### PR TITLE
minor Makefile fix

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -10,7 +10,6 @@ CLANG ?= clang
 CLANG_VERSION = $(shell $(CLANG) --version)
 LLVM_BINDIR = $(shell $(LLVM_CONFIG) --bindir)
 LLVM_AS = $(LLVM_BINDIR)/llvm-as
-CLANG = clang
 CXX_FLAGS = $(shell $(LLVM_CONFIG) --cflags) -Wall -Werror -fno-rtti -Woverloaded-virtual -Os
 LIBS = -L $(shell $(LLVM_CONFIG) --libdir) $(shell $(LLVM_CONFIG) --libs jit bitwriter bitreader x86 arm linker nvptx ipo)
 


### PR DESCRIPTION
I don't think the second CLANG declaration was meant to be there. It breaks things is I provide a different version of clang (like the one from macports)
