### PR TITLE
Enable assert in CodeGen.cpp

### DIFF
--- a/cpp/src/CodeGen.cpp
+++ b/cpp/src/CodeGen.cpp
@@ -2,7 +2,6 @@
 #include "IRPrinter.h"
 #include "CodeGen.h"
 #include "IROperator.h"
-#include "Util.h"
 #include "Log.h"
 #include "CodeGen_C.h"
 #include "Function.h"
@@ -118,6 +117,10 @@ CodeGen::CodeGen() :
         llvm_initialized = true;
     }
 }
+
+// llvm includes above disable assert.  Include Util.h here
+// to reenable assert.
+#include "Util.h"
 
 CodeGen::~CodeGen() {
     if (module && owns_module) {
@@ -1022,7 +1025,7 @@ void CodeGen::visit(const Call *op) {
     // handled in the standard library, but ones with e.g. varying
     // types are handled here.
     if (op->name == "shuffle vector") {
-        assert(op->args.size() == 1 + op->type.width);
+        assert((int) op->args.size() == 1 + op->type.width);
         vector<Constant *> indices(op->type.width);
         for (size_t i = 0; i < indices.size(); i++) {
             const IntImm *idx = op->args[i+1].as<IntImm>();

--- a/cpp/src/Util.h
+++ b/cpp/src/Util.h
@@ -1,12 +1,3 @@
-#ifndef HALIDE_UTIL_H
-#define HALIDE_UTIL_H
-
-/** \file
- * Various utility functions used internally Halide. */
-
-#include <vector>
-#include <string>
-
 // Always use assert, even if llvm-config defines NDEBUG
 #ifdef NDEBUG
 #undef NDEBUG
@@ -15,6 +6,15 @@
 #else
 #include <assert.h>
 #endif
+
+#ifndef HALIDE_UTIL_H
+#define HALIDE_UTIL_H
+
+/** \file
+ * Various utility functions used internally Halide. */
+
+#include <vector>
+#include <string>
 
 namespace Halide { 
 namespace Internal {


### PR DESCRIPTION
Hi

I found that assert is not working in CodeGen.cpp

As your comments note, assert is disabled by LLVM.  assert.h is reprocessed each time it is encountered, so llvm disables assert after Util.h enables it.  (Compilation environment: G++ 4.6 on Ubuntu)

Changes
1. Util.h: Move include of assert.h to front of Util.h so that each include of Util.h reincludes assert.h
2. CodeGen.cpp: Move include of Util.h after llvm includes that (may) disable assert.

Len Hamey
Macquarie University
