### PR TITLE
Add some comments to the generated-C++ output

### DIFF
--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -2,8 +2,8 @@
 #define HALIDE_CODEGEN_C_H
 
 /** \file
- * 
- * Defines an IRPrinter that emits C++ code equivalent to a halide stmt 
+ *
+ * Defines an IRPrinter that emits C++ code equivalent to a halide stmt
  */
 
 #include "IRPrinter.h"
@@ -14,7 +14,7 @@
 #include <ostream>
 #include <map>
 
-namespace Halide { 
+namespace Halide {
 namespace Internal {
 
 /** This class emits C++ code equivalent to a halide Stmt. It's
@@ -27,17 +27,17 @@ public:
     /** Initialize a C code generator pointing at a particular output
      * stream (e.g. a file, or std::cout) */
     CodeGen_C(std::ostream &);
- 
+
     /** Emit source code equivalent to the given statement, wrapped in
      * a function with the given type signature */
-    void compile(Stmt stmt, std::string name, const std::vector<Argument> &args);    
+    void compile(Stmt stmt, std::string name, const std::vector<Argument> &args);
 
     /** Emit a header file defining a halide pipeline with the given
      * type signature */
     void compile_header(const std::string &name, const std::vector<Argument> &args);
-    
+
     static void test();
-    
+
 protected:
     /** An for the most recently generated ssa variable */
     std::string id;
@@ -48,7 +48,7 @@ protected:
     /** Emit an expression as an assignment, then return the id of the
      * resulting var */
     std::string print_expr(Expr);
-    
+
     /** Emit a statement */
     void print_stmt(Stmt);
 
@@ -56,7 +56,7 @@ protected:
     virtual std::string print_type(Type);
 
     /** Emit a version of a string that is a valid identifier in C (. is replaced with _) */
-    std::string print_name(const std::string &);    
+    std::string print_name(const std::string &);
 
     /** Emit an SSA-style assignment, and set id to the freshly generated name */
     void print_assignment(Type t, const std::string &rhs);
@@ -65,7 +65,7 @@ protected:
     void open_scope();
 
     /** Close a C scope (i.e. throw in an end brace, decrease the indent) */
-    void close_scope();
+    void close_scope(const std::string &comment);
 
     /** Track the types of allocations to avoid unnecessary casts. */
     Scope<Type> allocations;
@@ -109,7 +109,7 @@ protected:
     void visit(const Allocate *);
     void visit(const Free *);
     void visit(const Realize *);
-    
+
     void visit_binop(Type t, Expr a, Expr b, const char *op);
 };
 

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -1,7 +1,7 @@
 #include "CodeGen_OpenCL_Dev.h"
 #include "Debug.h"
 
-namespace Halide { 
+namespace Halide {
 namespace Internal {
 
 using std::ostringstream;
@@ -27,7 +27,7 @@ string CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::print_type(Type type) {
         } else {
             assert(false && "Can't represent a float with this many bits in OpenCL C");
         }
-            
+
     } else {
         if (type.is_uint() && type.bits > 1) oss << 'u';
         switch (type.bits) {
@@ -47,7 +47,7 @@ string CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::print_type(Type type) {
             oss << "long";
             break;
         default:
-            assert(false && "Can't represent an integer with this many bits in OpenCL C");                
+            assert(false && "Can't represent an integer with this many bits in OpenCL C");
         }
     }
     return oss.str();
@@ -92,12 +92,12 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const For *loop) {
 
         do_indent();
         stream << "if (" << id_cond << ")\n";
-	    
+
         open_scope();
         do_indent();
         stream << print_type(Int(32)) << " " << print_name(loop->name) << " = " << id_idx << ";\n";
         loop->body.accept(this);
-        close_scope();
+        close_scope("for " + id_cond);
 
     } else {
     	assert(loop->for_type != For::Parallel && "Cannot emit parallel loops in OpenCL C");


### PR DESCRIPTION
Add some comments to the generated-C++ output to make scanning of the code a bit easier: which for-loop is being closed, which alloc is going out of scope.
