### PR TITLE
posix_clock.cpp should use sys/time.h 

### DIFF
--- a/src/runtime/posix_clock.cpp
+++ b/src/runtime/posix_clock.cpp
@@ -1,21 +1,12 @@
 #include <stdint.h>
 
-extern "C" {
-
-#ifndef _STRUCT_TIMEVAL
-#define _STRUCT_TIMEVAL
-#ifdef _LP64
-struct timeval {
-    int64_t tv_sec, tv_usec;
-};
+#if defined(_WIN32)
+  #include <time.h>
 #else
-struct timeval {
-    int32_t tv_sec, tv_usec;
-};
+  #include <sys/time.h>
 #endif
-#endif
-    
-extern int gettimeofday(timeval *tv, void *);
+
+extern "C" {
 
 WEAK timeval halide_reference_clock;
 
@@ -26,7 +17,7 @@ WEAK int halide_start_clock() {
 
 WEAK int halide_current_time() {
     timeval now;
-    gettimeofday(&now, NULL);    
+    gettimeofday(&now, NULL);
     int delta = (now.tv_sec - halide_reference_clock.tv_sec)*1000;
     delta += (now.tv_usec - halide_reference_clock.tv_usec)/1000;
     return delta;


### PR DESCRIPTION
posix_clock.cpp should use sys/time.h (or time.h on Windows) rather than trying to define timeval itself; the existing definition was wrong for OSX (Issue #107)
