### PR TITLE
Add built-in lerp operator to Halide. Documentation in IROperator.h doc ...

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -50,7 +50,7 @@ struct BufferContents {
         type(t), allocation(NULL), name(unique_name('b'))
     {
         assert(t.width == 1 && "Can't create of a buffer of a vector type");
-        buf.elem_size = t.bits / 8;        
+        buf.elem_size = (t.bits+ 7) / 8;        
         size_t size = 1;
         if (x_size) size *= x_size;
         if (y_size) size *= y_size;

--- a/src/CodeGen.cpp
+++ b/src/CodeGen.cpp
@@ -1180,6 +1180,147 @@ void CodeGen::visit(const Call *op) {
                 Intrinsic::readcyclecounter, std::vector<llvm::Type*>());
             CallInst *call = builder->CreateCall(fn);
             value = call;
+        } else if (op->name == Call::lerp) {
+            assert(op->args.size() == 3);
+
+            Expr zero_val = op->args[0];
+            Expr one_val  = op->args[1];
+            Expr weight   = op->args[2];
+
+            Expr result;
+
+            assert(zero_val.type() == one_val.type());
+            assert(weight.type().is_uint() || weight.type().is_float());
+
+            Type result_type = zero_val.type();
+
+            int bias_value = 0;
+            Type computation_type = result_type;
+
+            if (zero_val.type().is_int()) {
+                computation_type = UInt(zero_val.type().bits, zero_val.type().width);
+                bias_value = result_type.imin();
+            }
+
+            // For signed integer types, just convert everything to unsigned
+            // and then back at the end to ensure proper rounding, etc.
+            // There is likely a better way to handle this.
+            if (result_type != computation_type) {
+                zero_val = Cast::make(computation_type, zero_val - bias_value);
+                one_val =  Cast::make(computation_type, one_val  - bias_value);
+            }
+
+            if (result_type.is_bool()) {
+                Expr half_weight;
+                if (weight.type().is_float())
+                    half_weight = 0.5f;
+                else {
+                  half_weight = weight.type().imax() / 2; 
+                }
+
+                result = select(weight > half_weight, one_val, zero_val);
+            } else {
+                Expr typed_weight;
+                Expr inverse_typed_weight;
+
+                if (weight.type().is_float()) {
+                    typed_weight = weight;
+                    if (computation_type.is_uint()) {
+                        typed_weight =
+                            Cast::make(computation_type,
+                                       computation_type.imax() * typed_weight);
+                        inverse_typed_weight = computation_type.imax() - typed_weight;
+                    } else {
+                        inverse_typed_weight = 1.0f - typed_weight;
+                    }
+
+                } else {
+                    // This code rescales integer weights to the right number of bits.
+                    // It takes advantage of (2^n - 1) == (2^(n/2) - 1)(2^(n/2) + 1)
+                    // e.g. 65535 = 255 * 257. (Ditto for the 32-bit equivalent.)
+                    // To recale a weight of m bits to be n bits, we need to do:
+                    //     scaled_weight = (weight / (2^m - 1)) * (2^n - 1)
+                    // which power of two values for m and n, results in a series like
+                    // so:
+                    //     (2^(m/2) + 1) * (2^(m/4) + 1) ... (2^(n*2) + 1)
+                    // The loop below computes a scaling constant and either multiples
+                    // or divides by the constant and relies on lowering and llvm to
+                    // generate efficient code for the operation.
+                    int bit_size_difference = weight.type().bits - computation_type.bits;
+                    if (bit_size_difference == 0) {
+                        typed_weight = weight;
+                    } else {
+                        typed_weight = Cast::make(computation_type, weight);
+
+                        int bits_left = ::abs(bit_size_difference);
+                        int shift_amount = std::min(computation_type.bits, weight.type().bits);
+                        uint64_t scaling_factor = 1;
+                        while (bits_left != 0) {
+                          assert(bits_left > 0);
+                            scaling_factor = scaling_factor + (scaling_factor << shift_amount);
+                            bits_left -= shift_amount;
+                            shift_amount *= 2;
+                        }
+                        if (bit_size_difference < 0) {
+                            typed_weight =
+                              Cast::make(computation_type, weight) *
+                              Cast::make(computation_type, (int32_t)scaling_factor);
+                        } else {
+                            typed_weight =
+                                Cast::make(computation_type,
+                                           weight / 
+                                           Cast::make(weight.type(), (int32_t)scaling_factor));
+                        }
+                    }
+                    inverse_typed_weight =
+                        Cast::make(computation_type,
+                                   computation_type.imax() - typed_weight);
+                }
+
+                if (computation_type.is_float()) {
+                    result = zero_val * inverse_typed_weight + 
+                             one_val * typed_weight;
+                } else {
+                    int32_t bits = computation_type.bits;
+                    switch (bits) {
+                    case 1:
+                        result = select(typed_weight, one_val, zero_val);
+                        break;
+                    case 8:
+                    case 16:
+                    case 32: {
+                        Expr zero_expand = Cast::make(UInt(2 * bits, computation_type.width),
+                                                      zero_val);
+                        Expr  one_expand = Cast::make(UInt(2 * bits, one_val.type().width),
+                                                      one_val);
+
+                        Expr rounding = Cast::make(UInt(2 * bits), 1) << Cast::make(UInt(2 * bits), (bits - 1));
+                        Expr divisor  = Cast::make(UInt(2 * bits), 1) << Cast::make(UInt(2 * bits), bits);
+
+                        Expr prod_sum = zero_expand * inverse_typed_weight +
+                                        one_expand * typed_weight + rounding;
+                        Expr divided = ((prod_sum / divisor) + prod_sum) / divisor;
+
+                        result = Cast::make(UInt(bits, computation_type.width), divided);
+                        break;
+                    }
+                    case 64:
+                        // TODO: 64-bit lerp is not supported as current approach
+                        // requires double-width multiply.
+                        // There is an informative error message in IROperator.h.
+                        assert(false);
+                        break;
+                    default:
+                        break;
+                    }               
+                }
+
+                if (bias_value != 0) {
+                  result = Cast::make(result_type, result + bias_value);
+                }
+            }
+
+            value = codegen(result);
         } else {
             std::cerr << "Unknown intrinsic: " << op->name << "\n";
             assert(false);

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -87,6 +87,7 @@ const string Call::shift_right = "shift_right";
 const string Call::maybe_rewrite_buffer = "maybe_rewrite_buffer";
 const string Call::maybe_return = "maybe_return";
 const string Call::profiling_timer = "profiling_timer";
+const string Call::lerp = "lerp";
 
 }
 }

--- a/src/IR.h
+++ b/src/IR.h
@@ -912,7 +912,8 @@ struct Call : public ExprNode<Call> {
         shift_right,
         maybe_rewrite_buffer,
         maybe_return,
-        profiling_timer;
+        profiling_timer,
+        lerp;
 
     // If it's a call to another halide function, this call node
     // holds onto a pointer to that function

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -783,7 +783,7 @@ Stmt add_image_checks(Stmt s, Function f) {
         {
             string elem_size_name = name + ".elem_size";
             Expr elem_size = Variable::make(Int(32), elem_size_name);
-            int correct_size = type.bits / 8;
+            int correct_size = (type.bits + 7) / 8;
             ostringstream error_msg;
             error_msg << "Element size for " << name << " should be " << correct_size;
             asserts_elem_size.push_back(AssertStmt::make(elem_size == correct_size, error_msg.str()));

--- a/test/error/lerp_float_weight_out_of_range.cpp
+++ b/test/error/lerp_float_weight_out_of_range.cpp
@@ -1,0 +1,14 @@
+#include <Halide.h>
+
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // This should trigger an error.
+    Func f;
+    f() = lerp(0, 42, 1.5f);
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/lerp_mismatch.cpp
+++ b/test/error/lerp_mismatch.cpp
@@ -1,0 +1,14 @@
+#include <Halide.h>
+
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // This should trigger an error.
+    Func f;
+    f() = lerp(cast<uint16_t>(0), cast<uint8_t>(42), 0.5f);
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/lerp_signed_weight.cpp
+++ b/test/error/lerp_signed_weight.cpp
@@ -1,0 +1,14 @@
+#include <Halide.h>
+
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // This should trigger an error.
+    Func f;
+    f() = lerp(cast<uint8_t>(0), cast<uint8_t>(42), cast<int8_t>(16));
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/lerp.cpp
+++ b/test/lerp.cpp
@@ -1,0 +1,211 @@
+#include <Halide.h>
+#include <stdio.h>
+#include <limits>
+
+using namespace Halide;
+
+Var zero_val, one_val, weight;
+Param<int> step;
+
+template <typename weight_t>
+double weight_type_scale() {
+    if (std::numeric_limits<weight_t>::is_integer)
+        return std::numeric_limits<weight_t>::max();
+    else
+      return static_cast<weight_t>(1.0);
+}
+
+template <typename value_t>
+double conversion_rounding() {
+    if (std::numeric_limits<value_t>::is_integer)
+      return 0.5;
+    else
+      return 0.0;
+}
+
+template <typename value_t>
+value_t convert_to_value(double interpolated) {
+  return static_cast<value_t>(interpolated);
+}
+
+template <>
+bool convert_to_value<bool>(double interpolated) {
+  return interpolated >= 1; // Already has rounding added in
+}
+
+// Prevent iostream from printing 8-bit numbers as character constants.
+template <typename t> struct promote_if_char { typedef t promoted;  };
+template <> struct promote_if_char<signed char> { typedef int32_t promoted; };
+template <> struct promote_if_char<unsigned char> { typedef int32_t promoted; };
+
+template <typename value_t>
+bool relatively_equal(value_t a, value_t b) {
+    if (a == b) {
+        return true;
+    } else if (!std::numeric_limits<value_t>::is_integer) {
+        value_t relative_error;
+
+        // This test seems a bit high.
+        if (fabs(b - a) < .00001)
+          return true;
+
+        if (fabs(a) > fabs(b))
+            relative_error = fabs((b - a) / a);
+        else
+            relative_error = fabs((b - a) / b);
+
+        if (relative_error < .0000002)
+          return true;
+        std::cerr << "relatively_equal failed for (" << a << ", " << b <<
+          ") with relative error " << relative_error << std::endl;
+    }
+    return false;
+}
+
+template <typename value_t, typename weight_t>
+void check_range(int32_t zero_min, int32_t zero_extent, value_t zero_offset, value_t zero_scale,
+                 int32_t one_min, int32_t one_extent, value_t one_offset, value_t one_scale,
+                 int32_t weight_min, int32_t weight_extent, weight_t weight_offset, weight_t weight_scale,
+                 const char *name)
+{
+    // Stuff everything in Params as these can represent uint32_t where
+    // that fails in converting to Expr is we just use the raw C++ variables.
+    Param<value_t> zero_scale_p, zero_offset_p;
+    zero_scale_p.set(zero_scale); zero_offset_p.set(zero_offset);
+    Param<value_t> one_scale_p, one_offset_p;
+    one_scale_p.set(one_scale); one_offset_p.set(one_offset);
+    Param<weight_t> weight_scale_p, weight_offset_p;
+    weight_scale_p.set(weight_scale); weight_offset_p.set(weight_offset);
+
+    Func lerp_test("lerp_test");
+    lerp_test(zero_val, one_val, weight) =
+      lerp(cast<value_t>(zero_val * zero_scale_p + zero_offset_p),
+           cast<value_t>(one_val * one_scale_p + one_offset_p),
+           cast<weight_t>(weight * weight_scale_p + weight_offset_p));
+
+    Buffer result(type_of<value_t>(), zero_extent, one_extent, weight_extent);
+    result.raw_buffer()->min[0] = zero_min;
+    result.raw_buffer()->min[1] = one_min;
+    result.raw_buffer()->min[2] = weight_min;
+    lerp_test.realize(result);
+
+    const value_t *result_ptr = static_cast<value_t *>(result.host_ptr());
+    buffer_t *buffer = result.raw_buffer();
+    
+    for (int32_t i = buffer->min[0]; i < buffer->min[0] + buffer->extent[0]; i++) {
+        for (int32_t j = buffer->min[1]; j < buffer->min[1] + buffer->extent[1]; j++) {
+            for (int32_t k = buffer->min[2]; k < buffer->min[2] + buffer->extent[2]; k++) {
+                value_t zero_verify = (i * zero_scale + zero_offset);
+                value_t one_verify =  (j * one_scale + one_offset);
+                weight_t weight_verify = (weight_t)(k * weight_scale + weight_offset);
+                double actual_weight = weight_verify / weight_type_scale<weight_t>();
+
+                double verify_val_full = zero_verify * (1.0 - actual_weight) + one_verify * actual_weight;
+                if (verify_val_full < 0)
+                    verify_val_full -= conversion_rounding<value_t>();
+                else
+                    verify_val_full += conversion_rounding<value_t>();
+
+                value_t verify_val = convert_to_value<value_t>(verify_val_full);
+                value_t computed_val = result_ptr[(i - buffer->min[0]) * result.stride(0) +
+                                                  (j - buffer->min[1]) * result.stride(1) +
+                                                  (k - buffer->min[2]) * result.stride(2)];
+
+                if (!relatively_equal(verify_val, computed_val)) {
+                    std::cerr << "Expected " << (typename promote_if_char<value_t>::promoted)(verify_val) <<
+                      " got " << (typename promote_if_char<value_t>::promoted)(computed_val) <<
+                      " for lerp(" << (typename promote_if_char<value_t>::promoted)(zero_verify) << ", " <<
+                      (typename promote_if_char<value_t>::promoted)(one_verify) << ", " <<
+                      (typename promote_if_char<weight_t>::promoted)(weight_verify) <<
+                      ") " << actual_weight << ". " << name << std::endl;
+                    assert(false);
+                }
+            }
+        }
+    }
+}
+
+int main(int argc, char **argv) {
+  // Test bool
+  check_range<bool, uint8_t>(0, 2, 0, 1,
+                             0, 2, 0, 1,
+                             0, 256, 0, 1,
+                             "<bool, uint8_t> exhaustive");
+
+  // Exhaustively test 8-bit cases
+  check_range<uint8_t, uint8_t>(0, 256, 0, 1,
+                                0, 256, 0, 1,
+                                0, 256, 0, 1,
+                                "<uint8_t, uint8_t> exhaustive");
+  check_range<int8_t, uint8_t>(0, 256, -128, 1,
+                               0, 256, -128, 1,
+                               0, 256, 0, 1,
+                               "<int8_t, uint8_t> exhaustive");
+  check_range<uint8_t, float>(0, 256, 0, 1,
+                              0, 256, 0, 1,
+                              0, 256, 0, 1/255.0f,
+                              "<uint8_t, float> exhaustive");
+  check_range<int8_t, float>(0, 256, -128, 1,
+                             0, 256, -128, 1,
+                             0, 256, 0, 1/255.0f,
+                             "<int8_t, float> exhaustive");
+
+  // Check all delta values for 16-bit, verify swapping arguments doesn't break
+  check_range<uint16_t, uint16_t>(0, 65536, 0, 1,
+                                  65535, 1, 0, 1,
+                                  0, 257, 255, 1,
+                                  "<uint16_t, uint16_t> all zero starts");
+  check_range<uint16_t, uint16_t>(65535, 1, 0, 1,
+                                  0, 65536, 0, 1,
+                                  0, 257, 255, 1,
+                                  "<uint16_t, uint16_t> all one starts");
+
+
+  // Verify different bit sizes for value and weight types
+  check_range<uint16_t, uint8_t>(0, 1, 0, 1,
+                                 65535, 1, 0, 1,
+                                 0, 255, 1, 1,
+                                 "<uint16_t, uint8_t> zero, one uint8_t weight test");
+  check_range<uint16_t, uint32_t>(0, 1, 0, 1,
+                                 65535, 1, 0, 1,
+                                 std::numeric_limits<int32_t>::min(), 257, 255 * 65535, 1,
+                                 "<uint16_t, uint8_t> zero, one uint32_t weight test");
+  check_range<uint32_t, uint8_t>(0, 1, 0, 1,
+                                 1 << 31, 1, 0, 1,
+                                 0, 255, 0, 1,
+                                 "<uint32_t, uint8_t> weight test");
+  check_range<uint32_t, uint16_t>(0, 1, 0, 1,
+                                  1 << 31, 1, 0, 1,
+                                  0, 65535, 0, 1,
+                                 "<uint32_t, uint16_t> weight test");
+
+  // Verify float weights with integer values
+  check_range<uint16_t, float>(0, 1, 0, 1,
+                               65535, 1, 0, 1,
+                               0, 257, 255, 1/255.0f,
+                               "<uint16_t, float> zero, one float weight test");
+
+  check_range<int16_t, uint16_t>(0, 65536, -32768, 1,
+                                 0, 1, 0, 1,
+                                 0, 257, 255, 1,
+                                 "<int16_t, uint16_t> all zero starts");
+
+#if 0 // takes too long, difficult to test with uint32_t
+  // Check all delta values for 32-bit, do it in signed arithmetic
+  check_range<int32_t, uint32_t>(std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max(), 0, 1,
+                                 1 << 31, 1, 0, 1,
+                                 0, 1, 1 << 31, 1,
+                                  "<uint32_t, uint32_t> all zero starts");
+#endif
+
+  check_range<float, float>(0, 100, 0, .01,
+                            0, 100, 0, .01,
+                            0, 100, 0, .01,
+                            "<float, float> float values 0 to 1 by 1/100ths");
+
+  check_range<float, float>(0, 100, -5, .1,
+                            0, 100, 0, .1,
+                            0, 100, 0, .1,
+                            "<float, float> float values -5 to 5 by 1/100ths");
+
+}


### PR DESCRIPTION
...comment.

Includes correctness tests and tests for compilation error messages.

Also made two changes to allow writing a test cases that takes and
returns bool values. (Which are packed in an 8-bit byte.)
