### PR TITLE
Make Profiler usable on Android.

### DIFF
--- a/src/CodeGen.cpp
+++ b/src/CodeGen.cpp
@@ -1460,8 +1460,8 @@ void CodeGen::visit(const PrintStmt *op) {
     fmt_of_type_32[Halide::Type::Float] = "%3.3f";
 
     string fmt_of_type_64[3];
-    fmt_of_type_64[Halide::Type::UInt] = "%lu";
-    fmt_of_type_64[Halide::Type::Int] = "%ld";
+    fmt_of_type_64[Halide::Type::UInt] = "%llu";
+    fmt_of_type_64[Halide::Type::Int] = "%lld";
     fmt_of_type_64[Halide::Type::Float] = "%3.3f";
 
     vector<Value *> args;

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1171,6 +1171,21 @@ void CodeGen_ARM::visit(const Load *op) {
     CodeGen::visit(op);
 }
 
+void CodeGen_ARM::visit(const Call *op) {
+    if (use_android) {
+        if (op->call_type == Call::Intrinsic &&
+            op->name == Call::profiling_timer) {
+            // Android devices generally have read-cycle-counter
+            // disabled in user mode; fall back to calling
+            // halide_current_time_usec().
+            Expr e = Call::make(UInt(64), "halide_current_time_usec", std::vector<Expr>(), Call::Extern);
+            e.accept(this);
+            return;
+        }
+    }
+    CodeGen::visit(op);
+}
+
 string CodeGen_ARM::mcpu() const {
     return "cortex-a9";
 }

--- a/src/CodeGen_ARM.h
+++ b/src/CodeGen_ARM.h
@@ -69,6 +69,7 @@ protected:
     void visit(const Select *);
     void visit(const Store *);
     void visit(const Load *);
+    void visit(const Call *);
     // @}
 
     std::string mcpu() const;

--- a/src/runtime/posix_clock.cpp
+++ b/src/runtime/posix_clock.cpp
@@ -46,9 +46,9 @@ WEAK int halide_start_clock() {
 WEAK int64_t halide_current_time_usec() {
     timeval now = {0,0};
     gettimeofday(&now, NULL);
-    int64_t delta = (now.tv_sec - halide_reference_clock.tv_sec)*1000000;
-    delta += (now.tv_usec - halide_reference_clock.tv_usec);
-    return delta;
+    int64_t d = int64_t(now.tv_sec - halide_reference_clock.tv_sec)*1000000;
+    int64_t ud = int64_t(now.tv_usec) - int64_t(halide_reference_clock.tv_usec);
+    return d + ud;
 }
 
 WEAK int32_t halide_current_time() {


### PR DESCRIPTION
Add code to CodegenArm to force Android to use halide_current_time_usec() rather than performance counter (since the latter isn't available in user mode). Also correct some 64-bit assumptions.
