### PR TITLE
Add Func::unbind_image_params() method

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1918,6 +1918,16 @@ void Func::infer_input_bounds(Realization dst) {
     }
 }
 
+void Func::unbind_image_params() {
+    // Update the addresses of the image param args
+    Internal::debug(3) << image_param_args.size() << " image param args to unbind\n";
+    for (size_t i = 0; i < image_param_args.size(); i++) {
+        Internal::debug(3) << "Unbinding buffer from image param: " << image_param_args[i].second.name() << "\n";
+        image_param_args[i].second.set_buffer(Buffer());
+        assert(!image_param_args[i].second.get_buffer().defined());
+    }
+}
+
 void *Func::compile_jit(const Target &target) {
     assert(defined() && "Can't realize undefined function");
 

--- a/src/Func.h
+++ b/src/Func.h
@@ -459,6 +459,10 @@ public:
     EXPORT void infer_input_bounds(Buffer dst);
     // @}
 
+    /** Unbind all ImageParams. Useful when iteratively re-running
+     * infer_input_bounds. */
+    EXPORT void unbind_image_params();
+
     /** Statically compile this function to llvm bitcode, with the
      * given filename (which should probably end in .bc), type
      * signature, and C function name (which defaults to the same name


### PR DESCRIPTION
This is useful when iteratively re-running infer_input_bounds
given an enlarged output buffer computed by the previous iteration.
It simply clobbers all the Buffers in the image params tracked by
the Func. I _think_ the previous Buffers will be deallocated.
Comments welcome.
