### PR TITLE
Added minval_f32/maxval_f32 functions for the OpenCL target

### DIFF
--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -353,7 +353,9 @@ void CodeGen_OpenCL_Dev::init_module() {
     src_stream << "#pragma OPENCL FP_CONTRACT ON\n";
 
     // Write out the Halide math functions.
-    src_stream << "float nan_f32() { return NAN; }\n"
+    src_stream << "float maxval_f32() {return FLT_MAX;}\n"
+               << "float minval_f32() {return -FLT_MAX;}\n"
+               << "float nan_f32() { return NAN; }\n"
                << "float neg_inf_f32() { return -INFINITY; }\n"
                << "float inf_f32() { return INFINITY; }\n"
                << "float float_from_bits(unsigned int x) {return as_float(x);}\n"


### PR DESCRIPTION
I found that OpenCL program, which was generated from the following code, does not compile:

``` c++
Halide::Image<float> input(1024, 1024);

int winSize = 7;

Halide::Var x("x"), y("y");
Halide::Func minFilter("minFilter");
Halide::RDom minDomain(-winSize, 2 * winSize + 1, -winSize, 2 * winSize, "minLoop");

minFilter(x, y) = minimum(minDomain, input(x + minDomain.x, y + minDomain.y));

minFilter.gpu_tile(x, y, 16, 16);

Halide::Image<float> output(input.width() - 2 * winSize, input.height() - 2 * winSize);
output.set_min(winSize, winSize);

minFilter.realize(output);
```

it says that _maxval_f32_ function definition is missed, so I've copied _minval_f32/maxval_f32_ functions from the C code generator. 
