### PR TITLE
Incorrect release function for the OpenCL target

### DIFF
--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -321,7 +321,6 @@ WEAK void halide_release(void *user_context) {
     // cl_ctx/cl_q are going to be freed). I think a larger redesign of the global
     // context scheme might be necessary.
     cl_uint ctx_refs = 0, q_refs = 0;
-    CHECK_CALL(clGetContextInfo(*cl_ctx, CL_CONTEXT_REFERENCE_COUNT, sizeof(ctx_refs), &ctx_refs, NULL), "clGetContextInfo");
     CHECK_CALL(clGetCommandQueueInfo(*cl_q, CL_QUEUE_REFERENCE_COUNT, sizeof(q_refs), &q_refs, NULL), "clGetCommandQueueInfo");
 
     #ifdef DEBUG
@@ -334,6 +333,7 @@ WEAK void halide_release(void *user_context) {
     #ifdef DEBUG
     halide_printf(user_context, "clReleaseContext %p\n", *cl_ctx);
     #endif
+    CHECK_CALL(clGetContextInfo(*cl_ctx, CL_CONTEXT_REFERENCE_COUNT, sizeof(ctx_refs), &ctx_refs, NULL), "clGetContextInfo");
     CHECK_CALL( clReleaseContext(*cl_ctx), "clReleaseContext" );
 
     // See TODO above...


### PR DESCRIPTION
I found that following code crashes, when I am running it with HL_JIT_TARGET=opencl (I have Mac OS X 10.7.5):

``` c++
    for(int ix = 0; ix < 2; ix++)
    {
        Halide::Image<float> input(1024, 1024);

        Halide::Var x("x"), y("y");
        Halide::Func foo("foo");

        foo(x, y) = input(x, y);

        foo.gpu_tile(x, y, 16, 16);

        Halide::Image<float> output(input.width(), input.height());

        foo.realize(output);
    }
```

Crash happens on a second iteration of the loop. I did a small investigation and it seems that the problem is with halide_release function. More specifically, here:

``` c++
    cl_uint refs = 0;
    clGetContextInfo(*cl_ctx, CL_CONTEXT_REFERENCE_COUNT, sizeof(refs), &refs, NULL);

    // Unload context (ref counted).
    CHECK_CALL( clReleaseCommandQueue(*cl_q), "clReleaseCommandQueue" );
    #ifdef DEBUG
    halide_printf(user_context, "clReleaseContext %p\n", *cl_ctx);
    #endif
    CHECK_CALL( clReleaseContext(*cl_ctx), "clReleaseContext" );

    // See TODO above...
    if (--refs == 0) {
        *cl_ctx = NULL;
        *cl_q = NULL;
    }
```

I printed a number of references to the context and queue. In my particular case, I got 4 and 1 correspondingly. I traced all references to the context and found that: one reference is from clCreateContext, one from the clCreateCommandQueue and two from unreleased buffers (clCreateBuffers). As a result, queue will zero references after release, but will not have NULL assigned, because context still has references and this will cause problems on the next iteration.

I am not sure, what is a best solution, but I separated creation and release of the context and command queue and it fixes a problem.
