### PR TITLE
Fixed bug where GPU module state was not added to state list.

### DIFF
--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -319,17 +319,10 @@ WEAK void* halide_init_kernels(void *user_context, void *state_ptr, const char* 
     uint64_t t_before = halide_current_time_ns(user_context);
     #endif
 
-    // Create the module state if necessary
     module_state *state = (module_state*)state_ptr;
-    if (!state) {
-        state = (module_state*)malloc(sizeof(module_state));
-        state->program = NULL;
-        state->next = state_list;
-        state_list = state;
-    }
 
     // Create the program if necessary.
-    if (!state->program && size > 1) {
+    if (!(state && state->program) && size > 1) {
         cl_int err = 0;
         cl_device_id dev;
 
@@ -370,25 +363,25 @@ WEAK void* halide_init_kernels(void *user_context, void *state_ptr, const char* 
         DEBUG_PRINTF(user_context, "    Build options: %s\n", options);
 
         const char * sources[] = { src };
-        state->program = clCreateProgramWithSource(ctx.context, 1, &sources[0], NULL, &err );
+        cl_program program = clCreateProgramWithSource(ctx.context, 1, &sources[0], NULL, &err );
         if (err != CL_SUCCESS) {
             halide_error_varargs(user_context, "CL: clCreateProgramWithSource failed (%d)\n", err);
             return NULL;
         }
 
-        err = clBuildProgram(state->program, 1, devices, options, NULL, NULL );
+        err = clBuildProgram(program, 1, devices, options, NULL, NULL );
         if (err != CL_SUCCESS) {
             halide_error_varargs(user_context, "CL: clBuildProgram failed (%d)\n", err);
 
             // Allocate an appropriately sized buffer for the build log.
             size_t len = 0;
             char *buffer = NULL;
-            if (clGetProgramBuildInfo(state->program, dev, CL_PROGRAM_BUILD_LOG, 0, NULL, &len) == CL_SUCCESS) {
+            if (clGetProgramBuildInfo(program, dev, CL_PROGRAM_BUILD_LOG, 0, NULL, &len) == CL_SUCCESS) {
                 buffer = (char*)malloc((++len)*sizeof(char));
             }
 
             // Get build log
-            if (buffer && clGetProgramBuildInfo(state->program, dev, CL_PROGRAM_BUILD_LOG, len, buffer, NULL) == CL_SUCCESS) {
+            if (buffer && clGetProgramBuildInfo(program, dev, CL_PROGRAM_BUILD_LOG, len, buffer, NULL) == CL_SUCCESS) {
                 halide_printf(user_context, "    Build Log:\n %s\n-----\n", buffer);
             } else {
                 halide_printf(user_context, "    clGetProgramBuildInfo failed\n");
@@ -401,6 +394,16 @@ WEAK void* halide_init_kernels(void *user_context, void *state_ptr, const char* 
             halide_assert(user_context, err == CL_SUCCESS);
             return NULL;
         }
+
+        // Create the module state if necessary
+        if (!state) {
+            state = (module_state*)malloc(sizeof(module_state));
+        }
+
+        // Add module to the state list
+        state->program = program;
+        state->next = state_list;
+        state_list = state;
     }
 
     #ifdef DEBUG


### PR DESCRIPTION
This fixes a bug in the changes I made a while back to keep track of GPUs modules attached to a context (PR #238). The second time a module is initialised, the module was not being added to the state list, which meant that it was not being released properly.

I've also made it so that the state allocation only happens if module creation is successful, to avoid memory leaks from repeated unsuccessful initialisation attempts (not that this is likely to occur in practice).
