### PR TITLE
Synchronise Python Bindings to 22 June 2014 build.

### DIFF
--- a/python_bindings/README.md
+++ b/python_bindings/README.md
@@ -2,17 +2,16 @@ Python Bindings for Halide
 --------------------------
 
 By Connelly Barnes, 2012-2013.
+Updated by Fred Rotbart 2014.
 
-This library allows you to write Halide code in Python 2.7. The library has currently only been tested on Mac OS
-and Linux (Debian, Ubuntu), against a Halide source build, and is more experimental than the C++ Halide.
+This library allows you to write Halide code in Python 2.7. The library has currently only been tested on Mac OS, against a Halide source build.
 
 Installation
 ------------
 
 ### Prerequisites
 
-Install SWIG 2.0.4+, and Python libraries Numpy, and Python Image Library (PIL).
-Note that SWIG < 3.* should be used.
+Install SWIG and Python libraries Numpy, and Python Image Library (PIL).
 
 On Mac:
 

--- a/python_bindings/halide/cHalide.i
+++ b/python_bindings/halide/cHalide.i
@@ -19,6 +19,7 @@
 %ignore halide_shutdown_trace;
 %ignore halide_set_random_seed;
 %ignore halide_printf;
+%ignore halide_print;
 %ignore get_scalar;
 %ignore set_scalar;
 %ignore get;


### PR DESCRIPTION
This synchronizes Python Bindings to 22 June 2014 build.
Also the latest changes to the C++ code now allows building with SWIG 3.0.2.
- fcr
