### PR TITLE
Changed return type of Image::operator() const to const T&.

### DIFF
--- a/src/Image.h
+++ b/src/Image.h
@@ -196,25 +196,25 @@ public:
 
     /** Assuming this image is one-dimensional, get the value of the
      * element at position x */
-    T operator()(int x) const {
+    const T &operator()(int x) const {
         return ((T *)origin)[x*stride_0];
     }
 
     /** Assuming this image is two-dimensional, get the value of the
      * element at position (x, y) */
-    T operator()(int x, int y) const {
+    const T &operator()(int x, int y) const {
         return ((T *)origin)[x*stride_0 + y*stride_1];
     }
 
     /** Assuming this image is three-dimensional, get the value of the
      * element at position (x, y, z) */
-    T operator()(int x, int y, int z) const {
+    const T &operator()(int x, int y, int z) const {
         return ((T *)origin)[x*stride_0 + y*stride_1 + z*stride_2];
     }
 
     /** Assuming this image is four-dimensional, get the value of the
      * element at position (x, y, z, w) */
-    T operator()(int x, int y, int z, int w) const {
+    const T &operator()(int x, int y, int z, int w) const {
         return ((T *)origin)[x*stride_0 + y*stride_1 + z*stride_2 + w*stride_3];
     }
 


### PR DESCRIPTION
This is a very small pull request, but since static_image.h already does this, I thought there might be a reason why Halide::Image::operator () doesn't return a const reference.

This change enables Halide client code to take the address-of elements of const images, like they already can with non-const images. Of course, the pointer is still const, but this enables easy/efficient memcpy'ing from rows/slices of Images.
