### PR TITLE
Make halide_rewrite_buffer a static function

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -157,7 +157,7 @@ const string preamble =
     "template<typename A, typename B> A reinterpret(B b) {A a; memcpy(&a, &b, sizeof(a)); return a;}\n"
     "\n"
     + buffer_t_definition +
-    "bool halide_rewrite_buffer(buffer_t *b, int32_t elem_size,\n"
+    "static bool halide_rewrite_buffer(buffer_t *b, int32_t elem_size,\n"
     "                           int32_t min0, int32_t extent0, int32_t stride0,\n"
     "                           int32_t min1, int32_t extent1, int32_t stride1,\n"
     "                           int32_t min2, int32_t extent2, int32_t stride2,\n"


### PR DESCRIPTION
The scope of halide_rewrite_buffer is local to the compilation unit, and
when halide_rewrite_buffer is not static it causes a name clash in applications
that compile two C/C++ files generated from Func.compile_to_c
