### PR TITLE
Enable basic AArch64 code generation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ OBJECTS = $(SOURCE_FILES:%.cpp=$(BUILD_DIR)/%.o)
 HEADERS = $(HEADER_FILES:%.h=src/%.h)
 
 RUNTIME_CPP_COMPONENTS = android_io cuda fake_thread_pool gcd_thread_pool ios_io android_clock linux_clock nogpu opencl posix_allocator posix_clock osx_clock windows_clock posix_error_handler posix_io nacl_io osx_io posix_math posix_thread_pool android_host_cpu_count linux_host_cpu_count osx_host_cpu_count tracing write_debug_image cuda_debug opencl_debug windows_cuda windows_cuda_debug windows_opencl windows_opencl_debug windows_io windows_thread_pool ssp opengl opengl_debug linux_opengl_context osx_opengl_context android_opengl_context posix_print
-RUNTIME_LL_COMPONENTS = arm posix_math ptx_dev x86_avx x86 x86_sse41 pnacl_math win32_math
+RUNTIME_LL_COMPONENTS = arm posix_math ptx_dev x86_avx x86 x86_sse41 pnacl_math win32_math aarch64
 
 INITIAL_MODULES = $(RUNTIME_CPP_COMPONENTS:%=$(BUILD_DIR)/initmod.%_32.o) $(RUNTIME_CPP_COMPONENTS:%=$(BUILD_DIR)/initmod.%_64.o) $(RUNTIME_LL_COMPONENTS:%=$(BUILD_DIR)/initmod.%_ll.o) $(PTX_DEVICE_INITIAL_MODULES:libdevice.%.bc=$(BUILD_DIR)/initmod_ptx.%_ll.o)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,10 @@ if (TARGET_ARM)
   add_definitions("-DWITH_ARM=1")
 endif()
 
+if (TARGET_AARCH64)
+  add_definitions("-DWITH_AARCH64=1")
+endif()
+
 if (TARGET_PTX)
   add_definitions("-DWITH_PTX=1")
 endif()
@@ -102,6 +106,7 @@ set(RUNTIME_CPP
   posix_print)
 set (RUNTIME_LL
   arm
+  aarch64
   posix_math
   ptx_dev
   x86_avx

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -123,13 +123,15 @@ Expr _u32q(Expr e) {
 }
 
 CodeGen_ARM::CodeGen_ARM(Target t) : CodeGen_Posix(t) {
-    #if !(WITH_ARM)
-    user_error << "arm not enabled for this build of Halide.";
-    #endif
-
     if (t.bits == 32) {
+        #if !(WITH_ARM)
+        user_error << "arm not enabled for this build of Halide.";
+        #endif
         user_assert(llvm_ARM_enabled) << "llvm build not configured with ARM target enabled\n.";
     } else {
+        #if !(WITH_AARCH64)
+        user_error << "aarch64 not enabled for this build of Halide.";
+        #endif
         user_assert(llvm_AArch64_enabled) << "llvm build not configured with AArch64 target enabled.\n";
     }
 
@@ -141,193 +143,192 @@ CodeGen_ARM::CodeGen_ARM(Target t) : CodeGen_Posix(t) {
     // unfortunate, because they don't get generated automatically in
     // the signed case.
     #if LLVM_VERSION < 34
-    casts.push_back(Pattern("vaddhn.v8i8", _i8((wild_i16x8 + wild_i16x8)/256)));
-    casts.push_back(Pattern("vaddhn.v4i16", _i16((wild_i32x4 + wild_i32x4)/65536)));
-    casts.push_back(Pattern("vaddhn.v8i8", _u8((wild_u16x8 + wild_u16x8)/256)));
-    casts.push_back(Pattern("vaddhn.v4i16", _u16((wild_u32x4 + wild_u32x4)/65536)));
-    casts.push_back(Pattern("vsubhn.v8i8", _i8((wild_i16x8 - wild_i16x8)/256)));
-    casts.push_back(Pattern("vsubhn.v4i16", _i16((wild_i32x4 - wild_i32x4)/65536)));
-    casts.push_back(Pattern("vsubhn.v8i8", _u8((wild_u16x8 - wild_u16x8)/256)));
-    casts.push_back(Pattern("vsubhn.v4i16", _u16((wild_u32x4 - wild_u32x4)/65536)));
-    #endif
-
-    // Generate the cast patterns that can take vector types.  We need
-    // to iterate over all 64 and 128 bit integer types relevant for
-    // neon.
-    Type types[] = {Int(8, 8), Int(8, 16), UInt(8, 8), UInt(8, 16),
-                    Int(16, 4), Int(16, 8), UInt(16, 4), UInt(16, 8),
-                    Int(32, 2), Int(32, 4), UInt(32, 2), UInt(32, 4)};
-    for (int i = 0; i < 12; i++) {
-        Type t = types[i];
-        std::ostringstream oss;
-        oss << (t.is_int() ? 's' : 'u') << ".v" << t.width << "i" << t.bits;
-        string t_str = oss.str();
-
-        // Wider versions of the type
-        Type w = t;
-        w.bits *= 2;
-        Type ws = Int(t.bits*2, t.width);
-
-        // Vector wildcard for this type
-        Expr vector = Variable::make(t, "*");
-        Expr w_vector = Variable::make(w, "*");
-        Expr ws_vector = Variable::make(ws, "*");
-
-        // Bounds of the type stored in the wider vector type
-        Expr tmin = simplify(cast(w, t.imin()));
-        Expr tmax = simplify(cast(w, t.imax()));
-        Expr tsmin = simplify(cast(ws, t.imin()));
-        Expr tsmax = simplify(cast(ws, t.imax()));
-
-        // Can't fit uint32 max into an intimm
-        if (t.element_of() == UInt(32)) {
-            tmax = simplify(cast(w, t.max()));
-            tsmax = simplify(cast(ws, t.max()));
-        }
-
-        // Rounding-up averaging
-        casts.push_back(Pattern("vrhadd" + t_str, cast(t, (w_vector + w_vector + 1)/2), Pattern::NarrowArgs));
-        casts.push_back(Pattern("vrhadd" + t_str, cast(t, (w_vector + (w_vector + 1))/2), Pattern::NarrowArgs));
-        casts.push_back(Pattern("vrhadd" + t_str, cast(t, ((w_vector + 1) + w_vector)/2), Pattern::NarrowArgs));
-
-        // Rounding down averaging
-        casts.push_back(Pattern("vhadd" + t_str, cast(t, (w_vector + w_vector)/2), Pattern::NarrowArgs));
-
-        // Halving subtract
-        casts.push_back(Pattern("vhsub" + t_str, cast(t, (w_vector - w_vector)/2), Pattern::NarrowArgs));
-
-        // Saturating add
-        casts.push_back(Pattern("vqadd" + t_str, cast(t, clamp(w_vector + w_vector, tmin, tmax)), Pattern::NarrowArgs));
-
-        // In the unsigned case, the saturation below in unnecessary
-        if (t.is_uint()) {
-            casts.push_back(Pattern("vqadd" + t_str, cast(t, min(w_vector + w_vector, tmax)), Pattern::NarrowArgs));
-        }
-
-        // Saturating subtract
-        // N.B. Saturating subtracts always widen to a signed type
-        casts.push_back(Pattern("vqsub" + t_str, cast(t, clamp(ws_vector - ws_vector, tsmin, tsmax)), Pattern::NarrowArgs));
-
-        // In the unsigned case, we may detect that the top of the clamp is unnecessary
-        if (t.is_uint()) {
-            casts.push_back(Pattern("vqsub" + t_str, cast(t, max(ws_vector - ws_vector, 0)), Pattern::NarrowArgs));
-        }
+    if (target.bits == 32) {
+      casts.push_back(Pattern("vaddhn.v8i8", _i8((wild_i16x8 + wild_i16x8)/256)));
+      casts.push_back(Pattern("vaddhn.v4i16", _i16((wild_i32x4 + wild_i32x4)/65536)));
+      casts.push_back(Pattern("vaddhn.v8i8", _u8((wild_u16x8 + wild_u16x8)/256)));
+      casts.push_back(Pattern("vaddhn.v4i16", _u16((wild_u32x4 + wild_u32x4)/65536)));
+      casts.push_back(Pattern("vsubhn.v8i8", _i8((wild_i16x8 - wild_i16x8)/256)));
+      casts.push_back(Pattern("vsubhn.v4i16", _i16((wild_i32x4 - wild_i32x4)/65536)));
+      casts.push_back(Pattern("vsubhn.v8i8", _u8((wild_u16x8 - wild_u16x8)/256)));
+      casts.push_back(Pattern("vsubhn.v4i16", _u16((wild_u32x4 - wild_u32x4)/65536)));
     }
-
-    // At some point llvm started recognising narrowing shifts
-    // directly and these intrinsics went away.
-    #if LLVM_VERSION < 35
-    casts.push_back(Pattern("vshiftn.v8i8", _i8(wild_i16x8/wild_i16x8), Pattern::RightShift));
-    casts.push_back(Pattern("vshiftn.v4i16", _i16(wild_i32x4/wild_i32x4), Pattern::RightShift));
-    casts.push_back(Pattern("vshiftn.v2i32", _i32(wild_i64x2/wild_i64x2), Pattern::RightShift));
-    casts.push_back(Pattern("vshiftn.v8i8", _u8(wild_u16x8/wild_u16x8), Pattern::RightShift));
-    casts.push_back(Pattern("vshiftn.v4i16", _u16(wild_u32x4/wild_u32x4), Pattern::RightShift));
-    casts.push_back(Pattern("vshiftn.v2i32", _u32(wild_u64x2/wild_u64x2), Pattern::RightShift));
-
-    // Widening left shifts
-    left_shifts.push_back(Pattern("vshiftls.v8i16", _i16(wild_i8x8)*wild_i16x8, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshiftls.v4i32", _i32(wild_i16x4)*wild_i32x4, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshiftls.v2i64", _i64(wild_i32x2)*wild_i64x2, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshiftlu.v8i16", _u16(wild_u8x8)*wild_u16x8, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshiftlu.v4i32", _u32(wild_u16x4)*wild_u32x4, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshiftlu.v2i64", _u64(wild_u32x2)*wild_u64x2, Pattern::LeftShift));
     #endif
 
-    casts.push_back(Pattern("vqshiftns.v8i8", _i8q(wild_i16x8/wild_i16x8), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftns.v4i16", _i16q(wild_i32x4/wild_i32x4), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftns.v2i32", _i32q(wild_i64x2/wild_i64x2), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftnu.v8i8", _u8q(wild_u16x8/wild_u16x8), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftnu.v4i16", _u16q(wild_u32x4/wild_u32x4), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftnu.v2i32", _u32q(wild_u64x2/wild_u64x2), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftnsu.v8i8", _u8q(wild_i16x8/wild_i16x8), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftnsu.v4i16", _u16q(wild_i32x4/wild_i32x4), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftnsu.v2i32", _u32q(wild_i64x2/wild_i64x2), Pattern::RightShift));
+    if (target.bits == 32) {
+      // Generate the cast patterns that can take vector types.  We need
+      // to iterate over all 64 and 128 bit integer types relevant for
+      // neon.
+      Type types[] = {Int(8, 8), Int(8, 16), UInt(8, 8), UInt(8, 16),
+                      Int(16, 4), Int(16, 8), UInt(16, 4), UInt(16, 8),
+                      Int(32, 2), Int(32, 4), UInt(32, 2), UInt(32, 4)};
+      for (int i = 0; i < 12; i++) {
+          Type t = types[i];
+          std::ostringstream oss;
+          oss << (t.is_int() ? 's' : 'u') << ".v" << t.width << "i" << t.bits;
+          string t_str = oss.str();
 
-    casts.push_back(Pattern("vqshifts.v8i8", _i8q(_i16(wild_i8x8)*wild_i16x8), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshifts.v4i16", _i16q(_i32(wild_i16x4)*wild_i32x4), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshifts.v2i32", _i32q(_i64(wild_i32x2)*wild_i64x2), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftu.v8i8", _u8q(_u16(wild_u8x8)*wild_u16x8), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftu.v4i16", _u16q(_u32(wild_u16x4)*wild_u32x4), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftu.v2i32", _u32q(_u64(wild_u32x2)*wild_u64x2), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftsu.v8i8", _u8q(_i16(wild_i8x8)*wild_i16x8), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftsu.v4i16", _u16q(_i32(wild_i16x4)*wild_i32x4), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftsu.v2i32", _u32q(_i64(wild_i32x2)*wild_i64x2), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshifts.v16i8", _i8q(_i16(wild_i8x16)*wild_i16x16), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshifts.v8i16", _i16q(_i32(wild_i16x8)*wild_i32x8), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshifts.v4i32", _i32q(_i64(wild_i32x4)*wild_i64x4), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftu.v16i8", _u8q(_u16(wild_u8x16)*wild_u16x16), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftu.v8i16", _u16q(_u32(wild_u16x8)*wild_u32x8), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftu.v4i32", _u32q(_u64(wild_u32x4)*wild_u64x4), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftsu.v16i8", _u8q(_i16(wild_i8x16)*wild_i16x16), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftsu.v8i16", _u16q(_i32(wild_i16x8)*wild_i32x8), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftsu.v4i32", _u32q(_i64(wild_i32x4)*wild_i64x4), Pattern::LeftShift));
+          // Wider versions of the type
+          Type w = t;
+          w.bits *= 2;
+          Type ws = Int(t.bits*2, t.width);
 
-    casts.push_back(Pattern("vqmovns.v8i8", _i8q(wild_i16x8)));
-    casts.push_back(Pattern("vqmovns.v4i16", _i16q(wild_i32x4)));
-    casts.push_back(Pattern("vqmovns.v2i32", _i32q(wild_i64x2)));
-    casts.push_back(Pattern("vqmovnu.v8i8", _u8q(wild_u16x8)));
-    casts.push_back(Pattern("vqmovnu.v4i16", _u16q(wild_u32x4)));
-    casts.push_back(Pattern("vqmovnu.v2i32", _u32q(wild_u64x2)));
-    casts.push_back(Pattern("vqmovnsu.v8i8", _u8q(wild_i16x8)));
-    casts.push_back(Pattern("vqmovnsu.v4i16", _u16q(wild_i32x4)));
-    casts.push_back(Pattern("vqmovnsu.v2i32", _u32q(wild_i64x2)));
+          // Vector wildcard for this type
+          Expr vector = Variable::make(t, "*");
+          Expr w_vector = Variable::make(w, "*");
+          Expr ws_vector = Variable::make(ws, "*");
 
-    // Non-widening left shifts
-    left_shifts.push_back(Pattern("vshifts.v16i8", wild_i8x16*wild_i8x16, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshifts.v8i16", wild_i16x8*wild_i16x8, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshifts.v4i32", wild_i32x4*wild_i32x4, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshifts.v2i64", wild_i64x2*wild_i64x2, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshiftu.v16i8", wild_u8x16*wild_u8x16, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshiftu.v8i16", wild_u16x8*wild_u16x8, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshiftu.v4i32", wild_u32x4*wild_u32x4, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshiftu.v2i64", wild_u64x2*wild_u64x2, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshifts.v8i8",  wild_i8x8*wild_i8x8, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshifts.v4i16", wild_i16x4*wild_i16x4, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshifts.v2i32", wild_i32x2*wild_i32x2, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshiftu.v8i8",  wild_u8x8*wild_u8x8, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshiftu.v4i16", wild_u16x4*wild_u16x4, Pattern::LeftShift));
-    left_shifts.push_back(Pattern("vshiftu.v2i32", wild_u32x2*wild_u32x2, Pattern::LeftShift));
+          // Bounds of the type stored in the wider vector type
+          Expr tmin = simplify(cast(w, t.imin()));
+          Expr tmax = simplify(cast(w, t.imax()));
+          Expr tsmin = simplify(cast(ws, t.imin()));
+          Expr tsmax = simplify(cast(ws, t.imax()));
 
-    averagings.push_back(Pattern("vhadds.v8i8", (wild_i8x8 + wild_i8x8)));
-    averagings.push_back(Pattern("vhaddu.v8i8", (wild_u8x8 + wild_u8x8)));
-    averagings.push_back(Pattern("vhadds.v4i16", (wild_i16x4 + wild_i16x4)));
-    averagings.push_back(Pattern("vhaddu.v4i16", (wild_u16x4 + wild_u16x4)));
-    averagings.push_back(Pattern("vhadds.v2i32", (wild_i32x2 + wild_i32x2)));
-    averagings.push_back(Pattern("vhaddu.v2i32", (wild_u32x2 + wild_u32x2)));
-    averagings.push_back(Pattern("vhadds.v16i8", (wild_i8x16 + wild_i8x16)));
-    averagings.push_back(Pattern("vhaddu.v16i8", (wild_u8x16 + wild_u8x16)));
-    averagings.push_back(Pattern("vhadds.v8i16", (wild_i16x8 + wild_i16x8)));
-    averagings.push_back(Pattern("vhaddu.v8i16", (wild_u16x8 + wild_u16x8)));
-    averagings.push_back(Pattern("vhadds.v4i32", (wild_i32x4 + wild_i32x4)));
-    averagings.push_back(Pattern("vhaddu.v4i32", (wild_u32x4 + wild_u32x4)));
-    averagings.push_back(Pattern("vhsubs.v8i8", (wild_i8x8 - wild_i8x8)));
-    averagings.push_back(Pattern("vhsubu.v8i8", (wild_u8x8 - wild_u8x8)));
-    averagings.push_back(Pattern("vhsubs.v4i16", (wild_i16x4 - wild_i16x4)));
-    averagings.push_back(Pattern("vhsubu.v4i16", (wild_u16x4 - wild_u16x4)));
-    averagings.push_back(Pattern("vhsubs.v2i32", (wild_i32x2 - wild_i32x2)));
-    averagings.push_back(Pattern("vhsubu.v2i32", (wild_u32x2 - wild_u32x2)));
-    averagings.push_back(Pattern("vhsubs.v16i8", (wild_i8x16 - wild_i8x16)));
-    averagings.push_back(Pattern("vhsubu.v16i8", (wild_u8x16 - wild_u8x16)));
-    averagings.push_back(Pattern("vhsubs.v8i16", (wild_i16x8 - wild_i16x8)));
-    averagings.push_back(Pattern("vhsubu.v8i16", (wild_u16x8 - wild_u16x8)));
-    averagings.push_back(Pattern("vhsubs.v4i32", (wild_i32x4 - wild_i32x4)));
-    averagings.push_back(Pattern("vhsubu.v4i32", (wild_u32x4 - wild_u32x4)));
+          // Can't fit uint32 max into an intimm
+          if (t.element_of() == UInt(32)) {
+              tmax = simplify(cast(w, t.max()));
+              tsmax = simplify(cast(ws, t.max()));
+          }
 
-    negations.push_back(Pattern("vqneg.v8i8", -max(wild_i8x8, -127)));
-    negations.push_back(Pattern("vqneg.v16i8", -max(wild_i8x16, -127)));
-    negations.push_back(Pattern("vqneg.v4i16", -max(wild_i16x4, -32767)));
-    negations.push_back(Pattern("vqneg.v8i16", -max(wild_i16x8, -32767)));
-    negations.push_back(Pattern("vqneg.v2i32", -max(wild_i32x2, -(0x7fffffff))));
-    negations.push_back(Pattern("vqneg.v4i32", -max(wild_i32x4, -(0x7fffffff))));
+          // Rounding-up averaging
+          casts.push_back(Pattern("vrhadd" + t_str, cast(t, (w_vector + w_vector + 1)/2), Pattern::NarrowArgs));
+          casts.push_back(Pattern("vrhadd" + t_str, cast(t, (w_vector + (w_vector + 1))/2), Pattern::NarrowArgs));
+          casts.push_back(Pattern("vrhadd" + t_str, cast(t, ((w_vector + 1) + w_vector)/2), Pattern::NarrowArgs));
 
+          // Rounding down averaging
+          casts.push_back(Pattern("vhadd" + t_str, cast(t, (w_vector + w_vector)/2), Pattern::NarrowArgs));
+
+          // Halving subtract
+          casts.push_back(Pattern("vhsub" + t_str, cast(t, (w_vector - w_vector)/2), Pattern::NarrowArgs));
+
+          // Saturating add
+          casts.push_back(Pattern("vqadd" + t_str, cast(t, clamp(w_vector + w_vector, tmin, tmax)), Pattern::NarrowArgs));
+
+          // In the unsigned case, the saturation below in unnecessary
+          if (t.is_uint()) {
+              casts.push_back(Pattern("vqadd" + t_str, cast(t, min(w_vector + w_vector, tmax)), Pattern::NarrowArgs));
+          }
+
+          // Saturating subtract
+          // N.B. Saturating subtracts always widen to a signed type
+          casts.push_back(Pattern("vqsub" + t_str, cast(t, clamp(ws_vector - ws_vector, tsmin, tsmax)), Pattern::NarrowArgs));
+
+          // In the unsigned case, we may detect that the top of the clamp is unnecessary
+          if (t.is_uint()) {
+              casts.push_back(Pattern("vqsub" + t_str, cast(t, max(ws_vector - ws_vector, 0)), Pattern::NarrowArgs));
+          }
+      }
+
+      // At some point llvm started recognising narrowing shifts
+      // directly and these intrinsics went away.
+      #if LLVM_VERSION < 35
+      casts.push_back(Pattern("vshiftn.v8i8", _i8(wild_i16x8/wild_i16x8), Pattern::RightShift));
+      casts.push_back(Pattern("vshiftn.v4i16", _i16(wild_i32x4/wild_i32x4), Pattern::RightShift));
+      casts.push_back(Pattern("vshiftn.v2i32", _i32(wild_i64x2/wild_i64x2), Pattern::RightShift));
+      casts.push_back(Pattern("vshiftn.v8i8", _u8(wild_u16x8/wild_u16x8), Pattern::RightShift));
+      casts.push_back(Pattern("vshiftn.v4i16", _u16(wild_u32x4/wild_u32x4), Pattern::RightShift));
+      casts.push_back(Pattern("vshiftn.v2i32", _u32(wild_u64x2/wild_u64x2), Pattern::RightShift));
+
+      // Widening left shifts
+      left_shifts.push_back(Pattern("vshiftls.v8i16", _i16(wild_i8x8)*wild_i16x8, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshiftls.v4i32", _i32(wild_i16x4)*wild_i32x4, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshiftls.v2i64", _i64(wild_i32x2)*wild_i64x2, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshiftlu.v8i16", _u16(wild_u8x8)*wild_u16x8, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshiftlu.v4i32", _u32(wild_u16x4)*wild_u32x4, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshiftlu.v2i64", _u64(wild_u32x2)*wild_u64x2, Pattern::LeftShift));
+      #endif
+
+      casts.push_back(Pattern("vqshiftns.v8i8", _i8q(wild_i16x8/wild_i16x8), Pattern::RightShift));
+      casts.push_back(Pattern("vqshiftns.v4i16", _i16q(wild_i32x4/wild_i32x4), Pattern::RightShift));
+      casts.push_back(Pattern("vqshiftns.v2i32", _i32q(wild_i64x2/wild_i64x2), Pattern::RightShift));
+      casts.push_back(Pattern("vqshiftnu.v8i8", _u8q(wild_u16x8/wild_u16x8), Pattern::RightShift));
+      casts.push_back(Pattern("vqshiftnu.v4i16", _u16q(wild_u32x4/wild_u32x4), Pattern::RightShift));
+      casts.push_back(Pattern("vqshiftnu.v2i32", _u32q(wild_u64x2/wild_u64x2), Pattern::RightShift));
+      casts.push_back(Pattern("vqshiftnsu.v8i8", _u8q(wild_i16x8/wild_i16x8), Pattern::RightShift));
+      casts.push_back(Pattern("vqshiftnsu.v4i16", _u16q(wild_i32x4/wild_i32x4), Pattern::RightShift));
+      casts.push_back(Pattern("vqshiftnsu.v2i32", _u32q(wild_i64x2/wild_i64x2), Pattern::RightShift));
+
+      casts.push_back(Pattern("vqshifts.v8i8", _i8q(_i16(wild_i8x8)*wild_i16x8), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshifts.v4i16", _i16q(_i32(wild_i16x4)*wild_i32x4), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshifts.v2i32", _i32q(_i64(wild_i32x2)*wild_i64x2), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshiftu.v8i8", _u8q(_u16(wild_u8x8)*wild_u16x8), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshiftu.v4i16", _u16q(_u32(wild_u16x4)*wild_u32x4), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshiftu.v2i32", _u32q(_u64(wild_u32x2)*wild_u64x2), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshiftsu.v8i8", _u8q(_i16(wild_i8x8)*wild_i16x8), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshiftsu.v4i16", _u16q(_i32(wild_i16x4)*wild_i32x4), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshiftsu.v2i32", _u32q(_i64(wild_i32x2)*wild_i64x2), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshifts.v16i8", _i8q(_i16(wild_i8x16)*wild_i16x16), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshifts.v8i16", _i16q(_i32(wild_i16x8)*wild_i32x8), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshifts.v4i32", _i32q(_i64(wild_i32x4)*wild_i64x4), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshiftu.v16i8", _u8q(_u16(wild_u8x16)*wild_u16x16), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshiftu.v8i16", _u16q(_u32(wild_u16x8)*wild_u32x8), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshiftu.v4i32", _u32q(_u64(wild_u32x4)*wild_u64x4), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshiftsu.v16i8", _u8q(_i16(wild_i8x16)*wild_i16x16), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshiftsu.v8i16", _u16q(_i32(wild_i16x8)*wild_i32x8), Pattern::LeftShift));
+      casts.push_back(Pattern("vqshiftsu.v4i32", _u32q(_i64(wild_i32x4)*wild_i64x4), Pattern::LeftShift));
+
+      casts.push_back(Pattern("vqmovns.v8i8", _i8q(wild_i16x8)));
+      casts.push_back(Pattern("vqmovns.v4i16", _i16q(wild_i32x4)));
+      casts.push_back(Pattern("vqmovns.v2i32", _i32q(wild_i64x2)));
+      casts.push_back(Pattern("vqmovnu.v8i8", _u8q(wild_u16x8)));
+      casts.push_back(Pattern("vqmovnu.v4i16", _u16q(wild_u32x4)));
+      casts.push_back(Pattern("vqmovnu.v2i32", _u32q(wild_u64x2)));
+      casts.push_back(Pattern("vqmovnsu.v8i8", _u8q(wild_i16x8)));
+      casts.push_back(Pattern("vqmovnsu.v4i16", _u16q(wild_i32x4)));
+      casts.push_back(Pattern("vqmovnsu.v2i32", _u32q(wild_i64x2)));
+
+      // Non-widening left shifts
+      left_shifts.push_back(Pattern("vshifts.v16i8", wild_i8x16*wild_i8x16, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshifts.v8i16", wild_i16x8*wild_i16x8, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshifts.v4i32", wild_i32x4*wild_i32x4, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshifts.v2i64", wild_i64x2*wild_i64x2, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshiftu.v16i8", wild_u8x16*wild_u8x16, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshiftu.v8i16", wild_u16x8*wild_u16x8, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshiftu.v4i32", wild_u32x4*wild_u32x4, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshiftu.v2i64", wild_u64x2*wild_u64x2, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshifts.v8i8",  wild_i8x8*wild_i8x8, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshifts.v4i16", wild_i16x4*wild_i16x4, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshifts.v2i32", wild_i32x2*wild_i32x2, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshiftu.v8i8",  wild_u8x8*wild_u8x8, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshiftu.v4i16", wild_u16x4*wild_u16x4, Pattern::LeftShift));
+      left_shifts.push_back(Pattern("vshiftu.v2i32", wild_u32x2*wild_u32x2, Pattern::LeftShift));
+
+      averagings.push_back(Pattern("vhadds.v8i8", (wild_i8x8 + wild_i8x8)));
+      averagings.push_back(Pattern("vhaddu.v8i8", (wild_u8x8 + wild_u8x8)));
+      averagings.push_back(Pattern("vhadds.v4i16", (wild_i16x4 + wild_i16x4)));
+      averagings.push_back(Pattern("vhaddu.v4i16", (wild_u16x4 + wild_u16x4)));
+      averagings.push_back(Pattern("vhadds.v2i32", (wild_i32x2 + wild_i32x2)));
+      averagings.push_back(Pattern("vhaddu.v2i32", (wild_u32x2 + wild_u32x2)));
+      averagings.push_back(Pattern("vhadds.v16i8", (wild_i8x16 + wild_i8x16)));
+      averagings.push_back(Pattern("vhaddu.v16i8", (wild_u8x16 + wild_u8x16)));
+      averagings.push_back(Pattern("vhadds.v8i16", (wild_i16x8 + wild_i16x8)));
+      averagings.push_back(Pattern("vhaddu.v8i16", (wild_u16x8 + wild_u16x8)));
+      averagings.push_back(Pattern("vhadds.v4i32", (wild_i32x4 + wild_i32x4)));
+      averagings.push_back(Pattern("vhaddu.v4i32", (wild_u32x4 + wild_u32x4)));
+      averagings.push_back(Pattern("vhsubs.v8i8", (wild_i8x8 - wild_i8x8)));
+      averagings.push_back(Pattern("vhsubu.v8i8", (wild_u8x8 - wild_u8x8)));
+      averagings.push_back(Pattern("vhsubs.v4i16", (wild_i16x4 - wild_i16x4)));
+      averagings.push_back(Pattern("vhsubu.v4i16", (wild_u16x4 - wild_u16x4)));
+      averagings.push_back(Pattern("vhsubs.v2i32", (wild_i32x2 - wild_i32x2)));
+      averagings.push_back(Pattern("vhsubu.v2i32", (wild_u32x2 - wild_u32x2)));
+      averagings.push_back(Pattern("vhsubs.v16i8", (wild_i8x16 - wild_i8x16)));
+      averagings.push_back(Pattern("vhsubu.v16i8", (wild_u8x16 - wild_u8x16)));
+      averagings.push_back(Pattern("vhsubs.v8i16", (wild_i16x8 - wild_i16x8)));
+      averagings.push_back(Pattern("vhsubu.v8i16", (wild_u16x8 - wild_u16x8)));
+      averagings.push_back(Pattern("vhsubs.v4i32", (wild_i32x4 - wild_i32x4)));
+      averagings.push_back(Pattern("vhsubu.v4i32", (wild_u32x4 - wild_u32x4)));
+
+      negations.push_back(Pattern("vqneg.v8i8", -max(wild_i8x8, -127)));
+      negations.push_back(Pattern("vqneg.v16i8", -max(wild_i8x16, -127)));
+      negations.push_back(Pattern("vqneg.v4i16", -max(wild_i16x4, -32767)));
+      negations.push_back(Pattern("vqneg.v8i16", -max(wild_i16x8, -32767)));
+      negations.push_back(Pattern("vqneg.v2i32", -max(wild_i32x2, -(0x7fffffff))));
+      negations.push_back(Pattern("vqneg.v4i32", -max(wild_i32x4, -(0x7fffffff))));
+    }
 }
 
 llvm::Triple CodeGen_ARM::get_target_triple() const {
     llvm::Triple triple;
-
-    if (target.bits == 64) {
-
-    }
 
     if (target.bits == 32) {
         if (target.features & Target::ARMv7s) {
@@ -345,7 +346,6 @@ llvm::Triple CodeGen_ARM::get_target_triple() const {
     }
 
     if (target.os == Target::Android) {
-        user_assert(target.bits == 32) << "ARM android must be 32-bit\n";
         triple.setOS(llvm::Triple::Linux);
         triple.setEnvironment(llvm::Triple::EABI);
     } else if (target.os == Target::IOS) {
@@ -415,6 +415,9 @@ Value *CodeGen_ARM::call_intrin(Type result_type, const string &name, vector<Exp
 Value *CodeGen_ARM::call_intrin(llvm::Type *result_type,
                                 const string &name,
                                 vector<Value *> arg_values) {
+    // AArch64 shouldn't yet be calling here
+    internal_assert(target.bits == 32);
+
     vector<llvm::Type *> arg_types(arg_values.size());
     for (size_t i = 0; i < arg_values.size(); i++) {
         arg_types[i] = arg_values[i]->getType();
@@ -456,6 +459,9 @@ Instruction *CodeGen_ARM::call_void_intrin(const string &name, vector<Expr> args
 
 
 Instruction *CodeGen_ARM::call_void_intrin(const string &name, vector<Value *> arg_values) {
+    // AArch64 shouldn't yet be calling here
+    internal_assert(target.bits == 32);
+
     vector<llvm::Type *> arg_types(arg_values.size());
     for (size_t i = 0; i < arg_values.size(); i++) {
         arg_types[i] = arg_values[i]->getType();
@@ -521,6 +527,12 @@ Expr try_narrow(Expr a, Type target) {
 }
 
 void CodeGen_ARM::visit(const Cast *op) {
+    // AArch64 SIMD not yet supported
+    if (target.bits == 64) {
+        CodeGen::visit(op);
+        return;
+    }
+
     vector<Expr> matches;
 
     for (size_t i = 0; i < casts.size() ; i++) {
@@ -599,6 +611,12 @@ void CodeGen_ARM::visit(const Cast *op) {
 }
 
 void CodeGen_ARM::visit(const Mul *op) {
+    // AArch64 SIMD not yet supported
+    if (target.bits == 64) {
+        CodeGen::visit(op);
+        return;
+    }
+
     // We only have peephole optimizations for int vectors for now
     if (op->type.is_scalar() || op->type.is_float()) {
         CodeGen::visit(op);
@@ -644,6 +662,11 @@ void CodeGen_ARM::visit(const Mul *op) {
 }
 
 void CodeGen_ARM::visit(const Div *op) {
+    // AArch64 SIMD not yet supported
+    if (target.bits == 64) {
+        CodeGen::visit(op);
+        return;
+    }
 
     if (is_two(op->b) && (op->a.as<Add>() || op->a.as<Sub>())) {
         vector<Expr> matches;
@@ -831,6 +854,11 @@ void CodeGen_ARM::visit(const Add *op) {
 }
 
 void CodeGen_ARM::visit(const Sub *op) {
+    // AArch64 SIMD not yet supported
+    if (target.bits == 64) {
+        CodeGen::visit(op);
+        return;
+    }
 
     vector<Expr> matches;
     for (size_t i = 0; i < negations.size(); i++) {
@@ -865,6 +893,11 @@ void CodeGen_ARM::visit(const Sub *op) {
 }
 
 void CodeGen_ARM::visit(const Min *op) {
+    // AArch64 SIMD not yet supported
+    if (target.bits == 64) {
+        CodeGen::visit(op);
+        return;
+    }
 
     if (op->type == Float(32)) {
         // Use a 2-wide vector instead
@@ -908,6 +941,11 @@ void CodeGen_ARM::visit(const Min *op) {
 }
 
 void CodeGen_ARM::visit(const Max *op) {
+    // AArch64 SIMD not yet supported
+    if (target.bits == 64) {
+        CodeGen::visit(op);
+        return;
+    }
 
     if (op->type == Float(32)) {
         // Use a 2-wide vector instead
@@ -951,6 +989,12 @@ void CodeGen_ARM::visit(const Max *op) {
 }
 
 void CodeGen_ARM::visit(const LT *op) {
+    // AArch64 SIMD not yet supported
+    if (target.bits == 64) {
+        CodeGen::visit(op);
+        return;
+    }
+
     const Call *a = op->a.as<Call>(), *b = op->b.as<Call>();
 
     // Check if they're hidden behind a broadcast
@@ -998,6 +1042,12 @@ void CodeGen_ARM::visit(const LT *op) {
 }
 
 void CodeGen_ARM::visit(const LE *op) {
+    // AArch64 SIMD not yet supported
+    if (target.bits == 64) {
+        CodeGen::visit(op);
+        return;
+    }
+
     const Call *a = op->a.as<Call>(), *b = op->b.as<Call>();
 
     // Check if they're hidden behind a broadcast
@@ -1045,6 +1095,11 @@ void CodeGen_ARM::visit(const LE *op) {
 }
 
 void CodeGen_ARM::visit(const Select *op) {
+    // AArch64 SIMD not yet supported
+    if (target.bits == 64) {
+        CodeGen::visit(op);
+        return;
+    }
 
     // Absolute difference patterns:
     // select(a < b, b - a, a - b)
@@ -1091,6 +1146,11 @@ void CodeGen_ARM::visit(const Select *op) {
 }
 
 void CodeGen_ARM::visit(const Store *op) {
+    // AArch64 SIMD not yet supported
+    if (target.bits == 64) {
+        CodeGen::visit(op);
+        return;
+    }
 
     // A dense store of an interleaving can be done using a vst2 intrinsic
     const Ramp *ramp = op->index.as<Ramp>();
@@ -1197,6 +1257,12 @@ void CodeGen_ARM::visit(const Store *op) {
 }
 
 void CodeGen_ARM::visit(const Load *op) {
+    // AArch64 SIMD not yet supported
+    if (target.bits == 64) {
+        CodeGen::visit(op);
+        return;
+    }
+
     const Ramp *ramp = op->index.as<Ramp>();
 
     // We only deal with ramps here

--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -630,7 +630,7 @@ Value *CodeGen_GPU_Host<CodeGen_CPU>::get_module_state() {
 template class CodeGen_GPU_Host<CodeGen_X86>;
 #endif
 
-#ifdef WITH_ARM
+#if defined(WITH_ARM) || defined(WITH_AARCH64)
 template class CodeGen_GPU_Host<CodeGen_ARM>;
 #endif
 

--- a/src/StmtCompiler.cpp
+++ b/src/StmtCompiler.cpp
@@ -23,7 +23,7 @@ StmtCompiler::StmtCompiler(Target target) {
         if (target.arch == Target::X86) {
             contents = new CodeGen_GPU_Host<CodeGen_X86>(target);
         }
-#ifdef WITH_ARM
+#if defined(WITH_ARM) || defined(WITH_AARCH64)
         else if (target.arch == Target::ARM) {
             contents = new CodeGen_GPU_Host<CodeGen_ARM>(target);
         }

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -412,7 +412,16 @@ DECLARE_CPP_INITMOD(tracing)
 DECLARE_CPP_INITMOD(write_debug_image)
 DECLARE_CPP_INITMOD(posix_print)
 
+#ifdef WITH_ARM
 DECLARE_LL_INITMOD(arm)
+#else
+DECLARE_NO_INITMOD(arm)
+#endif
+#ifdef WITH_AARCH64
+DECLARE_LL_INITMOD(aarch64)
+#else
+DECLARE_NO_INITMOD(aarch64)
+#endif
 DECLARE_LL_INITMOD(posix_math)
 DECLARE_LL_INITMOD(pnacl_math)
 DECLARE_LL_INITMOD(win32_math)
@@ -622,7 +631,11 @@ llvm::Module *get_initial_module_for_target(Target t, llvm::LLVMContext *c) {
         modules.push_back(get_initmod_x86_ll(c));
     }
     if (t.arch == Target::ARM) {
-        modules.push_back(get_initmod_arm_ll(c));
+        if (t.bits == 64) {
+          modules.push_back(get_initmod_aarch64_ll(c));
+        } else {
+          modules.push_back(get_initmod_arm_ll(c));
+        }
     }
     if (t.features & Target::SSE41) {
         modules.push_back(get_initmod_x86_sse41_ll(c));

--- a/src/runtime/aarch64.ll
+++ b/src/runtime/aarch64.ll
@@ -1,0 +1,1 @@
+; TODO: add specializations for ARMv8A Advanced SIMD


### PR DESCRIPTION
A few points that bear consideration:

— WITH_ARM now implies 32-bit ARM (only); WITH_AARCH64 implies 64-bit
ARM (only). This is a little ugly, but since older LLVM versions don’t
support aarch64 it seems imprudent to have WITH_ARM require 64-bit as
well. (Alternately, we could have WITH_ARM mean “at least ARM32” and
WITH_ARM+WITH_AARCH64 mean 32+64, but none of the other WITH flags are
additive in this way AFAIK.)

— However, CodeGen_ARM.cpp generates code for both 32-bit and 64-bit
ARM; essentially all of the NEON specialization is omitted from the
64-bit paths, as the ARMv8A AdvSIMD instruction set has nontrivially
different assembly syntax from existing NEON code. (It’s not yet clear
to me if the naming patterns are similar enough to existing NEON that
some macro-ization might allow us to recycle existing code; if not, it
may prove simpler in the future to simply add a CodeGen_AARCH64.cpp,
but some experimention is likely prudent first.)

— Similarly, a stub aarch64.ll file was added to hold future
specializations for ARMv8A AdvSIMD; we’ll definitely need it as we
flesh out support.

Note that in order to generate AArch64 code, you’ll need to ensure that
your LLVM has aarch64 enabled as a target (we should probably update
the README to reflect this).
