### PR TITLE
Fix for Condition failed: op->args[0].as<StringImm>() running apps/glsl ...

### DIFF
--- a/apps/glsl/Makefile
+++ b/apps/glsl/Makefile
@@ -17,7 +17,7 @@ ifeq ($(UNAME), Darwin)
 OPENGL_LIBS = -framework AGL
 endif
 
-HALIDE_LIBS = $(HALIDE_LIB) -ldl -lpthread
+HALIDE_LIBS = $(HALIDE_LIB) -ldl -lpthread -lcurses
 
 all: opengl_test
 
@@ -25,7 +25,7 @@ run: opengl_test
 	LD_LIBRARY_PATH=../../bin ./opengl_test
 
 opengl_test: blur.o ycc.o opengl_test.o
-	$(CXX) $(CXXFLAGS) $^ -o $@ -ldl -lpthread -L$(TOP)/bin
+	$(CXX) $(CXXFLAGS) $^ -o $@ -ldl -lpthread -L$(TOP)/bin $(OPENGL_LIBS)
 
 blur.h blur.o: halide_blur
 	HL_TARGET=host-opengl-gpu_debug ./halide_blur

--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -134,7 +134,7 @@ struct FindOneCommonSubexpression : public IRGraphVisitor {
         set<const IRNode *>::iterator iter = visited.find(e.ptr);
 
         if (iter != visited.end()) {
-            if (e.as<Variable>() || is_const(e)) {
+            if (e.as<Variable>() || is_const(e) || e.as<StringImm>()) {
                 return;
             }
 


### PR DESCRIPTION
...test #384 

> This fixes the assert in the test:
> Internal error at src/CodeGen_GPU_Host.cpp:182
> Condition failed: op->args[0].as<StringImm>()
> 
> The op for the Call visitor is a glsl_texture_load and CodeGen_GPU_Host
> assumes that the first argument is a StringImm. The argument was originally
> assigned as one by the InjectOpenGLIntrinsics pass, but it appears that a
> CSE pass is changing it to an ExprNode.

The fix prevents the CSE pass from replacing StringImms.

The pull also includes updates to the build files for the apps/glsl test.
