### PR TITLE
Update make distrib for README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,9 +471,9 @@ $(DISTRIB_DIR)/halide.tgz: $(BIN_DIR)/libHalide.a $(BIN_DIR)/libHalide.so includ
 	cp include/HalideRuntime.h $(DISTRIB_DIR)/include
 	cp tutorial/images/*.png $(DISTRIB_DIR)/tutorial/images
 	cp tutorial/*.cpp tutorial/*.h $(DISTRIB_DIR)/tutorial
-	cp README $(DISTRIB_DIR)
+	cp README.md $(DISTRIB_DIR)
 	ln -sf $(DISTRIB_DIR) halide
-	tar -czf $(DISTRIB_DIR)/halide.tgz halide/bin halide/include halide/tutorial halide/README
+	tar -czf $(DISTRIB_DIR)/halide.tgz halide/bin halide/include halide/tutorial halide/README.md
 	rm halide
 
 distrib: $(DISTRIB_DIR)/halide.tgz


### PR DESCRIPTION
`make distrib` was looking for the non-existent file "README", which was renamed to "README.md" by commit 9fc6c65 as part of PR #427
