### PR TITLE
Removed extra comma from CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -275,7 +275,7 @@ set(HEADER_FILES
   UnifyDuplicateLets.h
   HumanReadableStmt.h
   StmtToHtml.h
-  Memoization.h,
+  Memoization.h
   CodeGen_MIPS.h)
 
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/include")


### PR DESCRIPTION
This patch removes a comma that breaks the CMake build.
