### PR TITLE
Specialize All Clamped Ramps

### DIFF
--- a/src/SpecializeClampedRamps.cpp
+++ b/src/SpecializeClampedRamps.cpp
@@ -17,8 +17,8 @@ private:
     using IRVisitor::visit;
 
     void visit(const Min *op) {
-        Expr a = mutate(op->a);
-        Expr b = mutate(op->b);
+        Expr a = simplify(mutate(op->a));
+        Expr b = simplify(mutate(op->b));
 
         const Ramp *ra = a.as<Ramp>();
         const Ramp *rb = b.as<Ramp>();
@@ -44,8 +44,8 @@ private:
     }
 
     void visit(const Max *op) {
-        Expr a = mutate(op->a);
-        Expr b = mutate(op->b);
+        Expr a = simplify(mutate(op->a));
+        Expr b = simplify(mutate(op->b));
 
         const Ramp *ra = a.as<Ramp>();
         const Ramp *rb = b.as<Ramp>();
@@ -94,8 +94,6 @@ class SpecializeClampedRamps : public IRMutator {
         if (simpler_store.same_as(op)) {
             stmt = op;
         } else {
-            simpler_store = simplify(simpler_store);
-            simpler_store = mutate(simpler_store);
             Expr predicate = simplify(p.min_predicate && p.max_predicate);
             stmt = IfThenElse::make(predicate, simpler_store, op);
         }
@@ -110,8 +108,7 @@ class SpecializeClampedRamps : public IRMutator {
         } else if (simpler_value.same_as(op->value)) {
             stmt = LetStmt::make(op->name, op->value, body);
         } else {
-            Stmt simpler_let = LetStmt::make(op->name, simplify(simpler_value), body);
-            simpler_let = mutate(simpler_let);
+            Stmt simpler_let = LetStmt::make(op->name, simpler_value, body);
             Expr predicate = simplify(p.min_predicate && p.max_predicate);
             stmt = IfThenElse::make(predicate, simpler_let, op);
         }


### PR DESCRIPTION
This change recursively applies the specialize_clamped_ramps mutator until the stmt is fixed. This allows us to specialize all of the clamped ramps rather than just the outermost. So, for example, we were previously generating stmts like:

```
produce output {
  for (output.s0.x.x, 0, ((output.extent.0 + 15)/16)) {
    let output.s0.x.tmp.base = min(((output.s0.x.x*16) + output.min.0), ((output.min.0 + output.extent.0) + -16))
    if ((((output.s0.x.tmp.base - input.extent.0) + 15) <= input.min.0)) {
      output[ramp((output.s0.x.tmp.base - output.min.0), 1, 16)] = uint8x16(max(min((((int16x16(input[ramp((output.s0.x.tmp.base - input.min.0), 1, 16)])*x16(int16(3))) + int16x16(input[(max(ramp((output.s0.x.tmp.base + -1), 1, 16), x16(input.min.0)) - x16(input.min.0))]))/x16(int16(4))), x16(int16(255))), x16(int16(0))))
    } else {
      output[ramp((output.s0.x.tmp.base - output.min.0), 1, 16)] = uint8x16(max(min((((int16x16(input[ramp((output.s0.x.tmp.base - input.min.0), 1, 16)])*x16(int16(3))) + int16x16(input[(max((min(ramp(output.s0.x.tmp.base, 1, 16), x16((input.min.0 + input.extent.0))) + x16(-1)), x16(input.min.0)) - x16(input.min.0))]))/x16(int16(4))), x16(int16(255))), x16(int16(0))))
    }
  }
}
```

After this change, we would generate the stmt:

```
produce output {
  for (output.s0.x.x, 0, ((output.extent.0 + 15)/16)) {
    let output.s0.x.tmp.base = min(((output.s0.x.x*16) + output.min.0), ((output.min.0 + output.extent.0) + -16))
    if ((((output.s0.x.tmp.base - input.extent.0) + 15) <= input.min.0)) {
      if (((input.min.0 + 1) <= output.s0.x.tmp.base)) {
        output[ramp((output.s0.x.tmp.base - output.min.0), 1, 16)] = uint8x16(max(min((((int16x16(input[ramp((output.s0.x.tmp.base - input.min.0), 1, 16)])*x16(int16(3))) + int16x16(input[ramp(((output.s0.x.tmp.base - input.min.0) + -1), 1, 16)]))/x16(int16(4))), x16(int16(255))), x16(int16(0))))
      } else {
        output[ramp((output.s0.x.tmp.base - output.min.0), 1, 16)] = uint8x16(max(min((((int16x16(input[ramp((output.s0.x.tmp.base - input.min.0), 1, 16)])*x16(int16(3))) + int16x16(input[(max(ramp((output.s0.x.tmp.base + -1), 1, 16), x16(input.min.0)) - x16(input.min.0))]))/x16(int16(4))), x16(int16(255))), x16(int16(0))))
      }
    } else {
      output[ramp((output.s0.x.tmp.base - output.min.0), 1, 16)] = uint8x16(max(min((((int16x16(input[ramp((output.s0.x.tmp.base - input.min.0), 1, 16)])*x16(int16(3))) + int16x16(input[(max((min(ramp(output.s0.x.tmp.base, 1, 16), x16((input.min.0 + input.extent.0))) + x16(-1)), x16(input.min.0)) - x16(input.min.0))]))/x16(int16(4))), x16(int16(255))), x16(int16(0))))
    }
  }
}
```
