### PR TITLE
Add Target::with_feature() and without_feature()

### DIFF
--- a/src/Target.h
+++ b/src/Target.h
@@ -110,6 +110,26 @@ struct Target {
         return true;
     }
 
+    /** Return a copy of the target with the given feature set.
+     * This is convenient when enabling certain features (e.g. NoBoundsQuery)
+     * in an initialization list, where the target to be mutated may be
+     * a const reference. */
+    Target with_feature(Feature f) const {
+        Target copy = *this;
+        copy.set_feature(f);
+        return copy;
+    }
+
+    /** Return a copy of the target with the given feature cleared.
+     * This is convenient when disabling certain features (e.g. NoBoundsQuery)
+     * in an initialization list, where the target to be mutated may be
+     * a const reference. */
+    Target without_feature(Feature f) const {
+        Target copy = *this;
+        copy.set_feature(f, false);
+        return copy;
+    }
+
     /** Is OpenCL or CUDA enabled in this target? I.e. is
      * Func::gpu_tile and similar going to work? We do not include
      * OpenGL, because it is not capable of gpgpu, and is not

--- a/test/correctness/target.cpp
+++ b/test/correctness/target.cpp
@@ -99,6 +99,25 @@ int main(int argc, char **argv) {
        return -1;
     }
 
+    // with_feature
+    t1 = Target(Target::Linux, Target::X86, 32, vec(Target::SSE41));
+    t2 = t1.with_feature(Target::NoAsserts).with_feature(Target::NoBoundsQuery);
+    ts = t2.to_string();
+    if (ts != "x86-32-linux-no_asserts-no_bounds_query-sse41") {
+       printf("to_string failure: %s\n", ts.c_str());
+       return -1;
+    }
+
+    // without_feature
+    t1 = Target(Target::Linux, Target::X86, 32, vec(Target::SSE41, Target::NoAsserts));
+    // Note that NoBoundsQuery wasn't set here, so 'without' is a no-op
+    t2 = t1.without_feature(Target::NoAsserts).without_feature(Target::NoBoundsQuery);
+    ts = t2.to_string();
+    if (ts != "x86-32-linux-sse41") {
+       printf("to_string failure: %s\n", ts.c_str());
+       return -1;
+    }
+
     printf("Success!\n");
     return 0;
 }


### PR DESCRIPTION
This is a bit of syntactic sugar to make setting/clearing Target
features a bit easier when initializing from a const reference; rather
than making a local copy and using set_feature, you can now use
(chained) with_feature() calls to make temporary mutated copies.
