### PR TITLE
Tuple constraints

### DIFF
--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -1518,7 +1518,7 @@ Stmt add_image_checks(Stmt s, Function f, const Target &t, const FuncValueBounds
 
                 std::string extent0_name = f.name() + ".0.extent." + dim;
                 if (replace_with_constrained.count(extent0_name) > 0 ) {
-                    min_constrained = replace_with_constrained[extent0_name];
+                    extent_constrained = replace_with_constrained[extent0_name];
                 } else {
                     extent_constrained = Variable::make(Int(32), extent0_name);
                 }


### PR DESCRIPTION
This is a small change to fix an issue Clay found with adding constraints to functions that spit out Tuples. To demonstrate, consider the Halide code:

```
  Func out("out");
  out(x) = Tuple(i_(x,0), i_(x,1), i_(x,2), i_(x,3));
  out.output_buffers()[0].set_min(0, 0).set_min(1, 0);
```

This was producing a stmt like:

```
produce out {
  for (out.s0.x, 0, out.0.extent.0) {
    let out.0.value = input[out.s0.x]
    let out.1.value = input[(out.s0.x + input.stride.1)]
    let out.2.value = input[(out.s0.x + (input.stride.1*2))]
    let out.3.value = input[(out.s0.x + (input.stride.1*3))]
    out.0[out.s0.x] = out.0.value
    out.1[(out.s0.x - out.0.min.0)] = out.1.value
    out.2[(out.s0.x - out.0.min.0)] = out.2.value
    out.3[(out.s0.x - out.0.min.0)] = out.3.value
  }
}
```

With this change we can get rid of the extraneous out.0.min.0 variables, and get a stmt like:

```
produce out {
  for (out.s0.x, 0, out.0.extent.0) {
    let out.0.value = input[out.s0.x]
    let out.1.value = input[(out.s0.x + input.stride.1)]
    let out.2.value = input[(out.s0.x + (input.stride.1*2))]
    let out.3.value = input[(out.s0.x + (input.stride.1*3))]
    out.0[out.s0.x] = out.0.value
    out.1[out.s0.x] = out.1.value
    out.2[out.s0.x] = out.2.value
    out.3[out.s0.x] = out.3.value
  }
}
```
