### PR TITLE
compile_header() marks function result as must-use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ TEST_OPENCL = 1
 endif
 endif
 
-TEST_CXX_FLAGS ?= $(BUILD_BIT_SIZE) -g -fno-omit-frame-pointer
+TEST_CXX_FLAGS ?= $(BUILD_BIT_SIZE) -g -fno-omit-frame-pointer -Werror -Wno-unused-function 
 ifeq ($(UNAME), Linux)
 TEST_CXX_FLAGS += -rdynamic
 ifneq ($(TEST_PTX), )

--- a/apps/HelloNaCl/Makefile
+++ b/apps/HelloNaCl/Makefile
@@ -1,7 +1,7 @@
 
 NACL_SDK_ROOT ?= $(HOME)/nacl_sdk/pepper_35
 
-WARNINGS := -Wall -Wswitch-enum
+WARNINGS := -Wall -Wswitch-enum -Werror -Wno-unused-function 
 CXXFLAGS := -pthread $(WARNINGS) -I $(NACL_SDK_ROOT)/include -I ../../include
 
 UNAME = $(shell uname)

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -12,7 +12,7 @@ bilateral_grid.o: bilateral_grid
 	./bilateral_grid 8
 
 filter: bilateral_grid.o filter.cpp
-	$(CXX) -I../support -O3 -ffast-math -Wall -Werror filter.cpp bilateral_grid.o -lpthread -ldl -o filter  $(PNGFLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS)
+	$(CXX) -I../support -O3  -ffast-math -Wall -Werror -Wno-unused-function filter.cpp bilateral_grid.o -lpthread -ldl -o filter  $(PNGFLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS)
 
 out.png: filter
 	./filter ../images/gray.png out.png 0.1

--- a/apps/bilateral_grid/filter.cpp
+++ b/apps/bilateral_grid/filter.cpp
@@ -21,7 +21,11 @@ int main(int argc, char **argv) {
     Image<float> input = load<float>(argv[1]);
     Image<float> output(input.width(), input.height(), 1);
 
-    bilateral_grid(atof(argv[3]), input, output);
+    int result = bilateral_grid(atof(argv[3]), input, output);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
 
 #if 1
     // Timing code
@@ -30,7 +34,11 @@ int main(int argc, char **argv) {
     for (int j = 0; j < 10; j++) {
         gettimeofday(&t1, NULL);
         for (int i = 0; i < 10; i++) {
-            bilateral_grid(atof(argv[3]), input, output);
+            int result = bilateral_grid(atof(argv[3]), input, output);
+            if (result != 0) {
+                printf("filter failed: %d\n", result);
+                return -1;
+            }
         }
         gettimeofday(&t2, NULL);
         double t = (t2.tv_sec - t1.tv_sec)*1000.0 + (t2.tv_usec - t1.tv_usec)/1000.0;

--- a/apps/blur/Makefile
+++ b/apps/blur/Makefile
@@ -19,7 +19,7 @@ endif
 
 # -O2 is faster than -O3 for this app (O3 unrolls too much)
 test: test.cpp halide_blur.o
-	$(CXX) $(OPENMP_FLAGS) -msse2 -Wall -O2 -I ../support/ test.cpp halide_blur.o -o test -lpthread -ldl $(PNGFLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS)
+	$(CXX) $(OPENMP_FLAGS) -msse2 -Wall -Werror -Wno-unused-function -Wno-unknown-pragmas -O2 -I ../support/ test.cpp halide_blur.o -o test -lpthread -ldl $(PNGFLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS)
 
 clean:
 	rm -f test halide_blur.o halide_blur

--- a/apps/blur/test.cpp
+++ b/apps/blur/test.cpp
@@ -181,13 +181,21 @@ Image<uint16_t> blur_halide(Image<uint16_t> in) {
     Image<uint16_t> out(in.width()-8, in.height()-2);
 
     // Call it once to initialize the halide runtime stuff
-    halide_blur(in, out);
+    int result = halide_blur(in, out);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        exit(-1);
+    }
 
     begin_timing;
 
     // Compute the same region of the output as blur_fast (i.e., we're
     // still being sloppy with boundary conditions)
-    halide_blur(in, out);
+    result = halide_blur(in, out);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        exit(-1);
+    }
 
     end_timing;
 

--- a/apps/c_backend/Makefile
+++ b/apps/c_backend/Makefile
@@ -16,7 +16,7 @@ pipeline_native.o: pipeline
 	./pipeline
 
 run: run.cpp pipeline_native.h pipeline_c.c
-	$(CXX) -Wall run.cpp pipeline_c.c pipeline_native.o -lpthread -o run $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS)
+	$(CXX) -Wall -Wno-unused-function run.cpp pipeline_c.c pipeline_native.o -lpthread -o run $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS)
 
 test: run
 	./run

--- a/apps/c_backend/run.cpp
+++ b/apps/c_backend/run.cpp
@@ -45,9 +45,17 @@ int main(int argc, char **argv) {
     Image<uint16_t> out_native(423, 633);
     Image<uint16_t> out_c(423, 633);
 
-    pipeline_native(in, out_native);
+    int result = pipeline_native(in, out_native);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
 
-    pipeline_c(in, out_c);
+    result = pipeline_c(in, out_c);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
 
     for (int y = 0; y < out_native.height(); y++) {
         for (int x = 0; x < out_native.width(); x++) {

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -22,7 +22,7 @@ fcam/Demosaic_ARM.o: fcam/Demosaic_ARM.cpp fcam/Demosaic_ARM.h
 	$(CXX) -c -I../support -Wall -fopenmp -O3 $< -o $@
 
 process: process.cpp curved.o fcam/Demosaic.o fcam/Demosaic_ARM.o
-	$(CXX) -I../support -Wall -O3 $^ -o $@ -lpthread -ldl -fopenmp $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS) $(PNGFLAGS)
+	$(CXX) -I../support -Wall -Werror -Wno-unused-function -O3 $^ -o $@ -lpthread -ldl -fopenmp $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS) $(PNGFLAGS)
 
 out.png: process
 	./process ../images/bayer_raw.png 3700 2.0 50 out.png

--- a/apps/glsl/Makefile
+++ b/apps/glsl/Makefile
@@ -7,7 +7,7 @@ HALIDE_LIB := $(TOP)/$(LIB_HALIDE)
 $(HALIDE_LIB): $(TOP)
 	$(MAKE) -C $(TOP) $(LIB_HALIDE)
 
-CXXFLAGS += -g -O0 -I../../include
+CXXFLAGS += -g -O0 -I../../include -Werror -Wno-unused-function 
 
 UNAME := $(shell uname)
 ifeq ($(UNAME), Linux)

--- a/apps/interpolate/Makefile
+++ b/apps/interpolate/Makefile
@@ -1,6 +1,6 @@
 include ../support/Makefile.inc
 
-CXXFLAGS += -g -Wall
+CXXFLAGS += -g -Wall -Werror -Wno-unused-function 
 
 .PHONY: clean
 

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -10,7 +10,7 @@ local_laplacian.o: local_laplacian
 	./local_laplacian
 
 process: process.cpp local_laplacian.o
-	$(CXX) -I../support -Wall -O3 process.cpp local_laplacian.o -o process -lpthread -ldl $(PNGFLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS)
+	$(CXX) -I../support -Wall -Werror -Wno-unused-function -O3 process.cpp local_laplacian.o -o process -lpthread -ldl $(PNGFLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS)
 
 out.png: process
 	./process ../images/rgb.png 8 1 1 out.png

--- a/apps/local_laplacian/process.cpp
+++ b/apps/local_laplacian/process.cpp
@@ -21,7 +21,11 @@ int main(int argc, char **argv) {
     unsigned int bestT = 0xffffffff;
     for (int i = 0; i < 5; i++) {
       gettimeofday(&t1, NULL);
-      local_laplacian(levels, alpha/(levels-1), beta, input, output);
+      int result = local_laplacian(levels, alpha/(levels-1), beta, input, output);
+      if (result != 0) {
+          printf("filter failed: %d\n", result);
+          return -1;
+      }
       gettimeofday(&t2, NULL);
       unsigned int t = (t2.tv_sec - t1.tv_sec) * 1000000 + (t2.tv_usec - t1.tv_usec);
       if (t < bestT) bestT = t;
@@ -29,7 +33,11 @@ int main(int argc, char **argv) {
     printf("%u\n", bestT);
 
 
-    local_laplacian(levels, alpha/(levels-1), beta, input, output);
+    int result = local_laplacian(levels, alpha/(levels-1), beta, input, output);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
 
     save(output, argv[5]);
 

--- a/apps/modules/Makefile
+++ b/apps/modules/Makefile
@@ -1,7 +1,7 @@
 include ../support/Makefile.inc
 
 HALIDE_LD_FLAGS=../../$(LIB_HALIDE) -lpthread -ldl -lz $(LDFLAGS)
-HALIDE_CXX_FLAGS=-I../../include -g
+HALIDE_CXX_FLAGS=-I../../include -g -Werror -Wno-unused-function 
 
 all: out.png
 

--- a/apps/modules/run_pipeline.cpp
+++ b/apps/modules/run_pipeline.cpp
@@ -12,7 +12,11 @@ int main(int argc, char **argv) {
     Image<uint8_t> input = load<uint8_t>(argv[1]);
     Image<uint8_t> output(input.width(), input.height(), 1);
 
-    pipeline(input, output);
+    int result = pipeline(input, output);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
 
     save(output, argv[2]);
 

--- a/apps/nacl_demos/Makefile
+++ b/apps/nacl_demos/Makefile
@@ -1,7 +1,7 @@
 
 NACL_SDK_ROOT ?= $(HOME)/nacl_sdk/pepper_35
 
-WARNINGS := -Wall -Wswitch-enum
+WARNINGS := -Wall -Wswitch-enum -Werror -Wno-unused-function 
 CXXFLAGS := -pthread $(WARNINGS) -I $(NACL_SDK_ROOT)/include -I ../../include
 
 UNAME = $(shell uname)

--- a/apps/resize/Makefile
+++ b/apps/resize/Makefile
@@ -1,6 +1,6 @@
 include ../support/Makefile.inc
 
-CXXFLAGS += -g -Wall
+CXXFLAGS += -g -Wall -Werror -Wno-unused-function 
 
 .PHONY: clean
 

--- a/apps/wavelet/Makefile
+++ b/apps/wavelet/Makefile
@@ -15,7 +15,7 @@ filter.o: filter.cpp $(HL_MODULES)
 	$(CXX) $(LIBPNG_CXX_FLAGS) -I../support -O3 -c filter.cpp
 
 filter: filter.o
-	$(CXX) filter.o $(HL_MODULES) $(PNGFLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS) -o filter -lpthread
+	$(CXX) filter.o -Werror -Wno-unused-function $(HL_MODULES) $(PNGFLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS) -o filter -lpthread
 
 clean:
 	rm -f wavelet filter filter.o $(HL_MODULES) $(HL_MODULES:%.o) $(HL_MODULES:%.o=%.h)

--- a/apps/wavelet/filter.cpp
+++ b/apps/wavelet/filter.cpp
@@ -37,22 +37,38 @@ int main(int argc, char **argv) {
     Image<float> inverse_transformed(input.width(), input.height(), 1);
 
     printf("haar_x\n");
-    haar_x(input, transformed);    
+    int result = haar_x(input, transformed);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
     printf("saving result...\n");
     save_transformed(transformed, "haar_x.png");
 
     printf("inverse_haar_x\n");
-    inverse_haar_x(transformed, inverse_transformed);
+    result = inverse_haar_x(transformed, inverse_transformed);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
     printf("saving result...\n");
     save(inverse_transformed, "inverse_haar_x.png");
 
     printf("daubechies_x\n");
-    daubechies_x(input, transformed);    
+    result = daubechies_x(input, transformed);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
     printf("saving result...\n");
     save_transformed(transformed, "daubechies_x.png");
 
     printf("inverse_daubechies_x\n");
-    inverse_daubechies_x(transformed, inverse_transformed);
+    result = inverse_daubechies_x(transformed, inverse_transformed);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
     printf("saving result...\n");
     save(inverse_transformed, "inverse_daubechies_x.png");
 

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -250,10 +250,20 @@ void CodeGen_C::compile_header(const string &name, const vector<Argument> &args)
     // Throw in a definition of a buffer_t
     stream << buffer_t_definition;
 
-    // Throw in a default (empty) definition of HALIDE_FUNCTION_ATTRS
-    // (some hosts may define this to e.g. __attribute__((warn_unused_result)))
+    stream << "#ifndef HALIDE_MUST_USE_RESULT\n";
+    stream << "#if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)\n";
+    stream << "#define HALIDE_MUST_USE_RESULT "
+              "__attribute__ ((warn_unused_result))\n";
+    stream << "#else\n";
+    stream << "#define HALIDE_MUST_USE_RESULT\n";
+    stream << "#endif\n";
+    stream << "#endif\n";
+
+    // Default HALIDE_FUNCTION_ATTRS to HALIDE_MUST_USE_RESULT;
+    // clients can undef this if they are certain that their implementation
+    // of halide_error() makes checking the  function result unnecessary.
     stream << "#ifndef HALIDE_FUNCTION_ATTRS\n";
-    stream << "#define HALIDE_FUNCTION_ATTRS\n";
+    stream << "#define HALIDE_FUNCTION_ATTRS HALIDE_MUST_USE_RESULT\n";
     stream << "#endif\n";
 
     // Now the function prototype

--- a/test/static/acquire_release_test.cpp
+++ b/test/static/acquire_release_test.cpp
@@ -206,7 +206,11 @@ int main(int argc, char **argv) {
 
     Image<float> output(W, H);
 
-    acquire_release(input, output);
+    int result = acquire_release(input, output);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
 
     output.copy_to_host();
 

--- a/test/static/embed_image_test.cpp
+++ b/test/static/embed_image_test.cpp
@@ -14,7 +14,11 @@ int main(int argc, char **argv) {
     }
     Image<float> output(10, 10, 3);
 
-    embed_image(input, output);
+    int result = embed_image(input, output);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
 
     // We expected the color channels to be flipped and multiplied by 0.5
     for (int y = 0; y < 10; y++) {
@@ -24,6 +28,7 @@ int main(int argc, char **argv) {
                 if (fabs(output(x, y, c) - correct) > 0.0001f) {
                     printf("output(%d, %d, %d) was %f instead of %f\n",
                            x, y, c, output(x, y, c), correct);
+                    return -1;
                 }
             }
         }

--- a/test/static/extended_buffer_t_test.cpp
+++ b/test/static/extended_buffer_t_test.cpp
@@ -16,7 +16,11 @@ int main(int argc, char **argv) {
     fancy_buffer_t fancy_input(input);
     fancy_input.extra_field = 17;
 
-    extended_buffer_t(&fancy_input, output);
+    int result = extended_buffer_t(&fancy_input, output);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
 
     // Output should be input + 17
     for (int y = 0; y < 10; y++) {

--- a/test/static/gpu_object_lifetime_test.cpp
+++ b/test/static/gpu_object_lifetime_test.cpp
@@ -18,7 +18,11 @@ int main(int argc, char **argv) {
     for (int i = 0; i < 2; i++) {
         Image<int> output(80);
 
-        func_gpu_object_lifetime(output);
+        int result = func_gpu_object_lifetime(output);
+        if (result != 0) {
+            printf("filter failed: %d\n", result);
+            return -1;
+        }
 
         output.copy_to_host();
         output.dev_free();

--- a/test/static/mandelbrot_test.cpp
+++ b/test/static/mandelbrot_test.cpp
@@ -12,7 +12,11 @@ int main(int argc, char **argv) {
     // Compute 100 different julia sets
     for (float t = 0; t < 100; t++) {
         float fx = cos(t/10.0f), fy = sin(t/10.0f);
-        mandelbrot(-2.0f, 2.0f, -1.4f, 1.4f, fx, fy, iters, output.width(), output.height(), output);
+        int result = mandelbrot(-2.0f, 2.0f, -1.4f, 1.4f, fx, fy, iters, output.width(), output.height(), output);
+        if (result != 0) {
+            printf("filter failed: %d\n", result);
+            return -1;
+        }
     }
 
     char buf[4096];

--- a/test/static/tiled_blur_test.cpp
+++ b/test/static/tiled_blur_test.cpp
@@ -37,7 +37,11 @@ int main(int argc, char **argv) {
 
     printf("Evaluating output over %d x %d in tiles of size 32 x 32\n",
            W, H);
-    tiled_blur(input, output);
+    int result = tiled_blur(input, output);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
 
     printf("Success!\n");
     return 0;

--- a/test/static/tiled_interleaved_test.cpp
+++ b/test/static/tiled_interleaved_test.cpp
@@ -61,7 +61,11 @@ int main(int argc, char **argv) {
     out.stride[2] = 1;
     out.elem_size = 4;
 
-    tiled_interleaved(&in, &out);
+    int result = tiled_interleaved(&in, &out);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
 
     printf("Success!\n");
     return 0;

--- a/test/static/user_context_insanity_test.cpp
+++ b/test/static/user_context_insanity_test.cpp
@@ -24,7 +24,11 @@ int launcher_task(void *user_context, int index, uint8_t *closure) {
     }
     Image<float> output(10, 10);
 
-    user_context_insanity(input, &got_context[index], output);
+    int result = user_context_insanity(input, &got_context[index], output);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
 
     return 0;
 }

--- a/test/static/user_context_test.cpp
+++ b/test/static/user_context_test.cpp
@@ -45,12 +45,20 @@ int main(int argc, char **argv) {
     }
     Image<float> output(10, 10);
 
-    user_context(input, context_pointer, output);
+    int result = user_context(input, context_pointer, output);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
     assert(called_malloc && called_free);
     assert(called_trace && !called_error);
 
     Image<float> big_output(11, 11);
-    user_context(input, context_pointer, big_output);
+    result = user_context(input, context_pointer, big_output);
+    if (result != 0) {
+        printf("filter failed: %d\n", result);
+        return -1;
+    }
     assert(called_error);
 
     printf("Success!\n");


### PR DESCRIPTION
Default HALIDE_FUNCTION_ATTRS to generate a warning then the function
result is unused (on gcc/clang, anyway), to encourage checking the
function results. (Users who which to defeat this can easily do so by
# define HALIDE_FUNCTION_ATTRS before including halide-generated

headers.) Fix all the tests that trigger the new warning. (Issue #473)
