### PR TITLE
Enable the LLVM JIT event listener

### DIFF
--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -19,7 +19,8 @@ using std::string;
 
 using namespace llvm;
 
-CodeGen_X86::CodeGen_X86(Target t) : CodeGen_Posix(t) {
+CodeGen_X86::CodeGen_X86(Target t) : CodeGen_Posix(t), 
+                                     jitEventListener(nullptr) {
 
     #if !(WITH_X86)
     user_error << "x86 not enabled for this build of Halide.\n";
@@ -683,6 +684,22 @@ string CodeGen_X86::mattrs() const {
 
 bool CodeGen_X86::use_soft_float_abi() const {
     return false;
+}
+
+void CodeGen_X86::jit_init(llvm::ExecutionEngine *ee, llvm::Module *) 
+{
+    jitEventListener = llvm::JITEventListener::createIntelJITEventListener();
+    if ( jitEventListener != nullptr ) {
+        ee->RegisterJITEventListener(jitEventListener);
+    }
+}
+void CodeGen_X86::jit_finalize(llvm::ExecutionEngine * ee, llvm::Module *, std::vector<JITCompiledModule::CleanupRoutine> *) 
+{
+    if ( jitEventListener != nullptr ) {
+        ee->UnregisterJITEventListener(jitEventListener);
+        delete jitEventListener;
+        jitEventListener = nullptr;
+    }
 }
 
 }}

--- a/src/CodeGen_X86.h
+++ b/src/CodeGen_X86.h
@@ -8,6 +8,10 @@
 #include "CodeGen_Posix.h"
 #include "Target.h"
 
+namespace llvm {
+class JITEventListener;
+}
+
 namespace Halide {
 namespace Internal {
 
@@ -29,6 +33,9 @@ public:
                  const std::vector<Buffer> &images_to_embed);
 
     static void test();
+    
+    void jit_init(llvm::ExecutionEngine *, llvm::Module *) override;    
+    void jit_finalize(llvm::ExecutionEngine *, llvm::Module *, std::vector<JITCompiledModule::CleanupRoutine> *) override;
 
 protected:
 
@@ -53,6 +60,9 @@ protected:
     std::string mcpu() const;
     std::string mattrs() const;
     bool use_soft_float_abi() const;
+
+private:
+    llvm::JITEventListener* jitEventListener;
 };
 
 }}

--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -23,6 +23,8 @@
 #else
 #include <llvm/ExecutionEngine/JIT.h>
 #endif
+#include <llvm/ExecutionEngine/JITEventListener.h>
+
 
 #if LLVM_VERSION < 35
 #include <llvm/Analysis/Verifier.h>


### PR DESCRIPTION
This PR enables the LLVM JIT event listener. It was tested on Windows with LLVM 3.3 and the JIT engine. It requires that LLVM is built with INTEL_JIT_EVENTS and should have no effect otherwise.

In Vtune, each function is identified separately and it is possible to browse the assembly along with the counters.
![vtune](https://cloud.githubusercontent.com/assets/8500539/4359670/db59adfe-4273-11e4-8d17-70a1606373f2.png)

Something similar should be possible with oprofile. 

Philippe
