### PR TITLE
FFT benchmark improvements

### DIFF
--- a/test/performance/fft.cpp
+++ b/test/performance/fft.cpp
@@ -523,14 +523,6 @@ Func make_complex(const Image<T> &re) {
     return ret;
 }
 
-template <typename T>
-Func make_complex(const Image<T> &re, const Image<T> &im) {
-    Var x, y;
-    Func ret;
-    ret(x, y) = Tuple(re(x, y), im(x, y));
-    return ret;
-}
-
 double log2(double x) {
     return log(x)/log(2.0);
 }


### PR DESCRIPTION
This PR cleans up the FFT to give benchmark numbers with fewer caveats:
- The complex case was actually real data, and Halide was doing some constant folding with the imaginary part. This is now fixed.
- The real transforms no longer use a transposed transform domain.
- The benchmark assumes the input and output is cached (again). I am pretty sure this matches the behavior of FFTW's benchmark.

There are also a few small optimizations and cleanups.
