### PR TITLE
Add set_type() and set_dimensions() to ImageParam.

### DIFF
--- a/src/Param.cpp
+++ b/src/Param.cpp
@@ -75,6 +75,16 @@ OutputImageParam &OutputImageParam::set_bounds(int dim, Expr min, Expr extent) {
     return set_min(dim, min).set_extent(dim, extent);
 }
 
+OutputImageParam &OutputImageParam::set_type(Type t) {
+    param.set_type(t);
+    return *this;
+}
+
+OutputImageParam &OutputImageParam::set_dimensions(int d) {
+    dims = d;
+    return *this;
+}
+
 int OutputImageParam::dimensions() const {
     return dims;
 }

--- a/src/Param.h
+++ b/src/Param.h
@@ -234,6 +234,12 @@ public:
     /** Set the min and extent in one call. */
     EXPORT OutputImageParam &set_bounds(int dim, Expr min, Expr extent);
 
+    /** Set the type. */
+    EXPORT OutputImageParam &set_type(Type t);
+
+    /** Set the dimensionality. */
+    EXPORT OutputImageParam &set_dimensions(int d);
+
     /** Get the dimensionality of this image parameter */
     EXPORT int dimensions() const;
 

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -167,6 +167,11 @@ Expr Parameter::get_max_value() {
     return contents.ptr->max_value;
 }
 
+void Parameter::set_type(Type t) {
+    check_defined();
+    contents.ptr->type = t;
+}
+
 void check_call_arg_types(const std::string &name, std::vector<Expr> *args, int dims) {
     user_assert(args->size() == (size_t)dims)
         << args->size() << "-argument call to \""

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -105,6 +105,9 @@ public:
     EXPORT void set_max_value(Expr e);
     EXPORT Expr get_max_value();
     // @}
+
+    /** Replace the Parameter's type. */
+    EXPORT void set_type(Type t);
 };
 
 /** Validate arguments to a call to a func, image or imageparam. */

--- a/test/correctness/constraints.cpp
+++ b/test/correctness/constraints.cpp
@@ -12,7 +12,13 @@ void my_error_handler(void *user_context, const char *msg) {
 int main(int argc, char **argv) {
     Func f, g;
     Var x, y;
-    ImageParam param(Int(32), 2);
+
+    // Note that we deliberately initialize to incorrect type and dimensions here,
+    // to verify that set_type and set_dimensions are working.
+    ImageParam param(Float(32), 3);
+    param.set_type(Int(32));
+    param.set_dimensions(2);
+
     Image<int> image1(128, 73);
     Image<int> image2(144, 23);
 


### PR DESCRIPTION
(Note that these are currently of limited usefulness, but will be quite
useful if/when the Generator branch lands; proposing this change here
to reduce noise there.)
