### PR TITLE
Fix for Bug #516. Make the GlobalState instance and its constructor not ...

### DIFF
--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -122,7 +122,7 @@ struct ModuleState {
 
 // All persistent state maintained by the runtime.
 struct GlobalState {
-    GlobalState();
+    void init();
 
     bool initialized;
 
@@ -153,7 +153,7 @@ struct GlobalState {
 };
 
 
-GlobalState global_state;
+WEAK GlobalState global_state;
 
 // A list of module-specific state. Each module corresponds to a single Halide filter
 WEAK ModuleState *state_list;
@@ -421,7 +421,7 @@ WEAK GLfloat quad_vertices[] = {
 };
 WEAK GLuint quad_indices[] = { 0, 1, 2, 3 };
 
-GlobalState::GlobalState() {
+WEAK void GlobalState::init() {
     initialized = false;
     profile = OpenGL;
     major_version = 2;
@@ -521,7 +521,7 @@ WEAK int halide_opengl_init(void *user_context) {
         return 0;
     }
 
-    global_state = GlobalState();
+    global_state.init();
 
     // Make a context if there isn't one
     if (halide_opengl_create_context(user_context)) {
@@ -1400,7 +1400,7 @@ WEAK void halide_opengl_context_lost(void *user_context) {
         tex = next;
     }
 
-    ST = GlobalState();
+    global_state.init();
     return;
 }
 


### PR DESCRIPTION
This change resolves the LLVM error reported in Bug 516 by making two symbols in the OpenGL runtime not-WEAK. 
