### PR TITLE
Allow Target::to_string/from_string roundtripping for PNaCl

### DIFF
--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -215,11 +215,7 @@ bool Target::merge_string(const std::string &target) {
             is_arch = true;
         } else if (tok == "pnacl") {
             arch = Target::PNaCl;
-            os = Target::NaCl;
-            bits = 32;
-            is_os = true;
             is_arch = true;
-            is_bits = true;
         } else if (tok == "mips") {
             arch = Target::MIPS;
             is_arch = true;
@@ -324,6 +320,16 @@ bool Target::merge_string(const std::string &target) {
 
     if (arch_specified && !bits_specified) {
         return false;
+    }
+
+    // If arch is PNaCl, require explicit setting of os and bits as well.
+    if (arch_specified && arch == Target::PNaCl) {
+        if (!os_specified || os != Target::NaCl) {
+            return false;
+        }
+        if (!bits_specified || bits != 32) {
+            return false;
+        }
     }
 
     return true;

--- a/test/correctness/target.cpp
+++ b/test/correctness/target.cpp
@@ -67,6 +67,22 @@ int main(int argc, char **argv) {
        return -1;
     }
 
+    // Full specification round-trip, PNacl
+    t1 = Target(Target::NaCl, Target::PNaCl, 32);
+    ts = t1.to_string();
+    if (ts != "pnacl-32-nacl") {
+       printf("to_string failure: %s\n", ts.c_str());
+       return -1;
+    }
+    if (!t2.from_string(ts)) {
+       printf("from_string failure: %s\n", ts.c_str());
+       return -1;
+    }
+    if (t2 != t1) {
+       printf("compare failure: %s %s\n", t1.to_string().c_str(), t2.to_string().c_str());
+       return -1;
+    }
+
     // Partial specification merging: os,arch,bits get replaced; features get combined
     t2 = Target(Target::Linux, Target::X86, 64, vec(Target::OpenCL));
     if (!t2.merge_string("x86-32-sse41")) {


### PR DESCRIPTION
Parsing the (valid) target string “pnacl-32-nacl” failed, because the
“pnacl” arch was considered to set the bits and os as well, so the 32
and nacl were considered redundant and failed. Bring into line with
other archs, but add a post-check to require that bits and os are
always explicitly set when specifying pnacl. (i.e.: “pnacl” is no
longer acceptable shorthand for pnacl targets, “pnacl-32-nacl” is the
minimum.)
