### PR TITLE
s/WITH_PNACL/WITH_NATIVE_CLIENT/ in a few places

### DIFF
--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -624,7 +624,7 @@ template class CodeGen_GPU_Host<CodeGen_ARM>;
 template class CodeGen_GPU_Host<CodeGen_MIPS>;
 #endif
 
-#ifdef WITH_PNACL
+#ifdef WITH_NATIVE_CLIENT
 template class CodeGen_GPU_Host<CodeGen_PNaCl>;
 #endif
 

--- a/src/StmtCompiler.cpp
+++ b/src/StmtCompiler.cpp
@@ -36,7 +36,7 @@ StmtCompiler::StmtCompiler(Target target) {
             contents = new CodeGen_GPU_Host<CodeGen_MIPS>(target);
         }
 #endif
-#ifdef WITH_PNACL
+#ifdef WITH_NATIVE_CLIENT
         if (target.arch == Target::PNACL) {
             contents = new CodeGen_GPU_Host<CodeGen_PNaCl>(target);
         }


### PR DESCRIPTION
This prevented specifying GPU targets with PNaCl targets
