### PR TITLE
Added profiling targets to Makefile. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # 'make test_apps' checks some of the apps build and run (but does not check their output)
 # 'make time_compilation_tests' records the compile time for each test module into a csv file.
 #     For correctness and performance tests this include halide build time and run time. For
-#     the tests in test/generator/ this times only the halide build time.
+#     the tests in test/static/ and test/generator/ this times only the halide build time.
 
 SHELL = bash
 CXX ?= g++


### PR DESCRIPTION
I've added a set of targets to the Makefile that can be used to generate profiling data for all the tests included with Halide. The main target profile_tests will run all tests and use the unix time command to gather runtime statistics. For most tests the run times include Halide JIT compilation as well as runtime execution of the generated function. The generator tests are profiled by timing the AOT compilation, and so provide timing for the Halide compilation only. Results of the timings are collected in csv files for later analysis.  
