### PR TITLE
Use the shared library for LLVM, if defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ CXX ?= g++
 LLVM_CONFIG ?= llvm-config
 LLVM_COMPONENTS= $(shell $(LLVM_CONFIG) --components)
 LLVM_VERSION = $(shell $(LLVM_CONFIG) --version | cut -b 1-3)
+LLVM_FULL_VERSION = $(shell $(LLVM_CONFIG) --version)
 CLANG ?= clang
 CLANG_VERSION = $(shell $(CLANG) --version)
 LLVM_BINDIR = $(shell $(LLVM_CONFIG) --bindir)
@@ -119,7 +120,28 @@ endif
 print-%:
 	@echo '$*=$($*)'
 
-LLVM_LIBS = -L $(LLVM_LIBDIR) $(shell $(LLVM_CONFIG) --libs bitwriter bitreader linker ipo mcjit $(LLVM_OLD_JIT_COMPONENT) $(X86_LLVM_CONFIG_LIB) $(ARM_LLVM_CONFIG_LIB) $(OPENCL_LLVM_CONFIG_LIB) $(NATIVE_CLIENT_LLVM_CONFIG_LIB) $(PTX_LLVM_CONFIG_LIB) $(AARCH64_LLVM_CONFIG_LIB) $(MIPS_LLVM_CONFIG_LIB))
+
+# Try to automatically check if we can use a shared library for 
+# LLVM. Using a shared library avoids a problem with LLVM's command
+# line parameters when loading an OpenCL implementation that also 
+# links in LLVM.
+ifndef USE_LLVM_SHARED_LIB
+ifneq (,$(wildcard $(LLVM_LIBDIR)/LLVM-$(LLVM_FULL_VERSION).so))
+$(info Could not find a shared LLVM lib)
+USE_LLVM_SHARED_LIB = 0
+else
+$(info Using a shared LLVM lib)
+USE_LLVM_SHARED_LIB = 1
+endif
+endif
+
+ifeq ($(USE_LLVM_SHARED_LIB), 0)
+LLVM_STATIC_LIBS = -L $(LLVM_LIBDIR) $(shell $(LLVM_CONFIG) --libs bitwriter bitreader linker ipo mcjit $(LLVM_OLD_JIT_COMPONENT) $(X86_LLVM_CONFIG_LIB) $(ARM_LLVM_CONFIG_LIB) $(OPENCL_LLVM_CONFIG_LIB) $(NATIVE_CLIENT_LLVM_CONFIG_LIB) $(PTX_LLVM_CONFIG_LIB) $(AARCH64_LLVM_CONFIG_LIB) $(MIPS_LLVM_CONFIG_LIB))
+LLVM_SHARED_LIBS = 
+else 
+LLVM_STATIC_LIBS = 
+LLVM_SHARED_LIBS = -L $(LLVM_LIBDIR) -lLLVM-$(LLVM_FULL_VERSION)
+endif
 
 LLVM_34_OR_OLDER = $(findstring $(LLVM_VERSION_TIMES_10), 32 33 34)
 ifneq ($(LLVM_34_OR_OLDER), )
@@ -141,7 +163,7 @@ endif
 endif
 
 # Remove some non-llvm libs that llvm-config has helpfully included
-LIBS = $(filter-out -lrt -lz -lpthread -ldl , $(LLVM_LIBS))
+LIBS = $(filter-out -lrt -lz -lpthread -ldl , $(LLVM_STATIC_LIBS))
 
 ifneq ($(WITH_PTX), )
 ifneq (,$(findstring ptx,$(HL_TARGET)))
@@ -239,7 +261,7 @@ $(BIN_DIR)/libHalide.a: $(OBJECTS) $(INITIAL_MODULES)
 	ranlib $(BIN_DIR)/libHalide.a
 
 $(BIN_DIR)/libHalide.so: $(BIN_DIR)/libHalide.a
-	$(CXX) $(BUILD_BIT_SIZE) -shared $(OBJECTS) $(INITIAL_MODULES) $(LIBS) $(LLVM_LDFLAGS) -ldl -lz -lpthread -o $(BIN_DIR)/libHalide.so
+	$(CXX) $(BUILD_BIT_SIZE) -shared $(OBJECTS) $(INITIAL_MODULES) $(LIBS) $(LLVM_LDFLAGS) $(LLVM_SHARED_LIBS) -ldl -lz -lpthread -o $(BIN_DIR)/libHalide.so
 
 include/Halide.h: $(HEADERS) src/HalideFooter.h $(BIN_DIR)/build_halide_h
 	mkdir -p include

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -6,7 +6,8 @@ $(LIB_HALIDE): ../.. ../../src
 	$(MAKE) -C ../../ $(LIB_HALIDE)
 
 bilateral_grid: bilateral_grid.cpp $(LIB_HALIDE)
-	$(CXX) $(CPPFLAGS) bilateral_grid.cpp -g -I ../../include/ ../../$(LIB_HALIDE) -o bilateral_grid -lpthread -ldl -lz $(LDFLAGS)
+	$(CXX) $(CPPFLAGS) bilateral_grid.cpp -g -I ../../include/ ../../$(LIB_HALIDE) -o bilateral_grid -lpthread -ldl -lz $(LDFLAGS) \
+	$(LLVM_SHARED_LIBS)
 
 bilateral_grid.o: bilateral_grid
 	./bilateral_grid 8

--- a/apps/interpolate/Makefile
+++ b/apps/interpolate/Makefile
@@ -6,7 +6,7 @@ CXXFLAGS += -g -Wall
 
 interpolate: ../../ interpolate.cpp
 	$(MAKE) -C ../../ $(LIB_HALIDE)
-	$(CXX) $(CXXFLAGS) interpolate.cpp -I ../../include/ -I ../support ../../$(LIB_HALIDE) -o interpolate -lpthread -ldl -lz $(PNGFLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS) $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) interpolate.cpp -I ../../include/ -I ../support ../../$(LIB_HALIDE) -o interpolate -lpthread -ldl -lz $(PNGFLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS) $(LDFLAGS) $(LLVM_SHARED_LIBS)
 
 out.png: interpolate
 	./interpolate ../images/rgba.png out.png

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -4,13 +4,14 @@ all: process
 
 local_laplacian: ../../ local_laplacian.cpp
 	$(MAKE) -C ../../ $(LIB_HALIDE)
-	$(CXX) local_laplacian.cpp -g -I ../../include ../../$(LIB_HALIDE) -o local_laplacian -lpthread -ldl -lz $(LDFLAGS)
+	$(CXX) local_laplacian.cpp -g -I ../../include ../../$(LIB_HALIDE) -o local_laplacian -lpthread -ldl -lz $(LDFLAGS) \
+	$(LLVM_SHARED_LIBS)
 
 local_laplacian.o: local_laplacian
 	./local_laplacian
 
 process: process.cpp local_laplacian.o
-	$(CXX) -I../support -Wall -O3 process.cpp local_laplacian.o -o process -lpthread -ldl $(PNGFLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS)
+	$(CXX) -I../support -Wall -O3 process.cpp local_laplacian.o -o process -lpthread -ldl $(PNGFLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS) $(LLVM_SHARED_LIBS)
 
 out.png: process
 	./process ../images/rgb.png 8 1 1 out.png

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -16,6 +16,31 @@ else
 LLVM_LDFLAGS = $(shell $(LLVM_CONFIG) --ldflags --system-libs)
 endif
 
+# Try to automatically check if we can use a shared library for 
+# LLVM. Using a shared library avoids a problem with LLVM's command
+# line parameters when loading an OpenCL implementation that also 
+# links in LLVM.
+LLVM_CONFIG ?= llvm-config
+LLVM_FULL_VERSION = $(shell $(LLVM_CONFIG) --version)
+LLVM_LIBDIR = $(shell $(LLVM_CONFIG) --libdir)
+
+ifndef USE_LLVM_SHARED_LIB
+ifneq (,$(wildcard $(LLVM_LIBDIR)/LLVM-$(LLVM_FULL_VERSION).so))
+USE_LLVM_SHARED_LIB = 0
+else
+USE_LLVM_SHARED_LIB = 1
+endif
+endif
+
+ifeq ($(USE_LLVM_SHARED_LIB), 0)
+LLVM_STATIC_LIBS = -L $(LLVM_LIBDIR) $(shell $(LLVM_CONFIG) --libs bitwriter bitreader linker ipo mcjit $(LLVM_OLD_JIT_COMPONENT) $(X86_LLVM_CONFIG_LIB) $(ARM_LLVM_CONFIG_LIB) $(OPENCL_LLVM_CONFIG_LIB) $(NATIVE_CLIENT_LLVM_CONFIG_LIB) $(PTX_LLVM_CONFIG_LIB) $(AARCH64_LLVM_CONFIG_LIB) $(MIPS_LLVM_CONFIG_LIB))
+LLVM_SHARED_LIBS = 
+else 
+LLVM_STATIC_LIBS = 
+LLVM_SHARED_LIBS = -L $(LLVM_LIBDIR) -lLLVM-$(LLVM_FULL_VERSION)
+endif
+
+
 LIBPNG_LIBS_DEFAULT = $(shell libpng-config --ldflags)
 LIBPNG_CXX_FLAGS ?= $(shell libpng-config --cflags)
 # Workaround for libpng-config pointing to 64-bit versions on linux even when we're building for 32-bit


### PR DESCRIPTION
with 'make USE_LLVM_SHARED_LIB=1'.

Using a shared library avoids a problem with LLVM's command
line parameters when loading an OpenCL implementation (at
least pocl) that also links in LLVM. Otherwise we get
assertion crashes like this:

... /llvm-3.5-svn/include/llvm/Support/CommandLine.h:682:
void llvm::cl::parser<llvm::ScheduleDAGInstrs
*(*)(llvm::MachineSchedContext *)>::addLiteralOption(const char _,
const DT &, const char *) [DataType = llvm::ScheduleDAGInstrs
*(_)(llvm::MachineSchedContext _), DT = llvm::ScheduleDAGInstrs
*(_)(llvm::MachineSchedContext *)]: Assertion findOption(Name) ==
Values.size() && "Option already exists!"' failed.
Aborted (core dumped)

Now doesn't detect and use the shared lib automatically.
