### PR TITLE
Fix Buffer::set_device_dirty()

### DIFF
--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -187,7 +187,7 @@ bool Buffer::device_dirty() const {
 
 void Buffer::set_device_dirty(bool dirty) {
     user_assert(defined()) << "Buffer is undefined\n";
-    contents.ptr->buf.host_dirty = dirty;
+    contents.ptr->buf.dev_dirty = dirty;
 }
 
 int Buffer::dimensions() const {


### PR DESCRIPTION
I'm only superficially familiar with the gpu backeds, but I would think that set_device_dirty() and set_host_dirty() should do different things, and set_device_dirty has a typo in it. What do you think?
