### PR TITLE
Added debug build into distrib_windows.ps1

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,7 +67,7 @@ if (WITH_TEST_STATIC)
     if (WIN32)
     add_custom_command(OUTPUT "${STATIC_LIB}"
       DEPENDS "${GENERATOR}"
-      COMMAND "${CMAKE_BINARY_DIR}/bin/Release/${GENERATOR}${CMAKE_EXECUTABLE_SUFFIX}"
+      COMMAND "${CMAKE_BINARY_DIR}/bin/${BUILD_TYPE}/${GENERATOR}${CMAKE_EXECUTABLE_SUFFIX}"
       COMMAND "lib.exe" "/OUT:${STATIC_LIB}" "${SCRATCH_DIR}/*.o"
       WORKING_DIRECTORY "${SCRATCH_DIR}"
       )
@@ -111,7 +111,7 @@ function(add_generator_dependency target scratch_dir gen_target gen_name func_na
     # TODO(srj): this has not yet been tested on Windows.
     add_custom_command(OUTPUT "${FILTER_LIB}" "${FILTER_HDR}"
       DEPENDS "${gen_target}"
-      COMMAND "${CMAKE_BINARY_DIR}/bin/Release/${gen_target}${CMAKE_EXECUTABLE_SUFFIX}" "-g" "${gen_name}" "-f" "${func_name}" "-o" "${scratch_dir}" ${ARGN}
+      COMMAND "${CMAKE_BINARY_DIR}/bin/${BUILD_TYPE}/${gen_target}${CMAKE_EXECUTABLE_SUFFIX}" "-g" "${gen_name}" "-f" "${func_name}" "-o" "${scratch_dir}" ${ARGN}
       COMMAND "lib.exe" "/OUT:${FILTER_LIB}" "${scratch_dir}\\${func_name}.o"
       WORKING_DIRECTORY "${scratch_dir}"
       )

--- a/test/scripts/distrib_windows.ps1
+++ b/test/scripts/distrib_windows.ps1
@@ -53,7 +53,8 @@ if (! (Test-Path build-64)) {
   mkdir build-64
 }
 cd build-64
-cmake -D LLVM_ENABLE_TERMINFO=OFF -D LLVM_TARGETS_TO_BUILD='X86;ARM;NVPTX;AArch64' -D LLVM_ENABLE_ASSERTIONS=ON -D CMAKE_BUILD_TYPE=Release -G "Visual Studio 12 Win64" ..
+cmake -D LLVM_ENABLE_TERMINFO=OFF -D LLVM_TARGETS_TO_BUILD='X86;ARM;NVPTX;AArch64' -D LLVM_ENABLE_ASSERTIONS=ON -G "Visual Studio 12 Win64" ..
+MSBuild.exe /m /t:Build /p:Configuration="Debug" .\ALL_BUILD.vcxproj
 MSBuild.exe /m /t:Build /p:Configuration="Release" .\ALL_BUILD.vcxproj
 
 cd $ROOT\llvm
@@ -61,7 +62,8 @@ if (! (Test-Path build-32)) {
   mkdir build-32
 }
 cd build-32
-cmake -D LLVM_ENABLE_TERMINFO=OFF -D LLVM_TARGETS_TO_BUILD='X86;ARM;NVPTX;AArch64' -D LLVM_ENABLE_ASSERTIONS=ON -D CMAKE_BUILD_TYPE=Release -D LLVM_BUILD_32_BITS=ON -G "Visual Studio 12" ..
+cmake -D LLVM_ENABLE_TERMINFO=OFF -D LLVM_TARGETS_TO_BUILD='X86;ARM;NVPTX;AArch64' -D LLVM_ENABLE_ASSERTIONS=ON -D LLVM_BUILD_32_BITS=ON -G "Visual Studio 12" ..
+MSBuild.exe /m /t:Build /p:Configuration="Debug" .\ALL_BUILD.vcxproj
 MSBuild.exe /m /t:Build /p:Configuration="Release" .\ALL_BUILD.vcxproj
 
 #cd $ROOT\pnacl-llvm
@@ -69,76 +71,80 @@ MSBuild.exe /m /t:Build /p:Configuration="Release" .\ALL_BUILD.vcxproj
 #  mkdir build-64
 #}
 #cd build-64
-#cmake -D LLVM_ENABLE_TERMINFO=OFF -D LLVM_TARGETS_TO_BUILD='X86;ARM;NVPTX;AArch64' -D LLVM_ENABLE_ASSERTIONS=ON -D CMAKE_BUILD_TYPE=Release -G "Visual Studio 12 Win64" ..
-#MSBuild.exe /t:Build /p:Configuration="Release" .\ALL_BUILD.vcxproj
+#cmake -D LLVM_ENABLE_TERMINFO=OFF -D LLVM_TARGETS_TO_BUILD='X86;ARM;NVPTX;AArch64' -D LLVM_ENABLE_ASSERTIONS=ON -G "Visual Studio 12 Win64" ..
+#MSBuild.exe /m /t:Build /p:Configuration="Debug" .\ALL_BUILD.vcxproj
+#MSBuild.exe /m /t:Build /p:Configuration="Release" .\ALL_BUILD.vcxproj
 
 #cd $ROOT\pnacl-llvm
 #if (! (Test-Path build-32)) {
 #  mkdir build-32
 #}
 #cd build-32
-#cmake -D LLVM_ENABLE_TERMINFO=OFF -D LLVM_TARGETS_TO_BUILD='X86;ARM;NVPTX;AArch64' -D LLVM_ENABLE_ASSERTIONS=ON -D CMAKE_BUILD_TYPE=Release -D LLVM_BUILD_32_BITS=ON -G "Visual Studio 12" ..
-#MSBuild.exe /t:Build /p:Configuration="Release" .\ALL_BUILD.vcxproj
+#cmake -D LLVM_ENABLE_TERMINFO=OFF -D LLVM_TARGETS_TO_BUILD='X86;ARM;NVPTX;AArch64' -D LLVM_ENABLE_ASSERTIONS=ON -D LLVM_BUILD_32_BITS=ON -G "Visual Studio 12" ..
+#MSBuild.exe /m /t:Build /p:Configuration="Debug" .\ALL_BUILD.vcxproj
+#MSBuild.exe /m /t:Build /p:Configuration="Release" .\ALL_BUILD.vcxproj
 
-# Build Halide
-cd $ROOT
-if (! (Test-Path build_64_trunk)) {
-  mkdir build_64_trunk
-}
-cd build_64_trunk
-cmake -D LLVM_BIN=$ROOT\llvm\build-64\Release\bin -D LLVM_INCLUDE="$ROOT\llvm\include;$ROOT\llvm\build-64\include" -D LLVM_LIB=$ROOT\llvm\build-64\Release\lib -D LLVM_VERSION=36 -D TARGET_ARM=ON -D TARGET_NATIVE_CLIENT=OFF -D TARGET_OPENCL=ON -D TARGET_PTX=ON -D TARGET_SPIR=ON -D TARGET_X86=ON -D WITH_TEST_CORRECTNESS=ON -D WITH_TEST_ERROR=ON -D WITH_TEST_WARNING=ON -D WITH_TEST_PERFORMANCE=ON -D WITH_TEST_STATIC=ON -D WITH_TEST_GENERATORS=ON -D HALIDE_SHARED_LIBRARY=ON -G "Visual Studio 12 Win64" ..
-MSBuild.exe /m /t:Build /p:Configuration="Release" .\All_BUILD.vcxproj
-if ($LastExitCode) {
-  echo "Build failed!"
-  exit $LastExitCode
-}
-
-
-cd $ROOT
-if (! (Test-Path build_32_trunk)) {
-  mkdir build_32_trunk
-}
-cd build_32_trunk
-cmake -D LLVM_BIN=$ROOT\llvm\build-32\Release\bin -D LLVM_INCLUDE="$ROOT\llvm\include;$ROOT\llvm\build-32\include" -D LLVM_LIB=$ROOT\llvm\build-32\Release\lib -D LLVM_VERSION=36 -D TARGET_ARM=ON -D TARGET_NATIVE_CLIENT=OFF -D TARGET_OPENCL=ON -D TARGET_PTX=ON -D TARGET_SPIR=ON -D TARGET_X86=ON -D WITH_TEST_CORRECTNESS=ON -D WITH_TEST_ERROR=ON -D WITH_TEST_WARNING=ON -D WITH_TEST_PERFORMANCE=ON -D WITH_TEST_STATIC=ON -D WITH_TEST_GENERATORS=ON -D HALIDE_SHARED_LIBRARY=ON -G "Visual Studio 12" ..
-MSBuild.exe /m /t:Build /p:Configuration="Release" .\All_BUILD.vcxproj
-if ($LastExitCode) {
-  echo "Build failed!"
-  exit $LastExitCode
-}
+foreach (${configuration} in "Release", "Debug") {
+  # Build Halide
+  cd $ROOT
+  if (! (Test-Path build_64_trunk_${configuration})) {
+    mkdir build_64_trunk_${configuration}
+  }
+  cd build_64_trunk_${configuration}
+  cmake -D LLVM_BIN=$ROOT\llvm\build-64\Release\bin -D LLVM_INCLUDE="$ROOT\llvm\include;$ROOT\llvm\build-64\include" -D LLVM_LIB=$ROOT\llvm\build-64\${configuration}\lib -D LLVM_VERSION=36 -D TARGET_ARM=ON -D TARGET_NATIVE_CLIENT=OFF -D TARGET_OPENCL=ON -D TARGET_PTX=ON -D TARGET_SPIR=ON -D TARGET_X86=ON -D WITH_TEST_CORRECTNESS=ON -D WITH_TEST_ERROR=ON -D WITH_TEST_WARNING=ON -D WITH_TEST_PERFORMANCE=ON -D WITH_TEST_STATIC=ON -D WITH_TEST_GENERATORS=ON -D HALIDE_SHARED_LIBRARY=ON -D BUILD_TYPE="${configuration}" -G "Visual Studio 12 Win64" ..
+  MSBuild.exe /m /t:Build /p:Configuration="${configuration}" .\All_BUILD.vcxproj
+  if ($LastExitCode) {
+    echo "Build failed!"
+    exit $LastExitCode
+  }
 
 
-# Build Halide against pnacl
-cd $ROOT
-if (! (Test-Path build_64_pnacl)) {
-  mkdir build_64_pnacl
-}
-cd build_64_pnacl
-# nacl-sdk-bin contains clang.exe, llvm-as.exe, and the required dlls scavenged from the nacl sdk version pepper_35
-cmake -D LLVM_BIN=$ROOT\pnacl-llvm\nacl-sdk-bin -D LLVM_INCLUDE="$ROOT\pnacl-llvm\include;$ROOT\pnacl-llvm\build-64\include" -D LLVM_LIB=$ROOT\pnacl-llvm\build-64\lib\Release -D LLVM_VERSION=34 -D TARGET_ARM=ON -D TARGET_NATIVE_CLIENT=ON -D TARGET_OPENCL=ON -D TARGET_PTX=ON -D TARGET_X86=ON -D WITH_TEST_CORRECTNESS=ON -D WITH_TEST_ERROR=ON -D WITH_TEST_WARNING=ON -D WITH_TEST_PERFORMANCE=ON -D WITH_TEST_STATIC=OFF -D WITH_TEST_GENERATORS=OFF -D HALIDE_SHARED_LIBRARY=ON -G "Visual Studio 12 Win64" ..
-MSBuild.exe /m /t:Build /p:Configuration="Release" .\All_BUILD.vcxproj
-if ($LastExitCode) {
-  echo "Build failed!"
-  exit $LastExitCode
-}
+  cd $ROOT
+  if (! (Test-Path build_32_trunk_${configuration})) {
+    mkdir build_32_trunk_${configuration}
+  }
+  cd build_32_trunk_${configuration}
+  cmake -D LLVM_BIN=$ROOT\llvm\build-32\Release\bin -D LLVM_INCLUDE="$ROOT\llvm\include;$ROOT\llvm\build-32\include" -D LLVM_LIB=$ROOT\llvm\build-32\${configuration}\lib -D LLVM_VERSION=36 -D TARGET_ARM=ON -D TARGET_NATIVE_CLIENT=OFF -D TARGET_OPENCL=ON -D TARGET_PTX=ON -D TARGET_SPIR=ON -D TARGET_X86=ON -D WITH_TEST_CORRECTNESS=ON -D WITH_TEST_ERROR=ON -D WITH_TEST_WARNING=ON -D WITH_TEST_PERFORMANCE=ON -D WITH_TEST_STATIC=ON -D WITH_TEST_GENERATORS=ON -D HALIDE_SHARED_LIBRARY=ON -D BUILD_TYPE="${configuration}" -G "Visual Studio 12" ..
+  MSBuild.exe /m /t:Build /p:Configuration="${configuration}" .\All_BUILD.vcxproj
+  if ($LastExitCode) {
+    echo "Build failed!"
+    exit $LastExitCode
+  }
 
-cd $ROOT
-if (! (Test-Path build_32_pnacl)) { 
-  mkdir build_32_pnacl
-}
-cd build_32_pnacl
-# nacl-sdk-bin contains clang.exe, llvm-as.exe, and the required dlls scavenged from the nacl sdk version pepper_35
-cmake -D LLVM_BIN=$ROOT\pnacl-llvm\nacl-sdk-bin -D LLVM_INCLUDE="$ROOT\pnacl-llvm\include;$ROOT\pnacl-llvm\build-32\include" -D LLVM_LIB=$ROOT\pnacl-llvm\build-32\lib\Release -D LLVM_VERSION=34 -D TARGET_ARM=ON -D TARGET_NATIVE_CLIENT=ON -D TARGET_OPENCL=ON -D TARGET_PTX=ON -D TARGET_X86=ON -D WITH_TEST_CORRECTNESS=ON -D WITH_TEST_ERROR=ON -D WITH_TEST_WARNING=ON -D WITH_TEST_PERFORMANCE=ON -D WITH_TEST_STATIC=OFF -D WITH_TEST_GENERATORS=OFF -D HALIDE_SHARED_LIBRARY=ON -G "Visual Studio 12" ..
-MSBuild.exe /m /t:Build /p:Configuration="Release" .\All_BUILD.vcxproj
-if ($LastExitCode) {
-  echo "Build failed!"
-  exit $LastExitCode
+
+  # Build Halide against pnacl
+  cd $ROOT
+  if (! (Test-Path build_64_pnacl_${configuration})) {
+   mkdir build_64_pnacl_${configuration}
+  }
+  cd build_64_pnacl_${configuration}
+  # nacl-sdk-bin contains clang.exe, llvm-as.exe, and the required dlls scavenged from the nacl sdk version pepper_35
+  cmake -D LLVM_BIN=$ROOT\pnacl-llvm\nacl-sdk-bin -D LLVM_INCLUDE="$ROOT\pnacl-llvm\include;$ROOT\pnacl-llvm\build-64\include" -D LLVM_LIB=$ROOT\pnacl-llvm\build-64\lib\${configuration} -D LLVM_VERSION=34 -D TARGET_ARM=ON -D TARGET_NATIVE_CLIENT=ON -D TARGET_OPENCL=ON -D TARGET_PTX=ON -D TARGET_X86=ON -D WITH_TEST_CORRECTNESS=ON -D WITH_TEST_ERROR=ON -D WITH_TEST_WARNING=ON -D WITH_TEST_PERFORMANCE=ON -D WITH_TEST_STATIC=OFF -D WITH_TEST_GENERATORS=OFF -D HALIDE_SHARED_LIBRARY=ON -D BUILD_TYPE="${configuration}" -G "Visual Studio 12 Win64" ..
+  MSBuild.exe /m /t:Build /p:Configuration="${configuration}" .\All_BUILD.vcxproj
+  if ($LastExitCode) {
+   echo "Build failed!"
+   exit $LastExitCode
+  }
+
+  cd $ROOT
+  if (! (Test-Path build_32_pnacl_${configuration})) {
+     mkdir build_32_pnacl_${configuration}
+  }
+  cd build_32_pnacl_${configuration}
+  # nacl-sdk-bin contains clang.exe, llvm-as.exe, and the required dlls scavenged from the nacl sdk version pepper_35
+  cmake -D LLVM_BIN=$ROOT\pnacl-llvm\nacl-sdk-bin -D LLVM_INCLUDE="$ROOT\pnacl-llvm\include;$ROOT\pnacl-llvm\build-32\include" -D LLVM_LIB=$ROOT\pnacl-llvm\build-32\lib\${configuration} -D LLVM_VERSION=34 -D TARGET_ARM=ON -D TARGET_NATIVE_CLIENT=ON -D TARGET_OPENCL=ON -D TARGET_PTX=ON -D TARGET_X86=ON -D WITH_TEST_CORRECTNESS=ON -D WITH_TEST_ERROR=ON -D WITH_TEST_WARNING=ON -D WITH_TEST_PERFORMANCE=ON -D WITH_TEST_STATIC=OFF -D WITH_TEST_GENERATORS=OFF -D HALIDE_SHARED_LIBRARY=ON -D BUILD_TYPE="${configuration}" -G "Visual Studio 12" ..
+  MSBuild.exe /m /t:Build /p:Configuration="${configuration}" .\All_BUILD.vcxproj
+  if ($LastExitCode) {
+   echo "Build failed!"
+   exit $LastExitCode
+  }
 }
 
 # Run the tests
-foreach ($d in "32_trunk","64_trunk","64_pnacl","32_pnacl") {
+foreach ($d in "32_trunk","64_trunk", "64_pnacl","32_pnacl") {
   $env:HL_JIT_TARGET = "host"
 
-  cd ${ROOT}\build_${d}\bin\Release
+  cd ${ROOT}\build_${d}_Release\bin\Release
 
   Get-ChildItem . -filter correctness*.exe | ForEach {
     echo ""
@@ -207,11 +213,13 @@ foreach ($d in "32_trunk","64_trunk","64_pnacl","32_pnacl") {
   }
   cd distrib
 
-  rm Halide.h
-  rm Halide.lib
-  rm Halide.dll
-  cp ..\build_${d}\include\Halide.h .
-  cp ..\build_${d}\lib\Release\Halide.lib .
-  cp ..\build_${d}\bin\Release\Halide.dll .
-  &7z a Halide_Windows_${d}_${COMMIT}_${DATE}.zip Halide.h Halide.lib Halide.dll
+  foreach (${configuration} in "Release", "Debug") {
+    rm Halide.h
+    rm Halide.lib
+    rm Halide.dll
+    cp ..\build_${d}_${configuration}\include\Halide.h .
+    cp ..\build_${d}_${configuration}\lib\${configuration}\Halide.lib .
+    cp ..\build_${d}_${configuration}\bin\${configuration}\Halide.dll .
+    &7z a Halide_Windows_${d}_${configuration}_${COMMIT}_${DATE}.zip Halide.h Halide.lib Halide.dll
+  }
 }


### PR DESCRIPTION
I've ran into issue #586 as well. I googled about this problem (using release libraries in debug build) a little bit and it seems that: a) it's hard to make it working b) it's considered to be a bad practice. Also, it seems that the most common recommendation is to use debug libraries in debug configuration, so I've added debug version into build script.

Few things I am not sure about, please let me know, if this should be fixed:
* Separate packages are created for Debug and Release.
* Currently, tests are executed only for Release build.