### PR TITLE
No partial linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -431,9 +431,10 @@ $(BIN_DIR)/libHalide.a: $(OBJECTS) $(INITIAL_MODULES)
 	# symbols. We only care about the libLLVM ones.
 	@rm -rf $(BUILD_DIR)/llvm_objects
 	@mkdir -p $(BUILD_DIR)/llvm_objects
-	$(CXX) -o /dev/null $(OBJECTS) -Wl,-t -Wl,-unresolved-symbols=ignore-all $(LLVM_STATIC_LIBS) | grep libLLVM | sed "s/[()]/ /g" > $(BUILD_DIR)/llvm_objects/list
+	echo "int main(int, char **) {return 0;}" > $(BUILD_DIR)/empty_main.cpp
+	$(CXX) -o /dev/null $(BUILD_DIR)/empty_main.cpp $(OBJECTS) $(INITIAL_MODULES) -Wl,-t $(LLVM_STATIC_LIBS) -ldl -lz -lpthread | grep libLLVM | sed "s/[()]/ /g" > $(BUILD_DIR)/llvm_objects/list
 	# Extract the necessary object files from the llvm archives.
-	cd $(BUILD_DIR)/llvm_objects; xargs -L1 ar x < list
+	cd $(BUILD_DIR)/llvm_objects; xargs -n2 ar x < list
 	# Archive together all the halide and llvm object files
 	@-mkdir -p $(BIN_DIR)
 	@rm -f $(BIN_DIR)/libHalide.a

--- a/Makefile
+++ b/Makefile
@@ -431,8 +431,7 @@ $(BIN_DIR)/libHalide.a: $(OBJECTS) $(INITIAL_MODULES)
 	# symbols. We only care about the libLLVM ones.
 	@rm -rf $(BUILD_DIR)/llvm_objects
 	@mkdir -p $(BUILD_DIR)/llvm_objects
-	echo "int main(int, char **) {return 0;}" > $(BUILD_DIR)/empty_main.cpp
-	$(CXX) -o /dev/null $(BUILD_DIR)/empty_main.cpp $(OBJECTS) $(INITIAL_MODULES) -Wl,-t $(LLVM_STATIC_LIBS) -ldl -lz -lpthread | grep libLLVM | sed "s/[()]/ /g" > $(BUILD_DIR)/llvm_objects/list
+	$(CXX) -o /dev/null -shared $(OBJECTS) $(INITIAL_MODULES) -Wl,-t $(LLVM_STATIC_LIBS) -ldl -lz -lpthread | grep libLLVM | sed "s/[()]/ /g" > $(BUILD_DIR)/llvm_objects/list
 	# Extract the necessary object files from the llvm archives.
 	cd $(BUILD_DIR)/llvm_objects; xargs -n2 ar x < list
 	# Archive together all the halide and llvm object files


### PR DESCRIPTION
Fixes an issue we have on OS X where the partially-linked object file was too large to be a mach-o object.

The fix is a bit of a hack, so other suggestions are welcome. The goal of the current and former approach is to include the necessary parts of LLVM inside libHalide.a for the convenience of users.

The LIBS vs STATIC_LIBS thing was removed because that no longer appears to be an issue with llvm >= 3.4