### PR TITLE
Fix cast for integer varying attribute expressions

### DIFF
--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -514,7 +514,7 @@ protected:
         if (std::find(names.begin(), names.end(), op->name) != names.end()) {
             // This case is used by integer type loop variables. They are cast
             // to float and offset.
-            expr = Sub::make(Cast::make(float_type(op), op), 0.5f);
+            expr = Expr(op) - 0.5f;
 
         } else if (scope.contains(op->name) && (op->type != scope.get(op->name).type())) {
             // Otherwise, check to see if it is defined by a modified let


### PR DESCRIPTION
This PR resolves bugs #595 and #596 

GLSL will only interpolate float values, previously varying attribute expressions were converted to float and the was promoted up through the expression. This change snaps and casts varying attribute variables for integer expressions from their floating point interpolated value to integers.

The test failure was caused by interpolated floating point values a few ulp less than the correct integer being cast to uint8 for output, with the cast introducing a floor operation that moved the value one integer away from the correct value.