### PR TITLE
Implemented osx HR clock using mach_absolute_time

### DIFF
--- a/src/runtime/osx_clock.cpp
+++ b/src/runtime/osx_clock.cpp
@@ -1,22 +1,40 @@
 #include "runtime_internal.h"
 
-#ifndef _STRUCT_TIMEVAL
-#define _STRUCT_TIMEVAL
-
-#ifdef BITS_64
-// OSX always uses an int32 for the usec field
-struct timeval {
-    int64_t tv_sec;
-    int32_t tv_usec;
+struct mach_timebase_info {
+    uint32_t numer;
+    uint32_t denom;
 };
-#else
-struct timeval {
-    int32_t tv_sec;
-    int32_t tv_usec;
-};
-#endif
 
-#endif
+typedef struct mach_timebase_info *mach_timebase_info_t;
+typedef struct mach_timebase_info  mach_timebase_info_data_t;
 
-#include "posix_clock.cpp"
+typedef int kern_return_t;
 
+namespace Halide { namespace Runtime { namespace Internal {
+WEAK bool halide_reference_clock_inited = false;
+WEAK uint64_t halide_reference_clock = 0;
+WEAK mach_timebase_info_data_t halide_timebase_info;
+}}} // namespace Halide::Runtime::Internal
+
+extern "C" {
+
+extern uint64_t mach_absolute_time(void);
+extern kern_return_t mach_timebase_info(mach_timebase_info_t info);
+
+WEAK int halide_start_clock(void *user_context) {
+    // Guard against multiple calls
+    if (!halide_reference_clock_inited) {
+        mach_timebase_info(&halide_timebase_info);
+        halide_reference_clock = mach_absolute_time();
+        halide_reference_clock_inited = true;
+    }
+
+    return 0;
+}
+
+WEAK int64_t halide_current_time_ns(void *user_context) {
+    uint64_t now = mach_absolute_time();
+
+    return (now - halide_reference_clock) * halide_timebase_info.numer / halide_timebase_info.denom;
+}
+}


### PR DESCRIPTION
It seems that mach_absolute_time() has better precision.