### PR TITLE
Better error checking in GeneratorParam

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -284,7 +284,7 @@ private:
         std::istringstream iss(s);
         T t;
         iss >> t;
-        user_assert(!iss.fail()) << "Unable to parse integer: " << s;
+        user_assert(!iss.fail() && iss.get() == EOF) << "Unable to parse integer: " << s;
         return t;
     }
     template <typename T2 = T,
@@ -302,7 +302,7 @@ private:
         std::istringstream iss(s);
         T t;
         iss >> t;
-        user_assert(!iss.fail()) << "Unable to parse float: " << s;
+        user_assert(!iss.fail() && iss.get() == EOF) << "Unable to parse float: " << s;
         return t;
     }
     template <typename T2 = T,


### PR DESCRIPTION
from_string() for int and float need to ensure that the string is fully
consumed, otherwise strings like “argname=1234,something” are parsed as
1234 rather than generating an error.