### PR TITLE
Introspect heap objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -615,7 +615,7 @@ $(BIN_DIR)/static_%_test: test/static/%_test.cpp $(BIN_DIR)/static_%_generate tm
 # usage can just add deps later.
 $(FILTERS_DIR)/%.generator: test/generator/%_generator.cpp $(GENGEN_DEPS)
 	@mkdir -p $(FILTERS_DIR)
-	$(CXX) -std=c++11 -fno-rtti -Iinclude $(filter %_generator.cpp,$^) tools/GenGen.cpp -L$(BIN_DIR) -lHalide -lz -lpthread -ldl -o $@
+	$(CXX) -std=c++11 -g $(CXX_WARNING_FLAGS) -fno-rtti -Iinclude $(filter %_generator.cpp,$^) tools/GenGen.cpp -L$(BIN_DIR) -lHalide -lz -lpthread -ldl -o $@
 
 # By default, %.o/.h are produced by executing %.generator
 $(FILTERS_DIR)/%.o $(FILTERS_DIR)/%.h: $(FILTERS_DIR)/%.generator

--- a/src/Error.h
+++ b/src/Error.h
@@ -78,7 +78,7 @@ struct ErrorReport {
         msg(NULL), file(f), condition_string(cs), line(l), condition(c), user(u), warning(w), runtime(r) {
         if (condition) return;
         msg = new std::ostringstream;
-        const std::string &source_loc = get_source_location();
+        const std::string &source_loc = Introspection::get_source_location();
 
         if (user) {
             // Only mention where inside of libHalide the error tripped if we have debug level > 0

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -429,7 +429,6 @@ void Function::define_extern(const std::string &function_name,
                              const std::vector<Type> &types,
                              int dimensionality) {
 
-    string source_loc = get_source_location();
     user_assert(!has_pure_definition() && !has_update_definition())
         << "In extern definition for Func \"" << name() << "\":\n"
         << "Func with a pure definition cannot have an extern definition.\n";

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -128,7 +128,7 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
 
 GeneratorParamBase::GeneratorParamBase(const std::string &name) : name(name) {
     ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::GeneratorParam,
-                                              this);
+                                              this, nullptr);
 }
 
 GeneratorParamBase::~GeneratorParamBase() { ObjectInstanceRegistry::unregister_instance(this); }
@@ -180,8 +180,8 @@ std::vector<std::string> GeneratorRegistry::enumerate() {
     return result;
 }
 
-GeneratorBase::GeneratorBase(size_t size) : size(size), params_built(false) {
-    ObjectInstanceRegistry::register_instance(this, size, ObjectInstanceRegistry::Generator, this);
+GeneratorBase::GeneratorBase(size_t size, const void *introspection_helper) : size(size), params_built(false) {
+    ObjectInstanceRegistry::register_instance(this, size, ObjectInstanceRegistry::Generator, this, introspection_helper);
 }
 
 GeneratorBase::~GeneratorBase() { ObjectInstanceRegistry::unregister_instance(this); }

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -93,6 +93,7 @@
 
 #include "Func.h"
 #include "ObjectInstanceRegistry.h"
+#include "Introspection.h"
 #include "Target.h"
 
 namespace Halide {
@@ -492,21 +493,13 @@ private:
 
 }  // namespace Internal
 
-namespace {
-// Return the address of a global with type T *. Never
-// assigned to. Used to assist the introspection framework.
-template<typename T>
-const void *get_introspection_helper() {
-    static T *introspection_helper = nullptr;
-    return &introspection_helper;
-}
-}
-
 template <class T> class RegisterGenerator;
 
 template <class T> class Generator : public Internal::GeneratorBase {
 public:
-    Generator() : Internal::GeneratorBase(sizeof(T), get_introspection_helper<T>()) {}
+    Generator() :
+        Internal::GeneratorBase(sizeof(T),
+                                Internal::Introspection::get_introspection_helper<T>()) {}
 private:
     friend class RegisterGenerator<T>;
     // Must wrap the static member in a static method to avoid static-member

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -410,7 +410,7 @@ public:
 
     // This is a bit of a stopgap: we need info that isn't in Argument,
     // but there's probably a better way than surfacing Internal::Parameter.
-    std::vector<Internal::Parameter> get_filter_parameters();
+    EXPORT std::vector<Internal::Parameter> get_filter_parameters();
 
     /** Given a data type, return an estimate of the "natural" vector size
      * for that data type when compiling for the current target. */
@@ -434,7 +434,7 @@ public:
                             const std::string &file_base_name = "", const EmitOptions &options = EmitOptions());
 
 protected:
-    EXPORT GeneratorBase(size_t size);
+    EXPORT GeneratorBase(size_t size, const void *introspection_helper);
 
 private:
     const size_t size;
@@ -492,11 +492,21 @@ private:
 
 }  // namespace Internal
 
+namespace {
+// Return the address of a global with type T *. Never
+// assigned to. Used to assist the introspection framework.
+template<typename T>
+const void *get_introspection_helper() {
+    static T *introspection_helper = nullptr;
+    return &introspection_helper;
+}
+}
+
 template <class T> class RegisterGenerator;
 
 template <class T> class Generator : public Internal::GeneratorBase {
 public:
-    Generator() : Internal::GeneratorBase(sizeof(T)) {}
+    Generator() : Internal::GeneratorBase(sizeof(T), get_introspection_helper<T>()) {}
 private:
     friend class RegisterGenerator<T>;
     // Must wrap the static member in a static method to avoid static-member
@@ -508,6 +518,8 @@ private:
     const std::string &generator_name() const override final {
         return *generator_name_storage();
     }
+
+
 };
 
 template <class T> class RegisterGenerator {

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -4,6 +4,7 @@
 
 #include "Debug.h"
 #include "LLVM_Headers.h"
+#include "Error.h"
 
 #include <string>
 #include <iostream>
@@ -19,6 +20,7 @@ using std::map;
 
 namespace Halide {
 namespace Internal {
+namespace Introspection {
 
 #ifdef __APPLE__
 extern "C" void _NSGetExecutablePath(char *, int32_t *);
@@ -74,6 +76,21 @@ class DebugSections {
         }
     };
     vector<GlobalVariable> global_variables;
+
+    struct HeapObject {
+        uint64_t addr;
+        TypeInfo *type;
+        struct Member {
+            uint64_t addr;
+            std::string name;
+            TypeInfo *type;
+            bool operator<(const Member &other) const {
+                return addr < other.addr;
+            }
+        };
+        vector<Member> members;
+    };
+    map<uint64_t, HeapObject> heap_objects;
 
     struct LocalVariable {
         std::string name;
@@ -257,11 +274,10 @@ public:
         return false;
     }
 
-    // Get the debug name of a global var from a pointer to it
-    std::string get_global_variable_name(const void *global_pointer, const std::string &type_name = "") {
+    int find_global_variable(const void *global_pointer) {
         if (global_variables.empty()) {
             debug(4) << "Considering possible global at " << global_pointer << " but global_variables is empty\n";
-            return "";
+            return -1;
         }
         debug(4) << "Considering possible global at " << global_pointer << "\n";
 
@@ -280,7 +296,7 @@ public:
         }
 
         if (lo >= global_variables.size()) {
-            return "";
+            return -1;
         }
 
         // There may be multiple matching addresses. Walk backwards to find the first one.
@@ -289,8 +305,22 @@ public:
             idx--;
         }
 
+        return (int)idx;
+    }
+
+    // Get the debug name of a global var from a pointer to it
+    std::string get_global_variable_name(const void *global_pointer, const std::string &type_name = "") {
+        // Find the index of the first global variable with this address
+        int idx = find_global_variable(global_pointer);
+
+        if (idx == -1) {
+            return "";
+        }
+
+        uint64_t address = (uint64_t)global_pointer;
+
         // Now test all of them
-        for (; idx < global_variables.size() && global_variables[idx].addr <= address; idx++) {
+        for (; (size_t)idx < global_variables.size() && global_variables[idx].addr <= address; idx++) {
 
             GlobalVariable &v = global_variables[idx];
             TypeInfo *elem_type = NULL;
@@ -326,6 +356,183 @@ public:
         }
 
         // No match
+        return "";
+    }
+
+    void register_heap_object(const void *obj, size_t size, const void *helper) {
+        // helper should be a pointer to a global
+        int idx = find_global_variable(helper);
+        if (idx == -1) return;
+        const GlobalVariable &ptr = global_variables[idx];
+        debug(4) << "helper object is " << ptr.name << " at " << std::hex << ptr.addr << std::dec;
+        if (ptr.type) {
+            debug(4) << " with type " << ptr.type->name << "\n";
+        } else {
+            debug(4) << " with unknown type!\n";
+            return;
+        }
+
+        internal_assert(ptr.type->type == TypeInfo::Pointer)
+            << "The type of the helper object was supposed to be a pointer\n";
+        internal_assert(ptr.type->members.size() == 1);
+        TypeInfo *object_type = ptr.type->members[0].type;
+        internal_assert(object_type);
+
+        debug(4) << "The object has type: " << object_type->name << "\n";
+
+        internal_assert(size == object_type->size);
+
+        HeapObject heap_object;
+        heap_object.type = object_type;
+        heap_object.addr = (uint64_t)obj;
+
+        // Recursively enumerate the members.
+        for (size_t i = 0; i < object_type->members.size(); i++) {
+            const LocalVariable &member_spec = object_type->members[i];
+            HeapObject::Member member;
+            member.name = member_spec.name;
+            member.type = member_spec.type;
+            member.addr = heap_object.addr + member_spec.stack_offset;
+            if (member.type) {
+                heap_object.members.push_back(member);
+                debug(4) << member.name << " - " << (int)(member.type->type) << "\n";
+            }
+        }
+
+        for (size_t i = 0; i < heap_object.members.size(); i++) {
+            HeapObject::Member parent = heap_object.members[i];
+
+            // Stop at references or pointers. We could register them
+            // recursively (and basically write a garbage collector
+            // object tracker), but that's beyond the scope of what
+            // we're trying to do here. Besides, predicting the
+            // addresses of their children-of-children might follow a
+            // danging pointer.
+            if (parent.type->type == TypeInfo::Pointer ||
+                parent.type->type == TypeInfo::Reference) continue;
+
+            for (size_t j = 0; j < parent.type->members.size(); j++) {
+                const LocalVariable &member_spec = parent.type->members[j];
+                TypeInfo *member_type = member_spec.type;
+
+                HeapObject::Member child;
+                child.type = member_type;
+
+                if (parent.type->type == TypeInfo::Typedef ||
+                    parent.type->type == TypeInfo::Const) {
+                    // We're just following a type modifier. It's still the same member.
+                    child.name = parent.name;
+                } else if (parent.type->type == TypeInfo::Array) {
+                    child.name = ""; // the '[index]' gets added in the query routine.
+                } else {
+                    child.name = member_spec.name;
+                }
+
+                child.addr = parent.addr + member_spec.stack_offset;
+
+                if (child.type) {
+                    debug(4) << child.name << " - " << (int)(child.type->type) << "\n";
+                    heap_object.members.push_back(child);
+                }
+            }
+        }
+
+        // Sort by member address, but use stable stort so that parents stay before children.
+        std::stable_sort(heap_object.members.begin(), heap_object.members.end());
+
+        debug(4) << "Children of heap object of type " << object_type->name << " at " << obj << ":\n";
+        for (size_t i = 0; i < heap_object.members.size(); i++) {
+            const HeapObject::Member &mem = heap_object.members[i];
+            debug(4) << std::hex << mem.addr << std::dec << ": " << mem.type->name << " " << mem.name << "\n";
+        }
+
+        heap_objects[heap_object.addr] = heap_object;
+    }
+
+    void deregister_heap_object(const void *obj, size_t size) {
+        heap_objects.erase((uint64_t)obj);
+    }
+
+    // Get the debug name of a member of a heap variable from a pointer to it
+    std::string get_heap_member_name(const void *ptr, const std::string &type_name = "") {
+        debug(4) << "Getting heap member name of " << ptr << "\n";
+
+        if (heap_objects.empty()) {
+            debug(4) << "No registered heap objects\n";
+            return "";
+        }
+
+        uint64_t addr = (uint64_t)ptr;
+        std::map<uint64_t, HeapObject>::iterator it = heap_objects.upper_bound(addr);
+
+        if (it == heap_objects.begin()) {
+            debug(4) << "No heap objects less than this address\n";
+            return "";
+        }
+
+        // 'it' is the first element strictly greater than addr, so go
+        // back one to get less-than-or-equal-to.
+        it--;
+
+        const HeapObject &obj = it->second;
+        uint64_t object_start = it->first;
+        uint64_t object_end = object_start + obj.type->size;
+        if (addr < object_start || addr >= object_end) {
+            debug(4) << "Not contained in any heap object\n";
+            return "";
+        }
+
+
+        std::ostringstream name;
+
+        // Look in the members for the appropriate offset.
+        for (size_t i = 0; i < obj.members.size(); i++) {
+            TypeInfo *t = obj.members[i].type;
+
+            if (!t) continue;
+
+            debug(4) << "Comparing to member " << obj.members[i].name
+                     << " at address " << std::hex << obj.members[i].addr << std::dec
+                     << " with type " << t->name
+                     << " and type type " << (int)t->type << "\n";
+
+
+            if (obj.members[i].addr == addr &&
+                type_name_match(t->name, type_name)) {
+                name << obj.members[i].name;
+                return name.str();
+            }
+
+            // For arrays, we only unpacked the first element.
+            if (t->type == TypeInfo::Array) {
+                TypeInfo *elem_type = t->members[0].type;
+                uint64_t array_start_addr = obj.members[i].addr;
+                uint64_t array_end_addr = array_start_addr + t->size * elem_type->size;
+                debug(4) << "Array runs from " << std::hex << array_start_addr << " to " << array_end_addr << "\n";
+                if (elem_type && addr >= array_start_addr && addr < array_end_addr) {
+                    // Adjust the query address backwards to lie
+                    // within the first array element and remember the
+                    // array index to correct the name later.
+                    uint64_t containing_elem = (addr - array_start_addr) / elem_type->size;
+                    addr -= containing_elem * elem_type->size;
+                    debug(4) << "Query belongs to this array. Adjusting query address backwards to "
+                             << std::hex << addr << std::dec << "\n";
+                    name << obj.members[i].name << '[' << containing_elem << ']';
+                }
+            } else if (t->type == TypeInfo::Struct ||
+                       t->type == TypeInfo::Class ||
+                       t->type == TypeInfo::Primitive) {
+                // If I'm not this member, but am contained within it, incorporate its name.
+                uint64_t struct_start_addr = obj.members[i].addr;
+                uint64_t struct_end_addr = struct_start_addr + t->size;
+                debug(4) << "Struct runs from " << std::hex << struct_start_addr << " to " << struct_end_addr << "\n";
+                if (addr >= struct_start_addr && addr < struct_end_addr) {
+                    name << obj.members[i].name << '.';
+                }
+            }
+        }
+
+        debug(4) << "Didn't seem to be any of the members of this heap object\n";
         return "";
     }
 
@@ -417,6 +624,8 @@ public:
             debug(4) << "Bailing out because containing function used an unknown mechanism for specifying stack offsets\n";
             return "";
         }
+
+        debug(4) << "Searching for var at offset " << offset << "\n";
 
         for (size_t j = 0; j < func->variables.size(); j++) {
             const LocalVariable &var = func->variables[j];
@@ -1501,18 +1710,34 @@ private:
                     new_vars.insert(new_vars.begin() + j + 1,
                                     v.type->members.begin(),
                                     v.type->members.end());
-                    // Correct the stack offsets and names
-                    for (size_t k = 0; k < members; k++) {
-                        new_vars[j+k+1].stack_offset += new_vars[j].stack_offset;
-                        if (new_vars[j+k+1].name.size() &&
-                            new_vars[j].name.size()) {
-                            new_vars[j+k+1].name = new_vars[j].name + "." + new_vars[j+k+1].name;
+
+                    // Typedefs retain the same name and stack offset
+                    if (new_vars[j].type->type == TypeInfo::Typedef) {
+                        new_vars[j+1].name = new_vars[j].name;
+                        new_vars[j+1].stack_offset = new_vars[j].stack_offset;
+                    } else {
+                        // Correct the stack offsets and names
+                        for (size_t k = 0; k < members; k++) {
+                            new_vars[j+k+1].stack_offset += new_vars[j].stack_offset;
+                            if (new_vars[j+k+1].name.size() &&
+                                new_vars[j].name.size()) {
+                                new_vars[j+k+1].name = new_vars[j].name + "." + new_vars[j+k+1].name;
+                            }
                         }
                     }
-
                 }
             }
             functions[i].variables.swap(new_vars);
+
+            if (functions[i].variables.size()) {
+                debug(4) << "Function " << functions[i].name << ":\n";
+                for (size_t j = 0; j < functions[i].variables.size(); j++) {
+                    if (functions[i].variables[j].type) {
+                        debug(4) << " " << functions[i].variables[j].type->name << " " << functions[i].variables[j].name << "\n";
+                    }
+                }
+            }
+
         }
 
         // Unpack class members of global variables
@@ -1921,9 +2146,14 @@ std::string get_variable_name(const void *var, const std::string &expected_type)
     if (!debug_sections->working) return "";
     std::string name = debug_sections->get_stack_variable_name(var, expected_type);
     if (name.empty()) {
+        // Maybe it's a member of a heap object.
+        name = debug_sections->get_heap_member_name(var, expected_type);
+    }
+    if (name.empty()) {
         // Maybe it's a global
         name = debug_sections->get_global_variable_name(var, expected_type);
     }
+
     return name;
 }
 
@@ -1931,6 +2161,19 @@ std::string get_source_location() {
     if (!debug_sections) return "";
     if (!debug_sections->working) return "";
     return debug_sections->get_source_location();
+}
+
+void register_heap_object(const void *obj, size_t size, const void *helper) {
+    if (!debug_sections) return;
+    if (!debug_sections->working) return;
+    if (!helper) return;
+    debug_sections->register_heap_object(obj, size, helper);
+}
+
+void deregister_heap_object(const void *obj, size_t size) {
+    if (!debug_sections) return;
+    if (!debug_sections->working) return;
+    debug_sections->deregister_heap_object(obj, size);
 }
 
 bool saves_frame_pointer(void *fn) {
@@ -1984,11 +2227,14 @@ void test_compilation_unit(bool (*test)(), void (*calib)()) {
 
 }
 }
+}
 
 #else // WITH_INTROSPECTION
 
 namespace Halide {
 namespace Internal {
+namespace Introspection {
+
 std::string get_variable_name(const void *var, const std::string &expected_type) {
     return "";
 }
@@ -1997,9 +2243,16 @@ std::string get_source_location() {
     return "";
 }
 
+void register_heap_object(const void *obj, const void *helper) {
+}
+
+void deregister_heap_object(const void *obj, const void *helper) {
+}
+
 void test_compilation_unit(bool (*test)(), void (*calib)()) {
 }
 
+}
 }
 }
 

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -22,6 +22,8 @@ namespace Halide {
 namespace Internal {
 namespace Introspection {
 
+// All of this only works with DWARF debug info on linux and OS X. For
+// other platforms, WITH_INTROSPECTION should be off.
 #ifdef __APPLE__
 extern "C" void _NSGetExecutablePath(char *, int32_t *);
 void get_program_name(char *name, int32_t size) {
@@ -313,7 +315,8 @@ public:
         // Find the index of the first global variable with this address
         int idx = find_global_variable(global_pointer);
 
-        if (idx == -1) {
+        if (idx < 0) {
+            // No matching global variable found.
             return "";
         }
 
@@ -407,7 +410,7 @@ public:
             // object tracker), but that's beyond the scope of what
             // we're trying to do here. Besides, predicting the
             // addresses of their children-of-children might follow a
-            // danging pointer.
+            // dangling pointer.
             if (parent.type->type == TypeInfo::Pointer ||
                 parent.type->type == TypeInfo::Reference) continue;
 

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -402,6 +402,9 @@ public:
             }
         }
 
+        // Note that this loop pushes elements onto the vector it's
+        // iterating over as it goes - that's what makes the
+        // enumeration recursive.
         for (size_t i = 0; i < heap_object.members.size(); i++) {
             HeapObject::Member parent = heap_object.members[i];
 

--- a/src/Introspection.h
+++ b/src/Introspection.h
@@ -32,6 +32,16 @@ EXPORT void register_heap_object(const void *obj, size_t size, const void *helpe
 /** Deregister a heap object. Not thread-safe. */
 EXPORT void deregister_heap_object(const void *obj, size_t size);
 
+/** Return the address of a global with type T *. Call this to
+ * generate something to pass as the last argument to
+ * register_heap_object.
+ */
+template<typename T>
+const void *get_introspection_helper() {
+    static T *introspection_helper = nullptr;
+    return &introspection_helper;
+}
+
 /** Get the source location in the call stack, skipping over calls in
  * the Halide namespace. */
 EXPORT std::string get_source_location();

--- a/src/ObjectInstanceRegistry.h
+++ b/src/ObjectInstanceRegistry.h
@@ -34,8 +34,25 @@ public:
      * but not for Generator. subject_ptr is the value actually associated
      * with this instance; it is usually (but not necessarily) the same
      * as this_ptr. Assert if this_ptr is already registered.
+     *
+     * If 'this' is directly heap allocated (not a member of a
+     * heap-allocated object) and you want the introspection subsystem
+     * to know about it and its members, set the introspection_helper
+     * argument to a pointer to a global variable with the same true
+     * type as 'this'. For example:
+     *
+     * MyObject *obj = new MyObject;
+     * static MyObject *introspection_helper = nullptr;
+     * register_instance(obj, sizeof(MyObject), kind, obj, &introspection_helper);
+     *
+     * I.e. introspection_helper should be a pointer to a pointer to
+     * an object instance. The inner pointer can be null. The
+     * introspection subsystem will then assume this new object is of
+     * the matching type, which will help its members deduce their
+     * names on construction.
      */
-    static void register_instance(void *this_ptr, size_t size, Kind kind, void *subject_ptr);
+    static void register_instance(void *this_ptr, size_t size, Kind kind, void *subject_ptr,
+                                  const void *introspection_helper);
 
     /** Remove an instance from the registry. Assert if not found.
      */
@@ -55,10 +72,11 @@ private:
         void *subject_ptr;  // May be different from the this_ptr in the key
         size_t size;  // May be 0 for params
         Kind kind;
+        bool registered_for_introspection;
 
-        InstanceInfo() : subject_ptr(NULL), size(0), kind(Invalid) {}
-        InstanceInfo(size_t size, Kind kind, void *subject_ptr)
-            : subject_ptr(subject_ptr), size(size), kind(kind) {}
+        InstanceInfo() : subject_ptr(NULL), size(0), kind(Invalid), registered_for_introspection(false) {}
+        InstanceInfo(size_t size, Kind kind, void *subject_ptr, bool registered_for_introspection)
+            : subject_ptr(subject_ptr), size(size), kind(kind), registered_for_introspection(registered_for_introspection) {}
     };
 
 #if __cplusplus > 199711L || _MSC_VER >= 1800

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -62,7 +62,7 @@ Parameter::Parameter(Type t, bool is_buffer, int d) :
     internal_assert(is_buffer || d == 0) << "Scalar parameters should be zero-dimensional";
     // Note that is_registered is always true here; this is just using a parallel code structure for clarity.
     if (contents.defined() && contents.ptr->is_registered) {
-        ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::FilterParam, this);
+        ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::FilterParam, this, NULL);
     }
 }
 
@@ -70,13 +70,13 @@ Parameter::Parameter(Type t, bool is_buffer, int d, const std::string &name, boo
     contents(new ParameterContents(t, is_buffer, d, name, is_explicit_name, register_instance)) {
     internal_assert(is_buffer || d == 0) << "Scalar parameters should be zero-dimensional";
     if (contents.defined() && contents.ptr->is_registered) {
-        ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::FilterParam, this);
+        ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::FilterParam, this, NULL);
     }
 }
 
 Parameter::Parameter(const Parameter& that) : contents(that.contents) {
     if (contents.defined() && contents.ptr->is_registered) {
-        ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::FilterParam, this);
+        ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::FilterParam, this, NULL);
     }
 }
 
@@ -88,7 +88,7 @@ Parameter& Parameter::operator=(const Parameter& that) {
         // This can happen if you do:
         // Parameter p; // undefined
         // p = make_interesting_parameter();
-        ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::FilterParam, this);
+        ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::FilterParam, this, NULL);
     } else if (!should_be_registered && was_registered) {
         // This can happen if you do:
         // Parameter p = make_interesting_parameter();

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -101,14 +101,7 @@ string base_name(const string &name, char delim) {
 }
 
 string make_entity_name(void *stack_ptr, const string &type, char prefix) {
-    string name = get_variable_name(stack_ptr, type);
-
-    if (name.empty() && starts_with(type, "Halide::")) {
-        // Maybe we're in a generator. Try again replacing any
-        // "Halide::" with "Halide::NamesInterface::"
-        string qualified_type = "Halide::NamesInterface::" + type.substr(8, type.size()-8);
-        name = get_variable_name(stack_ptr, qualified_type);
-    }
+    string name = Introspection::get_variable_name(stack_ptr, type);
 
     if (name.empty()) {
         return unique_name(prefix);


### PR DESCRIPTION
Now if you manually register a heap object Halide can figure out what
its members are called.

This is the introspection portion of the change mentioned on the mailing list.
