### PR TITLE
Fixed a small bug in interleave_vectors 

### DIFF
--- a/src/CodeGen.cpp
+++ b/src/CodeGen.cpp
@@ -1457,7 +1457,7 @@ Value *CodeGen::interleave_vectors(Type type, const std::vector<Expr>& vecs) {
         }
 
         return builder->CreateShuffleVector(value_ab, value_c, ConstantVector::get(indices));
-    } else if (vecs.size() == 4) {
+    } else if (vecs.size() == 4 && vecs[0].type().bits <= 32) {
         Expr a = vecs[0], b = vecs[1], c = vecs[2], d = vecs[3];
         debug(3) << "Vectors to interleave: " << a << ", " << b << ", " << c << ", " << d << "\n";
 


### PR DESCRIPTION
Small fix for a small bug. This only appeared when one attempted to interleave 4 vectors of a 64-bit type. Solution is to check bit width of the type and fall back to the recursive interleave if the vectors have 64-bit elements.