### PR TITLE
Added an emit options flag to the generate_main_filter function

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -118,10 +118,8 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
         return 1;
     }
     GeneratorBase::EmitOptions emit_options;
-    std::string emit_flag = flags_info["-e"];
-    while (emit_flag != "") {
-        size_t pos = emit_flag.find(",");
-        std::string opt = emit_flag.substr(0, pos);
+    std::vector<std::string> emit_flags = split_string(flags_info["-e"], ",");
+    for (const std::string &opt : emit_flags) {
         if (opt == "assembly") {
             emit_options.emit_assembly = true;
         } else if (opt == "bitcode") {
@@ -133,11 +131,6 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
         } else {
             user_warning << "Unrecognized emit option: " << opt
                          << " not one of [assembly, bitcode, stmt, html], ignoring.\n";
-        }
-        if (pos == std::string::npos) {
-            emit_flag = "";
-        } else {
-            emit_flag = emit_flag.substr(pos+1);
         }
     }
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -129,8 +129,8 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
         } else if (opt == "html") {
             emit_options.emit_stmt_html = true;
         } else {
-            user_warning << "Unrecognized emit option: " << opt
-                         << " not one of [assembly, bitcode, stmt, html], ignoring.\n";
+          cerr << "Unrecognized emit option: " << opt
+               << " not one of [assembly, bitcode, stmt, html], ignoring.\n";
         }
     }
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -129,8 +129,8 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
         } else if (opt == "html") {
             emit_options.emit_stmt_html = true;
         } else {
-          cerr << "Unrecognized emit option: " << opt
-               << " not one of [assembly, bitcode, stmt, html], ignoring.\n";
+            cerr << "Unrecognized emit option: " << opt
+                 << " not one of [assembly, bitcode, stmt, html], ignoring.\n";
         }
     }
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -49,7 +49,9 @@ const std::map<std::string, Halide::Type> &get_halide_type_enum_map() {
 
 int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
     const char kUsage[] = "gengen [-g GENERATOR_NAME] [-f FUNCTION_NAME] [-o OUTPUT_DIR] [-e EMIT_OPTIONS] "
-                          "target=target-string [generator_arg=value [...]]\n";
+                          "target=target-string [generator_arg=value [...]]\n\n"
+                          "  -e  A comma separated list of optional files to emit. Accepted values are "
+                          "[assembly, bitcode, stmt, html]\n";
 
     std::map<std::string, std::string> flags_info = { { "-f", "" }, { "-g", "" }, { "-o", "" }, { "-e", "" } };
     std::map<std::string, std::string> generator_args;
@@ -118,22 +120,25 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
     GeneratorBase::EmitOptions emit_options;
     std::string emit_flag = flags_info["-e"];
     while (emit_flag != "") {
-      size_t pos = emit_flag.find(",");
-      std::string opt = emit_flag.substr(0, pos);
-      if (opt == "assembly") {
-        emit_options.emit_assembly = true;
-      } else if (opt == "bitcode") {
-        emit_options.emit_bitcode = true;
-      } else if (opt == "stmt") {
-        emit_options.emit_stmt = true;
-      } else if (opt == "html") {
-        emit_options.emit_stmt_html = true;
-      }
-      if (pos == std::string::npos) {
-        emit_flag = "";
-      } else {
-        emit_flag = emit_flag.substr(pos+1);
-      }
+        size_t pos = emit_flag.find(",");
+        std::string opt = emit_flag.substr(0, pos);
+        if (opt == "assembly") {
+            emit_options.emit_assembly = true;
+        } else if (opt == "bitcode") {
+            emit_options.emit_bitcode = true;
+        } else if (opt == "stmt") {
+            emit_options.emit_stmt = true;
+        } else if (opt == "html") {
+            emit_options.emit_stmt_html = true;
+        } else {
+            user_warning << "Unrecognized emit option: " << opt
+                         << " not one of [assembly, bitcode, stmt, html], ignoring.\n";
+        }
+        if (pos == std::string::npos) {
+            emit_flag = "";
+        } else {
+            emit_flag = emit_flag.substr(pos+1);
+        }
     }
 
     std::unique_ptr<GeneratorBase> gen = GeneratorRegistry::create(generator_name, generator_args);
@@ -201,7 +206,7 @@ std::vector<std::string> GeneratorRegistry::enumerate() {
 }
 
 GeneratorBase::GeneratorBase(size_t size, const void *introspection_helper) : size(size), params_built(false) {
-  ObjectInstanceRegistry::register_instance(this, size, ObjectInstanceRegistry::Generator, this, introspection_helper);
+    ObjectInstanceRegistry::register_instance(this, size, ObjectInstanceRegistry::Generator, this, introspection_helper);
 }
 
 GeneratorBase::~GeneratorBase() { ObjectInstanceRegistry::unregister_instance(this); }
@@ -304,7 +309,7 @@ void GeneratorBase::emit_filter(const std::string &output_dir,
 }
 
 Func GeneratorBase::call_extern(std::initializer_list<ExternFuncArgument> function_arguments,
-                                 std::string function_name){
+                                std::string function_name){
     Func f = build();
     Func f_extern;
     if (function_name.empty()) {

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -48,10 +48,10 @@ const std::map<std::string, Halide::Type> &get_halide_type_enum_map() {
 }
 
 int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
-    const char kUsage[] = "gengen [-g GENERATOR_NAME] [-f FUNCTION_NAME] [-o OUTPUT_DIR]  "
+    const char kUsage[] = "gengen [-g GENERATOR_NAME] [-f FUNCTION_NAME] [-o OUTPUT_DIR] [-e EMIT_OPTIONS] "
                           "target=target-string [generator_arg=value [...]]\n";
 
-    std::map<std::string, std::string> flags_info = { { "-f", "" }, { "-g", "" }, { "-o", "" } };
+    std::map<std::string, std::string> flags_info = { { "-f", "" }, { "-g", "" }, { "-o", "" }, { "-e", "" } };
     std::map<std::string, std::string> generator_args;
 
     for (int i = 1; i < argc; ++i) {
@@ -115,6 +115,26 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
         cerr << kUsage;
         return 1;
     }
+    GeneratorBase::EmitOptions emit_options;
+    std::string emit_flag = flags_info["-e"];
+    while (emit_flag != "") {
+      size_t pos = emit_flag.find(",");
+      std::string opt = emit_flag.substr(0, pos);
+      if (opt == "assembly") {
+        emit_options.emit_assembly = true;
+      } else if (opt == "bitcode") {
+        emit_options.emit_bitcode = true;
+      } else if (opt == "stmt") {
+        emit_options.emit_stmt = true;
+      } else if (opt == "html") {
+        emit_options.emit_stmt_html = true;
+      }
+      if (pos == std::string::npos) {
+        emit_flag = "";
+      } else {
+        emit_flag = emit_flag.substr(pos+1);
+      }
+    }
 
     std::unique_ptr<GeneratorBase> gen = GeneratorRegistry::create(generator_name, generator_args);
     if (gen == nullptr) {
@@ -122,7 +142,7 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
         cerr << kUsage;
         return 1;
     }
-    gen->emit_filter(output_dir, function_name);
+    gen->emit_filter(output_dir, function_name, function_name, emit_options);
     return 0;
 }
 
@@ -181,7 +201,7 @@ std::vector<std::string> GeneratorRegistry::enumerate() {
 }
 
 GeneratorBase::GeneratorBase(size_t size, const void *introspection_helper) : size(size), params_built(false) {
-    ObjectInstanceRegistry::register_instance(this, size, ObjectInstanceRegistry::Generator, this, introspection_helper);
+  ObjectInstanceRegistry::register_instance(this, size, ObjectInstanceRegistry::Generator, this, introspection_helper);
 }
 
 GeneratorBase::~GeneratorBase() { ObjectInstanceRegistry::unregister_instance(this); }


### PR DESCRIPTION
 This allows a user to request that certain optional output files be generated, e.g. the stmt, assembly, or bitcode files. I've been wanting this feature for awhile now, and finally got around to providing a simple solution. 