### PR TITLE
Remove duplicate absd function after it got promoted to an intrinsic.

### DIFF
--- a/apps/camera_pipe/camera_pipe.cpp
+++ b/apps/camera_pipe/camera_pipe.cpp
@@ -43,10 +43,6 @@ Func deinterleave(Func raw) {
     return deinterleaved;
 }
 
-Expr absd(Expr a, Expr b) {
-    return select(a > b, a - b, b - a);
-}
-
 Func demosaic(Func deinterleaved) {
     // These are the values we already know from the input
     // x_y = the value of channel x at a site in the input of channel y


### PR DESCRIPTION
It got promoted to an intrinsic in 6ecdd51fe244698a54027ed98f18ac9999872af3.

Fixes #639.