### PR TITLE
Fixed warning in the JITModule.cpp: *_fn is not initialized

### DIFF
--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -332,8 +332,8 @@ void JITModule::compile_module(CodeGen *cg, llvm::Module *m, const string &funct
 
     std::map<std::string, Symbol> exports;
 
-    void *main_fn;
-    int (*wrapper_fn)(const void **);
+    void *main_fn = NULL;
+    int (*wrapper_fn)(const void **) = NULL;
     if (!function_name.empty()) {
         Symbol temp;
         exports[function_name] = temp = compile_and_get_function(ee, m, function_name);


### PR DESCRIPTION
I am getting following warnings (which are turning into errors with -Werror):
```
src/JITModule.cpp: In member function ‘void Halide::Internal::JITModule::compile_module(Halide::Internal::CodeGen*, llvm::Module*, const string&, const std::vector<Halide::Internal::JITModule>&, const std::vector<std::basic_string<char> >&)’:
src/JITModule.cpp:138:145: error: ‘wrapper_fn’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
                                                                                                        jit_wrapper_function(jit_wrapper_function) {
                                                                                                                                                 ^
src/JITModule.cpp:336:11: note: ‘wrapper_fn’ was declared here
     int (*wrapper_fn)(const void **);
           ^
src/JITModule.cpp:138:145: error: ‘main_fn’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
                                                                                                        jit_wrapper_function(jit_wrapper_function) {
                                                                                                                                                 ^
src/JITModule.cpp:335:11: note: ‘main_fn’ was declared here
     void *main_fn;
```