### PR TITLE
Inner loop parallelism

### DIFF
--- a/src/JITModule.h
+++ b/src/JITModule.h
@@ -106,17 +106,17 @@ struct JITUserContext {
 class JITSharedRuntime {
 public:
     // Note only the first CodeGen passed in here is used. The same shared runtime is used for all JIT.
-    static std::vector<JITModule> get(CodeGen *cg, const Target &target);
-    static void init_jit_user_context(JITUserContext &jit_user_context, void *user_context, const JITHandlers &handlers);
-    static JITHandlers set_default_handlers(const JITHandlers &handlers);
+    EXPORT static std::vector<JITModule> get(CodeGen *cg, const Target &target);
+    EXPORT static void init_jit_user_context(JITUserContext &jit_user_context, void *user_context, const JITHandlers &handlers);
+    EXPORT static JITHandlers set_default_handlers(const JITHandlers &handlers);
 
     /** Set the maximum number of bytes used by memoization caching.
      * If you are compiling statically, you should include HalideRuntime.h
      * and call halide_memoization_cache_set_size() instead.
      */
-    static void memoization_cache_set_size(int64_t size);
+    EXPORT static void memoization_cache_set_size(int64_t size);
 
-    static void release_all();
+    EXPORT static void release_all();
 };
 }
 }

--- a/src/runtime/posix_thread_pool.cpp
+++ b/src/runtime/posix_thread_pool.cpp
@@ -83,8 +83,24 @@ struct halide_work_queue_t {
     // Singly linked list for job stack
     work *jobs;
 
-    // Broadcast whenever items are added to the queue or a job completes.
-    pthread_cond_t state_change;
+    // Worker threads are divided into an 'A' team and a 'B' team. The
+    // B team sleeps on the wakeup_b_team condition variable. The A
+    // team does work. Threads transition to the B team if they wake
+    // up and find that a_team_size > target_a_team_size.  Threads
+    // move into the A team whenever they wake up and find that
+    // a_team_size < target_a_team_size.
+    int a_team_size, target_a_team_size;
+
+    // Broadcast when a job completes.
+    pthread_cond_t wakeup_owners;
+
+    // Broadcast whenever items are added to the work queue.
+    pthread_cond_t wakeup_a_team;
+
+    // May also be broadcast when items are added to the work queue if
+    // more threads are required than are currently in the A team.
+    pthread_cond_t wakeup_b_team;
+
     // Keep track of threads so they can be joined at shutdown
     pthread_t threads[MAX_THREADS];
 
@@ -120,9 +136,21 @@ WEAK void *halide_worker_thread(void *void_arg) {
             // There are no jobs pending, though some tasks may still
             // be in flight from the last job. Release the lock and
             // wait for something new to happen.
-            pthread_cond_wait(&halide_work_queue.state_change, &halide_work_queue.mutex);
+            if (owned_job) {
+                pthread_cond_wait(&halide_work_queue.wakeup_owners, &halide_work_queue.mutex);
+            } else {
+                pthread_cond_wait(&halide_work_queue.wakeup_a_team, &halide_work_queue.mutex);
+            }
+        } else if (!owned_job &&
+                   halide_work_queue.a_team_size > halide_work_queue.target_a_team_size) {
+            // I'm awake but shouldn't be.
+
+            // Transition to b team until the wakeup_b_team condition is fired.
+            halide_work_queue.a_team_size--;
+            pthread_cond_wait(&halide_work_queue.wakeup_b_team, &halide_work_queue.mutex);
+            halide_work_queue.a_team_size++;
         } else {
-            // There are jobs still to do. Grab the next one.
+            // Grab the next job.
             work *job = halide_work_queue.jobs;
 
             // Claim a task from it.
@@ -157,7 +185,7 @@ WEAK void *halide_worker_thread(void *void_arg) {
             // If the job is done and I'm not the owner of it, wake up
             // the owner.
             if (!job->running() && job != owned_job) {
-                pthread_cond_broadcast(&halide_work_queue.state_change);
+                pthread_cond_broadcast(&halide_work_queue.wakeup_owners);
             }
         }
     }
@@ -175,7 +203,9 @@ WEAK int default_do_par_for(void *user_context, halide_task f,
 
     if (!halide_thread_pool_initialized) {
         halide_work_queue.shutdown = false;
-        pthread_cond_init(&halide_work_queue.state_change, NULL);
+        pthread_cond_init(&halide_work_queue.wakeup_owners, NULL);
+        pthread_cond_init(&halide_work_queue.wakeup_a_team, NULL);
+        pthread_cond_init(&halide_work_queue.wakeup_b_team, NULL);
         halide_work_queue.jobs = NULL;
 
         if (!halide_num_threads) {
@@ -200,6 +230,8 @@ WEAK int default_do_par_for(void *user_context, halide_task f,
             //fprintf(stderr, "Creating thread %d\n", i);
             pthread_create(halide_work_queue.threads + i, NULL, halide_worker_thread, NULL);
         }
+        // Everyone starts on the a team.
+        halide_work_queue.a_team_size = halide_num_threads;
 
         halide_thread_pool_initialized = true;
     }
@@ -214,13 +246,33 @@ WEAK int default_do_par_for(void *user_context, halide_task f,
     job.exit_status = 0;     // The job hasn't failed yet
     job.active_workers = 0;  // Nobody is working on this yet
 
+    if (!halide_work_queue.jobs && size < halide_num_threads) {
+        // If there's no nested parallelism happening and there are
+        // fewer tasks to do than threads, then set the target A team
+        // size so that some threads will put themselves to sleep
+        // until a larger job arrives.
+        halide_work_queue.target_a_team_size = size;
+    } else {
+        halide_work_queue.target_a_team_size = halide_num_threads;
+    }
+
+    // If there are more tasks than threads in the A team, we should
+    // wake up everyone.
+    bool wake_b_team = size > halide_work_queue.a_team_size;
+
     // Push the job onto the stack.
     job.next_job = halide_work_queue.jobs;
     halide_work_queue.jobs = &job;
+
     pthread_mutex_unlock(&halide_work_queue.mutex);
 
-    // Wake up any idle worker threads.
-    pthread_cond_broadcast(&halide_work_queue.state_change);
+    // Wake up our a team.
+    pthread_cond_broadcast(&halide_work_queue.wakeup_a_team);
+
+    if (wake_b_team) {
+        // We need the b team too.
+        pthread_cond_broadcast(&halide_work_queue.wakeup_b_team);
+    }
 
     // Do some work myself.
     halide_worker_thread((void *)(&job));
@@ -261,7 +313,9 @@ WEAK void halide_shutdown_thread_pool() {
     // to go home
     pthread_mutex_lock(&halide_work_queue.mutex);
     halide_work_queue.shutdown = true;
-    pthread_cond_broadcast(&halide_work_queue.state_change);
+    pthread_cond_broadcast(&halide_work_queue.wakeup_owners);
+    pthread_cond_broadcast(&halide_work_queue.wakeup_a_team);
+    pthread_cond_broadcast(&halide_work_queue.wakeup_b_team);
     pthread_mutex_unlock(&halide_work_queue.mutex);
 
     // Wait until they leave
@@ -276,7 +330,9 @@ WEAK void halide_shutdown_thread_pool() {
     pthread_mutex_destroy(&halide_work_queue.mutex);
     // Reinitialize in case we call another do_par_for
     pthread_mutex_init(&halide_work_queue.mutex, NULL);
-    pthread_cond_destroy(&halide_work_queue.state_change);
+    pthread_cond_destroy(&halide_work_queue.wakeup_owners);
+    pthread_cond_destroy(&halide_work_queue.wakeup_a_team);
+    pthread_cond_destroy(&halide_work_queue.wakeup_b_team);
     halide_thread_pool_initialized = false;
 }
 

--- a/src/runtime/windows_thread_pool.cpp
+++ b/src/runtime/windows_thread_pool.cpp
@@ -79,8 +79,24 @@ struct halide_work_queue_t {
     // Singly linked list for job stack
     work *jobs;
 
-    // Broadcast whenever items are added to the queue or a job completes.
-    ConditionVariable state_change;
+    // Worker threads are divided into an 'A' team and a 'B' team. The
+    // B team sleeps on the wakeup_b_team condition variable. The A
+    // team does work. Threads transition to the B team if they wake
+    // up and find that a_team_size > target_a_team_size.  Threads
+    // move into the A team whenever they wake up and find that
+    // a_team_size < target_a_team_size.
+    int a_team_size, target_a_team_size;
+
+    // Broadcast when a job completes.
+    ConditionVariable wakeup_owners;
+
+    // Broadcast whenever items are added to the work queue.
+    ConditionVariable wakeup_a_team;
+
+    // May also be broadcast when items are added to the work queue if
+    // more threads are required than are currently in the A team.
+    ConditionVariable wakeup_b_team;
+
     // Keep track of threads so they can be joined at shutdown
     Thread threads[MAX_THREADS];
 
@@ -113,8 +129,6 @@ WEAK int default_do_task(void *user_context, halide_task f, int idx,
 WEAK void *halide_worker_thread(void *void_arg) {
     work *owned_job = (work *)void_arg;
 
-    // halide_printf(NULL, "Worker starting\n");
-
     // Grab the lock
     EnterCriticalSection(&halide_work_queue.mutex);
 
@@ -126,11 +140,21 @@ WEAK void *halide_worker_thread(void *void_arg) {
            : halide_work_queue.running()) {
 
         if (halide_work_queue.jobs == NULL) {
-            // There are no jobs pending, though some tasks may still
-            // be in flight from the last job. Release the lock and
-            // wait for something new to happen.
-            // halide_printf(NULL, "Worker sleeping\n");
-            SleepConditionVariableCS(&halide_work_queue.state_change, &halide_work_queue.mutex, -1);
+            if (owned_job) {
+                // There are no jobs pending. Wait for the last worker
+                // to signal that the job is finished.
+                SleepConditionVariableCS(&halide_work_queue.wakeup_owners, &halide_work_queue.mutex, -1);
+            } else if (halide_work_queue.a_team_size <= halide_work_queue.target_a_team_size) {
+                // There are no jobs pending. Wait until more jobs are enqueued.
+                SleepConditionVariableCS(&halide_work_queue.wakeup_a_team, &halide_work_queue.mutex, -1);
+            } else {
+                // There are no jobs pending, and there are too many
+                // threads in the A team. Transition to the B team
+                // until the wakeup_b_team condition is fired.
+                halide_work_queue.a_team_size--;
+                SleepConditionVariableCS(&halide_work_queue.wakeup_b_team, &halide_work_queue.mutex, -1);
+                halide_work_queue.a_team_size++;
+            }
         } else {
             // There are jobs still to do. Grab the next one.
             work *job = halide_work_queue.jobs;
@@ -151,13 +175,10 @@ WEAK void *halide_worker_thread(void *void_arg) {
             job->active_workers++;
 
             // Release the lock and do the task.
-            // halide_printf(NULL, "Worker about to work\n");
             LeaveCriticalSection(&halide_work_queue.mutex);
-            // halide_printf(NULL, "Worker doing work\n");
             int result = halide_do_task(myjob.user_context, myjob.f, myjob.next,
                                         myjob.closure);
             EnterCriticalSection(&halide_work_queue.mutex);
-            // halide_printf(NULL, "Worker done work\n");
 
             // If this task failed, set the exit status on the job.
             if (result) {
@@ -170,8 +191,7 @@ WEAK void *halide_worker_thread(void *void_arg) {
             // If the job is done and I'm not the owner of it, wake up
             // the owner.
             if (!job->running() && job != owned_job) {
-                // halide_printf(NULL, "Job done. Wake up the owner.\n");
-                WakeAllConditionVariable(&halide_work_queue.state_change);
+                WakeAllConditionVariable(&halide_work_queue.wakeup_owners);
             }
         }
     }
@@ -197,7 +217,9 @@ WEAK int default_do_par_for(void *user_context, int (*f)(void *, int, uint8_t *)
 
         //  halide_printf(user_context, "Making condition variable\n");
 
-        InitializeConditionVariable(&halide_work_queue.state_change);
+        InitializeConditionVariable(&halide_work_queue.wakeup_owners);
+        InitializeConditionVariable(&halide_work_queue.wakeup_a_team);
+        InitializeConditionVariable(&halide_work_queue.wakeup_b_team);
         halide_work_queue.jobs = NULL;
 
         if (!halide_num_threads) {
@@ -226,6 +248,8 @@ WEAK int default_do_par_for(void *user_context, int (*f)(void *, int, uint8_t *)
             halide_work_queue.threads[i] = CreateThread(NULL, 0, halide_worker_thread, NULL, 0, NULL);
         }
 
+        halide_work_queue.a_team_size = halide_num_threads;
+
         halide_thread_pool_initialized = true;
     }
 
@@ -239,16 +263,33 @@ WEAK int default_do_par_for(void *user_context, int (*f)(void *, int, uint8_t *)
     job.exit_status = 0;     // The job hasn't failed yet
     job.active_workers = 0;  // Nobody is working on this yet
 
+    if (!halide_work_queue.jobs && size < halide_num_threads) {
+        // If there's no nested parallelism happening and there are
+        // fewer tasks to do than threads, then set the target A team
+        // size so that some threads will put themselves to sleep
+        // until a larger job arrives.
+        halide_work_queue.target_a_team_size = size;
+    } else {
+        halide_work_queue.target_a_team_size = halide_num_threads;
+    }
+
+    // If there are more tasks than threads in the A team, we should
+    // wake up everyone.
+    bool wake_b_team = size > halide_work_queue.a_team_size;
+
     // Push the job onto the stack.
     job.next_job = halide_work_queue.jobs;
     halide_work_queue.jobs = &job;
 
-    // halide_printf(user_context, "Releasing mutex\n");
     LeaveCriticalSection(&halide_work_queue.mutex);
 
-    // Wake up any idle worker threads.
-    // halide_printf(user_context, "Waking up workers\n");
-    WakeAllConditionVariable(&halide_work_queue.state_change);
+    // Wake up our A team.
+    WakeAllConditionVariable(&halide_work_queue.wakeup_a_team);
+
+    if (wake_b_team) {
+        // We need the B team too.
+        WakeAllConditionVariable(&halide_work_queue.wakeup_b_team);
+    }
 
     // Do some work myself.
     halide_worker_thread((void *)(&job));
@@ -291,20 +332,24 @@ WEAK void halide_shutdown_thread_pool() {
     // to go home
     EnterCriticalSection(&halide_work_queue.mutex);
     halide_work_queue.shutdown = true;
-    WakeAllConditionVariable(&halide_work_queue.state_change);
+    WakeAllConditionVariable(&halide_work_queue.wakeup_owners);
+    WakeAllConditionVariable(&halide_work_queue.wakeup_a_team);
+    WakeAllConditionVariable(&halide_work_queue.wakeup_b_team);
     LeaveCriticalSection(&halide_work_queue.mutex);
 
     // Wait until they leave
     for (int i = 0; i < halide_num_threads-1; i++) {
-        //fprintf(stderr, "Waiting for thread %d to exit\n", i);
         WaitForSingleObject(halide_work_queue.threads[i], -1);
     }
 
-    //fprintf(stderr, "All threads have quit. Destroying mutex and condition variable.\n");
     // Tidy up
     DeleteCriticalSection(&halide_work_queue.mutex);
     halide_work_queue.init_once = 0;
-    //DestroyConditionVariable(&halide_work_queue.state_change);
+
+    // Condition variables aren't destroyed on windows.
+    // DestroyConditionVariable(&halide_work_queue.wakeup_owners);
+    // DestroyConditionVariable(&halide_work_queue.wakeup_a_team);
+    // DestroyConditionVariable(&halide_work_queue.wakeup_b_team);
     halide_thread_pool_initialized = false;
 }
 

--- a/test/performance/inner_loop_parallel.cpp
+++ b/test/performance/inner_loop_parallel.cpp
@@ -17,7 +17,10 @@ int main(int argc, char **argv) {
     for (int t = 2; t <= 64; t *= 2) {
         std::ostringstream ss;
         ss << "HL_NUM_THREADS=" << t;
-        putenv(ss.str().c_str());
+        std::string str = ss.str();
+        char buf[32] = {0};
+        memcpy(buf, str.c_str(), str.size());
+        putenv(buf);
         Halide::Internal::JITSharedRuntime::release_all();
         f.compile_jit();
         // Start the thread pool without giving any hints as to the

--- a/test/performance/inner_loop_parallel.cpp
+++ b/test/performance/inner_loop_parallel.cpp
@@ -1,0 +1,43 @@
+#include <Halide.h>
+#include <stdio.h>
+#include "clock.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+
+    Func f;
+    Var x, y;
+    f(x, y) = x + y;
+    f.parallel(x);
+
+    // Having more threads than tasks shouldn't hurt performance too much.
+    double correct_time = 0;
+
+    for (int t = 2; t <= 64; t *= 2) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "HL_NUM_THREADS=%d", t);
+        putenv(buf);
+        Halide::Internal::JITSharedRuntime::release_all();
+        f.compile_jit();
+        double min_time = 1e20;
+        for (int i = 0; i < 5; i++) {
+            double t1 = current_time();
+            f.realize(2, 100000);
+            double t2 = current_time();
+            min_time = std::min(min_time, t2 - t1);
+        }
+
+        printf("%d: %f ms\n", t, min_time);
+        if (t == 2) {
+            correct_time = min_time;
+        } else if (min_time > correct_time * 2) {
+            printf("Unacceptable overhead when using %d threads for 2 tasks: %f ms vs %f ms\n",
+                   t, min_time, correct_time);
+            return -1;
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
While working on linear algebra, which occasionally uses more threads
than there are tasks, I noticed that a ton of time was spent in the
linux kernel from contention on the mutex. Windows had the same issue.
A pathological case is:

    for i from 0 to 1000000:
      parallel for j from 0 to 2:
        do something trivial

When a job comes in that has fewer tasks than threads, this PR puts
some of the threads to sleep on a secondary condition variable, and 
only wakes them when a new job comes in that can actually make use
of them. Seems to remove all the overhead on linux. Windows timings
are a bit more noisy.

OS X should hopefully not suffer from this due to using gcd.