### PR TITLE
Fixed string comparison for user-specified OpenCL device types.

### DIFF
--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -225,13 +225,13 @@ WEAK int create_opencl_context(void *user_context, cl_context *ctx, cl_command_q
     cl_device_type device_type = 0;
     const char * dev_type = halide_get_ocl_device_type(user_context);
     if (dev_type != NULL) {
-        if (strstr("cpu", dev_type)) {
+        if (strstr(dev_type, "cpu")) {
             device_type |= CL_DEVICE_TYPE_CPU;
         }
-        if (strstr("gpu", dev_type)) {
+        if (strstr(dev_type, "gpu")) {
             device_type |= CL_DEVICE_TYPE_GPU;
         }
-        if (strstr("acc", dev_type)) {
+        if (strstr(dev_type, "acc")) {
             device_type |= CL_DEVICE_TYPE_ACCELERATOR;
         }
     }


### PR DESCRIPTION
The arguments to these `strstr()` function calls were backwards. If the user didn't specify a `HL_OCL_DEVICE_TYPE` variable, these were checking whether the empty string was present in a bunch of string literals, which is always the case. I only noticed this because some OpenCL platforms don't seem to accept the bitwise combinations of multiple device types.