### PR TITLE
Halide blas fixed testing and added some performance improvements

### DIFF
--- a/apps/linear_algebra/Makefile
+++ b/apps/linear_algebra/Makefile
@@ -7,10 +7,14 @@ EMIT_OPTIONS = stmt,assembly
 
 EIGEN_INCLUDES ?= -I/usr/include/eigen3
 CBLAS_LIBS ?= -lblas
-ATLAS_FLAGS ?= -DUSE_ATLAS -I/opt/ATLAS/include
-ATLAS_LIBS ?= -L/opt/ATLAS/lib -lptcblas -latlas
 OPENBLAS_FLAGS ?= -DUSE_OPENBLAS
 OPENBLAS_LIBS ?= -lopenblas
+
+# ATLAS should be built and installed locally to get the best performance.
+# It is designed to automatically tune its performance to your machine during
+# the build. Get the source code here: http://math-atlas.sourceforge.net/
+ATLAS_FLAGS ?= -DUSE_ATLAS -I/opt/ATLAS/include
+ATLAS_LIBS ?= -L/opt/ATLAS/lib -lptcblas -latlas
 
 KERNEL_DIR = src/kernels
 KERNELS = \

--- a/apps/linear_algebra/Makefile
+++ b/apps/linear_algebra/Makefile
@@ -12,9 +12,17 @@ OPENBLAS_LIBS ?= -lopenblas
 
 # ATLAS should be built and installed locally to get the best performance.
 # It is designed to automatically tune its performance to your machine during
-# the build. Get the source code here: http://math-atlas.sourceforge.net/
-ATLAS_FLAGS ?= -DUSE_ATLAS -I/opt/ATLAS/include
-ATLAS_LIBS ?= -L/opt/ATLAS/lib -lptcblas -latlas
+# the build. Get the source code here: http://math-atlas.sourceforge.net/,
+# then set the flags below to point to your local build of ATLAS.
+#
+# For example:
+# ATLAS_FLAGS ?= -DUSE_ATLAS -I/opt/ATLAS/include
+# ATLAS_LIBS ?= -L/opt/ATLAS/lib -lptcblas -latlas
+
+# By default use whatever ATLAS is installed, so that this at least builds.
+$(warning Warning: Defaulting to system ATLAS, which may be slow. See the Makefile for details.)
+ATLAS_FLAGS ?= -DUSE_ATLAS
+ATLAS_LIBS ?= -lcblas
 
 KERNEL_DIR = src/kernels
 KERNELS = \

--- a/apps/linear_algebra/Makefile
+++ b/apps/linear_algebra/Makefile
@@ -7,8 +7,8 @@ EMIT_OPTIONS = stmt,assembly
 
 EIGEN_INCLUDES ?= -I/usr/include/eigen3
 CBLAS_LIBS ?= -lblas
-ATLAS_FLAGS ?= -DUSE_ATLAS
-ATLAS_LIBS ?= -L/usr/lib/atlas-base -lcblas -latlas
+ATLAS_FLAGS ?= -DUSE_ATLAS -I/opt/ATLAS/include
+ATLAS_LIBS ?= -L/opt/ATLAS/lib -lptcblas -latlas
 OPENBLAS_FLAGS ?= -DUSE_OPENBLAS
 OPENBLAS_LIBS ?= -lopenblas
 

--- a/apps/linear_algebra/benchmarks/cblas_benchmarks.cpp
+++ b/apps/linear_algebra/benchmarks/cblas_benchmarks.cpp
@@ -14,16 +14,20 @@
 #include <iostream>
 #include <random>
 #include <string>
-#include <cblas.h>
 #include "Halide.h"
 #include "clock.h"
 
 #if defined(USE_ATLAS)
 # define BLAS_NAME "Atlas"
+extern "C" {
+# include <cblas.h>
+}
 #elif defined(USE_OPENBLAS)
 # define BLAS_NAME "OpenBLAS"
+# include <cblas.h>
 #else
 # define BLAS_NAME "Cblas"
+# include <cblas.h>
 #endif
 
 #include "macros.h"

--- a/apps/linear_algebra/src/blas_l2_generators.cpp
+++ b/apps/linear_algebra/src/blas_l2_generators.cpp
@@ -16,10 +16,9 @@ class GEMVGenerator :
     using Base::natural_vector_size;
 
     GeneratorParam<bool> assertions_enabled_ = {"assertions_enabled", false};
-    GeneratorParam<bool> use_fma_ = {"use_fma", false};
     GeneratorParam<bool> vectorize_ = {"vectorize", true};
     GeneratorParam<bool> parallel_ = {"parallel", true};
-    GeneratorParam<int>  block_size_ = {"block_size", 1 << 5};
+    GeneratorParam<int>  block_size_ = {"block_size", 1 << 8};
     GeneratorParam<bool> transpose_ = {"transpose", false};
 
     // Standard ordering of parameters in GEMV functions.
@@ -35,55 +34,78 @@ class GEMVGenerator :
                        .with_feature(Target::NoAsserts)
                        .with_feature(Target::NoBoundsQuery));
         }
-
-        if (use_fma_) {
-            target.set(get_target().with_feature(Target::FMA));
-        }
     }
 
     Func build() {
         SetupTarget();
 
         const int vec_size = vectorize_? natural_vector_size(type_of<T>()): 1;
-        const Expr num_rows = A_.width();
-        const Expr num_cols = A_.height();
+        const int unroll_size = 4;
 
         Var i("i"), j("j");
         Func result("result");
 
-        Func A;
-        A(i, j) = select(j < num_cols, A_(i, clamp(j, 0, num_cols)), cast<T>(0));
-
         if (transpose_) {
-            const Expr proxy_size = (num_cols + vec_size - 1) / vec_size;
+            const Expr size = A_.height();
+            const Expr sum_size = A_.width();
+            const Expr sum_size_vecs = sum_size / vec_size;
 
-            RDom k(0, proxy_size, "k");
-            Func Ax("Ax");
-            Ax(j, i) += A_(k*vec_size + j, i) * x_(k*vec_size + j);
-
-            Func At("At");
-            At(i, j) = Ax(j, i);
-
-            RDom sum_lanes(0, vec_size);
             Func prod("prod");
-            prod(i)  += At(i, sum_lanes);
-            result(i) = b_ * y_(i) + a_ * prod(i);
+            prod(j, i) = A_(j, i) * x_(j);
+
+            RDom k(0, sum_size_vecs, "k");
+            Func accum_vecs("accum_vecs");
+            accum_vecs(j, i) += prod(k * vec_size + j, i);
+
+            Func accum_vecs_transpose("accum_vecs_transpose");
+            accum_vecs_transpose(i, j) = accum_vecs(j, i);
+
+            RDom lanes(0, vec_size);
+            Func sum_lanes("sum_lanes");
+            sum_lanes(i) += accum_vecs_transpose(i, lanes);
+
+            RDom tail(sum_size_vecs * vec_size, sum_size - sum_size_vecs * vec_size);
+            Func sum_tail("sum_tail");
+            sum_tail(i) = sum_lanes(i);
+            sum_tail(i) += prod(tail, i);
+
+            Func Ax("Ax");
+            Ax(i) = sum_tail(i);
+            result(i) = b_ * y_(i) + a_ * Ax(i);
+
+            Var ii("ii"), t("t");
+            result.specialize((sum_size / vec_size) * vec_size == sum_size)
+                    .specialize(size >= unroll_size).vectorize(i, unroll_size)
+                    .specialize(size >= block_size_)
+                    .split(i, t, i, block_size_ / unroll_size).parallel(t);
+
+            result
+                    .specialize(size >= unroll_size).vectorize(i, unroll_size)
+                    .specialize(size >= block_size_)
+                    .split(i, t, i, block_size_ / unroll_size).parallel(t);
+
+            accum_vecs
+                    .compute_at(result, i).unroll(i).unroll(j)
+                    .update().reorder(i, j, k).unroll(i).unroll(j);
+            accum_vecs_transpose
+                    .compute_at(result, i).unroll(i).unroll(j);
+            sum_lanes
+                    .compute_at(result, i).update().unroll(lanes);
+            sum_tail
+                    .compute_at(result, i)
+                    .update().reorder(i, tail);//.unroll(i);
+
 
             if (vectorize_) {
-                result.specialize(num_rows >= vec_size).vectorize(i, vec_size);
+                accum_vecs.vectorize(j)
+                        .update().vectorize(j);
+                accum_vecs_transpose.vectorize(j);
 
-                prod.compute_at(result, i);
-                prod.vectorize(i, vec_size).unroll(i);
-                prod.update(0).specialize(num_rows >= vec_size)
-                    .reorder(i, sum_lanes).unroll(sum_lanes)
-                    .vectorize(i, vec_size).unroll(i);
+                sum_lanes.specialize(size >= vec_size).vectorize(i, vec_size);//.unroll(i);
+                sum_lanes.update().specialize(size >= vec_size).vectorize(i, vec_size);//.unroll(i);
 
-                Ax.compute_at(result, i).vectorize(j).unroll(i);
-                Ax.update(0).specialize(num_rows >= vec_size)
-                    .reorder(i, j, k)
-                    .vectorize(j).unroll(i);;
-
-                At.compute_at(result, i).vectorize(i, vec_size).unroll(j);
+                sum_tail.specialize(size >= vec_size).vectorize(i, vec_size);//.unroll(i);
+                sum_tail.update().specialize(size >= vec_size).vectorize(i, vec_size);//.unroll(i);
             }
 
             A_.set_min(0, 0).set_min(1, 0);
@@ -91,27 +113,43 @@ class GEMVGenerator :
             y_.set_bounds(0, 0, A_.height());
             result.output_buffer().set_bounds(0, 0, A_.height());
         } else {
-            const int block_size = 4;
-            const Expr proxy_size = ((num_cols + block_size - 1) / block_size) * block_size;
+            const Expr size = A_.width();
+            const Expr sum_size = A_.height();
+            const Expr sum_size_cols = (sum_size / unroll_size) * unroll_size;
+            const Expr tail_size = sum_size - sum_size_cols;
 
-            RDom k(0, proxy_size, "k");
-            result(i)  = b_ * y_(i);
-            result(i) += a_ * A_(i, k) * x_(k);
+            RDom k(0, sum_size_cols, "k");
+            RDom tail(sum_size_cols, tail_size, "tail");
+            Func block("block");
+            block(i)  = b_ * y_(i);
+            block(i) += a_ * A_(i, k) * x_(k);
+            block(i) += a_ * A_(i, tail) * x_(tail);
+            result(i) = block(i);
 
-            if (vectorize_) {
+            RVar ki("ki");
+            Var ii("ii");
+            result.specialize(tail_size == 0)
+                    .specialize(size >= vec_size).vectorize(i, vec_size)
+                    .specialize(size >= unroll_size * vec_size).unroll(i, unroll_size)
+                    .specialize(size >= block_size_)
+                    .split(i, i, ii, block_size_ / (unroll_size * vec_size)).parallel(i);
 
-                RVar ki("ki");
-                Var ii("ii");
-                result.update(0).specialize(num_rows >= vec_size && num_cols >= block_size)
+            result.specialize(size >= vec_size).vectorize(i, vec_size)
+                    .specialize(size >= unroll_size * vec_size).unroll(i, unroll_size)
+                    .specialize(size >= block_size_)
+                    .split(i, i, ii, block_size_ / (unroll_size * vec_size)).parallel(i);
+
+            block.compute_at(result, i);
+            block.specialize(size >= vec_size).vectorize(i, vec_size);
+            block.update().specialize(size >= vec_size && sum_size >= unroll_size)
                     .split(i, i, ii, vec_size)
-                    .split(k, k, ki, block_size)
+                    .split(k, k, ki, unroll_size)
                     .reorder(ii, ki, i, k)
                     .vectorize(ii).unroll(ki);
-
-                result.specialize(num_rows >= vec_size).vectorize(i, vec_size);
-                result.update(0).specialize(num_rows >= vec_size).vectorize(i, vec_size);
-            }
-
+            block.update().specialize(size >= vec_size).vectorize(i, vec_size);
+            block.update(1).reorder(i, tail)
+                    .specialize(size >= vec_size).vectorize(i, vec_size)
+                    .specialize(sum_size >= unroll_size).unroll(i, unroll_size);
 
             A_.set_min(0, 0).set_min(1, 0);
             x_.set_bounds(0, 0, A_.height());

--- a/apps/linear_algebra/tests/test_halide_blas.cpp
+++ b/apps/linear_algebra/tests/test_halide_blas.cpp
@@ -14,102 +14,102 @@
         std::cout << "PASSED\n";                                        \
     }                                                                   \
 
-#define L1_VECTOR_TEST(method, code)                    \
-    bool test_##method(int N) {                         \
-        Scalar alpha = random_scalar();                  \
-        std::unique_ptr<Vector> ex(random_vector(N));    \
-        std::unique_ptr<Vector> ey(random_vector(N));    \
-        Vector ax(*ex), ay(*ey);                        \
-                                                        \
-        {                                               \
-            Scalar *x = &(ex->front());                 \
-            Scalar *y = &(ey->front());                 \
-            cblas_##code;                               \
-        }                                               \
-                                                        \
-        {                                               \
-            Scalar *x = &(ax.front());                  \
-            Scalar *y = &(ay.front());                  \
-            hblas_##code;                               \
-        }                                               \
-                                                        \
-        return compareVectors(N, *ey, ay);              \
+#define L1_VECTOR_TEST(method, code)            \
+    bool test_##method(int N) {                 \
+        Scalar alpha = random_scalar();         \
+        Vector ex(random_vector(N));            \
+        Vector ey(random_vector(N));            \
+        Vector ax(ex), ay(ey);                  \
+                                                \
+        {                                       \
+            Scalar *x = &(ex[0]);               \
+            Scalar *y = &(ey[0]);               \
+            cblas_##code;                       \
+        }                                       \
+                                                \
+        {                                       \
+            Scalar *x = &(ax[0]);               \
+            Scalar *y = &(ay[0]);               \
+            hblas_##code;                       \
+        }                                       \
+                                                \
+        return compareVectors(N, ey, ay);       \
     }
 
-#define L1_SCALAR_TEST(method, code)                    \
-    bool test_##method(int N) {                         \
-        Scalar alpha = random_scalar();                  \
-        std::unique_ptr<Vector> ex(random_vector(N));    \
-        std::unique_ptr<Vector> ey(random_vector(N));    \
-        Vector ax(*ex), ay(*ey);                        \
-        Scalar er, ar;                                  \
-                                                        \
-        {                                               \
-            Scalar *x = &(ex->front());                 \
-            Scalar *y = &(ey->front());                 \
-            er = cblas_##code;                          \
-        }                                               \
-                                                        \
-        {                                               \
-            Scalar *x = &(ax.front());                  \
-            Scalar *y = &(ay.front());                  \
-            ar = hblas_##code;                          \
-        }                                               \
-                                                        \
-        return compareScalars(er, ar);                  \
+#define L1_SCALAR_TEST(method, code)            \
+    bool test_##method(int N) {                 \
+        Scalar alpha = random_scalar();         \
+        Vector ex(random_vector(N));            \
+        Vector ey(random_vector(N));            \
+        Vector ax(ex), ay(ey);                  \
+        Scalar er, ar;                          \
+                                                \
+        {                                       \
+            Scalar *x = &(ex[0]);               \
+            Scalar *y = &(ey[0]);               \
+            er = cblas_##code;                  \
+        }                                       \
+                                                \
+        {                                       \
+            Scalar *x = &(ax[0]);               \
+            Scalar *y = &(ay[0]);               \
+            ar = hblas_##code;                  \
+        }                                       \
+                                                \
+        return compareScalars(er, ar);          \
     }
 
-#define L2_TEST(method, cblas_code, hblas_code)         \
-    bool test_##method(int N) {                         \
-        Scalar alpha = random_scalar();                  \
-        Scalar beta = random_scalar();                   \
-        std::unique_ptr<Vector> ex(random_vector(N));    \
-        std::unique_ptr<Vector> ey(random_vector(N));    \
-        std::unique_ptr<Matrix> eA(random_matrix(N));    \
-        Vector ax(*ex), ay(*ey);                        \
-        Matrix aA(*eA);                                 \
-                                                        \
-        {                                               \
-            Scalar *x = &(ex->front());                 \
-            Scalar *y = &(ey->front());                 \
-            Scalar *A = &(eA->front());                 \
-            cblas_code;                                 \
-        }                                               \
-                                                        \
-        {                                               \
-            Scalar *x = &(ax.front());                  \
-            Scalar *y = &(ay.front());                  \
-            Scalar *A = &(aA.front());                  \
-            hblas_code;                                 \
-        }                                               \
-                                                        \
-        return compareVectors(N, *ey, ay);              \
+#define L2_TEST(method, cblas_code, hblas_code) \
+    bool test_##method(int N) {                 \
+        Scalar alpha = random_scalar();         \
+        Scalar beta = random_scalar();          \
+        Vector ex(random_vector(N));            \
+        Vector ey(random_vector(N));            \
+        Matrix eA(random_matrix(N));            \
+        Vector ax(ex), ay(ey);                  \
+        Matrix aA(eA);                          \
+                                                \
+        {                                       \
+            Scalar *x = &(ex[0]);               \
+            Scalar *y = &(ey[0]);               \
+            Scalar *A = &(eA[0]);               \
+            cblas_code;                         \
+        }                                       \
+                                                \
+        {                                       \
+            Scalar *x = &(ax[0]);               \
+            Scalar *y = &(ay[0]);               \
+            Scalar *A = &(aA[0]);               \
+            hblas_code;                         \
+        }                                       \
+                                                \
+        return compareVectors(N, ey, ay);       \
     }
 
-#define L3_TEST(method, cblas_code, hblas_code)         \
-    bool test_##method(int N) {                         \
-        Scalar alpha = random_scalar();                  \
-        Scalar beta = random_scalar();                   \
-        std::unique_ptr<Matrix> eA(random_matrix(N));    \
-        std::unique_ptr<Matrix> eB(random_matrix(N));    \
-        std::unique_ptr<Matrix> eC(random_matrix(N));    \
-        Matrix aA(*eA), aB(*eB), aC(*eC);               \
-                                                        \
-        {                                               \
-            Scalar *A = &(eA->front());                 \
-            Scalar *B = &(eB->front());                 \
-            Scalar *C = &(eC->front());                 \
-            cblas_code;                                 \
-        }                                               \
-                                                        \
-        {                                               \
-            Scalar *A = &(aA.front());                  \
-            Scalar *B = &(aB.front());                  \
-            Scalar *C = &(aC.front());                  \
-            hblas_code;                                 \
-        }                                               \
-                                                        \
-        return compareMatrices(N, *eC, aC);             \
+#define L3_TEST(method, cblas_code, hblas_code) \
+    bool test_##method(int N) {                 \
+        Scalar alpha = random_scalar();         \
+        Scalar beta = random_scalar();          \
+        Matrix eA(random_matrix(N));            \
+        Matrix eB(random_matrix(N));            \
+        Matrix eC(random_matrix(N));            \
+        Matrix aA(eA), aB(eB), aC(eC);          \
+                                                \
+        {                                       \
+            Scalar *A = &(eA[0]);               \
+            Scalar *B = &(eB[0]);               \
+            Scalar *C = &(eC[0]);               \
+            cblas_code;                         \
+        }                                       \
+                                                \
+        {                                       \
+            Scalar *A = &(aA[0]);               \
+            Scalar *B = &(aB[0]);               \
+            Scalar *C = &(aC[0]);               \
+            hblas_code;                         \
+        }                                       \
+                                                \
+        return compareMatrices(N, eC, aC);      \
     }
 
 
@@ -129,20 +129,18 @@ struct BLASTestBase {
         return uniform_dist(rand_eng);
     }
 
-    Vector *random_vector(int N) {
-        Vector *buff = new Vector(N);
-        Vector &x = *buff;
+    Vector random_vector(int N) {
+        Vector buff(N);
         for (int i=0; i<N; ++i) {
-            x[i] = random_scalar();
+            buff[i] = random_scalar();
         }
         return buff;
     }
 
-    Matrix *random_matrix(int N) {
-        Matrix *buff = new Matrix(N * N);
-        Matrix &A = *buff;
+    Matrix random_matrix(int N) {
+        Matrix buff(N * N);
         for (int i=0; i<N*N; ++i) {
-            A[i] = random_scalar();
+            buff[i] = random_scalar();
         }
         return buff;
     }
@@ -207,6 +205,9 @@ struct BLASFloatTests : public BLASTestBase<float> {
         RUN_TEST(sgemv_notrans);
         RUN_TEST(sgemv_trans);
         RUN_TEST(sgemm_notrans);
+        RUN_TEST(sgemm_transA);
+        RUN_TEST(sgemm_transB);
+        RUN_TEST(sgemm_transAB);
     }
 
     L1_VECTOR_TEST(scopy, scopy(N, x, 1, y, 1))
@@ -226,6 +227,15 @@ struct BLASFloatTests : public BLASTestBase<float> {
     L3_TEST(sgemm_notrans,
             cblas_sgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, N, N, N, alpha, A, N, B, N, beta, C, N),
             hblas_sgemm(HblasColMajor, HblasNoTrans, HblasNoTrans, N, N, N, alpha, A, N, B, N, beta, C, N));
+    L3_TEST(sgemm_transA,
+            cblas_sgemm(CblasColMajor, CblasTrans, CblasNoTrans, N, N, N, alpha, A, N, B, N, beta, C, N),
+            hblas_sgemm(HblasColMajor, HblasTrans, HblasNoTrans, N, N, N, alpha, A, N, B, N, beta, C, N));
+    L3_TEST(sgemm_transB,
+            cblas_sgemm(CblasColMajor, CblasNoTrans, CblasTrans, N, N, N, alpha, A, N, B, N, beta, C, N),
+            hblas_sgemm(HblasColMajor, HblasNoTrans, HblasTrans, N, N, N, alpha, A, N, B, N, beta, C, N));
+    L3_TEST(sgemm_transAB,
+            cblas_sgemm(CblasColMajor, CblasTrans, CblasTrans, N, N, N, alpha, A, N, B, N, beta, C, N),
+            hblas_sgemm(HblasColMajor, HblasTrans, HblasTrans, N, N, N, alpha, A, N, B, N, beta, C, N));
 };
 
 struct BLASDoubleTests : public BLASTestBase<double> {
@@ -238,6 +248,9 @@ struct BLASDoubleTests : public BLASTestBase<double> {
         RUN_TEST(dgemv_notrans);
         RUN_TEST(dgemv_trans);
         RUN_TEST(dgemm_notrans);
+        RUN_TEST(dgemm_transA);
+        RUN_TEST(dgemm_transB);
+        RUN_TEST(dgemm_transAB);
     }
 
     L1_VECTOR_TEST(dcopy, dcopy(N, x, 1, y, 1))
@@ -257,6 +270,15 @@ struct BLASDoubleTests : public BLASTestBase<double> {
     L3_TEST(dgemm_notrans,
             cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, N, N, N, alpha, A, N, B, N, beta, C, N),
             hblas_dgemm(HblasColMajor, HblasNoTrans, HblasNoTrans, N, N, N, alpha, A, N, B, N, beta, C, N));
+    L3_TEST(dgemm_transA,
+            cblas_dgemm(CblasColMajor, CblasTrans, CblasNoTrans, N, N, N, alpha, A, N, B, N, beta, C, N),
+            hblas_dgemm(HblasColMajor, HblasTrans, HblasNoTrans, N, N, N, alpha, A, N, B, N, beta, C, N));
+    L3_TEST(dgemm_transB,
+            cblas_dgemm(CblasColMajor, CblasNoTrans, CblasTrans, N, N, N, alpha, A, N, B, N, beta, C, N),
+            hblas_dgemm(HblasColMajor, HblasNoTrans, HblasTrans, N, N, N, alpha, A, N, B, N, beta, C, N));
+    L3_TEST(dgemm_transAB,
+            cblas_dgemm(CblasColMajor, CblasTrans, CblasTrans, N, N, N, alpha, A, N, B, N, beta, C, N),
+            hblas_dgemm(HblasColMajor, HblasTrans, HblasTrans, N, N, N, alpha, A, N, B, N, beta, C, N));
 };
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
This PR has a few tweaks to the BLAS stuff. First, I've updated the tests so that we all correctness tests can be easily run with 'make test'. One note on this is that the gemm_transAB algorithm is currently not passing the correctness test, and I haven't been able to find the source of the problem.

I've also improved the performance of the gemv subroutines so that the L2 algorithms are apparently running as fast as the fastest BLAS implementations. I have updated the performance benchmarks to reflect the improvements:

https://docs.google.com/spreadsheets/d/15pJP-oS4l_PZNvf63wcdxUNuaKwMOiQj-IMEAaUI-gw/edit?usp=sharing

These benchmarks also use a custom built version of ATLAS, which is more appropriate as ATLAS is intended to be built on the machine it is to run on.