### PR TITLE
Halide blas bug fixes

### DIFF
--- a/apps/linear_algebra/benchmarks/macros.h
+++ b/apps/linear_algebra/benchmarks/macros.h
@@ -13,6 +13,7 @@
         }                                           \
     }
 
+#define L1BytesUsed(N) 2 * N * sizeof(Scalar)
 #define L1Benchmark(benchmark, type, code)                              \
     virtual void bench_##benchmark(int N) {                             \
         Scalar alpha = random_scalar();                                 \
@@ -25,10 +26,11 @@
                   << std::setw(15) << type << #benchmark                \
                   << std::setw(8) << std::to_string(N)                  \
                   << std::setw(20) << std::to_string(elapsed)           \
-                  << std::setw(20) << 1000 * N / elapsed                \
+                  << std::setw(20) << 1000 * L1BytesUsed(N) / elapsed   \
                   << std::endl;                                         \
     }
 
+#define L2BytesUsed(N) (2 + N) * N * sizeof(Scalar)
 #define L2Benchmark(benchmark, type, code)                              \
     virtual void bench_##benchmark(int N) {                             \
         Scalar alpha = random_scalar();                                 \
@@ -43,10 +45,11 @@
         << std::setw(15) << type << #benchmark                          \
                   << std::setw(8) << std::to_string(N)                  \
                   << std::setw(20) << std::to_string(elapsed)           \
-                  << std::setw(20) << 1000 * N / elapsed                \
+                  << std::setw(20) << 1000 * L2BytesUsed(N) / elapsed   \
                   << std::endl;                                         \
     }
 
+#define L3BytesUsed(N) 3 * N * N * sizeof(Scalar)
 #define L3Benchmark(benchmark, type, code)                              \
     virtual void bench_##benchmark(int N) {                             \
         Scalar alpha = random_scalar();                                 \
@@ -61,6 +64,6 @@
                   << std::setw(15) << type << #benchmark                \
                   << std::setw(8) << std::to_string(N)                  \
                   << std::setw(20) << std::to_string(elapsed)           \
-                  << std::setw(20) << 1000 * N / elapsed                \
+                  << std::setw(20) << 1000 * L3BytesUsed(N) / elapsed   \
                   << std::endl;                                         \
     }

--- a/apps/linear_algebra/src/blas_l2_generators.cpp
+++ b/apps/linear_algebra/src/blas_l2_generators.cpp
@@ -157,7 +157,18 @@ class GEMVGenerator :
             result.output_buffer().set_bounds(0, 0, A_.width());
         }
 
-        return result;
+        Func output("output");
+        output(i) = result(i);
+        result.compute_root();
+
+        const Expr size = x_.width();
+        Var ii("ii");
+        output.specialize(size >= vec_size).vectorize(i, vec_size)
+                .specialize(size >= unroll_size * vec_size).unroll(i, unroll_size)
+                .specialize(size >= block_size_)
+                .split(i, i, ii, block_size_ / (unroll_size * vec_size)).parallel(i);
+
+        return output;
     }
 };
 

--- a/apps/linear_algebra/src/blas_l3_generators.cpp
+++ b/apps/linear_algebra/src/blas_l3_generators.cpp
@@ -116,7 +116,7 @@ class GEMMGenerator :
         // Add up any leftover elements when the sum size is not a
         // multiple of the vector size.
         Func sum_tail;
-        RDom tail(sum_size_vec, sum_size - sum_size_vec * vec_size);
+        RDom tail(sum_size_vec * vec_size, sum_size - sum_size_vec * vec_size);
         sum_tail(i, j) += prod(tail, i, j);
 
         // Add the two.

--- a/apps/linear_algebra/src/halide_blas.h
+++ b/apps/linear_algebra/src/halide_blas.h
@@ -68,27 +68,27 @@ inline int halide_dgemv(bool trans, double a, buffer_t *A, buffer_t *x, double b
 }
 
 inline int halide_sgemm(bool transA, bool transB, float a, buffer_t *A, buffer_t *B, float b, buffer_t *C) {
-    if (!transA && !transB) {
-        return halide_sgemm_notrans(a, A, B, b, C, C);
+    if (transA && transB) {
+        return halide_sgemm_transAB(a, A, B, b, C, C);
     } else if (transA) {
         return halide_sgemm_transA(a, A, B, b, C, C);
     } else if (transB) {
         return halide_sgemm_transB(a, A, B, b, C, C);
     } else {
-        return halide_sgemm_transAB(a, A, B, b, C, C);
+        return halide_sgemm_notrans(a, A, B, b, C, C);
     }
     return -1;
 }
 
 inline int halide_dgemm(bool transA, bool transB, double a, buffer_t *A, buffer_t *B, double b, buffer_t *C) {
-    if (!transA && !transB) {
-        return halide_dgemm_notrans(a, A, B, b, C, C);
+    if (transA && transB) {
+        return halide_dgemm_transAB(a, A, B, b, C, C);
     } else if (transA) {
         return halide_dgemm_transA(a, A, B, b, C, C);
     } else if (transB) {
         return halide_dgemm_transB(a, A, B, b, C, C);
     } else {
-        return halide_dgemm_transAB(a, A, B, b, C, C);
+        return halide_dgemm_notrans(a, A, B, b, C, C);
     }
     return -1;
 }

--- a/apps/linear_algebra/tests/test_halide_blas.cpp
+++ b/apps/linear_algebra/tests/test_halide_blas.cpp
@@ -163,7 +163,7 @@ struct BLASTestBase {
             }
 
             if (!equal) {
-                std::cout << "FAIL! expected = " << x << ", actual = " << y << "\n";
+                std::cerr << "FAIL! expected = " << x << ", actual = " << y << "\n";
             }
 
             return equal;
@@ -172,26 +172,28 @@ struct BLASTestBase {
 
     bool compareVectors(int N, const Vector &x, const Vector &y,
                         Scalar epsilon = 16 * std::numeric_limits<Scalar>::epsilon()) {
+        bool equal = true;
         for (int i = 0; i < N; ++i) {
             if (!compareScalars(x[i], y[i], epsilon)) {
                 std::cerr << "Vectors differ at index: " << i << "\n";
-                return false;
+                equal = false;
+                break;
             }
         }
-
-        return true;
+        return equal;
     }
 
-    bool compareMatrices(int N, const Vector &x, const Vector &y,
+    bool compareMatrices(int N, const Matrix &A, const Matrix &B,
                          Scalar epsilon = 16 * std::numeric_limits<Scalar>::epsilon()) {
+        bool equal = true;
         for (int i = 0; i < N*N; ++i) {
-            if (!compareScalars(x[i], y[i], epsilon)) {
+            if (!compareScalars(A[i], A[i], epsilon)) {
                 std::cerr << "Matrices differ at coords: (" << i%N << ", " << i/N << ")\n";
-                return false;
+                equal = false;
+                break;
             }
         }
-
-        return true;
+        return equal;
     }
 };
 
@@ -294,7 +296,7 @@ int main(int argc, char *argv[]) {
             d.run_tests(size);
         }
     } else {
-        int size = 256;
+        int size = 277;
         std::cout << "Testing halide_blas with N = " << size << ":\n";
         s.run_tests(size);
         d.run_tests(size);


### PR DESCRIPTION
Discovered that the implemented BLAS subroutines were producing incorrect results except in the rare cases that the size of the matrices/vectors were exact multiples of the blocking and/or vectorization size. It just so happened that the only size that was being tested for correctness was 256, which satisfied these conditions. I also fixed the problem with the gemm_transAB subroutines. All tests are passing now, and I am rerunning the benchmarks to determine the effect these changes have had on performance, which I expect to be fairly small.