### PR TITLE
profiling_timer() now may accept one dummy argument

### DIFF
--- a/src/CodeGen.cpp
+++ b/src/CodeGen.cpp
@@ -1929,7 +1929,7 @@ void CodeGen::visit(const Call *op) {
             }
 
         } else if (op->name == Call::profiling_timer) {
-            internal_assert(op->args.size() == 0);
+            internal_assert(op->args.size() < 2);
             llvm::Function *fn = Intrinsic::getDeclaration(module,
                 Intrinsic::readcyclecounter, std::vector<llvm::Type*>());
             CallInst *call = builder->CreateCall(fn);

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1264,6 +1264,7 @@ void CodeGen_ARM::visit(const Call *op) {
             // Android devices generally have read-cycle-counter
             // disabled in user mode; fall back to calling
             // halide_current_time_ns().
+            internal_assert(op->args.size() < 2);
             Expr e = Call::make(UInt(64), "halide_current_time_ns", std::vector<Expr>(), Call::Extern);
             e.accept(this);
             return;

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -755,7 +755,7 @@ void CodeGen_C::visit(const Call *op) {
             }
             rhs << ")";
         } else if (op->name == Call::profiling_timer) {
-            internal_assert(op->args.size() == 0);
+            internal_assert(op->args.size() < 2);
             rhs << "halide_profiling_timer(";
             rhs << (have_user_context ? "__user_context_" : "NULL");
             rhs << ")";


### PR DESCRIPTION
This related to the problem discussed in #655.