### PR TITLE
Profiler overhead measurement

### DIFF
--- a/src/CodeGen.cpp
+++ b/src/CodeGen.cpp
@@ -1929,7 +1929,7 @@ void CodeGen::visit(const Call *op) {
             }
 
         } else if (op->name == Call::profiling_timer) {
-            internal_assert(op->args.size() == 0);
+            internal_assert(op->args.size() == 1);
             llvm::Function *fn = Intrinsic::getDeclaration(module,
                 Intrinsic::readcyclecounter, std::vector<llvm::Type*>());
             CallInst *call = builder->CreateCall(fn);

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1264,6 +1264,7 @@ void CodeGen_ARM::visit(const Call *op) {
             // Android devices generally have read-cycle-counter
             // disabled in user mode; fall back to calling
             // halide_current_time_ns().
+            internal_assert(op->args.size() == 1);
             Expr e = Call::make(UInt(64), "halide_current_time_ns", std::vector<Expr>(), Call::Extern);
             e.accept(this);
             return;

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -755,7 +755,7 @@ void CodeGen_C::visit(const Call *op) {
             }
             rhs << ")";
         } else if (op->name == Call::profiling_timer) {
-            internal_assert(op->args.size() == 0);
+            internal_assert(op->args.size() == 1);
             rhs << "halide_profiling_timer(";
             rhs << (have_user_context ? "__user_context_" : "NULL");
             rhs << ")";

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -244,8 +244,12 @@ private:
             IRMutator::visit(op);
         }
         // We only instrument loops at profiling level 2 or higher
-        if ((level >= 2) && (current_loop_level <= maximum_loop_level) && (op->for_type != For::Vectorized)) {
-            stmt = add_count_and_ticks("forloop", op->name, stmt);
+        if ((level >= 2) && (current_loop_level <= maximum_loop_level)) {
+            // for loop with Vectorized type is unrolled into vectorized ops,
+            // which usually is too short to profile individually
+            if (op->for_type != For::Vectorized) {
+                stmt = add_count_and_ticks("forloop", op->name, stmt);
+            }
         }
         current_loop_level--;
     }

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -244,7 +244,7 @@ private:
             IRMutator::visit(op);
         }
         // We only instrument loops at profiling level 2 or higher
-        if (level >= 2 && current_loop_level <= maximum_loop_level) {
+        if ((level >= 2) && (current_loop_level <= maximum_loop_level) && (op->for_type != For::Vectorized)) {
             stmt = add_count_and_ticks("forloop", op->name, stmt);
         }
         current_loop_level--;

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -38,7 +38,9 @@ public:
         : level(profiling_level()),
           maximum_loop_level(profiling_loop_level()),
           current_loop_level(0),
-          func_name(sanitize(func_name)) {
+          func_name(sanitize(func_name)),
+          dummy(Variable::make(Int(32), "dummy")),
+          dummy_counter(0) {
     }
 
     Stmt inject(Stmt s) {
@@ -71,6 +73,8 @@ public:
             //
             // NOTE: we deliberately do this *after* measuring
             // the total, so this should *not* be included in "kToplevel".
+            Expr j = Variable::make(Int(32), "j");
+
             const int kIters = 1000000;
             const int kUnroll = 4;
             Stmt ticker_block = Stmt();
@@ -80,7 +84,6 @@ public:
                         ticker_block);
             }
 
-            Expr j = Variable::make(Int(32), "j");
             Stmt do_timings = For::make("j", 0, kIters, For::Serial, ticker_block);
             do_timings = add_ticks(kOverhead, kOverhead, do_timings);
             do_timings = add_delta("count", kOverhead, kOverhead, Cast::make(UInt(64), 0),
@@ -119,6 +122,9 @@ private:
     const string func_name;
     map<string, int> indices;   // map name -> index in buffer.
     vector<string> call_stack;  // names of the nodes upstream
+
+    Expr dummy;
+    int dummy_counter;
 
     class PushCallStack {
     public:
@@ -159,7 +165,7 @@ private:
     }
 
     Stmt add_ticks(const string& op_type, const string& op_name, Stmt s) {
-        Expr ticks = Call::make(UInt(64), Internal::Call::profiling_timer, vector<Expr>(), Call::Intrinsic);
+        Expr ticks = Call::make(UInt(64), Internal::Call::profiling_timer, {dummy + dummy_counter++}, Call::Intrinsic);
         return add_delta("ticks", op_type, op_name, ticks, ticks, s);
     }
 

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -165,7 +165,9 @@ private:
     }
 
     Stmt add_ticks(const string& op_type, const string& op_name, Stmt s) {
-        Expr ticks = Call::make(UInt(64), Internal::Call::profiling_timer, {dummy + dummy_counter++}, Call::Intrinsic);
+        std::vector<Expr> args;
+        args.push_back(dummy + dummy_counter++);
+        Expr ticks = Call::make(UInt(64), Internal::Call::profiling_timer, args, Call::Intrinsic);
         return add_delta("ticks", op_type, op_name, ticks, ticks, s);
     }
 

--- a/util/HalideProf.cpp
+++ b/util/HalideProf.cpp
@@ -130,8 +130,6 @@ namespace {
   int64_t AdjustOverhead(OpInfo& op_info, ChildMap& child_map, double overhead_ticks_avg) {
     int64_t overhead_ticks = op_info.count * overhead_ticks_avg;
 
-    op_info.ticks_only -= overhead_ticks;
-
     std::string qual_name = qualified_name(op_info.op_type, op_info.op_name);
     const std::vector<OpInfo*>& children = child_map[qual_name];
     for (std::vector<OpInfo*>::const_iterator it = children.begin(); it != children.end(); ++it) {
@@ -172,6 +170,11 @@ namespace {
       child_map[parent_qual_name].push_back(&op_info);
     }
 
+    if (adjust_for_overhead) {
+      // Adjust values to account for profiling overhead
+      AdjustOverhead(total, child_map, overhead_ticks_avg);
+    }
+
     for (OpInfoMap::iterator o = op_info_map.begin(); o != op_info_map.end(); ++o) {
       OpInfo& op_info = o->second;
       op_info.ticks_only = op_info.ticks;
@@ -180,11 +183,6 @@ namespace {
         OpInfo* c = *it;
         op_info.ticks_only -= c->ticks;
       }
-    }
-
-    if (adjust_for_overhead) {
-      // Adjust values to account for profiling overhead
-      AdjustOverhead(total, child_map, overhead_ticks_avg);
     }
 
     // Calc the derived fields

--- a/util/HalideProf.cpp
+++ b/util/HalideProf.cpp
@@ -128,7 +128,8 @@ namespace {
   typedef std::map<std::string, std::vector<OpInfo*> > ChildMap;
 
   int64_t AdjustOverhead(OpInfo& op_info, ChildMap& child_map, double overhead_ticks_avg) {
-    int64_t overhead_ticks = op_info.count * overhead_ticks_avg;
+    int64_t overhead_local = op_info.count * overhead_ticks_avg;
+    int64_t overhead_ticks = overhead_local;
 
     std::string qual_name = qualified_name(op_info.op_type, op_info.op_name);
     const std::vector<OpInfo*>& children = child_map[qual_name];
@@ -140,7 +141,8 @@ namespace {
 
     op_info.ticks -= overhead_ticks;
 
-    return overhead_ticks;
+    // double the overhead of this level
+    return overhead_ticks + overhead_local;
   }
 
   void FinishOpInfo(OpInfoMap& op_info_map, bool adjust_for_overhead) {

--- a/util/HalideProf.cpp
+++ b/util/HalideProf.cpp
@@ -161,7 +161,7 @@ namespace {
     OpInfoMap::iterator it = op_info_map.find(overhead_qual_name);
     if (it != op_info_map.end()) {
       OpInfo overhead = it->second;
-      overhead_ticks_avg = (double)overhead.ticks / (double)overhead.count;
+      overhead_ticks_avg = (double)overhead.ticks / ((double)overhead.count * 2.0);
       op_info_map.erase(it);
     }
 


### PR DESCRIPTION
I do not think this PR is fully ready (I apologize), but I wanted to ask about your opinion.

I've been trying to improve precision of overhead adjustment (as it sometimes leads to negative execution time values) and initially, for the overhead measurement,  it generates the following code (eight calls to profiling_timer()):
```c++
for (j, 0, 1000000) {
  let begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null = profiling_timer()
  $ignore_buf$[0] = uint32(0)
  ProfilerBuffer[13] = (ProfilerBuffer[13] + (profiling_timer() - begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null))
  let begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null = profiling_timer()
  $ignore_buf$[0] = uint32(0)
  ProfilerBuffer[13] = (ProfilerBuffer[13] + (profiling_timer() - begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null))
  let begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null = profiling_timer()
  $ignore_buf$[0] = uint32(0)
  ProfilerBuffer[13] = (ProfilerBuffer[13] + (profiling_timer() - begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null))
  let begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null = profiling_timer()
  $ignore_buf$[0] = uint32(0)
  ProfilerBuffer[13] = (ProfilerBuffer[13] + (profiling_timer() - begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null))
}
```
which gets simplified into (five calls to profiling_timer()):
```c++
for (j, 0, 1000000) {
  let begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null = profiling_timer()
  $ignore_buf$[0] = uint32(0)
  ProfilerBuffer[13] = (ProfilerBuffer[13] + (profiling_timer() - begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null))
  $ignore_buf$[0] = uint32(0)
  ProfilerBuffer[13] = (ProfilerBuffer[13] + (profiling_timer() - begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null))
  $ignore_buf$[0] = uint32(0)
  ProfilerBuffer[13] = (ProfilerBuffer[13] + (profiling_timer() - begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null))
  $ignore_buf$[0] = uint32(0)
  ProfilerBuffer[13] = (ProfilerBuffer[13] + (profiling_timer() - begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null))
}
```
As suggested in the #655, dummy argument passed to profiling_timer() prevents simplification of this code, so at the end, it turns into (again eight calls to profiling_timer()):
```c++
  for (j, 0, 1000000) {
    let begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null = profiling_timer((dummy + 9))
    $ignore_buf$[0] = uint32(0)
    ProfilerBuffer[13] = (ProfilerBuffer[13] + (profiling_timer((dummy + 9)) - begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null))
    let begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null = profiling_timer((dummy + 8))
    $ignore_buf$[0] = uint32(0)
    ProfilerBuffer[13] = (ProfilerBuffer[13] + (profiling_timer((dummy + 8)) - begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null))
    let begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null = profiling_timer((dummy + 7))
    $ignore_buf$[0] = uint32(0)
    ProfilerBuffer[13] = (ProfilerBuffer[13] + (profiling_timer((dummy + 7)) - begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null))
    let begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null = profiling_timer((dummy + 6))
    $ignore_buf$[0] = uint32(0)
    ProfilerBuffer[13] = (ProfilerBuffer[13] + (profiling_timer((dummy + 6)) - begin_halide_profiler_ticks_dst_$ignore$_$ignore$_null_null))
  }
```
Now, in order to calculate overhead (let call it P), total execution time needs to be divided by number of iterations (1000000 in this case) multiplied by number of measurements (4 in this case). However, this will give correct estimation only for inner loops/ops (i.e. for children), because it includes two calls to profiling_timer (here I am making assumption that profiling_timer() dominates everything else). However, in order, to get adjustment for loop/ops itself, P should be divided by two, as it includes only one call to profiling_timer(). So, my point is that children values should be adjusted differently. Does it make sense?

I am not sure about this one, but also, it seems that putting profiling around loop which is going to be vectorized (i.e. one line of SIMD) does not make much sense, because usually execution of it takes a really small amount of time and it's significantly smaller than one for profiling code.

