### PR TITLE
Make it possible to build for ARM without NEON.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -403,7 +403,7 @@ OBJECTS = $(SOURCE_FILES:%.cpp=$(BUILD_DIR)/%.o)
 HEADERS = $(HEADER_FILES:%.h=src/%.h)
 
 RUNTIME_CPP_COMPONENTS = android_io cuda fake_thread_pool gcd_thread_pool ios_io android_clock linux_clock nogpu opencl posix_allocator posix_clock osx_clock windows_clock posix_error_handler posix_io posix_math posix_thread_pool android_host_cpu_count linux_host_cpu_count osx_host_cpu_count tracing write_debug_image windows_cuda windows_opencl windows_io windows_thread_pool ssp opengl linux_opengl_context osx_opengl_context android_opengl_context posix_print gpu_device_selection cache nacl_host_cpu_count to_string module_jit_ref_count module_aot_ref_count
-RUNTIME_LL_COMPONENTS = arm posix_math ptx_dev x86_avx x86 x86_sse41 pnacl_math win32_math aarch64 mips
+RUNTIME_LL_COMPONENTS = arm posix_math ptx_dev x86_avx x86 x86_sse41 pnacl_math win32_math aarch64 mips arm_no_neon
 
 INITIAL_MODULES = $(RUNTIME_CPP_COMPONENTS:%=$(BUILD_DIR)/initmod.%_32.o) $(RUNTIME_CPP_COMPONENTS:%=$(BUILD_DIR)/initmod.%_64.o) $(RUNTIME_CPP_COMPONENTS:%=$(BUILD_DIR)/initmod.%_32_debug.o) $(RUNTIME_CPP_COMPONENTS:%=$(BUILD_DIR)/initmod.%_64_debug.o) $(RUNTIME_LL_COMPONENTS:%=$(BUILD_DIR)/initmod.%_ll.o) $(PTX_DEVICE_INITIAL_MODULES:libdevice.%.bc=$(BUILD_DIR)/initmod_ptx.%_ll.o)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,7 @@ set(RUNTIME_CPP
   module_aot_ref_count)
 set (RUNTIME_LL
   arm
+  arm_no_neon
   aarch64
   posix_math
   ptx_dev

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1317,10 +1317,12 @@ string CodeGen_ARM::mcpu() const {
 
 string CodeGen_ARM::mattrs() const {
     if (target.bits == 32) {
-        if (target.has_feature(Target::NoNEON)) {
-          return "-neon";
-        } else {
+        if (target.has_feature(Target::ARMv7s)) {
           return "+neon";
+        } if (!target.has_feature(Target::NoNEON)) {
+          return "+neon";
+        } else {
+          return "-neon";
         }
     } else {
         return "";

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1318,11 +1318,11 @@ string CodeGen_ARM::mcpu() const {
 string CodeGen_ARM::mattrs() const {
     if (target.bits == 32) {
         if (target.has_feature(Target::ARMv7s)) {
-          return "+neon";
+            return "+neon";
         } if (!target.has_feature(Target::NoNEON)) {
-          return "+neon";
+            return "+neon";
         } else {
-          return "-neon";
+            return "-neon";
         }
     } else {
         return "";

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -495,7 +495,7 @@ Expr try_narrow(Expr a, Type target) {
 
 void CodeGen_ARM::visit(const Cast *op) {
     // AArch64 SIMD not yet supported
-    if (target.bits == 64) {
+    if (target.bits == 64 || target.has_feature(Target::NoNEON)) {
         CodeGen_Posix::visit(op);
         return;
     }
@@ -597,7 +597,7 @@ void CodeGen_ARM::visit(const Cast *op) {
 
 void CodeGen_ARM::visit(const Mul *op) {
     // AArch64 SIMD not yet supported
-    if (target.bits == 64) {
+    if (target.bits == 64 || target.has_feature(Target::NoNEON)) {
         CodeGen_Posix::visit(op);
         return;
     }
@@ -650,7 +650,7 @@ void CodeGen_ARM::visit(const Mul *op) {
 
 void CodeGen_ARM::visit(const Div *op) {
     // AArch64 SIMD not yet supported
-    if (target.bits == 64) {
+    if (target.bits == 64 || target.has_feature(Target::NoNEON)) {
         CodeGen_Posix::visit(op);
         return;
     }
@@ -835,7 +835,7 @@ void CodeGen_ARM::visit(const Add *op) {
 
 void CodeGen_ARM::visit(const Sub *op) {
     // AArch64 SIMD not yet supported
-    if (target.bits == 64) {
+    if (target.bits == 64 || target.has_feature(Target::NoNEON)) {
         CodeGen_Posix::visit(op);
         return;
     }
@@ -876,7 +876,7 @@ void CodeGen_ARM::visit(const Sub *op) {
 
 void CodeGen_ARM::visit(const Min *op) {
     // AArch64 SIMD not yet supported
-    if (target.bits == 64) {
+    if (target.bits == 64 || target.has_feature(Target::NoNEON)) {
         CodeGen_Posix::visit(op);
         return;
     }
@@ -931,7 +931,7 @@ void CodeGen_ARM::visit(const Min *op) {
 
 void CodeGen_ARM::visit(const Max *op) {
     // AArch64 SIMD not yet supported
-    if (target.bits == 64) {
+    if (target.bits == 64 || target.has_feature(Target::NoNEON)) {
         CodeGen_Posix::visit(op);
         return;
     }
@@ -987,7 +987,7 @@ void CodeGen_ARM::visit(const Max *op) {
 
 void CodeGen_ARM::visit(const Store *op) {
     // AArch64 SIMD not yet supported
-    if (target.bits == 64) {
+    if (target.bits == 64 || target.has_feature(Target::NoNEON)) {
         CodeGen_Posix::visit(op);
         return;
     }
@@ -1132,7 +1132,7 @@ void CodeGen_ARM::visit(const Store *op) {
 
 void CodeGen_ARM::visit(const Load *op) {
     // AArch64 SIMD not yet supported
-    if (target.bits == 64) {
+    if (target.bits == 64 || target.has_feature(Target::NoNEON)) {
         CodeGen_Posix::visit(op);
         return;
     }
@@ -1317,7 +1317,11 @@ string CodeGen_ARM::mcpu() const {
 
 string CodeGen_ARM::mattrs() const {
     if (target.bits == 32) {
-        return "+neon";
+        if (target.has_feature(Target::NoNEON)) {
+          return "-neon";
+        } else {
+          return "+neon";
+        }
     } else {
         return "";
     }

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -265,6 +265,8 @@ bool Target::merge_string(const std::string &target) {
             set_features(vec(Target::SSE41, Target::AVX, Target::AVX2));
         } else if (tok == "armv7s") {
             set_feature(Target::ARMv7s);
+        } else if (tok == "no_neon") {
+            set_feature(Target::NoNEON);
         } else if (tok == "cuda" || tok == "ptx") {
             set_feature(Target::CUDA);
         } else if (tok == "cuda_capability_30") {
@@ -349,7 +351,7 @@ std::string Target::to_string() const {
   const char* const feature_names[] = {
       "jit", "debug", "no_asserts", "no_bounds_query",
       "sse41", "avx", "avx2", "fma", "fma4", "f16c",
-      "armv7s",
+      "armv7s", "no_neon",
       "cuda", "cuda_capability_30", "cuda_capability_32", "cuda_capability_35", "cuda_capability_50",
       "opencl", "cl_doubles",
       "opengl",
@@ -471,8 +473,10 @@ DECLARE_CPP_INITMOD(module_aot_ref_count)
 
 #ifdef WITH_ARM
 DECLARE_LL_INITMOD(arm)
+DECLARE_LL_INITMOD(arm_no_neon)
 #else
 DECLARE_NO_INITMOD(arm)
+DECLARE_NO_INITMOD(arm_no_neon)
 #endif
 #ifdef WITH_AARCH64
 DECLARE_LL_INITMOD(aarch64)
@@ -799,6 +803,8 @@ llvm::Module *get_initial_module_for_target(Target t, llvm::LLVMContext *c, bool
             if (t.arch == Target::ARM) {
                 if (t.bits == 64) {
                   modules.push_back(get_initmod_aarch64_ll(c));
+                } else if (t.has_feature(Target::NoNEON)) {
+                  modules.push_back(get_initmod_arm_no_neon_ll(c));
                 } else {
                   modules.push_back(get_initmod_arm_ll(c));
                 }

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -802,13 +802,13 @@ llvm::Module *get_initial_module_for_target(Target t, llvm::LLVMContext *c, bool
             }
             if (t.arch == Target::ARM) {
                 if (t.bits == 64) {
-                  modules.push_back(get_initmod_aarch64_ll(c));
+                    modules.push_back(get_initmod_aarch64_ll(c));
                 } else if (t.has_feature(Target::ARMv7s)) {
-                  modules.push_back(get_initmod_arm_ll(c));
+                    modules.push_back(get_initmod_arm_ll(c));
                 } else if (!t.has_feature(Target::NoNEON)) {
-                  modules.push_back(get_initmod_arm_ll(c));
+                    modules.push_back(get_initmod_arm_ll(c));
                 } else {
-                  modules.push_back(get_initmod_arm_no_neon_ll(c));
+                    modules.push_back(get_initmod_arm_no_neon_ll(c));
                 }
             }
             if (t.arch == Target::MIPS) {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -803,10 +803,12 @@ llvm::Module *get_initial_module_for_target(Target t, llvm::LLVMContext *c, bool
             if (t.arch == Target::ARM) {
                 if (t.bits == 64) {
                   modules.push_back(get_initmod_aarch64_ll(c));
-                } else if (t.has_feature(Target::NoNEON)) {
-                  modules.push_back(get_initmod_arm_no_neon_ll(c));
-                } else {
+                } else if (t.has_feature(Target::ARMv7s)) {
                   modules.push_back(get_initmod_arm_ll(c));
+                } else if (!t.has_feature(Target::NoNEON)) {
+                  modules.push_back(get_initmod_arm_ll(c));
+                } else {
+                  modules.push_back(get_initmod_arm_no_neon_ll(c));
                 }
             }
             if (t.arch == Target::MIPS) {

--- a/src/Target.h
+++ b/src/Target.h
@@ -49,6 +49,7 @@ struct Target {
         F16C,  ///< Enable x86 16-bit float support
 
         ARMv7s,  ///< Generate code for ARMv7s. Only relevant for 32-bit ARM.
+        NoNEON,  ///< Don't generate vectorized code for ARMv7. Only relevant for 32-bit ARM.
 
         CUDA,  ///< Enable the CUDA runtime. Defaults to compute capability 2.0 (Fermi)
         CUDACapability30,  ///< Enable CUDA compute capability 3.0 (Kepler)

--- a/src/Target.h
+++ b/src/Target.h
@@ -49,7 +49,7 @@ struct Target {
         F16C,  ///< Enable x86 16-bit float support
 
         ARMv7s,  ///< Generate code for ARMv7s. Only relevant for 32-bit ARM.
-        NoNEON,  ///< Don't generate vectorized code for ARMv7. Only relevant for 32-bit ARM.
+        NoNEON,  ///< Avoid using NEON instructions. Only relevant for 32-bit ARM.
 
         CUDA,  ///< Enable the CUDA runtime. Defaults to compute capability 2.0 (Fermi)
         CUDACapability30,  ///< Enable CUDA compute capability 3.0 (Kepler)

--- a/src/runtime/arm_no_neon.ll
+++ b/src/runtime/arm_no_neon.ll
@@ -1,0 +1,1 @@
+; TODO: add specializations for ARMv7 without NEON


### PR DESCRIPTION
This PR tries to enable at running Halide generated code on older devices.

When I run the HelloAndroid app on a Xoom tablet it crashes with SIGILL because the Halide generated code contains instructions incompatible with the Tegra2 processor. But, when I disable everything NEON in CodeGen_ARM.cpp I can run it and it's not too slow too.