### PR TITLE
Fix compilation issues against latest llvm trunk(3.7)

### DIFF
--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -314,7 +314,11 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     TargetMachine &Target = *target.get();
 
     // Set up passes
+    #if LLVM_VERSION < 37
     PassManager PM;
+    #else
+    legacy::PassManager PM;
+    #endif
 
     #if LLVM_VERSION < 37
     PM.add(new TargetLibraryInfo(TheTriple));
@@ -379,7 +383,11 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     PM.add(createAlwaysInlinerPass());
 
     // Override default to generate verbose assembly.
+    #if LLVM_VERSION < 37
     Target.setAsmVerbosityDefault(true);
+    #else
+    Target.Options.MCOptions.AsmVerbose = true;
+    #endif
 
     // Output string stream
     std::string outstr;

--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -27,7 +27,11 @@
 #if LLVM_VERSION < 36
 #include <llvm/ExecutionEngine/JITMemoryManager.h>
 #endif
+#if LLVM_VERSION < 37
 #include <llvm/PassManager.h>
+#else
+#include <llvm/IR/LegacyPassManager.h>
+#endif
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/FormattedStream.h>
 #include <llvm/Support/TargetRegistry.h>


### PR DESCRIPTION
Align Halide with the effects of two following revisions in llvm trunk:

---
r229094 | chandlerc | 2015-02-13 05:01:29 -0500 (Fri, 13 Feb 2015) | 16 lines

[PM] Remove the old 'PassManager.h' header file at the top level of
LLVM's include tree and the use of using declarations to hide the
'legacy' namespace for the old pass manager.

---
r228961 | rafael | 2015-02-12 16:16:34 -0500 (Thu, 12 Feb 2015) | 3 lines
Remove mostly unused setters.