### PR TITLE
Added an implementation of the sger/dger BLAS methods.

### DIFF
--- a/apps/linear_algebra/Makefile
+++ b/apps/linear_algebra/Makefile
@@ -19,11 +19,6 @@ OPENBLAS_LIBS ?= -lopenblas
 # ATLAS_FLAGS ?= -DUSE_ATLAS -I/opt/ATLAS/include
 # ATLAS_LIBS ?= -L/opt/ATLAS/lib -lptcblas -latlas
 
-# By default use whatever ATLAS is installed, so that this at least builds.
-$(warning Warning: Defaulting to system ATLAS, which may be slow. See the Makefile for details.)
-ATLAS_FLAGS ?= -DUSE_ATLAS
-ATLAS_LIBS ?= -lcblas
-
 KERNEL_DIR = src/kernels
 KERNELS = \
 	scopy_impl \
@@ -40,6 +35,8 @@ KERNELS = \
 	dgemv_notrans \
 	sgemv_trans \
 	dgemv_trans \
+	sger_impl \
+	dger_impl \
 	sgemm_notrans \
 	dgemm_notrans \
 	sgemm_transA \
@@ -95,7 +92,7 @@ L1_BENCHMARK_SIZES = 16 64 288 1056 2080
 L2_BENCHMARK_SIZES = 8 16 32 64 128 288 544 1056 2080
 L3_BENCHMARK_SIZES = 8 16 32 64 128 288 544 1056 2080
 L1_BENCHMARKS = scopy dcopy sscal dscal saxpy daxpy sdot ddot sasum dasum
-L2_BENCHMARKS = sgemv_notrans dgemv_notrans sgemv_trans dgemv_trans
+L2_BENCHMARKS = sgemv_notrans dgemv_notrans sgemv_trans dgemv_trans sger dger
 L3_BENCHMARKS = sgemm_notrans dgemm_notrans sgemm_transA dgemm_transA sgemm_transB dgemm_transB sgemm_transAB dgemm_transAB
 
 cblas_l1_benchmark_%: benchmarks/cblas_benchmarks
@@ -254,6 +251,14 @@ $(KERNEL_DIR)/halide_sgemv_trans.o $(KERNEL_DIR)/halide_sgemv_trans.h: $(KERNEL_
 $(KERNEL_DIR)/halide_dgemv_trans.o $(KERNEL_DIR)/halide_dgemv_trans.h: $(KERNEL_DIR)/blas_l2.generator
 	$(LD_PATH_SETUP) $< -g dgemv -f halide_dgemv_trans -o $(KERNEL_DIR) -e $(EMIT_OPTIONS) \
 	target=$(HL_TARGET) parallel=false vectorize=true transpose=true
+
+$(KERNEL_DIR)/halide_sger_impl.o $(KERNEL_DIR)/halide_sger_impl.h: $(KERNEL_DIR)/blas_l2.generator
+	$(LD_PATH_SETUP) $< -g sger -f halide_sger_impl -o $(KERNEL_DIR) -e $(EMIT_OPTIONS) \
+	target=$(HL_TARGET) parallel=false vectorize=true
+
+$(KERNEL_DIR)/halide_dger_impl.o $(KERNEL_DIR)/halide_dger_impl.h: $(KERNEL_DIR)/blas_l2.generator
+	$(LD_PATH_SETUP) $< -g dger -f halide_dger_impl -o $(KERNEL_DIR) -e $(EMIT_OPTIONS) \
+	target=$(HL_TARGET) parallel=false vectorize=true
 
 $(KERNEL_DIR)/halide_sgemm_notrans.o $(KERNEL_DIR)/halide_sgemm_notrans.h: $(KERNEL_DIR)/blas_l3.generator
 	$(LD_PATH_SETUP) $< -g sgemm -f halide_sgemm_notrans -o $(KERNEL_DIR) -e $(EMIT_OPTIONS) \

--- a/apps/linear_algebra/Makefile
+++ b/apps/linear_algebra/Makefile
@@ -19,6 +19,11 @@ OPENBLAS_LIBS ?= -lopenblas
 # ATLAS_FLAGS ?= -DUSE_ATLAS -I/opt/ATLAS/include
 # ATLAS_LIBS ?= -L/opt/ATLAS/lib -lptcblas -latlas
 
+# By default use whatever ATLAS is installed, so that this at least builds.
+$(warning Warning: Defaulting to system ATLAS, which may be slow. See the Makefile for details.)
+ATLAS_FLAGS ?= -DUSE_ATLAS
+ATLAS_LIBS ?= -lcblas
+
 KERNEL_DIR = src/kernels
 KERNELS = \
 	scopy_impl \

--- a/apps/linear_algebra/benchmarks/cblas_benchmarks.cpp
+++ b/apps/linear_algebra/benchmarks/cblas_benchmarks.cpp
@@ -81,6 +81,8 @@ struct BenchmarksBase {
             this->bench_gemv_notrans(size);
         } else if (benchmark == "gemv_trans") {
             this->bench_gemv_trans(size);
+        } else if (benchmark == "ger") {
+            this->bench_ger(size);
         } else if (benchmark == "gemm_notrans") {
             this->bench_gemm_notrans(size);
         } else if (benchmark == "gemm_transA") {
@@ -99,6 +101,7 @@ struct BenchmarksBase {
     virtual void bench_asum(int N) =0;
     virtual void bench_gemv_notrans(int N) =0;
     virtual void bench_gemv_trans(int N) =0;
+    virtual void bench_ger(int N) =0;
     virtual void bench_gemm_notrans(int N) =0;
     virtual void bench_gemm_transA(int N) =0;
     virtual void bench_gemm_transB(int N) =0;
@@ -125,6 +128,9 @@ struct BenchmarksFloat : public BenchmarksBase<float> {
     L2Benchmark(gemv_trans, "s", cblas_sgemv(CblasColMajor, CblasTrans, N, N,
                                              alpha, &(A[0]), N, &(x[0]), 1,
                                              beta, &(y[0]), 1))
+
+    L2Benchmark(ger, "s", cblas_sger(CblasColMajor, N, N, alpha, &(x[0]), 1,
+                                     &(y[0]), 1, &(A[0]), N))
 
     L3Benchmark(gemm_notrans, "s", cblas_sgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, N, N, N,
                                                alpha, &(A[0]), N, &(B[0]), N,
@@ -163,6 +169,9 @@ struct BenchmarksDouble : public BenchmarksBase<double> {
     L2Benchmark(gemv_trans, "d", cblas_dgemv(CblasColMajor, CblasTrans, N, N,
                                                   alpha, &(A[0]), N, &(x[0]), 1,
                                                   beta, &(y[0]), 1))
+
+    L2Benchmark(ger, "d", cblas_dger(CblasColMajor, N, N, alpha, &(x[0]), 1,
+                                     &(y[0]), 1, &(A[0]), N))
 
     L3Benchmark(gemm_notrans, "d", cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, N, N, N,
                                                alpha, &(A[0]), N, &(B[0]), N,

--- a/apps/linear_algebra/benchmarks/eigen_benchmarks.cpp
+++ b/apps/linear_algebra/benchmarks/eigen_benchmarks.cpp
@@ -67,6 +67,8 @@ struct Benchmarks {
             bench_gemv_notrans(size);
         } else if (benchmark == "gemv_trans") {
             bench_gemv_trans(size);
+        } else if (benchmark == "ger") {
+            bench_ger(size);
         } else if (benchmark == "gemm_notrans") {
             bench_gemm_notrans(size);
         } else if (benchmark == "gemm_transA") {
@@ -88,6 +90,7 @@ struct Benchmarks {
 
     L2Benchmark(gemv_notrans, type_name<T>(), y = alpha * A * x + beta * y);
     L2Benchmark(gemv_trans,   type_name<T>(), y = alpha * A.transpose() * x + beta * y);
+    L2Benchmark(ger,          type_name<T>(), A = alpha * x * y.transpose() + A);
 
     L3Benchmark(gemm_notrans, type_name<T>(), C = alpha * A * B + beta * C);
     L3Benchmark(gemm_transA, type_name<T>(), C = alpha * A.transpose() * B + beta * C);

--- a/apps/linear_algebra/benchmarks/halide_benchmarks.cpp
+++ b/apps/linear_algebra/benchmarks/halide_benchmarks.cpp
@@ -70,6 +70,8 @@ struct BenchmarksBase {
             bench_gemv_notrans(size);
         } else if (benchmark == "gemv_trans") {
             bench_gemv_trans(size);
+        } else if (benchmark == "ger") {
+            bench_ger(size);
         } else if (benchmark == "gemm_notrans") {
             bench_gemm_notrans(size);
         } else if (benchmark == "gemm_transA") {
@@ -88,6 +90,7 @@ struct BenchmarksBase {
     virtual void bench_asum(int N) =0;
     virtual void bench_gemv_notrans(int N) =0;
     virtual void bench_gemv_trans(int N) =0;
+    virtual void bench_ger(int N) =0;
     virtual void bench_gemm_notrans(int N) =0;
     virtual void bench_gemm_transA(int N) =0;
     virtual void bench_gemm_transB(int N) =0;
@@ -109,10 +112,12 @@ struct BenchmarksFloat : public BenchmarksBase<float> {
     L1Benchmark(asum, "s", halide_sasum(x.raw_buffer(), result.raw_buffer()))
 
     L2Benchmark(gemv_notrans, "s", halide_sgemv(false, alpha, A.raw_buffer(), x.raw_buffer(),
-                                                    beta, y.raw_buffer()))
+                                                beta, y.raw_buffer()))
 
     L2Benchmark(gemv_trans, "s", halide_sgemv(true, alpha, A.raw_buffer(), x.raw_buffer(),
-                                                  beta, y.raw_buffer()))
+                                              beta, y.raw_buffer()))
+
+    L2Benchmark(ger, "s", halide_sger(alpha, x.raw_buffer(), y.raw_buffer(), A.raw_buffer()))
 
     L3Benchmark(gemm_notrans, "s", halide_sgemm(false, false, alpha, A.raw_buffer(),
                                                 B.raw_buffer(), beta, C.raw_buffer()))
@@ -142,10 +147,12 @@ struct BenchmarksDouble : public BenchmarksBase<double> {
     L1Benchmark(asum, "d", halide_dasum(x.raw_buffer(), result.raw_buffer()))
 
     L2Benchmark(gemv_notrans, "d", halide_dgemv(false, alpha, A.raw_buffer(), x.raw_buffer(),
-                                                     beta, y.raw_buffer()))
+                                                beta, y.raw_buffer()))
 
     L2Benchmark(gemv_trans, "d", halide_dgemv(true, alpha, A.raw_buffer(), x.raw_buffer(),
-                                                   beta, y.raw_buffer()))
+                                              beta, y.raw_buffer()))
+
+    L2Benchmark(ger, "d", halide_dger(alpha, x.raw_buffer(), y.raw_buffer(), A.raw_buffer()))
 
     L3Benchmark(gemm_notrans, "d", halide_dgemm(false, false, alpha, A.raw_buffer(),
                                                 B.raw_buffer(), beta, C.raw_buffer()))

--- a/apps/linear_algebra/src/halide_blas.cpp
+++ b/apps/linear_algebra/src/halide_blas.cpp
@@ -197,10 +197,9 @@ double hblas_dasum(const int N, const double *x, const int incx) {
 // gemv //
 //////////
 
-void hblas_sgemv(const enum HBLAS_ORDER Order, const enum HBLAS_TRANSPOSE trans, const int M, const int N,
-                 const float a, const float *A, const int lda,
-                 const float *x, const int incx, const float b,
-                 float *y, const int incy) {
+void hblas_sgemv(const enum HBLAS_ORDER Order, const enum HBLAS_TRANSPOSE trans,
+                 const int M, const int N, const float a, const float *A, const int lda,
+                 const float *x, const int incx, const float b, float *y, const int incy) {
     bool t = false;
     switch (trans) {
     case HblasNoTrans:
@@ -223,10 +222,9 @@ void hblas_sgemv(const enum HBLAS_ORDER Order, const enum HBLAS_TRANSPOSE trans,
     assert_no_error(halide_sgemv(t, a, &buff_A, &buff_x, b, &buff_y));
 }
 
-void hblas_dgemv(const enum HBLAS_ORDER Order, const enum HBLAS_TRANSPOSE trans, const int M, const int N,
-                 const double a, const double *A, const int lda,
-                 const double *x, const int incx, const double b,
-                 double *y, const int incy) {
+void hblas_dgemv(const enum HBLAS_ORDER Order, const enum HBLAS_TRANSPOSE trans,
+                 const int M, const int N, const double a, const double *A, const int lda,
+                 const double *x, const int incx, const double b, double *y, const int incy) {
     bool t = false;
     switch (trans) {
     case HblasNoTrans:
@@ -248,6 +246,38 @@ void hblas_dgemv(const enum HBLAS_ORDER Order, const enum HBLAS_TRANSPOSE trans,
 
     assert_no_error(halide_dgemv(t, a, &buff_A, &buff_x, b, &buff_y));
 }
+
+//////////
+// ger  //
+//////////
+
+void hblas_sger(const enum HBLAS_ORDER order, const int M, const int N,
+                const float alpha, const float *x, const int incx,
+                const float *y, const int incy, float *A, const int lda)
+{
+    buffer_t buff_x, buff_y, buff_A;
+    init_vector_buffer(M, x, incx, &buff_x);
+    init_vector_buffer(N, y, incy, &buff_y);
+    init_matrix_buffer(M, N, A, lda, &buff_A);
+
+    assert_no_error(halide_sger(alpha, &buff_x, &buff_y, &buff_A));
+}
+
+void hblas_dger(const enum HBLAS_ORDER order, const int M, const int N,
+                const double alpha, const double *x, const int incx,
+                const double *y, const int incy, double *A, const int lda)
+{
+    buffer_t buff_x, buff_y, buff_A;
+    init_vector_buffer(M, x, incx, &buff_x);
+    init_vector_buffer(N, y, incy, &buff_y);
+    init_matrix_buffer(M, N, A, lda, &buff_A);
+
+    assert_no_error(halide_dger(alpha, &buff_x, &buff_y, &buff_A));
+}
+
+//////////
+// gemm //
+//////////
 
 void hblas_sgemm(const enum HBLAS_ORDER Order, const enum HBLAS_TRANSPOSE TransA,
                  const enum HBLAS_TRANSPOSE TransB, const int M, const int N,

--- a/apps/linear_algebra/src/halide_blas.h
+++ b/apps/linear_algebra/src/halide_blas.h
@@ -18,6 +18,8 @@
 #include "halide_dgemv_notrans.h"
 #include "halide_sgemv_trans.h"
 #include "halide_dgemv_trans.h"
+#include "halide_sger_impl.h"
+#include "halide_dger_impl.h"
 #include "halide_sgemm_notrans.h"
 #include "halide_dgemm_notrans.h"
 #include "halide_sgemm_transA.h"
@@ -65,6 +67,14 @@ inline int halide_dgemv(bool trans, double a, buffer_t *A, buffer_t *x, double b
     } else {
         return halide_dgemv_notrans(a, A, x, b, y, y);
     }
+}
+
+inline int halide_sger(float a, buffer_t *x, buffer_t *y, buffer_t *A) {
+    return halide_sger_impl(a, x, y, A, A);
+}
+
+inline int halide_dger(float a, buffer_t *x, buffer_t *y, buffer_t *A) {
+    return halide_dger_impl(a, x, y, A, A);
 }
 
 inline int halide_sgemm(bool transA, bool transB, float a, buffer_t *A, buffer_t *B, float b, buffer_t *C) {
@@ -204,6 +214,14 @@ void hblas_dgemv(const enum HBLAS_ORDER order,
                  const double alpha, const double *A, const int lda,
                  const double *X, const int incX, const double beta,
                  double *Y, const int incY);
+
+void hblas_sger(const enum HBLAS_ORDER order, const int M, const int N,
+                const float alpha, const float *X, const int incX,
+                const float *Y, const int incY, float *A, const int lda);
+
+void hblas_dger(const enum HBLAS_ORDER order, const int M, const int N,
+                const double alpha, const double *X, const int incX,
+                const double *Y, const int incY, double *A, const int lda);
 
 /*
  * ===========================================================================

--- a/apps/linear_algebra/tests/test_halide_blas.cpp
+++ b/apps/linear_algebra/tests/test_halide_blas.cpp
@@ -206,6 +206,7 @@ struct BLASFloatTests : public BLASTestBase<float> {
         RUN_TEST(sasum);
         RUN_TEST(sgemv_notrans);
         RUN_TEST(sgemv_trans);
+        RUN_TEST(sger);
         RUN_TEST(sgemm_notrans);
         RUN_TEST(sgemm_transA);
         RUN_TEST(sgemm_transB);
@@ -225,6 +226,9 @@ struct BLASFloatTests : public BLASTestBase<float> {
     L2_TEST(sgemv_trans,
             cblas_sgemv(CblasColMajor, CblasTrans, N, N, alpha, A, N, x, 1, beta, y, 1),
             hblas_sgemv(HblasColMajor, HblasTrans, N, N, alpha, A, N, x, 1, beta, y, 1));
+    L2_TEST(sger,
+            cblas_sger(CblasColMajor, N, N, alpha, x, 1, y, 1, A, N),
+            hblas_sger(HblasColMajor, N, N, alpha, x, 1, y, 1, A, N));
 
     L3_TEST(sgemm_notrans,
             cblas_sgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, N, N, N, alpha, A, N, B, N, beta, C, N),
@@ -249,6 +253,7 @@ struct BLASDoubleTests : public BLASTestBase<double> {
         RUN_TEST(dasum);
         RUN_TEST(dgemv_notrans);
         RUN_TEST(dgemv_trans);
+        RUN_TEST(dger);
         RUN_TEST(dgemm_notrans);
         RUN_TEST(dgemm_transA);
         RUN_TEST(dgemm_transB);
@@ -268,6 +273,9 @@ struct BLASDoubleTests : public BLASTestBase<double> {
     L2_TEST(dgemv_trans,
             cblas_dgemv(CblasColMajor, CblasTrans, N, N, alpha, A, N, x, 1, beta, y, 1),
             hblas_dgemv(HblasColMajor, HblasTrans, N, N, alpha, A, N, x, 1, beta, y, 1));
+    L2_TEST(dger,
+            cblas_dger(CblasColMajor, N, N, alpha, x, 1, y, 1, A, N),
+            hblas_dger(HblasColMajor, N, N, alpha, x, 1, y, 1, A, N));
 
     L3_TEST(dgemm_notrans,
             cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, N, N, N, alpha, A, N, B, N, beta, C, N),


### PR DESCRIPTION
These methods perform the generalized rank-1 update of a matrix, i.e. A += alpha * x * y^t. I've added tests and benchmarks for these methods, and updated the [performance charts](https://docs.google.com/spreadsheets/d/15pJP-oS4l_PZNvf63wcdxUNuaKwMOiQj-IMEAaUI-gw/edit#gid=625829285).