### PR TITLE
Add halide_type_code_t

### DIFF
--- a/src/Type.h
+++ b/src/Type.h
@@ -2,6 +2,7 @@
 #define HALIDE_TYPE_H
 
 #include <stdint.h>
+#include "runtime/HalideRuntime.h"
 #include "Util.h"
 
 /** \file
@@ -18,12 +19,17 @@ struct Expr;
  * larger than one). Front-end code shouldn't use vector
  * types. Instead vectorize a function. */
 struct Type {
-    /** The basic type code: signed integer, unsigned integer, or floating point */
+    /** The basic type code: signed integer, unsigned integer, or floating point.
+     *
+     * Note that TypeCode is guaranteed to have values identical to those of
+     * halide_type_code_t (HalideRuntime.h), but exists as a separate typedef
+     * to preserve source code compatibility.
+     */
     enum TypeCode {
-        Int,  //!< signed integers
-        UInt, //!< unsigned integers
-        Float, //!< floating point numbers
-        Handle //!< opaque pointer type (void *)
+        Int = HalideType_Int,
+        UInt = HalideType_UInt,
+        Float = HalideType_Float,
+        Handle = HalideType_Handle
     } code;
 
     /** The number of bits of precision of a single scalar value of this type. */

--- a/src/Type.h
+++ b/src/Type.h
@@ -26,10 +26,10 @@ struct Type {
      * to preserve source code compatibility.
      */
     enum TypeCode {
-        Int = HalideType_Int,
-        UInt = HalideType_UInt,
-        Float = HalideType_Float,
-        Handle = HalideType_Handle
+        Int = halide_type_int,
+        UInt = halide_type_uint,
+        Float = halide_type_float,
+        Handle = halide_type_handle
     } code;
 
     /** The number of bits of precision of a single scalar value of this type. */

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -293,10 +293,10 @@ extern void halide_memoization_cache_cleanup();
  * (the bit width is expected to be encoded in a separate value).
  */
 typedef enum halide_type_code_t {
-    HalideType_Int = 0,   //!< signed integers
-    HalideType_UInt = 1,  //!< unsigned integers
-    HalideType_Float = 2, //!< floating point numbers
-    HalideType_Handle = 3 //!< opaque pointer type (void *)
+    halide_type_int = 0,   //!< signed integers
+    halide_type_uint = 1,  //!< unsigned integers
+    halide_type_float = 2, //!< floating point numbers
+    halide_type_handle = 3 //!< opaque pointer type (void *)
 } halide_type_code_t;
 
 #ifndef BUFFER_T_DEFINED

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -287,6 +287,18 @@ extern void halide_memoization_cache_store(void *user_context, const uint8_t *ca
  */
 extern void halide_memoization_cache_cleanup();
 
+/** Types in the halide type system. They can be ints, unsigned ints,
+ * or floats (of various bit-widths), or a handle (which is always pointer-sized).
+ * Note that the int/uint/float values do not imply a specific bit width
+ * (the bit width is expected to be encoded in a separate value).
+ */
+typedef enum halide_type_code_t {
+    HalideType_Int = 0,   //!< signed integers
+    HalideType_UInt = 1,  //!< unsigned integers
+    HalideType_Float = 2, //!< floating point numbers
+    HalideType_Handle = 3 //!< opaque pointer type (void *)
+} halide_type_code_t;
+
 #ifndef BUFFER_T_DEFINED
 #define BUFFER_T_DEFINED
 


### PR DESCRIPTION
We need a runtime-suitable enum that corresponds to Type::TypeCode,
both for use in Metadata (Issue #664) and to add to buffer_t at some
point in the future. This defines an enum in HalideRuntime.h to pave
the way for these uses, and redefines the values of Type::TypeCode to
match them.

(It seems infeasible to replace Type::TypeCode entirely, as the runtime
version needs to be C-compatible, and preserving source compatibility
would require polluting the global namespace with (e.g.) “Int”, etc.)