### PR TITLE
Only flip a buffer from one device to another if dev != 0

### DIFF
--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -131,7 +131,7 @@ WEAK int halide_copy_to_device(void *user_context, struct buffer_t *buf, const h
         interface = buf_dev_interface;
     }
 
-    if (buf_dev_interface != interface) {
+    if (buf->dev && buf_dev_interface != interface) {
         debug(user_context) << "halide_copy_to_device " << buf << " flipping buffer to new device\n";
         if (buf_dev_interface != NULL && buf->dev_dirty) {
             halide_assert(user_context, !buf->host_dirty);
@@ -177,7 +177,7 @@ WEAK int halide_copy_to_device(void *user_context, struct buffer_t *buf, const h
 
 /** Wait for current GPU operations to complete. Calling this explicitly
  * should rarely be necessary, except maybe for profiling. */
-WEAK int halide_device_sync(void *user_context, struct buffer_t *buf) { 
+WEAK int halide_device_sync(void *user_context, struct buffer_t *buf) {
     const halide_device_interface *interface = NULL;
     if (buf) {
         interface = halide_get_device_interface(buf->dev);
@@ -192,7 +192,7 @@ WEAK int halide_device_sync(void *user_context, struct buffer_t *buf) {
 WEAK int halide_device_malloc(void *user_context, struct buffer_t *buf, const halide_device_interface *interface) {
     const halide_device_interface *current_interface = halide_get_device_interface(buf->dev);
     debug(user_context) << "halide_device_malloc: " << buf << " interface " << interface <<
-        " host: " << buf->host << ", dev: " << buf->dev << ", host_dirty: " << buf->host_dirty << ", dev_dirty:" << buf->dev_dirty << 
+        " host: " << buf->host << ", dev: " << buf->dev << ", host_dirty: " << buf->host_dirty << ", dev_dirty:" << buf->dev_dirty <<
         " buf current interface: " << current_interface << "\n";
 
     // halide_device_malloc does not support switching interfaces.

--- a/test/generator/gpu_only_aottest.cpp
+++ b/test/generator/gpu_only_aottest.cpp
@@ -3,8 +3,8 @@
 #include <HalideRuntime.h>
 #include <assert.h>
 #if defined(TEST_OPENCL)
-#include <HalideRuntimeOpencl.h>
-#else if defined(TEST_CUDA)
+#include <HalideRuntimeOpenCL.h>
+#elif defined(TEST_CUDA)
 #include <HalideRuntimeCuda.h>
 #endif
 


### PR DESCRIPTION
Fixes gpu_only_aottest, and skips a pointless copy in general. The bad path was:

Start with a buffer where dev == 0 && host_dirty == 0 and call halide_copy_to_device
dev is not the right device interface, so flip buffer to new device
copy to host (no-op, because dev == 0)
mark host dirty
copy to new device (pointless, because host_dirty was zero and there was no dev, so the buffer was undefined)

The pointless copy actually segfaulted for the test, because the test sets the host field to something invalid assuming that it will never get copied from. Turns out this test also tests that no pointless copy_to_device of the output buffer takes place!

This is a complex failure path, so I'd appreciate someone sanity checking me.