### PR TITLE
Add dimensions and def/min/max to Argument

### DIFF
--- a/src/Argument.h
+++ b/src/Argument.h
@@ -2,6 +2,7 @@
 #define HALIDE_ARGUMENT_H
 
 #include <string>
+#include "Error.h"
 #include "Expr.h"
 #include "Type.h"
 
@@ -22,19 +23,63 @@ struct Argument {
     std::string name;
 
     /** An argument is either a primitive type (for parameters), or a
-     * buffer pointer. If 'is_buffer' is true, then 'type' should be
-     * ignored.
+     * buffer pointer.
+     *
+     * If kind == Scalar, then type fully encodes the expected type
+     * of the scalar argument.
+     *
+     * If kind == Buffer, then type.bytes() should be used to determine
+     * elem_size of the buffer; additionally, type.code *should* reflect
+     * the expected interpretation of the buffer data (e.g. float vs int),
+     * but there is no runtime enforcement of this at present.
      */
-    bool is_buffer;
+    enum Kind {
+        Scalar,
+        Buffer
+    };
+    Kind kind;
 
-    /** If this is a scalar parameter, then this is its type */
+    /** If kind == Buffer is true, this is the dimensionality of the buffer.
+     * If kind == Scalar is false, this value is ignored (and should always be set to zero) */
+    uint8_t dimensions;
+
+    /** If this is a scalar parameter, then this is its type.
+     *
+     * If this is a buffer parameter, this is used to determine elem_size
+     * of the buffer_t.
+     *
+     * Note that type.width should always be 1 here. */
     Type type;
 
-    Argument() : is_buffer(false) {}
-    Argument(const std::string &_name, bool _is_buffer, Type _type) :
-        name(_name), is_buffer(_is_buffer), type(_type) {
+    /** If this is a scalar parameter, then these are its default, min, max values.
+     * By default, they are left unset, implying "no default, no min, no max".
+     *
+     * TODO: Expr is constrained to a 32-bit value (either int or float),
+     * so this constrains the default for int64 and double. (The same constraint
+     * has always applied to min and max, since they've always been expressed
+     * as Expr, so this is quite possibly a restriction which matters little
+     * in practice.) */
+    Expr def, min, max;
+
+    Argument() : kind(Scalar), dimensions(0) {}
+    Argument(const std::string &_name, Kind _kind, const Type &_type, uint8_t _dimensions,
+                Expr _def = Expr(),
+                Expr _min = Expr(),
+                Expr _max = Expr()) :
+        name(_name), kind(_kind), dimensions(_dimensions), type(_type), def(_def), min(_min), max(_max) {
+        user_assert(!(kind == Scalar && dimensions != 0))
+            << "Scalar Arguments must specify dimensions of 0";
+        user_assert(!(kind == Buffer && def.defined()))
+            << "Scalar default must not be defined for Buffer Arguments";
+        user_assert(!(kind == Buffer && min.defined()))
+            << "Scalar min must not be defined for Buffer Arguments";
+        user_assert(!(kind == Buffer && max.defined()))
+            << "Scalar max must not be defined for Buffer Arguments";
     }
+
+    bool is_buffer() const { return kind == Buffer; }
 };
+
 }
 
 #endif

--- a/src/Argument.h
+++ b/src/Argument.h
@@ -52,13 +52,7 @@ struct Argument {
     Type type;
 
     /** If this is a scalar parameter, then these are its default, min, max values.
-     * By default, they are left unset, implying "no default, no min, no max".
-     *
-     * TODO: Expr is constrained to a 32-bit value (either int or float),
-     * so this constrains the default for int64 and double. (The same constraint
-     * has always applied to min and max, since they've always been expressed
-     * as Expr, so this is quite possibly a restriction which matters little
-     * in practice.) */
+     * By default, they are left unset, implying "no default, no min, no max". */
     Expr def, min, max;
 
     Argument() : kind(Scalar), dimensions(0) {}

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -231,7 +231,7 @@ const std::string &Buffer::name() const {
 }
 
 Buffer::operator Argument() const {
-    return Argument(name(), true, type());
+    return Argument(name(), Argument::Buffer, type(), dimensions());
 }
 
 int Buffer::copy_to_host() {

--- a/src/CodeGen.cpp
+++ b/src/CodeGen.cpp
@@ -186,7 +186,7 @@ void CodeGen::compile(Stmt stmt, string name,
     // Now deduce the types of the arguments to our function
     vector<llvm::Type *> arg_types(args.size());
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+        if (args[i].is_buffer()) {
             arg_types[i] = buffer_t_type->getPointerTo();
         } else {
             arg_types[i] = llvm_type_of(args[i].type);
@@ -200,7 +200,7 @@ void CodeGen::compile(Stmt stmt, string name,
 
     // Mark the buffer args as no alias
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+        if (args[i].is_buffer()) {
             function->setDoesNotAlias(i+1);
         }
     }
@@ -216,7 +216,7 @@ void CodeGen::compile(Stmt stmt, string name,
              iter != function->arg_end();
              iter++) {
 
-            if (args[i].is_buffer) {
+            if (args[i].is_buffer()) {
                 unpack_buffer(args[i].name, iter);
             } else {
                 sym_push(args[i].name, iter);
@@ -316,7 +316,7 @@ void CodeGen::compile(Stmt stmt, string name,
         // Get the address of the nth argument
         Value *ptr = builder->CreateConstGEP1_32(arg_array, (int)i);
         ptr = builder->CreateLoad(ptr);
-        if (args[i].is_buffer) {
+        if (args[i].is_buffer()) {
             // Cast the argument to a buffer_t *
             wrapper_args[i] = builder->CreatePointerCast(ptr, buffer_t_type->getPointerTo());
         } else {
@@ -328,7 +328,7 @@ void CodeGen::compile(Stmt stmt, string name,
     debug(4) << "Creating call from wrapper to actual function\n";
     Value *result = builder->CreateCall(function, wrapper_args);
     builder->CreateRet(result);
-    internal_assert(verifyFunction(*wrapper) == false);       
+    internal_assert(verifyFunction(*wrapper) == false);
 
     // Finally, verify the module is ok
     internal_assert(verifyModule(*module) == false);

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -267,7 +267,7 @@ void CodeGen_C::compile_header(const string &name, const vector<Argument> &args)
     stream << "int " << name << "(";
     for (size_t i = 0; i < args.size(); i++) {
         if (i > 0) stream << ", ";
-        if (args[i].is_buffer) {
+        if (args[i].is_buffer()) {
             stream << "buffer_t *" << print_name(args[i].name);
         } else {
             stream << "const "
@@ -402,7 +402,7 @@ void CodeGen_C::compile(Stmt s, string name,
     // Emit the function prototype
     stream << "extern \"C\" int " << name << "(";
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+        if (args[i].is_buffer()) {
             stream << "buffer_t *"
                    << print_name(args[i].name)
                    << "_buffer";
@@ -420,7 +420,7 @@ void CodeGen_C::compile(Stmt s, string name,
 
     // Unpack the buffer_t's
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+        if (args[i].is_buffer()) {
             unpack_buffer(args[i].type, args[i].name);
         }
     }
@@ -1263,10 +1263,10 @@ void CodeGen_C::visit(const Evaluate *op) {
 }
 
 void CodeGen_C::test() {
-    Argument buffer_arg("buf", true, Int(32));
-    Argument float_arg("alpha", false, Float(32));
-    Argument int_arg("beta", false, Int(32));
-    Argument user_context_arg("__user_context", false, Handle());
+    Argument buffer_arg("buf", Argument::Buffer, Int(32), 3);
+    Argument float_arg("alpha", Argument::Scalar, Float(32), 0);
+    Argument int_arg("beta", Argument::Scalar, Int(32), 0);
+    Argument user_context_arg("__user_context", Argument::Scalar, Handle(), 0);
     vector<Argument> args(4);
     args[0] = buffer_arg;
     args[1] = float_arg;

--- a/src/CodeGen_GPU_Dev.h
+++ b/src/CodeGen_GPU_Dev.h
@@ -26,11 +26,11 @@ struct GPU_Argument : public Argument {
     bool write;
 
     GPU_Argument() : size(0), packed_index(0), read(false), write(false) {}
-    GPU_Argument(const std::string &_name, bool _is_buffer, Type _type) :
-        Argument(_name, _is_buffer, _type), size(0), packed_index(0), read(_is_buffer), write(_is_buffer) {}
-    GPU_Argument(const std::string &_name, bool _is_buffer, Type _type,
+    GPU_Argument(const std::string &_name, Kind _kind, Type _type, uint8_t _dimensions) :
+        Argument(_name, _kind, _type, _dimensions), size(0), packed_index(0), read(_kind == Buffer), write(_kind == Buffer) {}
+    GPU_Argument(const std::string &_name, Kind _kind, Type _type, uint8_t _dimensions,
                  size_t _size) :
-        Argument(_name, _is_buffer, _type), size(_size), packed_index(0), read(_is_buffer), write(_is_buffer) {}
+        Argument(_name, _kind, _type, _dimensions), size(_size), packed_index(0), read(_kind == Buffer), write(_kind == Buffer) {}
 };
 
 /** A code generator that emits GPU code from a given Halide stmt. */

--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -153,6 +153,7 @@ protected:
             string bufname = string_imm->value;
             BufferRef &ref = buffers[bufname];
             ref.type = op->type;
+            // TODO: do we need to set ref.dimensions?
 
             if (op->name == Call::glsl_texture_load) {
                 ref.read = true;
@@ -179,7 +180,7 @@ vector<GPU_Argument> GPU_Host_Closure::arguments() {
     vector<GPU_Argument> res;
     for (map<string, Type>::const_iterator iter = vars.begin(); iter != vars.end(); ++iter) {
         debug(2) << "var: " << iter->first << "\n";
-        res.push_back(GPU_Argument(iter->first, false, iter->second));
+        res.push_back(GPU_Argument(iter->first, Argument::Scalar, iter->second, 0));
     }
     for (map<string, BufferRef>::const_iterator iter = buffers.begin(); iter != buffers.end(); ++iter) {
         debug(2) << "buffer: " << iter->first << " " << iter->second.size;
@@ -187,7 +188,7 @@ vector<GPU_Argument> GPU_Host_Closure::arguments() {
         if (iter->second.write) debug(2) << " (write)";
         debug(2) << "\n";
 
-        GPU_Argument arg(iter->first, true, iter->second.type, iter->second.size);
+        GPU_Argument arg(iter->first, Argument::Buffer, iter->second.type, iter->second.dimensions, iter->second.size);
         arg.read = iter->second.read;
         arg.write = iter->second.write;
         res.push_back(arg);
@@ -491,7 +492,7 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
 
             // Pack scalar parameters into vec4
             for (size_t i = 0; i < closure_args.size(); i++) {
-                if (closure_args[i].is_buffer) {
+                if (closure_args[i].is_buffer()) {
                     continue;
                 } else if (ends_with(closure_args[i].name, ".varying")) {
                     closure_args[i].packed_index = num_varying_floats++;
@@ -504,7 +505,7 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
         }
 
         for (size_t i = 0; i < closure_args.size(); i++) {
-            if (closure_args[i].is_buffer && allocations.contains(closure_args[i].name)) {
+            if (closure_args[i].is_buffer() && allocations.contains(closure_args[i].name)) {
                 closure_args[i].size = allocations.get(closure_args[i].name).constant_bytes;
             }
         }
@@ -547,7 +548,7 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
             string name = closure_args[i].name;
             Value *val;
 
-            if (closure_args[i].is_buffer) {
+            if (closure_args[i].is_buffer()) {
                 // If it's a buffer, dereference the dev handle
                 val = buffer_dev(sym_get(name + ".buffer"));
             } else if (ends_with(name, ".varying")) {
@@ -574,11 +575,11 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
                                  builder->CreateConstGEP2_32(gpu_args_arr, 0, i));
 
             // store the size of the argument
-            int size_bits = (closure_args[i].is_buffer) ? target.bits : closure_args[i].type.bits;
+            int size_bits = (closure_args[i].is_buffer()) ? target.bits : closure_args[i].type.bits;
             builder->CreateStore(ConstantInt::get(target_size_t_type, size_bits/8),
                                  builder->CreateConstGEP2_32(gpu_arg_sizes_arr, 0, i));
 
-            builder->CreateStore(ConstantInt::get(i8, closure_args[i].is_buffer),
+            builder->CreateStore(ConstantInt::get(i8, closure_args[i].is_buffer()),
                                  builder->CreateConstGEP2_32(gpu_arg_is_buffer_arr, 0, i));
         }
         // NULL-terminate the lists

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -42,6 +42,7 @@ void Closure::visit(const Load *op) {
 
         // If reading an image/buffer, compute the size.
         if (op->image.defined()) {
+            ref.dimensions = op->image.dimensions();
             ref.size = 1;
             for (int i = 0; i < op->image.dimensions(); i++) {
                 ref.size += (op->image.extent(i) - 1)*op->image.stride(i);
@@ -60,6 +61,7 @@ void Closure::visit(const Store *op) {
         debug(3) << "Adding buffer " << op->name << " to closure\n";
         BufferRef & ref = buffers[op->name];
         ref.type = op->value.type(); // TODO: Validate type is the same as existing refs?
+        // TODO: do we need to set ref.dimensions?
         ref.write = true;
     } else {
         debug(3) << "Not adding " << op->name << " to closure\n";

--- a/src/CodeGen_Internal.h
+++ b/src/CodeGen_Internal.h
@@ -45,6 +45,9 @@ public:
         /** The type of the buffer referenced. */
         Type type;
 
+        /** The dimensionality of the buffer. */
+        uint8_t dimensions;
+
         /** The buffer is read from. */
         bool read;
 
@@ -54,7 +57,7 @@ public:
         /** The size of the buffer if known, otherwise zero. */
         size_t size;
 
-        BufferRef() : read(false), write(false), size(0) { }
+        BufferRef() : dimensions(0), read(false), write(false), size(0) { }
     };
 
 public:

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -406,7 +406,7 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
     // declaration.
     vector<BufferSize> constants;
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer &&
+        if (args[i].is_buffer() &&
             CodeGen_GPU_Dev::is_buffer_constant(s, args[i].name) &&
             args[i].size > 0) {
             constants.push_back(BufferSize(args[i].name, args[i].size));
@@ -427,7 +427,7 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
     // Create preprocessor replacements for the address spaces of all our buffers.
     stream << "// Address spaces for " << name << "\n";
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+        if (args[i].is_buffer()) {
             vector<BufferSize>::iterator constant = constants.begin();
             while (constant != constants.end() &&
                    constant->name != args[i].name) {
@@ -450,7 +450,7 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
     // Emit the function prototype
     stream << "__kernel void " << name << "(\n";
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+        if (args[i].is_buffer()) {
             stream << " " << get_memory_space(args[i].name) << " ";
             if (!args[i].write) stream << "const ";
             stream << print_type(args[i].type) << " *"
@@ -475,14 +475,14 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
 
     for (size_t i = 0; i < args.size(); i++) {
         // Remove buffer arguments from allocation scope
-        if (args[i].is_buffer) {
+        if (args[i].is_buffer()) {
             allocations.pop(args[i].name);
         }
     }
 
     // Undef all the buffer address spaces, in case they're different in another kernel.
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+        if (args[i].is_buffer()) {
             stream << "#undef " << get_memory_space(args[i].name) << "\n";
         }
     }
@@ -621,7 +621,7 @@ string CodeGen_OpenCL_Dev::get_current_kernel_name() {
 void CodeGen_OpenCL_Dev::dump() {
     std::cerr << src_stream.str() << std::endl;
 }
-    
+
 std::string CodeGen_OpenCL_Dev::print_gpu_name(const std::string &name) {
     return name;
 }

--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -594,7 +594,7 @@ void CodeGen_GLSL::compile(Stmt stmt, string name,
     ostringstream header;
     header << "/// KERNEL " << name << "\n";
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+        if (args[i].is_buffer()) {
             Type t = args[i].type.element_of();
 
             user_assert(args[i].read != args[i].write) <<
@@ -654,7 +654,7 @@ void CodeGen_GLSL::compile(Stmt stmt, string name,
 
     // Declare input textures and variables
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer && args[i].read) {
+        if (args[i].is_buffer() && args[i].read) {
             stream << "uniform sampler2D " << print_name(args[i].name) << ";\n";
         }
     }
@@ -676,7 +676,7 @@ void CodeGen_GLSL::compile(Stmt stmt, string name,
 
     // Unpack the uniform and varying parameters
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+        if (args[i].is_buffer()) {
             continue;
         } else if (ends_with(args[i].name, ".varying")) {
             do_indent();

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -36,7 +36,7 @@ void CodeGen_PTX_Dev::add_kernel(Stmt stmt,
     // Now deduce the types of the arguments to our function
     vector<llvm::Type *> arg_types(args.size());
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+        if (args[i].is_buffer()) {
             arg_types[i] = llvm_type_of(UInt(8))->getPointerTo();
         } else {
             arg_types[i] = llvm_type_of(args[i].type);
@@ -50,7 +50,7 @@ void CodeGen_PTX_Dev::add_kernel(Stmt stmt,
 
     // Mark the buffer args as no alias
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+        if (args[i].is_buffer()) {
             function->setDoesNotAlias(i+1);
         }
     }
@@ -69,7 +69,7 @@ void CodeGen_PTX_Dev::add_kernel(Stmt stmt,
              iter++) {
 
             string arg_sym_name = args[i].name;
-            if (args[i].is_buffer) {
+            if (args[i].is_buffer()) {
                 // HACK: codegen expects a load from foo to use base
                 // address 'foo.host', so we store the device pointer
                 // as foo.host in this scope.

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -215,8 +215,16 @@ void GeneratorBase::build_params() {
             user_assert(is_valid_name(param->name())) << "Invalid Param name: " << param->name();
             user_assert(filter_params.find(param->name()) == filter_params.end())
                 << "Duplicate Param name: " << param->name();
+            Expr def, min, max;
+            if (!param->is_buffer()) {
+                def = param->get_scalar_expr();
+                min = param->get_min_value();
+                max = param->get_max_value();
+            }
             filter_params[param->name()] = param;
-            filter_arguments.push_back(Argument(param->name(), param->is_buffer(), param->type()));
+            filter_arguments.push_back(Argument(param->name(),
+                param->is_buffer() ? Argument::Buffer : Argument::Scalar,
+                param->type(), param->dimensions(), def, min, max));
         }
 
         std::vector<void *> vg = ObjectInstanceRegistry::instances_in_range(

--- a/src/Param.cpp
+++ b/src/Param.cpp
@@ -119,7 +119,7 @@ Internal::Parameter OutputImageParam::parameter() const {
 }
 
 OutputImageParam::operator Argument() const {
-    return Argument(name(), true, type());
+    return Argument(name(), Argument::Buffer, type(), dimensions());
 }
 
 OutputImageParam::operator ExternFuncArgument() const {

--- a/src/Param.h
+++ b/src/Param.h
@@ -144,11 +144,11 @@ public:
         param.set_max_value(max);
     }
 
-    Expr get_min_value() {
+    Expr get_min_value() const {
         return param.get_min_value();
     }
 
-    Expr get_max_value() {
+    Expr get_max_value() const {
         return param.get_max_value();
     }
     // @}
@@ -169,7 +169,8 @@ public:
      * for the purpose of generating the right type signature when
      * statically compiling halide pipelines. */
     operator Argument() const {
-        return Argument(name(), false, type());
+        return Argument(name(), Argument::Scalar, type(), 0,
+            param.get_scalar_expr(), param.get_min_value(), param.get_max_value());
     }
 };
 

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -129,6 +129,42 @@ bool Parameter::is_buffer() const {
     return contents.ptr->is_buffer;
 }
 
+Expr Parameter::get_scalar_expr() const {
+    check_is_scalar();
+    const Type t = type();
+    if (t.is_bool()) {
+      return Expr(get_scalar<bool>());
+    } else if (t.is_float()) {
+      switch (t.bits) {
+        case 32: return Expr(get_scalar<float>());
+        // Note that we lose precision here, since Expr can only
+        // represent 32-bit ints or floats.
+        case 64: return Expr((float) get_scalar<double>());
+      }
+    } else if (t.is_int()) {
+      switch (t.bits) {
+        case 8: return Expr(get_scalar<int8_t>());
+        case 16: return Expr(get_scalar<int16_t>());
+        case 32: return Expr(get_scalar<int32_t>());
+        // Note that we lose precision here, since Expr can only
+        // represent 32-bit ints or floats.
+        case 64: return Expr((float) get_scalar<int64_t>());
+      }
+    } else if (t.is_uint()) {
+      switch (t.bits) {
+        case 8: return Expr(get_scalar<uint8_t>());
+        case 16: return Expr(get_scalar<uint16_t>());
+        // Fudge this a little bit: Expr handles 32-bit signed ints;
+        // cast uint32 to int32 with the assumption the destination
+        // will do the right thing.
+        case 32: return Expr((int32_t) get_scalar<uint32_t>());
+        // Note that we lose precision here, since Expr can only
+        // represent 32-bit ints or floats.
+        case 64: return Expr((float) get_scalar<uint64_t>());
+      }
+    }
+    return Expr();
+}
 
 Buffer Parameter::get_buffer() const {
     check_is_buffer();

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -2,6 +2,7 @@
 #include "IROperator.h"
 #include "ObjectInstanceRegistry.h"
 #include "Parameter.h"
+#include "Simplify.h"
 
 namespace Halide {
 namespace Internal {
@@ -153,7 +154,7 @@ Expr Parameter::get_scalar_expr() const {
             int64_t i = get_scalar<int64_t>();
             Expr lo = Expr((int32_t) i);
             Expr hi = Expr((int32_t) (i >> 32));
-            return (Cast::make(Int(64), hi) << Expr(32)) | Cast::make(Int(64), lo);
+            return simplify((Cast::make(Int(64), hi) << Expr(32)) | Cast::make(Int(64), lo));
         }
       }
     } else if (t.is_uint()) {
@@ -167,7 +168,7 @@ Expr Parameter::get_scalar_expr() const {
             uint64_t i = get_scalar<uint64_t>();
             Expr lo = Expr((int32_t) i);
             Expr hi = Expr((int32_t) (i >> 32));
-            return (Cast::make(UInt(64), hi) << Expr(32)) | Cast::make(UInt(64), lo);
+            return simplify((Cast::make(UInt(64), hi) << Expr(32)) | Cast::make(UInt(64), lo));
         }
       }
     }

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -77,6 +77,10 @@ public:
         return *((const T *)(get_scalar_address()));
     }
 
+    /** This returns the current value of get_scalar<type()>()
+     * as an Expr. */
+    EXPORT Expr get_scalar_expr() const;
+
     /** If the parameter is a scalar parameter, set its current
      * value. Only relevant when jitting */
     template<typename T>

--- a/test/correctness/infer_arguments.cpp
+++ b/test/correctness/infer_arguments.cpp
@@ -4,7 +4,7 @@
 using namespace Halide;
 
 template<typename T>
-bool ConstantExprEquals(Expr expr, T value) {
+bool constant_expr_equals(Expr expr, T value) {
     using Halide::Internal::Cast;
     using Halide::Internal::FloatImm;
     using Halide::Internal::IntImm;
@@ -19,7 +19,7 @@ bool ConstantExprEquals(Expr expr, T value) {
         return f->value == value;
     }
     if (const Cast* c = expr.as<Cast>()) {
-        return ConstantExprEquals(c->value, value);
+        return constant_expr_equals(c->value, value);
     }
     return false;
 }
@@ -69,32 +69,32 @@ int main(int argc, char **argv) {
         EXPECT(false, args[0].def.defined());
         EXPECT(false, args[1].def.defined());
         EXPECT(true, args[2].def.defined());
-        EXPECT(true, ConstantExprEquals<float>(args[2].def, 22.5f));
+        EXPECT(true, constant_expr_equals<float>(args[2].def, 22.5f));
         EXPECT(true, args[3].def.defined());
         EXPECT(true, args[4].def.defined());
         EXPECT(true, args[5].def.defined());
         EXPECT(true, args[6].def.defined());
-        EXPECT(true, ConstantExprEquals<uint32_t>(args[6].def, 0xdeadbeef));
+        EXPECT(true, constant_expr_equals<uint32_t>(args[6].def, 0xdeadbeef));
 
         EXPECT(false, args[0].min.defined());
         EXPECT(false, args[1].min.defined());
         EXPECT(true, args[2].min.defined());
-        EXPECT(true, ConstantExprEquals<float>(args[2].min, 11.25f));
+        EXPECT(true, constant_expr_equals<float>(args[2].min, 11.25f));
         EXPECT(false, args[3].min.defined());
         EXPECT(false, args[4].min.defined());
         EXPECT(false, args[5].min.defined());
         EXPECT(true, args[6].min.defined());
-        EXPECT(true, ConstantExprEquals<uint32_t>(args[6].min, 0x1));
+        EXPECT(true, constant_expr_equals<uint32_t>(args[6].min, 0x1));
 
         EXPECT(false, args[0].max.defined());
         EXPECT(false, args[1].max.defined());
         EXPECT(true, args[2].max.defined());
-        EXPECT(true, ConstantExprEquals<float>(args[2].max, 1e30f));
+        EXPECT(true, constant_expr_equals<float>(args[2].max, 1e30f));
         EXPECT(false, args[3].max.defined());
         EXPECT(false, args[4].max.defined());
         EXPECT(false, args[5].max.defined());
         EXPECT(true, args[6].max.defined());
-        EXPECT(true, ConstantExprEquals<uint32_t>(args[6].max, 0xfffffeed));
+        EXPECT(true, constant_expr_equals<uint32_t>(args[6].max, 0xfffffeed));
 
         EXPECT(3, args[0].dimensions);
         EXPECT(2, args[1].dimensions);

--- a/test/correctness/infer_arguments.cpp
+++ b/test/correctness/infer_arguments.cpp
@@ -3,10 +3,31 @@
 
 using namespace Halide;
 
+template<typename T>
+bool ConstantExprEquals(Expr expr, T value) {
+    using Halide::Internal::Cast;
+    using Halide::Internal::FloatImm;
+    using Halide::Internal::IntImm;
+
+    if (!expr.defined() || !expr.type().is_scalar()) {
+        return false;
+    }
+    if (const IntImm* i = expr.as<IntImm>()) {
+        return i->value == value;
+    }
+    if (const FloatImm* f = expr.as<FloatImm>()) {
+        return f->value == value;
+    }
+    if (const Cast* c = expr.as<Cast>()) {
+        return ConstantExprEquals(c->value, value);
+    }
+    return false;
+}
+
 int main(int argc, char **argv) {
 
 #define EXPECT(expect, actual) \
-    if (expect != actual) { printf("Failure, expected %s\n", #expect); return -1; }
+    if (expect != actual) { printf("Failure, expected %s for %s\n", #expect, #actual); return -1; }
 
     {
         ImageParam input1(UInt(8), 3, "input1");
@@ -14,15 +35,15 @@ int main(int argc, char **argv) {
         Param<int32_t> height("height");
         Param<int32_t> width("width");
         Param<uint8_t> thresh("thresh");
-        Param<float> frac("frac");
+        Param<float> frac("frac", 22.5f, 11.25f, 1e30f);
         // Named so that it will come last.
-        Param<float> z_ignored("z_ignored");
+        Param<uint32_t> z_unsigned("z_unsigned", 0xdeadbeef, 0x01, (int) 0xfffffeed);
 
         Var x("x"), y("y"), c("c");
 
         Func f("f");
         f(x, y, c) = frac * (input1(clamp(x, 0, height), clamp(y, 0, width), c) +
-                        min(thresh, input2(x, y))) + (0 * z_ignored);
+                        min(thresh, input2(x, y))) + (0 * z_unsigned);
 
         std::vector<Argument> args = f.infer_arguments();
         EXPECT(7, args.size());
@@ -33,21 +54,61 @@ int main(int argc, char **argv) {
         EXPECT("height", args[3].name);
         EXPECT("thresh", args[4].name);
         EXPECT("width", args[5].name);
-        EXPECT("z_ignored", args[6].name);
+        EXPECT("z_unsigned", args[6].name);
 
-        EXPECT(true, args[0].is_buffer);
-        EXPECT(true, args[1].is_buffer);
-        EXPECT(false, args[2].is_buffer);
-        EXPECT(false, args[3].is_buffer);
-        EXPECT(false, args[4].is_buffer);
-        EXPECT(false, args[5].is_buffer);
-        EXPECT(false, args[6].is_buffer);
+        EXPECT(true, args[0].is_buffer());
+        EXPECT(true, args[1].is_buffer());
+        EXPECT(false, args[2].is_buffer());
+        EXPECT(false, args[3].is_buffer());
+        EXPECT(false, args[4].is_buffer());
+        EXPECT(false, args[5].is_buffer());
+        EXPECT(false, args[6].is_buffer());
+
+        // All Scalar Arguments have a defined default when coming from
+        // infer_arguments.
+        EXPECT(false, args[0].def.defined());
+        EXPECT(false, args[1].def.defined());
+        EXPECT(true, args[2].def.defined());
+        EXPECT(true, ConstantExprEquals<float>(args[2].def, 22.5f));
+        EXPECT(true, args[3].def.defined());
+        EXPECT(true, args[4].def.defined());
+        EXPECT(true, args[5].def.defined());
+        EXPECT(true, args[6].def.defined());
+        EXPECT(true, ConstantExprEquals<uint32_t>(args[6].def, 0xdeadbeef));
+
+        EXPECT(false, args[0].min.defined());
+        EXPECT(false, args[1].min.defined());
+        EXPECT(true, args[2].min.defined());
+        EXPECT(true, ConstantExprEquals<float>(args[2].min, 11.25f));
+        EXPECT(false, args[3].min.defined());
+        EXPECT(false, args[4].min.defined());
+        EXPECT(false, args[5].min.defined());
+        EXPECT(true, args[6].min.defined());
+        EXPECT(true, ConstantExprEquals<uint32_t>(args[6].min, 0x1));
+
+        EXPECT(false, args[0].max.defined());
+        EXPECT(false, args[1].max.defined());
+        EXPECT(true, args[2].max.defined());
+        EXPECT(true, ConstantExprEquals<float>(args[2].max, 1e30f));
+        EXPECT(false, args[3].max.defined());
+        EXPECT(false, args[4].max.defined());
+        EXPECT(false, args[5].max.defined());
+        EXPECT(true, args[6].max.defined());
+        EXPECT(true, ConstantExprEquals<uint32_t>(args[6].max, 0xfffffeed));
+
+        EXPECT(3, args[0].dimensions);
+        EXPECT(2, args[1].dimensions);
+        EXPECT(0, args[2].dimensions);
+        EXPECT(0, args[3].dimensions);
+        EXPECT(0, args[4].dimensions);
+        EXPECT(0, args[5].dimensions);
+        EXPECT(0, args[6].dimensions);
 
         EXPECT(Type::Float, args[2].type.code);
         EXPECT(Type::Int, args[3].type.code);
         EXPECT(Type::UInt, args[4].type.code);
         EXPECT(Type::Int, args[5].type.code);
-        EXPECT(Type::Float, args[6].type.code);
+        EXPECT(Type::UInt, args[6].type.code);
 
         EXPECT(32, args[2].type.bits);
         EXPECT(32, args[3].type.bits);
@@ -68,9 +129,13 @@ int main(int argc, char **argv) {
         EXPECT("frac", args[1].name);
         EXPECT("thresh", args[2].name);
 
-        EXPECT(true, args[0].is_buffer);
-        EXPECT(false, args[1].is_buffer);
-        EXPECT(false, args[2].is_buffer);
+        EXPECT(true, args[0].is_buffer());
+        EXPECT(false, args[1].is_buffer());
+        EXPECT(false, args[2].is_buffer());
+
+        EXPECT(3, args[0].dimensions);
+        EXPECT(0, args[1].dimensions);
+        EXPECT(0, args[2].dimensions);
 
         EXPECT(Type::Float, args[1].type.code);
         EXPECT(Type::UInt, args[2].type.code);

--- a/test/correctness/infer_arguments.cpp
+++ b/test/correctness/infer_arguments.cpp
@@ -4,7 +4,57 @@
 using namespace Halide;
 
 template<typename T>
-bool constant_expr_equals(Expr expr, T value) {
+T extract_int(int32_t i32) {
+    return static_cast<T>(i32);
+}
+
+template<>
+uint64_t extract_int(int32_t i32) {
+    // for int32->uint64, assume we want the 32 bits as-is
+    // with no sign extension.
+    return static_cast<uint64_t>(i32) & 0xffffffff;
+}
+
+template<typename T>
+T bitwise_or(T lhs, T rhs) {
+    return lhs | rhs;
+}
+
+template<>
+float bitwise_or(float lhs, float rhs) {
+    assert(false);
+    return 0.0f;
+}
+
+template<>
+double bitwise_or(double lhs, double rhs) {
+    assert(false);
+    return 0.0;
+}
+
+template<typename T>
+T shift_left(T lhs, T rhs) {
+    return lhs << rhs;
+}
+
+template<>
+float shift_left(float lhs, float rhs) {
+    assert(false);
+    return 0.0f;
+}
+
+template<>
+double shift_left(double lhs, double rhs) {
+    assert(false);
+    return 0.0;
+}
+
+// Despite the name, this is NOT a generic eval-expr function (ha)...
+// It has just barely enough logic to decode the Expr forms that
+// we are likely to see from infer_arguments() and friends.
+template<typename T>
+bool eval_expr(Expr expr, T* value) {
+    using Halide::Internal::Call;
     using Halide::Internal::Cast;
     using Halide::Internal::FloatImm;
     using Halide::Internal::IntImm;
@@ -13,15 +63,51 @@ bool constant_expr_equals(Expr expr, T value) {
         return false;
     }
     if (const IntImm* i = expr.as<IntImm>()) {
-        return i->value == value;
+        *value = extract_int<T>(i->value);
+        return true;
     }
     if (const FloatImm* f = expr.as<FloatImm>()) {
-        return f->value == value;
+        *value = static_cast<T>(f->value);
+        return true;
     }
     if (const Cast* c = expr.as<Cast>()) {
-        return constant_expr_equals(c->value, value);
+        return eval_expr(c->value, value);
+    }
+    if (const Call* call = expr.as<Call>()) {
+        if (call->name == Call::bitwise_or) {
+            T lhs, rhs;
+            if (!eval_expr(call->args[0], &lhs) || !eval_expr(call->args[1], &rhs)) {
+                return false;
+            }
+            *value = bitwise_or<T>(lhs, rhs);
+            return true;
+        }
+        if (call->name == Call::shift_left) {
+            T lhs, rhs;
+            if (!eval_expr(call->args[0], &lhs) || !eval_expr(call->args[1], &rhs)) {
+                return false;
+            }
+            *value = shift_left<T>(lhs, rhs);
+            return true;
+        }
     }
     return false;
+}
+
+template<typename T>
+bool constant_expr_equals(Expr expr, T expected) {
+    T actual;
+    if (eval_expr(expr, &actual)) {
+        return expected == actual;
+    }
+    return false;
+}
+
+Expr uint64_expr(uint64_t u) {
+    using Halide::Internal::Cast;
+    Expr lo = Expr((int32_t) u);
+    Expr hi = Expr((int32_t) (u >> 32));
+    return (Cast::make(UInt(64), hi) << Expr(32)) | Cast::make(UInt(64), lo);
 }
 
 int main(int argc, char **argv) {
@@ -37,7 +123,7 @@ int main(int argc, char **argv) {
         Param<uint8_t> thresh("thresh");
         Param<float> frac("frac", 22.5f, 11.25f, 1e30f);
         // Named so that it will come last.
-        Param<uint32_t> z_unsigned("z_unsigned", 0xdeadbeef, 0x01, (int) 0xfffffeed);
+        Param<uint64_t> z_unsigned("z_unsigned", 0xdeadbeef, 0x01, uint64_expr(0xf00dcafedeadbeef));
 
         Var x("x"), y("y"), c("c");
 
@@ -74,7 +160,7 @@ int main(int argc, char **argv) {
         EXPECT(true, args[4].def.defined());
         EXPECT(true, args[5].def.defined());
         EXPECT(true, args[6].def.defined());
-        EXPECT(true, constant_expr_equals<uint32_t>(args[6].def, 0xdeadbeef));
+        EXPECT(true, constant_expr_equals<uint64_t>(args[6].def, 0xdeadbeef));
 
         EXPECT(false, args[0].min.defined());
         EXPECT(false, args[1].min.defined());
@@ -84,7 +170,7 @@ int main(int argc, char **argv) {
         EXPECT(false, args[4].min.defined());
         EXPECT(false, args[5].min.defined());
         EXPECT(true, args[6].min.defined());
-        EXPECT(true, constant_expr_equals<uint32_t>(args[6].min, 0x1));
+        EXPECT(true, constant_expr_equals<uint64_t>(args[6].min, 0x1));
 
         EXPECT(false, args[0].max.defined());
         EXPECT(false, args[1].max.defined());
@@ -94,7 +180,7 @@ int main(int argc, char **argv) {
         EXPECT(false, args[4].max.defined());
         EXPECT(false, args[5].max.defined());
         EXPECT(true, args[6].max.defined());
-        EXPECT(true, constant_expr_equals<uint32_t>(args[6].max, 0xfffffeed));
+        EXPECT(true, constant_expr_equals<uint64_t>(args[6].max, 0xf00dcafedeadbeef));
 
         EXPECT(3, args[0].dimensions);
         EXPECT(2, args[1].dimensions);
@@ -114,7 +200,7 @@ int main(int argc, char **argv) {
         EXPECT(32, args[3].type.bits);
         EXPECT(8, args[4].type.bits);
         EXPECT(32, args[5].type.bits);
-        EXPECT(32, args[6].type.bits);
+        EXPECT(64, args[6].type.bits);
 
         Func f_a("f_a"), f_b("f_b");
         f_a(x, y, c) = input1(x, y, c) * frac;

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -43,27 +43,16 @@ void check(const char *op, int vector_width, Expr e) {
     f.vectorize(x, vector_width);
 
     vector<Argument> arg_types;
-    Argument arg("", true, Int(1));
-    arg.name = "in_f32";
-    arg_types.push_back(arg);
-    arg.name = "in_f64";
-    arg_types.push_back(arg);
-    arg.name = "in_i8";
-    arg_types.push_back(arg);
-    arg.name = "in_u8";
-    arg_types.push_back(arg);
-    arg.name = "in_i16";
-    arg_types.push_back(arg);
-    arg.name = "in_u16";
-    arg_types.push_back(arg);
-    arg.name = "in_i32";
-    arg_types.push_back(arg);
-    arg.name = "in_u32";
-    arg_types.push_back(arg);
-    arg.name = "in_i64";
-    arg_types.push_back(arg);
-    arg.name = "in_u64";
-    arg_types.push_back(arg);
+    arg_types.push_back(Argument("in_f32", Argument::Buffer, Int(1), 1));
+    arg_types.push_back(Argument("in_f64", Argument::Buffer, Int(1), 1));
+    arg_types.push_back(Argument("in_i8", Argument::Buffer, Int(1), 1));
+    arg_types.push_back(Argument("in_u8", Argument::Buffer, Int(1), 1));
+    arg_types.push_back(Argument("in_i16", Argument::Buffer, Int(1), 1));
+    arg_types.push_back(Argument("in_u16", Argument::Buffer, Int(1), 1));
+    arg_types.push_back(Argument("in_i32", Argument::Buffer, Int(1), 1));
+    arg_types.push_back(Argument("in_u32", Argument::Buffer, Int(1), 1));
+    arg_types.push_back(Argument("in_i64", Argument::Buffer, Int(1), 1));
+    arg_types.push_back(Argument("in_u64", Argument::Buffer, Int(1), 1));
 
     char *module = new char[1024];
     snprintf(module, 1024, "test_%s_%s", op, f.name().c_str());

--- a/test/generator/paramtest_generator.cpp
+++ b/test/generator/paramtest_generator.cpp
@@ -11,7 +11,7 @@ public:
     GeneratorParam<Type> output_type{ "output_type", Float(32) };
 
     ImageParam input{ UInt(8), 3, "input" };
-    Param<float> float_arg{ "float_arg", 1.0 };
+    Param<float> float_arg{ "float_arg", 1.0f, 0.0f, 100.0f };
     Param<int32_t> int_arg{ "int_arg", 1 };
 
     Func build() override {

--- a/test/generator/paramtest_jittest.cpp
+++ b/test/generator/paramtest_jittest.cpp
@@ -43,7 +43,7 @@ void verify(const Image<InputType> &input, float float_arg, int int_arg, const I
 }
 
 template<typename T>
-bool ConstantExprEquals(Expr expr, T value) {
+bool constant_expr_equals(Expr expr, T value) {
     using Halide::Internal::Cast;
     using Halide::Internal::FloatImm;
     using Halide::Internal::IntImm;
@@ -58,7 +58,7 @@ bool ConstantExprEquals(Expr expr, T value) {
         return f->value == value;
     }
     if (const Cast* c = expr.as<Cast>()) {
-        return ConstantExprEquals(c->value, value);
+        return constant_expr_equals(c->value, value);
     }
     return false;
 }
@@ -126,13 +126,13 @@ int main(int argc, char **argv) {
             fprintf(stderr, "get_filter_arguments is incorrect\n");
             exit(-1);
         }
-        if (!ConstantExprEquals<float>(args[1].def, 1.f) ||
-            !ConstantExprEquals<float>(args[1].min, 0.f) ||
-            !ConstantExprEquals<float>(args[1].max, 100.f)) {
+        if (!constant_expr_equals<float>(args[1].def, 1.f) ||
+            !constant_expr_equals<float>(args[1].min, 0.f) ||
+            !constant_expr_equals<float>(args[1].max, 100.f)) {
             fprintf(stderr, "constraints for float_arg are incorrect\n");
             exit(-1);
         }
-        if (!ConstantExprEquals<int32_t>(args[2].def, 1) ||
+        if (!constant_expr_equals<int32_t>(args[2].def, 1) ||
             args[2].min.defined() ||
             args[2].max.defined()) {
             fprintf(stderr, "constraints for int_arg are incorrect\n");


### PR DESCRIPTION
Adding metadata (Issue #664) requires augmenting Argument to contain
some information previously contained only in Internal::Parameter. This
also includes some drive-by cleanup to the Argument API to make it a
bit more readable at the point of call (via use of enums rather than a
bool).