### PR TITLE
Fix build on OS X with clang

### DIFF
--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -511,7 +511,7 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
 
         CodeGen_GPU_Dev *gpu_codegen = cgdev[loop->device_api];
         user_assert(gpu_codegen != NULL)
-            << "Loop is scheduled on device " << loop->device_api
+            << "Loop is scheduled on device " << (int)loop->device_api
             << " which does not appear in target " << target.to_string() << "\n";
         gpu_codegen->add_kernel(loop, kernel_name, closure_args);
 


### PR DESCRIPTION
I'm getting error during a build (with clang on OS X):

```
src/Error.h:122:16: error: call to function 'operator<<' that is neither visible in the template definition nor found by argument-dependent lookup
        (*msg) << x;
               ^
src/CodeGen_GPU_Host.cpp:514:47: note: in instantiation of function template specialization 'Halide::Internal::ErrorReport::operator<<<Halide::DeviceAPI>' requested here
            << "Loop is scheduled on device " << loop->device_api
                                              ^
src/IRPrinter.h:42:15: note: 'operator<<' should be declared prior to the call site or in namespace 'Halide'
std::ostream &operator<<(std::ostream &stream, const DeviceAPI &);
              ^
1 error generated.
```

I am not absolutely sure, but it seems that the problem is that strongly typed enums are not converted to int implicitly.