### PR TITLE
Fix apps/HelloAndroid sample

### DIFF
--- a/apps/HelloAndroid/jni/native.cpp
+++ b/apps/HelloAndroid/jni/native.cpp
@@ -31,7 +31,7 @@ JNIEXPORT void JNICALL Java_com_example_hellohalide_CameraPreview_processFrame(
 
     const int w = j_w, h = j_h;
 
-    halide_start_clock();
+    halide_start_clock(NULL);
     halide_set_error_handler(handler);
 
     unsigned char *src = (unsigned char *)env->GetByteArrayElements(jSrc, NULL);
@@ -65,7 +65,9 @@ JNIEXPORT void JNICALL Java_com_example_hellohalide_CameraPreview_processFrame(
     uint8_t *dst = (uint8_t *)buf.bits;
 
     // If we're using opencl, use the gpu backend for it.
+#if COMPILING_FOR_OPENCL
     halide_opencl_set_device_type("gpu");
+#endif
 
     // Make these static so that we can reuse device allocations across frames.
     static buffer_t srcBuf = {0};


### PR DESCRIPTION
HelloAndroid sample is broken - see below. This should fix it, hope it makes sense too.

```
  Error Code:
  	2
  Output:
  	/Users/aam/Documents/halide-llvm_trunk_cmake/Halide/apps/HelloAndroid/jni/native.cpp: In function 'void Java_com_example_hellohalide_CameraPreview_processFrame(JNIEnv*, jobject, jbyteArray, jint, jint, jobject)':
  	/Users/aam/Documents/halide-llvm_trunk_cmake/Halide/apps/HelloAndroid/jni/native.cpp:34:24: error: too few arguments to function 'int halide_start_clock(void*)'
  	     halide_start_clock();
  	                        ^
  	/Users/aam/Documents/halide-llvm_trunk_cmake/Halide/apps/HelloAndroid/jni/native.cpp:20:16: note: declared here
  	 extern "C" int halide_start_clock(void *user_context);
  	                ^
  	make: *** [/Users/aam/Documents/halide-llvm_trunk_cmake/Halide/apps/HelloAndroid/build/intermediates/ndk/debug/obj/local/armeabi/objs/native/native.o] Error 1
```

```
  Output:
  	/Users/aam/Documents/halide-llvm_trunk_cmake/Halide/apps/HelloAndroid/jni/native.cpp:68: error: undefined reference to 'halide_opencl_set_device_type'
  	collect2: error: ld returned 1 exit status
  	make: *** [/Users/aam/Documents/halide-llvm_trunk_cmake/Halide/apps/HelloAndroid/build/intermediates/ndk/debug/obj/local/armeabi/libnative.so] Error 1
```