### PR TITLE
Change CodeGen::compile() arguments

### DIFF
--- a/src/Argument.h
+++ b/src/Argument.h
@@ -2,6 +2,8 @@
 #define HALIDE_ARGUMENT_H
 
 #include <string>
+#include <vector>
+
 #include "Error.h"
 #include "Expr.h"
 #include "Type.h"
@@ -73,6 +75,28 @@ struct Argument {
 
     bool is_buffer() const { return kind == Buffer; }
 };
+
+namespace Internal {
+
+/** struct to pass information about Arguments around internally. */
+struct ArgInfo {
+    /** The Arguments to a halide statement; these must
+     * always be the input Arguments (if any) followed by the
+     * output Arguments (>= 1) */
+    std::vector<Argument> args;
+
+    /** It is expected that the final "num_outputs"
+     * entries in args are outputs (should be 1 unless the statement
+     * returns a Tuple) */
+    int num_outputs;
+
+    // Note that since all valid pipelines have at least one output,
+    // initializing to zero makes for a known invalid value
+    ArgInfo() : num_outputs(0) {}
+};
+
+
+}  // namespace Internal
 
 }
 

--- a/src/CodeGen.h
+++ b/src/CodeGen.h
@@ -57,9 +57,9 @@ public:
 
     /** Take a halide statement and compiles it to an llvm module held
      * internally. Call this before calling compile_to_bitcode or
-     * compile_to_native. */
+     * compile_to_native. . */
     virtual void compile(Stmt stmt, std::string name,
-                         const std::vector<Argument> &args,
+                         const ArgInfo &arg_info,
                          const std::vector<Buffer> &images_to_embed);
 
     /** Emit a compiled halide statement as llvm bitcode. Call this

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -426,7 +426,7 @@ llvm::Triple CodeGen_ARM::get_target_triple() const {
 }
 
 void CodeGen_ARM::compile(Stmt stmt, string name,
-                          const vector<Argument> &args,
+                          const ArgInfo &arg_info,
                           const vector<Buffer> &images_to_embed) {
 
     init_module();
@@ -448,7 +448,7 @@ void CodeGen_ARM::compile(Stmt stmt, string name,
     debug(1) << "Target triple of initial module: " << module->getTargetTriple() << "\n";
 
     // Pass to the generic codegen
-    CodeGen_Posix::compile(stmt, name, args, images_to_embed);
+    CodeGen_Posix::compile(stmt, name, arg_info, images_to_embed);
 
     // Optimize
     CodeGen_Posix::optimize_module();

--- a/src/CodeGen_ARM.h
+++ b/src/CodeGen_ARM.h
@@ -24,7 +24,7 @@ public:
      * CodeGen::compile_to_function_pointer to get at the ARM machine
      * code. */
     void compile(Stmt stmt, std::string name,
-                 const std::vector<Argument> &args,
+                 const ArgInfo &arg_info,
                  const std::vector<Buffer> &images_to_embed);
 
     llvm::Triple get_target_triple() const;

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -34,12 +34,12 @@ public:
     /** Emit source code equivalent to the given statement, wrapped in
      * a function with the given type signature */
     void compile(Stmt stmt, std::string name,
-                 const std::vector<Argument> &args,
+                 const ArgInfo &arg_info,
                  const std::vector<Buffer> &images_to_embed);
 
     /** Emit a header file defining a halide pipeline with the given
      * type signature */
-    void compile_header(const std::string &name, const std::vector<Argument> &args);
+    void compile_header(const std::string &name, const ArgInfo &arg_info);
 
     static void test();
 

--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -258,7 +258,7 @@ CodeGen_GPU_Host<CodeGen_CPU>::~CodeGen_GPU_Host() {
 
 template<typename CodeGen_CPU>
 void CodeGen_GPU_Host<CodeGen_CPU>::compile(Stmt stmt, string name,
-                                            const vector<Argument> &args,
+                                            const ArgInfo &arg_info,
                                             const vector<Buffer> &images_to_embed) {
 
     init_module();
@@ -288,7 +288,7 @@ void CodeGen_GPU_Host<CodeGen_CPU>::compile(Stmt stmt, string name,
     debug(1) << "Target triple of initial module: " << module->getTargetTriple() << "\n";
 
     // Pass to the generic codegen
-    CodeGen::compile(stmt, name, args, images_to_embed);
+    CodeGen::compile(stmt, name, arg_info, images_to_embed);
 
     // Unset constant flag for embedded image global variables
     for (size_t i = 0; i < images_to_embed.size(); i++) {

--- a/src/CodeGen_GPU_Host.h
+++ b/src/CodeGen_GPU_Host.h
@@ -18,6 +18,7 @@ namespace Internal {
 
 struct CodeGen_GPU_Dev;
 struct GPU_Argument;
+struct GPU_ArgInfo;
 
 /** A code generator that emits GPU code from a given Halide stmt. */
 template<typename CodeGen_CPU>
@@ -38,7 +39,7 @@ public:
      * CodeGen::compile_to_function_pointer to get at the generated machine
      * code. */
     void compile(Stmt stmt, std::string name,
-                 const std::vector<Argument> &args,
+                 const ArgInfo &arg_info,
                  const std::vector<Buffer> &images_to_embed);
 
 protected:

--- a/src/CodeGen_MIPS.cpp
+++ b/src/CodeGen_MIPS.cpp
@@ -39,7 +39,7 @@ llvm::Triple CodeGen_MIPS::get_target_triple() const {
 }
 
 void CodeGen_MIPS::compile(Stmt stmt, string name,
-                          const vector<Argument> &args,
+                          const ArgInfo &arg_info,
                           const vector<Buffer> &images_to_embed) {
     init_module();
 
@@ -60,7 +60,7 @@ void CodeGen_MIPS::compile(Stmt stmt, string name,
     debug(1) << "Target triple of initial module: " << module->getTargetTriple() << "\n";
 
     // Pass to the generic codegen
-    CodeGen::compile(stmt, name, args, images_to_embed);
+    CodeGen::compile(stmt, name, arg_info, images_to_embed);
 
     // Optimize
     CodeGen::optimize_module();

--- a/src/CodeGen_MIPS.h
+++ b/src/CodeGen_MIPS.h
@@ -25,7 +25,7 @@ public:
      * CodeGen::compile_to_function_pointer to get at the mips machine
      * code. */
     void compile(Stmt stmt, std::string name,
-                 const std::vector<Argument> &args,
+                 const ArgInfo &arg_info,
                  const std::vector<Buffer> &images_to_embed);
 
     static void test();

--- a/src/CodeGen_PNaCl.cpp
+++ b/src/CodeGen_PNaCl.cpp
@@ -31,7 +31,7 @@ llvm::Triple CodeGen_PNaCl::get_target_triple() const {
 }
 
 void CodeGen_PNaCl::compile(Stmt stmt, string name,
-                          const vector<Argument> &args,
+                          const ArgInfo &arg_info,
                           const vector<Buffer> &images_to_embed) {
     #if (WITH_NATIVE_CLIENT)
 
@@ -51,7 +51,7 @@ void CodeGen_PNaCl::compile(Stmt stmt, string name,
     module->setDataLayout("e-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-p:32:32:32-v128:32:32");
 
     // Pass to the generic codegen
-    CodeGen::compile(stmt, name, args, images_to_embed);
+    CodeGen::compile(stmt, name, arg_info, images_to_embed);
 
     // Optimize
     CodeGen::optimize_module();

--- a/src/CodeGen_PNaCl.h
+++ b/src/CodeGen_PNaCl.h
@@ -24,7 +24,7 @@ public:
      * CodeGen::compile_to_file or CodeGen::compile_to_bitcode to get
      * at the pnacl bitcode. */
     void compile(Stmt stmt, std::string name,
-                 const std::vector<Argument> &args,
+                 const ArgInfo &arg_info,
                  const std::vector<Buffer> &images_to_embed);
 
     /** The PNaCl backend overrides compile_to_native to

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -90,7 +90,7 @@ llvm::Triple CodeGen_X86::get_target_triple() const {
 }
 
 void CodeGen_X86::compile(Stmt stmt, string name,
-                          const vector<Argument> &args,
+                          const ArgInfo &arg_info,
                           const vector<Buffer> &images_to_embed) {
 
     init_module();
@@ -110,7 +110,7 @@ void CodeGen_X86::compile(Stmt stmt, string name,
     debug(1) << "Target triple of initial module: " << module->getTargetTriple() << "\n";
 
     // Pass to the generic codegen
-    CodeGen::compile(stmt, name, args, images_to_embed);
+    CodeGen::compile(stmt, name, arg_info, images_to_embed);
 
     // Optimize
     CodeGen::optimize_module();

--- a/src/CodeGen_X86.h
+++ b/src/CodeGen_X86.h
@@ -29,7 +29,7 @@ public:
      * CodeGen::compile_to_function_pointer to get at the x86 machine
      * code. */
     void compile(Stmt stmt, std::string name,
-                 const std::vector<Argument> &args,
+                 const ArgInfo &arg_info,
                  const std::vector<Buffer> &images_to_embed);
 
     void jit_init(llvm::ExecutionEngine *, llvm::Module *);

--- a/src/StmtCompiler.cpp
+++ b/src/StmtCompiler.cpp
@@ -57,9 +57,9 @@ StmtCompiler::StmtCompiler(Target target) {
 }
 
 void StmtCompiler::compile(Stmt stmt, string name,
-                           const vector<Argument> &args,
+                           const ArgInfo &arg_info,
                            const vector<Buffer> &images_to_embed) {
-    contents.ptr->compile(stmt, name, args, images_to_embed);
+    contents.ptr->compile(stmt, name, arg_info, images_to_embed);
 }
 
 void StmtCompiler::compile_to_bitcode(const string &filename) {

--- a/src/StmtCompiler.h
+++ b/src/StmtCompiler.h
@@ -5,6 +5,7 @@
  * Defines a compiler that produces native code from halide statements
  */
 
+#include "CodeGen.h"
 #include "IR.h"
 #include "JITModule.h"
 #include "Target.h"
@@ -20,7 +21,6 @@ namespace Internal {
 /** A handle to a generic statement compiler. Can take Halide
  * statements and turn them into assembly, bitcode, machine code, or a
  * jit-compiled module. */
-class CodeGen;
 class StmtCompiler {
     IntrusivePtr<CodeGen> contents;
 public:
@@ -33,7 +33,7 @@ public:
      * inside it. The module is stored internally until one of the
      * later functions is called: */
     void compile(Stmt stmt, std::string name,
-                 const std::vector<Argument> &args,
+                 const ArgInfo &arg_info,
                  const std::vector<Buffer> &images_to_embed);
 
     /** Write the module to an llvm bitcode file */


### PR DESCRIPTION
Change the vector<Argument> into a struct that also contains
information about which entries are inputs vs. outputs. (Current code
paths don’t need this information, but future paths that generate
Metadata will require it.) (Issue #664)