### PR TITLE
Decouple GPU_Argument from Argument

### DIFF
--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -180,7 +180,7 @@ vector<GPU_Argument> GPU_Host_Closure::arguments() {
     vector<GPU_Argument> res;
     for (map<string, Type>::const_iterator iter = vars.begin(); iter != vars.end(); ++iter) {
         debug(2) << "var: " << iter->first << "\n";
-        res.push_back(GPU_Argument(iter->first, Argument::Scalar, iter->second, 0));
+        res.push_back(GPU_Argument(iter->first, false, iter->second, 0));
     }
     for (map<string, BufferRef>::const_iterator iter = buffers.begin(); iter != buffers.end(); ++iter) {
         debug(2) << "buffer: " << iter->first << " " << iter->second.size;
@@ -188,7 +188,7 @@ vector<GPU_Argument> GPU_Host_Closure::arguments() {
         if (iter->second.write) debug(2) << " (write)";
         debug(2) << "\n";
 
-        GPU_Argument arg(iter->first, Argument::Buffer, iter->second.type, iter->second.dimensions, iter->second.size);
+        GPU_Argument arg(iter->first, true, iter->second.type, iter->second.dimensions, iter->second.size);
         arg.read = iter->second.read;
         arg.write = iter->second.write;
         res.push_back(arg);
@@ -492,7 +492,7 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
 
             // Pack scalar parameters into vec4
             for (size_t i = 0; i < closure_args.size(); i++) {
-                if (closure_args[i].is_buffer()) {
+                if (closure_args[i].is_buffer) {
                     continue;
                 } else if (ends_with(closure_args[i].name, ".varying")) {
                     closure_args[i].packed_index = num_varying_floats++;
@@ -505,7 +505,7 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
         }
 
         for (size_t i = 0; i < closure_args.size(); i++) {
-            if (closure_args[i].is_buffer() && allocations.contains(closure_args[i].name)) {
+            if (closure_args[i].is_buffer && allocations.contains(closure_args[i].name)) {
                 closure_args[i].size = allocations.get(closure_args[i].name).constant_bytes;
             }
         }
@@ -549,7 +549,7 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
             string name = closure_args[i].name;
             Value *val;
 
-            if (closure_args[i].is_buffer()) {
+            if (closure_args[i].is_buffer) {
                 // If it's a buffer, dereference the dev handle
                 val = buffer_dev(sym_get(name + ".buffer"));
             } else if (ends_with(name, ".varying")) {
@@ -576,11 +576,11 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
                                  builder->CreateConstGEP2_32(gpu_args_arr, 0, i));
 
             // store the size of the argument
-            int size_bits = (closure_args[i].is_buffer()) ? target.bits : closure_args[i].type.bits;
+            int size_bits = (closure_args[i].is_buffer) ? target.bits : closure_args[i].type.bits;
             builder->CreateStore(ConstantInt::get(target_size_t_type, size_bits/8),
                                  builder->CreateConstGEP2_32(gpu_arg_sizes_arr, 0, i));
 
-            builder->CreateStore(ConstantInt::get(i8, closure_args[i].is_buffer()),
+            builder->CreateStore(ConstantInt::get(i8, closure_args[i].is_buffer),
                                  builder->CreateConstGEP2_32(gpu_arg_is_buffer_arr, 0, i));
         }
         // NULL-terminate the lists

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -406,7 +406,7 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
     // declaration.
     vector<BufferSize> constants;
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer() &&
+        if (args[i].is_buffer &&
             CodeGen_GPU_Dev::is_buffer_constant(s, args[i].name) &&
             args[i].size > 0) {
             constants.push_back(BufferSize(args[i].name, args[i].size));
@@ -427,7 +427,7 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
     // Create preprocessor replacements for the address spaces of all our buffers.
     stream << "// Address spaces for " << name << "\n";
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer()) {
+        if (args[i].is_buffer) {
             vector<BufferSize>::iterator constant = constants.begin();
             while (constant != constants.end() &&
                    constant->name != args[i].name) {
@@ -450,7 +450,7 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
     // Emit the function prototype
     stream << "__kernel void " << name << "(\n";
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer()) {
+        if (args[i].is_buffer) {
             stream << " " << get_memory_space(args[i].name) << " ";
             if (!args[i].write) stream << "const ";
             stream << print_type(args[i].type) << " *"
@@ -475,14 +475,14 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
 
     for (size_t i = 0; i < args.size(); i++) {
         // Remove buffer arguments from allocation scope
-        if (args[i].is_buffer()) {
+        if (args[i].is_buffer) {
             allocations.pop(args[i].name);
         }
     }
 
     // Undef all the buffer address spaces, in case they're different in another kernel.
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer()) {
+        if (args[i].is_buffer) {
             stream << "#undef " << get_memory_space(args[i].name) << "\n";
         }
     }

--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -594,7 +594,7 @@ void CodeGen_GLSL::compile(Stmt stmt, string name,
     ostringstream header;
     header << "/// KERNEL " << name << "\n";
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer()) {
+        if (args[i].is_buffer) {
             Type t = args[i].type.element_of();
 
             user_assert(args[i].read != args[i].write) <<
@@ -654,7 +654,7 @@ void CodeGen_GLSL::compile(Stmt stmt, string name,
 
     // Declare input textures and variables
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer() && args[i].read) {
+        if (args[i].is_buffer && args[i].read) {
             stream << "uniform sampler2D " << print_name(args[i].name) << ";\n";
         }
     }
@@ -676,7 +676,7 @@ void CodeGen_GLSL::compile(Stmt stmt, string name,
 
     // Unpack the uniform and varying parameters
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer()) {
+        if (args[i].is_buffer) {
             continue;
         } else if (ends_with(args[i].name, ".varying")) {
             do_indent();

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -36,7 +36,7 @@ void CodeGen_PTX_Dev::add_kernel(Stmt stmt,
     // Now deduce the types of the arguments to our function
     vector<llvm::Type *> arg_types(args.size());
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer()) {
+        if (args[i].is_buffer) {
             arg_types[i] = llvm_type_of(UInt(8))->getPointerTo();
         } else {
             arg_types[i] = llvm_type_of(args[i].type);
@@ -50,7 +50,7 @@ void CodeGen_PTX_Dev::add_kernel(Stmt stmt,
 
     // Mark the buffer args as no alias
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer()) {
+        if (args[i].is_buffer) {
             function->setDoesNotAlias(i+1);
         }
     }
@@ -69,7 +69,7 @@ void CodeGen_PTX_Dev::add_kernel(Stmt stmt,
              iter++) {
 
             string arg_sym_name = args[i].name;
-            if (args[i].is_buffer()) {
+            if (args[i].is_buffer) {
                 // HACK: codegen expects a load from foo to use base
                 // address 'foo.host', so we store the device pointer
                 // as foo.host in this scope.


### PR DESCRIPTION
GPU_Argument should neither is-a nor has-a Halide::Argument: they are
never actually used interchangeably, and GPU_Argument requires
read+write buffer semantics for some GPU backends (which
Halide::Argument does not allow for at present).