### PR TITLE
Deprecate 'ptx' flag, use 'cuda' instead

### DIFF
--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -269,7 +269,7 @@ bool Target::merge_string(const std::string &target) {
         } else if (tok == "cuda") {
             set_feature(Target::CUDA);
         } else if (tok == "ptx") {
-            internal_error << "The ptx target feature flag is deprecated, use 'cuda' instead\n";
+            internal_error << "The 'ptx' target feature flag is deprecated, use 'cuda' instead\n";
         } else if (tok == "cuda_capability_30") {
             set_features(vec(Target::CUDA, Target::CUDACapability30));
         } else if (tok == "cuda_capability_32") {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -266,8 +266,10 @@ bool Target::merge_string(const std::string &target) {
             set_feature(Target::ARMv7s);
         } else if (tok == "no_neon") {
             set_feature(Target::NoNEON);
-        } else if (tok == "cuda" || tok == "ptx") {
+        } else if (tok == "cuda") {
             set_feature(Target::CUDA);
+        } else if (tok == "ptx") {
+            internal_error << "The ptx target feature flag is deprecated, use 'cuda' instead\n";
         } else if (tok == "cuda_capability_30") {
             set_features(vec(Target::CUDA, Target::CUDACapability30));
         } else if (tok == "cuda_capability_32") {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -269,7 +269,7 @@ bool Target::merge_string(const std::string &target) {
         } else if (tok == "cuda") {
             set_feature(Target::CUDA);
         } else if (tok == "ptx") {
-            internal_error << "The 'ptx' target feature flag is deprecated, use 'cuda' instead\n";
+            user_error << "The 'ptx' target feature flag is deprecated, use 'cuda' instead\n";
         } else if (tok == "cuda_capability_30") {
             set_features(vec(Target::CUDA, Target::CUDACapability30));
         } else if (tok == "cuda_capability_32") {

--- a/test/scripts/test_all_targets.sh
+++ b/test/scripts/test_all_targets.sh
@@ -176,7 +176,7 @@ for LLVM in ${LLVMS}; do
     if [[ "$LLVM" == pnacl ]]; then
         TARGETS="x86-32-nacl x86-32-sse41-nacl x86-64-nacl x86-64-sse41-nacl"
     elif [[ "$LLVM" == trunk ]]; then
-        TARGETS="x86-32 x86-32-sse41 x86-64 x86-64-sse41 x86-64-avx ptx opencl"
+        TARGETS="x86-32 x86-32-sse41 x86-64 x86-64-sse41 x86-64-avx cuda opencl"
     else
         TARGETS="x86-32 x86-32-sse41 x86-64 x86-64-sse41 x86-64-avx"
     fi

--- a/test/scripts/test_target.sh
+++ b/test/scripts/test_target.sh
@@ -22,7 +22,7 @@ if [[ "$HL_TARGET" == x86-3* ]]; then
     export LIBPNG_CXX_FLAGS="-Itesting/deps -I../../testing/deps"
 else
     BITS=64
-    # ptx and opencl fall into this category
+    # cuda (ptx) and opencl fall into this category
     export LD="ld"
     export CC="${CC} -m64"
     export CXX="${CXX} -m64"
@@ -48,7 +48,7 @@ COMMIT=`git rev-parse HEAD`
 mv distrib/halide.tgz distrib/halide_${HOST}_${BITS}_${LLVM}_${COMMIT}_${DATE}.tgz
 chmod a+r distrib/*
 
-if [ "$HL_TARGET" == ptx -a "$HOST" == Darwin ]; then
+if [ "$HL_TARGET" == cuda -a "$HOST" == Darwin ]; then
     echo "Halide builds but tests not run"
 elif [ "$HL_TARGET" == opencl -a "$HOST" == Darwin ]; then
     echo "Halide builds but tests not run"


### PR DESCRIPTION
I'd like to eventually add 'ptx' as a target arch, rather than use it as a (redundant) flag for the CUDA runtime. This would let us get rid of the special case for PTX device initial modules (get_initial_module_for_ptx_device).