### PR TITLE
Split long Make/CMake lists into multiple lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,8 +409,58 @@ HEADER_FILES = \
 OBJECTS = $(SOURCE_FILES:%.cpp=$(BUILD_DIR)/%.o)
 HEADERS = $(HEADER_FILES:%.h=src/%.h)
 
-RUNTIME_CPP_COMPONENTS = android_io cuda fake_thread_pool gcd_thread_pool ios_io android_clock linux_clock opencl posix_allocator posix_clock osx_clock windows_clock posix_error_handler posix_io posix_math posix_thread_pool android_host_cpu_count linux_host_cpu_count osx_host_cpu_count tracing write_debug_image windows_cuda windows_opencl windows_io windows_thread_pool ssp opengl linux_opengl_context osx_opengl_context android_opengl_context posix_print gpu_device_selection cache nacl_host_cpu_count to_string module_jit_ref_count module_aot_ref_count device_interface
-RUNTIME_LL_COMPONENTS = arm posix_math ptx_dev x86_avx x86 x86_sse41 pnacl_math win32_math aarch64 mips arm_no_neon
+RUNTIME_CPP_COMPONENTS = \
+  android_clock \
+  android_host_cpu_count \
+  android_io \
+  android_opengl_context \
+  cache \
+  cuda \
+  device_interface \
+  fake_thread_pool \
+  gcd_thread_pool \
+  gpu_device_selection \
+  ios_io \
+  linux_clock \
+  linux_host_cpu_count \
+  linux_opengl_context \
+  module_aot_ref_count \
+  module_jit_ref_count \
+  nacl_host_cpu_count \
+  opencl \
+  opengl \
+  osx_clock \
+  osx_host_cpu_count \
+  osx_opengl_context \
+  posix_allocator \
+  posix_clock \
+  posix_error_handler \
+  posix_io \
+  posix_math \
+  posix_print \
+  posix_thread_pool \
+  to_string \
+  ssp \
+  tracing \
+  windows_clock \
+  windows_cuda \
+  windows_opencl \
+  windows_io \
+  windows_thread_pool \
+  write_debug_image
+
+RUNTIME_LL_COMPONENTS = \
+  aarch64 \
+  arm \
+  arm_no_neon \
+  mips \
+  pnacl_math \
+  posix_math \
+  ptx_dev \
+  win32_math \
+  x86 \
+  x86_avx \
+  x86_sse41
 
 RUNTIME_EXPORTED_INCLUDES = include/HalideRuntime.h include/HalideRuntimeCuda.h include/HalideRuntimeOpenCL.h include/HalideRuntimeOpenGL.h
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -236,103 +236,103 @@ add_dependencies(InitialModules
   bitcode2cpp)
 
 set(HEADER_FILES
-  Util.h
-  Type.h
+  AllocationBoundsInference.h
   Argument.h
+  BlockFlattening.h
+  BoundaryConditions.h
   Bounds.h
   BoundsInference.h
   Buffer.h
+  CSE.h
+  CodeGen_ARM.h
   CodeGen_C.h
-  CodeGen_LLVM.h
-  CodeGen_X86.h
+  CodeGen_GPU_Dev.h
   CodeGen_GPU_Host.h
-  CodeGen_PTX_Dev.h
+  CodeGen_LLVM.h
+  CodeGen_MIPS.h
   CodeGen_OpenCL_Dev.h
   CodeGen_OpenGL_Dev.h
-  CodeGen_GPU_Dev.h
   CodeGen_PNaCl.h
+  CodeGen_PTX_Dev.h
+  CodeGen_Posix.h
+  CodeGen_X86.h
+  Debug.h
+  DebugToFile.h
   Deinterleave.h
   Derivative.h
-  OneToOne.h
-  Extern.h
+  DeviceInterface.h
+  EarlyFree.h
+  Error.h
   Expr.h
+  ExprUsesVar.h
+  Extern.h
+  FastIntegerDivide.h
   FindCalls.h
   Func.h
   Function.h
-  Image.h
-  InlineReductions.h
-  IntegerDivisionTable.h
-  Introspection.h
-  IntrusivePtr.h
-  IREquality.h
+  Generator.h
+  HumanReadableStmt.h
   IR.h
+  IREquality.h
   IRMatch.h
   IRMutator.h
   IROperator.h
   IRPrinter.h
   IRVisitor.h
-  InjectOpenGLIntrinsics.h
+  Image.h
   InjectHostDevBufferCopies.h
+  InjectOpenGLIntrinsics.h
+  Inline.h
+  InlineReductions.h
+  IntegerDivisionTable.h
+  Introspection.h
+  IntrusivePtr.h
   JITModule.h
+  LLVM_Output.h
+  LLVM_Runtime_Linker.h
   Lambda.h
-  Debug.h
+  Lerp.h
   Lower.h
   MainPage.h
+  Memoization.h
+  Module.h
   ModulusRemainder.h
-  Parameter.h
+  ObjectInstanceRegistry.h
+  OneToOne.h
+  Output.h
+  ParallelRVar.h
   Param.h
+  Parameter.h
   PartitionLoops.h
+  Profiling.h
+  Qualify.h
   RDom.h
+  Random.h
   Reduction.h
+  RemoveDeadAllocations.h
   RemoveTrivialForLoops.h
+  RemoveUndef.h
   Schedule.h
   Scope.h
   Simplify.h
+  SkipStages.h
   SlidingWindow.h
   Solve.h
+  StmtToHtml.h
   StorageFlattening.h
   StorageFolding.h
   Substitute.h
-  Profiling.h
+  Target.h
   Tracing.h
+  Tuple.h
+  Type.h
+  UnifyDuplicateLets.h
+  UniquifyVariableNames.h
   UnrollLoops.h
+  Util.h
   Var.h
   VaryingAttributes.h
   VectorizeLoops.h
-  CodeGen_Posix.h
-  CodeGen_ARM.h
-  DebugToFile.h
-  EarlyFree.h
-  UniquifyVariableNames.h
-  CSE.h
-  Tuple.h
-  Lerp.h
-  Target.h
-  SkipStages.h
-  RemoveUndef.h
-  FastIntegerDivide.h
-  AllocationBoundsInference.h
-  Error.h
-  Inline.h
-  Qualify.h
-  ExprUsesVar.h
-  Random.h
-  ParallelRVar.h
-  BoundaryConditions.h
-  UnifyDuplicateLets.h
-  HumanReadableStmt.h
-  StmtToHtml.h
-  Memoization.h
-  CodeGen_MIPS.h
-  Generator.h
-  ObjectInstanceRegistry.h
-  BlockFlattening.h
-  RemoveDeadAllocations.h
-  LLVM_Runtime_Linker.h
-  Output.h
-  LLVM_Output.h
-  Module.h
-  DeviceInterface.h
   runtime/HalideRuntime.h
 )
 
@@ -351,98 +351,99 @@ file(COPY runtime/HalideRuntimeOpenGL.h DESTINATION "${CMAKE_BINARY_DIR}/include
 add_definitions("-DCOMPILING_HALIDE")
 
 add_library(Halide ${HALIDE_LIBRARY_TYPE}
-  CodeGen_LLVM.cpp
-  CodeGen_Internal.cpp
-  CodeGen_X86.cpp
+
+  AllocationBoundsInference.cpp
+  BlockFlattening.cpp
+  BoundaryConditions.cpp
+  Bounds.cpp
+  BoundsInference.cpp
+  Buffer.cpp
+  CSE.cpp
+  CodeGen_ARM.cpp
+  CodeGen_C.cpp
+  CodeGen_GPU_Dev.cpp
   CodeGen_GPU_Host.cpp
-  CodeGen_PTX_Dev.cpp
+  CodeGen_Internal.cpp
+  CodeGen_LLVM.cpp
+  CodeGen_MIPS.cpp
   CodeGen_OpenCL_Dev.cpp
   CodeGen_OpenGL_Dev.cpp
-  CodeGen_GPU_Dev.cpp
-  CodeGen_Posix.cpp
   CodeGen_PNaCl.cpp
-  CodeGen_ARM.cpp
-  IR.cpp
-  IRMutator.cpp
-  IRPrinter.cpp
-  IRVisitor.cpp
-  CodeGen_C.cpp
-  Substitute.cpp
-  ModulusRemainder.cpp
-  Bounds.cpp
+  CodeGen_PTX_Dev.cpp
+  CodeGen_Posix.cpp
+  CodeGen_X86.cpp
+  Debug.cpp
+  Debug.cpp
+  DebugToFile.cpp
+  Deinterleave.cpp
   Derivative.cpp
-  OneToOne.cpp
+  DeviceInterface.cpp
+  EarlyFree.cpp
+  Error.cpp
+  ExprUsesVar.cpp
+  FastIntegerDivide.cpp
   FindCalls.cpp
   Func.cpp
-  Simplify.cpp
-  IREquality.cpp
-  Util.cpp
   Function.cpp
+  FuseGPUThreadLoops.cpp
+  Generator.cpp
+  HumanReadableStmt.cpp
+  IR.cpp
+  IREquality.cpp
+  IRMatch.cpp
+  IRMutator.cpp
   IROperator.cpp
+  IRPrinter.cpp
+  IRVisitor.cpp
+  Image.cpp
+  InjectHostDevBufferCopies.cpp
+  InjectOpenGLIntrinsics.cpp
+  Inline.cpp
+  InlineReductions.cpp
+  IntegerDivisionTable.cpp
+  Introspection.cpp
+  JITModule.cpp
+  LLVM_Output.cpp
+  LLVM_Runtime_Linker.cpp
+  Lerp.cpp
   Lower.cpp
-  Debug.cpp
+  Memoization.cpp
+  Module.cpp
+  ModulusRemainder.cpp
+  ObjectInstanceRegistry.cpp
+  OneToOne.cpp
+  Output.cpp
+  ParallelRVar.cpp
+  Param.cpp
   Parameter.cpp
   PartitionLoops.cpp
-  Reduction.cpp
-  Random.cpp
-  RDom.cpp
-  Solve.cpp
   Profiling.cpp
-  Tracing.cpp
-  StorageFlattening.cpp
-  VectorizeLoops.cpp
-  UnrollLoops.cpp
-  BoundsInference.cpp
-  IRMatch.cpp
-  IntegerDivisionTable.cpp
-  SlidingWindow.cpp
-  StorageFolding.cpp
-  InlineReductions.cpp
-  RemoveTrivialForLoops.cpp
-  Deinterleave.cpp
-  DebugToFile.cpp
-  Type.cpp
-  JITModule.cpp
-  EarlyFree.cpp
-  UniquifyVariableNames.cpp
-  CSE.cpp
-  Tuple.cpp
-  Lerp.cpp
-  Target.cpp
-  SkipStages.cpp
-  RemoveUndef.cpp
-  FastIntegerDivide.cpp
-  AllocationBoundsInference.cpp
-  Inline.cpp
   Qualify.cpp
-  UnifyDuplicateLets.cpp
-  VaryingAttributes.cpp
-  ExprUsesVar.cpp
-  Introspection.cpp
-  Buffer.cpp
-  Param.cpp
-  Error.cpp
-  Image.cpp
-  Debug.cpp
-  InjectOpenGLIntrinsics.cpp
-  InjectHostDevBufferCopies.cpp
-  Schedule.cpp
-  FuseGPUThreadLoops.cpp
-  ParallelRVar.cpp
-  BoundaryConditions.cpp
-  HumanReadableStmt.cpp
-  StmtToHtml.cpp
-  Memoization.cpp
-  CodeGen_MIPS.cpp
-  Generator.cpp
-  ObjectInstanceRegistry.cpp
-  BlockFlattening.cpp
+  RDom.cpp
+  Random.cpp
+  Reduction.cpp
   RemoveDeadAllocations.cpp
-  LLVM_Runtime_Linker.cpp
-  Output.cpp
-  LLVM_Output.cpp
-  Module.cpp
-  DeviceInterface.cpp
+  RemoveTrivialForLoops.cpp
+  RemoveUndef.cpp
+  Schedule.cpp
+  Simplify.cpp
+  SkipStages.cpp
+  SlidingWindow.cpp
+  Solve.cpp
+  StmtToHtml.cpp
+  StorageFlattening.cpp
+  StorageFolding.cpp
+  Substitute.cpp
+  Target.cpp
+  Tracing.cpp
+  Tuple.cpp
+  Type.cpp
+  UnifyDuplicateLets.cpp
+  UniquifyVariableNames.cpp
+  UnrollLoops.cpp
+  Util.cpp
+  VaryingAttributes.cpp
+  VectorizeLoops.cpp
   "${CMAKE_BINARY_DIR}/include/Halide.h"
   ${HEADER_FILES}
 )


### PR DESCRIPTION
As silly as it might seem, this really does help with merging. I ran into this often over the last few months while we've had large outstanding PRs, but I wanted to wait until they got merged to make this change.