### PR TITLE
Device free on assertion failure

### DIFF
--- a/src/CodeGen_Posix.h
+++ b/src/CodeGen_Posix.h
@@ -83,8 +83,12 @@ private:
     /** Free the memory backing an allocation and pop it from the
      * symbol table and the allocations map. For heap allocations it
      * calls halide_free in the runtime, for stack allocations it
-     * marks the block as free so it can be reused. */
-    void free_allocation(const std::string &name);
+     * marks the block as free so it can be reused. Also frees any
+     * device-side allocations by calling halide_device_free. If
+     * in_error_handler is false, it additionally asserts that
+     * halide_device_free returned zero. */
+    void free_allocation(const std::string &name,
+                         bool in_error_handler = false);
 };
 
 }}

--- a/src/InjectHostDevBufferCopies.h
+++ b/src/InjectHostDevBufferCopies.h
@@ -15,9 +15,6 @@ namespace Internal {
  * halide_copy_to_host as needed. */
 Stmt inject_host_dev_buffer_copies(Stmt s, const Target &t);
 
-/** Inject calls to halide_dev_free as needed. */
-Stmt inject_dev_frees(Stmt s);
-
 }
 }
 

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -1909,12 +1909,6 @@ Stmt lower(Function f, const Target &t, const vector<IRMutator *> &custom_passes
     s = inject_early_frees(s);
     debug(2) << "Lowering after injecting early frees:\n" << s << "\n\n";
 
-    if (t.has_gpu_feature()) {
-        debug(1) << "Injecting device frees...\n";
-        s = inject_dev_frees(s);
-        debug(2) << "Lowering after injecting device frees:\n" << s << "\n\n";
-    }
-
     debug(1) << "Simplifying...\n";
     s = common_subexpression_elimination(s);
 

--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -105,8 +105,6 @@ WEAK void halide_device_release(void *user_context, const halide_device_interfac
 WEAK int halide_copy_to_host(void *user_context, struct buffer_t *buf) {
     ScopedMutexLock lock(&device_copy_mutex);
 
-    debug(NULL) << "halide_copy_to_host " << buf << "\n";
-
     return copy_to_host_already_locked(user_context, buf);
 }
 

--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -105,6 +105,8 @@ WEAK void halide_device_release(void *user_context, const halide_device_interfac
 WEAK int halide_copy_to_host(void *user_context, struct buffer_t *buf) {
     ScopedMutexLock lock(&device_copy_mutex);
 
+    debug(NULL) << "halide_copy_to_host " << buf << "\n";
+
     return copy_to_host_already_locked(user_context, buf);
 }
 


### PR DESCRIPTION
Device frees were injected in a separate pass, but this meant they weren't also freed on assertion failure. The call was being injected alongside the host free node, so I just moved the call into the host free codegen handler (which is also called on assertion failure).

Verified this is now doing the right thing by compiling local laplacian to assembly and inspecting the assertion failure handlers, and by injecting synthetic failures in device_free.
