### PR TITLE
Explicitly specify the memory layout of structs in the runtime

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -25,6 +25,7 @@ const string buffer_t_definition =
     "#ifndef BUFFER_T_DEFINED\n"
     "#define BUFFER_T_DEFINED\n"
     "#include <stdint.h>\n"
+    "#pragma pack(push, 1)\n"
     "typedef struct buffer_t {\n"
     "    uint64_t dev;\n"
     "    uint8_t* host;\n"
@@ -34,7 +35,9 @@ const string buffer_t_definition =
     "    int32_t elem_size;\n"
     "    bool host_dirty;\n"
     "    bool dev_dirty;\n"
+    "    uint8_t padding[2];\n"
     "} buffer_t;\n"
+    "#pragma pack(pop)\n"
     "#endif\n";
 
 const string headers =

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -135,6 +135,7 @@ enum halide_trace_event_code {halide_trace_load = 0,
                               halide_trace_consume = 6,
                               halide_trace_end_consume = 7};
 
+#pragma pack(push, 1)
 struct halide_trace_event {
     const char *func;
     halide_trace_event_code event;
@@ -147,6 +148,7 @@ struct halide_trace_event {
     int32_t dimensions;
     int32_t *coordinates;
 };
+#pragma pack(pop)
 
 /** Called when Funcs are marked as trace_load, trace_store, or
  * trace_realization. See Func::set_custom_trace. The default
@@ -307,6 +309,7 @@ typedef enum halide_type_code_t {
  * Halide code. It includes some stuff to track whether the image is
  * not actually in main memory, but instead on a device (like a
  * GPU). */
+#pragma pack(push, 1)
 typedef struct buffer_t {
   /** A device-handle for e.g. GPU memory used to back this buffer. */
   uint64_t dev;
@@ -344,7 +347,10 @@ typedef struct buffer_t {
    mirroring this buffer, and the data has been modified on the
    device side. */
   bool dev_dirty;
+
+  uint8_t _padding[2];
 } buffer_t;
+#pragma pack(pop)
 
 #endif
 

--- a/src/runtime/cache.cpp
+++ b/src/runtime/cache.cpp
@@ -412,16 +412,7 @@ WEAK void halide_memoization_cache_store(void *user_context, const uint8_t *cach
     current_cache_size += added_size;
     prune_cache();
 
-    // The size of buffer_t for pointer math is apparently slightly
-    // larger than sizeof(buffer_t) on 32-bit windows. There's some
-    // padding between elements when they're in an array that isn't
-    // captured by sizeof. This is presumably because clang evaluates
-    // sizeof at initial module construction, and the math below turns
-    // into a getelementptr llvm instruction. There must be a mismatch
-    // in struct padding settings between the two.
-    size_t extra_buffer_t_size = (size_t)(((buffer_t *)0) + 1);
-
-    void *entry_storage = halide_malloc(NULL, sizeof(CacheEntry) + extra_buffer_t_size * (tuple_count - 1));
+    void *entry_storage = halide_malloc(NULL, sizeof(CacheEntry) + sizeof(buffer_t) * (tuple_count - 1));
 
     CacheEntry *new_entry = (CacheEntry *)entry_storage;
     new_entry->init(cache_key, size, h, *computed_bounds, tuple_count, tuple_buffers);


### PR DESCRIPTION
Fixes a bug where the le32-unknown-nacl target triple we now use pads
bools out to 32-bits.

Also removes a nasty wart from the cache runtime module.

Seems to work with clang and g++. Should work with msvc too.

Even though it's a bugfix, submitted as a PR because it touches the definition of buffer_t.