### PR TITLE
This fixes 'mac' build

### DIFF
--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1477,43 +1477,6 @@ bool extract_immediate(Expr e, T *value) {
     return false;
 }
 
-template<>
-bool extract_immediate(Expr e, float *value) {
-    if (const FloatImm* f = e.as<FloatImm>()) {
-        *value = static_cast<float>(f->value);
-        return true;
-    }
-    return false;
-}
-
-// We expect a float64-immediate to be either a call to make_float64()
-// (with two IntImm), or a single FloatImm (if the value fits into a float32)
-template<>
-bool extract_immediate(Expr e, double *value) {
-    union {
-        int32_t as_int32[2];
-        double as_double;
-    } u;
-    if (const Call* call = e.as<Call>()) {
-        if (call->name == Call::make_float64) {
-            if (!extract_immediate(call->args[0], &u.as_int32[0]) ||
-                !extract_immediate(call->args[1], &u.as_int32[1])) {
-                return false;
-            }
-            *value = u.as_double;
-            return true;
-        }
-        return false;
-    }
-    float f0;
-    if (extract_immediate(e, &f0)) {
-        *value = static_cast<double>(f0);
-        return true;
-    }
-    return false;
-}
-
-
 // We expect an int64-immediate to be either a call to make_int64()
 // (with two IntImm), or a single IntImm (if the value fits into an int32)
 template<>

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1477,6 +1477,49 @@ bool extract_immediate(Expr e, T *value) {
     return false;
 }
 
+template<>
+bool extract_immediate(Expr e, float *value) {
+    if (const FloatImm* f = e.as<FloatImm>()) {
+        *value = static_cast<float>(f->value);
+        return true;
+    }
+    return false;
+}
+
+// We expect a float64-immediate to be either a call to make_float64()
+// (with two IntImm), or a single FloatImm (if the value fits into a float32)
+template<>
+bool extract_immediate(Expr e, double *value) {
+    union {
+        int32_t as_int32[2];
+        double as_double;
+    } u;
+    if (const Call* call = e.as<Call>()) {
+        if (call->name == Call::make_float64) {
+            if (!extract_immediate(call->args[0], &u.as_int32[0]) ||
+                !extract_immediate(call->args[1], &u.as_int32[1])) {
+                return false;
+            }
+            *value = u.as_double;
+            return true;
+        }
+        return false;
+    }
+    float f0;
+    if (extract_immediate(e, &f0)) {
+        *value = static_cast<double>(f0);
+        return true;
+    }
+    return false;
+}
+
+// Force use of the templated functions.
+inline bool _extract_immediate(Expr e, double *value) {
+    return extract_immediate(e, reinterpret_cast<double*>(value));
+}
+
+
+
 // We expect an int64-immediate to be either a call to make_int64()
 // (with two IntImm), or a single IntImm (if the value fits into an int32)
 template<>


### PR DESCRIPTION
On mac(llvm/clang) I'm getting following compilation errors:
```
c++ -Wall -Werror -Wno-unused-function -Wcast-qual -fno-rtti -Woverloaded-virtual -fPIC -O3 -fno-omit-frame-pointer -DCOMPILING_HALIDE  -I/Users/aam/Documents/halide/buildbot/mac-builder/mac-correctness-halide-llvm360-builder/llvm/include -I/Users/aam/Documents/halide/buildbot/mac-builder/mac-correctness-halide-llvm360-builder/llvm-build/include -fPIC -fvisibility-inlines-hidden -Wall -W -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -std=c++11 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DLLVM_VERSION=36 -std=c++11    -DWITH_PTX=1  -DWITH_ARM=1  -DWITH_AARCH64=1  -DWITH_X86=1  -DWITH_OPENCL=1  -DWITH_OPENGL=1  -DWITH_MIPS=1  -DWITH_INTROSPECTION   -c src/CodeGen_C.cpp -o build/CodeGen_C.o -MMD -MP -MF build/CodeGen_C.d -MT build/CodeGen_C.o
In file included from src/AllocationBoundsInference.cpp:1:
In file included from src/AllocationBoundsInference.h:12:
In file included from src/Bounds.h:5:
src/IROperator.h:1492:6: error: unused function 'extract_immediate' [-Werror,-Wunused-function]
bool extract_immediate(Expr e, double *value) {
     ^
1 error generated.
```

This PR fixes the problem by removing unused template functions.