### PR TITLE
fix 'using std' usage

### DIFF
--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -13,14 +13,14 @@
 #include "Simplify.h"
 #include "VaryingAttributes.h"
 
+namespace Halide {
+namespace Internal {
+
 using std::vector;
 using std::string;
 using std::map;
 
 using namespace llvm;
-
-namespace Halide {
-namespace Internal {
 
 // Sniff the contents of a kernel to extracts the bounds of all the
 // thread indices (so we know how many threads to launch), and the

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -25,10 +25,10 @@ static bool have_symbol(const char *s) {
 }
 #endif
 
-using std::string;
-
 namespace Halide {
 namespace Internal {
+
+using std::string;
 
 namespace {
 
@@ -232,8 +232,6 @@ void load_opengl() {
 }
 
 }
-
-using std::string;
 
 using namespace llvm;
 

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -6,8 +6,6 @@
 #include <iostream>
 #include <fstream>
 
-using namespace std;
-
 namespace Halide {
 
 llvm::raw_fd_ostream *new_raw_fd_ostream(const std::string &filename) {
@@ -128,11 +126,11 @@ void clone_target_options(const llvm::Module *from, llvm::Module *to) {
 
 
 llvm::TargetMachine *get_target_machine(const llvm::Module *module) {
-    string error_string;
+    std::string error_string;
 
     const llvm::Target *target = llvm::TargetRegistry::lookupTarget(module->getTargetTriple(), error_string);
     if (!target) {
-        cout << error_string << endl;
+        std::cout << error_string << std::endl;
         llvm::TargetRegistry::printRegisteredTargetsForVersion();
     }
     internal_assert(target) << "Could not create target\n";


### PR DESCRIPTION
— ‘using std::string’ (etc) must be inside the Halide namespace
— ‘using namespace std’ is forbidden anywhere.