### PR TITLE
compile_to_lowered_stmt() should take explicit args

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2148,8 +2148,8 @@ void Func::compile_to_c(const string &filename, const vector<Argument> &args,
     compile_module_to_c_source(compile_to_module(args, fn_name, target), filename);
 }
 
-void Func::compile_to_lowered_stmt(const string &filename, StmtOutputFormat fmt, const Target &target) {
-    Module m = compile_to_module(infer_arguments(), "", target);
+void Func::compile_to_lowered_stmt(const string &filename, const vector<Argument> &args, StmtOutputFormat fmt, const Target &target) {
+    Module m = compile_to_module(args, "", target);
     if (fmt == HTML) {
         compile_module_to_html(m, filename);
     } else {

--- a/src/Func.h
+++ b/src/Func.h
@@ -594,6 +594,7 @@ public:
      * for analyzing and debugging scheduling. Can emit html or plain
      * text. */
     EXPORT void compile_to_lowered_stmt(const std::string &filename,
+                                        const std::vector<Argument> &args,
                                         StmtOutputFormat fmt = Text,
                                         const Target &target = get_target_from_environment());
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -302,10 +302,10 @@ void GeneratorBase::emit_filter(const std::string &output_dir,
         func.compile_to_c(base_path + ".cpp", inputs, function_name, target);
     }
     if (options.emit_stmt) {
-        func.compile_to_lowered_stmt(base_path + ".stmt", Halide::Text, target);
+        func.compile_to_lowered_stmt(base_path + ".stmt", inputs, Halide::Text, target);
     }
     if (options.emit_stmt_html) {
-        func.compile_to_lowered_stmt(base_path + ".html", Halide::HTML, target);
+        func.compile_to_lowered_stmt(base_path + ".html", inputs, Halide::HTML, target);
     }
 }
 

--- a/test/correctness/compile_to_lowered_stmt.cpp
+++ b/test/correctness/compile_to_lowered_stmt.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
 
     {
         const char *result_file = "compile_to_lowered_stmt.stmt";
-        j.compile_to_lowered_stmt(result_file);
+        j.compile_to_lowered_stmt(result_file, j.infer_arguments());
 
         #ifndef _MSC_VER
         assert(access(result_file, F_OK) == 0 && "Output file not created.");


### PR DESCRIPTION
When called from Generator, it’s essential that the inputs match those
explicitly listed (which may differ from those inferred since some can
be unused).