### PR TITLE
Halide master

### DIFF
--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -401,9 +401,7 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
         llvm::Type *gpu_args_arr_type = ArrayType::get(arg_t, num_args+1);
         Value *gpu_args_arr =
             create_alloca_at_entry(
-#if LLVM_VERSION >= 37
                 gpu_args_arr_type,
-#endif
                 num_args+1,
                 kernel_name + "_args");
 
@@ -412,18 +410,14 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
                                                             num_args+1);
         Value *gpu_arg_sizes_arr =
             create_alloca_at_entry(
-#if LLVM_VERSION >= 37
                 gpu_arg_sizes_arr_type,
-#endif
                 num_args+1,
                 kernel_name + "_arg_sizes");
 
         llvm::Type *gpu_arg_is_buffer_arr_type = ArrayType::get(i8, num_args+1);
         Value *gpu_arg_is_buffer_arr =
             create_alloca_at_entry(
-#if LLVM_VERSION >= 37
                 gpu_arg_is_buffer_arr_type,
-#endif
                 num_args+1,
                 kernel_name + "_arg_is_buffer");
 

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -123,7 +123,14 @@ StructType *Closure::build_type(LLVMContext *context) {
     return struct_t;
 }
 
-void Closure::pack_struct(llvm::Type *type, Value *dst, const Scope<Value *> &src, IRBuilder<> *builder) {
+void Closure::pack_struct(llvm::Type *
+#if LLVM_VERSION >= 37
+                          type
+#endif
+                          ,
+                          Value *dst,
+                          const Scope<Value *> &src,
+                          IRBuilder<> *builder) {
     // type, type of dst should be a pointer to a struct of the type returned by build_type
     int idx = 0;
     LLVMContext &context = builder->getContext();
@@ -151,7 +158,11 @@ void Closure::pack_struct(llvm::Type *type, Value *dst, const Scope<Value *> &sr
 }
 
 void Closure::unpack_struct(Scope<Value *> &dst,
-                            llvm::Type *type,
+                            llvm::Type *
+#if LLVM_VERSION >= 37
+                            type
+#endif
+                            ,
                             Value *src,
                             IRBuilder<> *builder) {
     // type, type of src should be a pointer to a struct of the type returned by build_type

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -123,14 +123,18 @@ StructType *Closure::build_type(LLVMContext *context) {
     return struct_t;
 }
 
-void Closure::pack_struct(Value *dst, const Scope<Value *> &src, IRBuilder<> *builder) {
-    // dst should be a pointer to a struct of the type returned by build_type
+void Closure::pack_struct(llvm::Type *type, Value *dst, const Scope<Value *> &src, IRBuilder<> *builder) {
+    // type, type of dst should be a pointer to a struct of the type returned by build_type
     int idx = 0;
     LLVMContext &context = builder->getContext();
     vector<string> nm = names();
     vector<llvm::Type*> ty = llvm_types(&context);
     for (size_t i = 0; i < nm.size(); i++) {
+#if LLVM_VERSION >= 37
+        Value *ptr = builder->CreateConstInBoundsGEP2_32(type, dst, 0, idx);
+#else
         Value *ptr = builder->CreateConstInBoundsGEP2_32(dst, 0, idx);
+#endif
         Value *val;
         if (!ends_with(nm[i], ".buffer") || src.contains(nm[i])) {
             val = src.get(nm[i]);
@@ -147,14 +151,19 @@ void Closure::pack_struct(Value *dst, const Scope<Value *> &src, IRBuilder<> *bu
 }
 
 void Closure::unpack_struct(Scope<Value *> &dst,
+                            llvm::Type *type,
                             Value *src,
                             IRBuilder<> *builder) {
-    // src should be a pointer to a struct of the type returned by build_type
+    // type, type of src should be a pointer to a struct of the type returned by build_type
     int idx = 0;
     LLVMContext &context = builder->getContext();
     vector<string> nm = names();
     for (size_t i = 0; i < nm.size(); i++) {
+#if LLVM_VERSION >= 37
+        Value *ptr = builder->CreateConstInBoundsGEP2_32(type, src, 0, idx++);
+#else
         Value *ptr = builder->CreateConstInBoundsGEP2_32(src, 0, idx++);
+#endif
         LoadInst *load = builder->CreateLoad(ptr);
         if (load->getType()->isPointerTy()) {
             // Give it a unique type so that tbaa tells llvm that this can't alias anything

--- a/src/CodeGen_Internal.h
+++ b/src/CodeGen_Internal.h
@@ -88,16 +88,16 @@ public:
     llvm::StructType *build_type(llvm::LLVMContext *context);
 
     /** Emit code that builds a struct containing all the externally
-     * referenced state. Requires you to pass it a struct to fill in,
+     * referenced state. Requires you to pass it a type and struct to fill in,
      * a scope to retrieve the llvm values from and a builder to place
      * the packing code. */
-    void pack_struct(llvm::Value *dst, const Scope<llvm::Value *> &src, llvm::IRBuilder<> *builder);
+    void pack_struct(llvm::Type *type, llvm::Value *dst, const Scope<llvm::Value *> &src, llvm::IRBuilder<> *builder);
 
     /** Emit code that unpacks a struct containing all the externally
      * referenced state into a symbol table. Requires you to pass it a
-     * state struct value, a scope to fill, and a builder to place the
+     * state struct type and value, a scope to fill, and a builder to place the
      * unpacking code. */
-    void unpack_struct(Scope<llvm::Value *> &dst, llvm::Value *src, llvm::IRBuilder<> *builder);
+    void unpack_struct(Scope<llvm::Value *> &dst, llvm::Type *type, llvm::Value *src, llvm::IRBuilder<> *builder);
 
 };
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -990,7 +990,13 @@ Value *CodeGen_LLVM::buffer_min_ptr(Value *buffer, int i) {
     llvm::Value *field = ConstantInt::get(i32, 4);
     llvm::Value *idx = ConstantInt::get(i32, i);
     vector<llvm::Value *> args = vec(zero, field, idx);
-    return builder->CreateInBoundsGEP(buffer_t_type, buffer, args, "buf_min");
+    return builder->CreateInBoundsGEP(
+#if LLVM_VERSION >= 37
+        buffer_t_type,
+#endif
+        buffer,
+        args,
+        "buf_min");
 }
 
 Value *CodeGen_LLVM::buffer_elem_size_ptr(Value *buffer) {

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -914,19 +914,47 @@ Value *CodeGen_LLVM::buffer_elem_size(Value *buffer) {
 }
 
 Value *CodeGen_LLVM::buffer_host_ptr(Value *buffer) {
-    return builder->CreateConstInBoundsGEP2_32(buffer, 0, 1, "buf_host");
+    return builder->CreateConstInBoundsGEP2_32(
+#if LLVM_VERSION >= 37
+        buffer_t_type,
+#endif
+        buffer,
+        0,
+        1,
+        "buf_host");
 }
 
 Value *CodeGen_LLVM::buffer_dev_ptr(Value *buffer) {
-    return builder->CreateConstInBoundsGEP2_32(buffer, 0, 0, "buf_dev");
+    return builder->CreateConstInBoundsGEP2_32(
+#if LLVM_VERSION >= 37
+        buffer_t_type,
+#endif
+        buffer,
+        0,
+        0,
+        "buf_dev");
 }
 
 Value *CodeGen_LLVM::buffer_host_dirty_ptr(Value *buffer) {
-    return builder->CreateConstInBoundsGEP2_32(buffer, 0, 6, "buffer_host_dirty");
+    return builder->CreateConstInBoundsGEP2_32(
+#if LLVM_VERSION >= 37
+        buffer_t_type,
+#endif
+        buffer,
+        0,
+        6,
+        "buffer_host_dirty");
 }
 
 Value *CodeGen_LLVM::buffer_dev_dirty_ptr(Value *buffer) {
-    return builder->CreateConstInBoundsGEP2_32(buffer, 0, 7, "buffer_dev_dirty");
+    return builder->CreateConstInBoundsGEP2_32(
+#if LLVM_VERSION >= 37
+        buffer_t_type,
+#endif
+        buffer,
+        0,
+        7,
+        "buffer_dev_dirty");
 }
 
 Value *CodeGen_LLVM::buffer_extent_ptr(Value *buffer, int i) {
@@ -934,7 +962,13 @@ Value *CodeGen_LLVM::buffer_extent_ptr(Value *buffer, int i) {
     llvm::Value *field = ConstantInt::get(i32, 2);
     llvm::Value *idx = ConstantInt::get(i32, i);
     vector<llvm::Value *> args = vec(zero, field, idx);
-    return builder->CreateInBoundsGEP(buffer, args, "buf_extent");
+    return builder->CreateInBoundsGEP(
+#if LLVM_VERSION >= 37
+        buffer_t_type,
+#endif
+        buffer,
+        args,
+        "buf_extent");
 }
 
 Value *CodeGen_LLVM::buffer_stride_ptr(Value *buffer, int i) {
@@ -942,7 +976,13 @@ Value *CodeGen_LLVM::buffer_stride_ptr(Value *buffer, int i) {
     llvm::Value *field = ConstantInt::get(i32, 3);
     llvm::Value *idx = ConstantInt::get(i32, i);
     vector<llvm::Value *> args = vec(zero, field, idx);
-    return builder->CreateInBoundsGEP(buffer, args, "buf_stride");
+    return builder->CreateInBoundsGEP(
+#if LLVM_VERSION >= 37
+        buffer_t_type,
+#endif
+        buffer,
+        args,
+        "buf_stride");
 }
 
 Value *CodeGen_LLVM::buffer_min_ptr(Value *buffer, int i) {
@@ -950,11 +990,18 @@ Value *CodeGen_LLVM::buffer_min_ptr(Value *buffer, int i) {
     llvm::Value *field = ConstantInt::get(i32, 4);
     llvm::Value *idx = ConstantInt::get(i32, i);
     vector<llvm::Value *> args = vec(zero, field, idx);
-    return builder->CreateInBoundsGEP(buffer, args, "buf_min");
+    return builder->CreateInBoundsGEP(buffer_t_type, buffer, args, "buf_min");
 }
 
 Value *CodeGen_LLVM::buffer_elem_size_ptr(Value *buffer) {
-    return builder->CreateConstInBoundsGEP2_32(buffer, 0, 5, "buf_elem_size");
+    return builder->CreateConstInBoundsGEP2_32(
+#if LLVM_VERSION >= 37
+        buffer_t_type,
+#endif
+        buffer,
+        0,
+        5,
+        "buf_elem_size");
 }
 
 Value *CodeGen_LLVM::codegen(Expr e) {
@@ -2122,9 +2169,16 @@ void CodeGen_LLVM::visit(const Call *op) {
             // Allocate and populate a stack array for the integer args
             Value *coords;
             if (int_args > 0) {
-                coords = create_alloca_at_entry(llvm_type_of(op->args[5].type()), int_args);
+                llvm::Type *coords_type = llvm_type_of(op->args[5].type());
+                coords = create_alloca_at_entry(coords_type, int_args);
                 for (int i = 0; i < int_args; i++) {
-                    Value *coord_ptr = builder->CreateConstInBoundsGEP1_32(coords, i);
+                    Value *coord_ptr =
+                        builder->CreateConstInBoundsGEP1_32(
+#if LLVM_VERSION >= 37
+                            coords_type,
+#endif
+                            coords,
+                            i);
                     builder->CreateStore(codegen(op->args[5+i]), coord_ptr);
                 }
                 coords = builder->CreatePointerCast(coords, i32->getPointerTo());
@@ -2149,7 +2203,14 @@ void CodeGen_LLVM::visit(const Call *op) {
                 coords};
 
             for (size_t i = 0; i < sizeof(members)/sizeof(members[0]); i++) {
-                Value *field_ptr = builder->CreateConstInBoundsGEP2_32(trace_event, 0, i);
+                Value *field_ptr =
+                    builder->CreateConstInBoundsGEP2_32(
+#if LLVM_VERSION >= 37
+                        trace_event_type,
+#endif
+                        trace_event,
+                        0,
+                        i);
                 builder->CreateStore(members[i], field_ptr);
             }
 
@@ -2248,7 +2309,14 @@ void CodeGen_LLVM::visit(const Call *op) {
 
                 // Put the elements in the struct.
                 for (size_t i = 0; i < args.size(); i++) {
-                    Value *field_ptr = builder->CreateConstInBoundsGEP2_32(ptr, 0, i);
+                    Value *field_ptr =
+                        builder->CreateConstInBoundsGEP2_32(
+#if LLVM_VERSION >= 37
+                            struct_t,
+#endif
+                            ptr,
+                            0,
+                            i);
                     builder->CreateStore(args[i], field_ptr);
                 }
 
@@ -2695,7 +2763,7 @@ void CodeGen_LLVM::visit(const For *op) {
         Value *ptr = create_alloca_at_entry(closure_t, 1);
 
         // Fill in the closure
-        closure.pack_struct(ptr, symbol_table, builder);
+        closure.pack_struct(closure_t, ptr, symbol_table, builder);
 
         // Make a new function that does one iteration of the body of the loop
         llvm::Type *voidPointerType = (llvm::Type *)(i8->getPointerTo());
@@ -2735,7 +2803,7 @@ void CodeGen_LLVM::visit(const For *op) {
         iter->setName("closure");
         Value *closure_handle = builder->CreatePointerCast(iter, closure_t->getPointerTo());
         // Load everything from the closure into the new scope
-        closure.unpack_struct(symbol_table, closure_handle, builder);
+        closure.unpack_struct(symbol_table, closure_t, closure_handle, builder);
 
         // Generate the new function body
         codegen(op->body);
@@ -2813,7 +2881,8 @@ void CodeGen_LLVM::visit(const Store *op) {
                 add_tbaa_metadata(store, op->name, slice_index);
             }
         } else if (ramp) {
-            Value *ptr = codegen_buffer_pointer(op->name, value_type.element_of(), ramp->base);
+            Type ptr_type = value_type.element_of();
+            Value *ptr = codegen_buffer_pointer(op->name, ptr_type, ramp->base);
             const IntImm *const_stride = ramp->stride.as<IntImm>();
             Value *stride = codegen(ramp->stride);
             // Scatter without generating the indices as a vector
@@ -2822,7 +2891,13 @@ void CodeGen_LLVM::visit(const Store *op) {
                 Value *v = builder->CreateExtractElement(val, lane);
                 if (const_stride) {
                     // Use a constant offset from the base pointer
-                    Value *p = builder->CreateConstInBoundsGEP1_32(ptr, const_stride->value * i);
+                    Value *p =
+                        builder->CreateConstInBoundsGEP1_32(
+#if LLVM_VERSION >= 37
+                            llvm_type_of(ptr_type),
+#endif
+                            ptr,
+                            const_stride->value * i);
                     StoreInst *store = builder->CreateStore(v, p);
                     add_tbaa_metadata(store, op->name, op->index);
                 } else {


### PR DESCRIPTION
Accommodate LLVM trunk which as of couple days ago needs pointer types for CreateConstGEP2_32, CreateInBoundsGEP, CreateConstInBoundsGEP2_32, CreateConstInBoundsGEP1_32.