### PR TITLE
Add optional metadata registration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -699,9 +699,13 @@ $(FILTERS_DIR)/tiled_blur_blur_interleaved.o $(FILTERS_DIR)/tiled_blur_blur_inte
 	cd tmp; $(LD_PATH_SETUP) ../$< -g tiled_blur_blur -f tiled_blur_blur_interleaved -o ../$(FILTERS_DIR) target=$(HL_TARGET) is_interleaved=true
 
 # metadata_tester is built with and without user-context
+$(FILTERS_DIR)/metadata_tester.o $(FILTERS_DIR)/metadata_tester.h: $(FILTERS_DIR)/metadata_tester.generator
+	@-mkdir -p tmp
+	cd tmp; $(LD_PATH_SETUP) ../$< -f metadata_tester -o ../$(FILTERS_DIR) target=$(HL_TARGET)-register_metadata
+
 $(FILTERS_DIR)/metadata_tester_ucon.o $(FILTERS_DIR)/metadata_tester_ucon.h: $(FILTERS_DIR)/metadata_tester.generator
 	@-mkdir -p tmp
-	cd tmp; $(LD_PATH_SETUP) ../$< -f metadata_tester_ucon -o ../$(FILTERS_DIR) target=$(HL_TARGET)-user_context
+	cd tmp; $(LD_PATH_SETUP) ../$< -f metadata_tester_ucon -o ../$(FILTERS_DIR) target=$(HL_TARGET)-user_context-register_metadata
 
 $(BIN_DIR)/generator_aot_metadata_tester: $(FILTERS_DIR)/metadata_tester_ucon.o
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -738,7 +738,7 @@ llvm::Constant *CodeGen_LLVM::embed_metadata(string name, const vector<Argument>
 }
 
 void CodeGen_LLVM::register_metadata(string name, llvm::Constant *metadata, llvm::Function *argv_wrapper) {
-    llvm::Function *register_metadata = module->getFunction("_halide_runtime_internal_register_metadata");
+    llvm::Function *register_metadata = module->getFunction("halide_runtime_internal_register_metadata");
     internal_assert(register_metadata) << "Could not find register_metadata in initial module\n";
 
     llvm::StructType *register_t_type = module->getTypeByName("struct._halide_runtime_internal_registered_filter_t");

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -795,7 +795,7 @@ llvm::Constant *CodeGen_LLVM::embed_metadata(const std::string &metadata_name,
     return metadata;
 }
 
-void CodeGen_LLVM::register_metadata(string name, llvm::Constant *metadata, llvm::Function *argv_wrapper) {
+void CodeGen_LLVM::register_metadata(const std::string &name, llvm::Constant *metadata, llvm::Function *argv_wrapper) {
     llvm::Function *register_metadata = module->getFunction("halide_runtime_internal_register_metadata");
     internal_assert(register_metadata) << "Could not find register_metadata in initial module\n";
 
@@ -804,7 +804,6 @@ void CodeGen_LLVM::register_metadata(string name, llvm::Constant *metadata, llvm
 
     Constant *list_node_fields[] = {
         Constant::getNullValue(register_t_type->getPointerTo()),
-        create_string_constant(name),
         metadata,
         argv_wrapper
     };

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -423,7 +423,7 @@ private:
     /** Embed a constant expression as a global variable. */
     llvm::Constant *embed_constant_expr(Expr e);
 
-    void register_metadata(std::string name, llvm::Constant *metadata, llvm::Function *argv_wrapper);
+    void register_metadata(const std::string &name, llvm::Constant *metadata, llvm::Function *argv_wrapper);
 };
 
 }

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -395,9 +395,11 @@ private:
      * the given name (by convention, this should be ${FUNCTIONNAME}_metadata)
      * as extern "C" linkage.
      */
-    void embed_metadata(std::string name, const std::vector<Argument> &args);
+    llvm::Constant* embed_metadata(std::string name, const std::vector<Argument> &args);
 
     llvm::Constant *embed_constant_expr(Expr e);
+
+    void register_metadata(std::string name, llvm::Constant *metadata, llvm::Function *argv_wrapper);
 };
 
 }

--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -46,6 +46,7 @@
 #include <llvm/Target/TargetSubtargetInfo.h>
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
 #include <llvm/Transforms/IPO.h>
+#include <llvm/Transforms/Utils/ModuleUtils.h>
 #include <llvm/ADT/StringMap.h>
 #include <llvm/Object/ObjectFile.h>
 

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -286,6 +286,8 @@ bool Target::merge_string(const std::string &target) {
             set_feature(Target::OpenGL);
         } else if (tok == "user_context") {
             set_feature(Target::UserContext);
+        } else if (tok == "register_metadata") {
+            set_feature(Target::RegisterMetadata);
         } else if (tok == "no_asserts") {
             set_feature(Target::NoAsserts);
         } else if (tok == "no_bounds_query") {
@@ -356,7 +358,8 @@ std::string Target::to_string() const {
       "cuda", "cuda_capability_30", "cuda_capability_32", "cuda_capability_35", "cuda_capability_50",
       "opencl", "cl_doubles",
       "opengl",
-      "user_context"
+      "user_context",
+      "register_metadata"
   };
   internal_assert(sizeof(feature_names) / sizeof(feature_names[0]) == FeatureEnd);
   string result = string(arch_names[arch])

--- a/src/Target.h
+++ b/src/Target.h
@@ -59,6 +59,8 @@ struct Target {
 
         UserContext,  ///< Generated code takes a user_context pointer as first argument
 
+        RegisterMetadata,  ///< Generated code registers metadata for use with halide_enumerate_registered_filters
+
         FeatureEnd
         // NOTE: Changes to this enum must be reflected in the definition of
         // to_string()!

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -432,6 +432,34 @@ struct halide_filter_metadata_t {
     const char* target;
 };
 
+// TODO: should "name" be moved into halide_filter_metadata_t?
+// How about argv_func?
+
+/** enumerate_func_t is a callback for halide_enumerate_registered_filters; it
+ * is called once per registered filter discovered. Return 0 to continue
+ * the enumeration, or nonzero to terminate the enumeration. enumerate_context
+ * is an arbitrary pointer you can use to provide a callback argument. */
+typedef int (*enumerate_func_t)(void* enumerate_context, const char* name,
+    const halide_filter_metadata_t *metadata, int (*argv_func)(void **args));
+
+/** If a filter is compiled with Target::RegisterMetadata, it will register itself
+ * in an internal list at load time; halide_enumerate_registered_filters() allows
+ * you to enumerate all such filters at runtime. This allows you to link together
+ * arbitrary AOT-compiled filters and introspect/call them easily. Note:
+ *
+ * -- Only filters compiled with Target::RegisterMetadata enabled will be enumerated.
+ * -- This function should not be called before or after main() (i.e., must not
+ * be called from static ctors or dtors).
+ * -- Filters will be enumerated in an unpredictable order; it is essential
+ * you do not rely on a particular order of enumeration.
+ * -- It is *not* guaranteed that the names in an enumeration are unique!
+ *
+ * The return value is zero if the enumerate_func_t always returns zero;
+ * if the enumerate_func_t returns a nonzero value, enumeration will
+ * terminate early and return that nonzero result.
+ */
+extern int halide_enumerate_registered_filters(void *user_context, void* enumerate_context, enumerate_func_t func);
+
 #ifdef __cplusplus
 } // End extern "C"
 #endif

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -572,14 +572,11 @@ struct halide_filter_metadata_t {
     const char* name;
 };
 
-// TODO: should "name" be moved into halide_filter_metadata_t?
-// How about argv_func?
-
 /** enumerate_func_t is a callback for halide_enumerate_registered_filters; it
  * is called once per registered filter discovered. Return 0 to continue
  * the enumeration, or nonzero to terminate the enumeration. enumerate_context
  * is an arbitrary pointer you can use to provide a callback argument. */
-typedef int (*enumerate_func_t)(void* enumerate_context, const char* name,
+typedef int (*enumerate_func_t)(void* enumerate_context,
     const halide_filter_metadata_t *metadata, int (*argv_func)(void **args));
 
 /** If a filter is compiled with Target::RegisterMetadata, it will register itself

--- a/src/runtime/metadata.cpp
+++ b/src/runtime/metadata.cpp
@@ -5,7 +5,6 @@ extern "C" {
 
 struct _halide_runtime_internal_registered_filter_t {
     struct _halide_runtime_internal_registered_filter_t *next;
-    const char *name;
     const halide_filter_metadata_t* metadata;
     int (*argv_func)(void **args);
 };
@@ -47,7 +46,7 @@ WEAK int halide_enumerate_registered_filters(void *user_context, void* enumerate
     list_head_t* head = get_list_head();
     ScopedMutexLock lock(&head->mutex);
     for (_halide_runtime_internal_registered_filter_t* f = head->next; f != NULL; f = f->next) {
-        int r = (*func)(enumerate_context, f->name, f->metadata, f->argv_func);
+        int r = (*func)(enumerate_context, f->metadata, f->argv_func);
         if (r != 0) return r;
     }
     return 0;

--- a/src/runtime/metadata.cpp
+++ b/src/runtime/metadata.cpp
@@ -1,10 +1,56 @@
 #include "HalideRuntime.h"
+#include "scoped_mutex_lock.h"
 
-// This is a trick used to ensure that halide_filter_metadata_t (and related types)
-// are included in the runtime bitcode; since no (other) runtime function references them
-// they are ordinarily stripped, making Codegen_LLVM fail when we attempt to access
-// the types.
+extern "C" {
 
-#define INLINE inline __attribute__((weak)) __attribute__((used)) __attribute__((always_inline)) __attribute__((nothrow)) __attribute__((pure))
+struct _halide_runtime_internal_registered_filter_t {
+    struct _halide_runtime_internal_registered_filter_t *next;
+    const char *name;
+    const halide_filter_metadata_t* metadata;
+    int (*argv_func)(void **args);
+};
 
-INLINE void __force_include_halide_filter_metadata_t_types(halide_filter_metadata_t*) {}
+};
+
+namespace Halide { namespace Runtime { namespace Internal {
+
+struct list_head_t {
+    halide_mutex mutex;
+    _halide_runtime_internal_registered_filter_t *next;
+
+    list_head_t() : mutex(), next(NULL) {}
+};
+
+static list_head_t* get_list_head() {
+    static list_head_t head;
+    return &head;
+}
+
+} } }
+
+extern "C" {
+
+// This is looked up by name in Codegen_LLVM, which is easier to do
+// for functions with plain C linkage.
+WEAK void _halide_runtime_internal_register_metadata(_halide_runtime_internal_registered_filter_t *info) {
+    // Note that although the metadata pointer itself is valid, the contents pointed
+    // to by it may not be initialized yet (since order of execution is not guaranteed in this case);
+    // it is essential that this code not do anything with that pointer other than store
+    // it for future use. (The name argument will always be valid here, however.)
+    list_head_t* head = get_list_head();
+    ScopedMutexLock lock(&head->mutex);
+    info->next = head->next;
+    head->next = info;
+}
+
+WEAK int halide_enumerate_registered_filters(void *user_context, void* enumerate_context, enumerate_func_t func) {
+    list_head_t* head = get_list_head();
+    ScopedMutexLock lock(&head->mutex);
+    for (_halide_runtime_internal_registered_filter_t* f = head->next; f != NULL; f = f->next) {
+        int r = (*func)(enumerate_context, f->name, f->metadata, f->argv_func);
+        if (r != 0) return r;
+    }
+    return 0;
+}
+
+}  // extern "C"

--- a/src/runtime/metadata.cpp
+++ b/src/runtime/metadata.cpp
@@ -16,14 +16,9 @@ namespace Halide { namespace Runtime { namespace Internal {
 struct list_head_t {
     halide_mutex mutex;
     _halide_runtime_internal_registered_filter_t *next;
-
-    list_head_t() : mutex(), next(NULL) {}
 };
 
-static list_head_t* get_list_head() {
-    static list_head_t head;
-    return &head;
-}
+WEAK list_head_t list_head;
 
 } } }
 
@@ -36,16 +31,14 @@ WEAK void halide_runtime_internal_register_metadata(_halide_runtime_internal_reg
     // to by it may not be initialized yet (since order of execution is not guaranteed in this case);
     // it is essential that this code not do anything with that pointer other than store
     // it for future use. (The name argument will always be valid here, however.)
-    list_head_t* head = get_list_head();
-    ScopedMutexLock lock(&head->mutex);
-    info->next = head->next;
-    head->next = info;
+    ScopedMutexLock lock(&list_head.mutex);
+    info->next = list_head.next;
+    list_head.next = info;
 }
 
 WEAK int halide_enumerate_registered_filters(void *user_context, void* enumerate_context, enumerate_func_t func) {
-    list_head_t* head = get_list_head();
-    ScopedMutexLock lock(&head->mutex);
-    for (_halide_runtime_internal_registered_filter_t* f = head->next; f != NULL; f = f->next) {
+    ScopedMutexLock lock(&list_head.mutex);
+    for (_halide_runtime_internal_registered_filter_t* f = list_head.next; f != NULL; f = f->next) {
         int r = (*func)(enumerate_context, f->metadata, f->argv_func);
         if (r != 0) return r;
     }

--- a/src/runtime/metadata.cpp
+++ b/src/runtime/metadata.cpp
@@ -32,7 +32,7 @@ extern "C" {
 
 // This is looked up by name in Codegen_LLVM, which is easier to do
 // for functions with plain C linkage.
-WEAK void _halide_runtime_internal_register_metadata(_halide_runtime_internal_registered_filter_t *info) {
+WEAK void halide_runtime_internal_register_metadata(_halide_runtime_internal_registered_filter_t *info) {
     // Note that although the metadata pointer itself is valid, the contents pointed
     // to by it may not be initialized yet (since order of execution is not guaranteed in this case);
     // it is essential that this code not do anything with that pointer other than store

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -145,6 +145,18 @@ if (WITH_TEST_GENERATORS)
                                "${GEN_NAME}"
                                "${FUNC_NAME}"
                                "target=host-user_context")
+    # metadata_tester_aottest.cpp depends on two variants of metadata_generator
+    elseif(TEST_SRC STREQUAL "metadata_tester_aottest.cpp")
+      halide_add_generator_dependency("${TEST_RUNNER}"
+                               "generator_${GEN_NAME}"
+                               "${GEN_NAME}"
+                               "${FUNC_NAME}"
+                               "target=host-register_metadata")
+      halide_add_generator_dependency("${TEST_RUNNER}"
+                               "generator_${GEN_NAME}"
+                               "${GEN_NAME}"
+                               "${FUNC_NAME}_ucon"
+                               "target=host-register_metadata-user_context")
     else()
       # All the other foo_test.cpp just depend on foo_generator.cpp
       halide_add_generator_dependency("${TEST_RUNNER}"
@@ -159,14 +171,6 @@ if (WITH_TEST_GENERATORS)
                                  "tiled_blur_blur"
                                  "tiled_blur_blur"
                                  "target=host")
-      endif()
-      # metadata_tester_aottest.cpp depends on two variants of metadata_generator
-      if(TEST_SRC STREQUAL "metadata_tester_aottest.cpp")
-        halide_add_generator_dependency("${TEST_RUNNER}"
-                                 "generator_${GEN_NAME}"
-                                 "${GEN_NAME}"
-                                 "${FUNC_NAME}_ucon"
-                                 "target=host-user_context")
       endif()
     endif()
     target_include_directories("${TEST_RUNNER}" PRIVATE "${CMAKE_SOURCE_DIR}/apps/support")

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -421,11 +421,10 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
 }
 
 int EnumerateFunc(void* enumerate_context,
-    const char* name,
     const halide_filter_metadata_t *metadata,
     int (*argv_func)(void **args)) {
   std::map<std::string, int> &enum_results = *reinterpret_cast<std::map<std::string, int>*>(enumerate_context);
-  enum_results[name] = metadata->num_arguments;
+  enum_results[metadata->name] = metadata->num_arguments;
   return 0;
 }
 

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <iostream>
 #include <string.h>
+#include <map>
 
 #include "metadata_tester.h"
 #include "metadata_tester_ucon.h"
@@ -419,19 +420,36 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
     }
 }
 
+int EnumerateFunc(void* enumerate_context,
+    const char* name,
+    const halide_filter_metadata_t *metadata,
+    int (*argv_func)(void **args)) {
+  std::map<std::string, int> &enum_results = *reinterpret_cast<std::map<std::string, int>*>(enumerate_context);
+  enum_results[name] = metadata->num_arguments;
+  return 0;
+}
+
 int main(int argc, char **argv) {
+    void* user_context = NULL;
+
+    int result;
+
+    std::map<std::string, int> enum_results;
+    result = halide_enumerate_registered_filters(user_context, &enum_results, EnumerateFunc);
+    EXPECT_EQ(0, result);
+    EXPECT_EQ(2, enum_results.size());
+    EXPECT_EQ(15, enum_results["metadata_tester"]);
+    EXPECT_EQ(16, enum_results["metadata_tester_ucon"]);
 
     const Image<uint8_t> input = make_image<uint8_t>();
 
     Image<float> output0(kSize, kSize, 3);
     Image<float> output1(kSize, kSize, 3);
 
-    int result;
-
     result = metadata_tester(input, false, 0, 0, 0, 0, 0, 0, 0, 0, 0.f, 0.0, NULL, output0, output1);
     EXPECT_EQ(0, result);
 
-    result = metadata_tester_ucon(NULL, input, false, 0, 0, 0, 0, 0, 0, 0, 0, 0.f, 0.0, NULL, output0, output1);
+    result = metadata_tester_ucon(user_context, input, false, 0, 0, 0, 0, 0, 0, 0, 0, 0.f, 0.0, NULL, output0, output1);
     EXPECT_EQ(0, result);
 
     verify(input, output0, output1);


### PR DESCRIPTION
When built with Target::RegisterMetadata (which is off by default), we
add a small amount of load-time code to build a list of information
about filter metadata and argv-style calls; this can be enumerated to
introspect/call filters.

When this Target feature is disabled, the only extra code size hit
added is the code in runtime/metadata.cpp (some trivial list
manipulation code); in particular, there are no hard references to
metadata, so it can still be dead-stripped.

When this feature is enabled, we add a trivial amount of code (a
ctor-ish function for each filter), but effectively prevent the
metadata structures from being dead-stripped, hence the opt-in nature
of this feature.

Please consider the TODO in HalideRuntime.h (i.e.: should we move
‘name’ and ‘argv_func’ into the metadata itself?)