### PR TITLE
halide_add_generator_dependency() is broken

### DIFF
--- a/test/HalideGenerator.cmake
+++ b/test/HalideGenerator.cmake
@@ -47,6 +47,7 @@ function(halide_add_generator_dependency target gen_target gen_name func_name)
     add_custom_command(OUTPUT "${FILTER_LIB}" "${FILTER_HDR}"
       DEPENDS "${gen_target}"
       COMMAND "${CMAKE_BINARY_DIR}/bin/${gen_target}${CMAKE_EXECUTABLE_SUFFIX}" "-g" "${gen_name}" "-f" "${func_name}" "-o" "${SCRATCH_DIR}" ${ARGN}
+      COMMAND rm "${FILTER_LIB}"
       COMMAND "${CMAKE_AR}" q "${FILTER_LIB}" "${SCRATCH_DIR}/${func_name}.o"
       WORKING_DIRECTORY "${SCRATCH_DIR}"
       )


### PR DESCRIPTION
It does ‘ar q’ every build, so multiple builds with clean produce an
archive with multiple object files embedded, making for suboptimal
debugging.

Hack fix is to just rm it each time. (There’s probably a better flag to
ar.)