### PR TITLE
Add function name to metadata.

### DIFF
--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -395,7 +395,8 @@ private:
      * the given name (by convention, this should be ${FUNCTIONNAME}_metadata)
      * as extern "C" linkage.
      */
-    void embed_metadata(std::string name, const std::vector<Argument> &args);
+    void embed_metadata(const std::string &metadata_name,
+        const std::string &function_name, const std::vector<Argument> &args);
 
     llvm::Constant *embed_constant_expr(Expr e);
 };

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -430,6 +430,9 @@ struct halide_filter_metadata_t {
     /** The Target for which the filter was compiled. This is always
      * a canonical Target string (ie a product of Target::to_string). */
     const char* target;
+
+    /** The function name of the filter. */
+    const char* name;
 };
 
 #ifdef __cplusplus

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -437,7 +437,16 @@ int main(int argc, char **argv) {
     verify(input, output0, output1);
 
     check_metadata(metadata_tester_metadata, false);
+    if (!strcmp(metadata_tester_metadata.name, "metadata_tester_metadata")) {
+        fprintf(stderr, "Expected name %s\n", "metadata_tester_metadata");
+        exit(-1);
+    }
+
     check_metadata(metadata_tester_ucon_metadata, true);
+    if (!strcmp(metadata_tester_ucon_metadata.name, "metadata_tester_ucon_metadata")) {
+        fprintf(stderr, "Expected name %s\n", "metadata_tester_ucon_metadata");
+        exit(-1);
+    }
 
     printf("Success!\n");
     return 0;


### PR DESCRIPTION
(Note that I’m not bumping the metadata version field for this since
~nothing is using the structure yet.)