### PR TITLE
Replace the buffer_t host_dirty/dev_dirty fields with flags

### DIFF
--- a/apps/HelloAndroid/jni/native.cpp
+++ b/apps/HelloAndroid/jni/native.cpp
@@ -75,7 +75,7 @@ JNIEXPORT void JNICALL Java_com_example_hellohalide_CameraPreview_processFrame(
 
     if (dst) {
         srcBuf.host = (uint8_t *)src;
-        halide_set_buffer_flag(&srcBuf, halide_buffer_host_dirty, true);
+        halide_buffer_set_host_dirty(&srcBuf, true);
         srcBuf.extent[0] = w;
         srcBuf.extent[1] = h;
         srcBuf.extent[2] = 0;

--- a/apps/HelloAndroid/jni/native.cpp
+++ b/apps/HelloAndroid/jni/native.cpp
@@ -75,7 +75,7 @@ JNIEXPORT void JNICALL Java_com_example_hellohalide_CameraPreview_processFrame(
 
     if (dst) {
         srcBuf.host = (uint8_t *)src;
-        srcBuf.host_dirty = true;
+        halide_set_buffer_flag(&srcBuf, halide_buffer_host_dirty, true);
         srcBuf.extent[0] = w;
         srcBuf.extent[1] = h;
         srcBuf.extent[2] = 0;

--- a/apps/glsl/opengl_test.cpp
+++ b/apps/glsl/opengl_test.cpp
@@ -34,7 +34,7 @@ public:
         size_t size = w * h * c * elem_size;
         buf.host = (uint8_t*)malloc(size);
         memset(buf.host, 0, size);
-        halide_set_buffer_flag(&buf, halide_buffer_host_dirty, true);
+        halide_buffer_set_host_dirty(&buf, true);
     }
     ~Image() {
         free(buf.host);

--- a/apps/glsl/opengl_test.cpp
+++ b/apps/glsl/opengl_test.cpp
@@ -34,7 +34,7 @@ public:
         size_t size = w * h * c * elem_size;
         buf.host = (uint8_t*)malloc(size);
         memset(buf.host, 0, size);
-        buf.host_dirty = true;
+        halide_set_buffer_flag(&buf, halide_buffer_host_dirty, true);
     }
     ~Image() {
         free(buf.host);

--- a/apps/support/static_image.h
+++ b/apps/support/static_image.h
@@ -56,8 +56,8 @@ class Image {
 
         uint8_t *ptr = new uint8_t[sizeof(T)*size + 40];
         buf.host = ptr;
-        halide_set_buffer_flag(&buf, halide_buffer_host_dirty, false);
-        halide_set_buffer_flag(&buf, halide_buffer_dev_dirty, false);
+        halide_buffer_set_host_dirty(&buf, false);
+        halide_buffer_set_dev_dirty(&buf, false);
         buf.dev = 0;
         while ((size_t)buf.host & 0x1f) buf.host++;
         contents = new Contents(buf, ptr);
@@ -108,26 +108,26 @@ public:
     void set_host_dirty(bool dirty = true) {
         // If you use data directly, you must also call this so that
         // gpu-side code knows that it needs to copy stuff over.
-        halide_set_buffer_flag(&contents->buf, halide_buffer_host_dirty, dirty);
+        halide_buffer_set_host_dirty(&contents->buf, dirty);
     }
 
     void copy_to_host() {
-        if (halide_get_buffer_flag(&contents->buf, halide_buffer_dev_dirty)) {
+        if (halide_buffer_get_dev_dirty(&contents->buf)) {
             halide_copy_to_host(NULL, &contents->buf);
-            halide_set_buffer_flag(&contents->buf, halide_buffer_dev_dirty, false);
+            halide_buffer_set_dev_dirty(&contents->buf, false);
         }
     }
 
     void copy_to_device(const struct halide_device_interface *device_interface) {
-        if (halide_get_buffer_flag(&contents->buf, halide_buffer_host_dirty)) {
+        if (halide_buffer_get_host_dirty(&contents->buf)) {
             // If host
             halide_copy_to_device(NULL, &contents->buf, device_interface);
-            halide_set_buffer_flag(&contents->buf, halide_buffer_host_dirty, false);
+            halide_buffer_set_host_dirty(&contents->buf, false);
         }
     }
 
     void dev_free() {
-        assert(!halide_get_buffer_flag(&contents->buf, halide_buffer_dev_dirty));
+        assert(!halide_buffer_get_dev_dirty(&contents->buf));
         contents->dev_free();
     }
 

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -69,8 +69,7 @@ struct BufferContents {
             buf.host = data;
         }
         buf.dev = 0;
-        buf.host_dirty = false;
-        buf.dev_dirty = false;
+        buf.flags = 0;
         buf.extent[0] = x_size;
         buf.extent[1] = y_size;
         buf.extent[2] = z_size;
@@ -162,22 +161,22 @@ uint64_t Buffer::device_handle() const {
 
 bool Buffer::host_dirty() const {
     user_assert(defined()) << "Buffer is undefined\n";
-    return contents.ptr->buf.host_dirty;
+    return halide_get_buffer_flag(&contents.ptr->buf, halide_buffer_host_dirty);
 }
 
 void Buffer::set_host_dirty(bool dirty) {
     user_assert(defined()) << "Buffer is undefined\n";
-    contents.ptr->buf.host_dirty = dirty;
+    halide_set_buffer_flag(&contents.ptr->buf, halide_buffer_host_dirty, dirty);
 }
 
 bool Buffer::device_dirty() const {
     user_assert(defined()) << "Buffer is undefined\n";
-    return contents.ptr->buf.dev_dirty;
+    return halide_get_buffer_flag(&contents.ptr->buf, halide_buffer_dev_dirty);
 }
 
 void Buffer::set_device_dirty(bool dirty) {
     user_assert(defined()) << "Buffer is undefined\n";
-    contents.ptr->buf.dev_dirty = dirty;
+    halide_set_buffer_flag(&contents.ptr->buf, halide_buffer_dev_dirty, dirty);
 }
 
 int Buffer::dimensions() const {

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -161,22 +161,22 @@ uint64_t Buffer::device_handle() const {
 
 bool Buffer::host_dirty() const {
     user_assert(defined()) << "Buffer is undefined\n";
-    return halide_get_buffer_flag(&contents.ptr->buf, halide_buffer_host_dirty);
+    return halide_buffer_get_host_dirty(&contents.ptr->buf);
 }
 
 void Buffer::set_host_dirty(bool dirty) {
     user_assert(defined()) << "Buffer is undefined\n";
-    halide_set_buffer_flag(&contents.ptr->buf, halide_buffer_host_dirty, dirty);
+    halide_buffer_set_host_dirty(&contents.ptr->buf, dirty);
 }
 
 bool Buffer::device_dirty() const {
     user_assert(defined()) << "Buffer is undefined\n";
-    return halide_get_buffer_flag(&contents.ptr->buf, halide_buffer_dev_dirty);
+    return halide_buffer_get_dev_dirty(&contents.ptr->buf);
 }
 
 void Buffer::set_device_dirty(bool dirty) {
     user_assert(defined()) << "Buffer is undefined\n";
-    halide_set_buffer_flag(&contents.ptr->buf, halide_buffer_dev_dirty, dirty);
+    halide_buffer_set_dev_dirty(&contents.ptr->buf, dirty);
 }
 
 int Buffer::dimensions() const {

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -33,6 +33,7 @@ const string buffer_t_definition =
     "    int32_t min[4];\n"
     "    int32_t elem_size;\n"
     "    int32_t flags;\n"
+    "    void* _unused;\n"
     "} buffer_t;\n"
     "enum halide_buffer_flag_bits_t {\n"
     "    halide_buffer_host_dirty = (1 << 0),\n"

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -25,7 +25,6 @@ const string buffer_t_definition =
     "#ifndef BUFFER_T_DEFINED\n"
     "#define BUFFER_T_DEFINED\n"
     "#include <stdint.h>\n"
-    "#pragma pack(push, 1)\n"
     "typedef struct buffer_t {\n"
     "    uint64_t dev;\n"
     "    uint8_t* host;\n"
@@ -33,11 +32,12 @@ const string buffer_t_definition =
     "    int32_t stride[4];\n"
     "    int32_t min[4];\n"
     "    int32_t elem_size;\n"
-    "    bool host_dirty;\n"
-    "    bool dev_dirty;\n"
-    "    uint8_t _padding[2];\n"
+    "    int32_t flags;\n"
     "} buffer_t;\n"
-    "#pragma pack(pop)\n"
+    "enum halide_buffer_flag_bits_t {\n"
+    "    halide_buffer_host_dirty = (1 << 0),\n"
+    "    halide_buffer_dev_dirty = (1 << 1)\n"
+    "};\n"
     "#endif\n";
 
 const string headers =
@@ -480,7 +480,7 @@ void CodeGen_C::compile(const Buffer &buffer) {
 
     // Emit the buffer_t
     user_assert(b.host) << "Can't embed image: " << buffer.name() << " because it has a null host pointer\n";
-    user_assert(!b.dev_dirty) << "Can't embed image: " << buffer.name() << "because it has a dirty device pointer\n";
+    user_assert(!halide_get_buffer_flag(&b, halide_buffer_dev_dirty)) << "Can't embed image: " << buffer.name() << "because it has a dirty device pointer\n";
     stream << "static buffer_t " << name << "_buffer = {"
            << "0, " // dev
            << "&" << name << "_data[0], " // host
@@ -488,8 +488,7 @@ void CodeGen_C::compile(const Buffer &buffer) {
            << "{" << b.stride[0] << ", " << b.stride[1] << ", " << b.stride[2] << ", " << b.stride[3] << "}, "
            << "{" << b.min[0] << ", " << b.min[1] << ", " << b.min[2] << ", " << b.min[3] << "}, "
            << b.elem_size << ", "
-           << "0, " // host_dirty
-           << "0};\n"; //dev_dirty
+           << "0};\n"; //flags
 
     // Make a global pointer to it
     stream << "static buffer_t *" << name << " = &" << name << "_buffer;\n";
@@ -939,14 +938,14 @@ void CodeGen_C::visit(const Call *op) {
             string a0 = print_expr(op->args[0]);
             string a1 = print_expr(op->args[1]);
             do_indent();
-            stream << "((buffer_t *)(" << a0 << "))->host_dirty = " << a1 << ";\n";
+            stream << "halide_set_buffer_flag((buffer_t *)(" << a0 << "), halide_buffer_host_dirty, (" << a1 << "));\n";
             rhs << "0";
         } else if (op->name == Call::set_dev_dirty) {
             internal_assert(op->args.size() == 2);
             string a0 = print_expr(op->args[0]);
             string a1 = print_expr(op->args[1]);
             do_indent();
-            stream << "((buffer_t *)(" << a0 << "))->dev_dirty = " << a1 << ";\n";
+            stream << "halide_set_buffer_flag((buffer_t *)(" << a0 << "), halide_buffer_dev_dirty, (" << a1 << "));\n";
             rhs << "0";
         } else if (op->name == Call::abs) {
             internal_assert(op->args.size() == 1);

--- a/src/CodeGen_GPU_Host.h
+++ b/src/CodeGen_GPU_Host.h
@@ -51,8 +51,7 @@ protected:
     using CodeGen_CPU::sym_pop;
     using CodeGen_CPU::sym_get;
     using CodeGen_CPU::sym_exists;
-    using CodeGen_CPU::buffer_dev_dirty_ptr;
-    using CodeGen_CPU::buffer_host_dirty_ptr;
+    using CodeGen_CPU::buffer_flags_ptr;
     using CodeGen_CPU::buffer_elem_size_ptr;
     using CodeGen_CPU::buffer_min_ptr;
     using CodeGen_CPU::buffer_stride_ptr;

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -658,6 +658,7 @@ void CodeGen_LLVM::compile_buffer(const Buffer &buf) {
         ConstantArray::get(i32_array, get_constants(i32, b.min, b.min + 4)),
         ConstantInt::get(i32, b.elem_size),
         ConstantInt::get(i32, halide_buffer_host_dirty), // flags: host_dirty, !dev_dirty
+        Constant::getNullValue(i8->getPointerTo())
     };
     Constant *buffer_struct = ConstantStruct::get(buffer_t_type, fields);
     global->setInitializer(buffer_struct);

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -633,7 +633,7 @@ void CodeGen_LLVM::compile_buffer(const Buffer &buf) {
     buffer_t b = *(buf.raw_buffer());
     user_assert(b.host)
         << "Can't embed buffer " << buf.name() << " because it has a null host pointer.\n";
-    user_assert(!halide_get_buffer_flag(&b, halide_buffer_dev_dirty))
+    user_assert(!halide_buffer_get_dev_dirty(&b))
         << "Can't embed Image \"" << buf.name() << "\""
         << " because it has a dirty device pointer\n";
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -577,7 +577,7 @@ void CodeGen_LLVM::compile_buffer(const Buffer &buf) {
     buffer_t b = *(buf.raw_buffer());
     user_assert(b.host)
         << "Can't embed buffer " << buf.name() << " because it has a null host pointer.\n";
-    user_assert(!b.dev_dirty)
+    user_assert(!halide_get_buffer_flag(&b, halide_buffer_dev_dirty))
         << "Can't embed Image \"" << buf.name() << "\""
         << " because it has a dirty device pointer\n";
 
@@ -593,7 +593,6 @@ void CodeGen_LLVM::compile_buffer(const Buffer &buf) {
                                                 false, GlobalValue::PrivateLinkage,
                                                 0, buf.name() + ".buffer");
     llvm::ArrayType *i32_array = ArrayType::get(i32, 4);
-    llvm::ArrayType *padding_bytes = ArrayType::get(i8, 2);
 
     Constant *fields[] = {
         ConstantInt::get(i64, 0), // dev
@@ -602,10 +601,7 @@ void CodeGen_LLVM::compile_buffer(const Buffer &buf) {
         ConstantArray::get(i32_array, get_constants(i32, b.stride, b.stride + 4)),
         ConstantArray::get(i32_array, get_constants(i32, b.min, b.min + 4)),
         ConstantInt::get(i32, b.elem_size),
-        ConstantInt::get(i8, 1), // host_dirty
-        ConstantInt::get(i8, 0), // dev_dirty
-        ConstantArray::get(padding_bytes, vec(ConstantInt::get(i8, 0),
-                                              ConstantInt::get(i8, 0)))
+        ConstantInt::get(i32, halide_buffer_host_dirty), // flags: host_dirty, !dev_dirty
     };
     Constant *buffer_struct = ConstantStruct::get(buffer_t_type, fields);
     global->setInitializer(buffer_struct);
@@ -841,8 +837,7 @@ void CodeGen_LLVM::push_buffer(const string &name, llvm::Value *buffer) {
     Value *nullity_test = builder->CreateAnd(builder->CreateIsNull(host_ptr),
                                              builder->CreateIsNull(dev_ptr));
     sym_push(name + ".host_and_dev_are_null", nullity_test);
-    sym_push(name + ".host_dirty", buffer_host_dirty(buffer));
-    sym_push(name + ".dev_dirty", buffer_dev_dirty(buffer));
+    sym_push(name + ".flags", buffer_flags(buffer));
     sym_push(name + ".extent.0", buffer_extent(buffer, 0));
     sym_push(name + ".extent.1", buffer_extent(buffer, 1));
     sym_push(name + ".extent.2", buffer_extent(buffer, 2));
@@ -863,8 +858,7 @@ void CodeGen_LLVM::pop_buffer(const string &name) {
     sym_pop(name + ".host");
     sym_pop(name + ".dev");
     sym_pop(name + ".host_and_dev_are_null");
-    sym_pop(name + ".host_dirty");
-    sym_pop(name + ".dev_dirty");
+    sym_pop(name + ".flags");
     sym_pop(name + ".extent.0");
     sym_pop(name + ".extent.1");
     sym_pop(name + ".extent.2");
@@ -889,12 +883,8 @@ Value *CodeGen_LLVM::buffer_dev(Value *buffer) {
     return builder->CreateLoad(buffer_dev_ptr(buffer));
 }
 
-Value *CodeGen_LLVM::buffer_host_dirty(Value *buffer) {
-    return builder->CreateLoad(buffer_host_dirty_ptr(buffer));
-}
-
-Value *CodeGen_LLVM::buffer_dev_dirty(Value *buffer) {
-    return builder->CreateLoad(buffer_dev_dirty_ptr(buffer));
+Value *CodeGen_LLVM::buffer_flags(Value *buffer) {
+    return builder->CreateLoad(buffer_flags_ptr(buffer));
 }
 
 Value *CodeGen_LLVM::buffer_extent(Value *buffer, int i) {
@@ -935,7 +925,7 @@ Value *CodeGen_LLVM::buffer_dev_ptr(Value *buffer) {
         "buf_dev");
 }
 
-Value *CodeGen_LLVM::buffer_host_dirty_ptr(Value *buffer) {
+Value *CodeGen_LLVM::buffer_flags_ptr(Value *buffer) {
     return builder->CreateConstInBoundsGEP2_32(
 #if LLVM_VERSION >= 37
         buffer_t_type,
@@ -943,18 +933,7 @@ Value *CodeGen_LLVM::buffer_host_dirty_ptr(Value *buffer) {
         buffer,
         0,
         6,
-        "buffer_host_dirty");
-}
-
-Value *CodeGen_LLVM::buffer_dev_dirty_ptr(Value *buffer) {
-    return builder->CreateConstInBoundsGEP2_32(
-#if LLVM_VERSION >= 37
-        buffer_t_type,
-#endif
-        buffer,
-        0,
-        7,
-        "buffer_dev_dirty");
+        "buffer_flags");
 }
 
 Value *CodeGen_LLVM::buffer_extent_ptr(Value *buffer, int i) {
@@ -2073,8 +2052,7 @@ void CodeGen_LLVM::visit(const Call *op) {
             // This implement sets device pointer and dirty bits to
             // zero. GPU codegen should also catch this and do
             // something smarter.
-            builder->CreateStore(ConstantInt::get(i8, 0), buffer_host_dirty_ptr(buffer));
-            builder->CreateStore(ConstantInt::get(i8, 0), buffer_dev_dirty_ptr(buffer));
+            builder->CreateStore(ConstantInt::get(i32, 0), buffer_flags_ptr(buffer));
             builder->CreateStore(ConstantInt::get(i64, 0), buffer_dev_ptr(buffer));
 
             value = buffer;
@@ -2121,13 +2099,15 @@ void CodeGen_LLVM::visit(const Call *op) {
             internal_assert(op->args.size() == 2);
             Value *buffer = codegen(op->args[0]);
             Value *arg = codegen(op->args[1]);
-            builder->CreateStore(arg, buffer_host_dirty_ptr(buffer));
+            Value *nflags = set_bit_mask(buffer_flags(buffer), ConstantInt::get(i32, halide_buffer_host_dirty), arg);
+            builder->CreateStore(nflags, buffer_flags_ptr(buffer));
             value = ConstantInt::get(i32, 0);
         } else if (op->name == Call::set_dev_dirty) {
             internal_assert(op->args.size() == 2);
             Value *buffer = codegen(op->args[0]);
             Value *arg = codegen(op->args[1]);
-            builder->CreateStore(arg, buffer_dev_dirty_ptr(buffer));
+            Value *nflags = set_bit_mask(buffer_flags(buffer), ConstantInt::get(i32, halide_buffer_dev_dirty), arg);
+            builder->CreateStore(nflags, buffer_flags_ptr(buffer));
             value = ConstantInt::get(i32, 0);
         } else if (op->name == Call::null_handle) {
             internal_assert(op->args.size() == 0) << "null_handle takes no arguments\n";
@@ -3125,6 +3105,24 @@ Value *CodeGen_LLVM::concat_vectors(const vector<Value *> &v) {
     }
 
     return vecs[0];
+}
+
+llvm::Value *CodeGen_LLVM::set_bit_mask(llvm::Value *value, llvm::Value *mask, llvm::Value *flag) {
+    internal_assert(value->getType() == mask->getType());
+    internal_assert(value->getType()->isIntegerTy());
+    internal_assert(flag->getType()->isIntegerTy());
+    // Use the classic bit-twiddling hack to avoid a branch:
+    //     value = (value & ~mask) | (-flag & mask)
+    // this requires that flag is exactly 0 or 1, so also do:
+    //     flag = flag != 0 ? 1 : 0
+    Value *cmp = builder->CreateICmpNE(flag, ConstantInt::get(flag->getType(), 0));
+    flag = builder->CreateSelect(cmp,
+        ConstantInt::get(value->getType(), 1),
+        ConstantInt::get(value->getType(), 0));
+
+    Value *clr = builder->CreateAnd(value, builder->CreateNot(mask));
+    Value *set = builder->CreateAnd(builder->CreateNeg(flag), mask);
+    return builder->CreateOr(clr, set);
 }
 
 std::pair<llvm::Function *, int> CodeGen_LLVM::find_vector_runtime_function(const std::string &name, int width) {

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -224,16 +224,14 @@ protected:
     // @{
     llvm::Value *buffer_host(llvm::Value *);
     llvm::Value *buffer_dev(llvm::Value *);
-    llvm::Value *buffer_host_dirty(llvm::Value *);
-    llvm::Value *buffer_dev_dirty(llvm::Value *);
+    llvm::Value *buffer_flags(llvm::Value *);
     llvm::Value *buffer_min(llvm::Value *, int);
     llvm::Value *buffer_extent(llvm::Value *, int);
     llvm::Value *buffer_stride(llvm::Value *, int);
     llvm::Value *buffer_elem_size(llvm::Value *);
     llvm::Value *buffer_host_ptr(llvm::Value *);
     llvm::Value *buffer_dev_ptr(llvm::Value *);
-    llvm::Value *buffer_host_dirty_ptr(llvm::Value *);
-    llvm::Value *buffer_dev_dirty_ptr(llvm::Value *);
+    llvm::Value *buffer_flags_ptr(llvm::Value *);
     llvm::Value *buffer_min_ptr(llvm::Value *, int);
     llvm::Value *buffer_extent_ptr(llvm::Value *, int);
     llvm::Value *buffer_stride_ptr(llvm::Value *, int);
@@ -359,6 +357,11 @@ protected:
 
     /** Concatenate a bunch of llvm vectors. Must be of the same type. */
     llvm::Value *concat_vectors(const std::vector<llvm::Value *> &);
+
+    /** Perform if (flag) value |= mask; else value &= ~mask.
+     * Flag can be any integral type.
+     * value and mask must be identical integral types. */
+    llvm::Value *set_bit_mask(llvm::Value *value, llvm::Value *mask, llvm::Value *flag);
 
     /** Go looking for a vector version of a runtime function. Will
      * return the best match. Matches in the following order:

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -484,6 +484,15 @@ typedef struct buffer_t {
     void* _unused;
 } buffer_t;
 
+#endif
+
+#if defined(__cplusplus) && (__cplusplus > 199711L || _MSC_VER >= 1800)
+// Let's assert specific size expectations, because disagreement
+// between caller and callee produces suboptimal results.
+static_assert(sizeof(buffer_t) == (sizeof(void*) == 4 ? 72 : 80),
+              "sizeof(buffer_t) is incorrect");
+#endif
+
 enum halide_buffer_flag_bits_t {
     /** This should be true if there is an existing device allocation
     * mirroring this buffer, and the data has been modified on the
@@ -496,17 +505,27 @@ enum halide_buffer_flag_bits_t {
     halide_buffer_dev_dirty = (1 << 1)
 };
 
-#endif
-
-inline bool halide_get_buffer_flag(const buffer_t* buf, halide_buffer_flag_bits_t flag) {
-    return (buf->flags & flag) != 0;
+inline bool halide_buffer_get_host_dirty(const buffer_t* buf) {
+    return (buf->flags & halide_buffer_host_dirty) != 0;
 }
 
-inline void halide_set_buffer_flag(buffer_t* buf, halide_buffer_flag_bits_t flag, bool set) {
+inline bool halide_buffer_get_dev_dirty(const buffer_t* buf) {
+    return (buf->flags & halide_buffer_dev_dirty) != 0;
+}
+
+inline void halide_buffer_set_host_dirty(buffer_t* buf, bool set) {
     if (set) {
-        buf->flags |= flag;
+        buf->flags |= halide_buffer_host_dirty;
     } else {
-        buf->flags &= ~flag;
+        buf->flags &= ~halide_buffer_host_dirty;
+    }
+}
+
+inline void halide_buffer_set_dev_dirty(buffer_t* buf, bool set) {
+    if (set) {
+        buf->flags |= halide_buffer_dev_dirty;
+    } else {
+        buf->flags &= ~halide_buffer_dev_dirty;
     }
 }
 

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -499,10 +499,11 @@ inline bool halide_get_buffer_flag(const buffer_t* buf, halide_buffer_flag_bits_
 }
 
 inline void halide_set_buffer_flag(buffer_t* buf, halide_buffer_flag_bits_t flag, bool set) {
-    if (set)
+    if (set) {
         buf->flags |= flag;
-    else
+    } else {
         buf->flags &= ~flag;
+    }
 }
 
 /** halide_scalar_value_t is a simple union able to represent all the well-known

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -309,7 +309,6 @@ typedef enum halide_type_code_t {
  * Halide code. It includes some stuff to track whether the image is
  * not actually in main memory, but instead on a device (like a
  * GPU). */
-#pragma pack(push, 1)
 typedef struct buffer_t {
     /** A device-handle for e.g. GPU memory used to back this buffer. */
     uint64_t dev;
@@ -338,21 +337,36 @@ typedef struct buffer_t {
     * replaced with a more general type code in the future. */
     int32_t elem_size;
 
+    /**
+    * Flag bits from halide_buffer_flag_bits_t.
+    */
+    int32_t flags;
+} buffer_t;
+
+enum halide_buffer_flag_bits_t {
     /** This should be true if there is an existing device allocation
     * mirroring this buffer, and the data has been modified on the
     * host side. */
-    bool host_dirty;
+    halide_buffer_host_dirty = (1 << 0),
 
     /** This should be true if there is an existing device allocation
     mirroring this buffer, and the data has been modified on the
     device side. */
-    bool dev_dirty;
-
-    uint8_t _padding[2];
-} buffer_t;
-#pragma pack(pop)
+    halide_buffer_dev_dirty = (1 << 1)
+};
 
 #endif
+
+inline bool halide_get_buffer_flag(const buffer_t* buf, halide_buffer_flag_bits_t flag) {
+    return (buf->flags & flag) != 0;
+}
+
+inline void halide_set_buffer_flag(buffer_t* buf, halide_buffer_flag_bits_t flag, bool set) {
+    if (set)
+        buf->flags |= flag;
+    else
+        buf->flags &= ~flag;
+}
 
 /** halide_scalar_value_t is a simple union able to represent all the well-known
  * scalar values in a filter argument. Note that it isn't tagged with a type;

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -478,6 +478,10 @@ typedef struct buffer_t {
     * Flag bits from halide_buffer_flag_bits_t.
     */
     int32_t flags;
+
+    /** An unused field, used to ensure that the struct is an even multiple
+     * of 64 bits on 32-bit systems. */
+    void* _unused;
 } buffer_t;
 
 enum halide_buffer_flag_bits_t {

--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -28,10 +28,10 @@ WEAK halide_mutex device_copy_mutex;
 WEAK int copy_to_host_already_locked(void *user_context, struct buffer_t *buf) {
     int result = 0;
 
-    if (halide_get_buffer_flag(buf, halide_buffer_dev_dirty)) {
+    if (halide_buffer_get_dev_dirty(buf)) {
         debug(user_context) << "copy_to_host_already_locked " << buf << " dev_dirty is true\n";
         const halide_device_interface *interface = halide_get_device_interface(buf->dev);
-        if (halide_get_buffer_flag(buf, halide_buffer_host_dirty)) {
+        if (halide_buffer_get_host_dirty(buf)) {
             debug(user_context) << "copy_to_host_already_locked " << buf << " dev_dirty and host_dirty are true\n";
             result = halide_error_code_copy_to_host_failed;
         } else if (interface == NULL) {
@@ -40,7 +40,7 @@ WEAK int copy_to_host_already_locked(void *user_context, struct buffer_t *buf) {
         } else {
             result = interface->copy_to_host(user_context, buf);
             if (result == 0) {
-                halide_set_buffer_flag(buf, halide_buffer_dev_dirty, false);
+                halide_buffer_set_dev_dirty(buf, false);
             } else {
                 debug(user_context) << "copy_to_host_already_locked " << buf << " device copy_to_host returned an error\n";
                 result = halide_error_code_copy_to_host_failed;
@@ -120,7 +120,13 @@ WEAK int halide_copy_to_device(void *user_context, struct buffer_t *buf, const h
 
     ScopedMutexLock lock(&device_copy_mutex);
 
-    debug(user_context) << "halide_copy_to_device " << buf << ", host: " << buf->host << ", dev: " << buf->dev << ", host_dirty: " << halide_get_buffer_flag(buf, halide_buffer_host_dirty) << ", dev_dirty:" << halide_get_buffer_flag(buf, halide_buffer_dev_dirty) << "\n";
+    debug(user_context) << "halide_copy_to_device " << buf
+                        << ", host: " << buf->host
+                        << ", dev: " << buf->dev
+                        << ", host_dirty: "
+                        << halide_buffer_get_host_dirty(buf)
+                        << ", dev_dirty:" << halide_buffer_get_dev_dirty(buf)
+                        << "\n";
     const halide_device_interface *buf_dev_interface = halide_get_device_interface(buf->dev);
     if (interface == NULL) {
         debug(user_context) << "halide_copy_to_device " << buf << " interface is NULL\n";
@@ -133,8 +139,8 @@ WEAK int halide_copy_to_device(void *user_context, struct buffer_t *buf, const h
 
     if (buf->dev && buf_dev_interface != interface) {
         debug(user_context) << "halide_copy_to_device " << buf << " flipping buffer to new device\n";
-        if (buf_dev_interface != NULL && halide_get_buffer_flag(buf, halide_buffer_dev_dirty)) {
-            halide_assert(user_context, !halide_get_buffer_flag(buf, halide_buffer_host_dirty));
+        if (buf_dev_interface != NULL && halide_buffer_get_dev_dirty(buf)) {
+            halide_assert(user_context, !halide_buffer_get_host_dirty(buf));
             result = copy_to_host_already_locked(user_context, buf);
             if (result != 0) {
                 debug(user_context) << "halide_copy_to_device " << buf << " flipping buffer halide_copy_to_host failed\n";
@@ -146,7 +152,7 @@ WEAK int halide_copy_to_device(void *user_context, struct buffer_t *buf, const h
             debug(user_context) << "halide_copy_to_device " << buf << " flipping buffer halide_device_free failed\n";
             return result;
         }
-        halide_set_buffer_flag(buf, halide_buffer_host_dirty, true);  // force copy back to new device below.
+        halide_buffer_set_host_dirty(buf, true);  // force copy back to new device below.
     }
 
     if (buf->dev == 0) {
@@ -158,15 +164,15 @@ WEAK int halide_copy_to_device(void *user_context, struct buffer_t *buf, const h
         }
     }
 
-    if (halide_get_buffer_flag(buf, halide_buffer_host_dirty)) {
+    if (halide_buffer_get_host_dirty(buf)) {
         debug(user_context) << "halide_copy_to_device " << buf << " host is dirty\n";
-        if (halide_get_buffer_flag(buf, halide_buffer_dev_dirty)) {
+        if (halide_buffer_get_dev_dirty(buf)) {
             debug(user_context) << "halide_copy_to_device " << buf << " dev_dirty is true error\n";
             result = halide_error_code_copy_to_device_failed;
         } else {
             result = interface->copy_to_device(user_context, buf);
             if (result == 0) {
-                halide_set_buffer_flag(buf, halide_buffer_host_dirty, false);
+                halide_buffer_set_host_dirty(buf, false);
             } else {
                 debug(user_context) << "halide_copy_to_device "
                                     << buf << "device copy_to_device returned an error\n";
@@ -204,8 +210,8 @@ WEAK int halide_device_malloc(void *user_context, struct buffer_t *buf, const ha
                         << " interface " << interface
                         << " host: " << buf->host
                         << ", dev: " << buf->dev
-                        << ", host_dirty: " << halide_get_buffer_flag(buf, halide_buffer_host_dirty)
-                        << ", dev_dirty:" << halide_get_buffer_flag(buf, halide_buffer_dev_dirty)
+                        << ", host_dirty: " << halide_buffer_get_host_dirty(buf)
+                        << ", dev_dirty:" << halide_buffer_get_dev_dirty(buf)
                         << " buf current interface: " << current_interface << "\n";
 
     // halide_device_malloc does not support switching interfaces.
@@ -252,7 +258,7 @@ WEAK int halide_device_free(void *user_context, struct buffer_t *buf) {
             }
         }
     }
-    halide_set_buffer_flag(buf, halide_buffer_dev_dirty, false);
+    halide_buffer_set_dev_dirty(buf, false);
     return 0;
 }
 

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -245,8 +245,8 @@ WEAK void debug_buffer(void *user_context, buffer_t *buf) {
         << "  min: " << buf->min[0] << " " << buf->min[1]
         << " " << buf->min[2] << " " << buf->min[3] <<  "\n"
         << "  elem_size: " << buf->elem_size << "\n"
-        << "  host_dirty: " << buf->host_dirty << "\n"
-        << "  dev_dirty: " << buf->dev_dirty << "\n";
+        << "  host_dirty: " << halide_get_buffer_flag(buf, halide_buffer_host_dirty) << "\n"
+        << "  dev_dirty: " << halide_get_buffer_flag(buf, halide_buffer_dev_dirty) << "\n";
 }
 
 WEAK GLuint make_shader(void *user_context, GLenum type,

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -245,8 +245,8 @@ WEAK void debug_buffer(void *user_context, buffer_t *buf) {
         << "  min: " << buf->min[0] << " " << buf->min[1]
         << " " << buf->min[2] << " " << buf->min[3] <<  "\n"
         << "  elem_size: " << buf->elem_size << "\n"
-        << "  host_dirty: " << halide_get_buffer_flag(buf, halide_buffer_host_dirty) << "\n"
-        << "  dev_dirty: " << halide_get_buffer_flag(buf, halide_buffer_dev_dirty) << "\n";
+        << "  host_dirty: " << halide_buffer_get_host_dirty(buf) << "\n"
+        << "  dev_dirty: " << halide_buffer_get_dev_dirty(buf) << "\n";
 }
 
 WEAK GLuint make_shader(void *user_context, GLenum type,

--- a/test/correctness/many_small_extern_stages.cpp
+++ b/test/correctness/many_small_extern_stages.cpp
@@ -23,8 +23,8 @@ extern "C" DLLEXPORT int copy(buffer_t *in, buffer_t *out) {
         (*in) = (*out);
         in->host = NULL;
         in->dev = 0;
-        in->host_dirty = false;
-        in->dev_dirty = false;
+        halide_set_buffer_flag(in, halide_buffer_host_dirty, false);
+        halide_set_buffer_flag(in, halide_buffer_dev_dirty, false);
     } else {
         // Check the sizes and strides match. This is not guaranteed
         // by the interface, but it should happen with this schedule

--- a/test/correctness/many_small_extern_stages.cpp
+++ b/test/correctness/many_small_extern_stages.cpp
@@ -23,8 +23,8 @@ extern "C" DLLEXPORT int copy(buffer_t *in, buffer_t *out) {
         (*in) = (*out);
         in->host = NULL;
         in->dev = 0;
-        halide_set_buffer_flag(in, halide_buffer_host_dirty, false);
-        halide_set_buffer_flag(in, halide_buffer_dev_dirty, false);
+        halide_buffer_set_host_dirty(in, false);
+        halide_buffer_set_dev_dirty(in, false);
     } else {
         // Check the sizes and strides match. This is not guaranteed
         // by the interface, but it should happen with this schedule

--- a/test/generator/extended_buffer_t_common.h
+++ b/test/generator/extended_buffer_t_common.h
@@ -1,21 +1,7 @@
 #ifndef EXTENDED_BUFFER_T_COMMON_H
 #define EXTENDED_BUFFER_T_COMMON_H
 
-#ifndef BUFFER_T_DEFINED
-#define BUFFER_T_DEFINED
-#include <stdint.h>
-typedef struct buffer_t {
-    uint64_t dev;
-    uint8_t* host;
-    int32_t extent[4];
-    int32_t stride[4];
-    int32_t min[4];
-    int32_t elem_size;
-    bool host_dirty;
-    bool dev_dirty;
-} buffer_t;
-#endif
-
+#include "HalideRuntime.h"
 
 // A struct that extends buffer_t with an extra field
 struct fancy_buffer_t : public buffer_t {

--- a/tutorial/lesson_10_aot_compilation_run.cpp
+++ b/tutorial/lesson_10_aot_compilation_run.cpp
@@ -23,15 +23,14 @@ int main(int argc, char **argv) {
     //     int32_t stride[4];
     //     int32_t min[4];
     //     int32_t elem_size;
-    //     bool host_dirty;
-    //     bool dev_dirty;
+    //     int32_t flags;
     // } buffer_t;
     //
     // This is how Halide represents input and output images in
     // pre-compiled pipelines. There's a 'host' pointer that points to the
     // start of the image data, some fields that describe how to access
     // pixels, and some fields related to using the GPU that we'll ignore
-    // for now (dev, host_dirty, dev_dirty).
+    // for now (dev, flags).
 
     // Let's make some input data to test with:
     uint8_t input[640 * 480];


### PR DESCRIPTION
Adding #pragma pack turned out to have an unpleasant side effect: it
removed the alignment restriction on the entire buffer_t struct. On
some platforms this can cause misaligned loads. Let’s avoid this
entirely by replacing the fields at the end with an int32 bit mask.

(Also remove a few more rogue definitions of buffer_t.)