### PR TITLE
Require C++11 and LLVM3.5+ (Issue #741)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,16 +21,16 @@ LLVM_BINDIR = $(shell $(LLVM_CONFIG) --bindir)
 LLVM_LIBDIR = $(shell $(LLVM_CONFIG) --libdir)
 LLVM_AS = $(LLVM_BINDIR)/llvm-as
 LLVM_NM = $(LLVM_BINDIR)/llvm-nm
-LLVM_CXX_FLAGS = $(filter-out -O% -g -fomit-frame-pointer -pedantic -Wcovered-switch-default, $(shell $(LLVM_CONFIG) --cxxflags))
+LLVM_CXX_FLAGS = -std=c++11  $(filter-out -O% -g -fomit-frame-pointer -pedantic -Wcovered-switch-default, $(shell $(LLVM_CONFIG) --cxxflags))
 OPTIMIZE ?= -O3
 # This can be set to -m32 to get a 32-bit build of Halide on a 64-bit system.
 # (Normally this can be done via pointing to a compiler that defaults to 32-bits,
 #  but that is difficult in some testing situations because it requires having
 #  such a compiler handy. One still needs to have 32-bit llvm libraries, etc.)
 BUILD_BIT_SIZE ?=
-TEST_CXX_FLAGS ?= $(BUILD_BIT_SIZE) -g -fno-omit-frame-pointer -fno-rtti $(CXX_WARNING_FLAGS)
+TEST_CXX_FLAGS ?= -std=c++11 $(BUILD_BIT_SIZE) -g -fno-omit-frame-pointer -fno-rtti $(CXX_WARNING_FLAGS)
 # The tutorials contain example code with warnings that we don't want to be flagged as errors.
-TUTORIAL_CXX_FLAGS ?= $(BUILD_BIT_SIZE) -g -fno-omit-frame-pointer -fno-rtti
+TUTORIAL_CXX_FLAGS ?= -std=c++11 $(BUILD_BIT_SIZE) -g -fno-omit-frame-pointer -fno-rtti
 GENGEN_DEPS ?=$(BIN_DIR)/libHalide.so include/Halide.h tools/GenGen.cpp
 
 LLVM_VERSION_TIMES_10 = $(shell $(LLVM_CONFIG) --version | cut -b 1,3)
@@ -54,19 +54,6 @@ WITH_EXCEPTIONS ?=
 # If HL_TARGET or HL_JIT_TARGET aren't set, use host
 HL_TARGET ?= host
 HL_JIT_TARGET ?= host
-
-# turn off PTX for llvm 3.2
-ifneq ($(LLVM_VERSION), 3.2)
-WITH_PTX ?= $(findstring nvptx, $(LLVM_COMPONENTS))
-endif
-
-# turn on c++11 for llvm 3.5+
-CXX11 ?= $(findstring $(LLVM_VERSION_TIMES_10), 35 36 37 38 39 40)
-
-ifneq ($(CXX11),)
-LLVM_CXX_FLAGS += -std=c++11
-TEST_CXX_FLAGS += -std=c++11
-endif
 
 NATIVE_CLIENT_CXX_FLAGS = $(if $(WITH_NATIVE_CLIENT), -DWITH_NATIVE_CLIENT=1, )
 NATIVE_CLIENT_LLVM_CONFIG_LIB = $(if $(WITH_NATIVE_CLIENT), nacltransforms, )
@@ -612,28 +599,16 @@ test_warnings: $(WARNING_TESTS:test/warning/%.cpp=warning_%)
 test_tutorials: $(TUTORIALS:tutorial/%.cpp=tutorial_%)
 test_valgrind: $(CORRECTNESS_TESTS:test/correctness/%.cpp=valgrind_%)
 test_opengl: $(OPENGL_TESTS:test/opengl/%.cpp=opengl_%)
-ifneq ($(CXX11),)
 test_generators: $(GENERATOR_TESTS:test/generator/%_aottest.cpp=generator_aot_%) $(GENERATOR_TESTS:test/generator/%_jittest.cpp=generator_jit_%)
-else
-test_generators: ;
-endif
 
-ALL_TESTS = test_internal test_correctness test_errors test_tutorials test_warnings
-
-ifneq ($(CXX11),)
-ALL_TESTS += test_generators
-endif
+ALL_TESTS = test_internal test_correctness test_errors test_tutorials test_warnings test_generators
 
 # These targets perform timings of each test. For most tests this includes Halide JIT compile times, and run times.
 # For static and generator tests they time the compile time only. The times are recorded in CSV files.
 time_compilation_correctness: init_time_compilation_correctness $(CORRECTNESS_TESTS:test/correctness/%.cpp=time_compilation_test_%)
 time_compilation_performance: init_time_compilation_performance $(PERFORMANCE_TESTS:test/performance/%.cpp=time_compilation_performance_%)
 time_compilation_opengl: init_time_compilation_opengl $(OPENGL_TESTS:test/opengl/%.cpp=time_compilation_opengl_%)
-ifneq ($(CXX11),)
 time_compilation_generators: init_time_compilation_generator $(GENERATOR_TESTS:test/generator/%_aottest.cpp=time_compilation_generator_%)
-else
-time_compilation_generators: ;
-endif
 
 init_time_compilation_%:
 	echo "TEST,User (s),System (s),Real" > $(@:init_time_compilation_%=compile_times_%.csv)

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -2,7 +2,7 @@ CXX ?= g++
 GXX ?= g++
 
 CFLAGS += -I../../include/ -I../support/
-CXXFLAGS += -I../../include/ -I../support/
+CXXFLAGS += -std=c++11 -I../../include/ -I../support/
 
 ifdef BUILD_PREFIX
 LIB_HALIDE = bin/$(BUILD_PREFIX)/libHalide.a
@@ -12,12 +12,7 @@ endif
 
 LLVM_CONFIG ?= llvm-config
 LLVM_VERSION_TIMES_10 = $(shell $(LLVM_CONFIG) --version | cut -b 1,3)
-LLVM_34_OR_OLDER = $(findstring $(LLVM_VERSION_TIMES_10), 32 33 34)
-ifneq ($(LLVM_34_OR_OLDER), )
-LLVM_LDFLAGS = $(shell $(LLVM_CONFIG) --ldflags)
-else
 LLVM_LDFLAGS = $(shell $(LLVM_CONFIG) --ldflags --system-libs)
-endif
 
 LLVM_CONFIG ?= llvm-config
 LLVM_FULL_VERSION = $(shell $(LLVM_CONFIG) --version)

--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -51,8 +51,6 @@ namespace BoundaryConditions {
 
 namespace Internal {
 
-#if __cplusplus > 199711L // C++11 arbitrary number of args support
-
 inline NO_INLINE void collect_bounds(std::vector<std::pair<Expr, Expr> > &collected_bounds,
                                      Expr min, Expr extent) {
     collected_bounds.push_back(std::make_pair(min, extent));
@@ -64,8 +62,6 @@ inline NO_INLINE void collect_bounds(std::vector<std::pair<Expr, Expr> > &collec
     collected_bounds.push_back(std::make_pair(min, extent));
     collect_bounds(collected_bounds, bounds...);
 }
-
-#endif // C++11 support.
 
 inline const Func &func_like_to_func(const Func &func) {
     return func;
@@ -104,7 +100,6 @@ inline NO_INLINE Func constant_exterior(T func_like, Expr value) {
     return constant_exterior(Internal::func_like_to_func(func_like), value, object_bounds);
 }
 
-#if __cplusplus > 199711L // C++11 arbitrary number of args support
 template <typename T, typename ...Bounds>
 inline NO_INLINE Func constant_exterior(T func_like, Expr value,
                                         Bounds... bounds) {
@@ -112,85 +107,6 @@ inline NO_INLINE Func constant_exterior(T func_like, Expr value,
     Internal::collect_bounds(collected_bounds, bounds...);
     return constant_exterior(Internal::func_like_to_func(func_like), value, collected_bounds);
 }
-#else
-template <typename T>
-inline NO_INLINE Func constant_exterior(T func_like, Expr value,
-                                        Expr min0, Expr extent0) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    return constant_exterior(Internal::func_like_to_func(func_like), value, bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func constant_exterior(T func_like, Expr value,
-                                        Expr min0, Expr extent0,
-                                        Expr min1, Expr extent1) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    return constant_exterior(Internal::func_like_to_func(func_like), value, bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func constant_exterior(T func_like, Expr value,
-                                        Expr min0, Expr extent0,
-                                        Expr min1, Expr extent1,
-                                        Expr min2, Expr extent2) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    return constant_exterior(Internal::func_like_to_func(func_like), value, bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func constant_exterior(T func_like, Expr value,
-                                        Expr min0, Expr extent0,
-                                        Expr min1, Expr extent1,
-                                        Expr min2, Expr extent2,
-                                        Expr min3, Expr extent3) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    bounds.push_back(std::make_pair(min3, extent3));
-    return constant_exterior(Internal::func_like_to_func(func_like), value, bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func constant_exterior(T func_like, Expr value,
-                                        Expr min0, Expr extent0,
-                                        Expr min1, Expr extent1,
-                                        Expr min2, Expr extent2,
-                                        Expr min3, Expr extent3,
-                                        Expr min4, Expr extent4) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    bounds.push_back(std::make_pair(min3, extent3));
-    bounds.push_back(std::make_pair(min4, extent4));
-    return constant_exterior(Internal::func_like_to_func(func_like), value, bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func constant_exterior(T func_like, Expr value,
-                                        Expr min0, Expr extent0,
-                                        Expr min1, Expr extent1,
-                                        Expr min2, Expr extent2,
-                                        Expr min3, Expr extent3,
-                                        Expr min4, Expr extent4,
-                                        Expr min5, Expr extent5) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    bounds.push_back(std::make_pair(min3, extent3));
-    bounds.push_back(std::make_pair(min4, extent4));
-    bounds.push_back(std::make_pair(min5, extent5));
-    return constant_exterior(Internal::func_like_to_func(func_like), value, bounds);
-}
-#endif
 // @}
 
 /** Impose a boundary condition such that the nearest edge sample is returned
@@ -217,92 +133,12 @@ inline NO_INLINE Func repeat_edge(T func_like) {
 }
 
 
-#if __cplusplus > 199711L // C++11 arbitrary number of args support
 template <typename T, typename ...Bounds>
 inline NO_INLINE Func repeat_edge(T func_like, Bounds... bounds) {
     std::vector<std::pair<Expr, Expr> > collected_bounds;
     Internal::collect_bounds(collected_bounds, bounds...);
     return repeat_edge(Internal::func_like_to_func(func_like), collected_bounds);
 }
-#else
-template <typename T>
-inline NO_INLINE Func repeat_edge(T func_like,
-                                  Expr min0, Expr extent0) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    return repeat_edge(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func repeat_edge(T func_like,
-                                  Expr min0, Expr extent0,
-                                  Expr min1, Expr extent1) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    return repeat_edge(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func repeat_edge(T func_like,
-                                  Expr min0, Expr extent0,
-                                  Expr min1, Expr extent1,
-                                  Expr min2, Expr extent2) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    return repeat_edge(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func repeat_edge(T func_like,
-                                  Expr min0, Expr extent0,
-                                  Expr min1, Expr extent1,
-                                  Expr min2, Expr extent2,
-                                  Expr min3, Expr extent3) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    bounds.push_back(std::make_pair(min3, extent3));
-    return repeat_edge(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func repeat_edge(T func_like,
-                                  Expr min0, Expr extent0,
-                                  Expr min1, Expr extent1,
-                                  Expr min2, Expr extent2,
-                                  Expr min3, Expr extent3,
-                                  Expr min4, Expr extent4) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    bounds.push_back(std::make_pair(min3, extent3));
-    bounds.push_back(std::make_pair(min4, extent4));
-    return repeat_edge(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func repeat_edge(T func_like,
-                                  Expr min0, Expr extent0,
-                                  Expr min1, Expr extent1,
-                                  Expr min2, Expr extent2,
-                                  Expr min3, Expr extent3,
-                                  Expr min4, Expr extent4,
-                                  Expr min5, Expr extent5) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    bounds.push_back(std::make_pair(min3, extent3));
-    bounds.push_back(std::make_pair(min4, extent4));
-    bounds.push_back(std::make_pair(min5, extent5));
-    return repeat_edge(Internal::func_like_to_func(func_like), bounds);
-}
-#endif
 // @}
 
 /** Impose a boundary condition such that the entire coordinate space is
@@ -328,92 +164,12 @@ inline NO_INLINE Func repeat_image(T func_like) {
     return repeat_image(Internal::func_like_to_func(func_like), object_bounds);
 }
 
-#if __cplusplus > 199711L // C++11 arbitrary number of args support
 template <typename T, typename ...Bounds>
 inline NO_INLINE Func repeat_image(T func_like, Bounds... bounds) {
     std::vector<std::pair<Expr, Expr> > collected_bounds;
     Internal::collect_bounds(collected_bounds, bounds...);
     return repeat_image(Internal::func_like_to_func(func_like), collected_bounds);
 }
-#else
-template <typename T>
-inline NO_INLINE Func repeat_image(T func_like,
-                                   Expr min0, Expr extent0) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    return repeat_image(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func repeat_image(T func_like,
-                                   Expr min0, Expr extent0,
-                                   Expr min1, Expr extent1) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    return repeat_image(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func repeat_image(T func_like,
-                                   Expr min0, Expr extent0,
-                                   Expr min1, Expr extent1,
-                                   Expr min2, Expr extent2) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    return repeat_image(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func repeat_image(T func_like,
-                                   Expr min0, Expr extent0,
-                                   Expr min1, Expr extent1,
-                                   Expr min2, Expr extent2,
-                                   Expr min3, Expr extent3) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    bounds.push_back(std::make_pair(min3, extent3));
-    return repeat_image(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func repeat_image(T func_like,
-                                   Expr min0, Expr extent0,
-                                   Expr min1, Expr extent1,
-                                   Expr min2, Expr extent2,
-                                   Expr min3, Expr extent3,
-                                   Expr min4, Expr extent4) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    bounds.push_back(std::make_pair(min3, extent3));
-    bounds.push_back(std::make_pair(min4, extent4));
-    return repeat_image(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func repeat_image(T func_like,
-                                   Expr min0, Expr extent0,
-                                   Expr min1, Expr extent1,
-                                   Expr min2, Expr extent2,
-                                   Expr min3, Expr extent3,
-                                   Expr min4, Expr extent4,
-                                   Expr min5, Expr extent5) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    bounds.push_back(std::make_pair(min3, extent3));
-    bounds.push_back(std::make_pair(min4, extent4));
-    bounds.push_back(std::make_pair(min5, extent5));
-    return repeat_image(Internal::func_like_to_func(func_like), bounds);
-}
-#endif
 
 /** Impose a boundary condition such that the entire coordinate space is
  *  tiled with copies of the image abutted against each other, but mirror
@@ -439,92 +195,12 @@ inline NO_INLINE Func mirror_image(T func_like) {
     return mirror_image(Internal::func_like_to_func(func_like), object_bounds);
 }
 
-#if __cplusplus > 199711L // C++11 arbitrary number of args support
 template <typename T, typename ...Bounds>
 inline NO_INLINE Func mirror_image(T func_like, Bounds... bounds) {
     std::vector<std::pair<Expr, Expr> > collected_bounds;
     Internal::collect_bounds(collected_bounds, bounds...);
     return mirror_image(Internal::func_like_to_func(func_like), collected_bounds);
 }
-#else
-template <typename T>
-inline NO_INLINE Func mirror_image(T func_like,
-                                   Expr min0, Expr extent0) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    return mirror_image(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func mirror_image(T func_like,
-                                   Expr min0, Expr extent0,
-                                   Expr min1, Expr extent1) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    return mirror_image(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func mirror_image(T func_like,
-                                   Expr min0, Expr extent0,
-                                   Expr min1, Expr extent1,
-                                   Expr min2, Expr extent2) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    return mirror_image(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func mirror_image(T func_like,
-                                   Expr min0, Expr extent0,
-                                   Expr min1, Expr extent1,
-                                   Expr min2, Expr extent2,
-                                   Expr min3, Expr extent3) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    bounds.push_back(std::make_pair(min3, extent3));
-    return mirror_image(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func mirror_image(T func_like,
-                                   Expr min0, Expr extent0,
-                                   Expr min1, Expr extent1,
-                                   Expr min2, Expr extent2,
-                                   Expr min3, Expr extent3,
-                                   Expr min4, Expr extent4) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    bounds.push_back(std::make_pair(min3, extent3));
-    bounds.push_back(std::make_pair(min4, extent4));
-    return mirror_image(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func mirror_image(T func_like,
-                                   Expr min0, Expr extent0,
-                                   Expr min1, Expr extent1,
-                                   Expr min2, Expr extent2,
-                                   Expr min3, Expr extent3,
-                                   Expr min4, Expr extent4,
-                                   Expr min5, Expr extent5) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    bounds.push_back(std::make_pair(min3, extent3));
-    bounds.push_back(std::make_pair(min4, extent4));
-    bounds.push_back(std::make_pair(min5, extent5));
-    return mirror_image(Internal::func_like_to_func(func_like), bounds);
-}
-#endif
 // @}
 
 /** Impose a boundary condition such that the entire coordinate space is
@@ -553,92 +229,12 @@ inline NO_INLINE Func mirror_interior(T func_like) {
     return mirror_interior(Internal::func_like_to_func(func_like), object_bounds);
 }
 
-#if __cplusplus > 199711L // C++11 arbitrary number of args support
 template <typename T, typename ...Bounds>
 inline NO_INLINE Func mirror_interior(T func_like, Bounds... bounds) {
     std::vector<std::pair<Expr, Expr> > collected_bounds;
     Internal::collect_bounds(collected_bounds, bounds...);
     return mirror_interior(Internal::func_like_to_func(func_like), collected_bounds);
 }
-#else
-template <typename T>
-inline NO_INLINE Func mirror_interior(T func_like,
-                                      Expr min0, Expr extent0) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    return mirror_interior(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func mirror_interior(T func_like,
-                                      Expr min0, Expr extent0,
-                                      Expr min1, Expr extent1) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    return mirror_interior(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func mirror_interior(T func_like,
-                                      Expr min0, Expr extent0,
-                                      Expr min1, Expr extent1,
-                                      Expr min2, Expr extent2) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    return mirror_interior(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func mirror_interior(T func_like,
-                                      Expr min0, Expr extent0,
-                                      Expr min1, Expr extent1,
-                                      Expr min2, Expr extent2,
-                                      Expr min3, Expr extent3) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    bounds.push_back(std::make_pair(min3, extent3));
-    return mirror_interior(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func mirror_interior(T func_like,
-                                      Expr min0, Expr extent0,
-                                      Expr min1, Expr extent1,
-                                      Expr min2, Expr extent2,
-                                      Expr min3, Expr extent3,
-                                      Expr min4, Expr extent4) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    bounds.push_back(std::make_pair(min3, extent3));
-    bounds.push_back(std::make_pair(min4, extent4));
-    return mirror_interior(Internal::func_like_to_func(func_like), bounds);
-}
-
-template <typename T>
-inline NO_INLINE Func mirror_interior(T func_like,
-                                      Expr min0, Expr extent0,
-                                      Expr min1, Expr extent1,
-                                      Expr min2, Expr extent2,
-                                      Expr min3, Expr extent3,
-                                      Expr min4, Expr extent4,
-                                      Expr min5, Expr extent5) {
-    std::vector<std::pair<Expr, Expr> > bounds;
-    bounds.push_back(std::make_pair(min0, extent0));
-    bounds.push_back(std::make_pair(min1, extent1));
-    bounds.push_back(std::make_pair(min2, extent2));
-    bounds.push_back(std::make_pair(min3, extent3));
-    bounds.push_back(std::make_pair(min4, extent4));
-    bounds.push_back(std::make_pair(min5, extent5));
-    return mirror_interior(Internal::func_like_to_func(func_like), bounds);
-}
-#endif
 // @}
 
 }

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -20,6 +20,14 @@
 #include "CodeGen_MIPS.h"
 #include "CodeGen_PNaCl.h"
 
+#if !(__cplusplus > 199711L || _MSC_VER >= 1800)
+
+// VS2013 isn't fully C++11 compatible, but it supports enough of what Halide
+// needs for now to be an acceptable minimum for Windows.
+#error "Halide requires C++11 or VS2013+; please upgrade your compiler."
+
+#endif
+
 namespace Halide {
 
 llvm::Module *codegen_llvm(const Module &module, llvm::LLVMContext &context) {

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -220,7 +220,6 @@ struct ExprCompare {
 
 /** An enum describing a type of device API. Used by schedules, and in
  * the For loop IR node. */
-#if __cplusplus > 199711L // C++11 strongly typed enum
 enum class DeviceAPI {
     Parent, /// Used to denote for loops that inherit their device from where they are used, generally the default
     Host,
@@ -229,48 +228,17 @@ enum class DeviceAPI {
     OpenCL,
     GLSL
 };
-#else
-struct DeviceAPI {
-    enum Values {
-        Parent, /// Used to denote for loops that inherit their device from where they are used, generally the default
-        Host,
-        Default_GPU,
-        CUDA,
-        OpenCL,
-        GLSL
-    };
-    int val;
-    DeviceAPI() : val(Parent) { }
-    DeviceAPI(int val) : val(val) { }
-    operator int() const { return val; }
-};
-#endif
 
 namespace Internal {
 
 /** An enum describing a type of loop traversal. Used in schedules,
  * and in the For loop IR node. */
-#if __cplusplus > 199711L // C++11 strongly typed enum
 enum class ForType {
     Serial,
     Parallel,
     Vectorized,
     Unrolled
 };
-#else
-struct ForType {
-    enum Values {
-        Serial,
-        Parallel,
-        Vectorized,
-        Unrolled
-    };
-    int val;
-    ForType() : val(Serial) { }
-    ForType(int val) : val(val) { }
-    operator int() const { return val; }
-};
-#endif
 
 
 /** A reference-counted handle to a statement node. */

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1,6 +1,3 @@
-// Generator requires C++11
-#if __cplusplus > 199711L || _MSC_VER >= 1800
-
 #include "Generator.h"
 
 namespace {
@@ -334,5 +331,3 @@ Func GeneratorBase::call_extern_by_name(const std::string &generator_name,
 
 }  // namespace Internal
 }  // namespace Halide
-
-#endif  // __cplusplus > 199711L

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -80,9 +80,6 @@
  * methods provided in Target.h)
  */
 
-// Generator requires C++11
-#if __cplusplus > 199711L || _MSC_VER >= 1800
-
 #include <limits>
 #include <memory>
 #include <mutex>
@@ -537,7 +534,5 @@ public:
 };
 
 }  // namespace Halide
-
-#endif  // __cplusplus > 199711L
 
 #endif  // HALIDE_GENERATOR_H_

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -1,9 +1,6 @@
 #include <string>
 #include <stdint.h>
-
-#if __cplusplus > 199711L || _MSC_VER >= 1800
 #include <mutex>
-#endif
 
 #include "JITModule.h"
 #include "LLVM_Headers.h"
@@ -662,9 +659,7 @@ void adjust_module_ref_count(void *arg, int32_t count) {
     }
 }
 
-#if __cplusplus > 199711L || _MSC_VER >= 1800
 std::mutex shared_runtimes_mutex;
-#endif
 
 // The Halide runtime is broken up into pieces so that state can be
 // shared across JIT compilations that do not use the same target
@@ -802,9 +797,7 @@ JITModule &make_module(llvm::Module *for_module, Target target,
  * JITSharedRuntime::release_all is called, the global state is rest
  * and any newly compiled Funcs will get a new runtime. */
 std::vector<JITModule> JITSharedRuntime::get(llvm::Module *for_module, const Target &target, bool create) {
-    #if __cplusplus > 199711L || _MSC_VER >= 1800
     std::lock_guard<std::mutex> lock(shared_runtimes_mutex);
-    #endif
 
     std::vector<JITModule> result;
 
@@ -846,9 +839,7 @@ void JITSharedRuntime::init_jit_user_context(JITUserContext &jit_user_context,
 }
 
 void JITSharedRuntime::release_all() {
-    #if __cplusplus > 199711L || _MSC_VER >= 1800
     std::lock_guard<std::mutex> lock(shared_runtimes_mutex);
-    #endif
 
     for (int i = MaxRuntimeKind; i > 0; i--) {
         shared_runtimes((RuntimeKind)(i - 1)) = JITModule();
@@ -864,9 +855,7 @@ JITHandlers JITSharedRuntime::set_default_handlers(const JITHandlers &handlers) 
 }
 
 void JITSharedRuntime::memoization_cache_set_size(int64_t size) {
-    #if __cplusplus > 199711L || _MSC_VER >= 1800
     std::lock_guard<std::mutex> lock(shared_runtimes_mutex);
-    #endif
 
     if (size != default_cache_size && shared_runtimes(MainShared).defined()) {
         default_cache_size = size;

--- a/src/ObjectInstanceRegistry.cpp
+++ b/src/ObjectInstanceRegistry.cpp
@@ -14,7 +14,6 @@ ObjectInstanceRegistry &ObjectInstanceRegistry::get_registry() {
 /* static */
 void ObjectInstanceRegistry::register_instance(void *this_ptr, size_t size, Kind kind,
                                                void *subject_ptr, const void *introspection_helper) {
-#if __cplusplus > 199711L || _MSC_VER >= 1800
     ObjectInstanceRegistry &registry = get_registry();
     std::lock_guard<std::mutex> lock(registry.mutex);
     uintptr_t key = (uintptr_t)this_ptr;
@@ -25,12 +24,10 @@ void ObjectInstanceRegistry::register_instance(void *this_ptr, size_t size, Kind
     } else {
         registry.instances[key] = InstanceInfo(size, kind, subject_ptr, false);
     }
-#endif
 }
 
 /* static */
 void ObjectInstanceRegistry::unregister_instance(void *this_ptr) {
-#if __cplusplus > 199711L || _MSC_VER >= 1800
     ObjectInstanceRegistry &registry = get_registry();
     std::lock_guard<std::mutex> lock(registry.mutex);
     uintptr_t key = (uintptr_t)this_ptr;
@@ -40,7 +37,6 @@ void ObjectInstanceRegistry::unregister_instance(void *this_ptr) {
         Introspection::deregister_heap_object(this_ptr, it->second.size);
     }
     registry.instances.erase(it);
-#endif
 }
 
 /* static */
@@ -48,7 +44,6 @@ std::vector<void *> ObjectInstanceRegistry::instances_in_range(void *start, size
                                                                Kind kind) {
     std::vector<void *> results;
 
-#if __cplusplus > 199711L || _MSC_VER >= 1800
     ObjectInstanceRegistry &registry = get_registry();
     std::lock_guard<std::mutex> lock(registry.mutex);
 
@@ -68,7 +63,6 @@ std::vector<void *> ObjectInstanceRegistry::instances_in_range(void *start, size
             it++;
         }
     }
-#endif
 
     return results;
 }

--- a/src/ObjectInstanceRegistry.h
+++ b/src/ObjectInstanceRegistry.h
@@ -13,9 +13,7 @@
 #include <stdint.h>
 
 #include <map>
-#if __cplusplus > 199711L || _MSC_VER >= 1800
 #include <mutex>
-#endif
 #include <vector>
 
 namespace Halide {
@@ -79,9 +77,7 @@ private:
             : subject_ptr(subject_ptr), size(size), kind(kind), registered_for_introspection(registered_for_introspection) {}
     };
 
-#if __cplusplus > 199711L || _MSC_VER >= 1800
     std::mutex mutex;
-#endif
     std::map<uintptr_t, InstanceInfo> instances;
 
     ObjectInstanceRegistry() {}

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -2031,7 +2031,6 @@ private:
             } else {
                 expr = abs(a);
             }
-#if __cplusplus > 199711L // C++11 comes with a portable isnan
         } else if (op->call_type == Call::Extern &&
                    op->name == "is_nan_f32") {
             Expr arg = mutate(op->args[0]);
@@ -2043,7 +2042,6 @@ private:
             } else {
                 expr = Call::make(op->type, op->name, vec(arg), op->call_type);
             }
-#endif
         } else if (op->call_type == Call::Intrinsic &&
                    op->name == Call::stringify) {
             // Eagerly concat constant arguments to a stringify.
@@ -2124,9 +2122,7 @@ private:
             if (const float *f = as_const_float(arg)) {
                 if (op->name == "floor_f32") expr = std::floor(*f);
                 else if (op->name == "ceil_f32") expr = std::ceil(*f);
-#if __cplusplus > 199711L
                 else if (op->name == "round_f32") expr = std::nearbyint(*f);
-#endif
                 else if (op->name == "trunc_f32") {
                     expr = (*f < 0 ? std::ceil(*f) : std::floor(*f));
                 }
@@ -2873,10 +2869,8 @@ void simplify_test() {
 
     check(floor(0.98f), 0.0f);
     check(ceil(0.98f), 1.0f);
-#if __cplusplus > 199711L
     check(round(0.6f), 1.0f);
     check(round(-0.5f), 0.0f);
-#endif
     check(trunc(-1.6f), -1.0f);
     check(floor(round(x)), round(x));
     check(ceil(ceil(x)), ceil(x));

--- a/test/generator/example_jittest.cpp
+++ b/test/generator/example_jittest.cpp
@@ -1,5 +1,3 @@
-#if __cplusplus > 199711L
-
 #include "Halide.h"
 
 // When using Generators to JIT, just include the Generator .cpp file.
@@ -86,14 +84,3 @@ int main(int argc, char **argv) {
     printf("Success!\n");
     return 0;
 }
-
-#else
-
-#include <stdio.h>
-
-int main(int argc, char **argv) {
-    printf("This test requires C++11\n");
-    return 0;
-}
-
-#endif

--- a/test/generator/paramtest_jittest.cpp
+++ b/test/generator/paramtest_jittest.cpp
@@ -1,5 +1,3 @@
-#if __cplusplus > 199711L
-
 #include "Halide.h"
 
 #include "paramtest_generator.cpp"
@@ -172,14 +170,3 @@ int main(int argc, char **argv) {
     printf("Success!\n");
     return 0;
 }
-
-#else
-
-#include <stdio.h>
-
-int main(int argc, char **argv) {
-    printf("This test requires C++11\n");
-    return 0;
-}
-
-#endif

--- a/test/scripts/test_target.sh
+++ b/test/scripts/test_target.sh
@@ -33,9 +33,6 @@ else
     export LIBPNG_CXX_FLAGS="-Itesting/deps -I../../testing/deps"
 fi
 
-# Turn on C++11
-export CXX11=true
-
 echo Testing target $HL_TARGET with llvm $LLVM
 echo Using LD = $LD
 echo Using CC = $CC


### PR DESCRIPTION
Remove all ifdef’s that conditionalize C++11 usage; remove all makefile
directives that conditionalize C++11 features. Remove makfile code for
supporting LLVM prior to 3.5.