### PR TITLE
Add a debugging GeneratorParam to all Generators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -675,7 +675,7 @@ $(FILTERS_DIR)/metadata_tester.o $(FILTERS_DIR)/metadata_tester.h: $(FILTERS_DIR
 
 $(FILTERS_DIR)/metadata_tester_ucon.o $(FILTERS_DIR)/metadata_tester_ucon.h: $(FILTERS_DIR)/metadata_tester.generator
 	@-mkdir -p tmp
-	cd tmp; $(LD_PATH_SETUP) ../$< -f metadata_tester_ucon -o ../$(FILTERS_DIR) target=$(HL_TARGET)-user_context-register_metadata
+	cd tmp; $(LD_PATH_SETUP) ../$< -f metadata_tester_ucon -o ../$(FILTERS_DIR) target=$(HL_TARGET)-user_context-register_metadata debug=all
 
 $(BIN_DIR)/generator_aot_metadata_tester: $(FILTERS_DIR)/metadata_tester_ucon.o
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -329,5 +329,15 @@ Func GeneratorBase::call_extern_by_name(const std::string &generator_name,
     return extern_gen->call_extern(function_arguments, function_name);
 }
 
+const std::map<std::string, GeneratorBase::DebugLevel> &GeneratorBase::get_halide_debug_enum_map() {
+    static const std::map<std::string, GeneratorBase::DebugLevel> m{
+        {"none", DebugLevel::none},
+        {"some", DebugLevel::some},
+        {"lots", DebugLevel::lots},
+        {"all", DebugLevel::all}
+    };
+    return m;
+}
+
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -366,6 +366,19 @@ class GeneratorBase : public NamesInterface {
 public:
     GeneratorParam<Target> target{ "target", Halide::get_host_target() };
 
+    /** Possible values for the Generator's "debug" GeneratorParam.
+     * This always defaults to "none", so you can embed debugging code
+     * (e.g. calls to print_when() or debug_to_file()) without any degradation
+     * by default. The enum has four levels by default, with the usage
+     * deliberately fuzzy, but with the intention that "none" means all debugging
+     * information should be omitted, and "all" means, well, everything. */
+    enum class DebugLevel {
+        none,
+        some,
+        lots,
+        all
+    };
+
     struct EmitOptions {
         bool emit_o, emit_h, emit_cpp, emit_assembly, emit_bitcode, emit_stmt, emit_stmt_html;
         EmitOptions()
@@ -434,6 +447,8 @@ public:
 protected:
     EXPORT GeneratorBase(size_t size, const void *introspection_helper);
 
+    EXPORT static const std::map<std::string, DebugLevel> &get_halide_debug_enum_map();
+
 private:
     const size_t size;
 
@@ -494,6 +509,8 @@ template <class T> class RegisterGenerator;
 
 template <class T> class Generator : public Internal::GeneratorBase {
 public:
+    GeneratorParam<DebugLevel> debug{"debug", DebugLevel::none, get_halide_debug_enum_map()};
+
     Generator() :
         Internal::GeneratorBase(sizeof(T),
                                 Internal::Introspection::get_introspection_helper<T>()) {}
@@ -508,8 +525,6 @@ private:
     const std::string &generator_name() const override final {
         return *generator_name_storage();
     }
-
-
 };
 
 template <class T> class RegisterGenerator {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -156,7 +156,7 @@ if (WITH_TEST_GENERATORS)
                                "generator_${GEN_NAME}"
                                "${GEN_NAME}"
                                "${FUNC_NAME}_ucon"
-                               "target=host-register_metadata-user_context")
+                               "target=host-register_metadata-user_context debug=all")
     else()
       # All the other foo_test.cpp just depend on foo_generator.cpp
       halide_add_generator_dependency("${TEST_RUNNER}"

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -428,6 +428,12 @@ int EnumerateFunc(void* enumerate_context,
   return 0;
 }
 
+static bool halide_print_called = false;
+extern "C" void halide_print(void *user_context, const char *str) {
+    printf("halide_print: %s\n", str);
+    halide_print_called = true;
+}
+
 int main(int argc, char **argv) {
     void* user_context = NULL;
 
@@ -445,11 +451,18 @@ int main(int argc, char **argv) {
     Image<float> output0(kSize, kSize, 3);
     Image<float> output1(kSize, kSize, 3);
 
+    halide_print_called = false;
     result = metadata_tester(input, false, 0, 0, 0, 0, 0, 0, 0, 0, 0.f, 0.0, NULL, output0, output1);
     EXPECT_EQ(0, result);
+    // We expect that metadata_tester is built with debug=none
+    EXPECT_EQ(false, halide_print_called);
 
+    halide_print_called = false;
     result = metadata_tester_ucon(user_context, input, false, 0, 0, 0, 0, 0, 0, 0, 0, 0.f, 0.0, NULL, output0, output1);
     EXPECT_EQ(0, result);
+    // We expect that metadata_tester is built with debug=all
+    // (and that our input should product exactly one call to halide_print)
+    EXPECT_EQ(true, halide_print_called);
 
     verify(input, output0, output1);
 

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -33,8 +33,14 @@ public:
         f1(x, y, c) = cast(output_type, input(x, y, c));
         f2(x, y, c) = cast<float>(f1(x, y, c) + 1);
 
+        Func f2_d = f2;
+        if (debug >= DebugLevel::all) {
+            f2_d(x, y, c) = print_when(x == 0 && y == 0 && c == 0, f2(x, y, c));
+        }
+
         Func output("output");
-        output(x, y, c) = Tuple(f1(x, y, c), f2(x, y, c));
+        output(x, y, c) = Tuple(f1(x, y, c), f2_d(x, y, c));
+
         return output;
     }
 };


### PR DESCRIPTION
It’s handy to be able to leave debugging instrumentation in a Generator
without affecting real code; rather than using #ifdef or similar, let’s
add a standard GeneratorParam to enable this at the build-file level.

This defines it as a four-level enum; we could add more or less but
this seems likely to be a good compromise for most purposes.

(Unit test added to metadata_tester to minimize build-file churn.)