### PR TITLE
Move #include of IRVisitor

### DIFF
--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -1,4 +1,5 @@
 #include "CodeGen_GPU_Dev.h"
+#include "IRVisitor.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -10,13 +10,14 @@
 
 #include "Debug.h"
 #include "Error.h"
-#include "IRVisitor.h"
 #include "Type.h"
 #include "IntrusivePtr.h"
 #include "Util.h"
 
 namespace Halide {
 namespace Internal {
+
+class IRVisitor;
 
 /** A class representing a type of IR node (e.g. Add, or Mul, or
  * For). We use it for rtti (without having to compile with rtti). */
@@ -79,18 +80,14 @@ struct BaseExprNode : public IRNode {
    a concrete instantiation of a unique IRNodeType per class. */
 template<typename T>
 struct ExprNode : public BaseExprNode {
-    void accept(IRVisitor *v) const {
-        v->visit((const T *)this);
-    }
+    EXPORT void accept(IRVisitor *v) const;
     virtual IRNodeType *type_info() const {return &_type_info;}
     static EXPORT IRNodeType _type_info;
 };
 
 template<typename T>
 struct StmtNode : public BaseStmtNode {
-    void accept(IRVisitor *v) const {
-        v->visit((const T *)this);
-    }
+    EXPORT void accept(IRVisitor *v) const;
     virtual IRNodeType *type_info() const {return &_type_info;}
     static EXPORT IRNodeType _type_info;
 };

--- a/src/ExprUsesVar.h
+++ b/src/ExprUsesVar.h
@@ -6,6 +6,7 @@
  */
 
 #include "IR.h"
+#include "IRVisitor.h"
 #include "Scope.h"
 
 namespace Halide {

--- a/src/FindCalls.cpp
+++ b/src/FindCalls.cpp
@@ -1,4 +1,5 @@
 #include "FindCalls.h"
+#include "IRVisitor.h"
 
 namespace Halide{
 namespace Internal {

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -1,5 +1,6 @@
 #include "IR.h"
 #include "IRPrinter.h"
+#include "IRVisitor.h"
 
 namespace Halide {
 namespace Internal {
@@ -507,6 +508,46 @@ Expr Variable::make(Type type, std::string name, Buffer image, Parameter param, 
     node->reduction_domain = reduction_domain;
     return node;
 }
+
+template<> EXPORT void ExprNode<IntImm>::accept(IRVisitor *v) const { v->visit((const IntImm *)this); }
+template<> EXPORT void ExprNode<FloatImm>::accept(IRVisitor *v) const { v->visit((const FloatImm *)this); }
+template<> EXPORT void ExprNode<StringImm>::accept(IRVisitor *v) const { v->visit((const StringImm *)this); }
+template<> EXPORT void ExprNode<Cast>::accept(IRVisitor *v) const { v->visit((const Cast *)this); }
+template<> EXPORT void ExprNode<Variable>::accept(IRVisitor *v) const { v->visit((const Variable *)this); }
+template<> EXPORT void ExprNode<Add>::accept(IRVisitor *v) const { v->visit((const Add *)this); }
+template<> EXPORT void ExprNode<Sub>::accept(IRVisitor *v) const { v->visit((const Sub *)this); }
+template<> EXPORT void ExprNode<Mul>::accept(IRVisitor *v) const { v->visit((const Mul *)this); }
+template<> EXPORT void ExprNode<Div>::accept(IRVisitor *v) const { v->visit((const Div *)this); }
+template<> EXPORT void ExprNode<Mod>::accept(IRVisitor *v) const { v->visit((const Mod *)this); }
+template<> EXPORT void ExprNode<Min>::accept(IRVisitor *v) const { v->visit((const Min *)this); }
+template<> EXPORT void ExprNode<Max>::accept(IRVisitor *v) const { v->visit((const Max *)this); }
+template<> EXPORT void ExprNode<EQ>::accept(IRVisitor *v) const { v->visit((const EQ *)this); }
+template<> EXPORT void ExprNode<NE>::accept(IRVisitor *v) const { v->visit((const NE *)this); }
+template<> EXPORT void ExprNode<LT>::accept(IRVisitor *v) const { v->visit((const LT *)this); }
+template<> EXPORT void ExprNode<LE>::accept(IRVisitor *v) const { v->visit((const LE *)this); }
+template<> EXPORT void ExprNode<GT>::accept(IRVisitor *v) const { v->visit((const GT *)this); }
+template<> EXPORT void ExprNode<GE>::accept(IRVisitor *v) const { v->visit((const GE *)this); }
+template<> EXPORT void ExprNode<And>::accept(IRVisitor *v) const { v->visit((const And *)this); }
+template<> EXPORT void ExprNode<Or>::accept(IRVisitor *v) const { v->visit((const Or *)this); }
+template<> EXPORT void ExprNode<Not>::accept(IRVisitor *v) const { v->visit((const Not *)this); }
+template<> EXPORT void ExprNode<Select>::accept(IRVisitor *v) const { v->visit((const Select *)this); }
+template<> EXPORT void ExprNode<Load>::accept(IRVisitor *v) const { v->visit((const Load *)this); }
+template<> EXPORT void ExprNode<Ramp>::accept(IRVisitor *v) const { v->visit((const Ramp *)this); }
+template<> EXPORT void ExprNode<Broadcast>::accept(IRVisitor *v) const { v->visit((const Broadcast *)this); }
+template<> EXPORT void ExprNode<Call>::accept(IRVisitor *v) const { v->visit((const Call *)this); }
+template<> EXPORT void ExprNode<Let>::accept(IRVisitor *v) const { v->visit((const Let *)this); }
+template<> EXPORT void StmtNode<LetStmt>::accept(IRVisitor *v) const { v->visit((const LetStmt *)this); }
+template<> EXPORT void StmtNode<AssertStmt>::accept(IRVisitor *v) const { v->visit((const AssertStmt *)this); }
+template<> EXPORT void StmtNode<Pipeline>::accept(IRVisitor *v) const { v->visit((const Pipeline *)this); }
+template<> EXPORT void StmtNode<For>::accept(IRVisitor *v) const { v->visit((const For *)this); }
+template<> EXPORT void StmtNode<Store>::accept(IRVisitor *v) const { v->visit((const Store *)this); }
+template<> EXPORT void StmtNode<Provide>::accept(IRVisitor *v) const { v->visit((const Provide *)this); }
+template<> EXPORT void StmtNode<Allocate>::accept(IRVisitor *v) const { v->visit((const Allocate *)this); }
+template<> EXPORT void StmtNode<Free>::accept(IRVisitor *v) const { v->visit((const Free *)this); }
+template<> EXPORT void StmtNode<Realize>::accept(IRVisitor *v) const { v->visit((const Realize *)this); }
+template<> EXPORT void StmtNode<Block>::accept(IRVisitor *v) const { v->visit((const Block *)this); }
+template<> EXPORT void StmtNode<IfThenElse>::accept(IRVisitor *v) const { v->visit((const IfThenElse *)this); }
+template<> EXPORT void StmtNode<Evaluate>::accept(IRVisitor *v) const { v->visit((const Evaluate *)this); }
 
 template<> EXPORT IRNodeType ExprNode<IntImm>::_type_info = {};
 template<> EXPORT IRNodeType ExprNode<FloatImm>::_type_info = {};

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -509,85 +509,85 @@ Expr Variable::make(Type type, std::string name, Buffer image, Parameter param, 
     return node;
 }
 
-template<> EXPORT void ExprNode<IntImm>::accept(IRVisitor *v) const { v->visit((const IntImm *)this); }
-template<> EXPORT void ExprNode<FloatImm>::accept(IRVisitor *v) const { v->visit((const FloatImm *)this); }
-template<> EXPORT void ExprNode<StringImm>::accept(IRVisitor *v) const { v->visit((const StringImm *)this); }
-template<> EXPORT void ExprNode<Cast>::accept(IRVisitor *v) const { v->visit((const Cast *)this); }
-template<> EXPORT void ExprNode<Variable>::accept(IRVisitor *v) const { v->visit((const Variable *)this); }
-template<> EXPORT void ExprNode<Add>::accept(IRVisitor *v) const { v->visit((const Add *)this); }
-template<> EXPORT void ExprNode<Sub>::accept(IRVisitor *v) const { v->visit((const Sub *)this); }
-template<> EXPORT void ExprNode<Mul>::accept(IRVisitor *v) const { v->visit((const Mul *)this); }
-template<> EXPORT void ExprNode<Div>::accept(IRVisitor *v) const { v->visit((const Div *)this); }
-template<> EXPORT void ExprNode<Mod>::accept(IRVisitor *v) const { v->visit((const Mod *)this); }
-template<> EXPORT void ExprNode<Min>::accept(IRVisitor *v) const { v->visit((const Min *)this); }
-template<> EXPORT void ExprNode<Max>::accept(IRVisitor *v) const { v->visit((const Max *)this); }
-template<> EXPORT void ExprNode<EQ>::accept(IRVisitor *v) const { v->visit((const EQ *)this); }
-template<> EXPORT void ExprNode<NE>::accept(IRVisitor *v) const { v->visit((const NE *)this); }
-template<> EXPORT void ExprNode<LT>::accept(IRVisitor *v) const { v->visit((const LT *)this); }
-template<> EXPORT void ExprNode<LE>::accept(IRVisitor *v) const { v->visit((const LE *)this); }
-template<> EXPORT void ExprNode<GT>::accept(IRVisitor *v) const { v->visit((const GT *)this); }
-template<> EXPORT void ExprNode<GE>::accept(IRVisitor *v) const { v->visit((const GE *)this); }
-template<> EXPORT void ExprNode<And>::accept(IRVisitor *v) const { v->visit((const And *)this); }
-template<> EXPORT void ExprNode<Or>::accept(IRVisitor *v) const { v->visit((const Or *)this); }
-template<> EXPORT void ExprNode<Not>::accept(IRVisitor *v) const { v->visit((const Not *)this); }
-template<> EXPORT void ExprNode<Select>::accept(IRVisitor *v) const { v->visit((const Select *)this); }
-template<> EXPORT void ExprNode<Load>::accept(IRVisitor *v) const { v->visit((const Load *)this); }
-template<> EXPORT void ExprNode<Ramp>::accept(IRVisitor *v) const { v->visit((const Ramp *)this); }
-template<> EXPORT void ExprNode<Broadcast>::accept(IRVisitor *v) const { v->visit((const Broadcast *)this); }
-template<> EXPORT void ExprNode<Call>::accept(IRVisitor *v) const { v->visit((const Call *)this); }
-template<> EXPORT void ExprNode<Let>::accept(IRVisitor *v) const { v->visit((const Let *)this); }
-template<> EXPORT void StmtNode<LetStmt>::accept(IRVisitor *v) const { v->visit((const LetStmt *)this); }
-template<> EXPORT void StmtNode<AssertStmt>::accept(IRVisitor *v) const { v->visit((const AssertStmt *)this); }
-template<> EXPORT void StmtNode<Pipeline>::accept(IRVisitor *v) const { v->visit((const Pipeline *)this); }
-template<> EXPORT void StmtNode<For>::accept(IRVisitor *v) const { v->visit((const For *)this); }
-template<> EXPORT void StmtNode<Store>::accept(IRVisitor *v) const { v->visit((const Store *)this); }
-template<> EXPORT void StmtNode<Provide>::accept(IRVisitor *v) const { v->visit((const Provide *)this); }
-template<> EXPORT void StmtNode<Allocate>::accept(IRVisitor *v) const { v->visit((const Allocate *)this); }
-template<> EXPORT void StmtNode<Free>::accept(IRVisitor *v) const { v->visit((const Free *)this); }
-template<> EXPORT void StmtNode<Realize>::accept(IRVisitor *v) const { v->visit((const Realize *)this); }
-template<> EXPORT void StmtNode<Block>::accept(IRVisitor *v) const { v->visit((const Block *)this); }
-template<> EXPORT void StmtNode<IfThenElse>::accept(IRVisitor *v) const { v->visit((const IfThenElse *)this); }
-template<> EXPORT void StmtNode<Evaluate>::accept(IRVisitor *v) const { v->visit((const Evaluate *)this); }
+template<> void ExprNode<IntImm>::accept(IRVisitor *v) const { v->visit((const IntImm *)this); }
+template<> void ExprNode<FloatImm>::accept(IRVisitor *v) const { v->visit((const FloatImm *)this); }
+template<> void ExprNode<StringImm>::accept(IRVisitor *v) const { v->visit((const StringImm *)this); }
+template<> void ExprNode<Cast>::accept(IRVisitor *v) const { v->visit((const Cast *)this); }
+template<> void ExprNode<Variable>::accept(IRVisitor *v) const { v->visit((const Variable *)this); }
+template<> void ExprNode<Add>::accept(IRVisitor *v) const { v->visit((const Add *)this); }
+template<> void ExprNode<Sub>::accept(IRVisitor *v) const { v->visit((const Sub *)this); }
+template<> void ExprNode<Mul>::accept(IRVisitor *v) const { v->visit((const Mul *)this); }
+template<> void ExprNode<Div>::accept(IRVisitor *v) const { v->visit((const Div *)this); }
+template<> void ExprNode<Mod>::accept(IRVisitor *v) const { v->visit((const Mod *)this); }
+template<> void ExprNode<Min>::accept(IRVisitor *v) const { v->visit((const Min *)this); }
+template<> void ExprNode<Max>::accept(IRVisitor *v) const { v->visit((const Max *)this); }
+template<> void ExprNode<EQ>::accept(IRVisitor *v) const { v->visit((const EQ *)this); }
+template<> void ExprNode<NE>::accept(IRVisitor *v) const { v->visit((const NE *)this); }
+template<> void ExprNode<LT>::accept(IRVisitor *v) const { v->visit((const LT *)this); }
+template<> void ExprNode<LE>::accept(IRVisitor *v) const { v->visit((const LE *)this); }
+template<> void ExprNode<GT>::accept(IRVisitor *v) const { v->visit((const GT *)this); }
+template<> void ExprNode<GE>::accept(IRVisitor *v) const { v->visit((const GE *)this); }
+template<> void ExprNode<And>::accept(IRVisitor *v) const { v->visit((const And *)this); }
+template<> void ExprNode<Or>::accept(IRVisitor *v) const { v->visit((const Or *)this); }
+template<> void ExprNode<Not>::accept(IRVisitor *v) const { v->visit((const Not *)this); }
+template<> void ExprNode<Select>::accept(IRVisitor *v) const { v->visit((const Select *)this); }
+template<> void ExprNode<Load>::accept(IRVisitor *v) const { v->visit((const Load *)this); }
+template<> void ExprNode<Ramp>::accept(IRVisitor *v) const { v->visit((const Ramp *)this); }
+template<> void ExprNode<Broadcast>::accept(IRVisitor *v) const { v->visit((const Broadcast *)this); }
+template<> void ExprNode<Call>::accept(IRVisitor *v) const { v->visit((const Call *)this); }
+template<> void ExprNode<Let>::accept(IRVisitor *v) const { v->visit((const Let *)this); }
+template<> void StmtNode<LetStmt>::accept(IRVisitor *v) const { v->visit((const LetStmt *)this); }
+template<> void StmtNode<AssertStmt>::accept(IRVisitor *v) const { v->visit((const AssertStmt *)this); }
+template<> void StmtNode<Pipeline>::accept(IRVisitor *v) const { v->visit((const Pipeline *)this); }
+template<> void StmtNode<For>::accept(IRVisitor *v) const { v->visit((const For *)this); }
+template<> void StmtNode<Store>::accept(IRVisitor *v) const { v->visit((const Store *)this); }
+template<> void StmtNode<Provide>::accept(IRVisitor *v) const { v->visit((const Provide *)this); }
+template<> void StmtNode<Allocate>::accept(IRVisitor *v) const { v->visit((const Allocate *)this); }
+template<> void StmtNode<Free>::accept(IRVisitor *v) const { v->visit((const Free *)this); }
+template<> void StmtNode<Realize>::accept(IRVisitor *v) const { v->visit((const Realize *)this); }
+template<> void StmtNode<Block>::accept(IRVisitor *v) const { v->visit((const Block *)this); }
+template<> void StmtNode<IfThenElse>::accept(IRVisitor *v) const { v->visit((const IfThenElse *)this); }
+template<> void StmtNode<Evaluate>::accept(IRVisitor *v) const { v->visit((const Evaluate *)this); }
 
-template<> EXPORT IRNodeType ExprNode<IntImm>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<FloatImm>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<StringImm>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Cast>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Variable>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Add>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Sub>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Mul>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Div>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Mod>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Min>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Max>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<EQ>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<NE>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<LT>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<LE>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<GT>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<GE>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<And>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Or>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Not>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Select>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Load>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Ramp>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Broadcast>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Call>::_type_info = {};
-template<> EXPORT IRNodeType ExprNode<Let>::_type_info = {};
-template<> EXPORT IRNodeType StmtNode<LetStmt>::_type_info = {};
-template<> EXPORT IRNodeType StmtNode<AssertStmt>::_type_info = {};
-template<> EXPORT IRNodeType StmtNode<Pipeline>::_type_info = {};
-template<> EXPORT IRNodeType StmtNode<For>::_type_info = {};
-template<> EXPORT IRNodeType StmtNode<Store>::_type_info = {};
-template<> EXPORT IRNodeType StmtNode<Provide>::_type_info = {};
-template<> EXPORT IRNodeType StmtNode<Allocate>::_type_info = {};
-template<> EXPORT IRNodeType StmtNode<Free>::_type_info = {};
-template<> EXPORT IRNodeType StmtNode<Realize>::_type_info = {};
-template<> EXPORT IRNodeType StmtNode<Block>::_type_info = {};
-template<> EXPORT IRNodeType StmtNode<IfThenElse>::_type_info = {};
-template<> EXPORT IRNodeType StmtNode<Evaluate>::_type_info = {};
+template<> IRNodeType ExprNode<IntImm>::_type_info = {};
+template<> IRNodeType ExprNode<FloatImm>::_type_info = {};
+template<> IRNodeType ExprNode<StringImm>::_type_info = {};
+template<> IRNodeType ExprNode<Cast>::_type_info = {};
+template<> IRNodeType ExprNode<Variable>::_type_info = {};
+template<> IRNodeType ExprNode<Add>::_type_info = {};
+template<> IRNodeType ExprNode<Sub>::_type_info = {};
+template<> IRNodeType ExprNode<Mul>::_type_info = {};
+template<> IRNodeType ExprNode<Div>::_type_info = {};
+template<> IRNodeType ExprNode<Mod>::_type_info = {};
+template<> IRNodeType ExprNode<Min>::_type_info = {};
+template<> IRNodeType ExprNode<Max>::_type_info = {};
+template<> IRNodeType ExprNode<EQ>::_type_info = {};
+template<> IRNodeType ExprNode<NE>::_type_info = {};
+template<> IRNodeType ExprNode<LT>::_type_info = {};
+template<> IRNodeType ExprNode<LE>::_type_info = {};
+template<> IRNodeType ExprNode<GT>::_type_info = {};
+template<> IRNodeType ExprNode<GE>::_type_info = {};
+template<> IRNodeType ExprNode<And>::_type_info = {};
+template<> IRNodeType ExprNode<Or>::_type_info = {};
+template<> IRNodeType ExprNode<Not>::_type_info = {};
+template<> IRNodeType ExprNode<Select>::_type_info = {};
+template<> IRNodeType ExprNode<Load>::_type_info = {};
+template<> IRNodeType ExprNode<Ramp>::_type_info = {};
+template<> IRNodeType ExprNode<Broadcast>::_type_info = {};
+template<> IRNodeType ExprNode<Call>::_type_info = {};
+template<> IRNodeType ExprNode<Let>::_type_info = {};
+template<> IRNodeType StmtNode<LetStmt>::_type_info = {};
+template<> IRNodeType StmtNode<AssertStmt>::_type_info = {};
+template<> IRNodeType StmtNode<Pipeline>::_type_info = {};
+template<> IRNodeType StmtNode<For>::_type_info = {};
+template<> IRNodeType StmtNode<Store>::_type_info = {};
+template<> IRNodeType StmtNode<Provide>::_type_info = {};
+template<> IRNodeType StmtNode<Allocate>::_type_info = {};
+template<> IRNodeType StmtNode<Free>::_type_info = {};
+template<> IRNodeType StmtNode<Realize>::_type_info = {};
+template<> IRNodeType StmtNode<Block>::_type_info = {};
+template<> IRNodeType StmtNode<IfThenElse>::_type_info = {};
+template<> IRNodeType StmtNode<Evaluate>::_type_info = {};
 
 Call::ConstString Call::debug_to_file = "debug_to_file";
 Call::ConstString Call::shuffle_vector = "shuffle_vector";

--- a/src/IR.h
+++ b/src/IR.h
@@ -13,7 +13,6 @@
 #include "Error.h"
 #include "Expr.h"
 #include "Function.h"
-#include "IRVisitor.h"
 #include "IntrusivePtr.h"
 #include "Parameter.h"
 #include "Type.h"

--- a/src/IREquality.cpp
+++ b/src/IREquality.cpp
@@ -1,4 +1,5 @@
 #include "IREquality.h"
+#include "IRVisitor.h"
 #include "IROperator.h"
 
 namespace Halide {

--- a/src/IRMatch.cpp
+++ b/src/IRMatch.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <map>
 
+#include "IRVisitor.h"
 #include "IRMatch.h"
 #include "IREquality.h"
 #include "IROperator.h"

--- a/src/IRMutator.h
+++ b/src/IRMutator.h
@@ -6,6 +6,7 @@
  */
 
 #include "IR.h"
+#include "IRVisitor.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -4,6 +4,7 @@
 #include <ostream>
 
 #include "Module.h"
+#include "IRVisitor.h"
 
 namespace Halide {
 

--- a/src/IRVisitor.h
+++ b/src/IRVisitor.h
@@ -1,6 +1,7 @@
 #ifndef HALIDE_IR_VISITOR_H
 #define HALIDE_IR_VISITOR_H
 
+#include "IR.h"
 #include "Util.h"
 
 #include <set>
@@ -12,54 +13,7 @@
  */
 
 namespace Halide {
-
-struct Expr;
-
 namespace Internal {
-
-struct IRNode;
-struct Stmt;
-struct IntImm;
-struct FloatImm;
-struct StringImm;
-struct Cast;
-struct Variable;
-struct Add;
-struct Sub;
-struct Mul;
-struct Div;
-struct Mod;
-struct Min;
-struct Max;
-struct EQ;
-struct NE;
-struct LT;
-struct LE;
-struct GT;
-struct GE;
-struct And;
-struct Or;
-struct Not;
-struct Select;
-struct Load;
-struct Ramp;
-struct Broadcast;
-struct Call;
-struct Let;
-struct LetStmt;
-struct AssertStmt;
-struct Pipeline;
-struct For;
-struct Store;
-struct Provide;
-struct Allocate;
-struct Free;
-struct Realize;
-struct Block;
-struct IfThenElse;
-struct Evaluate;
-
-class Function;
 
 /** A base class for algorithms that need to recursively walk over the
  * IR. The default implementations just recursively walk over the

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <stdint.h>
 #include <mutex>
+#include <set>
 
 #include "JITModule.h"
 #include "LLVM_Headers.h"

--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -1,4 +1,5 @@
 #include "StmtToHtml.h"
+#include "IRVisitor.h"
 #include "IROperator.h"
 #include "Scope.h"
 


### PR DESCRIPTION
This PR moves the inclusion of IRVisitor such that it is only done where necessary. This will be the first of a series of PRs aimed at avoiding including internal headers as part of the public API. Although IRVisitor is part of the public API, this still cuts down the complexity of what gets included where.

This also seems to have made (Halide code) compile times very slightly faster (due to code size?).