### PR TITLE
Replace buffer_t #pragma pack with align directives

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -26,7 +26,7 @@ const string buffer_t_definition =
     "  #ifdef _MSC_VER\n"
     "    #define HALIDE_ATTRIBUTE_ALIGN(x) __declspec(align(x))\n"
     "  #else\n"
-    "    #define HALIDE_ATTRIBUTE_ALIGN __attribute__((aligned(x)))\n"
+    "    #define HALIDE_ATTRIBUTE_ALIGN(x) __attribute__((aligned(x)))\n"
     "  #endif\n"
     "#endif\n"
     "#ifndef BUFFER_T_DEFINED\n"

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -41,7 +41,7 @@ const string buffer_t_definition =
     "    int32_t elem_size;\n"
     "    HALIDE_ATTRIBUTE_ALIGN(1) bool host_dirty;\n"
     "    HALIDE_ATTRIBUTE_ALIGN(1) bool dev_dirty;\n"
-    "    HALIDE_ATTRIBUTE_ALIGN(1) uint8_t _padding[2];\n"
+    "    HALIDE_ATTRIBUTE_ALIGN(1) uint8_t _padding[10 - sizeof(void *)];\n"
     "} buffer_t;\n"
     "#endif\n";
 

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -22,10 +22,16 @@ using std::map;
 
 namespace {
 const string buffer_t_definition =
+    "#ifndef HALIDE_ATTRIBUTE_ALIGN\n"
+    "  #ifdef _MSC_VER\n"
+    "    #define HALIDE_ATTRIBUTE_ALIGN(x) __declspec(align(x))\n"
+    "  #else\n"
+    "    #define HALIDE_ATTRIBUTE_ALIGN __attribute__((aligned(x)))\n"
+    "  #endif\n"
+    "#endif\n"
     "#ifndef BUFFER_T_DEFINED\n"
     "#define BUFFER_T_DEFINED\n"
     "#include <stdint.h>\n"
-    "#pragma pack(push, 1)\n"
     "typedef struct buffer_t {\n"
     "    uint64_t dev;\n"
     "    uint8_t* host;\n"
@@ -33,11 +39,10 @@ const string buffer_t_definition =
     "    int32_t stride[4];\n"
     "    int32_t min[4];\n"
     "    int32_t elem_size;\n"
-    "    bool host_dirty;\n"
-    "    bool dev_dirty;\n"
-    "    uint8_t _padding[2];\n"
+    "    HALIDE_ATTRIBUTE_ALIGN(1) bool host_dirty;\n"
+    "    HALIDE_ATTRIBUTE_ALIGN(1) bool dev_dirty;\n"
+    "    HALIDE_ATTRIBUTE_ALIGN(1) uint8_t _padding[2];\n"
     "} buffer_t;\n"
-    "#pragma pack(pop)\n"
     "#endif\n";
 
 const string headers =

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -672,7 +672,9 @@ void CodeGen_LLVM::compile_buffer(const Buffer &buf) {
                                                 false, GlobalValue::PrivateLinkage,
                                                 0, buf.name() + ".buffer");
     llvm::ArrayType *i32_array = ArrayType::get(i32, 4);
-    llvm::ArrayType *padding_bytes = ArrayType::get(i8, 2);
+
+    llvm::Type *padding_bytes_type =
+        buffer_t_type->elements()[buffer_t_type->getNumElements()-1];
 
     Constant *fields[] = {
         ConstantInt::get(i64, 0), // dev
@@ -683,8 +685,7 @@ void CodeGen_LLVM::compile_buffer(const Buffer &buf) {
         ConstantInt::get(i32, b.elem_size),
         ConstantInt::get(i8, 1), // host_dirty
         ConstantInt::get(i8, 0), // dev_dirty
-        ConstantArray::get(padding_bytes, vec(ConstantInt::get(i8, 0),
-                                              ConstantInt::get(i8, 0)))
+        Constant::getNullValue(padding_bytes_type)
     };
     Constant *buffer_struct = ConstantStruct::get(buffer_t_type, fields);
     global->setInitializer(buffer_struct);

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -674,7 +674,7 @@ void CodeGen_LLVM::compile_buffer(const Buffer &buf) {
     llvm::ArrayType *i32_array = ArrayType::get(i32, 4);
 
     llvm::Type *padding_bytes_type =
-        buffer_t_type->elements()[buffer_t_type->getNumElements()-1];
+        buffer_t_type->getElementType(buffer_t_type->getNumElements()-1);
 
     Constant *fields[] = {
         ConstantInt::get(i64, 0), // dev

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -494,7 +494,10 @@ typedef struct buffer_t {
     device side. */
     HALIDE_ATTRIBUTE_ALIGN(1) bool dev_dirty;
 
-    HALIDE_ATTRIBUTE_ALIGN(1) uint8_t _padding[2];
+    // Some compilers will add extra padding at the end to ensure
+    // the size is a multiple of 8; we'll do that explicitly so that
+    // there is no ambiguity.
+    HALIDE_ATTRIBUTE_ALIGN(1) uint8_t _padding[10 - sizeof(void *)];
 } buffer_t;
 
 #endif

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -438,6 +438,16 @@ typedef enum halide_type_code_t {
     halide_type_handle = 3 //!< opaque pointer type (void *)
 } halide_type_code_t;
 
+// Note that while __attribute__ can go before or after the declaration,
+// __declspec apparently is only allowed before.
+#ifndef HALIDE_ATTRIBUTE_ALIGN
+    #ifdef _MSC_VER
+        #define HALIDE_ATTRIBUTE_ALIGN(x) __declspec(align(x))
+    #else
+        #define HALIDE_ATTRIBUTE_ALIGN(x) __attribute__((aligned(x)))
+    #endif
+#endif
+
 #ifndef BUFFER_T_DEFINED
 #define BUFFER_T_DEFINED
 
@@ -446,7 +456,6 @@ typedef enum halide_type_code_t {
  * Halide code. It includes some stuff to track whether the image is
  * not actually in main memory, but instead on a device (like a
  * GPU). */
-#pragma pack(push, 1)
 typedef struct buffer_t {
     /** A device-handle for e.g. GPU memory used to back this buffer. */
     uint64_t dev;
@@ -478,16 +487,15 @@ typedef struct buffer_t {
     /** This should be true if there is an existing device allocation
     * mirroring this buffer, and the data has been modified on the
     * host side. */
-    bool host_dirty;
+    HALIDE_ATTRIBUTE_ALIGN(1) bool host_dirty;
 
     /** This should be true if there is an existing device allocation
     mirroring this buffer, and the data has been modified on the
     device side. */
-    bool dev_dirty;
+    HALIDE_ATTRIBUTE_ALIGN(1) bool dev_dirty;
 
-    uint8_t _padding[2];
+    HALIDE_ATTRIBUTE_ALIGN(1) uint8_t _padding[2];
 } buffer_t;
-#pragma pack(pop)
 
 #endif
 

--- a/test/correctness/buffer_t.cpp
+++ b/test/correctness/buffer_t.cpp
@@ -17,7 +17,12 @@ int main(int argc, char **argv) {
     CHECK(dev_dirty, 65, 69);
     CHECK(_padding, 66, 70);
 
-    static_assert(sizeof(buffer_t) == (sizeof(void*) == 8 ? 72 : 68), "size is wrong");
+    static_assert(sizeof(void*) == 8 ?
+                    sizeof(buffer_t) == 72 :
+                    // Some compilers may insert padding at the end of the struct
+                    // so that an array will stay appropriately aligned for
+                    // the int64 field.
+                    (sizeof(buffer_t) == 68 || sizeof(buffer_t) == 72), "size is wrong");
 
     // Ensure alignment is at least that of a pointer.
     static_assert(alignof(buffer_t) >= alignof(uint8_t*), "align is wrong");

--- a/test/correctness/buffer_t.cpp
+++ b/test/correctness/buffer_t.cpp
@@ -4,6 +4,12 @@
 #define CHECK(f, s32, s64) \
     static_assert(offsetof(buffer_t, f) == (sizeof(void*) == 8 ? (s64) : (s32)), #f " is wrong")
 
+#ifdef _MSC_VER
+    // VC2013 doesn't support alignof, apparently
+    #define ALIGN_OF(x) __alignof(x)
+#else
+    #define ALIGN_OF(x) alignof(x)
+#endif
 
 int main(int argc, char **argv) {
 
@@ -25,7 +31,7 @@ int main(int argc, char **argv) {
                     (sizeof(buffer_t) == 68 || sizeof(buffer_t) == 72), "size is wrong");
 
     // Ensure alignment is at least that of a pointer.
-    static_assert(alignof(buffer_t) >= alignof(uint8_t*), "align is wrong");
+    static_assert(ALIGN_OF(buffer_t) >= ALIGN_OF(uint8_t*), "align is wrong");
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/buffer_t.cpp
+++ b/test/correctness/buffer_t.cpp
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include "Halide.h"
+
+#define CHECK(f, s32, s64) \
+    static_assert(offsetof(buffer_t, f) == (sizeof(void*) == 8 ? (s64) : (s32)), #f " is wrong")
+
+
+int main(int argc, char **argv) {
+
+    CHECK(dev, 0, 0);
+    CHECK(host, 8, 8);
+    CHECK(extent, 12, 16);
+    CHECK(stride, 28, 32);
+    CHECK(min, 44, 48);
+    CHECK(elem_size, 60, 64);
+    CHECK(host_dirty, 64, 68);
+    CHECK(dev_dirty, 65, 69);
+    CHECK(_padding, 66, 70);
+
+    static_assert(sizeof(buffer_t) == (sizeof(void*) == 8 ? 72 : 68), "size is wrong");
+
+    // Ensure alignment is at least that of a pointer.
+    static_assert(alignof(buffer_t) >= alignof(uint8_t*), "align is wrong");
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/buffer_t.cpp
+++ b/test/correctness/buffer_t.cpp
@@ -23,12 +23,7 @@ int main(int argc, char **argv) {
     CHECK(dev_dirty, 65, 69);
     CHECK(_padding, 66, 70);
 
-    static_assert(sizeof(void*) == 8 ?
-                    sizeof(buffer_t) == 72 :
-                    // Some compilers may insert padding at the end of the struct
-                    // so that an array will stay appropriately aligned for
-                    // the int64 field.
-                    (sizeof(buffer_t) == 68 || sizeof(buffer_t) == 72), "size is wrong");
+    static_assert(sizeof(buffer_t) == 72, "size is wrong");
 
     // Ensure alignment is at least that of a pointer.
     static_assert(ALIGN_OF(buffer_t) >= ALIGN_OF(uint8_t*), "align is wrong");


### PR DESCRIPTION
#pragma pack is bad because it imposes alignment assumptions on the
struct itself; on some processors this can cause access violations if
the buffer_t is stack-allocated without the necessary alignment.
Instead, force the alignment of the fields we care about.