### PR TITLE
Cleanup includes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,6 +283,7 @@ SOURCE_FILES = \
   UniquifyVariableNames.cpp \
   UnrollLoops.cpp \
   Util.cpp \
+  Var.cpp \
   VaryingAttributes.cpp \
   VectorizeLoops.cpp
 

--- a/src/AllocationBoundsInference.h
+++ b/src/AllocationBoundsInference.h
@@ -5,9 +5,6 @@
  * Defines the lowering pass that determines how large internal allocations should be.
  */
 
-#include <map>
-#include <string>
-
 #include "IR.h"
 #include "Bounds.h"
 

--- a/src/Argument.h
+++ b/src/Argument.h
@@ -1,15 +1,15 @@
 #ifndef HALIDE_ARGUMENT_H
 #define HALIDE_ARGUMENT_H
 
-#include "Error.h"
-#include "Expr.h"
-#include "Type.h"
-#include "runtime/HalideRuntime.h"
-
 /** \file
  * Defines a type used for expressing the type signature of a
  * generated halide pipeline
  */
+
+#include "Error.h"
+#include "Expr.h"
+#include "Type.h"
+#include "runtime/HalideRuntime.h"
 
 namespace Halide {
 

--- a/src/Argument.h
+++ b/src/Argument.h
@@ -1,7 +1,6 @@
 #ifndef HALIDE_ARGUMENT_H
 #define HALIDE_ARGUMENT_H
 
-#include <string>
 #include "Error.h"
 #include "Expr.h"
 #include "Type.h"

--- a/src/Bounds.h
+++ b/src/Bounds.h
@@ -1,15 +1,13 @@
 #ifndef HALIDE_BOUNDS_H
 #define HALIDE_BOUNDS_H
 
-#include "IR.h"
-#include "IROperator.h"
-#include "Scope.h"
-#include <vector>
-
 /** \file
  * Methods for computing the upper and lower bounds of an expression,
  * and the regions of a function read or written by a statement.
  */
+
+#include "IROperator.h"
+#include "Scope.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -1,15 +1,15 @@
 #ifndef HALIDE_BUFFER_H
 #define HALIDE_BUFFER_H
 
+/** \file
+ * Defines Buffer - A c++ wrapper around a buffer_t.
+ */
+
 #include <stdint.h>
 #include "runtime/HalideRuntime.h" // For buffer_t
 #include "IntrusivePtr.h"
 #include "Type.h"
 #include "Argument.h"
-
-/** \file
- * Defines Buffer - A c++ wrapper around a buffer_t.
- */
 
 namespace Halide {
 namespace Internal {

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -6,6 +6,7 @@
  */
 
 #include <stdint.h>
+
 #include "runtime/HalideRuntime.h" // For buffer_t
 #include "IntrusivePtr.h"
 #include "Type.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -444,6 +444,7 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   UniquifyVariableNames.cpp
   UnrollLoops.cpp
   Util.cpp
+  Var.cpp
   VaryingAttributes.cpp
   VectorizeLoops.cpp
   "${CMAKE_BINARY_DIR}/include/Halide.h"

--- a/src/CodeGen_ARM.h
+++ b/src/CodeGen_ARM.h
@@ -6,7 +6,6 @@
  */
 
 #include "CodeGen_Posix.h"
-#include "Target.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -6,12 +6,6 @@
  * Defines an IRPrinter that emits C++ code equivalent to a halide stmt
  */
 
-#include <string>
-#include <vector>
-#include <ostream>
-#include <map>
-#include <set>
-
 #include "IRPrinter.h"
 #include "Module.h"
 #include "Scope.h"

--- a/src/CodeGen_GPU_Dev.h
+++ b/src/CodeGen_GPU_Dev.h
@@ -6,7 +6,6 @@
  */
 
 #include "IR.h"
-#include "Target.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/CodeGen_GPU_Host.h
+++ b/src/CodeGen_GPU_Host.h
@@ -5,13 +5,14 @@
  * Defines the code-generator for producing GPU host code
  */
 
+#include <map>
+
 #include "CodeGen_ARM.h"
 #include "CodeGen_X86.h"
 #include "CodeGen_MIPS.h"
 #include "CodeGen_PNaCl.h"
 
 #include "IR.h"
-#include <map>
 
 namespace Halide {
 namespace Internal {

--- a/src/CodeGen_Internal.h
+++ b/src/CodeGen_Internal.h
@@ -8,10 +8,10 @@
  * front-end-facing interface to CodeGen).
  */
 
+#include "IR.h"
 #include "IRVisitor.h"
 #include "LLVM_Headers.h"
 #include "Scope.h"
-#include "IR.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -29,7 +29,6 @@ class BasicBlock;
 }
 
 #include <map>
-#include <stack>
 #include <string>
 #include <vector>
 

--- a/src/CodeGen_MIPS.h
+++ b/src/CodeGen_MIPS.h
@@ -6,7 +6,6 @@
  */
 
 #include "CodeGen_Posix.h"
-#include "Target.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/CodeGen_OpenGL_Dev.h
+++ b/src/CodeGen_OpenGL_Dev.h
@@ -5,13 +5,12 @@
  * Defines the code-generator for producing GLSL kernel code
  */
 
+#include <sstream>
+#include <map>
+
 #include "CodeGen_C.h"
 #include "CodeGen_GPU_Dev.h"
 #include "Target.h"
-
-#include <sstream>
-#include <map>
-#include <string>
 
 namespace Halide {
 namespace Internal {

--- a/src/CodeGen_PNaCl.h
+++ b/src/CodeGen_PNaCl.h
@@ -6,7 +6,6 @@
  */
 
 #include "CodeGen_Posix.h"
-#include "Target.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/DebugToFile.h
+++ b/src/DebugToFile.h
@@ -5,8 +5,9 @@
  * Defines the lowering pass that injects code at the end of
  * every realization to dump functions to a file for debugging.  */
 
-#include "IR.h"
 #include <map>
+
+#include "IR.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Error.h
+++ b/src/Error.h
@@ -1,7 +1,6 @@
 #ifndef HALIDE_ERROR_H
 #define HALIDE_ERROR_H
 
-#include <string>
 #include <sstream>
 #include <stdexcept>
 

--- a/src/Extern.h
+++ b/src/Extern.h
@@ -1,8 +1,6 @@
 #ifndef HALIDE_EXTERN_H
 #define HALIDE_EXTERN_H
 
-#include "Debug.h"
-
 /** \file
  *
  * Convenience macros that lift functions that take C types into
@@ -10,6 +8,8 @@
  * function at runtime under the hood. See test/c_function.cpp for
  * example usage.
  */
+
+#include "Debug.h"
 
 #define _halide_check_arg_type(t, name, e, n)                     \
     _halide_user_assert(e.type() == t) << "Type mismatch for argument " << n << " to extern function " << #name << ". Type expected is " << t << " but the argument " << e << " has type " << e.type() << ".\n";

--- a/src/FastIntegerDivide.h
+++ b/src/FastIntegerDivide.h
@@ -2,7 +2,6 @@
 #define HALIDE_FAST_INTEGER_DIVIDE_H
 
 #include "IR.h"
-#include "Func.h"
 #include "Image.h"
 
 namespace Halide {

--- a/src/FindCalls.h
+++ b/src/FindCalls.h
@@ -6,9 +6,9 @@
  * Defines analyses to extract the functions called a function.
  */
 
-#include "IR.h"
-#include <string>
 #include <map>
+
+#include "IR.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Function.h
+++ b/src/Function.h
@@ -11,10 +11,6 @@
 #include "Schedule.h"
 #include "Reduction.h"
 
-#include <string>
-#include <vector>
-#include <sstream>
-
 namespace Halide {
 
 namespace Internal {

--- a/src/HumanReadableStmt.h
+++ b/src/HumanReadableStmt.h
@@ -5,10 +5,11 @@
 * Defines methods for simplifying a stmt into a human-readable form.
 */
 
+#include <map>
+
 #include "IR.h"
-#include "Func.h"
-#include "Image.h"
-#include "Target.h"
+#include "Function.h"
+#include "Buffer.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -5,8 +5,6 @@
  * Defines a method to match a fragment of IR against a pattern containing wildcards
  */
 
-#include <vector>
-
 #include "IR.h"
 
 namespace Halide {

--- a/src/IRMutator.h
+++ b/src/IRMutator.h
@@ -5,7 +5,6 @@
  * Defines a base class for passes over the IR that modify it
  */
 
-#include "IR.h"
 #include "IRVisitor.h"
 
 namespace Halide {

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -1,11 +1,10 @@
 #include <iostream>
 #include <sstream>
-#include <math.h>
+#include <cmath>
 #include <algorithm>
 
 #include "IROperator.h"
 #include "IRPrinter.h"
-#include "Simplify.h"
 #include "Debug.h"
 #include "CSE.h"
 

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -1,13 +1,6 @@
 #ifndef HALIDE_IR_PRINTER_H
 #define HALIDE_IR_PRINTER_H
 
-#include <ostream>
-
-#include "Module.h"
-#include "IRVisitor.h"
-
-namespace Halide {
-
 /** \file
  * This header file defines operators that let you dump a Halide
  * expression, statement, or type directly into an output stream
@@ -20,6 +13,13 @@ namespace Halide {
  *
  * These operators are implemented using \ref Halide::Internal::IRPrinter
  */
+
+#include <ostream>
+
+#include "Module.h"
+#include "IRVisitor.h"
+
+namespace Halide {
 
 /** Emit an expression on an output stream (such as std::cout) in a
  * human-readable form */

--- a/src/IRVisitor.cpp
+++ b/src/IRVisitor.cpp
@@ -1,5 +1,4 @@
 #include "IRVisitor.h"
-#include "IR.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Image.h
+++ b/src/Image.h
@@ -5,9 +5,8 @@
  * Defines Halide's Image data type
  */
 
-#include "Buffer.h"
-#include "Tuple.h"
 #include "Var.h"
+#include "Tuple.h"
 
 namespace Halide {
 

--- a/src/InjectOpenGLIntrinsics.cpp
+++ b/src/InjectOpenGLIntrinsics.cpp
@@ -4,6 +4,7 @@
 #include "CodeGen_GPU_Dev.h"
 #include "Substitute.h"
 #include "FuseGPUThreadLoops.h"
+#include "Scope.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/InjectOpenGLIntrinsics.h
+++ b/src/InjectOpenGLIntrinsics.h
@@ -1,14 +1,12 @@
 #ifndef HALIDE_INJECT_OPENGL_INTRINSICS_H
 #define HALIDE_INJECT_OPENGL_INTRINSICS_H
 
-
 /** \file
  * Defines the lowering pass that injects texture loads and texture
  * stores for opengl.
  */
 
 #include "IR.h"
-#include "Scope.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Inline.h
+++ b/src/Inline.h
@@ -1,12 +1,11 @@
 #ifndef HALIDE_INLINE_H
 #define HALIDE_INLINE_H
 
-
-#include "IR.h"
-
 /** \file
  * Methods for replacing calls to functions with their definitions.
  */
+
+#include "IR.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/InlineReductions.h
+++ b/src/InlineReductions.h
@@ -2,8 +2,8 @@
 #define HALIDE_INLINE_REDUCTIONS_H
 
 #include "IR.h"
-#include "Tuple.h"
 #include "RDom.h"
+#include "Tuple.h"
 
 /** \file
  * Defines some inline reductions: sum, product, minimum, maximum.

--- a/src/IntrusivePtr.h
+++ b/src/IntrusivePtr.h
@@ -7,10 +7,10 @@
  * pointers.
  */
 
+#include <stdlib.h>
+
 #include "Util.h"
 
-#include <stdlib.h>
-#include <iostream>
 namespace Halide {
 namespace Internal {
 

--- a/src/JITModule.h
+++ b/src/JITModule.h
@@ -5,10 +5,10 @@
  * a JIT compiled halide pipeline
  */
 
+#include <map>
+
 #include "IntrusivePtr.h"
 #include "runtime/HalideRuntime.h"
-
-#include <map>
 
 namespace llvm {
 class Module;

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -1,6 +1,4 @@
 #include "LLVM_Runtime_Linker.h"
-
-#include <memory>
 #include "LLVM_Headers.h"
 
 namespace Halide {

--- a/src/Lerp.cpp
+++ b/src/Lerp.cpp
@@ -1,4 +1,4 @@
-#include <math.h>
+#include <cmath>
 #include <algorithm>
 
 #include "Lerp.h"

--- a/src/Lerp.h
+++ b/src/Lerp.h
@@ -1,11 +1,11 @@
 #ifndef HALIDE_LERP_H
 #define HALIDE_LERP_H
 
-#include "IR.h"
-
 /** \file
  * Defines methods for converting a lerp intrinsic into Halide IR.
  */
+
+#include "IR.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Memoization.h
+++ b/src/Memoization.h
@@ -8,8 +8,8 @@
  */
 
 #include <map>
+
 #include "IR.h"
-#include "Target.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Module.h
+++ b/src/Module.h
@@ -6,8 +6,6 @@
  * Defines Module, an IR container that fully describes a Halide program.
  */
 
-#include <iostream>
-
 #include "IR.h"
 #include "Buffer.h"
 #include "Target.h"

--- a/src/ParallelRVar.cpp
+++ b/src/ParallelRVar.cpp
@@ -2,7 +2,6 @@
 #include "ParallelRVar.h"
 #include "IRMutator.h"
 #include "Debug.h"
-#include "CSE.h"
 #include "Simplify.h"
 #include "IROperator.h"
 

--- a/src/ParallelRVar.h
+++ b/src/ParallelRVar.h
@@ -2,7 +2,6 @@
 #define HALIDE_PARALLEL_RVAR_H
 
 #include "Function.h"
-#include <string>
 
 /** \file
  *

--- a/src/ParallelRVar.h
+++ b/src/ParallelRVar.h
@@ -1,13 +1,13 @@
 #ifndef HALIDE_PARALLEL_RVAR_H
 #define HALIDE_PARALLEL_RVAR_H
 
-#include "Function.h"
-
 /** \file
  *
  * Method for checking if it's safe to parallelize an update
  * definition across a reduction variable.
  */
+
+#include "Function.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Param.h
+++ b/src/Param.h
@@ -6,9 +6,6 @@
  * Classes for declaring scalar and image parameters to halide pipelines
  */
 
-#include <sstream>
-#include <vector>
-
 #include "IR.h"
 #include "Var.h"
 #include "Util.h"

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -5,7 +5,6 @@
  * Defines the internal representation of parameters to halide piplines
  */
 
-#include <string>
 #include "Expr.h"
 
 namespace Halide {

--- a/src/Qualify.h
+++ b/src/Qualify.h
@@ -1,12 +1,12 @@
 #ifndef HALIDE_QUALIFY_H
 #define HALIDE_QUALIFY_H
 
-#include "IR.h"
-
 /** \file
  *
  * Defines methods for prefixing names in an expression with a prefix string.
  */
+
+#include "IR.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Random.h
+++ b/src/Random.h
@@ -1,15 +1,12 @@
 #ifndef HALIDE_RANDOM_H
 #define HALIDE_RANDOM_H
 
-#include <vector>
-#include <string>
-#include "IR.h"
-
 /** \file
  *
  * Defines deterministic random functions, and methods to redirect
  * front-end calls to random_float and random_int to use them. */
 
+#include "IR.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Reduction.h
+++ b/src/Reduction.h
@@ -5,9 +5,6 @@
  * Defines internal classes related to Reduction Domains
  */
 
-#include <string>
-#include <vector>
-
 #include "IR.h"
 
 namespace Halide {

--- a/src/Reduction.h
+++ b/src/Reduction.h
@@ -5,9 +5,10 @@
  * Defines internal classes related to Reduction Domains
  */
 
-#include "IntrusivePtr.h"
 #include <string>
 #include <vector>
+
+#include "IR.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -5,9 +5,9 @@
  * Defines the internal representation of the schedule for a function
  */
 
-#include "Expr.h"
-#include <string>
 #include <vector>
+
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -5,8 +5,6 @@
  * Defines the internal representation of the schedule for a function
  */
 
-#include <vector>
-
 #include "Expr.h"
 
 namespace Halide {

--- a/src/Simplify.h
+++ b/src/Simplify.h
@@ -5,10 +5,11 @@
  * Methods for simplifying halide statements and expressions
  */
 
+#include <cmath>
+
 #include "IR.h"
 #include "Bounds.h"
 #include "ModulusRemainder.h"
-#include <cmath>
 
 namespace Halide {
 namespace Internal {

--- a/src/SlidingWindow.h
+++ b/src/SlidingWindow.h
@@ -7,8 +7,9 @@
  * computing provably-already-computed values.
  */
 
-#include "IR.h"
 #include <map>
+
+#include "IR.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/StorageFlattening.h
+++ b/src/StorageFlattening.h
@@ -9,8 +9,6 @@
 #include <map>
 
 #include "IR.h"
-#include "Target.h"
-#include "Scope.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Target.h
+++ b/src/Target.h
@@ -5,10 +5,10 @@
  * Defines the structure that describes a Halide target.
  */
 
-#include <bitset>
-#include <limits>
 #include <stdint.h>
+#include <bitset>
 #include <string>
+
 #include "Error.h"
 #include "Type.h"
 #include "Util.h"

--- a/src/Tracing.h
+++ b/src/Tracing.h
@@ -5,8 +5,9 @@
  * Defines the lowering pass that injects print statements when tracing is turned on
  */
 
-#include "IR.h"
 #include <map>
+
+#include "IR.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Tuple.h
+++ b/src/Tuple.h
@@ -6,10 +6,11 @@
  * Defines Tuple - the front-end handle on small arrays of expressions.
  */
 
+#include <vector>
+
 #include "IR.h"
 #include "IROperator.h"
 #include "Util.h"
-#include <vector>
 
 namespace Halide {
 

--- a/src/Tuple.h
+++ b/src/Tuple.h
@@ -6,8 +6,6 @@
  * Defines Tuple - the front-end handle on small arrays of expressions.
  */
 
-#include <vector>
-
 #include "IR.h"
 #include "IROperator.h"
 #include "Util.h"

--- a/src/UniquifyVariableNames.cpp
+++ b/src/UniquifyVariableNames.cpp
@@ -1,6 +1,5 @@
 #include "UniquifyVariableNames.h"
 #include "IRMutator.h"
-#include "Scope.h"
 #include <sstream>
 
 namespace Halide {

--- a/src/Var.cpp
+++ b/src/Var.cpp
@@ -1,5 +1,3 @@
-#include <sstream>
-
 #include "Var.h"
 #include "Util.h"
 
@@ -15,9 +13,7 @@ Var::Var() : _name(Internal::make_entity_name(this, "Halide::Var", 'v')) {
 }
 
 Var Var::implicit(int n) {
-    std::ostringstream str;
-    str << "_" << n;
-    return Var(str.str());
+    return Var("_" + Internal::int_to_string(n));
 }
 
 bool Var::is_implicit(const std::string &name) {

--- a/src/Var.cpp
+++ b/src/Var.cpp
@@ -1,0 +1,28 @@
+#include <sstream>
+
+#include "Var.h"
+#include "Util.h"
+
+namespace Halide {
+
+Var::Var(const std::string &n) : _name(n) {
+    // Make sure we don't get a unique name with the same name as
+    // this later:
+    Internal::unique_name(n, false);
+}
+
+Var::Var() : _name(Internal::make_entity_name(this, "Halide::Var", 'v')) {
+}
+
+Var Var::implicit(int n) {
+    std::ostringstream str;
+    str << "_" << n;
+    return Var(str.str());
+}
+
+bool Var::is_implicit(const std::string &name) {
+    return Internal::starts_with(name, "_") &&
+        name.find_first_not_of("0123456789", 1) == std::string::npos;
+}
+
+}

--- a/src/Var.h
+++ b/src/Var.h
@@ -5,10 +5,7 @@
  * Defines the Var - the front-end variable
  */
 
-#include <sstream>
-
 #include "IR.h"
-#include "Util.h"
 
 namespace Halide {
 
@@ -21,14 +18,10 @@ class Var {
     std::string _name;
 public:
     /** Construct a Var with the given name */
-    Var(const std::string &n) : _name(n) {
-        // Make sure we don't get a unique name with the same name as
-        // this later:
-        Internal::unique_name(n, false);
-    }
+    Var(const std::string &n);
 
     /** Construct a Var with an automatically-generated unique name. */
-    Var() : _name(Internal::make_entity_name(this, "Halide::Var", 'v')) {}
+    Var();
 
     /** Get the name of a Var */
     const std::string &name() const {return _name;}
@@ -114,11 +107,7 @@ public:
      * anonymous functions (e.g. Func(_0 + _1)) this is considered
      * poor style. Instead use \ref lambda.
      */
-    static Var implicit(int n) {
-        std::ostringstream str;
-        str << "_" << n;
-        return Var(str.str());
-    }
+    EXPORT static Var implicit(int n);
 
     /** Return whether a variable name is of the form for an implicit argument.
      * TODO: This is almost guaranteed to incorrectly fire on user
@@ -126,10 +115,7 @@ public:
      * user Var declarations from making names of this form.
      */
     //{
-    static bool is_implicit(const std::string &name) {
-        return Internal::starts_with(name, "_") &&
-            name.find_first_not_of("0123456789", 1) == std::string::npos;
-    }
+    static bool is_implicit(const std::string &name);
     bool is_implicit() const {
         return is_implicit(name());
     }

--- a/src/Var.h
+++ b/src/Var.h
@@ -18,10 +18,10 @@ class Var {
     std::string _name;
 public:
     /** Construct a Var with the given name */
-    Var(const std::string &n);
+    EXPORT Var(const std::string &n);
 
     /** Construct a Var with an automatically-generated unique name. */
-    Var();
+    EXPORT Var();
 
     /** Get the name of a Var */
     const std::string &name() const {return _name;}
@@ -115,7 +115,7 @@ public:
      * user Var declarations from making names of this form.
      */
     //{
-    static bool is_implicit(const std::string &name);
+    EXPORT static bool is_implicit(const std::string &name);
     bool is_implicit() const {
         return is_implicit(name());
     }

--- a/src/Var.h
+++ b/src/Var.h
@@ -5,10 +5,10 @@
  * Defines the Var - the front-end variable
  */
 
-#include <string>
-#include "Util.h"
-#include "IR.h"
 #include <sstream>
+
+#include "IR.h"
+#include "Util.h"
 
 namespace Halide {
 

--- a/src/VaryingAttributes.h
+++ b/src/VaryingAttributes.h
@@ -2,7 +2,7 @@
 #define __HALIDE_VARYING_ATTRIBUTES__H
 
 /** \file
- * This file contains functions that detect expressions in a GLSL scheduled 
+ * This file contains functions that detect expressions in a GLSL scheduled
  * function that may be evaluated per vertex and interpolated across the domain
  * instead of being evaluated at each pixel location across the image.
  */
@@ -12,20 +12,21 @@
 namespace Halide {
 namespace Internal {
 
-    /** find_linear_expressions(Stmt s) identifies expressions that may be moved
-     * out of the generated fragment shader into a varying attribute. These 
-     * expressions are tagged by wrapping them in a glsl_varying intrinsic
-     */
-    Stmt find_linear_expressions(Stmt s);
+/** find_linear_expressions(Stmt s) identifies expressions that may be moved
+ * out of the generated fragment shader into a varying attribute. These
+ * expressions are tagged by wrapping them in a glsl_varying intrinsic
+ */
+Stmt find_linear_expressions(Stmt s);
 
-    /** Compute a set of 2D mesh coordinates based on the behavior of varying
-     * attribute expressions contained within a GLSL scheduled for loop. This 
-     * method is called during lowering to extract varying attribute
-     * expressions and generate code to evalue them at each mesh vertex 
-     * location. The operation is performed on the host before the draw call 
-     * to invoke the shader
-     */
-    Stmt setup_gpu_vertex_buffer(Stmt s);
+/** Compute a set of 2D mesh coordinates based on the behavior of varying
+ * attribute expressions contained within a GLSL scheduled for loop. This
+ * method is called during lowering to extract varying attribute
+ * expressions and generate code to evalue them at each mesh vertex
+ * location. The operation is performed on the host before the draw call
+ * to invoke the shader
+ */
+Stmt setup_gpu_vertex_buffer(Stmt s);
+
 }
 }
 


### PR DESCRIPTION
This is a cleanup/standardization of the includes/file comments in our headers. Note that this is a branch from #752. 

Surprisingly, this did not seem to observably affect compile time.