### PR TITLE
Fix compile command of turtorial

### DIFF
--- a/tutorial/lesson_01_basics.cpp
+++ b/tutorial/lesson_01_basics.cpp
@@ -12,7 +12,7 @@
 // LD_LIBRARY_PATH=../bin ./lesson_01
 
 // On os x:
-// g++ lesson_01*.cpp -g -I ../include -L ../bin -lHalide -o lesson_01
+// g++ lesson_01*.cpp -g -I ../include -L ../bin -lHalide -o lesson_01 -std=c++11
 // DYLD_LIBRARY_PATH=../bin ./lesson_01
 
 // The only Halide header file you need is Halide.h. It includes all of Halide.

--- a/tutorial/lesson_01_basics.cpp
+++ b/tutorial/lesson_01_basics.cpp
@@ -8,7 +8,7 @@
 // Otherwise, see the platform-specific compiler invocations below.
 
 // On linux, you can compile and run it like so:
-// g++ lesson_01*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_01
+// g++ lesson_01*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_01 -std=c++1
 // LD_LIBRARY_PATH=../bin ./lesson_01
 
 // On os x:

--- a/tutorial/lesson_02_input_image.cpp
+++ b/tutorial/lesson_02_input_image.cpp
@@ -8,11 +8,11 @@
 // Otherwise, see the platform-specific compiler invocations below.
 
 // On linux, you can compile and run it like so:
-// g++ lesson_02*.cpp -g -I ../include -L ../bin -lHalide `libpng-config --cflags --ldflags` -lpthread -ldl -o lesson_02
+// g++ lesson_02*.cpp -g -I ../include -L ../bin -lHalide `libpng-config --cflags --ldflags` -lpthread -ldl -o lesson_02 -std=c++1
 // LD_LIBRARY_PATH=../bin ./lesson_02
 
 // On os x:
-// g++ lesson_02*.cpp -g -I ../include -L ../bin -lHalide `libpng-config --cflags --ldflags` -o lesson_02
+// g++ lesson_02*.cpp -g -I ../include -L ../bin -lHalide `libpng-config --cflags --ldflags` -o lesson_02 -std=c++11
 // DYLD_LIBRARY_PATH=../bin ./lesson_02
 
 // The only Halide header file you need is Halide.h. It includes all of Halide.

--- a/tutorial/lesson_03_debugging_1.cpp
+++ b/tutorial/lesson_03_debugging_1.cpp
@@ -8,11 +8,11 @@
 // Otherwise, see the platform-specific compiler invocations below.
 
 // On linux, you can compile and run it like so:
-// g++ lesson_03*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_03
+// g++ lesson_03*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_03 -std=c++11
 // LD_LIBRARY_PATH=../bin ./lesson_03
 
 // On os x:
-// g++ lesson_03*.cpp -g -I ../include -L ../bin -lHalide -o lesson_03
+// g++ lesson_03*.cpp -g -I ../include -L ../bin -lHalide -o lesson_03 -std=c++11
 // DYLD_LIBRARY_PATH=../bin ./lesson_03
 
 #include "Halide.h"

--- a/tutorial/lesson_04_debugging_2.cpp
+++ b/tutorial/lesson_04_debugging_2.cpp
@@ -8,11 +8,11 @@
 // Otherwise, see the platform-specific compiler invocations below.
 
 // On linux, you can compile and run it like so:
-// g++ lesson_04*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_04
+// g++ lesson_04*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_04 -std=c++11
 // LD_LIBRARY_PATH=../bin ./lesson_04
 
 // On os x:
-// g++ lesson_04*.cpp -g -I ../include -L ../bin -lHalide -o lesson_04
+// g++ lesson_04*.cpp -g -I ../include -L ../bin -lHalide -o lesson_04 -std=c++11
 // DYLD_LIBRARY_PATH=../bin ./lesson_04
 
 #include "Halide.h"

--- a/tutorial/lesson_05_scheduling_1.cpp
+++ b/tutorial/lesson_05_scheduling_1.cpp
@@ -10,11 +10,11 @@
 // Otherwise, see the platform-specific compiler invocations below.
 
 // On linux, you can compile and run it like so:
-// g++ lesson_05*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_05
+// g++ lesson_05*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_05 -std=c++11
 // LD_LIBRARY_PATH=../bin ./lesson_05
 
 // On os x:
-// g++ lesson_05*.cpp -g -I ../include -L ../bin -lHalide -o lesson_05
+// g++ lesson_05*.cpp -g -I ../include -L ../bin -lHalide -o lesson_05 -std=c++11
 // DYLD_LIBRARY_PATH=../bin ./lesson_05
 
 #include "Halide.h"

--- a/tutorial/lesson_06_realizing_over_shifted_domains.cpp
+++ b/tutorial/lesson_06_realizing_over_shifted_domains.cpp
@@ -9,11 +9,11 @@
 // Otherwise, see the platform-specific compiler invocations below.
 
 // On linux, you can compile and run it like so:
-// g++ lesson_06*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_06
+// g++ lesson_06*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_06 -std=c++11
 // LD_LIBRARY_PATH=../bin ./lesson_06
 
 // On os x:
-// g++ lesson_06*.cpp -g -I ../include -L ../bin -lHalide -o lesson_06
+// g++ lesson_06*.cpp -g -I ../include -L ../bin -lHalide -o lesson_06 -std=c++11
 // DYLD_LIBRARY_PATH=../bin ./lesson_06
 
 #include "Halide.h"


### PR DESCRIPTION
The new version of Halide is using the c++11 feature,but the compile command of  tutorial still use old command to compile without c++11 which will fail when use new version.