### PR TITLE
Catch up with post-r235265 llvm.

### DIFF
--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -303,8 +303,10 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     #if LLVM_VERSION < 33
     Options.JITExceptionHandling = false;
     #endif
+    #if LLVM_VERSION <37
     Options.JITEmitDebugInfo = false;
     Options.JITEmitDebugInfoToDisk = false;
+    #endif
     Options.GuaranteedTailCallOpt = false;
     Options.StackAlignmentOverride = 0;
     // Options.DisableJumpTables = false;

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -303,7 +303,7 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     #if LLVM_VERSION < 33
     Options.JITExceptionHandling = false;
     #endif
-    #if LLVM_VERSION <37
+    #if LLVM_VERSION < 37
     Options.JITEmitDebugInfo = false;
     Options.JITEmitDebugInfoToDisk = false;
     #endif


### PR DESCRIPTION
Remove initializations of the fields that were removed in llvm trunk.

```
r235265: Remove the JITEmitDebugInfo TargetOptions as they're only set and 
not used anywhere in llvm.
```