### PR TITLE
C++11: space no longer needed for nested template brackets

### DIFF
--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -88,10 +88,10 @@ Stmt add_image_checks(Stmt s, Function f, const Target &t,
 
     // Now iterate through all the buffers, creating a list of lets
     // and a list of asserts.
-    vector<pair<string, Expr> > lets_overflow;
-    vector<pair<string, Expr> > lets_required;
-    vector<pair<string, Expr> > lets_constrained;
-    vector<pair<string, Expr> > lets_proposed;
+    vector<pair<string, Expr>> lets_overflow;
+    vector<pair<string, Expr>> lets_required;
+    vector<pair<string, Expr>> lets_constrained;
+    vector<pair<string, Expr>> lets_proposed;
     vector<Stmt> dims_no_overflow_asserts;
     vector<Stmt> asserts_required;
     vector<Stmt> asserts_constrained;
@@ -338,7 +338,7 @@ Stmt add_image_checks(Stmt s, Function f, const Target &t,
         buffer_rewrites.push_back(rewrite);
 
         // Build the constraints tests and proposed sizes.
-        vector<pair<string, Expr> > constraints;
+        vector<pair<string, Expr>> constraints;
         for (int i = 0; i < dimensions; i++) {
             string dim = int_to_string(i);
             string min_name = name + ".min." + dim;

--- a/src/AddParameterChecks.cpp
+++ b/src/AddParameterChecks.cpp
@@ -34,7 +34,7 @@ Stmt add_parameter_checks(Stmt s, const Target &t) {
     s.accept(&finder);
 
     map<string, Expr> replace_with_constrained;
-    vector<pair<string, Expr> > lets;
+    vector<pair<string, Expr>> lets;
 
     struct ParamAssert {
         Expr condition;

--- a/src/BoundaryConditions.cpp
+++ b/src/BoundaryConditions.cpp
@@ -5,7 +5,7 @@ namespace Halide {
 namespace BoundaryConditions {
 
 Func repeat_edge(const Func &source,
-                 const std::vector<std::pair<Expr, Expr> > &bounds) {
+                 const std::vector<std::pair<Expr, Expr>> &bounds) {
     std::vector<Var> args(source.args());
     user_assert(args.size() >= bounds.size()) <<
         "repeat_edge called with more bounds (" << bounds.size() <<
@@ -38,7 +38,7 @@ Func repeat_edge(const Func &source,
 }
 
 Func constant_exterior(const Func &source, Expr value,
-                       const std::vector<std::pair<Expr, Expr> > &bounds) {
+                       const std::vector<std::pair<Expr, Expr>> &bounds) {
     std::vector<Var> args(source.args());
     user_assert(args.size() >= bounds.size()) <<
         "constant_exterior called with more bounds (" << bounds.size() <<
@@ -70,7 +70,7 @@ Func constant_exterior(const Func &source, Expr value,
 
 
 Func repeat_image(const Func &source,
-                  const std::vector<std::pair<Expr, Expr> > &bounds) {
+                  const std::vector<std::pair<Expr, Expr>> &bounds) {
     std::vector<Var> args(source.args());
     user_assert(args.size() >= bounds.size()) <<
         "repeat_image called with more bounds (" << bounds.size() <<
@@ -111,7 +111,7 @@ Func repeat_image(const Func &source,
 }
 
 Func mirror_image(const Func &source,
-                  const std::vector<std::pair<Expr, Expr> > &bounds) {
+                  const std::vector<std::pair<Expr, Expr>> &bounds) {
     std::vector<Var> args(source.args());
     user_assert(args.size() >= bounds.size()) <<
         "mirror_image called with more bounds (" << bounds.size() <<
@@ -152,7 +152,7 @@ Func mirror_image(const Func &source,
 }
 
 Func mirror_interior(const Func &source,
-                     const std::vector<std::pair<Expr, Expr> > &bounds) {
+                     const std::vector<std::pair<Expr, Expr>> &bounds) {
     std::vector<Var> args(source.args());
     user_assert(args.size() >= bounds.size()) <<
         "mirror_interior called with more bounds (" << bounds.size() <<

--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -51,13 +51,13 @@ namespace BoundaryConditions {
 
 namespace Internal {
 
-inline NO_INLINE void collect_bounds(std::vector<std::pair<Expr, Expr> > &collected_bounds,
+inline NO_INLINE void collect_bounds(std::vector<std::pair<Expr, Expr>> &collected_bounds,
                                      Expr min, Expr extent) {
     collected_bounds.push_back(std::make_pair(min, extent));
 }
 
 template <typename ...Bounds>
-inline NO_INLINE void collect_bounds(std::vector<std::pair<Expr, Expr> > &collected_bounds,
+inline NO_INLINE void collect_bounds(std::vector<std::pair<Expr, Expr>> &collected_bounds,
                                      Expr min, Expr extent, Bounds... bounds) {
     collected_bounds.push_back(std::make_pair(min, extent));
     collect_bounds(collected_bounds, bounds...);
@@ -88,11 +88,11 @@ inline NO_INLINE Func func_like_to_func(T func_like) {
  */
 // @{
 EXPORT Func constant_exterior(const Func &source, Expr value,
-                              const std::vector<std::pair<Expr, Expr> > &bounds);
+                              const std::vector<std::pair<Expr, Expr>> &bounds);
 
 template <typename T>
 inline NO_INLINE Func constant_exterior(T func_like, Expr value) {
-    std::vector<std::pair<Expr, Expr> > object_bounds;
+    std::vector<std::pair<Expr, Expr>> object_bounds;
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.push_back(std::make_pair(Expr(func_like.min(i)), Expr(func_like.extent(i))));
     }
@@ -103,7 +103,7 @@ inline NO_INLINE Func constant_exterior(T func_like, Expr value) {
 template <typename T, typename ...Bounds>
 inline NO_INLINE Func constant_exterior(T func_like, Expr value,
                                         Bounds... bounds) {
-    std::vector<std::pair<Expr, Expr> > collected_bounds;
+    std::vector<std::pair<Expr, Expr>> collected_bounds;
     ::Halide::Internal::collect_paired_args(collected_bounds, bounds...);
     return constant_exterior(Internal::func_like_to_func(func_like), value, collected_bounds);
 }
@@ -120,11 +120,11 @@ inline NO_INLINE Func constant_exterior(T func_like, Expr value,
  */
 // @{
 EXPORT Func repeat_edge(const Func &source,
-                        const std::vector<std::pair<Expr, Expr> > &bounds);
+                        const std::vector<std::pair<Expr, Expr>> &bounds);
 
 template <typename T>
 inline NO_INLINE Func repeat_edge(T func_like) {
-    std::vector<std::pair<Expr, Expr> > object_bounds;
+    std::vector<std::pair<Expr, Expr>> object_bounds;
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.push_back(std::make_pair(Expr(func_like.min(i)), Expr(func_like.extent(i))));
     }
@@ -135,7 +135,7 @@ inline NO_INLINE Func repeat_edge(T func_like) {
 
 template <typename T, typename ...Bounds>
 inline NO_INLINE Func repeat_edge(T func_like, Bounds... bounds) {
-    std::vector<std::pair<Expr, Expr> > collected_bounds;
+    std::vector<std::pair<Expr, Expr>> collected_bounds;
     ::Halide::Internal::collect_paired_args(collected_bounds, bounds...);
     return repeat_edge(Internal::func_like_to_func(func_like), collected_bounds);
 }
@@ -152,11 +152,11 @@ inline NO_INLINE Func repeat_edge(T func_like, Bounds... bounds) {
  */
 // @{
 EXPORT Func repeat_image(const Func &source,
-                         const std::vector<std::pair<Expr, Expr> > &bounds);
+                         const std::vector<std::pair<Expr, Expr>> &bounds);
 
 template <typename T>
 inline NO_INLINE Func repeat_image(T func_like) {
-    std::vector<std::pair<Expr, Expr> > object_bounds;
+    std::vector<std::pair<Expr, Expr>> object_bounds;
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.push_back(std::make_pair(Expr(func_like.min(i)), Expr(func_like.extent(i))));
     }
@@ -166,7 +166,7 @@ inline NO_INLINE Func repeat_image(T func_like) {
 
 template <typename T, typename ...Bounds>
 inline NO_INLINE Func repeat_image(T func_like, Bounds... bounds) {
-    std::vector<std::pair<Expr, Expr> > collected_bounds;
+    std::vector<std::pair<Expr, Expr>> collected_bounds;
     ::Halide::Internal::collect_paired_args(collected_bounds, bounds...);
     return repeat_image(Internal::func_like_to_func(func_like), collected_bounds);
 }
@@ -183,11 +183,11 @@ inline NO_INLINE Func repeat_image(T func_like, Bounds... bounds) {
  */
 // @{
 EXPORT Func mirror_image(const Func &source,
-                         const std::vector<std::pair<Expr, Expr> > &bounds);
+                         const std::vector<std::pair<Expr, Expr>> &bounds);
 
 template <typename T>
 inline NO_INLINE Func mirror_image(T func_like) {
-    std::vector<std::pair<Expr, Expr> > object_bounds;
+    std::vector<std::pair<Expr, Expr>> object_bounds;
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.push_back(std::make_pair(Expr(func_like.min(i)), Expr(func_like.extent(i))));
     }
@@ -197,7 +197,7 @@ inline NO_INLINE Func mirror_image(T func_like) {
 
 template <typename T, typename ...Bounds>
 inline NO_INLINE Func mirror_image(T func_like, Bounds... bounds) {
-    std::vector<std::pair<Expr, Expr> > collected_bounds;
+    std::vector<std::pair<Expr, Expr>> collected_bounds;
     ::Halide::Internal::collect_paired_args(collected_bounds, bounds...);
     return mirror_image(Internal::func_like_to_func(func_like), collected_bounds);
 }
@@ -217,11 +217,11 @@ inline NO_INLINE Func mirror_image(T func_like, Bounds... bounds) {
  */
 // @{
 EXPORT Func mirror_interior(const Func &source,
-                            const std::vector<std::pair<Expr, Expr> > &bounds);
+                            const std::vector<std::pair<Expr, Expr>> &bounds);
 
 template <typename T>
 inline NO_INLINE Func mirror_interior(T func_like) {
-    std::vector<std::pair<Expr, Expr> > object_bounds;
+    std::vector<std::pair<Expr, Expr>> object_bounds;
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.push_back(std::make_pair(Expr(func_like.min(i)), Expr(func_like.extent(i))));
     }
@@ -231,7 +231,7 @@ inline NO_INLINE Func mirror_interior(T func_like) {
 
 template <typename T, typename ...Bounds>
 inline NO_INLINE Func mirror_interior(T func_like, Bounds... bounds) {
-    std::vector<std::pair<Expr, Expr> > collected_bounds;
+    std::vector<std::pair<Expr, Expr>> collected_bounds;
     ::Halide::Internal::collect_paired_args(collected_bounds, bounds...);
     return mirror_interior(Internal::func_like_to_func(func_like), collected_bounds);
 }

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -295,7 +295,7 @@ public:
 
             vector<Expr> bounds_inference_args;
 
-            vector<pair<string, Expr> > lets;
+            vector<pair<string, Expr>> lets;
 
             // Iterate through all of the input args to the extern
             // function building a suitable argument list for the
@@ -628,7 +628,7 @@ public:
         // Walk inside of any let statements that don't depend on
         // bounds inference results so that we don't needlessly
         // complicate our bounds expressions.
-        vector<pair<string, Expr> > lets;
+        vector<pair<string, Expr>> lets;
         while (const LetStmt *let = body.as<LetStmt>()) {
             if (depends_on_bounds_inference(let->value)) {
                 break;

--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -242,7 +242,7 @@ Expr common_subexpression_elimination(Expr e) {
     debug(4) << "Canonical form without lets " << e << "\n";
 
     // Figure out which ones we'll pull out as lets and variables.
-    vector<pair<string, Expr> > lets;
+    vector<pair<string, Expr>> lets;
     vector<Expr> new_version(gvn.entries.size());
     map<Expr, Expr, ExprCompare> replacements;
     for (size_t i = 0; i < gvn.entries.size(); i++) {

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -991,7 +991,7 @@ void CodeGen_ARM::visit(const Store *op) {
 
     // First dig through let expressions
     Expr rhs = op->value;
-    vector<pair<string, Expr> > lets;
+    vector<pair<string, Expr>> lets;
     while (const Let *let = rhs.as<Let>()) {
         rhs = let->body;
         lets.push_back(make_pair(let->name, let->value));

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -258,22 +258,22 @@ CodeGen_LLVM *CodeGen_LLVM::new_for_target(const Target &target,
                                    Target::OpenGL))) {
 #ifdef WITH_X86
         if (target.arch == Target::X86) {
-            return make_codegen<CodeGen_GPU_Host<CodeGen_X86> >(target, context);
+            return make_codegen<CodeGen_GPU_Host<CodeGen_X86>>(target, context);
         }
 #endif
 #if defined(WITH_ARM) || defined(WITH_AARCH64)
         if (target.arch == Target::ARM) {
-            return make_codegen<CodeGen_GPU_Host<CodeGen_ARM> >(target, context);
+            return make_codegen<CodeGen_GPU_Host<CodeGen_ARM>>(target, context);
         }
 #endif
 #ifdef WITH_MIPS
         if (target.arch == Target::MIPS) {
-            return make_codegen<CodeGen_GPU_Host<CodeGen_MIPS> >(target, context);
+            return make_codegen<CodeGen_GPU_Host<CodeGen_MIPS>>(target, context);
         }
 #endif
 #ifdef WITH_NATIVE_CLIENT
         if (target.arch == Target::PNaCl) {
-            return make_codegen<CodeGen_GPU_Host<CodeGen_PNaCl> >(target, context);
+            return make_codegen<CodeGen_GPU_Host<CodeGen_PNaCl>>(target, context);
         }
 #endif
 

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -106,7 +106,7 @@ protected:
     llvm::Module *module;
     llvm::Function *function;
     llvm::LLVMContext *context;
-    llvm::IRBuilder<true, llvm::ConstantFolder, llvm::IRBuilderDefaultInserter<true> > *builder;
+    llvm::IRBuilder<true, llvm::ConstantFolder, llvm::IRBuilderDefaultInserter<true>> *builder;
     llvm::Value *value;
     llvm::MDNode *very_likely_branch;
     //@}

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1606,8 +1606,8 @@ class InferArguments : public IRGraphVisitor {
 public:
     vector<Argument> arg_types;
     vector<const void *> arg_values;
-    vector<pair<int, Internal::Parameter> > image_param_args;
-    vector<pair<int, Buffer> > image_args;
+    vector<pair<int, Internal::Parameter>> image_param_args;
+    vector<pair<int, Buffer>> image_args;
 
     InferArguments(const string &o, bool include_buffers = true)
         : output(o), include_buffers(include_buffers) {

--- a/src/Func.h
+++ b/src/Func.h
@@ -416,7 +416,7 @@ class Func {
     /** Some of the arg_values need to be rebound on every call if the
      * image params change. The pointers for the scalar params will
      * still be valid though. */
-    std::vector<std::pair<int, Internal::Parameter> > image_param_args;
+    std::vector<std::pair<int, Internal::Parameter>> image_param_args;
 
     /** The user context that's used when jitting. This is not settable
      * by user code, but is reserved for internal use.

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -477,7 +477,7 @@ public:
                                                         const GeneratorParamValues &params);
 
 private:
-    using GeneratorFactoryMap = std::map<const std::string, std::unique_ptr<GeneratorFactory> >;
+    using GeneratorFactoryMap = std::map<const std::string, std::unique_ptr<GeneratorFactory>>;
 
     GeneratorFactoryMap factories;
     std::mutex mutex;

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -838,7 +838,7 @@ private:
         // Open the object file in question. The API to do this keeps changing.
         #if LLVM_VERSION >= 36
 
-        llvm::ErrorOr<llvm::object::OwningBinary<llvm::object::ObjectFile> > maybe_obj =
+        llvm::ErrorOr<llvm::object::OwningBinary<llvm::object::ObjectFile>> maybe_obj =
             llvm::object::ObjectFile::createObjectFile(binary);
 
         if (!maybe_obj) {
@@ -850,7 +850,7 @@ private:
 
         #elif LLVM_VERSION >= 35
 
-        llvm::ErrorOr<std::unique_ptr<llvm::object::ObjectFile> > maybe_obj =
+        llvm::ErrorOr<std::unique_ptr<llvm::object::ObjectFile>> maybe_obj =
             llvm::object::ObjectFile::createObjectFile(binary);
 
         if (!maybe_obj) {
@@ -1013,10 +1013,10 @@ private:
 
             uint8_t address_size = e.getU8(&off);
 
-            vector<pair<FunctionInfo, int> > func_stack;
-            vector<pair<TypeInfo, int> > type_stack;
-            vector<pair<std::string, int> > namespace_stack;
-            vector<pair<vector<LiveRange>, int> > live_range_stack;
+            vector<pair<FunctionInfo, int>> func_stack;
+            vector<pair<TypeInfo, int>> type_stack;
+            vector<pair<std::string, int>> namespace_stack;
+            vector<pair<vector<LiveRange>, int>> live_range_stack;
 
             int stack_depth = 0;
 

--- a/src/ParallelRVar.cpp
+++ b/src/ParallelRVar.cpp
@@ -30,7 +30,7 @@ class FindLoads : public IRVisitor {
 public:
     FindLoads(const string &f) : func(f) {}
 
-    vector<vector<Expr> > loads;
+    vector<vector<Expr>> loads;
 };
 
 /** Rename all free variables to unique new names. */

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -130,7 +130,7 @@ private:
 
     // A set of let statements for common subexpressions inside the
     // min_vals and max_vals.
-    vector<pair<string, Expr> > containing_lets;
+    vector<pair<string, Expr>> containing_lets;
 
     bool likely;
 
@@ -341,7 +341,7 @@ private:
         }
 
         // Peel off lets.
-        vector<pair<string, Expr> > new_lets;
+        vector<pair<string, Expr>> new_lets;
         while (const Let *let = solved.as<Let>()) {
             new_lets.push_back(make_pair(let->name, let->value) );
             solved = let->body;
@@ -646,7 +646,7 @@ class PartitionLoops : public IRMutator {
             bool make_epilogue = max_steady.defined();
 
             // Accrue a stack of let statements defining the steady state start and end.
-            vector<pair<string, Expr> > lets;
+            vector<pair<string, Expr>> lets;
 
             if (make_prologue) {
                 // Clamp the prologue end to within the existing loop bounds,

--- a/src/RDom.cpp
+++ b/src/RDom.cpp
@@ -72,7 +72,7 @@ RDom::RDom(ReductionDomain d) : dom(d) {
     }
 }
 
-void RDom::initialize_from_ranges(const std::vector<std::pair<Expr, Expr> > &ranges, string name) {
+void RDom::initialize_from_ranges(const std::vector<std::pair<Expr, Expr>> &ranges, string name) {
     if (name.empty()) {
         name = make_entity_name(this, "Halide::RDom", 'r');
     }

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -183,8 +183,8 @@ class RDom {
 
     void init_vars(std::string name);
 
-	EXPORT void initialize_from_ranges(const std::vector<std::pair<Expr, Expr> > &ranges, std::string name = "");
-	
+	EXPORT void initialize_from_ranges(const std::vector<std::pair<Expr, Expr>> &ranges, std::string name = "");
+
 	template <typename... Args>
 	NO_INLINE void initialize_from_ranges(std::vector<std::pair<Expr, Expr>> &ranges, Expr min, Expr extent, Args... args) {
 		ranges.push_back(std::make_pair(min, extent));
@@ -198,13 +198,13 @@ public:
     /** Construct a multi-dimensional reduction domain with the given name. If the name
      * is left blank, a unique one is auto-generated. */
 	// @{
-	NO_INLINE RDom(const std::vector<std::pair<Expr, Expr> > &ranges, std::string name = "") {
+	NO_INLINE RDom(const std::vector<std::pair<Expr, Expr>> &ranges, std::string name = "") {
 		initialize_from_ranges(ranges, name);
 	}
 
     template <typename... Args>
 	NO_INLINE RDom(Expr min, Expr extent, Args... args) {
-		// This should really just be a delegating constructor, but I couldn't make 
+		// This should really just be a delegating constructor, but I couldn't make
 		// that work with variadic template unpacking in visual studio 2013
 		std::vector<std::pair<Expr, Expr>> ranges;
 		initialize_from_ranges(ranges, min, extent, args...);

--- a/src/RealizationOrder.cpp
+++ b/src/RealizationOrder.cpp
@@ -13,13 +13,13 @@ using std::vector;
 using std::pair;
 
 void realization_order_dfs(string current,
-                           const map<string, set<string> > &graph,
+                           const map<string, set<string>> &graph,
                            set<string> &visited,
                            set<string> &result_set,
                            vector<string> &order) {
     visited.insert(current);
 
-    map<string, set<string> >::const_iterator iter = graph.find(current);
+    map<string, set<string>>::const_iterator iter = graph.find(current);
     internal_assert(iter != graph.end());
 
     for (const string &fn : iter->second) {
@@ -41,7 +41,7 @@ vector<string> realization_order(const Function &output,
 
     // Make a DAG representing the pipeline. Each function maps to the
     // set describing its inputs.
-    map<string, set<string> > graph;
+    map<string, set<string>> graph;
 
     for (const pair<string, Function> &caller : env) {
         set<string> &s = graph[caller.first];

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -118,7 +118,7 @@ Stmt build_provide_loop_nest(Function f,
     }
 
     // Define the function args in terms of the loop variables using the splits
-    map<string, pair<string, Expr> > base_values;
+    map<string, pair<string, Expr>> base_values;
     for (const Split &split : splits) {
         Expr outer = Variable::make(Int(32), prefix + split.outer);
         if (split.is_split()) {
@@ -342,7 +342,7 @@ Stmt build_produce(Function f) {
 
         const string &extern_name = f.extern_function_name();
 
-        vector<pair<string, Expr> > lets;
+        vector<pair<string, Expr>> lets;
 
         // Iterate through all of the input args to the extern
         // function building a suitable argument list for the
@@ -660,7 +660,7 @@ private:
         Stmt body = for_loop->body;
 
         // Dig through any let statements
-        vector<pair<string, Expr> > lets;
+        vector<pair<string, Expr>> lets;
         while (const LetStmt *l = body.as<LetStmt>()) {
             lets.push_back(make_pair(l->name, l->value));
             body = l->body;

--- a/src/Scope.h
+++ b/src/Scope.h
@@ -69,7 +69,7 @@ public:
 template<typename T>
 class Scope {
 private:
-    std::map<std::string, SmallStack<T> > table;
+    std::map<std::string, SmallStack<T>> table;
 
     // Copying a scope object copies a large table full of strings and
     // stacks. Bad idea.
@@ -99,7 +99,7 @@ public:
 
     /** Retrieve the value referred to by a name */
     T get(const std::string &name) const {
-        typename std::map<std::string, SmallStack<T> >::const_iterator iter = table.find(name);
+        typename std::map<std::string, SmallStack<T>>::const_iterator iter = table.find(name);
         if (iter == table.end() || iter->second.empty()) {
             if (containing_scope) {
                 return containing_scope->get(name);
@@ -112,7 +112,7 @@ public:
 
     /** Return a reference to an entry. Does not consider the containing scope. */
     T &ref(const std::string &name) {
-        typename std::map<std::string, SmallStack<T> >::iterator iter = table.find(name);
+        typename std::map<std::string, SmallStack<T>>::iterator iter = table.find(name);
         if (iter == table.end() || iter->second.empty()) {
             internal_error << "Symbol '" << name << "' not found\n";
         }
@@ -121,7 +121,7 @@ public:
 
     /** Tests if a name is in scope */
     bool contains(const std::string &name) const {
-        typename std::map<std::string, SmallStack<T> >::const_iterator iter = table.find(name);
+        typename std::map<std::string, SmallStack<T>>::const_iterator iter = table.find(name);
         if (iter == table.end() || iter->second.empty()) {
             if (containing_scope) {
                 return containing_scope->contains(name);
@@ -143,7 +143,7 @@ public:
      * was (or remove it entirely if there was nothing else of the
      * same name in an outer scope) */
     void pop(const std::string &name) {
-        typename std::map<std::string, SmallStack<T> >::iterator iter = table.find(name);
+        typename std::map<std::string, SmallStack<T>>::iterator iter = table.find(name);
         internal_assert(iter != table.end()) << "Name not in symbol table: " << name << "\n";
         iter->second.pop();
         if (iter->second.empty()) {
@@ -153,9 +153,9 @@ public:
 
     /** Iterate through the scope. Does not capture any containing scope. */
     class const_iterator {
-        typename std::map<std::string, SmallStack<T> >::const_iterator iter;
+        typename std::map<std::string, SmallStack<T>>::const_iterator iter;
     public:
-        explicit const_iterator(const typename std::map<std::string, SmallStack<T> >::const_iterator &i) :
+        explicit const_iterator(const typename std::map<std::string, SmallStack<T>>::const_iterator &i) :
             iter(i) {
         }
 
@@ -191,9 +191,9 @@ public:
     }
 
     class iterator {
-        typename std::map<std::string, SmallStack<T> >::iterator iter;
+        typename std::map<std::string, SmallStack<T>>::iterator iter;
     public:
-        explicit iterator(typename std::map<std::string, SmallStack<T> >::iterator i) :
+        explicit iterator(typename std::map<std::string, SmallStack<T>>::iterator i) :
             iter(i) {
         }
 

--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -1071,7 +1071,7 @@ public:
 
     // Expressions for the spatial values of each coordinate in the GPU scheduled
     // loop dimensions.
-    typedef std::map<std::string, std::vector<Expr> > DimsType;
+    typedef std::map<std::string, std::vector<Expr>> DimsType;
     DimsType dims;
 
     // The channel of each varying attribute in the interleaved vertex buffer
@@ -1160,7 +1160,7 @@ public:
             Expr loop0_max = Add::make(loop0->min, loop0->extent);
             Expr loop1_max = Add::make(loop1->min, loop1->extent);
 
-            std::vector<std::vector<Expr> > coords(2);
+            std::vector<std::vector<Expr>> coords(2);
 
             coords[0].push_back(loop0->min);
             coords[0].push_back(loop0_max);


### PR DESCRIPTION
This is purely stylistic, but IMHO removes a longstanding C++ wart.