### PR TITLE
Remove variadic compile to file

### DIFF
--- a/apps/bilateral_grid/bilateral_grid.cpp
+++ b/apps/bilateral_grid/bilateral_grid.cpp
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
         bilateral_grid.compute_root().parallel(y).vectorize(x, 4);
     }
 
-    bilateral_grid.compile_to_file("bilateral_grid", r_sigma, input, target);
+    bilateral_grid.compile_to_file("bilateral_grid", {r_sigma, input}, target);
 
     return 0;
 }

--- a/apps/blur/halide_blur.cpp
+++ b/apps/blur/halide_blur.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     blur_y.split(y, y, yi, 8).parallel(y).vectorize(x, 8);
     blur_x.store_at(blur_y, y).compute_at(blur_y, yi).vectorize(x, 8);
 
-    blur_y.compile_to_file("halide_blur", input);
+    blur_y.compile_to_file("halide_blur", {input});
 
     return 0;
 }

--- a/apps/local_laplacian/local_laplacian_gen.cpp
+++ b/apps/local_laplacian/local_laplacian_gen.cpp
@@ -145,7 +145,8 @@ int main(int argc, char **argv) {
         }
     }
 
-    output.compile_to_file("local_laplacian", levels, alpha, beta, input, target);
+    output.compile_to_file("local_laplacian", {levels, alpha, beta, input}, target);
+    output.compile_to_assembly("local_laplacian.s", {levels, alpha, beta, input}, target);
 
     return 0;
 }

--- a/apps/local_laplacian/local_laplacian_gen.cpp
+++ b/apps/local_laplacian/local_laplacian_gen.cpp
@@ -146,7 +146,6 @@ int main(int argc, char **argv) {
     }
 
     output.compile_to_file("local_laplacian", {levels, alpha, beta, input}, target);
-    output.compile_to_assembly("local_laplacian.s", {levels, alpha, beta, input}, target);
 
     return 0;
 }

--- a/apps/modules/generate_pipeline.cpp
+++ b/apps/modules/generate_pipeline.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
     vignette.compute_at(output, xo);
     flip.compute_at(output, xo);
 
-    output.compile_to_file("pipeline", in);
+    output.compile_to_file("pipeline", {in});
 
     return 0;
 }

--- a/apps/modules/my_library/flip.cpp
+++ b/apps/modules/my_library/flip.cpp
@@ -14,8 +14,7 @@ int main(int argc, char **argv) {
 
     flip.vectorize(x, 4);
 
-    flip.compile_to_file("flip_impl", in, total_width);
+    flip.compile_to_file("flip_impl", {in, total_width});
 
     return 0;
 }
-

--- a/apps/modules/my_library/vignette.cpp
+++ b/apps/modules/my_library/vignette.cpp
@@ -19,8 +19,7 @@ int main(int argc, char **argv) {
     // Any scheduling for a goes here
     vignette.vectorize(x, 4);
 
-    vignette.compile_to_file("vignette_impl", in, center_x, center_y, radius);
+    vignette.compile_to_file("vignette_impl", {in, center_x, center_y, radius});
 
     return 0;
 }
-

--- a/apps/wavelet/wavelet.cpp
+++ b/apps/wavelet/wavelet.cpp
@@ -64,16 +64,16 @@ int main(int argc, char **argv) {
     Func wavelet_clamped = BoundaryConditions::repeat_edge(wavelet);
 
     Func inv_haar_x = inverse_haar_x(wavelet_clamped);
-    inv_haar_x.compile_to_file("inverse_haar_x", wavelet);
+    inv_haar_x.compile_to_file("inverse_haar_x", {wavelet});
 
     Func for_haar_x = haar_x(clamped);
-    for_haar_x.compile_to_file("haar_x", image);
+    for_haar_x.compile_to_file("haar_x", {image});
 
     Func inv_daub_x = inverse_daubechies_x(wavelet_clamped);
-    inv_daub_x.compile_to_file("inverse_daubechies_x", wavelet);
+    inv_daub_x.compile_to_file("inverse_daubechies_x", {wavelet});
 
     Func for_daub_x = daubechies_x(clamped);
-    for_daub_x.compile_to_file("daubechies_x", image);
+    for_daub_x.compile_to_file("daubechies_x", {image});
 
     return 0;
 }

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2087,35 +2087,6 @@ void Func::compile_to_file(const string &filename_prefix, const vector<Argument>
     }
 }
 
-void Func::compile_to_file(const string &filename_prefix, const Target &target) {
-    compile_to_file(filename_prefix, vector<Argument>(), target);
-}
-
-void Func::compile_to_file(const string &filename_prefix, Argument a,
-                           const Target &target) {
-    compile_to_file(filename_prefix, Internal::vec(a), target);
-}
-
-void Func::compile_to_file(const string &filename_prefix, Argument a, Argument b,
-                           const Target &target) {
-    compile_to_file(filename_prefix, Internal::vec(a, b), target);
-}
-
-void Func::compile_to_file(const string &filename_prefix, Argument a, Argument b, Argument c,
-                           const Target &target) {
-    compile_to_file(filename_prefix, Internal::vec(a, b, c), target);
-}
-
-void Func::compile_to_file(const string &filename_prefix, Argument a, Argument b, Argument c, Argument d,
-                           const Target &target) {
-    compile_to_file(filename_prefix, Internal::vec(a, b, c, d), target);
-}
-
-void Func::compile_to_file(const string &filename_prefix, Argument a, Argument b, Argument c, Argument d, Argument e,
-                           const Target &target) {
-    compile_to_file(filename_prefix, Internal::vec(a, b, c, d, e), target);
-}
-
 void Func::compile_to_assembly(const string &filename, const vector<Argument> &args, const string &fn_name,
                                const Target &target) {
     compile_module_to_assembly(compile_to_module(args, fn_name, target), filename);

--- a/src/Func.h
+++ b/src/Func.h
@@ -669,20 +669,6 @@ public:
     // @{
     EXPORT void compile_to_file(const std::string &filename_prefix, const std::vector<Argument> &args,
                                 const Target &target = get_target_from_environment());
-// TODO: Add C++11 varargs template, which is trickier due to final optional argument.
-    EXPORT void compile_to_file(const std::string &filename_prefix,
-                                const Target &target = get_target_from_environment());
-    EXPORT void compile_to_file(const std::string &filename_prefix, Argument a,
-                                const Target &target = get_target_from_environment());
-    EXPORT void compile_to_file(const std::string &filename_prefix, Argument a, Argument b,
-                                const Target &target = get_target_from_environment());
-    EXPORT void compile_to_file(const std::string &filename_prefix, Argument a, Argument b, Argument c,
-                                const Target &target = get_target_from_environment());
-    EXPORT void compile_to_file(const std::string &filename_prefix, Argument a, Argument b, Argument c, Argument d,
-                                const Target &target = get_target_from_environment());
-    EXPORT void compile_to_file(const std::string &filename_prefix, Argument a, Argument b, Argument c, Argument d, Argument e,
-                                const Target &target = get_target_from_environment());
-
     // @}
 
     /** Store an internal representation of lowered code as a self


### PR DESCRIPTION
Now with C++11 available, I think they're less clear than just wrapping the arguments in {}