### PR TITLE
Add missing WEAK to android halide_opengl_get_proc_address()

### DIFF
--- a/src/runtime/android_opengl_context.cpp
+++ b/src/runtime/android_opengl_context.cpp
@@ -106,7 +106,7 @@ WEAK int halide_opengl_create_context(void *user_context) {
     return 0;
 }
 
-void *halide_opengl_get_proc_address(void *user_context, const char *name) {
+WEAK void *halide_opengl_get_proc_address(void *user_context, const char *name) {
     return (void*)eglGetProcAddress(name);
 }
 


### PR DESCRIPTION
HelloAndroidGL won’t build right now, as the LLVM linker requires all
runtime module functions beginning with “halide_” to be weak, and all
other platform versions of this function are also weak