### PR TITLE
Fix "client-bound" buffers in OpenGL runtime

### DIFF
--- a/apps/HelloAndroidGL/jni/android_halide_gl_native.cpp
+++ b/apps/HelloAndroidGL/jni/android_halide_gl_native.cpp
@@ -12,6 +12,8 @@
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,"halide_native",__VA_ARGS__)
 #define  LOGE(...)  __android_log_print(ANDROID_LOG_ERROR,"halide_native",__VA_ARGS__)
 
+void * const user_context = NULL;
+
 extern "C"
 JNIEXPORT void JNICALL Java_org_halide_1lang_hellohalidegl_HalideGLView_processTextureHalide(
     JNIEnv *env, jobject obj, jint dst, jint width, jint height) {
@@ -28,11 +30,11 @@ JNIEXPORT void JNICALL Java_org_halide_1lang_hellohalidegl_HalideGLView_processT
     dstBuf.min[2] = 0;
     dstBuf.elem_size = 1;
     dstBuf.host = NULL;
-    if (dst == 0) {
-        // Let Halide render directly to the current framebuffer.
-        dstBuf.dev = halide_opengl_output_client_bound();
-    } else {
-        dstBuf.dev = dst;
+    // If dst == 0, let Halide render directly to the current framebuffer.
+    uintptr_t textureId = (dst == 0) ? halide_opengl_client_bound_texture : dst;
+    int result = halide_opengl_wrap_texture(user_context, &dstBuf, textureId);
+    if (result != 0) {
+        halide_error(user_context, "halide_opengl_wrap_texture failed");
     }
 
     static float time = 0.0f;
@@ -40,6 +42,11 @@ JNIEXPORT void JNICALL Java_org_halide_1lang_hellohalidegl_HalideGLView_processT
         LOGD("Halide filter failed with error code %d\n", err);
     }
     time += 1.0f/16.0f;
+
+    uintptr_t detached = halide_opengl_detach_texture(user_context, &dstBuf);
+    if (detached != dst) {
+        halide_error(user_context, "halide_opengl_detach_texture failed");
+    }
 }
 
 extern "C"

--- a/apps/HelloAndroidGL/jni/android_halide_gl_native.cpp
+++ b/apps/HelloAndroidGL/jni/android_halide_gl_native.cpp
@@ -30,11 +30,17 @@ JNIEXPORT void JNICALL Java_org_halide_1lang_hellohalidegl_HalideGLView_processT
     dstBuf.min[2] = 0;
     dstBuf.elem_size = 1;
     dstBuf.host = NULL;
-    // If dst == 0, let Halide render directly to the current framebuffer.
-    uintptr_t textureId = (dst == 0) ? halide_opengl_client_bound_texture : dst;
-    int result = halide_opengl_wrap_texture(user_context, &dstBuf, textureId);
-    if (result != 0) {
-        halide_error(user_context, "halide_opengl_wrap_texture failed");
+    // If dst == 0, let Halide render directly to the current render target.
+    if (dst == 0) {
+        int result = halide_opengl_wrap_render_target(user_context, &dstBuf);
+        if (result != 0) {
+            halide_error(user_context, "halide_opengl_wrap_render_target failed");
+        }
+    } else {
+        int result = halide_opengl_wrap_texture(user_context, &dstBuf, dst);
+        if (result != 0) {
+            halide_error(user_context, "halide_opengl_wrap_texture failed");
+        }
     }
 
     static float time = 0.0f;

--- a/src/runtime/HalideRuntimeOpenGL.h
+++ b/src/runtime/HalideRuntimeOpenGL.h
@@ -35,7 +35,7 @@ extern int halide_opengl_run(void *user_context,
 // @}
 
 /** When passed to halide_opengl_wrap_texture, this value for texture id is used
- * to mark the buffer_t.dev field with a constantindicating that the OpenGL object
+ * to mark the buffer_t.dev field with a constant indicating that the OpenGL object
  * corresponding to the buffer_t is bound by the app and not by the Halide runtime.
  * For example, the buffer_t may be backed by an FBO already bound by the application.
  * (Note that 0 is never a legal OpenGL texture ID, so this should never overlap a valid id.)

--- a/src/runtime/HalideRuntimeOpenGL.h
+++ b/src/runtime/HalideRuntimeOpenGL.h
@@ -34,6 +34,14 @@ extern int halide_opengl_run(void *user_context,
                              int num_coords_dim1);
 // @}
 
+/** When passed to halide_opengl_wrap_texture, this value for texture id is used
+ * to mark the buffer_t.dev field with a constantindicating that the OpenGL object
+ * corresponding to the buffer_t is bound by the app and not by the Halide runtime.
+ * For example, the buffer_t may be backed by an FBO already bound by the application.
+ * (Note that 0 is never a legal OpenGL texture ID, so this should never overlap a valid id.)
+ */
+const uintptr_t halide_opengl_client_bound_texture = 0;
+
 /** Set the underlying OpenGL texture for a buffer. The texture must
  * have an extent large enough to cover that specified by the buffer_t
  * extent fields. The dev field of the buffer_t must be NULL when this
@@ -44,7 +52,7 @@ extern int halide_opengl_wrap_texture(void *user_context, struct buffer_t *buf, 
 
 /** Disconnect this buffer_t from the texture it was previously
  * wrapped around. Should only be called for a buffer_t that
- * halide_cuda_wrap_device_ptr was previously called on. Frees any
+ * halide_opengl_wrap_texture was previously called on. Frees any
  * storage associated with the binding of the buffer_t and the device
  * pointer, but does not free the texture. The previously wrapped
  * texture is returned. . The dev field of the buffer_t will be NULL
@@ -58,12 +66,6 @@ extern uintptr_t halide_opengl_detach_texture(void *user_context, struct buffer_
  *  returns 0.
  */
 extern uintptr_t halide_opengl_get_texture(void *user_context, struct buffer_t *buf);
-
-/** This function is called to populate the buffer_t.dev field with a constant
- * indicating that the OpenGL object corresponding to the buffer_t is bound by
- * the app and not by the Halide runtime. For example, the buffer_t may be
- * backed by an FBO already bound by the application. */
-extern uint64_t halide_opengl_output_client_bound();
 
 /** Forget all state associated with the previous OpenGL context.  This is
  * similar to halide_opengl_release, except that we assume that all OpenGL

--- a/src/runtime/HalideRuntimeOpenGL.h
+++ b/src/runtime/HalideRuntimeOpenGL.h
@@ -34,14 +34,6 @@ extern int halide_opengl_run(void *user_context,
                              int num_coords_dim1);
 // @}
 
-/** When passed to halide_opengl_wrap_texture, this value for texture id is used
- * to mark the buffer_t.dev field with a constant indicating that the OpenGL object
- * corresponding to the buffer_t is bound by the app and not by the Halide runtime.
- * For example, the buffer_t may be backed by an FBO already bound by the application.
- * (Note that 0 is never a legal OpenGL texture ID, so this should never overlap a valid id.)
- */
-const uintptr_t halide_opengl_client_bound_texture = 0;
-
 /** Set the underlying OpenGL texture for a buffer. The texture must
  * have an extent large enough to cover that specified by the buffer_t
  * extent fields. The dev field of the buffer_t must be NULL when this
@@ -50,20 +42,28 @@ const uintptr_t halide_opengl_client_bound_texture = 0;
  * are left unmodified. */
 extern int halide_opengl_wrap_texture(void *user_context, struct buffer_t *buf, uintptr_t texture_id);
 
+/** Set the underlying OpenGL texture for a buffer to refer to the current render target
+ * (e.g., the frame buffer or an FBO). The render target must have an extent large enough
+ * to cover that specified by the buffer_t extent fields. The dev field of the buffer_t
+ * must be NULL when this routine is called. This call can fail due to running out of memory
+ * The device and host dirty bits are left unmodified. */
+extern int halide_opengl_wrap_render_target(void *user_context, struct buffer_t *buf);
+
 /** Disconnect this buffer_t from the texture it was previously
  * wrapped around. Should only be called for a buffer_t that
  * halide_opengl_wrap_texture was previously called on. Frees any
  * storage associated with the binding of the buffer_t and the device
  * pointer, but does not free the texture. The previously wrapped
- * texture is returned. . The dev field of the buffer_t will be NULL
+ * texture is returned. (If the buffer was wrapped with halide_opengl_wrap_render_target,
+ * the return value is always zero.) The dev field of the buffer_t will be NULL
  * on return.
  */
 extern uintptr_t halide_opengl_detach_texture(void *user_context, struct buffer_t *buf);
 
 /** Return the underlying texture for a buffer_t. This buffer
  *  must be valid on an OpenGL device, or not have any associated device
- *  memory. If there is no device memory (dev field is NULL), this
- *  returns 0.
+ *  memory. If there is no device memory (dev field is NULL), or if the buffer
+ *  was wrapped via halide_opengl_wrap_render_target(), this returns 0.
  */
 extern uintptr_t halide_opengl_get_texture(void *user_context, struct buffer_t *buf);
 

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -773,7 +773,7 @@ WEAK TextureInfo *find_texture(GLuint tex) {
 }
 
 // Allocate new TextureInfo, fill it in, add to global list.
-static TextureInfo *new_texture(GLuint tex, int32_t min[4], int32_t extent[4], bool halide_allocated) {
+WEAK TextureInfo *new_texture(GLuint tex, int32_t min[4], int32_t extent[4], bool halide_allocated) {
     TextureInfo *texinfo = (TextureInfo*)malloc(sizeof(TextureInfo));
     texinfo->id = tex;
     for (int i=0; i<3; i++) {
@@ -790,7 +790,7 @@ static TextureInfo *new_texture(GLuint tex, int32_t min[4], int32_t extent[4], b
 
 // Find TextureInfo with the given texture ID and remove it from the global list,
 // but DO NOT free the TextureInfo itself. If not found, return NULL.
-static TextureInfo *unlink_texture(GLuint tex) {
+WEAK TextureInfo *unlink_texture(GLuint tex) {
     TextureInfo **ptr = &global_state.textures;
     TextureInfo *texinfo = *ptr;
     for (; texinfo != NULL; ptr = &texinfo->next, texinfo = *ptr) {


### PR DESCRIPTION
This was pretty much completely broken. HelloAndroidGL now works
properly.