### PR TITLE
Remove GeneratorBase::get_filter_parameters()

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -215,15 +215,15 @@ void GeneratorBase::build_params() {
             internal_assert(param != nullptr);
             user_assert(param->is_explicit_name()) << "Params in Generators must have explicit names: " << param->name();
             user_assert(is_valid_name(param->name())) << "Invalid Param name: " << param->name();
-            user_assert(filter_params.find(param->name()) == filter_params.end())
-                << "Duplicate Param name: " << param->name();
+            for (const Argument& arg : filter_arguments) {
+                user_assert(arg.name != param->name()) << "Duplicate Param name: " << param->name();
+            }
             Expr def, min, max;
             if (!param->is_buffer()) {
                 def = param->get_scalar_expr();
                 min = param->get_min_value();
                 max = param->get_max_value();
             }
-            filter_params[param->name()] = param;
             filter_arguments.push_back(Argument(param->name(),
                 param->is_buffer() ? Argument::InputBuffer : Argument::InputScalar,
                 param->type(), param->dimensions(), def, min, max));
@@ -241,15 +241,6 @@ void GeneratorBase::build_params() {
         }
         params_built = true;
     }
-}
-
-std::vector<Internal::Parameter> GeneratorBase::get_filter_parameters() {
-    build_params();
-    std::vector<Internal::Parameter> result;
-    for (size_t i = 0; i < filter_arguments.size(); ++i) {
-        result.push_back(*filter_params[filter_arguments[i].name]);
-    }
-    return result;
 }
 
 GeneratorParamValues GeneratorBase::get_generator_param_values() {

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -407,10 +407,6 @@ public:
         return filter_arguments;
     }
 
-    // This is a bit of a stopgap: we need info that isn't in Argument,
-    // but there's probably a better way than surfacing Internal::Parameter.
-    EXPORT std::vector<Internal::Parameter> get_filter_parameters();
-
     /** Given a data type, return an estimate of the "natural" vector size
      * for that data type when compiling for the current target. */
     int natural_vector_size(Halide::Type t) const {
@@ -442,7 +438,6 @@ private:
     // through these in a predictable order; do not change to unordered_map (etc)
     // without considering that.
     std::vector<Argument> filter_arguments;
-    std::map<std::string, Internal::Parameter *> filter_params;
     std::map<std::string, Internal::GeneratorParamBase *> generator_params;
     bool params_built;
 

--- a/test/generator/paramtest_jittest.cpp
+++ b/test/generator/paramtest_jittest.cpp
@@ -7,7 +7,6 @@ using Halide::Expr;
 using Halide::Func;
 using Halide::Image;
 using Halide::Internal::GeneratorParamValues;
-using Halide::Internal::Parameter;
 
 const int kSize = 32;
 
@@ -115,11 +114,10 @@ int main(int argc, char **argv) {
         }
     }
 
-    // Test Generator::get_filter_arguments() and Generator::get_filter_parameters()
+    // Test Generator::get_filter_arguments()
     {
         ParamTest gen;
         std::vector<Argument> args = gen.get_filter_arguments();
-        std::vector<Parameter> params = gen.get_filter_parameters();
         if (args.size() != 3 ||
             args[0].name != "input" || args[1].name != "float_arg" || args[2].name != "int_arg" ||
             !args[0].is_buffer() || !args[1].is_scalar() || !args[2].is_scalar() ||
@@ -137,32 +135,6 @@ int main(int argc, char **argv) {
             args[2].min.defined() ||
             args[2].max.defined()) {
             fprintf(stderr, "constraints for int_arg are incorrect\n");
-            exit(-1);
-        }
-        if (params.size() != 3 || params[0].name() != "input" || params[1].name() != "float_arg" || params[2].name() != "int_arg") {
-            fprintf(stderr, "get_filter_parameters is incorrect\n");
-            exit(-1);
-        }
-        // Default type for param[0] should be UInt(8)
-        if (params[0].type() != Halide::UInt(8)) {
-            fprintf(stderr, "params[0].type() should be uint8\n");
-            exit(-1);
-        }
-        // Change the GeneratorParam for input_type; this shouldn't affect anything
-        // until after build() is called.
-        gen.set_generator_param_values({ { "input_type", "float32" } });
-        params = gen.get_filter_parameters();
-        if (params[0].type() != Halide::UInt(8)) {
-            fprintf(stderr, "params[0].type() should be uint8\n");
-            exit(-1);
-        }
-
-        // This should change the type of param[0] (for subsequent calls to get_filter_parameters)
-        gen.build();
-
-        params = gen.get_filter_parameters();
-        if (params[0].type() != Halide::Float(32)) {
-            fprintf(stderr, "params[0].type() should be float32\n");
             exit(-1);
         }
     }


### PR DESCRIPTION
This was formerly needed for legacy reasons in at least one external
codebase, but recent changes to generate Metadata now make this
unnecessary; removing since Internal::Parameter should remain internal.