### PR TITLE
halide_copy_to_device() should always copy when dev is malloced

### DIFF
--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -156,6 +156,7 @@ WEAK int halide_copy_to_device(void *user_context, struct buffer_t *buf, const h
                                 << " halide_copy_to_device call to halide_device_malloc failed\n";
             return result;
         }
+        buf->host_dirty = true; // force copy back to new device below.
     }
 
     if (buf->host_dirty) {


### PR DESCRIPTION
If you call halide_copy_to_device() with host != NULL, dev == 0, we always allocate the device texture, but only copy host->dev if you explicitly set host_dirty. This seems wrong; in this case it seems that we should always force the copy regardless of host_dirty.