### PR TITLE
Fix Renderscript codegen' so it generates multiple kernels correctly.

### DIFF
--- a/apps/renderscript/jni/rstest.cpp
+++ b/apps/renderscript/jni/rstest.cpp
@@ -191,7 +191,6 @@ void runTest(const char* cacheDir) {
 
     if (sdk_version() >= 23) { // 3-dim image support was not added until 23
         buffer_t bt_input = make_planar_image(width, height, channels, input_image);
-        const int channels_stride = 1;  // chunky image
         for (int i = 0; i < std::min(bt_input.extent[0], width); i++) {
             for (int j = 0; j < std::min(bt_input.extent[1], height); j++) {
                 for (int k = 0; k < bt_input.extent[2]; k++) {

--- a/apps/renderscript/test_blur_copy.cpp
+++ b/apps/renderscript/test_blur_copy.cpp
@@ -30,9 +30,6 @@ void blur(std::string suffix, ImageParam input8, const int channels) {
          result.output_buffer().stride(2) == 1);
     Expr planar = result.output_buffer().stride(0) == 1;
 
-    /*result.output_buffer().min(2) == 0 &&
-      result.output_buffer().extent(2) == channels); */
-
     if (suffix == "_rs") {
         result.shader(x, y, c, DeviceAPI::Renderscript);
         result.specialize(interleaved).vectorize(c);
@@ -101,17 +98,10 @@ void copy(std::string suffix, ImageParam input8, const int channels) {
 int main(int argc, char **argv) {
     const int channels = 4;
 
-    ImageParam input_planar(UInt(8), 3, "input");
-    input_planar.set_stride(0, 1).set_bounds(2, 0, channels);
-    blur(argc > 1 ? argv[1] : "", input_planar, channels);
-    copy(argc > 1 ? argv[1] : "", input_planar, channels);
-
-    ImageParam input_interleaved(UInt(8), 3, "input");
-    input_interleaved.set_stride(0, channels)
-        .set_stride(2, 1)
-        .set_bounds(2, 0, channels);
-    blur(argc > 1 ? argv[1] : "", input_interleaved, channels);
-    copy(argc > 1 ? argv[1] : "", input_interleaved, channels);
+    ImageParam input(UInt(8), 3, "input");
+    input.set_stride(0, Expr());
+    blur(argc > 1 ? argv[1] : "", input, channels);
+    copy(argc > 1 ? argv[1] : "", input, channels);
 
     std::cout << "Done!" << std::endl;
 }

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -27,6 +27,7 @@ class MDNode;
 class NamedMDNode;
 class DataLayout;
 class BasicBlock;
+class GlobalVariable;
 }
 
 #include <map>

--- a/src/CodeGen_Renderscript_Dev.cpp
+++ b/src/CodeGen_Renderscript_Dev.cpp
@@ -94,66 +94,70 @@ void CodeGen_Renderscript_Dev::add_kernel(Stmt stmt, const std::string &kernel_n
     for (size_t i = 0; i < args.size(); i++) {
         string arg_name = args[i].name;
         debug(1) << "CodeGen_Renderscript_Dev arg[" << i << "].name=" << arg_name << "\n";
-        if (!args[i].is_buffer) {
-            GlobalVariable *gvar =
-                new GlobalVariable(*module, llvm::Type::getInt32Ty(*context),
-                                   false,  // isConstant
-                                   GlobalValue::CommonLinkage,
-                                   0,  // has initializer, specified below
-                                   arg_name);
-            gvar->setAlignment(4);
-            gvar->setInitializer(const_0);
-            globals_sym_names.push_back(std::make_tuple(arg_name, gvar));
-
-            //
-            //  "6" means "integer"-type for Renderscript.
-            //
-            rs_export_var->addOperand(MDNode::get(
-                *context,
-                vec<LLVMMDNodeArgumentType>(MDString::get(*context, arg_name),
-                                            MDString::get(*context, "6"))));
-        } else {
-            argument_type = VectorType::get(llvm_type_of(UInt(8)), args[i].type.width);
-
-            GlobalVariable *gvar =
-                new GlobalVariable(*module, StructTy_struct_rs_allocation,
-                                   false,  // isConstant
-                                   GlobalValue::CommonLinkage,
-                                   0,  // has initializer, specified below
-                                   arg_name);
-            gvar->setAlignment(4);
-            globals_sym_names.push_back(std::make_tuple(arg_name, gvar));
-            gvar->setInitializer(const_empty_allocation_struct);
-
-            //
-            //  "20" means "buffer"-type for Renderscript.
-            //
-            rs_export_var->addOperand(MDNode::get(
-                *context,
-                vec<LLVMMDNodeArgumentType>(MDString::get(*context, arg_name),
-                                            MDString::get(*context, "20"))));
-            rs_objects_slots->addOperand(
-                MDNode::get(*context, vec<LLVMMDNodeArgumentType>(MDString::get(
-                                          *context, std::to_string(i)))));
+        if (args[i].is_buffer) {
+            // Remember actual type of buffer argument - will use it for kernel input buffer type.
+            argument_type = llvm_type_of(args[i].type);
         }
-        Halide::Type type = args[i].type;
 
-        debug(2) << "args[" << i << "] = {"
-                 << "name=" << args[i].name
-                 << " is_buffer=" << args[i].is_buffer
-                 << " dimensions=" << args[i].dimensions << " type.code="
-                 << (type.code == Halide::Type::TypeCode::Int
-                         ? "Int"
-                         : type.code == Halide::Type::TypeCode::UInt
-                               ? "UInt"
-                               : type.code == Halide::Type::TypeCode::Float
-                                     ? "Float"
-                                     : type.code ==
-                                               Halide::Type::TypeCode::Handle
-                                           ? "Handle"
-                                           : "???") << ";bits=" << type.bits
-                 << ";width=" << type.width << " llvm_type=";
-        debug(2) << "\n";
+        // Reuse global variables between kernels.
+        std::map<std::string, GlobalVariable*>::const_iterator f = rs_global_vars.find(arg_name);
+        if (f != rs_global_vars.end()) {
+            globals_sym_names.push_back(std::make_tuple(arg_name, f->second));
+        } else {
+            enum RS_ARGUMENT_TYPE { RS_INT = 6, RS_BUFFER = 20 } rs_argument_type;
+            GlobalVariable *gvar;
+            if (!args[i].is_buffer) {
+                gvar = new GlobalVariable(*module, llvm::Type::getInt32Ty(*context),
+                                          false,  // isConstant
+                                          GlobalValue::CommonLinkage,
+                                          0,  // has initializer, specified below
+                                         arg_name);
+                gvar->setInitializer(const_0);
+                globals_sym_names.push_back(std::make_tuple(arg_name, gvar));
+
+                rs_argument_type = RS_INT;
+            } else {
+                gvar = new GlobalVariable(*module, StructTy_struct_rs_allocation,
+                                          false,  // isConstant
+                                          GlobalValue::CommonLinkage,
+                                          0,  // has initializer, specified below
+                                          arg_name);
+                gvar->setInitializer(const_empty_allocation_struct);
+
+                rs_argument_type = RS_BUFFER;
+                rs_objects_slots->addOperand(
+                    MDNode::get(*context,
+                                vec<LLVMMDNodeArgumentType>(MDString::get(
+                                    *context,
+                                    std::to_string(rs_export_var->getNumOperands())))));
+            }
+            gvar->setAlignment(4);
+            globals_sym_names.push_back(std::make_tuple(arg_name, gvar));
+            rs_global_vars.insert(std::pair<std::string,GlobalVariable*>(arg_name, gvar));
+
+            rs_export_var->addOperand(MDNode::get(
+                *context,
+                vec<LLVMMDNodeArgumentType>(MDString::get(*context, arg_name),
+                                            MDString::get(*context, std::to_string(rs_argument_type)))));
+
+            Halide::Type type = args[i].type;
+            debug(2) << "args[" << i << "] = {"
+                     << "name=" << args[i].name
+                     << " is_buffer=" << args[i].is_buffer
+                     << " dimensions=" << args[i].dimensions << " type.code="
+                     << (type.code == Halide::Type::TypeCode::Int
+                             ? "Int"
+                             : type.code == Halide::Type::TypeCode::UInt
+                                   ? "UInt"
+                                   : type.code == Halide::Type::TypeCode::Float
+                                         ? "Float"
+                                         : type.code ==
+                                                   Halide::Type::TypeCode::Handle
+                                               ? "Handle"
+                                               : "???") << ";bits=" << type.bits
+                     << ";width=" << type.width << " llvm_type=";
+            debug(2) << "\n";
+        }
     }
 
     // Make our function with arguments for kernel defined per Renderscript
@@ -577,7 +581,10 @@ int CodeGen_Renderscript_Dev::native_vector_bits() const {
     return 128;
 }
 
-string CodeGen_Renderscript_Dev::get_current_kernel_name() { return function->getName(); }
+string CodeGen_Renderscript_Dev::get_current_kernel_name() {
+    // Renderscript function to launch RS kernel needs number(slot index) as a kernel identifier.
+    return int_to_string(rs_export_foreach_name->getNumOperands() - 1);
+}
 
 void CodeGen_Renderscript_Dev::dump() { module->dump(); }
 

--- a/src/CodeGen_Renderscript_Dev.cpp
+++ b/src/CodeGen_Renderscript_Dev.cpp
@@ -140,23 +140,11 @@ void CodeGen_Renderscript_Dev::add_kernel(Stmt stmt, const std::string &kernel_n
                 vec<LLVMMDNodeArgumentType>(MDString::get(*context, arg_name),
                                             MDString::get(*context, std::to_string(rs_argument_type)))));
 
-            Halide::Type type = args[i].type;
             debug(2) << "args[" << i << "] = {"
                      << "name=" << args[i].name
                      << " is_buffer=" << args[i].is_buffer
-                     << " dimensions=" << args[i].dimensions << " type.code="
-                     << (type.code == Halide::Type::TypeCode::Int
-                             ? "Int"
-                             : type.code == Halide::Type::TypeCode::UInt
-                                   ? "UInt"
-                                   : type.code == Halide::Type::TypeCode::Float
-                                         ? "Float"
-                                         : type.code ==
-                                                   Halide::Type::TypeCode::Handle
-                                               ? "Handle"
-                                               : "???") << ";bits=" << type.bits
-                     << ";width=" << type.width << " llvm_type=";
-            debug(2) << "\n";
+                     << " dimensions=" << (+args[i].dimensions)
+                     << " type=" << args[i].type << "}\n";
         }
     }
 

--- a/src/CodeGen_Renderscript_Dev.h
+++ b/src/CodeGen_Renderscript_Dev.h
@@ -83,6 +83,8 @@ private:
     // Metadata records keep track of all Renderscript kernels.
     llvm::NamedMDNode *rs_export_foreach_name;
     llvm::NamedMDNode *rs_export_foreach;
+
+    std::map<std::string, llvm::GlobalVariable*> rs_global_vars;
 };
 }
 }

--- a/src/runtime/renderscript.cpp
+++ b/src/runtime/renderscript.cpp
@@ -1103,7 +1103,9 @@ WEAK int halide_renderscript_run(void *user_context, void *state_ptr,
         num_args++;
     }
 
-    debug(user_context) << "RS: halide_renderscript_run starting now with " << module
+    int slot = atoi(entry_name);
+    debug(user_context) << "RS: halide_renderscript_run starting script at slot " << slot
+                        << " now with " << module
                         << " script "
                         << " input: "
                         << ((void *)halide_get_device_handle(input_arg))
@@ -1113,7 +1115,7 @@ WEAK int halide_renderscript_run(void *user_context, void *state_ptr,
 
     Context::dispatch->ScriptForEach(
         ctx.mContext, module,
-        1,  // slot
+        slot,  // slot corresponding to entry point
         (void *)halide_get_device_handle(input_arg),  // in_id
         (void *)halide_get_device_handle(output_arg),  // out_id
         NULL,  // usr


### PR DESCRIPTION
This fixes problem with RS codegen support of multiple kernels, which effectively meant that only first kernel was working correctly.

Multiple(two) kernels are generated in apps/renderscript sample due to use of specialize() for planar and interleaved images. Unfortunately there is no easy way of testing planar without building your own publicly available master-copy of Android sources, because Allocation3DRead API call for handling 3d images was not released yet. So commonly only interleaved version of apps/renderscript is run.
Processing planar images is much slower, so it has very limited value besides testing.