### PR TITLE
Catch up to llvm trunk. NoFramePointerElim is gone.

### DIFF
--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -293,7 +293,6 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     TargetOptions Options;
     Options.LessPreciseFPMADOption = true;
     Options.PrintMachineCode = false;
-    Options.NoFramePointerElim = false;
     //Options.NoExcessFPPrecision = false;
     Options.AllowFPOpFusion = FPOpFusion::Fast;
     Options.UnsafeFPMath = true;
@@ -301,6 +300,7 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     Options.NoNaNsFPMath = false;
     Options.HonorSignDependentRoundingFPMathOption = false;
     #if LLVM_VERSION < 37
+    Options.NoFramePointerElim = false;
     Options.UseSoftFloat = false;
     #endif
     /* if (FloatABIForCalls != FloatABI::Default) */

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -72,13 +72,13 @@ void get_target_options(const llvm::Module *module, llvm::TargetOptions &options
 
     options = llvm::TargetOptions();
     options.LessPreciseFPMADOption = true;
-    options.NoFramePointerElim = false;
     options.AllowFPOpFusion = llvm::FPOpFusion::Fast;
     options.UnsafeFPMath = true;
     options.NoInfsFPMath = true;
     options.NoNaNsFPMath = true;
     options.HonorSignDependentRoundingFPMathOption = false;
     #if LLVM_VERSION < 37
+    options.NoFramePointerElim = false;
     options.UseSoftFloat = false;
     #endif
     options.NoZerosInBSS = false;


### PR DESCRIPTION
Flag removed from TargetOptions in r238244.