### PR TITLE
Better, less drastic fix for LandingPad API change.

### DIFF
--- a/src/BitWriter_3_2/BitcodeWriter.cpp
+++ b/src/BitWriter_3_2/BitcodeWriter.cpp
@@ -1305,14 +1305,24 @@ static void WriteInstruction(const Instruction &I, unsigned InstID,
   }
 
   case Instruction::LandingPad: {
-    // in LLVM (3.7) r239940 bitcode format of Instruction::LandingPad instruction
-    // was changed where PersonalityFn was moved from LandingPad instruction to
-    // Function instruction.
-    // With no simple fix in sight to address bitcode incompatibility between
-    // what can be produced from LLVM IR and what Android "3.2" bitcode expects,
-    // it seems that LandingPad instructions simply should not happen in
-    // Halide-generated code because there should be no exceptions used in Halide code.
-    assert("Unexpected LandingPad instruction. Exceptions should not be used.");
+    const LandingPadInst &LP = cast<LandingPadInst>(I);
+    Code = bitc::FUNC_CODE_INST_LANDINGPAD;
+    Vals.push_back(VE.getTypeID(LP.getType()));
+#if LLVM_VERSION < 37
+    PushValueAndType(LP.getPersonalityFn(), InstID, Vals, VE);
+#else
+    PushValueAndType(LP.getParent()->getParent()->getPersonalityFn(), InstID,
+                     Vals, VE);
+#endif
+    Vals.push_back(LP.isCleanup());
+    Vals.push_back(LP.getNumClauses());
+    for (unsigned I = 0, E = LP.getNumClauses(); I != E; ++I) {
+      if (LP.isCatch(I))
+        Vals.push_back(LandingPadInst::Catch);
+      else
+        Vals.push_back(LandingPadInst::Filter);
+      PushValueAndType(LP.getClause(I), InstID, Vals, VE);
+    }
     break;
   }
 


### PR DESCRIPTION
Turns out there is better fix for LandingPad bitcode format change than 0a52c605 :

```
$ git diff a3b13f9..HEAD src/BitWriter_3_2/BitcodeWriter.cpp
diff --git a/src/BitWriter_3_2/BitcodeWriter.cpp b/src/BitWriter_3_2/BitcodeWriter.cpp
index a4deae1..1de57b2 100644
--- a/src/BitWriter_3_2/BitcodeWriter.cpp
+++ b/src/BitWriter_3_2/BitcodeWriter.cpp
@@ -1308,7 +1308,12 @@ static void WriteInstruction(const Instruction &I, unsigned InstID,
     const LandingPadInst &LP = cast<LandingPadInst>(I);
     Code = bitc::FUNC_CODE_INST_LANDINGPAD;
     Vals.push_back(VE.getTypeID(LP.getType()));
+#if LLVM_VERSION < 37
     PushValueAndType(LP.getPersonalityFn(), InstID, Vals, VE);
+#else
+    PushValueAndType(LP.getParent()->getParent()->getPersonalityFn(), InstID,
+                     Vals, VE);
+#endif
     Vals.push_back(LP.isCleanup());
     Vals.push_back(LP.getNumClauses());
     for (unsigned I = 0, E = LP.getNumClauses(); I != E; ++I) {
```