### PR TITLE
bool OutputImageParam::defined() const

### DIFF
--- a/src/Param.cpp
+++ b/src/Param.cpp
@@ -38,7 +38,7 @@ Type OutputImageParam::type() const {
     return param.type();
 }
 
-bool OutputImageParam::defined() {
+bool OutputImageParam::defined() const {
     return param.defined();
 }
 


### PR DESCRIPTION
bool OutputImageParam::defined() => bool OutputImageParam::defined() const

Small fix to OutputImageParam constness.