### PR TITLE
Deinterleave tuples

### DIFF
--- a/src/BlockFlattening.cpp
+++ b/src/BlockFlattening.cpp
@@ -26,11 +26,15 @@ private:
             }
         }
 
-        if (first.same_as(op->first)) {
-            rest = mutate(rest);
-            stmt = rest.same_as(op->rest)? op: Block::make(first, rest);
+        // first might be a LetStmt or something else containing blocks that
+        // need to be flattened.
+        first = mutate(first);
+        rest = mutate(rest);
+
+        if (first.same_as(op->first) && rest.same_as(op->rest)) {
+            stmt = op;
         } else {
-            stmt = Block::make(first, mutate(rest));
+            stmt = Block::make(first, rest);
         }
     }
 };

--- a/test/correctness/interleave.cpp
+++ b/test/correctness/interleave.cpp
@@ -273,7 +273,7 @@ int main(int argc, char **argv) {
 
     for (int elements = 1; elements <= 5; elements++) {
         // Make sure we don't interleave when the reordering would change the meaning.
-        Realization* refs;
+        Realization* refs = NULL;
         for (int i = 0; i < 2; i++) {
             Func output6;
             define(output6(x, y), cast<uint8_t>(x), elements);

--- a/test/performance/fft.cpp
+++ b/test/performance/fft.cpp
@@ -344,7 +344,7 @@ Func fft2d_c2c(Func x, const std::vector<int> &R0, const std::vector<int> &R1, f
 
     Var n0 = xT.args()[0];
     Var n1 = xT.args()[1];
-    xT.compute_at(dft, outermost(dft)).vectorize(n0).unroll(n1);
+    xT.compute_at(dft, outermost(dft)).vectorize(n1).unroll(n0);
 
     dft1T.compute_at(dft, outermost(dft));
     dft.compute_root();


### PR DESCRIPTION
This PR enables `interleave_vectors` to be generated for Tuple-valued Funcs. To enable this, StoreCollector is now a bit more aggressive.

This enables interleave_vectors to fire in the fft2d_c2c benchmark, which makes it 15% faster on my laptop! But, somehow, it also makes it 10% slower on my desktop. Both are x86, which is surprising... Regardless, this does speed up all my real world code.