### PR TITLE
Fix Mac OSX jit(and tutorials) broken after llvm r240405

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ LLVM_BINDIR = $(shell $(LLVM_CONFIG) --bindir)
 LLVM_LIBDIR = $(shell $(LLVM_CONFIG) --libdir)
 LLVM_AS = $(LLVM_BINDIR)/llvm-as
 LLVM_NM = $(LLVM_BINDIR)/llvm-nm
-LLVM_CXX_FLAGS = -g -std=c++11  $(filter-out -O% -g -fomit-frame-pointer -pedantic -Wcovered-switch-default, $(shell $(LLVM_CONFIG) --cxxflags))
+LLVM_CXX_FLAGS = -std=c++11  $(filter-out -O% -g -fomit-frame-pointer -pedantic -Wcovered-switch-default, $(shell $(LLVM_CONFIG) --cxxflags))
 OPTIMIZE ?= -O3
 # This can be set to -m32 to get a 32-bit build of Halide on a 64-bit system.
 # (Normally this can be done via pointing to a compiler that defaults to 32-bits,

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ LLVM_BINDIR = $(shell $(LLVM_CONFIG) --bindir)
 LLVM_LIBDIR = $(shell $(LLVM_CONFIG) --libdir)
 LLVM_AS = $(LLVM_BINDIR)/llvm-as
 LLVM_NM = $(LLVM_BINDIR)/llvm-nm
-LLVM_CXX_FLAGS = -std=c++11  $(filter-out -O% -g -fomit-frame-pointer -pedantic -Wcovered-switch-default, $(shell $(LLVM_CONFIG) --cxxflags))
+LLVM_CXX_FLAGS = -g -std=c++11  $(filter-out -O% -g -fomit-frame-pointer -pedantic -Wcovered-switch-default, $(shell $(LLVM_CONFIG) --cxxflags))
 OPTIMIZE ?= -O3
 # This can be set to -m32 to get a 32-bit build of Halide on a 64-bit system.
 # (Normally this can be done via pointing to a compiler that defaults to 32-bits,
@@ -551,13 +551,19 @@ RUNTIME_TRIPLE_64 = "x86_64-unknown-unknown-unknown"
 else
 # Compile generic 32- or 64-bit code
 RUNTIME_TRIPLE_32 = "le32-unknown-nacl-unknown"
+RUNTIME_TRIPLE_OSX_32 = "i386-apple-macosx10.7.0"
 RUNTIME_TRIPLE_64 = "le64-unknown-unknown-unknown"
+RUNTIME_TRIPLE_OSX_64 = "x86_64-apple-macosx10.7.0"
 endif
 
 # win32 is tied to x86 due to the use of the __stdcall calling convention
 RUNTIME_TRIPLE_WIN_32 = "i386-unknown-unknown-unknown"
 
 # -m64 isn't respected unless we also use a 64-bit target
+$(BUILD_DIR)/initmod.osx_%_64.ll: src/runtime/osx_%.cpp $(BUILD_DIR)/clang_ok
+	@-mkdir -p $(BUILD_DIR)
+	$(CLANG) $(CXX_WARNING_FLAGS) -O3 -ffreestanding -fno-blocks -fno-exceptions -fno-unwind-tables -m64 -target $(RUNTIME_TRIPLE_OSX_64) -DCOMPILING_HALIDE_RUNTIME -DBITS_64 -emit-llvm -S src/runtime/osx_$*.cpp -o $@ -MMD -MP -MF $(BUILD_DIR)/initmod.osx_$*_64.d
+
 $(BUILD_DIR)/initmod.%_64.ll: src/runtime/%.cpp $(BUILD_DIR)/clang_ok
 	@-mkdir -p $(BUILD_DIR)
 	$(CLANG) $(CXX_WARNING_FLAGS) -O3 -ffreestanding -fno-blocks -fno-exceptions -fno-unwind-tables -m64 -target $(RUNTIME_TRIPLE_64) -DCOMPILING_HALIDE_RUNTIME -DBITS_64 -emit-llvm -S src/runtime/$*.cpp -o $@ -MMD -MP -MF $(BUILD_DIR)/initmod.$*_64.d
@@ -566,9 +572,17 @@ $(BUILD_DIR)/initmod.windows_%_32.ll: src/runtime/windows_%.cpp $(BUILD_DIR)/cla
 	@-mkdir -p $(BUILD_DIR)
 	$(CLANG) $(CXX_WARNING_FLAGS) -O3 -ffreestanding -fno-blocks -fno-exceptions -fno-unwind-tables -m32 -target $(RUNTIME_TRIPLE_WIN_32) -DCOMPILING_HALIDE_RUNTIME -DBITS_32 -emit-llvm -S src/runtime/windows_$*.cpp -o $@ -MMD -MP -MF $(BUILD_DIR)/initmod.windows_$*_32.d
 
+$(BUILD_DIR)/initmod.osx_%_32.ll: src/runtime/osx_%.cpp $(BUILD_DIR)/clang_ok
+	@-mkdir -p $(BUILD_DIR)
+	$(CLANG) $(CXX_WARNING_FLAGS) -O3 -ffreestanding -fno-blocks -fno-exceptions -fno-unwind-tables -m32 -target $(RUNTIME_TRIPLE_OSX_32) -DCOMPILING_HALIDE_RUNTIME -DBITS_32 -emit-llvm -S src/runtime/osx_$*.cpp -o $@ -MMD -MP -MF $(BUILD_DIR)/initmod.osx_$*_32.d
+
 $(BUILD_DIR)/initmod.%_32.ll: src/runtime/%.cpp $(BUILD_DIR)/clang_ok
 	@-mkdir -p $(BUILD_DIR)
 	$(CLANG) $(CXX_WARNING_FLAGS) -O3 -ffreestanding -fno-blocks -fno-exceptions -fno-unwind-tables -m32 -target $(RUNTIME_TRIPLE_32) -DCOMPILING_HALIDE_RUNTIME -DBITS_32 -emit-llvm -S src/runtime/$*.cpp -o $@ -MMD -MP -MF $(BUILD_DIR)/initmod.$*_32.d
+
+$(BUILD_DIR)/initmod.osx_%_64_debug.ll: src/runtime/osx_%.cpp $(BUILD_DIR)/clang_ok
+	@-mkdir -p $(BUILD_DIR)
+	$(CLANG) $(CXX_WARNING_FLAGS) -g -DDEBUG_RUNTIME -O3 -ffreestanding -fno-blocks -fno-exceptions -m64 -target  $(RUNTIME_TRIPLE_OSX_64) -DCOMPILING_HALIDE_RUNTIME -DBITS_64 -emit-llvm -S src/runtime/osx_$*.cpp -o $@ -MMD -MP -MF $(BUILD_DIR)/initmod.osx_$*_64_debug.d
 
 $(BUILD_DIR)/initmod.%_64_debug.ll: src/runtime/%.cpp $(BUILD_DIR)/clang_ok
 	@-mkdir -p $(BUILD_DIR)
@@ -577,6 +591,10 @@ $(BUILD_DIR)/initmod.%_64_debug.ll: src/runtime/%.cpp $(BUILD_DIR)/clang_ok
 $(BUILD_DIR)/initmod.windows_%_32_debug.ll: src/runtime/windows_%.cpp $(BUILD_DIR)/clang_ok
 	@-mkdir -p $(BUILD_DIR)
 	$(CLANG) $(CXX_WARNING_FLAGS) -g -DDEBUG_RUNTIME -O3 -ffreestanding -fno-blocks -fno-exceptions -m32 -target $(RUNTIME_TRIPLE_WIN_32) -DCOMPILING_HALIDE_RUNTIME -DBITS_32 -emit-llvm -S src/runtime/windows_$*.cpp -o $@ -MMD -MP -MF $(BUILD_DIR)/initmod.windows_$*_32_debug.d
+
+$(BUILD_DIR)/initmod.osx_%_32_debug.ll: src/runtime/osx_%.cpp $(BUILD_DIR)/clang_ok
+	@-mkdir -p $(BUILD_DIR)
+	$(CLANG) $(CXX_WARNING_FLAGS) -g -DDEBUG_RUNTIME -O3 -ffreestanding -fno-blocks -fno-exceptions -m32 -target $(RUNTIME_TRIPLE_OSX_32) -DCOMPILING_HALIDE_RUNTIME -DBITS_32 -emit-llvm -S src/runtime/osx_$*.cpp -o $@ -MMD -MP -MF $(BUILD_DIR)/initmod.osx_$*_32_debug.d
 
 $(BUILD_DIR)/initmod.%_32_debug.ll: src/runtime/%.cpp $(BUILD_DIR)/clang_ok
 	@-mkdir -p $(BUILD_DIR)

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -102,6 +102,8 @@ llvm::DataLayout CodeGen_X86::get_data_layout() const {
     } else { // 64-bit
         if (target.os == Target::NaCl) {
             return llvm::DataLayout("e-m:e-p:32:32-i64:64-f80:128-n8:16:32:64-S128");
+        } else if (target.os == Target::OSX) {
+            return llvm::DataLayout("e-m:o-i64:64-f80:128-n8:16:32:64-S128");
         } else {
             return llvm::DataLayout("e-m:e-i64:64-f80:128-n8:16:32:64-S128");
         }


### PR DESCRIPTION
Following r240405, specifically change in [IR/Mangler.cpp](http://llvm.org/viewvc/llvm-project/llvm/trunk/lib/IR/Mangler.cpp?r1=240405&r2=240404&pathrev=240405)

```
+  const DataLayout &DL = GV->getParent()->getDataLayout();
```

DataLayout for Function now comes from enclosing Module.

On MacOS DataLayout for Function it is expected to be "..-m:o.." but comes up from Module as "..m:e...". This PR fixes DataLayout for Module, so it is "...-m:o-...".
