### PR TITLE
Fix ``make clean`` not removing generator object files.

### DIFF
--- a/HalideGenerator.cmake
+++ b/HalideGenerator.cmake
@@ -77,6 +77,7 @@ function(halide_add_generator_dependency)
   # generated library
   if (WIN32)
     add_custom_command(OUTPUT "${SCRATCH_DIR}/${FILTER_LIB}" "${SCRATCH_DIR}/${FILTER_HDR}"
+                              "${SCRATCH_DIR}/${args_GENERATED_FUNCTION}.o"
       DEPENDS "${args_GENERATOR_TARGET}"
       COMMAND "${CMAKE_BINARY_DIR}/bin/${CMAKE_CFG_INTDIR}/${generator_exec}" ${invoke_args}
       COMMAND "lib.exe" "/OUT:${FILTER_LIB}" "${SCRATCH_DIR}\\${args_GENERATED_FUNCTION}.o"
@@ -85,6 +86,7 @@ function(halide_add_generator_dependency)
   elseif(XCODE)
     if (NOT target_is_pnacl)
       add_custom_command(OUTPUT "${SCRATCH_DIR}/${FILTER_LIB}" "${SCRATCH_DIR}/${FILTER_HDR}"
+                                "${SCRATCH_DIR}/${args_GENERATED_FUNCTION}.o"
         DEPENDS "${args_GENERATOR_TARGET}"
 
         # The generator executable will be placed in a configuration specific
@@ -110,6 +112,7 @@ function(halide_add_generator_dependency)
     if (NOT target_is_pnacl)
       message(STATUS "The filter lib is ${FILTER_LIB}")
       add_custom_command(OUTPUT "${SCRATCH_DIR}/${FILTER_LIB}" "${SCRATCH_DIR}/${FILTER_HDR}"
+                                "${SCRATCH_DIR}/${args_GENERATED_FUNCTION}.o"
         DEPENDS "${args_GENERATOR_TARGET}"
         COMMAND "${CMAKE_BINARY_DIR}/bin/${generator_exec}" ${invoke_args}
         # Create an archive using ar (or similar)


### PR DESCRIPTION
Running the clean target would not remove these files because
CMake was not aware that invoking the generators produced these
files.