### PR TITLE
Add TravisCI build file and build scripts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+language: cpp
+compiler:
+  # Comment out for now to keep build matrix small
+  #- clang
+  - gcc
+env:
+  # Configurations
+  #
+  # Each line in the ``env`` section represents a set of environment
+  # variables passed to a build configuration
+  #
+  # Test LLVM 3.5 at least once
+  - LLVM_VERSION=3.5 BUILD_SYSTEM=CMAKE BUILD_TYPE=Debug HALIDE_SHARED_LIBRARY=1
+  - LLVM_VERSION=3.6 BUILD_SYSTEM=CMAKE BUILD_TYPE=Debug HALIDE_SHARED_LIBRARY=1
+  - LLVM_VERSION=3.6 BUILD_SYSTEM=CMAKE BUILD_TYPE=Debug HALIDE_SHARED_LIBRARY=0
+  - LLVM_VERSION=3.6 BUILD_SYSTEM=MAKE  BUILD_TYPE=Debug
+  # Test Release builds
+  - LLVM_VERSION=3.6 BUILD_SYSTEM=MAKE  BUILD_TYPE=Release
+  - LLVM_VERSION=3.6 BUILD_SYSTEM=CMAKE BUILD_TYPE=Release HALIDE_SHARED_LIBRARY=1
+cache: apt
+# Note the commands below are written assuming Ubuntu 12.04LTS
+before_install:
+  # Needed for new libstdc++ and gcc4.8
+  - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test/
+  - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
+  - sudo sh -c 'echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-'${LLVM_VERSION}' main" >> /etc/apt/sources.list.d/llvm.list'
+  - sudo sh -c 'echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-'${LLVM_VERSION}' main" >> /etc/apt/sources.list.d/llvm.list'
+  - sudo apt-get update
+install:
+  - sudo apt-get -y install gcc-4.8 g++-4.8 libedit-dev
+  # Make gcc4.8 the default gcc version
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 20
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 20
+  # Make Clang ${LLVM_VERSION} the default clang version
+  - sudo apt-get -y install clang-${LLVM_VERSION}
+  - sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} 20
+  - sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 20
+  # Get libpng for the tutorials and apps
+  - sudo apt-get -y install libpng-dev
+  # For generating docs
+  - sudo apt-get -y --no-install-recommends install doxygen
+  # Grab a version of CMake >= 2.8.12
+  - wget http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.sh
+  - chmod a+x cmake-3.2.3-Linux-x86_64.sh
+  - sudo ./cmake-3.2.3-Linux-x86_64.sh --skip-license --prefix=/usr/local
+script:
+  - test/scripts/build_ubuntu1204.sh

--- a/test/scripts/build_generic.sh
+++ b/test/scripts/build_generic.sh
@@ -1,0 +1,107 @@
+#!/bin/bash -x
+set -e
+set -o pipefail
+
+# Note this script assumes that the current working directory
+# is the root of the repository
+if [ ! -f ./.travis.yml ]; then
+  echo "This script must be run from the root of the repository"
+  exit 1
+fi
+
+: ${LLVM_INCLUDE:?"LLVM_INCLUDE must be specified"}
+: ${LLVM_LIB:?"LLVM_LIB must be specified"}
+: ${LLVM_BIN:?"LLVM_BIN must be specified"}
+: ${LLVM_VERSION:?"LLVM_VERSION must be specified"}
+: ${BUILD_SYSTEM:?"BUILD_SYSTEM must be specified"}
+: ${NUM_JOBS:?"NUM_JOBS must be specified"}
+: ${CXX:?"CXX must be specified"}
+: ${BUILD_TYPE:?"BUILD_TYPE must be specified"}
+: ${RUN_TESTS:?"RUN_TESTS must be specified"}
+
+# By default don't do incremental build
+INCREMENTAL_BUILD="${INCREMENTAL_BUILD:-0}"
+
+if [ ${BUILD_SYSTEM} = 'CMAKE' ]; then
+  : ${HALIDE_SHARED_LIBRARY:?"HALIDE_SHARED_LIBRARY must be set"}
+  LLVM_VERSION_NO_DOT="$( echo ${LLVM_VERSION} | sed 's/\.//')"
+  if [ ${INCREMENTAL_BUILD} = '0' ]; then
+    rm -rf build/
+  fi
+  mkdir -p build/ && cd build/
+  cmake -DLLVM_INCLUDE="${LLVM_INCLUDE}" \
+        -DLLVM_LIB="${LLVM_LIB}" \
+        -DLLVM_BIN="${LLVM_BIN}" \
+        -DLLVM_VERSION="${LLVM_VERSION_NO_DOT}" \
+        -DHALIDE_SHARED_LIBRARY="${HALIDE_SHARED_LIBRARY}" \
+        -DWITH_APPS=ON \
+        -DWITH_TESTS="${RUN_TESTS}" \
+        -DWITH_TUTORIALS=OFF \
+        -DWITH_DOCS=ON \
+        -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+        -G "Unix Makefiles" \
+        ../
+
+  # Build
+  make -j ${NUM_JOBS}
+  # Build docs
+  make doc
+
+  if [ ${RUN_TESTS} = '1' ]; then
+    # Run correctness tests
+    TESTCASES=$(find bin/ -iname 'correctness_*' | \
+    grep -v _vector_math | \
+    grep -v _vector_cast | \
+    grep -v _lerp | \
+    grep -v _simd_op_check | \
+    grep -v _specialize_branched_loops | \
+    grep -v _print | \
+    grep -v _math | \
+    grep -v _div_mod | \
+    grep -v _fuzz_simplify | \
+    grep -v _round | \
+    sort)
+    for TESTCASE in ${TESTCASES}; do
+      echo "Running ${TESTCASE}"
+      ${TESTCASE}
+    done
+  else
+    echo "Not running tests"
+  fi
+elif [ ${BUILD_SYSTEM} = 'MAKE' ]; then
+  if [ ${BUILD_TYPE} = 'Debug' ]; then
+    OPT_FLAG='-O0'
+  else
+    OPT_FLAG='-O3'
+  fi
+  function make_build() {
+    make LLVM_BINDIR="${LLVM_BIN}" \
+         LLVM_LIBDIR="${LLVM_LIB}" \
+         LLVM_CONFIG="${LLVM_BIN}/llvm-config" \
+         CLANG="${LLVM_BIN}/clang" \
+         CXX=${CXX} \
+         OPTIMIZE="${OPT_FLAG}" \
+         "$@"
+  }
+
+  if [ ${INCREMENTAL_BUILD} = '0' ]; then
+    make clean
+  fi
+  # Build
+  # Note this runs the internal tests too
+  # FIXME: The CMake build system doesn't do this
+  make_build -j ${NUM_JOBS}
+
+  # Build the docs
+  make_build doc
+
+  if [ ${RUN_TESTS} = '1' ]; then
+    # Build an run the correctness tests
+    make_build -j ${NUM_JOBS} test_correctness
+  else
+    echo "Not running tests"
+  fi
+else
+  echo "Unexpected BUILD_SYSTEM: \"${BUILD_SYSTEM}\""
+  exit 1
+fi

--- a/test/scripts/build_ubuntu1204.sh
+++ b/test/scripts/build_ubuntu1204.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -x
+
+set -e
+set -o pipefail
+
+: ${LLVM_VERSION:?"LLVM_VERSION must be specified"}
+: ${BUILD_SYSTEM:?"BUILD_SYSTEM must be specified"}
+
+if [ $(echo "${LLVM_VERSION}" | grep -Ec '^[0-9]+\.[0-9]$') -ne 1 ]; then
+  echo "LLVM_VERSION (${LLVM_VERSION}) is not correctly formatted"
+  exit 1
+fi
+
+# Set variables that the build script needs
+export LLVM_INCLUDE="/usr/lib/llvm-${LLVM_VERSION}/include"
+export LLVM_LIB="/usr/lib/llvm-${LLVM_VERSION}/lib"
+export LLVM_BIN="/usr/lib/llvm-${LLVM_VERSION}/bin"
+# Travis has 2 CPUs but only 3GiB of RAM so we need
+# to avoid doing stuff in parallel to avoid the linker getting killed
+export NUM_JOBS=1
+export RUN_TESTS=1
+
+# Have the generic script to the real work
+test/scripts/build_generic.sh


### PR DESCRIPTION
The current configuration doesn't run the tests due to them failing
in various ways. So for now they are disabled and we will use TravisCI
for fast failing checks (i.e. compilation failures).

@abadams Once these files are added you need to enable TravisCI for this repository. Only admins of a repository/organisation can do this.