### PR TITLE
Aarch64 simd peephole optimizations

### DIFF
--- a/apps/simd_op_check/Makefile
+++ b/apps/simd_op_check/Makefile
@@ -1,0 +1,25 @@
+CXX-host ?= c++
+CXX-arm-64-android ?= $(ANDROID_NDK_HOME)/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-c++
+CXX-arm-32-android ?= $(ANDROID_NDK_HOME)/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-c++
+
+CXXFLAGS-host ?= -lpthread
+CXXFLAGS-arm-64-android ?= --sysroot $(ANDROID_NDK_HOME)/platforms/android-21/arch-arm64 -llog -fPIE -pie
+CXXFLAGS-arm-32-android ?= --sysroot $(ANDROID_NDK_HOME)/platforms/android-21/arch-arm -llog -fPIE -pie
+
+all: driver-host driver-arm-64-android driver-arm-32-android
+
+%/filters.h:
+	mkdir -p $*
+	make -C ../../ bin/test_simd_op_check
+	cd $* && HL_TARGET=$* LD_LIBRARY_PATH=../../../bin ../../../bin/test_simd_op_check
+	cat $*/test_*.h > $*/filter_headers.h
+	echo "filter filters[] = {" > $*/filters.h
+	cd $*; for f in test_*.h; do n=$${f/.h/}; echo '{"'$${n}'", &'$${n}'},'; done >> filters.h
+	echo '{NULL, NULL}};' >> $*/filters.h
+
+#driver-host driver-arm-32-android driver-arm-64-android : driver-%: driver.cpp %/filters.h
+driver-%: driver.cpp %/filters.h
+	$(CXX-$*) $(CXXFLAGS-$*) -I $* driver.cpp $*/test_*.o $*/simd_op_check_runtime.o -o driver-$* -ldl
+
+clean:
+	rm -rf test_*.h check_*.s test_*.o filters.h filter_headers.h driver-* arm-32-android arm-64-android host

--- a/apps/simd_op_check/driver.cpp
+++ b/apps/simd_op_check/driver.cpp
@@ -1,0 +1,93 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include "filter_headers.h"
+
+struct filter {
+    const char *name;
+    int (*fn)(buffer_t *, // float32
+              buffer_t *, // float64
+              buffer_t *, // int8
+              buffer_t *, // uint8
+              buffer_t *, // int16
+              buffer_t *, // uint16
+              buffer_t *, // int32
+              buffer_t *, // uint32
+              buffer_t *, // int64
+              buffer_t *, // uint64
+              buffer_t *); // output
+};
+
+template<typename T>
+T rand_value() {
+    return (T)(rand() * 0.125) - 100;
+}
+
+// Even on android, we want errors to stdout
+extern "C" void halide_print(void *, const char *msg) {
+    printf("%s\n", msg);
+}
+
+template<typename T>
+buffer_t make_buffer(int w, int h) {
+    T *mem = new T[w*h];
+    buffer_t buf = {0};
+    buf.host = (uint8_t *)mem;
+    buf.extent[0] = w;
+    buf.extent[1] = h;
+    buf.elem_size = sizeof(T);
+    buf.stride[0] = 1;
+    buf.stride[1] = w;
+
+    for (int i = 0; i < w*h; i++) {
+        mem[i] = rand_value<T>();
+    }
+
+    return buf;
+}
+
+#include "filters.h"
+
+int main(int argc, char **argv) {
+    const int W = 4096, H = 512;
+    // Make some input buffers
+    buffer_t bufs[] = {
+        make_buffer<float>(W, H),
+        make_buffer<double>(W, H),
+        make_buffer<int8_t>(W, H),
+        make_buffer<uint8_t>(W, H),
+        make_buffer<int16_t>(W, H),
+        make_buffer<uint16_t>(W, H),
+        make_buffer<int32_t>(W, H),
+        make_buffer<uint32_t>(W, H),
+        make_buffer<int64_t>(W, H),
+        make_buffer<uint64_t>(W, H)
+    };
+
+    buffer_t out = make_buffer<double>(1, 1);
+
+    double *out_value = (double *)(out.host);
+
+    for (int i = 0; filters[i].fn; i++) {
+        filter f = filters[i];
+        printf("Testing %s\n", f.name);
+        f.fn(bufs + 0,
+             bufs + 1,
+             bufs + 2,
+             bufs + 3,
+             bufs + 4,
+             bufs + 5,
+             bufs + 6,
+             bufs + 7,
+             bufs + 8,
+             bufs + 9,
+             &out);
+        if (*out_value) printf("Error: %f\n", *out_value);
+    }
+
+    for (int i = 0; i < sizeof(bufs)/sizeof(buffer_t); i++) {
+        delete[] bufs[i].host;
+    }
+    delete[] out.host;
+
+    return 0;
+}

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -808,7 +808,7 @@ void CodeGen_ARM::visit(const Max *op) {
         if (target.bits == 32) {
             wide_result = call_intrin(f32x2, 2, "llvm.arm.neon.vmaxs.v2f32", {a_wide, b_wide});
         } else {
-            wide_result = call_intrin(f32x2, 2, "llvm.aarch64.neon.smax.v2f32", {a_wide, b_wide});
+            wide_result = call_intrin(f32x2, 2, "llvm.aarch64.neon.fmax.v2f32", {a_wide, b_wide});
         }
         value = builder->CreateExtractElement(wide_result, zero);
         return;

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -424,7 +424,8 @@ void CodeGen_ARM::visit(const Cast *op) {
     // optimization recognizes logical shift right but not arithemtic
     // shift right for this pattern. This matters for vaddhn of signed
     // integers.
-    if ((t.is_int() || t.is_uint()) &&
+    if (t.is_vector() &&
+        (t.is_int() || t.is_uint()) &&
         op->value.type().is_int() &&
         t.bits == op->value.type().bits / 2) {
         const Div *d = op->value.as<Div>();
@@ -439,7 +440,8 @@ void CodeGen_ARM::visit(const Cast *op) {
     }
 
     // Catch widening of absolute difference
-    if ((t.is_int() || t.is_uint()) &&
+    if (t.is_vector() &&
+        (t.is_int() || t.is_uint()) &&
         (op->value.type().is_int() || op->value.type().is_uint()) &&
         t.bits == op->value.type().bits * 2) {
         Expr a, b;

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -735,7 +735,7 @@ void CodeGen_ARM::visit(const Min *op) {
         if (target.bits == 32) {
             wide_result = call_intrin(f32x2, 2, "llvm.arm.neon.vmins.v2f32", {a_wide, b_wide});
         } else {
-            wide_result = call_intrin(f32x2, 2, "llvm.aarch64.neon.smin.v2f32", {a_wide, b_wide});
+            wide_result = call_intrin(f32x2, 2, "llvm.aarch64.neon.fmin.v2f32", {a_wide, b_wide});
         }
         value = builder->CreateExtractElement(wide_result, zero);
         return;

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -3164,7 +3164,9 @@ Value *CodeGen_LLVM::call_intrin(Type result_type, int intrin_vector_width,
 
 Value *CodeGen_LLVM::call_intrin(llvm::Type *result_type, int intrin_vector_width,
                                  const string &name, vector<Value *> arg_values) {
-    int arg_vector_width = (int)result_type->getVectorNumElements();
+    internal_assert(result_type->isVectorTy()) << "call_intrin is for vector intrinsics only\n";
+
+    int arg_vector_width = (int)(result_type->getVectorNumElements());
 
     if (intrin_vector_width != arg_vector_width) {
         // Cut up each arg into appropriately-sized pieces, call the

--- a/src/runtime/aarch64.ll
+++ b/src/runtime/aarch64.ll
@@ -188,22 +188,6 @@ declare <2 x float> @llvm.aarch64.neon.frecps.v2f32(<2 x float> %x, <2 x float> 
 declare <4 x float> @llvm.aarch64.neon.frsqrts.v4f32(<4 x float> %x, <4 x float> %y) nounwind readnone;
 declare <2 x float> @llvm.aarch64.neon.frsqrts.v2f32(<2 x float> %x, <2 x float> %y) nounwind readnone;
 
-
-define weak_odr <4 x float> @fast_inverse_f32x4(<4 x float> %x) nounwind alwaysinline {
-       %approx = tail call <4 x float> @llvm.aarch64.neon.frecpe.v4f32(<4 x float> %x)
-       %correction = tail call <4 x float> @llvm.aarch64.neon.frecps.v4f32(<4 x float> %approx, <4 x float> %x)
-       %result = fmul <4 x float> %approx, %correction
-       ret <4 x float> %result
-}
-
-define weak_odr <4 x float> @fast_inverse_sqrt_f32x4(<4 x float> %x) nounwind alwaysinline {
-       %approx = tail call <4 x float> @llvm.aarch64.neon.frsqrte.v4f32(<4 x float> %x)
-       %approx2 = fmul <4 x float> %approx, %approx
-       %correction = tail call <4 x float> @llvm.aarch64.neon.frsqrts.v4f32(<4 x float> %approx2, <4 x float> %x)
-       %result = fmul <4 x float> %approx, %correction
-       ret <4 x float> %result
-}
-
 define weak_odr float @fast_inverse_f32(float %x) nounwind alwaysinline {
        %vec = insertelement <2 x float> undef, float %x, i32 0
        %approx = tail call <2 x float> @fast_inverse_f32x2(<2 x float> %vec)
@@ -218,6 +202,20 @@ define weak_odr <2 x float> @fast_inverse_f32x2(<2 x float> %x) nounwind alwaysi
        ret <2 x float> %result
 }
 
+define weak_odr <4 x float> @fast_inverse_f32x4(<4 x float> %x) nounwind alwaysinline {
+       %approx = tail call <4 x float> @llvm.aarch64.neon.frecpe.v4f32(<4 x float> %x)
+       %correction = tail call <4 x float> @llvm.aarch64.neon.frecps.v4f32(<4 x float> %approx, <4 x float> %x)
+       %result = fmul <4 x float> %approx, %correction
+       ret <4 x float> %result
+}
+
+define weak_odr float @fast_inverse_sqrt_f32(float %x) nounwind alwaysinline {
+       %vec = insertelement <2 x float> undef, float %x, i32 0
+       %approx = tail call <2 x float> @fast_inverse_sqrt_f32x2(<2 x float> %vec)
+       %result = extractelement <2 x float> %approx, i32 0
+       ret float %result
+}
+
 define weak_odr <2 x float> @fast_inverse_sqrt_f32x2(<2 x float> %x) nounwind alwaysinline {
        %approx = tail call <2 x float> @llvm.aarch64.neon.frsqrte.v2f32(<2 x float> %x)
        %approx2 = fmul <2 x float> %approx, %approx
@@ -226,11 +224,12 @@ define weak_odr <2 x float> @fast_inverse_sqrt_f32x2(<2 x float> %x) nounwind al
        ret <2 x float> %result
 }
 
-define weak_odr float @fast_inverse_sqrt_f32(float %x) nounwind alwaysinline {
-       %vec = insertelement <2 x float> undef, float %x, i32 0
-       %approx = tail call <2 x float> @fast_inverse_sqrt_f32x2(<2 x float> %vec)
-       %result = extractelement <2 x float> %approx, i32 0
-       ret float %result
+define weak_odr <4 x float> @fast_inverse_sqrt_f32x4(<4 x float> %x) nounwind alwaysinline {
+       %approx = tail call <4 x float> @llvm.aarch64.neon.frsqrte.v4f32(<4 x float> %x)
+       %approx2 = fmul <4 x float> %approx, %approx
+       %correction = tail call <4 x float> @llvm.aarch64.neon.frsqrts.v4f32(<4 x float> %approx2, <4 x float> %x)
+       %result = fmul <4 x float> %approx, %correction
+       ret <4 x float> %result
 }
 
 ; Declare all the vlds and vsts. Declaring them here simplifies the codegen class.

--- a/src/runtime/aarch64.ll
+++ b/src/runtime/aarch64.ll
@@ -1,13 +1,205 @@
-; TODO: add more specializations for ARMv8A Advanced SIMD
+; Absolute value ops
+
+
+declare <4 x float> @llvm.fabs.v4f32(<4 x float>) nounwind readnone
+declare <2 x float> @llvm.fabs.v2f32(<2 x float>) nounwind readnone
+declare <4 x i32> @llvm.aarch64.neon.abs.v4i32(<4 x i32>) nounwind readnone
+declare <2 x i32> @llvm.aarch64.neon.abs.v2i32(<2 x i32>) nounwind readnone
+declare <4 x i16> @llvm.aarch64.neon.abs.v4i16(<4 x i16>) nounwind readnone
+declare <8 x i16> @llvm.aarch64.neon.abs.v8i16(<8 x i16>) nounwind readnone
+declare <8 x i8>  @llvm.aarch64.neon.abs.v8i8(<8 x i8>)   nounwind readnone
+declare <16 x i8> @llvm.aarch64.neon.abs.v16i8(<16 x i8>) nounwind readnone
+
+define weak_odr <4 x float> @abs_f32x4(<4 x float> %x) nounwind alwaysinline {
+       %tmp = call <4 x float> @llvm.fabs.v4f32(<4 x float> %x)
+       ret <4 x float> %tmp
+}
+
+define weak_odr <2 x float> @abs_f32x2(<2 x float> %x) nounwind alwaysinline {
+       %tmp = call <2 x float> @llvm.fabs.v2f32(<2 x float> %x)
+       ret <2 x float> %tmp
+}
+
+define weak_odr <4 x i32> @abs_i32x4(<4 x i32> %x) nounwind alwaysinline {
+       %tmp = call <4 x i32> @llvm.aarch64.neon.abs.v4i32(<4 x i32> %x)
+       ret <4 x i32> %tmp
+}
+
+define weak_odr <2 x i32> @abs_i32x2(<2 x i32> %x) nounwind alwaysinline {
+       %tmp = call <2 x i32> @llvm.aarch64.neon.abs.v2i32(<2 x i32> %x)
+       ret <2 x i32> %tmp
+}
+
+define weak_odr <4 x i16> @abs_i16x4(<4 x i16> %x) nounwind alwaysinline {
+       %tmp = call <4 x i16> @llvm.aarch64.neon.abs.v4i16(<4 x i16> %x)
+       ret <4 x i16> %tmp
+}
+
+define weak_odr <8 x i16> @abs_i16x8(<8 x i16> %x) nounwind alwaysinline {
+       %tmp = call <8 x i16> @llvm.aarch64.neon.abs.v8i16(<8 x i16> %x)
+       ret <8 x i16> %tmp
+}
+
+define weak_odr <8 x i8> @abs_i8x8(<8 x i8> %x) nounwind alwaysinline {
+       %tmp = call <8 x i8> @llvm.aarch64.neon.abs.v8i8(<8 x i8> %x)
+       ret <8 x i8> %tmp
+}
+
+define weak_odr <16 x i8> @abs_i8x16(<16 x i8> %x) nounwind alwaysinline {
+       %tmp = call <16 x i8> @llvm.aarch64.neon.abs.v16i8(<16 x i8> %x)
+       ret <16 x i8> %tmp
+}
+
+declare <8 x i8> @llvm.aarch64.neon.sabd.v8i8(<8 x i8>, <8 x i8>) nounwind readnone
+declare <8 x i8> @llvm.aarch64.neon.uabd.v8i8(<8 x i8>, <8 x i8>) nounwind readnone
+declare <4 x i16> @llvm.aarch64.neon.sabd.v4i16(<4 x i16>, <4 x i16>) nounwind readnone
+declare <4 x i16> @llvm.aarch64.neon.uabd.v4i16(<4 x i16>, <4 x i16>) nounwind readnone
+declare <2 x i32> @llvm.aarch64.neon.sabd.v2i32(<2 x i32>, <2 x i32>) nounwind readnone
+declare <2 x i32> @llvm.aarch64.neon.uabd.v2i32(<2 x i32>, <2 x i32>) nounwind readnone
+declare <16 x i8> @llvm.aarch64.neon.sabd.v16i8(<16 x i8>, <16 x i8>) nounwind readnone
+declare <16 x i8> @llvm.aarch64.neon.uabd.v16i8(<16 x i8>, <16 x i8>) nounwind readnone
+declare <8 x i16> @llvm.aarch64.neon.sabd.v8i16(<8 x i16>, <8 x i16>) nounwind readnone
+declare <8 x i16> @llvm.aarch64.neon.uabd.v8i16(<8 x i16>, <8 x i16>) nounwind readnone
+declare <4 x i32> @llvm.aarch64.neon.sabd.v4i32(<4 x i32>, <4 x i32>) nounwind readnone
+declare <4 x i32> @llvm.aarch64.neon.uabd.v4i32(<4 x i32>, <4 x i32>) nounwind readnone
+
+; Absolute difference ops
+
+define weak_odr <4 x i32> @absd_i32x4(<4 x i32> %a, <4 x i32> %b) nounwind alwaysinline {
+       %tmp = call <4 x i32> @llvm.aarch64.neon.sabd.v4i32(<4 x i32> %a, <4 x i32> %b)
+       ret <4 x i32> %tmp
+}
+
+define weak_odr <2 x i32> @absd_i32x2(<2 x i32> %a, <2 x i32> %b) nounwind alwaysinline {
+       %tmp = call <2 x i32> @llvm.aarch64.neon.sabd.v2i32(<2 x i32> %a, <2 x i32> %b)
+       ret <2 x i32> %tmp
+}
+
+define weak_odr <4 x i16> @absd_i16x4(<4 x i16> %a, <4 x i16> %b) nounwind alwaysinline {
+       %tmp = call <4 x i16> @llvm.aarch64.neon.sabd.v4i16(<4 x i16> %a, <4 x i16> %b)
+       ret <4 x i16> %tmp
+}
+
+define weak_odr <8 x i16> @absd_i16x8(<8 x i16> %a, <8 x i16> %b) nounwind alwaysinline {
+       %tmp = call <8 x i16> @llvm.aarch64.neon.sabd.v8i16(<8 x i16> %a, <8 x i16> %b)
+       ret <8 x i16> %tmp
+}
+
+define weak_odr <8 x i8> @absd_i8x8(<8 x i8> %a, <8 x i8> %b) nounwind alwaysinline {
+       %tmp = call <8 x i8> @llvm.aarch64.neon.sabd.v8i8(<8 x i8> %a, <8 x i8> %b)
+       ret <8 x i8> %tmp
+}
+
+define weak_odr <16 x i8> @absd_i8x16(<16 x i8> %a, <16 x i8> %b) nounwind alwaysinline {
+       %tmp = call <16 x i8> @llvm.aarch64.neon.sabd.v16i8(<16 x i8> %a, <16 x i8> %b)
+       ret <16 x i8> %tmp
+}
+
+define weak_odr <4 x i32> @absd_u32x4(<4 x i32> %a, <4 x i32> %b) nounwind alwaysinline {
+       %tmp = call <4 x i32> @llvm.aarch64.neon.uabd.v4i32(<4 x i32> %a, <4 x i32> %b)
+       ret <4 x i32> %tmp
+}
+
+define weak_odr <2 x i32> @absd_u32x2(<2 x i32> %a, <2 x i32> %b) nounwind alwaysinline {
+       %tmp = call <2 x i32> @llvm.aarch64.neon.uabd.v2i32(<2 x i32> %a, <2 x i32> %b)
+       ret <2 x i32> %tmp
+}
+
+define weak_odr <4 x i16> @absd_u16x4(<4 x i16> %a, <4 x i16> %b) nounwind alwaysinline {
+       %tmp = call <4 x i16> @llvm.aarch64.neon.uabd.v4i16(<4 x i16> %a, <4 x i16> %b)
+       ret <4 x i16> %tmp
+}
+
+define weak_odr <8 x i16> @absd_u16x8(<8 x i16> %a, <8 x i16> %b) nounwind alwaysinline {
+       %tmp = call <8 x i16> @llvm.aarch64.neon.uabd.v8i16(<8 x i16> %a, <8 x i16> %b)
+       ret <8 x i16> %tmp
+}
+
+define weak_odr <8 x i8> @absd_u8x8(<8 x i8> %a, <8 x i8> %b) nounwind alwaysinline {
+       %tmp = call <8 x i8> @llvm.aarch64.neon.uabd.v8i8(<8 x i8> %a, <8 x i8> %b)
+       ret <8 x i8> %tmp
+}
+
+define weak_odr <16 x i8> @absd_u8x16(<16 x i8> %a, <16 x i8> %b) nounwind alwaysinline {
+       %tmp = call <16 x i8> @llvm.aarch64.neon.uabd.v16i8(<16 x i8> %a, <16 x i8> %b)
+       ret <16 x i8> %tmp
+}
+
+; Widening absolute difference ops. llvm peephole recognizes vabdl and
+; vabal as calls to vabd followed by widening. Regardless of the
+; signedness of the arg, these always zero-extend, because an absolute
+; difference is always positive and may overflow a signed int.
+
+define weak_odr <8 x i16> @vabdl_i8x8(<8 x i8> %a, <8 x i8> %b) nounwind alwaysinline {
+       %1 = call <8 x i8> @llvm.aarch64.neon.sabd.v8i8(<8 x i8> %a, <8 x i8> %b)
+       %2 = zext <8 x i8> %1 to <8 x i16>
+       ret <8 x i16> %2
+}
+
+define weak_odr <8 x i16> @vabdl_u8x8(<8 x i8> %a, <8 x i8> %b) nounwind alwaysinline {
+       %1 = call <8 x i8> @llvm.aarch64.neon.uabd.v8i8(<8 x i8> %a, <8 x i8> %b)
+       %2 = zext <8 x i8> %1 to <8 x i16>
+       ret <8 x i16> %2
+}
+
+define weak_odr <4 x i32> @vabdl_i16x4(<4 x i16> %a, <4 x i16> %b) nounwind alwaysinline {
+       %1 = call <4 x i16> @llvm.aarch64.neon.sabd.v4i16(<4 x i16> %a, <4 x i16> %b)
+       %2 = zext <4 x i16> %1 to <4 x i32>
+       ret <4 x i32> %2
+}
+
+define weak_odr <4 x i32> @vabdl_u16x4(<4 x i16> %a, <4 x i16> %b) nounwind alwaysinline {
+       %1 = call <4 x i16> @llvm.aarch64.neon.uabd.v4i16(<4 x i16> %a, <4 x i16> %b)
+       %2 = zext <4 x i16> %1 to <4 x i32>
+       ret <4 x i32> %2
+}
+
+define weak_odr <2 x i64> @vabdl_i32x2(<2 x i32> %a, <2 x i32> %b) nounwind alwaysinline {
+       %1 = call <2 x i32> @llvm.aarch64.neon.sabd.v2i32(<2 x i32> %a, <2 x i32> %b)
+       %2 = zext <2 x i32> %1 to <2 x i64>
+       ret <2 x i64> %2
+}
+
+define weak_odr <2 x i64> @vabdl_u32x2(<2 x i32> %a, <2 x i32> %b) nounwind alwaysinline {
+       %1 = call <2 x i32> @llvm.aarch64.neon.uabd.v2i32(<2 x i32> %a, <2 x i32> %b)
+       %2 = zext <2 x i32> %1 to <2 x i64>
+       ret <2 x i64> %2
+}
+
+declare <4 x float> @llvm.sqrt.v4f32(<4 x float>);
+declare <2 x double> @llvm.sqrt.v2f64(<2 x double>);
+
+define weak_odr <4 x float> @sqrt_f32x4(<4 x float> %x) nounwind alwaysinline {
+       %tmp = call <4 x float> @llvm.sqrt.v4f32(<4 x float> %x)
+       ret <4 x float> %tmp
+}
+
+define weak_odr <2 x double> @sqrt_f64x2(<2 x double> %x) nounwind alwaysinline {
+       %tmp = call <2 x double> @llvm.sqrt.v2f64(<2 x double> %x)
+       ret <2 x double> %tmp
+}
 
 declare <4 x float> @llvm.aarch64.neon.frecpe.v4f32(<4 x float> %x) nounwind readnone;
 declare <2 x float> @llvm.aarch64.neon.frecpe.v2f32(<2 x float> %x) nounwind readnone;
+declare <4 x float> @llvm.aarch64.neon.frsqrte.v4f32(<4 x float> %x) nounwind readnone;
+declare <2 x float> @llvm.aarch64.neon.frsqrte.v2f32(<2 x float> %x) nounwind readnone;
 declare <4 x float> @llvm.aarch64.neon.frecps.v4f32(<4 x float> %x, <4 x float> %y) nounwind readnone;
 declare <2 x float> @llvm.aarch64.neon.frecps.v2f32(<2 x float> %x, <2 x float> %y) nounwind readnone;
+declare <4 x float> @llvm.aarch64.neon.frsqrts.v4f32(<4 x float> %x, <4 x float> %y) nounwind readnone;
+declare <2 x float> @llvm.aarch64.neon.frsqrts.v2f32(<2 x float> %x, <2 x float> %y) nounwind readnone;
+
 
 define weak_odr <4 x float> @fast_inverse_f32x4(<4 x float> %x) nounwind alwaysinline {
        %approx = tail call <4 x float> @llvm.aarch64.neon.frecpe.v4f32(<4 x float> %x)
        %correction = tail call <4 x float> @llvm.aarch64.neon.frecps.v4f32(<4 x float> %approx, <4 x float> %x)
+       %result = fmul <4 x float> %approx, %correction
+       ret <4 x float> %result
+}
+
+define weak_odr <4 x float> @fast_inverse_sqrt_f32x4(<4 x float> %x) nounwind alwaysinline {
+       %approx = tail call <4 x float> @llvm.aarch64.neon.frsqrte.v4f32(<4 x float> %x)
+       %approx2 = fmul <4 x float> %approx, %approx
+       %correction = tail call <4 x float> @llvm.aarch64.neon.frsqrts.v4f32(<4 x float> %approx2, <4 x float> %x)
        %result = fmul <4 x float> %approx, %correction
        ret <4 x float> %result
 }
@@ -25,3 +217,99 @@ define weak_odr <2 x float> @fast_inverse_f32x2(<2 x float> %x) nounwind alwaysi
        %result = fmul <2 x float> %approx, %correction
        ret <2 x float> %result
 }
+
+define weak_odr <2 x float> @fast_inverse_sqrt_f32x2(<2 x float> %x) nounwind alwaysinline {
+       %approx = tail call <2 x float> @llvm.aarch64.neon.frsqrte.v2f32(<2 x float> %x)
+       %approx2 = fmul <2 x float> %approx, %approx
+       %correction = tail call <2 x float> @llvm.aarch64.neon.frsqrts.v2f32(<2 x float> %approx2, <2 x float> %x)
+       %result = fmul <2 x float> %approx, %correction
+       ret <2 x float> %result
+}
+
+define weak_odr float @fast_inverse_sqrt_f32(float %x) nounwind alwaysinline {
+       %vec = insertelement <2 x float> undef, float %x, i32 0
+       %approx = tail call <2 x float> @fast_inverse_sqrt_f32x2(<2 x float> %vec)
+       %result = extractelement <2 x float> %approx, i32 0
+       ret float %result
+}
+
+; Declare all the vlds and vsts. Declaring them here simplifies the codegen class.
+
+%v8xi8x2 = type { <8 x i8>, <8 x i8> }
+%v8xi8x3 = type { <8 x i8>, <8 x i8>, <8 x i8> }
+%v8xi8x4 = type { <8 x i8>, <8 x i8>, <8 x i8>, <8 x i8> }
+%v16xi8x2 = type { <16 x i8>, <16 x i8> }
+%v16xi8x3 = type { <16 x i8>, <16 x i8>, <16 x i8> }
+%v16xi8x4 = type { <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8> }
+%v4xi16x2 = type { <4 x i16>, <4 x i16> }
+%v4xi16x3 = type { <4 x i16>, <4 x i16>, <4 x i16> }
+%v4xi16x4 = type { <4 x i16>, <4 x i16>, <4 x i16>, <4 x i16> }
+%v8xi16x2 = type { <8 x i16>, <8 x i16> }
+%v8xi16x3 = type { <8 x i16>, <8 x i16>, <8 x i16> }
+%v8xi16x4 = type { <8 x i16>, <8 x i16>, <8 x i16>, <8 x i16> }
+%v2xi32x2 = type { <2 x i32>, <2 x i32> }
+%v2xi32x3 = type { <2 x i32>, <2 x i32>, <2 x i32> }
+%v2xi32x4 = type { <2 x i32>, <2 x i32>, <2 x i32>, <2 x i32> }
+%v4xi32x2 = type { <4 x i32>, <4 x i32> }
+%v4xi32x3 = type { <4 x i32>, <4 x i32>, <4 x i32> }
+%v4xi32x4 = type { <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32> }
+%v2xf32x2 = type { <2 x float>, <2 x float> }
+%v2xf32x3 = type { <2 x float>, <2 x float>, <2 x float> }
+%v2xf32x4 = type { <2 x float>, <2 x float>, <2 x float>, <2 x float> }
+%v4xf32x2 = type { <4 x float>, <4 x float> }
+%v4xf32x3 = type { <4 x float>, <4 x float>, <4 x float> }
+%v4xf32x4 = type { <4 x float>, <4 x float>, <4 x float>, <4 x float> }
+
+declare %v8xi8x2 @llvm.aarch64.neon.ld2.v8i8.p0i8(i8* nocapture) nounwind readonly
+declare %v16xi8x2 @llvm.aarch64.neon.ld2.v16i8.p0i8(i8* nocapture) nounwind readonly
+declare %v4xi16x2 @llvm.aarch64.neon.ld2.v4i16.p0i16(i16* nocapture) nounwind readonly
+declare %v8xi16x2 @llvm.aarch64.neon.ld2.v8i16.p0i16(i16* nocapture) nounwind readonly
+declare %v2xi32x2 @llvm.aarch64.neon.ld2.v2i32.p0i32(i32* nocapture) nounwind readonly
+declare %v4xi32x2 @llvm.aarch64.neon.ld2.v4i32.p0i32(i32* nocapture) nounwind readonly
+declare %v2xf32x2 @llvm.aarch64.neon.ld2.v2f32.p0f32(float* nocapture) nounwind readonly
+declare %v4xf32x2 @llvm.aarch64.neon.ld2.v4f32.p0f32(float* nocapture) nounwind readonly
+
+declare %v8xi8x3 @llvm.aarch64.neon.ld3.v8i8.p0i8(i8* nocapture) nounwind readonly
+declare %v16xi8x3 @llvm.aarch64.neon.ld3.v16i8.p0i8(i8* nocapture) nounwind readonly
+declare %v4xi16x3 @llvm.aarch64.neon.ld3.v4i16.p0i16(i16* nocapture) nounwind readonly
+declare %v8xi16x3 @llvm.aarch64.neon.ld3.v8i16.p0i16(i16* nocapture) nounwind readonly
+declare %v2xi32x3 @llvm.aarch64.neon.ld3.v2i32.p0i32(i32* nocapture) nounwind readonly
+declare %v4xi32x3 @llvm.aarch64.neon.ld3.v4i32.p0i32(i32* nocapture) nounwind readonly
+declare %v2xf32x3 @llvm.aarch64.neon.ld3.v2f32.p0f32(float* nocapture) nounwind readonly
+declare %v4xf32x3 @llvm.aarch64.neon.ld3.v4f32.p0f32(float* nocapture) nounwind readonly
+
+declare %v8xi8x4 @llvm.aarch64.neon.ld4.v8i8.p0i8(i8* nocapture) nounwind readonly
+declare %v16xi8x4 @llvm.aarch64.neon.ld4.v16i8.p0i8(i8* nocapture) nounwind readonly
+declare %v4xi16x4 @llvm.aarch64.neon.ld4.v4i16.p0i16(i16* nocapture) nounwind readonly
+declare %v8xi16x4 @llvm.aarch64.neon.ld4.v8i16.p0i16(i16* nocapture) nounwind readonly
+declare %v2xi32x4 @llvm.aarch64.neon.ld4.v2i32.p0i32(i32* nocapture) nounwind readonly
+declare %v4xi32x4 @llvm.aarch64.neon.ld4.v4i32.p0i32(i32* nocapture) nounwind readonly
+declare %v2xf32x4 @llvm.aarch64.neon.ld4.v2f32.p0f32(float* nocapture) nounwind readonly
+declare %v4xf32x4 @llvm.aarch64.neon.ld4.v4f32.p0f32(float* nocapture) nounwind readonly
+
+declare void @llvm.aarch64.neon.st2.v2f32.p0f32(<2 x float>, <2 x float>, float* nocapture) nounwind
+declare void @llvm.aarch64.neon.st2.v2i32.p0i32(<2 x i32>, <2 x i32>, i32* nocapture) nounwind
+declare void @llvm.aarch64.neon.st2.v4f32.p0f32(<4 x float>, <4 x float>, float* nocapture) nounwind
+declare void @llvm.aarch64.neon.st2.v4i16.p0i16(<4 x i16>, <4 x i16>, i16* nocapture) nounwind
+declare void @llvm.aarch64.neon.st2.v4i32.p0i32(<4 x i32>, <4 x i32>, i32* nocapture) nounwind
+declare void @llvm.aarch64.neon.st2.v8i16.p0i16(<8 x i16>, <8 x i16>, i16* nocapture) nounwind
+declare void @llvm.aarch64.neon.st2.v8i8.p0i8(<8 x i8>, <8 x i8>, i8* nocapture) nounwind
+declare void @llvm.aarch64.neon.st2.v16i8.p0i8(<16 x i8>, <16 x i8>, i8* nocapture) nounwind
+
+declare void @llvm.aarch64.neon.st3.v2f32.p0f32(<2 x float>, <2 x float>, <2 x float>, float* nocapture) nounwind
+declare void @llvm.aarch64.neon.st3.v2i32.p0i32(<2 x i32>, <2 x i32>, <2 x i32>, i32* nocapture) nounwind
+declare void @llvm.aarch64.neon.st3.v4f32.p0f32(<4 x float>, <4 x float>, <4 x float>, float* nocapture) nounwind
+declare void @llvm.aarch64.neon.st3.v4i16.p0i16(<4 x i16>, <4 x i16>, <4 x i16>, i16* nocapture) nounwind
+declare void @llvm.aarch64.neon.st3.v4i32.p0i32(<4 x i32>, <4 x i32>, <4 x i32>, i32* nocapture) nounwind
+declare void @llvm.aarch64.neon.st3.v8i16.p0i16(<8 x i16>, <8 x i16>, <8 x i16>, i16* nocapture) nounwind
+declare void @llvm.aarch64.neon.st3.v8i8.p0i8(<8 x i8>, <8 x i8>, <8 x i8>, i8* nocapture) nounwind
+declare void @llvm.aarch64.neon.st3.v16i8.p0i8(<16 x i8>, <16 x i8>, <16 x i8>, i8* nocapture) nounwind
+
+declare void @llvm.aarch64.neon.st4.v2f32.p0f32(<2 x float>, <2 x float>, <2 x float>, <2 x float>, float* nocapture) nounwind
+declare void @llvm.aarch64.neon.st4.v2i32.p0i32(<2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>, i32* nocapture) nounwind
+declare void @llvm.aarch64.neon.st4.v4f32.p0f32(<4 x float>, <4 x float>, <4 x float>, <4 x float>, float* nocapture) nounwind
+declare void @llvm.aarch64.neon.st4.v4i16.p0i16(<4 x i16>, <4 x i16>, <4 x i16>, <4 x i16>, i16* nocapture) nounwind
+declare void @llvm.aarch64.neon.st4.v4i32.p0i32(<4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, i32* nocapture) nounwind
+declare void @llvm.aarch64.neon.st4.v8i16.p0i16(<8 x i16>, <8 x i16>, <8 x i16>, <8 x i16>, i16* nocapture) nounwind
+declare void @llvm.aarch64.neon.st4.v8i8.p0i8(<8 x i8>, <8 x i8>, <8 x i8>, <8 x i8>, i8* nocapture) nounwind
+declare void @llvm.aarch64.neon.st4.v16i8.p0i8(<16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, i8* nocapture) nounwind

--- a/src/runtime/arm.ll
+++ b/src/runtime/arm.ll
@@ -188,22 +188,6 @@ declare <2 x float> @llvm.arm.neon.vrecps.v2f32(<2 x float> %x, <2 x float> %y) 
 declare <4 x float> @llvm.arm.neon.vrsqrts.v4f32(<4 x float> %x, <4 x float> %y) nounwind readnone;
 declare <2 x float> @llvm.arm.neon.vrsqrts.v2f32(<2 x float> %x, <2 x float> %y) nounwind readnone;
 
-
-define weak_odr <4 x float> @fast_inverse_f32x4(<4 x float> %x) nounwind alwaysinline {
-       %approx = tail call <4 x float> @llvm.arm.neon.vrecpe.v4f32(<4 x float> %x)
-       %correction = tail call <4 x float> @llvm.arm.neon.vrecps.v4f32(<4 x float> %approx, <4 x float> %x)
-       %result = fmul <4 x float> %approx, %correction
-       ret <4 x float> %result
-}
-
-define weak_odr <4 x float> @fast_inverse_sqrt_f32x4(<4 x float> %x) nounwind alwaysinline {
-       %approx = tail call <4 x float> @llvm.arm.neon.vrsqrte.v4f32(<4 x float> %x)
-       %approx2 = fmul <4 x float> %approx, %approx
-       %correction = tail call <4 x float> @llvm.arm.neon.vrsqrts.v4f32(<4 x float> %approx2, <4 x float> %x)
-       %result = fmul <4 x float> %approx, %correction
-       ret <4 x float> %result
-}
-
 define weak_odr float @fast_inverse_f32(float %x) nounwind alwaysinline {
        %vec = insertelement <2 x float> undef, float %x, i32 0
        %approx = tail call <2 x float> @fast_inverse_f32x2(<2 x float> %vec)
@@ -218,6 +202,20 @@ define weak_odr <2 x float> @fast_inverse_f32x2(<2 x float> %x) nounwind alwaysi
        ret <2 x float> %result
 }
 
+define weak_odr <4 x float> @fast_inverse_f32x4(<4 x float> %x) nounwind alwaysinline {
+       %approx = tail call <4 x float> @llvm.arm.neon.vrecpe.v4f32(<4 x float> %x)
+       %correction = tail call <4 x float> @llvm.arm.neon.vrecps.v4f32(<4 x float> %approx, <4 x float> %x)
+       %result = fmul <4 x float> %approx, %correction
+       ret <4 x float> %result
+}
+
+define weak_odr float @fast_inverse_sqrt_f32(float %x) nounwind alwaysinline {
+       %vec = insertelement <2 x float> undef, float %x, i32 0
+       %approx = tail call <2 x float> @fast_inverse_sqrt_f32x2(<2 x float> %vec)
+       %result = extractelement <2 x float> %approx, i32 0
+       ret float %result
+}
+
 define weak_odr <2 x float> @fast_inverse_sqrt_f32x2(<2 x float> %x) nounwind alwaysinline {
        %approx = tail call <2 x float> @llvm.arm.neon.vrsqrte.v2f32(<2 x float> %x)
        %approx2 = fmul <2 x float> %approx, %approx
@@ -226,11 +224,12 @@ define weak_odr <2 x float> @fast_inverse_sqrt_f32x2(<2 x float> %x) nounwind al
        ret <2 x float> %result
 }
 
-define weak_odr float @fast_inverse_sqrt_f32(float %x) nounwind alwaysinline {
-       %vec = insertelement <2 x float> undef, float %x, i32 0
-       %approx = tail call <2 x float> @fast_inverse_sqrt_f32x2(<2 x float> %vec)
-       %result = extractelement <2 x float> %approx, i32 0
-       ret float %result
+define weak_odr <4 x float> @fast_inverse_sqrt_f32x4(<4 x float> %x) nounwind alwaysinline {
+       %approx = tail call <4 x float> @llvm.arm.neon.vrsqrte.v4f32(<4 x float> %x)
+       %approx2 = fmul <4 x float> %approx, %approx
+       %correction = tail call <4 x float> @llvm.arm.neon.vrsqrts.v4f32(<4 x float> %approx2, <4 x float> %x)
+       %result = fmul <4 x float> %approx, %correction
+       ret <4 x float> %result
 }
 
 define weak_odr <8 x i8> @strided_load_i8x8(i8 * %ptr, i32 %stride) nounwind alwaysinline {


### PR DESCRIPTION
This PR adds aarch64 peephole optimizations for things like saturating add or interleaving store.

There are a few new things happening here:
1) A bunch of code in CodeGen_ARM.cpp and runtime/aarch64.ll to emit these 64-bit neon ops. The llvm intrinsics are similar but not the same as the 32-bit versions.
2) A bunch of code in test/simd_op_check to make sure we're generating them correctly.
3) A minimal app that you can run on a (rooted) device to make sure they all do the same thing as their unvectorized equivalents (works together with simd_op_check). The app currently passes.

I also deleted some dead code in CodeGen_ARM while I was there (LLVM_VERSION < 35 stuff)