### PR TITLE
Move build -> bin/build (Issue #873)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,7 +114,6 @@
 /apps/nacl_demos/reaction_diffusion_update.h
 /apps/HelloNaCl/halide_game_of_life.h
 bin/*
-build/*
 build-ios/*
 build-osx/*
 cmake_build/*

--- a/Makefile
+++ b/Makefile
@@ -193,15 +193,14 @@ endif
 LIBPNG_LIBS ?= $(LIBPNG_LIBS_DEFAULT)
 
 ifdef BUILD_PREFIX
-BUILD_DIR = build/$(BUILD_PREFIX)
 BIN_DIR = bin/$(BUILD_PREFIX)
 DISTRIB_DIR=distrib/$(BUILD_PREFIX)
 else
-BUILD_DIR = build
 BIN_DIR = bin
 DISTRIB_DIR=distrib
 endif
 
+BUILD_DIR = $(BIN_DIR)/build
 FILTERS_DIR = $(BUILD_DIR)/filters
 
 SOURCE_FILES = \

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ package, run 'make distrib'.
 
 If you wish to use cmake to build Halide, the build procedure is:
 
-    % mkdir build
-    % cd build
+    % mkdir cmake_build
+    % cd cmake_build
     % LLVM_ROOT=/path/to/llvm3.5
     % cmake -DLLVM_BIN=${LLVM_ROOT}/build/bin -DLLVM_INCLUDE="${LLVM_ROOT}/include;${LLVM_ROOT}/build/include" -DLLVM_LIB=${LLVM_ROOT}/build/lib -DLLVM_VERSION=35 ..
     % make -j8


### PR DESCRIPTION
Move the default location of Makefile’s BUILD_DIR to be inside bin/ and
update .gitignore to no longer ignore build/ at top-level. Also change
the README to suggest a different name for camp’s build folder.