### PR TITLE
Make sure handles load and store as uint64_t

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1614,6 +1614,12 @@ void CodeGen_LLVM::visit(const Load *op) {
 
     bool possibly_misaligned = (might_be_misaligned.find(op->name) != might_be_misaligned.end());
 
+    // If it's a Handle, load it as a uint64_t and then cast
+    if (op->type.is_handle()) {
+        codegen(reinterpret(op->type, Load::make(UInt(64, op->type.width), op->name, op->index, op->image, op->param)));
+        return;
+    }
+
     // There are several cases. Different architectures may wish to override some.
     if (op->type.is_scalar()) {
         // Scalar loads
@@ -2077,7 +2083,7 @@ void CodeGen_LLVM::visit(const Call *op) {
                 }
 
             } else if (dst.is_handle() && !src.is_handle()) {
-                internal_assert(dst.is_uint() && dst.bits == 64);
+                internal_assert(src.is_uint() && src.bits == 64);
 
                 // UInt64 -> Handle
                 llvm::DataLayout d(module);
@@ -2998,16 +3004,24 @@ void CodeGen_LLVM::visit(const For *op) {
 }
 
 void CodeGen_LLVM::visit(const Store *op) {
-    Value *val = codegen(op->value);
+    // Even on 32-bit systems, Handles are treated as 64-bit in
+    // memory, so convert stores of handles to stores of uint64_ts.
+    if (op->value.type().is_handle()) {
+        Expr v = reinterpret(UInt(64, op->value.type().width), op->value);
+        codegen(Store::make(op->name, v, op->index));
+        return;
+    }
+
     Halide::Type value_type = op->value.type();
+    Value *val = codegen(op->value);
     bool possibly_misaligned = (might_be_misaligned.find(op->name) != might_be_misaligned.end());
     // Scalar
     if (value_type.is_scalar()) {
         Value *ptr = codegen_buffer_pointer(op->name, value_type, op->index);
-        StoreInst *store = builder->CreateAlignedStore(val, ptr, op->value.type().bytes());
+        StoreInst *store = builder->CreateAlignedStore(val, ptr, value_type.bytes());
         add_tbaa_metadata(store, op->name, op->index);
     } else {
-        int alignment = op->value.type().bytes();
+        int alignment = value_type.bytes();
         const Ramp *ramp = op->index.as<Ramp>();
         if (ramp && is_one(ramp->stride)) {
 
@@ -3027,8 +3041,8 @@ void CodeGen_LLVM::visit(const Store *op) {
 
             // For dense vector stores wider than the native vector
             // width, bust them up into native vectors.
-            int store_lanes = op->value.type().width;
-            int native_lanes = native_bits / op->value.type().bits;
+            int store_lanes = value_type.width;
+            int native_lanes = native_bits / value_type.bits;
 
             for (int i = 0; i < store_lanes; i += native_lanes) {
                 int slice_lanes = std::min(native_lanes, store_lanes - i);

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -171,7 +171,7 @@ inline Expr cast(Type t, Expr a) {
     } else if (a.type().is_handle() && !t.is_handle()) {
         user_error << "Can't cast handle \"" << a << "\" to type " << t << ". "
                    << "The only legal cast from handles to scalar types is: "
-                   << "reinterpret(UInt64(), " << a << ");\n";
+                   << "reinterpret(UInt(64), " << a << ");\n";
     }
 
     if (t.is_vector()) {

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -20,13 +20,14 @@ void ImageBase::prepare_for_direct_pixel_access() {
         stride_1 = buffer.stride(1);
         stride_2 = buffer.stride(2);
         stride_3 = buffer.stride(3);
+        elem_size = buffer.type().bytes();
         // The host pointer points to the mins vec, but we want to
         // point to the origin of the coordinate system.
         size_t offset = (buffer.min(0) * stride_0 +
                          buffer.min(1) * stride_1 +
                          buffer.min(2) * stride_2 +
                          buffer.min(3) * stride_3);
-        offset *= buffer.type().bytes();
+        offset *= elem_size;
         origin = (void *)((uint8_t *)origin - offset);
         dims = buffer.dimensions();
     } else {

--- a/src/Image.h
+++ b/src/Image.h
@@ -34,6 +34,9 @@ protected:
     /** The dimensionality. */
     int dims;
 
+    /** The size of each element. */
+    int elem_size;
+
     /** Prepare the buffer to be used as an image. Makes sure that the
      * cached strides are correct, and that the image data is on the
      * host. */
@@ -150,6 +153,13 @@ public:
 
     /** Get a pointer to the raw buffer_t that this image holds */
     EXPORT buffer_t *raw_buffer() const;
+
+    /** Get the address of a particular pixel. */
+    void *address_of(int x, int y = 0, int z = 0, int w = 0) const {
+        uint8_t *ptr = (uint8_t *)origin;
+        size_t offset = x*stride_0 + y*stride_1 + z*stride_2 + w*stride_3;
+        return (void *)(ptr + offset * elem_size);
+    }
 };
 
 /** A reference-counted handle on a dense multidimensional array
@@ -203,49 +213,49 @@ public:
     /** Assuming this image is one-dimensional, get the value of the
      * element at position x */
     const T &operator()(int x) const {
-        return ((T *)origin)[x*stride_0];
+        return *((T *)(address_of(x)));
     }
 
     /** Assuming this image is two-dimensional, get the value of the
      * element at position (x, y) */
     const T &operator()(int x, int y) const {
-        return ((T *)origin)[x*stride_0 + y*stride_1];
+        return *((T *)(address_of(x, y)));
     }
 
     /** Assuming this image is three-dimensional, get the value of the
      * element at position (x, y, z) */
     const T &operator()(int x, int y, int z) const {
-        return ((T *)origin)[x*stride_0 + y*stride_1 + z*stride_2];
+        return *((T *)(address_of(x, y, z)));
     }
 
     /** Assuming this image is four-dimensional, get the value of the
      * element at position (x, y, z, w) */
     const T &operator()(int x, int y, int z, int w) const {
-        return ((T *)origin)[x*stride_0 + y*stride_1 + z*stride_2 + w*stride_3];
+        return *((T *)(address_of(x, y, z, w)));
     }
 
     /** Assuming this image is one-dimensional, get a reference to the
      * element at position x */
     T &operator()(int x) {
-        return ((T *)origin)[x*stride_0];
+        return *((T *)(address_of(x)));
     }
 
     /** Assuming this image is two-dimensional, get a reference to the
      * element at position (x, y) */
     T &operator()(int x, int y) {
-        return ((T *)origin)[x*stride_0 + y*stride_1];
+        return *((T *)(address_of(x, y)));
     }
 
     /** Assuming this image is three-dimensional, get a reference to the
      * element at position (x, y, z) */
     T &operator()(int x, int y, int z) {
-        return ((T *)origin)[x*stride_0 + y*stride_1 + z*stride_2];
+        return *((T *)(address_of(x, y, z)));
     }
 
     /** Assuming this image is four-dimensional, get a reference to the
      * element at position (x, y, z, w) */
     T &operator()(int x, int y, int z, int w) {
-        return ((T *)origin)[x*stride_0 + y*stride_1 + z*stride_2 + w*stride_3];
+        return *((T *)(address_of(x, y, z, w)));
     }
 
     /** Get a handle on the Buffer that this image holds */

--- a/test/correctness/handle.cpp
+++ b/test/correctness/handle.cpp
@@ -24,18 +24,60 @@ int my_strlen(const char *c) {
 HalideExtern_1(int, my_strlen, const char *);
 
 int main(int argc, char **argv) {
-    const char *c_message = "Hello, world!";
+    // Check we can pass a Handle through to an extern function.
+    {
+        const char *c_message = "Hello, world!";
 
-    Param<const char *> message;
-    message.set(c_message);
+        Param<const char *> message;
+        message.set(c_message);
 
-    int result = evaluate<int>(my_strlen(message));
+        int result = evaluate<int>(my_strlen(message));
 
-    int correct = my_strlen(c_message);
-    if (result != correct) {
-        printf("strlen(%s) -> %d instead of %d\n",
-               c_message, result, correct);
-        return -1;
+        int correct = my_strlen(c_message);
+        if (result != correct) {
+            printf("strlen(%s) -> %d instead of %d\n",
+                   c_message, result, correct);
+            return -1;
+        }
+    }
+
+    // Check that storing and loading handles acts like uint64_t
+    {
+        std::string msg = "hello!\n";
+        Func f, g, h;
+        Var x;
+        f(x) = msg;
+        f.compute_root().vectorize(x, 4);
+        g(x) = f(x);
+        g.compute_root();
+        h(x) = g(x);
+
+        Image<char *> im = h.realize(100);
+
+        uint64_t handle = (uint64_t)(im(0));
+        if (sizeof(handle) == 4) {
+            // On 32-bit systems, the upper four bytes should be zero
+            if (handle >> 32) {
+                printf("The upper four bytes of a handle should have been zero on a 32-bit system\n");
+            }
+        }
+        // As another sanity check, the internal pointer to the string constant should be aligned.
+        if (handle & 0x3) {
+            printf("Got handle: %llx. A handle should be aligned to at least four bytes\n", (long long)handle);
+            return -1;
+        }
+
+        for (int i = 0; i < im.width(); i++) {
+            if (im(i) != im(0)) {
+                printf("im(%d) = %p instead of %p\n",
+                       i, im(i), im(0));
+                return -1;
+            }
+            if (std::string(im(i)) != msg) {
+                printf("Handle was %s instead of %s\n", im(i), msg.c_str());
+                return -1;
+            }
+        }
     }
 
     printf("Success!\n");


### PR DESCRIPTION
On 32-bit systems this implies zero-padding on store and truncate on
load. I needed to update Image.h too to support Image<foo *> properly
with this change.

This PR fixes the 32-bit issues in #871 , which seem to be caused by undefined upper bytes in string immediate pointers.