### PR TITLE
Smaller html

### DIFF
--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -508,21 +508,18 @@ private:
     }
 
     // To avoid generating ridiculously deep DOMs, we flatten blocks here.
-    void visit_block(Stmt first, Stmt rest) {
-        if (const Block *b_first = first.as<Block>()) {
-            visit_block(b_first->first, b_first->rest);
-        } else {
-            print(first);
-        }
-        if (const Block *b_rest = rest.as<Block>()) {
-            visit_block(b_rest->first, b_rest->rest);
-        } else if (rest.defined()) {
-            print(rest);
+    void visit_block_stmt(Stmt stmt) {
+        if (const Block *b = stmt.as<Block>()) {
+            visit_block_stmt(b->first);
+            visit_block_stmt(b->rest);
+        } else if (stmt.defined()) {
+            print(stmt);
         }
     }
     void visit(const Block *op) {
         stream << open_div("Block");
-        visit_block(op->first, op->rest);
+        visit_block_stmt(op->first);
+        visit_block_stmt(op->rest);
         stream << close_div();
     }
     void visit(const IfThenElse *op) {

--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -489,10 +489,23 @@ private:
         stream << close_div();
         scope.pop(op->name);
     }
+
+    // To avoid generating ridiculously deep DOMs, we flatten blocks here.
+    void visit_block(Stmt first, Stmt rest) {
+        if (const Block *b_first = first.as<Block>()) {
+            visit_block(b_first->first, b_first->rest);
+        } else {
+            print(first);
+        }
+        if (const Block *b_rest = rest.as<Block>()) {
+            visit_block(b_rest->first, b_rest->rest);
+        } else if (rest.defined()) {
+            print(rest);
+        }
+    }
     void visit(const Block *op) {
         stream << open_div("Block");
-        print(op->first);
-        if (op->rest.defined()) print(op->rest);
+        visit_block(op->first, op->rest);
         stream << close_div();
     }
     void visit(const IfThenElse *op) {


### PR DESCRIPTION
This PR flattens blocks in the HTML output, to avoid generating huge div trees. This does change the "meaning" of the IR very slightly, but it is only changed in a way that is hard to observe in a browser.

This change makes it much easier to use the browser dev tools to inspect the HTML for issues.