### PR TITLE
CMake linking clean ups

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -525,7 +525,12 @@ else()
   string(REPLACE " " ";" LIBS "${LIBS_SPACES}")
 endif()
 
-target_link_libraries(Halide PUBLIC InitialModules ${LIBS})
+# When building a shared library the LLVM libraries will be
+# embedded in the Halide library. When building a static library
+# LLVM is not embedded but CMake knows that when building an executable
+# against the Halide static library that it needs to link LLVM too so
+# PRIVATE scope is the correct choice here.
+target_link_libraries(Halide PRIVATE InitialModules ${LIBS})
 
 if (NOT WIN32)
   if (${LLVM_VERSION} GREATER 34)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -186,11 +186,6 @@ foreach (i ${RUNTIME_BC} )
   list(APPEND INITIAL_MODULES "${INITMOD}")
 endforeach()
 
-add_library(InitialModules STATIC
-  ${INITIAL_MODULES})
-
-add_dependencies(InitialModules
-  bitcode2cpp)
 
 set(HEADER_FILES
   AddImageChecks.h
@@ -433,6 +428,7 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   ${BITWRITER_FILES}
   "${CMAKE_BINARY_DIR}/include/Halide.h"
   ${HEADER_FILES}
+  ${INITIAL_MODULES}
 )
 
 # List of LLVM Components required
@@ -530,7 +526,7 @@ endif()
 # LLVM is not embedded but CMake knows that when building an executable
 # against the Halide static library that it needs to link LLVM too so
 # PRIVATE scope is the correct choice here.
-target_link_libraries(Halide PRIVATE InitialModules ${LIBS})
+target_link_libraries(Halide PRIVATE ${LIBS})
 
 if (NOT WIN32)
   if (${LLVM_VERSION} GREATER 34)
@@ -546,6 +542,6 @@ if (NOT WIN32)
 endif()
 
 add_dependencies(Halide
-  InitialModules
+  bitcode2cpp
   build_halide_h
 )


### PR DESCRIPTION
This should help #861 by reducing the linker memory footprint which should make it possible to build the tests under CMake in the memory constrained TravisCI environment.