### PR TITLE
Fix compilation against LLVM 3.7 branch due to r243114. There was an API

### DIFF
--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -258,7 +258,11 @@ void JITModule::compile_module(llvm::Module *m, const string &function_name, con
 
     #if LLVM_VERSION >= 37
         TargetMachine *tm = engine_builder.selectTarget();
-        DataLayout target_data_layout(tm->createDataLayout());
+        #if LLVM_VERSION == 37
+            DataLayout target_data_layout(*(tm->getDataLayout()));
+        #else
+            DataLayout target_data_layout(tm->createDataLayout());
+        #endif
         if (m->getDataLayout() != target_data_layout) {
                 debug(0) << "Warning: data layout mismatch between module ("
                              << m->getDataLayout().getStringRepresentation()

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -214,7 +214,11 @@ void emit_file(llvm::Module *module, const std::string &filename, llvm::TargetMa
     llvm::TargetMachine *target_machine = get_target_machine(module);
     internal_assert(target_machine) << "Could not allocate target machine!\n";
 
-    llvm::DataLayout target_data_layout(target_machine->createDataLayout());
+    #if LLVM_VERSION == 37
+        llvm::DataLayout target_data_layout(*(target_machine->getDataLayout()));
+    #else
+        llvm::DataLayout target_data_layout(target_machine->createDataLayout());
+    #endif
     if (!(target_data_layout == module->getDataLayout())) {
         // This *might* be indicative on a bug elsewhere, but might
         // also be fine. It depends on what the differences are


### PR DESCRIPTION
change that happened after LLVM branched for 3.7

I'm not entirely sure if this is the best fix but it fixes compilation at least. An alternative would be to introduce a helper function that wraps getting a ``DataLayout`` from a ``TargetMachine``.