### PR TITLE
Fix Renderscript test. Add test_renderscript to ALL_TESTS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -669,7 +669,7 @@ test_generators:  \
   $(GENERATOR_EXTERNAL_TESTS:$(ROOT_DIR)/test/generator/%_aottest.cpp=generator_aot_%)  \
   $(GENERATOR_EXTERNAL_TESTS:$(ROOT_DIR)/test/generator/%_jittest.cpp=generator_jit_%)
 
-ALL_TESTS = test_internal test_correctness test_errors test_tutorials test_warnings test_generators
+ALL_TESTS = test_internal test_correctness test_errors test_tutorials test_warnings test_generators test_renderscript
 
 # These targets perform timings of each test. For most tests this includes Halide JIT compile times, and run times.
 # For static and generator tests they time the compile time only. The times are recorded in CSV files.

--- a/test/renderscript/jit_copy.cpp
+++ b/test/renderscript/jit_copy.cpp
@@ -31,6 +31,8 @@ class ValidateInterleavedPipeline: public IRMutator {
 //   }
 // }
 //
+    using IRMutator::visit;
+
     virtual void visit(const Call *call) {
         if (in_pipeline && call->call_type == Call::CallType::Intrinsic && call->name == Call::image_store) {
             assert(for_nest_level == 4);
@@ -94,7 +96,7 @@ class ValidateInterleavedPipeline: public IRMutator {
         IRMutator::visit(op);
     }
 
-    void visit(const Pipeline* op) {
+    void visit(const ProducerConsumer *op) {
         assert(!in_pipeline); // There should be only one pipeline in the test.
         for_nest_level = 0;
         in_pipeline = true;

--- a/test/renderscript/jit_copy.cpp
+++ b/test/renderscript/jit_copy.cpp
@@ -4,6 +4,7 @@ using namespace Halide;
 using namespace Halide::Internal;
 
 class ValidateInterleavedPipeline: public IRMutator {
+protected:
 //
 // This is roughly the structure that we are trying to validate in this custom pass:
 //
@@ -108,7 +109,7 @@ class ValidateInterleavedPipeline: public IRMutator {
         IRMutator::visit(op);
         stmt = Stmt();
     }
-protected:
+
     int for_nest_level = -1;
     bool in_pipeline = false;
     int channels;


### PR DESCRIPTION
This PR fixes broken renderscript test and adds test_renderscript to run_tests target to make sure that those tests always run.

Thanks to @delcypher for pointing out broken renderscript test.