### PR TITLE
Synchronize write calls to ensure atomicity.

### DIFF
--- a/src/runtime/tracing.cpp
+++ b/src/runtime/tracing.cpp
@@ -71,8 +71,11 @@ WEAK int32_t default_trace(void *user_context, const halide_trace_event *e) {
         }
 
 
-        size_t written = write(fd, &buffer[0], total_bytes);
-        halide_assert(user_context, written == total_bytes && "Can't write to trace file");
+        {
+            ScopedSpinLock lock(&halide_trace_file_lock);
+            size_t written = write(fd, &buffer[0], total_bytes);
+            halide_assert(user_context, written == total_bytes && "Can't write to trace file");
+        }
 
     } else {
         stringstream ss(user_context);


### PR DESCRIPTION
While writes to a file descriptor opened with O_APPEND are atomic, those opened for write do not appear to share that behavior.

This can result in a malformed event stream that cannot be reliably parsed. Wrapping this call in a lock removes this subtle requirement on the fd provided to the halide_set_trace_file API.