### PR TITLE
Make compile time assert failures into warnings

### DIFF
--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -2460,8 +2460,8 @@ private:
 
         const AssertStmt *a = stmt.as<AssertStmt>();
         if (a && is_zero(a->condition)) {
-            user_error << "This pipeline is guaranteed to fail an assertion at runtime: \n"
-                       << stmt << "\n";
+            user_warning << "This pipeline is guaranteed to fail an assertion at runtime: \n"
+                         << stmt << "\n";
         } else if (a && is_one(a->condition)) {
             stmt = Evaluate::make(0);
         }


### PR DESCRIPTION
This PR makes compile time assertion failures into warnings instead of errors. This enables one to inspect the IR, which is often by far the most useful way to diagnose and fix these kinds of assertion failures.