### PR TITLE
RFC: DO NOT COMMIT: Supporting half literals in Halide's Expression language

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,7 @@ SOURCE_FILES = \
   DeviceInterface.cpp \
   EarlyFree.cpp \
   Error.cpp \
+  Expr.cpp \
   ExprUsesVar.cpp \
   FastIntegerDivide.cpp \
   FindCalls.cpp \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -361,6 +361,7 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   DeviceInterface.cpp
   EarlyFree.cpp
   Error.cpp
+  Expr.cpp
   ExprUsesVar.cpp
   FastIntegerDivide.cpp
   FindCalls.cpp

--- a/src/Expr.cpp
+++ b/src/Expr.cpp
@@ -1,0 +1,12 @@
+#include "Expr.h"
+#include "IR.h"
+
+namespace Halide {
+// FIXME: This feels like a horrible hack. FloatImm should be able
+// to support float16_t directly rather than relying on a cast.
+//
+// Note cast is going to higher precision so this does not lose any information
+EXPORT Expr::Expr(float16_t x) : IRHandle(Internal::Cast::make(Float(16), Expr((float) x))) {
+}
+
+}

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -184,6 +184,10 @@ struct Expr : public Internal::IRHandle {
     EXPORT Expr(int x) : IRHandle(Internal::IntImm::make(x)) {
     }
 
+    /** Make an expression representing a const 16-bit float as a
+     * cast of a (i.e. a FloatImm).*/
+    EXPORT Expr(float16_t x);
+
     /** Make an expression representing a const 32-bit float (i.e. a FloatImm) */
     EXPORT Expr(float x) : IRHandle(Internal::FloatImm::make(x)) {
     }

--- a/test/correctness/float16_t_realize_constant.cpp
+++ b/test/correctness/float16_t_realize_constant.cpp
@@ -1,0 +1,57 @@
+#include "Halide.h"
+#include <stdio.h>
+#include <cmath>
+
+using namespace Halide;
+
+// EURGH: Why aren't we using a unit test framework for this?
+void h_assert(bool condition, const char* msg) {
+  if (!condition) {
+    printf("FAIL: %s\n", msg);
+    abort();
+  }
+}
+
+int main() {
+  Halide::Func f;
+  Halide::Var x,y;
+
+  // Function simply writes a constant
+  f(x, y) = float16_t(0.25);
+
+  // Use JIT for computation
+  h_assert(sizeof(float16_t) == 2, "float16_t has invalid size");
+  Image<float16_t>  simple = f.realize(/*x=*/10, /*y=*/3);
+
+  // Assert some basic properties of the image
+  h_assert(simple.extent(0) == 10, "invalid width");
+  h_assert(simple.extent(1) == 3, "invalid height");
+  h_assert(simple.min(0) == 0, "unexpected non zero min in x");
+  h_assert(simple.min(1) == 0, "unexpected non zero min in y");
+  h_assert(simple.channels() == 1, "invalid channels");
+  h_assert(simple.dimensions() == 2, "invalid number of dimensions");
+
+  // Read result back
+  for (int x=simple.min(0); x < simple.extent(0); ++x) {
+    for (int y = simple.min(1); y < simple.extent(1); ++y) {
+      h_assert(simple(x, y) == float16_t(0.25), "Invalid value read back");
+      h_assert(simple(x, y).to_bits() == 0x3400, "Bit pattern incorrect");
+    }
+  }
+
+  // Check we can also access via the raw buffer
+  buffer_t* rawImage = simple.raw_buffer();
+  for (int x=simple.min(0); x < simple.extent(0); ++x) {
+    for (int y = simple.min(1); y < simple.extent(1); ++y) {
+      uint8_t* loc = rawImage->host +
+                     sizeof(float16_t)*((x - rawImage->min[0])*rawImage->stride[0] +
+                                     (y - rawImage->min[1])*rawImage->stride[1]);
+      float16_t* pixel = (float16_t*) loc;
+      h_assert(*pixel == float16_t(0.25), "Failed to read value back via buffer_t");
+      h_assert(pixel->to_bits() == 0x3400, "Bit pattern incorrect via buffer_t");
+    }
+  }
+
+  printf("Success!\n");
+  return 0;
+}


### PR DESCRIPTION
Do not commit this PR. I'm simply making it to gather comments.

Note this PR includes commits from other ongoing PRs that have not yet been merged into master (#903 #897).

This is an attempt to add support for half precision floating point literals to the halide expression. **The commit of interest is 5fc7cf3b13a2bf26869bbecfc14f21f0e713311d, the other commits belong to other PRs**

This approach works by adding a constructor ``Expr::Expr(fp16_t)``. This implementation stores the literal  in the higher precision ``FloatImm`` and wraps that in a cast expression. Note that ``fp16_t`` is the software implementation of half precision floating point introduced by #903 .

This approach is very simple but I think it's going to make implementing constant folding (and other transforms) harder.

I considered other approaches but they seem to have problems

* Introduce a new IR node type ``HalfImm`` to represent half literals. The problem I found with this approach is that it would require changes to **all** the IRVisitors. @zvookin warned me against this approach and having looked at more of the code today I don't think it's a good approach.

* Teach ``FloatImm`` to also represent half precision floating point numbers. Add a ``FloatImm::make(fp16_t)`` interface, remove the ``Expr value`` field (possibly replace with a private union of ``float`` and ``fp16_t``) and add an interface for retrieving the right literal, e.g.

```
const float* tryGetFloat() // Returns nullptr is wrong type is requested
const fp16_t* tryGetHalf(); // Returns nullptr is wrong type is requested
```

The disadvantage of this approach is that it breaks the ``FloatImm`` interface, I can fix uses in tree but I'm not sure if this will effect out of tree users of Halide. Another problem might be implicit assumptions in the code that a ``FloatImm`` is always 32-bits wide, although I've not seen any examples of this in the code.

The advantage though is that we don't have the extra cast expression making code that works on the IR tree simpler. This would also pave the way for ``double`` floating point literals as well. I think it's a bit a strange limitation to not allow literals of that precision (the same goes for ``IntImm`` only being 32-bit and not supporting 64-bit constants).

Please let me know what you think
@abestephensg @zvookin @abadams @steven-johnson  @aam and others...