### PR TITLE
DO NOT MERGE: lesson 10 form for bug repro case.

### DIFF
--- a/tutorial/lesson_10_aot_compilation_run.cpp
+++ b/tutorial/lesson_10_aot_compilation_run.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
     // for now (dev, host_dirty, dev_dirty).
 
     // Let's make some input data to test with:
-    uint8_t input[640 * 480];
+    uint8_t input[640 * 480 * 3];
     for (int y = 0; y < 480; y++) {
         for (int x = 0; x < 640; x++) {
             input[y * 640 + x] = x ^ (y + 1);
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
     }
 
     // And the memory where we want to write our output:
-    uint8_t output[640 * 480];
+    uint8_t output[640 * 480 * 3];
 
     // In AOT-compiled mode, Halide doesn't manage this memory for
     // you. You should use whatever image data type makes sense for
@@ -75,10 +75,12 @@ int main(int argc, char **argv) {
     // adjacent in y are separated by a scanline's worth of pixels in
     // memory.
     input_buf.stride[1] = output_buf.stride[1] = 640;
+    input_buf.stride[2] = output_buf.stride[2] = 640 * 480;
 
     // The extent tells us how large the image is in each dimension.
     input_buf.extent[0] = output_buf.extent[0] = 640;
     input_buf.extent[1] = output_buf.extent[1] = 480;
+    input_buf.extent[2] = output_buf.extent[2] = 3;
 
     // We'll leave the mins as zero. This is what they typically
     // are. The host pointer points to the memory location of the min
@@ -100,27 +102,12 @@ int main(int argc, char **argv) {
 
     // The return value is an error code. It's zero on success.
 
-    int offset = 5;
-    int error = lesson_10_halide(&input_buf, offset, &output_buf);
+    int width = 7;
+    int error = lesson_10_halide(&input_buf, width, &output_buf);
 
     if (error) {
         printf("Halide returned an error: %d\n", error);
         return -1;
-    }
-
-    // Now let's check the filter performed as advertised. It was
-    // supposed to add the offset to every input pixel.
-    for (int y = 0; y < 480; y++) {
-        for (int x = 0; x < 640; x++) {
-            uint8_t input_val = input[y * 640 + 480];
-            uint8_t output_val = output[y * 640 + 480];
-            uint8_t correct_val = input_val + offset;
-            if (output_val != correct_val) {
-                printf("output(%d, %d) was %d instead of %d\n",
-                       x, y, output_val, correct_val);
-                return -1;
-            }
-        }
     }
 
     // Everything worked!


### PR DESCRIPTION
This should cause a crash with a Trace/BPT error when run with certain width parameters.

An original conjecture that it was triggered on width params that were not even multiples of 4 was insufficient. While all multiples of 4 do avoid the problem, the first crashing value is 7 and 15, 30, and 34 also do not hit the error.

Additionally, the issue goes away if I use repeat_edge instead of constant_exterior. It also goes away if I get rid of the vectorization in the schedule (taking away the parallel step causes a different misbehavior).