### PR TITLE
Fix buggy gpu schedule in bilateral grid

### DIFF
--- a/apps/bilateral_grid/bilateral_grid.cpp
+++ b/apps/bilateral_grid/bilateral_grid.cpp
@@ -68,9 +68,10 @@ int main(int argc, char **argv) {
 
     Target target = get_target_from_environment();
     if (target.has_gpu_feature()) {
-        // histogram.compute_root().reorder(c, z, x, y).gpu_tile(x, y, 8, 8);
+        //histogram.compute_root().reorder(c, z, x, y).gpu_tile(x, y, 8, 8);
+        //histogram.update().reorder(c, r.x, r.y, x, y).gpu_tile(x, y, 8, 8).unroll(c);
         histogram.reorder(c, z, x, y).compute_at(blurz, Var::gpu_blocks()).gpu_threads(x, y);
-        histogram.update().reorder(c, r.x, r.y, x, y).gpu_tile(x, y, 8, 8).unroll(c);
+        histogram.update().reorder(c, r.x, r.y, x, y).gpu_threads(x, y).unroll(c);
         blurz.compute_root().reorder(c,z,x,y).gpu_tile(x, y, 16, 16);
         blurx.compute_root().gpu_tile(x, y, z, 16, 16, 1);
         blury.compute_root().gpu_tile(x, y, z, 16, 16, 1);

--- a/test/generator/gpu_only_aottest.cpp
+++ b/test/generator/gpu_only_aottest.cpp
@@ -10,6 +10,7 @@
 
 #include "gpu_only.h"
 #include "halide_image.h"
+using namespace Halide::Tools;
 
 int main(int argc, char **argv) {
 #if defined(TEST_OPENCL) || defined(TEST_CUDA)


### PR DESCRIPTION
... and add a validation pass to prevent it from happening again

Nested copies of gpu_block for loops were causing one kernel to only run
over a few blocks, and silently produce junk output!