### PR TITLE
Better error message for bad compute_at

### DIFF
--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -818,25 +818,25 @@ string schedule_to_source(Function f,
     if (compute_at.is_inline()) {
         ss << ".compute_inline()";
     } else {
-        string store_var = store_at.var;
-        string compute_var = compute_at.var;
-        if (store_var == Var::outermost().name()) {
-            store_var = "Var::outermost()";
+        string store_var_name = store_at.var;
+        string compute_var_name = compute_at.var;
+        if (store_var_name == Var::outermost().name()) {
+            store_var_name = "Var::outermost()";
         }
-        if (compute_var == Var::outermost().name()) {
-            compute_var = "Var::outermost()";
+        if (compute_var_name == Var::outermost().name()) {
+            compute_var_name = "Var::outermost()";
         }
         if (!store_at.match(compute_at)) {
             if (store_at.is_root()) {
                 ss << ".store_root()";
             } else {
-                ss << ".store_at(" << store_at.func << ", " << store_var << ")";
+                ss << ".store_at(" << store_at.func << ", " << store_var_name << ")";
             }
         }
         if (compute_at.is_root()) {
             ss << ".compute_root()";
         } else {
-            ss << ".compute_at(" << compute_at.func << ", " << compute_var << ")";
+            ss << ".compute_at(" << compute_at.func << ", " << compute_var_name << ")";
         }
     }
     ss << ";";

--- a/test/error/bad_compute_at.cpp
+++ b/test/error/bad_compute_at.cpp
@@ -4,16 +4,24 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    Func f("f"), g("g"), h("h");
+    Func f("f"), g("g"), h("h"), junk1, junk2, junk3;
     Var x("x"), y("y");
 
     f(x) = x;
     g(x) = f(x);
-    h(x, y) = g(x);
+    junk1(x) = 3;
+    junk2(x) = 3;
+    junk3(x, y) = 3;
+    h(x, y) = g(x) + f(x) + junk1(x) + junk2(x) + junk3(x, y);
 
     g.compute_at(h, y);
 
-    // This makes no sense, because f is only used by g, which is computed at (h, y), which is outside of (h, x).
+    // Add some other junk functions to complicate the error message
+    junk1.compute_at(h, y);
+    junk2.compute_at(h, x);
+    junk3.compute_root();
+
+    // This makes no sense, because f is also used by g, which is computed at (h, y), which is outside of (h, x).
     f.compute_at(h, x);
 
     h.realize(10);


### PR DESCRIPTION
Alternative to #902

1) Don't print the distinct compute_at/store_at options - it squares the
number of things printed
2) Print the uses of the function by walking the IR

Sample error message (from bad_compute_at test):
```
Func "f" is computed at the following invalid location:
  f.compute_at(h, x);
Legal locations for this function are:
  f.compute_root();
  f.compute_at(h, Var::outermost());
  f.compute_at(h, y);
"f" is used in the following places:
  ...
  for h.s0.y:
      for g.s0.x:
        g uses f
      ...
      for h.s0.x:
        ...
        h uses f
```