### PR TITLE
RFC: DO NOT COMMIT: Half expression support, work in progress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,7 @@ SOURCE_FILES = \
   DeviceInterface.cpp \
   EarlyFree.cpp \
   Error.cpp \
+  Expr.cpp \
   ExprUsesVar.cpp \
   FastIntegerDivide.cpp \
   FindCalls.cpp \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -367,6 +367,7 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   DeviceInterface.cpp
   EarlyFree.cpp
   Error.cpp
+  Expr.cpp
   ExprUsesVar.cpp
   FastIntegerDivide.cpp
   FindCalls.cpp

--- a/src/Expr.cpp
+++ b/src/Expr.cpp
@@ -1,0 +1,24 @@
+#include "Expr.h"
+#include "llvm/Support/ErrorHandling.h"
+
+namespace Halide {
+namespace Internal {
+
+FloatImm::HighestPrecisionTy FloatImm::as_highest_precision_float() const {
+      if (const float16_t* asHalf = as<float16_t>()) {
+          return (HighestPrecisionTy) *asHalf;
+      }
+      else if (const float* asFloat = as<float>()) {
+          return (HighestPrecisionTy) *asFloat;
+      }
+      else if (const double* asDouble = as<double>()) {
+          return *asDouble;
+      }
+      else {
+          internal_error << "Float type not supported\n";
+      }
+      llvm_unreachable("float type not handled");
+}
+
+}
+}

--- a/src/IREquality.cpp
+++ b/src/IREquality.cpp
@@ -234,7 +234,12 @@ void IRComparer::visit(const IntImm *op) {
 
 void IRComparer::visit(const FloatImm *op) {
     const FloatImm *e = expr.as<FloatImm>();
-    compare_scalar(e->value, op->value);
+    // FIXME: Should we check that the types match?
+
+    // FIXME: Why are there no ( e== nullptr) checks?
+
+    // Upcasting to more precise type always preserves ordering
+    compare_scalar(e->as_highest_precision_float(), op->as_highest_precision_float());
 }
 
 void IRComparer::visit(const StringImm *op) {

--- a/src/IRMatch.cpp
+++ b/src/IRMatch.cpp
@@ -78,7 +78,8 @@ public:
 
     void visit(const FloatImm *op) {
         const FloatImm *e = expr.as<FloatImm>();
-        if (!e || e->value != op->value) {
+        // FIXME: Should we return false if types don't match but value is the same?
+        if (!e || e->as_highest_precision_float() != op->as_highest_precision_float()) {
             result = false;
         }
     }

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -600,7 +600,11 @@ inline Expr sin(Expr x) {
     user_assert(x.defined()) << "sin of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "sin_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "sin_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         return Internal::Call::make(Float(32), "sin_f32", {cast<float>(x)}, Internal::Call::Extern);
     }
 }
@@ -612,7 +616,11 @@ inline Expr asin(Expr x) {
     user_assert(x.defined()) << "asin of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "asin_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "asin_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         return Internal::Call::make(Float(32), "asin_f32", {cast<float>(x)}, Internal::Call::Extern);
     }
 }
@@ -624,7 +632,11 @@ inline Expr cos(Expr x) {
     user_assert(x.defined()) << "cos of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "cos_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "cos_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         return Internal::Call::make(Float(32), "cos_f32", {cast<float>(x)}, Internal::Call::Extern);
     }
 }
@@ -636,7 +648,11 @@ inline Expr acos(Expr x) {
     user_assert(x.defined()) << "acos of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "acos_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "acos_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         return Internal::Call::make(Float(32), "acos_f32", {cast<float>(x)}, Internal::Call::Extern);
     }
 }
@@ -648,7 +664,11 @@ inline Expr tan(Expr x) {
     user_assert(x.defined()) << "tan of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "tan_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "tan_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         return Internal::Call::make(Float(32), "tan_f32", {cast<float>(x)}, Internal::Call::Extern);
     }
 }
@@ -660,7 +680,11 @@ inline Expr atan(Expr x) {
     user_assert(x.defined()) << "atan of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "atan_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "atan_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         return Internal::Call::make(Float(32), "atan_f32", {cast<float>(x)}, Internal::Call::Extern);
     }
 }
@@ -674,7 +698,12 @@ inline Expr atan2(Expr y, Expr x) {
     if (y.type() == Float(64)) {
         x = cast<double>(x);
         return Internal::Call::make(Float(64), "atan2_f64", {y, x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (y.type() == Float(16)) {
+        x = cast<float16_t>(x);
+        return Internal::Call::make(Float(16), "atan2_f16", {y, x}, Internal::Call::Extern);
+    }
+    else {
         y = cast<float>(y);
         x = cast<float>(x);
         return Internal::Call::make(Float(32), "atan2_f32", {y, x}, Internal::Call::Extern);
@@ -688,7 +717,11 @@ inline Expr sinh(Expr x) {
     user_assert(x.defined()) << "sinh of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "sinh_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "sinh_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         return Internal::Call::make(Float(32), "sinh_f32", {cast<float>(x)}, Internal::Call::Extern);
     }
 }
@@ -700,7 +733,11 @@ inline Expr asinh(Expr x) {
     user_assert(x.defined()) << "asinh of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "asinh_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if(x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "asinh_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         return Internal::Call::make(Float(32), "asinh_f32", {cast<float>(x)}, Internal::Call::Extern);
     }
 }
@@ -712,7 +749,11 @@ inline Expr cosh(Expr x) {
     user_assert(x.defined()) << "cosh of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "cosh_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "cosh_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         return Internal::Call::make(Float(32), "cosh_f32", {cast<float>(x)}, Internal::Call::Extern);
     }
 }
@@ -724,7 +765,11 @@ inline Expr acosh(Expr x) {
     user_assert(x.defined()) << "acosh of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "acosh_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "acosh_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         return Internal::Call::make(Float(32), "acosh_f32", {cast<float>(x)}, Internal::Call::Extern);
     }
 }
@@ -736,7 +781,11 @@ inline Expr tanh(Expr x) {
     user_assert(x.defined()) << "tanh of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "tanh_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "tanh_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         return Internal::Call::make(Float(32), "tanh_f32", {cast<float>(x)}, Internal::Call::Extern);
     }
 }
@@ -748,7 +797,11 @@ inline Expr atanh(Expr x) {
     user_assert(x.defined()) << "atanh of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "atanh_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "atanh_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         return Internal::Call::make(Float(32), "atanh_f32", {cast<float>(x)}, Internal::Call::Extern);
     }
 }
@@ -760,7 +813,11 @@ inline Expr sqrt(Expr x) {
     user_assert(x.defined()) << "sqrt of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "sqrt_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "sqrt_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         return Internal::Call::make(Float(32), "sqrt_f32", {cast<float>(x)}, Internal::Call::Extern);
     }
 }
@@ -783,7 +840,11 @@ inline Expr exp(Expr x) {
     user_assert(x.defined()) << "exp of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "exp_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "exp_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         return Internal::Call::make(Float(32), "exp_f32", {cast<float>(x)}, Internal::Call::Extern);
     }
 }
@@ -799,7 +860,11 @@ inline Expr log(Expr x) {
     user_assert(x.defined()) << "log of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "log_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "log_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         return Internal::Call::make(Float(32), "log_f32", {cast<float>(x)}, Internal::Call::Extern);
     }
 }
@@ -820,7 +885,12 @@ inline Expr pow(Expr x, Expr y) {
     if (x.type() == Float(64)) {
         y = cast<double>(y);
         return Internal::Call::make(Float(64), "pow_f64", {x, y}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type() == Float(16)) {
+         y = cast<float16_t>(y);
+        return Internal::Call::make(Float(16), "pow_f16", {x, y}, Internal::Call::Extern);
+    }
+    else {
         x = cast<float>(x);
         y = cast<float>(y);
         return Internal::Call::make(Float(32), "pow_f32", {x, y}, Internal::Call::Extern);
@@ -885,7 +955,11 @@ inline Expr floor(Expr x) {
     user_assert(x.defined()) << "floor of undefined Expr\n";
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(x.type(), "floor_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type().element_of() == Float(16)) {
+        return Internal::Call::make(Float(16), "floor_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         Type t = Float(32, x.type().width);
         return Internal::Call::make(t, "floor_f32", {cast(t, x)}, Internal::Call::Extern);
     }
@@ -899,7 +973,11 @@ inline Expr ceil(Expr x) {
     user_assert(x.defined()) << "ceil of undefined Expr\n";
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(x.type(), "ceil_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type().element_of() == Float(16)) {
+        return Internal::Call::make(Float(16), "ceil_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         Type t = Float(32, x.type().width);
         return Internal::Call::make(t, "ceil_f32", {cast(t, x)}, Internal::Call::Extern);
     }
@@ -914,7 +992,11 @@ inline Expr round(Expr x) {
     user_assert(x.defined()) << "round of undefined Expr\n";
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(Float(64), "round_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type().element_of() == Float(16)) {
+        return Internal::Call::make(Float(16), "round_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         Type t = Float(32, x.type().width);
         return Internal::Call::make(t, "round_f32", {cast(t, x)}, Internal::Call::Extern);
     }
@@ -927,7 +1009,11 @@ inline Expr trunc(Expr x) {
     user_assert(x.defined()) << "trunc of undefined Expr\n";
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(Float(64), "trunc_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type().element_of() == Float(16)) {
+        return Internal::Call::make(Float(16), "trunc_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         Type t = Float(32, x.type().width);
         return Internal::Call::make(t, "trunc_f32", {cast(t, x)}, Internal::Call::Extern);
     }
@@ -941,7 +1027,11 @@ inline Expr is_nan(Expr x) {
     Type t = Bool(x.type().width);
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(t, "is_nan_f64", {x}, Internal::Call::Extern);
-    } else {
+    }
+    else if (x.type().element_of() == Float(64)) {
+        return Internal::Call::make(t, "is_nan_f16", {x}, Internal::Call::Extern);
+    }
+    else {
         Type ft = Float(32, x.type().width);
         return Internal::Call::make(t, "is_nan_f32", {cast(ft, x)}, Internal::Call::Extern);
     }

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1539,8 +1539,13 @@ inline bool extract_immediate(Expr e, T *value) {
 template<>
 inline bool extract_immediate(Expr e, float *value) {
     if (const FloatImm* f = e.as<FloatImm>()) {
-        *value = static_cast<float>(f->value);
-        return true;
+        if (const float* asFloat = f->as<float>()) {
+          *value = *asFloat;
+          return true;
+        }
+        else {
+            internal_error << "Unsupported float width\n";
+        }
     }
     if (const IntImm *i = e.as<IntImm>()) {
         *value = static_cast<float>(i->value);

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -214,7 +214,18 @@ void IRPrinter::visit(const IntImm *op) {
 }
 
 void IRPrinter::visit(const FloatImm *op) {
-    stream << op->value << 'f';
+    // FIXME: Not sure if this is the syntax we want
+    if (const float16_t* asHalf = op->as<float16_t>()) {
+      stream << asHalf->to_decimal_string() << 'h';
+    } else if (const float* asFloat = op->as<float>()) {
+        stream << *asFloat << 'f';
+    }
+    else if (const double* asDouble = op->as<double>()) {
+        stream << *asDouble << 'd';
+    }
+    else {
+        internal_error << "Unsupported float type\n";
+    }
 }
 
 void IRPrinter::visit(const StringImm *op) {

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -99,17 +99,20 @@ private:
 
     using IRMutator::visit;
 
+    // FIXME: What semantics should this have now that we
+    // can have half and double floating point constants too???
     bool const_float(Expr e, float *f) {
         if (!e.defined()) {
             return false;
         }
         const FloatImm *c = e.as<FloatImm>();
         if (c) {
-            *f = c->value;
-            return true;
-        } else {
-            return false;
+            if (const float* asFloat = c->as<float>()) {
+                *f = *asFloat;
+                return true;
+            }
         }
+        return false;
     }
 
     bool const_int(Expr e, int *i) {
@@ -2223,7 +2226,7 @@ private:
                     }
                     changed = true;
                 } else if (last && float_imm) {
-                    snprintf(buf, sizeof(buf), "%f", float_imm->value);
+                    snprintf(buf, sizeof(buf), "%f", float_imm->as_highest_precision_float());
                     if (last) {
                         new_args.back() = last->value + buf;
                     } else {

--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -144,7 +144,18 @@ private:
     }
     void visit(const FloatImm *op){
         stream << open_span("FloatImm Imm");
-        stream << op->value << 'f';
+        // FIXME: Not sure if this is the syntax we want
+        if (const float16_t* asHalf = op->as<float16_t>()) {
+          stream << asHalf->to_decimal_string() << 'h';
+        } else if (const float* asFloat = op->as<float>()) {
+            stream << *asFloat << 'f';
+        }
+        else if (const double* asDouble = op->as<double>()) {
+            stream << *asDouble << 'd';
+        }
+        else {
+            internal_error << "Unsupported float type\n";
+        }
         stream << close_span();
     }
     void visit(const StringImm *op){

--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -144,8 +144,22 @@ protected:
     }
 
     virtual void visit(const IntImm *op)    { visit_imm(op); }
-    virtual void visit(const FloatImm *op)  { visit_imm(op); }
     virtual void visit(const StringImm *op) { visit_imm(op); }
+    virtual void visit(const FloatImm *op) {
+        order = 0;
+        if (const float16_t* asHalf = op->as<float16_t>()) {
+            expr = FloatImm::make(*asHalf);
+        }
+        else if (const float* asFloat = op->as<float>()) {
+            expr = FloatImm::make(*asFloat);
+        }
+        else if (const double* asDouble = op->as<double>()) {
+            expr = FloatImm::make(*asDouble);
+        }
+        else {
+            internal_error << "Unsupported float type\n";
+        }
+    }
 
     virtual void visit(const Cast *op) {
 

--- a/src/runtime/posix_math.cpp
+++ b/src/runtime/posix_math.cpp
@@ -59,6 +59,18 @@ INLINE double double_from_bits(uint64_t bits) {
     return u.as_double;
 }
 
+INLINE double nan_f64() {
+    return double_from_bits(UINT64_C(0x7ff8000000000000));
+}
+
+INLINE double neg_inf_f64() {
+    return double_from_bits(UINT64_C(0xfff0000000000000));
+}
+
+INLINE double inf_f64() {
+    return double_from_bits(UINT64_C(0x7ff0000000000000));
+}
+
 INLINE double maxval_f64() {
     return double_from_bits(UINT64_C(0x7fefffffffffffff));
 }

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -90,6 +90,7 @@ WEAK char *halide_double_to_string(char *dst, char *end, double arg, int scienti
 WEAK char *halide_int64_to_string(char *dst, char *end, int64_t arg, int digits);
 WEAK char *halide_uint64_to_string(char *dst, char *end, uint64_t arg, int digits);
 WEAK char *halide_pointer_to_string(char *dst, char *end, const void *arg);
+WEAK char *halide_half_bits_to_hex_float_string(char *dst, char *end, uint16_t bits);
 
 // Search the current process for a symbol with the given name.
 WEAK void *halide_get_symbol(const char *name);
@@ -197,6 +198,11 @@ public:
 
     Printer &operator<<(const void *arg) {
         dst = halide_pointer_to_string(dst, end, arg);
+        return *this;
+    }
+
+    Printer & write_float16_from_bits_as_hex_float(uint16_t bits) {
+        dst = halide_half_bits_to_hex_float_string(dst, end, bits);
         return *this;
     }
 

--- a/src/runtime/tracing.cpp
+++ b/src/runtime/tracing.cpp
@@ -149,9 +149,12 @@ WEAK int32_t default_trace(void *user_context, const halide_trace_event *e) {
                         ss << ((uint64_t *)(e->value))[i];
                     }
                 } else if (e->type_code == 2) {
-                    halide_assert(user_context, print_bits >= 32 && "Tracing a bad type");
+                    halide_assert(user_context, print_bits >= 16 && "Tracing a bad type");
                     if (print_bits == 32) {
                         ss << ((float *)(e->value))[i];
+                    } else if (print_bits == 16) {
+                        // TODO: We should also emit a decimal approximation
+                        ss.write_float16_from_bits_as_hex_float( ((uint16_t *)(e->value))[i] );
                     } else {
                         ss << ((double *)(e->value))[i];
                     }

--- a/test/correctness/float16_t_realize_constant.cpp
+++ b/test/correctness/float16_t_realize_constant.cpp
@@ -1,0 +1,60 @@
+#include "Halide.h"
+#include <stdio.h>
+#include <cmath>
+
+using namespace Halide;
+
+// FIXME: Why aren't we using a unit test framework for this?
+// see Issue #898
+void h_assert(bool condition, const char *msg) {
+    if (!condition) {
+        printf("FAIL: %s\n", msg);
+        abort();
+    }
+}
+
+int main() {
+    Halide::Func f;
+    Halide::Var x, y;
+
+    // Function simply writes a constant
+    f(x, y) = float16_t(0.25);
+    // Make sure tracing works. It should abort if something is wrong.
+    f.trace_stores();
+
+    // Use JIT for computation
+    h_assert(sizeof(float16_t) == 2, "float16_t has invalid size");
+    Image<float16_t> simple = f.realize(10, 3);
+
+    // Assert some basic properties of the image
+    h_assert(simple.extent(0) == 10, "invalid width");
+    h_assert(simple.extent(1) == 3, "invalid height");
+    h_assert(simple.min(0) == 0, "unexpected non zero min in x");
+    h_assert(simple.min(1) == 0, "unexpected non zero min in y");
+    h_assert(simple.channels() == 1, "invalid channels");
+    h_assert(simple.dimensions() == 2, "invalid number of dimensions");
+
+    // Read result back
+    for (int x = simple.min(0); x < simple.extent(0); ++x) {
+        for (int y = simple.min(1); y < simple.extent(1); ++y) {
+            h_assert(simple(x, y) == float16_t(0.25), "Invalid value read back");
+            h_assert(simple(x, y).to_bits() == 0x3400, "Bit pattern incorrect");
+        }
+    }
+
+    // Check we can also access via the raw buffer
+    buffer_t *rawImage = simple.raw_buffer();
+    for (int x = simple.min(0); x < simple.extent(0); ++x) {
+        for (int y = simple.min(1); y < simple.extent(1); ++y) {
+            uint8_t *loc = rawImage->host +
+                           sizeof(float16_t) * ((x - rawImage->min[0]) * rawImage->stride[0] +
+                                                (y - rawImage->min[1]) * rawImage->stride[1]);
+            float16_t *pixel = (float16_t *)loc;
+            h_assert(*pixel == float16_t(0.25), "Failed to read value back via buffer_t");
+            h_assert(pixel->to_bits() == 0x3400, "Bit pattern incorrect via buffer_t");
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/float16_t_realize_constant.cpp
+++ b/test/correctness/float16_t_realize_constant.cpp
@@ -18,7 +18,7 @@ int main() {
     Halide::Var x, y;
 
     // Function simply writes a constant
-    f(x, y) = float16_t(0.25);
+    f(x, y) = float16_t(0.75);
     // Make sure tracing works. It should abort if something is wrong.
     f.trace_stores();
 
@@ -37,8 +37,8 @@ int main() {
     // Read result back
     for (int x = simple.min(0); x < simple.extent(0); ++x) {
         for (int y = simple.min(1); y < simple.extent(1); ++y) {
-            h_assert(simple(x, y) == float16_t(0.25), "Invalid value read back");
-            h_assert(simple(x, y).to_bits() == 0x3400, "Bit pattern incorrect");
+            h_assert(simple(x, y) == float16_t(0.75), "Invalid value read back");
+            h_assert(simple(x, y).to_bits() == 0x3a00, "Bit pattern incorrect");
         }
     }
 
@@ -50,8 +50,8 @@ int main() {
                            sizeof(float16_t) * ((x - rawImage->min[0]) * rawImage->stride[0] +
                                                 (y - rawImage->min[1]) * rawImage->stride[1]);
             float16_t *pixel = (float16_t *)loc;
-            h_assert(*pixel == float16_t(0.25), "Failed to read value back via buffer_t");
-            h_assert(pixel->to_bits() == 0x3400, "Bit pattern incorrect via buffer_t");
+            h_assert(*pixel == float16_t(0.75), "Failed to read value back via buffer_t");
+            h_assert(pixel->to_bits() == 0x3a00, "Bit pattern incorrect via buffer_t");
         }
     }
 

--- a/test/generator/paramtest_jittest.cpp
+++ b/test/generator/paramtest_jittest.cpp
@@ -52,7 +52,12 @@ bool constant_expr_equals(Expr expr, T value) {
         return i->value == value;
     }
     if (const FloatImm* f = expr.as<FloatImm>()) {
-        return f->value == value;
+        if (const float* asFloat = f->as<float>()) {
+            return *asFloat == value;
+        } else {
+            // FIXME: Unsupported float type
+            abort();
+        }
     }
     if (const Cast* c = expr.as<Cast>()) {
         return constant_expr_equals(c->value, value);


### PR DESCRIPTION
This work in progress that I'd like to get early feedback from to check that I'm going in the right direction.

452df48 is an attempt to do #904 differently by not using a cast and natively storing the right floating point type inside ``FloatImm`` (@zvookin seemed to prefer this idea). The changes are a lot more invasive but on the plus side there is now support for  double immediates. My gut feeling is that 452df48 is the **right way** to do it.

There is still a huge amount to do (e.g. simplification of half and double types is missing and none of the backends really support half properly) but I'm hoping that @abestephensg and I will work out which backend to focus on (most likely GLSL)

Thoughts?
@abadams @abestephensg @zvookin 