### PR TITLE
Bounds of cast of clamp

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -155,7 +155,7 @@ private:
         // If overflow is impossible, cast the min and max. If it's
         // possible, use the bounds of the destination type.
         bool could_overflow = true;
-        if (to.can_represent(from)) {
+        if (to.can_represent(from) || to.is_float()) {
             could_overflow = false;
         } else if (to.is_int() && to.bits >= 32) {
             // If we cast to an int32 or greater, assume that it won't
@@ -1470,6 +1470,11 @@ void bounds_test() {
 
     check(scope, print(x, y), 0, 10);
     check(scope, print_when(x > y, x, y), 0, 10);
+
+    check(scope, cast<int32_t>(abs(cast<int16_t>(x/y))), 0, 32768);
+    check(scope, cast<float>(x), 0.0f, 10.0f);
+
+    check(scope, cast<int32_t>(abs(cast<float>(x))), 0, 10);
 
     // Check some operations that may overflow
     check(scope, (cast<uint8_t>(x)+250), cast<uint8_t>(0), cast<uint8_t>(255));

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -173,6 +173,9 @@ private:
             expr = value;
         } else if (op->type == Int(32) && const_float(value, &f)) {
             expr = IntImm::make((int)f);
+        } else if (Int(32).can_represent(op->type) && const_float(value, &f)) {
+            // u16(123.25f) -> u16(123)
+            expr = Cast::make(op->type, IntImm::make((int)f));
         } else if (op->type == Float(32) && const_int(value, &i)) {
             expr = FloatImm::make((float)i);
         } else if (cast && op->type.code == cast->type.code && op->type.bits < cast->type.bits) {
@@ -2744,6 +2747,8 @@ void simplify_test() {
     check(cast(UInt(16), 65) == cast(UInt(16), 66), const_false());
     check(cast(UInt(16), -1) < cast(UInt(16), 65535), const_false());
     check(cast(UInt(16), 65) < cast(UInt(16), 66), const_true());
+    check(cast(UInt(16), 123.4f), cast(UInt(16), 123));
+    check(cast(Float(32), cast(UInt(16), 123456.0f)), 57920.0f);
     // Specific checks for 32 bit unsigned expressions - ensure simplifications are actually unsigned.
     // 4000000000 (4 billion) is less than 2^32 but more than 2^31.  As an int, it is negative.
     check(cast(UInt(32), (int) 4000000000UL) + cast(UInt(32), 5), cast(UInt(32), (int) 4000000005UL));
@@ -2755,6 +2760,8 @@ void simplify_test() {
     check(max(cast(UInt(32), (int) 4000000023UL) , cast(UInt(32), 1000)), cast(UInt(32), (int) 4000000023UL));
     check(cast(UInt(32), (int) 4000000023UL) < cast(UInt(32), 1000), const_false());
     check(cast(UInt(32), (int) 4000000023UL) == cast(UInt(32), 1000), const_false());
+
+
 
     // Check some specific expressions involving div and mod
     check(Expr(23) / 4, Expr(5));

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -2093,14 +2093,20 @@ private:
             Expr a = mutate(op->args[0]);
             Type ta = a.type();
             int ia = 0;
-            if (ta.is_int() && const_castint(a, &ia) && ia != ta.imin()) {
-                if (ia < 0) {
+            float fa = 0;
+            if (ta.is_int() && const_castint(a, &ia)) {
+                if (ia < 0 && ia != Int(32).imin()) {
                     ia = -ia;
                 }
                 expr = Cast::make(op->type, ia);
             } else if (ta.is_uint()) {
                 // abs(uint) is a no-op.
                 expr = a;
+            } else if (const_float(a, &fa)) {
+                if (fa < 0) {
+                    fa = -fa;
+                }
+                expr = fa;
             } else if (a.same_as(op->args[0])) {
                 expr = op;
             } else {


### PR DESCRIPTION
The bounds of

cast<uint16_t>(clamp(some_float_expr, 0.0f, 4096.0f))

were [0, 65535]

which surprised and annoyed a user.

This happened because Halide saw the bounds of the innermost thing as
some complex thing involving both 0/4096 and also some_float_expr. I.e.
it hadn't conservatively backed off to the clamp args, and then the
narrowing logic bailed on the nasty expressions, because it was only
designed to deal with constants.

This PR explicitly attempts to simplify the bounds of the innards
towards constants in that case, and simplifies some of the surrounding
code at the same time (I think it was written before Type::can_represent
existed).