### PR TITLE
More warning fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,11 @@ else()
 endif()
 
 if (NOT MSVC)
-  add_compile_options(-Wall -Wno-unused-function -Wcast-qual -Woverloaded-virtual)
+    add_compile_options(-Wall
+                        -Wno-unused-function
+                        -Wcast-qual
+                        -Woverloaded-virtual
+                        -Wignored-qualifiers)
   if (WARNINGS_AS_ERRORS)
     add_compile_options(-Werror)
   endif()

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ LLVM_BINDIR = $(shell $(LLVM_CONFIG) --bindir)
 LLVM_LIBDIR = $(shell $(LLVM_CONFIG) --libdir)
 LLVM_AS = $(LLVM_BINDIR)/llvm-as
 LLVM_NM = $(LLVM_BINDIR)/llvm-nm
-LLVM_CXX_FLAGS = -std=c++11  $(filter-out -O% -g -fomit-frame-pointer -pedantic -Wcovered-switch-default, $(shell $(LLVM_CONFIG) --cxxflags))
+LLVM_CXX_FLAGS = -std=c++11  $(filter-out -O% -g -fomit-frame-pointer -pedantic -W% -W, $(shell $(LLVM_CONFIG) --cxxflags))
 OPTIMIZE ?= -O3
 # This can be set to -m32 to get a 32-bit build of Halide on a 64-bit system.
 # (Normally this can be done via pointing to a compiler that defaults to 32-bits,

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ AARCH64_LLVM_CONFIG_LIB=$(if $(WITH_AARCH64), aarch64, )
 INTROSPECTION_CXX_FLAGS=$(if $(WITH_INTROSPECTION), -DWITH_INTROSPECTION, )
 EXCEPTIONS_CXX_FLAGS=$(if $(WITH_EXCEPTIONS), -DWITH_EXCEPTIONS, )
 
-CXX_WARNING_FLAGS = -Wall -Werror -Wno-unused-function -Wcast-qual
+CXX_WARNING_FLAGS = -Wall -Werror -Wno-unused-function -Wcast-qual -Wignored-qualifiers
 CXX_FLAGS = $(CXX_WARNING_FLAGS) -fno-rtti -Woverloaded-virtual -fPIC $(OPTIMIZE) -fno-omit-frame-pointer -DCOMPILING_HALIDE $(BUILD_BIT_SIZE)
 CXX_FLAGS += $(LLVM_CXX_FLAGS)
 CXX_FLAGS += $(NATIVE_CLIENT_CXX_FLAGS)


### PR DESCRIPTION
This came about because my build of ``llvm-config`` also emits the undocumented (AFAICT) ``-W`` flag which caused more errors to be emitted by the Makefile build compared to the CMake build. This difference is quite annoying so I've taught the Makefile to filter out warning flags from ``llvm-config``.

Whilst I was here I added ``-Wignored-qualifiers`` which was the warning that was tripping me up.