### PR TITLE
Make halide_assert() used in runtime more verbose.

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -62,7 +62,9 @@ extern void halide_error(void *user_context, const char *);
 /** A macro that calls halide_print if the supplied condition is
  * false, then aborts. Used for unrecoverable errors, or
  * should-never-happen errors. */
-#define halide_assert(user_context, cond) if (!(cond)) {halide_print(user_context, #cond); abort();}
+#define _halide_stringify(x) #x
+#define _halide_expand_and_stringify(x) _halide_stringify(x)
+#define halide_assert(user_context, cond) if (!(cond)) {halide_print(user_context, __FILE__ ":" _halide_expand_and_stringify(__LINE__) " Assert failed: " #cond "\n"); abort();}
 
 /** These are allocated statically inside the runtime, hence the fixed
  * size. They must be initialized with zero. The first time


### PR DESCRIPTION
The message now includes the filename and line number that where the
assert was written and mentions that it is an assertion failure.

Not sure if this is the cleanest approach as two extra macros had to
be declared to handle __LINE__.