### PR TITLE
Remove an unnecessary cast after widening types in match_types()

### DIFF
--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -277,6 +277,9 @@ void match_types(Expr &a, Expr &b) {
 
     Type ta = a.type(), tb = b.type();
 
+    // If type widening has made the types match no additional casts are needed
+    if (ta == tb) return;
+
     if (!ta.is_float() && tb.is_float()) {
         // int(a) * float(b) -> float(b)
         // uint(a) * float(b) -> float(b)


### PR DESCRIPTION
An example is

a.type() == {code = Halide::Type::Float, bits = 32, width = 1}
b.type() == {code = Halide::Type::Float, bits = 32, width = 8}

After widening the types match so there is no need to add a cast
around either expression. An example application where this was observed
was when running the generator for the "bilateral_grid" app.