### PR TITLE
[RFC] DO NOT MERGE: Half expr upcast software implementation

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1261,4 +1261,13 @@ int CodeGen_ARM::native_vector_bits() const {
     return 128;
 }
 
+bool CodeGen_ARM::target_needs_software_float16_cast(Type t, bool isDestinationType) const {
+    // TODO: This needs testing!
+    if (target.bits == 64) {
+        // AArch64 has native support (FCVT)
+        return false;
+    }
+    return true;
+}
+
 }}

--- a/src/CodeGen_ARM.h
+++ b/src/CodeGen_ARM.h
@@ -70,6 +70,8 @@ protected:
     bool neon_intrinsics_disabled() {
         return target.has_feature(Target::NoNEON);
     }
+
+    bool target_needs_software_float16_cast(Type t, bool isDestinationType) const override;
 };
 
 }}

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -405,6 +405,21 @@ protected:
      */
     std::pair<llvm::Function *, int> find_vector_runtime_function(const std::string &name, int width);
 
+    /**
+      * \param t the source/destination type for a cast (where the
+      *        destination/source type is float16)
+      *
+      * \param isDestinationType is true if ``t`` would be the destination type
+      *        (``float16`` -> ``t``) and false if ``t`` would be the source type
+      *        (``t`` -> ``float16``) for the cast
+      *
+      * \return True iff the target being used for CodeGen requires a software implementation
+     *          for the cast operation specified by the arguments ``t`` and ``isDestinationType``.
+      *
+      * This can be overriden by architecture specific code.
+      */
+    bool virtual target_needs_software_float16_cast(Type t, bool isDestinationType) const = 0;
+
 private:
 
     /** All the values in scope at the current code location during

--- a/src/CodeGen_MIPS.cpp
+++ b/src/CodeGen_MIPS.cpp
@@ -41,4 +41,11 @@ int CodeGen_MIPS::native_vector_bits() const {
     return 128;
 }
 
+
+bool CodeGen_MIPS::target_needs_software_float16_cast(Type t, bool isDestinationType) const {
+    // FIXME: Not sure if this right. I don't
+    // think any MIPS architecture has half precision
+    return true;
+}
+
 }}

--- a/src/CodeGen_MIPS.h
+++ b/src/CodeGen_MIPS.h
@@ -27,6 +27,7 @@ protected:
     std::string mattrs() const;
     bool use_soft_float_abi() const;
     int native_vector_bits() const;
+    bool target_needs_software_float16_cast(Type t, bool isDestinationType) const override;
 };
 
 }}

--- a/src/CodeGen_PNaCl.cpp
+++ b/src/CodeGen_PNaCl.cpp
@@ -35,4 +35,11 @@ int CodeGen_PNaCl::native_vector_bits() const {
     return 128;
 }
 
+bool CodeGen_PNaCl::target_needs_software_float16_cast(Type t, bool isDestinationType) const {
+    // FIXME: Not sure what to do here. PNaCl is supposed to be target
+    // indepedent LLVM IR but I'm not sure if the right thing will happen when
+    // PNaCl gets codegen'ed on the real target.
+    return false;
+}
+
 }}

--- a/src/CodeGen_PNaCl.h
+++ b/src/CodeGen_PNaCl.h
@@ -25,6 +25,7 @@ protected:
     std::string mattrs() const;
     bool use_soft_float_abi() const;
     int native_vector_bits() const;
+    bool target_needs_software_float16_cast(Type t, bool isDestinationType) const override;
 };
 
 }}

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -457,4 +457,9 @@ std::string CodeGen_PTX_Dev::print_gpu_name(const std::string &name) {
     return name;
 }
 
+bool CodeGen_PTX_Dev::target_needs_software_float16_cast(Type t, bool isDestinationType) const {
+    // FIXME: Not sure if this is correct
+    return false;
+}
+
 }}

--- a/src/CodeGen_PTX_Dev.h
+++ b/src/CodeGen_PTX_Dev.h
@@ -69,6 +69,7 @@ protected:
     /** Map from simt variable names (e.g. foo.__block_id_x) to the llvm
      * ptx intrinsic functions to call to get them. */
     std::string simt_intrinsic(const std::string &name);
+    bool target_needs_software_float16_cast(Type t, bool isDestinationType) const override;
 };
 
 }}

--- a/src/CodeGen_Renderscript_Dev.cpp
+++ b/src/CodeGen_Renderscript_Dev.cpp
@@ -611,5 +611,13 @@ void CodeGen_Renderscript_Dev::dump() { module->dump(); }
 std::string CodeGen_Renderscript_Dev::print_gpu_name(const std::string &name) {
     return name;
 }
+
+bool CodeGen_Renderscript_Dev::target_needs_software_float16_cast(Type t, bool isDestinationType) const {
+    // FIXME: Not sure what this needs to be
+    // so pretend that we have support so that
+    // compilation will fail if an attempt is made to use this feature
+    return false;
+}
+
 }
 }

--- a/src/CodeGen_Renderscript_Dev.h
+++ b/src/CodeGen_Renderscript_Dev.h
@@ -78,6 +78,8 @@ protected:
     llvm::Function *fetch_SetElement_func(Type type);
     std::vector<llvm::Value *> add_x_y_c_args(Expr name, Expr x, Expr y,
                                               Expr c);
+
+    bool target_needs_software_float16_cast(Type t, bool isDestinationType) const override;
 private:
     // Metadata records keep track of all Renderscript kernels.
     llvm::NamedMDNode *rs_export_foreach_name;

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -681,4 +681,42 @@ int CodeGen_X86::native_vector_bits() const {
     }
 }
 
+bool CodeGen_X86::target_needs_software_float16_cast(Type t, bool isDestinationType) const {
+    internal_assert(t.bits == 32 || t.bits == 64);
+    if (isDestinationType) {
+        // float16 -> t
+        internal_assert(t.is_float()) << "float16 -> t, where is not a float type not supported\n";
+        if (target.has_feature(Target::F16C)) {
+            // vctph2ps can handle float16 -> float
+            // it doesn't handle float16 -> double but LLVM
+            // seems to emit the correct code anyway (double cast)
+            return false;
+        }
+
+        // Without F16C there is no hardware support so must use
+        // software implementation
+        return true;
+    } else {
+        // t-> float16
+        internal_assert(t.is_float()) << "t -> float16, where is not a float type not supported\n";
+
+        if (target.has_feature(Target::F16C)) {
+            if (t.bits == 32) {
+                // vctps2ph can handle float -> float16
+                return false;
+            } else {
+              // double -> float16
+              // No native support for this.
+              // Doing ``double -> float -> float16`` is not safe.
+              // so request software implementation which will only round once
+              return true;
+            }
+        }
+
+        // Without F16C there is no hardware support so must use
+        // software implementation
+        return true;
+    }
+}
+
 }}

--- a/src/CodeGen_X86.h
+++ b/src/CodeGen_X86.h
@@ -47,6 +47,8 @@ protected:
     void visit(const NE *);
     void visit(const Select *);
     // @}
+
+    bool target_needs_software_float16_cast(Type t, bool isDestinationType) const override;
 };
 
 }}

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -755,7 +755,22 @@ extern float halide_float16_bits_to_float(uint16_t);
  *  the double that represents the same value */
 extern double halide_float16_bits_to_double(uint16_t);
 
-// TODO: Conversion functions to half
+/** Rounding modes (IEEE754 2008 4.3 Rounding-direction attributes) */
+typedef enum halide_rounding_mode_t {
+    halide_toward_zero, ///< Round towards zero (IEEE754 2008 4.3.2)
+    halide_to_nearest_ties_to_even, ///< Round to nearest, when there is a tie pick even integral significand (IEEE754 2008 4.3.1)
+    halide_to_nearest_ties_to_away, ///< Round to nearest, when there is a tie pick value furthest away from zero (IEEE754 2008 4.3.1)
+    halide_toward_positive_infinity, ///< Round towards positive infinity (IEEE754 2008 4.3.2)
+    halide_toward_negative_infinity ///< Round towards negative infinity (IEEE754 2008 4.3.2)
+} halide_rounding_mode_t;
+
+/** Convert a ``float`` to the bits representing a half precision floating point
+ * number using the specified rounding mode*/
+extern uint16_t halide_float_to_float16_bits(float, halide_rounding_mode_t);
+
+/** Convert a ``double`` to the bits representing a half precision floating point
+ * number using the specified rounding mode*/
+extern uint16_t halide_double_to_float16_bits(double, halide_rounding_mode_t);
 
 //@}
 

--- a/src/runtime/float16_t.cpp
+++ b/src/runtime/float16_t.cpp
@@ -1,4 +1,5 @@
-#include "runtime_internal.h"
+// HACK
+//#include "runtime_internal.h"
 #include "HalideRuntime.h"
 
 extern "C" {
@@ -72,5 +73,272 @@ WEAK double halide_float16_bits_to_double(uint16_t bits) {
     float valueAsFloat = halide_float16_bits_to_float(bits);
     return (double) valueAsFloat;
 }
+
+/* The implementation here is based on the description of
+ * rounding from "The Handbook of Floating-Point Arithmetic" in
+ * 2.2 (Rounding) and 8.2 (Implementing IEEE-754 2008 Rounding).
+ */
+__attribute__((always_inline)) static uint16_t performRounding(uint16_t result,
+                                                               bool roundBit,
+                                                               bool stickyBit,
+                                                               uint16_t signMask,
+                                                               halide_rounding_mode_t rm) {
+    // Computation of the successor in IEEE754 binary16 is very elegant. Simply
+    // adding 1 will compute the successor and will handle incrementing the
+    // exponent correctly. It should move into +/- Infinity correctly too.
+    uint16_t successor = result + 1;
+
+    /* Rounding: We now need to pick between ``result`` which is the input rounded
+     * down (or the exact result) and the ``successor`` (rounded up) based on
+     * the rounding mode and sign.
+     */
+
+    // For convenience for negative numbers for some rounding modes we pretend
+    // the rounding is something else using an identity to simplify the logic of
+    // subsequent code. By doing this we conceptually round in the region of
+    // positive numbers only and thus only need to think about the ``successor``
+    // and don't need to worry about the ``predecessor``. We don't actually
+    // bother changing the sign bit though because the rest of the logic doesn't
+    // depend on it.
+    if (signMask > 0) {
+        if (rm == halide_toward_positive_infinity) {
+            // if x < 0 : RU(x) == -RD(|x|)
+            rm = halide_toward_negative_infinity;
+        } else if ( rm == halide_toward_negative_infinity) {
+            // if x < 0: RD(x) == -RU(|x|)
+            rm = halide_toward_positive_infinity;
+        }
+    }
+
+    switch (rm) {
+        case halide_toward_zero: // RZ
+        case halide_toward_negative_infinity: // RD
+            // Alway returns the truncated result
+            return result;
+        case halide_to_nearest_ties_to_even: // RNE
+            if (!roundBit) {
+                // round down
+                return result;
+            } else {
+                if (stickyBit) {
+                    // round up
+                    return successor;
+                } else {
+                    // There is a tie
+                    // Pick the result with the even significand
+                    if ((successor & 0x0001) == 0) {
+                        return successor;
+                    } else {
+                        return result;
+                    }
+                }
+            }
+        case halide_to_nearest_ties_to_away: // RNA
+            if (!roundBit) {
+                // round down
+                return result;
+            } else {
+                if (stickyBit) {
+                    // round up
+                    return successor;
+                } else {
+                    // There is a tie
+                    // Pick the result that moves away from zero
+                    return successor;
+                }
+            }
+        case halide_toward_positive_infinity: // RU
+            if (roundBit | stickyBit) {
+                return successor;
+            } else {
+                // exact result so don't pick successor
+                return result;
+            }
+        default:
+            abort();
+    }
+}
+
+WEAK uint16_t halide_float_to_float16_bits(float value, halide_rounding_mode_t rm) {
+   union {
+        float asFloat;
+        uint32_t asUInt;
+    } data;
+    // FIXME: Need C++11 to use this
+    //static_assert(sizeof(float) == sizeof(uint32_t), "float is wrong size");
+    data.asFloat = value;
+    uint32_t bits = data.asUInt;
+    uint32_t signMask = (bits & 0x80000000) >> (31 - 15);
+    int32_t exponent = (bits & 0x7f800000) >> 23; // Shift into position
+    exponent -= 127; // binary32 exponent is stored as bias-127
+    uint32_t significandBits = (bits & 0x007fffff);
+
+    // e_max + 1 for binary32
+    if (exponent == 128 ) {
+        if (significandBits == 0) {
+            // +ve/-ve infinity
+            return signMask | (0x1f << 10);
+        } else {
+            // NaN
+            // Should we be dropping the sign?
+            return 0x7e00;
+        }
+    }
+
+    uint32_t truncatedSignificand=0;
+    bool stickyBit = false;
+    if (exponent <= -15) {
+        // The floating point number is subnormal
+        // as binary16 or zero
+        //
+        // Convert into subnormal form for binary 16
+        // e.g.
+        // 1.1 *2^-16 ==> 0.011* 2^-14
+        int32_t shiftAmount = -14 -exponent; // e_min - exponent
+        if (shiftAmount < 32) {
+            // Add implicit bit of normalised binary32.  The input must be
+            // normalised because if the input was a subnormal binary32 the
+            // shiftAmount would be >= (-14 - (-127)) == 113
+            truncatedSignificand = (1 << 23) | significandBits;
+
+            // We need to check if any of the significand bits we shift out
+            // are non zero so the "sticky bit" is set correctly.
+            stickyBit = ((1 << shiftAmount) -1) & truncatedSignificand;
+
+            // Now shift to the right
+            truncatedSignificand >>= shiftAmount;
+        } else {
+            // do not overshift which is undefined behaviour in C
+            stickyBit = significandBits > 0;
+            truncatedSignificand = 0;
+        }
+        exponent = -15; // e_min -1. Fake exponent so that reEncoded exponent will be 0.
+    } else if (exponent > 15) {
+        // **Overflow**
+        // The floating point number is larger than
+        // the largest normalised number as binary16
+        // so we return +/- Infinity
+        return signMask | (0x1f << 10);
+    } else {
+        truncatedSignificand = significandBits;
+    }
+
+    // Before truncating the significand compute the round bit and sticky bit.
+    // These are used to make rounding decisions later on.
+    //
+    // The roundBit is the single bit after truncation boundary
+    // It represents half the value of the least significant bit in the final
+    // half floating point number.
+    bool roundBit = (truncatedSignificand & 0x001000) > 0;
+    // The sticky bit is 1 if any of the bits after the "round bit"
+    // are one. Note we OR with existing value because it may have been
+    // set earlier when converting a normalised binary32 to a subnormal
+    // binary16.
+    stickyBit |= (truncatedSignificand & 0x000fff) > 0;
+
+    // Now finally truncate the significand
+    truncatedSignificand &= 0x7fe000;
+    // Move the bits into the right position
+    truncatedSignificand >>= (23 -10);
+
+    uint32_t reEncodedExponent = exponent + 15;
+    reEncodedExponent <<= 10; // Move bits into right position
+    uint16_t result = signMask | reEncodedExponent | truncatedSignificand;
+
+    return performRounding(result, roundBit, stickyBit, signMask, rm);
+}
+
+// FIXME: This function and halide_float_float16_bits() are very similar
+// they logic is the same but they have different types and constants.
+// We should refactor these some how...
+WEAK uint16_t halide_double_to_float16_bits(double value, halide_rounding_mode_t rm) {
+   union {
+        double asDouble;
+        uint64_t asUInt;
+    } data;
+    // FIXME: Need C++11 to use this
+    //static_assert(sizeof(double) == sizeof(uint64_t), "double is wrong size");
+    data.asDouble = value;
+    uint64_t bits = data.asUInt;
+    uint64_t signMask = (bits & 0x8000000000000000) >> (63 - 15);
+    int64_t exponent = (bits & 0x7ff0000000000000) >> 52; // Shift into position
+    exponent -= 1023; // binary64 exponent is stored as bias-1023
+    uint64_t significandBits = (bits & 0x000fffffffffffff);
+
+    // e_max + 1 for binary64
+    if (exponent == 1024 ) {
+        if (significandBits == 0) {
+            // +ve/-ve infinity
+            return signMask | (0x1f << 10);
+        } else {
+            // NaN
+            // Should we be dropping the sign?
+            return 0x7e00;
+        }
+    }
+
+    uint64_t truncatedSignificand=0;
+    bool stickyBit = false;
+    if (exponent <= -15) {
+        // The floating point number is subnormal
+        // as binary16 or zero
+        //
+        // Convert into subnormal form for binary 16
+        // e.g.
+        // 1.1 *2^-16 ==> 0.011* 2^-14
+        int64_t shiftAmount = -14 -exponent; // e_min - exponent
+        if (shiftAmount < 64) {
+            // Add implicit bit of normalised binary32.  The input must be
+            // normalised because if the input was a subnormal binary32 the
+            // shiftAmount would be >= (-14 - (-127)) == 113
+            truncatedSignificand = (1LL << 52) | significandBits;
+
+            // We need to check if any of the significand bits we shift out
+            // are non zero so the "sticky bit" is set correctly.
+            stickyBit = ((1 << shiftAmount) -1) & truncatedSignificand;
+
+            // Now shift to the right
+            truncatedSignificand >>= shiftAmount;
+        } else {
+            // do not overshift which is undefined behaviour in C
+            stickyBit = significandBits > 0;
+            truncatedSignificand = 0;
+        }
+        exponent = -15; // e_min -1. Fake exponent so that reEncoded exponent will be 0.
+    } else if (exponent > 15) {
+        // **Overflow**
+        // The floating point number is larger than
+        // the largest normalised number as binary16
+        // so we return +/- Infinity
+        return signMask | (0x1f << 10);
+    } else {
+        truncatedSignificand = significandBits;
+    }
+
+    // Before truncating the significand compute the round bit and sticky bit.
+    // These are used to make rounding decisions later on.
+    //
+    // The roundBit is the single bit after truncation boundary
+    // It represents half the value of the least significant bit in the final
+    // half floating point number.
+    bool roundBit = (truncatedSignificand & 0x0000020000000000) > 0;
+    // The sticky bit is 1 if any of the bits after the "round bit"
+    // are one. Note we OR with existing value because it may have been
+    // set earlier when converting a normalised binary32 to a subnormal
+    // binary16.
+    stickyBit |= (truncatedSignificand & 0x000001ffffffffff);
+
+    // Now finally truncate the significand
+    truncatedSignificand &= 0x000ffc0000000000;
+    // Move the bits into the right position
+    truncatedSignificand >>= (52 -10);
+
+    uint32_t reEncodedExponent = exponent + 15;
+    reEncodedExponent <<= 10; // Move bits into right position
+    uint16_t result = signMask | reEncodedExponent | truncatedSignificand;
+
+    return performRounding(result, roundBit, stickyBit, signMask, rm);
+}
+
 
 }

--- a/test/correctness/float16_t_realize_upcast.cpp
+++ b/test/correctness/float16_t_realize_upcast.cpp
@@ -1,0 +1,273 @@
+#include "Halide.h"
+#include <stdio.h>
+#include <cmath>
+#include <cinttypes>
+#include <vector>
+
+using namespace Halide;
+
+// FIXME: We should use a proper framework for this. See issue #898
+void h_assert(bool condition, const char *msg) {
+    if (!condition) {
+        printf("FAIL: %s\n", msg);
+        abort();
+    }
+}
+
+uint32_t bits_from_float(float v) {
+    union {
+        float asFloat;
+        uint32_t asUInt;
+    } out;
+    out.asFloat = v;
+    return out.asUInt;
+}
+
+float float_from_bits(uint32_t bits) {
+    union {
+        float asFloat;
+        uint32_t asUInt;
+    } out;
+    out.asUInt = bits;
+    return out.asFloat;
+}
+
+double double_from_bits(uint64_t bits) {
+    union {
+        double asDouble;
+        uint64_t asUInt;
+    } out;
+    out.asUInt = bits;
+    return out.asDouble;
+}
+
+uint64_t bits_from_double(double v) {
+    union {
+        double asDouble;
+        uint64_t asUInt;
+    } out;
+    out.asDouble = v;
+    return out.asUInt;
+}
+
+
+uint16_t inputs[] = {
+  0x0000, // +ve zero
+  0x8000, // -ve zero
+  0x7c00, // +ve infinity
+  0xfc00, // -ve infinity
+  0x7e00, // quiet NaN
+  0x7bff, // Largest +ve normal number
+  0xfbff, // Smallest -ve normal number
+  0x0001, // Smallest +ve subnormal number
+  0x8001, // Largest -ve subnormal number
+  0x0002, // 2nd smallest +ve subnormal number
+  0x8002, // 2nd largest -ve subnormal number
+  0x0003, // 3rd smallest subnormal number
+  0x03ff, // Largest subnormal
+  0x03fe, // 2nd largest subnormal
+  0x3c00, // 1.0
+  0xbc00  // -1.0
+};
+
+// Unfortunately we can't use the C99 hex float format
+// here because MSVC doesn't support them
+float expectedF[] = {
+    0.0f,
+    -0.0f,
+    INFINITY,
+    -INFINITY,
+    std::numeric_limits<float>::quiet_NaN(),
+    65504.0f,
+    -65504.0f,
+    (1.0f)/(1<<24),
+    (-1.0f)/(1<<24),
+    (1.0f)/(1<<23),  // 0x1.000000p-23
+    (-1.0f)/(1<<23), // -0x1.000000p-23
+    (1.5f)/(1<<23), // 0x1.800000p-23
+    float_from_bits(0x387fc000), //0x1.ff8000p-15,
+    float_from_bits(0x387f8000), // 0x1.ff0000p-15,
+    1.0f,
+    -1.0f
+};
+
+double expectedD[] = {
+    0.0,
+    -0.0,
+    (double) INFINITY,
+    (double) -INFINITY,
+    std::numeric_limits<double>::quiet_NaN(),
+    65504.0,
+    -65504.0,
+    (1.0)/(1<<24),
+    (-1.0)/(1<<24),
+    (1.0)/(1<<23), // 0x1.000000000000p-23
+    (-1.0)/(1<<23), // -0x1.000000000000p-23
+    (1.5)/(1<<23), // 0x1.800000000000p-23
+    double_from_bits(0x3f0ff80000000000), // 0x1.ff8000000000p-15,
+    double_from_bits(0x3f0ff00000000000), // 0x1.ff0000000000p-15,
+    1.0,
+    -1.0
+};
+
+// Make input image and expected output image that is filled
+// with our special values. We allow it to take any size so
+// we can test vectorisation later.
+// FIXME: Image class doesn't have Move constructor
+// so this will probably be super inefficient!!
+std::pair<Image<float16_t>,Image<float>> getInputAndExpectedResultImagesF(unsigned width, unsigned height) {
+    static_assert(sizeof(inputs)/sizeof(uint16_t) == sizeof(expectedF)/sizeof(float),
+                  "array size mismatch");
+
+    Image<float16_t> input(width, height);
+    Image<float> expected(width, height);
+
+    int modValue = sizeof(inputs)/sizeof(uint16_t);
+
+    for (unsigned x=0; x < width; ++x) {
+        for (unsigned y=0; y < height; ++y) {
+            input(x,y) = float16_t::make_from_bits(inputs[ (x +y*width) % modValue]);
+            expected(x,y) = expectedF[ (x +y*width) % modValue];
+        }
+    }
+    return std::make_pair(input, expected);
+}
+
+std::pair<Image<float16_t>,Image<double>> getInputAndExpectedResultImagesD(unsigned width, unsigned height) {
+    static_assert((sizeof(inputs)/sizeof(uint16_t)) == (sizeof(expectedD)/sizeof(double)),
+                  "array size mismatch");
+
+    Image<float16_t> input(width, height);
+    Image<double> expected(width, height);
+
+    int modValue = sizeof(inputs)/sizeof(uint16_t);
+
+    for (unsigned x=0; x < width; ++x) {
+        for (unsigned y=0; y < height; ++y) {
+            input(x,y) = float16_t::make_from_bits(inputs[ (x +y*width) % modValue]);
+            expected(x,y) = expectedD[ (x +y*width) % modValue];
+        }
+    }
+    return std::make_pair(input, expected);
+}
+
+void checkResult(Image<float>& result, Image<float>& expected) {
+    h_assert(result.extent(0) == expected.extent(0), "extend(0) mismatch");
+    h_assert(result.extent(1) == expected.extent(1), "extend(1) mismatch");
+    // Check result
+    for (int x=0; x < result.extent(0); ++x) {
+        for (int y=0; y < result.extent(1); ++y) {
+            float resultValue = result(x, y);
+            float expectedValue = expected(x, y);
+            // Convert to bits so we can check NaN
+            uint32_t resultValueAsBits = bits_from_float(resultValue);
+            uint32_t expectedValueAsBits = bits_from_float(expectedValue);
+            if (resultValueAsBits != expectedValueAsBits) {
+               printf("Failed to cast correctly: x:%u y:%u\n", x, y);
+               printf("resultValueAsBits  : 0x%.8" PRIx32 "\n", resultValueAsBits);
+               printf("expectedValueAsBits: 0x%.8" PRIx32 "\n", expectedValueAsBits);
+               h_assert(false, "Failed conversion");
+            }
+        }
+    }
+}
+
+void checkResult(Image<double>& result, Image<double>& expected) {
+    h_assert(result.extent(0) == expected.extent(0), "extend(0) mismatch");
+    h_assert(result.extent(1) == expected.extent(1), "extend(1) mismatch");
+    // Check result
+    for (int x=0; x < result.extent(0); ++x) {
+        for (int y=0; y < result.extent(1); ++y) {
+            double resultValue = result(x, y);
+            double expectedValue = expected(x, y);
+            // Convert to bits so we can check NaN
+            uint64_t resultValueAsBits = bits_from_double(resultValue);
+            uint64_t expectedValueAsBits = bits_from_double(expectedValue);
+            if (resultValueAsBits != expectedValueAsBits) {
+               printf("Failed to cast correctly: x:%u y:%u\n", x, y);
+               printf("resultValueAsBits  : 0x%.16" PRIx64 "\n", resultValueAsBits);
+               printf("expectedValueAsBits: 0x%.16" PRIx64 "\n", expectedValueAsBits);
+               h_assert(false, "Failed conversion");
+            }
+        }
+    }
+}
+
+void testFloatAndDoubleConversion(Target host, int vectorizeWidth=0) {
+    int width = 10;
+    int height = 10;
+    if (vectorizeWidth > 0) {
+        // use multiple of vectorization width
+        width = 3*vectorizeWidth;
+        height = 3*vectorizeWidth;
+    }
+    // Test conversion to float
+    {
+        std::pair<Image<float16_t>,Image<float>> tenByTen = getInputAndExpectedResultImagesF(width, height);
+        Var x, y;
+        Func upCast;
+        upCast(x, y) = cast<float>(tenByTen.first(x, y));
+        if (vectorizeWidth) {
+            upCast.vectorize(x, vectorizeWidth);
+        }
+        Image<float> result = upCast.realize( { tenByTen.first.width(),
+                                                tenByTen.first.height()},
+                                              host);
+        checkResult(result, tenByTen.second);
+        printf("Tested float16 -> float32\n");
+    }
+    // Test conversion to double
+    {
+        std::pair<Image<float16_t>,Image<double>> tenByTen = getInputAndExpectedResultImagesD(width, height);
+        Var x, y;
+        Func upCast;
+        upCast(x, y) = cast<double>(tenByTen.first(x, y));
+        Image<double> result = upCast.realize( { tenByTen.first.width(),
+                                                 tenByTen.first.height()},
+                                               host);
+        checkResult(result, tenByTen.second);
+        printf("Tested float16 -> float64\n");
+    }
+}
+
+int main() {
+    /*
+     * Test software implementation of converting float16 to single
+     * and double
+     */
+    Target host = get_jit_target_from_environment();
+
+    // FIXME: This seems a bit cumbersome and fragile, perhaps we should have
+    // a softf16c target feature that forces our software implementation to be used?
+
+    // We want to test the software implementation of floating
+    // point so remove support from target
+    if (host.arch == Target::X86) {
+        host.set_feature(Target::F16C, false);
+    }
+    // TODO: Add code for other architectures to disable their native float16
+    // conversion support if they have it
+
+    // Test software implementation of float16 to single/double conversion.
+    testFloatAndDoubleConversion(host);
+
+    /*
+     * Test hardware implementations of converting float16 to single
+     * and double
+     */
+    host = get_jit_target_from_environment();
+
+    // TODO: Add support for other architectures
+    if (host.arch == Target::X86 && host.has_feature(Target::F16C)) {
+        // x86-64 f16c intrinsics have 4 and 8 wide versions just try 4
+        // for now.
+        // FIXME: Is there a way to test that we vectorized correctly?
+        testFloatAndDoubleConversion(host, /*vectorizeWidth=*/4);
+    } else {
+        printf("No target specific float16 support available on target \"%s\"\n",
+               host.to_string().c_str());
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/runtime_float16_t_downcast.cpp
+++ b/test/correctness/runtime_float16_t_downcast.cpp
@@ -1,0 +1,417 @@
+#include "HalideRuntime.h"
+#include <cmath>
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits>
+#include <vector>
+
+
+// FIXME: We should use a proper framework for this. See issue #898
+void h_assert(bool condition, const char *msg) {
+    if (!condition) {
+        printf("FAIL: %s\n", msg);
+        abort();
+    }
+}
+
+float float_from_bits(uint32_t bits) {
+    union {
+        float asFloat;
+        uint32_t asUInt;
+    } out;
+    out.asUInt = bits;
+    return out.asFloat;
+}
+
+double double_from_bits(uint64_t bits) {
+    union {
+        double asDouble;
+        uint64_t asUInt;
+    } out;
+    out.asUInt = bits;
+    return out.asDouble;
+}
+struct Result {
+    uint16_t RZ; // Result for round to Zero
+    uint16_t RU; // Result for round to +ve infinity
+    uint16_t RD; // Result for round to -ve infinity
+    uint16_t RNE; // Result for round to nearest, ties to even
+    uint16_t RNA; // Result for round to nearest, ties to away from zero
+    static Result all(uint16_t v) {
+        Result r = {.RZ = v, .RU = v, .RD = v, .RNE = v, .RNA = v};
+        return r;
+    }
+};
+
+void test_float(float input, Result r) {
+    uint16_t floatAsHalfRZ = halide_float_to_float16_bits(input,
+                                                          halide_toward_zero);
+    uint16_t floatAsHalfRU = halide_float_to_float16_bits(input,
+                                                          halide_toward_positive_infinity);
+    uint16_t floatAsHalfRD = halide_float_to_float16_bits(input,
+                                                          halide_toward_negative_infinity);
+    uint16_t floatAsHalfRNE = halide_float_to_float16_bits(input,
+                                                           halide_to_nearest_ties_to_even);
+    uint16_t floatAsHalfRNA = halide_float_to_float16_bits(input,
+                                                           halide_to_nearest_ties_to_away);
+    h_assert(floatAsHalfRZ == r.RZ, "Failed RZ round from float");
+    h_assert(floatAsHalfRU == r.RU, "Failed RU round from float");
+    h_assert(floatAsHalfRD == r.RD, "Failed RD round from float");
+    h_assert(floatAsHalfRNE == r.RNE, "Failed RNE round from float");
+    h_assert(floatAsHalfRNA == r.RNA, "Failed RNA round from float");
+}
+
+void test_double(double input, Result r) {
+    uint16_t doubleAsHalfRZ = halide_double_to_float16_bits(input,
+                                                            halide_toward_zero);
+    uint16_t doubleAsHalfRU = halide_double_to_float16_bits(input,
+                                                            halide_toward_positive_infinity);
+    uint16_t doubleAsHalfRD = halide_double_to_float16_bits(input,
+                                                            halide_toward_negative_infinity);
+    uint16_t doubleAsHalfRNE = halide_double_to_float16_bits(input,
+                                                             halide_to_nearest_ties_to_even);
+    uint16_t doubleAsHalfRNA = halide_double_to_float16_bits(input,
+                                                             halide_to_nearest_ties_to_away);
+    h_assert(doubleAsHalfRZ == r.RZ, "Failed RZ round from double");
+    h_assert(doubleAsHalfRU == r.RU, "Failed RU round from double");
+    h_assert(doubleAsHalfRD == r.RD, "Failed RD round from double");
+    h_assert(doubleAsHalfRNE == r.RNE, "Failed RNE round from double");
+    h_assert(doubleAsHalfRNA == r.RNA, "Failed RNA round from double");
+}
+
+int main() {
+    /*
+     * Exact rounding:
+     *
+     * These are constants that can be represented exactly in half
+     */
+
+    // +ve 0
+    test_float(0.0f, Result::all(0x0000));
+    test_double(0.0, Result::all(0x0000));
+
+    // -ve 0
+    test_float(-0.0f, Result::all(0x8000));
+    test_double(-0.0, Result::all(0x8000));
+
+    // +ve Infinity
+    test_float(INFINITY, Result::all(0x7c00));
+    test_double(INFINITY, Result::all(0x7c00));
+
+    // -ve Infinity
+    test_float(-INFINITY, Result::all(0xfc00));
+    test_double(-INFINITY, Result::all(0xfc00));
+
+    // Quiet naN
+    test_float(std::numeric_limits<float>::quiet_NaN(), Result::all(0x7e00));
+    test_double(std::numeric_limits<double>::quiet_NaN(), Result::all(0x7e00));
+
+    // +1.0
+    test_float(1.0f, Result::all(0x3c00));
+    test_double(1.0, Result::all(0x3c00));
+
+    // -1.0
+    test_float(-1.0f, Result::all(0xbc00));
+    test_double(-1.0, Result::all(0xbc00));
+
+    // 0x0.004p-14, the smallest +ve
+    test_float((1.0f)/(1<<24), Result::all(0x0001));
+    test_double((1.0)/(1<<24), Result::all(0x0001));
+
+    // 0x0.008p-14, the 2nd smallest +ve
+    test_float((1.0f)/(1<<23), Result::all(0x0002));
+    test_double((1.0)/(1<<23), Result::all(0x0002));
+
+    // -0x0.004p-14, the largest -ve
+    test_float((-1.0f)/(1<<24), Result::all(0x8001));
+    test_double((-1.0)/(1<<24), Result::all(0x8001));
+
+    // -0x0.008p-14, the 2nd smallest -ve
+    test_float((-1.0f)/(1<<23), Result::all(0x8002));
+    test_double((-1.0)/(1<<23), Result::all(0x8002));
+
+    // Largest +ve
+    test_float(65504.0f, Result::all(0x7bff));
+    test_double(65504.0, Result::all(0x7bff));
+
+    // smallest -ve
+    test_float(-65504.0f, Result::all(0xfbff));
+    test_double(-65504.0, Result::all(0xfbff));
+
+    // Largest float16 subnormal
+    // 0x1.ff8000p-15
+    test_float(float_from_bits(0x387fc000), Result::all(0x03ff));
+    // 0x1.ff8000000000p-15,
+    test_double(double_from_bits(0x3f0ff80000000000), Result::all(0x03ff));
+
+    // 0x1.a000p-16 this is represented as a normal as a float or double but
+    // will become subnormal as a float16.
+    test_float(float_from_bits(0x37d00000), Result::all(0x01a0));
+    test_double(double_from_bits(0x3efa000000000000), Result::all(0x01a0));
+
+    // -0x1.a000p-16 this is represented as a normal as a float or double but
+    // will become subnormal as a float16.
+    test_float(float_from_bits(0xb7d00000), Result::all(0x81a0));
+    test_double(double_from_bits(0xbefa000000000000), Result::all(0x81a0));
+
+    /* Inexact rounding:
+     * These values cannot be represented exactly in half
+     */
+
+    // Overflow: These values are not representable and will not round to
+    // representable values
+    // Should go to +infinity
+    test_float(65536.0f, Result::all(0x7c00));
+    test_double(65536.0, Result::all(0x7c00));
+
+    // Should go to -infinity
+    test_float(-65536.0f, Result::all(0xfc00));
+    test_double(-65536.0, Result::all(0xfc00));
+
+    // Underflow: This value is too small to be representable and will
+    // be rounded to + zero apart from RU
+    // 0x1.0p-26
+    {
+        Result resultFromFloat = { .RZ = 0x0000,
+                                   .RU = 0x0001,
+                                   .RD = 0x0000,
+                                   .RNE = 0x0000,
+                                   .RNA = 0x0000
+                                 };
+        test_float(float_from_bits(0x32800000), resultFromFloat);
+        test_double(double_from_bits(0x3e50000000000000), resultFromFloat);
+    }
+    // -0x1.0p-26
+    // Will round to negative zero except for RD
+    {
+        Result resultFromFloat = { .RZ = 0x8000,
+                                   .RU = 0x8000,
+                                   .RD = 0x8001,
+                                   .RNE = 0x8000,
+                                   .RNA = 0x8000
+                                 };
+        test_float(float_from_bits(0xb2800000), resultFromFloat);
+        test_double(double_from_bits(0xbe50000000000000), resultFromFloat);
+    }
+
+
+    // ~0.1
+    // Has infinitely repeating bit pattern
+    // 0.000 1100 1100 1100 ...
+    {
+        // When rounding this constant the round bit is zero but the sticky bit is
+        // one which means the values for the rounding modes will all be the same
+        // accept for RU which will round up.
+        Result resultFromFloat = { .RZ = 0x2e66,
+                                   .RU = 0x2e67,
+                                   .RD = 0x2e66,
+                                   .RNE = 0x2e66,
+                                   .RNA = 0x2e66
+                                 };
+        test_float(0.1f, resultFromFloat);
+        test_double(0.1, resultFromFloat);
+    }
+
+    // -0.1
+    {
+        // When rounding this constant the round bit is zero but the sticky bit is
+        // one. All rounding modes give the same answer apart from round down.
+        Result resultFromFloat = { .RZ = 0xae66,
+                                   .RU = 0xae66,
+                                   .RD = 0xae67,
+                                   .RNE = 0xae66,
+                                   .RNA = 0xae66
+                                 };
+        test_float(-0.1f, resultFromFloat);
+        test_double(-0.1, resultFromFloat);
+    }
+
+    // 65488 is exactly half way between representable binary16
+    // floats (65472 and 66504). When rounding the round bit will
+    // be 1 but the stickbit will be zero.
+    {
+        Result resultFromFloat = { .RZ = 0x7bfe,
+                                   .RU = 0x7bff,
+                                   .RD = 0x7bfe,
+                                   .RNE = 0x7bfe, // Tie, picks even significand
+                                   .RNA = 0x7bff // Tie, picks value furthest from zero
+                                 };
+        test_float(65488.0f, resultFromFloat);
+        test_double(65488.0, resultFromFloat);
+    }
+    {
+        Result resultFromFloat = { .RZ = 0xfbfe,
+                                   .RU = 0xfbfe,
+                                   .RD = 0xfbff,
+                                   .RNE = 0xfbfe, // Tie, picks even significand
+                                   .RNA = 0xfbff // Tie, picks value furthest from zero
+                                 };
+        test_float(-65488.0f, resultFromFloat);
+        test_double(-65488.0, resultFromFloat);
+    }
+    // 65488.00390625 is slightly more than the half way point between the two
+    // representable floats (65472 and 66504) so both the round bit and sticky
+    // bit will be one.
+    {
+        Result resultFromFloat = { .RZ = 0x7bfe,
+                                   .RU = 0x7bff,
+                                   .RD = 0x7bfe,
+                                   .RNE = 0x7bff,
+                                   .RNA = 0x7bff
+                                 };
+        test_float(65488.00390625f, resultFromFloat);
+        test_double(65488.00390625, resultFromFloat);
+    }
+    {
+        Result resultFromFloat = { .RZ = 0xfbfe,
+                                   .RU = 0xfbfe,
+                                   .RD = 0xfbff,
+                                   .RNE = 0xfbff,
+                                   .RNA = 0xfbff
+                                 };
+        test_float(-65488.00390625f, resultFromFloat);
+        test_double(-65488.00390625, resultFromFloat);
+    }
+
+    // 65535.9, slightly smaller than 2^(e_max +1) so RZ and RD should not return
+    // +inf
+    {
+        Result resultFromFloat = { .RZ = 0x7bff,
+                                   .RU = 0x7c00, // +inf
+                                   .RD = 0x7bff,
+                                   .RNE = 0x7c00, // +inf
+                                   .RNA = 0x7c00 // +inf
+                                 };
+        test_float(65535.9f, resultFromFloat);
+        test_double(65535.9, resultFromFloat);
+    }
+    {
+        Result resultFromFloat = { .RZ = 0xfbff,
+                                   .RU = 0xfbff,
+                                   .RD = 0xfc00, // -inf
+                                   .RNE = 0xfc00, // -inf
+                                   .RNA = 0xfc00 // -inf
+                                 };
+        test_float(-65535.9f, resultFromFloat);
+        test_double(-65535.9, resultFromFloat);
+    }
+
+
+    // 66520 is half way between the 66504 (representable in binary16)
+    // and 66536 (not representable in binary16). For RNE and RNA
+    // there is a tie and both must pick infinity
+    {
+        Result resultFromFloat = { .RZ = 0x7bff,
+                                   .RU = 0x7c00, // +inf
+                                   .RD = 0x7bff,
+                                   .RNE = 0x7c00, // +inf
+                                   .RNA = 0x7c00 // +inf
+                                 };
+        test_float(65520.0f, resultFromFloat);
+        test_double(65520.0, resultFromFloat);
+    }
+    {
+        Result resultFromFloat = { .RZ = 0xfbff,
+                                   .RU = 0xfbff,
+                                   .RD = 0xfc00, // -inf
+                                   .RNE = 0xfc00, // -inf
+                                   .RNA = 0xfc00 // -inf
+                                 };
+        test_float(-65520.0f, resultFromFloat);
+        test_double(-65520.0, resultFromFloat);
+    }
+    
+    // 66519.9 is slightly less than 66520 so RNE and RNA should round toward
+    // zero
+    {
+        Result resultFromFloat = { .RZ = 0x7bff,
+                                   .RU = 0x7c00, // +inf
+                                   .RD = 0x7bff,
+                                   .RNE = 0x7bff,
+                                   .RNA = 0x7bff
+                                 };
+        test_float(65519.9f, resultFromFloat);
+        test_double(65519.9, resultFromFloat);
+    }
+    {
+        Result resultFromFloat = { .RZ = 0xfbff,
+                                   .RU = 0xfbff,
+                                   .RD = 0xfc00, // -inf
+                                   .RNE = 0xfbff,
+                                   .RNA = 0xfbff
+                                 };
+        test_float(-65519.9f, resultFromFloat);
+        test_double(-65519.9, resultFromFloat);
+    }
+
+    // 1.0 * 2^-25. This is a tie for RNE and RNA.
+    {
+        Result resultFromFloat = { .RZ = 0x0000,
+                                   .RU = 0x0001,
+                                   .RD = 0x0000,
+                                   .RNE = 0x0000, // pick even significand
+                                   .RNA = 0x0001 // away from zero. Is this compliant??
+                                 };
+        test_float(float_from_bits(0x33000000), resultFromFloat);
+        test_double(double_from_bits(0x3e60000000000000), resultFromFloat);
+    }
+    {
+        Result resultFromFloat = { .RZ = 0x8000,
+                                   .RU = 0x8000,
+                                   .RD = 0x8001,
+                                   .RNE = 0x8000, // pick even significand
+                                   .RNA = 0x8001 // away from zero. Is this compliant??
+                                 };
+        test_float(float_from_bits(0xb3000000), resultFromFloat);
+        test_double(double_from_bits(0xbe60000000000000), resultFromFloat);
+    }
+
+    // 1.0 * 2^-25 + delta . Where delta is the smallest increment available for
+    // the type. This is slightly over the tie boundary for RNE and RNA should
+    // not round to zero.
+    {
+        Result resultFromFloat = { .RZ = 0x0000,
+                                   .RU = 0x0001,
+                                   .RD = 0x0000,
+                                   .RNE = 0x0001,
+                                   .RNA = 0x0001
+                                 };
+        test_float(float_from_bits(0x33000001), resultFromFloat);
+        test_double(double_from_bits(0x3e60000000000001), resultFromFloat);
+    }
+    {
+        Result resultFromFloat = { .RZ = 0x8000,
+                                   .RU = 0x8000,
+                                   .RD = 0x8001,
+                                   .RNE = 0x8001,
+                                   .RNA = 0x8001
+                                 };
+        test_float(float_from_bits(0xb3000001), resultFromFloat);
+        test_double(double_from_bits(0xbe60000000000001), resultFromFloat);
+    }
+
+    // Try to smallest subnormal number for the type.
+    // Every rounding mode apart from RU should return 0
+    {
+        Result resultFromFloat = { .RZ = 0x0000,
+                                   .RU = 0x0001,
+                                   .RD = 0x0000,
+                                   .RNE = 0x0000,
+                                   .RNA = 0x0000
+                                 };
+        test_float(float_from_bits(0x00000001), resultFromFloat);
+        test_double(double_from_bits(0x0000000000000001), resultFromFloat);
+    }
+    {
+        Result resultFromFloat = { .RZ = 0x8000,
+                                   .RU = 0x8000,
+                                   .RD = 0x8001,
+                                   .RNE = 0x8000,
+                                   .RNA = 0x8000
+                                 };
+        test_float(float_from_bits(0x80000001), resultFromFloat);
+        test_double(double_from_bits(0x8000000000000001), resultFromFloat);
+    }
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/runtime_float16_t_upcast.cpp
+++ b/test/correctness/runtime_float16_t_upcast.cpp
@@ -21,7 +21,7 @@ float float_from_bits(uint32_t bits) {
     return out.asFloat;
 }
 
-float double_from_bits(uint64_t bits) {
+double double_from_bits(uint64_t bits) {
     union {
         double asDouble;
         uint64_t asUInt;


### PR DESCRIPTION
This is work in progress for using a software implementation for converting between half precision floating point.

I've added a software implementation for converting float/double to half but that isn't used yet. That isn't the part I want comments on (yet).

The bit I want comments on is the changes in ``CodeGen_LLVM.cpp`` in the last commit. It works but I don't like it. I want to know how we should be deciding when to use the software implementation of half to float/double conversion function. Right now the condition is it must be ``X86`` and ``F16C`` is not available which seems **way too** specific, it's likely that other CPU targets will need this software implementation too.

Thoughts...?

On a related note I also need a way when ``X86`` and ``F16C`` are available to just use the builder as before (LLVM will generate the necessary vector instructions without us having to do anything :) ). I could add some logic to ``CodeGen_X86.cpp``, something like

```
// If F16C is available make sure we don't call into parent class which might
// use software implementation for half -> float/double conversion. Instead
// just create the simple FPCast and LLVM will generate the right native instructions
// for us.
if (target.has_feature(Target::F16C)) {
   value = builder->CreateFPCast(value, llvm_dst);
   return;
}
```

but I'm not sure if this is the best way to go.

There's also a ``FIXME`` in the test related to testing if the target we will use for JIT'ing support half/float/double conversion. Maybe the fix for is to introduce ``Target::has_native_float16_conversion()`` so all the logic is one place so the test and the LLVM codegen can use this to decide what to do?

@abadams @abestephensg @zvookin Thoughts?