### PR TITLE
Typed create buffer_t

### DIFF
--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -333,7 +333,7 @@ public:
                     for (int k = 0; k < input.outputs(); k++) {
                         string name = input.name() + ".o" + std::to_string(k) + ".bounds_query." + func.name();
                         Expr buf = Call::make(Handle(), Call::create_buffer_t,
-                                              {null_handle, input.output_types()[k].bytes()},
+                                              {null_handle, make_zero(input.output_types()[k])},
                                               Call::Intrinsic);
                         lets.push_back(make_pair(name, buf));
                         bounds_inference_args.push_back(Variable::make(Handle(), name));
@@ -361,7 +361,7 @@ public:
             for (int j = 0; j < func.outputs(); j++) {
                 vector<Expr> output_buffer_t_args(2);
                 output_buffer_t_args[0] = null_handle;
-                output_buffer_t_args[1] = func.output_types()[j].bytes();
+                output_buffer_t_args[1] = make_zero(func.output_types()[j]);
                 for (size_t k = 0; k < func.args().size(); k++) {
                     const string &arg = func.args()[k];
                     string prefix = func.name() + ".s" + std::to_string(stage) + "." + arg;

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -912,7 +912,9 @@ void CodeGen_C::visit(const Call *op) {
         } else if (op->name == Call::create_buffer_t) {
             internal_assert(op->args.size() >= 2);
             vector<string> args;
-            for (size_t i = 0; i < op->args.size(); i++) {
+            args.push_back(print_expr(op->args[0]));
+            args.push_back(print_expr(op->args[1].type().bytes()));
+            for (size_t i = 2; i < op->args.size(); i++) {
                 args.push_back(print_expr(op->args[i]));
             }
             string buf_id = unique_name('B');

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2203,7 +2203,7 @@ void CodeGen_LLVM::visit(const Call *op) {
             Value *elem_size = codegen(op->args[1].type().bytes());
             builder->CreateStore(elem_size, buffer_elem_size_ptr(buffer));
 
-            int dims = (op->args.size() - 2)/3;
+            int dims = (op->args.size() - 2) / 3;
             user_assert(dims <= 4)
                 << "Halide currently has a limit of four dimensions on "
                 << "Funcs used on the GPU or passed to extern stages.\n";

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2192,15 +2192,18 @@ void CodeGen_LLVM::visit(const Call *op) {
             builder->CreateStore(host_ptr, buffer_host_ptr(buffer));
 
             // Type check integer arguments
-            for (size_t i = 1; i < op->args.size(); i++) {
+            for (size_t i = 2; i < op->args.size(); i++) {
                 internal_assert(op->args[i].type() == Int(32))
-                    << "All arguments to create_buffer_t beyond the first must have type Int(32)\n";
+                    << "All arguments to create_buffer_t beyond the second must have type Int(32)\n";
             }
 
-            Value *elem_size = codegen(op->args[1]);
+            // Second argument is used solely for its Type. Value is unimportant.
+            // Currenty, only the size matters, but ultimately we will encode
+            // complete type info in buffer_t.
+            Value *elem_size = codegen(op->args[1].type().bytes());
             builder->CreateStore(elem_size, buffer_elem_size_ptr(buffer));
 
-            int dims = op->args.size()/3;
+            int dims = (op->args.size() - 2)/3;
             user_assert(dims <= 4)
                 << "Halide currently has a limit of four dimensions on "
                 << "Funcs used on the GPU or passed to extern stages.\n";

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -427,7 +427,7 @@ private:
             std::vector<Expr> computed_bounds_args;
             Expr null_handle = Call::make(Handle(), Call::null_handle, std::vector<Expr>(), Call::Intrinsic);
             computed_bounds_args.push_back(null_handle);
-            computed_bounds_args.push_back(f.output_types()[0].bytes());
+            computed_bounds_args.push_back(make_zero(f.output_types()[0]));
             std::string max_stage_num = std::to_string(f.updates().size());
             for (int32_t i = 0; i < f.dimensions(); i++) {
                 Expr min = Variable::make(Int(32), op->name + ".s" + max_stage_num + "." + f.args()[i] + ".min");

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -412,7 +412,7 @@ Stmt build_produce(Function f) {
                 host_ptr = Call::make(Handle(), Call::address_of, {host_ptr}, Call::Intrinsic);
 
                 buffer_args[0] = host_ptr;
-                buffer_args[1] = f.output_types()[j].bytes();
+                buffer_args[1] = make_zero(f.output_types()[j]);
                 for (int k = 0; k < f.dimensions(); k++) {
                     string var = stage_name + f.args()[k];
                     Expr min = Variable::make(Int(32), var + ".min");

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -160,7 +160,7 @@ private:
             //args[0] = Call::make(Handle(), Call::null_handle, vector<Expr>(), Call::Intrinsic);
             Expr first_elem = Load::make(t, buffer_name, 0, Buffer(), Parameter());
             args[0] = Call::make(Handle(), Call::address_of, {first_elem}, Call::Intrinsic);
-            args[1] = realize->types[idx].bytes();
+            args[1] = make_zero(realize->types[idx]);
             for (int i = 0; i < dims; i++) {
                 args[3*i+2] = min_var[i];
                 args[3*i+3] = extent_var[i];


### PR DESCRIPTION
Change the second argument to create_buffer_t intrinsics from a byte
size to an Expr where the Type itself is the meaningful
information. This encodes more complete type information which is
needed immediately in the JavaScript branch and will be used
everywhere when we add complete type info to buffer_t.

I chose to replace the elem_size argument isntead of add a new one as
the information is redundant and this is a simpler code change. I
cannot think of a valid situation were elem_size should be allowed to
disagree with the byte size of the Type. In fact, I can see an
argument for elminating elem_size when the type info is added to
buffer_t.