### PR TITLE
Fix bug when creating static library archives from halide generated

### DIFF
--- a/HalideGenerator.cmake
+++ b/HalideGenerator.cmake
@@ -115,7 +115,7 @@ function(halide_add_generator_dependency)
         DEPENDS "${args_GENERATOR_TARGET}"
         COMMAND "${CMAKE_BINARY_DIR}/bin/${generator_exec}" ${invoke_args}
         # Create an archive using ar (or similar)
-        COMMAND "${CMAKE_AR}" q "${FILTER_LIB}" "${SCRATCH_DIR}/${args_GENERATED_FUNCTION}.o"
+        COMMAND "${CMAKE_AR}" r "${FILTER_LIB}" "${SCRATCH_DIR}/${args_GENERATED_FUNCTION}.o"
         WORKING_DIRECTORY "${SCRATCH_DIR}"
         )
     else()


### PR DESCRIPTION
code in the CMake build under Linux.

Previously the ``q`` flag was being used with ``ar`` which
just appends the object file to the archive without checking if it
was already present. This would lead to multiple versions of an object
file ending up in the archive. Then if an application linked against
this archive it would pick the first object file (i.e. the stale one)
rather than the latest version of the object file.

Now we use the ``r`` flag instead which is inserts object files into
the archive with **replacement**.