### PR TITLE
Support buffer sizes of 2^63 - 1 bytes on 64-bit systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,7 @@ SOURCE_FILES = \
   UnifyDuplicateLets.cpp \
   UniquifyVariableNames.cpp \
   UnrollLoops.cpp \
+  UpcastBufferIndices.cpp \
   Util.cpp \
   Var.cpp \
   VaryingAttributes.cpp \
@@ -443,6 +444,7 @@ HEADER_FILES = \
   UnifyDuplicateLets.h \
   UniquifyVariableNames.h \
   UnrollLoops.h \
+  UpcastBufferIndices.h \
   Util.h \
   Var.h \
   VectorizeLoops.h

--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -294,15 +294,21 @@ Stmt add_image_checks(Stmt s,
             }
             lets_required.push_back(make_pair(name + ".stride." + dim + ".required", stride_required));
 
-            // Insert checks to make sure the total size of all input
-            // and output buffers is <= 2^31 - 1.  And that no product
-            // of extents overflows 2^31 - 1. This second test is
-            // likely only needed if a fuse directive is used in the
-            // schedule to combine multiple extents, but it is here
-            // for extra safety. Ultimately we will want to make
-            // Halide handle larger single buffers, at least on 64-bit
-            // systems.
-            Expr max_size = cast<int64_t>(0x7fffffff);
+            // On 32-bit systems, insert checks to make sure the total
+            // size of all input and output buffers is <= 2^31 - 1.
+            // And that no product of extents overflows 2^31 - 1. This
+            // second test is likely only needed if a fuse directive
+            // is used in the schedule to combine multiple extents,
+            // but it is here for extra safety. On 64-bit systems the
+            // maximum size is 2^63 - 1.
+            Expr max_size, max_extent = cast<int64_t>(0x7fffffff);
+            if (t.bits < 64) {
+                max_size = cast<int64_t>(0x7fffffff);
+            } else {
+                // The Halide compiler currently can't represent
+                // 64-bit immediate values.
+                max_size = (cast<int64_t>(1) << cast<int64_t>(63)) - cast<int64_t>(1);
+            }
             Expr actual_size = cast<int64_t>(actual_extent) * actual_stride;
             Expr allocation_size_error = Call::make(Int(32), "halide_error_buffer_allocation_too_large",
                                                     {name, actual_size, max_size}, Call::Extern);

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -3,13 +3,19 @@
 #include "Error.h"
 #include "JITModule.h"
 #include "runtime/HalideRuntime.h"
+#include "Target.h"
 
 namespace Halide {
 namespace Internal {
 
 namespace {
 void check_buffer_size(uint64_t bytes, const std::string &name) {
-    user_assert(bytes < (1UL << 31)) << "Total size of buffer " << name << " exceeds 2^31 - 1\n";
+    Target t = get_target_from_environment();
+    if (t.bits == 64) {
+        user_assert(bytes < (1UL << 63)) << "Total size of buffer " << name << " exceeds 2^63 - 1\n";
+    } else {
+        user_assert(bytes < (1UL << 31)) << "Total size of buffer " << name << " exceeds 2^31 - 1\n";
+    }
 }
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -297,6 +297,7 @@ set(HEADER_FILES
   UnifyDuplicateLets.h
   UniquifyVariableNames.h
   UnrollLoops.h
+  UpcastBufferIndices.h
   Util.h
   Var.h
   VaryingAttributes.h
@@ -437,6 +438,7 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   UnifyDuplicateLets.cpp
   UniquifyVariableNames.cpp
   UnrollLoops.cpp
+  UpcastBufferIndices.cpp
   Util.cpp
   Var.cpp
   VaryingAttributes.cpp

--- a/src/CodeGen_Posix.cpp
+++ b/src/CodeGen_Posix.cpp
@@ -31,7 +31,14 @@ Value *CodeGen_Posix::codegen_allocation_size(const std::string &name, Type type
 
     Expr no_overflow = const_true(1);
     Expr total_size = cast<int64_t>(type.width * type.bytes());
-    Expr max_size = cast<int64_t>(0x7fffffff);
+    Expr max_size;
+    if (target.bits < 64) {
+        max_size = cast<int64_t>(0x7fffffff);
+    } else {
+        // The Halide compiler currently can't represent
+        // 64-bit immediate values.
+        max_size = (cast<int64_t>(1) << cast<int64_t>(63)) - cast<int64_t>(1);
+    }
     for (size_t i = 0; i < extents.size(); i++) {
         total_size *= extents[i];
         no_overflow = no_overflow && (total_size <= max_size);
@@ -45,7 +52,7 @@ Value *CodeGen_Posix::codegen_allocation_size(const std::string &name, Type type
                                     {name, total_size, max_size}, Call::Extern));
     }
 
-    total_size = simplify(cast<int32_t>(total_size));
+    total_size = simplify(total_size);
     return codegen(total_size);
 }
 
@@ -54,13 +61,15 @@ CodeGen_Posix::Allocation CodeGen_Posix::create_allocation(const std::string &na
                                                            Expr new_expr, std::string free_function) {
     Value *llvm_size = NULL;
     int64_t stack_bytes = 0;
+    const int64_t max_size = target.bits == 64 ? 0x7fffffffffffffff : 0x7fffffff;
     int32_t constant_bytes = 0;
     if (constant_allocation_size(extents, name, constant_bytes)) {
         constant_bytes *= type.bytes();
         stack_bytes = constant_bytes;
 
-        if (stack_bytes > ((int64_t(1) << 31) - 1)) {
-            user_error << "Total size for allocation " << name << " is constant but exceeds 2^31 - 1.";
+        if (stack_bytes > max_size) {
+            const string str_max_size = target.bits == 64 ? "2^63 - 1" : "2^31 - 1";
+            user_error << "Total size for allocation " << name << " is constant but exceeds " << str_max_size << ".";
         } else if (stack_bytes <= 1024 * 16) {
             // Round up to nearest multiple of 32.
             stack_bytes = ((stack_bytes + 31)/32)*32;

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -45,6 +45,7 @@
 #include "UnifyDuplicateLets.h"
 #include "UniquifyVariableNames.h"
 #include "UnrollLoops.h"
+#include "UpcastBufferIndices.h"
 #include "VaryingAttributes.h"
 #include "VectorizeLoops.h"
 
@@ -242,6 +243,13 @@ Stmt lower(const vector<Function> &outputs, const string &pipeline_name, const T
 
     s = remove_trivial_for_loops(s);
     s = simplify(s);
+
+    if (t.bits == 64) {
+        debug(1) << "Upcasting buffer indices...\n";
+        s = upcast_buffer_indices(s);
+        s = simplify(s);
+    }
+
     debug(1) << "Lowering after final simplification:\n" << s << "\n\n";
 
     if (!custom_passes.empty()) {

--- a/src/UpcastBufferIndices.cpp
+++ b/src/UpcastBufferIndices.cpp
@@ -1,0 +1,127 @@
+#include "UpcastBufferIndices.h"
+#include "IRMutator.h"
+#include "IROperator.h"
+#include "Scope.h"
+
+using std::set;
+using std::string;
+
+namespace Halide {
+namespace Internal {
+
+class UpcastBufferIndices : public IRMutator {
+    class UpcastVariables : public IRMutator {
+        Scope<Expr> scope;
+        using IRMutator::visit;
+
+        Type get_type(Expr e) const {
+            if (const Variable *v = e.as<Variable>()) {
+                if (!scope.contains(v->name)) {
+                    // If a variable is not in scope, it is an input
+                    // or output buffer min/extent. For now, buffer
+                    // mins/extents are still 32 bits.
+                    return Int(32);
+                }
+                return get_type(scope.get(v->name));
+            }
+            return e.type();
+        }
+
+        Expr upcast(Expr e) const {
+            Type t = Int(64, e.type().width);
+            if (e.type() == t) {
+                return e;
+            } else {
+                return Cast::make(t, e);
+            }
+        }
+
+        void visit(const Variable *op) {
+            if (starts_with(op->name, prefix)) {
+                expr = upcast(op);
+            } else {
+                expr = op;
+            }
+        }
+
+        template<typename T>
+        void mutate_binary_operator(const T *op) {
+            Expr a = mutate(op->a);
+            Expr b = mutate(op->b);
+            bool modified = !a.same_as(op->a) || !b.same_as(op->b);
+            bool type_mismatch = get_type(a) != get_type(b);
+            if (modified || type_mismatch) {
+                expr = T::make(upcast(a), upcast(b));
+            } else {
+                expr = op;
+            }
+        }
+
+        void visit(const Add *op) {mutate_binary_operator(op);}
+        void visit(const Sub *op) {mutate_binary_operator(op);}
+        void visit(const Mul *op) {mutate_binary_operator(op);}
+        void visit(const Div *op) {mutate_binary_operator(op);}
+        void visit(const Mod *op) {mutate_binary_operator(op);}
+        void visit(const Min *op) {mutate_binary_operator(op);}
+        void visit(const Max *op) {mutate_binary_operator(op);}
+
+        void visit(const Let *op) {
+            Expr value = mutate(op->value);
+            scope.push(op->name, value);
+            Expr body = mutate(op->body);
+            scope.pop(op->name);
+            if (!value.same_as(op->value) || !body.same_as(op->body)) {
+                expr = Let::make(op->name, value, body);
+            } else {
+                expr = op;
+            }
+        }
+
+        void visit(const LetStmt *op) {
+            Expr value = mutate(op->value);
+            scope.push(op->name, value);
+            Stmt body = mutate(op->body);
+            scope.pop(op->name);
+            if (!value.same_as(op->value) || !body.same_as(op->body)) {
+                stmt = LetStmt::make(op->name, value, body);
+            } else {
+                stmt = op;
+            }
+        }
+
+        void visit(const Ramp *op) {
+            Expr base = mutate(op->base);
+            Expr stride = mutate(op->stride);
+            bool modified = !base.same_as(op->base) || !stride.same_as(op->stride);
+            if (modified) {
+                expr = Ramp::make(upcast(base), upcast(stride), op->width);
+            } else {
+                expr = op;
+            }
+        }
+    public:
+        const string &prefix;
+        UpcastVariables(const string &p) : prefix(p) {}
+    };
+
+    using IRMutator::visit;
+
+    void visit(const Load *op) {
+        UpcastVariables vars(op->name);
+        Expr index = vars.mutate(op->index);
+        expr = Load::make(op->type, op->name, index, op->image, op->param);
+    }
+
+    void visit(const Store *op) {
+        UpcastVariables vars(op->name);
+        Expr index = vars.mutate(op->index);
+        stmt = Store::make(op->name, op->value, index);
+    }
+};
+
+Stmt upcast_buffer_indices(Stmt s) {
+    return UpcastBufferIndices().mutate(s);
+}
+
+}
+}

--- a/src/UpcastBufferIndices.h
+++ b/src/UpcastBufferIndices.h
@@ -1,0 +1,19 @@
+#ifndef HALIDE_UPCAST_BUFFER_INDICES_H
+#define HALIDE_UPCAST_BUFFER_INDICES_H
+
+/** \file
+ * Defines the lowering pass for upcasting buffer indices on 64-bit targets.
+ */
+
+#include "IR.h"
+
+namespace Halide {
+namespace Internal {
+
+/** Upcasts load and store indices to 64 bits. */
+Stmt upcast_buffer_indices(Stmt s);
+
+}
+}
+
+#endif

--- a/test/correctness/input_larger_than_two_gigs.cpp
+++ b/test/correctness/input_larger_than_two_gigs.cpp
@@ -11,31 +11,51 @@ void halide_error(void *ctx, const char *msg) {
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    uint8_t c[4096];
-    memset(c, 42, sizeof(c));
+    Target t = get_target_from_environment();
 
-    buffer_t buf;
-    memset(&buf, 0, sizeof(buf));
-    buf.host = c;
-    buf.extent[0] = 4096;
-    buf.extent[1] = 4096;
-    buf.extent[2] = 256;
-    buf.stride[0] = 1;
-    buf.stride[1] = 0;
-    buf.stride[2] = 0;
-    buf.elem_size = 1;
-
-    Buffer param_buf(UInt(8), &buf);
+    Image<uint8_t> image;
     ImageParam input(UInt(8), 3);
-    input.set(param_buf);
+
+    if (t.bits == 64) {
+        image = Image<uint8_t>(4096, 4096, 256);
+        uint8_t *p = image.data();
+        assert(p);
+        size_t size = (size_t)image.extent(0) * image.extent(1) * image.extent(2);
+        assert(size > 0);
+        memset(p, 1, size);
+        input.set(image);
+    } else {
+        uint8_t c[4096];
+        memset(c, 42, sizeof(c));
+
+        buffer_t buf;
+        memset(&buf, 0, sizeof(buf));
+        buf.host = c;
+        buf.extent[0] = 4096;
+        buf.extent[1] = 4096;
+        buf.extent[2] = 256;
+        buf.stride[0] = 1;
+        buf.stride[1] = 0;
+        buf.stride[2] = 0;
+        buf.elem_size = 1;
+
+        Buffer param_buf(UInt(8), &buf);
+        input.set(param_buf);
+    }
 
     RDom r(0, input.extent(0), 0, input.extent(1), 0, input.extent(2));
+    Var x;
     Func grand_total;
-    grand_total() = cast<uint8_t>(sum(input(r.x, r.y, r.z)));
+    grand_total() = cast<uint64_t>(sum(cast<uint64_t>(input(r.x, r.y, r.z))));
     grand_total.set_error_handler(&halide_error);
 
-    Image<uint8_t> result = grand_total.realize();
+    Image<uint64_t> result = grand_total.realize();
 
-    assert(error_occurred);
+    if (t.bits == 64) {
+        assert(!error_occurred);
+        assert(result(0) == (uint64_t)4096*4096*256);
+    } else {
+        assert(error_occurred);
+    }
     printf("Success!\n");
 }

--- a/test/correctness/output_larger_than_two_gigs.cpp
+++ b/test/correctness/output_larger_than_two_gigs.cpp
@@ -11,29 +11,39 @@ void halide_error(void *ctx, const char *msg) {
 using namespace Halide;
 
 int main(int argc, char **argv) {
+    Target t = get_target_from_environment();
+
     Var x, y, z;
     Func identity_uint8;
     identity_uint8(x, y, z) = cast<uint8_t>(42);
-
-    uint8_t c[4096];
-    memset(c, 42, sizeof(c));
-
-    buffer_t buf;
-    memset(&buf, 0, sizeof(buf));
-    buf.host = c;
-    buf.extent[0] = 4096;
-    buf.extent[1] = 4096;
-    buf.extent[2] = 256;
-    buf.stride[0] = 1;
-    buf.stride[1] = 0;
-    buf.stride[2] = 0;
-    buf.elem_size = 1;
-
     identity_uint8.set_error_handler(&halide_error);
 
-    Buffer output_buf(UInt(8), &buf);
-    identity_uint8.realize(output_buf);
+    if (t.bits == 64) {
+        Image<uint8_t> output(4096, 4096, 256);
+        assert(output.data());
+        identity_uint8.realize(output);
+    } else {
+        uint8_t c[4096];
+        memset(c, 42, sizeof(c));
 
-    assert(error_occurred);
+        buffer_t buf;
+        memset(&buf, 0, sizeof(buf));
+        buf.host = c;
+        buf.extent[0] = 4096;
+        buf.extent[1] = 4096;
+        buf.extent[2] = 256;
+        buf.stride[0] = 1;
+        buf.stride[1] = 0;
+        buf.stride[2] = 0;
+        buf.elem_size = 1;
+        Buffer output_buf(UInt(8), &buf);
+        identity_uint8.realize(output_buf);
+    }
+
+    if (t.bits == 64) {
+        assert(!error_occurred);
+    } else {
+        assert(error_occurred);
+    }
     printf("Success!\n");
 }

--- a/test/correctness/realize_larger_than_two_gigs.cpp
+++ b/test/correctness/realize_larger_than_two_gigs.cpp
@@ -11,6 +11,7 @@ void halide_error(void *ctx, const char *msg) {
 using namespace Halide;
 
 int main(int argc, char **argv) {
+    Target t = get_target_from_environment();
     Param<int> extent;
     Var x, y, z;
     RDom r(0, extent, 0, 4096, 0, 256);
@@ -26,6 +27,10 @@ int main(int argc, char **argv) {
 
     Image<uint8_t> result = grand_total.realize();
 
-    assert(error_occurred);
+    if (t.bits == 64) {
+        assert(!error_occurred);
+    } else {
+        assert(error_occurred);
+    }
     printf("Success!\n");
 }


### PR DESCRIPTION
This PR implements initial support for buffers of size 2^63 - 1 on 64-bit systems. Previously the limit was 2^31 - 1 bytes. The extents of a buffer must still be < 2^31 - 1, but the overall buffer size can now exceed 2GB.

The initial implementation upcasted buffer coordinates to 64 bit integers during storage flattening. This would have required making many changes to following passes and the simplification system. So, the current implementation is as a separate lowering pass that occurs after all other lowering passes.

All internal tests pass, and running `make test_correctness` on my 64-bit system reports all tests pass. However, I don't have access to a 32-bit development environment, so I have not run the correctness tests for 32-bit targets.