### PR TITLE
Added target flags for OpenCL embedded profile

### DIFF
--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -599,7 +599,9 @@ void CodeGen_OpenCL_Dev::init_module() {
 
     if (!target.has_feature(Target::CLEmbedded) || target.has_feature(Target::CLint64)) {
         if (target.has_feature(Target::CLEmbedded)) {
-            src_stream << "#pragma OPENCL EXTENSION cles_khr_int64 : enable\n";
+            src_stream << "#ifdef __EMBEDDED_PROFILE__\n"
+                       << "#pragma OPENCL EXTENSION cles_khr_int64 : enable\n"
+                       << "#endif\n";
         }
         src_stream << smod_def("long") << "\n"
                    << sdiv_def("long") << "\n";

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -535,11 +535,9 @@ void CodeGen_OpenCL_Dev::init_module() {
                << smod_def("char") << "\n"
                << smod_def("short") << "\n"
                << smod_def("int") << "\n"
-               << smod_def("long") << "\n"
                << sdiv_def("char") << "\n"
                << sdiv_def("short") << "\n"
                << sdiv_def("int") << "\n"
-               << sdiv_def("long") << "\n"
                << "#define sqrt_f32 sqrt \n"
                << "#define sin_f32 sin \n"
                << "#define cos_f32 cos \n"
@@ -572,7 +570,7 @@ void CodeGen_OpenCL_Dev::init_module() {
     // __shared always has address space __local.
     src_stream << "#define __address_space___shared __local\n";
 
-    if (target.has_feature(Target::CLDoubles)) {
+    if (target.has_feature(Target::CLfp64)) {
         src_stream << "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n"
                    << "bool is_nan_f64(double x) {return x != x; }\n"
                    << "#define sqrt_f64 sqrt\n"
@@ -597,6 +595,14 @@ void CodeGen_OpenCL_Dev::init_module() {
                    << "#define acosh_f64 acosh\n"
                    << "#define tanh_f64 tanh\n"
                    << "#define atanh_f64 atanh\n";
+    }
+
+    if (!target.has_feature(Target::CLEmbedded) || target.has_feature(Target::CLint64)) {
+        if (target.has_feature(Target::CLEmbedded)) {
+            src_stream << "#pragma OPENCL EXTENSION cles_khr_int64 : enable\n";
+        }
+        src_stream << smod_def("long") << "\n"
+                   << sdiv_def("long") << "\n";
     }
 
     src_stream << '\n';

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -296,8 +296,12 @@ bool Target::merge_string(const std::string &target) {
             set_feature(Target::NoAsserts);
         } else if (tok == "no_bounds_query") {
             set_feature(Target::NoBoundsQuery);
-        } else if (tok == "cl_doubles") {
-            set_feature(Target::CLDoubles);
+        } else if (tok == "cl_embedded") {
+            set_feature(Target::CLEmbedded);
+        } else if (tok == "cl_doubles" || tok == "cl_fp64") {
+            set_feature(Target::CLfp64);
+        } else if (tok == "cl_int64") {
+            set_feature(Target::CLint64);
         } else if (tok == "fma") {
             set_features({Target::FMA, Target::SSE41, Target::AVX});
         } else if (tok == "fma4") {
@@ -366,7 +370,7 @@ std::string Target::to_string() const {
         "sse41", "avx", "avx2", "fma", "fma4", "f16c",
         "armv7s", "no_neon",
         "cuda", "cuda_capability_30", "cuda_capability_32", "cuda_capability_35", "cuda_capability_50",
-        "opencl", "cl_doubles",
+        "opencl", "cl_embedded", "cl_fp64", "cl_int64",
         "opengl", "openglcompute", "renderscript",
         "user_context",
         "register_metadata",

--- a/src/Target.h
+++ b/src/Target.h
@@ -53,7 +53,9 @@ struct Target {
         CUDACapability50,  ///< Enable CUDA compute capability 5.0 (Maxwell)
 
         OpenCL,  ///< Enable the OpenCL runtime.
-        CLDoubles,  ///< Enable double support on OpenCL targets
+        CLEmbedded,  ///< Generate code compatible with the embedded profile of OpenCL.
+        CLfp64,  ///< Enable double support on OpenCL targets
+        CLint64, ///< Enable in64 support on OpenCL embedded targets
 
         OpenGL,  ///< Enable the OpenGL runtime.
         OpenGLCompute, ///< Enable OpenGL Compute runtime.
@@ -159,10 +161,19 @@ struct Target {
     bool supports_type(const Type &t) {
         if (t.bits == 64) {
             if (t.is_float()) {
-                return !has_feature(Metal) &&
-                       (!has_feature(Target::OpenCL) || has_feature(Target::CLDoubles));
+                if (has_feature(Target::Metal)) {
+                    return false;
+                }
+                if (has_feature(Target::OpenCL)) {
+                    return has_feature(Target::CLfp64);
+                }
             } else {
-                return !has_feature(Metal);
+                if (has_feature(Target::Metal)) {
+                    return false;
+                }
+                if (has_feature(Target::OpenCL) && has_feature(Target::CLEmbedded)) {
+                    return has_feature(Target::CLint64);
+                }
             }
         }
         return true;

--- a/src/Target.h
+++ b/src/Target.h
@@ -55,7 +55,7 @@ struct Target {
         OpenCL,  ///< Enable the OpenCL runtime.
         CLEmbedded,  ///< Generate code compatible with the embedded profile of OpenCL.
         CLfp64,  ///< Enable double support on OpenCL targets
-        CLint64, ///< Enable in64 support on OpenCL embedded targets
+        CLint64, ///< Enable int64 support on OpenCL embedded targets
 
         OpenGL,  ///< Enable the OpenGL runtime.
         OpenGLCompute, ///< Enable OpenGL Compute runtime.

--- a/test/correctness/newtons_method.cpp
+++ b/test/correctness/newtons_method.cpp
@@ -12,7 +12,7 @@ int find_pi() {
     // Skip test if data type is not supported by the target.
     Target target = get_jit_target_from_environment();
     if (target.has_feature(Target::OpenCL) &&
-        !target.has_feature(Target::CLDoubles) &&
+        !target.has_feature(Target::CLfp64) &&
         type_of<T>() == type_of<double>()) {
         return 0;
     }


### PR DESCRIPTION
This CL adds/changes a few target flags:

- CLEmbedded: generate code compatible with the OpenCL embedded profile
- CLint64: When generating embedded profile compatible code, enable the cles_khr_int64 extension
- CLDoubles is deprecated, CLfp64 is the new name (for consistency with CLint64). It still has the same functionality as before.