### PR TITLE
Change target string parsing and printing to use maps from string to numeric value.

### DIFF
--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -254,14 +254,14 @@ Target parse_target_string(const std::string &target) {
     if (!t.merge_string(target)) {
         const char *separator = "";
         std::string architectures;
-        for (auto arch_iter = arch_name_map.begin(); arch_iter != arch_name_map.end(); arch_iter++) {
-            architectures += separator + arch_iter->first;
+        for (auto const &arch_entry : arch_name_map) {
+            architectures += separator + arch_entry.first;
             separator = ", ";
         }
         separator = "";
         std::string oses;
-        for (auto os_iter = os_name_map.begin(); os_iter != os_name_map.end(); os_iter++) {
-            oses += separator + os_iter->first;
+        for (auto os_entry : os_name_map) {
+            oses += separator + os_entry.first;
             separator = ", ";
         }
         separator = "";
@@ -269,8 +269,8 @@ Target parse_target_string(const std::string &target) {
         // assume the first line starts with "Features are ".
         int line_char_start = -(int)sizeof("Features are");
         std::string features;
-        for (auto feature_iter = feature_name_map.begin(); feature_iter != feature_name_map.end(); feature_iter++) {
-            features += separator + feature_iter->first;
+        for (auto feature_entry : feature_name_map) {
+            features += separator + feature_entry.first;
             if (features.length() - line_char_start > 70) {
                 separator = "\n";
                 line_char_start = features.length();

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -132,7 +132,84 @@ string get_env(const char *name) {
     }
 #endif
 }
+
+const std::map<std::string, Target::OS> os_name_map = {
+    {"os_unknown", Target::OSUnknown},
+    {"linux", Target::Linux},
+    {"windows", Target::Windows},
+    {"osx", Target::OSX},
+    {"android", Target::Android},
+    {"ios", Target::IOS},
+    {"nacl", Target::NaCl},
+};
+
+bool lookup_os(const std::string &tok, Target::OS &result) {
+    auto os_iter = os_name_map.find(tok);
+    if (os_iter != os_name_map.end()) {
+        result = os_iter->second;
+        return true;
+    }
+    return false;
 }
+
+const std::map<std::string, Target::Arch> arch_name_map = {
+    {"arch_unknown", Target::ArchUnknown},
+    {"x86", Target::X86},
+    {"arm", Target::ARM},
+    {"pnacl", Target::PNaCl},
+    {"mips", Target::MIPS},
+};
+
+bool lookup_arch(const std::string &tok, Target::Arch &result) {
+    auto arch_iter = arch_name_map.find(tok);
+    if (arch_iter != arch_name_map.end()) {
+        result = arch_iter->second;
+        return true;
+    }
+    return false;
+}
+
+const std::map<std::string, Target::Feature> feature_name_map = {
+    {"jit", Target::JIT},
+    {"debug", Target::Debug},
+    {"no_asserts", Target::NoAsserts},
+    {"no_bounds_query", Target::NoBoundsQuery},
+    {"sse41", Target::SSE41},
+    {"avx", Target::AVX},
+    {"avx2", Target::AVX2},
+    {"fma", Target::FMA},
+    {"fma4", Target::FMA4},
+    {"f16c", Target::F16C},
+    {"armv7s", Target::ARMv7s},
+    {"no_neon", Target::NoNEON},
+    {"cuda", Target::CUDA},
+    {"cuda_capability_30", Target::CUDACapability30},
+    {"cuda_capability_32", Target::CUDACapability32},
+    {"cuda_capability_35", Target::CUDACapability35},
+    {"cuda_capability_50", Target::CUDACapability50},
+    {"opencl", Target::OpenCL},
+    {"cl_doubles", Target::CLDoubles},
+    {"opengl", Target::OpenGL},
+    {"openglcompute", Target::OpenGLCompute},
+    {"renderscript", Target::Renderscript},
+    {"user_context", Target::UserContext},
+    {"register_metadata", Target::RegisterMetadata},
+    {"matlab", Target::Matlab},
+    {"profile", Target::Profile},
+    {"no_runtime", Target::NoRuntime},
+    {"metal", Target::Metal},
+};
+
+bool lookup_feature(const std::string &tok, Target::Feature &result) {
+    auto feature_iter = feature_name_map.find(tok);
+    if (feature_iter != feature_name_map.end()) {
+        result = feature_iter->second;
+        return true;
+    }
+    return false;
+}
+
+} // End anonymous namespace
 
 Target get_target_from_environment() {
     string target = get_env("HL_TARGET");
@@ -175,13 +252,38 @@ Target parse_target_string(const std::string &target) {
     t.bits = host.bits;
 
     if (!t.merge_string(target)) {
+        const char *separator = "";
+        std::string architectures;
+        for (auto arch_iter = arch_name_map.begin(); arch_iter != arch_name_map.end(); arch_iter++) {
+            architectures += separator + arch_iter->first;
+            separator = ", ";
+        }
+        separator = "";
+        std::string oses;
+        for (auto os_iter = os_name_map.begin(); os_iter != os_name_map.end(); os_iter++) {
+            oses += separator + os_iter->first;
+            separator = ", ";
+        }
+        separator = "";
+        // Format the features to go one feature over 70 characters per line,
+        // assume the first line starts with "Features are ".
+        int line_char_start = -(int)sizeof("Features are");
+        std::string features;
+        for (auto feature_iter = feature_name_map.begin(); feature_iter != feature_name_map.end(); feature_iter++) {
+            features += separator + feature_iter->first;
+            if (features.length() - line_char_start > 70) {
+                separator = "\n";
+                line_char_start = features.length();
+            } else {
+                separator = ", ";
+            }
+        }
         user_error << "Did not understand HL_TARGET=" << target << "\n"
-                   << "Expected format is arch-os-feature1-feature2-... "
-                   << "Where arch is x86-32, x86-64, arm-32, arm-64, pnacl, mips"
-                   << "and os is linux, windows, osx, nacl, ios, or android. "
-                   << "If arch or os are omitted, they default to the host. "
-                   << "Features include sse41, avx, avx2, armv7s, cuda, "
-                   << "opencl, metal, no_asserts, no_bounds_query, and debug.\n"
+                   << "Expected format is arch-os-feature1-feature2-...\n"
+                   << "Where arch is " << architectures << " .\n"
+                   << "Os is " << oses << " .\n"
+                   << "If arch or os are omitted, they default to the host.\n"
+                   << "Features are " << features << " .\n"
                    << "HL_TARGET can also begin with \"host\", which sets the "
                    << "host's architecture, os, and feature set, with the "
                    << "exception of the GPU runtimes, which default to off.\n"
@@ -205,134 +307,35 @@ bool Target::merge_string(const std::string &target) {
     bool os_specified = false, arch_specified = false, bits_specified = false;
 
     for (size_t i = 0; i < tokens.size(); i++) {
-        bool is_arch = false, is_os = false, is_bits = false;
         const string &tok = tokens[i];
-        if (tok == "x86") {
-            arch = Target::X86;
-            is_arch = true;
-        } else if (tok == "arm") {
-            arch = Target::ARM;
-            is_arch = true;
-        } else if (tok == "pnacl") {
-            arch = Target::PNaCl;
-            is_arch = true;
-        } else if (tok == "mips") {
-            arch = Target::MIPS;
-            is_arch = true;
-        } else if (tok == "32") {
-            bits = 32;
-            is_bits = true;
-        } else if (tok == "64") {
-            bits = 64;
-            is_bits = true;
-        } else if (tok == "linux") {
-            os = Target::Linux;
-            is_os = true;
-        } else if (tok == "windows") {
-            os = Target::Windows;
-            is_os = true;
-        } else if (tok == "nacl") {
-            os = Target::NaCl;
-            is_os = true;
-        } else if (tok == "osx") {
-            os = Target::OSX;
-            is_os = true;
-        } else if (tok == "android") {
-            os = Target::Android;
-            is_os = true;
-        } else if (tok == "ios") {
-            os = Target::IOS;
-            is_os = true;
-        } else if (tok == "host") {
+        Target::Feature feature;
+
+        if (tok == "host") {
             if (i > 0) {
                 // "host" is now only allowed as the first token.
                 return false;
             }
             *this = get_host_target();
-            is_os = true;
-            is_arch = true;
-            is_bits = true;
-        } else if (tok == "jit") {
-            set_feature(Target::JIT);
-        } else if (tok == "sse41") {
-            set_feature(Target::SSE41);
-        } else if (tok == "avx") {
-            set_features({Target::SSE41, Target::AVX});
-        } else if (tok == "avx2") {
-            set_features({Target::SSE41, Target::AVX, Target::AVX2});
-        } else if (tok == "armv7s") {
-            set_feature(Target::ARMv7s);
-        } else if (tok == "no_neon") {
-            set_feature(Target::NoNEON);
-        } else if (tok == "cuda") {
-            set_feature(Target::CUDA);
-        } else if (tok == "ptx") {
-            user_error << "The 'ptx' target feature flag is deprecated, use 'cuda' instead\n";
-        } else if (tok == "cuda_capability_30") {
-            set_features({Target::CUDA, Target::CUDACapability30});
-        } else if (tok == "cuda_capability_32") {
-            set_features({Target::CUDA, Target::CUDACapability32});
-        } else if (tok == "cuda_capability_35") {
-            set_features({Target::CUDA, Target::CUDACapability35});
-        } else if (tok == "cuda_capability_50") {
-            set_features({Target::CUDA, Target::CUDACapability50});
-        } else if (tok == "opencl") {
-            set_feature(Target::OpenCL);
-        } else if (tok == "metal") {
-            set_feature(Target::Metal);
-        } else if (tok == "debug" || tok == "gpu_debug") {
-            set_feature(Target::Debug);
-        } else if (tok == "opengl") {
-            set_feature(Target::OpenGL);
-        } else if (tok == "openglcompute") {
-            set_feature(Target::OpenGLCompute);
-        } else if (tok == "renderscript") {
-            set_feature(Target::Renderscript);
-        } else if (tok == "user_context") {
-            set_feature(Target::UserContext);
-        } else if (tok == "register_metadata") {
-            set_feature(Target::RegisterMetadata);
-        } else if (tok == "no_asserts") {
-            set_feature(Target::NoAsserts);
-        } else if (tok == "no_bounds_query") {
-            set_feature(Target::NoBoundsQuery);
-        } else if (tok == "cl_doubles") {
-            set_feature(Target::CLDoubles);
-        } else if (tok == "fma") {
-            set_features({Target::FMA, Target::SSE41, Target::AVX});
-        } else if (tok == "fma4") {
-            set_features({Target::FMA4, Target::SSE41, Target::AVX});
-        } else if (tok == "f16c") {
-            set_features({Target::F16C, Target::SSE41, Target::AVX});
-        } else if (tok == "matlab") {
-            set_feature(Target::Matlab);
-        } else if (tok == "profile") {
-            set_feature(Target::Profile);
-        } else if (tok == "no_runtime") {
-            set_feature(Target::NoRuntime);
-        } else {
-            return false;
-        }
-
-        if (is_os) {
-            if (os_specified) {
-                return false;
-            }
-            os_specified = true;
-        }
-
-        if (is_arch) {
-            if (arch_specified) {
-                return false;
-            }
-            arch_specified = true;
-        }
-
-        if (is_bits) {
+        } else if (tok == "32" || tok == "64") {
             if (bits_specified) {
                 return false;
             }
             bits_specified = true;
+            bits = std::stoi(tok);
+        } else if (lookup_arch(tok, arch)) {
+            if (arch_specified) {
+                return false;
+            }
+            arch_specified = true;
+        } else if (lookup_os(tok, os)) {
+            if (os_specified) {
+                return false;
+            }
+            os_specified = true;
+        } else if (lookup_feature(tok, feature)) {
+            set_feature(feature);
+        } else {
+            return false;
         }
     }
 
@@ -354,37 +357,42 @@ bool Target::merge_string(const std::string &target) {
 }
 
 std::string Target::to_string() const {
-    const char* const arch_names[] = {
-        "arch_unknown", "x86", "arm", "pnacl", "mips"
-    };
-    const char* const os_names[] = {
-        "os_unknown", "linux", "windows", "osx", "android", "ios", "nacl"
-    };
-    // The contents of this array must match Target::Features.
-    const char* const feature_names[] = {
-        "jit", "debug", "no_asserts", "no_bounds_query",
-        "sse41", "avx", "avx2", "fma", "fma4", "f16c",
-        "armv7s", "no_neon",
-        "cuda", "cuda_capability_30", "cuda_capability_32", "cuda_capability_35", "cuda_capability_50",
-        "opencl", "cl_doubles",
-        "opengl", "openglcompute", "renderscript",
-        "user_context",
-        "register_metadata",
-        "matlab",
-        "profile",
-        "no_runtime",
-        "metal"
-    };
-    internal_assert(sizeof(feature_names) / sizeof(feature_names[0]) == FeatureEnd);
-    string result = string(arch_names[arch])
-        + "-" + std::to_string(bits)
-        + "-" + string(os_names[os]);
-    for (size_t i = 0; i < FeatureEnd; ++i) {
-        if (has_feature(static_cast<Feature>(i))) {
-            result += "-" + string(feature_names[i]);
+    string result;
+    for (auto const &arch_entry : arch_name_map) {
+        if (arch_entry.second == arch) {
+            result += arch_entry.first;
+            break;
+        }
+    }
+    result += "-" + std::to_string(bits);
+    for (auto const &os_entry : os_name_map) {
+        if (os_entry.second == os) {
+            result += "-" + os_entry.first;
+            break;
+        }
+    }
+    for (auto const &feature_entry : feature_name_map) {
+        if (has_feature(feature_entry.second)) {
+            result += "-" + feature_entry.first;
         }
     }
     return result;
+}
+
+namespace Internal{ 
+
+EXPORT void target_test() {
+    Target t;
+    for (auto const &feature : feature_name_map) {
+        t.set_feature(feature.second);
+    }
+    for (int i = 0; i < (int)(Target::FeatureEnd); i++) {
+        internal_assert(t.has_feature((Target::Feature)i)) << "Feature " << i << " not in feature_names_map.\n";
+    }
+    std::cout << "Target test passed" << std::endl;
+}
+
+
 }
 
 }

--- a/src/Target.h
+++ b/src/Target.h
@@ -18,18 +18,22 @@ namespace Halide {
 /** A struct representing a target machine and os to generate code for. */
 struct Target {
     /** The operating system used by the target. Determines which
-     * system calls to generate. */
+     * system calls to generate.
+     * Corresponds to os_name_map in Target.cpp. */
     enum OS {OSUnknown = 0, Linux, Windows, OSX, Android, IOS, NaCl} os;
 
     /** The architecture used by the target. Determines the
      * instruction set to use. For the PNaCl target, the "instruction
-     * set" is actually llvm bitcode. */
+     * set" is actually llvm bitcode.
+     * Corresponds to arch_name_map in Target.cpp. */
     enum Arch {ArchUnknown = 0, X86, ARM, PNaCl, MIPS} arch;
 
     /** The bit-width of the target machine. Must be 0 for unknown, or 32 or 64. */
     int bits;
 
-    /** Optional features a target can have. */
+    /** Optional features a target can have.
+     * Corresponds to feature_name_map in Target.cpp. */
+
     enum Feature {
         JIT,  ///< Generate code that will run immediately inside the calling process.
         Debug,  ///< Turn on debug info and output for runtime code.
@@ -72,8 +76,6 @@ struct Target {
         Metal, ///< Enable the (Apple) Metal runtime.
 
         FeatureEnd
-        // NOTE: Changes to this enum must be reflected in the definition of
-        // to_string()!
     };
 
     Target() : os(OSUnknown), arch(ArchUnknown), bits(0) {}
@@ -273,6 +275,12 @@ EXPORT Target get_jit_target_from_environment();
  * will be used instead. An empty string is exactly equivalent to get_host_target().
  */
 EXPORT Target parse_target_string(const std::string &target);
+
+namespace Internal {
+
+EXPORT void target_test();
+
+}
 
 }
 

--- a/test/correctness/target.cpp
+++ b/test/correctness/target.cpp
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
                  Target::CUDA, Target::OpenCL, Target::OpenGL, Target::OpenGLCompute, Target::Renderscript,
                  Target::Debug});
     ts = t1.to_string();
-    if (ts != "arm-32-android-jit-debug-sse41-avx-avx2-cuda-opencl-opengl-openglcompute-renderscript") {
+    if (ts != "arm-32-android-avx-avx2-cuda-debug-jit-opencl-opengl-openglcompute-renderscript-sse41") {
        printf("to_string failure: %s\n", ts.c_str());
        return -1;
     }
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
        return -1;
     }
     // expect 32 (not 64), and both sse41 and opencl
-    if (t2.to_string() != "x86-32-linux-sse41-opencl") {
+    if (t2.to_string() != "x86-32-linux-opencl-sse41") {
        printf("merge_string: %s\n", t2.to_string().c_str());
        return -1;
     }

--- a/test/internal.cpp
+++ b/test/internal.cpp
@@ -28,6 +28,7 @@ int main(int argc, const char **argv) {
     cse_test();
     simplify_test();
     solve_test();
+    target_test();
 
     return 0;
 }


### PR DESCRIPTION
This reduces the number of places information must be
edited when adding a target feature/arch/OS, and ensures the usage error
message reflects the actual target specification language.