### PR TITLE
Add interleave_vectors for OpenCL codegen

### DIFF
--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -214,6 +214,7 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Call *op) {
             // 3+ arguments, interleave via a vector literal
             // selecting the appropriate elements of the args
             int dest_width = op->type.width;
+            internal_assert(dest_width <= 16);
             int num_args = op->args.size();
             vector<string> arg_exprs(num_args);
             for (int i = 0; i < num_args; i++) {
@@ -225,8 +226,7 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Call *op) {
             do_indent();
             stream << print_type(op->type) << " " << id << ".s";
             for (int i = 0; i < dest_width; i++) {
-                char c = i < 10 ? '0' + i : 'a' + (i - 10);
-                stream << c;
+                stream << vector_elements[i];
             }
             stream << " = (" << print_type(op->type) << ")(";
             for (int i = 0; i < dest_width; i++) {

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -224,17 +224,13 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Call *op) {
             internal_assert(num_args * arg_width >= dest_width);
             id = unique_name('_');
             do_indent();
-            stream << print_type(op->type) << " " << id << ".s";
-            for (int i = 0; i < dest_width; i++) {
-                stream << vector_elements[i];
-            }
+            stream << print_type(op->type) << " " << id;
             stream << " = (" << print_type(op->type) << ")(";
             for (int i = 0; i < dest_width; i++) {
                 int arg = i % num_args;
                 int arg_idx = i / num_args;
                 internal_assert(arg_idx <= arg_width);
-                char arg_idxc = '0' + arg_idx;
-                stream << arg_exprs[arg] << ".s" << arg_idxc;
+                stream << arg_exprs[arg] << ".s" << vector_elements[arg_idx];
                 if (i != dest_width - 1) {
                     stream << ", ";
                 }

--- a/src/CodeGen_OpenCL_Dev.h
+++ b/src/CodeGen_OpenCL_Dev.h
@@ -61,6 +61,7 @@ protected:
         void visit(const For *);
         void visit(const Ramp *op);
         void visit(const Broadcast *op);
+        void visit(const Call *op);
         void visit(const Load *op);
         void visit(const Store *op);
         void visit(const Cast *op);


### PR DESCRIPTION
Based off of pull request #949, this adds support for the interleave_vectors intrinsic in OpenCL code generation. It also fixes in issue where vector variables did not have a leading underscore, causing compilation to fail in kernels that did vector loads.