### PR TITLE
Properly release context in CUDA runtime

### DIFF
--- a/src/runtime/cuda.cpp
+++ b/src/runtime/cuda.cpp
@@ -299,6 +299,14 @@ WEAK CUresult create_cuda_context(void *user_context, CUcontext *ctx) {
         cuCtxGetApiVersion(*ctx, &version);
         debug(user_context) << *ctx << "(" << version << ")\n";
     }
+    // Creation automatically pushes the context, but we'll pop to allow the caller
+    // to decide when to push.
+    err = cuCtxPopCurrent(&context);
+    if (err != CUDA_SUCCESS) {
+      error(user_context) << "CUDA: cuCtxPopCurrent failed: "
+                          << get_error_name(err);
+      return err;
+    }
 
     return CUDA_SUCCESS;
 }


### PR DESCRIPTION
The CUDA runtime uses `cuCxtPushCurrent` and `cuCtxPopCurrent` to manage its own CUDA context. The context is created with `cuCtxCreate` (https://github.com/halide/Halide/blob/master/src/runtime/cuda.cpp#L291) in `create_cuda_context` when needed.

However, creation automatically pushes the context (see https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#context, esp. Figure 19), while the runtime also pushes unconditionally (https://github.com/halide/Halide/blob/master/src/runtime/cuda.cpp#L152). The result is that the context gets pushed twice, and the final pop (https://github.com/halide/Halide/blob/master/src/runtime/cuda.cpp#L157) leaves it on the stack.

This isn't noticeable if you're only running CUDA code from Halide, since the correct context will always be active when launching kernels. If you call Halide from an application with other CUDA code, however (e.g., using cuBLAS), this will cause a crash, since code called after invoking Halide will try to use Halide's context.

This patch fixes the issue by adding a pop after (the only) call to `create_cuda_context`. This way `create_cuda_context` maintains the push semantics of `cuCtxCreate`. (Alternatively, the pop could be added to `create_cuda_context` itself, which would gain the (originally intended?) semantics of create-but-don't-push.)