### PR TITLE
Fix overflow in normalization of shifts to divisions

### DIFF
--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -2670,7 +2670,7 @@ private:
                     ib = -ib;
                 }
 
-                if (ib >= 0 && ib < std::min(t.bits, 64)) {
+                if (ib >= 0 && ib < std::min(t.bits, 64) - 1) {
                     ib = 1LL << ib;
                     b = make_const(t, ib);
 


### PR DESCRIPTION
Don't normalize x >> 31 to x / (1 << 31). It overflows.

Fixes #975