### PR TITLE
Added FFTW benchmark

### DIFF
--- a/apps/fft/Makefile
+++ b/apps/fft/Makefile
@@ -4,6 +4,11 @@ CXXFLAGS += -g -Wall
 
 .PHONY: clean
 
+ifeq ($(WITH_FFTW),1)
+CXXFLAGS += -DWITH_FFTW
+LDFLAGS += -lfftw3f
+endif
+
 bench_fft: main.cpp fft.cpp fft.h complex.h funct.h
 	$(CXX) $(CXXFLAGS) main.cpp fft.cpp $(LIB_HALIDE) -o bench_fft -lpthread -ldl -lz \
 	$(LDFLAGS) $(LLVM_SHARED_LIBS)

--- a/apps/fft/main.cpp
+++ b/apps/fft/main.cpp
@@ -9,6 +9,10 @@
 #include "fft.h"
 #include "benchmark.h"
 
+#ifdef WITH_FFTW
+#include <fftw3.h>
+#endif
+
 using namespace Halide;
 
 Var x("x"), y("y");
@@ -136,6 +140,9 @@ int main(int argc, char **argv) {
     Image<float> re_in = lambda(x, y, 0.0f).realize(W, H);
     Image<float> im_in = lambda(x, y, 0.0f).realize(W, H);
 
+    printf("%12s %5s%11s%5s %5s%11s%5s\n", "", "", "Halide", "", "", "FFTW", "");
+    printf("%12s %10s %10s %10s %10s %10s\n", "DFT type", "Time (us)", "MFLOP/s", "Time (us)", "MFLOP/s", "Ratio");
+
     ComplexFunc c2c_in;
     // Read all reps from the same place in memory. This effectively
     // benchmarks taking the FFT of cached inputs, which is a
@@ -153,8 +160,22 @@ int main(int argc, char **argv) {
     R_c2c[0].raw_buffer()->stride[2] = 0;
     R_c2c[1].raw_buffer()->stride[2] = 0;
 
-    double t = benchmark(samples, 1, [&]() { bench_c2c.realize(R_c2c); })*1e6/reps;
-    printf("c2c  time: %f us, %f MFLOP/s\n", t, 5*W*H*(log2(W) + log2(H))/t);
+    double halide_t = benchmark(samples, 1, [&]() { bench_c2c.realize(R_c2c); })*1e6/reps;
+#ifdef WITH_FFTW
+    std::vector<std::pair<float, float>> fftw_c1(W * H);
+    std::vector<std::pair<float, float>> fftw_c2(W * H);
+    fftwf_plan c2c_plan = fftwf_plan_dft_2d(W, H, (fftwf_complex*)&fftw_c1[0], (fftwf_complex*)&fftw_c2[0], FFTW_FORWARD, FFTW_EXHAUSTIVE);
+    double fftw_t = benchmark(samples, reps, [&]() { fftwf_execute(c2c_plan); })*1e6;
+#else
+    double fftw_t = 0;
+#endif
+    printf("%12s %10.3f %10.2f %10.3f %10.2f %10.3g\n", 
+           "c2c",
+           halide_t,
+           5*W*H*(log2(W) + log2(H))/halide_t,
+           fftw_t,
+           5*W*H*(log2(W) + log2(H))/fftw_t,
+           fftw_t / halide_t);
 
     Func r2c_in;
     // All reps read from the same input. See notes on c2c_in.
@@ -166,8 +187,21 @@ int main(int argc, char **argv) {
     R_r2c[0].raw_buffer()->stride[2] = 0;
     R_r2c[1].raw_buffer()->stride[2] = 0;
 
-    t = benchmark(samples, 1, [&]() { bench_r2c.realize(R_r2c); })*1e6/reps;
-    printf("r2c time: %f us, %f MFLOP/s\n", t, 2.5*W*H*(log2(W) + log2(H))/t);
+    halide_t = benchmark(samples, 1, [&]() { bench_r2c.realize(R_r2c); })*1e6/reps;
+#ifdef WITH_FFTW
+    std::vector<float> fftw_r(W * H);
+    fftwf_plan r2c_plan = fftwf_plan_dft_r2c_2d(W, H, &fftw_r[0], (fftwf_complex*)&fftw_c1[0], FFTW_EXHAUSTIVE);
+    fftw_t = benchmark(samples, reps, [&]() { fftwf_execute(r2c_plan); })*1e6;
+#else
+    fftw_t = 0;
+#endif
+    printf("%12s %10.3f %10.2f %10.3f %10.2f %10.3g\n", 
+           "r2c",
+           halide_t,
+           2.5*W*H*(log2(W) + log2(H))/halide_t,
+           fftw_t,
+           2.5*W*H*(log2(W) + log2(H))/fftw_t,
+           fftw_t / halide_t);
 
     ComplexFunc c2r_in;
     // All reps read from the same input. See notes on c2c_in.
@@ -178,8 +212,26 @@ int main(int argc, char **argv) {
     // Write all reps to the same place in memory. See notes on R_c2c.
     R_c2r[0].raw_buffer()->stride[2] = 0;
 
-    t = benchmark(samples, 1, [&]() { bench_c2r.realize(R_c2r); })*1e6/reps;
-    printf("c2r time: %f us, %f MFLOP/s\n", t, 2.5*W*H*(log2(W) + log2(H))/t);
+    halide_t = benchmark(samples, 1, [&]() { bench_c2r.realize(R_c2r); })*1e6/reps;
+#ifdef WITH_FFTW
+    fftwf_plan c2r_plan = fftwf_plan_dft_c2r_2d(W, H, (fftwf_complex*)&fftw_c1[0], &fftw_r[0], FFTW_EXHAUSTIVE);
+    fftw_t = benchmark(samples, reps, [&]() { fftwf_execute(c2r_plan); })*1e6;
+#else
+    fftw_t = 0;
+#endif
+    printf("%12s %10.3f %10.2f %10.3f %10.2f %10.3g\n", 
+           "c2r",
+           halide_t,
+           2.5*W*H*(log2(W) + log2(H))/halide_t,
+           fftw_t,
+           2.5*W*H*(log2(W) + log2(H))/fftw_t,
+           fftw_t / halide_t);
+
+#ifdef WITH_FFTW
+    fftwf_destroy_plan(c2c_plan);
+    fftwf_destroy_plan(r2c_plan);
+    fftwf_destroy_plan(c2r_plan);
+#endif
 
     return 0;
 }


### PR DESCRIPTION
This PR adds a benchmark of FFTW along side the Halide FFT. This makes it much easier to compare performance with a known gold standard. Here is the current output using FFTW 3.3.4, on a Haswell x86 CPU using a single core:

WITH_FFTW=1 make bench_16x16 bench_32x32 bench_48x48 bench_64x64
```
./bench_fft 16 16
                       Halide                  FFTW     
    DFT type  Time (us)    MFLOP/s  Time (us)    MFLOP/s      Ratio
         c2c      0.367   27901.91      0.417   24556.35       1.14
         r2c      0.288   17777.78      0.444   11531.53       1.54
         c2r      0.359   14261.84      0.455   11252.75       1.27

./bench_fft 32 32
                       Halide                  FFTW     
    DFT type  Time (us)    MFLOP/s  Time (us)    MFLOP/s      Ratio
         c2c      1.821   28116.42      1.944   26337.45       1.07
         r2c      1.175   21787.23      2.168   11808.12       1.85
         c2r      1.307   19586.84      2.099   12196.28       1.61

./bench_fft 48 48
                       Halide                  FFTW     
    DFT type  Time (us)    MFLOP/s  Time (us)    MFLOP/s      Ratio
         c2c      6.605   19481.84      7.153   17989.31       1.08
         r2c      3.873   16612.13      6.205   10368.86        1.6
         c2r      4.270   15067.63      6.429   10007.59       1.51

./bench_fft 64 64
                       Halide                  FFTW     
    DFT type  Time (us)    MFLOP/s  Time (us)    MFLOP/s      Ratio
         c2c     13.319   18451.84      9.870   24899.70      0.741
         r2c      7.990   15379.22      9.439   13018.33       1.18
         c2r     14.444    8507.34      8.715   14099.83      0.603
```
I verified that the FFTW benchmark numbers match what FFTW's provided benchmarking utility produce.

As you can see, we perform well up until 64x64 FFTs, at which point I believe it would be better to do FFTs one at a time and vectorize within each FFT, instead of vectorizing across columns of FFTs. This strategy isn't implemented yet in the Halide FFT.