### PR TITLE
Add ability to revert a Func's schedule to a pristine default state

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1160,6 +1160,12 @@ Func &Func::trace_realizations() {
     return *this;
 }
 
+Func &Func::reset_schedule() {
+    invalidate_cache();
+    func.reset_schedule();
+    return *this;
+}
+
 void Func::debug_to_file(const string &filename) {
     invalidate_cache();
     func.debug_file() = filename;

--- a/src/Func.h
+++ b/src/Func.h
@@ -1498,6 +1498,11 @@ public:
      * halide_trace. */
     EXPORT Func &trace_realizations();
 
+    /** Reset the schedule on this Func to the default. Undoes all
+     * calls to compute_at, store_at, vectorize, reorder, split,
+     * bound, specialize, etc. */
+    EXPORT Func &reset_schedule();
+
     /** Get a handle on the internal halide function that this Func
      * represents. Useful if you want to do introspection on Halide
      * functions */

--- a/src/Function.h
+++ b/src/Function.h
@@ -52,7 +52,7 @@ namespace Internal {
 
 struct UpdateDefinition {
     std::vector<Expr> values, args;
-    Schedule schedule;
+    Schedule schedule, default_schedule;
     ReductionDomain domain;
 };
 
@@ -135,6 +135,10 @@ public:
 
     /** Get a const handle to the schedule for inspecting it */
     EXPORT const Schedule &schedule() const;
+
+    /** Revert the schedule for all stages of this Function to its
+     * default initial state. */
+    EXPORT void reset_schedule();
 
     /** Get a handle on the output buffer used for setting constraints
      * on it. */

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -122,14 +122,12 @@ bool Pipeline::defined() const {
 }
 
 Pipeline::Pipeline(Func output) : contents(new PipelineContents) {
-    output.compute_root().store_root();
     output.function().freeze();
     contents.ptr->outputs.push_back(output.function());
 }
 
 Pipeline::Pipeline(const vector<Func> &outputs) : contents(new PipelineContents) {
     for (Func f: outputs) {
-        f.compute_root().store_root();
         f.function().freeze();
         contents.ptr->outputs.push_back(f.function());
     }

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -114,6 +114,11 @@ public:
     Schedule(const Schedule &other) : contents(other.contents) {}
     EXPORT Schedule();
 
+    /** Make a deep copy of this schedule (The regular copy
+     * constructor just makes a new reference to the same
+     * schedule). */
+    EXPORT Schedule copy() const;
+
     /** This flag is set to true if the schedule is memoized. */
     // @{
     bool &memoized();

--- a/test/correctness/reset_schedule.cpp
+++ b/test/correctness/reset_schedule.cpp
@@ -1,0 +1,37 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+
+
+int main(int argc, char **argv) {
+    Func f;
+    Var x;
+    f(x) = x+3;
+
+    Var xo, xi;
+
+    f.vectorize(x, 8);
+    Image<int> v1 = f.realize(100);
+
+    // We can't double-vectorize, so if the schedule wasn't getting reset, this would be an error.
+    f.reset_schedule();
+    f.split(x, xo, xi, 4).vectorize(xi);
+    Image<int> v2 = f.realize(100);
+
+    // If we don't reset the schedule, x would no longer exist, so this would be invalid.
+    f.reset_schedule();
+    f.unroll(x, 4);
+    Image<int> v3 = f.realize(100);
+
+    RDom r(0, 100);
+    uint32_t err = evaluate<uint32_t>(sum(abs(v1(r) - v2(r)) + abs(v1(r) - v3(r))));
+    if (err) {
+        printf("Error: the three methods returned different results\n");
+        return -1;
+    }
+
+    printf("Success!\n");
+    return 0;
+
+}


### PR DESCRIPTION
Resetting the schedule on a Func and repeatedly rescheduling and recompiling it is probably a bad idea when compared to a parameterized build method (or generator params). The motivation for this PR is that Fredo asked for this functionality to use in teaching Halide, and the auto scheduling work by Tyler had a hacky way to do the same thing, so it does come up in reasonable usage.

One catch is that if you're jitting, and you reschedule an intermediate pipeline stage, then the output func has no way of knowing that happened, so it'll incorrectly reuse cached code if you don't do something to invalidate the jit compilation cache on the output Func. Then again, the same problem exists now for all scheduling directives, not just reset_schedule, but reset_schedule encourages people to change a schedule after compiling and running stuff. Maybe a schedule object should contain an integer that increments on every scheduling call, and compile_jit should hash these to see if it needs to rejit...

I think I need to do that, and it's not a good idea to merge this PR without that. I'll open it anyway to see if people agree (or think this feature is evil and shouldn't be added in the first place).

Some of the code is because we used to compute_root any Func that you realize (or similar). That didn't work quite right with schedule resetting, so I instead made lowering treat outputs as if they were compute_root without explicitly marking them as such.
