### PR TITLE
Add operator and cast support for GeneratorParam.

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -330,103 +330,103 @@ private:
     }
 };
 
-/** Addition between GeneratorParam and arithmetic/enum types.
- * Returns arithmetic type. */
+/** Addition between GeneratorParam<T> and any type that supports operator+ with T.
+ * Returns type of underlying operator+. */
 // @{
-template <typename T1, typename T2>
-decltype((T1)0 + (T2)0) operator+(T1 a, const GeneratorParam<T2> &b) { return a + (T2)b; }
-template <typename T1, typename T2>
-decltype((T2)0 + (T1)0) operator+(const GeneratorParam<T2> &a, T1 b) { return (T2)a + b; }
+template <typename Other, typename T>
+decltype((Other)0 + (T)0) operator+(Other a, const GeneratorParam<T> &b) { return a + (T)b; }
+template <typename Other, typename T>
+decltype((T)0 + (Other)0) operator+(const GeneratorParam<T> &a, Other b) { return (T)a + b; }
 // @}
 
-/** Subtraction between GeneratorParam and arithmetic/enum types.
- * Returns arithmetic type. */
+/** Subtraction between GeneratorParam<T> and any type that supports operator- with T.
+ * Returns type of underlying operator-. */
 // @{
-template <typename T1, typename T2>
-decltype((T1)0 - (T2)0) operator-(T1 a, const GeneratorParam<T2> &b) { return a - (T2)b; }
-template <typename T1, typename T2>
-decltype((T2)0 - (T1)0)  operator-(const GeneratorParam<T2> &a, T1 b) { return (T2)a - b; }
+template <typename Other, typename T>
+decltype((Other)0 - (T)0) operator-(Other a, const GeneratorParam<T> &b) { return a - (T)b; }
+template <typename Other, typename T>
+decltype((T)0 - (Other)0)  operator-(const GeneratorParam<T> &a, Other b) { return (T)a - b; }
 // @}
 
-/** Multiplication between GeneratorParam and arithmetic/enum types.
- * Returns arithmetic type. */
+/** Multiplication between GeneratorParam<T> and any type that supports operator* with T.
+ * Returns type of underlying operator*. */
 // @{
-template <typename T1, typename T2>
-decltype((T1)0 * (T2)0) operator*(T1 a, const GeneratorParam<T2> &b) { return a * (T2)b; }
-template <typename T1, typename T2>
-decltype((T1)0 * (T2)0) operator*(const GeneratorParam<T2> &a, T1 b) { return (T2)a * b; }
+template <typename Other, typename T>
+decltype((Other)0 * (T)0) operator*(Other a, const GeneratorParam<T> &b) { return a * (T)b; }
+template <typename Other, typename T>
+decltype((Other)0 * (T)0) operator*(const GeneratorParam<T> &a, Other b) { return (T)a * b; }
 // @}
 
-/** Division between GeneratorParam and arithmetic/enum types.
- * Returns arithmetic type. */
+/** Division between GeneratorParam<T> and any type that supports operator/ with T.
+ * Returns type of underlying operator/. */
 // @{
-template <typename T1, typename T2>
-decltype((T1)0 / (T2)1) operator/(T1 a, const GeneratorParam<T2> &b) { return a / (T2)b; }
-template <typename T1, typename T2>
-decltype((T2)0 / (T1)1) operator/(const GeneratorParam<T2> &a, T1 b) { return (T2)a / b; }
+template <typename Other, typename T>
+decltype((Other)0 / (T)1) operator/(Other a, const GeneratorParam<T> &b) { return a / (T)b; }
+template <typename Other, typename T>
+decltype((T)0 / (Other)1) operator/(const GeneratorParam<T> &a, Other b) { return (T)a / b; }
 // @}
 
-/** Modulo between GeneratorParam and arithmetic/enum types.
- * Returns arithmetic type. */
+/** Modulo between GeneratorParam<T> and any type that supports operator% with T.
+ * Returns type of underlying operator%. */
 // @{
-template <typename T1, typename T2>
-decltype((T1)0 % (T2)1) operator%(T1 a, const GeneratorParam<T2> &b) { return a % (T2)b; }
-template <typename T1, typename T2>
-decltype((T2)0 % (T1)1) operator%(const GeneratorParam<T2> &a, T1 b) { return (T2)a % b; }
+template <typename Other, typename T>
+decltype((Other)0 % (T)1) operator%(Other a, const GeneratorParam<T> &b) { return a % (T)b; }
+template <typename Other, typename T>
+decltype((T)0 % (Other)1) operator%(const GeneratorParam<T> &a, Other b) { return (T)a % b; }
 // @}
 
-/** Greater than comparison between GeneratorParam and arithmetic/enum types.
- * Returns arithmetic type. */
+/** Greater than comparison between GeneratorParam<T> and any type that supports operator> with T.
+ * Returns type of underlying operator>. */
 // @{
-template <typename T1, typename T2>
-decltype((T1)0 > (T2)1) operator>(T1 a, const GeneratorParam<T2> &b) { return a > (T2)b; }
-template <typename T1, typename T2>
-decltype((T2)0 > (T1)1) operator>(const GeneratorParam<T2> &a, T1 b) { return (T2)a > b; }
+template <typename Other, typename T>
+decltype((Other)0 > (T)1) operator>(Other a, const GeneratorParam<T> &b) { return a > (T)b; }
+template <typename Other, typename T>
+decltype((T)0 > (Other)1) operator>(const GeneratorParam<T> &a, Other b) { return (T)a > b; }
 // @}
 
-/** Less than comparison between GeneratorParam and arithmetic/enum types.
- * Returns arithmetic type. */
+/** Less than comparison between GeneratorParam<T> and any type that supports operator< with T.
+ * Returns type of underlying operator<. */
 // @{
-template <typename T1, typename T2>
-decltype((T1)0 < (T2)1) operator<(T1 a, const GeneratorParam<T2> &b) { return a < (T2)b; }
-template <typename T1, typename T2>
-decltype((T2)0 < (T1)1) operator<(const GeneratorParam<T2> &a, T1 b) { return (T2)a < b; }
+template <typename Other, typename T>
+decltype((Other)0 < (T)1) operator<(Other a, const GeneratorParam<T> &b) { return a < (T)b; }
+template <typename Other, typename T>
+decltype((T)0 < (Other)1) operator<(const GeneratorParam<T> &a, Other b) { return (T)a < b; }
 // @}
 
-/** Greater than or equal comparison between GeneratorParam and arithmetic/enum types.
- * Returns arithmetic type. */
+/** Greater than or equal comparison between GeneratorParam<T> and any type that supports operator>= with T.
+ * Returns type of underlying operator>=. */
 // @{
-template <typename T1, typename T2>
-decltype((T1)0 >= (T2)1) operator>=(T1 a, const GeneratorParam<T2> &b) { return a >= (T2)b; }
-template <typename T1, typename T2>
-decltype((T2)0 >= (T1)1) operator>=(const GeneratorParam<T2> &a, T1 b) { return (T2)a >= b; }
+template <typename Other, typename T>
+decltype((Other)0 >= (T)1) operator>=(Other a, const GeneratorParam<T> &b) { return a >= (T)b; }
+template <typename Other, typename T>
+decltype((T)0 >= (Other)1) operator>=(const GeneratorParam<T> &a, Other b) { return (T)a >= b; }
 // @}
 
-/** Less than or equal comparison between GeneratorParam and arithmetic/enum types.
- * Returns arithmetic type. */
+/** Less than or equal comparison between GeneratorParam<T> and any type that supports operator<= with T.
+ * Returns type of underlying operator<=. */
 // @{
-template <typename T1, typename T2>
-decltype((T1)0 <= (T2)1) operator<=(T1 a, const GeneratorParam<T2> &b) { return a <= (T2)b; }
-template <typename T1, typename T2>
-decltype((T2)0 <= (T1)1) operator<=(const GeneratorParam<T2> &a, T1 b) { return (T2)a <= b; }
+template <typename Other, typename T>
+decltype((Other)0 <= (T)1) operator<=(Other a, const GeneratorParam<T> &b) { return a <= (T)b; }
+template <typename Other, typename T>
+decltype((T)0 <= (Other)1) operator<=(const GeneratorParam<T> &a, Other b) { return (T)a <= b; }
 // @}
 
-/** Equality comparison between GeneratorParam and arithmetic/enum types.
- * Returns arithmetic type. */
+/** Equality comparison between GeneratorParam<T> and any type that supports operator== with T.
+ * Returns type of underlying operator==. */
 // @{
-template <typename T1, typename T2>
-decltype((T1)0 == (T2)1) operator==(T1 a, const GeneratorParam<T2> &b) { return a == (T2)b; }
-template <typename T1, typename T2>
-decltype((T2)0 == (T1)1) operator==(const GeneratorParam<T2> &a, T1 b) { return (T2)a == b; }
+template <typename Other, typename T>
+decltype((Other)0 == (T)1) operator==(Other a, const GeneratorParam<T> &b) { return a == (T)b; }
+template <typename Other, typename T>
+decltype((T)0 == (Other)1) operator==(const GeneratorParam<T> &a, Other b) { return (T)a == b; }
 // @}
 
-/** Inequality comparison between between GeneratorParam and arithmetic/enum types.
- * Returns arithmetic type. */
+/** Inequality comparison between between GeneratorParam<T> and any type that supports operator!= with T.
+ * Returns type of underlying operator!=. */
 // @{
-template <typename T1, typename T2>
-decltype((T1)0 != (T2)1) operator!=(T1 a, const GeneratorParam<T2> &b) { return a != (T2)b; }
-template <typename T1, typename T2>
-decltype((T2)0 != (T1)1) operator!=(const GeneratorParam<T2> &a, T1 b) { return (T2)a != b; }
+template <typename Other, typename T>
+decltype((Other)0 != (T)1) operator!=(Other a, const GeneratorParam<T> &b) { return a != (T)b; }
+template <typename Other, typename T>
+decltype((T)0 != (Other)1) operator!=(const GeneratorParam<T> &a, Other b) { return (T)a != b; }
 // @}
 
 namespace Internal { namespace GeneratorMinMax {
@@ -434,22 +434,22 @@ namespace Internal { namespace GeneratorMinMax {
 using std::max;
 using std::min;
 
-/** Compute minimum between GeneratorParam and arithmetic/enum types.
- * Returns arithmetic type. */
+/** Compute minimum between GeneratorParam<T> and any type that supports min with T.
+ * Returns type of underlying min call. */
 // @{
-template <typename T1, typename T2>
-decltype(min((T1)0, (T2)1)) min(T1 a, const GeneratorParam<T2> &b) { return min(a, (T2)b); }
-template <typename T1, typename T2>
-decltype(min((T2)0, (T1)1)) min(const GeneratorParam<T2> &a, T1 b) { return min((T2)a, b); }
+template <typename Other, typename T>
+decltype(min((Other)0, (T)1)) min(Other a, const GeneratorParam<T> &b) { return min(a, (T)b); }
+template <typename Other, typename T>
+decltype(min((T)0, (Other)1)) min(const GeneratorParam<T> &a, Other b) { return min((T)a, b); }
 // @}
 
-/** Compute the maximum value between GeneratorParam and arithmetic/enum types.
- * Returns arithmetic type. */
+/** Compute the maximum value between GeneratorParam<T> and any type that supports max with T.
+ * Returns type of underlying max call. */
 // @{
-template <typename T1, typename T2>
-decltype(max((T1)0, (T2)1)) max(T1 a, const GeneratorParam<T2> &b) { return max(a, (T2)b); }
-template <typename T1, typename T2>
-decltype(max((T2)0, (T1)1)) max(const GeneratorParam<T2> &a, T1 b) { return max((T2)a, b); }
+template <typename Other, typename T>
+decltype(max((Other)0, (T)1)) max(Other a, const GeneratorParam<T> &b) { return max(a, (T)b); }
+template <typename Other, typename T>
+decltype(max((T)0, (Other)1)) max(const GeneratorParam<T> &a, Other b) { return max((T)a, b); }
 // @}
 
 }}

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -429,33 +429,52 @@ template <typename Other, typename T>
 decltype((T)0 != (Other)1) operator!=(const GeneratorParam<T> &a, Other b) { return (T)a != b; }
 // @}
 
+/* min and max are tricky as the language support for these is in the std
+ * namespace. In order to make this work, forwarding functions are used that
+ * are declared in a namespace that has std::min and std::max in scope.
+ */
 namespace Internal { namespace GeneratorMinMax {
 
 using std::max;
 using std::min;
 
-/** Compute minimum between GeneratorParam<T> and any type that supports min with T.
- * Returns type of underlying min call. */
-// @{
 template <typename Other, typename T>
-decltype(min((Other)0, (T)1)) min(Other a, const GeneratorParam<T> &b) { return min(a, (T)b); }
+decltype(min((Other)0, (T)1)) min_forward(Other a, const GeneratorParam<T> &b) { return min(a, (T)b); }
 template <typename Other, typename T>
-decltype(min((T)0, (Other)1)) min(const GeneratorParam<T> &a, Other b) { return min((T)a, b); }
-// @}
+decltype(min((T)0, (Other)1)) min_forward(const GeneratorParam<T> &a, Other b) { return min((T)a, b); }
 
-/** Compute the maximum value between GeneratorParam<T> and any type that supports max with T.
- * Returns type of underlying max call. */
-// @{
 template <typename Other, typename T>
-decltype(max((Other)0, (T)1)) max(Other a, const GeneratorParam<T> &b) { return max(a, (T)b); }
+decltype(max((Other)0, (T)1)) max_forward(Other a, const GeneratorParam<T> &b) { return max(a, (T)b); }
 template <typename Other, typename T>
-decltype(max((T)0, (Other)1)) max(const GeneratorParam<T> &a, Other b) { return max((T)a, b); }
-// @}
+decltype(max((T)0, (Other)1)) max_forward(const GeneratorParam<T> &a, Other b) { return max((T)a, b); }
 
 }}
 
-using Internal::GeneratorMinMax::max;
-using Internal::GeneratorMinMax::min;
+/** Compute minimum between GeneratorParam<T> and any type that supports min with T.
+ * Will automatically import std::min. Returns type of underlying min call. */
+// @{
+template <typename Other, typename T>
+auto min(Other a, const GeneratorParam<T> &b) -> decltype(Internal::GeneratorMinMax::min_forward(a, b)) {
+    return Internal::GeneratorMinMax::min_forward(a, b);
+}
+template <typename Other, typename T>
+auto min(const GeneratorParam<T> &a, Other b) -> decltype(Internal::GeneratorMinMax::min_forward(a, b)) {
+    return Internal::GeneratorMinMax::min_forward(a, b);
+}
+// @}
+
+/** Compute the maximum value between GeneratorParam<T> and any type that supports max with T.
+ * Will automatically import std::max. Returns type of underlying max call. */
+// @{
+template <typename Other, typename T>
+auto max(Other a, const GeneratorParam<T> &b) -> decltype(Internal::GeneratorMinMax::max_forward(a, b)) {
+    return Internal::GeneratorMinMax::max_forward(a, b);
+}
+template <typename Other, typename T>
+auto max(const GeneratorParam<T> &a, Other b) -> decltype(Internal::GeneratorMinMax::max_forward(a, b)) {
+    return Internal::GeneratorMinMax::max_forward(a, b);
+}
+// @}
 
 /** Not operator for GeneratorParam */
 template <typename T>

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -218,6 +218,7 @@ public:
     }
 
     operator T() const { return value; }
+    operator Expr() const { return Expr(value); }
 
 private:
     T value;
@@ -327,6 +328,231 @@ private:
         return "";
     }
 };
+
+/** Addition between GeneratorParam and arithmetic/enum types.
+ * Returns arithmetic type. */
+// @{
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T1)0 + (T2)0) operator+(T1 a, const GeneratorParam<T2> &b) { return a + (T2)b; }
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T2)0 + (T1)0) operator+(const GeneratorParam<T2> &a, T1 b) { return (T2)a + b; }
+// @}
+
+/** Subtraction between GeneratorParam and arithmetic/enum types.
+ * Returns arithmetic type. */
+// @{
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T1)0 - (T2)0) operator-(T1 a, const GeneratorParam<T2> &b) { return a - (T2)b; }
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T2)0 - (T1)0)  operator-(const GeneratorParam<T2> &a, T1 b) { return (T2)a - b; }
+// @}
+
+/** Multiplication between GeneratorParam and arithmetic/enum types.
+ * Returns arithmetic type. */
+// @{
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T1)0 * (T2)0) operator*(T1 a, const GeneratorParam<T2> &b) { return a * (T2)b; }
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T1)0 * (T2)0) operator*(const GeneratorParam<T2> &a, T1 b) { return (T2)a * b; }
+// @}
+
+/** Division between GeneratorParam and arithmetic/enum types.
+ * Returns arithmetic type. */
+// @{
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T1)0 / (T2)1) operator/(T1 a, const GeneratorParam<T2> &b) { return a / (T2)b; }
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T2)0 / (T1)1) operator/(const GeneratorParam<T2> &a, T1 b) { return (T2)a / b; }
+// @}
+
+/** Modulo between GeneratorParam and arithmetic/enum types.
+ * Returns arithmetic type. */
+// @{
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T1)0 % (T2)1) operator%(T1 a, const GeneratorParam<T2> &b) { return a % (T2)b; }
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T2)0 % (T1)1) operator%(const GeneratorParam<T2> &a, T1 b) { return (T2)a % b; }
+// @}
+
+/** Greater than comparison between GeneratorParam and arithmetic/enum types.
+ * Returns arithmetic type. */
+// @{
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T1)0 > (T2)1) operator>(T1 a, const GeneratorParam<T2> &b) { return a > (T2)b; }
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T2)0 > (T1)1) operator>(const GeneratorParam<T2> &a, T1 b) { return (T2)a > b; }
+// @}
+
+/** Less than comparison between GeneratorParam and arithmetic/enum types.
+ * Returns arithmetic type. */
+// @{
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T1)0 < (T2)1) operator<(T1 a, const GeneratorParam<T2> &b) { return a < (T2)b; }
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T2)0 < (T1)1) operator<(const GeneratorParam<T2> &a, T1 b) { return (T2)a < b; }
+// @}
+
+/** Greater than or equal comparison between GeneratorParam and arithmetic/enum types.
+ * Returns arithmetic type. */
+// @{
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T1)0 >= (T2)1) operator>=(T1 a, const GeneratorParam<T2> &b) { return a >= (T2)b; }
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T2)0 >= (T1)1) operator>=(const GeneratorParam<T2> &a, T1 b) { return (T2)a >= b; }
+// @}
+
+/** Less than or equal comparison between GeneratorParam and arithmetic/enum types.
+ * Returns arithmetic type. */
+// @{
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T1)0 <= (T2)1) operator<=(T1 a, const GeneratorParam<T2> &b) { return a <= (T2)b; }
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T2)0 <= (T1)1) operator<=(const GeneratorParam<T2> &a, T1 b) { return (T2)a <= b; }
+// @}
+
+/** Equality comparison between GeneratorParam and arithmetic/enum types.
+ * Returns arithmetic type. */
+// @{
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T1)0 == (T2)1) operator==(T1 a, const GeneratorParam<T2> &b) { return a == (T2)b; }
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T2)0 == (T1)1) operator==(const GeneratorParam<T2> &a, T1 b) { return (T2)a == b; }
+// @}
+
+/** Inequality comparison between between GeneratorParam and arithmetic/enum types.
+ * Returns arithmetic type. */
+// @{
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T1)0 != (T2)1) operator!=(T1 a, const GeneratorParam<T2> &b) { return a != (T2)b; }
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype((T2)0 != (T1)1) operator!=(const GeneratorParam<T2> &a, T1 b) { return (T2)a != b; }
+// @}
+
+/** Compute minimum between GeneratorParam and arithmetic/enum types.
+ * Returns arithmetic type. */
+// @{
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype(min((T1)0, (T2)1)) min(T1 a, const GeneratorParam<T2> &b) { return min(a, (T2)b); }
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype(min((T2)0, (T1)1)) min(const GeneratorParam<T2> &a, T1 b) { return min((T2)a, b); }
+// @}
+
+/** Compute the maximum value between GeneratorParam and arithmetic/enum types.
+ * Returns arithmetic type. */
+// @{
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype(max((T1)0, (T2)1)) max(T1 a, const GeneratorParam<T2> &b) { return max(a, (T2)b); }
+template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+decltype(max((T2)0, (T1)1)) max(const GeneratorParam<T2> &a, T1 b) { return max((T2)a, b); }
+// @}
+
+/** Not operator for GeneratorParam */
+template <typename T>
+T operator!(const GeneratorParam<T> &a) { return !(T)a; }
+
+/** Addition between GeneratorParam and Expr */
+// @{
+template <typename T2>
+Expr operator+(Expr a, const GeneratorParam<T2> &b) { return a + (T2)b; }
+template <typename T2>
+Expr operator+(const GeneratorParam<T2> &a, Expr b) { return (T2)a + b; }
+// @}
+
+/** Subtraction between GeneratorParam and Expr */
+// @{
+template <typename T2>
+Expr operator-(Expr a, const GeneratorParam<T2> &b) { return a - (T2)b; }
+template <typename T2>
+Expr operator-(const GeneratorParam<T2> &a, Expr b) { return (T2)a - b; }
+// @}
+
+/** Multiplication between GeneratorParam and Expr */
+// @{
+template <typename T2>
+Expr operator*(Expr a, const GeneratorParam<T2> &b) { return a * (T2)b; }
+template <typename T2>
+Expr operator*(const GeneratorParam<T2> &a, Expr b) { return (T2)a * b; }
+// @}
+
+/** Division between GeneratorParam and Expr */
+// @{
+template <typename T2>
+Expr operator/(Expr a, const GeneratorParam<T2> &b) { return a / (T2)b; }
+template <typename T2>
+Expr operator/(const GeneratorParam<T2> &a, Expr b) { return (T2)a / b; }
+// @}
+
+/** Modulo between GeneratorParam and Expr */
+// @{
+template <typename T2>
+Expr operator%(Expr a, const GeneratorParam<T2> &b) { return a % (T2)b; }
+template <typename T2>
+Expr operator%(const GeneratorParam<T2> &a, Expr b) { return (T2)a % b; }
+// @}
+
+/** Greater than comparison between GeneratorParam and Expr */
+// @{
+template <typename T2>
+Expr operator>(Expr a, const GeneratorParam<T2> &b) { return a > (T2)b; }
+template <typename T2>
+Expr operator>(const GeneratorParam<T2> &a, Expr b) { return (T2)a > b; }
+// @}
+
+/** Less than comparison between GeneratorParam and Expr */
+// @{
+template <typename T2>
+Expr operator<(Expr a, const GeneratorParam<T2> &b) { return a < (T2)b; }
+template <typename T2>
+Expr operator<(const GeneratorParam<T2> &a, Expr b) { return (T2)a < b; }
+// @}
+
+/** Greater than or equal comparison between GeneratorParam and Expr */
+// @{
+template <typename T2>
+Expr operator>=(Expr a, const GeneratorParam<T2> &b) { return a >= (T2)b; }
+template <typename T2>
+Expr operator>=(const GeneratorParam<T2> &a, Expr b) { return (T2)a >= b; }
+// @}
+
+/** Less than or equal comparison between GeneratorParam and Expr */
+// @{
+template <typename T2>
+Expr operator<=(Expr a, const GeneratorParam<T2> &b) { return a <= (T2)b; }
+template <typename T2>
+Expr operator<=(const GeneratorParam<T2> &a, Expr b) { return (T2)a <= b; }
+// @}
+
+/** Equality between GeneratorParam and Expr */
+// @{
+template <typename T2>
+Expr operator==(Expr a, const GeneratorParam<T2> &b) { return a == (T2)b; }
+template <typename T2>
+Expr operator==(const GeneratorParam<T2> &a, Expr b) { return (T2)a == b; }
+// @}
+
+/** Inequality comparison between GeneratorParam and Expr */
+// @{
+template <typename T2>
+Expr operator!=(Expr a, const GeneratorParam<T2> &b) { return a != (T2)b; }
+template <typename T2>
+Expr operator!=(const GeneratorParam<T2> &a, Expr b) { return (T2)a != b; }
+// @}
+
+/** Compute the minimum value between GeneratorParam and Expr */
+// @{
+template <typename T2>
+Expr min(Expr a, const GeneratorParam<T2> &b) { return min(a, (T2)b); }
+template <typename T2>
+Expr min(const GeneratorParam<T2> &a, Expr b) { return min((T2)a, b); }
+// @}
+
+/** Compute the maximum value between GeneratorParam and Expr */
+// @{
+template <typename T2>
+Expr max(Expr a, const GeneratorParam<T2> &b) { return max(a, (T2)b); }
+template <typename T2>
+Expr max(const GeneratorParam<T2> &a, Expr b) { return max((T2)a, b); }
+// @}
 
 class NamesInterface {
     // Names in this class are only intended for use in derived classes.

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -85,6 +85,7 @@
  * Pipeline object.
  */
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <mutex>
@@ -218,7 +219,7 @@ public:
     }
 
     operator T() const { return value; }
-    operator Expr() const { return Expr(value); }
+    operator Expr() const { return Internal::make_const(type_of<T>(), value); }
 
 private:
     T value;
@@ -332,227 +333,133 @@ private:
 /** Addition between GeneratorParam and arithmetic/enum types.
  * Returns arithmetic type. */
 // @{
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T1)0 + (T2)0) operator+(T1 a, const GeneratorParam<T2> &b) { return a + (T2)b; }
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T2)0 + (T1)0) operator+(const GeneratorParam<T2> &a, T1 b) { return (T2)a + b; }
 // @}
 
 /** Subtraction between GeneratorParam and arithmetic/enum types.
  * Returns arithmetic type. */
 // @{
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T1)0 - (T2)0) operator-(T1 a, const GeneratorParam<T2> &b) { return a - (T2)b; }
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T2)0 - (T1)0)  operator-(const GeneratorParam<T2> &a, T1 b) { return (T2)a - b; }
 // @}
 
 /** Multiplication between GeneratorParam and arithmetic/enum types.
  * Returns arithmetic type. */
 // @{
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T1)0 * (T2)0) operator*(T1 a, const GeneratorParam<T2> &b) { return a * (T2)b; }
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T1)0 * (T2)0) operator*(const GeneratorParam<T2> &a, T1 b) { return (T2)a * b; }
 // @}
 
 /** Division between GeneratorParam and arithmetic/enum types.
  * Returns arithmetic type. */
 // @{
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T1)0 / (T2)1) operator/(T1 a, const GeneratorParam<T2> &b) { return a / (T2)b; }
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T2)0 / (T1)1) operator/(const GeneratorParam<T2> &a, T1 b) { return (T2)a / b; }
 // @}
 
 /** Modulo between GeneratorParam and arithmetic/enum types.
  * Returns arithmetic type. */
 // @{
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T1)0 % (T2)1) operator%(T1 a, const GeneratorParam<T2> &b) { return a % (T2)b; }
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T2)0 % (T1)1) operator%(const GeneratorParam<T2> &a, T1 b) { return (T2)a % b; }
 // @}
 
 /** Greater than comparison between GeneratorParam and arithmetic/enum types.
  * Returns arithmetic type. */
 // @{
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T1)0 > (T2)1) operator>(T1 a, const GeneratorParam<T2> &b) { return a > (T2)b; }
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T2)0 > (T1)1) operator>(const GeneratorParam<T2> &a, T1 b) { return (T2)a > b; }
 // @}
 
 /** Less than comparison between GeneratorParam and arithmetic/enum types.
  * Returns arithmetic type. */
 // @{
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T1)0 < (T2)1) operator<(T1 a, const GeneratorParam<T2> &b) { return a < (T2)b; }
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T2)0 < (T1)1) operator<(const GeneratorParam<T2> &a, T1 b) { return (T2)a < b; }
 // @}
 
 /** Greater than or equal comparison between GeneratorParam and arithmetic/enum types.
  * Returns arithmetic type. */
 // @{
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T1)0 >= (T2)1) operator>=(T1 a, const GeneratorParam<T2> &b) { return a >= (T2)b; }
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T2)0 >= (T1)1) operator>=(const GeneratorParam<T2> &a, T1 b) { return (T2)a >= b; }
 // @}
 
 /** Less than or equal comparison between GeneratorParam and arithmetic/enum types.
  * Returns arithmetic type. */
 // @{
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T1)0 <= (T2)1) operator<=(T1 a, const GeneratorParam<T2> &b) { return a <= (T2)b; }
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T2)0 <= (T1)1) operator<=(const GeneratorParam<T2> &a, T1 b) { return (T2)a <= b; }
 // @}
 
 /** Equality comparison between GeneratorParam and arithmetic/enum types.
  * Returns arithmetic type. */
 // @{
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T1)0 == (T2)1) operator==(T1 a, const GeneratorParam<T2> &b) { return a == (T2)b; }
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T2)0 == (T1)1) operator==(const GeneratorParam<T2> &a, T1 b) { return (T2)a == b; }
 // @}
 
 /** Inequality comparison between between GeneratorParam and arithmetic/enum types.
  * Returns arithmetic type. */
 // @{
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T1)0 != (T2)1) operator!=(T1 a, const GeneratorParam<T2> &b) { return a != (T2)b; }
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype((T2)0 != (T1)1) operator!=(const GeneratorParam<T2> &a, T1 b) { return (T2)a != b; }
 // @}
+
+namespace Internal { namespace GeneratorMinMax {
+
+using std::max;
+using std::min;
 
 /** Compute minimum between GeneratorParam and arithmetic/enum types.
  * Returns arithmetic type. */
 // @{
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype(min((T1)0, (T2)1)) min(T1 a, const GeneratorParam<T2> &b) { return min(a, (T2)b); }
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype(min((T2)0, (T1)1)) min(const GeneratorParam<T2> &a, T1 b) { return min((T2)a, b); }
 // @}
 
 /** Compute the maximum value between GeneratorParam and arithmetic/enum types.
  * Returns arithmetic type. */
 // @{
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype(max((T1)0, (T2)1)) max(T1 a, const GeneratorParam<T2> &b) { return max(a, (T2)b); }
-template <typename T1, typename T2, typename std::enable_if<std::is_arithmetic<T1>::value || std::is_enum<T1>::value>::type * = nullptr>
+template <typename T1, typename T2>
 decltype(max((T2)0, (T1)1)) max(const GeneratorParam<T2> &a, T1 b) { return max((T2)a, b); }
 // @}
 
+}}
+
+using Internal::GeneratorMinMax::max;
+using Internal::GeneratorMinMax::min;
+
 /** Not operator for GeneratorParam */
 template <typename T>
-T operator!(const GeneratorParam<T> &a) { return !(T)a; }
-
-/** Addition between GeneratorParam and Expr */
-// @{
-template <typename T2>
-Expr operator+(Expr a, const GeneratorParam<T2> &b) { return a + (T2)b; }
-template <typename T2>
-Expr operator+(const GeneratorParam<T2> &a, Expr b) { return (T2)a + b; }
-// @}
-
-/** Subtraction between GeneratorParam and Expr */
-// @{
-template <typename T2>
-Expr operator-(Expr a, const GeneratorParam<T2> &b) { return a - (T2)b; }
-template <typename T2>
-Expr operator-(const GeneratorParam<T2> &a, Expr b) { return (T2)a - b; }
-// @}
-
-/** Multiplication between GeneratorParam and Expr */
-// @{
-template <typename T2>
-Expr operator*(Expr a, const GeneratorParam<T2> &b) { return a * (T2)b; }
-template <typename T2>
-Expr operator*(const GeneratorParam<T2> &a, Expr b) { return (T2)a * b; }
-// @}
-
-/** Division between GeneratorParam and Expr */
-// @{
-template <typename T2>
-Expr operator/(Expr a, const GeneratorParam<T2> &b) { return a / (T2)b; }
-template <typename T2>
-Expr operator/(const GeneratorParam<T2> &a, Expr b) { return (T2)a / b; }
-// @}
-
-/** Modulo between GeneratorParam and Expr */
-// @{
-template <typename T2>
-Expr operator%(Expr a, const GeneratorParam<T2> &b) { return a % (T2)b; }
-template <typename T2>
-Expr operator%(const GeneratorParam<T2> &a, Expr b) { return (T2)a % b; }
-// @}
-
-/** Greater than comparison between GeneratorParam and Expr */
-// @{
-template <typename T2>
-Expr operator>(Expr a, const GeneratorParam<T2> &b) { return a > (T2)b; }
-template <typename T2>
-Expr operator>(const GeneratorParam<T2> &a, Expr b) { return (T2)a > b; }
-// @}
-
-/** Less than comparison between GeneratorParam and Expr */
-// @{
-template <typename T2>
-Expr operator<(Expr a, const GeneratorParam<T2> &b) { return a < (T2)b; }
-template <typename T2>
-Expr operator<(const GeneratorParam<T2> &a, Expr b) { return (T2)a < b; }
-// @}
-
-/** Greater than or equal comparison between GeneratorParam and Expr */
-// @{
-template <typename T2>
-Expr operator>=(Expr a, const GeneratorParam<T2> &b) { return a >= (T2)b; }
-template <typename T2>
-Expr operator>=(const GeneratorParam<T2> &a, Expr b) { return (T2)a >= b; }
-// @}
-
-/** Less than or equal comparison between GeneratorParam and Expr */
-// @{
-template <typename T2>
-Expr operator<=(Expr a, const GeneratorParam<T2> &b) { return a <= (T2)b; }
-template <typename T2>
-Expr operator<=(const GeneratorParam<T2> &a, Expr b) { return (T2)a <= b; }
-// @}
-
-/** Equality between GeneratorParam and Expr */
-// @{
-template <typename T2>
-Expr operator==(Expr a, const GeneratorParam<T2> &b) { return a == (T2)b; }
-template <typename T2>
-Expr operator==(const GeneratorParam<T2> &a, Expr b) { return (T2)a == b; }
-// @}
-
-/** Inequality comparison between GeneratorParam and Expr */
-// @{
-template <typename T2>
-Expr operator!=(Expr a, const GeneratorParam<T2> &b) { return a != (T2)b; }
-template <typename T2>
-Expr operator!=(const GeneratorParam<T2> &a, Expr b) { return (T2)a != b; }
-// @}
-
-/** Compute the minimum value between GeneratorParam and Expr */
-// @{
-template <typename T2>
-Expr min(Expr a, const GeneratorParam<T2> &b) { return min(a, (T2)b); }
-template <typename T2>
-Expr min(const GeneratorParam<T2> &a, Expr b) { return min((T2)a, b); }
-// @}
-
-/** Compute the maximum value between GeneratorParam and Expr */
-// @{
-template <typename T2>
-Expr max(Expr a, const GeneratorParam<T2> &b) { return max(a, (T2)b); }
-template <typename T2>
-Expr max(const GeneratorParam<T2> &a, Expr b) { return max((T2)a, b); }
-// @}
+decltype(!(T)0) operator!(const GeneratorParam<T> &a) { return !(T)a; }
 
 class NamesInterface {
     // Names in this class are only intended for use in derived classes.

--- a/test/generator/paramtest_generator.cpp
+++ b/test/generator/paramtest_generator.cpp
@@ -5,10 +5,15 @@ namespace {
 // This Generator exists solely to do testing of GeneratorParam/ImageParam/Param
 // introspection; the actual operation done in build() matters very little
 // (except for setting the type of the input image, which is critical)
+// This test also verifies that various operators using GeneratorPAram work.
 class ParamTest : public Halide::Generator<ParamTest> {
 public:
     GeneratorParam<Type> input_type{ "input_type", UInt(8) };
     GeneratorParam<Type> output_type{ "output_type", Float(32) };
+
+    GeneratorParam<float> float_gen_arg{ "float_val", 1.0f };
+    GeneratorParam<int32_t> int_gen_arg{ "int_val", 1 };
+    GeneratorParam<bool> bool_gen_arg{ "bool_val", true };
 
     ImageParam input{ UInt(8), 3, "input" };
     Param<float> float_arg{ "float_arg", 1.0f, 0.0f, 100.0f };
@@ -17,12 +22,84 @@ public:
     Pipeline build() {
         input = ImageParam(input_type, input.dimensions(), input.name());
 
+        using std::min;
+        using std::max;
+
+        float test_float = float_gen_arg + 42; // Intentionally use integer 42
+        int32_t test_int = 42 + int_gen_arg;
+        test_float = float_gen_arg - 42;
+        test_int = 42 - int_gen_arg;
+        test_float = float_gen_arg * 42;
+        test_int = 42 * int_gen_arg;
+        test_float = float_gen_arg / 42;
+        test_int = 42 / int_gen_arg;
+        test_int = 42 % int_gen_arg;
+        test_int = 42 & int_gen_arg;
+        test_int = 42 | int_gen_arg;
+        test_float = float_gen_arg && 42;
+        test_int = 42 && int_gen_arg;
+        test_float = float_gen_arg || 42;
+        test_int = 42 || int_gen_arg;
+        test_float = max(float_gen_arg, 42.0f);
+        test_int = max(42, int_gen_arg);
+        test_float = min(float_gen_arg, 42.0f);
+        test_int = min(42, int_gen_arg);
+        bool flag_float = float_gen_arg > 42;
+        bool flag_int = 42 > int_gen_arg;
+        flag_float = float_gen_arg < 42;
+        flag_int = 42 < int_gen_arg;
+        flag_float = float_gen_arg >= 42;
+        flag_int = 42 >= int_gen_arg;
+        flag_float = float_gen_arg <= 42;
+        flag_int = 42 <= int_gen_arg;
+        flag_float = float_gen_arg == 42;
+        flag_int = 42 == int_gen_arg;
+        flag_float = float_gen_arg != 42;
+        flag_int = 42 != int_gen_arg;
+        bool not_result = !float_gen_arg;
+        not_result = !int_gen_arg;
+
+        Expr forty_two = 42;
+        Expr test_expr = float_gen_arg + forty_two;
+        test_expr = forty_two + int_gen_arg;
+        test_expr = float_gen_arg - forty_two;
+        test_expr = forty_two - int_gen_arg;
+        test_expr = float_gen_arg * forty_two;
+        test_expr = forty_two * int_gen_arg;
+        test_expr = float_gen_arg / forty_two;
+        test_expr = forty_two / int_gen_arg;
+        test_expr = forty_two % int_gen_arg;
+        test_expr = forty_two & int_gen_arg;
+        test_expr = forty_two | int_gen_arg;
+        test_expr = bool_gen_arg && (forty_two != 0);
+        test_expr = bool_gen_arg && (forty_two != 0);
+        test_expr = bool_gen_arg || (forty_two != 0);
+        test_expr = (forty_two != 0) || bool_gen_arg;
+        test_expr = max(float_gen_arg, forty_two);
+        test_expr = max(forty_two, int_gen_arg);
+        test_expr = min(float_gen_arg, forty_two);
+        test_expr = min(forty_two, int_gen_arg);
+        test_expr = float_gen_arg > forty_two;
+        test_expr = forty_two > int_gen_arg;
+        test_expr = float_gen_arg < forty_two;
+        test_expr = forty_two < int_gen_arg;
+        test_expr = float_gen_arg >= forty_two;
+        test_expr = forty_two >= int_gen_arg;
+        test_expr = float_gen_arg <= forty_two;
+        test_expr = forty_two <= int_gen_arg;
+        test_expr = float_gen_arg == forty_two;
+        test_expr = forty_two == int_gen_arg;
+        test_expr = float_gen_arg != forty_two;
+        test_expr = forty_two != int_gen_arg;
+
         Var x, y, c;
 
         Func f;
         f(x, y, c) = Tuple(
                 input(x, y, c),
-                cast(output_type, input(x, y, c) * float_arg + int_arg));
+                cast(output_type, input(x, y, c) * float_arg + int_arg +
+                     0 * (test_float + test_int + flag_float + flag_int +
+                          not_result + test_expr)));
 
         Func g;
         g(x, y) = cast<int16_t>(input(x, y, 0));

--- a/test/generator/paramtest_jittest.cpp
+++ b/test/generator/paramtest_jittest.cpp
@@ -94,7 +94,7 @@ int main(int argc, char **argv) {
     {
         ParamTest gen;
         GeneratorParamValues v = gen.get_generator_param_values();
-        if (v.size() != 3) {
+        if (v.size() != 6) {
             fprintf(stderr, "Wrong number of GeneratorParamValues %d\n", (int) v.size());
             exit(-1);
         }


### PR DESCRIPTION
Allows GeneratorParams to be used in expressions with arithmetic
types (integers, floats, etc.) and Expr. This was removed with the
recent changes to how immediates are handled in the IR and this restores
that functionality.

It is possible to use template metaprogramming to unify this with the operator overloads in IROperator.h, and it may be a good idea to do so. I've started working on an implementation of that and am not sure how long it is going to take. Hence I'd like to get consider this approach first and the more elaborate extensible one later. There is some risk of changing the language semantics slightly doing it this way so I am open to feedback here. The generalized code is good if we anticipate there being other types that need to interoperate with Expr and the arithmetic types in this way.