### PR TITLE
Added dft6 implemented using prime factor FFT algorithm.

### DIFF
--- a/apps/fft/fft.cpp
+++ b/apps/fft/fft.cpp
@@ -145,6 +145,42 @@ ComplexFunc dft4(ComplexFunc f, int sign, const string& prefix) {
     return F;
 }
 
+ComplexFunc dft6(ComplexFunc f, int sign, const string& prefix) {
+    const float re_W1_3 = -0.5f;
+    const float im_W1_3 = sign*0.866025404;
+
+    ComplexExpr W1_3(re_W1_3, im_W1_3);
+    ComplexExpr W2_3(re_W1_3, -im_W1_3);
+    ComplexExpr W4_3 = W1_3;
+
+    Type type = f.output_types()[0];
+
+    ComplexFunc F(prefix + "X8");
+    F(f.args()) = undef_z(type);
+
+    vector<ComplexFuncRefExpr> x = get_func_refs(f, 6);
+    vector<ComplexFuncRefExpr> X = get_func_refs(F, 6);
+    vector<ComplexFuncRefExpr> T = get_func_refs(F, 6, true);
+
+    // Prime factor FFT, N=2*3, no twiddle factors!
+    T[0] = (x[0] + x[3]);
+    T[3] = (x[0] - x[3]);
+    T[1] = (x[1] + x[4]);
+    T[4] = (x[1] - x[4]);
+    T[2] = (x[2] + x[5]);
+    T[5] = (x[2] - x[5]);
+
+    X[0] = T[0] + T[2] + T[1];
+    X[4] = T[0] + T[2]*W1_3 + T[1]*W2_3;
+    X[2] = T[0] + T[2]*W2_3 + T[1]*W4_3;
+
+    X[3] = T[3] + T[5] - T[4];
+    X[1] = T[3] + T[5]*W1_3 - T[4]*W2_3;
+    X[5] = T[3] + T[5]*W2_3 - T[4]*W4_3;
+
+    return F;
+}
+
 ComplexFunc dft8(ComplexFunc f, int sign, const string& prefix) {
     const float sqrt2_2 = 0.70710678f;
 
@@ -218,6 +254,7 @@ ComplexFunc dft1d_c2c(ComplexFunc x, int N, int sign,
     case 1: return x;
     case 2: return dft2(x, prefix);
     case 4: return dft4(x, sign, prefix);
+    case 6: return dft6(x, sign, prefix);
     case 8: return dft8(x, sign, prefix);
     default: return dftN(x, N, sign, prefix);
     }
@@ -977,7 +1014,7 @@ vector<int> radix_factor(int N) {
     }
 
     // Factor N into factors found in the 'radices' set.
-    static const int radices[] = { 8, 4, 2 };
+    static const int radices[] = { 8, 6, 4, 2 };
     vector<int> R;
     for (int r : radices) {
         while (N % r == 0) {


### PR DESCRIPTION
This makes the 48x48 benchmark case ~10% faster than before! Here's the current timing:

                       Halide                  FFTW     
    DFT type  Time (us)    MFLOP/s  Time (us)    MFLOP/s      Ratio
         c2c      6.077   21174.52      6.959   18490.81       1.15
         r2c      3.750   17157.00      6.514    9877.00       1.74
         c2r      4.102   15684.73      6.466    9950.32       1.58
