### PR TITLE
Plumb through unique_ptr use around llvm::Module.

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -31,11 +31,9 @@
 
 namespace Halide {
 
-llvm::Module *codegen_llvm(const Module &module, llvm::LLVMContext &context) {
-    Internal::CodeGen_LLVM *cg = Internal::CodeGen_LLVM::new_for_target(module.target(), context);
-    llvm::Module *out = cg->compile(module);
-    delete cg;
-    return out;
+std::unique_ptr<llvm::Module> codegen_llvm(const Module &module, llvm::LLVMContext &context) {
+    std::unique_ptr<Internal::CodeGen_LLVM> cg(Internal::CodeGen_LLVM::new_for_target(module.target(), context));
+    return cg->compile(module);
 }
 
 namespace Internal {
@@ -128,7 +126,6 @@ llvm::GlobalValue::LinkageTypes llvm_linkage(LoweredFunc::LinkageType t) {
 }
 
 CodeGen_LLVM::CodeGen_LLVM(Target t) :
-    module(NULL),
     function(NULL), context(NULL),
     builder(NULL),
     value(NULL),
@@ -368,7 +365,6 @@ void CodeGen_LLVM::init_module() {
     init_context();
 
     // Start with a module containing the initial module for this target.
-    delete module;
     module = get_initial_module_for_target(target, context);
 }
 
@@ -383,7 +379,7 @@ bool CodeGen_LLVM::llvm_AArch64_enabled = false;
 bool CodeGen_LLVM::llvm_NVPTX_enabled = false;
 bool CodeGen_LLVM::llvm_Mips_enabled = false;
 
-llvm::Module *CodeGen_LLVM::compile(const Module &input) {
+std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
     init_module();
 
     debug(1) << "Target triple of initial module: " << module->getTargetTriple() << "\n";
@@ -426,7 +422,7 @@ llvm::Module *CodeGen_LLVM::compile(const Module &input) {
         compile_func(input.functions[i]);
     }
 
-    debug(2) << module << "\n";
+    debug(2) << module.get() << "\n";
 
     // Verify the module is ok
     verifyModule(*module);
@@ -436,9 +432,7 @@ llvm::Module *CodeGen_LLVM::compile(const Module &input) {
     CodeGen_LLVM::optimize_module();
 
     // Disown the module and return it.
-    llvm::Module *m = module;
-    module = NULL;
-    return m;
+    return std::move(module);
 }
 
 namespace {
@@ -499,7 +493,7 @@ void CodeGen_LLVM::compile_func(const LoweredFunc &f) {
 
     // Make our function
     FunctionType *func_t = FunctionType::get(i32, arg_types, false);
-    function = llvm::Function::Create(func_t, llvm_linkage(f.linkage), name, module);
+    function = llvm::Function::Create(func_t, llvm_linkage(f.linkage), name, module.get());
 
     // Mark the buffer args as no alias
     for (size_t i = 0; i < args.size(); i++) {
@@ -545,21 +539,21 @@ void CodeGen_LLVM::compile_func(const LoweredFunc &f) {
     }
 
     module->setModuleIdentifier("halide_module_" + name);
-    debug(2) << module << "\n";
+    debug(2) << module.get() << "\n";
 
     internal_assert(!verifyFunction(*function));
 
     // If the Func is externally visible, also create the argv wrapper
     // (useful for calling from JIT and other machine interfaces).
     if (f.linkage == LoweredFunc::External) {
-        llvm::Function *wrapper = add_argv_wrapper(module, function, name + "_argv");
+        llvm::Function *wrapper = add_argv_wrapper(module.get(), function, name + "_argv");
         llvm::Constant *metadata = embed_metadata(name + "_metadata", name, args);
         if (target.has_feature(Target::RegisterMetadata)) {
             register_metadata(name, metadata, wrapper);
         }
 
         if (target.has_feature(Target::Matlab)) {
-            define_matlab_wrapper(module, name);
+            define_matlab_wrapper(module.get(), name);
         }
     }
 }
@@ -809,7 +803,7 @@ void CodeGen_LLVM::register_metadata(const std::string &name, llvm::Constant *me
         ConstantStruct::get(register_t_type, list_node_fields));
 
     llvm::FunctionType *func_t = llvm::FunctionType::get(void_t, false);
-    llvm::Function *ctor = llvm::Function::Create(func_t, llvm::GlobalValue::PrivateLinkage, name + ".register_metadata", module);
+    llvm::Function *ctor = llvm::Function::Create(func_t, llvm::GlobalValue::PrivateLinkage, name + ".register_metadata", module.get());
     llvm::BasicBlock *block = llvm::BasicBlock::Create(module->getContext(), "entry", ctor);
     builder->SetInsertPoint(block);
     llvm::Value *call_args[] = {list_node};
@@ -836,7 +830,7 @@ void CodeGen_LLVM::optimize_module() {
     FunctionPassManager function_pass_manager(module);
     PassManager module_pass_manager;
     #else
-    legacy::FunctionPassManager function_pass_manager(module);
+    legacy::FunctionPassManager function_pass_manager(module.get());
     legacy::PassManager module_pass_manager;
     #endif
 
@@ -1483,7 +1477,7 @@ Expr promote_64(Expr e) {
 
 Value *CodeGen_LLVM::codegen_buffer_pointer(string buffer, Halide::Type type, Expr index) {
     // Promote index to 64-bit on targets that use 64-bit pointers.
-    llvm::DataLayout d(module);
+    llvm::DataLayout d(module.get());
     if (promote_indices() && d.getPointerSize() == 8) {
         index = promote_64(index);
     }
@@ -1511,7 +1505,7 @@ Value *CodeGen_LLVM::codegen_buffer_pointer(string buffer, Halide::Type type, Va
     }
 
     // Promote index to 64-bit on targets that use 64-bit pointers.
-    llvm::DataLayout d(module);
+    llvm::DataLayout d(module.get());
     if (d.getPointerSize() == 8) {
         index = builder->CreateIntCast(index, i64, true);
     }
@@ -2048,7 +2042,7 @@ void CodeGen_LLVM::visit(const Call *op) {
                 internal_assert(dst.is_uint() && dst.bits() == 64);
 
                 // Handle -> UInt64
-                llvm::DataLayout d(module);
+                llvm::DataLayout d(module.get());
                 if (d.getPointerSize() == 4) {
                     llvm::Type *intermediate = llvm_type_of(UInt(32, dst.lanes()));
                     value = builder->CreatePtrToInt(value, intermediate);
@@ -2063,7 +2057,7 @@ void CodeGen_LLVM::visit(const Call *op) {
                 internal_assert(src.is_uint() && src.bits() == 64);
 
                 // UInt64 -> Handle
-                llvm::DataLayout d(module);
+                llvm::DataLayout d(module.get());
                 if (d.getPointerSize() == 4) {
                     llvm::Type *intermediate = llvm_type_of(UInt(32, src.lanes()));
                     value = builder->CreateTrunc(value, intermediate);
@@ -2364,7 +2358,7 @@ void CodeGen_LLVM::visit(const Call *op) {
             internal_assert(op->args.size() == 1);
             std::vector<llvm::Type*> arg_type(1);
             arg_type[0] = llvm_type_of(op->args[0].type());
-            llvm::Function *fn = Intrinsic::getDeclaration(module, Intrinsic::ctpop, arg_type);
+            llvm::Function *fn = Intrinsic::getDeclaration(module.get(), Intrinsic::ctpop, arg_type);
             CallInst *call = builder->CreateCall(fn, codegen(op->args[0]));
             value = call;
         } else if (op->name == Call::count_leading_zeros ||
@@ -2372,7 +2366,7 @@ void CodeGen_LLVM::visit(const Call *op) {
             internal_assert(op->args.size() == 1);
             std::vector<llvm::Type*> arg_type(1);
             arg_type[0] = llvm_type_of(op->args[0].type());
-            llvm::Function *fn = Intrinsic::getDeclaration(module,
+            llvm::Function *fn = Intrinsic::getDeclaration(module.get(),
                 (op->name == Call::count_leading_zeros) ? Intrinsic::ctlz :
                                                           Intrinsic::cttz,
                 arg_type);
@@ -2548,7 +2542,7 @@ void CodeGen_LLVM::visit(const Call *op) {
             if (!f) {
                 llvm::Type *arg_types[] = {i8->getPointerTo(), i8->getPointerTo()};
                 FunctionType *func_t = FunctionType::get(void_t, arg_types, false);
-                f = llvm::Function::Create(func_t, llvm::Function::ExternalLinkage, fn->value, module);
+                f = llvm::Function::Create(func_t, llvm::Function::ExternalLinkage, fn->value, module.get());
                 f->setCallingConv(CallingConv::C);
             }
             register_destructor(f, codegen(arg), Always);
@@ -2614,7 +2608,7 @@ void CodeGen_LLVM::visit(const Call *op) {
 
             FunctionType *func_t = FunctionType::get(scalar_result_type, arg_types, false);
 
-            fn = llvm::Function::Create(func_t, llvm::Function::ExternalLinkage, op->name, module);
+            fn = llvm::Function::Create(func_t, llvm::Function::ExternalLinkage, op->name, module.get());
             fn->setCallingConv(CallingConv::C);
             debug(4) << "Did not find " << op->name << ". Declared it extern \"C\".\n";
         } else {
@@ -2911,7 +2905,7 @@ void CodeGen_LLVM::visit(const For *op) {
         FunctionType *func_t = FunctionType::get(i32, args_t, false);
         llvm::Function *containing_function = function;
         function = llvm::Function::Create(func_t, llvm::Function::InternalLinkage,
-                                          "par for " + function->getName() + "_" + op->name, module);
+                                          "par for " + function->getName() + "_" + op->name, module.get());
         function->setDoesNotAlias(3);
 
         // Make the initial basic block and jump the builder into the new function
@@ -3199,7 +3193,7 @@ Value *CodeGen_LLVM::call_intrin(llvm::Type *result_type, int intrin_lanes,
     if (!fn) {
         llvm::Type *intrinsic_result_type = VectorType::get(result_type->getScalarType(), intrin_lanes);
         FunctionType *func_t = FunctionType::get(intrinsic_result_type, arg_types, false);
-        fn = llvm::Function::Create(func_t, llvm::Function::ExternalLinkage, name, module);
+        fn = llvm::Function::Create(func_t, llvm::Function::ExternalLinkage, name, module.get());
         fn->setCallingConv(CallingConv::C);
     }
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -412,7 +412,6 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
     scalar_value_t_type = module->getTypeByName("struct.halide_scalar_value_t");
     internal_assert(scalar_value_t_type) << "Did not find halide_scalar_value_t in initial module";
 
-
     // Generate the code for this module.
     debug(1) << "Generating llvm bitcode...\n";
     for (size_t i = 0; i < input.buffers.size(); i++) {
@@ -827,7 +826,7 @@ void CodeGen_LLVM::optimize_module() {
     }
 
     #if LLVM_VERSION < 37
-    FunctionPassManager function_pass_manager(module);
+    FunctionPassManager function_pass_manager(module.get());
     PassManager module_pass_manager;
     #else
     legacy::FunctionPassManager function_pass_manager(module.get());

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -33,6 +33,7 @@ class GlobalVariable;
 #include <map>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "IRVisitor.h"
 #include "Module.h"
@@ -58,7 +59,7 @@ public:
     virtual ~CodeGen_LLVM();
 
     /** Takes a halide Module and compiles it to an llvm Module. */
-    virtual llvm::Module *compile(const Module &module);
+    virtual std::unique_ptr<llvm::Module> compile(const Module &module);
 
     /** The target we're generating code for */
     const Target &get_target() const { return target; }
@@ -105,7 +106,7 @@ protected:
     static bool llvm_NVPTX_enabled;
     static bool llvm_Mips_enabled;
 
-    llvm::Module *module;
+    std::unique_ptr<llvm::Module> module;
     llvm::Function *function;
     llvm::LLVMContext *context;
     llvm::IRBuilder<true, llvm::ConstantFolder, llvm::IRBuilderDefaultInserter<true>> *builder;
@@ -442,7 +443,8 @@ private:
 }
 
 /** Given a Halide module, generate an llvm::Module. */
-EXPORT llvm::Module *codegen_llvm(const Module &module, llvm::LLVMContext &context);
+EXPORT std::unique_ptr<llvm::Module> codegen_llvm(const Module &module,
+                                                  llvm::LLVMContext &context);
 
 }
 

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -364,14 +364,14 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     if (TD) {
         PM.add(new DataLayout(*TD));
     } else {
-        PM.add(new DataLayout(module));
+        PM.add(new DataLayout(module.get()));
     }
     #else
     if (TD) {
         module->setDataLayout(TD);
     }
     #if LLVM_VERSION == 35
-    PM.add(new DataLayoutPass(module));
+    PM.add(new DataLayoutPass(module.get()));
     #else // llvm >= 3.6
     PM.add(new DataLayoutPass);
     #endif

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -31,6 +31,12 @@ CodeGen_PTX_Dev::CodeGen_PTX_Dev(Target host) : CodeGen_LLVM(host) {
 }
 
 CodeGen_PTX_Dev::~CodeGen_PTX_Dev() {
+    // This is required as destroying the context before the module
+    // results in a crash. Really, reponsbility for destruction
+    // should be entirely in the parent class.
+    // TODO: Figure out how to better manage the context -- e.g. allow using
+    // same one as the host.
+    module.reset();
     delete context;
 }
 
@@ -53,7 +59,7 @@ void CodeGen_PTX_Dev::add_kernel(Stmt stmt,
 
     // Make our function
     FunctionType *func_t = FunctionType::get(void_t, arg_types, false);
-    function = llvm::Function::Create(func_t, llvm::Function::ExternalLinkage, name, module);
+    function = llvm::Function::Create(func_t, llvm::Function::ExternalLinkage, name, module.get());
 
     // Mark the buffer args as no alias
     for (size_t i = 0; i < args.size(); i++) {
@@ -136,7 +142,6 @@ void CodeGen_PTX_Dev::init_module() {
     init_context();
 
     #ifdef WITH_PTX
-    delete module;
     module = get_initial_module_for_ptx_device(target, context);
     #endif
 }

--- a/src/CodeGen_Renderscript_Dev.cpp
+++ b/src/CodeGen_Renderscript_Dev.cpp
@@ -63,7 +63,15 @@ CodeGen_Renderscript_Dev::CodeGen_Renderscript_Dev(Target host) : CodeGen_LLVM(h
     context = new llvm::LLVMContext();
 }
 
-CodeGen_Renderscript_Dev::~CodeGen_Renderscript_Dev() { delete context; }
+CodeGen_Renderscript_Dev::~CodeGen_Renderscript_Dev() {
+    // This is required as destroying the context before the module
+    // results in a crash. Really, reponsbility for destruction
+    // should be entirely in the parent class.
+    // TODO: Figure out how to better manage the context -- e.g. allow using
+    // same one as the host.
+    module.reset();
+    delete context;
+}
 
 void CodeGen_Renderscript_Dev::add_kernel(Stmt stmt, const std::string &kernel_name,
                                 const std::vector<GPU_Argument> &args) {
@@ -160,7 +168,7 @@ void CodeGen_Renderscript_Dev::add_kernel(Stmt stmt, const std::string &kernel_n
 
     FunctionType *func_t = FunctionType::get(void_t, arg_types, false);
     function = llvm::Function::Create(func_t, llvm::Function::ExternalLinkage,
-                                      kernel_name, module);
+                                      kernel_name, module.get());
 
     vector<string> arg_sym_names;
 
@@ -255,7 +263,6 @@ void CodeGen_Renderscript_Dev::init_module() {
     debug(2) << "CodeGen_Renderscript_Dev::init_module\n";
     init_context();
 #ifdef WITH_RENDERSCRIPT
-    delete module;
     module = get_initial_module_for_renderscript_device(target, context);
 
     // Add Renderscript standard set of metadata.
@@ -562,7 +569,7 @@ vector<char> CodeGen_Renderscript_Dev::compile_to_src() {
 
     std::string str;
     llvm::raw_string_ostream OS(str);
-    llvm_3_2::WriteBitcodeToFile(module, OS);
+    llvm_3_2::WriteBitcodeToFile(module.get(), OS);
 
     OS.flush();
 

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -150,22 +150,6 @@ char *start, *end;
 #endif
 
 // Retrieve a function pointer from an llvm module, possibly by compiling it.
-#if 0
-JITModule::Symbol compile_and_get_function(ExecutionEngine *ee, llvm::Module *mod, const string &name) {
-    internal_assert(mod && ee);
-
-    debug(2) << "Retrieving " << name << " from module\n";
-    llvm::Function *fn = mod->getFunction(name);
-    if (!fn) {
-        internal_error << "Could not find function " << name << " in module\n";
-    }
-
-    debug(2) << "JIT Compiling " << name << "\n";
-    void *f = ee->getPointerToFunction(fn);
-    if (!f) {
-        internal_error << "Compiling " << name << " returned NULL\n";
-    }
-#else
 JITModule::Symbol compile_and_get_function(ExecutionEngine &ee, const string &name) {
     debug(2) << "JIT Compiling " << name << "\n";
     llvm::Function *fn = ee.FindFunctionNamed(name.c_str());
@@ -173,7 +157,6 @@ JITModule::Symbol compile_and_get_function(ExecutionEngine &ee, const string &na
     if (!f) {
         internal_error << "Compiling " << name << " returned NULL\n";
     }
-#endif
 
     JITModule::Symbol symbol(f, fn->getFunctionType());
 

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -115,22 +115,19 @@ public:
     mutable RefCount ref_count;
 
     // Just construct a module with symbols to import into other modules.
-    JITModuleContents() : execution_engine(NULL),
-                          module(NULL) {
+    JITModuleContents() : execution_engine(NULL) {
     }
 
     ~JITModuleContents() {
         if (execution_engine != NULL) {
             execution_engine->runStaticConstructorsDestructors(true);
             delete execution_engine;
-            // No need to delete the module - deleting the execution engine should take care of that.
         }
     }
 
     std::map<std::string, JITModule::Symbol> exports;
     llvm::LLVMContext context;
     ExecutionEngine *execution_engine;
-    llvm::Module *module;
     std::vector<JITModule> dependencies;
     JITModule::Symbol entrypoint;
     JITModule::Symbol argv_entrypoint;
@@ -153,26 +150,30 @@ char *start, *end;
 #endif
 
 // Retrieve a function pointer from an llvm module, possibly by compiling it.
-JITModule::Symbol compile_and_get_function(ExecutionEngine *ee, llvm::Module *mod, const string &name, bool optional = false) {
+#if 0
+JITModule::Symbol compile_and_get_function(ExecutionEngine *ee, llvm::Module *mod, const string &name) {
     internal_assert(mod && ee);
 
     debug(2) << "Retrieving " << name << " from module\n";
     llvm::Function *fn = mod->getFunction(name);
     if (!fn) {
-        if (optional) {
-            return JITModule::Symbol();
-        }
         internal_error << "Could not find function " << name << " in module\n";
     }
 
     debug(2) << "JIT Compiling " << name << "\n";
     void *f = ee->getPointerToFunction(fn);
     if (!f) {
-        if (optional) {
-            return JITModule::Symbol();
-        }
         internal_error << "Compiling " << name << " returned NULL\n";
     }
+#else
+JITModule::Symbol compile_and_get_function(ExecutionEngine &ee, const string &name) {
+    debug(2) << "JIT Compiling " << name << "\n";
+    llvm::Function *fn = ee.FindFunctionNamed(name.c_str());
+    void *f = (void *)ee.getFunctionAddress(name);
+    if (!f) {
+        internal_error << "Compiling " << name << " returned NULL\n";
+    }
+#endif
 
     JITModule::Symbol symbol(f, fn->getFunctionType());
 
@@ -223,14 +224,14 @@ JITModule::JITModule() {
 JITModule::JITModule(const Module &m, const LoweredFunc &fn,
                      const std::vector<JITModule> &dependencies) {
     jit_module = new JITModuleContents();
-    llvm::Module *llvm_module = compile_module_to_llvm_module(m, jit_module.ptr->context);
+    std::unique_ptr<llvm::Module> llvm_module(compile_module_to_llvm_module(m, jit_module.ptr->context));
     std::vector<JITModule> deps_with_runtime = dependencies;
-    std::vector<JITModule> shared_runtime = JITSharedRuntime::get(llvm_module, m.target());
+    std::vector<JITModule> shared_runtime = JITSharedRuntime::get(llvm_module.get(), m.target());
     deps_with_runtime.insert(deps_with_runtime.end(), shared_runtime.begin(), shared_runtime.end());
-    compile_module(llvm_module, fn.name, m.target(), deps_with_runtime);
+    compile_module(std::move(llvm_module), fn.name, m.target(), deps_with_runtime);
 }
 
-void JITModule::compile_module(llvm::Module *m, const string &function_name, const Target &target,
+void JITModule::compile_module(std::unique_ptr<llvm::Module> m, const string &function_name, const Target &target,
                                const std::vector<JITModule> &dependencies,
                                const std::vector<std::string> &requested_exports) {
 
@@ -242,12 +243,17 @@ void JITModule::compile_module(llvm::Module *m, const string &function_name, con
     string mcpu;
     string mattrs;
     llvm::TargetOptions options;
-    get_target_options(m, options, mcpu, mattrs);
+    get_target_options(*m, options, mcpu, mattrs);
+
+    #if LLVM_VERSION >= 37
+    DataLayout initial_module_data_layout = m->getDataLayout();
+    #endif
+    string module_name = m->getModuleIdentifier();
 
     #if LLVM_VERSION > 35
-    llvm::EngineBuilder engine_builder((std::unique_ptr<llvm::Module>(m)));
+    llvm::EngineBuilder engine_builder((std::move(m)));
     #else
-    llvm::EngineBuilder engine_builder(m);
+    llvm::EngineBuilder engine_builder(m.release());
     #endif
     engine_builder.setTargetOptions(options);
     engine_builder.setErrorStr(&error_string);
@@ -278,16 +284,15 @@ void JITModule::compile_module(llvm::Module *m, const string &function_name, con
         #else
             DataLayout target_data_layout(tm->createDataLayout());
         #endif
-        if (m->getDataLayout() != target_data_layout) {
-                debug(0) << "Warning: data layout mismatch between module ("
-                             << m->getDataLayout().getStringRepresentation()
-                                 << ") and what the execution engine expects ("
-                                 << target_data_layout.getStringRepresentation() << ")\n";
-                m->setDataLayout(target_data_layout);
+        if (initial_module_data_layout != target_data_layout) {
+                internal_error << "Warning: data layout mismatch between module ("
+                               << initial_module_data_layout.getStringRepresentation()
+                               << ") and what the execution engine expects ("
+                               << target_data_layout.getStringRepresentation() << ")\n";
         }
-    ExecutionEngine *ee = engine_builder.create(tm);
+        ExecutionEngine *ee = engine_builder.create(tm);
     #else
-    ExecutionEngine *ee = engine_builder.create();
+        ExecutionEngine *ee = engine_builder.create();
     #endif
 
     if (!ee) std::cerr << error_string << "\n";
@@ -312,21 +317,21 @@ void JITModule::compile_module(llvm::Module *m, const string &function_name, con
 
     // Retrieve function pointers from the compiled module (which also
     // triggers compilation)
-    debug(1) << "JIT compiling " << m->getModuleIdentifier() << "\n";
+    debug(1) << "JIT compiling " << module_name << "\n";
 
     std::map<std::string, Symbol> exports;
 
     Symbol entrypoint;
     Symbol argv_entrypoint;
     if (!function_name.empty()) {
-        entrypoint = compile_and_get_function(ee, m, function_name);
+        entrypoint = compile_and_get_function(*ee, function_name);
         exports[function_name] = entrypoint;
-        argv_entrypoint = compile_and_get_function(ee, m, function_name + "_argv");
+        argv_entrypoint = compile_and_get_function(*ee, function_name + "_argv");
         exports[function_name + "_argv"] = argv_entrypoint;
     }
 
     for (size_t i = 0; i < requested_exports.size(); i++) {
-        exports[requested_exports[i]] = compile_and_get_function(ee, m, requested_exports[i]);
+        exports[requested_exports[i]] = compile_and_get_function(*ee, requested_exports[i]);
     }
 
     debug(2) << "Finalizing object\n";
@@ -360,7 +365,6 @@ void JITModule::compile_module(llvm::Module *m, const string &function_name, con
     // Stash the various objects that need to stay alive behind a reference-counted pointer.
     jit_module.ptr->exports = exports;
     jit_module.ptr->execution_engine = ee;
-    jit_module.ptr->module = m;
     jit_module.ptr->dependencies = dependencies;
     jit_module.ptr->entrypoint = entrypoint;
     jit_module.ptr->argv_entrypoint = argv_entrypoint;
@@ -468,8 +472,7 @@ void JITModule::memoization_cache_set_size(int64_t size) const {
 }
 
 bool JITModule::compiled() const {
-    // TODO: Track down all uses and make sure changing this to not include "module != NULL" doesn't break anything.
-  return jit_module.ptr->module != NULL;
+  return jit_module.ptr->execution_engine != NULL;
 }
 
 namespace {
@@ -627,9 +630,6 @@ JITModule &make_module(llvm::Module *for_module, Target target,
                        bool create) {
     JITModule &runtime = shared_runtimes(runtime_kind);
     if (!runtime.compiled() && create) {
-        // If the module has not yet been compiled, we need a module to clone the target options from.
-        internal_assert(for_module != NULL);
-
         // Ensure that JIT feature is set on target as it must be in
         // order for the right runtime components to be added.
         target.set_feature(Target::JIT);
@@ -671,24 +671,23 @@ JITModule &make_module(llvm::Module *for_module, Target target,
         }
 
         // This function is protected by a mutex so this is thread safe.
-        llvm::Module *module =
-            get_initial_module_for_target(one_gpu, &runtime.jit_module.ptr->context, true, runtime_kind != MainShared);
-        clone_target_options(for_module, module);
+        std::unique_ptr<llvm::Module> module(get_initial_module_for_target(one_gpu,
+            &runtime.jit_module.ptr->context, true, runtime_kind != MainShared));
+        clone_target_options(*for_module, *module);
         module->setModuleIdentifier(module_name);
 
         std::set<std::string> halide_exports_unique;
 
         // Enumerate the functions.
-        for (llvm::Module::const_iterator iter = module->begin(); iter != module->end(); iter++) {
-            const llvm::Function *gv = cast<llvm::Function>(iter);
-            if (gv->hasWeakLinkage() && starts_with(gv->getName(), "halide_")) {
-                halide_exports_unique.insert(gv->getName());
+        for (auto &f : *module) {
+            if (f.hasWeakLinkage() && starts_with(f.getName(), "halide_")) {
+                halide_exports_unique.insert(f.getName());
             }
         }
 
         std::vector<std::string> halide_exports(halide_exports_unique.begin(), halide_exports_unique.end());
 
-        runtime.compile_module(module, "", target, deps, halide_exports);
+        runtime.compile_module(std::move(module), "", target, deps, halide_exports);
 
         if (runtime_kind == MainShared) {
             runtime_internal_handlers.custom_print =

--- a/src/JITModule.h
+++ b/src/JITModule.h
@@ -7,6 +7,7 @@
  */
 
 #include <map>
+#include <memory>
 
 #include "IntrusivePtr.h"
 #include "Type.h"
@@ -122,7 +123,8 @@ struct JITModule {
 
     /** Take an llvm module and compile it. The requested exports will
         be available via the exports method. */
-    EXPORT void compile_module(llvm::Module *mod, const std::string &function_name, const Target &target,
+    EXPORT void compile_module(std::unique_ptr<llvm::Module> mod,
+                               const std::string &function_name, const Target &target,
                                const std::vector<JITModule> &dependencies = std::vector<JITModule>(),
                                const std::vector<std::string> &requested_exports = std::vector<std::string>());
 

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -247,7 +247,7 @@ void emit_file(llvm::Module &module, const std::string &filename, llvm::TargetMa
 #endif
 }
 
-std::unique_ptr<llvm::Module>compile_module_to_llvm_module(const Module &module, llvm::LLVMContext &context) {
+std::unique_ptr<llvm::Module> compile_module_to_llvm_module(const Module &module, llvm::LLVMContext &context) {
     return codegen_llvm(module, context);
 }
 

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -194,7 +194,7 @@ void emit_file_legacy(llvm::Module &module, const std::string &filename, llvm::T
     // Ask the target to add backend passes as necessary.
     target_machine->addPassesToEmitFile(pass_manager, *out, file_type);
 
-    pass_manager.run(*module);
+    pass_manager.run(module);
 
     delete out;
     delete raw_out;

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -177,7 +177,7 @@ void emit_file_legacy(llvm::Module &module, const std::string &filename, llvm::T
     #endif
 
     #if LLVM_VERSION < 35
-    llvm::DataLayout *layout = new llvm::DataLayout(module);
+    llvm::DataLayout *layout = new llvm::DataLayout(module.get());
     Internal::debug(2) << "Data layout: " << layout->getStringRepresentation();
     pass_manager.add(layout);
     #endif

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -64,11 +64,11 @@ bool get_md_string(LLVMMDNodeArgumentType value, std::string &result) {
 
 }
 
-void get_target_options(const llvm::Module *module, llvm::TargetOptions &options, std::string &mcpu, std::string &mattrs) {
+void get_target_options(const llvm::Module &module, llvm::TargetOptions &options, std::string &mcpu, std::string &mattrs) {
     bool use_soft_float_abi = false;
-    Internal::get_md_bool(module->getModuleFlag("halide_use_soft_float_abi"), use_soft_float_abi);
-    Internal::get_md_string(module->getModuleFlag("halide_mcpu"), mcpu);
-    Internal::get_md_string(module->getModuleFlag("halide_mattrs"), mattrs);
+    Internal::get_md_bool(module.getModuleFlag("halide_use_soft_float_abi"), use_soft_float_abi);
+    Internal::get_md_string(module.getModuleFlag("halide_mcpu"), mcpu);
+    Internal::get_md_string(module.getModuleFlag("halide_mattrs"), mattrs);
 
     options = llvm::TargetOptions();
     options.LessPreciseFPMADOption = true;
@@ -102,51 +102,51 @@ void get_target_options(const llvm::Module *module, llvm::TargetOptions &options
 }
 
 
-void clone_target_options(const llvm::Module *from, llvm::Module *to) {
-    to->setTargetTriple(from->getTargetTriple());
+void clone_target_options(const llvm::Module &from, llvm::Module &to) {
+    to.setTargetTriple(from.getTargetTriple());
 
-    llvm::LLVMContext &context = to->getContext();
+    llvm::LLVMContext &context = to.getContext();
 
     bool use_soft_float_abi = false;
-    if (Internal::get_md_bool(from->getModuleFlag("halide_use_soft_float_abi"), use_soft_float_abi))
-        to->addModuleFlag(llvm::Module::Warning, "halide_use_soft_float_abi", use_soft_float_abi ? 1 : 0);
+    if (Internal::get_md_bool(from.getModuleFlag("halide_use_soft_float_abi"), use_soft_float_abi))
+        to.addModuleFlag(llvm::Module::Warning, "halide_use_soft_float_abi", use_soft_float_abi ? 1 : 0);
 
     std::string mcpu;
-    if (Internal::get_md_string(from->getModuleFlag("halide_mcpu"), mcpu)) {
+    if (Internal::get_md_string(from.getModuleFlag("halide_mcpu"), mcpu)) {
         #if LLVM_VERSION < 36
-        to->addModuleFlag(llvm::Module::Warning, "halide_mcpu", llvm::ConstantDataArray::getString(context, mcpu));
+        to.addModuleFlag(llvm::Module::Warning, "halide_mcpu", llvm::ConstantDataArray::getString(context, mcpu));
         #else
-        to->addModuleFlag(llvm::Module::Warning, "halide_mcpu", llvm::MDString::get(context, mcpu));
+        to.addModuleFlag(llvm::Module::Warning, "halide_mcpu", llvm::MDString::get(context, mcpu));
         #endif
     }
 
     std::string mattrs;
-    if (Internal::get_md_string(from->getModuleFlag("halide_mattrs"), mattrs)) {
+    if (Internal::get_md_string(from.getModuleFlag("halide_mattrs"), mattrs)) {
         #if LLVM_VERSION < 36
-        to->addModuleFlag(llvm::Module::Warning, "halide_mattrs", llvm::ConstantDataArray::getString(context, mattrs));
+        to.addModuleFlag(llvm::Module::Warning, "halide_mattrs", llvm::ConstantDataArray::getString(context, mattrs));
         #else
-        to->addModuleFlag(llvm::Module::Warning, "halide_mattrs", llvm::MDString::get(context, mattrs));
+        to.addModuleFlag(llvm::Module::Warning, "halide_mattrs", llvm::MDString::get(context, mattrs));
         #endif
     }
 }
 
 
-llvm::TargetMachine *get_target_machine(const llvm::Module *module) {
+llvm::TargetMachine *get_target_machine(const llvm::Module &module) {
     std::string error_string;
 
-    const llvm::Target *target = llvm::TargetRegistry::lookupTarget(module->getTargetTriple(), error_string);
+    const llvm::Target *target = llvm::TargetRegistry::lookupTarget(module.getTargetTriple(), error_string);
     if (!target) {
         std::cout << error_string << std::endl;
         llvm::TargetRegistry::printRegisteredTargetsForVersion();
     }
-    internal_assert(target) << "Could not create target for " << module->getTargetTriple() << "\n";
+    internal_assert(target) << "Could not create target for " << module.getTargetTriple() << "\n";
 
     llvm::TargetOptions options;
     std::string mcpu = "";
     std::string mattrs = "";
     get_target_options(module, options, mcpu, mattrs);
 
-    return target->createTargetMachine(module->getTargetTriple(),
+    return target->createTargetMachine(module.getTargetTriple(),
                                        mcpu, mattrs,
                                        options,
                                        llvm::Reloc::PIC_,
@@ -155,9 +155,9 @@ llvm::TargetMachine *get_target_machine(const llvm::Module *module) {
 }
 
 #if LLVM_VERSION < 37
-void emit_file_legacy(llvm::Module *module, const std::string &filename, llvm::TargetMachine::CodeGenFileType file_type) {
+void emit_file_legacy(llvm::Module &module, const std::string &filename, llvm::TargetMachine::CodeGenFileType file_type) {
     Internal::debug(1) << "emit_file_legacy.Compiling to native code...\n";
-    Internal::debug(2) << "Target triple: " << module->getTargetTriple() << "\n";
+    Internal::debug(2) << "Target triple: " << module.getTargetTriple() << "\n";
 
     // Get the target specific parser.
     llvm::TargetMachine *target_machine = get_target_machine(module);
@@ -167,7 +167,7 @@ void emit_file_legacy(llvm::Module *module, const std::string &filename, llvm::T
     llvm::PassManager pass_manager;
 
     // Add an appropriate TargetLibraryInfo pass for the module's triple.
-    pass_manager.add(new llvm::TargetLibraryInfo(llvm::Triple(module->getTargetTriple())));
+    pass_manager.add(new llvm::TargetLibraryInfo(llvm::Triple(module.getTargetTriple())));
 
     #if LLVM_VERSION < 33
     pass_manager.add(new llvm::TargetTransformInfo(target_machine->getScalarTargetTransformInfo(),
@@ -203,12 +203,12 @@ void emit_file_legacy(llvm::Module *module, const std::string &filename, llvm::T
 }
 #endif
 
-void emit_file(llvm::Module *module, const std::string &filename, llvm::TargetMachine::CodeGenFileType file_type) {
+void emit_file(llvm::Module &module, const std::string &filename, llvm::TargetMachine::CodeGenFileType file_type) {
 #if LLVM_VERSION < 37
     emit_file_legacy(module, filename, file_type);
 #else
     Internal::debug(1) << "emit_file.Compiling to native code...\n";
-    Internal::debug(2) << "Target triple: " << module->getTargetTriple() << "\n";
+    Internal::debug(2) << "Target triple: " << module.getTargetTriple() << "\n";
 
     // Get the target specific parser.
     llvm::TargetMachine *target_machine = get_target_machine(module);
@@ -219,14 +219,10 @@ void emit_file(llvm::Module *module, const std::string &filename, llvm::TargetMa
     #else
         llvm::DataLayout target_data_layout(target_machine->createDataLayout());
     #endif
-    if (!(target_data_layout == module->getDataLayout())) {
-        // This *might* be indicative on a bug elsewhere, but might
-        // also be fine. It depends on what the differences are
-        // precisely. Notify when in debug mode.
-        Internal::debug(1) << "Warning: module's data layout does not match target machine's\n"
-                           << target_data_layout.getStringRepresentation() << "\n"
-                           << module->getDataLayout().getStringRepresentation() << "\n";
-        module->setDataLayout(target_data_layout);
+    if (!(target_data_layout == module.getDataLayout())) {
+        internal_error << "Warning: module's data layout does not match target machine's\n"
+                       << target_data_layout.getStringRepresentation() << "\n"
+                       << module.getDataLayout().getStringRepresentation() << "\n";
     }
 
     std::unique_ptr<llvm::raw_fd_ostream> out(new_raw_fd_ostream(filename));
@@ -234,7 +230,7 @@ void emit_file(llvm::Module *module, const std::string &filename, llvm::TargetMa
     // Build up all of the passes that we want to do to the module.
     llvm::legacy::PassManager pass_manager;
 
-    pass_manager.add(new llvm::TargetLibraryInfoWrapperPass(llvm::Triple(module->getTargetTriple())));
+    pass_manager.add(new llvm::TargetLibraryInfoWrapperPass(llvm::Triple(module.getTargetTriple())));
 
     // Make sure things marked as always-inline get inlined
     pass_manager.add(llvm::createAlwaysInlinerPass());
@@ -245,40 +241,40 @@ void emit_file(llvm::Module *module, const std::string &filename, llvm::TargetMa
     // Ask the target to add backend passes as necessary.
     target_machine->addPassesToEmitFile(pass_manager, *out, file_type);
 
-    pass_manager.run(*module);
+    pass_manager.run(module);
 
     delete target_machine;
 #endif
 }
 
-llvm::Module *compile_module_to_llvm_module(const Module &module, llvm::LLVMContext &context) {
+std::unique_ptr<llvm::Module>compile_module_to_llvm_module(const Module &module, llvm::LLVMContext &context) {
     return codegen_llvm(module, context);
 }
 
-void compile_llvm_module_to_object(llvm::Module *module, const std::string &filename) {
+void compile_llvm_module_to_object(llvm::Module &module, const std::string &filename) {
     emit_file(module, filename, llvm::TargetMachine::CGFT_ObjectFile);
 }
 
-void compile_llvm_module_to_assembly(llvm::Module *module, const std::string &filename) {
+void compile_llvm_module_to_assembly(llvm::Module &module, const std::string &filename) {
     emit_file(module, filename, llvm::TargetMachine::CGFT_AssemblyFile);
 }
 
-void compile_llvm_module_to_native(llvm::Module *module,
+void compile_llvm_module_to_native(llvm::Module &module,
                                    const std::string &object_filename,
                                    const std::string &assembly_filename) {
     emit_file(module, object_filename, llvm::TargetMachine::CGFT_ObjectFile);
     emit_file(module, assembly_filename, llvm::TargetMachine::CGFT_AssemblyFile);
 }
 
-void compile_llvm_module_to_llvm_bitcode(llvm::Module *module, const std::string &filename) {
+void compile_llvm_module_to_llvm_bitcode(llvm::Module &module, const std::string &filename) {
     llvm::raw_fd_ostream *file = new_raw_fd_ostream(filename);
-    WriteBitcodeToFile(module, *file);
+    WriteBitcodeToFile(&module, *file);
     delete file;
 }
 
-void compile_llvm_module_to_llvm_assembly(llvm::Module *module, const std::string &filename) {
+void compile_llvm_module_to_llvm_assembly(llvm::Module &module, const std::string &filename) {
     llvm::raw_fd_ostream *file = new_raw_fd_ostream(filename);
-    module->print(*file, NULL);
+    module.print(*file, NULL);
     delete file;
 }
 

--- a/src/LLVM_Output.h
+++ b/src/LLVM_Output.h
@@ -16,26 +16,26 @@ class LLVMContext;
 namespace Halide {
 
 /** Get given an llvm Module, get the target options by extracting the Halide metadata. */
-EXPORT void get_target_options(const llvm::Module *module, llvm::TargetOptions &options, std::string &mcpu, std::string &mattrs);
-EXPORT void clone_target_options(const llvm::Module *from, llvm::Module *to);
+EXPORT void get_target_options(const llvm::Module &module, llvm::TargetOptions &options, std::string &mcpu, std::string &mattrs);
+EXPORT void clone_target_options(const llvm::Module &from, llvm::Module &to);
 
 /** Generate an LLVM module. */
-EXPORT llvm::Module *compile_module_to_llvm_module(const Module &module, llvm::LLVMContext &context);
+EXPORT std::unique_ptr<llvm::Module> compile_module_to_llvm_module(const Module &module, llvm::LLVMContext &context);
 
 /** Compile an LLVM module to native targets (objects, native assembly). */
 // @{
-EXPORT void compile_llvm_module_to_object(llvm::Module *module, const std::string &filename);
-EXPORT void compile_llvm_module_to_assembly(llvm::Module *module, const std::string &filename);
-EXPORT void compile_llvm_module_to_native(llvm::Module *module,
+EXPORT void compile_llvm_module_to_object(llvm::Module &module, const std::string &filename);
+EXPORT void compile_llvm_module_to_assembly(llvm::Module &module, const std::string &filename);
+EXPORT void compile_llvm_module_to_native(llvm::Module &module,
                                           const std::string &object_filename,
                                           const std::string &assembly_filename);
 // @}
 
 /** Compile an LLVM module to LLVM targets (bitcode, LLVM assembly). */
 // @{
-EXPORT void compile_llvm_module_to_llvm_bitcode(llvm::Module *module, const std::string &filename);
-EXPORT void compile_llvm_module_to_llvm_assembly(llvm::Module *module, const std::string &filename);
-EXPORT void compile_llvm_module_to_llvm(llvm::Module *module,
+EXPORT void compile_llvm_module_to_llvm_bitcode(llvm::Module &module, const std::string &filename);
+EXPORT void compile_llvm_module_to_llvm_assembly(llvm::Module &module, const std::string &filename);
+EXPORT void compile_llvm_module_to_llvm(llvm::Module &module,
                                         const std::string &bitcode_filename,
                                         const std::string &llvm_assembly_filename);
 // @}

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -16,18 +16,20 @@ std::unique_ptr<llvm::Module> parse_bitcode_file(llvm::StringRef buf, llvm::LLVM
     llvm::MemoryBuffer *bitcode_buffer = llvm::MemoryBuffer::getMemBuffer(buf);
     #endif
 
-    auto result = llvm::parseBitcodeFile(bitcode_buffer, *context);
-    if (!result) {
-      internal_error << "Could not parse built-in bitcode file " << id << " llvm error is " << result.getError() << "\n";
+    auto ret_val = llvm::parseBitcodeFile(bitcode_buffer, *context);
+    if (!ret_val) {
+        internal_error << "Could not parse built-in bitcode file " << id
+                       << " llvm error is " << ret_val.getError() << "\n";
     }
 
     #if LLVM_VERSION < 36
     delete bitcode_buffer;
     #endif
 
-    (*result)->setModuleIdentifier(id);
+    std::unique_ptr<llvm::Module> result(std::move(*ret_val));
+    result->setModuleIdentifier(id);
 
-    return std::move(*result);
+    return result;
 }
 
 }

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -376,9 +376,9 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t)
                                                 std::move(modules[i]));
         #else
             #if LLVM_VERSION >= 36
-            bool failed = llvm::Linker::LinkModules(modules[0], modules[i]);
+            bool failed = llvm::Linker::LinkModules(modules[0].get(), modules[i].get());
             #else
-            bool failed = llvm::Linker::LinkModules(modules[0], modules[i],
+            bool failed = llvm::Linker::LinkModules(modules[0].get(), modules[i].get(),
                                                 llvm::Linker::DestroySource, &err_msg);
             #endif
 
@@ -406,7 +406,6 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t)
                        ""};
 
     // Enumerate the global variables.
-    //    for (llvm::Module::global_iterator iter = module->global_begin(); iter != module->global_end(); iter++) {
     for (auto &gv : modules[0]->globals()) {
         // No variables are part of the public interface (even the ones labelled halide_)
         llvm::GlobalValue::LinkageTypes t = gv.getLinkage();
@@ -820,8 +819,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_ptx_device(Target target, l
     modules[0]->setDataLayout(&dl);
     #endif
 
-
-
     return std::move(modules[0]);
 }
 #endif
@@ -840,7 +837,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_renderscript_device(Target 
     m->setDataLayout(&dl);
     #endif
 
-    return std::move(m);
+    return m;
 }
 #endif
 

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -376,14 +376,11 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t)
                                                 std::move(modules[i]));
         #else
             #if LLVM_VERSION >= 36
-            bool failed = llvm::Linker::LinkModules(modules[0].get(), modules[i].get());
+            bool failed = llvm::Linker::LinkModules(modules[0].get(), modules[i].release());
             #else
-            bool failed = llvm::Linker::LinkModules(modules[0].get(), modules[i].get(),
-                                                llvm::Linker::DestroySource, &err_msg);
+            bool failed = llvm::Linker::LinkModules(modules[0].get(), modules[i].release(),
+                                                    llvm::Linker::DestroySource, &err_msg);
             #endif
-
-            // LLVM consumed the module so reset the unique_ptr.
-            modules[i].reset();
         #endif
 
         if (failed) {

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -8,7 +8,7 @@ using std::vector;
 
 namespace {
 
-llvm::Module *parse_bitcode_file(llvm::StringRef buf, llvm::LLVMContext *context, const char *id) {
+std::unique_ptr<llvm::Module> parse_bitcode_file(llvm::StringRef buf, llvm::LLVMContext *context, const char *id) {
 
     #if LLVM_VERSION >= 36
     llvm::MemoryBufferRef bitcode_buffer = llvm::MemoryBufferRef(buf, id);
@@ -16,43 +16,39 @@ llvm::Module *parse_bitcode_file(llvm::StringRef buf, llvm::LLVMContext *context
     llvm::MemoryBuffer *bitcode_buffer = llvm::MemoryBuffer::getMemBuffer(buf);
     #endif
 
-    #if LLVM_VERSION >= 37
-    llvm::Module *mod = llvm::parseBitcodeFile(bitcode_buffer, *context).get().release();
-    #elif LLVM_VERSION >= 35
-    llvm::Module *mod = llvm::parseBitcodeFile(bitcode_buffer, *context).get();
-    #else
-    llvm::Module *mod = llvm::ParseBitcodeFile(bitcode_buffer, *context);
-    #endif
+    auto result = llvm::parseBitcodeFile(bitcode_buffer, *context);
+    if (!result) {
+      internal_error << "Could not parse built-in bitcode file " << id << " llvm error is " << result.getError() << "\n";
+    }
 
     #if LLVM_VERSION < 36
     delete bitcode_buffer;
     #endif
 
-    mod->setModuleIdentifier(id);
+    (*result)->setModuleIdentifier(id);
 
-    return mod;
+    return std::move(*result);
 }
 
 }
 
-#define DECLARE_INITMOD(mod)                                            \
-    extern "C" unsigned char halide_internal_initmod_##mod[];           \
-    extern "C" int halide_internal_initmod_##mod##_length;              \
-    llvm::Module *get_initmod_##mod(llvm::LLVMContext *context) {      \
+#define DECLARE_INITMOD(mod)                                                              \
+    extern "C" unsigned char halide_internal_initmod_##mod[];                             \
+    extern "C" int halide_internal_initmod_##mod##_length;                                \
+    std::unique_ptr<llvm::Module> get_initmod_##mod(llvm::LLVMContext *context) {         \
         llvm::StringRef sb = llvm::StringRef((const char *)halide_internal_initmod_##mod, \
-                                             halide_internal_initmod_##mod##_length); \
-        llvm::Module *module = parse_bitcode_file(sb, context, #mod);   \
-        return module;                                                  \
+                                             halide_internal_initmod_##mod##_length);     \
+        return parse_bitcode_file(sb, context, #mod);                                    \
     }
 
-#define DECLARE_NO_INITMOD(mod)                                         \
-    llvm::Module *get_initmod_##mod(llvm::LLVMContext *, bool, bool) { \
-        user_error << "Halide was compiled without support for this target\n"; \
-        return NULL;                                                    \
-    }                                                                   \
-    llvm::Module *get_initmod_##mod##_ll(llvm::LLVMContext *) {         \
-        user_error << "Halide was compiled without support for this target\n"; \
-        return NULL;                                                    \
+#define DECLARE_NO_INITMOD(mod)                                                      \
+  std::unique_ptr<llvm::Module> get_initmod_##mod(llvm::LLVMContext *, bool, bool) { \
+        user_error << "Halide was compiled without support for this target\n";       \
+        return std::unique_ptr<llvm::Module>();                                      \
+    }                                                                                \
+  std::unique_ptr<llvm::Module> get_initmod_##mod##_ll(llvm::LLVMContext *) {        \
+        user_error << "Halide was compiled without support for this target\n";       \
+        return std::unique_ptr<llvm::Module>();                                      \
     }
 
 #define DECLARE_CPP_INITMOD(mod) \
@@ -60,7 +56,7 @@ llvm::Module *parse_bitcode_file(llvm::StringRef buf, llvm::LLVMContext *context
     DECLARE_INITMOD(mod ## _64_debug) \
     DECLARE_INITMOD(mod ## _32) \
     DECLARE_INITMOD(mod ## _64) \
-    llvm::Module *get_initmod_##mod(llvm::LLVMContext *context, bool bits_64, bool debug) { \
+    std::unique_ptr<llvm::Module> get_initmod_##mod(llvm::LLVMContext *context, bool bits_64, bool debug) { \
         if (bits_64) {                                                                      \
             if (debug) return get_initmod_##mod##_64_debug(context);                        \
             else return get_initmod_##mod##_64(context);                                    \
@@ -356,7 +352,7 @@ llvm::Triple get_triple_for_target(Target target) {
 // Link all modules together and with the result in modules[0], all
 // other input modules are destroyed. Sets the datalayout and target
 // triple appropriately for the target.
-void link_modules(std::vector<llvm::Module *> &modules, Target t) {
+void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t) {
 
     llvm::DataLayout data_layout = get_data_layout_for_target(t);
     llvm::Triple triple = get_triple_for_target(t);
@@ -376,18 +372,19 @@ void link_modules(std::vector<llvm::Module *> &modules, Target t) {
     for (size_t i = 1; i < modules.size(); i++) {
         string err_msg;
         #if LLVM_VERSION >= 38
-        bool failed = llvm::Linker::linkModules(*modules[0], std::unique_ptr<llvm::Module>(modules[i]));
-        #elif LLVM_VERSION >= 36
-        bool failed = llvm::Linker::LinkModules(modules[0], modules[i]);
+        bool failed = llvm::Linker::linkModules(*modules[0],
+                                                std::move(modules[i]));
         #else
-        bool failed = llvm::Linker::LinkModules(modules[0], modules[i],
+            #if LLVM_VERSION >= 36
+            bool failed = llvm::Linker::LinkModules(modules[0], modules[i]);
+            #else
+            bool failed = llvm::Linker::LinkModules(modules[0], modules[i],
                                                 llvm::Linker::DestroySource, &err_msg);
-        #endif
+            #endif
 
-        // No matter which version about ran, we passed ownership of
-        // the second module to LLVM. modules[i] is now a dangling
-        // pointer. null it out so we don't accidentally use it.
-        modules[i] = nullptr;
+            // LLVM consumed the module so reset the unique_ptr.
+            modules[i].reset();
+        #endif
 
         if (failed) {
             internal_error << "Failure linking initial modules: " << err_msg << "\n";
@@ -408,50 +405,45 @@ void link_modules(std::vector<llvm::Module *> &modules, Target t) {
                        "__stack_chk_fail",
                        ""};
 
-    llvm::Module *module = modules[0];
-
     // Enumerate the global variables.
-    for (llvm::Module::global_iterator iter = module->global_begin(); iter != module->global_end(); iter++) {
-        if (llvm::GlobalValue *gv = llvm::dyn_cast<llvm::GlobalValue>(iter)) {
-            // No variables are part of the public interface (even the ones labelled halide_)
-            llvm::GlobalValue::LinkageTypes t = gv->getLinkage();
-            if (t == llvm::GlobalValue::WeakAnyLinkage) {
-                gv->setLinkage(llvm::GlobalValue::LinkOnceAnyLinkage);
-            } else if (t == llvm::GlobalValue::WeakODRLinkage) {
-                gv->setLinkage(llvm::GlobalValue::LinkOnceODRLinkage);
-            }
+    //    for (llvm::Module::global_iterator iter = module->global_begin(); iter != module->global_end(); iter++) {
+    for (auto &gv : modules[0]->globals()) {
+        // No variables are part of the public interface (even the ones labelled halide_)
+        llvm::GlobalValue::LinkageTypes t = gv.getLinkage();
+        if (t == llvm::GlobalValue::WeakAnyLinkage) {
+            gv.setLinkage(llvm::GlobalValue::LinkOnceAnyLinkage);
+        } else if (t == llvm::GlobalValue::WeakODRLinkage) {
+            gv.setLinkage(llvm::GlobalValue::LinkOnceODRLinkage);
         }
     }
 
     // Enumerate the functions.
-    for (llvm::Module::iterator iter = module->begin(); iter != module->end(); iter++) {
-        llvm::Function *f = (llvm::Function *)(iter);
-
+    for (auto &f : *modules[0]) {
         bool can_strip = true;
         for (size_t i = 0; !retain[i].empty(); i++) {
-            if (f->getName() == retain[i]) {
+            if (f.getName() == retain[i]) {
                 can_strip = false;
             }
         }
 
-        bool is_halide_extern_c_sym = Internal::starts_with(f->getName(), "halide_");
-        internal_assert(!is_halide_extern_c_sym || f->isWeakForLinker() || f->isDeclaration())
-            << " for function " << (std::string)f->getName() << "\n";
+        bool is_halide_extern_c_sym = Internal::starts_with(f.getName(), "halide_");
+        internal_assert(!is_halide_extern_c_sym || f.isWeakForLinker() || f.isDeclaration())
+            << " for function " << (std::string)f.getName() << "\n";
         can_strip = can_strip && !is_halide_extern_c_sym;
 
         if (can_strip) {
-            llvm::GlobalValue::LinkageTypes t = f->getLinkage();
+            llvm::GlobalValue::LinkageTypes t = f.getLinkage();
             if (t == llvm::GlobalValue::WeakAnyLinkage) {
-                f->setLinkage(llvm::GlobalValue::LinkOnceAnyLinkage);
+                f.setLinkage(llvm::GlobalValue::LinkOnceAnyLinkage);
             } else if (t == llvm::GlobalValue::WeakODRLinkage) {
-                f->setLinkage(llvm::GlobalValue::LinkOnceODRLinkage);
+                f.setLinkage(llvm::GlobalValue::LinkOnceODRLinkage);
             }
         }
     }
 
     // Now remove the force-usage global that prevented clang from
     // dropping functions from the initial module.
-    llvm::GlobalValue *llvm_used = module->getNamedGlobal("llvm.used");
+    llvm::GlobalValue *llvm_used = modules[0]->getNamedGlobal("llvm.used");
     if (llvm_used) {
         llvm_used->eraseFromParent();
     }
@@ -543,7 +535,7 @@ void add_underscores_to_posix_calls_on_windows(llvm::Module *m) {
 }
 
 /** Create an llvm module containing the support code for a given target. */
-llvm::Module *get_initial_module_for_target(Target t, llvm::LLVMContext *c, bool for_shared_jit_runtime, bool just_gpu) {
+std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVMContext *c, bool for_shared_jit_runtime, bool just_gpu) {
     enum InitialModuleType {
         ModuleAOT,
         ModuleAOTNoRuntime,
@@ -575,7 +567,7 @@ llvm::Module *get_initial_module_for_target(Target t, llvm::LLVMContext *c, bool
     bool bits_64 = (t.bits == 64) && (t.os != Target::NaCl);
     bool debug = t.has_feature(Target::Debug);
 
-    vector<llvm::Module *> modules;
+    vector<std::unique_ptr<llvm::Module>> modules;
 
     if (module_type != ModuleGPU) {
         if (module_type != ModuleJITInlined && module_type != ModuleAOTNoRuntime) {
@@ -756,22 +748,22 @@ llvm::Module *get_initial_module_for_target(Target t, llvm::LLVMContext *c, bool
     if (t.os == Target::Windows &&
         t.bits == 32 &&
         (t.has_feature(Target::JIT))) {
-        undo_win32_name_mangling(modules[0]);
+        undo_win32_name_mangling(modules[0].get());
     }
 
     if (t.os == Target::Windows) {
-        add_underscores_to_posix_calls_on_windows(modules[0]);
+        add_underscores_to_posix_calls_on_windows(modules[0].get());
     }
 
-    return modules[0];
+    return std::move(modules[0]);
 }
 
 #ifdef WITH_PTX
-llvm::Module *get_initial_module_for_ptx_device(Target target, llvm::LLVMContext *c) {
-    std::vector<llvm::Module *> modules;
+std::unique_ptr<llvm::Module> get_initial_module_for_ptx_device(Target target, llvm::LLVMContext *c) {
+    std::vector<std::unique_ptr<llvm::Module>> modules;
     modules.push_back(get_initmod_ptx_dev_ll(c));
 
-    llvm::Module *module;
+    std::unique_ptr<llvm::Module> module;
 
     // This table is based on the guidance at:
     // http://docs.nvidia.com/cuda/libdevice-users-guide/basic-usage.html#linking-with-libdevice
@@ -786,7 +778,7 @@ llvm::Module *get_initial_module_for_ptx_device(Target target, llvm::LLVMContext
     } else {
         module = get_initmod_ptx_compute_20_ll(c);
     }
-    modules.push_back(module);
+    modules.push_back(std::move(module));
 
     link_modules(modules, target);
 
@@ -830,13 +822,13 @@ llvm::Module *get_initial_module_for_ptx_device(Target target, llvm::LLVMContext
 
 
 
-    return modules[0];
+    return std::move(modules[0]);
 }
 #endif
 
 #ifdef WITH_RENDERSCRIPT
-llvm::Module *get_initial_module_for_renderscript_device(Target target, llvm::LLVMContext *c) {
-    llvm::Module *m = get_initmod_renderscript_dev_ll(c);
+std::unique_ptr<llvm::Module> get_initial_module_for_renderscript_device(Target target, llvm::LLVMContext *c) {
+    std::unique_ptr<llvm::Module> m(get_initmod_renderscript_dev_ll(c));
 
     llvm::Triple triple("armv7-none-linux-gnueabi");
     m->setTargetTriple(triple.str());
@@ -848,7 +840,7 @@ llvm::Module *get_initial_module_for_renderscript_device(Target target, llvm::LL
     m->setDataLayout(&dl);
     #endif
 
-    return m;
+    return std::move(m);
 }
 #endif
 

--- a/src/LLVM_Runtime_Linker.h
+++ b/src/LLVM_Runtime_Linker.h
@@ -5,6 +5,7 @@
  * Support for linking LLVM modules that comprise the runtime.
  */
 
+#include <memory>
 #include "Target.h"
 
 namespace llvm {
@@ -17,13 +18,13 @@ namespace Halide {
 namespace Internal {
 
 /** Create an llvm module containing the support code for a given target. */
-llvm::Module *get_initial_module_for_target(Target, llvm::LLVMContext *, bool for_shared_jit_runtime = false, bool just_gpu = false);
+std::unique_ptr<llvm::Module> get_initial_module_for_target(Target, llvm::LLVMContext *, bool for_shared_jit_runtime = false, bool just_gpu = false);
 
 /** Create an llvm module containing the support code for ptx device. */
-llvm::Module *get_initial_module_for_ptx_device(Target, llvm::LLVMContext *c);
+std::unique_ptr<llvm::Module> get_initial_module_for_ptx_device(Target, llvm::LLVMContext *c);
 
 /** Create an llvm module containing the support code for renderscript. */
-llvm::Module *get_initial_module_for_renderscript_device(Target target, llvm::LLVMContext *c);
+std::unique_ptr<llvm::Module> get_initial_module_for_renderscript_device(Target target, llvm::LLVMContext *c);
 
 }
 

--- a/src/Output.cpp
+++ b/src/Output.cpp
@@ -19,18 +19,16 @@ void compile_module_to_object(const Module &module, std::string filename) {
     }
 
     llvm::LLVMContext context;
-    llvm::Module *llvm = compile_module_to_llvm_module(module, context);
-    compile_llvm_module_to_object(llvm, filename);
-    delete llvm;
+    std::unique_ptr<llvm::Module> llvm(compile_module_to_llvm_module(module, context));
+    compile_llvm_module_to_object(*llvm, filename);
 }
 
 void compile_module_to_assembly(const Module &module, std::string filename)  {
     if (filename.empty()) filename = module.name() + ".s";
 
     llvm::LLVMContext context;
-    llvm::Module *llvm = compile_module_to_llvm_module(module, context);
-    compile_llvm_module_to_assembly(llvm, filename);
-    delete llvm;
+    std::unique_ptr<llvm::Module> llvm(compile_module_to_llvm_module(module, context));
+    compile_llvm_module_to_assembly(*llvm, filename);
 }
 
 void compile_module_to_native(const Module &module,
@@ -48,28 +46,25 @@ void compile_module_to_native(const Module &module,
     }
 
     llvm::LLVMContext context;
-    llvm::Module *llvm = compile_module_to_llvm_module(module, context);
-    compile_llvm_module_to_object(llvm, object_filename);
-    compile_llvm_module_to_assembly(llvm, assembly_filename);
-    delete llvm;
+    std::unique_ptr<llvm::Module> llvm(compile_module_to_llvm_module(module, context));
+    compile_llvm_module_to_object(*llvm, object_filename);
+    compile_llvm_module_to_assembly(*llvm, assembly_filename);
 }
 
 void compile_module_to_llvm_bitcode(const Module &module, std::string filename)  {
     if (filename.empty()) filename = module.name() + ".bc";
 
     llvm::LLVMContext context;
-    llvm::Module *llvm = compile_module_to_llvm_module(module, context);
-    compile_llvm_module_to_llvm_bitcode(llvm, filename);
-    delete llvm;
+    std::unique_ptr<llvm::Module> llvm(compile_module_to_llvm_module(module, context));
+    compile_llvm_module_to_llvm_bitcode(*llvm, filename);
 }
 
 void compile_module_to_llvm_assembly(const Module &module, std::string filename)  {
     if (filename.empty()) filename = module.name() + ".ll";
 
     llvm::LLVMContext context;
-    llvm::Module *llvm = compile_module_to_llvm_module(module, context);
-    compile_llvm_module_to_llvm_assembly(llvm, filename);
-    delete llvm;
+    std::unique_ptr<llvm::Module> llvm(compile_module_to_llvm_module(module, context));
+    compile_llvm_module_to_llvm_assembly(*llvm, filename);
 }
 
 void compile_module_to_llvm(const Module &module,
@@ -79,10 +74,9 @@ void compile_module_to_llvm(const Module &module,
     if (llvm_assembly_filename.empty()) llvm_assembly_filename = module.name() + ".ll";
 
     llvm::LLVMContext context;
-    llvm::Module *llvm = compile_module_to_llvm_module(module, context);
-    compile_llvm_module_to_llvm_bitcode(llvm, bitcode_filename);
-    compile_llvm_module_to_llvm_assembly(llvm, llvm_assembly_filename);
-    delete llvm;
+    std::unique_ptr<llvm::Module> llvm(compile_module_to_llvm_module(module, context));
+    compile_llvm_module_to_llvm_bitcode(*llvm, bitcode_filename);
+    compile_llvm_module_to_llvm_assembly(*llvm, llvm_assembly_filename);
 }
 
 void compile_module_to_html(const Module &module, std::string filename) {

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -157,27 +157,25 @@ void Pipeline::compile_to(const Outputs &output_files,
     Module m = compile_to_module(args, fn_name, target);
 
     llvm::LLVMContext context;
-    llvm::Module *llvm_module = compile_module_to_llvm_module(m, context);
+    std::unique_ptr<llvm::Module> llvm_module(compile_module_to_llvm_module(m, context));
 
     if (!output_files.object_name.empty()) {
         if (target.arch == Target::PNaCl) {
-            compile_llvm_module_to_llvm_bitcode(llvm_module, output_files.object_name);
+            compile_llvm_module_to_llvm_bitcode(*llvm_module, output_files.object_name);
         } else {
-            compile_llvm_module_to_object(llvm_module, output_files.object_name);
+            compile_llvm_module_to_object(*llvm_module, output_files.object_name);
         }
     }
     if (!output_files.assembly_name.empty()) {
         if (target.arch == Target::PNaCl) {
-            compile_llvm_module_to_llvm_assembly(llvm_module, output_files.assembly_name);
+            compile_llvm_module_to_llvm_assembly(*llvm_module, output_files.assembly_name);
         } else {
-            compile_llvm_module_to_assembly(llvm_module, output_files.assembly_name);
+            compile_llvm_module_to_assembly(*llvm_module, output_files.assembly_name);
         }
     }
     if (!output_files.bitcode_name.empty()) {
-        compile_llvm_module_to_llvm_bitcode(llvm_module, output_files.bitcode_name);
+        compile_llvm_module_to_llvm_bitcode(*llvm_module, output_files.bitcode_name);
     }
-
-    delete llvm_module;
 }
 
 


### PR DESCRIPTION
A few other C++11 cleanups as well.