### PR TITLE
Remove stride_multiple infrastructure.

### DIFF
--- a/src/Argument.h
+++ b/src/Argument.h
@@ -56,13 +56,11 @@ struct Argument {
      * By default, they are left unset, implying "no default, no min, no max". */
     Expr def, min, max;
 
-  int stride_multiples[4];
     Argument() : kind(InputScalar), dimensions(0) {}
     Argument(const std::string &_name, Kind _kind, const Type &_type, uint8_t _dimensions,
                 Expr _def = Expr(),
                 Expr _min = Expr(),
-                Expr _max = Expr(),
-                int *_stride_multiples = nullptr) :
+                Expr _max = Expr()) :
         name(_name), kind(_kind), dimensions(_dimensions), type(_type), def(_def), min(_min), max(_max) {
         user_assert(!(is_scalar() && dimensions != 0))
             << "Scalar Arguments must specify dimensions of 0";
@@ -72,13 +70,6 @@ struct Argument {
             << "Scalar min must not be defined for Buffer Arguments";
         user_assert(!(is_buffer() && max.defined()))
             << "Scalar max must not be defined for Buffer Arguments";
-        if (_stride_multiples) {
-          for (int i = 0; i < _dimensions; i++)
-            stride_multiples[i] = _stride_multiples[i];
-        } else {
-          for (int i = 0; i < _dimensions; i++)
-            stride_multiples[i] = -1;
-        }
     }
 
     bool is_buffer() const { return kind == InputBuffer || kind == OutputBuffer; }

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -2655,7 +2655,8 @@ void CodeGen_Hexagon::visit(const Load *op) {
     const IntImm *stride = ramp ? ramp->stride.as<IntImm>() : NULL;
     if (ramp && stride && stride->value == 1) {
       int width = ramp->lanes;
-      ModulusRemainder mod_rem = getAlignmentInfo(ramp->base);
+      ModulusRemainder mod_rem = get_alignment_info(ramp->base);
+
       int alignment_required = CPICK(128, 64);
       if (width != alignment_required) {
         // This will happen only under two cases.

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -552,23 +552,6 @@ void CodeGen_LLVM::compile_func(const LoweredFunc &f) {
         }
     }
 
-    for (size_t i = 0; i < args.size(); i++) {
-      if (args[i].is_buffer()) {
-        const int *sm = &(args[i].stride_multiples[0]);
-        if (sm) {
-          int dims = args[i].dimensions;
-          string arg_name = args[i].name;
-          for (int j=0; j < dims; j++) {
-            if (sm[j] != -1) {
-              string dim = std::to_string(j);
-              string stride_name = arg_name + ".stride." + dim;
-              ModulusRemainder MR(sm[j], 0);
-              alignment_info.push(stride_name, MR);
-            }
-          }
-        }
-      }
-    }
     // Make our function
     FunctionType *func_t = FunctionType::get(i32, arg_types, false);
     function = llvm::Function::Create(func_t, llvm_linkage(f.linkage), name, module.get());
@@ -1672,9 +1655,7 @@ void CodeGen_LLVM::add_tbaa_metadata(llvm::Instruction *inst, string buffer, Exp
 
     inst->setMetadata("tbaa", tbaa);
 }
-ModulusRemainder CodeGen_LLVM::getAlignmentInfo(Expr e) {
-  return modulus_remainder(e, alignment_info);
-}
+
 void CodeGen_LLVM::visit(const Load *op) {
 
     bool possibly_misaligned = (might_be_misaligned.find(op->name) != might_be_misaligned.end());
@@ -1708,7 +1689,7 @@ void CodeGen_LLVM::visit(const Load *op) {
             // can infer based on the index alone.
 
             // Boost the alignment if possible, up to the native vector width.
-            ModulusRemainder mod_rem = modulus_remainder(ramp->base, alignment_info);
+            ModulusRemainder mod_rem = get_alignment_info(ramp->base);
             if (!possibly_misaligned) {
                 while ((mod_rem.remainder & 1) == 0 &&
                        (mod_rem.modulus & 1) == 0 &&
@@ -3166,7 +3147,7 @@ void CodeGen_LLVM::visit(const Store *op) {
             int native_bytes = native_bits / 8;
 
             // Boost the alignment if possible, up to the native vector width.
-            ModulusRemainder mod_rem = modulus_remainder(ramp->base, alignment_info);
+            ModulusRemainder mod_rem = get_alignment_info(ramp->base);
             if (!possibly_misaligned) {
                 while ((mod_rem.remainder & 1) == 0 &&
                        (mod_rem.modulus & 1) == 0 &&
@@ -3477,6 +3458,10 @@ std::pair<llvm::Function *, int> CodeGen_LLVM::find_vector_runtime_function(cons
     }
 
     return std::make_pair<llvm::Function *, int>(NULL, 0);
+}
+
+ModulusRemainder CodeGen_LLVM::get_alignment_info(Expr e) {
+    return modulus_remainder(e, alignment_info);
 }
 
 }}

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -424,7 +424,10 @@ protected:
      * If there's no match, returns (NULL, 0).
      */
     std::pair<llvm::Function *, int> find_vector_runtime_function(const std::string &name, int lanes);
-    ModulusRemainder getAlignmentInfo(Expr e);
+
+    /** Get the result of modulus-remainder analysis for a given expr. */
+    ModulusRemainder get_alignment_info(Expr e);
+
 private:
 
     /** All the values in scope at the current code location during

--- a/src/Param.cpp
+++ b/src/Param.cpp
@@ -71,10 +71,6 @@ OutputImageParam &OutputImageParam::set_stride(int dim, Expr stride) {
     param.set_stride_constraint(dim, stride);
     return *this;
 }
-OutputImageParam &OutputImageParam::set_stride_multiple(int dim, int stride) {
-    param.set_stride_multiple(dim, stride);
-    return *this;
-}
 
 OutputImageParam &OutputImageParam::set_bounds(int dim, Expr min, Expr extent) {
     return set_min(dim, min).set_extent(dim, extent);
@@ -124,7 +120,7 @@ Internal::Parameter OutputImageParam::parameter() const {
 }
 
 OutputImageParam::operator Argument() const {
-  return Argument(name(), kind, type(), dimensions(), Expr(), Expr(), Expr(), param.stride_multiples());
+  return Argument(name(), kind, type(), dimensions(), Expr(), Expr(), Expr());
 }
 
 OutputImageParam::operator ExternFuncArgument() const {

--- a/src/Param.h
+++ b/src/Param.h
@@ -188,7 +188,7 @@ protected:
 
     /** Is this an input or an output? OutputImageParam is the base class for both. */
     Argument::Kind kind;
-    
+
     void add_implicit_args_if_placeholder(std::vector<Expr> &args,
                                           Expr last_arg,
                                           int total_args,
@@ -255,7 +255,6 @@ public:
      * vectorizing. Known strides for the vectorized dimension
      * generate better code. */
     EXPORT OutputImageParam &set_stride(int dim, Expr stride);
-    EXPORT OutputImageParam &set_stride_multiple(int dim, int stride);
 
     /** Set the min and extent in one call. */
     EXPORT OutputImageParam &set_bounds(int dim, Expr min, Expr extent);

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -20,7 +20,6 @@ struct ParameterContents {
     Expr min_constraint[4];
     Expr extent_constraint[4];
     Expr stride_constraint[4];
-    int stride_multiple[4];
     Expr min_value, max_value;
     ParameterContents(Type t, bool b, int d, const std::string &n, bool e, bool r)
         : type(t), is_buffer(b), dimensions(d), is_explicit_name(e), is_registered(r), name(n), buffer(Buffer()), data(0) {
@@ -28,9 +27,6 @@ struct ParameterContents {
         // dense vectorization. You can unset it by setting it to a
         // null expression. (param.set_stride(0, Expr());)
         stride_constraint[0] = 1;
-        int i;
-        for (i = 0; i < 4; i++)
-          stride_multiple[i] = -1;
     }
 };
 
@@ -212,12 +208,6 @@ void Parameter::set_stride_constraint(int dim, Expr e) {
     contents.ptr->stride_constraint[dim] = e;
 }
 
-void Parameter::set_stride_multiple(int dim, int i) {
-    check_is_buffer();
-    check_dim_ok(dim);
-    contents.ptr->stride_multiple[dim] = i;
-}
-
 Expr Parameter::min_constraint(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
@@ -234,16 +224,6 @@ Expr Parameter::stride_constraint(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
     return contents.ptr->stride_constraint[dim];
-}
-
-int Parameter::stride_multiple(int dim) const {
-    check_is_buffer();
-    check_dim_ok(dim);
-    return contents.ptr->stride_multiple[dim];
-}
-int * Parameter::stride_multiples() const {
-    check_is_buffer();
-    return &(contents.ptr->stride_multiple[0]);
 }
 
 void Parameter::set_min_value(Expr e) {

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -115,12 +115,9 @@ public:
     EXPORT void set_min_constraint(int dim, Expr e);
     EXPORT void set_extent_constraint(int dim, Expr e);
     EXPORT void set_stride_constraint(int dim, Expr e);
-    EXPORT void set_stride_multiple(int dim, int e);
     EXPORT Expr min_constraint(int dim) const;
     EXPORT Expr extent_constraint(int dim) const;
     EXPORT Expr stride_constraint(int dim) const;
-    EXPORT int stride_multiple(int dim) const;
-    EXPORT int *stride_multiples() const;
     //@}
 
     /** Get and set constraints for scalar parameters. These are used

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -329,8 +329,7 @@ private:
         InferredArgument a = {
             Argument(p.name(),
                      p.is_buffer() ? Argument::InputBuffer : Argument::InputScalar,
-                     p.type(), p.dimensions(), def, min, max, p.is_buffer() ?
-                     p.stride_multiples() : nullptr),
+                     p.type(), p.dimensions(), def, min, max),
             p,
             Buffer()};
         args.push_back(a);
@@ -521,11 +520,10 @@ Module Pipeline::compile_to_module(const vector<Argument> &args,
     // Add the output buffer arguments
     for (Function out : contents.ptr->outputs) {
         for (Parameter buf : out.output_buffers()) {
-          // FIXME: PDB: Patch this up for stride_multiples
             public_args.push_back(Argument(buf.name(),
                                            Argument::OutputBuffer,
                                            buf.type(), buf.dimensions(), Expr(),
-                                           Expr(), Expr(), buf.stride_multiples()));
+                                           Expr(), Expr()));
         }
     }
 
@@ -537,7 +535,6 @@ Module Pipeline::compile_to_module(const vector<Argument> &args,
     vector<Argument> private_args = public_args;
     for (Buffer buf : global_images) {
         module.append(buf);
-        // FIXME: PDB: Patch this up for stride_multiples.
         private_args.push_back(Argument(buf.name(),
                                         Argument::InputBuffer,
                                         buf.type(), buf.dimensions()));

--- a/test/hexagon/include/halide-hexagon-setup.h
+++ b/test/hexagon/include/halide-hexagon-setup.h
@@ -58,12 +58,11 @@ void set_min(ImageParam &I, int dim, Expr a) {
 void set_output_buffer_min(Func &f, int dim, Expr a) {
   f.output_buffer().set_min(dim, a);
 }
-void set_stride_multiple(ImageParam &I, int dim, int m) {
-  I.set_stride_multiple(dim, m);
+void set_stride_multiple(OutputImageParam I, int dim, int m) {
+  I.set_stride(dim, (I.stride(dim) / m) * m);
 }
-void set_stride_multiple(Func &f, int dim, int m) {
-  Expr stride = f.output_buffer().stride(dim);
-  f.output_buffer().set_stride_multiple(dim, m);
+void set_stride_multiple(Func f, int dim, int m) {
+  set_stride_multiple(f.output_buffer(), dim, m);
 }
 
 Expr sat_8(Expr e) {


### PR DESCRIPTION
This PR removes the stride_multiple infrastructure, in favor of using the existing set_stride/stride mechanism.

edit: Should have pointed out, this is a pull request into the hexagon branch, not master.