### PR TITLE
Update fake thread pool implementation.

### DIFF
--- a/src/runtime/fake_thread_pool.cpp
+++ b/src/runtime/fake_thread_pool.cpp
@@ -34,7 +34,12 @@ WEAK int (*halide_custom_do_par_for)(void *, halide_task, int, int, uint8_t *) =
 
 extern "C" {
 
-WEAK void halide_mutex_destroy(halide_mutex *mutex_arg) {
+WEAK void halide_spawn_thread(void *user_context, void (*f)(void *), void *closure) {
+    // We can't fake spawning a thread. Emit an error.
+    halide_error(user_context, "halide_spawn_thread not implemented on this platform.");
+}
+
+WEAK void halide_mutex_cleanup(halide_mutex *mutex_arg) {
 }
 
 WEAK void halide_mutex_lock(halide_mutex *mutex) {
@@ -74,4 +79,4 @@ WEAK int halide_do_par_for(void *user_context, int (*f)(void *, int, uint8_t *),
     return (*halide_custom_do_par_for)(user_context, f, min, size, closure);
 }
 
-}
+}  // extern "C"


### PR DESCRIPTION
The fake thread pool was missing halide_spawn_thread, and halide_mutex_destroy needed to be renamed halide_mutex_cleanup.