### PR TITLE
[QTOOL-3157] Updates to Image & halide_malloc instrumentation

### DIFF
--- a/apps/camera_pipe/process.cpp
+++ b/apps/camera_pipe/process.cpp
@@ -5,6 +5,7 @@
 #include "curved.h"
 #include "halide_image.h"
 #include "halide_image_io.h"
+#include "halide_malloc_trace.h"
 
 #include <cstdint>
 #include <cstdio>
@@ -19,6 +20,10 @@ int main(int argc, char **argv) {
                "e.g. ./process raw.png 3200 2 50 5 output.png");
         return 0;
     }
+
+#ifdef HL_MEMINFO
+    halide_enable_malloc_trace();
+#endif
 
     Image<uint16_t> input = load_image(argv[1]);
     fprintf(stderr, "%d %d\n", input.width(), input.height());

--- a/apps/camera_pipe/process.cpp
+++ b/apps/camera_pipe/process.cpp
@@ -29,6 +29,12 @@ int main(int argc, char **argv) {
     fprintf(stderr, "%d %d\n", input.width(), input.height());
     Image<uint8_t> output(((input.width() - 32)/32)*32, ((input.height() - 24)/32)*32, 3);
 
+#ifdef HL_MEMINFO
+    info(input, "input");
+    stats(input, "input");
+    // dump(input, "input");
+#endif
+
     // These color matrices are for the sensor in the Nokia N900 and are
     // taken from the FCam source.
     float _matrix_3200[][4] = {{ 1.6697f, -0.2693f, -0.4004f, -42.4346f},

--- a/tools/halide_image.h
+++ b/tools/halide_image.h
@@ -71,6 +71,10 @@ class Image {
         buf.dev = 0;
         while ((size_t)buf.host & 0x1f) buf.host++;
         contents = new Contents(buf, ptr);
+
+#ifdef HL_MEMINIT
+        info("init");
+#endif
     }
 
 public:
@@ -223,9 +227,14 @@ public:
         contents->buf.min[2] = z;
         contents->buf.min[3] = w;
     }
+
+    void info(const char *tag = "Image") const;
+    void dump(const char *tag = "Image") const;
+    void stats(const char *tag = "Image") const;
 };
 
 }  // namespace Tools
 }  // namespace Halide
 
+#include "halide_image_info.h"
 #endif  // HALIDE_TOOLS_IMAGE_H

--- a/tools/halide_image.h
+++ b/tools/halide_image.h
@@ -184,10 +184,6 @@ public:
         return &(contents->buf);
     }
 
-    uint8_t *alloc() const {
-        return contents->alloc;
-    }
-
     int width() const {
         return dimensions() > 0 ? contents->buf.extent[0] : 1;
     }

--- a/tools/halide_image.h
+++ b/tools/halide_image.h
@@ -71,10 +71,6 @@ class Image {
         buf.dev = 0;
         while ((size_t)buf.host & 0x1f) buf.host++;
         contents = new Contents(buf, ptr);
-
-#ifdef HL_MEMINIT
-        info("init");
-#endif
     }
 
 public:
@@ -188,6 +184,10 @@ public:
         return &(contents->buf);
     }
 
+    uint8_t *alloc() const {
+        return contents->alloc;
+    }
+
     int width() const {
         return dimensions() > 0 ? contents->buf.extent[0] : 1;
     }
@@ -227,10 +227,6 @@ public:
         contents->buf.min[2] = z;
         contents->buf.min[3] = w;
     }
-
-    void info(const char *tag = "Image") const;
-    void dump(const char *tag = "Image") const;
-    void stats(const char *tag = "Image") const;
 };
 
 }  // namespace Tools

--- a/tools/halide_image_info.h
+++ b/tools/halide_image_info.h
@@ -1,0 +1,337 @@
+// This header defines a several methods useful for debugging programs that
+// operate on the Image class supporting images with arbitrary dimensions.
+//
+//   Image<uint16_t> input = load_image(argv[1]);
+//   input.info("input");  // Output the Image header info
+//   input.dump("input");  // Dump the Image data
+//   input.stats("input"); // Collect statistics on the Image
+//
+// These can also be called through macros which automatically tag the
+// output with the symbol name used in the program:
+//
+//   Image_info(input);    // Output the Image header info
+//   Image_dump(input);    // Dump the Image data
+//   Image_stats(input);   // Collect statistics on the Image
+//
+// Info can also be output when an Image is initialized without making any
+// modifications the program by compiling with -DHL_MEMINIT
+//
+// These features are off by default.  To enable, compile with the following
+// flags:
+//
+//   -DHL_MEMINFO  Produce Image info output
+//   -DHL_MEMINIT  Produce Image info when Image is first initialized
+//
+#ifndef HALIDE_TOOLS_IMAGE_INFO_H
+#define HALIDE_TOOLS_IMAGE_INFO_H
+
+#ifndef HL_MEMINFO
+#define Image_info(img)
+#define Image_dump(img)
+#define Image_stats(img)
+#else
+// Stringifying macros to automatically fill in the Image info tag
+#define Image_info(img)  img.info(#img)
+#define Image_dump(img)  img.dump(#img)
+#define Image_stats(img) img.stats(#img)
+#endif // HL_MEMINFO
+
+#if defined(HL_MEMINFO) || defined(HL_MEMINIT)
+#include <cassert>
+#include <cstdlib>
+#include <limits>
+#include <memory>
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <stdint.h>  // <cstdint> requires C++11
+
+#include "HalideRuntime.h"
+
+namespace Halide { namespace Tools {
+
+static inline void print_dimid(int d, int val) {
+    static const char *dimid[] = {"x", "y", "z", "w"};
+    int numdimid = 4;
+    if (d < numdimid)
+        std::cout << " " << dimid[d] << ":" << val;
+    else
+        std::cout << " extent[" << d << "]:" << val;
+}
+
+static inline void print_loc(int32_t *loc, int dim, int32_t *min) {
+    for (int d = 0; d < dim; d++) {
+        if (d) std::cout << ",";
+        std::cout << loc[d] + min[d];
+    }
+}
+
+static inline void print_memalign(intptr_t val) {
+    intptr_t align_chk = 1024*1024;
+    while (align_chk > 0) {
+        if ((val & (align_chk-1)) == 0) {
+            char aunit = ' ';
+            if (align_chk >= 1024) {
+                align_chk >>= 10;
+                aunit = 'K';
+            }
+            if (align_chk >= 1024) {
+                align_chk >>= 10;
+                aunit = 'M';
+            }
+            std::cout << "align:" << align_chk;
+            if (aunit != ' ') {
+                std::cout << aunit;
+            }
+            break;
+        }
+        align_chk >>= 1;
+    }
+}
+
+template<typename T>
+void Image<T>::info(const char *tag) const {
+    int32_t *min = contents->buf.min;
+    int32_t *extent = contents->buf.extent;
+    int32_t *stride = contents->buf.stride;
+    int dim = dimensions();
+    int bpp = contents->buf.elem_size;
+    int32_t size = 1;
+
+    std::cout << std::endl
+              << "-----------------------------------------------------------------------------";
+    std::cout << std::endl << "Image info: " << tag
+              << " dim:" << dim << " bpp:" << bpp;
+    for (int d = 0; d < dim; d++) {
+        print_dimid(d, extent[d]);
+        size *= extent[d];
+    }
+    std::cout << std::endl;
+    std::cout << tag << " class       = 0x" << std::left << std::setw(10) << (void*)this
+                     << std::right << " # ";
+    print_memalign((intptr_t)this); std::cout << std::endl;
+    std::cout << tag << " class size  = "<< sizeof(this)
+                     << " (0x"<< std::hex << sizeof(this) << std::dec <<")\n";
+    std::cout << tag << "-class => [ 0x" << (void*)this
+                     << ", 0x" << (void*)(((char*)this)+sizeof(this)-1)
+                     << " ], # size:" << sizeof(this) << ", ";
+    print_memalign((intptr_t)this); std::cout << std::endl;
+    int img_dim = dimensions();
+    int img_bpp = sizeof(T);
+    std::cout << tag << " img_dim     = " << img_dim << std::endl;
+    std::cout << tag << " bytes/pix   = " << img_bpp << std::endl;
+    std::cout << tag << " width       = " << width() << std::endl;
+    std::cout << tag << " height      = " << height() << std::endl;
+    std::cout << tag << " channels    = " << channels() << std::endl;
+    std::cout << tag << " extent[]    = ";
+    for (int d = 0; d < dim; d++) {
+        std::cout << extent[d] << " ";
+    }
+    std::cout << std::endl;
+    std::cout << tag << " min[]       = ";
+    for (int d = 0; d < dim; d++) {
+        std::cout << min[d] << " ";
+    }
+    std::cout << std::endl;
+    std::cout << tag << " stride[]    = ";
+    for (int d = 0; d < dim; d++) {
+        std::cout << stride[d] << " ";
+    }
+    std::cout << std::endl;
+    if (img_bpp > 1) {
+        for (int d = 0; d < dim; d++) {
+            std::cout << tag << " str[" << d << "]*bpp  = "
+                             << std::left << std::setw(12) << stride[d] * img_bpp
+                             << std::right << " # ";
+            print_memalign(stride[d] * img_bpp); std::cout << std::endl;
+        }
+    }
+
+    uint8_t *alloc = contents->alloc;
+    const T *img_data = data();
+    const T *img_next = img_data + size;
+    int32_t img_size = size * img_bpp;
+    int32_t data_size = (char*)img_next - (char*)img_data;
+    std::cout << tag << " size        = " << size << " (0x"
+                             << std::hex << size << ")" << std::dec << std::endl;
+    std::cout << tag << " img_size    = " << img_size << " (0x"
+                             << std::hex << img_size << ")" << std::dec << std::endl;
+    std::cout << tag << " data        = 0x" << std::left << std::setw(10) << (void *)img_data
+                     << std::right << " # ";
+    print_memalign((intptr_t)img_data); std::cout << std::endl;
+    std::cout << tag << " next        = 0x" << std::left << std::setw(10) << (void *)img_next
+                     << std::right << " # ";
+    print_memalign((intptr_t)img_next); std::cout << std::endl;
+    std::cout << tag << " alloc       = 0x" << std::left << std::setw(10) << (void *)alloc
+                     << std::right << " # ";
+    print_memalign((intptr_t)alloc); std::cout << std::endl;
+    std::cout << tag << " data_size   = " << data_size  << " (0x"
+                             << std::hex << data_size  << ")" << std::dec << std::endl;
+    std::cout << tag << " => [ 0x" << (void *)img_data
+                         << ", 0x" << (void *)(((char*)img_next)-1)
+                         << "], # size:" << data_size << ", ";
+    print_memalign((intptr_t)img_data); std::cout << std::endl;
+    uint8_t *img_headend = (alloc == (uint8_t *)img_data) ? alloc : (uint8_t*)img_data - 1;
+    std::cout << tag << "-header => [ 0x" << (void *)alloc
+                         << ", 0x" << (void *)(img_headend)
+                         << "], # size:" << (char*)img_data - (char*)alloc << ", ";
+    print_memalign((intptr_t)alloc); std::cout << std::endl;
+}
+
+template<typename T>
+void Image<T>::dump(const char *tag) const {
+    int32_t *min = contents->buf.min;
+    int32_t *extent = contents->buf.extent;
+    int32_t *stride = contents->buf.stride;
+    int dim = dimensions();
+    int bpp = contents->buf.elem_size;
+    int32_t size = 1;
+
+    std::cout << std::endl << "Image dump: " << tag
+              << " dim:" << dim << " bpp:" << bpp;
+    for (int d = 0; d < dim; d++) {
+        print_dimid(d, extent[d]);
+        size *= extent[d];
+    }
+
+    // Arbitrary dimension image traversal
+    const T *ptr = (const T *)contents->buf.host;
+    int32_t curloc[dim];
+    for (int d = 1; d < dim; d++) {
+        curloc[d] = -1;
+    }
+    curloc[0] = 0;
+
+    for (int32_t i = 0; i < size; i++) {
+        // Track changes in position in higher dimensions
+        for (int d = 1; d < dim; d++) {
+            if ((i % stride[d]) == 0) {
+                curloc[d]++;
+                for (int din = 0; din < d; din++) {
+                    curloc[din] = 0;
+                }
+                std::cout << std::endl;
+                // Print separators for dimensions beyond (x0,y1)
+                if (d > 1) {
+                    print_dimid(d, curloc[d]+min[d]);
+                    std::cout << "\n==========================================";
+                }
+            }
+        }
+
+        // Check for start of row (or wrap due to width)
+        if ((curloc[0] % 16) == 0) {
+            int widx = 0;
+            std::ostringstream idx;
+            if (dim > 1) {   // Multi-dim, just report (x0,y1) on each row
+               idx << "(" << curloc[0]+min[0] << "," << curloc[1]+min[1] << ")";
+               widx = 12;
+            } else {         // Single-dim
+               idx << curloc[0]+min[0];
+               widx = 4;
+            }
+            std::cout << std::endl << std::setw(widx) << idx.str() << ": ";
+        }
+
+        // Display data
+        std::cout << std::setw(4) << *ptr++ + 0 << " ";
+
+        curloc[0]++;  // Track position in row
+    }
+    std::cout << std::endl;
+}
+
+template<typename T>
+void Image<T>::stats(const char *tag) const {
+    int32_t *min = contents->buf.min;
+    int32_t *extent = contents->buf.extent;
+    int32_t *stride = contents->buf.stride;
+    int dim = dimensions();
+    int bpp = contents->buf.elem_size;
+    int32_t size = 1;
+    std::cout << std::endl << "Image stats: " << tag
+              << " dim:" << dim << " bpp:" << bpp;
+    for (int d = 0; d < dim; d++) {
+        print_dimid(d, extent[d]);
+        size *= extent[d];
+    }
+
+    // Arbitrary dimension image traversal
+    const T *ptr = (const T *)contents->buf.host;
+    int32_t curloc[dim];
+    for (int d = 1; d < dim; d++) {
+        curloc[d] = -1;
+    }
+    curloc[0] = 0;
+
+    // Statistics
+    int32_t cnt = 0;
+    double sum = 0;
+    T minval = *ptr;
+    T maxval = *ptr;
+    int32_t minloc[dim];
+    int32_t maxloc[dim];
+    for (int d = 0; d < dim; d++) {
+        minloc[d] = 0;
+        maxloc[d] = 0;
+    }
+
+    for (int32_t i = 0; i < size; i++) {
+        // Track changes in position in higher dimensions
+        for (int d = 1; d < dim; d++) {
+            if ((i % stride[d]) == 0) {
+                curloc[d]++;
+                for (int din = 0; din < d; din++) {
+                    curloc[din] = 0;
+                }
+            }
+        }
+
+        // Collect data
+        T val = *ptr++;
+        sum += val;
+        cnt++;
+        if (val < minval) {
+            minval = val;
+            for (int d = 0; d < dim; d++) {
+                minloc[d] = curloc[d];
+            }
+        }
+        if (val > maxval) {
+            maxval = val;
+            for (int d = 0; d < dim; d++) {
+                maxloc[d] = curloc[d];
+            }
+        }
+
+        curloc[0]++;  // Track position in row
+    }
+
+    double avg = sum / cnt;
+    std::cout << std::endl;
+    std::cout << "min        = " << minval + 0 << " @ (";
+    print_loc(minloc, dim, min);
+    std::cout << ")" << std::endl;
+    std::cout << "max        = " << maxval + 0 << " @ (";
+    print_loc(maxloc, dim, min);
+    std::cout << ")" << std::endl;
+    std::cout << "mean       = " << avg << std::endl;
+    std::cout << "N          = " << cnt << std::endl;
+    std::cout << std::endl;
+}
+
+}} // namespace Halide::Tools
+
+#else  // ! (HL_MEMINFO || HL_MEMINIT)
+namespace Halide { namespace Tools {
+
+template<typename T>
+void Image<T>::info(const char *tag) const { }
+template<typename T>
+void Image<T>::dump(const char *tag) const { }
+template<typename T>
+void Image<T>::stats(const char *tag) const { }
+
+}} // namespace Halide::Tools
+#endif  // HL_MEMINFO || HL_MEMINIT
+#endif  // HALIDE_TOOLS_IMAGE_INFO_H

--- a/tools/halide_image_info.h
+++ b/tools/halide_image_info.h
@@ -125,7 +125,6 @@ void info(Image<T> &img, const char *tag = "Image") {
         }
     }
 
-    uint8_t *alloc = img.alloc();
     const T *img_data = img.data();
     const T *img_next = img_data + size;
     int32_t img_size = size * img_bpp;
@@ -140,20 +139,12 @@ void info(Image<T> &img, const char *tag = "Image") {
     std::cout << tag << " next        = 0x" << std::left << std::setw(10) << (void *)img_next
                      << std::right << " # ";
     print_memalign((intptr_t)img_next); std::cout << std::endl;
-    std::cout << tag << " alloc       = 0x" << std::left << std::setw(10) << (void *)alloc
-                     << std::right << " # ";
-    print_memalign((intptr_t)alloc); std::cout << std::endl;
     std::cout << tag << " data_size   = " << data_size  << " (0x"
                              << std::hex << data_size  << ")" << std::dec << std::endl;
     std::cout << tag << " => [ 0x" << (void *)img_data
                          << ", 0x" << (void *)(((char*)img_next)-1)
                          << "], # size:" << data_size << ", ";
     print_memalign((intptr_t)img_data); std::cout << std::endl;
-    uint8_t *img_headend = (alloc == (uint8_t *)img_data) ? alloc : (uint8_t*)img_data - 1;
-    std::cout << tag << "-header => [ 0x" << (void *)alloc
-                         << ", 0x" << (void *)(img_headend)
-                         << "], # size:" << (char*)img_data - (char*)alloc << ", ";
-    print_memalign((intptr_t)alloc); std::cout << std::endl;
 }
 
 template<typename T>

--- a/tools/halide_image_info.h
+++ b/tools/halide_image_info.h
@@ -79,6 +79,9 @@ void info(Image<T> &img, const char *tag = "Image") {
     int img_csize = sizeof(Image<T>);
     int img_bsize = sizeof(buffer_t);
     int32_t size = 1;
+    uint64_t dev = buf->dev;
+    bool host_dirty = buf->host_dirty;
+    bool dev_dirty = buf->dev_dirty;
 
     std::cout << std::endl
               << "-----------------------------------------------------------------------------";
@@ -107,6 +110,9 @@ void info(Image<T> &img, const char *tag = "Image") {
     if (img_bpp != img_tsize) {
         std::cout << tag << " sizeof(T)   = " << img_tsize << std::endl;
     }
+    std::cout << tag << " host_dirty  = " << host_dirty << std::endl;
+    std::cout << tag << " dev_dirty   = " << dev_dirty << std::endl;
+    std::cout << tag << " dev handle  = " << dev << std::endl;
     std::cout << tag << " elem_size   = " << img_bpp << std::endl;
     std::cout << tag << " img_dim     = " << dim << std::endl;
     std::cout << tag << " width       = " << img.width() << std::endl;

--- a/tools/halide_image_info.h
+++ b/tools/halide_image_info.h
@@ -1,4 +1,4 @@
-// This header defines a several methods useful for debugging programs that
+// This header defines several methods useful for debugging programs that
 // operate on the Image class supporting images with arbitrary dimensions.
 //
 //   Image<uint16_t> input = load_image(argv[1]);
@@ -48,20 +48,24 @@
 
 #include "HalideRuntime.h"
 
-namespace Halide { namespace Tools {
+namespace Halide {
+namespace Tools {
 
 static inline void print_dimid(int d, int val) {
     static const char *dimid[] = {"x", "y", "z", "w"};
     int numdimid = 4;
-    if (d < numdimid)
+    if (d < numdimid) {
         std::cout << " " << dimid[d] << ":" << val;
-    else
+    } else {
         std::cout << " extent[" << d << "]:" << val;
+    }
 }
 
 static inline void print_loc(int32_t *loc, int dim, int32_t *min) {
     for (int d = 0; d < dim; d++) {
-        if (d) std::cout << ",";
+        if (d) { 
+            std::cout << ",";
+        }
         std::cout << loc[d] + min[d];
     }
 }
@@ -332,6 +336,7 @@ void Image<T>::dump(const char *tag) const { }
 template<typename T>
 void Image<T>::stats(const char *tag) const { }
 
-}} // namespace Halide::Tools
+} // namespace Tools
+} // namespace Halide
 #endif  // HL_MEMINFO || HL_MEMINIT
 #endif  // HALIDE_TOOLS_IMAGE_INFO_H

--- a/tools/halide_image_info.h
+++ b/tools/halide_image_info.h
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <iomanip>
 #include <sstream>
+#include <stdint.h>
 
 #include "HalideRuntime.h"
 
@@ -73,13 +74,16 @@ void info(Image<T> &img, const char *tag = "Image") {
     int32_t *extent = buf->extent;
     int32_t *stride = buf->stride;
     int dim = img.dimensions();
-    int bpp = buf->elem_size;
+    int img_bpp = buf->elem_size;
+    int img_tsize = sizeof(T);
+    int img_csize = sizeof(Image<T>);
+    int img_bsize = sizeof(buffer_t);
     int32_t size = 1;
 
     std::cout << std::endl
               << "-----------------------------------------------------------------------------";
     std::cout << std::endl << "Image info: " << tag
-              << " dim:" << dim << " bpp:" << bpp;
+              << " dim:" << dim << " bpp:" << img_bpp;
     for (int d = 0; d < dim; d++) {
         print_dimid(d, extent[d]);
         size *= extent[d];
@@ -88,15 +92,23 @@ void info(Image<T> &img, const char *tag = "Image") {
     std::cout << tag << " class       = 0x" << std::left << std::setw(10) << (void*)img
                      << std::right << " # ";
     print_memalign((intptr_t)&img); std::cout << std::endl;
-    std::cout << tag << " class size  = "<< sizeof(img)
-                     << " (0x"<< std::hex << sizeof(img) << std::dec <<")\n";
+    std::cout << tag << " class size  = "<< img_csize
+                     << " (0x"<< std::hex << img_csize << std::dec <<")\n";
     std::cout << tag << "-class => [ 0x" << (void*)&img
-                     << ", 0x" << (void*)(((char*)&img)+sizeof(img)-1)
-                     << " ], # size:" << sizeof(img) << ", ";
+                     << ", 0x" << (void*)(((char*)&img)+img_csize-1)
+                     << " ], # size:" << img_csize << ", ";
     print_memalign((intptr_t)&img); std::cout << std::endl;
-    int img_bpp = sizeof(T);
+    std::cout << tag << " buf_t size  = "<< img_bsize
+                     << " (0x"<< std::hex << img_bsize << std::dec <<")\n";
+    std::cout << tag << "-buf_t => [ 0x" << (void*)&buf
+                     << ", 0x" << (void*)(((char*)&buf)+img_bsize-1)
+                     << " ], # size:" << img_bsize << ", ";
+    print_memalign((intptr_t)&buf); std::cout << std::endl;
+    if (img_bpp != img_tsize) {
+        std::cout << tag << " sizeof(T)   = " << img_tsize << std::endl;
+    }
+    std::cout << tag << " elem_size   = " << img_bpp << std::endl;
     std::cout << tag << " img_dim     = " << dim << std::endl;
-    std::cout << tag << " bytes/pix   = " << img_bpp << std::endl;
     std::cout << tag << " width       = " << img.width() << std::endl;
     std::cout << tag << " height      = " << img.height() << std::endl;
     std::cout << tag << " channels    = " << img.channels() << std::endl;

--- a/tools/halide_image_info.h
+++ b/tools/halide_image_info.h
@@ -18,7 +18,6 @@
 #include <iostream>
 #include <iomanip>
 #include <sstream>
-#include <cstdint>
 
 #include "HalideRuntime.h"
 

--- a/tools/halide_malloc_trace.h
+++ b/tools/halide_malloc_trace.h
@@ -6,9 +6,7 @@
 //
 //   halide_enable_malloc_trace();
 //
-// The trace is off by default, compile with the following to turn it on:
-//
-//   -DHL_MEMINFO  Produce memory tracing in the custom malloc trace allocator
+// When the app is run, calls to halide_malloc/free will produce output like:
 //
 //   halide_malloc => [0x9e400, 0xa27ff], # size:17408, align:1K
 //   halide-header => [0x9e390, 0x9e3ff], # size:112, align:16
@@ -18,118 +16,15 @@
 //   halide_free   => [0xa2820, 0xa287f], # size:96, align:32
 //
 //---------------------------------------------------------------------------
-#define HL_MEMBUFLEN  128
 
-extern "C" {
+#include <cstdlib>
+#include <memory>
+#include <iostream>
 
-extern void *malloc(size_t);
-extern void free(void *);
+namespace Halide {
+namespace Tools {
 
-}
-
-namespace Halide { namespace Tools {
-
-#ifdef HL_MEMINFO
-//---------------------------------------------------------------------------
-// Lightweight string generation routines that don't perform any additional
-// heap allocation so that they can be called from halide_malloc/free
-
-// lw_strcpy
-//
-// String copy src to the dst string (not going past the end ptr of dst)
-//
-static char *lw_strcpy(char *dst, const char *end, const char *src) {
-    while (*src) {
-        if (dst < end)
-           *dst++ = *src++;
-        else
-           break;
-    }
-    if (dst <= end) *dst = '\0';
-    return dst;
-}
-
-// lw_endl
-//
-// Guarantee the dst string ends with a newline and NULL terminator even
-// if it means overwriting the last characters present at the end of dst
-//
-static char *lw_endl(char *dst, char *end) {
-    if (dst < end) {
-        *dst++ = '\n';
-        *dst   = '\0';
-    } else {
-        *(end-1) = '\n';
-        *end     = '\0';
-    }
-    return dst;
-}
-
-// lw_val2str
-//
-// Generate the text representation of val for a given base (2 - 16) in the
-// dst string (not going past the end ptr of dst)
-//
-static char *lw_val2str(char *dst, const char *end, intptr_t val, int base = 16) {
-    const char *dig2char = "0123456789abcdef";
-    int maxdigits = sizeof(intptr_t)*8;
-    char numbuf[maxdigits], *numptr = numbuf;
-    if ((base < 2) || (base > 16)) {
-        base = 16;
-    }
-    // Collect the digits (least to most significant digit)
-    if (base == 16) {
-        do { *numptr++ = dig2char[val & 0xf];  val >>= 4;   } while(val);
-    } else if (base == 8) {
-        do { *numptr++ = dig2char[val & 0x7];  val >>= 3;   } while(val);
-    } else if (base == 4) {
-        do { *numptr++ = dig2char[val & 0x3];  val >>= 2;   } while(val);
-    } else if (base == 2) {
-        do { *numptr++ = dig2char[val & 0x1];  val >>= 1;   } while(val);
-    } else if (base < 10) {
-        do { *numptr++ = (val % base) + '0';   val /= base; } while(val);
-    } else {
-        do { *numptr++ = dig2char[val % base]; val /= base; } while(val);
-    }
-    int numdigits = numptr - numbuf;
-    --numptr;   // Point to the most significant digit
-
-    // Add a prefix to identify the base
-    switch (base) {
-        case 16: if (dst < end) *dst++='0'; if (dst < end) *dst++='x'; break;
-        case 10: break;
-        case 8:  if (dst < end) *dst++='0'; break;
-        case 2:  if (dst < end) *dst++='0'; if (dst < end) *dst++='b'; break;
-        default:
-            if (dst < end) *dst++ = 'B';
-            if (dst < end) *dst++ = dig2char[base & 0xf];
-            if (dst < end) *dst++ = '_';
-            break;
-    }
-
-    // Skip leading zeros (all but the least significant digit)
-    int i = numdigits;
-    while ((i > 1) && (*numptr == '0')) {
-        numptr--; i--;
-    }
-    // Copy the digits to dst
-    while (i > 0) {
-        if (dst < end) {
-            *dst++ = *numptr--; i--;
-        } else {
-            break;
-        }
-    }
-    if (dst <= end) *dst = '\0';
-    return dst;
-}
-
-// lw_memalign2str
-//
-// Describe the memory alignment of the val ptr value in the dst string
-// (not going past the end ptr of dst)
-//
-static char *lw_memalign2str(char *dst, const char *end, intptr_t val) {
+static inline void print_meminfoalign(intptr_t val) {
     intptr_t align_chk = 1024*1024;
     while (align_chk > 0) {
         if ((val & (align_chk-1)) == 0) {
@@ -142,21 +37,15 @@ static char *lw_memalign2str(char *dst, const char *end, intptr_t val) {
                 align_chk >>= 10;
                 aunit = 'M';
             }
-
-            dst = lw_strcpy(dst, end, "align:");
-            dst = lw_val2str(dst, end, align_chk, 10);
+            std::cout << "align:" << align_chk;
             if (aunit != ' ') {
-                if (dst < end) *dst++ = aunit;
+                std::cout << aunit;
             }
             break;
         }
         align_chk >>= 1;
     }
-    if (dst <= end) *dst = '\0';
-    return dst;
 }
-//---------------------------------------------------------------------------
-#endif // lw_* HL_MEMINFO
 
 void *halide_malloc_trace(void *user_context, size_t x) {
     // Halide requires halide_malloc to allocate memory that can be
@@ -168,55 +57,37 @@ void *halide_malloc_trace(void *user_context, size_t x) {
         // Will result in a failed assertion and a call to halide_error
         return NULL;
     }
-    // Round up to next multiple of 128. Should add at least 8 bytes so we
-    // can fit the original pointer.
+    // Round up to next multiple of 128.
     void *ptr = (void *)((((size_t)orig + 128) >> 7) << 7);
     ((void **)ptr)[-1] = orig;
 
-#ifdef HL_MEMINFO
-    char mem_buf[HL_MEMBUFLEN], *dst, *end = &(mem_buf[HL_MEMBUFLEN-1]);
     void *headend = (orig == ptr) ? orig : (char *)ptr - 1;
-    dst = mem_buf;
-    dst = lw_strcpy(dst, end, "halide_malloc => [");
-    dst = lw_val2str(dst, end, (intptr_t)ptr);
-    dst = lw_strcpy(dst, end, ", ");
-    dst = lw_val2str(dst, end, (intptr_t)ptr + x-1);
-    dst = lw_strcpy(dst, end, "], # size:");
-    dst = lw_val2str(dst, end, (intptr_t)x, 10);
-    dst = lw_strcpy(dst, end, ", ");
-    dst = lw_memalign2str(dst, end, (intptr_t)ptr);
-    dst = lw_endl(dst, end);
-    halide_print(user_context, mem_buf);
-    dst = mem_buf;
-    dst = lw_strcpy(dst, end, "halide-header => [");
-    dst = lw_val2str(dst, end, (intptr_t)orig);
-    dst = lw_strcpy(dst, end, ", ");
-    dst = lw_val2str(dst, end, (intptr_t)headend);
-    dst = lw_strcpy(dst, end, "], # size:");
-    dst = lw_val2str(dst, end, (intptr_t)ptr - (intptr_t)orig, 10);
-    dst = lw_strcpy(dst, end, ", ");
-    dst = lw_memalign2str(dst, end, (intptr_t)orig);
-    dst = lw_endl(dst, end);
-    halide_print(user_context, mem_buf);
-#endif
+    std::cout << "halide_malloc => [0x" << std::hex
+              << (intptr_t)ptr << ", 0x"
+              << (intptr_t)ptr + x-1 << std::dec
+              << "], # size:"
+              << (intptr_t)x << ", ";
+    print_meminfoalign((intptr_t)ptr);
+    std::cout << std::endl;
+
+    std::cout << "halide-header => [0x" << std::hex
+              << (intptr_t)orig << ", 0x"
+              << (intptr_t)headend << std::dec
+              << "], # size:"
+              << (intptr_t)ptr - (intptr_t)orig << ", ";
+    print_meminfoalign((intptr_t)orig);
+    std::cout << std::endl;
     return ptr;
 }
 
 void halide_free_trace(void *user_context, void *ptr) {
-#ifdef HL_MEMINFO
-    char mem_buf[HL_MEMBUFLEN], *dst, *end = &(mem_buf[HL_MEMBUFLEN-1]);
-    dst = mem_buf;
-    dst = lw_strcpy(dst, end, "halide_free =>   [");
-    dst = lw_val2str(dst, end, (intptr_t)((void**)ptr)[-1]);
-    dst = lw_strcpy(dst, end, ", ");
-    dst = lw_val2str(dst, end, (intptr_t)ptr - 1);
-    dst = lw_strcpy(dst, end, "], # size:");
-    dst = lw_val2str(dst, end, (intptr_t)ptr - (intptr_t)((void**)ptr)[-1], 10);
-    dst = lw_strcpy(dst, end, ", ");
-    dst = lw_memalign2str(dst, end, (intptr_t)((void**)ptr)[-1]);
-    dst = lw_endl(dst, end);
-    halide_print(user_context, mem_buf);
-#endif
+    std::cout << "halide_free => [0x" << std::hex
+              << (intptr_t)((void**)ptr)[-1] << ", 0x"
+              << (intptr_t)ptr - 1 << std::dec
+              << "], # size:"
+              << (intptr_t)ptr - (intptr_t)((void**)ptr)[-1] << ", ";
+    print_meminfoalign((intptr_t)((void**)ptr)[-1]);
+    std::cout << std::endl;
     free(((void**)ptr)[-1]);
 }
 
@@ -225,6 +96,7 @@ void halide_enable_malloc_trace(void) {
     halide_set_custom_free(halide_free_trace);
 }
 
-}} // namespace Halide::Tools
+} // namespace Tools
+} // namespace Halide
 
 #endif // HALIDE_MALLOC_TRACE_H

--- a/tools/halide_malloc_trace.h
+++ b/tools/halide_malloc_trace.h
@@ -1,0 +1,230 @@
+#ifndef HALIDE_MALLOC_TRACE_H
+#define HALIDE_MALLOC_TRACE_H
+
+//---------------------------------------------------------------------------
+// The custom trace allocator can be used in an application by calling:
+//
+//   halide_enable_malloc_trace();
+//
+// The trace is off by default, compile with the following to turn it on:
+//
+//   -DHL_MEMINFO  Produce memory tracing in the custom malloc trace allocator
+//
+//   halide_malloc => [0x9e400, 0xa27ff], # size:17408, align:1K
+//   halide-header => [0x9e390, 0x9e3ff], # size:112, align:16
+//   halide_malloc => [0xa2880, 0xa6e9f], # size:17952, align:128
+//   halide-header => [0xa2820, 0xa287f], # size:96, align:32
+//   halide_free   => [0x9e390, 0x9e3ff], # size:112, align:16
+//   halide_free   => [0xa2820, 0xa287f], # size:96, align:32
+//
+//---------------------------------------------------------------------------
+#define HL_MEMBUFLEN  128
+
+extern "C" {
+
+extern void *malloc(size_t);
+extern void free(void *);
+
+}
+
+namespace Halide { namespace Tools {
+
+#ifdef HL_MEMINFO
+//---------------------------------------------------------------------------
+// Lightweight string generation routines that don't perform any additional
+// heap allocation so that they can be called from halide_malloc/free
+
+// lw_strcpy
+//
+// String copy src to the dst string (not going past the end ptr of dst)
+//
+static char *lw_strcpy(char *dst, const char *end, const char *src) {
+    while (*src) {
+        if (dst < end)
+           *dst++ = *src++;
+        else
+           break;
+    }
+    if (dst <= end) *dst = '\0';
+    return dst;
+}
+
+// lw_endl
+//
+// Guarantee the dst string ends with a newline and NULL terminator even
+// if it means overwriting the last characters present at the end of dst
+//
+static char *lw_endl(char *dst, char *end) {
+    if (dst < end) {
+        *dst++ = '\n';
+        *dst   = '\0';
+    } else {
+        *(end-1) = '\n';
+        *end     = '\0';
+    }
+    return dst;
+}
+
+// lw_val2str
+//
+// Generate the text representation of val for a given base (2 - 16) in the
+// dst string (not going past the end ptr of dst)
+//
+static char *lw_val2str(char *dst, const char *end, intptr_t val, int base = 16) {
+    const char *dig2char = "0123456789abcdef";
+    int maxdigits = sizeof(intptr_t)*8;
+    char numbuf[maxdigits], *numptr = numbuf;
+    if ((base < 2) || (base > 16)) {
+        base = 16;
+    }
+    // Collect the digits (least to most significant digit)
+    if (base == 16) {
+        do { *numptr++ = dig2char[val & 0xf];  val >>= 4;   } while(val);
+    } else if (base == 8) {
+        do { *numptr++ = dig2char[val & 0x7];  val >>= 3;   } while(val);
+    } else if (base == 4) {
+        do { *numptr++ = dig2char[val & 0x3];  val >>= 2;   } while(val);
+    } else if (base == 2) {
+        do { *numptr++ = dig2char[val & 0x1];  val >>= 1;   } while(val);
+    } else if (base < 10) {
+        do { *numptr++ = (val % base) + '0';   val /= base; } while(val);
+    } else {
+        do { *numptr++ = dig2char[val % base]; val /= base; } while(val);
+    }
+    int numdigits = numptr - numbuf;
+    --numptr;   // Point to the most significant digit
+
+    // Add a prefix to identify the base
+    switch (base) {
+        case 16: if (dst < end) *dst++='0'; if (dst < end) *dst++='x'; break;
+        case 10: break;
+        case 8:  if (dst < end) *dst++='0'; break;
+        case 2:  if (dst < end) *dst++='0'; if (dst < end) *dst++='b'; break;
+        default:
+            if (dst < end) *dst++ = 'B';
+            if (dst < end) *dst++ = dig2char[base & 0xf];
+            if (dst < end) *dst++ = '_';
+            break;
+    }
+
+    // Skip leading zeros (all but the least significant digit)
+    int i = numdigits;
+    while ((i > 1) && (*numptr == '0')) {
+        numptr--; i--;
+    }
+    // Copy the digits to dst
+    while (i > 0) {
+        if (dst < end) {
+            *dst++ = *numptr--; i--;
+        } else {
+            break;
+        }
+    }
+    if (dst <= end) *dst = '\0';
+    return dst;
+}
+
+// lw_memalign2str
+//
+// Describe the memory alignment of the val ptr value in the dst string
+// (not going past the end ptr of dst)
+//
+static char *lw_memalign2str(char *dst, const char *end, intptr_t val) {
+    intptr_t align_chk = 1024*1024;
+    while (align_chk > 0) {
+        if ((val & (align_chk-1)) == 0) {
+            char aunit = ' ';
+            if (align_chk >= 1024) {
+                align_chk >>= 10;
+                aunit = 'K';
+            }
+            if (align_chk >= 1024) {
+                align_chk >>= 10;
+                aunit = 'M';
+            }
+
+            dst = lw_strcpy(dst, end, "align:");
+            dst = lw_val2str(dst, end, align_chk, 10);
+            if (aunit != ' ') {
+                if (dst < end) *dst++ = aunit;
+            }
+            break;
+        }
+        align_chk >>= 1;
+    }
+    if (dst <= end) *dst = '\0';
+    return dst;
+}
+//---------------------------------------------------------------------------
+#endif // lw_* HL_MEMINFO
+
+void *halide_malloc_trace(void *user_context, size_t x) {
+    // Halide requires halide_malloc to allocate memory that can be
+    // read 8 bytes before the start and 8 bytes beyond the end.
+    // Additionally, we also need to align it to the natural vector
+    // width.
+    void *orig = malloc(x+(128+8));
+    if (orig == NULL) {
+        // Will result in a failed assertion and a call to halide_error
+        return NULL;
+    }
+    // Round up to next multiple of 128. Should add at least 8 bytes so we
+    // can fit the original pointer.
+    void *ptr = (void *)((((size_t)orig + 128) >> 7) << 7);
+    ((void **)ptr)[-1] = orig;
+
+#ifdef HL_MEMINFO
+    char mem_buf[HL_MEMBUFLEN], *dst, *end = &(mem_buf[HL_MEMBUFLEN-1]);
+    void *headend = (orig == ptr) ? orig : (char *)ptr - 1;
+    dst = mem_buf;
+    dst = lw_strcpy(dst, end, "halide_malloc => [");
+    dst = lw_val2str(dst, end, (intptr_t)ptr);
+    dst = lw_strcpy(dst, end, ", ");
+    dst = lw_val2str(dst, end, (intptr_t)ptr + x-1);
+    dst = lw_strcpy(dst, end, "], # size:");
+    dst = lw_val2str(dst, end, (intptr_t)x, 10);
+    dst = lw_strcpy(dst, end, ", ");
+    dst = lw_memalign2str(dst, end, (intptr_t)ptr);
+    dst = lw_endl(dst, end);
+    halide_print(user_context, mem_buf);
+    dst = mem_buf;
+    dst = lw_strcpy(dst, end, "halide-header => [");
+    dst = lw_val2str(dst, end, (intptr_t)orig);
+    dst = lw_strcpy(dst, end, ", ");
+    dst = lw_val2str(dst, end, (intptr_t)headend);
+    dst = lw_strcpy(dst, end, "], # size:");
+    dst = lw_val2str(dst, end, (intptr_t)ptr - (intptr_t)orig, 10);
+    dst = lw_strcpy(dst, end, ", ");
+    dst = lw_memalign2str(dst, end, (intptr_t)orig);
+    dst = lw_endl(dst, end);
+    halide_print(user_context, mem_buf);
+#endif
+    return ptr;
+}
+
+void halide_free_trace(void *user_context, void *ptr) {
+#ifdef HL_MEMINFO
+    char mem_buf[HL_MEMBUFLEN], *dst, *end = &(mem_buf[HL_MEMBUFLEN-1]);
+    dst = mem_buf;
+    dst = lw_strcpy(dst, end, "halide_free =>   [");
+    dst = lw_val2str(dst, end, (intptr_t)((void**)ptr)[-1]);
+    dst = lw_strcpy(dst, end, ", ");
+    dst = lw_val2str(dst, end, (intptr_t)ptr - 1);
+    dst = lw_strcpy(dst, end, "], # size:");
+    dst = lw_val2str(dst, end, (intptr_t)ptr - (intptr_t)((void**)ptr)[-1], 10);
+    dst = lw_strcpy(dst, end, ", ");
+    dst = lw_memalign2str(dst, end, (intptr_t)((void**)ptr)[-1]);
+    dst = lw_endl(dst, end);
+    halide_print(user_context, mem_buf);
+#endif
+    free(((void**)ptr)[-1]);
+}
+
+void halide_enable_malloc_trace(void) {
+    halide_set_custom_malloc(halide_malloc_trace);
+    halide_set_custom_free(halide_free_trace);
+}
+
+}} // namespace Halide::Tools
+
+#endif // HALIDE_MALLOC_TRACE_H

--- a/tools/halide_malloc_trace.h
+++ b/tools/halide_malloc_trace.h
@@ -49,10 +49,10 @@ static inline void print_meminfoalign(intptr_t val) {
 
 void *halide_malloc_trace(void *user_context, size_t x) {
     // Halide requires halide_malloc to allocate memory that can be
-    // read 8 bytes before the start and 8 bytes beyond the end.
+    // read 8 bytes before the start to store the original pointer.
     // Additionally, we also need to align it to the natural vector
     // width.
-    void *orig = malloc(x+(128+8));
+    void *orig = malloc(x+128);
     if (orig == NULL) {
         // Will result in a failed assertion and a call to halide_error
         return NULL;


### PR DESCRIPTION
- Added several methods useful for debugging programs that operate on
  the Image class supporting images with arbitrary dimensions.

     Image<uint16_t> input = load_image(argv[1]);
     input.info("input");  // Output the Image header info
     input.dump("input");  // Dump the Image data
     input.stats("input"); // Collect statistics on the Image

   These can also be called through macros which automatically tag the
   output with the symbol name used in the program:

     Image_info(input);    // Output the Image header info
     Image_dump(input);    // Dump the Image data
     Image_stats(input);   // Collect statistics on the Image

- These features are off by default.  To enable, compile with the following
  flags:

    -DHL_MEMINFO  Produce Image info output
    -DHL_MEMINIT  Produce Image info when Image is first initialized

- The custom trace allocator can be used in an application by calling:

    halide_enable_malloc_trace();

  The trace is off by default, compile with the following to turn it on:

    -DHL_MEMINFO  Produce memory tracing in the custom malloc trace allocator