### PR TITLE
Align memory on the heap to a 128 byte boundary.

### DIFF
--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -10,13 +10,13 @@ extern void free(void *);
 namespace Halide { namespace Runtime { namespace Internal {
 
 WEAK void *default_malloc(void *user_context, size_t x) {
-    void *orig = malloc(x+40);
+    void *orig = malloc(x+136);
     if (orig == NULL) {
         // Will result in a failed assertion and a call to halide_error
         return NULL;
     }
-    // Round up to next multiple of 32. Should add at least 8 bytes so we can fit the original pointer.
-    void *ptr = (void *)((((size_t)orig + 32) >> 5) << 5);
+    // Round up to next multiple of 128. Should add at least 8 bytes so we can fit the original pointer.
+    void *ptr = (void *)((((size_t)orig + 128) >> 7) << 7);
     ((void **)ptr)[-1] = orig;
     return ptr;
 }

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -11,10 +11,10 @@ namespace Halide { namespace Runtime { namespace Internal {
 
 WEAK void *default_malloc(void *user_context, size_t x) {
     // We want to return an aligned address to the application.
-    // In addition we should have at least the sizeof a pointer number
-    // of bytes so we can fit the original pointer for book keeping.
+    // In addition, we should be able to read a double beyond the
+    // buffer. So we allocate more space then what was asked for.
     const size_t alignment = 128;
-    void *orig = malloc(x + alignment + sizeof(void *));
+    void *orig = malloc(x + alignment + sizeof(double));
     if (orig == NULL) {
         // Will result in a failed assertion and a call to halide_error
         return NULL;


### PR DESCRIPTION
halide_malloc requires allocated memory to be aligned to
at least the natural vector width. Hexagon HVX has 128 byte
vectors. Short of defining a different halide_malloc for each
target, this patch makes halide_malloc return a pointer to a
128 byte aligned block of memory.