### PR TITLE
Alignment padding

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -3157,7 +3157,10 @@ Value *CodeGen_LLVM::create_alloca_at_entry(llvm::Type *t, int n, bool zero_init
         builder->SetInsertPoint(entry, entry->getFirstInsertionPt());
     }
     Value *size = ConstantInt::get(i32, n);
-    Value *ptr = builder->CreateAlloca(t, size, name);
+    AllocaInst *ptr = builder->CreateAlloca(t, size, name);
+    if (t->isVectorTy() || n > 1) {
+        ptr->setAlignment(native_vector_bits() / 8);
+    }
 
     if (zero_initialize) {
         internal_assert(n == 1) << "Zero initialization for stack arrays not implemented\n";

--- a/src/CodeGen_Posix.h
+++ b/src/CodeGen_Posix.h
@@ -41,6 +41,9 @@ protected:
         /** Function to accomplish the destruction. */
         llvm::Function *destructor_function;
 
+        /** The (Halide) type of the allocation. */
+        Type type;
+
         /** How many bytes this allocation is, or 0 if not
          * constant. */
         int constant_bytes;

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -10,16 +10,15 @@ extern void free(void *);
 namespace Halide { namespace Runtime { namespace Internal {
 
 WEAK void *default_malloc(void *user_context, size_t x) {
-    // We want to return an aligned address to the application.
-    // In addition, we should be able to read a double beyond the
-    // buffer. So we allocate more space than what was asked for.
+    // Allocate enough space for aligning the pointer we return.
     const size_t alignment = 128;
-    void *orig = malloc(x + alignment + sizeof(double));
+    void *orig = malloc(x + alignment);
     if (orig == NULL) {
         // Will result in a failed assertion and a call to halide_error
         return NULL;
     }
-    void *ptr = (void *)(((size_t)orig + alignment) & ~(alignment - 1));
+    // We want to store the original pointer prior to the pointer we return.
+    void *ptr = (void *)(((size_t)orig + alignment + sizeof(void*) - 1) & ~(alignment - 1));
     ((void **)ptr)[-1] = orig;
     return ptr;
 }

--- a/test/correctness/storage_folding.cpp
+++ b/test/correctness/storage_folding.cpp
@@ -34,8 +34,10 @@ int main(int argc, char **argv) {
         Image<int> im = g.realize(1000, 1000);
 
         // Should fold by a factor of two, but sliding window analysis makes it round up to 4.
-        if (custom_malloc_size == 0 || custom_malloc_size > 1002*4*sizeof(int)) {
-            printf("Scratch space allocated was %d instead of %d\n", (int)custom_malloc_size, (int)(1002*4*sizeof(int)));
+        // Halide allocates one extra scalar, so we account for that.
+        size_t expected_size = 1002*4*sizeof(int) + sizeof(int);
+        if (custom_malloc_size == 0 || custom_malloc_size > expected_size) {
+            printf("Scratch space allocated was %d instead of %d\n", (int)custom_malloc_size, (int)expected_size);
             return -1;
         }
     }
@@ -126,8 +128,10 @@ int main(int argc, char **argv) {
 
         Image<int> im = f.realize(1000, 1000);
 
-        if (custom_malloc_size == 0 || custom_malloc_size > 2*1002*4*sizeof(int)) {
-            printf("Scratch space allocated was %d instead of %d\n", (int)custom_malloc_size, (int)(1002*4*sizeof(int)));
+        // Halide allocates one extra scalar, so we account for that.
+        size_t expected_size = 2*1002*4*sizeof(int) + sizeof(int);
+        if (custom_malloc_size == 0 || custom_malloc_size > expected_size) {
+            printf("Scratch space allocated was %d instead of %d\n", (int)custom_malloc_size, (int)expected_size);
             return -1;
         }
 
@@ -163,8 +167,10 @@ int main(int argc, char **argv) {
 
         Image<int> im = f.realize(1000, 1000);
 
-        if (custom_malloc_size == 0 || custom_malloc_size > 1000*8*sizeof(int)) {
-            printf("Scratch space allocated was %d instead of %d\n", (int)custom_malloc_size, (int)(1000*8*sizeof(int)));
+        // Halide allocates one extra scalar, so we account for that.
+        size_t expected_size = 1000*8*sizeof(int) + sizeof(int);
+        if (custom_malloc_size == 0 || custom_malloc_size > expected_size) {
+            printf("Scratch space allocated was %d instead of %d\n", (int)custom_malloc_size, (int)expected_size);
             return -1;
         }
 


### PR DESCRIPTION
This PR moves the padding required by CodeGen_LLVM's implementation of Load out of the runtime allocator. This avoids the need for custom allocators to be aware of the requirement. This partially addresses #1044.

This also changes how stack allocations get allocated and aligned.