### PR TITLE
Refactor runtime

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -41,6 +41,7 @@ extern "C" {
  *
  */
 
+
 /** Print a message to stderr. Main use is to support HL_TRACE
  * functionality, print, and print_when calls. Also called by the default
  * halide_error.  This function can be replaced in JITed code by using
@@ -49,7 +50,8 @@ extern "C" {
  */
 // @{
 extern void halide_print(void *user_context, const char *);
-extern void (*halide_set_custom_print(void (*print)(void *, const char *)))(void *, const char *);
+typedef void (*halide_print_t)(void *, const char *);
+extern halide_print_t halide_set_custom_print(halide_print_t print);
 // @}
 
 /** Halide calls this function on runtime errors (for example bounds
@@ -61,7 +63,8 @@ extern void (*halide_set_custom_print(void (*print)(void *, const char *)))(void
  */
 // @{
 extern void halide_error(void *user_context, const char *);
-extern void (*halide_set_error_handler(void (*handler)(void *, const char *)))(void *, const char *);
+typedef void (*halide_error_handler_t)(void *, const char *);
+extern halide_error_handler_t halide_set_error_handler(halide_error_handler_t handler);
 // @}
 
 /** These are allocated statically inside the runtime, hence the fixed
@@ -104,11 +107,13 @@ extern void halide_shutdown_thread_pool();
 
 /** Set a custom method for performing a parallel for loop. Returns
  * the old do_par_for handler. */
-extern int (*halide_set_custom_do_par_for(int (*f)(void *, halide_task_t, int, int, uint8_t *)))(void *, halide_task_t, int, int, uint8_t *);
+typedef int (*halide_do_par_for_t)(void *, halide_task_t, int, int, uint8_t*);
+extern halide_do_par_for_t halide_set_custom_do_par_for(halide_do_par_for_t do_par_for);
 
 /** If you use the default do_par_for, you can still set a custom
  * handler to perform each individual task. Returns the old handler. */
-extern int (*halide_set_custom_do_task(int (*f)(void *, halide_task_t, int, uint8_t *)))(void *, halide_task_t, int, uint8_t *);
+typedef int (*halide_do_task_t)(void *, halide_task_t, int, uint8_t *);
+extern halide_do_task_t halide_set_custom_do_task(halide_do_task_t do_task);
 
 /** Spawn a thread, independent of halide's thread pool. */
 extern void halide_spawn_thread(void *user_context, void (*f)(void *), void *closure);
@@ -134,8 +139,10 @@ extern void halide_set_num_threads(int n);
 //@{
 extern void *halide_malloc(void *user_context, size_t x);
 extern void halide_free(void *user_context, void *ptr);
-extern void *(*halide_set_custom_malloc(void *(*user_malloc)(void *, size_t)))(void *, size_t);
-extern void (*halide_set_custom_free(void (*user_free)(void *, void *)))(void *, void *);
+typedef void *(*halide_malloc_t)(void *, size_t);
+typedef void (*halide_free_t)(void *, void *);
+extern halide_malloc_t halide_set_custom_malloc(halide_malloc_t user_malloc);
+extern halide_free_t halide_set_custom_free(halide_free_t user_free);
 //@}
 
 /** Called when debug_to_file is used inside %Halide code.  See
@@ -208,7 +215,8 @@ struct halide_trace_event {
  */
 // @}
 extern int32_t halide_trace(void *user_context, const struct halide_trace_event *event);
-extern int32_t (*halide_set_custom_trace(int32_t (*halide_trace)(void *, const struct halide_trace_event *)))(void *, const struct halide_trace_event *);
+typedef int32_t (*halide_trace_t)(void *user_context, const struct halide_trace_event *);
+extern halide_trace_t halide_set_custom_trace(halide_trace_t trace);
 // @}
 
 /** Set the file descriptor that Halide should write binary trace

--- a/src/runtime/fake_thread_pool.cpp
+++ b/src/runtime/fake_thread_pool.cpp
@@ -2,21 +2,19 @@
 
 #include "HalideRuntime.h"
 
-typedef int (*halide_task)(void *user_context, int, uint8_t *);
-
 extern "C" {
-WEAK int halide_do_task(void *user_context, halide_task f, int idx,
+WEAK int halide_do_task(void *user_context, halide_task_t f, int idx,
                         uint8_t *closure);
 }
 
 namespace Halide { namespace Runtime { namespace Internal {
 
-WEAK int default_do_task(void *user_context, halide_task f, int idx,
+WEAK int default_do_task(void *user_context, halide_task_t f, int idx,
                         uint8_t *closure) {
     return f(user_context, idx, closure);
 }
 
-WEAK int default_do_par_for(void *user_context, halide_task f,
+WEAK int default_do_par_for(void *user_context, halide_task_t f,
                            int min, int size, uint8_t *closure) {
     for (int x = min; x < min + size; x++) {
         int result = halide_do_task(user_context, f, x, closure);
@@ -27,8 +25,8 @@ WEAK int default_do_par_for(void *user_context, halide_task f,
     return 0;
 }
 
-WEAK int (*halide_custom_do_task)(void *user_context, halide_task, int, uint8_t *) = default_do_task;
-WEAK int (*halide_custom_do_par_for)(void *, halide_task, int, int, uint8_t *) = default_do_par_for;
+WEAK halide_do_task_t custom_do_task = default_do_task;
+WEAK halide_do_par_for_t custom_do_par_for = default_do_par_for;
 
 }}} // namespace Halide::Runtime::Internal
 
@@ -54,29 +52,26 @@ WEAK void halide_shutdown_thread_pool() {
 WEAK void halide_set_num_threads(int) {
 }
 
-WEAK int (*halide_set_custom_do_task(int (*f)(void *, halide_task, int, uint8_t *)))
-           (void *, halide_task, int, uint8_t *) {
-    int (*result)(void *, halide_task, int, uint8_t *) = halide_custom_do_task;
-    halide_custom_do_task = f;
+WEAK halide_do_task_t halide_set_custom_do_task(halide_do_task_t f) {
+    halide_do_task_t result = f;
+    custom_do_task = f;
     return result;
 }
 
-
-WEAK int (*halide_set_custom_do_par_for(int (*f)(void *, halide_task, int, int, uint8_t *)))
-          (void *, halide_task, int, int, uint8_t *) {
-    int (*result)(void *, halide_task, int, int, uint8_t *) = halide_custom_do_par_for;
-    halide_custom_do_par_for = f;
+WEAK halide_do_par_for_t halide_set_custom_do_par_for(halide_do_par_for_t f) {
+    halide_do_par_for_t result = f;
+    custom_do_par_for = f;
     return result;
 }
 
-WEAK int halide_do_task(void *user_context, halide_task f, int idx,
+WEAK int halide_do_task(void *user_context, halide_task_t f, int idx,
                         uint8_t *closure) {
-    return (*halide_custom_do_task)(user_context, f, idx, closure);
+    return (*custom_do_task)(user_context, f, idx, closure);
 }
 
-WEAK int halide_do_par_for(void *user_context, int (*f)(void *, int, uint8_t *),
+WEAK int halide_do_par_for(void *user_context, halide_task_t f,
                            int min, int size, uint8_t *closure) {
-    return (*halide_custom_do_par_for)(user_context, f, min, size, closure);
+  return (*custom_do_par_for)(user_context, f, min, size, closure);
 }
 
 }  // extern "C"

--- a/src/runtime/fake_thread_pool.cpp
+++ b/src/runtime/fake_thread_pool.cpp
@@ -53,13 +53,13 @@ WEAK void halide_set_num_threads(int) {
 }
 
 WEAK halide_do_task_t halide_set_custom_do_task(halide_do_task_t f) {
-    halide_do_task_t result = f;
+    halide_do_task_t result = custom_do_task;
     custom_do_task = f;
     return result;
 }
 
 WEAK halide_do_par_for_t halide_set_custom_do_par_for(halide_do_par_for_t f) {
-    halide_do_par_for_t result = f;
+    halide_do_par_for_t result = custom_do_par_for;
     custom_do_par_for = f;
     return result;
 }

--- a/src/runtime/gcd_thread_pool.cpp
+++ b/src/runtime/gcd_thread_pool.cpp
@@ -16,7 +16,7 @@ extern dispatch_queue_t dispatch_get_global_queue(
 extern void dispatch_apply_f(size_t iterations, dispatch_queue_t queue,
                              void *context, void (*work)(void *, size_t));
 extern void dispatch_async_f(dispatch_queue_t queue, void *context, void (*work)(void *));
-    
+
 typedef struct dispatch_semaphore_s *dispatch_semaphore_t;
 typedef uint64_t dispatch_time_t;
 #define DISPATCH_TIME_FOREVER (~0ull)
@@ -26,7 +26,7 @@ extern long dispatch_semaphore_wait(dispatch_semaphore_t dsema, dispatch_time_t 
 extern long dispatch_semaphore_signal(dispatch_semaphore_t dsema);
 extern void dispatch_release(void *object);
 
-    
+
 WEAK int halide_do_task(void *user_context, halide_task_t f, int idx,
                         uint8_t *closure);
 
@@ -63,7 +63,7 @@ struct halide_gcd_job {
 
 // Take a call from grand-central-dispatch's parallel for loop, and
 // make a call to Halide's do task
-WEAK void halide_do_gcd_task(void *job, size_t idx) {    
+WEAK void halide_do_gcd_task(void *job, size_t idx) {
     halide_gcd_job *j = (halide_gcd_job *)job;
     j->exit_status = halide_do_task(j->user_context, j->f, j->min + (int)idx,
                                     j->closure);
@@ -82,8 +82,8 @@ WEAK int default_do_par_for(void *user_context, halide_task_t f,
     return job.exit_status;
 }
 
-WEAK int (*halide_custom_do_task)(void *user_context, halide_task_t, int, uint8_t *) = default_do_task;
-WEAK int (*halide_custom_do_par_for)(void *, halide_task_t, int, int, uint8_t *) = default_do_par_for;
+WEAK halide_do_task_t custom_do_task = default_do_task;
+WEAK halide_do_par_for_t custom_do_par_for = default_do_par_for;
 
 }}} // namespace Halide::Runtime::Internal
 
@@ -114,28 +114,26 @@ WEAK void halide_shutdown_thread_pool() {
 WEAK void halide_set_num_threads(int) {
 }
 
-WEAK int (*halide_set_custom_do_task(int (*f)(void *, halide_task_t, int, uint8_t *)))
-          (void *, halide_task_t, int, uint8_t *) {
-    int (*result)(void *, halide_task_t, int, uint8_t *) = halide_custom_do_task;
-    halide_custom_do_task = f;
+WEAK halide_do_task_t halide_set_custom_do_task(halide_do_task_t f) {
+    halide_do_task_t result = custom_do_task;
+    custom_do_task = f;
     return result;
 }
 
-WEAK int (*halide_set_custom_do_par_for(int (*f)(void *, halide_task_t, int, int, uint8_t *)))
-          (void *, halide_task_t, int, int, uint8_t *) {
-    int (*result)(void *, halide_task_t, int, int, uint8_t *) = halide_custom_do_par_for;
-    halide_custom_do_par_for = f;
+WEAK halide_do_par_for_t halide_set_custom_do_par_for(halide_do_par_for_t f) {
+    halide_do_par_for_t result = custom_do_par_for;
+    custom_do_par_for = f;
     return result;
 }
 
 WEAK int halide_do_task(void *user_context, halide_task_t f, int idx,
                         uint8_t *closure) {
-    return (*halide_custom_do_task)(user_context, f, idx, closure);
+    return (*custom_do_task)(user_context, f, idx, closure);
 }
 
-WEAK int halide_do_par_for(void *user_context, int (*f)(void *, int, uint8_t *),
+WEAK int halide_do_par_for(void *user_context, halide_task_t f,
                            int min, int size, uint8_t *closure) {
-    return (*halide_custom_do_par_for)(user_context, f, min, size, closure);
+  return (*custom_do_par_for)(user_context, f, min, size, closure);
 }
 
 }

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -1,5 +1,7 @@
 #include "runtime_internal.h"
 
+#include "HalideRuntime.h"
+
 extern "C" {
 
 extern void *malloc(size_t);
@@ -27,21 +29,21 @@ WEAK void default_free(void *user_context, void *ptr) {
     free(((void**)ptr)[-1]);
 }
 
-WEAK void *(*custom_malloc)(void *, size_t) = default_malloc;
-WEAK void (*custom_free)(void *, void *) = default_free;
+WEAK halide_malloc_t custom_malloc = default_malloc;
+WEAK halide_free_t custom_free = default_free;
 
 }}} // namespace Halide::Runtime::Internal
 
 extern "C" {
 
-WEAK void *(*halide_set_custom_malloc(void *(*user_malloc)(void *, size_t)))(void *, size_t) {
-    void *(*result)(void *, size_t) = custom_malloc;
+WEAK halide_malloc_t halide_set_custom_malloc(halide_malloc_t user_malloc) {
+    halide_malloc_t result = custom_malloc;
     custom_malloc = user_malloc;
     return result;
 }
 
-WEAK void (*halide_set_custom_free(void (*user_free)(void *, void *)))(void *, void *) {
-    void (*result)(void *, void *) = custom_free;
+WEAK halide_free_t halide_set_custom_free(halide_free_t user_free) {
+    halide_free_t result = custom_free;
     custom_free = user_free;
     return result;
 }

--- a/src/runtime/posix_error_handler.cpp
+++ b/src/runtime/posix_error_handler.cpp
@@ -18,19 +18,19 @@ WEAK void default_error_handler(void *user_context, const char *msg) {
     abort();
 }
 
-WEAK void (*halide_error_handler)(void *, const char *) = default_error_handler;
+WEAK halide_error_handler_t error_handler = default_error_handler;
 
 }}} // namespace Halide::Runtime::Internal
 
 extern "C" {
 
 WEAK void halide_error(void *user_context, const char *msg) {
-    (*halide_error_handler)(user_context, msg);
+    (*error_handler)(user_context, msg);
 }
 
-WEAK void (*halide_set_error_handler(void (*handler)(void *, const char *)))(void *, const char *) {
-    void (*result)(void *, const char *) = halide_error_handler;
-    halide_error_handler = handler;
+WEAK halide_error_handler_t halide_set_error_handler(halide_error_handler_t handler) {
+    halide_error_handler_t result = handler;
+    error_handler = handler;
     return result;
 }
 

--- a/src/runtime/posix_error_handler.cpp
+++ b/src/runtime/posix_error_handler.cpp
@@ -29,7 +29,7 @@ WEAK void halide_error(void *user_context, const char *msg) {
 }
 
 WEAK halide_error_handler_t halide_set_error_handler(halide_error_handler_t handler) {
-    halide_error_handler_t result = handler;
+    halide_error_handler_t result = error_handler;
     error_handler = handler;
     return result;
 }

--- a/src/runtime/posix_print.cpp
+++ b/src/runtime/posix_print.cpp
@@ -4,20 +4,20 @@
 namespace Halide { namespace Runtime { namespace Internal {
 
 extern void halide_print_impl(void *, const char *);
-WEAK void (*halide_custom_print)(void *, const char *) = halide_print_impl;
+
+WEAK halide_print_t custom_print = halide_print_impl;
 
 }}} // namespace Halide::Runtime::Internal
 
 extern "C" {
 
 WEAK void halide_print(void *user_context, const char *msg) {
-    (*halide_custom_print)(user_context, msg);
+    (*custom_print)(user_context, msg);
 }
 
-WEAK void (*halide_set_custom_print(void (*print)(void *, const char *)))
-            (void *, const char *) {
-    void (*result)(void *, const char *) = halide_custom_print;
-    halide_custom_print = print;
+WEAK halide_print_t halide_set_custom_print(halide_print_t print) {
+    halide_print_t result = custom_print;
+    custom_print = print;
     return result;
 }
 

--- a/src/runtime/posix_thread_pool.cpp
+++ b/src/runtime/posix_thread_pool.cpp
@@ -58,8 +58,8 @@ WEAK int halide_do_task(void *user_context, halide_task_t f, int idx,
 
 namespace Halide { namespace Runtime { namespace Internal {
 
-WEAK int halide_num_threads;
-WEAK bool halide_thread_pool_initialized = false;
+WEAK int num_threads;
+WEAK bool thread_pool_initialized = false;
 
 struct work {
     work *next_job;
@@ -74,7 +74,7 @@ struct work {
 
 // The work queue and thread pool is weak, so one big work queue is shared by all halide functions
 #define MAX_THREADS 64
-struct halide_work_queue_t {
+struct work_queue_t {
     // all fields are protected by this mutex.
     pthread_mutex_t mutex;
 
@@ -110,45 +110,45 @@ struct halide_work_queue_t {
     }
 
 };
-WEAK halide_work_queue_t halide_work_queue;
+WEAK work_queue_t work_queue;
 
 WEAK int default_do_task(void *user_context, halide_task_t f, int idx,
                         uint8_t *closure) {
     return f(user_context, idx, closure);
 }
 
-WEAK void *halide_worker_thread(void *void_arg) {
+WEAK void *worker_thread(void *void_arg) {
     work *owned_job = (work *)void_arg;
 
     // Grab the lock
-    pthread_mutex_lock(&halide_work_queue.mutex);
+    pthread_mutex_lock(&work_queue.mutex);
 
     // If I'm a job owner, then I was the thread that called
     // do_par_for, and I should only stay in this function until my
     // job is complete. If I'm a lowly worker thread, I should stay in
     // this function as long as the work queue is running.
     while (owned_job != NULL ? owned_job->running()
-           : halide_work_queue.running()) {
+           : work_queue.running()) {
 
-        if (halide_work_queue.jobs == NULL) {
+        if (work_queue.jobs == NULL) {
             if (owned_job) {
                 // There are no jobs pending. Wait for the last worker
                 // to signal that the job is finished.
-                pthread_cond_wait(&halide_work_queue.wakeup_owners, &halide_work_queue.mutex);
-            } else if (halide_work_queue.a_team_size <= halide_work_queue.target_a_team_size) {
+                pthread_cond_wait(&work_queue.wakeup_owners, &work_queue.mutex);
+            } else if (work_queue.a_team_size <= work_queue.target_a_team_size) {
                 // There are no jobs pending. Wait until more jobs are enqueued.
-                pthread_cond_wait(&halide_work_queue.wakeup_a_team, &halide_work_queue.mutex);
+                pthread_cond_wait(&work_queue.wakeup_a_team, &work_queue.mutex);
             } else {
                 // There are no jobs pending, and there are too many
                 // threads in the A team. Transition to the B team
                 // until the wakeup_b_team condition is fired.
-                halide_work_queue.a_team_size--;
-                pthread_cond_wait(&halide_work_queue.wakeup_b_team, &halide_work_queue.mutex);
-                halide_work_queue.a_team_size++;
+                work_queue.a_team_size--;
+                pthread_cond_wait(&work_queue.wakeup_b_team, &work_queue.mutex);
+                work_queue.a_team_size++;
             }
         } else {
             // Grab the next job.
-            work *job = halide_work_queue.jobs;
+            work *job = work_queue.jobs;
 
             // Claim a task from it.
             work myjob = *job;
@@ -157,7 +157,7 @@ WEAK void *halide_worker_thread(void *void_arg) {
             // If there were no more tasks pending for this job,
             // remove it from the stack.
             if (job->next == job->max) {
-                halide_work_queue.jobs = job->next_job;
+                work_queue.jobs = job->next_job;
             }
 
             // Increment the active_worker count so that other threads
@@ -166,10 +166,10 @@ WEAK void *halide_worker_thread(void *void_arg) {
             job->active_workers++;
 
             // Release the lock and do the task.
-            pthread_mutex_unlock(&halide_work_queue.mutex);
+            pthread_mutex_unlock(&work_queue.mutex);
             int result = halide_do_task(myjob.user_context, myjob.f, myjob.next,
                                         myjob.closure);
-            pthread_mutex_lock(&halide_work_queue.mutex);
+            pthread_mutex_lock(&work_queue.mutex);
 
             // If this task failed, set the exit status on the job.
             if (result) {
@@ -182,11 +182,11 @@ WEAK void *halide_worker_thread(void *void_arg) {
             // If the job is done and I'm not the owner of it, wake up
             // the owner.
             if (!job->running() && job != owned_job) {
-                pthread_cond_broadcast(&halide_work_queue.wakeup_owners);
+                pthread_cond_broadcast(&work_queue.wakeup_owners);
             }
         }
     }
-    pthread_mutex_unlock(&halide_work_queue.mutex);
+    pthread_mutex_unlock(&work_queue.mutex);
     return NULL;
 }
 
@@ -196,41 +196,41 @@ WEAK int default_do_par_for(void *user_context, halide_task_t f,
     // field will be zero-initialized because it's a static
     // global. pthreads helpfully interprets zero-valued mutex objects
     // as uninitialized and initializes them for you (see PTHREAD_MUTEX_INITIALIZER).
-    pthread_mutex_lock(&halide_work_queue.mutex);
+    pthread_mutex_lock(&work_queue.mutex);
 
-    if (!halide_thread_pool_initialized) {
-        halide_work_queue.shutdown = false;
-        pthread_cond_init(&halide_work_queue.wakeup_owners, NULL);
-        pthread_cond_init(&halide_work_queue.wakeup_a_team, NULL);
-        pthread_cond_init(&halide_work_queue.wakeup_b_team, NULL);
-        halide_work_queue.jobs = NULL;
+    if (!thread_pool_initialized) {
+        work_queue.shutdown = false;
+        pthread_cond_init(&work_queue.wakeup_owners, NULL);
+        pthread_cond_init(&work_queue.wakeup_a_team, NULL);
+        pthread_cond_init(&work_queue.wakeup_b_team, NULL);
+        work_queue.jobs = NULL;
 
-        if (!halide_num_threads) {
+        if (!num_threads) {
             char *threads_str = getenv("HL_NUM_THREADS");
             if (!threads_str) {
                 // Legacy name for HL_NUM_THREADS
                 threads_str = getenv("HL_NUMTHREADS");
             }
             if (threads_str) {
-                halide_num_threads = atoi(threads_str);
+                num_threads = atoi(threads_str);
             } else {
-                halide_num_threads = halide_host_cpu_count();
-                // halide_printf(user_context, "HL_NUM_THREADS not defined. Defaulting to %d threads.\n", halide_num_threads);
+                num_threads = halide_host_cpu_count();
+                // halide_printf(user_context, "HL_NUM_THREADS not defined. Defaulting to %d threads.\n", num_threads);
             }
         }
-        if (halide_num_threads > MAX_THREADS) {
-            halide_num_threads = MAX_THREADS;
-        } else if (halide_num_threads < 1) {
-            halide_num_threads = 1;
+        if (num_threads > MAX_THREADS) {
+            num_threads = MAX_THREADS;
+        } else if (num_threads < 1) {
+            num_threads = 1;
         }
-        for (int i = 0; i < halide_num_threads-1; i++) {
+        for (int i = 0; i < num_threads-1; i++) {
             //fprintf(stderr, "Creating thread %d\n", i);
-            pthread_create(halide_work_queue.threads + i, NULL, halide_worker_thread, NULL);
+            pthread_create(work_queue.threads + i, NULL, worker_thread, NULL);
         }
         // Everyone starts on the a team.
-        halide_work_queue.a_team_size = halide_num_threads;
+        work_queue.a_team_size = num_threads;
 
-        halide_thread_pool_initialized = true;
+        thread_pool_initialized = true;
     }
 
     // Make the job.
@@ -243,50 +243,50 @@ WEAK int default_do_par_for(void *user_context, halide_task_t f,
     job.exit_status = 0;     // The job hasn't failed yet
     job.active_workers = 0;  // Nobody is working on this yet
 
-    if (!halide_work_queue.jobs && size < halide_num_threads) {
+    if (!work_queue.jobs && size < num_threads) {
         // If there's no nested parallelism happening and there are
         // fewer tasks to do than threads, then set the target A team
         // size so that some threads will put themselves to sleep
         // until a larger job arrives.
-        halide_work_queue.target_a_team_size = size;
+        work_queue.target_a_team_size = size;
     } else {
-        halide_work_queue.target_a_team_size = halide_num_threads;
+        work_queue.target_a_team_size = num_threads;
     }
 
     // If there are more tasks than threads in the A team, we should
     // wake up everyone.
-    bool wake_b_team = size > halide_work_queue.a_team_size;
+    bool wake_b_team = size > work_queue.a_team_size;
 
     // Push the job onto the stack.
-    job.next_job = halide_work_queue.jobs;
-    halide_work_queue.jobs = &job;
+    job.next_job = work_queue.jobs;
+    work_queue.jobs = &job;
 
-    pthread_mutex_unlock(&halide_work_queue.mutex);
+    pthread_mutex_unlock(&work_queue.mutex);
 
     // Wake up our A team.
-    pthread_cond_broadcast(&halide_work_queue.wakeup_a_team);
+    pthread_cond_broadcast(&work_queue.wakeup_a_team);
 
     if (wake_b_team) {
         // We need the B team too.
-        pthread_cond_broadcast(&halide_work_queue.wakeup_b_team);
+        pthread_cond_broadcast(&work_queue.wakeup_b_team);
     }
 
     // Do some work myself.
-    halide_worker_thread((void *)(&job));
+    worker_thread((void *)(&job));
 
     // Return zero if the job succeeded, otherwise return the exit
     // status of one of the failing jobs (whichever one failed last).
     return job.exit_status;
 }
 
-WEAK int (*halide_custom_do_task)(void *user_context, halide_task_t, int, uint8_t *) = default_do_task;
-WEAK int (*halide_custom_do_par_for)(void *, halide_task_t, int, int, uint8_t *) = default_do_par_for;
+WEAK halide_do_task_t custom_do_task = default_do_task;
+WEAK halide_do_par_for_t custom_do_par_for = default_do_par_for;
 
 struct spawn_thread_task {
     void (*f)(void *);
     void *closure;
 };
-WEAK void *halide_spawn_thread_helper(void *arg) {
+WEAK void *spawn_thread_helper(void *arg) {
     spawn_thread_task *t = (spawn_thread_task *)arg;
     t->f(t->closure);
     free(t);
@@ -296,7 +296,7 @@ WEAK void *halide_spawn_thread_helper(void *arg) {
 }}} // namespace Halide::Runtime::Internal
 
 extern "C" {
-    
+
 WEAK void halide_spawn_thread(void *user_context, void (*f)(void *), void *closure) {
     // Note that we don't pass the user_context through to the
     // thread. It may begin well after the user context is no longer a
@@ -309,7 +309,7 @@ WEAK void halide_spawn_thread(void *user_context, void (*f)(void *), void *closu
     spawn_thread_task *t = (spawn_thread_task *)malloc(sizeof(spawn_thread_task));
     t->f = f;
     t->closure = closure;
-    pthread_create(&thread, NULL, halide_spawn_thread_helper, t);
+    pthread_create(&thread, NULL, spawn_thread_helper, t);
 }
 
 WEAK void halide_mutex_cleanup(halide_mutex *mutex_arg) {
@@ -330,33 +330,33 @@ WEAK void halide_mutex_unlock(halide_mutex *mutex_arg) {
 
 
 WEAK void halide_shutdown_thread_pool() {
-    if (!halide_thread_pool_initialized) return;
+    if (!thread_pool_initialized) return;
 
     // Wake everyone up and tell them the party's over and it's time
     // to go home
-    pthread_mutex_lock(&halide_work_queue.mutex);
-    halide_work_queue.shutdown = true;
-    pthread_cond_broadcast(&halide_work_queue.wakeup_owners);
-    pthread_cond_broadcast(&halide_work_queue.wakeup_a_team);
-    pthread_cond_broadcast(&halide_work_queue.wakeup_b_team);
-    pthread_mutex_unlock(&halide_work_queue.mutex);
+    pthread_mutex_lock(&work_queue.mutex);
+    work_queue.shutdown = true;
+    pthread_cond_broadcast(&work_queue.wakeup_owners);
+    pthread_cond_broadcast(&work_queue.wakeup_a_team);
+    pthread_cond_broadcast(&work_queue.wakeup_b_team);
+    pthread_mutex_unlock(&work_queue.mutex);
 
     // Wait until they leave
-    for (int i = 0; i < halide_num_threads-1; i++) {
+    for (int i = 0; i < num_threads-1; i++) {
         //fprintf(stderr, "Waiting for thread %d to exit\n", i);
         void *retval;
-        pthread_join(halide_work_queue.threads[i], &retval);
+        pthread_join(work_queue.threads[i], &retval);
     }
 
     //fprintf(stderr, "All threads have quit. Destroying mutex and condition variable.\n");
     // Tidy up
-    pthread_mutex_destroy(&halide_work_queue.mutex);
+    pthread_mutex_destroy(&work_queue.mutex);
     // Reinitialize in case we call another do_par_for
-    pthread_mutex_init(&halide_work_queue.mutex, NULL);
-    pthread_cond_destroy(&halide_work_queue.wakeup_owners);
-    pthread_cond_destroy(&halide_work_queue.wakeup_a_team);
-    pthread_cond_destroy(&halide_work_queue.wakeup_b_team);
-    halide_thread_pool_initialized = false;
+    pthread_mutex_init(&work_queue.mutex, NULL);
+    pthread_cond_destroy(&work_queue.wakeup_owners);
+    pthread_cond_destroy(&work_queue.wakeup_a_team);
+    pthread_cond_destroy(&work_queue.wakeup_b_team);
+    thread_pool_initialized = false;
 }
 
 namespace {
@@ -367,40 +367,37 @@ WEAK void halide_posix_thread_pool_cleanup() {
 }
 
 WEAK void halide_set_num_threads(int n) {
-    if (halide_num_threads == n) {
+    if (num_threads == n) {
         return;
     }
 
-    if (halide_thread_pool_initialized) {
+    if (thread_pool_initialized) {
         halide_shutdown_thread_pool();
     }
 
-    halide_num_threads = n;
+    num_threads = n;
 }
 
-WEAK int (*halide_set_custom_do_task(int (*f)(void *, halide_task_t, int, uint8_t *)))
-          (void *, halide_task_t, int, uint8_t *) {
-    int (*result)(void *, halide_task_t, int, uint8_t *) = halide_custom_do_task;
-    halide_custom_do_task = f;
+WEAK halide_do_task_t halide_set_custom_do_task(halide_do_task_t f) {
+    halide_do_task_t result = custom_do_task;
+    custom_do_task = f;
     return result;
 }
 
-
-WEAK int (*halide_set_custom_do_par_for(int (*f)(void *, halide_task_t, int, int, uint8_t *)))
-          (void *, halide_task_t, int, int, uint8_t *) {
-    int (*result)(void *, halide_task_t, int, int, uint8_t *) = halide_custom_do_par_for;
-    halide_custom_do_par_for = f;
+WEAK halide_do_par_for_t halide_set_custom_do_par_for(halide_do_par_for_t f) {
+    halide_do_par_for_t result = custom_do_par_for;
+    custom_do_par_for = f;
     return result;
 }
 
 WEAK int halide_do_task(void *user_context, halide_task_t f, int idx,
                         uint8_t *closure) {
-    return (*halide_custom_do_task)(user_context, f, idx, closure);
+    return (*custom_do_task)(user_context, f, idx, closure);
 }
 
-WEAK int halide_do_par_for(void *user_context, int (*f)(void *, int, uint8_t *),
+WEAK int halide_do_par_for(void *user_context, halide_task_t f,
                            int min, int size, uint8_t *closure) {
-  return (*halide_custom_do_par_for)(user_context, f, min, size, closure);
+  return (*custom_do_par_for)(user_context, f, min, size, closure);
 }
 
 } // extern "C"

--- a/src/runtime/windows_thread_pool.cpp
+++ b/src/runtime/windows_thread_pool.cpp
@@ -67,7 +67,7 @@ struct work {
 
 // The work queue and thread pool is weak, so one big work queue is shared by all halide functions
 #define MAX_THREADS 64
-struct halide_work_queue_t {
+struct work_queue_t {
     // Initialization of the critical section is guarded by this
     InitOnce init_once;
 
@@ -107,55 +107,53 @@ struct halide_work_queue_t {
 
 };
 
-WEAK halide_work_queue_t halide_work_queue;
+WEAK work_queue_t work_queue;
 
 WEAK bool WIN32API InitOnceCallback(InitOnce *, void *, void **) {
-    InitializeCriticalSection(&halide_work_queue.mutex);
+    InitializeCriticalSection(&work_queue.mutex);
     return true;
 }
 
-WEAK int halide_num_threads;
-WEAK bool halide_thread_pool_initialized = false;
-
-
+WEAK int num_threads;
+WEAK bool thread_pool_initialized = false;
 
 WEAK int default_do_task(void *user_context, halide_task_t f, int idx,
                          uint8_t *closure) {
     return f(user_context, idx, closure);
 }
 
-WEAK void *halide_worker_thread(void *void_arg) {
+WEAK void *worker_thread(void *void_arg) {
     work *owned_job = (work *)void_arg;
 
     // Grab the lock
-    EnterCriticalSection(&halide_work_queue.mutex);
+    EnterCriticalSection(&work_queue.mutex);
 
     // If I'm a job owner, then I was the thread that called
     // do_par_for, and I should only stay in this function until my
     // job is complete. If I'm a lowly worker thread, I should stay in
     // this function as long as the work queue is running.
     while (owned_job != NULL ? owned_job->running()
-           : halide_work_queue.running()) {
+           : work_queue.running()) {
 
-        if (halide_work_queue.jobs == NULL) {
+        if (work_queue.jobs == NULL) {
             if (owned_job) {
                 // There are no jobs pending. Wait for the last worker
                 // to signal that the job is finished.
-                SleepConditionVariableCS(&halide_work_queue.wakeup_owners, &halide_work_queue.mutex, -1);
-            } else if (halide_work_queue.a_team_size <= halide_work_queue.target_a_team_size) {
+                SleepConditionVariableCS(&work_queue.wakeup_owners, &work_queue.mutex, -1);
+            } else if (work_queue.a_team_size <= work_queue.target_a_team_size) {
                 // There are no jobs pending. Wait until more jobs are enqueued.
-                SleepConditionVariableCS(&halide_work_queue.wakeup_a_team, &halide_work_queue.mutex, -1);
+                SleepConditionVariableCS(&work_queue.wakeup_a_team, &work_queue.mutex, -1);
             } else {
                 // There are no jobs pending, and there are too many
                 // threads in the A team. Transition to the B team
                 // until the wakeup_b_team condition is fired.
-                halide_work_queue.a_team_size--;
-                SleepConditionVariableCS(&halide_work_queue.wakeup_b_team, &halide_work_queue.mutex, -1);
-                halide_work_queue.a_team_size++;
+                work_queue.a_team_size--;
+                SleepConditionVariableCS(&work_queue.wakeup_b_team, &work_queue.mutex, -1);
+                work_queue.a_team_size++;
             }
         } else {
             // There are jobs still to do. Grab the next one.
-            work *job = halide_work_queue.jobs;
+            work *job = work_queue.jobs;
 
             // Claim a task from it.
             work myjob = *job;
@@ -164,7 +162,7 @@ WEAK void *halide_worker_thread(void *void_arg) {
             // If there were no more tasks pending for this job, or if
             // it has failed, remove it from the stack.
             if (job->next == job->max) {
-                halide_work_queue.jobs = job->next_job;
+                work_queue.jobs = job->next_job;
             }
 
             // Increment the active_worker count so that other threads
@@ -173,10 +171,10 @@ WEAK void *halide_worker_thread(void *void_arg) {
             job->active_workers++;
 
             // Release the lock and do the task.
-            LeaveCriticalSection(&halide_work_queue.mutex);
+            LeaveCriticalSection(&work_queue.mutex);
             int result = halide_do_task(myjob.user_context, myjob.f, myjob.next,
                                         myjob.closure);
-            EnterCriticalSection(&halide_work_queue.mutex);
+            EnterCriticalSection(&work_queue.mutex);
 
             // If this task failed, set the exit status on the job.
             if (result) {
@@ -189,12 +187,12 @@ WEAK void *halide_worker_thread(void *void_arg) {
             // If the job is done and I'm not the owner of it, wake up
             // the owner.
             if (!job->running() && job != owned_job) {
-                WakeAllConditionVariable(&halide_work_queue.wakeup_owners);
+                WakeAllConditionVariable(&work_queue.wakeup_owners);
             }
         }
     }
     // halide_printf(NULL, "Worker quitting\n");
-    LeaveCriticalSection(&halide_work_queue.mutex);
+    LeaveCriticalSection(&work_queue.mutex);
     return NULL;
 }
 
@@ -203,24 +201,24 @@ WEAK int default_do_par_for(void *user_context, int (*f)(void *, int, uint8_t *)
     // halide_printf(user_context, "In do_par_for\n");
 
     // Create the mutex
-    InitOnceExecuteOnce(&halide_work_queue.init_once, InitOnceCallback, NULL, NULL);
+    InitOnceExecuteOnce(&work_queue.init_once, InitOnceCallback, NULL, NULL);
 
     // halide_printf(user_context, "Grabbing mutex\n");
 
     // Grab it
-    EnterCriticalSection(&halide_work_queue.mutex);
+    EnterCriticalSection(&work_queue.mutex);
 
-    if (!halide_thread_pool_initialized) {
-        halide_work_queue.shutdown = false;
+    if (!thread_pool_initialized) {
+        work_queue.shutdown = false;
 
         //  halide_printf(user_context, "Making condition variable\n");
 
-        InitializeConditionVariable(&halide_work_queue.wakeup_owners);
-        InitializeConditionVariable(&halide_work_queue.wakeup_a_team);
-        InitializeConditionVariable(&halide_work_queue.wakeup_b_team);
-        halide_work_queue.jobs = NULL;
+        InitializeConditionVariable(&work_queue.wakeup_owners);
+        InitializeConditionVariable(&work_queue.wakeup_a_team);
+        InitializeConditionVariable(&work_queue.wakeup_b_team);
+        work_queue.jobs = NULL;
 
-        if (!halide_num_threads) {
+        if (!num_threads) {
             char *threadStr = getenv("HL_NUM_THREADS");
             if (!threadStr) {
                 // Legacy name
@@ -230,25 +228,25 @@ WEAK int default_do_par_for(void *user_context, int (*f)(void *, int, uint8_t *)
                 threadStr = getenv("NUMBER_OF_PROCESSORS"); // Apparently a standard windows environment variable
             }
             if (threadStr) {
-                halide_num_threads = atoi(threadStr);
+                num_threads = atoi(threadStr);
             } else {
-                halide_num_threads = 8;
-                // halide_printf(user_context, "HL_NUM_THREADS not defined. Defaulting to %d threads.\n", halide_num_threads);
+                num_threads = 8;
+                // halide_printf(user_context, "HL_NUM_THREADS not defined. Defaulting to %d threads.\n", num_threads);
             }
         }
-        if (halide_num_threads > MAX_THREADS) {
-            halide_num_threads = MAX_THREADS;
-        } else if (halide_num_threads < 1) {
-            halide_num_threads = 1;
+        if (num_threads > MAX_THREADS) {
+            num_threads = MAX_THREADS;
+        } else if (num_threads < 1) {
+            num_threads = 1;
         }
-        for (int i = 0; i < halide_num_threads-1; i++) {
+        for (int i = 0; i < num_threads-1; i++) {
             // halide_printf(user_context, "Creating thread %d\n", i);
-            halide_work_queue.threads[i] = CreateThread(NULL, 0, halide_worker_thread, NULL, 0, NULL);
+            work_queue.threads[i] = CreateThread(NULL, 0, worker_thread, NULL, 0, NULL);
         }
 
-        halide_work_queue.a_team_size = halide_num_threads;
+        work_queue.a_team_size = num_threads;
 
-        halide_thread_pool_initialized = true;
+        thread_pool_initialized = true;
     }
 
     // Make the job.
@@ -261,51 +259,51 @@ WEAK int default_do_par_for(void *user_context, int (*f)(void *, int, uint8_t *)
     job.exit_status = 0;     // The job hasn't failed yet
     job.active_workers = 0;  // Nobody is working on this yet
 
-    if (!halide_work_queue.jobs && size < halide_num_threads) {
+    if (!work_queue.jobs && size < num_threads) {
         // If there's no nested parallelism happening and there are
         // fewer tasks to do than threads, then set the target A team
         // size so that some threads will put themselves to sleep
         // until a larger job arrives.
-        halide_work_queue.target_a_team_size = size;
+        work_queue.target_a_team_size = size;
     } else {
-        halide_work_queue.target_a_team_size = halide_num_threads;
+        work_queue.target_a_team_size = num_threads;
     }
 
     // If there are more tasks than threads in the A team, we should
     // wake up everyone.
-    bool wake_b_team = size > halide_work_queue.a_team_size;
+    bool wake_b_team = size > work_queue.a_team_size;
 
     // Push the job onto the stack.
-    job.next_job = halide_work_queue.jobs;
-    halide_work_queue.jobs = &job;
+    job.next_job = work_queue.jobs;
+    work_queue.jobs = &job;
 
-    LeaveCriticalSection(&halide_work_queue.mutex);
+    LeaveCriticalSection(&work_queue.mutex);
 
     // Wake up our A team.
-    WakeAllConditionVariable(&halide_work_queue.wakeup_a_team);
+    WakeAllConditionVariable(&work_queue.wakeup_a_team);
 
     if (wake_b_team) {
         // We need the B team too.
-        WakeAllConditionVariable(&halide_work_queue.wakeup_b_team);
+        WakeAllConditionVariable(&work_queue.wakeup_b_team);
     }
 
     // Do some work myself.
-    halide_worker_thread((void *)(&job));
+    worker_thread((void *)(&job));
 
     // Return zero if the job succeeded, otherwise return the exit
     // status of one of the failing jobs (whichever one failed last).
     return job.exit_status;
 }
 
-WEAK int (*halide_custom_do_task)(void *user_context, halide_task_t, int, uint8_t *) = default_do_task;
-WEAK int (*halide_custom_do_par_for)(void *, halide_task_t, int, int, uint8_t *) = default_do_par_for;
+WEAK halide_do_task_t custom_do_task = default_do_task;
+WEAK halide_do_par_for_t custom_do_par_for = default_do_par_for;
 
 struct spawn_thread_task {
     void(*f)(void *);
     void *closure;
 };
-WEAK void *halide_spawn_thread_helper(void *arg) {
-        spawn_thread_task *t = (spawn_thread_task *)arg;
+WEAK void *spawn_thread_helper(void *arg) {
+    spawn_thread_task *t = (spawn_thread_task *)arg;
     t->f(t->closure);
     free(t);
     return NULL;
@@ -319,7 +317,7 @@ WEAK void halide_spawn_thread(void *user_context, void(*f)(void *), void *closur
     spawn_thread_task *t = (spawn_thread_task *)malloc(sizeof(spawn_thread_task));
         t->f = f;
     t->closure = closure;
-        CreateThread(NULL, 0, halide_spawn_thread_helper, t, 0, NULL);
+        CreateThread(NULL, 0, spawn_thread_helper, t, 0, NULL);
 }
 
 WEAK void halide_mutex_cleanup(halide_mutex *mutex_arg) {
@@ -342,31 +340,31 @@ WEAK void halide_mutex_unlock(halide_mutex *mutex_arg) {
 }
 
 WEAK void halide_shutdown_thread_pool() {
-    if (!halide_thread_pool_initialized) return;
+    if (!thread_pool_initialized) return;
 
     // Wake everyone up and tell them the party's over and it's time
     // to go home
-    EnterCriticalSection(&halide_work_queue.mutex);
-    halide_work_queue.shutdown = true;
-    WakeAllConditionVariable(&halide_work_queue.wakeup_owners);
-    WakeAllConditionVariable(&halide_work_queue.wakeup_a_team);
-    WakeAllConditionVariable(&halide_work_queue.wakeup_b_team);
-    LeaveCriticalSection(&halide_work_queue.mutex);
+    EnterCriticalSection(&work_queue.mutex);
+    work_queue.shutdown = true;
+    WakeAllConditionVariable(&work_queue.wakeup_owners);
+    WakeAllConditionVariable(&work_queue.wakeup_a_team);
+    WakeAllConditionVariable(&work_queue.wakeup_b_team);
+    LeaveCriticalSection(&work_queue.mutex);
 
     // Wait until they leave
-    for (int i = 0; i < halide_num_threads-1; i++) {
-        WaitForSingleObject(halide_work_queue.threads[i], -1);
+    for (int i = 0; i < num_threads-1; i++) {
+        WaitForSingleObject(work_queue.threads[i], -1);
     }
 
     // Tidy up
-    DeleteCriticalSection(&halide_work_queue.mutex);
-    halide_work_queue.init_once = 0;
+    DeleteCriticalSection(&work_queue.mutex);
+    work_queue.init_once = 0;
 
     // Condition variables aren't destroyed on windows.
-    // DestroyConditionVariable(&halide_work_queue.wakeup_owners);
-    // DestroyConditionVariable(&halide_work_queue.wakeup_a_team);
-    // DestroyConditionVariable(&halide_work_queue.wakeup_b_team);
-    halide_thread_pool_initialized = false;
+    // DestroyConditionVariable(&work_queue.wakeup_owners);
+    // DestroyConditionVariable(&work_queue.wakeup_a_team);
+    // DestroyConditionVariable(&work_queue.wakeup_b_team);
+    thread_pool_initialized = false;
 }
 
 namespace {
@@ -377,40 +375,37 @@ WEAK void halide_posix_thread_pool_cleanup() {
 }
 
 WEAK void halide_set_num_threads(int n) {
-    if (halide_num_threads == n) {
+    if (num_threads == n) {
         return;
     }
 
-    if (halide_thread_pool_initialized) {
+    if (thread_pool_initialized) {
         halide_shutdown_thread_pool();
     }
 
-    halide_num_threads = n;
+    num_threads = n;
 }
 
-WEAK int (*halide_set_custom_do_task(int (*f)(void *, halide_task_t, int, uint8_t *)))
-          (void *, halide_task_t, int, uint8_t *) {
-    int (*result)(void *, halide_task_t, int, uint8_t *) = halide_custom_do_task;
-    halide_custom_do_task = f;
+WEAK halide_do_task_t halide_set_custom_do_task(halide_do_task_t f) {
+    halide_do_task_t result = custom_do_task;
+    custom_do_task = f;
     return result;
 }
 
-
-WEAK int (*halide_set_custom_do_par_for(int (*f)(void *, halide_task_t, int, int, uint8_t *)))
-          (void *, halide_task_t, int, int, uint8_t *) {
-    int (*result)(void *, halide_task_t, int, int, uint8_t *) = halide_custom_do_par_for;
-    halide_custom_do_par_for = f;
+WEAK halide_do_par_for_t halide_set_custom_do_par_for(halide_do_par_for_t f) {
+    halide_do_par_for_t result = custom_do_par_for;
+    custom_do_par_for = f;
     return result;
 }
 
 WEAK int halide_do_task(void *user_context, halide_task_t f, int idx,
                         uint8_t *closure) {
-    return (*halide_custom_do_task)(user_context, f, idx, closure);
+    return (*custom_do_task)(user_context, f, idx, closure);
 }
 
-WEAK int halide_do_par_for(void *user_context, int (*f)(void *, int, uint8_t *),
+WEAK int halide_do_par_for(void *user_context, halide_task_t f,
                            int min, int size, uint8_t *closure) {
-    return (*halide_custom_do_par_for)(user_context, f, min, size, closure);
+  return (*custom_do_par_for)(user_context, f, min, size, closure);
 }
 
 } // extern "C"


### PR DESCRIPTION
This PR does some refactoring of the runtime:

- Use typedefs for function pointers.
- Rename a few halide_ things that are already inside the Halide::Runtime::Internal namespace.