### PR TITLE
CMake option to compile with RTTI enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ option(TARGET_OPENCL "Include OpenCL-C target" ON)
 option(TARGET_OPENGL "Include OpenGL/GLSL target" ON)
 option(TARGET_OPENGLCOMPUTE "Include OpenGLCompute target" ON)
 option(HALIDE_SHARED_LIBRARY "Build as a shared library" ON)
+option(HALIDE_ENABLE_RTTI "Build with RTTI enabled" OFF)
 
 function(halide_project name folder)
   add_executable("${name}" ${ARGN})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -545,7 +545,9 @@ else()
   # FIXME: These defines should come from ``llvm-config --cppflags``
   target_compile_definitions(Halide PRIVATE "-D__STDC_LIMIT_MACROS" "-D__STDC_CONSTANT_MACROS" "-D__STDC_FORMAT_MACROS")
   target_compile_options(Halide PUBLIC "-std=c++11") # Halide and its clients need to use C++11
-  target_compile_options(Halide PUBLIC "-fno-rtti")
+  if(NOT HALIDE_ENABLE_RTTI)
+    target_compile_options(Halide PUBLIC "-fno-rtti")
+  endif()
 endif()
 
 # Get the LLVM libraries we need


### PR DESCRIPTION
Adds a CMake option to compile with RTTI enabled, patterned after the corresponding option in LLVM.  This option makes it easier to use Halide within a code base that requires RTTI.  The option is disabled by default.