### PR TITLE
FindHalide.cmake lets `find_package()` discover Halide library paths

### DIFF
--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -11,6 +11,7 @@ if(USE_PYTHON EQUAL 2)
 	if (NOT USE_EXTERNAL_BOOST)
 		find_package(Boost COMPONENTS python REQUIRED)
 	endif()
+	find_package(Halide REQUIRED)
 else()
 	find_package(PythonInterp 3.4 REQUIRED)
 	find_package(PythonLibs 3.4 REQUIRED)
@@ -24,6 +25,7 @@ else()
 			find_package(Boost COMPONENTS python3 REQUIRED)
 		endif()
 	endif()
+	find_package(Halide REQUIRED)
 endif()
 
 option(USE_BOOST_NUMPY "Use Boost.Numpy dependency instead of Halide.Numpy" OFF)
@@ -54,7 +56,7 @@ endif()
 add_definitions("-std=c++11")
 
 include_directories(
-  ../build/include
+  ${HALIDE_INCLUDE_DIR}
   ${Boost_INCLUDE_DIRS}
   ${BoostNumpy_INCLUDE_DIRS}
   ${PYTHON_INCLUDE_DIRS}
@@ -63,6 +65,7 @@ include_directories(
 
 link_directories(
   ../build/lib
+  ${HALIDE_ROOT_DIR}/lib
   ${Boost_LIBRARY_DIR}
   ${BoostNumpy_LIBRARY_DIR}
   ${Numpy_LIBRARY_DIR}
@@ -81,7 +84,8 @@ python/*.cpp
 
 add_library(halide SHARED ${SrcCpp})
 target_link_libraries(halide
-  Halide InitialModules
+  ${HALIDE_LIBRARIES}
+  InitialModules
   ${Boost_LIBRARIES}
   ${BoostNumpy_LIBRARIES}
   ${PYTHON_LIBRARIES}

--- a/python_bindings/FindHalide.cmake
+++ b/python_bindings/FindHalide.cmake
@@ -1,0 +1,33 @@
+# FindHalide.cmake
+# ... shamelessly based on FindJeMalloc.cmake
+
+find_path(HALIDE_ROOT_DIR
+    NAMES include/Halide.h include/HalideRuntime.h
+)
+
+find_library(HALIDE_LIBRARIES
+    NAMES Halide
+    HINTS ${HALIDE_ROOT_DIR}/lib
+)
+
+find_path(HALIDE_INCLUDE_DIR
+    NAMES Halide.h HalideRuntime.h
+    HINTS ${HALIDE_ROOT_DIR}/include
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Halide DEFAULT_MSG
+    HALIDE_LIBRARIES
+    HALIDE_INCLUDE_DIR
+)
+
+set(HALIDE_LIBRARY HALIDE_LIBRARIES)
+set(HALIDE_INCLUDE_DIRS HALIDE_INCLUDE_DIR)
+
+mark_as_advanced(
+    HALIDE_ROOT_DIR
+    HALIDE_LIBRARY
+    HALIDE_LIBRARIES
+    HALIDE_INCLUDE_DIR
+    HALIDE_INCLUDE_DIRS
+)


### PR DESCRIPTION
... this allows one to build the Python bindings against a version of the Halide binaries found outside the immediately enclosing directory, e.g. those ensconced in a Homebrew-installed Halide package (I use [this formula](https://github.com/fish2000/homebrew-praxa/blob/master/halide.rb)), a Mac OS X framework, and the like