### PR TITLE
Update Halide camera_pipe to more closely match FCam

### DIFF
--- a/apps/camera_pipe/camera_pipe.cpp
+++ b/apps/camera_pipe/camera_pipe.cpp
@@ -2,8 +2,6 @@
 #include <stdint.h>
 
 using namespace Halide;
-using namespace Halide::Internal;
-IRPrinter irp(std::cerr);
 
 int schedule;
 

--- a/apps/camera_pipe/camera_pipe.cpp
+++ b/apps/camera_pipe/camera_pipe.cpp
@@ -2,6 +2,8 @@
 #include <stdint.h>
 
 using namespace Halide;
+using namespace Halide::Internal;
+IRPrinter irp(std::cerr);
 
 int schedule;
 
@@ -15,13 +17,18 @@ Expr avg(Expr a, Expr b) {
 }
 
 Func hot_pixel_suppression(Func input) {
+    // hot pixel maximum
     Expr a = max(max(input(x-2, y), input(x+2, y)),
                  max(input(x, y-2), input(x, y+2)));
-    Expr b = min(min(input(x-2, y), input(x+2, y)),
-                 min(input(x, y-2), input(x, y+2)));
+    // cold pixel minimum
+    // Expr b = min(min(input(x-2, y), input(x+2, y)),
+    //             min(input(x, y-2), input(x, y+2)));
 
     Func denoised;
-    denoised(x, y) = clamp(input(x, y), b, a);
+    // hot pixel suppression
+    denoised(x, y) = clamp(input(x, y), 0, a);
+    // hot & cold pixel suppression
+    // denoised(x, y) = clamp(input(x, y), b, a);
 
     return denoised;
 }
@@ -224,10 +231,11 @@ Func color_correct(Func input, ImageParam matrix_3200, ImageParam matrix_7000, P
 }
 
 
-Func apply_curve(Func input, Type result_type, Param<float> gamma, Param<float> contrast) {
+Func apply_curve(Func input, Type result_type, Param<float> gamma, Param<float> contrast, Param<int> blackLevel, Param<int> whiteLevel) {
     // copied from FCam
     Func curve("curve");
 
+#ifdef OLD_CURVE
     Expr xf = clamp(cast<float>(x)/1024.0f, 0.0f, 1.0f);
     Expr g = pow(xf, 1.0f/gamma);
     Expr b = 2.0f - pow(2.0f, contrast/100.0f);
@@ -242,13 +250,44 @@ Func apply_curve(Func input, Type result_type, Param<float> gamma, Param<float> 
 
     Func curved;
     curved(x, y, c) = curve(input(x, y, c));
+#else // NEW_CURVE (from FCam makeLUT)
+    Expr minRaw = 0 + blackLevel;
+    Expr maxRaw = whiteLevel;
+
+    Expr invRange = 1.0f/(maxRaw - minRaw);
+    Expr b = 2.0f - pow(2.0f, contrast/100.0f);
+    Expr a = 2.0f - 2.0f*b;
+
+    // Get a linear luminance in the range 0-1
+    Expr xf = clamp(cast<float>(x - minRaw)*invRange, 0.0f, 1.0f);
+    // Gamma correct it
+    Expr g = pow(xf, 1.0f/gamma);
+    // Apply a piecewise quadratic contrast curve
+    Expr z = select(g > 0.5f,
+                    1.0f - (a*(1.0f-g)*(1.0f-g) + b*(1.0f-g)),
+                    a*g*g + b*g);
+
+    // Convert to 8 bit and save
+    Expr val = cast(result_type, clamp(z*255.0f+0.5f, 0.0f, 255.0f));
+    // makeLUT add guard band outside of (minRaw, maxRaw]:
+    curve(x) = select(x <= minRaw, 0, select(x > maxRaw, 255, val));
+
+    curve.compute_root(); // It's a LUT, compute it once ahead of time.
+
+    Func curved;
+    // Use clamp to restrict size of LUT as allocated by compute_root
+    // - Clamp to variable whiteLevel
+    // curved(x, y, c) = curve(clamp(input(x, y, c), 0, whiteLevel));
+    // - Clamp to a constant upper value
+    curved(x, y, c) = curve(clamp(input(x, y, c), 0, 1023));
+#endif
 
     return curved;
 }
 
 Func process(Func raw, Type result_type,
              ImageParam matrix_3200, ImageParam matrix_7000, Param<float> color_temp,
-             Param<float> gamma, Param<float> contrast) {
+             Param<float> gamma, Param<float> contrast, Param<int> blackLevel, Param<int> whiteLevel) {
 
     Var xi, yi;
 
@@ -256,7 +295,7 @@ Func process(Func raw, Type result_type,
     Func deinterleaved = deinterleave(denoised);
     Func demosaiced = demosaic(deinterleaved);
     Func corrected = color_correct(demosaiced, matrix_3200, matrix_7000, color_temp);
-    Func curved = apply_curve(corrected, result_type, gamma, contrast);
+    Func curved = apply_curve(corrected, result_type, gamma, contrast, blackLevel, whiteLevel);
 
     processed(tx, ty, c) = curved(tx, ty, c);
 
@@ -294,6 +333,8 @@ int main(int argc, char **argv) {
     Param<float> color_temp("color_temp"); //, 3200.0f);
     Param<float> gamma("gamma"); //, 1.8f);
     Param<float> contrast("contrast"); //, 10.0f);
+    Param<int> blackLevel("blackLevel"); //, 25);
+    Param<int> whiteLevel("whiteLevel"); //, 1023);
 
     // shift things inwards to give us enough padding on the
     // boundaries so that we don't need to check bounds. We're going
@@ -311,7 +352,8 @@ int main(int argc, char **argv) {
     schedule = atoi(argv[2]);
 
     // Build the pipeline
-    Func processed = process(shifted, result_type, matrix_3200, matrix_7000, color_temp, gamma, contrast);
+    Func processed = process(shifted, result_type, matrix_3200, matrix_7000,
+                             color_temp, gamma, contrast, blackLevel, whiteLevel);
 
     // We can generate slightly better code if we know the output is a whole number of tiles.
     Expr out_width = processed.output_buffer().width();
@@ -323,7 +365,8 @@ int main(int argc, char **argv) {
     //string s = processed.serialize();
     //printf("%s\n", s.c_str());
 
-    std::vector<Argument> args = {color_temp, gamma, contrast, input, matrix_3200, matrix_7000};
+    std::vector<Argument> args = {color_temp, gamma, contrast, blackLevel, whiteLevel,
+                                  input, matrix_3200, matrix_7000};
     processed.compile_to_file("curved", args);
     processed.compile_to_assembly("curved.s", args);
 

--- a/apps/camera_pipe/fcam/Demosaic_ARM.cpp
+++ b/apps/camera_pipe/fcam/Demosaic_ARM.cpp
@@ -244,20 +244,15 @@ void demosaic_ARM(Halide::Tools::Image<uint16_t> input, Halide::Tools::Image<uin
                             int16x8_t under = vld1q_s16(ptr_in - VEC_WIDTH*4);
                             int16x8_t right = vld1q_s16(ptr_in + 1);
                             int16x8_t left  = vld1q_s16(ptr_in - 1);
-                            int16x8_t max, min;
+                            int16x8_t max;
 
-                            // find the max and min of the neighbors
+                            // find the max of the neighbors
                             max = vmaxq_s16(left, right);
                             max = vmaxq_s16(above, max);
                             max = vmaxq_s16(under, max);
 
-                            min = vminq_s16(left, right);
-                            min = vminq_s16(above, min);
-                            min = vminq_s16(under, min);
-
-                            // clamp here to be within this range
+                            // clamp here to be less than the max.
                             here  = vminq_s16(max, here);
-                            here  = vmaxq_s16(min, here);
 
                             vst1q_s16(ptr_out, here);
                             ptr_in += 8;

--- a/apps/camera_pipe/process.cpp
+++ b/apps/camera_pipe/process.cpp
@@ -25,8 +25,9 @@ int main(int argc, char **argv) {
     halide_enable_malloc_trace();
 #endif
 
+    fprintf(stderr, "input: %s\n", argv[1]);
     Image<uint16_t> input = load_image(argv[1]);
-    fprintf(stderr, "%d %d\n", input.width(), input.height());
+    fprintf(stderr, "       %d %d\n", input.width(), input.height());
     Image<uint8_t> output(((input.width() - 32)/32)*32, ((input.height() - 24)/32)*32, 3);
 
 #ifdef HL_MEMINFO
@@ -56,29 +57,38 @@ int main(int argc, char **argv) {
     float gamma = atof(argv[3]);
     float contrast = atof(argv[4]);
     int timing_iterations = atoi(argv[5]);
+    int blackLevel = 25;
+    int whiteLevel = 1023;
 
     double best;
 
     best = benchmark(timing_iterations, 1, [&]() {
-        curved(color_temp, gamma, contrast,
-               input, matrix_3200, matrix_7000, output);
+        curved(color_temp, gamma, contrast, blackLevel, whiteLevel,
+               input, matrix_3200, matrix_7000,
+               output);
     });
     fprintf(stderr, "Halide:\t%gus\n", best * 1e6);
+    fprintf(stderr, "output: %s\n", argv[6]);
     save_image(output, argv[6]);
+    fprintf(stderr, "        %d %d\n", output.width(), output.height());
 
     Image<uint8_t> output_c(output.width(), output.height(), output.channels());
     best = benchmark(timing_iterations, 1, [&]() {
-        FCam::demosaic(input, output_c, color_temp, contrast, true, 25, 1023, gamma);
+        FCam::demosaic(input, output_c, color_temp, contrast, true, blackLevel, whiteLevel, gamma);
     });
     fprintf(stderr, "C++:\t%gus\n", best * 1e6);
+    fprintf(stderr, "output_c: fcam_c.png\n");
     save_image(output_c, "fcam_c.png");
+    fprintf(stderr, "        %d %d\n", output_c.width(), output_c.height());
 
     Image<uint8_t> output_asm(output.width(), output.height(), output.channels());
     best = benchmark(timing_iterations, 1, [&]() {
-        FCam::demosaic_ARM(input, output_asm, color_temp, contrast, true, 25, 1023, gamma);
+        FCam::demosaic_ARM(input, output_asm, color_temp, contrast, true, blackLevel, whiteLevel, gamma);
     });
     fprintf(stderr, "ASM:\t%gus\n", best * 1e6);
+    fprintf(stderr, "output_asm: fcam_arm.png\n");
     save_image(output_asm, "fcam_arm.png");
+    fprintf(stderr, "        %d %d\n", output_asm.width(), output_asm.height());
 
     // Timings on N900 as of SIGGRAPH 2012 camera ready are (best of 10)
     // Halide: 722ms, FCam: 741ms


### PR DESCRIPTION
Previously the Halide generated image was much darker/lower-contrast
than the FCam generated image.  The reason for this was tracked down
to the following functions:

- hot_pixel_suppression
  no longer does cold pixel suppression (was causing the generated
  image to lose contrast)
- apply_curve
  This is the old Halide LUT code (see OLD_CURVE) didn't match the LUT
  computed in FCam.  The Halide code originally didn't take into
  account the blacklevel (was causing the generated image to be darker)
  which has been fixed (see NEW_CURVE).