### PR TITLE
Save and restore values over a loop backedge only if they are used in…

### DIFF
--- a/src/StoreForwarding.cpp
+++ b/src/StoreForwarding.cpp
@@ -1223,6 +1223,46 @@ class RenameVars : public IRMutator {
     }
 };
 
+class IsVarLoadOrStore : public IRVisitor {
+    using IRVisitor::visit;
+    std::string var_name;
+
+    template<typename LetStmtOrExpr>
+    void visit_let(const LetStmtOrExpr *op) {
+        if(op->name == var_name) {
+            Expr value = op->value;
+            const Load *l = value.as<Load>();
+            result = (l != NULL);
+        } else {
+            op->body.accept(this);
+        }
+    };
+
+    void visit(const Let *op) {
+        visit_let(op);
+    }
+
+    void visit(const LetStmt *op) {
+        visit_let(op);
+    }
+
+    void visit(const Store *op) {
+        const Variable *var = op->value.as<Variable>();
+        if (var && var->name == var_name)
+            result = true;
+    }
+public:
+    bool result = false;
+
+    IsVarLoadOrStore(const std::string &s) : var_name(s) {}
+};
+
+bool is_var_load_or_store(Expr e, const std::string &v) {
+    IsVarLoadOrStore i(v);
+    e.accept(&i);
+    return i.result;
+}
+
 vector<Stmt> find_non_aliasing_stores(Stmt stmt) {
     FindLoadsAndStores finder;
     stmt.accept(&finder);
@@ -1253,7 +1293,6 @@ class LoopCarry2 : public IRMutator {
             stmt = For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);
             return;
         }
-
         Expr prev_var = Variable::make(Int(32), op->name) - 1;
         Expr next_var = Variable::make(Int(32), op->name) + 1;
 
@@ -1419,6 +1458,10 @@ class LoopCarry2 : public IRMutator {
             // sense for us to save it.
             if (!expr_uses_var(curr_bundle, prev->name) ||
                 !expr_uses_var(curr_bundle, curr->name)) {
+                continue;
+            }
+            if (!is_var_load_or_store(curr_bundle, prev->name) ||
+                !is_var_load_or_store(curr_bundle, curr->name)) {
                 continue;
             }
 


### PR DESCRIPTION
… a load or store.

The loop store forwarding pass was sub-optimally moving indices to vector loads
and stores outside the loop by saving the previous iteration value of an index that
depended on the loop induction variable and reloading it in the next iteration. This
caused vector indices to be loaded from the stack thereby making it impossible for
modulusremainder analysis to be able to tell the alignment of vector loads and stores.
This was also causing an entire ramp to be stored on the stack and this was causing
camera_pipe to fail on hexagon.