### PR TITLE
Refactor compile_func to enable easier customization by codegen implementers

### DIFF
--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -86,12 +86,14 @@ protected:
 
     /** Helper functions for compiling Halide functions to llvm
      * functions. begin_func performs all the work necessary to begin
-     * generating code with the IRBuilder. A call to begin_func should
-     * be a followed by a call to end_func, to generate the
+     * generating code for a function with a given argument list with
+     * the IRBuilder. A call to begin_func should be a followed by a
+     * call to end_func with the same arguments, to generate the
      * appropriate cleanup code. */
     // @{
-    virtual void begin_func(const LoweredFunc &func);
-    virtual void end_func(const LoweredFunc &func);
+    virtual void begin_func(LoweredFunc::LinkageType linkage, const std::string &name,
+                            const std::vector<Argument> &args);
+    virtual void end_func(const std::vector<Argument> &args);
     // @}
 
     /** What should be passed as -mcpu, -mattrs, and related for

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -84,6 +84,12 @@ protected:
     virtual void compile_buffer(const Buffer &buffer);
     // @}
 
+    /** Helper functions for compiling Halide functions to llvm functions. */
+    // @{
+    virtual void begin_func(const LoweredFunc &func);
+    virtual void end_func(const LoweredFunc &func);
+    // @}
+
     /** What should be passed as -mcpu, -mattrs, and related for
      * compilation. The architecture-specific code generator should
      * define these. */

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -84,7 +84,9 @@ protected:
     virtual void compile_buffer(const Buffer &buffer);
     // @}
 
-    /** Helper functions for compiling Halide functions to llvm functions. */
+    /** Helper functions for compiling Halide functions to llvm
+     * functions. begin_func performs all the work necessary to begin
+     * generating code with the IRBuilder. */
     // @{
     virtual void begin_func(const LoweredFunc &func);
     virtual void end_func(const LoweredFunc &func);

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -86,7 +86,9 @@ protected:
 
     /** Helper functions for compiling Halide functions to llvm
      * functions. begin_func performs all the work necessary to begin
-     * generating code with the IRBuilder. */
+     * generating code with the IRBuilder. A call to begin_func should
+     * be a followed by a call to end_func, to generate the
+     * appropriate cleanup code. */
     // @{
     virtual void begin_func(const LoweredFunc &func);
     virtual void end_func(const LoweredFunc &func);


### PR DESCRIPTION
This refactors compile_func to make it easier for derived CodeGen class implementations to change the behavior of compile_func. Currently, if a derived class wants to generate some prolog/epilog code, it can't  replace compile_func without replicating the entire implementation.