### PR TITLE
XFAIL known failing hvx tests in simd_op_check.cpp

### DIFF
--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1352,6 +1352,9 @@ void check_hvx_all() {
     check("vshuffo(v*.b,v*.b)", hvx_width/1, u8(u16_1 >> 8));
     check("vshuffo(v*.h,v*.h)", hvx_width/2, u16(u32_1 >> 16));
 
+    // We know the following don't work yet; They are WIP. Do this to sort of
+    // XFAIL them.
+#if 0
     check("vabsdiff(v*.ub,v*.ub)", hvx_width/1, absd(u8_1, u8_2));
     check("vabsdiff(v*.uh,v*.uh)", hvx_width/2, absd(u16_1, u16_2));
     check("vabsdiff(v*.uw,v*.uw)", hvx_width/4, absd(u32_1, u32_2));
@@ -1365,6 +1368,7 @@ void check_hvx_all() {
     check("vasr(v*.b,v*.b,r*):sat", hvx_width/1, i8c((i16(i8_1) + i16(i8_2)) >> 4));
     check("vasr(v*.h,v*.h,r*):sat", hvx_width/1, i16c((i32(i16_1) + i32(i16_2)) >> 4));
     check("vasr(v*.w,v*.w,r*):sat", hvx_width/1, i32c((i64(i32_1) + i64(i32_2)) >> 4));
+#endif
 }
 
 void check_altivec_all() {


### PR DESCRIPTION
I am setting this up so that all future improvements that I make to HVX codegen can contain a simd_op_check check. Keeping this file clean will help. On the side though we can continue work to unXFAIL these tests.