### PR TITLE
compile_to_llvm_assembly convenience methods

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1604,6 +1604,16 @@ void Func::compile_to_bitcode(const string &filename, const vector<Argument> &ar
     pipeline().compile_to_bitcode(filename, args, "", target);
 }
 
+void Func::compile_to_llvm_assembly(const string &filename, const vector<Argument> &args, const string &fn_name,
+                                    const Target &target) {
+    pipeline().compile_to_llvm_assembly(filename, args, fn_name, target);
+}
+
+void Func::compile_to_llvm_assembly(const string &filename, const vector<Argument> &args,
+                                    const Target &target) {
+    pipeline().compile_to_llvm_assembly(filename, args, "", target);
+}
+
 void Func::compile_to_object(const string &filename, const vector<Argument> &args,
                              const string &fn_name, const Target &target) {
     pipeline().compile_to_object(filename, args, fn_name, target);

--- a/src/Func.h
+++ b/src/Func.h
@@ -455,6 +455,17 @@ public:
                                    const Target &target = get_target_from_environment());
     // @}
 
+    /** Statically compile this function to llvm assembly, with the
+     * given filename (which should probably end in .ll), type
+     * signature, and C function name (which defaults to the same name
+     * as this halide function */
+    //@{
+    EXPORT void compile_to_llvm_assembly(const std::string &filename, const std::vector<Argument> &, const std::string &fn_name,
+                                         const Target &target = get_target_from_environment());
+    EXPORT void compile_to_llvm_assembly(const std::string &filename, const std::vector<Argument> &,
+                                         const Target &target = get_target_from_environment());
+    // @}
+
     /** Statically compile this function to an object file, with the
      * given filename (which should probably end in .o or .obj), type
      * signature, and C function name (which defaults to the same name

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -186,6 +186,13 @@ void Pipeline::compile_to_bitcode(const string &filename,
     compile_module_to_llvm_bitcode(compile_to_module(args, fn_name, target), filename);
 }
 
+void Pipeline::compile_to_llvm_assembly(const string &filename,
+                                        const vector<Argument> &args,
+                                        const string &fn_name,
+                                        const Target &target) {
+    compile_module_to_llvm_assembly(compile_to_module(args, fn_name, target), filename);
+}
+
 void Pipeline::compile_to_object(const string &filename,
                                  const vector<Argument> &args,
                                  const string &fn_name,

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -136,6 +136,15 @@ public:
                                    const std::string &fn_name,
                                    const Target &target = get_target_from_environment());
 
+    /** Statically compile a pipeline to llvm assembly, with the given
+     * filename (which should probably end in .ll), type signature,
+     * and C function name. If you're compiling a pipeline with a
+     * single output Func, see also Func::compile_to_llvm_assembly. */
+    EXPORT void compile_to_llvm_assembly(const std::string &filename,
+                                   const std::vector<Argument> &args,
+                                   const std::string &fn_name,
+                                   const Target &target = get_target_from_environment());
+
     /** Statically compile a pipeline with multiple output functions to an
      * object file, with the given filename (which should probably end in
      * .o or .obj), type signature, and C function name (which defaults to

--- a/src/runtime/cuda.cpp
+++ b/src/runtime/cuda.cpp
@@ -500,6 +500,7 @@ WEAK int halide_cuda_device_release(void *user_context) {
         // Only destroy the context if we own it
         if (ctx == context) {
             debug(user_context) << "    cuCtxDestroy " << context << "\n";
+            err = cuProfilerStop();
             err = cuCtxDestroy(context);
             halide_assert(user_context, err == CUDA_SUCCESS || err == CUDA_ERROR_DEINITIALIZED);
             context = NULL;

--- a/src/runtime/cuda_functions.h
+++ b/src/runtime/cuda_functions.h
@@ -21,6 +21,7 @@ CUDA_FN(CUresult, cuDeviceGetName, (char *, int len, CUdevice dev));
 CUDA_FN(CUresult, cuDeviceTotalMem, (size_t *, CUdevice dev));
 CUDA_FN_3020(CUresult, cuCtxCreate, cuCtxCreate_v2, (CUcontext *pctx, unsigned int flags, CUdevice dev));
 CUDA_FN_4000(CUresult, cuCtxDestroy, cuCtxDestroy_v2, (CUcontext pctx));
+CUDA_FN(CUresult, cuProfilerStop, ());
 CUDA_FN(CUresult, cuCtxGetApiVersion, (CUcontext ctx, unsigned int *version));
 CUDA_FN(CUresult, cuModuleLoadData, (CUmodule *module, const void *image));
 CUDA_FN(CUresult, cuModuleUnload, (CUmodule module));


### PR DESCRIPTION
Harvested parts of #928.
Also added cuProfilerStop call as described in
http://devblogs.nvidia.com/parallelforall/pro-tip-clean-up-after-yourself-ensure-correct-profiling/.
Hopefully fixes #910.