### PR TITLE
Generate vshuff to interleave vectors.

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -2240,12 +2240,8 @@ void CodeGen_Hexagon::visit(const Call *op) {
         if ((arg0.type() == arg1.type()) &&
             op->type.element_of() == arg0.type().element_of()) {
           internal_assert(op->type.lanes() == 2*arg0.type().lanes());
-          std::vector<Value *> Ops;
-          Ops.push_back(codegen(arg1));
-          Ops.push_back(codegen(arg0));
           int scalar = -1 * op->type.bytes();
-          Value *scalar_value = codegen(IntImm::make(Int(32), scalar));
-          Ops.push_back(scalar_value);
+          std::vector<Value *> Ops = {codegen(arg1), codegen(arg0), codegen(scalar)};
           llvm::Function *F =
             Intrinsic::getDeclaration(module.get(),
                                       IPICK(Intrinsic::hexagon_V6_vshuffvdd));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1352,6 +1352,13 @@ void check_hvx_all() {
     check("vshuffo(v*.b,v*.b)", hvx_width/1, u8(u16_1 >> 8));
     check("vshuffo(v*.h,v*.h)", hvx_width/2, u16(u32_1 >> 16));
 
+    check("vshuff(v*,v*,r*)", hvx_width*2, select((x%2) == 0, u8(x/2), u8(x/2)));
+    check("vshuff(v*,v*,r*)", hvx_width*2, select((x%2) == 0, i8(x/2), i8(x/2)));
+    check("vshuff(v*,v*,r*)", (hvx_width*2)/2, select((x%2) == 0, u16(x/2), u16(x/2)));
+    check("vshuff(v*,v*,r*)", (hvx_width*2)/2, select((x%2) == 0, i16(x/2), i16(x/2)));
+    check("vshuff(v*,v*,r*)", (hvx_width*2)/4, select((x%2) == 0, u32(x/2), u32(x/2)));
+    check("vshuff(v*,v*,r*)", (hvx_width*2)/4, select((x%2) == 0, i32(x/2), i32(x/2)));
+
     // We know the following don't work yet; They are WIP. Do this to sort of
     // XFAIL them.
 #if 0

--- a/test/hexagon/codegen/interleave_vectors.cpp
+++ b/test/hexagon/codegen/interleave_vectors.cpp
@@ -1,0 +1,40 @@
+// RUN: ./interleave_vectors.out | FileCheck %s
+#include <Halide.h>
+#include "interleave_vectors.h"
+#include <stdio.h>
+using namespace Halide;
+using namespace Halide::Internal;
+IRPrinter irp(std::cerr);
+
+
+int main(int argc, char **argv) {
+  Target target;
+  setupHexagonTarget(target, Target::HVX_64);
+  commonPerfSetup(target);
+
+  // CHECK: __check_int8_t
+  // CHECK: v{{[0-9]+}}:{{[0-9]+}} = vshuff(v{{[0-9]+}},v{{[0-9]+}},r{{[0-9]+}})
+  check_interleave<int8_t>(target, "check_int8_t");
+
+  // CHECK: __check_uint8_t
+  // CHECK: v{{[0-9]+}}:{{[0-9]+}} = vshuff(v{{[0-9]+}},v{{[0-9]+}},r{{[0-9]+}})
+  check_interleave<uint8_t>(target, "check_uint8_t");
+
+  // CHECK: __check_int16_t
+  // CHECK: v{{[0-9]+}}:{{[0-9]+}} = vshuff(v{{[0-9]+}},v{{[0-9]+}},r{{[0-9]+}})
+  check_interleave<int16_t>(target, "check_int16_t");
+
+  // CHECK: __check_uint16_t
+  // CHECK: v{{[0-9]+}}:{{[0-9]+}} = vshuff(v{{[0-9]+}},v{{[0-9]+}},r{{[0-9]+}})
+  check_interleave<uint16_t>(target, "check_uint16_t");
+
+  // CHECK: __check_int32_t
+  // CHECK: v{{[0-9]+}}:{{[0-9]+}} = vshuff(v{{[0-9]+}},v{{[0-9]+}},r{{[0-9]+}})
+  check_interleave<int32_t>(target, "check_int32_t");
+
+  // CHECK: __check_uint32_t
+  // CHECK: v{{[0-9]+}}:{{[0-9]+}} = vshuff(v{{[0-9]+}},v{{[0-9]+}},r{{[0-9]+}})
+  check_interleave<uint32_t>(target, "check_uint32_t");
+
+  return 0;
+}

--- a/test/hexagon/codegen/interleave_vectors.h
+++ b/test/hexagon/codegen/interleave_vectors.h
@@ -1,0 +1,15 @@
+#include "halide-hexagon-setup.h"
+#define VECTOR_SIZE_IN_BYTES 64
+template <typename T>
+void check_interleave(Target target, const char *name) {
+  Halide::Var x("x"), y("y");
+  ImageParam i1 (type_of<T>(), 1);
+  ImageParam i2 (type_of<T>(), 1);
+  Halide::Func f;
+  f(x) = select((x%2) == 0, i1(x/2), i2(x/2));
+  std::vector<Argument> args(2);
+  args[0]  = i1;
+  args[1] = i2;
+  f.vectorize(x, (VECTOR_SIZE_IN_BYTES / sizeof(T)) * 2);
+  COMPILE(f, name);
+}


### PR DESCRIPTION
Added tests to both simd_op_check.cpp and test/hexagon/codegen. We
should deprecate test/hexagon/codegen only after all tests in that
directory have been ported to simd_op_check.cpp.