### PR TITLE
Refactor integer division optimization

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -468,7 +468,7 @@ void CodeGen_ARM::visit(const Mul *op) {
     CodeGen_Posix::visit(op);
 }
 
-llvm::Value *CodeGen_ARM::sorted_avg(llvm::Value *a, llvm::Value *b) {
+Value *CodeGen_ARM::sorted_avg(Value *a, Value *b) {
     internal_assert(a->getType() == b->getType());
     llvm::Type *ty = a->getType();
     if (!neon_intrinsics_disabled() && ty->isVectorTy()) {

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -8,7 +8,6 @@
 #include "Debug.h"
 #include "Util.h"
 #include "Simplify.h"
-#include "IntegerDivisionTable.h"
 #include "IRPrinter.h"
 #include "LLVM_Headers.h"
 
@@ -469,13 +468,36 @@ void CodeGen_ARM::visit(const Mul *op) {
     CodeGen_Posix::visit(op);
 }
 
-void CodeGen_ARM::visit(const Div *op) {
-    if (neon_intrinsics_disabled()) {
-        CodeGen_Posix::visit(op);
-        return;
+llvm::Value *CodeGen_ARM::sorted_avg(llvm::Value *a, llvm::Value *b) {
+    internal_assert(a->getType() == b->getType());
+    llvm::Type *ty = a->getType();
+    if (!neon_intrinsics_disabled() && ty->isVectorTy()) {
+        if (ty->getScalarSizeInBits() == 32) {
+            if (target.bits == 32) {
+                return call_intrin(ty, 2, "llvm.arm.neon.vhaddu.v2i32", {a, b});
+            } else {
+                return call_intrin(ty, 2, "llvm.aarch64.neon.uhadd.v2i32", {a, b});
+            }
+        } else if (ty->getScalarSizeInBits() == 16) {
+            if (target.bits == 32) {
+                return call_intrin(ty, 4, "llvm.arm.neon.vhaddu.v4i16", {a, b});
+            } else {
+                return call_intrin(ty, 4, "llvm.aarch64.neon.uhadd.v4i16", {a, b});
+            }
+        } else if (ty->getScalarSizeInBits() == 8) {
+            if (target.bits == 32) {
+                return call_intrin(ty, 8, "llvm.arm.neon.vhaddu.v8i8", {a, b});
+            } else {
+                return call_intrin(ty, 8, "llvm.aarch64.neon.uhadd.v8i8", {a, b});
+            }
+        }
     }
+    return CodeGen_Posix::sorted_avg(a, b);
+}
 
-    if (op->type.is_vector() && is_two(op->b) &&
+void CodeGen_ARM::visit(const Div *op) {
+    if (!neon_intrinsics_disabled() &&
+        op->type.is_vector() && is_two(op->b) &&
         (op->a.as<Add>() || op->a.as<Sub>())) {
         vector<Expr> matches;
         for (size_t i = 0; i < averagings.size(); i++) {
@@ -485,148 +507,7 @@ void CodeGen_ARM::visit(const Div *op) {
             }
         }
     }
-
-    // Detect if it's a small int division
-    const int64_t *const_int_divisor = as_const_int(op->b);
-    const uint64_t *const_uint_divisor = as_const_uint(op->b);
-
-    // Check if the divisor is a power of two
-    int shift_amount;
-    bool power_of_two = is_const_power_of_two_integer(op->b, &shift_amount);
-
-    vector<Expr> matches;
-    if (power_of_two && op->type.is_int()) {
-        Value *numerator = codegen(op->a);
-        Constant *shift = ConstantInt::get(llvm_type_of(op->type), shift_amount);
-        value = builder->CreateAShr(numerator, shift);
-    } else if (power_of_two && op->type.is_uint()) {
-        Value *numerator = codegen(op->a);
-        Constant *shift = ConstantInt::get(llvm_type_of(op->type), shift_amount);
-        value = builder->CreateLShr(numerator, shift);
-    } else if (const_int_divisor &&
-               op->type.is_int() &&
-               (op->type.bits() == 32 || op->type.bits() == 16 || op->type.bits() == 8) &&
-               *const_int_divisor > 1 &&
-               ((op->type.bits() > 8 && *const_int_divisor < 256) || *const_int_divisor < 128)) {
-
-        int64_t multiplier, shift;
-        if (op->type.bits() == 32) {
-            multiplier = IntegerDivision::table_s32[*const_int_divisor][2];
-            shift      = IntegerDivision::table_s32[*const_int_divisor][3];
-        } else if (op->type.bits() == 16) {
-            multiplier = IntegerDivision::table_s16[*const_int_divisor][2];
-            shift      = IntegerDivision::table_s16[*const_int_divisor][3];
-        } else {
-            // 8 bit
-            multiplier = IntegerDivision::table_s8[*const_int_divisor][2];
-            shift      = IntegerDivision::table_s8[*const_int_divisor][3];
-        }
-
-        Value *val = codegen(op->a);
-
-        // Make an all-ones mask if the numerator is negative
-        Value *sign = builder->CreateAShr(val, codegen(make_const(op->type, op->type.bits()-1)));
-        // Flip the numerator bits if the mask is high
-        Value *flipped = builder->CreateXor(sign, val);
-        // Grab the multiplier
-        Value *mult = codegen(make_const(op->type, (int)multiplier));
-        // Widening multiply
-        llvm::Type *narrower = llvm_type_of(op->type);
-        llvm::Type *wider = llvm_type_of(Int(op->type.bits()*2, op->type.lanes()));
-        // flipped's high bit is zero, so it's ok to zero-extend it
-        Value *flipped_wide = builder->CreateIntCast(flipped, wider, false);
-        Value *mult_wide = builder->CreateIntCast(mult, wider, false);
-        Value *wide_val = builder->CreateMul(flipped_wide, mult_wide);
-        // Do the shift (add 8 or 16 to narrow back down)
-        Constant *shift_amount = ConstantInt::get(wider, (shift + op->type.bits()));
-        val = builder->CreateLShr(wide_val, shift_amount);
-        val = builder->CreateIntCast(val, narrower, true);
-        // Maybe flip the bits again
-        value = builder->CreateXor(val, sign);
-
-    } else if (const_uint_divisor &&
-               op->type.is_uint() &&
-               (op->type.bits() == 32 || op->type.bits() == 16 || op->type.bits() == 8) &&
-               *const_uint_divisor > 1 && *const_uint_divisor < 256) {
-
-        int64_t method, multiplier, shift;
-        if (op->type.bits() == 32) {
-            method     = IntegerDivision::table_u32[*const_uint_divisor][1];
-            multiplier = IntegerDivision::table_u32[*const_uint_divisor][2];
-            shift      = IntegerDivision::table_u32[*const_uint_divisor][3];
-        } else if (op->type.bits() == 16) {
-            method     = IntegerDivision::table_u16[*const_uint_divisor][1];
-            multiplier = IntegerDivision::table_u16[*const_uint_divisor][2];
-            shift      = IntegerDivision::table_u16[*const_uint_divisor][3];
-        } else {
-            method     = IntegerDivision::table_u8[*const_uint_divisor][1];
-            multiplier = IntegerDivision::table_u8[*const_uint_divisor][2];
-            shift      = IntegerDivision::table_u8[*const_uint_divisor][3];
-        }
-
-        internal_assert(method != 0)
-            << "method 0 division is for powers of two and should have been handled elsewhere\n";
-
-        Value *num = codegen(op->a);
-
-        // Widen
-        llvm::Type *narrower = llvm_type_of(op->type);
-        llvm::Type *wider = llvm_type_of(UInt(op->type.bits()*2, op->type.lanes()));
-        Value *mult = ConstantInt::get(narrower, multiplier);
-        mult = builder->CreateIntCast(mult, wider, false);
-        Value *val = builder->CreateIntCast(num, wider, false);
-
-        // Multiply
-        val = builder->CreateMul(val, mult);
-
-        // Narrow
-        int shift_bits = op->type.bits();
-        // For method 1, we can do the final shift here too.
-        if (method == 1) {
-            shift_bits += (int)shift;
-        }
-        Constant *shift_amount = ConstantInt::get(wider, shift_bits);
-        val = builder->CreateLShr(val, shift_amount);
-        val = builder->CreateIntCast(val, narrower, false);
-
-        // Average with original numerator
-        if (method == 2) {
-            if (op->type.is_vector() && op->type.bits() == 32) {
-                if (target.bits == 32) {
-                    val = call_intrin(narrower, 2, "llvm.arm.neon.vhaddu.v2i32", {val, num});
-                } else {
-                    val = call_intrin(narrower, 2, "llvm.aarch64.neon.uhadd.v2i32", {val, num});
-                }
-            } else if (op->type.is_vector() && op->type.bits() == 16) {
-                if (target.bits == 32) {
-                    val = call_intrin(narrower, 4, "llvm.arm.neon.vhaddu.v4i16", {val, num});
-                } else {
-                    val = call_intrin(narrower, 4, "llvm.aarch64.neon.uhadd.v4i16", {val, num});
-                }
-            } else if (op->type.is_vector() && op->type.bits() == 8) {
-                if (target.bits == 32) {
-                    val = call_intrin(narrower, 8, "llvm.arm.neon.vhaddu.v8i8", {val, num});
-                } else {
-                    val = call_intrin(narrower, 8, "llvm.aarch64.neon.uhadd.v8i8", {val, num});
-                }
-            } else {
-                // num > val, so the following works without widening:
-                // val += (num - val)/2
-                Value *diff = builder->CreateSub(num, val);
-                diff = builder->CreateLShr(diff, ConstantInt::get(diff->getType(), 1));
-                val = builder->CreateAdd(val, diff);
-            }
-
-            // Do the final shift
-            if (shift) {
-                val = builder->CreateLShr(val, ConstantInt::get(narrower, shift));
-            }
-        }
-
-        value = val;
-    } else {
-        CodeGen_Posix::visit(op);
-    }
+    CodeGen_Posix::visit(op);
 }
 
 void CodeGen_ARM::visit(const Add *op) {

--- a/src/CodeGen_ARM.h
+++ b/src/CodeGen_ARM.h
@@ -18,6 +18,8 @@ public:
 
 protected:
 
+    llvm::Value *sorted_avg(llvm::Value *a, llvm::Value *b);
+
     using CodeGen_Posix::visit;
 
     /** Nodes for which we want to emit specific neon intrinsics */

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -15,6 +15,7 @@
 #include "Util.h"
 #include "LLVM_Runtime_Linker.h"
 #include "MatlabWrapper.h"
+#include "IntegerDivisionTable.h"
 
 #include "CodeGen_X86.h"
 #include "CodeGen_GPU_Host.h"
@@ -1259,9 +1260,133 @@ void CodeGen_LLVM::visit(const Mul *op) {
     }
 }
 
+llvm::Value *CodeGen_LLVM::unsigned_mulhi_shr(llvm::Value *a, llvm::Value *b, int shr) {
+    llvm::Type *ty = a->getType();
+    llvm::VectorType *vty = dyn_cast<VectorType>(ty);
+    llvm::Type *element_ty = vty ? vty->getElementType() : ty;
+    llvm::Type *wide_ty = llvm::IntegerType::get(ty->getContext(), element_ty->getIntegerBitWidth() * 2);
+    if (vty) {
+        wide_ty = llvm::VectorType::get(wide_ty, vty->getNumElements());
+    }
+
+    // flipped's high bit is zero, so it's ok to zero-extend it
+    Value *a_wide = builder->CreateIntCast(a, wide_ty, false);
+    Value *b_wide = builder->CreateIntCast(b, wide_ty, false);
+    Value *p_wide = builder->CreateMul(a_wide, b_wide);
+
+    // Do the shift (add 8 or 16 or 32 to narrow back down)
+    Constant *shift_amount = ConstantInt::get(wide_ty, shr + element_ty->getIntegerBitWidth());
+    Value *p = builder->CreateLShr(p_wide, shift_amount);
+    return builder->CreateIntCast(p, ty, true);
+}
+
+llvm::Value *CodeGen_LLVM::sorted_avg(llvm::Value *a, llvm::Value *b) {
+    // b > a, so the following works without widening:
+    // a + (b - a)/2
+    Value *diff = builder->CreateSub(b, a);
+    diff = builder->CreateLShr(diff, ConstantInt::get(diff->getType(), 1));
+    return builder->CreateAdd(a, diff);
+}
+
+
 void CodeGen_LLVM::visit(const Div *op) {
+    user_assert(!is_zero(op->b)) << "Division by constant zero in expression: " << Expr(op) << "\n";
+
+    // Detect if it's a small int division
+    const int64_t *const_int_divisor = as_const_int(op->b);
+    const uint64_t *const_uint_divisor = as_const_uint(op->b);
+
+    int shift_amount;
+    bool power_of_two = is_const_power_of_two_integer(op->b, &shift_amount);
+
     if (op->type.is_float()) {
         value = builder->CreateFDiv(codegen(op->a), codegen(op->b));
+    } else if (power_of_two && op->type.is_int()) {
+        Value *numerator = codegen(op->a);
+        Constant *shift = ConstantInt::get(llvm_type_of(op->type), shift_amount);
+        value = builder->CreateAShr(numerator, shift);
+    } else if (power_of_two && op->type.is_uint()) {
+        Value *numerator = codegen(op->a);
+        Constant *shift = ConstantInt::get(llvm_type_of(op->type), shift_amount);
+        value = builder->CreateLShr(numerator, shift);
+    } else if (const_int_divisor &&
+               op->type.is_int() &&
+               (op->type.bits() == 8 || op->type.bits() == 16 || op->type.bits() == 32) &&
+               *const_int_divisor > 1 &&
+               ((op->type.bits() > 8 && *const_int_divisor < 256) || *const_int_divisor < 128)) {
+
+        int64_t multiplier, shift;
+        if (op->type.bits() == 32) {
+            multiplier = IntegerDivision::table_s32[*const_int_divisor][2];
+            shift      = IntegerDivision::table_s32[*const_int_divisor][3];
+        } else if (op->type.bits() == 16) {
+            multiplier = IntegerDivision::table_s16[*const_int_divisor][2];
+            shift      = IntegerDivision::table_s16[*const_int_divisor][3];
+        } else {
+            // 8 bit
+            multiplier = IntegerDivision::table_s8[*const_int_divisor][2];
+            shift      = IntegerDivision::table_s8[*const_int_divisor][3];
+        }
+
+        Value *val = codegen(op->a);
+
+        // Make an all-ones mask if the numerator is negative
+        Value *sign = builder->CreateAShr(val, codegen(make_const(op->type, op->type.bits()-1)));
+        // Flip the numerator bits if the mask is high.
+        Value *flipped = builder->CreateXor(sign, val);
+
+        // Grab the multiplier.
+        Value *mult = ConstantInt::get(llvm_type_of(op->type), multiplier);
+
+        // Widening multiply, keep high half, shift
+        val = unsigned_mulhi_shr(flipped, mult, shift);
+
+        // Maybe flip the bits again
+        value = builder->CreateXor(val, sign);
+
+    } else if (const_uint_divisor &&
+               op->type.is_uint() &&
+               (op->type.bits() == 8 || op->type.bits() == 16 || op->type.bits() == 32) &&
+               *const_uint_divisor > 1 && *const_uint_divisor < 256) {
+
+        int64_t method, multiplier, shift;
+        if (op->type.bits() == 32) {
+            method     = IntegerDivision::table_u32[*const_uint_divisor][1];
+            multiplier = IntegerDivision::table_u32[*const_uint_divisor][2];
+            shift      = IntegerDivision::table_u32[*const_uint_divisor][3];
+        } else if (op->type.bits() == 16) {
+            method     = IntegerDivision::table_u16[*const_uint_divisor][1];
+            multiplier = IntegerDivision::table_u16[*const_uint_divisor][2];
+            shift      = IntegerDivision::table_u16[*const_uint_divisor][3];
+        } else {
+            method     = IntegerDivision::table_u8[*const_uint_divisor][1];
+            multiplier = IntegerDivision::table_u8[*const_uint_divisor][2];
+            shift      = IntegerDivision::table_u8[*const_uint_divisor][3];
+        }
+
+        internal_assert(method != 0)
+            << "method 0 division is for powers of two and should have been handled elsewhere\n";
+
+        Value *num = codegen(op->a);
+
+        // Widen, multiply, narrow
+        Value *mult = ConstantInt::get(llvm_type_of(op->type), multiplier);
+        Value *val = num;
+
+        val = unsigned_mulhi_shr(val, mult, method == 1 ? shift : 0);
+
+        // Average with original numerator. Can't use sse rounding ops
+        // because they round up.
+        if (method == 2) {
+            val = sorted_avg(val, num);
+
+            // Do the final shift
+            if (shift) {
+                val = builder->CreateLShr(val, ConstantInt::get(llvm_type_of(op->type), shift));
+            }
+        }
+
+        value = val;
     } else if (op->type.is_uint()) {
         value = builder->CreateUDiv(codegen(op->a), codegen(op->b));
     } else {

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -308,7 +308,9 @@ protected:
 
     /** Helpers for implementing fast integer division. */
     // @{
-    // Compute high_half(a*b) >> shr
+    // Compute high_half(a*b) >> shr. Note that this is a shift in
+    // addition to the implicit shift due to taking the upper half of
+    // the multiply result.
     virtual llvm::Value *unsigned_mulhi_shr(llvm::Value *a, llvm::Value *b, int shr);
     // Compute (a+b)/2, assuming a < b.
     virtual llvm::Value *sorted_avg(llvm::Value *a, llvm::Value *b);

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -306,6 +306,15 @@ protected:
      * different buffers */
     void add_tbaa_metadata(llvm::Instruction *inst, std::string buffer, Expr index);
 
+    /** Helpers for implementing fast integer division. */
+    // @{
+    // Compute high_half(a*b) >> shr
+    virtual llvm::Value *unsigned_mulhi_shr(llvm::Value *a, llvm::Value *b, int shr);
+    // Compute (a+b)/2, assuming a < b.
+    virtual llvm::Value *sorted_avg(llvm::Value *a, llvm::Value *b);
+    // @}
+
+
     using IRVisitor::visit;
 
     /** Generate code for various IR nodes. These can be overridden by

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -8,7 +8,6 @@
 #include "Util.h"
 #include "Var.h"
 #include "Param.h"
-#include "IntegerDivisionTable.h"
 #include "LLVM_Headers.h"
 #include "IRMutator.h"
 
@@ -370,157 +369,19 @@ void CodeGen_X86::visit(const Cast *op) {
     CodeGen_Posix::visit(op);
 }
 
-void CodeGen_X86::visit(const Div *op) {
+llvm::Value *CodeGen_X86::unsigned_mulhi_shr(llvm::Value *a, llvm::Value *b, int shr) {
+    internal_assert(a->getType() == b->getType());
+    llvm::Type *ty = a->getType();
 
-    user_assert(!is_zero(op->b)) << "Division by constant zero in expression: " << Expr(op) << "\n";
-
-    // Detect if it's a small int division
-    const int64_t *const_int_divisor = as_const_int(op->b);
-    const uint64_t *const_uint_divisor = as_const_uint(op->b);
-
-    int shift_amount;
-    bool power_of_two = is_const_power_of_two_integer(op->b, &shift_amount);
-
-    vector<Expr> matches;
-    if (power_of_two && op->type.is_int()) {
-        Value *numerator = codegen(op->a);
-        Constant *shift = ConstantInt::get(llvm_type_of(op->type), shift_amount);
-        value = builder->CreateAShr(numerator, shift);
-    } else if (power_of_two && op->type.is_uint()) {
-        Value *numerator = codegen(op->a);
-        Constant *shift = ConstantInt::get(llvm_type_of(op->type), shift_amount);
-        value = builder->CreateLShr(numerator, shift);
-    } else if (const_int_divisor &&
-               op->type.is_int() &&
-               (op->type.bits() == 8 || op->type.bits() == 16 || op->type.bits() == 32) &&
-               *const_int_divisor > 1 &&
-               ((op->type.bits() > 8 && *const_int_divisor < 256) || *const_int_divisor < 128)) {
-
-        int64_t multiplier, shift;
-        if (op->type.bits() == 32) {
-            multiplier = IntegerDivision::table_s32[*const_int_divisor][2];
-            shift      = IntegerDivision::table_s32[*const_int_divisor][3];
-        } else if (op->type.bits() == 16) {
-            multiplier = IntegerDivision::table_s16[*const_int_divisor][2];
-            shift      = IntegerDivision::table_s16[*const_int_divisor][3];
-        } else {
-            // 8 bit
-            multiplier = IntegerDivision::table_s8[*const_int_divisor][2];
-            shift      = IntegerDivision::table_s8[*const_int_divisor][3];
+    if (ty->isVectorTy() && ty->getScalarSizeInBits() == 16) {
+        llvm::Value *p = call_intrin(ty, 8, "llvm.x86.sse2.pmulhu.w", {a, b});
+        if (shr) {
+            Constant *shift_amount = ConstantInt::get(ty, shr);
+            p = builder->CreateLShr(p, shift_amount);
         }
-
-        Value *val = codegen(op->a);
-
-        // Make an all-ones mask if the numerator is negative
-        Value *sign = builder->CreateAShr(val, codegen(make_const(op->type, op->type.bits()-1)));
-        // Flip the numerator bits if the mask is high.
-        Value *flipped = builder->CreateXor(sign, val);
-
-        llvm::Type *narrower = llvm_type_of(op->type);
-        llvm::Type *wider = llvm_type_of(Int(op->type.bits()*2, op->type.lanes()));
-
-        // Grab the multiplier.
-        Value *mult = ConstantInt::get(narrower, multiplier);
-
-        // Widening multiply, keep high half, shift
-        if (op->type.element_of() == Int(16) && op->type.is_vector()) {
-            val = call_intrin(narrower, 8, "llvm.x86.sse2.pmulhu.w", {flipped, mult});
-            if (shift) {
-                Constant *shift_amount = ConstantInt::get(narrower, shift);
-                val = builder->CreateLShr(val, shift_amount);
-            }
-        } else {
-            // flipped's high bit is zero, so it's ok to zero-extend it
-            Value *flipped_wide = builder->CreateIntCast(flipped, wider, false);
-            Value *mult_wide = builder->CreateIntCast(mult, wider, false);
-            Value *wide_val = builder->CreateMul(flipped_wide, mult_wide);
-            // Do the shift (add 8 or 16 or 32 to narrow back down)
-            Constant *shift_amount = ConstantInt::get(wider, (shift + op->type.bits()));
-            val = builder->CreateLShr(wide_val, shift_amount);
-            val = builder->CreateIntCast(val, narrower, true);
-        }
-
-        // Maybe flip the bits again
-        value = builder->CreateXor(val, sign);
-
-    } else if (const_uint_divisor &&
-               op->type.is_uint() &&
-               (op->type.bits() == 8 || op->type.bits() == 16 || op->type.bits() == 32) &&
-               *const_uint_divisor > 1 && *const_uint_divisor < 256) {
-
-        int64_t method, multiplier, shift;
-        if (op->type.bits() == 32) {
-            method     = IntegerDivision::table_u32[*const_uint_divisor][1];
-            multiplier = IntegerDivision::table_u32[*const_uint_divisor][2];
-            shift      = IntegerDivision::table_u32[*const_uint_divisor][3];
-        } else if (op->type.bits() == 16) {
-            method     = IntegerDivision::table_u16[*const_uint_divisor][1];
-            multiplier = IntegerDivision::table_u16[*const_uint_divisor][2];
-            shift      = IntegerDivision::table_u16[*const_uint_divisor][3];
-        } else {
-            method     = IntegerDivision::table_u8[*const_uint_divisor][1];
-            multiplier = IntegerDivision::table_u8[*const_uint_divisor][2];
-            shift      = IntegerDivision::table_u8[*const_uint_divisor][3];
-        }
-
-        internal_assert(method != 0)
-            << "method 0 division is for powers of two and should have been handled elsewhere\n";
-
-        Value *num = codegen(op->a);
-
-        // Widen, multiply, narrow
-        llvm::Type *narrower = llvm_type_of(op->type);
-        llvm::Type *wider = llvm_type_of(UInt(op->type.bits()*2, op->type.lanes()));
-
-        Value *mult = ConstantInt::get(narrower, multiplier);
-        Value *val = num;
-
-        if (op->type.element_of() == UInt(16) && op->type.is_vector()) {
-            val = call_intrin(narrower, 8, "llvm.x86.sse2.pmulhu.w", {val, mult});
-            if (shift && method == 1) {
-                Constant *shift_amount = ConstantInt::get(narrower, shift);
-                val = builder->CreateLShr(val, shift_amount);
-            }
-        } else {
-
-            // Widen
-            mult = builder->CreateIntCast(mult, wider, false);
-            val = builder->CreateIntCast(val, wider, false);
-
-            // Multiply
-            val = builder->CreateMul(val, mult);
-
-            // Keep high half
-            int shift_bits = op->type.bits();
-            // For method 1, we can do the final shift here too
-            if (method == 1) {
-                shift_bits += (int)shift;
-            }
-            Constant *shift_amount = ConstantInt::get(wider, shift_bits);
-            val = builder->CreateLShr(val, shift_amount);
-            val = builder->CreateIntCast(val, narrower, false);
-        }
-
-        // Average with original numerator. Can't use sse rounding ops
-        // because they round up.
-        if (method == 2) {
-            // num > val, so the following works without widening:
-            // val += (num - val)/2
-            Value *diff = builder->CreateSub(num, val);
-            diff = builder->CreateLShr(diff, ConstantInt::get(diff->getType(), 1));
-            val = builder->CreateNUWAdd(val, diff);
-
-            // Do the final shift
-            if (shift) {
-                val = builder->CreateLShr(val, ConstantInt::get(narrower, shift));
-            }
-        }
-
-        value = val;
-
-    } else {
-        CodeGen_Posix::visit(op);
+        return p;
     }
+    return CodeGen_Posix::unsigned_mulhi_shr(a, b, shr);
 }
 
 void CodeGen_X86::visit(const Min *op) {

--- a/src/CodeGen_X86.h
+++ b/src/CodeGen_X86.h
@@ -29,7 +29,6 @@ protected:
     bool use_soft_float_abi() const;
     int native_vector_bits() const;
 
-    // Multiply two unsigned values, keep the high half, then shift it right.
     llvm::Value *unsigned_mulhi_shr(llvm::Value *a, llvm::Value *b, int shr);
 
     using CodeGen_Posix::visit;

--- a/src/CodeGen_X86.h
+++ b/src/CodeGen_X86.h
@@ -29,6 +29,9 @@ protected:
     bool use_soft_float_abi() const;
     int native_vector_bits() const;
 
+    // Multiply two unsigned values, keep the high half, then shift it right.
+    llvm::Value *unsigned_mulhi_shr(llvm::Value *a, llvm::Value *b, int shr);
+
     using CodeGen_Posix::visit;
 
     /** Nodes for which we want to emit specific sse/avx intrinsics */
@@ -36,7 +39,6 @@ protected:
     void visit(const Add *);
     void visit(const Sub *);
     void visit(const Cast *);
-    void visit(const Div *);
     void visit(const Min *);
     void visit(const Max *);
     void visit(const GT *);


### PR DESCRIPTION
This makes the optimization for fast integer division easier to share among targets that use CodeGen_LLVM.

Tested on x86 so far. ARM is passing simd_op_check (as well as master is anyways... I see the __modis3 check failing on both master and this branch), but haven't run the const_division test yet. It needs testing on ARM (and the rest of the targets too).