### PR TITLE
mark ImageBase.name() const

### DIFF
--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -104,7 +104,7 @@ ImageBase::ImageBase(Type t, const buffer_t *b, const std::string &name) :
     prepare_for_direct_pixel_access();
 }
 
-const std::string &ImageBase::name() {
+const std::string &ImageBase::name() const {
     return buffer.name();
 }
 

--- a/src/Image.h
+++ b/src/Image.h
@@ -65,7 +65,7 @@ public:
     EXPORT ImageBase(Type t, const buffer_t *b, const std::string &name = "");
 
     /** Get the name of this image. */
-    EXPORT const std::string &name();
+    EXPORT const std::string &name() const;
 
     /** Manually copy-back data to the host, if it's on a device. This
      * is done for you if you construct an image from a buffer, but


### PR DESCRIPTION
I don't see why it should not be const, maybe it's good to make it const.