### PR TITLE
[Hexagon] Codegen refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,7 +387,6 @@ HEADER_FILES = \
   Buffer.h \
   Closure.h \
   CodeGen_ARM.h \
-  CodeGen_Hexagon.h \
   CodeGen_C.h \
   CodeGen_GPU_Dev.h \
   CodeGen_GPU_Host.h \

--- a/src/CodeGen_Hexagon.h
+++ b/src/CodeGen_Hexagon.h
@@ -6,6 +6,12 @@
 
 #include "CodeGen_Posix.h"
 
+namespace llvm {
+namespace Intrinsic {
+enum ID;
+}
+}
+
 namespace Halide {
 namespace Internal {
 
@@ -48,7 +54,8 @@ protected:
     bool shouldUseVDMPY(const Add *, std::vector<llvm::Value *> &);
 
     llvm::Value *emitBinaryOp(const BaseExprNode *op, std::vector<Pattern> &Patterns);
-    llvm::Value *CallLLVMIntrinsic(llvm::Function *F, std::vector<llvm::Value *> Ops);
+    llvm::Value *callLLVMIntrinsic(llvm::Function *F, std::vector<llvm::Value *> Ops);
+    llvm::Value *callLLVMIntrinsic(llvm::Intrinsic::ID id, std::vector<llvm::Value *> Ops);
     std::vector<Expr> getHighAndLowVectors(Expr DoubleVec);
     std::vector<llvm::Value *> getHighAndLowVectors(llvm::Value *DoubleVec);
     llvm::Value *concatVectors(llvm::Value *High, llvm::Value *Low);

--- a/src/CodeGen_Hexagon.h
+++ b/src/CodeGen_Hexagon.h
@@ -47,14 +47,10 @@ protected:
     bool shouldUseVMPA(const Add *, std::vector<llvm::Value *> &);
     bool shouldUseVDMPY(const Add *, std::vector<llvm::Value *> &);
 
-    llvm::Value *emitBinaryOp(const BaseExprNode *op,
-                              std::vector<Pattern> &Patterns);
-    llvm::Value *CallLLVMIntrinsic(llvm::Function *F,
-                                   std::vector<llvm::Value *> &Ops);
-    void getHighAndLowVectors(Expr DoubleVec,
-                               std::vector<Expr> &Res);
-    void getHighAndLowVectors(llvm::Value *DoubleVec,
-                               std::vector<llvm::Value *> &Res);
+    llvm::Value *emitBinaryOp(const BaseExprNode *op, std::vector<Pattern> &Patterns);
+    llvm::Value *CallLLVMIntrinsic(llvm::Function *F, std::vector<llvm::Value *> Ops);
+    std::vector<Expr> getHighAndLowVectors(Expr DoubleVec);
+    std::vector<llvm::Value *> getHighAndLowVectors(llvm::Value *DoubleVec);
     llvm::Value *concatVectors(llvm::Value *High, llvm::Value *Low);
     llvm::Value *convertValueType(llvm::Value *V, llvm::Type *T);
     std::string mcpu() const;
@@ -82,7 +78,7 @@ protected:
 
     llvm::Value *getHiVectorFromPair(llvm::Value *Vec);
     llvm::Value *getLoVectorFromPair(llvm::Value *Vec);
-    void slice_into_halves(Expr, std::vector<Expr> &);
+    std::vector<Expr> slice_into_halves(Expr);
     llvm::Value *handleLargeVectors(const Add *);
     llvm::Value *handleLargeVectors(const Sub *);
     llvm::Value *handleLargeVectors(const Min *);

--- a/src/CodeGen_Hexagon_LV.h
+++ b/src/CodeGen_Hexagon_LV.h
@@ -48,11 +48,11 @@
       std::vector<Expr> VectorRegisterPairsA;
       std::vector<Expr> VectorRegisterPairsB;
       if (isDblVector(op->type, native_vector_bits())) {
-        getHighAndLowVectors(matches[0], VectorRegisterPairsA);
-        getHighAndLowVectors(matches[1], VectorRegisterPairsB);
+        VectorRegisterPairsA = getHighAndLowVectors(matches[0]);
+        VectorRegisterPairsB = getHighAndLowVectors(matches[1]);
       } else {
-        slice_into_halves(matches[0], VectorRegisterPairsA);
-        slice_into_halves(matches[1], VectorRegisterPairsB);
+        VectorRegisterPairsA = slice_into_halves(matches[0]);
+        VectorRegisterPairsB = slice_into_halves(matches[1]);
       }
 
       // 2. Operate on the halves
@@ -82,4 +82,3 @@
 
 #undef _OP
 #undef _EXCLu16x128
-


### PR DESCRIPTION
@pranavb-ca, I hope you don't mind, I went ahead and did some more refactoring of CodeGen_Hexagon. I'm trying to work with it to fix integer division and whatnot, this stuff helps make it easier to add patterns and call intrinsics. I keep running into things like needing to add handlers for every vector width. I'm working towards making the code work with any vector width via CodeGen_LLVM::call_intrin.

Here's the main changes:

- Add a helper for callLLVMIntrinsic that takes an Intrinsic::ID. Pretty much every single call site did the exact same thing to get the function from an ID, this just does that work for you.
- Don't mutate the arguments of callLLVMIntrinsic. This allows callLLVMIntrinsic to be used with an initializer list of operands, and IMO is also safer (lots of places in the code relied on the caller to clear the operands vector, before refilling it... IMO this is sketchy).
- Tried to simplify the patterns lists to where they can be denser (one per line). IMO, this makes them easier to read and check for bugs (because often only one small part of the pattern is intended to change in a predictable way, when these changes are lined up with eachother, it can be easier to see that they are correct).

It passes simd_op_check. I'll try to run the other tests on it now.