### PR TITLE
Better GPU shared memory and block size determination

### DIFF
--- a/apps/interpolate/interpolate.cpp
+++ b/apps/interpolate/interpolate.cpp
@@ -158,22 +158,36 @@ int main(int argc, char **argv) {
         // Some gpus don't have enough memory to process the entire
         // image, so we process the image in tiles.
         Var yo, yi, xo, xi;
-        final.reorder(c, x, y).bound(c, 0, 3).vectorize(x, 4);
-        final.tile(x, y, xo, yo, xi, yi, input.width()/8, input.height()/8);
-        normalize.compute_at(final, xo).reorder(c, x, y).gpu_tile(x, y, 16, 16, DeviceAPI::Default_GPU).unroll(c);
+        final
+            .reorder(c, x, y)
+            .bound(c, 0, 3)
+            .vectorize(x, 4)
+            .tile(x, y, xo, yo, xi, yi, input.width()/4, input.height()/4);
+
+        normalize
+            .compute_at(final, xo)
+            .reorder(c, x, y)
+            .gpu_tile(x, y, 16, 16, DeviceAPI::Default_GPU)
+            .unroll(c);
 
         // Start from level 1 to save memory - level zero will be computed on demand
         for (int l = 1; l < levels; ++l) {
             int tile_size = 32 >> l;
             if (tile_size < 1) tile_size = 1;
             if (tile_size > 8) tile_size = 8;
-            downsampled[l].compute_root();
-            if (false) {
-                // Outer loop on CPU for the larger ones.
-                downsampled[l].tile(x, y, xo, yo, x, y, 256, 256);
+            downsampled[l]
+                .compute_root()
+                .gpu_tile(x, y, c, tile_size, tile_size, 4, DeviceAPI::Default_GPU);
+            if (l == 1 || l == 4) {
+                interpolated[l]
+                    .compute_at(final, xo)
+                    .gpu_tile(x, y, c, 8, 8, 4);
+            } else {
+                int parent = l > 4 ? 4 : 1;
+                interpolated[l]
+                    .compute_at(interpolated[parent], Var::gpu_blocks())
+                    .gpu_threads(x, y, c);
             }
-            downsampled[l].gpu_tile(x, y, c, tile_size, tile_size, 4, DeviceAPI::Default_GPU);
-            interpolated[l].compute_at(final, xo).gpu_tile(x, y, c, tile_size, tile_size, 4, DeviceAPI::Default_GPU);
         }
         break;
     }

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -8,6 +8,7 @@
 #include "IREquality.h"
 #include "Simplify.h"
 #include "IRPrinter.h"
+#include "ExprUsesVar.h"
 
 namespace Halide {
 namespace Internal {
@@ -99,25 +100,34 @@ class ExtractBlockSize : public IRVisitor {
     }
 
     void visit(const For *op) {
-        Interval ie = bounds_of_expr_in_scope(op->extent, scope);
-        Interval im = bounds_of_expr_in_scope(op->min, scope);
-
         for (int i = 0; i < 4; i++) {
             if (ends_with(op->name, thread_names[i])) {
-                found_for(i, ie.max);
+                found_for(i, op->extent);
             }
         }
 
-        scope.push(op->name, Interval(im.min, im.max + ie.max - 1));
         IRVisitor::visit(op);
-        scope.pop(op->name);
+
+        Scope<Interval> s;
+        s.push(op->name,
+               Interval(Variable::make(Int(32), op->name + ".loop_min"),
+                        Variable::make(Int(32), op->name + ".loop_max")));
+        for (int i = 0; i < 4; i++) {
+            if (block_extent[i].defined() &&
+                expr_uses_var(block_extent[i], op->name)) {
+                block_extent[i] = simplify(bounds_of_expr_in_scope(block_extent[i], scope).max);
+            }
+        }
     }
 
     void visit(const LetStmt *op) {
-        Interval i = bounds_of_expr_in_scope(op->value, scope);
-        scope.push(op->name, i);
-        op->body.accept(this);
-        scope.pop(op->name);
+        IRVisitor::visit(op);
+        for (int i = 0; i < 4; i++) {
+            if (block_extent[i].defined() &&
+                expr_uses_var(block_extent[i], op->name)) {
+                block_extent[i] = simplify(Let::make(op->name, op->value, block_extent[i]));
+            }
+        }
     }
 
 public:
@@ -133,16 +143,6 @@ public:
     Expr extent(int d) const {
         return block_extent[d];
     }
-
-    void max_over_blocks(const Scope<Interval> &scope) {
-        for (int i = 0; i < 4; i++) {
-            if (block_extent[i].defined()) {
-                block_extent[i] = simplify(block_extent[i]);
-                block_extent[i] = bounds_of_expr_in_scope(block_extent[i], scope).max;
-            }
-        }
-    }
-
 };
 
 class NormalizeDimensionality : public IRMutator {
@@ -238,11 +238,10 @@ class ReplaceForWithIf : public IRMutator {
 
             internal_assert(dim >= 0 && dim < block_size.dimensions());
 
-            Expr var = Variable::make(Int(32), "." + thread_names[dim]);
-            internal_assert(is_zero(op->min));
             Stmt body = mutate(op->body);
 
-            body = substitute(op->name, var, body);
+            Expr var = Variable::make(Int(32), "." + thread_names[dim]);
+            body = substitute(op->name, var + op->min, body);
 
             if (equal(op->extent, block_size.extent(dim))) {
                 stmt = body;
@@ -269,8 +268,6 @@ class ExtractSharedAllocations : public IRMutator {
     };
     vector<SharedAllocation> allocations;
 
-    Scope<Interval> scope;
-
     set<string> shared;
 
     bool in_threads;
@@ -284,12 +281,28 @@ class ExtractSharedAllocations : public IRMutator {
             IRMutator::visit(op);
             in_threads = old;
         } else {
-            Interval min_bounds = bounds_of_expr_in_scope(op->min, scope);
-            Interval extent_bounds = bounds_of_expr_in_scope(op->extent, scope);
-            Interval bounds(min_bounds.min, min_bounds.max + extent_bounds.max - 1);
-            scope.push(op->name, bounds);
-            IRMutator::visit(op);
-            scope.pop(op->name);
+            vector<SharedAllocation> old;
+            old.swap(allocations);
+
+            Stmt body = mutate(op->body);
+
+            // Expand any new shared allocations found in the body using the loop bounds.
+            Scope<Interval> scope;
+            scope.push(op->name, Interval(Variable::make(Int(32), op->name + ".loop_min"),
+                                          Variable::make(Int(32), op->name + ".loop_max")));
+            for (SharedAllocation &s : allocations) {
+                if (expr_uses_var(s.size, op->name)) {
+                    s.size = bounds_of_expr_in_scope(s.size, scope).max;
+                }
+            }
+
+            if (!allocations.empty()) {
+                allocations.insert(allocations.end(), old.begin(), old.end());
+            } else {
+                allocations.swap(old);
+            }
+
+            stmt = For::make(op->name, mutate(op->min), mutate(op->extent), op->for_type, op->device_api, body);
         }
     }
 
@@ -315,7 +328,7 @@ class ExtractSharedAllocations : public IRMutator {
         for (size_t i = 0; i < op->extents.size(); i++) {
             alloc.size *= op->extents[i];
         }
-        alloc.size = bounds_of_expr_in_scope(simplify(alloc.size), scope).max;
+        alloc.size = simplify(alloc.size);
         allocations.push_back(alloc);
         stmt = op->body;
 
@@ -357,15 +370,16 @@ class ExtractSharedAllocations : public IRMutator {
             return;
         }
 
-        Expr value = mutate(op->value);
-        Interval bounds = bounds_of_expr_in_scope(value, scope);
-        bounds.min = simplify(bounds.min);
-        bounds.max = simplify(bounds.max);
-        scope.push(op->name, bounds);
         Stmt body = mutate(op->body);
-        scope.pop(op->name);
+        Expr value = mutate(op->value);
 
-        if (op->body.same_as(body) && op->value.same_as(value)) {
+        for (SharedAllocation &s : allocations) {
+            if (expr_uses_var(s.size, op->name)) {
+                s.size = simplify(Let::make(op->name, op->value, s.size));
+            }
+        }
+
+        if (op->body.same_as(body) && value.same_as(op->value)) {
             stmt = op;
         } else {
             stmt = LetStmt::make(op->name, value, body);
@@ -436,91 +450,47 @@ public:
     ExtractSharedAllocations(DeviceAPI d) : in_threads(false), device_api(d) {}
 };
 
-class FuseGPUThreadLoops : public IRMutator {
+class FuseGPUThreadLoopsSingleKernel : public IRMutator {
     using IRMutator::visit;
-
-    Scope<Interval> scope;
-
-    bool in_gpu_loop = false;
-
-    void visit(const LetStmt *op) {
-        if (in_gpu_loop) {
-            scope.push(op->name, bounds_of_expr_in_scope(op->value, scope));
-            IRMutator::visit(op);
-            scope.pop(op->name);
-        } else {
-            IRMutator::visit(op);
-        }
-    }
+    const ExtractBlockSize &block_size;
+    ExtractSharedAllocations &shared_mem;
 
     void visit(const For *op) {
-         if (op->device_api == DeviceAPI::GLSL) {
-            stmt = op;
-            return;
-        }
-
-        user_assert(!(CodeGen_GPU_Dev::is_gpu_thread_var(op->name)))
-            << "Loops over GPU thread variable: \"" << op->name
-            << "\" is outside of any loop over a GPU block variable. "
-            << "This schedule is malformed. There must be a GPU block "
-            << "variable, and it must reordered to be outside all GPU "
-            << "thread variables.\n";
-
-        bool should_pop = false;
-        bool old_in_gpu_loop = in_gpu_loop;
-        if (CodeGen_GPU_Dev::is_gpu_block_var(op->name)) {
-            Interval im = bounds_of_expr_in_scope(op->min, scope);
-            Interval ie = bounds_of_expr_in_scope(op->extent, scope);
-            scope.push(op->name, Interval(im.min, im.max + ie.max - 1));
-            should_pop = true;
-            in_gpu_loop = true;
-        }
-
         if (ends_with(op->name, ".__block_id_x")) {
-
             Stmt body = op->body;
 
-            ExtractBlockSize e;
-            body.accept(&e);
-            e.max_over_blocks(scope);
-
+            // This is the innermost loop over blocks.
             debug(3) << "Fusing thread block:\n" << body << "\n\n";
 
-            NormalizeDimensionality n(e, op->device_api);
+            NormalizeDimensionality n(block_size, op->device_api);
             body = n.mutate(body);
 
             debug(3) << "Normalized dimensionality:\n" << body << "\n\n";
-
-            ExtractSharedAllocations h(op->device_api);
-            body = h.mutate(body);
-
-            debug(3) << "Pulled out shared allocations:\n" << body << "\n\n";
 
             InjectThreadBarriers i;
             body = i.mutate(body);
 
             debug(3) << "Injected synchronization:\n" << body << "\n\n";
 
-            ReplaceForWithIf f(e);
+            ReplaceForWithIf f(block_size);
             body = f.mutate(body);
 
             debug(3) << "Replaced for with if:\n" << body << "\n\n";
 
             // Rewrap the whole thing in the loop over threads
-            for (int i = 0; i < e.dimensions(); i++) {
-                body = For::make("." + thread_names[i], 0, e.extent(i), ForType::Parallel, op->device_api, body);
+            for (int i = 0; i < block_size.dimensions(); i++) {
+                body = For::make("." + thread_names[i], 0, block_size.extent(i), ForType::Parallel, op->device_api, body);
             }
 
             // There at least needs to be a loop over __thread_id_x as a marker for codegen
-            if (e.dimensions() == 0) {
+            if (block_size.dimensions() == 0) {
                 body = For::make(".__thread_id_x", 0, 1, ForType::Parallel, op->device_api, body);
             }
 
             debug(3) << "Rewrapped in for loops:\n" << body << "\n\n";
 
             // Add back in the shared allocations
-            body = h.rewrap(body);
-
+            body = shared_mem.rewrap(body);
             debug(3) << "Add back in shared allocations:\n" << body << "\n\n";
 
             if (body.same_as(op->body)) {
@@ -532,10 +502,48 @@ class FuseGPUThreadLoops : public IRMutator {
             IRMutator::visit(op);
         }
 
-        if (should_pop) {
-            scope.pop(op->name);
+    }
+
+public:
+    FuseGPUThreadLoopsSingleKernel(const ExtractBlockSize &bs,
+                                   ExtractSharedAllocations &sm) :
+        block_size(bs), shared_mem(sm) {}
+
+};
+
+class FuseGPUThreadLoops : public IRMutator {
+    using IRMutator::visit;
+
+    void visit(const For *op) {
+        if (op->device_api == DeviceAPI::GLSL) {
+            stmt = op;
+            return;
         }
-        in_gpu_loop = old_in_gpu_loop;
+
+        user_assert(!(CodeGen_GPU_Dev::is_gpu_thread_var(op->name)))
+            << "Loops over GPU thread variable: \"" << op->name
+            << "\" is outside of any loop over a GPU block variable. "
+            << "This schedule is malformed. There must be a GPU block "
+            << "variable, and it must reordered to be outside all GPU "
+            << "thread variables.\n";
+
+        if (CodeGen_GPU_Dev::is_gpu_block_var(op->name)) {
+            // Do the analysis of thread block size and shared memory
+            // usage.
+            ExtractBlockSize block_size;
+            Stmt loop = Stmt(op);
+            loop.accept(&block_size);
+
+            ExtractSharedAllocations shared_mem(op->device_api);
+            loop = shared_mem.mutate(loop);
+
+            debug(3) << "Pulled out shared allocations:\n" << loop << "\n\n";
+
+            // Mutate the inside of the kernel
+            stmt = FuseGPUThreadLoopsSingleKernel(block_size, shared_mem).mutate(loop);
+        } else {
+            IRMutator::visit(op);
+        }
     }
 };
 
@@ -617,7 +625,7 @@ Stmt zero_gpu_loop_mins(Stmt s) {
 Stmt fuse_gpu_thread_loops(Stmt s) {
     ValidateGPULoopNesting validate;
     s.accept(&validate);
-    s = ZeroGPULoopMins().mutate(s);
+    //s = ZeroGPULoopMins().mutate(s);
     s = FuseGPUThreadLoops().mutate(s);
     return s;
 }

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -86,8 +86,6 @@ public:
 class ExtractBlockSize : public IRVisitor {
     Expr block_extent[4];
 
-    Scope<Interval> scope;
-
     using IRVisitor::visit;
 
     void found_for(int dim, Expr extent) {
@@ -108,10 +106,10 @@ class ExtractBlockSize : public IRVisitor {
 
         IRVisitor::visit(op);
 
-        Scope<Interval> s;
-        s.push(op->name,
-               Interval(Variable::make(Int(32), op->name + ".loop_min"),
-                        Variable::make(Int(32), op->name + ".loop_max")));
+        Scope<Interval> scope;
+        scope.push(op->name,
+                   Interval(Variable::make(Int(32), op->name + ".loop_min"),
+                            Variable::make(Int(32), op->name + ".loop_max")));
         for (int i = 0; i < 4; i++) {
             if (block_extent[i].defined() &&
                 expr_uses_var(block_extent[i], op->name)) {

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -623,8 +623,8 @@ Stmt zero_gpu_loop_mins(Stmt s) {
 Stmt fuse_gpu_thread_loops(Stmt s) {
     ValidateGPULoopNesting validate;
     s.accept(&validate);
-    //s = ZeroGPULoopMins().mutate(s);
     s = FuseGPUThreadLoops().mutate(s);
+    s = ZeroGPULoopMins().mutate(s);
     return s;
 }
 

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -702,6 +702,13 @@ private:
         const Max *max_a = a.as<Max>();
         const Max *max_b = b.as<Max>();
 
+        const Div *div_a = a.as<Div>();
+        const Div *div_b = b.as<Div>();
+        if (div_a) add_a_a = div_a->a.as<Add>();
+        if (div_b) add_b_a = div_b->a.as<Add>();
+        const Sub *sub_a_a = div_a ? div_a->a.as<Sub>() : nullptr;
+        const Sub *sub_b_a = div_b ? div_b->a.as<Sub>() : nullptr;
+
         const Select *select_a = a.as<Select>();
         const Select *select_b = b.as<Select>();
 
@@ -1004,6 +1011,101 @@ private:
                    is_zero(simplify((max_a->a + max_b->a) - (max_a->b + max_b->b)))) {
             // max(a, b) - max(c, d) where a-b == d-c -> b - c
             expr = mutate(max_a->b - max_b->a);
+        } else if (div_a &&
+                   div_b &&
+                   is_positive_const(div_a->b) &&
+                   equal(div_a->b, div_b->b) &&
+                   op->type.is_int() &&
+                   no_overflow(op->type) &&
+                   add_a_a &&
+                   add_b_a &&
+                   equal(add_a_a->a, add_b_a->a) &&
+                   (is_simple_const(add_a_a->b) ||
+                    is_simple_const(add_b_a->b))) {
+            // This pattern comes up in bounds inference on upsampling code:
+            // (x + a)/c - (x + b)/c ->
+            //    ((c + a - 1 - b) - (x + a)%c)/c (duplicates a)
+            // or ((x + b)%c + (a - b))/c         (duplicates b)
+            Expr x = add_a_a->a, a = add_a_a->b, b = add_b_a->b, c = div_a->b;
+            if (is_simple_const(b)) {
+                // Use the version that injects two copies of b
+                expr = mutate((((x + (b % c)) % c) + (a - b))/c);
+            } else {
+                // Use the version that injects two copies of a
+                expr = mutate((((c + a - 1) - b) - ((x + (a % c)) % c))/c);
+            }
+        } else if (div_a &&
+                   div_b &&
+                   is_positive_const(div_a->b) &&
+                   equal(div_a->b, div_b->b) &&
+                   op->type.is_int() &&
+                   no_overflow(op->type) &&
+                   add_b_a &&
+                   equal(div_a->a, add_b_a->a)) {
+            // Same as above, where a == 0
+            Expr x = div_a->a, b = add_b_a->b, c = div_a->b;
+            expr = mutate(((c - 1 - b) - (x % c))/c);
+        } else if (div_a &&
+                   div_b &&
+                   is_positive_const(div_a->b) &&
+                   equal(div_a->b, div_b->b) &&
+                   op->type.is_int() &&
+                   no_overflow(op->type) &&
+                   add_a_a &&
+                   equal(add_a_a->a, div_b->a)) {
+            // Same as above, where b == 0
+            Expr x = add_a_a->a, a = add_a_a->b, c = div_a->b;
+            expr = mutate(((x % c) + a)/c);
+        } else if (div_a &&
+                   div_b &&
+                   is_positive_const(div_a->b) &&
+                   equal(div_a->b, div_b->b) &&
+                   op->type.is_int() &&
+                   no_overflow(op->type) &&
+                   sub_b_a &&
+                   equal(div_a->a, sub_b_a->a)) {
+            // Same as above, where a == 0 and b is subtracted
+            Expr x = div_a->a, b = sub_b_a->b, c = div_a->b;
+            expr = mutate(((c - 1 + b) - (x % c))/c);
+        } else if (div_a &&
+                   div_b &&
+                   is_positive_const(div_a->b) &&
+                   equal(div_a->b, div_b->b) &&
+                   op->type.is_int() &&
+                   no_overflow(op->type) &&
+                   sub_a_a &&
+                   equal(sub_a_a->a, div_b->a)) {
+            // Same as above, where b == 0, and a is subtracted
+            Expr x = sub_a_a->a, a = sub_a_a->b, c = div_a->b;
+            expr = mutate(((x % c) - a)/c);
+        } else if (div_a &&
+                   div_b &&
+                   is_positive_const(div_a->b) &&
+                   equal(div_a->b, div_b->b) &&
+                   op->type.is_int() &&
+                   no_overflow(op->type) &&
+                   sub_a_a &&
+                   add_b_a &&
+                   equal(sub_a_a->a, add_b_a->a) &&
+                   is_simple_const(add_b_a->b)) {
+            // Same as above, where a is subtracted and b is a constant
+            // (x - a)/c - (x + b)/c -> ((x + b)%c - a - b)/c
+            Expr x = sub_a_a->a, a = sub_a_a->b, b = add_b_a->b, c = div_a->b;
+            expr = mutate((((x + (b % c)) % c) - a - b)/c);
+        } else if (div_a &&
+                   div_b &&
+                   is_positive_const(div_a->b) &&
+                   equal(div_a->b, div_b->b) &&
+                   op->type.is_int() &&
+                   no_overflow(op->type) &&
+                   add_a_a &&
+                   sub_b_a &&
+                   equal(add_a_a->a, sub_b_a->a) &&
+                   is_simple_const(add_a_a->b)) {
+            // Same as above, where b is subtracted and a is a constant
+            // (x + a)/c - (x - b)/c -> (b - (x + a)%c + (a + c - 1))/c
+            Expr x = add_a_a->a, a = add_a_a->b, b = sub_b_a->b, c = div_a->b;
+            expr = mutate((b - (x + (a % c))%c + (a + c - 1))/c);
         } else if (a.same_as(op->a) && b.same_as(op->b)) {
             expr = op;
         } else {
@@ -3606,6 +3708,22 @@ void check_algebra() {
 
     check((y + x%3) + (x/3)*3, y + x);
     check((y + (x/3*3)) + x%3, y + x);
+
+    // Almost-cancellations through integer divisions. These rules all
+    // deduplicate x and wrap it in a modulo operator, neutering it
+    // for the purposes of bounds inference. Patterns below look
+    // confusing, but were brute-force tested.
+    check((x + 17)/3 - (x + 7)/3, ((x+1)%3 + 10)/3);
+    check((x + 17)/3 - (x + y)/3, (19 - y - (x+2)%3)/3);
+    check((x + y )/3 - (x + 7)/3, ((x+1)%3 + y + -7)/3);
+    check( x      /3 - (x + y)/3, (2 - y - x % 3)/3);
+    check((x + y )/3 -  x     /3, (x%3 + y)/3);
+    check( x      /3 - (x + 7)/3, (-5 - x%3)/3);
+    check((x + 17)/3 -  x     /3, (x%3 + 17)/3);
+    check((x + 17)/3 - (x - y)/3, (y - (x+2)%3 + 19)/3);
+    check((x - y )/3 - (x + 7)/3, ((x+1)%3 - y + (-7))/3);
+    check( x      /3 - (x - y)/3, (y - x%3 + 2)/3);
+    check((x - y )/3 -  x     /3, (x%3 - y)/3);
 
     // Check some specific expressions involving div and mod
     check(Expr(23) / 4, Expr(5));


### PR DESCRIPTION
This reworks and simplifies how bounds inference is done for shared memory size determination and thread block size determination for Cuda and OpenCL. Instead of building a scope of intervals as you recurse inwards (which causes combinatorial explosion and some hard-to-simplify expressions), this recurses inwards to find the relevant expressions and then expands them using containing for loops as you unwind the stack and back out of the Stmt. The expressions stay simple, and remain constant when they can. The new behavior is exploited in the interpolate app to do block-level fusion of a bunch of the stages.

Also added some new simplifier rules that help out a little with the kinds of patterns you get when you tile a pyramid upsample. Proving these rules on paper is a pain. I've brute-force tested them, but someone please check my math. The way to do it is to first observe that:

For c > 0
((x+y)/c) - x/c = ((x%c + y)/c) 
and
x/c - (x + y)/c = (y - x%c)/c

Division here means integer division rounding down.

You can prove these by expanding x into (c(x/c) + (x%c)) (The Euclidean division identity that we obey). The first term cancels. Might also be true for c < 0 but I haven't verified that, so the rule doesn't trigger.

Then for the more general rules, e.g:

(x + a)/c - (x + b)/c

You can substitute x' = (x+a) or x' = (x+b) (thanks Dillon) and get two potential simplifications using the identities above. Once duplicates a and the other duplicates b, so either one might be better depending on whether a or b is a constant.

These rules are not necessary for the shared memory and block size inference to be correct, but they make the resulting code a little cleaner. The point of these rules is that by mostly cancelling x, you can dodge the problem that you get with interval arithmetic when you have the same variable on both sides of a subtraction.