### PR TITLE
Refactor CodeGen_LLVM to use codegen of Halide IR

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -468,31 +468,11 @@ void CodeGen_ARM::visit(const Mul *op) {
     CodeGen_Posix::visit(op);
 }
 
-Value *CodeGen_ARM::sorted_avg(Value *a, Value *b) {
-    internal_assert(a->getType() == b->getType());
-    llvm::Type *ty = a->getType();
-    if (!neon_intrinsics_disabled() && ty->isVectorTy()) {
-        if (ty->getScalarSizeInBits() == 32) {
-            if (target.bits == 32) {
-                return call_intrin(ty, 2, "llvm.arm.neon.vhaddu.v2i32", {a, b});
-            } else {
-                return call_intrin(ty, 2, "llvm.aarch64.neon.uhadd.v2i32", {a, b});
-            }
-        } else if (ty->getScalarSizeInBits() == 16) {
-            if (target.bits == 32) {
-                return call_intrin(ty, 4, "llvm.arm.neon.vhaddu.v4i16", {a, b});
-            } else {
-                return call_intrin(ty, 4, "llvm.aarch64.neon.uhadd.v4i16", {a, b});
-            }
-        } else if (ty->getScalarSizeInBits() == 8) {
-            if (target.bits == 32) {
-                return call_intrin(ty, 8, "llvm.arm.neon.vhaddu.v8i8", {a, b});
-            } else {
-                return call_intrin(ty, 8, "llvm.aarch64.neon.uhadd.v8i8", {a, b});
-            }
-        }
-    }
-    return CodeGen_Posix::sorted_avg(a, b);
+Expr CodeGen_ARM::sorted_avg(Expr a, Expr b) {
+    Type ty = a.type();
+    Type wide_ty = ty.with_bits(ty.bits() * 2);
+    // This will codegen to vhaddu (arm32) or uhadd (arm64).
+    return cast(ty, (cast(wide_ty, a) + cast(wide_ty, b))/2);
 }
 
 void CodeGen_ARM::visit(const Div *op) {

--- a/src/CodeGen_ARM.h
+++ b/src/CodeGen_ARM.h
@@ -18,7 +18,7 @@ public:
 
 protected:
 
-    llvm::Value *sorted_avg(llvm::Value *a, llvm::Value *b);
+    Expr sorted_avg(Expr a, Expr b);
 
     using CodeGen_Posix::visit;
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1313,17 +1313,20 @@ void CodeGen_LLVM::visit(const Div *op) {
             shift      = IntegerDivision::table_s8[*const_int_divisor][3];
         }
         Expr num = op->a;
+
         // Make an all-ones mask if the numerator is negative
         Expr sign = num >> make_const(op->type, op->type.bits() - 1);
-        // Take the absolute value.
+
+        // Flip the numerator bits if the mask is high.
         num = cast(num.type().with_code(Type::UInt), num);
         num = num ^ sign;
+
         // Multiply and keep the high half of the
         // result, and then apply the shift.
         Expr mult = make_const(num.type(), multiplier);
         num = mulhi_shr(num, mult, shift);
-        // If we negated when computing the absolute value, take the
-        // negative of the result.
+
+        // Maybe flip the bits back again.
         num = num ^ sign;
 
         value = codegen(num);

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -311,9 +311,9 @@ protected:
     // Compute high_half(a*b) >> shr. Note that this is a shift in
     // addition to the implicit shift due to taking the upper half of
     // the multiply result.
-    virtual llvm::Value *unsigned_mulhi_shr(llvm::Value *a, llvm::Value *b, int shr);
+    virtual Expr mulhi_shr(Expr a, Expr b, int shr);
     // Compute (a+b)/2, assuming a < b.
-    virtual llvm::Value *sorted_avg(llvm::Value *a, llvm::Value *b);
+    virtual Expr sorted_avg(Expr a, Expr b);
     // @}
 
 

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -369,19 +369,17 @@ void CodeGen_X86::visit(const Cast *op) {
     CodeGen_Posix::visit(op);
 }
 
-llvm::Value *CodeGen_X86::unsigned_mulhi_shr(llvm::Value *a, llvm::Value *b, int shr) {
-    internal_assert(a->getType() == b->getType());
-    llvm::Type *ty = a->getType();
-
-    if (ty->isVectorTy() && ty->getScalarSizeInBits() == 16) {
-        llvm::Value *p = call_intrin(ty, 8, "llvm.x86.sse2.pmulhu.w", {a, b});
+Expr CodeGen_X86::mulhi_shr(Expr a, Expr b, int shr) {
+    Type ty = a.type();
+    if (ty.is_vector() && ty.bits() == 16) {
+        // We can use pmulhu for this op.
+        Expr p = _u16(_u32(a) * _u32(b) / 65536);
         if (shr) {
-            Constant *shift_amount = ConstantInt::get(ty, shr);
-            p = builder->CreateLShr(p, shift_amount);
+            p = p >> shr;
         }
         return p;
     }
-    return CodeGen_Posix::unsigned_mulhi_shr(a, b, shr);
+    return CodeGen_Posix::mulhi_shr(a, b, shr);
 }
 
 void CodeGen_X86::visit(const Min *op) {

--- a/src/CodeGen_X86.h
+++ b/src/CodeGen_X86.h
@@ -29,7 +29,7 @@ protected:
     bool use_soft_float_abi() const;
     int native_vector_bits() const;
 
-    llvm::Value *unsigned_mulhi_shr(llvm::Value *a, llvm::Value *b, int shr);
+    Expr mulhi_shr(Expr a, Expr b, int shr);
 
     using CodeGen_Posix::visit;
 


### PR DESCRIPTION
This PR causes CodeGen_LLVM to use Halide IR to realize compound expressions where appropriate, which allows it to take advantage of overriden behavior and optimizations in derived codegen class implementations.