### PR TITLE
Add accumulating multiply patterns to Hexagon

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -306,8 +306,7 @@ void CodeGen_Hexagon::init_module() {
         { IPICK(Intrinsic::hexagon_V6_vmpyub_acc),  u16x2, "mpy.acc.vuh.vub.ub", {u16x2, u8x1,  u8} },
         { IPICK(Intrinsic::hexagon_V6_vmpyuh_acc),  u32x2, "mpy.acc.vuw.vuh.uh", {u32x2, u16x1, u16} },
         { IPICK(Intrinsic::hexagon_V6_vmpybus_acc), i16x2, "mpy.acc.vh.vub.b",   {i16x2, u8x1,  i8} },
-
-        { IPICK(Intrinsic::hexagon_V6_vmpyhsat_acc),   i32x2, "mpy.sat.acc.vw.vh.h",    {i32x2, i16x1, i16} },
+        // TODO: There's also vmpyhsat_acc.
 
         // Select/conditionals. Conditions are always signed integer
         // vectors (so widening sign extends).

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -273,23 +273,41 @@ void CodeGen_Hexagon::init_module() {
         { IPICK(Intrinsic::hexagon_V6_vmpyiwh), i32x1, "mpyi.vw.h",    {i32x1, i16} },
         { IPICK(Intrinsic::hexagon_V6_vmpyiwb), i32x1, "mpyi.vw.b",    {i32x1, i8} },
 
+        { IPICK(Intrinsic::hexagon_V6_vmpyih_acc),  i16x1, "mpyi.acc.vh.vh.vh",   {i16x1, i16x1, i16x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyihb_acc), i16x1, "mpyi.acc.vh.vh.b",    {i16x1, i16x1, i8} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyiwh_acc), i32x1, "mpyi.acc.vw.vw.h",    {i32x1, i32x1, i16} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyiwb_acc), i32x1, "mpyi.acc.vw.vw.b",    {i32x1, i32x1, i8} },
+
         // Widening vector multiplication:
-        { IPICK(Intrinsic::hexagon_V6_vmpyubv),  u16x2, "mpy.vub.vub", {u8x1,  u8x1} },
-        { IPICK(Intrinsic::hexagon_V6_vmpyuhv),  u32x2, "mpy.vuh.vuh", {u16x1, u16x1} },
-        { IPICK(Intrinsic::hexagon_V6_vmpybv),   i16x2, "mpy.vb.vb",   {i8x1,  i8x1} },
-        { IPICK(Intrinsic::hexagon_V6_vmpyhv),   i32x2, "mpy.vh.vh",   {i16x1, i16x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyubv), u16x2, "mpy.vub.vub", {u8x1,  u8x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyuhv), u32x2, "mpy.vuh.vuh", {u16x1, u16x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpybv),  i16x2, "mpy.vb.vb",   {i8x1,  i8x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyhv),  i32x2, "mpy.vh.vh",   {i16x1, i16x1} },
+
+        { IPICK(Intrinsic::hexagon_V6_vmpyubv_acc), u16x2, "mpy.acc.vuh.vub.vub", {u16x2, u8x1, u8x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyuhv_acc), u32x2, "mpy.acc.vuw.vuh.vuh", {u32x2, u16x1, u16x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpybv_acc),  i16x2, "mpy.acc.vh.vb.vb",    {i16x2, i8x1, i8x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyhv_acc),  i32x2, "mpy.acc.vw.vh.vh",    {i32x2, i16x1, i16x1} },
 
         // Inconsistencies: both are vector instructions despite the
         // missing 'v', and the signedness is indeed swapped.
         { IPICK(Intrinsic::hexagon_V6_vmpybusv), i16x2, "mpy.vub.vb",  {u8x1,  i8x1} },
         { IPICK(Intrinsic::hexagon_V6_vmpyhus),  i32x2, "mpy.vh.vuh",  {i16x1, u16x1} },
 
-        // Widening scalar multiplication:
-        { IPICK(Intrinsic::hexagon_V6_vmpyub),   u16x2, "mpy.vub.ub",  {u8x1,  u8} },
-        { IPICK(Intrinsic::hexagon_V6_vmpyuh),   u32x2, "mpy.vuh.uh",  {u16x1, u16} },
-        { IPICK(Intrinsic::hexagon_V6_vmpyh),    i32x2, "mpy.vh.h",    {i16x1, i16} },
+        { IPICK(Intrinsic::hexagon_V6_vmpybusv_acc), i16x2, "mpy.acc.vh.vub.vb",  {i16x2, u8x1,  i8x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyhus_acc),  i32x2, "mpy.acc.vw.vh.vuh",  {i32x2, i16x1, u16x1} },
 
-        { IPICK(Intrinsic::hexagon_V6_vmpybus),  i16x2, "mpy.vub.b",   {u8x1,  i8} },
+        // Widening scalar multiplication:
+        { IPICK(Intrinsic::hexagon_V6_vmpyub),  u16x2, "mpy.vub.ub",  {u8x1,  u8} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyuh),  u32x2, "mpy.vuh.uh",  {u16x1, u16} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyh),   i32x2, "mpy.vh.h",    {i16x1, i16} },
+        { IPICK(Intrinsic::hexagon_V6_vmpybus), i16x2, "mpy.vub.b",   {u8x1,  i8} },
+
+        { IPICK(Intrinsic::hexagon_V6_vmpyub_acc),  u16x2, "mpy.acc.vuh.vub.ub", {u16x2, u8x1,  u8} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyuh_acc),  u32x2, "mpy.acc.vuw.vuh.uh", {u32x2, u16x1, u16} },
+        { IPICK(Intrinsic::hexagon_V6_vmpybus_acc), i16x2, "mpy.acc.vh.vub.b",   {i16x2, u8x1,  i8} },
+
+        { IPICK(Intrinsic::hexagon_V6_vmpyhsat_acc),   i32x2, "mpy.sat.acc.vw.vh.h",    {i32x2, i16x1, i16} },
 
         // Select/conditionals. Conditions are always signed integer
         // vectors (so widening sign extends).

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -366,7 +366,7 @@ private:
         // Try commuting the op
         Expr commuted = T::make(op->b, op->a);
         expr = apply_patterns(commuted, patterns, this, target);
-        if (!expr.same_as(op)) return;
+        if (!expr.same_as(commuted)) return;
 
         IRMutator::visit(op);
     }

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1603,6 +1603,10 @@ void check_hvx_all() {
     check("v*.h += vmpy(v*.ub,r*.b)", hvx_width/1, i16_1 + 127 * i16(u8_1));
     check("v*.uw += vmpy(v*.uh,r*.uh)", hvx_width/2, u32_1 + 65535 * u32(u16_1));
 
+    check("v*.h += vmpy(v*.ub,r*.b)", hvx_width/1, i16_1 - i16(u8_1) * -127);
+    check("v*.h += vmpyi(v*.h,r*.b)", hvx_width/2, i16_1 - i16_2 * -127);
+
+
     check("vcl0(v*.uh)", hvx_width/2, count_leading_zeros(u16_1));
     check("vcl0(v*.uw)", hvx_width/4, count_leading_zeros(u32_1));
     check("vpopcount(v*.h)", hvx_width/2, popcount(u16_1));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1574,6 +1574,35 @@ void check_hvx_all() {
     check("vmpyi(v*.w,r*.b)", hvx_width/4, i32_1 * 127);
     check("vmpyi(v*.w,r*.b)", hvx_width/4, 127 * i32_1);
 
+    check("v*.h += vmpyi(v*.h,v*.h)", hvx_width/2, i16_1 + i16_2*i16_3);
+
+    check("v*.h += vmpyi(v*.h,r*.b)", hvx_width/2, i16_1 + i16_2 * 127);
+    check("v*.w += vmpyi(v*.w,r*.h)", hvx_width/4, i32_1 + i32_2 * 32767);
+    check("v*.h += vmpyi(v*.h,r*.b)", hvx_width/2, i16_1 + 127 * i16_2);
+    check("v*.w += vmpyi(v*.w,r*.h)", hvx_width/4, i32_1 + 32767 * i32_2);
+
+    check("v*.uh += vmpy(v*.ub,v*.ub)", hvx_width/1, u16_1 + u16(u8_1) * u16(u8_2));
+    check("v*.uw += vmpy(v*.uh,v*.uh)", hvx_width/2, u32_1 + u32(u16_1) * u32(u16_2));
+    check("v*.h += vmpy(v*.b,v*.b)", hvx_width/1, i16_1 + i16(i8_1) * i16(i8_2));
+    check("v*.w += vmpy(v*.h,v*.h)", hvx_width/2, i32_1 + i32(i16_1) * i32(i16_2));
+
+    check("v*.h += vmpy(v*.ub,v*.b)", hvx_width/1, i16_1 + i16(u8_1) * i16(i8_2));
+    check("v*.w += vmpy(v*.h,v*.uh)", hvx_width/2, i32_1 + i32(i16_1) * i32(u16_2));
+    check("v*.h += vmpy(v*.ub,v*.b)", hvx_width/1, i16_1 + i16(u8_1) * i16(i8_2));
+    check("v*.w += vmpy(v*.h,v*.uh)", hvx_width/2, i32_1 + i32(i16_1) * i32(u16_2));
+
+    check("v*.h += vmpy(v*.ub,v*.b)", hvx_width/1, i16_1 + i16(i8_1) * i16(u8_2));
+    check("v*.w += vmpy(v*.h,v*.uh)", hvx_width/2, i32_1 + i32(u16_1) * i32(i16_2));
+    check("v*.h += vmpy(v*.ub,v*.b)", hvx_width/1, i16_1 + i16(i8_1) * i16(u8_2));
+    check("v*.w += vmpy(v*.h,v*.uh)", hvx_width/2, i32_1 + i32(u16_1) * i32(i16_2));
+
+    check("v*.uh += vmpy(v*.ub,r*.ub)", hvx_width/1, u16_1 + u16(u8_1) * 255);
+    check("v*.h += vmpy(v*.ub,r*.b)", hvx_width/1, i16_1 + i16(u8_1) * 127);
+    check("v*.uw += vmpy(v*.uh,r*.uh)", hvx_width/2, u32_1 + u32(u16_1) * 65535);
+    check("v*.uh += vmpy(v*.ub,r*.ub)", hvx_width/1, u16_1 + 255 * u16(u8_1));
+    check("v*.h += vmpy(v*.ub,r*.b)", hvx_width/1, i16_1 + 127 * i16(u8_1));
+    check("v*.uw += vmpy(v*.uh,r*.uh)", hvx_width/2, u32_1 + 65535 * u32(u16_1));
+
     check("vcl0(v*.uh)", hvx_width/2, count_leading_zeros(u16_1));
     check("vcl0(v*.uw)", hvx_width/4, count_leading_zeros(u32_1));
     check("vpopcount(v*.h)", hvx_width/2, popcount(u16_1));


### PR DESCRIPTION
@pranavb-ca please take a look. Here are a few questions about this:

- When presented with something like `x_i16 + y_i8*2`, should we prefer an accumulating multiply, or a shift and an add?
- It seems like there's basically a random subset of the possible multiply instructions are missing. Am I missing the instructions, or do I have it right?