### PR TITLE
Further refactoring of CodeGen_LLVM's Div visitor.

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -283,7 +283,7 @@ string type_to_c_type(Type type, bool include_space, bool c_plus_plus = true) {
                 } else {
                     break;
                 }
-              
+
             }
         }
     } else {
@@ -483,7 +483,7 @@ void CodeGen_C::compile(const LoweredFunc &f) {
                     }
                 }
             }
-        }           
+        }
     }
 
     have_user_context = false;
@@ -782,18 +782,7 @@ void CodeGen_C::visit(const Div *op) {
         oss << print_expr(op->a) << " >> " << bits;
         print_assignment(op->type, oss.str());
     } else if (op->type.is_int()) {
-        string a = print_expr(op->a);
-        string b = print_expr(op->b);
-        // q = a / b
-        string q = print_assignment(op->type, a + " / " + b);
-        // r = a - q * b
-        string r = print_assignment(op->type, a + " - " + q + " * " + b);
-        // bs = b >> (8*sizeof(T) - 1)
-        string bs = print_assignment(op->type, b + " >> (" + print_type(op->type.element_of()) + ")" + std::to_string(op->type.bits() - 1));
-        // rs = r >> (8*sizeof(T) - 1)
-        string rs = print_assignment(op->type, r + " >> (" + print_type(op->type.element_of()) + ")" + std::to_string(op->type.bits() - 1));
-        // id = q - (rs & bs) + (rs & bs)
-        print_assignment(op->type, q + " - (" + rs + " & " + bs + ") + (" + rs + " & ~" + bs + ")");
+        print_expr(implement_div(op->a, op->b));
     } else {
         visit_binop(op->type, op->a, op->b, "/");
     }
@@ -806,16 +795,7 @@ void CodeGen_C::visit(const Mod *op) {
         oss << print_expr(op->a) << " & " << ((1 << bits)-1);
         print_assignment(op->type, oss.str());
     } else if (op->type.is_int()) {
-        string a = print_expr(op->a);
-        string b = print_expr(op->b);
-        // r = a % b
-        string r = print_assignment(op->type, a + " % " + b);
-        // rs = r >> (8*sizeof(T) - 1)
-        string rs = print_assignment(op->type, r + " >> (" + print_type(op->type.element_of()) + ")" + std::to_string(op->type.bits() - 1));
-        // abs_b = abs(b)
-        string abs_b = print_expr(cast(op->type, abs(op->b)));
-        // id = r + (abs_b & rs)
-        print_assignment(op->type, r + " + (" + abs_b + " & " + rs + ")");
+        print_expr(implement_mod(op->a, op->b));
     } else {
         visit_binop(op->type, op->a, op->b, "%");
     }
@@ -1210,6 +1190,10 @@ void CodeGen_C::visit(const Call *op) {
                << "~" << struct_name << "() {" << call << "}"
                << "} " << instance_name << "(" << arg << ");\n";
         rhs << print_expr(0);
+    } else if (op->is_intrinsic(Call::div_round_to_zero)) {
+        rhs << print_expr(op->args[0]) << " / " << print_expr(op->args[1]);
+    } else if (op->is_intrinsic(Call::mod_round_to_zero)) {
+        rhs << print_expr(op->args[0]) << " % " << print_expr(op->args[1]);
     } else if (op->call_type == Call::Intrinsic ||
                op->call_type == Call::PureIntrinsic) {
         // TODO: other intrinsics

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -782,7 +782,7 @@ void CodeGen_C::visit(const Div *op) {
         oss << print_expr(op->a) << " >> " << bits;
         print_assignment(op->type, oss.str());
     } else if (op->type.is_int()) {
-        print_expr(implement_div(op->a, op->b));
+        print_expr(lower_euclidean_div(op->a, op->b));
     } else {
         visit_binop(op->type, op->a, op->b, "/");
     }
@@ -795,7 +795,7 @@ void CodeGen_C::visit(const Mod *op) {
         oss << print_expr(op->a) << " & " << ((1 << bits)-1);
         print_assignment(op->type, oss.str());
     } else if (op->type.is_int()) {
-        print_expr(implement_mod(op->a, op->b));
+        print_expr(lower_euclidean_mod(op->a, op->b));
     } else {
         visit_binop(op->type, op->a, op->b, "%");
     }

--- a/src/CodeGen_Internal.h
+++ b/src/CodeGen_Internal.h
@@ -48,6 +48,13 @@ bool function_takes_user_context(const std::string &name);
  * non-positive. */
 bool can_allocation_fit_on_stack(int32_t size);
 
+/** Given a Halide Euclidean division/mod operation, define it in terms of
+ * div_round_to_zero or mod_round_to_zero. */
+///@{
+Expr implement_div(Expr a, Expr b);
+Expr implement_mod(Expr a, Expr b);
+///@}
+
 }}
 
 #endif

--- a/src/CodeGen_Internal.h
+++ b/src/CodeGen_Internal.h
@@ -51,8 +51,8 @@ bool can_allocation_fit_on_stack(int32_t size);
 /** Given a Halide Euclidean division/mod operation, define it in terms of
  * div_round_to_zero or mod_round_to_zero. */
 ///@{
-Expr implement_div(Expr a, Expr b);
-Expr implement_mod(Expr a, Expr b);
+Expr lower_euclidean_div(Expr a, Expr b);
+Expr lower_euclidean_mod(Expr a, Expr b);
 ///@}
 
 }}

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1302,19 +1302,6 @@ Expr CodeGen_LLVM::sorted_avg(Expr a, Expr b) {
     return a + (b - a)/2;
 }
 
-// Although these look like intrinsics, they are designed to be
-// produced and consumed entirely within CodeGen_LLVM. They represent
-// "native" division and mod operations, which round toward zero.
-Expr div_round_to_zero(Expr a, Expr b) {
-    internal_assert(a.type() == b.type());
-    return Call::make(a.type(), "div_round_to_zero", {a, b}, Call::PureIntrinsic);
-}
-
-Expr mod_round_to_zero(Expr a, Expr b) {
-    internal_assert(a.type() == b.type());
-    return Call::make(a.type(), "mod_round_to_zero", {a, b}, Call::PureIntrinsic);
-}
-
 void CodeGen_LLVM::visit(const Div *op) {
     user_assert(!is_zero(op->b)) << "Division by constant zero in expression: " << Expr(op) << "\n";
 
@@ -1404,33 +1391,8 @@ void CodeGen_LLVM::visit(const Div *op) {
         }
 
         value = codegen(val);
-    } else if (op->type.is_uint()) {
-        value = codegen(div_round_to_zero(op->a, op->b));
     } else {
-        // Signed integer division sucks. It should be defined such
-        // that it satisifies (a/b)*b + a%b = a, where 0 <= a%b < |b|,
-        // i.e. Euclidean division.
-
-        // We get rounding to work by examining the implied remainder
-        // and correcting the quotient.
-
-        /* Here's the C code that we're trying to match:
-        int q = a / b;
-        int r = a - q * b;
-        int bs = b >> (t.bits() - 1);
-        int rs = r >> (t.bits() - 1);
-        return q - (rs & bs) + (rs & ~bs);
-        */
-
-        Expr a = op->a;
-        Expr b = op->b;
-        Expr q = div_round_to_zero(a, b);
-        Expr r = a - q*b;
-        Expr bs = b >> (a.type().bits() - 1);
-        Expr rs = r >> (a.type().bits() - 1);
-        q = q - (rs & bs) + (rs & ~bs);
-        q = common_subexpression_elimination(q);
-        value = codegen(q);
+        value = codegen(implement_div(op->a, op->b));
     }
 }
 
@@ -1443,21 +1405,8 @@ void CodeGen_LLVM::visit(const Mod *op) {
         value = codegen(simplify(op->a - op->b * floor(op->a/op->b)));
     } else if (is_const_power_of_two_integer(op->b, &bits)) {
         value = codegen(op->a & (op->b - 1));
-    } else if (op->type.is_uint()) {
-        value = codegen(mod_round_to_zero(op->a, op->b));
     } else {
-        // Match this non-overflowing C code
-        /*
-          T r = a % b;
-          r = r + (r < 0 ? abs(b) : 0);
-        */
-
-        Expr a = op->a;
-        Expr b = op->b;
-        Expr r = mod_round_to_zero(a, b);
-        r = select(r < 0, r + abs(b), r);
-        r = common_subexpression_elimination(r);
-        value = codegen(r);
+        value = codegen(implement_mod(op->a, op->b));
     }
 }
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1392,21 +1392,20 @@ void CodeGen_LLVM::visit(const Div *op) {
 
         value = codegen(val);
     } else {
-        value = codegen(implement_div(op->a, op->b));
+        value = codegen(lower_euclidean_div(op->a, op->b));
     }
 }
 
 void CodeGen_LLVM::visit(const Mod *op) {
-    // To match our definition of division, mod should be between 0
-    // and |b|.
-
     int bits;
     if (op->type.is_float()) {
         value = codegen(simplify(op->a - op->b * floor(op->a/op->b)));
     } else if (is_const_power_of_two_integer(op->b, &bits)) {
         value = codegen(op->a & (op->b - 1));
     } else {
-        value = codegen(implement_mod(op->a, op->b));
+        // To match our definition of division, mod should be between 0
+        // and |b|.
+        value = codegen(lower_euclidean_mod(op->a, op->b));
     }
 }
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1301,6 +1301,19 @@ Expr CodeGen_LLVM::sorted_avg(Expr a, Expr b) {
     return a + (b - a)/2;
 }
 
+// Although these look like intrinsics, they are designed to be
+// produced and consumed entirely within CodeGen_LLVM. They represent
+// "native" division and mod operations, which round toward zero.
+Expr div_round_to_zero(Expr a, Expr b) {
+    internal_assert(a.type() == b.type());
+    return Call::make(a.type(), "div_round_to_zero", {a, b}, Call::PureIntrinsic);
+}
+
+Expr mod_round_to_zero(Expr a, Expr b) {
+    internal_assert(a.type() == b.type());
+    return Call::make(a.type(), "mod_round_to_zero", {a, b}, Call::PureIntrinsic);
+}
+
 void CodeGen_LLVM::visit(const Div *op) {
     user_assert(!is_zero(op->b)) << "Division by constant zero in expression: " << Expr(op) << "\n";
 
@@ -1309,18 +1322,11 @@ void CodeGen_LLVM::visit(const Div *op) {
     const uint64_t *const_uint_divisor = as_const_uint(op->b);
 
     int shift_amount;
-    bool power_of_two = is_const_power_of_two_integer(op->b, &shift_amount);
-
     if (op->type.is_float()) {
         value = builder->CreateFDiv(codegen(op->a), codegen(op->b));
-    } else if (power_of_two && op->type.is_int()) {
-        Value *numerator = codegen(op->a);
-        Constant *shift = ConstantInt::get(llvm_type_of(op->type), shift_amount);
-        value = builder->CreateAShr(numerator, shift);
-    } else if (power_of_two && op->type.is_uint()) {
-        Value *numerator = codegen(op->a);
-        Constant *shift = ConstantInt::get(llvm_type_of(op->type), shift_amount);
-        value = builder->CreateLShr(numerator, shift);
+    } else if (is_const_power_of_two_integer(op->b, &shift_amount) &&
+               (op->type.is_int() || op->type.is_uint())) {
+        value = codegen(op->a >> shift_amount);
     } else if (const_int_divisor &&
                op->type.is_int() &&
                (op->type.bits() == 8 || op->type.bits() == 16 || op->type.bits() == 32) &&
@@ -1398,22 +1404,11 @@ void CodeGen_LLVM::visit(const Div *op) {
 
         value = codegen(val);
     } else if (op->type.is_uint()) {
-        value = builder->CreateUDiv(codegen(op->a), codegen(op->b));
+        value = codegen(div_round_to_zero(op->a, op->b));
     } else {
         // Signed integer division sucks. It should be defined such
         // that it satisifies (a/b)*b + a%b = a, where 0 <= a%b < |b|,
         // i.e. Euclidean division.
-
-        // If it's a small const power of two, then we can just
-        // arithmetic right shift. This rounds towards negative
-        // infinity.
-        for (int bits = 1; bits < 30; bits++) {
-            if (is_const(op->b, 1 << bits)) {
-                Value *shift = codegen(make_const(op->a.type(), bits));
-                value = builder->CreateAShr(codegen(op->a), shift);
-                return;
-            }
-        }
 
         // We get rounding to work by examining the implied remainder
         // and correcting the quotient.
@@ -1426,16 +1421,25 @@ void CodeGen_LLVM::visit(const Div *op) {
         return q - (rs & bs) + (rs & ~bs);
         */
 
-        Value *a = codegen(op->a), *b = codegen(op->b);
+        string a_name = unique_name('a');
+        string b_name = unique_name('b');
+        string q_name = unique_name('q');
+        string bs_name = unique_name("bs");
+        string rs_name = unique_name("rs");
+        Expr a = Variable::make(op->a.type(), a_name);
+        Expr b = Variable::make(op->b.type(), b_name);
+        Expr q = Variable::make(op->a.type(), q_name);
+        Expr r = a - q*b;
+        Expr bs = Variable::make(op->b.type(), bs_name);
+        Expr rs = Variable::make(r.type(), rs_name);
+        q = q - (rs & bs) + (rs & ~bs);
+        q = Let::make(rs_name, r >> (op->a.type().bits() - 1), q);
+        q = Let::make(bs_name, b >> (op->a.type().bits() - 1), q);
+        q = Let::make(q_name, div_round_to_zero(a, b), q);
+        q = Let::make(b_name, op->b, q);
+        q = Let::make(a_name, op->a, q);
 
-        Value *q = builder->CreateSDiv(a, b);
-        Value *r = builder->CreateSub(a, builder->CreateMul(q, b));
-        Value *shift = ConstantInt::get(a->getType(), op->a.type().bits()-1);
-        Value *bs = builder->CreateAShr(b, shift);
-        Value *rs = builder->CreateAShr(r, shift);
-        Value *round_up = builder->CreateAnd(rs, bs);
-        Value *round_down = builder->CreateAnd(rs, builder->CreateNot(bs));
-        value = builder->CreateAdd(builder->CreateSub(q, round_up), round_down);
+        value = codegen(q);
     }
 }
 
@@ -1443,38 +1447,29 @@ void CodeGen_LLVM::visit(const Mod *op) {
     // To match our definition of division, mod should be between 0
     // and |b|.
 
+    int bits;
     if (op->type.is_float()) {
         value = codegen(simplify(op->a - op->b * floor(op->a/op->b)));
+    } else if (is_const_power_of_two_integer(op->b, &bits)) {
+        value = codegen(op->a & (op->b - 1));
     } else if (op->type.is_uint()) {
-        int bits;
-        if (is_const_power_of_two_integer(op->b, &bits)) {
-            Expr one = make_one(op->b.type());
-            value = builder->CreateAnd(codegen(op->a), codegen(op->b - one));
-        } else {
-            value = builder->CreateURem(codegen(op->a), codegen(op->b));
-        }
+        value = codegen(mod_round_to_zero(op->a, op->b));
     } else {
-        int bits;
-        if (is_const_power_of_two_integer(op->b, &bits)) {
-            Expr one = make_one(op->b.type());
-            value = builder->CreateAnd(codegen(op->a), codegen(op->b - one));
-        } else {
-            Value *a = codegen(op->a);
-            Value *b = codegen(op->b);
+        // Match this non-overflowing C code
+        /*
+          T r = a % b;
+          r = r + (r < 0 ? abs(b) : 0);
+        */
 
-            // Match this non-overflowing C code
-            /*
-              T r = a % b;
-              r = r + (r < 0 ? abs(b) : 0);
-            */
-
-            Value *r = builder->CreateSRem(a, b);
-            Value *zero = ConstantInt::get(r->getType(), 0);
-            Value *b_lt_0 = builder->CreateICmpSLT(b, zero);
-            Value *abs_b = builder->CreateSelect(b_lt_0, builder->CreateNeg(b), b);
-            Value *r_lt_0 = builder->CreateICmpSLT(r, zero);
-            value = builder->CreateSelect(r_lt_0, builder->CreateAdd(r, abs_b), r);
-        }
+        string b_name = unique_name('b');
+        string r_name = unique_name('r');
+        Expr a = op->a;
+        Expr b = Variable::make(op->b.type(), b_name);
+        Expr r = Variable::make(op->type, r_name);
+        r = select(r < 0, r + abs(b), r);
+        r = Let::make(r_name, mod_round_to_zero(a, b), r);
+        r = Let::make(b_name, op->b, r);
+        value = codegen(r);
     }
 }
 
@@ -2316,6 +2311,28 @@ void CodeGen_LLVM::visit(const Call *op) {
             codegen(Let::make(a_name, op->args[0],
                               Let::make(b_name, op->args[1],
                                         Select::make(a_var < b_var, b_var - a_var, a_var - b_var))));
+        }
+    } else if (op->is_intrinsic("div_round_to_zero")) {
+        internal_assert(op->args.size() == 2);
+        Value *a = codegen(op->args[0]);
+        Value *b = codegen(op->args[1]);
+        if (op->type.is_int()) {
+            value = builder->CreateSDiv(a, b);
+        } else if (op->type.is_uint()) {
+            value = builder->CreateUDiv(a, b);
+        } else {
+            internal_error << "div_round_to_zero of non-integer type.\n";
+        }
+    } else if (op->is_intrinsic("mod_round_to_zero")) {
+        internal_assert(op->args.size() == 2);
+        Value *a = codegen(op->args[0]);
+        Value *b = codegen(op->args[1]);
+        if (op->type.is_int()) {
+            value = builder->CreateSRem(a, b);
+        } else if (op->type.is_uint()) {
+            value = builder->CreateURem(a, b);
+        } else {
+            internal_error << "mod_round_to_zero of non-integer type.\n";
         }
     } else if (op->is_intrinsic(Call::copy_buffer_t)) {
         // Make some memory for this buffer_t

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -682,6 +682,8 @@ Call::ConstString Call::likely = "likely";
 Call::ConstString Call::make_int64 = "make_int64";
 Call::ConstString Call::make_float64 = "make_float64";
 Call::ConstString Call::register_destructor = "register_destructor";
+Call::ConstString Call::div_round_to_zero = "div_round_to_zero";
+Call::ConstString Call::mod_round_to_zero = "mod_round_to_zero";
 
 
 }

--- a/src/IR.h
+++ b/src/IR.h
@@ -425,7 +425,9 @@ struct Call : public ExprNode<Call> {
         likely,
         make_int64,
         make_float64,
-        register_destructor;
+        register_destructor,
+        div_round_to_zero,
+        mod_round_to_zero;
 
     // If it's a call to another halide function, this call node
     // holds onto a pointer to that function.

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1636,6 +1636,37 @@ inline Expr count_trailing_zeros(Expr x) {
                                 {x}, Internal::Call::PureIntrinsic);
 }
 
+/** Divide two integers, rounding towards zero. This is the typical
+ * behavior of most hardware architectures, which differs from
+ * Halide's division operator, which is Euclidean (rounds towards
+ * -infinity). */
+inline Expr div_round_to_zero(Expr x, Expr y) {
+    user_assert(x.type().is_int() || x.type().is_uint())
+        << "div_round_to_zero only takes integer arguments\n";
+    user_assert(y.type().is_int() || y.type().is_uint())
+        << "div_round_to_zero only takes integer arguments\n";
+    Internal::match_types(x, y);
+    return Internal::Call::make(x.type(), Internal::Call::div_round_to_zero,
+                                {x, y},
+                                Internal::Call::PureIntrinsic);
+}
+
+/** Compute the remainder of dividing two integers, when division is
+ * rounding toward zero. This is the typical behavior of most hardware
+ * architectures, which differs from Halide's mod operator, which is
+ * Euclidean (produces the remainder when division rounds towards
+ * -infinity). */
+inline Expr mod_round_to_zero(Expr x, Expr y) {
+    user_assert(x.type().is_int() || x.type().is_uint())
+        << "mod_round_to_zero only takes integer arguments\n";
+    user_assert(y.type().is_int() || y.type().is_uint())
+        << "mod_round_to_zero only takes integer arguments\n";
+    Internal::match_types(x, y);
+    return Internal::Call::make(x.type(), Internal::Call::mod_round_to_zero,
+                                {x, y},
+                                Internal::Call::PureIntrinsic);
+}
+
 /** Return a random variable representing a uniformly distributed
  * float in the half-open interval [0.0f, 1.0f). For random numbers of
  * other types, use lerp with a random float as the last parameter.

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1641,12 +1641,14 @@ inline Expr count_trailing_zeros(Expr x) {
  * Halide's division operator, which is Euclidean (rounds towards
  * -infinity). */
 inline Expr div_round_to_zero(Expr x, Expr y) {
+    user_assert(x.defined()) << "div_round_to_zero of undefined dividend\n";
+    user_assert(y.defined()) << "div_round_to_zero of undefined divisor\n";
     Internal::match_types(x, y);
     if (x.type().is_uint()) {
         return x / y;
     }
-    user_assert(x.type().is_int()) << "div_round_to_zero only takes integer arguments\n";
-    user_assert(y.type().is_int()) << "div_round_to_zero only takes integer arguments\n";
+    user_assert(x.type().is_int()) << "First argument to div_round_to_zero is not an integer: " << x << "\n";
+    user_assert(y.type().is_int()) << "Second argument to div_round_to_zero is not an integer: " << y << "\n";
     return Internal::Call::make(x.type(), Internal::Call::div_round_to_zero,
                                 {x, y},
                                 Internal::Call::PureIntrinsic);
@@ -1658,12 +1660,14 @@ inline Expr div_round_to_zero(Expr x, Expr y) {
  * Euclidean (produces the remainder when division rounds towards
  * -infinity). */
 inline Expr mod_round_to_zero(Expr x, Expr y) {
+    user_assert(x.defined()) << "mod_round_to_zero of undefined dividend\n";
+    user_assert(y.defined()) << "mod_round_to_zero of undefined divisor\n";
     Internal::match_types(x, y);
     if (x.type().is_uint()) {
         return x % y;
     }
-    user_assert(x.type().is_int()) << "mod_round_to_zero only takes integer arguments\n";
-    user_assert(y.type().is_int()) << "mod_round_to_zero only takes integer arguments\n";
+    user_assert(x.type().is_int()) << "First argument to mod_round_to_zero is not an integer: " << x << "\n";
+    user_assert(y.type().is_int()) << "Second argument to mod_round_to_zero is not an integer: " << y << "\n";
     return Internal::Call::make(x.type(), Internal::Call::mod_round_to_zero,
                                 {x, y},
                                 Internal::Call::PureIntrinsic);

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1641,11 +1641,12 @@ inline Expr count_trailing_zeros(Expr x) {
  * Halide's division operator, which is Euclidean (rounds towards
  * -infinity). */
 inline Expr div_round_to_zero(Expr x, Expr y) {
-    user_assert(x.type().is_int() || x.type().is_uint())
-        << "div_round_to_zero only takes integer arguments\n";
-    user_assert(y.type().is_int() || y.type().is_uint())
-        << "div_round_to_zero only takes integer arguments\n";
     Internal::match_types(x, y);
+    if (x.type().is_uint()) {
+        return x / y;
+    }
+    user_assert(x.type().is_int()) << "div_round_to_zero only takes integer arguments\n";
+    user_assert(y.type().is_int()) << "div_round_to_zero only takes integer arguments\n";
     return Internal::Call::make(x.type(), Internal::Call::div_round_to_zero,
                                 {x, y},
                                 Internal::Call::PureIntrinsic);
@@ -1657,11 +1658,12 @@ inline Expr div_round_to_zero(Expr x, Expr y) {
  * Euclidean (produces the remainder when division rounds towards
  * -infinity). */
 inline Expr mod_round_to_zero(Expr x, Expr y) {
-    user_assert(x.type().is_int() || x.type().is_uint())
-        << "mod_round_to_zero only takes integer arguments\n";
-    user_assert(y.type().is_int() || y.type().is_uint())
-        << "mod_round_to_zero only takes integer arguments\n";
     Internal::match_types(x, y);
+    if (x.type().is_uint()) {
+        return x % y;
+    }
+    user_assert(x.type().is_int()) << "mod_round_to_zero only takes integer arguments\n";
+    user_assert(y.type().is_int()) << "mod_round_to_zero only takes integer arguments\n";
     return Internal::Call::make(x.type(), Internal::Call::mod_round_to_zero,
                                 {x, y},
                                 Internal::Call::PureIntrinsic);


### PR DESCRIPTION
This PR uses Halide IR to define our euclidean division instructions, which makes them take advantage of CodeGen specializations (e.g. overridden handlers for shifts and bitwise ops).