### PR TITLE
[Hexagon] Rename intrinsic wrappers

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -188,24 +188,25 @@ void CodeGen_Hexagon::init_module() {
         // Truncation:
         // (Yes, there really are two fs in the b versions, and 1 f in
         // the h versions.)
-        { IPICK(Intrinsic::hexagon_V6_vshuffeb), i8x1,  "trunchi.vh",  {i16x2} },
-        { IPICK(Intrinsic::hexagon_V6_vshufeh),  i16x1, "trunchi.vw",  {i32x2} },
+        { IPICK(Intrinsic::hexagon_V6_vshuffeb), i8x1,  "trunc.vh",  {i16x2} },
+        { IPICK(Intrinsic::hexagon_V6_vshufeh),  i16x1, "trunc.vw",  {i32x2} },
         { IPICK(Intrinsic::hexagon_V6_vshuffob), i8x1,  "trunclo.vh",  {i16x2} },
         { IPICK(Intrinsic::hexagon_V6_vshufoh),  i16x1, "trunclo.vw",  {i32x2} },
 
         // Downcast with saturation:
-        { IPICK(Intrinsic::hexagon_V6_vsathub),  u8x1,  "satub.vh",  {i16x2} },
-        { IPICK(Intrinsic::hexagon_V6_vsatwh),   i16x1, "sath.vw",   {i32x2} },
+        { IPICK(Intrinsic::hexagon_V6_vsathub),  u8x1,  "trunc_satub.vh",  {i16x2} },
+        { IPICK(Intrinsic::hexagon_V6_vsatwh),   i16x1, "trunc_sath.vw",   {i32x2} },
 
-        { IPICK(Intrinsic::hexagon_V6_vpackhub_sat), u8x1,  "trunchi.satub.vh", {i16x2} },
-        { IPICK(Intrinsic::hexagon_V6_vpackwuh_sat), u16x1, "trunchi.satuh.vw", {i32x2} },
-        { IPICK(Intrinsic::hexagon_V6_vpackhb_sat),  i8x1,  "trunchi.satb.vh",  {i16x2} },
-        { IPICK(Intrinsic::hexagon_V6_vpackwh_sat),  i16x1, "trunchi.sath.vw",  {i32x2} },
+        { IPICK(Intrinsic::hexagon_V6_vroundhub), u8x1,  "trunc_satub_rnd.vh", {i16x2} },
+        { IPICK(Intrinsic::hexagon_V6_vroundhb),  i8x1,  "trunc_satb_rnd.vh",  {i16x2} },
+        { IPICK(Intrinsic::hexagon_V6_vroundwuh), u16x1, "trunc_satuh_rnd.vw", {i32x2} },
+        { IPICK(Intrinsic::hexagon_V6_vroundwh),  i16x1, "trunc_sath_rnd.vw",  {i32x2} },
 
-        { IPICK(Intrinsic::hexagon_V6_vroundhub), u8x1,  "roundu.vh", {i16x2} },
-        { IPICK(Intrinsic::hexagon_V6_vroundhb),  i8x1,  "round.vh",  {i16x2} },
-        { IPICK(Intrinsic::hexagon_V6_vroundwuh), u16x1, "roundu.vw", {i32x2} },
-        { IPICK(Intrinsic::hexagon_V6_vroundwh),  i16x1, "round.vw",  {i32x2} },
+        // vpack does not interleave its input.
+        { IPICK(Intrinsic::hexagon_V6_vpackhub_sat), u8x1,  "pack_satub.vh", {i16x2} },
+        { IPICK(Intrinsic::hexagon_V6_vpackwuh_sat), u16x1, "pack_satuh.vw", {i32x2} },
+        { IPICK(Intrinsic::hexagon_V6_vpackhb_sat),  i8x1,  "pack_satb.vh",  {i16x2} },
+        { IPICK(Intrinsic::hexagon_V6_vpackwh_sat),  i16x1, "pack_sath.vw",  {i32x2} },
 
         // Adds/subtracts:
         // Note that we just use signed arithmetic for unsigned
@@ -226,23 +227,23 @@ void CodeGen_Hexagon::init_module() {
 
 
         // Adds/subtract of unsigned values with saturation.
-        { IPICK(Intrinsic::hexagon_V6_vaddubsat),    u8x1,  "addsat.vub.vub",    {u8x1,  u8x1} },
-        { IPICK(Intrinsic::hexagon_V6_vadduhsat),    u16x1, "addsat.vuh.vuh",    {u16x1, u16x1} },
-        { IPICK(Intrinsic::hexagon_V6_vaddhsat),     i16x1, "addsat.vh.vh",      {i16x1, i16x1} },
-        { IPICK(Intrinsic::hexagon_V6_vaddwsat),     i32x1, "addsat.vw.vw",      {i32x1, i32x1} },
-        { IPICK(Intrinsic::hexagon_V6_vaddubsat_dv), u8x2,  "addsat.vub.vub.dv", {u8x2,  u8x2} },
-        { IPICK(Intrinsic::hexagon_V6_vadduhsat_dv), u16x2, "addsat.vuh.vuh.dv", {u16x2, u16x2} },
-        { IPICK(Intrinsic::hexagon_V6_vaddhsat_dv),  i16x2, "addsat.vh.vh.dv",   {i16x2, i16x2} },
-        { IPICK(Intrinsic::hexagon_V6_vaddwsat_dv),  i32x2, "addsat.vw.vw.dv",   {i32x2, i32x2} },
+        { IPICK(Intrinsic::hexagon_V6_vaddubsat),    u8x1,  "satub_add.vub.vub",    {u8x1,  u8x1} },
+        { IPICK(Intrinsic::hexagon_V6_vadduhsat),    u16x1, "satuh_add.vuh.vuh",    {u16x1, u16x1} },
+        { IPICK(Intrinsic::hexagon_V6_vaddhsat),     i16x1, "sath_add.vh.vh",       {i16x1, i16x1} },
+        { IPICK(Intrinsic::hexagon_V6_vaddwsat),     i32x1, "satw_add.vw.vw",       {i32x1, i32x1} },
+        { IPICK(Intrinsic::hexagon_V6_vaddubsat_dv), u8x2,  "satub_add.vub.vub.dv", {u8x2,  u8x2} },
+        { IPICK(Intrinsic::hexagon_V6_vadduhsat_dv), u16x2, "satuh_add.vuh.vuh.dv", {u16x2, u16x2} },
+        { IPICK(Intrinsic::hexagon_V6_vaddhsat_dv),  i16x2, "sath_add.vh.vh.dv",    {i16x2, i16x2} },
+        { IPICK(Intrinsic::hexagon_V6_vaddwsat_dv),  i32x2, "satw_add.vw.vw.dv",    {i32x2, i32x2} },
 
-        { IPICK(Intrinsic::hexagon_V6_vsububsat),    u8x1,  "subsat.vub.vub",    {u8x1,  u8x1} },
-        { IPICK(Intrinsic::hexagon_V6_vsubuhsat),    u16x1, "subsat.vuh.vuh",    {u16x1, u16x1} },
-        { IPICK(Intrinsic::hexagon_V6_vsubhsat),     i16x1, "subsat.vh.vh",      {i16x1, i16x1} },
-        { IPICK(Intrinsic::hexagon_V6_vsubwsat),     i32x1, "subsat.vw.vw",      {i32x1, i32x1} },
-        { IPICK(Intrinsic::hexagon_V6_vsububsat_dv), u8x2,  "subsat.vub.vub.dv", {u8x2,  u8x2} },
-        { IPICK(Intrinsic::hexagon_V6_vsubuhsat_dv), u16x2, "subsat.vuh.vuh.dv", {u16x2, u16x2} },
-        { IPICK(Intrinsic::hexagon_V6_vsubhsat_dv),  i16x2, "subsat.vh.vh.dv",   {i16x2, i16x2} },
-        { IPICK(Intrinsic::hexagon_V6_vsubwsat_dv),  i32x2, "subsat.vw.vw.dv",   {i32x2, i32x2} },
+        { IPICK(Intrinsic::hexagon_V6_vsububsat),    u8x1,  "satub_sub.vub.vub",    {u8x1,  u8x1} },
+        { IPICK(Intrinsic::hexagon_V6_vsubuhsat),    u16x1, "satuh_sub.vuh.vuh",    {u16x1, u16x1} },
+        { IPICK(Intrinsic::hexagon_V6_vsubhsat),     i16x1, "sath_sub.vh.vh",       {i16x1, i16x1} },
+        { IPICK(Intrinsic::hexagon_V6_vsubwsat),     i32x1, "satw_sub.vw.vw",       {i32x1, i32x1} },
+        { IPICK(Intrinsic::hexagon_V6_vsububsat_dv), u8x2,  "satub_sub.vub.vub.dv", {u8x2,  u8x2} },
+        { IPICK(Intrinsic::hexagon_V6_vsubuhsat_dv), u16x2, "satuh_sub.vuh.vuh.dv", {u16x2, u16x2} },
+        { IPICK(Intrinsic::hexagon_V6_vsubhsat_dv),  i16x2, "sath_sub.vh.vh.dv",    {i16x2, i16x2} },
+        { IPICK(Intrinsic::hexagon_V6_vsubwsat_dv),  i32x2, "satw_sub.vw.vw.dv",    {i32x2, i32x2} },
 
         // Absolute value:
         { IPICK(Intrinsic::hexagon_V6_vabsh),   u16x1, "abs.vh", {i16x1} },
@@ -260,25 +261,25 @@ void CodeGen_Hexagon::init_module() {
         { IPICK(Intrinsic::hexagon_V6_vavgh),  i16x1, "avg.vh.vh",   {i16x1, i16x1} },
         { IPICK(Intrinsic::hexagon_V6_vavgw),  i32x1, "avg.vw.vw",   {i32x1, i32x1} },
 
-        { IPICK(Intrinsic::hexagon_V6_vavgubrnd), u8x1,  "avgrnd.vub.vub", {u8x1,  u8x1} },
-        { IPICK(Intrinsic::hexagon_V6_vavguhrnd), u16x1, "avgrnd.vuh.vuh", {u16x1, u16x1} },
-        { IPICK(Intrinsic::hexagon_V6_vavghrnd),  i16x1, "avgrnd.vh.vh",   {i16x1, i16x1} },
-        { IPICK(Intrinsic::hexagon_V6_vavgwrnd),  i32x1, "avgrnd.vw.vw",   {i32x1, i32x1} },
+        { IPICK(Intrinsic::hexagon_V6_vavgubrnd), u8x1,  "avg_rnd.vub.vub", {u8x1,  u8x1} },
+        { IPICK(Intrinsic::hexagon_V6_vavguhrnd), u16x1, "avg_rnd.vuh.vuh", {u16x1, u16x1} },
+        { IPICK(Intrinsic::hexagon_V6_vavghrnd),  i16x1, "avg_rnd.vh.vh",   {i16x1, i16x1} },
+        { IPICK(Intrinsic::hexagon_V6_vavgwrnd),  i32x1, "avg_rnd.vw.vw",   {i32x1, i32x1} },
 
         { IPICK(Intrinsic::hexagon_V6_vnavgub), i8x1,  "navg.vub.vub", {u8x1,  u8x1} },
         { IPICK(Intrinsic::hexagon_V6_vnavgh),  i16x1, "navg.vh.vh",   {i16x1, i16x1} },
         { IPICK(Intrinsic::hexagon_V6_vnavgw),  i32x1, "navg.vw.vw",   {i32x1, i32x1} },
 
         // Non-widening multiplication:
-        { IPICK(Intrinsic::hexagon_V6_vmpyih),  i16x1, "mpyi.vh.vh",   {i16x1, i16x1} },
-        { IPICK(Intrinsic::hexagon_V6_vmpyihb), i16x1, "mpyi.vh.b",    {i16x1, i8}, HvxIntrinsic::BroadcastScalarsToWords },
-        { IPICK(Intrinsic::hexagon_V6_vmpyiwh), i32x1, "mpyi.vw.h",    {i32x1, i16}, HvxIntrinsic::BroadcastScalarsToWords },
-        { IPICK(Intrinsic::hexagon_V6_vmpyiwb), i32x1, "mpyi.vw.b",    {i32x1, i8}, HvxIntrinsic::BroadcastScalarsToWords },
+        { IPICK(Intrinsic::hexagon_V6_vmpyih),  i16x1, "mul.vh.vh",   {i16x1, i16x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyihb), i16x1, "mul.vh.b",    {i16x1, i8}, HvxIntrinsic::BroadcastScalarsToWords },
+        { IPICK(Intrinsic::hexagon_V6_vmpyiwh), i32x1, "mul.vw.h",    {i32x1, i16}, HvxIntrinsic::BroadcastScalarsToWords },
+        { IPICK(Intrinsic::hexagon_V6_vmpyiwb), i32x1, "mul.vw.b",    {i32x1, i8}, HvxIntrinsic::BroadcastScalarsToWords },
 
-        { IPICK(Intrinsic::hexagon_V6_vmpyih_acc),  i16x1, "mpyi.acc.vh.vh.vh",   {i16x1, i16x1, i16x1} },
-        { IPICK(Intrinsic::hexagon_V6_vmpyihb_acc), i16x1, "mpyi.acc.vh.vh.b",    {i16x1, i16x1, i8}, HvxIntrinsic::BroadcastScalarsToWords },
-        { IPICK(Intrinsic::hexagon_V6_vmpyiwh_acc), i32x1, "mpyi.acc.vw.vw.h",    {i32x1, i32x1, i16}, HvxIntrinsic::BroadcastScalarsToWords },
-        { IPICK(Intrinsic::hexagon_V6_vmpyiwb_acc), i32x1, "mpyi.acc.vw.vw.b",    {i32x1, i32x1, i8}, HvxIntrinsic::BroadcastScalarsToWords },
+        { IPICK(Intrinsic::hexagon_V6_vmpyih_acc),  i16x1, "add_mul.vh.vh.vh",   {i16x1, i16x1, i16x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyihb_acc), i16x1, "add_mul.vh.vh.b",    {i16x1, i16x1, i8}, HvxIntrinsic::BroadcastScalarsToWords },
+        { IPICK(Intrinsic::hexagon_V6_vmpyiwh_acc), i32x1, "add_mul.vw.vw.h",    {i32x1, i32x1, i16}, HvxIntrinsic::BroadcastScalarsToWords },
+        { IPICK(Intrinsic::hexagon_V6_vmpyiwb_acc), i32x1, "add_mul.vw.vw.b",    {i32x1, i32x1, i8}, HvxIntrinsic::BroadcastScalarsToWords },
 
         // Widening vector multiplication:
         { IPICK(Intrinsic::hexagon_V6_vmpyubv), u16x2, "mpy.vub.vub", {u8x1,  u8x1} },
@@ -286,18 +287,18 @@ void CodeGen_Hexagon::init_module() {
         { IPICK(Intrinsic::hexagon_V6_vmpybv),  i16x2, "mpy.vb.vb",   {i8x1,  i8x1} },
         { IPICK(Intrinsic::hexagon_V6_vmpyhv),  i32x2, "mpy.vh.vh",   {i16x1, i16x1} },
 
-        { IPICK(Intrinsic::hexagon_V6_vmpyubv_acc), u16x2, "mpy.acc.vuh.vub.vub", {u16x2, u8x1, u8x1} },
-        { IPICK(Intrinsic::hexagon_V6_vmpyuhv_acc), u32x2, "mpy.acc.vuw.vuh.vuh", {u32x2, u16x1, u16x1} },
-        { IPICK(Intrinsic::hexagon_V6_vmpybv_acc),  i16x2, "mpy.acc.vh.vb.vb",    {i16x2, i8x1, i8x1} },
-        { IPICK(Intrinsic::hexagon_V6_vmpyhv_acc),  i32x2, "mpy.acc.vw.vh.vh",    {i32x2, i16x1, i16x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyubv_acc), u16x2, "add_mpy.vuh.vub.vub", {u16x2, u8x1, u8x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyuhv_acc), u32x2, "add_mpy.vuw.vuh.vuh", {u32x2, u16x1, u16x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpybv_acc),  i16x2, "add_mpy.vh.vb.vb",    {i16x2, i8x1, i8x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyhv_acc),  i32x2, "add_mpy.vw.vh.vh",    {i32x2, i16x1, i16x1} },
 
         // Inconsistencies: both are vector instructions despite the
         // missing 'v', and the signedness is indeed swapped.
         { IPICK(Intrinsic::hexagon_V6_vmpybusv), i16x2, "mpy.vub.vb",  {u8x1,  i8x1} },
         { IPICK(Intrinsic::hexagon_V6_vmpyhus),  i32x2, "mpy.vh.vuh",  {i16x1, u16x1} },
 
-        { IPICK(Intrinsic::hexagon_V6_vmpybusv_acc), i16x2, "mpy.acc.vh.vub.vb",  {i16x2, u8x1,  i8x1} },
-        { IPICK(Intrinsic::hexagon_V6_vmpyhus_acc),  i32x2, "mpy.acc.vw.vh.vuh",  {i32x2, i16x1, u16x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpybusv_acc), i16x2, "add_mpy.vh.vub.vb",  {i16x2, u8x1,  i8x1} },
+        { IPICK(Intrinsic::hexagon_V6_vmpyhus_acc),  i32x2, "add_mpy.vw.vh.vuh",  {i32x2, i16x1, u16x1} },
 
         // Widening scalar multiplication:
         { IPICK(Intrinsic::hexagon_V6_vmpyub),  u16x2, "mpy.vub.ub",  {u8x1,  u8}, HvxIntrinsic::BroadcastScalarsToWords },
@@ -305,9 +306,9 @@ void CodeGen_Hexagon::init_module() {
         { IPICK(Intrinsic::hexagon_V6_vmpyh),   i32x2, "mpy.vh.h",    {i16x1, i16}, HvxIntrinsic::BroadcastScalarsToWords },
         { IPICK(Intrinsic::hexagon_V6_vmpybus), i16x2, "mpy.vub.b",   {u8x1,  i8}, HvxIntrinsic::BroadcastScalarsToWords },
 
-        { IPICK(Intrinsic::hexagon_V6_vmpyub_acc),  u16x2, "mpy.acc.vuh.vub.ub", {u16x2, u8x1,  u8}, HvxIntrinsic::BroadcastScalarsToWords },
-        { IPICK(Intrinsic::hexagon_V6_vmpyuh_acc),  u32x2, "mpy.acc.vuw.vuh.uh", {u32x2, u16x1, u16}, HvxIntrinsic::BroadcastScalarsToWords },
-        { IPICK(Intrinsic::hexagon_V6_vmpybus_acc), i16x2, "mpy.acc.vh.vub.b",   {i16x2, u8x1,  i8}, HvxIntrinsic::BroadcastScalarsToWords },
+        { IPICK(Intrinsic::hexagon_V6_vmpyub_acc),  u16x2, "add_mpy.vuh.vub.ub", {u16x2, u8x1,  u8}, HvxIntrinsic::BroadcastScalarsToWords },
+        { IPICK(Intrinsic::hexagon_V6_vmpyuh_acc),  u32x2, "add_mpy.vuw.vuh.uh", {u32x2, u16x1, u16}, HvxIntrinsic::BroadcastScalarsToWords },
+        { IPICK(Intrinsic::hexagon_V6_vmpybus_acc), i16x2, "add_mpy.vh.vub.b",   {i16x2, u8x1,  i8}, HvxIntrinsic::BroadcastScalarsToWords },
         // TODO: There's also vmpyhsat_acc.
 
         // Select/conditionals. Conditions are always signed integer
@@ -360,13 +361,13 @@ void CodeGen_Hexagon::init_module() {
         { IPICK(Intrinsic::hexagon_V6_vaslh),  i16x1, "shl.vh.h",   {i16x1, i16} },
         { IPICK(Intrinsic::hexagon_V6_vaslw),  i32x1, "shl.vw.w",   {i32x1, i32} },
 
-        { IPICK(Intrinsic::hexagon_V6_vasrw_acc), i32x1, "shr.acc.vw.vw.w", {i32x1, i32x1, i32} },
-        { IPICK(Intrinsic::hexagon_V6_vaslw_acc), i32x1, "shl.acc.vw.vw.w", {i32x1, i32x1, i32} },
+        { IPICK(Intrinsic::hexagon_V6_vasrw_acc), i32x1, "add_shr.vw.vw.w", {i32x1, i32x1, i32} },
+        { IPICK(Intrinsic::hexagon_V6_vaslw_acc), i32x1, "add_shl.vw.vw.w", {i32x1, i32x1, i32} },
 
-        { IPICK(Intrinsic::hexagon_V6_vasrwh), i16x1, "shrh.vw.w",   {i32x2, i32} },
-        { IPICK(Intrinsic::hexagon_V6_vasrhubsat), u8x1, "shrsatub.vh.h",  {i16x2, i16} },
-        { IPICK(Intrinsic::hexagon_V6_vasrwuhsat), u16x1, "shrsatuh.vw.w", {i32x2, i32} },
-        { IPICK(Intrinsic::hexagon_V6_vasrwhsat),  i16x1, "shrsath.vw.w",  {i32x2, i32} },
+        { IPICK(Intrinsic::hexagon_V6_vasrwh), i16x1, "trunc_shr.vw.w",   {i32x2, i32} },
+        { IPICK(Intrinsic::hexagon_V6_vasrhubsat), u8x1, "trunc_satub_shr.vh.h",  {i16x2, i16} },
+        { IPICK(Intrinsic::hexagon_V6_vasrwuhsat), u16x1, "trunc_satuh_shr.vw.w", {i32x2, i32} },
+        { IPICK(Intrinsic::hexagon_V6_vasrwhsat),  i16x1, "trunc_sath_shr.vw.w",  {i32x2, i32} },
 
         // Bitwise operators
         { IPICK(Intrinsic::hexagon_V6_vand),  u8x1,  "and.vb.vb",  {u8x1,  u8x1} },
@@ -756,7 +757,7 @@ void CodeGen_Hexagon::visit(const Mul *op) {
             Expr narrow_b = lossless_cast(b.type().with_bits(bits), b);
             Expr opb = narrow_b.defined() ? narrow_b : b;
             value = call_intrin(op->type,
-                                "halide.hexagon.mpyi" +
+                                "halide.hexagon.mul" +
                                 type_suffix(a, opb),
                                 {a, opb},
                                 true /*maybe*/);
@@ -766,7 +767,7 @@ void CodeGen_Hexagon::visit(const Mul *op) {
         // We didn't find an intrinsic for this type. Try again
         // without the scalar operand.
         value = call_intrin(op->type,
-                            "halide.hexagon.mpyi" + type_suffix(op->a, op->b),
+                            "halide.hexagon.mul" + type_suffix(op->a, op->b),
                             {op->a, op->b},
                             true /*maybe*/);
         if (value) return;
@@ -790,7 +791,7 @@ void CodeGen_Hexagon::visit(const Mul *op) {
             // but the trunc operation reinterleaves.
             Type wide = op->type.with_bits(op->type.bits()*2);
             value = call_intrin(llvm_type_of(op->type),
-                                "halide.hexagon.trunchi" + type_suffix(wide, false),
+                                "halide.hexagon.trunc" + type_suffix(wide, false),
                                 {value});
             return;
         }

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -148,10 +148,10 @@ std::vector<Pattern> casts = {
     { "halide.hexagon.avg.vh.vh", i16((wild_i32x + wild_i32x)/2), Pattern::NarrowOps },
     { "halide.hexagon.avg.vw.vw", i32((wild_i64x + wild_i64x)/2), Pattern::NarrowOps },
 
-    { "halide.hexagon.avgrnd.vub.vub", u8((wild_u16x + wild_u16x + 1)/2), Pattern::NarrowOps },
-    { "halide.hexagon.avgrnd.vuh.vuh", u16((wild_u32x + wild_u32x + 1)/2), Pattern::NarrowOps },
-    { "halide.hexagon.avgrnd.vh.vh", i16((wild_i32x + wild_i32x + 1)/2), Pattern::NarrowOps },
-    { "halide.hexagon.avgrnd.vw.vw", i32((wild_i64x + wild_i64x + 1)/2), Pattern::NarrowOps },
+    { "halide.hexagon.avg_rnd.vub.vub", u8((wild_u16x + wild_u16x + 1)/2), Pattern::NarrowOps },
+    { "halide.hexagon.avg_rnd.vuh.vuh", u16((wild_u32x + wild_u32x + 1)/2), Pattern::NarrowOps },
+    { "halide.hexagon.avg_rnd.vh.vh", i16((wild_i32x + wild_i32x + 1)/2), Pattern::NarrowOps },
+    { "halide.hexagon.avg_rnd.vw.vw", i32((wild_i64x + wild_i64x + 1)/2), Pattern::NarrowOps },
 
     { "halide.hexagon.navg.vub.vub", i8c((wild_i16x - wild_i16x)/2), Pattern::NarrowUnsignedOps },
     { "halide.hexagon.navg.vh.vh", i16c((wild_i32x - wild_i32x)/2), Pattern::NarrowOps },
@@ -159,29 +159,29 @@ std::vector<Pattern> casts = {
     // vnavg.uw doesn't exist.
 
     // Saturating add/subtract
-    { "halide.hexagon.addsat.vub.vub", u8c(wild_u16x + wild_u16x), Pattern::NarrowOps },
-    { "halide.hexagon.addsat.vuh.vuh", u16c(wild_u32x + wild_u32x), Pattern::NarrowOps },
-    { "halide.hexagon.addsat.vh.vh", i16c(wild_i32x + wild_i32x), Pattern::NarrowOps },
-    { "halide.hexagon.addsat.vw.vw", i32c(wild_i64x + wild_i64x), Pattern::NarrowOps },
+    { "halide.hexagon.satub_add.vub.vub", u8c(wild_u16x + wild_u16x), Pattern::NarrowOps },
+    { "halide.hexagon.satuh_add.vuh.vuh", u16c(wild_u32x + wild_u32x), Pattern::NarrowOps },
+    { "halide.hexagon.sath_add.vh.vh", i16c(wild_i32x + wild_i32x), Pattern::NarrowOps },
+    { "halide.hexagon.satw_add.vw.vw", i32c(wild_i64x + wild_i64x), Pattern::NarrowOps },
 
-    { "halide.hexagon.subsat.vub.vub", u8c(wild_i16x - wild_i16x), Pattern::NarrowUnsignedOps },
-    { "halide.hexagon.subsat.vuh.vuh", u16c(wild_i32x - wild_i32x), Pattern::NarrowUnsignedOps },
-    { "halide.hexagon.subsat.vh.vh", i16c(wild_i32x - wild_i32x), Pattern::NarrowOps },
-    { "halide.hexagon.subsat.vw.vw", i32c(wild_i64x - wild_i64x), Pattern::NarrowOps },
+    { "halide.hexagon.satub_sub.vub.vub", u8c(wild_i16x - wild_i16x), Pattern::NarrowUnsignedOps },
+    { "halide.hexagon.satuh_sub.vuh.vuh", u16c(wild_i32x - wild_i32x), Pattern::NarrowUnsignedOps },
+    { "halide.hexagon.sath_sub.vh.vh", i16c(wild_i32x - wild_i32x), Pattern::NarrowOps },
+    { "halide.hexagon.satw_sub.vw.vw", i32c(wild_i64x - wild_i64x), Pattern::NarrowOps },
 
     // Saturating narrowing casts with rounding
-    { "halide.hexagon.roundu.vh", u8c((wild_i32x + 128)/256), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
-    { "halide.hexagon.round.vh",  i8c((wild_i32x + 128)/256), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
-    { "halide.hexagon.roundu.vw", u16c((wild_i64x + 32768)/65536), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
-    { "halide.hexagon.round.vw",  i16c((wild_i64x + 32768)/65536), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
+    { "halide.hexagon.trunc_satub_rnd.vh", u8c((wild_i32x + 128)/256), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
+    { "halide.hexagon.trunc_satb_rnd.vh",  i8c((wild_i32x + 128)/256), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
+    { "halide.hexagon.trunc_satuh_rnd.vw", u16c((wild_i64x + 32768)/65536), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
+    { "halide.hexagon.trunc_sath_rnd.vw",  i16c((wild_i64x + 32768)/65536), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
 
     // Saturating narrowing casts
-    { "halide.hexagon.shrsatub.vh.h", u8c(wild_i16x >> wild_i16), Pattern::DeinterleaveOp0 },
-    { "halide.hexagon.shrsatuh.vw.w", u16c(wild_i32x >> wild_i32), Pattern::DeinterleaveOp0 },
-    { "halide.hexagon.shrsath.vw.w",  i16c(wild_i32x >> wild_i32), Pattern::DeinterleaveOp0 },
-    { "halide.hexagon.shrsatub.vh.h", u8c(wild_i16x/wild_i16), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
-    { "halide.hexagon.shrsatuh.vw.w", u16c(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
-    { "halide.hexagon.shrsath.vw.w",  i16c(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
+    { "halide.hexagon.trunc_satub_shr.vh.h", u8c(wild_i16x >> wild_i16), Pattern::DeinterleaveOp0 },
+    { "halide.hexagon.trunc_satuh_shr.vw.w", u16c(wild_i32x >> wild_i32), Pattern::DeinterleaveOp0 },
+    { "halide.hexagon.trunc_sath_shr.vw.w",  i16c(wild_i32x >> wild_i32), Pattern::DeinterleaveOp0 },
+    { "halide.hexagon.trunc_satub_shr.vh.h", u8c(wild_i16x/wild_i16), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
+    { "halide.hexagon.trunc_satuh_shr.vw.w", u16c(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
+    { "halide.hexagon.trunc_sath_shr.vw.w",  i16c(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
 
     // For these narrowing ops, we have the choice of non-interleaving
     // instructions (vpack), or instructions which interleave
@@ -189,10 +189,10 @@ std::vector<Pattern> casts = {
     // pattern matching, we match these for now and replace them with
     // the instructions that interleave later if it makes sense.
     // TODO: We can also do this with the non-saturating casts below.
-    { "halide.hexagon.trunchi.satub.vh", u8c(wild_i16x) },
-    { "halide.hexagon.trunchi.satuh.vw", u16c(wild_i32x) },
-    { "halide.hexagon.trunchi.satb.vh", i8c(wild_i16x) },
-    { "halide.hexagon.trunchi.sath.vw", i16c(wild_i32x) },
+    { "halide.hexagon.pack_satub.vh", u8c(wild_i16x) },
+    { "halide.hexagon.pack_satuh.vw", u16c(wild_i32x) },
+    { "halide.hexagon.pack_satb.vh", i8c(wild_i16x) },
+    { "halide.hexagon.pack_sath.vw", i16c(wild_i32x) },
 
     // Narrowing casts
     { "halide.hexagon.trunclo.vh", u8(wild_u16x/256), Pattern::DeinterleaveOp0 },
@@ -203,16 +203,16 @@ std::vector<Pattern> casts = {
     { "halide.hexagon.trunclo.vw", u16(wild_i32x/65536), Pattern::DeinterleaveOp0 },
     { "halide.hexagon.trunclo.vw", i16(wild_u32x/65536), Pattern::DeinterleaveOp0 },
     { "halide.hexagon.trunclo.vw", i16(wild_i32x/65536), Pattern::DeinterleaveOp0 },
-    { "halide.hexagon.shrh.vw.w",  i16(wild_i32x >> wild_i32), Pattern::DeinterleaveOp0 },
-    { "halide.hexagon.shrh.vw.w",  i16(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
-    { "halide.hexagon.trunchi.vh", u8(wild_u16x), Pattern::DeinterleaveOp0 },
-    { "halide.hexagon.trunchi.vh", u8(wild_i16x), Pattern::DeinterleaveOp0 },
-    { "halide.hexagon.trunchi.vh", i8(wild_u16x), Pattern::DeinterleaveOp0 },
-    { "halide.hexagon.trunchi.vh", i8(wild_i16x), Pattern::DeinterleaveOp0 },
-    { "halide.hexagon.trunchi.vw", u16(wild_u32x), Pattern::DeinterleaveOp0 },
-    { "halide.hexagon.trunchi.vw", u16(wild_i32x), Pattern::DeinterleaveOp0 },
-    { "halide.hexagon.trunchi.vw", i16(wild_u32x), Pattern::DeinterleaveOp0 },
-    { "halide.hexagon.trunchi.vw", i16(wild_i32x), Pattern::DeinterleaveOp0 },
+    { "halide.hexagon.trunc_shr.vw.w",  i16(wild_i32x >> wild_i32), Pattern::DeinterleaveOp0 },
+    { "halide.hexagon.trunc_shr.vw.w",  i16(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
+    { "halide.hexagon.trunc.vh", u8(wild_u16x), Pattern::DeinterleaveOp0 },
+    { "halide.hexagon.trunc.vh", u8(wild_i16x), Pattern::DeinterleaveOp0 },
+    { "halide.hexagon.trunc.vh", i8(wild_u16x), Pattern::DeinterleaveOp0 },
+    { "halide.hexagon.trunc.vh", i8(wild_i16x), Pattern::DeinterleaveOp0 },
+    { "halide.hexagon.trunc.vw", u16(wild_u32x), Pattern::DeinterleaveOp0 },
+    { "halide.hexagon.trunc.vw", u16(wild_i32x), Pattern::DeinterleaveOp0 },
+    { "halide.hexagon.trunc.vw", i16(wild_u32x), Pattern::DeinterleaveOp0 },
+    { "halide.hexagon.trunc.vw", i16(wild_i32x), Pattern::DeinterleaveOp0 },
 
     // Widening casts
     { "halide.hexagon.zxt.vub", u16(wild_u8x), Pattern::InterleaveResult },
@@ -249,43 +249,43 @@ const int ReinterleaveOp0 = Pattern::InterleaveResult | Pattern::DeinterleaveOp0
 
 std::vector<Pattern> adds = {
     // Shift-accumulates.
-    { "halide.hexagon.shr.acc.vw.vw.w", wild_i32x + (wild_i32x >> bc(wild_i32)) },
-    { "halide.hexagon.shl.acc.vw.vw.w", wild_i32x + (wild_i32x << bc(wild_i32)) },
-    { "halide.hexagon.shl.acc.vw.vw.w", wild_u32x + (wild_u32x << bc(wild_u32)) },
-    { "halide.hexagon.shr.acc.vw.vw.w", wild_i32x + (wild_i32x/bc(wild_i32)), Pattern::ExactLog2Op2 },
-    { "halide.hexagon.shl.acc.vw.vw.w", wild_i32x + (wild_i32x*bc(wild_i32)), Pattern::ExactLog2Op2 },
-    { "halide.hexagon.shl.acc.vw.vw.w", wild_u32x + (wild_u32x*bc(wild_u32)), Pattern::ExactLog2Op2 },
-    { "halide.hexagon.shl.acc.vw.vw.w", wild_i32x + (bc(wild_i32)*wild_i32x), Pattern::ExactLog2Op1 | Pattern::SwapOps12 },
-    { "halide.hexagon.shl.acc.vw.vw.w", wild_u32x + (bc(wild_u32)*wild_u32x), Pattern::ExactLog2Op1 | Pattern::SwapOps12 },
+    { "halide.hexagon.add_shr.vw.vw.w", wild_i32x + (wild_i32x >> bc(wild_i32)) },
+    { "halide.hexagon.add_shl.vw.vw.w", wild_i32x + (wild_i32x << bc(wild_i32)) },
+    { "halide.hexagon.add_shl.vw.vw.w", wild_u32x + (wild_u32x << bc(wild_u32)) },
+    { "halide.hexagon.add_shr.vw.vw.w", wild_i32x + (wild_i32x/bc(wild_i32)), Pattern::ExactLog2Op2 },
+    { "halide.hexagon.add_shl.vw.vw.w", wild_i32x + (wild_i32x*bc(wild_i32)), Pattern::ExactLog2Op2 },
+    { "halide.hexagon.add_shl.vw.vw.w", wild_u32x + (wild_u32x*bc(wild_u32)), Pattern::ExactLog2Op2 },
+    { "halide.hexagon.add_shl.vw.vw.w", wild_i32x + (bc(wild_i32)*wild_i32x), Pattern::ExactLog2Op1 | Pattern::SwapOps12 },
+    { "halide.hexagon.add_shl.vw.vw.w", wild_u32x + (bc(wild_u32)*wild_u32x), Pattern::ExactLog2Op1 | Pattern::SwapOps12 },
 
     // Widening multiply-accumulates with a scalar.
-    { "halide.hexagon.mpy.acc.vuh.vub.ub", wild_u16x + wild_u16x*bc(wild_u16), ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 },
-    { "halide.hexagon.mpy.acc.vh.vub.b",   wild_i16x + wild_i16x*bc(wild_i16), ReinterleaveOp0 | Pattern::NarrowUnsignedOp1 | Pattern::NarrowOp2 },
-    { "halide.hexagon.mpy.acc.vuw.vuh.uh", wild_u32x + wild_u32x*bc(wild_u32), ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 },
-    { "halide.hexagon.mpy.acc.vuh.vub.ub", wild_u16x + bc(wild_u16)*wild_u16x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 | Pattern::SwapOps12 },
-    { "halide.hexagon.mpy.acc.vh.vub.b",   wild_i16x + bc(wild_i16)*wild_i16x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowUnsignedOp2 | Pattern::SwapOps12 },
-    { "halide.hexagon.mpy.acc.vuw.vuh.uh", wild_u32x + bc(wild_u32)*wild_u32x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 | Pattern::SwapOps12 },
+    { "halide.hexagon.add_mpy.vuh.vub.ub", wild_u16x + wild_u16x*bc(wild_u16), ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 },
+    { "halide.hexagon.add_mpy.vh.vub.b",   wild_i16x + wild_i16x*bc(wild_i16), ReinterleaveOp0 | Pattern::NarrowUnsignedOp1 | Pattern::NarrowOp2 },
+    { "halide.hexagon.add_mpy.vuw.vuh.uh", wild_u32x + wild_u32x*bc(wild_u32), ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 },
+    { "halide.hexagon.add_mpy.vuh.vub.ub", wild_u16x + bc(wild_u16)*wild_u16x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 | Pattern::SwapOps12 },
+    { "halide.hexagon.add_mpy.vh.vub.b",   wild_i16x + bc(wild_i16)*wild_i16x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowUnsignedOp2 | Pattern::SwapOps12 },
+    { "halide.hexagon.add_mpy.vuw.vuh.uh", wild_u32x + bc(wild_u32)*wild_u32x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 | Pattern::SwapOps12 },
 
     // Non-widening multiply-accumulates with a scalar.
-    { "halide.hexagon.mpyi.acc.vh.vh.b", wild_i16x + wild_i16x*bc(wild_i16), Pattern::NarrowOp2 },
-    { "halide.hexagon.mpyi.acc.vw.vw.h", wild_i32x + wild_i32x*bc(wild_i32), Pattern::NarrowOp2 },
-    { "halide.hexagon.mpyi.acc.vh.vh.b", wild_i16x + bc(wild_i16)*wild_i16x, Pattern::NarrowOp1 | Pattern::SwapOps12 },
-    { "halide.hexagon.mpyi.acc.vw.vw.h", wild_i32x + bc(wild_i32)*wild_i32x, Pattern::NarrowOp1 | Pattern::SwapOps12 },
-    // TODO: There's also a mpyi.acc.vw.vw.b
+    { "halide.hexagon.add_mul.vh.vh.b", wild_i16x + wild_i16x*bc(wild_i16), Pattern::NarrowOp2 },
+    { "halide.hexagon.add_mul.vw.vw.h", wild_i32x + wild_i32x*bc(wild_i32), Pattern::NarrowOp2 },
+    { "halide.hexagon.add_mul.vh.vh.b", wild_i16x + bc(wild_i16)*wild_i16x, Pattern::NarrowOp1 | Pattern::SwapOps12 },
+    { "halide.hexagon.add_mul.vw.vw.h", wild_i32x + bc(wild_i32)*wild_i32x, Pattern::NarrowOp1 | Pattern::SwapOps12 },
+    // TODO: There's also a add_mul.vw.vw.b
 
     // Widening multiply-accumulates.
-    { "halide.hexagon.mpy.acc.vuh.vub.vub", wild_u16x + wild_u16x*wild_u16x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 },
-    { "halide.hexagon.mpy.acc.vuw.vuh.vuh", wild_u32x + wild_u32x*wild_u32x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 },
-    { "halide.hexagon.mpy.acc.vh.vb.vb",    wild_i16x + wild_i16x*wild_i16x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 },
-    { "halide.hexagon.mpy.acc.vw.vh.vh",    wild_i32x + wild_i32x*wild_i32x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 },
+    { "halide.hexagon.add_mpy.vuh.vub.vub", wild_u16x + wild_u16x*wild_u16x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 },
+    { "halide.hexagon.add_mpy.vuw.vuh.vuh", wild_u32x + wild_u32x*wild_u32x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 },
+    { "halide.hexagon.add_mpy.vh.vb.vb",    wild_i16x + wild_i16x*wild_i16x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 },
+    { "halide.hexagon.add_mpy.vw.vh.vh",    wild_i32x + wild_i32x*wild_i32x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 },
 
-    { "halide.hexagon.mpy.acc.vh.vub.vb",   wild_i16x + wild_i16x*wild_i16x, ReinterleaveOp0 | Pattern::NarrowUnsignedOp1 | Pattern::NarrowOp2 },
-    { "halide.hexagon.mpy.acc.vw.vh.vuh",   wild_i32x + wild_i32x*wild_i32x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowUnsignedOp2 },
-    { "halide.hexagon.mpy.acc.vh.vub.vb",   wild_i16x + wild_i16x*wild_i16x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowUnsignedOp2 | Pattern::SwapOps12 },
-    { "halide.hexagon.mpy.acc.vw.vh.vuh",   wild_i32x + wild_i32x*wild_i32x, ReinterleaveOp0 | Pattern::NarrowUnsignedOp1 | Pattern::NarrowOp2 | Pattern::SwapOps12 },
+    { "halide.hexagon.add_mpy.vh.vub.vb",   wild_i16x + wild_i16x*wild_i16x, ReinterleaveOp0 | Pattern::NarrowUnsignedOp1 | Pattern::NarrowOp2 },
+    { "halide.hexagon.add_mpy.vw.vh.vuh",   wild_i32x + wild_i32x*wild_i32x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowUnsignedOp2 },
+    { "halide.hexagon.add_mpy.vh.vub.vb",   wild_i16x + wild_i16x*wild_i16x, ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowUnsignedOp2 | Pattern::SwapOps12 },
+    { "halide.hexagon.add_mpy.vw.vh.vuh",   wild_i32x + wild_i32x*wild_i32x, ReinterleaveOp0 | Pattern::NarrowUnsignedOp1 | Pattern::NarrowOp2 | Pattern::SwapOps12 },
 
     // This pattern is very general, so it must come last.
-    { "halide.hexagon.mpyi.acc.vh.vh.vh", wild_i16x + wild_i16x*wild_i16x },
+    { "halide.hexagon.add_mul.vh.vh.vh", wild_i16x + wild_i16x*wild_i16x },
 };
 
 Expr apply_patterns(Expr x, const std::vector<Pattern> &patterns, IRMutator *op_mutator) {
@@ -678,12 +678,12 @@ private:
             vector<Expr> extra_args;
         };
         static std::map<string, DeinterleavingAlternative> deinterleaving_alts = {
-            { "halide.hexagon.trunchi.satub.vh", { "halide.hexagon.satub.vh" } },
-            { "halide.hexagon.trunchi.sath.vw", { "halide.hexagon.sath.vw" } },
+            { "halide.hexagon.pack_satub.vh", { "halide.hexagon.trunc_satub.vh" } },
+            { "halide.hexagon.pack_sath.vw", { "halide.hexagon.trunc_sath.vw" } },
             // For this one, we don't have a simple alternative. But,
             // we have a shift-saturate-narrow that we can use with a
             // shift of 0.
-            { "halide.hexagon.trunchi.satuh.vw", { "halide.hexagon.shrsatuh.vw.w", { 0 } } },
+            { "halide.hexagon.pack_satuh.vw", { "halide.hexagon.trunc_satuh_shr.vw.w", { 0 } } },
         };
 
         if (is_native_deinterleave(op) && yields_interleave(args[0])) {


### PR DESCRIPTION
This PR renames the intrinsic wrappers to have a more consistent convention. Here's the convention I used:

- Sequences of operations are read in "application order", i.e. a saturate followed by a truncate would be trunc_satuh, intended to be read more like trunc(satuh(...))
- I used 'mul' for non-widening multiply, and kept 'mpy' for widening multiply, I couldn't think of anything else consistent.
- Saturations are defined by the type they saturate to, e.g. satub = saturate to unsigned bytes. However, it does not imply a truncation, so usually saturation appears with a trunc following the saturate. The reason for this is to distinguish between trunc and pack, which both only keep the saturated result, but with different interleaving behavior.