### PR TITLE
[Hexagon] Handle double widening/narrowing

### DIFF
--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -220,11 +220,9 @@ std::vector<Pattern> casts = {
 
     // Saturating narrowing casts
     { "halide.hexagon.trunc_satub_shr.vh.h", u8c(wild_i16x >> wild_i16), Pattern::DeinterleaveOp0 },
-    { "halide.hexagon.trunc_satub_shr.vw.w", u8c(wild_i32x >> wild_i32), Pattern::DeinterleaveOp0 },
     { "halide.hexagon.trunc_satuh_shr.vw.w", u16c(wild_i32x >> wild_i32), Pattern::DeinterleaveOp0 },
     { "halide.hexagon.trunc_sath_shr.vw.w",  i16c(wild_i32x >> wild_i32), Pattern::DeinterleaveOp0 },
     { "halide.hexagon.trunc_satub_shr.vh.h", u8c(wild_i16x/wild_i16), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
-    { "halide.hexagon.trunc_satub_shr.vw.w", u8c(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
     { "halide.hexagon.trunc_satuh_shr.vw.w", u16c(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
     { "halide.hexagon.trunc_sath_shr.vw.w",  i16c(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
 
@@ -458,7 +456,9 @@ private:
 
     void visit(const Cast *op) {
         // To hit more of the patterns we want, rewrite "double casts"
-        // as two stage casts.
+        // as two stage casts. This also avoids letting vector casts
+        // fall through to LLVM, which will generate large unoptimized
+        // shuffles.
         static vector<pair<Expr, Expr>> cast_rewrites = {
             // Saturating narrowing
             { u8c(wild_u32x), u8c(u16c(wild_u32x)) },

--- a/src/runtime/hvx_128.ll
+++ b/src/runtime/hvx_128.ll
@@ -60,24 +60,6 @@ define weak_odr <256 x i8> @halide.hexagon.deinterleave.vb(<256 x i8> %arg) noun
   ret <256 x i8> %r
 }
 
-  ; Implements u8c(deinterleave.vh(i16(i32x4 >> c)))
-define weak_odr <128 x i8> @halide.hexagon.trunc_satub_shr.vw.w(<128 x i32> %arg0, i32 %arg1) nounwind uwtable readnone alwaysinline {
-  %low_dv = shufflevector <128 x i32> %arg0, <128 x i32> undef, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47, i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-  %high_dv = shufflevector <128 x i32> %arg0, <128 x i32> undef, <64 x i32> <i32 64, i32 65, i32 66, i32 67, i32 68, i32 69, i32 70, i32 71, i32 72, i32 73, i32 74, i32 75, i32 76, i32 77, i32 78, i32 79, i32 80, i32 81, i32 82, i32 83, i32 84, i32 85, i32 86, i32 87, i32 88, i32 89, i32 90, i32 91, i32 92, i32 93, i32 94, i32 95, i32 96, i32 97, i32 98, i32 99, i32 100, i32 101, i32 102, i32 103, i32 104, i32 105, i32 106, i32 107, i32 108, i32 109, i32 110, i32 111, i32 112, i32 113, i32 114, i32 115, i32 116, i32 117, i32 118, i32 119, i32 120, i32 121, i32 122, i32 123, i32 124, i32 125, i32 126, i32 127>
-  %ldv_lo = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %low_dv)
-  %ldv_hi = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %low_dv)
-  %lo = call <32 x i32> @llvm.hexagon.V6.vasrwhsat.128B(<32 x i32> %ldv_hi, <32 x i32> %ldv_lo, i32 %arg1)
-  %hdv_lo = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %high_dv)
-  %hdv_hi = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %high_dv)
-  %hi = call <32 x i32> @llvm.hexagon.V6.vasrwhsat.128B(<32 x i32> %hdv_hi, <32 x i32> %hdv_lo, i32 %arg1)
-  %vp_deint = call <64 x i32> @llvm.hexagon.V6.vdealvdd.128B(<32 x i32> %hi, <32 x i32> %lo, i32 -2)
-  %e = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %vp_deint)
-  %o = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %vp_deint)
-  %r = call <32 x i32> @llvm.hexagon.V6.vsathub.128B(<32 x i32> %o, <32 x i32> %e)
-  %retval = bitcast <32 x i32> %r to <128 x i8>
-  ret <128 x i8> %retval
-}
-
 declare <32 x i32> @llvm.hexagon.V6.lvsplatw.128B(i32)
 
 define weak_odr i16 @halide.hexagon.dup2.b(i8 %arg) nounwind uwtable readnone alwaysinline {

--- a/src/runtime/hvx_64.ll
+++ b/src/runtime/hvx_64.ll
@@ -60,25 +60,6 @@ define weak_odr <128 x i8> @halide.hexagon.deinterleave.vb(<128 x i8> %arg) noun
   ret <128 x i8> %r
 }
 
-  ; Implements u8c(deinterleave.vh(i16(i32x4 >> c)))
-define weak_odr <64 x i8> @halide.hexagon.trunc_satub_shr.vw.w(<64 x i32> %arg0, i32 %arg1) nounwind uwtable readnone alwaysinline {
-  %low_dv = shufflevector <64 x i32> %arg0, <64 x i32> undef, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-  %high_dv = shufflevector <64 x i32> %arg0, <64 x i32> undef, <32 x i32> <i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47, i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-  %ldv_lo = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %low_dv)
-  %ldv_hi = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %low_dv)
-  %lo = call <16 x i32> @llvm.hexagon.V6.vasrwhsat(<16 x i32> %ldv_hi, <16 x i32> %ldv_lo, i32 %arg1)
-  %hdv_lo = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %high_dv)
-  %hdv_hi = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %high_dv)
-  %hi = call <16 x i32> @llvm.hexagon.V6.vasrwhsat(<16 x i32> %hdv_hi, <16 x i32> %hdv_lo, i32 %arg1)
-  %vp_deint = call <32 x i32> @llvm.hexagon.V6.vdealvdd(<16 x i32> %hi, <16 x i32> %lo, i32 -2)
-  %e = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %vp_deint)
-  %o = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %vp_deint)
-  %r = call <16 x i32> @llvm.hexagon.V6.vsathub(<16 x i32> %o, <16 x i32> %e)
-  %retval = bitcast <16 x i32> %r to <64 x i8>
-  ret <64 x i8> %retval
-}
-
-
 declare <16 x i32> @llvm.hexagon.V6.lvsplatw(i32)
 
 define weak_odr i16 @halide.hexagon.dup2.b(i8 %arg) nounwind uwtable readnone alwaysinline {

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1331,11 +1331,15 @@ void check_hvx_all() {
     check("vzxt(v*.ub)", hvx_width/1, i16(u8_1));
     check("vzxt(v*.uh)", hvx_width/2, u32(u16_1));
     check("vzxt(v*.uh)", hvx_width/2, i32(u16_1));
-
     check("vsxt(v*.b)", hvx_width/1, u16(i8_1));
     check("vsxt(v*.b)", hvx_width/1, i16(i8_1));
     check("vsxt(v*.h)", hvx_width/2, u32(i16_1));
     check("vsxt(v*.h)", hvx_width/2, i32(i16_1));
+
+    check("vzxt(v*.ub)", hvx_width/1, u32(u8_1));
+    check("vzxt(v*.ub)", hvx_width/1, i32(u8_1));
+    check("vsxt(v*.b)", hvx_width/1, u32(i8_1));
+    check("vsxt(v*.b)", hvx_width/1, i32(i8_1));
 
     check("vadd(v*.b,v*.b)", hvx_width/1, u8_1 + u8_2);
     check("vadd(v*.h,v*.h)", hvx_width/2, u16_1 + u16_2);
@@ -1451,6 +1455,11 @@ void check_hvx_all() {
     check("v*.ub = vsat(v*.h,v*.h)", hvx_width/1, u8c(i16(i8_1) << 8));
     check("v*.uh = vasr(v*.w,v*.w,r*):sat", hvx_width/2, u16c(i32(i16_1) << 16));
     check("v*.h = vsat(v*.w,v*.w)", hvx_width/2, i16c(i32(i16_1) << 16));
+
+    // Also check double saturating narrows.
+    check("v*.ub = vpack(v*.h,v*.h):sat", hvx_width/1, u8c(i32_1));
+    check("v*.b = vpack(v*.h,v*.h):sat", hvx_width/1, i8c(i32_1));
+    check("v*.h = vsat(v*.w,v*.w)", hvx_width/1, u8c(i32(i16_1) << 8));
 
     check("vround(v*.h,v*.h)", hvx_width/1, u8c((i32(i16_1) + 128)/256));
     check("vround(v*.h,v*.h)", hvx_width/1, i8c((i32(i16_1) + 128)/256));


### PR DESCRIPTION
If left to LLVM, double widening/narrowing generate long unoptimized LLVM shuffles. This change rewrites double widenings/narrowings as two stage casts, which can be lowered to optimized instructions.

@pranavb-ca , I hope you don't mind, I'm pretty sure that this generates the same code as the double narrowing saturating shift implementation you just added. Please take a look.