### PR TITLE
Stronger Func::bound

### DIFF
--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -270,14 +270,19 @@ public:
                     const Bound &bound = func.schedule().bounds()[i];
                     string min_var = prefix + bound.var + ".min";
                     string max_var = prefix + bound.var + ".max";
+                    Expr min_required = Variable::make(Int(32), min_var);
+                    Expr max_required = Variable::make(Int(32), max_var);
+
                     Expr min_bound = bound.min;
-                    Expr max_bound = (bound.min + bound.extent) - 1;
+                    if (!min_bound.defined()) {
+                        min_bound = min_required;
+                    }
+                    Expr max_bound = (min_bound + bound.extent) - 1;
+
                     s = LetStmt::make(min_var, min_bound, s);
                     s = LetStmt::make(max_var, max_bound, s);
 
                     // Save the unbounded values to use in bounds-checking assertions
-                    Expr min_required = Variable::make(Int(32), min_var);
-                    Expr max_required = Variable::make(Int(32), max_var);
                     s = LetStmt::make(min_var + "_unbounded", min_required, s);
                     s = LetStmt::make(max_var + "_unbounded", max_required, s);
                 }
@@ -381,7 +386,7 @@ public:
             }
 
             // Make the extern call
-            Expr e = Call::make(Int(32), extern_name, bounds_inference_args, 
+            Expr e = Call::make(Int(32), extern_name, bounds_inference_args,
                                 func.extern_definition_is_c_plus_plus() ? Call::ExternCPlusPlus : Call::Extern);
             // Check if it succeeded
             string result_name = unique_name('t');

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -955,6 +955,10 @@ Func &Func::bound(Var var, Expr min, Expr extent) {
     return *this;
 }
 
+Func &Func::bound_extent(Var var, Expr extent) {
+    return bound(var, Expr(), extent);
+}
+
 Func &Func::tile(VarOrRVar x, VarOrRVar y,
                  VarOrRVar xo, VarOrRVar yo,
                  VarOrRVar xi, VarOrRVar yi,

--- a/src/Func.h
+++ b/src/Func.h
@@ -852,15 +852,16 @@ public:
      * vectorize the color channel dimension without the overhead of
      * splitting it up. If bounds inference decides that it requires
      * more of this function than the bounds you have stated, a
-     * runtime error will occur when you try to run your pipeline.
-     *
-     * The min argument may be an undefined Expr, in which case the
-     * extent is bounded but the min is whatever bounds inference
-     * computes. This can be useful for forcing a function's
-     * allocation to be a fixed size, which often means it can go on
-     * the stack.
-     */
+     * runtime error will occur when you try to run your pipeline. */
     EXPORT Func &bound(Var var, Expr min, Expr extent);
+
+    /** Bound the extent of a Func's realization, but not its
+     * min. This means the dimension can be unrolled or vectorized
+     * even when its min is not fixed (for example because it is
+     * compute_at tiles of another Func). This can also be useful for
+     * forcing a function's allocation to be a fixed size, which often
+     * means it can go on the stack. */
+    EXPORT Func &bound_extent(Var var, Expr extent);
 
     /** Split two dimensions at once by the given factors, and then
      * reorder the resulting dimensions to be xi, yi, xo, yo from

--- a/src/Func.h
+++ b/src/Func.h
@@ -853,6 +853,12 @@ public:
      * splitting it up. If bounds inference decides that it requires
      * more of this function than the bounds you have stated, a
      * runtime error will occur when you try to run your pipeline.
+     *
+     * The min argument may be an undefined Expr, in which case the
+     * extent is bounded but the min is whatever bounds inference
+     * computes. This can be useful for forcing a function's
+     * allocation to be a fixed size, which often means it can go on
+     * the stack.
      */
     EXPORT Func &bound(Var var, Expr min, Expr extent);
 

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -600,23 +600,27 @@ Stmt inject_explicit_bounds(Stmt body, Function func) {
     for (size_t stage = 0; stage <= func.updates().size(); stage++) {
         for (size_t i = 0; i < s.bounds().size(); i++) {
             Bound b = s.bounds()[i];
-            Expr max_val = (b.extent + b.min) - 1;
-            Expr min_val = b.min;
-            string prefix = func.name() + ".s" + std::to_string(stage) + "." + b.var;
-            string min_name = prefix + ".min_unbounded";
-            string max_name = prefix + ".max_unbounded";
-            Expr min_var = Variable::make(Int(32), min_name);
-            Expr max_var = Variable::make(Int(32), max_name);
-            Expr check = (min_val <= min_var) && (max_val >= max_var);
-            Expr error_msg = Call::make(Int(32), "halide_error_explicit_bounds_too_small",
-                                        {b.var, func.name(), min_val, max_val, min_var, max_var},
-                                        Call::Extern);
+            if (b.min.defined()) {
+                Expr max_val = (b.extent + b.min) - 1;
+                Expr min_val = b.min;
+                string prefix = func.name() + ".s" + std::to_string(stage) + "." + b.var;
+                string min_name = prefix + ".min_unbounded";
+                string max_name = prefix + ".max_unbounded";
+                Expr min_var = Variable::make(Int(32), min_name);
+                Expr max_var = Variable::make(Int(32), max_name);
+                Expr check = (min_val <= min_var) && (max_val >= max_var);
+                Expr error_msg = Call::make(Int(32), "halide_error_explicit_bounds_too_small",
+                                            {b.var, func.name(), min_val, max_val, min_var, max_var},
+                                            Call::Extern);
 
-            // bounds inference has already respected these values for us
-            //body = LetStmt::make(prefix + ".min", min_val, body);
-            //body = LetStmt::make(prefix + ".max", max_val, body);
+                // bounds inference has already respected these values for us
+                //body = LetStmt::make(prefix + ".min", min_val, body);
+                //body = LetStmt::make(prefix + ".max", max_val, body);
 
-            body = Block::make(AssertStmt::make(check, error_msg), body);
+                body = Block::make(AssertStmt::make(check, error_msg), body);
+            } else {
+                // TODO
+            }
         }
     }
 

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -600,27 +600,23 @@ Stmt inject_explicit_bounds(Stmt body, Function func) {
     for (size_t stage = 0; stage <= func.updates().size(); stage++) {
         for (size_t i = 0; i < s.bounds().size(); i++) {
             Bound b = s.bounds()[i];
-            if (b.min.defined()) {
-                Expr max_val = (b.extent + b.min) - 1;
-                Expr min_val = b.min;
-                string prefix = func.name() + ".s" + std::to_string(stage) + "." + b.var;
-                string min_name = prefix + ".min_unbounded";
-                string max_name = prefix + ".max_unbounded";
-                Expr min_var = Variable::make(Int(32), min_name);
-                Expr max_var = Variable::make(Int(32), max_name);
-                Expr check = (min_val <= min_var) && (max_val >= max_var);
-                Expr error_msg = Call::make(Int(32), "halide_error_explicit_bounds_too_small",
-                                            {b.var, func.name(), min_val, max_val, min_var, max_var},
-                                            Call::Extern);
-
-                // bounds inference has already respected these values for us
-                //body = LetStmt::make(prefix + ".min", min_val, body);
-                //body = LetStmt::make(prefix + ".max", max_val, body);
-
-                body = Block::make(AssertStmt::make(check, error_msg), body);
-            } else {
-                // TODO
+            string prefix = func.name() + ".s" + std::to_string(stage) + "." + b.var;
+            string min_name = prefix + ".min_unbounded";
+            string max_name = prefix + ".max_unbounded";
+            Expr min_var = Variable::make(Int(32), min_name);
+            Expr max_var = Variable::make(Int(32), max_name);
+            if (!b.min.defined()) {
+                b.min = min_var;
             }
+
+            Expr max_val = (b.extent + b.min) - 1;
+            Expr min_val = b.min;
+
+            Expr check = (min_val <= min_var) && (max_val >= max_var);
+            Expr error_msg = Call::make(Int(32), "halide_error_explicit_bounds_too_small",
+                                        {b.var, func.name(), min_val, max_val, min_var, max_var},
+                                        Call::Extern);
+            body = Block::make(AssertStmt::make(check, error_msg), body);
         }
     }
 

--- a/test/correctness/force_onto_stack.cpp
+++ b/test/correctness/force_onto_stack.cpp
@@ -25,36 +25,63 @@ void my_error(void *user_context, const char* msg) {
 
 int main(int argc, char **argv) {
 
-    Func f("f"), g;
-    Var x("x"), xo, xi;
+    {
+        Func f("f"), g;
+        Var x("x"), xo, xi;
 
-    Param<int> p;
+        Param<int> p;
 
-    f(x) = x;
-    g(x) = f(x);
-    g.split(x, xo, xi, p);
+        f(x) = x;
+        g(x) = f(x);
+        g.split(x, xo, xi, p);
 
-    // We need p elements of f per split of g. This could create a
-    // dynamic allocation. Instead we'll assert that 8 is enough, so
-    // that f can go on the stack and be entirely vectorized.
-    f.compute_at(g, xo).bound(x, Expr(), 8).vectorize(x);
+        // We need p elements of f per split of g. This could create a
+        // dynamic allocation. Instead we'll assert that 8 is enough, so
+        // that f can go on the stack and be entirely vectorized.
+        f.compute_at(g, xo).bound(x, Expr(), 8).vectorize(x);
 
-    // Check there's no malloc when the bound is good
-    g.set_custom_allocator(&my_malloc, &my_free);
-    p.set(5);
-    g.realize(20);
-    g.set_custom_allocator(nullptr, nullptr);
+        // Check there's no malloc when the bound is good
+        g.set_custom_allocator(&my_malloc, &my_free);
+        p.set(5);
+        g.realize(20);
+        g.set_custom_allocator(nullptr, nullptr);
 
-    // Check there was an assertion failure of the appropriate type when the bound is violated
-    g.set_error_handler(&my_error);
-    p.set(10);
-    g.realize(20);
+        // Check there was an assertion failure of the appropriate type when the bound is violated
+        g.set_error_handler(&my_error);
+        p.set(10);
+        g.realize(20);
 
 
-    if (!errored) {
-        printf("There was supposed to be an error\n");
-        return -1;
+        if (!errored) {
+            printf("There was supposed to be an error\n");
+            return -1;
+        }
     }
+
+    {
+        // Another way in which a larger static allocation is
+        // preferable to a smaller dynamic one is when you compute
+        // something at a split guarded by an if. In the very last
+        // split (the tail) you don't actually need the whole split's
+        // worth of the producer, and indeed asking for it may expand
+        // the bounds required of an input image.
+        Func f, g;
+        Var x, xo, xi;
+
+        f(x) = x;
+        g(x) = f(x);
+        g.split(x, xo, xi, 8, TailStrategy::GuardWithIf);
+
+        f.compute_at(g, xo);
+        // In the tail case, the amount of g required is min(8, some
+        // nasty thing), so we'll add a bound.
+        f.bound(x, Expr(), 8);
+
+        g.set_custom_allocator(&my_malloc, &my_free);
+        g.realize(20);
+
+    }
+
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/force_onto_stack.cpp
+++ b/test/correctness/force_onto_stack.cpp
@@ -1,0 +1,62 @@
+#include "Halide.h"
+using namespace Halide;
+
+
+void *my_malloc(void *user_context, size_t x) {
+    printf("There was not supposed to be a heap allocation\n");
+    exit(-1);
+    return nullptr;
+}
+
+void my_free(void *user_context, void *ptr) {
+}
+
+
+bool errored = false;
+void my_error(void *user_context, const char* msg) {
+    errored = true;
+    char expected[] = "Bounds given for f in x (from 0 to 7) do not cover required region (from 0 to 9)";
+    if (strncmp(expected, msg, sizeof(expected)-1)) {
+        printf("Unexpected error: '%s'\n", msg);
+        exit(-1);
+    }
+}
+
+
+int main(int argc, char **argv) {
+
+    Func f("f"), g;
+    Var x("x"), xo, xi;
+
+    Param<int> p;
+
+    f(x) = x;
+    g(x) = f(x);
+    g.split(x, xo, xi, p);
+
+    // We need p elements of f per split of g. This could create a
+    // dynamic allocation. Instead we'll assert that 8 is enough, so
+    // that f can go on the stack and be entirely vectorized.
+    f.compute_at(g, xo).bound(x, Expr(), 8).vectorize(x);
+
+    // Check there's no malloc when the bound is good
+    g.set_custom_allocator(&my_malloc, &my_free);
+    p.set(5);
+    g.realize(20);
+    g.set_custom_allocator(nullptr, nullptr);
+
+    // Check there was an assertion failure of the appropriate type when the bound is violated
+    g.set_error_handler(&my_error);
+    p.set(10);
+    g.realize(20);
+
+
+    if (!errored) {
+        printf("There was supposed to be an error\n");
+        return -1;
+    }
+
+    printf("Success!\n");
+    return 0;
+
+}

--- a/test/correctness/force_onto_stack.cpp
+++ b/test/correctness/force_onto_stack.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
         // We need p elements of f per split of g. This could create a
         // dynamic allocation. Instead we'll assert that 8 is enough, so
         // that f can go on the stack and be entirely vectorized.
-        f.compute_at(g, xo).bound(x, Expr(), 8).vectorize(x);
+        f.compute_at(g, xo).bound_extent(x, 8).vectorize(x);
 
         // Check there's no malloc when the bound is good
         g.set_custom_allocator(&my_malloc, &my_free);
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
         f.compute_at(g, xo);
         // In the tail case, the amount of g required is min(8, some
         // nasty thing), so we'll add a bound.
-        f.bound(x, Expr(), 8);
+        f.bound_extent(x, 8);
 
         g.set_custom_allocator(&my_malloc, &my_free);
         g.realize(20);


### PR DESCRIPTION
This augments Func::bound in two ways:

1) Allocation sizes respect it, so that you can force an allocation to be a constant size. This means that bound constrains the bounds allocated as well as the bounds computed, which is a change to previous behavior.

2) The min can be undefined, which makes it possible to bound things that are compute_at somewhere.