### PR TITLE
Refactor shufflevector generation

### DIFF
--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -427,6 +427,12 @@ protected:
     /** Concatenate a bunch of llvm vectors. Must be of the same type. */
     llvm::Value *concat_vectors(const std::vector<llvm::Value *> &);
 
+    /** Create an LLVM shuffle vectors instruction. */
+    llvm::Value *shuffle_vectors(llvm::Value *a, llvm::Value *b,
+                                 const std::vector<int> &indices);
+    /** Shorthand for shuffling a vector with an undef vector. */
+    llvm::Value *shuffle_vectors(llvm::Value *v, const std::vector<int> &indices);
+
     /** Go looking for a vector version of a runtime function. Will
      * return the best match. Matches in the following order:
      *


### PR DESCRIPTION
This refactors CodeGen_LLVM's generation of shuflevector operations, which will enable backends to intercept them and replace them with more optimized instructions. It also just makes it a bit easier to do (the ConstantInt noise is moved to one place).