### PR TITLE
Camera pipe fixes and schedule improvements

### DIFF
--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -1,18 +1,12 @@
 include ../support/Makefile.inc
 
-ifeq ($(HL_TARGET),ptx)
-  SCHEDULE=100
-else
-  SCHEDULE=0
-endif
-
 all: process
 
 camera_pipe: ../../ camera_pipe.cpp
 	$(CXX) $(CXXFLAGS) camera_pipe.cpp -g $(LIB_HALIDE) -o camera_pipe $(LDFLAGS)
 
 curved.o: camera_pipe
-	./camera_pipe 8 0 # 8-bit output,
+	./camera_pipe 8 # 8-bit output,
 
 fcam/Demosaic.o: fcam/Demosaic.cpp fcam/Demosaic.h
 	$(CXX) $(CXXFLAGS) -c -Wall -O3 $< -o $@
@@ -21,7 +15,7 @@ fcam/Demosaic_ARM.o: fcam/Demosaic_ARM.cpp fcam/Demosaic_ARM.h
 	$(CXX) $(CXXFLAGS) -c -Wall -O3 $< -o $@
 
 process: process.cpp curved.o fcam/Demosaic.o fcam/Demosaic_ARM.o
-	$(CXX) $(CXXFLAGS) -Wall -O3 $^ -o $@ $(PNGFLAGS)
+	$(CXX) $(CXXFLAGS) -Wall -O3 $^ -o $@ $(PNGFLAGS) -ldl -lpthread
 
 out.png: process
 	./process ../images/bayer_raw.png 3700 2.0 50 5 out.png

--- a/apps/camera_pipe/camera_pipe.cpp
+++ b/apps/camera_pipe/camera_pipe.cpp
@@ -205,7 +205,7 @@ Func color_correct(Func input, ImageParam matrix_3200, ImageParam matrix_7000, P
     Func matrix;
     Expr alpha = (1.0f/kelvin - 1.0f/3200) / (1.0f/7000 - 1.0f/3200);
     Expr val =  (matrix_3200(x, y) * alpha + matrix_7000(x, y) * (1 - alpha));
-    matrix(x, y) = cast<int32_t>(val * 256.0f); // Q8.8 fixed point
+    matrix(x, y) = cast<int16_t>(val * 256.0f); // Q8.8 fixed point
     matrix.compute_root();
 
     Func corrected;

--- a/apps/camera_pipe/camera_pipe.cpp
+++ b/apps/camera_pipe/camera_pipe.cpp
@@ -309,9 +309,10 @@ int main(int argc, char **argv) {
     // shift things inwards to give us enough padding on the
     // boundaries so that we don't need to check bounds. We're going
     // to make a 2560x1920 output image, just like the FCam pipe, so
-    // shift by 16, 12
+    // shift by 16, 12. We also convert it to be signed, so we can deal
+    // with values that fall below 0 during processing.
     Func shifted;
-    shifted(x, y) = input(x+16, y+12);
+    shifted(x, y) = cast<int16_t>(input(x+16, y+12));
 
     // Parameterized output type, because LLVM PTX (GPU) backend does not
     // currently allow 8-bit computations


### PR DESCRIPTION
This PR changes the camera pipe so scheduling is controlled by the target, rather than a schedule parameter.

It also fixes an underflow issue where random white pixels were generated by unsigned arithmetic in the demosaic wrapping around 0. The fix is to convert the input data to be signed, which matches the C implementation.