### PR TITLE
[Hexagon] Add mul.vw.vw implementation

### DIFF
--- a/src/runtime/hvx_128.ll
+++ b/src/runtime/hvx_128.ll
@@ -95,3 +95,39 @@ define weak_odr <64 x i16> @halide.hexagon.splat.h(i16 %arg) nounwind uwtable re
   %r = bitcast <32 x i32> %r_32 to <64 x i16>
   ret <64 x i16> %r
 }
+
+declare <32 x i32> @llvm.hexagon.V6.vaslw.128B(<32 x i32>, i32)
+declare <32 x i32> @llvm.hexagon.V6.vlsrw.128B(<32 x i32>, i32)
+declare <32 x i32> @llvm.hexagon.V6.vmpyieoh.128B(<32 x i32>, <32 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vmpyiowh.128B(<32 x i32>, <32 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vmpyiewuh.128B(<32 x i32>, <32 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vaddw.128B(<32 x i32>, <32 x i32>)
+
+define weak_odr <32 x i32> @halide.hexagon.mul.vw.vw(<32 x i32> %a, <32 x i32> %b) nounwind uwtable readnone alwaysinline {
+  %ab_lo = call <32 x i32> @llvm.hexagon.V6.vmpyiewuh.128B(<32 x i32> %a, <32 x i32> %b)
+  %ab_hi = call <32 x i32> @llvm.hexagon.V6.vmpyieoh.128B(<32 x i32> %a, <32 x i32> %b)
+  %ab = call <32 x i32> @llvm.hexagon.V6.vaddw.128B(<32 x i32> %ab_hi, <32 x i32> %ab_lo)
+  ret <32 x i32> %ab
+}
+
+define weak_odr <64 x i32> @halide.hexagon.mul.vw.vh(<64 x i32> %a, <64 x i16> %b) nounwind uwtable readnone alwaysinline {
+  %a_lo = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %a)
+  %a_hi = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %a)
+  %b_hi = bitcast <64 x i16> %b to <32 x i32>
+  %b_lo = call <32 x i32> @llvm.hexagon.V6.vaslw.128B(<32 x i32> %b_hi, i32 16)
+  %ab_lo = call <32 x i32> @llvm.hexagon.V6.vmpyiowh.128B(<32 x i32> %a_lo, <32 x i32> %b_lo)
+  %ab_hi = call <32 x i32> @llvm.hexagon.V6.vmpyiowh.128B(<32 x i32> %a_hi, <32 x i32> %b_hi)
+  %ab = call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %ab_hi, <32 x i32> %ab_lo)
+  ret <64 x i32> %ab
+}
+
+define weak_odr <64 x i32> @halide.hexagon.mul.vw.vuh(<64 x i32> %a, <64 x i16> %b) nounwind uwtable readnone alwaysinline {
+  %a_lo = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %a)
+  %a_hi = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %a)
+  %b_lo = bitcast <64 x i16> %b to <32 x i32>
+  %b_hi = call <32 x i32> @llvm.hexagon.V6.vlsrw.128B(<32 x i32> %b_lo, i32 16)
+  %ab_lo = call <32 x i32> @llvm.hexagon.V6.vmpyiewuh.128B(<32 x i32> %a_lo, <32 x i32> %b_lo)
+  %ab_hi = call <32 x i32> @llvm.hexagon.V6.vmpyiewuh.128B(<32 x i32> %a_hi, <32 x i32> %b_hi)
+  %ab = call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %ab_hi, <32 x i32> %ab_lo)
+  ret <64 x i32> %ab
+}

--- a/src/runtime/hvx_64.ll
+++ b/src/runtime/hvx_64.ll
@@ -95,3 +95,40 @@ define weak_odr <32 x i16> @halide.hexagon.splat.h(i16 %arg) nounwind uwtable re
   %r = bitcast <16 x i32> %r_32 to <32 x i16>
   ret <32 x i16> %r
 }
+
+declare <16 x i32> @llvm.hexagon.V6.vaslw(<16 x i32>, i32)
+declare <16 x i32> @llvm.hexagon.V6.vlsrw(<16 x i32>, i32)
+declare <16 x i32> @llvm.hexagon.V6.vmpyieoh(<16 x i32>, <16 x i32>)
+declare <16 x i32> @llvm.hexagon.V6.vmpyiowh(<16 x i32>, <16 x i32>)
+declare <16 x i32> @llvm.hexagon.V6.vmpyiewuh(<16 x i32>, <16 x i32>)
+declare <16 x i32> @llvm.hexagon.V6.vaddw(<16 x i32>, <16 x i32>)
+
+define weak_odr <16 x i32> @halide.hexagon.mul.vw.vw(<16 x i32> %a, <16 x i32> %b) nounwind uwtable readnone alwaysinline {
+  %ab_lo = call <16 x i32> @llvm.hexagon.V6.vmpyiewuh(<16 x i32> %a, <16 x i32> %b)
+  %ab_hi = call <16 x i32> @llvm.hexagon.V6.vmpyieoh(<16 x i32> %a, <16 x i32> %b)
+  %ab = call <16 x i32> @llvm.hexagon.V6.vaddw(<16 x i32> %ab_hi, <16 x i32> %ab_lo)
+  ret <16 x i32> %ab
+}
+
+define weak_odr <32 x i32> @halide.hexagon.mul.vw.vh(<32 x i32> %a, <32 x i16> %b) nounwind uwtable readnone alwaysinline {
+  %a_lo = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %a)
+  %a_hi = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %a)
+  %b_hi = bitcast <32 x i16> %b to <16 x i32>
+  %b_lo = call <16 x i32> @llvm.hexagon.V6.vaslw(<16 x i32> %b_hi, i32 16)
+  %ab_lo = call <16 x i32> @llvm.hexagon.V6.vmpyiowh(<16 x i32> %a_lo, <16 x i32> %b_lo)
+  %ab_hi = call <16 x i32> @llvm.hexagon.V6.vmpyiowh(<16 x i32> %a_hi, <16 x i32> %b_hi)
+  %ab = call <32 x i32> @llvm.hexagon.V6.vcombine(<16 x i32> %ab_hi, <16 x i32> %ab_lo)
+  ret <32 x i32> %ab
+}
+
+define weak_odr <32 x i32> @halide.hexagon.mul.vw.vuh(<32 x i32> %a, <32 x i16> %b) nounwind uwtable readnone alwaysinline {
+  %a_lo = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %a)
+  %a_hi = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %a)
+  %b_lo = bitcast <32 x i16> %b to <16 x i32>
+  %b_hi = call <16 x i32> @llvm.hexagon.V6.vlsrw(<16 x i32> %b_lo, i32 16)
+  %ab_lo = call <16 x i32> @llvm.hexagon.V6.vmpyiewuh(<16 x i32> %a_lo, <16 x i32> %b_lo)
+  %ab_hi = call <16 x i32> @llvm.hexagon.V6.vmpyiewuh(<16 x i32> %a_hi, <16 x i32> %b_hi)
+  %ab = call <32 x i32> @llvm.hexagon.V6.vcombine(<16 x i32> %ab_hi, <16 x i32> %ab_lo)
+  ret <32 x i32> %ab
+}
+

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1570,6 +1570,7 @@ void check_hvx_all() {
     check("vmpy(v*.uh,v*.uh)", hvx_width/2, u32(u16_1) * u32(u16_2));
     check("vmpy(v*.h,v*.h)", hvx_width/2, i32(i16_1) * i32(i16_2));
     check("vmpyi(v*.h,v*.h)", hvx_width/2, i16_1 * i16_2);
+    check("vmpyieo(v*.h,v*.h)", hvx_width/4, i32_1 * i32_2);
     // The inconsistency in the expected instructions here is
     // correct. For bytes, the unsigned value is first, for half
     // words, the signed value is first.


### PR DESCRIPTION
Although I ended up not needing this for camera pipe, I got far enough with it to see that it wouldn't be too hard to finish them.

Note that while I tested the 32 x 16 bit multiplies, there's no patterns for them currently. They're difficult to expose because they start catching lots of other multiplies that should fall through to CodeGen_Hexagon. Fixing this is going to require a refactoring at some point. But, the mul.vw.vw gets used currently.