### PR TITLE
Add align_storage directive

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1100,14 +1100,14 @@ Func &Func::glsl(Var x, Var y, Var c) {
 Func &Func::reorder_storage(Var x, Var y) {
     invalidate_cache();
 
-    vector<string> &dims = func.schedule().storage_dims();
+    vector<StorageDim> &dims = func.schedule().storage_dims();
     bool found_y = false;
     size_t y_loc = 0;
     for (size_t i = 0; i < dims.size(); i++) {
-        if (var_name_match(dims[i], y.name())) {
+        if (var_name_match(dims[i].var, y.name())) {
             found_y = true;
             y_loc = i;
-        } else if (var_name_match(dims[i], x.name())) {
+        } else if (var_name_match(dims[i].var, x.name())) {
             if (found_y) std::swap(dims[i], dims[y_loc]);
             return *this;
         }
@@ -1134,6 +1134,21 @@ Func &Func::reorder_storage(const std::vector<Var> &dims) {
         "reorder_storage must have at least two dimensions in reorder list.\n";
 
     return reorder_storage(dims, 0);
+}
+
+Func &Func::align_storage(Var dim, Expr alignment) {
+    invalidate_cache();
+
+    vector<StorageDim> &dims = func.schedule().storage_dims();
+    for (size_t i = 0; i < dims.size(); i++) {
+        if (var_name_match(dims[i].var, dim.name())) {
+            dims[i].alignment = alignment;
+            return *this;
+        }
+    }
+    user_error << "Could not find variable " << dim.name()
+               << " to align the storage of.\n";
+    return *this;
 }
 
 Func &Func::compute_at(Func f, RVar var) {

--- a/src/Func.h
+++ b/src/Func.h
@@ -1209,16 +1209,15 @@ public:
     }
     // @}
 
-    /** Align the storage extent of a particular dimension of
-     * realizations of this func. Strides of internal allocations for
-     * realizations of functions are computed to densely store the
-     * realization in memory. This function allows you to tell Halide
-     * to pad a particular dimension up to a multiple of the
-     * alignment, which guarantees that the strides for the dimensions
-     * stored outside of dim will be aligned to the specified
-     * alignment. For example, to guarantee that a func
-     * foo(x, y, c) has scanlines which start on multiples of 16, use
-     * foo.align_storage(x, 16). */
+    /** Pad the storage extent of a particular dimension of
+     * realizations of this function up to be a multiple of the
+     * specified alignment. This guarantees that the strides for the
+     * dimensions stored outside of dim will be multiples of the
+     * specified alignment.
+     *
+     * For example, to guarantee that a function foo(x, y, c)
+     * representing an image has scanlines starting on memory offsets
+     * aligned to multiples of 16, use foo.align_storage(x, 16). */
     EXPORT Func &align_storage(Var dim, Expr alignment);
 
     /** Compute this function as needed for each unique value of the

--- a/src/Func.h
+++ b/src/Func.h
@@ -1209,6 +1209,18 @@ public:
     }
     // @}
 
+    /** Align the storage extent of a particular dimension of
+     * realizations of this func. Strides of internal allocations for
+     * realizations of functions are computed to densely store the
+     * realization in memory. This function allows you to tell Halide
+     * to pad a particular dimension up to a multiple of the
+     * alignment, which guarantees that the strides for the dimensions
+     * stored outside of dim will be aligned to the specified
+     * alignment. For example, to guarantee that a func
+     * foo(x, y, c) has scanlines which start on multiples of 16, use
+     * foo.align_storage(x, 16). */
+    EXPORT Func &align_storage(Var dim, Expr alignment);
+
     /** Compute this function as needed for each unique value of the
      * given var for the given calling function f.
      *

--- a/src/Func.h
+++ b/src/Func.h
@@ -1214,7 +1214,7 @@ public:
      * specified alignment. This guarantees that the strides for the
      * dimensions stored outside of dim will be multiples of the
      * specified alignment, where the strides and alignment are
-     * described as numbers of elements.
+     * measured in numbers of elements.
      *
      * For example, to guarantee that a function foo(x, y, c)
      * representing an image has scanlines starting on offsets

--- a/src/Func.h
+++ b/src/Func.h
@@ -1213,10 +1213,11 @@ public:
      * realizations of this function up to be a multiple of the
      * specified alignment. This guarantees that the strides for the
      * dimensions stored outside of dim will be multiples of the
-     * specified alignment.
+     * specified alignment, where the strides and alignment are
+     * described as numbers of elements.
      *
      * For example, to guarantee that a function foo(x, y, c)
-     * representing an image has scanlines starting on memory offsets
+     * representing an image has scanlines starting on offsets
      * aligned to multiples of 16, use foo.align_storage(x, 16). */
     EXPORT Func &align_storage(Var dim, Expr alignment);
 

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -305,7 +305,8 @@ void Function::define(const vector<string> &args, vector<Expr> values) {
     for (size_t i = 0; i < args.size(); i++) {
         Dim d = {args[i], ForType::Serial, DeviceAPI::Parent, true};
         contents.ptr->schedule.dims().push_back(d);
-        contents.ptr->schedule.storage_dims().push_back(args[i]);
+        StorageDim sd = {args[i]};
+        contents.ptr->schedule.storage_dims().push_back(sd);
     }
 
     // Add the dummy outermost dim
@@ -550,7 +551,8 @@ void Function::define_extern(const std::string &function_name,
     for (int i = 0; i < dimensionality; i++) {
         string arg = unique_name('e');
         contents.ptr->args[i] = arg;
-        contents.ptr->schedule.storage_dims().push_back(arg);
+        StorageDim sd = {arg};
+        contents.ptr->schedule.storage_dims().push_back(sd);
     }
 }
 

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -14,7 +14,7 @@ struct ScheduleContents {
     LoopLevel store_level, compute_level;
     std::vector<Split> splits;
     std::vector<Dim> dims;
-    std::vector<std::string> storage_dims;
+    std::vector<StorageDim> storage_dims;
     std::vector<Bound> bounds;
     std::vector<Specialization> specializations;
     ReductionDomain reduction_domain;
@@ -70,11 +70,11 @@ const std::vector<Dim> &Schedule::dims() const {
     return contents.ptr->dims;
 }
 
-std::vector<std::string> &Schedule::storage_dims() {
+std::vector<StorageDim> &Schedule::storage_dims() {
     return contents.ptr->storage_dims;
 }
 
-const std::vector<std::string> &Schedule::storage_dims() const {
+const std::vector<StorageDim> &Schedule::storage_dims() const {
     return contents.ptr->storage_dims;
 }
 

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -152,6 +152,11 @@ struct Specialization {
     IntrusivePtr<ScheduleContents> schedule;
 };
 
+struct StorageDim {
+    std::string var;
+    Expr alignment;
+};
+
 class ReductionDomain;
 
 /** A schedule for a single stage of a Halide pipeline. Right now this
@@ -211,8 +216,8 @@ public:
      * innermost dimension for storage (i.e. which dimension is
      * tightly packed in memory) */
     // @{
-    const std::vector<std::string> &storage_dims() const;
-    std::vector<std::string> &storage_dims();
+    const std::vector<StorageDim> &storage_dims() const;
+    std::vector<StorageDim> &storage_dims();
     // @}
 
     /** You may explicitly bound some of the dimensions of a

--- a/test/correctness/reorder_storage.cpp
+++ b/test/correctness/reorder_storage.cpp
@@ -3,6 +3,20 @@
 
 using namespace Halide;
 
+size_t expected_allocation = 0;
+
+void *my_malloc(void *user_context, size_t x) {
+    if (x != expected_allocation) {
+        printf("Error! Expected allocation of %zu bytes, got %zu bytes\n", expected_allocation, x);
+        exit(-1);
+    }
+    return malloc(x);
+}
+
+void my_free(void *user_context, void *ptr) {
+    free(ptr);
+}
+
 int main(int argc, char **argv) {
     Var x, y, c;
     Func f("f"), g;
@@ -10,13 +24,28 @@ int main(int argc, char **argv) {
     f(x, y, c) = 1;
     g(x, y, c) = f(x, y, c);
 
-    // Store the intermediate with color channels innermost
     f.compute_root().reorder_storage(c, x, y);
+    g.set_custom_allocator(my_malloc, my_free);
 
-    Image<int> im = g.realize(10, 10, 3);
+    // Without any storage alignment, we should expect an allocation
+    // that is the product of the extents of the realization (plus one
+    // for the magical extra Halide element).
+    int W = 10;
+    int H = 11;
+    expected_allocation = (3*W*H + 1)*sizeof(int);
 
-    // The strides should be invisible to the front-end, so the only
-    // way to check this is to read the output with HL_DEBUG_CODEGEN=1
+    g.realize(W, H, 3);
+
+    int x_alignment = 16;
+    f.align_storage(x, x_alignment);
+
+    // We've aligned the x dimension, make sure the allocation reflects this.
+    int W_aligned = (W + x_alignment - 1) & ~(x_alignment - 1);
+    expected_allocation = (W_aligned*H*3 + 1)*sizeof(int);
+
+    // Force g to clear it's cache...
+    g.compute_root();
+    g.realize(W, H, 3);
 
     printf("Success!\n");
     return 0;


### PR DESCRIPTION
This PR adds a scheduling directive which allows the user to pad an internal allocation up to a specified alignment. This is useful for architectures that have strong alignment requirements for efficient memory access.