### PR TITLE
Add -fvisibility=hidden flag to OS X apps/ builds

### DIFF
--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -13,7 +13,7 @@ CXX ?= g++
 GXX ?= g++
 
 CFLAGS += -I $(HALIDE_BIN_PATH)/include/ -I $(HALIDE_SRC_PATH)/tools/ -I $(HALIDE_SRC_PATH)/apps/support/
-CXXFLAGS += -std=c++11 -I $(HALIDE_BIN_PATH)/include/ -I $(HALIDE_SRC_PATH)/tools/ -I $(HALIDE_SRC_PATH)/apps/support/ -fvisibility=hidden
+CXXFLAGS += -std=c++11 -I $(HALIDE_BIN_PATH)/include/ -I $(HALIDE_SRC_PATH)/tools/ -I $(HALIDE_SRC_PATH)/apps/support/ 
 
 ifeq ($(UNAME), Darwin)
 CXXFLAGS += -fvisibility=hidden

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -13,7 +13,11 @@ CXX ?= g++
 GXX ?= g++
 
 CFLAGS += -I $(HALIDE_BIN_PATH)/include/ -I $(HALIDE_SRC_PATH)/tools/ -I $(HALIDE_SRC_PATH)/apps/support/
-CXXFLAGS += -std=c++11 -I $(HALIDE_BIN_PATH)/include/ -I $(HALIDE_SRC_PATH)/tools/ -I $(HALIDE_SRC_PATH)/apps/support/
+CXXFLAGS += -std=c++11 -I $(HALIDE_BIN_PATH)/include/ -I $(HALIDE_SRC_PATH)/tools/ -I $(HALIDE_SRC_PATH)/apps/support/ -fvisibility=hidden
+
+ifeq ($(UNAME), Darwin)
+CXXFLAGS += -fvisibility=hidden
+endif
 
 LIB_HALIDE = $(HALIDE_BIN_PATH)/lib/libHalide.a
 


### PR DESCRIPTION
This removes a large number of harmless-but-annoying warnings when building test_apps for OS X