### PR TITLE
Remove halide_image_info includes

### DIFF
--- a/tools/halide_image.h
+++ b/tools/halide_image.h
@@ -228,5 +228,4 @@ public:
 }  // namespace Tools
 }  // namespace Halide
 
-#include "halide_image_info.h"
 #endif  // HALIDE_TOOLS_IMAGE_H

--- a/tools/halide_image_info.h
+++ b/tools/halide_image_info.h
@@ -22,6 +22,8 @@
 
 #include "HalideRuntime.h"
 
+#include "halide_image.h"
+
 namespace Halide {
 namespace Tools {
 


### PR DESCRIPTION
halide_image_info.h is quietly included at the *end* of halide_image.h,
which is just an abomination. Remove this, and require clients who want
halide_image_info.h to explicitly include it instead. (Add the
appropriate include of halide_image.h to the top of
halide_image_info.h.)