### PR TITLE
Don't propagate device APIs to parent loops

### DIFF
--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -804,7 +804,7 @@ Stmt bounds_inference(Stmt s,
     }
 
     // Add an outermost bounds inference marker
-    s = For::make("<outermost>", 0, 1, ForType::Serial, DeviceAPI::Parent, s);
+    s = For::make("<outermost>", 0, 1, ForType::Serial, DeviceAPI::None, s);
     s = BoundsInference(funcs, outputs, func_bounds).mutate(s);
     return s.as<For>()->body;
 }

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -259,7 +259,7 @@ struct ExprCompare {
 /** An enum describing a type of device API. Used by schedules, and in
  * the For loop IR node. */
 enum class DeviceAPI {
-    Parent, /// Used to denote for loops that inherit their device from where they are used, generally the default
+    None, /// Used to denote for loops that run on the same device as the containing code.
     Host,
     Default_GPU,
     CUDA,
@@ -272,7 +272,7 @@ enum class DeviceAPI {
 
 /** An array containing all the device apis. Useful for iterating
  * through them. */
-const DeviceAPI all_device_apis[] = {DeviceAPI::Parent,
+const DeviceAPI all_device_apis[] = {DeviceAPI::None,
                                      DeviceAPI::Host,
                                      DeviceAPI::Default_GPU,
                                      DeviceAPI::CUDA,

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -303,7 +303,7 @@ void Function::define(const vector<string> &args, vector<Expr> values) {
     }
 
     for (size_t i = 0; i < args.size(); i++) {
-        Dim d = {args[i], ForType::Serial, DeviceAPI::Parent, true};
+        Dim d = {args[i], ForType::Serial, DeviceAPI::None, true};
         contents.ptr->schedule.dims().push_back(d);
         StorageDim sd = {args[i]};
         contents.ptr->schedule.storage_dims().push_back(sd);
@@ -311,7 +311,7 @@ void Function::define(const vector<string> &args, vector<Expr> values) {
 
     // Add the dummy outermost dim
     {
-        Dim d = {Var::outermost().name(), ForType::Serial, DeviceAPI::Parent, true};
+        Dim d = {Var::outermost().name(), ForType::Serial, DeviceAPI::None, true};
         contents.ptr->schedule.dims().push_back(d);
     }
 
@@ -481,7 +481,7 @@ void Function::define_update(const vector<Expr> &_args, vector<Expr> values) {
 
             bool pure = can_parallelize_rvar(v, name(), r);
 
-            Dim d = {v, ForType::Serial, DeviceAPI::Parent, pure};
+            Dim d = {v, ForType::Serial, DeviceAPI::None, pure};
             r.schedule.dims().push_back(d);
         }
     }
@@ -489,14 +489,14 @@ void Function::define_update(const vector<Expr> &_args, vector<Expr> values) {
     // Then add the pure args outside of that
     for (size_t i = 0; i < pure_args.size(); i++) {
         if (!pure_args[i].empty()) {
-            Dim d = {pure_args[i], ForType::Serial, DeviceAPI::Parent, true};
+            Dim d = {pure_args[i], ForType::Serial, DeviceAPI::None, true};
             r.schedule.dims().push_back(d);
         }
     }
 
     // Then the dummy outermost dim
     {
-        Dim d = {Var::outermost().name(), ForType::Serial, DeviceAPI::Parent, true};
+        Dim d = {Var::outermost().name(), ForType::Serial, DeviceAPI::None, true};
         r.schedule.dims().push_back(d);
     }
 

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -749,7 +749,7 @@ class ZeroGPULoopMins : public IRMutator {
     void visit(const For *op) {
         bool old_in_non_glsl_gpu = in_non_glsl_gpu;
 
-        in_non_glsl_gpu = (in_non_glsl_gpu && op->device_api == DeviceAPI::Parent) ||
+        in_non_glsl_gpu = (in_non_glsl_gpu && op->device_api == DeviceAPI::None) ||
           (op->device_api == DeviceAPI::CUDA) || (op->device_api == DeviceAPI::OpenCL) ||
           (op->device_api == DeviceAPI::Metal);
 

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -60,9 +60,7 @@ ostream &operator<<(ostream &stream, const Module &m) {
 ostream &operator<<(ostream &out, const DeviceAPI &api) {
     switch (api) {
     case DeviceAPI::Host:
-        break;
     case DeviceAPI::Parent:
-        out << "<Parent>";
         break;
     case DeviceAPI::Default_GPU:
         out << "<Default_GPU>";

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -60,7 +60,7 @@ ostream &operator<<(ostream &stream, const Module &m) {
 ostream &operator<<(ostream &out, const DeviceAPI &api) {
     switch (api) {
     case DeviceAPI::Host:
-    case DeviceAPI::Parent:
+    case DeviceAPI::None:
         break;
     case DeviceAPI::Default_GPU:
         out << "<Default_GPU>";

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -206,7 +206,7 @@ private:
 
     void visit(const For *op) {
         // We profile by storing a token to global memory, so don't enter GPU loops
-        if (op->device_api == DeviceAPI::Parent ||
+        if (op->device_api == DeviceAPI::None ||
             op->device_api == DeviceAPI::Host) {
             IRMutator::visit(op);
         } else {

--- a/src/SelectGPUAPI.cpp
+++ b/src/SelectGPUAPI.cpp
@@ -12,13 +12,9 @@ class SelectGPUAPI : public IRMutator {
     DeviceAPI default_api, parent_api;
 
     void visit(const For *op) {
-        DeviceAPI selected_api;
+        DeviceAPI selected_api = op->device_api;
         if (op->device_api == DeviceAPI::Default_GPU) {
             selected_api = default_api;
-        } else if (op->device_api == DeviceAPI::Parent) {
-            selected_api = parent_api;
-        } else {
-            selected_api = op->device_api;
         }
 
         DeviceAPI old_parent_api = parent_api;

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -456,7 +456,7 @@ bool Target::supported() const {
 
 bool Target::supports_device_api(DeviceAPI api) const {
     switch (api) {
-    case DeviceAPI::Parent:      return true;
+    case DeviceAPI::None:        return true;
     case DeviceAPI::Host:        return true;
     case DeviceAPI::Default_GPU: return has_gpu_feature();
     default:                     return has_feature(target_feature_for_device_api(api));

--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -104,7 +104,7 @@ protected:
         bool old_in_glsl_loops = in_glsl_loops;
         // Check if the loop variable is a GPU variable thread variable and for GLSL
         if ((CodeGen_GPU_Dev::is_gpu_var(op->name) && op->device_api == DeviceAPI::GLSL) ||
-            (in_glsl_loops && op->device_api == DeviceAPI::Parent)) {
+            (in_glsl_loops && op->device_api == DeviceAPI::None)) {
             loop_vars.push_back(op->name);
             in_glsl_loops = true;
         }
@@ -1050,7 +1050,7 @@ public:
             // Add a let statement for the for-loop name variable
             Stmt loop_var = LetStmt::make(op->name, coord_expr, mutated_body);
 
-            stmt = For::make(name, 0, (int)dim.size(), ForType::Serial, DeviceAPI::Parent, loop_var);
+            stmt = For::make(name, 0, (int)dim.size(), ForType::Serial, DeviceAPI::None, loop_var);
 
         } else {
             IRFilter::visit(op);


### PR DESCRIPTION
I think that only loops that are directly involved in GPU scheduling should be explicitly marked as such, and that regular loops in the body of GPU kernels should remain "Parent" loops.

The motivation for this is that many optimizations need to respect GPU loops, and when all loops that run on a GPU are labelled GPU loops, the optimizations can't run, even though the loop has nothing to do with GPU scheduling.