### PR TITLE
Align allocation sizes in addition to pointers.

### DIFF
--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -10,8 +10,12 @@ extern void free(void *);
 namespace Halide { namespace Runtime { namespace Internal {
 
 WEAK void *default_malloc(void *user_context, size_t x) {
-    // Allocate enough space for aligning the pointer we return.
     const size_t alignment = 128;
+
+    // The size should also be aligned.
+    x = (x + alignment - 1) & ~(alignment - 1);
+
+    // Allocate enough space for aligning the pointer we return.
     void *orig = malloc(x + alignment);
     if (orig == NULL) {
         // Will result in a failed assertion and a call to halide_error


### PR DESCRIPTION
Code that depends on the address of a pointer being aligned also often relies on the size of the buffer being aligned. This PR changes halide_malloc to align the size of the buffers, in addition to the pointer to the buffer.