### PR TITLE
[Hexagon] Use vlut for shuffles, LUTs, and boundary conditions

### DIFF
--- a/apps/HelloHexagon/Makefile
+++ b/apps/HelloHexagon/Makefile
@@ -26,16 +26,20 @@ pipeline_cpu-%.o: pipeline
 	HL_TARGET=$* ./pipeline pipeline_cpu-$* pipeline_cpu
 
 pipeline_hvx64-%.o: pipeline
-	HL_TARGET=$*-debug-hvx_64 ./pipeline pipeline_hvx64-$* pipeline_hvx64
+	HL_TARGET=$*-hvx_64 ./pipeline pipeline_hvx64-$* pipeline_hvx64
 
 process-%: process.cpp pipeline_cpu-%.o pipeline_hvx64-%.o
 	$(CXX-$*) $(CXXFLAGS) $(CXXFLAGS-$*) -Wall -O3 process.cpp pipeline_cpu-$*.o pipeline_hvx64-$*.o -o process-$* $(LDFLAGS-$*)
 
-run-%: process-%
-	adb push process-$* /data/
-	adb shell chmod +x /data/process-$*
-	adb shell /data/process-$* cpu
-	adb shell /data/process-$* hvx64
+run-%-android: process-%-android
+	adb push process-$*-android /data/
+	adb shell chmod +x /data/process-$*-android
+	adb shell /data/process-$*-android cpu 10
+	adb shell /data/process-$*-android hvx64 10
+
+run-host: process-host
+	./process-host cpu 10
+	./process-host hvx64 1
 
 clean:
 	rm -f process-* pipeline-*.o pipeline pipeline.h

--- a/apps/HelloHexagon/pipeline.cpp
+++ b/apps/HelloHexagon/pipeline.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
         Var xo("xo"), xi("xi");
         blur.compute_root()
             .hexagon()
-            .split(x, xo, xi, vector_size, TailStrategy::RoundUp)
+            .split(x, xo, xi, vector_size*2, TailStrategy::RoundUp)
             .vectorize(xi, vector_size)
             .parallel(y, 16);
         blur_y.compute_at(blur, xo)

--- a/apps/HelloHexagon/pipeline.cpp
+++ b/apps/HelloHexagon/pipeline.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
         Var xo("xo"), xi("xi");
         blur.compute_root()
             .hexagon()
-            .split(x, xo, xi, vector_size*4, TailStrategy::RoundUp)
+            .split(x, xo, xi, vector_size, TailStrategy::RoundUp)
             .vectorize(xi, vector_size)
             .parallel(y, 16);
         blur_y.compute_at(blur, xo)

--- a/apps/HelloHexagon/process.cpp
+++ b/apps/HelloHexagon/process.cpp
@@ -33,6 +33,11 @@ T clamp(T x, T min, T max) {
 }
 
 int main(int argc, char **argv) {
+    if (argc < 3) {
+        printf("Usage: %s (cpu|hvx64) timing_iterations\n", argv[0]);
+        return 0;
+    }
+
     int (*pipeline)(buffer_t *, buffer_t*);
     if (strcmp(argv[1], "cpu") == 0) {
         pipeline = pipeline_cpu;
@@ -44,6 +49,8 @@ int main(int argc, char **argv) {
         printf("Unknown schedule, valid schedules are cpu or hvx64\n");
         return -1;
     }
+
+    int iterations = atoi(argv[2]);
 
     const int W = 1024;
     const int H = 1024;
@@ -72,7 +79,7 @@ int main(int argc, char **argv) {
     }
 
     printf("Running pipeline...\n");
-    double time = benchmark(10, 10, [&]() {
+    double time = benchmark(iterations, 10, [&]() {
         int result = pipeline(&in, &out);
         if (result != 0) {
             printf("pipeline failed! %d\n", result);

--- a/src/AlignLoads.cpp
+++ b/src/AlignLoads.cpp
@@ -62,13 +62,11 @@ private:
         int lanes = ramp->lanes;
         int native_lanes = required_alignment / op->type.bytes();
 
-        if (!(*const_stride == 1 || *const_stride == 2)) {
-            // If the ramp isn't stride 1 or 2, don't handle it.
+        if (!(*const_stride == 1 || *const_stride == 2 || *const_stride == 3)) {
+            // If the ramp isn't stride 1, 2, or 3, don't handle it.
 
             // TODO: We should handle reverse vector loads (stride ==
-            // -1), maybe others as well. Stride 3 might be
-            // particularly important. The code below probably handles
-            // stride 3 already.
+            // -1), maybe others as well.
             IRMutator::visit(op);
             return;
         }

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -101,6 +101,10 @@ void CodeGen_Hexagon::compile_func(const LoweredFunc &f,
 
     Stmt body = f.body;
 
+    debug(1) << "Optimizing shuffles...\n";
+    body = optimize_hexagon_shuffles(body);
+    debug(2) << "Lowering after optimizing shuffles:\n" << body << "\n\n";
+
     debug(1) << "Aligning loads for HVX....\n";
     body = align_loads(body, target.natural_vector_size(Int(8)));
     body = common_subexpression_elimination(body);
@@ -118,8 +122,8 @@ void CodeGen_Hexagon::compile_func(const LoweredFunc &f,
     debug(2) << "Lowering after eliminating boolean vectors: " << body << "\n\n";
 
     // Optimize the IR for Hexagon.
-    debug(1) << "Optimizing Hexagon code...\n";
-    body = optimize_hexagon(body);
+    debug(1) << "Optimizing Hexagon instructions...\n";
+    body = optimize_hexagon_instructions(body);
 
     if (uses_hvx(body)) {
         debug(1) << "Adding calls to qurt_hvx_lock...\n";
@@ -219,6 +223,8 @@ void CodeGen_Hexagon::init_module() {
         { IPICK(Intrinsic::hexagon_V6_vpackwuh_sat), u16x1, "pack_satuh.vw", {i32x2} },
         { IPICK(Intrinsic::hexagon_V6_vpackhb_sat),  i8x1,  "pack_satb.vh",  {i16x2} },
         { IPICK(Intrinsic::hexagon_V6_vpackwh_sat),  i16x1, "pack_sath.vw",  {i32x2} },
+        { IPICK(Intrinsic::hexagon_V6_vpackeb),      i8x1,  "pack.vh",       {i16x2} },
+        { IPICK(Intrinsic::hexagon_V6_vpackeh),      i16x1, "pack.vw",       {i32x2} },
 
         // Adds/subtracts:
         // Note that we just use signed arithmetic for unsigned

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1224,6 +1224,15 @@ void CodeGen_Hexagon::visit(const Call *op) {
                                 instr + type_suffix(op->args[0], b),
                                 {op->args[0], b});
             return;
+        } else if (op->is_intrinsic("dynamic_shuffle")) {
+            internal_assert(op->args.size() == 4);
+            const int64_t *min_index = as_const_int(op->args[2]);
+            const int64_t *max_index = as_const_int(op->args[3]);
+            internal_assert(min_index && max_index);
+            Value *lut = codegen(op->args[0]);
+            Value *idx = codegen(op->args[1]);
+            value = vlut(lut, idx, *min_index, *max_index);
+            return;
         }
     }
     CodeGen_Posix::visit(op);

--- a/src/CodeGen_Hexagon.h
+++ b/src/CodeGen_Hexagon.h
@@ -107,7 +107,7 @@ protected:
 
     /** Generate a LUT lookup using vlut instructions. */
     ///@{
-    llvm::Value *vlut(llvm::Value *lut, llvm::Value *indices);
+    llvm::Value *vlut(llvm::Value *lut, llvm::Value *indices, int min_index, int max_index);
     llvm::Value *vlut(llvm::Value *lut, const std::vector<int> &indices);
     ///@}
 

--- a/src/CodeGen_Hexagon.h
+++ b/src/CodeGen_Hexagon.h
@@ -105,6 +105,12 @@ protected:
                                  const std::vector<int> &indices);
     ///@}
 
+    /** Generate a LUT lookup using vlut instructions. */
+    ///@{
+    llvm::Value *vlut(llvm::Value *lut, llvm::Value *indices);
+    llvm::Value *vlut(llvm::Value *lut, const std::vector<int> &indices);
+    ///@}
+
     /** Because HVX intrinsics operate on vectors of i32, using them
      * requires a lot of extraneous bitcasts, which make it difficult
      * to manipulate the IR. This function avoids generating redundant

--- a/src/CodeGen_Hexagon.h
+++ b/src/CodeGen_Hexagon.h
@@ -57,8 +57,8 @@ protected:
 
     using CodeGen_Posix::visit;
 
-    /* /\** Nodes for which we want to emit specific hexagon intrinsics *\/ */
-    /* // @{ */
+    /** Nodes for which we want to emit specific hexagon intrinsics */
+    ///@{
     void visit(const Add *);
     void visit(const Sub *);
     void visit(const Broadcast *);
@@ -75,7 +75,7 @@ protected:
     void visit(const GT *);
     void visit(const EQ *);
     void visit(const Select *);
-    /* // @} */
+    ///@}
 
     /** Call an LLVM intrinsic, potentially casting the operands to
      * match the type of the function. */
@@ -103,11 +103,12 @@ protected:
     llvm::Value *interleave_vectors(const std::vector<llvm::Value *> &v);
     llvm::Value *shuffle_vectors(llvm::Value *a, llvm::Value *b,
                                  const std::vector<int> &indices);
+    using CodeGen_Posix::shuffle_vectors;
     ///@}
 
     /** Generate a LUT lookup using vlut instructions. */
     ///@{
-    llvm::Value *vlut(llvm::Value *lut, llvm::Value *indices, int min_index, int max_index);
+    llvm::Value *vlut(llvm::Value *lut, llvm::Value *indices, int min_index = 0, int max_index = 1 << 30);
     llvm::Value *vlut(llvm::Value *lut, const std::vector<int> &indices);
     ///@}
 

--- a/src/CodeGen_Hexagon.h
+++ b/src/CodeGen_Hexagon.h
@@ -77,6 +77,12 @@ protected:
     void visit(const Select *);
     ///@}
 
+    /** We ask for an extra vector on each allocation to enable fast
+     * clamped ramp loads. */
+    int allocation_padding(Type type) const {
+        return CodeGen_Posix::allocation_padding(type) + native_vector_bits()/8;
+    }
+
     /** Call an LLVM intrinsic, potentially casting the operands to
      * match the type of the function. */
     ///@{

--- a/src/CodeGen_Posix.h
+++ b/src/CodeGen_Posix.h
@@ -30,6 +30,12 @@ protected:
     void visit(const Free *);
     // @}
 
+    /** It can be convenient for backends to assume there is extra
+     * padding beyond the end of a buffer to enable faster
+     * loads/stores. This function gets the padding required by the
+     * implementing target. */
+    virtual int allocation_padding(Type type) const;
+
     /** A struct describing heap or stack allocations. */
     struct Allocation {
         /** The memory */

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -894,7 +894,7 @@ class OptimizeShuffles : public IRMutator {
         if (is_one(simplify(index_span < 256))) {
             // This is a lookup within an up to 256 element array. We
             // can use dynamic_shuffle for this.
-            int const_extent = as_const_int(index_span) ? *as_const_int(index_span) : 256;
+            int const_extent = as_const_int(index_span) ? *as_const_int(index_span) + 1 : 256;
             Expr base = index_bounds.min;
 
             // Load all of the possible indices loaded from the LUT.

--- a/src/HexagonOptimize.h
+++ b/src/HexagonOptimize.h
@@ -10,12 +10,16 @@
 namespace Halide {
 namespace Internal {
 
+/** Replace indirect and other loads with simple loads + vlut
+ * calls. */
+EXPORT Stmt optimize_hexagon_shuffles(Stmt s);
+
 /** Hexagon deinterleaves when performing widening operations, and
  * interleaves when performing narrowing operations. This pass
  * rewrites widenings/narrowings to be explicit in the IR, and
  * attempts to simplify away most of the
  * interleaving/deinterleaving. */
-EXPORT Stmt optimize_hexagon(Stmt s);
+EXPORT Stmt optimize_hexagon_instructions(Stmt s);
 
 /** Generate deinterleave or interleave operations, operating on
  * groups of vectors at a time. */

--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -378,6 +378,11 @@ WEAK int halide_hexagon_device_malloc(void *user_context, buffer_t *buf) {
 
     size_t size = buf_size(user_context, buf);
 
+    // Hexagon code generation generates clamped ramp loads in a way
+    // that requires up to an extra vector beyond the end of the
+    // buffer to be legal to access.
+    size += 128;
+
     halide_assert(user_context, buf->stride[0] >= 0 && buf->stride[1] >= 0 &&
                                 buf->stride[2] >= 0 && buf->stride[3] >= 0);
 

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1465,6 +1465,11 @@ void check_hvx_all() {
     check("vlut16(v*.b,v*.h,r*)", hvx_width/2, in_u16(3*x + 0));
     check("vlut16(v*.b,v*.h,r*)", hvx_width/2, in_u16(3*x + 2));
 
+    check("vlut32(v*.b,v*.b,r*)", hvx_width/1, in_u8(u8_1));
+    check("vlut32(v*.b,v*.b,r*)", hvx_width/1, in_u8(clamp(u16_1, 0, 63)));
+    check("vlut16(v*.b,v*.h,r*)", hvx_width/2, in_u16(u8_1));
+    check("vlut16(v*.b,v*.h,r*)", hvx_width/2, in_u16(clamp(u16_1, 0, 15)));
+
     check("v*.ub = vpack(v*.h,v*.h):sat", hvx_width/1, u8c(i16_1));
     check("v*.b = vpack(v*.h,v*.h):sat", hvx_width/1, i8c(i16_1));
     check("v*.uh = vpack(v*.w,v*.w):sat", hvx_width/2, u16c(i32_1));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1460,6 +1460,11 @@ void check_hvx_all() {
     check("vpacko(v*.w,v*.w)", hvx_width/2, in_u16(2*x + 1));
     check("vdeal(v*,v*,r*)", hvx_width/4, in_u32(2*x + 1));
 
+    check("vlut32(v*.b,v*.b,r*)", hvx_width/1, in_u8(3*x + 0));
+    check("vlut32(v*.b,v*.b,r*)", hvx_width/1, in_u8(3*x + 2));
+    check("vlut16(v*.b,v*.h,r*)", hvx_width/2, in_u16(3*x + 0));
+    check("vlut16(v*.b,v*.h,r*)", hvx_width/2, in_u16(3*x + 2));
+
     check("v*.ub = vpack(v*.h,v*.h):sat", hvx_width/1, u8c(i16_1));
     check("v*.b = vpack(v*.h,v*.h):sat", hvx_width/1, i8c(i16_1));
     check("v*.uh = vpack(v*.w,v*.w):sat", hvx_width/2, u16c(i32_1));


### PR DESCRIPTION
(Reopened from #1167)

This PR adds optimizations to use vlut instructions in 3 situations:

- Constant shuffles that are not otherwise handled, e.g. stride 3 loads (common when processing packed RGB images).
- "Dynamic shuffles" resulting from clamped ramp loads, which arise in boundary condition code.
- Up to 256 element lookup tables.

This cuts the runtime of HelloHexagon from 0.7 s to 0.1 s, on the simulator this reduced the number of cycles from 26e6 to 7.8e6. This is despite the boundary condition code only running on 1/8th of the image.

This required changing the schedule of HelloHexagon to avoid out of bounds reads, which is a problem I'll need to figure out how to solve.

This change also adds the ability to more easily run HelloHexagon on the simulator.