### PR TITLE
Add LLVM taget-based optimization. Enable vectorization.

### DIFF
--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -6,7 +6,7 @@ ifeq ($(OS), Windows_NT)
 # Flags for mingw environment
 LDFLAGS += -lole32 -luuid -Wl,--stack,8388608
 else
-LDFLAGS += -ldl -lpthread -lz -ltinfo
+LDFLAGS += -ldl -lpthread -lz
 endif
 
 CXX ?= g++

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -6,7 +6,7 @@ ifeq ($(OS), Windows_NT)
 # Flags for mingw environment
 LDFLAGS += -lole32 -luuid -Wl,--stack,8388608
 else
-LDFLAGS += -ldl -lpthread -lz
+LDFLAGS += -ldl -lpthread -lz -ltinfo
 endif
 
 CXX ?= g++

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -235,5 +235,128 @@ Expr lower_euclidean_mod(Expr a, Expr b) {
     }
 }
 
+bool get_md_bool(LLVMMDNodeArgumentType value, bool &result) {
+    #if LLVM_VERSION < 36 || defined(WITH_NATIVE_CLIENT)
+    llvm::ConstantInt *c = llvm::cast<llvm::ConstantInt>(value);
+    #else
+    llvm::ConstantAsMetadata *cam = llvm::cast<llvm::ConstantAsMetadata>(value);
+    llvm::ConstantInt *c = llvm::cast<llvm::ConstantInt>(cam->getValue());
+    #endif
+    if (c) {
+        result = !c->isZero();
+        return true;
+    }
+    return false;
+}
+
+bool get_md_string(LLVMMDNodeArgumentType value, std::string &result) {
+    #if LLVM_VERSION < 36
+    if (llvm::dyn_cast<llvm::ConstantAggregateZero>(value)) {
+        result = "";
+        return true;
+    }
+    llvm::ConstantDataArray *c = llvm::cast<llvm::ConstantDataArray>(value);
+    if (c) {
+        result = c->getAsCString();
+        return true;
+    }
+    #else
+    llvm::MDString *c = llvm::dyn_cast<llvm::MDString>(value);
+    if (c) {
+        result = c->getString();
+        return true;
+    }
+    #endif
+    return false;
+}
+
+void get_target_options(const llvm::Module &module, llvm::TargetOptions &options, std::string &mcpu, std::string &mattrs) {
+    bool use_soft_float_abi = false;
+    get_md_bool(module.getModuleFlag("halide_use_soft_float_abi"), use_soft_float_abi);
+    get_md_string(module.getModuleFlag("halide_mcpu"), mcpu);
+    get_md_string(module.getModuleFlag("halide_mattrs"), mattrs);
+
+    options = llvm::TargetOptions();
+    options.LessPreciseFPMADOption = true;
+    options.AllowFPOpFusion = llvm::FPOpFusion::Fast;
+    options.UnsafeFPMath = true;
+    options.NoInfsFPMath = true;
+    options.NoNaNsFPMath = true;
+    options.HonorSignDependentRoundingFPMathOption = false;
+    #if LLVM_VERSION < 37
+    options.NoFramePointerElim = false;
+    options.UseSoftFloat = false;
+    #endif
+    options.NoZerosInBSS = false;
+    options.GuaranteedTailCallOpt = false;
+    #if LLVM_VERSION < 37
+    options.DisableTailCalls = false;
+    #endif
+    options.StackAlignmentOverride = 0;
+    #if LLVM_VERSION < 37
+    options.TrapFuncName = "";
+    #endif
+    options.FunctionSections = true;
+    #ifdef WITH_NATIVE_CLIENT
+    options.UseInitArray = true;
+    #else
+    options.UseInitArray = false;
+    #endif
+    options.FloatABIType =
+        use_soft_float_abi ? llvm::FloatABI::Soft : llvm::FloatABI::Hard;
+}
+
+
+void clone_target_options(const llvm::Module &from, llvm::Module &to) {
+    to.setTargetTriple(from.getTargetTriple());
+
+    llvm::LLVMContext &context = to.getContext();
+
+    bool use_soft_float_abi = false;
+    if (get_md_bool(from.getModuleFlag("halide_use_soft_float_abi"), use_soft_float_abi))
+        to.addModuleFlag(llvm::Module::Warning, "halide_use_soft_float_abi", use_soft_float_abi ? 1 : 0);
+
+    std::string mcpu;
+    if (get_md_string(from.getModuleFlag("halide_mcpu"), mcpu)) {
+        #if LLVM_VERSION < 36
+        to.addModuleFlag(llvm::Module::Warning, "halide_mcpu", llvm::ConstantDataArray::getString(context, mcpu));
+        #else
+        to.addModuleFlag(llvm::Module::Warning, "halide_mcpu", llvm::MDString::get(context, mcpu));
+        #endif
+    }
+
+    std::string mattrs;
+    if (get_md_string(from.getModuleFlag("halide_mattrs"), mattrs)) {
+        #if LLVM_VERSION < 36
+        to.addModuleFlag(llvm::Module::Warning, "halide_mattrs", llvm::ConstantDataArray::getString(context, mattrs));
+        #else
+        to.addModuleFlag(llvm::Module::Warning, "halide_mattrs", llvm::MDString::get(context, mattrs));
+        #endif
+    }
+}
+
+llvm::TargetMachine *get_target_machine(const llvm::Module &module) {
+    std::string error_string;
+
+    const llvm::Target *target = llvm::TargetRegistry::lookupTarget(module.getTargetTriple(), error_string);
+    if (!target) {
+        std::cout << error_string << std::endl;
+        llvm::TargetRegistry::printRegisteredTargetsForVersion();
+    }
+    internal_assert(target) << "Could not create target for " << module.getTargetTriple() << "\n";
+
+    llvm::TargetOptions options;
+    std::string mcpu = "";
+    std::string mattrs = "";
+    get_target_options(module, options, mcpu, mattrs);
+
+    return target->createTargetMachine(module.getTargetTriple(),
+                                       mcpu, mattrs,
+                                       options,
+                                       llvm::Reloc::PIC_,
+                                       llvm::CodeModel::Default,
+                                       llvm::CodeGenOpt::Aggressive);
+}
+
 }
 }

--- a/src/CodeGen_Internal.h
+++ b/src/CodeGen_Internal.h
@@ -55,6 +55,15 @@ Expr lower_euclidean_div(Expr a, Expr b);
 Expr lower_euclidean_mod(Expr a, Expr b);
 ///@}
 
+/** Given an llvm::Module, set llvm:TargetOptions, cpu and attr information */
+void get_target_options(const llvm::Module &module, llvm::TargetOptions &options, std::string &mcpu, std::string &mattrs);
+
+/** Given two llvm::Modules, clone target options from one to the other */
+void clone_target_options(const llvm::Module &from, llvm::Module &to);
+
+/** Given an llvm::Module, get or create an llvm:TargetMachine */
+llvm::TargetMachine *get_target_machine(const llvm::Module &module);
+
 }}
 
 #endif

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -926,9 +926,11 @@ void CodeGen_LLVM::optimize_module() {
     module_pass_manager.add(new DataLayoutPass());
     #endif
 
+    #if (LLVM_VERSION >= 37)
     std::unique_ptr<TargetMachine> TM(get_target_machine(*module));
     module_pass_manager.add(createTargetTransformInfoWrapperPass(TM ? TM->getTargetIRAnalysis() : TargetIRAnalysis()));
     function_pass_manager.add(createTargetTransformInfoWrapperPass(TM ? TM->getTargetIRAnalysis() : TargetIRAnalysis()));
+    #endif
 
     PassManagerBuilder b;
     b.OptLevel = 3;

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -904,8 +904,6 @@ llvm::Type *CodeGen_LLVM::llvm_type_of(Type t) {
     return Internal::llvm_type_of(context, t);
 }
 
-llvm::TargetMachine *get_target_machine(const llvm::Module &module);
-
 void CodeGen_LLVM::optimize_module() {
     debug(3) << "Optimizing module\n";
 

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -129,6 +129,7 @@ void clone_target_options(const llvm::Module &from, llvm::Module &to) {
     }
 }
 
+namespace Internal {
 
 llvm::TargetMachine *get_target_machine(const llvm::Module &module) {
     std::string error_string;
@@ -153,13 +154,15 @@ llvm::TargetMachine *get_target_machine(const llvm::Module &module) {
                                        llvm::CodeGenOpt::Aggressive);
 }
 
+}
+
 #if LLVM_VERSION < 37
 void emit_file_legacy(llvm::Module &module, const std::string &filename, llvm::TargetMachine::CodeGenFileType file_type) {
     Internal::debug(1) << "emit_file_legacy.Compiling to native code...\n";
     Internal::debug(2) << "Target triple: " << module.getTargetTriple() << "\n";
 
     // Get the target specific parser.
-    llvm::TargetMachine *target_machine = get_target_machine(module);
+    llvm::TargetMachine *target_machine = Internal::get_target_machine(module);
     internal_assert(target_machine) << "Could not allocate target machine!\n";
 
     // Build up all of the passes that we want to do to the module.
@@ -210,7 +213,7 @@ void emit_file(llvm::Module &module, const std::string &filename, llvm::TargetMa
     Internal::debug(2) << "Target triple: " << module.getTargetTriple() << "\n";
 
     // Get the target specific parser.
-    llvm::TargetMachine *target_machine = get_target_machine(module);
+    llvm::TargetMachine *target_machine = Internal::get_target_machine(module);
     internal_assert(target_machine) << "Could not allocate target machine!\n";
 
     #if LLVM_VERSION == 37

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -2,6 +2,7 @@
 #include "LLVM_Output.h"
 #include "CodeGen_LLVM.h"
 #include "CodeGen_C.h"
+#include "CodeGen_Internal.h"
 
 #include <iostream>
 #include <fstream>
@@ -25,136 +26,6 @@ llvm::raw_fd_ostream *new_raw_fd_ostream(const std::string &filename) {
     return raw_out;
 }
 
-namespace Internal {
-
-bool get_md_bool(LLVMMDNodeArgumentType value, bool &result) {
-    #if LLVM_VERSION < 36 || defined(WITH_NATIVE_CLIENT)
-    llvm::ConstantInt *c = llvm::cast<llvm::ConstantInt>(value);
-    #else
-    llvm::ConstantAsMetadata *cam = llvm::cast<llvm::ConstantAsMetadata>(value);
-    llvm::ConstantInt *c = llvm::cast<llvm::ConstantInt>(cam->getValue());
-    #endif
-    if (c) {
-        result = !c->isZero();
-        return true;
-    }
-    return false;
-}
-
-bool get_md_string(LLVMMDNodeArgumentType value, std::string &result) {
-    #if LLVM_VERSION < 36
-    if (llvm::dyn_cast<llvm::ConstantAggregateZero>(value)) {
-        result = "";
-        return true;
-    }
-    llvm::ConstantDataArray *c = llvm::cast<llvm::ConstantDataArray>(value);
-    if (c) {
-        result = c->getAsCString();
-        return true;
-    }
-    #else
-    llvm::MDString *c = llvm::dyn_cast<llvm::MDString>(value);
-    if (c) {
-        result = c->getString();
-        return true;
-    }
-    #endif
-    return false;
-}
-
-}
-
-void get_target_options(const llvm::Module &module, llvm::TargetOptions &options, std::string &mcpu, std::string &mattrs) {
-    bool use_soft_float_abi = false;
-    Internal::get_md_bool(module.getModuleFlag("halide_use_soft_float_abi"), use_soft_float_abi);
-    Internal::get_md_string(module.getModuleFlag("halide_mcpu"), mcpu);
-    Internal::get_md_string(module.getModuleFlag("halide_mattrs"), mattrs);
-
-    options = llvm::TargetOptions();
-    options.LessPreciseFPMADOption = true;
-    options.AllowFPOpFusion = llvm::FPOpFusion::Fast;
-    options.UnsafeFPMath = true;
-    options.NoInfsFPMath = true;
-    options.NoNaNsFPMath = true;
-    options.HonorSignDependentRoundingFPMathOption = false;
-    #if LLVM_VERSION < 37
-    options.NoFramePointerElim = false;
-    options.UseSoftFloat = false;
-    #endif
-    options.NoZerosInBSS = false;
-    options.GuaranteedTailCallOpt = false;
-    #if LLVM_VERSION < 37
-    options.DisableTailCalls = false;
-    #endif
-    options.StackAlignmentOverride = 0;
-    #if LLVM_VERSION < 37
-    options.TrapFuncName = "";
-    #endif
-    options.FunctionSections = true;
-    #ifdef WITH_NATIVE_CLIENT
-    options.UseInitArray = true;
-    #else
-    options.UseInitArray = false;
-    #endif
-    options.FloatABIType =
-        use_soft_float_abi ? llvm::FloatABI::Soft : llvm::FloatABI::Hard;
-}
-
-
-void clone_target_options(const llvm::Module &from, llvm::Module &to) {
-    to.setTargetTriple(from.getTargetTriple());
-
-    llvm::LLVMContext &context = to.getContext();
-
-    bool use_soft_float_abi = false;
-    if (Internal::get_md_bool(from.getModuleFlag("halide_use_soft_float_abi"), use_soft_float_abi))
-        to.addModuleFlag(llvm::Module::Warning, "halide_use_soft_float_abi", use_soft_float_abi ? 1 : 0);
-
-    std::string mcpu;
-    if (Internal::get_md_string(from.getModuleFlag("halide_mcpu"), mcpu)) {
-        #if LLVM_VERSION < 36
-        to.addModuleFlag(llvm::Module::Warning, "halide_mcpu", llvm::ConstantDataArray::getString(context, mcpu));
-        #else
-        to.addModuleFlag(llvm::Module::Warning, "halide_mcpu", llvm::MDString::get(context, mcpu));
-        #endif
-    }
-
-    std::string mattrs;
-    if (Internal::get_md_string(from.getModuleFlag("halide_mattrs"), mattrs)) {
-        #if LLVM_VERSION < 36
-        to.addModuleFlag(llvm::Module::Warning, "halide_mattrs", llvm::ConstantDataArray::getString(context, mattrs));
-        #else
-        to.addModuleFlag(llvm::Module::Warning, "halide_mattrs", llvm::MDString::get(context, mattrs));
-        #endif
-    }
-}
-
-namespace Internal {
-
-llvm::TargetMachine *get_target_machine(const llvm::Module &module) {
-    std::string error_string;
-
-    const llvm::Target *target = llvm::TargetRegistry::lookupTarget(module.getTargetTriple(), error_string);
-    if (!target) {
-        std::cout << error_string << std::endl;
-        llvm::TargetRegistry::printRegisteredTargetsForVersion();
-    }
-    internal_assert(target) << "Could not create target for " << module.getTargetTriple() << "\n";
-
-    llvm::TargetOptions options;
-    std::string mcpu = "";
-    std::string mattrs = "";
-    get_target_options(module, options, mcpu, mattrs);
-
-    return target->createTargetMachine(module.getTargetTriple(),
-                                       mcpu, mattrs,
-                                       options,
-                                       llvm::Reloc::PIC_,
-                                       llvm::CodeModel::Default,
-                                       llvm::CodeGenOpt::Aggressive);
-}
-
-}
 
 #if LLVM_VERSION < 37
 void emit_file_legacy(llvm::Module &module, const std::string &filename, llvm::TargetMachine::CodeGenFileType file_type) {


### PR DESCRIPTION
For the apps, I needed the additional ldflag for local runs. Let me know if there are any issues with adding it.
Preliminary testing show no impact on apps performance.