### PR TITLE
[Hexagon] Use linear interpolation of 256 element LUT for camera pipe tonemap

### DIFF
--- a/apps/camera_pipe/camera_pipe.cpp
+++ b/apps/camera_pipe/camera_pipe.cpp
@@ -327,17 +327,18 @@ Func process(Func raw, Type result_type,
     if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
         const int tile_width = 512;
         const int tile_height = 64;
-        const int vector_size = target.has_feature(Target::HVX_128) ? 64 : 32;
+        const int vector_size = target.has_feature(Target::HVX_128) ? 128 : 64;
+        const int vector_size_16 = vector_size/2;
         denoised.compute_at(processed, tx)
-            .align_storage(x, vector_size)
-            .vectorize(x, vector_size);
+            .align_storage(x, vector_size_16)
+            .vectorize(x, vector_size_16);
         deinterleaved.compute_at(processed, tx)
-            .align_storage(x, vector_size)
-            .vectorize(x, vector_size)
+            .align_storage(x, vector_size_16)
+            .vectorize(x, vector_size_16)
             .reorder(c, x, y)
             .unroll(c);
         corrected.compute_at(processed, tx)
-            .vectorize(x, vector_size)
+            .vectorize(x, vector_size_16)
             .reorder(c, x, y)
             .unroll(c);
         processed.compute_root()

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -595,28 +595,35 @@ namespace {
 bool is_strided_ramp(const std::vector<int> &indices, int &start, int &stride) {
     int size = static_cast<int>(indices.size());
 
-    // To find the proposed start and stride, find two adjacent non-undef elements.
-    int non_undef[2] = { -1, -1 };
+    // To find the proposed start and stride, find two non-undef elements.
+    int x0 = -1;
+    int x1 = -1;
     for (int i = 0; i < size; i++) {
         if (indices[i] != -1) {
-            if (non_undef[0] == -1) {
-                non_undef[0] = i;
+            if (x0 == -1) {
+                x0 = i;
             } else {
-                non_undef[1] = i;
+                x1 = i;
                 break;
             }
         }
     }
-    if (non_undef[0] == -1 || non_undef[1] == -1) {
-        // Didn't find two non-undef elements.
-        return false;
+
+    if (x1 == -1) {
+        if (x0 == -1) {
+            // Didn't find any non-undef elements.
+            return false;
+        }
+
+        // If we only had a single non-undef element, just assume it is stride 1.
+        stride = 1;
+        start = indices[x0] - x0;
+        return true;
     }
 
-    int x0 = non_undef[0];
-    int x1 = non_undef[1];
     int dx = x1 - x0;
     int dy = indices[x1] - indices[x0];
-    stride = dy / dx;
+    stride = dy/dx;
     start = indices[x0] - stride*x0;
 
     // Verify that all of the non-undef elements are part of the strided ramp.

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -909,12 +909,10 @@ class OptimizeShuffles : public IRMutator {
                                   Ramp::make(base, 1, const_extent),
                                   op->image, op->param);
 
-            index = simplify(index - base);
-
             // We know the size of the LUT is not more than 256, so we
             // can safely cast the index to 8 bit, which
             // dynamic_shuffle requires.
-            index = cast(UInt(8).with_lanes(op->type.lanes()), index);
+            index = simplify(cast(UInt(8).with_lanes(op->type.lanes()), index - base));
 
             expr = Call::make(op->type, "dynamic_shuffle", {lut, index, 0, const_extent}, Call::PureIntrinsic);
         } else if (!index.same_as(op->index)) {

--- a/src/runtime/hvx_128.ll
+++ b/src/runtime/hvx_128.ll
@@ -131,3 +131,114 @@ define weak_odr <64 x i32> @halide.hexagon.mul.vw.vuh(<64 x i32> %a, <64 x i16> 
   %ab = call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %ab_hi, <32 x i32> %ab_lo)
   ret <64 x i32> %ab
 }
+
+; Hexagon is missing shifts for byte sized operands.
+declare <32 x i32> @llvm.hexagon.V6.vaslh.128B(<32 x i32>, i32)
+declare <32 x i32> @llvm.hexagon.V6.vasrh.128B(<32 x i32>, i32)
+declare <32 x i32> @llvm.hexagon.V6.vlsrh.128B(<32 x i32>, i32)
+declare <32 x i32> @llvm.hexagon.V6.vaslhv.128B(<32 x i32>, <32 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vasrhv.128B(<32 x i32>, <32 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vlsrhv.128B(<32 x i32>, <32 x i32>)
+declare <64 x i32> @llvm.hexagon.V6.vzb.128B(<32 x i32>)
+declare <64 x i32> @llvm.hexagon.V6.vsb.128B(<32 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vshuffeb.128B(<32 x i32>, <32 x i32>)
+
+define weak_odr <128 x i8> @halide.hexagon.shl.vub.ub(<128 x i8> %a, i8 %b) nounwind uwtable readnone alwaysinline {
+  %a_32 = bitcast <128 x i8> %a to <32 x i32>
+  %bw = zext i8 %b to i32
+  %aw = call <64 x i32> @llvm.hexagon.V6.vzb.128B(<32 x i32> %a_32)
+  %aw_lo = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %aw)
+  %sw_lo = call <32 x i32> @llvm.hexagon.V6.vaslh.128B(<32 x i32> %aw_lo, i32 %bw)
+  %aw_hi = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %aw)
+  %sw_hi = call <32 x i32> @llvm.hexagon.V6.vaslh.128B(<32 x i32> %aw_hi, i32 %bw)
+  %r_32 = tail call <32 x i32> @llvm.hexagon.V6.vshuffeb.128B(<32 x i32> %sw_hi, <32 x i32> %sw_lo)
+  %r = bitcast <32 x i32> %r_32 to <128 x i8>
+  ret <128 x i8> %r
+}
+
+define weak_odr <128 x i8> @halide.hexagon.shl.vb.b(<128 x i8> %a, i8 %b) nounwind uwtable readnone alwaysinline {
+  ; A shift left is the same whether it is signed or not.
+  %u = tail call <128 x i8> @halide.hexagon.shl.vub.ub(<128 x i8> %a, i8 %b)
+  ret <128 x i8> %u
+}
+
+define weak_odr <128 x i8> @halide.hexagon.shr.vub.ub(<128 x i8> %a, i8 %b) nounwind uwtable readnone alwaysinline {
+  %a_32 = bitcast <128 x i8> %a to <32 x i32>
+  %bw = zext i8 %b to i32
+  %aw = call <64 x i32> @llvm.hexagon.V6.vzb.128B(<32 x i32> %a_32)
+  %aw_lo = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %aw)
+  %sw_lo = call <32 x i32> @llvm.hexagon.V6.vlsrh.128B(<32 x i32> %aw_lo, i32 %bw)
+  %aw_hi = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %aw)
+  %sw_hi = call <32 x i32> @llvm.hexagon.V6.vlsrh.128B(<32 x i32> %aw_hi, i32 %bw)
+  %r_32 = tail call <32 x i32> @llvm.hexagon.V6.vshuffeb.128B(<32 x i32> %sw_hi, <32 x i32> %sw_lo)
+  %r = bitcast <32 x i32> %r_32 to <128 x i8>
+  ret <128 x i8> %r
+}
+
+define weak_odr <128 x i8> @halide.hexagon.shr.vb.b(<128 x i8> %a, i8 %b) nounwind uwtable readnone alwaysinline {
+  %a_32 = bitcast <128 x i8> %a to <32 x i32>
+  %bw = zext i8 %b to i32
+  %aw = call <64 x i32> @llvm.hexagon.V6.vsb.128B(<32 x i32> %a_32)
+  %aw_lo = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %aw)
+  %sw_lo = call <32 x i32> @llvm.hexagon.V6.vasrh.128B(<32 x i32> %aw_lo, i32 %bw)
+  %aw_hi = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %aw)
+  %sw_hi = call <32 x i32> @llvm.hexagon.V6.vasrh.128B(<32 x i32> %aw_hi, i32 %bw)
+  %r_32 = tail call <32 x i32> @llvm.hexagon.V6.vshuffeb.128B(<32 x i32> %sw_hi, <32 x i32> %sw_lo)
+  %r = bitcast <32 x i32> %r_32 to <128 x i8>
+  ret <128 x i8> %r
+}
+
+
+define weak_odr <128 x i8> @halide.hexagon.shl.vub.vub(<128 x i8> %a, <128 x i8> %b) nounwind uwtable readnone alwaysinline {
+  %a_32 = bitcast <128 x i8> %a to <32 x i32>
+  %b_32 = bitcast <128 x i8> %b to <32 x i32>
+  %aw = call <64 x i32> @llvm.hexagon.V6.vzb.128B(<32 x i32> %a_32)
+  %bw = call <64 x i32> @llvm.hexagon.V6.vzb.128B(<32 x i32> %b_32)
+  %aw_lo = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %aw)
+  %bw_lo = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %bw)
+  %sw_lo = call <32 x i32> @llvm.hexagon.V6.vaslhv.128B(<32 x i32> %aw_lo, <32 x i32> %bw_lo)
+  %aw_hi = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %aw)
+  %bw_hi = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %bw)
+  %sw_hi = call <32 x i32> @llvm.hexagon.V6.vaslhv.128B(<32 x i32> %aw_hi, <32 x i32> %bw_hi)
+  %r_32 = tail call <32 x i32> @llvm.hexagon.V6.vshuffeb.128B(<32 x i32> %sw_hi, <32 x i32> %sw_lo)
+  %r = bitcast <32 x i32> %r_32 to <128 x i8>
+  ret <128 x i8> %r
+}
+
+define weak_odr <128 x i8> @halide.hexagon.shl.vb.vb(<128 x i8> %a, <128 x i8> %b) nounwind uwtable readnone alwaysinline {
+  ; A shift left is the same whether it is signed or not.
+  %u = tail call <128 x i8> @halide.hexagon.shl.vub.vub(<128 x i8> %a, <128 x i8> %b)
+  ret <128 x i8> %u
+}
+
+define weak_odr <128 x i8> @halide.hexagon.shr.vub.vub(<128 x i8> %a, <128 x i8> %b) nounwind uwtable readnone alwaysinline {
+  %a_32 = bitcast <128 x i8> %a to <32 x i32>
+  %b_32 = bitcast <128 x i8> %b to <32 x i32>
+  %aw = call <64 x i32> @llvm.hexagon.V6.vzb.128B(<32 x i32> %a_32)
+  %bw = call <64 x i32> @llvm.hexagon.V6.vzb.128B(<32 x i32> %b_32)
+  %aw_lo = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %aw)
+  %bw_lo = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %bw)
+  %sw_lo = call <32 x i32> @llvm.hexagon.V6.vlsrhv.128B(<32 x i32> %aw_lo, <32 x i32> %bw_lo)
+  %aw_hi = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %aw)
+  %bw_hi = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %bw)
+  %sw_hi = call <32 x i32> @llvm.hexagon.V6.vlsrhv.128B(<32 x i32> %aw_hi, <32 x i32> %bw_hi)
+  %r_32 = tail call <32 x i32> @llvm.hexagon.V6.vshuffeb.128B(<32 x i32> %sw_hi, <32 x i32> %sw_lo)
+  %r = bitcast <32 x i32> %r_32 to <128 x i8>
+  ret <128 x i8> %r
+}
+
+define weak_odr <128 x i8> @halide.hexagon.shr.vb.vb(<128 x i8> %a, <128 x i8> %b) nounwind uwtable readnone alwaysinline {
+  %a_32 = bitcast <128 x i8> %a to <32 x i32>
+  %b_32 = bitcast <128 x i8> %b to <32 x i32>
+  %aw = call <64 x i32> @llvm.hexagon.V6.vsb.128B(<32 x i32> %a_32)
+  %bw = call <64 x i32> @llvm.hexagon.V6.vsb.128B(<32 x i32> %b_32)
+  %aw_lo = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %aw)
+  %bw_lo = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %bw)
+  %sw_lo = call <32 x i32> @llvm.hexagon.V6.vasrhv.128B(<32 x i32> %aw_lo, <32 x i32> %bw_lo)
+  %aw_hi = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %aw)
+  %bw_hi = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %bw)
+  %sw_hi = call <32 x i32> @llvm.hexagon.V6.vasrhv.128B(<32 x i32> %aw_hi, <32 x i32> %bw_hi)
+  %r_32 = tail call <32 x i32> @llvm.hexagon.V6.vshuffeb.128B(<32 x i32> %sw_hi, <32 x i32> %sw_lo)
+  %r = bitcast <32 x i32> %r_32 to <128 x i8>
+  ret <128 x i8> %r
+}

--- a/src/runtime/hvx_64.ll
+++ b/src/runtime/hvx_64.ll
@@ -132,3 +132,113 @@ define weak_odr <32 x i32> @halide.hexagon.mul.vw.vuh(<32 x i32> %a, <32 x i16> 
   ret <32 x i32> %ab
 }
 
+; Hexagon is missing shifts for byte sized operands.
+declare <16 x i32> @llvm.hexagon.V6.vaslh(<16 x i32>, i32)
+declare <16 x i32> @llvm.hexagon.V6.vasrh(<16 x i32>, i32)
+declare <16 x i32> @llvm.hexagon.V6.vlsrh(<16 x i32>, i32)
+declare <16 x i32> @llvm.hexagon.V6.vaslhv(<16 x i32>, <16 x i32>)
+declare <16 x i32> @llvm.hexagon.V6.vasrhv(<16 x i32>, <16 x i32>)
+declare <16 x i32> @llvm.hexagon.V6.vlsrhv(<16 x i32>, <16 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vzb(<16 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vsb(<16 x i32>)
+declare <16 x i32> @llvm.hexagon.V6.vshuffeb(<16 x i32>, <16 x i32>)
+
+define weak_odr <64 x i8> @halide.hexagon.shl.vub.ub(<64 x i8> %a, i8 %b) nounwind uwtable readnone alwaysinline {
+  %a_32 = bitcast <64 x i8> %a to <16 x i32>
+  %bw = zext i8 %b to i32
+  %aw = call <32 x i32> @llvm.hexagon.V6.vzb(<16 x i32> %a_32)
+  %aw_lo = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %aw)
+  %aw_hi = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %aw)
+  %sw_lo = call <16 x i32> @llvm.hexagon.V6.vaslh(<16 x i32> %aw_lo, i32 %bw)
+  %sw_hi = call <16 x i32> @llvm.hexagon.V6.vaslh(<16 x i32> %aw_hi, i32 %bw)
+  %r_32 = tail call <16 x i32> @llvm.hexagon.V6.vshuffeb(<16 x i32> %sw_hi, <16 x i32> %sw_lo)
+  %r = bitcast <16 x i32> %r_32 to <64 x i8>
+  ret <64 x i8> %r
+}
+
+define weak_odr <64 x i8> @halide.hexagon.shl.vb.b(<64 x i8> %a, i8 %b) nounwind uwtable readnone alwaysinline {
+  ; A shift left is the same whether it is signed or not.
+  %u = tail call <64 x i8> @halide.hexagon.shl.vub.ub(<64 x i8> %a, i8 %b)
+  ret <64 x i8> %u
+}
+
+define weak_odr <64 x i8> @halide.hexagon.shr.vub.ub(<64 x i8> %a, i8 %b) nounwind uwtable readnone alwaysinline {
+  %a_32 = bitcast <64 x i8> %a to <16 x i32>
+  %bw = zext i8 %b to i32
+  %aw = call <32 x i32> @llvm.hexagon.V6.vzb(<16 x i32> %a_32)
+  %aw_lo = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %aw)
+  %aw_hi = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %aw)
+  %sw_lo = call <16 x i32> @llvm.hexagon.V6.vlsrh(<16 x i32> %aw_lo, i32 %bw)
+  %sw_hi = call <16 x i32> @llvm.hexagon.V6.vlsrh(<16 x i32> %aw_hi, i32 %bw)
+  %r_32 = tail call <16 x i32> @llvm.hexagon.V6.vshuffeb(<16 x i32> %sw_hi, <16 x i32> %sw_lo)
+  %r = bitcast <16 x i32> %r_32 to <64 x i8>
+  ret <64 x i8> %r
+}
+
+define weak_odr <64 x i8> @halide.hexagon.shr.vb.b(<64 x i8> %a, i8 %b) nounwind uwtable readnone alwaysinline {
+  %a_32 = bitcast <64 x i8> %a to <16 x i32>
+  %bw = zext i8 %b to i32
+  %aw = call <32 x i32> @llvm.hexagon.V6.vsb(<16 x i32> %a_32)
+  %aw_lo = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %aw)
+  %aw_hi = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %aw)
+  %sw_lo = call <16 x i32> @llvm.hexagon.V6.vasrh(<16 x i32> %aw_lo, i32 %bw)
+  %sw_hi = call <16 x i32> @llvm.hexagon.V6.vasrh(<16 x i32> %aw_hi, i32 %bw)
+  %r_32 = tail call <16 x i32> @llvm.hexagon.V6.vshuffeb(<16 x i32> %sw_hi, <16 x i32> %sw_lo)
+  %r = bitcast <16 x i32> %r_32 to <64 x i8>
+  ret <64 x i8> %r
+}
+
+
+define weak_odr <64 x i8> @halide.hexagon.shl.vub.vub(<64 x i8> %a, <64 x i8> %b) nounwind uwtable readnone alwaysinline {
+  %a_32 = bitcast <64 x i8> %a to <16 x i32>
+  %b_32 = bitcast <64 x i8> %b to <16 x i32>
+  %aw = call <32 x i32> @llvm.hexagon.V6.vzb(<16 x i32> %a_32)
+  %bw = call <32 x i32> @llvm.hexagon.V6.vzb(<16 x i32> %b_32)
+  %aw_lo = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %aw)
+  %bw_lo = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %bw)
+  %sw_lo = call <16 x i32> @llvm.hexagon.V6.vaslhv(<16 x i32> %aw_lo, <16 x i32> %bw_lo)
+  %aw_hi = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %aw)
+  %bw_hi = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %bw)
+  %sw_hi = call <16 x i32> @llvm.hexagon.V6.vaslhv(<16 x i32> %aw_hi, <16 x i32> %bw_hi)
+  %r_32 = tail call <16 x i32> @llvm.hexagon.V6.vshuffeb(<16 x i32> %sw_hi, <16 x i32> %sw_lo)
+  %r = bitcast <16 x i32> %r_32 to <64 x i8>
+  ret <64 x i8> %r
+}
+
+define weak_odr <64 x i8> @halide.hexagon.shl.vb.vb(<64 x i8> %a, <64 x i8> %b) nounwind uwtable readnone alwaysinline {
+  ; A shift left is the same whether it is signed or not.
+  %u = tail call <64 x i8> @halide.hexagon.shl.vub.vub(<64 x i8> %a, <64 x i8> %b)
+  ret <64 x i8> %u
+}
+
+define weak_odr <64 x i8> @halide.hexagon.shr.vub.vub(<64 x i8> %a, <64 x i8> %b) nounwind uwtable readnone alwaysinline {
+  %a_32 = bitcast <64 x i8> %a to <16 x i32>
+  %b_32 = bitcast <64 x i8> %b to <16 x i32>
+  %aw = call <32 x i32> @llvm.hexagon.V6.vzb(<16 x i32> %a_32)
+  %bw = call <32 x i32> @llvm.hexagon.V6.vzb(<16 x i32> %b_32)
+  %aw_lo = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %aw)
+  %bw_lo = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %bw)
+  %sw_lo = call <16 x i32> @llvm.hexagon.V6.vlsrhv(<16 x i32> %aw_lo, <16 x i32> %bw_lo)
+  %aw_hi = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %aw)
+  %bw_hi = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %bw)
+  %sw_hi = call <16 x i32> @llvm.hexagon.V6.vlsrhv(<16 x i32> %aw_hi, <16 x i32> %bw_hi)
+  %r_32 = tail call <16 x i32> @llvm.hexagon.V6.vshuffeb(<16 x i32> %sw_hi, <16 x i32> %sw_lo)
+  %r = bitcast <16 x i32> %r_32 to <64 x i8>
+  ret <64 x i8> %r
+}
+
+define weak_odr <64 x i8> @halide.hexagon.shr.vb.vb(<64 x i8> %a, <64 x i8> %b) nounwind uwtable readnone alwaysinline {
+  %a_32 = bitcast <64 x i8> %a to <16 x i32>
+  %b_32 = bitcast <64 x i8> %b to <16 x i32>
+  %aw = call <32 x i32> @llvm.hexagon.V6.vsb(<16 x i32> %a_32)
+  %bw = call <32 x i32> @llvm.hexagon.V6.vsb(<16 x i32> %b_32)
+  %aw_lo = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %aw)
+  %bw_lo = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %bw)
+  %sw_lo = call <16 x i32> @llvm.hexagon.V6.vasrhv(<16 x i32> %aw_lo, <16 x i32> %bw_lo)
+  %aw_hi = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %aw)
+  %bw_hi = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %bw)
+  %sw_hi = call <16 x i32> @llvm.hexagon.V6.vasrhv(<16 x i32> %aw_hi, <16 x i32> %bw_hi)
+  %r_32 = tail call <16 x i32> @llvm.hexagon.V6.vshuffeb(<16 x i32> %sw_hi, <16 x i32> %sw_lo)
+  %r = bitcast <16 x i32> %r_32 to <64 x i8>
+  ret <64 x i8> %r
+}

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1411,27 +1411,35 @@ void check_hvx_all() {
 
     // The behavior of shifts larger than the type behave differently
     // on HVX vs. the scalar processor, so we clamp.
+    check("vlsr(v*.h,v*.h)", hvx_width/1, u8_1 >> clamp(u8_2, 0, 7));
     check("vlsr(v*.h,v*.h)", hvx_width/2, u16_1 >> clamp(u16_2, 0, 15));
     check("vlsr(v*.w,v*.w)", hvx_width/4, u32_1 >> clamp(u32_2, 0, 31));
+    check("vasr(v*.h,v*.h)", hvx_width/1, i8_1 >> clamp(i16_2, 0, 7));
     check("vasr(v*.h,v*.h)", hvx_width/2, i16_1 >> clamp(i16_2, 0, 15));
     check("vasr(v*.w,v*.w)", hvx_width/4, i32_1 >> clamp(i32_2, 0, 31));
     check("vasr(v*.h,v*.h,r*):sat", hvx_width/1, u8c(i16_1 >> 4));
     check("vasr(v*.w,v*.w,r*):sat", hvx_width/2, u16c(i32_1 >> 8));
     check("vasr(v*.w,v*.w,r*):sat", hvx_width/2, i16c(i32_1 >> 8));
     check("vasr(v*.w,v*.w,r*)", hvx_width/2, i16(i32_1 >> 8));
+    check("vasl(v*.h,v*.h)", hvx_width/1, u8_1 << clamp(u8_2, 0, 7));
     check("vasl(v*.h,v*.h)", hvx_width/2, u16_1 << clamp(u16_2, 0, 15));
     check("vasl(v*.w,v*.w)", hvx_width/4, u32_1 << clamp(u32_2, 0, 31));
+    check("vasl(v*.h,v*.h)", hvx_width/1, i8_1 << clamp(i8_2, 0, 7));
     check("vasl(v*.h,v*.h)", hvx_width/2, i16_1 << clamp(i16_2, 0, 15));
     check("vasl(v*.w,v*.w)", hvx_width/4, i32_1 << clamp(i32_2, 0, 31));
 
     // The scalar lsr generates uh/uw arguments, while the vector
     // version just generates h/w.
+    check("vlsr(v*.uh,r*)", hvx_width/1, u8_1 >> clamp(in_u8(0), 0, 7));
     check("vlsr(v*.uh,r*)", hvx_width/2, u16_1 >> clamp(in_u16(0), 0, 15));
     check("vlsr(v*.uw,r*)", hvx_width/4, u32_1 >> clamp(in_u32(0), 0, 31));
+    check("vasr(v*.h,r*)", hvx_width/1, i8_1 >> clamp(in_i8(0), 0, 7));
     check("vasr(v*.h,r*)", hvx_width/2, i16_1 >> clamp(in_i16(0), 0, 15));
     check("vasr(v*.w,r*)", hvx_width/4, i32_1 >> clamp(in_i32(0), 0, 31));
+    check("vasl(v*.h,r*)", hvx_width/1, u8_1 << clamp(in_u8(0), 0, 7));
     check("vasl(v*.h,r*)", hvx_width/2, u16_1 << clamp(in_u16(0), 0, 15));
     check("vasl(v*.w,r*)", hvx_width/4, u32_1 << clamp(in_u32(0), 0, 31));
+    check("vasl(v*.h,r*)", hvx_width/1, i8_1 << clamp(in_i8(0), 0, 7));
     check("vasl(v*.h,r*)", hvx_width/2, i16_1 << clamp(in_i16(0), 0, 15));
     check("vasl(v*.w,r*)", hvx_width/4, i32_1 << clamp(in_i32(0), 0, 31));
 


### PR DESCRIPTION
This PR uses a 256 element LUT instead of a 1024 element LUT for the tonemap in the camera pipe app, which can use vlut instructions on Hexagon.

Unfortunately, this is currently slower than the existing implementation, because there's a dumb shuffle getting through which ends up scalarizing. It's a *really* dumb shuffle:

    %967 = shufflevector <32 x i16> %966, <32 x i16> undef, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef,
 i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>

Note that this is simply a selection of %966.