### PR TITLE
No self references in updates

### DIFF
--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -345,7 +345,7 @@ Stmt add_image_checks(Stmt s,
             args.push_back(Variable::make(Int(32), name + ".extent." + dim + ".proposed"));
             args.push_back(Variable::make(Int(32), name + ".stride." + dim + ".proposed"));
         }
-        Expr call = Call::make(UInt(1), Call::rewrite_buffer, args, Call::Intrinsic, Function(), 0, image, param);
+        Expr call = Call::make(UInt(1), Call::rewrite_buffer, args, Call::Intrinsic, nullptr, 0, image, param);
         Stmt rewrite = Evaluate::make(call);
         rewrite = IfThenElse::make(inference_mode, rewrite);
         buffer_rewrites.push_back(rewrite);

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -90,11 +90,11 @@ public:
 private:
 
     // Compute the intrinsic bounds of a function.
-    void bounds_of_func(Function f, int value_index) {
+    void bounds_of_func(string name, int value_index, Type t) {
         // if we can't get a good bound from the function, fall back to the bounds of the type.
-        bounds_of_type(f.output_types()[value_index]);
+        bounds_of_type(t);
 
-        pair<string, int> key = make_pair(f.name(), value_index);
+        pair<string, int> key = make_pair(name, value_index);
 
         FuncValueBounds::const_iterator iter = func_bounds.find(key);
 
@@ -792,8 +792,8 @@ private:
             // trace_expr returns argument 4
             internal_assert(op->args.size() >= 5);
             op->args[4].accept(this);
-        } else if (op->func.has_pure_definition()) {
-            bounds_of_func(op->func, op->value_index);
+        } else if (op->call_type == Call::Halide) {
+            bounds_of_func(op->name, op->value_index, op->type);
         } else {
             // Just use the bounds of the type
             bounds_of_type(t);

--- a/src/FindCalls.cpp
+++ b/src/FindCalls.cpp
@@ -30,8 +30,8 @@ public:
     void visit(const Call *call) {
         IRVisitor::visit(call);
 
-        if (call->call_type == Call::Halide) {
-            Function f = call->func;
+        if (call->call_type == Call::Halide && call->func.defined()) {
+            Function f(call->func);
             include_function(f);
         }
 

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -425,6 +425,9 @@ void Function::define_update(const vector<Expr> &_args, vector<Expr> values) {
     for (size_t i = 0; i < values.size(); i++) {
         values[i].accept(&check);
     }
+    if (check.reduction_domain.defined()) {
+        check.reduction_domain.predicate().accept(&check);
+    }
 
     // Freeze all called functions
     FreezeFunctions freezer(name());
@@ -437,6 +440,7 @@ void Function::define_update(const vector<Expr> &_args, vector<Expr> values) {
 
     // Freeze the reduction domain if defined
     if (check.reduction_domain.defined()) {
+        check.reduction_domain.predicate().accept(&freezer);
         check.reduction_domain.freeze();
     }
 
@@ -459,6 +463,9 @@ void Function::define_update(const vector<Expr> &_args, vector<Expr> values) {
     }
     for (size_t i = 0; i < values.size(); i++) {
         values[i] = lower_random(values[i], free_vars, tag);
+    }
+    if (check.reduction_domain.defined()) {
+        check.reduction_domain.set_predicate(lower_random(check.reduction_domain.predicate(), free_vars, tag));
     }
 
     UpdateDefinition r;

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -175,9 +175,12 @@ struct CheckVars : public IRGraphVisitor {
     }
 };
 
-struct CountSelfReferences : public IRMutator {
-    int count;
-    const Function *func;
+struct DeleteSelfReferences : public IRMutator {
+    IntrusivePtr<FunctionContents> func;
+
+    // Also count the number of self references so we know if a Func
+    // has a recursive definition.
+    int count = 0;
 
     using IRMutator::visit;
 
@@ -185,9 +188,9 @@ struct CountSelfReferences : public IRMutator {
         IRMutator::visit(c);
         c = expr.as<Call>();
         internal_assert(c);
-        if (c->func.same_as(*func)) {
+        if (c->func.same_as(func)) {
             expr = Call::make(c->type, c->name, c->args, c->call_type,
-                              c->func, c->value_index,
+                              nullptr, c->value_index,
                               c->image, c->param);
             count++;
         }
@@ -202,8 +205,10 @@ class FreezeFunctions : public IRGraphVisitor {
 
     void visit(const Call *op) {
         IRGraphVisitor::visit(op);
-        if (op->call_type == Call::Halide && op->name != func) {
-            Function f = op->func;
+        if (op->call_type == Call::Halide &&
+            op->func.defined() &&
+            op->name != func) {
+            Function f(op->func);
             f.freeze();
         }
     }
@@ -217,6 +222,11 @@ static std::atomic<int> rand_counter;
 }
 
 Function::Function() : contents(new FunctionContents) {
+}
+
+Function::Function(const IntrusivePtr<FunctionContents> &ptr) : contents(ptr) {
+    internal_assert(ptr.defined())
+        << "Can't construct Function from undefined FunctionContents ptr\n";
 }
 
 Function::Function(const std::string &n) : contents(new FunctionContents) {
@@ -459,21 +469,18 @@ void Function::define_update(const vector<Expr> &_args, vector<Expr> values) {
 
     // The update value and args probably refer back to the
     // function itself, introducing circular references and hence
-    // memory leaks. We need to count the number of unique call nodes
-    // that point back to this function in order to break the cycles.
-    CountSelfReferences counter;
-    counter.func = this;
-    counter.count = 0;
+    // memory leaks. We need to break these cycles.
+    DeleteSelfReferences deleter;
+    deleter.func = contents;
+    deleter.count = 0;
     for (size_t i = 0; i < args.size(); i++) {
-        r.args[i] = counter.mutate(r.args[i]);
+        r.args[i] = deleter.mutate(r.args[i]);
     }
     for (size_t i = 0; i < values.size(); i++) {
-        r.values[i] = counter.mutate(r.values[i]);
+        r.values[i] = deleter.mutate(r.values[i]);
     }
-
-    for (int i = 0; i < counter.count; i++) {
-        int count = contents.ptr->ref_count.decrement();
-        internal_assert(count != 0);
+    if (r.domain.defined()) {
+        r.domain.set_predicate(deleter.mutate(r.domain.predicate()));
     }
 
     // First add any reduction domain
@@ -510,7 +517,7 @@ void Function::define_update(const vector<Expr> &_args, vector<Expr> values) {
     // the args are pure, then this definition completely hides
     // earlier ones!
     if (!r.domain.defined() &&
-        counter.count == 0 &&
+        deleter.count == 0 &&
         pure) {
         user_warning
             << "In update definition " << update_idx << " of Func \"" << name() << "\":\n"

--- a/src/Function.h
+++ b/src/Function.h
@@ -60,20 +60,20 @@ struct UpdateDefinition {
  * a function. Similar to a front-end Func object, but with no
  * syntactic sugar to help with definitions. */
 class Function {
-private:
-    IntrusivePtr<FunctionContents> contents;
 public:
+    IntrusivePtr<FunctionContents> contents;
+
     /** Construct a new function with no definitions and no name. This
      * constructor only exists so that you can make vectors of
      * functions, etc.
      */
     EXPORT Function();
 
-    /** Reconstruct a Function from a FunctionContents pointer. */
-    EXPORT Function(const IntrusivePtr<FunctionContents> &c) : contents(c) {}
-
     /** Construct a new function with the given name */
     EXPORT Function(const std::string &n);
+
+    /** Construct a Function from an existing FunctionContents pointer. Must be non-null */
+    EXPORT explicit Function(const IntrusivePtr<FunctionContents> &);
 
     /** Add a pure definition to this function. It may not already
      * have a definition. All the free variables in 'value' must

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -506,22 +506,15 @@ Stmt Evaluate::make(Expr v) {
 }
 
 Expr Call::make(Type type, std::string name, const std::vector<Expr> &args, CallType call_type,
-                Function func, int value_index,
+                IntrusivePtr<FunctionContents> func, int value_index,
                 Buffer image, Parameter param) {
     for (size_t i = 0; i < args.size(); i++) {
         internal_assert(args[i].defined()) << "Call of undefined\n";
     }
     if (call_type == Halide) {
-        internal_assert(value_index >= 0 &&
-                        value_index < func.outputs())
-            << "Value index out of range in call to halide function\n";
-        internal_assert((func.has_pure_definition() || func.has_extern_definition()))
-            << "Call to undefined halide function\n";
-        internal_assert((int)args.size() <= func.dimensions())
-            << "Call node with too many arguments.\n";
         for (size_t i = 0; i < args.size(); i++) {
             internal_assert(args[i].type() == Int(32))
-                << "Args to call to halide function must be type Int(32)\n";
+            << "Args to call to halide function must be type Int(32)\n";
         }
     } else if (call_type == Image) {
         internal_assert((param.defined() || image.defined()))

--- a/src/IR.h
+++ b/src/IR.h
@@ -429,9 +429,11 @@ struct Call : public ExprNode<Call> {
         div_round_to_zero,
         mod_round_to_zero;
 
-    // If it's a call to another halide function, this call node
-    // holds onto a pointer to that function.
-    Function func;
+    // If it's a call to another halide function, this call node holds
+    // onto a pointer to that function for the purposes of reference
+    // counting only. Self-references in update definitions do not
+    // have this set, to avoid cycles.
+    IntrusivePtr<FunctionContents> func;
 
     // If that function has multiple values, which value does this
     // call node refer to?
@@ -446,7 +448,7 @@ struct Call : public ExprNode<Call> {
     Parameter param;
 
     EXPORT static Expr make(Type type, std::string name, const std::vector<Expr> &args, CallType call_type,
-                            Function func = Function(), int value_index = 0,
+                            IntrusivePtr<FunctionContents> func = nullptr, int value_index = 0,
                             Buffer image = Buffer(), Parameter param = Parameter());
 
     /** Convenience constructor for calls to other halide functions */
@@ -456,17 +458,17 @@ struct Call : public ExprNode<Call> {
             << "Value index out of range in call to halide function\n";
         internal_assert(func.has_pure_definition() || func.has_extern_definition())
             << "Call to undefined halide function\n";
-        return make(func.output_types()[(size_t)idx], func.name(), args, Halide, func, idx, Buffer(), Parameter());
+        return make(func.output_types()[(size_t)idx], func.name(), args, Halide, func.contents, idx, Buffer(), Parameter());
     }
 
     /** Convenience constructor for loads from concrete images */
     static Expr make(Buffer image, const std::vector<Expr> &args) {
-        return make(image.type(), image.name(), args, Image, Function(), 0, image, Parameter());
+        return make(image.type(), image.name(), args, Image, nullptr, 0, image, Parameter());
     }
 
     /** Convenience constructor for loads from images parameters */
     static Expr make(Parameter param, const std::vector<Expr> &args) {
-        return make(param.type(), param.name(), args, Image, Function(), 0, Buffer(), param);
+        return make(param.type(), param.name(), args, Image, nullptr, 0, Buffer(), param);
     }
 
     /** Check if a call node is pure within a pipeline, meaning that

--- a/src/IRVisitor.cpp
+++ b/src/IRVisitor.cpp
@@ -129,12 +129,14 @@ void IRVisitor::visit(const Call *op) {
     }
 
     // Consider extern call args
-    Function f = op->func;
-    if (op->call_type == Call::Halide && f.has_extern_definition()) {
-        for (size_t i = 0; i < f.extern_arguments().size(); i++) {
-            ExternFuncArgument arg = f.extern_arguments()[i];
-            if (arg.is_expr()) {
-                arg.expr.accept(this);
+    if (op->func.defined()) {
+        Function f(op->func);
+        if (op->call_type == Call::Halide && f.has_extern_definition()) {
+            for (size_t i = 0; i < f.extern_arguments().size(); i++) {
+                ExternFuncArgument arg = f.extern_arguments()[i];
+                if (arg.is_expr()) {
+                    arg.expr.accept(this);
+                }
             }
         }
     }

--- a/src/InjectImageIntrinsics.cpp
+++ b/src/InjectImageIntrinsics.cpp
@@ -8,14 +8,16 @@
 namespace Halide {
 namespace Internal {
 
+using std::map;
 using std::string;
 using std::vector;
 
 class InjectImageIntrinsics : public IRMutator {
 public:
-    InjectImageIntrinsics() : inside_kernel_loop(false) {}
+    InjectImageIntrinsics(const map<string, Function> &e) : inside_kernel_loop(false), env(e) {}
     Scope<int> scope;
     bool inside_kernel_loop;
+    const map<string, Function> &env;
 
 private:
     using IRMutator::visit;
@@ -57,7 +59,10 @@ private:
         }
 
         string name = call->name;
-        if (call->call_type == Call::Halide && call->func.outputs() > 1) {
+        auto it = env.find(name);
+        if (call->call_type == Call::Halide &&
+            it != env.end() &&
+            it->second.outputs() > 1) {
             name = name + '.' + std::to_string(call->value_index);
         }
 
@@ -111,7 +116,7 @@ private:
                        Call::image_load,
                        args,
                        Call::PureIntrinsic,
-                       Function(),
+                       nullptr,
                        0,
                        call->image,
                        call->param);
@@ -145,12 +150,12 @@ private:
     }
 };
 
-Stmt inject_image_intrinsics(Stmt s) {
+Stmt inject_image_intrinsics(Stmt s, const map<string, Function> &env) {
     debug(4)
         << "InjectImageIntrinsics: inject_image_intrinsics stmt: "
         << s << "\n";
     s = zero_gpu_loop_mins(s);
-    InjectImageIntrinsics gl;
+    InjectImageIntrinsics gl(env);
     return gl.mutate(s);
 }
 }

--- a/src/InjectImageIntrinsics.h
+++ b/src/InjectImageIntrinsics.h
@@ -15,7 +15,7 @@ namespace Internal {
 /** Take a statement with for kernel for loops and turn loads and
  * stores inside the loops into image load and store
  * intrinsics. */
-Stmt inject_image_intrinsics(Stmt s);
+Stmt inject_image_intrinsics(Stmt s, const std::map<std::string, Function> &env);
 }
 }
 

--- a/src/InjectOpenGLIntrinsics.cpp
+++ b/src/InjectOpenGLIntrinsics.cpp
@@ -73,7 +73,7 @@ private:
 
             Expr load_call = Call::make(load_type, Call::glsl_texture_load,
                                         vector<Expr>(&args[0], &args[4]),
-                                        Call::Intrinsic, Function(), 0,
+                                        Call::Intrinsic, nullptr, 0,
                                         call->image, call->param);
 
             // Add a shuffle_vector intrinsic to swizzle a single channel

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -149,7 +149,7 @@ Stmt lower(const vector<Function> &outputs, const string &pipeline_name, const T
 
     if (t.has_feature(Target::OpenGL) || t.has_feature(Target::Renderscript)) {
         debug(1) << "Injecting image intrinsics...\n";
-        s = inject_image_intrinsics(s);
+        s = inject_image_intrinsics(s, env);
         debug(2) << "Lowering after image intrinsics:\n" << s << "\n\n";
     }
 

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -50,13 +50,14 @@ public:
             if (call->args.size() == 1) {
                 record(call->args[0]);
             } else {
+                // Do not look at anything inside a memoize_expr bracket.
                 for (size_t i = 1; i < call->args.size(); i++) {
                     record(call->args[i]);
                 }
             }
-        } else {
-            // Do not look at anything inside a memoize_expr bracket.
-            visit_function(call->func);
+        } else if (call->func.defined()) {
+            Function fn(call->func);
+            visit_function(fn);
             IRGraphVisitor::visit(call);
         }
     }

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -313,7 +313,7 @@ private:
         if (func.has_extern_definition()) {
             for (const ExternFuncArgument &extern_arg : func.extern_arguments()) {
                 if (extern_arg.is_func()) {
-                    visit_function(extern_arg.func);
+                    visit_function(Function(extern_arg.func));
                 } else if (extern_arg.is_buffer()) {
                     include_buffer(extern_arg.buffer);
                 } else if (extern_arg.is_image_param()) {

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -367,7 +367,10 @@ private:
 
     void visit(const Call *op) {
         IRGraphVisitor::visit(op);
-        visit_function(op->func);
+        if (op->func.defined()) {
+            Function fn(op->func);
+            visit_function(fn);
+        }
         include_buffer(op->image);
         include_parameter(op->param);
     }

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -34,7 +34,8 @@ public:
     /** Construct an RVar with the given name */
     explicit RVar(const std::string &n) : _name(n) {
         // Make sure we don't get a unique name with the same name as
-        // this later:
+        // this later. TODO: This uses more and more memory over time
+        // to track the used names.
         Internal::unique_name(n, false);
     }
 

--- a/src/Reduction.cpp
+++ b/src/Reduction.cpp
@@ -122,8 +122,12 @@ const std::vector<ReductionVariable> &ReductionDomain::domain() const {
     return contents.ptr->domain;
 }
 
+void ReductionDomain::set_predicate(Expr p) {
+    contents.ptr->predicate = p;
+}
+
 void ReductionDomain::where(Expr predicate) {
-    contents.ptr->predicate = simplify(contents.ptr->predicate && predicate);
+    set_predicate(simplify(contents.ptr->predicate && predicate));
 }
 
 Expr ReductionDomain::predicate() const {

--- a/src/Reduction.h
+++ b/src/Reduction.h
@@ -54,6 +54,9 @@ public:
     /** Return the predicate defined on this reducation demain. */
     EXPORT Expr predicate() const;
 
+    /** Set the predicate, replacing any previously set predicate. */
+    EXPORT void set_predicate(Expr);
+
     /** Split predicate into vector of ANDs. If there is no predicate (i.e. all
      * iteration domain in this reduction domain is valid), this returns an
      * empty vector. */

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -1072,6 +1072,19 @@ class AndConditionOverDomain : public IRMutator {
         }
     }
 
+    // Other unhandled sources of bools
+    void visit(const Cast *op) {
+        fail();
+    }
+
+    void visit(const Load *op) {
+        fail();
+    }
+
+    void visit(const Call *op) {
+        fail();
+    }
+
 public:
     bool relaxed = false;
 

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -332,8 +332,9 @@ private:
         if (call->call_type == Call::Halide ||
             call->call_type == Call::Image) {
             string name = call->name;
+            auto it = env.find(call->name);
             if (call->call_type == Call::Halide &&
-                call->func.outputs() > 1) {
+                it->second.outputs() > 1) {
                 name = name + '.' + std::to_string(call->value_index);
             }
 

--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -77,7 +77,7 @@ private:
         bool trace_it = false;
         Expr trace_parent;
         if (op->call_type == Call::Halide) {
-            Function f = op->func;
+            Function f = env.find(op->name)->second;
             bool inlined = f.schedule().compute_level().is_inline();
             if (f.has_update_definition()) inlined = false;
             trace_it = f.is_tracing_loads() || (global_level > 2 && !inlined);

--- a/test/correctness/reduction_non_rectangular.cpp
+++ b/test/correctness/reduction_non_rectangular.cpp
@@ -513,6 +513,96 @@ int tile_intermediate_bound_depend_on_output_test(int index) {
     return 0;
 }
 
+int self_reference_bound_test(int index) {
+    buffer_index = index;
+
+    Func f("f_" + std::to_string(index)), g("g_" + std::to_string(index));
+    Var x("x"), y("y");
+    f(x, y) = x + y;
+    g(x, y) = 10;
+
+    RDom r1(0, 100, 0, 100, "r1");
+    r1.where(f(r1.x, r1.y) >= 40);
+    r1.where(f(r1.x, r1.y) != 50);
+    f(r1.x, r1.y) += 1;
+    f.compute_root();
+
+    RDom r2(0, 50, 0, 50, "r2");
+    r2.where(f(r2.x, r2.y) < 30);
+    g(r2.x, r2.y) += f(r2.x, r2.y);
+
+    Image<int> im1 = f.realize(200, 200);
+    for (int y = 0; y < im1.height(); y++) {
+        for (int x = 0; x < im1.width(); x++) {
+            int correct = x + y;
+            if ((0 <= x && x <= 99) && (0 <= y && y <= 99)) {
+                correct += ((correct >= 40) && (correct != 50)) ? 1 : 0;
+            }
+            if (im1(x, y) != correct) {
+                printf("im1(%d, %d) = %d instead of %d\n",
+                       x, y, im1(x, y), correct);
+                return -1;
+            }
+        }
+    }
+
+    Image<int> im2 = g.realize(200, 200);
+    for (int y = 0; y < im2.height(); y++) {
+        for (int x = 0; x < im2.width(); x++) {
+            int correct = 10;
+            if ((0 <= x && x <= 49) && (0 <= y && y <= 49)) {
+                correct += (im1(x, y) < 30) ? im1(x, y) : 0;
+            }
+            if (im2(x, y) != correct) {
+                printf("im2(%d, %d) = %d instead of %d\n",
+                       x, y, im2(x, y), correct);
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
+
+int random_float_bound_test(int index) {
+    buffer_index = index;
+
+    Func f("f_" + std::to_string(index));
+    Var x("x"), y("y");
+
+    Expr e1 = random_float() < 0.5f;
+    f(x, y) = Tuple(e1, x + y);
+
+    RDom r(0, 100, 0, 100);
+    r.where(f(r.x, r.y)[0]);
+    f(r.x, r.y) = Tuple(f(r.x, r.y)[0], f(r.x, r.y)[1] + 10);
+
+    Realization res = f.realize(200, 200);
+    assert(res.size() == 2);
+    Image<bool> im0 = res[0];
+    Image<int> im1 = res[1];
+
+    int n_true = 0;
+    for (int y = 0; y < im1.height(); y++) {
+        for (int x = 0; x < im1.width(); x++) {
+            n_true += im0(x, y);
+            int correct = x + y;
+            if ((0 <= x && x <= 99) && (0 <= y && y <= 99)) {
+                correct += im0(x, y) ? 10 : 0;
+            }
+            if (im1(x, y) != correct) {
+                printf("im1(%d, %d) = %d instead of %d\n",
+                       x, y, im1(x, y), correct);
+                return -1;
+            }
+        }
+    }
+    if (!(19000 <= n_true && n_true <= 21000)) {
+        printf("Expected n_true to be between 19000 and 21000; got %d instead\n", n_true);
+        return -1;
+    }
+    return 0;
+}
+
 int newton_method_test() {
     Func inverse;
     Var x;
@@ -731,6 +821,16 @@ int main(int argc, char **argv) {
 
     printf("Running intermediate stage depend on output bound\n");
     if (intermediate_bound_depend_on_output_test(9) != 0) {
+        return -1;
+    }
+
+    printf("Running self reference bound test\n");
+    if (self_reference_bound_test(10) != 0) {
+        return -1;
+    }
+
+    printf("Running random float bound test\n");
+    if (random_float_bound_test(11) != 0) {
         return -1;
     }
 

--- a/test/correctness/reduction_non_rectangular.cpp
+++ b/test/correctness/reduction_non_rectangular.cpp
@@ -847,17 +847,17 @@ int main(int argc, char **argv) {
     }
 
     printf("Running initialization on gpu and update on cpu test\n");
-    if (init_on_gpu_update_on_cpu_test(19) != 0) {
+    if (init_on_gpu_update_on_cpu_test(12) != 0) {
         return -1;
     }
 
     printf("Running initialization on cpu and update on gpu test\n");
-    if (init_on_cpu_update_on_gpu_test(11) != 0) {
+    if (init_on_cpu_update_on_gpu_test(13) != 0) {
         return -1;
     }
 
     printf("Running gpu intermediate only computed if param is bigger than certain value test\n");
-    if (gpu_intermediate_computed_if_param_test(12) != 0) {
+    if (gpu_intermediate_computed_if_param_test(14) != 0) {
         return -1;
     }
 


### PR DESCRIPTION
We use reference counting to track memory. This is a problem for update
definitions where a Func recursively calls itself. We used to deal with
this by reducing the reference count appropriately, but the self-
reference can now appear in other ways (e.g. the predicate of an RDom),
which makes this approach no longer work in certain deletion orders.

This PR instead allows Call nodes of call type Halide which do not
contain a pointer to a Function object. Or more precisely, they now have
a nullable pointer (an IntrusivePtr<FunctionContents>) instead of a non-
nullable one (a Function). The self-references in an update definition
have these set to null.

This makes our pipelines acyclic by construction, so reference counting
works. However this unfortunately means that the func field of a Call is
no longer a useful way to query aspects of the Function being called.
You need the environment. Made this explicit to avoid errors, and fixed
the resulting errors.