### PR TITLE
Fixes a bug in halide_opengl_wrap_texture().

### DIFF
--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -1958,6 +1958,13 @@ WEAK void halide_opengl_context_lost(void *user_context) {
 }
 
 WEAK int halide_opengl_wrap_texture(void *user_context, struct buffer_t *buf, uintptr_t texture_id) {
+  if (!global_state.initialized) {
+      // Must initialize here: if not, we risk having the TextureInfo
+      // blown away when global state really is inited.
+      if (int error = halide_opengl_init(user_context)) {
+          return error;
+      }
+    }
     if (texture_id == 0) {
         error(user_context) << "Texture " << texture_id << " is not a valid texture name.";
         return -3;
@@ -1966,6 +1973,11 @@ WEAK int halide_opengl_wrap_texture(void *user_context, struct buffer_t *buf, ui
     if (buf->dev != 0) {
         return -2;
     }
+    if (find_texture_info(texture_id)) {
+        error(user_context) << "Internal error: texture " << texture_id << " is already wrapped.";
+        return -3;
+    }
+    (void) new_texture_info(texture_id, buf->min, buf->extent, /* halide_allocated */ false);
     buf->dev = halide_new_device_wrapper(texture_id, &opengl_device_interface);
     if (buf->dev == 0) {
         return -1;


### PR DESCRIPTION
The function was not creating a TextureInfo struct for the wrapped
texture, which would result in an error when halide_opengl_run()
looked up the TextureInfo object for the wrapped texture.