### PR TITLE
Simpler unique name

### DIFF
--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -246,7 +246,7 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
                  << bounds.num_blocks[3] << ") blocks\n";
 
         // compile the kernel
-        string kernel_name = unique_name("kernel_" + loop->name, false);
+        string kernel_name = unique_name("kernel_" + loop->name);
         for (size_t i = 0; i < kernel_name.size(); i++) {
             if (!isalnum(kernel_name[i])) {
                 kernel_name[i] = '_';

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -106,7 +106,7 @@ public:
         info.type = expr.type();
         info.size_expr = info.type.bytes();
         info.value_expr = expr;
-        dependency_info[DependencyKey(info.type.bytes(), unique_name("memoize_tag", false))] = info;
+        dependency_info[DependencyKey(info.type.bytes(), unique_name("memoize_tag"))] = info;
     }
 
     // Used to make sure larger parameters come before smaller ones

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -538,8 +538,8 @@ class PartitionLoops : public IRMutator {
         // Construct variables for the bounds of the simplified middle section
         Expr min_steady = op->min, max_steady = op->extent + op->min;
         Expr prologue_val, epilogue_val;
-        string prologue_name = unique_name(op->name + ".prologue", false);
-        string epilogue_name = unique_name(op->name + ".epilogue", false);
+        string prologue_name = unique_name(op->name + ".prologue");
+        string epilogue_name = unique_name(op->name + ".epilogue");
 
         if (make_prologue) {
             // They'll simplify better if you put them in
@@ -785,14 +785,14 @@ class RenormalizeGPULoops : public IRMutator {
             inner = LetStmt::make(condition_name, op->condition, inner);
             stmt = mutate(inner);
         } else if (let_a) {
-            string new_name = unique_name(let_a->name, false);
+            string new_name = unique_name(let_a->name);
             Stmt inner = let_a->body;
             inner = substitute(let_a->name, Variable::make(let_a->value.type(), new_name), inner);
             inner = IfThenElse::make(op->condition, inner, else_case);
             inner = LetStmt::make(new_name, let_a->value, inner);
             stmt = mutate(inner);
         } else if (let_b) {
-            string new_name = unique_name(let_b->name, false);
+            string new_name = unique_name(let_b->name);
             Stmt inner = let_b->body;
             inner = substitute(let_b->name, Variable::make(let_b->value.type(), new_name), inner);
             inner = IfThenElse::make(op->condition, then_case, inner);

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -561,7 +561,7 @@ Module Pipeline::compile_to_module(const vector<Argument> &args,
             private_params.push_back(Variable::make(arg.type, arg.name));
         }
     }
-    string private_result_name = unique_name(private_name + "_result", false);
+    string private_result_name = unique_name(private_name + "_result");
     Expr private_result_var = Variable::make(Int(32), private_result_name);
     Expr call_private = Call::make(Int(32), private_name, private_params, Call::Extern);
     Stmt public_body = AssertStmt::make(private_result_var == 0, private_result_var);

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -33,9 +33,6 @@ public:
 
     /** Construct an RVar with the given name */
     explicit RVar(const std::string &n) : _name(n) {
-        // Make sure we don't get a unique name with the same name as
-        // this later:
-        Internal::unique_name(n, false);
     }
 
     /** Construct a reduction variable with the given name and

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -1029,8 +1029,8 @@ class AndConditionOverDomain : public IRMutator {
         }
 
         if (!value_bounds.max.same_as(op->value) || !value_bounds.min.same_as(op->value)) {
-            string min_name = unique_name(op->name + ".min", false);
-            string max_name = unique_name(op->name + ".max", false);
+            string min_name = unique_name(op->name + ".min");
+            string max_name = unique_name(op->name + ".max");
             Expr min_var, max_var;
             if (!value_bounds.min.defined() ||
                 (is_const(value_bounds.min) && value_bounds.min.as<Variable>())) {

--- a/src/TrimNoOps.cpp
+++ b/src/TrimNoOps.cpp
@@ -386,9 +386,9 @@ class TrimNoOps : public IRMutator {
         // loop range is now truncated
         body = simplify(SimplifyUsingBounds(op->name, i).mutate(body));
 
-        string new_min_name = unique_name(op->name + ".new_min", false);
-        string new_max_name = unique_name(op->name + ".new_max", false);
-        string old_max_name = unique_name(op->name + ".old_max", false);
+        string new_min_name = unique_name(op->name + ".new_min");
+        string new_max_name = unique_name(op->name + ".new_max");
+        string old_max_name = unique_name(op->name + ".old_max");
         Expr new_min_var = Variable::make(Int(32), new_min_name);
         Expr new_max_var = Variable::make(Int(32), new_max_name);
         Expr old_max_var = Variable::make(Int(32), old_max_name);

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -64,11 +64,11 @@ string running_program_name() {
 }
 
 namespace {
-// We use 64K of memory to store unique counters. Using less memory
-// increases the likelihood of hash collisions. This wouldn't break
-// anything, but makes pipelines pseudocode slightly confusing to read
-// because names that are actually unique will get suffixes that
-// falsely hint that they are not.
+// We use 64K of memory to store unique counters for the purpose of
+// making names unique. Using less memory increases the likelihood of
+// hash collisions. This wouldn't break anything, but makes stmts
+// slightly confusing to read because names that are actually unique
+// will get suffixes that falsely hint that they are not.
 
 const int num_unique_name_counters = (1 << 14);
 std::atomic<int> unique_name_counters[num_unique_name_counters];

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -64,6 +64,12 @@ string running_program_name() {
 }
 
 namespace {
+// We use 64K of memory to store unique counters. Using less memory
+// increases the likelihood of hash collisions. This wouldn't break
+// anything, but makes pipelines pseudocode slightly confusing to read
+// because names that are actually unique will get suffixes that
+// falsely hint that they are not.
+
 const int num_unique_name_counters = (1 << 14);
 std::atomic<int> unique_name_counters[num_unique_name_counters];
 
@@ -74,9 +80,9 @@ int unique_count(size_t h) {
 }
 
 // There are three possible families of names returned by the methods below:
-// 1) (char that isn't '$') + number (e.g. v234)
-// 2) (string without '$') + '$' + number (e.g. fr#nk82$42)
-// 3) string that does not match the patterns above
+// 1) char pattern: (char that isn't '$') + number (e.g. v234)
+// 2) string pattern: (string without '$') + '$' + number (e.g. fr#nk82$42)
+// 3) a string that does not match the patterns above
 // There are no collisions within each family, due to the unique_count
 // done above, and there can be no collisions across families by
 // construction.

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <atomic>
 #include <mutex>
+#include <string>
 
 #ifdef __linux__
 #include <unistd.h>
@@ -62,18 +63,75 @@ string running_program_name() {
     #endif
 }
 
-// TODO: Rationalize the two different versions of unique_name,
-// possibly changing the name of one of them as they are used
-// for different things, and in fact the two versions can end
-// up returning the same name, thus they are not collectively
-// unique.
-string unique_name(char prefix) {
-    // arrays with static storage duration should be initialized to zero automatically
-    static std::atomic<int> instances[256];
-    ostringstream str;
-    str << prefix << instances[(unsigned char)prefix]++;
-    return str.str();
+namespace {
+const int num_unique_name_counters = (1 << 14);
+std::atomic<int> unique_name_counters[num_unique_name_counters];
+
+int unique_count(size_t h) {
+    h = h & (num_unique_name_counters - 1);
+    return unique_name_counters[h]++;
 }
+}
+
+// There are three possible families of names returned by the methods below:
+// 1) (char that isn't '$') + number (e.g. v234)
+// 2) (string without '$') + '$' + number (e.g. fr#nk82$42)
+// 3) string that does not match the patterns above
+// There are no collisions within each family, due to the unique_count
+// done above, and there can be no collisions across families by
+// construction.
+
+string unique_name(char prefix) {
+    if (prefix == '$') prefix = '_';
+    return prefix + std::to_string(unique_count((size_t)(prefix)));
+}
+
+string unique_name(const std::string &prefix) {
+    string sanitized = prefix;
+
+    // Does the input string look like something returned from unique_name(char)?
+    bool matches_char_pattern = true;
+
+    // Does the input string look like something returned from unique_name(string)?
+    bool matches_string_pattern = true;
+
+    // Rewrite '$' to '_'. This is a many-to-one mapping, but that's
+    // OK, we're about to hash anyway. It just means that some names
+    // will share the same counter.
+    int num_dollars = 0;
+    for (size_t i = 0; i < sanitized.size(); i++) {
+        if (sanitized[i] == '$') {
+            num_dollars++;
+            sanitized[i] = '_';
+        }
+        if (i > 0 && !isdigit(sanitized[i])) {
+            // Found a non-digit after the first char
+            matches_char_pattern = false;
+            if (num_dollars) {
+                // Found a non-digit after a '$'
+                matches_string_pattern = false;
+            }
+        }
+    }
+    matches_string_pattern &= num_dollars == 1;
+    matches_char_pattern &= prefix.size() > 1;
+
+    // Then add a suffix that's globally unique relative to the hash
+    // of the sanitized name.
+    int count = unique_count(std::hash<std::string>()(sanitized));
+    if (count == 0) {
+        // We can return the name as-is if there's no risk of it
+        // looking like something unique_name has ever returned in the
+        // past or will ever return in the future.
+        if (!matches_char_pattern && !matches_string_pattern) {
+            return prefix;
+        }
+    }
+
+    return sanitized + "$" + std::to_string(count);
+}
+
+
 
 bool starts_with(const string &str, const string &prefix) {
     if (str.size() < prefix.size()) return false;
@@ -99,43 +157,6 @@ string replace_all(string &str, const string &find, const string &replace) {
         pos += replace.length();
     }
     return str;
-}
-
-string unique_name(const string &name, bool user) {
-    static std::mutex known_names_lock;
-    static map<string, int> *known_names = new map<string, int>();
-    {
-        std::lock_guard<std::mutex> lock(known_names_lock);
-
-        // An empty string really does not make sense, but use 'z' as prefix.
-        if (name.length() == 0) {
-            return unique_name('z');
-        }
-
-        // Check the '$' character doesn't appear in the prefix. This lets
-        // us separate the name from the number using '$' as a delimiter,
-        // which guarantees uniqueness of the generated name, without
-        // having to track all names generated so far.
-        if (user) {
-            for (size_t i = 0; i < name.length(); i++) {
-                user_assert(name[i] != '$')
-                    << "Name \"" << name << "\" is invalid. "
-                    << "Halide names may not contain the character '$'\n";
-            }
-        }
-
-        int &count = (*known_names)[name];
-        count++;
-        if (count == 1) {
-            // The very first unique name is the original function name itself.
-            return name;
-        } else {
-            // Use the programmer-specified name but append a number to make it unique.
-            ostringstream oss;
-            oss << name << '$' << count;
-            return oss.str();
-        }
-    }
 }
 
 string base_name(const string &name, char delim) {

--- a/src/Util.h
+++ b/src/Util.h
@@ -67,14 +67,15 @@ EXPORT std::string get_env_variable(char const *env_var_name, size_t &var_define
  * If program name cannot be retrieved, function returns an empty string. */
 EXPORT std::string running_program_name();
 
-/** Generate a unique name starting with the given character. It's
- * unique relative to all other calls to unique_name done by this
- * process. Not thread-safe. */
+/** Generate a unique name starting with the given prefix. It's unique
+ * relative to all other strings returned by unique_name in this
+ * process. Will either return the input as-is, or some mangling of
+ * it.
+ */
+// @{
 EXPORT std::string unique_name(char prefix);
-
-/** Generate a unique name starting with the given string.  Not
- * thread-safe. */
-EXPORT std::string unique_name(const std::string &name, bool user = true);
+EXPORT std::string unique_name(const std::string &prefix);
+// @}
 
 /** Test if the first string starts with the second string */
 EXPORT bool starts_with(const std::string &str, const std::string &prefix);

--- a/src/Util.h
+++ b/src/Util.h
@@ -69,8 +69,19 @@ EXPORT std::string running_program_name();
 
 /** Generate a unique name starting with the given prefix. It's unique
  * relative to all other strings returned by unique_name in this
- * process. Will either return the input as-is, or some mangling of
- * it.
+ * process.
+ *
+ * The single-character version always appends a numeric suffix to the
+ * character.
+ *
+ * The string version will either return the input as-is (with high
+ * probability on the first time it is called with that input), or
+ * replace any existing '$' characters with underscores, then add a
+ * '$' sign and a numeric suffix to it.
+ *
+ * Note that unique_name('f') therefore differs from
+ * unique_name("f"). The former returns something like f123, and the
+ * latter returns either f or f$123.
  */
 // @{
 EXPORT std::string unique_name(char prefix);

--- a/src/Var.cpp
+++ b/src/Var.cpp
@@ -4,17 +4,6 @@
 namespace Halide {
 
 Var::Var(const std::string &n) : _name(n) {
-    // Make sure we don't get a unique name with the same name as this
-    // later. Implicits are constructed at startup and this deadlocks
-    // on Windows do to lock use. Plus the char version of unique_name
-    // can return names that are the same as implicits anyway, so
-    // it shouldn't matter much to protect them.
-    // TODO: Either there is some guarantee needed here or not. If so,
-    // it should be explicitly stated, if not, then this should not be
-    // done.
-    if (!is_implicit(n)) {
-        Internal::unique_name(n, false);
-    }
 }
 
 Var::Var() : _name(Internal::make_entity_name(this, "Halide::Var", 'v')) {

--- a/test/performance/profiler.cpp
+++ b/test/performance/profiler.cpp
@@ -8,7 +8,7 @@ float ms = 0;
 void my_print(void *, const char *msg) {
     float this_ms;
     int this_percentage;
-    int val = sscanf(msg, " f13: %fms (%d", &this_ms, &this_percentage);
+    int val = sscanf(msg, " fn13: %fms (%d", &this_ms, &this_percentage);
     if (val == 2) {
         ms = this_ms;
         percentage = this_percentage;
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
     Func f[30];
     Var c, x;
     for (int i = 0; i < 30; i++) {
-        f[i] = Func("f" + std::to_string(i));
+        f[i] = Func("fn" + std::to_string(i));
         if (i == 0) {
             f[i](c, x) = cast<float>(x + c);
         } else if (i == 13) {
@@ -52,7 +52,7 @@ int main(int argc, char **argv) {
 
     //out.compile_to_assembly("/dev/stdout", {}, t.with_feature(Target::JIT));
 
-    printf("Time spent in f13: %fms\n", ms);
+    printf("Time spent in fn13: %fms\n", ms);
 
     if (percentage < 40) {
         printf("Percentage of runtime spent in f13: %d\n"


### PR DESCRIPTION
Long running processes that created many RDoms would use more and more
memory due to tracking the unique names of their RVars. Overhauled
unique_name to avoid this sort of problem using a bloom filter-style
approach. There are some fixed number of atomic counters used to
generate suffixes, and prefixes map to one of those counters via a hash
function. Hash collisions just mean that multiple prefixes may share the same
counter, so no keys are stored.
