### PR TITLE
Access metadata via getter functions, rather than as extern global vars

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -589,7 +589,8 @@ void CodeGen_C::compile(const LoweredFunc &f) {
 
     if (is_header()) {
         // And also the metadata.
-       stream << "extern const struct halide_filter_metadata_t " << simple_name << "_metadata;\n";
+        stream << "// Result is never null and points to constant static data\n";
+        stream << "extern const struct halide_filter_metadata_t *" << simple_name << "_metadata();\n";
     }
 }
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -870,8 +870,6 @@ llvm::Function *CodeGen_LLVM::embed_metadata_getter(const std::string &metadata_
     llvm::BasicBlock *block = llvm::BasicBlock::Create(module.get()->getContext(), "entry", metadata_getter);
     builder->SetInsertPoint(block);
     builder->CreateRet(metadata_storage);
-    // LoadInst *result = builder->CreateLoad(metadata);
-    // return builder->CreateLoad(buffer_host_ptr(buffer));
     llvm::verifyFunction(*metadata_getter);
 
     return metadata_getter;

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -856,14 +856,13 @@ llvm::Function *CodeGen_LLVM::embed_metadata_getter(const std::string &metadata_
         /* name */ create_string_constant(function_name)
     };
 
-    const std::string metadata_storage_name = metadata_name + "_storage";
     GlobalVariable *metadata_storage = new GlobalVariable(
         *module,
         metadata_t_type,
         /*isConstant*/ true,
         GlobalValue::PrivateLinkage,
         ConstantStruct::get(metadata_t_type, metadata_fields),
-        metadata_storage_name);
+        metadata_name + "_storage");
 
     llvm::FunctionType *func_t = llvm::FunctionType::get(metadata_t_type->getPointerTo(), false);
     llvm::Function *metadata_getter = llvm::Function::Create(func_t, llvm::GlobalValue::ExternalLinkage, metadata_name, module.get());

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -545,13 +545,13 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
         // (useful for calling from JIT and other machine interfaces).
         if (f.linkage == LoweredFunc::External) {
             llvm::Function *wrapper = add_argv_wrapper(module.get(), function, argv_name);
-            llvm::Constant *metadata = embed_metadata(metadata_name, simple_name, f.args);
+            llvm::Function *metadata_getter = embed_metadata_getter(metadata_name, simple_name, f.args);
             if (target.has_feature(Target::RegisterMetadata)) {
-                register_metadata(simple_name, metadata, wrapper);
+                register_metadata(simple_name, metadata_getter, wrapper);
             }
 
             if (target.has_feature(Target::Matlab)) {
-                define_matlab_wrapper(module.get(), wrapper, metadata);
+                define_matlab_wrapper(module.get(), wrapper, metadata_getter);
             }
         }
     }
@@ -815,7 +815,7 @@ Constant* CodeGen_LLVM::embed_constant_expr(Expr e) {
         scalar_value_t_type->getPointerTo());
 }
 
-llvm::Constant *CodeGen_LLVM::embed_metadata(const std::string &metadata_name,
+llvm::Function *CodeGen_LLVM::embed_metadata_getter(const std::string &metadata_name,
         const std::string &function_name, const std::vector<Argument> &args) {
     Constant *zero = ConstantInt::get(i32, 0);
 
@@ -856,18 +856,28 @@ llvm::Constant *CodeGen_LLVM::embed_metadata(const std::string &metadata_name,
         /* name */ create_string_constant(function_name)
     };
 
-    GlobalVariable *metadata = new GlobalVariable(
+    const std::string metadata_storage_name = metadata_name + "_storage";
+    GlobalVariable *metadata_storage = new GlobalVariable(
         *module,
         metadata_t_type,
         /*isConstant*/ true,
-        GlobalValue::ExternalLinkage,
+        GlobalValue::PrivateLinkage,
         ConstantStruct::get(metadata_t_type, metadata_fields),
-        metadata_name);
+        metadata_storage_name);
 
-    return metadata;
+    llvm::FunctionType *func_t = llvm::FunctionType::get(metadata_t_type->getPointerTo(), false);
+    llvm::Function *metadata_getter = llvm::Function::Create(func_t, llvm::GlobalValue::ExternalLinkage, metadata_name, module.get());
+    llvm::BasicBlock *block = llvm::BasicBlock::Create(module.get()->getContext(), "entry", metadata_getter);
+    builder->SetInsertPoint(block);
+    builder->CreateRet(metadata_storage);
+    // LoadInst *result = builder->CreateLoad(metadata);
+    // return builder->CreateLoad(buffer_host_ptr(buffer));
+    llvm::verifyFunction(*metadata_getter);
+
+    return metadata_getter;
 }
 
-void CodeGen_LLVM::register_metadata(const std::string &name, llvm::Constant *metadata, llvm::Function *argv_wrapper) {
+void CodeGen_LLVM::register_metadata(const std::string &name, llvm::Function *metadata_getter, llvm::Function *argv_wrapper) {
     llvm::Function *register_metadata = module->getFunction("halide_runtime_internal_register_metadata");
     internal_assert(register_metadata) << "Could not find register_metadata in initial module\n";
 
@@ -876,7 +886,7 @@ void CodeGen_LLVM::register_metadata(const std::string &name, llvm::Constant *me
 
     Constant *list_node_fields[] = {
         Constant::getNullValue(i8->getPointerTo()),
-        metadata,
+        metadata_getter,
         argv_wrapper
     };
 

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -477,15 +477,16 @@ private:
 
     /** Embed an instance of halide_filter_metadata_t in the code, using
      * the given name (by convention, this should be ${FUNCTIONNAME}_metadata)
-     * as extern "C" linkage.
+     * as extern "C" linkage. Note that the return value is a function-returning-
+     * pointer-to-constant-data.
      */
-    llvm::Constant* embed_metadata(const std::string &metadata_name,
+    llvm::Function* embed_metadata_getter(const std::string &metadata_getter_name,
         const std::string &function_name, const std::vector<Argument> &args);
 
     /** Embed a constant expression as a global variable. */
     llvm::Constant *embed_constant_expr(Expr e);
 
-    void register_metadata(const std::string &name, llvm::Constant *metadata, llvm::Function *argv_wrapper);
+    void register_metadata(const std::string &name, llvm::Function *metadata_getter, llvm::Function *argv_wrapper);
 };
 
 }

--- a/src/MatlabWrapper.h
+++ b/src/MatlabWrapper.h
@@ -22,7 +22,7 @@ namespace Internal {
  * definition. */
 EXPORT llvm::Function *define_matlab_wrapper(llvm::Module *module,
                                              llvm::Function *pipeline_argv_wrapper,
-                                             llvm::Value *metadata);
+                                             llvm::Function *metadata_getter);
 
 }
 }

--- a/src/runtime/metadata.cpp
+++ b/src/runtime/metadata.cpp
@@ -30,7 +30,7 @@ WEAK int halide_enumerate_registered_filters(void *user_context, void* enumerate
     ScopedMutexLock lock(&list_head.mutex);
     for (_halide_runtime_internal_registered_filter_t* f = list_head.next; f != NULL;
          f = (_halide_runtime_internal_registered_filter_t *)(f->next)) {
-        int r = (*func)(enumerate_context, f->metadata, f->argv_func);
+        int r = (*func)(enumerate_context, f->metadata(), f->argv_func);
         if (r != 0) return r;
     }
     return 0;

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -127,7 +127,7 @@ struct _halide_runtime_internal_registered_filter_t {
     // recursive types currently break our method that copies types from
     // llvm module to llvm module
     void *next;
-    const halide_filter_metadata_t* metadata;
+    const halide_filter_metadata_t* (*metadata)();
     int (*argv_func)(void **args);
 };
 WEAK void halide_runtime_internal_register_metadata(_halide_runtime_internal_registered_filter_t *info);

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -457,14 +457,14 @@ int main(int argc, char **argv) {
 
     verify(input, output0, output1);
 
-    check_metadata(metadata_tester_metadata, false);
-    if (!strcmp(metadata_tester_metadata.name, "metadata_tester_metadata")) {
+    check_metadata(*metadata_tester_metadata(), false);
+    if (!strcmp(metadata_tester_metadata()->name, "metadata_tester_metadata")) {
         fprintf(stderr, "Expected name %s\n", "metadata_tester_metadata");
         exit(-1);
     }
 
-    check_metadata(metadata_tester_ucon_metadata, true);
-    if (!strcmp(metadata_tester_ucon_metadata.name, "metadata_tester_ucon_metadata")) {
+    check_metadata(*metadata_tester_ucon_metadata(), true);
+    if (!strcmp(metadata_tester_ucon_metadata()->name, "metadata_tester_ucon_metadata")) {
         fprintf(stderr, "Expected name %s\n", "metadata_tester_ucon_metadata");
         exit(-1);
     }


### PR DESCRIPTION
This is a useful precondition for fixing Issue #879: we want to ensure
that the metadata accessed at runtime also is vetted thru the
halide_can_use_features() function.

(Note that this a breaking change to the public API, but one that is
trivial to fix, and will probably affect very few users.)