### PR TITLE
Move Features enum to HalideRuntime.h

### DIFF
--- a/src/Target.h
+++ b/src/Target.h
@@ -13,6 +13,7 @@
 #include "Type.h"
 #include "Util.h"
 #include "Expr.h"
+#include "runtime/HalideRuntime.h"
 
 namespace Halide {
 
@@ -33,56 +34,43 @@ struct Target {
     int bits;
 
     /** Optional features a target can have.
-     * Corresponds to feature_name_map in Target.cpp. */
-
+     * Corresponds to feature_name_map in Target.cpp. 
+     * See definitions in HalideRuntime.h for full information.
+     */
     enum Feature {
-        JIT,  ///< Generate code that will run immediately inside the calling process.
-        Debug,  ///< Turn on debug info and output for runtime code.
-        NoAsserts,  ///< Disable all runtime checks, for slightly tighter code.
-        NoBoundsQuery, ///< Disable the bounds querying functionality.
-
-        SSE41,  ///< Use SSE 4.1 and earlier instructions. Only relevant on x86.
-        AVX,  ///< Use AVX 1 instructions. Only relevant on x86.
-        AVX2,  ///< Use AVX 2 instructions. Only relevant on x86.
-        FMA,  ///< Enable x86 FMA instruction
-        FMA4,  ///< Enable x86 (AMD) FMA4 instruction set
-        F16C,  ///< Enable x86 16-bit float support
-
-        ARMv7s,  ///< Generate code for ARMv7s. Only relevant for 32-bit ARM.
-        NoNEON,  ///< Avoid using NEON instructions. Only relevant for 32-bit ARM.
-
-        VSX,  ///< Use VSX instructions. Only relevant on POWERPC.
-        POWER_ARCH_2_07,  ///< Use POWER ISA 2.07 new instructions. Only relevant on POWERPC.
-
-        CUDA,  ///< Enable the CUDA runtime. Defaults to compute capability 2.0 (Fermi)
-        CUDACapability30,  ///< Enable CUDA compute capability 3.0 (Kepler)
-        CUDACapability32,  ///< Enable CUDA compute capability 3.2 (Tegra K1)
-        CUDACapability35,  ///< Enable CUDA compute capability 3.5 (Kepler)
-        CUDACapability50,  ///< Enable CUDA compute capability 5.0 (Maxwell)
-
-        OpenCL,  ///< Enable the OpenCL runtime.
-        CLDoubles,  ///< Enable double support on OpenCL targets
-
-        OpenGL,  ///< Enable the OpenGL runtime.
-        OpenGLCompute, ///< Enable OpenGL Compute runtime.
-
-        Renderscript, ///< Enable the Renderscript runtime.
-
-        UserContext,  ///< Generated code takes a user_context pointer as first argument
-
-        RegisterMetadata,  ///< Generated code registers metadata for use with halide_enumerate_registered_filters
-
-        Matlab,  ///< Generate a mexFunction compatible with Matlab mex libraries. See tools/mex_halide.m.
-
-        Profile, ///< Launch a sampling profiler alongside the Halide pipeline that monitors and reports the runtime used by each Func
-        NoRuntime, ///< Do not include a copy of the Halide runtime in any generated object file or assembly
-
-        Metal, ///< Enable the (Apple) Metal runtime.
-        MinGW, ///< For Windows compile to MinGW toolset rather then Visual Studio
-
-        CPlusPlusMangling, ///< Generate C++ mangled names for result function, et al
-
-        FeatureEnd ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
+        JIT = halide_target_feature_jit,
+        Debug = halide_target_feature_debug,
+        NoAsserts = halide_target_feature_no_asserts,
+        NoBoundsQuery = halide_target_feature_no_bounds_query,
+        SSE41 = halide_target_feature_sse41,
+        AVX = halide_target_feature_avx,
+        AVX2 = halide_target_feature_avx2,
+        FMA = halide_target_feature_fma,
+        FMA4 = halide_target_feature_fma4,
+        F16C = halide_target_feature_f16c,
+        ARMv7s = halide_target_feature_armv7s,
+        NoNEON = halide_target_feature_no_neon,
+        VSX = halide_target_feature_vsx,
+        POWER_ARCH_2_07 = halide_target_feature_power_arch_2_07,
+        CUDA = halide_target_feature_cuda,
+        CUDACapability30 = halide_target_feature_cuda_capability30,
+        CUDACapability32 = halide_target_feature_cuda_capability32,
+        CUDACapability35 = halide_target_feature_cuda_capability35,
+        CUDACapability50 = halide_target_feature_cuda_capability50,
+        OpenCL = halide_target_feature_opencl,
+        CLDoubles = halide_target_feature_cl_doubles,
+        OpenGL = halide_target_feature_opengl,
+        OpenGLCompute = halide_target_feature_openglcompute,
+        Renderscript = halide_target_feature_renderscript,
+        UserContext = halide_target_feature_user_context,
+        RegisterMetadata = halide_target_feature_register_metadata,
+        Matlab = halide_target_feature_matlab,
+        Profile = halide_target_feature_profile,
+        NoRuntime = halide_target_feature_no_runtime,
+        Metal = halide_target_feature_metal,
+        MinGW = halide_target_feature_mingw,
+        CPlusPlusMangling = halide_target_feature_c_plus_plus_mangling,
+        FeatureEnd = halide_target_feature_end
     };
 
     Target() : os(OSUnknown), arch(ArchUnknown), bits(0) {}

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -516,6 +516,58 @@ extern int halide_error_unaligned_host_ptr(void *user_context, const char *func_
 
 // @}
 
+/** Optional features a compilation Target can have. 
+ */
+typedef enum halide_target_feature_t {
+    halide_target_feature_jit = 0,  ///< Generate code that will run immediately inside the calling process.
+    halide_target_feature_debug = 1,  ///< Turn on debug info and output for runtime code.
+    halide_target_feature_no_asserts = 2,  ///< Disable all runtime checks, for slightly tighter code.
+    halide_target_feature_no_bounds_query = 3, ///< Disable the bounds querying functionality.
+
+    halide_target_feature_sse41 = 4,  ///< Use SSE 4.1 and earlier instructions. Only relevant on x86.
+    halide_target_feature_avx = 5,  ///< Use AVX 1 instructions. Only relevant on x86.
+    halide_target_feature_avx2 = 6,  ///< Use AVX 2 instructions. Only relevant on x86.
+    halide_target_feature_fma = 7,  ///< Enable x86 FMA instruction
+    halide_target_feature_fma4 = 8,  ///< Enable x86 (AMD) FMA4 instruction set
+    halide_target_feature_f16c = 9,  ///< Enable x86 16-bit float support
+
+    halide_target_feature_armv7s = 10,  ///< Generate code for ARMv7s. Only relevant for 32-bit ARM.
+    halide_target_feature_no_neon = 11,  ///< Avoid using NEON instructions. Only relevant for 32-bit ARM.
+
+    halide_target_feature_vsx = 12,  ///< Use VSX instructions. Only relevant on POWERPC.
+    halide_target_feature_power_arch_2_07 = 13,  ///< Use POWER ISA 2.07 new instructions. Only relevant on POWERPC.
+
+    halide_target_feature_cuda = 14,  ///< Enable the CUDA runtime. Defaults to compute capability 2.0 (Fermi)
+    halide_target_feature_cuda_capability30 = 15,  ///< Enable CUDA compute capability 3.0 (Kepler)
+    halide_target_feature_cuda_capability32 = 16,  ///< Enable CUDA compute capability 3.2 (Tegra K1)
+    halide_target_feature_cuda_capability35 = 17,  ///< Enable CUDA compute capability 3.5 (Kepler)
+    halide_target_feature_cuda_capability50 = 18,  ///< Enable CUDA compute capability 5.0 (Maxwell)
+
+    halide_target_feature_opencl = 19,  ///< Enable the OpenCL runtime.
+    halide_target_feature_cl_doubles = 20,  ///< Enable double support on OpenCL targets
+
+    halide_target_feature_opengl = 21,  ///< Enable the OpenGL runtime.
+    halide_target_feature_openglcompute = 22, ///< Enable OpenGL Compute runtime.
+
+    halide_target_feature_renderscript = 23, ///< Enable the Renderscript runtime.
+
+    halide_target_feature_user_context = 24,  ///< Generated code takes a user_context pointer as first argument
+
+    halide_target_feature_register_metadata = 25,  ///< Generated code registers metadata for use with halide_enumerate_registered_filters
+
+    halide_target_feature_matlab = 26,  ///< Generate a mexFunction compatible with Matlab mex libraries. See tools/mex_halide.m.
+
+    halide_target_feature_profile = 27, ///< Launch a sampling profiler alongside the Halide pipeline that monitors and reports the runtime used by each Func
+    halide_target_feature_no_runtime = 28, ///< Do not include a copy of the Halide runtime in any generated object file or assembly
+
+    halide_target_feature_metal = 29, ///< Enable the (Apple) Metal runtime.
+    halide_target_feature_mingw = 30, ///< For Windows compile to MinGW toolset rather then Visual Studio
+
+    halide_target_feature_c_plus_plus_mangling = 31, ///< Generate C++ mangled names for result function, et al
+
+    halide_target_feature_end = 32 ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
+} halide_target_feature_t;
+
 /** Types in the halide type system. They can be ints, unsigned ints,
  * or floats (of various bit-widths), or a handle (which is always 64-bits).
  * Note that the int/uint/float values do not imply a specific bit width


### PR DESCRIPTION
Work for Issue #879 requires exposing Features to a runtime function;
rather than relying on parsing Target’s string form, let’s make the
Features into supported runtime features (as we already did with
Halide::Type).