### PR TITLE
Util::replace_all() shouldn't mutate source string

### DIFF
--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -228,7 +228,7 @@ string CodeGen_GLSLBase::print_type(Type type, AppendSpaceIfNeeded space_option)
 // Identifiers containing double underscores '__' are reserved in GLSL, so we
 // have to use a different name mangling scheme than in the C code generator.
 std::string CodeGen_GLSLBase::print_name(const std::string &name) {
-    std::string mangled = CodeGen_C::print_name(name);
+    const std::string mangled = CodeGen_C::print_name(name);
     return replace_all(mangled, "__", "XX");
 }
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -156,13 +156,14 @@ bool ends_with(const string &str, const string &suffix) {
     return true;
 }
 
-string replace_all(string &str, const string &find, const string &replace) {
+string replace_all(const string &str, const string &find, const string &replace) {
     size_t pos = 0;
-    while ((pos = str.find(find, pos)) != string::npos) {
-        str.replace(pos, find.length(), replace);
+    string result = str;
+    while ((pos = result.find(find, pos)) != string::npos) {
+        result.replace(pos, find.length(), replace);
         pos += replace.length();
     }
-    return str;
+    return result;
 }
 
 string base_name(const string &name, char delim) {

--- a/src/Util.h
+++ b/src/Util.h
@@ -95,7 +95,7 @@ EXPORT bool starts_with(const std::string &str, const std::string &prefix);
 EXPORT bool ends_with(const std::string &str, const std::string &suffix);
 
 /** Replace all matches of the second string in the first string with the last string */
-EXPORT std::string replace_all(std::string &str, const std::string &find, const std::string &replace);
+EXPORT std::string replace_all(const std::string &str, const std::string &find, const std::string &replace);
 
 /** Return the final token of the name string using the given delimiter. */
 EXPORT std::string base_name(const std::string &name, char delim = '.');


### PR DESCRIPTION
It required an lvalue as first argument, which was mutated in-place as
well as returned (as a copy) as the result. This is inconvenient (since
you may want to pass rvalues as first arg) and dangerous (since you may
not want the input arg mutated in-place).