### PR TITLE
Minor style cleanup for Module

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -437,11 +437,11 @@ public:
 }
 
 void CodeGen_C::compile(const Module &input) {
-    for (size_t i = 0; i < input.buffers.size(); i++) {
-        compile(input.buffers[i]);
+    for (const auto &b : input.buffers()) {
+        compile(b);
     }
-    for (size_t i = 0; i < input.functions.size(); i++) {
-        compile(input.functions[i]);
+    for (const auto &f : input.functions()) {
+        compile(f);
     }
 }
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -537,23 +537,10 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
     for (const auto &b : input.buffers()) {
         compile_buffer(b);
     }
-<<<<<<< HEAD
     for (const auto &f : input.functions()) {
-        std::string simple_name;
-        std::string extern_name;
-        std::string argv_name;
-        std::string metadata_name;
-
-        mangled_names(f, get_target(), simple_name, extern_name, argv_name, metadata_name);
-
-        compile_func(f, simple_name, extern_name);
-=======
-    for (size_t i = 0; i < input.functions.size(); i++) {
-        const LoweredFunc &f = input.functions[i];
         const auto names = get_mangled_names(f, get_target());
 
         compile_func(f, names.simple_name, names.extern_name);
->>>>>>> master
 
         // If the Func is externally visible, also create the argv wrapper
         // (useful for calling from JIT and other machine interfaces).

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -526,12 +526,10 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
 
     // Generate the code for this module.
     debug(1) << "Generating llvm bitcode...\n";
-    for (size_t i = 0; i < input.buffers.size(); i++) {
-        compile_buffer(input.buffers[i]);
+    for (const auto &b : input.buffers()) {
+        compile_buffer(b);
     }
-    for (size_t i = 0; i < input.functions.size(); i++) {
-        const LoweredFunc &f = input.functions[i];
-
+    for (const auto &f : input.functions()) {
         std::string simple_name;
         std::string extern_name;
         std::string argv_name;

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -48,11 +48,11 @@ ostream &operator <<(ostream &stream, const Buffer &buffer) {
 
 ostream &operator<<(ostream &stream, const Module &m) {
     stream << "Target = " << m.target().to_string() << "\n";
-    for (size_t i = 0; i < m.buffers.size(); i++) {
-        stream << m.buffers[i] << "\n";
+    for (const auto &b : m.buffers()) {
+        stream << b << "\n";
     }
-    for (size_t i = 0; i < m.functions.size(); i++) {
-        stream << m.functions[i] << "\n";
+    for (const auto &f : m.functions()) {
+        stream << f << "\n";
     }
     return stream;
 }

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -18,11 +18,11 @@ Module link_modules(const std::string &name, const std::vector<Module> &modules)
 
         // TODO(dsharlet): Check for naming collisions, maybe rename
         // internal linkage declarations in the case of collision.
-        for (size_t i = 0; i < input.buffers.size(); i++) {
-            output.append(input.buffers[i]);
+        for (const auto &b : input.buffers()) {
+            output.append(b);
         }
-        for (size_t i = 0; i < input.functions.size(); i++) {
-            output.append(input.functions[i]);
+        for (const auto &f : input.functions()) {
+            output.append(f);
         }
     }
 

--- a/src/Module.h
+++ b/src/Module.h
@@ -47,6 +47,12 @@ class Module {
     std::string name_;
     Target target_;
 
+    /** The declarations contained in this module. */
+    // @{
+    std::vector<Buffer> buffers_;
+    std::vector<Internal::LoweredFunc> functions_;
+    // @}
+
 public:
     EXPORT Module(const std::string &name, const Target &target) : name_(name), target_(target) {}
 
@@ -57,19 +63,17 @@ public:
      * for output operations. */
     EXPORT const std::string &name() const { return name_; }
 
-    /** The declarations contained in this module. */
-    // @{
-    std::vector<Buffer> buffers;
-    std::vector<Internal::LoweredFunc> functions;
-    // @}
+    EXPORT const std::vector<Buffer> &buffers() const { return buffers_; }
+
+    EXPORT const std::vector<Internal::LoweredFunc> &functions() const { return functions_; }
 
     /** Add a declaration to this module. */
     // @{
     void append(const Buffer &buffer) {
-        buffers.push_back(buffer);
+        buffers_.push_back(buffer);
     }
     void append(const Internal::LoweredFunc &function) {
-        functions.push_back(function);
+        functions_.push_back(function);
     }
     // @}
 };

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -489,13 +489,13 @@ Module Pipeline::compile_to_module(const vector<Argument> &args,
     Stmt private_body;
 
     const Module &old_module = contents.ptr->module;
-    if (!old_module.functions.empty() &&
+    if (!old_module.functions().empty() &&
         old_module.target() == target) {
-        internal_assert(old_module.functions.size() == 2);
+        internal_assert(old_module.functions().size() == 2);
         // We can avoid relowering and just reuse the private body
         // from the old module. We expect two functions in the old
         // module: the private one then the public one.
-        private_body = old_module.functions[0].body;
+        private_body = old_module.functions().front().body;
         debug(2) << "Reusing old module\n";
     } else {
         vector<IRMutator *> custom_passes;
@@ -623,11 +623,11 @@ void *Pipeline::compile_jit(const Target &target_arg) {
     Module module = compile_to_module(args, name, target);
 
     // Make sure we're not embedding any images
-    internal_assert(module.buffers.empty());
+    internal_assert(module.buffers().empty());
 
     std::map<std::string, JITExtern> lowered_externs = contents.ptr->jit_externs;
     // Compile to jit module
-    JITModule jit_module(module, module.functions.back(),
+    JITModule jit_module(module, module.functions().back(),
                          make_externs_jit_module(target_arg, lowered_externs));
 
     // Dump bitcode to a file if the environment variable

--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -691,11 +691,11 @@ void print_to_html(string filename, Stmt s) {
 
 void print_to_html(string filename, const Module &m) {
     StmtToHtml sth(filename);
-    for (size_t i = 0; i < m.buffers.size(); i++) {
-        sth.print(m.buffers[i]);
+    for (const auto &b : m.buffers()) {
+        sth.print(b);
     }
-    for (size_t i = 0; i < m.functions.size(); i++) {
-        sth.print(m.functions[i]);
+    for (const auto &f : m.functions()) {
+        sth.print(f);
     }
 }
 

--- a/test/correctness/specialize.cpp
+++ b/test/correctness/specialize.cpp
@@ -395,7 +395,7 @@ int main(int argc, char **argv) {
 
         if_then_else_count = 0;
         CountIfThenElse pass1;
-        for (auto ff : out.compile_to_module(out.infer_arguments()).functions) {
+        for (auto ff : out.compile_to_module(out.infer_arguments()).functions()) {
             pass1.mutate(ff.body);
         }
 
@@ -425,7 +425,7 @@ int main(int argc, char **argv) {
 
         if_then_else_count = 0;
         CountIfThenElse pass2;
-        for (auto ff : out.compile_to_module(out.infer_arguments()).functions) {
+        for (auto ff : out.compile_to_module(out.infer_arguments()).functions()) {
             pass2.mutate(ff.body);
         }
 

--- a/test/correctness/trim_no_ops.cpp
+++ b/test/correctness/trim_no_ops.cpp
@@ -50,9 +50,9 @@ int main(int argc, char **argv) {
         // There should be no selects after trim_no_ops runs
         Module m = f.compile_to_module({});
         CountConditionals s;
-        m.functions[0].body.accept(&s);
+        m.functions().front().body.accept(&s);
         if (s.count != 0) {
-            std::cerr << "There were selects in the lowered code: \n" << m.functions[0].body << "\n";
+            std::cerr << "There were selects in the lowered code: \n" << m.functions().front().body << "\n";
             return -1;
         }
 
@@ -84,9 +84,9 @@ int main(int argc, char **argv) {
 
         // There should be no selects after trim_no_ops runs
         CountConditionals s;
-        m.functions[0].body.accept(&s);
+        m.functions().front().body.accept(&s);
         if (s.count != 0) {
-            std::cerr << "There were selects in the lowered code: \n" << m.functions[0].body << "\n";
+            std::cerr << "There were selects in the lowered code: \n" << m.functions().front().body << "\n";
             return -1;
         }
 
@@ -123,9 +123,9 @@ int main(int argc, char **argv) {
 
             Module m = hist.compile_to_module({});
             CountConditionals s;
-            m.functions[0].body.accept(&s);
+            m.functions().front().body.accept(&s);
             if (s.count != 0) {
-                std::cerr << "There were selects in the lowered code: \n" << m.functions[0].body << "\n";
+                std::cerr << "There were selects in the lowered code: \n" << m.functions().front().body << "\n";
                 return -1;
             }
         }
@@ -163,9 +163,9 @@ int main(int argc, char **argv) {
         // Check there are no if statements.
         Module m = f.compile_to_module({});
         CountConditionals s;
-        m.functions[0].body.accept(&s);
+        m.functions().front().body.accept(&s);
         if (s.count != 0) {
-            std::cerr << "There were selects or ifs in the lowered code: \n" << m.functions[0].body << "\n";
+            std::cerr << "There were selects or ifs in the lowered code: \n" << m.functions().front().body << "\n";
             return -1;
         }
     }
@@ -198,13 +198,13 @@ int main(int argc, char **argv) {
         gpu_target.set_feature(Target::CUDA);
         Module m = f.compile_to_module({}, "", gpu_target);
         CountConditionals s;
-        m.functions[0].body.accept(&s);
+        m.functions().front().body.accept(&s);
         if (s.count_select != 0) {
-            std::cerr << "There were selects in the lowered code: \n" << m.functions[0].body << "\n";
+            std::cerr << "There were selects in the lowered code: \n" << m.functions().front().body << "\n";
             return -1;
         }
         if (s.count_if != 1) {
-            std::cerr << "There should be 1 if in the lowered code: \n" << m.functions[0].body << "\n";
+            std::cerr << "There should be 1 if in the lowered code: \n" << m.functions().front().body << "\n";
             return -1;
         }
 


### PR DESCRIPTION
All existing use was possible via the accessors and mutators, so make
the public members private. Also change list iteration to use C++11
style iteration.

(Purely stylistic and maybe overkill, but it was bothering me.)