### PR TITLE
consolidate Pipeline compile_to logic

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -364,7 +364,7 @@ void GeneratorBase::emit_filter(const std::string &output_dir,
 
     std::string base_path = output_dir + "/" + (file_base_name.empty() ? simple_name : file_base_name);
 
-    Module m = build_pipeline().compile_to_module(inputs, function_name, target);
+    Module m = pipeline.compile_to_module(inputs, function_name, target);
 
     if (options.emit_o || options.emit_assembly || options.emit_bitcode) {
         Outputs output_files;

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -390,7 +390,7 @@ void GeneratorBase::emit_filter(const std::string &output_dir,
             // and passed to LLVM, for both the pnacl and ordinary archs
             output_files.bitcode_name = base_path + get_extension(".bc", options);
         }
-        compile_module_to(m, output_files);
+        compile_module_to_outputs(m, output_files);
     }
     if (options.emit_h) {
         compile_module_to_c_header(m, base_path + get_extension(".h", options));

--- a/src/Output.cpp
+++ b/src/Output.cpp
@@ -9,7 +9,7 @@
 
 namespace Halide {
 
-void compile_module_to(const Module &module, const Outputs &output_files) {
+void compile_module_to_outputs(const Module &module, const Outputs &output_files) {
     llvm::LLVMContext context;
     std::unique_ptr<llvm::Module> llvm_module(compile_module_to_llvm_module(module, context));
 
@@ -45,13 +45,13 @@ void compile_module_to_object(const Module &module, std::string filename) {
         }
     }
 
-    compile_module_to(module, Outputs().object(filename));
+    compile_module_to_outputs(module, Outputs().object(filename));
 }
 
 void compile_module_to_assembly(const Module &module, std::string filename)  {
     if (filename.empty()) filename = module.name() + ".s";
 
-    compile_module_to(module, Outputs().assembly(filename));
+    compile_module_to_outputs(module, Outputs().assembly(filename));
 }
 
 void compile_module_to_native(const Module &module,
@@ -69,19 +69,19 @@ void compile_module_to_native(const Module &module,
         assembly_filename = module.name() + ".s";
     }
 
-    compile_module_to(module, Outputs().object(object_filename).assembly(assembly_filename));
+    compile_module_to_outputs(module, Outputs().object(object_filename).assembly(assembly_filename));
 }
 
 void compile_module_to_llvm_bitcode(const Module &module, std::string filename)  {
     if (filename.empty()) filename = module.name() + ".bc";
 
-    compile_module_to(module, Outputs().bitcode(filename));
+    compile_module_to_outputs(module, Outputs().bitcode(filename));
 }
 
 void compile_module_to_llvm_assembly(const Module &module, std::string filename)  {
     if (filename.empty()) filename = module.name() + ".ll";
 
-    compile_module_to(module, Outputs().llvm_assembly(filename));
+    compile_module_to_outputs(module, Outputs().llvm_assembly(filename));
 }
 
 void compile_module_to_llvm(const Module &module,
@@ -90,7 +90,7 @@ void compile_module_to_llvm(const Module &module,
     if (bitcode_filename.empty()) bitcode_filename = module.name() + ".bc";
     if (llvm_assembly_filename.empty()) llvm_assembly_filename = module.name() + ".ll";
 
-    compile_module_to(module, Outputs().bitcode(bitcode_filename).llvm_assembly(llvm_assembly_filename));
+    compile_module_to_outputs(module, Outputs().bitcode(bitcode_filename).llvm_assembly(llvm_assembly_filename));
 }
 
 void compile_module_to_html(const Module &module, std::string filename) {

--- a/src/Output.h
+++ b/src/Output.h
@@ -8,8 +8,17 @@
  */
 
 #include "Module.h"
+#include "Pipeline.h"
 
 namespace Halide {
+
+/** Compile a halide Module to a native target (object file, native
+ * assembly) or an LLVM Target (bitcode file, llvm assembly), depending on 
+ * the target setting of the Module. The function that compiles both is more efficient
+ * because it re-uses internal results. The default filename is the
+ * name of the module with the default extension for the target type
+ * (.o for objects, .s for assembly). */
+EXPORT void compile_module_to(const Module &module, const Outputs &output_files);
 
 /** Compile a halide Module to a native target (object file, native
  * assembly). The function that compiles both is more efficient

--- a/src/Output.h
+++ b/src/Output.h
@@ -71,7 +71,7 @@ struct Outputs {
  * because it re-uses internal results. The default filename is the
  * name of the module with the default extension for the target type
  * (.o for objects, .s for assembly). */
-EXPORT void compile_module_to(const Module &module, const Outputs &output_files);
+EXPORT void compile_module_to_outputs(const Module &module, const Outputs &output_files);
 
 /** Compile a halide Module to a native target (object file, native
  * assembly). The function that compiles both is more efficient

--- a/src/Output.h
+++ b/src/Output.h
@@ -7,10 +7,63 @@
  * objects from Halide Module objects.
  */
 
+#include <string>
+
 #include "Module.h"
-#include "Pipeline.h"
 
 namespace Halide {
+
+/** A struct specifying a collection of outputs. Used as an argument
+ * to Pipeline::compile_to and Func::compile_to */
+struct Outputs {
+    /** The name of the emitted object file. Empty if no object file
+     * output is desired. */
+    std::string object_name;
+
+    /** The name of the emitted text assembly file. Empty if no
+     * assembly file output is desired. */
+    std::string assembly_name;
+
+    /** The name of the emitted llvm bitcode. Empty if no llvm bitcode
+     * output is desired. */
+    std::string bitcode_name;
+
+    /** The name of the emitted llvm assembly. Empty if no llvm assembly
+     * output is desired. */
+    std::string llvm_assembly_name;
+
+    /** Make a new Outputs struct that emits everything this one does
+     * and also an object file with the given name. */
+    Outputs object(const std::string &object_name) {
+        Outputs updated = *this;
+        updated.object_name = object_name;
+        return updated;
+    }
+
+    /** Make a new Outputs struct that emits everything this one does
+     * and also an assembly file with the given name. */
+    Outputs assembly(const std::string &assembly_name) {
+        Outputs updated = *this;
+        updated.assembly_name = assembly_name;
+        return updated;
+    }
+
+    /** Make a new Outputs struct that emits everything this one does
+     * and also an llvm bitcode file with the given name. */
+    Outputs bitcode(const std::string &bitcode_name) {
+        Outputs updated = *this;
+        updated.bitcode_name = bitcode_name;
+        return updated;
+    }
+
+    /** Make a new Outputs struct that emits everything this one does
+     * and also an llvm assembly file with the given name. */
+    Outputs llvm_assembly(const std::string &llvm_assembly_name) {
+        Outputs updated = *this;
+        updated.llvm_assembly_name = llvm_assembly_name;
+        return updated;
+    }
+};
 
 /** Compile a halide Module to a native target (object file, native
  * assembly) or an LLVM Target (bitcode file, llvm assembly), depending on 

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -154,28 +154,7 @@ void Pipeline::compile_to(const Outputs &output_files,
             << "Can't compile undefined Func.\n";
     }
 
-    Module m = compile_to_module(args, fn_name, target);
-
-    llvm::LLVMContext context;
-    std::unique_ptr<llvm::Module> llvm_module(compile_module_to_llvm_module(m, context));
-
-    if (!output_files.object_name.empty()) {
-        if (target.arch == Target::PNaCl) {
-            compile_llvm_module_to_llvm_bitcode(*llvm_module, output_files.object_name);
-        } else {
-            compile_llvm_module_to_object(*llvm_module, output_files.object_name);
-        }
-    }
-    if (!output_files.assembly_name.empty()) {
-        if (target.arch == Target::PNaCl) {
-            compile_llvm_module_to_llvm_assembly(*llvm_module, output_files.assembly_name);
-        } else {
-            compile_llvm_module_to_assembly(*llvm_module, output_files.assembly_name);
-        }
-    }
-    if (!output_files.bitcode_name.empty()) {
-        compile_llvm_module_to_llvm_bitcode(*llvm_module, output_files.bitcode_name);
-    }
+    compile_module_to(compile_to_module(args, fn_name, target), output_files);
 }
 
 

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -154,7 +154,7 @@ void Pipeline::compile_to(const Outputs &output_files,
             << "Can't compile undefined Func.\n";
     }
 
-    compile_module_to(compile_to_module(args, fn_name, target), output_files);
+    compile_module_to_outputs(compile_to_module(args, fn_name, target), output_files);
 }
 
 

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -25,7 +25,7 @@ struct PipelineContents;
 
 namespace Internal {
 class IRMutator;
-}
+}  // namespace Internal
 
 /**
  * Used to determine if the output printed to file should be as a normal string
@@ -42,7 +42,7 @@ template<typename T>
 void delete_lowering_pass(T *pass) {
     delete pass;
 }
-}
+}  // namespace
 
 /** A custom lowering pass. See Pipeline::add_custom_lowering_pass. */
 struct CustomLoweringPass {
@@ -65,6 +65,10 @@ struct Outputs {
      * output is desired. */
     std::string bitcode_name;
 
+    /** The name of the emitted llvm assembly. Empty if no llvm assembly
+     * output is desired. */
+    std::string llvm_assembly_name;
+
     /** Make a new Outputs struct that emits everything this one does
      * and also an object file with the given name. */
     Outputs object(const std::string &object_name) {
@@ -86,6 +90,14 @@ struct Outputs {
     Outputs bitcode(const std::string &bitcode_name) {
         Outputs updated = *this;
         updated.bitcode_name = bitcode_name;
+        return updated;
+    }
+
+    /** Make a new Outputs struct that emits everything this one does
+     * and also an llvm assembly file with the given name. */
+    Outputs llvm_assembly(const std::string &llvm_assembly_name) {
+        Outputs updated = *this;
+        updated.llvm_assembly_name = llvm_assembly_name;
         return updated;
     }
 };
@@ -495,6 +507,6 @@ struct JITExtern {
     }
 };
 
-}
+}  // namespace Halide
 
 #endif

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -14,7 +14,6 @@
 #include "Image.h"
 #include "JITModule.h"
 #include "Module.h"
-#include "Output.h"
 #include "Tuple.h"
 #include "Target.h"
 
@@ -22,6 +21,7 @@ namespace Halide {
 
 struct Argument;
 class Func;
+struct Outputs;
 struct PipelineContents;
 
 namespace Internal {

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -14,6 +14,7 @@
 #include "Image.h"
 #include "JITModule.h"
 #include "Module.h"
+#include "Output.h"
 #include "Tuple.h"
 #include "Target.h"
 
@@ -48,58 +49,6 @@ void delete_lowering_pass(T *pass) {
 struct CustomLoweringPass {
     Internal::IRMutator *pass;
     void (*deleter)(Internal::IRMutator *);
-};
-
-/** A struct specifying a collection of outputs. Used as an argument
- * to Pipeline::compile_to and Func::compile_to */
-struct Outputs {
-    /** The name of the emitted object file. Empty if no object file
-     * output is desired. */
-    std::string object_name;
-
-    /** The name of the emitted text assembly file. Empty if no
-     * assembly file output is desired. */
-    std::string assembly_name;
-
-    /** The name of the emitted llvm bitcode. Empty if no llvm bitcode
-     * output is desired. */
-    std::string bitcode_name;
-
-    /** The name of the emitted llvm assembly. Empty if no llvm assembly
-     * output is desired. */
-    std::string llvm_assembly_name;
-
-    /** Make a new Outputs struct that emits everything this one does
-     * and also an object file with the given name. */
-    Outputs object(const std::string &object_name) {
-        Outputs updated = *this;
-        updated.object_name = object_name;
-        return updated;
-    }
-
-    /** Make a new Outputs struct that emits everything this one does
-     * and also an assembly file with the given name. */
-    Outputs assembly(const std::string &assembly_name) {
-        Outputs updated = *this;
-        updated.assembly_name = assembly_name;
-        return updated;
-    }
-
-    /** Make a new Outputs struct that emits everything this one does
-     * and also an llvm bitcode file with the given name. */
-    Outputs bitcode(const std::string &bitcode_name) {
-        Outputs updated = *this;
-        updated.bitcode_name = bitcode_name;
-        return updated;
-    }
-
-    /** Make a new Outputs struct that emits everything this one does
-     * and also an llvm assembly file with the given name. */
-    Outputs llvm_assembly(const std::string &llvm_assembly_name) {
-        Outputs updated = *this;
-        updated.llvm_assembly_name = llvm_assembly_name;
-        return updated;
-    }
 };
 
 struct JITExtern;


### PR DESCRIPTION
— Move the logic from Pipeline::compile_to into the (new)
Outputs::compile_module_to() function
— Rework the other functions in Outputs.cpp to use compile_module_to()
as appropriate, rather than replicating the logic
— Rework GeneratorBase::emit_filter() to build a Module explicitly,
then use the compile_module_xxx() calls directly (rather than going
thru the equivalent Pipeline wrappers)

The motivation for this change is primarily to make some upcoming
changes for Issue #879, but as a nice side-effect it avoids a number of
redundant compile_to_module() calls in the Generator code path.