### PR TITLE
Emit correct metadata if params are mutated during build()

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -259,6 +259,13 @@ GeneratorBase::GeneratorBase(size_t size, const void *introspection_helper) : si
 
 GeneratorBase::~GeneratorBase() { ObjectInstanceRegistry::unregister_instance(this); }
 
+void GeneratorBase::rebuild_params() {
+    params_built = false;
+    filter_arguments.clear();
+    generator_params.clear();
+    build_params();
+}
+
 void GeneratorBase::build_params() {
     if (!params_built) {
         std::vector<void *> vf = ObjectInstanceRegistry::instances_in_range(
@@ -347,8 +354,11 @@ void GeneratorBase::emit_filter(const std::string &output_dir,
 
     Pipeline pipeline = build_pipeline();
 
+    // Building the pipeline may mutate the params and imageparams.
+    rebuild_params();
+
     std::vector<Halide::Argument> inputs = get_filter_arguments();
-    
+
     std::vector<std::string> namespaces;
     std::string simple_name = extract_namespaces(function_name, namespaces);
 

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -621,6 +621,7 @@ private:
     virtual const std::string &generator_name() const = 0;
 
     EXPORT void build_params();
+    EXPORT void rebuild_params();
 
     // Provide private, unimplemented, wrong-result-type methods here
     // so that Generators don't attempt to call the global methods


### PR DESCRIPTION
This shows up as pipelines failing a type check in matlab if the
generator's build() method changes the type of an imageparam.