### PR TITLE
Add utility to produce .a files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,6 +340,7 @@ SOURCE_FILES = \
   SkipStages.cpp \
   SlidingWindow.cpp \
   Solve.cpp \
+  StaticLibrary.cpp \
   StmtToHtml.cpp \
   StorageFlattening.cpp \
   StorageFolding.cpp \
@@ -470,6 +471,7 @@ HEADER_FILES = \
   SkipStages.h \
   SlidingWindow.h \
   Solve.h \
+  StaticLibrary.h \
   StmtToHtml.h \
   StorageFlattening.h \
   StorageFolding.h \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -296,6 +296,7 @@ set(HEADER_FILES
   SkipStages.h
   SlidingWindow.h
   Solve.h
+  StaticLibrary.h
   StmtToHtml.h
   StorageFlattening.h
   StorageFolding.h
@@ -439,6 +440,7 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   SkipStages.cpp
   SlidingWindow.cpp
   Solve.cpp
+  StaticLibrary.cpp
   StmtToHtml.cpp
   StorageFlattening.cpp
   StorageFolding.cpp

--- a/src/StaticLibrary.cpp
+++ b/src/StaticLibrary.cpp
@@ -101,7 +101,7 @@ private:
 };
 
 std::string pad_right(std::string s, size_t max) {
-    internal_assert(s.size() <= max) << s.size() << " "<<s;
+    internal_assert(s.size() <= max) << s.size() << " " << s;
     while (s.size() < max) {
         s += " ";
     }

--- a/src/StaticLibrary.cpp
+++ b/src/StaticLibrary.cpp
@@ -37,7 +37,6 @@ std::string octal_string(int value, size_t pad) {
 void create_ar_file(const std::vector<std::string> &src_files, 
                     const std::string &dst_file, bool deterministic) {
     std::ofstream ar(dst_file, std::ofstream::out | std::ofstream::binary);
-    user_assert(ar.good());
     ar << "!<arch>\x0A";
     for (const std::string &src_path : src_files) {
         FileStat stat = file_stat(src_path);
@@ -69,6 +68,7 @@ void create_ar_file(const std::vector<std::string> &src_files,
             ar << src.rdbuf();
         }
     }
+    user_assert(ar.good());
 }
 
 void static_library_test() {

--- a/src/StaticLibrary.cpp
+++ b/src/StaticLibrary.cpp
@@ -117,35 +117,39 @@ std::string octal_string(int value, size_t pad) {
 
 }  // namespace
 
-void create_ar_file(const std::vector<std::string> &src_files, const std::string &dst_file) {
+void create_ar_file(const std::vector<std::string> &src_files, 
+                    const std::string &dst_file, bool deterministic) {
     File ar(dst_file, "wb");
     ar.write("!<arch>\x0A", 8);
-    for (const std::string &src_file : src_files) {
-        File::Stat stat = File::stat(src_file);
+    for (const std::string &src_path : src_files) {
+        File::Stat stat = File::stat(src_path);
 
-        size_t filesize = stat.file_size;
-        if (src_file.size() > 16) {
-            ar.write("#1/" + decimal_string(src_file.size(), 13));
-            filesize += src_file.size();
-        } else {
-            ar.write(pad_right(src_file, 16));
-        }
-        ar.write(decimal_string(stat.mod_time, 12));  // mod time
-        ar.write(decimal_string(stat.uid, 6));  // user id
-        ar.write(decimal_string(stat.gid, 6));  // group id
-        ar.write(octal_string(stat.mode, 8));  // mode
-        ar.write(decimal_string(filesize, 10));  // filesize
-        ar.write("\x60\x0A");  // magic
-        if (src_file.size() > 16) {
-            ar.write(src_file);
-        }
-        {
-            File src(src_file, "rb");
-            // Just slurp everything into memory and write it back out.
-            ar.write(src.read(stat.file_size));  // slurp it all over
-        }
+        // Each member must begin on an even byte boundary; insert LF as needed
         if (ar.tell() & 1) {
             ar.write("\x0A");
+        }
+        // Need to embed just the leaf name
+        std::string src_name = base_name(src_path, '/');
+        size_t filesize = stat.file_size;
+        if (src_name.size() > 16) {
+            ar.write("#1/" + decimal_string(src_name.size(), 13));
+            filesize += src_name.size();
+        } else {
+            ar.write(pad_right(src_name, 16));
+        }
+        ar.write(decimal_string(deterministic ? 0 : stat.mod_time, 12));  // mod time
+        ar.write(decimal_string(deterministic ? 0 : stat.uid, 6));  // user id
+        ar.write(decimal_string(deterministic ? 0 : stat.gid, 6));  // group id
+        ar.write(octal_string(deterministic ? 0644 : stat.mode, 8));  // mode
+        ar.write(decimal_string(filesize, 10));  // filesize
+        ar.write("\x60\x0A");  // magic
+        if (src_name.size() > 16) {
+            ar.write(src_name);
+        }
+        {
+            File src(src_path, "rb");
+            // Just slurp everything into memory and write it back out.
+            ar.write(src.read(stat.file_size));  // slurp it all over
         }
     }
 }
@@ -157,20 +161,29 @@ void static_library_test() {
 
         File b("b_long_name_is_long.tmp", "w");
         b.write("c456d");
+
+        File c("./c_path.tmp", "w");
+        c.write("e789f");
     }
 
-    create_ar_file({"a.tmp", "b_long_name_is_long.tmp"}, "arfile.a");
+    create_ar_file({"a.tmp", "b_long_name_is_long.tmp", "./c_path.tmp"}, "arfile.a");
 
     File::Stat stat = File::stat("arfile.a");
-    internal_assert(stat.file_size == 162) << "Filesize was " << stat.file_size;
-
     {
         File ar("arfile.a", "r");
-        auto slurp = ar.read(162);
-        // TODO(srj): verify contents are correct, but ignore mod/uid/gid/mode
+        auto slurp = ar.read(stat.file_size);
+        const std::string actual = std::string((const char*)slurp.data(), slurp.size());
+        const std::string expected = R"literal(!<arch>
+a.tmp           0           0     0     644     5         `
+a123b
+#1/23           0           0     0     644     28        `
+b_long_name_is_long.tmpc456dc_path.tmp      0           0     0     644     5         `
+e789f)literal";
+        internal_assert(actual == expected) << "File contents wrong, expected:(" << expected << ")\nactual:(" << actual << ")\n";
     }
     File::unlink("a.tmp");
     File::unlink("b_long_name_is_long.tmp");
+    File::unlink("./c_path.tmp");
     File::unlink("arfile.a");
 
     debug(0) << "static_library_test passed\n";

--- a/src/StaticLibrary.cpp
+++ b/src/StaticLibrary.cpp
@@ -1,0 +1,180 @@
+#include "StaticLibrary.h"
+
+#include <stdio.h>
+#ifndef _MSC_VER
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#include "Error.h"
+
+namespace Halide {
+namespace Internal {
+
+namespace {
+
+class File {
+public:
+    File(const std::string &name, const char *mode) : name(name), f(fopen(name.c_str(), mode)) {
+        internal_assert(f != nullptr) << "Could not open file " << f << " in mode " << mode << "\n";
+    }
+    ~File() {
+        if (f != nullptr) {
+            fclose(f);
+        }
+    }
+    void write(const void *data, size_t size) {
+        if (!fwrite(data, size, 1, f)) {
+            user_error << "Could not write to " << name << "\n";
+        }
+    }
+
+    void write(const std::string &str) {
+        write(str.c_str(), str.size());
+    }
+
+    void write(const std::vector<uint8_t> &data) {
+        write(&data[0], data.size());
+    }
+
+    std::vector<uint8_t> read(size_t size) {
+        std::vector<uint8_t> result(size);
+        if (!fread(&result[0], size, 1, f)) {
+            user_error << "Could not read from " << name << "\n";
+        }
+        return result;
+    }
+
+    size_t tell() {
+        long offset = ftell(f);
+        if (offset < 0) {
+            user_error << "Could not ftell: " << name << "\n";
+        }
+        return (size_t) offset;
+    }
+
+    static bool exists(const std::string &name) {
+        #ifdef _MSC_VER
+        return _access(name.c_str(), 0) == 0;
+        #else
+        return ::access(name.c_str(), F_OK) == 0;
+        #endif
+    }
+
+    static void unlink(const std::string &name) {
+        #ifdef _MSC_VER
+        _unlink(name.c_str());
+        #else
+        ::unlink(name.c_str());
+        #endif
+    }
+
+    struct Stat {
+        off_t file_size;
+        time_t mod_time;
+        uid_t uid;
+        gid_t gid;
+        mode_t mode;
+    };
+
+    static Stat stat(const std::string &name) {
+        #ifdef _MSC_VER
+        struct _stat a;
+        if (_stat(name.c_str(), &a) != 0) {
+            user_error << "Could not stat " << name << "\n";
+        }
+        #else
+        struct stat a;
+        if (::stat(name.c_str(), &a) != 0) {
+            user_error << "Could not stat " << name << "\n";
+        }
+        #endif
+        return { a.st_size, a.st_mtime, a.st_uid, a.st_gid, a.st_mode };
+    }
+
+private:
+    const std::string name;
+    FILE *f;
+};
+
+std::string pad_right(std::string s, size_t max) {
+    internal_assert(s.size() <= max) << s.size() << " "<<s;
+    while (s.size() < max) {
+        s += " ";
+    }
+    return s;
+}
+
+std::string decimal_string(int value, size_t pad) {
+    return pad_right(std::to_string(value), pad);
+}
+
+std::string octal_string(int value, size_t pad) {
+    char buf[256];
+    snprintf(buf, sizeof(buf), "%o", value);
+    return pad_right(buf, pad);
+}
+
+}  // namespace
+
+void create_ar_file(const std::vector<std::string> &src_files, const std::string &dst_file) {
+    File ar(dst_file, "wb");
+    ar.write("!<arch>\x0A", 8);
+    for (const std::string &src_file : src_files) {
+        File::Stat stat = File::stat(src_file);
+
+        size_t filesize = stat.file_size;
+        if (src_file.size() > 16) {
+            ar.write("#1/" + decimal_string(src_file.size(), 13));
+            filesize += src_file.size();
+        } else {
+            ar.write(pad_right(src_file, 16));
+        }
+        ar.write(decimal_string(stat.mod_time, 12));  // mod time
+        ar.write(decimal_string(stat.uid, 6));  // user id
+        ar.write(decimal_string(stat.gid, 6));  // group id
+        ar.write(octal_string(stat.mode, 8));  // mode
+        ar.write(decimal_string(filesize, 10));  // filesize
+        ar.write("\x60\x0A");  // magic
+        if (src_file.size() > 16) {
+            ar.write(src_file);
+        }
+        {
+            File src(src_file, "rb");
+            // Just slurp everything into memory and write it back out.
+            ar.write(src.read(stat.file_size));  // slurp it all over
+        }
+        if (ar.tell() & 1) {
+            ar.write("\x0A");
+        }
+    }
+}
+
+void static_library_test() {
+    {
+        File a("a.tmp", "w");
+        a.write("a123b");
+
+        File b("b_long_name_is_long.tmp", "w");
+        b.write("c456d");
+    }
+
+    create_ar_file({"a.tmp", "b_long_name_is_long.tmp"}, "arfile.a");
+
+    File::Stat stat = File::stat("arfile.a");
+    internal_assert(stat.file_size == 162) << "Filesize was " << stat.file_size;
+
+    {
+        File ar("arfile.a", "r");
+        auto slurp = ar.read(162);
+        // TODO(srj): verify contents are correct, but ignore mod/uid/gid/mode
+    }
+    File::unlink("a.tmp");
+    File::unlink("b_long_name_is_long.tmp");
+    File::unlink("arfile.a");
+
+    debug(0) << "static_library_test passed\n";
+}
+
+}  // namespace Internal
+}  // namespace Halide

--- a/src/StaticLibrary.cpp
+++ b/src/StaticLibrary.cpp
@@ -1,10 +1,13 @@
 #include "StaticLibrary.h"
 
 #include <stdio.h>
-#ifndef _MSC_VER
-#include <sys/stat.h>
+#ifdef _MSC_VER
+#include <io.h>
+#else
 #include <unistd.h>
 #endif
+#include <sys/types.h>
+#include <sys/stat.h>
 
 #include "Error.h"
 
@@ -72,9 +75,9 @@ public:
     struct Stat {
         off_t file_size;
         time_t mod_time;
-        uid_t uid;
-        gid_t gid;
-        mode_t mode;
+        uint32_t uid;
+        uint32_t gid;
+        uint32_t mode;
     };
 
     static Stat stat(const std::string &name) {
@@ -111,7 +114,11 @@ std::string decimal_string(int value, size_t pad) {
 
 std::string octal_string(int value, size_t pad) {
     char buf[256];
+    #ifdef _MSC_VER
+    _snprintf(buf, sizeof(buf), "%o", value);
+    #else
     snprintf(buf, sizeof(buf), "%o", value);
+    #endif
     return pad_right(buf, pad);
 }
 

--- a/src/StaticLibrary.cpp
+++ b/src/StaticLibrary.cpp
@@ -1,13 +1,7 @@
 #include "StaticLibrary.h"
 
+#include <fstream>
 #include <stdio.h>
-#ifdef _MSC_VER
-#include <io.h>
-#else
-#include <unistd.h>
-#endif
-#include <sys/types.h>
-#include <sys/stat.h>
 
 #include "Error.h"
 
@@ -15,90 +9,6 @@ namespace Halide {
 namespace Internal {
 
 namespace {
-
-class File {
-public:
-    File(const std::string &name, const char *mode) : name(name), f(fopen(name.c_str(), mode)) {
-        internal_assert(f != nullptr) << "Could not open file " << f << " in mode " << mode << "\n";
-    }
-    ~File() {
-        if (f != nullptr) {
-            fclose(f);
-        }
-    }
-    void write(const void *data, size_t size) {
-        if (!fwrite(data, size, 1, f)) {
-            user_error << "Could not write to " << name << "\n";
-        }
-    }
-
-    void write(const std::string &str) {
-        write(str.c_str(), str.size());
-    }
-
-    void write(const std::vector<uint8_t> &data) {
-        write(&data[0], data.size());
-    }
-
-    std::vector<uint8_t> read(size_t size) {
-        std::vector<uint8_t> result(size);
-        if (!fread(&result[0], size, 1, f)) {
-            user_error << "Could not read from " << name << "\n";
-        }
-        return result;
-    }
-
-    size_t tell() {
-        long offset = ftell(f);
-        if (offset < 0) {
-            user_error << "Could not ftell: " << name << "\n";
-        }
-        return (size_t) offset;
-    }
-
-    static bool exists(const std::string &name) {
-        #ifdef _MSC_VER
-        return _access(name.c_str(), 0) == 0;
-        #else
-        return ::access(name.c_str(), F_OK) == 0;
-        #endif
-    }
-
-    static void unlink(const std::string &name) {
-        #ifdef _MSC_VER
-        _unlink(name.c_str());
-        #else
-        ::unlink(name.c_str());
-        #endif
-    }
-
-    struct Stat {
-        off_t file_size;
-        time_t mod_time;
-        uint32_t uid;
-        uint32_t gid;
-        uint32_t mode;
-    };
-
-    static Stat stat(const std::string &name) {
-        #ifdef _MSC_VER
-        struct _stat a;
-        if (_stat(name.c_str(), &a) != 0) {
-            user_error << "Could not stat " << name << "\n";
-        }
-        #else
-        struct stat a;
-        if (::stat(name.c_str(), &a) != 0) {
-            user_error << "Could not stat " << name << "\n";
-        }
-        #endif
-        return { a.st_size, a.st_mtime, a.st_uid, a.st_gid, a.st_mode };
-    }
-
-private:
-    const std::string name;
-    FILE *f;
-};
 
 std::string pad_right(std::string s, size_t max) {
     internal_assert(s.size() <= max) << s.size() << " " << s;
@@ -126,72 +36,77 @@ std::string octal_string(int value, size_t pad) {
 
 void create_ar_file(const std::vector<std::string> &src_files, 
                     const std::string &dst_file, bool deterministic) {
-    File ar(dst_file, "wb");
-    ar.write("!<arch>\x0A", 8);
+    std::ofstream ar(dst_file, std::ofstream::out | std::ofstream::binary);
+    user_assert(ar.good());
+    ar << "!<arch>\x0A";
     for (const std::string &src_path : src_files) {
-        File::Stat stat = File::stat(src_path);
+        FileStat stat = file_stat(src_path);
 
         // Each member must begin on an even byte boundary; insert LF as needed
-        if (ar.tell() & 1) {
-            ar.write("\x0A");
+        if (ar.tellp() & 1) {
+            ar << "\x0A";
         }
         // Need to embed just the leaf name
         std::string src_name = base_name(src_path, '/');
-        size_t filesize = stat.file_size;
+        uint64_t filesize = stat.file_size;
         if (src_name.size() > 16) {
-            ar.write("#1/" + decimal_string(src_name.size(), 13));
+            ar << "#1/" << decimal_string(src_name.size(), 13);
             filesize += src_name.size();
         } else {
-            ar.write(pad_right(src_name, 16));
+            ar << pad_right(src_name, 16);
         }
-        ar.write(decimal_string(deterministic ? 0 : stat.mod_time, 12));  // mod time
-        ar.write(decimal_string(deterministic ? 0 : stat.uid, 6));  // user id
-        ar.write(decimal_string(deterministic ? 0 : stat.gid, 6));  // group id
-        ar.write(octal_string(deterministic ? 0644 : stat.mode, 8));  // mode
-        ar.write(decimal_string(filesize, 10));  // filesize
-        ar.write("\x60\x0A");  // magic
+        ar << decimal_string(deterministic ? 0 : stat.mod_time, 12);  // mod time
+        ar << decimal_string(deterministic ? 0 : stat.uid, 6);  // user id
+        ar << decimal_string(deterministic ? 0 : stat.gid, 6);  // group id
+        ar << octal_string(deterministic ? 0644 : stat.mode, 8);  // mode
+        ar << decimal_string(filesize, 10);  // filesize
+        ar << "\x60\x0A";  // magic
         if (src_name.size() > 16) {
-            ar.write(src_name);
+            ar << src_name;
         }
         {
-            File src(src_path, "rb");
-            // Just slurp everything into memory and write it back out.
-            ar.write(src.read(stat.file_size));  // slurp it all over
+            std::ifstream src(src_path, std::ifstream::in | std::ifstream::binary);
+            ar << src.rdbuf();
         }
     }
 }
 
 void static_library_test() {
     {
-        File a("a.tmp", "w");
-        a.write("a123b");
-
-        File b("b_long_name_is_long.tmp", "w");
-        b.write("c456d");
-
-        File c("./c_path.tmp", "w");
-        c.write("e789f");
+        std::ofstream a("a.tmp", std::ofstream::out);
+        a << "a123b";
+        user_assert(a.good());
+    }
+    {
+        std::ofstream b("b_long_name_is_long.tmp", std::ofstream::out);
+        b << "c456d";
+        user_assert(b.good());
+    }
+    {
+        std::ofstream c("./c_path.tmp", std::ofstream::out);
+        c << "e789f";
+        user_assert(c.good());
     }
 
     create_ar_file({"a.tmp", "b_long_name_is_long.tmp", "./c_path.tmp"}, "arfile.a");
 
-    File::Stat stat = File::stat("arfile.a");
     {
-        File ar("arfile.a", "r");
-        auto slurp = ar.read(stat.file_size);
-        const std::string actual = std::string((const char*)slurp.data(), slurp.size());
+        std::ifstream ar("arfile.a", std::ifstream::in);
+        std::ostringstream actual;
+        actual << ar.rdbuf();
         const std::string expected = R"literal(!<arch>
 a.tmp           0           0     0     644     5         `
 a123b
 #1/23           0           0     0     644     28        `
 b_long_name_is_long.tmpc456dc_path.tmp      0           0     0     644     5         `
 e789f)literal";
-        internal_assert(actual == expected) << "File contents wrong, expected:(" << expected << ")\nactual:(" << actual << ")\n";
+        internal_assert(actual.str() == expected) 
+            << "File contents wrong, expected:(" << expected << ")\nactual:(" << actual.str() << ")\n";
     }
-    File::unlink("a.tmp");
-    File::unlink("b_long_name_is_long.tmp");
-    File::unlink("./c_path.tmp");
-    File::unlink("arfile.a");
+    file_unlink("a.tmp");
+    file_unlink("b_long_name_is_long.tmp");
+    file_unlink("./c_path.tmp");
+    file_unlink("arfile.a");
 
     debug(0) << "static_library_test passed\n";
 }

--- a/src/StaticLibrary.h
+++ b/src/StaticLibrary.h
@@ -1,0 +1,27 @@
+#ifndef HALIDE_STATIC_LIBRARY_H
+#define HALIDE_STATIC_LIBRARY_H
+
+/** \file
+ * Methods combining object files into static libraries.
+ * TODO(srj): add method for combing .COFF files (.obj -> .lib) for Windows.
+ */
+
+#include <string>
+#include <vector>
+
+#include "Util.h"
+
+namespace Halide {
+namespace Internal {
+
+/**
+ * Concatenate the list of src_files into dst_file, using Unix ar format.
+ */
+EXPORT void create_ar_file(const std::vector<std::string> &src_files, const std::string &dst_file);
+
+EXPORT void static_library_test();
+
+}  // namespace Halide
+}  // namespace Internal
+
+#endif  // HALIDE_STATIC_LIBRARY_H

--- a/src/StaticLibrary.h
+++ b/src/StaticLibrary.h
@@ -16,8 +16,11 @@ namespace Internal {
 
 /**
  * Concatenate the list of src_files into dst_file, using Unix ar format.
+ * If deterministic is true, emit 0 for all GID/UID/timestamps, and 0644 for
+ * all modes (equivalent to the ar -D option).
  */
-EXPORT void create_ar_file(const std::vector<std::string> &src_files, const std::string &dst_file);
+EXPORT void create_ar_file(const std::vector<std::string> &src_files, 
+                           const std::string &dst_file, bool deterministic = true);
 
 EXPORT void static_library_test();
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -8,10 +8,13 @@
 #include <mutex>
 #include <string>
 
-#ifdef __linux__
+#ifdef _MSC_VER
+#include <io.h>
+#else
 #include <unistd.h>
-#include <linux/limits.h>
 #endif
+#include <sys/types.h>
+#include <sys/stat.h>
 
 namespace Halide {
 namespace Internal {
@@ -212,6 +215,37 @@ std::string extract_namespaces(const std::string &name, std::vector<std::string>
     std::string result = namespaces.back();
     namespaces.pop_back();
     return result;
+}
+
+bool file_exists(const std::string &name) {
+    #ifdef _MSC_VER
+    return _access(name.c_str(), 0) == 0;
+    #else
+    return ::access(name.c_str(), F_OK) == 0;
+    #endif
+}
+
+void file_unlink(const std::string &name) {
+    #ifdef _MSC_VER
+    _unlink(name.c_str());
+    #else
+    ::unlink(name.c_str());
+    #endif
+}
+
+FileStat file_stat(const std::string &name) {
+    #ifdef _MSC_VER
+    struct _stat a;
+    if (_stat(name.c_str(), &a) != 0) {
+        user_error << "Could not stat " << name << "\n";
+    }
+    #else
+    struct stat a;
+    if (::stat(name.c_str(), &a) != 0) {
+        user_error << "Could not stat " << name << "\n";
+    }
+    #endif
+    return { static_cast<uint64_t>(a.st_size), static_cast<uint32_t>(a.st_mtime), a.st_uid, a.st_gid, a.st_mode };
 }
 
 }

--- a/src/Util.h
+++ b/src/Util.h
@@ -145,6 +145,23 @@ struct all_are_convertible : meta_and<std::is_convertible<Args, To>...> {};
 /** Returns base name and fills in namespaces, outermost one first in vector. */
 std::string extract_namespaces(const std::string &name, std::vector<std::string> &namespaces);
 
+struct FileStat {
+    uint64_t file_size;
+    uint32_t mod_time;  // Unix epoch time
+    uint32_t uid;
+    uint32_t gid;
+    uint32_t mode;
+};
+
+/** Wrapper for access(). Asserts upon error. */
+bool file_exists(const std::string &name);
+
+/** Wrapper for unlink(). Asserts upon error. */
+void file_unlink(const std::string &name);
+
+/** Wrapper for stat(). Asserts upon error. */
+FileStat file_stat(const std::string &name);
+
 }
 }
 

--- a/src/Util.h
+++ b/src/Util.h
@@ -13,6 +13,7 @@
 /** \file
  * Various utility functions used internally Halide. */
 
+#include <cstdint>
 #include <utility>
 #include <vector>
 #include <string>

--- a/test/internal.cpp
+++ b/test/internal.cpp
@@ -14,6 +14,7 @@
 #include "Solve.h"
 #include "Monotonic.h"
 #include "Reduction.h"
+#include "StaticLibrary.h"
 
 using namespace Halide;
 using namespace Halide::Internal;
@@ -33,6 +34,7 @@ int main(int argc, const char **argv) {
     cplusplus_mangle_test();
     is_monotonic_test();
     split_predicate_test();
+    static_library_test();
 
     return 0;
 }


### PR DESCRIPTION
Work for #879: add a way to combine .o files into .a files to simplify
downstream consumption of multi-architecture output that can’t easily
be linked directly by LLVM at this time.