### PR TITLE
Add fold_storage scheduling directive

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1258,13 +1258,14 @@ Func &Func::align_storage(Var dim, Expr alignment) {
     return *this;
 }
 
-Func &Func::fold_storage(Var dim, Expr factor) {
+Func &Func::fold_storage(Var dim, Expr factor, bool fold_forward) {
     invalidate_cache();
 
     vector<StorageDim> &dims = func.schedule().storage_dims();
     for (size_t i = 0; i < dims.size(); i++) {
         if (var_name_match(dims[i].var, dim.name())) {
             dims[i].fold_factor = factor;
+            dims[i].fold_forward = fold_forward;
             return *this;
         }
     }

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1258,6 +1258,21 @@ Func &Func::align_storage(Var dim, Expr alignment) {
     return *this;
 }
 
+Func &Func::fold_storage(Var dim, Expr factor) {
+    invalidate_cache();
+
+    vector<StorageDim> &dims = func.schedule().storage_dims();
+    for (size_t i = 0; i < dims.size(); i++) {
+        if (var_name_match(dims[i].var, dim.name())) {
+            dims[i].fold_factor = factor;
+            return *this;
+        }
+    }
+    user_error << "Could not find variable " << dim.name()
+               << " to fold the storage of.\n";
+    return *this;
+}
+
 Func &Func::compute_at(Func f, RVar var) {
     return compute_at(f, Var(var.name()));
 }

--- a/src/Func.h
+++ b/src/Func.h
@@ -1355,7 +1355,7 @@ public:
      * with an extent in y of 2, alternately storing each computed row
      * of g in row y=0 or y=1.
      */
-    EXPORT Func &fold_storage(Var dim, Expr extent);
+    EXPORT Func &fold_storage(Var dim, Expr extent, bool fold_forward = true);
 
     /** Compute this function as needed for each unique value of the
      * given var for the given calling function f.

--- a/src/Func.h
+++ b/src/Func.h
@@ -1330,6 +1330,33 @@ public:
      * aligned to multiples of 16, use foo.align_storage(x, 16). */
     EXPORT Func &align_storage(Var dim, Expr alignment);
 
+    /** Store realizations of this function in a circular buffer of a
+     * given extent. This can cause programs to be incorrect if the
+     * extent of the circular buffer is too small to avoid overwriting
+     * values of a producer before they are consumed. This is more
+     * efficient when the extent of the circular buffer is a power of
+     * 2.
+     *
+     * For example, consider the pipeline:
+     \code
+     Func f, g;
+     Var x, y;
+     g(x, y) = x*y;
+     f(x, y) = g(x, y) + g(x, y+1);
+     \endcode
+     *
+     * If we schedule f like so:
+     *
+     \code
+     g.compute_at(f, y).store_root().fold_storage(y, 2);
+     \endcode
+     *
+     * Then g will be computed at each row of f and stored in a buffer
+     * with an extent in y of 2, alternately storing each computed row
+     * of g in row y=0 or y=1.
+     */
+    EXPORT Func &fold_storage(Var dim, Expr extent);
+
     /** Compute this function as needed for each unique value of the
      * given var for the given calling function f.
      *

--- a/src/Func.h
+++ b/src/Func.h
@@ -1336,6 +1336,12 @@ public:
      * small, or the dimension is not accessed monotonically, the
      * pipeline will generate an error at runtime.
      *
+     * The fold_forward option indicates that the new values of the
+     * producer are accessed by the consumer in a monotonically
+     * increasing order. Folding storage of producers is also
+     * supported if the new values are accessed in a monotonically
+     * decreasing order by setting fold_forward to false.
+     *
      * For example, consider the pipeline:
      \code
      Func f, g;

--- a/src/Func.h
+++ b/src/Func.h
@@ -1331,11 +1331,10 @@ public:
     EXPORT Func &align_storage(Var dim, Expr alignment);
 
     /** Store realizations of this function in a circular buffer of a
-     * given extent. This can cause programs to be incorrect if the
-     * extent of the circular buffer is too small to avoid overwriting
-     * values of a producer before they are consumed. This is more
-     * efficient when the extent of the circular buffer is a power of
-     * 2.
+     * given extent. This is more efficient when the extent of the
+     * circular buffer is a power of 2. If the fold factor is too
+     * small, or the dimension is not accessed monotonically, the
+     * pipeline will generate an error at runtime.
      *
      * For example, consider the pipeline:
      \code

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -134,7 +134,7 @@ Stmt lower(vector<Function> outputs, const string &pipeline_name, const Target &
     debug(2) << "Lowering after uniquifying variable names:\n" << s << "\n\n";
 
     debug(1) << "Performing storage folding optimization...\n";
-    s = storage_folding(s);
+    s = storage_folding(s, env);
     debug(2) << "Lowering after storage folding:\n" << s << '\n';
 
     debug(1) << "Injecting debug_to_file calls...\n";

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -158,6 +158,7 @@ struct StorageDim {
     std::string var;
     Expr alignment;
     Expr fold_factor;
+    bool fold_forward;
 };
 
 class ReductionDomain;

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -157,6 +157,7 @@ struct Specialization {
 struct StorageDim {
     std::string var;
     Expr alignment;
+    Expr fold_factor;
 };
 
 class ReductionDomain;

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -159,10 +159,12 @@ class AttemptStorageFoldingOfFunction : public IRMutator {
 
                     max_extent = find_constant_bound(max_extent, Direction::Upper);
 
-                    if (const int64_t *extent = as_const_int(max_extent)) {
-                        factor = static_cast<int>(next_power_of_two(*extent));
+                    const int max_fold = 1024;
+                    const int64_t *const_max_extent = as_const_int(max_extent);
+                    if (const_max_extent && *const_max_extent <= max_fold) {
+                        factor = static_cast<int>(next_power_of_two(*const_max_extent));
                     } else {
-                        debug(3) << "Not folding because extent not bounded by a constant\n"
+                        debug(3) << "Not folding because extent not bounded by a constant not greater than " << max_fold << "\n"
                                  << "extent = " << extent << "\n"
                                  << "max extent = " << max_extent << "\n";
                     }

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -249,7 +249,8 @@ class StorageFolding : public IRMutator {
         IsBufferSpecial special(op->name);
         op->accept(&special);
 
-        // Do explicit storage folding first.
+        // Get the function associated with this realization, which
+        // contains the explicit fold directives from the schedule.
         auto func_it = env.find(op->name);
         Function func = func_it != env.end() ? func_it->second : Function();
 
@@ -269,15 +270,7 @@ class StorageFolding : public IRMutator {
         } else {
             AttemptStorageFoldingOfFunction folder(func);
             debug(3) << "Attempting to fold " << op->name << "\n";
-            if (folder.dims_folded.empty()) {
-                // We can only attempt to fold if there were no
-                // explicit folds.
-                // TODO: We could try to use the same logic in
-                // AttemptStorageFoldingOfFunction to detect if the
-                // explicit folds were on a stencil, and if not, allow
-                // further storage folding attempts.
-                body = folder.mutate(body);
-            }
+            body = folder.mutate(body);
 
             if (body.same_as(op->body)) {
                 stmt = op;

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -117,7 +117,6 @@ class AttemptStorageFoldingOfFunction : public IRMutator {
                 Expr loop_var = Variable::make(Int(32), op->name);
                 if (storage_dim.fold_forward) {
                     Expr min_next = substitute(op->name, loop_var + 1, min);
-                    Expr min_increased =
                     condition = min_next >= min;
 
                     // After we assert that the min increased, assume

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -12,6 +12,14 @@
 namespace Halide {
 namespace Internal {
 
+namespace {
+
+int64_t next_power_of_two(int64_t x) {
+    return static_cast<int64_t>(1) << static_cast<int64_t>(std::ceil(std::log2(x + 1)));
+}
+
+}  // namespace
+
 using std::string;
 using std::vector;
 using std::map;
@@ -55,12 +63,12 @@ public:
 
 // Attempt to fold the storage of a particular function in a statement
 class AttemptStorageFoldingOfFunction : public IRMutator {
-    string func;
+    Function func;
 
     using IRMutator::visit;
 
     void visit(const ProducerConsumer *op) {
-        if (op->name == func) {
+        if (op->name == func.name()) {
             // Can't proceed into the pipeline for this func
             stmt = op;
         } else {
@@ -80,16 +88,18 @@ class AttemptStorageFoldingOfFunction : public IRMutator {
             return;
         }
 
-        Box box = box_touched(op->body, func);
-
-        Stmt result = op;
+        Stmt body = op->body;
+        Box box = box_touched(body, func.name());
 
         // Try each dimension in turn from outermost in
         for (size_t i = box.size(); i > 0; i--) {
             Expr min = simplify(box[i-1].min);
             Expr max = simplify(box[i-1].max);
 
-            debug(3) << "\nConsidering folding " << func << " over for loop over " << op->name << '\n'
+            const StorageDim &storage_dim = func.schedule().storage_dims()[i-1];
+            Expr explicit_factor = storage_dim.fold_factor;
+
+            debug(3) << "\nConsidering folding " << func.name() << " over for loop over " << op->name << '\n'
                      << "Min: " << min << '\n'
                      << "Max: " << max << '\n';
 
@@ -99,31 +109,72 @@ class AttemptStorageFoldingOfFunction : public IRMutator {
             bool max_monotonic_decreasing =
                 (is_monotonic(max, op->name) == Monotonic::Decreasing);
 
+            if (!min_monotonic_increasing && !max_monotonic_decreasing &&
+                explicit_factor.defined()) {
+                // If we didn't find a monotonic dimension, and we have an explicit fold factor,
+                // assert that the min/max do in fact monotonically increase/decrease.
+                Expr condition;
+                Expr loop_var = Variable::make(Int(32), op->name);
+                if (storage_dim.fold_forward) {
+                    Expr min_next = substitute(op->name, loop_var + 1, min);
+                    Expr min_increased =
+                    condition = min_next >= min;
+
+                    // After we assert that the min increased, assume
+                    // the min is monotonically increasing.
+                    min_monotonic_increasing = true;
+                } else {
+                    Expr max_next = substitute(op->name, loop_var + 1, max);
+                    condition = max_next <= max;
+
+                    // After we assert that the max decreased, assume
+                    // the max is monotonically decreasing.
+                    max_monotonic_decreasing = true;
+                }
+                Expr error = Call::make(Int(32), "halide_error_bad_fold",
+                                        {func.name(), storage_dim.var, op->name},
+                                        Call::Extern);
+
+                body = Block::make(AssertStmt::make(condition, error), body);
+            }
+
             // The min or max has to be monotonic with the loop
             // variable, and should depend on the loop variable.
-            if (min_monotonic_increasing ||
-                max_monotonic_decreasing) {
-
-                // The max of the extent over all values of the loop variable must be a constant
+            if (min_monotonic_increasing || max_monotonic_decreasing) {
                 Expr extent = simplify(max - min);
-                Scope<Interval> scope;
-                scope.push(op->name, Interval(Variable::make(Int(32), op->name + ".loop_min"),
-                                              Variable::make(Int(32), op->name + ".loop_max")));
-                Expr max_extent = bounds_of_expr_in_scope(extent, scope).max;
-                scope.pop(op->name);
+                Expr factor;
+                if (explicit_factor.defined()) {
+                    Expr error = Call::make(Int(32), "halide_error_fold_factor_too_small",
+                                            {func.name(), storage_dim.var, explicit_factor, op->name, extent},
+                                            Call::Extern);
+                    body = Block::make(AssertStmt::make(extent <= explicit_factor, error), body);
 
-                max_extent = find_constant_bound(simplify(max_extent), Direction::Upper);
+                    factor = explicit_factor;
+                } else {
+                    // The max of the extent over all values of the loop variable must be a constant
+                    Scope<Interval> scope;
+                    scope.push(op->name, Interval(Variable::make(Int(32), op->name + ".loop_min"),
+                                                  Variable::make(Int(32), op->name + ".loop_max")));
+                    Expr max_extent = simplify(bounds_of_expr_in_scope(extent, scope).max);
+                    scope.pop(op->name);
 
-                if (const int64_t *extent = as_const_int(max_extent)) {
+                    max_extent = find_constant_bound(max_extent, Direction::Upper);
 
-                    int factor = 1;
-                    while (factor <= *extent && factor < 1024) factor *= 2;
+                    if (const int64_t *extent = as_const_int(max_extent)) {
+                        factor = static_cast<int>(next_power_of_two(*extent));
+                    } else {
+                        debug(3) << "Not folding because extent not bounded by a constant\n"
+                                 << "extent = " << extent << "\n"
+                                 << "max extent = " << max_extent << "\n";
+                    }
+                }
 
+                if (factor.defined()) {
                     debug(3) << "Proceeding with factor " << factor << "\n";
 
                     Fold fold = {(int)i - 1, factor};
                     dims_folded.push_back(fold);
-                    result = FoldStorageOfFunction(func, (int)i - 1, factor).mutate(result);
+                    body = FoldStorageOfFunction(func.name(), (int)i - 1, factor).mutate(body);
 
                     Expr next_var = Variable::make(Int(32), op->name) + 1;
                     Expr next_min = substitute(op->name, next_var, min);
@@ -132,15 +183,13 @@ class AttemptStorageFoldingOfFunction : public IRMutator {
                         // iterations, so we can continue to search
                         // for further folding opportinities
                         // recursively.
+                    } else if (!body.same_as(op->body)) {
+                        stmt = For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);
+                        return;
                     } else {
-                        stmt = result;
+                        stmt = op;
                         return;
                     }
-
-                } else {
-                    debug(3) << "Not folding because extent not bounded by a constant\n"
-                             << "extent = " << extent << "\n"
-                             << "max extent = " << max_extent << "\n";
                 }
             } else {
                 debug(3) << "Not folding because loop min or max not monotonic in the loop variable\n"
@@ -150,17 +199,12 @@ class AttemptStorageFoldingOfFunction : public IRMutator {
         }
 
         // Any folds that took place folded dimensions away entirely, so we can proceed recursively.
-        if (const For *f = result.as<For>()) {
-            Stmt body = mutate(f->body);
-            if (body.same_as(f->body)) {
-                stmt = result;
-            } else {
-                stmt = For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);
-            }
+        body = mutate(body);
+        if (body.same_as(op->body)) {
+            stmt = op;
         } else {
-            stmt = result;
+            stmt = For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);
         }
-
     }
 
 public:
@@ -170,7 +214,7 @@ public:
     };
     vector<Fold> dims_folded;
 
-    AttemptStorageFoldingOfFunction(string f) : func(f) {}
+    AttemptStorageFoldingOfFunction(Function f) : func(f) {}
 };
 
 /** Check if a buffer's allocated is referred to directly via an
@@ -203,32 +247,20 @@ class StorageFolding : public IRMutator {
     void visit(const Realize *op) {
         Stmt body = mutate(op->body);
 
-        AttemptStorageFoldingOfFunction folder(op->name);
         IsBufferSpecial special(op->name);
         op->accept(&special);
 
         // Do explicit storage folding first.
-        auto f = env.find(op->name);
-        if (f != env.end()) {
-            const std::vector<StorageDim> &storage_dims = f->second.schedule().storage_dims();
-            const vector<string> &args = f->second.args();
-            for (size_t i = 0; i < storage_dims.size(); i++) {
-                Expr factor = storage_dims[i].fold_factor;
-                if (!factor.defined()) continue;
-
-                user_assert(!special.special) << "Dimension " << storage_dims[i].var << " of " << op->name
-                                              << " cannot be folded because it is accessed by extern or device stages.\n";
-
-                for (int j = 0; j < static_cast<int>(args.size()); j++) {
-                    if (args[j] == storage_dims[i].var) {
-                        body = FoldStorageOfFunction(op->name, j, factor).mutate(body);
-                        folder.dims_folded.push_back({j, factor});
-                    }
-                }
-            }
-        }
+        auto func_it = env.find(op->name);
+        Function func = func_it != env.end() ? func_it->second : Function();
 
         if (special.special) {
+            for (const StorageDim &i : func.schedule().storage_dims()) {
+                user_assert(!i.fold_factor.defined())
+                    << "Dimension " << i.var << " of " << op->name
+                    << " cannot be folded because it is accessed by extern or device stages.\n";
+            }
+
             debug(3) << "Not attempting to fold " << op->name << " because its buffer is used\n";
             if (body.same_as(op->body)) {
                 stmt = op;
@@ -236,6 +268,7 @@ class StorageFolding : public IRMutator {
                 stmt = Realize::make(op->name, op->types, op->bounds, op->condition, body);
             }
         } else {
+            AttemptStorageFoldingOfFunction folder(func);
             debug(3) << "Attempting to fold " << op->name << "\n";
             if (folder.dims_folded.empty()) {
                 // We can only attempt to fold if there were no

--- a/src/StorageFolding.h
+++ b/src/StorageFolding.h
@@ -24,7 +24,7 @@ namespace Internal {
  * We can store f as a circular buffer of size two, instead of
  * allocating space for all of it.
  */
-Stmt storage_folding(Stmt s);
+Stmt storage_folding(Stmt s, const std::map<std::string, Function> &env);
 
 }
 }

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -460,6 +460,15 @@ enum halide_error_code_t {
      * the alignment set for it by way of a call to
      * set_host_alignment */
     halide_error_code_unaligned_host_ptr = -24,
+
+    /** A fold_storage directive was used on a dimension that is not
+     * accessed in a monotonically increasing or decreasing fashion. */
+    halide_error_code_bad_fold = -25,
+
+    /** A fold_storage directive was used with a fold factor that was
+     * too small to store all the values of a producer needed by the
+     * consumer. */
+    halide_error_code_fold_factor_too_small = -26,
 };
 
 /** Halide calls the functions below on various error conditions. The
@@ -513,10 +522,14 @@ extern int halide_error_buffer_argument_is_null(void *user_context, const char *
 extern int halide_error_debug_to_file_failed(void *user_context, const char *func,
                                              const char *filename, int error_code);
 extern int halide_error_unaligned_host_ptr(void *user_context, const char *func_name, int alignment);
+extern int halide_error_bad_fold(void *user_context, const char *func_name, const char *var_name,
+                                 const char *loop_name);
+extern int halide_error_fold_factor_too_small(void *user_context, const char *func_name, const char *var_name,
+                                              int fold_factor, const char *loop_name, int required_extent);
 
 // @}
 
-/** Optional features a compilation Target can have. 
+/** Optional features a compilation Target can have.
  */
 typedef enum halide_target_feature_t {
     halide_target_feature_jit = 0,  ///< Generate code that will run immediately inside the calling process.

--- a/src/runtime/errors.cpp
+++ b/src/runtime/errors.cpp
@@ -174,4 +174,24 @@ WEAK int halide_error_unaligned_host_ptr(void *user_context, const char *func,
         << " bytes boundary.";
     return halide_error_code_unaligned_host_ptr;
 }
+
+WEAK int halide_error_bad_fold(void *user_context, const char *func_name, const char *var_name,
+                               const char *loop_name) {
+    error(user_context)
+        << "The folded storage dimension " << var_name << " of " << func_name
+        << " was accessed out of order by loop " << loop_name << ".";
+    return halide_error_code_bad_fold;
 }
+
+WEAK int halide_error_fold_factor_too_small(void *user_context, const char *func_name, const char *var_name,
+                                            int fold_factor, const char *loop_name, int required_extent) {
+    error(user_context)
+        << "The fold factor (" << fold_factor
+        << ") of dimension " << var_name << " of " << func_name
+        << " is too small to store the required region accessed by loop "
+        << loop_name << " (" << required_extent << ").";
+    return halide_error_code_fold_factor_too_small;
+}
+
+
+}  // extern "C"

--- a/src/runtime/runtime_api.cpp
+++ b/src/runtime/runtime_api.cpp
@@ -52,6 +52,8 @@ extern "C" __attribute__((used)) void *halide_runtime_api_functions[] = {
     (void *)&halide_error_param_too_small_f64,
     (void *)&halide_error_param_too_small_i64,
     (void *)&halide_error_param_too_small_u64,
+    (void *)&halide_error_bad_fold,
+    (void *)&halide_error_fold_factor_too_small,
     (void *)&halide_float16_bits_to_double,
     (void *)&halide_float16_bits_to_float,
     (void *)&halide_free,

--- a/test/correctness/storage_folding.cpp
+++ b/test/correctness/storage_folding.cpp
@@ -226,7 +226,7 @@ int main(int argc, char **argv) {
         Func f, g;
 
         g(x, y) = x * y;
-        f(x, y) = g(x/2, y/2) + g(x/2, y/2+1);
+        f(x, y) = g(x, y/2) + g(x, y/2+1);
 
         // The automatic storage folding optimization can't figure
         // this out due to the downsampling. Explicitly fold it.
@@ -245,7 +245,7 @@ int main(int argc, char **argv) {
 
         for (int y = 0; y < im.height(); y++) {
             for (int x = 0; x < im.width(); x++) {
-                int correct = (x/2) * (y/2) + (x/2) * (y/2 + 1);
+                int correct = (x) * (y/2) + (x) * (y/2 + 1);
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n", x, y, im(x, y), correct);
                     return -1;

--- a/test/correctness/storage_folding.cpp
+++ b/test/correctness/storage_folding.cpp
@@ -33,15 +33,12 @@ int main(int argc, char **argv) {
 
         Image<int> im = g.realize(1000, 1000);
 
-        // Should fold by a factor of two, but sliding window analysis makes it round up to 4.
-        // Halide allocates one extra scalar, so we account for that.
-        size_t expected_size = 1002*4*sizeof(int) + sizeof(int);
+        size_t expected_size = 1002*2*sizeof(int) + sizeof(int);
         if (custom_malloc_size == 0 || custom_malloc_size > expected_size) {
             printf("Scratch space allocated was %d instead of %d\n", (int)custom_malloc_size, (int)expected_size);
             return -1;
         }
     }
-
 
     {
         custom_malloc_size = 0;
@@ -147,7 +144,7 @@ int main(int argc, char **argv) {
 
     }
 
-   {
+    {
         custom_malloc_size = 0;
         Func f, g;
 
@@ -177,6 +174,44 @@ int main(int argc, char **argv) {
         for (int y = 0; y < im.height(); y++) {
             for (int x = 0; x < im.width(); x++) {
                 int correct = x*y;
+                if (im(x, y) != correct) {
+                    printf("im(%d, %d) = %d instead of %d\n", x, y, im(x, y), correct);
+                    return -1;
+                }
+            }
+        }
+
+    }
+
+    {
+        custom_malloc_size = 0;
+        Func f, g;
+
+        g(x, y) = x * y;
+        f(x, y) = g(2*x, y) + g(2*x+1, y+2);
+
+        // This is the same test as the above, except the stencil
+        // requires 3 rows, of g, not 4. Test explicit storage folding
+        // by forcing it to fold over 3 elements. Automatic storage
+        // folding would prefer to fold by 4 elements to make modular
+        // arithmetic cheaper, but folding by 3 is valid and supported
+        // (e.g. if memory usage is a concern.)
+        g.compute_at(f, x).store_root().fold_storage(y, 3);
+
+        f.set_custom_allocator(my_malloc, my_free);
+
+        Image<int> im = f.realize(1000, 1000);
+
+        // Halide allocates one extra scalar, so we account for that.
+        size_t expected_size = 2*1002*3*sizeof(int) + sizeof(int);
+        if (custom_malloc_size == 0 || custom_malloc_size > expected_size) {
+            printf("Scratch space allocated was %d instead of %d\n", (int)custom_malloc_size, (int)expected_size);
+            return -1;
+        }
+
+        for (int y = 0; y < im.height(); y++) {
+            for (int x = 0; x < im.width(); x++) {
+                int correct = (2*x) * y + (2*x+1) * (y+2);
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n", x, y, im(x, y), correct);
                     return -1;


### PR DESCRIPTION
This PR adds an explicit fold_storage scheduling directive, which enables storage folding on pipelines where the automatic storage folding optimization fails. The last new test is an example of such a pipeline (a stencil on a downsampled image).