### PR TITLE
GenGen -r param should not take .o suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -781,7 +781,7 @@ $(BIN_DIR)/runtime.generator: $(ROOT_DIR)/tools/GenGen.cpp $(BIN_DIR)/libHalide.
 # Generate a standalone runtime for a given target string
 $(RUNTIMES_DIR)/runtime_%.o: $(BIN_DIR)/runtime.generator
 	@mkdir -p $(RUNTIMES_DIR)
-	$(LD_PATH_SETUP) $(CURDIR)/$< -r $(notdir $@) -o $(CURDIR)/$(RUNTIMES_DIR) target=$*
+	$(LD_PATH_SETUP) $(CURDIR)/$< -r $(basename $(notdir $@)) -o $(CURDIR)/$(RUNTIMES_DIR) target=$*
 
 $(BIN_DIR)/test_internal: $(ROOT_DIR)/test/internal.cpp $(BIN_DIR)/libHalide.$(SHARED_EXT)
 	$(CXX) $(CXX_FLAGS)  $< -I$(SRC_DIR) -L$(BIN_DIR) -lHalide $(TEST_LDFLAGS) -lpthread $(LIBDL) -lz -o $@

--- a/apps/wavelet/Makefile
+++ b/apps/wavelet/Makefile
@@ -25,7 +25,7 @@ $(BUILD_DIR)/%.o $(BUILD_DIR)/%.h: $(BUILD_DIR)/%.generator
 $(BUILD_DIR)/runtime_$(HL_TARGET).o: $(BUILD_DIR)/haar_x.generator
 	@echo Compiling Halide runtime for target $(HL_TARGET)
 	@mkdir -p $(BUILD_DIR)
-	@$< -r runtime_$(HL_TARGET).o -o $(BUILD_DIR) target=$(HL_TARGET)
+	@$< -r runtime_$(HL_TARGET) -o $(BUILD_DIR) target=$(HL_TARGET)
 
 HL_MODULES = \
 	$(BUILD_DIR)/daubechies_x.o \

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -245,7 +245,9 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
     const Target target = parse_target_string(target_string);
 
     if (!runtime_name.empty()) {
-        compile_standalone_runtime(output_dir + "/" + runtime_name, target);
+        std::string base_path = compute_base_path(output_dir, runtime_name, "");
+        Outputs output_files = compute_outputs(target, base_path, emit_options);
+        compile_standalone_runtime(output_files, target);
     }
 
     if (!generator_name.empty()) {

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -247,7 +247,9 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
     if (!runtime_name.empty()) {
         std::string base_path = compute_base_path(output_dir, runtime_name, "");
         Outputs output_files = compute_outputs(target, base_path, emit_options);
-        compile_standalone_runtime(output_files, target);
+        // For runtime, it only makes sense to output object files (for now), so ignore
+        // everything else. (Soon, this will also support static libraries.)
+        compile_standalone_runtime(output_files.object_name, target);
     }
 
     if (!generator_name.empty()) {

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -145,9 +145,11 @@ void Module::compile(const Outputs &output_files) const {
     }
 }
 
-void compile_standalone_runtime(std::string object_filename, Target t) {
+void compile_standalone_runtime(const Outputs &output_files, Target t) {
     Module empty("standalone_runtime", t.without_feature(Target::NoRuntime).without_feature(Target::JIT));
-    empty.compile(Outputs().object(object_filename));
+    // For runtime, it only makes sense to output object files (for now), so ignore
+    // everything else. (Soon, this will also support static libraries.)
+    empty.compile(Outputs().object(output_files.object_name));
 }
 
 }

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -145,11 +145,11 @@ void Module::compile(const Outputs &output_files) const {
     }
 }
 
-void compile_standalone_runtime(const Outputs &output_files, Target t) {
+void compile_standalone_runtime(const std::string &object_filename, Target t) {
     Module empty("standalone_runtime", t.without_feature(Target::NoRuntime).without_feature(Target::JIT));
     // For runtime, it only makes sense to output object files (for now), so ignore
     // everything else. (Soon, this will also support static libraries.)
-    empty.compile(Outputs().object(output_files.object_name));
+    empty.compile(Outputs().object(object_filename));
 }
 
 }

--- a/src/Module.h
+++ b/src/Module.h
@@ -81,7 +81,7 @@ EXPORT Module link_modules(const std::string &name, const std::vector<Module> &m
 
 /** Create an object file containing the Halide runtime for a given
  * target. For use with Target::NoRuntime. */
-EXPORT void compile_standalone_runtime(const Outputs &output_files, Target t);
+EXPORT void compile_standalone_runtime(const std::string &object_filename, Target t);
 
 }
 

--- a/src/Module.h
+++ b/src/Module.h
@@ -81,7 +81,7 @@ EXPORT Module link_modules(const std::string &name, const std::vector<Module> &m
 
 /** Create an object file containing the Halide runtime for a given
  * target. For use with Target::NoRuntime. */
-EXPORT void compile_standalone_runtime(std::string object_filename, Target t);
+EXPORT void compile_standalone_runtime(const Outputs &output_files, Target t);
 
 }
 

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1485,7 +1485,7 @@ int main(int argc, char **argv) {
     }
 
     // Compile a runtime for this target, for use in the static test.
-    compile_standalone_runtime(Outputs().object("simd_op_check_runtime"), target);
+    compile_standalone_runtime("simd_op_check_runtime", target);
 
     // Wait for any children to terminate
     for (int child : children) {

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1485,7 +1485,7 @@ int main(int argc, char **argv) {
     }
 
     // Compile a runtime for this target, for use in the static test.
-    compile_standalone_runtime("simd_op_check_runtime.o", target);
+    compile_standalone_runtime(Outputs().object("simd_op_check_runtime"), target);
 
     // Wait for any children to terminate
     for (int child : children) {

--- a/tutorial/lesson_15_generators_usage.sh
+++ b/tutorial/lesson_15_generators_usage.sh
@@ -206,7 +206,7 @@ check_no_runtime my_first_generator_avx.o
 check_symbol     my_first_generator_avx.o my_first_generator_avx
 
 # We can then use the generator to emit just the runtime:
-./lesson_15_generate -r halide_runtime_x86.o -o . target=host-x86-64
+./lesson_15_generate -r halide_runtime_x86 -o . target=host-x86-64
 check_runtime halide_runtime_x86.o
 
 # Linking the standalone runtime with the three generated object files


### PR DESCRIPTION
This is a bit of hygiene: the -r parameter (for “generate the runtime
only”) should omit the .o, and have it added as appropriate downstream.
Justifications for this:
(1) That’s the pattern for other outputs of this rule
(2) on Windows, it should be .obj, not .o
(3) once static library support is finished, this will allow us to
specify the output as library via the -e format instead