### PR TITLE
Add LoweredArgument

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -455,7 +455,7 @@ void CodeGen_C::compile(const LoweredFunc &f) {
         << "Function '" << f.name << "'  has already been emitted.\n";
     emitted.insert(f.name);
 
-    const std::vector<Argument> &args = f.args;
+    const std::vector<LoweredArgument> &args = f.args;
 
     for (size_t i = 0; i < args.size(); i++) {
         if (args[i].type.handle_type != NULL) {
@@ -1531,15 +1531,11 @@ void CodeGen_C::visit(const Evaluate *op) {
 }
 
 void CodeGen_C::test() {
-    Argument buffer_arg("buf", Argument::OutputBuffer, Int(32), 3);
-    Argument float_arg("alpha", Argument::InputScalar, Float(32), 0);
-    Argument int_arg("beta", Argument::InputScalar, Int(32), 0);
-    Argument user_context_arg("__user_context", Argument::InputScalar, Handle(), 0);
-    vector<Argument> args(4);
-    args[0] = buffer_arg;
-    args[1] = float_arg;
-    args[2] = int_arg;
-    args[3] = user_context_arg;
+    LoweredArgument buffer_arg("buf", Argument::OutputBuffer, Int(32), 3);
+    LoweredArgument float_arg("alpha", Argument::InputScalar, Float(32), 0);
+    LoweredArgument int_arg("beta", Argument::InputScalar, Int(32), 0);
+    LoweredArgument user_context_arg("__user_context", Argument::InputScalar, Handle(), 0);
+    vector<LoweredArgument> args = { buffer_arg, float_arg, int_arg, user_context_arg };
     Var x("x");
     Param<float> alpha("alpha");
     Param<int> beta("beta");

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -436,7 +436,7 @@ MangledNames get_mangled_names(const LoweredFunc &f, const Target &target) {
     names.argv_name = names.simple_name + "_argv";
     names.metadata_name = names.simple_name + "_metadata";
 
-    const std::vector<Argument> &args = f.args;
+    const std::vector<LoweredArgument> &args = f.args;
 
     if (f.linkage == LoweredFunc::External &&
         target.has_feature(Target::CPlusPlusMangling) &&
@@ -534,7 +534,7 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
 
 
 void CodeGen_LLVM::begin_func(LoweredFunc::LinkageType linkage, const std::string& name,
-                              const std::string& extern_name, const std::vector<Argument>& args) {
+                              const std::string& extern_name, const std::vector<LoweredArgument>& args) {
     // Deduce the types of the arguments to our function
     vector<llvm::Type *> arg_types(args.size());
     for (size_t i = 0; i < args.size(); i++) {
@@ -574,12 +574,16 @@ void CodeGen_LLVM::begin_func(LoweredFunc::LinkageType linkage, const std::strin
                 push_buffer(args[i].name, &arg);
             }
 
+            if (args[i].alignment.modulus != 0) {
+                alignment_info.push(args[i].name, args[i].alignment);
+            }
+
             i++;
         }
     }
 }
 
-void CodeGen_LLVM::end_func(const std::vector<Argument>& args) {
+void CodeGen_LLVM::end_func(const std::vector<LoweredArgument>& args) {
     return_with_error_code(ConstantInt::get(i32, 0));
 
     // Remove the arguments from the symbol table
@@ -587,6 +591,10 @@ void CodeGen_LLVM::end_func(const std::vector<Argument>& args) {
         sym_pop(args[i].name);
         if (args[i].is_buffer()) {
             pop_buffer(args[i].name);
+        }
+
+        if (args[i].alignment.modulus != 0) {
+            alignment_info.pop(args[i].name);
         }
     }
 
@@ -814,7 +822,7 @@ llvm::Function *CodeGen_LLVM::add_argv_wrapper(const std::string &name) {
 }
 
 llvm::Function *CodeGen_LLVM::embed_metadata_getter(const std::string &metadata_name,
-        const std::string &function_name, const std::vector<Argument> &args) {
+        const std::string &function_name, const std::vector<LoweredArgument> &args) {
     Constant *zero = ConstantInt::get(i32, 0);
 
     const int num_args = (int) args.size();

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -122,7 +122,6 @@ protected:
     static bool llvm_initialized;
     static bool llvm_X86_enabled;
     static bool llvm_ARM_enabled;
-    static bool llvm_Hexagon_enabled;
     static bool llvm_AArch64_enabled;
     static bool llvm_NVPTX_enabled;
     static bool llvm_Mips_enabled;

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -92,8 +92,8 @@ protected:
      * appropriate cleanup code. */
     // @{
     virtual void begin_func(LoweredFunc::LinkageType linkage, const std::string &simple_name,
-                            const std::string &extern_name, const std::vector<Argument> &args);
-    virtual void end_func(const std::vector<Argument> &args);
+                            const std::string &extern_name, const std::vector<LoweredArgument> &args);
+    virtual void end_func(const std::vector<LoweredArgument> &args);
     // @}
 
     /** What should be passed as -mcpu, -mattrs, and related for
@@ -122,6 +122,7 @@ protected:
     static bool llvm_initialized;
     static bool llvm_X86_enabled;
     static bool llvm_ARM_enabled;
+    static bool llvm_Hexagon_enabled;
     static bool llvm_AArch64_enabled;
     static bool llvm_NVPTX_enabled;
     static bool llvm_Mips_enabled;
@@ -195,6 +196,7 @@ protected:
     Expr wild_u8x16, wild_u16x8, wild_u32x4, wild_u64x2; // 128-bit unsigned ints
     Expr wild_i8x32, wild_i16x16, wild_i32x8, wild_i64x4; // 256-bit signed ints
     Expr wild_u8x32, wild_u16x16, wild_u32x8, wild_u64x4; // 256-bit unsigned ints
+
     Expr wild_f32x2; // 64-bit floats
     Expr wild_f32x4, wild_f64x2; // 128-bit floats
     Expr wild_f32x8, wild_f64x4; // 256-bit floats
@@ -203,7 +205,6 @@ protected:
     Expr wild_u1x_, wild_i8x_, wild_u8x_, wild_i16x_, wild_u16x_;
     Expr wild_i32x_, wild_u32x_, wild_i64x_, wild_u64x_;
     Expr wild_f32x_, wild_f64x_;
-
     Expr min_i8, max_i8, max_u8;
     Expr min_i16, max_i16, max_u16;
     Expr min_i32, max_i32, max_u32;
@@ -457,6 +458,9 @@ protected:
      */
     std::pair<llvm::Function *, int> find_vector_runtime_function(const std::string &name, int lanes);
 
+    /** Get the result of modulus-remainder analysis for a given expr. */
+    ModulusRemainder get_alignment_info(Expr e);
+
 private:
 
     /** All the values in scope at the current code location during
@@ -481,7 +485,7 @@ private:
      * pointer-to-constant-data.
      */
     llvm::Function* embed_metadata_getter(const std::string &metadata_getter_name,
-        const std::string &function_name, const std::vector<Argument> &args);
+        const std::string &function_name, const std::vector<LoweredArgument> &args);
 
     /** Embed a constant expression as a global variable. */
     llvm::Constant *embed_constant_expr(Expr e);

--- a/src/Module.h
+++ b/src/Module.h
@@ -15,6 +15,9 @@
 namespace Halide {
 namespace Internal {
 
+/** Definition of an argument to a LoweredFunc. This is similar to
+ * Argument, except it enables passing extra information useful to
+ * some targets to LoweredFunc. */
 struct LoweredArgument : public Argument {
     /** For scalar arguments, the modulus and remainder of this
      * argument. */

--- a/src/Module.h
+++ b/src/Module.h
@@ -8,11 +8,25 @@
 
 #include "IR.h"
 #include "Buffer.h"
+#include "ModulusRemainder.h"
 #include "Outputs.h"
 #include "Target.h"
 
 namespace Halide {
 namespace Internal {
+
+struct LoweredArgument : public Argument {
+    /** For scalar arguments, the modulus and remainder of this
+     * argument. */
+    ModulusRemainder alignment;
+
+    LoweredArgument() {}
+    LoweredArgument(const Argument &arg) : Argument(arg) {}
+    LoweredArgument(const std::string &_name, Kind _kind, const Type &_type, uint8_t _dimensions,
+                    Expr _def = Expr(),
+                    Expr _min = Expr(),
+                    Expr _max = Expr()) : Argument(_name, _kind, _type, _dimensions, _def, _min, _max) {}
+};
 
 /** Definition of a lowered function. This object provides a concrete
  * mapping between parameters used in the function body and their
@@ -21,7 +35,7 @@ struct LoweredFunc {
     std::string name;
 
     /** Arguments referred to in the body of this function. */
-    std::vector<Argument> args;
+    std::vector<LoweredArgument> args;
 
     /** Body of this function. */
     Stmt body;
@@ -35,8 +49,14 @@ struct LoweredFunc {
     /** The linkage of this function. */
     LinkageType linkage;
 
-    LoweredFunc(const std::string &name, const std::vector<Argument> &args, Stmt body, LinkageType linkage)
+    LoweredFunc(const std::string &name, const std::vector<LoweredArgument> &args, Stmt body, LinkageType linkage)
         : name(name), args(args), body(body), linkage(linkage) {}
+    LoweredFunc(const std::string &name, const std::vector<Argument> &args, Stmt body, LinkageType linkage)
+        : name(name), body(body), linkage(linkage) {
+        for (const Argument &i : args) {
+            this->args.push_back(i);
+        }
+    }
 };
 
 }
@@ -71,7 +91,7 @@ public:
     EXPORT void append(const Internal::LoweredFunc &function);
     // @}
 
-    /** Compile a halide Module to variety of outputs, depending on 
+    /** Compile a halide Module to variety of outputs, depending on
      * the fields set in output_files. */
     EXPORT void compile(const Outputs &output_files) const;
 };


### PR DESCRIPTION
This PR adds LoweredArgument, which stores alignment info and passes it into LLVM.

Unfortunately, there's not a good way to directly test this change (aside from being sure it doesn't break existing functionality). I'm trying to split this off from the hexagon2 branch, it is a frequent source of merge conflicts.