### PR TITLE
CodeGen_Posix refactoring

### DIFF
--- a/src/CodeGen_Posix.h
+++ b/src/CodeGen_Posix.h
@@ -30,6 +30,12 @@ protected:
     void visit(const Free *);
     // @}
 
+    /** It can be convenient for backends to assume there is extra
+     * padding beyond the end of a buffer to enable faster
+     * loads/stores. This function gets the padding required by the
+     * implementing target. */
+    virtual int allocation_padding(Type type) const;
+
     /** A struct describing heap or stack allocations. */
     struct Allocation {
         /** The memory */
@@ -93,6 +99,11 @@ private:
     Allocation create_allocation(const std::string &name, Type type,
                                  const std::vector<Expr> &extents,
                                  Expr condition, Expr new_expr, std::string free_function);
+
+    /** Free an allocation previously allocated with
+     * create_allocation */
+    void free_allocation(const std::string &name);
+
 };
 
 }}


### PR DESCRIPTION
This PR has some changes/cleanups to CodeGen_Posix:

- Allocate scalars without attempting to reuse a stack allocation, to help LLVM promote them to registers.
- Allow backends to customize the extra allocation padding, instead of hardcoding one extra scalar.
- Free allocations if there is no early Free, instead of asserting that a Free node existed.