### PR TITLE
Add file_make_temp() utility

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -109,7 +109,8 @@ void Module::compile(const Outputs &output_files) const {
 
             std::string object_name = output_files.object_name;
             if (object_name.empty()) {
-                object_name = output_files.static_library_name + ".tmp";
+                const char* ext = target().os == Target::Windows && !target().has_feature(Target::MinGW) ? ".obj" : ".o";
+                object_name = Internal::file_make_temp(output_files.static_library_name, ext);
                 file_to_delete.reset(new Internal::FileUnlinker(object_name));
             }
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -19,6 +19,9 @@
 #ifdef __linux__
 #include <linux/limits.h>  // For PATH_MAX
 #endif
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 namespace Halide {
 namespace Internal {

--- a/src/Util.h
+++ b/src/Util.h
@@ -185,14 +185,15 @@ struct FileStat {
     uint32_t mode;
 };
 
-// Create a unique file with a name of the form baseXXXXXext in an arbitrary
-// (but writable) directory; this is typically $TMP or /tmp, but the specific
-// location is not guaranteed. (Note that the exact form of the file name
-// may vary; in particular, the extension may be ignored.)
-// The file is created (but not opened), thus this can be called from
-// different threads (or processes, e.g. when building with parallel make)
-// without risking collision. Note that if this file is used as a temporary
-// file, the caller is responsibly for deleting it.
+/** Create a unique file with a name of the form baseXXXXXext in an arbitrary
+ * (but writable) directory; this is typically $TMP or /tmp, but the specific
+ * location is not guaranteed. (Note that the exact form of the file name
+ * may vary; in particular, the extension may be ignored.)
+ * The file is created (but not opened), thus this can be called from
+ * different threads (or processes, e.g. when building with parallel make)
+ * without risking collision. Note that if this file is used as a temporary
+ * file, the caller is responsibly for deleting it.
+ */
 std::string file_make_temp(const std::string &base, const std::string &ext);
 
 /** Wrapper for access(). Asserts upon error. */

--- a/src/Util.h
+++ b/src/Util.h
@@ -185,6 +185,16 @@ struct FileStat {
     uint32_t mode;
 };
 
+// Create a unique file with a name of the form baseXXXXXext in an arbitrary
+// (but writable) directory; this is typically $TMP or /tmp, but the specific
+// location is not guaranteed. (Note that the exact form of the file name
+// may vary; in particular, the extension may be ignored.)
+// The file is created (but not opened), thus this can be called from
+// different threads (or processes, e.g. when building with parallel make)
+// without risking collision. Note that if this file is used as a temporary
+// file, the caller is responsibly for deleting it.
+std::string file_make_temp(const std::string &base, const std::string &ext);
+
 /** Wrapper for access(). Asserts upon error. */
 bool file_exists(const std::string &name);
 


### PR DESCRIPTION
The code in Module::compile() can be subject to race conditions when
building in parallel (e.g. if there are duplicate rules that attempt to
make the same file); add a utility to safely create a unique temporary
file and use it to avoid this problem.

(Note: Windows code believed to be correct but not yet compiled or
tested.)