### PR TITLE
Fix CMake-on-Mac builds

### DIFF
--- a/HalideGenerator.cmake
+++ b/HalideGenerator.cmake
@@ -88,48 +88,36 @@ function(halide_add_generator_dependency)
       WORKING_DIRECTORY "${SCRATCH_DIR}"
       )
   elseif(XCODE)
-    if (NOT target_is_pnacl)
-      add_custom_command(OUTPUT "${SCRATCH_DIR}/${FILTER_LIB}" "${SCRATCH_DIR}/${FILTER_HDR}"
-                                "${SCRATCH_DIR}/${args_GENERATED_FUNCTION}.o"
-        DEPENDS "${args_GENERATOR_TARGET}"
+    add_custom_command(OUTPUT "${SCRATCH_DIR}/${FILTER_LIB}" "${SCRATCH_DIR}/${FILTER_HDR}"
+                              "${SCRATCH_DIR}/${args_GENERATED_FUNCTION}.o"
+      DEPENDS "${args_GENERATOR_TARGET}"
 
-        # The generator executable will be placed in a configuration specific
-        # directory, so the Xcode variable $(CONFIGURATION) is passed in the custom
-        # build script.
-        COMMAND "${CMAKE_BINARY_DIR}/bin/$(CONFIGURATION)/${generator_exec}" ${invoke_args}
+      # The generator executable will be placed in a configuration specific
+      # directory, so the Xcode variable $(CONFIGURATION) is passed in the custom
+      # build script.
+      COMMAND "${CMAKE_BINARY_DIR}/bin/$(CONFIGURATION)/${generator_exec}" ${invoke_args}
 
-        # If we are building an ordinary executable, use libtool to create the
-        # static library.
-        COMMAND libtool -static -o "${FILTER_LIB}" "${SCRATCH_DIR}/${args_GENERATED_FUNCTION}.o"
-        WORKING_DIRECTORY "${SCRATCH_DIR}"
-        )
-    else()
-      # For pnacl targets, there is no libtool step
-      add_custom_command(OUTPUT "${SCRATCH_DIR}/${FILTER_LIB}" "${SCRATCH_DIR}/${FILTER_HDR}"
-        DEPENDS "${args_GENERATOR_TARGET}"
-        COMMAND "${CMAKE_BINARY_DIR}/bin/$(CONFIGURATION)/${generator_exec}" ${invoke_args}
-        WORKING_DIRECTORY "${SCRATCH_DIR}"
-        )
-    endif()
-
+      # If we are building an ordinary executable, use libtool to create the
+      # static library.
+      COMMAND libtool -static -o "${FILTER_LIB}" "${SCRATCH_DIR}/${args_GENERATED_FUNCTION}.o"
+      WORKING_DIRECTORY "${SCRATCH_DIR}"
+      )
+  elseif(target_is_pnacl)
+    # No archive step for pnacl targets
+    add_custom_command(OUTPUT "${SCRATCH_DIR}/${FILTER_LIB}" "${SCRATCH_DIR}/${FILTER_HDR}"
+      DEPENDS "${args_GENERATOR_TARGET}"
+      COMMAND "${CMAKE_BINARY_DIR}/bin/${generator_exec}" ${invoke_args}
+      WORKING_DIRECTORY "${SCRATCH_DIR}"
+      )
   else()
-    if (NOT target_is_pnacl)
-      add_custom_command(OUTPUT "${SCRATCH_DIR}/${FILTER_LIB}" "${SCRATCH_DIR}/${FILTER_HDR}"
-                                "${SCRATCH_DIR}/${args_GENERATED_FUNCTION}.o"
-        DEPENDS "${args_GENERATOR_TARGET}"
-        COMMAND "${CMAKE_BINARY_DIR}/bin/${generator_exec}" ${invoke_args}
-        # Create an archive using ar (or similar)
-        COMMAND "${CMAKE_AR}" r "${FILTER_LIB}" "${SCRATCH_DIR}/${args_GENERATED_FUNCTION}.o"
-        WORKING_DIRECTORY "${SCRATCH_DIR}"
-        )
-    else()
-      # No archive step for pnacl targets
-      add_custom_command(OUTPUT "${SCRATCH_DIR}/${FILTER_LIB}" "${SCRATCH_DIR}/${FILTER_HDR}"
-        DEPENDS "${args_GENERATOR_TARGET}"
-        COMMAND "${CMAKE_BINARY_DIR}/bin/${generator_exec}" ${invoke_args}
-        WORKING_DIRECTORY "${SCRATCH_DIR}"
-        )
-    endif()
+    add_custom_command(OUTPUT "${SCRATCH_DIR}/${FILTER_LIB}" "${SCRATCH_DIR}/${FILTER_HDR}"
+                              "${SCRATCH_DIR}/${args_GENERATED_FUNCTION}.o"
+      DEPENDS "${args_GENERATOR_TARGET}"
+      COMMAND "${CMAKE_BINARY_DIR}/bin/${generator_exec}" ${invoke_args}
+      # Create an archive using ar (or similar)
+      COMMAND "${CMAKE_AR}" r "${FILTER_LIB}" "${SCRATCH_DIR}/${args_GENERATED_FUNCTION}.o"
+      WORKING_DIRECTORY "${SCRATCH_DIR}"
+      )
   endif()
 
   # Use a custom target to force it to run the generator before the

--- a/apps/camera_pipe/CMakeLists.txt
+++ b/apps/camera_pipe/CMakeLists.txt
@@ -6,7 +6,8 @@ set(curved_obj "${CMAKE_CURRENT_BINARY_DIR}/curved${CMAKE_CXX_OUTPUT_EXTENSION}"
 
 # FIXME: Set -O3 here
 add_library(fcam fcam/Demosaic.cpp fcam/Demosaic_ARM.cpp)
-if (NOT MSVC)
+FIND_PACKAGE(OpenMP)
+if (OPENMP_FOUND)
     target_compile_options(fcam PUBLIC "-fopenmp")
 endif()
 

--- a/apps/glsl/CMakeLists.txt
+++ b/apps/glsl/CMakeLists.txt
@@ -10,7 +10,7 @@ set(hycc_obj "${CMAKE_CURRENT_BINARY_DIR}/ycc.o")
 add_executable(opengl_test opengl_test.cpp ${hb_header} ${hycc_header})
 target_link_libraries(opengl_test PRIVATE Halide ${OPENGL_LIBRARIES}
                     "${hb_obj}" "${hycc_obj}")
-if (NOT WIN32)
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 target_link_libraries(opengl_test PRIVATE pthread dl X11 GL)
 endif()
 target_include_directories(opengl_test PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
— use CMake’s detection for OpenMP instead of assuming all non-MSVC
systems provide it (recent Mac clang does not)
—  change if-not-MSVC to if-Linux in apps/glsl due to X11 link
requirements