### PR TITLE
Catch signed integer overflow during constant folding

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1183,6 +1183,10 @@ void CodeGen_C::visit(const Call *op) {
         rhs << print_expr(op->args[0]) << " / " << print_expr(op->args[1]);
     } else if (op->is_intrinsic(Call::mod_round_to_zero)) {
         rhs << print_expr(op->args[0]) << " % " << print_expr(op->args[1]);
+    } else if (op->is_intrinsic(Call::signed_integer_overflow)) {
+        user_error << "Signed integer overflow occurred during constant-folding. Signed"
+            " integer overflow for int32 and int64 is undefined behavior in"
+            " Halide.\n";
     } else if (op->call_type == Call::Intrinsic ||
                op->call_type == Call::PureIntrinsic) {
         // TODO: other intrinsics

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2626,6 +2626,10 @@ void CodeGen_LLVM::visit(const Call *op) {
             f->setCallingConv(CallingConv::C);
         }
         register_destructor(f, codegen(arg), Always);
+    } else if (op->is_intrinsic(Call::signed_integer_overflow)) {
+        user_error << "Signed integer overflow occurred during constant-folding. Signed"
+            " integer overflow for int32 and int64 is undefined behavior in"
+            " Halide.\n";
     } else if (op->call_type == Call::Intrinsic ||
                op->call_type == Call::PureIntrinsic) {
         internal_error << "Unknown intrinsic: " << op->name << "\n";

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -694,6 +694,7 @@ Call::ConstString Call::likely = "likely";
 Call::ConstString Call::register_destructor = "register_destructor";
 Call::ConstString Call::div_round_to_zero = "div_round_to_zero";
 Call::ConstString Call::mod_round_to_zero = "mod_round_to_zero";
+Call::ConstString Call::signed_integer_overflow = "signed_integer_overflow";
 
 
 }

--- a/src/IR.h
+++ b/src/IR.h
@@ -426,7 +426,8 @@ struct Call : public ExprNode<Call> {
         likely,
         register_destructor,
         div_round_to_zero,
-        mod_round_to_zero;
+        mod_round_to_zero,
+        signed_integer_overflow;
 
     // If it's a call to another halide function, this call node holds
     // onto a pointer to that function for the purposes of reference

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -56,6 +56,15 @@ bool no_overflow(Type t) {
     return t.is_float() || no_overflow_scalar_int(t.element_of());
 }
 
+// Make a poison value used when overflow is detected during constant
+// folding.
+Expr signed_integer_overflow_error(Type t) {
+    // Mark each call with an atomic counter, so that the errors can't
+    // cancel against each other.
+    static std::atomic<int> counter;
+    return Call::make(t, Call::signed_integer_overflow, {counter++}, Call::Intrinsic);
+}
+
 }
 
 class Simplify : public IRMutator {
@@ -413,8 +422,12 @@ private:
 
         if (const_int(a, &ia) &&
             const_int(b, &ib)) {
-            // const int + const int
-            expr = IntImm::make(a.type(), ia + ib);
+            if (no_overflow(a.type()) &&
+                add_would_overflow(a.type().bits(), ia, ib)) {
+                expr = signed_integer_overflow_error(a.type());
+            } else {
+                expr = IntImm::make(a.type(), ia + ib);
+            }
         } else if (const_uint(a, &ua) &&
                    const_uint(b, &ub)) {
             // const uint + const uint
@@ -737,7 +750,12 @@ private:
         } else if (equal(a, b)) {
             expr = make_zero(op->type);
         } else if (const_int(a, &ia) && const_int(b, &ib)) {
-            expr = IntImm::make(a.type(), ia - ib);
+            if (no_overflow(a.type()) &&
+                sub_would_overflow(a.type().bits(), ia, ib)) {
+                expr = signed_integer_overflow_error(a.type());
+            } else {
+                expr = IntImm::make(a.type(), ia - ib);
+            }
         } else if (const_uint(a, &ua) && const_uint(b, &ub)) {
             expr = UIntImm::make(a.type(), ua - ub);
         } else if (const_float(a, &fa) && const_float(b, &fb)) {
@@ -1179,7 +1197,12 @@ private:
         } else if (is_one(b)) {
             expr = a;
         } else if (const_int(a, &ia) && const_int(b, &ib)) {
-            expr = IntImm::make(a.type(), ia * ib);
+            if (no_overflow(a.type()) &&
+                mul_would_overflow(a.type().bits(), ia, ib)) {
+                expr = signed_integer_overflow_error(a.type());
+            } else {
+                expr = IntImm::make(a.type(), ia * ib);
+            }
         } else if (const_uint(a, &ua) && const_uint(b, &ub)) {
             expr = UIntImm::make(a.type(), ua * ub);
         } else if (const_float(a, &fa) && const_float(b, &fb)) {
@@ -4514,6 +4537,54 @@ void check_math() {
     check(ceil(ceil(x)), ceil(x));
 }
 
+void check_overflow() {
+    Expr overflowing[] = {
+        make_const(Int(32), 0x7fffffff) + 1,
+        make_const(Int(32), 0x7ffffff0) + 16,
+        (make_const(Int(32), 0x7fffffff) +
+         make_const(Int(32), 0x7fffffff)),
+        make_const(Int(32), 0x08000000) * 16,
+        (make_const(Int(32), 0x00ffffff) *
+         make_const(Int(32), 0x00ffffff)),
+        make_const(Int(32), 0x80000000) - 1,
+        0 - make_const(Int(32), 0x80000000),
+        make_const(Int(64), (int64_t)0x7fffffffffffffffLL) + 1,
+        make_const(Int(64), (int64_t)0x7ffffffffffffff0LL) + 16,
+        (make_const(Int(64), (int64_t)0x7fffffffffffffffLL) +
+         make_const(Int(64), (int64_t)0x7fffffffffffffffLL)),
+        make_const(Int(64), (int64_t)0x0800000000000000LL) * 16,
+        (make_const(Int(64), (int64_t)0x00ffffffffffffffLL) *
+         make_const(Int(64), (int64_t)0x00ffffffffffffffLL)),
+        make_const(Int(64), (int64_t)0x8000000000000000LL) - 1,
+        0 - make_const(Int(64), (int64_t)0x8000000000000000LL),
+    };
+    Expr not_overflowing[] = {
+        make_const(Int(32), 0x7ffffffe) + 1,
+        make_const(Int(32), 0x7fffffef) + 16,
+        make_const(Int(32), 0x07ffffff) * 2,
+        (make_const(Int(32), 0x0000ffff) *
+         make_const(Int(32), 0x00008000)),
+        make_const(Int(32), 0x80000001) - 1,
+        0 - make_const(Int(32), 0x7fffffff),
+        make_const(Int(64), (int64_t)0x7ffffffffffffffeLL) + 1,
+        make_const(Int(64), (int64_t)0x7fffffffffffffefLL) + 16,
+        make_const(Int(64), (int64_t)0x07ffffffffffffffLL) * 16,
+        (make_const(Int(64), (int64_t)0x00000000ffffffffLL) *
+         make_const(Int(64), (int64_t)0x0000000080000000LL)),
+        make_const(Int(64), (int64_t)0x8000000000000001LL) - 1,
+        0 - make_const(Int(64), (int64_t)0x7fffffffffffffffLL),
+    };
+
+    for (Expr e : overflowing) {
+        internal_assert(!is_const(simplify(e)))
+            << "Overflowing expression should not have simplified: " << e << "\n";
+    }
+    for (Expr e : not_overflowing) {
+        internal_assert(is_const(simplify(e)))
+            << "Non-everflowing expression should have simplified: " << e << "\n";
+    }
+}
+
 }
 
 void simplify_test() {
@@ -4528,6 +4599,7 @@ void simplify_test() {
     check_bounds();
     check_math();
     check_boolean();
+    check_overflow();
 
     // Check bitshift operations
     check(cast(Int(16), x) << 10, cast(Int(16), x) * 1024);

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -1334,6 +1334,19 @@ void solve_test() {
     check_and_condition((x != 0) && (y != 0), const_false(), Interval(-10, 10));
     check_and_condition((x != 0) && (y != 0), y != 0, Interval(-20, -10));
 
+    {
+        // This case used to break due to signed integer overflow in
+        // the simplifier.
+        Expr a16 = Load::make(Int(16), "a", {x}, Buffer(), Parameter());
+        Expr b16 = Load::make(Int(16), "b", {x}, Buffer(), Parameter());
+        Expr lhs = pow(cast<int32_t>(a16), 2) + pow(cast<int32_t>(b16), 2);
+
+        Scope<Interval> s;
+        s.push("x", Interval(-10, 10));
+        Expr cond = and_condition_over_domain(lhs < 0, s);
+        internal_assert(!is_one(simplify(cond)));
+    }
+
     debug(0) << "Solve test passed\n";
 
 }

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -279,5 +279,40 @@ std::string file_make_temp(const std::string &prefix, const std::string &suffix)
     #endif
 }
 
+bool add_would_overflow(int bits, int64_t a, int64_t b) {
+    int64_t max_val = 0x7fffffffffffffffLL >> (64 - bits);
+    int64_t min_val = -max_val - 1;
+    return
+        ((b > 0 && a > max_val - b) || // (a + b) > max_val, rewritten to avoid overflow
+         (b < 0 && a < min_val - b));  // (a + b) < min_val, rewritten to avoid overflow
+}
+
+bool sub_would_overflow(int bits, int64_t a, int64_t b) {
+    int64_t max_val = 0x7fffffffffffffffLL >> (64 - bits);
+    int64_t min_val = -max_val - 1;
+    return
+        ((b < 0 && a > max_val + b) || // (a - b) > max_val, rewritten to avoid overflow
+         (b > 0 && a < min_val + b));  // (a - b) < min_val, rewritten to avoid overflow
+}
+
+bool mul_would_overflow(int bits, int64_t a, int64_t b) {
+    int64_t max_val = 0x7fffffffffffffffLL >> (64 - bits);
+    int64_t min_val = -max_val - 1;
+    if (a == 0) {
+        return false;
+    } else if (a == -1) {
+        return b == min_val;
+    } else {
+        // Do the multiplication as a uint64, for which overflow is
+        // well defined, then cast the bits back to int64 to get
+        // multiplication modulo 2^64.
+        int64_t ab = (int64_t)((uint64_t)a)*((uint64_t)b);
+        // The first two clauses catch overflow mod 2^bits, assuming
+        // no 64-bit overflow occurs, and the third clause catches
+        // 64-bit overflow.
+        return ab < min_val || ab > max_val || (ab / a != b);
+    }
+}
+
 }
 }

--- a/src/Util.h
+++ b/src/Util.h
@@ -211,7 +211,7 @@ EXPORT FileStat file_stat(const std::string &name);
  */
 class TemporaryFile final {
 public:
-    TemporaryFile(const std::string &prefix, const std::string &suffix) 
+    TemporaryFile(const std::string &prefix, const std::string &suffix)
         : temp_path(file_make_temp(prefix, suffix)) {}
     const std::string &pathname() const { return temp_path; }
     ~TemporaryFile() { file_unlink(temp_path); }
@@ -220,6 +220,15 @@ private:
     TemporaryFile(const TemporaryFile &) = delete;
     void operator=(const TemporaryFile &) = delete;
 };
+
+/** Routines to test if math would overflow for signed integers with
+ * the given number of bits. */
+// @{
+bool add_would_overflow(int bits, int64_t a, int64_t b);
+bool sub_would_overflow(int bits, int64_t a, int64_t b);
+bool mul_would_overflow(int bits, int64_t a, int64_t b);
+// @}
+
 
 }
 }

--- a/test/error/overflow_during_constant_folding.cpp
+++ b/test/error/overflow_during_constant_folding.cpp
@@ -1,0 +1,13 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Func f;
+    Var x;
+    f(x) = Expr(0x12345678) * Expr(0x76543210);
+
+    f.realize(10);
+
+    return 0;
+}


### PR DESCRIPTION
This was causing the prover to prove false things (see the new test in
Solve.cpp)