### PR TITLE
Defer inject-likely on shiftinwards heuristic until loop partitioning

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -738,7 +738,8 @@ private:
                 // If the argument is unbounded on one side, then the max is unbounded.
                 max = Expr();
             }
-        } else if (op->is_intrinsic(Call::likely)) {
+        } else if (op->is_intrinsic(Call::likely) ||
+                   op->is_intrinsic(Call::likely_if_innermost)) {
             assert(op->args.size() == 1);
             op->args[0].accept(this);
         } else if (op->is_intrinsic(Call::return_second)) {
@@ -1250,7 +1251,8 @@ private:
                 // of conditions for now.
                 Expr c = op->condition;
                 const Call *call = c.as<Call>();
-                if (call && call->is_intrinsic(Call::likely)) {
+                if (call && (call->is_intrinsic(Call::likely) ||
+                             call->is_intrinsic(Call::likely_if_innermost))) {
                     c = call->args[0];
                 }
                 const LT *lt = c.as<LT>();
@@ -1282,6 +1284,9 @@ private:
                         if (call && call->is_intrinsic(Call::likely)) {
                             likely_i.min = likely(i.min);
                             likely_i.max = likely(i.max);
+                        } else if (call && call->is_intrinsic(Call::likely_if_innermost)) {
+                            likely_i.min = likely_if_innermost(i.min);
+                            likely_i.max = likely_if_innermost(i.max);
                         }
 
                         Interval bi = bounds_of_expr_in_scope(b, scope, func_bounds);
@@ -1310,6 +1315,9 @@ private:
                         if (call && call->is_intrinsic(Call::likely)) {
                             likely_i.min = likely(i.min);
                             likely_i.max = likely(i.max);
+                        } else if (call && call->is_intrinsic(Call::likely_if_innermost)) {
+                            likely_i.min = likely_if_innermost(i.min);
+                            likely_i.max = likely_if_innermost(i.max);
                         }
 
                         Interval ai = bounds_of_expr_in_scope(a, scope, func_bounds);

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -691,6 +691,7 @@ Call::ConstString Call::stringify = "stringify";
 Call::ConstString Call::memoize_expr = "memoize_expr";
 Call::ConstString Call::copy_memory = "copy_memory";
 Call::ConstString Call::likely = "likely";
+Call::ConstString Call::likely_if_innermost = "likely_if_innermost";
 Call::ConstString Call::register_destructor = "register_destructor";
 Call::ConstString Call::div_round_to_zero = "div_round_to_zero";
 Call::ConstString Call::mod_round_to_zero = "mod_round_to_zero";

--- a/src/IR.h
+++ b/src/IR.h
@@ -424,6 +424,7 @@ struct Call : public ExprNode<Call> {
         memoize_expr,
         copy_memory,
         likely,
+        likely_if_innermost,
         register_destructor,
         div_round_to_zero,
         mod_round_to_zero,

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1880,6 +1880,13 @@ inline Expr likely(Expr e) {
                                 {e}, Internal::Call::PureIntrinsic);
 }
 
+/** Equivalent to likely, but only triggers a loop partitioning if
+ * found in an innermost loop. */
+inline Expr likely_if_innermost(Expr e) {
+    return Internal::Call::make(e.type(), Internal::Call::likely_if_innermost,
+                                {e}, Internal::Call::PureIntrinsic);
+}
+
 }
 
 #endif

--- a/src/Monotonic.cpp
+++ b/src/Monotonic.cpp
@@ -288,8 +288,10 @@ class MonotonicVisitor : public IRVisitor {
 
     void visit(const Call *op) {
         // Some functions are known to be monotonic
-        if (op->is_intrinsic(Call::likely)) {
-            op->args[0].accept(this);
+        if (op->is_intrinsic(Call::likely) ||
+            op->is_intrinsic(Call::likely_if_innermost) ||
+            op->is_intrinsic(Call::return_second)) {
+            op->args.back().accept(this);
             return;
         }
 

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -19,6 +19,7 @@ using std::map;
 using std::vector;
 using std::pair;
 using std::make_pair;
+using std::set;
 
 namespace {
 // A structure representing a containing LetStmt, IfThenElse, or For
@@ -84,15 +85,6 @@ Stmt build_provide_loop_nest(Function f,
     }
 
     vector<Split> splits = s.splits();
-
-    Dim innermost_non_trivial_loop;
-    for (const Dim &d : s.dims()) {
-        if (d.for_type != ForType::Vectorized &&
-            d.for_type != ForType::Unrolled) {
-            innermost_non_trivial_loop = d;
-            break;
-        }
-    }
 
     // Define the function args in terms of the loop variables using the splits
     for (const Split &split : splits) {
@@ -173,14 +165,10 @@ Stmt build_provide_loop_nest(Function f,
                 // Adjust the base downwards to not compute off the
                 // end of the realization.
 
-                // Only mark the base as likely (triggering a loop
-                // partition) if the outer var is the innermost
-                // non-trivial loop and it's a serial loop. This
-                // usually is due to an unroll or vectorize call.
-                if (split.outer == innermost_non_trivial_loop.var &&
-                    innermost_non_trivial_loop.for_type == ForType::Serial) {
-                    base = likely(base);
-                }
+                // We'll only mark the base as likely (triggering a loop
+                // partition) if we're at or inside the innermost
+                // non-trivial loop.
+                base = likely_if_innermost(base);
 
                 base = Min::make(base, old_max + (1 - split.factor));
             } else {

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -323,7 +323,8 @@ private:
 
     void visit(const Call *op) {
         // Ignore likely intrinsics
-        if (op->is_intrinsic(Call::likely)) {
+        if (op->is_intrinsic(Call::likely) ||
+            op->is_intrinsic(Call::likely_if_innermost)) {
             expr = mutate(op->args[0]);
         } else {
             IRMutator::visit(op);

--- a/src/TrimNoOps.cpp
+++ b/src/TrimNoOps.cpp
@@ -31,7 +31,8 @@ class StripIdentities : public IRMutator {
         if (op->is_intrinsic(Call::trace_expr)) {
             expr = mutate(op->args[4]);
         } else if (op->is_intrinsic(Call::return_second) ||
-                   op->is_intrinsic(Call::likely)) {
+                   op->is_intrinsic(Call::likely) ||
+                   op->is_intrinsic(Call::likely_if_innermost)) {
             expr = mutate(op->args.back());
         } else {
             IRMutator::visit(op);


### PR DESCRIPTION
We have a heuristic in ScheduleFunctions that decides whether or not to
apply a likely on the base for the ShiftInwards tail strategy. This is
to trade off code size vs performance. It was pretty broken in a bunch
of cases. The basic problem is that you can't tell at that point what's
going to be an innermost loop. This PR defers the decision until loop
partitioning time, which is after vectorization and unrolling. This
unfortunately required a new variant of likely.

likely always partitions a loop

likely_if_innermost converts to likely if it's in an innermost loop
(after vectorization and unrolling). Otherwise it just goes away.

Note that this doesn't necessarily mean we'll partition the innermost
loop. This would be bad, e.g. if it's a small loop over a convolution
kernel inside a large loop over pixels. We still partition the outermost
loop we can that simplifies the likely intrinsics. We just only care
about simplifying likely_if_innermost intrinsics if we find them in an
innermost loop.