### PR TITLE
Save and restore OpenGL state when running a pipeline.

### DIFF
--- a/src/runtime/mini_opengl.h
+++ b/src/runtime/mini_opengl.h
@@ -23,6 +23,7 @@ typedef void GLvoid;
 #define GL_TRIANGLE_STRIP 0x0005
 #define GL_CULL_FACE 0x0B44
 #define GL_DEPTH_TEST 0x0B71
+#define GL_VIEWPORT 0x0BA2
 #define GL_PACK_ALIGNMENT 0x0D05
 #define GL_UNPACK_ALIGNMENT 0x0CF5
 #define GL_UNPACK_ROW_LENGTH 0x0CF2
@@ -53,6 +54,7 @@ typedef void GLvoid;
 #define GL_TEXTURE_WRAP_T 0x2803
 #define GL_CLAMP_TO_EDGE 0x812F
 #define GL_TEXTURE0 0x84C0
+#define GL_ACTIVE_TEXTURE 0x84E0
 
 typedef void (*PFNGLACTIVETEXTUREPROC) (GLenum texture);
 typedef void (*PFNGLBINDTEXTUREPROC)(GLenum target, GLuint texture);
@@ -112,6 +114,7 @@ typedef void (*PFNGLBUFFERDATAPROC)(GLenum target, GLsizeiptr size, const GLvoid
 #define GL_INFO_LOG_LENGTH 0x8B84
 #define GL_IMPLEMENTATION_COLOR_READ_FORMAT 0x8B9B
 #define GL_IMPLEMENTATION_COLOR_READ_TYPE 0x8B9A
+#define GL_CURRENT_PROGRAM 0x8B8D
 
 typedef void (*PFNGLATTACHSHADERPROC) (GLuint program, GLuint shader);
 typedef void (*PFNGLCOMPILESHADERPROC) (GLuint shader);
@@ -137,6 +140,7 @@ typedef void (*PFNGLUNIFORM1FVPROC) (GLint location, GLsizei count, const GLfloa
 typedef void (*PFNGLUSEPROGRAMPROC) (GLuint program);
 typedef void (*PFNGLVERTEXATTRIBPOINTERPROC) (GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid *pointer);
 typedef void (*PFNGLGETINTEGERV)(GLenum pname, GLint *data);
+typedef void (*PFNGLGETBOOLEANV)(GLenum pname, GLboolean *data);
 typedef void (*PFNGLFINISHPROC) (void);
 
 

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -28,6 +28,7 @@
     GLFUNC(PFNGLTEXIMAGE2DPROC, TexImage2D);                            \
     GLFUNC(PFNGLTEXSUBIMAGE2DPROC, TexSubImage2D);                      \
     GLFUNC(PFNGLDISABLEPROC, Disable);                                  \
+    GLFUNC(PFNGLDISABLEPROC, Enable);                                   \
     GLFUNC(PFNGLCREATESHADERPROC, CreateShader);                        \
     GLFUNC(PFNGLACTIVETEXTUREPROC, ActiveTexture);                      \
     GLFUNC(PFNGLSHADERSOURCEPROC, ShaderSource);                        \
@@ -61,7 +62,8 @@
     GLFUNC(PFNGLPIXELSTOREIPROC, PixelStorei);                          \
     GLFUNC(PFNGLREADPIXELS, ReadPixels);                                \
     GLFUNC(PFNGLGETSTRINGPROC, GetString);                              \
-    GLFUNC(PFNGLGETINTEGERV, GetIntegerv);
+    GLFUNC(PFNGLGETINTEGERV, GetIntegerv);                              \
+    GLFUNC(PFNGLGETBOOLEANV, GetBooleanv);
 
 // List of all OpenGL functions used by the runtime, which may not
 // exist due to an older or less capable version of GL. In using any
@@ -174,6 +176,16 @@ struct ModuleState {
     ModuleState *next;
 };
 
+// OpenGL state to save and restore before/after
+// running a filter.
+struct SavedGLState {
+    GLint active_texture;
+	  GLint program;
+	  GLint viewport[4];
+    GLboolean cull_face;
+    GLboolean depth_test;
+};
+
 // All persistent state maintained by the runtime.
 struct GlobalState {
     void init();
@@ -198,6 +210,11 @@ struct GlobalState {
     // A list of all textures that are still active
     TextureInfo *textures;
 
+    // Saved OpenGL state prior to running filter
+    struct SavedGLState saved_state;
+    void SaveGLState();
+    void RestoreGLState();
+
     // Declare pointers used OpenGL functions
 #define GLFUNC(PTYPE,VAR) PTYPE VAR
     USED_GL_FUNCTIONS;
@@ -213,6 +230,47 @@ WEAK bool GlobalState::CheckAndReportError(void *user_context, const char *locat
         return true;
     }
     return false;
+}
+
+WEAK void GlobalState::SaveGLState() {
+    this->GetIntegerv(GL_ACTIVE_TEXTURE, &(saved_state.active_texture));
+    this->GetIntegerv(GL_CURRENT_PROGRAM, &(saved_state.program));
+    this->GetIntegerv(GL_VIEWPORT, saved_state.viewport);
+    this->GetBooleanv(GL_CULL_FACE, &(saved_state.cull_face));
+    this->GetBooleanv(GL_DEPTH_TEST, &(saved_state.depth_test));
+
+#ifdef DEBUG_RUNTIME
+    debug(NULL) << "Saved OpenGL state:\n "
+      << "\tactive texture: " << saved_state.active_texture << "\n"
+      << "\tprogram: "  << saved_state.program << "\n"
+      << "\tviewport: (" << saved_state.viewport[0] << ", "
+                         << saved_state.viewport[1] << ", "
+                         << saved_state.viewport[2] << ", "
+                         << saved_state.viewport[3] << ")\n"
+      << "\tcull face: " << saved_state.cull_face << "\n"
+      << "\tdepth test: " << saved_state.depth_test << "\n";
+#endif
+}
+
+WEAK void GlobalState::RestoreGLState() {
+#ifdef DEBUG_RUNTIME
+    debug(NULL) << "Restoring OpenGL state:\n "
+      << "\tactive texture: " << saved_state.active_texture << "\n"
+      << "\tprogram: "  << saved_state.program << "\n"
+      << "\tviewport: (" << saved_state.viewport[0] << ", "
+                         << saved_state.viewport[1] << ", "
+                         << saved_state.viewport[2] << ", "
+                         << saved_state.viewport[3] << ")\n"
+      << "\tcull face: " << saved_state.cull_face << "\n"
+      << "\tdepth test: " << saved_state.depth_test << "\n";
+#endif
+
+    this->ActiveTexture(saved_state.active_texture);
+    this->UseProgram(saved_state.program);
+    this->Viewport(saved_state.viewport[0], saved_state.viewport[1],
+         saved_state.viewport[2], saved_state.viewport[3]);
+    (saved_state.cull_face ? this->Enable : this->Disable)(GL_CULL_FACE);
+    (saved_state.depth_test ? this->Enable : this->Disable)(GL_DEPTH_TEST);
 }
 
 
@@ -1320,6 +1378,9 @@ WEAK int halide_opengl_run(void *user_context,
         return 1;
     }
 
+    // save current OpenGL state
+    global_state.SaveGLState();
+
     ModuleState *mod = (ModuleState *)state_ptr;
     if (!mod) {
         error(user_context) << "Internal error: module state is NULL";
@@ -1796,6 +1857,9 @@ WEAK int halide_opengl_run(void *user_context,
 
     global_state.DeleteBuffers(1, &vertex_buffer_id);
     global_state.DeleteBuffers(1, &element_buffer_id);
+
+    // Restore OpenGL state
+    global_state.RestoreGLState();
 
     return 0;
 }


### PR DESCRIPTION
This commit modifies `halide_opengl_run()` to save and restore
state that's modified by the runtime.  Note that we don't know
if this is comprehensive, so further pieces of state may need
to be saved/restored.

This fixes #1165 and #1166.  PTAL.