### PR TITLE
[Hexagon] Fix assert for boolean comparison simplifications

### DIFF
--- a/test/correctness/logical.cpp
+++ b/test/correctness/logical.cpp
@@ -82,6 +82,35 @@ int main(int argc, char **argv) {
         }
     }
 
+    // Test a condition that uses differently sized types.
+    {
+        Func f;
+        Expr ten = 10;
+        f(x, y) = select(input(x, y) > ten, u8(255), u8(0));
+
+        Target target = get_jit_target_from_environment();
+        if (target.has_gpu_feature()) {
+            f.gpu_tile(x, y, 16, 16).vectorize(Var::gpu_threads(), 4);
+        } else if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
+            f.hexagon().vectorize(x, 64);
+        } else {
+            f.vectorize(x, 8);
+        }
+
+        Image<uint8_t> output = f.realize(64, 64, target);
+
+        for (int y = 0; y < 64; y++) {
+            for (int x = 0; x < 64; x++) {
+                bool cond = input(x, y) > 10;
+                uint8_t correct = cond ? 255 : 0;
+                if (correct != output(x, y)) {
+                    printf("output(%d, %d) = %d instead of %d\n", x, y, output(x, y), correct);
+                    return -1;
+                }
+            }
+        }
+    }
+
 
     printf("Success!\n");
     return 0;


### PR DESCRIPTION
When trying to move interleaves through casts, we need to skip over the boolean vector to avoid attempting to interleave it.