### PR TITLE
Opengl fix immediate codegen

### DIFF
--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -250,6 +250,18 @@ void CodeGen_GLSL::visit(const FloatImm *op) {
     id = oss.str();
 }
 
+void CodeGen_GLSL::visit(const IntImm *op) {
+    if (op->type == Int(32)) {
+        id = std::to_string(op->value);
+    } else {
+        print_assignment(op->type, print_type(op->type) + "(" + std::to_string(op->value) + ")");
+    }
+}
+
+void CodeGen_GLSL::visit(const UIntImm *op) {
+    print_assignment(op->type, print_type(op->type) + "(" + std::to_string(op->value) + ")");
+}
+
 void CodeGen_GLSL::visit(const Cast *op) {
     Type value_type = op->value.type();
     // If both types are represented by the same GLSL type, no explicit cast

--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -251,11 +251,7 @@ void CodeGen_GLSL::visit(const FloatImm *op) {
 }
 
 void CodeGen_GLSL::visit(const IntImm *op) {
-    if (op->type == Int(32)) {
-        id = std::to_string(op->value);
-    } else {
-        print_assignment(op->type, print_type(op->type) + "(" + std::to_string(op->value) + ")");
-    }
+    print_assignment(op->type, print_type(op->type) + "(" + std::to_string(op->value) + ")");
 }
 
 void CodeGen_GLSL::visit(const UIntImm *op) {

--- a/src/CodeGen_OpenGL_Dev.h
+++ b/src/CodeGen_OpenGL_Dev.h
@@ -85,6 +85,8 @@ protected:
     using CodeGen_C::visit;
 
     void visit(const FloatImm *);
+    void visit(const UIntImm *);
+    void visit(const IntImm *);
 
     void visit(const Cast *);
     void visit(const Let *);


### PR DESCRIPTION
Integers immediates (signed and unsigned) are cast at
variable declaration time in CodeGen_C, but GLSL requires
a constructor instead of cast.

This makes all but the `opengl_shifted_domain` test pass,
mostly resolving #1252.