### PR TITLE
Infer arguments after lowering to grab new global images

### DIFF
--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -291,11 +291,14 @@ class InferArguments : public IRGraphVisitor {
 public:
     vector<InferredArgument> &args;
 
-    InferArguments(vector<InferredArgument> &a,
-                   const vector<Function> &o) : args(a), outputs(o) {
+    InferArguments(vector<InferredArgument> &a, const vector<Function> &o, Stmt body)
+        : args(a), outputs(o) {
         args.clear();
         for (const Function &f : outputs) {
             visit_function(f);
+        }
+        if (body.defined()) {
+            body.accept(this);
         }
     }
 
@@ -408,21 +411,21 @@ private:
 
 } // namespace Internal
 
-vector<Argument> Pipeline::infer_arguments() {
+vector<Argument> Pipeline::infer_arguments(Stmt body) {
+
     user_assert(defined()) << "Can't infer arguments on an undefined Pipeline\n";
 
-    if (contents->inferred_args.empty()) {
-        // Infer an arguments vector by walking the IR
-        InferArguments infer_args(contents->inferred_args,
-                                  contents->outputs);
+    // Infer an arguments vector by walking the IR
+    InferArguments infer_args(contents->inferred_args,
+                              contents->outputs,
+                              body);
 
-        // Sort the Arguments with all buffers first (alphabetical by name),
-        // followed by all non-buffers (alphabetical by name).
-        std::sort(contents->inferred_args.begin(), contents->inferred_args.end());
+    // Sort the Arguments with all buffers first (alphabetical by name),
+    // followed by all non-buffers (alphabetical by name).
+    std::sort(contents->inferred_args.begin(), contents->inferred_args.end());
 
-        // Add the user context argument.
-        contents->inferred_args.push_back(contents->user_context_arg);
-    }
+    // Add the user context argument.
+    contents->inferred_args.push_back(contents->user_context_arg);
 
     // Return the inferred argument types, minus any constant images
     // (we'll embed those in the binary by default), and minus the user_context arg.
@@ -439,10 +442,14 @@ vector<Argument> Pipeline::infer_arguments() {
     return result;
 }
 
+vector<Argument> Pipeline::infer_arguments() {
+    return infer_arguments(Stmt());
+}
+
 /** Check that all the necessary arguments are in an args vector. Any
  * images in the source that aren't in the args vector are returned. */
-vector<Buffer> Pipeline::validate_arguments(const vector<Argument> &args) {
-    infer_arguments();
+vector<Buffer> Pipeline::validate_arguments(const vector<Argument> &args, Stmt body) {
+    infer_arguments(body);
 
     vector<Buffer> images_to_embed;
 
@@ -572,7 +579,7 @@ Module Pipeline::compile_to_module(const vector<Argument> &args,
     // Get all the arguments/global images referenced in this function.
     vector<Argument> public_args = build_public_args(args, target);
 
-    vector<Buffer> global_images = validate_arguments(public_args);
+    vector<Buffer> global_images = validate_arguments(public_args, private_body);
 
     // Create a module with all the global images in it.
     Module module(simple_new_fn_name, target);
@@ -658,8 +665,10 @@ void *Pipeline::compile_jit(const Target &target_arg) {
     // Compile to a module
     Module module = compile_to_module(args, name, target);
 
-    // Make sure we're not embedding any images
-    internal_assert(module.buffers().empty());
+    // We need to infer the arguments again, because compiling (GPU
+    // and offload targets) might have added new buffers we need to
+    // embed.
+    infer_arguments(module.functions().back().body);
 
     std::map<std::string, JITExtern> lowered_externs = contents->jit_externs;
     // Compile to jit module

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -58,7 +58,8 @@ struct JITExtern;
 class Pipeline {
     Internal::IntrusivePtr<PipelineContents> contents;
 
-    std::vector<Buffer> validate_arguments(const std::vector<Argument> &args);
+    std::vector<Argument> infer_arguments(Internal::Stmt body);
+    std::vector<Buffer> validate_arguments(const std::vector<Argument> &args, Internal::Stmt body);
     std::vector<const void *> prepare_jit_call_arguments(Realization dst, const Target &target);
 
     static std::vector<Internal::JITModule> make_externs_jit_module(const Target &target,
@@ -416,7 +417,7 @@ bool voidable_halide_type(Type &t) {
 template<>
 inline bool voidable_halide_type<void>(Type &t) {
     return true;
-}        
+}
 
 template <typename T>
 bool scalar_arg_type_or_buffer(Type &t) {


### PR DESCRIPTION
This PR stops caching inferred arguments, and uses the lowered body to validate the arguments, so it can grab global images added during lowering.

This enables lowering passes to add global "images" to the function, which enables things like GPU targets to be implemented during lowering (instead of a custom codegen implementation!).