### PR TITLE
[Hexagon] Line buffer the camera pipe schedule

### DIFF
--- a/apps/camera_pipe/camera_pipe.cpp
+++ b/apps/camera_pipe/camera_pipe.cpp
@@ -5,7 +5,7 @@ using namespace Halide;
 
 Target target;
 
-Var x, y, tx("tx"), ty("ty"), c("c");
+Var x, y, yi("yi"), yo("yo"), c("c");
 Func processed("processed");
 
 // Average two positive values rounding up
@@ -147,73 +147,31 @@ Func demosaic(Func deinterleaved) {
 
 
     /* THE SCHEDULE */
-    if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
-        // Compute these in chunks over tiles
-        const int vector_size = target.has_feature(Target::HVX_128) ? 64 : 32;
-
-        // It helps hexagon to align each scanline of the storage to the vector size.
-        g_r.compute_at(processed, tx).align_storage(x, vector_size).vectorize(x, vector_size);
-        g_b.compute_at(processed, tx).align_storage(x, vector_size).vectorize(x, vector_size);
-        r_gr.compute_at(processed, tx).align_storage(x, vector_size).vectorize(x, vector_size);
-        b_gr.compute_at(processed, tx).align_storage(x, vector_size).vectorize(x, vector_size);
-        r_gb.compute_at(processed, tx).align_storage(x, vector_size).vectorize(x, vector_size);
-        b_gb.compute_at(processed, tx).align_storage(x, vector_size).vectorize(x, vector_size);
-        r_b.compute_at(processed, tx).align_storage(x, vector_size).vectorize(x, vector_size);
-        b_r.compute_at(processed, tx).align_storage(x, vector_size).vectorize(x, vector_size);
-
-        // These interleave in y, so unrolling them in y helps
-        output.compute_at(processed, tx)
-            .vectorize(x, vector_size * 2)
-            .unroll(y, 2)
-            .reorder(c, x, y)
-            .bound(c, 0, 3).unroll(c);
-    } else if (target.arch == Target::ARM) {
-        // Optimized for ARM
-        // Compute these in chunks over tiles, vectorized by 8
-        g_r.compute_at(processed, tx).vectorize(x, 8);
-        g_b.compute_at(processed, tx).vectorize(x, 8);
-        r_gr.compute_at(processed, tx).vectorize(x, 8);
-        b_gr.compute_at(processed, tx).vectorize(x, 8);
-        r_gb.compute_at(processed, tx).vectorize(x, 8);
-        b_gb.compute_at(processed, tx).vectorize(x, 8);
-        r_b.compute_at(processed, tx).vectorize(x, 8);
-        b_r.compute_at(processed, tx).vectorize(x, 8);
-
-        // These interleave in y, so unrolling them in y helps
-        output.compute_at(processed, tx)
-            .vectorize(x, 8)
-            .unroll(y, 2)
-            .reorder(c, x, y)
-            .bound(c, 0, 3).unroll(c);
-    } else if (target.arch == Target::X86) {
-        // Don't vectorize, because sse is bad at 16-bit interleaving
-        g_r.compute_at(processed, tx);
-        g_b.compute_at(processed, tx);
-        r_gr.compute_at(processed, tx);
-        b_gr.compute_at(processed, tx);
-        r_gb.compute_at(processed, tx);
-        b_gb.compute_at(processed, tx);
-        r_b.compute_at(processed, tx);
-        b_r.compute_at(processed, tx);
-
-        // These interleave in x and y, so unrolling them helps
-        output.compute_at(processed, tx)
-            .unroll(x, 2)
-            .unroll(y, 2)
-            .reorder(c, x, y)
-            .bound(c, 0, 3).unroll(c);
-    } else {
-        // Basic naive schedule
-        g_r.compute_root();
-        g_b.compute_root();
-        r_gr.compute_root();
-        b_gr.compute_root();
-        r_gb.compute_root();
-        b_gb.compute_root();
-        r_b.compute_root();
-        b_r.compute_root();
-        output.compute_root();
+    int vec = target.natural_vector_size(UInt(16));
+    if (target.has_feature(Target::HVX_64)) {
+        vec = 32;
+    } else if (target.has_feature(Target::HVX_128)) {
+        vec = 64;
     }
+    g_r.compute_at(processed, yi)
+        .store_at(processed, yo)
+        .vectorize(x, vec, TailStrategy::RoundUp)
+        .fold_storage(y, 2);
+    g_b.compute_at(processed, yi)
+        .store_at(processed, yo)
+        .vectorize(x, vec, TailStrategy::RoundUp)
+        .fold_storage(y, 2);
+    output.compute_at(processed, x)
+        .vectorize(x)
+        .unroll(y)
+        .reorder(c, x, y)
+        .unroll(c);
+
+    if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
+        g_r.align_storage(x, vec);
+        g_b.align_storage(x, vec);
+    }
+
     return output;
 }
 
@@ -241,11 +199,11 @@ Func color_correct(Func input, ImageParam matrix_3200, ImageParam matrix_7000, P
     g = cast<int16_t>(g/256);
     b = cast<int16_t>(b/256);
     corrected(x, y, c) = select(c == 0, r,
-                                select(c == 1, g, b));
+                                c == 1, g,
+                                        b);
 
     return corrected;
 }
-
 
 Func apply_curve(Func input, Type result_type, Expr gamma, Expr contrast,
                  Expr blackLevel, Expr whiteLevel) {
@@ -309,7 +267,7 @@ Func process(Func raw, Type result_type,
              ImageParam matrix_3200, ImageParam matrix_7000, Param<float> color_temp,
              Param<float> gamma, Param<float> contrast, Param<int> blackLevel, Param<int> whiteLevel) {
 
-    Var xi, yi;
+    Var yii, xi;
 
     Func denoised = hot_pixel_suppression(raw);
     Func deinterleaved = deinterleave(denoised);
@@ -323,78 +281,45 @@ Func process(Func raw, Type result_type,
     Expr out_width = processed.output_buffer().width();
     Expr out_height = processed.output_buffer().height();
 
-    processed.bound(c, 0, 3); // bound color loop 0-3, properly
-    if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
-        const int tile_width = 512;
-        const int tile_height = 64;
-        const int vector_size = target.has_feature(Target::HVX_128) ? 128 : 64;
-        const int vector_size_16 = vector_size/2;
-        denoised.compute_at(processed, tx)
-            .align_storage(x, vector_size_16)
-            .vectorize(x, vector_size_16);
-        deinterleaved.compute_at(processed, tx)
-            .align_storage(x, vector_size_16)
-            .vectorize(x, vector_size_16)
-            .reorder(c, x, y)
-            .unroll(c);
-        corrected.compute_at(processed, tx)
-            .vectorize(x, vector_size_16)
-            .reorder(c, x, y)
-            .unroll(c);
-        processed.compute_root()
-            .hexagon()
-            .tile(x, y, tx, ty, xi, yi, tile_width, tile_height)
-            .reorder(xi, yi, c, tx, ty)
-            .vectorize(xi, vector_size)
-            .parallel(ty);
-
-        // We can generate slightly better code if we know the output is a whole number of tiles.
-        processed
-            .bound(x, 0, (out_width/tile_width)*tile_width)
-            .bound(y, 0, (out_height/tile_height)*tile_height);
-    } else if (target.arch == Target::ARM) {
-        // Compute in chunks over tiles, vectorized by 8
-        const int tile_size = 32;
-        denoised.compute_at(processed, tx)
-            .vectorize(x, 8);
-        deinterleaved.compute_at(processed, tx)
-            .vectorize(x, 8)
-            .reorder(c, x, y)
-            .unroll(c);
-        corrected.compute_at(processed, tx)
-            .vectorize(x, 4)
-            .reorder(c, x, y)
-            .unroll(c);
-        processed.compute_root()
-            .tile(x, y, tx, ty, xi, yi, tile_size, tile_size)
-            .reorder(xi, yi, c, tx, ty)
-            .parallel(ty);
-
-        // We can generate slightly better code if we know the output is a whole number of tiles.
-        processed
-            .bound(x, 0, (out_width/tile_size)*tile_size)
-            .bound(y, 0, (out_height/tile_size)*tile_size);
-    } else if (target.arch == Target::X86) {
-        // Same as above, but don't vectorize (sse is bad at interleaved 16-bit ops)
-        const int tile_size = 128;
-        denoised.compute_at(processed, tx);
-        deinterleaved.compute_at(processed, tx);
-        corrected.compute_at(processed, tx);
-        processed.compute_root()
-            .tile(x, y, tx, ty, xi, yi, tile_size, tile_size)
-            .reorder(xi, yi, c, tx, ty)
-            .parallel(ty);
-
-        // We can generate slightly better code if we know the output is a whole number of tiles.
-        processed
-            .bound(x, 0, (out_width/tile_size)*tile_size)
-            .bound(y, 0, (out_height/tile_size)*tile_size);
-    } else {
-        denoised.compute_root();
-        deinterleaved.compute_root();
-        corrected.compute_root();
-        processed.compute_root();
+    int strip_size = 32;
+    int vec = target.natural_vector_size(UInt(16));
+    if (target.has_feature(Target::HVX_64)) {
+        vec = 32;
+    } else if (target.has_feature(Target::HVX_128)) {
+        vec = 64;
     }
+    denoised.compute_at(processed, yi).store_at(processed, yo)
+        .fold_storage(y, 8)
+        .vectorize(x, vec);
+    deinterleaved.compute_at(processed, yi).store_at(processed, yo)
+        .fold_storage(y, 4)
+        .vectorize(x, 2*vec, TailStrategy::RoundUp)
+        .reorder(c, x, y)
+        .unroll(c);
+    corrected.compute_at(processed, x)
+        .vectorize(x, vec)
+        .reorder(c, x, y)
+        .unroll(c);
+    processed.compute_root()
+        .split(y, yo, yi, strip_size)
+        .split(yi, yi, yii, 2)
+        .split(x, x, xi, 2*vec, TailStrategy::RoundUp)
+        .reorder(xi, c, yii, x, yi, yo)
+        .vectorize(xi, 2*vec)
+        .parallel(yo);
+
+    if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
+        processed.hexagon();
+        denoised.align_storage(x, vec);
+        deinterleaved.align_storage(x, vec);
+        corrected.align_storage(x, vec);
+    }
+
+    // We can generate slightly better code if we know the splits divide the extent.
+    processed
+        .bound(c, 0, 3)
+        .bound(x, 0, ((out_width)/(2*vec))*(2*vec))
+        .bound(y, 0, (out_height/strip_size)*strip_size);
 
     return processed;
 }
@@ -429,9 +354,6 @@ int main(int argc, char **argv) {
     // Build the pipeline
     Func processed = process(shifted, result_type, matrix_3200, matrix_7000,
                              color_temp, gamma, contrast, blackLevel, whiteLevel);
-
-    // Assert our input is aligned, which helps Hexagon generate better code.
-    input.set_host_alignment(128);
 
     std::vector<Argument> args = {color_temp, gamma, contrast, blackLevel, whiteLevel,
                                   input, matrix_3200, matrix_7000};


### PR DESCRIPTION
This pulls Andrew's line buffer schedule from master, and adds an HVX schedule. This is pretty quick and dirty, it needs some comments at least if we want this to be an example for HVX.

It improves performance on the simulator slightly, I suspect the difference will be bigger on real hardware (where memory access patterns actually matter).