### PR TITLE
Simplify target <-> string API

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -358,7 +358,7 @@ class ExternCallPrototypes : public IRGraphVisitor {
             if (op->call_type == Call::ExternCPlusPlus) {
                 std::vector<std::string> namespaces;
                 name = extract_namespaces(op->name, namespaces);
-                for (auto const &ns : namespaces) {
+                for (const auto &ns : namespaces) {
                     stream << "namespace " << ns << " { ";
                 }
                 namespace_count = namespaces.size();

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -254,7 +254,7 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
     auto target_strings = split_string(target_string, ",");
     std::vector<Target> targets;
     for (const auto &s : target_strings) {
-        targets.push_back(parse_target_string(s));
+        targets.push_back(Target(s));
     }
 
     if (!runtime_name.empty()) {

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -233,7 +233,7 @@ private:
     template <typename T2 = T,
               typename std::enable_if<std::is_same<T2, Target>::value>::type * = nullptr>
     T from_string_impl(const std::string &s) const {
-        return parse_target_string(s);
+        return Target(s);
     }
     template <typename T2 = T,
               typename std::enable_if<std::is_same<T2, Target>::value>::type * = nullptr>

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -499,7 +499,7 @@ class PartitionLoops : public IRMutator {
         }
 
         // Find simplifications we can apply to the prologue and epilogue.
-        for (auto const &s : middle_simps) {
+        for (const auto &s : middle_simps) {
             // If it goes down to minus infinity, we can also
             // apply it to the prologue
             if (can_simplify_prologue &&

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -372,13 +372,13 @@ void bad_target_string(const std::string &target) {
             separator = ", ";
         }
     }
-    user_error << "Did not understand HL_TARGET=" << target << "\n"
+    user_error << "Did not understand Halide target " << target << "\n"
                << "Expected format is arch-os-feature1-feature2-...\n"
                << "Where arch is " << architectures << " .\n"
                << "Os is " << oses << " .\n"
                << "If arch or os are omitted, they default to the host.\n"
                << "Features are " << features << " .\n"
-               << "HL_TARGET can also begin with \"host\", which sets the "
+               << "The target can also begin with \"host\", which sets the "
                << "host's architecture, os, and feature set, with the "
                << "exception of the GPU runtimes, which default to off.\n"
                << "On this platform, the host target is: " << get_host_target().to_string() << "\n";

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -260,7 +260,7 @@ Target get_target_from_environment() {
     if (target.empty()) {
         return get_host_target();
     } else {
-        return parse_target_string(target);
+        return Target(target);
     }
 }
 
@@ -271,7 +271,7 @@ Target get_jit_target_from_environment() {
     if (target.empty()) {
         return host;
     } else {
-        Target t = parse_target_string(target);
+        Target t(target);
         t.set_feature(Target::JIT);
         user_assert(t.os == host.os && t.arch == host.arch && t.bits == host.bits)
             << "HL_JIT_TARGET must match the host OS, architecture, and bit width.\n"
@@ -281,65 +281,8 @@ Target get_jit_target_from_environment() {
     }
 }
 
-Target parse_target_string(const std::string &target) {
-    Target host = get_host_target();
-
-    if (target.empty()) {
-        // If nothing is specified, use the full host target.
-        return host;
-    }
-
-    // Default to the host OS and architecture in case of partially
-    // specified targets (e.g. x86-64-cuda doesn't specify the OS, so
-    // use the host OS).
-    Target t;
-    t.os = host.os;
-    t.arch = host.arch;
-    t.bits = host.bits;
-
-    if (!t.merge_string(target)) {
-        const char *separator = "";
-        std::string architectures;
-        for (auto const &arch_entry : arch_name_map) {
-            architectures += separator + arch_entry.first;
-            separator = ", ";
-        }
-        separator = "";
-        std::string oses;
-        for (auto os_entry : os_name_map) {
-            oses += separator + os_entry.first;
-            separator = ", ";
-        }
-        separator = "";
-        // Format the features to go one feature over 70 characters per line,
-        // assume the first line starts with "Features are ".
-        int line_char_start = -(int)sizeof("Features are");
-        std::string features;
-        for (auto feature_entry : feature_name_map) {
-            features += separator + feature_entry.first;
-            if (features.length() - line_char_start > 70) {
-                separator = "\n";
-                line_char_start = features.length();
-            } else {
-                separator = ", ";
-            }
-        }
-        user_error << "Did not understand HL_TARGET=" << target << "\n"
-                   << "Expected format is arch-os-feature1-feature2-...\n"
-                   << "Where arch is " << architectures << " .\n"
-                   << "Os is " << oses << " .\n"
-                   << "If arch or os are omitted, they default to the host.\n"
-                   << "Features are " << features << " .\n"
-                   << "HL_TARGET can also begin with \"host\", which sets the "
-                   << "host's architecture, os, and feature set, with the "
-                   << "exception of the GPU runtimes, which default to off.\n"
-                   << "On this platform, the host target is: " << host.to_string() << "\n";
-    }
-
-    return t;
-}
-
-bool Target::merge_string(const std::string &target) {
+namespace {
+bool merge_string(Target &t, const std::string &target) {
     string rest = target;
     vector<string> tokens;
     size_t first_dash;
@@ -361,25 +304,25 @@ bool Target::merge_string(const std::string &target) {
                 // "host" is now only allowed as the first token.
                 return false;
             }
-            *this = get_host_target();
+            t = get_host_target();
         } else if (tok == "32" || tok == "64") {
             if (bits_specified) {
                 return false;
             }
             bits_specified = true;
-            bits = std::stoi(tok);
-        } else if (lookup_arch(tok, arch)) {
+            t.bits = std::stoi(tok);
+        } else if (lookup_arch(tok, t.arch)) {
             if (arch_specified) {
                 return false;
             }
             arch_specified = true;
-        } else if (lookup_os(tok, os)) {
+        } else if (lookup_os(tok, t.os)) {
             if (os_specified) {
                 return false;
             }
             os_specified = true;
         } else if (lookup_feature(tok, feature)) {
-            set_feature(feature);
+            t.set_feature(feature);
         } else {
             return false;
         }
@@ -390,11 +333,11 @@ bool Target::merge_string(const std::string &target) {
     }
 
     // If arch is PNaCl, require explicit setting of os and bits as well.
-    if (arch_specified && arch == Target::PNaCl) {
-        if (!os_specified || os != Target::NaCl) {
+    if (arch_specified && t.arch == Target::PNaCl) {
+        if (!os_specified || t.os != Target::NaCl) {
             return false;
         }
-        if (!bits_specified || bits != 32) {
+        if (!bits_specified || t.bits != 32) {
             return false;
         }
     }
@@ -402,22 +345,93 @@ bool Target::merge_string(const std::string &target) {
     return true;
 }
 
+void bad_target_string(const std::string &target) {
+    const char *separator = "";
+    std::string architectures;
+    for (const auto &arch_entry : arch_name_map) {
+        architectures += separator + arch_entry.first;
+        separator = ", ";
+    }
+    separator = "";
+    std::string oses;
+    for (auto os_entry : os_name_map) {
+        oses += separator + os_entry.first;
+        separator = ", ";
+    }
+    separator = "";
+    // Format the features to go one feature over 70 characters per line,
+    // assume the first line starts with "Features are ".
+    int line_char_start = -(int)sizeof("Features are");
+    std::string features;
+    for (auto feature_entry : feature_name_map) {
+        features += separator + feature_entry.first;
+        if (features.length() - line_char_start > 70) {
+            separator = "\n";
+            line_char_start = features.length();
+        } else {
+            separator = ", ";
+        }
+    }
+    user_error << "Did not understand HL_TARGET=" << target << "\n"
+               << "Expected format is arch-os-feature1-feature2-...\n"
+               << "Where arch is " << architectures << " .\n"
+               << "Os is " << oses << " .\n"
+               << "If arch or os are omitted, they default to the host.\n"
+               << "Features are " << features << " .\n"
+               << "HL_TARGET can also begin with \"host\", which sets the "
+               << "host's architecture, os, and feature set, with the "
+               << "exception of the GPU runtimes, which default to off.\n"
+               << "On this platform, the host target is: " << get_host_target().to_string() << "\n";
+}
+
+}
+
+Target::Target(const std::string &target) {
+    Target host = get_host_target();
+
+    if (target.empty()) {
+        // If nothing is specified, use the full host target.
+        *this = host;
+    } else {
+
+        // Default to the host OS and architecture in case of partially
+        // specified targets (e.g. x86-64-cuda doesn't specify the OS, so
+        // use the host OS).
+        os = host.os;
+        arch = host.arch;
+        bits = host.bits;
+
+        if (!merge_string(*this, target)) {
+            bad_target_string(target);
+        }
+    }
+}
+
+Target::Target(const char *s) {
+    *this = Target(std::string(s));
+}
+
+bool Target::validate_target_string(const std::string &s) {
+    Target t;
+    return merge_string(t, s);
+}
+
 std::string Target::to_string() const {
     string result;
-    for (auto const &arch_entry : arch_name_map) {
+    for (const auto &arch_entry : arch_name_map) {
         if (arch_entry.second == arch) {
             result += arch_entry.first;
             break;
         }
     }
     result += "-" + std::to_string(bits);
-    for (auto const &os_entry : os_name_map) {
+    for (const auto &os_entry : os_name_map) {
         if (os_entry.second == os) {
             result += "-" + os_entry.first;
             break;
         }
     }
-    for (auto const &feature_entry : feature_name_map) {
+    for (const auto &feature_entry : feature_name_map) {
         if (has_feature(feature_entry.second)) {
             result += "-" + feature_entry.first;
         }
@@ -489,7 +503,7 @@ namespace Internal {
 
 EXPORT void target_test() {
     Target t;
-    for (auto const &feature : feature_name_map) {
+    for (const auto &feature : feature_name_map) {
         t.set_feature(feature.second);
     }
     for (int i = 0; i < (int)(Target::FeatureEnd); i++) {

--- a/src/Target.h
+++ b/src/Target.h
@@ -245,11 +245,6 @@ private:
 /** Return the target corresponding to the host machine. */
 EXPORT Target get_host_target();
 
-/** Return the host target with all features that start with "No"
- * enabled. Produces the smallest possible assembly, which makes it
- * useful for inspecting what Halide is doing. */
-EXPORT Target get_minimal_target();
-
 /** Return the target that Halide will use. If HL_TARGET is set it
  * uses that. Otherwise calls \ref get_host_target */
 EXPORT Target get_target_from_environment();

--- a/src/Target.h
+++ b/src/Target.h
@@ -88,6 +88,8 @@ struct Target {
      * omit (say) an OS specification, the host OS will be used
      * instead. An empty string is exactly equivalent to
      * get_host_target().
+     *
+     * Invalid target strings will fail with a user_error.
      */
     // @{
     EXPORT explicit Target(const std::string &s);

--- a/src/Target.h
+++ b/src/Target.h
@@ -81,6 +81,22 @@ struct Target {
         }
     }
 
+    /** Given a string of the form used in HL_TARGET
+     * (e.g. "x86-64-avx"), construct the Target it specifies. Note
+     * that this always starts with the result of get_host_target(),
+     * replacing only the parts found in the target string, so if you
+     * omit (say) an OS specification, the host OS will be used
+     * instead. An empty string is exactly equivalent to
+     * get_host_target().
+     */
+    // @{
+    EXPORT explicit Target(const std::string &s);
+    EXPORT explicit Target(const char *s);
+    // @}
+
+    /** Check if a target string is valid. */
+    EXPORT static bool validate_target_string(const std::string &s);
+
     void set_feature(Feature f, bool value = true) {
         if (f == FeatureEnd) return;
         user_assert(f < FeatureEnd) << "Invalid Target feature.\n";
@@ -191,37 +207,6 @@ struct Target {
      */
     EXPORT std::string to_string() const;
 
-    /**
-     * Parse the contents of 'target' and merge into 'this',
-     * replacing only the parts that are specified. (e.g., if 'target' specifies
-     * only an arch, only the arch field of 'this' will be changed, leaving
-     * the other fields untouched). Any features specified in 'target'
-     * are added to 'this', whether or not originally present.
-     *
-     * If the string contains unknown tokens, or multiple tokens of the
-     * same category (e.g. multiple arch values), return false
-     * (possibly leaving 'this' munged). (Multiple feature specifications
-     * will not cause a failure.)
-     *
-     * If 'target' contains "host" as the first token, it replaces the entire
-     * contents of 'this' with get_host_target(), then proceeds to parse the
-     * remaining tokens (allowing for things like "host-opencl" to mean
-     * "host configuration, but with opencl added").
-     *
-     * Note that unlike parse_from_string(), this will never print to cerr or
-     * assert in the event of a parse failure. Note also that an empty target
-     * string is essentially a no-op, leaving 'this' unaffected.
-     */
-    EXPORT bool merge_string(const std::string &target);
-
-    /**
-     * Like merge_string(), but reset the contents of 'this' first.
-     */
-    EXPORT bool from_string(const std::string &target) {
-        *this = Target();
-        return merge_string(target);
-    }
-
     /** Given a data type, return an estimate of the "natural" vector size
      * for that data type when compiling for this Target. */
     int natural_vector_size(Halide::Type t) const {
@@ -260,6 +245,11 @@ private:
 /** Return the target corresponding to the host machine. */
 EXPORT Target get_host_target();
 
+/** Return the host target with all features that start with "No"
+ * enabled. Produces the smallest possible assembly, which makes it
+ * useful for inspecting what Halide is doing. */
+EXPORT Target get_minimal_target();
+
 /** Return the target that Halide will use. If HL_TARGET is set it
  * uses that. Otherwise calls \ref get_host_target */
 EXPORT Target get_target_from_environment();
@@ -270,15 +260,6 @@ EXPORT Target get_target_from_environment();
  * and OS of the target do not match the host target, so this is only
  * useful for controlling the feature set. */
 EXPORT Target get_jit_target_from_environment();
-
-/** Given a string of the form used in HL_TARGET (e.g. "x86-64-avx"),
- * return the Target it specifies. Note that this always starts with
- * the result of get_host_target(), replacing only the parts found in the
- * target string, so if you omit (say) an OS specification, the host OS
- * will be used instead. An empty string is exactly equivalent to get_host_target().
- */
-EXPORT Target parse_target_string(const std::string &target);
-
 
 /** Get the Target feature corresponding to a DeviceAPI. For device
  * apis that do not correspond to any single target feature, returns

--- a/test/correctness/compile_to_multitarget.cpp
+++ b/test/correctness/compile_to_multitarget.cpp
@@ -6,15 +6,6 @@
 
 using namespace Halide;
 
-Target from_string(const char* target_string) {
-    Target t;
-    if (!t.from_string(target_string)) {
-        fprintf(stderr, "from_string failed\n");
-        exit(-1);
-    }
-    return t;
-}
-
 void testCompileToOutput(Func j) {
     std::string fn_object = "compile_to_multitarget";
 
@@ -22,8 +13,8 @@ void testCompileToOutput(Func j) {
     assert(!Internal::file_exists(fn_object) && "Output file already exists.");
 
     std::vector<Target> targets = {
-         from_string("host-profile-debug"),
-         from_string("host-profile"),
+        Target("host-profile-debug"),
+        Target("host-profile"),
     };
     j.compile_to_multitarget_static_library(fn_object, j.infer_arguments(), targets);
 #ifdef _MSC_VER

--- a/test/correctness/cross_compilation.cpp
+++ b/test/correctness/cross_compilation.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
     };
 
     for (const std::string &t : targets) {
-        Target target = parse_target_string(t);
+        Target target(t);
         if (!target.supported()) continue;
         f.compile_to_file("test_object_" + t, std::vector<Argument>(), target);
         f.compile_to_static_library("test_lib_" + t, std::vector<Argument>(), target);

--- a/test/correctness/target.cpp
+++ b/test/correctness/target.cpp
@@ -26,10 +26,6 @@ int main(int argc, char **argv) {
        printf("validate_target_string failure: %s\n", ts.c_str());
        return -1;
     }
-    if (t2 != t1) {
-       printf("compare failure: %s %s\n", t1.to_string().c_str(), t2.to_string().c_str());
-       return -1;
-    }
 
     // Full specification round-trip:
     t1 = Target(Target::Linux, Target::X86, 32, {Target::SSE41});
@@ -40,10 +36,6 @@ int main(int argc, char **argv) {
     }
     if (!Target::validate_target_string(ts)) {
        printf("validate_target_string failure: %s\n", ts.c_str());
-       return -1;
-    }
-    if (t2 != t1) {
-       printf("compare failure: %s %s\n", t1.to_string().c_str(), t2.to_string().c_str());
        return -1;
     }
 
@@ -61,10 +53,6 @@ int main(int argc, char **argv) {
        printf("validate_target_string failure: %s\n", ts.c_str());
        return -1;
     }
-    if (t2 != t1) {
-       printf("compare failure: %s %s\n", t1.to_string().c_str(), t2.to_string().c_str());
-       return -1;
-    }
 
     // Full specification round-trip, PNacl
     t1 = Target(Target::NaCl, Target::PNaCl, 32);
@@ -75,10 +63,6 @@ int main(int argc, char **argv) {
     }
     if (!Target::validate_target_string(ts)) {
        printf("validate_target_string failure: %s\n", ts.c_str());
-       return -1;
-    }
-    if (t2 != t1) {
-       printf("compare failure: %s %s\n", t1.to_string().c_str(), t2.to_string().c_str());
        return -1;
     }
 

--- a/test/correctness/target.cpp
+++ b/test/correctness/target.cpp
@@ -7,9 +7,9 @@ int main(int argc, char **argv) {
     Target t1, t2;
     std::string ts;
 
-    // parse_target_string("") should be exactly like get_host_target().
+    // Target("") should be exactly like get_host_target().
     t1 = get_host_target();
-    t2 = parse_target_string("");
+    t2 = Target("");
     if (t2 != t1){
        printf("parse_from_string failure: %s\n", ts.c_str());
        return -1;
@@ -22,8 +22,8 @@ int main(int argc, char **argv) {
        return -1;
     }
     // We expect from_string() to fail, since it doesn't know about 'unknown'
-    if (t2.from_string(ts)) {
-       printf("from_string failure: %s\n", ts.c_str());
+    if (Target::validate_target_string(ts)) {
+       printf("validate_target_string failure: %s\n", ts.c_str());
        return -1;
     }
     if (t2 != t1) {
@@ -38,8 +38,8 @@ int main(int argc, char **argv) {
        printf("to_string failure: %s\n", ts.c_str());
        return -1;
     }
-    if (!t2.from_string(ts)) {
-       printf("from_string failure: %s\n", ts.c_str());
+    if (!Target::validate_target_string(ts)) {
+       printf("validate_target_string failure: %s\n", ts.c_str());
        return -1;
     }
     if (t2 != t1) {
@@ -57,8 +57,8 @@ int main(int argc, char **argv) {
        printf("to_string failure: %s\n", ts.c_str());
        return -1;
     }
-    if (!t2.from_string(ts)) {
-       printf("from_string failure: %s\n", ts.c_str());
+    if (!Target::validate_target_string(ts)) {
+       printf("validate_target_string failure: %s\n", ts.c_str());
        return -1;
     }
     if (t2 != t1) {
@@ -73,8 +73,8 @@ int main(int argc, char **argv) {
        printf("to_string failure: %s\n", ts.c_str());
        return -1;
     }
-    if (!t2.from_string(ts)) {
-       printf("from_string failure: %s\n", ts.c_str());
+    if (!Target::validate_target_string(ts)) {
+       printf("validate_target_string failure: %s\n", ts.c_str());
        return -1;
     }
     if (t2 != t1) {
@@ -82,35 +82,23 @@ int main(int argc, char **argv) {
        return -1;
     }
 
-    // Partial specification merging: os,arch,bits get replaced; features get combined
-    t2 = Target(Target::Linux, Target::X86, 64, {Target::OpenCL});
-    if (!t2.merge_string("x86-32-sse41")) {
-       printf("merge_string failure: %s\n", ts.c_str());
-       return -1;
-    }
-    // expect 32 (not 64), and both sse41 and opencl
-    if (t2.to_string() != "x86-32-linux-opencl-sse41") {
-       printf("merge_string: %s\n", t2.to_string().c_str());
-       return -1;
-    }
-
     // Expected failures:
     ts = "host-unknowntoken";
-    if (t2.from_string(ts)) {
-       printf("from_string failure: %s\n", ts.c_str());
-       return -1;
+    if (Target::validate_target_string(ts)) {
+        printf("validate_target_string failure: %s\n", ts.c_str());
+        return -1;
     }
 
     ts = "x86-23";
-    if (t2.from_string(ts)) {
-       printf("from_string failure: %s\n", ts.c_str());
+    if (Target::validate_target_string(ts)) {
+       printf("validate_target_string failure: %s\n", ts.c_str());
        return -1;
     }
 
     // "host" is only supported as the first token
     ts = "opencl-host";
-    if (t2.from_string(ts)) {
-       printf("from_string failure: %s\n", ts.c_str());
+    if (Target::validate_target_string(ts)) {
+       printf("validate_target_string failure: %s\n", ts.c_str());
        return -1;
     }
 


### PR DESCRIPTION
Converting strings to targets always felt wonky to me. This is a proposed simplification of the API that just adds an explicit Target(string) constructor, and provides a separate way to validate target strings.