### PR TITLE
OpenGL: Fix remaining tests

### DIFF
--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -397,7 +397,11 @@ std::string CodeGen_GLSL::get_vector_suffix(Expr e) {
         return ".rg";
     } else {
         // GLSL 1.0 Section 5.5 supports subscript based vector indexing
-        return std::string("[") + ((e.type()!=Int(32)) ? "(int)" : "") + print_expr(e) + "]";
+        std::string id = print_assignment(e.type(), print_expr(e));
+        if (e.type() != Int(32)) {
+          id = "int(" + id + ")";
+        }
+        return std::string("[" + id + "]");
     }
 }
 
@@ -449,8 +453,9 @@ void CodeGen_GLSL::visit(const Call *op) {
     } else if (op->is_intrinsic(Call::glsl_texture_store)) {
         internal_assert(op->args.size() == 6);
         std::string sval = print_expr(op->args[5]);
+        std::string suffix = get_vector_suffix(op->args[4]);
         do_indent();
-        stream << "gl_FragColor" << get_vector_suffix(op->args[4])
+        stream << "gl_FragColor" << suffix
                << " = " << sval;
         if (op->args[5].type().is_uint()) {
             stream << " / " << print_expr(cast<float>(op->args[5].type().max()));
@@ -894,7 +899,8 @@ void CodeGen_GLSL::test() {
     Expr load4 = Call::make(Float(32, 4), Call::glsl_texture_load,
                             {string("buf"), 0, 0, 0},
                             Call::Intrinsic);
-    check(load4, "vec4 $ = texture2D($buf, vec2(0, 0));\n");
+    check(load4, "int $ = int(0);\n"
+                 "vec4 $ = texture2D($buf, vec2($, $));\n");
 
     check(log(1.0f), "float $ = log(1.0);\n");
     check(exp(1.0f), "float $ = exp(1.0);\n");

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -1157,11 +1157,7 @@ WEAK int halide_opengl_copy_to_device(void *user_context, buffer_t *buf) {
     bool is_packed = (buf->stride[1] == buf->extent[0] * buf->stride[0]);
     if (is_interleaved && is_packed) {
         global_state.PixelStorei(GL_UNPACK_ALIGNMENT, 1);
-        uint8_t *host_ptr = buf->host + buf->elem_size *
-            (buf->min[0] * buf->stride[0] +
-             buf->min[1] * buf->stride[1] +
-             buf->min[2] * buf->stride[2] +
-             buf->min[3] * buf->stride[3]);
+        uint8_t *host_ptr = buf->host;
         global_state.TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, format, type, host_ptr);
         if (global_state.CheckAndReportError(user_context, "halide_opengl_copy_to_device TexSubImage2D(1)")) {
             return 1;
@@ -1286,11 +1282,7 @@ WEAK int halide_opengl_copy_to_host(void *user_context, buffer_t *buf) {
     bool is_packed = (buf->stride[1] == buf->extent[0] * buf->stride[0]);
     if (is_interleaved && is_packed && texture_channels == buffer_channels) {
         global_state.PixelStorei(GL_PACK_ALIGNMENT, 1);
-        uint8_t *host_ptr = buf->host + buf->elem_size *
-            (buf->min[0] * buf->stride[0] +
-             buf->min[1] * buf->stride[1] +
-             buf->min[2] * buf->stride[2] +
-             buf->min[3] * buf->stride[3]);
+        uint8_t *host_ptr = buf->host;
 #ifdef DEBUG_RUNTIME
         int64_t t1 = halide_current_time_ns(user_context);
 #endif


### PR DESCRIPTION
This fixes the rest of #1252.  Now all OpenGL tests pass, and we should consider having Travis run these if possible.

PTAL at the texture load/store code in particular, for correctness.