### PR TITLE
Upgrade compile_multitarget() to output 'extra' files when requested

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -870,7 +870,7 @@ $(BIN_DIR)/generator_aot_metadata_tester: $(FILTERS_DIR)/metadata_tester_ucon.a
 
 $(FILTERS_DIR)/multitarget.a $(FILTERS_DIR)/multitarget.h: $(FILTERS_DIR)/multitarget.generator
 	@-mkdir -p $(TMP_DIR)
-	cd $(TMP_DIR); $(LD_PATH_SETUP) $(CURDIR)/$< -f multitarget -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-debug-no_runtime,$(HL_TARGET)-no_runtime
+	cd $(TMP_DIR); $(LD_PATH_SETUP) $(CURDIR)/$< -f multitarget -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-debug-no_runtime,$(HL_TARGET)-no_runtime -e assembly,bitcode,cpp,h,html,static_library,stmt
 
 # user_context needs to be generated with user_context as the first argument to its calls
 $(FILTERS_DIR)/user_context.a $(FILTERS_DIR)/user_context.h: $(FILTERS_DIR)/user_context.generator


### PR DESCRIPTION
e.g., stmt files and suchlike. This is a little awkward (since multiple
files are output for these vs. a single output for .h and .a) but
probably the least weird solution here.

Note that .o files are still forbidden here: it’s not really useful and
potentially wrong without extra effort.