### PR TITLE
[Hexagon] Implement u32 x u16 -> u32 multiplication

### DIFF
--- a/src/runtime/hvx_128.ll
+++ b/src/runtime/hvx_128.ll
@@ -96,12 +96,17 @@ define weak_odr <64 x i16> @halide.hexagon.splat.h(i16 %arg) nounwind uwtable re
   ret <64 x i16> %r
 }
 
+; Implement various 32 bit multiplications.
 declare <32 x i32> @llvm.hexagon.V6.vaslw.128B(<32 x i32>, i32)
 declare <32 x i32> @llvm.hexagon.V6.vlsrw.128B(<32 x i32>, i32)
 declare <32 x i32> @llvm.hexagon.V6.vmpyieoh.128B(<32 x i32>, <32 x i32>)
 declare <32 x i32> @llvm.hexagon.V6.vmpyiowh.128B(<32 x i32>, <32 x i32>)
 declare <32 x i32> @llvm.hexagon.V6.vmpyiewuh.128B(<32 x i32>, <32 x i32>)
 declare <32 x i32> @llvm.hexagon.V6.vaddw.128B(<32 x i32>, <32 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vshufeh.128B(<32 x i32>, <32 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vshufoh.128B(<32 x i32>, <32 x i32>)
+declare <64 x i32> @llvm.hexagon.V6.vmpyuhv.128B(<32 x i32>, <32 x i32>)
+declare <64 x i32> @llvm.hexagon.V6.vaddw.dv.128B(<64 x i32>, <64 x i32>)
 
 define weak_odr <32 x i32> @halide.hexagon.mul.vw.vw(<32 x i32> %a, <32 x i32> %b) nounwind uwtable readnone alwaysinline {
   %ab_lo = call <32 x i32> @llvm.hexagon.V6.vmpyiewuh.128B(<32 x i32> %a, <32 x i32> %b)
@@ -129,6 +134,23 @@ define weak_odr <64 x i32> @halide.hexagon.mul.vw.vuh(<64 x i32> %a, <64 x i16> 
   %ab_lo = call <32 x i32> @llvm.hexagon.V6.vmpyiewuh.128B(<32 x i32> %a_lo, <32 x i32> %b_lo)
   %ab_hi = call <32 x i32> @llvm.hexagon.V6.vmpyiewuh.128B(<32 x i32> %a_hi, <32 x i32> %b_hi)
   %ab = call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %ab_hi, <32 x i32> %ab_lo)
+  ret <64 x i32> %ab
+}
+
+define weak_odr <64 x i32> @halide.hexagon.mul.vuw.vuh(<64 x i32> %a, <64 x i16> %b) nounwind uwtable readnone alwaysinline {
+  %a_lo = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %a)
+  %a_hi = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %a)
+  %a_e = call <32 x i32> @llvm.hexagon.V6.vshufeh.128B(<32 x i32> %a_hi, <32 x i32> %a_lo)
+  %a_o = call <32 x i32> @llvm.hexagon.V6.vshufoh.128B(<32 x i32> %a_hi, <32 x i32> %a_lo)
+  %b_32 = bitcast <64 x i16> %b to <32 x i32>
+  %ab_e = call <64 x i32> @llvm.hexagon.V6.vmpyuhv.128B(<32 x i32> %a_e, <32 x i32> %b_32)
+  %ab_o = call <64 x i32> @llvm.hexagon.V6.vmpyuhv.128B(<32 x i32> %a_o, <32 x i32> %b_32)
+  %ab_o_lo = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %ab_o)
+  %ab_o_shifted_lo = call <32 x i32> @llvm.hexagon.V6.vaslw.128B(<32 x i32> %ab_o_lo, i32 16)
+  %ab_o_hi = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %ab_o)
+  %ab_o_shifted_hi = call <32 x i32> @llvm.hexagon.V6.vaslw.128B(<32 x i32> %ab_o_hi, i32 16)
+  %ab_o_shifted = call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %ab_o_shifted_hi, <32 x i32> %ab_o_shifted_lo)
+  %ab = call <64 x i32> @llvm.hexagon.V6.vaddw.dv.128B(<64 x i32> %ab_e, <64 x i32> %ab_o_shifted)
   ret <64 x i32> %ab
 }
 

--- a/src/runtime/hvx_64.ll
+++ b/src/runtime/hvx_64.ll
@@ -96,12 +96,17 @@ define weak_odr <32 x i16> @halide.hexagon.splat.h(i16 %arg) nounwind uwtable re
   ret <32 x i16> %r
 }
 
+; Implement various 32 bit multiplications.
 declare <16 x i32> @llvm.hexagon.V6.vaslw(<16 x i32>, i32)
 declare <16 x i32> @llvm.hexagon.V6.vlsrw(<16 x i32>, i32)
 declare <16 x i32> @llvm.hexagon.V6.vmpyieoh(<16 x i32>, <16 x i32>)
 declare <16 x i32> @llvm.hexagon.V6.vmpyiowh(<16 x i32>, <16 x i32>)
 declare <16 x i32> @llvm.hexagon.V6.vmpyiewuh(<16 x i32>, <16 x i32>)
 declare <16 x i32> @llvm.hexagon.V6.vaddw(<16 x i32>, <16 x i32>)
+declare <16 x i32> @llvm.hexagon.V6.vshufeh(<16 x i32>, <16 x i32>)
+declare <16 x i32> @llvm.hexagon.V6.vshufoh(<16 x i32>, <16 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vmpyuhv(<16 x i32>, <16 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vaddw.dv(<32 x i32>, <32 x i32>)
 
 define weak_odr <16 x i32> @halide.hexagon.mul.vw.vw(<16 x i32> %a, <16 x i32> %b) nounwind uwtable readnone alwaysinline {
   %ab_lo = call <16 x i32> @llvm.hexagon.V6.vmpyiewuh(<16 x i32> %a, <16 x i32> %b)
@@ -129,6 +134,23 @@ define weak_odr <32 x i32> @halide.hexagon.mul.vw.vuh(<32 x i32> %a, <32 x i16> 
   %ab_lo = call <16 x i32> @llvm.hexagon.V6.vmpyiewuh(<16 x i32> %a_lo, <16 x i32> %b_lo)
   %ab_hi = call <16 x i32> @llvm.hexagon.V6.vmpyiewuh(<16 x i32> %a_hi, <16 x i32> %b_hi)
   %ab = call <32 x i32> @llvm.hexagon.V6.vcombine(<16 x i32> %ab_hi, <16 x i32> %ab_lo)
+  ret <32 x i32> %ab
+}
+
+define weak_odr <32 x i32> @halide.hexagon.mul.vuw.vuh(<32 x i32> %a, <32 x i16> %b) nounwind uwtable readnone alwaysinline {
+  %a_lo = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %a)
+  %a_hi = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %a)
+  %a_e = call <16 x i32> @llvm.hexagon.V6.vshufeh(<16 x i32> %a_hi, <16 x i32> %a_lo)
+  %a_o = call <16 x i32> @llvm.hexagon.V6.vshufoh(<16 x i32> %a_hi, <16 x i32> %a_lo)
+  %b_32 = bitcast <32 x i16> %b to <16 x i32>
+  %ab_e = call <32 x i32> @llvm.hexagon.V6.vmpyuhv(<16 x i32> %a_e, <16 x i32> %b_32)
+  %ab_o = call <32 x i32> @llvm.hexagon.V6.vmpyuhv(<16 x i32> %a_o, <16 x i32> %b_32)
+  %ab_o_lo = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %ab_o)
+  %ab_o_shifted_lo = call <16 x i32> @llvm.hexagon.V6.vaslw(<16 x i32> %ab_o_lo, i32 16)
+  %ab_o_hi = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %ab_o)
+  %ab_o_shifted_hi = call <16 x i32> @llvm.hexagon.V6.vaslw(<16 x i32> %ab_o_hi, i32 16)
+  %ab_o_shifted = call <32 x i32> @llvm.hexagon.V6.vcombine(<16 x i32> %ab_o_shifted_hi, <16 x i32> %ab_o_shifted_lo)
+  %ab = call <32 x i32> @llvm.hexagon.V6.vaddw.dv(<32 x i32> %ab_e, <32 x i32> %ab_o_shifted)
   ret <32 x i32> %ab
 }
 

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1616,6 +1616,9 @@ void check_hvx_all() {
     check("vmpy(v*.uh,v*.uh)", hvx_width/2, u32(u16_1) * u32(u16_2));
     check("vmpy(v*.h,v*.h)", hvx_width/2, i32(i16_1) * i32(i16_2));
     check("vmpyi(v*.h,v*.h)", hvx_width/2, i16_1 * i16_2);
+    check("vmpyio(v*.w,v*.h)", hvx_width/2, i32_1 * i32(i16_1));
+    check("vmpyie(v*.w,v*.uh)", hvx_width/2, i32_1 * i32(u16_1));
+    check("vmpy(v*.uh,v*.uh)", hvx_width/2, u32_1 * u32(u16_1));
     check("vmpyieo(v*.h,v*.h)", hvx_width/4, i32_1 * i32_2);
     // The inconsistency in the expected instructions here is
     // correct. For bytes, the unsigned value is first, for half
@@ -1639,8 +1642,6 @@ void check_hvx_all() {
     check("vmpyi(v*.h,r*.b)", hvx_width/2, 127 * i16_1);
     check("vmpyi(v*.w,r*.h)", hvx_width/4, i32_1 * 32767);
     check("vmpyi(v*.w,r*.h)", hvx_width/4, 32767 * i32_1);
-    check("vmpyi(v*.w,r*.b)", hvx_width/4, i32_1 * 127);
-    check("vmpyi(v*.w,r*.b)", hvx_width/4, 127 * i32_1);
 
     check("v*.h += vmpyi(v*.h,v*.h)", hvx_width/2, i16_1 + i16_2*i16_3);
 


### PR DESCRIPTION
This PR implements u32 x u16 -> u32 multiplication. It also required moving some of the logic for generating multiplications to OptimizePatterns (from CodeGen_Hexagon). 

@pranavb-ca @ronlieb @dpalermo please take a look. In particular:

- Please check my implementation of mul.vuw.vuh, maybe it could be faster. I just used two u16 x u16 -> u32 widening multiplies, shifted the higher order bits up by 16, and added the two. vw.vh has an instruction for 32 x 16 bit multiplies that works here, I didn't see something similar for vuw.vuh...

- I removed our ability to generate 32 x 8, vector x scalar multiplication, 32 x 16 will get used instead. Is 32 x 16 slower? I think it might actually be a bit faster, if the scalar isn't compile time constant, since it needs to be broadcasted to 32 bits with 1 step (16 bit) instead of 2 (8 bit).