### PR TITLE
Halide trace viz fix

### DIFF
--- a/apps/HalideTraceViz/mac/HalideTraceViz.xcodeproj/project.pbxproj
+++ b/apps/HalideTraceViz/mac/HalideTraceViz.xcodeproj/project.pbxproj
@@ -1,0 +1,431 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2DCA31D51D08A1F000EE38F4 /* README.md in Sources */ = {isa = PBXBuildFile; fileRef = 2DCA31D41D08A1F000EE38F4 /* README.md */; };
+		2DCA31D81D08A20C00EE38F4 /* HalideTraceViz.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2DCA31D71D08A20C00EE38F4 /* HalideTraceViz.cpp */; };
+		2DCA31E01D08A21E00EE38F4 /* MakePipeline.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2DCA31DF1D08A21E00EE38F4 /* MakePipeline.cpp */; };
+		2DCA31EB1D08A22700EE38F4 /* RunPipeline.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2DCA31EA1D08A22700EE38F4 /* RunPipeline.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		2DCA31C81D08A18200EE38F4 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		2DCA31DB1D08A21E00EE38F4 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		2DCA31E61D08A22700EE38F4 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		2DCA31CA1D08A18200EE38F4 /* HalideTraceViz */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = HalideTraceViz; sourceTree = BUILT_PRODUCTS_DIR; };
+		2DCA31D41D08A1F000EE38F4 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		2DCA31D71D08A20C00EE38F4 /* HalideTraceViz.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = HalideTraceViz.cpp; path = ../../../util/HalideTraceViz.cpp; sourceTree = "<group>"; };
+		2DCA31DD1D08A21E00EE38F4 /* MakePipeline */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = MakePipeline; sourceTree = BUILT_PRODUCTS_DIR; };
+		2DCA31DF1D08A21E00EE38F4 /* MakePipeline.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MakePipeline.cpp; sourceTree = "<group>"; };
+		2DCA31E81D08A22700EE38F4 /* RunPipeline */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = RunPipeline; sourceTree = BUILT_PRODUCTS_DIR; };
+		2DCA31EA1D08A22700EE38F4 /* RunPipeline.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RunPipeline.cpp; sourceTree = "<group>"; };
+		2DCA31F01D08A30700EE38F4 /* VisualizeRunPipeline.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; name = VisualizeRunPipeline.sh; path = Scripts/VisualizeRunPipeline.sh; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		2DCA31C71D08A18200EE38F4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2DCA31DA1D08A21E00EE38F4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2DCA31E51D08A22700EE38F4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		2DCA31C11D08A18200EE38F4 = {
+			isa = PBXGroup;
+			children = (
+				2DCA31D41D08A1F000EE38F4 /* README.md */,
+				2DCA31D61D08A1F600EE38F4 /* HalideTraceViz */,
+				2DCA31DE1D08A21E00EE38F4 /* MakePipeline */,
+				2DCA31E91D08A22700EE38F4 /* RunPipeline */,
+				2DCA31EF1D08A2EE00EE38F4 /* Scripts */,
+				2DCA31CB1D08A18200EE38F4 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		2DCA31CB1D08A18200EE38F4 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				2DCA31CA1D08A18200EE38F4 /* HalideTraceViz */,
+				2DCA31DD1D08A21E00EE38F4 /* MakePipeline */,
+				2DCA31E81D08A22700EE38F4 /* RunPipeline */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		2DCA31D61D08A1F600EE38F4 /* HalideTraceViz */ = {
+			isa = PBXGroup;
+			children = (
+				2DCA31D71D08A20C00EE38F4 /* HalideTraceViz.cpp */,
+			);
+			name = HalideTraceViz;
+			sourceTree = "<group>";
+		};
+		2DCA31DE1D08A21E00EE38F4 /* MakePipeline */ = {
+			isa = PBXGroup;
+			children = (
+				2DCA31DF1D08A21E00EE38F4 /* MakePipeline.cpp */,
+			);
+			path = MakePipeline;
+			sourceTree = "<group>";
+		};
+		2DCA31E91D08A22700EE38F4 /* RunPipeline */ = {
+			isa = PBXGroup;
+			children = (
+				2DCA31EA1D08A22700EE38F4 /* RunPipeline.cpp */,
+			);
+			path = RunPipeline;
+			sourceTree = "<group>";
+		};
+		2DCA31EF1D08A2EE00EE38F4 /* Scripts */ = {
+			isa = PBXGroup;
+			children = (
+				2DCA31F01D08A30700EE38F4 /* VisualizeRunPipeline.sh */,
+			);
+			name = Scripts;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		2DCA31C91D08A18200EE38F4 /* HalideTraceViz */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2DCA31D11D08A18200EE38F4 /* Build configuration list for PBXNativeTarget "HalideTraceViz" */;
+			buildPhases = (
+				2DCA31C61D08A18200EE38F4 /* Sources */,
+				2DCA31C71D08A18200EE38F4 /* Frameworks */,
+				2DCA31C81D08A18200EE38F4 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HalideTraceViz;
+			productName = HalideTraceViz;
+			productReference = 2DCA31CA1D08A18200EE38F4 /* HalideTraceViz */;
+			productType = "com.apple.product-type.tool";
+		};
+		2DCA31DC1D08A21E00EE38F4 /* MakePipeline */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2DCA31E11D08A21E00EE38F4 /* Build configuration list for PBXNativeTarget "MakePipeline" */;
+			buildPhases = (
+				2DCA31D91D08A21E00EE38F4 /* Sources */,
+				2DCA31DA1D08A21E00EE38F4 /* Frameworks */,
+				2DCA31DB1D08A21E00EE38F4 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MakePipeline;
+			productName = MakePipeline;
+			productReference = 2DCA31DD1D08A21E00EE38F4 /* MakePipeline */;
+			productType = "com.apple.product-type.tool";
+		};
+		2DCA31E71D08A22700EE38F4 /* RunPipeline */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2DCA31EC1D08A22700EE38F4 /* Build configuration list for PBXNativeTarget "RunPipeline" */;
+			buildPhases = (
+				2DCA31E41D08A22700EE38F4 /* Sources */,
+				2DCA31E51D08A22700EE38F4 /* Frameworks */,
+				2DCA31E61D08A22700EE38F4 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RunPipeline;
+			productName = RunPipeline;
+			productReference = 2DCA31E81D08A22700EE38F4 /* RunPipeline */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		2DCA31C21D08A18200EE38F4 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0730;
+				ORGANIZATIONNAME = "mPerpetuo, inc.";
+				TargetAttributes = {
+					2DCA31C91D08A18200EE38F4 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+					2DCA31DC1D08A21E00EE38F4 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+					2DCA31E71D08A22700EE38F4 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+				};
+			};
+			buildConfigurationList = 2DCA31C51D08A18200EE38F4 /* Build configuration list for PBXProject "HalideTraceViz" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 2DCA31C11D08A18200EE38F4;
+			productRefGroup = 2DCA31CB1D08A18200EE38F4 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				2DCA31C91D08A18200EE38F4 /* HalideTraceViz */,
+				2DCA31DC1D08A21E00EE38F4 /* MakePipeline */,
+				2DCA31E71D08A22700EE38F4 /* RunPipeline */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		2DCA31C61D08A18200EE38F4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2DCA31D81D08A20C00EE38F4 /* HalideTraceViz.cpp in Sources */,
+				2DCA31D51D08A1F000EE38F4 /* README.md in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2DCA31D91D08A21E00EE38F4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2DCA31E01D08A21E00EE38F4 /* MakePipeline.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2DCA31E41D08A22700EE38F4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2DCA31EB1D08A22700EE38F4 /* RunPipeline.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		2DCA31CF1D08A18200EE38F4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		2DCA31D01D08A18200EE38F4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		2DCA31D21D08A18200EE38F4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		2DCA31D31D08A18200EE38F4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		2DCA31E21D08A21E00EE38F4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = $PROJECT_DIR/components/halide/include;
+				OTHER_LDFLAGS = $PROJECT_DIR/components/halide/bin/libHalide.so;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		2DCA31E31D08A21E00EE38F4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = $PROJECT_DIR/components/halide/include;
+				OTHER_LDFLAGS = $PROJECT_DIR/components/halide/bin/libHalide.so;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		2DCA31ED1D08A22700EE38F4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = $PROJECT_DIR/build/Debug/;
+				OTHER_LDFLAGS = $PROJECT_DIR/build/Debug/brighten.o;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		2DCA31EE1D08A22700EE38F4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = $PROJECT_DIR/build/Debug/;
+				OTHER_LDFLAGS = $PROJECT_DIR/build/Debug/brighten.o;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2DCA31C51D08A18200EE38F4 /* Build configuration list for PBXProject "HalideTraceViz" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2DCA31CF1D08A18200EE38F4 /* Debug */,
+				2DCA31D01D08A18200EE38F4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2DCA31D11D08A18200EE38F4 /* Build configuration list for PBXNativeTarget "HalideTraceViz" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2DCA31D21D08A18200EE38F4 /* Debug */,
+				2DCA31D31D08A18200EE38F4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2DCA31E11D08A21E00EE38F4 /* Build configuration list for PBXNativeTarget "MakePipeline" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2DCA31E21D08A21E00EE38F4 /* Debug */,
+				2DCA31E31D08A21E00EE38F4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2DCA31EC1D08A22700EE38F4 /* Build configuration list for PBXNativeTarget "RunPipeline" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2DCA31ED1D08A22700EE38F4 /* Debug */,
+				2DCA31EE1D08A22700EE38F4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 2DCA31C21D08A18200EE38F4 /* Project object */;
+}

--- a/apps/HalideTraceViz/mac/HalideTraceViz.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/apps/HalideTraceViz/mac/HalideTraceViz.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:HalideTraceViz.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/apps/HalideTraceViz/mac/HalideTraceViz.xcodeproj/xcshareddata/xcschemes/HalideTraceViz.xcscheme
+++ b/apps/HalideTraceViz/mac/HalideTraceViz.xcodeproj/xcshareddata/xcschemes/HalideTraceViz.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2DCA31C91D08A18200EE38F4"
+               BuildableName = "HalideTraceViz"
+               BlueprintName = "HalideTraceViz"
+               ReferencedContainer = "container:HalideTraceViz.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DCA31C91D08A18200EE38F4"
+            BuildableName = "HalideTraceViz"
+            BlueprintName = "HalideTraceViz"
+            ReferencedContainer = "container:HalideTraceViz.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DCA31C91D08A18200EE38F4"
+            BuildableName = "HalideTraceViz"
+            BlueprintName = "HalideTraceViz"
+            ReferencedContainer = "container:HalideTraceViz.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DCA31C91D08A18200EE38F4"
+            BuildableName = "HalideTraceViz"
+            BlueprintName = "HalideTraceViz"
+            ReferencedContainer = "container:HalideTraceViz.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/apps/HalideTraceViz/mac/HalideTraceViz.xcodeproj/xcshareddata/xcschemes/MakePipeline.xcscheme
+++ b/apps/HalideTraceViz/mac/HalideTraceViz.xcodeproj/xcshareddata/xcschemes/MakePipeline.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2DCA31DC1D08A21E00EE38F4"
+               BuildableName = "MakePipeline"
+               BlueprintName = "MakePipeline"
+               ReferencedContainer = "container:HalideTraceViz.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DCA31DC1D08A21E00EE38F4"
+            BuildableName = "MakePipeline"
+            BlueprintName = "MakePipeline"
+            ReferencedContainer = "container:HalideTraceViz.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DCA31DC1D08A21E00EE38F4"
+            BuildableName = "MakePipeline"
+            BlueprintName = "MakePipeline"
+            ReferencedContainer = "container:HalideTraceViz.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DCA31DC1D08A21E00EE38F4"
+            BuildableName = "MakePipeline"
+            BlueprintName = "MakePipeline"
+            ReferencedContainer = "container:HalideTraceViz.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/apps/HalideTraceViz/mac/HalideTraceViz.xcodeproj/xcshareddata/xcschemes/RunPipeline.xcscheme
+++ b/apps/HalideTraceViz/mac/HalideTraceViz.xcodeproj/xcshareddata/xcschemes/RunPipeline.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2DCA31E71D08A22700EE38F4"
+               BuildableName = "RunPipeline"
+               BlueprintName = "RunPipeline"
+               ReferencedContainer = "container:HalideTraceViz.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DCA31E71D08A22700EE38F4"
+            BuildableName = "RunPipeline"
+            BlueprintName = "RunPipeline"
+            ReferencedContainer = "container:HalideTraceViz.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DCA31E71D08A22700EE38F4"
+            BuildableName = "RunPipeline"
+            BlueprintName = "RunPipeline"
+            ReferencedContainer = "container:HalideTraceViz.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DCA31E71D08A22700EE38F4"
+            BuildableName = "RunPipeline"
+            BlueprintName = "RunPipeline"
+            ReferencedContainer = "container:HalideTraceViz.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/apps/HalideTraceViz/mac/MakePipeline/MakePipeline.cpp
+++ b/apps/HalideTraceViz/mac/MakePipeline/MakePipeline.cpp
@@ -1,0 +1,32 @@
+//
+//  main.cpp
+//  MakePipeline
+//
+//  Created by Jaime Rios on 2016-06-08.
+//  Copyright © 2016 mPerpetuo, inc. All rights reserved.
+//
+//  Code inspired from Halide tutorial, at:
+//       http://halide-lang.org/tutorials/tutorial_lesson_10_aot_compilation_generate.html
+
+#include <iostream>
+#include "Halide.h"
+
+int main(int argc, const char * argv[])
+{
+    auto x      = Halide::Var{"x"};
+    auto y      = Halide::Var{"y"};
+    auto input  = Halide::ImageParam(Halide::type_of<uint8_t>(), 2, std::string{"input"});
+    auto offset = Halide::Param<uint8_t>{"offset"};
+    
+    auto brighten = Halide::Func{"output"};
+    brighten(x, y) = input(x, y) + offset;
+    
+    //brighten.compute_root();
+    brighten.vectorize(x, 16).parallel(y);
+    
+    auto args  = std::vector<Halide::Argument>{input, offset};
+    
+    brighten.compile_to_file("brighten", args);
+    
+    return 0;
+}

--- a/apps/HalideTraceViz/mac/README.md
+++ b/apps/HalideTraceViz/mac/README.md
@@ -1,0 +1,22 @@
+# HalideTraceViz
+## mPerpetuo, inc.
+Jaime Rios
+
+### What is this?
+A Xcode project illustrating the needed components to successfully render a Halide schedule to a mp4 movie.
+
+### Example usage
+There is a VisualizeRunPipeline.sh script that shows the usage of the HalideTraceViz application. Examine the script and ask Jaime any questions you may have.
+
+### Requirements
+Things you need for this to run:
+
+* AOT generator app
+* App to run the filter
+* Binaries all in the same directory
+
+### Additional dependencies
+* 7-zip, required to decompress ffmpeg distribution
+* ffmpeg binary, available at: http://evermeet.cx/ffmpeg/ffmpeg-3.0.2.7z
+
+There is a script, DownloadRequiredFiles.sh, in the Scripts directory, that will download the ffmpeg binary for you; you can use this to get the binary and place it into the correct directory.

--- a/apps/HalideTraceViz/mac/RunPipeline/RunPipeline.cpp
+++ b/apps/HalideTraceViz/mac/RunPipeline/RunPipeline.cpp
@@ -1,0 +1,59 @@
+//
+//  main.cpp
+//  RunPipeline
+//
+//  Created by Jaime Rios on 2016-06-08.
+//  Copyright © 2016 mPerpetuo, inc. All rights reserved.
+//
+//  Code inspired from Halide tutorial, at:
+//    http://halide-lang.org/tutorials/tutorial_lesson_10_aot_compilation_run.html
+
+
+#include <cassert>
+#include <iostream>
+#include <vector>
+#include "brighten.h"
+
+int main(int argc, const char * argv[])
+{
+    std::cout << "Run pipeline\n";
+    
+    const auto width  = 16 * 4;
+    const auto height = 16 * 4;
+    
+    auto input = std::vector<uint8_t>(width*height, 0);
+    
+    for (auto y = 0; y < width; y++)
+    {
+        for (auto x = 0; x < height; x++)
+        {
+            auto val = x ^ (y + 1);
+            const auto index = y * height + x;
+            input[index] = val;
+        }
+    }
+    
+    auto output = std::vector<uint8_t>(width*height, 0);
+    assert(output.size() != 0);
+    
+    auto input_buf  = buffer_t{0};
+    auto output_buf = buffer_t{0};
+    
+    input_buf.host  = input.data();
+    output_buf.host = output.data();
+    
+    input_buf.stride[0] = output_buf.stride[0] = 1;
+    
+    input_buf.stride[1] = output_buf.stride[1] = width;
+    
+    input_buf.extent[0] = output_buf.extent[0] = width;
+    input_buf.extent[1] = output_buf.extent[1] = height;
+    
+    input_buf.elem_size = output_buf.elem_size = 1;
+    
+    auto offset = 1;
+    auto error = brighten(&input_buf, offset, &output_buf);
+    (void)error;
+    
+    return 0;
+}

--- a/apps/HalideTraceViz/mac/Scripts/DownloadRequiredFiles.sh
+++ b/apps/HalideTraceViz/mac/Scripts/DownloadRequiredFiles.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# DownloadRequiredFiles.sh
+# mPerpetuo, inc.
+# Jaime Rios
+
+set -e
+set -u
+
+function DownloadFFMPEG()
+{
+    cd ..
+
+    if [[ ! -d components/ffmpeg ]]; then
+        echo "components/ffmpeg folder not found; attempting to create"
+        mkdir -pv components/ffmpeg
+    fi
+
+    cd components/ffmpeg
+
+    echo "Attempting to download ffmpeg"
+    curl -L -O http://evermeet.cx/ffmpeg/ffmpeg-3.0.2.7z
+
+    echo "Don't forget to decompress ffmpeg-3.0.2.7z prior to running Visualize script"
+
+    cd $CURRENT_PATH
+}
+
+function DownloadHalideDistro()
+{
+    cd ../components
+
+    echo "Attempting to download ffmpeg"
+    curl -L -O https://github.com/halide/Halide/releases/download/release_2016_04_27/halide-mac-64-trunk-2f11b9fce62f596e832907b82d87e8f75c53dd07.tgz
+
+    echo "Decompressing Halide distro"
+    tar -xvzf halide-mac-64-trunk-2f11b9fce62f596e832907b82d87e8f75c53dd07.tgz 
+
+    cd $CURRENT_PATH
+}
+
+echo "Starting ${0##*/}"
+
+CURRENT_PATH=$PWD
+
+DownloadFFMPEG
+DownloadHalideDistro
+
+echo "Script ${0##*/} done"

--- a/apps/HalideTraceViz/mac/Scripts/VisualizeRunPipeline.sh
+++ b/apps/HalideTraceViz/mac/Scripts/VisualizeRunPipeline.sh
@@ -106,7 +106,7 @@ function VisualizeFunctions()
 \
     -f input 0 127 -1 $BLANK $ZOOM $COST 0 26 $STRIDE0 $STRIDE1 \
     -f output 1 128 -1 $BLANK $ZOOM $COST 516 26 $STRIDE0 $STRIDE1 | \
-    ../../../components/ffmpeg/ffmpeg -r 30 -f rawvideo -pix_fmt bgra \
+    ../../../components/ffmpeg/ffmpeg -r 30 -f rawvideo -pix_fmt rgba \
     -s 1290X1024  -i - -y -pix_fmt yuv420p ../../movies/Brighten_schedule.mp4
 
     cd $CURRENT_PATH

--- a/apps/HalideTraceViz/mac/Scripts/VisualizeRunPipeline.sh
+++ b/apps/HalideTraceViz/mac/Scripts/VisualizeRunPipeline.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# VisualizeRunPipeline.sh
+# mPerpetuo, inc.
+# Jaime Rios
+
+set -e
+set -u
+set -o errexit
+
+function BuildBinaries()
+{
+    echo "${FUNCNAME[0]}"
+    cd ..
+
+    xcodebuild -project HalideTraceViz.xcodeproj -scheme HalideTraceViz \
+    CONFIGURATION_BUILD_DIR=build/Debug -configuration "Debug" clean build
+
+    xcodebuild -project HalideTraceViz.xcodeproj -scheme MakePipeline \
+    CONFIGURATION_BUILD_DIR=build/Debug -configuration "Debug" clean build
+
+    # Since libHalide.so is not compiled with @rpath enabled, we have to copy
+    # the binary local to the MakePipeline binary
+    cp -vR components/halide/bin build/Debug/
+
+    # Create .o file with HALIDE_TRACE flag turned on for RunPipeline to link
+    # against
+    cd build/Debug
+    HL_TRACE=3 ./MakePipeline
+    cd ../..
+
+    xcodebuild -project HalideTraceViz.xcodeproj -scheme RunPipeline \
+    CONFIGURATION_BUILD_DIR=build/Debug -configuration "Debug" clean build
+
+
+    cd $CURRENT_PATH
+}
+
+function CopyBinaries()
+{
+    echo "${FUNCNAME[0]}"
+
+    if [[ -d ./VisualizePipeline ]]; then
+        rm -Rv ./VisualizePipeline
+    fi
+    mkdir VisualizePipeline
+
+    cp -Rv ../build/Debug ./VisualizePipeline/Debug
+}
+
+# Function simply checks our required binary files and fails if 
+# all of them are not in place
+function CheckForRequiredBinaries()
+{
+    echo "${FUNCNAME[0]} started"
+
+    cd $CURRENT_PATH/VisualizePipeline/Debug
+    if [[ ! -f MakePipeline ]]; then
+        echo "MakePipeline not found!"
+        exit 1
+    fi
+
+    if [[ ! -f RunPipeline ]]; then
+        echo "RunPipeline not found!"
+        exit 1
+    fi
+
+    if [[ ! -f HalideTraceViz ]]; then
+        echo "HalideTraceViz not found!"
+        exit 1
+    fi
+
+    cd $CURRENT_PATH/..
+    if [[ ! -f components/ffmpeg/ffmpeg ]]; then
+        echo "ffmpeg not found!"
+        exit 1
+    fi
+
+    echo "${FUNCNAME[0]} completed successfully"
+    cd $CURRENT_PATH
+}
+
+function VisualizeFunctions()
+{
+    echo "${FUNCNAME[0]}"
+
+    local NIBLANK=0
+    local NIZOOM=8
+    local NICOST=1
+
+    local STRIDE0="1 0"
+    local STRIDE1="0 1"
+
+    if [[ ! -d movies ]]; then
+        mkdir movies
+    fi
+
+    cd $CURRENT_PATH/VisualizePipeline/Debug
+
+    HL_TRACE=3 ./MakePipeline && \
+    HL_TRACE_FILE=/dev/stdout ./RunPipeline | \
+    ./HalideTraceViz -s 1290 1024 -t 1 -d 100 \
+\
+    -l input Input 2 24 1 \
+    -l output Onput 516 24 1 \
+\
+    -f input 0 127 -1 $NIBLANK $NIZOOM $NICOST 0 26 $STRIDE0 $STRIDE1 \
+    -f output 1 128 -1 $NIBLANK $NIZOOM $NICOST 516 26 $STRIDE0 $STRIDE1 | \
+    ../../../components/ffmpeg/ffmpeg -r 30 -f rawvideo -pix_fmt bgra -s 1290X1024  -i - -y -pix_fmt yuv420p ../../movies/Brighten_schedule.mp4
+
+    cd $CURRENT_PATH
+}
+
+echo "Starting ${0##*/}"
+CURRENT_PATH=$PWD
+
+BuildBinaries
+CopyBinaries
+CheckForRequiredBinaries
+VisualizeFunctions
+
+echo "All done"

--- a/apps/HalideTraceViz/mac/Scripts/VisualizeRunPipeline.sh
+++ b/apps/HalideTraceViz/mac/Scripts/VisualizeRunPipeline.sh
@@ -84,9 +84,9 @@ function VisualizeFunctions()
 {
     echo "${FUNCNAME[0]}"
 
-    local NIBLANK=0
-    local NIZOOM=8
-    local NICOST=1
+    local BLANK=0
+    local ZOOM=8
+    local COST=1
 
     local STRIDE0="1 0"
     local STRIDE1="0 1"
@@ -104,9 +104,10 @@ function VisualizeFunctions()
     -l input Input 2 24 1 \
     -l output Onput 516 24 1 \
 \
-    -f input 0 127 -1 $NIBLANK $NIZOOM $NICOST 0 26 $STRIDE0 $STRIDE1 \
-    -f output 1 128 -1 $NIBLANK $NIZOOM $NICOST 516 26 $STRIDE0 $STRIDE1 | \
-    ../../../components/ffmpeg/ffmpeg -r 30 -f rawvideo -pix_fmt bgra -s 1290X1024  -i - -y -pix_fmt yuv420p ../../movies/Brighten_schedule.mp4
+    -f input 0 127 -1 $BLANK $ZOOM $COST 0 26 $STRIDE0 $STRIDE1 \
+    -f output 1 128 -1 $BLANK $ZOOM $COST 516 26 $STRIDE0 $STRIDE1 | \
+    ../../../components/ffmpeg/ffmpeg -r 30 -f rawvideo -pix_fmt bgra \
+    -s 1290X1024  -i - -y -pix_fmt yuv420p ../../movies/Brighten_schedule.mp4
 
     cd $CURRENT_PATH
 }

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -621,8 +621,8 @@ int run(int argc, char **argv) {
                     }
 
                     // Stores are orange, loads are blue.
-                    uint32_t color = p.event == 0 ? 0xffffdd44 : 0xff44ddff;
-
+                    const auto color = p.event == 0 ? 0xff44ddff : 0xffffdd44;
+                    
                     uint32_t image_color;
                     bool update_image = false;
 

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -621,8 +621,8 @@ int run(int argc, char **argv) {
                     }
 
                     // Stores are orange, loads are blue.
-                    const auto color = p.event == 0 ? 0xff44ddff : 0xffffdd44;
-                    
+                    uint32_t color = p.event == 0 ? 0xffffdd44 : 0xff44ddff;
+
                     uint32_t image_color;
                     bool update_image = false;
 


### PR DESCRIPTION
Fixed code related to selecting color for Load/Store event. 

Code indicates that "Stores are orange, loads are blue." on line 623 of file HalideTraceViz.cpp, and this is supported by the tutorial movies listed on halide-lang.org, e.g.: http://halide-lang.org/tutorials/tutorial_lesson_05_scheduling_1.html . 

However, when a Halide schedule is rendered to a movie file, the colors are reversed, where Blue is rendered for a Store event and Yellow is rendered for a Load event. 

Reviewing the binary output from the pipeline verifies that the events do not match up what code in HalideTraceViz.cpp expects.

A Xcode project has been created to compile a simple filter and pipeline executor so that a mp4 movie can be created to review the Halide schedule.

Supporting scripts have also been added to download required files and illustrate how to execute the pipeline to successfully render the Halide schedule to a mp4 file.