### PR TITLE
Make vectorize+GuardWithIf work

### DIFF
--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -3315,6 +3315,18 @@ private:
             } else {
                 expr = Call::make(op->type, op->name, new_args, op->call_type);
             }
+        } else if (op->is_intrinsic(Call::shuffle_vector) &&
+                   op->args.size() == 2 &&
+                   (op->args[0].as<Ramp>() ||
+                    op->args[0].as<Broadcast>())) {
+            // Extracting a single lane of a ramp or broadcast
+            if (const Ramp *r = op->args[0].as<Ramp>()) {
+                expr = mutate(r->base + op->args[1]*r->stride);
+            } else if (const Broadcast *b = op->args[0].as<Broadcast>()) {
+                expr = mutate(b->value);
+            } else {
+                internal_error << "Unreachable";
+            }
         } else if (op->is_intrinsic(Call::stringify)) {
             // Eagerly concat constant arguments to a stringify.
             bool changed = false;

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -425,23 +425,45 @@ class VectorizeLoops : public IRMutator {
                      << "Old: " << op->condition << "\n"
                      << "New: " << cond << "\n";
             if (lanes > 1) {
-                // It's an if statement on a vector of
-                // conditions. We'll have to scalarize and make
-                // multiple copies of the if statement.
-                debug(3) << "Scalarizing if then else\n";
-                stmt = scalarize(op);
+                // We have an if statement with a vector condition,
+                // which would mean control flow divergence within the
+                // SIMD lanes.
 
-                // If the condition is likely, we should generate an all-true case.
+                // First check if the condition is marked as likely.
                 const Call *c = cond.as<Call>();
                 if (c && (c->is_intrinsic(Call::likely) ||
                           c->is_intrinsic(Call::likely_if_innermost))) {
+
+                    // The meaning of the likely intrinsic is that Halide
+                    // should optimize for the case in which *every*
+                    // likely value is true. We can do that by generating
+                    // a scalar condition that checks if all lanes are
+                    // true, and marking that likely.
+
                     Expr all_true = const_true();
                     for (int i = 0; i < lanes; i++) {
                         all_true = all_true && extract_lane(c->args[0], i);
                     }
+
+                    // Wrap it in the same flavor of likely
+                    all_true = Call::make(Bool(), c->name,
+                                          {all_true}, Call::PureIntrinsic);
+
+                    // We should strip the likelies from the case
+                    // that's going to scalarize, because it's no
+                    // longer likely.
+                    Stmt without_likelies =
+                        IfThenElse::make(op->condition.as<Call>()->args[0],
+                                         op->then_case, op->else_case);
+
                     stmt =
-                        IfThenElse::make(Call::make(Bool(), c->name, {all_true}, Call::PureIntrinsic),
-                                         mutate(op->then_case), stmt);
+                        IfThenElse::make(all_true,
+                                         mutate(op->then_case),
+                                         scalarize(without_likelies));
+                } else {
+                    // It's some arbitrary vector condition. Scalarize
+                    // it.
+                    stmt = scalarize(op);
                 }
             } else {
                 // It's an if statement on a scalar, we're ok to vectorize the innards.
@@ -534,6 +556,12 @@ class VectorizeLoops : public IRMutator {
         }
 
         Stmt scalarize(Stmt s) {
+            // To consider in the future: Perhaps scalarize should
+            // generate a serial loop instead of a fully unrolled
+            // thing to save code size. When we can't respect a
+            // request to vectorize, we effectively unroll instead. Is
+            // this really better than leaving it as a serial loop?
+
             Stmt result;
             int lanes = replacement.type().lanes();
             Expr old_replacement = replacement;

--- a/test/correctness/vectorize_guard_with_if.cpp
+++ b/test/correctness/vectorize_guard_with_if.cpp
@@ -1,0 +1,56 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int num_vector_stores = 0;
+int num_scalar_stores = 0;
+int my_trace(void *user_context, const halide_trace_event *e) {
+    if (e->event == halide_trace_store) {
+        if (e->vector_width > 1) {
+            num_vector_stores++;
+        } else {
+            num_scalar_stores++;
+        }
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    Func f;
+    Var x;
+
+    f(x) = x;
+
+    const int w = 100, v = 8;
+    f.vectorize(x, v, TailStrategy::GuardWithIf);
+    const int expected_vector_stores = w/v;
+    const int expected_scalar_stores = w%v;
+
+    f.set_custom_trace(&my_trace);
+    f.trace_stores();
+
+    Image<int> result = f.realize(w);
+
+    if (num_vector_stores != expected_vector_stores) {
+        printf("There were %d vector stores instead of %d\n",
+               num_vector_stores, expected_vector_stores);
+        return -1;
+    }
+
+    if (num_scalar_stores != expected_scalar_stores) {
+        printf("There were %d scalar stores instead of %d\n",
+               num_vector_stores, w%8);
+        return -1;
+    }
+
+    for (int i = 0; i < w; i++) {
+        if (result(i) != i) {
+            printf("result(%d) == %d instead of %d\n",
+                   i, result(i), i);
+            return -1;
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Previously it scalarized entirely. Now it generates a likely all-true
case so that it doesn't have to.

Required a new simplification.