### PR TITLE
Add optional HL_HEXAGON_CLANG env var

### DIFF
--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -266,7 +266,21 @@ public:
         debug(1) << "Hexagon device code module: " << device_code << "\n";
         device_code.compile(Outputs().bitcode(tmp_bitcode.pathname()));
 
-        string hex_command = "${HL_HEXAGON_TOOLS}/bin/hexagon-clang ";
+        string hex_command;
+
+        const char *path = getenv("HL_HEXAGON_CLANG");
+        if (path && path[0]) {
+            hex_command = path;
+        } else {
+            path = getenv("HL_HEXAGON_TOOLS");
+            if (path && path[0]) {
+                hex_command = string(path) + "/bin/hexagon-clang";
+            } else {
+                internal_error << "Unable to find hexagon-clang";
+            }
+        }
+
+        hex_command += " ";
         hex_command += tmp_bitcode.pathname();
         hex_command += " -fPIC -O3 -Wno-override-module -shared ";
         if (device_code.target().has_feature(Target::HVX_v62)) {

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -276,7 +276,7 @@ public:
             if (path && path[0]) {
                 hex_command = string(path) + "/bin/hexagon-clang";
             } else {
-                internal_error << "Unable to find hexagon-clang";
+                user_error << "Unable to find hexagon-clang: neither HL_HEXAGON_CLANG nor HL_HEXAGON_TOOLS are set properly.";
             }
         }
 


### PR DESCRIPTION
If defined, use this to find the hexagon-clang tool. If not, fall back
to HL_HEXAGON_TOOLS/bin/hexagon-clang.