### PR TITLE
Python: Added boundary condition functions accepting bounds parameters

### DIFF
--- a/python_bindings/python/BoundaryConditions.cpp
+++ b/python_bindings/python/BoundaryConditions.cpp
@@ -2,6 +2,7 @@
 
 // to avoid compiler confusion, python.hpp must be include before Halide headers
 #include <boost/python.hpp>
+#include <boost/python/stl_iterator.hpp>
 
 #include "../../src/Lambda.h" // needed by BoundaryConditions.h
 #include "../../src/ImageParam.h"
@@ -9,10 +10,30 @@
 #include "../../src/Func.h"
 
 #include <string>
+#include <vector>
+#include <algorithm>
 
 namespace h = Halide;
 namespace hb = Halide::BoundaryConditions;
 namespace p = boost::python;
+
+template<typename T, typename S> inline std::pair<T, S> to_pair(const p::object& iterable)
+{
+    return std::pair<T, S>(p::extract<T>(iterable[0]), p::extract<T>(iterable[1]));
+}
+
+template<typename T> inline std::vector<T> to_vector(const p::object& iterable)
+{
+    return std::vector<T>(p::stl_input_iterator<T>(iterable), p::stl_input_iterator<T>());
+}
+
+std::vector<std::pair<h::Expr, h::Expr>> inline pyobject_to_bounds(const p::object& pybounds)
+{
+    std::vector<p::object> intermediate = to_vector<p::object>(pybounds);
+    std::vector<std::pair<h::Expr, h::Expr>> result(intermediate.size());
+    std::transform(intermediate.begin(), intermediate.end(), result.begin(), to_pair<h::Expr, h::Expr>);
+    return result;
+}
 
 namespace {
 
@@ -20,6 +41,11 @@ template<typename T>
 h::Func constant_exterior0(T func_like, h::Expr value)
 {
     return hb::constant_exterior(func_like, value);
+}
+
+h::Func constant_exterior_bounds(h::Func func, h::Expr value, p::object bounds_)
+{
+    return hb::constant_exterior(func, value, pyobject_to_bounds(bounds_));
 }
 
 // C++ fun, variadic template recursive function !
@@ -48,6 +74,11 @@ h::Func repeat_edge0(T func_like)
     return hb::repeat_edge(func_like);
 }
 
+h::Func repeat_edge_bounds(h::Func func, p::object bounds_)
+{
+    return hb::repeat_edge(func, pyobject_to_bounds(bounds_));
+}
+
 // C++ fun, variadic template recursive function !
 template<typename T=void, typename ...Types>
 void def_repeat_edge_for_image()
@@ -71,6 +102,11 @@ template<typename T>
 h::Func repeat_image0(T func_like)
 {
     return hb::repeat_image(func_like);
+}
+
+h::Func repeat_image_bounds(h::Func func, p::object bounds_)
+{
+    return hb::repeat_image(func, pyobject_to_bounds(bounds_));
 }
 
 // C++ fun, variadic template recursive function !
@@ -99,6 +135,11 @@ h::Func mirror_image0(T func_like)
     return hb::mirror_image(func_like);
 }
 
+h::Func mirror_image_bounds(h::Func func, p::object bounds_)
+{
+    return hb::mirror_image(func, pyobject_to_bounds(bounds_));
+}
+
 // C++ fun, variadic template recursive function !
 template<typename T=void, typename ...Types>
 void def_mirror_image_for_image()
@@ -124,6 +165,11 @@ h::Func mirror_interior0(T func_like)
     return hb::mirror_interior(func_like);
 }
 
+h::Func mirror_interior_bounds(h::Func func, p::object bounds_)
+{
+    return hb::mirror_interior(func, pyobject_to_bounds(bounds_));
+}
+
 // C++ fun, variadic template recursive function !
 template<typename T=void, typename ...Types>
 void def_mirror_interior_for_image()
@@ -143,9 +189,7 @@ void def_mirror_interior_for_image<void>()
 
 void defineBoundaryConditions()
 {
-
-
-    // Other variants of constant_exterior exist, but not yet implemented
+    // constant_exterior
 
     p::def("constant_exterior", &constant_exterior0<h::ImageParam>, p::args("source", "value"),
            "Impose a boundary condition such that a given expression is returned "
@@ -163,10 +207,10 @@ void defineBoundaryConditions()
             boost::int8_t, boost::int16_t, boost::int32_t,
             float, double >();
 
-    // The following variant is not yet implemented
-    //    EXPORT Func constant_exterior(const Func &source, Expr value,
-    //                                  const std::vector<std::pair<Expr, Expr>> &bounds);
+    p::def("constant_exterior", &constant_exterior_bounds, p::args("source", "value", "bounds"));
 
+
+    // repeat_edge
 
     p::def("repeat_edge", &repeat_edge0<h::ImageParam>, p::args("source"),
            "Impose a boundary condition such that the nearest edge sample is returned "
@@ -181,11 +225,10 @@ void defineBoundaryConditions()
             boost::int8_t, boost::int16_t, boost::int32_t,
             float, double >();
 
-    // The following variant is not yet implemented
-    //    EXPORT Func repeat_edge(const Func &source,
-    //                            const std::vector<std::pair<Expr, Expr>> &bounds);
+    p::def("repeat_edge", &repeat_edge_bounds, p::args("source", "bounds"));
 
 
+    // repeat_image
 
     p::def("repeat_image", &repeat_image0<h::ImageParam>, p::args("source"),
            "Impose a boundary condition such that the entire coordinate space is "
@@ -200,10 +243,10 @@ void defineBoundaryConditions()
             boost::int8_t, boost::int16_t, boost::int32_t,
             float, double >();
 
-    //The following variant is not yet implemented
-    //        EXPORT Func repeat_image(const Func &source,
-    //                                 const std::vector<std::pair<Expr, Expr>> &bounds);
+    p::def("repeat_image", &repeat_image_bounds, p::args("source", "bounds"));
 
+
+    // mirror_image
 
     p::def("mirror_image", &mirror_image0<h::ImageParam>, p::args("source"),
            "Impose a boundary condition such that the entire coordinate space is "
@@ -219,10 +262,10 @@ void defineBoundaryConditions()
             boost::int8_t, boost::int16_t, boost::int32_t,
             float, double >();
 
-    // The following variant is not yet implemented
-    //        EXPORT Func mirror_image(const Func &source,
-    //                                 const std::vector<std::pair<Expr, Expr>> &bounds);
+    p::def("mirror_image", &mirror_image_bounds, p::args("source", "bounds"));
 
+
+    // mirror_interior
 
     p::def("mirror_interior", &mirror_interior0<h::ImageParam>, p::args("source"),
            "Impose a boundary condition such that the entire coordinate space is "
@@ -239,9 +282,7 @@ void defineBoundaryConditions()
             boost::int8_t, boost::int16_t, boost::int32_t,
             float, double >();
 
-    // The following variant is not yet implemented
-    //    EXPORT Func mirror_interior(const Func &source,
-    //                                const std::vector<std::pair<Expr, Expr>> &bounds);
+    p::def("mirror_interior", &mirror_interior_bounds, p::args("source", "bounds"));
 
     return;
 }


### PR DESCRIPTION
Hello,
as I was porting a little project from C++ to the new Python binding, I stumbled upon the problem that the boundary condition functions did not accept `Func` and bounds parameters. (And this was marked as not-yet-implemented in the source: [`BoundaryConditions.cpp:166`](https://github.com/halide/Halide/blob/d9f2d8f62173f00bde47f9971d543e26f6bdce44/python_bindings/python/BoundaryConditions.cpp#L166))
I've added the missing functions; while I have not extensively tested it, some quick tests have proven it working for me.

Best regards, Christian Sachs