### PR TITLE
Fix min/max handling for llvm trunk

### DIFF
--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -133,7 +133,7 @@ void CodeGen_X86::visit(const Sub *op) {
 void CodeGen_X86::visit(const GT *op) {
     Type t = op->a.type();
     int bits = t.lanes() * t.bits();
-    if (t.lanes() == 1) {
+    if (t.is_scalar()) {
         // LLVM is fine for scalars
         CodeGen_Posix::visit(op);
     } else {
@@ -169,7 +169,7 @@ void CodeGen_X86::visit(const GT *op) {
 void CodeGen_X86::visit(const EQ *op) {
     Type t = op->a.type();
     int bits = t.lanes() * t.bits();
-    if (t.lanes() == 1) {
+    if (t.is_scalar()) {
         // LLVM is fine for scalars
         CodeGen_Posix::visit(op);
     } else {

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -133,8 +133,8 @@ void CodeGen_X86::visit(const Sub *op) {
 void CodeGen_X86::visit(const GT *op) {
     Type t = op->a.type();
     int bits = t.lanes() * t.bits();
-    if (t.lanes() == 1 || bits % 128 == 0) {
-        // LLVM is fine for native vector widths or scalars
+    if (t.lanes() == 1) {
+        // LLVM is fine for scalars
         CodeGen_Posix::visit(op);
     } else {
         // Non-native vector widths get legalized poorly by llvm. We
@@ -169,8 +169,8 @@ void CodeGen_X86::visit(const GT *op) {
 void CodeGen_X86::visit(const EQ *op) {
     Type t = op->a.type();
     int bits = t.lanes() * t.bits();
-    if (t.lanes() == 1 || bits % 128 == 0) {
-        // LLVM is fine for native vector widths or scalars
+    if (t.lanes() == 1) {
+        // LLVM is fine for scalars
         CodeGen_Posix::visit(op);
     } else {
         // Non-native vector widths get legalized poorly by llvm. We
@@ -218,50 +218,33 @@ void CodeGen_X86::visit(const NE *op) {
 
 void CodeGen_X86::visit(const Select *op) {
 
-    // LLVM doesn't correctly use pblendvb for u8 vectors that aren't
-    // width 16, so we peephole optimize them to intrinsics.
-    struct Pattern {
-        string intrin;
-        Expr pattern;
-    };
-
-    static Pattern patterns[] = {
-        {"pblendvb_ult_i8x16", select(wild_u8x_ < wild_u8x_, wild_i8x_, wild_i8x_)},
-        {"pblendvb_ult_i8x16", select(wild_u8x_ < wild_u8x_, wild_u8x_, wild_u8x_)},
-        {"pblendvb_slt_i8x16", select(wild_i8x_ < wild_i8x_, wild_i8x_, wild_i8x_)},
-        {"pblendvb_slt_i8x16", select(wild_i8x_ < wild_i8x_, wild_u8x_, wild_u8x_)},
-        {"pblendvb_ule_i8x16", select(wild_u8x_ <= wild_u8x_, wild_i8x_, wild_i8x_)},
-        {"pblendvb_ule_i8x16", select(wild_u8x_ <= wild_u8x_, wild_u8x_, wild_u8x_)},
-        {"pblendvb_sle_i8x16", select(wild_i8x_ <= wild_i8x_, wild_i8x_, wild_i8x_)},
-        {"pblendvb_sle_i8x16", select(wild_i8x_ <= wild_i8x_, wild_u8x_, wild_u8x_)},
-        {"pblendvb_ne_i8x16", select(wild_u8x_ != wild_u8x_, wild_i8x_, wild_i8x_)},
-        {"pblendvb_ne_i8x16", select(wild_u8x_ != wild_u8x_, wild_u8x_, wild_u8x_)},
-        {"pblendvb_ne_i8x16", select(wild_i8x_ != wild_i8x_, wild_i8x_, wild_i8x_)},
-        {"pblendvb_ne_i8x16", select(wild_i8x_ != wild_i8x_, wild_i8x_, wild_i8x_)},
-        {"pblendvb_eq_i8x16", select(wild_u8x_ == wild_u8x_, wild_i8x_, wild_i8x_)},
-        {"pblendvb_eq_i8x16", select(wild_u8x_ == wild_u8x_, wild_u8x_, wild_u8x_)},
-        {"pblendvb_eq_i8x16", select(wild_i8x_ == wild_i8x_, wild_i8x_, wild_i8x_)},
-        {"pblendvb_eq_i8x16", select(wild_i8x_ == wild_i8x_, wild_i8x_, wild_i8x_)},
-        {"pblendvb_i8x16", select(wild_u1x_, wild_i8x_, wild_i8x_)},
-        {"pblendvb_i8x16", select(wild_u1x_, wild_u8x_, wild_u8x_)}
-    };
-
-    if (target.has_feature(Target::SSE41) &&
-        op->condition.type().is_vector() &&
-        op->type.bits() == 8 &&
-        op->type.lanes() != 16) {
-
-        vector<Expr> matches;
-        for (size_t i = 0; i < sizeof(patterns)/sizeof(patterns[0]); i++) {
-            if (expr_match(patterns[i].pattern, op, matches)) {
-                value = call_intrin(op->type, 16, patterns[i].intrin, matches);
-                return;
-            }
+    // LLVM handles selects on vector conditions much better at native width
+    if (op->condition.type().is_vector()) {
+        Value *cond = codegen(op->condition);
+        Value *true_val = codegen(op->true_value);
+        Value *false_val = codegen(op->false_value);
+        Type t = op->true_value.type();
+        int slice_size = 128 / t.bits();
+        if (t.bits() * t.lanes() > 128 &&
+            ((t.is_float() && target.has_feature(Target::AVX)) ||
+             target.has_feature(Target::AVX2))) {
+            slice_size *= 2;
         }
+
+        vector<Value *> result;
+        for (int i = 0; i < t.lanes(); i += slice_size) {
+            Value *st = slice_vector(true_val, i, slice_size);
+            Value *sf = slice_vector(false_val, i, slice_size);
+            Value *sc = slice_vector(cond, i, slice_size);
+            Value *slice_value = builder->CreateSelect(sc, st, sf);
+            result.push_back(slice_value);
+        }
+
+        value = concat_vectors(result);
+        value = slice_vector(value, 0, t.lanes());
+    } else {
+        CodeGen_Posix::visit(op);
     }
-
-    CodeGen_Posix::visit(op);
-
 }
 
 void CodeGen_X86::visit(const Cast *op) {
@@ -383,7 +366,7 @@ Expr CodeGen_X86::mulhi_shr(Expr a, Expr b, int shr) {
 }
 
 void CodeGen_X86::visit(const Min *op) {
-    if (!op->type.is_vector()) {
+    if (LLVM_VERSION >= 39 || op->type.is_scalar()) {
         CodeGen_Posix::visit(op);
         return;
     }
@@ -401,28 +384,13 @@ void CodeGen_X86::visit(const Min *op) {
         value = call_intrin(op->type, 4, "llvm.x86.sse41.pminsd", {op->a, op->b});
     } else if (use_sse_41 && op->type.element_of() == UInt(32)) {
         value = call_intrin(op->type, 4, "llvm.x86.sse41.pminud", {op->a, op->b});
-    } else if (op->type.element_of() == Float(32)) {
-        if (op->type.lanes() % 8 == 0 && target.has_feature(Target::AVX)) {
-            // This condition should possibly be > 4, rather than a
-            // multiple of 8, but shuffling in undefs seems to work
-            // poorly with avx.
-            value = call_intrin(op->type, 8, "min_f32x8", {op->a, op->b});
-        } else {
-            value = call_intrin(op->type, 4, "min_f32x4", {op->a, op->b});
-        }
-    } else if (op->type.element_of() == Float(64)) {
-         if (op->type.lanes() % 4 == 0 && target.has_feature(Target::AVX)) {
-            value = call_intrin(op->type, 4, "min_f64x4", {op->a, op->b});
-        } else {
-            value = call_intrin(op->type, 2, "min_f64x2", {op->a, op->b});
-        }
     } else {
         CodeGen_Posix::visit(op);
     }
 }
 
 void CodeGen_X86::visit(const Max *op) {
-    if (!op->type.is_vector()) {
+    if (LLVM_VERSION >= 39 || op->type.is_scalar()) {
         CodeGen_Posix::visit(op);
         return;
     }
@@ -440,18 +408,6 @@ void CodeGen_X86::visit(const Max *op) {
         value = call_intrin(op->type, 4, "llvm.x86.sse41.pmaxsd", {op->a, op->b});
     } else if (use_sse_41 && op->type.element_of() == UInt(32)) {
         value = call_intrin(op->type, 4, "llvm.x86.sse41.pmaxud", {op->a, op->b});
-    } else if (op->type.element_of() == Float(32)) {
-        if (op->type.lanes() % 8 == 0 && target.has_feature(Target::AVX)) {
-            value = call_intrin(op->type, 8, "max_f32x8", {op->a, op->b});
-        } else {
-            value = call_intrin(op->type, 4, "max_f32x4", {op->a, op->b});
-        }
-    } else if (op->type.element_of() == Float(64)) {
-      if (op->type.lanes() % 4 == 0 && target.has_feature(Target::AVX)) {
-            value = call_intrin(op->type, 4, "max_f64x4", {op->a, op->b});
-        } else {
-            value = call_intrin(op->type, 2, "max_f64x2", {op->a, op->b});
-        }
     } else {
         CodeGen_Posix::visit(op);
     }

--- a/src/runtime/x86_avx.ll
+++ b/src/runtime/x86_avx.ll
@@ -83,27 +83,3 @@ define weak_odr <8 x float> @fast_inverse_sqrt_f32x8(<8 x float> %x) nounwind uw
   %approx = tail call <8 x float> @llvm.x86.avx.rsqrt.ps.256(<8 x float> %x);
   ret <8 x float> %approx
 }
-
-define weak_odr <8 x float> @min_f32x8(<8 x float> %a, <8 x float> %b) nounwind uwtable readnone alwaysinline {
-  %c = fcmp olt <8 x float> %a, %b
-  %result = select <8 x i1> %c, <8 x float> %a, <8 x float> %b
-  ret <8 x float> %result
-}
-
-define weak_odr <8 x float> @max_f32x8(<8 x float> %a, <8 x float> %b) nounwind uwtable readnone alwaysinline {
-  %c = fcmp olt <8 x float> %a, %b
-  %result = select <8 x i1> %c, <8 x float> %b, <8 x float> %a
-  ret <8 x float> %result
-}
-
-define weak_odr <4 x double> @min_f64x4(<4 x double> %a, <4 x double> %b) nounwind uwtable readnone alwaysinline {
-  %c = fcmp olt <4 x double> %a, %b
-  %result = select <4 x i1> %c, <4 x double> %a, <4 x double> %b
-  ret <4 x double> %result
-}
-
-define weak_odr <4 x double> @max_f64x4(<4 x double> %a, <4 x double> %b) nounwind uwtable readnone alwaysinline {
-  %c = fcmp olt <4 x double> %a, %b
-  %result = select <4 x i1> %c, <4 x double> %b, <4 x double> %a
-  ret <4 x double> %result
-}

--- a/src/runtime/x86_sse41.ll
+++ b/src/runtime/x86_sse41.ll
@@ -7,47 +7,6 @@ define weak_odr <8 x i16>  @packusdwx8(<8 x i32> %arg) nounwind alwaysinline {
   ret <8 x i16> %3
 }
 
-define weak_odr <16 x i8> @pblendvb_i8x16(<16 x i1> %c, <16 x i8> %t, <16 x i8> %f) nounwind alwaysinline {
-  %1 = select <16 x i1> %c, <16 x i8> %t, <16 x i8> %f
-  ret <16 x i8> %1
-}
-
-define weak_odr <16 x i8> @pblendvb_eq_i8x16(<16 x i8> %a, <16 x i8> %b, <16 x i8> %t, <16 x i8> %f) nounwind alwaysinline {
-  %1 = icmp eq <16 x i8> %a, %b
-  %2 = select <16 x i1> %1, <16 x i8> %t, <16 x i8> %f
-  ret <16 x i8> %2
-}
-
-define weak_odr <16 x i8> @pblendvb_ne_i8x16(<16 x i8> %a, <16 x i8> %b, <16 x i8> %t, <16 x i8> %f) nounwind alwaysinline {
-  %1 = icmp ne <16 x i8> %a, %b
-  %2 = select <16 x i1> %1, <16 x i8> %t, <16 x i8> %f
-  ret <16 x i8> %2
-}
-
-define weak_odr <16 x i8> @pblendvb_ult_i8x16(<16 x i8> %a, <16 x i8> %b, <16 x i8> %t, <16 x i8> %f) nounwind alwaysinline {
-  %1 = icmp ult <16 x i8> %a, %b
-  %2 = select <16 x i1> %1, <16 x i8> %t, <16 x i8> %f
-  ret <16 x i8> %2
-}
-
-define weak_odr <16 x i8> @pblendvb_slt_i8x16(<16 x i8> %a, <16 x i8> %b, <16 x i8> %t, <16 x i8> %f) nounwind alwaysinline {
-  %1 = icmp slt <16 x i8> %a, %b
-  %2 = select <16 x i1> %1, <16 x i8> %t, <16 x i8> %f
-  ret <16 x i8> %2
-}
-
-define weak_odr <16 x i8> @pblendvb_ule_i8x16(<16 x i8> %a, <16 x i8> %b, <16 x i8> %t, <16 x i8> %f) nounwind alwaysinline {
-  %1 = icmp ule <16 x i8> %a, %b
-  %2 = select <16 x i1> %1, <16 x i8> %t, <16 x i8> %f
-  ret <16 x i8> %2
-}
-
-define weak_odr <16 x i8> @pblendvb_sle_i8x16(<16 x i8> %a, <16 x i8> %b, <16 x i8> %t, <16 x i8> %f) nounwind alwaysinline {
-  %1 = icmp sle <16 x i8> %a, %b
-  %2 = select <16 x i1> %1, <16 x i8> %t, <16 x i8> %f
-  ret <16 x i8> %2
-}
-
 define weak_odr <4 x float> @floor_f32x4(<4 x float> %x) nounwind uwtable readnone optsize inlinehint alwaysinline {
   %1 = tail call <4 x float> @llvm.x86.sse41.round.ps(<4 x float> %x, i32 1)
   ret <4 x float> %1


### PR DESCRIPTION
This hopefully fixes the tests for trunk llvm (some intrinsics were removed).

It turned out to be simplest to consolidate a bunch of code into select handling logic.