### PR TITLE
Use likely_if_innermost for sliding window warmup branch

### DIFF
--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -226,11 +226,11 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
 
             Expr new_min, new_max;
             if (can_slide_up) {
-                new_min = select(loop_var_expr <= loop_min, min_required, likely(prev_max_plus_one));
+                new_min = select(loop_var_expr <= loop_min, min_required, likely_if_innermost(prev_max_plus_one));
                 new_max = max_required;
             } else {
                 new_min = min_required;
-                new_max = select(loop_var_expr <= loop_min, max_required, likely(prev_min_minus_one));
+                new_max = select(loop_var_expr <= loop_min, max_required, likely_if_innermost(prev_min_minus_one));
             }
 
             Expr early_stages_min_required = new_min;


### PR DESCRIPTION
This is a change @abadams suggested a while back, I'm now finding it necessary. This reduces the amount of code generated by Halide quite significantly (and improves compile times) while not significantly impacting performance.