### PR TITLE
Set LSR complexity limit back to the LLVM default

### DIFF
--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -300,7 +300,7 @@ public:
 
         hex_command += " ";
         hex_command += tmp_bitcode.pathname();
-        hex_command += " -fPIC -O3 -Wno-override-module -shared ";
+        hex_command += " -fPIC -O3 -mllvm -lsr-complexity-limit=65535 -Wno-override-module -shared ";
         if (device_code.target().has_feature(Target::HVX_v62)) {
             hex_command += " -mv62";
         }


### PR DESCRIPTION
Reduces compile time of app of interest from 4.5 minutes to
less than 10 seconds.

Note:
  - The llvm default for LSR complexity is UINT16_MAX
  - When compiling for Hexagon, this is changed to UINT16_MAX*10
  - The exact setting of this limit could be increased if
    performance is not sufficient with the llvm default setting