### PR TITLE
Set LSR complexity limit on hexagon-clang command line

### DIFF
--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -300,7 +300,7 @@ public:
 
         hex_command += " ";
         hex_command += tmp_bitcode.pathname();
-        hex_command += " -fPIC -O3 -mllvm -lsr-complexity-limit=65535 -Wno-override-module -shared ";
+        hex_command += " -fPIC -O3 -mllvm -lsr-complexity-limit=655350 -Wno-override-module -shared ";
         if (device_code.target().has_feature(Target::HVX_v62)) {
             hex_command += " -mv62";
         }


### PR DESCRIPTION
There is something strange going on here as I've also just noticed that I can set the limit to UINT16_MAX*10 and the test still compiles in less than 10seconds:

[dpalermo-ubuntu /local/scratch/dpalermo/tot-work/halide-new/bugs] time /prj/dsp/qdsp6/release/internal/branch-8.1/linux64/latest/Tools/bin/hexagon-clang hex2.bc -O1 -fPIC -Wno-override-module -shared -o hex2.o -mhvx-double -mllvm -time-passes -mllvm -lsr-complexity-limit=655350
...
8.964u 0.212s 0:09.24 99.2%     0+0k 0+288io 2pf+0w

So I'm updating the pull request to use the desired value and will continue to debug what is going on when the value is not specified on the command line.