### PR TITLE
Add a bottleneck for loading libhalide_hexagon_host.so

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -164,6 +164,7 @@ bool function_takes_user_context(const std::string &name) {
         "halide_hexagon_initialize_kernels",
         "halide_hexagon_run",
         "halide_hexagon_device_release",
+        "halide_hexagon_load_host_lib",
         "halide_qurt_hvx_lock",
         "halide_qurt_hvx_unlock",
         "halide_qurt_hvx_unlock_as_destructor",

--- a/src/runtime/HalideRuntimeHexagonHost.h
+++ b/src/runtime/HalideRuntimeHexagonHost.h
@@ -53,6 +53,13 @@ extern int halide_hexagon_run(void *user_context,
                               void *args[],
                               int arg_flags[]);
 extern int halide_hexagon_device_release(void* user_context);
+
+/**
+ * This is essentially a wrapper for halide_load_library("libhalide_hexagon_host.so");
+ * it exists to allow clients to override the search path without having to doctor
+ * environment variables (e.g. LD_LIBRARY_PATH).
+ */
+extern void *halide_hexagon_load_host_lib(void *user_context);
 // @}
 
 #ifdef __cplusplus

--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -66,17 +66,9 @@ WEAK int init_hexagon_runtime(void *user_context) {
     debug(user_context) << "Hexagon: init_hexagon_runtime (user_context: " << user_context << ")\n";
 
     // Load the library.
-    const char *host_lib_name = "libhalide_hexagon_host.so";
-    debug(user_context) << "    halide_load_library('" << host_lib_name << "') -> \n";
-    void *host_lib = halide_load_library(host_lib_name);
-    debug(user_context) << "        " << host_lib << "\n";
-    if (!host_lib) {
-        error(user_context) << host_lib_name << " not found.\n";
-        return -1;
-    }
+    void *host_lib = halide_hexagon_load_host_lib(user_context);
 
     // Get the symbols we need from the library.
-
     get_symbol(user_context, host_lib, "halide_hexagon_remote_initialize_kernels", remote_initialize_kernels);
     if (!remote_initialize_kernels) return -1;
     get_symbol(user_context, host_lib, "halide_hexagon_remote_get_symbol", remote_get_symbol);
@@ -625,6 +617,17 @@ WEAK size_t halide_hexagon_get_device_size(void *user_context, struct buffer_t *
 
 WEAK const halide_device_interface *halide_hexagon_device_interface() {
     return &hexagon_device_interface;
+}
+
+WEAK void *halide_hexagon_load_host_lib(void *user_context) {
+    const char *host_lib_name = "libhalide_hexagon_host.so";
+    debug(user_context) << "    halide_load_library('" << host_lib_name << "') -> \n";
+    void *host_lib = halide_load_library(host_lib_name);
+    debug(user_context) << "        " << host_lib << "\n";
+    if (!host_lib) {
+        error(user_context) << host_lib_name << " not found.\n";
+    }
+    return host_lib;
 }
 
 namespace {

--- a/src/runtime/runtime_api.cpp
+++ b/src/runtime/runtime_api.cpp
@@ -73,6 +73,7 @@ extern "C" __attribute__((used)) void *halide_runtime_api_functions[] = {
     (void *)&halide_hexagon_initialize_kernels,
     (void *)&halide_hexagon_run,
     (void *)&halide_hexagon_device_release,
+    (void *)&halide_hexagon_load_host_lib,
     (void *)&halide_qurt_hvx_lock,
     (void *)&halide_qurt_hvx_unlock,
     (void *)&halide_qurt_hvx_unlock_as_destructor,


### PR DESCRIPTION
We can override this at present by using (e.g.) LD_LIBRARY_PATHS, in
some cases anyway, but having a weak runtime method to override makes
some use cases much simpler and safer.