### PR TITLE
Fix HelloHexagon 32-bit build

### DIFF
--- a/apps/HelloHexagon/Makefile
+++ b/apps/HelloHexagon/Makefile
@@ -6,7 +6,7 @@ include ../support/Makefile.inc
 #$ build/tools/make-standalone-toolchain.sh --arch=arm --platform=android-21 --install-dir=$ANDROID_ARM_TOOLCHAIN
 CXX-host ?= $(CXX)
 CXX-arm-64-android ?= $(ANDROID_ARM64_TOOLCHAIN)/bin/aarch64-linux-android-c++
-CXX-arm-32-android ?= $(ANDROID_ARM_TOOLCHAIN)/bin/arm-linux-android-c++
+CXX-arm-32-android ?= $(ANDROID_ARM_TOOLCHAIN)/bin/arm-linux-androideabi-c++
 
 CXXFLAGS-host ?=
 CXXFLAGS-arm-64-android ?=

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -187,8 +187,6 @@ class InjectHexagonRpc : public IRMutator {
             for (const auto& i : c.vars) {
                 Expr arg = Variable::make(i.second, i.first);
                 Expr arg_ptr = Call::make(type_of<void *>(), Call::make_struct, {arg}, Call::Intrinsic);
-
-                // sizeof(scalar-type) will always fit into int32
                 arg_sizes.push_back(Expr((uint64_t) i.second.bytes()));
                 arg_ptrs.push_back(arg_ptr);
                 arg_flags.push_back(0x0);

--- a/src/runtime/HalideRuntimeHexagonHost.h
+++ b/src/runtime/HalideRuntimeHexagonHost.h
@@ -23,7 +23,7 @@ extern const struct halide_device_interface *halide_hexagon_device_interface();
  * or being passed an invalid device handle. The device and host
  * dirty bits are left unmodified. */
 extern int halide_hexagon_wrap_device_handle(void *user_context, struct buffer_t *buf,
-                                             void *ptr, size_t size);
+                                             void *ptr, uint64_t size);
 
 /** Disconnect this buffer_t from the device handle it was previously
  * wrapped around. Should only be called for a buffer_t that
@@ -37,19 +37,19 @@ extern void *halide_hexagon_detach_device_handle(void *user_context, struct buff
 /** Return the underlying device handle for a buffer_t. If there is
  * no device memory (dev field is NULL), this returns 0. */
 extern void *halide_hexagon_get_device_handle(void *user_context, struct buffer_t *buf);
-extern size_t halide_hexagon_get_device_size(void *user_context, struct buffer_t *buf);
+extern uint64_t halide_hexagon_get_device_size(void *user_context, struct buffer_t *buf);
 
 /** These are forward declared here to allow clients to override the
  *  Halide Hexagon runtime. Do not call them. */
 // @{
 extern int halide_hexagon_initialize_kernels(void *user_context,
                                              void **module_ptr,
-                                             const uint8_t *code, size_t code_size);
+                                             const uint8_t *code, uint64_t code_size);
 extern int halide_hexagon_run(void *user_context,
                               void *module_ptr,
                               const char *name,
                               halide_hexagon_handle_t *function,
-                              size_t arg_sizes[],
+                              uint64_t arg_sizes[],
                               void *args[],
                               int arg_flags[]);
 extern int halide_hexagon_device_release(void* user_context);

--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -150,7 +150,7 @@ WEAK int write_shared_object(void *user_context, const uint8_t *data, size_t siz
 }  // namespace
 
 WEAK int halide_hexagon_initialize_kernels(void *user_context, void **state_ptr,
-                                           const uint8_t *code, size_t code_size) {
+                                           const uint8_t *code, uint64_t code_size) {
     int result = init_hexagon_runtime(user_context);
     if (result != 0) return result;
 
@@ -222,11 +222,11 @@ namespace {
 // necessary. Only arguments with flags&flag_mask == flag_value are
 // added to the mapped_args array. Returns the number of arguments
 // mapped, or a negative number on error.
-WEAK int map_arguments(void *user_context, size_t arg_count,
-                       size_t arg_sizes[], void *args[], int arg_flags[], int flag_mask, int flag_value,
+WEAK int map_arguments(void *user_context, int arg_count,
+                       uint64_t arg_sizes[], void *args[], int arg_flags[], int flag_mask, int flag_value,
                        remote_buffer *mapped_args) {
     int mapped_count = 0;
-    for (size_t i = 0; i < arg_count; i++) {
+    for (int i = 0; i < arg_count; i++) {
         if ((arg_flags[i] & flag_mask) != flag_value) continue;
         remote_buffer &mapped_arg = mapped_args[mapped_count++];
         if (arg_flags[i] != 0) {
@@ -253,7 +253,7 @@ WEAK int halide_hexagon_run(void *user_context,
                             void *state_ptr,
                             const char *name,
                             halide_hexagon_handle_t* function,
-                            size_t arg_sizes[],
+                            uint64_t arg_sizes[],
                             void *args[],
                             int arg_flags[]) {
     halide_assert(user_context, state_ptr != NULL);
@@ -571,7 +571,7 @@ WEAK int halide_hexagon_device_sync(void *user_context, struct buffer_t *) {
 }
 
 WEAK int halide_hexagon_wrap_device_handle(void *user_context, struct buffer_t *buf,
-                                           void *ion_buf, size_t size) {
+                                           void *ion_buf, uint64_t size) {
     halide_assert(user_context, buf->dev == 0);
     if (buf->dev != 0) {
         return -2;
@@ -614,7 +614,7 @@ WEAK void *halide_hexagon_get_device_handle(void *user_context, struct buffer_t 
     return handle->buffer;
 }
 
-WEAK size_t halide_hexagon_get_device_size(void *user_context, struct buffer_t *buf) {
+WEAK uint64_t halide_hexagon_get_device_size(void *user_context, struct buffer_t *buf) {
     if (buf->dev == NULL) {
         return 0;
     }


### PR DESCRIPTION
Running make didn't work. Mostly because HexagonOffload.cpp makes uint64
expressions, but the runtime expects size_ts.