### PR TITLE
fixed bugs in PartitionLoops epilogue runs before start of the loop

### DIFF
--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -574,8 +574,11 @@ class PartitionLoops : public IRMutator {
             std::sort(max_vals.begin(), max_vals.end(), IRDeepCompare());
             max_vals.push_back(op->min + op->extent - 1);
             epilogue_val = fold_left(max_vals, Min::make) + 1;
+            // Stop the epilogue from running before the start of the loop/prologue
             if (make_prologue) {
                 epilogue_val = max(epilogue_val, prologue_val);
+            } else {
+                epilogue_val = max(op->min, epilogue_val);
             }
             // epilogue_val = print(epilogue_val, epilogue_name);
             max_steady = Variable::make(Int(32), epilogue_name);

--- a/test/correctness/specialize.cpp
+++ b/test/correctness/specialize.cpp
@@ -404,9 +404,8 @@ int main(int argc, char **argv) {
         im.set(input);
         out.realize(output);
 
-        // The tail case of the vectorized for loop converts to a second if statement.
-        if (if_then_else_count != 2) {
-            printf("Expected 2 IfThenElse stmts. Found %d.\n", if_then_else_count);
+        if (if_then_else_count != 1) {
+            printf("Expected 1 IfThenElse stmts. Found %d.\n", if_then_else_count);
             return -1;
         }
     }
@@ -434,13 +433,12 @@ int main(int argc, char **argv) {
         im.set(input);
         out.realize(output);
 
-        // There should have been 3 Ifs total: The first two are the
+        // There should have been 2 Ifs total: They are the
         // outer cond1 && cond2, and the condition in the true case
         // should have been simplified away. The If in the false
-        // branch cannot be simplified. The tail case of the
-        // vectorized for loop converts to a third if statement.
-        if (if_then_else_count != 3) {
-            printf("Expected 3 IfThenElse stmts. Found %d.\n", if_then_else_count);
+        // branch cannot be simplified.
+        if (if_then_else_count != 2) {
+            printf("Expected 2 IfThenElse stmts. Found %d.\n", if_then_else_count);
             return -1;
         }
     }


### PR DESCRIPTION
This PR fixed bugs in PartitionLoops where epilogue runs before start of the loop. However,
the fix makes some cases that was simplifiable previously not simplifiable due to the additional `max(..., loop_min)`, e.g. `for (out.s0.x.x, max((out.extent.0/4), 0), (((out.extent.0 + 3)/4) - max((out.extent.0/4), 0)))`