### PR TITLE
Add halide_mutex_destroy to fake_thread_pool

### DIFF
--- a/src/runtime/fake_thread_pool.cpp
+++ b/src/runtime/fake_thread_pool.cpp
@@ -45,6 +45,9 @@ WEAK void halide_mutex_lock(halide_mutex *mutex) {
 WEAK void halide_mutex_unlock(halide_mutex *mutex) {
 }
 
+WEAK void halide_mutex_destroy(halide_mutex *mutex) {
+}
+
 WEAK void halide_shutdown_thread_pool() {
 }
 


### PR DESCRIPTION
Add halide_mutex_destroy to the fake thread pool.
Hexagon standalone compilation mode was failing to resolve the symbol