### PR TITLE
pass -mhvx as its not the default on tip

### DIFF
--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -308,6 +308,8 @@ public:
         }
         if (device_code.target().has_feature(Target::HVX_128)) {
             hex_command += " -mhvx-double";
+        } else {
+            hex_command += " -mhvx";
         }
         hex_command += " -o " + tmp_shared_object.pathname();
         int result = system(hex_command.c_str());


### PR DESCRIPTION
llvm.org's build of hexagon-clang does not have hvx enabled by default, so in 64 byte mode we need to ask for the hvx feature, much like we ask for the hvx-double feature for 128 byte mode.
This allows 64 byte toyCamera to compile vector IR properly.