### PR TITLE
add Hexagon to supports_device_api and all_device_apis

### DIFF
--- a/src/Expr.h
+++ b/src/Expr.h
@@ -322,7 +322,8 @@ const DeviceAPI all_device_apis[] = {DeviceAPI::None,
                                      DeviceAPI::GLSL,
                                      DeviceAPI::Renderscript,
                                      DeviceAPI::OpenGLCompute,
-                                     DeviceAPI::Metal};
+                                     DeviceAPI::Metal,
+                                     DeviceAPI::Hexagon};
 
 namespace Internal {
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1427,7 +1427,6 @@ Stage &Stage::gpu_tile(VarOrRVar x, VarOrRVar y, VarOrRVar z,
 }
 
 Stage &Stage::hexagon(VarOrRVar x) {
-    invalidate_cache();
     set_dim_device_api(x, DeviceAPI::Hexagon);
     return *this;
 }
@@ -1778,6 +1777,7 @@ Func &Func::glsl(Var x, Var y, Var c) {
 }
 
 Func &Func::hexagon(VarOrRVar x) {
+    invalidate_cache();
     Stage(func.definition(), name(), args(), func.schedule().storage_dims()).hexagon(x);
     return *this;
 }

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1427,6 +1427,7 @@ Stage &Stage::gpu_tile(VarOrRVar x, VarOrRVar y, VarOrRVar z,
 }
 
 Stage &Stage::hexagon(VarOrRVar x) {
+    invalidate_cache();
     set_dim_device_api(x, DeviceAPI::Hexagon);
     return *this;
 }

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -494,6 +494,8 @@ bool Target::supports_device_api(DeviceAPI api) const {
     case DeviceAPI::None:        return true;
     case DeviceAPI::Host:        return true;
     case DeviceAPI::Default_GPU: return has_gpu_feature() || has_feature(Target::OpenGLCompute);
+    case DeviceAPI::Hexagon:     return has_feature(Target::HVX_64) || has_feature(Target::HVX_128) ||
+                                        has_feature(Target::HVX_v62);
     default:                     return has_feature(target_feature_for_device_api(api));
     }
 }


### PR DESCRIPTION
Added Hexagon handler to supports_device_api and all_device_apis + invalidates caches when hexagon scheduling directive is called. 

@dsharletg  Could you please take a look at this PR? I'm not sure if you're intentionally skip to add the Hexagon.