### PR TITLE
Add a setter for a can_use_target_features function pointer

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -715,8 +715,6 @@ extern halide_can_use_target_features_t halide_set_custom_can_use_target_feature
 extern int halide_default_can_use_target_features(uint64_t features);
 
 
-
-
 #ifndef BUFFER_T_DEFINED
 #define BUFFER_T_DEFINED
 

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -692,7 +692,11 @@ typedef enum halide_target_feature_t {
  *
  * The default implementation simply calls halide_default_can_use_target_features.
  */
+// @{
 extern int halide_can_use_target_features(uint64_t features);
+typedef int (*halide_can_use_target_features_t)(uint64_t);
+extern halide_can_use_target_features_t halide_set_custom_can_use_target_features(halide_can_use_target_features_t);
+// @}
 
 /**
  * This is the default implementation of halide_can_use_target_features; it is provided
@@ -709,6 +713,8 @@ extern int halide_can_use_target_features(uint64_t features);
  *     }
  */
 extern int halide_default_can_use_target_features(uint64_t features);
+
+
 
 
 #ifndef BUFFER_T_DEFINED

--- a/src/runtime/can_use_target.cpp
+++ b/src/runtime/can_use_target.cpp
@@ -1,9 +1,19 @@
 #include "HalideRuntime.h"
 
+namespace Halide { namespace Runtime { namespace Internal {
+WEAK halide_can_use_target_features_t custom_can_use_target_features = halide_default_can_use_target_features;
+}}}
+
 extern "C" {
 
+WEAK halide_can_use_target_features_t halide_set_custom_can_use_target_features(halide_can_use_target_features_t fn) {
+    halide_can_use_target_features_t result = custom_can_use_target_features;
+    custom_can_use_target_features = fn;
+    return result;
+}
+
 WEAK int halide_can_use_target_features(uint64_t features) {
-    return halide_default_can_use_target_features(features);
+    return (*custom_can_use_target_features)(features);
 }
 
 WEAK int halide_default_can_use_target_features(uint64_t features) {

--- a/test/generator/multitarget_aottest.cpp
+++ b/test/generator/multitarget_aottest.cpp
@@ -36,7 +36,7 @@ bool use_debug_feature() {
 
 static std::atomic<int> can_use_count;
 
-extern "C" int halide_can_use_target_features(uint64_t features) {
+int my_can_use_target_features(uint64_t features) {
     can_use_count += 1;
     if (features & (1ULL << halide_target_feature_debug)) {
         if (use_debug_feature()) {
@@ -51,6 +51,8 @@ extern "C" int halide_can_use_target_features(uint64_t features) {
 int main(int argc, char **argv) {
     const int W = 32, H = 32;
     Image<uint32_t> output(W, H);
+
+    halide_set_custom_can_use_target_features(my_can_use_target_features);
 
     buffer_t *o_buf = output;
     if (HalideTest::multitarget(o_buf) != 0) {


### PR DESCRIPTION
weak-symbol-based overriding doesn't work well on Windows or mingw, so
the generator tests all use function-pointer-setting instead.

This is part of my ongoing quest to get mingw working again.

@steven-johnson ptal