### PR TITLE
func bound and bitwise ops should only take integers

### DIFF
--- a/src/AllocationBoundsInference.cpp
+++ b/src/AllocationBoundsInference.cpp
@@ -90,6 +90,9 @@ class AllocationInference : public IRMutator {
             Expr min_var = Variable::make(Int(32), min_name);
             Expr max_var = Variable::make(Int(32), max_name);
 
+            internal_assert(min_var.type() == min.type());
+            internal_assert(max_var.type() == max.type());
+
             Expr error_msg = Call::make(Int(32), "halide_error_explicit_bounds_too_small",
                                         {f_args[i], f.name(), min_var, max_var, b[i].min, b[i].max},
                                         Call::Extern);

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1616,6 +1616,10 @@ Func &Func::unroll(VarOrRVar var, int factor, TailStrategy tail) {
 }
 
 Func &Func::bound(Var var, Expr min, Expr extent) {
+    user_assert(!min.defined() || (min.type() == Int(32))) << "Min bound of a Func must be of type int32\n";
+    user_assert(extent.defined()) << "Extent bound of a Func can't be undefined\n";
+    user_assert(extent.type() == Int(32)) << "Extent bound of a Func must be of type int32\n";
+
     invalidate_cache();
     bool found = false;
     for (size_t i = 0; i < func.args().size(); i++) {

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1616,9 +1616,14 @@ Func &Func::unroll(VarOrRVar var, int factor, TailStrategy tail) {
 }
 
 Func &Func::bound(Var var, Expr min, Expr extent) {
-    user_assert(!min.defined() || (min.type() == Int(32))) << "Min bound of a Func must be of type int32\n";
+    user_assert(!min.defined() || Int(32).can_represent(min.type())) << "Can't represent min bound in int32\n";
     user_assert(extent.defined()) << "Extent bound of a Func can't be undefined\n";
-    user_assert(extent.type() == Int(32)) << "Extent bound of a Func must be of type int32\n";
+    user_assert(Int(32).can_represent(extent.type())) << "Can't represent extent bound in int32\n";
+
+    if (min.defined()) {
+        min = cast<int32_t>(min);
+    }
+    extent = cast<int32_t>(extent);
 
     invalidate_cache();
     bool found = false;

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1412,7 +1412,10 @@ inline Expr reinterpret(Expr e) {
  * argument. */
 inline Expr operator&(Expr x, Expr y) {
     user_assert(x.defined() && y.defined()) << "bitwise and of undefined Expr\n";
-    user_assert(!x.type().is_float() && !y.type().is_float()) << "bitwise and only takes integers\n";
+    user_assert(x.type().is_int() || x.type().is_uint())
+        << "The first argument to bitwise and must be an integer or unsigned integer";
+    user_assert(y.type().is_int() || y.type().is_uint())
+        << "The second argument to bitwise and must be an integer or unsigned integer";
     // First widen or narrow, then bitcast.
     if (y.type().bits() != x.type().bits()) {
         y = cast(y.type().with_bits(x.type().bits()), y);
@@ -1428,7 +1431,10 @@ inline Expr operator&(Expr x, Expr y) {
  * argument. */
 inline Expr operator|(Expr x, Expr y) {
     user_assert(x.defined() && y.defined()) << "bitwise or of undefined Expr\n";
-    user_assert(!x.type().is_float() && !y.type().is_float()) << "bitwise or only takes integers\n";
+    user_assert(x.type().is_int() || x.type().is_uint())
+        << "The first argument to bitwise or must be an integer or unsigned integer";
+    user_assert(y.type().is_int() || y.type().is_uint())
+        << "The second argument to bitwise or must be an integer or unsigned integer";
     // First widen or narrow, then bitcast.
     if (y.type().bits() != x.type().bits()) {
         y = cast(y.type().with_bits(x.type().bits()), y);
@@ -1444,7 +1450,10 @@ inline Expr operator|(Expr x, Expr y) {
  * first argument. */
 inline Expr operator^(Expr x, Expr y) {
     user_assert(x.defined() && y.defined()) << "bitwise xor of undefined Expr\n";
-    user_assert(!x.type().is_float() && !y.type().is_float()) << "bitwise xor only takes integers\n";
+    user_assert(x.type().is_int() || x.type().is_uint())
+        << "The first argument to bitwise xor must be an integer or unsigned integer";
+    user_assert(y.type().is_int() || y.type().is_uint())
+        << "The second argument to bitwise xor must be an integer or unsigned integer";
     // First widen or narrow, then bitcast.
     if (y.type().bits() != x.type().bits()) {
         y = cast(y.type().with_bits(x.type().bits()), y);
@@ -1458,7 +1467,8 @@ inline Expr operator^(Expr x, Expr y) {
 /** Return the bitwise not of an expression. */
 inline Expr operator~(Expr x) {
     user_assert(x.defined()) << "bitwise not of undefined Expr\n";
-    user_assert(!x.type().is_float()) << "bitwise not only takes integer\n";
+    user_assert(x.type().is_int() || x.type().is_uint())
+        << "Argument to bitwise not must be an integer or unsigned integer";
     return Internal::Call::make(x.type(), Internal::Call::bitwise_not, {x}, Internal::Call::PureIntrinsic);
 }
 

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1412,6 +1412,7 @@ inline Expr reinterpret(Expr e) {
  * argument. */
 inline Expr operator&(Expr x, Expr y) {
     user_assert(x.defined() && y.defined()) << "bitwise and of undefined Expr\n";
+    user_assert(!x.type().is_float() && !y.type().is_float()) << "bitwise and only takes integers\n";
     // First widen or narrow, then bitcast.
     if (y.type().bits() != x.type().bits()) {
         y = cast(y.type().with_bits(x.type().bits()), y);
@@ -1427,6 +1428,7 @@ inline Expr operator&(Expr x, Expr y) {
  * argument. */
 inline Expr operator|(Expr x, Expr y) {
     user_assert(x.defined() && y.defined()) << "bitwise or of undefined Expr\n";
+    user_assert(!x.type().is_float() && !y.type().is_float()) << "bitwise or only takes integers\n";
     // First widen or narrow, then bitcast.
     if (y.type().bits() != x.type().bits()) {
         y = cast(y.type().with_bits(x.type().bits()), y);
@@ -1441,7 +1443,8 @@ inline Expr operator|(Expr x, Expr y) {
  * have the same type). The type of the result is the type of the
  * first argument. */
 inline Expr operator^(Expr x, Expr y) {
-    user_assert(x.defined() && y.defined()) << "bitwise or of undefined Expr\n";
+    user_assert(x.defined() && y.defined()) << "bitwise xor of undefined Expr\n";
+    user_assert(!x.type().is_float() && !y.type().is_float()) << "bitwise xor only takes integers\n";
     // First widen or narrow, then bitcast.
     if (y.type().bits() != x.type().bits()) {
         y = cast(y.type().with_bits(x.type().bits()), y);
@@ -1454,7 +1457,8 @@ inline Expr operator^(Expr x, Expr y) {
 
 /** Return the bitwise not of an expression. */
 inline Expr operator~(Expr x) {
-    user_assert(x.defined()) << "bitwise or of undefined Expr\n";
+    user_assert(x.defined()) << "bitwise not of undefined Expr\n";
+    user_assert(!x.type().is_float()) << "bitwise not only takes integer\n";
     return Internal::Call::make(x.type(), Internal::Call::bitwise_not, {x}, Internal::Call::PureIntrinsic);
 }
 


### PR DESCRIPTION
Bug fixes: added user asserts in Func::bound and bitwise ops to check that they should take integers as arguments