### PR TITLE
Add a target feature that fuzzes floating point stores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,6 +311,7 @@ SOURCE_FILES = \
   Func.cpp \
   Function.cpp \
   FuseGPUThreadLoops.cpp \
+  FuzzFloatStores.cpp \
   Generator.cpp \
   HexagonOffload.cpp \
   HexagonOptimize.cpp \
@@ -446,6 +447,7 @@ HEADER_FILES = \
   Func.h \
   Function.h \
   FuseGPUThreadLoops.h \
+  FuzzFloatStores.h \
   Generator.h \
   HexagonOffload.h \
   HexagonOptimize.h \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -263,6 +263,8 @@ set(HEADER_FILES
   Float16.h
   Func.h
   Function.h
+  FuseGPUThreadLoops.h
+  FuzzFloatStores.h
   Generator.h
   HexagonOffload.h
   HexagonOptimize.h
@@ -423,6 +425,7 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   Func.cpp
   Function.cpp
   FuseGPUThreadLoops.cpp
+  FuzzFloatStores.cpp
   Generator.cpp
   HexagonOffload.cpp
   HexagonOptimize.cpp

--- a/src/FuzzFloatStores.cpp
+++ b/src/FuzzFloatStores.cpp
@@ -1,0 +1,34 @@
+#include "FuzzFloatStores.h"
+#include "IRMutator.h"
+#include "IROperator.h"
+
+namespace Halide {
+namespace Internal {
+
+namespace {
+class FuzzFloatStores : public IRMutator {
+    using IRMutator::visit;
+
+    void visit(const Store *op) {
+        Type t = op->value.type();
+        if (t.is_float()) {
+            // Drop the last bit of the mantissa.
+            Expr value = op->value;
+            Expr mask = make_one(t.with_code(Type::UInt));
+            value = reinterpret(mask.type(), value);
+            value = value & ~mask;
+            value = reinterpret(t, value);
+            stmt = Store::make(op->name, value, op->index, op->param);
+        } else {
+            IRMutator::visit(op);
+        }
+    }
+};
+}
+
+Stmt fuzz_float_stores(Stmt s) {
+    return FuzzFloatStores().mutate(s);
+}
+
+}
+}

--- a/src/FuzzFloatStores.h
+++ b/src/FuzzFloatStores.h
@@ -1,0 +1,25 @@
+#ifndef FUZZ_FLOAT_STORES_H
+#define FUZZ_FLOAT_STORES_H
+
+#include "Expr.h"
+
+/** \file
+ * Defines a lowering pass that messes with floating point stores.
+ */
+
+namespace Halide {
+namespace Internal {
+
+/** On every store of a floating point value, mask off the
+ * least-significant-bit of the mantissa. We've found that whether or
+ * not this dramatically changes the output of a pipeline correlates
+ * very well with whether or not a pipeline will produce very
+ * different outputs on different architectures (e.g. with and without
+ * FMA). It's a useful way to detect bad tests, such as those that
+ * expect exact floating point equality across platforms. */
+Stmt fuzz_float_stores(Stmt s);
+
+}
+}
+
+#endif

--- a/src/FuzzFloatStores.h
+++ b/src/FuzzFloatStores.h
@@ -15,8 +15,8 @@ namespace Internal {
  * not this dramatically changes the output of a pipeline correlates
  * very well with whether or not a pipeline will produce very
  * different outputs on different architectures (e.g. with and without
- * FMA). It's a useful way to detect bad tests, such as those that
- * expect exact floating point equality across platforms. */
+ * FMA). It's also a useful way to detect bad tests, such as those
+ * that expect exact floating point equality across platforms. */
 Stmt fuzz_float_stores(Stmt s);
 
 }

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -19,6 +19,7 @@
 #include "FindCalls.h"
 #include "Function.h"
 #include "FuseGPUThreadLoops.h"
+#include "FuzzFloatStores.h"
 #include "HexagonOffload.h"
 #include "InjectHostDevBufferCopies.h"
 #include "InjectImageIntrinsics.h"
@@ -243,7 +244,13 @@ Stmt lower(vector<Function> outputs, const string &pipeline_name, const Target &
     if (t.has_feature(Target::Profile)) {
         debug(1) << "Injecting profiling...\n";
         s = inject_profiling(s, pipeline_name);
-        debug(2) << "Lowering after injecting profiling:\n" << s << '\n';
+        debug(2) << "Lowering after injecting profiling:\n" << s << "\n\n";
+    }
+
+    if (t.has_feature(Target::FuzzFloatStores)) {
+        debug(1) << "Fuzzing floating point stores...\n";
+        s = fuzz_float_stores(s);
+        debug(2) << "Lowering after fuzzing floating point stores:\n" << s << "\n\n";
     }
 
     debug(1) << "Simplifying...\n";

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -249,6 +249,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"hvx_64", Target::HVX_64},
     {"hvx_128", Target::HVX_128},
     {"hvx_v62", Target::HVX_v62},
+    {"fuzz_float_stores", Target::FuzzFloatStores}
 };
 
 bool lookup_feature(const std::string &tok, Target::Feature &result) {

--- a/src/Target.h
+++ b/src/Target.h
@@ -74,6 +74,7 @@ struct Target {
         HVX_64 = halide_target_feature_hvx_64,
         HVX_128 = halide_target_feature_hvx_128,
         HVX_v62 = halide_target_feature_hvx_v62,
+        FuzzFloatStores = halide_target_feature_fuzz_float_stores,
         FeatureEnd = halide_target_feature_end
     };
     Target() : os(OSUnknown), arch(ArchUnknown), bits(0) {}

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -674,8 +674,8 @@ typedef enum halide_target_feature_t {
     halide_target_feature_hvx_64 = 33, ///< Enable HVX 64 byte mode.
     halide_target_feature_hvx_128 = 34, ///< Enable HVX 128 byte mode.
     halide_target_feature_hvx_v62 = 35, ///< Enable Hexagon v62 architecture.
-
-    halide_target_feature_end = 36 ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
+    halide_target_feature_fuzz_float_stores = 36, ///< On every floating point store, set the last bit of the mantissa to zero. Pipelines for which the output is very different with this feature enabled may also produce very different output on different processors.
+    halide_target_feature_end = 37 ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 
 /** This function is called internally by Halide in some situations to determine

--- a/test/correctness/fuzz_float_stores.cpp
+++ b/test/correctness/fuzz_float_stores.cpp
@@ -36,14 +36,12 @@ int main(int argc, char **argv) {
         f(x) = sqrt(x - 42.3333333f) / 17.0f - tan(x);
         f.vectorize(x, 8);
 
-        // Pipelines that use all the bits should be wrong about half the time
         Image<float> im_ref = f.realize(size, target);
         Image<float> im_fuzzed = f.realize(size, target_fuzzed);
 
         int differences = 0;
         for (int i = 0; i < im_ref.width(); i++) {
-            // Test for exact floating point equality, which is exactly
-            // the sort of thing FuzzFloatStores is trying to discourage.
+            // Pipelines that use all the bits should be wrong about half the time
             if (im_ref(i) != im_fuzzed(i)) {
                 differences++;
             }

--- a/test/correctness/fuzz_float_stores.cpp
+++ b/test/correctness/fuzz_float_stores.cpp
@@ -1,0 +1,71 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    Target target_fuzzed = target.with_feature(Target::FuzzFloatStores);
+
+    const int size = 1000;
+
+    {
+        // Check some code that should be unaffected
+        Func f;
+        Var x;
+        f(x) = (x - 42.5f) / 16.0f;
+        f.vectorize(x, 8);
+
+        // Pipelines that only use a few significant bits of the float should be unaffected
+        Image<float> im_ref = f.realize(size, target);
+        Image<float> im_fuzzed = f.realize(size, target_fuzzed);
+
+        for (int i = 0; i < im_ref.width(); i++) {
+            // Test for exact floating point equality, which is exactly
+            // the sort of thing FuzzFloatStores is trying to discourage.
+            if (im_ref(i) != im_fuzzed(i)) {
+                printf("Expected exact floating point equality between %10.10g and %10.10g\n", im_ref(i), im_fuzzed(i));
+                return -1;
+            }
+        }
+    }
+
+    {
+        // Check some code that should be affected
+        Func f;
+        Var x;
+        f(x) = sqrt(x - 42.3333333f) / 17.0f - tan(x);
+        f.vectorize(x, 8);
+
+        // Pipelines that use all the bits should be wrong about half the time
+        Image<float> im_ref = f.realize(size, target);
+        Image<float> im_fuzzed = f.realize(size, target_fuzzed);
+
+        int differences = 0;
+        for (int i = 0; i < im_ref.width(); i++) {
+            // Test for exact floating point equality, which is exactly
+            // the sort of thing FuzzFloatStores is trying to discourage.
+            if (im_ref(i) != im_fuzzed(i)) {
+                differences++;
+            }
+        }
+
+        if (differences == 0) {
+            printf("fuzzing float stores should have done something\n");
+            return -1;
+        }
+
+        // It should change the output about half the time. Assuming
+        // it's sum of 'size' coin flips...
+        int mean = size/2;
+        int variance = size/4;
+        int five_sigma = 5 * ceil(sqrt(variance));
+        if (differences < mean - five_sigma || differences > mean + five_sigma) {
+            printf("There were %d differences with floating point fuzzing on. Expected more like %d +/- %d.\n",
+                   differences, mean, five_sigma);
+            return -1;
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
When the FuzzFloatStores target feature is on, the LSB of all floating
point stores is set to zero before storing.

Because we apply (and tell LLVM to apply) -ffast-math style floating
point optimizations in a target-specific way, you can't rely on Halide
code producing exactly the same outputs on every platform for code that
uses floats. This new target features is intended to flush out tests
that make this bad assumption. If a test passes with FuzzFloatStores
off, but fails with it on, it's likely to also fail on different
architectures.

There are probably all sorts of more elaborate ways to fuzz floating
point computations, but we've found that this surprisingly simple method
works well for finding the bad tests and has few false positives.