### PR TITLE
enforce halide_set_num_threads(n) behavior for n <= 1 (Issue #1371)

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -144,7 +144,21 @@ extern struct halide_thread *halide_spawn_thread(void (*f)(void *), void *closur
 extern void halide_join_thread(struct halide_thread *);
 
 /** Set the number of threads used by Halide's thread pool. Returns
- * the old number. No effect on OS X or iOS. */
+ * the old number. 
+ *
+ * n < 0  : error condition
+ * n == 0 : use a reasonable system default (typically, number of cpus online).
+ * n == 1 : use exactly one thread; this will always enforce serial execution
+ * n > 1  : use a pool of exactly n threads.
+ *
+ * Note that the default iOS and OSX behavior will treat n > 1 like n == 0;
+ * that is, any positive value other than 1 will use a system-determined number
+ * of threads.
+ *
+ * (Note that this is only guaranteed when using the default implementations
+ * of halide_do_par_for(); custom implementations may completely ignore values
+ * passed to halide_set_num_threads().)
+ */
 extern int halide_set_num_threads(int n);
 
 /** Halide calls these functions to allocate and free memory. To

--- a/src/runtime/fake_thread_pool.cpp
+++ b/src/runtime/fake_thread_pool.cpp
@@ -48,7 +48,10 @@ WEAK void halide_mutex_unlock(halide_mutex *mutex) {
 WEAK void halide_shutdown_thread_pool() {
 }
 
-WEAK int halide_set_num_threads(int) {
+WEAK int halide_set_num_threads(int n) {
+    if (n < 0) {
+        halide_error(NULL, "halide_set_num_threads: must be >= 0.");
+    }
     return 1;
 }
 

--- a/src/runtime/gcd_thread_pool.cpp
+++ b/src/runtime/gcd_thread_pool.cpp
@@ -100,7 +100,7 @@ WEAK void halide_do_gcd_task(void *job, size_t idx) {
 
 WEAK int default_do_par_for(void *user_context, halide_task_t f,
                             int min, int size, uint8_t *closure) {
-    if (custom_num_threads == 1) {
+    if (custom_num_threads == 1 || size == 1) {
         // GCD doesn't really allow us to limit the threads,
         // so ensure that there's no parallelism by executing serially.
         for (int x = min; x < min + size; x++) {

--- a/src/runtime/gcd_thread_pool.cpp
+++ b/src/runtime/gcd_thread_pool.cpp
@@ -65,6 +65,8 @@ WEAK void halide_join_thread(halide_thread *thread_arg) {
 
 namespace Halide { namespace Runtime { namespace Internal {
 
+WEAK int custom_num_threads = 0;
+
 struct gcd_mutex {
     dispatch_once_t once;
     dispatch_semaphore_t semaphore;
@@ -98,6 +100,18 @@ WEAK void halide_do_gcd_task(void *job, size_t idx) {
 
 WEAK int default_do_par_for(void *user_context, halide_task_t f,
                             int min, int size, uint8_t *closure) {
+    if (custom_num_threads == 1) {
+        // GCD doesn't really allow us to limit the threads,
+        // so ensure that there's no parallelism by executing serially.
+        for (int x = min; x < min + size; x++) {
+            int result = halide_do_task(user_context, f, x, closure);
+            if (result) {
+                return result;
+            }
+        }
+        return 0;
+    }
+
     halide_gcd_job job;
     job.f = f;
     job.user_context = user_context;
@@ -138,8 +152,13 @@ WEAK void halide_mutex_unlock(halide_mutex *mutex_arg) {
 WEAK void halide_shutdown_thread_pool() {
 }
 
-WEAK int halide_set_num_threads(int) {
-    return 1;
+WEAK int halide_set_num_threads(int n) {
+    if (n < 0) {
+        halide_error(NULL, "halide_set_num_threads: must be >= 0.");
+    }
+    int old_custom_num_threads = custom_num_threads;
+    custom_num_threads = n;
+    return old_custom_num_threads;
 }
 
 WEAK halide_do_task_t halide_set_custom_do_task(halide_do_task_t f) {

--- a/src/runtime/thread_pool_common.h
+++ b/src/runtime/thread_pool_common.h
@@ -64,6 +64,30 @@ WEAK int default_do_task(void *user_context, halide_task_t f, int idx,
     return f(user_context, idx, closure);
 }
 
+WEAK int clamp_num_threads(int desired_num_threads) {
+    if (desired_num_threads > MAX_THREADS) {
+        desired_num_threads = MAX_THREADS;
+    } else if (desired_num_threads < 1) {
+        desired_num_threads = 1;
+    }
+    return desired_num_threads;
+}
+
+WEAK int default_desired_num_threads() {
+    int desired_num_threads = 0;
+    char *threads_str = getenv("HL_NUM_THREADS");
+    if (!threads_str) {
+        // Legacy name for HL_NUM_THREADS
+        threads_str = getenv("HL_NUMTHREADS");
+    }
+    if (threads_str) {
+        desired_num_threads = atoi(threads_str);
+    } else {
+        desired_num_threads = halide_host_cpu_count();
+    }
+    return desired_num_threads;
+}
+
 WEAK void worker_thread_already_locked(work *owned_job) {
     // If I'm a job owner, then I was the thread that called
     // do_par_for, and I should only stay in this function until my
@@ -154,22 +178,9 @@ WEAK int default_do_par_for(void *user_context, halide_task_t f,
         // can also mess with this value, but only when the work queue
         // is locked.
         if (!work_queue.desired_num_threads) {
-            char *threads_str = getenv("HL_NUM_THREADS");
-            if (!threads_str) {
-                // Legacy name for HL_NUM_THREADS
-                threads_str = getenv("HL_NUMTHREADS");
-            }
-            if (threads_str) {
-                work_queue.desired_num_threads = atoi(threads_str);
-            } else {
-                work_queue.desired_num_threads = halide_host_cpu_count();
-            }
+            work_queue.desired_num_threads = default_desired_num_threads();
         }
-        if (work_queue.desired_num_threads > MAX_THREADS) {
-            work_queue.desired_num_threads = MAX_THREADS;
-        } else if (work_queue.desired_num_threads < 1) {
-            work_queue.desired_num_threads = 1;
-        }
+        work_queue.desired_num_threads = clamp_num_threads(work_queue.desired_num_threads);
         work_queue.threads_created = 0;
 
         // Everyone starts on the a team.
@@ -246,8 +257,11 @@ WEAK int halide_set_num_threads(int n) {
     // the desired number of threads while another thread is in the
     // middle of a sequence of non-atomic operations.
     halide_mutex_lock(&work_queue.mutex);
+    if (n == 0) {
+        n = default_desired_num_threads();
+    }
     int old = work_queue.desired_num_threads;
-    work_queue.desired_num_threads = n;
+    work_queue.desired_num_threads = clamp_num_threads(n);
     halide_mutex_unlock(&work_queue.mutex);
     return old;
 }

--- a/src/runtime/thread_pool_common.h
+++ b/src/runtime/thread_pool_common.h
@@ -239,6 +239,9 @@ using namespace Halide::Runtime::Internal;
 extern "C" {
 
 WEAK int halide_set_num_threads(int n) {
+    if (n < 0) {
+        halide_error(NULL, "halide_set_num_threads: must be >= 0.");
+    }
     // Don't make this an atomic swap - we don't want to be changing
     // the desired number of threads while another thread is in the
     // middle of a sequence of non-atomic operations.


### PR DESCRIPTION
If n < 0, call halide_error() everywhere.

if n == 0, use a “system-determined” number of threads.

if n == 1, ensure that there is no thread parallelism anywhere (by
special-casing the iOS/OSX GCD threadpool).

if n > 1, use a thread pool of size n (except on iOS and OSX).

This allows testing/benchmarking to ensure single-CPU-core behavior by
calling halide_set_num_threads(1) regardless of platform.