### PR TITLE
Reduce the number of vlut instructions

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -944,10 +944,10 @@ Value *CodeGen_Hexagon::vlut(Value *lut, Value *idx, int min_index, int max_inde
         Value *result_i = nullptr;
         for (int j = 0; j < static_cast<int>(lut_slices.size()); j++) {
             for (int k = 0; k < lut_passes; k++) {
-                int pass_index = lut_passes*j + k;
+                int pass_index = lut_passes * j + k;
                 Value *mask[2] = {
-                    ConstantInt::get(i32_t, 2*pass_index + 0),
-                    ConstantInt::get(i32_t, 2*pass_index + 1),
+                    ConstantInt::get(i32_t, 2 * pass_index + 0),
+                    ConstantInt::get(i32_t, 2 * pass_index + 1),
                 };
                 if (result_i == nullptr) {
                     // The first native LUT, use vlut.
@@ -955,7 +955,7 @@ Value *CodeGen_Hexagon::vlut(Value *lut, Value *idx, int min_index, int max_inde
                                                 {idx_i, lut_slices[j], mask[0]});
                     result_i = call_intrin_cast(native_result_ty, vlut_acc_id,
                                                 {result_i, idx_i, lut_slices[j], mask[1]});
-                } else if (max_index >= pass_index*native_lut_elements/lut_passes) {
+                } else if (max_index >= pass_index * native_lut_elements / lut_passes) {
                     // Not the first native LUT, accumulate the LUT
                     // with the previous result.
                     for (int m = 0; m < 2; m++) {

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -932,8 +932,10 @@ Value *CodeGen_Hexagon::vlut(Value *lut, Value *idx, int min_index, int max_inde
     // The result will have the same number of elements as idx.
     int idx_elements = idx_ty->getVectorNumElements();
 
-    // Each LUT has 2 mask values for HVX 64, 4 mask values for HVX 128.
-    int lut_passes = is_128B ? 4 : 2;
+    // Each LUT has 1 pair of even/odd mask values for HVX 64, 2 for
+    // HVX 128.  We may not need all of the passes, if the LUT has
+    // fewer than half of the elements in an HVX 128 vector.
+    int lut_passes = is_128B ? 2 : 1;
 
     vector<Value *> result;
     for (int i = 0; i < idx_elements; i += native_idx_elements) {
@@ -942,16 +944,24 @@ Value *CodeGen_Hexagon::vlut(Value *lut, Value *idx, int min_index, int max_inde
         Value *result_i = nullptr;
         for (int j = 0; j < static_cast<int>(lut_slices.size()); j++) {
             for (int k = 0; k < lut_passes; k++) {
-                Value *mask = ConstantInt::get(i32_t, lut_passes*j + k);
+                int pass_index = lut_passes*j + k;
+                Value *mask[2] = {
+                    ConstantInt::get(i32_t, 2*pass_index + 0),
+                    ConstantInt::get(i32_t, 2*pass_index + 1),
+                };
                 if (result_i == nullptr) {
                     // The first native LUT, use vlut.
                     result_i = call_intrin_cast(native_result_ty, vlut_id,
-                                                {idx_i, lut_slices[j], mask});
-                } else {
+                                                {idx_i, lut_slices[j], mask[0]});
+                    result_i = call_intrin_cast(native_result_ty, vlut_acc_id,
+                                                {result_i, idx_i, lut_slices[j], mask[1]});
+                } else if (max_index >= pass_index*native_lut_elements/lut_passes) {
                     // Not the first native LUT, accumulate the LUT
                     // with the previous result.
-                    result_i = call_intrin_cast(native_result_ty, vlut_acc_id,
-                                                {result_i, idx_i, lut_slices[j], mask});
+                    for (int m = 0; m < 2; m++) {
+                        result_i = call_intrin_cast(native_result_ty, vlut_acc_id,
+                                                    {result_i, idx_i, lut_slices[j], mask[m]});
+                    }
                 }
             }
         }


### PR DESCRIPTION
In HVX 128 mode, the vlut instruction requires 4 vlut calls per LUT vector: the even/odd elements of the lower half of the vector, and the even/odd elements of the upper half of the vector. Prior to this PR, if the LUT used any of the vector, we called vlut all 4 times, even if the LUT only needed the 2 vlut instructions for the lower half of the vector.