### PR TITLE
Save & restore OpenGL state

### DIFF
--- a/src/runtime/mini_opengl.h
+++ b/src/runtime/mini_opengl.h
@@ -55,6 +55,7 @@ typedef void GLvoid;
 #define GL_CLAMP_TO_EDGE 0x812F
 #define GL_TEXTURE0 0x84C0
 #define GL_ACTIVE_TEXTURE 0x84E0
+#define GL_TEXTURE_BINDING_2D 0x8069
 
 typedef void (*PFNGLACTIVETEXTUREPROC) (GLenum texture);
 typedef void (*PFNGLBINDTEXTUREPROC)(GLenum target, GLuint texture);
@@ -99,6 +100,8 @@ typedef void (*PFNGLREADPIXELS)(GLint x, GLint y,
 #define GL_ARRAY_BUFFER 0x8892
 #define GL_ELEMENT_ARRAY_BUFFER 0x8893
 #define GL_STATIC_DRAW 0x88E4
+#define GL_ARRAY_BUFFER_BINDING 0x8894
+#define GL_ELEMENT_ARRAY_BUFFER_BINDING 0x8895
 
 typedef void (*PFNGLGENBUFFERSPROC)(GLsizei n, GLuint *buffers);
 typedef void (*PFNGLDELETEBUFFERSPROC) (GLsizei n, const GLuint *buffers);
@@ -115,6 +118,9 @@ typedef void (*PFNGLBUFFERDATAPROC)(GLenum target, GLsizeiptr size, const GLvoid
 #define GL_IMPLEMENTATION_COLOR_READ_FORMAT 0x8B9B
 #define GL_IMPLEMENTATION_COLOR_READ_TYPE 0x8B9A
 #define GL_CURRENT_PROGRAM 0x8B8D
+#define GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS 0x8B4D
+#define GL_MAX_VERTEX_ATTRIBS             0x8869
+#define GL_VERTEX_ATTRIB_ARRAY_ENABLED    0x8622
 
 typedef void (*PFNGLATTACHSHADERPROC) (GLuint program, GLuint shader);
 typedef void (*PFNGLCOMPILESHADERPROC) (GLuint shader);
@@ -142,6 +148,8 @@ typedef void (*PFNGLVERTEXATTRIBPOINTERPROC) (GLuint index, GLint size, GLenum t
 typedef void (*PFNGLGETINTEGERV)(GLenum pname, GLint *data);
 typedef void (*PFNGLGETBOOLEANV)(GLenum pname, GLboolean *data);
 typedef void (*PFNGLFINISHPROC) (void);
+typedef void (*PFNGLGETVERTEXATTRIBIVPROC) (GLuint index, GLenum pname, GLint *params);
+
 
 
 // ---------- OpenGL 3.0 ----------
@@ -155,11 +163,13 @@ typedef void (*PFNGLFINISHPROC) (void);
 #define GL_RGBA32F 0x8814
 #define GL_RGB32F 0x8815
 #define GL_LUMINANCE32F 0x8818
+#define GL_VERTEX_ARRAY_BINDING 0x85B5
 
 // GL_ARB_framebuffer_object
 #define GL_FRAMEBUFFER_COMPLETE 0x8CD5
 #define GL_COLOR_ATTACHMENT0 0x8CE0
 #define GL_FRAMEBUFFER 0x8D40
+#define GL_FRAMEBUFFER_BINDING 0x8CA6
 
 typedef void (*PFNGLBINDFRAMEBUFFERPROC) (GLenum target, GLuint framebuffer);
 typedef GLenum (*PFNGLCHECKFRAMEBUFFERSTATUSPROC) (GLenum target);

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -59,6 +59,7 @@
     GLFUNC(PFNGLDRAWELEMENTSPROC, DrawElements);                        \
     GLFUNC(PFNGLENABLEVERTEXATTRIBARRAYPROC, EnableVertexAttribArray);  \
     GLFUNC(PFNGLDISABLEVERTEXATTRIBARRAYPROC, DisableVertexAttribArray); \
+    GLFUNC(PFNGLGETVERTEXATTRIBIVPROC, GetVertexAttribiv);              \
     GLFUNC(PFNGLPIXELSTOREIPROC, PixelStorei);                          \
     GLFUNC(PFNGLREADPIXELS, ReadPixels);                                \
     GLFUNC(PFNGLGETSTRINGPROC, GetString);                              \
@@ -177,15 +178,6 @@ struct ModuleState {
     ModuleState *next;
 };
 
-// OpenGL state to save and restore before/after
-// running a filter.
-struct SavedGLState {
-    GLint active_texture;
-          GLint program;
-          GLint viewport[4];
-    GLboolean cull_face;
-    GLboolean depth_test;
-};
 
 // All persistent state maintained by the runtime.
 struct GlobalState {
@@ -211,11 +203,6 @@ struct GlobalState {
     // A list of all textures that are still active
     TextureInfo *textures;
 
-    // Saved OpenGL state prior to running filter
-    struct SavedGLState saved_state;
-    void SaveGLState();
-    void RestoreGLState();
-
     // Declare pointers used OpenGL functions
 #define GLFUNC(PTYPE,VAR) PTYPE VAR
     USED_GL_FUNCTIONS;
@@ -233,33 +220,103 @@ WEAK bool GlobalState::CheckAndReportError(void *user_context, const char *locat
     return false;
 }
 
-WEAK void GlobalState::SaveGLState() {
-    this->GetIntegerv(GL_ACTIVE_TEXTURE, &(saved_state.active_texture));
-    this->GetIntegerv(GL_CURRENT_PROGRAM, &(saved_state.program));
-    this->GetIntegerv(GL_VIEWPORT, saved_state.viewport);
-    this->GetBooleanv(GL_CULL_FACE, &(saved_state.cull_face));
-    this->GetBooleanv(GL_DEPTH_TEST, &(saved_state.depth_test));
+WEAK GlobalState global_state;
+
+// Saves & restores OpenGL state
+class GLStateSaver {
+    public:
+
+    GLStateSaver() { save(); }
+    ~GLStateSaver() { restore(); }
+
+    private:
+
+    // The state variables
+    GLint active_texture;
+    GLint array_buffer_binding;
+    GLint element_array_buffer_binding;
+    GLint framebuffer_binding;
+    GLint program;
+    GLint vertex_array_binding;
+    GLint viewport[4];
+    GLboolean cull_face;
+    GLboolean depth_test;
+    int max_combined_texture_image_units;
+    GLint *texture_2d_binding;
+    int max_vertex_attribs;
+    GLint *vertex_attrib_array_enabled;
+
+    // Define these out-of-line as WEAK, to avoid LLVM error "MachO doesn't support COMDATs"
+    void save();
+    void restore();
+};
+
+WEAK void GLStateSaver::save()
+{
+    global_state.GetIntegerv(GL_ACTIVE_TEXTURE, &active_texture);
+    global_state.GetIntegerv(GL_ARRAY_BUFFER_BINDING, &array_buffer_binding);
+    global_state.GetIntegerv(GL_ELEMENT_ARRAY_BUFFER_BINDING, &element_array_buffer_binding);
+    global_state.GetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer_binding);
+    global_state.GetIntegerv(GL_CURRENT_PROGRAM, &program);
+    global_state.GetBooleanv(GL_CULL_FACE, &cull_face);
+    global_state.GetBooleanv(GL_DEPTH_TEST, &depth_test);
+    global_state.GetIntegerv(GL_VIEWPORT, viewport);
+
+    global_state.GetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &max_combined_texture_image_units);
+    texture_2d_binding = (GLint *) malloc(max_combined_texture_image_units * sizeof(GLint));
+    for (int i=0; i < max_combined_texture_image_units; i++) {
+        global_state.ActiveTexture(GL_TEXTURE0 + i);
+        global_state.GetIntegerv(GL_TEXTURE_BINDING_2D, &texture_2d_binding[i]);
+    }
+
+    global_state.GetIntegerv(GL_MAX_VERTEX_ATTRIBS, &max_vertex_attribs);
+    vertex_attrib_array_enabled = (GLint *) malloc(max_vertex_attribs * sizeof(GLint));
+    for (int i=0; i< max_vertex_attribs; i++) {
+        global_state.GetVertexAttribiv(i, GL_VERTEX_ATTRIB_ARRAY_ENABLED, &vertex_attrib_array_enabled[i]);
+    }
+
+    if (global_state.have_vertex_array_objects) {
+        global_state.GetIntegerv(GL_VERTEX_ARRAY_BINDING, &vertex_array_binding);
+    }
 
 #ifdef DEBUG_RUNTIME
     debug(NULL) << "Saved OpenGL state\n";
 #endif
 }
 
-WEAK void GlobalState::RestoreGLState() {
+WEAK void GLStateSaver::restore()
+{
 #ifdef DEBUG_RUNTIME
     debug(NULL) << "Restoring OpenGL state\n";
 #endif
 
-    this->ActiveTexture(saved_state.active_texture);
-    this->UseProgram(saved_state.program);
-    this->Viewport(saved_state.viewport[0], saved_state.viewport[1],
-         saved_state.viewport[2], saved_state.viewport[3]);
-    (saved_state.cull_face ? this->Enable : this->Disable)(GL_CULL_FACE);
-    (saved_state.depth_test ? this->Enable : this->Disable)(GL_DEPTH_TEST);
+    for (int i=0; i < max_combined_texture_image_units; i++) {
+        global_state.ActiveTexture(GL_TEXTURE0 + i);
+        global_state.BindTexture(GL_TEXTURE_2D, texture_2d_binding[i]);
+    }
+    free(texture_2d_binding);
+
+    for (int i=0; i< max_vertex_attribs; i++) {
+        if (vertex_attrib_array_enabled[i])
+            global_state.EnableVertexAttribArray(i);
+        else
+            global_state.DisableVertexAttribArray(i);
+    }
+    free(vertex_attrib_array_enabled);
+
+    if (global_state.have_vertex_array_objects) {
+        global_state.BindVertexArray(vertex_array_binding);
+    }
+
+    global_state.ActiveTexture(active_texture);
+    global_state.BindFramebuffer(GL_FRAMEBUFFER, framebuffer_binding);
+    global_state.BindBuffer(GL_ARRAY_BUFFER, array_buffer_binding);
+    global_state.BindBuffer(GL_ELEMENT_ARRAY_BUFFER, element_array_buffer_binding);
+    global_state.UseProgram(program);
+    global_state.Viewport(viewport[0], viewport[1], viewport[2], viewport[3]);
+    (cull_face ? global_state.Enable : global_state.Disable)(GL_CULL_FACE);
+    (depth_test ? global_state.Enable : global_state.Disable)(GL_DEPTH_TEST);
 }
-
-
-WEAK GlobalState global_state;
 
 // A list of module-specific state. Each module corresponds to a single Halide filter
 WEAK ModuleState *state_list;
@@ -1093,6 +1150,8 @@ WEAK int halide_opengl_copy_to_device(void *user_context, buffer_t *buf) {
         return 1;
     }
 
+    GLStateSaver state_saver;
+
     int err = halide_opengl_device_malloc(user_context, buf);
     if (err) {
         return err;
@@ -1117,12 +1176,6 @@ WEAK int halide_opengl_copy_to_device(void *user_context, buffer_t *buf) {
     if (global_state.CheckAndReportError(user_context, "halide_opengl_copy_to_device BindTexture")) {
         return 1;
     }
-    struct BindTextureCleanup {
-        ~BindTextureCleanup() {
-            global_state.BindTexture(GL_TEXTURE_2D, 0);
-        }
-    } bind_texture_cleanup;
-
     GLint internal_format, format, type;
     if (!get_texture_format(user_context, buf, &internal_format, &format, &type)) {
         error(user_context) << "Invalid texture format";
@@ -1187,6 +1240,8 @@ WEAK int halide_opengl_copy_to_host(void *user_context, buffer_t *buf) {
         return 1;
     }
 
+    GLStateSaver state_saver;
+
     if (!buf->host || !buf->dev) {
         debug_buffer(user_context, buf);
         error(user_context) << "Invalid copy_to_host operation: host or dev NULL";
@@ -1206,13 +1261,6 @@ WEAK int halide_opengl_copy_to_host(void *user_context, buffer_t *buf) {
     }
     GLint texture_channels = buffer_channels;
 
-    // Ensure that Framebuffer is cleaned up regardless of subsequent return point
-    struct FramebufferCleanup {
-        ~FramebufferCleanup() {
-            global_state.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
-            global_state.BindFramebuffer(GL_FRAMEBUFFER, 0);
-        }
-    } framebuffer_cleanup;
 
     uint64_t handle = halide_get_device_handle(buf->dev);
     if (handle != HALIDE_OPENGL_RENDER_TARGET) {
@@ -1355,8 +1403,7 @@ WEAK int halide_opengl_run(void *user_context,
         return 1;
     }
 
-    // save current OpenGL state
-    global_state.SaveGLState();
+    GLStateSaver state_saver;
 
     ModuleState *mod = (ModuleState *)state_ptr;
     if (!mod) {
@@ -1809,34 +1856,13 @@ WEAK int halide_opengl_run(void *user_context,
         return 1;
     }
 
-    for (int i=0;i!=num_packed_attributes;++i) {
-        if (attrib_ids[i] != -1)
-            global_state.DisableVertexAttribArray(attrib_ids[i]);
-    }
-
     // Cleanup
-    for (int i = 0; i < num_active_textures; i++) {
-        global_state.ActiveTexture(GL_TEXTURE0 + i);
-        global_state.BindTexture(GL_TEXTURE_2D, 0);
-    }
-
-    if (bind_render_targets) {
-        global_state.BindFramebuffer(GL_FRAMEBUFFER, 0);
-    }
-
-    global_state.BindBuffer(GL_ARRAY_BUFFER, 0);
-    global_state.BindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-
     if (global_state.have_vertex_array_objects) {
-        global_state.BindVertexArray(0);
         global_state.DeleteVertexArrays(1, &vertex_array_object);
     }
 
     global_state.DeleteBuffers(1, &vertex_buffer_id);
     global_state.DeleteBuffers(1, &element_buffer_id);
-
-    // Restore OpenGL state
-    global_state.RestoreGLState();
 
     return 0;
 }

--- a/test/opengl/save_state.cpp
+++ b/test/opengl/save_state.cpp
@@ -1,0 +1,275 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <cstring>
+
+#if defined(__APPLE__)
+#include <OpenGL/gl.h>
+#else
+#include <GL/gl.h>
+#endif
+
+#include "Halide.h"
+
+// Generates an arbitrary program.
+class Program
+{
+    public:
+
+    static GLuint handle()
+    {
+        const char *vertexShader = " \
+                                    attribute vec4 Position;  \
+                                    attribute vec2 TexCoordIn; \
+                                    varying vec2 TexCoordOut; \
+                                    void main(void) {  \
+                                        gl_Position = Position; \
+                                        TexCoordOut = TexCoordIn; \
+                                    }";
+
+        const char *fragmentShader = " \
+                                      varying vec2 TexCoordOut; \
+                                      uniform sampler2D Texture; \
+                                      void main(void) { \
+                                          gl_FragColor = texture2D(Texture, TexCoordOut); \
+                                      }";
+
+        GLuint handle = glCreateProgram();
+        glAttachShader(handle, compileShader("vertex", vertexShader, GL_VERTEX_SHADER));
+        glAttachShader(handle, compileShader("fragment", fragmentShader, GL_FRAGMENT_SHADER));
+        glLinkProgram(handle);
+
+        GLint linkSuccess;
+        glGetProgramiv(handle, GL_LINK_STATUS, &linkSuccess);
+        if (linkSuccess == GL_FALSE) {
+            GLchar messages[256];
+            glGetProgramInfoLog(handle, sizeof(messages), 0, messages);
+            fprintf(stderr, "Error linking program: %s\n", messages);
+            exit(1);
+        }
+
+        return handle;
+    }
+
+    private:
+
+    static GLuint compileShader(const char *label, const char *shaderString, GLenum shaderType)
+    {
+        const GLuint handle = glCreateShader(shaderType);    
+        const int len = strlen(shaderString);
+        glShaderSource(handle, 1, &shaderString, &len);
+        glCompileShader(handle);
+        GLint compileSuccess;
+        glGetShaderiv(handle, GL_COMPILE_STATUS, &compileSuccess);
+        if (compileSuccess == GL_FALSE) {
+            GLchar messages[256];
+            glGetShaderInfoLog(handle, sizeof(messages), 0, messages);
+            fprintf(stderr, "Error compiling %s shader: %s\n", label, messages);
+            exit(1);
+        }
+        return handle;
+    }
+};
+
+
+// Encapsulates setting OpenGL's state to arbitrary values, and checking
+// whether the state matches those values.
+class KnownState
+{
+    private:
+
+    void gl_enable(GLenum cap, bool state)
+    {
+	(state ? glEnable : glDisable)(cap);
+    }
+
+    GLuint gl_gen(void (*fn)(GLsizei, GLuint *))
+    {
+        GLuint val;
+        (*fn)(1, &val);
+        return val;
+    }
+
+
+    void check_value(const char *operation, const char *label, GLenum pname, GLint initial)
+    {
+	GLint val;
+	glGetIntegerv(pname, &val);
+	if (val != initial) {
+	    fprintf(stderr, "%s did not restore %s: initial value was %d (%#x), current value is %d (%#x)\n", operation, label, initial, initial, val, val);
+	    errors = true;
+	}
+    }
+
+    void check_value(const char *operation, const char *label, GLenum pname, GLenum initial)
+    {
+        check_value(operation, label, pname, (GLint) initial);
+    }
+
+    void check_value(const char *operation, const char *label, GLenum pname, GLint initial[], int n=4)
+    {
+        GLint val[2048];
+        glGetIntegerv(pname, val);
+        for (int i=0; i<n; i++) {
+            if (val[i] != initial[i]) {
+                fprintf(stderr, "%s did not restore %s: initial value was", operation, label);
+                for (int j=0; j<n; j++) fprintf(stderr, " %d", initial[j]);
+                fprintf(stderr, ", current value is");
+                for (int j=0; j<n; j++) fprintf(stderr, " %d", val[j]);
+                fprintf(stderr, "\n");
+                errors = true;
+                return;
+            }
+        }
+    }
+
+    void check_value(const char *operation, const char *label, GLenum pname, bool initial)
+    {
+	GLboolean val;
+	glGetBooleanv(pname, &val);
+	if (val != initial) {
+	    fprintf(stderr, "%s did not restore boolean %s: initial value was %s, current value is %s\n", operation, label, initial ? "true" : "false", val ? "true" : "false");
+	    errors = true;
+	}
+    }
+
+    void check_error(const char *label)
+    {
+	GLenum err = glGetError();
+	if (err != GL_NO_ERROR) {
+	    fprintf(stderr, "Error setting %s: OpenGL error %#x\n", label, err);
+	    errors = true;
+	}
+    }
+
+    GLenum initial_active_texture;
+    GLint initial_viewport[4];
+    GLuint initial_array_buffer_binding;
+    GLuint initial_element_array_buffer_binding;
+    GLuint initial_current_program;
+    GLuint initial_framebuffer_binding;
+    static const int ntextures = 10;
+    GLuint initial_bound_textures[ntextures];
+    bool initial_cull_face;
+    bool initial_depth_test;
+
+    static const int nvertex_attribs = 10;
+    bool initial_vertex_attrib_array_enabled[nvertex_attribs];
+
+#ifdef GL_VERTEX_ARRAY_BINDING
+    GLuint initial_vertex_array_binding;
+#endif
+
+    public:
+
+    bool errors;
+
+    // This sets most values to generated or arbitrary values, which the
+    // halide calls would be unlikely to accidentally use.  But for boolean
+    // values, we want to be sure that halide is really restoring the
+    // initial value, not just setting it to true or false.  So we need to
+    // be able to try both.
+    void setup(bool boolval)
+    {
+        glGenTextures(ntextures, initial_bound_textures);
+        for (int i=0; i<ntextures; i++) {
+            glActiveTexture(GL_TEXTURE0 + i);
+            glBindTexture(GL_TEXTURE_2D, initial_bound_textures[i]);
+        }
+	glActiveTexture(initial_active_texture = GL_TEXTURE3);
+
+        for (int i=0; i<nvertex_attribs; i++) {
+            if ( (initial_vertex_attrib_array_enabled[i] = boolval ) )
+                glEnableVertexAttribArray(i);
+            else
+                glDisableVertexAttribArray(i);
+            char buf[256];
+            sprintf(buf, "vertex attrib array %d state", i);
+            check_error(buf);
+        }
+
+	glUseProgram(initial_current_program = Program::handle());
+	glViewport(initial_viewport[0] = 111, initial_viewport[1] = 222, initial_viewport[2] = 333, initial_viewport[3] = 444);
+	gl_enable(GL_CULL_FACE, initial_cull_face = boolval);
+	gl_enable(GL_DEPTH_TEST, initial_depth_test = boolval);
+	glBindBuffer(GL_ARRAY_BUFFER, initial_array_buffer_binding = gl_gen(glGenBuffers));
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, initial_element_array_buffer_binding = gl_gen(glGenBuffers));
+	glBindFramebuffer(GL_FRAMEBUFFER, initial_framebuffer_binding = gl_gen(glGenFramebuffers));
+
+#ifdef GL_VERTEX_ARRAY_BINDING
+        glBindVertexArray(initial_vertex_array_binding = gl_gen(glGenVertexArrays));
+#endif
+        check_error("known state");
+    }
+
+    void check(const char *operation)
+    {
+	check_value(operation, "ActiveTexture", GL_ACTIVE_TEXTURE, initial_active_texture);
+	check_value(operation, "current program", GL_CURRENT_PROGRAM, initial_current_program);
+	check_value(operation, "framebuffer binding", GL_FRAMEBUFFER_BINDING, initial_framebuffer_binding);
+	check_value(operation, "array buffer binding", GL_ARRAY_BUFFER_BINDING, initial_array_buffer_binding);
+	check_value(operation, "element array buffer binding", GL_ELEMENT_ARRAY_BUFFER_BINDING, initial_element_array_buffer_binding);
+	check_value(operation, "viewport", GL_VIEWPORT, initial_viewport);
+	check_value(operation, "GL_CULL_FACE", GL_CULL_FACE, initial_cull_face);
+	check_value(operation, "GL_DEPTH_TEST", GL_DEPTH_TEST, initial_cull_face);
+
+#ifdef GL_VERTEX_ARRAY_BINDING
+	check_value(operation, "vertex array binding", GL_VERTEX_ARRAY_BINDING, initial_vertex_array_binding);
+#endif
+
+        for (int i=0; i<ntextures; i++) {
+            char buf[100];
+            sprintf(buf, "bound texture (unit %d)", i);
+            glActiveTexture(GL_TEXTURE0 + i);
+            check_value(operation, buf, GL_TEXTURE_BINDING_2D, initial_bound_textures[i]);
+        }
+
+        for (int i=0; i < nvertex_attribs; i++) {
+            int initial = initial_vertex_attrib_array_enabled[i];
+            GLint val;
+            glGetVertexAttribiv(i, GL_VERTEX_ATTRIB_ARRAY_ENABLED, &val);
+            if (val != initial) {
+                fprintf(stderr, "%s did not restore boolean VertexAttributeArrayEnabled(%d): initial value was %s, current value is %s\n", operation, i, initial ? "true" : "false", val ? "true" : "false");
+                errors = true;
+            }
+        }
+    }
+};
+
+using namespace Halide;
+
+int main() {
+    KnownState known_state;
+
+    Image<uint8_t> input(255, 10, 3);
+    Buffer out(UInt(8), 255, 10, 3);
+
+    Var x, y, c;
+    Func g;
+    g(x, y, c) = input(x, y, c);
+    g.bound(c, 0, 3);
+    g.glsl(x, y, c);
+    g.realize(out); // let Halide initialize OpenGL
+
+    known_state.setup(true);
+    g.realize(out);
+    known_state.check("realize");
+
+    known_state.setup(true);
+    out.copy_to_host();
+    known_state.check("copy_to_host");
+
+    known_state.setup(false);
+    g.realize(out);
+    known_state.check("realize");
+
+    known_state.setup(false);
+    out.copy_to_host();
+    known_state.check("copy_to_host");
+
+    if (known_state.errors) {
+	return 1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Avoid clobbering the client's OpenGL state.  This is particularly important when the client wraps textures, to use the Halide filter in the context of a larger OpenGL application.

This PR extends the work done in #1257:

* It saves and restores more state (including: framebuffer binding, array buffer binding, texture binding, active texture, vertex attribute array status)

* It includes a test case

* The implementation now uses RAII style for cleanliness and simplicity

* It replaces previous ad-hoc "cleanups" which bound things to 0 rather than restoring the original values.

The first commit (ec7a096) is a cherry-pick and squash of the commits from #1374 that add linking with OpenGL to the `test_opengl` suite tests and disable building them on travis.   
