### PR TITLE
Add more non-interleaving versions of downcasts

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -224,6 +224,12 @@ void CodeGen_Hexagon::init_module() {
         { IPICK(is_128B, Intrinsic::hexagon_V6_vsb), i16v2,  "sxt.vb",  {i8v1} },
         { IPICK(is_128B, Intrinsic::hexagon_V6_vsh), i32v2,  "sxt.vh",  {i16v1} },
 
+        // Similar to zxt/sxt, but without deinterleaving the result.
+        { IPICK(is_128B, Intrinsic::hexagon_V6_vunpackub), u16v2, "unpack.vub", {u8v1} },
+        { IPICK(is_128B, Intrinsic::hexagon_V6_vunpackuh), u32v2, "unpack.vuh", {u16v1} },
+        { IPICK(is_128B, Intrinsic::hexagon_V6_vunpackb),  i16v2, "unpack.vb",  {i8v1} },
+        { IPICK(is_128B, Intrinsic::hexagon_V6_vunpackh),  i32v2, "unpack.vh",  {i16v1} },
+
         // Truncation:
         // (Yes, there really are two fs in the b versions, and 1 f in
         // the h versions.)
@@ -250,6 +256,7 @@ void CodeGen_Hexagon::init_module() {
         { IPICK(is_128B, Intrinsic::hexagon_V6_vpackeh),      i16v1, "pack.vw",       {i32v2} },
         { IPICK(is_128B, Intrinsic::hexagon_V6_vpackob),      i8v1,  "packhi.vh",     {i16v2} },
         { IPICK(is_128B, Intrinsic::hexagon_V6_vpackoh),      i16v1, "packhi.vw",     {i32v2} },
+
 
         // Adds/subtracts:
         // Note that we just use signed arithmetic for unsigned

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -248,6 +248,8 @@ void CodeGen_Hexagon::init_module() {
         { IPICK(is_128B, Intrinsic::hexagon_V6_vpackwh_sat),  i16v1, "pack_sath.vw",  {i32v2} },
         { IPICK(is_128B, Intrinsic::hexagon_V6_vpackeb),      i8v1,  "pack.vh",       {i16v2} },
         { IPICK(is_128B, Intrinsic::hexagon_V6_vpackeh),      i16v1, "pack.vw",       {i32v2} },
+        { IPICK(is_128B, Intrinsic::hexagon_V6_vpackob),      i8v1,  "packhi.vh",     {i16v2} },
+        { IPICK(is_128B, Intrinsic::hexagon_V6_vpackoh),      i16v1, "packhi.vw",     {i32v2} },
 
         // Adds/subtracts:
         // Note that we just use signed arithmetic for unsigned

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -461,30 +461,33 @@ private:
             { "halide.hexagon.trunc_satuh_shr.vw.w", u16_sat(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
             { "halide.hexagon.trunc_sath_shr.vw.w",  i16_sat(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
 
-            // For these narrowing ops, we have the choice of non-interleaving
-            // instructions (vpack), or instructions which interleave
-            // (vsat). Because we don't know which one we prefer during
-            // pattern matching, we match these for now and replace them with
-            // the instructions that interleave later if it makes sense.
+            // For some of the following narrowing casts, we have the choice of
+            // non-interleaving or interleaving instructions. Because we don't
+            // know which one we prefer during pattern matching, we match the
+            // non-interleaving versions for now and replace them with the
+            // instructions that interleave later if it makes sense.
+
+            // Saturating narrowing casts. These may interleave later with trunc_sat.
             { "halide.hexagon.pack_satub.vh", u8_sat(wild_i16x) },
             { "halide.hexagon.pack_satuh.vw", u16_sat(wild_i32x) },
             { "halide.hexagon.pack_satb.vh", i8_sat(wild_i16x) },
             { "halide.hexagon.pack_sath.vw", i16_sat(wild_i32x) },
 
-            // Narrowing casts
-            { "halide.hexagon.trunclo.vh", u8(wild_u16x/256), Pattern::DeinterleaveOp0 },
-            { "halide.hexagon.trunclo.vh", u8(wild_i16x/256), Pattern::DeinterleaveOp0 },
-            { "halide.hexagon.trunclo.vh", i8(wild_u16x/256), Pattern::DeinterleaveOp0 },
-            { "halide.hexagon.trunclo.vh", i8(wild_i16x/256), Pattern::DeinterleaveOp0 },
-            { "halide.hexagon.trunclo.vw", u16(wild_u32x/65536), Pattern::DeinterleaveOp0 },
-            { "halide.hexagon.trunclo.vw", u16(wild_i32x/65536), Pattern::DeinterleaveOp0 },
-            { "halide.hexagon.trunclo.vw", i16(wild_u32x/65536), Pattern::DeinterleaveOp0 },
-            { "halide.hexagon.trunclo.vw", i16(wild_i32x/65536), Pattern::DeinterleaveOp0 },
+            // Narrowing casts. These may interleave later with trunclo.
+            { "halide.hexagon.packhi.vh", u8(wild_u16x/256) },
+            { "halide.hexagon.packhi.vh", u8(wild_i16x/256) },
+            { "halide.hexagon.packhi.vh", i8(wild_u16x/256) },
+            { "halide.hexagon.packhi.vh", i8(wild_i16x/256) },
+            { "halide.hexagon.packhi.vw", u16(wild_u32x/65536) },
+            { "halide.hexagon.packhi.vw", u16(wild_i32x/65536) },
+            { "halide.hexagon.packhi.vw", i16(wild_u32x/65536) },
+            { "halide.hexagon.packhi.vw", i16(wild_i32x/65536) },
+
+            // Narrowing with shifting.
             { "halide.hexagon.trunc_shr.vw.w",  i16(wild_i32x >> wild_i32), Pattern::DeinterleaveOp0 },
             { "halide.hexagon.trunc_shr.vw.w",  i16(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
 
-            // Similar to saturating narrows above, we have the choice of
-            // non-interleaving or interleaving instructions.
+            // Narrowing casts. These may interleave later with trunc.
             { "halide.hexagon.pack.vh", u8(wild_u16x) },
             { "halide.hexagon.pack.vh", u8(wild_i16x) },
             { "halide.hexagon.pack.vh", i8(wild_u16x) },
@@ -905,6 +908,8 @@ private:
         static std::map<string, DeinterleavingAlternative> deinterleaving_alts = {
             { "halide.hexagon.pack.vh", { "halide.hexagon.trunc.vh" } },
             { "halide.hexagon.pack.vw", { "halide.hexagon.trunc.vw" } },
+            { "halide.hexagon.packhi.vh", { "halide.hexagon.trunclo.vh" } },
+            { "halide.hexagon.packhi.vw", { "halide.hexagon.trunclo.vw" } },
             { "halide.hexagon.pack_satub.vh", { "halide.hexagon.trunc_satub.vh" } },
             { "halide.hexagon.pack_sath.vw", { "halide.hexagon.trunc_sath.vw" } },
             // For this one, we don't have a simple alternative. But,

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -963,7 +963,6 @@ private:
 // otherwise this might eat some interleaves that could have cancelled
 // with other operations.
 class FuseInterleaves : public IRMutator {
-private:
     void visit(const Call *op) {
         // This is a list of {f, g} pairs that if the first operation
         // is interleaved, interleave(f(x)) is equivalent to g(x).

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1323,19 +1323,37 @@ void check_hvx_all() {
     check("valign(v*,v*,r*)", hvx_width/1, in_u16(x + 4));
     check("valign(v*,v*,r*)", hvx_width/1, in_u16(x + hvx_width - 4));
 
-    check("vzxt(v*.ub)", hvx_width/1, u16(u8_1));
-    check("vzxt(v*.ub)", hvx_width/1, i16(u8_1));
-    check("vzxt(v*.uh)", hvx_width/2, u32(u16_1));
-    check("vzxt(v*.uh)", hvx_width/2, i32(u16_1));
-    check("vsxt(v*.b)", hvx_width/1, u16(i8_1));
-    check("vsxt(v*.b)", hvx_width/1, i16(i8_1));
-    check("vsxt(v*.h)", hvx_width/2, u32(i16_1));
-    check("vsxt(v*.h)", hvx_width/2, i32(i16_1));
+    check("vunpack(v*.ub)", hvx_width/1, u16(u8_1));
+    check("vunpack(v*.ub)", hvx_width/1, i16(u8_1));
+    check("vunpack(v*.uh)", hvx_width/2, u32(u16_1));
+    check("vunpack(v*.uh)", hvx_width/2, i32(u16_1));
+    check("vunpack(v*.b)", hvx_width/1, u16(i8_1));
+    check("vunpack(v*.b)", hvx_width/1, i16(i8_1));
+    check("vunpack(v*.h)", hvx_width/2, u32(i16_1));
+    check("vunpack(v*.h)", hvx_width/2, i32(i16_1));
 
-    check("vzxt(v*.ub)", hvx_width/1, u32(u8_1));
-    check("vzxt(v*.ub)", hvx_width/1, i32(u8_1));
-    check("vsxt(v*.b)", hvx_width/1, u32(i8_1));
-    check("vsxt(v*.b)", hvx_width/1, i32(i8_1));
+    check("vunpack(v*.ub)", hvx_width/1, u32(u8_1));
+    check("vunpack(v*.ub)", hvx_width/1, i32(u8_1));
+    check("vunpack(v*.b)", hvx_width/1, u32(i8_1));
+    check("vunpack(v*.b)", hvx_width/1, i32(i8_1));
+
+#if 0
+    // It's quite difficult to write a single expression that tests vzxt
+    // and vsxt, because it gets rewritten as vpack/vunpack.
+    check("vzxt(v*.ub)", hvx_width/1, u16(u8(u16_1)));
+    check("vzxt(v*.ub)", hvx_width/1, i16(u8(u16_1)));
+    check("vzxt(v*.uh)", hvx_width/2, u32(u16(u32_1)));
+    check("vzxt(v*.uh)", hvx_width/2, i32(u16(u32_1)));
+    check("vsxt(v*.b)", hvx_width/1, u16(i8(i16_1)));
+    check("vsxt(v*.b)", hvx_width/1, i16(i8(i16_1)));
+    check("vsxt(v*.h)", hvx_width/2, u32(i16(i32_1)));
+    check("vsxt(v*.h)", hvx_width/2, i32(i16(i32_1)));
+
+    check("vzxt(v*.ub)", hvx_width/1, u32(u8(u32_1)));
+    check("vzxt(v*.ub)", hvx_width/1, i32(u8(u32_1)));
+    check("vsxt(v*.b)", hvx_width/1, u32(i8(i32_1)));
+    check("vsxt(v*.b)", hvx_width/1, i32(i8(i32_1)));
+#endif
 
     check("vadd(v*.b,v*.b)", hvx_width/1, u8_1 + u8_2);
     check("vadd(v*.h,v*.h)", hvx_width/2, u16_1 + u16_2);
@@ -1489,6 +1507,7 @@ void check_hvx_all() {
     check("v*.b = vpack(v*.h,v*.h):sat", hvx_width/1, i8_sat(i16_1));
     check("v*.uh = vpack(v*.w,v*.w):sat", hvx_width/2, u16_sat(i32_1));
     check("v*.h = vpack(v*.w,v*.w):sat", hvx_width/2, i16_sat(i32_1));
+
     // vpack doesn't interleave its inputs, which means it doesn't
     // simplify with widening. This is preferable for when the
     // pipeline doesn't widen to begin with, as in the above

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1453,22 +1453,22 @@ void check_hvx_all() {
     // different instructions that have a built in interleaving that
     // we can cancel with the deinterleaving from widening.
     check("vshuffe(v*.b,v*.b)", hvx_width/1, u8(u16(u8_1) * 127));
-    check("vshuffe(v*.b,v*.b)", hvx_width/1, u8(i16(i8_1) * 127));
+    check("vshuffe(v*.b,v*.b)", hvx_width/1, u8(i16(i8_1) * 63));
     check("vshuffe(v*.b,v*.b)", hvx_width/1, i8(u16(u8_1) * 127));
-    check("vshuffe(v*.b,v*.b)", hvx_width/1, i8(i16(i8_1) * 127));
+    check("vshuffe(v*.b,v*.b)", hvx_width/1, i8(i16(i8_1) * 63));
     check("vshuffe(v*.h,v*.h)", hvx_width/2, u16(u32(u16_1) * 32767));
-    check("vshuffe(v*.h,v*.h)", hvx_width/2, u16(i32(i16_1) * 32767));
+    check("vshuffe(v*.h,v*.h)", hvx_width/2, u16(i32(i16_1) * 16383));
     check("vshuffe(v*.h,v*.h)", hvx_width/2, i16(u32(u16_1) * 32767));
-    check("vshuffe(v*.h,v*.h)", hvx_width/2, i16(i32(i16_1) * 32767));
+    check("vshuffe(v*.h,v*.h)", hvx_width/2, i16(i32(i16_1) * 16383));
 
     check("vshuffo(v*.b,v*.b)", hvx_width/1, u8((u16(u8_1) * 127) >> 8));
-    check("vshuffo(v*.b,v*.b)", hvx_width/1, u8((i16(i8_1) * 127) >> 8));
+    check("vshuffo(v*.b,v*.b)", hvx_width/1, u8((i16(i8_1) * 63) >> 8));
     check("vshuffo(v*.b,v*.b)", hvx_width/1, i8((u16(u8_1) * 127) >> 8));
-    check("vshuffo(v*.b,v*.b)", hvx_width/1, i8((i16(i8_1) * 127) >> 8));
+    check("vshuffo(v*.b,v*.b)", hvx_width/1, i8((i16(i8_1) * 63) >> 8));
     check("vshuffo(v*.h,v*.h)", hvx_width/2, u16((u32(u16_1) * 32767) >> 16));
-    check("vshuffo(v*.h,v*.h)", hvx_width/2, u16((i32(i16_1) * 32767) >> 16));
+    check("vshuffo(v*.h,v*.h)", hvx_width/2, u16((i32(i16_1) * 16383) >> 16));
     check("vshuffo(v*.h,v*.h)", hvx_width/2, i16((u32(u16_1) * 32767) >> 16));
-    check("vshuffo(v*.h,v*.h)", hvx_width/2, i16((i32(i16_1) * 32767) >> 16));
+    check("vshuffo(v*.h,v*.h)", hvx_width/2, i16((i32(i16_1) * 16383) >> 16));
 
     check("vpacke(v*.h,v*.h)", hvx_width/1, in_u8(2*x));
     check("vpacke(v*.w,v*.w)", hvx_width/2, in_u16(2*x));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1437,6 +1437,15 @@ void check_hvx_all() {
     check("vpacke(v*.w,v*.w)", hvx_width/2, i16(u32_1));
     check("vpacke(v*.w,v*.w)", hvx_width/2, i16(i32_1));
 
+    check("vpacko(v*.h,v*.h)", hvx_width/1, u8(u16_1 >> 8));
+    check("vpacko(v*.h,v*.h)", hvx_width/1, u8(i16_1 >> 8));
+    check("vpacko(v*.h,v*.h)", hvx_width/1, i8(u16_1 >> 8));
+    check("vpacko(v*.h,v*.h)", hvx_width/1, i8(i16_1 >> 8));
+    check("vpacko(v*.w,v*.w)", hvx_width/2, u16(u32_1 >> 16));
+    check("vpacko(v*.w,v*.w)", hvx_width/2, u16(i32_1 >> 16));
+    check("vpacko(v*.w,v*.w)", hvx_width/2, i16(u32_1 >> 16));
+    check("vpacko(v*.w,v*.w)", hvx_width/2, i16(i32_1 >> 16));
+
     // vpack doesn't interleave its inputs, which means it doesn't
     // simplify with widening. This is preferable for when the
     // pipeline doesn't widen to begin with, as in the above
@@ -1452,14 +1461,14 @@ void check_hvx_all() {
     check("vshuffe(v*.h,v*.h)", hvx_width/2, i16(u32(u16_1) << 8));
     check("vshuffe(v*.h,v*.h)", hvx_width/2, i16(i32(i16_1) << 8));
 
-    check("vshuffo(v*.b,v*.b)", hvx_width/1, u8(u16_1 >> 8));
-    check("vshuffo(v*.b,v*.b)", hvx_width/1, u8(i16_1 >> 8));
-    check("vshuffo(v*.b,v*.b)", hvx_width/1, i8(u16_1 >> 8));
-    check("vshuffo(v*.b,v*.b)", hvx_width/1, i8(i16_1 >> 8));
-    check("vshuffo(v*.h,v*.h)", hvx_width/2, u16(u32_1 >> 16));
-    check("vshuffo(v*.h,v*.h)", hvx_width/2, u16(i32_1 >> 16));
-    check("vshuffo(v*.h,v*.h)", hvx_width/2, i16(u32_1 >> 16));
-    check("vshuffo(v*.h,v*.h)", hvx_width/2, i16(i32_1 >> 16));
+    check("vshuffo(v*.b,v*.b)", hvx_width/1, u8((u16(u8_1) + 1) >> 8));
+    check("vshuffo(v*.b,v*.b)", hvx_width/1, u8((i16(i8_1) + 1) >> 8));
+    check("vshuffo(v*.b,v*.b)", hvx_width/1, i8((u16(u8_1) + 1) >> 8));
+    check("vshuffo(v*.b,v*.b)", hvx_width/1, i8((i16(i8_1) + 1) >> 8));
+    check("vshuffo(v*.h,v*.h)", hvx_width/2, u16((u32(u16_1) + 1) >> 16));
+    check("vshuffo(v*.h,v*.h)", hvx_width/2, u16((i32(i16_1) + 1) >> 16));
+    check("vshuffo(v*.h,v*.h)", hvx_width/2, i16((u32(u16_1) + 1) >> 16));
+    check("vshuffo(v*.h,v*.h)", hvx_width/2, i16((i32(i16_1) + 1) >> 16));
 
     check("vpacke(v*.h,v*.h)", hvx_width/1, in_u8(2*x));
     check("vpacke(v*.w,v*.w)", hvx_width/2, in_u16(2*x));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1452,23 +1452,23 @@ void check_hvx_all() {
     // tests. However, if the pipeline does widen, we want to generate
     // different instructions that have a built in interleaving that
     // we can cancel with the deinterleaving from widening.
-    check("vshuffe(v*.b,v*.b)", hvx_width/1, u8(u16(u8_1) << 4));
-    check("vshuffe(v*.b,v*.b)", hvx_width/1, u8(i16(i8_1) << 4));
-    check("vshuffe(v*.b,v*.b)", hvx_width/1, i8(u16(u8_1) << 4));
-    check("vshuffe(v*.b,v*.b)", hvx_width/1, i8(i16(i8_1) << 4));
-    check("vshuffe(v*.h,v*.h)", hvx_width/2, u16(u32(u16_1) << 8));
-    check("vshuffe(v*.h,v*.h)", hvx_width/2, u16(i32(i16_1) << 8));
-    check("vshuffe(v*.h,v*.h)", hvx_width/2, i16(u32(u16_1) << 8));
-    check("vshuffe(v*.h,v*.h)", hvx_width/2, i16(i32(i16_1) << 8));
+    check("vshuffe(v*.b,v*.b)", hvx_width/1, u8(u16(u8_1) * 127));
+    check("vshuffe(v*.b,v*.b)", hvx_width/1, u8(i16(i8_1) * 127));
+    check("vshuffe(v*.b,v*.b)", hvx_width/1, i8(u16(u8_1) * 127));
+    check("vshuffe(v*.b,v*.b)", hvx_width/1, i8(i16(i8_1) * 127));
+    check("vshuffe(v*.h,v*.h)", hvx_width/2, u16(u32(u16_1) * 32767));
+    check("vshuffe(v*.h,v*.h)", hvx_width/2, u16(i32(i16_1) * 32767));
+    check("vshuffe(v*.h,v*.h)", hvx_width/2, i16(u32(u16_1) * 32767));
+    check("vshuffe(v*.h,v*.h)", hvx_width/2, i16(i32(i16_1) * 32767));
 
-    check("vshuffo(v*.b,v*.b)", hvx_width/1, u8((u16(u8_1) + 1) >> 8));
-    check("vshuffo(v*.b,v*.b)", hvx_width/1, u8((i16(i8_1) + 1) >> 8));
-    check("vshuffo(v*.b,v*.b)", hvx_width/1, i8((u16(u8_1) + 1) >> 8));
-    check("vshuffo(v*.b,v*.b)", hvx_width/1, i8((i16(i8_1) + 1) >> 8));
-    check("vshuffo(v*.h,v*.h)", hvx_width/2, u16((u32(u16_1) + 1) >> 16));
-    check("vshuffo(v*.h,v*.h)", hvx_width/2, u16((i32(i16_1) + 1) >> 16));
-    check("vshuffo(v*.h,v*.h)", hvx_width/2, i16((u32(u16_1) + 1) >> 16));
-    check("vshuffo(v*.h,v*.h)", hvx_width/2, i16((i32(i16_1) + 1) >> 16));
+    check("vshuffo(v*.b,v*.b)", hvx_width/1, u8((u16(u8_1) * 127) >> 8));
+    check("vshuffo(v*.b,v*.b)", hvx_width/1, u8((i16(i8_1) * 127) >> 8));
+    check("vshuffo(v*.b,v*.b)", hvx_width/1, i8((u16(u8_1) * 127) >> 8));
+    check("vshuffo(v*.b,v*.b)", hvx_width/1, i8((i16(i8_1) * 127) >> 8));
+    check("vshuffo(v*.h,v*.h)", hvx_width/2, u16((u32(u16_1) * 32767) >> 16));
+    check("vshuffo(v*.h,v*.h)", hvx_width/2, u16((i32(i16_1) * 32767) >> 16));
+    check("vshuffo(v*.h,v*.h)", hvx_width/2, i16((u32(u16_1) * 32767) >> 16));
+    check("vshuffo(v*.h,v*.h)", hvx_width/2, i16((i32(i16_1) * 32767) >> 16));
 
     check("vpacke(v*.h,v*.h)", hvx_width/1, in_u8(2*x));
     check("vpacke(v*.w,v*.w)", hvx_width/2, in_u16(2*x));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1340,19 +1340,19 @@ void check_hvx_all() {
 #if 0
     // It's quite difficult to write a single expression that tests vzxt
     // and vsxt, because it gets rewritten as vpack/vunpack.
-    check("vzxt(v*.ub)", hvx_width/1, u16(u8(u16_1)));
-    check("vzxt(v*.ub)", hvx_width/1, i16(u8(u16_1)));
-    check("vzxt(v*.uh)", hvx_width/2, u32(u16(u32_1)));
-    check("vzxt(v*.uh)", hvx_width/2, i32(u16(u32_1)));
-    check("vsxt(v*.b)", hvx_width/1, u16(i8(i16_1)));
-    check("vsxt(v*.b)", hvx_width/1, i16(i8(i16_1)));
-    check("vsxt(v*.h)", hvx_width/2, u32(i16(i32_1)));
-    check("vsxt(v*.h)", hvx_width/2, i32(i16(i32_1)));
+    check("vzxt(v*.ub)", hvx_width/1, u16(u8_1));
+    check("vzxt(v*.ub)", hvx_width/1, i16(u8_1));
+    check("vzxt(v*.uh)", hvx_width/2, u32(u16_1));
+    check("vzxt(v*.uh)", hvx_width/2, i32(u16_1));
+    check("vsxt(v*.b)", hvx_width/1, u16(i8_1));
+    check("vsxt(v*.b)", hvx_width/1, i16(i8_1));
+    check("vsxt(v*.h)", hvx_width/2, u32(i16_1));
+    check("vsxt(v*.h)", hvx_width/2, i32(i16_1));
 
-    check("vzxt(v*.ub)", hvx_width/1, u32(u8(u32_1)));
-    check("vzxt(v*.ub)", hvx_width/1, i32(u8(u32_1)));
-    check("vsxt(v*.b)", hvx_width/1, u32(i8(i32_1)));
-    check("vsxt(v*.b)", hvx_width/1, i32(i8(i32_1)));
+    check("vzxt(v*.ub)", hvx_width/1, u32(u8_1));
+    check("vzxt(v*.ub)", hvx_width/1, i32(u8_1));
+    check("vsxt(v*.b)", hvx_width/1, u32(i8_1));
+    check("vsxt(v*.b)", hvx_width/1, i32(i8_1));
 #endif
 
     check("vadd(v*.b,v*.b)", hvx_width/1, u8_1 + u8_2);


### PR DESCRIPTION
This PR adds patterns for Hexagon to use vpacko, which take the upper half of a wider type, without interleaving. The deinterleaving versions are still generated when it is more efficient to do so (it can cancel out an interleave).