### PR TITLE
Handle the rewrite of multiple identical loads in Loop Carry.

### DIFF
--- a/src/LoopCarry.cpp
+++ b/src/LoopCarry.cpp
@@ -267,8 +267,9 @@ class LoopCarryOverLoop : public IRMutator {
             if (!safe) continue;
 
             bool represented = false;
-            for (const vector<const Load *> &v : loads) {
+            for (vector<const Load *> &v : loads) {
                 if (graph_equal(Expr(load), Expr(v[0]))) {
+                    v.push_back(load);
                     represented = true;
                 }
             }


### PR DESCRIPTION
Suppose we have more than one identical load in a for loop that
are identical, then we should group them together so that if we
ecide to replace them with a load from a scratch buffer, we'll be
able to replace all of these identical loads.

@abadams @dsharletg : PTAL.