### PR TITLE
User OpenGL state check

### DIFF
--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -662,6 +662,10 @@ WEAK const char *parse_opengl_version(const char *str, int *major, int *minor) {
 // Initialize the OpenGL-specific parts of the runtime.
 WEAK int halide_opengl_init(void *user_context) {
     if (global_state.initialized) {
+        // Check if the user put OpenGL in error state before/between Halide calls
+        if (global_state.CheckAndReportError(user_context, "user OpenGL state")) {
+            return 1;
+        }
         return 0;
     }
 
@@ -708,6 +712,12 @@ WEAK int halide_opengl_init(void *user_context) {
         << "  texture_rg: " << (global_state.have_texture_rg ? "yes\n" : "no\n")
         << "  have_texture_rgb8_rgba8: " << (global_state.have_texture_rgb8_rgba8 ? "yes\n" : "no\n")
         << "  texture_float: " << (global_state.have_texture_float ? "yes\n" : "no\n");
+
+    // Check if [user-provided] halide_opengl_create_context() left OpenGL
+    // in error state.
+    if (global_state.CheckAndReportError(user_context, "user OpenGL state")) {
+        return 1;
+    }
 
     // Initialize framebuffer.
     global_state.GenFramebuffers(1, &global_state.framebuffer_id);

--- a/test/opengl/user_state_check.cpp
+++ b/test/opengl/user_state_check.cpp
@@ -1,3 +1,13 @@
+// Test doesn't build on windows, because OpenGL on windows is a nightmare.
+#ifdef _WIN32
+#include <stdio.h>
+int main() {
+    printf("Skipping test on Windows\n");
+    return 0;
+}
+#else // not _WIN32
+
+
 #include <csetjmp>
 #include <unistd.h>
 
@@ -80,3 +90,5 @@ int main()
     printf("Success!\n");
     return 0;
 }
+
+#endif // not _WIN32

--- a/test/opengl/user_state_check.cpp
+++ b/test/opengl/user_state_check.cpp
@@ -1,0 +1,82 @@
+#include <csetjmp>
+#include <unistd.h>
+
+#if defined(__APPLE__)
+#include <OpenGL/gl.h>
+#else
+#include <GL/gl.h>
+#endif
+
+#include "Halide.h"
+#include "HalideRuntimeOpenGL.h"
+
+std::string error_message;
+
+/*
+** Don't rely on func.set_error_handler() mechanism, it doesn't seem to catch
+** the user OpenGL state errors. That might be a separate bug.
+*/
+jmp_buf env;
+void on_sigabrt (int signum)
+{
+  longjmp (env, 1);
+}
+void catching_stderr_abort(std::function<void ()> func)
+{
+    auto ferr = tmpfile();
+    auto prev_stderr = dup(2);
+    dup2(fileno(ferr), 2);
+    if (setjmp (env) == 0) {
+        auto prev_handler = signal(SIGABRT, &on_sigabrt);
+        (func)();
+        signal(SIGABRT, prev_handler);
+    }
+    fseek(ferr, 0, SEEK_END);
+    error_message.resize(ftell(ferr));
+    rewind(ferr);
+    fread(&error_message[0], 1, error_message.size(), ferr);
+    dup2(prev_stderr, 2);
+    close(prev_stderr);
+}
+
+using namespace Halide;
+
+int main()
+{
+    // This test must be run with an OpenGL target
+    const Target &target = get_jit_target_from_environment();
+    if (!target.has_feature(Target::OpenGL))  {
+        fprintf(stderr,"ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
+        return 1;
+    }
+
+    Image<uint8_t> output(255, 10, 3);
+
+    Var x, y, c;
+    Func g;
+    g(x, y, c) = Halide::cast<uint8_t>(255);
+    g.bound(c, 0, 3);
+    g.glsl(x, y, c);
+
+    // Let Halide initialize OpenGL
+    g.realize(output);
+
+    // Bad OpenGL call leaves OpenGL in a bad state
+    glEnableVertexAttribArray(-1);
+
+    // Halide should report that the OpenGL context is in a bad state due to user code`
+    catching_stderr_abort( [&] () { g.realize(output); } );
+
+    if (error_message.empty()) {
+        fprintf(stderr, "Failed to report error in user OpenGL state\n");
+        return 1;
+    }
+    else if (error_message.find("user OpenGL state") == std::string::npos) {
+        error_message.erase(error_message.size() - 1); // remove trailing newline
+        fprintf(stderr, "Reported error '%s' rather than identifying error at 'user OpenGL state'\n", error_message.c_str());
+        return 1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
It comes up reasonably often that a user gets tripped up when Halide reports a mystery OpenGL error, such as: `Error: OpenGL error GL_INVALID_ENUM(1280) at halide_opengl_init GenFramebuffers.`.  It seems like an internal error in Halide, and in some cases it can be extra mysterious because of things like (as in this case) `GL_ENVALID_ENUM` isn't even a documented error for `glGenFramebuffers`.

Those cases often turn out that the user made an OpenGL error and didn't check it using `glGetError()` -- so the OpenGL error flag remains set, and next time Halide performs an operation (which doesn't fail) then calls `glGetError()`, Halide gets the user's error and reports it as its own.

This PR addresses that by having Halide call glGetError() on initial entry, and report the error as "user OpenGL state".  This PR includes a test case as well as the implementation.

Three notes:

* The wording of the error is  `Error: OpenGL error GL_INVALID_VALUE(1281) at user OpenGL state.`  If there's a better way of phrasing "user OpenGL state" to make it more clear I'm happy to improve it.

* The backend code includes checks for errors before/between Halide calls, and also checks if a user-provided `halide_opengl_create_context()` function left OpenGL in an error state.  Unfortunately there doesn't seem to be a way to override `halide_opengl_create_context()` in JIT mode so that case isn't tested.

* It seems that `func.set_error_handler()` doesn't actually handle these errors, so the test checks  for stderr & SIGABRT.   Probably a separate bug should be filed for `func.set_error_handler()` once this PR is merged.



(cc @shoaibkamil)