### PR TITLE
Align bounds

### DIFF
--- a/src/AllocationBoundsInference.cpp
+++ b/src/AllocationBoundsInference.cpp
@@ -86,6 +86,17 @@ class AllocationInference : public IRMutator {
                 max = b[i].max;
                 extent = simplify((max - min) + 1);
             }
+            if (bound.modulus.defined()) {
+                internal_assert(bound.remainder.defined());
+                min -= bound.remainder;
+                min = (min / bound.modulus) * bound.modulus;
+                min += bound.remainder;
+                Expr max_plus_one = max + 1;
+                max_plus_one -= bound.remainder;
+                max_plus_one = ((max_plus_one + bound.modulus - 1) / bound.modulus) * bound.modulus;
+                max_plus_one += bound.remainder;
+                extent = simplify(max_plus_one - min);
+            }
 
             Expr min_var = Variable::make(Int(32), min_name);
             Expr max_var = Variable::make(Int(32), max_name);

--- a/src/AllocationBoundsInference.cpp
+++ b/src/AllocationBoundsInference.cpp
@@ -96,6 +96,7 @@ class AllocationInference : public IRMutator {
                 max_plus_one = ((max_plus_one + bound.modulus - 1) / bound.modulus) * bound.modulus;
                 max_plus_one += bound.remainder;
                 extent = simplify(max_plus_one - min);
+                max = max_plus_one - 1;
             }
 
             Expr min_var = Variable::make(Int(32), min_name);

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1656,6 +1656,9 @@ Func &Func::align_bounds(Var var, Expr modulus, Expr remainder) {
     modulus = cast<int32_t>(modulus);
     remainder = cast<int32_t>(remainder);
 
+    // Reduce the remainder
+    remainder = remainder % modulus;
+
     invalidate_cache();
 
     bool found = false;

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1638,13 +1638,22 @@ Func &Func::bound(Var var, Expr min, Expr extent) {
         << " because " << var.name()
         << " is not one of the pure variables of " << name() << ".\n";
 
-    Bound b = {var.name(), min, extent};
+    Bound b = {var.name(), min, extent, Expr(), Expr()};
     func.schedule().bounds().push_back(b);
     return *this;
 }
 
 Func &Func::bound_extent(Var var, Expr extent) {
     return bound(var, Expr(), extent);
+}
+
+Func &Func::align_bounds(Var var, Expr modulus, Expr remainder) {
+    // TODO: error checking
+    invalidate_cache();
+
+    Bound b = {var.name(), Expr(), Expr(), modulus, remainder};
+    func.schedule().bounds().push_back(b);
+    return *this;
 }
 
 Func &Func::tile(VarOrRVar x, VarOrRVar y,

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1648,8 +1648,27 @@ Func &Func::bound_extent(Var var, Expr extent) {
 }
 
 Func &Func::align_bounds(Var var, Expr modulus, Expr remainder) {
-    // TODO: error checking
+    user_assert(modulus.defined()) << "modulus is undefined\n";
+    user_assert(remainder.defined()) << "remainder is undefined\n";
+    user_assert(Int(32).can_represent(modulus.type())) << "Can't represent modulus as int32\n";
+    user_assert(Int(32).can_represent(remainder.type())) << "Can't represent remainder as int32\n";
+
+    modulus = cast<int32_t>(modulus);
+    remainder = cast<int32_t>(remainder);
+
     invalidate_cache();
+
+    bool found = false;
+    for (size_t i = 0; i < func.args().size(); i++) {
+        if (var.name() == func.args()[i]) {
+            found = true;
+        }
+    }
+    user_assert(found)
+        << "Can't align bounds of variable " << var.name()
+        << " of function " << name()
+        << " because " << var.name()
+        << " is not one of the pure variables of " << name() << ".\n";
 
     Bound b = {var.name(), Expr(), Expr(), modulus, remainder};
     func.schedule().bounds().push_back(b);

--- a/src/Func.h
+++ b/src/Func.h
@@ -1084,6 +1084,14 @@ public:
      * runtime error will occur when you try to run your pipeline. */
     EXPORT Func &bound(Var var, Expr min, Expr extent);
 
+    /** Expand the region computed so that the min coordinates is
+     * congruent to 'remainder' modulo 'modulus', and the extent is a
+     * multiple of 'modulus'. For example, f.align_bounds(x, 2) forces
+     * the min and extent realized to be even, and calling
+     * f.align_bounds(x, 2, 1) forces the min to be odd and the extent
+     * to be even. The region computed always contains the region that
+     * would have been computed without this directive, so no
+     * assertions are injected. */
     EXPORT Func &align_bounds(Var var, Expr modulus, Expr remainder = 0);
 
     /** Bound the extent of a Func's realization, but not its

--- a/src/Func.h
+++ b/src/Func.h
@@ -1084,6 +1084,8 @@ public:
      * runtime error will occur when you try to run your pipeline. */
     EXPORT Func &bound(Var var, Expr min, Expr extent);
 
+    EXPORT Func &align_bounds(Var var, Expr modulus, Expr remainder = 0);
+
     /** Bound the extent of a Func's realization, but not its
      * min. This means the dimension can be unrolled or vectorized
      * even when its min is not fixed (for example because it is

--- a/src/Inline.cpp
+++ b/src/Inline.cpp
@@ -76,13 +76,20 @@ class Inliner : public IRMutator {
         }
 
         for (size_t i = 0; i < s.bounds().size(); i++) {
-            user_warning << "It is meaningless to bound dimension "
-                         << s.bounds()[i].var << " of function "
-                         << f.name() << " to be within ["
-                         << s.bounds()[i].min << ", "
-                         << s.bounds()[i].extent << "] because the function is scheduled inline.\n";
+            if (s.bounds()[i].min.defined()) {
+                user_warning << "It is meaningless to bound dimension "
+                             << s.bounds()[i].var << " of function "
+                             << f.name() << " to be within ["
+                             << s.bounds()[i].min << ", "
+                             << s.bounds()[i].extent << "] because the function is scheduled inline.\n";
+            } else if (s.bounds()[i].modulus.defined()) {
+                user_warning << "It is meaningless to align the bounds of dimension "
+                             << s.bounds()[i].var << " of function "
+                             << f.name() << " to have modulus/remainder ["
+                             << s.bounds()[i].modulus << ", "
+                             << s.bounds()[i].remainder << "] because the function is scheduled inline.\n";
+            }
         }
-
     }
 
     void visit(const Call *op) {

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -51,6 +51,12 @@ struct ScheduleContents {
             if (b.extent.defined()) {
                 b.extent = mutator->mutate(b.extent);
             }
+            if (b.modulus.defined()) {
+                b.modulus = mutator->mutate(b.modulus);
+            }
+            if (b.remainder.defined()) {
+                b.remainder = mutator->mutate(b.remainder);
+            }
         }
     }
 };

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -228,6 +228,12 @@ void Schedule::accept(IRVisitor *visitor) const {
         if (b.extent.defined()) {
             b.extent.accept(visitor);
         }
+        if (b.modulus.defined()) {
+            b.modulus.accept(visitor);
+        }
+        if (b.remainder.defined()) {
+            b.remainder.accept(visitor);
+        }
     }
 }
 

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -243,8 +243,9 @@ public:
     std::vector<StorageDim> &storage_dims();
     // @}
 
-    /** You may explicitly bound some of the dimensions of a
-     * function. See \ref Func::bound */
+    /** You may explicitly bound some of the dimensions of a function,
+     * or constrain them to lie on multiples of a given factor. See
+     * \ref Func::bound and \ref Func::align_bounds */
     // @{
     const std::vector<Bound> &bounds() const;
     std::vector<Bound> &bounds();

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -155,7 +155,7 @@ struct Dim {
 
 struct Bound {
     std::string var;
-    Expr min, extent;
+    Expr min, extent, modulus, remainder;
 };
 
 struct ScheduleContents;

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -73,21 +73,24 @@ Stmt build_provide_loop_nest_helper(string func_name,
     // Make the (multi-dimensional multi-valued) store node.
     Stmt stmt = Provide::make(func_name, values, site);
 
-    // The dimensions for which we have a known static size.
-    map<string, Expr> known_size_dims;
+    // A map of the dimensions for which we know the extent is a
+    // multiple of some Expr. This can happen due to a bound, or
+    // align_bounds directive, or if a dim comes from the inside
+    // of a split.
+    map<string, Expr> dim_extent_alignment;
 
     // First hunt through the bounds for them.
     for (const Bound &i : s.bounds()) {
         if (i.extent.defined()) {
-            known_size_dims[i.var] = i.extent;
+            dim_extent_alignment[i.var] = i.extent;
         }
         if (i.modulus.defined()) {
-            known_size_dims[i.var] = i.modulus;
+            dim_extent_alignment[i.var] = i.modulus;
         }
     }
     // Then use any reduction domain.
     for (const ReductionVariable &i : s.rvars()) {
-        known_size_dims[i.var] = i.extent;
+        dim_extent_alignment[i.var] = i.extent;
     }
 
     vector<Split> splits = s.splits();
@@ -102,7 +105,7 @@ Stmt build_provide_loop_nest_helper(string func_name,
             Expr old_min = Variable::make(Int(32), prefix + split.old_var + ".loop_min");
             Expr old_extent = Variable::make(Int(32), prefix + split.old_var + ".loop_extent");
 
-            known_size_dims[split.inner] = split.factor;
+            dim_extent_alignment[split.inner] = split.factor;
 
             Expr base = outer * split.factor + old_min;
             string base_name = prefix + split.inner + ".base";
@@ -110,7 +113,7 @@ Stmt build_provide_loop_nest_helper(string func_name,
             string old_var_name = prefix + split.old_var;
             Expr old_var = Variable::make(Int(32), old_var_name);
 
-            map<string, Expr>::iterator iter = known_size_dims.find(split.old_var);
+            map<string, Expr>::iterator iter = dim_extent_alignment.find(split.old_var);
 
             if (is_update) {
                 user_assert(split.tail != TailStrategy::ShiftInwards)
@@ -138,12 +141,12 @@ Stmt build_provide_loop_nest_helper(string func_name,
                 }
             }
 
-            if ((iter != known_size_dims.end()) &&
+            if ((iter != dim_extent_alignment.end()) &&
                 is_zero(simplify(iter->second % split.factor))) {
                 // We have proved that the split factor divides the
                 // old extent. No need to adjust the base or add an if
                 // statement.
-                known_size_dims[split.outer] = iter->second / split.factor;
+                dim_extent_alignment[split.outer] = iter->second / split.factor;
             } else if (is_negative_const(split.factor) || is_zero(split.factor)) {
                 user_error << "Can't split " << split.old_var << " by " << split.factor
                            << ". Split factors must be strictly positive\n";
@@ -213,11 +216,11 @@ Stmt build_provide_loop_nest_helper(string func_name,
 
             // Maintain the known size of the fused dim if
             // possible. This is important for possible later splits.
-            map<string, Expr>::iterator inner_dim = known_size_dims.find(split.inner);
-            map<string, Expr>::iterator outer_dim = known_size_dims.find(split.outer);
-            if (inner_dim != known_size_dims.end() &&
-                outer_dim != known_size_dims.end()) {
-                known_size_dims[split.old_var] = inner_dim->second*outer_dim->second;
+            map<string, Expr>::iterator inner_dim = dim_extent_alignment.find(split.inner);
+            map<string, Expr>::iterator outer_dim = dim_extent_alignment.find(split.outer);
+            if (inner_dim != dim_extent_alignment.end() &&
+                outer_dim != dim_extent_alignment.end()) {
+                dim_extent_alignment[split.old_var] = inner_dim->second*outer_dim->second;
             }
         } else {
             // rename or purify

--- a/test/correctness/align_bounds.cpp
+++ b/test/correctness/align_bounds.cpp
@@ -12,38 +12,133 @@ public:
     bool result = false;
 };
 
+int trace_min, trace_extent;
+int my_trace(void *user_context, const halide_trace_event *e) {
+    if (e->event == 2) {
+        trace_min = e->coordinates[0];
+        trace_extent = e->coordinates[1];
+    }
+    return 0;
+}
 
 int main(int argc, char **argv) {
-    Func f, g, h;
-    Var x;
+    // Force the bounds of an intermediate pipeline stage to be even to remove a select
+    {
+        Func f, g, h;
+        Var x;
 
-    f(x) = 3;
+        f(x) = 3;
 
-    g(x) = select(x % 2 == 0, f(x+1), f(x-1)+8);
+        g(x) = select(x % 2 == 0, f(x+1), f(x-1)+8);
 
-    Param<int> p;
-    h(x) = g(x-p) + g(x+p);
+        Param<int> p;
+        h(x) = g(x-p) + g(x+p);
 
-    f.compute_root();
-    g.compute_root().align_bounds(x, 2).unroll(x, 2);
+        f.compute_root();
+        g.compute_root().align_bounds(x, 2).unroll(x, 2).trace_realizations();
 
-    // The lowered IR should contain no selects.
-    Module m = g.compile_to_module({p});
-    CheckForSelects checker;
-    m.functions()[0].body.accept(&checker);
-    if (checker.result) {
-        printf("Lowered code contained a select\n");
-        return -1;
+        // The lowered IR should contain no selects.
+        Module m = g.compile_to_module({p});
+        CheckForSelects checker;
+        m.functions()[0].body.accept(&checker);
+        if (checker.result) {
+            printf("Lowered code contained a select\n");
+            return -1;
+        }
+
+        p.set(3);
+        h.set_custom_trace(my_trace);
+        Image<int> result = h.realize(10);
+
+        for (int i = 0; i < 10; i++) {
+            int correct = (i&1) == 1 ? 6 : 22;
+            if (result(i) != correct) {
+                printf("result(%d) = %d instead of %d\n",
+                       i, result(i), correct);
+                return -1;
+            }
+        }
+
+        // Bounds of f should be [-p, 10+2*p] rounded outwards
+        if (trace_min != -4 || trace_extent != 18) {
+            printf("Wrong bounds: [%d, %d]\n", trace_min, trace_extent);
+            return -1;
+        }
+
+        // Increasing p by one should have no effect
+        p.set(4);
+        h.realize(result);
+        if (trace_min != -4 || trace_extent != 18) {
+            printf("Wrong bounds: [%d, %d]\n", trace_min, trace_extent);
+            return -1;
+        }
+
+        // But increasing it again should cause a jump of two in the bounds computed.
+        p.set(5);
+        h.realize(result);
+        if (trace_min != -6 || trace_extent != 22) {
+            printf("Wrong bounds: [%d, %d]\n", trace_min, trace_extent);
+            return -1;
+        }
     }
 
-    p.set(3);
-    Image<int> result = h.realize(10);
+    // Now try a case where we misalign with an offset (i.e. force the
+    // bounds to be odd). This should also remove the select.
+    {
+        Func f, g, h;
+        Var x;
 
-    for (int i = 0; i < 10; i++) {
-        int correct = (i&1) == 1 ? 6 : 22;
-        if (result(i) != correct) {
-            printf("result(%d) = %d instead of %d\n",
-                   i, result(i), correct);
+        f(x) = 3;
+
+        g(x) = select(x % 2 == 0, f(x+1), f(x-1)+8);
+
+        Param<int> p;
+        h(x) = g(x-p) + g(x+p);
+
+        f.compute_root();
+        g.compute_root().align_bounds(x, 2, 1).unroll(x, 2).trace_realizations();
+
+        // The lowered IR should contain no selects.
+        Module m = g.compile_to_module({p});
+        CheckForSelects checker;
+        m.functions()[0].body.accept(&checker);
+        if (checker.result) {
+            printf("Lowered code contained a select\n");
+            return -1;
+        }
+
+        p.set(3);
+        h.set_custom_trace(my_trace);
+        Image<int> result = h.realize(10);
+
+        for (int i = 0; i < 10; i++) {
+            int correct = (i&1) == 1 ? 6 : 22;
+            if (result(i) != correct) {
+                printf("result(%d) = %d instead of %d\n",
+                       i, result(i), correct);
+                return -1;
+            }
+        }
+
+        // Now the min/max should stick to odd numbers
+        if (trace_min != -3 || trace_extent != 16) {
+            printf("Wrong bounds: [%d, %d]\n", trace_min, trace_extent);
+            return -1;
+        }
+
+        // Increasing p by one should have no effect
+        p.set(4);
+        h.realize(result);
+        if (trace_min != -5 || trace_extent != 20) {
+            printf("Wrong bounds: [%d, %d]\n", trace_min, trace_extent);
+            return -1;
+        }
+
+        // But increasing it again should cause a jump of two in the bounds computed.
+        p.set(5);
+        h.realize(result);
+        if (trace_min != -5 || trace_extent != 20) {
+            printf("Wrong bounds: [%d, %d]\n", trace_min, trace_extent);
             return -1;
         }
     }

--- a/test/correctness/align_bounds.cpp
+++ b/test/correctness/align_bounds.cpp
@@ -1,0 +1,53 @@
+#include "Halide.h"
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+class CheckForSelects : public IRVisitor {
+    using IRVisitor::visit;
+    void visit(const Select *op) {
+        result = true;
+    }
+public:
+    bool result = false;
+};
+
+
+int main(int argc, char **argv) {
+    Func f, g, h;
+    Var x;
+
+    f(x) = 3;
+
+    g(x) = select(x % 2 == 0, f(x+1), f(x-1)+8);
+
+    Param<int> p;
+    h(x) = g(x-p) + g(x+p);
+
+    f.compute_root();
+    g.compute_root().align_bounds(x, 2).unroll(x, 2);
+
+    // The lowered IR should contain no selects.
+    Module m = g.compile_to_module({p});
+    CheckForSelects checker;
+    m.functions()[0].body.accept(&checker);
+    if (checker.result) {
+        printf("Lowered code contained a select\n");
+        return -1;
+    }
+
+    p.set(3);
+    Image<int> result = h.realize(10);
+
+    for (int i = 0; i < 10; i++) {
+        int correct = (i&1) == 1 ? 6 : 22;
+        if (result(i) != correct) {
+            printf("result(%d) = %d instead of %d\n",
+                   i, result(i), correct);
+            return -1;
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Add a much-discussed directive to forcibly align or misalign the bounds of a computation/realization. See the test for an example. This useful for code that does interleaving. If you want a select(x%2==0, a, b) to simplify away, you can say:

f.align_bounds(x, 2).unroll(x, 2);

This forces the min and the max-plus-one of the computation to a multiple of the argument.

This is also probably useful to help generate code that does aligned loads and stores.