### PR TITLE
fixed bugs in implicit_args

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1,7 +1,5 @@
 #include <algorithm>
-#include <iostream>
 #include <string.h>
-#include <fstream>
 
 #ifdef _MSC_VER
 #include <intrin.h>
@@ -35,12 +33,10 @@ namespace Halide {
 
 using std::max;
 using std::min;
-using std::make_pair;
 using std::map;
 using std::string;
 using std::vector;
 using std::pair;
-using std::ofstream;
 
 using namespace Internal;
 
@@ -200,10 +196,10 @@ FuncRef Func::operator()(vector<Expr> args) const {
     return FuncRef(func, args, placeholder_pos, count);
 }
 
-std::pair<int, int> Func::add_implicit_vars(vector<Var> &args) const {
+pair<int, int> Func::add_implicit_vars(vector<Var> &args) const {
     int placeholder_pos = -1;
     int count = 0;
-    std::vector<Var>::iterator iter = args.begin();
+    vector<Var>::iterator iter = args.begin();
 
     while (iter != args.end() && !iter->same_as(_)) {
         iter++;
@@ -225,13 +221,13 @@ std::pair<int, int> Func::add_implicit_vars(vector<Var> &args) const {
                    << args.size() << " arguments, but was defined with " << dimensions() << "\n";
     }
 
-    return std::make_pair(placeholder_pos, count);
+    return {placeholder_pos, count};
 }
 
-std::pair<int, int> Func::add_implicit_vars(vector<Expr> &args) const {
+pair<int, int> Func::add_implicit_vars(vector<Expr> &args) const {
     int placeholder_pos = -1;
     int count = 0;
-    std::vector<Expr>::iterator iter = args.begin();
+    vector<Expr>::iterator iter = args.begin();
     while (iter != args.end()) {
         const Variable *var = iter->as<Variable>();
         if (var && var->name == _.name())
@@ -255,7 +251,7 @@ std::pair<int, int> Func::add_implicit_vars(vector<Expr> &args) const {
                    << args.size() << " arguments, but was defined with " << dimensions() << "\n";
     }
 
-    return std::make_pair(placeholder_pos, count);
+    return {placeholder_pos, count};
 }
 
 namespace {

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -189,17 +189,20 @@ int Func::dimensions() const {
 }
 
 FuncRef Func::operator()(vector<Var> args) const {
-    int placeholder_pos = add_implicit_vars(args);
-    return FuncRef(func, args, placeholder_pos);
+    int placeholder_pos, count;
+    std::tie(placeholder_pos, count) = add_implicit_vars(args);
+    return FuncRef(func, args, placeholder_pos, count);
 }
 
 FuncRef Func::operator()(vector<Expr> args) const {
-    int placeholder_pos = add_implicit_vars(args);
-    return FuncRef(func, args, placeholder_pos);
+    int placeholder_pos, count;
+    std::tie(placeholder_pos, count) = add_implicit_vars(args);
+    return FuncRef(func, args, placeholder_pos, count);
 }
 
-int Func::add_implicit_vars(vector<Var> &args) const {
+std::pair<int, int> Func::add_implicit_vars(vector<Var> &args) const {
     int placeholder_pos = -1;
+    int count = 0;
     std::vector<Var>::iterator iter = args.begin();
 
     while (iter != args.end() && !iter->same_as(_)) {
@@ -213,6 +216,7 @@ int Func::add_implicit_vars(vector<Var> &args) const {
             Internal::debug(2) << "Adding implicit var " << i << " to call to " << name() << "\n";
             iter = args.insert(iter, Var::implicit(i++));
             iter++;
+            count++;
         }
     }
 
@@ -221,11 +225,12 @@ int Func::add_implicit_vars(vector<Var> &args) const {
                    << args.size() << " arguments, but was defined with " << dimensions() << "\n";
     }
 
-    return placeholder_pos;
+    return std::make_pair(placeholder_pos, count);
 }
 
-int Func::add_implicit_vars(vector<Expr> &args) const {
+std::pair<int, int> Func::add_implicit_vars(vector<Expr> &args) const {
     int placeholder_pos = -1;
+    int count = 0;
     std::vector<Expr>::iterator iter = args.begin();
     while (iter != args.end()) {
         const Variable *var = iter->as<Variable>();
@@ -241,6 +246,7 @@ int Func::add_implicit_vars(vector<Expr> &args) const {
             Internal::debug(2) << "Adding implicit var " << i << " to call to " << name() << "\n";
             iter = args.insert(iter, Var::implicit(i++));
             iter++;
+            count++;
         }
     }
 
@@ -249,7 +255,7 @@ int Func::add_implicit_vars(vector<Expr> &args) const {
                    << args.size() << " arguments, but was defined with " << dimensions() << "\n";
     }
 
-    return placeholder_pos;
+    return std::make_pair(placeholder_pos, count);
 }
 
 namespace {
@@ -1998,12 +2004,14 @@ public:
 };
 }
 
-FuncRef::FuncRef(Internal::Function f, const vector<Expr> &a, int placeholder_pos) : func(f), args(a) {
+FuncRef::FuncRef(Internal::Function f, const vector<Expr> &a, int placeholder_pos,
+                 int count) : func(f), implicit_count(count), args(a){
     implicit_placeholder_pos = placeholder_pos;
     Internal::check_call_arg_types(f.name(), &args, args.size());
 }
 
-FuncRef::FuncRef(Internal::Function f, const vector<Var> &a, int placeholder_pos) : func(f) {
+FuncRef::FuncRef(Internal::Function f, const vector<Var> &a, int placeholder_pos,
+                 int count) : func(f), implicit_count(count) {
     implicit_placeholder_pos = placeholder_pos;
     args.resize(a.size());
     for (size_t i = 0; i < a.size(); i++) {
@@ -2014,24 +2022,33 @@ FuncRef::FuncRef(Internal::Function f, const vector<Var> &a, int placeholder_pos
 vector<Expr> FuncRef::args_with_implicit_vars(const vector<Expr> &e) const {
     vector<Expr> a = args;
 
+    for (size_t i = 0; i < a.size(); i++) {
+        user_assert(a[i].defined())
+            << "Argument " << (i+1) << " in call to \"" << func.name() << "\" is undefined.\n";
+    }
     for (size_t i = 0; i < e.size(); i++) {
         user_assert(e[i].defined())
-            << "Argument " << (i+1) << " in call to \"" << func.name() << "\" is undefined.\n";
+            << "Value " << (i+1) << " in definition of \"" << func.name() << "\" is undefined.\n";
     }
 
     CountImplicitVars count(e);
-    // TODO: Check if there is a test case for this and add one if not.
-    // Implicit vars are also allowed in the lhs of an update. E.g.:
-    // f(x, y, z) = x+y
-    // g(x, y, z) = 0
-    // g(f(r.x, _), _) = 1   (this means g(f(r.x, _0, _1), _0, _1) = 1)
-
     for (size_t i = 0; i < a.size(); i++) {
         a[i].accept(&count);
     }
 
     if (count.count > 0) {
-        if (implicit_placeholder_pos != -1) {
+        if (func.has_pure_definition()) {
+            // If the func already has pure definition, the number of implicit
+            // vars in the RHS can only be at most the number of implicit vars
+            // in the LHS.
+            user_assert(implicit_count >= count.count)
+                << "The update definition of " << func.name() << " uses " << count.count
+                << " implicit variables, but the initial definition uses only "
+                << implicit_count << " implicit variables.\n";
+        } else if (implicit_placeholder_pos != -1) {
+            internal_assert(implicit_count == 0)
+                << "Pure definition can't possibly already have implicit variables defined\n";
+
             Internal::debug(2) << "Adding " << count.count << " implicit vars to LHS of " << func.name() << "\n";
 
             vector<Expr>::iterator iter = a.begin() + implicit_placeholder_pos;
@@ -2075,14 +2092,14 @@ Stage FuncRef::operator=(const Tuple &e) {
         }
 
         // Find implicit args in the expr and add them to the args list before calling define
-        vector<Expr> a = args_with_implicit_vars(e.as_vector());
-        vector<string> a_str(a.size());
-        for (size_t i = 0; i < a.size(); ++i) {
-            const Variable *v = a[i].as<Variable>();
+        vector<Expr> expanded_args = args_with_implicit_vars(e.as_vector());
+        vector<string> expanded_args_str(expanded_args.size());
+        for (size_t i = 0; i < expanded_args.size(); ++i) {
+            const Variable *v = expanded_args[i].as<Variable>();
             internal_assert(v);
-            a_str[i] = v->name;
+            expanded_args_str[i] = v->name;
         }
-        func.define(a_str, e.as_vector());
+        func.define(expanded_args_str, e.as_vector());
         return Stage(func.definition(), func.name(), func.args(), func.schedule().storage_dims());
 
     } else {
@@ -2106,8 +2123,10 @@ Stage FuncRef::operator=(const FuncRef &e) {
 
 // Inject a suitable base-case definition given an update
 // definition. This is a helper for FuncRef::operator+= and co.
-void define_base_case(Internal::Function func, const vector<Expr> &a, const Tuple &e) {
-    if (func.has_pure_definition()) return;
+Func define_base_case(Internal::Function func, const vector<Expr> &a, const Tuple &e) {
+    Func f(func);
+
+    if (func.has_pure_definition()) return f;
     vector<Var> pure_args(a.size());
 
     // Reuse names of existing pure args
@@ -2121,11 +2140,12 @@ void define_base_case(Internal::Function func, const vector<Expr> &a, const Tupl
         }
     }
 
-    FuncRef(func, pure_args) = e;
+    f(pure_args) = e;
+    return f;
 }
 
-void define_base_case(Internal::Function func, const vector<Expr> &a, Expr e) {
-    define_base_case(func, a, Tuple(e));
+Func define_base_case(Internal::Function func, const vector<Expr> &a, Expr e) {
+    return define_base_case(func, a, Tuple(e));
 }
 
 template <typename BinaryOp>
@@ -2136,21 +2156,21 @@ Stage FuncRef::func_ref_update(const Tuple &e, int init_val) {
     for (int i = 0; i < (int)init_values.size(); ++i) {
         init_values[i] = cast(e[i].type(), init_val);
     }
-    vector<Expr> a = args_with_implicit_vars(e.as_vector());
-    define_base_case(func, a, Tuple(init_values));
+    vector<Expr> expanded_args = args_with_implicit_vars(e.as_vector());
+    FuncRef self_ref = define_base_case(func, expanded_args, Tuple(init_values))(expanded_args);
 
     vector<Expr> values(e.size());
     for (int i = 0; i < (int)values.size(); ++i) {
-        values[i] = BinaryOp()((*this)[i], e[i]);
+        values[i] = BinaryOp()(self_ref[i], e[i]);
     }
-    return (*this) = Tuple(values);
+    return self_ref = Tuple(values);
 }
 
 template <typename BinaryOp>
 Stage FuncRef::func_ref_update(Expr e, int init_val) {
-    vector<Expr> a = args_with_implicit_vars({e});
-    define_base_case(func, a, cast(e.type(), init_val));
-    return (*this) = BinaryOp()(Expr(*this), e);
+    vector<Expr> expanded_args = args_with_implicit_vars({e});
+    FuncRef self_ref = define_base_case(func, expanded_args, cast(e.type(), init_val))(expanded_args);
+    return self_ref = BinaryOp()(Expr(self_ref), e);
 }
 
 Stage FuncRef::operator+=(Expr e) {

--- a/src/Func.h
+++ b/src/Func.h
@@ -249,6 +249,7 @@ class FuncRef;
 class FuncRef {
     Internal::Function func;
     int implicit_placeholder_pos;
+    int implicit_count;
     std::vector<Expr> args;
     std::vector<Expr> args_with_implicit_vars(const std::vector<Expr> &e) const;
 
@@ -266,9 +267,9 @@ class FuncRef {
 
 public:
     FuncRef(Internal::Function, const std::vector<Expr> &,
-                int placeholder_pos = -1);
+                int placeholder_pos = -1, int count = 0);
     FuncRef(Internal::Function, const std::vector<Var> &,
-                int placeholder_pos = -1);
+                int placeholder_pos = -1, int count = 0);
 
     /** Use this as the left-hand-side of a definition or an update definition
      * (see \ref RDom).
@@ -365,8 +366,8 @@ class Func {
      * up with 'implicit' vars with canonical names. This lets you
      * pass around partially applied Halide functions. */
     // @{
-    int add_implicit_vars(std::vector<Var> &) const;
-    int add_implicit_vars(std::vector<Expr> &) const;
+    std::pair<int, int> add_implicit_vars(std::vector<Var> &) const;
+    std::pair<int, int> add_implicit_vars(std::vector<Expr> &) const;
     // @}
 
     /** The imaging pipeline that outputs this Func alone. */

--- a/test/correctness/implicit_args_tests.cpp
+++ b/test/correctness/implicit_args_tests.cpp
@@ -1,0 +1,265 @@
+#include "Halide.h"
+#include <stdio.h>
+#include <functional>
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+typedef std::function<int(int,int,int)> FuncChecker;
+
+int check_image(const Realization &r, const std::vector<FuncChecker> &funcs) {
+    for (size_t idx = 0; idx < funcs.size(); idx++) {
+        const Image<int> &im = r[idx];
+        for (int z = 0; z < im.channels(); z++) {
+            for (int y = 0; y < im.height(); y++) {
+                for (int x = 0; x < im.width(); x++) {
+                    int correct = funcs[idx](x, y, z);
+                    if (im(x, y, z) != correct) {
+                        printf("im(%d, %d, %d) = %d instead of %d\n",
+                               x, y, z, im(x, y, z), correct);
+                        return -1;
+                    }
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    {
+        Var x("x"), y("y");
+        Func f("f"), h("h");
+
+        h(x, y) = x + y;
+        h.compute_root();
+
+        f(x, _) = h(_) + 2;     // This means f(x, _0, _1) = h(_0, _1) + 2
+
+        Realization result = f.realize(100, 100, 100);
+        auto func = [](int x, int y, int z) {
+            return y + z + 2;
+        };
+        if (check_image(result, {func})) {
+            return -1;
+        }
+    }
+
+    {
+        Var x("x"), y("y"), z("z");
+        Func f("f"), g("g"), h("h");
+
+        h(x, y) = x + y;
+        h.compute_root();
+
+        f(x, y, z) = x;
+        f.compute_root();
+
+        RDom r(0, 2);
+        g(x, _) = h(_) + 1;                   // This means g(x, _0, _1) = h(_0, _1) + 1
+        g(clamp(f(r.x, _), 0, 50), _) += 2;   // This means g(f(r.x, _0, _1), _0, _1) += 2
+
+        Realization result = g.realize(100, 100, 100);
+        auto func = [](int x, int y, int z) {
+            return (x == 0) || (x == 1) ? y + z + 3 : y + z + 1;
+        };
+        if (check_image(result, {func})) {
+            return -1;
+        }
+    }
+
+    {
+        Var x("x"), y("y");
+        Func f("f"), g("g"), h("h");
+
+        h(x, y) = x + y;
+        h.compute_root();
+
+        g(x)  = x + 2;
+        g.compute_root();
+
+        f(x, _) = h(_) + 3;     // This means f(x, _0, _1) = h(_0, _1) + 3
+        f(x, _) += h(_)*g(_);   // This means f(x, _0, _1) += h(_0, _1) * g(_0)
+
+        Realization result = f.realize(100, 100, 100);
+        auto func = [](int x, int y, int z) {
+            return (y + z + 3) + (y + z)*(y + 2);
+        };
+        if (check_image(result, {func})) {
+            return -1;
+        }
+    }
+
+    {
+        Var x("x"), y("y");
+        Func f("f"), h("h");
+
+        h(x, y) = x + y;
+        h.compute_root();
+
+        // This is equivalent to:
+        //   f(x, _0, _1) = 0
+        //   f(x, _0, _1) += h(_0, _1) + 2
+        f(x, _) += h(_) + 2;
+
+        Realization result = f.realize(100, 100, 100);
+        auto func = [](int x, int y, int z) {
+            return y + z + 2;
+        };
+        if (check_image(result, {func})) {
+            return -1;
+        }
+    }
+
+    {
+        Var x("x"), y("y");
+        Func f("f"), g("g"), h("h");
+
+        h(x, y) = x + y;
+        h.compute_root();
+
+        g(x)  = x + 2;
+        g.compute_root();
+
+        // This is equivalent to:
+        //   f(_0, _1) = 0
+        //   f(_0, _1) += h(_0, _1)*g(_0) + 3
+        f(_) += h(_)*g(_) + 3;
+
+        Realization result = f.realize(100, 100);
+        auto func = [](int x, int y, int z) {
+            return (x + y)*(x + 2) + 3;
+        };
+        if (check_image(result, {func})) {
+            return -1;
+        }
+    }
+
+    {
+        Var x("x"), y("y");
+        Func f("f"), h("h");
+
+        h(x, y) = x + y;
+        h.compute_root();
+
+        // This means f(x, _0, _1) = {h(_0, _1) + 2, x + 2}
+        f(x, _) = Tuple(h(_) + 2, x + 2);
+
+        Realization result = f.realize(100, 100, 100);
+        auto func1 = [](int x, int y, int z) {
+            return y + z + 2;
+        };
+        auto func2 = [](int x, int y, int z) {
+            return x + 2;
+        };
+        if (check_image(result, {func1, func2})) {
+            return -1;
+        }
+    }
+
+    {
+        Var x("x"), y("y"), z("z");
+        Func f("f"), g("g"), h("h");
+
+        h(x, y) = x + y;
+        h.compute_root();
+
+        f(x, y, z) = x;
+        f.compute_root();
+
+        RDom r(0, 2);
+        // This means g(x, _0, _1) = {h(_0, _1) + 1}
+        g(x, _) = Tuple(h(_) + 1);
+        // This means g(f(r.x, _0, _1), _0, _1) += {2}
+        g(clamp(f(r.x, _), 0, 50), _) += Tuple(2);
+
+        Realization result = g.realize(100, 100, 100);
+        auto func = [](int x, int y, int z) {
+            return (x == 0) || (x == 1) ? y + z + 3 : y + z + 1;
+        };
+        if (check_image(result, {func})) {
+            return -1;
+        }
+    }
+
+    {
+        Var x("x"), y("y");
+        Func f("f"), h("h");
+
+        h(x, y) = x + y;
+        h.compute_root();
+
+        // This is equivalent to:
+        //   f(x, _0, _1) = {1, 1}
+        //   f(x, _0, _1) += {h(_0, _1)[0] + 2, h(_0, _1)[1] * 3}
+        f(x, _) *= Tuple(h(_) + 2, h(_) * 3);
+
+        Realization result = f.realize(100, 100, 100);
+        auto func1 = [](int x, int y, int z) {
+            return y + z + 2;
+        };
+        auto func2 = [](int x, int y, int z) {
+            return (y + z)*3;
+        };
+        if (check_image(result, {func1, func2})) {
+            return -1;
+        }
+    }
+
+    {
+        Var x("x"), y("y");
+        Func f("f"), g("g"), h("h");
+
+        h(x, y) = Tuple(x + y, x - y);
+        h.compute_root();
+
+        g(x)  = Tuple(x + 2, x - 2);
+        g.compute_root();
+
+        // This means f(x, _0, _1) = {h(_0, _1)[0] + 3, h(_0, _1)[1] + 4}
+        f(x, _) = Tuple(h(_)[0] + 3, h(_)[1] + 4);
+        // This means f(x, _0, _1) += {h(_0, _1)[0]*g(_0)[0], h(_0, _1)[1]*g(_0)[1]}
+        f(x, _) += Tuple(h(_)[0]*g(_)[0], h(_)[1]*g(_)[1]);
+
+        Realization result = f.realize(100, 100, 100);
+        auto func1 = [](int x, int y, int z) {
+            return (y + z + 3) + (y + z)*(y + 2);
+        };
+        auto func2 = [](int x, int y, int z) {
+            return (y - z + 4) + (y - z)*(y - 2);
+        };
+        if (check_image(result, {func1, func2})) {
+            return -1;
+        }
+    }
+
+    {
+        Var x("x"), y("y");
+        Func f("f"), g("g"), h("h");
+
+        h(x, y) = Tuple(x + y, x - y);
+        h.compute_root();
+
+        g(x)  = Tuple(x + 2, x- 2);
+        g.compute_root();
+
+        // This is equivalent to:
+        //   f(_0, _1) = 0
+        //   f(_0, _1) += {h(_0, _1)[0]*g(_0)[0] + 3, h(_0, _1)[1]*g(_0)[1] + 4}
+        f(_) += Tuple(h(_)[0]*g(_)[0] + 3, h(_)[1]*g(_)[1] + 4);
+
+        Realization result = f.realize(100, 100);
+        auto func1 = [](int x, int y, int z) {
+            return (x + y)*(x + 2) + 3;
+        };
+        auto func2 = [](int x, int y, int z) {
+            return (x - y)*(x - 2) + 4;
+        };
+        if (check_image(result, {func1, func2})) {
+            return -1;
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/implicit_args.cpp
+++ b/test/error/implicit_args.cpp
@@ -1,0 +1,24 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+   	Var x("x"), y("y"), z("z");
+
+    Func f("f"), g("g"), h("h");
+
+    g(x, y) = x + y;
+    g.compute_root();
+
+    h(x, y, z) = x + y + z;
+    h.compute_root();
+
+    // The initial definition uses 2 implicit vars: f(x, _0, _1) = g(_0, _1) + 2.
+    // The update definition, however, calls h(_) which will be expanded into
+    // h(_0, _1, _2), which is invalid.
+    f(x, _) = g(_) + 2;
+    f(x, _) += h(_) + 3;
+
+    return 0;
+}


### PR DESCRIPTION
Fixed bugs in args_with_implicit_vars: implicit vars are not properly inserted for update definition. 

This PR also allows usage of implicit vars for update definition of a function which does not already have a pure definition, like in the following:

```
h(x, y) = x + y;
f(x, _) += h(_) + 2;
```
This is equivalent to:
```
f(x, _0, _1) = 0
f(x, _0, _1) += h(_0, _1) + 2
```