### PR TITLE
Fix printer.h to not crash when malloc returns nullptr.

### DIFF
--- a/src/runtime/printer.h
+++ b/src/runtime/printer.h
@@ -34,8 +34,13 @@ public:
     Printer(void *ctx, char *mem = NULL) : user_context(ctx), own_mem(mem == NULL) {
         buf = mem ? mem : (char *)halide_malloc(user_context, length);
         dst = buf;
-        end = buf + (length-1);
-        *end = 0;
+        if (dst) {
+            end = buf + (length-1);
+            *end = 0;
+        } else {
+            // Pointers equal ensures no writes to buffer via formatting code
+            end = dst;
+        }
     }
 
     Printer &operator<<(const char *arg) {
@@ -86,36 +91,55 @@ public:
 
     // Use it like a stringstream.
     const char *str() {
-        return buf;
+        if (buf) {
+            return buf;
+        } else {
+            return allocation_error();
+        }
     }
 
     // Clear it. Useful for reusing a stringstream.
     void clear() {
         dst = buf;
-        dst[0] = 0;
+        if (dst) {
+            dst[0] = 0;
+        }
     }
 
     // Returns the number of characters in the buffer
     uint64_t size() const {
-        return (uint64_t)(dst-buf);
+        return (uint64_t)(dst - buf);
     }
 
     // Delete the last N characters
     void erase(int n) {
-        dst -= n;
-        if (dst < buf) dst = buf;
-        dst[0] = 0;
+        if (dst) {
+            dst -= n;
+            if (dst < buf) {
+                dst = buf;
+            }
+            dst[0] = 0;
+        }
+    }
+
+    const char *allocation_error() {
+        return "Printer buffer allocation failed.\n";
     }
 
     ~Printer() {
-        if (type == ErrorPrinter) {
+        if (!buf) {
+            halide_error(user_context, allocation_error());
+        } else if (type == ErrorPrinter) {
             halide_error(user_context, buf);
         } else if (type == BasicPrinter) {
             halide_print(user_context, buf);
         } else {
             // It's a stringstream. Do nothing.
         }
-        if (own_mem) halide_free(user_context, buf);
+
+        if (own_mem) {
+            halide_free(user_context, buf);
+        }
     }
 };
 

--- a/src/runtime/to_string.cpp
+++ b/src/runtime/to_string.cpp
@@ -37,7 +37,7 @@ WEAK char *halide_uint64_to_string(char *dst, char *end, uint64_t arg, int min_d
 }
 
 WEAK char *halide_int64_to_string(char *dst, char *end, int64_t arg, int min_digits) {
-    if (arg < 0 && dst <= end) {
+    if (arg < 0 && dst < end) {
         *dst++ = '-';
         arg = -arg;
     }


### PR DESCRIPTION
Fixed off by one error in halide_int64_to_string that could result in
writing a byte to the end location, which does not seem to be
correct. (And caused a crash in testing this.)

Tested change by turning on CACHE_DEBUGGING in src/runtime/cache.cpp then
running the command:
    HL_JIT_TARGET=host-debug make correctness_memoize