### PR TITLE
Don't use temporary-file names for archive members

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -236,7 +236,7 @@ void file_unlink(const std::string &name) {
 void dir_rmdir(const std::string &name) {
     #ifdef _MSC_VER
     BOOL r = RemoveDirectoryA(name.c_str());
-    internal_assert(r == 0) << "Unable to remove dir: " << name << "\n";
+    internal_assert(r != 0) << "Unable to remove dir: " << name << ":" << GetLastError() << "\n";
     #else
     int r = ::rmdir(name.c_str());
     internal_assert(r == 0) << "Unable to remove dir: " << name << "\n";
@@ -303,10 +303,12 @@ std::string dir_make_temp() {
         HRESULT hr = CoCreateGuid(&guid);
         internal_assert(hr == S_OK);
         char name[256];
-        int result = StringFromGUID2A(guid, name, sizeof(name));
-        internal_assert(result > 0);
-        std::string dir = std::string(tmp_path) + "\\" + std::string(name);
-        result = CreateDirectoryA(dir.c_str, nullptr);
+        sprintf(name, "%08X%04X%04X%02X%02X%02X%02X%02X%02X%02X%02X", 
+            guid.Data1, guid.Data2, guid.Data3, guid.Data4[0], 
+            guid.Data4[1], guid.Data4[2], guid.Data4[3], guid.Data4[4], 
+            guid.Data4[5], guid.Data4[6], guid.Data4[7]);
+        std::string dir = std::string(tmp_path) + std::string(name);
+        BOOL result = CreateDirectoryA(dir.c_str(), nullptr);
         if (result) {
             debug(1) << "temp dir is: " << dir << "\n";
             return dir;

--- a/src/Util.h
+++ b/src/Util.h
@@ -192,13 +192,24 @@ struct FileStat {
  * file, the caller is responsibly for deleting it. Neither the prefix nor suffix
  * may contain a directory separator.
  */
-std::string file_make_temp(const std::string &prefix, const std::string &suffix);
+EXPORT std::string file_make_temp(const std::string &prefix, const std::string &suffix);
+
+/** Create a unique directory in an arbitrary (but writable) directory; this is 
+ * typically somewhere inside /tmp, but the specific location is not guaranteed. 
+ * The directory will be empty (i.e., this will never return /tmp itself,
+ * but rather a new directory inside /tmp). The caller is responsible for removing the 
+ * directory after use.
+ */
+EXPORT std::string dir_make_temp();
 
 /** Wrapper for access(). Asserts upon error. */
 EXPORT bool file_exists(const std::string &name);
 
 /** Wrapper for unlink(). Asserts upon error. */
 EXPORT void file_unlink(const std::string &name);
+
+/** Wrapper for rmdir(). Asserts upon error. */
+EXPORT void dir_rmdir(const std::string &name);
 
 /** Wrapper for stat(). Asserts upon error. */
 EXPORT FileStat file_stat(const std::string &name);


### PR DESCRIPTION
This embeds randomness into the contents of the output from build to
build, which is bad for hermeticity of build products. Instead, create
a unique directory for the temporary files; the directory name isn’t
reflected in the final .a output.