### PR TITLE
Improve simplification

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -840,6 +840,7 @@ void merge_boxes(Box &a, const Box &b) {
                 } else {
                     a[i].min = Interval::make_min(a[i].min, b[i].min);
                 }
+                a[i].min = simplify(a[i].min);
             } else {
                 a[i].min = Interval::neg_inf;
             }
@@ -861,6 +862,7 @@ void merge_boxes(Box &a, const Box &b) {
                 } else {
                     a[i].max = Interval::make_max(a[i].max, b[i].max);
                 }
+                a[i].max = simplify(a[i].max);
             } else {
                 a[i].max = Interval::pos_inf;
             }

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -5017,15 +5017,15 @@ void check_boolean() {
     check(broadcast(b1, 4) && broadcast(b1, 4), broadcast(b1, 4));
     check(broadcast(b1, 4) || broadcast(b1, 4), broadcast(b1, 4));
 
-    check((x == 1) && (x != 2), (x == 1) && (1 != 2));
-    check((x != 1) && (x == 2), (x == 2) && (1 != 2));
-    check((x == 1) && (x != 1), (x == 1) && (1 != 1));
-    check((x != 1) && (x == 1), (x == 1) && (1 != 1));
+    check((x == 1) && (x != 2), f);
+    check((x != 1) && (x == 2), f);
+    check((x == 1) && (x != 1), f);
+    check((x != 1) && (x == 1), f);
 
-    check((x == 1) || (x != 2), (x != 2) || (1 == 2));
-    check((x != 1) || (x == 2), (x != 1) || (1 == 2));
-    check((x == 1) || (x != 1), (x != 1) || (1 == 1));
-    check((x != 1) || (x == 1), (x != 1) || (1 == 1));
+    check((x == 1) || (x != 2), (x != 2));
+    check((x != 1) || (x == 2), (x != 1));
+    check((x == 1) || (x != 1), t);
+    check((x != 1) || (x == 1), t);
 
     check(t && (x < 0), x < 0);
     check(f && (x < 0), f);

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -71,12 +71,10 @@ bool is_var_relop_simple_const(Expr e, string* name) {
 }
 
 bool is_var_simple_const_comparison(Expr e, string* name) {
+    // It's not clear if GT, LT, etc would be useful 
+    // here; leaving them out until proven otherwise.
     return is_var_relop_simple_const<EQ>(e, name) ||
-           is_var_relop_simple_const<NE>(e, name) ||
-           is_var_relop_simple_const<LT>(e, name) ||
-           is_var_relop_simple_const<LE>(e, name) ||
-           is_var_relop_simple_const<GT>(e, name) ||
-           is_var_relop_simple_const<GE>(e, name);
+           is_var_relop_simple_const<NE>(e, name);
 }
 
 // Returns true iff t is a scalar integral type where overflow is undefined

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -5017,8 +5017,8 @@ void check_boolean() {
     check(broadcast(b1, 4) && broadcast(b1, 4), broadcast(b1, 4));
     check(broadcast(b1, 4) || broadcast(b1, 4), broadcast(b1, 4));
 
-    check((x == 1) && (x != 2), f);
-    check((x != 1) && (x == 2), f);
+    check((x == 1) && (x != 2), (x == 1));
+    check((x != 1) && (x == 2), (x == 2));
     check((x == 1) && (x != 1), f);
     check((x != 1) && (x == 1), f);
 

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -3112,14 +3112,12 @@ private:
                    expr_uses_var(b, eq_a->a.as<Variable>()->name)) {
             // (somevar == k) && b -> (somevar == k) && substitute(somevar, k, b)
             expr = mutate(And::make(a, substitute(eq_a->a.as<Variable>(), eq_a->b, b)));
-            debug(1) << "WOOHOO3: " << Expr(op) << " -> " << expr << "\n";
         } else if (eq_b &&
                    eq_b->a.as<Variable>() &&
                    is_simple_const(eq_b->b) &&
                    expr_uses_var(a, eq_b->a.as<Variable>()->name)) {
             // a && (somevar == k) -> substitute(somevar, k1, a) && (somevar == k)
             expr = mutate(And::make(substitute(eq_b->a.as<Variable>(), eq_b->b, a), b));
-            debug(1) << "WOOHOO4: " << Expr(op) << " -> " << expr << "\n";
         } else if (broadcast_a &&
                    broadcast_b &&
                    broadcast_a->lanes == broadcast_b->lanes) {

--- a/test/correctness/cascaded_filters.cpp
+++ b/test/correctness/cascaded_filters.cpp
@@ -4,10 +4,11 @@
 using namespace Halide;
 
 Var x, y;
+Param<int> divisor;
 
 Func blur(Func in, std::string n) {
     Func blurry(n);
-    blurry(x) = (in(x) + in(x+1)) / 2;
+    blurry(x) = (in(x) + in(x+1)) / divisor;
     return blurry;
 }
 
@@ -27,6 +28,13 @@ int main(int argc, char **argv) {
         stages[i].store_root().compute_at(stages.back(), x);
     }
 
+    // Add an unreasonable number of specialize() calls, to ensure
+    // that various parts of the pipeline don't blow up
+    for (int i = 1; i <= 10; i++) {
+        stages.back().specialize(divisor == i);
+    }
+
+    divisor.set(2);
     Image<float> result = stages.back().realize(10);
 
     // After all the averaging, the result should be a flat 1.0f


### PR DESCRIPTION
In merge_boxes(), keep min and max simplified as we go along.

Add new simplifier rules that targets patterns often emitted by
specialize() conditions.

Don’t consider NaN a “simple const”.