### PR TITLE
Parameter cleanup

### DIFF
--- a/src/Param.h
+++ b/src/Param.h
@@ -141,10 +141,6 @@ public:
     }
     // @}
 
-    void set_default_value(const T &value) {
-        param.set_default(value);
-    }
-
     /** You can use this parameter as an expression in a halide
      * function definition */
     operator Expr() const {

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -15,7 +15,7 @@ struct ParameterContents {
     const std::string handle_type;
     Buffer buffer;
     uint64_t data;
-    const int host_alignment;
+    int host_alignment;
     Expr min_constraint[4];
     Expr extent_constraint[4];
     Expr stride_constraint[4];

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -9,30 +9,27 @@ namespace Internal {
 
 struct ParameterContents {
     mutable RefCount ref_count;
-    Type type;
-    const bool is_buffer;
-    int dimensions;
-    const bool is_explicit_name;
-    const bool is_registered;
-    std::string name;
-    std::string handle_type;
+    const Type type;
+    const int dimensions;
+    const std::string name;
+    const std::string handle_type;
     Buffer buffer;
-    bool initialized;
     uint64_t data;
-    uint64_t default_val;
-    int host_alignment;
+    const int host_alignment;
     Expr min_constraint[4];
     Expr extent_constraint[4];
     Expr stride_constraint[4];
     Expr min_value, max_value;
+    const bool is_buffer;
+    const bool is_explicit_name;
+    const bool is_registered;
     ParameterContents(Type t, bool b, int d, const std::string &n, bool e, bool r)
-        : type(t), is_buffer(b), dimensions(d), is_explicit_name(e), is_registered(r),
-          name(n), buffer(Buffer()), data(0), default_val(0) {
+        : type(t), dimensions(d), name(n), buffer(Buffer()), data(0), 
+          host_alignment(t.bytes()), is_buffer(b), is_explicit_name(e), is_registered(r) {
         // stride_constraint[0] defaults to 1. This is important for
         // dense vectorization. You can unset it by setting it to a
         // null expression. (param.set_stride(0, Expr());)
         stride_constraint[0] = 1;
-        host_alignment = type.bytes();
     }
 };
 
@@ -185,12 +182,6 @@ void *Parameter::get_scalar_address() const {
     check_is_scalar();
     return &contents->data;
 }
-
-void *Parameter::get_default_address() const {
-    check_is_scalar();
-    return &contents->default_val;
-}
-
 
 /** Tests if this handle is the same as another handle */
 bool Parameter::same_as(const Parameter &other) const {

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -91,27 +91,6 @@ public:
         *((T *)(get_scalar_address())) = val;
     }
 
-    /** If the parameter is a scalar parameter, get its default
-     * value. */
-    template<typename T>
-    NO_INLINE T get_default() const {
-        user_assert(type() == type_of<T>())
-            << "Can't get default for Param<" << type()
-            << "> to scalar of type " << type_of<T>() << "\n";
-        return *((T *)(get_default_address()));
-    }
-
-    /** If the parameter is a scalar parameter, set its default
-     * value. Useful when jitting and for introspection on code
-     * written in Halide. */
-    template<typename T>
-    NO_INLINE T set_default(const T &val) const {
-        user_assert(type() == type_of<T>())
-            << "Can't set default for Param<" << type()
-            << "> to scalar of type " << type_of<T>() << "\n";
-        *((T *)(get_default_address())) = val;
-    }
-
     /** If the parameter is a buffer parameter, get its currently
      * bound buffer. Only relevant when jitting */
     EXPORT Buffer get_buffer() const;
@@ -125,7 +104,6 @@ public:
      * change. Only relevant when jitting. */
 
     EXPORT void *get_scalar_address() const;
-    EXPORT void *get_default_address() const;
 
     /** Tests if this handle is the same as another handle */
     EXPORT bool same_as(const Parameter &other) const;


### PR DESCRIPTION
— remove initialized and default_val, which were totally unused (except
with also-unused accessor methods for the latter, which are now also
gone)
— group the bool fields together at the end of the struct for trivial
memory savings
— drive-by constification of fields that are const after construction