### PR TITLE
Fix predicate conversion to 1 instead of -1 on Hexagon

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1312,10 +1312,11 @@ void CodeGen_Hexagon::visit(const Div *op) {
 }
 
 void CodeGen_Hexagon::visit(const Cast *op) {
-    if (op->value.type().bits() == 1 && op->type.bits() > 1) {
-        // If left to LLVM, this maps true to one. However,
-        // eliminate_bool_vectors assumes that it maps to negative
-        // one. This will map true to negative one instead.
+    if (op->type.is_vector() && op->value.type().bits() == 1 && op->type.bits() > 1) {
+        // If left to LLVM, this maps true to a value that has each
+        // byte of the value set to 1. However, eliminate_bool_vectors
+        // assumes that it maps to negative one. This will map true to
+        // negative one instead.
         value = call_intrin(op->type,
                             "halide.hexagon.predicate_to_mask" + type_suffix(op->type, false),
                             {op->value});

--- a/src/CodeGen_Hexagon.h
+++ b/src/CodeGen_Hexagon.h
@@ -35,10 +35,12 @@ protected:
     llvm::Function *define_hvx_intrinsic(int intrin, Type ret_ty,
                                          const std::string &name,
                                          const std::vector<Type> &arg_types,
+                                         const std::vector<llvm::Value *> &extra_args,
                                          bool broadcast_scalar_word = false);
     llvm::Function *define_hvx_intrinsic(llvm::Function *intrin, Type ret_ty,
                                          const std::string &name,
                                          std::vector<Type> arg_types,
+                                         const std::vector<llvm::Value *> &extra_args,
                                          bool broadcast_scalar_word = false);
 
     using CodeGen_Posix::visit;


### PR DESCRIPTION
Eliminate bool vectors expects the masks used to represent booleans are either 0 or -1, so sign extension works to widen a boolean vector. However, Hexagon converts booleans (predicates) to 0 or 1, which leads to problems. This PR causes Hexagon to generate 0 or -1 instead. This fixes correctness_logical on Hexagon.