### PR TITLE
Rework EliminateBoolVectors

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1355,6 +1355,25 @@ void CodeGen_Hexagon::visit(const Call *op) {
             Value *idx = codegen(op->args[1]);
             value = vlut(lut, idx, *min_index, *max_index);
             return;
+        } else if (op->is_intrinsic(Call::select_mask)) {
+            internal_assert(op->args.size() == 3);
+            // eliminate_bool_vectors has replaced all boolean vectors
+            // with integer vectors of the appropriate size, so we
+            // just need to convert the select_mask intrinsic to a
+            // hexagon mux intrinsic.
+            value = call_intrin(op->type,
+                                "halide.hexagon.mux" +
+                                type_suffix(op->args[1], op->args[2], false),
+                                op->args);
+            return;
+        } else if (op->is_intrinsic(Call::bool_to_mask)) {
+            internal_assert(op->args.size() == 1);
+            // The arg must have come from a comparison, and so is
+            // already a mask of the right width.
+            codegen(op->args[0]);
+            return;
+        } else if (op->is_intrinsic(Call::cast_mask)) {
+            internal_error << "cast_mask should already have been handled in HexagonOptimize\n";
         }
     }
     CodeGen_Posix::visit(op);
@@ -1395,51 +1414,10 @@ void CodeGen_Hexagon::visit(const Min *op) {
 }
 
 void CodeGen_Hexagon::visit(const Select *op) {
-    if (op->type.is_vector() && op->condition.type().is_vector()) {
-        // eliminate_bool_vectors has replaced all boolean vectors
-        // with integer vectors of the appropriate size, and this
-        // condition is of the form 'cond != 0'. We just need to grab
-        // cond and use that as the operand for vmux.
-        Expr cond = op->condition;
-        const NE *cond_ne_0 = cond.as<NE>();
-        if (cond_ne_0) {
-            internal_assert(is_zero(cond_ne_0->b));
-            cond = cond_ne_0->a;
-        }
-        Expr t = op->true_value;
-        Expr f = op->false_value;
-        value = call_intrin(op->type,
-                            "halide.hexagon.mux" + type_suffix(t, f, false),
-                            {cond, t, f});
-    } else if (op->type.is_vector()) {
-        // Implement scalar conditions with if-then-else.
-        BasicBlock *true_bb = BasicBlock::Create(*context, "true_bb", function);
-        BasicBlock *false_bb = BasicBlock::Create(*context, "false_bb", function);
-        BasicBlock *after_bb = BasicBlock::Create(*context, "after_bb", function);
-        builder->CreateCondBr(codegen(op->condition), true_bb, false_bb);
+    internal_assert(op->condition.type().is_scalar());
 
-        builder->SetInsertPoint(true_bb);
-        Value *true_value = codegen(op->true_value);
-        builder->CreateBr(after_bb);
-        // The true value might have jumped to a new block (e.g. if there was a
-        // nested select). To generate a correct PHI node, grab the current
-        // block.
-        BasicBlock *true_pred = builder->GetInsertBlock();
-
-        builder->SetInsertPoint(false_bb);
-        Value *false_value = codegen(op->false_value);
-        builder->CreateBr(after_bb);
-        BasicBlock *false_pred = builder->GetInsertBlock();
-
-        builder->SetInsertPoint(after_bb);
-        PHINode *phi = builder->CreatePHI(true_value->getType(), 2);
-        phi->addIncoming(true_value, true_pred);
-        phi->addIncoming(false_value, false_pred);
-
-        value = phi;
-    } else {
-        CodeGen_Posix::visit(op);
-    }
+    // Implement scalar conditions with if-then-else.
+    codegen(Call::make(op->type, Call::if_then_else, {op->condition, op->true_value, op->false_value}, Call::Intrinsic));
 }
 
 void CodeGen_Hexagon::visit(const GT *op) {

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1425,9 +1425,9 @@ void CodeGen_Hexagon::visit(const Select *op) {
 
     if (op->type.is_vector()) {
         // Implement scalar conditions on vector values with if-then-else.
-        codegen(Call::make(op->type, Call::if_then_else,
-                           {op->condition, op->true_value, op->false_value},
-                           Call::Intrinsic));
+        value = codegen(Call::make(op->type, Call::if_then_else,
+                                   {op->condition, op->true_value, op->false_value},
+                                   Call::Intrinsic));
     } else {
         CodeGen_Posix::visit(op);
     }

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1379,6 +1379,7 @@ void CodeGen_Hexagon::visit(const Call *op) {
                 Expr equiv = -Cast::make(op->type, op->args[0]);
                 equiv.accept(this);
             }
+            return;
         } else if (op->is_intrinsic(Call::cast_mask)) {
             internal_error << "cast_mask should already have been handled in HexagonOptimize\n";
         }

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -240,10 +240,12 @@ Expr lower_euclidean_mod(Expr a, Expr b) {
         // Match this non-overflowing C code
         /*
           T r = a % b;
-          r = r + (r < 0 ? abs(b) : 0);
+          T sign_mask = (r >> (sizeof(r)*8 - 1));
+          r = r + sign_mask & abs(b);
         */
 
-        r = select(r < 0, r + abs(b), r);
+        Expr sign_mask = r >> (a.type().bits()-1);
+        r += sign_mask & abs(b);
         return common_subexpression_elimination(r);
     } else {
         return r;

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2555,9 +2555,12 @@ void CodeGen_LLVM::visit(const Call *op) {
         codegen(op->args[0]);
         value = codegen(op->args[1]);
     } else if (op->is_intrinsic(Call::if_then_else)) {
-        if (op->type.is_vector()) {
+        Expr cond = op->args[0];
+        if (const Broadcast *b = cond.as<Broadcast>()) {
+            cond = b->value;
+        }
+        if (cond.type().is_vector()) {
             scalarize(op);
-
         } else {
 
             internal_assert(op->args.size() == 3);
@@ -2565,20 +2568,21 @@ void CodeGen_LLVM::visit(const Call *op) {
             BasicBlock *true_bb = BasicBlock::Create(*context, "true_bb", function);
             BasicBlock *false_bb = BasicBlock::Create(*context, "false_bb", function);
             BasicBlock *after_bb = BasicBlock::Create(*context, "after_bb", function);
-            builder->CreateCondBr(codegen(op->args[0]), true_bb, false_bb);
+            builder->CreateCondBr(codegen(cond), true_bb, false_bb);
             builder->SetInsertPoint(true_bb);
             Value *true_value = codegen(op->args[1]);
             builder->CreateBr(after_bb);
-
+            BasicBlock *true_pred = builder->GetInsertBlock();
+            
             builder->SetInsertPoint(false_bb);
             Value *false_value = codegen(op->args[2]);
             builder->CreateBr(after_bb);
+            BasicBlock *false_pred = builder->GetInsertBlock();
 
             builder->SetInsertPoint(after_bb);
-
             PHINode *phi = builder->CreatePHI(true_value->getType(), 2);
-            phi->addIncoming(true_value, true_bb);
-            phi->addIncoming(false_value, false_bb);
+            phi->addIncoming(true_value, true_pred);
+            phi->addIncoming(false_value, false_pred);
 
             value = phi;
         }

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -220,6 +220,48 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Call *op) {
             }
             stream << ");\n";
         }
+    } else if (op->is_intrinsic(Call::bool_to_mask)) {
+        if (op->args[0].type().is_vector()) {
+            // The argument is already some sort of mask. Just sign-extend
+            // to the expected type.
+            Expr equiv = Cast::make(op->type, op->args[0]);
+            equiv.accept(this);
+        } else {
+            // The argument is a scalar bool. Casting it to an int
+            // produces zero or one. Convert it to -1 of the requested
+            // type.
+            Expr equiv = -Cast::make(op->type, op->args[0]);
+            equiv.accept(this);
+        }
+    } else if (op->is_intrinsic(Call::cast_mask)) {
+        // Sign-extension is fine
+        Expr equiv = Cast::make(op->type, op->args[0]);
+        equiv.accept(this);
+    } else if (op->is_intrinsic(Call::select_mask)) {
+        internal_assert(op->args.size() == 3);
+        string cond = print_expr(op->args[0]);
+        string true_val = print_expr(op->args[1]);
+        string false_val = print_expr(op->args[2]);
+
+        // Yes, you read this right. OpenCL's select function is declared
+        // 'select(false_case, true_case, condition)'.
+        ostringstream rhs;
+        rhs << "select(" << false_val << ", " << true_val << ", " << cond << ")";
+        print_assignment(op->type, rhs.str());
+    } else if (op->is_intrinsic(Call::abs)) {
+        if (op->type.is_float()) {
+            ostringstream rhs;
+            rhs << "abs_f" << op->type.bits() << "(" << print_expr(op->args[0]) << ")";
+            print_assignment(op->type, rhs.str());
+        } else {
+            ostringstream rhs;
+            rhs << "abs(" << print_expr(op->args[0]) << ")";
+            print_assignment(op->type, rhs.str());
+        }
+    } else if (op->is_intrinsic(Call::absd)) {
+        ostringstream rhs;
+        rhs << "abs_diff(" << print_expr(op->args[0]) << ", " << print_expr(op->args[1]) << ")";
+        print_assignment(op->type, rhs.str());
     } else {
         CodeGen_C::visit(op);
     }
@@ -383,19 +425,8 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Cast *op) {
 }
 
 void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Select *op) {
-    if (op->condition.type().is_vector()) {
-        string true_val = print_expr(op->true_value);
-        string false_val = print_expr(op->false_value);
-        string cond = print_expr(op->condition);
-
-        // Yes, you read this right. OpenCL's select function is declared
-        // 'select(false_case, true_case, condition)'.
-        ostringstream rhs;
-        rhs << "select(" << false_val << ", " << true_val << ", " << cond << ")";
-        print_assignment(op->type, rhs.str());
-    } else {
-        CodeGen_C::visit(op);
-    }
+    internal_assert(op->condition.type().is_scalar());
+    CodeGen_C::visit(op);
 }
 
 void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Allocate *op) {

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -222,10 +222,9 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Call *op) {
         }
     } else if (op->is_intrinsic(Call::bool_to_mask)) {
         if (op->args[0].type().is_vector()) {
-            // The argument is already some sort of mask. Just sign-extend
-            // to the expected type.
-            Expr equiv = Cast::make(op->type, op->args[0]);
-            equiv.accept(this);
+            // The argument is already a mask of the right width. Just
+            // sign-extend to the expected type.
+            op->args[0].accept(this);
         } else {
             // The argument is a scalar bool. Casting it to an int
             // produces zero or one. Convert it to -1 of the requested

--- a/src/EliminateBoolVectors.h
+++ b/src/EliminateBoolVectors.h
@@ -14,12 +14,14 @@ namespace Internal {
  * that the boolean operation is being used to operate on. For
  * example, instead of select(i1x8, u16x8, u16x8), the target would
  * prefer to see select(u16x8, u16x8, u16x8), where the first argument
- * is a vector of integers that are either all ones or all zeros. This
- * pass converts vectors of bools to vectors of integers to meet this
- * requirement. This is done by casting boolean vectors to integers
- * (with sign extension), using bitwise instead of logical operators,
- * and replacing the conditions of select with a not equals zero
- * expression. */
+ * is a vector of integers representing a mask. This pass converts
+ * vectors of bools to vectors of integers to meet this
+ * requirement. This is done by injecting intrinsics to convert bools
+ * to architecture-specific masks, and using a select_mask instrinsic
+ * instead of a Select node. Because the masks are architecture
+ * specific, they may not be stored or loaded. On Stores, the masks
+ * are converted to UInt(8) with a value of 0 or 1, which is our
+ * canonical in-memory representation of a bool. */
 ///@{
 EXPORT Stmt eliminate_bool_vectors(Stmt s);
 EXPORT Expr eliminate_bool_vectors(Expr s);

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -627,6 +627,8 @@ Call::ConstString Call::mod_round_to_zero = "mod_round_to_zero";
 Call::ConstString Call::slice_vector = "slice_vector";
 Call::ConstString Call::call_cached_indirect_function = "call_cached_indirect_function";
 Call::ConstString Call::signed_integer_overflow = "signed_integer_overflow";
-
+Call::ConstString Call::bool_to_mask = "bool_to_mask";
+Call::ConstString Call::cast_mask = "cast_mask";
+Call::ConstString Call::select_mask = "select_mask";
 }
 }

--- a/src/IR.h
+++ b/src/IR.h
@@ -498,7 +498,10 @@ struct Call : public ExprNode<Call> {
         mod_round_to_zero,
         slice_vector,
         call_cached_indirect_function,
-        signed_integer_overflow;
+        signed_integer_overflow,
+        bool_to_mask,
+        cast_mask,
+        select_mask;
 
     // If it's a call to another halide function, this call node holds
     // onto a pointer to that function for the purposes of reference


### PR DESCRIPTION
... so that the intermediate IR is well-formed and produces the same
results on every platform. Now on Hexagon and OpenCL we promote bool
vectors to multi-bit "masks" immediately after creating them (with a
comparison). This is codegenned as a no-op, because that's what the
comparisons do natively. All of the bits of a mask must be zero when it
represents a false value. True values are represented by architecture-
specific values (0x01 in every byte on hexagon, 0xff in every byte on
opencl). There is a cast and a select equivalent that work on these
masks. They must be implemented per-backend in a way that works with
that backend's representation. Logical operators are handled with
bitwise operators.

Storing a mask, or casting it to an actual int, forces it to be zero or
one, because at that point it might escape one architecture and leak to
another (e.g. storing on Hexagon followed by loading on ARM).