### PR TITLE
Support allocations (arrays) inside GL kernels

### DIFF
--- a/src/CodeGen_OpenGL_Dev.h
+++ b/src/CodeGen_OpenGL_Dev.h
@@ -95,7 +95,9 @@ protected:
 
     void visit(const Load *);
     void visit(const Store *);
-
+    void visit(const Allocate *);
+    void visit(const Free *);    
+    
     void visit(const Call *);
     void visit(const AssertStmt *);
     void visit(const Ramp *op);

--- a/src/CodeGen_OpenGL_Dev.h
+++ b/src/CodeGen_OpenGL_Dev.h
@@ -96,8 +96,8 @@ protected:
     void visit(const Load *);
     void visit(const Store *);
     void visit(const Allocate *);
-    void visit(const Free *);    
-    
+    void visit(const Free *);
+
     void visit(const Call *);
     void visit(const AssertStmt *);
     void visit(const Ramp *op);
@@ -107,6 +107,7 @@ protected:
 
 private:
     std::string get_vector_suffix(Expr e);
+    char get_lane_suffix(int i);
 
     const Target target;
 };

--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -112,17 +112,23 @@ protected:
 
     virtual void visit(const For *op) {
         bool old_in_glsl_loops = in_glsl_loops;
+        bool kernel_loop = op->device_api == DeviceAPI::GLSL;
+        bool within_kernel_loop = !kernel_loop && in_glsl_loops;
         // Check if the loop variable is a GPU variable thread variable and for GLSL
-        if ((CodeGen_GPU_Dev::is_gpu_var(op->name) && op->device_api == DeviceAPI::GLSL) ||
-            (in_glsl_loops && op->device_api == DeviceAPI::None)) {
+        if (kernel_loop) {
             loop_vars.push_back(op->name);
             in_glsl_loops = true;
+        } else if (within_kernel_loop) {
+            // The inner loop variable is non-linear w.r.t the glsl pixel coordinate.
+            scope.push(op->name, 2); 
         }
 
         Stmt mutated_body = mutate(op->body);
 
-        if (CodeGen_GPU_Dev::is_gpu_var(op->name)  && op->device_api == DeviceAPI::GLSL) {
+        if (kernel_loop) {
             loop_vars.pop_back();
+        } else if (within_kernel_loop) {
+            scope.pop(op->name);
         }
 
         in_glsl_loops = old_in_glsl_loops;

--- a/test/opengl/inline_reduction.cpp
+++ b/test/opengl/inline_reduction.cpp
@@ -14,10 +14,23 @@ int main() {
     Func f;
     Var x, y, c;
     RDom r(0, 10);
-    f(x, y, c) = sum(r);
+    f(x, y, c) = sum(cast<float>(r));
     f.bound(c, 0, 3).glsl(x, y, c);
 
-    f.realize(100, 100, 3);
+    Image<float> result = f.realize(100, 100, 3);
+
+    for (int c = 0; c < result.channels(); c++) {
+        for (int y = 0; y < result.height(); y++) {
+            for (int x = 0; x < result.width(); x++) {
+                float correct = 45;
+                if (result(x, y, c) != correct) {
+                    printf("result(%d, %d, %d) = %f instead of %f\n",
+                           x, y, c, result(x, y, c), correct);
+                    return -1;
+                }
+            }
+        }
+    }
 
     printf("Success!\n");
 


### PR DESCRIPTION
This adds some level of support for Allocate/Load/Store nodes (e.g. due to an inline reduction) inside GLSL kernels. It doesn't generate amazing GLSL, but it seems to work for some simple cases.

@shoaibkamil @ronen PTAL