### PR TITLE
Glsl loop partitioning

### DIFF
--- a/src/CodeGen_OpenGL_Dev.h
+++ b/src/CodeGen_OpenGL_Dev.h
@@ -95,7 +95,9 @@ protected:
 
     void visit(const Load *);
     void visit(const Store *);
-
+    void visit(const Allocate *);
+    void visit(const Free *);    
+    
     void visit(const Call *);
     void visit(const AssertStmt *);
     void visit(const Ramp *op);

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -726,6 +726,7 @@ class RenormalizeGPULoops : public IRMutator {
         if (op->device_api == DeviceAPI::GLSL) {
             // The partitioner did not enter GLSL loops
             stmt = op;
+            return;
         }
         
         if (ends_with(op->name, Var::gpu_threads().name())) {

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -448,6 +448,14 @@ class PartitionLoops : public IRMutator {
             return;
         }
 
+        // We shouldn't partition GLSL loops - they have control-flow
+        // constraints.
+        if (op->device_api == DeviceAPI::GLSL) {
+            stmt = op;
+            in_gpu_loop = old_in_gpu_loop;
+            return;
+        }
+        
         // Find simplifications in this loop body
         FindSimplifications finder(op->name);
         body.accept(&finder);
@@ -715,6 +723,11 @@ class RenormalizeGPULoops : public IRMutator {
     vector<pair<string, Expr> > lifted_lets;
 
     void visit(const For *op) {
+        if (op->device_api == DeviceAPI::GLSL) {
+            // The partitioner did not enter GLSL loops
+            stmt = op;
+        }
+        
         if (ends_with(op->name, Var::gpu_threads().name())) {
             in_thread_loop = true;
             IRMutator::visit(op);

--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -112,17 +112,23 @@ protected:
 
     virtual void visit(const For *op) {
         bool old_in_glsl_loops = in_glsl_loops;
+        bool kernel_loop = op->device_api == DeviceAPI::GLSL;
+        bool within_kernel_loop = !kernel_loop && in_glsl_loops;
         // Check if the loop variable is a GPU variable thread variable and for GLSL
-        if ((CodeGen_GPU_Dev::is_gpu_var(op->name) && op->device_api == DeviceAPI::GLSL) ||
-            (in_glsl_loops && op->device_api == DeviceAPI::None)) {
+        if (kernel_loop) {
             loop_vars.push_back(op->name);
             in_glsl_loops = true;
+        } else if (within_kernel_loop) {
+            // The inner loop variable is non-linear w.r.t the glsl pixel coordinate.
+            scope.push(op->name, 2); 
         }
 
         Stmt mutated_body = mutate(op->body);
 
-        if (CodeGen_GPU_Dev::is_gpu_var(op->name)  && op->device_api == DeviceAPI::GLSL) {
+        if (kernel_loop) {
             loop_vars.pop_back();
+        } else if (within_kernel_loop) {
+            scope.pop(op->name);
         }
 
         in_glsl_loops = old_in_glsl_loops;

--- a/test/opengl/inline_reduction.cpp
+++ b/test/opengl/inline_reduction.cpp
@@ -14,10 +14,23 @@ int main() {
     Func f;
     Var x, y, c;
     RDom r(0, 10);
-    f(x, y, c) = sum(r);
+    f(x, y, c) = sum(cast<float>(r));
     f.bound(c, 0, 3).glsl(x, y, c);
 
-    f.realize(100, 100, 3);
+    Image<float> result = f.realize(100, 100, 3);
+
+    for (int c = 0; c < result.channels(); c++) {
+        for (int y = 0; y < result.height(); y++) {
+            for (int x = 0; x < result.width(); x++) {
+                float correct = 45;
+                if (result(x, y, c) != correct) {
+                    printf("result(%d, %d, %d) = %f instead of %f\n",
+                           x, y, c, result(x, y, c), correct);
+                    return -1;
+                }
+            }
+        }
+    }
 
     printf("Success!\n");
 


### PR DESCRIPTION
Builds on #1427 

This PR just turns off the loop partitioner for GLSL loops. It's not clear loop partitioning is a good idea, given gl control flow constraints. The underlying issue here that made things break was that the loop partitioner expects a loop over threads inside the loop over blocks, and there isn't one with GLSL. GLSL should probably represent its magic loops in some other way, instead of using our block variables for Cuda/OpenCL.