### PR TITLE
Promote LoopLevel to public type

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1898,13 +1898,8 @@ Func &Func::fold_storage(Var dim, Expr factor, bool fold_forward) {
     return *this;
 }
 
-Func &Func::compute_at(Func f, RVar var) {
-    return compute_at(f, Var(var.name()));
-}
-
-Func &Func::compute_at(Func f, Var var) {
+Func &Func::compute_at(LoopLevel loop_level) {
     invalidate_cache();
-    LoopLevel loop_level(f.name(), var.name());
     func.schedule().compute_level() = loop_level;
     if (func.schedule().store_level().is_inline()) {
         func.schedule().store_level() = loop_level;
@@ -1912,36 +1907,38 @@ Func &Func::compute_at(Func f, Var var) {
     return *this;
 }
 
+Func &Func::compute_at(Func f, RVar var) {
+    return compute_at(LoopLevel(f, var));
+}
+
+Func &Func::compute_at(Func f, Var var) {
+    return compute_at(LoopLevel(f, var));
+}
+
 Func &Func::compute_root() {
+    return compute_at(LoopLevel::root());
+}
+
+Func &Func::store_at(LoopLevel loop_level) {
     invalidate_cache();
-    func.schedule().compute_level() = LoopLevel::root();
-    if (func.schedule().store_level().is_inline()) {
-        func.schedule().store_level() = LoopLevel::root();
-    }
+    func.schedule().store_level() = loop_level;
     return *this;
 }
 
 Func &Func::store_at(Func f, RVar var) {
-    return store_at(f, Var(var.name()));
+    return store_at(LoopLevel(f, var));
 }
 
 Func &Func::store_at(Func f, Var var) {
-    invalidate_cache();
-    func.schedule().store_level() = LoopLevel(f.name(), var.name());
-    return *this;
+    return store_at(LoopLevel(f, var));
 }
 
 Func &Func::store_root() {
-    invalidate_cache();
-    func.schedule().store_level() = LoopLevel::root();
-    return *this;
+    return store_at(LoopLevel::root());
 }
 
 Func &Func::compute_inline() {
-    invalidate_cache();
-    func.schedule().compute_level() = LoopLevel();
-    func.schedule().store_level() = LoopLevel();
-    return *this;
+    return compute_at(LoopLevel());
 }
 
 Func &Func::trace_loads() {

--- a/src/Func.h
+++ b/src/Func.h
@@ -1523,6 +1523,10 @@ public:
      * to the version of compute_at that takes a Var. */
     EXPORT Func &compute_at(Func f, RVar var);
 
+    /** Schedule a function to be computed within the iteration over
+     * a given LoopLevel. */
+    EXPORT Func &compute_at(LoopLevel loop_level);
+
     /** Compute all of this function once ahead of time. Reusing
      * the example in \ref Func::compute_at :
      *
@@ -1666,6 +1670,11 @@ public:
      * schedules storage within the loop over a dimension of a
      * reduction domain */
     EXPORT Func &store_at(Func f, RVar var);
+
+
+    /** Equivalent to the version of store_at that takes a Var, but
+     * schedules storage at a given LoopLevel. */
+    EXPORT Func &store_at(LoopLevel loop_level);
 
     /** Equivalent to \ref Func::store_at, but schedules storage
      * outside the outermost loop. */

--- a/src/Function.h
+++ b/src/Function.h
@@ -77,7 +77,7 @@ public:
     EXPORT Function();
 
     /** Construct a new function with the given name */
-    EXPORT Function(const std::string &n);
+    EXPORT explicit Function(const std::string &n);
 
     /** Construct a Function from an existing FunctionContents pointer. Must be non-null */
     EXPORT explicit Function(const IntrusivePtr<FunctionContents> &);

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -506,8 +506,9 @@ protected:
     using Expr = Halide::Expr;
     using ExternFuncArgument = Halide::ExternFuncArgument;
     using Func = Halide::Func;
-    using Pipeline = Halide::Pipeline;
     using ImageParam = Halide::ImageParam;
+    using LoopLevel = Halide::LoopLevel;
+    using Pipeline = Halide::Pipeline;
     using RDom = Halide::RDom;
     using TailStrategy = Halide::TailStrategy;
     using Target = Halide::Target;

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -15,7 +15,7 @@ LoopLevel::LoopLevel(Internal::Function f, VarOrRVar v) : LoopLevel(f.get_conten
 LoopLevel::LoopLevel(Func f, VarOrRVar v) : LoopLevel(f.function().get_contents(), v.name(), v.is_rvar) {}
 
 std::string LoopLevel::func_name() const {
-    if (function_contents.get() != nullptr) {
+    if (function_contents.defined()) {
         return Internal::Function(function_contents).name();
     }
     return "";
@@ -23,7 +23,7 @@ std::string LoopLevel::func_name() const {
 
 Func LoopLevel::func() const {
     internal_assert(!is_inline() && !is_root());
-    internal_assert(function_contents.get() != nullptr);
+    internal_assert(function_contents.defined());
     return Func(Internal::Function(function_contents));
 }
 
@@ -46,7 +46,7 @@ bool LoopLevel::is_root() const {
 }
 
 std::string LoopLevel::to_string() const {
-    return (function_contents.get() ? Internal::Function(function_contents).name() : "") + "." + var_name;
+    return (function_contents.defined() ? Internal::Function(function_contents).name() : "") + "." + var_name;
 }
 
 bool LoopLevel::match(const std::string &loop) const {

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -1,8 +1,15 @@
+#include "Func.h"
 #include "IR.h"
 #include "IRMutator.h"
 #include "Schedule.h"
+#include "Var.h"
 
 namespace Halide {
+
+LoopLevel::LoopLevel(Func f, Var v) : func_(f.name()), var_(v.name()) {}
+
+LoopLevel::LoopLevel(Func f, RVar v) : func_(f.name()), var_(v.name()) {}
+
 namespace Internal {
 
 typedef std::map<IntrusivePtr<FunctionContents>, IntrusivePtr<FunctionContents>> DeepCopyMap;
@@ -243,5 +250,6 @@ void Schedule::mutate(IRMutator *mutator) {
     }
 }
 
-}
-}
+}  // namespace Internal
+}  // namespace Halide
+

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -813,7 +813,7 @@ public:
     };
     vector<Site> sites_allowed;
 
-    ComputeLegalSchedules(Function f) : func(f), found(false) {}
+    ComputeLegalSchedules(Function f, const map<string, Function> &env) : func(f), found(false), env(env) {}
 
 private:
     using IRVisitor::visit;
@@ -821,6 +821,7 @@ private:
     vector<Site> sites;
     Function func;
     bool found;
+    const map<string, Function> &env;
 
     void visit(const For *f) {
         f->min.accept(this);
@@ -830,9 +831,18 @@ private:
         internal_assert(first_dot != string::npos && last_dot != string::npos);
         string func = f->name.substr(0, first_dot);
         string var = f->name.substr(last_dot + 1);
+        LoopLevel loop_level;
+        if (func.empty()) {
+            internal_assert(!var.empty());
+            loop_level = LoopLevel::root();
+        } else {
+            auto it = env.find(func);
+            internal_assert(it != env.end()) << "Unable to find Function " << func << " in env (Var = " << var << ")\n";
+            loop_level = LoopLevel(it->second, Var(var));
+        }
         Site s = {f->for_type == ForType::Parallel ||
                   f->for_type == ForType::Vectorized,
-                  LoopLevel(func, var)};
+                  loop_level};
         sites.push_back(s);
         f->body.accept(this);
         sites.pop_back();
@@ -884,8 +894,8 @@ string schedule_to_source(Function f,
     if (compute_at.is_inline()) {
         ss << ".compute_inline()";
     } else {
-        string store_var_name = store_at.var();
-        string compute_var_name = compute_at.var();
+        string store_var_name = store_at.var().name();
+        string compute_var_name = compute_at.var().name();
         if (store_var_name == Var::outermost().name()) {
             store_var_name = "Var::outermost()";
         }
@@ -896,13 +906,13 @@ string schedule_to_source(Function f,
             if (store_at.is_root()) {
                 ss << ".store_root()";
             } else {
-                ss << ".store_at(" << store_at.func() << ", " << store_var_name << ")";
+                ss << ".store_at(" << store_at.func().name() << ", " << store_var_name << ")";
             }
         }
         if (compute_at.is_root()) {
             ss << ".compute_root()";
         } else {
-            ss << ".compute_at(" << compute_at.func() << ", " << compute_var_name << ")";
+            ss << ".compute_at(" << compute_at.func().name() << ", " << compute_var_name << ")";
         }
     }
     ss << ";";
@@ -939,7 +949,7 @@ class PrintUsesOfFunc : public IRVisitor {
 
     void visit(const For *op) {
         if (ends_with(op->name, Var::outermost().name()) ||
-            ends_with(op->name, LoopLevel::root().var())) {
+            ends_with(op->name, LoopLevel::root().to_string())) {
             IRVisitor::visit(op);
         } else {
 
@@ -990,7 +1000,7 @@ public:
     PrintUsesOfFunc(string f, std::ostream &s) : func(f), stream(s) {}
 };
 
-void validate_schedule(Function f, Stmt s, const Target &target, bool is_output) {
+void validate_schedule(Function f, Stmt s, const Target &target, bool is_output, const map<string, Function> &env) {
 
     // If f is extern, check that none of its inputs are scheduled inline.
     if (f.has_extern_definition()) {
@@ -1076,7 +1086,7 @@ void validate_schedule(Function f, Stmt s, const Target &target, bool is_output)
     }
 
     // Otherwise inspect the uses to see what's ok.
-    ComputeLegalSchedules legal(f);
+    ComputeLegalSchedules legal(f, env);
     s.accept(&legal);
 
     bool store_at_ok = false, compute_at_ok = false;
@@ -1101,7 +1111,7 @@ void validate_schedule(Function f, Stmt s, const Target &target, bool is_output)
             if (sites[i].is_parallel) {
                 err << "Func \"" << f.name()
                     << "\" is stored outside the parallel loop over "
-                    << sites[i].loop_level.func() << "." << sites[i].loop_level.var()
+                    << sites[i].loop_level.to_string()
                     << " but computed within it. This is a potential race condition.\n";
                 store_at_ok = compute_at_ok = false;
             }
@@ -1153,7 +1163,7 @@ Stmt schedule_functions(const vector<Function> &outputs,
                         const Target &target,
                         bool &any_memoized) {
 
-    string root_var = LoopLevel::root().func() + "." + LoopLevel::root().var();
+    string root_var = LoopLevel::root().to_string();
     Stmt s = For::make(root_var, 0, 1, ForType::Serial, DeviceAPI::Host, Evaluate::make(0));
 
     any_memoized = false;
@@ -1166,7 +1176,7 @@ Stmt schedule_functions(const vector<Function> &outputs,
             is_output |= o.same_as(f);
         }
 
-        validate_schedule(f, s, target, is_output);
+        validate_schedule(f, s, target, is_output, env);
 
         if (f.can_be_inlined() &&
             f.schedule().compute_level().is_inline()) {


### PR DESCRIPTION
LoopLevel will be useful for some upcoming scheduling work (e.g. where
you need to specify compute_at or store_at via a lambda), so promote it
out of Internal namespace and:
— give it properly typed ctors and hide the data members
— add compute_at() and store_at() overloads that accept one
— reimplement all other
compute_at()/store_at()/compute_root()/store_root() implements to use
the LoopLevel-based one