### PR TITLE
Add support for fast vectorized modulus

### DIFF
--- a/src/FastIntegerDivide.cpp
+++ b/src/FastIntegerDivide.cpp
@@ -226,4 +226,9 @@ Expr fast_integer_divide(Expr numerator, Expr denominator) {
     return result;
 
 }
+
+Expr fast_integer_modulo(Expr numerator, Expr denominator) {
+    return numerator - fast_integer_divide(numerator, denominator) * denominator;
+}
+
 }

--- a/src/FastIntegerDivide.h
+++ b/src/FastIntegerDivide.h
@@ -42,6 +42,11 @@ EXPORT Image<uint32_t> integer_divide_table_s32();
  */
 EXPORT Expr fast_integer_divide(Expr numerator, Expr denominator);
 
+/** Use the fast integer division tables to implement a modulo
+ * operation via the Euclidean identity: a%b = a - (a/b)*b
+ */
+EXPORT Expr fast_integer_modulo(Expr numerator, Expr denominator);
+
 }
 
 #endif

--- a/test/performance/const_division.cpp
+++ b/test/performance/const_division.cpp
@@ -6,15 +6,15 @@
 using namespace Halide;
 
 template<typename T>
-bool test(int w) {
+bool test(int w, bool div) {
     Func f, g, h;
     Var x, y;
 
     size_t bits = sizeof(T)*8;
     bool is_signed = (T)(-1) < (T)(0);
 
-    printf("Testing %sint%d_t x %d\n",
-           is_signed ? "" : "u",
+    printf("%sInt(%2d, %2d)    ",
+           is_signed ? " " : "U",
            (int)bits, w);
 
     int min_val = 2, num_vals = 254;
@@ -37,13 +37,25 @@ bool test(int w) {
         }
     }
 
-    f(x, y) = input(x, y)/cast<T>(y + min_val);
+    if (div) {
+        // Test div
+        f(x, y) = input(x, y) / cast<T>(y + min_val);
 
-    // Reference good version
-    g(x, y) = input(x, y)/cast<T>(y + min_val);
+        // Reference good version
+        g(x, y) = input(x, y) / cast<T>(y + min_val);
 
-    // Version that uses fast_integer_divide
-    h(x, y) = Halide::fast_integer_divide(input(x, y), cast<uint8_t>(y + min_val));
+        // Version that uses fast_integer_divide
+        h(x, y) = Halide::fast_integer_divide(input(x, y), cast<uint8_t>(y + min_val));
+    } else {
+        // Test mod
+        f(x, y) = input(x, y) % cast<T>(y + min_val);
+
+        // Reference good version
+        g(x, y) = input(x, y) % cast<T>(y + min_val);
+
+        // Version that uses fast_integer_modulo
+        h(x, y) = Halide::fast_integer_modulo(input(x, y), cast<uint8_t>(y + min_val));
+    }
 
     // Try dividing by all the known constants using vectors
     f.bound(y, 0, num_vals).bound(x, 0, input.width()).unroll(y);
@@ -58,16 +70,15 @@ bool test(int w) {
     h.compile_jit();
 
     Image<T> correct = g.realize(input.width(), num_vals);
-    double t_correct = benchmark(1, 30, [&]() { g.realize(correct); });
+    double t_correct = benchmark(5, 200, [&]() { g.realize(correct); });
 
     Image<T> fast = f.realize(input.width(), num_vals);
-    double t_fast = benchmark(1, 30, [&]() { f.realize(fast); });
+    double t_fast = benchmark(5, 200, [&]() { f.realize(fast); });
 
     Image<T> fast_dynamic = h.realize(input.width(), num_vals);
-    double t_fast_dynamic = benchmark(1, 30, [&]() { h.realize(fast_dynamic); });
+    double t_fast_dynamic = benchmark(10, 200, [&]() { h.realize(fast_dynamic); });
 
-    printf("compile-time-constant divisor path is %1.3f x faster \n", t_correct / t_fast);
-    printf("fast_integer_divide path is           %1.3f x faster \n", t_fast_dynamic / t_fast);
+    printf("%6.3f                  %6.3f\n", t_correct / t_fast, t_correct / t_fast_dynamic);
 
     for (int y = 0; y < num_vals; y++) {
         for (int x = 0; x < input.width(); x++) {
@@ -92,22 +103,24 @@ int main(int argc, char **argv) {
     srand(time(nullptr));
 
     bool success = true;
-    // Scalar
-    success = success && test<int32_t>(1);
-    success = success && test<int16_t>(1);
-    success = success && test<int8_t>(1);
-    success = success && test<uint32_t>(1);
-    success = success && test<uint16_t>(1);
-    success = success && test<uint8_t>(1);
-    // Vector
-    success = success && test<int32_t>(4);
-    success = success && test<int16_t>(8);
-    success = success && test<int8_t>(16);
-    success = success && test<uint32_t>(4);
-    success = success && test<uint16_t>(8);
-    success = success && test<uint8_t>(16);
-
-    //success = test<uint16_t>(8);
+    for (int i = 0; i < 2; i++) {
+        const char *name = (i == 0 ? "divisor" : "modulus");
+        printf("type            const-%s speed-up  runtime-%s speed-up\n", name, name);
+        // Scalar
+        success = success && test<int32_t>(1, i == 0);
+        success = success && test<int16_t>(1, i == 0);
+        success = success && test<int8_t>(1, i == 0);
+        success = success && test<uint32_t>(1, i == 0);
+        success = success && test<uint16_t>(1, i == 0);
+        success = success && test<uint8_t>(1, i == 0);
+        // Vector
+        success = success && test<int32_t>(8, i == 0);
+        success = success && test<int16_t>(16, i == 0);
+        success = success && test<int8_t>(32, i == 0);
+        success = success && test<uint32_t>(8, i == 0);
+        success = success && test<uint16_t>(16, i == 0);
+        success = success && test<uint8_t>(32, i == 0);
+    }
 
     if (success) {
         printf("Success!\n");

--- a/test/performance/const_division.cpp
+++ b/test/performance/const_division.cpp
@@ -76,7 +76,7 @@ bool test(int w, bool div) {
     double t_fast = benchmark(5, 200, [&]() { f.realize(fast); });
 
     Image<T> fast_dynamic = h.realize(input.width(), num_vals);
-    double t_fast_dynamic = benchmark(10, 200, [&]() { h.realize(fast_dynamic); });
+    double t_fast_dynamic = benchmark(5, 200, [&]() { h.realize(fast_dynamic); });
 
     printf("%6.3f                  %6.3f\n", t_correct / t_fast, t_correct / t_fast_dynamic);
 


### PR DESCRIPTION
Uses the support for fast vectorized division by small constants and the
Euclidean identity to make a fast vector modulus. Should speed up
storage folding by non-power-of-two factors.

@dsharletg 