### PR TITLE
Generate less openGL source

### DIFF
--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -65,10 +65,10 @@ Type map_type(const Type &type) {
 
 // Most GLSL builtins are only defined for float arguments, so we may have to
 // introduce type casts around the arguments and the entire function call.
-Expr call_builtin(const Type &result_type, const std::string &func,
-                  const std::vector<Expr> &args) {
+Expr call_builtin(const Type &result_type, const string &func,
+                  const vector<Expr> &args) {
     Type float_type = Float(32, result_type.lanes());
-    std::vector<Expr> new_args(args.size());
+    vector<Expr> new_args(args.size());
     for (size_t i = 0; i < args.size(); i++) {
         if (!args[i].type().is_float()) {
             new_args[i] = Cast::make(float_type, args[i]);
@@ -120,7 +120,7 @@ void CodeGen_OpenGL_Dev::dump() {
     std::cerr << src_stream.str() << std::endl;
 }
 
-std::string CodeGen_OpenGL_Dev::print_gpu_name(const std::string &name) {
+string CodeGen_OpenGL_Dev::print_gpu_name(const string &name) {
     return glc->print_name(name);
 }
 
@@ -227,8 +227,8 @@ string CodeGen_GLSLBase::print_type(Type type, AppendSpaceIfNeeded space_option)
 
 // Identifiers containing double underscores '__' are reserved in GLSL, so we
 // have to use a different name mangling scheme than in the C code generator.
-std::string CodeGen_GLSLBase::print_name(const std::string &name) {
-    const std::string mangled = CodeGen_C::print_name(name);
+string CodeGen_GLSLBase::print_name(const string &name) {
+    const string mangled = CodeGen_C::print_name(name);
     return replace_all(mangled, "__", "XX");
 }
 
@@ -251,11 +251,15 @@ void CodeGen_GLSL::visit(const FloatImm *op) {
 }
 
 void CodeGen_GLSL::visit(const IntImm *op) {
-    print_assignment(op->type, print_type(op->type) + "(" + std::to_string(op->value) + ")");
+    if (op->type == Int(32)) {
+        id = std::to_string(op->value);
+    } else {
+        id = print_type(op->type) + "(" + std::to_string(op->value) + ")";
+    }
 }
 
 void CodeGen_GLSL::visit(const UIntImm *op) {
-    print_assignment(op->type, print_type(op->type) + "(" + std::to_string(op->value) + ")");
+    id = print_type(op->type) + "(" + std::to_string(op->value) + ")";
 }
 
 void CodeGen_GLSL::visit(const Cast *op) {
@@ -285,7 +289,7 @@ void CodeGen_GLSL::visit(const Cast *op) {
 
 void CodeGen_GLSL::visit(const Let *op) {
 
-    if (op->name.find(".varying") != std::string::npos) {
+    if (op->name.find(".varying") != string::npos) {
 
         // Skip let statements for varying attributes
         op->body.accept(this);
@@ -316,9 +320,9 @@ void CodeGen_GLSL::visit(const For *loop) {
     }
 }
 
-std::vector<Expr> evaluate_vector_select(const Select *op) {
+vector<Expr> evaluate_vector_select(const Select *op) {
     const int lanes = op->type.lanes();
-    std::vector<Expr> result(lanes);
+    vector<Expr> result(lanes);
     for (int i = 0; i < lanes; i++) {
         Expr cond = extract_lane(op->condition, i);
         Expr true_value = extract_lane(op->true_value, i);
@@ -366,8 +370,8 @@ void CodeGen_GLSL::visit(const Select *op) {
         // directly without lowering to a sequence of "if" statements.
         internal_assert(op->condition.type().lanes() == op->type.lanes());
         int lanes = op->type.lanes();
-        std::vector<Expr> result = evaluate_vector_select(op);
-        std::vector<std::string> ids(lanes);
+        vector<Expr> result = evaluate_vector_select(op);
+        vector<string> ids(lanes);
         for (int i = 0; i < lanes; i++) {
             ids[i] = print_expr(result[i]);
         }
@@ -383,25 +387,27 @@ void CodeGen_GLSL::visit(const Select *op) {
     id = id_value;
 }
 
-std::string CodeGen_GLSL::get_vector_suffix(Expr e) {
-    std::vector<Expr> matches;
+string CodeGen_GLSL::get_vector_suffix(Expr e) {
+    vector<Expr> matches;
     Expr w = Variable::make(Int(32), "*");
 
     // The vectorize pass will insert a ramp in the color dimension argument.
-    if (expr_match(Ramp::make(w, 1, 4), e, matches)) {
+    const Ramp *r = e.as<Ramp>();
+    if (r && is_zero(r->base) && is_one(r->stride) && r->lanes == 4) {
         // No suffix is needed when accessing a full RGBA vector.
         return "";
-    } else if (expr_match(Ramp::make(w, 1, 3), e, matches)) {
+    } else if (r && is_zero(r->base) && is_one(r->stride) && r->lanes == 3) {
         return ".rgb";
-    } else if (expr_match(Ramp::make(w, 1, 2), e, matches)) {
+    } else if (r && is_zero(r->base) && is_one(r->stride) && r->lanes == 2) {
         return ".rg";
     } else {
         // GLSL 1.0 Section 5.5 supports subscript based vector indexing
-        std::string id = print_assignment(e.type(), print_expr(e));
+        internal_assert(e.type().is_scalar());
+        string id = print_expr(e);
         if (e.type() != Int(32)) {
             id = "int(" + id + ")";
         }
-        return std::string("[" + id + "]");
+        return string("[" + id + "]");
     }
 }
 
@@ -410,19 +416,46 @@ char CodeGen_GLSL::get_lane_suffix(int i) {
     return "rgba"[i];
 }
 
+vector<string> CodeGen_GLSL::print_lanes(Expr e) {
+    int l = e.type().lanes();
+    internal_assert(e.type().is_vector());
+    vector<string> result(l);
+    if (const Broadcast *b = e.as<Broadcast>()) {
+        string val = print_expr(b->value);
+        for (int i = 0; i < l; i++) {
+            result[i] = val;
+        }
+    } else if (const Ramp *r = e.as<Ramp>()) {
+        for (int i = 0; i < l; i++) {
+            result[i] = print_expr(simplify(r->base + i * r->stride));
+        }
+    } else {
+        string val = print_expr(e);
+        for (int i = 0; i < l; i++) {
+            result[i] = val + "[" + std::to_string(i) + "]";
+        }
+    }
+    return result;
+}
+
 void CodeGen_GLSL::visit(const Load *op) {
-    string idx = print_expr(op->index);
-    if (op->type.is_scalar()) {
+    if (scalar_vars.contains(op->name)) {
+        internal_assert(is_zero(op->index));
+        id = print_name(op->name);
+    } else if (vector_vars.contains(op->name)) {
+        id = print_name(op->name) + get_vector_suffix(op->index);
+    } else if (op->type.is_scalar()) {
+        string idx = print_expr(op->index);
         print_assignment(op->type, print_name(op->name) + "[" + idx + "]");
     } else {
+        vector<string> indices = print_lanes(op->index);
         ostringstream rhs;
         rhs << print_type(op->type) << "(";
         for (int i = 0; i < op->type.lanes(); i++) {
-            char c = get_lane_suffix(i);
             if (i > 0) {
                 rhs << ", ";
             }
-            rhs << print_name(op->name) << "[" << idx << "." << c << "]";
+            rhs << print_name(op->name) << "[" + indices[i] + "]";
         }
         rhs << ")";
         print_assignment(op->type, rhs.str());
@@ -430,17 +463,29 @@ void CodeGen_GLSL::visit(const Load *op) {
 }
 
 void CodeGen_GLSL::visit(const Store *op) {
-    string val = print_expr(op->value);
-    string idx = print_expr(op->index);
-    if (op->value.type().is_scalar()) {
+    if (scalar_vars.contains(op->name)) {
+        internal_assert(is_zero(op->index));
+        string val = print_expr(op->value);
+        do_indent();
+        stream << print_name(op->name) << " = " << val << ";\n";
+    } else if (vector_vars.contains(op->name)) {
+        string val = print_expr(op->value);
+        do_indent();
+        stream << print_name(op->name) << get_vector_suffix(op->index)
+               << " = " << val << ";\n";
+    } else if (op->value.type().is_scalar()) {
+        string val = print_expr(op->value);
+        string idx = print_expr(op->index);
         do_indent();
         stream << print_name(op->name) << "[" << idx << "] = " << val << ";\n";
     } else {
-        internal_assert(op->value.type().lanes() <= 4);
+        vector<string> indices = print_lanes(op->index);
+        vector<string> values = print_lanes(op->value);
         for (int i = 0; i < op->value.type().lanes(); i++) {
-            char l = get_lane_suffix(i);
             do_indent();
-            stream << print_name(op->name) << "[" << idx << "." << l << "] = " << val << "." << l << ";\n";
+            stream << print_name(op->name)
+                   << "[" << indices[i] << "] = "
+                   << values[i] << ";\n";
         }
     }
 }
@@ -505,30 +550,34 @@ void CodeGen_GLSL::visit(const Call *op) {
                 }
             } else {
                 // Otherwise do one load per lane and make a vector
+                vector<string> xs = print_lanes(op->args[2]);
+                vector<string> ys = print_lanes(op->args[3]);
+                vector<string> cs = print_lanes(op->args[4]);
+                string name = print_name(buffername);
+
                 string x = print_expr(op->args[2]), y = print_expr(op->args[3]);
-                rhs << "vec" << op->type.lanes() << "(";
+                rhs << print_type(op->type) << "(";
                 for (int i = 0; i < op->type.lanes(); i++) {
                     if (i > 0) {
                         rhs << ", ";
                     }
-                    Expr l = extract_lane(c, i);
-                    const int64_t *ic = as_const_int(l);
-                    internal_assert(ic && *ic >= 0 && *ic < 4) << c << "\n";
-                    char c_swizzle = get_lane_suffix(*ic);
-                    char xy_swizzle = get_lane_suffix(i);
-                    rhs << "texture2D(" << print_name(buffername) << ", vec2("
-                        << x << "." << xy_swizzle << ", "
-                        << y << "." << xy_swizzle << "))." << c_swizzle;
+                    rhs << "texture2D(" << name << ", vec2("
+                        << xs[i] << ", " << ys[i] << "))[" << cs[i] << "]";
                 }
                 rhs << ")";
             }
-        } else {
-            const int64_t *ic = as_const_int(op->args[4]);
-            internal_assert(ic && *ic >= 0 && *ic < 4);
+        } else if (const int64_t *ic = as_const_int(op->args[4])) {
+            internal_assert(*ic >= 0 && *ic < 4);
             rhs << "texture2D(" << print_name(buffername) << ", vec2("
                 << print_expr(op->args[2]) << ", "
                 << print_expr(op->args[3]) << "))."
                 << get_lane_suffix(*ic);
+        } else {
+            rhs << "texture2D(" << print_name(buffername) << ", vec2("
+                << print_expr(op->args[2]) << ", "
+                << print_expr(op->args[3]) << "))["
+                << print_expr(op->args[4]) << "]";
+
         }
 
         if (op->type.is_uint()) {
@@ -537,8 +586,8 @@ void CodeGen_GLSL::visit(const Call *op) {
 
     } else if (op->is_intrinsic(Call::glsl_texture_store)) {
         internal_assert(op->args.size() == 6);
-        std::string sval = print_expr(op->args[5]);
-        std::string suffix = get_vector_suffix(op->args[4]);
+        string sval = print_expr(op->args[5]);
+        string suffix = get_vector_suffix(op->args[4]);
         do_indent();
         stream << "gl_FragColor" << suffix
                << " = " << sval;
@@ -666,12 +715,56 @@ void CodeGen_GLSL::visit(const Call *op) {
     print_assignment(op->type, rhs.str());
 }
 
+namespace {
+class AllAccessConstant : public IRVisitor {
+    using IRVisitor::visit;
+
+    void visit(const Load *op) {
+        if (op->name == buf && !is_const(op->index)) {
+            result = false;
+        }
+        IRVisitor::visit(op);
+    }
+
+    void visit(const Store *op) {
+        if (op->name == buf && !is_const(op->index)) {
+            result = false;
+        }
+        IRVisitor::visit(op);
+    }
+
+public:
+    bool result = true;
+    string buf;
+};
+}
+
 void CodeGen_GLSL::visit(const Allocate *op) {
     int32_t size = op->constant_allocation_size();
     user_assert(size) << "Allocations inside GLSL kernels must be constant-sized\n";
+
+    // Check if all access to the allocation uses a constant index
+    AllAccessConstant all_access_constant;
+    all_access_constant.buf = op->name;
+    op->body.accept(&all_access_constant);
+
     do_indent();
-    stream << print_type(op->type) << " " << print_name(op->name) << "[" << size << "];\n";
-    op->body.accept(this);
+    if (size == 1) {
+        // We can use a variable
+        stream << print_type(op->type) << " " << print_name(op->name) << ";\n";
+        scalar_vars.push(op->name, 0);
+        op->body.accept(this);
+        scalar_vars.pop(op->name);
+    } else if (size <= 4 && all_access_constant.result) {
+        // We can just use a vector variable
+        stream << print_type(op->type.with_lanes(size)) << " " << print_name(op->name) << ";\n";
+        vector_vars.push(op->name, 0);
+        op->body.accept(this);
+        vector_vars.pop(op->name);
+    } else {
+        stream << print_type(op->type) << " " << print_name(op->name) << "[" << size << "];\n";
+        op->body.accept(this);
+    }
 }
 
 void CodeGen_GLSL::visit(const Free *op) {
@@ -736,7 +829,7 @@ void CodeGen_GLSL::add_kernel(Stmt stmt, string name,
 
             user_assert(args[i].read != args[i].write) <<
                 "GLSL: buffers may only be read OR written inside a kernel loop.\n";
-            std::string type_name;
+            string type_name;
             if (t == UInt(8)) {
                 type_name = "uint8_t";
             } else if (t == UInt(16)) {
@@ -996,8 +1089,7 @@ void CodeGen_GLSL::test() {
                              Broadcast::make(0, 4),
                              Ramp::make(0, 1, 4)},
                             Call::Intrinsic);
-    check(load4, "int $ = int(0);\n"
-                 "vec4 $ = texture2D($buf, vec2($, $));\n");
+    check(load4, "vec4 $ = texture2D($buf, vec2(0, 0));\n");
 
     check(log(1.0f), "float $ = log(1.0);\n");
     check(exp(1.0f), "float $ = exp(1.0);\n");

--- a/src/CodeGen_OpenGL_Dev.h
+++ b/src/CodeGen_OpenGL_Dev.h
@@ -109,6 +109,10 @@ private:
     std::string get_vector_suffix(Expr e);
     char get_lane_suffix(int i);
 
+    std::vector<std::string> print_lanes(Expr expr);
+
+    Scope<int> scalar_vars, vector_vars;
+
     const Target target;
 };
 

--- a/test/opengl/sumcolor_reduction.cpp
+++ b/test/opengl/sumcolor_reduction.cpp
@@ -1,0 +1,56 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main() {
+    // This test must be run with an OpenGL target.
+    const Target &target = get_jit_target_from_environment();
+    if (!target.has_feature(Target::OpenGL)) {
+        fprintf(stderr, "ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
+        return 1;
+    }
+
+
+    // Define the input.
+    const int width = 10, height = 10, channels = 3;
+    Image<float> input(width, height, channels);
+    for (int c = 0; c < input.channels(); c++) {
+        for (int y = 0; y < input.height(); y++) {
+            for (int x = 0; x < input.width(); x++) {
+                input(x, y, c) = x + y;
+            }
+        }
+    }
+
+    // Define the algorithm.
+    Var x, y, c;
+    RDom r(0, 3, "r");
+    Func g;
+
+    g(x, y, c) = sum(input(x, y, r));
+
+    // Schedule f and g to compute in separate passes on the GPU.
+    g.bound(c, 0, 3).glsl(x, y, c);
+
+    // Generate the result.
+    Image<float> result = g.realize(10, 10, 3);
+    result.copy_to_host();
+
+    // Check the result.
+    for (int c = 0; c < result.channels(); c++) {
+        for (int y = 0; y < result.height(); y++) {
+            for (int x = 0; x < result.width(); x++) {
+                float correct = 3.0f * (x + y);
+                if (fabs(result(x, y, c) - correct) > 1e-6) {
+                    fprintf(stderr, "result(%d, %d, %d) = %f instead of %f\n",
+                            x, y, c, result(x, y, c), correct);
+                    return 1;
+                }
+            }
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
by inlining IntImms where possible, by being more clever about how we scalarize access to a vector, and by using variables for small allocations that are always accessed at constant offsets.

Also allows non-const access to the channels of a loaded vector (via []).