### PR TITLE
Update ARM code generation of strided loads to generic vector code.

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -869,8 +869,6 @@ void CodeGen_ARM::visit(const Load *op) {
         alignment = gcd(alignment, 16);
         internal_assert(alignment > 0);
 
-        Value *align = ConstantInt::get(i32_t, alignment);
-
         // Decide what width to slice things into. If not a multiple
         // of 64 or 128 bits, then we can't safely slice it up into
         // some number of vlds, so we hand it over the base class.
@@ -885,72 +883,27 @@ void CodeGen_ARM::visit(const Load *op) {
             return;
         }
 
-        // Declare the intrinsic
-        ostringstream intrin;
-        llvm::FunctionType *fn_type;
-        llvm::Type *return_type;
-        {
-            llvm::Type *one_vec = llvm_type_of(op->type.with_lanes(intrin_lanes));
-            vector<llvm::Type *> elements(stride->value, one_vec);
-            return_type = StructType::get(*context, elements);
+        llvm::Type *load_return_type = llvm_type_of(op->type.with_lanes(intrin_lanes*stride->value));
+        llvm::Type *load_return_pointer_type = load_return_type->getPointerTo();
+        Value *undef = UndefValue::get(load_return_type);
+        SmallVector<Constant*, 256> constants;
+        for(int j = 0; j < intrin_lanes; j++) {
+            Constant *constant = ConstantInt::get(i32_t, j*stride->value+offset);
+            constants.push_back(constant);
         }
-        if (target.bits == 32) {
-            intrin << "llvm.arm.neon.vld"
-                   << stride->value
-                   << ".v" << intrin_lanes
-                   << (op->type.is_float() ? 'f' : 'i')
-                   << op->type.bits()
-#if LLVM_VERSION > 37
-                   << ".p0i8"
-#endif
-                   ;
-            // The intrinsic takes an i8 pointer and an alignment, and
-            // returns a struct of stride->value vectors of width
-            // intrin_lanes.
-            llvm::Type *arg_types[] = {i8_t->getPointerTo(), i32_t};
-            fn_type = llvm::FunctionType::get(return_type, arg_types, false);
-        } else {
-            intrin << "llvm.aarch64.neon.ld"
-                   << stride->value
-                   << ".v" << intrin_lanes
-                   << (op->type.is_float() ? 'f' : 'i')
-                   << op->type.bits()
-                   << ".p0"
-                   << (op->type.is_float() ? 'f' : 'i')
-                   << op->type.bits();
-            // The intrinsic takes a pointer to the element type and
-            // returns a struct of stride->value vectors of width
-            // intrin_lanes.
-            llvm::Type *arg_type = llvm_type_of(op->type.element_of())->getPointerTo();
-            llvm::Type *arg_types[] = {arg_type};
-            fn_type = llvm::FunctionType::get(return_type, arg_types, false);
-        }
+        Constant* constantsV = ConstantVector::get(constants);
 
-        // Get the intrinsic
-        llvm::Function *fn = dyn_cast_or_null<llvm::Function>(module->getOrInsertFunction(intrin.str(), fn_type));
-        internal_assert(fn);
-
-        // Load each slice.
         vector<Value *> results;
         for (int i = 0; i < op->type.lanes(); i += intrin_lanes) {
             Expr slice_base = simplify(base + i*ramp->stride);
             Expr slice_ramp = Ramp::make(slice_base, ramp->stride, intrin_lanes);
             Value *ptr = codegen_buffer_pointer(op->name, op->type.element_of(), slice_base);
-            CallInst *call = nullptr;
-            if (target.bits == 32) {
-                // The arm32 versions always take an i8* pointer.
-                ptr = builder->CreatePointerCast(ptr, i8_t->getPointerTo());
-                Value *args[] = {ptr, align};
-                call = builder->CreateCall(fn, args);
-            } else {
-                // The aarch64 versions allow arbitrary alignment.
-                Value *args[] = {ptr};
-                call = builder->CreateCall(fn, args);
-            }
-            add_tbaa_metadata(call, op->name, slice_ramp);
-
-            Value *elt = builder->CreateExtractValue(call, {(unsigned int)offset});
-            results.push_back(elt);
+            Value *bitcastI = builder->CreateBitOrPointerCast(ptr, load_return_pointer_type);
+            LoadInst *loadI = cast<LoadInst>(builder->CreateLoad(bitcastI));
+            loadI->setAlignment(alignment);
+            add_tbaa_metadata(loadI, op->name, slice_ramp);
+            Value *shuffleInstr = builder->CreateShuffleVector(loadI, undef, constantsV);
+            results.push_back(shuffleInstr);
         }
 
         // Concat the results


### PR DESCRIPTION
LLVM >=3.7 lowers this to the correct intrinsics in the interleave access pass.