### PR TITLE
Remove Generator::call_extern() and call_extern_by_name()

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -455,32 +455,5 @@ void GeneratorBase::emit_filter(const std::string &output_dir,
     compile_module_to_filter(build_module(function_name), base_path, options);
 }
 
-Func GeneratorBase::call_extern(std::initializer_list<ExternFuncArgument> function_arguments,
-                                std::string function_name){
-    Pipeline p = build_pipeline();
-    user_assert(p.outputs().size() == 1) \
-        << "Can only call_extern Pipelines with a single output Func\n";
-    Func f = p.outputs()[0];
-    Func f_extern;
-    if (function_name.empty()) {
-        function_name = generator_name();
-        user_assert(!function_name.empty())
-            << "call_extern: generator_name is empty\n";
-    }
-    f_extern.define_extern(function_name, function_arguments, f.output_types(), f.dimensions());
-    return f_extern;
-}
-
-Func GeneratorBase::call_extern_by_name(const std::string &generator_name,
-                                        std::initializer_list<ExternFuncArgument> function_arguments,
-                                        const std::string &function_name,
-                                        const GeneratorParamValues &generator_params) {
-    std::unique_ptr<GeneratorBase> extern_gen = GeneratorRegistry::create(generator_name, generator_params);
-    user_assert(extern_gen != nullptr) << "Unknown generator: " << generator_name << "\n";
-    // Note that the Generator's target is not set; at present, this shouldn't matter for
-    // define_extern() functions, since none of the linkage should vary by Target.
-    return extern_gen->call_extern(function_arguments, function_name);
-}
-
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -553,24 +553,6 @@ public:
 
     EXPORT virtual ~GeneratorBase();
 
-    /** Return a Func that calls a previously-generated instance of this Generator.
-     * This is (essentially) a smart wrapper around define_extern(), but uses the
-     * output types and dimensionality of the Func returned by build. It is
-     * expected that the previously-generated instance will be available (at link time)
-     * as extern "C" function_name (if function_name is empty, it is assumed to
-     * match generator_name()). */
-    EXPORT Func call_extern(std::initializer_list<ExternFuncArgument> function_arguments,
-                            std::string function_name = "");
-
-    /** Similar to call_extern(), but first creates a new Generator
-     * (from the current Registry) with the given name and params;
-     * this is more convenient to use if you don't have access to the C++
-     * Generator class definition at compile-time. */
-    EXPORT static Func call_extern_by_name(const std::string &generator_name,
-                                           std::initializer_list<ExternFuncArgument> function_arguments,
-                                           const std::string &function_name = "",
-                                           const GeneratorParamValues &generator_params = GeneratorParamValues());
-
     Target get_target() const { return target; }
 
     EXPORT GeneratorParamValues get_generator_param_values();

--- a/test/generator/nested_externs_generator.cpp
+++ b/test/generator/nested_externs_generator.cpp
@@ -36,31 +36,23 @@ public:
     Param<float> value {"value", 1.0f};
 
     Func build() {
-        // We can make an extern call to any (registered) Generator
-        // by using call_extern_by_name() with the generator_name we're calling,
-        // and a vector of ExternFuncArguments. We can (optionally) also
-        // specify GeneratorParams for the Generator, and the function name we
-        // expect that Generator to be linked under.
-        Func extern_stage_1 = call_extern_by_name("nested_externs_leaf", {value});
-
+        Func extern_stage_1;
+        extern_stage_1.define_extern("nested_externs_leaf", {value}, Float(32), 3);
         extern_stage_1.reorder_storage(extern_stage_1.args()[2],
                                         extern_stage_1.args()[0],
                                         extern_stage_1.args()[1]);
         extern_stage_1.compute_root();
 
-        Func extern_stage_2 = call_extern_by_name("nested_externs_leaf", {value+1});
+        Func extern_stage_2;
+        extern_stage_2.define_extern("nested_externs_leaf", {value+1}, Float(32), 3);
         extern_stage_2.reorder_storage(extern_stage_2.args()[2],
                                         extern_stage_2.args()[0],
                                         extern_stage_2.args()[1]);
         extern_stage_2.compute_root();
 
-        // If the Generator is available at C++ compile time
-        // (either via .h or inlined in the same file, as is the case here),
-        // you can simply instantiate the Generator and make the call.
-        // (Here we assume that it will be available at link time with
-        // a function name that matches the generator name; we can
-        // specify an optional function name otherwise.)
-        Func extern_stage_combine = NestedExternsCombine().call_extern({extern_stage_1, extern_stage_2});
+        Func extern_stage_combine;
+        extern_stage_combine.define_extern("nested_externs_combine", 
+            {extern_stage_1, extern_stage_2}, Float(32), 3);
         extern_stage_combine.compute_root();
 
         set_interleaved(extern_stage_combine.output_buffer());
@@ -92,17 +84,21 @@ public:
     Param<float> value {"value", 1.0f};
 
     Func build() {
-        Func extern_stage_1 = NestedExternsInner().call_extern({value});
+        Func extern_stage_1;
+        extern_stage_1.define_extern("nested_externs_inner", {value}, Float(32), 3);
         extern_stage_1.reorder_storage(extern_stage_1.args()[2],
                                         extern_stage_1.args()[0],
                                         extern_stage_1.args()[1]);
 
-        Func extern_stage_2 = NestedExternsInner().call_extern({value+1});
+        Func extern_stage_2;
+        extern_stage_2.define_extern("nested_externs_inner", {value+1}, Float(32), 3);
         extern_stage_2.reorder_storage(extern_stage_2.args()[2],
                                         extern_stage_2.args()[0],
                                         extern_stage_2.args()[1]);
 
-        Func extern_stage_combine = NestedExternsCombine().call_extern({extern_stage_1, extern_stage_2});
+        Func extern_stage_combine;
+        extern_stage_combine.define_extern("nested_externs_combine", 
+            {extern_stage_1, extern_stage_2}, Float(32), 3);
         extern_stage_combine.reorder_storage(extern_stage_combine.args()[2],
                                              extern_stage_combine.args()[0],
                                              extern_stage_combine.args()[1]);

--- a/test/generator/tiled_blur_generator.cpp
+++ b/test/generator/tiled_blur_generator.cpp
@@ -18,15 +18,11 @@ public:
         Func brighter1("brighter1");
         brighter1(x, y, c) = input(x, y, c) * 1.2f;
 
-        Func tiled_blur = call_extern_by_name(
-            /* generator_name */
-            "tiled_blur_blur",
-            /* ExternFuncArguments */
-            { brighter1, input.width(), input.height() },
-            /* optional: function name */
+        Func tiled_blur;
+        tiled_blur.define_extern(
             is_interleaved ? "tiled_blur_blur_interleaved" : "tiled_blur_blur",
-            /* optional: generator_args */
-            { { "is_interleaved", is_interleaved ? "true" : "false" } });
+            { brighter1, input.width(), input.height() },
+            Float(32), 3);
 
         Func brighter2("brighter2");
         brighter2(x, y, c) = tiled_blur(x, y, c) * 1.2f;


### PR DESCRIPTION
These have never been used outside of Halide test code, and are never
likely to be. Remove them and replace with define_extern() usage for
now. (We’re need a better syntax than define_extern(), but this isn’t
it.)