### PR TITLE
Return partially solved expr instead of undefined

### DIFF
--- a/src/Associativity.cpp
+++ b/src/Associativity.cpp
@@ -200,8 +200,9 @@ pair<bool, vector<AssociativeOp>> prove_associativity(const string &f, vector<Ex
 
         expr = common_subexpression_elimination(expr);
         expr = simplify(expr);
-        expr = solve_expression(expr, op_x); // Move 'x' to the left as possible
-        if (!expr.defined()) {
+        bool success;
+        std::tie(success, expr) = solve_expression(expr, op_x); // Move 'x' to the left as possible
+        if (!success) {
             return std::make_pair(false, vector<AssociativeOp>());
         }
         expr = substitute_in_all_lets(expr);

--- a/src/Associativity.cpp
+++ b/src/Associativity.cpp
@@ -200,9 +200,8 @@ pair<bool, vector<AssociativeOp>> prove_associativity(const string &f, vector<Ex
 
         expr = common_subexpression_elimination(expr);
         expr = simplify(expr);
-        bool success;
-        std::tie(success, expr) = solve_expression(expr, op_x); // Move 'x' to the left as possible
-        if (!success) {
+        expr = solve_expression(expr, op_x).second; // Move 'x' to the left as possible
+        if (!expr.defined()) {
             return std::make_pair(false, vector<AssociativeOp>());
         }
         expr = substitute_in_all_lets(expr);

--- a/src/Associativity.cpp
+++ b/src/Associativity.cpp
@@ -200,7 +200,7 @@ pair<bool, vector<AssociativeOp>> prove_associativity(const string &f, vector<Ex
 
         expr = common_subexpression_elimination(expr);
         expr = simplify(expr);
-        expr = solve_expression(expr, op_x).second; // Move 'x' to the left as possible
+        expr = solve_expression(expr, op_x).result; // Move 'x' to the left as possible
         if (!expr.defined()) {
             return std::make_pair(false, vector<AssociativeOp>());
         }

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -2192,6 +2192,18 @@ private:
             // min(max(a, 4), ((a + 3)/4)*4) -> max(a, 4)
             expr = a;
         } else if (max_a &&
+                   min_b &&
+                   equal(max_a->a, min_b->a) &&
+                   equal(max_a->b, min_b->b)) {
+            // min(max(x, y), min(x, y)) -> min(x, y)
+            expr = mutate(min(max_a->a, max_a->b));
+        } else if (max_a &&
+                   min_b &&
+                   equal(max_a->a, min_b->b) &&
+                   equal(max_a->b, min_b->a)) {
+            // min(max(x, y), min(y, x)) -> min(x, y)
+            expr = mutate(min(max_a->a, max_a->b));
+        } else if (max_a &&
                    equal(max_a->b, b)) {
             // min(max(x, y), y) -> y
             expr = b;
@@ -2533,6 +2545,18 @@ private:
             } else {
                 expr = b;
             }
+        } else if (min_a &&
+                   max_b &&
+                   equal(min_a->a, max_b->a) &&
+                   equal(min_a->b, max_b->b)) {
+            // max(min(x, y), max(x, y)) -> max(x, y)
+            expr = mutate(max(min_a->a, min_a->b));
+        } else if (min_a &&
+                   max_b &&
+                   equal(min_a->a, max_b->b) &&
+                   equal(min_a->b, max_b->a)) {
+            // max(min(x, y), max(y, x)) -> max(x, y)
+            expr = mutate(max(min_a->a, min_a->b));
         } else if (min_a &&
                    equal(min_a->b, b)) {
             // max(min(x, y), y) -> y
@@ -5719,6 +5743,18 @@ void simplify_test() {
     check(min(x, y) + max(y, x), x + y);
     check(max(x, y) + min(x, y), x + y);
     check(max(y, x) + min(x, y), x + y);
+
+    // Check max(min(x, y), max(x, y)) gets simplified into max(x, y)
+    check(max(min(x, y), max(x, y)), max(x, y));
+    check(max(min(x, y), max(y, x)), max(x, y));
+    check(max(max(x, y), min(x, y)), max(x, y));
+    check(max(max(y, x), min(x, y)), max(x, y));
+
+    // Check min(max(x, y), min(x, y)) gets simplified into min(x, y)
+    check(min(max(x, y), min(x, y)), min(x, y));
+    check(min(max(x, y), min(y, x)), min(x, y));
+    check(min(min(x, y), max(x, y)), min(x, y));
+    check(min(min(y, x), max(x, y)), min(x, y));
 
     // Check if we can simplify away comparison on vector types considering bounds.
     Scope<Interval> bounds_info;

--- a/src/Solve.h
+++ b/src/Solve.h
@@ -10,15 +10,20 @@
 namespace Halide {
 namespace Internal {
 
+struct SolverResult {
+	Expr result;
+	bool fully_solved;
+};
+
 /** Attempts to collect all instances of a variable in an expression
  * tree and place it as far to the left as possible, and as far up the
  * tree as possible (i.e. outside most parentheses). If the expression
  * is an equality or comparison, this 'solves' the equation. Returns a
- * pair of bool and Expr. The Expr is the mutated expression, and the
+ * pair of Expr and bool. The Expr is the mutated expression, and the
  * bool indicates whether there is a single instance of the variable
  * in the result. If it is false, the expression has only been partially
  * solved, and there are still multiple instances of the variable. */
-EXPORT std::pair<bool, Expr> solve_expression(
+EXPORT SolverResult solve_expression(
 	Expr e, const std::string &variable,
 	const Scope<Expr> &scope = Scope<Expr>::empty_scope());
 

--- a/src/Solve.h
+++ b/src/Solve.h
@@ -14,9 +14,10 @@ namespace Internal {
  * tree and place it as far to the left as possible, and as far up the
  * tree as possible (i.e. outside most parentheses). If the expression
  * is an equality or comparison, this 'solves' the equation. Returns
- * an undefined expression on failure. */
-EXPORT Expr solve_expression(Expr e, const std::string &variable,
-                             const Scope<Expr> &scope = Scope<Expr>::empty_scope());
+ * a boolen False and partially solved expression on failure. */
+EXPORT std::pair<bool, Expr> solve_expression(
+	Expr e, const std::string &variable,
+	const Scope<Expr> &scope = Scope<Expr>::empty_scope());
 
 /** Find the smallest interval such that the condition is either true
  * or false inside of it, but definitely false outside of it. Never

--- a/src/Solve.h
+++ b/src/Solve.h
@@ -13,8 +13,11 @@ namespace Internal {
 /** Attempts to collect all instances of a variable in an expression
  * tree and place it as far to the left as possible, and as far up the
  * tree as possible (i.e. outside most parentheses). If the expression
- * is an equality or comparison, this 'solves' the equation. Returns
- * a boolen False and partially solved expression on failure. */
+ * is an equality or comparison, this 'solves' the equation. Returns a
+ * pair of bool and Expr. The Expr is the mutated expression, and the
+ * bool indicates whether there is a single instance of the variable
+ * in the result. If it is false, the expression has only been partially
+ * solved, and there are still multiple instances of the variable. */
 EXPORT std::pair<bool, Expr> solve_expression(
 	Expr e, const std::string &variable,
 	const Scope<Expr> &scope = Scope<Expr>::empty_scope());

--- a/src/TrimNoOps.cpp
+++ b/src/TrimNoOps.cpp
@@ -222,9 +222,9 @@ class SimplifyUsingBounds : public IRMutator {
                 Scope<Interval> s;
                 // Rearrange the expression if possible so that the
                 // loop var only occurs once.
-                pair<bool, Expr> solved = solve_expression(test, loop.var);
-                if (solved.first) {
-                    test = solved.second;
+                SolverResult solved = solve_expression(test, loop.var);
+                if (solved.fully_solved) {
+                    test = solved.result;
                 }
                 s.push(loop.var, loop.i);
                 test = and_condition_over_domain(test, s);

--- a/src/TrimNoOps.cpp
+++ b/src/TrimNoOps.cpp
@@ -222,9 +222,9 @@ class SimplifyUsingBounds : public IRMutator {
                 Scope<Interval> s;
                 // Rearrange the expression if possible so that the
                 // loop var only occurs once.
-                Expr solved = solve_expression(test, loop.var);
-                if (solved.defined()) {
-                    test = solved;
+                pair<bool, Expr> solved = solve_expression(test, loop.var);
+                if (solved.first) {
+                    test = solved.second;
                 }
                 s.push(loop.var, loop.i);
                 test = and_condition_over_domain(test, s);


### PR DESCRIPTION
This PR changes solve_expression to return a pair of boolean indicating whether the solve is successful and a partially solved expression, instead of returning undefined Expr if it can't solve the expression. For example, `max(min(y, x), x)` will return {false, `max(min(x, y), x)`} instead of `Expr()`. 

This also adds new simplification rules for: 
```
min(x, y)*max(x, y) -> x*y
min(x, y) + max(x, y) -> x + y
```