### PR TITLE
Revise PR#1448 to use C++11 Perfect Forwarding

### DIFF
--- a/src/Func.h
+++ b/src/Func.h
@@ -192,10 +192,7 @@ public:
     template <typename... Args>
     NO_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Stage &>::type
     reorder(VarOrRVar x, VarOrRVar y, Args&&... args) {
-        std::vector<VarOrRVar> collected_args;
-        collected_args.push_back(x);
-        collected_args.push_back(y);
-        Internal::collect_args(collected_args, std::forward<Args>(args)...);
+        std::vector<VarOrRVar> collected_args{x, y, std::forward<Args>(args)...};
         return reorder(collected_args);
     }
 
@@ -918,8 +915,7 @@ public:
     template <typename... Args>
     NO_INLINE typename std::enable_if<Internal::all_are_convertible<Var, Args...>::value, FuncRef>::type
     operator()(Args&&... args) const {
-        std::vector<Var> collected_args;
-        Internal::collect_args(collected_args, std::forward<Args>(args)...);
+        std::vector<Var> collected_args{std::forward<Args>(args)...};
         return this->operator()(collected_args);
     }
     // @}
@@ -936,9 +932,7 @@ public:
     template <typename... Args>
     NO_INLINE typename std::enable_if<Internal::all_are_convertible<Expr, Args...>::value, FuncRef>::type
     operator()(Expr x, Args&&... args) const {
-        std::vector<Expr> collected_args;
-        collected_args.push_back(x);
-        Internal::collect_args(collected_args, std::forward<Args>(args)...);
+        std::vector<Expr> collected_args{x, std::forward<Args>(args)...};
         return (*this)(collected_args);
     }
     // @}
@@ -1150,10 +1144,7 @@ public:
     template <typename... Args>
     NO_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Func &>::type
     reorder(VarOrRVar x, VarOrRVar y, Args&&... args) {
-        std::vector<VarOrRVar> collected_args;
-        collected_args.push_back(x);
-        collected_args.push_back(y);
-        Internal::collect_args(collected_args, std::forward<Args>(args)...);
+        std::vector<VarOrRVar> collected_args{x, y, std::forward<Args>(args)...};
         return reorder(collected_args);
     }
 
@@ -1469,10 +1460,7 @@ public:
     template <typename... Args>
     NO_INLINE typename std::enable_if<Internal::all_are_convertible<Var, Args...>::value, Func &>::type
     reorder_storage(Var x, Var y, Args&&... args) {
-        std::vector<Var> collected_args;
-        collected_args.push_back(x);
-        collected_args.push_back(y);
-        Internal::collect_args(collected_args, std::forward<Args>(args)...);
+        std::vector<Var> collected_args{x, y, std::forward<Args>(args)...};
         return reorder_storage(collected_args);
     }
     // @}

--- a/src/Func.h
+++ b/src/Func.h
@@ -191,11 +191,11 @@ public:
 
     template <typename... Args>
     NO_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Stage &>::type
-    reorder(VarOrRVar x, VarOrRVar y, const Args &... args) {
+    reorder(VarOrRVar x, VarOrRVar y, Args&&... args) {
         std::vector<VarOrRVar> collected_args;
         collected_args.push_back(x);
         collected_args.push_back(y);
-        Internal::collect_args(collected_args, args...);
+        Internal::collect_args(collected_args, std::forward<Args>(args)...);
         return reorder(collected_args);
     }
 
@@ -917,9 +917,9 @@ public:
 
     template <typename... Args>
     NO_INLINE typename std::enable_if<Internal::all_are_convertible<Var, Args...>::value, FuncRef>::type
-    operator()(const Args &... args) const {
+    operator()(Args&&... args) const {
         std::vector<Var> collected_args;
-        Internal::collect_args(collected_args, args...);
+        Internal::collect_args(collected_args, std::forward<Args>(args)...);
         return this->operator()(collected_args);
     }
     // @}
@@ -935,10 +935,10 @@ public:
 
     template <typename... Args>
     NO_INLINE typename std::enable_if<Internal::all_are_convertible<Expr, Args...>::value, FuncRef>::type
-    operator()(Expr x, const Args &... args) const {
+    operator()(Expr x, Args&&... args) const {
         std::vector<Expr> collected_args;
         collected_args.push_back(x);
-        Internal::collect_args(collected_args, args...);
+        Internal::collect_args(collected_args, std::forward<Args>(args)...);
         return (*this)(collected_args);
     }
     // @}
@@ -1149,11 +1149,11 @@ public:
 
     template <typename... Args>
     NO_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Func &>::type
-    reorder(VarOrRVar x, VarOrRVar y, const Args &... args) {
+    reorder(VarOrRVar x, VarOrRVar y, Args&&... args) {
         std::vector<VarOrRVar> collected_args;
         collected_args.push_back(x);
         collected_args.push_back(y);
-        Internal::collect_args(collected_args, args...);
+        Internal::collect_args(collected_args, std::forward<Args>(args)...);
         return reorder(collected_args);
     }
 
@@ -1468,11 +1468,11 @@ public:
     EXPORT Func &reorder_storage(Var x, Var y);
     template <typename... Args>
     NO_INLINE typename std::enable_if<Internal::all_are_convertible<Var, Args...>::value, Func &>::type
-    reorder_storage(Var x, Var y, const Args &... args) {
+    reorder_storage(Var x, Var y, Args&&... args) {
         std::vector<Var> collected_args;
         collected_args.push_back(x);
         collected_args.push_back(y);
-        Internal::collect_args(collected_args, args...);
+        Internal::collect_args(collected_args, std::forward<Args>(args)...);
         return reorder_storage(collected_args);
     }
     // @}

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -695,13 +695,17 @@ Expr print_when(Expr condition, const std::vector<Expr> &args) {
                                 Internal::Call::PureIntrinsic);
 }
 
-Expr memoize_tag(Expr result, const std::vector<Expr> &cache_key_values) {
+namespace Internal {
+
+Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_values) {
     std::vector<Expr> args;
     args.push_back(result);
     args.insert(args.end(), cache_key_values.begin(), cache_key_values.end());
     return Internal::Call::make(result.type(), Internal::Call::memoize_expr,
                                 args, Internal::Call::PureIntrinsic);
 }
+
+}  // namespace Internal
 
 Expr saturating_cast(Type t, Expr e) {
     // For float to float, guarantee infinities are always pinned to range.

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1776,15 +1776,15 @@ inline NO_INLINE void collect_print_args(std::vector<Expr> &args) {
 }
 
 template<typename ...Args>
-inline NO_INLINE void collect_print_args(std::vector<Expr> &args, const char *arg, const Args &... more_args) {
+inline NO_INLINE void collect_print_args(std::vector<Expr> &args, const char *arg, Args&&... more_args) {
     args.push_back(Expr(std::string(arg)));
-    collect_print_args(args, more_args...);
+    collect_print_args(args, std::forward<Args>(more_args)...);
 }
 
 template<typename ...Args>
-inline NO_INLINE void collect_print_args(std::vector<Expr> &args, Expr arg, const Args &... more_args) {
+inline NO_INLINE void collect_print_args(std::vector<Expr> &args, Expr arg, Args&&... more_args) {
     args.push_back(arg);
-    collect_print_args(args, more_args...);
+    collect_print_args(args, std::forward<Args>(more_args)...);
 }
 }
 
@@ -1796,9 +1796,9 @@ inline NO_INLINE void collect_print_args(std::vector<Expr> &args, Expr arg, cons
 EXPORT Expr print(const std::vector<Expr> &values);
 
 template <typename... Args>
-inline NO_INLINE Expr print(Expr a, const Args &... args) {
+inline NO_INLINE Expr print(Expr a, Args&&... args) {
     std::vector<Expr> collected_args = {a};
-    Internal::collect_print_args(collected_args, args...);
+    Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
     return print(collected_args);
 }
 //@}
@@ -1809,9 +1809,9 @@ inline NO_INLINE Expr print(Expr a, const Args &... args) {
 EXPORT Expr print_when(Expr condition, const std::vector<Expr> &values);
 
 template<typename ...Args>
-inline NO_INLINE Expr print_when(Expr condition, Expr a, const Args &... args) {
+inline NO_INLINE Expr print_when(Expr condition, Expr a, Args&&... args) {
     std::vector<Expr> collected_args = {a};
-    Internal::collect_print_args(collected_args, args...);
+    Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
     return print_when(condition, collected_args);
 }
 
@@ -1877,9 +1877,9 @@ inline Expr undef() {
 EXPORT Expr memoize_tag(Expr result, const std::vector<Expr> &cache_key_values);
 
 template<typename ...Args>
-inline NO_INLINE Expr memoize_tag(Expr result, const Args &... args) {
+inline NO_INLINE Expr memoize_tag(Expr result, Args&&... args) {
     std::vector<Expr> collected_args;
-    Internal::collect_args(collected_args, args...);
+    Internal::collect_args(collected_args, std::forward<Args>(args)...);
     return memoize_tag(result, collected_args);
 }
 // @}

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1880,8 +1880,7 @@ EXPORT Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_v
 // @{
 template<typename ...Args>
 inline NO_INLINE Expr memoize_tag(Expr result, Args&&... args) {
-    std::vector<Expr> collected_args;
-    Internal::collect_args(collected_args, std::forward<Args>(args)...);
+    std::vector<Expr> collected_args{std::forward<Args>(args)...};
     return Internal::memoize_tag_helper(result, collected_args);
 }
 // @}

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1847,6 +1847,10 @@ inline Expr undef() {
     return undef(type_of<T>());
 }
 
+namespace Internal {
+EXPORT Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_values);
+}  // namespace Internal
+
 /** Control the values used in the memoization cache key for memoize.
  * Normally parameters and other external dependencies are
  * automatically inferred and added to the cache key. The memoize_tag
@@ -1874,13 +1878,11 @@ inline Expr undef() {
  * digest, memoize_tag can be used to key computations using that image
  * on the digest. */
 // @{
-EXPORT Expr memoize_tag(Expr result, const std::vector<Expr> &cache_key_values);
-
 template<typename ...Args>
 inline NO_INLINE Expr memoize_tag(Expr result, Args&&... args) {
     std::vector<Expr> collected_args;
     Internal::collect_args(collected_args, std::forward<Args>(args)...);
-    return memoize_tag(result, collected_args);
+    return Internal::memoize_tag_helper(result, collected_args);
 }
 // @}
 

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -184,9 +184,9 @@ class RDom {
     EXPORT void initialize_from_ranges(const std::vector<std::pair<Expr, Expr>> &ranges, std::string name = "");
 
     template <typename... Args>
-    NO_INLINE void initialize_from_ranges(std::vector<std::pair<Expr, Expr>> &ranges, Expr min, Expr extent, const Args &... args) {
+    NO_INLINE void initialize_from_ranges(std::vector<std::pair<Expr, Expr>> &ranges, Expr min, Expr extent, Args&&... args) {
         ranges.push_back(std::make_pair(min, extent));
-        initialize_from_ranges(ranges, args...);
+        initialize_from_ranges(ranges, std::forward<Args>(args)...);
     }
 
 public:
@@ -201,11 +201,11 @@ public:
     }
 
     template <typename... Args>
-    NO_INLINE RDom(Expr min, Expr extent, const Args &... args) {
+    NO_INLINE RDom(Expr min, Expr extent, Args&&... args) {
         // This should really just be a delegating constructor, but I couldn't make
         // that work with variadic template unpacking in visual studio 2013
         std::vector<std::pair<Expr, Expr>> ranges;
-        initialize_from_ranges(ranges, min, extent, args...);
+        initialize_from_ranges(ranges, min, extent, std::forward<Args>(args)...);
     }
     // @}
 

--- a/src/Tuple.h
+++ b/src/Tuple.h
@@ -44,9 +44,7 @@ public:
     //@{
     template<typename ...Args>
     Tuple(Expr a, Expr b, Args&&... args) {
-        exprs.push_back(a);
-        exprs.push_back(b);
-        Internal::collect_args(exprs, std::forward<Args>(args)...);
+        exprs = std::vector<Expr>{a, b, std::forward<Args>(args)...};
     }
     //@}
 
@@ -94,8 +92,8 @@ public:
     /** Construct a Realization from some Buffers. */
     //@{
     template<typename ...Args>
-    Realization(Buffer a, Buffer b, Args&&... args) : buffers({a, b}) {
-        Internal::collect_args(buffers, std::forward<Args>(args)...);
+    Realization(Buffer a, Buffer b, Args&&... args) {
+        buffers = std::vector<Buffer>{a, b, std::forward<Args>(args)...};
     }
     //@}
 

--- a/src/Tuple.h
+++ b/src/Tuple.h
@@ -43,10 +43,10 @@ public:
     /** Construct a Tuple from some Exprs. */
     //@{
     template<typename ...Args>
-    Tuple(Expr a, Expr b, const Args &... args) {
+    Tuple(Expr a, Expr b, Args&&... args) {
         exprs.push_back(a);
         exprs.push_back(b);
-        Internal::collect_args(exprs, args...);
+        Internal::collect_args(exprs, std::forward<Args>(args)...);
     }
     //@}
 
@@ -94,8 +94,8 @@ public:
     /** Construct a Realization from some Buffers. */
     //@{
     template<typename ...Args>
-    Realization(Buffer a, Buffer b, const Args &... args) : buffers({a, b}) {
-        Internal::collect_args(buffers, args...);
+    Realization(Buffer a, Buffer b, Args&&... args) : buffers({a, b}) {
+        Internal::collect_args(buffers, std::forward<Args>(args)...);
     }
     //@}
 

--- a/src/Util.h
+++ b/src/Util.h
@@ -144,9 +144,9 @@ inline NO_INLINE void collect_args(std::vector<T> &collected_args,
 
 template <typename T, typename T2, typename ...Args>
 inline NO_INLINE void collect_args(std::vector<T> &collected_args,
-                                   const T2 &arg, const Args &... args) {
+                                   const T2 &arg, Args&&... args) {
     collected_args.push_back(arg);
-    collect_args(collected_args, args...);
+    collect_args(collected_args, std::forward<Args>(args)...);
 }
 
 template <typename T1, typename T2, typename T3, typename T4 >
@@ -157,9 +157,9 @@ inline NO_INLINE void collect_paired_args(std::vector<std::pair<T1, T2>> &collec
 
 template <typename T1, typename T2, typename T3, typename T4, typename ...Args>
 inline NO_INLINE void collect_paired_args(std::vector<std::pair<T1, T2>> &collected_args,
-                                   const T3 &a1, const T4 &a2, const Args &... args) {
+                                   const T3 &a1, const T4 &a2, Args&&... args) {
     collected_args.push_back(std::pair<T1, T2>(a1, a2));
-    collect_paired_args(collected_args, args...);
+    collect_paired_args(collected_args, std::forward<Args>(args)...);
 }
 
 template<typename... T>

--- a/src/Util.h
+++ b/src/Util.h
@@ -132,23 +132,6 @@ T fold_right(const std::vector<T> &vec, Fn f) {
     return result;
 }
 
-template <typename T>
-inline NO_INLINE void collect_args(std::vector<T> &collected_args) {
-}
-
-template <typename T, typename T2>
-inline NO_INLINE void collect_args(std::vector<T> &collected_args,
-                                   const T2 &arg) {
-    collected_args.push_back(arg);
-}
-
-template <typename T, typename T2, typename ...Args>
-inline NO_INLINE void collect_args(std::vector<T> &collected_args,
-                                   const T2 &arg, Args&&... args) {
-    collected_args.push_back(arg);
-    collect_args(collected_args, std::forward<Args>(args)...);
-}
-
 template <typename T1, typename T2, typename T3, typename T4 >
 inline NO_INLINE void collect_paired_args(std::vector<std::pair<T1, T2>> &collected_args,
                                      const T3 &a1, const T4 &a2) {

--- a/tools/halide_image.h
+++ b/tools/halide_image.h
@@ -98,7 +98,7 @@ class Image {
 
     /** Initialize the shape from a parameter pack of ints */
     template<typename ...Args>
-    void initialize_shape(int next, int first, Args&&... rest) {
+    void initialize_shape(int next, int first, const Args &... rest) {
         buf.min[next] = 0;
         buf.extent[next] = first;
         if (next == 0) {
@@ -106,7 +106,7 @@ class Image {
         } else {
             buf.stride[next] = buf.stride[next-1] * buf.extent[next-1];
         }
-        initialize_shape(next + 1, std::forward<Args>(rest)...);
+        initialize_shape(next + 1, rest...);
     }
 
     /** Base case for the template recursion above. */
@@ -142,9 +142,9 @@ class Image {
 
     /** Check if any args in a parameter pack are zero */
     template<typename ...Args>
-    static bool any_zero(int first, Args&&... rest) {
+    static bool any_zero(int first, const Args &... rest) {
         if (first == 0) return true;
-        return any_zero(std::forward<Args>(rest)...);
+        return any_zero(rest...);
     }
 
     static bool any_zero() {
@@ -239,13 +239,13 @@ public:
     /** Allocate a new image of the given size. Pass zeroes to make a
      * buffer suitable for bounds query calls. */
     template<typename ...Args>
-    Image(int first, Args&&... rest) {
+    Image(int first, const Args &... rest) {
         static_assert(sizeof...(rest) < D,
                       "Too many arguments to constructor. Use Image<T, D>, where D is at least the desired number of dimensions");
-        initialize_shape(0, first, std::forward<Args>(rest)...);
+        initialize_shape(0, first, rest...);
         buf.elem_size = sizeof(T);
         dims = 1 + (int)(sizeof...(rest));
-        if (!any_zero(first, std::forward<Args>(rest)...)) {
+        if (!any_zero(first, rest...)) {
             allocate();
         }
     }
@@ -264,11 +264,11 @@ public:
      * dense row-major packing and a min coordinate of zero. Does not
      * take ownership of the data. */
     template<typename ...Args>
-    explicit Image(T *data, int first, Args&&... rest) {
+    explicit Image(T *data, int first, const Args &... rest) {
         static_assert(sizeof...(rest) < D,
                       "Too many arguments to constructor. Use Image<T, D>, where D is at least the desired number of dimensions");
         memset(&buf, 0, sizeof(buffer_t));
-        initialize_shape(0, first, std::forward<Args>(rest)...);
+        initialize_shape(0, first, rest...);
         buf.elem_size = sizeof(T);
         dims = 1 + (int)(sizeof...(rest));
         buf.host = data;
@@ -319,8 +319,8 @@ public:
 
 private:
     template<typename ...Args>
-    T *address_of(int d, int first, Args&&... rest) const {
-        return address_of(d+1, std::forward<Args>(rest)...) + buf.stride[d] * (first - buf.min[d]);
+    T *address_of(int d, int first, const Args &... rest) const {
+        return address_of(d+1, rest...) + buf.stride[d] * (first - buf.min[d]);
     }
 
     T *address_of(int d) const {
@@ -369,8 +369,8 @@ public:
      */
     //@{
     template<typename ...Args>
-    const T &operator()(int first, Args&&... rest) const {
-        return *(address_of(0, first, std::forward<Args>(rest)...));
+    const T &operator()(int first, const Args &... rest) const {
+        return *(address_of(0, first, rest...));
     }
 
     template<typename ...Args>
@@ -383,8 +383,8 @@ public:
     }
 
     template<typename ...Args>
-    T &operator()(int first, Args&&... rest) {
-        return *(address_of(0, first, std::forward<Args>(rest)...));
+    T &operator()(int first, const Args &... rest) {
+        return *(address_of(0, first, rest...));
     }
 
     template<typename ...Args>
@@ -554,26 +554,26 @@ struct for_each_element_helpers {
      * resolution. The decltype is to make this version impossible if
      * the function is not callable with this many args. */
     template<typename ...Args>
-    static auto for_each_element_variadic(int, int d, Fn f, const buffer_t &buf, Args&&... args)
+    static auto for_each_element_variadic(int, int d, Fn f, const buffer_t &buf, const Args &... args)
         -> decltype(f(args...)) {
-        f(std::forward<Args>(args)...);
+        f(args...);
     }
 
     /** If the above overload is impossible, we add an outer loop over
      * an additional argument and try again. This trick is known as
      * SFINAE. */
     template<typename ...Args>
-    static void for_each_element_variadic(double, int d, Fn f, const buffer_t &buf, Args&&... args) {
+    static void for_each_element_variadic(double, int d, Fn f, const buffer_t &buf, const Args &... args) {
         int e = buf.extent[d] == 0 ? 1 : buf.extent[d];
         for (int i = 0; i < e; i++) {
-            for_each_element_variadic(0, d-1, f, buf, buf.min[d] + i, std::forward<Args>(args)...);
+            for_each_element_variadic(0, d-1, f, buf, buf.min[d] + i, args...);
         }
     }
 
     /** Determine the minimum number of arguments a callable can take
      * using the same trick. */
     template<typename ...Args>
-    static auto num_args(int, int *result, Fn f, Args&&... args) -> decltype(f(args...)) {
+    static auto num_args(int, int *result, Fn f, const Args &... args) -> decltype(f(args...)) {
         *result = sizeof...(args);
     }
 
@@ -581,11 +581,11 @@ struct for_each_element_helpers {
      * of 256. This catches callables that aren't callable with any
      * number of ints. */
     template<typename ...Args>
-    static void num_args(double, int *result, Fn f, Args&&... args) {
+    static void num_args(double, int *result, Fn f, const Args &... args) {
         static_assert(sizeof...(args) <= 256,
                       "Callable passed to for_each_element must accept either a const int *,"
                       " or up to 256 ints. No such operator found. Expect infinite template recursion.");
-        return num_args(0, result, f, 0, std::forward<Args>(args)...);
+        return num_args(0, result, f, 0, args...);
     }
 
     static int get_number_of_args(Fn f) {


### PR DESCRIPTION
Using this approach is more verbose but more robust. See (e.g.)
http://eli.thegreenplace.net/2014/perfect-forwarding-and-universal-refer
ences-in-c/