### PR TITLE
Generate proper GLSL for vector comparisons.

### DIFF
--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -237,61 +237,48 @@ string CodeGen_GLSLBase::print_type(Type type, AppendSpaceIfNeeded space_option)
 // types, so we don't use call_builtin
 void CodeGen_GLSLBase::visit(const EQ *op) {
     if (op->type.is_vector()) {
-        Type bool_type = Bool(op->type.lanes());
-        print_expr(Call::make(bool_type, "equal", {op->a, op->b}, Call::Extern));
-    }
-    else {
+        print_expr(Call::make(op->type, "equal", {op->a, op->b}, Call::Extern));
+    } else {
         CodeGen_C::visit(op);
     }
 }
 
 void CodeGen_GLSLBase::visit(const NE *op) {
     if (op->type.is_vector()) {
-        Type bool_type = Bool(op->type.lanes());
-        print_expr(Call::make(bool_type, "notEqual", {op->a, op->b}, Call::Extern));
-    }
-    else {
+        print_expr(Call::make(op->type, "notEqual", {op->a, op->b}, Call::Extern));
+    } else {
         CodeGen_C::visit(op);
     }
-
 }
 
 void CodeGen_GLSLBase::visit(const LT *op) {
     if (op->type.is_vector()) {
-        Type bool_type = Bool(op->type.lanes());
-        print_expr(Call::make(bool_type, "lessThan", {op->a, op->b}, Call::Extern));
-    }
-    else {
+        print_expr(Call::make(op->type, "lessThan", {op->a, op->b}, Call::Extern));
+    } else {
         CodeGen_C::visit(op);
     }
 }
 
 void CodeGen_GLSLBase::visit(const LE *op) {
     if (op->type.is_vector()) {
-        Type bool_type = Bool(op->type.lanes());
-        print_expr(Call::make(bool_type, "lessThanEqual", {op->a, op->b}, Call::Extern));
-    }
-    else {
+        print_expr(Call::make(op->type, "lessThanEqual", {op->a, op->b}, Call::Extern));
+    } else {
         CodeGen_C::visit(op);
     }
 }
 
 void CodeGen_GLSLBase::visit(const GT *op) {
     if (op->type.is_vector()) {
-        Type bool_type = Bool(op->type.lanes());
-        print_expr(Call::make(bool_type, "greaterThan", {op->a, op->b}, Call::Extern));
-    }
-    else {
+        print_expr(Call::make(op->type, "greaterThan", {op->a, op->b}, Call::Extern));
+    } else {
         CodeGen_C::visit(op);
     }
 }
 
 void CodeGen_GLSLBase::visit(const GE *op) {
     if (op->type.is_vector()) {
-        Type bool_type = Bool(op->type.lanes());
-        print_expr(Call::make(bool_type, "greaterThanEqual", {op->a, op->b}, Call::Extern));
-    }
-    else {
+        print_expr(Call::make(op->type, "greaterThanEqual", {op->a, op->b}, Call::Extern));
+    } else {
         CodeGen_C::visit(op);
     }
 }

--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -150,6 +150,14 @@ CodeGen_GLSLBase::CodeGen_GLSLBase(std::ostream &s) : CodeGen_C(s) {
     builtin["isnan"] = "isnan";
     builtin["round_f32"] = "roundEven";
     builtin["trunc_f32"] = "_trunc_f32";
+
+    // functions that produce bvecs
+    builtin["equal"] = "equal";
+    builtin["notEqual"] = "notEqual";
+    builtin["lessThan"] = "lessThan";
+    builtin["lessThanEqual"] = "lessThanEqual";
+    builtin["greaterThan"] = "greaterThan";
+    builtin["greaterThanEqual"] = "greaterThanEqual";
 }
 
 void CodeGen_GLSLBase::visit(const Max *op) {
@@ -223,6 +231,69 @@ string CodeGen_GLSLBase::print_type(Type type, AppendSpaceIfNeeded space_option)
     }
 
     return oss.str();
+}
+
+// The following comparisons are defined for ivec and vec
+// types, so we don't use call_builtin
+void CodeGen_GLSLBase::visit(const EQ *op) {
+    if (op->type.is_vector()) {
+        Type bool_type = Bool(op->type.lanes());
+        print_expr(Call::make(bool_type, "equal", {op->a, op->b}, Call::Extern));
+    }
+    else {
+        CodeGen_C::visit(op);
+    }
+}
+
+void CodeGen_GLSLBase::visit(const NE *op) {
+    if (op->type.is_vector()) {
+        Type bool_type = Bool(op->type.lanes());
+        print_expr(Call::make(bool_type, "notEqual", {op->a, op->b}, Call::Extern));
+    }
+    else {
+        CodeGen_C::visit(op);
+    }
+
+}
+
+void CodeGen_GLSLBase::visit(const LT *op) {
+    if (op->type.is_vector()) {
+        Type bool_type = Bool(op->type.lanes());
+        print_expr(Call::make(bool_type, "lessThan", {op->a, op->b}, Call::Extern));
+    }
+    else {
+        CodeGen_C::visit(op);
+    }
+}
+
+void CodeGen_GLSLBase::visit(const LE *op) {
+    if (op->type.is_vector()) {
+        Type bool_type = Bool(op->type.lanes());
+        print_expr(Call::make(bool_type, "lessThanEqual", {op->a, op->b}, Call::Extern));
+    }
+    else {
+        CodeGen_C::visit(op);
+    }
+}
+
+void CodeGen_GLSLBase::visit(const GT *op) {
+    if (op->type.is_vector()) {
+        Type bool_type = Bool(op->type.lanes());
+        print_expr(Call::make(bool_type, "greaterThan", {op->a, op->b}, Call::Extern));
+    }
+    else {
+        CodeGen_C::visit(op);
+    }
+}
+
+void CodeGen_GLSLBase::visit(const GE *op) {
+    if (op->type.is_vector()) {
+        Type bool_type = Bool(op->type.lanes());
+        print_expr(Call::make(bool_type, "greaterThanEqual", {op->a, op->b}, Call::Extern));
+    }
+    else {
+        CodeGen_C::visit(op);
+    }
 }
 
 // Identifiers containing double underscores '__' are reserved in GLSL, so we

--- a/src/CodeGen_OpenGL_Dev.h
+++ b/src/CodeGen_OpenGL_Dev.h
@@ -65,6 +65,15 @@ protected:
     void visit(const Mod *op);
     void visit(const Call *op);
 
+    // these have specific functions
+    // in GLSL that operate on vectors
+    void visit(const EQ *);
+    void visit(const NE *);
+    void visit(const LT *);
+    void visit(const LE *);
+    void visit(const GT *);
+    void visit(const GE *);
+
 private:
     std::map<std::string, std::string> builtin;
 };

--- a/test/opengl/conv_select.cpp
+++ b/test/opengl/conv_select.cpp
@@ -1,0 +1,65 @@
+// test case provided by Lee Yuguang
+
+
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main() {
+    // This test must be run with an OpenGL target.
+    const Target &target = get_jit_target_from_environment();
+    if (!target.has_feature(Target::OpenGL)) {
+        fprintf(stderr, "ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
+        return 1;
+    }
+
+    // Define the input
+    const int width = 10, height = 10, channels = 4, res_channels = 2;
+    Image<float> input(width, height, channels);
+    for (int c = 0; c < input.channels(); c++) {
+        for (int y = 0; y < input.height(); y++) {
+            for (int x = 0; x < input.width(); x++) {
+                input(x, y, c) = float(x + y);
+            }
+        }
+    }
+
+    // Define the algorithm.
+    Var x, y, c;
+    RDom r(0, 2, "r");
+    Func f, g;
+
+    Expr coordx = clamp(x + r, 0, input.width() - 1);
+    f(x, y, c) = cast<float>(sum(input(coordx, y, c)));
+
+    Expr R = select(f(x, y, c) > 9.0f, 1.0f, 0.0f);
+    Expr G = select(f(x, y, c) > 9.0f, 0.f, 1.0f);
+    g(x, y, c) = select(c==0, R, G);
+
+    // Schedule f and g to compute in separate passes on the GPU.
+    g.bound(c, 0, 2).glsl(x, y, c);
+
+    // Generate the result.
+    Image<float> result = g.realize(width, height, res_channels);
+    result.copy_to_host();
+
+    //Check the result.
+    for (int c = 0; c < result.channels(); c++) {
+        for (int y = 0; y < result.height(); y++) {
+            for (int x = 0; x < result.width(); x++) {
+                float temp = ((x + y)>4)?1.0f:0.0f;
+
+                float correct = (c==0)? temp : (1.0f - temp);
+                if (result(x, y, c) != correct) {
+                    fprintf(stderr, "result(%d, %d, %d) = %f instead of %f\n",
+                            x, y, c, result(x, y, c), correct);
+                    return 1;
+                }
+            }
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
GLSL uses functions for vector comparisons, so this PR implements them for the supported operations in GLSL.  Fixes the bug reported by Lee Yuguang ("Can't do color channel synthesis using select after convolution").