### PR TITLE
remove unnecessary -g arg from most generator calls

### DIFF
--- a/HalideGenerator.cmake
+++ b/HalideGenerator.cmake
@@ -58,7 +58,7 @@ function(halide_add_generator_dependency)
   set(multiValueArgs GENERATOR_ARGS)
   cmake_parse_arguments(args "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
-  set(unique_generator_target "${args_GENERATOR_NAME}${args_TARGET_SUFFIX}")
+  set(unique_generator_target "${args_GENERATED_FUNCTION}${args_TARGET_SUFFIX}")
 
   # Determine a scratch directory to build and execute the generator. ${args_TARGET}
   # will include the generated header from this directory.
@@ -68,11 +68,18 @@ function(halide_add_generator_dependency)
   set(FILTER_LIB "${args_GENERATED_FUNCTION}${CMAKE_STATIC_LIBRARY_SUFFIX}")
   set(FILTER_HDR "${args_GENERATED_FUNCTION}.h")
 
-  set(generator_exec_args 
-      "-g" "${args_GENERATOR_NAME}" 
-      "-f" "${args_GENERATED_FUNCTION_NAMESPACE}${args_GENERATED_FUNCTION}" 
-      "-o" "${SCRATCH_DIR}" ${args_GENERATOR_ARGS}
-  )
+  if (NOT ${args_GENERATOR_NAME} STREQUAL "")
+    set(generator_exec_args 
+        "-g" "${args_GENERATOR_NAME}" 
+        "-f" "${args_GENERATED_FUNCTION_NAMESPACE}${args_GENERATED_FUNCTION}" 
+        "-o" "${SCRATCH_DIR}" ${args_GENERATOR_ARGS}
+    )
+  else()
+    set(generator_exec_args 
+        "-f" "${args_GENERATED_FUNCTION_NAMESPACE}${args_GENERATED_FUNCTION}" 
+        "-o" "${SCRATCH_DIR}" ${args_GENERATOR_ARGS}
+    )
+  endif()
   if(MSVC)
     # In MSVC, the generator executable will be placed in a configuration specific
     # directory specified by ${CMAKE_CFG_INTDIR}.

--- a/Makefile
+++ b/Makefile
@@ -885,7 +885,7 @@ NAME_MANGLING_TARGET=$(NON_EMPTY_TARGET)-c_plus_plus_name_mangling
 $(FILTERS_DIR)/%.a: $(BIN_DIR)/%.generator
 	@mkdir -p $(FILTERS_DIR)
 	@-mkdir -p $(TMP_DIR)
-	cd $(TMP_DIR); $(CURDIR)/$< -g $(notdir $*) -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime
+	cd $(TMP_DIR); $(CURDIR)/$< -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime
 
 $(FILTERS_DIR)/%.h: $(FILTERS_DIR)/%.a
 	@echo $@ produced implicitly by $^
@@ -895,22 +895,22 @@ $(FILTERS_DIR)/%.h: $(FILTERS_DIR)/%.a
 $(FILTERS_DIR)/cxx_mangling.a: $(BIN_DIR)/cxx_mangling.generator
 	@mkdir -p $(FILTERS_DIR)
 	@-mkdir -p $(TMP_DIR)
-	cd $(TMP_DIR); $(CURDIR)/$< -g $(notdir $*) -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime-c_plus_plus_name_mangling -f "HalideTest::cxx_mangling"
+	cd $(TMP_DIR); $(CURDIR)/$< -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime-c_plus_plus_name_mangling -f "HalideTest::cxx_mangling"
 
 $(FILTERS_DIR)/cxx_mangling_define_extern.a: $(BIN_DIR)/cxx_mangling_define_extern.generator
 	@mkdir -p $(FILTERS_DIR)
 	@-mkdir -p $(TMP_DIR)
-	cd $(TMP_DIR); $(CURDIR)/$< -g $(notdir $*) -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime-c_plus_plus_name_mangling-user_context -f "HalideTest::cxx_mangling_define_extern"
+	cd $(TMP_DIR); $(CURDIR)/$< -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime-c_plus_plus_name_mangling-user_context -f "HalideTest::cxx_mangling_define_extern"
 
 $(FILTERS_DIR)/tiled_blur_interleaved.a: $(BIN_DIR)/tiled_blur.generator
 	@mkdir -p $(FILTERS_DIR)
 	@-mkdir -p $(TMP_DIR)
-	cd $(TMP_DIR); $(CURDIR)/$< -g tiled_blur -f tiled_blur_interleaved -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime is_interleaved=true
+	cd $(TMP_DIR); $(CURDIR)/$< -f tiled_blur_interleaved -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime is_interleaved=true
 
 $(FILTERS_DIR)/tiled_blur_blur_interleaved.a: $(BIN_DIR)/tiled_blur_blur.generator
 	@mkdir -p $(FILTERS_DIR)
 	@-mkdir -p $(TMP_DIR)
-	cd $(TMP_DIR); $(CURDIR)/$< -g tiled_blur_blur -f tiled_blur_blur_interleaved -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime is_interleaved=true
+	cd $(TMP_DIR); $(CURDIR)/$< -f tiled_blur_blur_interleaved -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime is_interleaved=true
 
 # metadata_tester is built with and without user-context
 $(FILTERS_DIR)/metadata_tester.a: $(BIN_DIR)/metadata_tester.generator
@@ -947,8 +947,6 @@ $(FILTERS_DIR)/user_context_insanity.a: $(BIN_DIR)/user_context_insanity.generat
 # (1) Ensuring the extra _generator.cpp is built into the .generator.
 # (2) Ensuring the extra .a is linked into the final output.
 
-# tiled_blur also needs tiled_blur_blur, due to an extern_generator dependency.
-$(BIN_DIR)/tiled_blur.generator: $(ROOT_DIR)/test/generator/tiled_blur_blur_generator.cpp
 # TODO(srj): we really want to say "anything that depends on tiled_blur.a also depends on tiled_blur_blur.a";
 # is there a way to specify that in Make?
 $(BIN_DIR)/generator_aot_tiled_blur: $(FILTERS_DIR)/tiled_blur_blur.a

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,12 +96,7 @@ if (WITH_TEST_GENERATORS)
   set(OBJ_GEN_EXE_SUFFIX ".generator")
   foreach(gen_src ${GENS})
     string(REPLACE "_generator.cpp" "" gen_name "${gen_src}${OBJ_GEN_EXE_SUFFIX}")
-    # tiled_blur also needs tiled_blur_blur
-    if(gen_name STREQUAL "tiled_blur${OBJ_GEN_EXE_SUFFIX}")
-      halide_project(${gen_name} "generator" "${CMAKE_CURRENT_SOURCE_DIR}/../tools/GenGen.cpp" "generator/${gen_src}" "generator/tiled_blur_blur_generator.cpp")
-    else()
-      halide_project(${gen_name} "generator" "${CMAKE_CURRENT_SOURCE_DIR}/../tools/GenGen.cpp" "generator/${gen_src}")
-    endif()
+    halide_project(${gen_name} "generator" "${CMAKE_CURRENT_SOURCE_DIR}/../tools/GenGen.cpp" "generator/${gen_src}")
   endforeach()
 
   # Next create the test case targets. For each target
@@ -130,14 +125,12 @@ if (WITH_TEST_GENERATORS)
       # generator args.
       halide_add_generator_dependency(TARGET "${TEST_RUNNER}"
                                GENERATOR_TARGET "tiled_blur${OBJ_GEN_EXE_SUFFIX}"
-                               GENERATOR_NAME "tiled_blur"
                                GENERATED_FUNCTION "tiled_blur_interleaved"
                                GENERATOR_ARGS "target=host" "is_interleaved=true")
       # "tiled_blur_blur_interleaved" is produced by using tiled_blur_blur with
       # different generator args.
       halide_add_generator_dependency(TARGET "${TEST_RUNNER}"
                                GENERATOR_TARGET "tiled_blur_blur${OBJ_GEN_EXE_SUFFIX}"
-                               GENERATOR_NAME "tiled_blur_blur"
                                GENERATED_FUNCTION "tiled_blur_blur_interleaved"
                                GENERATOR_ARGS "target=host" "is_interleaved=true")
     elseif(TEST_SRC STREQUAL "nested_externs_aottest.cpp")
@@ -165,20 +158,17 @@ if (WITH_TEST_GENERATORS)
     elseif(TEST_SRC STREQUAL "user_context_aottest.cpp")
       halide_add_generator_dependency(TARGET "${TEST_RUNNER}"
                                GENERATOR_TARGET "${GEN_NAME}${OBJ_GEN_EXE_SUFFIX}"
-                               GENERATOR_NAME "${GEN_NAME}"
                                GENERATED_FUNCTION "${FUNC_NAME}"
                                GENERATOR_ARGS "target=host-user_context")
     elseif(TEST_SRC STREQUAL "user_context_insanity_aottest.cpp")
       halide_add_generator_dependency(TARGET "${TEST_RUNNER}"
                                GENERATOR_TARGET "${GEN_NAME}${OBJ_GEN_EXE_SUFFIX}"
-                               GENERATOR_NAME "${GEN_NAME}"
                                GENERATED_FUNCTION "${FUNC_NAME}"
                                GENERATOR_ARGS "target=host-user_context")
     elseif(TEST_SRC STREQUAL "multitarget_aottest.cpp")
       # Needs custom target string
       halide_add_generator_dependency(TARGET "${TEST_RUNNER}"
                                GENERATOR_TARGET "${GEN_NAME}${OBJ_GEN_EXE_SUFFIX}"
-                               GENERATOR_NAME "${GEN_NAME}"
                                GENERATED_FUNCTION "${FUNC_NAME}"
                                GENERATED_FUNCTION_NAMESPACE "HalideTest::"
                                GENERATOR_ARGS "target=host-debug-c_plus_plus_name_mangling,host-c_plus_plus_name_mangling")
@@ -186,25 +176,21 @@ if (WITH_TEST_GENERATORS)
     elseif(TEST_SRC STREQUAL "metadata_tester_aottest.cpp")
       halide_add_generator_dependency(TARGET "${TEST_RUNNER}"
                                GENERATOR_TARGET "${GEN_NAME}${OBJ_GEN_EXE_SUFFIX}"
-                               GENERATOR_NAME "${GEN_NAME}"
                                GENERATED_FUNCTION "${FUNC_NAME}"
                                GENERATOR_ARGS "target=host-register_metadata")
       halide_add_generator_dependency(TARGET "${TEST_RUNNER}"
                                GENERATOR_TARGET "${GEN_NAME}${OBJ_GEN_EXE_SUFFIX}"
-                               GENERATOR_NAME "${GEN_NAME}"
                                GENERATED_FUNCTION "${FUNC_NAME}_ucon"
                                GENERATOR_ARGS "target=host-register_metadata-user_context")
     elseif(TEST_SRC STREQUAL "cxx_mangling_aottest.cpp")
       halide_add_generator_dependency(TARGET "${TEST_RUNNER}"
                                GENERATOR_TARGET "${GEN_NAME}${OBJ_GEN_EXE_SUFFIX}"
-                               GENERATOR_NAME "${GEN_NAME}"
                                GENERATED_FUNCTION "${FUNC_NAME}"
                                GENERATED_FUNCTION_NAMESPACE "HalideTest::"
                                GENERATOR_ARGS "target=host-c_plus_plus_name_mangling")
     elseif(TEST_SRC STREQUAL "cxx_mangling_define_extern_aottest.cpp")
       halide_add_generator_dependency(TARGET "${TEST_RUNNER}"
                                GENERATOR_TARGET "cxx_mangling${OBJ_GEN_EXE_SUFFIX}"
-                               GENERATOR_NAME "cxx_mangling"
                                TARGET_SUFFIX "_2"
                                GENERATED_FUNCTION "cxx_mangling"
                                GENERATED_FUNCTION_NAMESPACE "HalideTest::"
@@ -212,7 +198,6 @@ if (WITH_TEST_GENERATORS)
                                OUTPUT_LIB_VAR LIB_cxx_mangling)
       halide_add_generator_dependency(TARGET "${TEST_RUNNER}"
                                GENERATOR_TARGET "${GEN_NAME}${OBJ_GEN_EXE_SUFFIX}"
-                               GENERATOR_NAME "${GEN_NAME}"
                                GENERATED_FUNCTION "${FUNC_NAME}"
                                GENERATED_FUNCTION_NAMESPACE "HalideTest::"
                                GENERATOR_ARGS "target=host-c_plus_plus_name_mangling-user_context")
@@ -221,14 +206,12 @@ if (WITH_TEST_GENERATORS)
       # All the other foo_test.cpp just depend on foo_generator.cpp
       halide_add_generator_dependency(TARGET "${TEST_RUNNER}"
                                GENERATOR_TARGET "${GEN_NAME}${OBJ_GEN_EXE_SUFFIX}"
-                               GENERATOR_NAME "${GEN_NAME}"
                                GENERATED_FUNCTION "${FUNC_NAME}"
                                GENERATOR_ARGS "target=host")
       # tiled_blur_aottest.cpp depends on tiled_blur AND ALSO tiled_blur_blur
       if (TEST_SRC STREQUAL "tiled_blur_aottest.cpp")
         halide_add_generator_dependency(TARGET "${TEST_RUNNER}"
                                  GENERATOR_TARGET "tiled_blur_blur${OBJ_GEN_EXE_SUFFIX}"
-                                 GENERATOR_NAME "tiled_blur_blur"
                                  GENERATED_FUNCTION "tiled_blur_blur"
                                  GENERATOR_ARGS "target=host")
       endif()


### PR DESCRIPTION
Only nested_externs actually needed it. (Ditto GENERATOR_NAME in CMake.)