### PR TITLE
OpenGL: fix state save test

### DIFF
--- a/test/opengl/save_state.cpp
+++ b/test/opengl/save_state.cpp
@@ -178,6 +178,10 @@ class KnownState
         }
     }
 
+    // version of OpenGL
+    int gl_major_version;
+    int gl_minor_version;
+
     GLenum initial_active_texture;
     GLint initial_viewport[4];
     GLuint initial_array_buffer_binding;
@@ -220,11 +224,6 @@ class KnownState
     GLuint initial_vertex_array_binding;
 
     public:
-
-    // version of OpenGL
-    int gl_major_version;
-    int gl_minor_version;
-
 
     bool errors;
 

--- a/test/opengl/save_state.cpp
+++ b/test/opengl/save_state.cpp
@@ -267,8 +267,9 @@ class KnownState
         // Vertex array objects are only used by Halide if the OpenGL version >=3
         if (gl_major_version >= 3) {
             glBindVertexArray(initial_vertex_array_binding = gl_gen(glGenVertexArrays));
-            check_error("known state");
         }
+
+        check_error("known state");
     }
 
     void check(const char *operation)
@@ -285,6 +286,8 @@ class KnownState
         // Vertex array objects are only used by Halide if the OpenGL version >=3
         if (gl_major_version >= 3) {
             check_value(operation, "vertex array binding", GL_VERTEX_ARRAY_BINDING, initial_vertex_array_binding);
+        } else {
+            fprintf(stderr, "Skipping vertex array binding tests because OpenGL version is %d.%d (<3.0)\n", gl_major_version, gl_minor_version);
         }
 
         for (int i=0; i<ntextures; i++) {

--- a/test/opengl/save_state.cpp
+++ b/test/opengl/save_state.cpp
@@ -244,7 +244,7 @@ class KnownState
             glActiveTexture(GL_TEXTURE0 + i);
             glBindTexture(GL_TEXTURE_2D, initial_bound_textures[i]);
         }
-	    glActiveTexture(initial_active_texture = GL_TEXTURE3);
+        glActiveTexture(initial_active_texture = GL_TEXTURE3);
 
         for (int i=0; i<nvertex_attribs; i++) {
             if ( (initial_vertex_attrib_array_enabled[i] = boolval ) )

--- a/test/opengl/save_state.cpp
+++ b/test/opengl/save_state.cpp
@@ -45,6 +45,7 @@ extern "C" void glBindFramebuffer(GLenum, GLuint);
 extern "C" void glGenVertexArrays(GLsizei, GLuint *);
 extern "C" void glBindVertexArray(GLuint);
 extern "C" void glGetVertexAttribiv(GLuint, GLenum, GLint *);
+extern "C" const GLubyte* glGetString(GLenum name);
 
 // Generates an arbitrary program.
 class Program
@@ -115,7 +116,7 @@ class KnownState
 
     void gl_enable(GLenum cap, bool state)
     {
-	(state ? glEnable : glDisable)(cap);
+        (state ? glEnable : glDisable)(cap);
     }
 
     GLuint gl_gen(void (*fn)(GLsizei, GLuint *))
@@ -128,12 +129,12 @@ class KnownState
 
     void check_value(const char *operation, const char *label, GLenum pname, GLint initial)
     {
-	GLint val;
-	glGetIntegerv(pname, &val);
-	if (val != initial) {
-	    fprintf(stderr, "%s did not restore %s: initial value was %d (%#x), current value is %d (%#x)\n", operation, label, initial, initial, val, val);
-	    errors = true;
-	}
+        GLint val;
+        glGetIntegerv(pname, &val);
+        if (val != initial) {
+            fprintf(stderr, "%s did not restore %s: initial value was %d (%#x), current value is %d (%#x)\n", operation, label, initial, initial, val, val);
+            errors = true;
+        }
     }
 
     void check_value(const char *operation, const char *label, GLenum pname, GLenum initial)
@@ -160,21 +161,21 @@ class KnownState
 
     void check_value(const char *operation, const char *label, GLenum pname, bool initial)
     {
-	GLboolean val;
-	glGetBooleanv(pname, &val);
-	if (val != initial) {
-	    fprintf(stderr, "%s did not restore boolean %s: initial value was %s, current value is %s\n", operation, label, initial ? "true" : "false", val ? "true" : "false");
-	    errors = true;
-	}
+        GLboolean val;
+        glGetBooleanv(pname, &val);
+        if (val != initial) {
+            fprintf(stderr, "%s did not restore boolean %s: initial value was %s, current value is %s\n", operation, label, initial ? "true" : "false", val ? "true" : "false");
+            errors = true;
+        }
     }
 
     void check_error(const char *label)
     {
-	GLenum err = glGetError();
-	if (err != GL_NO_ERROR) {
-	    fprintf(stderr, "Error setting %s: OpenGL error %#x\n", label, err);
-	    errors = true;
-	}
+        GLenum err = glGetError();
+        if (err != GL_NO_ERROR) {
+            fprintf(stderr, "Error setting %s: OpenGL error %#x\n", label, err);
+            errors = true;
+        }
     }
 
     GLenum initial_active_texture;
@@ -191,13 +192,42 @@ class KnownState
     static const int nvertex_attribs = 10;
     bool initial_vertex_attrib_array_enabled[nvertex_attribs];
 
-#ifdef GL_VERTEX_ARRAY_BINDING
+    // The next two functions are stolen from opengl.cpp
+    // and are used to parse the major/minor version of OpenGL
+    // to see if vertex array objects are supported
+    const char *parse_int(const char *str, int *val) {
+        int v = 0;
+        size_t i = 0;
+        while (str[i] >= '0' && str[i] <= '9') {
+            v = 10 * v + (str[i] - '0');
+            i++;
+        }
+        if (i > 0) {
+            *val = v;
+            return &str[i];
+        }
+        return NULL;
+    }
+
+    const char *parse_opengl_version(const char *str, int *major, int *minor) {
+        str = parse_int(str, major);
+        if (str == NULL || *str != '.') {
+            return NULL;
+        }
+        return parse_int(str + 1, minor);
+    }
+
     GLuint initial_vertex_array_binding;
-#endif
 
     public:
 
+    // version of OpenGL
+    int gl_major_version;
+    int gl_minor_version;
+
+
     bool errors;
+
 
     // This sets most values to generated or arbitrary values, which the
     // halide calls would be unlikely to accidentally use.  But for boolean
@@ -206,12 +236,16 @@ class KnownState
     // be able to try both.
     void setup(bool boolval)
     {
+        // parse the OpenGL version
+        const char *version = (const char *)glGetString(GL_VERSION);
+        parse_opengl_version(version, &gl_major_version, &gl_minor_version);
+
         glGenTextures(ntextures, initial_bound_textures);
         for (int i=0; i<ntextures; i++) {
             glActiveTexture(GL_TEXTURE0 + i);
             glBindTexture(GL_TEXTURE_2D, initial_bound_textures[i]);
         }
-	glActiveTexture(initial_active_texture = GL_TEXTURE3);
+	    glActiveTexture(initial_active_texture = GL_TEXTURE3);
 
         for (int i=0; i<nvertex_attribs; i++) {
             if ( (initial_vertex_attrib_array_enabled[i] = boolval ) )
@@ -223,34 +257,36 @@ class KnownState
             check_error(buf);
         }
 
-	glUseProgram(initial_current_program = Program::handle());
-	glViewport(initial_viewport[0] = 111, initial_viewport[1] = 222, initial_viewport[2] = 333, initial_viewport[3] = 444);
-	gl_enable(GL_CULL_FACE, initial_cull_face = boolval);
-	gl_enable(GL_DEPTH_TEST, initial_depth_test = boolval);
-	glBindBuffer(GL_ARRAY_BUFFER, initial_array_buffer_binding = gl_gen(glGenBuffers));
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, initial_element_array_buffer_binding = gl_gen(glGenBuffers));
-	glBindFramebuffer(GL_FRAMEBUFFER, initial_framebuffer_binding = gl_gen(glGenFramebuffers));
+        glUseProgram(initial_current_program = Program::handle());
+        glViewport(initial_viewport[0] = 111, initial_viewport[1] = 222, initial_viewport[2] = 333, initial_viewport[3] = 444);
+        gl_enable(GL_CULL_FACE, initial_cull_face = boolval);
+        gl_enable(GL_DEPTH_TEST, initial_depth_test = boolval);
+        glBindBuffer(GL_ARRAY_BUFFER, initial_array_buffer_binding = gl_gen(glGenBuffers));
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, initial_element_array_buffer_binding = gl_gen(glGenBuffers));
+        glBindFramebuffer(GL_FRAMEBUFFER, initial_framebuffer_binding = gl_gen(glGenFramebuffers));
 
-#ifdef GL_VERTEX_ARRAY_BINDING
-        glBindVertexArray(initial_vertex_array_binding = gl_gen(glGenVertexArrays));
-#endif
-        check_error("known state");
+        // Vertex array objects are only used by Halide if the OpenGL version >=3
+        if (gl_major_version >= 3) {
+            glBindVertexArray(initial_vertex_array_binding = gl_gen(glGenVertexArrays));
+            check_error("known state");
+        }
     }
 
     void check(const char *operation)
     {
-	check_value(operation, "ActiveTexture", GL_ACTIVE_TEXTURE, initial_active_texture);
-	check_value(operation, "current program", GL_CURRENT_PROGRAM, initial_current_program);
-	check_value(operation, "framebuffer binding", GL_FRAMEBUFFER_BINDING, initial_framebuffer_binding);
-	check_value(operation, "array buffer binding", GL_ARRAY_BUFFER_BINDING, initial_array_buffer_binding);
-	check_value(operation, "element array buffer binding", GL_ELEMENT_ARRAY_BUFFER_BINDING, initial_element_array_buffer_binding);
-	check_value(operation, "viewport", GL_VIEWPORT, initial_viewport);
-	check_value(operation, "GL_CULL_FACE", GL_CULL_FACE, initial_cull_face);
-	check_value(operation, "GL_DEPTH_TEST", GL_DEPTH_TEST, initial_cull_face);
+        check_value(operation, "ActiveTexture", GL_ACTIVE_TEXTURE, initial_active_texture);
+        check_value(operation, "current program", GL_CURRENT_PROGRAM, initial_current_program);
+        check_value(operation, "framebuffer binding", GL_FRAMEBUFFER_BINDING, initial_framebuffer_binding);
+        check_value(operation, "array buffer binding", GL_ARRAY_BUFFER_BINDING, initial_array_buffer_binding);
+        check_value(operation, "element array buffer binding", GL_ELEMENT_ARRAY_BUFFER_BINDING, initial_element_array_buffer_binding);
+        check_value(operation, "viewport", GL_VIEWPORT, initial_viewport);
+        check_value(operation, "GL_CULL_FACE", GL_CULL_FACE, initial_cull_face);
+        check_value(operation, "GL_DEPTH_TEST", GL_DEPTH_TEST, initial_cull_face);
 
-#ifdef GL_VERTEX_ARRAY_BINDING
-	check_value(operation, "vertex array binding", GL_VERTEX_ARRAY_BINDING, initial_vertex_array_binding);
-#endif
+        // Vertex array objects are only used by Halide if the OpenGL version >=3
+        if (gl_major_version >= 3) {
+            check_value(operation, "vertex array binding", GL_VERTEX_ARRAY_BINDING, initial_vertex_array_binding);
+        }
 
         for (int i=0; i<ntextures; i++) {
             char buf[100];


### PR DESCRIPTION
Vertex array objects are only present (and used by Halide) on OpenGL >= 3.0.  This uses logic from the runtime to only check state saving/restore for VAOs for OpenGL versions that support them.

Also fix formatting: tabs-> 4 spaces.

CC: @ronen 