### PR TITLE
Add Matlab support for multitarget builds

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -23,16 +23,16 @@ namespace {
 class TemporaryObjectFileDir final {
 public:
     TemporaryObjectFileDir() : dir_path(dir_make_temp()) {}
-    ~TemporaryObjectFileDir() { 
+    ~TemporaryObjectFileDir() {
         for (const auto &f : dir_files) {
             debug(1) << "file_unlink: " << f << "\n";
             file_unlink(f);
         }
         debug(1) << "dir_rmdir: " << dir_path << "\n";
-        dir_rmdir(dir_path); 
+        dir_rmdir(dir_path);
     }
-    std::string add_temp_object_file(const std::string &base_path_name, 
-                                     const std::string &suffix, 
+    std::string add_temp_object_file(const std::string &base_path_name,
+                                     const std::string &suffix,
                                      const Target &target,
                                      bool in_front = false) {
         const char* ext = target.os == Target::Windows && !target.has_feature(Target::MinGW) ? ".obj" : ".o";
@@ -98,14 +98,14 @@ EXPORT void destroy<ModuleContents>(const ModuleContents *f) {
 
 LoweredFunc::LoweredFunc(const std::string &name, const std::vector<LoweredArgument> &args, Stmt body, LinkageType linkage)
     : name(name), args(args), body(body), linkage(linkage) {}
-  
+
 LoweredFunc::LoweredFunc(const std::string &name, const std::vector<Argument> &args, Stmt body, LinkageType linkage)
     : name(name), body(body), linkage(linkage) {
     for (const Argument &i : args) {
         this->args.push_back(i);
     }
 }
-  
+
 }  // namespace Internal
 
 using namespace Halide::Internal;
@@ -254,7 +254,7 @@ void Module::compile(const Outputs &output_files) const {
 Outputs compile_standalone_runtime(const Outputs &output_files, Target t) {
     Module empty("standalone_runtime", t.without_feature(Target::NoRuntime).without_feature(Target::JIT));
     // For runtime, it only makes sense to output object files or static_library, so ignore
-    // everything else. 
+    // everything else.
     Outputs actual_outputs = Outputs().object(output_files.object_name).static_library(output_files.static_library_name);
     empty.compile(actual_outputs);
     return actual_outputs;
@@ -264,9 +264,9 @@ void compile_standalone_runtime(const std::string &object_filename, Target t) {
     compile_standalone_runtime(Outputs().object(object_filename), t);
 }
 
-void compile_multitarget(const std::string &fn_name, 
+void compile_multitarget(const std::string &fn_name,
                          const Outputs &output_files,
-                         const std::vector<Target> &targets, 
+                         const std::vector<Target> &targets,
                          ModuleProducer module_producer) {
     user_assert(!fn_name.empty()) << "Function name must be specified.\n";
     user_assert(!targets.empty()) << "Must specify at least one target.\n";
@@ -325,8 +325,15 @@ void compile_multitarget(const std::string &fn_name,
         auto suffix = "_" + replace_all(target.to_string(), "-", "_");
         std::string sub_fn_name = fn_name + suffix;
 
+        Target sub_fn_target = target;
+
         // We always produce the runtime separately, so add NoRuntime explicitly.
-        Module module = module_producer(sub_fn_name, target.with_feature(Target::NoRuntime));
+        sub_fn_target = sub_fn_target.with_feature(Target::NoRuntime);
+
+        // Matlab should be added to the wrapper pipeline, instead of each sub-pipeline.
+        sub_fn_target = sub_fn_target.without_feature(Target::Matlab);
+
+        Module module = module_producer(sub_fn_name, sub_fn_target);
         Outputs sub_out = add_suffixes(output_files, suffix);
         if (sub_out.object_name.empty()) {
             sub_out.object_name = temp_dir.add_temp_object_file(output_files.static_library_name, suffix, target);
@@ -356,7 +363,7 @@ void compile_multitarget(const std::string &fn_name,
     // and add that to the result.
     if (!base_target.has_feature(Target::NoRuntime)) {
         const Target runtime_target = base_target.without_feature(Target::NoRuntime);
-        compile_standalone_runtime(Outputs().object(temp_dir.add_temp_object_file(output_files.static_library_name, "_runtime", runtime_target)), 
+        compile_standalone_runtime(Outputs().object(temp_dir.add_temp_object_file(output_files.static_library_name, "_runtime", runtime_target)),
             runtime_target);
     }
 
@@ -375,10 +382,17 @@ void compile_multitarget(const std::string &fn_name,
     // does mean we get redundant check-for-null tests in the wrapper code for buffer_t*
     // arguments; this is regrettable but fairly minor in terms of both code size and speed,
     // at least for real-world code.)
-    const Target wrapper_target = base_target
+    Target wrapper_target = base_target
         .with_feature(Target::NoRuntime)
         .with_feature(Target::NoBoundsQuery)
         .without_feature(Target::NoAsserts);
+
+    // If the base target specified the Matlab target, we want the Matlab target
+    // on the wrapper instead.
+    if (base_target.has_feature(Target::Matlab)) {
+        wrapper_target = wrapper_target.with_feature(Target::Matlab);
+    }
+
     Module wrapper_module(fn_name, wrapper_target);
     wrapper_module.append(LoweredFunc(fn_name, base_target_args, wrapper_body, LoweredFunc::External));
     // The wrapper module must come *first* in the archive, otherwise libraries
@@ -386,7 +400,7 @@ void compile_multitarget(const std::string &fn_name,
     // may get optimized away at link time.
     wrapper_module.compile(Outputs().object(temp_dir.add_temp_object_file(output_files.static_library_name, "_wrapper", base_target, /* in_front*/ true)));
 
-    if (!output_files.c_header_name.empty()) { 
+    if (!output_files.c_header_name.empty()) {
         debug(1) << "compile_multitarget: c_header_name " << output_files.c_header_name << "\n";
         wrapper_module.compile(Outputs().c_header(output_files.c_header_name));
     }

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -325,13 +325,11 @@ void compile_multitarget(const std::string &fn_name,
         auto suffix = "_" + replace_all(target.to_string(), "-", "_");
         std::string sub_fn_name = fn_name + suffix;
 
-        Target sub_fn_target = target;
-
         // We always produce the runtime separately, so add NoRuntime explicitly.
-        sub_fn_target = sub_fn_target.with_feature(Target::NoRuntime);
-
-        // Matlab should be added to the wrapper pipeline, instead of each sub-pipeline.
-        sub_fn_target = sub_fn_target.without_feature(Target::Matlab);
+        // Matlab should be added to the wrapper pipeline below, instead of each sub-pipeline.
+        Target sub_fn_target = target
+            .with_feature(Target::NoRuntime)
+            .without_feature(Target::Matlab);
 
         Module module = module_producer(sub_fn_name, sub_fn_target);
         Outputs sub_out = add_suffixes(output_files, suffix);


### PR DESCRIPTION
This PR adds support for Matlab in multitarget builds. It continues to require that all of the targets have the Matlab feature. However, it then removes the Matlab feature from the subobjects, and then adds the Matlab feature to the wrapper pipeline. This way, we only generate one mexFunction, that properly dispatches to the appropriate subobject.