### PR TITLE
OpenGL: Multiple stages and Update stages

### DIFF
--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -49,7 +49,10 @@ private:
     using IRVisitor::visit;
 
     void visit(const For *op) {
-        if (CodeGen_GPU_Dev::is_gpu_var(op->name)) {
+        // For GLSL, we the loop bound is not transformed into
+        // zero
+        if (CodeGen_GPU_Dev::is_gpu_var(op->name) &&
+            op->device_api != DeviceAPI::GLSL) {
             internal_assert(is_zero(op->min));
         }
 

--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -483,7 +483,6 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
         debug(3) << "bounds.num_threads[0] = " << bounds.num_threads[0] << "\n";
         debug(3) << "bounds.num_threads[1] = " << bounds.num_threads[1] << "\n";
         debug(3) << "bounds.num_threads[2] = " << bounds.num_threads[2] << "\n";
-
         Value *launch_args[] = {
             get_user_context(),
             builder->CreateLoad(get_module_state(api_unique_name)),
@@ -514,7 +513,6 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
             gpu_num_coords_dim0,
             gpu_num_coords_dim1,
         };
-
         std::string run_fn_name = "halide_" + api_unique_name + "_run";
         llvm::Function *dev_run_fn = module->getFunction(run_fn_name);
         internal_assert(dev_run_fn) << "Could not find " << run_fn_name << " in module\n";

--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -95,6 +95,7 @@ CodeGen_OpenGL_Dev::~CodeGen_OpenGL_Dev() {
 void CodeGen_OpenGL_Dev::add_kernel(Stmt s, const string &name,
                                     const vector<DeviceArgument> &args) {
     cur_kernel_name = name;
+    kernel_id[name] = kernel_id.size();
     glc->add_kernel(s, name, args);
 }
 
@@ -102,6 +103,7 @@ void CodeGen_OpenGL_Dev::init_module() {
     src_stream.str("");
     src_stream.clear();
     cur_kernel_name = "";
+    kernel_id.clear();
 }
 
 vector<char> CodeGen_OpenGL_Dev::compile_to_src() {

--- a/src/CodeGen_OpenGL_Dev.h
+++ b/src/CodeGen_OpenGL_Dev.h
@@ -36,6 +36,8 @@ public:
 
     std::string api_unique_name() { return "opengl"; }
 
+    std::map<std::string, int> kernel_id;
+
 private:
     CodeGen_GLSL *glc;
 

--- a/src/CodeGen_OpenGL_Dev.h
+++ b/src/CodeGen_OpenGL_Dev.h
@@ -37,7 +37,6 @@ public:
     std::string api_unique_name() { return "opengl"; }
 
     std::map<std::string, int> kernel_id;
-
 private:
     CodeGen_GLSL *glc;
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1830,7 +1830,6 @@ Func &Func::gpu_tile(VarOrRVar x, VarOrRVar y, VarOrRVar z,
     return *this;
 }
 
-
 Func &Func::shader(Var x, Var y, Var c, DeviceAPI device_api) {
     invalidate_cache();
     Stage(func.definition(), name(), args(), func.schedule().storage_dims()).gpu_blocks(x, y, device_api);
@@ -1848,7 +1847,6 @@ Func &Func::shader(Var x, Var y, Var c, DeviceAPI device_api) {
     }
     user_assert(constant_bounds)
         << "The color channel for image loops must have constant bounds, e.g., .bound(c, 0, 3).\n";
-
     return *this;
 }
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1462,6 +1462,15 @@ Stage &Stage::shader(VarOrRVar x, VarOrRVar y, VarOrRVar c, DeviceAPI device_api
     user_assert(constant_bounds)
         << "The color channel for image loops must have constant bounds, e.g., .bound(c, 0, 3).\n";
     */
+
+    // Check to make sure the stage uses only naked Vars or RVars in the LHS.
+    for (auto v: this->definition.args()) {
+        user_assert(v.as<Variable>())
+            << "Unsupported expression in LHS of an update definition: " << v << "\n"
+            << "GLSL code generation only supports naked Vars/RVars in update definitions,\n"
+            << "e.g. f(r.x, y, c) = ...\n";
+    }
+
     return *this;
 }
 

--- a/src/Func.h
+++ b/src/Func.h
@@ -229,6 +229,9 @@ public:
 
     EXPORT Stage &allow_race_conditions();
 
+    EXPORT Stage &shader(VarOrRVar x, VarOrRVar y, VarOrRVar c, DeviceAPI device_api);
+    EXPORT Stage &glsl(VarOrRVar x, VarOrRVar y, VarOrRVar c);
+
     EXPORT Stage &hexagon(VarOrRVar x = Var::outermost());
     // @}
 };

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -750,7 +750,8 @@ class ZeroGPULoopMins : public IRMutator {
 
         in_non_glsl_gpu = (in_non_glsl_gpu && op->device_api == DeviceAPI::None) ||
           (op->device_api == DeviceAPI::CUDA) || (op->device_api == DeviceAPI::OpenCL) ||
-          (op->device_api == DeviceAPI::Metal);
+          (op->device_api == DeviceAPI::Renderscript) ||    // for this visitor only, consider
+          (op->device_api == DeviceAPI::Metal);             // Renderscript to be non-GLSL
 
         IRMutator::visit(op);
         if (CodeGen_GPU_Dev::is_gpu_var(op->name) && !is_zero(op->min) &&

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -753,7 +753,8 @@ class ZeroGPULoopMins : public IRMutator {
           (op->device_api == DeviceAPI::Metal);
 
         IRMutator::visit(op);
-        if (CodeGen_GPU_Dev::is_gpu_var(op->name) && !is_zero(op->min)) {
+        if (CodeGen_GPU_Dev::is_gpu_var(op->name) && !is_zero(op->min) &&
+            in_non_glsl_gpu) {
             op = stmt.as<For>();
             internal_assert(op);
             Expr adjusted = Variable::make(Int(32), op->name) + op->min;

--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -1040,21 +1040,23 @@ public:
                 Expr output_texture = store_buf_finder.buffer_name;
 
                 // Confirm that we found something reasonable
-                internal_assert(output_texture.type().is_handle()) 
+                internal_assert(output_texture.type().is_handle())
                   << "No output buffer found in loop: " << op;
 
                 // Find the total size of this texture in the two loop
                 // dimensions
+                Expr texture_min_0 = Call::make(Int(32), "extract_buffer_min", {output_texture, 0}, Call::PureIntrinsic);
+                Expr texture_min_1 = Call::make(Int(32), "extract_buffer_min", {output_texture, 1}, Call::PureIntrinsic);
                 Expr texture_extent_0 = Call::make(Int(32), "extract_buffer_max", {output_texture, 0}, Call::PureIntrinsic)
-                    - Call::make(Int(32), "extract_buffer_min", {output_texture, 0}, Call::PureIntrinsic)
+                    - texture_min_0
                     + 1;
                 Expr texture_extent_1 = Call::make(Int(32), "extract_buffer_max", {output_texture, 1}, Call::PureIntrinsic)
-                    - Call::make(Int(32), "extract_buffer_min", {output_texture, 1}, Call::PureIntrinsic)
+                    - texture_min_1
                     + 1;
 
                 // Now map from coordinate space to texture space
-                coord1 = (coord1 / texture_extent_1) * 2.0f - 1.0f;
-                coord0 = (coord0 / texture_extent_0) * 2.0f - 1.0f;
+                coord1 = ((coord1 - texture_min_1) / texture_extent_1) * 2.0f - 1.0f;
+                coord0 = ((coord0 - texture_min_0) / texture_extent_0) * 2.0f - 1.0f;
 
                 // Remove varying attribute intrinsics from the vertex setup IR
                 // tree.

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -1444,7 +1444,6 @@ WEAK int halide_opengl_run(void *user_context,
         return 1;
     }
 
-
     // TODO(abstephensg) it would be great to codegen these vec4 uniform buffers
     // directly, instead of passing an array of arguments and then copying them
     // out at runtime.
@@ -1490,7 +1489,6 @@ WEAK int halide_opengl_run(void *user_context,
             }
         }
     }
-
 
     // Pad up to a multiple of four
     int num_padded_uniform_floats = (num_uniform_floats + 0x3) & ~0x3;

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -1457,14 +1457,10 @@ WEAK int halide_opengl_run(void *user_context,
         return 1;
     }
 
-    int kernel_id_location = 0;
-    // TODO(shoaibkamil) optimize
-    for (; args[kernel_id_location]; kernel_id_location++);
-    int* kernel_id = (int*)args[kernel_id_location-1];
+    // kernel id is passed in as the first argument
+    int* kernel_id = (int*)args[0];
 
-    debug(0) << "here1\n";
     KernelInfo *kernel = mod->kernel[*kernel_id];
-    debug(0) << "here2\n";
 
     global_state.UseProgram(kernel->program_id);
     if (global_state.CheckAndReportError(user_context, "halide_opengl_run UseProgram")) {
@@ -1483,7 +1479,7 @@ WEAK int halide_opengl_run(void *user_context,
     int num_uniform_ints = 0;
 
     Argument *kernel_arg = kernel->arguments;
-    for (int i = 0; args[i+1]; i++, kernel_arg = kernel_arg->next) {
+    for (int i = 1; args[i]; i++, kernel_arg = kernel_arg->next) {
 
         // Check for a mismatch between the number of arguments declared in the
         // fragment shader source header and the number passed to this function
@@ -1535,7 +1531,7 @@ WEAK int halide_opengl_run(void *user_context,
     int uniform_int_idx = 0;
 
     kernel_arg = kernel->arguments;
-    for (int i = 0; args[i+1]; i++, kernel_arg = kernel_arg->next) {
+    for (int i = 1; args[i]; i++, kernel_arg = kernel_arg->next) {
 
         if (kernel_arg->kind == Argument::Outbuf) {
             halide_assert(user_context, is_buffer[i] && "OpenGL Outbuf argument is not a buffer.")
@@ -1685,7 +1681,7 @@ WEAK int halide_opengl_run(void *user_context,
 
     GLint num_output_textures = 0;
     kernel_arg = kernel->arguments;
-    for (int i = 0; args[i+1]; i++, kernel_arg = kernel_arg->next) {
+    for (int i = 1; args[i]; i++, kernel_arg = kernel_arg->next) {
         if (kernel_arg->kind != Argument::Outbuf) continue;
 
         halide_assert(user_context, is_buffer[i] && "OpenGL Outbuf argument is not a buffer.")

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -726,6 +726,8 @@ WEAK int halide_opengl_init(void *user_context) {
         << "  have_texture_rgb8_rgba8: " << (global_state.have_texture_rgb8_rgba8 ? "yes\n" : "no\n")
         << "  texture_float: " << (global_state.have_texture_float ? "yes\n" : "no\n");
 
+    GLStateSaver state_saver;
+
     // Initialize framebuffer.
     global_state.GenFramebuffers(1, &global_state.framebuffer_id);
     if (global_state.CheckAndReportError(user_context, "halide_opengl_init GenFramebuffers")) {
@@ -1440,7 +1442,7 @@ WEAK int halide_opengl_run(void *user_context,
     GLStateSaver state_saver;
 
     // Find the right module
-    ModuleState *mod = find_module(entry_name);
+    ModuleState *mod = (ModuleState*)state_ptr;
     if (!mod) {
       error(user_context) << "Internal error: module state for stage " << entry_name << " not found\n";
       return 1;
@@ -1930,7 +1932,7 @@ WEAK int halide_opengl_initialize_kernels(void *user_context, void **state_ptr,
     ModuleState **state = (ModuleState **)state_ptr;
     ModuleState *module = *state;
 
-    while (this_kernel) {
+    while (this_kernel && !module) {
         // Find the start of the next kernel
         const char *next_kernel = strstr(this_kernel+1, kernel_marker);        
 

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -1932,17 +1932,10 @@ WEAK int halide_opengl_initialize_kernels(void *user_context, void **state_ptr,
     ModuleState **state = (ModuleState **)state_ptr;
     ModuleState *module = *state;
 
-    while (this_kernel && !module) {
-        // Find the start of the next kernel
-        const char *next_kernel = strstr(this_kernel+1, kernel_marker);        
+    while (!module && this_kernel) {
 
         // Use that to compute the length of this kernel
-        int len = 0;
-        if (!next_kernel) {
-            len = strlen(this_kernel);
-        } else {
-            len = next_kernel - this_kernel;
-        }
+        int len = size;
         
         // Construct a new ModuleState and add it to the global list
         module = (ModuleState *)malloc(sizeof(ModuleState));
@@ -2051,7 +2044,6 @@ WEAK int halide_opengl_initialize_kernels(void *user_context, void **state_ptr,
         }
         kernel->program_id = program;
         
-        this_kernel = next_kernel;
     }
     return 0;
 }

--- a/test/opengl/sum_reduction.cpp
+++ b/test/opengl/sum_reduction.cpp
@@ -45,7 +45,7 @@ int main() {
                     temp += input(std::min(x+r, input.width()-1), y, c);
                 }
                 float correct = temp / 10.0f * 255.0f;
-                if (fabs(result(x, y, c) - correct) > 1e-6) {
+                if (fabs(result(x, y, c) - correct) > 1e-3) {
                     fprintf(stderr, "result(%d, %d, %d) = %f instead of %f\n",
                             x, y, c, result(x, y, c), correct);
                     return 1;

--- a/test/opengl/update_stage.cpp
+++ b/test/opengl/update_stage.cpp
@@ -1,0 +1,65 @@
+// test case provided by Lee Yuguang
+
+
+#include "Halide.h"
+#include <stdio.h>
+#include <chrono>
+
+using namespace Halide;
+
+int main() {
+    // This test must be run with an OpenGL target.
+    const Target &target = get_jit_target_from_environment();
+    if (!target.has_feature(Target::OpenGL)) {
+        fprintf(stderr, "ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
+        return 1;
+    }
+
+    // Define the input
+    const int width = 10, height = 12, channels = 2, res_channels = 2;
+    Image<float> input(width, height, channels);
+    for (int c = 0; c < input.channels(); c++) {
+        for (int y = 0; y < input.height(); y++) {
+            for (int x = 0; x < input.width(); x++) {
+                input(x, y, c) = float(x + y);
+            }
+        }
+    }
+
+    // Define the algorithm.
+    Var x, y, c;
+    RDom r(3, 5, "r");
+    Func f, g;
+
+    Expr coordx = clamp(x + r, 0, input.width() - 1);
+    f(x, y, c) = cast<uint8_t>(0);
+    f(r.x, y, c) = cast<uint8_t>(11);
+
+
+    // Schedule f and g to compute in separate passes on the GPU.
+    f.bound(c, 0, 2);
+    f.update(0).glsl(r.x, y, c);
+
+    // Generate the result.
+    Image<uint8_t> result = f.realize(width, height, res_channels);
+
+
+    result.copy_to_host();
+
+    //Check the result.
+    for (int c = 0; c < result.channels(); c++) {
+        for (int y = 0; y < result.height(); y++) {
+            for (int x = 0; x < result.width(); x++) {
+                uint8_t correct = (x>=3 && x<8) ? 11 : 0;
+                if (result(x, y, c) != correct) {
+                    fprintf(stderr, "result(%d, %d, %d) = %d, should be %d\n",
+                            x, y, c, result(x, y, c), correct);
+                    return 1;
+                }
+            }
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/opengl/varying.cpp
+++ b/test/opengl/varying.cpp
@@ -85,10 +85,10 @@ int main() {
     f0.realize(out0);
 
     // Check for the correct number of varying attributes
-    if (varyings.size() != 2) {
+    if (varyings.size() != 1) {
         fprintf(stderr,
                 "Error: wrong number of varying attributes: %d should be %d\n",
-                (int)varyings.size(), 2);
+                (int)varyings.size(), 1);
         return 1;
     }
 
@@ -156,10 +156,10 @@ int main() {
     f1.realize(out1);
 
     // Check for the correct number of varying attributes
-    if (varyings.size() != 4) {
+    if (varyings.size() != 2) {
         fprintf(stderr,
                 "Error: wrong number of varying attributes: %d should be %d\n",
-                (int)varyings.size(), 4);
+                (int)varyings.size(), 2);
         return 1;
     }
 
@@ -215,10 +215,11 @@ int main() {
     f2.realize(out2);
 
     // Check for the correct number of varying attributes
-    if (varyings.size() != 4) {
+    // In this case, the varyings are just the actual pixel locations
+    if (varyings.size() != 0) {
         fprintf(stderr,
                 "Error: wrong number of varying attributes: %d should be %d\n",
-                (int)varyings.size(), 4);
+                (int)varyings.size(), 0);
         return 1;
     }
 
@@ -286,7 +287,7 @@ int main() {
     f3.realize(out3);
 
     // Check for the correct number of varying attributes
-    if (varyings.size() != 2) {
+    if (varyings.size() != 1) {
         fprintf(stderr,
                 "Error: wrong number of varying attributes: %d should be %d\n",
                 (int)varyings.size(), 2);


### PR DESCRIPTION
This is another attempt at sanely allowing multiple stages of a pipeline to be scheduled with `.glsl()`, including some kinds of update stages.  Creating the PR now for discussion.

For OpenGL, we pass in the kernel ID as the first parameter to the function; alternatively, we could alter the call to `halide_opengl_run()` but that seemed to require more manipulation (since the arguments are in an array intializer).  I'm happy to change this if it's objectionable.

Specific questions: 
- `bound()` is not a member of `Stage`, and the definition's schedule does not seem to get updated with `bound()` called on the `Func`.  Is there a way I'm missing to check the channel dimension is bounded for a `Stage`?
- This may have broken Renderscript/OpenGLCompute, but I have no way of checking
- Any advice on how to restrict the form of update stages to pre-check if it is of a form we support would be really appreciated.  Clearly OpenGL can't do things like

```
f(g(x,y)) = ...
```

but can do things like:

```
RDom r(0, 5, a, b);
f(r) = ...
```
