### PR TITLE
Add explicit soft float target feature

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1052,9 +1052,10 @@ string CodeGen_ARM::mattrs() const {
 bool CodeGen_ARM::use_soft_float_abi() const {
     // One expects the flag is irrelevant on 64-bit, but we'll make the logic
     // exhaustive anyway. It is not clear the armv7s case is necessary either.
-    return target.bits == 32 &&
-        ((target.os == Target::Android) ||
-         (target.os == Target::IOS && !target.has_feature(Target::ARMv7s)));
+    return target.has_feature(Target::SoftFloatABI) ||
+        (target.bits == 32 &&
+         ((target.os == Target::Android) ||
+          (target.os == Target::IOS && !target.has_feature(Target::ARMv7s))));
 }
 
 int CodeGen_ARM::native_vector_bits() const {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -248,7 +248,8 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"hvx_64", Target::HVX_64},
     {"hvx_128", Target::HVX_128},
     {"hvx_v62", Target::HVX_v62},
-    {"fuzz_float_stores", Target::FuzzFloatStores}
+    {"fuzz_float_stores", Target::FuzzFloatStores},
+    {"soft_float_abi", Target::SoftFloatABI},
 };
 
 bool lookup_feature(const std::string &tok, Target::Feature &result) {

--- a/src/Target.h
+++ b/src/Target.h
@@ -74,6 +74,7 @@ struct Target {
         HVX_128 = halide_target_feature_hvx_128,
         HVX_v62 = halide_target_feature_hvx_v62,
         FuzzFloatStores = halide_target_feature_fuzz_float_stores,
+        SoftFloatABI = halide_target_feature_soft_float_abi,
         FeatureEnd = halide_target_feature_end
     };
     Target() : os(OSUnknown), arch(ArchUnknown), bits(0) {}

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -708,7 +708,8 @@ typedef enum halide_target_feature_t {
     halide_target_feature_hvx_128 = 33, ///< Enable HVX 128 byte mode.
     halide_target_feature_hvx_v62 = 34, ///< Enable Hexagon v62 architecture.
     halide_target_feature_fuzz_float_stores = 35, ///< On every floating point store, set the last bit of the mantissa to zero. Pipelines for which the output is very different with this feature enabled may also produce very different output on different processors.
-    halide_target_feature_end = 36 ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
+    halide_target_feature_soft_float_abi = 36, ///< Enable soft float ABI. This only enables the soft float ABI calling convention, which does not necessarily use soft floats.
+    halide_target_feature_end = 37 ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 
 /** This function is called internally by Halide in some situations to determine


### PR DESCRIPTION
It's useful to be able to explicitly specify that we want to target a
soft float ABI.