### PR TITLE
Enable symbol rewriter pass

### DIFF
--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -41,6 +41,7 @@
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/Utils/ModuleUtils.h>
+#include <llvm/Transforms/Utils/SymbolRewriter.h>
 #include <llvm/ADT/StringMap.h>
 #if !defined(WITH_NATIVE_CLIENT)
 #include <llvm/Object/ArchiveWriter.h>

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -52,6 +52,12 @@ void emit_file(llvm::Module &module, Internal::LLVMOStream& out, llvm::TargetMac
     pass_manager.add(llvm::createAlwaysInlinerLegacyPass());
     #endif
 
+    // Enable symbol rewriting. This allows code outside libHalide to
+    // use symbol rewriting when compiling Halide code (for example, by
+    // using cl::ParseCommandLineOption and then passing the appropriate
+    // rewrite options via -mllvm flags).
+    pass_manager.add(llvm::createRewriteSymbolsPass());
+
     // Override default to generate verbose assembly.
     target_machine->Options.MCOptions.AsmVerbose = true;
 


### PR DESCRIPTION
LLVM has a symbol rewriter pass which enables symbol interpositioning.
Enable this pass in Halide, to allow code generation to use it.