### PR TITLE
Allow roundtripping of default Target() strings

### DIFF
--- a/src/Target.h
+++ b/src/Target.h
@@ -204,8 +204,8 @@ struct Target {
      *
      *   arch-bits-os-feature1-feature2...featureN.
      *
-     * Note that is guaranteed that t2.from_string(t1.to_string()) == t1,
-     * but not that from_string(s).to_string() == s (since there can be
+     * Note that is guaranteed that Target(t1.to_string()) == t1,
+     * but not that Target(s).to_string() == s (since there can be
      * multiple strings that parse to the same Target)...
      * *unless* t1 contains 'unknown' fields (in which case you'll get a string
      * that can't be parsed, which is intentional).

--- a/test/correctness/target.cpp
+++ b/test/correctness/target.cpp
@@ -10,7 +10,7 @@ int main(int argc, char **argv) {
     // Target("") should be exactly like get_host_target().
     t1 = get_host_target();
     t2 = Target("");
-    if (t2 != t1){
+    if (t2 != t1) {
        printf("parse_from_string failure: %s\n", ts.c_str());
        return -1;
     }
@@ -21,9 +21,13 @@ int main(int argc, char **argv) {
        printf("to_string failure: %s\n", ts.c_str());
        return -1;
     }
-    // We expect from_string() to fail, since it doesn't know about 'unknown'
-    if (Target::validate_target_string(ts)) {
+    if (!Target::validate_target_string(ts)) {
        printf("validate_target_string failure: %s\n", ts.c_str());
+       return -1;
+    }
+    t2 = Target(ts);
+    if (t2 != t1) {
+       printf("roundtrip failure: %s\n", ts.c_str());
        return -1;
     }
 
@@ -74,6 +78,20 @@ int main(int argc, char **argv) {
     }
 
     ts = "x86-23";
+    if (Target::validate_target_string(ts)) {
+       printf("validate_target_string failure: %s\n", ts.c_str());
+       return -1;
+    }
+
+    // bits == 0 is allowed only if arch_unknown and os_unknown are specified,
+    // and no features are set
+    ts = "x86-0";
+    if (Target::validate_target_string(ts)) {
+       printf("validate_target_string failure: %s\n", ts.c_str());
+       return -1;
+    }
+
+    ts = "0-arch_unknown-os_unknown-sse41";
     if (Target::validate_target_string(ts)) {
        printf("validate_target_string failure: %s\n", ts.c_str());
        return -1;


### PR DESCRIPTION
Target.h promises that Target(t1.to_string()) == t1, but this fails if
t1 == Target(), sinces bits == 0. Add just enough special-casing to
allow this to roundtrip as well.