### PR TITLE
Add missing "bits" field to invalid Target error message.

### DIFF
--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -391,14 +391,19 @@ void bad_target_string(const std::string &target) {
         }
     }
     user_error << "Did not understand Halide target " << target << "\n"
-               << "Expected format is arch-os-feature1-feature2-...\n"
-               << "Where arch is " << architectures << " .\n"
-               << "Os is " << oses << " .\n"
-               << "If arch or os are omitted, they default to the host.\n"
-               << "Features are " << features << " .\n"
+               << "Expected format is arch-bits-os-feature1-feature2-...\n"
+               << "Where arch is: " << architectures << ".\n"
+               << "bits is either 32 or 64.\n"
+               << "os is: " << oses << ".\n"
+               << "\n"
+               << "If arch, bits, or os are omitted, they default to the host.\n"
+               << "\n"
+               << "Features are: " << features << ".\n"
+               << "\n"
                << "The target can also begin with \"host\", which sets the "
                << "host's architecture, os, and feature set, with the "
                << "exception of the GPU runtimes, which default to off.\n"
+               << "\n"
                << "On this platform, the host target is: " << get_host_target().to_string() << "\n";
 }
 


### PR DESCRIPTION
Also tweaked some formatting.

It now looks like:

$ ./lesson_15_generate -g my_first_generator -o . target=foo
Error at ../tools/GenGen.cpp:4:
Did not understand Halide target foo
Expected format is arch-bits-os-feature1-feature2-...
Where arch is: arch_unknown, arm, hexagon, mips, pnacl, powerpc, x86.
bits is either 32 or 64.
os is: android, ios, linux, nacl, noos, os_unknown, osx, qurt, windows.

If arch, bits, or os are omitted, they default to the host.

Features are: armv7s, avx, avx2, c_plus_plus_name_mangling, cl_doubles, cuda
cuda_capability_30, cuda_capability_32, cuda_capability_35, cuda_capability_50
debug, f16c, fma, fma4, fuzz_float_stores, hvx_128, hvx_64, hvx_v62, jit
large_buffers, matlab, metal, mingw, no_asserts, no_bounds_query, no_neon
no_runtime, opencl, opengl, openglcompute, power_arch_2_07, profile, renderscript
sse41, user_context, vsx.

The target can also begin with "host", which sets the host's architecture, os, and feature set, with the exception of the GPU runtimes, which default to off.

On this platform, the host target is: x86-64-osx-avx-f16c-sse41
Abort trap: 6