### PR TITLE
Rework GeneratorParam implementation

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -410,7 +410,7 @@ void GeneratorBase::set_generator_param_values(const std::map<std::string, std::
         const std::string &value = key_value.second;
         auto p = m.find(key);
         user_assert(p != m.end()) << "Generator has no GeneratorParam named: " << key;
-        p->second->from_string(value);
+        p->second->set_from_string(value);
     }
     generator_params_set = true;
 }

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -151,7 +151,9 @@ private:
 // Note that the conditions are evaluated in order; the first evaluating to true
 // is chosen.
 //
-// Note that if no conditions evaluate to true, the type is 'void' (i.e. illegal).
+// Note that if no conditions evaluate to true, the resulting type is illegal
+// and will produce a compilation error. (You can provide a default by simply
+// using cond<true, SomeType> as the final entry.)
 template<bool B, typename T>
 struct cond {
     static constexpr bool value = B;

--- a/test/generator/pyramid_aottest.cpp
+++ b/test/generator/pyramid_aottest.cpp
@@ -1,6 +1,5 @@
 #include <math.h>
 #include <stdio.h>
-#include <ratio>
 
 #include "pyramid.h"
 #include "HalideBuffer.h"
@@ -9,34 +8,8 @@
 using std::vector;
 using namespace Halide;
 
-template<bool B, typename T>
-struct cond {
-    static constexpr bool value = B;
-    using type = T;
-};
-
-template <typename First, typename... Rest>
-struct select : std::conditional<First::value, First, typename select<Rest...>::type> { };
-
-template<typename First>
-struct select<First> {
-    //static_assert(T::value, "No case of select was chosen");
-    using type = std::conditional<First::value, typename First::type, void>;
-};
-
-template<int a>
-struct tester : public select<cond<a == 0, std::ratio<1, 2>>,
-                              cond<a == 1, std::ratio<3, 2>>,
-                              cond<a == 2, std::ratio<7, 2>>>::type {};
-
-
 int main(int argc, char **argv) {
     Image<float> input(1024, 1024);
-
-    using T0 = tester<0>::type; printf("t0 %d %d\n", (int)T0::num, (int)T0::den);
-    using T1 = tester<1>::type; printf("t0 %d %d\n", (int)T1::num, (int)T1::den);
-    using T2 = tester<2>::type; printf("t0 %d %d\n", (int)T2::num, (int)T2::den);
-    //using T3 = tester<3>::type; printf("t0 %d %d\n", (int)T3::num, (int)T3::den);
 
     // Put some junk in the input. Keep it to small integers so the float averaging stays exact.
     for (int y = 0; y < input.height(); y++) {

--- a/test/generator/pyramid_aottest.cpp
+++ b/test/generator/pyramid_aottest.cpp
@@ -1,5 +1,6 @@
 #include <math.h>
 #include <stdio.h>
+#include <ratio>
 
 #include "pyramid.h"
 #include "HalideBuffer.h"
@@ -8,8 +9,34 @@
 using std::vector;
 using namespace Halide;
 
+template<bool B, typename T>
+struct cond {
+    static constexpr bool value = B;
+    using type = T;
+};
+
+template <typename First, typename... Rest>
+struct select : std::conditional<First::value, First, typename select<Rest...>::type> { };
+
+template<typename First>
+struct select<First> {
+    //static_assert(T::value, "No case of select was chosen");
+    using type = std::conditional<First::value, typename First::type, void>;
+};
+
+template<int a>
+struct tester : public select<cond<a == 0, std::ratio<1, 2>>,
+                              cond<a == 1, std::ratio<3, 2>>,
+                              cond<a == 2, std::ratio<7, 2>>>::type {};
+
+
 int main(int argc, char **argv) {
     Image<float> input(1024, 1024);
+
+    using T0 = tester<0>::type; printf("t0 %d %d\n", (int)T0::num, (int)T0::den);
+    using T1 = tester<1>::type; printf("t0 %d %d\n", (int)T1::num, (int)T1::den);
+    using T2 = tester<2>::type; printf("t0 %d %d\n", (int)T2::num, (int)T2::den);
+    //using T3 = tester<3>::type; printf("t0 %d %d\n", (int)T3::num, (int)T3::den);
 
     // Put some junk in the input. Keep it to small integers so the float averaging stays exact.
     for (int y = 0; y < input.height(); y++) {


### PR DESCRIPTION
Existing version relied on enable_if’s everywhere; this splits it into
helper classes, so adding methods will be less horribly wordy.