### PR TITLE
MSAN needs to handle bound-inference too

### DIFF
--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -110,6 +110,7 @@ public:
     const FuncValueBounds &func_bounds;
     set<string> in_pipeline, inner_productions;
     Scope<int> in_stages;
+    const Target target;
 
     struct CondValue {
         Expr cond; // Condition on params only (can't depend on loop variable)
@@ -264,7 +265,8 @@ public:
                            string loop_level,
                            const Scope<int> &in_stages,
                            const set<string> &in_pipeline,
-                           const set<string> inner_productions) {
+                           const set<string> inner_productions,
+                           const Target &target) {
 
             // Merge all the relevant boxes.
             Box b;
@@ -331,7 +333,7 @@ public:
                 // Because we're wrapping a stmt, this happens in reverse order.
 
                 // 4)
-                s = do_bounds_query(s, in_pipeline);
+                s = do_bounds_query(s, in_pipeline, target);
 
 
                 if (!in_pipeline.empty()) {
@@ -363,7 +365,7 @@ public:
                     }
 
                     // 2)
-                    s = do_bounds_query(s, in_pipeline);
+                    s = do_bounds_query(s, in_pipeline, target);
 
                     // 1)
                     s = LetStmt::make(func.name() + ".outer_bounds_query",
@@ -389,7 +391,7 @@ public:
                         s = LetStmt::make(func.name() + ".s0." + func_args[i] + ".min", new_min, s);
                     }
 
-                    s = do_bounds_query(s, in_pipeline);
+                    s = do_bounds_query(s, in_pipeline, target);
 
                 }
 
@@ -469,7 +471,7 @@ public:
             return s;
         }
 
-        Stmt do_bounds_query(Stmt s, const set<string> &in_pipeline) {
+        Stmt do_bounds_query(Stmt s, const set<string> &in_pipeline, const Target &target) {
 
             const string &extern_name = func.extern_function_name();
             const vector<ExternFuncArgument> &args = func.extern_arguments();
@@ -485,6 +487,7 @@ public:
 
             Expr null_handle = Call::make(Handle(), Call::null_handle, vector<Expr>(), Call::PureIntrinsic);
 
+            vector<Expr> buffers_to_annotate;
             for (size_t j = 0; j < args.size(); j++) {
                 if (args[j].is_expr()) {
                     bounds_inference_args.push_back(args[j].expr);
@@ -497,6 +500,7 @@ public:
                                               Call::Intrinsic);
                         lets.push_back(make_pair(name, buf));
                         bounds_inference_args.push_back(Variable::make(type_of<struct buffer_t *>(), name));
+                        buffers_to_annotate.push_back(bounds_inference_args.back());
                     }
                 } else if (args[j].is_image_param() || args[j].is_buffer()) {
                     Parameter p = args[j].image_param;
@@ -511,6 +515,11 @@ public:
                     lets.push_back(make_pair(query_name, query_buf));
                     Expr buf = Variable::make(type_of<struct buffer_t *>(), query_name, b, p, ReductionDomain());
                     bounds_inference_args.push_back(buf);
+                    if (!args[j].is_image_param()) {
+                        // Do not annotate ImageParams: the buffer_t itself should be filled by the caller;
+                        // if we mark it here, we might mask a missed initialization.
+                        buffers_to_annotate.push_back(bounds_inference_args.back());
+                    }
                 } else {
                     internal_error << "Bad ExternFuncArgument type";
                 }
@@ -536,8 +545,26 @@ public:
 
                 string buf_name = func.name() + ".o" + std::to_string(j) + ".bounds_query";
                 bounds_inference_args.push_back(Variable::make(type_of<struct buffer_t *>(), buf_name));
-
+                // Since this is a temporary, internal-only buffer used for bounds inference,
+                // we need to mark it
+                buffers_to_annotate.push_back(bounds_inference_args.back());
                 lets.push_back(make_pair(buf_name, output_buffer_t));
+            }
+
+            Stmt annotate;
+            if (target.has_feature(Target::MSAN)) {
+                // Mark the buffers as initialized before calling out.
+                for (const auto &buffer: buffers_to_annotate) {
+                    // Return type is really 'void', but no way to represent that in our IR.
+                    // Precedent (from halide_print, etc) is to use Int(32) and ignore the result.
+                    Expr sizeof_buffer_t((uint64_t) sizeof(buffer_t));
+                    Stmt mark_buffer = Evaluate::make(Call::make(Int(32), "halide_msan_annotate_memory_is_initialized", {buffer, sizeof_buffer_t}, Call::Extern));
+                    if (annotate.defined()) {
+                        annotate = Block::make(annotate, mark_buffer);
+                    } else {
+                        annotate = mark_buffer;
+                    }
+                }
             }
 
             // Make the extern call
@@ -551,6 +578,10 @@ public:
             Stmt check = AssertStmt::make(EQ::make(result, 0), error);
 
             check = LetStmt::make(result_name, e, check);
+    
+            if (annotate.defined()) {
+                check = Block::make(annotate, check);
+            }
 
             // Now inner code is free to extract the fields from the buffer_t
             s = Block::make(check, s);
@@ -593,8 +624,9 @@ public:
 
     BoundsInference(const vector<Function> &f,
                     const vector<Function> &outputs,
-                    const FuncValueBounds &fb) :
-        funcs(f), func_bounds(fb) {
+                    const FuncValueBounds &fb, 
+                    const Target &target) :
+        funcs(f), func_bounds(fb), target(target) {
         internal_assert(!f.empty());
 
         // Compute the intrinsic relationships between the stages of
@@ -864,7 +896,7 @@ public:
                     for (size_t j = 0; j < stages[i].consumers.size(); j++) {
                         bounds_needed[stages[i].consumers[j]] = true;
                     }
-                    body = stages[i].define_bounds(body, stage_name, op->name, in_stages, in_pipeline, inner_productions);
+                    body = stages[i].define_bounds(body, stage_name, op->name, in_stages, in_pipeline, inner_productions, target);
                 }
             }
 
@@ -950,7 +982,8 @@ Stmt bounds_inference(Stmt s,
                       const vector<Function> &outputs,
                       const vector<string> &order,
                       const map<string, Function> &env,
-                      const FuncValueBounds &func_bounds) {
+                      const FuncValueBounds &func_bounds,
+                      const Target &target) {
 
     vector<Function> funcs(order.size());
     for (size_t i = 0; i < order.size(); i++) {
@@ -959,7 +992,7 @@ Stmt bounds_inference(Stmt s,
 
     // Add an outermost bounds inference marker
     s = For::make("<outermost>", 0, 1, ForType::Serial, DeviceAPI::None, s);
-    s = BoundsInference(funcs, outputs, func_bounds).mutate(s);
+    s = BoundsInference(funcs, outputs, func_bounds, target).mutate(s);
     return s.as<For>()->body;
 }
 

--- a/src/BoundsInference.h
+++ b/src/BoundsInference.h
@@ -9,6 +9,7 @@
 
 #include "IR.h"
 #include "Bounds.h"
+#include "Target.h"
 
 namespace Halide {
 namespace Internal {
@@ -21,7 +22,8 @@ Stmt bounds_inference(Stmt,
                       const std::vector<Function> &outputs,
                       const std::vector<std::string> &realization_order,
                       const std::map<std::string, Function> &environment,
-                      const std::map<std::pair<std::string, int>, Interval> &func_bounds);
+                      const std::map<std::pair<std::string, int>, Interval> &func_bounds,
+                      const Target &target);
 
 }
 }

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -123,7 +123,7 @@ Stmt lower(vector<Function> outputs, const string &pipeline_name, const Target &
     // can't simplify statements from here until we fix them up. (We
     // can still simplify Exprs).
     debug(1) << "Performing computation bounds inference...\n";
-    s = bounds_inference(s, outputs, order, env, func_bounds);
+    s = bounds_inference(s, outputs, order, env, func_bounds, t);
     debug(2) << "Lowering after computation bounds inference:\n" << s << '\n';
 
     debug(1) << "Performing sliding window optimization...\n";

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -449,6 +449,7 @@ Stmt build_produce(Function f, const Target &target) {
         // function building a suitable argument list for the
         // extern function call.
         vector<Expr> buffers_to_annotate;
+        vector<Expr> buffers_contents_to_annotate;
         for (const ExternFuncArgument &arg : args) {
             if (arg.is_expr()) {
                 extern_call_args.push_back(arg.expr);
@@ -463,6 +464,7 @@ Stmt build_produce(Function f, const Target &target) {
                     Expr buffer = Variable::make(type_of<struct buffer_t *>(), buf_name);
                     extern_call_args.push_back(buffer);
                     buffers_to_annotate.push_back(buffer);
+                    buffers_contents_to_annotate.push_back(buffer);
                 }
             } else if (arg.is_buffer()) {
                 BufferPtr b = arg.buffer;
@@ -472,6 +474,7 @@ Stmt build_produce(Function f, const Target &target) {
                 Expr buf = Variable::make(type_of<struct buffer_t *>(), buf_name, p);
                 extern_call_args.push_back(buf);
                 buffers_to_annotate.push_back(buf);
+                buffers_contents_to_annotate.push_back(buf);
             } else if (arg.is_image_param()) {
                 Parameter p = arg.image_param;
                 string buf_name = p.name() + ".buffer";
@@ -481,6 +484,7 @@ Stmt build_produce(Function f, const Target &target) {
                 // and the contents it points to, should be filled by the caller;
                 // if we mark it here, we might mask a missed initialization.
                 // buffers_to_annotate.push_back(buf);
+                // buffers_contents_to_annotate.push_back(buf);
             } else {
                 internal_error << "Bad ExternFuncArgument type\n";
             }
@@ -539,6 +543,9 @@ Stmt build_produce(Function f, const Target &target) {
 
                 string buf_name = f.name() + "." + std::to_string(j) + ".tmp_buffer";
                 extern_call_args.push_back(Variable::make(type_of<struct buffer_t *>(), buf_name));
+                // Since this is a temporary, internal-only buffer, make sure it's marked.
+                // (but not the contents! callee is expected to fill that in.)
+                buffers_to_annotate.push_back(extern_call_args.back());
                 lets.push_back(make_pair(buf_name, output_buffer_t));
             }
         }
@@ -551,12 +558,20 @@ Stmt build_produce(Function f, const Target &target) {
                 // Precedent (from halide_print, etc) is to use Int(32) and ignore the result.
                 Expr sizeof_buffer_t((uint64_t) sizeof(buffer_t));
                 Stmt mark_buffer = Evaluate::make(Call::make(Int(32), "halide_msan_annotate_memory_is_initialized", {buffer, sizeof_buffer_t}, Call::Extern));
-                Stmt mark_contents = Evaluate::make(Call::make(Int(32), "halide_msan_annotate_buffer_is_initialized", {buffer}, Call::Extern));
-                Stmt mark = Block::make(mark_buffer, mark_contents);
                 if (annotate.defined()) {
-                    annotate = Block::make(annotate, mark);
+                    annotate = Block::make(annotate, mark_buffer);
                 } else {
-                    annotate = mark;
+                    annotate = mark_buffer;
+                }
+            }
+            for (const auto &buffer: buffers_contents_to_annotate) {
+                // Return type is really 'void', but no way to represent that in our IR.
+                // Precedent (from halide_print, etc) is to use Int(32) and ignore the result.
+                Stmt mark_contents = Evaluate::make(Call::make(Int(32), "halide_msan_annotate_buffer_is_initialized", {buffer}, Call::Extern));
+                if (annotate.defined()) {
+                    annotate = Block::make(annotate, mark_contents);
+                } else {
+                    annotate = mark_contents;
                 }
             }
         }


### PR DESCRIPTION
Specifically, we need to mark the synthesized buffer_t inputs as
initialized