### PR TITLE
Fix for vectorizing modulos where the vector width is not a multiple …

### DIFF
--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -464,7 +464,9 @@ class Interleaver : public IRMutator {
     void visit(const Mod *op) {
         const Ramp *r = op->a.as<Ramp>();
         for (int i = 2; i <= 4; ++i) {
-            if (r && is_const(op->b, i)) {
+            if (r &&
+                is_const(op->b, i) &&
+                (r->type.lanes() % i) == 0) {
                 should_deinterleave = true;
                 num_lanes = i;
                 break;


### PR DESCRIPTION
…of the modulo argument

e.g.

  Func f;
  Var x;
  f(x) = x % 3;
  f.vectorize(x, 8);
  f.realize(16);