### PR TITLE
Upgrade GenGen's -x argument

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -41,8 +41,8 @@ std::string compute_base_path(const std::string &output_dir,
 }
 
 std::string get_extension(const std::string& def, const GeneratorBase::EmitOptions &options) {
-    auto it = options.extensions.find(def);
-    if (it != options.extensions.end()) {
+    auto it = options.substitutions.find(def);
+    if (it != options.substitutions.end()) {
         return it->second;
     }
     return def;
@@ -126,7 +126,7 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
                           "target=target-string[,target-string...] [generator_arg=value [...]]\n\n"
                           "  -e  A comma separated list of files to emit. Accepted values are "
                           "[assembly, bitcode, cpp, h, html, o, static_library, stmt]. If omitted, default value is [static_library, h].\n"
-                          "  -x  A comma separated list of file extension pairs to substitute during file naming, "
+                          "  -x  A comma separated list of file extension (or file-suffix) pairs to substitute during file naming, "
                           "in the form [.old=.new[,.old2=.new2]]\n";
 
     std::map<std::string, std::string> flags_info = { { "-f", "" },
@@ -238,18 +238,18 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
         }
     }
 
-    auto extension_flags = split_string(flags_info["-x"], ",");
-    for (const std::string &x : extension_flags) {
+    auto substitution_flags = split_string(flags_info["-x"], ",");
+    for (const std::string &x : substitution_flags) {
         if (x.empty()) {
             continue;
         }
-        auto ext_pair = split_string(x, "=");
-        if (ext_pair.size() != 2) {
+        auto subst_pair = split_string(x, "=");
+        if (subst_pair.size() != 2) {
             cerr << "Malformed -x option: " << x << "\n";
             cerr << kUsage;
             return 1;
         }
-        emit_options.extensions[ext_pair[0]] = ext_pair[1];
+        emit_options.substitutions[subst_pair[0]] = subst_pair[1];
     }
 
     const auto target_string = generator_args["target"];
@@ -284,13 +284,7 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
                 }
                 return gen->build_module(name);
             };
-        if (targets.size() > 1) {
-            compile_multitarget(function_name, output_files, targets, module_producer);
-        } else {
-            // compile_multitarget() will fail if we request anything but library and/or header,
-            // so defer directly to Module::compile if there is a single target.
-            module_producer(function_name, targets[0]).compile(output_files);
-        }
+        compile_multitarget(function_name, output_files, targets, module_producer, emit_options.substitutions);
     }
 
     return 0;

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -547,7 +547,7 @@ public:
         // empty by default; it's mainly useful in build environments where the default
         // extensions are problematic, and avoids the need to rename output files
         // after the fact.
-        std::map<std::string, std::string> extensions;
+        std::map<std::string, std::string> substitutions;
         EmitOptions()
             : emit_o(false), emit_h(true), emit_cpp(false), emit_assembly(false),
               emit_bitcode(false), emit_stmt(false), emit_stmt_html(false), emit_static_library(true) {}

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -267,7 +267,8 @@ void compile_standalone_runtime(const std::string &object_filename, Target t) {
 void compile_multitarget(const std::string &fn_name,
                          const Outputs &output_files,
                          const std::vector<Target> &targets,
-                         ModuleProducer module_producer) {
+                         ModuleProducer module_producer,
+                         const std::map<std::string, std::string> &suffixes) {
     user_assert(!fn_name.empty()) << "Function name must be specified.\n";
     user_assert(!targets.empty()) << "Must specify at least one target.\n";
 
@@ -321,8 +322,14 @@ void compile_multitarget(const std::string &fn_name,
             }
         }
 
-        // Each sub-target has a function name that is the 'real' name plus the target string.
-        auto suffix = "_" + replace_all(target.to_string(), "-", "_");
+        // Each sub-target has a function name that is the 'real' name plus a suffix
+        // (which defaults to the target string but can be customized via the suffixes map)
+        std::string suffix = replace_all(target.to_string(), "-", "_");
+        auto it = suffixes.find(suffix);
+        if (it != suffixes.end()) {
+          suffix = it->second;
+        }
+        suffix = "_" + suffix;
         std::string sub_fn_name = fn_name + suffix;
 
         // We always produce the runtime separately, so add NoRuntime explicitly.

--- a/src/Module.h
+++ b/src/Module.h
@@ -114,7 +114,8 @@ typedef std::function<Module(const std::string &, const Target &)> ModuleProduce
 EXPORT void compile_multitarget(const std::string &fn_name,
                                 const Outputs &output_files,
                                 const std::vector<Target> &targets,
-                                ModuleProducer module_producer);
+                                ModuleProducer module_producer,
+                                const std::map<std::string, std::string> &suffixes = {});
 
 }
 


### PR DESCRIPTION
In addition to replacing the extensions used (e.g., ".txt" instead of
".s"), it's useful to be able to replace the default suffixes of
auxiliary files (rather than using the target string) in certain build
environments.