### PR TITLE
allow compile_to_static_library() and compile_to_file() to use full paths

### DIFF
--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -256,7 +256,8 @@ void Pipeline::compile_to_lowered_stmt(const string &filename,
 void Pipeline::compile_to_static_library(const string &filename_prefix,
                                          const vector<Argument> &args,
                                          const Target &target) {
-    Module m = compile_to_module(args, filename_prefix, target);
+    string fn_name = split_string(filename_prefix, "/").back();
+    Module m = compile_to_module(args, fn_name, target);
     Outputs outputs = static_library_outputs(filename_prefix, target);
     m.compile(outputs);
 }
@@ -274,7 +275,8 @@ void Pipeline::compile_to_multitarget_static_library(const std::string &filename
 void Pipeline::compile_to_file(const string &filename_prefix,
                                const vector<Argument> &args,
                                const Target &target) {
-    Module m = compile_to_module(args, filename_prefix, target);
+    string fn_name = split_string(filename_prefix, "/").back();
+    Module m = compile_to_module(args, fn_name, target);
     Outputs outputs = Outputs().c_header(filename_prefix + ".h");
 
     if (target.arch == Target::PNaCl) {


### PR DESCRIPTION
They assume that the filename_prefix is also the function name, so if
you pass in (say) /path/to/foo you’ll get a bad function name.

Fix to allow existing code to work is to just split the filename_prefix
on “/“ and take the final segment as the fn_name; this allows all
existing use cases to work seamlessly.