### PR TITLE
Add fn_name as arg to compile_to_file() and compile_to_static_library()

### DIFF
--- a/apps/HelloAndroid/jni/halide.cpp
+++ b/apps/HelloAndroid/jni/halide.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
     Func sharper;
     sharper(x, y) = 9*curved(x, y) - 2*(curved(x-1, y) + curved(x+1, y) + curved(x, y-1) + curved(x, y+1));
 
-    Func result("result");
+    Func result;
     result(x, y) = u8(clamp(sharper(x, y), 0, 255));
 
     tone_curve.compute_root();
@@ -55,9 +55,7 @@ int main(int argc, char **argv) {
     curved.specialize(input.stride(0) == 1);
     curved.specialize(input.stride(0) == -1);
         
-    std::vector<Argument> args;
-    args.push_back(input);
-    result.compile_to_file("halide_generated", args);
+    result.compile_to_file("halide_generated", {input}, "halide_generated");
 
     return 0;
 }

--- a/apps/HelloAndroidGL/jni/halide_gl_filter.cpp
+++ b/apps/HelloAndroidGL/jni/halide_gl_filter.cpp
@@ -37,9 +37,7 @@ int main(int argc, char **argv) {
     result.bound(c, 0, 4);
     result.glsl(x, y, c);
 
-    std::vector<Argument> args;
-    args.push_back(time);
-    result.compile_to_file("halide_gl_filter", args);
+    result.compile_to_file("halide_gl_filter", {time}, "halide_gl_filter");
 
     return 0;
 }

--- a/apps/HelloAppleMetal/HelloAppleMetal/reaction_diffusion_2.cpp
+++ b/apps/HelloAppleMetal/HelloAppleMetal/reaction_diffusion_2.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
         initial.output_buffer().set_bounds(2, 0, 3);
         initial.output_buffer().set_stride(0, 3);
         initial.output_buffer().set_stride(2, 1);
-        initial.compile_to_file("reaction_diffusion_2_init", {cx, cy});
+        initial.compile_to_file("reaction_diffusion_2_init", {cx, cy}, "reaction_diffusion_2_init");
     }
 
     // Then the function that updates the state. Also depends on user input.
@@ -127,7 +127,7 @@ int main(int argc, char **argv) {
         new_state.output_buffer().set_extent(2, 3);
         new_state.output_buffer().set_stride(0, 3);
         new_state.output_buffer().set_stride(2, 1);
-        new_state.compile_to_file("reaction_diffusion_2_update", args);
+        new_state.compile_to_file("reaction_diffusion_2_update", args, "reaction_diffusion_2_update");
     }
 
     // Now the function that converts the state into an bgra8 image.
@@ -156,7 +156,7 @@ int main(int argc, char **argv) {
         state.set_stride(0, 3);
         render.gpu_tile(x, y, 32, 4);
 
-        render.compile_to_file("reaction_diffusion_2_render", {state});
+        render.compile_to_file("reaction_diffusion_2_render", {state}, "reaction_diffusion_2_render");
     }
 
     return 0;

--- a/apps/HelloiOS/HelloiOS/reaction_diffusion_2.cpp
+++ b/apps/HelloiOS/HelloiOS/reaction_diffusion_2.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
         Expr r = dx * dx + dy * dy;
         Expr mask = r < 200 * 200;
         initial(x, y, c) = random_float();// * select(mask, 1.0f, 0.001f);
-        initial.compile_to_file("reaction_diffusion_2_init", {cx, cy});
+        initial.compile_to_file("reaction_diffusion_2_init", {cx, cy}, "reaction_diffusion_2_init");
     }
 
     // Then the function that updates the state. Also depends on user input.
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
         args[3] = cx;
         args[4] = cy;
         args[5] = frame;
-        new_state.compile_to_file("reaction_diffusion_2_update", args);
+        new_state.compile_to_file("reaction_diffusion_2_update", args, "reaction_diffusion_2_update");
     }
 
     // Now the function that converts the state into an argb image.
@@ -142,7 +142,7 @@ int main(int argc, char **argv) {
         Var yi;
         render.split(y, y, yi, 64).parallel(y);
 
-        render.compile_to_file("reaction_diffusion_2_render", {state});
+        render.compile_to_file("reaction_diffusion_2_render", {state}, "reaction_diffusion_2_render");
     }
 
     return 0;

--- a/apps/bilateral_grid/bilateral_grid.cpp
+++ b/apps/bilateral_grid/bilateral_grid.cpp
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
         bilateral_grid.compute_root().parallel(y).vectorize(x, 8);
     }
 
-    bilateral_grid.compile_to_static_library("bilateral_grid", {r_sigma, input}, target);
+    bilateral_grid.compile_to_static_library("bilateral_grid", {r_sigma, input}, "bilateral_grid", target);
 
     return 0;
 }

--- a/apps/blur/halide_blur.cpp
+++ b/apps/blur/halide_blur.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     blur_y.split(y, y, yi, 8).parallel(y).vectorize(x, 8);
     blur_x.store_at(blur_y, y).compute_at(blur_y, yi).vectorize(x, 8);
 
-    blur_y.compile_to_static_library("halide_blur", {input});
+    blur_y.compile_to_static_library("halide_blur", {input}, "halide_blur");
 
     return 0;
 }

--- a/apps/camera_pipe/camera_pipe.cpp
+++ b/apps/camera_pipe/camera_pipe.cpp
@@ -358,7 +358,7 @@ int main(int argc, char **argv) {
     std::vector<Argument> args = {color_temp, gamma, contrast, blackLevel, whiteLevel,
                                   input, matrix_3200, matrix_7000};
     // TODO: it would be more efficient to call compile_to() a single time with the right arguments
-    processed.compile_to_static_library("curved", args, target);
+    processed.compile_to_static_library("curved", args, "curved", target);
     processed.compile_to_assembly("curved.s", args, target);
 
     return 0;

--- a/apps/glsl/halide_blur.cpp
+++ b/apps/glsl/halide_blur.cpp
@@ -25,6 +25,6 @@ int main(int argc, char **argv) {
 
     std::vector<Argument> args;
     args.push_back(input8);
-    out.compile_to_static_library("blur", args, target);
+    out.compile_to_static_library("blur", args, "blur", target);
     return 0;
 }

--- a/apps/glsl/halide_ycc.cpp
+++ b/apps/glsl/halide_ycc.cpp
@@ -41,7 +41,7 @@ void RgbToYcc() {
     std::vector<Argument> args;
     args.push_back(input8);
 
-    cpuout.compile_to_static_library("ycc", args, target);
+    cpuout.compile_to_static_library("ycc", args, "ycc", target);
 }
 
 int main() {

--- a/apps/local_laplacian/local_laplacian_gen.cpp
+++ b/apps/local_laplacian/local_laplacian_gen.cpp
@@ -156,7 +156,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    output.compile_to_static_library("local_laplacian", {levels, alpha, beta, input}, target);
+    output.compile_to_static_library("local_laplacian", {levels, alpha, beta, input}, "local_laplacian", target);
 
     return 0;
 }

--- a/apps/modules/generate_pipeline.cpp
+++ b/apps/modules/generate_pipeline.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
     vignette.compute_at(output, xo);
     flip.compute_at(output, xo);
 
-    output.compile_to_file("pipeline", {in});
+    output.compile_to_file("pipeline", {in}, "pipeline");
 
     return 0;
 }

--- a/apps/modules/my_library/flip.cpp
+++ b/apps/modules/my_library/flip.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
 
     flip.vectorize(x, 4);
 
-    flip.compile_to_file("flip_impl", {in, total_width});
+    flip.compile_to_file("flip_impl", {in, total_width}, "flip_impl");
 
     return 0;
 }

--- a/apps/modules/my_library/vignette.cpp
+++ b/apps/modules/my_library/vignette.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
     // Any scheduling for a goes here
     vignette.vectorize(x, 4);
 
-    vignette.compile_to_file("vignette_impl", {in, center_x, center_y, radius});
+    vignette.compile_to_file("vignette_impl", {in, center_x, center_y, radius}, "vignette_impl");
 
     return 0;
 }

--- a/apps/nacl_demos/game_of_life.cpp
+++ b/apps/nacl_demos/game_of_life.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
         Func initial;
 
         initial(x, y, c) = random_bit;
-        initial.compile_to_static_library("game_of_life_init", {});
+        initial.compile_to_static_library("game_of_life_init", {}, "game_of_life_init");
     }
 
     // Then the function that updates the state. Also depends on user input.
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
         Var yi;
         output.split(y, y, yi, 16).reorder(x, yi, c, y).parallel(y);
 
-        output.compile_to_static_library("game_of_life_update", {state, mouse_x, mouse_y});
+        output.compile_to_static_library("game_of_life_update", {state, mouse_x, mouse_y}, "game_of_life_update");
     }
 
     // Now the function that converts the state into an argb image.
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
         Var yi;
         render.split(y, y, yi, 16).parallel(y);
 
-        render.compile_to_static_library("game_of_life_render", {state});
+        render.compile_to_static_library("game_of_life_render", {state}, "game_of_life_render");
     }
 
     return 0;

--- a/apps/nacl_demos/julia.cpp
+++ b/apps/nacl_demos/julia.cpp
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
 
         // The state is just a counter
         initial() = 0;
-        initial.compile_to_static_library("julia_init", {});
+        initial.compile_to_static_library("julia_init", {}, "julia_init");
     }
 
     // Then the function that updates the state. Also depends on user input.
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
         Func new_state;
         // Increment the counter
         new_state() = state() + 1;
-        new_state.compile_to_static_library("julia_update", {state, mouse_x, mouse_y});
+        new_state.compile_to_static_library("julia_update", {state, mouse_x, mouse_y}, "julia_update");
     }
 
     // Now the function that converts the state into an argb image.
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
         render.vectorize(x, 4);
         julia.update().vectorize(x, 4);
         final.vectorize(x, 4);
-        final.compile_to_static_library("julia_render", {state});
+        final.compile_to_static_library("julia_render", {state}, "julia_render");
     }
 
     return 0;

--- a/apps/nacl_demos/reaction_diffusion.cpp
+++ b/apps/nacl_demos/reaction_diffusion.cpp
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
 
         // The initial state is a quantity of two chemicals present at each pixel
         initial(x, y, c) = random_float();
-        initial.compile_to_static_library("reaction_diffusion_init", {});
+        initial.compile_to_static_library("reaction_diffusion_init", {}, "reaction_diffusion_init");
     }
 
     // Then the function that updates the state. Also depends on user input.
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
 
         clamped.store_at(new_state, y).compute_at(new_state, yi);
 
-        new_state.compile_to_static_library("reaction_diffusion_update", {state, mouse_x, mouse_y});
+        new_state.compile_to_static_library("reaction_diffusion_update", {state, mouse_x, mouse_y}, "reaction_diffusion_update");
     }
 
     // Now the function that converts the state into an argb image.
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
         Var yi;
         render.split(y, y, yi, 16).parallel(y);
 
-        render.compile_to_static_library("reaction_diffusion_render", {state});
+        render.compile_to_static_library("reaction_diffusion_render", {state}, "reaction_diffusion_render");
     }
 
     return 0;

--- a/apps/nacl_demos/reaction_diffusion_2.cpp
+++ b/apps/nacl_demos/reaction_diffusion_2.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
         Expr r = dx * dx + dy * dy;
         Expr mask = r < 200 * 200;
         initial(x, y, c) = random_float() * select(mask, 1.0f, 0.001f);
-        initial.compile_to_static_library("reaction_diffusion_2_init", {});
+        initial.compile_to_static_library("reaction_diffusion_2_init", {}, "reaction_diffusion_2_init");
     }
 
     // Then the function that updates the state. Also depends on user input.
@@ -110,7 +110,7 @@ int main(int argc, char **argv) {
         blur_x.vectorize(x, 4);
         blur_y.vectorize(x, 4);
 
-        new_state.compile_to_static_library("reaction_diffusion_2_update", {state, mouse_x, mouse_y});
+        new_state.compile_to_static_library("reaction_diffusion_2_update", {state, mouse_x, mouse_y}, "reaction_diffusion_2_update");
     }
 
     // Now the function that converts the state into an argb image.
@@ -131,7 +131,7 @@ int main(int argc, char **argv) {
         Var yi;
         render.split(y, y, yi, 16).parallel(y);
 
-        render.compile_to_static_library("reaction_diffusion_2_render", {state});
+        render.compile_to_static_library("reaction_diffusion_2_render", {state}, "reaction_diffusion_2_render");
     }
 
     return 0;

--- a/apps/openglcompute/test_oglc_avg.cpp
+++ b/apps/openglcompute/test_oglc_avg.cpp
@@ -17,7 +17,7 @@ void blur(std::string suffix, ImageParam input) {
                        clamped(x, y, c) +
                        clamped(x + 1, y, c)) / 3;
 
-    Func result("result");
+    Func result("avg_filter");
     result(x, y, c) = (blur_x(x, y - 1, c) +
                        blur_x(x, y, c) +
                        blur_x(x, y + 1, c)) / 3;
@@ -45,8 +45,8 @@ void blur(std::string suffix, ImageParam input) {
             .vectorize(x, 4);
     }
 
-    std::string filename("avg_filter");
-    result.compile_to_file(filename + suffix, {input});
+    std::string fn_name = std::string("avg_filter") + suffix;
+    result.compile_to_file(fn_name, {input}, fn_name);
 }
 
 int main(int argc, char** argv) {

--- a/apps/openglcompute/test_two_kernels.cpp
+++ b/apps/openglcompute/test_two_kernels.cpp
@@ -34,6 +34,6 @@ int main(int argc, char** argv) {
     }
     g.output_buffer().set_bounds(2, 0, CHANNELS).set_stride(0, CHANNELS).set_stride(2, 1);
 
-    std::string filename("two_kernels_filter");
-    g.compile_to_file(filename + (argc > 1? argv[1]: ""), {input});
+    std::string fn_name = std::string("two_kernels_filter") + (argc > 1 ? argv[1] : "");
+    g.compile_to_file(fn_name, {input}, fn_name);
 }

--- a/apps/renderscript/test_blur_copy.cpp
+++ b/apps/renderscript/test_blur_copy.cpp
@@ -53,8 +53,8 @@ void blur_float(std::string suffix, ImageParam input8, const int channels) {
 
     std::vector<Argument> args;
     args.push_back(input8);
-    std::string filename("generated_blur");
-    result.compile_to_file(filename + suffix + "_float", args);
+    std::string fn_name = "generated_blur" + suffix + "_float";
+    result.compile_to_file(fn_name, args, fn_name);
 }
 
 void copy_float(std::string suffix, ImageParam input8, const int channels) {
@@ -88,8 +88,8 @@ void copy_float(std::string suffix, ImageParam input8, const int channels) {
 
     std::vector<Argument> args;
     args.push_back(input8);
-    std::string filename("generated_copy");
-    result.compile_to_file(filename + suffix + "_float", args);
+    std::string fn_name = "generated_copy" + suffix + "_float";
+    result.compile_to_file(fn_name, args, fn_name);
 }
 
 void blur_uint8(std::string suffix, ImageParam input8, const int channels) {
@@ -146,8 +146,8 @@ void blur_uint8(std::string suffix, ImageParam input8, const int channels) {
 
     std::vector<Argument> args;
     args.push_back(input8);
-    std::string filename("generated_blur");
-    result.compile_to_file(filename + suffix + "_uint8", args);
+    std::string fn_name = "generated_blur" + suffix + "_uint8";
+    result.compile_to_file(fn_name, args, fn_name);
 }
 
 void copy_uint8(std::string suffix, ImageParam input8, const int channels) {
@@ -181,8 +181,8 @@ void copy_uint8(std::string suffix, ImageParam input8, const int channels) {
 
     std::vector<Argument> args;
     args.push_back(input8);
-    std::string filename("generated_copy");
-    result.compile_to_file(filename + suffix + "_uint8", args);
+    std::string fn_name = "generated_copy" + suffix + "_uint8";
+    result.compile_to_file(fn_name, args, fn_name);
 }
 
 int main(int argc, char **argv) {

--- a/apps/renderscript/test_two_kernels.cpp
+++ b/apps/renderscript/test_two_kernels.cpp
@@ -24,6 +24,6 @@ int main(int argc, char** argv) {
     g.vectorize(c);
 
     Target target = get_target_from_environment();
-    std::string filename(target.arch == Target::Arch::ARM? "generated_test_two_kernels": "generated_test_two_kernels");
-    g.compile_to_file(filename + (argc > 1? argv[1]: ""), {input});
+    std::string fn_name = std::string("generated_test_two_kernels") + (argc > 1? argv[1]: "");
+    g.compile_to_file(fn_name, {input}, fn_name);
 }

--- a/python_bindings/apps/bilateral_grid.py
+++ b/python_bindings/apps/bilateral_grid.py
@@ -102,6 +102,7 @@ def generate_compiled_file(bilateral_grid):
     arguments.append(Argument('input', InputBuffer, UInt(16), 2))
     bilateral_grid.compile_to_file("bilateral_grid",
                                    arguments,
+                                   "bilateral_grid",
                                    target)
     print("Generated compiled file for bilateral_grid function.")
     return

--- a/python_bindings/apps/local_laplacian.py
+++ b/python_bindings/apps/local_laplacian.py
@@ -179,7 +179,7 @@ def generate_compiled_file(local_laplacian):
     arguments.append(Argument('beta', False, float_t))
     arguments.append(Argument('input', True, UInt(16)))
     target = get_target_from_environment()
-    local_laplacian.compile_to_file("local_laplacian", arguments, target)
+    local_laplacian.compile_to_file("local_laplacian", arguments, "local_laplacian", target)
     print("Generated compiled file for local_laplacian function.")
     return
 

--- a/python_bindings/python/Func.cpp
+++ b/python_bindings/python/Func.cpp
@@ -124,12 +124,13 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(func_compile_to_c0_overloads, func_compile_to_c0
 
 void func_compile_to_file0(h::Func &that, const std::string &filename_prefix,
                            p::list args,
+                           const std::string fn_name = "",
                            const h::Target &target = h::get_target_from_environment()) {
     auto args_vec = python_collection_to_vector<h::Argument>(args);
-    that.compile_to_file(filename_prefix, args_vec, target);
+    that.compile_to_file(filename_prefix, args_vec, fn_name, target);
 }
 
-BOOST_PYTHON_FUNCTION_OVERLOADS(func_compile_to_file0_overloads, func_compile_to_file0, 3, 4)
+BOOST_PYTHON_FUNCTION_OVERLOADS(func_compile_to_file0_overloads, func_compile_to_file0, 3, 5)
 
 void func_compile_to_lowered_stmt0(h::Func &that,
                                    const std::string &filename,
@@ -381,9 +382,9 @@ void defineFunc() {
     func_class.def("compile_to_file",
                    &func_compile_to_file0,
                    func_compile_to_file0_overloads(
-                       p::args("self", "filename_prefix", "args", "target"),
+                       p::args("self", "filename_prefix", "args", "fn_name", "target"),
                        "Compile to object file and header pair, with the given arguments. "
-                       "Also names the C function to match the first argument."));
+                       "The name defaults to the same name as the Halide Func."));
 
     func_class.def("compile_jit", &func_compile_jit1, p::args("self", "target"),
                    "Eagerly jit compile the function to machine code. This "

--- a/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
+++ b/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
@@ -72,7 +72,7 @@ def main():
     # For AOT-compiled code, we need to explicitly declare the
     # arguments to the routine. This routine takes two. Arguments are
     # usually Params or ImageParams.
-    brighter.compile_to_file("lesson_10_halide", [input, offset])
+    brighter.compile_to_file("lesson_10_halide", [input, offset], "lesson_10_halide")
 
     print("Halide pipeline compiled, but not yet run.")
 

--- a/python_bindings/tutorial/lesson_11_cross_compilation.py
+++ b/python_bindings/tutorial/lesson_11_cross_compilation.py
@@ -45,7 +45,7 @@ def main():
     # program on.  For example, if you compile and run this file on
     # 64-bit linux on an x86 cpu with sse4.1, then the generated code
     # will be suitable for 64-bit linux on x86 with sse4.1.
-    brighter.compile_to_file("lesson_11_host", args)
+    brighter.compile_to_file("lesson_11_host", args, "lesson_11_host")
 
     # We can also compile object files suitable for other cpus and
     # operating systems. You do this with an optional third argument
@@ -64,7 +64,7 @@ def main():
         arm_features = []             # A list of features to set
         target.set_features(arm_features)
         # Pass the target as the last argument.
-        brighter.compile_to_file("lesson_11_arm_32_android", args, target)
+        brighter.compile_to_file("lesson_11_arm_32_android", args, "lesson_11_arm_32_android", target)
 
     if create_windows:
         # And now a Windows object file for 64-bit x86 with AVX and SSE 4.1:
@@ -73,7 +73,7 @@ def main():
         target.arch = TargetArch.X86
         target.bits = 64
         target.set_features([TargetFeature.AVX, TargetFeature.SSE41])
-        brighter.compile_to_file("lesson_11_x86_64_windows", args, target)
+        brighter.compile_to_file("lesson_11_x86_64_windows", args, "lesson_11_x86_64_windows", target)
 
     if create_ios:
         # And finally an iOS mach-o object file for one of Apple's 32-bit
@@ -87,7 +87,7 @@ def main():
         target.arch = TargetArch.ARM
         target.bits = 32
         target.set_features([TargetFeature.ARMv7s])
-        brighter.compile_to_file("lesson_11_arm_32_ios", args, target)
+        brighter.compile_to_file("lesson_11_arm_32_ios", args, "lesson_11_arm_32_ios", target)
 
 
     # Now let's check these files are what they claim, by examining

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2473,14 +2473,16 @@ void Func::print_loop_nest() {
 
 void Func::compile_to_file(const string &filename_prefix,
                            const vector<Argument> &args,
+                           const std::string &fn_name,
                            const Target &target) {
-    pipeline().compile_to_file(filename_prefix, args, target);
+    pipeline().compile_to_file(filename_prefix, args, fn_name, target);
 }
 
 void Func::compile_to_static_library(const string &filename_prefix,
                                      const vector<Argument> &args,
+                                     const std::string &fn_name,
                                      const Target &target) {
-    pipeline().compile_to_static_library(filename_prefix, args, target);
+    pipeline().compile_to_static_library(filename_prefix, args, fn_name, target);
 }
 
 void Func::compile_to_multitarget_static_library(const std::string &filename_prefix,

--- a/src/Func.h
+++ b/src/Func.h
@@ -630,17 +630,19 @@ public:
     EXPORT void print_loop_nest();
 
     /** Compile to object file and header pair, with the given
-     * arguments. Also names the C function to match the first
-     * argument.
+     * arguments. The name defaults to the same name as this halide
+     * function.
      */
     EXPORT void compile_to_file(const std::string &filename_prefix, const std::vector<Argument> &args,
+                                const std::string &fn_name = "",
                                 const Target &target = get_target_from_environment());
 
     /** Compile to static-library file and header pair, with the given
-     * arguments. Also names the C function to match the first
-     * argument.
+     * arguments. The name defaults to the same name as this halide
+     * function.
      */
     EXPORT void compile_to_static_library(const std::string &filename_prefix, const std::vector<Argument> &args,
+                                          const std::string &fn_name = "",
                                           const Target &target = get_target_from_environment());
 
     /** Compile to static-library file and header pair once for each target;

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -255,8 +255,9 @@ void Pipeline::compile_to_lowered_stmt(const string &filename,
 
 void Pipeline::compile_to_static_library(const string &filename_prefix,
                                          const vector<Argument> &args,
+                                         const std::string &fn_name,
                                          const Target &target) {
-    Module m = compile_to_module(args, filename_prefix, target);
+    Module m = compile_to_module(args, fn_name, target);
     Outputs outputs = static_library_outputs(filename_prefix, target);
     m.compile(outputs);
 }
@@ -273,8 +274,9 @@ void Pipeline::compile_to_multitarget_static_library(const std::string &filename
 
 void Pipeline::compile_to_file(const string &filename_prefix,
                                const vector<Argument> &args,
+                               const std::string &fn_name,
                                const Target &target) {
-    Module m = compile_to_module(args, filename_prefix, target);
+    Module m = compile_to_module(args, fn_name, target);
     Outputs outputs = Outputs().c_header(filename_prefix + ".h");
 
     if (target.arch == Target::PNaCl) {

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -160,17 +160,17 @@ public:
     EXPORT void print_loop_nest();
 
     /** Compile to object file and header pair, with the given
-     * arguments. Also names the C function to match the filename
-     * argument. */
+     * arguments. */
     EXPORT void compile_to_file(const std::string &filename_prefix,
                                 const std::vector<Argument> &args,
+                                const std::string &fn_name,
                                 const Target &target = get_target_from_environment());
 
     /** Compile to static-library file and header pair, with the given
-     * arguments. Also names the C function to match the filename
-     * argument. */
+     * arguments. */
     EXPORT void compile_to_static_library(const std::string &filename_prefix,
                                           const std::vector<Argument> &args,
+                                          const std::string &fn_name,
                                           const Target &target = get_target_from_environment());
 
     /** Compile to static-library file and header pair once for each target;

--- a/test/correctness/cross_compilation.cpp
+++ b/test/correctness/cross_compilation.cpp
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
     // targets. This provides early warning that you may have broken
     // Halide on some other platform.
 
-    Func f;
+    Func f("f");
     Var x;
     f(x) = x;
 
@@ -30,8 +30,8 @@ int main(int argc, char **argv) {
     for (const std::string &t : targets) {
         Target target(t);
         if (!target.supported()) continue;
-        f.compile_to_file("test_object_" + t, std::vector<Argument>(), target);
-        f.compile_to_static_library("test_lib_" + t, std::vector<Argument>(), target);
+        f.compile_to_file("test_object_" + t, std::vector<Argument>(), "", target);
+        f.compile_to_static_library("test_lib_" + t, std::vector<Argument>(), "", target);
 
         std::string object_name = "test_object_" + t;
         std::string lib_name = "test_lib_" + t;

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -162,7 +162,8 @@ void check(string op, int vector_width, Expr e) {
     }
 
     // Also compile the error checking Func (to be sure it compiles without error)
-    error.compile_to_file("test_" + name, arg_types, target);
+    std::string fn_name = "test_" + name;
+    error.compile_to_file(fn_name, arg_types, fn_name, target);
 
     bool can_run_the_code = can_run_code();
     if (can_run_the_code) {

--- a/test/renderscript/aot_copy.cpp
+++ b/test/renderscript/aot_copy.cpp
@@ -30,7 +30,7 @@ void copy_interleaved(bool vectorize, int channels) {
     std::vector<Argument> args;
     args.push_back(input8);
 
-    result.compile_to_file("aot_copy", args);
+    result.compile_to_file("aot_copy", args, "aot_copy");
 }
 
 int main(int argc, char **argv) {

--- a/test/renderscript/aot_copy_error.cpp
+++ b/test/renderscript/aot_copy_error.cpp
@@ -28,7 +28,7 @@ void copy_interleaved(bool vectorize, int channels) {
     std::vector<Argument> args;
     args.push_back(input8);
 
-    result.compile_to_file("aot_copy_error", args);
+    result.compile_to_file("aot_copy_error", args, "aot_copy_error");
 }
 
 int main(int argc, char **argv) {

--- a/tutorial/lesson_10_aot_compilation_generate.cpp
+++ b/tutorial/lesson_10_aot_compilation_generate.cpp
@@ -72,10 +72,10 @@ int main(int argc, char **argv) {
     // arguments to the routine. This routine takes two. Arguments are
     // usually Params or ImageParams.
     std::vector<Argument> args = {input, offset};
-    brighter.compile_to_static_library("lesson_10_halide", args, "lesson_10_halide");
+    brighter.compile_to_static_library("lesson_10_halide", args, "brighter");
 
     // If you're using C++11, you can just say:
-    // brighter.compile_to_static_library("lesson_10_halide", {input, offset}, "lesson_10_halide");
+    // brighter.compile_to_static_library("lesson_10_halide", {input, offset}, "brighter");
 
     printf("Halide pipeline compiled, but not yet run.\n");
 

--- a/tutorial/lesson_10_aot_compilation_generate.cpp
+++ b/tutorial/lesson_10_aot_compilation_generate.cpp
@@ -72,10 +72,10 @@ int main(int argc, char **argv) {
     // arguments to the routine. This routine takes two. Arguments are
     // usually Params or ImageParams.
     std::vector<Argument> args = {input, offset};
-    brighter.compile_to_static_library("lesson_10_halide", args);
+    brighter.compile_to_static_library("lesson_10_halide", args, "lesson_10_halide");
 
     // If you're using C++11, you can just say:
-    // brighter.compile_to_static_library("lesson_10_halide", {input, offset});
+    // brighter.compile_to_static_library("lesson_10_halide", {input, offset}, "lesson_10_halide");
 
     printf("Halide pipeline compiled, but not yet run.\n");
 

--- a/tutorial/lesson_11_cross_compilation.cpp
+++ b/tutorial/lesson_11_cross_compilation.cpp
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
     // program on.  For example, if you compile and run this file on
     // 64-bit linux on an x86 cpu with sse4.1, then the generated code
     // will be suitable for 64-bit linux on x86 with sse4.1.
-    brighter.compile_to_file("lesson_11_host", args);
+    brighter.compile_to_file("lesson_11_host", args, "lesson_11_host");
 
     // We can also compile object files suitable for other cpus and
     // operating systems. You do this with an optional third argument
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
     std::vector<Target::Feature> arm_features; // A list of features to set
     target.set_features(arm_features);
     // We then pass the target as the last argument to compile_to_file.
-    brighter.compile_to_file("lesson_11_arm_32_android", args, target);
+    brighter.compile_to_file("lesson_11_arm_32_android", args, "lesson_11_arm_32_android", target);
 
     // And now a Windows object file for 64-bit x86 with AVX and SSE 4.1:
     target.os = Target::Windows;
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
     x86_features.push_back(Target::AVX);
     x86_features.push_back(Target::SSE41);
     target.set_features(x86_features);
-    brighter.compile_to_file("lesson_11_x86_64_windows", args, target);
+    brighter.compile_to_file("lesson_11_x86_64_windows", args, "lesson_11_x86_64_windows", target);
 
     // And finally an iOS mach-o object file for one of Apple's 32-bit
     // ARM processors - the A6. It's used in the iPhone 5. The A6 uses
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
     std::vector<Target::Feature> armv7s_features;
     armv7s_features.push_back(Target::ARMv7s);
     target.set_features(armv7s_features);
-    brighter.compile_to_file("lesson_11_arm_32_ios", args, target);
+    brighter.compile_to_file("lesson_11_arm_32_ios", args, "lesson_11_arm_32_ios", target);
 
 
     // Now let's check these files are what they claim, by examining

--- a/tutorial/lesson_11_cross_compilation.cpp
+++ b/tutorial/lesson_11_cross_compilation.cpp
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
     // program on.  For example, if you compile and run this file on
     // 64-bit linux on an x86 cpu with sse4.1, then the generated code
     // will be suitable for 64-bit linux on x86 with sse4.1.
-    brighter.compile_to_file("lesson_11_host", args, "lesson_11_host");
+    brighter.compile_to_file("lesson_11_host", args, "brighter");
 
     // We can also compile object files suitable for other cpus and
     // operating systems. You do this with an optional third argument
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
     std::vector<Target::Feature> arm_features; // A list of features to set
     target.set_features(arm_features);
     // We then pass the target as the last argument to compile_to_file.
-    brighter.compile_to_file("lesson_11_arm_32_android", args, "lesson_11_arm_32_android", target);
+    brighter.compile_to_file("lesson_11_arm_32_android", args, "brighter", target);
 
     // And now a Windows object file for 64-bit x86 with AVX and SSE 4.1:
     target.os = Target::Windows;
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
     x86_features.push_back(Target::AVX);
     x86_features.push_back(Target::SSE41);
     target.set_features(x86_features);
-    brighter.compile_to_file("lesson_11_x86_64_windows", args, "lesson_11_x86_64_windows", target);
+    brighter.compile_to_file("lesson_11_x86_64_windows", args, "brighter", target);
 
     // And finally an iOS mach-o object file for one of Apple's 32-bit
     // ARM processors - the A6. It's used in the iPhone 5. The A6 uses
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
     std::vector<Target::Feature> armv7s_features;
     armv7s_features.push_back(Target::ARMv7s);
     target.set_features(armv7s_features);
-    brighter.compile_to_file("lesson_11_arm_32_ios", args, "lesson_11_arm_32_ios", target);
+    brighter.compile_to_file("lesson_11_arm_32_ios", args, "brighter", target);
 
 
     // Now let's check these files are what they claim, by examining


### PR DESCRIPTION
These APIs used the “filename_prefix” argument as the function’s C name
as well, preventing callers from passing a full (or partial) pathname
for output. Added a new fn_name argument similar to others in these
classes: if non-empty, use as C function name; if empty, use Func’s
intrinsic name if possible. Updated many tests and demos appropriately,
generally preferring to explicitly provide the new arg in most cases
(rather than updating the Func’s name).