### PR TITLE
make OpenGL and RenderScript tests less env-var dependent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1090,23 +1090,18 @@ warning_%: $(BIN_DIR)/warning_%
 	cd $(TMP_DIR) ; $(CURDIR)/$< 2>&1 | egrep --q "^Warning"
 	@-echo
 
-opengl_%: HL_JIT_TARGET ?= host-opengl
 opengl_%: $(BIN_DIR)/opengl_%
 	@-mkdir -p $(TMP_DIR)
-	cd $(TMP_DIR) ; HL_JIT_TARGET=$(HL_JIT_TARGET) $(CURDIR)/$< 2>&1
+	cd $(TMP_DIR) ; $(CURDIR)/$< 2>&1
 	@-echo
 
-renderscript_jit_%: HL_JIT_TARGET = host-renderscript
-renderscript_jit_%: HL_TARGET =
-renderscript_aot_%: HL_TARGET = arm-32-android-armv7s-renderscript
-renderscript_aot_%: HL_JIT_TARGET =
 renderscript_%_error: $(BIN_DIR)/renderscript_%_error
 	@-mkdir -p $(TMP_DIR)
-	cd $(TMP_DIR) ; HL_JIT_TARGET=$(HL_JIT_TARGET) HL_TARGET=$(HL_TARGET) $(CURDIR)/$< 2>&1 | egrep --q "terminating with uncaught exception|^terminate called|^Error"
+	cd $(TMP_DIR) ; $(CURDIR)/$< 2>&1 | egrep --q "terminating with uncaught exception|^terminate called|^Error"
 	@-echo
 renderscript_%: $(BIN_DIR)/renderscript_%
 	@-mkdir -p $(TMP_DIR)
-	cd $(TMP_DIR) ; HL_JIT_TARGET=$(HL_JIT_TARGET) HL_TARGET=$(HL_TARGET) $(CURDIR)/$<
+	cd $(TMP_DIR) ; $(CURDIR)/$<
 	@-echo
 
 generator_%: $(BIN_DIR)/generator_%

--- a/test/opengl/conv_select.cpp
+++ b/test/opengl/conv_select.cpp
@@ -8,11 +8,7 @@ using namespace Halide;
 
 int main() {
     // This test must be run with an OpenGL target.
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL)) {
-        fprintf(stderr, "ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     // Define the input
     const int width = 10, height = 10, channels = 4, res_channels = 2;
@@ -41,7 +37,7 @@ int main() {
     g.bound(c, 0, 2).glsl(x, y, c);
 
     // Generate the result.
-    Image<float> result = g.realize(width, height, res_channels);
+    Image<float> result = g.realize(width, height, res_channels, target);
     result.copy_to_host();
 
     //Check the result.

--- a/test/opengl/copy_pixels.cpp
+++ b/test/opengl/copy_pixels.cpp
@@ -5,13 +5,8 @@
 using namespace Halide;
 
 int main() {
-
-    // This test must be run with an OpenGL target
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL))  {
-        fprintf(stderr,"ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Image<uint8_t> input(255, 10, 3);
     for (int y=0; y<input.height(); y++) {
@@ -29,7 +24,7 @@ int main() {
     Image<uint8_t> out(255, 10, 3);
     g.bound(c, 0, 3);
     g.glsl(x, y, c);
-    g.realize(out);
+    g.realize(out, target);
     out.copy_to_host();
 
     for (int y=0; y<out.height(); y++) {

--- a/test/opengl/copy_to_device.cpp
+++ b/test/opengl/copy_to_device.cpp
@@ -7,13 +7,8 @@ using namespace Halide;
 // Test that internal allocations work correctly with copy_to_device.
 // This requires that suitable buffer_t objects are created internally.
 int main() {
-
-    // This test must be run with an OpenGL target
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL))  {
-        fprintf(stderr,"ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Image<uint8_t> input(255, 10, 3);
     for (int y=0; y<input.height(); y++) {
@@ -35,7 +30,7 @@ int main() {
     g.glsl(x, y, c);
 
     Image<uint8_t> out(255, 10, 3);
-    g.realize(out);
+    g.realize(out, target);
     out.copy_to_host();
 
     for (int y=0; y<out.height(); y++) {

--- a/test/opengl/copy_to_host.cpp
+++ b/test/opengl/copy_to_host.cpp
@@ -5,13 +5,8 @@
 using namespace Halide;
 
 int main() {
-
-    // This test must be run with an OpenGL target
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL))  {
-        fprintf(stderr,"ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Func gpu("gpu"), cpu("cpu");
     Var x, y, c;
@@ -28,7 +23,7 @@ int main() {
     cpu(x, y, c) = gpu(x, y, c);
 
     Image<uint8_t> out(10, 10, 3);
-    cpu.realize(out);
+    cpu.realize(out, target);
 
     for (int y=0; y<out.height(); y++) {
         for (int x=0; x<out.width(); x++) {

--- a/test/opengl/float_texture.cpp
+++ b/test/opengl/float_texture.cpp
@@ -5,13 +5,8 @@
 using namespace Halide;
 
 int main() {
-
-    // This test must be run with an OpenGL target
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL))  {
-        fprintf(stderr,"ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Image<float> input(255, 255, 3);
     for (int y=0; y<input.height(); y++) {
@@ -34,7 +29,7 @@ int main() {
     Image<float> out(255, 255, 3);
     g.bound(c, 0, 3);
     g.glsl(x, y, c);
-    g.realize(out);
+    g.realize(out, target);
     out.copy_to_host();
 
     for (int y=0; y<out.height(); y++) {

--- a/test/opengl/inline_reduction.cpp
+++ b/test/opengl/inline_reduction.cpp
@@ -3,13 +3,8 @@
 using namespace Halide;
 
 int main() {
-
-    // This test must be run with an OpenGL target
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL)) {
-        fprintf(stderr, "ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Func f;
     Var x, y, c;
@@ -17,7 +12,7 @@ int main() {
     f(x, y, c) = sum(cast<float>(r));
     f.bound(c, 0, 3).glsl(x, y, c);
 
-    Image<float> result = f.realize(100, 100, 3);
+    Image<float> result = f.realize(100, 100, 3, target);
 
     for (int c = 0; c < result.channels(); c++) {
         for (int y = 0; y < result.height(); y++) {

--- a/test/opengl/lut.cpp
+++ b/test/opengl/lut.cpp
@@ -9,6 +9,9 @@ using namespace Halide;
 
 int test_lut1d() {
 
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
+
     Var x("x");
     Var y("y");
     Var c("c");
@@ -40,45 +43,8 @@ int test_lut1d() {
 
     f0.bound(c, 0, 3);
     f0.glsl(x, y, c);
-    f0.realize(out0);
+    f0.realize(out0, target);
     out0.copy_to_host();
-
-#if 0
-    printf("Input:\n");
-    for (int c = 0; c != input.extent(2); ++c) {
-        printf("c == %d\n",c);
-        for (int y = 0; y != input.extent(1); ++y) {
-            for (int x = 0; x != input.extent(0); ++x) {
-                printf("%d ", (int)input(x, y, c));
-            }
-            printf("\n");
-        }
-    }
-    printf("\n");
-
-    printf("LUT:\n");
-    for (int c = 0; c != lut1d.extent(2); ++c) {
-        printf("c == %d\n",c);
-        for (int y=0; y != lut1d.extent(1); ++y) {
-            for (int x = 0; x != lut1d.extent(0); ++x) {
-                printf("%1.1f ", lut1d(x, y, c));
-            }
-            printf("\n");
-        }
-    }
-    printf("\n");
-
-    printf("Output:\n");
-    for (int c = 0; c != out0.extent(2); ++c) {
-        printf("c == %d\n",c);
-        for (int y = 0; y != out0.extent(1); ++y) {
-            for (int x = 0; x != out0.extent(0); ++x) {
-                printf("%1.1f ", out0(x, y, c));
-            }
-            printf("\n");
-        }
-    }
-#endif
 
     for (int c = 0; c != out0.extent(2); ++c) {
         for (int y = 0; y != out0.extent(1); ++y) {
@@ -109,13 +75,6 @@ int test_lut1d() {
 }
 
 int main() {
-
-    // This test must be run with an OpenGL target
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL))  {
-        fprintf(stderr,"ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
 
     if (test_lut1d() == 0) {
         printf("PASSED\n");

--- a/test/opengl/multiple_stages.cpp
+++ b/test/opengl/multiple_stages.cpp
@@ -4,12 +4,8 @@ using namespace Halide;
 
 int main() {
 
-    // This test must be run with an OpenGL target
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL)) {
-        fprintf(stderr, "ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Func f,g,h;
     Var x, y, c;
@@ -20,7 +16,7 @@ int main() {
     h.bound(c, 0, 3).compute_root();
     g.bound(c, 0, 3).compute_root().glsl(x, y, c);
 
-    Image<uint8_t> result = f.realize(10, 10, 3);
+    Image<uint8_t> result = f.realize(10, 10, 3, target);
     result.copy_to_host();
 
     for (int i=0; i<10; i++) {
@@ -42,7 +38,7 @@ int main() {
     f2.bound(c, 0, 3).glsl(x, y, c).compute_root();
     g2.bound(c, 0, 3).glsl(x, y, c);
 
-    Image<float> result2 = g2.realize(10, 10, 3);
+    Image<float> result2 = g2.realize(10, 10, 3, target);
 
     for (int i=0; i<10; i++) {
         for (int j=0; j<10; j++) {

--- a/test/opengl/produce.cpp
+++ b/test/opengl/produce.cpp
@@ -10,6 +10,9 @@ using namespace Halide;
 
 int test_lut1d() {
 
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
+
     Var x("x");
     Var y("y");
     Var c("c");
@@ -38,7 +41,7 @@ int test_lut1d() {
     f0.glsl(x, y, c);
 
     Image<float> out0(8, 8, 3);
-    f0.realize(out0);
+    f0.realize(out0, target);
 
     out0.copy_to_host();
 
@@ -71,13 +74,6 @@ int test_lut1d() {
 }
 
 int main() {
-
-    // This test must be run with an OpenGL target
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL)) {
-        fprintf(stderr, "ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
 
     if (test_lut1d() == 0) {
         printf("PASSED\n");

--- a/test/opengl/rewrap_texture.cpp
+++ b/test/opengl/rewrap_texture.cpp
@@ -25,13 +25,8 @@ extern "C" void glTexImage2D(GLenum, GLint, GLint, GLsizei, GLsizei, GLint, GLen
 
 int main() {
 
-    // This test must be run with an OpenGL target
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL))  {
-        fprintf(stderr,"ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
-
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     const int width = 255;
     const int height = 10;
@@ -48,7 +43,7 @@ int main() {
     g.glsl(x, y, c);
 
 
-    g.realize(out1); // run once to initialize OpenGL
+    g.realize(out1, target); // run once to initialize OpenGL
 
     GLuint texture_id;
     glGenTextures(1, &texture_id);
@@ -61,12 +56,12 @@ int main() {
 
     // wrapping a texture should work
     halide_opengl_wrap_texture(nullptr, out2.raw_buffer(), texture_id);
-    g.realize(out2);
+    g.realize(out2, target);
     halide_opengl_detach_texture(nullptr, out2.raw_buffer());
 
     // re-wrapping the texture should not abort
     halide_opengl_wrap_texture(nullptr, out3.raw_buffer(), texture_id);
-    g.realize(out3);
+    g.realize(out3, target);
     halide_opengl_detach_texture(nullptr, out3.raw_buffer());
 
     printf("Success!\n");

--- a/test/opengl/save_state.cpp
+++ b/test/opengl/save_state.cpp
@@ -312,6 +312,9 @@ class KnownState
 using namespace Halide;
 
 int main() {
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
+
     KnownState known_state;
 
     Image<uint8_t> input(255, 10, 3);
@@ -322,10 +325,10 @@ int main() {
     g(x, y, c) = input(x, y, c);
     g.bound(c, 0, 3);
     g.glsl(x, y, c);
-    g.realize(out); // let Halide initialize OpenGL
+    g.realize(out, target); // let Halide initialize OpenGL
 
     known_state.setup(true);
-    g.realize(out);
+    g.realize(out, target);
     known_state.check("realize");
 
     known_state.setup(true);
@@ -333,7 +336,7 @@ int main() {
     known_state.check("copy_to_host");
 
     known_state.setup(false);
-    g.realize(out);
+    g.realize(out, target);
     known_state.check("realize");
 
     known_state.setup(false);

--- a/test/opengl/select.cpp
+++ b/test/opengl/select.cpp
@@ -6,6 +6,9 @@ using namespace Halide;
 
 int test_per_channel_select() {
 
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
+
     Func gpu("gpu"), cpu("cpu");
     Var x("x"), y("y"), c("c");
 
@@ -20,7 +23,7 @@ int test_per_channel_select() {
     cpu(x, y, c) = gpu(x, y, c);
 
     Image<uint8_t> out(10, 10, 4);
-    cpu.realize(out);
+    cpu.realize(out, target);
 
     // Verify the result
     for (int y=0; y!=out.height(); ++y) {
@@ -50,6 +53,9 @@ int test_per_channel_select() {
 
 int test_flag_scalar_select() {
 
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
+
     Func gpu("gpu"), cpu("cpu");
     Var x("x"), y("y"), c("c");
 
@@ -68,7 +74,7 @@ int test_flag_scalar_select() {
     cpu(x, y, c) = gpu(x, y, c);
 
     Image<uint8_t> out(10, 10, 4);
-    cpu.realize(out);
+    cpu.realize(out, target);
 
     // Verify the result
     for (int y=0; y!=out.height(); ++y) {
@@ -91,6 +97,9 @@ int test_flag_scalar_select() {
 }
 
 int test_flag_pixel_select() {
+
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Func gpu("gpu"), cpu("cpu");
     Var x("x"), y("y"), c("c");
@@ -119,7 +128,7 @@ int test_flag_pixel_select() {
     cpu(x, y, c) = gpu(x, y, c);
 
     Image<uint8_t> out(10, 10, 4);
-    cpu.realize(out);
+    cpu.realize(out, target);
 
     // Verify the result
     for (int y=0; y!=out.height(); ++y) {
@@ -144,13 +153,6 @@ int test_flag_pixel_select() {
 
 
 int main() {
-
-    // This test must be run with an OpenGL target
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL))  {
-        fprintf(stderr,"ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
 
     int err = 0;
 

--- a/test/opengl/set_pixels.cpp
+++ b/test/opengl/set_pixels.cpp
@@ -5,12 +5,8 @@
 using namespace Halide;
 
 int main() {
-    // This test must be run with an OpenGL target
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL))  {
-        fprintf(stderr,"ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Func f;
     Var x, y, c;
@@ -19,7 +15,7 @@ int main() {
 
     Image<uint8_t> out(10, 10, 3);
     f.bound(c, 0, 3).glsl(x, y, c);
-    f.realize(out);
+    f.realize(out, target);
 
     out.copy_to_host();
     for (int y=0; y<out.height(); y++) {

--- a/test/opengl/shifted_domains.cpp
+++ b/test/opengl/shifted_domains.cpp
@@ -9,6 +9,9 @@ using namespace Halide;
 // GLSL
 int shifted_domains() {
 
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
+
     int errors = 0;
 
     Func gradient("gradient");
@@ -20,7 +23,7 @@ int shifted_domains() {
 
     printf("Evaluating gradient from (0, 0) to (7, 7)\n");
     Image<float> result(8, 8, 1);
-    gradient.realize(result);
+    gradient.realize(result, target);
     result.copy_to_host();
 
     for (int y = 0; y < 8; y++) {
@@ -40,7 +43,7 @@ int shifted_domains() {
 
     printf("Evaluating gradient from (100, 50) to (104, 56)\n");
 
-    gradient.realize(shifted);
+    gradient.realize(shifted, target);
     shifted.copy_to_host();
 
     for (int y = 50; y < 57; y++) {
@@ -60,7 +63,7 @@ int shifted_domains() {
 
     printf("Evaluating gradient from (-100, -50) to (-96, -44)\n");
 
-    gradient.realize(shifted);
+    gradient.realize(shifted, target);
     shifted.copy_to_host();
 
     for (int y = -50; y < -44; y++) {
@@ -79,14 +82,6 @@ int shifted_domains() {
 }
 
 int main() {
-
-    // This test must be run with an OpenGL target
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL)) {
-        fprintf(stderr, "ERROR: This test must be run with an OpenGL target, "
-                        "e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
 
     if (shifted_domains() == 0) {
         printf("PASSED\n");

--- a/test/opengl/special_funcs.cpp
+++ b/test/opengl/special_funcs.cpp
@@ -14,20 +14,17 @@ double square(double x) {
 
 template <typename T>
 void test_function(Expr e, Image<T> &cpu_result, Image<T> &gpu_result) {
-    Func cpu, gpu;
+    Func cpu("cpu"), gpu("gpu");
 
     Target cpu_target = get_host_target();
-    Target gpu_target = get_host_target();
-    gpu_target.set_feature(Target::OpenGL);
+    Target gpu_target = get_host_target().with_feature(Target::OpenGL);
     cpu(x, y, c) = e;
     gpu(x, y, c) = e;
-    cpu.compile_jit(cpu_target);
-    gpu.compile_jit(gpu_target);
 
-    cpu.realize(cpu_result);
+    cpu.realize(cpu_result, cpu_target);
 
     gpu.bound(c, 0, 3).glsl(x, y, c);
-    gpu.realize(gpu_result);
+    gpu.realize(gpu_result, gpu_target);
     gpu_result.copy_to_host();
 
 }

--- a/test/opengl/sum_reduction.cpp
+++ b/test/opengl/sum_reduction.cpp
@@ -5,11 +5,7 @@ using namespace Halide;
 
 int main() {
     // This test must be run with an OpenGL target.
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL)) {
-        fprintf(stderr, "ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     // Define the input
     const int width = 10, height = 10, channels = 4;
@@ -33,7 +29,7 @@ int main() {
     g.bound(c, 0, 4).glsl(x, y, c);
 
     // Generate the result.
-    Image<float> result = g.realize(width, height, channels);
+    Image<float> result = g.realize(width, height, channels, target);
     result.copy_to_host();
 
     // Check the result.
@@ -45,7 +41,7 @@ int main() {
                     temp += input(std::min(x+r, input.width()-1), y, c);
                 }
                 float correct = temp / 10.0f * 255.0f;
-                if (fabs(result(x, y, c) - correct) > 1e-6) {
+                if (fabs(result(x, y, c) - correct) > 1e-3) {
                     fprintf(stderr, "result(%d, %d, %d) = %f instead of %f\n",
                             x, y, c, result(x, y, c), correct);
                     return 1;

--- a/test/opengl/sumcolor_reduction.cpp
+++ b/test/opengl/sumcolor_reduction.cpp
@@ -5,12 +5,7 @@ using namespace Halide;
 
 int main() {
     // This test must be run with an OpenGL target.
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL)) {
-        fprintf(stderr, "ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
-
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     // Define the input.
     const int width = 10, height = 10, channels = 3;
@@ -34,7 +29,7 @@ int main() {
     g.bound(c, 0, 3).glsl(x, y, c);
 
     // Generate the result.
-    Image<float> result = g.realize(10, 10, 3);
+    Image<float> result = g.realize(10, 10, 3, target);
     result.copy_to_host();
 
     // Check the result.

--- a/test/opengl/varying.cpp
+++ b/test/opengl/varying.cpp
@@ -52,12 +52,8 @@ class CountVarying : public IRMutator {
 
 int main() {
 
-    // This test must be run with an OpenGL target
-    const Target &target = get_jit_target_from_environment();
-    if (!target.has_feature(Target::OpenGL))  {
-        fprintf(stderr,"ERROR: This test must be run with an OpenGL target, e.g. by setting HL_JIT_TARGET=host-opengl.\n");
-        return 1;
-    }
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Var x("x");
     Var y("y");
@@ -82,7 +78,7 @@ int main() {
     // Run the test
     varyings.clear();
     f0.add_custom_lowering_pass(new CountVarying);
-    f0.realize(out0);
+    f0.realize(out0, target);
 
     // Check for the correct number of varying attributes
     if (varyings.size() != 2) {
@@ -153,7 +149,7 @@ int main() {
     // Run the test
     varyings.clear();
     f1.add_custom_lowering_pass(new CountVarying);
-    f1.realize(out1);
+    f1.realize(out1, target);
 
     // Check for the correct number of varying attributes
     if (varyings.size() != 4) {
@@ -212,7 +208,7 @@ int main() {
     // Run the test
     varyings.clear();
     f2.add_custom_lowering_pass(new CountVarying);
-    f2.realize(out2);
+    f2.realize(out2, target);
 
     // Check for the correct number of varying attributes
     if (varyings.size() != 4) {
@@ -283,7 +279,7 @@ int main() {
     // Run the test
     varyings.clear();
     f3.add_custom_lowering_pass(new CountVarying);
-    f3.realize(out3);
+    f3.realize(out3, target);
 
     // Check for the correct number of varying attributes
     if (varyings.size() != 2) {

--- a/test/renderscript/aot_copy.cpp
+++ b/test/renderscript/aot_copy.cpp
@@ -30,7 +30,7 @@ void copy_interleaved(bool vectorize, int channels) {
     std::vector<Argument> args;
     args.push_back(input8);
 
-    result.compile_to_file("aot_copy", args, "aot_copy");
+    result.compile_to_file("aot_copy", args, "aot_copy", Target("arm-32-android-armv7s-renderscript"));
 }
 
 int main(int argc, char **argv) {

--- a/test/renderscript/aot_copy_error.cpp
+++ b/test/renderscript/aot_copy_error.cpp
@@ -28,7 +28,7 @@ void copy_interleaved(bool vectorize, int channels) {
     std::vector<Argument> args;
     args.push_back(input8);
 
-    result.compile_to_file("aot_copy_error", args, "aot_copy_error");
+    result.compile_to_file("aot_copy_error", args, "aot_copy_error", Target("arm-32-android-armv7s-renderscript"));
 }
 
 int main(int argc, char **argv) {

--- a/test/renderscript/jit_copy.cpp
+++ b/test/renderscript/jit_copy.cpp
@@ -209,7 +209,7 @@ void copy_interleaved(bool vectorized = false, int channels = 4) {
             new ValidateInterleavedVectorizedPipeline(channels):
             new ValidateInterleavedPipeline(channels));
 
-    result.compile_jit();
+    result.compile_jit(get_jit_target_from_environment().with_feature(Target::Renderscript));
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
test/opengl and test/renderscript requires the build system to set
HL_TARGET and/or HL_JIT_TARGET correctly; it’s simpler and more robust
to set the Target features we need inside the tests, and not require
the build/test harness to do it. (Makefile did set them correctly, but
CMake never did.)

Also loosen error on sum_reduction a bit.