### PR TITLE
build_halide_h should skip runtime_internal.h

### DIFF
--- a/tools/build_halide_h.cpp
+++ b/tools/build_halide_h.cpp
@@ -11,6 +11,11 @@ void dump_header(std::string header) {
     if (done.find(header) != done.end()) return;
     done.insert(header);
 
+    if (header.find("runtime_internal") != std::string::npos) {
+        fprintf(stdout, "#error \"COMPILING_HALIDE_RUNTIME should never be defined for Halide.h\"\n");
+        return;
+    }
+
     FILE *f = fopen(header.c_str(), "r");
 
     if (f == NULL) {


### PR DESCRIPTION
Currently it inlines runtime_internal.h into Halide.h… but this code
should never be used since it’s only ifdef COMPILING_HALIDE_RUNTIME.
Let’s not tempt users by exposing stuff that we don’t want exposed.