### PR TITLE
Fixed indentation in ProducerConsumer IRPrinter

### DIFF
--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -129,10 +129,8 @@ void IRPrinter::test() {
         "    buf[(y - 1)] = ((x*17)/(x - 3))\n"
         "  }\n"
         "}\n"
-        "consume buf {\n"
-        "  vectorized (x, 0, y) {\n"
-        "    out[x] = (buf((x % 3)) + 1)\n"
-        "  }\n"
+        "vectorized (x, 0, y) {\n"
+        "  out[x] = (buf((x % 3)) + 1)\n"
         "}\n";
 
     if (source.str() != correct_source) {
@@ -498,17 +496,18 @@ void IRPrinter::visit(const AssertStmt *op) {
 }
 
 void IRPrinter::visit(const ProducerConsumer *op) {
-    do_indent();
     if (op->is_producer) {
         stream << "produce " << op->name << " {\n";
+        do_indent();
+        indent += 2;
+        print(op->body);
+        indent -= 2;
+        do_indent();
+        stream << "}\n";
     } else {
-        stream << "consume " << op->name << " {\n";
+        print(op->body);
     }
-    indent += 2;
-    print(op->body);
-    indent -= 2;
-    do_indent();
-    stream << "}\n";
+
 }
 
 void IRPrinter::visit(const For *op) {


### PR DESCRIPTION
Fix for ProducerConsumer IRPrinter: consumer should not be indented