### PR TITLE
Revise matlab_generator test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -946,6 +946,12 @@ $(FILTERS_DIR)/user_context_insanity.a: $(BIN_DIR)/user_context_insanity.generat
 	@-mkdir -p $(TMP_DIR)
 	cd $(TMP_DIR); $(CURDIR)/$< -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime-user_context
 
+# matlab needs to be generated with matlab in TARGET
+$(FILTERS_DIR)/matlab.a: $(BIN_DIR)/matlab.generator
+	@mkdir -p $(FILTERS_DIR)
+	@-mkdir -p $(TMP_DIR)
+	cd $(TMP_DIR); $(CURDIR)/$< -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime-matlab
+
 # Some .generators have additional dependencies (usually due to define_extern usage).
 # These typically require two extra dependencies:
 # (1) Ensuring the extra _generator.cpp is built into the .generator.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -211,11 +211,13 @@ if (WITH_TEST_GENERATORS)
   halide_define_aot_test(gpu_only)
   halide_define_aot_test(image_from_array)
   halide_define_aot_test(mandelbrot)
-  halide_define_aot_test(matlab)
   halide_define_aot_test(memory_profiler_mandelbrot)
   halide_define_aot_test(variable_num_threads)
 
   # Tests that require nonstandard targets, namespaces, etc.
+  halide_define_aot_test(matlab
+                         GENERATOR_HALIDE_TARGET host-matlab)
+
   halide_define_aot_test(multitarget
                          GENERATOR_HALIDE_TARGET host-debug-c_plus_plus_name_mangling,host-c_plus_plus_name_mangling
                          GENERATED_FUNCTION HalideTest::multitarget)

--- a/test/generator/matlab_generator.cpp
+++ b/test/generator/matlab_generator.cpp
@@ -11,10 +11,6 @@ public:
     Param<bool> negate{"negate"};
 
     Func build() {
-        // This would normally be done in the build file, but this
-        // test is explicitly for matlab, and provides its own Matlab
-        // API implementation.
-        target.set(get_target().with_feature(Target::Matlab));
         Var x, y;
         Func f("f");
         f(x, y) = input(x, y) * scale * select(negate, -1.0f, 1.0f);


### PR DESCRIPTION
Dancing on the target inside the Generator is a Bad Idea and hard to
support in Bazel; set the target flag in the build file(s) instead