### PR TITLE
Compute root reset at lowering

### DIFF
--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -17,6 +17,7 @@
 #include "Deinterleave.h"
 #include "EarlyFree.h"
 #include "FindCalls.h"
+#include "Func.h"
 #include "Function.h"
 #include "FuseGPUThreadLoops.h"
 #include "FuzzFloatStores.h"
@@ -76,6 +77,10 @@ Stmt lower(vector<Function> outputs, const string &pipeline_name, const Target &
 
     // Create a deep-copy of the entire graph of Funcs.
     std::tie(outputs, env) = deep_copy(outputs, env);
+
+    for (Function f: outputs) {
+        Func(f).compute_root().store_root();
+    }
 
     // Substitute in wrapper Funcs
     env = wrap_func_calls(env);

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -78,6 +78,7 @@ Stmt lower(vector<Function> outputs, const string &pipeline_name, const Target &
     // Create a deep-copy of the entire graph of Funcs.
     std::tie(outputs, env) = deep_copy(outputs, env);
 
+    // Output functions should all be computed and stored at root.
     for (Function f: outputs) {
         Func(f).compute_root().store_root();
     }

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -148,14 +148,12 @@ bool Pipeline::defined() const {
 }
 
 Pipeline::Pipeline(Func output) : contents(new PipelineContents) {
-    output.compute_root().store_root();
     output.function().freeze();
     contents->outputs.push_back(output.function());
 }
 
 Pipeline::Pipeline(const vector<Func> &outputs) : contents(new PipelineContents) {
     for (Func f: outputs) {
-        f.compute_root().store_root();
         f.function().freeze();
         contents->outputs.push_back(f.function());
     }
@@ -911,7 +909,7 @@ struct JITFuncCallContext {
 
 // Make a vector of void *'s to pass to the jit call using the
 // currently bound value for all of the params and image
-// params. 
+// params.
 vector<const void *> Pipeline::prepare_jit_call_arguments(Realization dst, const Target &target) {
     user_assert(defined()) << "Can't realize an undefined Pipeline\n";
 

--- a/test/correctness/set_custom_trace.cpp
+++ b/test/correctness/set_custom_trace.cpp
@@ -1,0 +1,64 @@
+#include <stdio.h>
+#include "Halide.h"
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+// Make sure that "f" is computed at "g"
+class CheckCompute : public IRVisitor {
+protected:
+    using IRVisitor::visit;
+
+    std::string producer;
+    std::string consumer;
+
+    void visit(const ProducerConsumer *op) {
+        if (op->is_producer) {
+            if (op->name == "f") {
+                if (producer != "g") {
+                    printf("Produce \"f\" should be inside of produce \"g\"\n");
+                    exit(-1);
+                }
+            }
+            std::string old_producer = producer;
+            producer = op->name;
+            IRVisitor::visit(op);
+            producer = old_producer;
+        } else {
+            if (op->name == "f") {
+                if (producer != "g") {
+                    printf("Consume \"f\" should be inside of produce \"g\"\n");
+                    exit(-1);
+                }
+            }
+            std::string old_consumer = consumer;
+            consumer = op->name;
+            IRVisitor::visit(op);
+            consumer = old_consumer;
+        }
+    }
+};
+
+int allocation_bound_test_trace(void *user_context, const halide_trace_event *e) {
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    // Setting custom trace on "f" should not have nuked its compute_at schedule.
+
+    Var x("x");
+    Func f("f"), g("g");
+
+    f(x) = x;
+    g(x) += f(x);
+
+    f.compute_at(g, x);
+    f.set_custom_trace(allocation_bound_test_trace);
+
+    Module m = g.compile_to_module({g.infer_arguments()});
+    CheckCompute checker;
+    m.functions().front().body.accept(&checker);
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
`output.compute_root().store_root()` should not be done in Pipeline constructor; otherwise, it will mess up with the compute_at/store_at. Consider the following example: 
```
    f(x) = x;
    g(x) += f(x);
    f.compute_at(g, x);
    f.set_custom_trace(allocation_bound_test_trace);
    g.realize(10);
```
`f.set_custom_trace()` creates a new pipeline that will nuke `f.compute_at(g, x)` causing `f` to be computed at root. 

In this PR, the `compute_root()`/`store_root()` reset on output functions is done after `deep_copy()` inside lowering.