### PR TITLE
Reduce CMake-on-Windows noise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,10 @@ function(halide_project name folder)
   if (MSVC)
     set_target_properties("${name}" PROPERTIES LINK_FLAGS "/STACK:8388608,1048576")
     # 4006: "already defined, second definition ignored"
-    set_target_properties(${name} PROPERTIES LINK_FLAGS "/ignore:4006")
+    # 4088: "/FORCE used, image may not work"
+    # (Note that MSVC apparently considers 4088 too important to allow us to ignore it;
+    # I'm nevertheless leaving this here to document that we don't care about it.)
+    set_target_properties(${name} PROPERTIES LINK_FLAGS "/ignore:4006 /ignore:4088")
     target_compile_definitions("${name}" PRIVATE _CRT_SECURE_NO_WARNINGS)
     target_link_libraries("${name}" PRIVATE Kernel32)
   endif()

--- a/HalideGenerator.cmake
+++ b/HalideGenerator.cmake
@@ -145,7 +145,12 @@ function(halide_add_aot_library_dependency TARGET AOT_LIBRARY_TARGET)
     if (WIN32)
       if (MSVC)
         # /FORCE:multiple allows clobbering the halide runtime symbols in the lib
-        set_target_properties("${TARGET}" PROPERTIES LINK_FLAGS "/STACK:8388608,1048576 /FORCE:multiple")
+        # linker warnings disabled: 
+        # 4006: "already defined, second definition ignored"
+        # 4088: "/FORCE used, image may not work"
+        # (Note that MSVC apparently considers 4088 too important to allow us to ignore it;
+        # I'm nevertheless leaving this here to document that we don't care about it.)
+        set_target_properties("${TARGET}" PROPERTIES LINK_FLAGS "/STACK:8388608,1048576 /FORCE:multiple /ignore:4006 /ignore:4088")
       else()
         set_target_properties("${TARGET}" PROPERTIES LINK_FLAGS "-Wl,--allow-multiple-definition")
       endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,12 @@ add_executable(build_halide_h ../tools/build_halide_h.cpp)
 add_executable(bitcode2cpp ../tools/bitcode2cpp.cpp)
 
 if (MSVC)
+  # disable irrelevant warnings
+  target_compile_options(build_halide_h PUBLIC /wd4996)
+  target_compile_options(bitcode2cpp PUBLIC /wd4996)
+endif()
+
+if (MSVC)
   # -g produces dwarf debugging info, which is not useful on windows
   #  (and fails to compile due to llvm bug 15393)
   set(RUNTIME_DEBUG_FLAG "")
@@ -566,7 +572,16 @@ target_compile_definitions(Halide PRIVATE "-DCOMPILING_HALIDE")
 
 if (MSVC)
   # Suppress some warnings
+  # 4244: conversion, possible loss of data
+  # 4267: conversion, possible loss of data
+  # 4800: BOOL -> true or false
+  # 4996: compiler encountered deprecated declaration
   target_compile_options(Halide PUBLIC /wd4244 /wd4267 /wd4800 /wd4996)
+  # Injected from recent LLVM:
+  target_compile_options(Halide PUBLIC /wd4141)  # 'inline' used more than once
+  target_compile_options(Halide PUBLIC /wd4146)  # unary minus applied to unsigned type
+  target_compile_options(Halide PUBLIC /wd4291)  # No matching operator delete found
+
   target_compile_definitions(Halide PUBLIC "-D_CRT_SECURE_NO_WARNINGS" "-D_SCL_SECURE_NO_WARNINGS")
   # To compile LLVM headers following was taken from LLVM CMake files:
   # Disable sized deallocation if the flag is supported. MSVC fails to compile

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -124,6 +124,10 @@ function(halide_define_aot_test NAME)
     halide_add_generator_stub_dependency(TARGET "${TARGET}" 
                                          STUB_GENERATOR_TARGET ${STUB_DEP})
   endforeach()
+  if (MSVC)
+    # 4088: "/FORCE used, image may not work"
+    set_target_properties("${TARGET}" PROPERTIES LINK_FLAGS "/ignore:4088")
+  endif()
 
   if (NOT ${args_OMIT_DEFAULT_GENERATOR})
     if (NOT args_GENERATED_FUNCTION)


### PR DESCRIPTION
Disable a grab bag of compiler/linker warnings that are irrelevant
