### PR TITLE
Fix CMake for Stubs

### DIFF
--- a/HalideGenerator.cmake
+++ b/HalideGenerator.cmake
@@ -160,6 +160,14 @@ function(halide_add_generator NAME)
   set(multiValueArgs SRCS STUB_DEPS)
   cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
+  # We need to generate an "object" library for every generator, so that any
+  # generator that depends on our stub can link in our generator as well. 
+  # Unfortunately, an ordinary static library won't do: CMake has no way to
+  # force "alwayslink=1", and a static library with just a self-registering
+  # Generator is almost certain to get optimized away at link time. Using
+  # an "Object Library" lets us dodge this (it basically just groups .o files
+  # together and presents them at the end), at the cost of some decidedly
+  # ugly bits right here.
   set(OBJLIB "${NAME}.objlib")
   add_library("${OBJLIB}" OBJECT ${args_SRCS})
   add_dependencies("${OBJLIB}" Halide)

--- a/HalideGenerator.cmake
+++ b/HalideGenerator.cmake
@@ -160,10 +160,24 @@ function(halide_add_generator NAME)
   set(multiValueArgs SRCS STUB_DEPS)
   cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
+  set(OBJLIB "${NAME}.objlib")
+  add_library("${OBJLIB}" OBJECT ${args_SRCS})
+  add_dependencies("${OBJLIB}" Halide)
+  target_include_directories("${OBJLIB}" PRIVATE "${CMAKE_BINARY_DIR}/include")
+  target_compile_options("${OBJLIB}" PRIVATE "-std=c++11" "-fno-rtti")
+  foreach(STUB ${args_STUB_DEPS})
+    halide_add_generator_stub_dependency(TARGET ${OBJLIB} STUB_GENERATOR_TARGET ${STUB})
+  endforeach()
+
+  set(ALLSTUBS $<TARGET_OBJECTS:${OBJLIB}>)
+  foreach(STUB ${args_STUB_DEPS})
+    list(APPEND ALLSTUBS $<TARGET_OBJECTS:${STUB}.objlib>)
+  endforeach()
+
   halide_project("${NAME}" 
                  "generator" 
-                 "${CMAKE_SOURCE_DIR}/tools/GenGen.cpp" 
-                 ${args_SRCS})
+                 "${CMAKE_SOURCE_DIR}/tools/GenGen.cpp"
+                 ${ALLSTUBS})
 
   # Declare a stub library if requested.
   if (${args_WITH_STUB})
@@ -172,9 +186,6 @@ function(halide_add_generator NAME)
   endif()
 
   # Add any stub deps passed to us.
-  foreach(STUB ${args_STUB_DEPS})
-    halide_add_generator_stub_dependency(TARGET ${NAME} STUB_GENERATOR_TARGET ${STUB})
-  endforeach()
 endfunction(halide_add_generator)
 
 function(halide_add_generator_stub_library)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -238,6 +238,7 @@ if (WITH_TEST_GENERATORS)
   halide_define_aot_test(image_from_array)
   halide_define_aot_test(mandelbrot)
   halide_define_aot_test(memory_profiler_mandelbrot)
+  halide_define_aot_test(stubuser)
   halide_define_aot_test(variable_num_threads)
 
   # Tests that require nonstandard targets, namespaces, args, etc.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -91,9 +91,15 @@ function(halide_define_jit_test NAME)
   set(multiValueArgs STUB_DEPS)
   cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
+  set(ALLSTUBS )
+  foreach(STUB ${args_STUB_DEPS})
+    list(APPEND ALLSTUBS $<TARGET_OBJECTS:${STUB}.objlib>)
+  endforeach()
+  
   halide_project("generator_jit_${NAME}" 
                  "generator" 
-                 "${CMAKE_CURRENT_SOURCE_DIR}/generator/${NAME}_jittest.cpp")
+                 "${CMAKE_CURRENT_SOURCE_DIR}/generator/${NAME}_jittest.cpp"
+                 ${ALLSTUBS})
   foreach(STUB_DEP ${args_STUB_DEPS})
     halide_add_generator_stub_dependency(TARGET "generator_jit_${NAME}" 
                                          STUB_GENERATOR_TARGET ${STUB_DEP})


### PR DESCRIPTION
the aot test for stubuser had been omitted; adding it revealed that
CMake builds for stubs were broken (not linking in the dependent
generator libs)