### PR TITLE
Improve camera pipe schedule

### DIFF
--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -324,7 +324,9 @@ Func CameraPipe::build() {
     denoised.compute_at(processed, yi).store_at(processed, yo)
         .prefetch(y, 2)
         .fold_storage(y, 8)
-        .vectorize(x, vec);
+        .tile(x, y, x, y, xi, yi, 2*vec, 2)
+        .vectorize(xi)
+        .unroll(yi);
     deinterleaved.compute_at(processed, yi).store_at(processed, yo)
         .fold_storage(y, 4)
         .vectorize(x, 2*vec, TailStrategy::RoundUp)
@@ -333,13 +335,15 @@ Func CameraPipe::build() {
     corrected.compute_at(processed, x)
         .vectorize(x, vec)
         .reorder(c, x, y)
+        .unroll(y)
         .unroll(c);
     processed.compute_root()
+        .reorder(c, x, y)
         .split(y, yo, yi, strip_size)
-        .split(yi, yi, yii, 2)
-        .split(x, x, xi, 2*vec, TailStrategy::RoundUp)
-        .reorder(xi, c, yii, x, yi, yo)
-        .vectorize(xi, 2*vec)
+        .tile(x, yi, x, yi, xi, yii, 2*vec, 2, TailStrategy::RoundUp)
+        .vectorize(xi)
+        .unroll(yii)
+        .unroll(c)
         .parallel(yo);
 
     demosaiced_scheduler(processed);
@@ -364,4 +368,3 @@ Func CameraPipe::build() {
 Halide::RegisterGenerator<CameraPipe> register_me{"camera_pipe"};
 
 }  // namespace
-

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -329,12 +329,12 @@ Func CameraPipe::build() {
         .unroll(yi);
     deinterleaved.compute_at(processed, yi).store_at(processed, yo)
         .fold_storage(y, 4)
-        .vectorize(x, 2*vec, TailStrategy::RoundUp)
         .reorder(c, x, y)
+        .vectorize(x, 2*vec, TailStrategy::RoundUp)
         .unroll(c);
     corrected.compute_at(processed, x)
-        .vectorize(x, vec)
         .reorder(c, x, y)
+        .vectorize(x)
         .unroll(y)
         .unroll(c);
     processed.compute_root()

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -185,11 +185,11 @@ std::pair<Func, Scheduler> CameraPipe::demosaic(Func deinterleaved) {
         assert(processed.defined());
         g_r.compute_at(processed, yi)
             .store_at(processed, yo)
-            .vectorize(x, vec, TailStrategy::RoundUp)
+            .vectorize(x, 2*vec, TailStrategy::RoundUp)
             .fold_storage(y, 2);
         g_b.compute_at(processed, yi)
             .store_at(processed, yo)
-            .vectorize(x, vec, TailStrategy::RoundUp)
+            .vectorize(x, 2*vec, TailStrategy::RoundUp)
             .fold_storage(y, 2);
         output.compute_at(processed, x)
             .vectorize(x)


### PR DESCRIPTION
No impact on x86, did not measure ARM.

On Hexagon, simulated cycles go from 13.84e6 to 11.77e6. I'm guessing this is due to improved instruction level parallelism (I started doing this because I happened to notice bad instruction pipelining here) and reduced loop overhead.