### PR TITLE
Rfactor on inner dims should check for commutativity

### DIFF
--- a/src/Associativity.cpp
+++ b/src/Associativity.cpp
@@ -194,9 +194,14 @@ ProveAssociativityResult prove_associativity(const string &f, vector<Expr> args,
     }
 
     bool all_commutative = true;
+
     // For a Tuple of exprs to be associative/commutative, each element of the Tuple
     // has to be associative/commutative. This does not handle dependencies across
-    // Tuple's elements
+    // Tuple's elements.
+
+    // Note that if any of the tuple op is failed to be proven as associative,
+    // we return early and hence, the 'is_commutative' result is not valid.
+
     for (size_t idx = 0; idx < exprs.size(); ++idx) {
         string op_x = unique_name("_x_" + std::to_string(idx));
         string op_y = unique_name("_y_" + std::to_string(idx));

--- a/src/Associativity.cpp
+++ b/src/Associativity.cpp
@@ -49,6 +49,8 @@ class ConvertSelfRef : public IRMutator {
             if (op->value_index != value_index) {
                 debug(4) << "Self-reference of " << op->name
                          << " with different index. Cannot prove associativity\n";
+                is_solvable = false;
+                return;
             } else if (is_conditional && (op->value_index == value_index)) {
                 debug(4) << "Self-reference of " << op->name
                          << " inside a conditional. Operation is not associative\n";
@@ -96,37 +98,46 @@ public:
 };
 
 template<typename T>
-bool visit_associative_binary_op(const string &op_x, const string &op_y, Expr x_part,
-                                 Expr lhs, Expr rhs, AssociativeOp &op) {
+std::pair<bool, bool> visit_associative_binary_op(
+        const string &op_x, const string &op_y, Expr x_part,
+        Expr lhs, Expr rhs, AssociativeOp &op) {
     const Variable *var_a = lhs.as<Variable>();
     if (!var_a || (var_a->name != op_x)) {
         debug(4) << "Can't prove associativity of " << T::make(lhs, rhs) << "\n";
-        return false;
+        return std::make_pair(false, false);
     } else if (expr_uses_var(rhs, op_x)) {
         debug(4) << "Can't prove associativity of " << T::make(lhs, rhs) << "\n";
-        return false;
+        return std::make_pair(false, false);
     } else {
         // op(x, y)
         op.x = {op_x, x_part};
         op.y = {op_y, rhs};
     }
-    return true;
+    if (std::is_same<T, Sub>::value) {
+        // Sub is associative but not commutative
+        return std::make_pair(true, false);
+    }
+    return std::make_pair(true, true);
 }
 
-bool extract_associative_op(const string &op_x, const string &op_y, Expr x_part,
-                            Expr e, AssociativeOp &op) {
+// Return a pair of booleans indicating if an operator is associative and commutative
+// respectively. 'op' contains the the equivalent associative binary/unary operator
+// for that operator. If the operator is non-associative, 'op' is not valid.
+std::pair<bool, bool> extract_associative_op(
+        const string &op_x, const string &op_y, Expr x_part, Expr e, AssociativeOp &op) {
     Type t = e.type();
     Expr x = Variable::make(t, op_x);
     Expr y = Variable::make(t, op_y);
 
     if (!x_part.defined()) { // op(y)
         // Update with no self-recurrence is associative and the identity can be
-        // anything since it's going to be replaced anyway
+        // anything since it's going to be replaced anyway, but it's not
+        // commutative
         op.op = y;
         op.identity = make_const(t, 0);
         op.x = {"", Expr()};
         op.y = {op_y, e};
-        return true;
+        return std::make_pair(true, false);
     }
 
     if (const Add *a = e.as<Add>()) {
@@ -161,9 +172,9 @@ bool extract_associative_op(const string &op_x, const string &op_y, Expr x_part,
         internal_error << "Let should have been substituted before calling this function\n";
     } else {
         debug(4) << "Can't prove associativity of " << e << "\n";
-        return false;
+        return std::make_pair(false, false);
     }
-    return false;
+    return std::make_pair(false, false);
 }
 
 } // anonymous namespace
@@ -171,8 +182,8 @@ bool extract_associative_op(const string &op_x, const string &op_y, Expr x_part,
 
 // TODO(psuriana): This does not handle cross-dependencies among tuple elements.
 // It also is not able to handle associative select() (e.g. argmin/argmax)
-pair<bool, vector<AssociativeOp>> prove_associativity(const string &f, vector<Expr> args,
-                                                      vector<Expr> exprs) {
+ProveAssociativityResult prove_associativity(const string &f, vector<Expr> args,
+                                             vector<Expr> exprs) {
     vector<AssociativeOp> ops;
     map<Expr, string, ExprCompare> y_subs;
 
@@ -182,8 +193,9 @@ pair<bool, vector<AssociativeOp>> prove_associativity(const string &f, vector<Ex
         arg = substitute_in_all_lets(arg);
     }
 
-    // For a Tuple of exprs to be associative, each element of the Tuple
-    // has to be associative. This does not handle dependencies across
+    bool all_commutative = true;
+    // For a Tuple of exprs to be associative/commutative, each element of the Tuple
+    // has to be associative/commutative. This does not handle dependencies across
     // Tuple's elements
     for (size_t idx = 0; idx < exprs.size(); ++idx) {
         string op_x = unique_name("_x_" + std::to_string(idx));
@@ -195,27 +207,29 @@ pair<bool, vector<AssociativeOp>> prove_associativity(const string &f, vector<Ex
         ConvertSelfRef csr(f, args, idx, op_x);
         expr = csr.mutate(expr);
         if (!csr.is_solvable) {
-            return std::make_pair(false, vector<AssociativeOp>());
+            return ProveAssociativityResult();
         }
 
         expr = common_subexpression_elimination(expr);
         expr = simplify(expr);
         expr = solve_expression(expr, op_x).result; // Move 'x' to the left as possible
         if (!expr.defined()) {
-            return std::make_pair(false, vector<AssociativeOp>());
+            return ProveAssociativityResult();
         }
         expr = substitute_in_all_lets(expr);
 
         // Try to infer the 'y' part of the operator. If we couldn't find
         // a single 'y' that satisfy the operator, give up
         AssociativeOp op;
-        bool is_associative = extract_associative_op(op_x, op_y, csr.x_part, expr, op);
+        bool is_associative, is_commutative;
+        std::tie(is_associative, is_commutative) = extract_associative_op(op_x, op_y, csr.x_part, expr, op);
         if (!is_associative) {
-            return std::make_pair(false, vector<AssociativeOp>());
+            return ProveAssociativityResult();
         }
         ops.push_back(op);
+        all_commutative = all_commutative && is_commutative;
     }
-    return std::make_pair(true, ops);
+    return ProveAssociativityResult(true, all_commutative, ops);
 }
 
 namespace {
@@ -249,13 +263,13 @@ std::string print_args(const string &f, const vector<Expr> &args, const vector<E
 void check_associativity(const string &f, vector<Expr> args, vector<Expr> exprs,
                          bool is_associative, vector<AssociativeOp> ops) {
     auto result = prove_associativity(f, args, exprs);
-    internal_assert(result.first == is_associative)
+    internal_assert(result.is_associative == is_associative)
         << "Checking associativity: " << print_args(f, args, exprs) << "\n"
         << "  Expect is_associative: " << is_associative << "\n"
-        << "  instead of " << result.first << "\n";
+        << "  instead of " << result.is_associative << "\n";
     if (is_associative) {
         for (size_t i = 0; i < ops.size(); ++i) {
-            const AssociativeOp &op = result.second[i];
+            const AssociativeOp &op = result.ops[i];
             internal_assert(equal(op.identity, ops[i].identity))
                 << "Checking associativity: " << print_args(f, args, exprs) << "\n"
                 << "  Expect identity: " << ops[i].identity << "\n"

--- a/src/Associativity.cpp
+++ b/src/Associativity.cpp
@@ -104,10 +104,10 @@ std::pair<bool, bool> visit_associative_binary_op(
     const Variable *var_a = lhs.as<Variable>();
     if (!var_a || (var_a->name != op_x)) {
         debug(4) << "Can't prove associativity of " << T::make(lhs, rhs) << "\n";
-        return std::make_pair(false, false);
+        return {false, false};
     } else if (expr_uses_var(rhs, op_x)) {
         debug(4) << "Can't prove associativity of " << T::make(lhs, rhs) << "\n";
-        return std::make_pair(false, false);
+        return {false, false};
     } else {
         // op(x, y)
         op.x = {op_x, x_part};
@@ -115,9 +115,9 @@ std::pair<bool, bool> visit_associative_binary_op(
     }
     if (std::is_same<T, Sub>::value) {
         // Sub is associative but not commutative
-        return std::make_pair(true, false);
+        return {true, false};
     }
-    return std::make_pair(true, true);
+    return {true, true};
 }
 
 // Return a pair of booleans indicating if an operator is associative and commutative
@@ -137,7 +137,7 @@ std::pair<bool, bool> extract_associative_op(
         op.identity = make_const(t, 0);
         op.x = {"", Expr()};
         op.y = {op_y, e};
-        return std::make_pair(true, false);
+        return {true, false};
     }
 
     if (const Add *a = e.as<Add>()) {
@@ -172,9 +172,9 @@ std::pair<bool, bool> extract_associative_op(
         internal_error << "Let should have been substituted before calling this function\n";
     } else {
         debug(4) << "Can't prove associativity of " << e << "\n";
-        return std::make_pair(false, false);
+        return {false, false};
     }
-    return std::make_pair(false, false);
+    return {false, false};
 }
 
 } // anonymous namespace

--- a/src/Associativity.h
+++ b/src/Associativity.h
@@ -51,11 +51,10 @@ struct AssociativeOp {
 /**
  * Represent the result of calling \ref prove_associativity on an update definition.
  * 'is_associative' indicates if the operation was successfuly proven as associative.
+ * 'is_commutative' indicates if the operation was successfuly proven as commutative.
  * 'ops' contains the list of AssociativeOps for each Tuple element in the update
- * definition. If it fails to prove associativity, 'ops' is not valid (it will
- * be empty). 'is_commutative' indicates if the operation was successfuly proven
- * as commutative. The update definition may be associative but not commutative,
- * or vice versa. See \ref prove_associativity for more details.
+ * definition. If it fails to prove associativity, 'ops' is not valid (i.e. it will
+ * be empty) as well as 'is_commutative'. See \ref prove_associativity for more details.
  */
 struct ProveAssociativityResult {
     bool is_associative;
@@ -70,10 +69,12 @@ struct ProveAssociativityResult {
 
 /**
  * Given an update definition of a Func 'f', determine its equivalent associative
- * binary/unary operator if there is any. This will also compute the commutativity
- * of the update definition. For a tuple update, this will compute a vector
- * containing the list of AssociativeOps for each Tuple element in the update
- * definition.
+ * binary/unary operator if there is any. For an associative tuple update, this
+ * will compute a vector containing the list of AssociativeOps for each Tuple
+ * element in the update definition. This will also compute the commutativity
+ * of the associative update definition. If the update definition is failed to
+ * be proven as associative, neither the AssociativeOps vector nor the
+ * 'is_commutative' result is valid.
  *
  * For instance, f(x) = min(f(x), g(r.x)) will return true for associativity and
  * commutativity and it will also return {{min(_x_0, _y_0), +inf, {_x_0, f(x)},

--- a/src/Associativity.h
+++ b/src/Associativity.h
@@ -20,10 +20,10 @@ namespace Internal {
  * is the self-recurrence term, will be represented as:
  \code
  AssociativeOp assoc = {
-        min(x, y),
-        +inf,
-        {"x", f(x)},
-        {"y", g(r.x) + 2},
+    min(x, y),
+    +inf,
+    {"x", f(x)},
+    {"y", g(r.x) + 2},
  };
  \endcode
  *
@@ -32,41 +32,61 @@ namespace Internal {
  * this case. For example, min(g(r.x), 4), will be represented as:
  \code
  AssociativeOp assoc = {
-        y,
-        0,
-        {"", Expr()},
-        {"y", min(g(r.x), 4)},
+    y,
+    0,
+    {"", Expr()},
+    {"y", min(g(r.x), 4)},
  };
  \endcode
  * Since it is a unary operator, the identity does not matter. It can be
  * anything.
  */
 struct AssociativeOp {
-        Expr op; // op(x, y)
-        Expr identity;
-        std::pair<std::string, Expr> x;
-        std::pair<std::string, Expr> y;
+    Expr op; // op(x, y)
+    Expr identity;
+    std::pair<std::string, Expr> x;
+    std::pair<std::string, Expr> y;
+};
+
+/**
+ * Represent the result of calling \ref prove_associativity on an update definition.
+ * 'is_associative' indicates if the operation was successfuly proven as associative.
+ * 'ops' contains the list of AssociativeOps for each Tuple element in the update
+ * definition. If it fails to prove associativity, 'ops' is not valid (it will
+ * be empty). 'is_commutative' indicates if the operation was successfuly proven
+ * as commutative. The update definition may be associative but not commutative,
+ * or vice versa. See \ref prove_associativity for more details.
+ */
+struct ProveAssociativityResult {
+    bool is_associative;
+    bool is_commutative;
+    std::vector<AssociativeOp> ops;
+
+    ProveAssociativityResult(bool associative, bool commutative, const std::vector<AssociativeOp> &ops)
+        : is_associative(associative), is_commutative(commutative), ops(ops) {}
+
+    ProveAssociativityResult() : ProveAssociativityResult(false, false, std::vector<AssociativeOp>()) {}
 };
 
 /**
  * Given an update definition of a Func 'f', determine its equivalent associative
- * binary/unary operator if there is any. The first boolean value of the returned pair
- * indicates if the operation was successfuly proven as associative, and the second
- * vector contains the list of AssociativeOps for each Tuple element in the update
- * definition. If it fails to prove associativity, the second vector will be empty.
+ * binary/unary operator if there is any. This will also compute the commutativity
+ * of the update definition. For a tuple update, this will compute a vector
+ * containing the list of AssociativeOps for each Tuple element in the update
+ * definition.
  *
- * For instance, f(x) = min(f(x), g(r.x)) will return true and it will also return
- * {{min(_x_0, _y_0), +inf, {_x_0, f(x)}, {_y_0, g(r.x)}}}, where the first Expr
- * is the equivalent binary operator, the second Expr is identity of the binary
- * operator, the third and the last pair contain the corresponding definition of
- * each variable in the binary operator.
+ * For instance, f(x) = min(f(x), g(r.x)) will return true for associativity and
+ * commutativity and it will also return {{min(_x_0, _y_0), +inf, {_x_0, f(x)},
+ * {_y_0, g(r.x)}}}, where the first Expr is the equivalent binary operator,
+ * the second Expr is identity of the binary operator, the third and the last
+ * pair contain the corresponding definition of each variable in the binary operator.
  *
  * Note that even though f(x) = f(x) is associative, we'll treat it as non-associative
  * since it doesn't really make any sense to do any associative reduction on that
  * particular update definition.
  */
-std::pair<bool, std::vector<AssociativeOp>> prove_associativity(
-        const std::string &f, std::vector<Expr> args, std::vector<Expr> exprs);
+ProveAssociativityResult prove_associativity(
+    const std::string &f, std::vector<Expr> args, std::vector<Expr> exprs);
 
 EXPORT void associativity_test();
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -531,7 +531,7 @@ Func Stage::rfactor(vector<pair<RVar, Var>> preserved) {
                 user_assert(is_rfactored[last_rvar])
                     << "In schedule for " << stage_name
                     << ", can't rfactor an inner dimension " << dims[i].var
-                    << "without rfactoring the outer dimensions, since the "
+                    << " without rfactoring the outer dimensions, since the "
                     << "operator is non-commutative.\n"
                     << dump_argument_list();
             }

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -482,10 +482,9 @@ Func Stage::rfactor(vector<pair<RVar, Var>> preserved) {
 
     // Check whether the operator is associative and determine the operator and
     // its identity for each value in the definition if it is a Tuple
-    bool is_assoc;
-    vector<AssociativeOp> ops;
-    std::tie(is_assoc, ops) = prove_associativity(func_name, args, values);
-    user_assert(is_assoc)
+    ProveAssociativityResult prover_result = prove_associativity(func_name, args, values);
+    vector<AssociativeOp> &ops = prover_result.ops;
+    user_assert(prover_result.is_associative)
         << "Failed to call rfactor() on " << stage_name
         << " since it can't prove associativity of the operator\n";
     internal_assert(ops.size() == values.size());
@@ -496,6 +495,7 @@ Func Stage::rfactor(vector<pair<RVar, Var>> preserved) {
     Scope<string> scope; // Contains list of RVars lifted to the intermediate Func
     vector<string> rvars_removed;
 
+    vector<bool> is_rfactored(dims.size(), false);
     for (const pair<RVar, Var> &i : preserved) {
         const RVar &rv = i.first;
         const Var &v = i.second;
@@ -508,6 +508,7 @@ Func Stage::rfactor(vector<pair<RVar, Var>> preserved) {
                 << ", can't perform rfactor() on " << rv.name()
                 << " since it is not in the reduction domain\n"
                 << dump_argument_list();
+            is_rfactored[iter - dims.begin()] = true;
         }
         {
             // Check that the new pure Vars we used to rename the RVar aren't already in the dims list
@@ -518,6 +519,25 @@ Func Stage::rfactor(vector<pair<RVar, Var>> preserved) {
                 << ", can't rename the rvars " << rv.name() << " into " << v.name()
                 << ", since it is already used in this Func's schedule elsewhere.\n"
                 << dump_argument_list();
+        }
+    }
+
+    // If the operator is associative but non-commutative, rfactor() on inner
+    // dimensions (excluding the outer dimensions) is not valid.
+    if (!prover_result.is_commutative) {
+        int last_rvar = -1;
+        for (int i = dims.size() - 1; i >= 0; --i) {
+            if ((last_rvar != -1) && is_rfactored[i]) {
+                user_assert(is_rfactored[last_rvar])
+                    << "In schedule for " << stage_name
+                    << ", can't rfactor an inner dimension " << dims[i].var
+                    << "without rfactoring the outer dimensions, since the "
+                    << "operator is non-commutative.\n"
+                    << dump_argument_list();
+            }
+            if (dims[i].is_rvar()) {
+                last_rvar = i;
+            }
         }
     }
 

--- a/src/Func.h
+++ b/src/Func.h
@@ -100,7 +100,8 @@ public:
      * operator and identity of the operator. If it can't prove the operation
      * is associative or if it cannot find an identity for that operator, this
      * will throw an error. In addition, commutativity of the operator is required
-     * if rfactor() is called on the inner dimension and not on the outer dimensions.
+     * if rfactor() is called on the inner dimension but excluding the outer
+     * dimensions.
      *
      * rfactor() takes as input 'preserved', which is a list of <RVar, Var> pairs.
      * The rvars not listed in 'preserved' are removed from the original Func and

--- a/src/Func.h
+++ b/src/Func.h
@@ -99,7 +99,8 @@ public:
      * throw an error. rfactor() will automatically infer the associative reduction
      * operator and identity of the operator. If it can't prove the operation
      * is associative or if it cannot find an identity for that operator, this
-     * will throw an error.
+     * will throw an error. In addition, commutativity of the operator is required
+     * if rfactor() is called on the inner dimension and not on the outer dimensions.
      *
      * rfactor() takes as input 'preserved', which is a list of <RVar, Var> pairs.
      * The rvars not listed in 'preserved' are removed from the original Func and

--- a/test/correctness/rfactor.cpp
+++ b/test/correctness/rfactor.cpp
@@ -760,14 +760,14 @@ int subtraction_rfactor_test() {
     g(x, y) = 40;
     g(x, y) -= f(r.x, r.y);
 
-    RVar rxi("rxi"), rxo("rxo");
-    g.update(0).split(r.x, rxo, rxi, 2);
+    RVar ryi("ryi"), ryo("ryo");
+    g.update(0).split(r.y, ryo, ryi, 2);
 
-    // rfactoring an outer dimension "rxo" is okay since subtraction is
-    // associative. However, rfactoring "rxi" without "rxo" is not okay
-    // since subtraction is non-commutative.
+    // rfactoring the outermost dimension "ryo" is okay since subtraction is
+    // associative. However, rfactoring "ryi" without "ryo" or "r.x" without
+    // "ryi" and "ryo" is not okay since subtraction is non-commutative.
     Var u("u");
-    Func intm = g.update(0).rfactor(rxo, u);
+    Func intm = g.update(0).rfactor(ryo, u);
     intm.compute_root();
     intm.update(0).vectorize(u, 2);
 

--- a/test/correctness/rfactor.cpp
+++ b/test/correctness/rfactor.cpp
@@ -763,6 +763,9 @@ int subtraction_rfactor_test() {
     RVar rxi("rxi"), rxo("rxo");
     g.update(0).split(r.x, rxo, rxi, 2);
 
+    // rfactoring an outer dimension "rxo" is okay since subtraction is
+    // associative. However, rfactoring "rxi" without "rxo" is not okay
+    // since subtraction is non-commutative.
     Var u("u");
     Func intm = g.update(0).rfactor(rxo, u);
     intm.compute_root();

--- a/test/error/rfactor_inner_dim_non_commutative.cpp
+++ b/test/error/rfactor_inner_dim_non_commutative.cpp
@@ -1,0 +1,30 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+   	Func f("f"), g("g");
+    Var x("x"), y("y");
+
+    f(x, y) = x + y;
+    f.compute_root();
+
+    Param<int> inner_extent, outer_extent;
+    RDom r(10, inner_extent, 30, outer_extent);
+    inner_extent.set(20);
+    outer_extent.set(40);
+
+    g(x, y) = 40;
+    g(x, y) -= f(r.x, r.y);
+
+    RVar rxi("rxi"), rxo("rxo");
+    g.update(0).split(r.x, rxo, rxi, 2);
+
+    // rfactor() on the inned dimension of a non-commutative operator like
+    // subtraction is not valid as it may change order of computation.
+    Var u("u");
+    g.update(0).rfactor(rxi, u);
+
+    return 0;
+}

--- a/test/error/rfactor_inner_dim_non_commutative.cpp
+++ b/test/error/rfactor_inner_dim_non_commutative.cpp
@@ -4,7 +4,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-   	Func f("f"), g("g");
+    Func f("f"), g("g");
     Var x("x"), y("y");
 
     f(x, y) = x + y;
@@ -18,14 +18,11 @@ int main(int argc, char **argv) {
     g(x, y) = 40;
     g(x, y) -= f(r.x, r.y);
 
-    RVar rxi("rxi"), rxo("rxo");
-    g.update(0).split(r.x, rxo, rxi, 2);
-
-    // rfactor() on the inner dimensions of a non-commutative operator with
-    // excluding the outer dimensions like subtraction is not valid as it may
-    // change order of computation.
+    // Calling rfactor() on the inner dimensions of a non-commutative operator
+    // with excluding the outer dimensions like subtraction is not valid as it
+    // may change order of computation.
     Var u("u");
-    g.update(0).rfactor(rxi, u);
+    g.update(0).rfactor(r.x, u);
 
     return 0;
 }

--- a/test/error/rfactor_inner_dim_non_commutative.cpp
+++ b/test/error/rfactor_inner_dim_non_commutative.cpp
@@ -21,8 +21,9 @@ int main(int argc, char **argv) {
     RVar rxi("rxi"), rxo("rxo");
     g.update(0).split(r.x, rxo, rxi, 2);
 
-    // rfactor() on the inned dimension of a non-commutative operator like
-    // subtraction is not valid as it may change order of computation.
+    // rfactor() on the inner dimensions of a non-commutative operator with
+    // excluding the outer dimensions like subtraction is not valid as it may
+    // change order of computation.
     Var u("u");
     g.update(0).rfactor(rxi, u);
 


### PR DESCRIPTION
Added a pass to check for commutativity of an operator in rfactor. When rfactoring an inner dimension of a non-commutative operator (e.g. subtraction), it is required for the containing outer dimensions to be rfactored as well; otherwise, it will change the order of operation. 

For example, for the following definition:

```
    g(x, y) = 40;
    g(x, y) -= f(r.x, r.y);
    RVar rxi("rxi"), rxo("rxo");
    g.update(0).split(r.x, rxo, rxi, 2);
```

The following schedule is okay:

```
    Var u("u");
    g.update(0).rfactor(rxo, u);
```

But not the following:

```
   Var u("u");
   g.update(0).rfactor(rxi, u);
```

If it had been `g(x, y) += f(r.x, r.y)` instead, then the second schedule is okay.
