### PR TITLE
Make it possible to use Halide::Buffer without a runtime linked

### DIFF
--- a/src/DeviceInterface.cpp
+++ b/src/DeviceInterface.cpp
@@ -14,9 +14,9 @@
 // a linker flag. Because the pragma is in a macro, we use __pragma
 // instead of #pragma
 #ifdef _WIN64
-#define EXPORT_SYM(n) __pragma(comment(linker, "/EXPORT:" #n))  
+#define EXPORT_SYM(n) __pragma(comment(linker, "/EXPORT:" #n))
 #else
-#define EXPORT_SYM(n) __pragma(comment(linker, "/EXPORT:_" #n)) 
+#define EXPORT_SYM(n) __pragma(comment(linker, "/EXPORT:_" #n))
 #endif
 #else
 #define EXPORT_SYM(n)
@@ -139,6 +139,11 @@ int halide_device_free(void *user_context, struct buffer_t *buf) {
     }
 }
 EXPORT_SYM(halide_device_free)
+
+int halide_weak_device_free(void *user_context, struct buffer_t *buf) {
+    return halide_device_free(user_context, buf);
+}
+EXPORT_SYM(halide_weak_device_free)
 
 const struct halide_device_interface *halide_cuda_device_interface() {
     Target target(get_host_target());

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -168,9 +168,14 @@ class Buffer {
             int new_count = --(alloc->ref_count);
             if (new_count == 0) {
                 if (buf.dev) {
-                    assert(halide_device_free_weak &&
-                           "Buffer has a device allocation but no Halide Runtime linked");
-                    halide_device_free_weak(nullptr, &buf);
+#ifdef _MSC_VER
+					assert((const void **)(halide_device_free_weak) != &halide_null &&
+						"Buffer has a device allocation but no Halide Runtime linked");
+#else
+					assert(halide_device_free_weak &&
+						"Buffer has a device allocation but no Halide Runtime linked");
+#endif
+					halide_device_free_weak(nullptr, &buf);
                 }
                 void (*fn)(void *) = alloc->deallocate_fn;
                 fn(alloc);

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -168,14 +168,10 @@ class Buffer {
             int new_count = --(alloc->ref_count);
             if (new_count == 0) {
                 if (buf.dev) {
-#ifdef _MSC_VER
-					assert((const void **)(halide_device_free_weak) != &halide_null &&
-						"Buffer has a device allocation but no Halide Runtime linked");
-#else
-					assert(halide_device_free_weak &&
-						"Buffer has a device allocation but no Halide Runtime linked");
-#endif
-					halide_device_free_weak(nullptr, &buf);
+                    halide_device_free_t fn = halide_get_device_free_fn();
+                    assert(fn &&
+                           "Buffer has a device allocation but no Halide Runtime linked");
+                    (*fn)(nullptr, &buf);
                 }
                 void (*fn)(void *) = alloc->deallocate_fn;
                 fn(alloc);

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -168,7 +168,9 @@ class Buffer {
             int new_count = --(alloc->ref_count);
             if (new_count == 0) {
                 if (buf.dev) {
-                    device_free();
+                    assert(halide_device_free_weak &&
+                           "Buffer has a device allocation but no Halide Runtime linked");
+                    halide_device_free_weak(nullptr, &buf);
                 }
                 void (*fn)(void *) = alloc->deallocate_fn;
                 fn(alloc);
@@ -1127,12 +1129,7 @@ public:
     }
 
     int device_free(void *ctx = nullptr) {
-        if (!halide_device_free) {
-            assert(false && "Can't call device_free with no Halide runtime linked in");
-            return -1;
-        } else {
-            return halide_device_free(ctx, &buf);
-        }
+        return halide_device_free(ctx, &buf);
     }
 
     int device_sync(void *ctx = nullptr) {

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -422,7 +422,6 @@ public:
                                    typename std::remove_const<T2>::type>::value ||
                       T_is_void || Buffer<T2, D2>::T_is_void,
                       "type mismatch constructing Buffer");
-
         if (D < D2) {
             assert(other.dimensions() <= D);
         }

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -422,6 +422,7 @@ public:
                                    typename std::remove_const<T2>::type>::value ||
                       T_is_void || Buffer<T2, D2>::T_is_void,
                       "type mismatch constructing Buffer");
+
         if (D < D2) {
             assert(other.dimensions() <= D);
         }
@@ -1127,7 +1128,12 @@ public:
     }
 
     int device_free(void *ctx = nullptr) {
-        return halide_device_free(ctx, &buf);
+        if (!halide_device_free) {
+            assert(false && "Can't call device_free with no Halide runtime linked in");
+            return -1;
+        } else {
+            return halide_device_free(ctx, &buf);
+        }
     }
 
     int device_sync(void *ctx = nullptr) {

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -389,11 +389,14 @@ extern int halide_device_sync(void *user_context, struct buffer_t *buf);
 /** Allocate device memory to back a buffer_t. */
 extern int halide_device_malloc(void *user_context, struct buffer_t *buf, const struct halide_device_interface *device_interface);
 
-/** Free device memory. If no Halide runtime is linked, this symbol
- * will be nullptr rather than a linker error, allowing code to
- * refer to halide_device_free whether or not a runtime has
- * actually been linked in. */
-extern __attribute__((weak)) int halide_device_free(void *user_context, struct buffer_t *buf);
+/** Free device memory. */
+extern int halide_device_free(void *user_context, struct buffer_t *buf);
+
+/* A weak variant of halide_device_free. If no Halide runtime is
+ * linked, this symbol will be nullptr rather than a linker error,
+ * allowing code to refer to halide_device_free_weak whether or not a
+ * runtime has actually been linked in. */
+extern __attribute__((weak)) int halide_device_free_weak(void *user_context, struct buffer_t *buf);
 
 /** Selects which gpu device to use. 0 is usually the display
  * device. If never called, Halide uses the environment variable

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -400,7 +400,7 @@ extern int halide_device_free(void *user_context, struct buffer_t *buf);
 #ifdef _MSC_VER
 extern int halide_device_free_weak(void *user_context, struct buffer_t *buf);
 extern const void *halide_null = nullptr;
-#pragma comment(linker, "/alternatename:_halide_device_free_weak=_halide_null")
+#pragma comment(linker, "/alternatename:halide_device_free_weak=halide_null")
 #else
 extern __attribute__((weak)) int halide_device_free_weak(void *user_context, struct buffer_t *buf);
 #endif

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -395,8 +395,15 @@ extern int halide_device_free(void *user_context, struct buffer_t *buf);
 /* A weak variant of halide_device_free. If no Halide runtime is
  * linked, this symbol will be nullptr rather than a linker error,
  * allowing code to refer to halide_device_free_weak whether or not a
- * runtime has actually been linked in. */
+ * runtime has actually been linked in. This requires a different
+ * mechanism on Windows and other platforms. */
+#ifdef _MSC_VER
+extern int halide_device_free_weak(void *user_context, struct buffer_t *buf);
+extern const void *halide_null = nullptr;
+#pragma comment(linker, "/alternatename:_halide_device_free_weak=_halide_null")
+#else
 extern __attribute__((weak)) int halide_device_free_weak(void *user_context, struct buffer_t *buf);
+#endif
 
 /** Selects which gpu device to use. 0 is usually the display
  * device. If never called, Halide uses the environment variable

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -389,7 +389,11 @@ extern int halide_device_sync(void *user_context, struct buffer_t *buf);
 /** Allocate device memory to back a buffer_t. */
 extern int halide_device_malloc(void *user_context, struct buffer_t *buf, const struct halide_device_interface *device_interface);
 
-extern int halide_device_free(void *user_context, struct buffer_t *buf);
+/** Free device memory. If no Halide runtime is linked, this symbol
+ * will be nullptr rather than a linker error, allowing code to
+ * refer to halide_device_free whether or not a runtime has
+ * actually been linked in. */
+extern __attribute__((weak)) int halide_device_free(void *user_context, struct buffer_t *buf);
 
 /** Selects which gpu device to use. 0 is usually the display
  * device. If never called, Halide uses the environment variable

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -392,17 +392,29 @@ extern int halide_device_malloc(void *user_context, struct buffer_t *buf, const 
 /** Free device memory. */
 extern int halide_device_free(void *user_context, struct buffer_t *buf);
 
-/* A weak variant of halide_device_free. If no Halide runtime is
- * linked, this symbol will be nullptr rather than a linker error,
- * allowing code to refer to halide_device_free_weak whether or not a
- * runtime has actually been linked in. This requires a different
- * mechanism on Windows and other platforms. */
-#ifdef _MSC_VER
-extern int halide_device_free_weak(void *user_context, struct buffer_t *buf);
-extern const void *halide_null = nullptr;
-#pragma comment(linker, "/alternatename:halide_device_free_weak=halide_null")
+/** Get a pointer to halide_device_free if a Halide runtime has been
+ * linked in. Returns null if it has not. This requires a different
+ * mechanism on different platforms. */
+typedef int (*halide_device_free_t)(void *, struct buffer_t *);
+#ifdef MSC_VER
+extern const void *halide_dummy_device_free = nullptr;
+extern int halide_weak_device_free(void *user_context, struct buffer_t *buf);
+// The following pragma tells the windows linker to make
+// halide_device_free_weak the same symbol as halide_dummy_device_free
+// if it can't resolve halide_weak_device_free normally
+#pragma comment(linker, "/alternatename:halide_weak_device_free=halide_dummy_device_free")
+inline halide_device_free_t halide_get_device_free_fn() {
+    if ((const void **)(&halide_device_free_weak) == &halide_dummy_device_free) {
+        return nullptr;
+    } else {
+        return &halide_weak_device_free;
+    }
+};
 #else
-extern __attribute__((weak)) int halide_device_free_weak(void *user_context, struct buffer_t *buf);
+extern __attribute__((weak)) int halide_weak_device_free(void *user_context, struct buffer_t *buf);
+inline halide_device_free_t halide_get_device_free_fn() {
+    return &halide_weak_device_free;
+}
 #endif
 
 /** Selects which gpu device to use. 0 is usually the display

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -396,7 +396,7 @@ extern int halide_device_free(void *user_context, struct buffer_t *buf);
  * linked in. Returns null if it has not. This requires a different
  * mechanism on different platforms. */
 typedef int (*halide_device_free_t)(void *, struct buffer_t *);
-#ifdef MSC_VER
+#ifdef _MSC_VER
 extern const void *halide_dummy_device_free = nullptr;
 extern int halide_weak_device_free(void *user_context, struct buffer_t *buf);
 // The following pragma tells the windows linker to make
@@ -404,7 +404,7 @@ extern int halide_weak_device_free(void *user_context, struct buffer_t *buf);
 // if it can't resolve halide_weak_device_free normally
 #pragma comment(linker, "/alternatename:halide_weak_device_free=halide_dummy_device_free")
 inline halide_device_free_t halide_get_device_free_fn() {
-    if ((const void **)(&halide_device_free_weak) == &halide_dummy_device_free) {
+    if ((const void **)(&halide_weak_device_free) == &halide_dummy_device_free) {
         return nullptr;
     } else {
         return &halide_weak_device_free;

--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -257,7 +257,7 @@ WEAK int halide_device_free(void *user_context, struct buffer_t *buf) {
     return 0;
 }
 
-WEAK int halide_device_free_weak(void *user_context, struct buffer_t *buf) {
+WEAK int halide_weak_device_free(void *user_context, struct buffer_t *buf) {
     return halide_device_free(user_context, buf);
 }
 

--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -257,6 +257,10 @@ WEAK int halide_device_free(void *user_context, struct buffer_t *buf) {
     return 0;
 }
 
+WEAK int halide_device_free_weak(void *user_context, struct buffer_t *buf) {
+    return halide_device_free(user_context, buf);
+}
+
 /** Free any device memory associated with a buffer_t and ignore any
  * error. Used when freeing as a destructor on an error. */
 WEAK void halide_device_free_as_destructor(void *user_context, void *obj) {


### PR DESCRIPTION
using the magic of extern_weak, symbols become null rather than
undefined references