### PR TITLE
Fix windows stack size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,6 @@ function(halide_project name folder)
   target_include_directories("${name}" PRIVATE "${CMAKE_SOURCE_DIR}/tools")
   set_target_properties("${name}" PROPERTIES FOLDER "${folder}")
   if (MSVC)
-    set_target_properties("${name}" PROPERTIES LINK_FLAGS "/STACK:8388608,1048576")
     # 4006: "already defined, second definition ignored"
     # 4088: "/FORCE used, image may not work"
     # (Note that MSVC apparently considers 4088 too important to allow us to ignore it;

--- a/src/Util.h
+++ b/src/Util.h
@@ -41,6 +41,11 @@
 #endif
 #endif
 
+// On windows, Halide needs a larger stack than the default MSVC provides
+#ifdef _MSC_VER
+#pragma comment(linker, "/STACK:8388608,1048576")
+#endif
+
 namespace Halide {
 namespace Internal {
 


### PR DESCRIPTION
Our stack size flag was lost at some point resulting in stack overflows
on windows. Given that this is also a frequent user question, it seems
better to force the linker flag on inside something that ends up in
Halide.h