### PR TITLE
Have simd_op_check wildcard_match also ignore spaces in patterns or strings

### DIFF
--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -78,6 +78,16 @@ bool wildcard_match(const char* p, const char* str) {
                 return true;
             }
         } while(*str++);
+    } else if (*p == ' ') {     // ignore whitespace in pattern
+        p++;
+        if (wildcard_match(p, str)) {
+            return true;
+        }
+    } else if (*str == ' ') {   // ignore whitespace in string
+        str++;
+        if (wildcard_match(p, str)) {
+            return true;
+        }
     }
     return !*p;
 }


### PR DESCRIPTION

This is needed to generated code patterns such as:

     check("v*.ub = vpack(v*.h,v*.h):sat", hvx_width/1, u8_sat(i16_1));

The upcoming LLVM Hexagon 8.1 release assembly generation has removed
spaces around assignments.  This change allows simd_opt_check to correctly
work when run against 8.0, 8.1, or llvm.org tip (which is closest to 8.0
at the moment but will soon be picking up 8.1 functionality).