### PR TITLE
Func value assignment should check for RVar

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2240,7 +2240,8 @@ Stage FuncRef::operator=(Expr e) {
 Stage FuncRef::operator=(const Tuple &e) {
     if (!func.has_pure_definition()) {
         for (size_t i = 0; i < args.size(); ++i) {
-            user_assert(args[i].as<Variable>())
+            const Variable *var = args[i].as<Variable>();
+            user_assert((var != nullptr) && (!var->reduction_domain.defined()))
                 << "Argument " << (i+1) << " in initial definition of \""
                 << func.name() << "\" is not a Var.\n";
         }

--- a/test/error/init_def_should_be_all_vars.cpp
+++ b/test/error/init_def_should_be_all_vars.cpp
@@ -1,0 +1,15 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Image<int> in(10, 10);
+
+    Func f("f");
+    RDom r(0, in.width(), 0, in.height());
+    f(r.x, r.y) = in(r.x, r.y) + 2;
+    f.realize(in.width(), in.height());
+
+    return 0;
+}


### PR DESCRIPTION
The previous Func value assignment only checked for whether the args are all variables, but it didn't check if the variables refer to RVar or not. 