### PR TITLE
Vmpa for hvx

### DIFF
--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -112,16 +112,16 @@ struct Pattern {
         ExactLog2Op1 = 1 << 3, // Replace operand 1 with its log base 2, if the log base 2 is exact.
         ExactLog2Op2 = 1 << 4, // Save as above, but for operand 2.
 
-        FirstExactLog2Op = 1,   // FirstExactLog2Op and NumExactLog2Op ensure that we check only op1 and op2
-        NumExactLog2Op = 2,     // for ExactLog2Op
+        BeginExactLog2Op = 1,   // BeginExactLog2Op and EndExactLog2Op ensure that we check only op1 and op2
+        EndExactLog2Op = 3,     // for ExactLog2Op
 
         DeinterleaveOp0 = 1 << 5,  // Prior to evaluating the pattern, deinterleave native vectors of operand 0.
         DeinterleaveOp1 = 1 << 6,  // Same as above, but for operand 1.
         DeinterleaveOp2 = 1 << 7,
         DeinterleaveOps = DeinterleaveOp0 | DeinterleaveOp1 | DeinterleaveOp2,
 
-        FirstDeinterleaveOp = 0, // FirstDeinterleaveOp and NumDeinterleaveOp ensure that we check only three
-        NumDeinterleaveOp = 3,   // bits of the flag from DeinterleaveOp0 onwards and apply that only to the first three operands.
+        BeginDeinterleaveOp = 0, // BeginDeinterleaveOp and EndDeinterleaveOp ensure that we check only three
+        EndDeinterleaveOp = 3,   // deinterleave Op0, 1 and 2.
         // Many patterns are instructions that widen only
         // operand 0, which need to both deinterleave operand 0, and then
         // re-interleave the result.
@@ -192,12 +192,11 @@ Expr apply_patterns(Expr x, const vector<Pattern> &patterns, IRMutator *op_mutat
             }
             if (!is_match) continue;
 
-            for (size_t i = Pattern::FirstExactLog2Op;
-                 i < (Pattern::FirstExactLog2Op + Pattern::NumExactLog2Op) && is_match; i++) {
+            for (size_t i = Pattern::BeginExactLog2Op; i < Pattern::EndExactLog2Op && is_match; i++) {
                 // This flag is mainly to capture shifts. When the
                 // operand of a div or mul is a power of 2, we can use
                 // a shift instead.
-                if (p.flags & (Pattern::ExactLog2Op1 << (i - Pattern::FirstExactLog2Op))) {
+                if (p.flags & (Pattern::ExactLog2Op1 << (i - Pattern::BeginExactLog2Op))) {
                     int pow;
                     if (is_const_power_of_two_integer(matches[i], &pow)) {
                         matches[i] = cast(matches[i].type().with_lanes(1), pow);
@@ -208,10 +207,9 @@ Expr apply_patterns(Expr x, const vector<Pattern> &patterns, IRMutator *op_mutat
             }
             if (!is_match) continue;
 
-            for (size_t i = Pattern::FirstDeinterleaveOp;
-                 i < (Pattern::FirstDeinterleaveOp + Pattern::NumDeinterleaveOp); i++) {
+            for (size_t i = Pattern::BeginDeinterleaveOp; i < Pattern::EndDeinterleaveOp; i++) {
                 if (p.flags &
-                    (Pattern::DeinterleaveOp0 << (i - Pattern::FirstDeinterleaveOp))) {
+                    (Pattern::DeinterleaveOp0 << (i - Pattern::BeginDeinterleaveOp))) {
                     internal_assert(matches[i].type().is_vector());
                     matches[i] = native_deinterleave(matches[i]);
                 }
@@ -277,45 +275,10 @@ Expr apply_commutative_patterns(const T *op, const vector<Pattern> &patterns, IR
 class OptimizePatterns : public IRMutator {
 private:
     using IRMutator::visit;
-
-    string get_suffix(vector<Expr> exprs) {
-        string type_suffix;
-        for (Expr e : exprs) {
-            Type t = e.type();
-            type_suffix = type_suffix + (t.is_vector() ? ".v" : ".");
-            if (t.is_int()) {
-                switch(t.bits()) {
-                case 8:
-                    type_suffix = type_suffix + "b";
-                    break;
-                case 16:
-                    type_suffix = type_suffix + "h";
-                    break;
-                case 32:
-                    type_suffix = type_suffix + "w";
-                    break;
-                }
-            } else {
-                switch(t.bits()) {
-                case 8:
-                    type_suffix = type_suffix + "ub";
-                    break;
-                case 16:
-                    type_suffix = type_suffix + "uh";
-                    break;
-                case 32:
-                    type_suffix = type_suffix + "uw";
-                    break;
-                }
-            }
-        }
-        return type_suffix;
-    }
-
-    Expr halide_hexagon_add_mpy_mpy(Expr v0, Expr v1, Expr c0, Expr c1) {
+    Expr halide_hexagon_add_mpy_mpy(Expr v0, Expr v1, Expr c0, Expr c1, string suffix) {
         Type t = v0.type();
         Type result_type = Int(t.bits()*2).with_lanes(t.lanes());
-        Expr call = Call::make(result_type, "halide.hexagon.add_mpy_mpy" + get_suffix({ v0, v1, c0, c1 }), {v0, v1, c0, c1}, Call::PureExtern);
+        Expr call = Call::make(result_type, "halide.hexagon.add_mpy_mpy" + suffix, {v0, v1, c0, c1}, Call::PureExtern);
         return native_interleave(call);
     }
 
@@ -448,8 +411,9 @@ private:
             const Add *add = old_expr.as<Add>();
             if (add) {
                 static vector<Pattern> post_process_adds = {
-                    { "halide.hexagon.acc_add_mpy_mpy.vh.vub.vub.b.b", wild_i16x + halide_hexagon_add_mpy_mpy(wild_u8x, wild_u8x, wild_i8, wild_i8), Pattern::ReinterleaveOp0 },
-            };
+                    { "halide.hexagon.acc_add_mpy_mpy.vh.vub.vub.b.b",
+                      wild_i16x + halide_hexagon_add_mpy_mpy(wild_u8x, wild_u8x, wild_i8, wild_i8,".vub.vub.b.b"), Pattern::ReinterleaveOp0 },
+                };
                 Expr res = apply_commutative_patterns(add, post_process_adds, this);
                 if (!res.same_as(add)) {
                     debug(4) << "Converted " << old_expr << "\n\t to \t\n" << res << "\n";

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -112,11 +112,16 @@ struct Pattern {
         ExactLog2Op1 = 1 << 3, // Replace operand 1 with its log base 2, if the log base 2 is exact.
         ExactLog2Op2 = 1 << 4, // Save as above, but for operand 2.
 
+        FirstExactLog2Op = 1,   // FirstExactLog2Op and NumExactLog2Op ensure that we check only op1 and op2
+        NumExactLog2Op = 2,     // for ExactLog2Op
+
         DeinterleaveOp0 = 1 << 5,  // Prior to evaluating the pattern, deinterleave native vectors of operand 0.
         DeinterleaveOp1 = 1 << 6,  // Same as above, but for operand 1.
         DeinterleaveOp2 = 1 << 7,
         DeinterleaveOps = DeinterleaveOp0 | DeinterleaveOp1 | DeinterleaveOp2,
 
+        FirstDeinterleaveOp = 0, // FirstDeinterleaveOp and NumDeinterleaveOp ensure that we check only three
+        NumDeinterleaveOp = 3,   // bits of the flag from DeinterleaveOp0 onwards and apply that only to the first three operands.
         // Many patterns are instructions that widen only
         // operand 0, which need to both deinterleave operand 0, and then
         // re-interleave the result.
@@ -187,11 +192,12 @@ Expr apply_patterns(Expr x, const vector<Pattern> &patterns, IRMutator *op_mutat
             }
             if (!is_match) continue;
 
-            for (size_t i = 1; i < matches.size() && is_match; i++) {
+            for (size_t i = Pattern::FirstExactLog2Op;
+                 i < (Pattern::FirstExactLog2Op + Pattern::NumExactLog2Op) && is_match; i++) {
                 // This flag is mainly to capture shifts. When the
                 // operand of a div or mul is a power of 2, we can use
                 // a shift instead.
-                if (p.flags & (Pattern::ExactLog2Op1 << (i - 1))) {
+                if (p.flags & (Pattern::ExactLog2Op1 << (i - Pattern::FirstExactLog2Op))) {
                     int pow;
                     if (is_const_power_of_two_integer(matches[i], &pow)) {
                         matches[i] = cast(matches[i].type().with_lanes(1), pow);
@@ -202,8 +208,10 @@ Expr apply_patterns(Expr x, const vector<Pattern> &patterns, IRMutator *op_mutat
             }
             if (!is_match) continue;
 
-            for (size_t i = 0; i < matches.size(); i++) {
-                if (p.flags & (Pattern::DeinterleaveOp0 << i)) {
+            for (size_t i = Pattern::FirstDeinterleaveOp;
+                 i < (Pattern::FirstDeinterleaveOp + Pattern::NumDeinterleaveOp); i++) {
+                if (p.flags &
+                    (Pattern::DeinterleaveOp0 << (i - Pattern::FirstDeinterleaveOp))) {
                     internal_assert(matches[i].type().is_vector());
                     matches[i] = native_deinterleave(matches[i]);
                 }
@@ -269,6 +277,47 @@ Expr apply_commutative_patterns(const T *op, const vector<Pattern> &patterns, IR
 class OptimizePatterns : public IRMutator {
 private:
     using IRMutator::visit;
+
+    string get_suffix(vector<Expr> exprs) {
+        string type_suffix;
+        for (Expr e : exprs) {
+            Type t = e.type();
+            type_suffix = type_suffix + (t.is_vector() ? ".v" : ".");
+            if (t.is_int()) {
+                switch(t.bits()) {
+                case 8:
+                    type_suffix = type_suffix + "b";
+                    break;
+                case 16:
+                    type_suffix = type_suffix + "h";
+                    break;
+                case 32:
+                    type_suffix = type_suffix + "w";
+                    break;
+                }
+            } else {
+                switch(t.bits()) {
+                case 8:
+                    type_suffix = type_suffix + "ub";
+                    break;
+                case 16:
+                    type_suffix = type_suffix + "uh";
+                    break;
+                case 32:
+                    type_suffix = type_suffix + "uw";
+                    break;
+                }
+            }
+        }
+        return type_suffix;
+    }
+
+    Expr halide_hexagon_add_mpy_mpy(Expr v0, Expr v1, Expr c0, Expr c1) {
+        Type t = v0.type();
+        Type result_type = Int(t.bits()*2).with_lanes(t.lanes());
+        Expr call = Call::make(result_type, "halide.hexagon.add_mpy_mpy" + get_suffix({ v0, v1, c0, c1 }), {v0, v1, c0, c1}, Call::PureExtern);
+        return native_interleave(call);
+    }
 
     void visit(const Mul *op) {
         static vector<Pattern> scalar_muls = {
@@ -392,6 +441,22 @@ private:
             if (!expr.same_as(op)) return;
         }
         IRMutator::visit(op);
+        if (op->type.is_vector() && !expr.same_as(op)) {
+            // We may have created a vmpa out of op->a or op->b.
+            // Be greedy and see we if can create a vmpa_acc
+            Expr old_expr = expr;
+            const Add *add = old_expr.as<Add>();
+            if (add) {
+                static vector<Pattern> post_process_adds = {
+                    { "halide.hexagon.acc_add_mpy_mpy.vh.vub.vub.b.b", wild_i16x + halide_hexagon_add_mpy_mpy(wild_u8x, wild_u8x, wild_i8, wild_i8), Pattern::ReinterleaveOp0 },
+            };
+                Expr res = apply_commutative_patterns(add, post_process_adds, this);
+                if (!res.same_as(add)) {
+                    debug(4) << "Converted " << old_expr << "\n\t to \t\n" << res << "\n";
+                    expr = res;
+                }
+            }
+        }
     }
 
     void visit(const Sub *op) {

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -125,7 +125,8 @@ struct Pattern {
         NarrowOp0 = 1 << 10,  // Replace operand 0 with its half-width equivalent.
         NarrowOp1 = 1 << 11,  // Same as above, but for operand 1.
         NarrowOp2 = 1 << 12,
-        NarrowOps = NarrowOp0 | NarrowOp1 | NarrowOp2,
+        NarrowOp3 = 1 << 13,
+        NarrowOps = NarrowOp0 | NarrowOp1 | NarrowOp2 | NarrowOp3,
 
         NarrowUnsignedOp0 = 1 << 15,  // Similar to the above, but narrow to an unsigned half width type.
         NarrowUnsignedOp1 = 1 << 16,
@@ -334,6 +335,9 @@ private:
             { "halide.hexagon.add_vh.vub.vub", wild_i16x + wild_i16x, Pattern::InterleaveResult | Pattern::NarrowUnsignedOp0 | Pattern::NarrowUnsignedOp1 },
             { "halide.hexagon.add_vw.vuh.vuh", wild_i32x + wild_i32x, Pattern::InterleaveResult | Pattern::NarrowUnsignedOp0 | Pattern::NarrowUnsignedOp1 },
             { "halide.hexagon.add_vw.vh.vh", wild_i32x + wild_i32x, Pattern::InterleaveResult | Pattern::NarrowOps },
+
+            // Generate vmpa(Vx.ub, Rx.b). Todo: Generate vmpa(Vx.h, Rx.b)
+            { "halide.hexagon.add_mpy_mpy.vub.vub.b.b", wild_i16x*bc(wild_i16) + wild_i16x*bc(wild_i16), Pattern::InterleaveResult | Pattern::NarrowUnsignedOp0 | Pattern::NarrowUnsignedOp2 | Pattern::NarrowOp1 | Pattern::NarrowOp3 | Pattern::SwapOps12 },
 
             // Widening multiply-accumulates with a scalar.
             { "halide.hexagon.add_mpy.vuh.vub.ub", wild_u16x + wild_u16x*bc(wild_u16), Pattern::ReinterleaveOp0 | Pattern::NarrowOp1 | Pattern::NarrowOp2 },

--- a/src/runtime/hvx_128.ll
+++ b/src/runtime/hvx_128.ll
@@ -298,6 +298,7 @@ define weak_odr <128 x i8> @halide.hexagon.shr.vb.vb(<128 x i8> %a, <128 x i8> %
 }
 
 declare <64 x i32> @llvm.hexagon.V6.vmpabus.128B(<64 x i32>, i32)
+declare <64 x i32> @llvm.hexagon.V6.vmpabus.acc.128B(<64 x i32>, <64 x i32>, i32)
 
 define weak_odr <128 x i16> @halide.hexagon.add_mpy_mpy.vub.vub.b.b(<128 x i8> %low_v, <128 x i8> %high_v, i8 %low_c, i8 %high_c) nounwind uwtable readnone {
   %const = call i32 @halide.hexagon.interleave.b.dup2.h(i8 %low_c, i8 %high_c)
@@ -305,6 +306,17 @@ define weak_odr <128 x i16> @halide.hexagon.add_mpy_mpy.vub.vub.b.b(<128 x i8> %
   %high = bitcast <128 x i8> %high_v to <32 x i32>
   %dv = call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %high, <32 x i32> %low)
   %res = call <64 x i32> @llvm.hexagon.V6.vmpabus.128B(<64 x i32> %dv, i32 %const)
+  %ret_val = bitcast <64 x i32> %res to <128 x i16>
+  ret <128 x i16> %ret_val
+}
+
+define weak_odr <128 x i16> @halide.hexagon.acc_add_mpy_mpy.vh.vub.vub.b.b(<128 x i16> %acc, <128 x i8> %low_v, <128 x i8> %high_v, i8 %low_c, i8 %high_c) nounwind uwtable readnone {
+  %dv0 = bitcast <128 x i16> %acc to <64 x i32>
+  %const = call i32 @halide.hexagon.interleave.b.dup2.h(i8 %low_c, i8 %high_c)
+  %low = bitcast <128 x i8> %low_v to <32 x i32>
+  %high = bitcast <128 x i8> %high_v to <32 x i32>
+  %dv1 = call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %high, <32 x i32> %low)
+  %res = call <64 x i32> @llvm.hexagon.V6.vmpabus.acc.128B(<64 x i32> %dv0, <64 x i32> %dv1, i32 %const)
   %ret_val = bitcast <64 x i32> %res to <128 x i16>
   ret <128 x i16> %ret_val
 }

--- a/src/runtime/hvx_128.ll
+++ b/src/runtime/hvx_128.ll
@@ -82,6 +82,15 @@ define weak_odr i32 @halide.hexagon.dup4.b(i8 %arg) nounwind uwtable readnone al
   ret i32 %dup4
 }
 
+define weak_odr i32 @halide.hexagon.interleave.b.dup2.h(i8 %low, i8 %high) nounwind uwtable readnone alwaysinline {
+  %high_i16 = zext i8 %high to i16
+  %high_i16_s = shl i16 %high_i16, 8
+  %low_i16 = zext i8 %low to i16
+  %i16_const = or i16 %high_i16_s, %low_i16
+  %r = call i32 @halide.hexagon.dup2.h(i16 %i16_const)
+  ret i32 %r
+}
+
 define weak_odr <128 x i8> @halide.hexagon.splat.b(i8 %arg) nounwind uwtable readnone alwaysinline {
   %dup4 = call i32 @halide.hexagon.dup4.b(i8 %arg)
   %r_32 = tail call <32 x i32> @llvm.hexagon.V6.lvsplatw.128B(i32 %dup4)
@@ -288,3 +297,14 @@ define weak_odr <128 x i8> @halide.hexagon.shr.vb.vb(<128 x i8> %a, <128 x i8> %
   ret <128 x i8> %r
 }
 
+declare <64 x i32> @llvm.hexagon.V6.vmpabus.128B(<64 x i32>, i32)
+
+define weak_odr <128 x i16> @halide.hexagon.add_mpy_mpy.vub.vub.b.b(<128 x i8> %low_v, <128 x i8> %high_v, i8 %low_c, i8 %high_c) nounwind uwtable readnone {
+  %const = call i32 @halide.hexagon.interleave.b.dup2.h(i8 %low_c, i8 %high_c)
+  %low = bitcast <128 x i8> %low_v to <32 x i32>
+  %high = bitcast <128 x i8> %high_v to <32 x i32>
+  %dv = call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %high, <32 x i32> %low)
+  %res = call <64 x i32> @llvm.hexagon.V6.vmpabus.128B(<64 x i32> %dv, i32 %const)
+  %ret_val = bitcast <64 x i32> %res to <128 x i16>
+  ret <128 x i16> %ret_val
+}

--- a/src/runtime/hvx_64.ll
+++ b/src/runtime/hvx_64.ll
@@ -298,6 +298,7 @@ define weak_odr <64 x i8> @halide.hexagon.shr.vb.vb(<64 x i8> %a, <64 x i8> %b) 
 }
 
 declare <32 x i32> @llvm.hexagon.V6.vmpabus(<32 x i32>, i32)
+declare <32 x i32> @llvm.hexagon.V6.vmpabus.acc(<32 x i32>, <32 x i32>, i32)
 
 define weak_odr <64 x i16> @halide.hexagon.add_mpy_mpy.vub.vub.b.b(<64 x i8> %low_v, <64 x i8> %high_v, i8 %low_c, i8 %high_c) nounwind uwtable readnone {
   %const = call i32 @halide.hexagon.interleave.b.dup2.h(i8 %low_c, i8 %high_c)
@@ -305,6 +306,17 @@ define weak_odr <64 x i16> @halide.hexagon.add_mpy_mpy.vub.vub.b.b(<64 x i8> %lo
   %high = bitcast <64 x i8> %high_v to <16 x i32>
   %dv = call <32 x i32> @llvm.hexagon.V6.vcombine(<16 x i32> %high, <16 x i32> %low)
   %res = call <32 x i32> @llvm.hexagon.V6.vmpabus(<32 x i32> %dv, i32 %const)
+  %ret_val = bitcast <32 x i32> %res to <64 x i16>
+  ret <64 x i16> %ret_val
+}
+
+define weak_odr <64 x i16> @halide.hexagon.acc_add_mpy_mpy.vh.vub.vub.b.b(<64 x i16> %acc, <64 x i8> %low_v, <64 x i8> %high_v, i8 %low_c, i8 %high_c) nounwind uwtable readnone {
+  %dv0 = bitcast <64 x i16> %acc to <32 x i32>
+  %const = call i32 @halide.hexagon.interleave.b.dup2.h(i8 %low_c, i8 %high_c)
+  %low = bitcast <64 x i8> %low_v to <16 x i32>
+  %high = bitcast <64 x i8> %high_v to <16 x i32>
+  %dv1 = call <32 x i32> @llvm.hexagon.V6.vcombine(<16 x i32> %high, <16 x i32> %low)
+  %res = call <32 x i32> @llvm.hexagon.V6.vmpabus.acc(<32 x i32> %dv0, <32 x i32> %dv1, i32 %const)
   %ret_val = bitcast <32 x i32> %res to <64 x i16>
   ret <64 x i16> %ret_val
 }

--- a/src/runtime/hvx_64.ll
+++ b/src/runtime/hvx_64.ll
@@ -82,6 +82,15 @@ define weak_odr i32 @halide.hexagon.dup4.b(i8 %arg) nounwind uwtable readnone al
   ret i32 %dup4
 }
 
+define weak_odr i32 @halide.hexagon.interleave.b.dup2.h(i8 %low, i8 %high) nounwind uwtable readnone alwaysinline {
+  %high_i16 = zext i8 %high to i16
+  %high_i16_s = shl i16 %high_i16, 8
+  %low_i16 = zext i8 %low to i16
+  %i16_const = or i16 %high_i16_s, %low_i16
+  %r = call i32 @halide.hexagon.dup2.h(i16 %i16_const)
+  ret i32 %r
+}
+
 define weak_odr <64 x i8> @halide.hexagon.splat.b(i8 %arg) nounwind uwtable readnone alwaysinline {
   %dup4 = call i32 @halide.hexagon.dup4.b(i8 %arg)
   %r_32 = tail call <16 x i32> @llvm.hexagon.V6.lvsplatw(i32 %dup4)
@@ -288,3 +297,14 @@ define weak_odr <64 x i8> @halide.hexagon.shr.vb.vb(<64 x i8> %a, <64 x i8> %b) 
   ret <64 x i8> %r
 }
 
+declare <32 x i32> @llvm.hexagon.V6.vmpabus(<32 x i32>, i32)
+
+define weak_odr <64 x i16> @halide.hexagon.add_mpy_mpy.vub.vub.b.b(<64 x i8> %low_v, <64 x i8> %high_v, i8 %low_c, i8 %high_c) nounwind uwtable readnone {
+  %const = call i32 @halide.hexagon.interleave.b.dup2.h(i8 %low_c, i8 %high_c)
+  %low = bitcast <64 x i8> %low_v to <16 x i32>
+  %high = bitcast <64 x i8> %high_v to <16 x i32>
+  %dv = call <32 x i32> @llvm.hexagon.V6.vcombine(<16 x i32> %high, <16 x i32> %low)
+  %res = call <32 x i32> @llvm.hexagon.V6.vmpabus(<32 x i32> %dv, i32 %const)
+  %ret_val = bitcast <32 x i32> %res to <64 x i16>
+  ret <64 x i16> %ret_val
+}

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1688,6 +1688,7 @@ void check_hvx_all() {
     check("vmpa(v*.ub,r*.b)", hvx_width/1, i16(u8_1)*2 + i16(u8_2)*3);
     check("vmpa(v*.ub,r*.b)", hvx_width/1, i16(u8_1)*2 + 3*i16(u8_2));
     check("vmpa(v*.ub,r*.b)", hvx_width/1, 2*i16(u8_1) + 3*i16(u8_2));
+    check("v*.h += vmpa(v*.ub,r*.b)", hvx_width/1, 2*i16(u8_1) + 3*i16(u8_2) + i16(u8_3));
 
     check("vmpy(v*.ub,v*.ub)", hvx_width/1, u16(u8_1) * u16(u8_2));
     check("vmpy(v*.b,v*.b)", hvx_width/1, i16(i8_1) * i16(i8_2));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1685,6 +1685,10 @@ void check_hvx_all() {
     check("vabs(v*.h)", hvx_width/2, abs(i16_1));
     check("vabs(v*.w)", hvx_width/4, abs(i32_1));
 
+    check("vmpa(v*.ub,r*.b)", hvx_width/1, i16(u8_1)*2 + i16(u8_2)*3);
+    check("vmpa(v*.ub,r*.b)", hvx_width/1, i16(u8_1)*2 + 3*i16(u8_2));
+    check("vmpa(v*.ub,r*.b)", hvx_width/1, 2*i16(u8_1) + 3*i16(u8_2));
+
     check("vmpy(v*.ub,v*.ub)", hvx_width/1, u16(u8_1) * u16(u8_2));
     check("vmpy(v*.b,v*.b)", hvx_width/1, i16(i8_1) * i16(i8_2));
     check("vmpy(v*.uh,v*.uh)", hvx_width/2, u32(u16_1) * u32(u16_2));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1688,7 +1688,7 @@ void check_hvx_all() {
     check("vmpa(v*.ub,r*.b)", hvx_width/1, i16(u8_1)*2 + i16(u8_2)*3);
     check("vmpa(v*.ub,r*.b)", hvx_width/1, i16(u8_1)*2 + 3*i16(u8_2));
     check("vmpa(v*.ub,r*.b)", hvx_width/1, 2*i16(u8_1) + 3*i16(u8_2));
-    check("v*.h += vmpa(v*.ub,r*.b)", hvx_width/1, 2*i16(u8_1) + 3*i16(u8_2) + i16(u8_3));
+    check("v*.h += vmpa(v*.ub,r*.b)", hvx_width/1, 2*i16(u8_1) + 3*i16(u8_2) + i16_1);
 
     check("vmpy(v*.ub,v*.ub)", hvx_width/1, u16(u8_1) * u16(u8_2));
     check("vmpy(v*.b,v*.b)", hvx_width/1, i16(i8_1) * i16(i8_2));


### PR DESCRIPTION
This patch adds the ability to generate vmpa instructions. So, for the following

3 * vector0 + 4 * vector1

we generate
vmpa(vcombine(vector0, vector1), 0x34343434)

@dsharletg, @ronlieb, @dpalermo : PTAL