### PR TITLE
Fix HelloAndroid MIPS build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /apps/*/bin
 /apps/HelloMatlab/blurred.png
 /apps/HelloMatlab/iir_blur.mex
-/apps/HelloAndroid/jni/halide.h
 bazel-bin
 bazel-genfiles
 bazel-Halide
@@ -75,12 +74,8 @@ apps/*/*.sass
 apps/*/filter
 apps/seam_carving/seam_carving.h
 apps/snake/halide_snake
-apps/HelloAndroid*/bin
 apps/HelloAndroid*/gen
-apps/HelloAndroid*/obj
-apps/HelloAndroid*/libs
 apps/HelloAndroidGL/jni/halide_gl_filter.h
-apps/HelloAndroid*/local.properties
 apps/HelloAndroid*/proguard-project.txt
 
 # tutorial intermediates

--- a/apps/HelloAndroid/.gitignore
+++ b/apps/HelloAndroid/.gitignore
@@ -3,9 +3,7 @@
 /.idea/workspace.xml
 /.idea/libraries
 .DS_Store
-/build
 /captures
-/jni/halide_generated**
 
 # Eclipse
 .classpath

--- a/apps/HelloAndroid/.gitignore
+++ b/apps/HelloAndroid/.gitignore
@@ -12,3 +12,8 @@
 .project
 project.properties
 /.settings
+
+# AndroidStudio
+build/**
+obj/**
+HelloAndroid.iml

--- a/apps/HelloAndroid/build.gradle
+++ b/apps/HelloAndroid/build.gradle
@@ -49,12 +49,13 @@ executables {
     halide_generator {
         binaries.all {
             cppCompiler.args "-std=c++11", "-g", "-Wall", "-fno-rtti", "-I", "${projectDir}/../../include", "-I", "${projectDir}/../../build/include"
-            linker.args "-lHalide", "-ldl", "-lpthread", "-lz", "-L", "${projectDir}/../../bin", "-L", "${projectDir}/../../build/lib"
+            linker.args "-lHalide", "-ldl", "-lpthread", "-lz", "-L", "${projectDir}/../../bin"
         }
     }
 }
 
 binaries.withType(NativeExecutableBinary) { binary ->
+    def bin = "${projectDir}/bin"
     def jnis = "${projectDir}/jni"
     def halideRoot = "${projectDir}/../../"
     def linkTask = binary.tasks.link
@@ -73,7 +74,7 @@ binaries.withType(NativeExecutableBinary) { binary ->
         def android_abi = arch.key
         def hl_target = arch.value
         def task_name = "generate_halide_binary_${binary.name.capitalize()}_${android_abi}"
-        def destDir = new File(jnis, "/halide_generated_${android_abi}")
+        def destDir = new File(bin, "/halide_generated_${android_abi}")
         def generateHalideTask = task(task_name) {
             dependsOn linkTask
             doFirst {

--- a/apps/HelloAndroid/build.sh
+++ b/apps/HelloAndroid/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
-android update project -p . --target android-17
-cd jni
-c++ halide.cpp -g -Wall -std=c++11 -L ../../../bin -L ../../../build/lib -lHalide -I ../../../include -I ../../../build/include -ldl -lpthread -lz
+mkdir -p bin
+# android update project -p . --target android-17
+c++ jni/halide.cpp -g -Wall -std=c++11 -L ../../bin -lHalide -I ../../include -I ../../build/include -ldl -lpthread -lz -o bin/a.out
 
 # 64-bit MIPS (mips-64-android,mips64) currently does not build since
 # llvm will not compile for the R6 version of the ISA without Nan2008
@@ -13,16 +13,15 @@ for archs in arm-32-android,armeabi arm-32-android-armv7s,armeabi-v7a arm-64-and
     set $archs
     hl_target=$1
     android_abi=$2
-    mkdir -p halide_generated_$android_abi
-    cd halide_generated_$android_abi
+    mkdir -p bin/halide_generated_$android_abi
+    cd bin/halide_generated_$android_abi
     HL_TARGET=$hl_target DYLD_LIBRARY_PATH=../../../../bin LD_LIBRARY_PATH=../../../../bin ../a.out
-    cd ..
+    cd ../..
     unset IFS
 done
 
-cd ..
 pwd
-ndk-build # NDK_LOG=1
+ndk-build NDK_GEN_OUT=./bin/gen NDK_LIBS_OUT=./bin/lib NDK_OUT=./bin/obj
 ant debug
 adb install -r bin/HelloAndroid-debug.apk
 adb logcat

--- a/apps/HelloAndroid/jni/Android.mk
+++ b/apps/HelloAndroid/jni/Android.mk
@@ -5,10 +5,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE    := native
 LOCAL_ARM_MODE  := arm
 LOCAL_SRC_FILES := native.cpp
-LOCAL_LDFLAGS   := -Ljni
-LOCAL_LDLIBS    := -lm -llog -landroid $(LOCAL_PATH)/halide_generated_$(TARGET_ARCH_ABI)/halide_generated.o # -lOpenCL -lllvm-a3xx
+LOCAL_LDFLAGS   := -L$(LOCAL_PATH)/../jni
+LOCAL_LDLIBS    := -lm -llog -landroid $(LOCAL_PATH)/../bin/halide_generated_$(TARGET_ARCH_ABI)/halide_generated.o
 LOCAL_STATIC_LIBRARIES := android_native_app_glue
-LOCAL_C_INCLUDES := $(LOCAL_PATH)/../../../include $(LOCAL_PATH)/../../../build/include $(LOCAL_PATH)/halide_generated_$(TARGET_ARCH_ABI)/
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/../../../include $(LOCAL_PATH)/../../../build/include $(LOCAL_PATH)/../bin/halide_generated_$(TARGET_ARCH_ABI)/
 
 include $(BUILD_SHARED_LIBRARY)
 

--- a/apps/HelloAndroid/jni/native.cpp
+++ b/apps/HelloAndroid/jni/native.cpp
@@ -15,13 +15,11 @@
 
 #define DEBUG 1
 
-extern "C" void halide_set_error_handler(int (*handler)(void *user_context, const char *));
 extern "C" int halide_host_cpu_count();
 extern "C" int halide_start_clock(void *user_context);
 extern "C" int64_t halide_current_time_ns();
-extern "C" int halide_copy_to_host(void *, buffer_t *);
 
-int handler(void */* user_context */, const char *msg) {
+void handler(void */* user_context */, const char *msg) {
     LOGE("%s", msg);
 }
 

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -643,7 +643,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_posix_threads(c, bits_64, debug));
                 modules.push_back(get_initmod_thread_pool(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_get_symbol(c, bits_64, debug));
-                modules.push_back(get_initmod_profiler(c, bits_64, debug));
             } else if (t.os == Target::OSX) {
                 modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
@@ -653,7 +652,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_posix_tempfile(c, bits_64, debug));
                 modules.push_back(get_initmod_gcd_thread_pool(c, bits_64, debug));
                 modules.push_back(get_initmod_osx_get_symbol(c, bits_64, debug));
-                modules.push_back(get_initmod_profiler(c, bits_64, debug));
             } else if (t.os == Target::Android) {
                 modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
@@ -669,7 +667,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_posix_threads(c, bits_64, debug));
                 modules.push_back(get_initmod_thread_pool(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_get_symbol(c, bits_64, debug));
-                modules.push_back(get_initmod_profiler(c, bits_64, debug));
             } else if (t.os == Target::Windows) {
                 modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
@@ -683,7 +680,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 if (t.has_feature(Target::MinGW)) {
                     modules.push_back(get_initmod_mingw_math(c, bits_64, debug));
                 }
-                modules.push_back(get_initmod_profiler(c, bits_64, debug));
             } else if (t.os == Target::IOS) {
                 modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
@@ -692,7 +688,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_ios_io(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_tempfile(c, bits_64, debug));
                 modules.push_back(get_initmod_gcd_thread_pool(c, bits_64, debug));
-                modules.push_back(get_initmod_profiler(c, bits_64, debug));
             } else if (t.os == Target::QuRT) {
                 modules.push_back(get_initmod_qurt_allocator(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
@@ -701,7 +696,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_posix_io(c, bits_64, debug));
                 // TODO: Replace fake thread pool with a real implementation.
                 modules.push_back(get_initmod_fake_thread_pool(c, bits_64, debug));
-                modules.push_back(get_initmod_profiler(c, bits_64, debug));
             } else if (t.os == Target::NoOS) {
                 // No externally resolved symbols are allowed here.
                 modules.push_back(get_initmod_noos(c, bits_64, debug));
@@ -737,6 +731,11 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
             modules.push_back(get_initmod_metadata(c, bits_64, debug));
             modules.push_back(get_initmod_float16_t(c, bits_64, debug));
             modules.push_back(get_initmod_errors(c, bits_64, debug));
+
+            if (t.arch != Target::MIPS && t.os != Target::NoOS) {
+                // MIPS doesn't support the atomics the profiler requires.
+                modules.push_back(get_initmod_profiler(c, bits_64, debug));
+            }
 
             if (t.has_feature(Target::MSAN)) {
                 modules.push_back(get_initmod_msan(c, bits_64, debug));


### PR DESCRIPTION
build.sh is broken and has been for a while:
— Minor syntactic errors in native.cpp prevent any build from working
— Profiler runtime doesn’t work on MIPS; rework linker code to only
attempt to link it in for non-MIPS, non-NoOS cases

(Note that the Android Studio/Gradle support is still broken, and I
don’t know how to fix it; support for JNI in AS/G has changed and I
don’t know what the status quo is. IMHO we’d be better off scrapping it
entirely in favor of a Bazel-based solution.)