### PR TITLE
Add support for vmpa for 16 bit vector operands.

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -273,9 +273,9 @@ void CodeGen_Hexagon::init_module() {
 
         // Widening adds. There are other instructions that add two vub and two vuh but do not widen.
         // To differentiate those from the widening ones, we encode the return type in the name here.
-        { IPICK(is_128B, Intrinsic::hexagon_V6_vaddubh), i16v2, "add_vh.vub.vub", {u8v1, u8v1} },
+        { IPICK(is_128B, Intrinsic::hexagon_V6_vaddubh), i16v2, "add_vuh.vub.vub", {u8v1, u8v1} },
         { IPICK(is_128B, Intrinsic::hexagon_V6_vaddhw), i32v2, "add_vw.vh.vh", {i16v1, i16v1} },
-        { IPICK(is_128B, Intrinsic::hexagon_V6_vadduhw), i32v2, "add_vw.vuh.vuh", {u16v1, u16v1} },
+        { IPICK(is_128B, Intrinsic::hexagon_V6_vadduhw), i32v2, "add_vuw.vuh.vuh", {u16v1, u16v1} },
 
         { IPICK(is_128B, Intrinsic::hexagon_V6_vsubb),     i8v1,  "sub.vb.vb",     {i8v1,  i8v1} },
         { IPICK(is_128B, Intrinsic::hexagon_V6_vsubh),     i16v1, "sub.vh.vh",     {i16v1, i16v1} },
@@ -286,9 +286,9 @@ void CodeGen_Hexagon::init_module() {
 
         // Widening subtracts. There are other instructions that subtact two vub and two vuh but do not widen.
         // To differentiate those from the widening ones, we encode the return type in the name here.
-        { IPICK(is_128B, Intrinsic::hexagon_V6_vsububh), i16v2, "sub_vh.vub.vub", {u8v1, u8v1} },
+        { IPICK(is_128B, Intrinsic::hexagon_V6_vsububh), i16v2, "sub_vuh.vub.vub", {u8v1, u8v1} },
         { IPICK(is_128B, Intrinsic::hexagon_V6_vsubhw), i32v2, "sub_vw.vh.vh", {i16v1, i16v1} },
-        { IPICK(is_128B, Intrinsic::hexagon_V6_vsubuhw), i32v2, "sub_vw.vuh.vuh", {u16v1, u16v1} },
+        { IPICK(is_128B, Intrinsic::hexagon_V6_vsubuhw), i32v2, "sub_vuw.vuh.vuh", {u16v1, u16v1} },
 
 
         // Adds/subtract of unsigned values with saturation.

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -356,6 +356,10 @@ private:
             Expr c1 = lossless_cast(Int(8), matches[3]);
 
             if (v0.defined() && v1.defined() && c0.defined() && c1.defined()) {
+                v0 = mutate(v0);
+                v1 = mutate(v1);
+                c0 = mutate(c0);
+                c1 = mutate(c1);
                 expr = halide_hexagon_add_mpy_mpy(".vub.vub.b.b", v0, v1, c0, c1);
                 return;
             }
@@ -367,6 +371,10 @@ private:
             Expr c1 = lossless_cast(Int(8), matches[3]);
 
             if (v0.defined() && v1.defined() && c0.defined() && c1.defined()) {
+                v0 = mutate(v0);
+                v1 = mutate(v1);
+                c0 = mutate(c0);
+                c1 = mutate(c1);
                 expr = halide_hexagon_add_mpy_mpy(".vh.vh.b.b", v0, v1, c0, c1);
                 return;
             }

--- a/src/runtime/hvx_128.ll
+++ b/src/runtime/hvx_128.ll
@@ -320,3 +320,24 @@ define weak_odr <128 x i16> @halide.hexagon.acc_add_mpy_mpy.vh.vub.vub.b.b(<128 
   %ret_val = bitcast <64 x i32> %res to <128 x i16>
   ret <128 x i16> %ret_val
 }
+
+declare <64 x i32> @llvm.hexagon.V6.vmpahb.128B(<64 x i32>, i32)
+declare <64 x i32> @llvm.hexagon.V6.vmpahb.acc.128B(<64 x i32>, <64 x i32>, i32)
+
+define weak_odr <64 x i32> @halide.hexagon.add_mpy_mpy.vh.vh.b.b(<64 x i16> %low_v, <64 x i16> %high_v, i8 %low_c, i8 %high_c) nounwind uwtable readnone {
+  %const = call i32 @halide.hexagon.interleave.b.dup2.h(i8 %low_c, i8 %high_c)
+  %low = bitcast <64 x i16> %low_v to <32 x i32>
+  %high = bitcast <64 x i16> %high_v to <32 x i32>
+  %dv = call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %high, <32 x i32> %low)
+  %res = call <64 x i32> @llvm.hexagon.V6.vmpahb.128B(<64 x i32> %dv, i32 %const)
+  ret <64 x i32> %res
+}
+
+define weak_odr <64 x i32> @halide.hexagon.acc_add_mpy_mpy.vw.vh.vh.b.b(<64 x i32> %acc, <64 x i16> %low_v, <64 x i16> %high_v, i8 %low_c, i8 %high_c) nounwind uwtable readnone {
+  %const = call i32 @halide.hexagon.interleave.b.dup2.h(i8 %low_c, i8 %high_c)
+  %low = bitcast <64 x i16> %low_v to <32 x i32>
+  %high = bitcast <64 x i16> %high_v to <32 x i32>
+  %dv1 = call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %high, <32 x i32> %low)
+  %res = call <64 x i32> @llvm.hexagon.V6.vmpahb.acc.128B(<64 x i32> %acc, <64 x i32> %dv1, i32 %const)
+  ret <64 x i32> %res
+}

--- a/src/runtime/hvx_64.ll
+++ b/src/runtime/hvx_64.ll
@@ -320,3 +320,24 @@ define weak_odr <64 x i16> @halide.hexagon.acc_add_mpy_mpy.vh.vub.vub.b.b(<64 x 
   %ret_val = bitcast <32 x i32> %res to <64 x i16>
   ret <64 x i16> %ret_val
 }
+
+declare <32 x i32> @llvm.hexagon.V6.vmpahb(<32 x i32>, i32)
+declare <32 x i32> @llvm.hexagon.V6.vmpahb.acc(<32 x i32>, <32 x i32>, i32)
+
+define weak_odr <32 x i32> @halide.hexagon.add_mpy_mpy.vh.vh.b.b(<32 x i16> %low_v, <32 x i16> %high_v, i8 %low_c, i8 %high_c) nounwind uwtable readnone {
+  %const = call i32 @halide.hexagon.interleave.b.dup2.h(i8 %low_c, i8 %high_c)
+  %low = bitcast <32 x i16> %low_v to <16 x i32>
+  %high = bitcast <32 x i16> %high_v to <16 x i32>
+  %dv = call <32 x i32> @llvm.hexagon.V6.vcombine(<16 x i32> %high, <16 x i32> %low)
+  %res = call <32 x i32> @llvm.hexagon.V6.vmpahb(<32 x i32> %dv, i32 %const)
+  ret <32 x i32> %res
+}
+
+define weak_odr <32 x i32> @halide.hexagon.acc_add_mpy_mpy.vw.vh.vh.b.b(<32 x i32> %acc, <32 x i16> %low_v, <32 x i16> %high_v, i8 %low_c, i8 %high_c) nounwind uwtable readnone {
+  %const = call i32 @halide.hexagon.interleave.b.dup2.h(i8 %low_c, i8 %high_c)
+  %low = bitcast <32 x i16> %low_v to <16 x i32>
+  %high = bitcast <32 x i16> %high_v to <16 x i32>
+  %dv1 = call <32 x i32> @llvm.hexagon.V6.vcombine(<16 x i32> %high, <16 x i32> %low)
+  %res = call <32 x i32> @llvm.hexagon.V6.vmpahb.acc(<32 x i32> %acc, <32 x i32> %dv1, i32 %const)
+  ret <32 x i32> %res
+}

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1690,6 +1690,11 @@ void check_hvx_all() {
     check("vmpa(v*.ub,r*.b)", hvx_width/1, 2*i16(u8_1) + 3*i16(u8_2));
     check("v*.h += vmpa(v*.ub,r*.b)", hvx_width/1, 2*i16(u8_1) + 3*i16(u8_2) + i16_1);
 
+    check("vmpa(v*.h,r*.b)", hvx_width/1, i32(i16_1)*2 + i32(i16_2)*3);
+    check("vmpa(v*.h,r*.b)", hvx_width/1, i32(i16_1)*2 + 3*i32(i16_2));
+    check("vmpa(v*.h,r*.b)", hvx_width/1, 2*i32(i16_1) + 3*i32(i16_2));
+    check("v*.w += vmpa(v*.h,r*.b)", hvx_width/1, 2*i32(i16_1) + 3*i32(i16_2) + i32_1);
+
     check("vmpy(v*.ub,v*.ub)", hvx_width/1, u16(u8_1) * u16(u8_2));
     check("vmpy(v*.b,v*.b)", hvx_width/1, i16(i8_1) * i16(i8_2));
     check("vmpy(v*.uh,v*.uh)", hvx_width/2, u32(u16_1) * u32(u16_2));
@@ -1896,7 +1901,7 @@ int main(int argc, char **argv) {
     target.set_features({Target::NoBoundsQuery, Target::NoAsserts, Target::NoRuntime});
 
     use_avx512_knl = target.has_feature(Target::AVX512_KNL);
-    use_avx512_cannonlake = target.has_feature(Target::AVX512_Cannonlake);    
+    use_avx512_cannonlake = target.has_feature(Target::AVX512_Cannonlake);
     use_avx512_skylake = use_avx512_cannonlake || target.has_feature(Target::AVX512_Skylake);
     use_avx512 = use_avx512_knl || use_avx512_skylake || use_avx512_cannonlake || target.has_feature(Target::AVX512);
     use_avx2 = use_avx512 || target.has_feature(Target::AVX2);


### PR DESCRIPTION
We really need the 16 bit version of vmpa more than the 8 bit version. This adds the 16 bit version of the instruction. Rather than add a new pattern matching flag that is only used by this instruction, I just matched it manually instead, and did the same thing for the 8 bit instruction (for consistency).

I also thought we could do away with the post process adds (and handle them normally), but that is the easier way to do it.