### PR TITLE
Rename HelloAndroid native module

### DIFF
--- a/apps/HelloAndroid/build.gradle
+++ b/apps/HelloAndroid/build.gradle
@@ -131,7 +131,7 @@ android {
             // which would use parameters defined in build.gradle. Use our own
             // task (ndkBuild) below.
             jni.srcDirs = []
-            jniLibs.srcDirs = ["libs/"] // default is src/main/jniLibs
+            jniLibs.srcDirs = ["bin/lib/"] // default is src/main/jniLibs
             manifest.srcFile "AndroidManifest.xml"
             res.srcDirs = ["res/"] // default is src/main/res
         }
@@ -147,7 +147,7 @@ android {
         } else {
             ndkBuildCmd = "ndk-build"
         }
-        commandLine "$ndkDir/$ndkBuildCmd", '-C', file('jni').absolutePath
+        commandLine "$ndkDir/$ndkBuildCmd", "NDK_GEN_OUT=./bin/gen", "NDK_LIBS_OUT=./bin/lib", "NDK_OUT=./bin/obj"
     }
 
     tasks.withType(JavaCompile) {

--- a/apps/HelloAndroid/jni/Android.mk
+++ b/apps/HelloAndroid/jni/Android.mk
@@ -2,7 +2,7 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE    := native
+LOCAL_MODULE    := HelloAndroid
 LOCAL_ARM_MODE  := arm
 LOCAL_SRC_FILES := hello_wrapper.cpp
 LOCAL_LDFLAGS   := -L$(LOCAL_PATH)/../jni

--- a/apps/HelloAndroid/src/com/example/hellohalide/CameraPreview.java
+++ b/apps/HelloAndroid/src/com/example/hellohalide/CameraPreview.java
@@ -22,7 +22,7 @@ public class CameraPreview extends SurfaceView
 
     // Link to native Halide code
     static {
-        System.loadLibrary("native");
+        System.loadLibrary("HelloAndroid");
     }
     private static native void processFrame(byte[] src, int w, int h, int orientation, Surface dst);
 

--- a/apps/HelloAndroidCamera2/HelloAndroidCamera2.iml
+++ b/apps/HelloAndroidCamera2/HelloAndroidCamera2.iml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/apps/HelloAndroidCamera2/HelloAndroidCamera2.iml
+++ b/apps/HelloAndroidCamera2/HelloAndroidCamera2.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
renaming the native module to match the apk name (“libHelloAndroid.so”
instead of “libnative.so”) turns out to be easier to support in Bazel
at the present time; since it’s abitrary elsewhere, just use that
convention everywhere. (Also some driveby fixes to ndk-build calls in
Gradle which were just happening to work before.)