### PR TITLE
Remove extern “C” from symbols in  Halide::Runtime::Internal::OpenGL

### DIFF
--- a/src/runtime/osx_opengl_context.cpp
+++ b/src/runtime/osx_opengl_context.cpp
@@ -11,8 +11,6 @@ extern "C" void aglDestroyPixelFormat(void *);
 extern "C" unsigned char aglSetCurrentContext(void *);
 #endif
 
-extern "C" {
-
 #if !USE_AGL
 namespace Halide { namespace Runtime { namespace Internal { namespace OpenGL {
 
@@ -27,6 +25,8 @@ WEAK int (*CGLSetCurrentContext)(void *);
 
 using namespace Halide::Runtime::Internal::OpenGL;
 #endif
+
+extern "C" {
 
 WEAK void *halide_opengl_get_proc_address(void *user_context, const char *name) {
     static void *dylib = NULL;


### PR DESCRIPTION
Having extern “C” wrapped around the definition of the internal symbols meant that their unmangled names were visibile at global scope.  

In particular, that meant these symbols intending to hold function pointers to the corresponding functions when looked up dynamically:

  `Halide::Runtime::Internal::OpenGL::CGLChoosePixelFormat`
  `Halide::Runtime::Internal::OpenGL::CGLCreateContext`
  `Halide::Runtime::Internal::OpenGL::CGLDestroyPixelFormat`
  `Halide::Runtime::Internal::OpenGL::CGLSetCurrentContext`

Were actually shadowing the symbols of the functions themselves, causing trouble for programs that directly call those functions outside Halide.

Fixes #1635