### PR TITLE
halide_metal_acquire_context() decl should be plain C, not C++

### DIFF
--- a/src/runtime/HalideRuntimeMetal.h
+++ b/src/runtime/HalideRuntimeMetal.h
@@ -77,8 +77,8 @@ struct halide_metal_command_queue;
  * - halide_device_release has been called on the interface returned from
  *     halide_metal_device_interface(). (This releases the programs on the context.)
  */
-extern int halide_metal_acquire_context(void *user_context, struct halide_metal_device *&device_ret,
-                                        halide_metal_command_queue *&queue_ret, bool create = true);
+extern int halide_metal_acquire_context(void *user_context, struct halide_metal_device **device_ret,
+                                        struct halide_metal_command_queue **queue_ret, bool create);
 
 /** This call balances each successfull halide_metal_acquire_context call.
  * If halide_metal_acquire_context is replaced, this routine must be replaced


### PR DESCRIPTION
ObjC “.m” files don’t have C++ enabled in all compiler configs, so we
should restrict this API to use plain C conventions to maximize
compatibility.