### PR TITLE
Select tail strategy

### DIFF
--- a/src/ApplySplit.cpp
+++ b/src/ApplySplit.cpp
@@ -31,31 +31,9 @@ vector<ApplySplitResult> apply_split(const Split &split, bool is_update, string 
 
         map<string, Expr>::iterator iter = dim_extent_alignment.find(split.old_var);
 
-        if (is_update) {
-            user_assert(split.tail != TailStrategy::ShiftInwards)
-                << "When splitting Var " << split.old_var
-                << " ShiftInwards is not a legal tail strategy for update definitions, as"
-                << " it may change the meaning of the algorithm\n";
-        }
-
-        if (split.exact) {
-            user_assert(split.tail == TailStrategy::Auto ||
-                        split.tail == TailStrategy::GuardWithIf)
-                << "When splitting Var " << split.old_var
-                << " the tail strategy must be GuardWithIf or Auto. "
-                << "Anything else may change the meaning of the algorithm\n";
-        }
-
         TailStrategy tail = split.tail;
-        if (tail == TailStrategy::Auto) {
-            if (split.exact) {
-                tail = TailStrategy::GuardWithIf;
-            } else if (is_update) {
-                tail = TailStrategy::RoundUp;
-            } else {
-                tail = TailStrategy::ShiftInwards;
-            }
-        }
+        internal_assert(tail != TailStrategy::Auto)
+            << "An explicit tail strategy should exist at this point\n";
 
         if ((iter != dim_extent_alignment.end()) &&
             is_zero(simplify(iter->second % split.factor))) {

--- a/test/correctness/bounds_inference_outer_split.cpp
+++ b/test/correctness/bounds_inference_outer_split.cpp
@@ -7,6 +7,8 @@ using namespace Halide::Internal;
 
 class CheckAllocationSize : public IRVisitor {
     
+    using IRVisitor::visit;
+	
     void visit(const Allocate *op) {
         if (op->name == "input_cpy") {
             result = op->extents[0];

--- a/test/correctness/bounds_inference_outer_split.cpp
+++ b/test/correctness/bounds_inference_outer_split.cpp
@@ -1,0 +1,77 @@
+// This was a failing case from https://github.com/halide/Halide/issues/1618
+
+#include "Halide.h"
+#include <stdio.h>
+using namespace Halide;
+using namespace Halide::Internal;
+
+class CheckAllocationSize : public IRVisitor {
+    
+    void visit(const Allocate *op) {
+        if (op->name == "input_cpy") {
+            result = op->extents[0];
+        } else {
+            op->body.accept(this);
+        }
+    }
+
+public:
+    Expr result;
+};
+
+int main(int argc, char **argv) {
+    Var x, y, xout, xin;
+
+    ImageParam input(type_of<int16_t>(), 2);
+
+    Func input_cpy("input_cpy");
+    input_cpy(x, y) = input(x, y);
+	
+    Func input_cpy_2;
+    input_cpy_2(x, y) = input_cpy(x, y);
+    
+    Func sum_stage;
+    sum_stage(x, y) = (input_cpy_2(x, y - 4)+
+                       input_cpy_2(x,y - 3)+
+                       input_cpy_2(x,y - 2)+
+                       input_cpy_2(x,y - 1)+
+                       input_cpy_2(x,y));
+                       
+    Func sum_stage_cpy;
+    sum_stage_cpy(x, y) = sum_stage(x, y);
+    
+    Func sum_stage_cpy_2;
+    sum_stage_cpy_2(x, y) = sum_stage_cpy(x, y);
+
+
+    // bound the output to a fixed size
+    sum_stage_cpy_2.bound(x, 0, 512);
+    sum_stage_cpy_2.bound(y, 0, 512);
+    
+    // This stage was grossly overdimensioned by bounds inference: it
+    // should only need 5 complete lines (512 * 5) = 2560 pixels.
+    input_cpy.compute_at(sum_stage_cpy, y);
+    
+    input_cpy_2.compute_at(sum_stage_cpy, xout)
+        .split(x, xout, xin, 32)
+        .unroll(xout, 4);
+
+    sum_stage_cpy
+        .compute_at(sum_stage_cpy_2, y)
+        .split(x, xout, xin, 32)
+        .unroll(xout, 4);
+	
+    Module m = sum_stage_cpy_2.compile_to_module({input});
+
+    CheckAllocationSize checker;
+    m.functions()[0].body.accept(&checker);
+
+    if (!is_const(checker.result, 512)) {
+        std::cerr << m.functions()[0].body << "\n\n"
+                  << "Allocation size was supposed to be 512 in dimension 0 in the stmt above\n";
+        return -1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Changes the behavior of TailStrategy::Auto in some cases. See issue #1618 for the full discussion. Also moves error handling for bad tailstrategies earlier (scheduling time, instead of lowering time).