### PR TITLE
Add patterns for some more multiply instructions on Hexagon.

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -376,6 +376,11 @@ void CodeGen_Hexagon::init_module() {
         { IPICK(is_128B, Intrinsic::hexagon_V6_vmpybus_acc),  i16v2, "add_mpy.vh.vub.b",     {i16v2, u8v1,  i8}, HvxIntrinsic::BroadcastScalarsToWords },
         { IPICK(is_128B, Intrinsic::hexagon_V6_vmpyhsat_acc), i32v2, "satw_add_mpy.vw.vh.h", {i32v2, i16v1, i16}, HvxIntrinsic::BroadcastScalarsToWords },
 
+        // Multiply keep high half, with multiplication by 2.
+        { IPICK(is_128B, Intrinsic::hexagon_V6_vmpyhvsrs), i16v1, "trunc_satw_mpy2_rnd.vh.vh", {i16v1, i16v1} },
+        { IPICK(is_128B, Intrinsic::hexagon_V6_vmpyhss), i16v1, "trunc_satw_mpy2.vh.h", {i16v1, i16}, HvxIntrinsic::BroadcastScalarsToWords },
+        { IPICK(is_128B, Intrinsic::hexagon_V6_vmpyhsrs), i16v1, "trunc_satw_mpy2_rnd.vh.h", {i16v1, i16}, HvxIntrinsic::BroadcastScalarsToWords },
+
         // Select/conditionals. Conditions are always signed integer
         // vectors (so widening sign extends).
         { IPICK(is_128B, Intrinsic::hexagon_V6_vmux), i8v1,  "mux.vb.vb",  {i8v1,  i8v1,  i8v1} },

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -541,6 +541,16 @@ private:
             { "halide.hexagon.trunc_satuh_shr.vw.w", u16_sat(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
             { "halide.hexagon.trunc_sath_shr.vw.w",  i16_sat(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
 
+            // Scalar multiply keep high half, with multiplication by 2.
+            // TODO: We should also be able to match multiplication by
+            // constants, without the multiply by 2, where the
+            // constant is divisible by 2.
+            { "halide.hexagon.trunc_satw_mpy2.vh.h", i16(i32_sat(i64(wild_i32x*bc(wild_i32))*2)/65536), Pattern::NarrowOps },
+            { "halide.hexagon.trunc_satw_mpy2_rnd.vh.h", i16(i32_sat(i64(wild_i32x*bc(wild_i32))*2 + 32768)/65536), Pattern::NarrowOps },
+
+            // Vector multiply keep high half, with multiplication by 2.
+            { "halide.hexagon.trunc_satw_mpy2_rnd.vh.vh", i16(i32_sat(i64(wild_i32x*wild_i32x)*2 + 32768)/65536), Pattern::NarrowOps },
+
             // For some of the following narrowing casts, we have the choice of
             // non-interleaving or interleaving instructions. Because we don't
             // know which one we prefer during pattern matching, we match the

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -535,7 +535,9 @@ private:
 
             // Scalar multiply keep high half, with multiplication by 2.
             { "halide.hexagon.trunc_satw_mpy2.vh.h", i16_sat((wild_i32x*bc(wild_i32))/32768), Pattern::NarrowOps },
+            { "halide.hexagon.trunc_satw_mpy2.vh.h", i16_sat((bc(wild_i32)*wild_i32x)/32768), Pattern::NarrowOps | Pattern::SwapOps01 },
             { "halide.hexagon.trunc_satw_mpy2_rnd.vh.h", i16_sat((wild_i32x*bc(wild_i32) + 16384)/32768), Pattern::NarrowOps },
+            { "halide.hexagon.trunc_satw_mpy2_rnd.vh.h", i16_sat((bc(wild_i32)*wild_i32x + 16384)/32768), Pattern::NarrowOps | Pattern::SwapOps01 },
 
             // Vector multiply keep high half, with multiplication by 2.
             { "halide.hexagon.trunc_satw_mpy2_rnd.vh.vh", i16_sat((wild_i32x*wild_i32x + 16384)/32768), Pattern::NarrowOps },

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -533,6 +533,13 @@ private:
             { "halide.hexagon.trunc_satuh_rnd.vw", u16_sat((wild_i64x + 32768)/65536), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
             { "halide.hexagon.trunc_sath_rnd.vw",  i16_sat((wild_i64x + 32768)/65536), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
 
+            // Scalar multiply keep high half, with multiplication by 2.
+            { "halide.hexagon.trunc_satw_mpy2.vh.h", i16_sat((wild_i32x*bc(wild_i32))/32768), Pattern::NarrowOps },
+            { "halide.hexagon.trunc_satw_mpy2_rnd.vh.h", i16_sat((wild_i32x*bc(wild_i32) + 16384)/32768), Pattern::NarrowOps },
+
+            // Vector multiply keep high half, with multiplication by 2.
+            { "halide.hexagon.trunc_satw_mpy2_rnd.vh.vh", i16_sat((wild_i32x*wild_i32x + 16384)/32768), Pattern::NarrowOps },
+
             // Saturating narrowing casts
             { "halide.hexagon.trunc_satub_shr.vh.h", u8_sat(wild_i16x >> wild_i16), Pattern::DeinterleaveOp0 },
             { "halide.hexagon.trunc_satuh_shr.vw.w", u16_sat(wild_i32x >> wild_i32), Pattern::DeinterleaveOp0 },
@@ -540,16 +547,6 @@ private:
             { "halide.hexagon.trunc_satub_shr.vh.h", u8_sat(wild_i16x/wild_i16), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
             { "halide.hexagon.trunc_satuh_shr.vw.w", u16_sat(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
             { "halide.hexagon.trunc_sath_shr.vw.w",  i16_sat(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
-
-            // Scalar multiply keep high half, with multiplication by 2.
-            // TODO: We should also be able to match multiplication by
-            // constants, without the multiply by 2, where the
-            // constant is divisible by 2.
-            { "halide.hexagon.trunc_satw_mpy2.vh.h", i16(i32_sat(i64(wild_i32x*bc(wild_i32))*2)/65536), Pattern::NarrowOps },
-            { "halide.hexagon.trunc_satw_mpy2_rnd.vh.h", i16(i32_sat(i64(wild_i32x*bc(wild_i32))*2 + 32768)/65536), Pattern::NarrowOps },
-
-            // Vector multiply keep high half, with multiplication by 2.
-            { "halide.hexagon.trunc_satw_mpy2_rnd.vh.vh", i16(i32_sat(i64(wild_i32x*wild_i32x)*2 + 32768)/65536), Pattern::NarrowOps },
 
             // For some of the following narrowing casts, we have the choice of
             // non-interleaving or interleaving instructions. Because we don't

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1768,9 +1768,9 @@ void check_hvx_all() {
     check("v*.w += vmpy(v*.h,r*.h)", hvx_width/1, i32_1 + i32(i16_1)*32767);
     check("v*.w += vmpy(v*.h,r*.h)", hvx_width/1, i32_1 + 32767*i32(i16_1));
 
-    check("vmpy(v*.h,v*.h):<<1:rnd:sat", hvx_width/2, i16(i32_sat(i64(i32(i16_1)*i32(i16_2))*2 + 32768)/65536));
-    check("vmpy(v*.h,r*.h):<<1:sat", hvx_width/2, i16(i32_sat(i64(i32(i16_1)*7)*2)/65536));
-    check("vmpy(v*.h,r*.h):<<1:rnd:sat", hvx_width/2, i16(i32_sat(i64(i32(i16_1)*7)*2 + 32768)/65536));
+    check("vmpy(v*.h,v*.h):<<1:rnd:sat", hvx_width/2, i16_sat((i32(i16_1)*i32(i16_2) + 16384)/32768));
+    check("vmpy(v*.h,r*.h):<<1:sat", hvx_width/2, i16_sat((i32(i16_1)*32767)/32768));
+    check("vmpy(v*.h,r*.h):<<1:rnd:sat", hvx_width/2, i16_sat((i32(i16_1)*32767 + 16384)/32768));
 
     check("v*.w += vasl(v*.w,r*)", hvx_width/4, u32_1 + (u32_2 * 8));
     check("v*.w += vasl(v*.w,r*)", hvx_width/4, i32_1 + (i32_2 * 8));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1768,6 +1768,10 @@ void check_hvx_all() {
     check("v*.w += vmpy(v*.h,r*.h)", hvx_width/1, i32_1 + i32(i16_1)*32767);
     check("v*.w += vmpy(v*.h,r*.h)", hvx_width/1, i32_1 + 32767*i32(i16_1));
 
+    check("vmpy(v*.h,v*.h):<<1:rnd:sat", hvx_width/2, i16(i32_sat(i64(i32(i16_1)*i32(i16_2))*2 + 32768)/65536));
+    check("vmpy(v*.h,r*.h):<<1:sat", hvx_width/2, i16(i32_sat(i64(i32(i16_1)*7)*2)/65536));
+    check("vmpy(v*.h,r*.h):<<1:rnd:sat", hvx_width/2, i16(i32_sat(i64(i32(i16_1)*7)*2 + 32768)/65536));
+
     check("v*.w += vasl(v*.w,r*)", hvx_width/4, u32_1 + (u32_2 * 8));
     check("v*.w += vasl(v*.w,r*)", hvx_width/4, i32_1 + (i32_2 * 8));
     check("v*.w += vasr(v*.w,r*)", hvx_width/4, i32_1 + (i32_2 / 8));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1770,7 +1770,9 @@ void check_hvx_all() {
 
     check("vmpy(v*.h,v*.h):<<1:rnd:sat", hvx_width/2, i16_sat((i32(i16_1)*i32(i16_2) + 16384)/32768));
     check("vmpy(v*.h,r*.h):<<1:sat", hvx_width/2, i16_sat((i32(i16_1)*32767)/32768));
+    check("vmpy(v*.h,r*.h):<<1:sat", hvx_width/2, i16_sat((32767*i32(i16_1))/32768));
     check("vmpy(v*.h,r*.h):<<1:rnd:sat", hvx_width/2, i16_sat((i32(i16_1)*32767 + 16384)/32768));
+    check("vmpy(v*.h,r*.h):<<1:rnd:sat", hvx_width/2, i16_sat((32767*i32(i16_1) + 16384)/32768));
 
     check("v*.w += vasl(v*.w,r*)", hvx_width/4, u32_1 + (u32_2 * 8));
     check("v*.w += vasl(v*.w,r*)", hvx_width/4, i32_1 + (i32_2 * 8));


### PR DESCRIPTION
This PR adds support for vmpyh instructions that also multiply by 2, keep the high half, and optionally round.