### PR TITLE
Fix grab-bag of minor bugs found by Blaze

### DIFF
--- a/src/Expr.h
+++ b/src/Expr.h
@@ -123,12 +123,14 @@ template<typename T>
 struct ExprNode : public BaseExprNode {
     EXPORT void accept(IRVisitor *v) const;
     virtual IRNodeType type_info() const {return T::_type_info;}
+    virtual ~ExprNode() {}
 };
 
 template<typename T>
 struct StmtNode : public BaseStmtNode {
     EXPORT void accept(IRVisitor *v) const;
     virtual IRNodeType type_info() const {return T::_type_info;}
+    virtual ~StmtNode() {}
 };
 
 /** IR nodes are passed around opaque handles to them. This is a

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -490,6 +490,15 @@ Stmt Evaluate::make(Expr v) {
     return node;
 }
 
+Expr Call::make(Function func, const std::vector<Expr> &args, int idx) {
+    internal_assert(idx >= 0 &&
+                    idx < func.outputs())
+        << "Value index out of range in call to halide function\n";
+    internal_assert(func.has_pure_definition() || func.has_extern_definition())
+        << "Call to undefined halide function\n";
+    return make(func.output_types()[(size_t)idx], func.name(), args, Halide, func.get_contents(), idx, BufferPtr(), Parameter());
+}
+
 Expr Call::make(Type type, std::string name, const std::vector<Expr> &args, CallType call_type,
                 IntrusivePtr<FunctionContents> func, int value_index,
                 BufferPtr image, Parameter param) {

--- a/src/IR.h
+++ b/src/IR.h
@@ -534,14 +534,7 @@ struct Call : public ExprNode<Call> {
                             BufferPtr image = BufferPtr(), Parameter param = Parameter());
 
     /** Convenience constructor for calls to other halide functions */
-    static Expr make(Function func, const std::vector<Expr> &args, int idx = 0) {
-        internal_assert(idx >= 0 &&
-                        idx < func.outputs())
-            << "Value index out of range in call to halide function\n";
-        internal_assert(func.has_pure_definition() || func.has_extern_definition())
-            << "Call to undefined halide function\n";
-        return make(func.output_types()[(size_t)idx], func.name(), args, Halide, func.get_contents(), idx, BufferPtr(), Parameter());
-    }
+    EXPORT static Expr make(Function func, const std::vector<Expr> &args, int idx = 0);
 
     /** Convenience constructor for loads from concrete images */
     static Expr make(BufferPtr image, const std::vector<Expr> &args) {

--- a/src/IntegerDivisionTable.cpp
+++ b/src/IntegerDivisionTable.cpp
@@ -9,7 +9,7 @@
  * expensive method, while the compile-time set uses
  * the cheapest method for the given divisor.
  */
-#include <stdint.h>
+#include <cstdint>
 namespace Halide {
 namespace Internal {
 namespace IntegerDivision {

--- a/src/IntegerDivisionTable.h
+++ b/src/IntegerDivisionTable.h
@@ -1,6 +1,8 @@
 #ifndef HALIDE_INTEGER_DIVISION_TABLE_H
 #define HALIDE_INTEGER_DIVISION_TABLE_H
 
+#include <cstdint>
+
 /** \file
  * Tables telling us how to do integer division via fixed-point
  * multiplication for various small constants.

--- a/src/Reduction.h
+++ b/src/Reduction.h
@@ -5,10 +5,12 @@
  * Defines internal classes related to Reduction Domains
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {
+
+class IRMutator;
 
 /** A single named dimension of a reduction domain */
 struct ReductionVariable {

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -193,8 +193,6 @@ struct Prefetch {
     Expr offset;
 };
 
-class ReductionDomain;
-
 struct FunctionContents;
 
 /** A schedule for a single stage of a Halide pipeline. Right now this


### PR DESCRIPTION
Compiling in a stricter mode revealed a few minor things:
— virtual functions but no virtual dtor
— missing #includes
— classes should not be only-forward-declared class if they are used in
inline code in a way that could invoke ctors/dtors