### PR TITLE
Add simple output to StubTest, rationalize names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -958,7 +958,7 @@ $(BIN_DIR)/stubuser.generator: $(BIN_DIR)/stubtest_generator.o
 $(FILTERS_DIR)/stubtest.a: $(BIN_DIR)/stubtest.generator
 	@mkdir -p $(FILTERS_DIR)
 	@-mkdir -p $(TMP_DIR)
-	cd $(TMP_DIR); $(CURDIR)/$< -f stubtest -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime input.type=float32 input.size=2 int_arg.size=2 f.type=float32,float32
+	cd $(TMP_DIR); $(CURDIR)/$< -f stubtest -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime input.type=float32 input.size=2 int_arg.size=2 tuple_output.type=float32,float32
 
 # Usually, it's considered best practice to have one Generator per
 # .cpp file, with the generator-name and filename matching;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -283,7 +283,7 @@ if (WITH_TEST_GENERATORS)
   # concrete via generator args.
   halide_define_aot_test(stubtest
                          GENERATOR_NAME StubNS1::StubNS2::StubTest
-                         GENERATOR_ARGS input.type=float32 input.size=2 int_arg.size=2 f.type=float32,float32)
+                         GENERATOR_ARGS input.type=float32 input.size=2 int_arg.size=2 tuple_output.type=float32,float32)
 
   # Tests that require additional dependencies, args, etc
   set(MDTEST_GEN_ARGS input.type=uint8 input.dim=3 output.type=float32,float32 output.dim=3 input_not_nod.type=uint8 input_not_nod.dim=3 input_nod.dim=3 input_not.type=uint8 array_input.size=2 array_i8.size=2 array_i16.size=2 array_i32.size=2 array_h.size=2 array_outputs.size=2)

--- a/test/generator/stubtest_aottest.cpp
+++ b/test/generator/stubtest_aottest.cpp
@@ -46,15 +46,17 @@ void verify(const Buffer<InputType> &input, float float_arg, int int_arg, const 
 int main(int argc, char **argv) {
     Buffer<float> in0 = make_image<float>(0);
     Buffer<float> in1 = make_image<float>(1);
-    Buffer<float> f0(kSize, kSize, 3), f1(kSize, kSize, 3);
-    Buffer<int16_t> g0(kSize, kSize), g1(kSize, kSize);
+    Buffer<float> simple_output(kSize, kSize, 3);
+    Buffer<float> tuple_output0(kSize, kSize, 3), tuple_output1(kSize, kSize, 3);
+    Buffer<int16_t> array_output0(kSize, kSize), array_output1(kSize, kSize);
 
-    stubtest(in0, in1, 1.25f, 33, 66, f0, f1, g0, g1);
+    stubtest(in0, in1, 1.25f, 33, 66, simple_output, tuple_output0, tuple_output1, array_output0, array_output1);
 
-    verify(in0, 1.25f, 0, f0);
-    verify(in0, 1.25f, 33, f1);
-    verify(in0, 1.0f, 33, g0);
-    verify(in1, 1.0f, 66, g1);
+    verify(in0, 1.f, 0, simple_output);
+    verify(in0, 1.25f, 0, tuple_output0);
+    verify(in0, 1.25f, 33, tuple_output1);
+    verify(in0, 1.0f, 33, array_output0);
+    verify(in1, 1.0f, 66, array_output1);
 
     printf("Success!\n");
     return 0;

--- a/test/generator/stubtest_generator.cpp
+++ b/test/generator/stubtest_generator.cpp
@@ -19,21 +19,24 @@ public:
     Input<float> float_arg{ "float_arg", 1.0f, 0.0f, 100.0f }; 
     Input<int32_t[]> int_arg{ "int_arg", 1 };  // leave ArraySize unspecified
 
-    Output<Func> f{"f", 3};  // require a 3-dimensional Func but leave Type(s) unspecified
-    Output<Func[]> g{ "g", Int(16), 2};   // leave ArraySize unspecified
+    Output<Func> simple_output{ "simple_output", Float(32), 3};
+    Output<Func> tuple_output{"tuple_output", 3};  // require a 3-dimensional Func but leave Type(s) unspecified
+    Output<Func[]> array_output{ "array_output", Int(16), 2};   // leave ArraySize unspecified
 
     void generate() {
+        simple_output(x, y, c) = cast<float>(input[0](x, y, c));
+
         // Gratuitous intermediate for the purpose of exercising
         // ScheduleParam<LoopLevel>
         intermediate(x, y, c) = input[0](x, y, c) * float_arg;
 
-        f(x, y, c) = Tuple(
+        tuple_output(x, y, c) = Tuple(
                 intermediate(x, y, c),
                 intermediate(x, y, c) + int_arg[0]);
 
-        g.resize(input.size());
+        array_output.resize(input.size());
         for (size_t i = 0; i < input.size(); ++i) {
-            g[i](x, y) = cast<int16_t>(input[i](x, y, 0) + int_arg[i]);
+            array_output[i](x, y) = cast<int16_t>(input[i](x, y, 0) + int_arg[i]);
         }
     }
 
@@ -41,9 +44,11 @@ public:
         if (intermediate_level.defined()) {
             intermediate.compute_at(intermediate_level);
         } else {
-            intermediate.compute_at(f, x);
+            intermediate.compute_at(tuple_output, x);
         }
-        if (vectorize) intermediate.vectorize(x, natural_vector_size<float>());
+        if (vectorize) {
+            intermediate.vectorize(x, natural_vector_size<float>());
+        }
     }
 
 private:

--- a/test/generator/stubtest_jittest.cpp
+++ b/test/generator/stubtest_jittest.cpp
@@ -76,22 +76,26 @@ int main(int argc, char **argv) {
     // This generator defaults intermediate_level to "undefined",
     // so we *must* specify something for it (else we'll crater at
     // Halide compile time). We'll use this:
-    sp.intermediate_level = LoopLevel(gen.f, gen.f.args().at(1));
+    sp.intermediate_level = LoopLevel(gen.tuple_output, gen.tuple_output.args().at(1));
     // ...but any of the following would also be OK:
     // sp.intermediate_level = LoopLevel::root();
-    // sp.intermediate_level = LoopLevel(gen.f, Var("x"));
-    // sp.intermediate_level = LoopLevel(gen.f, Var("c"));
+    // sp.intermediate_level = LoopLevel(gen.tuple_output, Var("x"));
+    // sp.intermediate_level = LoopLevel(gen.tuple_output, Var("c"));
     gen.schedule(sp);
 
-    Halide::Realization f_realized = gen.realize(kSize, kSize, 3);
-    Buffer<float> f0 = f_realized[0];
-    Buffer<float> f1 = f_realized[1];
+    Halide::Realization simple_output_realized = gen.realize(kSize, kSize, 3);
+    Buffer<float> s0 = simple_output_realized;
+    verify(src[0], 1.f, 0, s0);
+
+    Halide::Realization tuple_output_realized = gen.tuple_output.realize(kSize, kSize, 3);
+    Buffer<float> f0 = tuple_output_realized[0];
+    Buffer<float> f1 = tuple_output_realized[1];
     verify(src[0], 1.25f, 0, f0);
     verify(src[0], 1.25f, 33, f1);
 
     for (int i = 0; i < kArrayCount; ++i) {
-        Halide::Realization g_realized = gen.g[i].realize(kSize, kSize, gen.get_target());
-        Buffer<int16_t> g0 = g_realized;
+        Halide::Realization array_output_realized = gen.array_output[i].realize(kSize, kSize, gen.get_target());
+        Buffer<int16_t> g0 = array_output_realized;
         verify(src[i], 1.0f, int_args[i], g0);
     }
 

--- a/test/generator/stubuser_generator.cpp
+++ b/test/generator/stubuser_generator.cpp
@@ -25,7 +25,7 @@ public:
         stub = StubTest(this, inputs);
 
         const float kOffset = 2.f;
-        output(x, y, c) = cast<uint8_t>(stub.f(x, y, c)[1] + kOffset);
+        output(x, y, c) = cast<uint8_t>(stub.tuple_output(x, y, c)[1] + kOffset);
     }
 
     void schedule() {


### PR DESCRIPTION
We had testcases for tuple-outputs and array-outputs, but not for the
common case of neither. Add that, update tests, and rationalize names.