### PR TITLE
Add stride (etc) schedule options to Input/Output<Func>

### DIFF
--- a/apps/HelloAndroid/jni/hello_generator.cpp
+++ b/apps/HelloAndroid/jni/hello_generator.cpp
@@ -6,44 +6,43 @@ namespace {
 
 class Hello : public Generator<Hello> {
 public:
-    ImageParam input{UInt(8), 2, "input"};
+    Input<Func>  input{"input", UInt(8), 2};
+    Output<Func> result{"result", UInt(8), 2};
 
-    Func build() {
-        Var x, y;
-
-        Func tone_curve;
+    void generate() {
         tone_curve(x) = cast<int16_t>(pow(cast<float>(x)/256.0f, 1.8f) * 256.0f);
-        tone_curve.compute_root();
 
         Func clamped = BoundaryConditions::repeat_edge(input);
 
-        Func curved;
         curved(x, y) = tone_curve(clamped(x, y));
 
         Func sharper;
         sharper(x, y) = 9*curved(x, y) - 2*(curved(x-1, y) + curved(x+1, y) + curved(x, y-1) + curved(x, y+1));
 
-        Func result;
         result(x, y) = cast<uint8_t>(clamp(sharper(x, y), 0, 255));
+    }
 
-
+    void schedule() {
         Var yi;
 
-        result.split(y, y, yi, 60).vectorize(x, 8).parallel(y);
+        tone_curve.compute_root();
+        Func(result).split(y, y, yi, 60).vectorize(x, 8).parallel(y);
         curved.store_at(result, y).compute_at(result, yi);
 
         // We want to handle inputs that may be rotated 180 due to camera module placement.
 
         // Unset the default stride constraint
-        input.set_stride(0, Expr());
-
-        // Make specialized versions for input stride +/-1 to get dense vector loads
-        curved.specialize(input.stride(0) == 1);
-        curved.specialize(input.stride(0) == -1);
-
-        return result;
+        if (input.has_buffer()) {
+            input.set_stride_constraint(0, Expr());
+            // Make specialized versions for input stride +/-1 to get dense vector loads
+            curved.specialize(input.stride(0) == 1);
+            curved.specialize(input.stride(0) == -1);
+        }
     }
 
+private:
+    Var x{"x"}, y{"y"};
+    Func tone_curve, curved;
 };
 
 HALIDE_REGISTER_GENERATOR(Hello, "hello")

--- a/apps/fft/fft_generator.cpp
+++ b/apps/fft/fft_generator.cpp
@@ -80,15 +80,13 @@ public:
     // Dim0: extent = size0, stride = 2
     // Dim1: extent = size1, stride = size0 * 2
     // Dim2: extent = 2, stride = 1 (real followed by imaginary components)
-    ImageParam input{Float(32), 3, "input"};
+    Input<Func>  input{"input", Float(32), 3};
+    Output<Func> output{"output", Float(32), 3};
 
-    Func build() {
-        Var c{"c"}, x{"x"}, y{"y"};
-
+    void generate() {
         _halide_user_assert(size0 > 0) << "FFT must be at least 1D\n";
 
         Fft2dDesc desc;
-
         desc.gain = gain;
         desc.vector_width = vector_width;
 
@@ -99,11 +97,6 @@ public:
 
         const int sign = (direction == FFTDirection::SamplesToFrequency) ? -1 : 1;
 
-        const int input_comps = (input_number_type == FFTNumberType::Real) ? 1 : 2;
-        const int output_comps = (output_number_type == FFTNumberType::Real) ? 1 : 2;
-
-        Func real_result;
-        ComplexFunc complex_result;
         if (input_number_type == FFTNumberType::Real) {
             if (direction == FFTDirection::SamplesToFrequency) {
                 // TODO: Not sure why this is necessary as ImageParam
@@ -130,32 +123,45 @@ public:
             }
         }
 
-        Func result("result");
         if (output_number_type == FFTNumberType::Real) {
             if (real_result.defined()) {
-                 result(x, y, c) = real_result(x, y);
-                 real_result.compute_at(result, y);
+                 output(x, y, c) = real_result(x, y);
             } else {
-                 result(x, y, c) = re(complex_result(x, y));
+                 output(x, y, c) = re(complex_result(x, y));
             }
         } else {
-            result(x, y, c) = select(c == 0, 
+            output(x, y, c) = select(c == 0, 
                                      re(complex_result(x, y)), 
                                      im(complex_result(x, y)));
         }
-
-        input.set_stride(0, input_comps)
-             .set_min(2, 0)
-             .set_extent(2, input_comps)
-             .set_stride(2, 1);
-
-        result.output_buffer().set_stride(0, output_comps)
-                              .set_min(2, 0)
-                              .set_extent(2, output_comps)
-                              .set_stride(2, 1);
-
-        return result;
     }
+
+    void schedule() {
+        const int input_comps = (input_number_type == FFTNumberType::Real) ? 1 : 2;
+        const int output_comps = (output_number_type == FFTNumberType::Real) ? 1 : 2;
+
+        if (input.has_buffer()) {
+            input.set_stride_constraint(0, input_comps)
+                 .set_min_constraint(2, 0)
+                 .set_extent_constraint(2, input_comps)
+                 .set_stride_constraint(2, 1);
+        }
+
+        if (output.has_buffer()) {
+            output.set_stride_constraint(0, output_comps)
+                  .set_min_constraint(2, 0)
+                  .set_extent_constraint(2, output_comps)
+                  .set_stride_constraint(2, 1);
+        }
+
+        if (real_result.defined()) {
+            real_result.compute_at(output, y);
+        }
+    }
+private:
+    Var x{"x"}, y{"y"}, c{"c"};
+    Func real_result;
+    ComplexFunc complex_result;
 };
 
 Halide::RegisterGenerator<FFTGenerator> register_fft{"fft"};

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -356,7 +356,7 @@ void StubEmitter::emit() {
         // on the other hand, since this file is just a couple of comments, it's
         // really not an issue if it's included multiple times.
         stream << "/* MACHINE-GENERATED - DO NOT EDIT */\n";
-        stream << "/* There is no Stub for the Generator named " << generator_name << " */\n";
+        stream << "/* The Generator named " << generator_name << " uses ImageParam or Param, thus cannot have a Stub generated. */\n";
         return;
     }
 
@@ -1161,6 +1161,12 @@ void GeneratorBase::set_inputs(const std::vector<std::vector<FuncOrExpr>> &input
             << " inputs but got " << inputs.size() << "\n";
     for (size_t i = 0; i < filter_inputs.size(); ++i) {
         filter_inputs[i]->set_inputs(inputs[i]);
+    }
+    for (auto input : filter_inputs) {
+        input->is_stub_usage_ = true;
+    }
+    for (auto output : filter_outputs) {
+        output->is_stub_usage_ = true;
     }
     inputs_set = true;
 }

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -151,9 +151,16 @@ class Buffer {
      * systems. */
     using storage_T = typename std::conditional<std::is_pointer<T>::value, uint64_t, not_void_T>::type;
 
+public:
+    /** Return true if the Halide type is not void (or const void). */
+    static bool has_static_halide_type() {
+        return !T_is_void;
+    }
+
     /** Get the Halide type of T. Callers should not use the result if
-     * T is void. */
+     * has_static_halide_type() returns false. */
     static halide_type_t static_halide_type() {
+        // assert(has_static_halide_type());  TODO
         return halide_type_of<typename std::remove_cv<not_void_T>::type>();
     }
 
@@ -162,6 +169,12 @@ class Buffer {
         return alloc != nullptr;
     }
     
+    /** Return the maximum number of dimensions for this Buffer type. */
+    static int static_halide_max_dimensions() {
+        return D;
+    }
+
+private:
     /** Increment the reference count of any owned allocation */
     void incref() const {
         if (!manages_memory()) return;

--- a/test/generator/msan_generator.cpp
+++ b/test/generator/msan_generator.cpp
@@ -4,37 +4,40 @@ namespace {
 
 class MSAN : public Halide::Generator<MSAN> {
 public:
-    Func build() {
-        // Currently the test just exercises Target::MSAN
-        Var x, y, c;
+    Output<Func> msan_output{"msan_output", Int(32), 3};
 
-        Func input("input");
+    void generate() {
+        // Currently the test just exercises Target::MSAN
         input(x, y, c) = cast<int32_t>(x + y + c);
 
         // This just makes an exact copy
-        Func msan_extern_stage;
         msan_extern_stage.define_extern("msan_extern_stage", {input}, Int(32), 3);
 
         RDom r(0, 4);
-        Func msan_output("msan_output");
         msan_output(x, y, c) = sum(msan_extern_stage(r, y, c));
 
         // Add two update phases to be sure annotation happens post-update
         msan_output(r, y, c) += 1;
         msan_output(x, r, c) += 2;
+    }
 
+    void schedule() {
         input.compute_root();
         msan_extern_stage.compute_root();
-        msan_output.parallel(y).vectorize(x, 4);
+        Func(msan_output).parallel(y).vectorize(x, 4);
+        if (msan_output.has_buffer()) {
+            msan_output.set_stride_constraint(0, Expr())
+                       .set_extent_constraint(0, 4)
+                       .set_extent_constraint(1, 4)
+                       .set_extent_constraint(2, 3);
+        }
 
-        msan_output.output_buffer()
-                   .set_stride(0, Expr())
-                   .set_extent(0, 4)
-                   .set_extent(1, 4)
-                   .set_extent(2, 3);
-
-        return msan_output;
     }
+private:
+    // Currently the test just exercises Target::MSAN
+    Var x, y, c;
+
+    Func input, msan_extern_stage;
 };
 
 Halide::RegisterGenerator<MSAN> register_my_gen{"msan"};

--- a/test/generator/nested_externs_generator.cpp
+++ b/test/generator/nested_externs_generator.cpp
@@ -4,118 +4,104 @@ using namespace Halide;
 
 namespace {
 
-void set_interleaved(OutputImageParam m) {
-    m.set_stride(0, 3);
-    //m.set_stride(0, 3).set_stride(2, 1).set_bounds(2, 0, 3);
+template<typename T>
+void set_interleaved(T &t) {
+    if (t.has_buffer()) {
+        t.set_stride_constraint(0, 3)
+         .set_min_constraint(2, 0)
+         .set_extent_constraint(2, 3)
+         .set_stride_constraint(2, 1);
+    }
 }
 
 // Add two inputs
 class NestedExternsCombine : public Generator<NestedExternsCombine> {
 public:
-    ImageParam input_a{ Float(32), 3, "a" };
-    ImageParam input_b{ Float(32), 3, "b" };
+    Input<Func>  input_a{ "input_a", Float(32), 3 };
+    Input<Func>  input_b{ "input_b", Float(32), 3 };
+    Output<Func> combine{ "combine", Float(32), 3 };
 
-    Func build() {
-        Func result("combine");
+    void generate() {
         Var x, y, c;
+        combine(x, y, c) = input_a(x, y, c) + input_b(x, y, c);
+    }
 
+    void schedule() {
         set_interleaved(input_a);
         set_interleaved(input_b);
-
-        result(x, y, c) = input_a(x, y, c) + input_b(x, y, c);
-
-        set_interleaved(result.output_buffer());
-
-        return result;
+        set_interleaved(combine);
     }
 };
 
 // Call two extern stages then pass the two results to another extern stage.
 class NestedExternsInner : public Generator<NestedExternsInner> {
 public:
-    Param<float> value {"value", 1.0f};
+    Input<float> value{ "value", 1.0f };
+    Output<Func> inner{ "inner", Float(32), 3 };
 
-    Func build() {
-        Func extern_stage_1;
+    void generate() {
         extern_stage_1.define_extern("nested_externs_leaf", {value}, Float(32), 3);
-        extern_stage_1.reorder_storage(extern_stage_1.args()[2],
-                                        extern_stage_1.args()[0],
-                                        extern_stage_1.args()[1]);
-        extern_stage_1.compute_root();
-
-        Func extern_stage_2;
         extern_stage_2.define_extern("nested_externs_leaf", {value+1}, Float(32), 3);
-        extern_stage_2.reorder_storage(extern_stage_2.args()[2],
-                                        extern_stage_2.args()[0],
-                                        extern_stage_2.args()[1]);
-        extern_stage_2.compute_root();
-
-        Func extern_stage_combine;
         extern_stage_combine.define_extern("nested_externs_combine", 
             {extern_stage_1, extern_stage_2}, Float(32), 3);
-        extern_stage_combine.compute_root();
-
-        set_interleaved(extern_stage_combine.output_buffer());
-
-        return extern_stage_combine;
+        inner(x, y, c) = extern_stage_combine(x, y, c);
     }
+
+    void schedule() {
+        for (Func f : { extern_stage_1, extern_stage_2, extern_stage_combine }) {
+            auto args = f.args();
+            f.compute_root().reorder_storage(args[2], args[0], args[1]);
+        }
+        set_interleaved(inner);
+    }
+
+private:
+    Var x, y, c;
+    Func extern_stage_1, extern_stage_2, extern_stage_combine;
 };
 
 // Basically a memset.
 class NestedExternsLeaf : public Generator<NestedExternsLeaf> {
 public:
+    Input<float> value{ "value", 1.0f };
+    Output<Func> leaf{ "leaf", Float(32), 3 };
 
-    Param<float> value {"value", 1.0f};
-
-    Func build() {
-        Func f("leaf");
+    void generate() {
         Var x, y, c;
-        f(x, y, c) = value;
+        leaf(x, y, c) = value;
+    }
 
-        set_interleaved(f.output_buffer());
-
-        return f;
+    void schedule() {
+        set_interleaved(leaf);
     }
 };
 
 // Call two extern stages then pass the two results to another extern stage.
 class NestedExternsRoot : public Generator<NestedExternsRoot> {
 public:
-    Param<float> value {"value", 1.0f};
+    Input<float> value{ "value", 1.0f };
+    Output<Func> root{ "root", Float(32), 3 };
 
-    Func build() {
-        Func extern_stage_1;
+    void generate() {
         extern_stage_1.define_extern("nested_externs_inner", {value}, Float(32), 3);
-        extern_stage_1.reorder_storage(extern_stage_1.args()[2],
-                                        extern_stage_1.args()[0],
-                                        extern_stage_1.args()[1]);
-
-        Func extern_stage_2;
         extern_stage_2.define_extern("nested_externs_inner", {value+1}, Float(32), 3);
-        extern_stage_2.reorder_storage(extern_stage_2.args()[2],
-                                        extern_stage_2.args()[0],
-                                        extern_stage_2.args()[1]);
-
-        Func extern_stage_combine;
         extern_stage_combine.define_extern("nested_externs_combine", 
             {extern_stage_1, extern_stage_2}, Float(32), 3);
-        extern_stage_combine.reorder_storage(extern_stage_combine.args()[2],
-                                             extern_stage_combine.args()[0],
-                                             extern_stage_combine.args()[1]);
-        set_interleaved(extern_stage_combine.output_buffer());
-
-        Func wrapper;
-        Var x, y, c;
-        wrapper(x, y, c) = extern_stage_combine(x, y, c);
-
-        wrapper.reorder(c, x, y);
-        extern_stage_1.compute_at(wrapper, y);
-        extern_stage_2.compute_at(wrapper, y);
-        extern_stage_combine.compute_at(wrapper, y);
-        set_interleaved(wrapper.output_buffer());
-
-        return wrapper;
+        root(x, y, c) = extern_stage_combine(x, y, c);
     }
+
+    void schedule() {
+        for (Func f : { extern_stage_1, extern_stage_2, extern_stage_combine }) {
+            auto args = f.args();
+            f.compute_at(root, y).reorder_storage(args[2], args[0], args[1]);
+        }
+        set_interleaved(root);
+        Func(root).reorder_storage(c, x, y);
+    }
+
+private:
+    Var x, y, c;
+    Func extern_stage_1, extern_stage_2, extern_stage_combine;
 };
 
 HALIDE_REGISTER_GENERATOR(NestedExternsCombine, "nested_externs_combine")

--- a/test/generator/stubtest_generator.cpp
+++ b/test/generator/stubtest_generator.cpp
@@ -49,6 +49,23 @@ public:
         if (vectorize) {
             intermediate.vectorize(x, natural_vector_size<float>());
         }
+
+        if (input.has_buffer()) {
+            for (size_t i = 0; i < input.size(); ++i) {
+                input.set_stride_constraint(i, 0, 1);
+            }
+        }
+        if (simple_output.has_buffer()) {
+            simple_output.set_stride_constraint(0, 1);
+        }
+        if (tuple_output.has_buffer()) {
+            tuple_output.set_stride_constraint(0, 1);
+        }
+        if (array_output.has_buffer()) {
+            for (size_t i = 0; i < array_output.size(); ++i) {
+                array_output.set_stride_constraint(i, 0, 1);
+            }
+        }
     }
 
 private:

--- a/test/generator/tiled_blur_blur_generator.cpp
+++ b/test/generator/tiled_blur_blur_generator.cpp
@@ -2,21 +2,25 @@
 
 namespace {
 
-Halide::Expr is_interleaved(const Halide::OutputImageParam &p, int channels = 3) {
+template<typename T>
+Halide::Expr is_interleaved(const T &p, int channels = 3) {
     return p.stride(0) == channels && p.stride(2) == 1 && p.extent(2) == channels;
 }
 
-Halide::Expr is_planar(const Halide::OutputImageParam &p, int channels = 3) {
+template<typename T>
+Halide::Expr is_planar(const T &p, int channels = 3) {
     return p.stride(0) == 1 && p.extent(2) == channels;
 }
 
 class TiledBlurBlur : public Halide::Generator<TiledBlurBlur> {
 public:
-    ImageParam input{ Int(32), 3, "input" };
-    Param<int> width{ "width" };
-    Param<int> height{ "height" };
+    Input<Func>    input{ "input", Int(32), 3 };
+    Input<int32_t> width{ "width" };
+    Input<int32_t> height{ "height" };
 
-    Func build() {
+    Output<Func>   blur{ "blur", Float(32), 3 };
+
+    void generate() {
         // We pass in parameters to tell us where the boundary
         // condition kicks in. This is decoupled from the size of the
         // input tile.
@@ -26,32 +30,36 @@ public:
         // kernel we can cope with any size input, so it would always
         // pass us 1x1 tiles.
 
-        Var x("x"), y("y"), c("c");
+        Func input_clamped = Halide::BoundaryConditions::repeat_edge(
+            input, 0, width, 0, height);
 
-        Func input_clamped = Halide::BoundaryConditions::repeat_edge(input, 0, width, 0, height);
-
-        Func blur("blur");
         blur(x, y, c) = 
             (input_clamped(x - 1, y, c) + input_clamped(x + 1, y, c) +
              input_clamped(x, y - 1, c) + input_clamped(x, y + 1, c)) /
             4.0f;
-
-        // Unset default constraints so that specialization works.
-        input.set_stride(0, Expr());
-        blur.output_buffer().set_stride(0, Expr());
-
-        // Add specialization for input and output buffers that are both planar.
-        blur.specialize(is_planar(input) && is_planar(blur.output_buffer()));
-
-        // Add specialization for input and output buffers that are both interleaved.
-        blur.specialize(is_interleaved(input) && is_interleaved(blur.output_buffer()));
-
-        // Note that other combinations (e.g. interleaved -> planar) will work
-        // but be relatively unoptimized.
-
-        return blur;
     }
+
+    void schedule() {
+        if (input.has_buffer() && blur.has_buffer()) {
+            // Unset default constraints so that specialization works.
+            input.set_stride_constraint(0, Expr());
+            blur.set_stride_constraint(0, Expr());
+
+            // Add specialization for input and output buffers that are both planar.
+            Func(blur).specialize(is_planar(input) && is_planar(blur));
+
+            // Add specialization for input and output buffers that are both interleaved.
+            Func(blur).specialize(is_interleaved(input) && is_interleaved(blur));
+
+            // Note that other combinations (e.g. interleaved -> planar) will work
+            // but be relatively unoptimized.
+        }
+    }
+
+private:
+    Var x{"x"}, y{"y"}, c{"c"};
 };
-Halide::RegisterGenerator<TiledBlurBlur> register_my_gen{"tiled_blur_blur"};
+
+HALIDE_REGISTER_GENERATOR(TiledBlurBlur, "tiled_blur_blur")
 
 }  // namespace

--- a/test/generator/tiled_blur_generator.cpp
+++ b/test/generator/tiled_blur_generator.cpp
@@ -2,40 +2,41 @@
 
 namespace {
 
-Halide::Expr is_interleaved(const Halide::OutputImageParam &p, int channels = 3) {
+template<typename T>
+Halide::Expr is_interleaved(const T &p, int channels = 3) {
     return p.stride(0) == channels && p.stride(2) == 1 && p.extent(2) == channels;
 }
 
-Halide::Expr is_planar(const Halide::OutputImageParam &p, int channels = 3) {
+template<typename T>
+Halide::Expr is_planar(const T &p, int channels = 3) {
     return p.stride(0) == 1 && p.extent(2) == channels;
 }
 
 class TiledBlur : public Halide::Generator<TiledBlur> {
 public:
-    ImageParam input{ Int(32), 3, "input" };
+    Input<Func>  input{ "input", Int(32), 3 };
+    Output<Func> brighter2{ "brighter2", Float(32), 3 };
 
-    Func build() {
+    void generate() {
+        assert(input.has_buffer());
+
         // This is the outermost pipeline, so input width and height
         // are meaningful. If you want to be able to call this outer
         // pipeline in a tiled fashion itself, then you should pass in
         // width and height as params, as with the blur above.
-
-        Var x("x"), y("y"), c("c");
-
-        Func brighter1("brighter1");
         brighter1(x, y, c) = input(x, y, c) * 1.2f;
 
-        Func tiled_blur;
         tiled_blur.define_extern(
             "tiled_blur_blur",
             { brighter1, input.width(), input.height() },
             Float(32), 3);
 
-        Func brighter2("brighter2");
         brighter2(x, y, c) = tiled_blur(x, y, c) * 1.2f;
+    }
 
+    void schedule() {
         Var xi, yi;
-        brighter2.reorder(c, x, y).tile(x, y, xi, yi, 32, 32);
+        Func(brighter2).reorder(c, x, y).tile(x, y, xi, yi, 32, 32);
         tiled_blur.compute_at(brighter2, x);
         brighter1.compute_at(brighter2, x);
 
@@ -45,22 +46,27 @@ public:
         // 33x33 near the boundaries
         brighter1.trace_realizations();
 
-        // Unset default constraints so that specialization works.
-        input.set_stride(0, Expr());
-        brighter2.output_buffer().set_stride(0, Expr());
+        if (input.has_buffer()) {
+            // Unset default constraints so that specialization works.
+            input.set_stride_constraint(0, Expr());
+            brighter2.set_stride_constraint(0, Expr());
 
-        // Add specialization for input and output buffers that are both planar.
-        brighter2.specialize(is_planar(input) && is_planar(brighter2.output_buffer()));
+            // Add specialization for input and output buffers that are both planar.
+            Func(brighter2).specialize(is_planar(input) && is_planar(brighter2));
 
-        // Add specialization for input and output buffers that are both interleaved.
-        brighter2.specialize(is_interleaved(input) && is_interleaved(brighter2.output_buffer()));
+            // Add specialization for input and output buffers that are both interleaved.
+            Func(brighter2).specialize(is_interleaved(input) && is_interleaved(brighter2));
 
-        // Note that other combinations (e.g. interleaved -> planar) will work
-        // but be relatively unoptimized.
-
-        return brighter2;
+            // Note that other combinations (e.g. interleaved -> planar) will work
+            // but be relatively unoptimized.
+        }
     }
+private:
+    Var x{"x"}, y{"y"}, c{"c"};
+    Func tiled_blur{"tiled_blur"};
+    Func brighter1{"brighter1"};
 };
-Halide::RegisterGenerator<TiledBlur> register_my_gen{"tiled_blur"};
+
+HALIDE_REGISTER_GENERATOR(TiledBlur, "tiled_blur")
 
 }  // namespace


### PR DESCRIPTION
(This PR is being offered as an alternative to PR#1649)

Currently, you are disallowed from using `ImageParam` with new-style Generators; this is problematic for Generators that need to make scheduling decisions based on attributes of the underlying Buffer. 

We could just allow ImageParams back in, but:
- syntactically this is weird
- we need something for `Output<>` as well, and using `OutputImageParam` for this is even weirder syntactically

This PR proposes to add `.has_buffer()` methods to `Input<Func>` and `Output<Func>`, which allows the scheduling code to determine if the Generator is being built in a configuration that guarantees that a given input or output is backed by a Buffer.

It also provides methods to get/set the stride/min/extent/alignment constraints for inputs and outputs; these methods all assert-fail at Halide compilation time if .has_buffer() returns false.

This PR also converts enough Generators in the tests and apps to demonstrate that this concept should be adequate to meet existing needs. 