### PR TITLE
Add require() operator

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2626,6 +2626,12 @@ void CodeGen_LLVM::visit(const Call *op) {
                 if (s) {
                     call_args.push_back(codegen(op->args[i]));
                     dst = builder->CreateCall(append_string, call_args);
+                } else if (t.is_bool()) {
+                    call_args.push_back(builder->CreateSelect(
+                        codegen(op->args[i]), 
+                        codegen(StringImm::make("true")), 
+                        codegen(StringImm::make("false"))));
+                    dst = builder->CreateCall(append_string, call_args);
                 } else if (t.is_int()) {
                     call_args.push_back(codegen(Cast::make(Int(64), op->args[i])));
                     call_args.push_back(ConstantInt::get(i32_t, 1));

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -657,23 +657,28 @@ Expr fast_exp(Expr x_full) {
     result = common_subexpression_elimination(result);
     return result;
 }
+Expr stringify(const std::vector<Expr> &args) {
+    return Internal::Call::make(type_of<const char *>(), Internal::Call::stringify,
+                                args, Internal::Call::Intrinsic);
+}
 
-Expr print(const std::vector<Expr> &args) {
+Expr combine_strings(const std::vector<Expr> &args) {
     // Insert spaces between each expr.
-    std::vector<Expr> print_args(args.size()*2);
+    std::vector<Expr> strings(args.size()*2);
     for (size_t i = 0; i < args.size(); i++) {
-        print_args[i*2] = args[i];
+        strings[i*2] = args[i];
         if (i < args.size() - 1) {
-            print_args[i*2+1] = Expr(" ");
+            strings[i*2+1] = Expr(" ");
         } else {
-            print_args[i*2+1] = Expr("\n");
+            strings[i*2+1] = Expr("\n");
         }
     }
 
-    // Concat all the args at runtime using stringify.
-    Expr combined_string =
-        Internal::Call::make(type_of<const char *>(), Internal::Call::stringify,
-                             print_args, Internal::Call::Intrinsic);
+    return stringify(strings);
+}
+
+Expr print(const std::vector<Expr> &args) {
+    Expr combined_string = combine_strings(args);
 
     // Call halide_print.
     Expr print_call =
@@ -692,6 +697,26 @@ Expr print_when(Expr condition, const std::vector<Expr> &args) {
     return Internal::Call::make(p.type(),
                                 Internal::Call::if_then_else,
                                 {condition, p, args[0]},
+                                Internal::Call::PureIntrinsic);
+}
+
+Expr require(Expr condition, const std::vector<Expr> &args) {
+    user_assert(condition.defined()) << "Require of undefined condition\n";
+    user_assert(condition.type().is_bool()) << "Require condition must be a boolean type\n";
+    user_assert(args.at(0).defined()) << "Require of undefined value\n";
+
+    Expr requirement_failed_error = 
+        Internal::Call::make(Int(32), 
+                             "halide_error_requirement_failed",
+                             {stringify({condition}), combine_strings(args)}, 
+                             Internal::Call::Extern);
+    // Just cast to the type expected by the success path: since the actual
+    // value will never be used in the failure branch, it doesn't really matter
+    // what it is, but the type must match.
+    Expr failure_value = cast(args[0].type(), requirement_failed_error);
+    return Internal::Call::make(args[0].type(),
+                                Internal::Call::if_then_else,
+                                {likely(condition), args[0], failure_value},
                                 Internal::Call::PureIntrinsic);
 }
 

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -652,6 +652,9 @@ enum halide_error_code_t {
      * too small to store all the values of a producer needed by the
      * consumer. */
     halide_error_code_fold_factor_too_small = -26,
+
+    /** User-specified require() expression was not satisfied. */
+    halide_error_code_requirement_failed = -27,
 };
 
 /** Halide calls the functions below on various error conditions. The
@@ -709,6 +712,7 @@ extern int halide_error_bad_fold(void *user_context, const char *func_name, cons
                                  const char *loop_name);
 extern int halide_error_fold_factor_too_small(void *user_context, const char *func_name, const char *var_name,
                                               int fold_factor, const char *loop_name, int required_extent);
+extern int halide_error_requirement_failed(void *user_context, const char *condition, const char *message);
 
 // @}
 

--- a/src/runtime/errors.cpp
+++ b/src/runtime/errors.cpp
@@ -193,5 +193,11 @@ WEAK int halide_error_fold_factor_too_small(void *user_context, const char *func
     return halide_error_code_fold_factor_too_small;
 }
 
+WEAK int halide_error_requirement_failed(void *user_context, const char *condition, const char *message) {
+    error(user_context)
+        << "Requirement Failed: (" << condition << ") " << message;
+    return halide_error_code_requirement_failed;
+}
+
 
 }  // extern "C"

--- a/src/runtime/runtime_api.cpp
+++ b/src/runtime/runtime_api.cpp
@@ -65,6 +65,7 @@ extern "C" __attribute__((used)) void *halide_runtime_api_functions[] = {
     (void *)&halide_error_param_too_small_f64,
     (void *)&halide_error_param_too_small_i64,
     (void *)&halide_error_param_too_small_u64,
+    (void *)&halide_error_requirement_failed,
     (void *)&halide_error_unaligned_host_ptr,
     (void *)&halide_float16_bits_to_double,
     (void *)&halide_float16_bits_to_float,

--- a/test/correctness/require.cpp
+++ b/test/correctness/require.cpp
@@ -1,0 +1,60 @@
+#include "Halide.h"
+#include <stdio.h>
+#include <memory>
+
+int error_occurred = false;
+void halide_error(void *ctx, const char *msg) {
+    printf("Saw Halide Error: %s\n", msg);
+    error_occurred = true;
+}
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // Use something other than 'int' here to ensure that the return
+    // type of the error-handler path doesn't need to match the expr type
+    const float kPrime1 = 7829.f;
+    const float kPrime2 = 7919.f;
+
+    Buffer<float> result;
+    Param<float> p1, p2;
+    Var x;
+    Func f;
+    f(x) = require((p1 + p2) == kPrime1, 
+                   (p1 + p2) * kPrime2,
+                   "The parameters should add to exactly", (kPrime1 * kPrime2), "but were", p1, p2);
+    f.set_error_handler(&halide_error);
+
+    // It should be the case that the non-error path of the code
+    // assumes (p1 + p2) == kPrime1, and thus hardcodes the body to fill
+    // in the result to the constant kPrime1*kPrime2 (rather than
+    // actually computing the result at runtime).
+    // f.compile_to_assembly("require_.s", {p1, p2}, "require_body");
+
+    p1.set(1);
+    p2.set(2);
+    error_occurred = false;
+    result = f.realize(1);
+    if (!error_occurred) {
+        printf("There should have been a requirement error\n");
+        return 1;
+    }
+
+
+    p1.set(1);
+    p2.set(kPrime1-1);
+    error_occurred = false;
+    result = f.realize(1);
+    if (error_occurred) {
+        printf("There should not have been a requirement error\n");
+        return 1;
+    }
+    if (result(0) != (kPrime1 * kPrime2)) {
+        printf("Unexpected value: %f\n", result(0));
+        return 1;
+    }
+
+    printf("Success!\n");
+    return 0;
+
+}


### PR DESCRIPTION
require() is essentially a runtime assertion; it verifies that an Expr
satisfies a precondition (terminating via halide_error() if it does
not).

Since this inserts runtime checks, it needs to be used with caution:
inserting into an inner loop could severely degrade performance.

The intended use is for:
— preconditions on Param<> inputs that need failure rather than silent
clamping
— debugging, in situations where print()/print_when() aren’t adequate
— in the future: unit testing, via enhancements to Generator