### PR TITLE
Fix realizing into multiple existing buffers

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -963,7 +963,7 @@ void Stage::split(const string &old, const string &outer, const string &inner, E
             // f.split(x, x, xi, 32).vectorize(xi, 8).unroll(xi);
             //
             // It's only the tail/epilogue that changes.
-            
+
             std::set<string> descends_from_shiftinwards_outer;
             for (const Split &s : definition.schedule().splits()) {
                 if (s.is_split() && s.tail == TailStrategy::ShiftInwards) {
@@ -983,7 +983,7 @@ void Stage::split(const string &old, const string &outer, const string &inner, E
             }
         }
     }
-    
+
     if (!definition.is_init()) {
         user_assert(tail != TailStrategy::ShiftInwards)
             << "When splitting Var " << old_name
@@ -2761,11 +2761,11 @@ const Internal::JITHandlers &Func::jit_handlers() {
     return pipeline().jit_handlers();
 }
 
-void Func::realize(Realization dst, const Target &target) {
+void Func::realize(BufferRefCollection dst, const Target &target) {
     pipeline().realize(dst, target);
 }
 
-void Func::infer_input_bounds(Realization dst) {
+void Func::infer_input_bounds(BufferRefCollection dst) {
     pipeline().infer_input_bounds(dst);
 }
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2761,11 +2761,11 @@ const Internal::JITHandlers &Func::jit_handlers() {
     return pipeline().jit_handlers();
 }
 
-void Func::realize(BufferRefCollection dst, const Target &target) {
+void Func::realize(BufferRefs dst, const Target &target) {
     pipeline().realize(dst, target);
 }
 
-void Func::infer_input_bounds(BufferRefCollection dst) {
+void Func::infer_input_bounds(BufferRefs dst) {
     pipeline().infer_input_bounds(dst);
 }
 

--- a/src/Func.h
+++ b/src/Func.h
@@ -524,11 +524,6 @@ public:
      * automatically copy data back from the GPU. */
     // @{
     EXPORT void realize(BufferRefs dst, const Target &target = Target());
-
-    template<typename T, int D>
-    NO_INLINE void realize(Buffer<T, D> &dst, const Target &target = Target()) {
-        realize({dst}, target);
-    }
     // @}
 
     /** For a given size of output, or a given output buffer,
@@ -539,11 +534,6 @@ public:
     // @{
     EXPORT void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0);
     EXPORT void infer_input_bounds(BufferRefs dst);
-
-    template<typename T, int D>
-    NO_INLINE void infer_input_bounds(Buffer<T, D> &im) {
-        infer_input_bounds({im});
-    }
     // @}
 
     /** Statically compile this function to llvm bitcode, with the

--- a/src/Func.h
+++ b/src/Func.h
@@ -523,7 +523,7 @@ public:
      * they must have matching sizes. This form of realize does *not*
      * automatically copy data back from the GPU. */
     // @{
-    EXPORT void realize(BufferRefCollection dst, const Target &target = Target());
+    EXPORT void realize(BufferRefs dst, const Target &target = Target());
 
     template<typename T, int D>
     NO_INLINE void realize(Buffer<T, D> &dst, const Target &target = Target()) {
@@ -538,7 +538,7 @@ public:
      * ImageParams. */
     // @{
     EXPORT void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0);
-    EXPORT void infer_input_bounds(BufferRefCollection dst);
+    EXPORT void infer_input_bounds(BufferRefs dst);
 
     template<typename T, int D>
     NO_INLINE void infer_input_bounds(Buffer<T, D> &im) {

--- a/src/Func.h
+++ b/src/Func.h
@@ -523,13 +523,11 @@ public:
      * they must have matching sizes. This form of realize does *not*
      * automatically copy data back from the GPU. */
     // @{
-    EXPORT void realize(Realization dst, const Target &target = Target());
+    EXPORT void realize(BufferRefCollection dst, const Target &target = Target());
 
     template<typename T, int D>
     NO_INLINE void realize(Buffer<T, D> &dst, const Target &target = Target()) {
-        Realization r(dst);
-        realize(r, target);
-        dst = r[0];
+        realize({dst}, target);
     }
     // @}
 
@@ -540,17 +538,11 @@ public:
      * ImageParams. */
     // @{
     EXPORT void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0);
-    EXPORT void infer_input_bounds(Realization dst);
+    EXPORT void infer_input_bounds(BufferRefCollection dst);
 
     template<typename T, int D>
     NO_INLINE void infer_input_bounds(Buffer<T, D> &im) {
-        // It's possible for bounds inference to also manipulate
-        // output buffers if their host pointer is null, so we must
-        // take Buffers by reference and communicate the bounds query
-        // result by modifying the argument.
-        Realization r(im);
-        infer_input_bounds(r);
-        im = r[0];
+        infer_input_bounds({im});
     }
     // @}
 

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -920,7 +920,7 @@ struct JITFuncCallContext {
 // Make a vector of void *'s to pass to the jit call using the
 // currently bound value for all of the params and image
 // params.
-vector<const void *> Pipeline::prepare_jit_call_arguments(Realization dst, const Target &target) {
+vector<const void *> Pipeline::prepare_jit_call_arguments(BufferRefCollection &dst, const Target &target) {
     user_assert(defined()) << "Can't realize an undefined Pipeline\n";
 
     compile_jit(target);
@@ -994,8 +994,8 @@ vector<const void *> Pipeline::prepare_jit_call_arguments(Realization dst, const
     }
 
     // Then the outputs
-    for (const Buffer<> &buf : dst) {
-        arg_values.push_back(buf.raw_buffer());
+    for (size_t i = 0; i < dst.size(); i++) {
+        arg_values.push_back(dst[i].raw_buffer());
         const void *ptr = arg_values.back();
         debug(1) << "JIT output buffer @ " << ptr << "\n";
     }
@@ -1052,7 +1052,7 @@ Pipeline::make_externs_jit_module(const Target &target,
     return result;
 }
 
-void Pipeline::realize(Realization dst, const Target &t) {
+void Pipeline::realize(BufferRefCollection dst, const Target &t) {
     Target target = t;
     user_assert(defined()) << "Can't realize an undefined Pipeline\n";
 
@@ -1165,7 +1165,7 @@ void Pipeline::realize(Realization dst, const Target &t) {
     jit_context.finalize(exit_status);
 }
 
-void Pipeline::infer_input_bounds(Realization dst) {
+void Pipeline::infer_input_bounds(BufferRefCollection dst) {
 
     Target target = get_jit_target_from_environment();
 

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -920,7 +920,7 @@ struct JITFuncCallContext {
 // Make a vector of void *'s to pass to the jit call using the
 // currently bound value for all of the params and image
 // params.
-vector<const void *> Pipeline::prepare_jit_call_arguments(BufferRefCollection &dst, const Target &target) {
+vector<const void *> Pipeline::prepare_jit_call_arguments(BufferRefs &dst, const Target &target) {
     user_assert(defined()) << "Can't realize an undefined Pipeline\n";
 
     compile_jit(target);
@@ -1052,7 +1052,7 @@ Pipeline::make_externs_jit_module(const Target &target,
     return result;
 }
 
-void Pipeline::realize(BufferRefCollection dst, const Target &t) {
+void Pipeline::realize(BufferRefs dst, const Target &t) {
     Target target = t;
     user_assert(defined()) << "Can't realize an undefined Pipeline\n";
 
@@ -1165,7 +1165,7 @@ void Pipeline::realize(BufferRefCollection dst, const Target &t) {
     jit_context.finalize(exit_status);
 }
 
-void Pipeline::infer_input_bounds(BufferRefCollection dst) {
+void Pipeline::infer_input_bounds(BufferRefs dst) {
 
     Target target = get_jit_target_from_environment();
 

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -355,10 +355,6 @@ public:
     EXPORT Realization realize(const Target &target = Target());
 
     EXPORT void realize(BufferRefs bufs, const Target &target = Target());
-    template<typename T, int D>
-    NO_INLINE void realize(Buffer<T, D> &buf, const Target &target = Target()) {
-        realize({buf}, target);
-    }
     // @}
 
     /** For a given size of output, or a given set of output buffers,
@@ -369,10 +365,6 @@ public:
     // @{
     EXPORT void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0);
     EXPORT void infer_input_bounds(BufferRefs bufs);
-    template<typename T, int D>
-    NO_INLINE void infer_input_bounds(Buffer<T, D> &buf) {
-        infer_input_bounds({buf});
-    }
     // @}
 
     /** Infer the arguments to the Pipeline, sorted into a canonical order:

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -59,7 +59,7 @@ class Pipeline {
 
     std::vector<Argument> infer_arguments(Internal::Stmt body);
     std::vector<Internal::BufferPtr> validate_arguments(const std::vector<Argument> &args, Internal::Stmt body);
-    std::vector<const void *> prepare_jit_call_arguments(BufferRefCollection &dst, const Target &target);
+    std::vector<const void *> prepare_jit_call_arguments(BufferRefs &dst, const Target &target);
 
     static std::vector<Internal::JITModule> make_externs_jit_module(const Target &target,
                                                                     std::map<std::string, JITExtern> &externs_in_out);
@@ -354,7 +354,7 @@ public:
                                const Target &target = Target());
     EXPORT Realization realize(const Target &target = Target());
 
-    EXPORT void realize(BufferRefCollection bufs, const Target &target = Target());
+    EXPORT void realize(BufferRefs bufs, const Target &target = Target());
     template<typename T, int D>
     NO_INLINE void realize(Buffer<T, D> &buf, const Target &target = Target()) {
         realize({buf}, target);
@@ -368,7 +368,7 @@ public:
      * ImageParams. */
     // @{
     EXPORT void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0);
-    EXPORT void infer_input_bounds(BufferRefCollection bufs);
+    EXPORT void infer_input_bounds(BufferRefs bufs);
     template<typename T, int D>
     NO_INLINE void infer_input_bounds(Buffer<T, D> &buf) {
         infer_input_bounds({buf});

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -59,7 +59,7 @@ class Pipeline {
 
     std::vector<Argument> infer_arguments(Internal::Stmt body);
     std::vector<Internal::BufferPtr> validate_arguments(const std::vector<Argument> &args, Internal::Stmt body);
-    std::vector<const void *> prepare_jit_call_arguments(Realization dst, const Target &target);
+    std::vector<const void *> prepare_jit_call_arguments(BufferRefCollection &dst, const Target &target);
 
     static std::vector<Internal::JITModule> make_externs_jit_module(const Target &target,
                                                                     std::map<std::string, JITExtern> &externs_in_out);
@@ -353,13 +353,11 @@ public:
     EXPORT Realization realize(int x_size,
                                const Target &target = Target());
     EXPORT Realization realize(const Target &target = Target());
-    EXPORT void realize(Realization dst, const Target &target = Target());
 
+    EXPORT void realize(BufferRefCollection bufs, const Target &target = Target());
     template<typename T, int D>
-    NO_INLINE void realize(Buffer<T, D> &dst, const Target &target = Target()) {
-        Realization r(dst);
-        realize(r, target);
-        dst = r[0];
+    NO_INLINE void realize(Buffer<T, D> &buf, const Target &target = Target()) {
+        realize({buf}, target);
     }
     // @}
 
@@ -370,17 +368,10 @@ public:
      * ImageParams. */
     // @{
     EXPORT void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0);
-    EXPORT void infer_input_bounds(Realization dst);
-
+    EXPORT void infer_input_bounds(BufferRefCollection bufs);
     template<typename T, int D>
-    NO_INLINE void infer_input_bounds(Buffer<T, D> &im) {
-        // It's possible for bounds inference to also manipulate
-        // output buffers if their host pointer is null, so we must
-        // take Images by reference and communicate the bounds query
-        // result by modifying the argument.
-        Realization r(im);
-        infer_input_bounds(r);
-        im = r[0];
+    NO_INLINE void infer_input_bounds(Buffer<T, D> &buf) {
+        infer_input_bounds({buf});
     }
     // @}
 

--- a/src/Tuple.h
+++ b/src/Tuple.h
@@ -63,7 +63,7 @@ public:
 };
 
 /** Funcs with Tuple values return multiple images when you realize
- * them. Tuples are to Exprs as Realizations are to Images. */
+ * them. Tuples are to Exprs as Realizations are to Buffers. */
 class Realization {
 private:
     std::vector<Internal::BufferPtr> images;
@@ -83,13 +83,13 @@ public:
         return images[x].get();
     }
 
-    /** Single-element realizations are implicitly castable to Images. */
+    /** Single-element realizations are implicitly castable to Buffers. */
     template<typename T, int D>
     operator Buffer<T, D>() const {
         return images[0];
     }
 
-    /** Construct a Realization from some Images. */
+    /** Construct a Realization from some Buffers. */
     //@{
     template<typename T,
              int D,
@@ -108,7 +108,7 @@ public:
         }
     }
 
-    /** Support for iterating over a the Images in a Realization */
+    /** Support for iterating over a the Buffers in a Realization */
     struct iterator {
         std::vector<Internal::BufferPtr>::iterator iter;
 
@@ -155,6 +155,45 @@ public:
         return {images.end()};
     }
 
+};
+
+/** It's also useful to be able to collect some mutable references to
+ * existing buffer objects into an aggregate structure, so that the
+ * metadata on those buffers can be mutated. This is a temporary type
+ * used for argument passing groups of Buffers into Pipeline::realize
+ * and Pipeline::infer_input_bounds. It does not affect the lifetime
+ * of the buffers that it refers to. */
+class BufferRefCollection {
+    std::vector<Buffer<> *> ptrs;
+
+    template<typename T, int D, typename ...Args>
+    void init(Buffer<T, D> *first, Args... rest) {
+        ptrs.push_back(&(first->template as<void>()));
+        init(rest...);
+    }
+
+    void init() {}
+
+public:
+    template<typename T, int D, typename ...Args,
+             typename = std::enable_if<Internal::all_are_convertible<Buffer<>, Args...>::value>>
+    BufferRefCollection(Buffer<T, D> &first, Args&... rest) {
+        init(&first, &rest...);
+    }
+
+    BufferRefCollection(Realization r) : ptrs(r.size()) {
+        for (size_t i = 0; i < r.size(); i++) {
+            ptrs[i] = &r[i];
+        }
+    }
+
+    size_t size() const {
+        return ptrs.size();
+    }
+
+    Buffer<> &operator[](int i) const {
+        return *ptrs[i];
+    }
 };
 
 /** Equivalents of some standard operators for tuples. */

--- a/src/Tuple.h
+++ b/src/Tuple.h
@@ -163,7 +163,7 @@ public:
  * used for argument passing groups of Buffers into Pipeline::realize
  * and Pipeline::infer_input_bounds. It does not affect the lifetime
  * of the buffers that it refers to. */
-class BufferRefCollection {
+class BufferRefs {
     std::vector<Buffer<> *> ptrs;
 
     template<typename T, int D, typename ...Args>
@@ -177,11 +177,11 @@ class BufferRefCollection {
 public:
     template<typename T, int D, typename ...Args,
              typename = std::enable_if<Internal::all_are_convertible<Buffer<>, Args...>::value>>
-    BufferRefCollection(Buffer<T, D> &first, Args&... rest) {
+    BufferRefs(Buffer<T, D> &first, Args&... rest) {
         init(&first, &rest...);
     }
 
-    BufferRefCollection(Realization r) : ptrs(r.size()) {
+    BufferRefs(Realization r) : ptrs(r.size()) {
         for (size_t i = 0; i < r.size(); i++) {
             ptrs[i] = &r[i];
         }

--- a/test/correctness/multiple_outputs.cpp
+++ b/test/correctness/multiple_outputs.cpp
@@ -4,6 +4,8 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
+    const bool use_gpu = get_jit_target_from_environment().has_gpu_feature();
+
     // An internal Func that produces multiple values.
     {
         Func f, g;
@@ -14,6 +16,10 @@ int main(int argc, char **argv) {
 
         Tuple t = f(x);
         g(x) = t[0] + t[1];
+
+        if (use_gpu) {
+            g.gpu_tile(x, 8);
+        }
 
         g.realize(100);
     }
@@ -36,6 +42,10 @@ int main(int argc, char **argv) {
                            {r.x, r.y, next_value},
                            {best_x, best_y, best_so_far});
 
+        if (use_gpu) {
+            g.gpu_single_thread();
+        }
+
         Realization result = g.realize();
         // int result_x = Buffer<int>(result[0])(0);
         // int result_y = Buffer<int>(result[1])(0);
@@ -52,9 +62,21 @@ int main(int argc, char **argv) {
         Var x;
         f(x) = 100*x;
         g(x) = x;
+
+        if (use_gpu) {
+            f.gpu_tile(x, 8);
+            g.gpu_tile(x, 8);
+        }
+
         Buffer<int> f_im(100);
         Buffer<int> g_im(10);
         Pipeline({f, g}).realize({f_im, g_im});
+
+        if (use_gpu) {
+            assert(f_im.device_dirty() && g_im.device_dirty());
+            f_im.copy_to_host();
+            g_im.copy_to_host();
+        }
 
         for (int x = 0; x < f_im.width(); x++) {
             if (f_im(x) != 100*x) {
@@ -80,9 +102,27 @@ int main(int argc, char **argv) {
         h(x) = {f(x) + 17, f(x) - 17};
         g(x, y) = {f(x + y) * 2, h(x)[0] * y, h(x)[1] - 2};
 
+        if (get_jit_target_from_environment().has_gpu_feature()) {
+            g.gpu_tile(x, y, 1, 1);
+        }
+
         Buffer<int> f_im(100), g_im0(20, 20), g_im1(20, 20), g_im2(20, 20), h_im0(50), h_im1(50);
 
         Pipeline({h, g, f}).realize({h_im0, h_im1, g_im0, g_im1, g_im2, f_im});
+
+        if (use_gpu) {
+            // g should have been written on the device
+            assert(g_im0.device_dirty() &&
+                   g_im1.device_dirty() &&
+                   g_im2.device_dirty());
+            // f and h should have been copied to the device for g to read
+            assert(f_im.has_device_allocation() &&
+                   h_im0.has_device_allocation() &&
+                   h_im1.has_device_allocation());
+            g_im0.copy_to_host();
+            g_im1.copy_to_host();
+            g_im2.copy_to_host();
+        }
 
         for (int x = 0; x < 100; x++) {
             if (f_im(x) != x) {


### PR DESCRIPTION
The natural way to realize into multiple existing buffers currently is
to put them in a temporary Realization:

f.realize({im1, im2});

This doesn't do precisely you want (it used to, before the Buffer
change). The Realization constructor makes a copy of those buffer
objects that it can own, so you'll lose any mutation of the metadata
(e.g. device allocations). It's also different to this:

f.realize(im1);

which takes im1 by reference and updates the metadata

This PR adds a new realization-like class that collects an array of
mutable references to existing buffers. It's a temporary type solely
used for passing groups of buffers to realize and infer_input_bounds. It
changes the meaning of

f.realize({im1, im2})

to take im1 and im2 by reference, the way it used to be.