### PR TITLE
fix C++ name-mangling for GPU targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -875,6 +875,13 @@ $(FILTERS_DIR)/cxx_mangling_define_extern.a: $(BIN_DIR)/cxx_mangling_define_exte
 	@-mkdir -p $(TMP_DIR)
 	cd $(TMP_DIR); $(CURDIR)/$< -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime-c_plus_plus_name_mangling-user_context -f "HalideTest::cxx_mangling_define_extern"
 
+# acquire_release needs a custom target: in addition to enabling a GPU target,
+# we build with C++ name mangling to ensure that the GPU-Host code path mangles properly.
+$(FILTERS_DIR)/acquire_release.a: $(BIN_DIR)/acquire_release.generator
+	@mkdir -p $(FILTERS_DIR)
+	@-mkdir -p $(TMP_DIR)
+	cd $(TMP_DIR); $(CURDIR)/$< -f acquire_release -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-c_plus_plus_name_mangling-opencl
+
 # pyramid needs a custom arg
 $(FILTERS_DIR)/pyramid.a: $(BIN_DIR)/pyramid.generator
 	@mkdir -p $(FILTERS_DIR)

--- a/Makefile
+++ b/Makefile
@@ -872,17 +872,18 @@ $(FILTERS_DIR)/cxx_mangling.a: $(BIN_DIR)/cxx_mangling.generator
 	@-mkdir -p $(TMP_DIR)
 	cd $(TMP_DIR); $(CURDIR)/$< -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime-c_plus_plus_name_mangling -f "HalideTest::cxx_mangling"
 
+# Also build with a gpu target to ensure that the GPU-Host generation
+# code handles name mangling properly. (Note that we don't need to
+# run this code, just check for link errors.)
+$(FILTERS_DIR)/cxx_mangling_gpu.a: $(BIN_DIR)/cxx_mangling.generator
+	@mkdir -p $(FILTERS_DIR)
+	@-mkdir -p $(TMP_DIR)
+	cd $(TMP_DIR); $(CURDIR)/$< -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime-c_plus_plus_name_mangling-cuda -f "HalideTest::cxx_mangling_gpu"
+
 $(FILTERS_DIR)/cxx_mangling_define_extern.a: $(BIN_DIR)/cxx_mangling_define_extern.generator
 	@mkdir -p $(FILTERS_DIR)
 	@-mkdir -p $(TMP_DIR)
 	cd $(TMP_DIR); $(CURDIR)/$< -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-no_runtime-c_plus_plus_name_mangling-user_context -f "HalideTest::cxx_mangling_define_extern"
-
-# acquire_release needs a custom target: in addition to enabling a GPU target,
-# we build with C++ name mangling to ensure that the GPU-Host code path mangles properly.
-$(FILTERS_DIR)/acquire_release.a: $(BIN_DIR)/acquire_release.generator
-	@mkdir -p $(FILTERS_DIR)
-	@-mkdir -p $(TMP_DIR)
-	cd $(TMP_DIR); $(CURDIR)/$< -f acquire_release -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-c_plus_plus_name_mangling-opencl
 
 # pyramid needs a custom arg
 $(FILTERS_DIR)/pyramid.a: $(BIN_DIR)/pyramid.generator
@@ -956,6 +957,7 @@ $(FILTERS_DIR)/matlab.a: $(BIN_DIR)/matlab.generator
 # TODO(srj): we really want to say "anything that depends on tiled_blur.a also depends on tiled_blur_blur.a";
 # is there a way to specify that in Make?
 $(BIN_DIR)/generator_aot_tiled_blur: $(FILTERS_DIR)/tiled_blur_blur.a
+$(BIN_DIR)/generator_aot_cxx_mangling: $(FILTERS_DIR)/cxx_mangling_gpu.a
 $(BIN_DIR)/generator_aot_cxx_mangling_define_extern: $(FILTERS_DIR)/cxx_mangling.a
 
 $(BIN_DIR)/stubuser_generator.o: $(FILTERS_DIR)/stubtest.stub.h

--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -135,7 +135,7 @@ CodeGen_GPU_Host<CodeGen_CPU>::~CodeGen_GPU_Host() {
 template<typename CodeGen_CPU>
 void CodeGen_GPU_Host<CodeGen_CPU>::compile_func(const LoweredFunc &f,
                                                  const std::string &simple_name,
-                                                 const std::string &/* extern_name */) {
+                                                 const std::string &extern_name) {
     function_name = simple_name;
 
     // Create a new module for all of the kernels we find in this function.
@@ -144,7 +144,7 @@ void CodeGen_GPU_Host<CodeGen_CPU>::compile_func(const LoweredFunc &f,
     }
 
     // Call the base implementation to create the function.
-    CodeGen_CPU::compile_func(f, f.name, f.name);
+    CodeGen_CPU::compile_func(f, simple_name, extern_name);
 
     // We need to insert code after the existing entry block, so that
     // the destructor stack slots exist before we do the assertions

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -238,8 +238,7 @@ if (WITH_TEST_GENERATORS)
   # test that executes the generated code (e.g. from example_aottest.cpp).
 
   # Tests with no special requirements
-  halide_define_aot_test(acquire_release
-                         GENERATOR_HALIDE_TARGET host-c_plus_plus_name_mangling-opencl)
+  halide_define_aot_test(acquire_release)
   halide_define_aot_test(argvcall)
   halide_define_aot_test(can_use_target)
   halide_define_aot_test(cleanup_on_error)
@@ -272,6 +271,10 @@ if (WITH_TEST_GENERATORS)
   halide_define_aot_test(cxx_mangling 
                          GENERATOR_HALIDE_TARGET host-c_plus_plus_name_mangling
                          GENERATED_FUNCTION HalideTest::cxx_mangling)
+  halide_add_aot_test_dependency(cxx_mangling
+                               AOT_LIBRARY_TARGET cxx_mangling_gpu
+                               GENERATED_FUNCTION HalideTest::cxx_mangling_gpu
+                               GENERATOR_HALIDE_TARGET host-c_plus_plus_name_mangling-cuda)
 
   halide_define_aot_test(pyramid
                          GENERATOR_ARGS levels=10)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -238,7 +238,8 @@ if (WITH_TEST_GENERATORS)
   # test that executes the generated code (e.g. from example_aottest.cpp).
 
   # Tests with no special requirements
-  halide_define_aot_test(acquire_release)
+  halide_define_aot_test(acquire_release
+                         GENERATOR_HALIDE_TARGET host-c_plus_plus_name_mangling-opencl)
   halide_define_aot_test(argvcall)
   halide_define_aot_test(can_use_target)
   halide_define_aot_test(cleanup_on_error)

--- a/test/generator/acquire_release_generator.cpp
+++ b/test/generator/acquire_release_generator.cpp
@@ -1,4 +1,4 @@
-#include "Halide.h"
+ #include "Halide.h"
 
 namespace {
 
@@ -16,6 +16,9 @@ public:
         Target target = get_target();
         if (target.has_gpu_feature()) {
             f.gpu_tile(x, y, 16, 16).compute_root();
+        } else {
+            assert(!"This Generator should always be build with a GPU feature");
+            exit(1);  // just in case we're build with NDEBUG
         }
         return f;
     }

--- a/test/generator/acquire_release_generator.cpp
+++ b/test/generator/acquire_release_generator.cpp
@@ -1,4 +1,4 @@
- #include "Halide.h"
+#include "Halide.h"
 
 namespace {
 
@@ -16,9 +16,6 @@ public:
         Target target = get_target();
         if (target.has_gpu_feature()) {
             f.gpu_tile(x, y, 16, 16).compute_root();
-        } else {
-            assert(!"This Generator should always be built with a GPU feature");
-            exit(1);  // just in case we're build with NDEBUG
         }
         return f;
     }

--- a/test/generator/acquire_release_generator.cpp
+++ b/test/generator/acquire_release_generator.cpp
@@ -17,7 +17,7 @@ public:
         if (target.has_gpu_feature()) {
             f.gpu_tile(x, y, 16, 16).compute_root();
         } else {
-            assert(!"This Generator should always be build with a GPU feature");
+            assert(!"This Generator should always be built with a GPU feature");
             exit(1);  // just in case we're build with NDEBUG
         }
         return f;

--- a/test/generator/cxx_mangling_aottest.cpp
+++ b/test/generator/cxx_mangling_aottest.cpp
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #include "cxx_mangling.h"
+#include "cxx_mangling_gpu.h"
 
 using namespace Halide;
 
@@ -42,6 +43,11 @@ int main(int argc, char **argv) {
     const void *const_void_ptr = nullptr;
     std::string *string_ptr = nullptr;
     const std::string *const_string_ptr = nullptr;
+
+    // Don't bother calling this (we haven't linked in the CUDA support it needs),
+    // just force a reference to ensure it is linked in.
+    auto f = HalideTest::cxx_mangling_gpu;
+    printf("HalideTest::cxx_mangling is at: %p\n", (void*) f);
 
     int r = HalideTest::cxx_mangling(input, -1, 0xff, -1, 0xffff, -1, 0xffffffff,
                                     -1, 0xffffffffffffffffLL, true, 42.0, 4239.0f,


### PR DESCRIPTION
We never name-mangled the external functions if the target had a GPU
feature; we never noticed this because we didn’t attempt to test it.