### PR TITLE
Buffer::decref()/decref_dev() need to null alloc and buf.host

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -618,6 +618,10 @@ public:
      * own memory. */
     void deallocate() {
         decref();
+        if (manages_memory()) {
+            buf.host = nullptr;
+            alloc = nullptr;
+        }
     }
 
     /** Drop reference to any owned device memory, possibly freeing it

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -617,10 +617,10 @@ public:
      * the buffer. Does nothing if this buffer did not allocate its
      * own memory. */
     void deallocate() {
-        decref();
         if (manages_memory()) {
-            buf.host = nullptr;
+            decref();
             alloc = nullptr;
+            buf.host = nullptr;
         }
     }
 
@@ -631,6 +631,8 @@ public:
     void device_deallocate() {
         if (manages_memory()) {
             decref_dev();
+            dev_ref_count = nullptr;
+            buf.dev = 0;
         }
     }
 

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -190,10 +190,11 @@ class Buffer {
             if (new_count == 0) {
                 void (*fn)(void *) = alloc->deallocate_fn;
                 fn(alloc);
-                buf.host = nullptr;
-                alloc = nullptr;
             }
         }
+        buf.host = nullptr;
+        alloc = nullptr;
+
         decref_dev();
     }
 
@@ -215,10 +216,10 @@ class Buffer {
             }
             if (dev_ref_count) {
                 delete dev_ref_count;
-                dev_ref_count = nullptr;
             }
         }
         buf.dev = 0;
+        dev_ref_count = nullptr;
     }
 
     /** A temporary helper function to get the number of dimensions in
@@ -617,11 +618,7 @@ public:
      * the buffer. Does nothing if this buffer did not allocate its
      * own memory. */
     void deallocate() {
-        if (manages_memory()) {
-            decref();
-            alloc = nullptr;
-            buf.host = nullptr;
-        }
+        decref();
     }
 
     /** Drop reference to any owned device memory, possibly freeing it
@@ -631,8 +628,6 @@ public:
     void device_deallocate() {
         if (manages_memory()) {
             decref_dev();
-            dev_ref_count = nullptr;
-            buf.dev = 0;
         }
     }
 


### PR DESCRIPTION
Otherwise explicitly calling deallocate() could lead to double-frees
later.

(Note: do we need a similar fix in device_deallocate()?)