### PR TITLE
Remove buffer_t from tutorials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1019,7 +1019,7 @@ $(BIN_DIR)/tutorial_%: $(ROOT_DIR)/tutorial/%.cpp $(BIN_DIR)/libHalide.$(SHARED_
 		export LESSON=`echo $${TUTORIAL} | cut -b1-9`; \
 		make -f $(THIS_MAKEFILE) tutorial_$${TUTORIAL/run/generate}; \
 		$(CXX) $(TUTORIAL_CXX_FLAGS) $(LIBPNG_CXX_FLAGS) $(OPTIMIZE) $< \
-		-I$(TMP_DIR) $(TMP_DIR)/$${LESSON}_*.a -lpthread $(LIBDL) $(LIBPNG_LIBS) -lz -o $@; \
+		-I$(TMP_DIR) -I$(INCLUDE_DIR) $(TMP_DIR)/$${LESSON}_*.a -lpthread $(LIBDL) $(LIBPNG_LIBS) -lz -o $@; \
 	else \
 		$(CXX) $(TUTORIAL_CXX_FLAGS) $(LIBPNG_CXX_FLAGS) $(OPTIMIZE) $< \
 		-I$(INCLUDE_DIR) -I$(ROOT_DIR)/tools $(TEST_LD_FLAGS) $(LIBPNG_LIBS) -o $@;\

--- a/tutorial/lesson_10_aot_compilation_generate.cpp
+++ b/tutorial/lesson_10_aot_compilation_generate.cpp
@@ -19,7 +19,7 @@
 // On os x:
 // g++ lesson_10*generate.cpp -g -std=c++11 -I ../include -L ../bin -lHalide -o lesson_10_generate
 // DYLD_LIBRARY_PATH=../bin ./lesson_10_generate
-// g++ lesson_10*run.cpp lesson_10_halide.a -o lesson_10_run
+// g++ lesson_10*run.cpp lesson_10_halide.a -o lesson_10_run -I ../include
 // ./lesson_10_run
 
 // The benefits of this approach are that the final program:

--- a/tutorial/lesson_10_aot_compilation_run.cpp
+++ b/tutorial/lesson_10_aot_compilation_run.cpp
@@ -10,98 +10,37 @@
 // produced when we ran it:
 #include "lesson_10_halide.h"
 
+// We want to continue to use our Halide::Buffer with AOT-compiled
+// code, so we explicitly include it. It's a header-only class, and
+// doesn't require libHalide.
+#include "HalideBuffer.h"
+
 #include <stdio.h>
 
 int main(int argc, char **argv) {
     // Have a look in the header file above (it won't exist until you've run
-    // lesson_10_generate).
-
-    // It starts with a definition of a buffer_t:
-    //
-    // typedef struct buffer_t {
-    //     uint64_t dev;
-    //     uint8_t* host;
-    //     int32_t extent[4];
-    //     int32_t stride[4];
-    //     int32_t min[4];
-    //     int32_t elem_size;
-    //     bool host_dirty;
-    //     bool dev_dirty;
-    // } buffer_t;
-    //
-    // This is how Halide represents input and output images in
-    // pre-compiled pipelines. There's a 'host' pointer that points to the
-    // start of the image data, some fields that describe how to access
-    // pixels, and some fields related to using the GPU that we'll ignore
-    // for now (dev, host_dirty, dev_dirty).
-
-    // Let's make some input data to test with:
-    uint8_t input[640 * 480];
-    for (int y = 0; y < 480; y++) {
-        for (int x = 0; x < 640; x++) {
-            input[y * 640 + x] = x ^ (y + 1);
-        }
-    }
-
-    // And the memory where we want to write our output:
-    uint8_t output[640 * 480];
-
-    // In AOT-compiled mode, Halide doesn't manage this memory for
-    // you. You should use whatever image data type makes sense for
-    // your application. Halide just needs pointers to it.
-
-    // Now we make a buffer_t to represent our input and output. It's
-    // important to zero-initialize them so you don't end up with
-    // garbage fields that confuse Halide.
-    buffer_t input_buf = {0}, output_buf = {0};
-
-    // The host pointers point to the start of the image data:
-    input_buf.host  = &input[0];
-    output_buf.host = &output[0];
-
-    // To access pixel (x, y) in a two-dimensional buffer_t, Halide
-    // looks at memory address:
-
-    // host + elem_size * ((x - min[0])*stride[0] + (y - min[1])*stride[1])
-
-    // The stride in a dimension represents the number of elements in
-    // memory between adjacent entries in that dimension. We have a
-    // grayscale image stored in scanline order, so stride[0] is 1,
-    // because pixels that are adjacent in x are next to each other in
-    // memory.
-    input_buf.stride[0] = output_buf.stride[0] = 1;
-
-    // stride[1] is the width of the image, because pixels that are
-    // adjacent in y are separated by a scanline's worth of pixels in
-    // memory.
-    input_buf.stride[1] = output_buf.stride[1] = 640;
-
-    // The extent tells us how large the image is in each dimension.
-    input_buf.extent[0] = output_buf.extent[0] = 640;
-    input_buf.extent[1] = output_buf.extent[1] = 480;
-
-    // We'll leave the mins as zero. This is what they typically
-    // are. The host pointer points to the memory location of the min
-    // coordinate (not the origin!).  See lesson 6 for more detail
-    // about the mins.
-
-    // The elem_size field tells us how many bytes each element
-    // uses. For the 8-bit image we use in this test it's one.
-    input_buf.elem_size = output_buf.elem_size = 1;
-
-    // To avoid repeating all the boilerplate above, We recommend you
-    // make a helper function that populates a buffer_t given whatever
-    // image type you're using.
-
-    // Now that we've setup our input and output buffers, we can call
-    // our function. Looking in the header file, its signature is:
+    // lesson_10_generate). At the bottom is the signature of the function we generated:
 
     // int brighter(buffer_t *_input_buffer, uint8_t _offset, buffer_t *_brighter_buffer);
 
+    // The ImageParam inputs have become pointers to "buffer_t"
+    // structs. This is struct that Halide uses to represent arrays of
+    // data.  Unless you're calling the Halide pipeline from pure C
+    // code, you don't want to use it directly. Halide::Buffer will
+    // implicitly convert to a buffer_t *, so we can pass
+    // Halide::Buffer objects in those slots.
+
     // The return value is an error code. It's zero on success.
 
+    // Let's make a buffer for our input and output.
+    Halide::Buffer<uint8_t> input(640, 480), output(640, 480);
+
+    // Halide::Buffer also has constructors that wrap existing
+    // data instead of allocating new memory. Use these if you
+    // have your own Image type that you want to use.
+
     int offset = 5;
-    int error = brighter(&input_buf, offset, &output_buf);
+    int error = brighter(input, offset, output);
 
     if (error) {
         printf("Halide returned an error: %d\n", error);
@@ -112,8 +51,8 @@ int main(int argc, char **argv) {
     // supposed to add the offset to every input pixel.
     for (int y = 0; y < 480; y++) {
         for (int x = 0; x < 640; x++) {
-            uint8_t input_val = input[y * 640 + x];
-            uint8_t output_val = output[y * 640 + x];
+            uint8_t input_val = input(x, y);
+            uint8_t output_val = output(x, y);
             uint8_t correct_val = input_val + offset;
             if (output_val != correct_val) {
                 printf("output(%d, %d) was %d instead of %d\n",

--- a/tutorial/lesson_16_rgb_run.cpp
+++ b/tutorial/lesson_16_rgb_run.cpp
@@ -12,64 +12,16 @@
 #include "brighten_either.h"
 #include "brighten_specialized.h"
 
+// We'll use the Halide::Buffer class for passing data into and out of
+// the pipeline.
+#include "HalideBuffer.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 
 #include "clock.h"
-
-buffer_t make_planar_rgb_image(int width, int height) {
-    buffer_t buf = {0};
-    // Allocate the memory required and clear it
-    buf.host = (uint8_t *)malloc(width * height * 3);
-    memset(buf.host, 0, width * height * 3);
-    // This will be an 8-bit image.
-    buf.elem_size = 1;
-
-    // Set the sizes of each dimension
-    buf.extent[0] = width;
-    buf.extent[1] = height;
-    // There are three color channels
-    buf.extent[2] = 3;
-
-    // Planar layout means that the stride in x is 1
-    buf.stride[0] = 1;
-    // The stride in y is the width of the image
-    buf.stride[1] = width;
-    // And the stride in c is width times height. This means that to
-    // get to the next color channel, one should step forwards
-    // width*height elements in memory.
-    buf.stride[2] = width*height;
-
-    return buf;
-}
-
-buffer_t make_interleaved_rgb_image(int width, int height) {
-    buffer_t buf = {0};
-    // This code will be the same as making a planar rgb image ...
-    buf.host = (uint8_t *)malloc(width * height * 3);
-    memset(buf.host, 0, width * height * 3);
-    buf.elem_size = 1;
-    buf.extent[0] = width;
-    buf.extent[1] = height;
-    buf.extent[2] = 3;
-
-    // ... except we'll set up the strides differently.
-    // Interleaved layout means that the stride in x is 3
-    buf.stride[0] = 3;
-    // The stride in y is three times the width of the image
-    buf.stride[1] = 3*width;
-    // And the stride in c is 1.
-    buf.stride[2] = 1;
-
-    return buf;
-}
-
-void destroy_image(buffer_t *b) {
-    free(b->host);
-    b->host = NULL;
-}
 
 // A function to help us report runtimes of various things. Prints the
 // time elapsed since the last time you called this function.
@@ -87,11 +39,22 @@ double tick(const char *name) {
 int main(int argc, char **argv) {
 
     // Let's make some images stored with interleaved and planar
-    // memory, and buffer_ts that describe them.
-    buffer_t planar_input = make_planar_rgb_image(1024, 768);
-    buffer_t planar_output = make_planar_rgb_image(1024, 768);
-    buffer_t interleaved_input = make_interleaved_rgb_image(1024, 768);
-    buffer_t interleaved_output = make_interleaved_rgb_image(1024, 768);
+    // memory. Halide::Buffer is planar by default.
+    Halide::Buffer<uint8_t> planar_input(1024, 768, 3);
+    Halide::Buffer<uint8_t> planar_output(1024, 768, 3);
+    Halide::Buffer<uint8_t> interleaved_input =
+        Halide::Buffer<uint8_t>::make_interleaved(1024, 768, 3);
+    Halide::Buffer<uint8_t> interleaved_output =
+        Halide::Buffer<uint8_t>::make_interleaved(1024, 768, 3);
+
+    // Let's check the strides are what we expect, given the
+    // constraints we set up in the generator.
+    assert(planar_input.dim(0).stride() == 1);
+    assert(planar_output.dim(0).stride() == 1);
+    assert(interleaved_input.dim(0).stride() == 3);
+    assert(interleaved_output.dim(0).stride() == 3);
+    assert(interleaved_input.dim(2).stride() == 1);
+    assert(interleaved_output.dim(2).stride() == 1);
 
     // We'll now call the various functions we compiled and check the
     // performance of each.
@@ -103,12 +66,12 @@ int main(int argc, char **argv) {
     // interleaved version of the code on the interleaved
     // images. We'll run each 1000 times for benchmarking.
     for (int i = 0; i < 1000; i++) {
-        brighten_planar(&planar_input, 1, &planar_output);
+        brighten_planar(planar_input, 1, planar_output);
     }
     double planar_time = tick("brighten_planar");
 
     for (int i = 0; i < 1000; i++) {
-        brighten_interleaved(&interleaved_input, 1, &interleaved_output);
+        brighten_interleaved(interleaved_input, 1, interleaved_output);
     }
     double interleaved_time = tick("brighten_interleaved");
 
@@ -120,22 +83,22 @@ int main(int argc, char **argv) {
     // error, because the stride is not what we promised it would be
     // in the generator.
 
-    // brighten_planar(&interleaved_input, 1, &interleaved_output);
+    // brighten_planar(interleaved_input, 1, interleaved_output);
     // Error: Constraint violated: brighter.stride.0 (3) == 1 (1)
 
-    // brighten_interleaved(&planar_input, 1, &planar_output);
+    // brighten_interleaved(planar_input, 1, planar_output);
     // Error: Constraint violated: brighter.stride.0 (1) == 3 (3)
 
     // Run the flexible version of the code and check performance. It
     // should work, but it'll be slower than the versions above.
     for (int i = 0; i < 1000; i++) {
-        brighten_either(&planar_input, 1, &planar_output);
+        brighten_either(planar_input, 1, planar_output);
     }
     double either_planar_time = tick("brighten_either on planar images");
     assert(planar_time < either_planar_time);
 
     for (int i = 0; i < 1000; i++) {
-        brighten_either(&interleaved_input, 1, &interleaved_output);
+        brighten_either(interleaved_input, 1, interleaved_output);
     }
     double either_interleaved_time = tick("brighten_either on interleaved images");
     assert(interleaved_time < either_interleaved_time);
@@ -145,7 +108,7 @@ int main(int argc, char **argv) {
     // for each case above by branching internally to equivalent
     // code.
     for (int i = 0; i < 1000; i++) {
-        brighten_specialized(&planar_input, 1, &planar_output);
+        brighten_specialized(planar_input, 1, planar_output);
     }
     double specialized_planar_time = tick("brighten_specialized on planar images");
 
@@ -155,16 +118,10 @@ int main(int argc, char **argv) {
     assert(specialized_planar_time < 1.5 * planar_time);
 
     for (int i = 0; i < 1000; i++) {
-        brighten_specialized(&interleaved_input, 1, &interleaved_output);
+        brighten_specialized(interleaved_input, 1, interleaved_output);
     }
     double specialized_interleaved_time = tick("brighten_specialized on interleaved images");
     assert(specialized_interleaved_time < 1.5 * interleaved_time);
-
-    // Remember to free our allocated memory...
-    destroy_image(&planar_input);
-    destroy_image(&planar_output);
-    destroy_image(&interleaved_input);
-    destroy_image(&interleaved_output);
 
     return 0;
 }

--- a/tutorial/todo.txt
+++ b/tutorial/todo.txt
@@ -10,3 +10,4 @@
 - scheduling rvars
 - tail strategies
 - RDom::where
+- Wrapping existing memory in a Halide::Buffer


### PR DESCRIPTION
We now want people to always just use Halide::Buffer. Encouraging people
to use naked buffer_t was a mistake - everyone just wrote their own
wrapper classes.