### PR TITLE
Move Dimension from OutputImageParam into Parameter.h

### DIFF
--- a/src/OutputImageParam.cpp
+++ b/src/OutputImageParam.cpp
@@ -3,6 +3,8 @@
 
 namespace Halide {
 
+using Internal::Dimension;
+
 OutputImageParam::OutputImageParam(const Internal::Parameter &p, Argument::Kind k) :
     param(p), kind(k) {
 }
@@ -19,75 +21,16 @@ bool OutputImageParam::defined() const {
     return param.defined();
 }
 
-OutputImageParam::Dimension OutputImageParam::dim(int i) {
-    user_assert(defined())
-        << "Can't access the dimensions of an undefined ImageParam\n";
-    user_assert(i >= 0 && i < dimensions())
-        << "Can't access dimension " << i
-        << " of a " << dimensions() << "-dimensional ImageParam\n";
-    return OutputImageParam::Dimension(param, i);
+Dimension OutputImageParam::dim(int i) {
+    return Dimension(param, i);
 }
 
-const OutputImageParam::Dimension OutputImageParam::dim(int i) const {
-    user_assert(defined())
-        << "Can't access the dimensions of an undefined ImageParam\n";
-    user_assert(i >= 0 && i < dimensions())
-        << "Can't access dimension " << i
-        << " of a " << dimensions() << "-dimensional ImageParam\n";
-    return OutputImageParam::Dimension(param, i);
+const Dimension OutputImageParam::dim(int i) const {
+    return Dimension(param, i);
 }
 
-Expr OutputImageParam::Dimension::min() const {
-    std::ostringstream s;
-    s << param.name() << ".min." << d;
-    return Internal::Variable::make(Int(32), s.str(), param);
-}
-
-Expr OutputImageParam::Dimension::extent() const {
-    std::ostringstream s;
-    s << param.name() << ".extent." << d;
-    return Internal::Variable::make(Int(32), s.str(), param);
-}
-
-Expr OutputImageParam::Dimension::max() const {
-    return min() + extent() - 1;
-}
-
-Expr OutputImageParam::Dimension::stride() const {
-    std::ostringstream s;
-    s << param.name() << ".stride." << d;
-    return Internal::Variable::make(Int(32), s.str(), param);
-}
 int OutputImageParam::host_alignment() const {
     return param.host_alignment();
-}
-
-OutputImageParam::Dimension OutputImageParam::Dimension::set_extent(Expr extent) {
-    param.set_extent_constraint(d, extent);
-    return *this;
-}
-
-OutputImageParam::Dimension OutputImageParam::Dimension::set_min(Expr min) {
-    param.set_min_constraint(d, min);
-    return *this;
-}
-
-OutputImageParam::Dimension OutputImageParam::Dimension::set_stride(Expr stride) {
-    param.set_stride_constraint(d, stride);
-    return *this;
-}
-
-
-OutputImageParam::Dimension OutputImageParam::Dimension::set_bounds(Expr min, Expr extent) {
-    return set_min(min).set_extent(extent);
-}
-
-OutputImageParam::Dimension OutputImageParam::Dimension::dim(int i) {
-    return OutputImageParam::Dimension(param, i);
-}
-
-const OutputImageParam::Dimension OutputImageParam::Dimension::dim(int i) const {
-    return OutputImageParam::Dimension(param, i);
 }
 
 OutputImageParam &OutputImageParam::set_host_alignment(int bytes) {

--- a/src/OutputImageParam.h
+++ b/src/OutputImageParam.h
@@ -27,82 +27,6 @@ protected:
                                           bool *placeholder_seen) const;
 public:
 
-    struct Dimension {
-        /** Get an expression representing the minimum coordinates of this image
-         * parameter in the given dimension. */
-        EXPORT Expr min() const;
-
-        /** Get an expression representing the extent of this image
-         * parameter in the given dimension */
-        EXPORT Expr extent() const;
-
-        /** Get an expression representing the maximum coordinates of
-         * this image parameter in the given dimension. */
-        EXPORT Expr max() const;
-
-        /** Get an expression representing the stride of this image in the
-         * given dimension */
-        EXPORT Expr stride() const;
-
-        /** Set the min in a given dimension to equal the given
-         * expression. Setting the mins to zero may simplify some
-         * addressing math. */
-        EXPORT Dimension set_min(Expr e);
-
-        /** Set the extent in a given dimension to equal the given
-         * expression. Images passed in that fail this check will generate
-         * a runtime error. Returns a reference to the ImageParam so that
-         * these calls may be chained.
-         *
-         * This may help the compiler generate better
-         * code. E.g:
-         \code
-         im.dim(0).set_extent(100);
-         \endcode
-         * tells the compiler that dimension zero must be of extent 100,
-         * which may result in simplification of boundary checks. The
-         * value can be an arbitrary expression:
-         \code
-         im.dim(0).set_extent(im.dim(1).extent());
-         \endcode
-         * declares that im is a square image (of unknown size), whereas:
-         \code
-         im.dim(0).set_extent((im.dim(0).extent()/32)*32);
-         \endcode
-         * tells the compiler that the extent is a multiple of 32. */
-        EXPORT Dimension set_extent(Expr e);
-
-        /** Set the stride in a given dimension to equal the given
-         * value. This is particularly helpful to set when
-         * vectorizing. Known strides for the vectorized dimension
-         * generate better code. */
-        EXPORT Dimension set_stride(Expr e);
-
-        /** Set the min and extent in one call. */
-        EXPORT Dimension set_bounds(Expr min, Expr extent);
-
-        /** Get a different dimension of the same buffer */
-        // @{
-        EXPORT Dimension dim(int i);
-        EXPORT const Dimension dim(int i) const;
-        // @}
-
-    private:
-        friend class OutputImageParam;
-
-        /** Construct a Dimension representing dimension d of some
-         * Internal::Parameter p. Only OutputImageParam may construct
-         * these. */
-        Dimension(const Internal::Parameter &p, int d) : param(p), d(d) {}
-
-        /** Only OutputImageParam may copy these, too. This prevents
-         * users removing constness by making a non-const copy. */
-        Dimension(const Dimension &) = default;
-
-        Internal::Parameter param;
-        int d;
-    };
-
     /** Construct a null image parameter handle. */
     OutputImageParam() {}
 
@@ -120,11 +44,11 @@ public:
 
     /** Get a handle on one of the dimensions for the purposes of
      * inspecting or constraining its min, extent, or stride. */
-    EXPORT Dimension dim(int i);
+    EXPORT Internal::Dimension dim(int i);
 
     /** Get a handle on one of the dimensions for the purposes of
      * inspecting its min, extent, or stride. */
-    EXPORT const Dimension dim(int i) const;
+    EXPORT const Internal::Dimension dim(int i) const;
 
     /** Get or constrain the shape of the dimensions. Soon to be
      * deprecated. Do not use. */

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -272,6 +272,66 @@ Expr Parameter::get_max_value() const {
     return contents->max_value;
 }
 
+Dimension::Dimension(const Internal::Parameter &p, int d) : param(p), d(d) {
+    user_assert(param.defined())
+        << "Can't access the dimensions of an undefined Parameter\n";
+    user_assert(param.is_buffer())
+        << "Can't access the dimensions of a scalar Parameter\n";
+    user_assert(d >= 0 && d < param.dimensions())
+        << "Can't access dimension " << d
+        << " of a " << param.dimensions() << "-dimensional Parameter\n";
+}
+
+Expr Dimension::min() const {
+    std::ostringstream s;
+    s << param.name() << ".min." << d;
+    return Variable::make(Int(32), s.str(), param);
+}
+
+Expr Dimension::extent() const {
+    std::ostringstream s;
+    s << param.name() << ".extent." << d;
+    return Variable::make(Int(32), s.str(), param);
+}
+
+Expr Dimension::max() const {
+    return min() + extent() - 1;
+}
+
+Expr Dimension::stride() const {
+    std::ostringstream s;
+    s << param.name() << ".stride." << d;
+    return Variable::make(Int(32), s.str(), param);
+}
+
+Dimension Dimension::set_extent(Expr extent) {
+    param.set_extent_constraint(d, extent);
+    return *this;
+}
+
+Dimension Dimension::set_min(Expr min) {
+    param.set_min_constraint(d, min);
+    return *this;
+}
+
+Dimension Dimension::set_stride(Expr stride) {
+    param.set_stride_constraint(d, stride);
+    return *this;
+}
+
+
+Dimension Dimension::set_bounds(Expr min, Expr extent) {
+    return set_min(min).set_extent(extent);
+}
+
+Dimension Dimension::dim(int i) {
+    return Dimension(param, i);
+}
+
+const Dimension Dimension::dim(int i) const {
+    return Dimension(param, i);
+}
+
 void check_call_arg_types(const std::string &name, std::vector<Expr> *args, int dims) {
     user_assert(args->size() == (size_t)dims)
         << args->size() << "-argument call to \""
@@ -287,7 +347,7 @@ void check_call_arg_types(const std::string &name, std::vector<Expr> *args, int 
         }
         // We're allowed to implicitly cast from other varieties of int
         if (t != Int(32)) {
-            (*args)[i] = Internal::Cast::make(Int(32), (*args)[i]);
+            (*args)[i] = Cast::make(Int(32), (*args)[i]);
         }
     }
 }

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -9,6 +9,9 @@
 #include "BufferPtr.h"
 
 namespace Halide {
+
+class OutputImageParam;
+
 namespace Internal {
 
 struct ParameterContents;
@@ -135,6 +138,84 @@ public:
     EXPORT Expr get_max_value() const;
     // @}
 };
+
+class Dimension {
+public:
+    /** Get an expression representing the minimum coordinates of this image
+     * parameter in the given dimension. */
+    EXPORT Expr min() const;
+
+    /** Get an expression representing the extent of this image
+     * parameter in the given dimension */
+    EXPORT Expr extent() const;
+
+    /** Get an expression representing the maximum coordinates of
+     * this image parameter in the given dimension. */
+    EXPORT Expr max() const;
+
+    /** Get an expression representing the stride of this image in the
+     * given dimension */
+    EXPORT Expr stride() const;
+
+    /** Set the min in a given dimension to equal the given
+     * expression. Setting the mins to zero may simplify some
+     * addressing math. */
+    EXPORT Dimension set_min(Expr e);
+
+    /** Set the extent in a given dimension to equal the given
+     * expression. Images passed in that fail this check will generate
+     * a runtime error. Returns a reference to the ImageParam so that
+     * these calls may be chained.
+     *
+     * This may help the compiler generate better
+     * code. E.g:
+     \code
+     im.dim(0).set_extent(100);
+     \endcode
+     * tells the compiler that dimension zero must be of extent 100,
+     * which may result in simplification of boundary checks. The
+     * value can be an arbitrary expression:
+     \code
+     im.dim(0).set_extent(im.dim(1).extent());
+     \endcode
+     * declares that im is a square image (of unknown size), whereas:
+     \code
+     im.dim(0).set_extent((im.dim(0).extent()/32)*32);
+     \endcode
+     * tells the compiler that the extent is a multiple of 32. */
+    EXPORT Dimension set_extent(Expr e);
+
+    /** Set the stride in a given dimension to equal the given
+     * value. This is particularly helpful to set when
+     * vectorizing. Known strides for the vectorized dimension
+     * generate better code. */
+    EXPORT Dimension set_stride(Expr e);
+
+    /** Set the min and extent in one call. */
+    EXPORT Dimension set_bounds(Expr min, Expr extent);
+
+    /** Get a different dimension of the same buffer */
+    // @{
+    EXPORT Dimension dim(int i);
+    EXPORT const Dimension dim(int i) const;
+    // @}
+
+private:
+    friend class ::Halide::OutputImageParam;
+
+    /** Construct a Dimension representing dimension d of some
+     * Internal::Parameter p. Only friends may construct
+     * these. */
+    EXPORT Dimension(const Internal::Parameter &p, int d);
+
+    /** Only friends may copy these, too. This prevents
+     * users removing constness by making a non-const copy. */
+    Dimension(const Dimension &) = default;
+
+    Parameter param;
+    int d;
+};
+
 
 /** Validate arguments to a call to a func, image or imageparam. */
 void check_call_arg_types(const std::string &name, std::vector<Expr> *args, int dims);


### PR DESCRIPTION
I need to re-use it for Generator purposes; mostly-decoupling it from
OutputImageParam makes that less weird. (“Mostly” because we still
grant friend access for ctors, though frankly, we could probably just
make them public)