### PR TITLE
Fix openglcompute app

### DIFF
--- a/apps/openglcompute/Makefile
+++ b/apps/openglcompute/Makefile
@@ -23,7 +23,7 @@ AVG_FILTER_SRC = jni/oglc_run.cpp \
                  avg_filter_float_arm.o avg_filter_float_arm.h
 
 libs/armeabi-v7a/oglc_run: $(HALIDE_LIB) $(AVG_FILTER_SRC)
-	ndk-build libs/armeabi-v7a/oglc_run libs/armeabi-v7a/libstlport_shared.so
+	ndk-build libs/armeabi-v7a/oglc_run
 
 two_kernels_filter.o two_kernels_filter.h: test_two_kernels
 	LD_LIBRARY_PATH=../../bin DYLD_LIBRARY_PATH=../../bin HL_TARGET=arm-32-android-armv7s-openglcompute ./$<
@@ -34,15 +34,11 @@ TWO_KERNELS_SRC = jni/oglc_two_kernels_run.cpp \
 libs/armeabi-v7a/oglc_two_kernels_run: $(HALIDE_LIB) $(TWO_KERNELS_SRC)
 	ndk-build libs/armeabi-v7a/oglc_two_kernels_run libs/armeabi-v7a/liboglc_two_kernels.so
 
-libs/armeabi-v7a/libstlport_shared.so: $(HALIDE_LIB) $(AVG_FILTER_SRC)
-	ndk-build libs/armeabi-v7a/oglc_run libs/armeabi-v7a/libstlport_shared.so
-
 jni-libs: $(HALIDE_LIB) $(AVG_FILTER_SRC) $(TWO_KERNELS_SRC)
-	ndk-build libs/armeabi-v7a/liboglc_two_kernels.so libs/armeabi-v7a/liboglc.so libs/armeabi-v7a/libstlport_shared.so
+	ndk-build libs/armeabi-v7a/liboglc_two_kernels.so libs/armeabi-v7a/liboglc.so
 
-deploy: libs/armeabi-v7a/oglc_run libs/armeabi-v7a/libstlport_shared.so
+deploy: libs/armeabi-v7a/oglc_run
 	adb push libs/armeabi-v7a/oglc_run /mnt/sdcard/
-	adb push libs/armeabi-v7a/libstlport_shared.so /mnt/sdcard/
 
 define RUN_STEPS
 su
@@ -53,7 +49,6 @@ cd /data/tmp/oglc
 pwd
 cp /mnt/sdcard/oglc_run .
 chmod 777 /data/tmp/oglc/oglc_run
-cp /mnt/sdcard/libstlport_shared.so .
 LD_LIBRARY_PATH=. ./oglc_run
 exit
 exit
@@ -78,7 +73,6 @@ cd /data/tmp
 pwd
 cp /mnt/sdcard/oglc_two_kernels_run .
 chmod 777 /data/tmp/oglc_two_kernels_run
-cp /mnt/sdcard/libstlport_shared.so .
 LD_LIBRARY_PATH=. ./oglc_two_kernels_run
 exit
 exit

--- a/apps/openglcompute/jni/Application.mk
+++ b/apps/openglcompute/jni/Application.mk
@@ -3,5 +3,5 @@
 APP_ABI := armeabi-v7a
 APP_PLATFORM := android-17
 
-APP_STL := stlport_shared
+APP_STL := c++_static
 LOCAL_C_INCLUDES += ${ANDROID_NDK}/sources/cxx-stl/gnu-libstdc++/4.8/include

--- a/apps/openglcompute/jni/oglc_run.cpp
+++ b/apps/openglcompute/jni/oglc_run.cpp
@@ -8,42 +8,37 @@
 #include "avg_filter_float_arm.h"
 #include <sstream>
 
+#include "HalideBuffer.h"
 #include "HalideRuntimeOpenGLCompute.h"
 
 #define  LOGI(...)  __android_log_print(ANDROID_LOG_INFO, "oglc_run", __VA_ARGS__)
 #define  LOGE(...)  __android_log_print(ANDROID_LOG_ERROR, "oglc_run", __VA_ARGS__)
 
-extern "C" int halide_copy_to_host(void *, buffer_t *);
-extern "C" int halide_device_sync(void *, buffer_t *);
-extern "C" int halide_device_free(void *, buffer_t* buf);
-extern "C" void halide_device_release(void *, const halide_device_interface_t *interface);
-
 typedef int (*filter_t) (buffer_t *, buffer_t *);
 
 struct timing {
     filter_t filter;
-    buffer_t *bt_input;
-    buffer_t *bt_output;
+    Halide::Buffer<> *input;
+    Halide::Buffer<> *output;
     double worst_t = 0;
     int worst_rep = 0;
     double best_t = DBL_MAX;
     int best_rep = 0;
 
-    timing(filter_t _filter, buffer_t *_bt_input, buffer_t *_bt_output):
-        filter(_filter), bt_input(_bt_input), bt_output(_bt_output) {}
+    template<typename T>
+    timing(filter_t filter, Halide::Buffer<T> *input, Halide::Buffer<T> *output):
+        filter(filter), input(&input->template as<void>()), output(&output->template as<void>()) {}
 
     int run(int n_reps, bool with_copying) {
         timeval t1, t2;
         for (int i = 0; i < n_reps; i++) {
-            bt_input->host_dirty = true;
+            input->set_host_dirty();
             gettimeofday(&t1, NULL);
-            int error = filter(bt_input, bt_output);
-            halide_device_sync(NULL, bt_output);
+            int error = filter(*input, *output);
+            output->device_sync();
 
             if (with_copying) {
-                if (bt_output->dev) {
-                    halide_copy_to_host(NULL, bt_output);
-                }
+                output->copy_to_host();
             }
             gettimeofday(&t2, NULL);
             if (error) {
@@ -65,11 +60,17 @@ struct timing {
 
 template<class T> class Tester;
 
-template<class T> bool doBlur(Tester<T> *tester, buffer_t bt_input, buffer_t bt_output, buffer_t bt_output_arm) {
+template<class T> bool doBlur(Tester<T> *tester,
+                              Halide::Buffer<T> bt_input,
+                              Halide::Buffer<T> bt_output,
+                              Halide::Buffer<T> bt_output_arm) {
     return false; // This abstract implementation should never be called
 }
 
-template<class T> bool doCopy(Tester<T> *tester, buffer_t bt_input, buffer_t bt_output, buffer_t bt_output_arm) {
+template<class T> bool doCopy(Tester<T> *tester,
+                              Halide::Buffer<T> bt_input,
+                              Halide::Buffer<T> bt_output,
+                              Halide::Buffer<T> bt_output_arm) {
     return false; // This abstract implementation should never be called
 }
 
@@ -80,64 +81,39 @@ template<class T> class Tester {
 
   private:
 
-    bool validate(buffer_t actual, buffer_t expected) {
+    bool validate(Halide::Buffer<T> actual, Halide::Buffer<T> expected) {
         int count_mismatches = 0;
-        for (int i = 0; i < actual.extent[0]; i++) {
-            for (int j = 0; j < actual.extent[1]; j++) {
-                for (int k = 0; k < actual.extent[2]; k++) {
-                    T actual_value =
-                        ((T*)actual.host)[i * actual.stride[0] +
-                                          j * actual.stride[1] +
-                                          k * actual.stride[2]];
-                    T expected_value =
-                        ((T*)expected.host)[i * expected.stride[0] +
-                                            j * expected.stride[1] +
-                                            k * expected.stride[2]];
-                    const float EPSILON = 0.00001f;
-                    if (abs((double((actual_value - expected_value)) > EPSILON))) {
-                        if (count_mismatches < 100) {
-                            std::ostringstream str;
-                            str << "actual and expected results differ at "
-                                << "(" << i << ", " << j << ", " << k << "):"
-                                << +actual_value << " != " << +expected_value
-                                << "\n";
-                            LOGI("%s", str.str().c_str());
-                        }
-                        count_mismatches++;
-                    }
+        actual.for_each_element([&](int x, int y, int c) {
+            T actual_value = actual(x, y, c);
+            T expected_value = expected(x, y, c);
+            const float EPSILON = 0.00001f;
+            if (abs((double((actual_value - expected_value)) > EPSILON))) {
+                if (count_mismatches < 100) {
+                    std::ostringstream str;
+                    str << "actual and expected results differ at "
+                        << "(" << x << ", " << y << ", " << c << "):"
+                        << +actual_value << " != " << +expected_value
+                        << "\n";
+                    LOGI("%s", str.str().c_str());
                 }
+                count_mismatches++;
             }
-        }
+        });
 
         return count_mismatches == 0;
     }
 
-    buffer_t make_interleaved_image(int width, int height, int channels, T host[]) {
-        buffer_t bt_input = { 0 };
-        bt_input.host = (uint8_t*)&host[0];
-        bt_input.stride[0] = channels;
-        bt_input.extent[0] = width;
-        bt_input.stride[1] = channels * width;
-        bt_input.extent[1] = height;
-        bt_input.stride[2] = 1;
-        bt_input.extent[2] = channels;
-        bt_input.elem_size = sizeof(T);
-        return bt_input;
-    }
-
-    void print(buffer_t bt) {
-        for (int j = 0; j < std::min(bt.extent[1], 10); j++) {
+    void print(Halide::Buffer<T> buf) {
+        for (int j = 0; j < std::min(buf.height(), 10); j++) {
             std::stringstream oss;
-            for (int i = 0; i < std::min(bt.extent[0], 10); i++) {
+            for (int i = 0; i < std::min(buf.width(), 10); i++) {
                 oss << " [";
-                for (int k = 0; k < bt.extent[2]; k++) {
+                for (int k = 0; k < buf.channels(); k++) {
                     oss << std::fixed << std::setprecision(1);
                     if (k > 0) {
                         oss << std::setw(4);
                     }
-                    oss << +((T*)bt.host)[i * bt.stride[0] +
-                                          j * bt.stride[1] +
-                                          k * bt.stride[2]];
+                    oss << +buf(i, j, k);
                 }
                 oss << "]";
             }
@@ -146,16 +122,19 @@ template<class T> class Tester {
     }
 
   public:
-    bool test(buffer_t bt_input, buffer_t bt_output, buffer_t bt_output_arm,
-        filter_t avg_filter, filter_t avg_filter_arm) {
+    bool test(Halide::Buffer<T> input,
+              Halide::Buffer<T> output,
+              Halide::Buffer<T> output_arm,
+              filter_t avg_filter,
+              filter_t avg_filter_arm) {
 
         // Performance check
-        bt_input.host_dirty = true;
-        timing openglcompute(avg_filter, &bt_input, &bt_output);
-        bt_input.host_dirty = true;
-        timing openglcompute_with_copying(avg_filter, &bt_input, &bt_output);
-        bt_input.host_dirty = true;
-        timing arm(avg_filter_arm, &bt_input, &bt_output_arm);
+        input.set_host_dirty();
+        timing openglcompute(avg_filter, &input, &output);
+        input.set_host_dirty();
+        timing openglcompute_with_copying(avg_filter, &input, &output);
+        input.set_host_dirty();
+        timing arm(avg_filter_arm, &input, &output_arm);
 
         const int N_REPS = 10;
         arm.run(N_REPS, false);
@@ -180,24 +159,21 @@ template<class T> class Tester {
                 arm.worst_t, arm.worst_rep);
 
         // Data correctness check
-        bt_input.host_dirty = true;
-        avg_filter(&bt_input, &bt_output);
+        input.set_host_dirty();
+        avg_filter(input, output);
         LOGI("Filter is done.");
-        halide_device_sync(NULL, &bt_output);
+        output.device_sync();
         LOGI("Sync is done");
-        halide_copy_to_host(NULL, &bt_output);
+        output.copy_to_host();
 
         LOGI("Output arm:");
-        print(bt_output_arm);
+        print(output_arm);
         LOGI("Output openglcompute:");
-        print(bt_output);
+        print(output);
 
-        bool matches = validate(bt_output, bt_output_arm);
+        bool matches = validate(output, output_arm);
         LOGI(matches? "Test passed.\n": "Test failed.\n");
 
-        halide_device_free(NULL, &bt_input);
-        halide_device_free(NULL, &bt_output);
-        halide_device_free(NULL, &bt_output_arm);
         return matches;
     }
 
@@ -206,41 +182,37 @@ template<class T> class Tester {
         int height = 2048;
         int channels = 4;
 
-        T *input = (T*)malloc(width * height * channels * sizeof(T));
-        T *output = (T*)malloc(width * height * channels * sizeof(T));
-        T *output_arm = (T*)malloc(width * height * channels * sizeof(T));
+        auto input = Halide::Buffer<T>::make_interleaved(width, height, channels);
         LOGI("Allocated memory for %dx%dx%d image", width, height, channels);
 
-        buffer_t bt_input = make_interleaved_image(width, height, channels, input);
-        for (int i = 0; i < std::min(bt_input.extent[0], width); i++) {
-            for (int j = 0; j < std::min(bt_input.extent[1], height); j++) {
-                for (int k = 0; k < bt_input.extent[2]; k++) {
-                    input[i * bt_input.stride[0] +
-                          j * bt_input.stride[1] +
-                          k * bt_input.stride[2]] = ((i + j) % 2) * 6;
-                }
-            }
-        }
-        bt_input.host_dirty = true;
+        input.for_each_element([&](int i, int j, int k) {
+            input(i, j, k) = ((i + j) % 2) * 6;
+        });
 
         LOGI("Input :\n");
-        print(bt_input);
+        print(input);
 
-        buffer_t bt_output = make_interleaved_image(width, height, channels, output);
-        buffer_t bt_output_arm = make_interleaved_image(width, height, channels, output_arm);
+        auto output = Halide::Buffer<T>::make_interleaved(width, height, channels);
+        auto output_arm = Halide::Buffer<T>::make_interleaved(width, height, channels);
 
-        doBlur(this, bt_input, bt_output, bt_output_arm);
+        doBlur(this, input, output, output_arm);
     }
 };
 
-template<> bool doBlur<float>(Tester<float> *tester, buffer_t bt_input, buffer_t bt_output, buffer_t bt_output_arm) {
+template<> bool doBlur<float>(Tester<float> *tester,
+                              Halide::Buffer<float> bt_input,
+                              Halide::Buffer<float> bt_output,
+                              Halide::Buffer<float> bt_output_arm) {
     return tester->test(bt_input,
                         bt_output, bt_output_arm,
                         avg_filter_float,
                         avg_filter_float_arm);
 }
 
-template<> bool doBlur<uint32_t>(Tester<uint32_t> *tester, buffer_t bt_input, buffer_t bt_output, buffer_t bt_output_arm) {
+template<> bool doBlur<uint32_t>(Tester<uint32_t> *tester,
+                                 Halide::Buffer<uint32_t> bt_input,
+                                 Halide::Buffer<uint32_t> bt_output,
+                                 Halide::Buffer<uint32_t> bt_output_arm) {
     return tester->test(bt_input,
                         bt_output, bt_output_arm,
                         avg_filter_uint32t,

--- a/apps/openglcompute/jni/oglc_two_kernels_run.cpp
+++ b/apps/openglcompute/jni/oglc_two_kernels_run.cpp
@@ -5,6 +5,7 @@
 #include "two_kernels_filter.h"
 #include <sstream>
 
+#include "HalideBuffer.h"
 #include "HalideRuntimeOpenGLCompute.h"
 
 #define  LOGI(...)  __android_log_print(ANDROID_LOG_INFO, "oglc_run", __VA_ARGS__)
@@ -15,32 +16,18 @@ extern "C" int halide_device_sync(void *, buffer_t *);
 extern "C" int halide_device_free(void *, buffer_t* buf);
 extern "C" void halide_device_release(void *, const halide_device_interface_t *interface);
 
-buffer_t make_interleaved_image(int width, int height, int channels, int32_t host[]) {
-    buffer_t bt_input = { 0 };
-    bt_input.host = (uint8_t*)&host[0];
-    bt_input.stride[0] = channels;
-    bt_input.extent[0] = width;
-    bt_input.stride[1] = channels * width;
-    bt_input.extent[1] = height;
-    bt_input.stride[2] = 1;
-    bt_input.extent[2] = channels;
-    bt_input.elem_size = sizeof(int32_t);
-    return bt_input;
-}
-
-void print(buffer_t bt) {
-    for (int j = 0; j < std::min(bt.extent[1], 10); j++) {
+template<typename T>
+void print(Halide::Buffer<T> buf) {
+    for (int j = 0; j < std::min(buf.height(), 10); j++) {
         std::stringstream oss;
-        for (int i = 0; i < std::min(bt.extent[0], 10); i++) {
+        for (int i = 0; i < std::min(buf.width(), 10); i++) {
             oss << " [";
-            for (int k = 0; k < bt.extent[2]; k++) {
+            for (int k = 0; k < buf.channels(); k++) {
                 oss << std::fixed << std::setprecision(1);
                 if (k > 0) {
                     oss << std::setw(4);
                 }
-                oss << +((int32_t*)bt.host)[i * bt.stride[0] +
-                                      j * bt.stride[1] +
-                                      k * bt.stride[2]];
+                oss << +buf(i, j, k);
             }
             oss << "]";
         }
@@ -55,66 +42,45 @@ int main(int argc, char** argv) {
     int height = 128;
     int channels = 4;
 
-    int32_t *input = (int32_t*)malloc(width * height * channels * sizeof(int32_t));
-    int32_t *output = (int32_t*)malloc(width * height * channels * sizeof(int32_t));
+    auto input = Halide::Buffer<int>::make_interleaved(width, height, channels);
     LOGI("Allocated memory for %dx%dx%d image", width, height, channels);
 
-    buffer_t bt_input = make_interleaved_image(width, height, channels, input);
-    for (int i = 0; i < std::min(bt_input.extent[0], width); i++) {
-        for (int j = 0; j < std::min(bt_input.extent[1], height); j++) {
-            for (int k = 0; k < bt_input.extent[2]; k++) {
-                input[i * bt_input.stride[0] +
-                      j * bt_input.stride[1] +
-                      k * bt_input.stride[2]] = ((i + j) % 2) * 6;
-            }
-        }
-    }
+    input.for_each_element([&](int i, int j, int k) {
+        input(i, j, k) = ((i + j) % 2) * 6;
+    });
+
     LOGI("Input :\n");
-    print(bt_input);
-    bt_input.host_dirty = true;
+    print(input);
 
-    buffer_t bt_output = make_interleaved_image(width, height, channels, output);
+    auto output = Halide::Buffer<int>::make_interleaved(width, height, channels);
 
-    two_kernels_filter(&bt_input, &bt_output);
+    two_kernels_filter(input, output);
     LOGI("Filter is done.");
-    halide_device_sync(NULL, &bt_output);
+    output.device_sync();
     LOGI("Sync is done");
-    halide_copy_to_host(NULL, &bt_output);
+    output.copy_to_host();
 
     LOGI("Output :\n");
-    print(bt_output);
+    print(output);
 
     int count_mismatches = 0;
-    for (int i = 0; i < bt_output.extent[0]; i++) {
-        for (int j = 0; j < bt_output.extent[1]; j++) {
-            for (int k = 0; k < bt_output.extent[2]; k++) {
-                int32_t output_value =
-                    ((int32_t*)bt_output.host)[i * bt_output.stride[0] +
-                                               j * bt_output.stride[1] +
-                                               k * bt_output.stride[2]];
-                int32_t input_value =
-                    ((int32_t*)bt_input.host)[i * bt_input.stride[0] +
-                                              j * bt_input.stride[1] +
-                                              k * bt_input.stride[2]];
-                if (output_value != input_value) {
-                    if (count_mismatches < 100) {
-                        std::ostringstream str;
-                        str << "bt_output and bt_input results differ at "
-                            << "(" << i << ", " << j << ", " << k << "):"
-                            << output_value << " != " << input_value
-                            << "\n";
-                        LOGI("%s", str.str().c_str());
-                    }
-                    count_mismatches++;
-                }
+    output.for_each_element([&](int i, int j, int k) {
+        int32_t output_value = output(i, j, k);
+        int32_t input_value = input(i, j, k);
+        if (output_value != input_value) {
+            if (count_mismatches < 100) {
+                std::ostringstream str;
+                str << "output and input results differ at "
+                    << "(" << i << ", " << j << ", " << k << "):"
+                    << output_value << " != " << input_value
+                    << "\n";
+                LOGI("%s", str.str().c_str());
             }
+            count_mismatches++;
         }
-    }
+    });
 
-    LOGI(count_mismatches == 0? "Test passed.\n": "Test failed.\n");
-
-    halide_device_free(NULL, &bt_input);
-    halide_device_free(NULL, &bt_output);
+    LOGI(count_mismatches == 0 ? "Test passed.\n": "Test failed.\n");
 
     halide_device_release(NULL, halide_openglcompute_device_interface());
 

--- a/apps/openglcompute/test_oglc_avg.cpp
+++ b/apps/openglcompute/test_oglc_avg.cpp
@@ -29,8 +29,8 @@ void blur(std::string suffix, ImageParam input) {
           .reorder_storage(c, x, y)
           .reorder(c, x, y);
     if (target.has_gpu_feature() || target.has_feature(Target::OpenGLCompute)) {
-        result.vectorize(c, 4)
-              .gpu_tile(x, y, 64, 64);
+        result.unroll(c)
+            .gpu_tile(x, y, 64, 64);
     } else {
         Var yi("yi");
         result

--- a/apps/openglcompute/test_two_kernels.cpp
+++ b/apps/openglcompute/test_two_kernels.cpp
@@ -19,7 +19,7 @@ int main(int argc, char** argv) {
 
     Target target = get_target_from_environment();
     if (target.has_gpu_feature() || target.has_feature(Target::OpenGLCompute)) {
-        f.vectorize(c, 4)
+        f.unroll(c)
          .gpu_tile(x, y, 64, 64);
     }
 
@@ -29,7 +29,7 @@ int main(int argc, char** argv) {
      .reorder_storage(c, x, y)
      .reorder(c, x, y);
     if (target.has_gpu_feature() || target.has_feature(Target::OpenGLCompute)) {
-        g.vectorize(c, 4)
+        g.unroll(c)
          .gpu_tile(x, y, 64, 64);
     }
     g.output_buffer().set_bounds(2, 0, CHANNELS).set_stride(0, CHANNELS).set_stride(2, 1);

--- a/apps/simd_op_check/Makefile
+++ b/apps/simd_op_check/Makefile
@@ -1,15 +1,17 @@
 CXX-host ?= c++
-CXX-arm-64-android ?= $(ANDROID_NDK_HOME)/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-c++
-CXX-arm-32-android ?= $(ANDROID_NDK_HOME)/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-c++
+# Use the build/tools/make-standalone-toolchain.sh script inside the
+# android ndk to make a standalone toolchain to use for this app.
+CXX-arm-64-android ?= $(ANDROID_ARM64_TOOLCHAIN)/bin/aarch64-linux-android-c++
+CXX-arm-32-android ?= $(ANDROID_ARM_TOOLCHAIN)/bin/arm-linux-androideabi-c++
 CXX-hexagon-32-qurt-hvx_64 ?= $(HL_HEXAGON_TOOLS)/bin/hexagon-clang++
 CXX-hexagon-32-qurt-hvx_128 ?= $(HL_HEXAGON_TOOLS)/bin/hexagon-clang++
 
-CXXFLAGS-arm-64-android ?= --sysroot $(ANDROID_NDK_HOME)/platforms/android-21/arch-arm64 -llog -fPIE -pie
-CXXFLAGS-arm-32-android ?= --sysroot $(ANDROID_NDK_HOME)/platforms/android-21/arch-arm -llog -fPIE -pie
+CXXFLAGS-arm-64-android ?= -llog -fPIE -pie
+CXXFLAGS-arm-32-android ?= -llog -fPIE -pie
 CXXFLAGS-hexagon-32-qurt-hvx_64 ?= -mhvx -G0
 CXXFLAGS-hexagon-32-qurt-hvx_128 ?= -mhvx-double -G0
 
-LDFLAGS-host ?= -lpthread
+LDFLAGS-host ?= -lpthread -ldl
 LDFLAGS-hexagon-32-qurt-hvx_64 ?= -L../../tools/sim_qurt -lsim_qurt
 LDFLAGS-hexagon-32-qurt-hvx_128 ?= -L../../tools/sim_qurt -lsim_qurt
 
@@ -31,7 +33,7 @@ all: \
 	echo '{NULL, NULL}};' >> $*/filters.h
 
 driver-%: driver.cpp %/filters.h
-	$(CXX-$*) $(CXXFLAGS-$*) -O3 -I $* driver.cpp $*/test_*.o $*/simd_op_check_runtime.o -o driver-$* $(LDFLAGS-$*)
+	$(CXX-$*) $(CXXFLAGS-$*) -I ../../include -O3 -I $* driver.cpp $*/test_*.o $*/simd_op_check_runtime.o -o driver-$* $(LDFLAGS-$*)
 
 clean:
 	rm -rf filters.h filter_headers.h

--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -179,18 +179,9 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Broadcast *
 }
 
 void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Load *op) {
-    string id_index;
-    const Ramp *ramp = op->index.as<Ramp>();
-    if (ramp) {
-        const IntImm *stride = ramp ? ramp->stride.as<IntImm>() : nullptr;
-        user_assert(stride && stride->value == 1 && ramp->lanes == 4) <<
-            "Only trivial packed 4x vectors(stride==1, lanes==4) are supported by OpenGLCompute.";
-
-        // Buffer type is 4-elements wide, that's why we divide by ramp->lanes.
-        id_index = print_expr(Div::make(ramp->base, ramp->lanes));
-    } else {
-        id_index = print_expr(op->index);
-    }
+    // TODO: support vectors
+    internal_assert(op->type.is_scalar());
+    string id_index = print_expr(op->index);
 
     ostringstream oss;
     oss << print_name(op->name);
@@ -202,21 +193,9 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Load *op) {
 }
 
 void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Store *op) {
-    string id_index;
-    const Ramp *ramp = op->index.as<Ramp>();
-    if (ramp) {
-        const IntImm *stride = ramp ? ramp->stride.as<IntImm>() : nullptr;
-        user_assert(stride && stride->value == 1 && ramp->lanes == 4)
-            << "Only trivial packed 4x vectors(stride==1, lanes==4) are supported by OpenGLCompute."
-            << " Got integer stride "
-            << (stride ? std::to_string(stride->value): "undefined")
-            << " and lanes " << ramp->lanes << " instead.";
-
-        // Buffer type is 4-elements wide, that's why we divide by ramp->lanes.
-        id_index = print_expr(Div::make(ramp->base, ramp->lanes));
-    } else {
-        id_index = print_expr(op->index);
-    }
+    // TODO: support vectors
+    internal_assert(op->value.type().is_scalar());
+    string id_index = print_expr(op->index);
 
     string id_value = print_expr(op->value);
 


### PR DESCRIPTION
Made it use Halide::Buffer.

While doing this I discovered that the vector support in OpenGLCompute
codegen was broken, and made a dangerous assumption anyway (all vector
access is aligned), so I neutered it for now. It needs a pass that
actually detects if all buffer access is aligned dense vectors, and if
so, declares the buffer as an array of vectors.