### PR TITLE
CodeGen_PTX: Optimize module before code generation

### DIFF
--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -275,6 +275,8 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     /*int argc = sizeof(argv)/sizeof(char*);*/
     /*cl::ParseCommandLineOptions(argc, argv, "Halide PTX internal compiler\n");*/
 
+    optimize_module();
+
     llvm::Triple triple(module->getTargetTriple());
 
     // Allocate target machine


### PR DESCRIPTION
- Before invoking code generation, run LLVM optimization passes to optimize the
  generated code further.
- It's necessary as the current CSE implementation only eliminates CSE within a
  single statement. There would be redundant calculation amrong statements for
  certain schedules.