### PR TITLE
Deinterleave storage

### DIFF
--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -690,26 +690,58 @@ class EliminateInterleaves : public IRMutator {
     bool interleave_mask = false;
 
     // Check if x is an expression that is either an interleave, or
-    // can pretend to be one (is a scalar or a broadcast).
-    bool yields_interleave(Expr x) {
+    // transitively is an interleave.
+    bool yields_removable_interleave(Expr x) {
         if (is_native_interleave(x)) {
             return true;
-        } else if (x.type().is_scalar() || x.as<Broadcast>()) {
-            return true;
         }
+
+        const Let *let = x.as<Let>();
+        if (let) {
+            return yields_removable_interleave(let->body);
+        }
+
         const Variable *var = x.as<Variable>();
         if (var && vars.contains(var->name + ".deinterleaved")) {
             return true;
         }
+
         return false;
     }
 
-    // Check that at least one of exprs is an interleave, and that all
-    // of the exprs can yield an interleave.
+    // Check if x either has a removable interleave, or it can pretend
+    // to be an interleave at no cost (a scalar or a broadcast).
+    bool yields_interleave(Expr x) {
+        if (yields_removable_interleave(x)) {
+            return true;
+        }
+
+        // These yield an interleave, but we shouldn't
+        // deinterleave them if we want to remove an actual
+        // interleave.
+        if (x.type().is_scalar() || x.as<Broadcast>()) {
+            return true;
+        }
+
+        const Let *let = x.as<Let>();
+        if (let) {
+            return yields_interleave(let->body);
+        }
+
+        const Variable *var = x.as<Variable>();
+        if (var && vars.contains(var->name + ".weak_deinterleaved")) {
+            return true;
+        }
+
+        return false;
+    }
+
+    // Check that at least one of exprs is an interleave that should
+    // be removed, and that all of the exprs can yield an interleave.
     bool yields_removable_interleave(const vector<Expr> &exprs) {
         bool any_is_interleave = false;
         for (const Expr &i : exprs) {
-            if (is_native_interleave(i)) {
+            if (yields_removable_interleave(i)) {
                 any_is_interleave = true;
             } else if (!yields_interleave(i)) {
                 return false;
@@ -728,8 +760,15 @@ class EliminateInterleaves : public IRMutator {
         }
         const Variable *var = x.as<Variable>();
         if (var) {
-            internal_assert(vars.contains(var->name + ".deinterleaved"));
-            return Variable::make(var->type, var->name + ".deinterleaved");
+            if (vars.contains(var->name + ".deinterleaved")) {
+                return Variable::make(var->type, var->name + ".deinterleaved");
+            } else if (vars.contains(var->name + ".weak_deinterleaved")) {
+                return Variable::make(var->type, var->name + ".weak_deinterleaved");
+            }
+        }
+        const Let *let = x.as<Let>();
+        if (let) {
+            return Let::make(let->name, let->value, remove_interleave(let->body));
         }
         internal_error << "Expression '" << x << "' does not yield an interleave.\n";
         return x;
@@ -819,10 +858,20 @@ class EliminateInterleaves : public IRMutator {
     template <typename NodeType, typename LetType>
     void visit_let(NodeType &result, const LetType *op) {
         Expr value = mutate(op->value);
-        string deinterleaved_name = op->name + ".deinterleaved";
+        string deinterleaved_name;
         NodeType body;
-        if (is_native_interleave(value)) {
+        // Other code in this mutator needs to be able to tell the
+        // difference between a Let that yields a deinterleave, and a
+        // let that has a remoable deinterleave.
+        if (yields_removable_interleave(value)) {
             // We can provide a deinterleaved version of this let value.
+            deinterleaved_name = op->name + ".deinterleaved";
+            vars.push(deinterleaved_name, true);
+            body = mutate(op->body);
+            vars.pop(deinterleaved_name);
+        } else if (yields_interleave(value)) {
+            // We have a soft deinterleaved version of this let value.
+            deinterleaved_name = op->name + ".weak_deinterleaved";
             vars.push(deinterleaved_name, true);
             body = mutate(op->body);
             vars.pop(deinterleaved_name);
@@ -861,16 +910,24 @@ class EliminateInterleaves : public IRMutator {
         }
     }
 
-    void visit(const Let *op) { visit_let(expr, op); }
+    void visit(const Let *op) {
+        visit_let(expr, op);
+
+        // Lift interleaves out of Let expression bodies.
+        const Let *let = expr.as<Let>();
+        if (yields_removable_interleave(let->body)) {
+            expr = native_interleave(Let::make(let->name, let->value, remove_interleave(let->body)));
+        }
+    }
+
     void visit(const LetStmt *op) { visit_let(stmt, op); }
 
     void visit(const Cast *op) {
         if (op->type.bits() == op->value.type().bits()) {
             // We can only move interleaves through casts of the same size.
-
             Expr value = mutate(op->value);
 
-            if (is_native_interleave(value)) {
+            if (yields_removable_interleave(value)) {
                 value = remove_interleave(value);
                 expr = native_interleave(Cast::make(op->type, value));
             } else if (!value.same_as(op->value)) {
@@ -883,7 +940,7 @@ class EliminateInterleaves : public IRMutator {
         }
     }
 
-    bool is_interleavable(const Call *op) {
+    static bool is_interleavable(const Call *op) {
         // These calls can have interleaves moved from operands to the
         // result...
         static set<string> interleavable = {
@@ -950,6 +1007,13 @@ class EliminateInterleaves : public IRMutator {
             return;
         }
 
+        if (op->is_intrinsic(Call::concat_vectors)) {
+            // The loads we care about for storage deinterleaving are
+            // concat_vectors calls.
+            visit_concat_vectors(op);
+            return;
+        }
+
         vector<Expr> args(op->args);
 
         // mutate all the args.
@@ -976,6 +1040,17 @@ class EliminateInterleaves : public IRMutator {
             { "halide.hexagon.pack_satuh.vw", "halide.hexagon.trunc_satuh.vw" },
         };
 
+        // The reverse mapping of the above.
+        static std::map<string, string> interleaving_alts = {
+            { "halide.hexagon.trunc.vh", "halide.hexagon.pack.vh" },
+            { "halide.hexagon.trunc.vw", "halide.hexagon.pack.vw" },
+            { "halide.hexagon.trunclo.vh", "halide.hexagon.packhi.vh" },
+            { "halide.hexagon.trunclo.vw", "halide.hexagon.packhi.vw" },
+            { "halide.hexagon.trunc_satub.vh", "halide.hexagon.pack_satub.vh" },
+            { "halide.hexagon.trunc_sath.vw", "halide.hexagon.pack_sath.vw" },
+            { "halide.hexagon.trunc_satuh.vw", "halide.hexagon.pack_satuh.vw" },
+        };
+
         if (is_native_deinterleave(op) && yields_interleave(args[0])) {
             // This is a deinterleave of an interleave! Remove them both.
             expr = remove_interleave(args[0]);
@@ -999,12 +1074,158 @@ class EliminateInterleaves : public IRMutator {
                 i = remove_interleave(i);
             }
             expr = Call::make(op->type, deinterleaving_alts[op->name], args, op->call_type);
+        } else if (interleaving_alts.count(op->name) && is_native_deinterleave(args[0])) {
+            // This is an interleaving alternative with a
+            // deinterleave, which can be generated when we
+            // deinterleave storage. Revert back to the interleaving
+            // op so we can remove the deinterleave.
+            Expr arg = args[0].as<Call>()->args[0];
+            expr = Call::make(op->type, interleaving_alts[op->name], { arg }, op->call_type,
+                              op->func, op->value_index, op->image, op->param);
         } else if (changed) {
             expr = Call::make(op->type, op->name, args, op->call_type,
                               op->func, op->value_index, op->image, op->param);
         } else {
             expr = op;
         }
+    }
+
+    // Track whether buffers are interleaved or not.
+    enum class BufferState {
+        Unknown,         // We don't know if this buffer is interleaved or not.
+        Interleaved,     // We know the buffer is interleaved.
+        NotInterleaved,  // We know the buffer is not interleaved.
+    };
+    Scope<BufferState> buffers;
+
+    // Buffers we should deinterleave the storage of.
+    Scope<bool> deinterleave_buffers;
+
+    void visit(const Allocate *op) {
+        Expr condition = mutate(op->condition);
+
+        // First, we need to mutate the op, to pull native interleaves
+        // down, and to gather information about the loads and stores.
+        buffers.push(op->name, BufferState::Unknown);
+        Stmt body = mutate(op->body);
+        bool deinterleave = buffers.get(op->name) == BufferState::Interleaved;
+        buffers.pop(op->name);
+
+        // Second, if we decided it would be useful to deinterleave
+        // the storage of this buffer, do so now.
+        if (deinterleave) {
+            deinterleave_buffers.push(op->name, true);
+            body = mutate(op->body);
+            deinterleave_buffers.pop(op->name);
+        }
+
+        if (!body.same_as(op->body) || !condition.same_as(op->condition)) {
+            stmt = Allocate::make(op->name, op->type, op->extents, condition, body,
+                                  op->new_expr, op->free_function);
+        } else {
+            stmt = op;
+        }
+    }
+
+    void visit(const Store *op) {
+        Expr value = mutate(op->value);
+        Expr index = mutate(op->index);
+
+        if (buffers.contains(op->name)) {
+            // When inspecting the stores to a buffer, update the state.
+            BufferState &state = buffers.ref(op->name);
+            if (yields_removable_interleave(value)) {
+                // The value yields a removable interleave. If we aren't tracking
+                // this buffer, mark it as interleaved.
+                if (state == BufferState::Unknown) {
+                    state = BufferState::Interleaved;
+                }
+            } else if (!yields_interleave(value)) {
+                // The value does not yield an interleave. Mark the
+                // buffer as not interleaved.
+                state = BufferState::NotInterleaved;
+            } else {
+                // If the buffer yields an interleave, but is not an
+                // interleave itself, we don't want to change the
+                // buffer state.
+            }
+        }
+
+        if (deinterleave_buffers.contains(op->name)) {
+            // We're deinterleaving this buffer, remove the interleave
+            // from the store.
+            value = remove_interleave(value);
+        }
+
+        if (value.same_as(op->value) && index.same_as(op->index)) {
+            stmt = op;
+        } else {
+            stmt = Store::make(op->name, value, index, op->param);
+        }
+    }
+
+    // We need to be able to find loads of multiples of pairs from a
+    // buffer, concatenated into one vector.
+    static const std::string *is_double_vector_load(const Call *op) {
+        if (!op->is_intrinsic(Call::concat_vectors)) {
+            return nullptr;
+        }
+
+        if (op->args.size() % 2 != 0) {
+            return nullptr;
+        }
+
+        Expr first = op->args.front();
+        const Load *example = first.as<Load>();
+        if (!example) {
+            return nullptr;
+        }
+
+        for (size_t i = 1; i < op->args.size(); i++) {
+            const Load *load_i = op->args[i].as<Load>();
+            if (!load_i || load_i->name != example->name) {
+                return nullptr;
+            }
+        }
+        return &example->name;
+    }
+
+    void visit_concat_vectors(const Call *op) {
+        expr = op;
+
+        const std::string *load_from = is_double_vector_load(op);
+        if (load_from) {
+            if (buffers.contains(*load_from)) {
+                // We don't want to actually do anything to the buffer
+                // state here. We know we can interleave the load if
+                // necessary, but we don't want to cause it to be
+                // interleaved unless it is a useful improvement,
+                // which is only true if any of the stores are
+                // actually interleaved (and don't just yield an
+                // interleave).
+            }
+
+            if (deinterleave_buffers.contains(*load_from)) {
+                expr = native_interleave(expr);
+            }
+        } else {
+            IRMutator::visit(op);
+        }
+    }
+
+    void visit(const Load *op) {
+        if (buffers.contains(op->name)) {
+            // When inspecting the stores to a buffer, update the state.
+            BufferState &state = buffers.ref(op->name);
+
+            // If we found a load, it must have been outside a
+            // concat_vectors intrinsic (handled above), and so it
+            // must not be a double vector load (since we've broken up
+            // loads into native vector loads). Therefore, we can't
+            // deinterleave the storage of this buffer.
+            state = BufferState::NotInterleaved;
+        }
+        IRMutator::visit(op);
     }
 
     using IRMutator::visit;
@@ -1020,7 +1241,7 @@ class FuseInterleaves : public IRMutator {
     void visit(const Call *op) {
         // This is a list of {f, g} pairs that if the first operation
         // is interleaved, interleave(f(x)) is equivalent to g(x).
-        static std::vector<std::pair<std::string, std::string>> non_deinterleaving_alts = {
+        static std::vector<std::pair<string, string>> non_deinterleaving_alts = {
             { "halide.hexagon.zxt.vub", "halide.hexagon.unpack.vub" },
             { "halide.hexagon.sxt.vb", "halide.hexagon.unpack.vb" },
             { "halide.hexagon.zxt.vuh", "halide.hexagon.unpack.vuh" },
@@ -1194,11 +1415,6 @@ Stmt optimize_hexagon_instructions(Stmt s) {
     // There may be interleaves left over that we can fuse with other
     // operations.
     s = FuseInterleaves().mutate(s);
-
-    // TODO: If all of the stores to a buffer are interleaved, and all
-    // of the loads are immediately deinterleaved, then we can remove
-    // all of the interleave/deinterleaves, and just let the storage
-    // be deinterleaved.
 
     return s;
 }

--- a/src/runtime/hvx_128.ll
+++ b/src/runtime/hvx_128.ll
@@ -341,3 +341,14 @@ define weak_odr <64 x i32> @halide.hexagon.acc_add_mpy_mpy.vw.vh.vh.b.b(<64 x i3
   %res = call <64 x i32> @llvm.hexagon.V6.vmpahb.acc.128B(<64 x i32> %acc, <64 x i32> %dv1, i32 %const)
   ret <64 x i32> %res
 }
+
+; Define a missing saturating narrow instruction in terms of a saturating narrowing shift.
+declare <32 x i32> @llvm.hexagon.V6.vasrwuhsat.128B(<32 x i32>, <32 x i32>, i32)
+
+define weak_odr <64 x i16> @halide.hexagon.trunc_satuh.vw(<64 x i32> %arg) nounwind uwtable readnone alwaysinline {
+  %e = call <32 x i32> @llvm.hexagon.V6.lo.128B(<64 x i32> %arg)
+  %o = call <32 x i32> @llvm.hexagon.V6.hi.128B(<64 x i32> %arg)
+  %r_32 = call <32 x i32> @llvm.hexagon.V6.vasrwuhsat.128B(<32 x i32> %o, <32 x i32> %e, i32 0)
+  %r = bitcast <32 x i32> %r_32 to <64 x i16>
+  ret <64 x i16> %r
+}

--- a/src/runtime/hvx_64.ll
+++ b/src/runtime/hvx_64.ll
@@ -341,3 +341,14 @@ define weak_odr <32 x i32> @halide.hexagon.acc_add_mpy_mpy.vw.vh.vh.b.b(<32 x i3
   %res = call <32 x i32> @llvm.hexagon.V6.vmpahb.acc(<32 x i32> %acc, <32 x i32> %dv1, i32 %const)
   ret <32 x i32> %res
 }
+
+; Define a missing saturating narrow instruction in terms of a saturating narrowing shift.
+declare <16 x i32> @llvm.hexagon.V6.vasrwuhsat(<16 x i32>, <16 x i32>, i32)
+
+define weak_odr <32 x i16> @halide.hexagon.trunc_satuh.vw(<32 x i32> %arg) nounwind uwtable readnone alwaysinline {
+  %e = call <16 x i32> @llvm.hexagon.V6.lo(<32 x i32> %arg)
+  %o = call <16 x i32> @llvm.hexagon.V6.hi(<32 x i32> %arg)
+  %r_32 = call <16 x i32> @llvm.hexagon.V6.vasrwuhsat(<16 x i32> %o, <16 x i32> %e, i32 0)
+  %r = bitcast <16 x i32> %r_32 to <32 x i16>
+  ret <32 x i16> %r
+}

--- a/test/correctness/widening_reduction.cpp
+++ b/test/correctness/widening_reduction.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 
 using namespace Halide;
+using namespace Halide::ConciseCasts;
 
 int main(int arch, char **argv) {
     const int W = 256, H = 256;
@@ -15,13 +16,11 @@ int main(int arch, char **argv) {
     }
 
     // Define a convolution kernel, and its sum.
-    Buffer<uint8_t> kernel(3, 3);
+    Buffer<int8_t> kernel(3, 3);
     kernel.set_min(-1, -1);
-    int kernel_sum = 0;
     for (int y = -1; y <= 1; y++) {
         for (int x = -1; x <= 1; x++) {
-            kernel(x, y) = rand() % 0x7;
-            kernel_sum += kernel(x, y);
+            kernel(x, y) = rand() % 8 - 4;
         }
     }
 
@@ -35,33 +34,30 @@ int main(int arch, char **argv) {
     // Test a widening reduction, followed by a narrowing.
     {
         Func f;
-        f(x, y) = sum(cast<uint16_t>(input(x + r.x, y + r.y)) * kernel(r.x, r.y));
-
-        Func g;
-        g(x, y) = cast<uint8_t>(f(x, y) / kernel_sum);
+        f(x, y) = u8_sat(sum(i16(input(x + r.x, y + r.y)) * kernel(r.x, r.y)) / 16);
 
         // Schedule.
         Target target = get_jit_target_from_environment();
         if (target.has_gpu_feature()) {
-            g.gpu_tile(x, y, 16, 16);
+            f.gpu_tile(x, y, 16, 16);
         } else if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
-            g.hexagon().vectorize(x, 128);
+            f.hexagon().vectorize(x, 128);
         } else {
-            g.vectorize(x, target.natural_vector_size<uint8_t>());
+            f.vectorize(x, target.natural_vector_size<uint8_t>());
         }
 
         // Run the pipeline and verify the results are correct.
-        Buffer<uint8_t> out = g.realize(W, H, target);
+        Buffer<uint8_t> out = f.realize(W, H, target);
 
         for (int y = 1; y < H-1; y++) {
             for (int x = 1; x < W-1; x++) {
-                uint16_t correct = 0;
+                int16_t correct = 0;
                 for (int ry = -1; ry <= 1; ry++) {
                     for (int rx = -1; rx <= 1; rx++) {
-                        correct += static_cast<uint16_t>(in(x + rx, y + ry)) * kernel(rx, ry);
+                        correct += static_cast<int16_t>(in(x + rx, y + ry)) * kernel(rx, ry);
                     }
                 }
-                correct /= kernel_sum;
+                correct = std::min(std::max(correct / 16, 0), 255);
                 if (correct != out(x, y)) {
                     std::cout << "out(" << x << ", " << y << ") = " << (int)out(x, y) << " instead of " << correct << "\n";
                     return -1;
@@ -73,14 +69,14 @@ int main(int arch, char **argv) {
     // Test a tuple reduction with widening, followed by narrowing the result.
     {
         Func f;
-        f(x, y) = { cast<uint16_t>(0), cast<uint8_t>(0) };
+        f(x, y) = { i16(0), i8(0) };
         f(x, y) = {
-            f(x, y)[0] + cast<uint16_t>(input(x + r.x, y + r.y)) * kernel(r.x, r.y),
+            f(x, y)[0] + i16(input(x + r.x, y + r.y)) * kernel(r.x, r.y),
             f(x, y)[1] + kernel(r.x, r.y),
         };
 
         Func g;
-        g(x, y) = cast<uint8_t>((f(x, y)[0] + f(x, y)[1]) / kernel_sum);
+        g(x, y) = u8_sat((f(x, y)[0] + f(x, y)[1]) / 16);
 
         // Schedule.
         Target target = get_jit_target_from_environment();
@@ -97,13 +93,14 @@ int main(int arch, char **argv) {
 
         for (int y = 1; y < H-1; y++) {
             for (int x = 1; x < W-1; x++) {
-                uint16_t correct = kernel_sum;
+                int16_t correct = 0;
                 for (int ry = -1; ry <= 1; ry++) {
                     for (int rx = -1; rx <= 1; rx++) {
-                        correct += static_cast<uint16_t>(in(x + rx, y + ry)) * kernel(rx, ry);
+                        correct += static_cast<int16_t>(in(x + rx, y + ry)) * kernel(rx, ry);
+                        correct += kernel(rx, ry);
                     }
                 }
-                correct /= kernel_sum;
+                correct = std::min(std::max(correct / 16, 0), 255);
                 if (correct != out(x, y)) {
                     std::cout << "out(" << x << ", " << y << ") = " << (int)out(x, y) << " instead of " << correct << "\n";
                     return -1;

--- a/test/correctness/widening_reduction.cpp
+++ b/test/correctness/widening_reduction.cpp
@@ -1,0 +1,116 @@
+#include "Halide.h"
+#include <iostream>
+
+using namespace Halide;
+
+int main(int arch, char **argv) {
+    const int W = 256, H = 256;
+
+    Buffer<uint8_t> in(W, H);
+    // Set up the input.
+    for (int y = 0; y < H; y++) {
+        for (int x = 0; x < W; x++) {
+            in(x, y) = rand() & 0xff;
+        }
+    }
+
+    // Define a convolution kernel, and its sum.
+    Buffer<uint8_t> kernel(3, 3);
+    kernel.set_min(-1, -1);
+    int kernel_sum = 0;
+    for (int y = -1; y <= 1; y++) {
+        for (int x = -1; x <= 1; x++) {
+            kernel(x, y) = rand() % 0x7;
+            kernel_sum += kernel(x, y);
+        }
+    }
+
+    Var x("x"), y("y");
+    RDom r(-1, 3, -1, 3);
+
+    // Boundary condition.
+    Func input = BoundaryConditions::repeat_edge(in);
+    input.compute_root();
+
+    // Test a widening reduction, followed by a narrowing.
+    {
+        Func f;
+        f(x, y) = sum(cast<uint16_t>(input(x + r.x, y + r.y)) * kernel(r.x, r.y));
+
+        Func g;
+        g(x, y) = cast<uint8_t>(f(x, y) / kernel_sum);
+
+        // Schedule.
+        Target target = get_jit_target_from_environment();
+        if (target.has_gpu_feature()) {
+            g.gpu_tile(x, y, 16, 16);
+        } else if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
+            g.hexagon().vectorize(x, 128);
+        } else {
+            g.vectorize(x, target.natural_vector_size<uint8_t>());
+        }
+
+        // Run the pipeline and verify the results are correct.
+        Buffer<uint8_t> out = g.realize(W, H, target);
+
+        for (int y = 1; y < H-1; y++) {
+            for (int x = 1; x < W-1; x++) {
+                uint16_t correct = 0;
+                for (int ry = -1; ry <= 1; ry++) {
+                    for (int rx = -1; rx <= 1; rx++) {
+                        correct += static_cast<uint16_t>(in(x + rx, y + ry)) * kernel(rx, ry);
+                    }
+                }
+                correct /= kernel_sum;
+                if (correct != out(x, y)) {
+                    std::cout << "out(" << x << ", " << y << ") = " << (int)out(x, y) << " instead of " << correct << "\n";
+                    return -1;
+                }
+            }
+        }
+    }
+
+    // Test a tuple reduction with widening, followed by narrowing the result.
+    {
+        Func f;
+        f(x, y) = { cast<uint16_t>(0), cast<uint8_t>(0) };
+        f(x, y) = {
+            f(x, y)[0] + cast<uint16_t>(input(x + r.x, y + r.y)) * kernel(r.x, r.y),
+            f(x, y)[1] + kernel(r.x, r.y),
+        };
+
+        Func g;
+        g(x, y) = cast<uint8_t>((f(x, y)[0] + f(x, y)[1]) / kernel_sum);
+
+        // Schedule.
+        Target target = get_jit_target_from_environment();
+        if (target.has_gpu_feature()) {
+            g.gpu_tile(x, y, 16, 16);
+        } else if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
+            g.hexagon().vectorize(x, 128);
+        } else {
+            g.vectorize(x, target.natural_vector_size<uint8_t>());
+        }
+
+        // Run the pipeline and verify the results are correct.
+        Buffer<uint8_t> out = g.realize(W, H, target);
+
+        for (int y = 1; y < H-1; y++) {
+            for (int x = 1; x < W-1; x++) {
+                uint16_t correct = kernel_sum;
+                for (int ry = -1; ry <= 1; ry++) {
+                    for (int rx = -1; rx <= 1; rx++) {
+                        correct += static_cast<uint16_t>(in(x + rx, y + ry)) * kernel(rx, ry);
+                    }
+                }
+                correct /= kernel_sum;
+                if (correct != out(x, y)) {
+                    std::cout << "out(" << x << ", " << y << ") = " << (int)out(x, y) << " instead of " << correct << "\n";
+                    return -1;
+                }
+            }
+        }
+    }
+    std::cout << "Success!\n";
+    return 0;
+}


### PR DESCRIPTION
This PR has a number of improvements to the eliminate interleaves optimization in Hexagon:

- The old optimization was a bit too conservative about when it removed interleaves, it would fail to see opportunities to remove interleaves through Let and LetStmt.
- Simplified the logic around dealing with boolean/mask vectors.
- The optimization now attempts to deinterleave buffers which are only stored interleaved and deinterleaved upon being loaded from. This means that reductions which widen, followed by usages that narrow the result, will be deinterleaved. 
- To make it easier to implement, moved some crufty logic to implement trunc_satuh(vw) to the runtime.

This significantly impacts some workloads, the widening reduction test drops in simulated cycles by ~1/3.