### PR TITLE
CSE: Let inside predicated intrinsics when value is a Load

### DIFF
--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -175,7 +175,7 @@ public:
     void visit(const Call *call) {
         bool old_protect_loads_in_scope = protect_loads_in_scope;
         if (call->is_intrinsic(Call::address_of)) {
-            // We shouldn't lift load out of a address_of/predicated_store/predicated_load node
+            // We shouldn't lift a load out of an address_of node
             protect_loads_in_scope = true;
         }
         IRMutator::visit(call);

--- a/test/correctness/cse_load_in_predicated_store.cpp
+++ b/test/correctness/cse_load_in_predicated_store.cpp
@@ -1,0 +1,24 @@
+#include "Halide.h"
+
+using namespace Halide;
+int main(int argc, char** argv) {
+  ImageParam input1(type_of<float>(), 1);
+  ImageParam input2(type_of<float>(), 2);
+
+  Func output{"output"};
+  Var x{"x"}, y{"y"};
+
+  Expr a = input1(0);
+  Expr b = input2(x, y);
+
+  output(x, y)  = a - a * b;
+
+  output.vectorize(x, 8, TailStrategy::GuardWithIf);
+
+  output.compile_to_static_library("tst", {input1, input2});
+
+  printf("Success!\n");
+
+  return 0;
+
+}


### PR DESCRIPTION
Previously, if a Let with a value that was a Load was encountered
in one of the intrinsics related to predication, it would cause
an assertion to be raised in CSE. (See #1704).