### PR TITLE
Add 32 bit multiply-keep-high-half instructions for Hexagon

### DIFF
--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -533,6 +533,9 @@ private:
             { "halide.hexagon.trunc_satuh_rnd.vw", u16_sat((wild_i64x + 32768)/65536), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
             { "halide.hexagon.trunc_sath_rnd.vw",  i16_sat((wild_i64x + 32768)/65536), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
 
+            // Multiply keep high half
+            { "halide.hexagon.trunc_mpy.vw.vw", i32((wild_i64x*wild_i64x)/Expr(static_cast<int64_t>(1) << 32)), Pattern::NarrowOps },
+
             // Scalar multiply keep high half, with multiplication by 2.
             { "halide.hexagon.trunc_satw_mpy2.vh.h", i16_sat((wild_i32x*bc(wild_i32))/32768), Pattern::NarrowOps },
             { "halide.hexagon.trunc_satw_mpy2.vh.h", i16_sat((bc(wild_i32)*wild_i32x)/32768), Pattern::NarrowOps | Pattern::SwapOps01 },
@@ -541,6 +544,8 @@ private:
 
             // Vector multiply keep high half, with multiplication by 2.
             { "halide.hexagon.trunc_satw_mpy2_rnd.vh.vh", i16_sat((wild_i32x*wild_i32x + 16384)/32768), Pattern::NarrowOps },
+            { "halide.hexagon.trunc_satdw_mpy2.vw.vw", i32_sat((wild_i64x*wild_i64x)/(1 << 31)), Pattern::NarrowOps },
+            { "halide.hexagon.trunc_satdw_mpy2_rnd.vw.vw", i32_sat((wild_i64x*wild_i64x + (1 << 30))/(1 << 31)), Pattern::NarrowOps },
 
             // Saturating narrowing casts
             { "halide.hexagon.trunc_satub_shr.vh.h", u8_sat(wild_i16x >> wild_i16), Pattern::DeinterleaveOp0 },

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -544,8 +544,8 @@ private:
 
             // Vector multiply keep high half, with multiplication by 2.
             { "halide.hexagon.trunc_satw_mpy2_rnd.vh.vh", i16_sat((wild_i32x*wild_i32x + 16384)/32768), Pattern::NarrowOps },
-            { "halide.hexagon.trunc_satdw_mpy2.vw.vw", i32_sat((wild_i64x*wild_i64x)/(1 << 31)), Pattern::NarrowOps },
-            { "halide.hexagon.trunc_satdw_mpy2_rnd.vw.vw", i32_sat((wild_i64x*wild_i64x + (1 << 30))/(1 << 31)), Pattern::NarrowOps },
+            { "halide.hexagon.trunc_satdw_mpy2.vw.vw", i32_sat((wild_i64x*wild_i64x)/Expr(static_cast<int64_t>(1) << 31)), Pattern::NarrowOps },
+            { "halide.hexagon.trunc_satdw_mpy2_rnd.vw.vw", i32_sat((wild_i64x*wild_i64x + (1 << 30))/Expr(static_cast<int64_t>(1) << 31)), Pattern::NarrowOps },
 
             // Saturating narrowing casts
             { "halide.hexagon.trunc_satub_shr.vh.h", u8_sat(wild_i16x >> wild_i16), Pattern::DeinterleaveOp0 },

--- a/src/runtime/hvx_128.ll
+++ b/src/runtime/hvx_128.ll
@@ -186,6 +186,38 @@ define weak_odr <64 x i32> @halide.hexagon.mul.vuw.vuw(<64 x i32> %a, <64 x i32>
   ret <64 x i32> %ab
 }
 
+; 32 bit multiply keep high half.
+declare <32 x i32> @llvm.hexagon.V6.vmpyewuh.128B(<32 x i32>, <32 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vmpyowh.sacc.128B(<32 x i32>, <32 x i32>, <32 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vmpyowh.rnd.sacc.128B(<32 x i32>, <32 x i32>, <32 x i32>)
+declare <32 x i32> @llvm.hexagon.V6.vasrw.128B(<32 x i32>, i32)
+declare <32 x i32> @llvm.hexagon.V6.vsubw.128B(<32 x i32>, <32 x i32>)
+
+define weak_odr <32 x i32> @halide.hexagon.trunc_mpy.vw.vw(<32 x i32> %a, <32 x i32> %b) nounwind uwtable readnone alwaysinline {
+  %ab1 = call <32 x i32> @llvm.hexagon.V6.vmpyewuh.128B(<32 x i32> %a, <32 x i32> %b)
+  %ab2 = call <32 x i32> @llvm.hexagon.V6.vmpyowh.sacc.128B(<32 x i32> %ab1, <32 x i32> %a, <32 x i32> %b)
+  %ab = call <32 x i32> @llvm.hexagon.V6.vasrw.128B(<32 x i32> %ab2, i32 1)
+  ret <32 x i32> %ab
+}
+
+define weak_odr <32 x i32> @halide.hexagon.trunc_satdw_mpy2.vw.vw(<32 x i32> %a, <32 x i32> %b) nounwind uwtable readnone alwaysinline {
+  %ab1 = call <32 x i32> @llvm.hexagon.V6.vmpyewuh.128B(<32 x i32> %a, <32 x i32> %b)
+  %ab = call <32 x i32> @llvm.hexagon.V6.vmpyowh.sacc.128B(<32 x i32> %ab1, <32 x i32> %a, <32 x i32> %b)
+  ; For some reason, this function returns the negative of the product.
+  %zero = tail call <32 x i32> @llvm.hexagon.V6.lvsplatw.128B(i32 0) #6
+  %negated_ab = call <32 x i32> @llvm.hexagon.V6.vsubw.128B(<32 x i32> %zero, <32 x i32> %ab)
+  ret <32 x i32> %negated_ab
+}
+
+define weak_odr <32 x i32> @halide.hexagon.trunc_satdw_mpy2_rnd.vw.vw(<32 x i32> %a, <32 x i32> %b) nounwind uwtable readnone alwaysinline {
+  %ab1 = call <32 x i32> @llvm.hexagon.V6.vmpyewuh.128B(<32 x i32> %a, <32 x i32> %b)
+  %ab = call <32 x i32> @llvm.hexagon.V6.vmpyowh.rnd.sacc.128B(<32 x i32> %ab1, <32 x i32> %a, <32 x i32> %b)
+  ; For some reason, this function returns the negative of the product.
+  %zero = tail call <32 x i32> @llvm.hexagon.V6.lvsplatw.128B(i32 0) #6
+  %negated_ab = call <32 x i32> @llvm.hexagon.V6.vsubw.128B(<32 x i32> %zero, <32 x i32> %ab)
+  ret <32 x i32> %negated_ab
+}
+
 ; Hexagon is missing shifts for byte sized operands.
 declare <32 x i32> @llvm.hexagon.V6.vaslh.128B(<32 x i32>, i32)
 declare <32 x i32> @llvm.hexagon.V6.vasrh.128B(<32 x i32>, i32)

--- a/src/runtime/hvx_128.ll
+++ b/src/runtime/hvx_128.ll
@@ -191,7 +191,6 @@ declare <32 x i32> @llvm.hexagon.V6.vmpyewuh.128B(<32 x i32>, <32 x i32>)
 declare <32 x i32> @llvm.hexagon.V6.vmpyowh.sacc.128B(<32 x i32>, <32 x i32>, <32 x i32>)
 declare <32 x i32> @llvm.hexagon.V6.vmpyowh.rnd.sacc.128B(<32 x i32>, <32 x i32>, <32 x i32>)
 declare <32 x i32> @llvm.hexagon.V6.vasrw.128B(<32 x i32>, i32)
-declare <32 x i32> @llvm.hexagon.V6.vsubw.128B(<32 x i32>, <32 x i32>)
 
 define weak_odr <32 x i32> @halide.hexagon.trunc_mpy.vw.vw(<32 x i32> %a, <32 x i32> %b) nounwind uwtable readnone alwaysinline {
   %ab1 = call <32 x i32> @llvm.hexagon.V6.vmpyewuh.128B(<32 x i32> %a, <32 x i32> %b)
@@ -203,19 +202,13 @@ define weak_odr <32 x i32> @halide.hexagon.trunc_mpy.vw.vw(<32 x i32> %a, <32 x 
 define weak_odr <32 x i32> @halide.hexagon.trunc_satdw_mpy2.vw.vw(<32 x i32> %a, <32 x i32> %b) nounwind uwtable readnone alwaysinline {
   %ab1 = call <32 x i32> @llvm.hexagon.V6.vmpyewuh.128B(<32 x i32> %a, <32 x i32> %b)
   %ab = call <32 x i32> @llvm.hexagon.V6.vmpyowh.sacc.128B(<32 x i32> %ab1, <32 x i32> %a, <32 x i32> %b)
-  ; For some reason, this function returns the negative of the product.
-  %zero = tail call <32 x i32> @llvm.hexagon.V6.lvsplatw.128B(i32 0) #6
-  %negated_ab = call <32 x i32> @llvm.hexagon.V6.vsubw.128B(<32 x i32> %zero, <32 x i32> %ab)
-  ret <32 x i32> %negated_ab
+  ret <32 x i32> %ab
 }
 
 define weak_odr <32 x i32> @halide.hexagon.trunc_satdw_mpy2_rnd.vw.vw(<32 x i32> %a, <32 x i32> %b) nounwind uwtable readnone alwaysinline {
   %ab1 = call <32 x i32> @llvm.hexagon.V6.vmpyewuh.128B(<32 x i32> %a, <32 x i32> %b)
   %ab = call <32 x i32> @llvm.hexagon.V6.vmpyowh.rnd.sacc.128B(<32 x i32> %ab1, <32 x i32> %a, <32 x i32> %b)
-  ; For some reason, this function returns the negative of the product.
-  %zero = tail call <32 x i32> @llvm.hexagon.V6.lvsplatw.128B(i32 0) #6
-  %negated_ab = call <32 x i32> @llvm.hexagon.V6.vsubw.128B(<32 x i32> %zero, <32 x i32> %ab)
-  ret <32 x i32> %negated_ab
+  ret <32 x i32> %ab
 }
 
 ; Hexagon is missing shifts for byte sized operands.

--- a/src/runtime/hvx_64.ll
+++ b/src/runtime/hvx_64.ll
@@ -186,6 +186,38 @@ define weak_odr <32 x i32> @halide.hexagon.mul.vuw.vuw(<32 x i32> %a, <32 x i32>
   ret <32 x i32> %ab
 }
 
+; 32 bit multiply keep high half.
+declare <16 x i32> @llvm.hexagon.V6.vmpyewuh(<16 x i32>, <16 x i32>)
+declare <16 x i32> @llvm.hexagon.V6.vmpyowh.sacc(<16 x i32>, <16 x i32>, <16 x i32>)
+declare <16 x i32> @llvm.hexagon.V6.vmpyowh.rnd.sacc(<16 x i32>, <16 x i32>, <16 x i32>)
+declare <16 x i32> @llvm.hexagon.V6.vasrw(<16 x i32>, i32)
+declare <16 x i32> @llvm.hexagon.V6.vsubw(<16 x i32>, <16 x i32>)
+
+define weak_odr <16 x i32> @halide.hexagon.trunc_mpy.vw.vw(<16 x i32> %a, <16 x i32> %b) nounwind uwtable readnone alwaysinline {
+  %ab1 = call <16 x i32> @llvm.hexagon.V6.vmpyewuh(<16 x i32> %a, <16 x i32> %b)
+  %ab2 = call <16 x i32> @llvm.hexagon.V6.vmpyowh.sacc(<16 x i32> %ab1, <16 x i32> %a, <16 x i32> %b)
+  %ab = call <16 x i32> @llvm.hexagon.V6.vasrw(<16 x i32> %ab2, i32 1)
+  ret <16 x i32> %ab
+}
+
+define weak_odr <16 x i32> @halide.hexagon.trunc_satdw_mpy2.vw.vw(<16 x i32> %a, <16 x i32> %b) nounwind uwtable readnone alwaysinline {
+  %ab1 = call <16 x i32> @llvm.hexagon.V6.vmpyewuh(<16 x i32> %a, <16 x i32> %b)
+  %ab = call <16 x i32> @llvm.hexagon.V6.vmpyowh.sacc(<16 x i32> %ab1, <16 x i32> %a, <16 x i32> %b)
+  ; For some reason, this function returns the negative of the product.
+  %zero = tail call <16 x i32> @llvm.hexagon.V6.lvsplatw(i32 0) #6
+  %negated_ab = call <16 x i32> @llvm.hexagon.V6.vsubw(<16 x i32> %zero, <16 x i32> %ab)
+  ret <16 x i32> %negated_ab
+}
+
+define weak_odr <16 x i32> @halide.hexagon.trunc_satdw_mpy2_rnd.vw.vw(<16 x i32> %a, <16 x i32> %b) nounwind uwtable readnone alwaysinline {
+  %ab1 = call <16 x i32> @llvm.hexagon.V6.vmpyewuh(<16 x i32> %a, <16 x i32> %b)
+  %ab = call <16 x i32> @llvm.hexagon.V6.vmpyowh.rnd.sacc(<16 x i32> %ab1, <16 x i32> %a, <16 x i32> %b)
+  ; For some reason, this function returns the negative of the product.
+  %zero = tail call <16 x i32> @llvm.hexagon.V6.lvsplatw(i32 0) #6
+  %negated_ab = call <16 x i32> @llvm.hexagon.V6.vsubw(<16 x i32> %zero, <16 x i32> %ab)
+  ret <16 x i32> %negated_ab
+}
+
 ; Hexagon is missing shifts for byte sized operands.
 declare <16 x i32> @llvm.hexagon.V6.vaslh(<16 x i32>, i32)
 declare <16 x i32> @llvm.hexagon.V6.vasrh(<16 x i32>, i32)

--- a/src/runtime/hvx_64.ll
+++ b/src/runtime/hvx_64.ll
@@ -191,7 +191,6 @@ declare <16 x i32> @llvm.hexagon.V6.vmpyewuh(<16 x i32>, <16 x i32>)
 declare <16 x i32> @llvm.hexagon.V6.vmpyowh.sacc(<16 x i32>, <16 x i32>, <16 x i32>)
 declare <16 x i32> @llvm.hexagon.V6.vmpyowh.rnd.sacc(<16 x i32>, <16 x i32>, <16 x i32>)
 declare <16 x i32> @llvm.hexagon.V6.vasrw(<16 x i32>, i32)
-declare <16 x i32> @llvm.hexagon.V6.vsubw(<16 x i32>, <16 x i32>)
 
 define weak_odr <16 x i32> @halide.hexagon.trunc_mpy.vw.vw(<16 x i32> %a, <16 x i32> %b) nounwind uwtable readnone alwaysinline {
   %ab1 = call <16 x i32> @llvm.hexagon.V6.vmpyewuh(<16 x i32> %a, <16 x i32> %b)
@@ -203,19 +202,13 @@ define weak_odr <16 x i32> @halide.hexagon.trunc_mpy.vw.vw(<16 x i32> %a, <16 x 
 define weak_odr <16 x i32> @halide.hexagon.trunc_satdw_mpy2.vw.vw(<16 x i32> %a, <16 x i32> %b) nounwind uwtable readnone alwaysinline {
   %ab1 = call <16 x i32> @llvm.hexagon.V6.vmpyewuh(<16 x i32> %a, <16 x i32> %b)
   %ab = call <16 x i32> @llvm.hexagon.V6.vmpyowh.sacc(<16 x i32> %ab1, <16 x i32> %a, <16 x i32> %b)
-  ; For some reason, this function returns the negative of the product.
-  %zero = tail call <16 x i32> @llvm.hexagon.V6.lvsplatw(i32 0) #6
-  %negated_ab = call <16 x i32> @llvm.hexagon.V6.vsubw(<16 x i32> %zero, <16 x i32> %ab)
-  ret <16 x i32> %negated_ab
+  ret <16 x i32> %ab
 }
 
 define weak_odr <16 x i32> @halide.hexagon.trunc_satdw_mpy2_rnd.vw.vw(<16 x i32> %a, <16 x i32> %b) nounwind uwtable readnone alwaysinline {
   %ab1 = call <16 x i32> @llvm.hexagon.V6.vmpyewuh(<16 x i32> %a, <16 x i32> %b)
   %ab = call <16 x i32> @llvm.hexagon.V6.vmpyowh.rnd.sacc(<16 x i32> %ab1, <16 x i32> %a, <16 x i32> %b)
-  ; For some reason, this function returns the negative of the product.
-  %zero = tail call <16 x i32> @llvm.hexagon.V6.lvsplatw(i32 0) #6
-  %negated_ab = call <16 x i32> @llvm.hexagon.V6.vsubw(<16 x i32> %zero, <16 x i32> %ab)
-  ret <16 x i32> %negated_ab
+  ret <16 x i32> %ab
 }
 
 ; Hexagon is missing shifts for byte sized operands.

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1775,8 +1775,8 @@ void check_hvx_all() {
     check("vmpy(v*.h,r*.h):<<1:rnd:sat", hvx_width/2, i16_sat((32767*i32(i16_1) + 16384)/32768));
 
     check("vmpyo(v*.w,v*.h)", hvx_width/4, i32((i64(i32_1)*i64(i32_2))/(i64(1) << 32)));
-    check("vmpyo(v*.w,v*.h):<<1:sat", hvx_width/4, i32_sat((i64(i32_1)*i64(i32_2))/(1 << 31)));
-    check("vmpyo(v*.w,v*.h):<<1:rnd:sat", hvx_width/4, i32_sat((i64(i32_1)*i64(i32_2) + (1 << 30))/(1 << 31)));
+    check("vmpyo(v*.w,v*.h):<<1:sat", hvx_width/4, i32_sat((i64(i32_1)*i64(i32_2))/(i64(1) << 31)));
+    check("vmpyo(v*.w,v*.h):<<1:rnd:sat", hvx_width/4, i32_sat((i64(i32_1)*i64(i32_2) + (1 << 30))/(i64(1) << 31)));
 
     check("v*.w += vasl(v*.w,r*)", hvx_width/4, u32_1 + (u32_2 * 8));
     check("v*.w += vasl(v*.w,r*)", hvx_width/4, i32_1 + (i32_2 * 8));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1774,6 +1774,10 @@ void check_hvx_all() {
     check("vmpy(v*.h,r*.h):<<1:rnd:sat", hvx_width/2, i16_sat((i32(i16_1)*32767 + 16384)/32768));
     check("vmpy(v*.h,r*.h):<<1:rnd:sat", hvx_width/2, i16_sat((32767*i32(i16_1) + 16384)/32768));
 
+    check("vmpyo(v*.w,v*.h)", hvx_width/4, i32((i64(i32_1)*i64(i32_2))/(i64(1) << 32)));
+    check("vmpyo(v*.w,v*.h):<<1:sat", hvx_width/4, i32_sat((i64(i32_1)*i64(i32_2))/(1 << 31)));
+    check("vmpyo(v*.w,v*.h):<<1:rnd:sat", hvx_width/4, i32_sat((i64(i32_1)*i64(i32_2) + (1 << 30))/(1 << 31)));
+
     check("v*.w += vasl(v*.w,r*)", hvx_width/4, u32_1 + (u32_2 * 8));
     check("v*.w += vasl(v*.w,r*)", hvx_width/4, i32_1 + (i32_2 * 8));
     check("v*.w += vasr(v*.w,r*)", hvx_width/4, i32_1 + (i32_2 / 8));


### PR DESCRIPTION
This PR adds support for the 32 bit doubling multiply keep high half instructions on Hexagon.

@ronlieb @dpalermo please take a look. Do you know of a way to implement the non-doubling multiply without an extra shift? I didn't see the relevant instructions.