### PR TITLE
Add Input<Buffer> and Output<Buffer> to Generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -896,6 +896,8 @@ $(FILTERS_DIR)/pyramid.a: $(BIN_DIR)/pyramid.generator
 
 METADATA_TESTER_GENERATOR_ARGS=\
 	input.type=uint8 input.dim=3 \
+	semityped_input_buffer.dim=3 \
+	untyped_input_buffer.type=uint8 untyped_input_buffer.dim=3 \
 	output.type=float32,float32 output.dim=3 \
 	input_not_nod.type=uint8 input_not_nod.dim=3 \
 	input_nod.dim=3 \
@@ -970,6 +972,7 @@ $(BIN_DIR)/stubuser.generator: $(BIN_DIR)/stubtest_generator.o
 # usage (the types can be inferred), but for AOT compilation, we must make the types
 # concrete via generator args.
 STUBTEST_GENERATOR_ARGS=\
+    untyped_buffer_input.type=uint8 untyped_buffer_input.dim=3 \
 	simple_input.type=float32 \
 	array_input.type=float32 array_input.size=2 \
 	int_arg.size=2 \

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -4,6 +4,7 @@
 
 #include "Generator.h"
 #include "Outputs.h"
+#include "Simplify.h"
 
 namespace Halide {
 namespace Internal {
@@ -191,6 +192,68 @@ Func make_param_func(const Parameter &p, const std::string &name) {
 }
 
 }  // namespace
+
+void ValueTracker::track_values(const std::string &name, const std::vector<Expr> &values) {
+    std::vector<std::vector<Expr>> &history = values_history[name];
+    if (history.empty()) {
+        for (size_t i = 0; i < values.size(); ++i) {
+            history.push_back({values[i]});
+        }
+        return;
+    }
+
+    internal_assert(history.size() == values.size())
+        << "Expected values of size " << history.size()
+        << " but saw size " << values.size()
+        << " for name " << name << "\n";
+
+    // For each item, see if we have a new unique value
+    for (size_t i = 0; i < values.size(); ++i) {
+        Expr oldval = history[i].back();
+        Expr newval = values[i];
+        if (oldval.defined() && newval.defined()) {
+            if (can_prove(newval == oldval)) {
+                continue;
+            }
+        } else if (!oldval.defined() && !newval.defined()) {
+            // Expr::operator== doesn't work with undefined
+            // values, but they are equal for our purposes here.
+            continue;
+        }
+        history[i].push_back(newval);
+        // If we exceed max_unique_values, fail immediately.
+        // TODO: could be useful to log all the entries that
+        // overflow max_unique_values before failing.
+        // TODO: this could be more helpful about labeling the values
+        // that have multiple setttings.
+        if (history[i].size() > max_unique_values) {
+            std::ostringstream o;
+            o << "Saw too many unique values in ValueTracker[" + std::to_string(i) + "]; "
+              << "expected a maximum of " << max_unique_values << ":\n";
+            for (auto e : history[i]) {
+                o << "    " << e << "\n";
+            }
+            user_error << o.str();
+        }
+    }
+}
+
+std::vector<Expr> parameter_constraints(const Parameter &p) {
+    internal_assert(p.defined());
+    std::vector<Expr> values;
+    values.push_back(Expr(p.host_alignment()));
+    if (p.is_buffer()) {
+        for (int i = 0; i < p.dimensions(); ++i) {
+            values.push_back(p.min_constraint(i));
+            values.push_back(p.extent_constraint(i));
+            values.push_back(p.stride_constraint(i));
+        }
+    } else {
+        values.push_back(p.get_min_value());
+        values.push_back(p.get_max_value());
+    }
+    return values;
+}
 
 class StubEmitter {
 public:
@@ -394,7 +457,8 @@ void StubEmitter::emit() {
         std::string c_type = output->get_c_type();
         std::string getter;
         if (output->is_array()) getter = "get_output_vector";
-        else getter = "get_output";
+        else if (c_type == "Func") getter = "get_output";
+        else getter = "get_output_buffer<" + c_type + ">";
         out_info.push_back({
             output->name(),
             output->is_array() ? "std::vector<" + c_type + ">" : c_type,
@@ -619,6 +683,8 @@ GeneratorStub::GeneratorStub(const GeneratorContext *context,
                              const std::vector<std::vector<Internal::StubInput>> &inputs)
     : generator(generator_factory(generator_params)) {
     user_assert(context != nullptr) << "Context may not be null";
+    internal_assert(generator->value_tracker == nullptr);
+    generator->value_tracker = context->get_value_tracker();
     generator->target.set(context->get_target());
     generator->set_inputs(inputs);
     generator->call_generate();
@@ -1091,6 +1157,9 @@ void GeneratorBase::set_generator_param_values(const std::map<std::string, std::
     }
     std::map<std::string, GIOBase *> type_names, dim_names, array_size_names;
     for (auto i : filter_inputs) {
+        if (!i->allow_synthetic_generator_params()) {
+            continue;
+        }
         if (i->kind() != IOKind::Scalar) {
             type_names[i->name() + ".type"] = i;
             dim_names[i->name() + ".dim"] = i;
@@ -1100,6 +1169,9 @@ void GeneratorBase::set_generator_param_values(const std::map<std::string, std::
         }
     }
     for (auto o : filter_outputs) {
+        if (!o->allow_synthetic_generator_params()) {
+            continue;
+        }
         if (o->kind() != IOKind::Scalar) {
             type_names[o->name() + ".type"] = o;
             dim_names[o->name() + ".dim"] = o;
@@ -1184,6 +1256,28 @@ void GeneratorBase::set_inputs(const std::vector<std::vector<StubInput>> &inputs
     inputs_set = true;
 }
 
+void GeneratorBase::track_parameter_values(bool include_outputs) {
+    if (value_tracker == nullptr) {
+        value_tracker = std::make_shared<ValueTracker>();
+    }
+    for (auto input : filter_inputs) {
+        if (input->kind() == IOKind::Buffer) {
+            Parameter p = input->parameter();
+            // This must use p.name(), *not* input->name()
+            value_tracker->track_values(p.name(), parameter_constraints(p));
+        }
+    }
+    if (include_outputs) {
+        for (auto output : filter_outputs) {
+            if (output->kind() == IOKind::Buffer) {
+                Parameter p = output->parameter();
+                // This must use p.name(), *not* output->name()
+                value_tracker->track_values(p.name(), parameter_constraints(p));
+            }
+        }
+    }
+}
+
 void GeneratorBase::pre_generate() {
     user_assert(!generate_called) << "You may not call the generate() method more than once per instance.";
     user_assert(filter_params.size() == 0) << "May not use generate() method with Param<> or ImageParam.";
@@ -1197,28 +1291,33 @@ void GeneratorBase::pre_generate() {
     for (auto output : filter_outputs) {
         output->init_internals();
     }
+    track_parameter_values(false);
 }
 
 void GeneratorBase::post_generate() {
     generate_called = true;
+    track_parameter_values(true);
 }
 
 void GeneratorBase::pre_schedule() {
     user_assert(generate_called) << "You must call the generate() method before calling the schedule() method.";
     user_assert(!schedule_called) << "You may not call the schedule() method more than once per instance.";
+    track_parameter_values(true);
 }
 
 void GeneratorBase::post_schedule() {
     schedule_called = true;
+    track_parameter_values(true);
 }
 
 void GeneratorBase::pre_build() {
     user_assert(filter_inputs.size() == 0) << "May not use build() method with Input<>.";
     user_assert(filter_outputs.size() == 0) << "May not use build() method with Output<>.";
+    track_parameter_values(false);
 }
 
 void GeneratorBase::post_build() {
-    // nothing yet
+    track_parameter_values(true);
 }
 
 Pipeline GeneratorBase::produce_pipeline() {
@@ -1227,18 +1326,22 @@ Pipeline GeneratorBase::produce_pipeline() {
     for (auto output : filter_outputs) {
         for (const auto &f : output->funcs()) {
             user_assert(f.defined()) << "Output \"" << f.name() << "\" was not defined.\n";
-            user_assert(f.dimensions() == output->dimensions()) << "Output \"" << f.name() 
-                << "\" requires dimensions=" << output->dimensions() 
-                << " but was defined as dimensions=" << f.dimensions() << ".\n";
-            user_assert((int)f.outputs() == (int)output->types().size()) << "Output \"" << f.name() 
-                    << "\" requires a Tuple of size " << output->types().size() 
-                    << " but was defined as Tuple of size " << f.outputs() << ".\n";
-            for (size_t i = 0; i < f.output_types().size(); ++i) {
-                Type expected = output->types().at(i);
-                Type actual = f.output_types()[i];
-                user_assert(expected == actual) << "Output \"" << f.name() 
-                    << "\" requires type " << expected 
-                    << " but was defined as type " << actual << ".\n";
+            if (output->dimensions_defined()) {
+                user_assert(f.dimensions() == output->dimensions()) << "Output \"" << f.name() 
+                    << "\" requires dimensions=" << output->dimensions() 
+                    << " but was defined as dimensions=" << f.dimensions() << ".\n";
+            }
+            if (output->types_defined()) {
+                user_assert((int)f.outputs() == (int)output->types().size()) << "Output \"" << f.name() 
+                        << "\" requires a Tuple of size " << output->types().size() 
+                        << " but was defined as Tuple of size " << f.outputs() << ".\n";
+                for (size_t i = 0; i < f.output_types().size(); ++i) {
+                    Type expected = output->types().at(i);
+                    Type actual = f.output_types()[i];
+                    user_assert(expected == actual) << "Output \"" << f.name() 
+                        << "\" requires type " << expected 
+                        << " but was defined as type " << actual << ".\n";
+                }
             }
             funcs.push_back(f);
         }
@@ -1481,6 +1584,11 @@ void GeneratorInputBase::set_inputs(const std::vector<StubInput> &inputs) {
             check_matching_type_and_dim(f.output_types(), f.dimensions());
             funcs_.push_back(f);
             parameters_.emplace_back(f.output_types().at(0), true, f.dimensions(), array_name(i), true, false);
+        } else if (kind() == IOKind::Buffer) {
+            auto p = in.parameter();
+            check_matching_type_and_dim({p.type()}, p.dimensions());
+            funcs_.push_back(make_param_func(p, name()));
+            parameters_.push_back(p);
         } else {
             auto e = in.expr();
             check_matching_type_and_dim({e.type()}, 0);
@@ -1527,6 +1635,13 @@ void GeneratorOutputBase::resize(size_t size) {
     init_internals();
 }
 
+void StubOutputBufferBase::check_scheduled(const char* m) const { 
+    user_assert(generator->schedule_called) << "Must call schedule() before calling " << m << "()"; 
+}
+
+Target StubOutputBufferBase::get_target() const { 
+    return generator->get_target();
+}
 
 void generator_test() {
     GeneratorParam<int> gp("gp", 1);

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -881,6 +881,8 @@ decltype(!(T)0) operator!(const GeneratorParam<T> &a) { return !(T)a; }
 
 namespace Internal {
 
+template<typename T2> class GeneratorInput_Buffer;
+
 enum class IOKind { Scalar, Function, Buffer };
 
 /**

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -214,8 +214,8 @@ namespace Internal {
 
 /**
  * ValueTracker is an internal utility class that attempts to track and flag certain
- * obvious Stub-related errors at Halide compiletime: it tracks the constraints set
- * on any Parameter-basedd argument (i.e., Input<Buffer> and Output<Buffer>) to
+ * obvious Stub-related errors at Halide compile time: it tracks the constraints set
+ * on any Parameter-based argument (i.e., Input<Buffer> and Output<Buffer>) to
  * ensure that incompatible values aren't set. 
  *
  * e.g.: if a Generator A requires stride[0] == 1, 

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -208,7 +208,46 @@
 
 namespace Halide {
 
+template<typename T, int D> class Buffer;
+
 namespace Internal {
+
+/**
+ * ValueTracker is an internal utility class that attempts to track and flag certain
+ * obvious Stub-related errors at Halide compiletime: it tracks the constraints set
+ * on any Parameter-basedd argument (i.e., Input<Buffer> and Output<Buffer>) to
+ * ensure that incompatible values aren't set. 
+ *
+ * e.g.: if a Generator A requires stride[0] == 1, 
+ * and Generator B uses Generator A via stub, but requires stride[0] == 4,
+ * we should be able to detect this at Halide compilation time, and fail immediately,
+ * rather than producing code that fails at runtime and/or runs slowly due to
+ * vectorization being unavailable.
+ *
+ * We do this by tracking the active values at entrance and exit to all user-provided
+ * Generator methods (build()/generate()/schedule()); if we ever find more than two unique
+ * values active, we know we have a potential conflict. ("two" here because the first
+ * value is the default value for a given constraint.)
+ *
+ * Note that this won't catch all cases:
+ * -- JIT compilation has no way to check for conflicts at the top-level
+ * -- constraints that match the default value (e.g. if dim(0).set_stride(1) is the
+ * first value seen by the tracker) will be ignored, so an explicit requirement set
+ * this way can be missed
+ *
+ * Nevertheless, this is likely to be much better than nothing when composing multiple
+ * layers of Stubs in a single fused result.
+ */
+class ValueTracker {
+private:
+    std::map<std::string, std::vector<std::vector<Expr>>> values_history;
+    const size_t max_unique_values;
+public:
+    explicit ValueTracker(size_t max_unique_values = 2) : max_unique_values(max_unique_values) {}
+    EXPORT void track_values(const std::string &name, const std::vector<Expr> &values);
+};
+
+EXPORT std::vector<Expr> parameter_constraints(const Parameter &p);
 
 template <typename T>
 NO_INLINE std::string enum_to_string(const std::map<std::string, T> &enum_map, const T& t) {
@@ -842,7 +881,102 @@ decltype(!(T)0) operator!(const GeneratorParam<T> &a) { return !(T)a; }
 
 namespace Internal {
 
-enum class IOKind { Scalar, Function };
+enum class IOKind { Scalar, Function, Buffer };
+
+/**
+ * StubInputBuffer is the placeholder that a Stub uses when it requires 
+ * a Buffer for an input (rather than merely a Func or Expr). It is constructed
+ * to allow only two possible sorts of input:
+ * -- Assignment of an Input<Buffer<>>, with compatible type and dimensions;
+ * this is useful in both AOT and JIT compilation modes.
+ * -- Assignment of a Buffer<>, with compatible type and dimensions;
+ * this is useful only in JIT compilation modes (and shouldn't be usable otherwise).
+ */
+template<typename T = void, int D = 4>
+class StubInputBuffer {
+    friend class GeneratorStub;
+    friend class StubInput;
+    template<typename T2> friend class GeneratorInput_Buffer;
+
+    Parameter parameter_;
+
+    NO_INLINE explicit StubInputBuffer(const Parameter &p) : parameter_(p) {
+        // Create an empty 1-element buffer with the right runtime typing and dimensions,
+        // which we'll use only to pass to can_convert_from() to verify this
+        // Parameter is compatible with our constraints.
+        Buffer<> other(p.type(), nullptr, std::vector<int>(p.dimensions(), 1));
+        internal_assert((Buffer<T, D>::can_convert_from(other)));
+    }
+
+    template<typename T2, int D2>
+    NO_INLINE static Parameter parameter_from_buffer(const Buffer<T2, D2> &b) {
+        user_assert((Buffer<T, D>::can_convert_from(b)));
+        Parameter p(b.type(), true, b.dimensions());
+        p.set_buffer(b);
+        return p;
+    }
+
+public:
+    StubInputBuffer() {}
+
+    // *not* explicit -- this ctor should only be used when jitting.
+    // Note that Buffer arguments are always converted to a static type of 
+    // Buffer<void> (but retain their dynamic type-and-dimensions internally).    
+    template<typename T2, int D2>
+    StubInputBuffer(const Buffer<T2, D2> &b) : parameter_(parameter_from_buffer(b)) {}
+};
+
+class GeneratorBase;
+
+class StubOutputBufferBase {
+protected:
+    Func f;
+    std::shared_ptr<GeneratorBase> generator;
+
+    EXPORT void check_scheduled(const char* m) const;
+    EXPORT Target get_target() const;
+
+    explicit StubOutputBufferBase(const Func &f, std::shared_ptr<GeneratorBase> generator) : f(f), generator(generator) {}
+    StubOutputBufferBase() {}
+
+public:
+    Realization realize(std::vector<int32_t> sizes) { 
+        check_scheduled("realize");
+        return f.realize(sizes, get_target()); 
+    }
+    
+    template <typename... Args> 
+    Realization realize(Args&&... args) { 
+        check_scheduled("realize");
+        return f.realize(std::forward<Args>(args)..., get_target()); 
+    }
+
+    template<typename Dst> 
+    void realize(Dst dst) { 
+        check_scheduled("realize");
+        f.realize(dst, get_target()); 
+    }
+};
+
+/**
+ * StubOutputBuffer is the placeholder that a Stub uses when it requires 
+ * a Buffer for an output (rather than merely a Func). It is constructed
+ * to allow only two possible sorts of things:
+ * -- Assignment to an Output<Buffer<>>, with compatible type and dimensions;
+ * this is useful in both AOT and JIT compilation modes.
+ * -- Realization into a Buffer<>; this is useful only in JIT compilation modes 
+ * (and shouldn't be usable otherwise).
+ * 
+ * It is deliberate that StubOutputBuffer is not (easily) convertible to Func.
+ */
+template<typename T = void, int D = 4>
+class StubOutputBuffer : public StubOutputBufferBase {
+    template<typename T2> friend class GeneratorOutput_Buffer;
+    friend class GeneratorStub;
+    explicit StubOutputBuffer(const Func &f, std::shared_ptr<GeneratorBase> generator) : StubOutputBufferBase(f, generator) {}
+public:
+    StubOutputBuffer() {}
+};
 
 // This is a union-like class that allows for convenient initialization of Stub Inputs
 // via C++11 initializer-list syntax; it is only used in situations where the
@@ -850,10 +984,12 @@ enum class IOKind { Scalar, Function };
 // of the expected/required kind.
 class StubInput {
     const IOKind kind_;
+    const Parameter parameter_;
     const Func func_;
     const Expr expr_;
 public:
     // *not* explicit. 
+    StubInput(const StubInputBuffer<> &b) : StubInput(b.parameter_) {}
     StubInput(const Func &f) : kind_(IOKind::Function), func_(f) {}
     StubInput(const Expr &e) : kind_(IOKind::Scalar), expr_(e) {}
 
@@ -861,8 +997,17 @@ private:
     friend class GeneratorInputBase;
     friend class GeneratorStub;
 
+    StubInput(const Parameter &p) : kind_(IOKind::Buffer), parameter_(p) {
+        internal_assert(p.is_buffer());
+    }
+
     IOKind kind() const {
         return kind_;
+    }
+
+    Parameter parameter() const {
+        internal_assert(kind_ == IOKind::Buffer);
+        return parameter_;
     }
 
     Func func() const {
@@ -873,6 +1018,30 @@ private:
     Expr expr() const {
         internal_assert(kind_ == IOKind::Scalar);
         return expr_;
+    }
+};
+
+class Constrainable {
+public:
+    virtual ~Constrainable() {}
+
+    virtual Parameter parameter() const = 0;
+
+    Dimension dim(int i) {
+        return Dimension(parameter(), i);
+    }
+
+    const Dimension dim(int i) const {
+        return Dimension(parameter(), i);
+    }
+
+    int host_alignment() const {
+        return parameter().host_alignment();
+    }
+
+    Constrainable &set_host_alignment(int alignment) {
+        parameter().set_host_alignment(alignment);
+        return *this;
     }
 };
 
@@ -944,6 +1113,15 @@ protected:
 
     template<typename ElemType>
     const std::vector<ElemType> &get_values() const;
+
+    virtual bool allow_synthetic_generator_params() const {
+        return true;
+    }
+
+    virtual Parameter parameter() const {
+        internal_error << "Unimplemented";
+        return Parameter();
+    }
 
 private:
     explicit GIOBase(const GIOBase &) = delete;
@@ -1052,6 +1230,71 @@ public:
         return get_values<ValueType>().end();
     }
 };
+
+template<typename T>
+class GeneratorInput_Buffer : public GeneratorInputImpl<T, Func>, public Constrainable {
+private:
+    using Super = GeneratorInputImpl<T, Func>;
+
+protected:
+    using TBase = typename Super::TBase;
+
+    bool allow_synthetic_generator_params() const override {
+        return !T::has_static_halide_type();
+    }
+
+    std::string get_c_type() const override {
+        if (T::has_static_halide_type()) {
+            return "Halide::Internal::StubInputBuffer<" + 
+                halide_type_to_c_type(T::static_halide_type()) + 
+                ">";
+        } else {
+            return "Halide::Internal::StubInputBuffer<>";
+        }
+    }
+
+    Parameter parameter() const override {
+        internal_assert(this->parameters_.size() == 1);
+        return this->parameters_.at(0);
+    }
+
+public:
+    GeneratorInput_Buffer(const std::string &name)
+        : Super(name, IOKind::Buffer,
+                T::has_static_halide_type() ? std::vector<Type>{ T::static_halide_type() } : std::vector<Type>{}, 
+                -1) {
+    }
+
+    GeneratorInput_Buffer(const std::string &name, const Type &t, int d = -1)
+        : Super(name, IOKind::Buffer, {t}, d) {
+        static_assert(!T::has_static_halide_type(), "Cannot use pass a Type argument for a Buffer with a non-void static type");
+    }
+
+    GeneratorInput_Buffer(const std::string &name, int d)
+        : Super(name, IOKind::Buffer, std::vector<Type>{ T::static_halide_type() }, d) {
+        static_assert(T::has_static_halide_type(), "Must pass a Type argument for a Buffer with a static type of void");
+    }
+
+
+    template <typename... Args>
+    Expr operator()(Args&&... args) const {
+        return this->funcs().at(0)(std::forward<Args>(args)...);
+    }
+
+    Expr operator()(std::vector<Expr> args) const {
+        return this->funcs().at(0)(args);
+    }
+
+    template<typename T2, int D2>
+    operator StubInputBuffer<T2, D2>() const {
+        return StubInputBuffer<T2, D2>(parameter());
+    }
+
+    operator Func() const { 
+        return this->funcs().at(0); 
+    }
+};
+
 
 template<typename T>
 class GeneratorInput_Func : public GeneratorInputImpl<T, Func> {
@@ -1215,12 +1458,22 @@ public:
     }
 };
 
+template<typename> 
+struct type_sink { typedef void type; };
+
+template<typename T2, typename = void> 
+struct has_static_halide_type_method : std::false_type {}; 
+
+template<typename T2> 
+struct has_static_halide_type_method<T2, typename type_sink<decltype(T2::static_halide_type())>::type> : std::true_type {};
+
 template<typename T, typename TBase = typename std::remove_all_extents<T>::type> 
 using GeneratorInputImplBase =
     typename select_type<
-        cond<std::is_same<TBase, Func>::value, GeneratorInput_Func<T>>,
-        cond<std::is_arithmetic<TBase>::value, GeneratorInput_Arithmetic<T>>,
-        cond<std::is_scalar<TBase>::value,     GeneratorInput_Scalar<T>>
+        cond<has_static_halide_type_method<TBase>::value, GeneratorInput_Buffer<T>>,
+        cond<std::is_same<TBase, Func>::value,            GeneratorInput_Func<T>>,
+        cond<std::is_arithmetic<TBase>::value,            GeneratorInput_Arithmetic<T>>,
+        cond<std::is_scalar<TBase>::value,                GeneratorInput_Scalar<T>>
     >::type;
 
 }  // namespace Internal
@@ -1238,8 +1491,9 @@ protected:
     struct Unused;
     using IntIfNonScalar =
         typename Internal::select_type<
+            Internal::cond<Internal::has_static_halide_type_method<TBase>::value, int>,
             Internal::cond<std::is_same<TBase, Func>::value, int>,
-            Internal::cond<true,                             Unused>
+            Internal::cond<true, Unused>
         >::type;
 
 public:
@@ -1411,6 +1665,89 @@ public:
 };
 
 template<typename T>
+class GeneratorOutput_Buffer : public GeneratorOutputImpl<T>, public Constrainable {
+private:
+    using Super = GeneratorOutputImpl<T>;
+
+protected:
+    using TBase = typename Super::TBase;
+
+protected:
+    GeneratorOutput_Buffer(const std::string &name)
+        : Super(name, IOKind::Buffer, 
+                T::has_static_halide_type() ? std::vector<Type>{ T::static_halide_type() } : std::vector<Type>{}, 
+                -1) {
+    }
+
+    GeneratorOutput_Buffer(const std::string &name, const std::vector<Type> &t, int d = -1)
+        : Super(name, IOKind::Buffer, 
+                T::has_static_halide_type() ? std::vector<Type>{ T::static_halide_type() } : t, 
+                d) {
+        if (T::has_static_halide_type()) {
+            user_assert(t.empty()) << "Cannot use pass a Type argument for a Buffer with a non-void static type\n";
+        } else {
+            user_assert(t.size() == 1) << "Output<Buffer<>> requires exactly one Type\n";
+        }
+    }
+
+    GeneratorOutput_Buffer(const std::string &name, int d)
+        : Super(name, IOKind::Buffer, std::vector<Type>{ T::static_halide_type() }, d) {
+        static_assert(T::has_static_halide_type(), "Must pass a Type argument for a Buffer with a static type of void");
+    }
+
+    NO_INLINE std::string get_c_type() const override {
+        if (T::has_static_halide_type()) {
+            return "Halide::Internal::StubOutputBuffer<" + 
+                halide_type_to_c_type(T::static_halide_type()) + 
+                ">";
+        } else {
+            return "Halide::Internal::StubOutputBuffer<>";
+        }
+    }
+
+    Parameter parameter() const override {
+        internal_assert(this->funcs().size() == 1);
+        return this->funcs().at(0).output_buffer().parameter();
+    }
+
+public:
+
+    // Allow assignment from a StubOutputBuffer to an Output<Buffer>;
+    // this allows us to pipeline the results of a Stub to the results
+    // of the enclosing Generator.
+    template<typename T2, int D2>
+    NO_INLINE GeneratorOutput_Buffer<T> &operator=(const StubOutputBuffer<T2, D2> &stub_output_buffer) {
+        const auto &f = stub_output_buffer.f;
+        internal_assert(f.defined());
+
+        const auto &output_types = f.output_types();
+        user_assert(output_types.size() == 1) 
+            << "Output should have size=1 but saw size=" << output_types.size() << "\n";
+
+        Buffer<> other(output_types.at(0), nullptr, std::vector<int>(f.dimensions(), 1));
+        user_assert(T::can_convert_from(other)) 
+            << "Cannot assign to the Output \"" << this->name() 
+            << "\": the expression is not convertible to the same Buffer type and/or dimensions.\n";
+
+        if (this->types_defined()) {
+            user_assert(output_types.at(0) == this->type()) 
+                << "Output should have type=" << this->type() << " but saw type=" << output_types.at(0) << "\n";
+        }
+        if (this->dimensions_defined()) {
+            user_assert(f.dimensions() == this->dimensions()) 
+                << "Output should have dim=" << this->dimensions() << " but saw dim=" << f.dimensions() << "\n";
+        }
+
+        internal_assert(this->exprs_.empty() && this->funcs_.size() == 1);
+        user_assert(!this->funcs_.at(0).defined());
+        this->funcs_[0] = f;
+
+        return *this;
+    }
+};
+
+
+template<typename T>
 class GeneratorOutput_Func : public GeneratorOutputImpl<T> {
 private:
     using Super = GeneratorOutputImpl<T>;
@@ -1449,6 +1786,7 @@ protected:
 template<typename T, typename TBase = typename std::remove_all_extents<T>::type> 
 using GeneratorOutputImplBase =
     typename select_type<
+        cond<has_static_halide_type_method<TBase>::value, GeneratorOutput_Buffer<T>>,
         cond<std::is_same<TBase, Func>::value, GeneratorOutput_Func<T>>,
         cond<std::is_arithmetic<TBase>::value, GeneratorOutput_Arithmetic<T>>
     >::type;
@@ -1498,7 +1836,19 @@ public:
     GeneratorOutput(size_t array_size, const std::string &name, const std::vector<Type> &t, int d)
         : Super(array_size, name, t, d) {
     }
+
+    template <typename T2, int D2>
+    GeneratorOutput<T> &operator=(const Internal::StubOutputBuffer<T2, D2> &stub_output_buffer) {
+        Super::operator=(stub_output_buffer);
+        return *this;
+    }
 };
+
+namespace Internal {
+
+class GeneratorStub;
+
+}  // namespace Internal
 
 /** GeneratorContext is an abstract interface that is used when constructing a Generator Stub;
  * it is used to allow the outer context (typically, either a Generator or "top-level" code)
@@ -1509,6 +1859,9 @@ class GeneratorContext {
 public:
     virtual ~GeneratorContext() {};
     virtual Target get_target() const = 0;
+protected:
+    friend class Internal::GeneratorStub;
+    virtual std::shared_ptr<Internal::ValueTracker> get_value_tracker() const = 0;
 };
 
 /** JITGeneratorContext is a utility implementation of GeneratorContext that
@@ -1527,10 +1880,15 @@ public:
  */
 class JITGeneratorContext : public GeneratorContext {
 public:
-    explicit JITGeneratorContext(const Target &t) : target(t) {}
+    explicit JITGeneratorContext(const Target &t) 
+        : target(t)
+        , value_tracker(std::make_shared<Internal::ValueTracker>()) {}
     Target get_target() const override { return target; }
+protected:
+    std::shared_ptr<Internal::ValueTracker> get_value_tracker() const override { return value_tracker; }
 private:
     const Target target;
+    const std::shared_ptr<Internal::ValueTracker> value_tracker;
 };
 
 class NamesInterface {
@@ -1622,6 +1980,10 @@ protected:
     EXPORT virtual void call_generate() = 0;
     EXPORT virtual void call_schedule() = 0;
 
+    std::shared_ptr<ValueTracker> get_value_tracker() const override { return value_tracker; }
+
+    EXPORT void track_parameter_values(bool include_outputs);
+
     EXPORT void pre_build();
     EXPORT void post_build();
     EXPORT void pre_generate();
@@ -1643,12 +2005,14 @@ protected:
 private:
     friend class GeneratorStub;
     friend class SimpleGeneratorFactory;
+    friend class StubOutputBufferBase;
 
     const size_t size;
     std::vector<Internal::Parameter *> filter_params;
     std::vector<Internal::GeneratorInputBase *> filter_inputs;
     std::vector<Internal::GeneratorOutputBase *> filter_outputs;
     std::vector<Internal::GeneratorParamBase *> generator_params;
+    std::shared_ptr<Internal::ValueTracker> value_tracker;
     bool params_built{false};
     bool generator_params_set{false};
     bool schedule_params_set{false};
@@ -1923,6 +2287,11 @@ protected:
         return generator->get_output(n); 
     }
 
+    template<typename T2>
+    T2 get_output_buffer(const std::string &n) const {
+        return T2(get_output(n), generator);
+    }
+
     std::vector<Func> get_output_vector(const std::string &n) const { 
         return generator->get_output_vector(n); 
     }
@@ -1944,6 +2313,11 @@ protected:
         return { StubInput(f) };
     }
 
+    template<typename T = void, int D = 4>
+    static std::vector<StubInput> to_stub_input_vector(const StubInputBuffer<T, D> &b) {
+        return { StubInput(b.parameter_) };
+    }
+
     template <typename T>
     static std::vector<StubInput> to_stub_input_vector(const std::vector<T> &v) {
         std::vector<StubInput> r;
@@ -1953,6 +2327,11 @@ protected:
 
     EXPORT void verify_same_funcs(const Func &a, const Func &b);
     EXPORT void verify_same_funcs(const std::vector<Func>& a, const std::vector<Func>& b);
+
+    template<typename T2, int D2>
+    void verify_same_funcs(const StubOutputBuffer<T2, D2> &a, const StubOutputBuffer<T2, D2> &b) {
+        verify_same_funcs(a.f, b.f);
+    }
 
 private:
     std::shared_ptr<GeneratorBase> generator;

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -14,6 +14,7 @@ class OutputImageParam;
 
 namespace Internal {
 
+class Constrainable;
 struct ParameterContents;
 
 /** A reference-counted handle to a parameter to a halide
@@ -202,6 +203,7 @@ public:
 
 private:
     friend class ::Halide::OutputImageParam;
+    friend class Constrainable;
 
     /** Construct a Dimension representing dimension d of some
      * Internal::Parameter p. Only friends may construct

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -160,8 +160,14 @@ class Buffer {
      * systems. */
     using storage_T = typename std::conditional<std::is_pointer<T>::value, uint64_t, not_void_T>::type;
 
+public:
+    /** Return true if the Halide type is not void (or const void). */
+    static constexpr bool has_static_halide_type() {
+        return !T_is_void;
+    }
+
     /** Get the Halide type of T. Callers should not use the result if
-     * T is void. */
+     * has_static_halide_type() returns false. */
     static halide_type_t static_halide_type() {
         return halide_type_of<typename std::remove_cv<not_void_T>::type>();
     }
@@ -171,6 +177,7 @@ class Buffer {
         return alloc != nullptr;
     }
 
+private:
     /** Increment the reference count of any owned allocation */
     void incref() const {
         if (!manages_memory()) return;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -288,6 +288,7 @@ if (WITH_TEST_GENERATORS)
   # usage (the types can be inferred), but for AOT compilation, we must make the types
   # concrete via generator args.
   set(STUBTEST_GENERATOR_ARGS
+      untyped_buffer_input.type=uint8 untyped_buffer_input.dim=3
       simple_input.type=float32
       array_input.type=float32 array_input.size=2
       int_arg.size=2
@@ -299,16 +300,18 @@ if (WITH_TEST_GENERATORS)
 
   # Tests that require additional dependencies, args, etc
   set(MDTEST_GEN_ARGS 
-      input.type=uint8 input.dim=3
-      output.type=float32,float32 output.dim=3
-      input_not_nod.type=uint8 input_not_nod.dim=3
-      input_nod.dim=3
-      input_not.type=uint8
-      array_input.size=2
-      array_i8.size=2
-      array_i16.size=2
-      array_i32.size=2
-      array_h.size=2
+      input.type=uint8 input.dim=3 
+      semityped_input_buffer.dim=3
+      untyped_input_buffer.type=uint8 untyped_input_buffer.dim=3 
+      output.type=float32,float32 output.dim=3 
+      input_not_nod.type=uint8 input_not_nod.dim=3 
+      input_nod.dim=3 
+      input_not.type=uint8 
+      array_input.size=2 
+      array_i8.size=2 
+      array_i16.size=2 
+      array_i32.size=2 
+      array_h.size=2 
       array_outputs.size=2
   )
   halide_define_aot_test(metadata_tester

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -286,6 +286,33 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           nullptr,
         },
         {
+          "typed_input_buffer",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_uint, 8),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "semityped_input_buffer",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_uint, 8),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "untyped_input_buffer",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_uint, 8),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
           "b",
           halide_argument_kind_input_scalar,
           0,
@@ -601,6 +628,24 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           nullptr,
         },
         {
+          "typed_output_buffer",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "untyped_output_buffer",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
           "output_scalar",
           halide_argument_kind_output_buffer,
           0,
@@ -690,6 +735,8 @@ int main(int argc, char **argv) {
 
     Buffer<float> output0(kSize, kSize, 3);
     Buffer<float> output1(kSize, kSize, 3);
+    Buffer<float> typed_output_buffer(kSize, kSize, 3);
+    Buffer<float> untyped_output_buffer(kSize, kSize, 3);
     Buffer<float> output_scalar = Buffer<float>::make_scalar();
     Buffer<float> output_array[2] = {{kSize, kSize, 3}, {kSize, kSize, 3}};
     Buffer<float> output_array2[2] = {{kSize, kSize, 3}, {kSize, kSize, 3}};
@@ -697,6 +744,9 @@ int main(int argc, char **argv) {
 
     result = metadata_tester(
         input,             // Input<Func>
+        input,             // Input<Buffer<uint8_t>>
+        input,             // Input<Buffer<>>(uint8)
+        input,             // Input<Buffer<>>
         false,             // Input<bool>
         0,                 // Input<i8>
         0,                 // Input<i16>
@@ -722,6 +772,8 @@ int main(int argc, char **argv) {
         0, 0,              // Input<int32_t[2]>
         nullptr, nullptr,  // Input<void*[]>
         output0, output1,  // Output<Tuple(Func, Func)>
+        typed_output_buffer,    // Output<Buffer<float>>
+        untyped_output_buffer,  // Output<Buffer<>>
         output_scalar,     // Output<float>
         output_array[0], output_array[1],   // Output<Func[]>
         output_array2[0], output_array2[1], // Output<Func[2]>
@@ -732,6 +784,9 @@ int main(int argc, char **argv) {
     result = metadata_tester_ucon(
         user_context, 
         input,             // Input<Func>
+        input,             // Input<Buffer<uint8_t>>
+        input,             // Input<Buffer<>>(uint8)
+        input,             // Input<Buffer<>>
         false,             // Input<bool>
         0,                 // Input<i8>
         0,                 // Input<i16>
@@ -757,6 +812,8 @@ int main(int argc, char **argv) {
         0, 0,              // Input<int32_t[2]>
         nullptr, nullptr,  // Input<void*[]>
         output0, output1,  // Output<Tuple(Func, Func)>
+        typed_output_buffer,    // Output<Buffer<float>>
+        untyped_output_buffer,  // Output<Buffer<>>
         output_scalar,     // Output<float>
         output_array[0], output_array[1],    // Output<Func[]>
         output_array2[0], output_array2[1], // Output<Func[2]>

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -8,6 +8,9 @@ enum class SomeEnum { Foo,
 class MetadataTester : public Halide::Generator<MetadataTester> {
 public:
     Input<Func> input{ "input", Int(16), 2 };  // must be overridden to {UInt(8), 3}
+    Input<Buffer<uint8_t>> typed_input_buffer{ "typed_input_buffer", 3 };
+    Input<Buffer<>> semityped_input_buffer{ "semityped_input_buffer", UInt(8) };  // must be overridden to dim=3
+    Input<Buffer<>> untyped_input_buffer{ "untyped_input_buffer" };  // must be overridden to {UInt(8), 3}
     Input<bool> b{ "b", true };
     Input<int8_t> i8{ "i8", 8, -8, 127 }; 
     Input<int16_t> i16{ "i16", 16, -16, 127 };
@@ -21,23 +24,25 @@ public:
     Input<double> f64{ "f64", 64.25f, -6400.25f, 6400.25f };
     Input<void *> h{ "h", nullptr };
     
-    Input<Func> input_not_nod{ "input_not_nod" };  // must specify type=uint8 dim=3
-    Input<Func> input_nod{ "input_nod", UInt(8) }; // must specify type=uint8 dim=3
-    Input<Func> input_not{ "input_not", 3 };       // must specify type=uint8
+    Input<Func> input_not_nod{ "input_not_nod" };  // must be overridden to type=uint8 dim=3
+    Input<Func> input_nod{ "input_nod", UInt(8) }; // must be overridden to type=uint8 dim=3
+    Input<Func> input_not{ "input_not", 3 };       // must be overridden to type=uint8
 
-    Input<Func[]> array_input{ "array_input", UInt(8), 3 };  // must specify size=2
+    Input<Func[]> array_input{ "array_input", UInt(8), 3 };  // must be overridden to size=2
     Input<Func[2]> array2_input{ "array2_input", UInt(8), 3 };
-    Input<int8_t[]> array_i8{ "array_i8" };  // must specify size=2
+    Input<int8_t[]> array_i8{ "array_i8" };  // must be overridden to size=2
     Input<int8_t[2]> array2_i8{ "array2_i8" };
-    Input<int16_t[]> array_i16{ "array_i16", 16 };  // must specify size=2
+    Input<int16_t[]> array_i16{ "array_i16", 16 };  // must be overridden to size=2
     Input<int16_t[2]> array2_i16{ "array2_i16", 16 };
-    Input<int32_t[]> array_i32{ "array_i32", 32, -32, 127 };  // must specify size=2
+    Input<int32_t[]> array_i32{ "array_i32", 32, -32, 127 };  // must be overridden to size=2
     Input<int32_t[2]> array2_i32{ "array2_i32", 32, -32, 127 };
-    Input<void *[]> array_h{ "array_h", nullptr };  // must specify size=2
+    Input<void *[]> array_h{ "array_h", nullptr };  // must be overridden to size=2
 
     Output<Func> output{ "output", {Int(16), UInt(8)}, 2 };  // must be overridden to {{Float(32), Float(32)}, 3}
+    Output<Buffer<float>> typed_output_buffer{ "typed_output_buffer", 3 };
+    Output<Buffer<>> untyped_output_buffer{ "untyped_output_buffer" };  // untyped outputs can have type and dimensions inferred
     Output<float> output_scalar{ "output_scalar" };
-    Output<Func[]> array_outputs{ "array_outputs", Float(32), 3 };  // must specify size=2
+    Output<Func[]> array_outputs{ "array_outputs", Float(32), 3 };  // must be overridden to size=2
     Output<Func[2]> array_outputs2{ "array_outputs2", Float(32), 3 };
     Output<float[2]> array_outputs3{ "array_outputs3" };
 
@@ -56,6 +61,8 @@ public:
         f2(x, y, c) = cast<float>(f1(x, y, c) + 1);
 
         output(x, y, c) = Tuple(f1(x, y, c), f2(x, y, c));
+        typed_output_buffer(x, y, c) = f1(x, y, c);
+        untyped_output_buffer(x, y, c) = f2(x, y, c);
         output_scalar() = 1234.25f;
         for (size_t i = 0; i < array_outputs.size(); ++i) {
             array_outputs[i](x, y, c) = (i + 1) * 1.5f;

--- a/test/generator/msan_generator.cpp
+++ b/test/generator/msan_generator.cpp
@@ -4,36 +4,37 @@ namespace {
 
 class MSAN : public Halide::Generator<MSAN> {
 public:
-    Func build() {
-        // Currently the test just exercises Target::MSAN
-        Var x, y, c;
+    Output<Buffer<int32_t>> msan_output{"msan_output"};
 
-        Func input("input");
+    void generate() {
+        // Currently the test just exercises Target::MSAN
         input(x, y, c) = cast<int32_t>(x + y + c);
 
         // This just makes an exact copy
-        Func msan_extern_stage;
         msan_extern_stage.define_extern("msan_extern_stage", {input}, Int(32), 3);
 
         RDom r(0, 4);
-        Func msan_output("msan_output");
         msan_output(x, y, c) = sum(msan_extern_stage(r, y, c));
 
         // Add two update phases to be sure annotation happens post-update
         msan_output(r, y, c) += 1;
         msan_output(x, r, c) += 2;
+    }
 
+    void schedule() {
         input.compute_root();
         msan_extern_stage.compute_root();
-        msan_output.parallel(y).vectorize(x, 4);
+        Func(msan_output).parallel(y).vectorize(x, 4);
+        msan_output.dim(0).set_stride(Expr()).set_extent(4)
+                   .dim(1).set_extent(4)
+                   .dim(2).set_extent(3);
 
-        msan_output.output_buffer()
-            .dim(0).set_stride(Expr()).set_extent(4)
-            .dim(1).set_extent(4)
-            .dim(2).set_extent(3);
-
-        return msan_output;
     }
+private:
+    // Currently the test just exercises Target::MSAN
+    Var x, y, c;
+
+    Func input, msan_extern_stage;
 };
 
 Halide::RegisterGenerator<MSAN> register_my_gen{"msan"};

--- a/test/generator/nested_externs_generator.cpp
+++ b/test/generator/nested_externs_generator.cpp
@@ -4,117 +4,100 @@ using namespace Halide;
 
 namespace {
 
-void set_interleaved(OutputImageParam m) {
-    m.dim(0).set_stride(3);
+template<typename T>
+void set_interleaved(T &t) {
+    t.dim(0).set_stride(3)
+     .dim(2).set_min(0).set_extent(3).set_stride(1);
 }
 
 // Add two inputs
 class NestedExternsCombine : public Generator<NestedExternsCombine> {
 public:
-    ImageParam input_a{ Float(32), 3, "a" };
-    ImageParam input_b{ Float(32), 3, "b" };
+    Input<Buffer<float>>  input_a{ "input_a", 3 };
+    Input<Buffer<float>>  input_b{ "input_b", 3 };
+    Output<Buffer<>>      combine{ "combine" };  // unspecified type-and-dim will be inferred
 
-    Func build() {
-        Func result("combine");
+    void generate() {
         Var x, y, c;
+        combine(x, y, c) = input_a(x, y, c) + input_b(x, y, c);
+    }
 
+    void schedule() {
         set_interleaved(input_a);
         set_interleaved(input_b);
-
-        result(x, y, c) = input_a(x, y, c) + input_b(x, y, c);
-
-        set_interleaved(result.output_buffer());
-
-        return result;
+        set_interleaved(combine);
     }
 };
 
 // Call two extern stages then pass the two results to another extern stage.
 class NestedExternsInner : public Generator<NestedExternsInner> {
 public:
-    Param<float> value {"value", 1.0f};
+    Input<float>            value{ "value", 1.0f };
+    Output<Buffer<float>>   inner{ "inner", 3 };
 
-    Func build() {
-        Func extern_stage_1;
+    void generate() {
         extern_stage_1.define_extern("nested_externs_leaf", {value}, Float(32), 3);
-        extern_stage_1.reorder_storage(extern_stage_1.args()[2],
-                                        extern_stage_1.args()[0],
-                                        extern_stage_1.args()[1]);
-        extern_stage_1.compute_root();
-
-        Func extern_stage_2;
         extern_stage_2.define_extern("nested_externs_leaf", {value+1}, Float(32), 3);
-        extern_stage_2.reorder_storage(extern_stage_2.args()[2],
-                                        extern_stage_2.args()[0],
-                                        extern_stage_2.args()[1]);
-        extern_stage_2.compute_root();
-
-        Func extern_stage_combine;
         extern_stage_combine.define_extern("nested_externs_combine", 
             {extern_stage_1, extern_stage_2}, Float(32), 3);
-        extern_stage_combine.compute_root();
-
-        set_interleaved(extern_stage_combine.output_buffer());
-
-        return extern_stage_combine;
+        inner(x, y, c) = extern_stage_combine(x, y, c);
     }
+
+    void schedule() {
+        for (Func f : { extern_stage_1, extern_stage_2, extern_stage_combine }) {
+            auto args = f.args();
+            f.compute_root().reorder_storage(args[2], args[0], args[1]);
+        }
+        set_interleaved(inner);
+    }
+
+private:
+    Var x, y, c;
+    Func extern_stage_1, extern_stage_2, extern_stage_combine;
 };
 
 // Basically a memset.
 class NestedExternsLeaf : public Generator<NestedExternsLeaf> {
 public:
+    Input<float>            value{ "value", 1.0f };
+    Output<Buffer<float>>   leaf{ "leaf", 3 };
 
-    Param<float> value {"value", 1.0f};
-
-    Func build() {
-        Func f("leaf");
+    void generate() {
         Var x, y, c;
-        f(x, y, c) = value;
+        leaf(x, y, c) = value;
+    }
 
-        set_interleaved(f.output_buffer());
-
-        return f;
+    void schedule() {
+        set_interleaved(leaf);
     }
 };
 
 // Call two extern stages then pass the two results to another extern stage.
 class NestedExternsRoot : public Generator<NestedExternsRoot> {
 public:
-    Param<float> value {"value", 1.0f};
+    Input<float>           value{ "value", 1.0f };
+    Output<Buffer<float>>  root{ "root", 3 };
 
-    Func build() {
-        Func extern_stage_1;
+    void generate() {
         extern_stage_1.define_extern("nested_externs_inner", {value}, Float(32), 3);
-        extern_stage_1.reorder_storage(extern_stage_1.args()[2],
-                                        extern_stage_1.args()[0],
-                                        extern_stage_1.args()[1]);
-
-        Func extern_stage_2;
         extern_stage_2.define_extern("nested_externs_inner", {value+1}, Float(32), 3);
-        extern_stage_2.reorder_storage(extern_stage_2.args()[2],
-                                        extern_stage_2.args()[0],
-                                        extern_stage_2.args()[1]);
-
-        Func extern_stage_combine;
         extern_stage_combine.define_extern("nested_externs_combine", 
             {extern_stage_1, extern_stage_2}, Float(32), 3);
-        extern_stage_combine.reorder_storage(extern_stage_combine.args()[2],
-                                             extern_stage_combine.args()[0],
-                                             extern_stage_combine.args()[1]);
-        set_interleaved(extern_stage_combine.output_buffer());
-
-        Func wrapper;
-        Var x, y, c;
-        wrapper(x, y, c) = extern_stage_combine(x, y, c);
-
-        wrapper.reorder(c, x, y);
-        extern_stage_1.compute_at(wrapper, y);
-        extern_stage_2.compute_at(wrapper, y);
-        extern_stage_combine.compute_at(wrapper, y);
-        set_interleaved(wrapper.output_buffer());
-
-        return wrapper;
+        root(x, y, c) = extern_stage_combine(x, y, c);
     }
+
+    void schedule() {
+        for (Func f : { extern_stage_1, extern_stage_2, extern_stage_combine }) {
+            auto args = f.args();
+            f.compute_at(root, y).reorder_storage(args[2], args[0], args[1]);
+        }
+        set_interleaved(root);
+        Func(root).reorder_storage(c, x, y);
+    }
+
+private:
+    Var x, y, c;
+    Func extern_stage_1, extern_stage_2, extern_stage_combine;
 };
 
 HALIDE_REGISTER_GENERATOR(NestedExternsCombine, "nested_externs_combine")

--- a/test/generator/stubtest_aottest.cpp
+++ b/test/generator/stubtest_aottest.cpp
@@ -53,6 +53,7 @@ int main(int argc, char **argv) {
     Buffer<float> simple_output(kSize, kSize, 3);
     Buffer<float> tuple_output0(kSize, kSize, 3), tuple_output1(kSize, kSize, 3);
     Buffer<int16_t> array_output0(kSize, kSize), array_output1(kSize, kSize);
+    Buffer<uint8_t> static_compiled_buffer_output(kSize, kSize, 3);
 
     stubtest(
         buffer_input,
@@ -66,7 +67,8 @@ int main(int argc, char **argv) {
         tuple_output0, tuple_output1, 
         array_output0, array_output1,
         typed_buffer_output,
-        untyped_buffer_output
+        untyped_buffer_output,
+        static_compiled_buffer_output
     );
 
     verify(buffer_input, 1.f, 0, typed_buffer_output);
@@ -77,6 +79,7 @@ int main(int argc, char **argv) {
     verify(array_input0, 1.25f, 33, tuple_output1);
     verify(array_input0, 1.0f, 33, array_output0);
     verify(array_input1, 1.0f, 66, array_output1);
+    verify(buffer_input, 1.0f, 42, static_compiled_buffer_output);
 
     printf("Success!\n");
     return 0;

--- a/test/generator/stubtest_aottest.cpp
+++ b/test/generator/stubtest_aottest.cpp
@@ -44,14 +44,19 @@ void verify(const Buffer<InputType> &input, float float_arg, int int_arg, const 
 }
 
 int main(int argc, char **argv) {
+    Buffer<uint8_t> buffer_input = make_image<uint8_t>(0);
     Buffer<float> simple_input = make_image<float>(0);
     Buffer<float> array_input0 = make_image<float>(0);
     Buffer<float> array_input1 = make_image<float>(1);
+    Buffer<float> typed_buffer_output(kSize, kSize, 3);
+    Buffer<float> untyped_buffer_output(kSize, kSize, 3);
     Buffer<float> simple_output(kSize, kSize, 3);
     Buffer<float> tuple_output0(kSize, kSize, 3), tuple_output1(kSize, kSize, 3);
     Buffer<int16_t> array_output0(kSize, kSize), array_output1(kSize, kSize);
 
     stubtest(
+        buffer_input,
+        buffer_input,
         simple_input, 
         array_input0, array_input1, 
         1.25f, 
@@ -59,9 +64,13 @@ int main(int argc, char **argv) {
         66, 
         simple_output, 
         tuple_output0, tuple_output1, 
-        array_output0, array_output1
+        array_output0, array_output1,
+        typed_buffer_output,
+        untyped_buffer_output
     );
 
+    verify(buffer_input, 1.f, 0, typed_buffer_output);
+    verify(buffer_input, 1.f, 0, untyped_buffer_output);
     verify(simple_input, 1.f, 0, simple_output);
     verify(array_input0, 1.f, 0, simple_output);
     verify(array_input0, 1.25f, 0, tuple_output0);

--- a/test/generator/stubtest_jittest.cpp
+++ b/test/generator/stubtest_jittest.cpp
@@ -53,6 +53,7 @@ void verify(const Buffer<InputType> &input, float float_arg, int int_arg, const 
 int main(int argc, char **argv) {
     constexpr int kArrayCount = 2;
 
+    Buffer<uint8_t> buffer_input = make_image<uint8_t>(0);
     Buffer<float> simple_input = make_image<float>(0);
     Buffer<float> array_input[kArrayCount] = {
         make_image<float>(0),
@@ -68,6 +69,8 @@ int main(int argc, char **argv) {
         JITGeneratorContext(Halide::get_target_from_environment()),
         // Use aggregate-initialization syntax to fill in an Inputs struct.
         {
+            buffer_input,  // typed_buffer_input
+            buffer_input,  // untyped_buffer_input
             Func(simple_input),
             { Func(array_input[0]), Func(array_input[1]) },
             1.25f,
@@ -100,6 +103,14 @@ int main(int argc, char **argv) {
         Buffer<int16_t> g0 = array_output_realized;
         verify(array_input[i], 1.0f, int_args[i], g0);
     }
+
+    Halide::Realization typed_buffer_output_realized = gen.typed_buffer_output.realize(kSize, kSize, 3);
+    Buffer<float> b0 = typed_buffer_output_realized;
+    verify(buffer_input, 1.f, 0, b0);
+
+    Halide::Realization untyped_buffer_output_realized = gen.untyped_buffer_output.realize(kSize, kSize, 3);
+    Buffer<float> b1 = untyped_buffer_output_realized;
+    verify(buffer_input, 1.f, 0, b1);
 
     printf("Success!\n");
     return 0;

--- a/test/generator/stubtest_jittest.cpp
+++ b/test/generator/stubtest_jittest.cpp
@@ -112,6 +112,10 @@ int main(int argc, char **argv) {
     Buffer<float> b1 = untyped_buffer_output_realized;
     verify(buffer_input, 1.f, 0, b1);
 
+    Halide::Realization static_compiled_buffer_output_realized = gen.static_compiled_buffer_output.realize(kSize, kSize, 3);
+    Buffer<uint8_t> b2 = static_compiled_buffer_output_realized;
+    verify(buffer_input, 1.f, 42, b2);
+
     printf("Success!\n");
     return 0;
 }

--- a/test/generator/stubuser_aottest.cpp
+++ b/test/generator/stubuser_aottest.cpp
@@ -25,11 +25,17 @@ const int kIntArg = 33;
 const float kOffset = 2.f;
 
 template<typename InputType, typename OutputType>
-void verify(const Buffer<InputType> &input, const Buffer<OutputType> &output) {
-    for (int x = 0; x < kSize; x++) {
-        for (int y = 0; y < kSize; y++) {
-            for (int c = 0; c < 3; c++) {
-                const OutputType expected = static_cast<OutputType>(input(x, y, c) * kFloatArg + kIntArg) + kOffset;
+void verify(const Buffer<InputType> &input, float float_arg, int int_arg, float offset, const Buffer<OutputType> &output) {
+    if (input.width() != output.width() ||
+        input.height() != output.height()) {
+        fprintf(stderr, "size mismatch\n");
+        exit(-1);
+    }
+    int channels = std::max(1, std::min(input.channels(), output.channels()));
+    for (int x = 0; x < output.width(); x++) {
+        for (int y = 0; y < output.height(); y++) {
+            for (int c = 0; c < channels; c++) {
+                const OutputType expected = static_cast<OutputType>(input(x, y, c) * float_arg + int_arg + offset);
                 const OutputType actual = output(x, y, c);
                 if (expected != actual) {
                     fprintf(stderr, "img[%d, %d, %d] = %f, expected %f\n", x, y, c, (double)actual, (double)expected);
@@ -43,10 +49,14 @@ void verify(const Buffer<InputType> &input, const Buffer<OutputType> &output) {
 int main(int argc, char **argv) {
 
   Buffer<uint8_t> input = make_image<uint8_t>();
-  Buffer<uint8_t> output(kSize, kSize, 3);
+  Buffer<uint8_t> calculated_output(kSize, kSize, 3);
+  Buffer<float> float32_buffer_output(kSize, kSize, 3);
+  Buffer<> int32_buffer_output(halide_type_t(halide_type_int, 32), kSize, kSize, 3);
 
-  stubuser(input, output);
-  verify(input, output);
+  stubuser(input, calculated_output, float32_buffer_output, int32_buffer_output);
+  verify(input, kFloatArg, kIntArg, kOffset, calculated_output);
+  verify(input, 1.f, 0, 0.f, float32_buffer_output); 
+  verify<uint8_t, int32_t>(input, 1.f, 0, 0.f, int32_buffer_output); 
 
   printf("Success!\n");
   return 0;

--- a/test/generator/stubuser_generator.cpp
+++ b/test/generator/stubuser_generator.cpp
@@ -9,8 +9,10 @@ class StubUser : public Halide::Generator<StubUser> {
 public:
     GeneratorParam<int32_t> int_arg{ "int_arg", 33 };
 
-    Input<Func> input{ "input", UInt(8), 3 };
-    Output<Func> output{"output", UInt(8), 3};
+    Input<Buffer<uint8_t>> input{ "input", 3 };
+    Output<Buffer<uint8_t>> calculated_output{"calculated_output" };
+    Output<Buffer<float>> float32_buffer_output{"float32_buffer_output" };
+    Output<Buffer<int32_t>> int32_buffer_output{"int32_buffer_output" };
 
     void generate() {
 
@@ -18,20 +20,32 @@ public:
         // it as an option. (Alternately, we could fill it in by using
         // C++11 aggregate-initialization syntax.)
         StubTest::Inputs inputs;
+        inputs.typed_buffer_input = input;
+        inputs.untyped_buffer_input = input;
         inputs.simple_input = input;
         inputs.array_input = { input };
         inputs.float_arg = 1.234f;
         inputs.int_arg = { int_arg };
 
-        stub = StubTest(this, inputs);
+        StubTest::GeneratorParams gp;
+        gp.untyped_buffer_output_type = int32_buffer_output.type();
+
+        stub = StubTest(this, inputs, gp);
 
         const float kOffset = 2.f;
-        output(x, y, c) = cast<uint8_t>(stub.tuple_output(x, y, c)[1] + kOffset);
+        calculated_output(x, y, c) = cast<uint8_t>(stub.tuple_output(x, y, c)[1] + kOffset);
+
+        // Stub outputs that are Output<Buffer> (rather than Output<Func>)
+        // can really only be assigned to another Output<Buffer>; this is 
+        // nevertheless useful, as we can still set stride (etc) constraints
+        // on the Output.
+        float32_buffer_output = stub.typed_buffer_output;
+        int32_buffer_output = stub.untyped_buffer_output;
     }
 
     void schedule() {
         const bool vectorize = true;
-        stub.schedule({ vectorize, LoopLevel(output, Var("y")) });
+        stub.schedule({ vectorize, LoopLevel(calculated_output, Var("y")) });
     }
 
 private:

--- a/test/generator/stubuser_generator.cpp
+++ b/test/generator/stubuser_generator.cpp
@@ -1,9 +1,23 @@
 #include "Halide.h"
 #include "stubtest.stub.h"
 
+using Halide::Buffer;
 using StubNS1::StubNS2::StubTest;
 
 namespace {
+
+template<typename Type, int size = 32>
+Buffer<Type> make_image() {
+    Buffer<Type> im(size, size, 3);
+    for (int x = 0; x < size; x++) {
+        for (int y = 0; y < size; y++) {
+            for (int c = 0; c < 3; c++) {
+                im(x, y, c) = static_cast<Type>(x + y + c);
+            }
+        }
+    }
+    return im;
+}
 
 class StubUser : public Halide::Generator<StubUser> {
 public:
@@ -16,11 +30,13 @@ public:
 
     void generate() {
 
+        Buffer<uint8_t> constant_image = make_image<uint8_t>();
+
         // We'll explicitly fill in the struct fields by name, just to show
         // it as an option. (Alternately, we could fill it in by using
         // C++11 aggregate-initialization syntax.)
         StubTest::Inputs inputs;
-        inputs.typed_buffer_input = input;
+        inputs.typed_buffer_input = constant_image;
         inputs.untyped_buffer_input = input;
         inputs.simple_input = input;
         inputs.array_input = { input };

--- a/test/generator/tiled_blur_blur_generator.cpp
+++ b/test/generator/tiled_blur_blur_generator.cpp
@@ -2,21 +2,25 @@
 
 namespace {
 
-Halide::Expr is_interleaved(const Halide::OutputImageParam &p, int channels = 3) {
+template<typename T>
+Halide::Expr is_interleaved(const T &p, int channels = 3) {
     return p.dim(0).stride() == channels && p.dim(2).stride() == 1 && p.dim(2).extent() == channels;
 }
 
-Halide::Expr is_planar(const Halide::OutputImageParam &p, int channels = 3) {
+template<typename T>
+Halide::Expr is_planar(const T &p, int channels = 3) {
     return p.dim(0).stride() == 1 && p.dim(2).extent() == channels;
 }
 
 class TiledBlurBlur : public Halide::Generator<TiledBlurBlur> {
 public:
-    ImageParam input{ Float(32), 3, "input" };
-    Param<int> width{ "width" };
-    Param<int> height{ "height" };
+    Input<Buffer<int32_t>> input{ "input", 3 };
+    Input<int32_t> width{ "width" };
+    Input<int32_t> height{ "height" };
 
-    Func build() {
+    Output<Buffer<float>> blur{ "blur", 3 };
+
+    void generate() {
         // We pass in parameters to tell us where the boundary
         // condition kicks in. This is decoupled from the size of the
         // input tile.
@@ -26,32 +30,35 @@ public:
         // kernel we can cope with any size input, so it would always
         // pass us 1x1 tiles.
 
-        Var x("x"), y("y"), c("c");
+        Func input_clamped = Halide::BoundaryConditions::repeat_edge(
+            input, 0, width, 0, height);
 
-        Func input_clamped = Halide::BoundaryConditions::repeat_edge(input, 0, width, 0, height);
-
-        Func blur("blur");
-        blur(x, y, c) =
+        blur(x, y, c) = 
             (input_clamped(x - 1, y, c) + input_clamped(x + 1, y, c) +
              input_clamped(x, y - 1, c) + input_clamped(x, y + 1, c)) /
             4.0f;
+    }
 
+    void schedule() {
         // Unset default constraints so that specialization works.
         input.dim(0).set_stride(Expr());
-        blur.output_buffer().dim(0).set_stride(Expr());
+        blur.dim(0).set_stride(Expr());
 
         // Add specialization for input and output buffers that are both planar.
-        blur.specialize(is_planar(input) && is_planar(blur.output_buffer()));
+        Func(blur).specialize(is_planar(input) && is_planar(blur));
 
         // Add specialization for input and output buffers that are both interleaved.
-        blur.specialize(is_interleaved(input) && is_interleaved(blur.output_buffer()));
+        Func(blur).specialize(is_interleaved(input) && is_interleaved(blur));
 
         // Note that other combinations (e.g. interleaved -> planar) will work
         // but be relatively unoptimized.
 
-        return blur;
     }
+
+private:
+    Var x{"x"}, y{"y"}, c{"c"};
 };
-Halide::RegisterGenerator<TiledBlurBlur> register_my_gen{"tiled_blur_blur"};
+
+HALIDE_REGISTER_GENERATOR(TiledBlurBlur, "tiled_blur_blur")
 
 }  // namespace

--- a/test/generator/tiled_blur_generator.cpp
+++ b/test/generator/tiled_blur_generator.cpp
@@ -2,40 +2,39 @@
 
 namespace {
 
-Halide::Expr is_interleaved(const Halide::OutputImageParam &p, int channels = 3) {
+template<typename T>
+Halide::Expr is_interleaved(const T &p, int channels = 3) {
     return p.dim(0).stride() == channels && p.dim(2).stride() == 1 && p.dim(2).extent() == channels;
 }
 
-Halide::Expr is_planar(const Halide::OutputImageParam &p, int channels = 3) {
+template<typename T>
+Halide::Expr is_planar(const T &p, int channels = 3) {
     return p.dim(0).stride() == 1 && p.dim(2).extent() == channels;
 }
 
 class TiledBlur : public Halide::Generator<TiledBlur> {
 public:
-    ImageParam input{ Int(32), 3, "input" };
+    Input<Buffer<int32_t>> input{ "input", 3 };
+    Output<Buffer<float>> brighter2{ "brighter2", 3 };
 
-    Func build() {
+    void generate() {
         // This is the outermost pipeline, so input width and height
         // are meaningful. If you want to be able to call this outer
         // pipeline in a tiled fashion itself, then you should pass in
         // width and height as params, as with the blur above.
-
-        Var x("x"), y("y"), c("c");
-
-        Func brighter1("brighter1");
         brighter1(x, y, c) = input(x, y, c) * 1.2f;
 
-        Func tiled_blur;
         tiled_blur.define_extern(
             "tiled_blur_blur",
-            { brighter1, input.width(), input.height() },
+            { brighter1, input.dim(0).extent(), input.dim(1).extent() },
             Float(32), 3);
 
-        Func brighter2("brighter2");
         brighter2(x, y, c) = tiled_blur(x, y, c) * 1.2f;
+    }
 
+    void schedule() {
         Var xi, yi;
-        brighter2.reorder(c, x, y).tile(x, y, xi, yi, 32, 32);
+        Func(brighter2).reorder(c, x, y).tile(x, y, xi, yi, 32, 32);
         tiled_blur.compute_at(brighter2, x);
         brighter1.compute_at(brighter2, x);
 
@@ -47,20 +46,23 @@ public:
 
         // Unset default constraints so that specialization works.
         input.dim(0).set_stride(Expr());
-        brighter2.output_buffer().dim(0).set_stride(Expr());
+        brighter2.dim(0).set_stride(Expr());
 
         // Add specialization for input and output buffers that are both planar.
-        brighter2.specialize(is_planar(input) && is_planar(brighter2.output_buffer()));
+        Func(brighter2).specialize(is_planar(input) && is_planar(brighter2));
 
         // Add specialization for input and output buffers that are both interleaved.
-        brighter2.specialize(is_interleaved(input) && is_interleaved(brighter2.output_buffer()));
+        Func(brighter2).specialize(is_interleaved(input) && is_interleaved(brighter2));
 
         // Note that other combinations (e.g. interleaved -> planar) will work
         // but be relatively unoptimized.
-
-        return brighter2;
     }
+private:
+    Var x{"x"}, y{"y"}, c{"c"};
+    Func tiled_blur{"tiled_blur"};
+    Func brighter1{"brighter1"};
 };
-Halide::RegisterGenerator<TiledBlur> register_my_gen{"tiled_blur"};
+
+HALIDE_REGISTER_GENERATOR(TiledBlur, "tiled_blur")
 
 }  // namespace


### PR DESCRIPTION
Currently, you are disallowed from using `ImageParam` with new-style Generators; this is problematic for Generators that need to make scheduling decisions based on attributes of the underlying Buffer. 

We could just allow ImageParams back in, but:
- syntactically this is weird
- we need something for `Output<>` as well, and using `OutputImageParam` for this is even weirder syntactically

This PR proposes to add `Input<Buffer<>>` and `Output<Buffer<>>` to new-style Generators:

- `Input<Buffer<>>` and `Output<Buffer<>>` autoconvert to `Func` (just like `ImageParam`), but also provide methods to set constraints on the required min/extent/stride of the underlying Buffer, and to get the actual min/extent/stride from the underlying Buffer.

- Buffer type can be specified either statically (via template argument) or dynamically (via ctor argument):

  ```
  Input<Buffer<uint8_t>> static_type_input{"static_type_input", 3};
  Input<Buffer<>>        dynamic_type_input{"dynamic_type_input", UInt(8), 3};
  ```

If a type is specified statically, you *cannot* override the type via synthetic GeneratorParams; in the example above, specifying `static_type_input.type=uint16` as an argument to GenGen would fail, but `dynamic_type_input.type=uint16` would be fine.

- Buffer dimensions are always specified via a ctor argument; 

  ```
  Input<Buffer<uint8_t>> three_dimensional_input{"three_dimensional_input", 3};
  Input<Buffer<>> two_dimensional_input{"two_dimensional_input", UInt(8), 2};
  Output<Buffer<>> unspecified_output{"unspecified_output"};  
  ```

 Buffer dimensions can optionally be omitted from `Output<>` (it will be inferred from the actual values filled in), but not from `Input<>`

- Buffer type and/or dimensions can optionally be omitted from `Output<>` (in which case will be inferred from how the `Output<>` is specified in the `generate()` method); however, type and dimension *must* be available at compile time for all `Input<>`:

  ```
  Input<Buffer<>>  illegal_input{"illegal_input", 3};  // this would be legal if "illegal_input.type=something" is specified to GenGen
  Output<Buffer<>> three_dimensional_output{"three_dimensional_output", 3};  // legal: output type will be whatever output's Func is defined as
  ```

- An `Input<Buffer>` is handled specially in the Stub code; it can be set in only two ways:
    - It can be assigned from another `Input<Buffer>`, which must have compatible type and dimensions;
      this is useful in AOT and JIT modes (basically 'piping' input from one Generator to another, with the option to add constraints)
    - It can be assigned from a `Buffer<>`, which must have compatible type and dimensions;
      this is useful only in JIT compilation modes (and shouldn't be usable otherwise).

- An `Output<Buffer>` is handled specially in the Stub code; it can be used in only two ways:
    - It can used to set the value of another `Output<Buffer>`, which must have compatible type and dimensions;
      this is useful in AOT and JIT modes (basically 'piping' input from one Generator to another, with the option to add constraints)
    - It can be used to `realize()` into a `Buffer<>`;
      this is useful only in JIT compilation modes (and shouldn't be usable otherwise).


This PR also converts enough Generators in the tests and apps to demonstrate that this concept should be adequate to meet existing needs. 

