### PR TITLE
Move llvm #includes out of Float16.cpp and into LLVM_Headers.h

### DIFF
--- a/src/Float16.cpp
+++ b/src/Float16.cpp
@@ -1,9 +1,6 @@
 #include "Float16.h"
 #include "Error.h"
-#include "llvm/ADT/APFloat.h"
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringRef.h"
-#include "llvm/Support/ErrorHandling.h"
+#include "LLVM_Headers.h"
 
 using namespace Halide;
 
@@ -32,7 +29,7 @@ getLLVMAPFRoundingMode(Halide::RoundingMode mode) {
 float16_t toFP16(llvm::APFloat v) {
     uint64_t bits = v.bitcastToAPInt().getZExtValue();
     internal_assert(bits <= 0xFFFF) << "Invalid bits for float16_t\n";
-    return float16_t::make_from_bits(bits);
+    return float16_t::make_from_bits((uint16_t) bits);
 }
 
 llvm::APFloat toLLVMAPF(float16_t v) {

--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -25,6 +25,7 @@
 
 #include <llvm/IR/Verifier.h>
 #include <llvm/Linker/Linker.h>
+#include "llvm/Support/ErrorHandling.h"
 #include <llvm/Support/FileSystem.h>
 #if LLVM_VERSION >= 40
 #include <llvm/Bitcode/BitcodeReader.h>
@@ -46,6 +47,9 @@
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/Utils/ModuleUtils.h>
 #include <llvm/Transforms/Utils/SymbolRewriter.h>
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 #include <llvm/ADT/StringMap.h>
 #include <llvm/Object/ArchiveWriter.h>
 #include <llvm/Object/ObjectFile.h>


### PR DESCRIPTION
All LLVM includes should go via that route, to suppress warnings. Also
added a missing cast-to-uint16.