### PR TITLE
Add explicit casts to HalideBuffer.h

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -682,7 +682,7 @@ public:
                       "Too many arguments to constructor. Use Buffer<T, D>, "
                       "where D is at least the desired number of dimensions");
         initialize_shape(0, first, rest...);
-        buf.elem_size = ty.bytes();
+        buf.elem_size = (int32_t) ty.bytes();
         dims = 1 + (int)(sizeof...(rest));
         if (!any_zero(first, rest...)) {
             check_overflow();
@@ -702,7 +702,7 @@ public:
                       "Too many arguments to constructor. Use Buffer<T, D>, "
                       "where D is at least the desired number of dimensions");
         initialize_shape(0, first, rest...);
-        buf.elem_size = ty.bytes();
+        buf.elem_size = (int32_t) ty.bytes();
         dims = 1 + (int)(sizeof...(rest));
         if (!any_zero(first, rest...)) {
             check_overflow();
@@ -717,7 +717,7 @@ public:
         }
         assert(sizes.size() <= D);
         initialize_shape(sizes);
-        buf.elem_size = ty.bytes();
+        buf.elem_size = (int32_t) ty.bytes();
         dims = (int)sizes.size();
         if (!any_zero(sizes)) {
             check_overflow();
@@ -732,7 +732,7 @@ public:
         dims = dimensionality_of_array(vals);
         initialize_shape_from_array_shape(dims - 1, vals);
         ty = scalar_type_of_array(vals);
-        buf.elem_size = ty.bytes();
+        buf.elem_size = (int32_t) ty.bytes();
         buf.host = (uint8_t *)vals;
     }
 
@@ -751,7 +751,7 @@ public:
                       "where D is at least the desired number of dimensions");
         ty = t;
         initialize_shape(0, first, int(rest)...);
-        buf.elem_size = ty.bytes();
+        buf.elem_size = (int32_t) ty.bytes();
         dims = 1 + (int)(sizeof...(rest));
         buf.host = (uint8_t *)data;
     }
@@ -767,7 +767,7 @@ public:
                       "where D is at least the desired number of dimensions");
         ty = static_halide_type();
         initialize_shape(0, first, int(rest)...);
-        buf.elem_size = ty.bytes();
+        buf.elem_size = (int32_t) ty.bytes();
         dims = 1 + (int)(sizeof...(rest));
         buf.host = (uint8_t *)data;
     }
@@ -780,7 +780,7 @@ public:
         assert(sizes.size() <= D);
         initialize_shape(sizes);
         ty = static_halide_type();
-        buf.elem_size = ty.bytes();
+        buf.elem_size = (int32_t) ty.bytes();
         dims = (int)sizes.size();
         buf.host = (uint8_t *)data;
     }
@@ -796,7 +796,7 @@ public:
         assert(sizes.size() <= D);
         initialize_shape(sizes);
         ty = t;
-        buf.elem_size = ty.bytes();
+        buf.elem_size = (int32_t) ty.bytes();
         dims = (int)sizes.size();
         buf.host = (uint8_t *)data;
     }
@@ -815,7 +815,7 @@ public:
             buf.extent[i] = shape[i].extent;
             buf.stride[i] = shape[i].stride;
         }
-        buf.elem_size = ty.bytes();
+        buf.elem_size = (int32_t) ty.bytes();
         buf.host = (uint8_t *)data;
     }
 
@@ -830,7 +830,7 @@ public:
             buf.extent[i] = shape[i].extent;
             buf.stride[i] = shape[i].stride;
         }
-        buf.elem_size = ty.bytes();
+        buf.elem_size = (int32_t) ty.bytes();
         buf.host = (uint8_t *)data;
     }
 


### PR DESCRIPTION
Compilers that have -Wconversion (or equivalent) set will generate
warnings about size_t -> int32_t