### PR TITLE
Type should use consistent types for bits, lanes params

### DIFF
--- a/src/Type.h
+++ b/src/Type.h
@@ -278,7 +278,7 @@ struct Type {
      * code: The fundamental type from an enum.
      * bits: The bit size of one element.
      * lanes: The number of vector elements in the type. */
-    Type(halide_type_code_t code, uint8_t bits, int lanes, const halide_handle_cplusplus_type *handle_type = nullptr)
+    Type(halide_type_code_t code, int bits, int lanes, const halide_handle_cplusplus_type *handle_type = nullptr)
         : type(code, (uint8_t)bits, (uint16_t)lanes), handle_type(handle_type) {
     }
 
@@ -310,13 +310,13 @@ struct Type {
     }
 
     /** Return Type with same type code and lanes, but new_bits for the number of bits. */
-    Type with_bits(uint8_t new_bits) const {
+    Type with_bits(int new_bits) const {
         return Type(code(), new_bits, lanes());
     }
 
     /** Return Type with same type code and number of bits,
      * but new_lanes for the number of vector lanes. */
-    Type with_lanes(uint16_t new_lanes) const {
+    Type with_lanes(int new_lanes) const {
         return Type(code(), bits(), new_lanes);
     }
 


### PR DESCRIPTION
Currently there is a mixture of ‘int’ and ‘uint8/uint16’; compiling
with -Wconversion or equivalent can generate lots of spurious warnings.
Standardize on ‘int’ for the argument type and return value.