### PR TITLE
can_allocation_fit_on_stack() should accept an int64

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -176,7 +176,7 @@ bool function_takes_user_context(const std::string &name) {
     return starts_with(name, "halide_error_");
 }
 
-bool can_allocation_fit_on_stack(int32_t size) {
+bool can_allocation_fit_on_stack(int64_t size) {
     user_assert(size > 0) << "Allocation size should be a positive number\n";
     return (size <= 1024 * 16);
 }

--- a/src/CodeGen_Internal.h
+++ b/src/CodeGen_Internal.h
@@ -49,7 +49,7 @@ bool function_takes_user_context(const std::string &name);
 /** Given a size (in bytes), return True if the allocation size can fit
  * on the stack; otherwise, return False. This routine asserts if size is
  * non-positive. */
-bool can_allocation_fit_on_stack(int32_t size);
+bool can_allocation_fit_on_stack(int64_t size);
 
 /** Given a Halide Euclidean division/mod operation, define it in terms of
  * div_round_to_zero or mod_round_to_zero. */


### PR DESCRIPTION
All call sites were passing it an int64; truncating to int32 can
generate conversion warnings in some compiler configurations.