### PR TITLE
Argument ctor should use int for dimensions

### DIFF
--- a/src/Argument.h
+++ b/src/Argument.h
@@ -60,11 +60,12 @@ struct Argument {
     Expr def, min, max;
 
     Argument() : kind(InputScalar), dimensions(0) {}
-    Argument(const std::string &_name, Kind _kind, const Type &_type, uint8_t _dimensions,
+    Argument(const std::string &_name, Kind _kind, const Type &_type, int _dimensions,
                 Expr _def = Expr(),
                 Expr _min = Expr(),
                 Expr _max = Expr()) :
-        name(_name), kind(_kind), dimensions(_dimensions), type(_type), def(_def), min(_min), max(_max) {
+        name(_name), kind(_kind), dimensions((uint8_t) _dimensions), type(_type), def(_def), min(_min), max(_max) {
+        internal_assert(_dimensions >= 0 && _dimensions <= 255);
         user_assert(!(is_scalar() && dimensions != 0))
             << "Scalar Arguments must specify dimensions of 0";
         user_assert(!(is_buffer() && def.defined()))


### PR DESCRIPTION
Convention elsewhere (e.g. Param) is to use int for dimensions, rather
than uint8; using int avoids conversion-warnings at point of call in
some compile configs