### PR TITLE
Grab-bag of MSVC conversion warning fixes

### DIFF
--- a/test/correctness/constant_expr.cpp
+++ b/test/correctness/constant_expr.cpp
@@ -113,9 +113,9 @@ int main(int argc, char **argv) {
     test_expr<uint64_t>((uint64_t) 0x8000000000000000);
     test_expr<uint64_t>((uint64_t) 0x8000000000000001);
 
-    test_expr<float>(3.141592);
-    test_expr<float>(3.40282e+38);
-    test_expr<float>(3.40282e+38);
+    test_expr<float>(3.141592f);
+    test_expr<float>(3.40282e+38f);
+    test_expr<float>(3.40282e+38f);
 
     test_expr<double>(3.1415926535897932384626433832795);
     test_expr<double>(1.79769e+308);

--- a/test/correctness/lerp.cpp
+++ b/test/correctness/lerp.cpp
@@ -190,27 +190,27 @@ int main(int argc, char **argv) {
                                     "<uint32_t, uint32_t> all zero starts");
   #endif
 
-    check_range<float, float>(0, 100, 0, .01,
-                              0, 100, 0, .01,
-                              0, 100, 0, .01,
+    check_range<float, float>(0, 100, 0, .01f,
+                              0, 100, 0, .01f,
+                              0, 100, 0, .01f,
                               "<float, float> float values 0 to 1 by 1/100ths");
 
-    check_range<float, float>(0, 100, -5, .1,
-                              0, 100, 0, .1,
-                              0, 100, 0, .1,
+    check_range<float, float>(0, 100, -5, .1f,
+                              0, 100, 0, .1f,
+                              0, 100, 0, .1f,
                               "<float, float> float values -5 to 5 by 1/100ths");
 
     // Verify float values with integer weights
-    check_range<float, uint8_t>(0, 100, -5, .1,
-                              0, 100, 0, .1,
+    check_range<float, uint8_t>(0, 100, -5, .1f,
+                              0, 100, 0, .1f,
                               0, 255, 0, 1,
                               "<float, uint8_t> float values -5 to 5 by 1/100ths");
-    check_range<float, uint16_t>(0, 100, -5, .1,
-                                 0, 100, 0, .1,
+    check_range<float, uint16_t>(0, 100, -5, .1f,
+                                 0, 100, 0, .1f,
                                  0, 255, 0, 257,
                                  "<float, uint16_t> float values -5 to 5 by 1/100ths");
-    check_range<float, uint32_t>(0, 100, -5, .1,
-                                 0, 100, 0, .1,
+    check_range<float, uint32_t>(0, 100, -5, .1f,
+                                 0, 100, 0, .1f,
                                  std::numeric_limits<int32_t>::min(), 257, 255 * 65535, 1,
                                  "<float, uint32_t> float values -5 to 5 by 1/100ths");
 

--- a/test/correctness/math.cpp
+++ b/test/correctness/math.cpp
@@ -211,18 +211,18 @@ int main(int argc, char **argv) {
     call_1_float_types(abs, 256, -1000, 1000);
     call_1_float_types(sqrt, 256, 0, 1000000);
 
-    call_1_float_types(sin, 256, 5 * -3.1415, 5 * 3.1415);
-    call_1_float_types(cos, 256, 5 * -3.1415, 5 * 3.1415);
-    call_1_float_types(tan, 256, 5 * -3.1415, 5 * 3.1415);
+    call_1_float_types(sin, 256, 5 * -3.1415f, 5 * 3.1415f);
+    call_1_float_types(cos, 256, 5 * -3.1415f, 5 * 3.1415f);
+    call_1_float_types(tan, 256, 5 * -3.1415f, 5 * 3.1415f);
 
     call_1_float_types(asin, 256, -1.0, 1.0);
     call_1_float_types(acos, 256, -1.0, 1.0);
     call_1_float_types(atan, 256, -256, 100);
-    call_2_float_types(atan2, 256, -20, 20, -2, 2.001);
+    call_2_float_types(atan2, 256, -20, 20, -2, 2.001f);
 
-    call_1_float_types(sinh, 256, 5 * -3.1415, 5 * 3.1415);
+    call_1_float_types(sinh, 256, 5 * -3.1415f, 5 * 3.1415f);
     call_1_float_types(cosh, 256, 0, 1);
-    call_1_float_types(tanh, 256, 5 * -3.1415, 5 * 3.1415);
+    call_1_float_types(tanh, 256, 5 * -3.1415f, 5 * 3.1415f);
 
 #ifndef _MSC_VER
     call_1_float_types(asinh, 256, -10.0, 10.0);
@@ -236,7 +236,7 @@ int main(int argc, char **argv) {
     call_1_float_types(floor, 256, -25, 25);
     call_1_float_types(ceil, 256, -25, 25);
     call_1_float_types(trunc, 256, -25, 25);
-    call_2_float_types(pow, 256, .1, 20, .1, 2);
+    call_2_float_types(pow, 256, .1f, 20, .1f, 2);
 
     const int8_t int8_min = std::numeric_limits<int8_t>::min();
     const int16_t int16_min = std::numeric_limits<int16_t>::min();

--- a/test/generator/embed_image_aottest.cpp
+++ b/test/generator/embed_image_aottest.cpp
@@ -10,9 +10,9 @@ int main(int argc, char **argv) {
     Buffer<float> input(10, 10, 3);
     for (int y = 0; y < 10; y++) {
         for (int x = 0; x < 10; x++) {
-            input(x, y, 0) = sinf(x * y + 1);
-            input(x, y, 1) = cosf(x * y + 1);
-            input(x, y, 2) = sqrtf(x * x + y * y);
+            input(x, y, 0) = sinf((float)(x * y + 1));
+            input(x, y, 1) = cosf((float)(x * y + 1));
+            input(x, y, 2) = sqrtf((float)(x * x + y * y));
         }
     }
     Buffer<float> output(10, 10, 3);

--- a/test/generator/float16_t_aottest.cpp
+++ b/test/generator/float16_t_aottest.cpp
@@ -20,7 +20,7 @@ float float_from_bits(uint32_t bits) {
     return out.asFloat;
 }
 
-float double_from_bits(uint64_t bits) {
+double double_from_bits(uint64_t bits) {
     union {
         double asDouble;
         uint64_t asUInt;
@@ -55,7 +55,7 @@ int main() {
         0.0f,
         -0.0f,
         std::numeric_limits<float>::infinity(),
-	-std::numeric_limits<float>::infinity(),
+        -std::numeric_limits<float>::infinity(),
         std::numeric_limits<float>::quiet_NaN(),
         65504.0f,
         -65504.0f,
@@ -74,7 +74,7 @@ int main() {
         0.0,
         -0.0,
         std::numeric_limits<double>::infinity(),
-	-std::numeric_limits<double>::infinity(),
+        -std::numeric_limits<double>::infinity(),
         std::numeric_limits<double>::quiet_NaN(),
         65504.0,
         -65504.0,

--- a/test/generator/mandelbrot_aottest.cpp
+++ b/test/generator/mandelbrot_aottest.cpp
@@ -10,7 +10,7 @@ using namespace Halide;
 int main(int argc, char **argv) {
     Buffer<int> output(100, 30);
     const char *code = " .:-~*={}&%#@";
-    const int iters = strlen(code) - 1;
+    const int iters = (int) strlen(code) - 1;
 
     // Compute 100 different julia sets
     for (float t = 0; t < 100; t++) {

--- a/test/generator/matlab_aottest.cpp
+++ b/test/generator/matlab_aottest.cpp
@@ -73,7 +73,7 @@ EXPORT size_t mxGetNumberOfDimensions_730(const mxArray *a) {
 }
 
 EXPORT int mxGetNumberOfDimensions_700(const mxArray *a) {
-    return a->get_number_of_dimensions();
+    return (int) a->get_number_of_dimensions();
 }
 
 EXPORT const size_t *mxGetDimensions_730(const mxArray *a) {
@@ -140,7 +140,7 @@ int main(int argc, char **argv) {
 
     for (int i = 0; i < 3; i++) {
         for (int j = 0; j < 5; j++) {
-            input(i, j) = i * 5 + j;
+            input(i, j) = (float)(i * 5 + j);
         }
     }
 

--- a/test/generator/pyramid_aottest.cpp
+++ b/test/generator/pyramid_aottest.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
     // Put some junk in the input. Keep it to small integers so the float averaging stays exact.
     for (int y = 0; y < input.height(); y++) {
         for (int x = 0; x < input.width(); x++) {
-            input(x, y) = ((x * 17 + y)/8) % 32;
+            input(x, y) = (float) (((x * 17 + y)/8) % 32);
         }
     }
 

--- a/test/generator/user_context_insanity_aottest.cpp
+++ b/test/generator/user_context_insanity_aottest.cpp
@@ -22,7 +22,7 @@ int launcher_task(void *user_context, int index, uint8_t *closure) {
     Buffer<float> input(10, 10);
     for (int y = 0; y < 10; y++) {
         for (int x = 0; x < 10; x++) {
-            input(x, y) = x * y;
+            input(x, y) = (float)(x * y);
         }
     }
     Buffer<float> output(10, 10);


### PR DESCRIPTION
Mostly double-to-float and int-to-float “possible loss of precision” —
fixed by changing constants to be float or inserting explicit casts.
None look at risk of meaningful failure, except for the
float_16_t_aottest, which was actually just wrong.