### PR TITLE
Add set_jit_externs() wrapper to Func

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2885,6 +2885,10 @@ void Func::set_custom_print(void (*cust_print)(void *, const char *)) {
     pipeline().set_custom_print(cust_print);
 }
 
+void Func::set_jit_externs(const std::map<std::string, JITExtern> &externs) {
+    pipeline().set_jit_externs(externs);
+}
+
 void Func::add_custom_lowering_pass(IRMutator *pass, void (*deleter)(IRMutator *)) {
     pipeline().add_custom_lowering_pass(pass, deleter);
 }

--- a/src/Func.h
+++ b/src/Func.h
@@ -813,6 +813,12 @@ public:
      * used by JIT. */
     EXPORT const Internal::JITHandlers &jit_handlers();
 
+    /** Install a set of external C functions or Funcs to satisfy
+     * dependencies introduced by HalideExtern and define_extern
+     * mechanisms. These will be used by calls to realize,
+     * infer_bounds, and compile_jit. */
+    EXPORT void set_jit_externs(const std::map<std::string, JITExtern> &externs);
+
     /** Add a custom pass to be used during lowering. It is run after
      * all other lowering passes. Can be used to verify properties of
      * the lowered Stmt, instrument it with extra code, or otherwise

--- a/test/correctness/pipeline_set_jit_externs_func.cpp
+++ b/test/correctness/pipeline_set_jit_externs_func.cpp
@@ -26,10 +26,8 @@ int main(int argc, char **argv) {
 
     Func f;
     f.define_extern("extern_func", args, Float(32), 2);
-
-    Pipeline p(f);
-    p.set_jit_externs({ { "extern_func", monitor } });
-    Buffer<float> imf = p.realize(32, 32);
+    f.set_jit_externs({ { "extern_func", monitor } });
+    Buffer<float> imf = f.realize(32, 32);
 
     // Check the result was what we expected
     for (int i = 0; i < 32; i++) {


### PR DESCRIPTION
It’s just a pass-thru to the underlying Pipeline, like many other
methods in Func.