### PR TITLE
Split JITExtern into two classes

### DIFF
--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -417,7 +417,7 @@ void JITModule::add_symbol_for_export(const std::string &name, const Symbol &ext
 
 void JITModule::add_extern_for_export(const std::string &name, const ExternCFunction &extern_c_function) {
     Symbol symbol;
-    symbol.address = extern_c_function.address;
+    symbol.address = extern_c_function.address();
 
     // Struct types are uniqued on the context, but the lookup API is only available
     // on the Module, not the Context.
@@ -429,18 +429,19 @@ void JITModule::add_extern_for_export(const std::string &name, const ExternCFunc
     llvm::Type *buffer_t_star = llvm::PointerType::get(buffer_t, 0);
 
     llvm::Type *ret_type;
-    if (extern_c_function.signature.is_void_return) {
+    auto signature = extern_c_function.signature();
+    if (signature.is_void_return()) {
         ret_type = llvm::Type::getVoidTy(jit_module->context);
     } else {
-        ret_type = llvm_type_of(&jit_module->context, extern_c_function.signature.ret_type);
+        ret_type = llvm_type_of(&jit_module->context, signature.ret_type());
     }
 
     std::vector<llvm::Type *> llvm_arg_types;
-    for (const ScalarOrBufferT &scalar_or_buffer_t : extern_c_function.signature.arg_types) {
-        if (scalar_or_buffer_t.is_buffer) {
+    for (const ScalarOrBufferT &scalar_or_buffer_t : signature.arg_types()) {
+        if (scalar_or_buffer_t.is_buffer()) {
             llvm_arg_types.push_back(buffer_t_star);
         } else {
-            llvm_arg_types.push_back(llvm_type_of(&jit_module->context, scalar_or_buffer_t.scalar_type));
+            llvm_arg_types.push_back(llvm_type_of(&jit_module->context, scalar_or_buffer_t.scalar_type()));
         }
     }
 

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -687,31 +687,31 @@ JITModule &make_module(llvm::Module *for_module, Target target,
 
         if (runtime_kind == MainShared) {
             runtime_internal_handlers.custom_print =
-                hook_function(shared_runtimes(MainShared).exports(), "halide_set_custom_print", print_handler);
+                hook_function(runtime.exports(), "halide_set_custom_print", print_handler);
 
             runtime_internal_handlers.custom_malloc =
-                hook_function(shared_runtimes(MainShared).exports(), "halide_set_custom_malloc", malloc_handler);
+                hook_function(runtime.exports(), "halide_set_custom_malloc", malloc_handler);
 
             runtime_internal_handlers.custom_free =
-                hook_function(shared_runtimes(MainShared).exports(), "halide_set_custom_free", free_handler);
+                hook_function(runtime.exports(), "halide_set_custom_free", free_handler);
 
             runtime_internal_handlers.custom_do_task =
-                hook_function(shared_runtimes(MainShared).exports(), "halide_set_custom_do_task", do_task_handler);
+                hook_function(runtime.exports(), "halide_set_custom_do_task", do_task_handler);
 
             runtime_internal_handlers.custom_do_par_for =
-                hook_function(shared_runtimes(MainShared).exports(), "halide_set_custom_do_par_for", do_par_for_handler);
+                hook_function(runtime.exports(), "halide_set_custom_do_par_for", do_par_for_handler);
 
             runtime_internal_handlers.custom_error =
-                hook_function(shared_runtimes(MainShared).exports(), "halide_set_error_handler", error_handler_handler);
+                hook_function(runtime.exports(), "halide_set_error_handler", error_handler_handler);
 
             runtime_internal_handlers.custom_trace =
-                hook_function(shared_runtimes(MainShared).exports(), "halide_set_custom_trace", trace_handler);
+                hook_function(runtime.exports(), "halide_set_custom_trace", trace_handler);
 
             active_handlers = runtime_internal_handlers;
             merge_handlers(active_handlers, default_handlers);
 
             if (default_cache_size != 0) {
-                shared_runtimes(MainShared).memoization_cache_set_size(default_cache_size);
+                runtime.memoization_cache_set_size(default_cache_size);
             }
 
             runtime.jit_module->name = "MainShared";

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -437,11 +437,11 @@ void JITModule::add_extern_for_export(const std::string &name, const ExternCFunc
     }
 
     std::vector<llvm::Type *> llvm_arg_types;
-    for (const ScalarOrBufferT &scalar_or_buffer_t : signature.arg_types()) {
-        if (scalar_or_buffer_t.is_buffer()) {
+    for (const Type &t : signature.arg_types()) {
+        if (t == type_of<struct buffer_t *>()) {
             llvm_arg_types.push_back(buffer_t_star);
         } else {
-            llvm_arg_types.push_back(llvm_type_of(&jit_module->context, scalar_or_buffer_t.scalar_type()));
+            llvm_arg_types.push_back(llvm_type_of(&jit_module->context, t));
         }
     }
 

--- a/src/JITModule.h
+++ b/src/JITModule.h
@@ -25,23 +25,6 @@ struct JITExtern;
 struct Target;
 class Module;
 
-// TODO: Consider moving these two types elsewhere and seeing if they
-// can be combined with other types used for argument handling, or used
-// elsewhere.
-struct ScalarOrBufferT {
-    bool is_buffer;
-    Type scalar_type; // Only meaningful if is_buffer is false.
-    ScalarOrBufferT() : is_buffer(false) { }
-};
-
-struct ExternSignature {
-    bool is_void_return;
-    Type ret_type;
-    std::vector<ScalarOrBufferT> arg_types;
-
-    ExternSignature() : is_void_return(false) { }
-};
-
 namespace Internal {
 
 class JITModuleContents;

--- a/src/JITModule.h
+++ b/src/JITModule.h
@@ -20,6 +20,8 @@ class Type;
 
 namespace Halide {
 
+struct ExternCFunction;
+struct JITExtern;
 struct Target;
 class Module;
 
@@ -116,7 +118,7 @@ struct JITModule {
      * info into an LLVM type, which allows type safe linkage of
      * external routines. */
     EXPORT void add_extern_for_export(const std::string &name,
-                                      const ExternSignature &signature, void *address);
+                                      const ExternCFunction &extern_c_function);
 
     /** Look up a symbol by name in this module or its dependencies. */
     EXPORT Symbol find_symbol_by_name(const std::string &) const;


### PR DESCRIPTION
Move the variant that is always an
extern-c-function-address-and-signature into its own class; this will
be useful in subsequent revisions to SharedJITRuntime code, but is
being split into a separate PR for easier review