### PR TITLE
Add JITSharedRuntime::set_jit_externs()

### DIFF
--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -687,31 +687,31 @@ JITModule &make_module(llvm::Module *for_module, Target target,
 
         if (runtime_kind == MainShared) {
             runtime_internal_handlers.custom_print =
-                hook_function(shared_runtimes(MainShared).exports(), "halide_set_custom_print", print_handler);
+                hook_function(runtime.exports(), "halide_set_custom_print", print_handler);
 
             runtime_internal_handlers.custom_malloc =
-                hook_function(shared_runtimes(MainShared).exports(), "halide_set_custom_malloc", malloc_handler);
+                hook_function(runtime.exports(), "halide_set_custom_malloc", malloc_handler);
 
             runtime_internal_handlers.custom_free =
-                hook_function(shared_runtimes(MainShared).exports(), "halide_set_custom_free", free_handler);
+                hook_function(runtime.exports(), "halide_set_custom_free", free_handler);
 
             runtime_internal_handlers.custom_do_task =
-                hook_function(shared_runtimes(MainShared).exports(), "halide_set_custom_do_task", do_task_handler);
+                hook_function(runtime.exports(), "halide_set_custom_do_task", do_task_handler);
 
             runtime_internal_handlers.custom_do_par_for =
-                hook_function(shared_runtimes(MainShared).exports(), "halide_set_custom_do_par_for", do_par_for_handler);
+                hook_function(runtime.exports(), "halide_set_custom_do_par_for", do_par_for_handler);
 
             runtime_internal_handlers.custom_error =
-                hook_function(shared_runtimes(MainShared).exports(), "halide_set_error_handler", error_handler_handler);
+                hook_function(runtime.exports(), "halide_set_error_handler", error_handler_handler);
 
             runtime_internal_handlers.custom_trace =
-                hook_function(shared_runtimes(MainShared).exports(), "halide_set_custom_trace", trace_handler);
+                hook_function(runtime.exports(), "halide_set_custom_trace", trace_handler);
 
             active_handlers = runtime_internal_handlers;
             merge_handlers(active_handlers, default_handlers);
 
             if (default_cache_size != 0) {
-                shared_runtimes(MainShared).memoization_cache_set_size(default_cache_size);
+                runtime.memoization_cache_set_size(default_cache_size);
             }
 
             runtime.jit_module->name = "MainShared";

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -462,6 +462,7 @@ bool JITModule::compiled() const {
 
 namespace {
 
+std::map<std::string, ExternCFunction> jit_externs;
 JITHandlers runtime_internal_handlers;
 JITHandlers default_handlers;
 JITHandlers active_handlers;
@@ -686,6 +687,10 @@ JITModule &make_module(llvm::Module *for_module, Target target,
         runtime.compile_module(std::move(module), "", target, deps, halide_exports);
 
         if (runtime_kind == MainShared) {
+            for (auto it = jit_externs.begin(); it != jit_externs.end(); it++) {
+                runtime.add_extern_for_export(it->first, it->second);
+            }
+
             runtime_internal_handlers.custom_print =
                 hook_function(runtime.exports(), "halide_set_custom_print", print_handler);
 
@@ -819,6 +824,13 @@ JITHandlers JITSharedRuntime::set_default_handlers(const JITHandlers &handlers) 
     default_handlers = handlers;
     active_handlers = runtime_internal_handlers;
     merge_handlers(active_handlers, default_handlers);
+    return result;
+}
+
+std::map<std::string, ExternCFunction> JITSharedRuntime::set_jit_externs(
+        const std::map<std::string, ExternCFunction> &externs) {
+    auto result = jit_externs;
+    jit_externs = externs;
     return result;
 }
 

--- a/src/JITModule.h
+++ b/src/JITModule.h
@@ -168,6 +168,22 @@ public:
     EXPORT static void init_jit_user_context(JITUserContext &jit_user_context, void *user_context, const JITHandlers &handlers);
     EXPORT static JITHandlers set_default_handlers(const JITHandlers &handlers);
 
+    // Set a map of external functions to replace when jitting; unlike the similarly-named
+    // method in Pipeline, this can replace functions in the runtime itself, and
+    // thus should be used only with great caution; generally, use of this outside
+    // of Halide is likely to be fragile and should be avoided.
+    //
+    // Note that this only affects subsequent lazy-initialization of the shared runtime(s);
+    // if shared runtimes have already been built, you must call release_all() after
+    // this to ensure that the runtimes will be rebuilt with the new externs.
+    //
+    // Note that JITSharedRuntime::set_jit_externs can only accept literal C functions
+    // (unlike Pipeline::set_jit_externs, which can also accept Pipelines or Funcs).
+    //
+    // Note also that this *replaces* any previous calls; if you want to merge, you can call
+    // to get the previous set of externs, merge manually, then call again with the merged set.
+    EXPORT static std::map<std::string, ExternCFunction> set_jit_externs(const std::map<std::string, ExternCFunction> &externs);
+
     /** Set the maximum number of bytes used by memoization caching.
      * If you are compiling statically, you should include HalideRuntime.h
      * and call halide_memoization_cache_set_size() instead.

--- a/src/JITModule.h
+++ b/src/JITModule.h
@@ -20,6 +20,8 @@ class Type;
 
 namespace Halide {
 
+struct ExternCFunction;
+struct JITExtern;
 struct Target;
 class Module;
 
@@ -116,7 +118,7 @@ struct JITModule {
      * info into an LLVM type, which allows type safe linkage of
      * external routines. */
     EXPORT void add_extern_for_export(const std::string &name,
-                                      const ExternSignature &signature, void *address);
+                                      const ExternCFunction &extern_c_function);
 
     /** Look up a symbol by name in this module or its dependencies. */
     EXPORT Symbol find_symbol_by_name(const std::string &) const;

--- a/test/correctness/shared_runtime_set_jit_externs.cpp
+++ b/test/correctness/shared_runtime_set_jit_externs.cpp
@@ -1,0 +1,110 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+const int kSize = 10;
+
+namespace {
+
+enum {
+    expect_none,
+    expect_set_custom_print,
+    expect_set_default_handlers_print,
+    expect_set_jit_externs_print,
+} expected_print_func = expect_none;
+
+std::vector<std::string> messages;
+
+void my_print(void *user_context, const char *message) {
+    printf("%d: %s", expected_print_func, message);
+    messages.push_back(message);
+}
+
+}  // namespace
+
+extern "C" DLLEXPORT void set_custom_print(void *user_context, const char *message) {
+    assert(expected_print_func == expect_set_custom_print);
+    my_print(user_context, message);
+}
+
+extern "C" DLLEXPORT void set_default_handlers_print(void *user_context, const char *message) {
+    assert(expected_print_func == expect_set_default_handlers_print);
+    my_print(user_context, message);
+}
+
+extern "C" DLLEXPORT void set_jit_externs_print(void *user_context, const char *message) {
+    assert(expected_print_func == expect_set_jit_externs_print);
+    my_print(user_context, message);
+}
+
+void check_results(const Buffer<int32_t> &result) {
+    for (int32_t i = 0; i < kSize; i++) {
+        if (result(i) != i * i) {
+            fprintf(stderr, "Wrong answer\n");
+            exit(-1);
+        }
+    }
+    assert(messages.size() == kSize);
+}
+
+int main(int argc, char **argv) {
+    Var x, y;
+    {
+        messages.clear();
+        expected_print_func = expect_none;
+
+        Func f;
+        f(x) = print(x * x, "the answer is", 42.0f, "unsigned", cast<uint32_t>(145));
+        Buffer<int32_t> result = f.realize(kSize);
+        assert(messages.empty());
+    }
+    {
+        messages.clear();
+        expected_print_func = expect_set_default_handlers_print;
+
+        Internal::JITHandlers handlers;
+        handlers.custom_print = set_default_handlers_print;
+        Internal::JITSharedRuntime::set_default_handlers(handlers);
+
+        Func f;
+        f(x) = print(x * x, "the answer is", 42.0f, "unsigned", cast<uint32_t>(145));
+        Buffer<int32_t> result = f.realize(kSize);
+        check_results(result);
+    }
+    {
+        messages.clear();
+        expected_print_func = expect_set_jit_externs_print;
+
+        Internal::JITSharedRuntime::set_jit_externs({
+            { "halide_print", set_jit_externs_print },
+        });
+        Internal::JITSharedRuntime::release_all();
+
+        Func f;
+        f(x) = print(x * x, "the answer is", 42.0f, "unsigned", cast<uint32_t>(145));
+        Buffer<int32_t> result = f.realize(kSize);
+        check_results(result);
+    }
+    {
+        Internal::JITSharedRuntime::set_jit_externs({});
+        Internal::JITSharedRuntime::release_all();
+        messages.clear();
+        expected_print_func = expect_set_custom_print;
+
+        Func f;
+        f(x) = print(x * x, "the answer is", 42.0f, "unsigned", cast<uint32_t>(145));
+        f.set_custom_print(set_custom_print);
+        Buffer<int32_t> result = f.realize(kSize);
+        check_results(result);
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/shared_runtime_set_jit_externs.cpp
+++ b/test/correctness/shared_runtime_set_jit_externs.cpp
@@ -55,6 +55,13 @@ void check_results(const Buffer<int32_t> &result) {
 }
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().has_feature(Target::Profile)) {
+        // The profiler adds lots of extra prints, so counting the
+        // number of prints is not useful.
+        printf("Skipping test because profiler is active\n");
+        return 0;
+    }
+
     Var x, y;
     {
         messages.clear();


### PR DESCRIPTION
At present there is no good, reliable way to override arbitrary runtime
functions when using the JIT. JITSharedRuntime ::set_default_handlers()
allows overriding of selected runtime methods, but extending for
multiple entrypoints (e.g. all of a GPU backend, to allow running on a
simulator) is tedious. This PR adds the ability to selectively override
arbitrary functions in JIT compilation mode, including runtime
functions.

(It is likely that this change could be used to reimplement or simply
replace set_default_handlers(); I invite comments on the wisdom of
that.)

(Note that this is built atop
https://github.com/halide/Halide/pull/1723, and cannot land before it
does)