### PR TITLE
Faster build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # 'make' builds libHalide.a, the internal test suite, and runs the internal test suite
 # 'make run_tests' builds and runs all the end-to-end tests in the test subdirectory
 # 'make {error,performance}_foo' builds and runs test/{...}/foo.cpp for any
-#     cpp file in the corresponding subdirectoy of the test folder
+#     cpp file in the corresponding subdirectory of the test folder
 # 'make test_foo' builds and runs test/correctness/foo.cpp for any
 #     cpp file in the correctness/ subdirectoy of the test folder
 # 'make test_apps' checks some of the apps build and run (but does not check their output)

--- a/Makefile
+++ b/Makefile
@@ -623,19 +623,18 @@ extract_llvm_objects: $(OBJECTS) $(INITIAL_MODULES)
 	# object files in which archives it uses to resolve
 	# symbols. We only care about the libLLVM ones.
 	@mkdir -p $(BUILD_DIR)/llvm_objects
-	touch $(BUILD_DIR)/llvm_objects/list
 	$(CXX) -o /dev/null -shared $(OBJECTS) $(INITIAL_MODULES) -Wl,-t $(LLVM_STATIC_LIBS) $(LIBDL) -lz -lpthread | egrep "libLLVM" > $(BUILD_DIR)/llvm_objects/list.new
-	# if the list has changed since the previous build, then
-	# delete the old object files and re-extract the required
-	# object files
+	# if the list has changed since the previous build, or there
+	# is no list from a previous build, then delete any old object
+	# files and re-extract the required object files
 	cd $(BUILD_DIR)/llvm_objects; \
-	if cmp -s list.new list; \
+	if cmp -s list.new list.old; \
 	then \
 	echo "No changes in LLVM deps"; \
 	else \
 	rm -f llvm_*.o*; \
-	mv list.new list; \
-	cat list | sed = | sed "N;s/[()]/ /g;s/\n /\n/;s/\([0-9]*\)\n\([^ ]*\) \([^ ]*\)/ar x \2 \3; mv \3 llvm_\1_\3/" | bash -; \
+	cat list.new | sed = | sed "N;s/[()]/ /g;s/\n /\n/;s/\([0-9]*\)\n\([^ ]*\) \([^ ]*\)/ar x \2 \3; mv \3 llvm_\1_\3/" | bash -; \
+	mv list.new list.old; \
 	fi
 
 $(LIB_DIR)/libHalide.a: $(OBJECTS) $(INITIAL_MODULES) extract_llvm_objects

--- a/Makefile
+++ b/Makefile
@@ -625,15 +625,17 @@ extract_llvm_objects: $(OBJECTS) $(INITIAL_MODULES)
 	@mkdir -p $(BUILD_DIR)/llvm_objects
 	touch $(BUILD_DIR)/llvm_objects/list
 	$(CXX) -o /dev/null -shared $(OBJECTS) $(INITIAL_MODULES) -Wl,-t $(LLVM_STATIC_LIBS) $(LIBDL) -lz -lpthread | egrep "libLLVM" > $(BUILD_DIR)/llvm_objects/list.new
-	# if the list has changed since the previous build, then delete the old object files and regenerate the extractor script
-	if cmp -s $(BUILD_DIR)/llvm_objects/list.new $(BUILD_DIR)/llvm_objects/list; \
+	# if the list has changed since the previous build, then
+	# delete the old object files and re-extract the required
+	# object files
+	cd $(BUILD_DIR)/llvm_objects; \
+	if cmp -s list.new list; \
 	then \
 	echo "No changes in LLVM deps"; \
 	else \
-	rm -f $(BUILD_DIR)/llvm_objects/llvm_*; \
-	mv $(BUILD_DIR)/llvm_objects/list.new $(BUILD_DIR)/llvm_objects/list; \
-	cat $(BUILD_DIR)/llvm_objects/list | sed = | sed "N;s/[()]/ /g;s/\n /\n/;s/\([0-9]*\)\n\([^ ]*\) \([^ ]*\)/ar x \2 \3; mv \3 llvm_\1_\3/" > $(BUILD_DIR)/llvm_objects/extract.sh; \
-	cd $(BUILD_DIR)/llvm_objects; bash ./extract.sh; \
+	rm -f llvm_*.o*; \
+	mv list.new list; \
+	cat list | sed = | sed "N;s/[()]/ /g;s/\n /\n/;s/\([0-9]*\)\n\([^ ]*\) \([^ ]*\)/ar x \2 \3; mv \3 llvm_\1_\3/" | bash -; \
 	fi
 
 $(LIB_DIR)/libHalide.a: $(OBJECTS) $(INITIAL_MODULES) extract_llvm_objects


### PR DESCRIPTION
Two changes to the makefile:

1) When building the static library, only re-extract objects from libLLVM if the list has changed since last build. This reduces linking time from 52 seconds down to 12 seconds on mingw (there are nearly a thousand of them, and extracting them is slow)

2) The shared library doesn't depend on the static library. When building the tests, you shouldn't need to rebuild the static library. Reduces time spent linking the static library from 12 seconds down to zero if you're just running a JIT test.