### PR TITLE
Remove halide_hexagon_host_get_symbol()

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -149,7 +149,6 @@ bool function_takes_user_context(const std::string &name) {
         "halide_hexagon_initialize_kernels",
         "halide_hexagon_run",
         "halide_hexagon_device_release",
-        "halide_hexagon_host_get_symbol",
         "halide_hexagon_power_hvx_on",
         "halide_hexagon_power_hvx_on_mode",
         "halide_hexagon_power_hvx_on_perf",

--- a/src/runtime/HalideRuntimeHexagonHost.h
+++ b/src/runtime/HalideRuntimeHexagonHost.h
@@ -105,17 +105,6 @@ extern int halide_hexagon_run(void *user_context,
                               void *args[],
                               int arg_flags[]);
 extern int halide_hexagon_device_release(void* user_context);
-
-/**
- * This is essentially a wrapper for
- *
- *    halide_get_library_symbol(halide_load_library("libhalide_hexagon_host.so"), name)
- *
- * it exists to allow clients to easily customize the host library interface;
- * most interestingly, it allows the function pointers returned to be statically
- * linked into the same executable (rather than requiring them to be in a dynamic library).
- */
-extern void* halide_hexagon_host_get_symbol(void* user_context, const char *name);
 // @}
 
 #ifdef __cplusplus

--- a/src/runtime/runtime_api.cpp
+++ b/src/runtime/runtime_api.cpp
@@ -89,7 +89,6 @@ extern "C" __attribute__((used)) void *halide_runtime_api_functions[] = {
     (void *)&halide_hexagon_run,
     (void *)&halide_hexagon_wrap_device_handle,
     (void *)&halide_hexagon_device_release,
-    (void *)&halide_hexagon_host_get_symbol,
     (void *)&halide_qurt_hvx_lock,
     (void *)&halide_qurt_hvx_unlock,
     (void *)&halide_qurt_hvx_unlock_as_destructor,


### PR DESCRIPTION
It was intended as a convenience for certain Hexagon testing tasks, but
it turns out to be simpler to override halide_load_library() +
halide_get_library_symbol() for those purposes.