### PR TITLE
Add memset() calls to fix MSAN failures

### DIFF
--- a/src/runtime/posix_error_handler.cpp
+++ b/src/runtime/posix_error_handler.cpp
@@ -12,7 +12,9 @@ WEAK void default_error_handler(void *user_context, const char *msg) {
     if (dst[-1] != '\n') {
         dst[0] = '\n';
         dst[1] = 0;
+        dst += 1;
     }
+    halide_msan_annotate_memory_is_initialized(user_context, buf, dst - buf + 1);
     halide_print(user_context, buf);
     abort();
 }

--- a/src/runtime/printer.h
+++ b/src/runtime/printer.h
@@ -129,12 +129,15 @@ public:
     ~Printer() {
         if (!buf) {
             halide_error(user_context, allocation_error());
-        } else if (type == ErrorPrinter) {
-            halide_error(user_context, buf);
-        } else if (type == BasicPrinter) {
-            halide_print(user_context, buf);
         } else {
-            // It's a stringstream. Do nothing.
+          halide_msan_annotate_memory_is_initialized(user_context, buf, dst - buf + 1);
+          if (type == ErrorPrinter) {
+              halide_error(user_context, buf);
+          } else if (type == BasicPrinter) {
+              halide_print(user_context, buf);
+          } else {
+              // It's a stringstream. Do nothing.
+          }
         }
 
         if (own_mem) {


### PR DESCRIPTION
Stack memory used for logging/errors is unknown to MSAN, which can flag
false-positive failures inside (e.g.) the halide_print() callback.
Since MSAN intercepts memset(), using that to initialize the stack
memory in these case corrects these false positives.