### PR TITLE
avoid halide_malloc when tracing

### DIFF
--- a/src/runtime/printer.h
+++ b/src/runtime/printer.h
@@ -151,18 +151,22 @@ public:
         return "Printer buffer allocation failed.\n";
     }
 
+    void msan_annotate_is_initialized() {
+        halide_msan_annotate_memory_is_initialized(user_context, buf, dst - buf + 1);
+    }
+
     ~Printer() {
         if (!buf) {
             halide_error(user_context, allocation_error());
         } else {
-          halide_msan_annotate_memory_is_initialized(user_context, buf, dst - buf + 1);
-          if (type == ErrorPrinter) {
-              halide_error(user_context, buf);
-          } else if (type == BasicPrinter) {
-              halide_print(user_context, buf);
-          } else {
-              // It's a stringstream. Do nothing.
-          }
+            msan_annotate_is_initialized();
+            if (type == ErrorPrinter) {
+                halide_error(user_context, buf);
+            } else if (type == BasicPrinter) {
+                halide_print(user_context, buf);
+            } else {
+                // It's a stringstream. Do nothing.
+            }
         }
 
         if (own_mem) {

--- a/src/runtime/tracing.cpp
+++ b/src/runtime/tracing.cpp
@@ -20,6 +20,8 @@ WEAK int32_t default_trace(void *user_context, const halide_trace_event *e) {
 
     int32_t my_id = __sync_fetch_and_add(&ids, 1);
 
+    uint8_t buffer[4096];
+
     // If we're dumping to a file, use a binary format
     int fd = halide_get_trace_file(user_context);
     if (fd > 0) {
@@ -37,7 +39,6 @@ WEAK int32_t default_trace(void *user_context, const halide_trace_event *e) {
         size_t value_bytes = clamped_width * bytes;
         size_t int_arg_bytes = clamped_dimensions * sizeof(int32_t);
         size_t total_bytes = header_bytes + value_bytes + int_arg_bytes;
-        uint8_t buffer[4096];
         halide_assert(user_context, total_bytes <= 4096 && "Tracing packet too large");
 
         ((int32_t *)buffer)[0] = my_id;
@@ -77,7 +78,7 @@ WEAK int32_t default_trace(void *user_context, const halide_trace_event *e) {
         }
 
     } else {
-        stringstream ss(user_context);
+        Printer<StringStreamPrinter, sizeof(buffer)> ss(user_context, (char *)buffer);
 
         // Round up bits to 8, 16, 32, or 64
         int print_bits = 8;
@@ -169,7 +170,7 @@ WEAK int32_t default_trace(void *user_context, const halide_trace_event *e) {
 
         {
             ScopedSpinLock lock(&halide_trace_file_lock);
-            halide_print(user_context, ss.str());
+            halide_print(user_context, (const char *)buffer);
         }
     }
 

--- a/src/runtime/tracing.cpp
+++ b/src/runtime/tracing.cpp
@@ -167,6 +167,7 @@ WEAK int32_t default_trace(void *user_context, const halide_trace_event *e) {
             }
         }
         ss << "\n";
+        ss.msan_annotate_is_initialized();
 
         {
             ScopedSpinLock lock(&halide_trace_file_lock);


### PR DESCRIPTION
It's a very minor speed-up to text-based tracing of local laplacian (2%)

This function was already allocating a page on the stack for the binary
case, and then not even using it in the text branch. May as well use it
and skip the halide_malloc call inside the printer.