### PR TITLE
Add assertion check for negative buffer extents

### DIFF
--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -259,6 +259,11 @@ Stmt add_image_checks(Stmt s,
                            << j << "\n";
             }
 
+            Expr negative_extent_condition = actual_extent >= 0;
+            Expr negative_extent_error = Call::make(Int(32), "halide_error_buffer_extents_negative",
+                                                    {error_name, j, actual_extent}, Call::Extern);
+            asserts_required.push_back(AssertStmt::make(negative_extent_condition, negative_extent_error));
+
             Expr min_required = touched[j].min;
             Expr extent_required = touched[j].max + 1 - touched[j].min;
 

--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -259,11 +259,6 @@ Stmt add_image_checks(Stmt s,
                            << j << "\n";
             }
 
-            Expr negative_extent_condition = actual_extent >= 0;
-            Expr negative_extent_error = Call::make(Int(32), "halide_error_buffer_extents_negative",
-                                                    {error_name, j, actual_extent}, Call::Extern);
-            asserts_required.push_back(AssertStmt::make(negative_extent_condition, negative_extent_error));
-
             Expr min_required = touched[j].min;
             Expr extent_required = touched[j].max + 1 - touched[j].min;
 
@@ -342,6 +337,12 @@ Stmt add_image_checks(Stmt s,
                     Stmt check = AssertStmt::make(this_dim_var <= max_size, error);
                     dims_no_overflow_asserts.push_back(check);
                 }
+
+                // It is never legal to have a negative buffer extent.
+                Expr negative_extent_condition = actual_extent >= 0;
+                Expr negative_extent_error = Call::make(Int(32), "halide_error_buffer_extents_negative",
+                                                        {error_name, j, actual_extent}, Call::Extern);
+                asserts_required.push_back(AssertStmt::make(negative_extent_condition, negative_extent_error));
             }
         }
 

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -663,6 +663,9 @@ enum halide_error_code_t {
 
     /** User-specified require() expression was not satisfied. */
     halide_error_code_requirement_failed = -27,
+
+    /** At least one of the buffer's extents are negative. */
+    halide_error_code_buffer_extents_negative = -28,
 };
 
 /** Halide calls the functions below on various error conditions. The
@@ -691,6 +694,7 @@ extern int halide_error_access_out_of_bounds(void *user_context, const char *fun
                                              int min_valid, int max_valid);
 extern int halide_error_buffer_allocation_too_large(void *user_context, const char *buffer_name,
                                                     uint64_t allocation_size, uint64_t max_size);
+extern int halide_error_buffer_extents_negative(void *user_context, const char *buffer_name, int dimension, int extent);
 extern int halide_error_buffer_extents_too_large(void *user_context, const char *buffer_name,
                                                  int64_t actual_size, int64_t max_size);
 extern int halide_error_constraints_make_required_region_smaller(void *user_context, const char *buffer_name,

--- a/src/runtime/errors.cpp
+++ b/src/runtime/errors.cpp
@@ -65,7 +65,7 @@ WEAK int halide_error_buffer_extents_negative(void *user_context, const char *bu
     error(user_context)
         << "The extents for buffer " << buffer_name
         << " dimension " << dimension
-        << " is negative (" << extent << ", which is never legal.";
+        << " is negative (" << extent << ")";
     return halide_error_code_buffer_extents_negative;
 }
 

--- a/src/runtime/errors.cpp
+++ b/src/runtime/errors.cpp
@@ -61,6 +61,14 @@ WEAK int halide_error_buffer_allocation_too_large(void *user_context, const char
     return halide_error_code_buffer_allocation_too_large;
 }
 
+WEAK int halide_error_buffer_extents_negative(void *user_context, const char *buffer_name, int dimension, int extent) {
+    error(user_context)
+        << "The extents for buffer " << buffer_name
+        << " dimension " << dimension
+        << " is negative (" << extent << ", which is never legal.";
+    return halide_error_code_buffer_extents_negative;
+}
+
 WEAK int halide_error_buffer_extents_too_large(void *user_context, const char *buffer_name, int64_t actual_size, int64_t max_size) {
     error(user_context)
         << "Product of extents for buffer " << buffer_name

--- a/src/runtime/runtime_api.cpp
+++ b/src/runtime/runtime_api.cpp
@@ -51,6 +51,7 @@ extern "C" __attribute__((used)) void *halide_runtime_api_functions[] = {
     (void *)&halide_error_bounds_inference_call_failed,
     (void *)&halide_error_buffer_allocation_too_large,
     (void *)&halide_error_buffer_argument_is_null,
+    (void *)&halide_error_buffer_extents_negative,
     (void *)&halide_error_buffer_extents_too_large,
     (void *)&halide_error_constraint_violated,
     (void *)&halide_error_constraints_make_required_region_smaller,

--- a/test/generator/error_codes_aottest.cpp
+++ b/test/generator/error_codes_aottest.cpp
@@ -55,12 +55,21 @@ int main(int argc, char **argv) {
     check(result, correct);
     in.extent[0] = 64;
 
-    // Input buffer extent negative
-    in.extent[0] = -42;
-    result = error_codes(&in, 64, &out);
-    correct = halide_error_code_buffer_extents_negative;
-    check(result, correct);
-    in.extent[0] = 64;
+    // buffer extent negative, but in a way that doesn't trigger oob checks
+    {
+        buffer_t i = in, o = out;
+        i.extent[0] = 64;
+        i.extent[1] = -64;
+        i.stride[0] = 1;
+        i.stride[1] = 64;
+        o.extent[0] = 64;
+        o.extent[1] = -64;
+        o.stride[0] = 1;
+        o.stride[1] = 64;
+        result = error_codes(&i, 0, &o);
+        correct = halide_error_code_buffer_extents_negative;
+        check(result, correct);
+    }
 
     // Input buffer larger than 2GB
     in.extent[0] = 10000000;

--- a/test/generator/error_codes_aottest.cpp
+++ b/test/generator/error_codes_aottest.cpp
@@ -55,6 +55,13 @@ int main(int argc, char **argv) {
     check(result, correct);
     in.extent[0] = 64;
 
+    // Input buffer extent negative
+    in.extent[0] = -42;
+    result = error_codes(&in, 64, &out);
+    correct = halide_error_code_buffer_extents_negative;
+    check(result, correct);
+    in.extent[0] = 64;
+
     // Input buffer larger than 2GB
     in.extent[0] = 10000000;
     in.extent[1] = 10000000;


### PR DESCRIPTION
This is never legal, but can cause surprisingly hard-to-track-down
errors.