### PR TITLE
Cleanup tests that write tmp files (Part 1)

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -236,12 +236,22 @@ bool file_exists(const std::string &name) {
     #endif
 }
 
+bool file_exists_or_die(const std::string &name) {
+    internal_assert(file_exists(name)) << "file_exists failed for " << name;
+    return true;
+}
+
 void file_unlink(const std::string &name) {
     #ifdef _MSC_VER
     _unlink(name.c_str());
     #else
     ::unlink(name.c_str());
     #endif
+}
+
+void file_unlink_or_die(const std::string &name) {
+    file_unlink(name);
+    internal_assert(!file_exists(name)) << "file_unlink failed for " << name;
 }
 
 void dir_rmdir(const std::string &name) {

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -236,9 +236,12 @@ bool file_exists(const std::string &name) {
     #endif
 }
 
-bool file_exists_or_die(const std::string &name) {
-    internal_assert(file_exists(name)) << "file_exists failed for " << name;
-    return true;
+void assert_file_exists(const std::string &name) {
+    internal_assert(file_exists(name)) << "File not found: " << name;
+}
+
+void assert_no_file_exists(const std::string &name) {
+    internal_assert(file_exists(name)) << "File (wrongly) found: " << name;
 }
 
 void file_unlink(const std::string &name) {
@@ -249,9 +252,11 @@ void file_unlink(const std::string &name) {
     #endif
 }
 
-void file_unlink_or_die(const std::string &name) {
-    file_unlink(name);
-    internal_assert(!file_exists(name)) << "file_unlink failed for " << name;
+void ensure_no_file_exists(const std::string &name) {
+    if (file_exists(name)) {
+        file_unlink(name);
+    }
+    assert_no_file_exists(name);
 }
 
 void dir_rmdir(const std::string &name) {

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -241,7 +241,7 @@ void assert_file_exists(const std::string &name) {
 }
 
 void assert_no_file_exists(const std::string &name) {
-    internal_assert(file_exists(name)) << "File (wrongly) found: " << name;
+    internal_assert(!file_exists(name)) << "File (wrongly) found: " << name;
 }
 
 void file_unlink(const std::string &name) {

--- a/src/Util.h
+++ b/src/Util.h
@@ -196,11 +196,23 @@ EXPORT std::string file_make_temp(const std::string &prefix, const std::string &
  */
 EXPORT std::string dir_make_temp();
 
-/** Wrapper for access(). Asserts upon error. */
+/** Wrapper for access(). Quietly ignores errors. */
 EXPORT bool file_exists(const std::string &name);
+
+/** Like file_exists(), but assert-fails if the file doesn't exist
+ * (and thus always returns true); useful primarily for testing purposes. */
+EXPORT bool file_exists_or_die(const std::string &name);
 
 /** Wrapper for unlink(). Asserts upon error. */
 EXPORT void file_unlink(const std::string &name);
+
+/** Wrapper for unlink(). Quietly ignores errors. */
+EXPORT void file_unlink(const std::string &name);
+
+/** Like file_unlink(), but assert-fails if file cannot be removed. 
+ * (Note that it is fine to call this on a non-existent path; assert-fail
+ * only occurs if the path is still valid after removal attempts.) */
+EXPORT void file_unlink_or_die(const std::string &name);
 
 /** Wrapper for rmdir(). Asserts upon error. */
 EXPORT void dir_rmdir(const std::string &name);

--- a/src/Util.h
+++ b/src/Util.h
@@ -199,9 +199,11 @@ EXPORT std::string dir_make_temp();
 /** Wrapper for access(). Quietly ignores errors. */
 EXPORT bool file_exists(const std::string &name);
 
-/** Like file_exists(), but assert-fails if the file doesn't exist
- * (and thus always returns true); useful primarily for testing purposes. */
-EXPORT bool file_exists_or_die(const std::string &name);
+/** assert-fail if the file doesn't exist. useful primarily for testing purposes. */
+EXPORT void assert_file_exists(const std::string &name);
+
+/** assert-fail if the file DOES exist. useful primarily for testing purposes. */
+EXPORT void assert_no_file_exists(const std::string &name);
 
 /** Wrapper for unlink(). Asserts upon error. */
 EXPORT void file_unlink(const std::string &name);
@@ -209,10 +211,9 @@ EXPORT void file_unlink(const std::string &name);
 /** Wrapper for unlink(). Quietly ignores errors. */
 EXPORT void file_unlink(const std::string &name);
 
-/** Like file_unlink(), but assert-fails if file cannot be removed. 
- * (Note that it is fine to call this on a non-existent path; assert-fail
- * only occurs if the path is still valid after removal attempts.) */
-EXPORT void file_unlink_or_die(const std::string &name);
+/** Ensure that no file with this path exists. If such a file
+ * exists and cannot be removed, assert-fail. */
+EXPORT void ensure_no_file_exists(const std::string &name);
 
 /** Wrapper for rmdir(). Asserts upon error. */
 EXPORT void dir_rmdir(const std::string &name);

--- a/test/correctness/compile_to.cpp
+++ b/test/correctness/compile_to.cpp
@@ -6,26 +6,26 @@ using namespace Halide;
 void testCompileToOutput(Func j) {
     const char *fn_object = "compile_to_native.o";
 
-    Internal::file_unlink_or_die(fn_object);
+    Internal::ensure_no_file_exists(fn_object);
 
     std::vector<Argument> empty_args;
     j.compile_to(Outputs().object(fn_object), empty_args, "");
 
-    Internal::file_exists_or_die(fn_object);
+    Internal::assert_file_exists(fn_object);
 }
 
 void testCompileToOutputAndAssembly(Func j) {
     const char *fn_object = "compile_to_native1.o";
     const char *fn_assembly = "compile_to_assembly1.s";
 
-    Internal::file_unlink_or_die(fn_object);
-    Internal::file_unlink_or_die(fn_assembly);
+    Internal::ensure_no_file_exists(fn_object);
+    Internal::ensure_no_file_exists(fn_assembly);
 
     std::vector<Argument> empty_args;
     j.compile_to(Outputs().object(fn_object).assembly(fn_assembly), empty_args, "");
 
-    Internal::file_exists_or_die(fn_object);
-    Internal::file_exists_or_die(fn_assembly);
+    Internal::assert_file_exists(fn_object);
+    Internal::assert_file_exists(fn_assembly);
 }
 
 int main(int argc, char **argv) {

--- a/test/correctness/compile_to.cpp
+++ b/test/correctness/compile_to.cpp
@@ -1,45 +1,31 @@
 #include "Halide.h"
 #include <stdio.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 
 using namespace Halide;
 
 void testCompileToOutput(Func j) {
     const char *fn_object = "compile_to_native.o";
 
-    #ifndef _MSC_VER
-    if (access(fn_object, F_OK) == 0) { unlink(fn_object); }
-    assert(access(fn_object, F_OK) != 0 && "Output file already exists.");
-    #endif
+    Internal::file_unlink_or_die(fn_object);
 
     std::vector<Argument> empty_args;
     j.compile_to(Outputs().object(fn_object), empty_args, "");
 
-    #ifndef _MSC_VER
-    assert(access(fn_object, F_OK) == 0 && "Output file not created.");
-    #endif
+    Internal::file_exists_or_die(fn_object);
 }
 
 void testCompileToOutputAndAssembly(Func j) {
     const char *fn_object = "compile_to_native1.o";
     const char *fn_assembly = "compile_to_assembly1.s";
 
-    #ifndef _MSC_VER
-    if (access(fn_object, F_OK) == 0) { unlink(fn_object); }
-    if (access(fn_assembly, F_OK) == 0) { unlink(fn_assembly); }
-    assert(access(fn_object, F_OK) != 0 && "Output file already exists.");
-    assert(access(fn_assembly, F_OK) != 0 && "Assembly file already exists.");
-    #endif
+    Internal::file_unlink_or_die(fn_object);
+    Internal::file_unlink_or_die(fn_assembly);
 
     std::vector<Argument> empty_args;
     j.compile_to(Outputs().object(fn_object).assembly(fn_assembly), empty_args, "");
 
-    #ifndef _MSC_VER
-    assert(access(fn_object, F_OK) == 0 && "Output file not created.");
-    assert(access(fn_assembly, F_OK) == 0 && "Assembly file not created.");
-    #endif
+    Internal::file_exists_or_die(fn_object);
+    Internal::file_exists_or_die(fn_assembly);
 }
 
 int main(int argc, char **argv) {

--- a/test/correctness/compile_to_bitcode.cpp
+++ b/test/correctness/compile_to_bitcode.cpp
@@ -17,12 +17,12 @@ int main(int argc, char **argv) {
 
     const char *result_file = "compile_to_bitcode.bc";
 
-    Internal::file_unlink_or_die(result_file);
+    Internal::ensure_no_file_exists(result_file);
 
     std::vector<Argument> empty_args;
     j.compile_to_bitcode(result_file, empty_args);
 
-    Internal::file_exists_or_die(result_file);
+    Internal::assert_file_exists(result_file);
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/compile_to_bitcode.cpp
+++ b/test/correctness/compile_to_bitcode.cpp
@@ -1,8 +1,5 @@
 #include "Halide.h"
 #include <stdio.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 
 using namespace Halide;
 
@@ -19,12 +16,13 @@ int main(int argc, char **argv) {
     h.compute_root();
 
     const char *result_file = "compile_to_bitcode.bc";
+
+    Internal::file_unlink_or_die(result_file);
+
     std::vector<Argument> empty_args;
     j.compile_to_bitcode(result_file, empty_args);
 
-    #ifndef _MSC_VER
-    assert(access("compile_to_bitcode.bc", F_OK) == 0 && "Output file not created.");
-    #endif
+    Internal::file_exists_or_die(result_file);
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/compile_to_lowered_stmt.cpp
+++ b/test/correctness/compile_to_lowered_stmt.cpp
@@ -19,11 +19,11 @@ int main(int argc, char **argv) {
     {
         const char *result_file = "compile_to_lowered_stmt.stmt";
 
-        Internal::file_unlink_or_die(result_file);
+        Internal::ensure_no_file_exists(result_file);
 
         j.compile_to_lowered_stmt(result_file, j.infer_arguments());
 
-        Internal::file_exists_or_die(result_file);
+        Internal::assert_file_exists(result_file);
     }
 
     printf("Success!\n");

--- a/test/correctness/compile_to_lowered_stmt.cpp
+++ b/test/correctness/compile_to_lowered_stmt.cpp
@@ -1,8 +1,5 @@
 #include "Halide.h"
 #include <stdio.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 
 using namespace Halide;
 
@@ -21,11 +18,12 @@ int main(int argc, char **argv) {
 
     {
         const char *result_file = "compile_to_lowered_stmt.stmt";
+
+        Internal::file_unlink_or_die(result_file);
+
         j.compile_to_lowered_stmt(result_file, j.infer_arguments());
 
-        #ifndef _MSC_VER
-        assert(access(result_file, F_OK) == 0 && "Output file not created.");
-        #endif
+        Internal::file_exists_or_die(result_file);
     }
 
     printf("Success!\n");

--- a/test/correctness/compile_to_multitarget.cpp
+++ b/test/correctness/compile_to_multitarget.cpp
@@ -15,7 +15,6 @@ void testCompileToOutput(Func j) {
 #endif
     std::string expected_h = fn_object + ".h";
 
-    Internal::file_unlink_or_die(fn_object);
     Internal::file_unlink_or_die(expected_lib);
     Internal::file_unlink_or_die(expected_h);
 
@@ -25,7 +24,6 @@ void testCompileToOutput(Func j) {
     };
     j.compile_to_multitarget_static_library(fn_object, j.infer_arguments(), targets);
 
-    Internal::file_exists_or_die(fn_object);
     Internal::file_exists_or_die(expected_lib);
     Internal::file_exists_or_die(expected_h);
 }

--- a/test/correctness/compile_to_multitarget.cpp
+++ b/test/correctness/compile_to_multitarget.cpp
@@ -1,8 +1,5 @@
 #include "Halide.h"
 #include <stdio.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 
 using namespace Halide;
 
@@ -15,8 +12,8 @@ void testCompileToOutput(Func j) {
 #endif
     std::string expected_h = fn_object + ".h";
 
-    Internal::file_unlink_or_die(expected_lib);
-    Internal::file_unlink_or_die(expected_h);
+    Internal::ensure_no_file_exists(expected_lib);
+    Internal::ensure_no_file_exists(expected_h);
 
     std::vector<Target> targets = {
         Target("host-profile-debug"),
@@ -24,8 +21,8 @@ void testCompileToOutput(Func j) {
     };
     j.compile_to_multitarget_static_library(fn_object, j.infer_arguments(), targets);
 
-    Internal::file_exists_or_die(expected_lib);
-    Internal::file_exists_or_die(expected_h);
+    Internal::assert_file_exists(expected_lib);
+    Internal::assert_file_exists(expected_h);
 }
 
 int main(int argc, char **argv) {

--- a/test/correctness/compile_to_multitarget.cpp
+++ b/test/correctness/compile_to_multitarget.cpp
@@ -8,15 +8,6 @@ using namespace Halide;
 
 void testCompileToOutput(Func j) {
     std::string fn_object = "compile_to_multitarget";
-
-    if (Internal::file_exists(fn_object)) { Internal::file_unlink(fn_object); }
-    assert(!Internal::file_exists(fn_object) && "Output file already exists.");
-
-    std::vector<Target> targets = {
-        Target("host-profile-debug"),
-        Target("host-profile"),
-    };
-    j.compile_to_multitarget_static_library(fn_object, j.infer_arguments(), targets);
 #ifdef _MSC_VER
     std::string expected_lib = fn_object + ".lib";
 #else
@@ -24,8 +15,19 @@ void testCompileToOutput(Func j) {
 #endif
     std::string expected_h = fn_object + ".h";
 
-    assert(Internal::file_exists(expected_lib) && "Output lib not created.");
-    assert(Internal::file_exists(expected_h) && "Output h not created.");
+    Internal::file_unlink_or_die(fn_object);
+    Internal::file_unlink_or_die(expected_lib);
+    Internal::file_unlink_or_die(expected_h);
+
+    std::vector<Target> targets = {
+        Target("host-profile-debug"),
+        Target("host-profile"),
+    };
+    j.compile_to_multitarget_static_library(fn_object, j.infer_arguments(), targets);
+
+    Internal::file_exists_or_die(fn_object);
+    Internal::file_exists_or_die(expected_lib);
+    Internal::file_exists_or_die(expected_h);
 }
 
 int main(int argc, char **argv) {

--- a/test/correctness/constraints.cpp
+++ b/test/correctness/constraints.cpp
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
     h.realize(image1);
 
     const char *assembly_file = "h.s";
-    Internal::file_unlink_or_die(assembly_file);
+    Internal::ensure_no_file_exists(assembly_file);
 
     // Also check it compiles ok without an inferred argument list
     h.compile_to_assembly(assembly_file, {image1}, "h");
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
         return -1;
     }
 
-    Internal::file_exists_or_die(assembly_file);
+    Internal::assert_file_exists(assembly_file);
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/constraints.cpp
+++ b/test/correctness/constraints.cpp
@@ -63,12 +63,18 @@ int main(int argc, char **argv) {
             .set_bounds(0, image1.dim(1).extent());
     error_occurred = false;
     h.realize(image1);
+
+    const char *assembly_file = "h.s";
+    Internal::file_unlink_or_die(assembly_file);
+
     // Also check it compiles ok without an inferred argument list
-    h.compile_to_assembly("h.s", {image1}, "h");
+    h.compile_to_assembly(assembly_file, {image1}, "h");
     if (error_occurred) {
         printf("Error incorrectly raised when constraining output buffer\n");
         return -1;
     }
+
+    Internal::file_exists_or_die(assembly_file);
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/cross_compilation.cpp
+++ b/test/correctness/cross_compilation.cpp
@@ -30,8 +30,6 @@ int main(int argc, char **argv) {
     for (const std::string &t : targets) {
         Target target(t);
         if (!target.supported()) continue;
-        f.compile_to_file("test_object_" + t, std::vector<Argument>(), "", target);
-        f.compile_to_static_library("test_lib_" + t, std::vector<Argument>(), "", target);
 
         std::string object_name = "test_object_" + t;
         std::string lib_name = "test_lib_" + t;
@@ -42,7 +40,15 @@ int main(int argc, char **argv) {
             object_name += ".o";
             lib_name += ".a";
         }
-        assert(Internal::file_exists(object_name) && "Output file not created.");
+
+        Internal::file_unlink_or_die(object_name);
+        Internal::file_unlink_or_die(lib_name);
+
+        f.compile_to_file("test_object_" + t, std::vector<Argument>(), "", target);
+        f.compile_to_static_library("test_lib_" + t, std::vector<Argument>(), "", target);
+
+        Internal::file_exists_or_die(object_name);
+        Internal::file_exists_or_die(lib_name);
     }
 
     printf("Success!\n");

--- a/test/correctness/cross_compilation.cpp
+++ b/test/correctness/cross_compilation.cpp
@@ -41,14 +41,14 @@ int main(int argc, char **argv) {
             lib_name += ".a";
         }
 
-        Internal::file_unlink_or_die(object_name);
-        Internal::file_unlink_or_die(lib_name);
+        Internal::ensure_no_file_exists(object_name);
+        Internal::ensure_no_file_exists(lib_name);
 
         f.compile_to_file("test_object_" + t, std::vector<Argument>(), "", target);
         f.compile_to_static_library("test_lib_" + t, std::vector<Argument>(), "", target);
 
-        Internal::file_exists_or_die(object_name);
-        Internal::file_exists_or_die(lib_name);
+        Internal::assert_file_exists(object_name);
+        Internal::assert_file_exists(lib_name);
     }
 
     printf("Success!\n");

--- a/test/correctness/stmt_to_html.cpp
+++ b/test/correctness/stmt_to_html.cpp
@@ -1,8 +1,5 @@
 #include "Halide.h"
 #include <stdio.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 
 using namespace Halide;
 
@@ -27,30 +24,24 @@ int main() {
 
 
     const char *result_file_1 = "stmt_to_html_dump_1.html";
+    Internal::file_unlink_or_die(result_file_1);
     gradient_fast.compile_to_lowered_stmt(result_file_1, {}, Halide::HTML);
-
-    #ifndef _MSC_VER
-    assert(access(result_file_1, F_OK) == 0 && "Output file not created.");
-    #endif
+    Internal::file_exists_or_die(result_file_1);
 
     // Also check using an image.
     const char *result_file_2 = "stmt_to_html_dump_2.html";
+    Internal::file_unlink_or_die(result_file_2);
     Buffer<int> im(800, 600);
     gradient_fast.compile_to_lowered_stmt(result_file_2, {im}, Halide::HTML);
-
-    #ifndef _MSC_VER
-    assert(access(result_file_2, F_OK) == 0 && "Output file not created.");
-    #endif
+    Internal::file_exists_or_die(result_file_2);
 
     // Check a multi-output pipeline.
     const char *result_file_3 = "stmt_to_html_dump_3.html";
+    Internal::file_unlink_or_die(result_file_3);
     Func tuple_func;
     tuple_func(x, y) = Tuple(x, y);
     tuple_func.compile_to_lowered_stmt(result_file_3, {}, Halide::HTML);
-
-    #ifndef _MSC_VER
-    assert(access(result_file_2, F_OK) == 0 && "Output file not created.");
-    #endif
+    Internal::file_exists_or_die(result_file_3);
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/stmt_to_html.cpp
+++ b/test/correctness/stmt_to_html.cpp
@@ -24,24 +24,24 @@ int main() {
 
 
     const char *result_file_1 = "stmt_to_html_dump_1.html";
-    Internal::file_unlink_or_die(result_file_1);
+    Internal::ensure_no_file_exists(result_file_1);
     gradient_fast.compile_to_lowered_stmt(result_file_1, {}, Halide::HTML);
-    Internal::file_exists_or_die(result_file_1);
+    Internal::assert_file_exists(result_file_1);
 
     // Also check using an image.
     const char *result_file_2 = "stmt_to_html_dump_2.html";
-    Internal::file_unlink_or_die(result_file_2);
+    Internal::ensure_no_file_exists(result_file_2);
     Buffer<int> im(800, 600);
     gradient_fast.compile_to_lowered_stmt(result_file_2, {im}, Halide::HTML);
-    Internal::file_exists_or_die(result_file_2);
+    Internal::assert_file_exists(result_file_2);
 
     // Check a multi-output pipeline.
     const char *result_file_3 = "stmt_to_html_dump_3.html";
-    Internal::file_unlink_or_die(result_file_3);
+    Internal::ensure_no_file_exists(result_file_3);
     Func tuple_func;
     tuple_func(x, y) = Tuple(x, y);
     tuple_func.compile_to_lowered_stmt(result_file_3, {}, Halide::HTML);
-    Internal::file_exists_or_die(result_file_3);
+    Internal::assert_file_exists(result_file_3);
 
     printf("Success!\n");
     return 0;


### PR DESCRIPTION
— Add “or_die” variations for file_exists and file_unlink
— convert several existing tests to use these instead of #ifdef for
WIN32
— ensure that all of these reliably delete the files before trying to
generate them
— stmt_to_html was just wrong for the final case