### PR TITLE
Fix Closures with regards to predicated_store.

### DIFF
--- a/src/Closure.h
+++ b/src/Closure.h
@@ -32,6 +32,7 @@ protected:
     void visit(const Store *op);
     void visit(const Allocate *op);
     void visit(const Variable *op);
+    void visit(const Call *op);
 
 public:
     /** Information about a buffer reference from a closure. */

--- a/test/correctness/predicated_store_load.cpp
+++ b/test/correctness/predicated_store_load.cpp
@@ -123,8 +123,7 @@ int vectorized_dense_load_with_stride_minus_one_test() {
 
     Target target = get_jit_target_from_environment();
     if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
-        //TODO(psuriana): the hexagon test for this one is broken
-        //f.hexagon().vectorize(x, 16);
+        f.hexagon().vectorize(x, 16);
     } else if (target.arch == Target::X86) {
         f.vectorize(x, 32);
         f.add_custom_lowering_pass(new CheckPredicatedStoreLoad(true, true));
@@ -162,8 +161,7 @@ int multiple_vectorized_predicate_test() {
 
     Target target = get_jit_target_from_environment();
     if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
-        //TODO(psuriana): the hexagon test for this one is broken
-        //f.update(0).hexagon().vectorize(r.x, 32);
+        f.update(0).hexagon().vectorize(r.x, 32);
     } else if (target.arch == Target::X86) {
         f.update(0).vectorize(r.x, 32);
         f.add_custom_lowering_pass(new CheckPredicatedStoreLoad(true, true));


### PR DESCRIPTION
A buffer that a predicated_store writes to should also be considered
an output buffer. Re-enable test/correctness/predicated_store_load.cpp
for hexagon.

@psuriana @dsharletg : PTAL.