### PR TITLE
Mark various methods ALWAYS_INLINE

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -16,14 +16,6 @@
 
 #include "HalideRuntime.h"
 
-// Certain methods of Buffer *must* be inlined for reasonable
-// performance in debug builds.
-#ifdef _MSC_VER
-#define ALWAYS_INLINE __forceinline
-#else
-#define ALWAYS_INLINE __attribute__((always_inline))
-#endif
-
 #ifndef EXPORT
 #if defined(_WIN32) && defined(Halide_SHARED)
 #ifdef Halide_EXPORTS


### PR DESCRIPTION
This is needed to fix the dreaded “MachO doesn't support COMDATs”
problem on iOS builds. Moved ALWAYS_INLINE definition to
HalideRuntime.h to accomodate.