### PR TITLE
Fix Param::set_range crash on undefined bound

### DIFF
--- a/src/Param.h
+++ b/src/Param.h
@@ -120,6 +120,9 @@ public:
     }
 
     void set_min_value(Expr min) {
+        if (!min.defined()) {
+            return;
+        }
         if (min.type() != type_of<T>()) {
             min = Internal::Cast::make(type_of<T>(), min);
         }
@@ -127,6 +130,9 @@ public:
     }
 
     void set_max_value(Expr max) {
+        if (!max.defined()) {
+            return;
+        }
         if (max.type() != type_of<T>()) {
             max = Internal::Cast::make(type_of<T>(), max);
         }


### PR DESCRIPTION
The documentation for Param::set_range states: "Get or set the possible range of this parameter. Use undefined Exprs to mean unbounded." However, the AOT compilation segfaults if I try:

`Param<float> scale{"scale", 1.0f, 0.0f, Halide::Expr()};`

If I instead try `Param<float> scale{"scale", 1.0f, 0.0f, Halide::undef<float>()};`, I get:
> Internal error at third_party/halide/halide/src/CodeGen_LLVM.cpp:3024
> Unknown intrinsic: undef