### PR TITLE
Revise get_test_tmp_dir()

### DIFF
--- a/test/common/halide_test_dirs.h
+++ b/test/common/halide_test_dirs.h
@@ -46,7 +46,6 @@ inline std::string get_current_directory() {
         dir = p;
     }
     return dir;
-};
 #else
     std::string dir;
     char *p = getcwd(nullptr, 0);

--- a/test/common/halide_test_dirs.h
+++ b/test/common/halide_test_dirs.h
@@ -78,7 +78,7 @@ inline std::string get_test_tmp_dir() {
     char sep = '/';
 #ifdef _WIN32
     // Allow for C:\whatever on Windows
-    if (dir.size() >= 3 && dir[1] == '\\' && dir[2] == ':') {
+    if (dir.size() >= 3 && dir[1] == ':' && dir[2] == '\\') {
         is_absolute = true;
         sep = '\\';
     }

--- a/test/common/halide_test_dirs.h
+++ b/test/common/halide_test_dirs.h
@@ -16,11 +16,13 @@
 namespace Halide {
 namespace Internal {
 
-std::string get_env(const char *name) {
+namespace Test {
+
+inline std::string get_env_variable(const char *name) {
 #ifdef _MSC_VER
     char buf[MAX_PATH];
     size_t read = 0;
-    getenv_s(&read, buf, name);
+    if (getenv_s(&read, buf, name) != 0) read = 0;
     if (read) {
         return std::string(buf);
     }
@@ -56,6 +58,8 @@ inline std::string get_current_directory() {
 #endif
 }
 
+}  // namespace Test
+
 /** Return the path to a directory that can be safely written to
  * when running tests; the contents directory may or may not outlast
  * the lifetime of test itself (ie, the files may be cleaned up after test
@@ -66,10 +70,10 @@ inline std::string get_current_directory() {
  */
 inline std::string get_test_tmp_dir() {
     // If TEST_TMPDIR is specified, we assume it is a valid absolute path
-    std::string dir = get_env("TEST_TMPDIR");
+    std::string dir = Test::get_env_variable("TEST_TMPDIR");
     if (dir.empty()) {
         // If not specified, use current dir.
-        dir = get_current_directory();
+        dir = Test::get_current_directory();
     }
     bool is_absolute = dir.size() >= 1 && dir[0] == '/';
     char sep = '/';

--- a/test/common/halide_test_dirs.h
+++ b/test/common/halide_test_dirs.h
@@ -42,7 +42,7 @@ inline std::string get_current_directory() {
     std::string dir;
     char p[MAX_PATH];
     DWORD ret = GetCurrentDirectoryA(MAX_PATH, p);
-    if (p != 0) {
+    if (ret != 0) {
         dir = p;
     }
     return dir;


### PR DESCRIPTION
Putting it under /tmp/ causes race conditions in Travis (etc), as
multiple tests contend for the same dir. Instead:
— If the TEST_TMPDIR env var is defined, use it. (Bazel defines this
env var automatically.)
— Otherwise, use the current working directory (essentially reverting
to the same behavior as we used to have, but via absolute path rather
than relative).

Assert that paths must be absolute.

(Pushing out for review, but I’m going to test this locally on Windows
before committing.)