### PR TITLE
calls to getenv_s() should check the result code

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -338,8 +338,7 @@ void CodeGen_LLVM::initialize_llvm() {
 
         // You can hack in command-line args to llvm with the
         // environment variable HL_LLVM_ARGS, e.g. HL_LLVM_ARGS="-print-after-all"
-        size_t defined = 0;
-        std::string args = get_env_variable("HL_LLVM_ARGS", defined);
+        std::string args = get_env_variable("HL_LLVM_ARGS");
         if (!args.empty()) {
             vector<std::string> arg_vec = split_string(args, " ");
             vector<const char *> c_arg_vec;

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -52,13 +52,8 @@ struct debug {
     debug(int v) : verbosity(v) {
         if (!initialized) {
             // Read the debug level from the environment
-            size_t read;
-            std::string lvl = get_env_variable("HL_DEBUG_CODEGEN", read);
-            if (read) {
-                debug_level = atoi(lvl.c_str());
-            } else {
-                debug_level = 0;
-            }
+            std::string lvl = get_env_variable("HL_DEBUG_CODEGEN");
+            debug_level = lvl.empty() ? 0 : atoi(lvl.c_str());
             initialized = true;
         }
     }

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -688,10 +688,8 @@ void *Pipeline::compile_jit(const Target &target_arg) {
                          make_externs_jit_module(target_arg, lowered_externs));
 
     // Dump bitcode to a file if the environment variable
-    // HL_GENBITCODE is non-zero.
-    size_t gen;
-    get_env_variable("HL_GENBITCODE", gen);
-    if (gen) {
+    // HL_GENBITCODE is defined to a nonzero value.
+    if (atoi(get_env_variable("HL_GENBITCODE").c_str())) {
         string program_name = running_program_name();
         if (program_name.empty()) {
             program_name = "unknown" + unique_name('_').substr(1);

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -176,25 +176,6 @@ Target get_host_target() {
 }
 
 namespace {
-string get_env(const char *name) {
-#ifdef _MSC_VER
-    char buf[128];
-    size_t read = 0;
-    if (getenv_s(&read, buf, name) != 0) read = 0;
-    if (read) {
-        return string(buf);
-    } else {
-        return "";
-    }
-#else
-    char *buf = getenv(name);
-    if (buf) {
-        return string(buf);
-    } else {
-        return "";
-    }
-#endif
-}
 
 const std::map<std::string, Target::OS> os_name_map = {
     {"os_unknown", Target::OSUnknown},
@@ -290,7 +271,7 @@ bool lookup_feature(const std::string &tok, Target::Feature &result) {
 } // End anonymous namespace
 
 Target get_target_from_environment() {
-    string target = get_env("HL_TARGET");
+    string target = Internal::get_env_variable("HL_TARGET");
     if (target.empty()) {
         return get_host_target();
     } else {
@@ -301,7 +282,7 @@ Target get_target_from_environment() {
 Target get_jit_target_from_environment() {
     Target host = get_host_target();
     host.set_feature(Target::JIT);
-    string target = get_env("HL_JIT_TARGET");
+    string target = Internal::get_env_variable("HL_JIT_TARGET");
     if (target.empty()) {
         return host;
     } else {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -180,7 +180,7 @@ string get_env(const char *name) {
 #ifdef _MSC_VER
     char buf[128];
     size_t read = 0;
-    getenv_s(&read, buf, name);
+    if (getenv_s(&read, buf, name) != 0) read = 0;
     if (read) {
         return string(buf);
     } else {

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -46,7 +46,7 @@ std::string get_env_variable(char const *env_var_name, size_t &read) {
 
     #ifdef _MSC_VER
     char lvl[32];
-    getenv_s(&read, lvl, env_var_name);
+    if (getenv_s(&read, lvl, env_var_name) != 0) read = 0;
     #else
     char *lvl = getenv(env_var_name);
     read = (lvl)?1:0;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -38,26 +38,22 @@ using std::vector;
 using std::ostringstream;
 using std::map;
 
-std::string get_env_variable(char const *env_var_name, size_t &read) {
+std::string get_env_variable(char const *env_var_name) {
     if (!env_var_name) {
         return "";
     }
-    read = 0;
 
     #ifdef _MSC_VER
-    char lvl[32];
+    char lvl[128];
+    size_t read = 0;
     if (getenv_s(&read, lvl, env_var_name) != 0) read = 0;
+    if (read) return std::string(lvl);
     #else
     char *lvl = getenv(env_var_name);
-    read = (lvl)?1:0;
+    if (lvl) return std::string(lvl);
     #endif
 
-    if (read) {
-        return std::string(lvl);
-    }
-    else {
-        return "";
-    }
+    return "";
 }
 
 string running_program_name() {

--- a/src/Util.h
+++ b/src/Util.h
@@ -64,10 +64,10 @@ DstType reinterpret_bits(const SrcType &src) {
 EXPORT std::string make_entity_name(void *stack_ptr, const std::string &type, char prefix);
 
 /** Get value of an environment variable. Returns its value
- * is defined in the environment. Input: env_var_name. Output: var_defined.
- * Sets to true var_defined if the environment var is defined; false otherwise.
+ * is defined in the environment. If the var is not defined, an empty string
+ * is returned.
  */
-EXPORT std::string get_env_variable(char const *env_var_name, size_t &var_defined);
+EXPORT std::string get_env_variable(char const *env_var_name);
 
 /** Get the name of the currently running executable. Platform-specific.
  * If program name cannot be retrieved, function returns an empty string. */

--- a/test/generator/multitarget_aottest.cpp
+++ b/test/generator/multitarget_aottest.cpp
@@ -16,7 +16,7 @@ std::pair<std::string, bool> get_env_variable(char const *env_var_name) {
         size_t read = 0;
         #ifdef _MSC_VER
         char lvl[32];
-        getenv_s(&read, lvl, env_var_name);
+        if (getenv_s(&read, lvl, env_var_name) != 0) read = 0;
         #else
         char *lvl = getenv(env_var_name);
         read = (lvl)?1:0;


### PR DESCRIPTION
Checking the out-param “read” is probably fine, but better form to
(also) check the result code (which is nonzero if the var doesn’t exist
or an error occurs).