### PR TITLE
set_min_value() and set_max_value() should allow Expr()

### DIFF
--- a/src/Param.h
+++ b/src/Param.h
@@ -120,14 +120,14 @@ public:
     }
 
     void set_min_value(Expr min) {
-        if (min.type() != type_of<T>()) {
+        if (min.defined() && min.type() != type_of<T>()) {
             min = Internal::Cast::make(type_of<T>(), min);
         }
         param.set_min_value(min);
     }
 
     void set_max_value(Expr max) {
-        if (max.type() != type_of<T>()) {
+        if (max.defined() && max.type() != type_of<T>()) {
             max = Internal::Cast::make(type_of<T>(), max);
         }
         param.set_max_value(max);

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -244,11 +244,13 @@ int Parameter::host_alignment() const {
 }
 void Parameter::set_min_value(Expr e) {
     check_is_scalar();
-    user_assert(e.type() == contents->type)
-        << "Can't set parameter " << name()
-        << " of type " << contents->type
-        << " to have min value " << e
-        << " of type " << e.type() << "\n";
+    if (e.defined()) {
+        user_assert(e.type() == contents->type)
+            << "Can't set parameter " << name()
+            << " of type " << contents->type
+            << " to have min value " << e
+            << " of type " << e.type() << "\n";
+    }
     contents->min_value = e;
 }
 
@@ -259,11 +261,13 @@ Expr Parameter::get_min_value() const {
 
 void Parameter::set_max_value(Expr e) {
     check_is_scalar();
-    user_assert(e.type() == contents->type)
-        << "Can't set parameter " << name()
-        << " of type " << contents->type
-        << " to have max value " << e
-        << " of type " << e.type() << "\n";
+    if (e.defined()) {
+        user_assert(e.type() == contents->type)
+            << "Can't set parameter " << name()
+            << " of type " << contents->type
+            << " to have max value " << e
+            << " of type " << e.type() << "\n";
+    }
     contents->max_value = e;
 }
 


### PR DESCRIPTION
If the Expr has no defined value, we should skip the type cast / check.