### PR TITLE
Make extern stage name mangling match the target by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,6 @@ TEST_LD_FLAGS = -L$(BIN_DIR) -lHalide -lpthread $(LIBDL) -lz
 
 # gcc 4.8 fires a bogus warning on old versions of png.h
 CXX_VERSION = $(shell $(CXX) --version | head -n1)
-$(info $(CXX_VERSION))
 ifneq (,$(findstring g++,$(CXX_VERSION)))
 ifneq (,$(findstring 4.8,$(CXX_VERSION)))
 TEST_CXX_FLAGS += -Wno-literal-suffix

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -352,7 +352,7 @@ public:
                                                     {inner_query, i}, Call::Extern);
                         Expr inner_max = Call::make(Int(32), Call::buffer_get_max,
                                                     {inner_query, i}, Call::Extern);
-                        
+
                         // Push 'inner' inside of 'outer'
                         Expr shift = Min::make(0, outer_max - inner_max);
                         Expr new_min = inner_min + shift;
@@ -570,8 +570,8 @@ public:
             }
 
             // Make the extern call
-            Expr e = Call::make(Int(32), extern_name, bounds_inference_args,
-                                func.extern_definition_is_c_plus_plus() ? Call::ExternCPlusPlus : Call::Extern);
+            Expr e = func.make_call_to_extern_definition(bounds_inference_args, target);
+
             // Check if it succeeded
             string result_name = unique_name('t');
             Expr result = Variable::make(Int(32), result_name);

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -198,7 +198,7 @@ CodeGen_C::CodeGen_C(ostream &s, OutputKind output_kind, const std::string &guar
 }
 
 CodeGen_C::~CodeGen_C() {
-    switch_to_c_or_c_plus_plus(NameMangling::Default);
+    set_name_mangling_mode(NameMangling::Default);
 
     if (is_header()) {
         stream << "#endif\n";
@@ -286,7 +286,7 @@ string type_to_c_type(Type type, bool include_space, bool c_plus_plus = true) {
 }
 }
 
-void CodeGen_C::switch_to_c_or_c_plus_plus(NameMangling mode) {
+void CodeGen_C::set_name_mangling_mode(NameMangling mode) {
     if (extern_c_open && mode != NameMangling::C) {
         stream << "\n#ifdef __cplusplus\n";
         stream << "}  // extern \"C\"\n";
@@ -508,17 +508,17 @@ void CodeGen_C::compile(const LoweredFunc &f) {
         f.body.accept(&e);
 
         if (e.has_c_plus_plus_declarations()) {
-            switch_to_c_or_c_plus_plus(NameMangling::CPlusPlus);
+            set_name_mangling_mode(NameMangling::CPlusPlus);
             e.emit_c_plus_plus_declarations(stream);
         }
 
         if (e.has_c_declarations()) {
-            switch_to_c_or_c_plus_plus(NameMangling::C);
+            set_name_mangling_mode(NameMangling::C);
             e.emit_c_declarations(stream);
         }
     }
 
-    switch_to_c_or_c_plus_plus(is_c_plus_plus_interface() ? NameMangling::Default : NameMangling::C);
+    set_name_mangling_mode(is_c_plus_plus_interface() ? NameMangling::Default : NameMangling::C);
     stream << "\n";
 
     std::vector<std::string> namespaces;

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -198,7 +198,7 @@ CodeGen_C::CodeGen_C(ostream &s, OutputKind output_kind, const std::string &guar
 }
 
 CodeGen_C::~CodeGen_C() {
-    switch_to_c_or_c_plus_plus(COrCPlusPlus::Default);
+    switch_to_c_or_c_plus_plus(NameMangling::Default);
 
     if (is_header()) {
         stream << "#endif\n";
@@ -286,13 +286,13 @@ string type_to_c_type(Type type, bool include_space, bool c_plus_plus = true) {
 }
 }
 
-void CodeGen_C::switch_to_c_or_c_plus_plus(COrCPlusPlus mode) {
-    if (extern_c_open && mode != COrCPlusPlus::C) {
+void CodeGen_C::switch_to_c_or_c_plus_plus(NameMangling mode) {
+    if (extern_c_open && mode != NameMangling::C) {
         stream << "\n#ifdef __cplusplus\n";
         stream << "}  // extern \"C\"\n";
         stream << "#endif\n";
         extern_c_open = false;
-    } else if (!extern_c_open && mode == COrCPlusPlus::C) {
+    } else if (!extern_c_open && mode == NameMangling::C) {
         stream << "#ifdef __cplusplus\n";
         stream << "extern \"C\" {\n";
         stream << "#endif\n";
@@ -508,17 +508,17 @@ void CodeGen_C::compile(const LoweredFunc &f) {
         f.body.accept(&e);
 
         if (e.has_c_plus_plus_declarations()) {
-            switch_to_c_or_c_plus_plus(COrCPlusPlus::CPlusPlus);
+            switch_to_c_or_c_plus_plus(NameMangling::CPlusPlus);
             e.emit_c_plus_plus_declarations(stream);
         }
 
         if (e.has_c_declarations()) {
-            switch_to_c_or_c_plus_plus(COrCPlusPlus::C);
+            switch_to_c_or_c_plus_plus(NameMangling::C);
             e.emit_c_declarations(stream);
         }
     }
 
-    switch_to_c_or_c_plus_plus(is_c_plus_plus_interface() ? COrCPlusPlus::Default : COrCPlusPlus::C);
+    switch_to_c_or_c_plus_plus(is_c_plus_plus_interface() ? NameMangling::Default : NameMangling::C);
     stream << "\n";
 
     std::vector<std::string> namespaces;

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -127,17 +127,10 @@ protected:
     /** True if there is a void * __user_context parameter in the arguments. */
     bool have_user_context;
 
-    /** An enum to make calling convention changes clearer. */
-    enum class COrCPlusPlus {
-        Default,   ///< Whatever compiler is being used
-        C,         ///< extern "C" is forced if C++
-        CPlusPlus, ///< Operationally same as "default" but shows in code which things are expected to be mangled.
-    };
-
     /** Track current calling convention scope. */
     bool extern_c_open;
 
-    void switch_to_c_or_c_plus_plus(COrCPlusPlus mode);
+    void switch_to_c_or_c_plus_plus(NameMangling mode);
 
     using IRPrinter::visit;
 

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -130,7 +130,7 @@ protected:
     /** Track current calling convention scope. */
     bool extern_c_open;
 
-    void switch_to_c_or_c_plus_plus(NameMangling mode);
+    void set_name_mangling_mode(NameMangling mode);
 
     using IRPrinter::visit;
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -163,8 +163,8 @@ void Func::define_extern(const std::string &function_name,
                          const std::vector<ExternFuncArgument> &args,
                          const std::vector<Type> &types,
                          int dimensionality,
-                         bool is_c_plus_plus) {
-    func.define_extern(function_name, args, types, dimensionality, is_c_plus_plus);
+                         NameMangling mangling) {
+    func.define_extern(function_name, args, types, dimensionality, mangling);
 }
 
 /** Get the types of the buffers returned by an extern definition. */

--- a/src/Func.h
+++ b/src/Func.h
@@ -921,14 +921,15 @@ public:
                               const std::vector<ExternFuncArgument> &params,
                               Type t,
                               int dimensionality,
-                              bool is_c_plus_plus = false) {
-        define_extern(function_name, params, std::vector<Type>{t}, dimensionality, is_c_plus_plus);
+                              NameMangling mangling = NameMangling::Default) {
+        define_extern(function_name, params, std::vector<Type>{t}, dimensionality, mangling);
     }
 
     EXPORT void define_extern(const std::string &function_name,
                               const std::vector<ExternFuncArgument> &params,
                               const std::vector<Type> &types,
-                              int dimensionality, bool is_c_plus_plus = false);
+                              int dimensionality,
+                              NameMangling mangling = NameMangling::Default);
     // @}
 
     /** Get the types of the outputs of this Func. */

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -45,13 +45,13 @@ struct FunctionContents {
 
     std::vector<ExternFuncArgument> extern_arguments;
     std::string extern_function_name;
-    bool extern_is_c_plus_plus;
+    NameMangling extern_mangling;
 
     bool trace_loads, trace_stores, trace_realizations;
 
     bool frozen;
 
-    FunctionContents() : extern_is_c_plus_plus(false), trace_loads(false),
+    FunctionContents() : extern_mangling(NameMangling::Default), trace_loads(false),
                          trace_stores(false), trace_realizations(false),
                          frozen(false) {}
 
@@ -304,7 +304,7 @@ void deep_copy_function_contents_helper(const IntrusivePtr<FunctionContents> &sr
     dst->output_types = src->output_types;
     dst->debug_file = src->debug_file;
     dst->extern_function_name = src->extern_function_name;
-    dst->extern_is_c_plus_plus = src->extern_is_c_plus_plus;
+    dst->extern_mangling = src->extern_mangling;
     dst->trace_loads = src->trace_loads;
     dst->trace_stores = src->trace_stores;
     dst->trace_realizations = src->trace_realizations;
@@ -677,7 +677,7 @@ void Function::define_extern(const std::string &function_name,
                              const std::vector<ExternFuncArgument> &args,
                              const std::vector<Type> &types,
                              int dimensionality,
-                             bool is_c_plus_plus) {
+                             NameMangling mangling) {
 
     user_assert(!has_pure_definition() && !has_update_definition())
         << "In extern definition for Func \"" << name() << "\":\n"
@@ -690,7 +690,7 @@ void Function::define_extern(const std::string &function_name,
     contents->extern_function_name = function_name;
     contents->extern_arguments = args;
     contents->output_types = types;
-    contents->extern_is_c_plus_plus = is_c_plus_plus;
+    contents->extern_mangling = mangling;
 
     for (size_t i = 0; i < types.size(); i++) {
         string buffer_name = name();
@@ -798,8 +798,29 @@ bool Function::has_extern_definition() const {
     return !contents->extern_function_name.empty();
 }
 
-bool Function::extern_definition_is_c_plus_plus() const {
-    return contents->extern_is_c_plus_plus;
+NameMangling Function::extern_definition_name_mangling() const {
+    return contents->extern_mangling;
+}
+
+Expr Function::make_call_to_extern_definition(const std::vector<Expr> &args,
+                                              const Target &target) const {
+    internal_assert(has_extern_definition());
+
+    Call::CallType call_type;
+    switch (contents->extern_mangling) {
+    case NameMangling::Default:
+        call_type = (target.has_feature(Target::CPlusPlusMangling) ?
+                     Call::ExternCPlusPlus :
+                     Call::Extern);
+        break;
+    case NameMangling::CPlusPlus:
+        call_type = Call::ExternCPlusPlus;
+        break;
+    case NameMangling::C:
+        call_type = Call::Extern;
+        break;
+    }
+    return Call::make(Int(32), contents->extern_function_name, args, call_type);
 }
 
 const std::vector<ExternFuncArgument> &Function::extern_arguments() const {

--- a/src/Function.h
+++ b/src/Function.h
@@ -52,6 +52,13 @@ struct ExternFuncArgument {
     bool defined() const {return arg_type != UndefinedArg;}
 };
 
+/** An enum to specify calling convention for extern stages. */
+enum class NameMangling {
+    Default,   ///< Match whatever is specified in the Target
+    C,         ///< No name mangling
+    CPlusPlus, ///< C++ name mangling
+};
+
 namespace Internal {
 
 /** A reference-counted handle to Halide's internal representation of
@@ -119,50 +126,50 @@ public:
      * of this function. */
     EXPORT void accept(IRVisitor *visitor) const;
 
-    /** Get the name of the function */
+    /** Get the name of the function. */
     EXPORT const std::string &name() const;
 
     /** Get a mutable handle to the init definition. */
     EXPORT Definition &definition();
 
-    /** Get the init definition */
+    /** Get the init definition. */
     EXPORT const Definition &definition() const;
 
-    /** Get the pure arguments */
+    /** Get the pure arguments. */
     EXPORT const std::vector<std::string> args() const;
 
-    /** Get the dimensionality */
+    /** Get the dimensionality. */
     EXPORT int dimensions() const;
 
-    /** Get the number of outputs */
+    /** Get the number of outputs. */
     int outputs() const {
         return (int)output_types().size();
     }
 
-    /** Get the types of the outputs */
+    /** Get the types of the outputs. */
     EXPORT const std::vector<Type> &output_types() const;
 
-    /** Get the right-hand-side of the pure definition */
+    /** Get the right-hand-side of the pure definition. */
     EXPORT const std::vector<Expr> &values() const;
 
-    /** Does this function have a pure definition */
+    /** Does this function have a pure definition? */
     EXPORT bool has_pure_definition() const;
 
-    /** Does this function *only* have a pure definition */
+    /** Does this function *only* have a pure definition? */
     bool is_pure() const {
         return (has_pure_definition() &&
                 !has_update_definition() &&
                 !has_extern_definition());
     }
 
-    /** Is it legal to inline this function */
+    /** Is it legal to inline this function? */
     EXPORT bool can_be_inlined() const;
 
     /** Get a handle to the schedule for the purpose of modifying
-     * it */
+     * it. */
     EXPORT Schedule &schedule();
 
-    /** Get a const handle to the schedule for inspecting it */
+    /** Get a const handle to the schedule for inspecting it. */
     EXPORT const Schedule &schedule() const;
 
     /** Get a handle on the output buffer used for setting constraints
@@ -170,7 +177,7 @@ public:
     EXPORT const std::vector<Parameter> &output_buffers() const;
 
     /** Get a mutable handle to the schedule for the update
-     * stage */
+     * stage. */
     EXPORT Schedule &update_schedule(int idx = 0);
 
     /** Get a mutable handle to this function's update definition at
@@ -184,38 +191,43 @@ public:
     /** Get a const reference to this function's update definitions. */
     EXPORT const std::vector<Definition> &updates() const;
 
-    /** Does this function have an update definition */
+    /** Does this function have an update definition? */
     EXPORT bool has_update_definition() const;
 
-    /** Check if the function has an extern definition */
+    /** Check if the function has an extern definition. */
     EXPORT bool has_extern_definition() const;
 
-    /** Check if the function has an extern definition */
-    EXPORT bool extern_definition_is_c_plus_plus() const;
+    /** Get the name mangling specified for the extern definition. */
+    EXPORT NameMangling extern_definition_name_mangling() const;
 
-    /** Add an external definition of this Func */
+    /** Make a call node to the extern definition. An error if the
+     * function has no extern definition. */
+    EXPORT Expr make_call_to_extern_definition(const std::vector<Expr> &args,
+                                               const Target &t) const;
+
+    /** Add an external definition of this Func. */
     EXPORT void define_extern(const std::string &function_name,
                               const std::vector<ExternFuncArgument> &args,
                               const std::vector<Type> &types,
                               int dimensionality,
-                              bool is_c_plus_plus);
+                              NameMangling mangling);
 
-    /** Retrive the arguments of the extern definition */
+    /** Retrive the arguments of the extern definition. */
     EXPORT const std::vector<ExternFuncArgument> &extern_arguments() const;
 
     /** Get the name of the extern function called for an extern
      * definition. */
     EXPORT const std::string &extern_function_name() const;
 
-    /** Equality of identity */
+    /** Test for equality of identity. */
     bool same_as(const Function &other) const {
         return contents.same_as(other.contents);
     }
 
-    /** Get a const handle to the debug filename */
+    /** Get a const handle to the debug filename. */
     EXPORT const std::string &debug_file() const;
 
-    /** Get a handle to the debug filename */
+    /** Get a handle to the debug filename. */
     EXPORT std::string &debug_file();
 
     /** Use an an extern argument to another function. */

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1948,6 +1948,7 @@ protected:
     using Tuple = Halide::Tuple;
     using Type = Halide::Type;
     using Var = Halide::Var;
+    using NameMangling = Halide::NameMangling;
     template <typename T> static Expr cast(Expr e) { return Halide::cast<T>(e); }
     static inline Expr cast(Halide::Type t, Expr e) { return Halide::cast(t, e); }
     template <typename T> using GeneratorParam = Halide::GeneratorParam<T>;

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -440,12 +440,11 @@ Stmt build_produce(Function f, const Target &target) {
         }
 
         // Make the extern call
-        Expr e = Call::make(Int(32), extern_name, extern_call_args,
-                            f.extern_definition_is_c_plus_plus() ? Call::ExternCPlusPlus
-                                                                 : Call::Extern);
+        Expr e = f.make_call_to_extern_definition(extern_call_args, target);
+
+        // Check if it succeeded
         string result_name = unique_name('t');
         Expr result = Variable::make(Int(32), result_name);
-        // Check if it succeeded
         Expr error = Call::make(Int(32), "halide_error_extern_stage_failed",
                                 {extern_name, result}, Call::Extern);
         Stmt check = AssertStmt::make(EQ::make(result, 0), error);

--- a/test/generator/cxx_mangling_define_extern_aottest.cpp
+++ b/test/generator/cxx_mangling_define_extern_aottest.cpp
@@ -7,6 +7,7 @@
 #include <string.h>
 
 #include "cxx_mangling_define_extern.h"
+#include "cxx_mangling.h"
 
 using namespace Halide::Runtime;
 
@@ -22,6 +23,22 @@ int32_t extract_value_ns(const int32_t *arg) {
 
 }
 
+namespace HalideTest {
+
+int cxx_mangling_1(buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, buffer_t *_f_buffer) {
+    return cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, _f_buffer);
+}
+
+int cxx_mangling_2(buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, buffer_t *_f_buffer) {
+    return cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, _f_buffer);
+}
+
+extern "C" int cxx_mangling_3(buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, buffer_t *_f_buffer) {
+    return cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, _f_buffer);
+}
+
+};
+
 int main(int argc, char **argv) {
     Buffer<uint8_t> input(100);
 
@@ -29,7 +46,7 @@ int main(int argc, char **argv) {
         input(i) = i;
     }
 
-    Buffer<double> result(100);
+    Buffer<double> result_1(100), result_2(100), result_3(100);
 
     const void *user_context = nullptr;
     int ptr_arg = 42;
@@ -39,8 +56,9 @@ int main(int argc, char **argv) {
     const void *const_void_ptr = nullptr;
     std::string *string_ptr = nullptr;
     const std::string *const_string_ptr = nullptr;
-    int r = HalideTest::cxx_mangling_define_extern(user_context, input, int_ptr, const_int_ptr, 
-        void_ptr, const_void_ptr, string_ptr, const_string_ptr, result);
+    int r = HalideTest::cxx_mangling_define_extern(user_context, input, int_ptr, const_int_ptr,
+                                                   void_ptr, const_void_ptr, string_ptr, const_string_ptr,
+                                                   result_1, result_2, result_3);
     if (r != 0) {
         fprintf(stderr, "Failure!\n");
         exit(1);

--- a/test/generator/cxx_mangling_define_extern_generator.cpp
+++ b/test/generator/cxx_mangling_define_extern_generator.cpp
@@ -12,14 +12,14 @@ public:
     Param<std::string *> string_ptr{"string_ptr", 0};
     Param<std::string const *> const_string_ptr{"const_string_ptr", 0};
 
-    Func build() {
+    Pipeline build() {
         assert(get_target().has_feature(Target::CPlusPlusMangling));
         Var x("x");
 
         Func g("g");
         g(x) = input(x) + 42;
 
-        Func f("f");
+        Func f1("f1"), f2("f2"), f3("f3");
 
         std::vector<ExternFuncArgument> args;
         args.push_back(g);
@@ -40,12 +40,16 @@ public:
         args.push_back(const_void_ptr);
         args.push_back(string_ptr);
         args.push_back(const_string_ptr);
-        f.define_extern("HalideTest::cxx_mangling",
-                        args, Float(64), 1, true);
+        f1.define_extern("HalideTest::cxx_mangling_1",
+                         args, Float(64), 1, NameMangling::Default);
+        f2.define_extern("HalideTest::cxx_mangling_2",
+                         args, Float(64), 1, NameMangling::CPlusPlus);
+        f3.define_extern("cxx_mangling_3",
+                         args, Float(64), 1, NameMangling::C);
 
         g.compute_root();
 
-        return f;
+        return Pipeline({f1, f2, f3});
     }
 };
 


### PR DESCRIPTION
For name mangling, define_extern currently requires you to specify C
(the default) or C++ via a boolean arg. This PR makes the name mangling
setting on a define_extern stage a three-state enum:

CPlusPlus - Uses c++ mangling
C - Uses C mangling (i.e. no mangling)
Default - Use the same mangling as the pipeline being compiled (switches
based on target.has_feature(Target::CPlusPlusMangling))

The default value is "Default". This will change the default linkage on
extern stages for codebases with Target::CPlusPlusMangling on. It should
not affect any other code.