### PR TITLE
Remove Generator multitarget special-cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -960,7 +960,7 @@ $(BIN_DIR)/generator_aot_metadata_tester: $(FILTERS_DIR)/metadata_tester_ucon.a
 $(FILTERS_DIR)/multitarget.a: $(BIN_DIR)/multitarget.generator
 	@mkdir -p $(FILTERS_DIR)
 	@-mkdir -p $(TMP_DIR)
-	cd $(TMP_DIR); $(LD_PATH_SETUP) $(CURDIR)/$< -f "HalideTest::multitarget" -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-debug-no_runtime-c_plus_plus_name_mangling,$(HL_TARGET)-no_runtime-c_plus_plus_name_mangling  -e assembly,bitcode,cpp,h,html,static_library,stmt
+	cd $(TMP_DIR); $(LD_PATH_SETUP) $(CURDIR)/$< -f "HalideTest::multitarget" -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-debug-no_runtime-c_plus_plus_name_mangling,$(HL_TARGET)-no_runtime-c_plus_plus_name_mangling  -e assembly,bitcode,h,html,static_library,stmt
 
 $(FILTERS_DIR)/msan.a: $(BIN_DIR)/msan.generator
 	@mkdir -p $(FILTERS_DIR)

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2608,10 +2608,11 @@ void CodeGen_LLVM::visit(const Call *op) {
         // It is assumed/required that all of the sub-functions have arguments
         // (and return values) that are identical to those of this->function.
         //
-        // Note that it's fine to use this with only a single condition+function
-        // pair: it will collapse to a single unconditional branch to the 
-        // underlying function.
-        internal_assert(op->args.size() >= 2);
+        // Note that we require >= 4 arguments: fewer would imply
+        // only one condition+function pair, which is pointless to use
+        // (the function should always be called directly).
+        //
+        internal_assert(op->args.size() >= 4);
         internal_assert(!(op->args.size() & 1));
 
         // Gather information we need about each function.

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -949,14 +949,7 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
                     auto gen = GeneratorRegistry::create(generator_name, sub_generator_args);
                     return gen->build_module(name);
                 };
-            if (targets.size() > 1 || !emit_options.substitutions.empty()) {
-                compile_multitarget(function_name, output_files, targets, module_producer, emit_options.substitutions);
-            } else {
-                user_assert(emit_options.substitutions.empty()) << "substitutions not supported for single-target";
-                // compile_multitarget() will fail if we request anything but library and/or header,
-                // so defer directly to Module::compile if there is a single target.
-                module_producer(function_name, targets[0]).compile(output_files);
-            }
+            compile_multitarget(function_name, output_files, targets, module_producer, emit_options.substitutions);
         }
     }
 

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -339,6 +339,11 @@ void compile_multitarget(const std::string &fn_name,
         Outputs sub_out = add_suffixes(output_files, suffix);
         internal_assert(sub_out.object_name.empty());
         sub_out.object_name = temp_dir.add_temp_object_file(output_files.static_library_name, suffix, target);
+        if (!sub_out.c_source_name.empty()) {
+            user_assert(targets.size() == 1) << "Cannot request c_source_name for multiple targets.\n";
+            // C source output always is emitted unadorned.
+            sub_out.c_source_name = output_files.c_source_name;
+        }
         module.compile(sub_out);
 
         static_assert(sizeof(uint64_t)*8 >= Target::FeatureEnd, "Features will not fit in uint64_t");

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -69,6 +69,7 @@ private:
 
 
 // Given a pathname of the form /path/to/name.ext, append suffix before ext to produce /path/to/namesuffix.ext
+// Note that name.ext1.ext2 -> name.ext1suffix.ext2
 std::string add_suffix(const std::string &path, const std::string &suffix) {
     const auto found = path.rfind(".");
     if (found == std::string::npos) {
@@ -288,6 +289,9 @@ void compile_multitarget(const std::string &fn_name,
     // JIT makes no sense.
     user_assert(!base_target.has_feature(Target::JIT)) << "JIT not allowed for compile_multitarget.\n";
 
+    // If only one target, don't bother with the runtime feature detection wrapping.
+    const bool needs_wrapper = (targets.size() > 1);
+
     TemporaryObjectFileDir temp_dir;
     std::vector<Expr> wrapper_args;
     std::vector<LoweredArgument> base_target_args;
@@ -322,13 +326,14 @@ void compile_multitarget(const std::string &fn_name,
           suffix = it->second;
         }
         suffix = "_" + suffix;
-        std::string sub_fn_name = fn_name + suffix;
+        std::string sub_fn_name = needs_wrapper ? (fn_name + suffix) : fn_name;
 
         // We always produce the runtime separately, so add NoRuntime explicitly.
-        // Matlab should be added to the wrapper pipeline below, instead of each sub-pipeline.
-        Target sub_fn_target = target
-            .with_feature(Target::NoRuntime)
-            .without_feature(Target::Matlab);
+        Target sub_fn_target = target.with_feature(Target::NoRuntime);
+        if (needs_wrapper) {
+            // Matlab should be added to the wrapper pipeline below, instead of each sub-pipeline.
+            sub_fn_target = sub_fn_target.without_feature(Target::Matlab);
+        }
 
         Module module = module_producer(sub_fn_name, sub_fn_target);
         Outputs sub_out = add_suffixes(output_files, suffix);
@@ -363,40 +368,44 @@ void compile_multitarget(const std::string &fn_name,
             runtime_target);
     }
 
-    Expr indirect_result = Call::make(Int(32), Call::call_cached_indirect_function, wrapper_args, Call::Intrinsic);
-    std::string private_result_name = unique_name(fn_name + "_result");
-    Expr private_result_var = Variable::make(Int(32), private_result_name);
-    Stmt wrapper_body = AssertStmt::make(private_result_var == 0, private_result_var);
-    wrapper_body = LetStmt::make(private_result_name, indirect_result, wrapper_body);
+    if (needs_wrapper) {
+        Expr indirect_result = Call::make(Int(32), Call::call_cached_indirect_function, wrapper_args, Call::Intrinsic);
+        std::string private_result_name = unique_name(fn_name + "_result");
+        Expr private_result_var = Variable::make(Int(32), private_result_name);
+        Stmt wrapper_body = AssertStmt::make(private_result_var == 0, private_result_var);
+        wrapper_body = LetStmt::make(private_result_name, indirect_result, wrapper_body);
 
-    // Always build with NoRuntime: that's handled as a separate module.
-    //
-    // Always build with NoBoundsQuery: underlying code will implement that (or not).
-    //
-    // Always build *without* NoAsserts (ie, with Asserts enabled): that's the
-    // only way to propagate a nonzero result code to our caller. (Note that this
-    // does mean we get redundant check-for-null tests in the wrapper code for buffer_t*
-    // arguments; this is regrettable but fairly minor in terms of both code size and speed,
-    // at least for real-world code.)
-    Target wrapper_target = base_target
-        .with_feature(Target::NoRuntime)
-        .with_feature(Target::NoBoundsQuery)
-        .without_feature(Target::NoAsserts);
+        // Always build with NoRuntime: that's handled as a separate module.
+        //
+        // Always build with NoBoundsQuery: underlying code will implement that (or not).
+        //
+        // Always build *without* NoAsserts (ie, with Asserts enabled): that's the
+        // only way to propagate a nonzero result code to our caller. (Note that this
+        // does mean we get redundant check-for-null tests in the wrapper code for buffer_t*
+        // arguments; this is regrettable but fairly minor in terms of both code size and speed,
+        // at least for real-world code.)
+        Target wrapper_target = base_target
+            .with_feature(Target::NoRuntime)
+            .with_feature(Target::NoBoundsQuery)
+            .without_feature(Target::NoAsserts);
 
-    // If the base target specified the Matlab target, we want the Matlab target
-    // on the wrapper instead.
-    if (base_target.has_feature(Target::Matlab)) {
-        wrapper_target = wrapper_target.with_feature(Target::Matlab);
+        // If the base target specified the Matlab target, we want the Matlab target
+        // on the wrapper instead.
+        if (base_target.has_feature(Target::Matlab)) {
+            wrapper_target = wrapper_target.with_feature(Target::Matlab);
+        }
+
+        Module wrapper_module(fn_name, wrapper_target);
+        wrapper_module.append(LoweredFunc(fn_name, base_target_args, wrapper_body, LoweredFunc::External));
+        wrapper_module.compile(Outputs().object(temp_dir.add_temp_object_file(output_files.static_library_name, "_wrapper", base_target, /* in_front*/ true)));
     }
-
-    Module wrapper_module(fn_name, wrapper_target);
-    wrapper_module.append(LoweredFunc(fn_name, base_target_args, wrapper_body, LoweredFunc::External));
-    wrapper_module.compile(Outputs().object(temp_dir.add_temp_object_file(output_files.static_library_name, "_wrapper", base_target, /* in_front*/ true)));
 
     if (!output_files.c_header_name.empty()) {
-        debug(1) << "compile_multitarget: c_header_name " << output_files.c_header_name << "\n";
-        wrapper_module.compile(Outputs().c_header(output_files.c_header_name));
+        Module header_module(fn_name, base_target);
+        header_module.append(LoweredFunc(fn_name, base_target_args, {}, LoweredFunc::External));
+        header_module.compile(Outputs().c_header(output_files.c_header_name));
     }
+
     if (!output_files.static_library_name.empty()) {
         debug(1) << "compile_multitarget: static_library_name " << output_files.static_library_name << "\n";
         create_static_library(temp_dir.files(), base_target, output_files.static_library_name);

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -291,13 +291,6 @@ void compile_multitarget(const std::string &fn_name,
     // JIT makes no sense.
     user_assert(!base_target.has_feature(Target::JIT)) << "JIT not allowed for compile_multitarget.\n";
 
-    // If only one target, don't bother with the runtime feature detection wrapping.
-    if (targets.size() == 1) {
-        debug(1) << "compile_multitarget: single target is " << base_target.to_string() << "\n";
-        module_producer(fn_name, base_target).compile(output_files);
-        return;
-    }
-
     TemporaryObjectFileDir temp_dir;
     std::vector<Expr> wrapper_args;
     std::vector<LoweredArgument> base_target_args;


### PR DESCRIPTION
The code path for Generators formerly went thru compile_multitarget()
only for cases where there were multitargets; this meant that the
contents of static libraries (and the patterns of filename
substitution) could be subtly different for single- vs multi-target,
making some bugs hard to track down (since some Generator tests use
single and some use multi). Now, the code uniformly goes thru the
multitarget case; this means that a ‘wrapper’ function is now generated
for the single-target case where none was before, but in terms of code
size and speed, it’s essentially a wash (the wrapper is just the an
unconditional branch to the underlying function). This will make
subsequent changes to this code much easier to verify across all usages.