### PR TITLE
IO<Buffer> should have allowed for dim-only and type-only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -931,7 +931,8 @@ $(FILTERS_DIR)/pyramid.a: $(BIN_DIR)/pyramid.generator
 
 METADATA_TESTER_GENERATOR_ARGS=\
 	input.type=uint8 input.dim=3 \
-	semityped_input_buffer.dim=3 \
+	type_only_input_buffer.dim=3 \
+	dim_only_input_buffer.type=uint8 \
 	untyped_input_buffer.type=uint8 untyped_input_buffer.dim=3 \
 	output.type=float32,float32 output.dim=3 \
 	input_not_nod.type=uint8 input_not_nod.dim=3 \

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1273,8 +1273,7 @@ public:
     }
 
     GeneratorInput_Buffer(const std::string &name, int d)
-        : Super(name, IOKind::Buffer, std::vector<Type>{ T::static_halide_type() }, d) {
-        static_assert(T::has_static_halide_type(), "Must pass a Type argument for a Buffer with a static type of void");
+        : Super(name, IOKind::Buffer, T::has_static_halide_type() ? std::vector<Type>{ T::static_halide_type() } : std::vector<Type>{}, d) {
     }
 
 
@@ -1688,7 +1687,7 @@ protected:
         if (T::has_static_halide_type()) {
             user_assert(t.empty()) << "Cannot use pass a Type argument for a Buffer with a non-void static type\n";
         } else {
-            user_assert(t.size() == 1) << "Output<Buffer<>> requires exactly one Type\n";
+            user_assert(t.size() <= 1) << "Output<Buffer<>>(" << name << ") requires at most one Type, but has " << t.size() << "\n";
         }
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -302,7 +302,8 @@ if (WITH_TEST_GENERATORS)
   # Tests that require additional dependencies, args, etc
   set(MDTEST_GEN_ARGS
       input.type=uint8 input.dim=3
-      semityped_input_buffer.dim=3
+      type_only_input_buffer.dim=3
+      dim_only_input_buffer.type=uint8
       untyped_input_buffer.type=uint8 untyped_input_buffer.dim=3
       output.type=float32,float32 output.dim=3
       input_not_nod.type=uint8 input_not_nod.dim=3

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -295,7 +295,16 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           nullptr,
         },
         {
-          "semityped_input_buffer",
+          "type_only_input_buffer",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_uint, 8),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "dim_only_input_buffer",
           halide_argument_kind_input_buffer,
           3,
           halide_type_t(halide_type_uint, 8),
@@ -637,6 +646,24 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           nullptr,
         },
         {
+          "type_only_output_buffer",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "dim_only_output_buffer",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
           "untyped_output_buffer",
           halide_argument_kind_output_buffer,
           3,
@@ -736,6 +763,8 @@ int main(int argc, char **argv) {
     Buffer<float> output0(kSize, kSize, 3);
     Buffer<float> output1(kSize, kSize, 3);
     Buffer<float> typed_output_buffer(kSize, kSize, 3);
+    Buffer<float> type_only_output_buffer(kSize, kSize, 3);
+    Buffer<float> dim_only_output_buffer(kSize, kSize, 3);
     Buffer<float> untyped_output_buffer(kSize, kSize, 3);
     Buffer<float> output_scalar = Buffer<float>::make_scalar();
     Buffer<float> output_array[2] = {{kSize, kSize, 3}, {kSize, kSize, 3}};
@@ -746,6 +775,7 @@ int main(int argc, char **argv) {
         input,             // Input<Func>
         input,             // Input<Buffer<uint8_t>>
         input,             // Input<Buffer<>>(uint8)
+        input,             // Input<Buffer<>>(3)
         input,             // Input<Buffer<>>
         false,             // Input<bool>
         0,                 // Input<i8>
@@ -772,7 +802,9 @@ int main(int argc, char **argv) {
         0, 0,              // Input<int32_t[2]>
         nullptr, nullptr,  // Input<void*[]>
         output0, output1,  // Output<Tuple(Func, Func)>
-        typed_output_buffer,    // Output<Buffer<float>>
+        typed_output_buffer,    // Output<Buffer<float>>(3)
+        type_only_output_buffer,    // Output<Buffer<float>>
+        dim_only_output_buffer,    // Output<Buffer<>>(3)
         untyped_output_buffer,  // Output<Buffer<>>
         output_scalar,     // Output<float>
         output_array[0], output_array[1],   // Output<Func[]>
@@ -786,6 +818,7 @@ int main(int argc, char **argv) {
         input,             // Input<Func>
         input,             // Input<Buffer<uint8_t>>
         input,             // Input<Buffer<>>(uint8)
+        input,             // Input<Buffer<>>(3)
         input,             // Input<Buffer<>>
         false,             // Input<bool>
         0,                 // Input<i8>
@@ -812,7 +845,9 @@ int main(int argc, char **argv) {
         0, 0,              // Input<int32_t[2]>
         nullptr, nullptr,  // Input<void*[]>
         output0, output1,  // Output<Tuple(Func, Func)>
-        typed_output_buffer,    // Output<Buffer<float>>
+        typed_output_buffer,    // Output<Buffer<float>>(3)
+        type_only_output_buffer,    // Output<Buffer<float>>
+        dim_only_output_buffer,    // Output<Buffer<>>(3)
         untyped_output_buffer,  // Output<Buffer<>>
         output_scalar,     // Output<float>
         output_array[0], output_array[1],    // Output<Func[]>

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -9,7 +9,8 @@ class MetadataTester : public Halide::Generator<MetadataTester> {
 public:
     Input<Func> input{ "input", Int(16), 2 };  // must be overridden to {UInt(8), 3}
     Input<Buffer<uint8_t>> typed_input_buffer{ "typed_input_buffer", 3 };
-    Input<Buffer<>> semityped_input_buffer{ "semityped_input_buffer", UInt(8) };  // must be overridden to dim=3
+    Input<Buffer<>> type_only_input_buffer{ "type_only_input_buffer", UInt(8) };  // must be overridden to dim=3
+    Input<Buffer<>> dim_only_input_buffer{ "dim_only_input_buffer", 3 };  // must be overridden to type=UInt(8)
     Input<Buffer<>> untyped_input_buffer{ "untyped_input_buffer" };  // must be overridden to {UInt(8), 3}
     Input<bool> b{ "b", true };
     Input<int8_t> i8{ "i8", 8, -8, 127 }; 
@@ -40,7 +41,9 @@ public:
 
     Output<Func> output{ "output", {Int(16), UInt(8)}, 2 };  // must be overridden to {{Float(32), Float(32)}, 3}
     Output<Buffer<float>> typed_output_buffer{ "typed_output_buffer", 3 };
-    Output<Buffer<>> untyped_output_buffer{ "untyped_output_buffer" };  // untyped outputs can have type and dimensions inferred
+    Output<Buffer<float>> type_only_output_buffer{ "type_only_output_buffer" };  // untyped outputs can have type and/or dimensions inferred
+    Output<Buffer<>> dim_only_output_buffer{ "dim_only_output_buffer", 3 };  // untyped outputs can have type and/or dimensions inferred
+    Output<Buffer<>> untyped_output_buffer{ "untyped_output_buffer" };  // untyped outputs can have type and/or dimensions inferred
     Output<float> output_scalar{ "output_scalar" };
     Output<Func[]> array_outputs{ "array_outputs", Float(32), 3 };  // must be overridden to size=2
     Output<Func[2]> array_outputs2{ "array_outputs2", Float(32), 3 };
@@ -62,6 +65,8 @@ public:
 
         output(x, y, c) = Tuple(f1(x, y, c), f2(x, y, c));
         typed_output_buffer(x, y, c) = f1(x, y, c);
+        type_only_output_buffer(x, y, c) = f1(x, y, c);
+        dim_only_output_buffer(x, y, c) = f1(x, y, c);
         untyped_output_buffer(x, y, c) = f2(x, y, c);
         output_scalar() = 1234.25f;
         for (size_t i = 0; i < array_outputs.size(); ++i) {


### PR DESCRIPTION
Specifying an Input<Buffer> or Output<Buffer> with one of type or dim
(but not both) should have worked, but didn’t. Now it does.