### PR TITLE
Test cases and fix for issue #1781

### DIFF
--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -544,7 +544,8 @@ private:
             // if replacement is defined, we should substitute it in (unless
             // it's a var that has been hidden by a nested scope).
             if (info.replacement.defined()) {
-                internal_assert(info.replacement.type() == op->type);
+                internal_assert(info.replacement.type() == op->type) << "Cannot replace variable " << op->name
+                    << " of type " << op->type << " with expression of type " << info.replacement.type() << "\n";
                 expr = info.replacement;
                 info.new_uses++;
             } else {


### PR DESCRIPTION
This change includes test cases that were failing because of issue #1781: Internal assertion failures when compiling certain select expressions for OpenGL target.

In VaryingAttributes.cpp, `CastVariablesToFloatAndOffset` was mutating the true and false branches of a select expression but neglecting to mutate the condition. And for ramp expressions, if either base or stride mutates into a float, a cast may be require to make their types match.

Also added a diagnostic message to one of the assertions that was failing.