### PR TITLE
Add convenience macro for declaring types

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -231,11 +231,11 @@ string type_to_c_type(Type type, bool include_space, bool c_plus_plus = true) {
               type.handle_type->inner_name.cpp_type_type == halide_cplusplus_type_name::Class))) {
             oss << "void *";
         } else {
-            if (type.handle_type->inner_name.cpp_type_type == halide_cplusplus_type_name::Struct) {
+            if (type.handle_type->inner_name.cpp_type_type ==
+                halide_cplusplus_type_name::Struct) {
                 oss << "struct ";
-            } else if (type.handle_type->inner_name.cpp_type_type == halide_cplusplus_type_name::Class) {
-                oss << "class ";
             }
+
             if (!type.handle_type->namespaces.empty() ||
                 !type.handle_type->enclosing_types.empty()) {
                 oss << "::";
@@ -467,31 +467,23 @@ void CodeGen_C::compile(const LoweredFunc &f) {
     const std::vector<LoweredArgument> &args = f.args;
 
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].type.handle_type != NULL) {
-            if (!args[i].type.handle_type->namespaces.empty()) {
-                if (args[i].type.handle_type->inner_name.cpp_type_type != halide_cplusplus_type_name::Simple) {
-                    for (size_t ns = 0; ns < args[i].type.handle_type->namespaces.size(); ns++ ) {
-                        for (size_t indent = 0; indent < ns; indent++) {
-                           stream << "    ";
-                        }
-                        stream << indent << "namespace " << args[i].type.handle_type->namespaces[ns] << " {\n";
-                    }
-                    for (size_t indent = 0; indent < args[i].type.handle_type->namespaces.size(); indent++) {
-                        stream << "    ";
-                    }
-                    if (args[i].type.handle_type->inner_name.cpp_type_type != halide_cplusplus_type_name::Struct) {
-                        stream << "struct " << args[i].type.handle_type->inner_name.name << ";\n";
-                    } else {
-                        stream << "class " << args[i].type.handle_type->inner_name.name << ";\n";
-                    }
-                    for (size_t ns = 0; ns < args[i].type.handle_type->namespaces.size(); ns++ ) {
-                        for (size_t indent = 0; indent < ns; indent++) {
-                           stream << "    ";
-                        }
-                        stream << indent << "}\n";
-                    }
-                }
-            }
+        auto handle_type = args[i].type.handle_type;
+        if (!handle_type) continue;
+        auto type_type = handle_type->inner_name.cpp_type_type;
+        for (size_t ns = 0; ns < handle_type->namespaces.size(); ns++ ) {
+            stream << "namespace " << handle_type->namespaces[ns] << " {\n";
+        }
+        if (type_type == halide_cplusplus_type_name::Struct) {
+            stream << "struct " << handle_type->inner_name.name << ";\n";
+        } else if (type_type == halide_cplusplus_type_name::Class) {
+            stream << "class " << handle_type->inner_name.name << ";\n";
+        } else if (type_type == halide_cplusplus_type_name::Union) {
+            stream << "union " << handle_type->inner_name.name << ";\n";
+        } else if (type_type == halide_cplusplus_type_name::Enum) {
+            internal_error << "Passing pointers to enums is unsupported\n";
+        }
+        for (size_t ns = 0; ns < handle_type->namespaces.size(); ns++ ) {
+            stream << "}\n";
         }
     }
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -34,19 +34,6 @@
 
 #endif
 
-// We must make halide_filter_metadata_t a "Known" type for name-mangling to work
-// properly on Windows: the return type isn't part of the name-mangling scheme
-// on *nix, but is for MSVC. Note also that this specialization must be in the
-// same (global) namespace as the others.
-template<>
-struct halide_c_type_to_name<struct halide_filter_metadata_t> {
-    static const bool known_type = true;
-    static halide_cplusplus_type_name name() {
-        return { halide_cplusplus_type_name::Struct,  "halide_filter_metadata_t"};
-    }
-};
-
-
 namespace Halide {
 
 std::unique_ptr<llvm::Module> codegen_llvm(const Module &module, llvm::LLVMContext &context) {

--- a/src/Type.h
+++ b/src/Type.h
@@ -118,32 +118,45 @@ struct halide_c_type_to_name {
   static const bool known_type = false;
 };
 
-template<> struct halide_c_type_to_name<bool> { static const bool known_type = true; static halide_cplusplus_type_name name() { return { halide_cplusplus_type_name::Simple, "bool"}; } };
-template<> struct halide_c_type_to_name<int8_t> { static const bool known_type = true; static halide_cplusplus_type_name name() { return { halide_cplusplus_type_name::Simple,  "int8_t"}; } };
-template<> struct halide_c_type_to_name<uint8_t> { static const bool known_type = true; static halide_cplusplus_type_name name() { return { halide_cplusplus_type_name::Simple,  "uint8_t"}; } };
-template<> struct halide_c_type_to_name<int16_t> { static const bool known_type = true; static halide_cplusplus_type_name name() { return { halide_cplusplus_type_name::Simple,  "int16_t"}; } };
-template<> struct halide_c_type_to_name<uint16_t> { static const bool known_type = true; static halide_cplusplus_type_name name() { return { halide_cplusplus_type_name::Simple,  "uint16_t"}; } };
-template<> struct halide_c_type_to_name<int32_t> { static const bool known_type = true; static halide_cplusplus_type_name name() { return { halide_cplusplus_type_name::Simple,  "int32_t"}; } };
-template<> struct halide_c_type_to_name<uint32_t> { static const bool known_type = true; static halide_cplusplus_type_name name() { return { halide_cplusplus_type_name::Simple,  "uint32_t"}; } };
-template<> struct halide_c_type_to_name<float> { static const bool known_type = true; static halide_cplusplus_type_name name() { return { halide_cplusplus_type_name::Simple,  "float"}; } };
-template<> struct halide_c_type_to_name<double> { static const bool known_type = true; static halide_cplusplus_type_name name() { return { halide_cplusplus_type_name::Simple,  "double"}; } };
-template<> struct halide_c_type_to_name<struct buffer_t> { static const bool known_type = true; static halide_cplusplus_type_name name() { return { halide_cplusplus_type_name::Struct,  "buffer_t"}; } };
+#define HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(T) \
+    template<> struct halide_c_type_to_name<T> {                        \
+        static const bool known_type = true;                            \
+        static halide_cplusplus_type_name name() {                      \
+            return { halide_cplusplus_type_name::Simple, #T};           \
+        }                                                               \
+    }
 
-// You can make arbitrary user-defined types be "Known" by adding your own specialization of
-// halide_c_type_to_name in your code; this is useful for making Param<> arguments for Generators
-// type safe. e.g.,
+#define HALIDE_DECLARE_EXTERN_STRUCT_TYPE(T) \
+    template<> struct halide_c_type_to_name<struct T> {                 \
+        static const bool known_type = true;                            \
+        static halide_cplusplus_type_name name() {                      \
+            return { halide_cplusplus_type_name::Struct, #T};           \
+        }                                                               \
+    }
+
+HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(bool);
+HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(int8_t);
+HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(uint8_t);
+HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(int16_t);
+HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(uint16_t);
+HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(int32_t);
+HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(uint32_t);
+HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(int64_t);
+HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(uint64_t);
+HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(float);
+HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(double);
+HALIDE_DECLARE_EXTERN_STRUCT_TYPE(buffer_t);
+HALIDE_DECLARE_EXTERN_STRUCT_TYPE(halide_filter_metadata_t);
+
+// You can make arbitrary user-defined types be "Known" using the
+// macro above. This is useful for making Param<> arguments for
+// Generators type safe. e.g.,
 //
 //    struct MyFunStruct { ... };
 //
 //    ...
 //
-//    template<>
-//    struct halide_c_type_to_name<struct MyFunStruct> {
-//      static const bool known_type = true;
-//      static halide_cplusplus_type_name name() {
-//        return { halide_cplusplus_type_name::Struct,  "MyFunStruct"};
-//      }
-//    };
+//    HALIDE_DECLARE_EXTERN_STRUCT_TYPE(MyFunStruct);
 //
 //    ...
 //
@@ -151,6 +164,7 @@ template<> struct halide_c_type_to_name<struct buffer_t> { static const bool kno
 //       Param<const MyFunStruct *> my_struct_ptr;
 //       ...
 //    };
+
 
 // Default case (should be only Unknown types, since we specialize for Known types below).
 // We require that all unknown types be pointers, and translate them all to void*

--- a/src/Type.h
+++ b/src/Type.h
@@ -149,7 +149,8 @@ HALIDE_DECLARE_EXTERN_STRUCT_TYPE(buffer_t);
 HALIDE_DECLARE_EXTERN_STRUCT_TYPE(halide_filter_metadata_t);
 
 // You can make arbitrary user-defined types be "Known" using the
-// macro above. This is useful for making Param<> arguments for
+// macro above. The macro must be invoked outside of any namespaces,
+// at global scope. This is useful for making Param<> arguments for
 // Generators type safe. e.g.,
 //
 //    struct MyFunStruct { ... };

--- a/test/generator/cxx_mangling_aottest.cpp
+++ b/test/generator/cxx_mangling_aottest.cpp
@@ -22,6 +22,18 @@ int32_t extract_value_ns(const int32_t *arg) {
 
 }
 
+
+namespace my_namespace {
+class my_class {int foo;};
+namespace my_subnamespace {
+struct my_struct {int foo;};
+}
+}
+union my_union {
+    float a;
+    int b;
+};
+
 int main(int argc, char **argv) {
     Buffer<uint8_t> input(100);
 
@@ -49,10 +61,15 @@ int main(int argc, char **argv) {
     auto f = HalideTest::cxx_mangling_gpu;
     printf("HalideTest::cxx_mangling is at: %p\n", (void*) f);
 
+    my_namespace::my_class mc;
+    my_namespace::my_subnamespace::my_struct ms;
+    my_union mu;
+
     int r = HalideTest::cxx_mangling(input, -1, 0xff, -1, 0xffff, -1, 0xffffffff,
-                                    -1, 0xffffffffffffffffLL, true, 42.0, 4239.0f,
-                                    int_ptr, const_int_ptr, void_ptr, const_void_ptr,
-                                    string_ptr, const_string_ptr, result);
+                                     -1, 0xffffffffffffffffLL, true, 42.0, 4239.0f,
+                                     int_ptr, const_int_ptr, void_ptr, const_void_ptr,
+                                     string_ptr, const_string_ptr,
+                                     &mc, &ms, &mu, result);
     if (r != 0) {
         fprintf(stderr, "Failure!\n");
         exit(1);

--- a/test/generator/cxx_mangling_define_extern_aottest.cpp
+++ b/test/generator/cxx_mangling_define_extern_aottest.cpp
@@ -26,15 +26,15 @@ int32_t extract_value_ns(const int32_t *arg) {
 namespace HalideTest {
 
 int cxx_mangling_1(void *ctx, buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, buffer_t *_f_buffer) {
-    return cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, _f_buffer);
+    return cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, nullptr, nullptr, nullptr, _f_buffer);
 }
 
 int cxx_mangling_2(void *ctx, buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, buffer_t *_f_buffer) {
-    return cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, _f_buffer);
+    return cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, nullptr, nullptr, nullptr, _f_buffer);
 }
 
 extern "C" int cxx_mangling_3(void *ctx, buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, buffer_t *_f_buffer) {
-    return cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, _f_buffer);
+    return cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, nullptr, nullptr, nullptr, _f_buffer);
 }
 
 };

--- a/test/generator/cxx_mangling_generator.cpp
+++ b/test/generator/cxx_mangling_generator.cpp
@@ -13,6 +13,21 @@ Halide::Expr extract_value_ns(Halide::Expr arg) {
                                         Halide::Internal::Call::ExternCPlusPlus);
 }
 
+namespace my_namespace {
+class my_class {int foo;};
+namespace my_subnamespace {
+struct my_struct {int foo;};
+}
+}
+union my_union {
+    float a;
+    int b;
+};
+
+HALIDE_DECLARE_EXTERN_CLASS_TYPE(my_namespace::my_class);
+HALIDE_DECLARE_EXTERN_STRUCT_TYPE(my_namespace::my_subnamespace::my_struct);
+HALIDE_DECLARE_EXTERN_UNION_TYPE(my_union);
+
 class CPlusPlusNameManglingGenerator : public Halide::Generator<CPlusPlusNameManglingGenerator> {
 public:
     // Use all the parameter types to make sure mangling works for each of them.
@@ -39,6 +54,11 @@ public:
     // should be preserved).
     Param<std::string *> string_ptr{"string_ptr", 0};
     Param<std::string const *> const_string_ptr{"const_string_ptr", 0};
+
+    // Test some manually-registered types. These won't be void *.
+    Param<const my_namespace::my_class *> const_my_class_ptr{"const_my_class_ptr", 0};
+    Param<const my_namespace::my_subnamespace::my_struct *> const_my_struct_ptr{"const_my_struct_ptr", 0};
+    Param<const my_union *> const_my_union_ptr{"const_my_union_ptr", 0};
 
     Func build() {
         assert(get_target().has_feature(Target::CPlusPlusMangling));


### PR DESCRIPTION
Helps with name mangling in code using define_extern that passes
pointers to user types as arguments.