### PR TITLE
thread_safety test should use std::thread instead of OMP

### DIFF
--- a/test/correctness/thread_safety.cpp
+++ b/test/correctness/thread_safety.cpp
@@ -1,26 +1,34 @@
 #include "Halide.h"
 #include <stdio.h>
-#include <future>
+#include <thread>
 
 using namespace Halide;
-
-static std::atomic<int> foo;
 
 int main(int argc, char **argv) {
     // Test if the compiler itself is thread-safe. This test is
     // intended to be run in a thread-sanitizer.
-    std::vector<std::future<void>> futures;
-    for (int i = 0; i < 1000; i++) {
-        futures.emplace_back(std::async(std::launch::async, []{
-            Func f;
-            Var x;
-            f(x) = x;
-            f.realize(100);
-        }));
+
+    // std::thread has implementation-dependent behavior; some implementations
+    // may refuse to create an arbitrary number. So let's create a smallish
+    // number (8) and have each one do enough work that contention is likely
+    // to be encountered.
+    constexpr int total_iters = 1024;
+    constexpr int num_threads = 8;
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < num_threads; i++) {
+        threads.emplace_back([]{
+            for (int i = 0; i < (total_iters / num_threads); i++) {
+                Func f;
+                Var x;
+                f(x) = x;
+                f.realize(100);
+            }
+        });
     }
 
-    for (auto &f : futures) {
-        f.wait();
+    for (auto &t : threads) {
+        t.join();
     }
 
     printf("Success!\n");

--- a/test/correctness/thread_safety.cpp
+++ b/test/correctness/thread_safety.cpp
@@ -1,24 +1,26 @@
 #include "Halide.h"
 #include <stdio.h>
-#include <thread>
+#include <future>
 
 using namespace Halide;
+
+static std::atomic<int> foo;
 
 int main(int argc, char **argv) {
     // Test if the compiler itself is thread-safe. This test is
     // intended to be run in a thread-sanitizer.
-    std::vector<std::thread> threads;
+    std::vector<std::future<void>> futures;
     for (int i = 0; i < 1000; i++) {
-        threads.emplace_back([]{
+        futures.emplace_back(std::async(std::launch::async, []{
             Func f;
             Var x;
             f(x) = x;
             f.realize(100);
-        });
+        }));
     }
 
-    for (auto &t : threads) {
-        t.join();
+    for (auto &f : futures) {
+        f.wait();
     }
 
     printf("Success!\n");

--- a/test/correctness/thread_safety.cpp
+++ b/test/correctness/thread_safety.cpp
@@ -1,19 +1,24 @@
 #include "Halide.h"
 #include <stdio.h>
+#include <thread>
 
 using namespace Halide;
 
 int main(int argc, char **argv) {
     // Test if the compiler itself is thread-safe. This test is
-    // intended to be run in a thread-sanitizer with openmp turned on.
-    #ifdef _OPENMP
-    #pragma omp parallel for
-    #endif
+    // intended to be run in a thread-sanitizer.
+    std::vector<std::thread> threads;
     for (int i = 0; i < 1000; i++) {
-        Func f;
-        Var x;
-        f(x) = x;
-        f.realize(100);
+        threads.emplace_back([]{
+            Func f;
+            Var x;
+            f(x) = x;
+            f.realize(100);
+        });
+    }
+
+    for (auto &t : threads) {
+        t.join();
     }
 
     printf("Success!\n");


### PR DESCRIPTION
OMP isn’t available on all interesting targets, so this test serializes
(and effectively hangs) on those. Explicitly spawn threads instead.