### PR TITLE
Revert "Remove Generator multitarget special-cases"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -961,7 +961,7 @@ $(BIN_DIR)/generator_aot_metadata_tester: $(FILTERS_DIR)/metadata_tester_ucon.a
 $(FILTERS_DIR)/multitarget.a: $(BIN_DIR)/multitarget.generator
 	@mkdir -p $(FILTERS_DIR)
 	@-mkdir -p $(TMP_DIR)
-	cd $(TMP_DIR); $(LD_PATH_SETUP) $(CURDIR)/$< -f "HalideTest::multitarget" -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-debug-no_runtime-c_plus_plus_name_mangling,$(HL_TARGET)-no_runtime-c_plus_plus_name_mangling  -e assembly,bitcode,h,html,static_library,stmt
+	cd $(TMP_DIR); $(LD_PATH_SETUP) $(CURDIR)/$< -f "HalideTest::multitarget" -o $(CURDIR)/$(FILTERS_DIR) target=$(HL_TARGET)-debug-no_runtime-c_plus_plus_name_mangling,$(HL_TARGET)-no_runtime-c_plus_plus_name_mangling  -e assembly,bitcode,cpp,h,html,static_library,stmt
 
 $(FILTERS_DIR)/msan.a: $(BIN_DIR)/msan.generator
 	@mkdir -p $(FILTERS_DIR)

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2597,7 +2597,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         //
         // The final condition (cond_N) must evaluate to a constant TRUE
         // value (so that the final function will be selected if all others
-        // fail); failure to do so will fail at compile time.
+        // fail); failure to do so will cause unpredictable results.
         //
         // There is currently no way to clear the cached function pointer.
         //
@@ -2648,10 +2648,6 @@ void CodeGen_LLVM::visit(const Call *op) {
                                                 /*initializer*/ nullptr, extern_sub_fn_name);
             }
             auto cond = op->args[i];
-            if (i == op->args.size() - 2) {
-                // Final condition must be constant TRUE.
-                internal_assert(is_one(simplify(cond))) << "Expected constant TRUE but saw " << cond << "\n";
-            }
             sub_fns.push_back({sub_fn, sub_fn_ptr, cond});
         }
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -949,7 +949,14 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
                     auto gen = GeneratorRegistry::create(generator_name, sub_generator_args);
                     return gen->build_module(name);
                 };
-            compile_multitarget(function_name, output_files, targets, module_producer, emit_options.substitutions);
+            if (targets.size() > 1 || !emit_options.substitutions.empty()) {
+                compile_multitarget(function_name, output_files, targets, module_producer, emit_options.substitutions);
+            } else {
+                user_assert(emit_options.substitutions.empty()) << "substitutions not supported for single-target";
+                // compile_multitarget() will fail if we request anything but library and/or header,
+                // so defer directly to Module::compile if there is a single target.
+                module_producer(function_name, targets[0]).compile(output_files);
+            }
         }
     }
 


### PR DESCRIPTION
Reverts halide/Halide#1777

Broken Tutorial #15, and while I can fix that, there are now more special-case to this than I'd like. Reverting and rethinking.