### PR TITLE
Add Module::get_function_by_name()

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -145,6 +145,16 @@ const std::vector<Internal::LoweredFunc> &Module::functions() const {
     return contents->functions;
 }
 
+Internal::LoweredFunc Module::get_function_by_name(const std::string &name) const {
+    for (const auto &f : functions()) {
+        if (f.name == name) {
+            return f;
+        }
+    }
+    user_error << "get_function_by_name: function " << name << " not found.\n";
+    return Internal::LoweredFunc("", std::vector<Argument>{}, {}, LoweredFunc::External);
+}
+
 void Module::append(const Buffer<> &buffer) {
     contents->buffers.push_back(buffer);
 }
@@ -355,7 +365,7 @@ void compile_multitarget(const std::string &fn_name,
 
         if (target == base_target) {
             can_use = IntImm::make(Int(32), 1);
-            base_target_args = module.functions().back().args;
+            base_target_args = module.get_function_by_name(sub_fn_name).args;
         }
 
         wrapper_args.push_back(can_use != 0);

--- a/src/Module.h
+++ b/src/Module.h
@@ -84,6 +84,10 @@ public:
     EXPORT const std::vector<Internal::LoweredFunc> &functions() const;
     // @}
 
+    /** Return the function with the given name. If no such function
+    * exists in this module, assert. */
+    EXPORT Internal::LoweredFunc get_function_by_name(const std::string &name) const;
+
     /** Add a declaration to this module. */
     // @{
     EXPORT void append(const Buffer<> &buffer);

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -680,12 +680,12 @@ void *Pipeline::compile_jit(const Target &target_arg) {
     // We need to infer the arguments again, because compiling (GPU
     // and offload targets) might have added new buffers we need to
     // embed.
-    infer_arguments(module.functions().back().body);
+    auto f = module.get_function_by_name(name);
+    infer_arguments(f.body);
 
     std::map<std::string, JITExtern> lowered_externs = contents->jit_externs;
     // Compile to jit module
-    JITModule jit_module(module, module.functions().back(),
-                         make_externs_jit_module(target_arg, lowered_externs));
+    JITModule jit_module(module, f, make_externs_jit_module(target_arg, lowered_externs));
 
     // Dump bitcode to a file if the environment variable
     // HL_GENBITCODE is defined to a nonzero value.


### PR DESCRIPTION
Some code assumes that functions().back() is the ‘public’ fn in a
Module, but this isn’t guaranteed and will change soon. Add a function
to look up by name and use it in a few relevant places.