### PR TITLE
Allow Generator::schedule() to be a std::function member var

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2203,10 +2203,10 @@ private:
     template <typename T2 = T,
               typename std::enable_if<has_generate_method<T2>::value>::type * = nullptr>
     void call_generate_impl() {
-        typedef typename std::result_of<decltype(&T::generate)(T)>::type GenerateRetType;
-        static_assert(std::is_void<GenerateRetType>::value, "generate() must return void");
+        T *t = (T*)this;
+        static_assert(std::is_void<decltype(t->generate())>::value, "generate() must return void");
         pre_generate();
-        ((T *)this)->generate();
+        t->generate();
         post_generate();
     }
 
@@ -2222,10 +2222,10 @@ private:
     template <typename T2 = T,
               typename std::enable_if<has_schedule_method<T2>::value>::type * = nullptr>
     void call_schedule_impl() {
-        typedef typename std::result_of<decltype(&T::schedule)(T)>::type ScheduleRetType;
-        static_assert(std::is_void<ScheduleRetType>::value, "schedule() must return void");
+        T *t = (T*)this;
+        static_assert(std::is_void<decltype(t->schedule())>::value, "schedule() must return void");
         pre_schedule();
-        ((T *)this)->schedule();
+        t->schedule();
         post_schedule();
     }
 

--- a/test/generator/pyramid_generator.cpp
+++ b/test/generator/pyramid_generator.cpp
@@ -7,40 +7,42 @@ public:
     GeneratorParam<int> levels{"levels", 1};  // deliberately wrong value, must be overridden to 10
 
     Input<Func> input{ "input", Float(32), 2 };
-
     Output<Func[]> pyramid{ "pyramid", Float(32), 2 }; 
 
     void generate() {
+        Var x{"x"}, y{"y"};
+
         pyramid.resize(levels);
-
         pyramid[0](x, y) = input(x, y);
-
         for (size_t i = 1; i < pyramid.size(); i++) {
-            pyramid[i](x, y) = downsample(pyramid[i-1])(x, y);
+            Func p = pyramid[i-1];
+            pyramid[i](x, y) = (p(2*x, 2*y) +
+                                p(2*x+1, 2*y) +
+                                p(2*x, 2*y+1) +
+                                p(2*x+1, 2*y+1))/4;
         }
-    }
-
-    void schedule() {
-        for (Func p : pyramid) {
-            // No need to specify compute_root() for outputs
-            p.parallel(y);
-            // Vectorize if we're still wide enough at this level
-            const int v = natural_vector_size<float>();
-            p.specialize(p.output_buffer().width() >= v).vectorize(x, v);
-        }
+    
+        // Be sure we set the 'schedule' member before we finish.
+        schedule = [=]() mutable {
+            for (Func p : pyramid) {
+                // No need to specify compute_root() for outputs
+                p.parallel(y);
+                // Vectorize if we're still wide enough at this level
+                const int v = natural_vector_size<float>();
+                p.specialize(p.output_buffer().width() >= v).vectorize(x, v);
+            }
+        };
      }
 
-private:
-    Var x, y;
-
-    Func downsample(Func big) {
-        Func small;
-        small(x, y) = (big(2*x, 2*y) +
-                       big(2*x+1, 2*y) +
-                       big(2*x, 2*y+1) +
-                       big(2*x+1, 2*y+1))/4;
-        return small;
-    }
+    // Note that you can define the schedule() method either as a conventional
+    // member method, *or*, a public std::function; for the latter approach, 
+    // you must ensure the value is set by the generate() method.
+    // The main reason to do this is to capture the scheduling instructions
+    // via a lambda function, allowing you to keep intermediate Funcs and Vars
+    // as captured automatic variables in the generate() method, rather than
+    // member variables at class scope. There is no intrinsic reason to prefer
+    // either approach; it is purely a stylistic preference.
+    std::function<void()> schedule;
 };
 
 Halide::RegisterGenerator<Pyramid> register_my_gen{"pyramid"};


### PR DESCRIPTION
The static_assert logic in Generator required schedule() to be an
actual member method; now it can also be a member variable (e.g.
std::function) that is filled in by the generate() method, to support
lambdas for scheduling. Modified pyramid_generator.cpp to use this
approach.