### PR TITLE
Limit max threads in simd_op_check

### DIFF
--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1963,6 +1963,7 @@ struct Test {
     }
 
     bool test_all() {
+        // Queue up a bunch of tasks representing each test to run.
         if (target.arch == Target::X86) {
             check_sse_all();
         } else if (target.arch == Target::ARM) {
@@ -1973,6 +1974,8 @@ struct Test {
             check_altivec_all();
         }
 
+        // Use a small thread pool to run the tests. Just statically
+        // partition the work between the threads.
         bool success = true;
         std::vector<std::thread> threads;
         for (size_t i = 0; i < num_threads; i++) {


### PR DESCRIPTION
simd op check was spinning up a thread for every test. This caused the OS X buildbot to barf with too many open files. I applied a similar strategy to the thread-safety test.

https://buildbot.halide-lang.org/master/builders/mac-64-391/builds/52/steps/make%20test_correctness_2/logs/stdio