### PR TITLE
Add GeneratorStub::realize_all()

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2304,10 +2304,18 @@ public:
         return get_first_output().realize(std::forward<Args>(args)..., get_target());
     }
 
-    template<typename Dst>
-    void realize(Dst dst) {
+    template<typename Realization>
+    void realize(Realization r) {
         check_scheduled("realize");
-        get_first_output().realize(dst, get_target());
+        get_first_output().realize(r, get_target());
+    }
+
+    // Note that the Realization here is expected to have the appropriate number-and-type
+    // of buffers to realize *all* of this Generator's Outputs (not just the first one).
+    template<typename Realization>
+    void realize_all(Realization r) {
+        check_scheduled("realize_all");
+        generator->produce_pipeline().realize(r, get_target());
     }
 
     virtual ~GeneratorStub() {}

--- a/test/generator/example_jittest.cpp
+++ b/test/generator/example_jittest.cpp
@@ -59,7 +59,8 @@ int main(int argc, char **argv) {
         sp.vectorize = false;
         gen.schedule(sp);
 
-        Halide::Buffer<int32_t> img = gen.realize(kSize, kSize, 3);
+        Halide::Buffer<int32_t> img(kSize, kSize, 3);
+        gen.realize_all(img);
         verify(img, 1, 1, 3);
     }
 


### PR DESCRIPTION
There wasn’t previously a convenient way to realize all of a
Generator’s Outputs in a single call.