### PR TITLE
print test should tread "-nan" output as "nan"

### DIFF
--- a/test/correctness/print.cpp
+++ b/test/correctness/print.cpp
@@ -158,10 +158,12 @@ int main(int argc, char **argv) {
         char correct[1024];
         for (int i = 0; i < N; i++) {
             snprintf(correct, sizeof(correct), "%f\n", imf(i));
-            // OS X prints -nan as nan
-            #ifdef __APPLE__
+            // Some versions of the std library can emit some NaN patterns
+            // as "-nan", due to sloppy conversion (or not) of the sign bit.
+            // Halide considers all NaN's equivalent, so paper over this
+            // noise in the test by normalizing all -nan -> nan.
             if (messages[i] == "-nan\n") messages[i] = "nan\n";
-            #endif
+            if (!strcmp(correct, "-nan\n")) strcpy(correct, "nan\n");
             if (messages[i] != correct) {
                 printf("float %d: %s vs %s for %10.20e\n", i, messages[i].c_str(), correct, imf(i));
                 return -1;


### PR DESCRIPTION
AFAIK, “-nan” is not actually a thing in IEEE754, and the fact that
some printf implementations can emit this string for some bit patterns
is a bug. The test here was special-casing it for __APPLE__, but I am
seeing it in other builds too.

(Note the old comment was wrong, and should have read “OSX prints some
nan values as -nan”)