### PR TITLE
Convert IROperator.h args to const-ref where trivial

### DIFF
--- a/src/Expr.h
+++ b/src/Expr.h
@@ -295,7 +295,7 @@ struct Expr : public Internal::IRHandle {
 /** This lets you use an Expr as a key in a map of the form
  * map<Expr, Foo, ExprCompare> */
 struct ExprCompare {
-    bool operator()(Expr a, Expr b) const {
+    bool operator()(const Expr &a, const Expr &b) const {
         return a.get() < b.get();
     }
 };

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -5,7 +5,7 @@
 namespace Halide {
 namespace Internal {
 
-Expr Cast::make(Type t, Expr v) {
+Expr Cast::make(Type t, const Expr &v) {
     internal_assert(v.defined()) << "Cast of undefined\n";
     internal_assert(t.lanes() == v.type().lanes()) << "Cast may not change vector widths\n";
 
@@ -15,7 +15,7 @@ Expr Cast::make(Type t, Expr v) {
     return node;
 }
 
-Expr Add::make(Expr a, Expr b) {
+Expr Add::make(const Expr &a, const Expr &b) {
     internal_assert(a.defined()) << "Add of undefined\n";
     internal_assert(b.defined()) << "Add of undefined\n";
     internal_assert(a.type() == b.type()) << "Add of mismatched types\n";
@@ -27,7 +27,7 @@ Expr Add::make(Expr a, Expr b) {
     return node;
 }
 
-Expr Sub::make(Expr a, Expr b) {
+Expr Sub::make(const Expr &a, const Expr &b) {
     internal_assert(a.defined()) << "Sub of undefined\n";
     internal_assert(b.defined()) << "Sub of undefined\n";
     internal_assert(a.type() == b.type()) << "Sub of mismatched types\n";
@@ -39,7 +39,7 @@ Expr Sub::make(Expr a, Expr b) {
     return node;
 }
 
-Expr Mul::make(Expr a, Expr b) {
+Expr Mul::make(const Expr &a, const Expr &b) {
     internal_assert(a.defined()) << "Mul of undefined\n";
     internal_assert(b.defined()) << "Mul of undefined\n";
     internal_assert(a.type() == b.type()) << "Mul of mismatched types\n";
@@ -51,7 +51,7 @@ Expr Mul::make(Expr a, Expr b) {
     return node;
 }
 
-Expr Div::make(Expr a, Expr b) {
+Expr Div::make(const Expr &a, const Expr &b) {
     internal_assert(a.defined()) << "Div of undefined\n";
     internal_assert(b.defined()) << "Div of undefined\n";
     internal_assert(a.type() == b.type()) << "Div of mismatched types\n";
@@ -63,7 +63,7 @@ Expr Div::make(Expr a, Expr b) {
     return node;
 }
 
-Expr Mod::make(Expr a, Expr b) {
+Expr Mod::make(const Expr &a, const Expr &b) {
     internal_assert(a.defined()) << "Mod of undefined\n";
     internal_assert(b.defined()) << "Mod of undefined\n";
     internal_assert(a.type() == b.type()) << "Mod of mismatched types\n";
@@ -75,7 +75,7 @@ Expr Mod::make(Expr a, Expr b) {
     return node;
 }
 
-Expr Min::make(Expr a, Expr b) {
+Expr Min::make(const Expr &a, const Expr &b) {
     internal_assert(a.defined()) << "Min of undefined\n";
     internal_assert(b.defined()) << "Min of undefined\n";
     internal_assert(a.type() == b.type()) << "Min of mismatched types\n";
@@ -87,7 +87,7 @@ Expr Min::make(Expr a, Expr b) {
     return node;
 }
 
-Expr Max::make(Expr a, Expr b) {
+Expr Max::make(const Expr &a, const Expr &b) {
     internal_assert(a.defined()) << "Max of undefined\n";
     internal_assert(b.defined()) << "Max of undefined\n";
     internal_assert(a.type() == b.type()) << "Max of mismatched types\n";
@@ -99,7 +99,7 @@ Expr Max::make(Expr a, Expr b) {
     return node;
 }
 
-Expr EQ::make(Expr a, Expr b) {
+Expr EQ::make(const Expr &a, const Expr &b) {
     internal_assert(a.defined()) << "EQ of undefined\n";
     internal_assert(b.defined()) << "EQ of undefined\n";
     internal_assert(a.type() == b.type()) << "EQ of mismatched types\n";
@@ -111,7 +111,7 @@ Expr EQ::make(Expr a, Expr b) {
     return node;
 }
 
-Expr NE::make(Expr a, Expr b) {
+Expr NE::make(const Expr &a, const Expr &b) {
     internal_assert(a.defined()) << "NE of undefined\n";
     internal_assert(b.defined()) << "NE of undefined\n";
     internal_assert(a.type() == b.type()) << "NE of mismatched types\n";
@@ -123,7 +123,7 @@ Expr NE::make(Expr a, Expr b) {
     return node;
 }
 
-Expr LT::make(Expr a, Expr b) {
+Expr LT::make(const Expr &a, const Expr &b) {
     internal_assert(a.defined()) << "LT of undefined\n";
     internal_assert(b.defined()) << "LT of undefined\n";
     internal_assert(a.type() == b.type()) << "LT of mismatched types\n";
@@ -136,7 +136,7 @@ Expr LT::make(Expr a, Expr b) {
 }
 
 
-Expr LE::make(Expr a, Expr b) {
+Expr LE::make(const Expr &a, const Expr &b) {
     internal_assert(a.defined()) << "LE of undefined\n";
     internal_assert(b.defined()) << "LE of undefined\n";
     internal_assert(a.type() == b.type()) << "LE of mismatched types\n";
@@ -148,7 +148,7 @@ Expr LE::make(Expr a, Expr b) {
     return node;
 }
 
-Expr GT::make(Expr a, Expr b) {
+Expr GT::make(const Expr &a, const Expr &b) {
     internal_assert(a.defined()) << "GT of undefined\n";
     internal_assert(b.defined()) << "GT of undefined\n";
     internal_assert(a.type() == b.type()) << "GT of mismatched types\n";
@@ -161,7 +161,7 @@ Expr GT::make(Expr a, Expr b) {
 }
 
 
-Expr GE::make(Expr a, Expr b) {
+Expr GE::make(const Expr &a, const Expr &b) {
     internal_assert(a.defined()) << "GE of undefined\n";
     internal_assert(b.defined()) << "GE of undefined\n";
     internal_assert(a.type() == b.type()) << "GE of mismatched types\n";
@@ -173,7 +173,7 @@ Expr GE::make(Expr a, Expr b) {
     return node;
 }
 
-Expr And::make(Expr a, Expr b) {
+Expr And::make(const Expr &a, const Expr &b) {
     internal_assert(a.defined()) << "And of undefined\n";
     internal_assert(b.defined()) << "And of undefined\n";
     internal_assert(a.type().is_bool()) << "lhs of And is not a bool\n";
@@ -187,7 +187,7 @@ Expr And::make(Expr a, Expr b) {
     return node;
 }
 
-Expr Or::make(Expr a, Expr b) {
+Expr Or::make(const Expr &a, const Expr &b) {
     internal_assert(a.defined()) << "Or of undefined\n";
     internal_assert(b.defined()) << "Or of undefined\n";
     internal_assert(a.type().is_bool()) << "lhs of Or is not a bool\n";
@@ -201,7 +201,7 @@ Expr Or::make(Expr a, Expr b) {
     return node;
 }
 
-Expr Not::make(Expr a) {
+Expr Not::make(const Expr &a) {
     internal_assert(a.defined()) << "Not of undefined\n";
     internal_assert(a.type().is_bool()) << "argument of Not is not a bool\n";
 
@@ -211,7 +211,7 @@ Expr Not::make(Expr a) {
     return node;
 }
 
-Expr Select::make(Expr condition, Expr true_value, Expr false_value) {
+Expr Select::make(const Expr &condition, const Expr &true_value, const Expr &false_value) {
     internal_assert(condition.defined()) << "Select of undefined\n";
     internal_assert(true_value.defined()) << "Select of undefined\n";
     internal_assert(false_value.defined()) << "Select of undefined\n";
@@ -229,7 +229,7 @@ Expr Select::make(Expr condition, Expr true_value, Expr false_value) {
     return node;
 }
 
-Expr Load::make(Type type, std::string name, Expr index, Buffer<> image, Parameter param, Expr predicate) {
+Expr Load::make(Type type, const std::string &name, const Expr &index, Buffer<> image, Parameter param, const Expr &predicate) {
     internal_assert(predicate.defined()) << "Load with undefined predicate\n";
     internal_assert(index.defined()) << "Load of undefined\n";
     internal_assert(type.lanes() == index.type().lanes()) << "Vector lanes of Load must match vector lanes of index\n";
@@ -246,7 +246,7 @@ Expr Load::make(Type type, std::string name, Expr index, Buffer<> image, Paramet
     return node;
 }
 
-Expr Ramp::make(Expr base, Expr stride, int lanes) {
+Expr Ramp::make(const Expr &base, const Expr &stride, int lanes) {
     internal_assert(base.defined()) << "Ramp of undefined\n";
     internal_assert(stride.defined()) << "Ramp of undefined\n";
     internal_assert(base.type().is_scalar()) << "Ramp with vector base\n";
@@ -262,7 +262,7 @@ Expr Ramp::make(Expr base, Expr stride, int lanes) {
     return node;
 }
 
-Expr Broadcast::make(Expr value, int lanes) {
+Expr Broadcast::make(const Expr &value, int lanes) {
     internal_assert(value.defined()) << "Broadcast of undefined\n";
     internal_assert(value.type().is_scalar()) << "Broadcast of vector\n";
     internal_assert(lanes != 1) << "Broadcast of lanes 1\n";
@@ -274,7 +274,7 @@ Expr Broadcast::make(Expr value, int lanes) {
     return node;
 }
 
-Expr Let::make(std::string name, Expr value, Expr body) {
+Expr Let::make(const std::string &name, const Expr &value, const Expr &body) {
     internal_assert(value.defined()) << "Let of undefined\n";
     internal_assert(body.defined()) << "Let of undefined\n";
 
@@ -286,7 +286,7 @@ Expr Let::make(std::string name, Expr value, Expr body) {
     return node;
 }
 
-Stmt LetStmt::make(std::string name, Expr value, Stmt body) {
+Stmt LetStmt::make(const std::string &name, const Expr &value, const Stmt &body) {
     internal_assert(value.defined()) << "Let of undefined\n";
     internal_assert(body.defined()) << "Let of undefined\n";
 
@@ -297,7 +297,7 @@ Stmt LetStmt::make(std::string name, Expr value, Stmt body) {
     return node;
 }
 
-Stmt AssertStmt::make(Expr condition, Expr message) {
+Stmt AssertStmt::make(const Expr &condition, const Expr &message) {
     internal_assert(condition.defined()) << "AssertStmt of undefined\n";
     internal_assert(message.type() == Int(32)) << "AssertStmt message must be an int:" << message << "\n";
 
@@ -307,7 +307,7 @@ Stmt AssertStmt::make(Expr condition, Expr message) {
     return node;
 }
 
-Stmt ProducerConsumer::make(std::string name, bool is_producer, Stmt body) {
+Stmt ProducerConsumer::make(const std::string &name, bool is_producer, const Stmt &body) {
     internal_assert(body.defined()) << "ProducerConsumer of undefined\n";
 
     ProducerConsumer *node = new ProducerConsumer;
@@ -317,15 +317,15 @@ Stmt ProducerConsumer::make(std::string name, bool is_producer, Stmt body) {
     return node;
 }
 
-Stmt ProducerConsumer::make_produce(std::string name, Stmt body) {
+Stmt ProducerConsumer::make_produce(const std::string &name, const Stmt &body) {
     return ProducerConsumer::make(name, true, body);
 }
 
-Stmt ProducerConsumer::make_consume(std::string name, Stmt body) {
+Stmt ProducerConsumer::make_consume(const std::string &name, const Stmt &body) {
     return ProducerConsumer::make(name, false, body);
 }
 
-Stmt For::make(std::string name, Expr min, Expr extent, ForType for_type, DeviceAPI device_api, Stmt body) {
+Stmt For::make(const std::string &name, const Expr &min, const Expr &extent, ForType for_type, DeviceAPI device_api, const Stmt &body) {
     internal_assert(min.defined()) << "For of undefined\n";
     internal_assert(extent.defined()) << "For of undefined\n";
     internal_assert(min.type().is_scalar()) << "For with vector min\n";
@@ -342,7 +342,7 @@ Stmt For::make(std::string name, Expr min, Expr extent, ForType for_type, Device
     return node;
 }
 
-Stmt Store::make(std::string name, Expr value, Expr index, Parameter param, Expr predicate) {
+Stmt Store::make(const std::string &name, const Expr &value, const Expr &index, Parameter param, const Expr &predicate) {
     internal_assert(predicate.defined()) << "Store with undefined predicate\n";
     internal_assert(value.defined()) << "Store of undefined\n";
     internal_assert(index.defined()) << "Store of undefined\n";
@@ -359,7 +359,7 @@ Stmt Store::make(std::string name, Expr value, Expr index, Parameter param, Expr
     return node;
 }
 
-Stmt Provide::make(std::string name, const std::vector<Expr> &values, const std::vector<Expr> &args) {
+Stmt Provide::make(const std::string &name, const std::vector<Expr> &values, const std::vector<Expr> &args) {
     internal_assert(!values.empty()) << "Provide of no values\n";
     for (size_t i = 0; i < values.size(); i++) {
         internal_assert(values[i].defined()) << "Provide of undefined value\n";
@@ -375,9 +375,9 @@ Stmt Provide::make(std::string name, const std::vector<Expr> &values, const std:
     return node;
 }
 
-Stmt Allocate::make(std::string name, Type type, const std::vector<Expr> &extents,
-                    Expr condition, Stmt body,
-                    Expr new_expr, std::string free_function) {
+Stmt Allocate::make(const std::string &name, Type type, const std::vector<Expr> &extents,
+                    const Expr &condition, const Stmt &body,
+                    const Expr &new_expr, const std::string &free_function) {
     for (size_t i = 0; i < extents.size(); i++) {
         internal_assert(extents[i].defined()) << "Allocate of undefined extent\n";
         internal_assert(extents[i].type().is_scalar() == 1) << "Allocate of vector extent\n";
@@ -432,13 +432,13 @@ int32_t Allocate::constant_allocation_size() const {
     return Allocate::constant_allocation_size(extents, name);
 }
 
-Stmt Free::make(std::string name) {
+Stmt Free::make(const std::string &name) {
     Free *node = new Free;
     node->name = name;
     return node;
 }
 
-Stmt Realize::make(const std::string &name, const std::vector<Type> &types, const Region &bounds, Expr condition, Stmt body) {
+Stmt Realize::make(const std::string &name, const std::vector<Type> &types, const Region &bounds, const Expr &condition, const Stmt &body) {
     for (size_t i = 0; i < bounds.size(); i++) {
         internal_assert(bounds[i].min.defined()) << "Realize of undefined\n";
         internal_assert(bounds[i].extent.defined()) << "Realize of undefined\n";
@@ -459,7 +459,7 @@ Stmt Realize::make(const std::string &name, const std::vector<Type> &types, cons
     return node;
 }
 
-Stmt Block::make(Stmt first, Stmt rest) {
+Stmt Block::make(const Stmt &first, const Stmt &rest) {
     internal_assert(first.defined()) << "Block of undefined\n";
     internal_assert(rest.defined()) << "Block of undefined\n";
 
@@ -488,7 +488,7 @@ Stmt Block::make(const std::vector<Stmt> &stmts) {
     return result;
 }
 
-Stmt IfThenElse::make(Expr condition, Stmt then_case, Stmt else_case) {
+Stmt IfThenElse::make(const Expr &condition, const Stmt &then_case, const Stmt &else_case) {
     internal_assert(condition.defined() && then_case.defined()) << "IfThenElse of undefined\n";
     // else_case may be null.
 
@@ -499,7 +499,7 @@ Stmt IfThenElse::make(Expr condition, Stmt then_case, Stmt else_case) {
     return node;
 }
 
-Stmt Evaluate::make(Expr v) {
+Stmt Evaluate::make(const Expr &v) {
     internal_assert(v.defined()) << "Evaluate of undefined\n";
 
     Evaluate *node = new Evaluate;
@@ -516,7 +516,7 @@ Expr Call::make(Function func, const std::vector<Expr> &args, int idx) {
     return make(func.output_types()[(size_t)idx], func.name(), args, Halide, func.get_contents(), idx, Buffer<>(), Parameter());
 }
 
-Expr Call::make(Type type, std::string name, const std::vector<Expr> &args, CallType call_type,
+Expr Call::make(Type type, const std::string &name, const std::vector<Expr> &args, CallType call_type,
                 IntrusivePtr<FunctionContents> func, int value_index,
                 Buffer<> image, Parameter param) {
     for (size_t i = 0; i < args.size(); i++) {
@@ -548,7 +548,7 @@ Expr Call::make(Type type, std::string name, const std::vector<Expr> &args, Call
     return node;
 }
 
-Expr Variable::make(Type type, std::string name, Buffer<> image, Parameter param, ReductionDomain reduction_domain) {
+Expr Variable::make(Type type, const std::string &name, Buffer<> image, Parameter param, ReductionDomain reduction_domain) {
     internal_assert(!name.empty());
     Variable *node = new Variable;
     node->type = type;
@@ -622,7 +622,7 @@ Expr Shuffle::make_concat(const std::vector<Expr> &vectors) {
     return make(vectors, indices);
 }
 
-Expr Shuffle::make_slice(Expr vector, int begin, int stride, int size) {
+Expr Shuffle::make_slice(const Expr &vector, int begin, int stride, int size) {
     if (begin == 0 && size == vector.type().lanes() && stride == 1) {
         return vector;
     }
@@ -635,7 +635,7 @@ Expr Shuffle::make_slice(Expr vector, int begin, int stride, int size) {
     return make({vector}, indices);
 }
 
-Expr Shuffle::make_extract_element(Expr vector, int i) {
+Expr Shuffle::make_extract_element(const Expr &vector, int i) {
     return make_slice(vector, i, 1, 1);
 }
 

--- a/src/IR.h
+++ b/src/IR.h
@@ -28,7 +28,7 @@ namespace Internal {
 struct Cast : public ExprNode<Cast> {
     Expr value;
 
-    EXPORT static Expr make(Type t, Expr v);
+    EXPORT static Expr make(Type t, const Expr &v);
 
     static const IRNodeType _type_info = IRNodeType::Cast;
 };
@@ -37,7 +37,7 @@ struct Cast : public ExprNode<Cast> {
 struct Add : public ExprNode<Add> {
     Expr a, b;
 
-    EXPORT static Expr make(Expr a, Expr b);
+    EXPORT static Expr make(const Expr &a, const Expr &b);
 
     static const IRNodeType _type_info = IRNodeType::Add;
 };
@@ -46,7 +46,7 @@ struct Add : public ExprNode<Add> {
 struct Sub : public ExprNode<Sub> {
     Expr a, b;
 
-    EXPORT static Expr make(Expr a, Expr b);
+    EXPORT static Expr make(const Expr &a, const Expr &b);
 
     static const IRNodeType _type_info = IRNodeType::Sub;
 };
@@ -55,7 +55,7 @@ struct Sub : public ExprNode<Sub> {
 struct Mul : public ExprNode<Mul> {
     Expr a, b;
 
-    EXPORT static Expr make(Expr a, Expr b);
+    EXPORT static Expr make(const Expr &a, const Expr &b);
 
     static const IRNodeType _type_info = IRNodeType::Mul;
 };
@@ -64,7 +64,7 @@ struct Mul : public ExprNode<Mul> {
 struct Div : public ExprNode<Div> {
     Expr a, b;
 
-    EXPORT static Expr make(Expr a, Expr b);
+    EXPORT static Expr make(const Expr &a, const Expr &b);
 
     static const IRNodeType _type_info = IRNodeType::Div;
 };
@@ -75,7 +75,7 @@ struct Div : public ExprNode<Div> {
 struct Mod : public ExprNode<Mod> {
     Expr a, b;
 
-    EXPORT static Expr make(Expr a, Expr b);
+    EXPORT static Expr make(const Expr &a, const Expr &b);
 
     static const IRNodeType _type_info = IRNodeType::Mod;
 };
@@ -84,7 +84,7 @@ struct Mod : public ExprNode<Mod> {
 struct Min : public ExprNode<Min> {
     Expr a, b;
 
-    EXPORT static Expr make(Expr a, Expr b);
+    EXPORT static Expr make(const Expr &a, const Expr &b);
 
     static const IRNodeType _type_info = IRNodeType::Min;
 };
@@ -93,7 +93,7 @@ struct Min : public ExprNode<Min> {
 struct Max : public ExprNode<Max> {
     Expr a, b;
 
-    EXPORT static Expr make(Expr a, Expr b);
+    EXPORT static Expr make(const Expr &a, const Expr &b);
 
     static const IRNodeType _type_info = IRNodeType::Max;
 };
@@ -102,7 +102,7 @@ struct Max : public ExprNode<Max> {
 struct EQ : public ExprNode<EQ> {
     Expr a, b;
 
-    EXPORT static Expr make(Expr a, Expr b);
+    EXPORT static Expr make(const Expr &a, const Expr &b);
 
     static const IRNodeType _type_info = IRNodeType::EQ;
 };
@@ -111,7 +111,7 @@ struct EQ : public ExprNode<EQ> {
 struct NE : public ExprNode<NE> {
     Expr a, b;
 
-    EXPORT static Expr make(Expr a, Expr b);
+    EXPORT static Expr make(const Expr &a, const Expr &b);
 
     static const IRNodeType _type_info = IRNodeType::NE;
 };
@@ -120,7 +120,7 @@ struct NE : public ExprNode<NE> {
 struct LT : public ExprNode<LT> {
     Expr a, b;
 
-    EXPORT static Expr make(Expr a, Expr b);
+    EXPORT static Expr make(const Expr &a, const Expr &b);
 
     static const IRNodeType _type_info = IRNodeType::LT;
 };
@@ -129,7 +129,7 @@ struct LT : public ExprNode<LT> {
 struct LE : public ExprNode<LE> {
     Expr a, b;
 
-    EXPORT static Expr make(Expr a, Expr b);
+    EXPORT static Expr make(const Expr &a, const Expr &b);
 
     static const IRNodeType _type_info = IRNodeType::LE;
 };
@@ -138,7 +138,7 @@ struct LE : public ExprNode<LE> {
 struct GT : public ExprNode<GT> {
     Expr a, b;
 
-    EXPORT static Expr make(Expr a, Expr b);
+    EXPORT static Expr make(const Expr &a, const Expr &b);
 
     static const IRNodeType _type_info = IRNodeType::GT;
 };
@@ -147,7 +147,7 @@ struct GT : public ExprNode<GT> {
 struct GE : public ExprNode<GE> {
     Expr a, b;
 
-    EXPORT static Expr make(Expr a, Expr b);
+    EXPORT static Expr make(const Expr &a, const Expr &b);
 
     static const IRNodeType _type_info = IRNodeType::GE;
 };
@@ -156,7 +156,7 @@ struct GE : public ExprNode<GE> {
 struct And : public ExprNode<And> {
     Expr a, b;
 
-    EXPORT static Expr make(Expr a, Expr b);
+    EXPORT static Expr make(const Expr &a, const Expr &b);
 
     static const IRNodeType _type_info = IRNodeType::And;
 };
@@ -165,7 +165,7 @@ struct And : public ExprNode<And> {
 struct Or : public ExprNode<Or> {
     Expr a, b;
 
-    EXPORT static Expr make(Expr a, Expr b);
+    EXPORT static Expr make(const Expr &a, const Expr &b);
 
     static const IRNodeType _type_info = IRNodeType::Or;
 };
@@ -174,7 +174,7 @@ struct Or : public ExprNode<Or> {
 struct Not : public ExprNode<Not> {
     Expr a;
 
-    EXPORT static Expr make(Expr a);
+    EXPORT static Expr make(const Expr &a);
 
     static const IRNodeType _type_info = IRNodeType::Not;
 };
@@ -185,7 +185,7 @@ struct Not : public ExprNode<Not> {
 struct Select : public ExprNode<Select> {
     Expr condition, true_value, false_value;
 
-    EXPORT static Expr make(Expr condition, Expr true_value, Expr false_value);
+    EXPORT static Expr make(const Expr &condition, const Expr &true_value, const Expr &false_value);
 
     static const IRNodeType _type_info = IRNodeType::Select;
 };
@@ -205,8 +205,9 @@ struct Load : public ExprNode<Load> {
     // If it's a load from an image parameter, this points to that
     Parameter param;
 
-    EXPORT static Expr make(Type type, std::string name, Expr index, Buffer<> image,
-                            Parameter param, Expr predicate);
+    EXPORT static Expr make(Type type, const std::string &name, 
+                            const Expr &index, Buffer<> image, 
+                            Parameter param, const Expr &predicate);
 
     static const IRNodeType _type_info = IRNodeType::Load;
 };
@@ -220,7 +221,7 @@ struct Ramp : public ExprNode<Ramp> {
     Expr base, stride;
     int lanes;
 
-    EXPORT static Expr make(Expr base, Expr stride, int lanes);
+    EXPORT static Expr make(const Expr &base, const Expr &stride, int lanes);
 
     static const IRNodeType _type_info = IRNodeType::Ramp;
 };
@@ -232,7 +233,7 @@ struct Broadcast : public ExprNode<Broadcast> {
     Expr value;
     int lanes;
 
-    EXPORT static Expr make(Expr value, int lanes);
+    EXPORT static Expr make(const Expr &value, int lanes);
 
     static const IRNodeType _type_info = IRNodeType::Broadcast;
 };
@@ -244,7 +245,7 @@ struct Let : public ExprNode<Let> {
     std::string name;
     Expr value, body;
 
-    EXPORT static Expr make(std::string name, Expr value, Expr body);
+    EXPORT static Expr make(const std::string &name, const Expr &value, const Expr &body);
 
     static const IRNodeType _type_info = IRNodeType::Let;
 };
@@ -256,7 +257,7 @@ struct LetStmt : public StmtNode<LetStmt> {
     Expr value;
     Stmt body;
 
-    EXPORT static Stmt make(std::string name, Expr value, Stmt body);
+    EXPORT static Stmt make(const std::string &name, const Expr &value, const Stmt &body);
 
     static const IRNodeType _type_info = IRNodeType::LetStmt;
 };
@@ -268,7 +269,7 @@ struct AssertStmt : public StmtNode<AssertStmt> {
     Expr condition;
     Expr message;
 
-    EXPORT static Stmt make(Expr condition, Expr message);
+    EXPORT static Stmt make(const Expr &condition, const Expr &message);
 
     static const IRNodeType _type_info = IRNodeType::AssertStmt;
 };
@@ -289,10 +290,10 @@ struct ProducerConsumer : public StmtNode<ProducerConsumer> {
     bool is_producer;
     Stmt body;
 
-    EXPORT static Stmt make(std::string name, bool is_producer, Stmt body);
+    EXPORT static Stmt make(const std::string &name, bool is_producer, const Stmt &body);
 
-    EXPORT static Stmt make_produce(std::string name, Stmt body);
-    EXPORT static Stmt make_consume(std::string name, Stmt body);
+    EXPORT static Stmt make_produce(const std::string &name, const Stmt &body);
+    EXPORT static Stmt make_consume(const std::string &name, const Stmt &body);
 
     static const IRNodeType _type_info = IRNodeType::ProducerConsumer;
 };
@@ -306,8 +307,8 @@ struct Store : public StmtNode<Store> {
     // If it's a store to an output buffer, then this parameter points to it.
     Parameter param;
 
-    EXPORT static Stmt make(std::string name, Expr value, Expr index,
-                            Parameter param, Expr predicate);
+    EXPORT static Stmt make(const std::string &name, const Expr &value, const Expr &index,
+                            Parameter param, const Expr &predicate);
 
     static const IRNodeType _type_info = IRNodeType::Store;
 };
@@ -321,7 +322,7 @@ struct Provide : public StmtNode<Provide> {
     std::vector<Expr> values;
     std::vector<Expr> args;
 
-    EXPORT static Stmt make(std::string name, const std::vector<Expr> &values, const std::vector<Expr> &args);
+    EXPORT static Stmt make(const std::string &name, const std::vector<Expr> &values, const std::vector<Expr> &args);
 
     static const IRNodeType _type_info = IRNodeType::Provide;
 };
@@ -348,9 +349,9 @@ struct Allocate : public StmtNode<Allocate> {
     std::string free_function;
     Stmt body;
 
-    EXPORT static Stmt make(std::string name, Type type, const std::vector<Expr> &extents,
-                            Expr condition, Stmt body,
-                            Expr new_expr = Expr(), std::string free_function = std::string());
+    EXPORT static Stmt make(const std::string &name, Type type, const std::vector<Expr> &extents,
+                            const Expr &condition, const Stmt &body,
+                            const Expr &new_expr = Expr(), const std::string &free_function = std::string());
 
     /** A routine to check if the extents are all constants, and if so verify
      * the total size is less than 2^31 - 1. If the result is constant, but
@@ -367,7 +368,7 @@ struct Allocate : public StmtNode<Allocate> {
 struct Free : public StmtNode<Free> {
     std::string name;
 
-    EXPORT static Stmt make(std::string name);
+    EXPORT static Stmt make(const std::string &name);
 
     static const IRNodeType _type_info = IRNodeType::Free;
 };
@@ -377,7 +378,7 @@ struct Free : public StmtNode<Free> {
 struct Range {
     Expr min, extent;
     Range() {}
-    Range(Expr min, Expr extent) : min(min), extent(extent) {
+    Range(const Expr &min, const Expr &extent) : min(min), extent(extent) {
         internal_assert(min.type() == extent.type()) << "Region min and extent must have same type\n";
     }
 };
@@ -397,7 +398,7 @@ struct Realize : public StmtNode<Realize> {
     Expr condition;
     Stmt body;
 
-    EXPORT static Stmt make(const std::string &name, const std::vector<Type> &types, const Region &bounds, Expr condition, Stmt body);
+    EXPORT static Stmt make(const std::string &name, const std::vector<Type> &types, const Region &bounds, const Expr &condition, const Stmt &body);
 
     static const IRNodeType _type_info = IRNodeType::Realize;
 
@@ -408,7 +409,7 @@ struct Realize : public StmtNode<Realize> {
 struct Block : public StmtNode<Block> {
     Stmt first, rest;
 
-    EXPORT static Stmt make(Stmt first, Stmt rest);
+    EXPORT static Stmt make(const Stmt &first, const Stmt &rest);
     EXPORT static Stmt make(const std::vector<Stmt> &stmts);
 
     static const IRNodeType _type_info = IRNodeType::Block;
@@ -419,7 +420,7 @@ struct IfThenElse : public StmtNode<IfThenElse> {
     Expr condition;
     Stmt then_case, else_case;
 
-    EXPORT static Stmt make(Expr condition, Stmt then_case, Stmt else_case = Stmt());
+    EXPORT static Stmt make(const Expr &condition, const Stmt &then_case, const Stmt &else_case = Stmt());
 
     static const IRNodeType _type_info = IRNodeType::IfThenElse;
 };
@@ -428,7 +429,7 @@ struct IfThenElse : public StmtNode<IfThenElse> {
 struct Evaluate : public StmtNode<Evaluate> {
     Expr value;
 
-    EXPORT static Stmt make(Expr v);
+    EXPORT static Stmt make(const Expr &v);
 
     static const IRNodeType _type_info = IRNodeType::Evaluate;
 };
@@ -534,7 +535,7 @@ struct Call : public ExprNode<Call> {
     // pointer to that
     Parameter param;
 
-    EXPORT static Expr make(Type type, std::string name, const std::vector<Expr> &args, CallType call_type,
+    EXPORT static Expr make(Type type, const std::string &name, const std::vector<Expr> &args, CallType call_type,
                             IntrusivePtr<FunctionContents> func = nullptr, int value_index = 0,
                             Buffer<> image = Buffer<>(), Parameter param = Parameter());
 
@@ -589,23 +590,23 @@ struct Variable : public ExprNode<Variable> {
     /** Reduction variables hang onto their domains */
     ReductionDomain reduction_domain;
 
-    static Expr make(Type type, std::string name) {
+    static Expr make(Type type, const std::string &name) {
         return make(type, name, Buffer<>(), Parameter(), ReductionDomain());
     }
 
-    static Expr make(Type type, std::string name, Parameter param) {
+    static Expr make(Type type, const std::string &name, Parameter param) {
         return make(type, name, Buffer<>(), param, ReductionDomain());
     }
 
-    static Expr make(Type type, std::string name, Buffer<> image) {
+    static Expr make(Type type, const std::string &name, Buffer<> image) {
         return make(type, name, image, Parameter(), ReductionDomain());
     }
 
-    static Expr make(Type type, std::string name, ReductionDomain reduction_domain) {
+    static Expr make(Type type, const std::string &name, ReductionDomain reduction_domain) {
         return make(type, name, Buffer<>(), Parameter(), reduction_domain);
     }
 
-    EXPORT static Expr make(Type type, std::string name, Buffer<> image,
+    EXPORT static Expr make(Type type, const std::string &name, Buffer<> image,
                             Parameter param, ReductionDomain reduction_domain);
 
     static const IRNodeType _type_info = IRNodeType::Variable;
@@ -630,7 +631,7 @@ struct For : public StmtNode<For> {
     DeviceAPI device_api;
     Stmt body;
 
-    EXPORT static Stmt make(std::string name, Expr min, Expr extent, ForType for_type, DeviceAPI device_api, Stmt body);
+    EXPORT static Stmt make(const std::string &name, const Expr &min, const Expr &extent, ForType for_type, DeviceAPI device_api, const Stmt &body);
 
     bool is_parallel() const {
         return (for_type == ForType::Parallel ||
@@ -664,11 +665,11 @@ struct Shuffle : public ExprNode<Shuffle> {
 
     /** Convenience constructor for making a shuffle representing a
      * contiguous subset of a vector. */
-    EXPORT static Expr make_slice(Expr vector, int begin, int stride, int size);
+    EXPORT static Expr make_slice(const Expr &vector, int begin, int stride, int size);
 
     /** Convenience constructor for making a shuffle representing
      * extracting a single element. */
-    EXPORT static Expr make_extract_element(Expr vector, int i);
+    EXPORT static Expr make_extract_element(const Expr &vector, int i);
 
     /** Check if this shuffle is an interleaving of the vector
      * arguments. */

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -16,7 +16,7 @@ namespace Halide {
 // into account. The high order terms come first. n is the number of
 // terms, which is the degree plus one.
 namespace {
-Expr evaluate_polynomial(Expr x, float *coeff, int n) {
+Expr evaluate_polynomial(const Expr &x, float *coeff, int n) {
     internal_assert(n >= 2);
 
     Expr x2 = x * x;
@@ -50,7 +50,7 @@ Expr evaluate_polynomial(Expr x, float *coeff, int n) {
 
 namespace Internal {
 
-bool is_const(Expr e) {
+bool is_const(const Expr &e) {
     if (e.as<IntImm>() ||
         e.as<UIntImm>() ||
         e.as<FloatImm>() ||
@@ -67,7 +67,7 @@ bool is_const(Expr e) {
     }
 }
 
-bool is_const(Expr e, int64_t value) {
+bool is_const(const Expr &e, int64_t value) {
     if (const IntImm *i = e.as<IntImm>()) {
         return i->value == value;
     } else if (const UIntImm *i = e.as<UIntImm>()) {
@@ -83,13 +83,13 @@ bool is_const(Expr e, int64_t value) {
     }
 }
 
-bool is_no_op(Stmt s) {
+bool is_no_op(const Stmt &s) {
     if (!s.defined()) return true;
     const Evaluate *e = s.as<Evaluate>();
     return e && is_const(e->value);
 }
 
-const int64_t *as_const_int(Expr e) {
+const int64_t *as_const_int(const Expr &e) {
     if (!e.defined()) {
         return nullptr;
     } else if (const Broadcast *b = e.as<Broadcast>()) {
@@ -101,7 +101,7 @@ const int64_t *as_const_int(Expr e) {
     }
 }
 
-const uint64_t *as_const_uint(Expr e) {
+const uint64_t *as_const_uint(const Expr &e) {
     if (!e.defined()) {
         return nullptr;
     } else if (const Broadcast *b = e.as<Broadcast>()) {
@@ -113,7 +113,7 @@ const uint64_t *as_const_uint(Expr e) {
     }
 }
 
-const double *as_const_float(Expr e) {
+const double *as_const_float(const Expr &e) {
     if (!e.defined()) {
         return nullptr;
     } else if (const Broadcast *b = e.as<Broadcast>()) {
@@ -125,7 +125,7 @@ const double *as_const_float(Expr e) {
     }
 }
 
-bool is_const_power_of_two_integer(Expr e, int *bits) {
+bool is_const_power_of_two_integer(const Expr &e, int *bits) {
     if (!(e.type().is_int() || e.type().is_uint())) return false;
 
     const Broadcast *b = e.as<Broadcast>();
@@ -154,7 +154,7 @@ bool is_const_power_of_two_integer(Expr e, int *bits) {
     return false;
 }
 
-bool is_positive_const(Expr e) {
+bool is_positive_const(const Expr &e) {
     if (const IntImm *i = e.as<IntImm>()) return i->value > 0;
     if (const UIntImm *u = e.as<UIntImm>()) return u->value > 0;
     if (const FloatImm *f = e.as<FloatImm>()) return f->value > 0.0f;
@@ -171,7 +171,7 @@ bool is_positive_const(Expr e) {
     return false;
 }
 
-bool is_negative_const(Expr e) {
+bool is_negative_const(const Expr &e) {
     if (const IntImm *i = e.as<IntImm>()) return i->value < 0;
     if (const FloatImm *f = e.as<FloatImm>()) return f->value < 0.0f;
     if (const Cast *c = e.as<Cast>()) {
@@ -187,7 +187,7 @@ bool is_negative_const(Expr e) {
     return false;
 }
 
-bool is_negative_negatable_const(Expr e, Type T) {
+bool is_negative_negatable_const(const Expr &e, Type T) {
     if (const IntImm *i = e.as<IntImm>()) {
         return (i->value < 0 && !T.is_min(i->value));
     }
@@ -205,16 +205,16 @@ bool is_negative_negatable_const(Expr e, Type T) {
     return false;
 }
 
-bool is_negative_negatable_const(Expr e) {
+bool is_negative_negatable_const(const Expr &e) {
     return is_negative_negatable_const(e, e.type());
 }
 
-bool is_undef(Expr e) {
+bool is_undef(const Expr &e) {
     if (const Call *c = e.as<Call>()) return c->is_intrinsic(Call::undef);
     return false;
 }
 
-bool is_zero(Expr e) {
+bool is_zero(const Expr &e) {
     if (const IntImm *int_imm = e.as<IntImm>()) return int_imm->value == 0;
     if (const UIntImm *uint_imm = e.as<UIntImm>()) return uint_imm->value == 0;
     if (const FloatImm *float_imm = e.as<FloatImm>()) return float_imm->value == 0.0;
@@ -227,7 +227,7 @@ bool is_zero(Expr e) {
     return false;
 }
 
-bool is_one(Expr e) {
+bool is_one(const Expr &e) {
     if (const IntImm *int_imm = e.as<IntImm>()) return int_imm->value == 1;
     if (const UIntImm *uint_imm = e.as<UIntImm>()) return uint_imm->value == 1;
     if (const FloatImm *float_imm = e.as<FloatImm>()) return float_imm->value == 1.0;
@@ -240,7 +240,7 @@ bool is_one(Expr e) {
     return false;
 }
 
-bool is_two(Expr e) {
+bool is_two(const Expr &e) {
     if (e.type().bits() < 2) return false;
     if (const IntImm *int_imm = e.as<IntImm>()) return int_imm->value == 2;
     if (const UIntImm *uint_imm = e.as<UIntImm>()) return uint_imm->value == 2;
@@ -309,7 +309,7 @@ Expr const_false(int w) {
     return make_zero(UInt(1, w));
 }
 
-Expr lossless_cast(Type t, Expr e) {
+Expr lossless_cast(Type t, const Expr &e) {
     if (t == e.type()) {
         return e;
     } else if (t.can_represent(e.type())) {
@@ -425,7 +425,7 @@ void match_types(Expr &a, Expr &b) {
 // Fast math ops based on those from Syrah (http://github.com/boulos/syrah). Thanks, Solomon!
 
 // Factor a float into 2^exponent * reduced, where reduced is between 0.75 and 1.5
-void range_reduce_log(Expr input, Expr *reduced, Expr *exponent) {
+void range_reduce_log(const Expr &input, Expr *reduced, Expr *exponent) {
     Type type = input.type();
     Type int_type = Int(32, type.lanes());
     Expr int_version = reinterpret(int_type, input);
@@ -454,7 +454,7 @@ void range_reduce_log(Expr input, Expr *reduced, Expr *exponent) {
     *reduced = reinterpret(type, blended);
 }
 
-Expr halide_log(Expr x_full) {
+Expr halide_log(const Expr &x_full) {
     Type type = x_full.type();
     internal_assert(type.element_of() == Float(32));
 
@@ -498,7 +498,7 @@ Expr halide_log(Expr x_full) {
     return result;
 }
 
-Expr halide_exp(Expr x_full) {
+Expr halide_exp(const Expr &x_full) {
     Type type = x_full.type();
     internal_assert(type.element_of() == Float(32));
 
@@ -545,7 +545,7 @@ Expr halide_exp(Expr x_full) {
     return result;
 }
 
-Expr halide_erf(Expr x_full) {
+Expr halide_erf(const Expr &x_full) {
     user_assert(x_full.type() == Float(32)) << "halide_erf only works for Float(32)";
 
     // Extract the sign and magnitude.
@@ -585,7 +585,7 @@ Expr halide_erf(Expr x_full) {
     return result;
 }
 
-Expr raise_to_integer_power(Expr e, int64_t p) {
+Expr raise_to_integer_power(const Expr &e, int64_t p) {
     Expr result;
     if (p == 0) {
         result = make_one(e.type());
@@ -602,7 +602,7 @@ Expr raise_to_integer_power(Expr e, int64_t p) {
     return result;
 }
 
-void split_into_ands(Expr cond, std::vector<Expr> &result) {
+void split_into_ands(const Expr &cond, std::vector<Expr> &result) {
     if (!cond.defined()) {
         return;
     }
@@ -672,7 +672,7 @@ Expr BufferBuilder::build() const {
 
 } // namespace Internal
 
-Expr fast_log(Expr x) {
+Expr fast_log(const Expr &x) {
     user_assert(x.type() == Float(32)) << "fast_log only works for Float(32)";
 
     Expr reduced, exponent;
@@ -696,7 +696,7 @@ Expr fast_log(Expr x) {
     return result;
 }
 
-Expr fast_exp(Expr x_full) {
+Expr fast_exp(const Expr &x_full) {
     user_assert(x_full.type() == Float(32)) << "fast_exp only works for Float(32)";
 
     Expr scaled = x_full / logf(2.0);
@@ -759,7 +759,7 @@ Expr print(const std::vector<Expr> &args) {
     return result;
 }
 
-Expr print_when(Expr condition, const std::vector<Expr> &args) {
+Expr print_when(const Expr &condition, const std::vector<Expr> &args) {
     Expr p = print(args);
     return Internal::Call::make(p.type(),
                                 Internal::Call::if_then_else,
@@ -767,7 +767,7 @@ Expr print_when(Expr condition, const std::vector<Expr> &args) {
                                 Internal::Call::PureIntrinsic);
 }
 
-Expr require(Expr condition, const std::vector<Expr> &args) {
+Expr require(const Expr &condition, const std::vector<Expr> &args) {
     user_assert(condition.defined()) << "Require of undefined condition\n";
     user_assert(condition.type().is_bool()) << "Require condition must be a boolean type\n";
     user_assert(args.at(0).defined()) << "Require of undefined value\n";
@@ -789,7 +789,7 @@ Expr require(Expr condition, const std::vector<Expr> &args) {
 
 namespace Internal {
 
-Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_values) {
+Expr memoize_tag_helper(const Expr &result, const std::vector<Expr> &cache_key_values) {
     std::vector<Expr> args;
     args.push_back(result);
     args.insert(args.end(), cache_key_values.begin(), cache_key_values.end());

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -17,36 +17,36 @@ namespace Internal {
 /** Is the expression either an IntImm, a FloatImm, a StringImm, or a
  * Cast of the same, or a Ramp or Broadcast of the same. Doesn't do
  * any constant folding. */
-EXPORT bool is_const(Expr e);
+EXPORT bool is_const(const Expr &e);
 
 /** Is the expression an IntImm, FloatImm of a particular value, or a
  * Cast, or Broadcast of the same. */
-EXPORT bool is_const(Expr e, int64_t v);
+EXPORT bool is_const(const Expr &e, int64_t v);
 
 /** If an expression is an IntImm or a Broadcast of an IntImm, return
  * a pointer to its value. Otherwise returns nullptr. */
-EXPORT const int64_t *as_const_int(Expr e);
+EXPORT const int64_t *as_const_int(const Expr &e);
 
 /** If an expression is a UIntImm or a Broadcast of a UIntImm, return
  * a pointer to its value. Otherwise returns nullptr. */
-EXPORT const uint64_t *as_const_uint(Expr e);
+EXPORT const uint64_t *as_const_uint(const Expr &e);
 
 /** If an expression is a FloatImm or a Broadcast of a FloatImm,
  * return a pointer to its value. Otherwise returns nullptr. */
-EXPORT const double *as_const_float(Expr e);
+EXPORT const double *as_const_float(const Expr &e);
 
 /** Is the expression a constant integer power of two. Also returns
  * log base two of the expression if it is. Only returns true for
  * integer types. */
-EXPORT bool is_const_power_of_two_integer(Expr e, int *bits);
+EXPORT bool is_const_power_of_two_integer(const Expr &e, int *bits);
 
 /** Is the expression a const (as defined by is_const), and also
  * strictly greater than zero (in all lanes, if a vector expression) */
-EXPORT bool is_positive_const(Expr e);
+EXPORT bool is_positive_const(const Expr &e);
 
 /** Is the expression a const (as defined by is_const), and also
  * strictly less than zero (in all lanes, if a vector expression) */
-EXPORT bool is_negative_const(Expr e);
+EXPORT bool is_negative_const(const Expr &e);
 
 /** Is the expression a const (as defined by is_const), and also
  * strictly less than zero (in all lanes, if a vector expression) and
@@ -54,26 +54,26 @@ EXPORT bool is_negative_const(Expr e);
  * negative value of the Expr's type from inclusion. Intended to be
  * used when the value will be negated as part of simplification.)
  */
-EXPORT bool is_negative_negatable_const(Expr e);
+EXPORT bool is_negative_negatable_const(const Expr &e);
 
 /** Is the expression an undef */
-EXPORT bool is_undef(Expr e);
+EXPORT bool is_undef(const Expr &e);
 
 /** Is the expression a const (as defined by is_const), and also equal
  * to zero (in all lanes, if a vector expression) */
-EXPORT bool is_zero(Expr e);
+EXPORT bool is_zero(const Expr &e);
 
 /** Is the expression a const (as defined by is_const), and also equal
  * to one (in all lanes, if a vector expression) */
-EXPORT bool is_one(Expr e);
+EXPORT bool is_one(const Expr &e);
 
 /** Is the expression a const (as defined by is_const), and also equal
  * to two (in all lanes, if a vector expression) */
-EXPORT bool is_two(Expr e);
+EXPORT bool is_two(const Expr &e);
 
 /** Is the statement a no-op (which we represent as either an
  * undefined Stmt, or as an Evaluate node of a constant) */
-EXPORT bool is_no_op(Stmt s);
+EXPORT bool is_no_op(const Stmt &s);
 
 /** Construct an immediate of the given type from any numeric C++ type. */
 // @{
@@ -124,7 +124,7 @@ EXPORT Expr const_false(int lanes = 1);
 /** Attempt to cast an expression to a smaller type while provably not
  * losing information. If it can't be done, return an undefined
  * Expr. */
-EXPORT Expr lossless_cast(Type t, Expr e);
+EXPORT Expr lossless_cast(Type t, const Expr &e);
 
 /** Coerce the two expressions to have the same type, using C-style
  * casting rules. For the purposes of casting, a boolean type is
@@ -154,18 +154,18 @@ EXPORT void match_types(Expr &a, Expr &b);
 
 /** Halide's vectorizable transcendentals. */
 // @{
-EXPORT Expr halide_log(Expr a);
-EXPORT Expr halide_exp(Expr a);
-EXPORT Expr halide_erf(Expr a);
+EXPORT Expr halide_log(const Expr &a);
+EXPORT Expr halide_exp(const Expr &a);
+EXPORT Expr halide_erf(const Expr &a);
 // @}
 
 /** Raise an expression to an integer power by repeatedly multiplying
  * it by itself. */
-EXPORT Expr raise_to_integer_power(Expr a, int64_t b);
+EXPORT Expr raise_to_integer_power(const Expr &a, int64_t b);
 
 /** Split a boolean condition into vector of ANDs. If 'cond' is undefined,
  * return an empty vector. */
-EXPORT void split_into_ands(Expr cond, std::vector<Expr> &result);
+EXPORT void split_into_ands(const Expr &cond, std::vector<Expr> &result);
 
 /** A builder to help create Exprs representing buffer_t structs
  * (e.g. foo.buffer) via calls to halide_buffer_init. Fill out the
@@ -188,12 +188,12 @@ struct BufferBuilder {
 
 /** Cast an expression to the halide type corresponding to the C++ type T. */
 template<typename T>
-inline Expr cast(Expr a) {
+inline Expr cast(const Expr &a) {
     return cast(type_of<T>(), a);
 }
 
 /** Cast an expression to a new type. */
-inline Expr cast(Type t, Expr a) {
+inline Expr cast(Type t, const Expr &a) {
     user_assert(a.defined()) << "cast of undefined Expr\n";
     if (a.type() == t) return a;
 
@@ -241,7 +241,7 @@ inline Expr operator+(Expr a, Expr b) {
  * integer to match the type of the expression. Errors if the integer
  * cannot be represented in the type of the expression. */
 // @{
-inline Expr operator+(Expr a, int b) {
+inline Expr operator+(const Expr &a, int b) {
     user_assert(a.defined()) << "operator+ of undefined Expr\n";
     Internal::check_representable(a.type(), b);
     return Internal::Add::make(a, Internal::make_const(a.type(), b));
@@ -250,7 +250,7 @@ inline Expr operator+(Expr a, int b) {
 /** Add a constant integer and an expression. Coerces the type of the
  * integer to match the type of the expression. Errors if the integer
  * cannot be represented in the type of the expression. */
-inline Expr operator+(int a, Expr b) {
+inline Expr operator+(int a, const Expr &b) {
     user_assert(b.defined()) << "operator+ of undefined Expr\n";
     Internal::check_representable(b.type(), a);
     return Internal::Add::make(Internal::make_const(b.type(), a), b);
@@ -259,7 +259,7 @@ inline Expr operator+(int a, Expr b) {
 /** Modify the first expression to be the sum of two expressions,
  * without changing its type. This casts the second argument to match
  * the type of the first. */
-inline Expr &operator+=(Expr &a, Expr b) {
+inline Expr &operator+=(Expr &a, const Expr &b) {
     user_assert(a.defined() && b.defined()) << "operator+= of undefined Expr\n";
     a = Internal::Add::make(a, cast(a.type(), b));
     return a;
@@ -276,7 +276,7 @@ inline Expr operator-(Expr a, Expr b) {
 /** Subtracts a constant integer from an expression. Coerces the type of the
  * integer to match the type of the expression. Errors if the integer
  * cannot be represented in the type of the expression. */
-inline Expr operator-(Expr a, int b) {
+inline Expr operator-(const Expr &a, int b) {
     user_assert(a.defined()) << "operator- of undefined Expr\n";
     Internal::check_representable(a.type(), b);
     return Internal::Sub::make(a, Internal::make_const(a.type(), b));
@@ -285,7 +285,7 @@ inline Expr operator-(Expr a, int b) {
 /** Subtracts an expression from a constant integer. Coerces the type
  * of the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator-(int a, Expr b) {
+inline Expr operator-(int a, const Expr &b) {
     user_assert(b.defined()) << "operator- of undefined Expr\n";
     Internal::check_representable(b.type(), a);
     return Internal::Sub::make(Internal::make_const(b.type(), a), b);
@@ -296,7 +296,7 @@ inline Expr operator-(int a, Expr b) {
  * yields zero of the same type. For unsigned integers the negative is
  * still an unsigned integer. E.g. in UInt(8), the negative of 56 is
  * 200, because 56 + 200 == 0 */
-inline Expr operator-(Expr a) {
+inline Expr operator-(const Expr &a) {
     user_assert(a.defined()) << "operator- of undefined Expr\n";
     return Internal::Sub::make(Internal::make_zero(a.type()), a);
 }
@@ -304,7 +304,7 @@ inline Expr operator-(Expr a) {
 /** Modify the first expression to be the difference of two expressions,
  * without changing its type. This casts the second argument to match
  * the type of the first. */
-inline Expr &operator-=(Expr &a, Expr b) {
+inline Expr &operator-=(Expr &a, const Expr &b) {
     user_assert(a.defined() && b.defined()) << "operator-= of undefined Expr\n";
     a = Internal::Sub::make(a, cast(a.type(), b));
     return a;
@@ -321,7 +321,7 @@ inline Expr operator*(Expr a, Expr b) {
 /** Multiply an expression and a constant integer. Coerces the type of the
  * integer to match the type of the expression. Errors if the integer
  * cannot be represented in the type of the expression. */
-inline Expr operator*(Expr a, int b) {
+inline Expr operator*(const Expr &a, int b) {
     user_assert(a.defined()) << "operator* of undefined Expr\n";
     Internal::check_representable(a.type(), b);
     return Internal::Mul::make(a, Internal::make_const(a.type(), b));
@@ -330,7 +330,7 @@ inline Expr operator*(Expr a, int b) {
 /** Multiply a constant integer and an expression. Coerces the type of
  * the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator*(int a, Expr b) {
+inline Expr operator*(int a, const Expr &b) {
     user_assert(b.defined()) << "operator* of undefined Expr\n";
     Internal::check_representable(b.type(), a);
     return Internal::Mul::make(Internal::make_const(b.type(), a), b);
@@ -339,7 +339,7 @@ inline Expr operator*(int a, Expr b) {
 /** Modify the first expression to be the product of two expressions,
  * without changing its type. This casts the second argument to match
  * the type of the first. */
-inline Expr &operator*=(Expr &a, Expr b) {
+inline Expr &operator*=(Expr &a, const Expr &b) {
     user_assert(a.defined() && b.defined()) << "operator*= of undefined Expr\n";
     a = Internal::Mul::make(a, cast(a.type(), b));
     return a;
@@ -360,7 +360,7 @@ inline Expr operator/(Expr a, Expr b) {
  * the type of the first. Note that signed integer division in Halide
  * rounds towards minus infinity, unlike C, which rounds towards
  * zero. */
-inline Expr &operator/=(Expr &a, Expr b) {
+inline Expr &operator/=(Expr &a, const Expr &b) {
     user_assert(a.defined() && b.defined()) << "operator/= of undefined Expr\n";
     a = Internal::Div::make(a, cast(a.type(), b));
     return a;
@@ -371,7 +371,7 @@ inline Expr &operator/=(Expr &a, Expr b) {
 /** Divides an expression by a constant integer. Coerces the type
  * of the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator/(Expr a, int b) {
+inline Expr operator/(const Expr &a, int b) {
     user_assert(a.defined()) << "operator/ of undefined Expr\n";
     Internal::check_representable(a.type(), b);
     return Internal::Div::make(a, Internal::make_const(a.type(), b));
@@ -380,7 +380,7 @@ inline Expr operator/(Expr a, int b) {
 /** Divides a constant integer by an expression. Coerces the type
  * of the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator/(int a, Expr b) {
+inline Expr operator/(int a, const Expr &b) {
     user_assert(b.defined()) << "operator- of undefined Expr\n";
     Internal::check_representable(b.type(), a);
     return Internal::Div::make(Internal::make_const(b.type(), a), b);
@@ -402,7 +402,7 @@ inline Expr operator%(Expr a, Expr b) {
 /** Mods an expression by a constant integer. Coerces the type
  * of the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator%(Expr a, int b) {
+inline Expr operator%(const Expr &a, int b) {
     user_assert(a.defined()) << "operator% of undefined Expr\n";
     user_assert(b != 0) << "operator% with constant 0 modulus\n";
     Internal::check_representable(a.type(), b);
@@ -411,7 +411,7 @@ inline Expr operator%(Expr a, int b) {
 /** Mods a constant integer by an expression. Coerces the type
  * of the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator%(int a, Expr b) {
+inline Expr operator%(int a, const Expr &b) {
     user_assert(b.defined()) << "operator% of undefined Expr\n";
     user_assert(!Internal::is_zero(b)) << "operator% with constant 0 modulus\n";
     Internal::check_representable(b.type(), a);
@@ -431,7 +431,7 @@ inline Expr operator>(Expr a, Expr b) {
  * greater than a constant integer. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator>(Expr a, int b) {
+inline Expr operator>(const Expr &a, int b) {
     user_assert(a.defined()) << "operator> of undefined Expr\n";
     Internal::check_representable(a.type(), b);
     return Internal::GT::make(a, Internal::make_const(a.type(), b));
@@ -441,7 +441,7 @@ inline Expr operator>(Expr a, int b) {
  * greater than an expression. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator>(int a, Expr b) {
+inline Expr operator>(int a, const Expr &b) {
     user_assert(b.defined()) << "operator> of undefined Expr\n";
     Internal::check_representable(b.type(), a);
     return Internal::GT::make(Internal::make_const(b.type(), a), b);
@@ -460,7 +460,7 @@ inline Expr operator<(Expr a, Expr b) {
  * less than a constant integer. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator<(Expr a, int b) {
+inline Expr operator<(const Expr &a, int b) {
     user_assert(a.defined()) << "operator< of undefined Expr\n";
     Internal::check_representable(a.type(), b);
     return Internal::LT::make(a, Internal::make_const(a.type(), b));
@@ -470,7 +470,7 @@ inline Expr operator<(Expr a, int b) {
  * less than an expression. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator<(int a, Expr b) {
+inline Expr operator<(int a, const Expr &b) {
     user_assert(b.defined()) << "operator< of undefined Expr\n";
     Internal::check_representable(b.type(), a);
     return Internal::LT::make(Internal::make_const(b.type(), a), b);
@@ -489,7 +489,7 @@ inline Expr operator<=(Expr a, Expr b) {
  * less than or equal to a constant integer. Coerces the integer to
  * the type of the expression. Errors if the integer is not
  * representable in that type. */
-inline Expr operator<=(Expr a, int b) {
+inline Expr operator<=(const Expr &a, int b) {
     user_assert(a.defined()) << "operator<= of undefined Expr\n";
     Internal::check_representable(a.type(), b);
     return Internal::LE::make(a, Internal::make_const(a.type(), b));
@@ -499,7 +499,7 @@ inline Expr operator<=(Expr a, int b) {
  * is less than or equal to an expression. Coerces the integer to the
  * type of the expression. Errors if the integer is not representable
  * in that type. */
-inline Expr operator<=(int a, Expr b) {
+inline Expr operator<=(int a, const Expr &b) {
     user_assert(b.defined()) << "operator<= of undefined Expr\n";
     Internal::check_representable(b.type(), a);
     return Internal::LE::make(Internal::make_const(b.type(), a), b);
@@ -518,7 +518,7 @@ inline Expr operator>=(Expr a, Expr b) {
  * greater than or equal to a constant integer. Coerces the integer to
  * the type of the expression. Errors if the integer is not
  * representable in that type. */
-inline Expr operator>=(Expr a, int b) {
+inline Expr operator>=(const Expr &a, int b) {
     user_assert(a.defined()) << "operator>= of undefined Expr\n";
     Internal::check_representable(a.type(), b);
     return Internal::GE::make(a, Internal::make_const(a.type(), b));
@@ -528,7 +528,7 @@ inline Expr operator>=(Expr a, int b) {
  * is greater than or equal to an expression. Coerces the integer to the
  * type of the expression. Errors if the integer is not representable
  * in that type. */
-inline Expr operator>=(int a, Expr b) {
+inline Expr operator>=(int a, const Expr &b) {
     user_assert(b.defined()) << "operator>= of undefined Expr\n";
     Internal::check_representable(b.type(), a);
     return Internal::GE::make(Internal::make_const(b.type(), a), b);
@@ -547,7 +547,7 @@ inline Expr operator==(Expr a, Expr b) {
  * equal to a constant integer. Coerces the integer to the type of the
  * expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator==(Expr a, int b) {
+inline Expr operator==(const Expr &a, int b) {
     user_assert(a.defined()) << "operator== of undefined Expr\n";
     Internal::check_representable(a.type(), b);
     return Internal::EQ::make(a, Internal::make_const(a.type(), b));
@@ -557,7 +557,7 @@ inline Expr operator==(Expr a, int b) {
  * is equal to an expression. Coerces the integer to the type of the
  * expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator==(int a, Expr b) {
+inline Expr operator==(int a, const Expr &b) {
     user_assert(b.defined()) << "operator== of undefined Expr\n";
     Internal::check_representable(b.type(), a);
     return Internal::EQ::make(Internal::make_const(b.type(), a), b);
@@ -576,7 +576,7 @@ inline Expr operator!=(Expr a, Expr b) {
  * not equal to a constant integer. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator!=(Expr a, int b) {
+inline Expr operator!=(const Expr &a, int b) {
     user_assert(a.defined()) << "operator!= of undefined Expr\n";
     Internal::check_representable(a.type(), b);
     return Internal::NE::make(a, Internal::make_const(a.type(), b));
@@ -586,7 +586,7 @@ inline Expr operator!=(Expr a, int b) {
  * is not equal to an expression. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator!=(int a, Expr b) {
+inline Expr operator!=(int a, const Expr &b) {
     user_assert(b.defined()) << "operator!= of undefined Expr\n";
     Internal::check_representable(b.type(), a);
     return Internal::NE::make(Internal::make_const(b.type(), a), b);
@@ -601,7 +601,7 @@ inline Expr operator&&(Expr a, Expr b) {
 /** Logical and of an Expr and a bool. Either returns the Expr or an
  * Expr representing false, depending on the bool. */
 // @{
-inline Expr operator&&(Expr a, bool b) {
+inline Expr operator&&(const Expr &a, bool b) {
     internal_assert(a.defined()) << "operator&& of undefined Expr\n";
     internal_assert(a.type().is_bool()) << "operator&& of Expr of type " << a.type() << "\n";
     if (b) {
@@ -610,7 +610,7 @@ inline Expr operator&&(Expr a, bool b) {
         return Internal::make_zero(a.type());
     }
 }
-inline Expr operator&&(bool a, Expr b) {
+inline Expr operator&&(bool a, const Expr &b) {
     return b && a;
 }
 // @}
@@ -624,7 +624,7 @@ inline Expr operator||(Expr a, Expr b) {
 /** Logical or of an Expr and a bool. Either returns the Expr or an
  * Expr representing true, depending on the bool. */
 // @{
-inline Expr operator||(Expr a, bool b) {
+inline Expr operator||(const Expr &a, bool b) {
     internal_assert(a.defined()) << "operator|| of undefined Expr\n";
     internal_assert(a.type().is_bool()) << "operator|| of Expr of type " << a.type() << "\n";
     if (b) {
@@ -633,14 +633,14 @@ inline Expr operator||(Expr a, bool b) {
         return a;
     }
 }
-inline Expr operator||(bool a, Expr b) {
+inline Expr operator||(bool a, const Expr &b) {
     return b || a;
 }
 // @}
 
 
 /** Returns the logical not the argument */
-inline Expr operator!(Expr a) {
+inline Expr operator!(const Expr &a) {
     return Internal::Not::make(a);
 }
 
@@ -660,7 +660,7 @@ inline Expr max(Expr a, Expr b) {
  * expression. Errors if the integer is not representable as that
  * type. Vectorizes cleanly on most platforms (with the exception of
  * integer types on x86 without SSE4). */
-inline Expr max(Expr a, int b) {
+inline Expr max(const Expr &a, int b) {
     user_assert(a.defined()) << "max of undefined Expr\n";
     Internal::check_representable(a.type(), b);
     return Internal::Max::make(a, Internal::make_const(a.type(), b));
@@ -672,7 +672,7 @@ inline Expr max(Expr a, int b) {
  * the expression. Errors if the integer is not representable as that
  * type. Vectorizes cleanly on most platforms (with the exception of
  * integer types on x86 without SSE4). */
-inline Expr max(int a, Expr b) {
+inline Expr max(int a, const Expr &b) {
     user_assert(b.defined()) << "max of undefined Expr\n";
     Internal::check_representable(b.type(), a);
     return Internal::Max::make(Internal::make_const(b.type(), a), b);
@@ -694,7 +694,7 @@ inline Expr min(Expr a, Expr b) {
  * expression. Errors if the integer is not representable as that
  * type. Vectorizes cleanly on most platforms (with the exception of
  * integer types on x86 without SSE4). */
-inline Expr min(Expr a, int b) {
+inline Expr min(const Expr &a, int b) {
     user_assert(a.defined()) << "max of undefined Expr\n";
     Internal::check_representable(a.type(), b);
     return Internal::Min::make(a, Internal::make_const(a.type(), b));
@@ -705,7 +705,7 @@ inline Expr min(Expr a, int b) {
  * the expression. Errors if the integer is not representable as that
  * type. Vectorizes cleanly on most platforms (with the exception of
  * integer types on x86 without SSE4). */
-inline Expr min(int a, Expr b) {
+inline Expr min(int a, const Expr &b) {
     user_assert(b.defined()) << "max of undefined Expr\n";
     Internal::check_representable(b.type(), a);
     return Internal::Min::make(Internal::make_const(b.type(), a), b);
@@ -715,37 +715,37 @@ inline Expr min(int a, Expr b) {
  * explicit prevents implicit float->int casts that might otherwise
  * occur. */
 // @{
-inline Expr operator+(Expr a, float b) {return a + Expr(b);}
-inline Expr operator+(float a, Expr b) {return Expr(a) + b;}
-inline Expr operator-(Expr a, float b) {return a - Expr(b);}
-inline Expr operator-(float a, Expr b) {return Expr(a) - b;}
-inline Expr operator*(Expr a, float b) {return a * Expr(b);}
-inline Expr operator*(float a, Expr b) {return Expr(a) * b;}
-inline Expr operator/(Expr a, float b) {return a / Expr(b);}
-inline Expr operator/(float a, Expr b) {return Expr(a) / b;}
-inline Expr operator%(Expr a, float b) {return a % Expr(b);}
-inline Expr operator%(float a, Expr b) {return Expr(a) % b;}
-inline Expr operator>(Expr a, float b) {return a > Expr(b);}
-inline Expr operator>(float a, Expr b) {return Expr(a) > b;}
-inline Expr operator<(Expr a, float b) {return a < Expr(b);}
-inline Expr operator<(float a, Expr b) {return Expr(a) < b;}
-inline Expr operator>=(Expr a, float b) {return a >= Expr(b);}
-inline Expr operator>=(float a, Expr b) {return Expr(a) >= b;}
-inline Expr operator<=(Expr a, float b) {return a <= Expr(b);}
-inline Expr operator<=(float a, Expr b) {return Expr(a) <= b;}
-inline Expr operator==(Expr a, float b) {return a == Expr(b);}
-inline Expr operator==(float a, Expr b) {return Expr(a) == b;}
-inline Expr operator!=(Expr a, float b) {return a != Expr(b);}
-inline Expr operator!=(float a, Expr b) {return Expr(a) != b;}
-inline Expr min(float a, Expr b) {return min(Expr(a), b);}
-inline Expr min(Expr a, float b) {return min(a, Expr(b));}
-inline Expr max(float a, Expr b) {return max(Expr(a), b);}
-inline Expr max(Expr a, float b) {return max(a, Expr(b));}
+inline Expr operator+(const Expr &a, float b) {return a + Expr(b);}
+inline Expr operator+(float a, const Expr &b) {return Expr(a) + b;}
+inline Expr operator-(const Expr &a, float b) {return a - Expr(b);}
+inline Expr operator-(float a, const Expr &b) {return Expr(a) - b;}
+inline Expr operator*(const Expr &a, float b) {return a * Expr(b);}
+inline Expr operator*(float a, const Expr &b) {return Expr(a) * b;}
+inline Expr operator/(const Expr &a, float b) {return a / Expr(b);}
+inline Expr operator/(float a, const Expr &b) {return Expr(a) / b;}
+inline Expr operator%(const Expr &a, float b) {return a % Expr(b);}
+inline Expr operator%(float a, const Expr &b) {return Expr(a) % b;}
+inline Expr operator>(const Expr &a, float b) {return a > Expr(b);}
+inline Expr operator>(float a, const Expr &b) {return Expr(a) > b;}
+inline Expr operator<(const Expr &a, float b) {return a < Expr(b);}
+inline Expr operator<(float a, const Expr &b) {return Expr(a) < b;}
+inline Expr operator>=(const Expr &a, float b) {return a >= Expr(b);}
+inline Expr operator>=(float a, const Expr &b) {return Expr(a) >= b;}
+inline Expr operator<=(const Expr &a, float b) {return a <= Expr(b);}
+inline Expr operator<=(float a, const Expr &b) {return Expr(a) <= b;}
+inline Expr operator==(const Expr &a, float b) {return a == Expr(b);}
+inline Expr operator==(float a, const Expr &b) {return Expr(a) == b;}
+inline Expr operator!=(const Expr &a, float b) {return a != Expr(b);}
+inline Expr operator!=(float a, const Expr &b) {return Expr(a) != b;}
+inline Expr min(float a, const Expr &b) {return min(Expr(a), b);}
+inline Expr min(const Expr &a, float b) {return min(a, Expr(b));}
+inline Expr max(float a, const Expr &b) {return max(Expr(a), b);}
+inline Expr max(const Expr &a, float b) {return max(a, Expr(b));}
 // @}
 
 /** Clamps an expression to lie within the given bounds. The bounds
  * are type-cast to match the expression. Vectorizes as well as min/max. */
-inline Expr clamp(Expr a, Expr min_val, Expr max_val) {
+inline Expr clamp(const Expr &a, const Expr &min_val, const Expr &max_val) {
     user_assert(a.defined() && min_val.defined() && max_val.defined())
         << "clamp of undefined Expr\n";
     Expr n_min_val = lossless_cast(a.type(), min_val);
@@ -761,7 +761,7 @@ inline Expr clamp(Expr a, Expr min_val, Expr max_val) {
  * expression. Vectorizes cleanly. Unlike in C, abs of a signed
  * integer returns an unsigned integer of the same bit width. This
  * means that abs of the most negative integer doesn't overflow. */
-inline Expr abs(Expr a) {
+inline Expr abs(const Expr &a) {
     user_assert(a.defined())
         << "abs of undefined Expr\n";
     Type t = a.type();
@@ -830,49 +830,49 @@ inline Expr select(Expr condition, Expr true_value, Expr false_value) {
  * to the first value for which the condition is true. Returns the
  * final value if all conditions are false. */
 // @{
-inline Expr select(Expr c1, Expr v1,
-                   Expr c2, Expr v2,
-                   Expr default_val) {
+inline Expr select(const Expr &c1, const Expr &v1,
+                   const Expr &c2, const Expr &v2,
+                   const Expr &default_val) {
     return select(c1, v1,
                   select(c2, v2, default_val));
 }
-inline Expr select(Expr c1, Expr v1,
-                   Expr c2, Expr v2,
-                   Expr c3, Expr v3,
-                   Expr default_val) {
+inline Expr select(const Expr &c1, const Expr &v1,
+                   const Expr &c2, const Expr &v2,
+                   const Expr &c3, const Expr &v3,
+                   const Expr &default_val) {
     return select(c1, v1,
                   c2, v2,
                   select(c3, v3, default_val));
 }
-inline Expr select(Expr c1, Expr v1,
-                   Expr c2, Expr v2,
-                   Expr c3, Expr v3,
-                   Expr c4, Expr v4,
-                   Expr default_val) {
+inline Expr select(const Expr &c1, const Expr &v1,
+                   const Expr &c2, const Expr &v2,
+                   const Expr &c3, const Expr &v3,
+                   const Expr &c4, const Expr &v4,
+                   const Expr &default_val) {
     return select(c1, v1,
                   c2, v2,
                   c3, v3,
                   select(c4, v4, default_val));
 }
-inline Expr select(Expr c1, Expr v1,
-                   Expr c2, Expr v2,
-                   Expr c3, Expr v3,
-                   Expr c4, Expr v4,
-                   Expr c5, Expr v5,
-                   Expr default_val) {
+inline Expr select(const Expr &c1, const Expr &v1,
+                   const Expr &c2, const Expr &v2,
+                   const Expr &c3, const Expr &v3,
+                   const Expr &c4, const Expr &v4,
+                   const Expr &c5, const Expr &v5,
+                   const Expr &default_val) {
     return select(c1, v1,
                   c2, v2,
                   c3, v3,
                   c4, v4,
                   select(c5, v5, default_val));
 }
-inline Expr select(Expr c1, Expr v1,
-                   Expr c2, Expr v2,
-                   Expr c3, Expr v3,
-                   Expr c4, Expr v4,
-                   Expr c5, Expr v5,
-                   Expr c6, Expr v6,
-                   Expr default_val) {
+inline Expr select(const Expr &c1, const Expr &v1,
+                   const Expr &c2, const Expr &v2,
+                   const Expr &c3, const Expr &v3,
+                   const Expr &c4, const Expr &v4,
+                   const Expr &c5, const Expr &v5,
+                   const Expr &c6, const Expr &v6,
+                   const Expr &default_val) {
     return select(c1, v1,
                   c2, v2,
                   c3, v3,
@@ -880,14 +880,14 @@ inline Expr select(Expr c1, Expr v1,
                   c5, v5,
                   select(c6, v6, default_val));
 }
-inline Expr select(Expr c1, Expr v1,
-                   Expr c2, Expr v2,
-                   Expr c3, Expr v3,
-                   Expr c4, Expr v4,
-                   Expr c5, Expr v5,
-                   Expr c6, Expr v6,
-                   Expr c7, Expr v7,
-                   Expr default_val) {
+inline Expr select(const Expr &c1, const Expr &v1,
+                   const Expr &c2, const Expr &v2,
+                   const Expr &c3, const Expr &v3,
+                   const Expr &c4, const Expr &v4,
+                   const Expr &c5, const Expr &v5,
+                   const Expr &c6, const Expr &v6,
+                   const Expr &c7, const Expr &v7,
+                   const Expr &default_val) {
     return select(c1, v1,
                   c2, v2,
                   c3, v3,
@@ -896,15 +896,15 @@ inline Expr select(Expr c1, Expr v1,
                   c6, v6,
                   select(c7, v7, default_val));
 }
-inline Expr select(Expr c1, Expr v1,
-                   Expr c2, Expr v2,
-                   Expr c3, Expr v3,
-                   Expr c4, Expr v4,
-                   Expr c5, Expr v5,
-                   Expr c6, Expr v6,
-                   Expr c7, Expr v7,
-                   Expr c8, Expr v8,
-                   Expr default_val) {
+inline Expr select(const Expr &c1, const Expr &v1,
+                   const Expr &c2, const Expr &v2,
+                   const Expr &c3, const Expr &v3,
+                   const Expr &c4, const Expr &v4,
+                   const Expr &c5, const Expr &v5,
+                   const Expr &c6, const Expr &v6,
+                   const Expr &c7, const Expr &v7,
+                   const Expr &c8, const Expr &v8,
+                   const Expr &default_val) {
     return select(c1, v1,
                   c2, v2,
                   c3, v3,
@@ -914,16 +914,16 @@ inline Expr select(Expr c1, Expr v1,
                   c7, v7,
                   select(c8, v8, default_val));
 }
-inline Expr select(Expr c1, Expr v1,
-                   Expr c2, Expr v2,
-                   Expr c3, Expr v3,
-                   Expr c4, Expr v4,
-                   Expr c5, Expr v5,
-                   Expr c6, Expr v6,
-                   Expr c7, Expr v7,
-                   Expr c8, Expr v8,
-                   Expr c9, Expr v9,
-                   Expr default_val) {
+inline Expr select(const Expr &c1, const Expr &v1,
+                   const Expr &c2, const Expr &v2,
+                   const Expr &c3, const Expr &v3,
+                   const Expr &c4, const Expr &v4,
+                   const Expr &c5, const Expr &v5,
+                   const Expr &c6, const Expr &v6,
+                   const Expr &c7, const Expr &v7,
+                   const Expr &c8, const Expr &v8,
+                   const Expr &c9, const Expr &v9,
+                   const Expr &default_val) {
     return select(c1, v1,
                   c2, v2,
                   c3, v3,
@@ -934,17 +934,17 @@ inline Expr select(Expr c1, Expr v1,
                   c8, v8,
                   select(c9, v9, default_val));
 }
-inline Expr select(Expr c1, Expr v1,
-                   Expr c2, Expr v2,
-                   Expr c3, Expr v3,
-                   Expr c4, Expr v4,
-                   Expr c5, Expr v5,
-                   Expr c6, Expr v6,
-                   Expr c7, Expr v7,
-                   Expr c8, Expr v8,
-                   Expr c9, Expr v9,
-                   Expr c10, Expr v10,
-                   Expr default_val) {
+inline Expr select(const Expr &c1, const Expr &v1,
+                   const Expr &c2, const Expr &v2,
+                   const Expr &c3, const Expr &v3,
+                   const Expr &c4, const Expr &v4,
+                   const Expr &c5, const Expr &v5,
+                   const Expr &c6, const Expr &v6,
+                   const Expr &c7, const Expr &v7,
+                   const Expr &c8, const Expr &v8,
+                   const Expr &c9, const Expr &v9,
+                   const Expr &c10, const Expr &v10,
+                   const Expr &default_val) {
     return select(c1, v1,
                   c2, v2,
                   c3, v3,
@@ -964,7 +964,7 @@ inline Expr select(Expr c1, Expr v1,
 /** Return the sine of a floating-point expression. If the argument is
  * not floating-point, it is cast to Float(32). Does not vectorize
  * well. */
-inline Expr sin(Expr x) {
+inline Expr sin(const Expr &x) {
     user_assert(x.defined()) << "sin of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "sin_f64", {x}, Internal::Call::PureExtern);
@@ -980,7 +980,7 @@ inline Expr sin(Expr x) {
 /** Return the arcsine of a floating-point expression. If the argument
  * is not floating-point, it is cast to Float(32). Does not vectorize
  * well. */
-inline Expr asin(Expr x) {
+inline Expr asin(const Expr &x) {
     user_assert(x.defined()) << "asin of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "asin_f64", {x}, Internal::Call::PureExtern);
@@ -996,7 +996,7 @@ inline Expr asin(Expr x) {
 /** Return the cosine of a floating-point expression. If the argument
  * is not floating-point, it is cast to Float(32). Does not vectorize
  * well. */
-inline Expr cos(Expr x) {
+inline Expr cos(const Expr &x) {
     user_assert(x.defined()) << "cos of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "cos_f64", {x}, Internal::Call::PureExtern);
@@ -1012,7 +1012,7 @@ inline Expr cos(Expr x) {
 /** Return the arccosine of a floating-point expression. If the
  * argument is not floating-point, it is cast to Float(32). Does not
  * vectorize well. */
-inline Expr acos(Expr x) {
+inline Expr acos(const Expr &x) {
     user_assert(x.defined()) << "acos of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "acos_f64", {x}, Internal::Call::PureExtern);
@@ -1028,7 +1028,7 @@ inline Expr acos(Expr x) {
 /** Return the tangent of a floating-point expression. If the argument
  * is not floating-point, it is cast to Float(32). Does not vectorize
  * well. */
-inline Expr tan(Expr x) {
+inline Expr tan(const Expr &x) {
     user_assert(x.defined()) << "tan of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "tan_f64", {x}, Internal::Call::PureExtern);
@@ -1044,7 +1044,7 @@ inline Expr tan(Expr x) {
 /** Return the arctangent of a floating-point expression. If the
  * argument is not floating-point, it is cast to Float(32). Does not
  * vectorize well. */
-inline Expr atan(Expr x) {
+inline Expr atan(const Expr &x) {
     user_assert(x.defined()) << "atan of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "atan_f64", {x}, Internal::Call::PureExtern);
@@ -1081,7 +1081,7 @@ inline Expr atan2(Expr y, Expr x) {
 /** Return the hyperbolic sine of a floating-point expression.  If the
  *  argument is not floating-point, it is cast to Float(32). Does not
  *  vectorize well. */
-inline Expr sinh(Expr x) {
+inline Expr sinh(const Expr &x) {
     user_assert(x.defined()) << "sinh of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "sinh_f64", {x}, Internal::Call::PureExtern);
@@ -1097,7 +1097,7 @@ inline Expr sinh(Expr x) {
 /** Return the hyperbolic arcsinhe of a floating-point expression.  If
  * the argument is not floating-point, it is cast to Float(32). Does
  * not vectorize well. */
-inline Expr asinh(Expr x) {
+inline Expr asinh(const Expr &x) {
     user_assert(x.defined()) << "asinh of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "asinh_f64", {x}, Internal::Call::PureExtern);
@@ -1113,7 +1113,7 @@ inline Expr asinh(Expr x) {
 /** Return the hyperbolic cosine of a floating-point expression.  If
  * the argument is not floating-point, it is cast to Float(32). Does
  * not vectorize well. */
-inline Expr cosh(Expr x) {
+inline Expr cosh(const Expr &x) {
     user_assert(x.defined()) << "cosh of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "cosh_f64", {x}, Internal::Call::PureExtern);
@@ -1129,7 +1129,7 @@ inline Expr cosh(Expr x) {
 /** Return the hyperbolic arccosine of a floating-point expression.
  * If the argument is not floating-point, it is cast to
  * Float(32). Does not vectorize well. */
-inline Expr acosh(Expr x) {
+inline Expr acosh(const Expr &x) {
     user_assert(x.defined()) << "acosh of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "acosh_f64", {x}, Internal::Call::PureExtern);
@@ -1145,7 +1145,7 @@ inline Expr acosh(Expr x) {
 /** Return the hyperbolic tangent of a floating-point expression.  If
  * the argument is not floating-point, it is cast to Float(32). Does
  * not vectorize well. */
-inline Expr tanh(Expr x) {
+inline Expr tanh(const Expr &x) {
     user_assert(x.defined()) << "tanh of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "tanh_f64", {x}, Internal::Call::PureExtern);
@@ -1161,7 +1161,7 @@ inline Expr tanh(Expr x) {
 /** Return the hyperbolic arctangent of a floating-point expression.
  * If the argument is not floating-point, it is cast to
  * Float(32). Does not vectorize well. */
-inline Expr atanh(Expr x) {
+inline Expr atanh(const Expr &x) {
     user_assert(x.defined()) << "atanh of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "atanh_f64", {x}, Internal::Call::PureExtern);
@@ -1177,7 +1177,7 @@ inline Expr atanh(Expr x) {
 /** Return the square root of a floating-point expression. If the
  * argument is not floating-point, it is cast to Float(32). Typically
  * vectorizes cleanly. */
-inline Expr sqrt(Expr x) {
+inline Expr sqrt(const Expr &x) {
     user_assert(x.defined()) << "sqrt of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "sqrt_f64", {x}, Internal::Call::PureExtern);
@@ -1193,7 +1193,7 @@ inline Expr sqrt(Expr x) {
 /** Return the square root of the sum of the squares of two
  * floating-point expressions. If the argument is not floating-point,
  * it is cast to Float(32). Vectorizes cleanly. */
-inline Expr hypot(Expr x, Expr y) {
+inline Expr hypot(const Expr &x, const Expr &y) {
     return sqrt(x*x + y*y);
 }
 
@@ -1204,7 +1204,7 @@ inline Expr hypot(Expr x, Expr y) {
  * vectorizable, does the right thing for extremely small or extremely
  * large inputs, and is accurate up to the last bit of the
  * mantissa. Vectorizes cleanly. */
-inline Expr exp(Expr x) {
+inline Expr exp(const Expr &x) {
     user_assert(x.defined()) << "exp of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "exp_f64", {x}, Internal::Call::PureExtern);
@@ -1224,7 +1224,7 @@ inline Expr exp(Expr x) {
  * vectorizable, does the right thing for inputs <= 0 (returns -inf or
  * nan), and is accurate up to the last bit of the
  * mantissa. Vectorizes cleanly. */
-inline Expr log(Expr x) {
+inline Expr log(const Expr &x) {
     user_assert(x.defined()) << "log of undefined Expr\n";
     if (x.type() == Float(64)) {
         return Internal::Call::make(Float(64), "log_f64", {x}, Internal::Call::PureExtern);
@@ -1268,7 +1268,7 @@ inline Expr pow(Expr x, Expr y) {
 /** Evaluate the error function erf. Only available for
  * Float(32). Accurate up to the last three bits of the
  * mantissa. Vectorizes cleanly. */
-inline Expr erf(Expr x) {
+inline Expr erf(const Expr &x) {
     user_assert(x.defined()) << "erf of undefined Expr\n";
     user_assert(x.type() == Float(32)) << "erf only takes float arguments\n";
     return Internal::halide_erf(x);
@@ -1277,13 +1277,13 @@ inline Expr erf(Expr x) {
 /** Fast approximate cleanly vectorizable log for Float(32). Returns
  * nonsense for x <= 0.0f. Accurate up to the last 5 bits of the
  * mantissa. Vectorizes cleanly. */
-EXPORT Expr fast_log(Expr x);
+EXPORT Expr fast_log(const Expr &x);
 
 /** Fast approximate cleanly vectorizable exp for Float(32). Returns
  * nonsense for inputs that would overflow or underflow. Typically
  * accurate up to the last 5 bits of the mantissa. Gets worse when
  * approaching overflow. Vectorizes cleanly. */
-EXPORT Expr fast_exp(Expr x);
+EXPORT Expr fast_exp(const Expr &x);
 
 /** Fast approximate cleanly vectorizable pow for Float(32). Returns
  * nonsense for x < 0.0f. Accurate up to the last 5 bits of the
@@ -1302,7 +1302,7 @@ inline Expr fast_pow(Expr x, Expr y) {
 /** Fast approximate inverse for Float(32). Corresponds to the rcpps
  * instruction on x86, and the vrecpe instruction on ARM. Vectorizes
  * cleanly. */
-inline Expr fast_inverse(Expr x) {
+inline Expr fast_inverse(const Expr &x) {
     user_assert(x.type() == Float(32)) << "fast_inverse only takes float arguments\n";
     return Internal::Call::make(x.type(), "fast_inverse_f32", {x}, Internal::Call::PureExtern);
 }
@@ -1310,7 +1310,7 @@ inline Expr fast_inverse(Expr x) {
 /** Fast approximate inverse square root for Float(32). Corresponds to
  * the rsqrtps instruction on x86, and the vrsqrte instruction on
  * ARM. Vectorizes cleanly. */
-inline Expr fast_inverse_sqrt(Expr x) {
+inline Expr fast_inverse_sqrt(const Expr &x) {
     user_assert(x.type() == Float(32)) << "fast_inverse_sqrt only takes float arguments\n";
     return Internal::Call::make(x.type(), "fast_inverse_sqrt_f32", {x}, Internal::Call::PureExtern);
 }
@@ -1319,7 +1319,7 @@ inline Expr fast_inverse_sqrt(Expr x) {
  * floating-point expression. If the argument is not floating-point,
  * it is cast to Float(32). The return value is still in floating
  * point, despite being a whole number. Vectorizes cleanly. */
-inline Expr floor(Expr x) {
+inline Expr floor(const Expr &x) {
     user_assert(x.defined()) << "floor of undefined Expr\n";
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(x.type(), "floor_f64", {x}, Internal::Call::PureExtern);
@@ -1337,7 +1337,7 @@ inline Expr floor(Expr x) {
  * floating-point expression. If the argument is not floating-point,
  * it is cast to Float(32). The return value is still in floating
  * point, despite being a whole number. Vectorizes cleanly. */
-inline Expr ceil(Expr x) {
+inline Expr ceil(const Expr &x) {
     user_assert(x.defined()) << "ceil of undefined Expr\n";
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(x.type(), "ceil_f64", {x}, Internal::Call::PureExtern);
@@ -1356,7 +1356,7 @@ inline Expr ceil(Expr x) {
  * is still in floating point, despite being a whole number. On ties, we
  * follow IEEE754 conventions and round to the nearest even number. Vectorizes
  * cleanly. */
-inline Expr round(Expr x) {
+inline Expr round(const Expr &x) {
     user_assert(x.defined()) << "round of undefined Expr\n";
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(Float(64), "round_f64", {x}, Internal::Call::PureExtern);
@@ -1373,7 +1373,7 @@ inline Expr round(Expr x) {
 /** Return the integer part of a floating-point expression. If the argument is
  * not floating-point, it is cast to Float(32). The return value is still in
  * floating point, despite being a whole number. Vectorizes cleanly. */
-inline Expr trunc(Expr x) {
+inline Expr trunc(const Expr &x) {
     user_assert(x.defined()) << "trunc of undefined Expr\n";
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(Float(64), "trunc_f64", {x}, Internal::Call::PureExtern);
@@ -1389,7 +1389,7 @@ inline Expr trunc(Expr x) {
 
 /** Returns true if the argument is a Not a Number (NaN). Requires a
   * floating point argument.  Vectorizes cleanly. */
-inline Expr is_nan(Expr x) {
+inline Expr is_nan(const Expr &x) {
     user_assert(x.defined()) << "is_nan of undefined Expr\n";
     user_assert(x.type().is_float()) << "is_nan only works for float";
     Type t = Bool(x.type().lanes());
@@ -1408,13 +1408,13 @@ inline Expr is_nan(Expr x) {
 /** Return the fractional part of a floating-point expression. If the argument
  *  is not floating-point, it is cast to Float(32). The return value has the
  *  same sign as the original expression. Vectorizes cleanly. */
-inline Expr fract(Expr x) {
+inline Expr fract(const Expr &x) {
     user_assert(x.defined()) << "fract of undefined Expr\n";
     return x - trunc(x);
 }
 
 /** Reinterpret the bits of one value as another type. */
-inline Expr reinterpret(Type t, Expr e) {
+inline Expr reinterpret(Type t, const Expr &e) {
     user_assert(e.defined()) << "reinterpret of undefined Expr\n";
     int from_bits = e.type().bits() * e.type().lanes();
     int to_bits = t.bits() * t.lanes();
@@ -1427,7 +1427,7 @@ inline Expr reinterpret(Type t, Expr e) {
 }
 
 template<typename T>
-inline Expr reinterpret(Expr e) {
+inline Expr reinterpret(const Expr &e) {
     return reinterpret(type_of<T>(), e);
 }
 
@@ -1489,7 +1489,7 @@ inline Expr operator^(Expr x, Expr y) {
 }
 
 /** Return the bitwise not of an expression. */
-inline Expr operator~(Expr x) {
+inline Expr operator~(const Expr &x) {
     user_assert(x.defined()) << "bitwise not of undefined Expr\n";
     user_assert(x.type().is_int() || x.type().is_uint())
         << "Argument to bitwise not must be an integer or unsigned integer";
@@ -1511,11 +1511,11 @@ inline Expr operator<<(Expr x, Expr y) {
     Internal::match_types(x, y);
     return Internal::Call::make(x.type(), Internal::Call::shift_left, {x, y}, Internal::Call::PureIntrinsic);
 }
-inline Expr operator<<(Expr x, int y) {
+inline Expr operator<<(const Expr &x, int y) {
     Internal::check_representable(x.type(), y);
     return x << Internal::make_const(x.type(), y);
 }
-inline Expr operator<<(int x, Expr y) {
+inline Expr operator<<(int x, const Expr &y) {
     Internal::check_representable(y.type(), x);
     return Internal::make_const(y.type(), x) << y;
 }
@@ -1537,11 +1537,11 @@ inline Expr operator>>(Expr x, Expr y) {
     Internal::match_types(x, y);
     return Internal::Call::make(x.type(), Internal::Call::shift_right, {x, y}, Internal::Call::PureIntrinsic);
 }
-inline Expr operator>>(Expr x, int y) {
+inline Expr operator>>(const Expr &x, int y) {
     Internal::check_representable(x.type(), y);
     return x >> Internal::make_const(x.type(), y);
 }
-inline Expr operator>>(int x, Expr y) {
+inline Expr operator>>(int x, const Expr &y) {
     Internal::check_representable(y.type(), x);
     return Internal::make_const(y.type(), x) >> y;
 }
@@ -1655,7 +1655,7 @@ inline Expr lerp(Expr zero_val, Expr one_val, Expr weight) {
 }
 
 /** Count the number of set bits in an expression. */
-inline Expr popcount(Expr x) {
+inline Expr popcount(const Expr &x) {
     user_assert(x.defined()) << "popcount of undefined Expr\n";
     return Internal::Call::make(x.type(), Internal::Call::popcount,
                                 {x}, Internal::Call::PureIntrinsic);
@@ -1663,7 +1663,7 @@ inline Expr popcount(Expr x) {
 
 /** Count the number of leading zero bits in an expression. The result is
  *  undefined if the value of the expression is zero. */
-inline Expr count_leading_zeros(Expr x) {
+inline Expr count_leading_zeros(const Expr &x) {
     user_assert(x.defined()) << "count leading zeros of undefined Expr\n";
     return Internal::Call::make(x.type(), Internal::Call::count_leading_zeros,
                                 {x}, Internal::Call::PureIntrinsic);
@@ -1671,7 +1671,7 @@ inline Expr count_leading_zeros(Expr x) {
 
 /** Count the number of trailing zero bits in an expression. The result is
  *  undefined if the value of the expression is zero. */
-inline Expr count_trailing_zeros(Expr x) {
+inline Expr count_trailing_zeros(const Expr &x) {
     user_assert(x.defined()) << "count trailing zeros of undefined Expr\n";
     return Internal::Call::make(x.type(), Internal::Call::count_trailing_zeros,
                                 {x}, Internal::Call::PureIntrinsic);
@@ -1743,7 +1743,7 @@ inline Expr mod_round_to_zero(Expr x, Expr y) {
  *
  * This function vectorizes cleanly.
  */
-inline Expr random_float(Expr seed = Expr()) {
+inline Expr random_float(const Expr &seed = Expr()) {
     // Random floats get even IDs
     static std::atomic<int> counter;
     int id = (counter++)*2;
@@ -1765,7 +1765,7 @@ inline Expr random_float(Expr seed = Expr()) {
 
 /** Return a random variable representing a uniformly distributed
  * unsigned 32-bit integer. See \ref random_float. Vectorizes cleanly. */
-inline Expr random_uint(Expr seed = Expr()) {
+inline Expr random_uint(const Expr &seed = Expr()) {
     // Random ints get odd IDs
     static std::atomic<int> counter;
     int id = (counter++)*2 + 1;
@@ -1785,7 +1785,7 @@ inline Expr random_uint(Expr seed = Expr()) {
 
 /** Return a random variable representing a uniformly distributed
  * 32-bit integer. See \ref random_float. Vectorizes cleanly. */
-inline Expr random_int(Expr seed = Expr()) {
+inline Expr random_int(const Expr &seed = Expr()) {
     return cast<int32_t>(random_uint(seed));
 }
 
@@ -1801,7 +1801,7 @@ inline NO_INLINE void collect_print_args(std::vector<Expr> &args, const char *ar
 }
 
 template<typename ...Args>
-inline NO_INLINE void collect_print_args(std::vector<Expr> &args, Expr arg, Args&&... more_args) {
+inline NO_INLINE void collect_print_args(std::vector<Expr> &args, const Expr &arg, Args&&... more_args) {
     args.push_back(arg);
     collect_print_args(args, std::forward<Args>(more_args)...);
 }
@@ -1815,7 +1815,7 @@ inline NO_INLINE void collect_print_args(std::vector<Expr> &args, Expr arg, Args
 EXPORT Expr print(const std::vector<Expr> &values);
 
 template <typename... Args>
-inline NO_INLINE Expr print(Expr a, Args&&... args) {
+inline NO_INLINE Expr print(const Expr &a, Args&&... args) {
     std::vector<Expr> collected_args = {a};
     Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
     return print(collected_args);
@@ -1825,10 +1825,10 @@ inline NO_INLINE Expr print(Expr a, Args&&... args) {
 /** Create an Expr that prints whenever it is evaluated, provided that
  * the condition is true. */
 // @{
-EXPORT Expr print_when(Expr condition, const std::vector<Expr> &values);
+EXPORT Expr print_when(const Expr &condition, const std::vector<Expr> &values);
 
 template<typename ...Args>
-inline NO_INLINE Expr print_when(Expr condition, Expr a, Args&&... args) {
+inline NO_INLINE Expr print_when(const Expr &condition, const Expr &a, Args&&... args) {
     std::vector<Expr> collected_args = {a};
     Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
     return print_when(condition, collected_args);
@@ -1857,10 +1857,10 @@ inline NO_INLINE Expr print_when(Expr condition, Expr a, Args&&... args) {
  * will allow the optimizer to assume positive, nonzero values for y.
  */
 // @{
-EXPORT Expr require(Expr condition, const std::vector<Expr> &values);
+EXPORT Expr require(const Expr &condition, const std::vector<Expr> &values);
 
 template<typename ...Args>
-inline NO_INLINE Expr require(Expr condition, Expr value, Args&&... args) {
+inline NO_INLINE Expr require(const Expr &condition, const Expr &value, Args&&... args) {
     std::vector<Expr> collected_args = {value};
     Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
     return require(condition, collected_args);
@@ -1899,7 +1899,7 @@ inline Expr undef() {
 }
 
 namespace Internal {
-EXPORT Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_values);
+EXPORT Expr memoize_tag_helper(const Expr &result, const std::vector<Expr> &cache_key_values);
 }  // namespace Internal
 
 /** Control the values used in the memoization cache key for memoize.
@@ -1930,7 +1930,7 @@ EXPORT Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_v
  * on the digest. */
 // @{
 template<typename ...Args>
-inline NO_INLINE Expr memoize_tag(Expr result, Args&&... args) {
+inline NO_INLINE Expr memoize_tag(const Expr &result, Args&&... args) {
     std::vector<Expr> collected_args{std::forward<Args>(args)...};
     return Internal::memoize_tag_helper(result, collected_args);
 }
@@ -1949,14 +1949,14 @@ inline NO_INLINE Expr memoize_tag(Expr result, Args&&... args) {
  * use the boundary condition helpers in the BoundaryConditions
  * namespace instead.
  */
-inline Expr likely(Expr e) {
+inline Expr likely(const Expr &e) {
     return Internal::Call::make(e.type(), Internal::Call::likely,
                                 {e}, Internal::Call::PureIntrinsic);
 }
 
 /** Equivalent to likely, but only triggers a loop partitioning if
  * found in an innermost loop. */
-inline Expr likely_if_innermost(Expr e) {
+inline Expr likely_if_innermost(const Expr &e) {
     return Internal::Call::make(e.type(), Internal::Call::likely_if_innermost,
                                 {e}, Internal::Call::PureIntrinsic);
 }
@@ -1966,7 +1966,7 @@ inline Expr likely_if_innermost(Expr e) {
  * type T clamping to the minimum and maximum values of the result
  * type. */
 template <typename T>
-Expr saturating_cast(Expr e) {
+Expr saturating_cast(const Expr &e) {
     return saturating_cast(type_of<T>(), e);
 }
 

--- a/src/Substitute.cpp
+++ b/src/Substitute.cpp
@@ -83,26 +83,26 @@ public:
 
 };
 
-Expr substitute(string name, Expr replacement, Expr expr) {
+Expr substitute(const string &name, const Expr &replacement, const Expr &expr) {
     map<string, Expr> m;
     m[name] = replacement;
     Substitute s(m);
     return s.mutate(expr);
 }
 
-Stmt substitute(string name, Expr replacement, Stmt stmt) {
+Stmt substitute(const string &name, const Expr &replacement, const Stmt &stmt) {
     map<string, Expr> m;
     m[name] = replacement;
     Substitute s(m);
     return s.mutate(stmt);
 }
 
-Expr substitute(const map<string, Expr> &m, Expr expr) {
+Expr substitute(const map<string, Expr> &m, const Expr &expr) {
     Substitute s(m);
     return s.mutate(expr);
 }
 
-Stmt substitute(const map<string, Expr> &m, Stmt stmt) {
+Stmt substitute(const map<string, Expr> &m, const Stmt &stmt) {
     Substitute s(m);
     return s.mutate(stmt);
 }
@@ -123,14 +123,14 @@ public:
     }
 };
 
-Expr substitute(Expr find, Expr replacement, Expr expr) {
+Expr substitute(const Expr &find, const Expr &replacement, const Expr &expr) {
     SubstituteExpr s;
     s.find = find;
     s.replacement = replacement;
     return s.mutate(expr);
 }
 
-Stmt substitute(Expr find, Expr replacement, Stmt stmt) {
+Stmt substitute(const Expr &find, const Expr &replacement, const Stmt &stmt) {
     SubstituteExpr s;
     s.find = find;
     s.replacement = replacement;
@@ -154,7 +154,7 @@ class GraphSubstitute : public IRGraphMutator {
 
 public:
 
-    GraphSubstitute(const string &var, Expr value) : var(var), value(value) {}
+    GraphSubstitute(const string &var, const Expr &value) : var(var), value(value) {}
 };
 
 /** Substitute an Expr for another Expr in a graph. Unlike substitute,
@@ -170,22 +170,22 @@ public:
         return IRGraphMutator::mutate(e);
     }
 
-    GraphSubstituteExpr(Expr find, Expr replace) : find(find), replace(replace) {}
+    GraphSubstituteExpr(const Expr &find, const Expr &replace) : find(find), replace(replace) {}
 };
 
-Expr graph_substitute(string name, Expr replacement, Expr expr) {
+Expr graph_substitute(const string &name, const Expr &replacement, const Expr &expr) {
     return GraphSubstitute(name, replacement).mutate(expr);
 }
 
-Stmt graph_substitute(string name, Expr replacement, Stmt stmt) {
+Stmt graph_substitute(const string &name, const Expr &replacement, const Stmt &stmt) {
     return GraphSubstitute(name, replacement).mutate(stmt);
 }
 
-Expr graph_substitute(Expr find, Expr replacement, Expr expr) {
+Expr graph_substitute(const Expr &find, const Expr &replacement, const Expr &expr) {
     return GraphSubstituteExpr(find, replacement).mutate(expr);
 }
 
-Stmt graph_substitute(Expr find, Expr replacement, Stmt stmt) {
+Stmt graph_substitute(const Expr &find, const Expr &replacement, const Stmt &stmt) {
     return GraphSubstituteExpr(find, replacement).mutate(stmt);
 }
 
@@ -200,11 +200,11 @@ class SubstituteInAllLets : public IRGraphMutator {
     }
 };
 
-Expr substitute_in_all_lets(Expr expr) {
+Expr substitute_in_all_lets(const Expr &expr) {
     return SubstituteInAllLets().mutate(expr);
 }
 
-Stmt substitute_in_all_lets(Stmt stmt) {
+Stmt substitute_in_all_lets(const Stmt &stmt) {
     return SubstituteInAllLets().mutate(stmt);
 }
 

--- a/src/Substitute.h
+++ b/src/Substitute.h
@@ -19,31 +19,31 @@ namespace Internal {
  * statements with the same name as the first argument, moving a piece
  * of syntax around can change its meaning, because it can cross lets
  * that redefine variable names that it includes references to. */
-EXPORT Expr substitute(std::string name, Expr replacement, Expr expr);
+EXPORT Expr substitute(const std::string &name, const Expr &replacement, const Expr &expr);
 
 /** Substitute variables with the given name with the replacement
  * expression within stmt. */
-EXPORT Stmt substitute(std::string name, Expr replacement, Stmt stmt);
+EXPORT Stmt substitute(const std::string &name, const Expr &replacement, const Stmt &stmt);
 
 /** Substitute variables with names in the map. */
 // @{
-EXPORT Expr substitute(const std::map<std::string, Expr> &replacements, Expr expr);
-EXPORT Stmt substitute(const std::map<std::string, Expr> &replacements, Stmt stmt);
+EXPORT Expr substitute(const std::map<std::string, Expr> &replacements, const Expr &expr);
+EXPORT Stmt substitute(const std::map<std::string, Expr> &replacements, const Stmt &stmt);
 // @}
 
 /** Substitute expressions for other expressions. */
 // @{
-EXPORT Expr substitute(Expr find, Expr replacement, Expr expr);
-EXPORT Stmt substitute(Expr find, Expr replacement, Stmt stmt);
+EXPORT Expr substitute(const Expr &find, const Expr &replacement, const Expr &expr);
+EXPORT Stmt substitute(const Expr &find, const Expr &replacement, const Stmt &stmt);
 // @}
 
 /** Substitutions where the IR may be a general graph (and not just a
  * DAG). */
 // @{
-Expr graph_substitute(std::string name, Expr replacement, Expr expr);
-Stmt graph_substitute(std::string name, Expr replacement, Stmt stmt);
-Expr graph_substitute(Expr find, Expr replacement, Expr expr);
-Stmt graph_substitute(Expr find, Expr replacement, Stmt stmt);
+Expr graph_substitute(const std::string &name, const Expr &replacement, const Expr &expr);
+Stmt graph_substitute(const std::string &name, const Expr &replacement, const Stmt &stmt);
+Expr graph_substitute(const Expr &find, const Expr &replacement, const Expr &expr);
+Stmt graph_substitute(const Expr &find, const Expr &replacement, const Stmt &stmt);
 // @}
 
 /** Substitute in all let Exprs in a piece of IR. Doesn't substitute
@@ -52,8 +52,8 @@ Stmt graph_substitute(Expr find, Expr replacement, Stmt stmt);
  * non-graph-aware visitors or mutators on it until you've CSE'd the
  * result. */
 // @{
-Expr substitute_in_all_lets(Expr expr);
-Stmt substitute_in_all_lets(Stmt stmt);
+Expr substitute_in_all_lets(const Expr &expr);
+Stmt substitute_in_all_lets(const Stmt &stmt);
 // @}
 
 }

--- a/test/correctness/fuzz_simplify.cpp
+++ b/test/correctness/fuzz_simplify.cpp
@@ -68,7 +68,7 @@ Expr random_leaf(Type T, bool overflow_undef = false, bool imm_only = false) {
 Expr random_expr(Type T, int depth, bool overflow_undef = false);
 
 Expr random_condition(Type T, int depth, bool maybe_scalar) {
-    typedef Expr (*make_bin_op_fn)(Expr, Expr);
+    typedef Expr (*make_bin_op_fn)(const Expr &, const Expr &);
     static make_bin_op_fn make_bin_op[] = {
         EQ::make,
         NE::make,
@@ -90,7 +90,7 @@ Expr random_condition(Type T, int depth, bool maybe_scalar) {
 }
 
 Expr random_expr(Type T, int depth, bool overflow_undef) {
-    typedef Expr (*make_bin_op_fn)(Expr, Expr);
+    typedef Expr (*make_bin_op_fn)(const Expr &, const Expr &);
     static make_bin_op_fn make_bin_op[] = {
         Add::make,
         Sub::make,


### PR DESCRIPTION
Convert Expr-by-value args to Expr-by-const-ref in IROperator.h; this
is motivated by reducing of temporaries (and thus stack space) for
debug/non-opt builds of Halide.

This is a very conservative change: only functions that could continue
to work unmodified were changed (if the args were mutated in any way,
pass-by-value is retained).

(It’s arguably preferable to be consistent within a file and convert
100% of the calls to const-ref, even if it means minor cleanup to the
interior code of a few methods; if reviewers prefer this be done here,
LMK)