### PR TITLE
Avoid unnecessary temp copies in ErrorReport::<<

### DIFF
--- a/src/Error.h
+++ b/src/Error.h
@@ -116,9 +116,10 @@ struct ErrorReport {
     }
 
     template<typename T>
-    ErrorReport &operator<<(T x) {
-        if (condition) return *this;
-        (*msg) << x;
+    ErrorReport &operator<<(const T &x) {
+        if (!condition) {
+            (*msg) << x;
+        }
         return *this;
     }
 


### PR DESCRIPTION
Existing code will make redundant copies in non-opt build.