### PR TITLE
correctness_image_io was broken

### DIFF
--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -78,9 +78,12 @@ int main(int argc, char **argv) {
     std::string formats[] = {"jpg", "png", "ppm"};
     for (std::string format : formats) {
         test_round_trip(color_buf, format);
-        test_round_trip(luma_buf, format);
-        return 0;
+        if (format != "ppm") {
+            // ppm really only supports RGB images.
+            test_round_trip(luma_buf, format);
+        }
     }
+    return 0;
 }
 
 #endif

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -514,6 +514,8 @@ bool load_ppm(const std::string &filename, ImageType *im) {
 // "im" is not const-ref because copy_to_host() is not const.
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
 bool save_ppm(ImageType &im, const std::string &filename) {
+    if (!check(im.channels() == 3, "save_ppm() requires a 3-channel image.\n")) { return false; }
+
     im.copy_to_host();
 
     unsigned int bit_depth = sizeof(typename ImageType::ElemType) == 1 ? 8: 16;


### PR DESCRIPTION
It only tested jpg, not png or ppm, due to a misplaced return. Fixing
this revealed that the luma case can’t work for ppm (since ppm is
RGB-only); skipped it in the test and added assertion to save_ppm() to
avoid pain for future users.