### PR TITLE
Add ThreadPool utility for testing & output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -499,6 +499,7 @@ HEADER_FILES = \
   StorageFolding.h \
   Substitute.h \
   Target.h \
+  ThreadPool.h \
   Tracing.h \
   TrimNoOps.h \
   Tuple.h \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -339,6 +339,7 @@ set(HEADER_FILES
   StorageFolding.h
   Substitute.h
   Target.h
+  ThreadPool.h
   Tracing.h
   TrimNoOps.h
   Tuple.h

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -13,6 +13,7 @@
 #include "IROperator.h"
 #include "Outputs.h"
 #include "StmtToHtml.h"
+#include "ThreadPool.h"
 
 using Halide::Internal::debug;
 
@@ -319,9 +320,10 @@ void compile_multitarget(const std::string &fn_name,
     }
 
     std::vector<std::future<void>> futures;
-    // If we are running with HL_DEBUG_CODEGEN=1, choose a policy that enforces
+    // If we are running with HL_DEBUG_CODEGEN=1, use threads=1 to enforce
     // sequential execution, so that debug output won't be utterly incomprehensible
-    std::launch policy = debug::debug_level() > 0 ? std::launch::deferred : std::launch::async;
+    const size_t num_threads = (debug::debug_level() > 0) ? 1 : (targets.size() + 3);
+    Internal::ThreadPool<void> pool(num_threads);
 
     TemporaryObjectFileDir temp_dir;
     std::vector<Expr> wrapper_args;
@@ -374,7 +376,7 @@ void compile_multitarget(const std::string &fn_name,
         Outputs sub_out = add_suffixes(output_files, suffix);
         internal_assert(sub_out.object_name.empty());
         sub_out.object_name = temp_dir.add_temp_object_file(output_files.static_library_name, suffix, target);
-        futures.emplace_back(std::async(policy, [](Module m, Outputs o) {
+        futures.emplace_back(pool.async([](Module m, Outputs o) {
             debug(1) << "compile_multitarget: compile_sub_target " << o.object_name << "\n";
             m.compile(o);
         }, std::move(sub_module), std::move(sub_out)));
@@ -395,7 +397,7 @@ void compile_multitarget(const std::string &fn_name,
         Target runtime_target = base_target.without_feature(Target::NoRuntime);
         Outputs runtime_out = Outputs().object(
             temp_dir.add_temp_object_file(output_files.static_library_name, "_runtime", runtime_target));
-        futures.emplace_back(std::async(policy, [](Target t, Outputs o) {
+        futures.emplace_back(pool.async([](Target t, Outputs o) {
             debug(1) << "compile_multitarget: compile_standalone_runtime " << o.static_library_name << "\n";
             compile_standalone_runtime(o, t);
         }, std::move(runtime_target), std::move(runtime_out)));
@@ -432,7 +434,7 @@ void compile_multitarget(const std::string &fn_name,
         wrapper_module.append(LoweredFunc(fn_name, base_target_args, wrapper_body, LoweredFunc::External));
         Outputs wrapper_out = Outputs().object(
             temp_dir.add_temp_object_file(output_files.static_library_name, "_wrapper", base_target, /* in_front*/ true));
-        futures.emplace_back(std::async(policy, [](Module m, Outputs o) {
+        futures.emplace_back(pool.async([](Module m, Outputs o) {
             debug(1) << "compile_multitarget: wrapper " << o.object_name << "\n";
             m.compile(o);
         }, std::move(wrapper_module), std::move(wrapper_out)));
@@ -442,7 +444,7 @@ void compile_multitarget(const std::string &fn_name,
         Module header_module(fn_name, base_target);
         header_module.append(LoweredFunc(fn_name, base_target_args, {}, LoweredFunc::External));
         Outputs header_out = Outputs().c_header(output_files.c_header_name);
-        futures.emplace_back(std::async(policy, [](Module m, Outputs o) {
+        futures.emplace_back(pool.async([](Module m, Outputs o) {
             debug(1) << "compile_multitarget: c_header_name " << o.c_header_name << "\n";
             m.compile(o);
         }, std::move(header_module), std::move(header_out)));

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -322,7 +322,7 @@ void compile_multitarget(const std::string &fn_name,
     std::vector<std::future<void>> futures;
     // If we are running with HL_DEBUG_CODEGEN=1, use threads=1 to enforce
     // sequential execution, so that debug output won't be utterly incomprehensible
-    const size_t num_threads = (debug::debug_level() > 0) ? 1 : (targets.size() + 3);
+    const size_t num_threads = (debug::debug_level() > 0) ? 1 : Internal::ThreadPool<void>::num_processors_online();
     Internal::ThreadPool<void> pool(num_threads);
 
     TemporaryObjectFileDir temp_dir;

--- a/src/ThreadPool.h
+++ b/src/ThreadPool.h
@@ -1,4 +1,5 @@
 #ifndef HALIDE_THREAD_POOL_H
+#define HALIDE_THREAD_POOL_H
 
 #include <condition_variable>
 #include <future>

--- a/src/ThreadPool.h
+++ b/src/ThreadPool.h
@@ -118,7 +118,13 @@ public:
         Job job;
         // Don't use std::forward here: we never want args passed by reference,
         // since they will be accessed from an arbitrary thread.
-        job.func = [func, args...]() -> T { return func(args...); };
+        //
+        // Some versions of GCC won't allow capturing variadic arguments in a lambda;
+        //
+        //     job.func = [func, args...]() -> T { return func(args...); };  // Nope, sorry
+        //
+        // fortunately, we can use std::bind() to accomplish the same thing.
+        job.func = std::bind(func, args...);
         jobs.emplace(std::move(job));
         std::future<T> result = jobs.back().result.get_future();
 

--- a/src/ThreadPool.h
+++ b/src/ThreadPool.h
@@ -1,0 +1,152 @@
+#ifndef HALIDE_THREAD_POOL_H
+
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <queue>
+#include <thread>
+
+#ifdef _MSC_VER
+#else
+#include <unistd.h>
+#endif
+
+/** \file
+ * Define a simple thread pool utility that is modeled on the api of
+ * C++11 std::async(); since implementation details of std::async
+ * can vary considerably, with no control over thread spawning, this class
+ * allows us to use the same model but with precise control over thread usage.
+ *
+ * A ThreadPool is created with a specific number of threads, which will never
+ * vary over the life of the ThreadPool. (If created without a specific number
+ * of threads, it will attempt to use threads == number-of-cores.)
+ *
+ * Each async request will go into a queue, and will be serviced by the next 
+ * available thread from the pool.
+ * 
+ * The ThreadPool's dtor will block until all currently-executing tasks
+ * to finish (but won't schedule any more).
+ * 
+ * Note that this is a fairly simpleminded ThreadPool, meant for tasks
+ * that are fairly coarse (e.g. different tasks in a test); it is specifically 
+ * *not* intended to be the underlying implementation for Halide runtime threads
+ */
+namespace Halide {
+namespace Internal {
+
+template<typename T>
+class ThreadPool {
+    struct Job {
+        std::function<T()> func;
+        std::promise<T> result;
+
+        void run_unlocked(std::unique_lock<std::mutex> &unique_lock);
+    };
+
+    // all fields are protected by this mutex.
+    std::mutex mutex;
+
+    // Queue of Jobs.
+    std::queue<Job> jobs;
+
+    // Broadcast whenever items are added to the Job queue.
+    std::condition_variable wakeup_threads;
+
+    // Keep track of threads so they can be joined at shutdown
+    std::vector<std::thread> threads;
+
+    // True if the pool is shutting down.
+    bool shutting_down{false};
+
+    void worker_thread() {
+        std::unique_lock<std::mutex> unique_lock(mutex);
+        while (!shutting_down) {
+            if (jobs.empty()) {
+                // There are no jobs pending. Wait until more jobs are enqueued.
+                wakeup_threads.wait(unique_lock);
+            } else {
+                // Grab the next job.
+                Job cur_job = std::move(jobs.front());
+                jobs.pop();
+                cur_job.run_unlocked(unique_lock);
+            }
+        }
+    }
+
+public:
+
+    static size_t num_processors_online() {
+    #ifdef _MSC_VER
+        char *num_cores = getenv("NUMBER_OF_PROCESSORS");
+        return num_cores ? atoi(num_cores) : 8;
+    #else
+        return sysconf(_SC_NPROCESSORS_ONLN);
+    #endif
+    }
+
+    // Default to number of available cores if not specified otherwise
+    ThreadPool(size_t desired_num_threads = num_processors_online()) {
+        assert(desired_num_threads > 0);
+
+        std::lock_guard<std::mutex> lock(mutex);
+
+        // Create all the threads.
+        for (size_t i = 0; i < desired_num_threads; ++i) {
+            threads.emplace_back([this]{ worker_thread(); });
+        }
+    }
+
+    ~ThreadPool() {
+        // Wake everyone up and tell them the party's over and it's time to go home
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            shutting_down = true;
+            wakeup_threads.notify_all();
+        }
+
+        // Wait until they leave
+        for (auto &t : threads) {
+            t.join();
+        }
+    }
+
+    template<typename Func, typename... Args>
+    std::future<T> async(Func func, Args... args) {
+        std::lock_guard<std::mutex> lock(mutex);
+
+        Job job;
+        // Don't use std::forward here: we never want args passed by reference,
+        // since they will be accessed from an arbitrary thread.
+        job.func = [func, args...]() -> T { return func(args...); };
+        jobs.emplace(std::move(job));
+        std::future<T> result = jobs.back().result.get_future();
+
+        // Wake up our threads.
+        wakeup_threads.notify_all();
+
+        return result;
+    }
+};
+
+template<typename T>
+inline void ThreadPool<T>::Job::run_unlocked(std::unique_lock<std::mutex> &unique_lock) {
+    unique_lock.unlock();
+    T r = func();
+    unique_lock.lock();
+    result.set_value(std::move(r));
+}
+
+template<>
+inline void ThreadPool<void>::Job::run_unlocked(std::unique_lock<std::mutex> &unique_lock) {
+    unique_lock.unlock();
+    func();
+    unique_lock.lock();
+    result.set_value();
+}
+
+
+}  // namespace Internal
+}  // namespace Halide
+
+#endif  // HALIDE_THREAD_POOL_H
+

--- a/test/correctness/boundary_conditions.cpp
+++ b/test/correctness/boundary_conditions.cpp
@@ -374,10 +374,11 @@ bool test_all(int vector_width, Target t) {
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
 
+    Halide::Internal::ThreadPool<bool> pool;
     std::vector<std::future<bool>> futures;
     for (int vector_width = 1; vector_width <= 32; vector_width *= 2) {
         std::cout << "Testing vector_width: " << vector_width << "\n";
-        futures.push_back(std::async(test_all, vector_width, target));
+        futures.push_back(pool.async(test_all, vector_width, target));
     }
 
     bool success = true;

--- a/test/correctness/mul_div_mod.cpp
+++ b/test/correctness/mul_div_mod.cpp
@@ -570,20 +570,21 @@ int main(int argc, char **argv) {
         div_vector_widths.push_back(1);
     }
 
+    Halide::Internal::ThreadPool<bool> pool;
     std::vector<std::future<bool>> futures;
     for (int vector_width : mul_vector_widths) {
         std::cout << "Testing mul vector_width: " << vector_width << "\n";
-        auto f = std::async(test_mul, vector_width, scheduling, target);
+        auto f = pool.async(test_mul, vector_width, scheduling, target);
         futures.push_back(std::move(f));
     }
 
     for (int vector_width : div_vector_widths) {
         std::cout << "Testing div_mod vector_width: " << vector_width << "\n";
-        auto f = std::async(test_div_mod, vector_width, scheduling, target);
+        auto f = pool.async(test_div_mod, vector_width, scheduling, target);
         futures.push_back(std::move(f));
     }
 
-    futures.push_back(std::async(f_mod<float, double>));
+    futures.push_back(pool.async(f_mod<float, double>));
 
     bool success = true;
     for (auto &f : futures) {

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -40,7 +40,7 @@ struct Task {
     Expr expr;
 };
 
-size_t num_threads = 8;
+size_t num_threads = Halide::Internal::ThreadPool<void>::num_processors_online();
 
 struct Test {
     bool use_avx2{false};
@@ -1974,25 +1974,22 @@ struct Test {
             check_altivec_all();
         }
 
-        // Use a small thread pool to run the tests. Just statically
-        // partition the work between the threads.
-        bool success = true;
-        std::vector<std::thread> threads;
-        for (size_t i = 0; i < num_threads; i++) {
-            threads.emplace_back([this, i, &success]{
-                for (size_t t = i; t < tasks.size(); t += num_threads) {
-                    Task &task = tasks[t];
-                    TestResult result = check_one(task.op, task.name, task.vector_width, task.expr);
-                    std::cout << result.op << "\n";
-                    if (!result.error_msg.empty()) {
-                        std::cerr << result.error_msg;
-                        success = false;
-                    }
-                }
-            });
+        Halide::Internal::ThreadPool<TestResult> pool(num_threads);
+        std::vector<std::future<TestResult>> futures;
+        for (const Task &task : tasks) {
+            futures.push_back(pool.async([this, task]() {
+                return check_one(task.op, task.name, task.vector_width, task.expr);
+            }));
         }
-        for (auto &t : threads) {
-            t.join();
+
+        bool success = true;
+        for (auto &f : futures) {
+            const TestResult &result = f.get();
+            std::cout << result.op << "\n";
+            if (!result.error_msg.empty()) {
+                std::cerr << result.error_msg;
+                success = false;
+            }
         }
 
         return success;

--- a/test/correctness/vector_cast.cpp
+++ b/test/correctness/vector_cast.cpp
@@ -141,9 +141,10 @@ int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
 
     // We only test power-of-two vector widths for now
+    Halide::Internal::ThreadPool<bool> pool;
     std::vector<std::future<bool>> futures;
     for (int vec_width = 1; vec_width <= 64; vec_width*=2) {
-        futures.push_back(std::async(std::launch::async, [=]() {
+        futures.push_back(pool.async([=]() {
             bool success = true;
             success = success && test_all<float>(vec_width, target);
             success = success && test_all<double>(vec_width, target);

--- a/test/correctness/vector_math.cpp
+++ b/test/correctness/vector_math.cpp
@@ -623,16 +623,17 @@ bool test(int lanes) {
 int main(int argc, char **argv) {
 
     // Only native vector widths - llvm doesn't handle others well
+    Halide::Internal::ThreadPool<bool> pool;
     std::vector<std::future<bool>> futures;
-    futures.push_back(std::async(test<float>, 4));
-    futures.push_back(std::async(test<float>, 8));
-    futures.push_back(std::async(test<double>, 2));
-    futures.push_back(std::async(test<uint8_t>, 16));
-    futures.push_back(std::async(test<int8_t>, 16));
-    futures.push_back(std::async(test<uint16_t>, 8));
-    futures.push_back(std::async(test<int16_t>, 8));
-    futures.push_back(std::async(test<uint32_t>, 4));
-    futures.push_back(std::async(test<int32_t>, 4));
+    futures.push_back(pool.async(test<float>, 4));
+    futures.push_back(pool.async(test<float>, 8));
+    futures.push_back(pool.async(test<double>, 2));
+    futures.push_back(pool.async(test<uint8_t>, 16));
+    futures.push_back(pool.async(test<int8_t>, 16));
+    futures.push_back(pool.async(test<uint16_t>, 8));
+    futures.push_back(pool.async(test<int16_t>, 8));
+    futures.push_back(pool.async(test<uint32_t>, 4));
+    futures.push_back(pool.async(test<int32_t>, 4));
 
     bool ok = true;
     for (auto &f : futures) {


### PR DESCRIPTION
std::async() is problematic because details are too implementation-defined. This introduces a simple ThreadPool class that provides essentially the same API as std::async, but implemented as a fixed-size pool of std::thread. 