### PR TITLE
Prevent GeneratorParam values from being examined by Inputs/Outputs

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -970,6 +970,10 @@ GeneratorParamBase::GeneratorParamBase(const std::string &name) : name(name) {
 
 GeneratorParamBase::~GeneratorParamBase() { ObjectInstanceRegistry::unregister_instance(this); }
 
+void GeneratorParamBase::check_value_valid() const {
+    user_assert(value_valid) << "The GeneratorParam " << name << " cannot be accessed before build() or generate() is called.\n";
+}
+
 /* static */
 GeneratorRegistry &GeneratorRegistry::get_registry() {
     static GeneratorRegistry *registry = new GeneratorRegistry;
@@ -1212,6 +1216,9 @@ void GeneratorBase::set_generator_param_values(const std::map<std::string, std::
             }
         }
         user_error << "Generator " << generator_name << " has no GeneratorParam named: " << key << "\n";
+    }
+    for (auto p : generator_params) {
+        p->value_valid = true;
     }
     generator_params_set = true;
 }

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1662,6 +1662,7 @@ Target StubOutputBufferBase::get_target() const {
 
 void generator_test() {
     GeneratorParam<int> gp("gp", 1);
+    gp.value_valid = true;
 
     // Verify that RDom parameter-pack variants can convert GeneratorParam to Expr
     RDom rdom(0, gp, 0, gp);
@@ -1713,6 +1714,8 @@ void generator_test() {
     check_ratio(NAN, {0, 0});
     check_ratio(INFINITY, {1, 0});
     check_ratio(-INFINITY, {-1, 0});
+
+    std::cout << "Generator test passed" << std::endl;
 }
 
 }  // namespace Internal

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -317,6 +317,8 @@ struct select_type : std::conditional<First::value, typename First::type, typena
 template<typename First>
 struct select_type<First> { using type = typename std::conditional<First::value, typename First::type, void>::type; };
 
+class GeneratorBase;
+
 class GeneratorParamBase {
 public:
     EXPORT explicit GeneratorParamBase(const std::string &name);
@@ -327,6 +329,8 @@ public:
 protected:
     friend class GeneratorBase;
     friend class StubEmitter;
+
+    void check_value_valid() const;
 
     virtual void set_from_string(const std::string &value_string) = 0;
     virtual std::string to_string() const = 0;
@@ -360,6 +364,11 @@ protected:
 private:
     explicit GeneratorParamBase(const GeneratorParamBase &) = delete;
     void operator=(const GeneratorParamBase &) = delete;
+
+    // It is only valid to examine a GeneratorParam's value after the owning
+    // Generator has had set_generator_param_values() called (even if this
+    // particular GP was left unaffected).
+    bool value_valid{false};
 };
 
 template<typename T>
@@ -367,7 +376,7 @@ class GeneratorParamImpl : public GeneratorParamBase {
 public:
     GeneratorParamImpl(const std::string &name, const T &value) : GeneratorParamBase(name), value_(value) {}
 
-    T value() const { return value_; }
+    T value() const { check_value_valid(); return value_; }
 
     operator T() const { return this->value(); }
 
@@ -928,8 +937,6 @@ public:
     template<typename T2>
     StubInputBuffer(const Buffer<T2> &b) : parameter_(parameter_from_buffer(b)) {}
 };
-
-class GeneratorBase;
 
 class StubOutputBufferBase {
 protected:

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -212,6 +212,8 @@ template<typename T> class Buffer;
 
 namespace Internal {
 
+EXPORT void generator_test();
+
 /**
  * ValueTracker is an internal utility class that attempts to track and flag certain
  * obvious Stub-related errors at Halide compile time: it tracks the constraints set
@@ -327,6 +329,7 @@ public:
     const std::string name;
 
 protected:
+    friend void ::Halide::Internal::generator_test();
     friend class GeneratorBase;
     friend class StubEmitter;
 
@@ -2140,8 +2143,6 @@ private:
     GeneratorRegistry(const GeneratorRegistry &) = delete;
     void operator=(const GeneratorRegistry &) = delete;
 };
-
-EXPORT void generator_test();
 
 }  // namespace Internal
 


### PR DESCRIPTION
Due to operator overloading, you could do something like


    GeneratorParam<int> foo{“foo”, 1};
    Input<Int> bar{“bar”, 3*foo};

This happened to compile, but was never intended to work, and probably didn’t do what you wanted (it always used the default-contructed value of the GP, rather than the possibly-different value specified in a build file).

Now we force a compile-time error if you attempt to read from a GeneratorParam before the build()/generate() method is called.
