### PR TITLE
Array variants of Input<>/Output<> should make operator[] and at() return const refs

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1223,12 +1223,12 @@ public:
     }
 
     template <typename T2 = T, typename std::enable_if<std::is_array<T2>::value>::type * = nullptr>
-    ValueType operator[](size_t i) const {
+    const ValueType &operator[](size_t i) const {
         return get_values<ValueType>()[i];
     }
 
     template <typename T2 = T, typename std::enable_if<std::is_array<T2>::value>::type * = nullptr>
-    ValueType at(size_t i) const {
+    const ValueType &at(size_t i) const {
         return get_values<ValueType>().at(i);
     }
 
@@ -1647,12 +1647,12 @@ public:
     }
 
     template <typename T2 = T, typename std::enable_if<std::is_array<T2>::value>::type * = nullptr>
-    ValueType operator[](size_t i) const {
+    const ValueType &operator[](size_t i) const {
         return get_values<ValueType>()[i];
     }
 
     template <typename T2 = T, typename std::enable_if<std::is_array<T2>::value>::type * = nullptr>
-    ValueType at(size_t i) const {
+    const ValueType &at(size_t i) const {
         return get_values<ValueType>().at(i);
     }
 


### PR DESCRIPTION
As of now, these fields are not intended to be settable; this was
enforced for non-Array variants, but the Array variants allowed you to
attempt this, causing a confusing compile-time message:

Output<Func[]> out{…};
….
out[0] = Func();

Previously this gave a confusing message at Generation time about
“out_1 not defined”; now this fails at C++ compile time with “no viable
overloaded ‘=‘”.

(Note that while Input<> values are always read-only, for obvious
reasons, re-assigning the Funcs for Output<> should be made legal in
general. That will happen in a subsequent PR.)