### PR TITLE
use std::declval<> instead of dummy_runtime_buffer()

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -289,24 +289,20 @@ public:
     }
     // @}
 
-private:
-    // Helpers for decltypes used below
-    static const Runtime::Buffer<T> &dummy_const_runtime_buffer();
-    static Runtime::Buffer<T> &dummy_runtime_buffer();
 public:
 
     // We forward numerous methods from the underlying Buffer
 #define HALIDE_BUFFER_FORWARD_CONST(method)                             \
     template<typename ...Args>                                          \
     auto method(Args&&... args) const ->                                \
-        decltype(dummy_const_runtime_buffer().method(std::forward<Args>(args)...)) { \
+        decltype(std::declval<const Runtime::Buffer<T>>().method(std::forward<Args>(args)...)) { \
         return get()->method(std::forward<Args>(args)...);              \
     }
 
 #define HALIDE_BUFFER_FORWARD(method)                                   \
     template<typename ...Args>                                          \
     auto method(Args&&... args) ->                                      \
-        decltype(dummy_runtime_buffer().method(std::forward<Args>(args)...)) { \
+        decltype(std::declval<Runtime::Buffer<T>>().method(std::forward<Args>(args)...)) { \
         return get()->method(std::forward<Args>(args)...);              \
     }
 
@@ -392,33 +388,33 @@ public:
 
     template<typename ...Args>
     auto operator()(int first, Args&&... args) ->
-        decltype(dummy_runtime_buffer()(first, std::forward<Args>(args)...)) {
+        decltype(std::declval<Runtime::Buffer<T>>()(first, std::forward<Args>(args)...)) {
         return (*get())(first, std::forward<Args>(args)...);
     }
 
     template<typename ...Args>
     auto operator()(int first, Args&&... args) const ->
-        decltype(dummy_const_runtime_buffer()(first, std::forward<Args>(args)...)) {
+        decltype(std::declval<const Runtime::Buffer<T>>()(first, std::forward<Args>(args)...)) {
         return (*get())(first, std::forward<Args>(args)...);
     }
 
     auto operator()(const int *pos) ->
-        decltype(dummy_runtime_buffer()(pos)) {
+        decltype(std::declval<Runtime::Buffer<T>>()(pos)) {
         return (*get())(pos);
     }
 
     auto operator()(const int *pos) const ->
-        decltype(dummy_const_runtime_buffer()(pos)) {
+        decltype(std::declval<const Runtime::Buffer<T>>()(pos)) {
         return (*get())(pos);
     }
 
     auto operator()() ->
-        decltype(dummy_runtime_buffer()()) {
+        decltype(std::declval<Runtime::Buffer<T>>()()) {
         return (*get())();
     }
 
     auto operator()() const ->
-        decltype(dummy_const_runtime_buffer()()) {
+        decltype(std::declval<const Runtime::Buffer<T>>()()) {
         return (*get())();
     }
     // @}


### PR DESCRIPTION
Just a minor nit, but this is really what std::declval<> is intended
for, and is arguably cleaner than the declared-but-undefined static
methods.