### PR TITLE
Prefetch fixes, avoid trimming loops that only prefetch

### DIFF
--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -205,24 +205,11 @@ private:
                 // either read or written.
                 for (const auto &b : boxes_read) {
                     const string &buf_name = b.first;
-                    Box prefetch_box = b.second;
 
                     // Only prefetch the region that is in bounds.
                     Box bounds = buffer_bounds(buf_name, b.second.size());
+                    Box prefetch_box = box_intersection(b.second, bounds);
 
-#if 1
-                    // TODO: Consider enabling this, which adds likely intrinsics to the
-                    // box prior to clamping it to the bounds of the buffer. This leads
-                    // the loops to be split up such that the steady state does not have
-                    // any boundary condition logic. On matrix multiplication on Hexagon,
-                    // this reduced the runtime by ~4%.
-                    for (auto &i : prefetch_box.bounds) {
-                        i.min = likely(i.min);
-                        i.max = likely(i.max);
-                    }
-#endif
-
-                    prefetch_box = box_intersection(prefetch_box, bounds);
                     body = add_prefetch(buf_name, prefetch_box, body);
                 }
             }

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -139,14 +139,14 @@ private:
             // The prefetch is only 1 dimensional, just emit a flat prefetch.
             prefetch = Evaluate::make(Call::make(Int(32), Call::prefetch,
                                                  {prefetch_addr, extent_0_bytes},
-                                                 Call::PureIntrinsic));
+                                                 Call::Intrinsic));
         } else {
             // Make a 2D prefetch.
             Expr stride_1 = Variable::make(Int(32), buf_name + ".stride.1");
             Expr stride_1_bytes = stride_1 * type.bytes();
             prefetch = Evaluate::make(Call::make(Int(32), Call::prefetch_2d,
                                                  {prefetch_addr, extent_0_bytes, prefetch_extent[1], stride_1_bytes},
-                                                 Call::PureIntrinsic));
+                                                 Call::Intrinsic));
 
             // Make loops for the rest of the dimensions (possibly zero).
             for (size_t i = 2; i < box.size(); i++) {
@@ -205,11 +205,24 @@ private:
                 // either read or written.
                 for (const auto &b : boxes_read) {
                     const string &buf_name = b.first;
+                    Box prefetch_box = b.second;
 
                     // Only prefetch the region that is in bounds.
                     Box bounds = buffer_bounds(buf_name, b.second.size());
-                    Box prefetch_box = box_intersection(b.second, bounds);
 
+#if 1
+                    // TODO: Consider enabling this, which adds likely intrinsics to the
+                    // box prior to clamping it to the bounds of the buffer. This leads
+                    // the loops to be split up such that the steady state does not have
+                    // any boundary condition logic. On matrix multiplication on Hexagon,
+                    // this reduced the runtime by ~4%.
+                    for (auto &i : prefetch_box.bounds) {
+                        i.min = likely(i.min);
+                        i.max = likely(i.max);
+                    }
+#endif
+
+                    prefetch_box = box_intersection(prefetch_box, bounds);
                     body = add_prefetch(buf_name, prefetch_box, body);
                 }
             }

--- a/src/TrimNoOps.cpp
+++ b/src/TrimNoOps.cpp
@@ -146,10 +146,9 @@ class IsNoOp : public IRVisitor {
     }
 
     void visit(const Call *op) {
-        // Certain intrinsics that may appear in loops have side-effects. Most notably: image_store.
-        if (op->call_type == Call::Intrinsic &&
-            (op->name == Call::image_store ||
-             op->name == Call::copy_memory)) {
+        // If the loop calls an impure function, we can't remove the
+        // call to it. Most notably: image_store.
+        if (!op->is_pure()) {
             condition = const_false();
             return;
         }

--- a/src/runtime/qurt_hvx.cpp
+++ b/src/runtime/qurt_hvx.cpp
@@ -52,6 +52,9 @@ WEAK void halide_qurt_hvx_unlock_as_destructor(void *user_context, void * /*obj*
     halide_qurt_hvx_unlock(user_context);
 }
 
+// These need to inline, otherwise the extern call with the ptr
+// parameter breaks a lot of optimizations.
+__attribute__((always_inline))
 WEAK int halide_prefetch_2d(const void *ptr, int width_bytes, int height, int stride_bytes) {
     // Notes:
     //  - Prefetches can be queued up to 3 deep (MAX_PREFETCH)
@@ -70,6 +73,7 @@ WEAK int halide_prefetch_2d(const void *ptr, int width_bytes, int height, int st
     return 0;
 }
 
+__attribute__((always_inline))
 WEAK int halide_prefetch(const void *ptr, int size) {
     halide_prefetch_2d(ptr, size, 1, 1);
     return 0;


### PR DESCRIPTION
This PR has a few fixes for prefetching:

- Trim no-ops was removing loops that did prefetching, because prefetch was marked as a pure function.
- The Hexagon runtime function should always be inlined, otherwise, the call with the pointer parameter breaks a lot of important optimizations. Inlining also often enables the l2fetch argument to be lifted out of a loop.
- Added a (currently disabled) block of code that causes Halide to partition the loops for the prefetching bounds checking. It seemed to only have a small impact on the workload I was benchmarking. I'm considering removing this since it's dead code...