### PR TITLE
Opengl tests cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -769,6 +769,8 @@ OPENGL_TESTS := $(shell ls $(ROOT_DIR)/test/opengl/*.cpp)
 GENERATOR_EXTERNAL_TESTS := $(shell ls $(ROOT_DIR)/test/generator/*test.cpp)
 TUTORIALS = $(filter-out %_generate.cpp, $(shell ls $(ROOT_DIR)/tutorial/*.cpp))
 
+-include $(OPENGL_TESTS:$(ROOT_DIR)/test/opengl/%.cpp=$(BUILD_DIR)/test_opengl_%.d)
+
 test_correctness: $(CORRECTNESS_TESTS:$(ROOT_DIR)/test/correctness/%.cpp=correctness_%) $(CORRECTNESS_TESTS:$(ROOT_DIR)/test/correctness/%.c=correctness_%)
 test_performance: $(PERFORMANCE_TESTS:$(ROOT_DIR)/test/performance/%.cpp=performance_%)
 test_errors: $(ERROR_TESTS:$(ROOT_DIR)/test/error/%.cpp=error_%)
@@ -870,7 +872,7 @@ $(BIN_DIR)/warning_%: $(ROOT_DIR)/test/warning/%.cpp $(BIN_DIR)/libHalide.$(SHAR
 	$(CXX) $(TEST_CXX_FLAGS) $(OPTIMIZE) $< -I$(INCLUDE_DIR) $(TEST_LD_FLAGS) -o $@
 
 $(BIN_DIR)/opengl_%: $(ROOT_DIR)/test/opengl/%.cpp $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR)/Halide.h
-	$(CXX) $(TEST_CXX_FLAGS) $(OPTIMIZE) $< -I$(INCLUDE_DIR) -I$(SRC_DIR) $(TEST_LD_FLAGS) $(OPENGL_LD_FLAGS) -o $@
+	$(CXX) $(TEST_CXX_FLAGS) $(OPTIMIZE) $< -I$(INCLUDE_DIR) -I$(SRC_DIR) $(TEST_LD_FLAGS) $(OPENGL_LD_FLAGS) -o $@ -MMD -MF $(BUILD_DIR)/test_opengl_$*.d
 
 
 # TODO(srj): this doesn't auto-delete, why not?

--- a/test/opengl/conv_select.cpp
+++ b/test/opengl/conv_select.cpp
@@ -4,6 +4,8 @@
 #include "Halide.h"
 #include <stdio.h>
 
+#include "./testing.h"
+
 using namespace Halide;
 
 int main() {
@@ -13,13 +15,9 @@ int main() {
     // Define the input
     const int width = 10, height = 10, channels = 4, res_channels = 2;
     Buffer<float> input(width, height, channels);
-    for (int c = 0; c < input.channels(); c++) {
-        for (int y = 0; y < input.height(); y++) {
-            for (int x = 0; x < input.width(); x++) {
-                input(x, y, c) = float(x + y);
-            }
-        }
-    }
+    Testing::fill<float>(input, [](int x, int y, int c) {
+            return float(x + y);
+        });
 
     // Define the algorithm.
     Var x, y, c;
@@ -41,20 +39,11 @@ int main() {
     result.copy_to_host();
 
     //Check the result.
-    for (int c = 0; c < result.channels(); c++) {
-        for (int y = 0; y < result.height(); y++) {
-            for (int x = 0; x < result.width(); x++) {
-                float temp = ((x + y)>4)?1.0f:0.0f;
-
-                float correct = (c==0)? temp : (1.0f - temp);
-                if (result(x, y, c) != correct) {
-                    fprintf(stderr, "result(%d, %d, %d) = %f instead of %f\n",
-                            x, y, c, result(x, y, c), correct);
-                    return 1;
-                }
-            }
-        }
-    }
+    if (!(Testing::check_result<float>(result, [](int x, int y, int c) {
+                const float temp = ((x + y)>4)?1.0f:0.0f;
+                return (c==0)? temp : (1.0f - temp);
+            })))
+        return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/conv_select.cpp
+++ b/test/opengl/conv_select.cpp
@@ -15,7 +15,7 @@ int main() {
     // Define the input
     const int width = 10, height = 10, channels = 4, res_channels = 2;
     Buffer<float> input(width, height, channels);
-    Testing::fill<float>(input, [](int x, int y, int c) {
+    input.fill([](int x, int y, int c) {
             return float(x + y);
         });
 

--- a/test/opengl/conv_select.cpp
+++ b/test/opengl/conv_select.cpp
@@ -39,10 +39,10 @@ int main() {
     result.copy_to_host();
 
     //Check the result.
-    if (!(Testing::check_result<float>(result, [](int x, int y, int c) {
+    if (!Testing::check_result<float>(result, [](int x, int y, int c) {
                 const float temp = ((x + y)>4)?1.0f:0.0f;
                 return (c==0)? temp : (1.0f - temp);
-            })))
+            }))
         return 1;
 
     printf("Success!\n");

--- a/test/opengl/conv_select.cpp
+++ b/test/opengl/conv_select.cpp
@@ -1,6 +1,5 @@
 // test case provided by Lee Yuguang
 
-
 #include "Halide.h"
 #include <stdio.h>
 
@@ -16,8 +15,8 @@ int main() {
     const int width = 10, height = 10, channels = 4, res_channels = 2;
     Buffer<float> input(width, height, channels);
     input.fill([](int x, int y, int c) {
-            return float(x + y);
-        });
+        return float(x + y);
+    });
 
     // Define the algorithm.
     Var x, y, c;
@@ -29,7 +28,7 @@ int main() {
 
     Expr R = select(f(x, y, c) > 9.0f, 1.0f, 0.0f);
     Expr G = select(f(x, y, c) > 9.0f, 0.f, 1.0f);
-    g(x, y, c) = select(c==0, R, G);
+    g(x, y, c) = select(c == 0, R, G);
 
     // Schedule f and g to compute in separate passes on the GPU.
     g.bound(c, 0, 2).glsl(x, y, c);
@@ -40,9 +39,9 @@ int main() {
 
     //Check the result.
     if (!Testing::check_result<float>(result, [](int x, int y, int c) {
-                const float temp = ((x + y)>4)?1.0f:0.0f;
-                return (c==0)? temp : (1.0f - temp);
-            }))
+            const float temp = ((x + y) > 4) ? 1.0f : 0.0f;
+            return (c == 0) ? temp : (1.0f - temp);
+        }))
         return 1;
 
     printf("Success!\n");

--- a/test/opengl/conv_select.cpp
+++ b/test/opengl/conv_select.cpp
@@ -41,8 +41,9 @@ int main() {
     if (!Testing::check_result<float>(result, [](int x, int y, int c) {
             const float temp = ((x + y) > 4) ? 1.0f : 0.0f;
             return (c == 0) ? temp : (1.0f - temp);
-        }))
+        })) {
         return 1;
+    }
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/conv_select.cpp
+++ b/test/opengl/conv_select.cpp
@@ -3,7 +3,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 

--- a/test/opengl/copy_pixels.cpp
+++ b/test/opengl/copy_pixels.cpp
@@ -11,8 +11,8 @@ int main() {
 
     Buffer<uint8_t> input(255, 10, 3);
     input.fill([](int x, int y, int c) {
-            return 10*x + y + c;
-        });
+        return 10 * x + y + c;
+    });
 
     Var x, y, c;
     Func g;

--- a/test/opengl/copy_pixels.cpp
+++ b/test/opengl/copy_pixels.cpp
@@ -24,8 +24,9 @@ int main() {
     g.realize(out, target);
     out.copy_to_host();
 
-    if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) { return input(x, y, c); }))
+    if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) { return input(x, y, c); })) {
         return 1;
+    }
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/copy_pixels.cpp
+++ b/test/opengl/copy_pixels.cpp
@@ -1,6 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
-#include <stdlib.h>
+
+#include "./testing.h"
 
 using namespace Halide;
 
@@ -9,13 +10,9 @@ int main() {
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Buffer<uint8_t> input(255, 10, 3);
-    for (int y=0; y<input.height(); y++) {
-        for (int x=0; x<input.width(); x++) {
-            for (int c=0; c<3; c++) {
-              input(x, y, c) = 10*x + y + c;
-            }
-        }
-    }
+    Testing::fill<uint8_t>(input, [](int x, int y, int c) {
+            return 10*x + y + c;
+        });
 
     Var x, y, c;
     Func g;
@@ -27,19 +24,8 @@ int main() {
     g.realize(out, target);
     out.copy_to_host();
 
-    for (int y=0; y<out.height(); y++) {
-        for (int x=0; x<out.width(); x++) {
-            if (!(out(x, y, 0) == input(x, y, 0) &&
-                  out(x, y, 1) == input(x, y, 1) &&
-                  out(x, y, 2) == input(x, y, 2))) {
-                fprintf(stderr, "Incorrect pixel (%d,%d,%d) != (%d,%d,%d) at x=%d y=%d.\n",
-                        out(x, y, 0), out(x, y, 1), out(x, y, 2),
-                        input(x, y, 0), input(x, y, 1), input(x, y, 2),
-                        x, y);
-                return 1;
-            }
-        }
-    }
+    if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) { return input(x, y, c); }))
+        return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/copy_pixels.cpp
+++ b/test/opengl/copy_pixels.cpp
@@ -1,7 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 

--- a/test/opengl/copy_pixels.cpp
+++ b/test/opengl/copy_pixels.cpp
@@ -10,7 +10,7 @@ int main() {
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Buffer<uint8_t> input(255, 10, 3);
-    Testing::fill<uint8_t>(input, [](int x, int y, int c) {
+    input.fill([](int x, int y, int c) {
             return 10*x + y + c;
         });
 

--- a/test/opengl/copy_to_device.cpp
+++ b/test/opengl/copy_to_device.cpp
@@ -29,8 +29,9 @@ int main() {
     g.realize(out, target);
     out.copy_to_host();
 
-    if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) { return input(x, y, c); }))
+    if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) { return input(x, y, c); })) {
         return 1;
+    }
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/copy_to_device.cpp
+++ b/test/opengl/copy_to_device.cpp
@@ -1,6 +1,6 @@
 #include "Halide.h"
-#include <stdio.h>
-#include <stdlib.h>
+
+#include "./testing.h"
 
 using namespace Halide;
 
@@ -11,13 +11,9 @@ int main() {
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Buffer<uint8_t> input(255, 10, 3);
-    for (int y=0; y<input.height(); y++) {
-        for (int x=0; x<input.width(); x++) {
-            for (int c=0; c<3; c++) {
-              input(x, y, c) = 10*x + y + c;
-            }
-        }
-    }
+    Testing::fill<uint8_t>(input, [](int x, int y, int c) {
+            return 10*x + y + c;
+        });
 
     Var x, y, c;
     Func g, h;
@@ -33,19 +29,8 @@ int main() {
     g.realize(out, target);
     out.copy_to_host();
 
-    for (int y=0; y<out.height(); y++) {
-        for (int x=0; x<out.width(); x++) {
-            if (!(out(x, y, 0) == input(x, y, 0) &&
-                  out(x, y, 1) == input(x, y, 1) &&
-                  out(x, y, 2) == input(x, y, 2))) {
-                fprintf(stderr, "Incorrect pixel (%d,%d,%d) != (%d,%d,%d) at x=%d y=%d.\n",
-                        out(x, y, 0), out(x, y, 1), out(x, y, 2),
-                        input(x, y, 0), input(x, y, 1), input(x, y, 2),
-                        x, y);
-                return 1;
-            }
-        }
-    }
+    if (!(Testing::check_result<uint8_t>(out, [&](int x, int y, int c) { return input(x, y, c); })))
+        return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/copy_to_device.cpp
+++ b/test/opengl/copy_to_device.cpp
@@ -11,7 +11,7 @@ int main() {
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Buffer<uint8_t> input(255, 10, 3);
-    Testing::fill<uint8_t>(input, [](int x, int y, int c) {
+    input.fill([](int x, int y, int c) {
             return 10*x + y + c;
         });
 

--- a/test/opengl/copy_to_device.cpp
+++ b/test/opengl/copy_to_device.cpp
@@ -12,8 +12,8 @@ int main() {
 
     Buffer<uint8_t> input(255, 10, 3);
     input.fill([](int x, int y, int c) {
-            return 10*x + y + c;
-        });
+        return 10 * x + y + c;
+    });
 
     Var x, y, c;
     Func g, h;

--- a/test/opengl/copy_to_device.cpp
+++ b/test/opengl/copy_to_device.cpp
@@ -29,7 +29,7 @@ int main() {
     g.realize(out, target);
     out.copy_to_host();
 
-    if (!(Testing::check_result<uint8_t>(out, [&](int x, int y, int c) { return input(x, y, c); })))
+    if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) { return input(x, y, c); }))
         return 1;
 
     printf("Success!\n");

--- a/test/opengl/copy_to_device.cpp
+++ b/test/opengl/copy_to_device.cpp
@@ -1,6 +1,6 @@
 #include "Halide.h"
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 

--- a/test/opengl/copy_to_host.cpp
+++ b/test/opengl/copy_to_host.cpp
@@ -32,8 +32,9 @@ int main() {
                 case 1: return 127;
                 case 2: return 12;
                 default: return -1;
-            } }))
+            } })) {
         return 1;
+    }
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/copy_to_host.cpp
+++ b/test/opengl/copy_to_host.cpp
@@ -13,7 +13,7 @@ int main() {
     Var x, y, c;
 
     // Fill buffer using GLSL
-    gpu(x, y, c) = cast<uint8_t>(select(c == 0, 10*x + y,
+    gpu(x, y, c) = cast<uint8_t>(select(c == 0, 10 * x + y,
                                         c == 1, 127,
                                         12));
     gpu.bound(c, 0, 3);
@@ -32,7 +32,7 @@ int main() {
                 case 1: return 127;
                 case 2: return 12;
                 default: return -1;
-            }}))
+            } }))
         return 1;
 
     printf("Success!\n");

--- a/test/opengl/copy_to_host.cpp
+++ b/test/opengl/copy_to_host.cpp
@@ -26,13 +26,13 @@ int main() {
     Buffer<uint8_t> out(10, 10, 3);
     cpu.realize(out, target);
 
-    if (!(Testing::check_result<uint8_t>(out, [&](int x, int y, int c) {
+    if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) {
             switch (c) {
                 case 0: return 10*x+y;
                 case 1: return 127;
                 case 2: return 12;
                 default: return -1;
-            }})))
+            }}))
         return 1;
 
     printf("Success!\n");

--- a/test/opengl/copy_to_host.cpp
+++ b/test/opengl/copy_to_host.cpp
@@ -1,7 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 

--- a/test/opengl/copy_to_host.cpp
+++ b/test/opengl/copy_to_host.cpp
@@ -1,6 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
-#include <stdlib.h>
+
+#include "./testing.h"
 
 using namespace Halide;
 
@@ -25,16 +26,14 @@ int main() {
     Buffer<uint8_t> out(10, 10, 3);
     cpu.realize(out, target);
 
-    for (int y=0; y<out.height(); y++) {
-        for (int x=0; x<out.width(); x++) {
-            if (!(out(x, y, 0) == 10*x+y && out(x, y, 1) == 127 && out(x, y, 2) == 12)) {
-                fprintf(stderr, "Incorrect pixel (%d, %d, %d) at x=%d y=%d.\n",
-                        out(x, y, 0), out(x, y, 1), out(x, y, 2),
-                        x, y);
-                return 1;
-            }
-        }
-    }
+    if (!(Testing::check_result<uint8_t>(out, [&](int x, int y, int c) {
+            switch (c) {
+                case 0: return 10*x+y;
+                case 1: return 127;
+                case 2: return 12;
+                default: return -1;
+            }})))
+        return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/float_texture.cpp
+++ b/test/opengl/float_texture.cpp
@@ -10,7 +10,7 @@ int main() {
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Buffer<float> input(255, 255, 3);
-    Testing::fill<float>(input, [](int x, int y, int c) {
+    input.fill([](int x, int y, int c) {
             // Note: the following values can be >1.0f to test whether
             // OpenGL performs clamping operations as part of the copy
             // operation.  (It may do so if something other than floats

--- a/test/opengl/float_texture.cpp
+++ b/test/opengl/float_texture.cpp
@@ -1,6 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
-#include <stdlib.h>
+
+#include "./testing.h"
 
 using namespace Halide;
 
@@ -9,18 +10,13 @@ int main() {
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Buffer<float> input(255, 255, 3);
-    for (int y=0; y<input.height(); y++) {
-        for (int x=0; x<input.width(); x++) {
-            for (int c=0; c<3; c++) {
-                // Note: the following values can be >1.0f to test whether
-                // OpenGL performs clamping operations as part of the copy
-                // operation.  (It may do so if something other than floats
-                // are stored in the actual texture.)
-                float v = (10 * x + y + c);
-                input(x, y, c) = v;
-            }
-        }
-    }
+    Testing::fill<float>(input, [](int x, int y, int c) {
+            // Note: the following values can be >1.0f to test whether
+            // OpenGL performs clamping operations as part of the copy
+            // operation.  (It may do so if something other than floats
+            // are stored in the actual texture.)
+            return (10 * x + y + c);
+        });
 
     Var x, y, c;
     Func g;
@@ -32,19 +28,8 @@ int main() {
     g.realize(out, target);
     out.copy_to_host();
 
-    for (int y=0; y<out.height(); y++) {
-        for (int x=0; x<out.width(); x++) {
-            if (!(out(x, y, 0) == input(x, y, 0) &&
-                  out(x, y, 1) == input(x, y, 1) &&
-                  out(x, y, 2) == input(x, y, 2))) {
-                fprintf(stderr, "Incorrect pixel (%g,%g,%g) != (%g,%g,%g) at x=%d y=%d.\n",
-                        out(x, y, 0), out(x, y, 1), out(x, y, 2),
-                        input(x, y, 0), input(x, y, 1), input(x, y, 2),
-                        x, y);
-                return 1;
-            }
-        }
-    }
+    if (!Testing::check_result<float>(out, [&](int x, int y, int c) { return input(x, y, c); }))
+        return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/float_texture.cpp
+++ b/test/opengl/float_texture.cpp
@@ -1,7 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 

--- a/test/opengl/float_texture.cpp
+++ b/test/opengl/float_texture.cpp
@@ -28,8 +28,9 @@ int main() {
     g.realize(out, target);
     out.copy_to_host();
 
-    if (!Testing::check_result<float>(out, [&](int x, int y, int c) { return input(x, y, c); }))
+    if (!Testing::check_result<float>(out, [&](int x, int y, int c) { return input(x, y, c); })) {
         return 1;
+    }
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/float_texture.cpp
+++ b/test/opengl/float_texture.cpp
@@ -11,12 +11,12 @@ int main() {
 
     Buffer<float> input(255, 255, 3);
     input.fill([](int x, int y, int c) {
-            // Note: the following values can be >1.0f to test whether
-            // OpenGL performs clamping operations as part of the copy
-            // operation.  (It may do so if something other than floats
-            // are stored in the actual texture.)
-            return (10 * x + y + c);
-        });
+        // Note: the following values can be >1.0f to test whether
+        // OpenGL performs clamping operations as part of the copy
+        // operation.  (It may do so if something other than floats
+        // are stored in the actual texture.)
+        return (10 * x + y + c);
+    });
 
     Var x, y, c;
     Func g;

--- a/test/opengl/inline_reduction.cpp
+++ b/test/opengl/inline_reduction.cpp
@@ -17,8 +17,9 @@ int main() {
 
     Buffer<float> result = f.realize(100, 100, 3, target);
 
-    if (!Testing::check_result<float>(result, [&](int x, int y, int c) { return 45; }))
+    if (!Testing::check_result<float>(result, [&](int x, int y, int c) { return 45; })) {
         return 1;
+    }
 
     printf("Success!\n");
 

--- a/test/opengl/inline_reduction.cpp
+++ b/test/opengl/inline_reduction.cpp
@@ -1,4 +1,7 @@
 #include "Halide.h"
+#include <stdio.h>
+
+#include "./testing.h"
 
 using namespace Halide;
 
@@ -14,18 +17,8 @@ int main() {
 
     Buffer<float> result = f.realize(100, 100, 3, target);
 
-    for (int c = 0; c < result.channels(); c++) {
-        for (int y = 0; y < result.height(); y++) {
-            for (int x = 0; x < result.width(); x++) {
-                float correct = 45;
-                if (result(x, y, c) != correct) {
-                    printf("result(%d, %d, %d) = %f instead of %f\n",
-                           x, y, c, result(x, y, c), correct);
-                    return -1;
-                }
-            }
-        }
-    }
+    if (!Testing::check_result<float>(result, [&](int x, int y, int c) { return 45; }))
+        return 1;
 
     printf("Success!\n");
 

--- a/test/opengl/inline_reduction.cpp
+++ b/test/opengl/inline_reduction.cpp
@@ -1,7 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 

--- a/test/opengl/lut.cpp
+++ b/test/opengl/lut.cpp
@@ -2,7 +2,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 

--- a/test/opengl/lut.cpp
+++ b/test/opengl/lut.cpp
@@ -57,8 +57,9 @@ int test_lut1d() {
                 case 1: return (float)(8 - x);
                 case 2: return (x > 3) ? 8.0f : 1.0f;
                 default: return std::numeric_limits<float>::infinity();
-            } }))
+            } })) {
         return 1;
+    }
 
     return 0;
 }

--- a/test/opengl/lut.cpp
+++ b/test/opengl/lut.cpp
@@ -20,7 +20,7 @@ int test_lut1d() {
     Var c("c");
 
     Buffer<uint8_t> input(8, 8, 3);
-    Testing::fill<uint8_t>(input, [](int x, int y, int c) {
+    input.fill([](int x, int y, int c) {
             const float v = (1.0f/16.0f) + (float)x/8.0f;
             switch (c) {
             case 0: return (uint8_t)(v * 255.0f);

--- a/test/opengl/lut.cpp
+++ b/test/opengl/lut.cpp
@@ -4,7 +4,6 @@
 
 #include "./testing.h"
 
-
 using namespace Halide;
 
 // This test creates two input images and uses one to perform a dependent lookup
@@ -21,13 +20,16 @@ int test_lut1d() {
 
     Buffer<uint8_t> input(8, 8, 3);
     input.fill([](int x, int y, int c) {
-            const float v = (1.0f/16.0f) + (float)x/8.0f;
-            switch (c) {
-            case 0: return (uint8_t)(v * 255.0f);
-            case 1: return (uint8_t)((1.0f - v)*255.0f);
-            default: return (uint8_t)((v > 0.5 ? 1.0 : 0.0)*255.0f);
-            }
-        });
+        const float v = (1.0f / 16.0f) + (float)x / 8.0f;
+        switch (c) {
+        case 0:
+            return (uint8_t)(v * 255.0f);
+        case 1:
+            return (uint8_t)((1.0f - v) * 255.0f);
+        default:
+            return (uint8_t)((v > 0.5 ? 1.0 : 0.0) * 255.0f);
+        }
+    });
 
     // 1D Look Up Table case
     Buffer<float> lut1d(8, 1, 3);
@@ -38,7 +40,7 @@ int test_lut1d() {
     }
 
     Func f0("f");
-    Expr e = cast<int>(8.0f * cast<float>(input(x, y, c))/255.0f);
+    Expr e = cast<int>(8.0f * cast<float>(input(x, y, c)) / 255.0f);
 
     f0(x, y, c) = lut1d(clamp(e, 0, 7), 0, c);
 
@@ -55,7 +57,7 @@ int test_lut1d() {
                 case 1: return (float)(8 - x);
                 case 2: return (x > 3) ? 8.0f : 1.0f;
                 default: return std::numeric_limits<float>::infinity();
-            }}))
+            } }))
         return 1;
 
     return 0;

--- a/test/opengl/lut.cpp
+++ b/test/opengl/lut.cpp
@@ -1,6 +1,9 @@
+
 #include "Halide.h"
 #include <stdio.h>
-#include <stdlib.h>
+
+#include "./testing.h"
+
 
 using namespace Halide;
 
@@ -17,14 +20,14 @@ int test_lut1d() {
     Var c("c");
 
     Buffer<uint8_t> input(8, 8, 3);
-    for (int y = 0; y < input.height(); y++) {
-        for (int x = 0; x < input.width(); x++) {
-            float v = (1.0f/16.0f) + (float)x/8.0f;
-            input(x, y, 0) = (uint8_t)(v * 255.0f);
-            input(x, y, 1) = (uint8_t)((1.0f - v)*255.0f);
-            input(x, y, 2) = (uint8_t)((v > 0.5 ? 1.0 : 0.0)*255.0f);
-        }
-    }
+    Testing::fill<uint8_t>(input, [](int x, int y, int c) {
+            const float v = (1.0f/16.0f) + (float)x/8.0f;
+            switch (c) {
+            case 0: return (uint8_t)(v * 255.0f);
+            case 1: return (uint8_t)((1.0f - v)*255.0f);
+            default: return (uint8_t)((v > 0.5 ? 1.0 : 0.0)*255.0f);
+            }
+        });
 
     // 1D Look Up Table case
     Buffer<float> lut1d(8, 1, 3);
@@ -46,30 +49,14 @@ int test_lut1d() {
     f0.realize(out0, target);
     out0.copy_to_host();
 
-    for (int c = 0; c != out0.extent(2); ++c) {
-        for (int y = 0; y != out0.extent(1); ++y) {
-            for (int x = 0; x != out0.extent(0); ++x) {
-                float expected = std::numeric_limits<float>::infinity();
-                switch (c) {
-                    case 0:
-                        expected = (float)(1 + x);
-                        break;
-                    case 1:
-                        expected = (float)(8 - x);
-                        break;
-                    case 2:
-                        expected = x > 3 ? 8.0f : 1.0f;
-                        break;
-                }
-                float result = out0(x, y, c);
-
-                if (result != expected) {
-                    fprintf(stderr, "Error at %d,%d,%d %f != %f\n", x, y, c, result, expected);
-                    return 1;
-                }
-            }
-        }
-    }
+    if (!Testing::check_result<float>(out0, [](int x, int y, int c) {
+            switch (c) {
+                case 0: return  (float)(1 + x);
+                case 1: return (float)(8 - x);
+                case 2: return (x > 3) ? 8.0f : 1.0f;
+                default: return std::numeric_limits<float>::infinity();
+            }}))
+        return 1;
 
     return 0;
 }

--- a/test/opengl/multiple_stages.cpp
+++ b/test/opengl/multiple_stages.cpp
@@ -1,4 +1,7 @@
 #include "Halide.h"
+#include <stdio.h>
+
+#include "./testing.h"
 
 using namespace Halide;
 
@@ -19,17 +22,8 @@ int main() {
     Buffer<uint8_t> result = f.realize(10, 10, 3, target);
     result.copy_to_host();
 
-    for (int i=0; i<10; i++) {
-        for (int j=0; j<10; j++) {
-            for (int k=0; k<3; k++) {
-                if (result(i,j,k) != i+j+1) {
-                    printf("FAILED: expected %d but got %d\n",
-                      i+j+1, result(i,j,k));
-                  return 1;
-                }
-            }
-        }
-    }
+    if (!Testing::check_result<uint8_t>(result, [&](int i, int j, int k) { return i+j+1; }))
+        return 1;
 
     Func f2, g2;
     f2(x, y, c) = cast<float>(x);
@@ -39,19 +33,8 @@ int main() {
     g2.bound(c, 0, 3).glsl(x, y, c);
 
     Buffer<float> result2 = g2.realize(10, 10, 3, target);
-    for (int i=0; i<10; i++) {
-        for (int j=0; j<10; j++) {
-            for (int k=0; k<3; k++) {
-                float diff = (result2(i,j,k) - (float)(i+j));
-                diff *= diff;
-                if (diff > 0.0001) {
-                    printf("FAILED: expected %f but got %f (diff is %f)\n",
-                      (float)(i+j), result2(i,j,k), diff);
-                    return 1;
-                }
-            }
-        }
-    }
+    if (!Testing::check_result<float>(result2, [&](int i, int j, int k) { return (float)(i+j); }, 0.01f))
+	return 1;
 
     printf("Success!\n");
 

--- a/test/opengl/multiple_stages.cpp
+++ b/test/opengl/multiple_stages.cpp
@@ -10,7 +10,7 @@ int main() {
     // This test must be run with an OpenGL target.
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
-    Func f,g,h;
+    Func f, g, h;
     Var x, y, c;
     g(x, y, c) = cast<uint8_t>(x);
     h(x, y, c) = 1 + g(x, y, c);
@@ -22,7 +22,7 @@ int main() {
     Buffer<uint8_t> result = f.realize(10, 10, 3, target);
     result.copy_to_host();
 
-    if (!Testing::check_result<uint8_t>(result, [&](int i, int j, int k) { return i+j+1; }))
+    if (!Testing::check_result<uint8_t>(result, [&](int i, int j, int k) { return i + j + 1; }))
         return 1;
 
     Func f2, g2;
@@ -33,8 +33,8 @@ int main() {
     g2.bound(c, 0, 3).glsl(x, y, c);
 
     Buffer<float> result2 = g2.realize(10, 10, 3, target);
-    if (!Testing::check_result<float>(result2, [&](int i, int j, int k) { return (float)(i+j); }, 0.01f))
-	return 1;
+    if (!Testing::check_result<float>(result2, [&](int i, int j, int k) { return (float)(i + j); }, 0.01f))
+        return 1;
 
     printf("Success!\n");
 

--- a/test/opengl/multiple_stages.cpp
+++ b/test/opengl/multiple_stages.cpp
@@ -22,8 +22,9 @@ int main() {
     Buffer<uint8_t> result = f.realize(10, 10, 3, target);
     result.copy_to_host();
 
-    if (!Testing::check_result<uint8_t>(result, [&](int i, int j, int k) { return i + j + 1; }))
+    if (!Testing::check_result<uint8_t>(result, [&](int i, int j, int k) { return i + j + 1; })) {
         return 1;
+    }
 
     Func f2, g2;
     f2(x, y, c) = cast<float>(x);
@@ -33,8 +34,9 @@ int main() {
     g2.bound(c, 0, 3).glsl(x, y, c);
 
     Buffer<float> result2 = g2.realize(10, 10, 3, target);
-    if (!Testing::check_result<float>(result2, [&](int i, int j, int k) { return (float)(i + j); }, 0.01f))
+    if (!Testing::check_result<float>(result2, [&](int i, int j, int k) { return (float)(i + j); }, 0.01f)) {
         return 1;
+    }
 
     printf("Success!\n");
 

--- a/test/opengl/multiple_stages.cpp
+++ b/test/opengl/multiple_stages.cpp
@@ -1,7 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 

--- a/test/opengl/multiple_stages.cpp
+++ b/test/opengl/multiple_stages.cpp
@@ -34,7 +34,7 @@ int main() {
     g2.bound(c, 0, 3).glsl(x, y, c);
 
     Buffer<float> result2 = g2.realize(10, 10, 3, target);
-    if (!Testing::check_result<float>(result2, [&](int i, int j, int k) { return (float)(i + j); }, 0.01f)) {
+    if (!Testing::check_result<float>(result2, 0.01f, [&](int i, int j, int k) { return (float)(i + j); })) {
         return 1;
     }
 

--- a/test/opengl/produce.cpp
+++ b/test/opengl/produce.cpp
@@ -19,7 +19,7 @@ int test_lut1d() {
     Var c("c");
 
     Buffer<uint8_t> input(8, 8, 3);
-    Testing::fill<uint8_t>(input, [](int x, int y, int c) {
+    input.fill([](int x, int y, int c) {
             float v = (1.0f / 16.0f) + (float)x / 8.0f;
 	    switch (c) {
 	    case 0: return (uint8_t)(v * 255.0f);

--- a/test/opengl/produce.cpp
+++ b/test/opengl/produce.cpp
@@ -51,8 +51,9 @@ int test_lut1d() {
                 case 1: return (float)(8 - x);
                 case 2: return (x > 3) ? 8.0f : 1.0f;
 		default: return -1.0f;
-	    } }))
+	    } })) {
         return 1;
+    }
 
     return 0;
 }

--- a/test/opengl/produce.cpp
+++ b/test/opengl/produce.cpp
@@ -1,7 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 

--- a/test/opengl/produce.cpp
+++ b/test/opengl/produce.cpp
@@ -45,13 +45,13 @@ int test_lut1d() {
 
     out0.copy_to_host();
 
-    if (!(Testing::check_result<float>(out0, [](int x, int y, int c) {
+    if (!Testing::check_result<float>(out0, [](int x, int y, int c) {
 	    switch (c) {
                 case 0: return (float)(1 + x);
                 case 1: return (float)(8 - x);
                 case 2: return (x > 3) ? 8.0f : 1.0f;
 		default: return -1.0f;
-	    }})))
+	    }}))
 	return 1;
 
     return 0;

--- a/test/opengl/produce.cpp
+++ b/test/opengl/produce.cpp
@@ -1,6 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
-#include <stdlib.h>
+
+#include "./testing.h"
 
 using namespace Halide;
 
@@ -18,14 +19,13 @@ int test_lut1d() {
     Var c("c");
 
     Buffer<uint8_t> input(8, 8, 3);
-    for (int y = 0; y < input.height(); y++) {
-        for (int x = 0; x < input.width(); x++) {
+    Testing::fill<uint8_t>(input, [](int x, int y, int c) {
             float v = (1.0f / 16.0f) + (float)x / 8.0f;
-            input(x, y, 0) = (uint8_t)(v * 255.0f);
-            input(x, y, 1) = (uint8_t)((1.0f - v) * 255.0f);
-            input(x, y, 2) = (uint8_t)((v > 0.5 ? 1.0 : 0.0) * 255.0f);
-        }
-    }
+	    switch (c) {
+	    case 0: return (uint8_t)(v * 255.0f);
+	    case 1: return (uint8_t)((1.0f - v) * 255.0f);
+	    default: return (uint8_t)((v > 0.5 ? 1.0 : 0.0) * 255.0f);
+        }});
 
     // 1D Look Up Table case
     Func lut1d("lut1d");
@@ -45,30 +45,14 @@ int test_lut1d() {
 
     out0.copy_to_host();
 
-    for (int c = 0; c != out0.extent(2); ++c) {
-        for (int y = 0; y != out0.extent(1); ++y) {
-            for (int x = 0; x != out0.extent(0); ++x) {
-                float expected = std::numeric_limits<float>::infinity();
-                switch (c) {
-                case 0:
-                    expected = (float)(1 + x);
-                    break;
-                case 1:
-                    expected = (float)(8 - x);
-                    break;
-                case 2:
-                    expected = x > 3 ? 8.0f : 1.0f;
-                    break;
-                }
-                float result = out0(x, y, c);
-
-                if (result != expected) {
-                    fprintf(stderr, "Error at %d,%d,%d %f != %f\n", x, y, c, result, expected);
-                    return 1;
-                }
-            }
-        }
-    }
+    if (!(Testing::check_result<float>(out0, [](int x, int y, int c) {
+	    switch (c) {
+                case 0: return (float)(1 + x);
+                case 1: return (float)(8 - x);
+                case 2: return (x > 3) ? 8.0f : 1.0f;
+		default: return -1.0f;
+	    }})))
+	return 1;
 
     return 0;
 }

--- a/test/opengl/produce.cpp
+++ b/test/opengl/produce.cpp
@@ -25,7 +25,7 @@ int test_lut1d() {
 	    case 0: return (uint8_t)(v * 255.0f);
 	    case 1: return (uint8_t)((1.0f - v) * 255.0f);
 	    default: return (uint8_t)((v > 0.5 ? 1.0 : 0.0) * 255.0f);
-        }});
+        } });
 
     // 1D Look Up Table case
     Func lut1d("lut1d");
@@ -51,8 +51,8 @@ int test_lut1d() {
                 case 1: return (float)(8 - x);
                 case 2: return (x > 3) ? 8.0f : 1.0f;
 		default: return -1.0f;
-	    }}))
-	return 1;
+	    } }))
+        return 1;
 
     return 0;
 }

--- a/test/opengl/rewrap_texture.cpp
+++ b/test/opengl/rewrap_texture.cpp
@@ -7,10 +7,10 @@ int main() {
 }
 #else
 
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
-#include <stddef.h>
 
 #include "Halide.h"
 #include "HalideRuntimeOpenGL.h"
@@ -43,8 +43,7 @@ int main() {
     g.bound(c, 0, 3);
     g.glsl(x, y, c);
 
-
-    g.realize(out1, target); // run once to initialize OpenGL
+    g.realize(out1, target);  // run once to initialize OpenGL
 
     GLuint texture_id;
     glGenTextures(1, &texture_id);

--- a/test/opengl/save_state.cpp
+++ b/test/opengl/save_state.cpp
@@ -7,10 +7,10 @@ int main() {
 }
 #else
 
+#include <cstring>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stddef.h>
-#include <cstring>
 
 #include "Halide.h"
 
@@ -47,15 +47,12 @@ extern "C" void glBindFramebuffer(GLenum, GLuint);
 extern "C" void glGenVertexArrays(GLsizei, GLuint *);
 extern "C" void glBindVertexArray(GLuint);
 extern "C" void glGetVertexAttribiv(GLuint, GLenum, GLint *);
-extern "C" const GLubyte* glGetString(GLenum name);
+extern "C" const GLubyte *glGetString(GLenum name);
 
 // Generates an arbitrary program.
-class Program
-{
-    public:
-
-    static GLuint handle()
-    {
+class Program {
+public:
+    static GLuint handle() {
         const char *vertexShader = " \
                                     attribute vec4 Position;  \
                                     attribute vec2 TexCoordIn; \
@@ -89,10 +86,8 @@ class Program
         return handle;
     }
 
-    private:
-
-    static GLuint compileShader(const char *label, const char *shaderString, GLenum shaderType)
-    {
+private:
+    static GLuint compileShader(const char *label, const char *shaderString, GLenum shaderType) {
         const GLuint handle = glCreateShader(shaderType);
         const int len = strlen(shaderString);
         glShaderSource(handle, 1, &shaderString, &len);
@@ -109,28 +104,21 @@ class Program
     }
 };
 
-
 // Encapsulates setting OpenGL's state to arbitrary values, and checking
 // whether the state matches those values.
-class KnownState
-{
-    private:
-
-    void gl_enable(GLenum cap, bool state)
-    {
+class KnownState {
+private:
+    void gl_enable(GLenum cap, bool state) {
         (state ? glEnable : glDisable)(cap);
     }
 
-    GLuint gl_gen(void (*fn)(GLsizei, GLuint *))
-    {
+    GLuint gl_gen(void (*fn)(GLsizei, GLuint *)) {
         GLuint val;
         (*fn)(1, &val);
         return val;
     }
 
-
-    void check_value(const char *operation, const char *label, GLenum pname, GLint initial)
-    {
+    void check_value(const char *operation, const char *label, GLenum pname, GLint initial) {
         GLint val;
         glGetIntegerv(pname, &val);
         if (val != initial) {
@@ -139,21 +127,21 @@ class KnownState
         }
     }
 
-    void check_value(const char *operation, const char *label, GLenum pname, GLenum initial)
-    {
-        check_value(operation, label, pname, (GLint) initial);
+    void check_value(const char *operation, const char *label, GLenum pname, GLenum initial) {
+        check_value(operation, label, pname, (GLint)initial);
     }
 
-    void check_value(const char *operation, const char *label, GLenum pname, GLint initial[], int n=4)
-    {
+    void check_value(const char *operation, const char *label, GLenum pname, GLint initial[], int n = 4) {
         GLint val[2048];
         glGetIntegerv(pname, val);
-        for (int i=0; i<n; i++) {
+        for (int i = 0; i < n; i++) {
             if (val[i] != initial[i]) {
                 fprintf(stderr, "%s did not restore %s: initial value was", operation, label);
-                for (int j=0; j<n; j++) fprintf(stderr, " %d", initial[j]);
+                for (int j = 0; j < n; j++)
+                    fprintf(stderr, " %d", initial[j]);
                 fprintf(stderr, ", current value is");
-                for (int j=0; j<n; j++) fprintf(stderr, " %d", val[j]);
+                for (int j = 0; j < n; j++)
+                    fprintf(stderr, " %d", val[j]);
                 fprintf(stderr, "\n");
                 errors = true;
                 return;
@@ -161,8 +149,7 @@ class KnownState
         }
     }
 
-    void check_value(const char *operation, const char *label, GLenum pname, bool initial)
-    {
+    void check_value(const char *operation, const char *label, GLenum pname, bool initial) {
         GLboolean val;
         glGetBooleanv(pname, &val);
         if (val != initial) {
@@ -171,8 +158,7 @@ class KnownState
         }
     }
 
-    void check_error(const char *label)
-    {
+    void check_error(const char *label) {
         GLenum err = glGetError();
         if (err != GL_NO_ERROR) {
             fprintf(stderr, "Error setting %s: OpenGL error %#x\n", label, err);
@@ -225,31 +211,28 @@ class KnownState
 
     GLuint initial_vertex_array_binding;
 
-    public:
-
-    bool errors{false};
-
+public:
+    bool errors{ false };
 
     // This sets most values to generated or arbitrary values, which the
     // halide calls would be unlikely to accidentally use.  But for boolean
     // values, we want to be sure that halide is really restoring the
     // initial value, not just setting it to true or false.  So we need to
     // be able to try both.
-    void setup(bool boolval)
-    {
+    void setup(bool boolval) {
         // parse the OpenGL version
         const char *version = (const char *)glGetString(GL_VERSION);
         parse_opengl_version(version, &gl_major_version, &gl_minor_version);
 
         glGenTextures(ntextures, initial_bound_textures);
-        for (int i=0; i<ntextures; i++) {
+        for (int i = 0; i < ntextures; i++) {
             glActiveTexture(GL_TEXTURE0 + i);
             glBindTexture(GL_TEXTURE_2D, initial_bound_textures[i]);
         }
         glActiveTexture(initial_active_texture = GL_TEXTURE3);
 
-        for (int i=0; i<nvertex_attribs; i++) {
-            if ( (initial_vertex_attrib_array_enabled[i] = boolval ) )
+        for (int i = 0; i < nvertex_attribs; i++) {
+            if ((initial_vertex_attrib_array_enabled[i] = boolval))
                 glEnableVertexAttribArray(i);
             else
                 glDisableVertexAttribArray(i);
@@ -274,8 +257,7 @@ class KnownState
         check_error("known state");
     }
 
-    void check(const char *operation)
-    {
+    void check(const char *operation) {
         check_value(operation, "ActiveTexture", GL_ACTIVE_TEXTURE, initial_active_texture);
         check_value(operation, "current program", GL_CURRENT_PROGRAM, initial_current_program);
         check_value(operation, "framebuffer binding", GL_FRAMEBUFFER_BINDING, initial_framebuffer_binding);
@@ -292,14 +274,14 @@ class KnownState
             fprintf(stderr, "Skipping vertex array binding tests because OpenGL version is %d.%d (<3.0)\n", gl_major_version, gl_minor_version);
         }
 
-        for (int i=0; i<ntextures; i++) {
+        for (int i = 0; i < ntextures; i++) {
             char buf[100];
             sprintf(buf, "bound texture (unit %d)", i);
             glActiveTexture(GL_TEXTURE0 + i);
             check_value(operation, buf, GL_TEXTURE_BINDING_2D, initial_bound_textures[i]);
         }
 
-        for (int i=0; i < nvertex_attribs; i++) {
+        for (int i = 0; i < nvertex_attribs; i++) {
             int initial = initial_vertex_attrib_array_enabled[i];
             GLint val;
             glGetVertexAttribiv(i, GL_VERTEX_ATTRIB_ARRAY_ENABLED, &val);
@@ -327,7 +309,7 @@ int main() {
     g(x, y, c) = input(x, y, c);
     g.bound(c, 0, 3);
     g.glsl(x, y, c);
-    g.realize(out, target); // let Halide initialize OpenGL
+    g.realize(out, target);  // let Halide initialize OpenGL
 
     known_state.setup(true);
     g.realize(out, target);
@@ -346,7 +328,7 @@ int main() {
     known_state.check("copy_to_host");
 
     if (known_state.errors) {
-	return 1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/opengl/save_state.cpp
+++ b/test/opengl/save_state.cpp
@@ -137,11 +137,13 @@ private:
         for (int i = 0; i < n; i++) {
             if (val[i] != initial[i]) {
                 fprintf(stderr, "%s did not restore %s: initial value was", operation, label);
-                for (int j = 0; j < n; j++)
+                for (int j = 0; j < n; j++) {
                     fprintf(stderr, " %d", initial[j]);
+                }
                 fprintf(stderr, ", current value is");
-                for (int j = 0; j < n; j++)
+                for (int j = 0; j < n; j++) {
                     fprintf(stderr, " %d", val[j]);
+                }
                 fprintf(stderr, "\n");
                 errors = true;
                 return;
@@ -232,10 +234,11 @@ public:
         glActiveTexture(initial_active_texture = GL_TEXTURE3);
 
         for (int i = 0; i < nvertex_attribs; i++) {
-            if ((initial_vertex_attrib_array_enabled[i] = boolval))
+            if ((initial_vertex_attrib_array_enabled[i] = boolval)) {
                 glEnableVertexAttribArray(i);
-            else
+            } else {
                 glDisableVertexAttribArray(i);
+            }
             char buf[256];
             sprintf(buf, "vertex attrib array %d state", i);
             check_error(buf);

--- a/test/opengl/select.cpp
+++ b/test/opengl/select.cpp
@@ -18,7 +18,7 @@ int test_per_channel_select() {
     gpu(x, y, c) = cast<uint8_t>(select(c == 0, 128,
                                         c == 1, x,
                                         c == 2, y,
-                                        x*y));
+                                        x * y));
     gpu.bound(c, 0, 4);
     gpu.glsl(x, y, c);
     gpu.compute_root();
@@ -35,7 +35,7 @@ int test_per_channel_select() {
 		case 1: return x;
 		case 2: return y;
 		default: return x*y;
-	    }}))
+	    } }))
         return 1;
 
     return 0;
@@ -70,8 +70,8 @@ int test_flag_scalar_select() {
 
     // Verify the result
     if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) {
-	    return !flag_value ? 255 : 128;
-	}))
+            return !flag_value ? 255 : 128;
+        }))
         return 1;
 
     return 0;
@@ -93,15 +93,15 @@ int test_flag_pixel_select() {
     flag.set(flag_value);
 
     Buffer<uint8_t> image(10, 10, 4);
-    for (int y=0; y<image.height(); y++) {
-        for (int x=0; x<image.width(); x++) {
-            for (int c=0; c<image.channels(); c++) {
+    for (int y = 0; y < image.height(); y++) {
+        for (int x = 0; x < image.width(); x++) {
+            for (int c = 0; c < image.channels(); c++) {
                 image(x, y, c) = 128;
             }
         }
     }
 
-    gpu(x, y, c) = cast<uint8_t>(select(flag != 0, image(x,y,c),
+    gpu(x, y, c) = cast<uint8_t>(select(flag != 0, image(x, y, c),
                                         255));
     gpu.bound(c, 0, 4);
     gpu.glsl(x, y, c);
@@ -115,8 +115,8 @@ int test_flag_pixel_select() {
 
     // Verify the result
     if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) {
-	    return !flag_value ? 255 : 128;
-	}))
+            return !flag_value ? 255 : 128;
+        }))
         return 1;
 
     return 0;

--- a/test/opengl/select.cpp
+++ b/test/opengl/select.cpp
@@ -1,6 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
-#include <stdlib.h>
+
+#include "./testing.h"
 
 using namespace Halide;
 
@@ -28,27 +29,14 @@ int test_per_channel_select() {
     cpu.realize(out, target);
 
     // Verify the result
-    for (int y=0; y!=out.height(); ++y) {
-        for (int x=0; x!=out.width(); ++x) {
-            for (int c=0; c!=out.channels(); ++c) {
-                uint8_t expected;
-                switch (c) {
-                    case 0: expected = 128; break;
-                    case 1: expected = x; break;
-                    case 2: expected = y; break;
-                    default: expected = x*y; break;
-                }
-                uint8_t actual  = out(x,y,c);
-
-                if (expected != actual) {
-                    fprintf(stderr, "Incorrect pixel (%d, %d, %d, %d) at x=%d y=%d.\n",
-                            out(x, y, 0), out(x, y, 1), out(x, y, 2), out(x, y, 3),
-                            x, y);
-                    return 1;
-                }
-            }
-        }
-    }
+    if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) {
+	    switch (c) {
+		case 0: return 128;
+		case 1: return x;
+		case 2: return y;
+		default: return x*y;
+	    }}))
+        return 1;
 
     return 0;
 }
@@ -81,21 +69,10 @@ int test_flag_scalar_select() {
     cpu.realize(out, target);
 
     // Verify the result
-    for (int y=0; y!=out.height(); ++y) {
-        for (int x=0; x!=out.width(); ++x) {
-            for (int c=0; c!=out.channels(); ++c) {
-                uint8_t expected = !flag_value ? 255 : 128;
-                uint8_t actual  = out(x,y,c);
-
-                if (expected != actual) {
-                    fprintf(stderr, "Incorrect pixel (%d, %d, %d, %d) at x=%d y=%d.\n",
-                            out(x, y, 0), out(x, y, 1), out(x, y, 2), out(x, y, 3),
-                            x, y);
-                    return 1;
-                }
-            }
-        }
-    }
+    if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) {
+	    return !flag_value ? 255 : 128;
+	}))
+        return 1;
 
     return 0;
 }
@@ -137,21 +114,10 @@ int test_flag_pixel_select() {
     cpu.realize(out, target);
 
     // Verify the result
-    for (int y=0; y!=out.height(); ++y) {
-        for (int x=0; x!=out.width(); ++x) {
-            for (int c=0; c!=out.channels(); ++c) {
-                uint8_t expected = !flag_value ? 255 : 128;
-                uint8_t actual  = out(x,y,c);
-
-                if (expected != actual) {
-                    fprintf(stderr, "Incorrect pixel (%d, %d, %d, %d) at x=%d y=%d.\n",
-                            out(x, y, 0), out(x, y, 1), out(x, y, 2), out(x, y, 3),
-                            x, y);
-                    return 1;
-                }
-            }
-        }
-    }
+    if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) {
+	    return !flag_value ? 255 : 128;
+	}))
+        return 1;
 
     return 0;
 }

--- a/test/opengl/select.cpp
+++ b/test/opengl/select.cpp
@@ -1,7 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 

--- a/test/opengl/select.cpp
+++ b/test/opengl/select.cpp
@@ -35,8 +35,9 @@ int test_per_channel_select() {
 		case 1: return x;
 		case 2: return y;
 		default: return x*y;
-	    } }))
+	    } })) {
         return 1;
+    }
 
     return 0;
 }
@@ -71,8 +72,9 @@ int test_flag_scalar_select() {
     // Verify the result
     if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) {
             return !flag_value ? 255 : 128;
-        }))
+        })) {
         return 1;
+    }
 
     return 0;
 }
@@ -116,8 +118,9 @@ int test_flag_pixel_select() {
     // Verify the result
     if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) {
             return !flag_value ? 255 : 128;
-        }))
+        })) {
         return 1;
+    }
 
     return 0;
 }

--- a/test/opengl/set_pixels.cpp
+++ b/test/opengl/set_pixels.cpp
@@ -20,7 +20,7 @@ int main() {
 
     out.copy_to_host();
     if (!Testing::check_result<uint8_t>(out, [](int x, int y, int c) { return 42; }))
-	return 1;
+        return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/set_pixels.cpp
+++ b/test/opengl/set_pixels.cpp
@@ -19,7 +19,7 @@ int main() {
     f.realize(out, target);
 
     out.copy_to_host();
-    if (!(Testing::check_result<uint8_t>(out, [](int x, int y, int c) { return 42; })))
+    if (!Testing::check_result<uint8_t>(out, [](int x, int y, int c) { return 42; }))
 	return 1;
 
     printf("Success!\n");

--- a/test/opengl/set_pixels.cpp
+++ b/test/opengl/set_pixels.cpp
@@ -19,8 +19,9 @@ int main() {
     f.realize(out, target);
 
     out.copy_to_host();
-    if (!Testing::check_result<uint8_t>(out, [](int x, int y, int c) { return 42; }))
+    if (!Testing::check_result<uint8_t>(out, [](int x, int y, int c) { return 42; })) {
         return 1;
+    }
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/set_pixels.cpp
+++ b/test/opengl/set_pixels.cpp
@@ -1,6 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
-#include <stdlib.h>
+
+#include "./testing.h"
 
 using namespace Halide;
 
@@ -18,17 +19,8 @@ int main() {
     f.realize(out, target);
 
     out.copy_to_host();
-    for (int y=0; y<out.height(); y++) {
-        for (int x=0; x<out.width(); x++) {
-            for (int z=0; x<out.channels(); x++) {
-                if (!(out(x, y, z) == 42)) {
-                    fprintf(stderr, "Incorrect pixel (%d) at x=%d y=%d z=%d.\n",
-                            out(x, y, z), x, y, z);
-                    return 1;
-                }
-            }
-        }
-    }
+    if (!(Testing::check_result<uint8_t>(out, [](int x, int y, int c) { return 42; })))
+	return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/set_pixels.cpp
+++ b/test/opengl/set_pixels.cpp
@@ -1,7 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 

--- a/test/opengl/shifted_domains.cpp
+++ b/test/opengl/shifted_domains.cpp
@@ -27,8 +27,8 @@ int shifted_domains() {
     gradient.realize(result, target);
     result.copy_to_host();
 
-    if (!Testing::check_result<float>(result, [](int x, int y) { return float(x+y); }, 5e-5))
-	errors++;
+    if (!Testing::check_result<float>(result, [](int x, int y) { return float(x + y); }, 5e-5))
+        errors++;
 
     Buffer<float> shifted(5, 7, 1);
     shifted.set_min(100, 50);
@@ -38,8 +38,8 @@ int shifted_domains() {
     gradient.realize(shifted, target);
     shifted.copy_to_host();
 
-    if (!Testing::check_result<float>(shifted, [](int x, int y) { return float(x+y); }, 5e-5))
-	errors++;
+    if (!Testing::check_result<float>(shifted, [](int x, int y) { return float(x + y); }, 5e-5))
+        errors++;
 
     // Test with a negative min
     shifted.set_min(-100, -50);
@@ -49,8 +49,8 @@ int shifted_domains() {
     gradient.realize(shifted, target);
     shifted.copy_to_host();
 
-    if (!Testing::check_result<float>(shifted, [](int x, int y) { return float(x+y); }, 5e-5))
-	errors++;
+    if (!Testing::check_result<float>(shifted, [](int x, int y) { return float(x + y); }, 5e-5))
+        errors++;
 
     return errors;
 }

--- a/test/opengl/shifted_domains.cpp
+++ b/test/opengl/shifted_domains.cpp
@@ -27,7 +27,7 @@ int shifted_domains() {
     gradient.realize(result, target);
     result.copy_to_host();
 
-    if (!Testing::check_result<float>(result, [](int x, int y) { return float(x + y); }, 5e-5))
+    if (!Testing::check_result<float>(result, 5e-5, [](int x, int y) { return float(x + y); }))
         errors++;
 
     Buffer<float> shifted(5, 7, 1);
@@ -38,7 +38,7 @@ int shifted_domains() {
     gradient.realize(shifted, target);
     shifted.copy_to_host();
 
-    if (!Testing::check_result<float>(shifted, [](int x, int y) { return float(x + y); }, 5e-5))
+    if (!Testing::check_result<float>(shifted, 5e-5, [](int x, int y) { return float(x + y); }))
         errors++;
 
     // Test with a negative min
@@ -49,7 +49,7 @@ int shifted_domains() {
     gradient.realize(shifted, target);
     shifted.copy_to_host();
 
-    if (!Testing::check_result<float>(shifted, [](int x, int y) { return float(x + y); }, 5e-5))
+    if (!Testing::check_result<float>(shifted, 5e-5, [](int x, int y) { return float(x + y); }))
         errors++;
 
     return errors;

--- a/test/opengl/shifted_domains.cpp
+++ b/test/opengl/shifted_domains.cpp
@@ -1,7 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 

--- a/test/opengl/shifted_domains.cpp
+++ b/test/opengl/shifted_domains.cpp
@@ -27,7 +27,7 @@ int shifted_domains() {
     gradient.realize(result, target);
     result.copy_to_host();
 
-    if (Testing::check_result<float>(result, [](int x, int y) { return float(x+y); }))
+    if (!Testing::check_result<float>(result, [](int x, int y) { return float(x+y); }, 5e-5))
 	errors++;
 
     Buffer<float> shifted(5, 7, 1);
@@ -38,7 +38,7 @@ int shifted_domains() {
     gradient.realize(shifted, target);
     shifted.copy_to_host();
 
-    if (Testing::check_result<float>(shifted, [](int x, int y) { return float(x+y); }))
+    if (!Testing::check_result<float>(shifted, [](int x, int y) { return float(x+y); }, 5e-5))
 	errors++;
 
     // Test with a negative min
@@ -49,7 +49,7 @@ int shifted_domains() {
     gradient.realize(shifted, target);
     shifted.copy_to_host();
 
-    if (Testing::check_result<float>(shifted, [](int x, int y) { return float(x+y); }))
+    if (!Testing::check_result<float>(shifted, [](int x, int y) { return float(x+y); }, 5e-5))
 	errors++;
 
     return errors;
@@ -57,9 +57,10 @@ int shifted_domains() {
 
 int main() {
 
-    if (shifted_domains() == 0) {
-        printf("PASSED\n");
+    if (shifted_domains() != 0) {
+        return 1;
     }
 
+    printf("Success\n");
     return 0;
 }

--- a/test/opengl/shifted_domains.cpp
+++ b/test/opengl/shifted_domains.cpp
@@ -1,6 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
-#include <stdlib.h>
+
+#include "./testing.h"
 
 using namespace Halide;
 
@@ -26,17 +27,8 @@ int shifted_domains() {
     gradient.realize(result, target);
     result.copy_to_host();
 
-    for (int y = 0; y < 8; y++) {
-        for (int x = 0; x < 8; x++) {
-            float actual = result(x, y);
-            float expected = float(x + y);
-            if (actual != expected) {
-                printf("Error at %d,%d result %f should be %f\n",
-                       x, y, actual, expected);
-                errors++;
-            }
-        }
-    }
+    if (Testing::check_result<float>(result, [](int x, int y) { return float(x+y); }))
+	errors++;
 
     Buffer<float> shifted(5, 7, 1);
     shifted.set_min(100, 50);
@@ -46,17 +38,8 @@ int shifted_domains() {
     gradient.realize(shifted, target);
     shifted.copy_to_host();
 
-    for (int y = 50; y < 57; y++) {
-        for (int x = 100; x < 105; x++) {
-            float actual = shifted(x, y);
-            float expected = float(x + y);
-            if (actual != expected) {
-                printf("Error at %d,%d result %f should be %f\n",
-                       x, y, actual, expected);
-                errors++;
-            }
-        }
-    }
+    if (Testing::check_result<float>(shifted, [](int x, int y) { return float(x+y); }))
+	errors++;
 
     // Test with a negative min
     shifted.set_min(-100, -50);
@@ -66,17 +49,8 @@ int shifted_domains() {
     gradient.realize(shifted, target);
     shifted.copy_to_host();
 
-    for (int y = -50; y < -44; y++) {
-        for (int x = -100; x < -96; x++) {
-            float actual = shifted(x, y);
-            float expected = float(x + y);
-            if (actual != expected) {
-                printf("Error at %d,%d result %f should be %f\n",
-                       x, y, actual, expected);
-                errors++;
-            }
-        }
-    }
+    if (Testing::check_result<float>(shifted, [](int x, int y) { return float(x+y); }))
+	errors++;
 
     return errors;
 }

--- a/test/opengl/special_funcs.cpp
+++ b/test/opengl/special_funcs.cpp
@@ -1,8 +1,8 @@
 #include "Halide.h"
-#include <stdio.h>
 #include <algorithm>
-#include <stdlib.h>
 #include <iostream>
+#include <stdio.h>
+#include <stdlib.h>
 
 using namespace Halide;
 
@@ -26,7 +26,6 @@ void test_function(Expr e, Buffer<T> &cpu_result, Buffer<T> &gpu_result) {
     gpu.bound(c, 0, 3).glsl(x, y, c);
     gpu.realize(gpu_result, gpu_target);
     gpu_result.copy_to_host();
-
 }
 
 template <typename T>
@@ -39,8 +38,8 @@ bool test_exact(Expr r, Expr g, Expr b) {
     Buffer<T> gpu_result(W, H, 3);
     test_function(e, cpu_result, gpu_result);
 
-    for (int y=0; y<gpu_result.height(); y++) {
-        for (int x=0; x<gpu_result.width(); x++) {
+    for (int y = 0; y < gpu_result.height(); y++) {
+        for (int x = 0; x < gpu_result.width(); x++) {
             if (!(gpu_result(x, y, 0) == cpu_result(x, y, 0) &&
                   gpu_result(x, y, 1) == cpu_result(x, y, 1) &&
                   gpu_result(x, y, 2) == cpu_result(x, y, 2))) {
@@ -69,8 +68,8 @@ bool test_approx(Expr r, Expr g, Expr b, double rms_error) {
     test_function(e, cpu_result, gpu_result);
 
     double err = 0.0;
-    for (int y=0; y<gpu_result.height(); y++) {
-        for (int x=0; x<gpu_result.width(); x++) {
+    for (int y = 0; y < gpu_result.height(); y++) {
+        for (int x = 0; x < gpu_result.width(); x++) {
             err += square(gpu_result(x, y, 0) - cpu_result(x, y, 0));
             err += square(gpu_result(x, y, 1) - cpu_result(x, y, 1));
             err += square(gpu_result(x, y, 2) - cpu_result(x, y, 2));
@@ -100,9 +99,9 @@ int main() {
     }
 
     if (!test_exact<uint8_t>(
-        max(x, y),
-        cast<int>(min(cast<float>(x), cast<float>(y))),
-        clamp(x, 0, 10))) {
+            max(x, y),
+            cast<int>(min(cast<float>(x), cast<float>(y))),
+            clamp(x, 0, 10))) {
         printf("Failed min/max test\n");
         errors++;
     }
@@ -114,7 +113,7 @@ int main() {
 
     // Trigonometric functions in GLSL are fast but not very accurate,
     // especially outside of 0..2pi.
-    // The GLSL ES 1.0 spec does not define the precision of these operations 
+    // The GLSL ES 1.0 spec does not define the precision of these operations
     // so a wide error bound is used in this test.
     Expr r = (256 * x + y) / ceilf(65536.f / (2 * 3.1415926536f));
     if (!test_approx<float>(sin(r), cos(r), 0, 5e-2)) {
@@ -127,18 +126,18 @@ int main() {
     // the operation is performed in float in the GLSL shader, and then
     // converted back to a normalized integer value.
     if (!test_approx<uint8_t>(
-        (x - 127) / 3 + 127,
-        (x - 127) % 3 + 127,
-        0,
-        1)) {
+            (x - 127) / 3 + 127,
+            (x - 127) % 3 + 127,
+            0,
+            1)) {
         printf("Failed integer operation test\n");
         errors++;
     }
 
     if (!test_exact<uint8_t>(
-        lerp(cast<uint8_t>(x), cast<uint8_t>(y), cast<uint8_t>(128)),
-        lerp(cast<uint8_t>(x), cast<uint8_t>(y), 0.5f),
-        cast<uint8_t>(lerp(cast<float>(x), cast<float>(y), 0.2f)))) {
+            lerp(cast<uint8_t>(x), cast<uint8_t>(y), cast<uint8_t>(128)),
+            lerp(cast<uint8_t>(x), cast<uint8_t>(y), 0.5f),
+            cast<uint8_t>(lerp(cast<float>(x), cast<float>(y), 0.2f)))) {
         printf("Failed lerp test\n");
         errors++;
     }
@@ -147,7 +146,7 @@ int main() {
         printf("Success!\n");
         return 0;
     } else {
-        printf("FAILED %d tests\n",errors);
+        printf("FAILED %d tests\n", errors);
         return 1;
     }
 }

--- a/test/opengl/sum_reduction.cpp
+++ b/test/opengl/sum_reduction.cpp
@@ -38,8 +38,9 @@ int main() {
             }
             return temp / 10.0f * 255.0f;
         },
-                                      1e-3))
+                                      1e-3)) {
         return 1;
+    }
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/sum_reduction.cpp
+++ b/test/opengl/sum_reduction.cpp
@@ -1,6 +1,8 @@
 #include "Halide.h"
 #include <stdio.h>
 
+#include "./testing.h"
+
 using namespace Halide;
 
 int main() {
@@ -10,13 +12,9 @@ int main() {
     // Define the input
     const int width = 10, height = 10, channels = 4;
     Buffer<float> input(width, height, channels);
-    for (int c = 0; c < input.channels(); c++) {
-        for (int y = 0; y < input.height(); y++) {
-            for (int x = 0; x < input.width(); x++) {
-                input(x, y, c) = float(x + y);
-            }
-        }
-    }
+    Testing::fill<float>(input, [](int x, int y, int c) {
+            return float(x + y);
+        });
 
     // Define the algorithm.
     Var x, y, c;
@@ -33,22 +31,14 @@ int main() {
     result.copy_to_host();
 
     // Check the result.
-    for (int c = 0; c < result.channels(); c++) {
-        for (int y = 0; y < result.height(); y++) {
-            for (int x = 0; x < result.width(); x++) {
-                float temp = 0.0f;
-                for (int r = 0; r < 5; r++){
-                    temp += input(std::min(x+r, input.width()-1), y, c);
-                }
-                float correct = temp / 10.0f * 255.0f;
-                if (fabs(result(x, y, c) - correct) > 1e-3) {
-                    fprintf(stderr, "result(%d, %d, %d) = %f instead of %f\n",
-                            x, y, c, result(x, y, c), correct);
-                    return 1;
-                }
-            }
-        }
-    }
+    if (!Testing::check_result<float>(result, [&](int x, int y, int c) {
+	    float temp = 0.0f;
+	    for (int r = 0; r < 5; r++){
+		temp += input(std::min(x+r, input.width()-1), y, c);
+	    }
+	    return temp / 10.0f * 255.0f;
+	    }, 1e-3))
+	return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/sum_reduction.cpp
+++ b/test/opengl/sum_reduction.cpp
@@ -31,14 +31,13 @@ int main() {
     result.copy_to_host();
 
     // Check the result.
-    if (!Testing::check_result<float>(result, [&](int x, int y, int c) {
+    if (!Testing::check_result<float>(result, 1e-3, [&](int x, int y, int c) {
             float temp = 0.0f;
             for (int r = 0; r < 5; r++) {
                 temp += input(std::min(x + r, input.width() - 1), y, c);
             }
             return temp / 10.0f * 255.0f;
-        },
-                                      1e-3)) {
+        })) {
         return 1;
     }
 

--- a/test/opengl/sum_reduction.cpp
+++ b/test/opengl/sum_reduction.cpp
@@ -13,15 +13,15 @@ int main() {
     const int width = 10, height = 10, channels = 4;
     Buffer<float> input(width, height, channels);
     input.fill([](int x, int y, int c) {
-            return float(x + y);
-        });
+        return float(x + y);
+    });
 
     // Define the algorithm.
     Var x, y, c;
     RDom r(0, 5, "r");
     Func g;
     Expr coordx = clamp(x + r, 0, input.width() - 1);
-    g(x, y, c) = cast<float>( sum(input(coordx, y, c)) / sum(r) * 255.0f );
+    g(x, y, c) = cast<float>(sum(input(coordx, y, c)) / sum(r) * 255.0f);
 
     // Schedule f and g to compute in separate passes on the GPU.
     g.bound(c, 0, 4).glsl(x, y, c);
@@ -32,13 +32,14 @@ int main() {
 
     // Check the result.
     if (!Testing::check_result<float>(result, [&](int x, int y, int c) {
-	    float temp = 0.0f;
-	    for (int r = 0; r < 5; r++){
-		temp += input(std::min(x+r, input.width()-1), y, c);
-	    }
-	    return temp / 10.0f * 255.0f;
-	    }, 1e-3))
-	return 1;
+            float temp = 0.0f;
+            for (int r = 0; r < 5; r++) {
+                temp += input(std::min(x + r, input.width() - 1), y, c);
+            }
+            return temp / 10.0f * 255.0f;
+        },
+                                      1e-3))
+        return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/sum_reduction.cpp
+++ b/test/opengl/sum_reduction.cpp
@@ -1,7 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 

--- a/test/opengl/sum_reduction.cpp
+++ b/test/opengl/sum_reduction.cpp
@@ -12,7 +12,7 @@ int main() {
     // Define the input
     const int width = 10, height = 10, channels = 4;
     Buffer<float> input(width, height, channels);
-    Testing::fill<float>(input, [](int x, int y, int c) {
+    input.fill([](int x, int y, int c) {
             return float(x + y);
         });
 

--- a/test/opengl/sumcolor_reduction.cpp
+++ b/test/opengl/sumcolor_reduction.cpp
@@ -31,8 +31,9 @@ int main() {
     result.copy_to_host();
 
     // Check the result.
-    if (!Testing::check_result<float>(result, [](int x, int y, int c) { return 3.0f * (x + y); }, 1e-6))
+    if (!Testing::check_result<float>(result, [](int x, int y, int c) { return 3.0f * (x + y); }, 1e-6)) {
         return 1;
+    }
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/sumcolor_reduction.cpp
+++ b/test/opengl/sumcolor_reduction.cpp
@@ -1,7 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 

--- a/test/opengl/sumcolor_reduction.cpp
+++ b/test/opengl/sumcolor_reduction.cpp
@@ -12,7 +12,7 @@ int main() {
     // Define the input.
     const int width = 10, height = 10, channels = 3;
     Buffer<float> input(width, height, channels);
-    Testing::fill<float>(input, [](int x, int y, int c) {
+    input.fill([](int x, int y, int c) {
             return x + y;
         });
 

--- a/test/opengl/sumcolor_reduction.cpp
+++ b/test/opengl/sumcolor_reduction.cpp
@@ -31,7 +31,7 @@ int main() {
     result.copy_to_host();
 
     // Check the result.
-    if (!Testing::check_result<float>(result, [](int x, int y, int c) { return 3.0f * (x + y); }, 1e-6)) {
+    if (!Testing::check_result<float>(result, 1e-6, [](int x, int y, int c) { return 3.0f * (x + y); })) {
         return 1;
     }
 

--- a/test/opengl/sumcolor_reduction.cpp
+++ b/test/opengl/sumcolor_reduction.cpp
@@ -1,6 +1,8 @@
 #include "Halide.h"
 #include <stdio.h>
 
+#include "./testing.h"
+
 using namespace Halide;
 
 int main() {
@@ -10,13 +12,9 @@ int main() {
     // Define the input.
     const int width = 10, height = 10, channels = 3;
     Buffer<float> input(width, height, channels);
-    for (int c = 0; c < input.channels(); c++) {
-        for (int y = 0; y < input.height(); y++) {
-            for (int x = 0; x < input.width(); x++) {
-                input(x, y, c) = x + y;
-            }
-        }
-    }
+    Testing::fill<float>(input, [](int x, int y, int c) {
+            return x + y;
+        });
 
     // Define the algorithm.
     Var x, y, c;
@@ -33,18 +31,8 @@ int main() {
     result.copy_to_host();
 
     // Check the result.
-    for (int c = 0; c < result.channels(); c++) {
-        for (int y = 0; y < result.height(); y++) {
-            for (int x = 0; x < result.width(); x++) {
-                float correct = 3.0f * (x + y);
-                if (fabs(result(x, y, c) - correct) > 1e-6) {
-                    fprintf(stderr, "result(%d, %d, %d) = %f instead of %f\n",
-                            x, y, c, result(x, y, c), correct);
-                    return 1;
-                }
-            }
-        }
-    }
+    if (!Testing::check_result<float>(result, [](int x, int y, int c) { return 3.0f * (x + y); }, 1e-6))
+	return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/sumcolor_reduction.cpp
+++ b/test/opengl/sumcolor_reduction.cpp
@@ -13,8 +13,8 @@ int main() {
     const int width = 10, height = 10, channels = 3;
     Buffer<float> input(width, height, channels);
     input.fill([](int x, int y, int c) {
-            return x + y;
-        });
+        return x + y;
+    });
 
     // Define the algorithm.
     Var x, y, c;
@@ -32,7 +32,7 @@ int main() {
 
     // Check the result.
     if (!Testing::check_result<float>(result, [](int x, int y, int c) { return 3.0f * (x + y); }, 1e-6))
-	return 1;
+        return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/testing.h
+++ b/test/opengl/testing.h
@@ -2,83 +2,77 @@
 #define _TESTING_H_
 
 #include "Halide.h"
-#include <iostream>
+#include <cmath>
 #include <exception>
 #include <functional>
-#include <cmath>
+#include <iostream>
 
 namespace Testing {
 
-    template <typename T>
-        bool neq(T a, T b, T tol)
-        {
-            return std::abs(a-b) > tol;
-        }
-
-    // check 3-dimension buffer
-    template<typename T>
-        bool check_result(const Halide::Buffer<T> &buf, std::function<T(int x, int y, int c)> f, T tol=0)
-        {
-            class err : std::exception {
-                public: static void vector(const std::vector<T> &v) {
-                    for (size_t i=0; i<v.size(); i++) {
-                        if (i > 0) std::cerr << ",";
-                        std::cerr << v[i]+0; // need to add 0 to get output -- compiler bug??
-                    }
-                }
-            };
-            try {
-                buf.for_each_element([&](int x, int y) {
-                    std::vector<T> expected;
-                    std::vector<T> result;
-                    for (int c=0; c < buf.channels(); c++) {
-                        expected.push_back(f(x, y, c));
-                        result.push_back(buf(x,y,c));
-                    }
-                    for (int c=0; c< buf.channels(); c++) {
-                        if (neq(result[c], expected[c], tol)) {
-                            std::cerr << "Error: result (";
-                            err::vector(result);
-                            std::cerr << ") should be (";
-                            err::vector(expected);
-                            std::cerr << ") at x=" << x << " y=" << y << std::endl;
-                            throw err();
-                        }
-                    }
-                });
-            }
-            catch (err) {
-                return false;
-            }
-            return true;
-        }
-
-    // check 2-dimension buffer
-    template<typename T>
-        bool check_result(const Halide::Buffer<T> &buf, std::function<T(int x, int y)> f, T tol=0)
-        {
-            class err : std::exception {};
-            try {
-                buf.for_each_element([&](int x, int y) {
-                    const T expected = f(x, y);
-                    const T result = buf(x, y);
-                    if (neq(result, expected, tol)) {
-                        std::cerr << "Error: result (";
-                        std::cerr << result+0;
-                        std::cerr << ") should be (";
-                        std::cerr << expected+0;
-                        std::cerr << ") at x=" << x << " y=" << y << std::endl;
-                        throw err();
-                    }
-                });
-            }
-            catch (err) {
-                return false;
-            }
-            return true;
-        }
-
+template <typename T>
+bool neq(T a, T b, T tol) {
+    return std::abs(a - b) > tol;
 }
 
-#endif // _TESTING_H_
+// check 3-dimension buffer
+template <typename T>
+bool check_result(const Halide::Buffer<T> &buf, std::function<T(int x, int y, int c)> f, T tol = 0) {
+    class err : std::exception {
+    public:
+        static void vector(const std::vector<T> &v) {
+            for (size_t i = 0; i < v.size(); i++) {
+                if (i > 0) std::cerr << ",";
+                std::cerr << v[i] + 0;  // need to add 0 to get output -- compiler bug??
+            }
+        }
+    };
+    try {
+        buf.for_each_element([&](int x, int y) {
+            std::vector<T> expected;
+            std::vector<T> result;
+            for (int c = 0; c < buf.channels(); c++) {
+                expected.push_back(f(x, y, c));
+                result.push_back(buf(x, y, c));
+            }
+            for (int c = 0; c < buf.channels(); c++) {
+                if (neq(result[c], expected[c], tol)) {
+                    std::cerr << "Error: result (";
+                    err::vector(result);
+                    std::cerr << ") should be (";
+                    err::vector(expected);
+                    std::cerr << ") at x=" << x << " y=" << y << std::endl;
+                    throw err();
+                }
+            }
+        });
+    } catch (err) {
+        return false;
+    }
+    return true;
+}
 
+// check 2-dimension buffer
+template <typename T>
+bool check_result(const Halide::Buffer<T> &buf, std::function<T(int x, int y)> f, T tol = 0) {
+    class err : std::exception {};
+    try {
+        buf.for_each_element([&](int x, int y) {
+            const T expected = f(x, y);
+            const T result = buf(x, y);
+            if (neq(result, expected, tol)) {
+                std::cerr << "Error: result (";
+                std::cerr << result + 0;
+                std::cerr << ") should be (";
+                std::cerr << expected + 0;
+                std::cerr << ") at x=" << x << " y=" << y << std::endl;
+                throw err();
+            }
+        });
+    } catch (err) {
+        return false;
+    }
+    return true;
+}
+}
+
+#endif  // _TESTING_H_

--- a/test/opengl/testing.h
+++ b/test/opengl/testing.h
@@ -14,9 +14,9 @@ bool neq(T a, T b, T tol) {
     return std::abs(a - b) > tol;
 }
 
-// check 3-dimension buffer
+// Check 3-dimension buffer
 template <typename T>
-bool check_result(const Halide::Buffer<T> &buf, std::function<T(int x, int y, int c)> f, T tol = 0) {
+bool check_result(const Halide::Buffer<T> &buf, T tol, std::function<T(int x, int y, int c)> f) {
     class err : std::exception {
     public:
         static void vector(const std::vector<T> &v) {
@@ -53,9 +53,9 @@ bool check_result(const Halide::Buffer<T> &buf, std::function<T(int x, int y, in
     return true;
 }
 
-// check 2-dimension buffer
+// Check 2-dimension buffer
 template <typename T>
-bool check_result(const Halide::Buffer<T> &buf, std::function<T(int x, int y)> f, T tol = 0) {
+bool check_result(const Halide::Buffer<T> &buf, T tol, std::function<T(int x, int y)> f) {
     class err : std::exception {};
     try {
         buf.for_each_element([&](int x, int y) {
@@ -74,6 +74,12 @@ bool check_result(const Halide::Buffer<T> &buf, std::function<T(int x, int y)> f
         return false;
     }
     return true;
+}
+
+// Shorthand to check with tolerance=0
+template <typename T, typename Func>
+bool check_result(const Halide::Buffer<T> &buf, Func f) {
+    return check_result<T>(buf, 0, f);
 }
 }
 

--- a/test/opengl/testing.h
+++ b/test/opengl/testing.h
@@ -21,8 +21,10 @@ bool check_result(const Halide::Buffer<T> &buf, std::function<T(int x, int y, in
     public:
         static void vector(const std::vector<T> &v) {
             for (size_t i = 0; i < v.size(); i++) {
-                if (i > 0) std::cerr << ",";
-                std::cerr << +v[i];     // use unary + to promote uint8_t from char to numeric
+                if (i > 0) {
+                    std::cerr << ",";
+                }
+                std::cerr << +v[i];  // use unary + to promote uint8_t from char to numeric
             }
         }
     };

--- a/test/opengl/testing.h
+++ b/test/opengl/testing.h
@@ -1,0 +1,99 @@
+#ifndef _TESTING_H_
+#define _TESTING_H_
+
+#include "Halide.h"
+#include <iostream>
+#include <functional>
+#include <cmath>
+
+namespace Testing {
+
+    // fill 3-dimension buffer
+    template <typename T>
+        void fill(Halide::Buffer<T> &buf, std::function<T(int x, int y, int c)> f)
+        {
+            for (int y = buf.top(); y <= buf.bottom(); y++) {
+                for (int x = buf.left(); x <= buf.right(); x++) {
+                    for (int c = 0; c < buf.channels(); c++) {
+                        buf(x, y, c) = f(x, y, c);
+                    }
+                }
+            }
+        }
+
+
+    // check 3-dimension buffer
+    template<typename T>
+        bool check_result(const Halide::Buffer<T> &buf, std::function<T(int x, int y, int c)> f, T tol=0)
+        {
+            auto neq = [&](T a, T b) { return std::abs(a-b) > tol; };
+
+            for (int y = buf.top(); y <= buf.bottom(); ++y) {
+                for (int x = buf.left(); x <= buf.right(); ++x) {
+                    if (buf.channels() == 3) {
+                        const auto expected0 = f(x, y, 0);
+                        const auto expected1 = f(x, y, 1);
+                        const auto expected2 = f(x, y, 2);
+                        const auto result0 = buf(x, y, 0);
+                        const auto result1 = buf(x, y, 1);
+                        const auto result2 = buf(x, y, 2);
+                        if (neq(result0, expected0) || neq(result1, expected1) || neq(result2,  expected2)) {
+                            // need to include +0 to overcome compiler bug(?) that doesn't
+                            // properly call the ostream operator
+                            auto errpixel = [](T a, T b, T c) { std::cerr << "(" << a+0 << "," << b+0 << "," << c+0 << ")"; };
+
+                            std::cerr << "Error: result pixel ";
+                            errpixel(result0, result1, result2);
+                            std::cerr << " should be ";
+                            errpixel(expected0, expected1, expected2);
+                            std::cerr << " at x=" << x << " y=" << y;
+                            if (tol != 0) std::cerr << " [tolerance=" << tol << "]";
+                            std::cout << std::endl;
+                            return false;
+                        }
+                    } else {
+                        for (int c = 0; c != buf.extent(2); ++c) {
+                            const auto expected = f(x, y, c);
+                            const auto result = buf(x, y, c);
+                            if (neq(result, expected)) {
+                                std::cerr << "Error: result value " << result;
+                                std::cerr << " should be " << expected;
+                                std::cerr << " at x=" << x << " y=" << y << " c=" << c;
+                                if (tol != 0) std::cerr << " [tolerance=" << tol << "]";
+                                std::cout << std::endl;
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+    // check 2-dimension buffer
+    template<typename T>
+        bool check_result(const Halide::Buffer<T> &buf, std::function<T(int x, int y)> f, T tol=0)
+        {
+            auto neq = [&](T a, T b) { return std::abs(a-b) > tol; };
+
+            for (int y = buf.top(); y <= buf.bottom(); ++y) {
+                for (int x = buf.left(); x <= buf.right(); ++x) {
+                    const auto expected = f(x, y);
+                    const auto result = buf(x, y);
+                    if (neq(result, expected)) {
+                        std::cerr << "Error: result value " << result;
+                        std::cerr << " should be " << expected;
+                        std::cerr << " at x=" << x << " y=" << y;
+                        if (tol != 0) std::cerr << " [tolerance=" << tol << "]";
+                        std::cout << std::endl;
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+}
+
+#endif // _TESTING_H_
+

--- a/test/opengl/testing.h
+++ b/test/opengl/testing.h
@@ -22,7 +22,7 @@ bool check_result(const Halide::Buffer<T> &buf, std::function<T(int x, int y, in
         static void vector(const std::vector<T> &v) {
             for (size_t i = 0; i < v.size(); i++) {
                 if (i > 0) std::cerr << ",";
-                std::cerr << v[i] + 0;  // need to add 0 to get output -- compiler bug??
+                std::cerr << +v[i];     // use unary + to promote uint8_t from char to numeric
             }
         }
     };
@@ -61,9 +61,9 @@ bool check_result(const Halide::Buffer<T> &buf, std::function<T(int x, int y)> f
             const T result = buf(x, y);
             if (neq(result, expected, tol)) {
                 std::cerr << "Error: result (";
-                std::cerr << result + 0;
+                std::cerr << +result;
                 std::cerr << ") should be (";
-                std::cerr << expected + 0;
+                std::cerr << +expected;
                 std::cerr << ") at x=" << x << " y=" << y << std::endl;
                 throw err();
             }

--- a/test/opengl/testing.h
+++ b/test/opengl/testing.h
@@ -9,15 +9,6 @@
 
 namespace Testing {
 
-    // fill 3-dimension buffer
-    template <typename T>
-        void fill(Halide::Buffer<T> &buf, std::function<T(int x, int y, int c)> f)
-        {
-            buf.for_each_element([&](int x, int y, int c) { 
-                    buf(x, y, c) = f(x, y, c);
-                    });
-        }
-
     template <typename T>
         bool neq(T a, T b, T tol)
         {

--- a/test/opengl/tuples.cpp
+++ b/test/opengl/tuples.cpp
@@ -31,7 +31,7 @@ int main() {
     h.realize(out, target);
     out.copy_to_host();
 
-    if (!(Testing::check_result<uint8_t>(out, [&](int x, int y, int c) { return input(x, y, c) / 2; })))
+    if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) { return input(x, y, c) / 2; }))
 	return 1;
 
     printf("Success!\n");

--- a/test/opengl/tuples.cpp
+++ b/test/opengl/tuples.cpp
@@ -1,6 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
-#include <stdlib.h>
+
+#include "./testing.h"
 
 using namespace Halide;
 
@@ -9,13 +10,9 @@ int main() {
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Buffer<uint8_t> input(255, 10, 3);
-    for (int y = 0; y < input.height(); y++) {
-        for (int x = 0; x < input.width(); x++) {
-            for (int c = 0; c < 3; c++) {
-                input(x, y, c) = 10*x + y + c;
-            }
-        }
-    }
+    Testing::fill<uint8_t>(input, [](int x, int y, int c) {
+            return 10*x + y + c;
+        });
 
     Var x, y, c;
     Func g;
@@ -34,19 +31,8 @@ int main() {
     h.realize(out, target);
     out.copy_to_host();
 
-    for (int y = 0; y < out.height(); y++) {
-        for (int x = 0; x < out.width(); x++) {
-            if (!(out(x, y, 0) == input(x, y, 0) / 2 &&
-                  out(x, y, 1) == input(x, y, 1) / 2 &&
-                  out(x, y, 2) == input(x, y, 2) / 2)) {
-                fprintf(stderr, "Incorrect pixel (%d, %d, %d) != (%d, %d, %d) at x=%d y=%d.\n",
-                        out(x, y, 0), out(x, y, 1), out(x, y, 2),
-                        input(x, y, 0) / 2, input(x, y, 1) / 2, input(x, y, 2) / 2,
-                        x, y);
-                return 1;
-            }
-        }
-    }
+    if (!(Testing::check_result<uint8_t>(out, [&](int x, int y, int c) { return input(x, y, c) / 2; })))
+	return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/tuples.cpp
+++ b/test/opengl/tuples.cpp
@@ -11,12 +11,12 @@ int main() {
 
     Buffer<uint8_t> input(255, 10, 3);
     input.fill([](int x, int y, int c) {
-            return 10*x + y + c;
-        });
+        return 10 * x + y + c;
+    });
 
     Var x, y, c;
     Func g;
-    g(x, y, c) = {input(x, y, c), input(x, y, c) / 2};
+    g(x, y, c) = { input(x, y, c), input(x, y, c) / 2 };
 
     // h will be an opengl stage with tuple input. Tuple outputs
     // aren't supported because OpenGL ES 2.0 doesn't support multiple
@@ -32,7 +32,7 @@ int main() {
     out.copy_to_host();
 
     if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) { return input(x, y, c) / 2; }))
-	return 1;
+        return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/tuples.cpp
+++ b/test/opengl/tuples.cpp
@@ -31,8 +31,9 @@ int main() {
     h.realize(out, target);
     out.copy_to_host();
 
-    if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) { return input(x, y, c) / 2; }))
+    if (!Testing::check_result<uint8_t>(out, [&](int x, int y, int c) { return input(x, y, c) / 2; })) {
         return 1;
+    }
 
     printf("Success!\n");
     return 0;

--- a/test/opengl/tuples.cpp
+++ b/test/opengl/tuples.cpp
@@ -1,7 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 

--- a/test/opengl/tuples.cpp
+++ b/test/opengl/tuples.cpp
@@ -10,7 +10,7 @@ int main() {
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
     Buffer<uint8_t> input(255, 10, 3);
-    Testing::fill<uint8_t>(input, [](int x, int y, int c) {
+    input.fill([](int x, int y, int c) {
             return 10*x + y + c;
         });
 

--- a/test/opengl/vagrant/Vagrantfile
+++ b/test/opengl/vagrant/Vagrantfile
@@ -29,6 +29,8 @@ Vagrant.configure("2") do |config|
     SHELL
   end
 
+  config.vm.boot_timeout = 600
+
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/test/opengl/varying.cpp
+++ b/test/opengl/varying.cpp
@@ -50,211 +50,124 @@ class CountVarying : public IRMutator {
     }
 };
 
-int main() {
+bool perform_test(const char *label, const Target target, Func f, int expected_nvarying, float tol, std::function<float(int x, int y, int c)> expected_val) {
+    fprintf(stderr, "%s\n", label);
 
-    // This test must be run with an OpenGL target.
-    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
+    Buffer<float> out(8, 8, 3);
 
-    Var x("x");
-    Var y("y");
-    Var c("c");
+    varyings.clear();
+    f.add_custom_lowering_pass(new CountVarying);
+    f.realize(out, target);
 
-    // This is a simple test case where there are two expressions that are not
-    // linearly varying in terms of a loop variable and one expression that is.
-    fprintf(stderr, "Test f0\n");
+    // Check for the correct number of varying attributes
+    if ((int) varyings.size() != expected_nvarying) {
+        fprintf(stderr,
+                "%s: Error: wrong number of varying attributes: %d should be %d\n",
+                label, (int)varyings.size(), expected_nvarying);
+        return false;
+    }
 
+    // Check for correct result values
+    out.copy_to_host();
+
+    for (int c=0; c != out.extent(2); ++c) {
+        for (int y=0; y != out.extent(1); ++y) {
+            for (int x=0; x != out.extent(0); ++x) {
+                const float expected = expected_val(x, y, c);
+                const float result = out(x, y, c);
+                if (fabs(result - expected) > tol) {
+                    fprintf(stderr, "%s: Incorrect value: %f != %f at %d,%d,%d.\n",
+                            label, result, expected, x, y, c);
+                    return false;
+                }
+            }
+        }
+    }
+    fprintf(stderr, "%s Passed!\n", label);
+    return true;
+}
+
+// This is a simple test case where there are two expressions that are not
+// linearly varying in terms of a loop variable and one expression that is.
+bool test0(const Target target, Var &x, Var &y, Var &c) {
     float p_value = 8.0f;
     Param<float> p("p"); p.set(p_value);
 
     Func f0("f0");
     f0(x, y, c) = select(c == 0, 4.0f,             // Constant term
-                      c == 1, p * 10.0f,        // Linear expression not in terms of a loop parameter
-                      cast<float>(x) * 100.0f); // Linear expression in terms of x
+            c == 1, p * 10.0f,        // Linear expression not in terms of a loop parameter
+            cast<float>(x) * 100.0f); // Linear expression in terms of x
 
-    Buffer<float> out0(8, 8, 3);
     f0.bound(c, 0, 3);
     f0.glsl(x, y, c);
-
-    // Run the test
-    varyings.clear();
-    f0.add_custom_lowering_pass(new CountVarying);
-    f0.realize(out0, target);
-
-    // Check for the correct number of varying attributes
-    if (varyings.size() != 2) {
-        fprintf(stderr,
-                "Error: wrong number of varying attributes: %d should be %d\n",
-                (int)varyings.size(), 2);
-        return 1;
-    }
-
-    // Check for correct result values
-    out0.copy_to_host();
-
-    for (int c=0; c != out0.extent(2); ++c) {
-        for (int y=0; y != out0.extent(1); ++y) {
-            for (int x=0; x != out0.extent(0); ++x) {
-                float expected;
+    return perform_test("Test0", target, f0, 2, 0.0f, [&](int x, int y, int c) {
                 switch (c) {
-                    case 0:
-                        expected = 4.0f;
-                        break;
-                    case 1:
-                        expected = p_value * 10.0f;
-                        break;
-                    default:
-                        expected = static_cast<float>(x) * 100.0f;
+                case 0: return 4.0f;
+                case 1: return p_value * 10.0f;
+                default: return static_cast<float>(x) * 100.0f;
+                }});
+}
 
-                }
-                float result = out0(x, y, c);
-                if (result != expected) {
-                    fprintf(stderr, "Incorrect value: %f != %f at %d,%d,%d.\n",
-                            result, expected, x, y, c);
-                    return 1;
-                }
-            }
-        }
-    }
-    fprintf(stderr, "Passed!\n");
-
-    // This is a more complicated test case where several expressions are linear
-    // in all of the loop variables. This is the coordinate transformation case
-    fprintf(stderr, "Test f1\n");
-
-    float th = 3.141592f/8.0f;
-    float s_th = sinf(th);
-    float c_th = cosf(th);
-
-    float m[] = {
-        c_th, -s_th, 0.0f,
-        s_th,  c_th, 0.0f
+struct CoordXform {
+    const float th = 3.141592f/8.0f;
+    const float s_th = sinf(th);
+    const float c_th = cosf(th);
+    const float m[6] = {
+            c_th, -s_th, 0.0f,
+            s_th,  c_th, 0.0f
     };
+    Param<float> m0, m1, m2, m3, m4, m5;
+    CoordXform() : m0("m0"), m1("m1"), m2("m2"), m3("m3"), m4("m4"), m5("m5") {
+        m0.set(m[0]); m1.set(m[1]); m2.set(m[2]);
+        m3.set(m[3]); m4.set(m[4]); m5.set(m[5]);
+    }
+};
 
-    Param<float> m0("m0"), m1("m1"), m2("m2"),
-                 m3("m3"), m4("m4"), m5("m5");
-
-    m0.set(m[0]); m1.set(m[1]); m2.set(m[2]);
-    m3.set(m[3]); m4.set(m[4]); m5.set(m[5]);
-
+// This is a more complicated test case where several expressions are linear
+// in all of the loop variables. This is the coordinate transformation case
+bool test1(const Target target, Var &x, Var &y, Var &c) {
+    struct CoordXform m;
     Func f1("f1");
-    f1(x, y, c) = select(c == 0, m0 * x + m1 * y + m2,
-                       c == 1, m3 * x + m4 * y + m5,
+    f1(x, y, c) = select(c == 0, m.m0 * x + m.m1 * y + m.m2,
+                       c == 1, m.m3 * x + m.m4 * y + m.m5,
                        1.0f);
 
     f1.bound(c, 0, 3);
     f1.glsl(x, y, c);
 
-    Buffer<float> out1(8, 8, 3);
-
-    // Run the test
-    varyings.clear();
-    f1.add_custom_lowering_pass(new CountVarying);
-    f1.realize(out1, target);
-
-    // Check for the correct number of varying attributes
-    if (varyings.size() != 4) {
-        fprintf(stderr,
-                "Error: wrong number of varying attributes: %d should be %d\n",
-                (int)varyings.size(), 4);
-        return 1;
-    }
-
-    // Check for correct result values
-    out1.copy_to_host();
-    for (int c=0; c != out1.extent(2); ++c) {
-        for (int y=0; y != out1.extent(1); ++y) {
-            for (int x=0; x != out1.extent(0); ++x) {
-                float expected;
+    return perform_test("Test1", target, f1, 4, 0.000001f, [&](int x, int y, int c) {
                 switch (c) {
-                    case 0:
-                        expected = m[0] * x + m[1] * y + m[2];
-                        break;
-                    case 1:
-                        expected = m[3] * x + m[4] * y + m[5];
-                        break;
-                    default:
-                        expected = 1.0f;
+                    case 0: return m.m[0] * x + m.m[1] * y + m.m[2];
+                    case 1: return m.m[3] * x + m.m[4] * y + m.m[5];
+                    default: return 1.0f;
+                }});
+}
 
-                }
-                float result = out1(x, y, c);
-
-                // There is no defined precision requirement in this case so an
-                // arbitrary threshold is used to compare the result of the CPU
-                // and GPU arithmetic
-                if (fabs(result-expected) > 0.000001f) {
-                    fprintf(stderr, "Incorrect value: %f != %f at %d,%d,%d.\n",
-                            result, expected, x, y, c);
-                    return 1;
-                }
-            }
-        }
-    }
-    fprintf(stderr, "Passed!\n");
-
-    // The feature is supposed to find linearly varying sub-expressions as well
-    // so for example, if the above expressions are wrapped in a non-linear
-    // function like sqrt, they should still be extracted.
-    fprintf(stderr, "Test f2\n");
+// The feature is supposed to find linearly varying sub-expressions as well
+// so for example, if the above expressions are wrapped in a non-linear
+// function like sqrt, they should still be extracted.
+bool test2(const Target target, Var &x, Var &y, Var &c) {
+    struct CoordXform m;
     Func f2("f2");
-    f2(x, y, c) = select(c == 0, sqrt(m0 * x + m1 * y + m2),
-                       c == 1, sqrt(m3 * x + m4 * y + m5),
+    f2(x, y, c) = select(c == 0, sqrt(m.m0 * x + m.m1 * y + m.m2),
+                       c == 1, sqrt(m.m3 * x + m.m4 * y + m.m5),
                        1.0f);
-
     f2.bound(c, 0, 3);
     f2.glsl(x, y, c);
 
-    Buffer<float> out2(8, 8, 3);
-
-    // Run the test
-    varyings.clear();
-    f2.add_custom_lowering_pass(new CountVarying);
-    f2.realize(out2, target);
-
-    // Check for the correct number of varying attributes
-    if (varyings.size() != 4) {
-        fprintf(stderr,
-                "Error: wrong number of varying attributes: %d should be %d\n",
-                (int)varyings.size(), 4);
-        return 1;
-    }
-
-    // Check for correct result values
-    out2.copy_to_host();
-
-    for (int c=0; c != out2.extent(2); ++c) {
-        for (int y=0; y != out2.extent(1); ++y) {
-            for (int x=0; x != out2.extent(0); ++x) {
-                float expected;
+    return perform_test("Test2", target, f2, 4, 0.000001f, [&](int x, int y, int c) {
                 switch (c) {
-                    case 0:
-                        expected = sqrtf(m[0] * x + m[1] * y + m[2]);
-                        break;
-                    case 1:
-                        expected = sqrtf(m[3] * x + m[4] * y + m[5]);
-                        break;
-                    default:
-                        expected = 1.0f;
+                    case 0: return sqrtf(m.m[0] * x + m.m[1] * y + m.m[2]);
+                    case 1: return sqrtf(m.m[3] * x + m.m[4] * y + m.m[5]);
+                    default: return 1.0f;
+                }});
+}
 
-                }
-                float result = out2(x, y, c);
-
-                // There is no defined precision requirement in this case so an
-                // arbitrary threshold is used to compare the result of the CPU
-                // and GPU arithmetic
-                if (fabs(result-expected) > 0.000001f) {
-                    fprintf(stderr, "Incorrect value: %f != %f at %d,%d,%d.\n",
-                            result, expected, x, y, c);
-                    return 1;
-                }
-            }
-        }
-    }
-    fprintf(stderr, "Passed!\n");
-
-    // This case tests a large expression linearly varying in terms of a loop
-    // variable
-    fprintf(stderr, "Test f3\n");
-
+// This case tests a large expression linearly varying in terms of a loop
+// variable
+bool test3(const Target target, Var &x, Var &y, Var &c) {
+    float p_value = 8.0f;
+    Param<float> p("p"); p.set(p_value);
     Expr foo = p;
     for (int i = 0; i < 10; i++) {
         foo = foo+foo+foo;
@@ -268,59 +181,35 @@ int main() {
 
     Func f3("f3");
     f3(x, y, c) = select(c == 0, foo,
-                       c == 1, 1.0f,
-                       2.0f);
+            c == 1, 1.0f,
+            2.0f);
 
     f3.bound(c, 0, 3);
     f3.glsl(x, y, c);
 
-    Buffer<float> out3(8, 8, 3);
-
-    // Run the test
-    varyings.clear();
-    f3.add_custom_lowering_pass(new CountVarying);
-    f3.realize(out3, target);
-
-    // Check for the correct number of varying attributes
-    if (varyings.size() != 2) {
-        fprintf(stderr,
-                "Error: wrong number of varying attributes: %d should be %d\n",
-                (int)varyings.size(), 2);
-        return 1;
-    }
-
-    // Check for correct result values
-    out3.copy_to_host();
-
-    for (int c=0; c != out3.extent(2); ++c) {
-        for (int y=0; y != out3.extent(1); ++y) {
-            for (int x=0; x != out3.extent(0); ++x) {
-                float expected;
+    return perform_test("Test3", target, f3, 2, 0.000001f, [&](int x, int y, int c) {
                 switch (c) {
-                    case 0:
-                        expected = (float)x + foo_value;
-                        break;
-                    case 1:
-                        expected = 1.0f;
-                        break;
-                    default:
-                        expected = 2.0f;
+                    case 0: return (float)x + foo_value;
+                    case 1: return 1.0f;
+                    default: return 2.0f;
+                }});
+}
 
-                }
-                float result = out3(x, y, c);
 
-                // There is no defined precision requirement in this case so an
-                // arbitrary threshold is used to compare the result of the CPU
-                // and GPU arithmetic
-                if (fabs(result-expected) > 0.000001f) {
-                    fprintf(stderr, "Incorrect value: %f != %f at %d,%d,%d.\n",
-                            result, expected, x, y, c);
-                    return 1;
-                }
-            }
-        }
-    }
-    fprintf(stderr, "Passed!\n");
+int main() {
+    // This test must be run with an OpenGL target.
+    const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
+
+    Var x("x");
+    Var y("y");
+    Var c("c");
+
+    bool pass = true;
+    pass &= test0(target, x, y, c);
+    pass &= test1(target, x, y, c);
+    pass &= test2(target, x, y, c);
+    pass &= test3(target, x, y, c);
+    if (!pass) return 1;
 
     // The test will return early on error.
     fprintf(stderr, "Success!\n");

--- a/test/opengl/varying.cpp
+++ b/test/opengl/varying.cpp
@@ -30,7 +30,7 @@ std::set<std::string> varyings;
 // This function is a HalideExtern used to add variables to the set. The tests
 // below check the total number of unique variables found--not the specific
 // names of the variables which are arbitrary.
-extern "C" DLLEXPORT const Variable* record_varying(const Variable *op) {
+extern "C" DLLEXPORT const Variable *record_varying(const Variable *op) {
     if (varyings.find(op->name) == varyings.end()) {
         fprintf(stderr, "Found varying attribute: %s\n", op->name.c_str());
         varyings.insert(op->name);
@@ -61,7 +61,7 @@ bool perform_test(const char *label, const Target target, Func f, int expected_n
     f.realize(out, target);
 
     // Check for the correct number of varying attributes
-    if ((int) varyings.size() != expected_nvarying) {
+    if ((int)varyings.size() != expected_nvarying) {
         fprintf(stderr,
                 "%s: Error: wrong number of varying attributes: %d should be %d\n",
                 label, (int)varyings.size(), expected_nvarying);
@@ -72,7 +72,7 @@ bool perform_test(const char *label, const Target target, Func f, int expected_n
     out.copy_to_host();
 
     if (!Testing::check_result<float>(out, expected_val, tol))
-	return false;
+        return false;
 
     fprintf(stderr, "%s Passed!\n", label);
     return true;
@@ -82,12 +82,13 @@ bool perform_test(const char *label, const Target target, Func f, int expected_n
 // linearly varying in terms of a loop variable and one expression that is.
 bool test0(const Target target, Var &x, Var &y, Var &c) {
     float p_value = 8.0f;
-    Param<float> p("p"); p.set(p_value);
+    Param<float> p("p");
+    p.set(p_value);
 
     Func f0("f0");
-    f0(x, y, c) = select(c == 0, 4.0f,             // Constant term
-            c == 1, p * 10.0f,        // Linear expression not in terms of a loop parameter
-            cast<float>(x) * 100.0f); // Linear expression in terms of x
+    f0(x, y, c) = select(c == 0, 4.0f,  // Constant term
+                         c == 1, p * 10.0f,  // Linear expression not in terms of a loop parameter
+                         cast<float>(x) * 100.0f);  // Linear expression in terms of x
 
     f0.bound(c, 0, 3);
     f0.glsl(x, y, c);
@@ -96,21 +97,25 @@ bool test0(const Target target, Var &x, Var &y, Var &c) {
                 case 0: return 4.0f;
                 case 1: return p_value * 10.0f;
                 default: return static_cast<float>(x) * 100.0f;
-                }});
+                } });
 }
 
 struct CoordXform {
-    const float th = 3.141592f/8.0f;
+    const float th = 3.141592f / 8.0f;
     const float s_th = sinf(th);
     const float c_th = cosf(th);
     const float m[6] = {
-            c_th, -s_th, 0.0f,
-            s_th,  c_th, 0.0f
+        c_th, -s_th, 0.0f,
+        s_th, c_th, 0.0f
     };
     Param<float> m0, m1, m2, m3, m4, m5;
     CoordXform() : m0("m0"), m1("m1"), m2("m2"), m3("m3"), m4("m4"), m5("m5") {
-        m0.set(m[0]); m1.set(m[1]); m2.set(m[2]);
-        m3.set(m[3]); m4.set(m[4]); m5.set(m[5]);
+        m0.set(m[0]);
+        m1.set(m[1]);
+        m2.set(m[2]);
+        m3.set(m[3]);
+        m4.set(m[4]);
+        m5.set(m[5]);
     }
 };
 
@@ -120,8 +125,8 @@ bool test1(const Target target, Var &x, Var &y, Var &c) {
     struct CoordXform m;
     Func f1("f1");
     f1(x, y, c) = select(c == 0, m.m0 * x + m.m1 * y + m.m2,
-                       c == 1, m.m3 * x + m.m4 * y + m.m5,
-                       1.0f);
+                         c == 1, m.m3 * x + m.m4 * y + m.m5,
+                         1.0f);
 
     f1.bound(c, 0, 3);
     f1.glsl(x, y, c);
@@ -131,7 +136,7 @@ bool test1(const Target target, Var &x, Var &y, Var &c) {
                     case 0: return m.m[0] * x + m.m[1] * y + m.m[2];
                     case 1: return m.m[3] * x + m.m[4] * y + m.m[5];
                     default: return 1.0f;
-                }});
+                } });
 }
 
 // The feature is supposed to find linearly varying sub-expressions as well
@@ -141,8 +146,8 @@ bool test2(const Target target, Var &x, Var &y, Var &c) {
     struct CoordXform m;
     Func f2("f2");
     f2(x, y, c) = select(c == 0, sqrt(m.m0 * x + m.m1 * y + m.m2),
-                       c == 1, sqrt(m.m3 * x + m.m4 * y + m.m5),
-                       1.0f);
+                         c == 1, sqrt(m.m3 * x + m.m4 * y + m.m5),
+                         1.0f);
     f2.bound(c, 0, 3);
     f2.glsl(x, y, c);
 
@@ -151,29 +156,30 @@ bool test2(const Target target, Var &x, Var &y, Var &c) {
                     case 0: return sqrtf(m.m[0] * x + m.m[1] * y + m.m[2]);
                     case 1: return sqrtf(m.m[3] * x + m.m[4] * y + m.m[5]);
                     default: return 1.0f;
-                }});
+                } });
 }
 
 // This case tests a large expression linearly varying in terms of a loop
 // variable
 bool test3(const Target target, Var &x, Var &y, Var &c) {
     float p_value = 8.0f;
-    Param<float> p("p"); p.set(p_value);
+    Param<float> p("p");
+    p.set(p_value);
     Expr foo = p;
     for (int i = 0; i < 10; i++) {
-        foo = foo+foo+foo;
+        foo = foo + foo + foo;
     }
     foo = x + foo;
 
     float foo_value = p_value;
     for (int i = 0; i < 10; i++) {
-        foo_value = foo_value+foo_value+foo_value;
+        foo_value = foo_value + foo_value + foo_value;
     }
 
     Func f3("f3");
     f3(x, y, c) = select(c == 0, foo,
-            c == 1, 1.0f,
-            2.0f);
+                         c == 1, 1.0f,
+                         2.0f);
 
     f3.bound(c, 0, 3);
     f3.glsl(x, y, c);
@@ -183,9 +189,8 @@ bool test3(const Target target, Var &x, Var &y, Var &c) {
                     case 0: return (float)x + foo_value;
                     case 1: return 1.0f;
                     default: return 2.0f;
-                }});
+                } });
 }
-
 
 int main() {
     // This test must be run with an OpenGL target.

--- a/test/opengl/varying.cpp
+++ b/test/opengl/varying.cpp
@@ -1,7 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#include "./testing.h"
+#include "testing.h"
 
 using namespace Halide;
 using namespace Halide::Internal;

--- a/test/opengl/varying.cpp
+++ b/test/opengl/varying.cpp
@@ -71,8 +71,9 @@ bool perform_test(const char *label, const Target target, Func f, int expected_n
     // Check for correct result values
     out.copy_to_host();
 
-    if (!Testing::check_result<float>(out, expected_val, tol))
+    if (!Testing::check_result<float>(out, expected_val, tol)) {
         return false;
+    }
 
     fprintf(stderr, "%s Passed!\n", label);
     return true;
@@ -205,7 +206,9 @@ int main() {
     pass &= test1(target, x, y, c);
     pass &= test2(target, x, y, c);
     pass &= test3(target, x, y, c);
-    if (!pass) return 1;
+    if (!pass) {
+        return 1;
+    }
 
     // The test will return early on error.
     fprintf(stderr, "Success!\n");

--- a/test/opengl/varying.cpp
+++ b/test/opengl/varying.cpp
@@ -71,7 +71,7 @@ bool perform_test(const char *label, const Target target, Func f, int expected_n
     // Check for correct result values
     out.copy_to_host();
 
-    if (!Testing::check_result<float>(out, expected_val, tol)) {
+    if (!Testing::check_result<float>(out, tol, expected_val)) {
         return false;
     }
 

--- a/test/opengl/varying.cpp
+++ b/test/opengl/varying.cpp
@@ -1,6 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
-#include <stdlib.h>
+
+#include "./testing.h"
 
 using namespace Halide;
 using namespace Halide::Internal;
@@ -70,19 +71,9 @@ bool perform_test(const char *label, const Target target, Func f, int expected_n
     // Check for correct result values
     out.copy_to_host();
 
-    for (int c=0; c != out.extent(2); ++c) {
-        for (int y=0; y != out.extent(1); ++y) {
-            for (int x=0; x != out.extent(0); ++x) {
-                const float expected = expected_val(x, y, c);
-                const float result = out(x, y, c);
-                if (fabs(result - expected) > tol) {
-                    fprintf(stderr, "%s: Incorrect value: %f != %f at %d,%d,%d.\n",
-                            label, result, expected, x, y, c);
-                    return false;
-                }
-            }
-        }
-    }
+    if (!Testing::check_result<float>(out, expected_val, tol))
+	return false;
+
     fprintf(stderr, "%s Passed!\n", label);
     return true;
 }


### PR DESCRIPTION
DRY up the OpenGL test suite by adding helpers `Testing::fill` and `Testing::check_result`, which are themselves wrappers around `Buffer.for_each_element`.

Also along the way cleaned up some of the tests themselves.  In particular, `shifted_domains.cpp` didn't exit with 1 in case of failure.

cc: @estollnitz @shoaibkamil 