### PR TITLE
Move delegating ctors to .cpp instead of .h

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1532,6 +1532,11 @@ GeneratorInputBase::GeneratorInputBase(size_t array_size,
     ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::GeneratorInput, this, nullptr);
 }
 
+GeneratorInputBase::GeneratorInputBase(const std::string &name, IOKind kind, const std::vector<Type> &t, int d)
+    : GeneratorInputBase(1, name, kind, t, d) {
+    // nothing
+}
+
 GeneratorInputBase::~GeneratorInputBase() { 
     ObjectInstanceRegistry::unregister_instance(this); 
 }
@@ -1624,6 +1629,11 @@ GeneratorOutputBase::GeneratorOutputBase(size_t array_size, const std::string &n
     internal_assert(kind != IOKind::Scalar);
     ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::GeneratorOutput,
                                               this, nullptr);
+}
+
+GeneratorOutputBase::GeneratorOutputBase(const std::string &name, IOKind kind, const std::vector<Type> &t, int d)
+    : GeneratorOutputBase(1, name, kind, t, d) {
+    // nothing
 }
 
 GeneratorOutputBase::~GeneratorOutputBase() { 

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1158,8 +1158,7 @@ protected:
                        const std::vector<Type> &t,
                        int d);
 
-    EXPORT GeneratorInputBase(const std::string &name, IOKind kind, const std::vector<Type> &t, int d)
-      : GeneratorInputBase(1, name, kind, t, d) {}
+    EXPORT GeneratorInputBase(const std::string &name, IOKind kind, const std::vector<Type> &t, int d);
 
     EXPORT ~GeneratorInputBase() override;
 
@@ -1575,8 +1574,7 @@ protected:
     EXPORT GeneratorOutputBase(const std::string &name,
                                IOKind kind,
                                const std::vector<Type> &t,
-                               int d)
-      : GeneratorOutputBase(1, name, kind, t, d) {}
+                               int d);
 
     EXPORT ~GeneratorOutputBase() override;
 


### PR DESCRIPTION
Clang and GCC can disagree about name-mangling conventions for inlined
delegating ctors (C1 , “complete object constructor” vs C2, “base
object constructor”); move the two important cases from Generator info
.cpp to avoid weird linker errors.