### PR TITLE
Revert "Convert IRMutator::mutate methods to pass-by-ref"

### DIFF
--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -89,7 +89,7 @@ public:
 
     GVN() : protect_loads_in_scope(false), number(0), cache(8) {}
 
-    Stmt mutate(const Stmt &s) {
+    Stmt mutate(Stmt s) {
         internal_error << "Can't call GVN on a Stmt: " << s << "\n";
         return Stmt();
     }
@@ -98,9 +98,7 @@ public:
         return ExprWithCompareCache(e, &cache);
     }
 
-    Expr mutate(const Expr &e_in) {
-        Expr e = e_in;
-
+    Expr mutate(Expr e) {
         // Early out if we've already seen this exact Expr.
         {
             map<Expr, int, ExprCompare>::iterator iter = shallow_numbering.find(e);
@@ -276,7 +274,7 @@ public:
 
     using IRMutator::mutate;
 
-    Expr mutate(const Expr &e) {
+    Expr mutate(Expr e) {
         map<Expr, Expr, ExprCompare>::iterator iter = replacements.find(e);
 
         if (iter != replacements.end()) {
@@ -297,7 +295,7 @@ class CSEEveryExprInStmt : public IRMutator {
 public:
     using IRMutator::mutate;
 
-    Expr mutate(const Expr &e) {
+    Expr mutate(Expr e) {
         return common_subexpression_elimination(e);
     }
 };

--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -5,7 +5,7 @@ namespace Internal {
 
 using std::vector;
 
-Expr IRMutator::mutate(const Expr &e) {
+Expr IRMutator::mutate(Expr e) {
     if (e.defined()) {
         e.accept(this);
     } else {
@@ -15,7 +15,7 @@ Expr IRMutator::mutate(const Expr &e) {
     return expr;
 }
 
-Stmt IRMutator::mutate(const Stmt &s) {
+Stmt IRMutator::mutate(Stmt s) {
     if (s.defined()) {
         s.accept(this);
     } else {
@@ -336,7 +336,7 @@ void IRMutator::visit(const Shuffle *op) {
 }
 
 
-Stmt IRGraphMutator::mutate(const Stmt &s) {
+Stmt IRGraphMutator::mutate(Stmt s) {
     auto iter = stmt_replacements.find(s);
     if (iter != stmt_replacements.end()) {
         return iter->second;
@@ -346,7 +346,7 @@ Stmt IRGraphMutator::mutate(const Stmt &s) {
     return new_s;
 }
 
-Expr IRGraphMutator::mutate(const Expr &e) {
+Expr IRGraphMutator::mutate(Expr e) {
     auto iter = expr_replacements.find(e);
     if (iter != expr_replacements.end()) {
         return iter->second;

--- a/src/IRMutator.h
+++ b/src/IRMutator.h
@@ -28,8 +28,8 @@ public:
      * these in your subclass to mutate sub-expressions and
      * sub-statements.
      */
-    EXPORT virtual Expr mutate(const Expr &expr);
-    EXPORT virtual Stmt mutate(const Stmt &stmt);
+    EXPORT virtual Expr mutate(Expr expr);
+    EXPORT virtual Stmt mutate(Stmt stmt);
 
 protected:
 
@@ -94,8 +94,8 @@ protected:
     std::map<Stmt, Stmt, Stmt::Compare> stmt_replacements;
 
 public:
-    EXPORT Stmt mutate(const Stmt &s) override;
-    EXPORT Expr mutate(const Expr &e) override;
+    EXPORT Stmt mutate(Stmt s);
+    EXPORT Expr mutate(Expr e);
 };
 
 

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -399,7 +399,7 @@ public:
     MakeSimplifications(const vector<Simplification> &s) : simplifications(s) {}
 
     using IRMutator::mutate;
-    Expr mutate(const Expr &e) {
+    Expr mutate(Expr e) {
         for (auto const &s : simplifications) {
             if (e.same_as(s.old_expr)) {
                 return mutate(s.likely_value);

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -192,7 +192,7 @@ public:
     }
 
 #if LOG_EXPR_MUTATIONS
-    Expr mutate(const Expr &e) {
+    Expr mutate(Expr e) {
         const std::string spaces(debug_indent, ' ');
         debug(1) << spaces << "Simplifying Expr: " << e << "\n";
         debug_indent++;
@@ -208,7 +208,7 @@ public:
 #endif
 
 #if LOG_STMT_MUTATIONS
-    Stmt mutate(const Stmt &s) {
+    Stmt mutate(Stmt s) {
         const std::string spaces(debug_indent, ' ');
         debug(1) << spaces << "Simplifying Stmt: " << s << "\n";
         debug_indent++;
@@ -4832,7 +4832,7 @@ Stmt simplify(Stmt s, bool simplify_lets,
 class SimplifyExprs : public IRMutator {
 public:
     using IRMutator::mutate;
-    Expr mutate(const Expr &e) {
+    Expr mutate(Expr e) {
         return simplify(e);
     }
 };

--- a/src/SimplifySpecializations.cpp
+++ b/src/SimplifySpecializations.cpp
@@ -33,7 +33,7 @@ class SimplifyUsingFact : public IRMutator {
 public:
     using IRMutator::mutate;
 
-    Expr mutate(const Expr &e) {
+    Expr mutate(Expr e) {
         if (e.type().is_bool()) {
             if (equal(fact, e) ||
                 can_prove(!fact || e)) {

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -34,7 +34,7 @@ public:
 
     using IRMutator::mutate;
 
-    Expr mutate(const Expr &e) {
+    Expr mutate(Expr e) {
         map<Expr, CacheEntry, ExprCompare>::iterator iter = cache.find(e);
         if (iter == cache.end()) {
             // Not in the cache, call the base class version.

--- a/src/Substitute.cpp
+++ b/src/Substitute.cpp
@@ -114,7 +114,7 @@ public:
 
     using IRMutator::mutate;
 
-    Expr mutate(const Expr &e) {
+    Expr mutate(Expr e) {
         if (equal(e, find)) {
             return replacement;
         } else {
@@ -165,7 +165,7 @@ public:
 
     using IRGraphMutator::mutate;
 
-    Expr mutate(const Expr &e) {
+    Expr mutate(Expr e) {
         if (e.same_as(find)) return replace;
         return IRGraphMutator::mutate(e);
     }

--- a/src/UnifyDuplicateLets.cpp
+++ b/src/UnifyDuplicateLets.cpp
@@ -19,7 +19,7 @@ class UnifyDuplicateLets : public IRMutator {
 public:
     using IRMutator::mutate;
 
-    Expr mutate(const Expr &e) {
+    Expr mutate(Expr e) {
 
         if (e.defined()) {
             map<Expr, string, IRDeepCompare>::iterator iter = scope.find(e);

--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -676,8 +676,8 @@ public:
 // existing structure of Let variable scopes around them.
 class IRFilter : public IRVisitor {
 public:
-    virtual Stmt mutate(const Expr &expr);
-    virtual Stmt mutate(const Stmt &stmt);
+    virtual Stmt mutate(Expr expr);
+    virtual Stmt mutate(Stmt stmt);
 
 protected:
     using IRVisitor::visit;
@@ -725,7 +725,7 @@ protected:
     virtual void visit(const Evaluate *);
 };
 
-Stmt IRFilter::mutate(const Expr &e) {
+Stmt IRFilter::mutate(Expr e) {
     if (e.defined()) {
         e.accept(this);
     }
@@ -735,7 +735,7 @@ Stmt IRFilter::mutate(const Expr &e) {
     return stmt;
 }
 
-Stmt IRFilter::mutate(const Stmt &s) {
+Stmt IRFilter::mutate(Stmt s) {
     if (s.defined()) {
         s.accept(this);
     } else {

--- a/test/correctness/gpu_thread_barrier.cpp
+++ b/test/correctness/gpu_thread_barrier.cpp
@@ -27,7 +27,7 @@ public:
     CheckBarrierCount(int correct) : correct(correct) {}
     using IRMutator::mutate;
 
-    Stmt mutate(const Stmt &s) {
+    Stmt mutate(Stmt s) {
         CountBarriers c;
         s.accept(&c);
 

--- a/test/correctness/likely.cpp
+++ b/test/correctness/likely.cpp
@@ -36,7 +36,7 @@ class CheckSinCount : public IRMutator {
 public:
     using IRMutator::mutate;
 
-    Stmt mutate(const Stmt &s) {
+    Stmt mutate(Stmt s) {
         Counter c("");
         s.accept(&c);
         if (c.sin_count != correct) {
@@ -56,7 +56,7 @@ class CheckStoreCount : public IRMutator {
 public:
     using IRMutator::mutate;
 
-    Stmt mutate(const Stmt &s) {
+    Stmt mutate(Stmt s) {
         Counter c(func);
         s.accept(&c);
         if (c.store_count != correct) {

--- a/test/correctness/predicated_store_load.cpp
+++ b/test/correctness/predicated_store_load.cpp
@@ -47,7 +47,7 @@ public:
         has_store_count(store), has_load_count(load) {}
     using IRMutator::mutate;
 
-    Stmt mutate(const Stmt &s) {
+    Stmt mutate(Stmt s) {
         CountPredicatedStoreLoad c;
         s.accept(&c);
 

--- a/test/correctness/tuple_undef.cpp
+++ b/test/correctness/tuple_undef.cpp
@@ -24,7 +24,7 @@ public:
     CheckStoreCount(int correct) : correct(correct) {}
     using IRMutator::mutate;
 
-    Stmt mutate(const Stmt &s) {
+    Stmt mutate(Stmt s) {
         CountStores c;
         s.accept(&c);
 


### PR DESCRIPTION
Reverts halide/Halide#1844, which could cause correctness problems in existing code.

dsharletg@: "When a mutator assigns expr, it may invalidate the 'op' parameter to visit (because the old value of 'expr' was the only thing holding a reference to 'op')."

The speedup is nice, but unless/until I can find a way to ensure no correctness issues occur (or can easily creep in), it's not worth the risk.