### PR TITLE
new_buffer_t_v2: Fix missing halide_weak_device_free function in runtime

### DIFF
--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -220,6 +220,10 @@ WEAK int halide_device_free(void *user_context, struct halide_buffer_t *buf) {
     return 0;
 }
 
+WEAK int halide_weak_device_free(void *user_context, struct halide_buffer_t *buf) {
+    return halide_device_free(user_context, buf);
+}
+
 /** Free any device memory associated with a halide_buffer_t and ignore any
  * error. Used when freeing as a destructor on an error. */
 WEAK void halide_device_free_as_destructor(void *user_context, void *obj) {


### PR DESCRIPTION
In the new_buffer_t_v2 branch, aot-generated files are failing to link with this error when not linking with libHalide (e.g. this is from `make test_generators`):

```
Undefined symbols for architecture x86_64:
  "_halide_weak_device_free", referenced from:
      _halide_get_device_free_fn in acquire_release_aottest-99d32d.o
```

This is because `halide_weak_device_free` is missing from device_interface.cpp in the new_buffer_t_v2 branch (it is present in master).