### PR TITLE
new_buffer_t_v2: Fix assertion error in InjectHostDevBufferCopies

### DIFF
--- a/src/InjectHostDevBufferCopies.cpp
+++ b/src/InjectHostDevBufferCopies.cpp
@@ -621,17 +621,6 @@ class InjectBufferCopies : public IRMutator {
             if (!should_track(buf_name)) {
                 return;
             }
-
-            Expr value = op->value;
-            if (!state[buf_name].host_touched) {
-                // Use null as a host pointer if there's no host allocation
-                const Call *create_buffer = op->value.as<Call>();
-                internal_assert(create_buffer && create_buffer->name == Call::buffer_init);
-                vector<Expr> args = create_buffer->args;
-                args[1] = make_zero(Handle());
-                value = Call::make(type_of<struct halide_buffer_t *>(), Call::buffer_init, args, Call::Extern);
-                stmt = LetStmt::make(op->name, value, op->body);
-            }
         }
     }
 


### PR DESCRIPTION
This issue arises when using memoization, e.g. when running `HL_JIT_TARGET=host-opencl make correctness_memoize`:

```
Internal error at /Users/brian/src/Halide/src/InjectHostDevBufferCopies.cpp:629
Condition failed: create_buffer && create_buffer->name == Call::buffer_init
```

Also occurs for the `correctness_skip_stages_memoize` test.

The cause is that the body of the let statement could be something like:

```
  let f6.computed_bounds.buffer = (let t31 = make_struct((halide_dimension_t *), f6.s0.e4.min_1, ((f6.s0.e4.max_1 - f6.s0.e4.min_1) + 1), 0, 0, f6.s0.e5.min_1, ((f6.s0.e5.max_1 - f6.s0.e5.min_1) + 1), 0, 0) in _halide_buffer_init(alloca(56), t31, reinterpret((void *), (uint64)0), (uint64)0, reinterpret((halide_device_interface_t *), (uint64)0), 3, 0, 2, t31, (uint64)0))
```

That is, the halide_buffer_init is behind a Let expr that creates the halide_dimension_t for the buffer. One fix could be check if the Let etc. nodes are present if it isn't a Call::buffer_init, but I found that this code as actually unnecessary, since the arg it's changing always already 0, so I just removed it.