### PR TITLE
Tweak schedule for camera_pipe, ~4% improvement in hexagon cycles

### DIFF
--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -314,7 +314,7 @@ Func CameraPipe::build() {
     Expr out_width = processed.output_buffer().width();
     Expr out_height = processed.output_buffer().height();
 
-    int strip_size = 32;
+    int strip_size = 128;
     int vec = get_target().natural_vector_size(UInt(16));
     if (get_target().has_feature(Target::HVX_64)) {
         vec = 32;

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -314,11 +314,13 @@ Func CameraPipe::build() {
     Expr out_width = processed.output_buffer().width();
     Expr out_height = processed.output_buffer().height();
 
-    int strip_size = 128;
+    Expr strip_size = 32;
     int vec = get_target().natural_vector_size(UInt(16));
     if (get_target().has_feature(Target::HVX_64)) {
+        strip_size = 64;
         vec = 32;
     } else if (get_target().has_feature(Target::HVX_128)) {
+        strip_size = 128;
         vec = 64;
     }
     denoised.compute_at(processed, yi).store_at(processed, yo)

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -313,6 +313,9 @@ Func CameraPipe::build() {
     // Schedule
     Expr out_width = processed.output_buffer().width();
     Expr out_height = processed.output_buffer().height();
+    // In HVX 128, we need 2 threads to saturate HVX with work,
+    //and in HVX 64 we need 4 threads, and on other devices,
+    // we might need many threads.
     Expr strip_size;
     if (get_target().has_feature(Target::HVX_128)) {
         strip_size = processed.output_buffer().dim(1).extent() / 2;


### PR DESCRIPTION
Small improvement in camera_pipe performance.
should the  strip_size only be set for the hexagon_target? 