### PR TITLE
Fix camera_pipe viz script

### DIFF
--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -6,11 +6,15 @@ TIMING_ITERATIONS ?= 5
 
 $(BIN)/camera_pipe_exec: camera_pipe_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 
 $(BIN)/camera_pipe.a: $(BIN)/camera_pipe_exec
 	@-mkdir -p $(BIN)
 	$^ -o $(BIN) target=$(HL_TARGET)
+
+$(BIN)/viz/camera_pipe.a: $(BIN)/camera_pipe_exec
+	@-mkdir -p $(BIN)/viz
+	HL_TRACE=3 $^ -o $(BIN)/viz target=$(HL_TARGET)
 
 $(BIN)/Demosaic.o: fcam/Demosaic.cpp fcam/Demosaic.h
 	$(CXX) $(CXXFLAGS) -c -Wall -O3 $< -o $@
@@ -21,13 +25,16 @@ $(BIN)/Demosaic_ARM.o: fcam/Demosaic_ARM.cpp fcam/Demosaic_ARM.h
 $(BIN)/process: process.cpp $(BIN)/camera_pipe.a $(BIN)/Demosaic.o $(BIN)/Demosaic_ARM.o
 	$(CXX) $(CXXFLAGS) -Wall -O3 -I$(BIN) $^ -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
 
+$(BIN)/viz/process: process.cpp $(BIN)/viz/camera_pipe.a $(BIN)/Demosaic.o $(BIN)/Demosaic_ARM.o
+	$(CXX) $(CXXFLAGS) -Wall -O3 -I$(BIN)/viz $^ -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
+
 $(BIN)/out.png: $(BIN)/process
 	$(BIN)/process $(IMAGES)/bayer_raw.png 3700 2.0 50 $(TIMING_ITERATIONS) $@ $(BIN)/fcam_c.png $(BIN)/fcam_arm.png
 
 ../../bin/HalideTraceViz:
 	$(MAKE) -C ../../ bin/HalideTraceViz
 
-$(BIN)/camera_pipe.avi: $(BIN)/process viz.sh $(HALIDE_TRACE_VIZ) ../../bin/HalideTraceViz
+$(BIN)/camera_pipe.avi: $(BIN)/viz/process viz.sh $(HALIDE_TRACE_VIZ) ../../bin/HalideTraceViz
 	bash viz.sh $(BIN)
 
 clean:

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -48,7 +48,7 @@ Func CameraPipe::hot_pixel_suppression(Func input) {
     Expr a = max(max(input(x-2, y), input(x+2, y)),
                  max(input(x, y-2), input(x, y+2)));
 
-    Func denoised;
+    Func denoised("denoised");
     denoised(x, y) = clamp(input(x, y), 0, a);
 
     return denoised;
@@ -68,7 +68,7 @@ Func CameraPipe::interleave_y(Func a, Func b) {
 
 Func CameraPipe::deinterleave(Func raw) {
     // Deinterleave the color channels
-    Func deinterleaved;
+    Func deinterleaved("deinterleaved");
 
     deinterleaved(x, y, c) = select(c == 0, raw(2*x, 2*y),
                                     c == 1, raw(2*x+1, 2*y),
@@ -84,14 +84,15 @@ std::pair<Func, Scheduler> CameraPipe::demosaic(Func deinterleaved) {
     // gr refers to green sites in the red rows
 
     // Give more convenient names to the four channels we know
-    Func r_r, g_gr, g_gb, b_b;
+    Func r_r("r_r"), g_gr("g_gr"), g_gb("g_gb"), b_b("b_b");
     g_gr(x, y) = deinterleaved(x, y, 0);
     r_r(x, y)  = deinterleaved(x, y, 1);
     b_b(x, y)  = deinterleaved(x, y, 2);
     g_gb(x, y) = deinterleaved(x, y, 3);
 
     // These are the ones we need to interpolate
-    Func b_r, g_r, b_gr, r_gr, b_gb, r_gb, r_b, g_b;
+    Func b_r("b_r"), g_r("g_r"), b_gr("b_gr"), r_gr("r_gr");
+    Func b_gb("b_gb"), r_gb("r_gb"), r_b("r_b"), g_b("g_b");
 
     // First calculate green at the red and blue sites
 
@@ -169,10 +170,10 @@ std::pair<Func, Scheduler> CameraPipe::demosaic(Func deinterleaved) {
     Func b = interleave_y(interleave_x(b_gr, b_r),
                           interleave_x(b_b, b_gb));
 
-    Func output;
+    Func output("output");
     output(x, y, c) = select(c == 0, r(x, y),
-                             c == 1, g(x, y),
-                                     b(x, y));
+                                 c == 1, g(x, y),
+                                 b(x, y));
 
     Scheduler scheduler = [=](Func processed) mutable {
         assert(g_r.defined());
@@ -218,7 +219,7 @@ Func CameraPipe::color_correct(Func input) {
     matrix(x, y) = cast<int16_t>(val * 256.0f); // Q8.8 fixed point
     matrix.compute_root();
 
-    Func corrected;
+    Func corrected("corrected");
     Expr ir = cast<int32_t>(input(x, y, 0));
     Expr ig = cast<int32_t>(input(x, y, 1));
     Expr ib = cast<int32_t>(input(x, y, 2));
@@ -276,7 +277,7 @@ Func CameraPipe::apply_curve(Func input) {
 
     curve.compute_root(); // It's a LUT, compute it once ahead of time.
 
-    Func curved;
+    Func curved("curved");
 
     if (lutResample == 1) {
         // Use clamp to restrict size of LUT as allocated by compute_root

--- a/apps/camera_pipe/viz.sh
+++ b/apps/camera_pipe/viz.sh
@@ -3,25 +3,25 @@ export HL_TRACE=3
 export HL_TRACE_FILE=/dev/stdout
 export HL_NUMTHREADS=4
 rm -f $1/camera_pipe.avi
-$1/process ../images/bayer_small.png 3700 1.8 50 1 $1/out.png |
+$1/viz/process ../images/bayer_small.png 3700 1.8 50 1 $1/out.png |
 ../../bin/HalideTraceViz -t 1000 -s 1920 1080 \
--f input         0 1024  -1 1 1 10   348 1 0 0 1 \
--f denoised      0 1024  -1 1 1 305  360 1 0 0 1 \
--f deinterleaved 0 1024  -1 1 1 580  120 1 0 0 1 0 220 \
--f r_gr          0 1024  -1 1 1 720  120 1 0 0 1 \
--f g_gr          0 1024  -1 1 1 860  120 1 0 0 1 \
--f b_gr          0 1024  -1 1 1 1000 120 1 0 0 1 \
--f r_r           0 1024  -1 1 1 720  340 1 0 0 1 \
--f g_r           0 1024  -1 1 1 860  340 1 0 0 1 \
--f b_r           0 1024  -1 1 1 1000 340 1 0 0 1 \
--f r_b           0 1024  -1 1 1 720  560 1 0 0 1 \
--f g_b           0 1024  -1 1 1 860  560 1 0 0 1 \
--f b_b           0 1024  -1 1 1 1000 560 1 0 0 1 \
--f r_gb          0 1024  -1 1 1 720  780 1 0 0 1 \
--f g_gb          0 1024  -1 1 1 860  780 1 0 0 1 \
--f b_gb          0 1024  -1 1 1 1000 780 1 0 0 1 \
--f demosaiced    0 1024   2 1 1 1140 360 1 0 0 1 0 0 \
--f corrected     0 1024   2 1 1 1400 360 1 0 0 1 0 0 \
--f processed     0 256    2 1 1 1660 360 1 0 0 1 0 0 | \
+-f input         0 1024  -1 0 1 1 10   348 1 0 0 1 \
+-f denoised      0 1024  -1 0 1 1 305  360 1 0 0 1 \
+-f deinterleaved 0 1024  -1 0 1 1 580  120 1 0 0 1 0 220 \
+-f r_gr          0 1024  -1 0 1 1 720  120 1 0 0 1 \
+-f g_gr          0 1024  -1 0 1 1 860  120 1 0 0 1 \
+-f b_gr          0 1024  -1 0 1 1 1000 120 1 0 0 1 \
+-f r_r           0 1024  -1 0 1 1 720  340 1 0 0 1 \
+-f g_r           0 1024  -1 0 1 1 860  340 1 0 0 1 \
+-f b_r           0 1024  -1 0 1 1 1000 340 1 0 0 1 \
+-f r_b           0 1024  -1 0 1 1 720  560 1 0 0 1 \
+-f g_b           0 1024  -1 0 1 1 860  560 1 0 0 1 \
+-f b_b           0 1024  -1 0 1 1 1000 560 1 0 0 1 \
+-f r_gb          0 1024  -1 0 1 1 720  780 1 0 0 1 \
+-f g_gb          0 1024  -1 0 1 1 860  780 1 0 0 1 \
+-f b_gb          0 1024  -1 0 1 1 1000 780 1 0 0 1 \
+-f output        0 1024   2 0 1 1 1140 360 1 0 0 1 0 0 \
+-f corrected     0 1024   2 0 1 1 1400 360 1 0 0 1 0 0 \
+-f curved        0 256    2 0 1 1 1660 360 1 0 0 1 0 0 | \
 avconv -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 $1/camera_pipe.avi
 #mplayer -demuxer rawvideo -rawvideo w=1920:h=1080:format=rgba:fps=30 -idle -fixed-vo -

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -584,7 +584,7 @@ int run(int argc, char **argv) {
                 }
             }
 
-            if (p.event == 1) {
+            if (p.event == halide_trace_store) {
                 // Stores take time proportional to the number of
                 // items stored times the cost of the func.
                 halide_clock += fi.config.cost * p.type.lanes;
@@ -610,7 +610,7 @@ int run(int argc, char **argv) {
                     }
 
                     // Stores are orange, loads are blue.
-                    uint32_t color = p.event == 0 ? 0xffffdd44 : 0xff44ddff;
+                    uint32_t color = p.event == halide_trace_load ? 0xffffdd44 : 0xff44ddff;
 
                     uint32_t image_color;
                     bool update_image = false;
@@ -618,7 +618,8 @@ int run(int argc, char **argv) {
                     // Update one or more of the color channels of the
                     // image layer in case it's a store or a load from
                     // the input.
-                    if (true /** TODO: only do this if it's a store or load from the input */) {
+                    if (p.event == halide_trace_store ||
+                        fi.stats.num_realizations == 0 /* load from an input */) {
                         update_image = true;
                         // Get the old color, in case we're only
                         // updating one of the color channels.


### PR DESCRIPTION
Fix the camera pipe visualization. It was using an old version of the arguments to trace viz, and some of the function names were messed up.

There's still a minor problem with viz: sometimes Halide intentionally
loads out of bounds memory, and uses it to compute and store garbage
values, when it knows those values can't affect the output. These show
up as noise in the viz. This is true to what's going on, but looks
pretty distracting. The visualizer doesn't track bounds in a detailed
enough way to detect these things.

Also, tracing should be in the target, not an env var. This would let us
use the convention of ./bin/$(TARGET) for generator outputs instead of
repeating makefile rules for viz targets.