### PR TITLE
ErrorReport::explode should append a newline if needed

### DIFF
--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -87,6 +87,10 @@ ErrorReport::~ErrorReport()
     noexcept(false)
 #endif
 {
+    if (!msg.str().empty() && msg.str().back() != '\n') {
+        msg << '\n';
+    }
+
     if (custom_error_reporter != nullptr) {
         if (flags & Warning) {
             custom_error_reporter->warning(msg.str().c_str());


### PR DESCRIPTION
Minor, but it means that all assertion failures are uniformly printed
with newlines at end (vs the some-that-are, some-that-aren’t right now)