### PR TITLE
OpenCL Textures support

### DIFF
--- a/src/Closure.h
+++ b/src/Closure.h
@@ -29,6 +29,7 @@ protected:
     void visit(const LetStmt *op);
     void visit(const For *op);
     void visit(const Load *op);
+    void visit(const Call *op);
     void visit(const Store *op);
     void visit(const Allocate *op);
     void visit(const Variable *op);

--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -113,7 +113,7 @@ CodeGen_GPU_Host<CodeGen_CPU>::CodeGen_GPU_Host(Target target) : CodeGen_CPU(tar
     }
     if (target.has_feature(Target::OpenCL)) {
         debug(1) << "Constructing OpenCL device codegen\n";
-        cgdev[DeviceAPI::OpenCL] = new CodeGen_OpenCL_Dev(target);
+        cgdev[DeviceAPI::OpenCL] = cgdev[DeviceAPI::OpenCLTextures] = new CodeGen_OpenCL_Dev(target);
     }
     if (target.has_feature(Target::Metal)) {
         debug(1) << "Constructing Metal device codegen\n";
@@ -128,7 +128,10 @@ CodeGen_GPU_Host<CodeGen_CPU>::CodeGen_GPU_Host(Target target) : CodeGen_CPU(tar
 template<typename CodeGen_CPU>
 CodeGen_GPU_Host<CodeGen_CPU>::~CodeGen_GPU_Host() {
     for (pair<const DeviceAPI, CodeGen_GPU_Dev *> &i : cgdev) {
-        delete i.second;
+        // TODO(zalman): This is a special kind of ugly. Probably worth uniq'ing the collection of pointers.
+        if (i.first != DeviceAPI::OpenCLTextures) {
+            delete i.second;
+        }
     }
 }
 

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -17,7 +17,7 @@ using std::vector;
 using std::sort;
 
 CodeGen_OpenCL_Dev::CodeGen_OpenCL_Dev(Target t) :
-    clc(src_stream, t) {
+    clc(src_stream, t), target(t) {
 }
 
 string CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::print_type(Type type, AppendSpaceIfNeeded space) {
@@ -214,6 +214,128 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Call *op) {
         ostringstream rhs;
         rhs << "abs_diff(" << print_expr(op->args[0]) << ", " << print_expr(op->args[1]) << ")";
         print_assignment(op->type, rhs.str());
+    } else if (op->is_intrinsic(Call::image_load)) {
+        // image_load(<image name>, <buffer>, <x>, <x-extent>, <y>,
+        // <y-extent>, <z>, <z-extent>)
+        int dims = (op->args.size() - 2) / 2;
+        internal_assert(dims >= 1 && dims <= 3);
+        const StringImm *string_imm = op->args[0].as<StringImm>();
+        if (!string_imm) {
+            internal_assert(op->args[0].as<Broadcast>());
+            string_imm = op->args[0].as<Broadcast>()->value.as<StringImm>();
+        }
+        internal_assert(string_imm);
+        Type arg_type = op->args[2].type();
+        internal_assert(arg_type.lanes() <= 16);
+        internal_assert(arg_type.lanes() == op->type.lanes());
+
+        string type_suffix;
+        if (op->type.is_int()) {
+            type_suffix = "i";
+        } else if (op->type.is_uint()) {
+            type_suffix = "ui";
+        } else if (op->type.is_float()) {
+            type_suffix = "f";
+        } else {
+            internal_error << "Invalid type for read_image: " << op->type << "\n";
+        }
+
+        std::array<string, 3> coord;
+        for (int i = 0; i < dims; i++) {
+            coord[i] = print_expr(op->args[i*2 + 2]);
+        }
+        vector<string> results(arg_type.lanes());
+        // For vectorized reads, codegen as a sequence of read_image calls
+        for (int i = 0; i < arg_type.lanes(); i++) {
+            ostringstream rhs;
+            rhs << "read_image" << type_suffix << "(" << print_name(string_imm->value) << ", ";
+            string idx = arg_type.is_vector() ? string(".s") + vector_elements[i] : "";
+            switch (dims) {
+            case 1:
+                rhs << coord[0] << idx << ").s0";
+                break;
+            case 2:
+                rhs << "(int2)(" << coord[0] << idx << ", " << coord[1] << idx << ")).s0";
+                break;
+            case 3:
+                rhs << "(int4)(" << coord[0] << idx << ", " << coord[1] << idx
+                    << ", " << coord[2] << idx << ", 0)).s0";
+                break;
+            }
+            print_assignment(op->type.with_bits(32).with_lanes(1), rhs.str());
+            results[i] = id;
+        }
+
+        if (op->type.is_vector()) {
+            // Combine all results into a single vector
+            ostringstream rhs;
+            rhs << "(" << print_type(op->type) << ")(";
+            for (int i = 0; i < op->type.lanes(); i++) {
+                rhs << results[i];
+                if (i < op->type.lanes() -1) {
+                    rhs << ", ";
+                }
+            }
+            rhs << ")";
+            print_assignment(op->type, rhs.str());
+        }
+        if (op->type.bits() != 32) {
+            // Widen to the correct type
+            print_assignment(op->type, "convert_" + print_type(op->type) + "(" + id + ")");
+        }
+    } else if (op->is_intrinsic(Call::image_store)) {
+        // image_store(<image name>, <buffer>, <x>, <y>, <z>, <value>)
+        const StringImm *string_imm = op->args[0].as<StringImm>();
+        if (!string_imm) {
+            internal_assert(op->args[0].as<Broadcast>());
+            string_imm = op->args[0].as<Broadcast>()->value.as<StringImm>();
+        }
+        internal_assert(string_imm);
+        int dims = op->args.size() - 3;
+        internal_assert(dims >= 1 && dims <= 3);
+        Type arg_type = op->args[2].type();
+        internal_assert(arg_type.lanes() <= 16);
+        Type value_type = op->args.back().type();
+        internal_assert(arg_type.lanes() == value_type.lanes());
+
+        string type_suffix;
+        if (op->type.is_int()) {
+            type_suffix = "i";
+        } else if (op->type.is_uint()) {
+            type_suffix = "ui";
+        } else if (op->type.is_float()) {
+            type_suffix = "f";
+        } else {
+            internal_error << "Invalid type for write_image: " << op->type << "\n";
+        }
+
+        std::array<string, 3> coord;
+        for (int i = 0; i < dims; i++) {
+            coord[i] = print_expr(op->args[i + 2]);
+        }
+        string value = print_expr(op->args.back());
+        // For vectorized writes, codegen as a sequence of write_image calls
+        for (int i = 0; i < arg_type.lanes(); i++) {
+            ostringstream write_image;
+            write_image << "write_image" << type_suffix << "(" << print_name(string_imm->value) << ", ";
+            string idx = arg_type.is_vector() ? string(".s") + vector_elements[i] : "";
+            switch (dims) {
+            case 1:
+                write_image << coord[0] << idx;
+                break;
+            case 2:
+                write_image << "(int2)(" << coord[0] << idx << ", " << coord[1] << idx << ")";
+                break;
+            case 3:
+                write_image << "(int4)(" << coord[0] << idx << ", " << coord[1] << idx
+                            << ", " << coord[2] << idx << ", 0)";
+                break;
+            }
+            write_image << ", (" << print_type(value_type.with_bits(32).with_lanes(4))
+                        << ")(" << value << idx << ", 0, 0, 0));\n";
+            do_indent();
+            stream << write_image.str();
+        }
     } else {
         CodeGen_C::visit(op);
     }
@@ -588,11 +710,28 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
     stream << "__kernel void " << name << "(\n";
     for (size_t i = 0; i < args.size(); i++) {
         if (args[i].is_buffer) {
-            stream << " " << get_memory_space(args[i].name) << " ";
-            if (!args[i].write) stream << "const ";
-            stream << print_type(args[i].type) << " *"
-                   << "restrict "
-                   << print_name(args[i].name);
+            if (args[i].is_texture) {
+                int dims = args[i].dimensions;
+                internal_assert(dims >= 1 && dims <= 3) << "dims = " << dims << "\n";
+                if (args[i].read && args[i].write) {
+                    stream << " __read_write ";
+                } else if (args[i].read) {
+                    stream << " __read_only ";
+                } else if (args[i].write) {
+                    stream << " __write_only ";
+                } else {
+                    internal_error << "CL Image argument " << args[i].name
+                                   << " is neither read nor write";
+                }
+                stream << "image" << dims << "d_t "
+                       << print_name(args[i].name);
+            } else {
+                stream << " " << get_memory_space(args[i].name) << " ";
+                if (!args[i].write) stream << "const ";
+                stream << print_type(args[i].type) << " *"
+                       << "restrict "
+                       << print_name(args[i].name);
+            }
             Allocation alloc;
             alloc.type = args[i].type;
             allocations.push(args[i].name, alloc);

--- a/src/DeviceArgument.h
+++ b/src/DeviceArgument.h
@@ -34,6 +34,12 @@ struct DeviceArgument {
      */
     bool is_buffer;
 
+    /** If is_buffer is true, this is also true if the buffer is
+     * specified as a texture and is accessed via image_load and
+     * image_store.
+     */
+    bool is_texture;
+
     /** If is_buffer is true, this is the dimensionality of the buffer.
      * If is_buffer is false, this value is ignored (and should always be set to zero) */
     uint8_t dimensions;
@@ -61,6 +67,7 @@ struct DeviceArgument {
 
     DeviceArgument() :
         is_buffer(false),
+        is_texture(false),
         dimensions(0),
         size(0),
         packed_index(0),
@@ -69,11 +76,13 @@ struct DeviceArgument {
 
     DeviceArgument(const std::string &_name,
                    bool _is_buffer,
+                   bool _is_texture,
                    Type _type,
                    uint8_t _dimensions,
                    size_t _size = 0) :
         name(_name),
         is_buffer(_is_buffer),
+        is_texture(_is_texture),
         dimensions(_dimensions),
         type(_type),
         size(_size),
@@ -92,6 +101,7 @@ public:
     std::vector<DeviceArgument> arguments();
 
 protected:
+    std::set<std::string> textures;
     using Internal::Closure::visit;
     void visit(const For *loop);
     void visit(const Call *op);

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -308,6 +308,7 @@ enum class DeviceAPI {
     Default_GPU,
     CUDA,
     OpenCL,
+    OpenCLTextures,
     GLSL,
     OpenGLCompute,
     Metal,

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -686,7 +686,8 @@ class ZeroGPULoopMins : public IRMutator {
         bool old_in_non_glsl_gpu = in_non_glsl_gpu;
 
         in_non_glsl_gpu = (in_non_glsl_gpu && op->device_api == DeviceAPI::None) ||
-          (op->device_api == DeviceAPI::CUDA) || (op->device_api == DeviceAPI::OpenCL) ||
+          (op->device_api == DeviceAPI::CUDA) ||
+          (op->device_api == DeviceAPI::OpenCL) || (op->device_api == DeviceAPI::OpenCLTextures) ||
           (op->device_api == DeviceAPI::Metal);
 
         IRMutator::visit(op);

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -77,6 +77,9 @@ ostream &operator<<(ostream &out, const DeviceAPI &api) {
     case DeviceAPI::OpenCL:
         out << "<OpenCL>";
         break;
+    case DeviceAPI::OpenCLTextures:
+        out << "<OpenCLTextures>";
+        break;
     case DeviceAPI::OpenGLCompute:
         out << "<OpenGLCompute>";
         break;

--- a/src/InjectHostDevBufferCopies.cpp
+++ b/src/InjectHostDevBufferCopies.cpp
@@ -174,6 +174,9 @@ class InjectBufferCopies : public IRMutator {
           case DeviceAPI::OpenCL:
             interface_name = "halide_opencl_device_interface";
             break;
+        case DeviceAPI::OpenCLTextures:
+            interface_name = "halide_opencl_textures_device_interface";
+            break;
           case DeviceAPI::Metal:
             interface_name = "halide_metal_device_interface";
             break;
@@ -424,7 +427,8 @@ class InjectBufferCopies : public IRMutator {
             }
         } else if (op->is_intrinsic(Call::image_load)) {
             // counts as a device read
-            internal_assert(device_api == DeviceAPI::GLSL);
+            internal_assert(device_api == DeviceAPI::GLSL ||
+                            device_api == DeviceAPI::OpenCLTextures);
             internal_assert(op->args.size() >= 2);
             const Variable *buffer_var = op->args[1].as<Variable>();
             internal_assert(buffer_var && ends_with(buffer_var->name, ".buffer"));
@@ -434,7 +438,8 @@ class InjectBufferCopies : public IRMutator {
             IRMutator::visit(op);
         } else if (op->is_intrinsic(Call::image_store)) {
             // counts as a device store
-            internal_assert(device_api == DeviceAPI::GLSL);
+            internal_assert(device_api == DeviceAPI::GLSL ||
+                            device_api == DeviceAPI::OpenCLTextures);
             internal_assert(op->args.size() >= 2);
             const Variable *buffer_var = op->args[1].as<Variable>();
             internal_assert(buffer_var && ends_with(buffer_var->name, ".buffer"));

--- a/src/InjectImageIntrinsics.h
+++ b/src/InjectImageIntrinsics.h
@@ -8,6 +8,7 @@
 
 #include "IR.h"
 #include "Scope.h"
+#include "Target.h"
 
 namespace Halide {
 namespace Internal {
@@ -15,7 +16,7 @@ namespace Internal {
 /** Take a statement with for kernel for loops and turn loads and
  * stores inside the loops into image load and store
  * intrinsics. */
-Stmt inject_image_intrinsics(Stmt s, const std::map<std::string, Function> &env);
+Stmt inject_image_intrinsics(Stmt s, const std::map<std::string, Function> &env, Target t);
 }
 }
 

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -184,9 +184,9 @@ Stmt lower(const vector<Function> &output_funcs, const string &pipeline_name,
     s = split_tuples(s, env);
     debug(2) << "Lowering after destructuring tuple-valued realizations:\n" << s << "\n\n";
 
-    if (t.has_feature(Target::OpenGL)) {
+    if (t.features_any_of({Target::OpenGL, Target::Textures})) {
         debug(1) << "Injecting image intrinsics...\n";
-        s = inject_image_intrinsics(s, env);
+        s = inject_image_intrinsics(s, env, t);
         debug(2) << "Lowering after image intrinsics:\n" << s << "\n\n";
     }
 

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -701,6 +701,14 @@ class ExprContainsLoad : public IRVisitor {
         result = true;
     }
 
+    void visit(const Call *op) {
+        if (op->is_intrinsic(Call::image_load)) {
+            result = true;
+        } else {
+            IRVisitor::visit(op);
+        }
+    }
+
 public:
     bool result = false;
 };

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -258,6 +258,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"avx512_knl", Target::AVX512_KNL},
     {"avx512_skylake", Target::AVX512_Skylake},
     {"avx512_cannonlake", Target::AVX512_Cannonlake},
+    {"textures", Target::Textures},
 };
 
 bool lookup_feature(const std::string &tok, Target::Feature &result) {

--- a/src/Target.h
+++ b/src/Target.h
@@ -79,6 +79,7 @@ struct Target {
         AVX512_KNL = halide_target_feature_avx512_knl,
         AVX512_Skylake = halide_target_feature_avx512_skylake,
         AVX512_Cannonlake = halide_target_feature_avx512_cannonlake,
+        Textures = halide_target_feature_textures,
         FeatureEnd = halide_target_feature_end
     };
     Target() : os(OSUnknown), arch(ArchUnknown), bits(0) {}

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -909,7 +909,8 @@ typedef enum halide_target_feature_t {
     halide_target_feature_avx512_skylake = 40, ///< Enable the AVX512 features supported by Skylake Xeon server processors. This adds AVX512-VL, AVX512-BW, and AVX512-DQ to the base set. The main difference from the base AVX512 set is better support for small integer ops. Note that this does not include the Knight's Landing features. Note also that these features are not available on Skylake desktop and mobile processors.
     halide_target_feature_avx512_cannonlake = 41, ///< Enable the AVX512 features expected to be supported by future Cannonlake processors. This includes all of the Skylake features, plus AVX512-IFMA and AVX512-VBMI.
     halide_target_feature_hvx_use_shared_object = 42, ///< Build shared object code for Hexagon, and use dlopenbuf API.
-    halide_target_feature_end = 43 ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
+    halide_target_feature_textures = 43, ///< Default to using textures for GPU buffers. Only usable with OpenCL
+    halide_target_feature_end = 44 ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 
 /** This function is called internally by Halide in some situations to determine

--- a/src/runtime/HalideRuntimeOpenCL.h
+++ b/src/runtime/HalideRuntimeOpenCL.h
@@ -12,6 +12,7 @@ extern "C" {
  */
 
 extern const struct halide_device_interface_t *halide_opencl_device_interface();
+extern const struct halide_device_interface_t *halide_opencl_textures_device_interface();
 
 /** These are forward declared here to allow clients to override the
  *  Halide OpenCL runtime. Do not call them. */

--- a/test/common/gpu_object_lifetime_tracker.h
+++ b/test/common/gpu_object_lifetime_tracker.h
@@ -21,14 +21,15 @@ class GpuObjectLifetimeTracker {
             is_global(is_global), total_created(0), live_count(0) {}
     };
 
-    std::array<ObjectType, 13> object_types = {{
+    std::array<ObjectType, 14> object_types = {{
         // OpenCL objects
         {"clCreateContext", "clReleaseContext", true},
         {"clCreateCommandQueue", "clReleaseCommandQueue", true},
         // This handles both "clCreateProgramWithSource" and
         // "clCreateProgramWithBinary".
         {"clCreateProgram", "clReleaseProgram"},
-        {"clCreateBuffer", "clReleaseMemObject"},
+        {"clCreateBuffer", "clReleaseMemObject Buffer"},
+        {"clCreateImage", "clReleaseMemObject Image"},
         {"clCreateKernel", "clReleaseKernel"},
 
         // CUDA objects


### PR DESCRIPTION
Work on this feature started a while ago on the gpu_textures_api_variants branch, but was never fully completed. I am resurrecting this, now being based off of the new halide_buffer_t implementation, which has the necessary type info to allow the call to clCreateImage to always create the right type of image.

In summary, this adds the Target::Textures feature, which when used with Target::OpenCL feature will change the buffers passed into the kernel to be cl_images instead, supporting 1, 2, or 3 dimensions. The standard loads and stores in the kernel are replaced by multidimensional read_image and write_image calls.

The old gpu_textures_api_variants had preliminary support for Metal Textures as well, but it was never completed so I left it out. It can still be added later.