### PR TITLE
Refactor some code from GeneratorStub->GeneratorBase

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2079,8 +2079,6 @@ public:
     }
 
 protected:
-    // In an ideal world, the GeneratorContext would be a required argument to the ctor;
-    // unfortunately, 
     EXPORT GeneratorBase(size_t size, const void *introspection_helper);
     EXPORT void init_from_context(const Halide::GeneratorContext &context);
 


### PR DESCRIPTION
Some of the functionality in GeneratorStub really belonged in
GeneratorBase (e.g., GeneratorContext usage); moved code around to make
some upcoming functional changes easier to review.