### PR TITLE
Fix segv while running camera_pipe

### DIFF
--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -324,7 +324,7 @@ WEAK int halide_device_and_host_free(void *user_context, struct buffer_t *buf) {
             } else {
                 return 0;
             }
-        } else if (buf && buf->host) {
+        } else if (buf->host) {
             // device_free must have been called on this buffer (which
             // must be legal for the device interface that was
             // used). We'd better still free the host pointer.

--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -324,7 +324,7 @@ WEAK int halide_device_and_host_free(void *user_context, struct buffer_t *buf) {
             } else {
                 return 0;
             }
-        } else {
+        } else if (buf && buf->host) {
             // device_free must have been called on this buffer (which
             // must be legal for the device interface that was
             // used). We'd better still free the host pointer.


### PR DESCRIPTION
seeing segv on a few tests, i think you might have to be running hexagon() to see the failures

Camera_pipe
Received archstring from environment=--l2cache_perfect 1
ARCHSTRING set l2cache_perfect = 1
make: *** [bin/out.png] Segmentation fault

a few correctness tests as well
bash: line 1: 47448 Segmentation fault      /local/mnt/workspace/bots/hexbotmaster-aus-perses-10-2/halide-82/src/halide/bin/correctness_argmax
make: *** [correctness_argmax] Error 139
