### PR TITLE
Tracing call should widen its call args

### DIFF
--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -496,8 +496,13 @@ class VectorSubs : public IRMutator {
                 // vector of distinct structs.
                 const Call *call = new_args[i].as<Call>();
                 internal_assert(call && call->is_intrinsic(Call::make_struct));
+                // Widen the call args to have the same lanes as the max lanes found
+                vector<Expr> call_args(call->args.size());
+                for (size_t i = 0; i < call_args.size(); i++) {
+                    call_args[i] = widen(call->args[i], max_lanes);
+                }
                 new_args[i] = Call::make(call->type.element_of(), Call::make_struct,
-                                         call->args, Call::Intrinsic);
+                                         call_args, Call::Intrinsic);
             }
             // One of the arguments to the trace helper
             // records the number of vector lanes in the type being

--- a/test/correctness/tracing_broadcast.cpp
+++ b/test/correctness/tracing_broadcast.cpp
@@ -1,0 +1,34 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int my_trace(void *user_context, const halide_trace_event_t *e) {
+    if (e->event == halide_trace_store) {
+        for (int i = 0; i < e->type.lanes; ++i) {
+            int val = ((const int *)(e->value))[i];
+            if (val != 1234567890) {
+                printf("All values stored should have been 1234567890\n"
+                       "Instead they are: %d\n", val);
+                exit(-1);
+            }
+        }
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    Func f("f");
+    Var x("x"), y("y");
+    f(x, y) = 1234567890;
+    f.vectorize(x, 8);
+
+    f.trace_stores();
+    f.set_custom_trace(&my_trace);
+    f.realize(8, 8);
+
+    printf("Success!\n");
+
+    return 0;
+
+}


### PR DESCRIPTION
Vectorize trace call handler didn't widen the call args (for broadcast) causing garbage to be traced. 