### PR TITLE
Add Generator set_inputs() convenience wrapper

### DIFF
--- a/src/Util.h
+++ b/src/Util.h
@@ -247,8 +247,61 @@ bool sub_would_overflow(int bits, int64_t a, int64_t b);
 bool mul_would_overflow(int bits, int64_t a, int64_t b);
 // @}
 
+// Wrappers for some C++14-isms that are useful and trivially implementable
+// in C++11; these are defined in the Halide::Internal namespace. If we
+// are compiling under C++14 or later, we just use the standard implementations
+// rather than our own.
+#if __cplusplus >= 201402L
 
-}
-}
+// C++14: Use the standard implementations
+using std::integer_sequence;
+using std::make_integer_sequence;
+using std::index_sequence;
+using std::make_index_sequence;
+
+#else
+
+// C++11: std::integer_sequence (etc) is standard in C++14 but not C++11, but
+// is easily written in C++11. This is a simple version that could 
+// probably be improved.
+
+template<typename T, T... Ints> 
+struct integer_sequence {
+    static constexpr size_t size() { return sizeof...(Ints); }
+};
+
+template<typename T> 
+struct next_integer_sequence;
+
+template<typename T, T... Ints> 
+struct next_integer_sequence<integer_sequence<T, Ints...>> {
+    using type = integer_sequence<T, Ints..., sizeof...(Ints)>;
+};
+
+template<typename T, T I, T N> 
+struct make_integer_sequence_helper {
+    using type = typename next_integer_sequence<
+        typename make_integer_sequence_helper<T, I+1, N>::type
+    >::type;
+};
+
+template<typename T, T N> 
+struct make_integer_sequence_helper<T, N, N> {
+    using type = integer_sequence<T>;
+};
+
+template<typename T, T N>
+using make_integer_sequence = typename make_integer_sequence_helper<T, 0, N>::type;
+
+template<size_t... Ints>
+using index_sequence = integer_sequence<size_t, Ints...>;
+
+template<size_t N>
+using make_index_sequence = make_integer_sequence<size_t, N>;
+
+#endif
+
+}  // namespace Internal
+}  // namespace Halide
 
 #endif


### PR DESCRIPTION
GeneratorBase::set_inputs() is a variadic wrapper around
set_inputs_vector(), which infers the C++ type of each argument and
builds up a wrapper of StubInputs appropriately. This makes for much
more idiomatic C++ code, and also makes some of the relevant
error-checking for type much clearer.