### PR TITLE
Validate schedule of inlined function with multiple update stages

### DIFF
--- a/src/Inline.cpp
+++ b/src/Inline.cpp
@@ -14,83 +14,80 @@ using std::set;
 using std::string;
 using std::vector;
 
+// Sanity check that this is a reasonable function to inline
+void validate_schedule_inlined_function(Function f) {
+    const Schedule &s = f.schedule();
+
+    if (!s.store_level().is_inline()) {
+        user_error << "Function " << f.name() << " is scheduled to be computed inline, "
+                   << "but is not scheduled to be stored inline. A storage schedule "
+                   << "is meaningless for functions computed inline.\n";
+    }
+
+    if (s.memoized()) {
+        user_error << "Cannot memoize function "
+                   << f.name() << " because the function is scheduled inline.\n";
+    }
+
+    for (size_t i = 0; i < s.dims().size(); i++) {
+        Dim d = s.dims()[i];
+        if (d.is_parallel()) {
+            user_error << "Cannot parallelize dimension "
+                       << d.var << " of function "
+                       << f.name() << " because the function is scheduled inline.\n";
+        } else if (d.for_type == ForType::Unrolled) {
+            user_error << "Cannot unroll dimension "
+                       << d.var << " of function "
+                       << f.name() << " because the function is scheduled inline.\n";
+        } else if (d.for_type == ForType::Vectorized) {
+            user_error << "Cannot vectorize dimension "
+                       << d.var << " of function "
+                       << f.name() << " because the function is scheduled inline.\n";
+        }
+    }
+
+    for (size_t i = 0; i < s.splits().size(); i++) {
+        if (s.splits()[i].is_rename()) {
+            user_warning << "It is meaningless to rename variable "
+                         << s.splits()[i].old_var << " of function "
+                         << f.name() << " to " << s.splits()[i].outer
+                         << " because " << f.name() << " is scheduled inline.\n";
+        } else if (s.splits()[i].is_fuse()) {
+            user_warning << "It is meaningless to fuse variables "
+                         << s.splits()[i].inner << " and " << s.splits()[i].outer
+                         << " because " << f.name() << " is scheduled inline.\n";
+        } else {
+            user_warning << "It is meaningless to split variable "
+                         << s.splits()[i].old_var << " of function "
+                         << f.name() << " into "
+                         << s.splits()[i].outer << " * "
+                         << s.splits()[i].factor << " + "
+                         << s.splits()[i].inner << " because "
+                         << f.name() << " is scheduled inline.\n";
+        }
+    }
+
+    for (size_t i = 0; i < s.bounds().size(); i++) {
+        if (s.bounds()[i].min.defined()) {
+            user_warning << "It is meaningless to bound dimension "
+                         << s.bounds()[i].var << " of function "
+                         << f.name() << " to be within ["
+                         << s.bounds()[i].min << ", "
+                         << s.bounds()[i].extent << "] because the function is scheduled inline.\n";
+        } else if (s.bounds()[i].modulus.defined()) {
+            user_warning << "It is meaningless to align the bounds of dimension "
+                         << s.bounds()[i].var << " of function "
+                         << f.name() << " to have modulus/remainder ["
+                         << s.bounds()[i].modulus << ", "
+                         << s.bounds()[i].remainder << "] because the function is scheduled inline.\n";
+        }
+    }
+}
+
 class Inliner : public IRMutator {
     using IRMutator::visit;
 
     Function func;
-
-    // Sanity check that this is a reasonable function to inline
-    void check(Function f) {
-
-        internal_assert(f.can_be_inlined()) << "Illegal to inline " << f.name() << "\n";
-
-        const Schedule &s = f.schedule();
-
-        if (!s.store_level().is_inline()) {
-            user_error << "Function " << f.name() << " is scheduled to be computed inline, "
-                       << "but is not scheduled to be stored inline. A storage schedule "
-                       << "is meaningless for functions computed inline.\n";
-        }
-
-        if (s.memoized()) {
-            user_error << "Cannot memoize function "
-                       << f.name() << " because the function is scheduled inline.\n";
-        }
-
-        for (size_t i = 0; i < s.dims().size(); i++) {
-            Dim d = s.dims()[i];
-            if (d.is_parallel()) {
-                user_error << "Cannot parallelize dimension "
-                           << d.var << " of function "
-                           << f.name() << " because the function is scheduled inline.\n";
-            } else if (d.for_type == ForType::Unrolled) {
-                user_error << "Cannot unroll dimension "
-                           << d.var << " of function "
-                           << f.name() << " because the function is scheduled inline.\n";
-            } else if (d.for_type == ForType::Vectorized) {
-                user_error << "Cannot vectorize dimension "
-                           << d.var << " of function "
-                           << f.name() << " because the function is scheduled inline.\n";
-            }
-        }
-
-        for (size_t i = 0; i < s.splits().size(); i++) {
-            if (s.splits()[i].is_rename()) {
-                user_warning << "It is meaningless to rename variable "
-                             << s.splits()[i].old_var << " of function "
-                             << f.name() << " to " << s.splits()[i].outer
-                             << " because " << f.name() << " is scheduled inline.\n";
-            } else if (s.splits()[i].is_fuse()) {
-                user_warning << "It is meaningless to fuse variables "
-                             << s.splits()[i].inner << " and " << s.splits()[i].outer
-                             << " because " << f.name() << " is scheduled inline.\n";
-            } else {
-                user_warning << "It is meaningless to split variable "
-                             << s.splits()[i].old_var << " of function "
-                             << f.name() << " into "
-                             << s.splits()[i].outer << " * "
-                             << s.splits()[i].factor << " + "
-                             << s.splits()[i].inner << " because "
-                             << f.name() << " is scheduled inline.\n";
-            }
-        }
-
-        for (size_t i = 0; i < s.bounds().size(); i++) {
-            if (s.bounds()[i].min.defined()) {
-                user_warning << "It is meaningless to bound dimension "
-                             << s.bounds()[i].var << " of function "
-                             << f.name() << " to be within ["
-                             << s.bounds()[i].min << ", "
-                             << s.bounds()[i].extent << "] because the function is scheduled inline.\n";
-            } else if (s.bounds()[i].modulus.defined()) {
-                user_warning << "It is meaningless to align the bounds of dimension "
-                             << s.bounds()[i].var << " of function "
-                             << f.name() << " to have modulus/remainder ["
-                             << s.bounds()[i].modulus << ", "
-                             << s.bounds()[i].remainder << "] because the function is scheduled inline.\n";
-            }
-        }
-    }
 
     void visit(const Call *op) {
         if (op->name == func.name()) {
@@ -138,7 +135,8 @@ public:
     bool found;
 
     Inliner(Function f) : func(f), found(false) {
-        check(func);
+        internal_assert(f.can_be_inlined()) << "Illegal to inline " << f.name() << "\n";
+        validate_schedule_inlined_function(f);
     }
 
 };

--- a/src/Inline.cpp
+++ b/src/Inline.cpp
@@ -24,6 +24,7 @@ void validate_schedule_inlined_function(Function f) {
                    << "is meaningless for functions computed inline.\n";
     }
 
+    // Inlining is allowed only if there is no specialization.
     user_assert(f.definition().specializations().empty())
         << "Function " << f.name() << " is scheduled inline, so it"
         << " must not have any specializations. Specialize on the"

--- a/src/Inline.cpp
+++ b/src/Inline.cpp
@@ -24,6 +24,11 @@ void validate_schedule_inlined_function(Function f) {
                    << "is meaningless for functions computed inline.\n";
     }
 
+    user_assert(f.definition().specializations().empty())
+        << "Function " << f.name() << " is scheduled inline, so it"
+        << " must not have any specializations. Specialize on the"
+        << " scheduled function instead.\n";
+
     if (s.memoized()) {
         user_error << "Cannot memoize function "
                    << f.name() << " because the function is scheduled inline.\n";

--- a/src/Inline.h
+++ b/src/Inline.h
@@ -18,6 +18,10 @@ Stmt inline_function(Stmt, Function);
 Expr inline_function(Expr, Function);
 // @}
 
+/** Check if the schedule of an inlined function is legal, throwing an error
+ * if it is not. */
+void validate_schedule_inlined_function(Function f);
+
 }
 }
 

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1021,6 +1021,8 @@ bool validate_schedule(Function f, Stmt s, const Target &target, bool is_output,
             << "Func " << f.name() << " is scheduled inline, so it"
             << " must not have any specializations. Specialize on the"
             << " scheduled Func instead.\n";
+        // Check if the schedule of the inlined function is legal.
+        validate_schedule_inlined_function(f);
         return true;
     }
 

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1017,10 +1017,6 @@ bool validate_schedule(Function f, Stmt s, const Target &target, bool is_output,
 
     // Inlining is allowed only if there is no specialization.
     if (store_at.is_inline() && compute_at.is_inline()) {
-        user_assert(f.definition().specializations().empty())
-            << "Func " << f.name() << " is scheduled inline, so it"
-            << " must not have any specializations. Specialize on the"
-            << " scheduled Func instead.\n";
         // Check if the schedule of the inlined function is legal.
         validate_schedule_inlined_function(f);
         return true;

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1015,7 +1015,6 @@ bool validate_schedule(Function f, Stmt s, const Target &target, bool is_output,
         return false;
     }
 
-    // Inlining is allowed only if there is no specialization.
     if (store_at.is_inline() && compute_at.is_inline()) {
         // Check if the schedule of the inlined function is legal.
         validate_schedule_inlined_function(f);

--- a/test/error/cannot_schedule_inlined_stages.cpp
+++ b/test/error/cannot_schedule_inlined_stages.cpp
@@ -1,0 +1,21 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Func f, g;
+    Var x, y;
+
+    f(x) = x;
+    f(x) += x;
+    g(x) = f(x);
+
+    // f is inlined, so this schedule is bad.
+    f.vectorize(x, 4);
+
+    g.realize(10);
+
+    printf("There should have been an error\n");
+    return 0;
+}


### PR DESCRIPTION
The following is used to be allowed in Halide even though `f` is not scheduled to be computed at root or at some consumer's level:
```
f(x) = 10;
f(x) += x;
g(x) = 2 * f(x);
f.parallelize(x);
```

This PR adds a pass that validates all functions scheduled 'inline' can't be parallelized, vectorized, etc. 

