### PR TITLE
Fix incorrect closure data for loads in address_of

### DIFF
--- a/src/Closure.cpp
+++ b/src/Closure.cpp
@@ -38,25 +38,30 @@ void Closure::visit(const For *op) {
     ignore.pop(op->name);
 }
 
+void Closure::found_buffer_ref(const string &name, Type type,
+                               bool read, bool written, Halide::Buffer<> image) {
+    if (!ignore.contains(name)) {
+        debug(3) << "Adding buffer " << name << " to closure\n";
+        Buffer &ref = buffers[name];
+        ref.type = type.element_of(); // TODO: Validate type is the same as existing refs?
+        ref.read = read;
+        ref.write = written;
+
+        // If reading an image/buffer, compute the size.
+        if (image.defined()) {
+            ref.size = image.size_in_bytes();
+            ref.dimensions = image.dimensions();
+        }
+    } else {
+        debug(3) << "Not adding " << name << " to closure\n";
+    }
+}
+
 void Closure::visit(const Call *op) {
     if (op->is_intrinsic(Call::address_of)) {
         const Load *load = op->args[0].as<Load>();
         internal_assert(load);
-        if (!ignore.contains(load->name)) {
-            debug(3) << "Adding buffer " << load->name << " to closure\n";
-            Buffer &ref = buffers[load->name];
-            ref.type = load->type.element_of(); // TODO: Validate type is the same as existing refs?
-            ref.read = address_of_read;
-            ref.write = address_of_written;
-
-            // If reading an image/buffer, compute the size.
-            if (op->image.defined()) {
-                ref.size = op->image.size_in_bytes();
-                ref.dimensions = op->image.dimensions();
-            }
-        } else {
-            debug(3) << "Not adding " << load->name << " to closure\n";
-        }
+        found_buffer_ref(load->name, load->type, address_of_read, address_of_written, op->image);
     } else if (op->is_intrinsic(Call::copy_memory)) {
         internal_assert(op->args.size() == 3);
         bool old_address_of_read = address_of_read;
@@ -79,6 +84,9 @@ void Closure::visit(const Call *op) {
     } else {
         bool old_address_of_written = address_of_written;
         if (!op->is_pure()) {
+            // Assume that non-pure calls using an address_of will
+            // write to the result of address_of. Reads use the
+            // inherited behavior (default true).
             address_of_written = true;
         }
         IRVisitor::visit(op);
@@ -89,35 +97,14 @@ void Closure::visit(const Call *op) {
 void Closure::visit(const Load *op) {
     op->predicate.accept(this);
     op->index.accept(this);
-    if (!ignore.contains(op->name)) {
-        debug(3) << "Adding buffer " << op->name << " to closure\n";
-        Buffer & ref = buffers[op->name];
-        ref.type = op->type.element_of(); // TODO: Validate type is the same as existing refs?
-        ref.read = true;
-
-        // If reading an image/buffer, compute the size.
-        if (op->image.defined()) {
-            ref.size = op->image.size_in_bytes();
-            ref.dimensions = op->image.dimensions();
-        }
-    } else {
-        debug(3) << "Not adding " << op->name << " to closure\n";
-    }
+    found_buffer_ref(op->name, op->type, true, false, op->image);
 }
 
 void Closure::visit(const Store *op) {
     op->predicate.accept(this);
     op->index.accept(this);
     op->value.accept(this);
-    if (!ignore.contains(op->name)) {
-        debug(3) << "Adding buffer " << op->name << " to closure\n";
-        Buffer & ref = buffers[op->name];
-        ref.type = op->value.type().element_of(); // TODO: Validate type is the same as existing refs?
-        // TODO: do we need to set ref.dimensions?
-        ref.write = true;
-    } else {
-        debug(3) << "Not adding " << op->name << " to closure\n";
-    }
+    found_buffer_ref(op->name, op->value.type(), false, true, Halide::Buffer<>());
 }
 
 void Closure::visit(const Allocate *op) {

--- a/src/Closure.h
+++ b/src/Closure.h
@@ -9,6 +9,7 @@
 #include "IR.h"
 #include "IRVisitor.h"
 #include "Scope.h"
+#include "Buffer.h"
 
 namespace Halide {
 namespace Internal {
@@ -60,6 +61,10 @@ public:
 
         Buffer() : dimensions(0), read(false), write(false), size(0) { }
     };
+
+protected:
+    void found_buffer_ref(const std::string &name, Type type,
+                          bool read, bool written, Halide::Buffer<> image);
 
 public:
     Closure() {}

--- a/src/Closure.h
+++ b/src/Closure.h
@@ -23,6 +23,11 @@ class Closure : public IRVisitor {
 protected:
     Scope<int> ignore;
 
+    // Indicates whether the pointer obtained by address_of is read or written.
+    // By default, assume address_of users read but not write.
+    bool address_of_read = true;
+    bool address_of_written = false;
+
     using IRVisitor::visit;
 
     void visit(const Let *op);
@@ -32,6 +37,7 @@ protected:
     void visit(const Store *op);
     void visit(const Allocate *op);
     void visit(const Variable *op);
+    void visit(const Call *op);
 
 public:
     /** Information about a buffer reference from a closure. */


### PR DESCRIPTION
This PR fixes a bug where buffers captured by Closure might be incorrectly marked as read only, when the use of the buffer is in a Load inside an address_of that is used to modify the buffer (e.g. copy_memory).

This corrects a bug that can't actually be triggered by the Halide front end as it exists today, so there is no test for this. The only possible test would be brittle and not cover very much.