### PR TITLE
Affordances to upgrade code in anticipation of #1899

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -163,7 +163,7 @@ void Func::define_extern(const std::string &function_name,
                          const std::vector<Type> &types,
                          int dimensionality,
                          NameMangling mangling,
-                         bool uses_old_buffer_t) {
+                         bool /* uses_old_buffer_t */) {
     func.define_extern(function_name, args, types, dimensionality, mangling);
 }
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -162,7 +162,8 @@ void Func::define_extern(const std::string &function_name,
                          const std::vector<ExternFuncArgument> &args,
                          const std::vector<Type> &types,
                          int dimensionality,
-                         NameMangling mangling) {
+                         NameMangling mangling,
+                         bool uses_old_buffer_t) {
     func.define_extern(function_name, args, types, dimensionality, mangling);
 }
 

--- a/src/Func.h
+++ b/src/Func.h
@@ -921,15 +921,18 @@ public:
                               const std::vector<ExternFuncArgument> &params,
                               Type t,
                               int dimensionality,
-                              NameMangling mangling = NameMangling::Default) {
-        define_extern(function_name, params, std::vector<Type>{t}, dimensionality, mangling);
+                              NameMangling mangling = NameMangling::Default,
+                              bool uses_old_buffer_t = false /* currently does nothing. See PR #1899. */) {
+        define_extern(function_name, params, std::vector<Type>{t},
+                      dimensionality, mangling, uses_old_buffer_t);
     }
 
     EXPORT void define_extern(const std::string &function_name,
                               const std::vector<ExternFuncArgument> &params,
                               const std::vector<Type> &types,
                               int dimensionality,
-                              NameMangling mangling = NameMangling::Default);
+                              NameMangling mangling = NameMangling::Default,
+                              bool uses_old_buffer_t = false /* currently does nothing. See PR #1899. */);
     // @}
 
     /** Get the types of the outputs of this Func. */

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -856,6 +856,11 @@ public:
         return &buf;
     }
 
+    /** Affordance for upgrading code. See PR #1899 */
+    buffer_t make_legacy_buffer_t() const {
+        return buf;
+    }
+
     /** Return a typed reference to this Buffer. Useful for converting
      * a reference to a Buffer<void> to a reference to, for example, a
      * Buffer<const uint8_t>. Does a runtime assert if the source

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -989,6 +989,7 @@ typedef struct buffer_t {
 
 #endif
 
+// See PR #1899
 typedef buffer_t halide_buffer_t;
 
 /** halide_scalar_value_t is a simple union able to represent all the well-known

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -989,6 +989,8 @@ typedef struct buffer_t {
 
 #endif
 
+typedef buffer_t halide_buffer_t;
+
 /** halide_scalar_value_t is a simple union able to represent all the well-known
  * scalar values in a filter argument. Note that it isn't tagged with a type;
  * you must ensure you know the proper type before accessing. Most user


### PR DESCRIPTION
Adds a useless extra flag to define_extern, and adds halide_buffer_t as a typedef of buffer_t.

If we land #1899, we should land this first so that it's possible to syntactically update some of the user code before the body of the change lands. I'm assuming that companies that use Halide have some process where they pick a Halide revision to pull into their source tree. The intended procedure is to merge in Halide just after this PR, then update internal user code as much as possible, using these features, and also by using Halide::Runtime::Buffer instead of buffer_t wherever possible, then merge in Halide just after PR #1899.

 The idea is that for many users this will decouple updating user code from updating Halide, so that the whole thing can be staged per user project instead of one atomic change.