### PR TITLE
Make gpu_only test actually run on CUDA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,10 +162,10 @@ endif
 
 ifneq ($(WITH_PTX), )
 ifneq (,$(findstring ptx,$(HL_TARGET)))
-TEST_PTX = 1
+TEST_CUDA = 1
 endif
 ifneq (,$(findstring cuda,$(HL_TARGET)))
-TEST_PTX = 1
+TEST_CUDA = 1
 endif
 endif
 
@@ -182,7 +182,7 @@ endif
 endif
 
 ifeq ($(UNAME), Linux)
-ifneq ($(TEST_PTX), )
+ifneq ($(TEST_CUDA), )
 CUDA_LD_FLAGS ?= -L/usr/lib/nvidia-current -lcuda
 endif
 ifneq ($(TEST_OPENCL), )
@@ -194,7 +194,7 @@ endif
 
 ifeq ($(UNAME), Darwin)
 # Someone with an osx box with cuda installed please fix the line below
-ifneq ($(TEST_PTX), )
+ifneq ($(TEST_CUDA), )
 CUDA_LD_FLAGS ?= -L/usr/local/cuda/lib -lcuda
 endif
 ifneq ($(TEST_OPENCL), )
@@ -215,8 +215,8 @@ ifneq ($(TEST_METAL), )
 TEST_CXX_FLAGS += -DTEST_METAL
 endif
 
-ifneq ($(TEST_PTX), )
-TEST_CXX_FLAGS += -DTEST_PTX
+ifneq ($(TEST_CUDA), )
+TEST_CXX_FLAGS += -DTEST_CUDA
 endif
 
 # Compiling the tutorials requires libpng

--- a/test/generator/acquire_release_aottest.cpp
+++ b/test/generator/acquire_release_aottest.cpp
@@ -116,7 +116,7 @@ extern "C" int halide_release_cl_context(void *user_context) {
     printf("Releasing CL context %p\n", cl_ctx);
     return 0;
 }
-#elif defined(TEST_PTX)
+#elif defined(TEST_CUDA)
 // Implement CUDA custom context.
 #include <cuda.h>
 


### PR DESCRIPTION
If "cuda" is in the target, we want to run the gpu generator tests. One
of the two tests for which this applies uses the #define TEST_CUDA, and
the other uses TEST_PTX. The Makefile only defines TEST_PTX.

I just switched everything to TEST_CUDA