### PR TITLE
The python bindings shouldn't include internal libHalide headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1230,7 +1230,7 @@ test_apps: $(LIB_DIR)/libHalide.a $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_D
 	cd apps/HelloMatlab; HALIDE_PATH=$(CURDIR) HALIDE_CXX=$(CXX) ./run_blur.sh
 
 .PHONY: test_python
-test_python: $(LIB_DIR)/libHalide.a
+test_python: $(LIB_DIR)/libHalide.a $(INCLUDE_DIR)/Halide.h
 	mkdir -p python_bindings
 	make -C python_bindings -f $(ROOT_DIR)/python_bindings/Makefile test
 

--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -5,14 +5,14 @@ ROOT_DIR = $(strip $(shell dirname $(THIS_MAKEFILE)))
 
 ifeq ($(UNAME), Linux)
 # Disable some warnings that are pervasive in Boost
-CCFLAGS=$(shell python3-config --cflags) -std=c++11 -fPIC -Wno-unused-local-typedef -Wno-shorten-64-to-32
+CCFLAGS=$(shell python3-config --cflags) -I $(ROOT_DIR)/../include -std=c++11 -fPIC -Wno-unused-local-typedef -Wno-shorten-64-to-32
 LDFLAGS=$(shell python3-config --ldflags) -lboost_python-py34 -lz
 endif
 
 ifeq ($(UNAME), Darwin)
 # The /opt includes are in case this is a macports install of python and boost python
 # Disable some warnings that are pervasive in Boost
-CCFLAGS=$(shell python-config --cflags) -I /opt/local/include -std=c++11 -Wno-unused-local-typedef -Wno-shorten-64-to-32
+CCFLAGS=$(shell python-config --cflags) -I $(ROOT_DIR)/../include -I /opt/local/include -std=c++11 -Wno-unused-local-typedef -Wno-shorten-64-to-32
 LDFLAGS=$(shell python-config --ldflags) -L /opt/local/lib -lboost_python3-mt -lz
 endif
 
@@ -22,8 +22,6 @@ PY_SRCS=$(shell ls $(ROOT_DIR)/python/*.cpp)
 PY_OBJS=$(PY_SRCS:$(ROOT_DIR)/python/%.cpp=build/py_%.o)
 NUMPY_SRCS=$(shell ls $(ROOT_DIR)/numpy/*.cpp)
 NUMPY_OBJS=$(NUMPY_SRCS:$(ROOT_DIR)/numpy/%.cpp=build/numpy_%.o)
-
-
 
 build/py_%.o: $(ROOT_DIR)/python/%.cpp
 	mkdir -p build
@@ -35,7 +33,7 @@ build/numpy_%.o: $(ROOT_DIR)/numpy/%.cpp
 
 build/halide.so: $(PY_SRCS) $(PY_OBJS) $(NUMPY_SRCS) $(NUMPY_OBJS)
 	mkdir -p build
-	$(CXX) $(PY_OBJS) $(NUMPY_OBJS) $(LDFLAGS) ../lib/libHalide.a -shared -o $@
+	$(CXX) $(PY_OBJS) $(NUMPY_OBJS) $(LDFLAGS) $(ROOT_DIR)/../lib/libHalide.a -shared -o $@
 
 clean:
 	rm -rf build

--- a/python_bindings/python/Argument.cpp
+++ b/python_bindings/python/Argument.cpp
@@ -3,7 +3,7 @@
 // to avoid compiler confusion, python.hpp must be include before Halide headers
 #include <boost/python.hpp>
 
-#include "../../src/Argument.h"
+#include "Halide.h"
 
 #include <string>
 

--- a/python_bindings/python/BoundaryConditions.cpp
+++ b/python_bindings/python/BoundaryConditions.cpp
@@ -4,10 +4,7 @@
 #include <boost/python.hpp>
 #include <boost/python/stl_iterator.hpp>
 
-#include "../../src/BoundaryConditions.h"
-#include "../../src/Func.h"
-#include "../../src/ImageParam.h"
-#include "../../src/Lambda.h"  // needed by BoundaryConditions.h
+#include "Halide.h"
 
 #include <algorithm>
 #include <string>

--- a/python_bindings/python/Error.cpp
+++ b/python_bindings/python/Error.cpp
@@ -3,7 +3,7 @@
 // to avoid compiler confusion, python.hpp must be include before Halide headers
 #include <boost/python.hpp>
 
-#include "../../src/Error.h"
+#include "Halide.h"
 
 #include <string>
 

--- a/python_bindings/python/Expr.cpp
+++ b/python_bindings/python/Expr.cpp
@@ -5,9 +5,7 @@
 
 #include "add_operators.h"
 
-#include "../../src/Expr.h"
-#include "../../src/IROperator.h"
-#include "../../src/Var.h"
+#include "Halide.h"
 
 #include "Type.h"
 

--- a/python_bindings/python/Func.cpp
+++ b/python_bindings/python/Func.cpp
@@ -4,7 +4,7 @@
 #include "add_operators.h"
 #include <boost/python.hpp>
 
-#include "../../src/Func.h"
+#include "Halide.h"
 #include "Image.h"
 
 #include <boost/format.hpp>

--- a/python_bindings/python/Func_Ref.cpp
+++ b/python_bindings/python/Func_Ref.cpp
@@ -4,8 +4,7 @@
 #include "add_operators.h"
 #include <boost/python.hpp>
 
-#include "../../src/Func.h"
-#include "../../src/Tuple.h"
+#include "Halide.h"
 
 #include <string>
 #include <vector>

--- a/python_bindings/python/Func_Stage.cpp
+++ b/python_bindings/python/Func_Stage.cpp
@@ -4,7 +4,7 @@
 #include <boost/python.hpp>
 //#include "add_operators.h"
 
-#include "../../src/Func.h"
+#include "Halide.h"
 #include "Func.h"
 #include "Func_gpu.h"
 

--- a/python_bindings/python/Func_VarOrRVar.cpp
+++ b/python_bindings/python/Func_VarOrRVar.cpp
@@ -4,7 +4,7 @@
 #include <boost/python.hpp>
 //#include "add_operators.h"
 
-#include "../../src/Func.h"
+#include "Halide.h"
 
 #include <string>
 #include <vector>

--- a/python_bindings/python/Func_gpu.cpp
+++ b/python_bindings/python/Func_gpu.cpp
@@ -3,7 +3,7 @@
 // to avoid compiler confusion, python.hpp must be include before Halide headers
 #include <boost/python.hpp>
 
-#include "../../src/Func.h"
+#include "Halide.h"
 
 namespace h = Halide;
 namespace p = boost::python;

--- a/python_bindings/python/Function.cpp
+++ b/python_bindings/python/Function.cpp
@@ -3,7 +3,7 @@
 // to avoid compiler confusion, python.hpp must be include before Halide headers
 #include <boost/python.hpp>
 
-#include "../../src/Func.h"  // includes everything needed here
+#include "Halide.h"
 
 #include <vector>
 

--- a/python_bindings/python/Halide.h
+++ b/python_bindings/python/Halide.h
@@ -1,2 +1,0 @@
-
-// nothing to define here

--- a/python_bindings/python/IROperator.cpp
+++ b/python_bindings/python/IROperator.cpp
@@ -3,7 +3,7 @@
 // to avoid compiler confusion, python.hpp must be include before Halide headers
 #include <boost/python.hpp>
 
-#include "../../src/IROperator.h"
+#include "Halide.h"
 
 #include <string>
 

--- a/python_bindings/python/InlineReductions.cpp
+++ b/python_bindings/python/InlineReductions.cpp
@@ -3,7 +3,7 @@
 // to avoid compiler confusion, python.hpp must be include before Halide headers
 #include <boost/python.hpp>
 
-#include "../../src/InlineReductions.h"
+#include "Halide.h"
 
 #include "Expr.h"
 

--- a/python_bindings/python/Lambda.cpp
+++ b/python_bindings/python/Lambda.cpp
@@ -3,7 +3,7 @@
 // to avoid compiler confusion, python.hpp must be include before Halide headers
 #include <boost/python.hpp>
 
-#include "../../src/Lambda.h"
+#include "Halide.h"
 
 namespace h = Halide;
 

--- a/python_bindings/python/Param.cpp
+++ b/python_bindings/python/Param.cpp
@@ -6,10 +6,7 @@
 #include <boost/mpl/list.hpp>
 #include <boost/python.hpp>
 
-#include "../../src/IROperator.h"  // enables Param + Expr operations (which include is it ?)
-#include "../../src/ImageParam.h"
-#include "../../src/OutputImageParam.h"
-#include "../../src/Param.h"
+#include "Halide.h"
 #include "Type.h"
 
 #include <boost/format.hpp>

--- a/python_bindings/python/RDom.cpp
+++ b/python_bindings/python/RDom.cpp
@@ -4,9 +4,7 @@
 #include "add_operators.h"
 #include <boost/python.hpp>
 
-#include "../../src/IROperator.h"  // for operations with RVar
-#include "../../src/ImageParam.h"
-#include "../../src/RDom.h"
+#include "Halide.h"
 
 #include <string>
 

--- a/python_bindings/python/Target.cpp
+++ b/python_bindings/python/Target.cpp
@@ -3,7 +3,7 @@
 // to avoid compiler confusion, python.hpp must be include before Halide headers
 #include <boost/python.hpp>
 
-#include "../../src/Target.h"
+#include "Halide.h"
 
 #include "Expr.h"
 

--- a/python_bindings/python/Type.cpp
+++ b/python_bindings/python/Type.cpp
@@ -4,8 +4,7 @@
 #include <boost/format.hpp>
 #include <boost/python.hpp>
 
-#include "../../src/Expr.h"
-#include "../../src/Type.h"
+#include "Halide.h"
 
 #include <string>
 #include <vector>

--- a/python_bindings/python/Var.cpp
+++ b/python_bindings/python/Var.cpp
@@ -4,8 +4,7 @@
 #include "add_operators.h"
 #include <boost/python.hpp>
 
-#include "../../src/IROperator.h"
-#include "../../src/Var.h"
+#include "Halide.h"
 
 #include <boost/format.hpp>
 #include <string>


### PR DESCRIPTION
You should be able to compile them using an installed libHalide.

Occurred to me while getting #1904 to work on my system.