### PR TITLE
halide_memoization_cache_cleanup() needs to null the MRU and LRU globals

### DIFF
--- a/src/runtime/cache.cpp
+++ b/src/runtime/cache.cpp
@@ -538,6 +538,8 @@ WEAK void halide_memoization_cache_cleanup() {
         }
     }
     current_cache_size = 0;
+    most_recently_used = NULL;
+    least_recently_used = NULL;
     halide_mutex_destroy(&memoization_lock);
 }
 


### PR DESCRIPTION
Otherwise they can point to dangling memory and fun ensues