### PR TITLE
Prefetch IR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -573,6 +573,7 @@ RUNTIME_CPP_COMPONENTS = \
   posix_tempfile \
   posix_threads \
   powerpc_cpu_features \
+  prefetch \
   profiler \
   profiler_inlined \
   qurt_allocator \

--- a/apps/HelloHexagon/pipeline.cpp
+++ b/apps/HelloHexagon/pipeline.cpp
@@ -60,7 +60,7 @@ public:
                 Var yo("yo");
                 Func(blur).compute_root()
                     .hexagon()
-                    .prefetch(y, 2)
+                    .prefetch(input, y, 2)
                     .split(y, yo, y, 128).parallel(yo)
                     .vectorize(x, vector_size * 2, TailStrategy::RoundUp);
                 blur_y

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -334,7 +334,7 @@ Func CameraPipe::build() {
         vec = 64;
     }
     denoised.compute_at(processed, yi).store_at(processed, yo)
-        .prefetch(y, 2)
+        .prefetch(input, y, 2)
         .fold_storage(y, 8)
         .tile(x, y, x, y, xi, yi, 2*vec, 2)
         .vectorize(xi)

--- a/apps/hexagon_matmul/pipeline.cpp
+++ b/apps/hexagon_matmul/pipeline.cpp
@@ -80,8 +80,8 @@ public:
                     .unroll(y);
 
                 AB.update(0)
-                    .prefetch(A, rk, 2)
                     .reorder(x, y, rk)
+                    .prefetch(A, rk, 2)
                     .vectorize(x)
                     .unroll(y)
                     .unroll(rk, k_unroll_factor);

--- a/apps/hexagon_matmul/pipeline.cpp
+++ b/apps/hexagon_matmul/pipeline.cpp
@@ -80,6 +80,7 @@ public:
                     .unroll(y);
 
                 AB.update(0)
+                    .prefetch(A, rk, 2)
                     .reorder(x, y, rk)
                     .vectorize(x)
                     .unroll(y)

--- a/apps/hexagon_matmul/pipeline.cpp
+++ b/apps/hexagon_matmul/pipeline.cpp
@@ -69,7 +69,8 @@ public:
                 Func(output).compute_root()
                     .hexagon()
                     .tile(x, y, xo, yo, x, y, vector_size_u8, tile_rows, TailStrategy::RoundUp)
-                    .reorder(yo, xo)
+                    .reorder(x, y, yo, xo)
+                    .prefetch(A, yo, 1)
                     .vectorize(x)
                     .unroll(y)
                     .parallel(xo);
@@ -79,14 +80,11 @@ public:
                     .vectorize(x)
                     .unroll(y);
 
-                RVar rko("rko"), rki("rki");
                 AB.update(0)
                     .reorder(x, y, rk)
-                    .split(rk, rko, rki, 16, TailStrategy::GuardWithIf)
-                    .prefetch(A, rko, 1)
                     .vectorize(x)
                     .unroll(y)
-                    .unroll(rki, k_unroll_factor);
+                    .unroll(rk, k_unroll_factor);
 
                 // Lift the swizzling out of the inner loop.
                 B_swizzled.compute_at(output, xo)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,7 @@ set(RUNTIME_CPP
   posix_tempfile
   posix_threads
   powerpc_cpu_features
+  prefetch
   profiler
   profiler_inlined
   qurt_allocator

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -172,6 +172,7 @@ protected:
     void visit(const IfThenElse *);
     void visit(const Evaluate *);
     void visit(const Shuffle *);
+    void visit(const Prefetch *);
 
     void visit_binop(Type t, Expr a, Expr b, const char *op);
 };

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1506,9 +1506,9 @@ void CodeGen_Hexagon::visit(const Call *op) {
 
         llvm::Function *prefetch_fn = nullptr;
         if (op->args.size() == 3) { // 1D prefetch: {base address, extent0, stride0}
-            prefetch_fn = module->getFunction("halide_prefetch");
+            prefetch_fn = module->getFunction("_halide_prefetch");
         } else { // 2D prefetch: {base address, extent0, stride0, extent1, stride1}
-            prefetch_fn = module->getFunction("halide_prefetch_2d");
+            prefetch_fn = module->getFunction("_halide_prefetch_2d");
             args.push_back(codegen(op->args[3]));
             Expr stride_1_bytes = op->args[4] * op->type.bytes();
             args.push_back(codegen(stride_1_bytes));

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1495,13 +1495,26 @@ void CodeGen_Hexagon::visit(const Call *op) {
         return;
     }
 
-    if (op->is_intrinsic(Call::prefetch) || op->is_intrinsic(Call::prefetch_2d)) {
-        llvm::Function *prefetch_fn = module->getFunction("halide_" + op->name);
-        internal_assert(prefetch_fn);
+    if (op->is_intrinsic(Call::prefetch)) {
+        internal_assert((op->args.size() == 3) || (op->args.size() == 5))
+            << "Hexagon only supports 1D or 2D prefetch\n";
+
         vector<llvm::Value *> args;
-        for (Expr i : op->args) {
-            args.push_back(codegen(i));
+        args.push_back(codegen(op->args[0]));
+        Expr extent_0_bytes = op->args[1] * op->args[2] * op->type.bytes();
+        args.push_back(codegen(extent_0_bytes));
+
+        llvm::Function *prefetch_fn = nullptr;
+        if (op->args.size() == 3) { // 1D prefetch: {base address, extent0, stride0}
+            prefetch_fn = module->getFunction("halide_prefetch");
+        } else { // 2D prefetch: {base address, extent0, stride0, extent1, stride1}
+            prefetch_fn = module->getFunction("halide_prefetch_2d");
+            args.push_back(codegen(op->args[3]));
+            Expr stride_1_bytes = op->args[4] * op->type.bytes();
+            args.push_back(codegen(stride_1_bytes));
         }
+        internal_assert(prefetch_fn);
+
         // The first argument is a pointer, which has type i8*. We
         // need to cast the argument, which might be a pointer to a
         // different type.

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2705,10 +2705,23 @@ void CodeGen_LLVM::visit(const Call *op) {
 
         llvm::CallInst *call = builder->CreateCall(base_fn->getFunctionType(), phi, call_args);
         value = call;
-    } else if (op->is_intrinsic(Call::prefetch) ||
-               op->is_intrinsic(Call::prefetch_2d)) {
-        // Convert to a no-op since prefetch was not supported by target
-        value = ConstantInt::get(i32_t, 0);
+    } else if (op->is_intrinsic(Call::prefetch)) {
+        user_assert((op->args.size() == 3) && is_one(op->args[1]))
+            << "Only prefetch of 1 cache line is supported.\n";
+
+        llvm::Function *prefetch_fn = module->getFunction("halide_prefetch");
+        internal_assert(prefetch_fn);
+
+        vector<llvm::Value *> args;
+        args.push_back(codegen(op->args[0]));
+        // The first argument is a pointer, which has type i8*. We
+        // need to cast the argument, which might be a pointer to a
+        // different type.
+        llvm::Type *ptr_type = prefetch_fn->getFunctionType()->params()[0];
+        args[0] = builder->CreateBitCast(args[0], ptr_type);
+
+        value = builder->CreateCall(prefetch_fn, args);
+
     } else if (op->is_intrinsic(Call::signed_integer_overflow)) {
         user_error << "Signed integer overflow occurred during constant-folding. Signed"
             " integer overflow for int32 and int64 is undefined behavior in"
@@ -2879,6 +2892,10 @@ void CodeGen_LLVM::visit(const Call *op) {
             }
         }
     }
+}
+
+void CodeGen_LLVM::visit(const Prefetch *op) {
+    internal_error << "Prefetch encountered during codegen\n";
 }
 
 void CodeGen_LLVM::visit(const Let *op) {

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2709,7 +2709,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         user_assert((op->args.size() == 3) && is_one(op->args[1]))
             << "Only prefetch of 1 cache line is supported.\n";
 
-        llvm::Function *prefetch_fn = module->getFunction("halide_prefetch");
+        llvm::Function *prefetch_fn = module->getFunction("_halide_prefetch");
         internal_assert(prefetch_fn);
 
         vector<llvm::Value *> args;

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -368,6 +368,7 @@ protected:
     virtual void visit(const IfThenElse *);
     virtual void visit(const Evaluate *);
     virtual void visit(const Shuffle *);
+    virtual void visit(const Prefetch *);
     // @}
 
     /** Generate code for an allocate node. It has no default

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -63,6 +63,7 @@ enum class IRNodeType {
     IfThenElse,
     Evaluate,
     Shuffle,
+    Prefetch,
 };
 
 /** The abstract base classes for a node in the Halide IR. */

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -30,6 +30,7 @@
 #include "Solve.h"
 #include "Associativity.h"
 #include "ApplySplit.h"
+#include "ImageParam.h"
 
 namespace Halide {
 
@@ -1710,10 +1711,15 @@ Stage &Stage::hexagon(VarOrRVar x) {
     return *this;
 }
 
-Stage &Stage::prefetch(VarOrRVar var, Expr offset) {
-    Prefetch prefetch = {var.name(), offset};
+Stage &Stage::prefetch(const Func &f, VarOrRVar var, Expr offset, PrefetchBoundStrategy strategy) {
+    PrefetchDirective prefetch = {f.name(), var.name(), offset, strategy, Parameter()};
     definition.schedule().prefetches().push_back(prefetch);
+    return *this;
+}
 
+Stage &Stage::prefetch(const Internal::Parameter &param, VarOrRVar var, Expr offset, PrefetchBoundStrategy strategy) {
+    PrefetchDirective prefetch = {param.name(), var.name(), offset, strategy, param};
+    definition.schedule().prefetches().push_back(prefetch);
     return *this;
 }
 
@@ -2183,9 +2189,15 @@ Func &Func::hexagon(VarOrRVar x) {
     return *this;
 }
 
-Func &Func::prefetch(VarOrRVar var, Expr offset) {
+Func &Func::prefetch(const Func &f, VarOrRVar var, Expr offset, PrefetchBoundStrategy strategy) {
     invalidate_cache();
-    Stage(func.definition(), name(), args(), func.schedule().storage_dims()).prefetch(var, offset);
+    Stage(func.definition(), name(), args(), func.schedule().storage_dims()).prefetch(f, var, offset);
+    return *this;
+}
+
+Func &Func::prefetch(const Internal::Parameter &param, VarOrRVar var, Expr offset, PrefetchBoundStrategy strategy) {
+    invalidate_cache();
+    Stage(func.definition(), name(), args(), func.schedule().storage_dims()).prefetch(param, var, offset);
     return *this;
 }
 

--- a/src/Func.h
+++ b/src/Func.h
@@ -41,6 +41,8 @@ struct VarOrRVar {
     bool is_rvar;
 };
 
+class ImageParam;
+
 namespace Internal {
 struct Split;
 struct StorageDim;
@@ -279,7 +281,15 @@ public:
     EXPORT Stage &allow_race_conditions();
 
     EXPORT Stage &hexagon(VarOrRVar x = Var::outermost());
-    EXPORT Stage &prefetch(VarOrRVar var, Expr offset = 1);
+    EXPORT Stage &prefetch(const Func &f, VarOrRVar var, Expr offset = 1,
+                           PrefetchBoundStrategy strategy = PrefetchBoundStrategy::GuardWithIf);
+    EXPORT Stage &prefetch(const Internal::Parameter &param, VarOrRVar var, Expr offset = 1,
+                           PrefetchBoundStrategy strategy = PrefetchBoundStrategy::GuardWithIf);
+    template<typename T>
+    Stage &prefetch(const T &image, VarOrRVar var, Expr offset = 1,
+                    PrefetchBoundStrategy strategy = PrefetchBoundStrategy::GuardWithIf) {
+        return prefetch(image.parameter(), var, offset, strategy);
+    }
     // @}
 };
 
@@ -1527,11 +1537,47 @@ public:
      * Hexagon, that loop is executed on a Hexagon DSP. */
     EXPORT Func &hexagon(VarOrRVar x = Var::outermost());
 
-    /** Prefetch data read by a subsequent loop iteration, at an
-     * optionally specified iteration offset. This is currently only
-     * implemented on Hexagon, prefetch directives are ignored on
-     * other targets. */
-    EXPORT Func &prefetch(VarOrRVar var, Expr offset = 1);
+    /** Prefetch data written to or read from a Func or an ImageParam by a
+     * subsequent loop iteration, at an optionally specified iteration offset.
+     * 'var' specifies at which loop level the prefetch calls should be inserted.
+     * The final argument specifies how prefetch of region outside bounds
+     * should be handled.
+     *
+     * For example, consider this pipeline:
+     \code
+     Func f, g;
+     Var x, y;
+     f(x, y) = x + y;
+     g(x, y) = 2 * f(x, y);
+     \endcode
+     *
+     * The following schedule:
+     \code
+     f.compute_root();
+     g.prefetch(f, x, 2);
+     \endcode
+     *
+     * will inject prefetch call at the innermost loop of 'g' and generate
+     * the following loop nest:
+     * for y = ...
+     *   for x = ...
+     *     f(x, y) = x + y
+     * for y = ..
+     *   for x = ...
+     *     prefetch(f, extent, stride);
+     *     g(x, y) = 2 * f(x, y)
+     */
+    // @{
+    EXPORT Func &prefetch(const Func &f, VarOrRVar var, Expr offset = 1,
+                          PrefetchBoundStrategy strategy = PrefetchBoundStrategy::GuardWithIf);
+    EXPORT Func &prefetch(const Internal::Parameter &param, VarOrRVar var, Expr offset = 1,
+                          PrefetchBoundStrategy strategy = PrefetchBoundStrategy::GuardWithIf);
+    template<typename T>
+    Func &prefetch(const T &image, VarOrRVar var, Expr offset = 1,
+                   PrefetchBoundStrategy strategy = PrefetchBoundStrategy::GuardWithIf) {
+        return prefetch(image.parameter(), var, offset, strategy);
+    }
+    // @}
 
     /** Specify how the storage for the function is laid out. These
      * calls let you specify the nesting order of the dimensions. For

--- a/src/Func.h
+++ b/src/Func.h
@@ -1564,7 +1564,7 @@ public:
      *     f(x, y) = x + y
      * for y = ..
      *   for x = ...
-     *     prefetch(&f[x + 2], 1, 16);
+     *     prefetch(&f[x + 2, y], 1, 16);
      *     g(x, y) = 2 * f(x, y)
      */
     // @{

--- a/src/Func.h
+++ b/src/Func.h
@@ -1554,7 +1554,7 @@ public:
      * The following schedule:
      \code
      f.compute_root();
-     g.prefetch(f, x, 2);
+     g.prefetch(f, x, 2, PrefetchBoundStrategy::NonFaulting);
      \endcode
      *
      * will inject prefetch call at the innermost loop of 'g' and generate
@@ -1564,7 +1564,7 @@ public:
      *     f(x, y) = x + y
      * for y = ..
      *   for x = ...
-     *     prefetch(f, extent, stride);
+     *     prefetch(&f[x + 2], 1, 16);
      *     g(x, y) = 2 * f(x, y)
      */
     // @{

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -329,7 +329,7 @@ public:
     const std::string name;
 
     // overload the set() function to call the right virtual method based on type.
-    // This allows us to attempt to set a GeneratorParam via a 
+    // This allows us to attempt to set a GeneratorParam via a
     // plain C++ type, even if we don't know the specific templated
     // subclass. Attempting to set the wrong type will assert.
     // Notice that there is no typed setter for Enums, for obvious reasons;
@@ -460,8 +460,8 @@ private:
     template <typename T2, typename std::enable_if<std::is_convertible<T, T2>::value>::type * = nullptr>
     HALIDE_ALWAYS_INLINE void typed_setter_impl(const T2 &t2, const char * msg) {
         // Arithmetic types must roundtrip losslessly.
-        if (!std::is_same<T, T2>::value && 
-            std::is_arithmetic<T>::value && 
+        if (!std::is_same<T, T2>::value &&
+            std::is_arithmetic<T>::value &&
             std::is_arithmetic<T2>::value) {
             const T t = t2;
             const T2 t2a = t;
@@ -1342,6 +1342,9 @@ private:
 protected:
     using TBase = typename Super::TBase;
 
+    friend class ::Halide::Func;
+    friend class ::Halide::Stage;
+
     bool allow_synthetic_generator_params() const override {
         return !T::has_static_halide_type();
     }
@@ -1910,7 +1913,7 @@ public:
     GeneratorOutput_Func<T> &operator=(const Func &f) {
         this->check_value_writable();
 
-        // Don't bother verifying the Func type, dimensions, etc., here: 
+        // Don't bother verifying the Func type, dimensions, etc., here:
         // That's done later, when we produce the pipeline.
         get_assignable_func_ref(0) = f;
         return *this;
@@ -2257,8 +2260,8 @@ public:
     void set_inputs(const Args &...args) {
         // set_inputs_vector() checks this too, but checking it here allows build_inputs() to avoid out-of-range checks.
         ParamInfo &pi = param_info();
-        user_assert(sizeof...(args) == pi.filter_inputs.size()) 
-                << "Expected exactly " << pi.filter_inputs.size() 
+        user_assert(sizeof...(args) == pi.filter_inputs.size())
+                << "Expected exactly " << pi.filter_inputs.size()
                 << " inputs but got " << sizeof...(args) << "\n";
         set_inputs_vector(build_inputs(std::forward_as_tuple<const Args &...>(args...), make_index_sequence<sizeof...(Args)>{}));
     }
@@ -2364,9 +2367,9 @@ private:
     };
 
     const size_t size;
-    // Lazily-allocated-and-inited struct with info about our various Params. 
+    // Lazily-allocated-and-inited struct with info about our various Params.
     // Do not access directly: use the param_info() getter to lazy-init.
-    std::unique_ptr<ParamInfo> param_info_ptr; 
+    std::unique_ptr<ParamInfo> param_info_ptr;
 
     std::shared_ptr<Internal::ValueTracker> value_tracker;
     bool inputs_set{false};
@@ -2540,7 +2543,7 @@ private:
     }
 
     template<typename... Args, size_t... Indices>
-    std::vector<std::vector<StubInput>> build_inputs(const std::tuple<const Args &...>& t, index_sequence<Indices...>) { 
+    std::vector<std::vector<StubInput>> build_inputs(const std::tuple<const Args &...>& t, index_sequence<Indices...>) {
         return {build_input(Indices, std::get<Indices>(t))...};
     }
 
@@ -2557,7 +2560,7 @@ public:
     virtual ~GeneratorFactory() {}
     // Note that this method must never return null:
     // if it cannot return a valid Generator, it should assert-fail.
-    virtual std::unique_ptr<GeneratorBase> create(const GeneratorContext &context, 
+    virtual std::unique_ptr<GeneratorBase> create(const GeneratorContext &context,
                                                   const std::map<std::string, std::string> &params) const = 0;
 };
 
@@ -2609,7 +2612,7 @@ private:
 
 }  // namespace Internal
 
-template <class T> 
+template <class T>
 class Generator : public Internal::GeneratorBase {
 protected:
     Generator() :
@@ -2726,7 +2729,7 @@ private:
     void operator=(Generator&& that) = delete;
 };
 
-template <class GeneratorClass> 
+template <class GeneratorClass>
 class RegisterGenerator {
 public:
     RegisterGenerator(const char* generator_name) {

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -459,6 +459,23 @@ Stmt Realize::make(const std::string &name, const std::vector<Type> &types, cons
     return node;
 }
 
+Stmt Prefetch::make(const std::string &name, const std::vector<Type> &types, const Region &bounds, Parameter param) {
+    for (size_t i = 0; i < bounds.size(); i++) {
+        internal_assert(bounds[i].min.defined()) << "Prefetch of undefined\n";
+        internal_assert(bounds[i].extent.defined()) << "Prefetch of undefined\n";
+        internal_assert(bounds[i].min.type().is_scalar()) << "Prefetch of vector size\n";
+        internal_assert(bounds[i].extent.type().is_scalar()) << "Prefetch of vector size\n";
+    }
+    internal_assert(!types.empty()) << "Prefetch has empty type\n";
+
+    Prefetch *node = new Prefetch;
+    node->name = name;
+    node->types = types;
+    node->bounds = bounds;
+    node->param = param;
+    return node;
+}
+
 Stmt Block::make(const Stmt &first, const Stmt &rest) {
     internal_assert(first.defined()) << "Block of undefined\n";
     internal_assert(rest.defined()) << "Block of undefined\n";
@@ -752,6 +769,7 @@ template<> void StmtNode<Realize>::accept(IRVisitor *v) const { v->visit((const 
 template<> void StmtNode<Block>::accept(IRVisitor *v) const { v->visit((const Block *)this); }
 template<> void StmtNode<IfThenElse>::accept(IRVisitor *v) const { v->visit((const IfThenElse *)this); }
 template<> void StmtNode<Evaluate>::accept(IRVisitor *v) const { v->visit((const Evaluate *)this); }
+template<> void StmtNode<Prefetch>::accept(IRVisitor *v) const { v->visit((const Prefetch *)this); }
 
 Call::ConstString Call::debug_to_file = "debug_to_file";
 Call::ConstString Call::reinterpret = "reinterpret";
@@ -789,7 +807,6 @@ Call::ConstString Call::div_round_to_zero = "div_round_to_zero";
 Call::ConstString Call::mod_round_to_zero = "mod_round_to_zero";
 Call::ConstString Call::call_cached_indirect_function = "call_cached_indirect_function";
 Call::ConstString Call::prefetch = "prefetch";
-Call::ConstString Call::prefetch_2d = "prefetch_2d";
 Call::ConstString Call::signed_integer_overflow = "signed_integer_overflow";
 Call::ConstString Call::indeterminate_expression = "indeterminate_expression";
 Call::ConstString Call::bool_to_mask = "bool_to_mask";

--- a/src/IR.h
+++ b/src/IR.h
@@ -205,8 +205,8 @@ struct Load : public ExprNode<Load> {
     // If it's a load from an image parameter, this points to that
     Parameter param;
 
-    EXPORT static Expr make(Type type, const std::string &name, 
-                            const Expr &index, Buffer<> image, 
+    EXPORT static Expr make(Type type, const std::string &name,
+                            const Expr &index, Buffer<> image,
                             Parameter param, const Expr &predicate);
 
     static const IRNodeType _type_info = IRNodeType::Load;
@@ -497,7 +497,6 @@ struct Call : public ExprNode<Call> {
         mod_round_to_zero,
         call_cached_indirect_function,
         prefetch,
-        prefetch_2d,
         signed_integer_overflow,
         indeterminate_expression,
         bool_to_mask,
@@ -696,6 +695,22 @@ struct Shuffle : public ExprNode<Shuffle> {
     EXPORT bool is_extract_element() const;
 
     static const IRNodeType _type_info = IRNodeType::Shuffle;
+};
+
+/** Represent a multi-dimensional region of a Func or an ImageParam that
+ * needs to be prefetched. */
+struct Prefetch : public StmtNode<Prefetch> {
+    std::string name;
+    std::vector<Type> types;
+    Region bounds;
+
+    /** If it's a prefetch load from an image parameter, this points to that. */
+    Parameter param;
+
+    EXPORT static Stmt make(const std::string &name, const std::vector<Type> &types,
+                            const Region &bounds, Parameter param = Parameter());
+
+    static const IRNodeType _type_info = IRNodeType::Prefetch;
 };
 
 }

--- a/src/IREquality.cpp
+++ b/src/IREquality.cpp
@@ -89,6 +89,7 @@ private:
     void visit(const IfThenElse *);
     void visit(const Evaluate *);
     void visit(const Shuffle *);
+    void visit(const Prefetch *);
 };
 
 template<typename T>
@@ -447,6 +448,17 @@ void IRComparer::visit(const Shuffle *op) {
     compare_scalar(e->indices.size(), op->indices.size());
     for (size_t i = 0; (i < e->indices.size()) && result == Equal; i++) {
         compare_scalar(e->indices[i], op->indices[i]);
+    }
+}
+
+void IRComparer::visit(const Prefetch *op) {
+    const Prefetch *s = expr.as<Prefetch>();
+
+    compare_names(s->name, op->name);
+    compare_scalar(s->bounds.size(), op->bounds.size());
+    for (size_t i = 0; (result == Equal) && (i < s->bounds.size()); i++) {
+        compare_expr(s->bounds[i].min, op->bounds[i].min);
+        compare_expr(s->bounds[i].extent, op->bounds[i].extent);
     }
 }
 

--- a/src/IRMutator.h
+++ b/src/IRMutator.h
@@ -82,6 +82,7 @@ protected:
     EXPORT virtual void visit(const IfThenElse *);
     EXPORT virtual void visit(const Evaluate *);
     EXPORT virtual void visit(const Shuffle *);
+    EXPORT virtual void visit(const Prefetch *);
 };
 
 

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -605,6 +605,20 @@ void IRPrinter::visit(const Realize *op) {
     stream << "}\n";
 }
 
+void IRPrinter::visit(const Prefetch *op) {
+    do_indent();
+    stream << "prefetch " << op->name << "(";
+    for (size_t i = 0; i < op->bounds.size(); i++) {
+        stream << "[";
+        print(op->bounds[i].min);
+        stream << ", ";
+        print(op->bounds[i].extent);
+        stream << "]";
+        if (i < op->bounds.size() - 1) stream << ", ";
+    }
+    stream << ")\n";
+}
+
 void IRPrinter::visit(const Block *op) {
     print(op->first);
     if (op->rest.defined()) print(op->rest);

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -120,6 +120,7 @@ protected:
     void visit(const IfThenElse *);
     void visit(const Evaluate *);
     void visit(const Shuffle *);
+    void visit(const Prefetch *);
 };
 }
 }

--- a/src/IRVisitor.cpp
+++ b/src/IRVisitor.cpp
@@ -206,6 +206,13 @@ void IRVisitor::visit(const Realize *op) {
     op->body.accept(this);
 }
 
+void IRVisitor::visit(const Prefetch *op) {
+    for (size_t i = 0; i < op->bounds.size(); i++) {
+        op->bounds[i].min.accept(this);
+        op->bounds[i].extent.accept(this);
+    }
+}
+
 void IRVisitor::visit(const Block *op) {
     op->first.accept(this);
     if (op->rest.defined()) {
@@ -436,6 +443,13 @@ void IRGraphVisitor::visit(const Realize *op) {
     }
     include(op->condition);
     include(op->body);
+}
+
+void IRGraphVisitor::visit(const Prefetch *op) {
+    for (size_t i = 0; i < op->bounds.size(); i++) {
+        include(op->bounds[i].min);
+        include(op->bounds[i].extent);
+    }
 }
 
 void IRGraphVisitor::visit(const Block *op) {

--- a/src/IRVisitor.h
+++ b/src/IRVisitor.h
@@ -63,6 +63,7 @@ public:
     EXPORT virtual void visit(const IfThenElse *);
     EXPORT virtual void visit(const Evaluate *);
     EXPORT virtual void visit(const Shuffle *);
+    EXPORT virtual void visit(const Prefetch *);
 };
 
 /** A base class for algorithms that walk recursively over the IR
@@ -128,6 +129,7 @@ public:
     EXPORT virtual void visit(const IfThenElse *);
     EXPORT virtual void visit(const Evaluate *);
     EXPORT virtual void visit(const Shuffle *);
+    EXPORT virtual void visit(const Prefetch *);
     // @}
 };
 

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -113,6 +113,7 @@ DECLARE_CPP_INITMOD(posix_io)
 DECLARE_CPP_INITMOD(posix_tempfile)
 DECLARE_CPP_INITMOD(posix_print)
 DECLARE_CPP_INITMOD(posix_threads)
+DECLARE_CPP_INITMOD(prefetch)
 DECLARE_CPP_INITMOD(profiler)
 DECLARE_CPP_INITMOD(profiler_inlined)
 DECLARE_CPP_INITMOD(qurt_allocator)
@@ -768,6 +769,8 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 } else if (t.has_feature(Target::HVX_128)) {
                     modules.push_back(get_initmod_hvx_128_ll(c));
                 }
+            } else {
+                modules.push_back(get_initmod_prefetch(c, bits_64, debug));
             }
             if (t.has_feature(Target::SSE41)) {
                 modules.push_back(get_initmod_x86_sse41_ll(c));

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -234,6 +234,10 @@ Stmt lower(const vector<Function> &output_funcs, const string &pipeline_name,
     s = remove_trivial_for_loops(s);
     debug(2) << "Lowering after second simplifcation:\n" << s << "\n\n";
 
+    debug(1) << "Reduce prefetch dimension...\n";
+    s = reduce_prefetch_dimension(s, t);
+    debug(2) << "Lowering after reduce prefetch dimension:\n" << s << "\n";
+
     debug(1) << "Unrolling...\n";
     s = unroll_loops(s);
     s = simplify(s);

--- a/src/ModulusRemainder.cpp
+++ b/src/ModulusRemainder.cpp
@@ -60,6 +60,7 @@ public:
     void visit(const Free *);
     void visit(const Evaluate *);
     void visit(const Shuffle *);
+    void visit(const Prefetch *);
 };
 
 ModulusRemainder modulus_remainder(Expr e) {
@@ -441,6 +442,10 @@ void ComputeModulusRemainder::visit(const IfThenElse *) {
 }
 
 void ComputeModulusRemainder::visit(const Evaluate *) {
+    internal_assert(false) << "modulus_remainder of statement\n";
+}
+
+void ComputeModulusRemainder::visit(const Prefetch *) {
     internal_assert(false) << "modulus_remainder of statement\n";
 }
 

--- a/src/Monotonic.cpp
+++ b/src/Monotonic.cpp
@@ -378,6 +378,10 @@ class MonotonicVisitor : public IRVisitor {
         internal_error << "Monotonic of statement\n";
     }
 
+    void visit(const Prefetch *op) {
+        internal_error << "Monotonic of statement\n";
+    }
+
 public:
     Monotonic result;
 

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -3,214 +3,200 @@
 #include <string>
 
 #include "Prefetch.h"
-#include "IRMutator.h"
 #include "Bounds.h"
+#include "IRMutator.h"
 #include "Scope.h"
+#include "Simplify.h"
 #include "Util.h"
 
 namespace Halide {
 namespace Internal {
 
 using std::map;
+using std::set;
 using std::string;
 using std::vector;
 
 namespace {
 
-// We need to be able to make loads from a buffer that refer to the
-// same original image/param/etc. This visitor finds a load to the
-// buffer we want to load from, and generates a similar load, but with
-// different args.
-class MakeSimilarLoad : public IRVisitor {
-public:
-    const string &buf_name;
-    const vector<Expr> &args;
-    Expr load;
-
-    MakeSimilarLoad(const string &name, const vector<Expr> &args)
-        : buf_name(name), args(args) {}
-
-private:
-    using IRVisitor::visit;
-
-    void visit(const Call *op) {
-        if (op->name == buf_name) {
-            load = Call::make(op->type, op->name, args, op->call_type, op->func, op->value_index, op->image, op->param);
-        } else {
-            IRVisitor::visit(op);
-        }
+const Definition &get_stage_definition(const Function &f, int stage_num) {
+    if (stage_num == 0) {
+        return f.definition();
     }
-};
-
-Expr make_similar_load(Stmt s, const string &name, const vector<Expr> &args) {
-    MakeSimilarLoad v(name, args);
-    s.accept(&v);
-    return v.load;
-}
-
-// Build a Box representing the bounds of a buffer.
-Box buffer_bounds(const string &buf_name, int dims) {
-    Box bounds;
-    for (int i = 0; i < dims; i++) {
-        string dim_name = std::to_string(i);
-
-        Expr buf_min_i = Variable::make(Int(32), buf_name + ".min." + dim_name);
-        Expr buf_extent_i = Variable::make(Int(32), buf_name + ".extent." + dim_name);
-        Expr buf_max_i = buf_min_i + buf_extent_i - 1;
-
-        bounds.push_back(Interval(buf_min_i, buf_max_i));
-    }
-    return bounds;
+    return f.update(stage_num - 1);
 }
 
 class InjectPrefetch : public IRMutator {
 public:
-    InjectPrefetch(const map<string, Function> &e) : env(e) { }
+    InjectPrefetch(const map<string, Function> &e)
+        : env(e), current_func(nullptr), stage(-1) { }
 
 private:
     const map<string, Function> &env;
-    const vector<Prefetch> *prefetches = nullptr;
-    Scope<Interval> bounds;
+    const Function *current_func;
+    int stage;
+    Scope<Interval> scope;
+    Scope<Box> buffer_bounds;
 
 private:
     using IRMutator::visit;
 
-    void visit(const Let *op) {
-        Interval in = bounds_of_expr_in_scope(op->value, bounds);
-        bounds.push(op->name, in);
+    const vector<PrefetchDirective> &get_prefetch_list(const string &loop_name) {
+        if (!current_func || !starts_with(loop_name, current_func->name() + ".s" + std::to_string(stage))) {
+            vector<string> v = split_string(loop_name, ".");
+            internal_assert(v.size() > 2);
+            const string &func_name = v[0];
+
+            // Get the stage index
+            stage = -1;
+            internal_assert(v[1].substr(0, 1) == "s");
+            {
+                string str = v[1].substr(1, v[1].size() - 1);
+                bool has_only_digits = (str.find_first_not_of( "0123456789" ) == string::npos);
+                internal_assert(has_only_digits);
+                stage = atoi(str.c_str());
+            }
+            internal_assert(stage >= 0);
+
+            const auto &it = env.find(func_name);
+            internal_assert(it != env.end());
+
+            current_func = &it->second;
+            internal_assert(stage <= (int)current_func->updates().size());
+        }
+
+        const Definition &def = get_stage_definition(*current_func, stage);
+        return def.schedule().prefetches();
+    }
+
+    const Box &get_buffer_bounds(string name, int dims) {
+        if (buffer_bounds.contains(name)) {
+            const Box &b = buffer_bounds.ref(name);
+            internal_assert((int)b.size() == dims);
+            return b;
+        }
+
+        // It is an image
+        internal_assert(env.find(name) == env.end());
+        Box b;
+        for (int i = 0; i < dims; i++) {
+            string dim_name = std::to_string(i);
+            Expr buf_min_i = Variable::make(Int(32), name + ".min." + dim_name);
+            Expr buf_extent_i = Variable::make(Int(32), name + ".extent." + dim_name);
+            Expr buf_max_i = buf_min_i + buf_extent_i - 1;
+            b.push_back(Interval(buf_min_i, buf_max_i));
+        }
+        buffer_bounds.push(name, b);
+        return buffer_bounds.ref(name);
+    }
+
+    void visit(const Realize *op) {
+        Box b;
+        b.used = op->condition;
+        for (const auto &r : op->bounds) {
+            b.push_back(Interval(r.min, r.min + r.extent - 1));
+        }
+        buffer_bounds.push(op->name, b);
         IRMutator::visit(op);
-        bounds.pop(op->name);
+        buffer_bounds.pop(op->name);
+    }
+
+    void visit(const Let *op) {
+        Interval in = bounds_of_expr_in_scope(op->value, scope);
+        scope.push(op->name, in);
+        IRMutator::visit(op);
+        scope.pop(op->name);
     }
 
     void visit(const LetStmt *op) {
-        Interval in = bounds_of_expr_in_scope(op->value, bounds);
-        bounds.push(op->name, in);
+        Interval in = bounds_of_expr_in_scope(op->value, scope);
+        scope.push(op->name, in);
         IRMutator::visit(op);
-        bounds.pop(op->name);
+        scope.pop(op->name);
     }
 
-    void visit(const ProducerConsumer *op) {
-        const vector<Prefetch> *old_prefetches = prefetches;
-
-        map<string, Function>::const_iterator iter = env.find(op->name);
-        internal_assert(iter != env.end()) << "function not in environment.\n";
-        prefetches = &iter->second.schedule().prefetches();
-        IRMutator::visit(op);
-        prefetches = old_prefetches;
-    }
-
-    Stmt add_prefetch(const string &buf_name, const Box &box, Stmt body) {
-        // Construct the bounds to be prefetched.
-        vector<Expr> prefetch_min;
-        vector<Expr> prefetch_extent;
+    Stmt add_prefetch(string buf_name, const Parameter &param, const Box &box, Stmt body) {
+        // Construct the region to be prefetched.
+        Region bounds;
         for (size_t i = 0; i < box.size(); i++) {
-            prefetch_min.push_back(box[i].min);
-            prefetch_extent.push_back(box[i].max - box[i].min + 1);
+            Expr extent = box[i].max - box[i].min + 1;
+            bounds.push_back(Range(box[i].min, extent));
         }
-
-        // Construct an array of index expressions to construct
-        // address_of calls with. The first 2 dimensions are handled
-        // by (up to) 2D prefetches, the rest we will generate loops
-        // to define.
-        vector<string> index_names(box.size());
-        vector<Expr> indices(box.size());
-        for (size_t i = 0; i < box.size(); i++) {
-            index_names[i] = "prefetch_" + buf_name + "." + std::to_string(i);
-            indices[i] = i < 2 ? prefetch_min[i] : Variable::make(Int(32), index_names[i]);
-        }
-
-        // Make a load at the index and get the address.
-        Expr prefetch_load = make_similar_load(body, buf_name, indices);
-        internal_assert(prefetch_load.defined());
-        Type type = prefetch_load.type();
-        Expr prefetch_addr = Call::make(Handle(), Call::address_of, {prefetch_load}, Call::Intrinsic);
 
         Stmt prefetch;
-        Expr stride_0 = Variable::make(Int(32), buf_name + ".stride.0");
-        // TODO: This is inefficient if stride_0 != 1, because memory
-        // potentially not accessed will be prefetched, and it will be
-        // fetched multiple times. The right way to handle this would
-        // be to set up a prefetch for each individual element of the
-        // buffer, in case it is sparse, and then try to optimize the
-        // prefetch to fetch dense ranges of addresses. This is hard
-        // to do statically.
-        Expr extent_0_bytes = prefetch_extent[0] * stride_0 * type.bytes();
-        if (box.size() == 1) {
-            // The prefetch is only 1 dimensional, just emit a flat prefetch.
-            prefetch = Evaluate::make(Call::make(Int(32), Call::prefetch,
-                                                 {prefetch_addr, extent_0_bytes},
-                                                 Call::Intrinsic));
+        if (param.defined()) {
+            prefetch = Prefetch::make(buf_name, {param.type()}, bounds, param);
         } else {
-            // Make a 2D prefetch.
-            Expr stride_1 = Variable::make(Int(32), buf_name + ".stride.1");
-            Expr stride_1_bytes = stride_1 * type.bytes();
-            prefetch = Evaluate::make(Call::make(Int(32), Call::prefetch_2d,
-                                                 {prefetch_addr, extent_0_bytes, prefetch_extent[1], stride_1_bytes},
-                                                 Call::Intrinsic));
-
-            // Make loops for the rest of the dimensions (possibly zero).
-            for (size_t i = 2; i < box.size(); i++) {
-                prefetch = For::make(index_names[i], prefetch_min[i], prefetch_extent[i],
-                                     ForType::Serial, DeviceAPI::None,
-                                     prefetch);
-            }
+            const auto &it = env.find(buf_name);
+            internal_assert(it != env.end());
+            prefetch = Prefetch::make(buf_name, it->second.output_types(), bounds);
         }
 
-        // We should only prefetch buffers that are used.
         if (box.maybe_unused()) {
             prefetch = IfThenElse::make(box.used, prefetch);
         }
-
         return Block::make({prefetch, body});
     }
 
     void visit(const For *op) {
+        const Function *old_func = current_func;
+        int old_stage = stage;
+
+        const vector<PrefetchDirective> &prefetch_list = get_prefetch_list(op->name);
+
         // Add loop variable to interval scope for any inner loop prefetch
         Expr loop_var = Variable::make(Int(32), op->name);
-        bounds.push(op->name, Interval(loop_var, loop_var));
+        scope.push(op->name, Interval(loop_var, loop_var));
         Stmt body = mutate(op->body);
-        bounds.pop(op->name);
+        scope.pop(op->name);
 
-        if (prefetches) {
-            for (const Prefetch &p : *prefetches) {
-                if (!ends_with(op->name, "." + p.var)) {
+        if (!prefetch_list.empty()) {
+            // If there are multiple prefetches of the same Func or ImageParam,
+            // use the most recent one
+            set<string> seen;
+            for (int i = prefetch_list.size() - 1; i >= 0; --i) {
+                const PrefetchDirective &p = prefetch_list[i];
+                if (!ends_with(op->name, "." + p.var) || (seen.find(p.name) != seen.end())) {
                     continue;
                 }
+                seen.insert(p.name);
+
                 // Add loop variable + prefetch offset to interval scope for box computation
                 Expr fetch_at = loop_var + p.offset;
-                bounds.push(op->name, Interval(fetch_at, fetch_at));
-                map<string, Box> boxes_read = boxes_required(body, bounds);
-                bounds.pop(op->name);
+                scope.push(op->name, Interval(fetch_at, fetch_at));
+                map<string, Box> boxes_rw = boxes_touched(body, scope);
+                scope.pop(op->name);
 
-                // Don't prefetch buffers that are written to. We assume that these already
-                // have good locality.
-                // TODO: This is not a good assumption. It would be better to have the
-                // prefetch directive specify the buffer that we want to prefetch, instead
-                // of trying to figure out which buffers should be prefetched. This would also
-                // mean that we don't need the "make_similar_load" hack, because we can make
-                // calls the standard way (using the ImageParam/Function object referenced in
-                // the prefetch).
-                map<string, Box> boxes_written = boxes_provided(body, bounds);
-                for (const auto &b : boxes_written) {
-                    auto it = boxes_read.find(b.first);
-                    if (it != boxes_read.end()) {
-                        debug(2) << "Not prefetching buffer " << it->first
-                                 << " also written in loop " << op->name << "\n";
-                        boxes_read.erase(it);
-                    }
-                }
+                // TODO(psuriana): Only prefetch the newly accessed data. We
+                // should subtract the box accessed during previous iteration
+                // from the one accessed during this iteration.
 
-                // TODO: Only prefetch the newly accessed data from the previous iteration.
-                // This should use boxes_touched (instead of boxes_required) so we exclude memory
-                // either read or written.
-                for (const auto &b : boxes_read) {
-                    const string &buf_name = b.first;
-
+                // TODO(psuriana): Shift the base address of the prefetched box
+                // instead of intersecting the extents with the bounds to simplify
+                // the extent exprs. We may have a higher chance a collapsing the
+                // box this way.
+                const auto &b = boxes_rw.find(p.name);
+                if (b != boxes_rw.end()) {
+                    Box prefetch_box = b->second;
                     // Only prefetch the region that is in bounds.
-                    Box bounds = buffer_bounds(buf_name, b.second.size());
-                    Box prefetch_box = box_intersection(b.second, bounds);
+                    const Box &bounds = get_buffer_bounds(b->first, b->second.size());
+                    internal_assert(prefetch_box.size() == bounds.size());
 
-                    body = add_prefetch(buf_name, prefetch_box, body);
+                    if (p.strategy == PrefetchBoundStrategy::Clamp) {
+                        prefetch_box = box_intersection(prefetch_box, bounds);
+                    } else if (p.strategy == PrefetchBoundStrategy::GuardWithIf) {
+                        Expr predicate = const_true();
+                        for (size_t i = 0; i < bounds.size(); ++i) {
+                            predicate = predicate && (prefetch_box[i].min >= bounds[i].min) &&
+                                        (prefetch_box[i].max <= bounds[i].max);
+                        }
+                        prefetch_box.used = simplify(predicate);
+                    } else {
+                        internal_assert(p.strategy == PrefetchBoundStrategy::NonFaulting);
+                        // Assume the prefetch won't fault when accessing region
+                        // outside the bounds.
+                    }
+                    body = add_prefetch(b->first, p.param, prefetch_box, body);
                 }
             }
         }
@@ -220,14 +206,149 @@ private:
         } else {
             stmt = op;
         }
+
+        current_func = old_func;
+        stage = old_stage;
+    }
+};
+
+class ReducePrefetchDimension : public IRMutator {
+    using IRMutator::visit;
+
+    size_t max_dim;
+
+    void visit(const Evaluate *op) {
+        IRMutator::visit(op);
+        op = stmt.as<Evaluate>();
+        internal_assert(op);
+        const Call *call = op->value.as<Call>();
+
+        // Reduce the prefetch dimension if bigger than 'max_dim'.
+        // TODO(psuriana): Ideally, we want to keep the loop size minimal to
+        // minimize the number of prefetch calls. We probably want to lift
+        // the dimensions with larger strides and keep the smaller ones in
+        // the prefetch call.
+
+        size_t max_arg_size = 1 + 2 * max_dim; // Prefetch: {base, extent0, stride0, extent1, stride1, ...}
+        if (call && call->is_intrinsic(Call::prefetch) && (call->args.size() > max_arg_size)) {
+            const Call *base_addr = call->args[0].as<Call>();
+            internal_assert(base_addr && base_addr->is_intrinsic(Call::address_of));
+            const Load *base = base_addr->args[0].as<Load>();
+            internal_assert(base);
+
+            vector<string> index_names;
+            Expr offset = 0;
+            for (size_t i = max_arg_size; i < call->args.size(); i += 2) {
+                Expr stride = call->args[i+1];
+                string index_name = "prefetch_reduce_" + base->name + "." + std::to_string((i-1)/2);
+                index_names.push_back(index_name);
+                offset += Variable::make(Int(32), index_name) * stride;
+            }
+            Expr new_base = Load::make(base->type, base->name, simplify(base->index + offset),
+                                       base->image, base->param, base->predicate);
+            Expr new_base_addr = Call::make(Handle(), Call::address_of, {new_base}, Call::Intrinsic);
+
+            vector<Expr> args = {new_base_addr};
+            for (size_t i = 1; i < max_arg_size; ++i) {
+                args.push_back(call->args[i]);
+            }
+
+            stmt = Evaluate::make(Call::make(call->type, Call::prefetch, args, Call::Intrinsic));
+            for (size_t i = 0; i < index_names.size(); ++i) {
+                stmt = For::make(index_names[i], 0, call->args[(i+max_dim)*2 + 1],
+                                 ForType::Serial, DeviceAPI::None, stmt);
+            }
+            debug(5) << "\nReduce prefetch to " << max_dim << " dim:\n"
+                     << "Before:\n" << Expr(call) << "\nAfter:\n" << stmt << "\n";
+        }
     }
 
+public:
+    ReducePrefetchDimension(size_t dim) : max_dim(dim) {}
+};
+
+class SplitPrefetch : public IRMutator {
+    using IRMutator::visit;
+
+    Expr max_byte_size;
+
+    void visit(const Evaluate *op) {
+        IRMutator::visit(op);
+        op = stmt.as<Evaluate>();
+        internal_assert(op);
+        const Call *call = op->value.as<Call>();
+
+        // If the prefetched data is larger than 'max_byte_size', we need to
+        // tile the prefetch.
+
+        if (call && call->is_intrinsic(Call::prefetch)) {
+            const Call *base_addr = call->args[0].as<Call>();
+            internal_assert(base_addr && base_addr->is_intrinsic(Call::address_of));
+            const Load *base = base_addr->args[0].as<Load>();
+            internal_assert(base);
+
+            int elem_size = base->type.bytes();
+
+            vector<string> index_names;
+            vector<Expr> extents;
+            Expr offset = 0;
+            for (size_t i = 1; i < call->args.size(); i += 2) {
+                Expr extent = call->args[i];
+                Expr stride = call->args[i+1];
+                Expr stride_bytes = stride * elem_size;
+
+                string index_name = "prefetch_split_" + base->name + "." + std::to_string((i-1)/2);
+                index_names.push_back(index_name);
+                offset += Variable::make(Int(32), index_name) * stride_bytes;
+
+                Expr outer_extent = simplify((extent * stride_bytes + max_byte_size - 1)/max_byte_size);
+                extents.push_back(outer_extent);
+            }
+
+            Expr new_base = Load::make(base->type, base->name, simplify(base->index + offset),
+                                       base->image, base->param, base->predicate);
+            Expr new_base_addr = Call::make(Handle(), Call::address_of, {new_base}, Call::Intrinsic);
+
+            vector<Expr> args = {new_base_addr, Expr(1), simplify(max_byte_size / elem_size)};
+            stmt = Evaluate::make(Call::make(call->type, Call::prefetch, args, Call::Intrinsic));
+            for (size_t i = 0; i < index_names.size(); ++i) {
+                stmt = For::make(index_names[i], 0, extents[i],
+                                 ForType::Serial, DeviceAPI::None, stmt);
+            }
+            debug(5) << "\nSplit prefetch to max of " << max_byte_size << " bytes:\n"
+                     << "Before:\n" << Expr(call) << "\nAfter:\n" << stmt << "\n";
+        }
+    }
+
+public:
+    SplitPrefetch(Expr bytes) : max_byte_size(bytes) {}
 };
 
 } // namespace
 
 Stmt inject_prefetch(Stmt s, const map<string, Function> &env) {
     return InjectPrefetch(env).mutate(s);
+}
+
+Stmt reduce_prefetch_dimension(Stmt stmt, const Target &t) {
+    size_t max_dim = 0;
+    Expr max_byte_size;
+
+    if (t.features_any_of({Target::HVX_64, Target::HVX_128})) {
+        max_dim = 2;
+    } else {
+        max_dim = 1;
+        max_byte_size = 64;
+    }
+    internal_assert(max_dim > 0);
+
+    stmt = ReducePrefetchDimension(max_dim).mutate(stmt);
+    if (max_byte_size.defined()) {
+        // If the max byte size is specified, we may need to tile
+        // the prefetch
+        stmt = SplitPrefetch(max_byte_size).mutate(stmt);
+    }
+    return stmt;
 }
 
 }

--- a/src/Prefetch.h
+++ b/src/Prefetch.h
@@ -16,6 +16,13 @@ namespace Internal {
 
 Stmt inject_prefetch(Stmt s, const std::map<std::string, Function> &env);
 
+/** Reduce a multi-dimensional prefetch into a prefetch of lower dimension
+ * (max dimension of the prefetch is specified by target architecture).
+ * This keeps the 'max_dim' innermost dimensions and adds loops for the rest
+ * of the dimensions. If maximum prefetched-byte-size is specified (depending
+ * on the architecture), this also adds an outer loops that tile the prefetches. */
+Stmt reduce_prefetch_dimension(Stmt stmt, const Target &t);
+
 }
 }
 

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -75,7 +75,7 @@ struct ScheduleContents {
     std::vector<Dim> dims;
     std::vector<StorageDim> storage_dims;
     std::vector<Bound> bounds;
-    std::vector<Prefetch> prefetches;
+    std::vector<PrefetchDirective> prefetches;
     std::map<std::string, IntrusivePtr<Internal::FunctionContents>> wrappers;
     bool memoized;
     bool touched;
@@ -112,7 +112,7 @@ struct ScheduleContents {
                 b.remainder = mutator->mutate(b.remainder);
             }
         }
-        for (Prefetch &p : prefetches) {
+        for (PrefetchDirective &p : prefetches) {
             if (p.offset.defined()) {
                 p.offset = mutator->mutate(p.offset);
             }
@@ -214,11 +214,11 @@ const std::vector<Bound> &Schedule::bounds() const {
     return contents->bounds;
 }
 
-std::vector<Prefetch> &Schedule::prefetches() {
+std::vector<PrefetchDirective> &Schedule::prefetches() {
     return contents->prefetches;
 }
 
-const std::vector<Prefetch> &Schedule::prefetches() const {
+const std::vector<PrefetchDirective> &Schedule::prefetches() const {
     return contents->prefetches;
 }
 
@@ -303,7 +303,7 @@ void Schedule::accept(IRVisitor *visitor) const {
             b.remainder.accept(visitor);
         }
     }
-    for (const Prefetch &p : prefetches()) {
+    for (const PrefetchDirective &p : prefetches()) {
         if (p.offset.defined()) {
             p.offset.accept(visitor);
         }

--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -9,8 +9,25 @@ using std::map;
 using std::string;
 using std::vector;
 using std::pair;
+using std::set;
 
 namespace {
+
+// Collect all value indices of internal halide calls.
+class FindCallValueIndices : public IRVisitor {
+public:
+    const string func;
+    map<string, set<int>> func_value_indices;
+
+    using IRVisitor::visit;
+
+    void visit(const Call *call) {
+        IRVisitor::visit(call);
+        if ((call->call_type == Call::Halide) && call->func.defined()) {
+            func_value_indices[call->name].insert(call->value_index);
+        }
+    }
+};
 
 // Visitor and helper function to test if a piece of IR uses an extern image.
 class UsesExternImage : public IRVisitor {
@@ -37,6 +54,8 @@ inline bool uses_extern_image(Stmt s) {
 class SplitTuples : public IRMutator {
     using IRMutator::visit;
 
+    map<string, set<int>> func_value_indices;
+
     void visit(const Realize *op) {
         realizations.push(op->name, 0);
         if (op->types.size() > 1) {
@@ -52,8 +71,39 @@ class SplitTuples : public IRMutator {
         realizations.pop(op->name);
     }
 
+    void visit(const For *op) {
+        map<string, set<int>> old_func_value_indices = func_value_indices;
+
+        FindCallValueIndices find;
+        op->body.accept(&find);
+
+        func_value_indices = find.func_value_indices;
+        IRMutator::visit(op);
+        func_value_indices = old_func_value_indices;
+    }
+
+    void visit(const Prefetch *op) {
+        if (!op->param.defined() && (op->types.size() > 1)) {
+            // Split the prefetch from a multi-dimensional halide tuple to
+            // prefetches of each tuple element. Keep only prefetches of
+            // elements that are actually used in the loop body.
+            const auto &indices = func_value_indices.find(op->name);
+            internal_assert(indices != func_value_indices.end());
+
+            auto it = indices->second.begin();
+            internal_assert((*it) < (int)op->types.size());
+            stmt = Prefetch::make(op->name + "." + std::to_string(*it), {op->types[(*it)]}, op->bounds);
+            for (++it; it != indices->second.end(); ++it) {
+                internal_assert((*it) < (int)op->types.size());
+                stmt = Block::make(stmt, Prefetch::make(op->name + "." + std::to_string(*it), {op->types[(*it)]}, op->bounds));
+            }
+        } else {
+            IRMutator::visit(op);
+        }
+    }
+
     void visit(const Call *op) {
-        if (op->call_type == Call::Halide) {            
+        if (op->call_type == Call::Halide) {
             auto it = env.find(op->name);
             internal_assert(it != env.end());
             Function f = it->second;
@@ -85,7 +135,7 @@ class SplitTuples : public IRMutator {
         // this we mean can we compute and store the values one at a
         // time (not atomic), or must we compute them all, and then
         // store them all (atomic).
-        bool atomic = false;        
+        bool atomic = false;
         if (!realizations.contains(op->name) &&
             uses_extern_image(op)) {
             // If the provide is an output (it's not inside a
@@ -128,7 +178,7 @@ class SplitTuples : public IRMutator {
             provides.push_back(Provide::make(name, {val}, args));
         }
 
-        Stmt result = Block::make(provides);        
+        Stmt result = Block::make(provides);
 
         while (!lets.empty()) {
             auto p = lets.back();
@@ -138,10 +188,10 @@ class SplitTuples : public IRMutator {
 
         stmt = result;
     }
-    
+
     const map<string, Function> &env;
     Scope<int> realizations;
-    
+
 public:
 
     SplitTuples(const map<string, Function> &e) : env(e) {}

--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -483,6 +483,19 @@ private:
         scope.pop(op->name);
     }
 
+    void visit(const Prefetch *op) {
+        stream << open_span("Prefetch");
+        stream << keyword("prefetch") << " ";
+        stream << var(op->name);
+        stream << matched("(");
+        for (size_t i = 0; i < op->bounds.size(); i++) {
+            print_list("[", {op->bounds[i].min, op->bounds[i].extent}, "]");
+            if (i < op->bounds.size() - 1) stream << ", ";
+        }
+        stream << matched(")");
+        stream << close_span();
+    }
+
     // To avoid generating ridiculously deep DOMs, we flatten blocks here.
     void visit_block_stmt(Stmt stmt) {
         if (const Block *b = stmt.as<Block>()) {

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -91,7 +91,7 @@ private:
         Stmt body = mutate(op->body);
 
         // Compute the size
-        std::vector<Expr> extents;
+        vector<Expr> extents;
         for (size_t i = 0; i < op->bounds.size(); i++) {
             extents.push_back(op->bounds[i].extent);
             extents[i] = mutate(extents[i]);
@@ -103,8 +103,8 @@ private:
         vector<int> storage_permutation;
         {
             auto iter = env.find(op->name);
-            Function f = iter->second.first;
             internal_assert(iter != env.end()) << "Realize node refers to function not in environment.\n";
+            Function f = iter->second.first;
             const vector<StorageDim> &storage_dims = f.schedule().storage_dims();
             const vector<string> &args = f.args();
             for (size_t i = 0; i < storage_dims.size(); i++) {
@@ -200,6 +200,60 @@ private:
         } else {
             IRMutator::visit(op);
         }
+    }
+
+    void visit(const Prefetch *op) {
+        internal_assert(op->types.size() == 1)
+            << "Prefetch from multi-dimensional halide tuple should have been split\n";
+
+        vector<Expr> prefetch_min(op->bounds.size());
+        vector<Expr> prefetch_extent(op->bounds.size());
+        vector<Expr> prefetch_stride(op->bounds.size());
+        for (size_t i = 0; i < op->bounds.size(); i++) {
+            prefetch_min[i] = mutate(op->bounds[i].min);
+            prefetch_extent[i] = mutate(op->bounds[i].extent);
+            prefetch_stride[i] = Variable::make(Int(32), op->name + ".stride." + std::to_string(i));
+        }
+
+        Expr base_index = mutate(flatten_args(op->name, prefetch_min));
+        Expr base_load = Load::make(op->types[0], op->name, base_index, Buffer<>(),
+                                    op->param, const_true(op->types[0].lanes()));
+        Expr base_address = Call::make(Handle(), Call::address_of, {base_load}, Call::Intrinsic);
+        vector<Expr> args = {base_address};
+
+        auto iter = env.find(op->name);
+        if (iter != env.end()) {
+            // Order the <min, extent> args based on the storage dims (i.e. innermost
+            // dimension should be first in args)
+            vector<int> storage_permutation;
+            {
+                Function f = iter->second.first;
+                const vector<StorageDim> &storage_dims = f.schedule().storage_dims();
+                const vector<string> &args = f.args();
+                for (size_t i = 0; i < storage_dims.size(); i++) {
+                    for (size_t j = 0; j < args.size(); j++) {
+                        if (args[j] == storage_dims[i].var) {
+                            storage_permutation.push_back((int)j);
+                        }
+                    }
+                    internal_assert(storage_permutation.size() == i+1);
+                }
+            }
+            internal_assert(storage_permutation.size() == op->bounds.size());
+
+            for (size_t i = 0; i < op->bounds.size(); i++) {
+                internal_assert(storage_permutation[i] < (int)op->bounds.size());
+                args.push_back(prefetch_extent[storage_permutation[i]]);
+                args.push_back(prefetch_stride[storage_permutation[i]]);
+            }
+        } else {
+            for (size_t i = 0; i < op->bounds.size(); i++) {
+                args.push_back(prefetch_extent[i]);
+                args.push_back(prefetch_stride[i]);
+            }
+        }
+
+        stmt = Evaluate::make(Call::make(op->types[0], Call::prefetch, args, Call::Intrinsic));
     }
 
     void visit(const LetStmt *let) {

--- a/src/runtime/prefetch.cpp
+++ b/src/runtime/prefetch.cpp
@@ -1,0 +1,13 @@
+#include "HalideRuntime.h"
+
+extern "C" {
+
+// These need to inline, otherwise the extern call with the ptr
+// parameter breaks a lot of optimizations.
+__attribute__((always_inline))
+WEAK int halide_prefetch(const void *ptr) {
+    __builtin_prefetch(ptr, 1);
+    return 0;
+}
+
+}

--- a/src/runtime/prefetch.cpp
+++ b/src/runtime/prefetch.cpp
@@ -5,8 +5,8 @@ extern "C" {
 // These need to inline, otherwise the extern call with the ptr
 // parameter breaks a lot of optimizations.
 __attribute__((always_inline))
-WEAK int halide_prefetch(const void *ptr) {
-    __builtin_prefetch(ptr, 1);
+WEAK int _halide_prefetch(const void *ptr) {
+    __builtin_prefetch(ptr, 1, 3);
     return 0;
 }
 

--- a/src/runtime/qurt_hvx.cpp
+++ b/src/runtime/qurt_hvx.cpp
@@ -55,7 +55,7 @@ WEAK void halide_qurt_hvx_unlock_as_destructor(void *user_context, void * /*obj*
 // These need to inline, otherwise the extern call with the ptr
 // parameter breaks a lot of optimizations.
 __attribute__((always_inline))
-WEAK int halide_prefetch_2d(const void *ptr, int width_bytes, int height, int stride_bytes) {
+WEAK int _halide_prefetch_2d(const void *ptr, int width_bytes, int height, int stride_bytes) {
     // Notes:
     //  - Prefetches can be queued up to 3 deep (MAX_PREFETCH)
     //  - If 3 are already pending, the oldest request is dropped
@@ -74,8 +74,8 @@ WEAK int halide_prefetch_2d(const void *ptr, int width_bytes, int height, int st
 }
 
 __attribute__((always_inline))
-WEAK int halide_prefetch(const void *ptr, int size) {
-    halide_prefetch_2d(ptr, size, 1, 1);
+WEAK int _halide_prefetch(const void *ptr, int size) {
+    _halide_prefetch_2d(ptr, size, 1, 1);
     return 0;
 }
 


### PR DESCRIPTION
Add a new Prefetch IR that holds the box region to be prefetched. The prefetch IR gets lowered into Call::prefetch intrinsic after storage flattening. The new Call::prefetch is now variadic (it can take any number of dimensions). Depending on the architecture, the prefetch call may get reduced into lower dimension or may get tiled by wrapping it with for-loops.

The new prefetch interface takes in the function/image buffer we should prefetch from, in addition to the loop level at which the prefetch should be inserted and the iteration offset. 