### PR TITLE
Simplify concatenated loads

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -195,7 +195,8 @@ void CodeGen_Hexagon::compile_func(const LoweredFunc &f,
     debug(1) << "Aligning loads for HVX....\n";
     body = align_loads(body, target.natural_vector_size(Int(8)));
     body = common_subexpression_elimination(body);
-    body = simplify(body);
+    // Don't simplify here, otherwise it will re-collapse the loads we
+    // want to carry across loop iterations.
     debug(2) << "Lowering after aligning loads:\n" << body << "\n\n";
 
     debug(1) << "Carrying values across loop iterations...\n";
@@ -211,7 +212,7 @@ void CodeGen_Hexagon::compile_func(const LoweredFunc &f,
 
     // Optimize the IR for Hexagon.
     debug(1) << "Optimizing Hexagon instructions...\n";
-    body = optimize_hexagon_instructions(body);
+    body = optimize_hexagon_instructions(body, target.natural_vector_size(Int(8)));
 
     if (uses_hvx(body)) {
         debug(1) << "Adding calls to qurt_hvx_lock...\n";

--- a/src/HexagonOptimize.h
+++ b/src/HexagonOptimize.h
@@ -19,7 +19,7 @@ EXPORT Stmt optimize_hexagon_shuffles(Stmt s, int lut_alignment);
  * rewrites widenings/narrowings to be explicit in the IR, and
  * attempts to simplify away most of the
  * interleaving/deinterleaving. */
-EXPORT Stmt optimize_hexagon_instructions(Stmt s);
+EXPORT Stmt optimize_hexagon_instructions(Stmt s, int native_vector_bytes);
 
 /** Generate deinterleave or interleave operations, operating on
  * groups of vectors at a time. */

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -4270,31 +4270,28 @@ private:
             new_vectors.push_back(new_vector);
         }
 
-        // Only try to simplify shuffles of loads that aren't concats
-        // of vectors. This is a bit of a hacky heuristic to avoid
-        // undoing the work of AlignLoads for Hexagon.
-        if (!op->is_concat() || new_vectors[0].type().is_scalar()) {
-            // Try to convert a load with shuffled indices into a
-            // shuffle of a dense load.
-            if (const Load *first_load = new_vectors[0].as<Load>()) {
-                vector<Expr> load_predicates;
-                vector<Expr> load_indices;
-                bool unpredicated = true;
-                for (Expr e : new_vectors) {
-                    const Load *load = e.as<Load>();
-                    if (load && load->name == first_load->name) {
-                        load_predicates.push_back(load->predicate);
-                        load_indices.push_back(load->index);
-                        unpredicated = unpredicated && is_one(load->predicate);
-                    } else {
-                        break;
-                    }
+        // Try to convert a load with shuffled indices into a
+        // shuffle of a dense load.
+        if (const Load *first_load = new_vectors[0].as<Load>()) {
+            vector<Expr> load_predicates;
+            vector<Expr> load_indices;
+            bool unpredicated = true;
+            for (Expr e : new_vectors) {
+                const Load *load = e.as<Load>();
+                if (load && load->name == first_load->name) {
+                    load_predicates.push_back(load->predicate);
+                    load_indices.push_back(load->index);
+                    unpredicated = unpredicated && is_one(load->predicate);
+                } else {
+                    break;
                 }
+            }
 
-                if (load_indices.size() == new_vectors.size()) {
-                    Type t = load_indices[0].type().with_lanes(op->indices.size());
-                    Expr shuffled_index = Shuffle::make(load_indices, op->indices);
-                    shuffled_index = mutate(shuffled_index);
+            if (load_indices.size() == new_vectors.size()) {
+                Type t = load_indices[0].type().with_lanes(op->indices.size());
+                Expr shuffled_index = Shuffle::make(load_indices, op->indices);
+                shuffled_index = mutate(shuffled_index);
+                if (shuffled_index.as<Ramp>()) {
                     Expr shuffled_predicate;
                     if (unpredicated) {
                         shuffled_predicate = const_true(t.lanes());
@@ -4302,13 +4299,11 @@ private:
                         shuffled_predicate = Shuffle::make(load_predicates, op->indices);
                         shuffled_predicate = mutate(shuffled_predicate);
                     }
-                    if (shuffled_index.as<Ramp>()) {
-                        t = first_load->type;
-                        t = t.with_lanes(op->indices.size());
-                        expr = Load::make(t, first_load->name, shuffled_index, first_load->image,
-                                          first_load->param, shuffled_predicate);
-                        return;
-                    }
+                    t = first_load->type;
+                    t = t.with_lanes(op->indices.size());
+                    expr = Load::make(t, first_load->name, shuffled_index, first_load->image,
+                                      first_load->param, shuffled_predicate);
+                    return;
                 }
             }
         }


### PR DESCRIPTION
Previously, we avoided some simplifications of loads because the Hexagon backend simplified between running align_loads and loop_carry. I don't think simplification is necessary between these passes (CSE yes, simplify no), @abadams can you confirm?

This PR removes that simplification, which makes things less fragile, and allows other logic to be simpler. This also rather significantly reduces the size of the IR we pass to LLVM for some workloads. At the very least, it's much easier to read.

I've tested this for performance regressions on a number of workloads, I see identical performance.