### PR TITLE
Use variadic templates to improve min/max for > 2 args

### DIFF
--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -45,8 +45,8 @@ Expr CameraPipe::avg(Expr a, Expr b) {
 
 Func CameraPipe::hot_pixel_suppression(Func input) {
 
-    Expr a = max({ input(x - 2, y), input(x + 2, y),
-                   input(x, y - 2), input(x, y + 2) });
+    Expr a = max(input(x - 2, y), input(x + 2, y),
+                 input(x, y - 2), input(x, y + 2));
 
     Func denoised("denoised");
     denoised(x, y) = clamp(input(x, y), 0, a);

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -678,26 +678,20 @@ inline Expr max(int a, const Expr &b) {
     return Internal::Max::make(Internal::make_const(b.type(), a), b);
 }
 
+inline Expr max(float a, const Expr &b) {return max(Expr(a), b);}
+inline Expr max(const Expr &a, float b) {return max(a, Expr(b));}
+
 /** Returns an expression representing the greater of an expressions
  * vector, after doing any necessary type coersion using
  * \ref Internal::match_types. Vectorizes cleanly on most platforms
  * (with the exception of integer types on x86 without SSE4).
- * The expressions are folded from left ie. max(.., max(.., ..)). */
-inline Expr max(std::vector<Expr> vec) {
-    for (auto &e : vec) {
-        user_assert(e.defined()) << "max of undefined Expr\n";
-    }
-    return Internal::fold_right(vec,
-                                [](Expr lhs, Expr rhs) -> Expr {
-                                    Internal::match_types(lhs, rhs);
-                                    return Internal::Max::make(lhs, rhs);
-                                });
+ * The expressions are folded from right ie. max(.., max(.., ..)). 
+ * The arguments can be any mix of types but must all be convertible to Expr. */
+template<typename A, typename B, typename C, typename... Rest>
+inline Expr max(const A &a, const B &b, const C &c, const Rest &... rest) {
+    return max(a, max(b, c, rest...));
 }
 
-/** Returns an expression representing the lesser of the two
- * arguments, after doing any necessary type coercion using
- * \ref Internal::match_types. Vectorizes cleanly on most platforms
- * (with the exception of integer types on x86 without SSE4). */
 inline Expr min(Expr a, Expr b) {
     user_assert(a.defined() && b.defined())
         << "min of undefined Expr\n";
@@ -727,20 +721,18 @@ inline Expr min(int a, const Expr &b) {
     return Internal::Min::make(Internal::make_const(b.type(), a), b);
 }
 
+inline Expr min(float a, const Expr &b) {return min(Expr(a), b);}
+inline Expr min(const Expr &a, float b) {return min(a, Expr(b));}
+
 /** Returns an expression representing the lesser of an expressions
  * vector, after doing any necessary type coersion using
  * \ref Internal::match_types. Vectorizes cleanly on most platforms
  * (with the exception of integer types on x86 without SSE4).
- * The expressions are folded from right ie. min(.., min(.., ..)). */
-inline Expr min(std::vector<Expr> vec) {
-    for (auto &e : vec) {
-        user_assert(e.defined()) << "min of undefined Expr\n";
-    }
-    return Internal::fold_right(vec,
-                                [](Expr lhs, Expr rhs) -> Expr {
-                                    Internal::match_types(lhs, rhs);
-                                    return Internal::Min::make(lhs, rhs);
-                                });
+ * The expressions are folded from right ie. min(.., min(.., ..)).
+ * The arguments can be any mix of types but must all be convertible to Expr. */
+template<typename A, typename B, typename C, typename... Rest>
+inline Expr min(const A &a, const B &b, const C &c, const Rest &... rest) {
+    return min(a, min(b, c, rest...));
 }
 
 /** Operators on floats treats those floats as Exprs. Making these
@@ -769,10 +761,6 @@ inline Expr operator==(const Expr &a, float b) {return a == Expr(b);}
 inline Expr operator==(float a, const Expr &b) {return Expr(a) == b;}
 inline Expr operator!=(const Expr &a, float b) {return a != Expr(b);}
 inline Expr operator!=(float a, const Expr &b) {return Expr(a) != b;}
-inline Expr min(float a, const Expr &b) {return min(Expr(a), b);}
-inline Expr min(const Expr &a, float b) {return min(a, Expr(b));}
-inline Expr max(float a, const Expr &b) {return max(Expr(a), b);}
-inline Expr max(const Expr &a, float b) {return max(a, Expr(b));}
 // @}
 
 /** Clamps an expression to lie within the given bounds. The bounds

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -688,8 +688,8 @@ inline Expr max(const Expr &a, float b) {return max(a, Expr(b));}
  * The expressions are folded from right ie. max(.., max(.., ..)). 
  * The arguments can be any mix of types but must all be convertible to Expr. */
 template<typename A, typename B, typename C, typename... Rest>
-inline Expr max(const A &a, const B &b, const C &c, const Rest &... rest) {
-    return max(a, max(b, c, rest...));
+inline Expr max(const A &a, const B &b, const C &c, Rest&&... rest) {
+    return max(a, max(b, c, std::forward<Rest>(rest)...));
 }
 
 inline Expr min(Expr a, Expr b) {
@@ -731,8 +731,8 @@ inline Expr min(const Expr &a, float b) {return min(a, Expr(b));}
  * The expressions are folded from right ie. min(.., min(.., ..)).
  * The arguments can be any mix of types but must all be convertible to Expr. */
 template<typename A, typename B, typename C, typename... Rest>
-inline Expr min(const A &a, const B &b, const C &c, const Rest &... rest) {
-    return min(a, min(b, c, rest...));
+inline Expr min(const A &a, const B &b, const C &c, Rest&&... rest) {
+    return min(a, min(b, c, std::forward<Rest>(rest)...));
 }
 
 /** Operators on floats treats those floats as Exprs. Making these

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -6355,6 +6355,31 @@ void simplify_test() {
         check(stmt, Evaluate::make(0));
     }
 
+    {
+        // Verify that integer types passed to min() and max() are coerced to match
+        // Exprs, rather than being promoted to int first. (TODO: This doesn't really
+        // belong in the test for Simplify, but IROperator has no test unit of its own.)
+        Expr one = cast<uint16_t>(1);
+        const int two = 2;  // note that type is int, not uint16_t
+        Expr r1, r2, r3;
+
+        r1 = min(one, two);
+        internal_assert(r1.type() == halide_type_of<uint16_t>());
+        r2 = min(one, two, one);
+        internal_assert(r2.type() == halide_type_of<uint16_t>());
+        // Explicitly passing 'two' as an Expr, rather than an int, will defeat this logic.
+        r3 = min(one, Expr(two), one);
+        internal_assert(r3.type() == halide_type_of<int>());
+
+        r1 = max(one, two);
+        internal_assert(r1.type() == halide_type_of<uint16_t>());
+        r2 = max(one, two, one);
+        internal_assert(r2.type() == halide_type_of<uint16_t>());
+        // Explicitly passing 'two' as an Expr, rather than an int, will defeat this logic.
+        r3 = max(one, Expr(two), one);
+        internal_assert(r3.type() == halide_type_of<int>());
+    }
+
     std::cout << "Simplify test passed" << std::endl;
 }
 }

--- a/test/correctness/dilate3x3.cpp
+++ b/test/correctness/dilate3x3.cpp
@@ -22,8 +22,8 @@ int main(int argc, char **argv) {
     // Define the dilate algorithm.
     Func max_x("max_x");
     Func dilate3x3("dilate3x3");
-    max_x(x, y) = max({ input(x-1, y), input(x, y), input(x+1, y) });
-    dilate3x3(x, y) = max({ max_x(x, y-1), max_x(x, y), max_x(x, y+1) });
+    max_x(x, y) = max(input(x-1, y), input(x, y), input(x+1, y));
+    dilate3x3(x, y) = max(max_x(x, y-1), max_x(x, y), max_x(x, y+1));
 
     // Schedule.
     Target target = get_jit_target_from_environment();

--- a/test/correctness/median3x3.cpp
+++ b/test/correctness/median3x3.cpp
@@ -30,13 +30,13 @@ int main(int arch, char **argv) {
 
     // Algorithm.
     Func max_x("max_x"), min_x("min_x"), mid_x("mid_x");
-    max_x(x, y) = max({ input(x - 1, y), input(x, y), input(x + 1, y) });
-    min_x(x, y) = min({ input(x - 1, y), input(x, y), input(x + 1, y) });
+    max_x(x, y) = max(input(x - 1, y), input(x, y), input(x + 1, y));
+    min_x(x, y) = min(input(x - 1, y), input(x, y), input(x + 1, y));
     mid_x(x, y) = mid3(input(x-1, y), input(x, y), input(x+1, y));
 
     Func min_max("min_max"), max_min("max_min"), mid_mid("mid_mid");
-    min_max(x, y) = min({ max_x(x, y - 1), max_x(x, y), max_x(x, y + 1) });
-    max_min(x, y) = max({ min_x(x, y - 1), min_x(x, y), min_x(x, y + 1) });
+    min_max(x, y) = min(max_x(x, y - 1), max_x(x, y), max_x(x, y + 1));
+    max_min(x, y) = max(min_x(x, y - 1), min_x(x, y), min_x(x, y + 1));
     mid_mid(x, y) = mid3(mid_x(x, y-1), mid_x(x, y), mid_x(x, y+1));
 
     Func median3x3("median3x3");

--- a/test/correctness/reduction_schedule.cpp
+++ b/test/correctness/reduction_schedule.cpp
@@ -26,9 +26,9 @@ int main(int argc, char **argv) {
     Expr xm = max(r.x - 1, 0), xp = min(r.x + 1, noise.width() - 1);
     energy(x, y) = 0.0f;
     energy(x, 0) = noise(x, 0); // The first row is just the first row of the input.
-    energy(r.x, r.y) = noise(r.x, r.y) + min({ energy(xm, r.y - 1),
-                                               energy(r.x, r.y - 1),
-                                               energy(xp, r.y - 1) });
+    energy(r.x, r.y) = noise(r.x, r.y) + min(energy(xm, r.y - 1),
+                                             energy(r.x, r.y - 1),
+                                             energy(xp, r.y - 1));
 
     Buffer<float> im_energy = energy.realize(size,size);
     Buffer<float> ref_energy(size, size);


### PR DESCRIPTION
The real motivation here is that this allows a uniform syntax for
multiple -arg calls to min() and max(); the >2 arg version no longer
requires wrapper.

Additionally, by adding a variadic template function version of min()
and max(), we can preserve the proper behavior for arguments which are
ints (rather than Expr), which should be coerced to match the paired
Expr, rather than promoted to Expr first.