### PR TITLE
IRPrinter in case of inline reductions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -343,6 +343,7 @@ set(HEADER_FILES
   Parameter.h
   PartitionLoops.h
   Pipeline.h
+  PrintLoopNest.h
   Prefetch.h
   Profiling.h
   Qualify.h

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -491,8 +491,8 @@ void IRPrinter::visit(const Call *op) {
         stream << op->type << ", ";
     }
 
+    bool is_inline_reduction = false;
     if (op->func.defined()) {
-        bool is_inline_reduction = false;
         Halide::Internal::Function f(op->func);
         if (f.has_update_definition()) {
             Halide::Expr e = f.update(0).values()[0];
@@ -517,10 +517,8 @@ void IRPrinter::visit(const Call *op) {
               break;
             }
         }
-        if (!is_inline_reduction) {
-          print_list(f.values());
-        }
-    } else {
+    }
+    if (!is_inline_reduction) {
       print_list(op->args);
     }
     stream << ")";

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -491,8 +491,8 @@ void IRPrinter::visit(const Call *op) {
         stream << op->type << ", ";
     }
 
-    bool is_inline_reduction = false;
     if (op->func.defined()) {
+        bool is_inline_reduction = false;
         Halide::Internal::Function f(op->func);
         if (f.has_update_definition()) {
             Halide::Expr e = f.update(0).values()[0];
@@ -517,8 +517,10 @@ void IRPrinter::visit(const Call *op) {
               break;
             }
         }
-    }
-    if (!is_inline_reduction) {
+        if (!is_inline_reduction) {
+          print_list(f.values());
+        }
+    } else {
       print_list(op->args);
     }
     stream << ")";


### PR DESCRIPTION
Proposal in extend IRPrinter in case of inline reductions (sum, product, maximum, minimum).

```cpp
Halide::Var x("x");
Halide::RDom r(0, 4);
Halide::Expr e = sum(x + 10 + r);
std::cout << e << std::endl;
```
Output before:
```cpp
sum(x)
```

Proposed:
```cpp
sum(((x + 10) + r$x))
```

Motivation: make the same output format like for other `Call` expressions. For example, `sin`:
```cpp
std::cout << sin(x + 10) << std::endl;
```
```cpp
sin_f32(float32((x + 10)))
```