### PR TITLE
Add forwarding methods for scheduling for Output<> types

### DIFF
--- a/apps/HelloAndroid/jni/hello_generator.cpp
+++ b/apps/HelloAndroid/jni/hello_generator.cpp
@@ -26,7 +26,7 @@ public:
         Var yi;
 
         tone_curve.compute_root();
-        Func(result).split(y, y, yi, 60).vectorize(x, 8).parallel(y);
+        result.split(y, y, yi, 60).vectorize(x, 8).parallel(y);
         curved.store_at(result, y).compute_at(result, yi);
 
         // We want to handle inputs that may be rotated 180 due to camera module placement.

--- a/apps/HelloHexagon/pipeline.cpp
+++ b/apps/HelloHexagon/pipeline.cpp
@@ -47,7 +47,7 @@ public:
 
         schedule = [=]() mutable {
             // Require the input and output to have 3 channels.
-            Func(blur).bound(c, 0, 3);
+            blur.bound(c, 0, 3);
             input.dim(2).set_bounds(0, 3);
 
             if (get_target().features_any_of({Target::HVX_64, Target::HVX_128})) {
@@ -58,7 +58,7 @@ public:
                 // blur in y at each chunk. We use the RoundUp tail strategy to
                 // keep the last chunk's memory accesses aligned.
                 Var yo("yo");
-                Func(blur).compute_root()
+                blur.compute_root()
                     .hexagon()
                     .prefetch(input, y, 2)
                     .split(y, yo, y, 128).parallel(yo)
@@ -87,11 +87,11 @@ public:
             } else {
                 const int vector_size = natural_vector_size<uint8_t>();
 
-                Func(blur).compute_root()
-                .parallel(y, 16)
-                .vectorize(x, vector_size);
+                blur.compute_root()
+                    .parallel(y, 16)
+                    .vectorize(x, vector_size);
                 blur_y.compute_at(blur, y)
-                .vectorize(x, vector_size);
+                    .vectorize(x, vector_size);
             }
         };
     }

--- a/apps/HelloiOS/HelloiOS/reaction_diffusion_2_generator.cpp
+++ b/apps/HelloiOS/HelloiOS/reaction_diffusion_2_generator.cpp
@@ -12,7 +12,7 @@ public:
 
     void schedule() {
         if (get_target().has_gpu_feature()) {
-            Func(output)
+            output
                 .reorder(c, x, y)
                 .bound(c, 0, 3)
                 .vectorize(c)
@@ -109,7 +109,7 @@ public:
 
     void schedule() {
         state.dim(2).set_bounds(0, 3);
-        Func(new_state)
+        new_state
             .reorder(c, x, y)
             .bound(c, 0, 3)
             .unroll(c);
@@ -120,21 +120,21 @@ public:
                 .vectorize(c)
                 .compute_at(new_state, Var::gpu_threads());
 
-            Func(new_state).gpu_tile(x, y, 8, 2);
+            new_state.gpu_tile(x, y, 8, 2);
 
             for (int i = 0; i <= 1; ++i) {
-                Func(new_state).update(i)
+                new_state.update(i)
                     .reorder(c, x)
                     .unroll(c)
                     .gpu_tile(x, 8);
             }
             for (int i = 2; i <= 3; ++i) {
-                Func(new_state).update(i)
+                new_state.update(i)
                     .reorder(c, y)
                     .unroll(c)
                     .gpu_tile(y, 8);
             }
-            Func(new_state).update(4)
+            new_state.update(4)
                 .reorder(c, clobber.x)
                 .unroll(c)
                 .gpu_tile(clobber.x, clobber.y, 1, 1);
@@ -147,7 +147,7 @@ public:
                 .dim(2).set_stride(1).set_extent(3);
         } else {
             Var yi;
-            Func(new_state)
+            new_state
                 .split(y, y, yi, 64)
                 .parallel(y)
                 .vectorize(x, natural_vector_size<float>());
@@ -215,21 +215,21 @@ public:
             state
                 .dim(0).set_stride(3)
                 .dim(2).set_stride(1).set_bounds(0, 3);
-            Func(render)
+            render
                 .reorder(c, x, y)
                 .unroll(c)
                 .gpu_tile(x, y, 32, 4);
         } else {
             Var yi;
-            Func(render)
+            render
                 .reorder(c, x, y)
                 .unroll(c)
                 .vectorize(x, natural_vector_size<float>())
                 .split(y, y, yi, 64)
                 .parallel(y);
         }
-        Func(render).specialize(output_bgra == true);
-        Func(render).specialize(output_bgra == false);
+        render.specialize(output_bgra == true);
+        render.specialize(output_bgra == false);
     }
 
 private:

--- a/apps/hexagon_benchmarks/conv3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/conv3x3_generator.cpp
@@ -29,9 +29,8 @@ public:
         input.dim(0).set_min(0);
         input.dim(1).set_min(0);
 
-        auto output_buffer = Func(output).output_buffer();
-        output_buffer.dim(0).set_min(0);
-        output_buffer.dim(1).set_min(0);
+        output.dim(0).set_min(0);
+        output.dim(1).set_min(0);
 
         if (get_target().features_any_of({Target::HVX_64, Target::HVX_128})) {
             const int vector_size = get_target().has_feature(Target::HVX_128) ? 128 : 64;
@@ -41,14 +40,14 @@ public:
             Expr output_stride = output_buffer.dim(1).stride();
             output_buffer.dim(1).set_stride((output_stride/vector_size) * vector_size);
             bounded_input.compute_root();
-            Func(output)
+            output
                 .hexagon()
                 .tile(x, y, xi, yi, vector_size, 4, TailStrategy::RoundUp)
                 .vectorize(xi)
                 .unroll(yi);
         } else {
             const int vector_size = natural_vector_size<uint8_t>();
-            Func(output)
+            output
                 .vectorize(x, vector_size)
                 .parallel(y, 16);
         }

--- a/apps/hexagon_benchmarks/dilate3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/dilate3x3_generator.cpp
@@ -22,26 +22,25 @@ public:
         input.dim(0).set_min(0);
         input.dim(1).set_min(0);
 
-        auto output_buffer = Func(output).output_buffer();
-        output_buffer.dim(0).set_min(0);
-        output_buffer.dim(1).set_min(0);
+        output.dim(0).set_min(0);
+        output.dim(1).set_min(0);
 
         if (get_target().features_any_of({Target::HVX_64, Target::HVX_128})) {
             const int vector_size = get_target().has_feature(Target::HVX_128) ? 128 : 64;
             Expr input_stride = input.dim(1).stride();
             input.dim(1).set_stride((input_stride/vector_size) * vector_size);
 
-            Expr output_stride = output_buffer.dim(1).stride();
-            output_buffer.dim(1).set_stride((output_stride/vector_size) * vector_size);
+            Expr output_stride = output.dim(1).stride();
+            output.dim(1).set_stride((output_stride/vector_size) * vector_size);
             bounded_input.compute_root();
-            Func(output)
+            output
                 .hexagon()
                 .tile(x, y, xi, yi, vector_size, 4)
                 .vectorize(xi)
                 .unroll(yi);
         } else {
             const int vector_size = natural_vector_size<uint8_t>();
-            Func(output)
+            output
                 .vectorize(x, vector_size)
                 .parallel(y, 16);
         }

--- a/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
+++ b/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
@@ -26,29 +26,28 @@ public:
         input.dim(0).set_min(0);
         input.dim(1).set_min(0);
 
-        auto output_buffer = Func(output).output_buffer();
-        output_buffer.dim(0).set_min(0);
-        output_buffer.dim(1).set_min(0);
+        output.dim(0).set_min(0);
+        output.dim(1).set_min(0);
 
         if (get_target().features_any_of({Target::HVX_64, Target::HVX_128})) {
             const int vector_size = get_target().has_feature(Target::HVX_128) ? 128 : 64;
             Expr input_stride = input.dim(1).stride();
             input.dim(1).set_stride((input_stride/vector_size) * vector_size);
 
-            Expr output_stride = output_buffer.dim(1).stride();
-            output_buffer.dim(1).set_stride((output_stride/vector_size) * vector_size);
-            Func(output)
+            Expr output_stride = output.dim(1).stride();
+            output.dim(1).set_stride((output_stride/vector_size) * vector_size);
+            output
                 .hexagon()
                 .tile(x, y, xi, yi, vector_size, 4, TailStrategy::RoundUp)
                 .vectorize(xi)
                 .unroll(yi);
-            rows.compute_at(Func(output), y)
+            rows.compute_at(output, y)
                 .tile(x, y, x, y, xi, yi, vector_size, 4, TailStrategy::RoundUp)
                 .vectorize(xi)
                 .unroll(yi);
         } else {
             const int vector_size = natural_vector_size<uint8_t>();
-            Func(output)
+            output
                 .vectorize(x, vector_size)
                 .parallel(y, 16);
         }

--- a/apps/hexagon_benchmarks/median3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/median3x3_generator.cpp
@@ -33,26 +33,25 @@ public:
         input.dim(0).set_min(0);
         input.dim(1).set_min(0);
 
-        auto output_buffer = Func(output).output_buffer();
-        output_buffer.dim(0).set_min(0);
-        output_buffer.dim(1).set_min(0);
+        output.dim(0).set_min(0);
+        output.dim(1).set_min(0);
 
         if (get_target().features_any_of({Target::HVX_64, Target::HVX_128})) {
             const int vector_size = get_target().has_feature(Target::HVX_128) ? 128 : 64;
             Expr input_stride = input.dim(1).stride();
             input.dim(1).set_stride((input_stride/vector_size) * vector_size);
 
-            Expr output_stride = output_buffer.dim(1).stride();
-            output_buffer.dim(1).set_stride((output_stride/vector_size) * vector_size);
+            Expr output_stride = output.dim(1).stride();
+            output.dim(1).set_stride((output_stride/vector_size) * vector_size);
             bounded_input.compute_root();
-            Func(output)
+            output
                 .hexagon()
                 .tile(x, y, xi, yi, vector_size, 4)
                 .vectorize(xi)
                 .unroll(yi);
         } else {
             const int vector_size = natural_vector_size<uint8_t>();
-            Func(output)
+            output
                 .vectorize(x, vector_size)
                 .parallel(y, 16);
         }

--- a/apps/hexagon_benchmarks/sobel_generator.cpp
+++ b/apps/hexagon_benchmarks/sobel_generator.cpp
@@ -30,26 +30,22 @@ public:
         input.dim(0).set_min(0);
         input.dim(1).set_min(0);
 
-        auto output_buffer = Func(output).output_buffer();
-        output_buffer.dim(0).set_min(0);
-        output_buffer.dim(1).set_min(0);
-
         if (get_target().features_any_of({Target::HVX_64, Target::HVX_128})) {
             const int vector_size = get_target().has_feature(Target::HVX_128) ? 128 : 64;
             Expr input_stride = input.dim(1).stride();
             input.dim(1).set_stride((input_stride/vector_size) * vector_size);
 
-            Expr output_stride = output_buffer.dim(1).stride();
-            output_buffer.dim(1).set_stride((output_stride/vector_size) * vector_size);
+            Expr output_stride = output.dim(1).stride();
+            output.dim(1).set_stride((output_stride/vector_size) * vector_size);
             bounded_input.compute_root();
-            Func(output)
+            output
                 .hexagon()
                 .tile(x, y, xi, yi, vector_size, 4, TailStrategy::RoundUp)
                 .vectorize(xi)
                 .unroll(yi);
         } else {
             const int vector_size = natural_vector_size<uint8_t>();
-            Func(output)
+            output
                 .vectorize(x, vector_size)
                 .parallel(y, 16);
         }

--- a/apps/hexagon_matmul/pipeline.cpp
+++ b/apps/hexagon_matmul/pipeline.cpp
@@ -66,7 +66,7 @@ public:
 
                 // Split the output into tiles, traversed in columns of tiles
                 // that we parallelize over.
-                Func(output).compute_root()
+                output.compute_root()
                     .hexagon()
                     .tile(x, y, xo, yo, x, y, vector_size_u8, tile_rows, TailStrategy::RoundUp)
                     .reorder(x, y, yo, xo)
@@ -100,7 +100,7 @@ public:
                 constexpr int kBlockSize = 32;
                 const int kBlockSizeXi = 8;
 
-                Func(output).compute_root()
+                output.compute_root()
                     .tile(x, y, x, y, xi, yi, vector_size_u8, tile_rows, TailStrategy::RoundUp)
                     .reorder(xi, yi, x, y)
                     .vectorize(xi)

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1668,17 +1668,24 @@ public:
         return get_func_ref().method(std::forward<Args>(args)...);          \
     }
 
+#define HALIDE_OUTPUT_FORWARD_CONST(method)                                 \
+    template<typename ...Args>                                              \
+    inline auto method(Args&&... args) const ->                             \
+        decltype(std::declval<Func>().method(std::forward<Args>(args)...)) {\
+        return get_func_ref().method(std::forward<Args>(args)...);          \
+    }
+
     /** Forward schedule-related methods to the underlying Func. */
     // @{
     HALIDE_OUTPUT_FORWARD(align_bounds)
     HALIDE_OUTPUT_FORWARD(align_storage)
-    HALIDE_OUTPUT_FORWARD(args)
+    HALIDE_OUTPUT_FORWARD_CONST(args)
     HALIDE_OUTPUT_FORWARD(bound)
     HALIDE_OUTPUT_FORWARD(bound_extent)
     HALIDE_OUTPUT_FORWARD(compute_at)
     HALIDE_OUTPUT_FORWARD(compute_inline)
     HALIDE_OUTPUT_FORWARD(compute_root)
-    HALIDE_OUTPUT_FORWARD(defined)
+    HALIDE_OUTPUT_FORWARD_CONST(defined)
     HALIDE_OUTPUT_FORWARD(fold_storage)
     HALIDE_OUTPUT_FORWARD(fuse)
     HALIDE_OUTPUT_FORWARD(glsl)
@@ -1687,19 +1694,19 @@ public:
     HALIDE_OUTPUT_FORWARD(gpu_single_thread)
     HALIDE_OUTPUT_FORWARD(gpu_threads)
     HALIDE_OUTPUT_FORWARD(gpu_tile)
-    HALIDE_OUTPUT_FORWARD(has_update_definition)
+    HALIDE_OUTPUT_FORWARD_CONST(has_update_definition)
     HALIDE_OUTPUT_FORWARD(hexagon)
     HALIDE_OUTPUT_FORWARD(in)
     HALIDE_OUTPUT_FORWARD(memoize)
-    HALIDE_OUTPUT_FORWARD(num_update_definitions)
-    HALIDE_OUTPUT_FORWARD(output_types)
-    HALIDE_OUTPUT_FORWARD(outputs)
+    HALIDE_OUTPUT_FORWARD_CONST(num_update_definitions)
+    HALIDE_OUTPUT_FORWARD_CONST(output_types)
+    HALIDE_OUTPUT_FORWARD_CONST(outputs)
     HALIDE_OUTPUT_FORWARD(parallel)
     HALIDE_OUTPUT_FORWARD(prefetch)
     HALIDE_OUTPUT_FORWARD(rename)
     HALIDE_OUTPUT_FORWARD(reorder)
     HALIDE_OUTPUT_FORWARD(reorder_storage)
-    HALIDE_OUTPUT_FORWARD(rvars)
+    HALIDE_OUTPUT_FORWARD_CONST(rvars)
     HALIDE_OUTPUT_FORWARD(serial)
     HALIDE_OUTPUT_FORWARD(shader)
     HALIDE_OUTPUT_FORWARD(specialize)
@@ -1709,11 +1716,11 @@ public:
     HALIDE_OUTPUT_FORWARD(tile)
     HALIDE_OUTPUT_FORWARD(unroll)
     HALIDE_OUTPUT_FORWARD(update)
-    HALIDE_OUTPUT_FORWARD(update_args)
-    HALIDE_OUTPUT_FORWARD(update_value)
-    HALIDE_OUTPUT_FORWARD(update_values)
-    HALIDE_OUTPUT_FORWARD(value)
-    HALIDE_OUTPUT_FORWARD(values)
+    HALIDE_OUTPUT_FORWARD_CONST(update_args)
+    HALIDE_OUTPUT_FORWARD_CONST(update_value)
+    HALIDE_OUTPUT_FORWARD_CONST(update_values)
+    HALIDE_OUTPUT_FORWARD_CONST(value)
+    HALIDE_OUTPUT_FORWARD_CONST(values)
     HALIDE_OUTPUT_FORWARD(vectorize)
     // }@
 
@@ -1746,6 +1753,12 @@ protected:
     EXPORT void check_value_writable() const override;
 
     NO_INLINE Func &get_func_ref() {
+        internal_assert(kind() != IOKind::Scalar);
+        internal_assert(funcs_.size() == array_size() && exprs_.empty());
+        return funcs_[0];
+    }
+
+    NO_INLINE const Func &get_func_ref() const {
         internal_assert(kind() != IOKind::Scalar);
         internal_assert(funcs_.size() == array_size() && exprs_.empty());
         return funcs_[0];

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1658,7 +1658,67 @@ public:
 
 namespace Internal {
 
+
 class GeneratorOutputBase : public GIOBase {
+public:
+#define HALIDE_OUTPUT_FORWARD(method)                                       \
+    template<typename ...Args>                                              \
+    inline auto method(Args&&... args) ->                                   \
+        decltype(std::declval<Func>().method(std::forward<Args>(args)...)) {\
+        return get_func_ref().method(std::forward<Args>(args)...);          \
+    }
+
+    /** Forward schedule-related methods to the underlying Func. */
+    // @{
+    HALIDE_OUTPUT_FORWARD(align_bounds)
+    HALIDE_OUTPUT_FORWARD(align_storage)
+    HALIDE_OUTPUT_FORWARD(args)
+    HALIDE_OUTPUT_FORWARD(bound)
+    HALIDE_OUTPUT_FORWARD(bound_extent)
+    HALIDE_OUTPUT_FORWARD(compute_at)
+    HALIDE_OUTPUT_FORWARD(compute_inline)
+    HALIDE_OUTPUT_FORWARD(compute_root)
+    HALIDE_OUTPUT_FORWARD(defined)
+    HALIDE_OUTPUT_FORWARD(fold_storage)
+    HALIDE_OUTPUT_FORWARD(fuse)
+    HALIDE_OUTPUT_FORWARD(glsl)
+    HALIDE_OUTPUT_FORWARD(gpu)
+    HALIDE_OUTPUT_FORWARD(gpu_blocks)
+    HALIDE_OUTPUT_FORWARD(gpu_single_thread)
+    HALIDE_OUTPUT_FORWARD(gpu_threads)
+    HALIDE_OUTPUT_FORWARD(gpu_tile)
+    HALIDE_OUTPUT_FORWARD(has_update_definition)
+    HALIDE_OUTPUT_FORWARD(hexagon)
+    HALIDE_OUTPUT_FORWARD(in)
+    HALIDE_OUTPUT_FORWARD(memoize)
+    HALIDE_OUTPUT_FORWARD(num_update_definitions)
+    HALIDE_OUTPUT_FORWARD(output_types)
+    HALIDE_OUTPUT_FORWARD(outputs)
+    HALIDE_OUTPUT_FORWARD(parallel)
+    HALIDE_OUTPUT_FORWARD(prefetch)
+    HALIDE_OUTPUT_FORWARD(rename)
+    HALIDE_OUTPUT_FORWARD(reorder)
+    HALIDE_OUTPUT_FORWARD(reorder_storage)
+    HALIDE_OUTPUT_FORWARD(rvars)
+    HALIDE_OUTPUT_FORWARD(serial)
+    HALIDE_OUTPUT_FORWARD(shader)
+    HALIDE_OUTPUT_FORWARD(specialize)
+    HALIDE_OUTPUT_FORWARD(split)
+    HALIDE_OUTPUT_FORWARD(store_at)
+    HALIDE_OUTPUT_FORWARD(store_root)
+    HALIDE_OUTPUT_FORWARD(tile)
+    HALIDE_OUTPUT_FORWARD(unroll)
+    HALIDE_OUTPUT_FORWARD(update)
+    HALIDE_OUTPUT_FORWARD(update_args)
+    HALIDE_OUTPUT_FORWARD(update_value)
+    HALIDE_OUTPUT_FORWARD(update_values)
+    HALIDE_OUTPUT_FORWARD(value)
+    HALIDE_OUTPUT_FORWARD(values)
+    HALIDE_OUTPUT_FORWARD(vectorize)
+    // }@
+
+#undef HALIDE_OUTPUT_FORWARD
+
 protected:
     EXPORT GeneratorOutputBase(size_t array_size,
                         const std::string &name,
@@ -1684,6 +1744,12 @@ protected:
     }
 
     EXPORT void check_value_writable() const override;
+
+    NO_INLINE Func &get_func_ref() {
+        internal_assert(kind() != IOKind::Scalar);
+        internal_assert(funcs_.size() == array_size() && exprs_.empty());
+        return funcs_[0];
+    }
 };
 
 template<typename T>

--- a/test/generator/example_generator.cpp
+++ b/test/generator/example_generator.cpp
@@ -77,7 +77,7 @@ public:
     }
 
     void schedule() {
-        Func(output)
+        output
             .bound(c, 0, channels)
             .reorder(c, x, y)
             .unroll(c);
@@ -85,7 +85,7 @@ public:
             // Note that we can use the Generator method natural_vector_size()
             // here; this produces the width of the SIMD vector being targeted
             // divided by the width of the data type.
-            Func(output)
+            output
                 .vectorize(x, natural_vector_size(output.type()));
         }
     }

--- a/test/generator/msan_generator.cpp
+++ b/test/generator/msan_generator.cpp
@@ -24,7 +24,7 @@ public:
     void schedule() {
         input.compute_root();
         msan_extern_stage.compute_root();
-        Func(msan_output).parallel(y).vectorize(x, 4);
+        msan_output.parallel(y).vectorize(x, 4);
         msan_output.dim(0).set_stride(Expr()).set_extent(4)
                    .dim(1).set_extent(4)
                    .dim(2).set_extent(3);

--- a/test/generator/nested_externs_generator.cpp
+++ b/test/generator/nested_externs_generator.cpp
@@ -92,7 +92,7 @@ public:
             f.compute_at(root, y).reorder_storage(args[2], args[0], args[1]);
         }
         set_interleaved(root);
-        Func(root).reorder_storage(c, x, y);
+        root.reorder_storage(c, x, y);
     }
 
 private:

--- a/test/generator/tiled_blur_blur_generator.cpp
+++ b/test/generator/tiled_blur_blur_generator.cpp
@@ -45,10 +45,10 @@ public:
         blur.dim(0).set_stride(Expr());
 
         // Add specialization for input and output buffers that are both planar.
-        Func(blur).specialize(is_planar(input) && is_planar(blur));
+        blur.specialize(is_planar(input) && is_planar(blur));
 
         // Add specialization for input and output buffers that are both interleaved.
-        Func(blur).specialize(is_interleaved(input) && is_interleaved(blur));
+        blur.specialize(is_interleaved(input) && is_interleaved(blur));
 
         // Note that other combinations (e.g. interleaved -> planar) will work
         // but be relatively unoptimized.

--- a/test/generator/tiled_blur_generator.cpp
+++ b/test/generator/tiled_blur_generator.cpp
@@ -34,7 +34,7 @@ public:
 
     void schedule() {
         Var xi, yi;
-        Func(brighter2).reorder(c, x, y).tile(x, y, xi, yi, 32, 32);
+        brighter2.reorder(c, x, y).tile(x, y, xi, yi, 32, 32);
         tiled_blur.compute_at(brighter2, x);
         brighter1.compute_at(brighter2, x);
 
@@ -49,10 +49,10 @@ public:
         brighter2.dim(0).set_stride(Expr());
 
         // Add specialization for input and output buffers that are both planar.
-        Func(brighter2).specialize(is_planar(input) && is_planar(brighter2));
+        brighter2.specialize(is_planar(input) && is_planar(brighter2));
 
         // Add specialization for input and output buffers that are both interleaved.
-        Func(brighter2).specialize(is_interleaved(input) && is_interleaved(brighter2));
+        brighter2.specialize(is_interleaved(input) && is_interleaved(brighter2));
 
         // Note that other combinations (e.g. interleaved -> planar) will work
         // but be relatively unoptimized.


### PR DESCRIPTION
Uses the same technique as Buffer -> Runtime::Buffer. Fixed/removed all
of the unnecessary explicit-cast-to-Func that I could find.