### PR TITLE
Remove deprecated "cuda_xxx" APIs

### DIFF
--- a/apps/blur/halide_blur_generator.cpp
+++ b/apps/blur/halide_blur_generator.cpp
@@ -50,7 +50,7 @@ public:
             case BlurGPUSchedule::Cache:
                 // - Cache blur_x calculation.
                 blur_y.gpu_tile(x, y, xi, yi, tile_x, tile_y);
-                blur_x.compute_at(blur_y, xi).gpu_threads(x, y);
+                blur_x.compute_at(blur_y, x).gpu_threads(x, y);
                 break;
             case BlurGPUSchedule::Slide: {
                 // - Instead caching blur_x calculation explicitly, the

--- a/apps/blur/halide_blur_generator.cpp
+++ b/apps/blur/halide_blur_generator.cpp
@@ -33,7 +33,7 @@ public:
 
     Func build() {
         Func blur_x("blur_x"), blur_y("blur_y");
-        Var x("x"), y("y"), xi("xi"), yi("yi"), tx("tx"), ty("ty");
+        Var x("x"), y("y"), xi("xi"), yi("yi");
 
         // The algorithm
         blur_x(x, y) = (input(x, y) + input(x+1, y) + input(x+2, y))/3;
@@ -45,12 +45,12 @@ public:
             switch (schedule) {
             case BlurGPUSchedule::Inline:
                 // - Fully inlining.
-                blur_y.gpu_tile(x, y, tx, ty, tile_x, tile_y);
+                blur_y.gpu_tile(x, y, xi, yi, tile_x, tile_y);
                 break;
             case BlurGPUSchedule::Cache:
                 // - Cache blur_x calculation.
-                blur_y.gpu_tile(x, y, tx, ty, tile_x, tile_y);
-                blur_x.compute_at(blur_y, tx).gpu_threads(x, y);
+                blur_y.gpu_tile(x, y, xi, yi, tile_x, tile_y);
+                blur_x.compute_at(blur_y, xi).gpu_threads(x, y);
                 break;
             case BlurGPUSchedule::Slide: {
                 // - Instead caching blur_x calculation explicitly, the
@@ -58,18 +58,18 @@ public:
                 //   in CUDA to calculate more rows of blur_y so that temporary
                 //   blur_x calculation is re-used implicitly. This achieves
                 //   the similar schedule of sliding window.
-                Var yi("yi");
-                blur_y.split(y, y, yi, tile_y).reorder(yi, x).unroll(yi)
-                    .gpu_tile(x, y, tx, ty, tile_x, 1);
+                Var y_inner("y_inner");
+                blur_y.split(y, y, y_inner, tile_y).reorder(y_inner, x).unroll(y_inner)
+                    .gpu_tile(x, y, xi, yi, tile_x, 1);
                 break;
             }
             case BlurGPUSchedule::SlideVectorize: {
                 // Vectorization factor.
                 int factor = sizeof(int)/sizeof(short);
-                Var yi("yi");
+                Var y_inner("y_inner");
                 blur_y.vectorize(x, factor)
-                    .split(y, y, yi, tile_y).reorder(yi, x).unroll(yi)
-                    .gpu_tile(x, y, tx, ty, tile_x, 1);
+                    .split(y, y, y_inner, tile_y).reorder(y_inner, x).unroll(y_inner)
+                    .gpu_tile(x, y, xi, yi, tile_x, 1);
                 break;
             }
             default:

--- a/src/Func.h
+++ b/src/Func.h
@@ -1401,19 +1401,6 @@ public:
      * touch a very small part of your Func. */
     EXPORT Func &gpu_single_thread(DeviceAPI device_api = DeviceAPI::Default_GPU);
 
-    /** \deprecated Old name for #gpu_threads. */
-    // @{
-    EXPORT Func &cuda_threads(VarOrRVar thread_x) {
-        return gpu_threads(thread_x);
-    }
-    EXPORT Func &cuda_threads(VarOrRVar thread_x, VarOrRVar thread_y) {
-        return gpu_threads(thread_x, thread_y);
-    }
-    EXPORT Func &cuda_threads(VarOrRVar thread_x, VarOrRVar thread_y, VarOrRVar thread_z) {
-        return gpu_threads(thread_x, thread_y, thread_z);
-    }
-    // @}
-
     /** Tell Halide that the following dimensions correspond to GPU
      * block indices. This is useful for scheduling stages that will
      * run serially within each GPU block. If the selected target is
@@ -1422,19 +1409,6 @@ public:
     EXPORT Func &gpu_blocks(VarOrRVar block_x, DeviceAPI device_api = DeviceAPI::Default_GPU);
     EXPORT Func &gpu_blocks(VarOrRVar block_x, VarOrRVar block_y, DeviceAPI device_api = DeviceAPI::Default_GPU);
     EXPORT Func &gpu_blocks(VarOrRVar block_x, VarOrRVar block_y, VarOrRVar block_z, DeviceAPI device_api = DeviceAPI::Default_GPU);
-    // @}
-
-    /** \deprecated Old name for #gpu_blocks. */
-    // @{
-    EXPORT Func &cuda_blocks(VarOrRVar block_x) {
-        return gpu_blocks(block_x);
-    }
-    EXPORT Func &cuda_blocks(VarOrRVar block_x, VarOrRVar block_y) {
-        return gpu_blocks(block_x, block_y);
-    }
-    EXPORT Func &cuda_blocks(VarOrRVar block_x, VarOrRVar block_y, VarOrRVar block_z) {
-        return gpu_blocks(block_x, block_y, block_z);
-    }
     // @}
 
     /** Tell Halide that the following dimensions correspond to GPU
@@ -1448,21 +1422,6 @@ public:
                      VarOrRVar thread_x, VarOrRVar thread_y, DeviceAPI device_api = DeviceAPI::Default_GPU);
     EXPORT Func &gpu(VarOrRVar block_x, VarOrRVar block_y, VarOrRVar block_z,
                      VarOrRVar thread_x, VarOrRVar thread_y, VarOrRVar thread_z, DeviceAPI device_api = DeviceAPI::Default_GPU);
-    // @}
-
-    /** \deprecated Old name for #gpu. */
-    // @{
-    EXPORT Func &cuda(VarOrRVar block_x, VarOrRVar thread_x) {
-        return gpu(block_x, thread_x);
-    }
-    EXPORT Func &cuda(VarOrRVar block_x, VarOrRVar block_y,
-                      VarOrRVar thread_x, VarOrRVar thread_y) {
-        return gpu(block_x, thread_x, block_y, thread_y);
-    }
-    EXPORT Func &cuda(VarOrRVar block_x, VarOrRVar block_y, VarOrRVar block_z,
-                      VarOrRVar thread_x, VarOrRVar thread_y, VarOrRVar thread_z) {
-        return gpu(block_x, thread_x, block_y, thread_y, block_z, thread_z);
-    }
     // @}
 
     /** Short-hand for tiling a domain and mapping the tile indices

--- a/src/Func.h
+++ b/src/Func.h
@@ -263,16 +263,16 @@ public:
                            TailStrategy tail = TailStrategy::Auto,
                            DeviceAPI device_api = DeviceAPI::Default_GPU);
 
-    // Will be deprecated.
+    HALIDE_ATTRIBUTE_DEPRECATED("This form of gpu_tile() is deprecated.") 
     EXPORT Stage &gpu_tile(VarOrRVar x, Expr x_size,
                            TailStrategy tail = TailStrategy::Auto,
                            DeviceAPI device_api = DeviceAPI::Default_GPU);
-    // Will be deprecated.
+    HALIDE_ATTRIBUTE_DEPRECATED("This form of gpu_tile() is deprecated.") 
     EXPORT Stage &gpu_tile(VarOrRVar x, VarOrRVar y,
                            Expr x_size, Expr y_size,
                            TailStrategy tail = TailStrategy::Auto,
                            DeviceAPI device_api = DeviceAPI::Default_GPU);
-    // Will be deprecated.
+    HALIDE_ATTRIBUTE_DEPRECATED("This form of gpu_tile() is deprecated.") 
     EXPORT Stage &gpu_tile(VarOrRVar x, VarOrRVar y, VarOrRVar z,
                            Expr x_size, Expr y_size, Expr z_size,
                            TailStrategy tail = TailStrategy::Auto,
@@ -1469,13 +1469,15 @@ public:
                           TailStrategy tail = TailStrategy::Auto,
                           DeviceAPI device_api = DeviceAPI::Default_GPU);
 
-    // Will be deprecated.
+    HALIDE_ATTRIBUTE_DEPRECATED("This form of gpu_tile() is deprecated.") 
     EXPORT Func &gpu_tile(VarOrRVar x, int x_size,
                           TailStrategy tail = TailStrategy::Auto,
                           DeviceAPI device_api = DeviceAPI::Default_GPU);
+    HALIDE_ATTRIBUTE_DEPRECATED("This form of gpu_tile() is deprecated.") 
     EXPORT Func &gpu_tile(VarOrRVar x, VarOrRVar y, int x_size, int y_size,
                           TailStrategy tail = TailStrategy::Auto,
                           DeviceAPI device_api = DeviceAPI::Default_GPU);
+    HALIDE_ATTRIBUTE_DEPRECATED("This form of gpu_tile() is deprecated.") 
     EXPORT Func &gpu_tile(VarOrRVar x, VarOrRVar y, VarOrRVar z,
                           int x_size, int y_size, int z_size,
                           TailStrategy tail = TailStrategy::Auto,

--- a/src/Func.h
+++ b/src/Func.h
@@ -263,16 +263,19 @@ public:
                            TailStrategy tail = TailStrategy::Auto,
                            DeviceAPI device_api = DeviceAPI::Default_GPU);
 
-    HALIDE_ATTRIBUTE_DEPRECATED("This form of gpu_tile() is deprecated.") 
+    // If we mark these as deprecated, some build environments will complain
+    // about the internal-only calls. Since these are rarely used outside
+    // Func itself, we'll just comment them as deprecated for now.
+    // HALIDE_ATTRIBUTE_DEPRECATED("This form of gpu_tile() is deprecated.") 
     EXPORT Stage &gpu_tile(VarOrRVar x, Expr x_size,
                            TailStrategy tail = TailStrategy::Auto,
                            DeviceAPI device_api = DeviceAPI::Default_GPU);
-    HALIDE_ATTRIBUTE_DEPRECATED("This form of gpu_tile() is deprecated.") 
+    // HALIDE_ATTRIBUTE_DEPRECATED("This form of gpu_tile() is deprecated.") 
     EXPORT Stage &gpu_tile(VarOrRVar x, VarOrRVar y,
                            Expr x_size, Expr y_size,
                            TailStrategy tail = TailStrategy::Auto,
                            DeviceAPI device_api = DeviceAPI::Default_GPU);
-    HALIDE_ATTRIBUTE_DEPRECATED("This form of gpu_tile() is deprecated.") 
+    // HALIDE_ATTRIBUTE_DEPRECATED("This form of gpu_tile() is deprecated.") 
     EXPORT Stage &gpu_tile(VarOrRVar x, VarOrRVar y, VarOrRVar z,
                            Expr x_size, Expr y_size, Expr z_size,
                            TailStrategy tail = TailStrategy::Auto,

--- a/src/Var.h
+++ b/src/Var.h
@@ -151,9 +151,11 @@ public:
 
     /** Vars to use for scheduling producer/consumer pairs on the gpu. Deprecated. */
     // @{
+    HALIDE_ATTRIBUTE_DEPRECATED("Var::gpu_blocks() is deprecated.") 
     static Var gpu_blocks() {
         return Var("__deprecated_block_id_x");
     }
+    HALIDE_ATTRIBUTE_DEPRECATED("Var::gpu_threads() is deprecated.") 
     static Var gpu_threads() {
         return Var("__deprecated_thread_id_x");
     }

--- a/test/correctness/gpu_give_input_buffers_device_allocations.cpp
+++ b/test/correctness/gpu_give_input_buffers_device_allocations.cpp
@@ -25,9 +25,9 @@ int main(int argc, char **argv) {
 
     // Run a pipeline that uses it as an input
     Func f;
-    Var x, y, tx, ty;
+    Var x, y, xi, yi;
     f(x, y) = in(x, y);
-    f.gpu_tile(x, y, tx, ty, 8, 8);
+    f.gpu_tile(x, y, xi, yi, 8, 8);
     Buffer<float> out = f.realize(100, 100);
 
     // Check the output has a device allocation, and was copied to

--- a/test/correctness/gpu_give_input_buffers_device_allocations.cpp
+++ b/test/correctness/gpu_give_input_buffers_device_allocations.cpp
@@ -25,9 +25,9 @@ int main(int argc, char **argv) {
 
     // Run a pipeline that uses it as an input
     Func f;
-    Var x, y;
+    Var x, y, tx, ty;
     f(x, y) = in(x, y);
-    f.gpu_tile(x, y, 8, 8);
+    f.gpu_tile(x, y, tx, ty, 8, 8);
     Buffer<float> out = f.realize(100, 100);
 
     // Check the output has a device allocation, and was copied to

--- a/test/correctness/gpu_jit_explicit_copy_to_device.cpp
+++ b/test/correctness/gpu_jit_explicit_copy_to_device.cpp
@@ -35,9 +35,9 @@ int main(int argc, char **argv) {
         assert(b.host_dirty());
 
         Func f;
-        Var x, y;
+        Var x, y, tx, ty;
         f(x, y) = a(x, y) + b(x, y) + 2;
-        f.gpu_tile(x, y, 8, 8, TailStrategy::Auto, d);
+        f.gpu_tile(x, y, tx, ty, 8, 8, TailStrategy::Auto, d);
 
         Buffer<float> out = f.realize(100, 100);
 

--- a/test/correctness/load_library.cpp
+++ b/test/correctness/load_library.cpp
@@ -71,11 +71,11 @@ int main(int argc, char **argv) {
     handlers.custom_get_library_symbol = my_get_library_symbol_impl;
     Internal::JITSharedRuntime::set_default_handlers(handlers);
 
-    Var x, y;
+    Var x, y, tx, ty;
     Func f;
     f(x, y) = cast<int32_t>(x + y);
     Target target = get_jit_target_from_environment().with_feature(Target::OpenCL);
-    f.gpu_tile(x, y, 8, 8, TailStrategy::Auto, DeviceAPI::OpenCL);
+    f.gpu_tile(x, y, tx, ty, 8, 8, TailStrategy::Auto, DeviceAPI::OpenCL);
     f.set_error_handler(my_error_handler);
 
     Buffer<int32_t> out = f.realize(64, 64, target);

--- a/test/correctness/load_library.cpp
+++ b/test/correctness/load_library.cpp
@@ -71,11 +71,11 @@ int main(int argc, char **argv) {
     handlers.custom_get_library_symbol = my_get_library_symbol_impl;
     Internal::JITSharedRuntime::set_default_handlers(handlers);
 
-    Var x, y, tx, ty;
+    Var x, y, xi, yi;
     Func f;
     f(x, y) = cast<int32_t>(x + y);
     Target target = get_jit_target_from_environment().with_feature(Target::OpenCL);
-    f.gpu_tile(x, y, tx, ty, 8, 8, TailStrategy::Auto, DeviceAPI::OpenCL);
+    f.gpu_tile(x, y, xi, yi, 8, 8, TailStrategy::Auto, DeviceAPI::OpenCL);
     f.set_error_handler(my_error_handler);
 
     Buffer<int32_t> out = f.realize(64, 64, target);

--- a/test/correctness/logical.cpp
+++ b/test/correctness/logical.cpp
@@ -94,10 +94,12 @@ int main(int argc, char **argv) {
         Target target = get_jit_target_from_environment();
 
         if (target.has_gpu_feature()) {
-            f.gpu_tile(x, y, 16, 16).vectorize(Var::gpu_threads(), 4);
+            f.gpu_tile(x, y, xi, yi, 16, 16).vectorize(xi, 4);
         } else if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
+assert(0);
             f.hexagon().vectorize(x, 128);
         } else {
+assert(0);
             f.vectorize(x, 128);
         }
 

--- a/test/correctness/logical.cpp
+++ b/test/correctness/logical.cpp
@@ -96,10 +96,8 @@ int main(int argc, char **argv) {
         if (target.has_gpu_feature()) {
             f.gpu_tile(x, y, xi, yi, 16, 16).vectorize(xi, 4);
         } else if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
-assert(0);
             f.hexagon().vectorize(x, 128);
         } else {
-assert(0);
             f.vectorize(x, 128);
         }
 

--- a/test/correctness/multiple_outputs.cpp
+++ b/test/correctness/multiple_outputs.cpp
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
     // An internal Func that produces multiple values.
     {
         Func f, g;
-        Var x, tx;
+        Var x, xi;
         f(x) = {x, sin(x)};
 
         f.compute_root();
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
         g(x) = t[0] + t[1];
 
         if (use_gpu) {
-            g.gpu_tile(x, tx, 8);
+            g.gpu_tile(x, xi, 8);
         }
 
         g.realize(100);
@@ -59,13 +59,13 @@ int main(int argc, char **argv) {
     // Now multiple output Funcs with different sizes
     {
         Func f, g;
-        Var x, tx;
+        Var x, xi;
         f(x) = 100*x;
         g(x) = x;
 
         if (use_gpu) {
-            f.gpu_tile(x, tx, 8);
-            g.gpu_tile(x, tx, 8);
+            f.gpu_tile(x, xi, 8);
+            g.gpu_tile(x, xi, 8);
         }
 
         Buffer<int> f_im(100);
@@ -96,13 +96,13 @@ int main(int argc, char **argv) {
     // Now multiple output Funcs via inferred Realization
     {
         Func f, g;
-        Var x, tx;
+        Var x, xi;
         f(x) = cast<float>(100*x);
         g(x) = Tuple(cast<uint8_t>(x), cast<int16_t>(x+1));
 
         if (use_gpu) {
-            f.gpu_tile(x, tx, 8);
-            g.gpu_tile(x, tx, 8);
+            f.gpu_tile(x, xi, 8);
+            g.gpu_tile(x, xi, 8);
         }
 
         Realization r = Pipeline({f, g}).realize(100);
@@ -135,14 +135,14 @@ int main(int argc, char **argv) {
     // Multiple output Funcs of different dimensionalities that call each other and some of them are Tuples.
     {
         Func f, g, h;
-        Var x, y, tx, ty;
+        Var x, y, xi, yi;
 
         f(x) = x;
         h(x) = {f(x) + 17, f(x) - 17};
         g(x, y) = {f(x + y) * 2, h(x)[0] * y, h(x)[1] - 2};
 
         if (get_jit_target_from_environment().has_gpu_feature()) {
-            g.gpu_tile(x, y, tx, ty, 1, 1);
+            g.gpu_tile(x, y, xi, yi, 1, 1);
         }
 
         Buffer<int> f_im(100), g_im0(20, 20), g_im1(20, 20), g_im2(20, 20), h_im0(50), h_im1(50);

--- a/test/correctness/multiple_outputs.cpp
+++ b/test/correctness/multiple_outputs.cpp
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
     // An internal Func that produces multiple values.
     {
         Func f, g;
-        Var x;
+        Var x, tx;
         f(x) = {x, sin(x)};
 
         f.compute_root();
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
         g(x) = t[0] + t[1];
 
         if (use_gpu) {
-            g.gpu_tile(x, 8);
+            g.gpu_tile(x, tx, 8);
         }
 
         g.realize(100);
@@ -59,13 +59,13 @@ int main(int argc, char **argv) {
     // Now multiple output Funcs with different sizes
     {
         Func f, g;
-        Var x;
+        Var x, tx;
         f(x) = 100*x;
         g(x) = x;
 
         if (use_gpu) {
-            f.gpu_tile(x, 8);
-            g.gpu_tile(x, 8);
+            f.gpu_tile(x, tx, 8);
+            g.gpu_tile(x, tx, 8);
         }
 
         Buffer<int> f_im(100);
@@ -96,13 +96,13 @@ int main(int argc, char **argv) {
     // Now multiple output Funcs via inferred Realization
     {
         Func f, g;
-        Var x;
+        Var x, tx;
         f(x) = cast<float>(100*x);
         g(x) = Tuple(cast<uint8_t>(x), cast<int16_t>(x+1));
 
         if (use_gpu) {
-            f.gpu_tile(x, 8);
-            g.gpu_tile(x, 8);
+            f.gpu_tile(x, tx, 8);
+            g.gpu_tile(x, tx, 8);
         }
 
         Realization r = Pipeline({f, g}).realize(100);
@@ -135,14 +135,14 @@ int main(int argc, char **argv) {
     // Multiple output Funcs of different dimensionalities that call each other and some of them are Tuples.
     {
         Func f, g, h;
-        Var x, y;
+        Var x, y, tx, ty;
 
         f(x) = x;
         h(x) = {f(x) + 17, f(x) - 17};
         g(x, y) = {f(x + y) * 2, h(x)[0] * y, h(x)[1] - 2};
 
         if (get_jit_target_from_environment().has_gpu_feature()) {
-            g.gpu_tile(x, y, 1, 1);
+            g.gpu_tile(x, y, tx, ty, 1, 1);
         }
 
         Buffer<int> f_im(100), g_im0(20, 20), g_im1(20, 20), g_im2(20, 20), h_im0(50), h_im1(50);

--- a/test/correctness/widening_reduction.cpp
+++ b/test/correctness/widening_reduction.cpp
@@ -24,7 +24,7 @@ int main(int arch, char **argv) {
         }
     }
 
-    Var x("x"), y("y");
+    Var x("x"), y("y"), tx("tx"), ty("ty");
     RDom r(-1, 3, -1, 3);
 
     // Boundary condition.
@@ -39,7 +39,7 @@ int main(int arch, char **argv) {
         // Schedule.
         Target target = get_jit_target_from_environment();
         if (target.has_gpu_feature()) {
-            f.gpu_tile(x, y, 16, 16);
+            f.gpu_tile(x, y, tx, ty, 16, 16);
         } else if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
             f.hexagon().vectorize(x, 128);
         } else {
@@ -81,7 +81,7 @@ int main(int arch, char **argv) {
         // Schedule.
         Target target = get_jit_target_from_environment();
         if (target.has_gpu_feature()) {
-            g.gpu_tile(x, y, 16, 16);
+            g.gpu_tile(x, y, tx, ty, 16, 16);
         } else if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
             g.hexagon().vectorize(x, 128);
         } else {

--- a/test/correctness/widening_reduction.cpp
+++ b/test/correctness/widening_reduction.cpp
@@ -24,7 +24,7 @@ int main(int arch, char **argv) {
         }
     }
 
-    Var x("x"), y("y"), tx("tx"), ty("ty");
+    Var x("x"), y("y"), xi("xi"), yi("yi");
     RDom r(-1, 3, -1, 3);
 
     // Boundary condition.
@@ -39,7 +39,7 @@ int main(int arch, char **argv) {
         // Schedule.
         Target target = get_jit_target_from_environment();
         if (target.has_gpu_feature()) {
-            f.gpu_tile(x, y, tx, ty, 16, 16);
+            f.gpu_tile(x, y, xi, yi, 16, 16);
         } else if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
             f.hexagon().vectorize(x, 128);
         } else {
@@ -81,7 +81,7 @@ int main(int arch, char **argv) {
         // Schedule.
         Target target = get_jit_target_from_environment();
         if (target.has_gpu_feature()) {
-            g.gpu_tile(x, y, tx, ty, 16, 16);
+            g.gpu_tile(x, y, xi, yi, 16, 16);
         } else if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
             g.hexagon().vectorize(x, 128);
         } else {


### PR DESCRIPTION
These have been deprecated for ~3 years now; I think we should let them
go now.

(Side note: three variants of gpu_tile() in this file are marked as
“will be deprecated” — we should mark them as such if they really are)