### PR TITLE
Metal: Use setBytes:length:atIndex for arguments

### DIFF
--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -212,8 +212,8 @@ WEAK module_state *state_list = NULL;
 
 // API Capabilities.  If more capabilities need to be checked,
 // this can be refactored to something more robust/general.
-bool halide_metal_api_supports_set_bytes;
-mtl_device *halide_metal_api_checked_device;
+WEAK bool metal_api_supports_set_bytes;
+WEAK mtl_device *metal_api_checked_device;
 
 }}}}
 
@@ -688,15 +688,15 @@ WEAK int halide_metal_run(void *user_context,
         uint8_t small_args_buffer[4096];    // used if the total arguments size is small
         char *args_ptr;
 
-        if (halide_metal_api_checked_device != metal_context.device) {
-            halide_metal_api_supports_set_bytes = buffer_supports_set_bytes(encoder);
-            halide_metal_api_checked_device = metal_context.device;
-            if (halide_metal_api_supports_set_bytes) {
+        if (metal_api_checked_device != metal_context.device) {
+            metal_api_supports_set_bytes = buffer_supports_set_bytes(encoder);
+            metal_api_checked_device = metal_context.device;
+            if (metal_api_supports_set_bytes) {
                 debug(user_context) << "Metal - supports setBytes\n";
             }
         }
 
-        if (total_args_size < 4096 && halide_metal_api_supports_set_bytes) {
+        if (total_args_size < 4096 && metal_api_supports_set_bytes) {
             args_ptr = (char *)small_args_buffer;
         } else {
             args_buffer = new_buffer(metal_context.device, total_args_size);
@@ -717,7 +717,7 @@ WEAK int halide_metal_run(void *user_context,
             }
         }
         halide_assert(user_context, offset == total_args_size);
-        if (total_args_size < 4096 && halide_metal_api_supports_set_bytes) {
+        if (total_args_size < 4096 && metal_api_supports_set_bytes) {
             set_input_buffer_from_bytes(encoder, small_args_buffer,
                                         total_args_size, buffer_index);
         } else {

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -673,17 +673,10 @@ WEAK int halide_metal_run(void *user_context,
     int32_t buffer_index = 0;
     if (total_args_size > 0) {
         mtl_buffer *args_buffer = 0;        // used if the total arguments size large
-        uint8_t *small_args_buffer = 0;     // used if the total arguments size is small
+        uint8_t small_args_buffer[4096];    // used if the total arguments size is small
         char *args_ptr;
 
         if (total_args_size < 4096) {
-            small_args_buffer = (uint8_t*)malloc(sizeof(uint8_t) * total_args_size);
-            if (small_args_buffer == 0) {
-                error(user_context) << "Metal: Could not allocate (small) arguments buffer.\n";
-                release_ns_object(pipeline_state);
-                release_ns_object(function);
-                return -1;
-            }
             args_ptr = (char *)small_args_buffer;
         } else {
             args_buffer = new_buffer(metal_context.device, total_args_size);
@@ -707,7 +700,6 @@ WEAK int halide_metal_run(void *user_context,
         if (total_args_size < 4096) {
             set_input_buffer_from_bytes(encoder, small_args_buffer,
                                         total_args_size, buffer_index);
-            free(small_args_buffer);
         } else {
             set_input_buffer(encoder, args_buffer, buffer_index);
             release_ns_object(args_buffer);

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -117,6 +117,13 @@ WEAK void end_encoding(mtl_blit_command_encoder *encoder) {
     objc_msgSend(encoder, sel_getUid("endEncoding"));
 }
 
+WEAK bool buffer_supports_set_bytes(mtl_compute_command_encoder *encoder) {
+    typedef bool (*responds_to_selector_method)(objc_id obj, objc_sel sel_1, objc_sel sel_2);
+    responds_to_selector_method method1 = (responds_to_selector_method)&objc_msgSend;
+    objc_sel set_bytes_sel = sel_getUid("setBytes:length:atIndex:");
+    return (*method1)(encoder, sel_getUid("respondsToSelector:"), set_bytes_sel);
+}
+
 WEAK mtl_library *new_library_with_source(mtl_device *device, const char *source, size_t source_len) {
     objc_id error_return;
     objc_id source_str = wrap_string_as_ns_string(source, source_len);
@@ -202,6 +209,11 @@ struct module_state {
     module_state *next;
 };
 WEAK module_state *state_list = NULL;
+
+// API Capabilities.  If more capabilities need to be checked,
+// this can be refactored to something more robust/general.
+bool halide_metal_api_supports_set_bytes;
+mtl_device *halide_metal_api_checked_device;
 
 }}}}
 
@@ -676,7 +688,15 @@ WEAK int halide_metal_run(void *user_context,
         uint8_t small_args_buffer[4096];    // used if the total arguments size is small
         char *args_ptr;
 
-        if (total_args_size < 4096) {
+        if (halide_metal_api_checked_device != metal_context.device) {
+            halide_metal_api_supports_set_bytes = buffer_supports_set_bytes(encoder);
+            halide_metal_api_checked_device = metal_context.device;
+            if (halide_metal_api_supports_set_bytes) {
+                debug(user_context) << "Metal - supports setBytes\n";
+            }
+        }
+
+        if (total_args_size < 4096 && halide_metal_api_supports_set_bytes) {
             args_ptr = (char *)small_args_buffer;
         } else {
             args_buffer = new_buffer(metal_context.device, total_args_size);
@@ -697,7 +717,7 @@ WEAK int halide_metal_run(void *user_context,
             }
         }
         halide_assert(user_context, offset == total_args_size);
-        if (total_args_size < 4096) {
+        if (total_args_size < 4096 && halide_metal_api_supports_set_bytes) {
             set_input_buffer_from_bytes(encoder, small_args_buffer,
                                         total_args_size, buffer_index);
         } else {


### PR DESCRIPTION
Instead of allocating a temporary `MTLBuffer`, if the arguments
size is less than 4KB, use `setBytes:length:atIndex`.  
See https://developer.apple.com/reference/metal/mtlcomputecommandencoder/1443159-setbytes?language=objc#discussion for more information.

This change should never be slower than the existing approach, and helps remove one source of overhead for small pipelines.

CC @estollnitz 