### PR TITLE
Use open instead of fopen in write_debug_image.

### DIFF
--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -50,7 +50,11 @@ typedef int32_t intptr_t;
 #define STDERR_FILENO 2
 
 #define O_RDONLY 0
+#define O_WRONLY 1
 #define O_RDWR 2
+#define O_CREAT 64
+#define O_TRUNC 512
+#define O_APPEND 1024
 
 // Commonly-used extern functions
 extern "C" {

--- a/src/runtime/tracing.cpp
+++ b/src/runtime/tracing.cpp
@@ -180,9 +180,6 @@ WEAK void halide_set_trace_file(int fd) {
 
 extern int errno;
 
-#define O_APPEND 1024
-#define O_CREAT 64
-#define O_WRONLY 1
 WEAK int halide_get_trace_file(void *user_context) {
     // Prevent multiple threads both trying to initialize the trace
     // file at the same time.

--- a/src/runtime/write_debug_image.cpp
+++ b/src/runtime/write_debug_image.cpp
@@ -1,8 +1,5 @@
+#include "runtime_internal.h"
 #include "HalideRuntime.h"
-
-extern "C" void *fopen(const char *, const char *);
-extern "C" int fclose(void *);
-extern "C" size_t fwrite(const void *, size_t, size_t, void *);
 
 // Use TIFF because it meets the following criteria:
 // - Supports uncompressed data
@@ -114,6 +111,11 @@ WEAK uint8_t *get_pointer_to_data(int32_t dim0, int32_t dim1, int32_t dim2, int3
 
 }}} // namespace Halide::Runtime::Internal
 
+// We need a helper function that converts the return value to bool.
+static bool write_helper(int fd, void *ptr, ssize_t size) {
+    return write(fd, ptr, size) == size;
+}
+
 WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *filename,
                                              int32_t type_code, struct halide_buffer_t *buf) {
 
@@ -124,8 +126,8 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
 
     halide_copy_to_host(user_context, buf);
 
-    void *f = fopen(filename, "wb");
-    if (!f) return -1;
+    int f = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (f == -1) return -1;
 
     int32_t s0 = buf->dimensions > 0 ? buf->dim[0].extent : 1;
     int32_t s1 = buf->dimensions > 1 ? buf->dim[1].extent : 1;
@@ -192,8 +194,8 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
         header.height_resolution[0] = 1;
         header.height_resolution[1] = 1;
 
-        if (!fwrite((void *)(&header), sizeof(header), 1, f)) {
-            fclose(f);
+        if (!write_helper(f, (void *)(&header), sizeof(header))) {
+            close(f);
             return -2;
         }
 
@@ -201,24 +203,24 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
           int32_t offset = sizeof(header) + channels * sizeof(int32_t) * 2;
 
           for (int32_t i = 0; i < channels; i++) {
-              if (!fwrite((void*)(&offset), 4, 1, f)) {
-                  fclose(f);
+              if (write_helper(f, (void*)(&offset), 4)) {
+                  close(f);
                   return -2;
               }
               offset += s0 * s1 * depth * bytes_per_element;
           }
           int32_t count = s0 * s1 * depth;
           for (int32_t i = 0; i < channels; i++) {
-              if (!fwrite((void*)(&count), 4, 1, f)) {
-                  fclose(f);
+              if (!write_helper(f, (void*)(&count), 4)) {
+                  close(f);
                   return -2;
               }
           }
         }
     } else {
         int32_t header[] = {s0, s1, s2, s3, type_code};
-        if (!fwrite((void *)(&header[0]), sizeof(header), 1, f)) {
-            fclose(f);
+        if (!write_helper(f, (void *)(&header[0]), sizeof(header))) {
+            close(f);
             return -2;
         }
     }
@@ -241,8 +243,8 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
 
                     if (counter == max_elts) {
                         counter = 0;
-                        if (!fwrite((void *)temp, max_elts*bytes_per_element, 1, f)) {
-                            fclose(f);
+                        if (!write_helper(f, (void *)temp, max_elts*bytes_per_element)) {
+                            close(f);
                             return -1;
                         }
                     }
@@ -251,12 +253,12 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
         }
     }
     if (counter > 0) {
-        if (!fwrite((void *)temp, counter*bytes_per_element, 1, f)) {
-            fclose(f);
+        if (!write_helper(f, (void *)temp, counter*bytes_per_element)) {
+            close(f);
             return -1;
         }
     }
-    fclose(f);
+    close(f);
 
     return 0;
 }

--- a/src/runtime/write_debug_image.cpp
+++ b/src/runtime/write_debug_image.cpp
@@ -109,12 +109,12 @@ WEAK uint8_t *get_pointer_to_data(int32_t dim0, int32_t dim1, int32_t dim2, int3
     return ptr;
 }
 
-}}} // namespace Halide::Runtime::Internal
-
 // We need a helper function that converts the return value to bool.
-static bool write_helper(int fd, void *ptr, ssize_t size) {
+WEAK bool write_helper(int fd, void *ptr, ssize_t size) {
     return write(fd, ptr, size) == size;
 }
+
+}}} // namespace Halide::Runtime::Internal
 
 WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *filename,
                                              int32_t type_code, struct halide_buffer_t *buf) {


### PR DESCRIPTION
This PR changes write_debug_image to use open instead of fopen. It appears that open is available on Hexagon on 8998, but fopen is not.