### PR TITLE
Make LoopLevel a refcounted-contents type

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2312,7 +2312,7 @@ Func &Func::store_root() {
 }
 
 Func &Func::compute_inline() {
-    return compute_at(LoopLevel());
+    return compute_at(LoopLevel::inlined());
 }
 
 Func &Func::trace_loads() {

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -742,16 +742,11 @@ std::string halide_type_to_c_type(const Type &t) {
     return m.at(encode(t));
 }
 
-LoopLevel get_halide_undefined_looplevel() {
-    static LoopLevel undefined(Func("__undefined_looplevel_func"), Var("__undefined_looplevel_var"));
-    return undefined;
-}
-
 const std::map<std::string, LoopLevel> &get_halide_looplevel_enum_map() {
     static const std::map<std::string, LoopLevel> halide_looplevel_enum_map{
         {"root", LoopLevel::root()},
-        {"undefined", get_halide_undefined_looplevel()},
-        {"inline", LoopLevel()},
+        {"undefined", LoopLevel()},
+        {"inline", LoopLevel::inlined()},
     };
     return halide_looplevel_enum_map;
 }

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -274,7 +274,6 @@ inline std::string halide_type_to_enum_string(const Type &t) {
     return enum_to_string(get_halide_type_enum_map(), t);
 }
 
-EXPORT extern Halide::LoopLevel get_halide_undefined_looplevel();
 EXPORT extern const std::map<std::string, Halide::LoopLevel> &get_halide_looplevel_enum_map();
 inline std::string halide_looplevel_to_enum_string(const LoopLevel &loop_level){
     return enum_to_string(get_halide_looplevel_enum_map(), loop_level);
@@ -705,9 +704,9 @@ public:
     }
 
     std::string get_default_value() const override {
-        if (def == "undefined") return "Halide::Internal::get_halide_undefined_looplevel()";
+        if (def == "undefined") return "LoopLevel()";
         if (def == "root") return "LoopLevel::root()";
-        if (def == "inline") return "LoopLevel()";
+        if (def == "inline") return "LoopLevel::inlined()";
         user_error << "LoopLevel value " << def << " not found.\n";
         return "";
     }
@@ -717,7 +716,7 @@ public:
     }
 
     bool defined() const {
-        return this->value() != get_halide_undefined_looplevel();
+        return this->value().defined();
     }
 
 private:

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -7,24 +7,66 @@
 
 namespace Halide {
 
-LoopLevel::LoopLevel(const std::string &func_name,
-                     const std::string &var_name,
-                     bool is_rvar)
+namespace Internal {
+
+struct LoopLevelContents {
+    mutable RefCount ref_count;
+
+    // Note: func_ is empty for inline or root.
+    std::string func_name;
+    // TODO: these two fields should really be VarOrRVar,
+    // but cyclical include dependencies make this challenging.
+    std::string var_name;
+    bool is_rvar;
+
+    LoopLevelContents(const std::string &func_name,
+                      const std::string &var_name,
+                      bool is_rvar)
     : func_name(func_name), var_name(var_name), is_rvar(is_rvar) {}
+};
+
+template<>
+EXPORT RefCount &ref_count<LoopLevelContents>(const LoopLevelContents *p) {
+    return p->ref_count;
+}
+
+template<>
+EXPORT void destroy<LoopLevelContents>(const LoopLevelContents *p) {
+    delete p;
+}
+
+}  // namespace Internal
+
+LoopLevel::LoopLevel(const std::string &func_name, const std::string &var_name, bool is_rvar) 
+    : contents(new Internal::LoopLevelContents(func_name, var_name, is_rvar)) {}
+
 LoopLevel::LoopLevel(Internal::Function f, VarOrRVar v) : LoopLevel(f.name(), v.name(), v.is_rvar) {}
+
 LoopLevel::LoopLevel(Func f, VarOrRVar v) : LoopLevel(f.function().name(), v.name(), v.is_rvar) {}
 
+bool LoopLevel::defined() const {
+    return contents.defined();
+}
+
 std::string LoopLevel::func() const {
-    return func_name;
+    internal_assert(defined());
+    return contents->func_name;
 }
 
 VarOrRVar LoopLevel::var() const {
+    internal_assert(defined());
     internal_assert(!is_inline() && !is_root());
-    return VarOrRVar(var_name, is_rvar);
+    return VarOrRVar(contents->var_name, contents->is_rvar);
+}
+
+/*static*/
+LoopLevel LoopLevel::inlined() {
+    return LoopLevel("", "", false);
 }
 
 bool LoopLevel::is_inline() const {
-    return var_name.empty();
+    internal_assert(defined());
+    return contents->var_name.empty();
 }
 
 /*static*/
@@ -33,27 +75,33 @@ LoopLevel LoopLevel::root() {
 }
 
 bool LoopLevel::is_root() const {
-    return var_name == "__root";
+    internal_assert(defined());
+    return contents->var_name == "__root";
 }
 
 std::string LoopLevel::to_string() const {
-    return func_name + "." + var_name;
+    internal_assert(defined());
+    return contents->func_name + "." + contents->var_name;
 }
 
 bool LoopLevel::match(const std::string &loop) const {
-    return Internal::starts_with(loop, func_name + ".") &&
-           Internal::ends_with(loop, "." + var_name);
+    internal_assert(defined());
+    return Internal::starts_with(loop, contents->func_name + ".") &&
+           Internal::ends_with(loop, "." + contents->var_name);
 }
 
 bool LoopLevel::match(const LoopLevel &other) const {
-    return (func_name == other.func_name &&
-            (var_name == other.var_name ||
-             Internal::ends_with(var_name, "." + other.var_name) ||
-             Internal::ends_with(other.var_name, "." + var_name)));
+    internal_assert(defined());
+    return (contents->func_name == other.contents->func_name &&
+            (contents->var_name == other.contents->var_name ||
+             Internal::ends_with(contents->var_name, "." + other.contents->var_name) ||
+             Internal::ends_with(other.contents->var_name, "." + contents->var_name)));
 }
 
 bool LoopLevel::operator==(const LoopLevel &other) const {
-    return func_name == other.func_name && var_name == other.var_name;
+    internal_assert(defined());
+    return contents->func_name == other.contents->func_name && 
+           contents->var_name == other.contents->var_name;
 }
 
 namespace Internal {
@@ -81,7 +129,8 @@ struct ScheduleContents {
     bool touched;
     bool allow_race_conditions;
 
-    ScheduleContents() : memoized(false), touched(false), allow_race_conditions(false) {};
+    ScheduleContents() : store_level(LoopLevel::inlined()), compute_level(LoopLevel::inlined()), 
+    memoized(false), touched(false), allow_race_conditions(false) {};
 
     // Pass an IRMutator through to all Exprs referenced in the ScheduleContents
     void mutate(IRMutator *mutator) {

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -99,8 +99,8 @@ bool LoopLevel::match(const LoopLevel &other) const {
 }
 
 bool LoopLevel::operator==(const LoopLevel &other) const {
-    internal_assert(defined());
-    return contents->func_name == other.contents->func_name && 
+    return defined() == other.defined() &&
+           contents->func_name == other.contents->func_name && 
            contents->var_name == other.contents->var_name;
 }
 

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -106,7 +106,7 @@ public:
     // @}
 
     /** Construct an undefined LoopLevel. Calling any method on an undefined
-     * LoopLevel (other than defined()) will assert. */
+     * LoopLevel (other than defined() or operator==) will assert. */
     LoopLevel() = default;
 
     /** Return true iff the LoopLevel is defined. */

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -18,6 +18,7 @@ struct VarOrRVar;
 namespace Internal {
 class Function;
 struct FunctionContents;
+struct LoopLevelContents;
 }  // namespace Internal
 
 /** Different ways to handle a tail case in a split when the
@@ -92,13 +93,9 @@ enum class PrefetchBoundStrategy {
  * recursively injecting realizations for them at particular sites
  * in this loop nest. A LoopLevel identifies such a site. */
 class LoopLevel {
-    // Note: func_ is nullptr for inline or root.
-    std::string func_name;
-    // TODO: these two fields should really be VarOrRVar,
-    // but cyclical include dependencies make this challenging.
-    std::string var_name;
-    bool is_rvar;
+    Internal::IntrusivePtr<Internal::LoopLevelContents> contents;
 
+    explicit LoopLevel(Internal::IntrusivePtr<Internal::LoopLevelContents> c) : contents(c) {}
     EXPORT LoopLevel(const std::string &func_name, const std::string &var_name, bool is_rvar);
 
 public:
@@ -108,16 +105,22 @@ public:
     EXPORT LoopLevel(Func f, VarOrRVar v);
     // @}
 
-    /** Construct an empty LoopLevel, which is interpreted as
-     * 'inline'. This is a special LoopLevel value that implies
-     * that a function should be inlined away */
-    LoopLevel() : func_name(""), var_name(""), is_rvar(false) {}
+    /** Construct an undefined LoopLevel. Calling any method on an undefined
+     * LoopLevel (other than defined()) will assert. */
+    LoopLevel() = default;
+
+    /** Return true iff the LoopLevel is defined. */
+    EXPORT bool defined() const;
 
     /** Return the Func name. Asserts if the LoopLevel is_root() or is_inline(). */
     EXPORT std::string func() const;
 
     /** Return the VarOrRVar. Asserts if the LoopLevel is_root() or is_inline(). */
     EXPORT VarOrRVar var() const;
+
+    /** inlined is a special LoopLevel value that implies
+     * that a function should be inlined away. */
+    EXPORT static LoopLevel inlined();
 
     /** Test if a loop level corresponds to inlining the function */
     EXPORT bool is_inline() const;


### PR DESCRIPTION
The motivation here is to make it easier to implement
ScheduleParam<LoopLevel> in a way that allows deferred setting of
values. Note that the default ctor for LoopLevel now produces an
*undefined* LoopLevel (which didn’t exist before); to get an “inline”
LoopLevel you must now use the LoopLevel::inlined() method (similar to
the previous LoopLevel::root() method).