### PR TITLE
Our open flags were linux-specific. Use the more portable fopen instead

### DIFF
--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -569,7 +569,7 @@ void add_underscore_to_posix_call(llvm::CallInst *call, llvm::Function *fn, llvm
  * of mcjit, so we just rewrite uses of these functions to include an
  * underscore. */
 void add_underscores_to_posix_calls_on_windows(llvm::Module *m) {
-    string posix_fns[] = {"vsnprintf", "open", "close", "write"};
+    string posix_fns[] = {"vsnprintf", "open", "close", "write", "fileno"};
 
     string *posix_fns_begin = posix_fns;
     string *posix_fns_end = posix_fns + sizeof(posix_fns) / sizeof(posix_fns[0]);

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -71,9 +71,9 @@ const char *strchr(const char* s, int c);
 void* memcpy(void* s1, const void* s2, size_t n);
 int memcmp(const void* s1, const void* s2, size_t n);
 void *memset(void *s, int val, size_t n);
-void *fopen(const char *, const char *);
 // Use fopen+fileno+fclose instead of open+close - the value of the
 // flags passed to open are different on every platform
+void *fopen(const char *, const char *);
 int fileno(void *); 
 int fclose(void *);
 int close(int);

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -49,9 +49,6 @@ typedef int32_t intptr_t;
 #define STDOUT_FILENO 1
 #define STDERR_FILENO 2
 
-#define O_RDONLY 0
-#define O_RDWR 2
-
 // Commonly-used extern functions
 extern "C" {
 void *halide_malloc(void *user_context, size_t x);
@@ -74,8 +71,13 @@ const char *strchr(const char* s, int c);
 void* memcpy(void* s1, const void* s2, size_t n);
 int memcmp(const void* s1, const void* s2, size_t n);
 void *memset(void *s, int val, size_t n);
-int open(const char *filename, int opts, int mode);
-int close(int fd);
+void *fopen(const char *, const char *);
+// Use fopen+fileno+fclose instead of open+close - the value of the
+// flags passed to open are different on every platform
+int fileno(void *); 
+int fclose(void *);
+int close(int);
+size_t fwrite(const void *, size_t, size_t, void *);
 ssize_t write(int fd, const void *buf, size_t bytes);
 int remove(const char *pathname);
 int ioctl(int fd, unsigned long request, ...);

--- a/src/runtime/tracing.cpp
+++ b/src/runtime/tracing.cpp
@@ -13,7 +13,7 @@ namespace Halide { namespace Runtime { namespace Internal {
 WEAK int halide_trace_file = 0;
 WEAK int halide_trace_file_lock = 0;
 WEAK bool halide_trace_file_initialized = false;
-WEAK bool halide_trace_file_internally_opened = false;
+WEAK void *halide_trace_file_internally_opened = NULL;
 
 WEAK int32_t default_trace(void *user_context, const halide_trace_event_t *e) {
     static int32_t ids = 1;
@@ -180,9 +180,6 @@ WEAK void halide_set_trace_file(int fd) {
 
 extern int errno;
 
-#define O_APPEND 1024
-#define O_CREAT 64
-#define O_WRONLY 1
 WEAK int halide_get_trace_file(void *user_context) {
     // Prevent multiple threads both trying to initialize the trace
     // file at the same time.
@@ -190,10 +187,10 @@ WEAK int halide_get_trace_file(void *user_context) {
     if (!halide_trace_file_initialized) {
         const char *trace_file_name = getenv("HL_TRACE_FILE");
         if (trace_file_name) {
-            int fd = open(trace_file_name, O_APPEND | O_CREAT | O_WRONLY, 0644);
-            halide_assert(user_context, (fd > 0) && "Failed to open trace file\n");
-            halide_set_trace_file(fd);
-            halide_trace_file_internally_opened = true;
+            void *file = fopen(trace_file_name, "ab");
+            halide_assert(user_context, file && "Failed to open trace file\n");
+            halide_set_trace_file(fileno(file));
+            halide_trace_file_internally_opened = file;
         } else {
             halide_set_trace_file(0);
         }
@@ -207,10 +204,10 @@ WEAK int32_t halide_trace(void *user_context, const halide_trace_event_t *e) {
 
 WEAK int halide_shutdown_trace() {
     if (halide_trace_file_internally_opened) {
-        int ret = close(halide_trace_file);
+        int ret = fclose(halide_trace_file_internally_opened);
         halide_trace_file = 0;
         halide_trace_file_initialized = false;
-        halide_trace_file_internally_opened = false;
+        halide_trace_file_internally_opened = NULL;
         return ret;
     } else {
         return 0;

--- a/src/runtime/write_debug_image.cpp
+++ b/src/runtime/write_debug_image.cpp
@@ -1,9 +1,5 @@
 #include "HalideRuntime.h"
 
-extern "C" void *fopen(const char *, const char *);
-extern "C" int fclose(void *);
-extern "C" size_t fwrite(const void *, size_t, size_t, void *);
-
 // Use TIFF because it meets the following criteria:
 // - Supports uncompressed data
 // - Supports 3D images as well as 2D


### PR DESCRIPTION
binary tracing to a file was broken on other platforms. It's only used for generating visualizations, so I didn't notice until #1957 