### PR TITLE
Don't use swap in our move constructors

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -599,8 +599,11 @@ public:
     template<typename T2, int D2>
     Buffer<T, D> &operator=(Buffer<T2, D2> &&other) {
         assert_can_convert_from(other);
-        std::swap(alloc, other.alloc);
-        std::swap(dev_ref_count, other.dev_ref_count);
+        decref();
+        alloc = other.alloc;
+        other.alloc = nullptr;
+        dev_ref_count = other.dev_ref_count;
+        other.dev_ref_count = nullptr;
         free_shape_storage();
         buf = other.buf;
         move_shape_from(std::forward<Buffer<T2, D2>>(other));
@@ -609,8 +612,11 @@ public:
 
     /** Standard move-assignment operator */
     Buffer<T, D> &operator=(Buffer<T, D> &&other) {
-        std::swap(alloc, other.alloc);
-        std::swap(dev_ref_count, other.dev_ref_count);
+        decref();
+        alloc = other.alloc;
+        other.alloc = nullptr;
+        dev_ref_count = other.dev_ref_count;
+        other.dev_ref_count = nullptr;
         free_shape_storage();
         buf = other.buf;
         move_shape_from(std::forward<Buffer<T, D>>(other));


### PR DESCRIPTION
The Buffer move constructors partially used swap (for alloc and
dev_ref_count) and partially used direct copying (for buf). This is
fishy in the case where the buffer being moved into already owns a
device allocation. The ownership may get swapped to the dying buffer but
the dev field may not.