### PR TITLE
msan_generator should specify NameMangling::C

### DIFF
--- a/test/generator/msan_generator.cpp
+++ b/test/generator/msan_generator.cpp
@@ -11,7 +11,7 @@ public:
         input(x, y, c) = cast<int32_t>(x + y + c);
 
         // This just makes an exact copy
-        msan_extern_stage.define_extern("msan_extern_stage", {input}, Int(32), 3);
+        msan_extern_stage.define_extern("msan_extern_stage", {input}, Int(32), 3, NameMangling::C);
 
         RDom r(0, 4);
         msan_output(x, y, c) = sum(msan_extern_stage(r, y, c));


### PR DESCRIPTION
NameMangling::Default leaves it at the mercy of what’s in the Target,
which can differ between Makefile and Bazel (the latter defaults to c++
mangling on).