### PR TITLE
Fix a bug that overwrote a part of the mattrs string on Hexagon.

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1282,11 +1282,12 @@ string CodeGen_Hexagon::mcpu() const {
 }
 
 string CodeGen_Hexagon::mattrs() const {
-    std::stringstream attrs("+hvx");
+    std::stringstream attrs;
     if (target.has_feature(Halide::Target::HVX_128)) {
-        attrs << ",+hvx-double";
+        attrs << "+hvx-double";
+    } else {
+        attrs << "+hvx";
     }
-    attrs.seekp(0, std::ios_base::end);
     attrs << ",+long-calls";
     return attrs.str();
 }

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1286,6 +1286,7 @@ string CodeGen_Hexagon::mattrs() const {
     if (target.has_feature(Halide::Target::HVX_128)) {
         attrs << ",+hvx-double";
     }
+    attrs.seekp(0, std::ios_base::end);
     attrs << ",+long-calls";
     return attrs.str();
 }


### PR DESCRIPTION
This is sort of a latent bug; the reason this piece of code has worked
for so long is that when mcpu is hexagonv60 it has _always_ implied
hvx support. This may not always be true going forward.

The std::stringstream constructor puts the "put" pointer at the start
or 0. So, the very next call to "<<" will overwrite the contents that
the stream was constructed with. However, subsequent calls to "<<" will
work fine.