### PR TITLE
Alternative fix for interleaved pngs

### DIFF
--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -289,6 +289,9 @@ bool save_png(ImageType &im, const std::string &filename) {
 
     Internal::PngRowPointers row_pointers(im.height(), png_get_rowbytes(png_ptr, info_ptr));
 
+    // We don't require that the image type provided has any
+    // particular way to get at the strides, so take differences of
+    // addresses of pixels to compute them.
     int c_stride = (im.channels() == 1) ? 0 : ((&im(0, 0, 1)) - (&im(0, 0, 0)));
     int x_stride = (int)((&im(1, 0, 0)) - (&im(0, 0, 0)));
     typename ImageType::ElemType *srcPtr = (typename ImageType::ElemType*)im.data();

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -289,9 +289,8 @@ bool save_png(ImageType &im, const std::string &filename) {
 
     Internal::PngRowPointers row_pointers(im.height(), png_get_rowbytes(png_ptr, info_ptr));
 
-    // im.copyToHost(); // in case the image is on the gpu
-
     int c_stride = (im.channels() == 1) ? 0 : ((&im(0, 0, 1)) - (&im(0, 0, 0)));
+    int x_stride = (int)((&im(1, 0, 0)) - (&im(0, 0, 0)));
     typename ImageType::ElemType *srcPtr = (typename ImageType::ElemType*)im.data();
 
     for (int y = 0; y < im.height(); y++) {
@@ -305,7 +304,7 @@ bool save_png(ImageType &im, const std::string &filename) {
                     *dstPtr++ = out >> 8;
                     *dstPtr++ = out & 0xff;
                 }
-                srcPtr++;
+                srcPtr += x_stride;
             }
         } else if (bit_depth == 8) {
             // convert to uint8_t
@@ -315,7 +314,7 @@ bool save_png(ImageType &im, const std::string &filename) {
                     Internal::convert(srcPtr[c*c_stride], out);
                     *dstPtr++ = out;
                 }
-                srcPtr++;
+                srcPtr += x_stride;
             }
         } else {
             if (!check(bit_depth == 8 || bit_depth == 16, "We only support saving 8- and 16-bit images.")) return false;


### PR DESCRIPTION
Fixes mingw build bot, which was the only one that caught the out-of-bounds reads.

@srj I did it this way to avoid requiring a dim(int).min() method on the image type. Is that silly? I doubt anyone is using this for anything other than Halide::Buffer or Halide::Runtime::Buffer.