### PR TITLE
Upgrade binary2cpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -746,17 +746,17 @@ $(BUILD_DIR)/initmod.%.bc: $(BUILD_DIR)/initmod.%.ll $(BUILD_DIR)/llvm_ok
 	$(LLVM_AS) $(BUILD_DIR)/initmod.$*.ll -o $(BUILD_DIR)/initmod.$*.bc
 
 $(BUILD_DIR)/initmod.%.cpp: $(BIN_DIR)/binary2cpp $(BUILD_DIR)/initmod.%.bc
-	./$(BIN_DIR)/binary2cpp initmod_$* < $(BUILD_DIR)/initmod.$*.bc > $@
+	./$(BIN_DIR)/binary2cpp halide_internal_initmod_$* < $(BUILD_DIR)/initmod.$*.bc > $@
 
 $(BUILD_DIR)/initmod.%_h.cpp: $(BIN_DIR)/binary2cpp $(SRC_DIR)/runtime/%.h
-	./$(BIN_DIR)/binary2cpp runtime_header_$*_h < $(SRC_DIR)/runtime/$*.h > $@
+	./$(BIN_DIR)/binary2cpp halide_internal_runtime_header_$*_h < $(SRC_DIR)/runtime/$*.h > $@
 
 # Any c in the runtime that must be inlined needs to be copy-pasted into the output for the C backend.
 $(BUILD_DIR)/initmod.inlined_c.cpp: $(BIN_DIR)/binary2cpp $(SRC_DIR)/runtime/buffer_t.cpp
-	./$(BIN_DIR)/binary2cpp initmod_inlined_c < $(SRC_DIR)/runtime/buffer_t.cpp > $@
+	./$(BIN_DIR)/binary2cpp halide_internal_initmod_inlined_c < $(SRC_DIR)/runtime/buffer_t.cpp > $@
 
 $(BUILD_DIR)/initmod_ptx.%_ll.cpp: $(BIN_DIR)/binary2cpp $(SRC_DIR)/runtime/nvidia_libdevice_bitcode/libdevice.%.bc
-	./$(BIN_DIR)/binary2cpp initmod_ptx_$(basename $*)_ll < $(SRC_DIR)/runtime/nvidia_libdevice_bitcode/libdevice.$*.bc > $@
+	./$(BIN_DIR)/binary2cpp halide_internal_initmod_ptx_$(basename $*)_ll < $(SRC_DIR)/runtime/nvidia_libdevice_bitcode/libdevice.$*.bc > $@
 
 $(BIN_DIR)/binary2cpp: $(ROOT_DIR)/tools/binary2cpp.cpp
 	@-mkdir -p $(BIN_DIR)
@@ -918,11 +918,11 @@ $(BIN_DIR)/%.generator: $(BUILD_DIR)/GenGen.o $(BIN_DIR)/libHalide.$(SHARED_EXT)
 # of the target is used.
 $(BUILD_DIR)/external_code_extern_bitcode_32.cpp : $(ROOT_DIR)/test/generator/external_code_extern.cpp
 	$(CLANG) $(CXX_WARNING_FLAGS) -O3 -c -m32 -target $(RUNTIME_TRIPLE_32) -emit-llvm $< -o $(BUILD_DIR)/external_code_extern_32.bc || echo -n > $(BUILD_DIR)/external_code_extern_32.bc
-	./$(BIN_DIR)/binary2cpp external_code_extern_32 < $(BUILD_DIR)/external_code_extern_32.bc > $@
+	./$(BIN_DIR)/binary2cpp halide_internal_external_code_extern_32 < $(BUILD_DIR)/external_code_extern_32.bc > $@
 
 $(BUILD_DIR)/external_code_extern_bitcode_64.cpp : $(ROOT_DIR)/test/generator/external_code_extern.cpp
 	$(CLANG) $(CXX_WARNING_FLAGS) -O3 -c -m64 -target $(RUNTIME_TRIPLE_64) -emit-llvm $< -o $(BUILD_DIR)/external_code_extern_64.bc || echo -n > $(BUILD_DIR)/external_code_extern_64.bc
-	./$(BIN_DIR)/binary2cpp external_code_extern_64 < $(BUILD_DIR)/external_code_extern_64.bc > $@
+	./$(BIN_DIR)/binary2cpp halide_internal_external_code_extern_64 < $(BUILD_DIR)/external_code_extern_64.bc > $@
 
 $(BIN_DIR)/external_code.generator: $(BUILD_DIR)/GenGen.o $(BIN_DIR)/libHalide.$(SHARED_EXT) $(BUILD_DIR)/external_code_generator.o $(BUILD_DIR)/external_code_extern_bitcode_32.cpp $(BUILD_DIR)/external_code_extern_bitcode_64.cpp
 	@mkdir -p $(BIN_DIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -184,11 +184,11 @@ function(add_runtime_modules TARGET_RUNTIME_FILES TARGET_RUNTIME_DIR)
 
       add_custom_command(OUTPUT "${INITMOD_D}"
                          DEPENDS "${BC_D}"
-                         COMMAND binary2cpp "initmod_${i}_${j}_debug" < "${BC_D}" > "${INITMOD_D}"
+                         COMMAND binary2cpp "halide_internal_initmod_${i}_${j}_debug" < "${BC_D}" > "${INITMOD_D}"
                          COMMENT "${BC_D} -> ${INITMOD_D}")
       add_custom_command(OUTPUT "${INITMOD}"
                          DEPENDS "${BC}"
-                         COMMAND binary2cpp "initmod_${i}_${j}" < "${BC}" > "${INITMOD}"
+                         COMMAND binary2cpp "halide_internal_initmod_${i}_${j}" < "${BC}" > "${INITMOD}"
                          COMMENT "${BC} -> ${INITMOD}")
       list(APPEND INITIAL_MODULES ${INITMOD})
       list(APPEND INITIAL_MODULES ${INITMOD_D})
@@ -211,14 +211,14 @@ foreach (i ${RUNTIME_LL} )
                      COMMENT "${LL} -> ${BC}")
   add_custom_command(OUTPUT "${INITMOD}"
                      DEPENDS "${BC}"
-                     COMMAND binary2cpp "initmod_${i}_ll" < "${BC}" > "${INITMOD}"
+                     COMMAND binary2cpp "halide_internal_initmod_${i}_ll" < "${BC}" > "${INITMOD}"
                      COMMENT "${BC} -> ${INITMOD}")
   list(APPEND INITIAL_MODULES "${INITMOD}")
 endforeach()
 foreach (i ${RUNTIME_BC} )
   set(INITMOD "${INITMOD_PREFIX}ptx_${i}.cpp")
   add_custom_command(OUTPUT "${INITMOD}"
-                     COMMAND binary2cpp "initmod_ptx_${i}_ll" < "${NATIVE_RUNTIME_DIR}nvidia_libdevice_bitcode/libdevice.${i}.10.bc" > "${INITMOD}"
+                     COMMAND binary2cpp "halide_internal_initmod_ptx_${i}_ll" < "${NATIVE_RUNTIME_DIR}nvidia_libdevice_bitcode/libdevice.${i}.10.bc" > "${INITMOD}"
                      COMMENT "Building initial module ptx_${i}..."
                      VERBATIM)
   list(APPEND INITIAL_MODULES "${INITMOD}")
@@ -226,7 +226,7 @@ endforeach()
 
 add_custom_command(OUTPUT "${INITMOD_PREFIX}inlined_c.cpp"
   DEPENDS "${NATIVE_RUNTIME_DIR}buffer_t.cpp"
-  COMMAND binary2cpp "initmod_inlined_c" < "${NATIVE_RUNTIME_DIR}buffer_t.cpp" > "${INITMOD_PREFIX}inlined_c.cpp"
+  COMMAND binary2cpp "halide_internal_initmod_inlined_c" < "${NATIVE_RUNTIME_DIR}buffer_t.cpp" > "${INITMOD_PREFIX}inlined_c.cpp"
   COMMENT "buffer_t.cpp -> ${INITMOD_PREFIX}inlined_c.cpp")
 list(APPEND INITIAL_MODULES "${INITMOD_PREFIX}inlined_c.cpp")
 
@@ -246,7 +246,7 @@ foreach (i ${RUNTIME_HEADER_FILES})
   string(REPLACE "." "_" SYM_NAME "${i}")
   add_custom_command(OUTPUT "${INITMOD_PREFIX}${SYM_NAME}.cpp"
     DEPENDS "${NATIVE_RUNTIME_DIR}${i}"
-    COMMAND binary2cpp "runtime_header_${SYM_NAME}" < "${NATIVE_RUNTIME_DIR}${i}" > "${INITMOD_PREFIX}${SYM_NAME}.cpp"
+    COMMAND binary2cpp "halide_internal_runtime_header_${SYM_NAME}" < "${NATIVE_RUNTIME_DIR}${i}" > "${INITMOD_PREFIX}${SYM_NAME}.cpp"
     COMMENT "${i} -> ${INITMOD_PREFIX}${SYM_NAME}.cpp")
   list(APPEND INITIAL_MODULES "${INITMOD_PREFIX}${SYM_NAME}.cpp")
 endforeach()

--- a/tools/binary2cpp.cpp
+++ b/tools/binary2cpp.cpp
@@ -1,6 +1,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <assert.h>
 
 #ifdef _WIN32
@@ -11,23 +12,50 @@
 // Embeds a binary blob (from stdin) in a C++ source array of unsigned
 // chars. Similar to the xxd utility.
 
+static int usage() {
+    fprintf(stderr, "Usage: binary2cpp identifier [-header]\n");
+    return -1;
+}
+
 int main(int argc, const char **argv) {
-    assert(argc == 2 && "Requires an identifier as an argument (e.g. initmod_x86_64)");
+    const char *target = argv[1];
+    if (argc == 3) {
+        if (!strcmp(argv[2], "-header")) {
+            printf("#ifndef _H_%s_binary2cpp\n", target);
+            printf("#define _H_%s_binary2cpp\n", target);
+            printf("extern \"C\" {\n");
+            printf("unsigned char %s[];\n", target);
+            printf("int %s_length;\n", target);
+            printf("}  // extern \"C\"\n");
+            printf("#endif  // _H_%s_binary2cpp\n", target);
+            return 0;
+        } else {
+            return usage();
+        }
+    } else if (argc > 3) {
+        return usage();
+    }
+
 #ifdef _WIN32
     setmode(fileno(stdin), O_BINARY); // On windows bad things will happen unless we read stdin in binary mode
 #endif
-    const char *target = argv[1];
     printf("extern \"C\" {\n");
-    printf("unsigned char halide_internal_%s[] = {\n", target);
+    printf("unsigned char %s[] = {\n", target);
     int count = 0;
+    int line_break = 0;
     while (1) {
         int c = getchar();
         if (c == EOF) break;
-        printf("%d, ", c);
+        printf("0x%02x, ", c);
+        // Not necessary, but makes a bit easier to read
+        if (++line_break > 12) {
+            printf("\n");
+            line_break = 0;
+        }
         count++;
     }
     printf("0};\n");
-    printf("int halide_internal_%s_length = %d;\n", target, count);
-    printf("}\n"); // extern "C"
+    printf("int %s_length = %d;\n", target, count);
+    printf("}  // extern \"C\"\n");
     return 0;
 }


### PR DESCRIPTION
— remove the implicit “halide_internal_” prefix so this tool can be
used for other purposes (callers must now prepend that prefix)
— add option to emit a .h file, for clients that would prefer to avoid
explicit extern decls
— add line breaks so that dump isn’t a single enormous line