### PR TITLE
compile_multitarget() needs love to handle External_Code blocks properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -966,6 +966,12 @@ $(FILTERS_DIR)/cxx_mangling_define_extern.a: $(BIN_DIR)/cxx_mangling_define_exte
 	@-mkdir -p $(TMP_DIR)
 	cd $(TMP_DIR); $(CURDIR)/$< -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime-c_plus_plus_name_mangling-user_context -f "HalideTest::cxx_mangling_define_extern"
 
+# external_code is built multitarget just to ensure that the externs aren't duplicated
+$(FILTERS_DIR)/external_code.a: $(BIN_DIR)/external_code.generator
+	@mkdir -p $(FILTERS_DIR)
+	@-mkdir -p $(TMP_DIR)
+	cd $(TMP_DIR); $(CURDIR)/$< -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime,$(TARGET)-no_runtime-debug
+
 # pyramid needs a custom arg
 $(FILTERS_DIR)/pyramid.a: $(BIN_DIR)/pyramid.generator
 	@mkdir -p $(FILTERS_DIR)

--- a/src/Module.h
+++ b/src/Module.h
@@ -126,6 +126,12 @@ public:
     /** Return a new module with all submodules compiled to buffers on
      * on the result Module. */
     EXPORT Module resolve_submodules() const;
+
+    /** Return a pair of Modules: the first is the input Module, minus all ExternalCode blocks
+     * (including those from submodules); the second is a new Module that contains
+     * only the ExternalCode blocks from the first.
+     */
+    EXPORT std::pair<Module, Module> split_external_code() const;
 };
 
 /** Link a set of modules together into one module. */


### PR DESCRIPTION
Previously, we’d output them multiple times, causing duplicate-symbol
errors at link time.