### PR TITLE
Aggressively prune specialize() branches

### DIFF
--- a/src/Definition.h
+++ b/src/Definition.h
@@ -66,32 +66,32 @@ public:
     }
 
     /** Is this an init definition; otherwise it's an update definition */
-    bool is_init() const;
+    EXPORT bool is_init() const;
 
     /** Pass an IRVisitor through to all Exprs referenced in the
      * definition. */
-    void accept(IRVisitor *) const;
+    EXPORT void accept(IRVisitor *) const;
 
     /** Pass an IRMutator through to all Exprs referenced in the
      * definition. */
-    void mutate(IRMutator *);
+    EXPORT void mutate(IRMutator *);
 
     /** Get the default (no-specialization) arguments (left-hand-side) of the definition */
     // @{
-    const std::vector<Expr> &args() const;
-    std::vector<Expr> &args();
+    EXPORT const std::vector<Expr> &args() const;
+    EXPORT std::vector<Expr> &args();
     // @}
 
     /** Get the default (no-specialization) right-hand-side of the definition */
     // @{
-    const std::vector<Expr> &values() const;
-    std::vector<Expr> &values();
+    EXPORT const std::vector<Expr> &values() const;
+    EXPORT std::vector<Expr> &values();
     // @}
 
     /** Get the predicate on the definition */
     // @{
-    const Expr &predicate() const;
-    Expr &predicate();
+    EXPORT const Expr &predicate() const;
+    EXPORT Expr &predicate();
     // @}
 
     /** Split predicate into vector of ANDs. If there is no predicate (i.e. this
@@ -100,17 +100,17 @@ public:
 
     /** Get the default (no-specialization) schedule associated with this definition. */
     // @{
-    const Schedule &schedule() const;
-    Schedule &schedule();
+    EXPORT const Schedule &schedule() const;
+    EXPORT Schedule &schedule();
     // @}
 
     /** You may create several specialized versions of a func with
      * different schedules. They trigger when the condition is
      * true. See \ref Func::specialize */
     // @{
-    const std::vector<Specialization> &specializations() const;
-    std::vector<Specialization> &specializations();
-    const Specialization &add_specialization(Expr condition);
+    EXPORT const std::vector<Specialization> &specializations() const;
+    EXPORT std::vector<Specialization> &specializations();
+    EXPORT const Specialization &add_specialization(Expr condition);
     // @}
 
 };

--- a/src/SimplifySpecializations.cpp
+++ b/src/SimplifySpecializations.cpp
@@ -65,6 +65,15 @@ void simplify_using_fact(Expr fact, vector<Definition> &definitions) {
     }
 }
 
+bool equal(const std::vector<Expr> &a, const std::vector<Expr> &b) {
+    if (a.size() != b.size()) return false;
+    for (size_t i = 0; i < a.size(); ++i) {
+        if (!equal(a[i], b[i])) return false;
+    }
+    return true;
+}
+
+
 vector<Definition> propagate_specialization_in_definition(Definition &def, const string &name) {
     vector<Definition> result;
 
@@ -105,8 +114,9 @@ vector<Definition> propagate_specialization_in_definition(Definition &def, const
         specializations.pop_back();
 
         def.predicate() = s_def.predicate();
-        def.values() = s_def.values();
-        def.args() = s_def.args();
+        // values and args should be identical -- if not, something is badly wrong.
+        internal_assert(equal(def.values(), s_def.values()));
+        internal_assert(equal(def.args(), s_def.args()));
         def.schedule() = s_def.schedule();
         // Append our sub-specializations to the Definition's list
         specializations.insert(specializations.end(), s_def.specializations().begin(), s_def.specializations().end());

--- a/src/SimplifySpecializations.cpp
+++ b/src/SimplifySpecializations.cpp
@@ -139,28 +139,5 @@ void simplify_specializations(map<string, Function> &env) {
     }
 }
 
-namespace {
-
-uint16_t vector_store_lanes = 0;
-
-int my_trace(void *user_context, const halide_trace_event_t *ev) {
-    if (ev->event == halide_trace_store) {
-        if (ev->type.lanes > 1) {
-            vector_store_lanes = ev->type.lanes;
-        } else {
-            vector_store_lanes = 0;
-        }
-    }
-    return 0;
-}
-
-}  // namespace
-
-void simplify_specializations_test() {
-
-
-    std::cout << "SimplifySpecializations test passed" << std::endl;
-}
-
 }
 }

--- a/src/SimplifySpecializations.cpp
+++ b/src/SimplifySpecializations.cpp
@@ -65,15 +65,6 @@ void simplify_using_fact(Expr fact, vector<Definition> &definitions) {
     }
 }
 
-bool equal(const std::vector<Expr> &a, const std::vector<Expr> &b) {
-    if (a.size() != b.size()) return false;
-    for (size_t i = 0; i < a.size(); ++i) {
-        if (!equal(a[i], b[i])) return false;
-    }
-    return true;
-}
-
-
 vector<Definition> propagate_specialization_in_definition(Definition &def, const string &name) {
     vector<Definition> result;
 
@@ -114,9 +105,8 @@ vector<Definition> propagate_specialization_in_definition(Definition &def, const
         specializations.pop_back();
 
         def.predicate() = s_def.predicate();
-        // values and args should be identical -- if not, something is badly wrong.
-        internal_assert(equal(def.values(), s_def.values()));
-        internal_assert(equal(def.args(), s_def.args()));
+        def.values() = s_def.values();
+        def.args() = s_def.args();
         def.schedule() = s_def.schedule();
         // Append our sub-specializations to the Definition's list
         specializations.insert(specializations.end(), s_def.specializations().begin(), s_def.specializations().end());

--- a/src/SimplifySpecializations.cpp
+++ b/src/SimplifySpecializations.cpp
@@ -5,6 +5,8 @@
 #include "Substitute.h"
 #include "Definition.h"
 #include "IREquality.h"
+#include "Param.h"
+#include "Func.h"
 
 #include <set>
 
@@ -65,19 +67,47 @@ void simplify_using_fact(Expr fact, vector<Definition> &definitions) {
     }
 }
 
-vector<Definition> propagate_specialization_in_definition(Definition &def) {
+vector<Definition> propagate_specialization_in_definition(Definition &def, const string &name) {
     vector<Definition> result;
 
     result.push_back(def);
 
     vector<Specialization> &specializations = def.specializations();
+
+    // Prune specializations based on constants:
+    // -- Any Specializations that have const-false as a condition
+    // can never trigger; go ahead and prune them now to save time & energy
+    // during later phases.
+    // -- Once we encounter a Specialization that is const-true, no subsequent
+    // Specializations can ever trigger (since we evaluate them in order), 
+    // so erase them. (Note however that it is legal to call specialize(true)
+    // multiple times, which is required to return the same handle, so leave in
+    // subsequent true specializations; since this is an odd edge case, don't
+    // bother trying to combine them into a single Definition here.)
+    bool seen_const_true = false;
+    for (auto it = specializations.begin(); it != specializations.end(); /*no-increment*/) {
+        Expr old_c = it->condition;
+        Expr c = simplify(it->condition);
+        // Go ahead and save the simplified condition now
+        it->condition = c;
+        bool is_const_true = is_one(c);
+        if (is_zero(c) || (seen_const_true && !is_const_true)) {
+            debug(1) << "Erasing unreachable specialization (" 
+                << old_c << ") -> (" << c << ") for function \"" << name << "\"\n";
+            it = specializations.erase(it);
+        } else {
+            it++;
+        }
+        seen_const_true |= is_const_true;
+    }
+
     for (size_t i = specializations.size(); i > 0; i--) {
         Expr c = specializations[i-1].condition;
         Definition &s_def = specializations[i-1].definition;
         const EQ *eq = c.as<EQ>();
         const Variable *var = eq ? eq->a.as<Variable>() : c.as<Variable>();
 
-        vector<Definition> s_result = propagate_specialization_in_definition(s_def);
+        vector<Definition> s_result = propagate_specialization_in_definition(s_def, name);
 
         if (var && eq) {
             // Then case
@@ -111,8 +141,110 @@ vector<Definition> propagate_specialization_in_definition(Definition &def) {
 void simplify_specializations(map<string, Function> &env) {
     for (auto &iter : env) {
         Function &func = iter.second;
-        propagate_specialization_in_definition(func.definition());
+        propagate_specialization_in_definition(func.definition(), func.name());
     }
+}
+
+namespace {
+
+uint16_t vector_store_lanes = 0;
+
+int my_trace(void *user_context, const halide_trace_event_t *ev) {
+    if (ev->event == halide_trace_store) {
+        if (ev->type.lanes > 1) {
+            vector_store_lanes = ev->type.lanes;
+        } else {
+            vector_store_lanes = 0;
+        }
+    }
+    return 0;
+}
+
+}  // namespace
+
+void simplify_specializations_test() {
+    Var x, y;
+    Param<int> p;
+    Expr const_false = Expr(0) == Expr(1);
+    Expr const_true = Expr(0) == Expr(0);
+    Expr different_const_true = Expr(1) == Expr(1);
+
+    {
+        // Check that we aggressively prune specialize(const-false)
+        Func f;
+        f(x) = x;
+        f.specialize(p == 0).vectorize(x, 32);      // will *not* be pruned
+        f.specialize(const_false).vectorize(x, 8);  // will be pruned
+        f.vectorize(x, 4);                          // default case, not a specialization
+
+        internal_assert(f.function().definition().specializations().size() == 2);
+
+        map<string, Function> env;
+        env.insert({f.function().name(), f.function()});
+        simplify_specializations(env);
+
+        const auto &s = f.function().definition().specializations();
+        internal_assert(s.size() == 1);
+        // should be (something) == 0
+        internal_assert(s[0].condition.as<EQ>() && is_zero(s[0].condition.as<EQ>()->b));
+
+        f.set_custom_trace(&my_trace);
+        f.trace_stores();
+
+        vector_store_lanes = 0;
+        p.set(0);
+        f.realize(100);
+        internal_assert(vector_store_lanes == 32);
+
+        vector_store_lanes = 0;
+        p.set(42);  // just a nonzero value
+        f.realize(100);
+        internal_assert(vector_store_lanes == 4);
+    }
+    {
+        // Check that we aggressively prune all specializations after specialize(const-true)
+        // except for other occurrences of specialize(const-true)
+        Func f;
+        f(x) = x;
+        f.specialize(p == 0).vectorize(x, 32);      // will *not* be pruned
+        f.specialize(const_true).vectorize(x, 16);  // will *not* be pruned
+        f.specialize(const_false).vectorize(x, 4);  // will be pruned
+        f.specialize(p == 42).vectorize(x, 8);      // will be pruned
+        f.specialize(const_true);                   // dupe of call above, won't add new specialization
+        // Note that specialize() will return the same schedule for subsequent
+        // calls with the same Expr, but doesn't guarantee that all Exprs
+        // that evaluate to the same value collapse. Use a deliberately-
+        // different Expr here to check that we don't elide these.
+        f.specialize(different_const_true);         // will *not* be pruned
+
+        internal_assert(f.function().definition().specializations().size() == 5);
+
+        map<string, Function> env;
+        env.insert({f.function().name(), f.function()});
+        simplify_specializations(env);
+
+        const auto &s = f.function().definition().specializations();
+        internal_assert(s.size() == 3);
+        // should be (something) == 0
+        internal_assert(s[0].condition.as<EQ>() && is_zero(s[0].condition.as<EQ>()->b));
+        internal_assert(is_one(s[1].condition));
+        internal_assert(is_one(s[2].condition));
+
+        f.set_custom_trace(&my_trace);
+        f.trace_stores();
+
+        vector_store_lanes = 0;
+        p.set(42);  // Chosen to ensure pruned branch is pruned
+        f.realize(100);
+        internal_assert(vector_store_lanes == 16);
+
+        vector_store_lanes = 0;
+        p.set(0);
+        f.realize(100);
+        internal_assert(vector_store_lanes == 32);
+    }
+
+    std::cout << "SimplifySpecializations test passed" << std::endl;
 }
 
 }

--- a/src/SimplifySpecializations.h
+++ b/src/SimplifySpecializations.h
@@ -16,7 +16,7 @@ namespace Internal {
 
 /** Try to simplify the RHS/LHS of a function's definition based on its
  * specializations. */
-void simplify_specializations(std::map<std::string, Function> &env);
+EXPORT void simplify_specializations(std::map<std::string, Function> &env);
 
 }
 }

--- a/src/SimplifySpecializations.h
+++ b/src/SimplifySpecializations.h
@@ -16,9 +16,7 @@ namespace Internal {
 
 /** Try to simplify the RHS/LHS of a function's definition based on its
  * specializations. */
-EXPORT void simplify_specializations(std::map<std::string, Function> &env);
-
-EXPORT void simplify_specializations_test();
+void simplify_specializations(std::map<std::string, Function> &env);
 
 }
 }

--- a/src/SimplifySpecializations.h
+++ b/src/SimplifySpecializations.h
@@ -16,7 +16,9 @@ namespace Internal {
 
 /** Try to simplify the RHS/LHS of a function's definition based on its
  * specializations. */
-void simplify_specializations(std::map<std::string, Function> &env);
+EXPORT void simplify_specializations(std::map<std::string, Function> &env);
+
+EXPORT void simplify_specializations_test();
 
 }
 }

--- a/test/correctness/specialize.cpp
+++ b/test/correctness/specialize.cpp
@@ -590,7 +590,7 @@ int main(int argc, char **argv) {
 
         const auto &s = f.function().definition().specializations();
         // Note that this is 1 (rather than 2) because the final const-true
-        // Specialization will be hoisted into the main Schdule.
+        // Specialization will be hoisted into the main Schedule.
         _halide_user_assert(s.size() == 1);
         // should be (something) == 0
         _halide_user_assert(s[0].condition.as<Internal::EQ>() && is_zero(s[0].condition.as<Internal::EQ>()->b));

--- a/test/correctness/specialize.cpp
+++ b/test/correctness/specialize.cpp
@@ -5,8 +5,10 @@ using namespace Halide;
 
 bool vector_store;
 bool scalar_store;
+uint16_t vector_store_lanes;
 
 void reset_trace() {
+    vector_store_lanes = 0;
     vector_store = scalar_store = false;
 }
 
@@ -16,6 +18,7 @@ int my_trace(void *user_context, const halide_trace_event_t *ev) {
     if (ev->event == halide_trace_store) {
         if (ev->type.lanes > 1) {
             vector_store = true;
+            vector_store_lanes = ev->type.lanes;
         } else {
             scalar_store = true;
         }
@@ -517,6 +520,92 @@ int main(int argc, char **argv) {
             printf("Incorrect inferred size: %d %d\n", w, h);
             return -1;
         }
+    }
+
+    {
+        Var x, y;
+        Param<int> p;
+        Expr const_false = Expr(0) == Expr(1);
+        Expr const_true = Expr(0) == Expr(0);
+        Expr different_const_true = Expr(1) == Expr(1);
+
+        // Check that we aggressively prune specialize(const-false)
+        Func f;
+        f(x) = x;
+        f.specialize(p == 0).vectorize(x, 32);      // will *not* be pruned
+        f.specialize(const_false).vectorize(x, 8);  // will be pruned
+        f.vectorize(x, 4);                          // default case, not a specialization
+
+        _halide_user_assert(f.function().definition().specializations().size() == 2);
+
+        std::map<std::string, Internal::Function> env;
+        env.insert({f.function().name(), f.function()});
+        simplify_specializations(env);
+
+        const auto &s = f.function().definition().specializations();
+        _halide_user_assert(s.size() == 1);
+        // should be (something) == 0
+        _halide_user_assert(s[0].condition.as<Internal::EQ>() && is_zero(s[0].condition.as<Internal::EQ>()->b));
+
+        f.set_custom_trace(&my_trace);
+        f.trace_stores();
+
+        vector_store_lanes = 0;
+        p.set(0);
+        f.realize(100);
+        _halide_user_assert(vector_store_lanes == 32);
+
+        vector_store_lanes = 0;
+        p.set(42);  // just a nonzero value
+        f.realize(100);
+        _halide_user_assert(vector_store_lanes == 4);
+    }
+    {
+        Var x, y;
+        Param<int> p;
+        Expr const_false = Expr(0) == Expr(1);
+        Expr const_true = Expr(0) == Expr(0);
+        Expr different_const_true = Expr(1) == Expr(1);
+
+        // Check that we aggressively prune all specializations after specialize(const-true)
+        // except for other occurrences of specialize(const-true)
+        Func f;
+        f(x) = x;
+        f.specialize(p == 0).vectorize(x, 32);      // will *not* be pruned
+        f.specialize(const_true).vectorize(x, 16);  // will *not* be pruned
+        f.specialize(const_false).vectorize(x, 4);  // will be pruned
+        f.specialize(p == 42).vectorize(x, 8);      // will be pruned
+        f.specialize(const_true);                   // dupe of call above, won't add new specialization
+        // Note that specialize() will return the same schedule for subsequent
+        // calls with the same Expr, but doesn't guarantee that all Exprs
+        // that evaluate to the same value collapse. Use a deliberately-
+        // different Expr here to check that we do elide these.
+        f.specialize(different_const_true);         // will be pruned
+
+        _halide_user_assert(f.function().definition().specializations().size() == 5);
+
+        std::map<std::string, Internal::Function> env;
+        env.insert({f.function().name(), f.function()});
+        simplify_specializations(env);
+
+        const auto &s = f.function().definition().specializations();
+        _halide_user_assert(s.size() == 2);
+        // should be (something) == 0
+        _halide_user_assert(s[0].condition.as<Internal::EQ>() && is_zero(s[0].condition.as<Internal::EQ>()->b));
+        _halide_user_assert(is_one(s[1].condition));
+
+        f.set_custom_trace(&my_trace);
+        f.trace_stores();
+
+        vector_store_lanes = 0;
+        p.set(42);  // Chosen to ensure pruned branch is pruned
+        f.realize(100);
+        _halide_user_assert(vector_store_lanes == 16);
+
+        vector_store_lanes = 0;
+        p.set(0);
+        f.realize(100);
+        _halide_user_assert(vector_store_lanes == 32);
     }
 
     printf("Success!\n");

--- a/test/correctness/specialize.cpp
+++ b/test/correctness/specialize.cpp
@@ -569,7 +569,6 @@ int main(int argc, char **argv) {
         Expr different_const_true = Expr(1) == Expr(1);
 
         // Check that we aggressively prune all specializations after specialize(const-true)
-        // except for other occurrences of specialize(const-true)
         Func f;
         f(x) = x;
         f.specialize(p == 0).vectorize(x, 32);      // will *not* be pruned

--- a/test/correctness/specialize.cpp
+++ b/test/correctness/specialize.cpp
@@ -560,6 +560,7 @@ int main(int argc, char **argv) {
         f.realize(100);
         _halide_user_assert(vector_store_lanes == 4);
     }
+
     {
         Var x, y;
         Param<int> p;
@@ -589,10 +590,11 @@ int main(int argc, char **argv) {
         simplify_specializations(env);
 
         const auto &s = f.function().definition().specializations();
-        _halide_user_assert(s.size() == 2);
+        // Note that this is 1 (rather than 2) because the final const-true
+        // Specialization will be hoisted into the main Schdule.
+        _halide_user_assert(s.size() == 1);
         // should be (something) == 0
         _halide_user_assert(s[0].condition.as<Internal::EQ>() && is_zero(s[0].condition.as<Internal::EQ>()->b));
-        _halide_user_assert(is_one(s[1].condition));
 
         f.set_custom_trace(&my_trace);
         f.trace_stores();

--- a/test/internal.cpp
+++ b/test/internal.cpp
@@ -17,7 +17,6 @@
 #include "Interval.h"
 #include "Associativity.h"
 #include "Generator.h"
-#include "SimplifySpecializations.h"
 
 using namespace Halide;
 using namespace Halide::Internal;
@@ -40,7 +39,6 @@ int main(int argc, const char **argv) {
     interval_test();
     associativity_test();
     generator_test();
-    simplify_specializations_test();
 
     return 0;
 }

--- a/test/internal.cpp
+++ b/test/internal.cpp
@@ -17,6 +17,7 @@
 #include "Interval.h"
 #include "Associativity.h"
 #include "Generator.h"
+#include "SimplifySpecializations.h"
 
 using namespace Halide;
 using namespace Halide::Internal;
@@ -39,6 +40,7 @@ int main(int argc, const char **argv) {
     interval_test();
     associativity_test();
     generator_test();
+    simplify_specializations_test();
 
     return 0;
 }


### PR DESCRIPTION
When a specialize() condition is const-false, we should always prune it
away before lowering.

When a specialize() condition is const-true, we should always prune
away all subsequent specializations (except for those that are also
const-true).

(Note that this pruning already effectively happened later during
simplification, but pruning earlier removes a nontrivial amount of
work.)