### PR TITLE
Hexagon benchmarks new schedules

### DIFF
--- a/apps/hexagon_benchmarks/conv3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/conv3x3_generator.cpp
@@ -41,7 +41,6 @@ public:
             output.dim(1).set_stride((output_stride/vector_size) * vector_size);
             bounded_input
                 .compute_at(Func(output), y)
-                .store_at(Func(output), y)
                 .align_storage(x, 128)
                 .vectorize(x, vector_size, TailStrategy::RoundUp);
             output

--- a/apps/hexagon_benchmarks/conv3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/conv3x3_generator.cpp
@@ -39,7 +39,11 @@ public:
 
             Expr output_stride = output.dim(1).stride();
             output.dim(1).set_stride((output_stride/vector_size) * vector_size);
-            bounded_input.compute_root();
+            bounded_input
+                .compute_at(Func(output), y)
+                .store_at(Func(output), y)
+                .align_storage(x, 128)
+                .vectorize(x, vector_size, TailStrategy::RoundUp);
             output
                 .hexagon()
                 .tile(x, y, xi, yi, vector_size, 4, TailStrategy::RoundUp)

--- a/apps/hexagon_benchmarks/dilate3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/dilate3x3_generator.cpp
@@ -32,7 +32,10 @@ public:
 
             Expr output_stride = output.dim(1).stride();
             output.dim(1).set_stride((output_stride/vector_size) * vector_size);
-            bounded_input.compute_root();
+            bounded_input
+                .compute_at(Func(output), y)
+                .align_storage(x, 128)
+                .vectorize(x, vector_size, TailStrategy::RoundUp);
             output
                 .hexagon()
                 .tile(x, y, xi, yi, vector_size, 4)

--- a/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
+++ b/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
@@ -8,7 +8,6 @@ public:
     Output<Buffer<uint8_t>> output{"output", 2};
 
     void generate() {
-        Func bounded_input{"bounded_input"};
         bounded_input(x, y) = BoundaryConditions::repeat_edge(input)(x, y);
 
         Func input_16("input_16");
@@ -35,13 +34,17 @@ public:
             input.dim(1).set_stride((input_stride/vector_size) * vector_size);
 
             Expr output_stride = output.dim(1).stride();
+            bounded_input
+                .compute_at(Func(output), y)
+                .align_storage(x, 128)
+                .vectorize(x, vector_size, TailStrategy::RoundUp);
             output.dim(1).set_stride((output_stride/vector_size) * vector_size);
             output
                 .hexagon()
                 .tile(x, y, xi, yi, vector_size, 4, TailStrategy::RoundUp)
                 .vectorize(xi)
                 .unroll(yi);
-            rows.compute_at(output, y)
+            rows.compute_at(Func(output), y)
                 .tile(x, y, x, y, xi, yi, vector_size, 4, TailStrategy::RoundUp)
                 .vectorize(xi)
                 .unroll(yi);
@@ -53,7 +56,7 @@ public:
         }
     }
 private:
-    Func rows{"rows"}, cols{"cols"};
+    Func rows{"rows"}, cols{"cols"}, bounded_input{"bounded_input"};
     Var x{"x"}, y{"y"};
 };
 

--- a/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
+++ b/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
@@ -41,7 +41,7 @@ public:
             output.dim(1).set_stride((output_stride/vector_size) * vector_size);
             output
                 .hexagon()
-                .tile(x, y, xi, yi, vector_size, 4, TailStrategy::RoundUp)
+                .tile(x, y, xi, yi, vector_size*2, 4, TailStrategy::RoundUp)
                 .vectorize(xi)
                 .unroll(yi);
             rows.compute_at(Func(output), y)

--- a/apps/hexagon_benchmarks/median3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/median3x3_generator.cpp
@@ -43,7 +43,10 @@ public:
 
             Expr output_stride = output.dim(1).stride();
             output.dim(1).set_stride((output_stride/vector_size) * vector_size);
-            bounded_input.compute_root();
+            bounded_input
+                .compute_at(Func(output), y)
+                .align_storage(x, 128)
+                .vectorize(x, vector_size, TailStrategy::RoundUp);
             output
                 .hexagon()
                 .tile(x, y, xi, yi, vector_size, 4)

--- a/apps/hexagon_benchmarks/sobel_generator.cpp
+++ b/apps/hexagon_benchmarks/sobel_generator.cpp
@@ -37,7 +37,10 @@ public:
 
             Expr output_stride = output.dim(1).stride();
             output.dim(1).set_stride((output_stride/vector_size) * vector_size);
-            bounded_input.compute_root();
+            bounded_input
+                .compute_at(Func(output), y)
+                .align_storage(x, 128)
+                .vectorize(x, vector_size, TailStrategy::RoundUp);
             output
                 .hexagon()
                 .tile(x, y, xi, yi, vector_size, 4, TailStrategy::RoundUp)


### PR DESCRIPTION
Before:
Done, time (conv3x3a16): 0.0049175 s (128 byte mode)
Done, time (dilate3x3): 0.0042597 s (128 byte mode)
Done, time (median3x3): 0.0050552 s (128 byte mode)
Done, time (gaussian5x5): 0.0042595 s (128 byte mode)
Done, time (sobel): 0.0054079 s (128 byte mode)
Done, time (conv3x3a32): 0.0051582 s (128 byte mode)


After:
Done, time (conv3x3a16): 0.0017923 s (128 byte mode)
Done, time (dilate3x3): 0.0019679 s (128 byte mode)
Done, time (median3x3): 0.0021045 s (128 byte mode)
Done, time (gaussian5x5): 0.0021509 s (128 byte mode)
Done, time (sobel): 0.0019982 s (128 byte mode)
Done, time (conv3x3a32): 0.0021427 s (128 byte mode)

@dsharletg, @dpalermo, @ronlieb - There may be better schedules out there that we can explore over time. These are the best I have *so far*. 