### PR TITLE
If specialize(true) replaces default schedule, propagate compute/store level for output Funcs

### DIFF
--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -104,7 +104,7 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
 
     // Try to simplify the RHS/LHS of a function definition by propagating its
     // specializations' conditions
-    simplify_specializations(env);
+    simplify_specializations(outputs, env);
 
     bool any_memoized = false;
 

--- a/src/PrintLoopNest.cpp
+++ b/src/PrintLoopNest.cpp
@@ -179,7 +179,7 @@ string print_loop_nest(const vector<Function> &output_funcs) {
 
     // Try to simplify the RHS/LHS of a function definition by propagating its
     // specializations' conditions
-    simplify_specializations(env);
+    simplify_specializations(outputs, env);
 
     // For the purposes of printing the loop nest, we don't want to
     // worry about which features are and aren't enabled.

--- a/src/SimplifySpecializations.h
+++ b/src/SimplifySpecializations.h
@@ -16,7 +16,7 @@ namespace Internal {
 
 /** Try to simplify the RHS/LHS of a function's definition based on its
  * specializations. */
-EXPORT void simplify_specializations(std::map<std::string, Function> &env);
+EXPORT void simplify_specializations(const std::vector<Function> &outputs, std::map<std::string, Function> &env);
 
 }
 }

--- a/test/correctness/specialize.cpp
+++ b/test/correctness/specialize.cpp
@@ -523,7 +523,7 @@ int main(int argc, char **argv) {
     }
 
     {
-        Var x, y;
+        Var x;
         Param<int> p;
         Expr const_false = Expr(0) == Expr(1);
         Expr const_true = Expr(0) == Expr(0);
@@ -540,7 +540,7 @@ int main(int argc, char **argv) {
 
         std::map<std::string, Internal::Function> env;
         env.insert({f.function().name(), f.function()});
-        simplify_specializations(env);
+        simplify_specializations({f.function()}, env);
 
         const auto &s = f.function().definition().specializations();
         _halide_user_assert(s.size() == 1);
@@ -586,7 +586,7 @@ int main(int argc, char **argv) {
 
         std::map<std::string, Internal::Function> env;
         env.insert({f.function().name(), f.function()});
-        simplify_specializations(env);
+        simplify_specializations({f.function()}, env);
 
         const auto &s = f.function().definition().specializations();
         // Note that this is 1 (rather than 2) because the final const-true
@@ -602,6 +602,33 @@ int main(int argc, char **argv) {
         p.set(42);  // Chosen to ensure pruned branch is pruned
         f.realize(100);
         _halide_user_assert(vector_store_lanes == 16);
+
+        vector_store_lanes = 0;
+        p.set(0);
+        f.realize(100);
+        _halide_user_assert(vector_store_lanes == 32);
+    }
+
+    {
+        Var x;
+        Param<int> p;
+        Expr const_true = Expr(0) == Expr(0);
+        Expr different_const_true = Expr(1) == Expr(1);
+
+        // Check that if we promote a final const-true specialize, we keep the
+        // implicit compute/store_root required for outputs.
+        Func f("foof");
+        f(x) = x;
+        f.specialize(p == 0).vectorize(x, 32);      // will *not* be pruned
+        f.specialize(const_true);                   // dupe of call above, won't add new specialization
+
+        f.set_custom_trace(&my_trace);
+        f.trace_stores();
+
+        vector_store_lanes = 0;
+        p.set(42);  // arbitrary nonzero value
+        f.realize(100);
+        _halide_user_assert(vector_store_lanes == 0);
 
         vector_store_lanes = 0;
         p.set(0);


### PR DESCRIPTION
Edge case from PR#1986; output Funcs get implicitly set to
compute/store_root in lower, so replacement schedules should also
maintain this behavior.