### PR TITLE
Move outputs.compute/store_root() to *after* simplify_specializations()

### DIFF
--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -91,11 +91,6 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
     vector<Function> outputs;
     std::tie(outputs, env) = deep_copy(output_funcs, env);
 
-    // Output functions should all be computed and stored at root.
-    for (Function f: outputs) {
-        Func(f).compute_root().store_root();
-    }
-
     // Substitute in wrapper Funcs
     env = wrap_func_calls(env);
 
@@ -105,6 +100,12 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
     // Try to simplify the RHS/LHS of a function definition by propagating its
     // specializations' conditions
     simplify_specializations(env);
+
+    // Output functions should all be computed and stored at root.
+    // (Must do this *after* simplify_specializations.)
+    for (Function f: outputs) {
+        Func(f).compute_root().store_root();
+    }
 
     bool any_memoized = false;
 

--- a/src/PrintLoopNest.cpp
+++ b/src/PrintLoopNest.cpp
@@ -166,11 +166,6 @@ string print_loop_nest(const vector<Function> &output_funcs) {
     vector<Function> outputs;
     std::tie(outputs, env) = deep_copy(output_funcs, env);
 
-    // Output functions should all be computed and stored at root.
-    for (Function f: outputs) {
-        Func(f).compute_root().store_root();
-    }
-
     // Substitute in wrapper Funcs
     env = wrap_func_calls(env);
 
@@ -180,6 +175,12 @@ string print_loop_nest(const vector<Function> &output_funcs) {
     // Try to simplify the RHS/LHS of a function definition by propagating its
     // specializations' conditions
     simplify_specializations(env);
+
+    // Output functions should all be computed and stored at root.
+    // (Must do this *after* simplify_specializations.)
+    for (Function f: outputs) {
+        Func(f).compute_root().store_root();
+    }
 
     // For the purposes of printing the loop nest, we don't want to
     // worry about which features are and aren't enabled.

--- a/test/correctness/specialize.cpp
+++ b/test/correctness/specialize.cpp
@@ -562,7 +562,7 @@ int main(int argc, char **argv) {
     }
 
     {
-        Var x, y;
+        Var x;
         Param<int> p;
         Expr const_false = Expr(0) == Expr(1);
         Expr const_true = Expr(0) == Expr(0);
@@ -602,6 +602,33 @@ int main(int argc, char **argv) {
         p.set(42);  // Chosen to ensure pruned branch is pruned
         f.realize(100);
         _halide_user_assert(vector_store_lanes == 16);
+
+        vector_store_lanes = 0;
+        p.set(0);
+        f.realize(100);
+        _halide_user_assert(vector_store_lanes == 32);
+    }
+
+    {
+        Var x;
+        Param<int> p;
+        Expr const_true = Expr(0) == Expr(0);
+        Expr different_const_true = Expr(1) == Expr(1);
+
+        // Check that if we promote a final const-true specialize, we keep the
+        // implicit compute/store_root required for outputs.
+        Func f("foof");
+        f(x) = x;
+        f.specialize(p == 0).vectorize(x, 32);      // will *not* be pruned
+        f.specialize(const_true);                   // dupe of call above, won't add new specialization
+
+        f.set_custom_trace(&my_trace);
+        f.trace_stores();
+
+        vector_store_lanes = 0;
+        p.set(42);  // arbitrary nonzero value
+        f.realize(100);
+        _halide_user_assert(vector_store_lanes == 0);
 
         vector_store_lanes = 0;
         p.set(0);


### PR DESCRIPTION
Simpler alternative to PR#1997