### PR TITLE
Fix some scheduling bugs in the FFT generator

### DIFF
--- a/apps/fft/fft_generator.cpp
+++ b/apps/fft/fft_generator.cpp
@@ -146,10 +146,17 @@ public:
 
         output.dim(0).set_stride(output_comps)
               .dim(2).set_min(0).set_extent(output_comps).set_stride(1);
+	
+	if (output_comps != 1) {
+  	    output.reorder(c, x, y).unroll(c);
+	}
 
         if (real_result.defined()) {
-            real_result.compute_at(output, y);
-        }
+  	    real_result.compute_at(output, Var::outermost());
+        } else {
+	    assert(complex_result.defined());
+	    complex_result.compute_at(output, Var::outermost());
+	}
     }
 private:
     Var x{"x"}, y{"y"}, c{"c"};

--- a/apps/fft/fft_generator.cpp
+++ b/apps/fft/fft_generator.cpp
@@ -147,16 +147,16 @@ public:
         output.dim(0).set_stride(output_comps)
               .dim(2).set_min(0).set_extent(output_comps).set_stride(1);
 	
-	if (output_comps != 1) {
-  	    output.reorder(c, x, y).unroll(c);
-	}
+        if (output_comps != 1) {
+            output.reorder(c, x, y).unroll(c);
+        }
 
         if (real_result.defined()) {
-  	    real_result.compute_at(output, Var::outermost());
+            real_result.compute_at(output, Var::outermost());
         } else {
-	    assert(complex_result.defined());
-	    complex_result.compute_at(output, Var::outermost());
-	}
+            assert(complex_result.defined());
+            complex_result.compute_at(output, Var::outermost());
+        }
     }
 private:
     Var x{"x"}, y{"y"}, c{"c"};


### PR DESCRIPTION
The FFT generator schedule had a few problems:

- For complex outputs, the FFT was getting computed redundantly for each re, im result of the output.

- For real results, the FFT was getting redundantly computed for each *line* of the result. Our FFT had `N1*N2*N2*log(N1*N2)` complexity!

This should partially fix #2002. There are still some issues here, it seems hardcoded to produce interleaved complex data, which is sub-optical, we should steer people towards using planar complex data.