### PR TITLE
Also sort all ifs introduced by apply_splits

### DIFF
--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -123,20 +123,33 @@ Stmt build_provide_loop_nest_helper(string func_name,
         nest.push_back(c);
     }
 
-    // Strip off the lets into the containers vector.
-    while (const LetStmt *let = stmt.as<LetStmt>()) {
-        Container c = {Container::Let, 0, let->name, let->value};
-        nest.push_back(c);
-        stmt = let->body;
+    vector<Container> pred_container;
+    // Strip off the lets/ifs into the containers vector.
+    while (true) {
+        const LetStmt *let = stmt.as<LetStmt>();
+        const IfThenElse *if_else = stmt.as<IfThenElse>();
+        if (let) {
+            Container c = {Container::Let, 0, let->name, let->value};
+            nest.push_back(c);
+            stmt = let->body;
+        } else if (if_else && !if_else->else_case.defined()) {
+            Container c = {Container::If, 0, "", if_else->condition};
+            pred_container.push_back(c);
+            stmt = if_else->then_case;
+        } else {
+            break;
+        }
     }
 
     // Put all the reduction domain predicates into the containers vector.
-    int n_predicates = predicates.size();
     for (Expr pred : predicates) {
         pred = qualify(prefix, pred);
         Container c = {Container::If, 0, "", likely(pred)};
-        nest.push_back(c);
+        pred_container.push_back(c);
     }
+    int n_predicates = pred_container.size();
+
+    nest.insert(nest.end(), pred_container.begin(), pred_container.end());
 
     // Resort the containers vector so that lets are as far outwards
     // as possible. Use reverse insertion sort. Start at the first letstmt.
@@ -156,13 +169,19 @@ Stmt build_provide_loop_nest_helper(string func_name,
         }
     }
 
-    // Sort the predicate guards so they are as far outwards as possible.
+    // Sort the ifs so they are as far outwards as possible.
+    // BoxesTouched trims the domain of a variable within a scope of if-then-else
+    // based on the likely condition. However, it doesn't do it transitively; it
+    // doesn't trim the domains of other variables that directly/indirectly
+    // depend on the original variable in the likely condition outside the scope
+    // of the if-then-else. That's why it's necessary to move the ifs as far
+    // outwards as possible, so that those variables can have tighter bounds.
     for (int i = (int)nest.size() - n_predicates; i < (int)nest.size(); i++) {
         // Only push up LetStmts.
         internal_assert(nest[i].value.defined());
         internal_assert(nest[i].type == Container::If);
 
-        // Cannot lift out the predicate guard if it contains call to non-pure function
+        // Cannot lift out the 'if' if it contains call to non-pure function
         if (contains_impure_call(nest[i].value)) {
             continue;
         }
@@ -436,11 +455,11 @@ Stmt build_produce(Function f, const Target &target) {
                 // Return type is really 'void', but no way to represent that in our IR.
                 // Precedent (from halide_print, etc) is to use Int(32) and ignore the result.
                 Expr sizeof_buffer_t((uint64_t) sizeof(halide_buffer_t));
-                Stmt mark_buffer = 
+                Stmt mark_buffer =
                     Evaluate::make(Call::make(Int(32), "halide_msan_annotate_memory_is_initialized", {buffer, sizeof_buffer_t}, Call::Extern));
                 Expr shape = Call::make(type_of<halide_dimension_t *>(), Call::buffer_get_shape, {buffer}, Call::Extern);
                 Expr shape_size = Expr((uint64_t)(sizeof(halide_dimension_t) * dimensions));
-                Stmt mark_shape = 
+                Stmt mark_shape =
                     Evaluate::make(Call::make(Int(32), "halide_msan_annotate_memory_is_initialized", {shape, shape_size}, Call::Extern));
                 mark_buffer = Block::make(mark_buffer, mark_shape);
                 if (annotate.defined()) {


### PR DESCRIPTION
We should also sort all ifs introduced by apply splits so that we can get tighter bounds by BoxesTouched. This also fixes the bugs when rdom's predicate depends on let-stmt inside the ifs and is injected at the wrong level. 