### PR TITLE
Wrap let value to prevent code explosion in prefetch

### DIFF
--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -178,10 +178,6 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
     s = storage_folding(s, env);
     debug(2) << "Lowering after storage folding:\n" << s << '\n';
 
-    debug(1) << "Injecting prefetches...\n";
-    s = inject_prefetch(s, env);
-    debug(2) << "Lowering after injecting prefetches:\n" << s << "\n\n";
-
     debug(1) << "Injecting debug_to_file calls...\n";
     s = debug_to_file(s, outputs, env);
     debug(2) << "Lowering after injecting debug_to_file calls:\n" << s << '\n';
@@ -189,6 +185,10 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
     debug(1) << "Simplifying...\n"; // without removing dead lets, because storage flattening needs the strides
     s = simplify(s, false);
     debug(2) << "Lowering after first simplification:\n" << s << "\n\n";
+
+    debug(1) << "Injecting prefetches...\n";
+    s = inject_prefetch(s, env);
+    debug(2) << "Lowering after injecting prefetches:\n" << s << "\n\n";
 
     debug(1) << "Dynamically skipping stages...\n";
     s = skip_stages(s, order);

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -112,7 +112,7 @@ private:
     T visit_let(const LetOrLetStmt *op) {
         Interval value_bounds = bounds_of_expr_in_scope(op->value, scope);
 
-        bool fixed = value_bounds.min.same_as(value_bounds.max);
+        bool fixed = value_bounds.is_single_point();
         value_bounds.min = simplify(value_bounds.min);
         value_bounds.max = fixed ? value_bounds.min : simplify(value_bounds.max);
 


### PR DESCRIPTION
Blindly substituting the let/let_stmt value when calling the bounds_expr_in_scope causes combinatorial expansion of the lets which takes forever to compile. Instead, we introduce a dummy variable and push it onto the scope and re-wrap the let on the way out. Also, move the inject_prefetch after the first simplify; hopefully the simplifier would have simplified lets. 