### PR TITLE
Use the Target for sizeof(halide_buffer_t) instead of the host system

### DIFF
--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -515,10 +515,11 @@ public:
                     // Copy the input buffer into a query buffer to mutate.
                     string query_name = name + ".bounds_query." + func.name();
 
+                    Expr alloca_size = Call::make(Int(32), Call::size_of_halide_buffer_t, {}, Call::Intrinsic);
                     Expr query_buf = Call::make(type_of<struct halide_buffer_t *>(), Call::alloca,
-                                                {(int)sizeof(halide_buffer_t)}, Call::Intrinsic);
+                                                {alloca_size}, Call::Intrinsic);
                     Expr query_shape = Call::make(type_of<struct halide_dimension_t *>(), Call::alloca,
-                                                  {(int)sizeof(halide_dimension_t) * dims}, Call::Intrinsic);
+                                                  {(int)(sizeof(halide_dimension_t) * dims)}, Call::Intrinsic);
                     query_buf = Call::make(type_of<struct halide_buffer_t *>(), Call::buffer_init_from_buffer,
                                            {query_buf, query_shape, in_buf}, Call::Extern);
 
@@ -563,8 +564,11 @@ public:
                 for (const auto &buffer: buffers_to_annotate) {
                     // Return type is really 'void', but no way to represent that in our IR.
                     // Precedent (from halide_print, etc) is to use Int(32) and ignore the result.
-                    Expr sizeof_buffer_t((uint64_t) sizeof(halide_buffer_t));
-                    Stmt mark_buffer = Evaluate::make(Call::make(Int(32), "halide_msan_annotate_memory_is_initialized", {buffer, sizeof_buffer_t}, Call::Extern));
+                    Expr sizeof_buffer_t =
+                        Call::make(Int(32), Call::size_of_halide_buffer_t, {}, Call::Intrinsic);
+                    Stmt mark_buffer =
+                        Evaluate::make(Call::make(Int(32), "halide_msan_annotate_memory_is_initialized",
+                                                  {buffer, sizeof_buffer_t}, Call::Extern));
                     if (annotate.defined()) {
                         annotate = Block::make(annotate, mark_buffer);
                     } else {

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -565,7 +565,7 @@ public:
                     // Return type is really 'void', but no way to represent that in our IR.
                     // Precedent (from halide_print, etc) is to use Int(32) and ignore the result.
                     Expr sizeof_buffer_t =
-                        Call::make(Int(32), Call::size_of_halide_buffer_t, {}, Call::Intrinsic);
+                        cast<uint64_t>(Call::make(Int(32), Call::size_of_halide_buffer_t, {}, Call::Intrinsic));
                     Stmt mark_buffer =
                         Evaluate::make(Call::make(Int(32), "halide_msan_annotate_memory_is_initialized",
                                                   {buffer, sizeof_buffer_t}, Call::Extern));

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -977,8 +977,9 @@ void CodeGen_C::visit(const Call *op) {
     } else if (op->is_intrinsic(Call::alloca)) {
         internal_assert(op->args.size() == 1);
         internal_assert(op->type.is_handle());
+        const Call *call = op->args[0].as<Call>();
         if (op->type == type_of<struct halide_buffer_t *>() &&
-            is_const(op->args[0], (int)sizeof(halide_buffer_t))) {
+            call && call->is_intrinsic(Call::size_of_halide_buffer_t)) {
             do_indent();
             string buf_name = unique_name('b');
             stream << "halide_buffer_t " << buf_name << ";\n";
@@ -1100,6 +1101,8 @@ void CodeGen_C::visit(const Call *op) {
             << " + " << print_expr(op->args[1]) << "), 1)";
     } else if (op->is_intrinsic(Call::indeterminate_expression)) {
         user_error << "Indeterminate expression occurred during constant-folding.\n";
+    } else if (op->is_intrinsic(Call::size_of_halide_buffer_t)) {
+        rhs << "(sizeof(halide_buffer_t))";
     } else if (op->call_type == Call::Intrinsic ||
                op->call_type == Call::PureIntrinsic) {
         // TODO: other intrinsics

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -816,6 +816,7 @@ Call::ConstString Call::bool_to_mask = "bool_to_mask";
 Call::ConstString Call::cast_mask = "cast_mask";
 Call::ConstString Call::select_mask = "select_mask";
 Call::ConstString Call::extract_mask_element = "extract_mask_element";
+Call::ConstString Call::size_of_halide_buffer_t = "size_of_halide_buffer_t";
 
 Call::ConstString Call::buffer_get_min = "_halide_buffer_get_min";
 Call::ConstString Call::buffer_get_extent = "_halide_buffer_get_extent";

--- a/src/IR.h
+++ b/src/IR.h
@@ -510,7 +510,8 @@ struct Call : public ExprNode<Call> {
         bool_to_mask,
         cast_mask,
         select_mask,
-        extract_mask_element;
+        extract_mask_element,
+        size_of_halide_buffer_t;
 
     // We also declare some symbolic names for some of the runtime
     // functions that we want to construct Call nodes to here to avoid

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -620,7 +620,8 @@ Expr BufferBuilder::build() const {
     if (buffer_memory.defined()) {
         args[0] = buffer_memory;
     } else {
-        args[0] = Call::make(type_of<struct halide_buffer_t *>(), Call::alloca, {(int)sizeof(halide_buffer_t)}, Call::Intrinsic);
+        Expr sz = Call::make(Int(32), Call::size_of_halide_buffer_t, {}, Call::Intrinsic);
+        args[0] = Call::make(type_of<struct halide_buffer_t *>(), Call::alloca, {sz}, Call::Intrinsic);
     }
 
     std::string shape_var_name = unique_name('t');

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -414,8 +414,9 @@ Stmt build_produce(Function f, const Target &target) {
                 src_buf_name += ".buffer";
                 Expr src_buffer = Variable::make(type_of<struct halide_buffer_t *>(), src_buf_name);
 
+                Expr alloca_size = Call::make(Int(32), Call::size_of_halide_buffer_t, {}, Call::Intrinsic);
                 Expr output_buffer_t = Call::make(type_of<struct halide_buffer_t *>(), Call::alloca,
-                                                  {(int)sizeof(halide_buffer_t)}, Call::Intrinsic);
+                                                  {alloca_size}, Call::Intrinsic);
 
                 vector<Expr> args(5);
                 args[0] = output_buffer_t;
@@ -454,13 +455,15 @@ Stmt build_produce(Function f, const Target &target) {
                 int dimensions = p.second;
                 // Return type is really 'void', but no way to represent that in our IR.
                 // Precedent (from halide_print, etc) is to use Int(32) and ignore the result.
-                Expr sizeof_buffer_t((uint64_t) sizeof(halide_buffer_t));
+                Expr sizeof_buffer_t = Call::make(Int(32), Call::size_of_halide_buffer_t, {}, Call::Intrinsic);
                 Stmt mark_buffer =
-                    Evaluate::make(Call::make(Int(32), "halide_msan_annotate_memory_is_initialized", {buffer, sizeof_buffer_t}, Call::Extern));
+                    Evaluate::make(Call::make(Int(32), "halide_msan_annotate_memory_is_initialized",
+                                              {buffer, sizeof_buffer_t}, Call::Extern));
                 Expr shape = Call::make(type_of<halide_dimension_t *>(), Call::buffer_get_shape, {buffer}, Call::Extern);
                 Expr shape_size = Expr((uint64_t)(sizeof(halide_dimension_t) * dimensions));
                 Stmt mark_shape =
-                    Evaluate::make(Call::make(Int(32), "halide_msan_annotate_memory_is_initialized", {shape, shape_size}, Call::Extern));
+                    Evaluate::make(Call::make(Int(32), "halide_msan_annotate_memory_is_initialized",
+                                              {shape, shape_size}, Call::Extern));
                 mark_buffer = Block::make(mark_buffer, mark_shape);
                 if (annotate.defined()) {
                     annotate = Block::make(annotate, mark_buffer);

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -455,7 +455,7 @@ Stmt build_produce(Function f, const Target &target) {
                 int dimensions = p.second;
                 // Return type is really 'void', but no way to represent that in our IR.
                 // Precedent (from halide_print, etc) is to use Int(32) and ignore the result.
-                Expr sizeof_buffer_t = Call::make(Int(32), Call::size_of_halide_buffer_t, {}, Call::Intrinsic);
+                Expr sizeof_buffer_t = cast<uint64_t>(Call::make(Int(32), Call::size_of_halide_buffer_t, {}, Call::Intrinsic));
                 Stmt mark_buffer =
                     Evaluate::make(Call::make(Int(32), "halide_msan_annotate_memory_is_initialized",
                                               {buffer, sizeof_buffer_t}, Call::Extern));

--- a/test/correctness/buffer_t.cpp
+++ b/test/correctness/buffer_t.cpp
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include "Halide.h"
 
+using namespace Halide;
+
 #define CHECK(f, s32, s64) \
     static_assert(offsetof(halide_buffer_t, f) == (sizeof(void*) == 8 ? (s64) : (s32)), #f " is wrong")
 
@@ -30,6 +32,14 @@ int main(int argc, char **argv) {
 
     // Ensure alignment is at least that of a pointer.
     static_assert(ALIGN_OF(halide_buffer_t) >= ALIGN_OF(uint8_t*), "align is wrong");
+
+    // Also check that Halide understands the size correctly:
+    int runtime_size = evaluate<int>(
+        Internal::Call::make(Int(32), Internal::Call::size_of_halide_buffer_t, {}, Internal::Call::Intrinsic));
+    if (runtime_size != sizeof(halide_buffer_t)) {
+        printf("size_of_halide_buffer_t intrinsic returned %d instead of %d\n",
+               runtime_size, (int)sizeof(halide_buffer_t));
+    }
 
     printf("Success!\n");
     return 0;


### PR DESCRIPTION
via an intrinsic handled in codegen

fixes #1991