### PR TITLE
expose default implementations of replaceable runtime functions

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -68,6 +68,7 @@ struct buffer_t;
  */
 // @{
 extern void halide_print(void *user_context, const char *);
+extern void halide_default_print(void *user_context, const char *);
 typedef void (*halide_print_t)(void *, const char *);
 extern halide_print_t halide_set_custom_print(halide_print_t print);
 // @}
@@ -81,6 +82,7 @@ extern halide_print_t halide_set_custom_print(halide_print_t print);
  */
 // @{
 extern void halide_error(void *user_context, const char *);
+extern void halide_default_error(void *user_context, const char *);
 typedef void (*halide_error_handler_t)(void *, const char *);
 extern halide_error_handler_t halide_set_error_handler(halide_error_handler_t handler);
 // @}
@@ -140,6 +142,16 @@ extern int halide_do_task(void *user_context, halide_task_t f, int idx,
                           uint8_t *closure);
 //@}
 
+/** The default versions of do_task and do_par_for. Can be convenient
+ * to call from overrides in certain circumstances. */
+// @{
+extern int halide_default_do_par_for(void *user_context,
+                                     halide_task_t task,
+                                     int min, int size, uint8_t *closure);
+extern int halide_default_do_task(void *user_context, halide_task_t f, int idx,
+                                  uint8_t *closure);
+// @}
+
 struct halide_thread;
 
 /** Spawn a thread. Returns a handle to the thread for the purposes of
@@ -174,6 +186,10 @@ extern int halide_set_num_threads(int n);
  * linking), simply define these functions yourself. In JIT-compiled
  * code use Func::set_custom_allocator.
  *
+ * If you override them, and find yourself wanting to call the default
+ * implementation from within your override, use
+ * halide_default_malloc/free.
+ *
  * Note that halide_malloc must return a pointer aligned to the
  * maximum meaningful alignment for the platform for the purpose of
  * vector loads and stores. The default implementation uses 32-byte
@@ -184,6 +200,8 @@ extern int halide_set_num_threads(int n);
 //@{
 extern void *halide_malloc(void *user_context, size_t x);
 extern void halide_free(void *user_context, void *ptr);
+extern void *halide_default_malloc(void *user_context, size_t x);
+extern void halide_default_free(void *user_context, void *ptr);
 typedef void *(*halide_malloc_t)(void *, size_t);
 typedef void (*halide_free_t)(void *, void *);
 extern halide_malloc_t halide_set_custom_malloc(halide_malloc_t user_malloc);
@@ -204,6 +222,9 @@ extern halide_free_t halide_set_custom_free(halide_free_t user_free);
 extern void *halide_get_symbol(const char *name);
 extern void *halide_load_library(const char *name);
 extern void *halide_get_library_symbol(void *lib, const char *name);
+extern void *halide_default_get_symbol(const char *name);
+extern void *halide_default_load_library(const char *name);
+extern void *halide_default_get_library_symbol(void *lib, const char *name);
 typedef void *(*halide_get_symbol_t)(const char *name);
 typedef void *(*halide_load_library_t)(const char *name);
 typedef void *(*halide_get_library_symbol_t)(void *lib, const char *name);
@@ -384,6 +405,7 @@ struct halide_trace_event_t {
  */
 // @}
 extern int32_t halide_trace(void *user_context, const struct halide_trace_event_t *event);
+extern int32_t halide_default_trace(void *user_context, const struct halide_trace_event_t *event);
 typedef int32_t (*halide_trace_t)(void *user_context, const struct halide_trace_event_t *);
 extern halide_trace_t halide_set_custom_trace(halide_trace_t trace);
 // @}

--- a/src/runtime/android_io.cpp
+++ b/src/runtime/android_io.cpp
@@ -6,12 +6,8 @@ extern "C" {
 
 extern int __android_log_print(int, const char *, const char *, ...);
 
-}
-
-namespace Halide { namespace Runtime { namespace Internal {
-
-WEAK void halide_print_impl(void *user_context, const char * str) {
+WEAK void halide_default_print(void *user_context, const char * str) {
     __android_log_print(ANDROID_LOG_INFO, "halide", "%s", str);
 }
 
-}}}
+}

--- a/src/runtime/fake_thread_pool.cpp
+++ b/src/runtime/fake_thread_pool.cpp
@@ -1,19 +1,14 @@
 #include "HalideRuntime.h"
 
 extern "C" {
-WEAK int halide_do_task(void *user_context, halide_task_t f, int idx,
-                        uint8_t *closure);
-}
 
-namespace Halide { namespace Runtime { namespace Internal {
-
-WEAK int default_do_task(void *user_context, halide_task_t f, int idx,
-                        uint8_t *closure) {
+WEAK int halide_default_do_task(void *user_context, halide_task_t f, int idx,
+                                uint8_t *closure) {
     return f(user_context, idx, closure);
 }
 
-WEAK int default_do_par_for(void *user_context, halide_task_t f,
-                           int min, int size, uint8_t *closure) {
+WEAK int halide_default_do_par_for(void *user_context, halide_task_t f,
+                                   int min, int size, uint8_t *closure) {
     for (int x = min; x < min + size; x++) {
         int result = halide_do_task(user_context, f, x, closure);
         if (result) {
@@ -23,8 +18,12 @@ WEAK int default_do_par_for(void *user_context, halide_task_t f,
     return 0;
 }
 
-WEAK halide_do_task_t custom_do_task = default_do_task;
-WEAK halide_do_par_for_t custom_do_par_for = default_do_par_for;
+}
+
+namespace Halide { namespace Runtime { namespace Internal {
+
+WEAK halide_do_task_t custom_do_task = halide_default_do_task;
+WEAK halide_do_par_for_t custom_do_par_for = halide_default_do_par_for;
 
 }}} // namespace Halide::Runtime::Internal
 

--- a/src/runtime/ios_io.cpp
+++ b/src/runtime/ios_io.cpp
@@ -1,12 +1,12 @@
 #include "HalideRuntime.h"
 #include "objc_support.h"
 
-namespace Halide { namespace Runtime { namespace Internal {
+extern "C" {
 
-WEAK void halide_print_impl(void *user_context, const char *str) {
+WEAK void halide_default_print(void *user_context, const char *str) {
     void *pool = create_autorelease_pool();
     ns_log_utf8_string(str);
     drain_autorelease_pool(pool);
 }
 
-}}} // namespace Halide::Runtime::Internal
+}  // extern "C"

--- a/src/runtime/osx_get_symbol.cpp
+++ b/src/runtime/osx_get_symbol.cpp
@@ -10,19 +10,15 @@ void *dlsym(void *, const char *);
 #define RTLD_LAZY 0x1
 #define RTLD_LOCAL 0x4
 
-}  // extern "C"
-
-namespace Halide { namespace Runtime { namespace Internal {
-
-WEAK void *halide_get_symbol_impl(const char *name) {
+WEAK void *halide_default_get_symbol(const char *name) {
     return dlsym(RTLD_DEFAULT, name);
 }
 
-WEAK void *halide_load_library_impl(const char *name) {
+WEAK void *halide_default_load_library(const char *name) {
     return dlopen(name, RTLD_LAZY | RTLD_LOCAL);
 }
 
-WEAK void *halide_get_library_symbol_impl(void *lib, const char *name) {
+WEAK void *halide_default_get_library_symbol(void *lib, const char *name) {
     // We want our semantics to be such that if lib is NULL, this call
     // is equivalent to halide_get_symbol.
     if (lib == NULL) {
@@ -31,9 +27,13 @@ WEAK void *halide_get_library_symbol_impl(void *lib, const char *name) {
     return dlsym(lib, name);
 }
 
-WEAK halide_get_symbol_t custom_get_symbol = halide_get_symbol_impl;
-WEAK halide_load_library_t custom_load_library = halide_load_library_impl;
-WEAK halide_get_library_symbol_t custom_get_library_symbol = halide_get_library_symbol_impl;
+}  // extern "C"
+
+namespace Halide { namespace Runtime { namespace Internal {
+
+WEAK halide_get_symbol_t custom_get_symbol = halide_default_get_symbol;
+WEAK halide_load_library_t custom_load_library = halide_default_load_library;
+WEAK halide_get_library_symbol_t custom_get_library_symbol = halide_default_get_library_symbol;
 
 }}} // namespace Halide::Runtime::Internal
 

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -5,11 +5,7 @@ extern "C" {
 extern void *malloc(size_t);
 extern void free(void *);
 
-}
-
-namespace Halide { namespace Runtime { namespace Internal {
-
-WEAK void *default_malloc(void *user_context, size_t x) {
+WEAK void *halide_default_malloc(void *user_context, size_t x) {
     // Allocate enough space for aligning the pointer we return.
     const size_t alignment = 128;
     void *orig = malloc(x + alignment);
@@ -23,12 +19,16 @@ WEAK void *default_malloc(void *user_context, size_t x) {
     return ptr;
 }
 
-WEAK void default_free(void *user_context, void *ptr) {
+WEAK void halide_default_free(void *user_context, void *ptr) {
     free(((void**)ptr)[-1]);
 }
 
-WEAK halide_malloc_t custom_malloc = default_malloc;
-WEAK halide_free_t custom_free = default_free;
+}
+
+namespace Halide { namespace Runtime { namespace Internal {
+
+WEAK halide_malloc_t custom_malloc = halide_default_malloc;
+WEAK halide_free_t custom_free = halide_default_free;
 
 }}} // namespace Halide::Runtime::Internal
 

--- a/src/runtime/posix_error_handler.cpp
+++ b/src/runtime/posix_error_handler.cpp
@@ -1,9 +1,9 @@
 #include "HalideRuntime.h"
 #include "printer.h"
 
-namespace Halide { namespace Runtime { namespace Internal {
+extern "C" {
 
-WEAK void default_error_handler(void *user_context, const char *msg) {
+WEAK void halide_default_error(void *user_context, const char *msg) {
     char buf[4096];
     char *dst = halide_string_to_string(buf, buf + 4094, "Error: ");
     dst = halide_string_to_string(dst, buf + 4094, msg);
@@ -19,7 +19,11 @@ WEAK void default_error_handler(void *user_context, const char *msg) {
     abort();
 }
 
-WEAK halide_error_handler_t error_handler = default_error_handler;
+}
+
+namespace Halide { namespace Runtime { namespace Internal {
+
+WEAK halide_error_handler_t error_handler = halide_default_error;
 
 }}} // namespace Halide::Runtime::Internal
 

--- a/src/runtime/posix_get_symbol.cpp
+++ b/src/runtime/posix_get_symbol.cpp
@@ -9,15 +9,11 @@ char *dlerror();
 
 #define RTLD_LAZY 0x1
 
-}  // extern "C"
-
-namespace Halide { namespace Runtime { namespace Internal {
-
-WEAK void *halide_get_symbol_impl(const char *name) {
+WEAK void *halide_default_get_symbol(const char *name) {
     return dlsym(NULL, name);
 }
 
-WEAK void *halide_load_library_impl(const char *name) {
+WEAK void *halide_default_load_library(const char *name) {
     void *lib = dlopen(name, RTLD_LAZY);
     if (!lib) {
         debug(NULL) << "dlerror: " << dlerror() << "\n";
@@ -25,13 +21,17 @@ WEAK void *halide_load_library_impl(const char *name) {
     return lib;
 }
 
-WEAK void *halide_get_library_symbol_impl(void *lib, const char *name) {
+WEAK void *halide_default_get_library_symbol(void *lib, const char *name) {
     return dlsym(lib, name);
 }
 
-WEAK halide_get_symbol_t custom_get_symbol = halide_get_symbol_impl;
-WEAK halide_load_library_t custom_load_library = halide_load_library_impl;
-WEAK halide_get_library_symbol_t custom_get_library_symbol = halide_get_library_symbol_impl;
+}  // extern "C"
+
+namespace Halide { namespace Runtime { namespace Internal {
+
+WEAK halide_get_symbol_t custom_get_symbol = halide_default_get_symbol;
+WEAK halide_load_library_t custom_load_library = halide_default_load_library;
+WEAK halide_get_library_symbol_t custom_get_library_symbol = halide_default_get_library_symbol;
 
 }}} // namespace Halide::Runtime::Internal
 

--- a/src/runtime/posix_io.cpp
+++ b/src/runtime/posix_io.cpp
@@ -1,9 +1,9 @@
 #include "HalideRuntime.h"
 
-namespace Halide { namespace Runtime { namespace Internal {
+extern "C" {
 
-WEAK void halide_print_impl(void *user_context, const char *str) {
+WEAK void halide_default_print(void *user_context, const char *str) {
     write(STDERR_FILENO, str, strlen(str));
 }
 
-}}} // namespace Halide::Runtime::Internal
+}

--- a/src/runtime/posix_print.cpp
+++ b/src/runtime/posix_print.cpp
@@ -1,10 +1,10 @@
 #include "HalideRuntime.h"
 
+extern "C" void halide_default_print(void *, const char *);
+
 namespace Halide { namespace Runtime { namespace Internal {
 
-extern void halide_print_impl(void *, const char *);
-
-WEAK halide_print_t custom_print = halide_print_impl;
+WEAK halide_print_t custom_print = halide_default_print;
 
 }}} // namespace Halide::Runtime::Internal
 

--- a/src/runtime/qurt_allocator.cpp
+++ b/src/runtime/qurt_allocator.cpp
@@ -5,11 +5,7 @@ extern "C" {
 extern void *malloc(size_t);
 extern void free(void *);
 
-}
-
-namespace Halide { namespace Runtime { namespace Internal {
-
-WEAK void *default_malloc(void *user_context, size_t x) {
+WEAK void *halide_default_malloc(void *user_context, size_t x) {
     // Hexagon needs up to 128 byte alignment.
     const size_t alignment = 128;
 
@@ -28,12 +24,16 @@ WEAK void *default_malloc(void *user_context, size_t x) {
     return ptr;
 }
 
-WEAK void default_free(void *user_context, void *ptr) {
+WEAK void halide_default_free(void *user_context, void *ptr) {
     free(((void**)ptr)[-1]);
 }
 
-WEAK halide_malloc_t custom_malloc = default_malloc;
-WEAK halide_free_t custom_free = default_free;
+}
+
+namespace Halide { namespace Runtime { namespace Internal {
+
+WEAK halide_malloc_t custom_malloc = halide_default_malloc;
+WEAK halide_free_t custom_free = halide_default_free;
 
 }}} // namespace Halide::Runtime::Internal
 

--- a/src/runtime/thread_pool.cpp
+++ b/src/runtime/thread_pool.cpp
@@ -11,8 +11,8 @@ WEAK void halide_thread_pool_cleanup() {
 }
 
 namespace Halide { namespace Runtime { namespace Internal {
-WEAK halide_do_task_t custom_do_task = default_do_task;
-WEAK halide_do_par_for_t custom_do_par_for = default_do_par_for;
+WEAK halide_do_task_t custom_do_task = halide_default_do_task;
+WEAK halide_do_par_for_t custom_do_par_for = halide_default_do_par_for;
 }}}
 
 WEAK halide_do_task_t halide_set_custom_do_task(halide_do_task_t f) {

--- a/src/runtime/tracing.cpp
+++ b/src/runtime/tracing.cpp
@@ -15,7 +15,11 @@ WEAK int halide_trace_file_lock = 0;
 WEAK bool halide_trace_file_initialized = false;
 WEAK void *halide_trace_file_internally_opened = NULL;
 
-WEAK int32_t default_trace(void *user_context, const halide_trace_event_t *e) {
+}}}
+
+extern "C" {
+
+WEAK int32_t halide_default_trace(void *user_context, const halide_trace_event_t *e) {
     static int32_t ids = 1;
 
     int32_t my_id = __sync_fetch_and_add(&ids, 1);
@@ -161,7 +165,11 @@ WEAK int32_t default_trace(void *user_context, const halide_trace_event_t *e) {
     return my_id;
 }
 
-WEAK trace_fn halide_custom_trace = default_trace;
+} // extern "C"
+
+namespace Halide { namespace Runtime { namespace Internal {
+
+WEAK trace_fn halide_custom_trace = halide_default_trace;
 
 }}} // namespace Halide::Runtime::Internal
 

--- a/src/runtime/windows_get_symbol.cpp
+++ b/src/runtime/windows_get_symbol.cpp
@@ -14,15 +14,11 @@ WIN32API unsigned SetErrorMode(unsigned);
 #define SEM_FAILCRITICALERRORS 0x0001
 #define SEM_NOOPENFILEERRORBOX 0x8000
 
-}  // extern "C"
-
-namespace Halide { namespace Runtime { namespace Internal {
-
-WEAK void *halide_get_symbol_impl(const char *name) {
+WEAK void *halide_default_get_symbol(const char *name) {
     return GetProcAddress(NULL, name);
 }
 
-WEAK void *halide_load_library_impl(const char *name) {
+WEAK void *halide_default_load_library(const char *name) {
     // Suppress dialog windows during library open.
     unsigned old_mode = SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOOPENFILEERRORBOX);
     void *lib = LoadLibraryA(name);
@@ -30,13 +26,17 @@ WEAK void *halide_load_library_impl(const char *name) {
     return lib;
 }
 
-WEAK void *halide_get_library_symbol_impl(void *lib, const char *name) {
+WEAK void *halide_default_get_library_symbol(void *lib, const char *name) {
     return GetProcAddress(lib, name);
 }
 
-WEAK halide_get_symbol_t custom_get_symbol = halide_get_symbol_impl;
-WEAK halide_load_library_t custom_load_library = halide_load_library_impl;
-WEAK halide_get_library_symbol_t custom_get_library_symbol = halide_get_library_symbol_impl;
+}  // extern "C"
+
+namespace Halide { namespace Runtime { namespace Internal {
+
+WEAK halide_get_symbol_t custom_get_symbol = halide_default_get_symbol;
+WEAK halide_load_library_t custom_load_library = halide_default_load_library;
+WEAK halide_get_library_symbol_t custom_get_library_symbol = halide_default_get_library_symbol;
 
 }}} // namespace Halide::Runtime::Internal
 

--- a/src/runtime/windows_io.cpp
+++ b/src/runtime/windows_io.cpp
@@ -1,9 +1,9 @@
 #include "HalideRuntime.h"
 
-namespace Halide { namespace Runtime { namespace Internal {
+extern "C" {
 
-WEAK void halide_print_impl(void *user_context, const char *str) {
+WEAK void halide_default_print(void *user_context, const char *str) {
     write(STDOUT_FILENO, str, strlen(str));
 }
 
-}}} // namespace Halide::Runtime::Internal
+}


### PR DESCRIPTION
So that custom overrides can build on top of the default implementations (e.g. add logging), instead of having to replace them completely.