### PR TITLE
msan_aottest should be skipped for MSVC as well as MinGW

### DIFF
--- a/test/generator/msan_aottest.cpp
+++ b/test/generator/msan_aottest.cpp
@@ -1,8 +1,8 @@
-#ifdef __MINGW32__
+#if defined(__MINGW32__) || defined(_MSC_VER)
 #include <stdio.h>
-// Mingw doesn't support weak linkage
+// MSAN isn't supported for any Windows variant
 int main(int argc, char **argv) {
-    printf("Skipping test on mingw");
+    printf("Skipping test on Windows\n");
     return 0;
 }
 #else

--- a/test/generator/msan_aottest.cpp
+++ b/test/generator/msan_aottest.cpp
@@ -1,4 +1,4 @@
-#if defined(__MINGW32__) || defined(_MSC_VER)
+#ifdef _WIN32
 #include <stdio.h>
 // MSAN isn't supported for any Windows variant
 int main(int argc, char **argv) {


### PR DESCRIPTION
(1) overriding the msan hooks requires weak linkage or /FORCE usage;
the former isn’t available and the latter we want to turn down
(2) MSAN isn’t supported on Windows targets anyway