### PR TITLE
Add chainable setters for ScheduleParams in stubs

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -366,22 +366,25 @@ void StubEmitter::emit_generator_params_struct() {
 void StubEmitter::emit_schedule_params_setters() {
     stream << indent() << "// set_schedule_param methods\n";
     stream << indent() << "template <typename T>\n";
-    stream << indent() << class_name << " &set_schedule_param(const std::string &name, const T &value) {\n";
+    stream << indent() << "inline " << class_name << " &set_schedule_param(const std::string &name, const T &value) {\n";
     indent_level++;
     stream << indent() << "(void) GeneratorStub::set_schedule_param(name, value);\n";
     stream << indent() << "return *this;\n";
     indent_level--;
     stream << indent() << "}\n";
 
-    // TODO: do we still want these, now that we have ScheduleParams replicated?
-    // for (auto *sp : schedule_params) {
-    //     std::string c_type = sp->is_looplevel_param() ? "LoopLevel" : halide_type_to_c_type(sp->scalar_type());
-    //     stream << indent() << class_name << " &set_" << sp->name() << "(const " << c_type << " &value) {\n";
-    //     indent_level++;
-    //     stream << indent() << "return set_schedule_param(\"" << sp->name() <<  "\", value);\n";
-    //     indent_level--;
-    //     stream << indent() << "}\n";
-    // }
+    const auto &v = schedule_params;
+    if (!v.empty()) {
+        for (auto *p : v) {
+            std::string c_type = p->is_looplevel_param() ? "LoopLevel" : halide_type_to_c_type(p->scalar_type());
+            stream << indent() << "inline " << class_name << " &set_" << p->name() << "(const " << c_type << " &value) {\n";
+            indent_level++;
+            stream << indent() << "this->" << p->name() << ".set(value);\n";
+            stream << indent() << "return *this;\n";
+            indent_level--;
+            stream << indent() << "}\n";
+        }
+    }
     stream << "\n";
 }
 

--- a/test/generator/example_generator.cpp
+++ b/test/generator/example_generator.cpp
@@ -45,6 +45,7 @@ public:
                                        { "bar", Bar } } };
     // ...or bools: {default}
     ScheduleParam<bool> vectorize{ "vectorize", true };
+    ScheduleParam<bool> parallelize{ "parallelize", true };
 
     // These are bad names that will produce errors at build time:
     // GeneratorParam<bool> badname{ " flag", true };
@@ -84,9 +85,17 @@ public:
         // Note that we can use the Generator method natural_vector_size()
         // here; this produces the width of the SIMD vector being targeted
         // divided by the width of the data type.
+        const int v = natural_vector_size(output.type());
+        output
+            .specialize(parallelize && vectorize)
+            .parallel(y)
+            .vectorize(x, v);
+        output
+            .specialize(parallelize)
+            .parallel(y);
         output
             .specialize(vectorize)
-            .vectorize(x, natural_vector_size(output.type()));
+            .vectorize(x, v);
     }
 
 private:

--- a/test/generator/example_jittest.cpp
+++ b/test/generator/example_jittest.cpp
@@ -47,10 +47,25 @@ int main(int argc, char **argv) {
         // the GeneratorParams entirely to use their default values.
         auto gen = example(context, /* inputs: */ { 1.f });
 
-        // We'll set "vectorize=false" in the ScheduleParams, just to
+        // We'll set "vectorize=false parallelize=false" in the ScheduleParams, just to
         // show that we can:
         gen.vectorize.set(false);
+        gen.parallelize.set(false);
         gen.schedule();
+
+        Halide::Buffer<int32_t> img(kSize, kSize, 3);
+        gen.realize(img);
+        verify(img, 1, 1, 3);
+    }
+
+    {
+        auto gen = example(context, /* inputs: */ { 1.f });
+
+        // Same as before, but we'll use chained setters for the ScheduleParams;
+        // this is identical in function to the previous block, but a style that
+        // some people prefer. Note that we can also chain the "schedule()"
+        // call on the end.
+        gen.set_vectorize(false).set_parallelize(false).schedule();
 
         Halide::Buffer<int32_t> img(kSize, kSize, 3);
         gen.realize(img);


### PR DESCRIPTION
This is purely an optional stylistic choice; I personally prefer this
because of the symmetry with scheduling calls, and the overhead for
supporting it is pretty close to nil.

(I’m cherry-picking some pieces from other not-ready-to-land PRs I have
that I think are worthwhile on their own.)