### PR TITLE
Use log2 from <cmath>

### DIFF
--- a/apps/fft/main.cpp
+++ b/apps/fft/main.cpp
@@ -6,6 +6,8 @@
 #include "Halide.h"
 #include <cstdio>
 #include <vector>
+#include <cmath>  // for log2
+
 #include "fft.h"
 #include "halide_benchmark.h"
 
@@ -30,10 +32,6 @@ ComplexFunc make_complex(const Buffer<T> &re) {
     ComplexFunc ret;
     ret(x, y) = re(x, y);
     return ret;
-}
-
-double log2(double x) {
-    return log(x)/log(2.0);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Defining our own causes link errors in some configurations.