### PR TITLE
Pass entire buffers to dev_run

### DIFF
--- a/apps/openglcompute/Makefile
+++ b/apps/openglcompute/Makefile
@@ -1,5 +1,7 @@
 include ../support/Makefile.inc
 
+CXX ?= c++
+
 TOP := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
 .PHONY: all $(TOP)
 all: run run-two
@@ -8,7 +10,7 @@ $(HALIDE_LIB): $(TOP)
 	$(MAKE) -C $(TOP)
 
 test_%: test_%.cpp
-	g++ -std=c++11 -I ../../include/ $< -L ../../bin/ -lHalide -o $@ -g
+	$(CXX) -std=c++11 -I ../../include/ $< -L ../../bin/ -lHalide -o $@ -g
 
 avg_filter_uint32t.o avg_filter_uint32t.h avg_filter_float.o avg_filter_float.h: test_oglc_avg
 	LD_LIBRARY_PATH=../../bin DYLD_LIBRARY_PATH=../../bin HL_TARGET=arm-32-android-armv7s-openglcompute ./$<

--- a/apps/openglcompute/jni/oglc_two_kernels_run.cpp
+++ b/apps/openglcompute/jni/oglc_two_kernels_run.cpp
@@ -11,11 +11,6 @@
 #define  LOGI(...)  __android_log_print(ANDROID_LOG_INFO, "oglc_run", __VA_ARGS__)
 #define  LOGE(...)  __android_log_print(ANDROID_LOG_ERROR, "oglc_run", __VA_ARGS__)
 
-extern "C" int halide_copy_to_host(void *, buffer_t *);
-extern "C" int halide_device_sync(void *, buffer_t *);
-extern "C" int halide_device_free(void *, buffer_t* buf);
-extern "C" void halide_device_release(void *, const halide_device_interface_t *interface);
-
 template<typename T>
 void print(Halide::Runtime::Buffer<T> buf) {
     for (int j = 0; j < std::min(buf.height(), 10); j++) {

--- a/apps/openglcompute/test_two_kernels.cpp
+++ b/apps/openglcompute/test_two_kernels.cpp
@@ -6,12 +6,12 @@ int main(int argc, char** argv) {
     ImageParam input(UInt(32), 3, "input");
     input.dim(2).set_bounds(0, 4).set_stride(1).dim(0).set_stride(4);
 
-    Var x, y, c;
+    Var x, y, c, xi, yi;
     Func f("f");
     f(x, y, c) = input(x, y, c) + 1;
     f.bound(c, 0, 4)
-     .reorder_storage(c, x, y)
-     .reorder(c, x, y);
+        .reorder_storage(c, x, y)
+        .reorder(c, x, y);
 
     f.compute_root();
     f.output_buffer().dim(2).set_bounds(0, 4).set_stride(1).dim(0).set_stride(4);
@@ -19,20 +19,22 @@ int main(int argc, char** argv) {
     Target target = get_target_from_environment();
     if (target.has_gpu_feature() || target.has_feature(Target::OpenGLCompute)) {
         f.unroll(c)
-         .gpu_tile(x, y, 64, 64);
+            .gpu_tile(x, y, xi, yi, 64, 64);
     }
 
     Func g("g");
     g(x, y, c) = f(x, y, c) - 1;
     g.bound(c, 0, 4)
-     .reorder_storage(c, x, y)
-     .reorder(c, x, y);
+        .reorder_storage(c, x, y)
+        .reorder(c, x, y);
     if (target.has_gpu_feature() || target.has_feature(Target::OpenGLCompute)) {
         g.unroll(c)
-         .gpu_tile(x, y, 64, 64);
+            .gpu_tile(x, y, xi, yi, 64, 64);
     }
     g.output_buffer().dim(2).set_bounds(0, 4).set_stride(1).dim(0).set_stride(4);
 
     std::string fn_name = std::string("two_kernels_filter") + (argc > 1 ? argv[1] : "");
     g.compile_to_file(fn_name, {input}, fn_name);
+
+    return 0;
 }

--- a/src/runtime/cuda.cpp
+++ b/src/runtime/cuda.cpp
@@ -765,7 +765,7 @@ WEAK int halide_cuda_run(void *user_context,
     for (size_t i = 0; i <= num_args; i++) { // Get NULL at end.
         if (arg_is_buffer[i]) {
             halide_assert(user_context, arg_sizes[i] == sizeof(uint64_t));
-            dev_handles[i] = (*(uint64_t *)args[i]);
+            dev_handles[i] = ((halide_buffer_t *)args[i])->device;
             translated_args[i] = &(dev_handles[i]);
             debug(user_context) << "    halide_cuda_run translated arg" << (int)i
                                 << " [" << (*((void **)translated_args[i])) << " ...]\n";

--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -255,7 +255,7 @@ WEAK int map_arguments(void *user_context, int arg_count,
             // This is a buffer, map it and put the mapped buffer into
             // the result.
             halide_assert(user_context, arg_sizes[i] == sizeof(uint64_t));
-            uint64_t device_handle = *((uint64_t *)args[i]);
+            uint64_t device_handle = ((halide_buffer_t *)args[i])->device;
             ion_device_handle *ion_handle = reinterpret<ion_device_handle *>(device_handle);
             debug(user_context) << i << ", " << device_handle << "\n";
             mapped_arg.data = reinterpret_cast<uint8_t*>(ion_handle->buffer);

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -689,7 +689,8 @@ WEAK int halide_metal_run(void *user_context,
     for (size_t i = 0; arg_sizes[i] != 0; i++) {
         if (arg_is_buffer[i]) {
             halide_assert(user_context, arg_sizes[i] == sizeof(uint64_t));
-            mtl_buffer *metal_buffer = *((mtl_buffer **)args[i]);
+            uint64_t handle = ((halide_buffer_t *)args[i])->device;
+            mtl_buffer *metal_buffer = (mtl_buffer *)handle;
             set_input_buffer(encoder, metal_buffer, buffer_index);
             buffer_index++;
         }

--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -974,7 +974,7 @@ WEAK int halide_opencl_run(void *user_context,
 
         if (arg_is_buffer[i]) {
             halide_assert(user_context, arg_sizes[i] == sizeof(uint64_t));
-            uint64_t opencl_handle = *((uint64_t *)this_arg);
+            uint64_t opencl_handle = ((halide_buffer_t *)this_arg)->device;
             debug(user_context) << "Mapped dev handle is: " << (void *)opencl_handle << "\n";
             // In 32-bit mode, opencl only wants the bottom 32 bits of
             // the handle, so use sizeof(void *) instead of

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -1510,10 +1510,10 @@ WEAK int halide_opengl_run(void *user_context,
     for (int i = 0; args[i]; i++, kernel_arg = kernel_arg->next) {
 
         if (kernel_arg->kind == Argument::Outbuf) {
-            halide_assert(user_context, is_buffer[i] && "OpenGL Outbuf argument is not a buffer.")
+            halide_assert(user_context, is_buffer[i] && "OpenGL Outbuf argument is not a buffer.");
             // Check if the output buffer will be bound by the client instead of
             // the Halide runtime
-            uint64_t handle = *(uint64_t *)args[i];
+            uint64_t handle = ((halide_buffer_t *)args[i])->device;
             if (!handle) {
                 error(user_context) << "GLSL: Encountered invalid NULL dev pointer";
                 return 1;
@@ -1534,7 +1534,7 @@ WEAK int halide_opengl_run(void *user_context,
                 error(user_context) << "No sampler defined for input texture.";
                 return 1;
             }
-            uint64_t handle = *(uint64_t *)args[i];
+            uint64_t handle = ((halide_buffer_t *)args[i])->device;
             if (!handle) {
                 error(user_context) << "GLSL: Encountered invalid NULL dev pointer";
                 return 1;

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -1667,7 +1667,7 @@ WEAK int halide_opengl_run(void *user_context,
             return 1;
         }
 
-        uint64_t handle = *(uint64_t *)args[i];
+        uint64_t handle = ((halide_buffer_t *)args[i])->device;
         if (!handle) {
             error(user_context) << "GLSL: Encountered invalid NULL dev pointer";
             return 1;

--- a/src/runtime/openglcompute.cpp
+++ b/src/runtime/openglcompute.cpp
@@ -480,7 +480,7 @@ WEAK int halide_openglcompute_run(void *user_context, void *state_ptr,
                 return -1;
             }
         } else {
-            uint64_t arg_value = *(uint64_t *)args[i];
+            uint64_t arg_value = ((halide_buffer_t *)args[i])->device;
 
             GLuint the_buffer = (GLuint)arg_value;
             global_state.BindBufferBase(GL_SHADER_STORAGE_BUFFER, i, the_buffer);


### PR DESCRIPTION
instead of just the device handle

The opengl backend could be simplified if it knew the dimensions of the
output buffer.