### PR TITLE
More simplification using static bounds of Params.

### DIFF
--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -310,7 +310,7 @@ private:
             *min_val = *max_val = *i;
             return true;
         } else if (const uint64_t *u = as_const_uint(e)) {
-            if (t.bits() < 64) {
+            if (Int(64).can_represent(*u)) {
                 *min_val = *max_val = (int64_t) *u;
                 return true;
             }
@@ -456,12 +456,12 @@ private:
             int64_t min, max;
             if ((cast->type.is_int() || cast->type.is_uint()) &&
                 const_int_bounds(cast->value, &min, &max)) {
-                    if (can_prove(Expr(min) >= cast->type.min()) &&
-                        can_prove(Expr(max) <= cast->type.max())) {
-                        *min_val = min;
-                        *max_val = max;
-                        return true;
-                    }
+                if (can_prove(Expr(min) >= cast->type.min()) &&
+                    can_prove(Expr(max) <= cast->type.max())) {
+                    *min_val = min;
+                    *max_val = max;
+                    return true;
+                }
             }
         }
         return false;

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -309,11 +309,11 @@ private:
         if (const int64_t *i = as_const_int(e)) {
             *min_val = *max_val = *i;
             return true;
-        } else if (t.is_uint() && is_const(e) && t.is_scalar()
-                   && t.bits() < 64) {
-            const uint64_t *u = as_const_uint(e);
-            *min_val = *max_val = (int64_t) *u;
-            return true;
+        } else if (const uint64_t *u = as_const_uint(e)) {
+            if (t.bits() < 64) {
+                *min_val = *max_val = (int64_t) *u;
+                return true;
+            }
         } else if (const Variable *v = e.as<Variable>()) {
             if (bounds_info.contains(v->name)) {
                 pair<int64_t, int64_t> b = bounds_info.get(v->name);
@@ -328,7 +328,6 @@ private:
                     const_int_bounds(v->param.get_max_value(), &min_b, &max_b)) {
                     *min_val = std::min(min_a, min_b);
                     *max_val = std::max(max_a, max_b);
-                    bounds_info.push(v->name, { *min_val, *max_val });
                     return true;
                 }
             }


### PR DESCRIPTION
This PR adds the ability to simplify bounds using the static bounds of Params.

const_int_bounds() also digs into Uint and Cast to a limited extent.