### PR TITLE
Added PrintLoopNest.h into CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -346,6 +346,7 @@ set(HEADER_FILES
   Parameter.h
   PartitionLoops.h
   Pipeline.h
+  PrintLoopNest.h
   Prefetch.h
   Profiling.h
   Qualify.h


### PR DESCRIPTION
It allows get output string of internal `print_loop_nest`.