### PR TITLE
Compiler performance penny-pinching

### DIFF
--- a/python_bindings/python/IROperator.cpp
+++ b/python_bindings/python/IROperator.cpp
@@ -201,12 +201,12 @@ void defineOperators() {
     // defined in IROperator.h
 
     h::Expr (*max_exprs)(h::Expr, h::Expr) = &h::max;
-    h::Expr (*max_expr_int)(const h::Expr &, int) = &h::max;
-    h::Expr (*max_int_expr)(int, const h::Expr &) = &h::max;
+    h::Expr (*max_expr_int)(h::Expr, int) = &h::max;
+    h::Expr (*max_int_expr)(int, h::Expr) = &h::max;
 
     h::Expr (*min_exprs)(h::Expr, h::Expr) = &h::min;
-    h::Expr (*min_expr_int)(const h::Expr &, int) = &h::min;
-    h::Expr (*min_int_expr)(int, const h::Expr &) = &h::min;
+    h::Expr (*min_expr_int)(h::Expr, int) = &h::min;
+    h::Expr (*min_int_expr)(int, h::Expr) = &h::min;
 
     p::def("max", max_exprs,
            p::args("a", "b"),

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -5,175 +5,175 @@
 namespace Halide {
 namespace Internal {
 
-Expr Cast::make(Type t, const Expr &v) {
+Expr Cast::make(Type t, Expr v) {
     internal_assert(v.defined()) << "Cast of undefined\n";
     internal_assert(t.lanes() == v.type().lanes()) << "Cast may not change vector widths\n";
 
     Cast *node = new Cast;
     node->type = t;
-    node->value = v;
+    node->value = std::move(v);
     return node;
 }
 
-Expr Add::make(const Expr &a, const Expr &b) {
+Expr Add::make(Expr a, Expr b) {
     internal_assert(a.defined()) << "Add of undefined\n";
     internal_assert(b.defined()) << "Add of undefined\n";
     internal_assert(a.type() == b.type()) << "Add of mismatched types\n";
 
     Add *node = new Add;
     node->type = a.type();
-    node->a = a;
-    node->b = b;
+    node->a = std::move(a);
+    node->b = std::move(b);
     return node;
 }
 
-Expr Sub::make(const Expr &a, const Expr &b) {
+Expr Sub::make(Expr a, Expr b) {
     internal_assert(a.defined()) << "Sub of undefined\n";
     internal_assert(b.defined()) << "Sub of undefined\n";
     internal_assert(a.type() == b.type()) << "Sub of mismatched types\n";
 
     Sub *node = new Sub;
     node->type = a.type();
-    node->a = a;
-    node->b = b;
+    node->a = std::move(a);
+    node->b = std::move(b);
     return node;
 }
 
-Expr Mul::make(const Expr &a, const Expr &b) {
+Expr Mul::make(Expr a, Expr b) {
     internal_assert(a.defined()) << "Mul of undefined\n";
     internal_assert(b.defined()) << "Mul of undefined\n";
     internal_assert(a.type() == b.type()) << "Mul of mismatched types\n";
 
     Mul *node = new Mul;
     node->type = a.type();
-    node->a = a;
-    node->b = b;
+    node->a = std::move(a);
+    node->b = std::move(b);
     return node;
 }
 
-Expr Div::make(const Expr &a, const Expr &b) {
+Expr Div::make(Expr a, Expr b) {
     internal_assert(a.defined()) << "Div of undefined\n";
     internal_assert(b.defined()) << "Div of undefined\n";
     internal_assert(a.type() == b.type()) << "Div of mismatched types\n";
 
     Div *node = new Div;
     node->type = a.type();
-    node->a = a;
-    node->b = b;
+    node->a = std::move(a);
+    node->b = std::move(b);
     return node;
 }
 
-Expr Mod::make(const Expr &a, const Expr &b) {
+Expr Mod::make(Expr a, Expr b) {
     internal_assert(a.defined()) << "Mod of undefined\n";
     internal_assert(b.defined()) << "Mod of undefined\n";
     internal_assert(a.type() == b.type()) << "Mod of mismatched types\n";
 
     Mod *node = new Mod;
     node->type = a.type();
-    node->a = a;
-    node->b = b;
+    node->a = std::move(a);
+    node->b = std::move(b);
     return node;
 }
 
-Expr Min::make(const Expr &a, const Expr &b) {
+Expr Min::make(Expr a, Expr b) {
     internal_assert(a.defined()) << "Min of undefined\n";
     internal_assert(b.defined()) << "Min of undefined\n";
     internal_assert(a.type() == b.type()) << "Min of mismatched types\n";
 
     Min *node = new Min;
     node->type = a.type();
-    node->a = a;
-    node->b = b;
+    node->a = std::move(a);
+    node->b = std::move(b);
     return node;
 }
 
-Expr Max::make(const Expr &a, const Expr &b) {
+Expr Max::make(Expr a, Expr b) {
     internal_assert(a.defined()) << "Max of undefined\n";
     internal_assert(b.defined()) << "Max of undefined\n";
     internal_assert(a.type() == b.type()) << "Max of mismatched types\n";
 
     Max *node = new Max;
     node->type = a.type();
-    node->a = a;
-    node->b = b;
+    node->a = std::move(a);
+    node->b = std::move(b);
     return node;
 }
 
-Expr EQ::make(const Expr &a, const Expr &b) {
+Expr EQ::make(Expr a, Expr b) {
     internal_assert(a.defined()) << "EQ of undefined\n";
     internal_assert(b.defined()) << "EQ of undefined\n";
     internal_assert(a.type() == b.type()) << "EQ of mismatched types\n";
 
     EQ *node = new EQ;
     node->type = Bool(a.type().lanes());
-    node->a = a;
-    node->b = b;
+    node->a = std::move(a);
+    node->b = std::move(b);
     return node;
 }
 
-Expr NE::make(const Expr &a, const Expr &b) {
+Expr NE::make(Expr a, Expr b) {
     internal_assert(a.defined()) << "NE of undefined\n";
     internal_assert(b.defined()) << "NE of undefined\n";
     internal_assert(a.type() == b.type()) << "NE of mismatched types\n";
 
     NE *node = new NE;
     node->type = Bool(a.type().lanes());
-    node->a = a;
-    node->b = b;
+    node->a = std::move(a);
+    node->b = std::move(b);
     return node;
 }
 
-Expr LT::make(const Expr &a, const Expr &b) {
+Expr LT::make(Expr a, Expr b) {
     internal_assert(a.defined()) << "LT of undefined\n";
     internal_assert(b.defined()) << "LT of undefined\n";
     internal_assert(a.type() == b.type()) << "LT of mismatched types\n";
 
     LT *node = new LT;
     node->type = Bool(a.type().lanes());
-    node->a = a;
-    node->b = b;
+    node->a = std::move(a);
+    node->b = std::move(b);
     return node;
 }
 
 
-Expr LE::make(const Expr &a, const Expr &b) {
+Expr LE::make(Expr a, Expr b) {
     internal_assert(a.defined()) << "LE of undefined\n";
     internal_assert(b.defined()) << "LE of undefined\n";
     internal_assert(a.type() == b.type()) << "LE of mismatched types\n";
 
     LE *node = new LE;
     node->type = Bool(a.type().lanes());
-    node->a = a;
-    node->b = b;
+    node->a = std::move(a);
+    node->b = std::move(b);
     return node;
 }
 
-Expr GT::make(const Expr &a, const Expr &b) {
+Expr GT::make(Expr a, Expr b) {
     internal_assert(a.defined()) << "GT of undefined\n";
     internal_assert(b.defined()) << "GT of undefined\n";
     internal_assert(a.type() == b.type()) << "GT of mismatched types\n";
 
     GT *node = new GT;
     node->type = Bool(a.type().lanes());
-    node->a = a;
-    node->b = b;
+    node->a = std::move(a);
+    node->b = std::move(b);
     return node;
 }
 
 
-Expr GE::make(const Expr &a, const Expr &b) {
+Expr GE::make(Expr a, Expr b) {
     internal_assert(a.defined()) << "GE of undefined\n";
     internal_assert(b.defined()) << "GE of undefined\n";
     internal_assert(a.type() == b.type()) << "GE of mismatched types\n";
 
     GE *node = new GE;
     node->type = Bool(a.type().lanes());
-    node->a = a;
-    node->b = b;
+    node->a = std::move(a);
+    node->b = std::move(b);
     return node;
 }
 
-Expr And::make(const Expr &a, const Expr &b) {
+Expr And::make(Expr a, Expr b) {
     internal_assert(a.defined()) << "And of undefined\n";
     internal_assert(b.defined()) << "And of undefined\n";
     internal_assert(a.type().is_bool()) << "lhs of And is not a bool\n";
@@ -182,12 +182,12 @@ Expr And::make(const Expr &a, const Expr &b) {
 
     And *node = new And;
     node->type = Bool(a.type().lanes());
-    node->a = a;
-    node->b = b;
+    node->a = std::move(a);
+    node->b = std::move(b);
     return node;
 }
 
-Expr Or::make(const Expr &a, const Expr &b) {
+Expr Or::make(Expr a, Expr b) {
     internal_assert(a.defined()) << "Or of undefined\n";
     internal_assert(b.defined()) << "Or of undefined\n";
     internal_assert(a.type().is_bool()) << "lhs of Or is not a bool\n";
@@ -196,22 +196,22 @@ Expr Or::make(const Expr &a, const Expr &b) {
 
     Or *node = new Or;
     node->type = Bool(a.type().lanes());
-    node->a = a;
-    node->b = b;
+    node->a = std::move(a);
+    node->b = std::move(b);
     return node;
 }
 
-Expr Not::make(const Expr &a) {
+Expr Not::make(Expr a) {
     internal_assert(a.defined()) << "Not of undefined\n";
     internal_assert(a.type().is_bool()) << "argument of Not is not a bool\n";
 
     Not *node = new Not;
     node->type = Bool(a.type().lanes());
-    node->a = a;
+    node->a = std::move(a);
     return node;
 }
 
-Expr Select::make(const Expr &condition, const Expr &true_value, const Expr &false_value) {
+Expr Select::make(Expr condition, Expr true_value, Expr false_value) {
     internal_assert(condition.defined()) << "Select of undefined\n";
     internal_assert(true_value.defined()) << "Select of undefined\n";
     internal_assert(false_value.defined()) << "Select of undefined\n";
@@ -223,13 +223,13 @@ Expr Select::make(const Expr &condition, const Expr &true_value, const Expr &fal
 
     Select *node = new Select;
     node->type = true_value.type();
-    node->condition = condition;
-    node->true_value = true_value;
-    node->false_value = false_value;
+    node->condition = std::move(condition);
+    node->true_value = std::move(true_value);
+    node->false_value = std::move(false_value);
     return node;
 }
 
-Expr Load::make(Type type, const std::string &name, const Expr &index, Buffer<> image, Parameter param, const Expr &predicate) {
+Expr Load::make(Type type, const std::string &name, Expr index, Buffer<> image, Parameter param, Expr predicate) {
     internal_assert(predicate.defined()) << "Load with undefined predicate\n";
     internal_assert(index.defined()) << "Load of undefined\n";
     internal_assert(type.lanes() == index.type().lanes()) << "Vector lanes of Load must match vector lanes of index\n";
@@ -239,14 +239,14 @@ Expr Load::make(Type type, const std::string &name, const Expr &index, Buffer<> 
     Load *node = new Load;
     node->type = type;
     node->name = name;
-    node->predicate = predicate;
-    node->index = index;
-    node->image = image;
-    node->param = param;
+    node->predicate = std::move(predicate);
+    node->index = std::move(index);
+    node->image = std::move(image);
+    node->param = std::move(param);
     return node;
 }
 
-Expr Ramp::make(const Expr &base, const Expr &stride, int lanes) {
+Expr Ramp::make(Expr base, Expr stride, int lanes) {
     internal_assert(base.defined()) << "Ramp of undefined\n";
     internal_assert(stride.defined()) << "Ramp of undefined\n";
     internal_assert(base.type().is_scalar()) << "Ramp with vector base\n";
@@ -256,76 +256,76 @@ Expr Ramp::make(const Expr &base, const Expr &stride, int lanes) {
 
     Ramp *node = new Ramp;
     node->type = base.type().with_lanes(lanes);
-    node->base = base;
-    node->stride = stride;
-    node->lanes = lanes;
+    node->base = std::move(base);
+    node->stride = std::move(stride);
+    node->lanes = std::move(lanes);
     return node;
 }
 
-Expr Broadcast::make(const Expr &value, int lanes) {
+Expr Broadcast::make(Expr value, int lanes) {
     internal_assert(value.defined()) << "Broadcast of undefined\n";
     internal_assert(value.type().is_scalar()) << "Broadcast of vector\n";
     internal_assert(lanes != 1) << "Broadcast of lanes 1\n";
 
     Broadcast *node = new Broadcast;
     node->type = value.type().with_lanes(lanes);
-    node->value = value;
+    node->value = std::move(value);
     node->lanes = lanes;
     return node;
 }
 
-Expr Let::make(const std::string &name, const Expr &value, const Expr &body) {
+Expr Let::make(const std::string &name, Expr value, Expr body) {
     internal_assert(value.defined()) << "Let of undefined\n";
     internal_assert(body.defined()) << "Let of undefined\n";
 
     Let *node = new Let;
     node->type = body.type();
     node->name = name;
-    node->value = value;
-    node->body = body;
+    node->value = std::move(value);
+    node->body = std::move(body);
     return node;
 }
 
-Stmt LetStmt::make(const std::string &name, const Expr &value, const Stmt &body) {
+Stmt LetStmt::make(const std::string &name, Expr value, Stmt body) {
     internal_assert(value.defined()) << "Let of undefined\n";
     internal_assert(body.defined()) << "Let of undefined\n";
 
     LetStmt *node = new LetStmt;
     node->name = name;
-    node->value = value;
-    node->body = body;
+    node->value = std::move(value);
+    node->body = std::move(body);
     return node;
 }
 
-Stmt AssertStmt::make(const Expr &condition, const Expr &message) {
+Stmt AssertStmt::make(Expr condition, Expr message) {
     internal_assert(condition.defined()) << "AssertStmt of undefined\n";
     internal_assert(message.type() == Int(32)) << "AssertStmt message must be an int:" << message << "\n";
 
     AssertStmt *node = new AssertStmt;
-    node->condition = condition;
-    node->message = message;
+    node->condition = std::move(condition);
+    node->message = std::move(message);
     return node;
 }
 
-Stmt ProducerConsumer::make(const std::string &name, bool is_producer, const Stmt &body) {
+Stmt ProducerConsumer::make(const std::string &name, bool is_producer, Stmt body) {
     internal_assert(body.defined()) << "ProducerConsumer of undefined\n";
 
     ProducerConsumer *node = new ProducerConsumer;
     node->name = name;
     node->is_producer = is_producer;
-    node->body = body;
+    node->body = std::move(body);
     return node;
 }
 
-Stmt ProducerConsumer::make_produce(const std::string &name, const Stmt &body) {
-    return ProducerConsumer::make(name, true, body);
+Stmt ProducerConsumer::make_produce(const std::string &name, Stmt body) {
+    return ProducerConsumer::make(name, true, std::move(body));
 }
 
-Stmt ProducerConsumer::make_consume(const std::string &name, const Stmt &body) {
-    return ProducerConsumer::make(name, false, body);
+Stmt ProducerConsumer::make_consume(const std::string &name, Stmt body) {
+    return ProducerConsumer::make(name, false, std::move(body));
 }
 
-Stmt For::make(const std::string &name, const Expr &min, const Expr &extent, ForType for_type, DeviceAPI device_api, const Stmt &body) {
+Stmt For::make(const std::string &name, Expr min, Expr extent, ForType for_type, DeviceAPI device_api, Stmt body) {
     internal_assert(min.defined()) << "For of undefined\n";
     internal_assert(extent.defined()) << "For of undefined\n";
     internal_assert(min.type().is_scalar()) << "For with vector min\n";
@@ -334,15 +334,15 @@ Stmt For::make(const std::string &name, const Expr &min, const Expr &extent, For
 
     For *node = new For;
     node->name = name;
-    node->min = min;
-    node->extent = extent;
+    node->min = std::move(min);
+    node->extent = std::move(extent);
     node->for_type = for_type;
     node->device_api = device_api;
-    node->body = body;
+    node->body = std::move(body);
     return node;
 }
 
-Stmt Store::make(const std::string &name, const Expr &value, const Expr &index, Parameter param, const Expr &predicate) {
+Stmt Store::make(const std::string &name, Expr value, Expr index, Parameter param, Expr predicate) {
     internal_assert(predicate.defined()) << "Store with undefined predicate\n";
     internal_assert(value.defined()) << "Store of undefined\n";
     internal_assert(index.defined()) << "Store of undefined\n";
@@ -352,10 +352,10 @@ Stmt Store::make(const std::string &name, const Expr &value, const Expr &index, 
 
     Store *node = new Store;
     node->name = name;
-    node->predicate = predicate;
-    node->value = value;
-    node->index = index;
-    node->param = param;
+    node->predicate = std::move(predicate);
+    node->value = std::move(value);
+    node->index = std::move(index);
+    node->param = std::move(param);
     return node;
 }
 
@@ -376,8 +376,8 @@ Stmt Provide::make(const std::string &name, const std::vector<Expr> &values, con
 }
 
 Stmt Allocate::make(const std::string &name, Type type, const std::vector<Expr> &extents,
-                    const Expr &condition, const Stmt &body,
-                    const Expr &new_expr, const std::string &free_function) {
+                    Expr condition, Stmt body,
+                    Expr new_expr, const std::string &free_function) {
     for (size_t i = 0; i < extents.size(); i++) {
         internal_assert(extents[i].defined()) << "Allocate of undefined extent\n";
         internal_assert(extents[i].type().is_scalar() == 1) << "Allocate of vector extent\n";
@@ -390,10 +390,10 @@ Stmt Allocate::make(const std::string &name, Type type, const std::vector<Expr> 
     node->name = name;
     node->type = type;
     node->extents = extents;
-    node->new_expr = new_expr;
+    node->new_expr = std::move(new_expr);
     node->free_function = free_function;
-    node->condition = condition;
-    node->body = body;
+    node->condition = std::move(condition);
+    node->body = std::move(body);
     return node;
 }
 
@@ -438,7 +438,7 @@ Stmt Free::make(const std::string &name) {
     return node;
 }
 
-Stmt Realize::make(const std::string &name, const std::vector<Type> &types, const Region &bounds, const Expr &condition, const Stmt &body) {
+Stmt Realize::make(const std::string &name, const std::vector<Type> &types, const Region &bounds, Expr condition, Stmt body) {
     for (size_t i = 0; i < bounds.size(); i++) {
         internal_assert(bounds[i].min.defined()) << "Realize of undefined\n";
         internal_assert(bounds[i].extent.defined()) << "Realize of undefined\n";
@@ -454,8 +454,8 @@ Stmt Realize::make(const std::string &name, const std::vector<Type> &types, cons
     node->name = name;
     node->types = types;
     node->bounds = bounds;
-    node->condition = condition;
-    node->body = body;
+    node->condition = std::move(condition);
+    node->body = std::move(body);
     return node;
 }
 
@@ -472,11 +472,11 @@ Stmt Prefetch::make(const std::string &name, const std::vector<Type> &types, con
     node->name = name;
     node->types = types;
     node->bounds = bounds;
-    node->param = param;
+    node->param = std::move(param);
     return node;
 }
 
-Stmt Block::make(const Stmt &first, const Stmt &rest) {
+Stmt Block::make(Stmt first, Stmt rest) {
     internal_assert(first.defined()) << "Block of undefined\n";
     internal_assert(rest.defined()) << "Block of undefined\n";
 
@@ -485,10 +485,10 @@ Stmt Block::make(const Stmt &first, const Stmt &rest) {
     if (const Block *b = first.as<Block>()) {
         // Use a canonical block nesting order
         node->first = b->first;
-        node->rest  = Block::make(b->rest, rest);
+        node->rest  = Block::make(b->rest, std::move(rest));
     } else {
-        node->first = first;
-        node->rest = rest;
+        node->first = std::move(first);
+        node->rest = std::move(rest);
     }
 
     return node;
@@ -505,22 +505,22 @@ Stmt Block::make(const std::vector<Stmt> &stmts) {
     return result;
 }
 
-Stmt IfThenElse::make(const Expr &condition, const Stmt &then_case, const Stmt &else_case) {
+Stmt IfThenElse::make(Expr condition, Stmt then_case, Stmt else_case) {
     internal_assert(condition.defined() && then_case.defined()) << "IfThenElse of undefined\n";
     // else_case may be null.
 
     IfThenElse *node = new IfThenElse;
-    node->condition = condition;
-    node->then_case = then_case;
-    node->else_case = else_case;
+    node->condition = std::move(condition);
+    node->then_case = std::move(then_case);
+    node->else_case = std::move(else_case);
     return node;
 }
 
-Stmt Evaluate::make(const Expr &v) {
+Stmt Evaluate::make(Expr v) {
     internal_assert(v.defined()) << "Evaluate of undefined\n";
 
     Evaluate *node = new Evaluate;
-    node->value = v;
+    node->value = std::move(v);
     return node;
 }
 
@@ -563,10 +563,10 @@ Expr Call::make(Type type, const std::string &name, const std::vector<Expr> &arg
     node->name = name;
     node->args = args;
     node->call_type = call_type;
-    node->func = func;
+    node->func = std::move(func);
     node->value_index = value_index;
-    node->image = image;
-    node->param = param;
+    node->image = std::move(image);
+    node->param = std::move(param);
     return node;
 }
 
@@ -575,9 +575,9 @@ Expr Variable::make(Type type, const std::string &name, Buffer<> image, Paramete
     Variable *node = new Variable;
     node->type = type;
     node->name = name;
-    node->image = image;
-    node->param = param;
-    node->reduction_domain = reduction_domain;
+    node->image = std::move(image);
+    node->param = std::move(param);
+    node->reduction_domain = std::move(reduction_domain);
     return node;
 }
 
@@ -644,7 +644,7 @@ Expr Shuffle::make_concat(const std::vector<Expr> &vectors) {
     return make(vectors, indices);
 }
 
-Expr Shuffle::make_slice(const Expr &vector, int begin, int stride, int size) {
+Expr Shuffle::make_slice(Expr vector, int begin, int stride, int size) {
     if (begin == 0 && size == vector.type().lanes() && stride == 1) {
         return vector;
     }
@@ -654,11 +654,11 @@ Expr Shuffle::make_slice(const Expr &vector, int begin, int stride, int size) {
         indices.push_back(begin + i * stride);
     }
 
-    return make({vector}, indices);
+    return make({std::move(vector)}, indices);
 }
 
-Expr Shuffle::make_extract_element(const Expr &vector, int i) {
-    return make_slice(vector, i, 1, 1);
+Expr Shuffle::make_extract_element(Expr vector, int i) {
+    return make_slice(std::move(vector), i, 1, 1);
 }
 
 bool Shuffle::is_interleave() const {

--- a/src/IR.h
+++ b/src/IR.h
@@ -28,45 +28,45 @@ namespace Internal {
 struct Cast : public ExprNode<Cast> {
     Expr value;
 
-    EXPORT static Expr make(Type t, const Expr &v);
+    EXPORT static Expr make(Type t, Expr v);
 
-    static const IRNodeType _type_info = IRNodeType::Cast;
+    static const IRNodeType _node_type = IRNodeType::Cast;
 };
 
 /** The sum of two expressions */
 struct Add : public ExprNode<Add> {
     Expr a, b;
 
-    EXPORT static Expr make(const Expr &a, const Expr &b);
+    EXPORT static Expr make(Expr a, Expr b);
 
-    static const IRNodeType _type_info = IRNodeType::Add;
+    static const IRNodeType _node_type = IRNodeType::Add;
 };
 
 /** The difference of two expressions */
 struct Sub : public ExprNode<Sub> {
     Expr a, b;
 
-    EXPORT static Expr make(const Expr &a, const Expr &b);
+    EXPORT static Expr make(Expr a, Expr b);
 
-    static const IRNodeType _type_info = IRNodeType::Sub;
+    static const IRNodeType _node_type = IRNodeType::Sub;
 };
 
 /** The product of two expressions */
 struct Mul : public ExprNode<Mul> {
     Expr a, b;
 
-    EXPORT static Expr make(const Expr &a, const Expr &b);
+    EXPORT static Expr make(Expr a, Expr b);
 
-    static const IRNodeType _type_info = IRNodeType::Mul;
+    static const IRNodeType _node_type = IRNodeType::Mul;
 };
 
 /** The ratio of two expressions */
 struct Div : public ExprNode<Div> {
     Expr a, b;
 
-    EXPORT static Expr make(const Expr &a, const Expr &b);
+    EXPORT static Expr make(Expr a, Expr b);
 
-    static const IRNodeType _type_info = IRNodeType::Div;
+    static const IRNodeType _node_type = IRNodeType::Div;
 };
 
 /** The remainder of a / b. Mostly equivalent to '%' in C, except that
@@ -75,108 +75,108 @@ struct Div : public ExprNode<Div> {
 struct Mod : public ExprNode<Mod> {
     Expr a, b;
 
-    EXPORT static Expr make(const Expr &a, const Expr &b);
+    EXPORT static Expr make(Expr a, Expr b);
 
-    static const IRNodeType _type_info = IRNodeType::Mod;
+    static const IRNodeType _node_type = IRNodeType::Mod;
 };
 
 /** The lesser of two values. */
 struct Min : public ExprNode<Min> {
     Expr a, b;
 
-    EXPORT static Expr make(const Expr &a, const Expr &b);
+    EXPORT static Expr make(Expr a, Expr b);
 
-    static const IRNodeType _type_info = IRNodeType::Min;
+    static const IRNodeType _node_type = IRNodeType::Min;
 };
 
 /** The greater of two values */
 struct Max : public ExprNode<Max> {
     Expr a, b;
 
-    EXPORT static Expr make(const Expr &a, const Expr &b);
+    EXPORT static Expr make(Expr a, Expr b);
 
-    static const IRNodeType _type_info = IRNodeType::Max;
+    static const IRNodeType _node_type = IRNodeType::Max;
 };
 
 /** Is the first expression equal to the second */
 struct EQ : public ExprNode<EQ> {
     Expr a, b;
 
-    EXPORT static Expr make(const Expr &a, const Expr &b);
+    EXPORT static Expr make(Expr a, Expr b);
 
-    static const IRNodeType _type_info = IRNodeType::EQ;
+    static const IRNodeType _node_type = IRNodeType::EQ;
 };
 
 /** Is the first expression not equal to the second */
 struct NE : public ExprNode<NE> {
     Expr a, b;
 
-    EXPORT static Expr make(const Expr &a, const Expr &b);
+    EXPORT static Expr make(Expr a, Expr b);
 
-    static const IRNodeType _type_info = IRNodeType::NE;
+    static const IRNodeType _node_type = IRNodeType::NE;
 };
 
 /** Is the first expression less than the second. */
 struct LT : public ExprNode<LT> {
     Expr a, b;
 
-    EXPORT static Expr make(const Expr &a, const Expr &b);
+    EXPORT static Expr make(Expr a, Expr b);
 
-    static const IRNodeType _type_info = IRNodeType::LT;
+    static const IRNodeType _node_type = IRNodeType::LT;
 };
 
 /** Is the first expression less than or equal to the second. */
 struct LE : public ExprNode<LE> {
     Expr a, b;
 
-    EXPORT static Expr make(const Expr &a, const Expr &b);
+    EXPORT static Expr make(Expr a, Expr b);
 
-    static const IRNodeType _type_info = IRNodeType::LE;
+    static const IRNodeType _node_type = IRNodeType::LE;
 };
 
 /** Is the first expression greater than the second. */
 struct GT : public ExprNode<GT> {
     Expr a, b;
 
-    EXPORT static Expr make(const Expr &a, const Expr &b);
+    EXPORT static Expr make(Expr a, Expr b);
 
-    static const IRNodeType _type_info = IRNodeType::GT;
+    static const IRNodeType _node_type = IRNodeType::GT;
 };
 
 /** Is the first expression greater than or equal to the second. */
 struct GE : public ExprNode<GE> {
     Expr a, b;
 
-    EXPORT static Expr make(const Expr &a, const Expr &b);
+    EXPORT static Expr make(Expr a, Expr b);
 
-    static const IRNodeType _type_info = IRNodeType::GE;
+    static const IRNodeType _node_type = IRNodeType::GE;
 };
 
 /** Logical and - are both expressions true */
 struct And : public ExprNode<And> {
     Expr a, b;
 
-    EXPORT static Expr make(const Expr &a, const Expr &b);
+    EXPORT static Expr make(Expr a, Expr b);
 
-    static const IRNodeType _type_info = IRNodeType::And;
+    static const IRNodeType _node_type = IRNodeType::And;
 };
 
 /** Logical or - is at least one of the expression true */
 struct Or : public ExprNode<Or> {
     Expr a, b;
 
-    EXPORT static Expr make(const Expr &a, const Expr &b);
+    EXPORT static Expr make(Expr a, Expr b);
 
-    static const IRNodeType _type_info = IRNodeType::Or;
+    static const IRNodeType _node_type = IRNodeType::Or;
 };
 
 /** Logical not - true if the expression false */
 struct Not : public ExprNode<Not> {
     Expr a;
 
-    EXPORT static Expr make(const Expr &a);
+    EXPORT static Expr make(Expr a);
 
-    static const IRNodeType _type_info = IRNodeType::Not;
+    static const IRNodeType _node_type = IRNodeType::Not;
 };
 
 /** A ternary operator. Evalutes 'true_value' and 'false_value',
@@ -185,9 +185,9 @@ struct Not : public ExprNode<Not> {
 struct Select : public ExprNode<Select> {
     Expr condition, true_value, false_value;
 
-    EXPORT static Expr make(const Expr &condition, const Expr &true_value, const Expr &false_value);
+    EXPORT static Expr make(Expr condition, Expr true_value, Expr false_value);
 
-    static const IRNodeType _type_info = IRNodeType::Select;
+    static const IRNodeType _node_type = IRNodeType::Select;
 };
 
 /** Load a value from a named symbol if predicate is true. The buffer
@@ -208,10 +208,10 @@ struct Load : public ExprNode<Load> {
     Parameter param;
 
     EXPORT static Expr make(Type type, const std::string &name,
-                            const Expr &index, Buffer<> image,
-                            Parameter param, const Expr &predicate);
+                            Expr index, Buffer<> image,
+                            Parameter param, Expr predicate);
 
-    static const IRNodeType _type_info = IRNodeType::Load;
+    static const IRNodeType _node_type = IRNodeType::Load;
 };
 
 /** A linear ramp vector node. This is vector with 'lanes' elements,
@@ -223,9 +223,9 @@ struct Ramp : public ExprNode<Ramp> {
     Expr base, stride;
     int lanes;
 
-    EXPORT static Expr make(const Expr &base, const Expr &stride, int lanes);
+    EXPORT static Expr make(Expr base, Expr stride, int lanes);
 
-    static const IRNodeType _type_info = IRNodeType::Ramp;
+    static const IRNodeType _node_type = IRNodeType::Ramp;
 };
 
 /** A vector with 'lanes' elements, in which every element is
@@ -235,9 +235,9 @@ struct Broadcast : public ExprNode<Broadcast> {
     Expr value;
     int lanes;
 
-    EXPORT static Expr make(const Expr &value, int lanes);
+    EXPORT static Expr make(Expr value, int lanes);
 
-    static const IRNodeType _type_info = IRNodeType::Broadcast;
+    static const IRNodeType _node_type = IRNodeType::Broadcast;
 };
 
 /** A let expression, like you might find in a functional
@@ -247,9 +247,9 @@ struct Let : public ExprNode<Let> {
     std::string name;
     Expr value, body;
 
-    EXPORT static Expr make(const std::string &name, const Expr &value, const Expr &body);
+    EXPORT static Expr make(const std::string &name, Expr value, Expr body);
 
-    static const IRNodeType _type_info = IRNodeType::Let;
+    static const IRNodeType _node_type = IRNodeType::Let;
 };
 
 /** The statement form of a let node. Within the statement 'body',
@@ -259,9 +259,9 @@ struct LetStmt : public StmtNode<LetStmt> {
     Expr value;
     Stmt body;
 
-    EXPORT static Stmt make(const std::string &name, const Expr &value, const Stmt &body);
+    EXPORT static Stmt make(const std::string &name, Expr value, Stmt body);
 
-    static const IRNodeType _type_info = IRNodeType::LetStmt;
+    static const IRNodeType _node_type = IRNodeType::LetStmt;
 };
 
 /** If the 'condition' is false, then evaluate and return the message,
@@ -271,9 +271,9 @@ struct AssertStmt : public StmtNode<AssertStmt> {
     Expr condition;
     Expr message;
 
-    EXPORT static Stmt make(const Expr &condition, const Expr &message);
+    EXPORT static Stmt make(Expr condition, Expr message);
 
-    static const IRNodeType _type_info = IRNodeType::AssertStmt;
+    static const IRNodeType _node_type = IRNodeType::AssertStmt;
 };
 
 /** This node is a helpful annotation to do with permissions. If 'is_produce' is
@@ -292,12 +292,12 @@ struct ProducerConsumer : public StmtNode<ProducerConsumer> {
     bool is_producer;
     Stmt body;
 
-    EXPORT static Stmt make(const std::string &name, bool is_producer, const Stmt &body);
+    EXPORT static Stmt make(const std::string &name, bool is_producer, Stmt body);
 
-    EXPORT static Stmt make_produce(const std::string &name, const Stmt &body);
-    EXPORT static Stmt make_consume(const std::string &name, const Stmt &body);
+    EXPORT static Stmt make_produce(const std::string &name, Stmt body);
+    EXPORT static Stmt make_consume(const std::string &name, Stmt body);
 
-    static const IRNodeType _type_info = IRNodeType::ProducerConsumer;
+    static const IRNodeType _node_type = IRNodeType::ProducerConsumer;
 };
 
 /** Store a 'value' to the buffer called 'name' at a given 'index' if
@@ -311,10 +311,10 @@ struct Store : public StmtNode<Store> {
     // If it's a store to an output buffer, then this parameter points to it.
     Parameter param;
 
-    EXPORT static Stmt make(const std::string &name, const Expr &value, const Expr &index,
-                            Parameter param, const Expr &predicate);
+    EXPORT static Stmt make(const std::string &name, Expr value, Expr index,
+                            Parameter param, Expr predicate);
 
-    static const IRNodeType _type_info = IRNodeType::Store;
+    static const IRNodeType _node_type = IRNodeType::Store;
 };
 
 /** This defines the value of a function at a multi-dimensional
@@ -329,7 +329,7 @@ struct Provide : public StmtNode<Provide> {
 
     EXPORT static Stmt make(const std::string &name, const std::vector<Expr> &values, const std::vector<Expr> &args);
 
-    static const IRNodeType _type_info = IRNodeType::Provide;
+    static const IRNodeType _node_type = IRNodeType::Provide;
 };
 
 /** Allocate a scratch area called with the given name, type, and
@@ -357,8 +357,8 @@ struct Allocate : public StmtNode<Allocate> {
     Stmt body;
 
     EXPORT static Stmt make(const std::string &name, Type type, const std::vector<Expr> &extents,
-                            const Expr &condition, const Stmt &body,
-                            const Expr &new_expr = Expr(), const std::string &free_function = std::string());
+                            Expr condition, Stmt body,
+                            Expr new_expr = Expr(), const std::string &free_function = std::string());
 
     /** A routine to check if the extents are all constants, and if so verify
      * the total size is less than 2^31 - 1. If the result is constant, but
@@ -368,7 +368,7 @@ struct Allocate : public StmtNode<Allocate> {
     EXPORT static int32_t constant_allocation_size(const std::vector<Expr> &extents, const std::string &name);
     EXPORT int32_t constant_allocation_size() const;
 
-    static const IRNodeType _type_info = IRNodeType::Allocate;
+    static const IRNodeType _node_type = IRNodeType::Allocate;
 };
 
 /** Free the resources associated with the given buffer. */
@@ -377,7 +377,7 @@ struct Free : public StmtNode<Free> {
 
     EXPORT static Stmt make(const std::string &name);
 
-    static const IRNodeType _type_info = IRNodeType::Free;
+    static const IRNodeType _node_type = IRNodeType::Free;
 };
 
 /** A single-dimensional span. Includes all numbers between min and
@@ -385,7 +385,7 @@ struct Free : public StmtNode<Free> {
 struct Range {
     Expr min, extent;
     Range() {}
-    Range(const Expr &min, const Expr &extent) : min(min), extent(extent) {
+    Range(Expr min, Expr extent) : min(min), extent(extent) {
         internal_assert(min.type() == extent.type()) << "Region min and extent must have same type\n";
     }
 };
@@ -406,9 +406,9 @@ struct Realize : public StmtNode<Realize> {
     Expr condition;
     Stmt body;
 
-    EXPORT static Stmt make(const std::string &name, const std::vector<Type> &types, const Region &bounds, const Expr &condition, const Stmt &body);
+    EXPORT static Stmt make(const std::string &name, const std::vector<Type> &types, const Region &bounds, Expr condition, Stmt body);
 
-    static const IRNodeType _type_info = IRNodeType::Realize;
+    static const IRNodeType _node_type = IRNodeType::Realize;
 
 };
 
@@ -417,12 +417,12 @@ struct Realize : public StmtNode<Realize> {
 struct Block : public StmtNode<Block> {
     Stmt first, rest;
 
-    EXPORT static Stmt make(const Stmt &first, const Stmt &rest);
+    EXPORT static Stmt make(Stmt first, Stmt rest);
     /** Construct zero or more Blocks to invoke a list of statements in order.
      * This method may not return a Block statement if stmts.size() <= 1. */
     EXPORT static Stmt make(const std::vector<Stmt> &stmts);
 
-    static const IRNodeType _type_info = IRNodeType::Block;
+    static const IRNodeType _node_type = IRNodeType::Block;
 };
 
 /** An if-then-else block. 'else' may be undefined. */
@@ -430,18 +430,18 @@ struct IfThenElse : public StmtNode<IfThenElse> {
     Expr condition;
     Stmt then_case, else_case;
 
-    EXPORT static Stmt make(const Expr &condition, const Stmt &then_case, const Stmt &else_case = Stmt());
+    EXPORT static Stmt make(Expr condition, Stmt then_case, Stmt else_case = Stmt());
 
-    static const IRNodeType _type_info = IRNodeType::IfThenElse;
+    static const IRNodeType _node_type = IRNodeType::IfThenElse;
 };
 
 /** Evaluate and discard an expression, presumably because it has some side-effect. */
 struct Evaluate : public StmtNode<Evaluate> {
     Expr value;
 
-    EXPORT static Stmt make(const Expr &v);
+    EXPORT static Stmt make(Expr v);
 
-    static const IRNodeType _type_info = IRNodeType::Evaluate;
+    static const IRNodeType _node_type = IRNodeType::Evaluate;
 };
 
 /** A function call. This can represent a call to some extern function
@@ -592,7 +592,7 @@ struct Call : public ExprNode<Call> {
              name == intrin_name);
     }
 
-    static const IRNodeType _type_info = IRNodeType::Call;
+    static const IRNodeType _node_type = IRNodeType::Call;
 };
 
 /** A named variable. Might be a loop variable, function argument,
@@ -630,7 +630,7 @@ struct Variable : public ExprNode<Variable> {
     EXPORT static Expr make(Type type, const std::string &name, Buffer<> image,
                             Parameter param, ReductionDomain reduction_domain);
 
-    static const IRNodeType _type_info = IRNodeType::Variable;
+    static const IRNodeType _node_type = IRNodeType::Variable;
 };
 
 /** A for loop. Execute the 'body' statement for all values of the
@@ -652,7 +652,7 @@ struct For : public StmtNode<For> {
     DeviceAPI device_api;
     Stmt body;
 
-    EXPORT static Stmt make(const std::string &name, const Expr &min, const Expr &extent, ForType for_type, DeviceAPI device_api, const Stmt &body);
+    EXPORT static Stmt make(const std::string &name, Expr min, Expr extent, ForType for_type, DeviceAPI device_api, Stmt body);
 
     bool is_parallel() const {
         return (for_type == ForType::Parallel ||
@@ -660,7 +660,7 @@ struct For : public StmtNode<For> {
                 for_type == ForType::GPUThread);
     }
 
-    static const IRNodeType _type_info = IRNodeType::For;
+    static const IRNodeType _node_type = IRNodeType::For;
 };
 
 /** Construct a new vector by taking elements from another sequence of
@@ -686,11 +686,11 @@ struct Shuffle : public ExprNode<Shuffle> {
 
     /** Convenience constructor for making a shuffle representing a
      * contiguous subset of a vector. */
-    EXPORT static Expr make_slice(const Expr &vector, int begin, int stride, int size);
+    EXPORT static Expr make_slice(Expr vector, int begin, int stride, int size);
 
     /** Convenience constructor for making a shuffle representing
      * extracting a single element. */
-    EXPORT static Expr make_extract_element(const Expr &vector, int i);
+    EXPORT static Expr make_extract_element(Expr vector, int i);
 
     /** Check if this shuffle is an interleaving of the vector
      * arguments. */
@@ -713,7 +713,7 @@ struct Shuffle : public ExprNode<Shuffle> {
      * arguments. */
     EXPORT bool is_extract_element() const;
 
-    static const IRNodeType _type_info = IRNodeType::Shuffle;
+    static const IRNodeType _node_type = IRNodeType::Shuffle;
 };
 
 /** Represent a multi-dimensional region of a Func or an ImageParam that
@@ -729,7 +729,7 @@ struct Prefetch : public StmtNode<Prefetch> {
     EXPORT static Stmt make(const std::string &name, const std::vector<Type> &types,
                             const Region &bounds, Parameter param = Parameter());
 
-    static const IRNodeType _type_info = IRNodeType::Prefetch;
+    static const IRNodeType _node_type = IRNodeType::Prefetch;
 };
 
 }

--- a/src/IREquality.cpp
+++ b/src/IREquality.cpp
@@ -136,7 +136,7 @@ IRComparer::CmpResult IRComparer::compare_expr(const Expr &a, const Expr &b) {
     //   return result;
     // }
 
-    if (compare_scalar(a->type_info(), b->type_info()) != Equal) {
+    if (compare_scalar(a->node_type, b->node_type) != Equal) {
         return result;
     }
 
@@ -185,7 +185,7 @@ IRComparer::CmpResult IRComparer::compare_stmt(const Stmt &a, const Stmt &b) {
         return result;
     }
 
-    if (compare_scalar(a->type_info(), b->type_info()) != Equal) {
+    if (compare_scalar(a->node_type, b->node_type) != Equal) {
         return result;
     }
 

--- a/src/IRMutator.h
+++ b/src/IRMutator.h
@@ -28,8 +28,8 @@ public:
      * these in your subclass to mutate sub-expressions and
      * sub-statements.
      */
-    EXPORT virtual Expr mutate(Expr expr);
-    EXPORT virtual Stmt mutate(Stmt stmt);
+    EXPORT virtual Expr mutate(const Expr &expr);
+    EXPORT virtual Stmt mutate(const Stmt &stmt);
 
 protected:
 
@@ -95,8 +95,8 @@ protected:
     std::map<Stmt, Stmt, Stmt::Compare> stmt_replacements;
 
 public:
-    EXPORT Stmt mutate(Stmt s);
-    EXPORT Expr mutate(Expr e);
+    EXPORT Stmt mutate(const Stmt &s);
+    EXPORT Expr mutate(const Expr &e);
 };
 
 

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1223,12 +1223,13 @@ inline Expr fast_inverse_sqrt(Expr x) {
  * point, despite being a whole number. Vectorizes cleanly. */
 inline Expr floor(Expr x) {
     user_assert(x.defined()) << "floor of undefined Expr\n";
-    if (x.type().element_of() == Float(64)) {
-        return Internal::Call::make(x.type(), "floor_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type().element_of() == Float(16)) {
-        return Internal::Call::make(Float(16), "floor_f16", {std::move(x)}, Internal::Call::PureExtern);
+    Type t = x.type();
+    if (t.element_of() == Float(64)) {
+        return Internal::Call::make(t, "floor_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (t.element_of() == Float(16)) {
+        return Internal::Call::make(t, "floor_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        Type t = Float(32, x.type().lanes());
+        t = t.with_code(Type::Float);
         return Internal::Call::make(t, "floor_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
     }
 }
@@ -1239,12 +1240,13 @@ inline Expr floor(Expr x) {
  * point, despite being a whole number. Vectorizes cleanly. */
 inline Expr ceil(Expr x) {
     user_assert(x.defined()) << "ceil of undefined Expr\n";
-    if (x.type().element_of() == Float(64)) {
-        return Internal::Call::make(x.type(), "ceil_f64", {std::move(x)}, Internal::Call::PureExtern);
+    Type t = x.type();
+    if (t.element_of() == Float(64)) {
+        return Internal::Call::make(t, "ceil_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type().element_of() == Float(16)) {
-        return Internal::Call::make(Float(16), "ceil_f16", {std::move(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(t, "ceil_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        Type t = Float(32, x.type().lanes());
+        t = t.with_code(Type::Float);
         return Internal::Call::make(t, "ceil_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
     }
 }
@@ -1256,12 +1258,13 @@ inline Expr ceil(Expr x) {
  * cleanly. */
 inline Expr round(Expr x) {
     user_assert(x.defined()) << "round of undefined Expr\n";
-    if (x.type().element_of() == Float(64)) {
-        return Internal::Call::make(Float(64), "round_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type().element_of() == Float(16)) {
-        return Internal::Call::make(Float(16), "round_f16", {std::move(x)}, Internal::Call::PureExtern);
+    Type t = x.type();
+    if (t.element_of() == Float(64)) {
+        return Internal::Call::make(t, "round_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (t.element_of() == Float(16)) {
+        return Internal::Call::make(t, "round_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        Type t = Float(32, x.type().lanes());
+        t = t.with_code(Type::Float);
         return Internal::Call::make(t, "round_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
     }
 }
@@ -1271,12 +1274,13 @@ inline Expr round(Expr x) {
  * floating point, despite being a whole number. Vectorizes cleanly. */
 inline Expr trunc(Expr x) {
     user_assert(x.defined()) << "trunc of undefined Expr\n";
-    if (x.type().element_of() == Float(64)) {
-        return Internal::Call::make(Float(64), "trunc_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type().element_of() == Float(16)) {
-        return Internal::Call::make(Float(16), "trunc_f16", {std::move(x)}, Internal::Call::PureExtern);
+    Type t = x.type();
+    if (t.element_of() == Float(64)) {
+        return Internal::Call::make(t, "trunc_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (t.element_of() == Float(16)) {
+        return Internal::Call::make(t, "trunc_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        Type t = Float(32, x.type().lanes());
+        t = t.with_code(Type::Float);
         return Internal::Call::make(t, "trunc_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
     }
 }
@@ -1292,7 +1296,7 @@ inline Expr is_nan(Expr x) {
     } else if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(t, "is_nan_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        Type ft = Float(32, x.type().lanes());
+        Type ft = x.type().with_code(Type::Float);
         return Internal::Call::make(t, "is_nan_f32", {cast(ft, std::move(x))}, Internal::Call::PureExtern);
     }
 }

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -125,7 +125,7 @@ EXPORT Expr const_false(int lanes = 1);
 /** Attempt to cast an expression to a smaller type while provably not
  * losing information. If it can't be done, return an undefined
  * Expr. */
-EXPORT Expr lossless_cast(Type t, const Expr &e);
+EXPORT Expr lossless_cast(Type t, Expr e);
 
 /** Coerce the two expressions to have the same type, using C-style
  * casting rules. For the purposes of casting, a boolean type is
@@ -155,14 +155,14 @@ EXPORT void match_types(Expr &a, Expr &b);
 
 /** Halide's vectorizable transcendentals. */
 // @{
-EXPORT Expr halide_log(const Expr &a);
-EXPORT Expr halide_exp(const Expr &a);
-EXPORT Expr halide_erf(const Expr &a);
+EXPORT Expr halide_log(Expr a);
+EXPORT Expr halide_exp(Expr a);
+EXPORT Expr halide_erf(Expr a);
 // @}
 
 /** Raise an expression to an integer power by repeatedly multiplying
  * it by itself. */
-EXPORT Expr raise_to_integer_power(const Expr &a, int64_t b);
+EXPORT Expr raise_to_integer_power(Expr a, int64_t b);
 
 /** Split a boolean condition into vector of ANDs. If 'cond' is undefined,
  * return an empty vector. */
@@ -192,14 +192,16 @@ struct BufferBuilder {
 
 /** Cast an expression to the halide type corresponding to the C++ type T. */
 template<typename T>
-inline Expr cast(const Expr &a) {
-    return cast(type_of<T>(), a);
+inline Expr cast(Expr a) {
+    return cast(type_of<T>(), std::move(a));
 }
 
 /** Cast an expression to a new type. */
-inline Expr cast(Type t, const Expr &a) {
+inline Expr cast(Type t, Expr a) {
     user_assert(a.defined()) << "cast of undefined Expr\n";
-    if (a.type() == t) return a;
+    if (a.type() == t) {
+        return a;
+    }
 
     if (t.is_handle() && !a.type().is_handle()) {
         user_error << "Can't cast \"" << a << "\" to a handle. "
@@ -224,13 +226,13 @@ inline Expr cast(Type t, const Expr &a) {
 
     if (t.is_vector()) {
         if (a.type().is_scalar()) {
-            return Internal::Broadcast::make(cast(t.element_of(), a), t.lanes());
+            return Internal::Broadcast::make(cast(t.element_of(), std::move(a)), t.lanes());
         } else if (const Internal::Broadcast *b = a.as<Internal::Broadcast>()) {
             internal_assert(b->lanes == t.lanes());
             return Internal::Broadcast::make(cast(t.element_of(), b->value), t.lanes());
         }
     }
-    return Internal::Cast::make(t, a);
+    return Internal::Cast::make(t, std::move(a));
 }
 
 /** Return the sum of two expressions, doing any necessary type
@@ -238,34 +240,37 @@ inline Expr cast(Type t, const Expr &a) {
 inline Expr operator+(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator+ of undefined Expr\n";
     Internal::match_types(a, b);
-    return Internal::Add::make(a, b);
+    return Internal::Add::make(std::move(a), std::move(b));
 }
 
 /** Add an expression and a constant integer. Coerces the type of the
  * integer to match the type of the expression. Errors if the integer
  * cannot be represented in the type of the expression. */
 // @{
-inline Expr operator+(const Expr &a, int b) {
+inline Expr operator+(Expr a, int b) {
     user_assert(a.defined()) << "operator+ of undefined Expr\n";
-    Internal::check_representable(a.type(), b);
-    return Internal::Add::make(a, Internal::make_const(a.type(), b));
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::Add::make(std::move(a), Internal::make_const(t, b));
 }
 
 /** Add a constant integer and an expression. Coerces the type of the
  * integer to match the type of the expression. Errors if the integer
  * cannot be represented in the type of the expression. */
-inline Expr operator+(int a, const Expr &b) {
+inline Expr operator+(int a, Expr b) {
     user_assert(b.defined()) << "operator+ of undefined Expr\n";
-    Internal::check_representable(b.type(), a);
-    return Internal::Add::make(Internal::make_const(b.type(), a), b);
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::Add::make(Internal::make_const(t, a), std::move(b));
 }
 
 /** Modify the first expression to be the sum of two expressions,
  * without changing its type. This casts the second argument to match
  * the type of the first. */
-inline Expr &operator+=(Expr &a, const Expr &b) {
+inline Expr &operator+=(Expr &a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator+= of undefined Expr\n";
-    a = Internal::Add::make(a, cast(a.type(), b));
+    Type t = a.type();
+    a = Internal::Add::make(std::move(a), cast(t, std::move(b)));
     return a;
 }
 
@@ -274,25 +279,27 @@ inline Expr &operator+=(Expr &a, const Expr &b) {
 inline Expr operator-(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator- of undefined Expr\n";
     Internal::match_types(a, b);
-    return Internal::Sub::make(a, b);
+    return Internal::Sub::make(std::move(a), std::move(b));
 }
 
 /** Subtracts a constant integer from an expression. Coerces the type of the
  * integer to match the type of the expression. Errors if the integer
  * cannot be represented in the type of the expression. */
-inline Expr operator-(const Expr &a, int b) {
+inline Expr operator-(Expr a, int b) {
     user_assert(a.defined()) << "operator- of undefined Expr\n";
-    Internal::check_representable(a.type(), b);
-    return Internal::Sub::make(a, Internal::make_const(a.type(), b));
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::Sub::make(std::move(a), Internal::make_const(t, b));
 }
 
 /** Subtracts an expression from a constant integer. Coerces the type
  * of the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator-(int a, const Expr &b) {
+inline Expr operator-(int a, Expr b) {
     user_assert(b.defined()) << "operator- of undefined Expr\n";
-    Internal::check_representable(b.type(), a);
-    return Internal::Sub::make(Internal::make_const(b.type(), a), b);
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::Sub::make(Internal::make_const(t, a), std::move(b));
 }
 
 /** Return the negative of the argument. Does no type casting, so more
@@ -300,17 +307,19 @@ inline Expr operator-(int a, const Expr &b) {
  * yields zero of the same type. For unsigned integers the negative is
  * still an unsigned integer. E.g. in UInt(8), the negative of 56 is
  * 200, because 56 + 200 == 0 */
-inline Expr operator-(const Expr &a) {
+inline Expr operator-(Expr a) {
     user_assert(a.defined()) << "operator- of undefined Expr\n";
-    return Internal::Sub::make(Internal::make_zero(a.type()), a);
+    Type t = a.type();
+    return Internal::Sub::make(Internal::make_zero(t), std::move(a));
 }
 
 /** Modify the first expression to be the difference of two expressions,
  * without changing its type. This casts the second argument to match
  * the type of the first. */
-inline Expr &operator-=(Expr &a, const Expr &b) {
+inline Expr &operator-=(Expr &a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator-= of undefined Expr\n";
-    a = Internal::Sub::make(a, cast(a.type(), b));
+    Type t = a.type();
+    a = Internal::Sub::make(std::move(a), cast(t, std::move(b)));
     return a;
 }
 
@@ -319,7 +328,7 @@ inline Expr &operator-=(Expr &a, const Expr &b) {
 inline Expr operator*(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator* of undefined Expr\n";
     Internal::match_types(a, b);
-    return Internal::Mul::make(a, b);
+    return Internal::Mul::make(std::move(a), std::move(b));
 }
 
 /** Multiply an expression and a constant integer. Coerces the type of the
@@ -327,25 +336,28 @@ inline Expr operator*(Expr a, Expr b) {
  * cannot be represented in the type of the expression. */
 inline Expr operator*(const Expr &a, int b) {
     user_assert(a.defined()) << "operator* of undefined Expr\n";
-    Internal::check_representable(a.type(), b);
-    return Internal::Mul::make(a, Internal::make_const(a.type(), b));
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::Mul::make(std::move(a), Internal::make_const(t, b));
 }
 
 /** Multiply a constant integer and an expression. Coerces the type of
  * the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator*(int a, const Expr &b) {
+inline Expr operator*(int a, Expr b) {
     user_assert(b.defined()) << "operator* of undefined Expr\n";
-    Internal::check_representable(b.type(), a);
-    return Internal::Mul::make(Internal::make_const(b.type(), a), b);
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::Mul::make(Internal::make_const(t, a), std::move(b));
 }
 
 /** Modify the first expression to be the product of two expressions,
  * without changing its type. This casts the second argument to match
  * the type of the first. */
-inline Expr &operator*=(Expr &a, const Expr &b) {
+inline Expr &operator*=(Expr &a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator*= of undefined Expr\n";
-    a = Internal::Mul::make(a, cast(a.type(), b));
+    Type t = a.type();
+    a = Internal::Mul::make(std::move(a), cast(t, std::move(b)));
     return a;
 }
 
@@ -356,7 +368,7 @@ inline Expr &operator*=(Expr &a, const Expr &b) {
 inline Expr operator/(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator/ of undefined Expr\n";
     Internal::match_types(a, b);
-    return Internal::Div::make(a, b);
+    return Internal::Div::make(std::move(a), std::move(b));
 }
 
 /** Modify the first expression to be the ratio of two expressions,
@@ -364,30 +376,31 @@ inline Expr operator/(Expr a, Expr b) {
  * the type of the first. Note that signed integer division in Halide
  * rounds towards minus infinity, unlike C, which rounds towards
  * zero. */
-inline Expr &operator/=(Expr &a, const Expr &b) {
+inline Expr &operator/=(Expr &a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator/= of undefined Expr\n";
-    a = Internal::Div::make(a, cast(a.type(), b));
+    Type t = a.type();
+    a = Internal::Div::make(std::move(a), cast(t, std::move(b)));
     return a;
 }
-
-
 
 /** Divides an expression by a constant integer. Coerces the type
  * of the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator/(const Expr &a, int b) {
+inline Expr operator/(Expr a, int b) {
     user_assert(a.defined()) << "operator/ of undefined Expr\n";
-    Internal::check_representable(a.type(), b);
-    return Internal::Div::make(a, Internal::make_const(a.type(), b));
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::Div::make(std::move(a), Internal::make_const(t, b));
 }
 
 /** Divides a constant integer by an expression. Coerces the type
  * of the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator/(int a, const Expr &b) {
+inline Expr operator/(int a, Expr b) {
     user_assert(b.defined()) << "operator- of undefined Expr\n";
-    Internal::check_representable(b.type(), a);
-    return Internal::Div::make(Internal::make_const(b.type(), a), b);
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::Div::make(Internal::make_const(t, a), std::move(b));
 }
 
 /** Return the first argument reduced modulo the second, doing any
@@ -400,17 +413,18 @@ inline Expr operator%(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator% of undefined Expr\n";
     user_assert(!Internal::is_zero(b)) << "operator% with constant 0 modulus\n";
     Internal::match_types(a, b);
-    return Internal::Mod::make(a, b);
+    return Internal::Mod::make(std::move(a), std::move(b));
 }
 
 /** Mods an expression by a constant integer. Coerces the type
  * of the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator%(const Expr &a, int b) {
+inline Expr operator%(Expr a, int b) {
     user_assert(a.defined()) << "operator% of undefined Expr\n";
     user_assert(b != 0) << "operator% with constant 0 modulus\n";
-    Internal::check_representable(a.type(), b);
-    return Internal::Mod::make(a, Internal::make_const(a.type(), b));
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::Mod::make(std::move(a), Internal::make_const(t, b));
 }
 /** Mods a constant integer by an expression. Coerces the type
  * of the integer to match the type of the expression. Errors if the
@@ -418,8 +432,9 @@ inline Expr operator%(const Expr &a, int b) {
 inline Expr operator%(int a, const Expr &b) {
     user_assert(b.defined()) << "operator% of undefined Expr\n";
     user_assert(!Internal::is_zero(b)) << "operator% with constant 0 modulus\n";
-    Internal::check_representable(b.type(), a);
-    return Internal::Mod::make(Internal::make_const(b.type(), a), b);
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::Mod::make(Internal::make_const(t, a), std::move(b));
 }
 
 /** Return a boolean expression that tests whether the first argument
@@ -428,27 +443,29 @@ inline Expr operator%(int a, const Expr &b) {
 inline Expr operator>(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator> of undefined Expr\n";
     Internal::match_types(a, b);
-    return Internal::GT::make(a, b);
+    return Internal::GT::make(std::move(a), std::move(b));
 }
 
 /** Return a boolean expression that tests whether an expression is
  * greater than a constant integer. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator>(const Expr &a, int b) {
+inline Expr operator>(Expr a, int b) {
     user_assert(a.defined()) << "operator> of undefined Expr\n";
-    Internal::check_representable(a.type(), b);
-    return Internal::GT::make(a, Internal::make_const(a.type(), b));
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::GT::make(std::move(a), Internal::make_const(t, b));
 }
 
 /** Return a boolean expression that tests whether a constant integer is
  * greater than an expression. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator>(int a, const Expr &b) {
+inline Expr operator>(int a, Expr b) {
     user_assert(b.defined()) << "operator> of undefined Expr\n";
-    Internal::check_representable(b.type(), a);
-    return Internal::GT::make(Internal::make_const(b.type(), a), b);
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::GT::make(Internal::make_const(t, a), std::move(b));
 }
 
 /** Return a boolean expression that tests whether the first argument
@@ -457,27 +474,29 @@ inline Expr operator>(int a, const Expr &b) {
 inline Expr operator<(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator< of undefined Expr\n";
     Internal::match_types(a, b);
-    return Internal::LT::make(a, b);
+    return Internal::LT::make(std::move(a), std::move(b));
 }
 
 /** Return a boolean expression that tests whether an expression is
  * less than a constant integer. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator<(const Expr &a, int b) {
+inline Expr operator<(Expr a, int b) {
     user_assert(a.defined()) << "operator< of undefined Expr\n";
-    Internal::check_representable(a.type(), b);
-    return Internal::LT::make(a, Internal::make_const(a.type(), b));
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::LT::make(std::move(a), Internal::make_const(t, b));
 }
 
 /** Return a boolean expression that tests whether a constant integer is
  * less than an expression. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator<(int a, const Expr &b) {
+inline Expr operator<(int a, Expr b) {
     user_assert(b.defined()) << "operator< of undefined Expr\n";
-    Internal::check_representable(b.type(), a);
-    return Internal::LT::make(Internal::make_const(b.type(), a), b);
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::LT::make(Internal::make_const(t, a), std::move(b));
 }
 
 /** Return a boolean expression that tests whether the first argument
@@ -486,27 +505,29 @@ inline Expr operator<(int a, const Expr &b) {
 inline Expr operator<=(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator<= of undefined Expr\n";
     Internal::match_types(a, b);
-    return Internal::LE::make(a, b);
+    return Internal::LE::make(std::move(a), std::move(b));
 }
 
 /** Return a boolean expression that tests whether an expression is
  * less than or equal to a constant integer. Coerces the integer to
  * the type of the expression. Errors if the integer is not
  * representable in that type. */
-inline Expr operator<=(const Expr &a, int b) {
+inline Expr operator<=(Expr a, int b) {
     user_assert(a.defined()) << "operator<= of undefined Expr\n";
-    Internal::check_representable(a.type(), b);
-    return Internal::LE::make(a, Internal::make_const(a.type(), b));
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::LE::make(std::move(a), Internal::make_const(t, b));
 }
 
 /** Return a boolean expression that tests whether a constant integer
  * is less than or equal to an expression. Coerces the integer to the
  * type of the expression. Errors if the integer is not representable
  * in that type. */
-inline Expr operator<=(int a, const Expr &b) {
+inline Expr operator<=(int a, Expr b) {
     user_assert(b.defined()) << "operator<= of undefined Expr\n";
-    Internal::check_representable(b.type(), a);
-    return Internal::LE::make(Internal::make_const(b.type(), a), b);
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::LE::make(Internal::make_const(t, a), std::move(b));
 }
 
 /** Return a boolean expression that tests whether the first argument
@@ -515,27 +536,29 @@ inline Expr operator<=(int a, const Expr &b) {
 inline Expr operator>=(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator>= of undefined Expr\n";
     Internal::match_types(a, b);
-    return Internal::GE::make(a, b);
+    return Internal::GE::make(std::move(a), std::move(b));
 }
 
 /** Return a boolean expression that tests whether an expression is
  * greater than or equal to a constant integer. Coerces the integer to
  * the type of the expression. Errors if the integer is not
  * representable in that type. */
-inline Expr operator>=(const Expr &a, int b) {
+inline Expr operator>=(Expr a, int b) {
     user_assert(a.defined()) << "operator>= of undefined Expr\n";
-    Internal::check_representable(a.type(), b);
-    return Internal::GE::make(a, Internal::make_const(a.type(), b));
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::GE::make(a, Internal::make_const(t, b));
 }
 
 /** Return a boolean expression that tests whether a constant integer
  * is greater than or equal to an expression. Coerces the integer to the
  * type of the expression. Errors if the integer is not representable
  * in that type. */
-inline Expr operator>=(int a, const Expr &b) {
+inline Expr operator>=(int a, Expr b) {
     user_assert(b.defined()) << "operator>= of undefined Expr\n";
-    Internal::check_representable(b.type(), a);
-    return Internal::GE::make(Internal::make_const(b.type(), a), b);
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::GE::make(Internal::make_const(t, a), b);
 }
 
 /** Return a boolean expression that tests whether the first argument
@@ -544,27 +567,29 @@ inline Expr operator>=(int a, const Expr &b) {
 inline Expr operator==(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator== of undefined Expr\n";
     Internal::match_types(a, b);
-    return Internal::EQ::make(a, b);
+    return Internal::EQ::make(std::move(a), std::move(b));
 }
 
 /** Return a boolean expression that tests whether an expression is
  * equal to a constant integer. Coerces the integer to the type of the
  * expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator==(const Expr &a, int b) {
+inline Expr operator==(Expr a, int b) {
     user_assert(a.defined()) << "operator== of undefined Expr\n";
-    Internal::check_representable(a.type(), b);
-    return Internal::EQ::make(a, Internal::make_const(a.type(), b));
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::EQ::make(std::move(a), Internal::make_const(t, b));
 }
 
 /** Return a boolean expression that tests whether a constant integer
  * is equal to an expression. Coerces the integer to the type of the
  * expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator==(int a, const Expr &b) {
+inline Expr operator==(int a, Expr b) {
     user_assert(b.defined()) << "operator== of undefined Expr\n";
-    Internal::check_representable(b.type(), a);
-    return Internal::EQ::make(Internal::make_const(b.type(), a), b);
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::EQ::make(Internal::make_const(t, a), std::move(b));
 }
 
 /** Return a boolean expression that tests whether the first argument
@@ -573,33 +598,35 @@ inline Expr operator==(int a, const Expr &b) {
 inline Expr operator!=(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator!= of undefined Expr\n";
     Internal::match_types(a, b);
-    return Internal::NE::make(a, b);
+    return Internal::NE::make(std::move(a), std::move(b));
 }
 
 /** Return a boolean expression that tests whether an expression is
  * not equal to a constant integer. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator!=(const Expr &a, int b) {
+inline Expr operator!=(Expr a, int b) {
     user_assert(a.defined()) << "operator!= of undefined Expr\n";
-    Internal::check_representable(a.type(), b);
-    return Internal::NE::make(a, Internal::make_const(a.type(), b));
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::NE::make(std::move(a), Internal::make_const(t, b));
 }
 
 /** Return a boolean expression that tests whether a constant integer
  * is not equal to an expression. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator!=(int a, const Expr &b) {
+inline Expr operator!=(int a, Expr b) {
     user_assert(b.defined()) << "operator!= of undefined Expr\n";
-    Internal::check_representable(b.type(), a);
-    return Internal::NE::make(Internal::make_const(b.type(), a), b);
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::NE::make(Internal::make_const(t, a), std::move(b));
 }
 
 /** Returns the logical and of the two arguments */
 inline Expr operator&&(Expr a, Expr b) {
     Internal::match_types(a, b);
-    return Internal::And::make(a, b);
+    return Internal::And::make(std::move(a), std::move(b));
 }
 
 /** Logical and of an Expr and a bool. Either returns the Expr or an
@@ -615,14 +642,14 @@ inline Expr operator&&(const Expr &a, bool b) {
     }
 }
 inline Expr operator&&(bool a, const Expr &b) {
-    return b && a;
+    return std::move(b) && a;
 }
 // @}
 
 /** Returns the logical or of the two arguments */
 inline Expr operator||(Expr a, Expr b) {
     Internal::match_types(a, b);
-    return Internal::Or::make(a, b);
+    return Internal::Or::make(std::move(a), std::move(b));
 }
 
 /** Logical or of an Expr and a bool. Either returns the Expr or an
@@ -644,8 +671,8 @@ inline Expr operator||(bool a, const Expr &b) {
 
 
 /** Returns the logical not the argument */
-inline Expr operator!(const Expr &a) {
-    return Internal::Not::make(a);
+inline Expr operator!(Expr a) {
+    return Internal::Not::make(std::move(a));
 }
 
 /** Returns an expression representing the greater of the two
@@ -656,7 +683,7 @@ inline Expr max(Expr a, Expr b) {
     user_assert(a.defined() && b.defined())
         << "max of undefined Expr\n";
     Internal::match_types(a, b);
-    return Internal::Max::make(a, b);
+    return Internal::Max::make(std::move(a), std::move(b));
 }
 
 /** Returns an expression representing the greater of an expression
@@ -664,10 +691,11 @@ inline Expr max(Expr a, Expr b) {
  * expression. Errors if the integer is not representable as that
  * type. Vectorizes cleanly on most platforms (with the exception of
  * integer types on x86 without SSE4). */
-inline Expr max(const Expr &a, int b) {
+inline Expr max(Expr a, int b) {
     user_assert(a.defined()) << "max of undefined Expr\n";
-    Internal::check_representable(a.type(), b);
-    return Internal::Max::make(a, Internal::make_const(a.type(), b));
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::Max::make(std::move(a), Internal::make_const(t, b));
 }
 
 
@@ -676,32 +704,33 @@ inline Expr max(const Expr &a, int b) {
  * the expression. Errors if the integer is not representable as that
  * type. Vectorizes cleanly on most platforms (with the exception of
  * integer types on x86 without SSE4). */
-inline Expr max(int a, const Expr &b) {
+inline Expr max(int a, Expr b) {
     user_assert(b.defined()) << "max of undefined Expr\n";
-    Internal::check_representable(b.type(), a);
-    return Internal::Max::make(Internal::make_const(b.type(), a), b);
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::Max::make(Internal::make_const(t, a), std::move(b));
 }
 
-inline Expr max(float a, const Expr &b) {return max(Expr(a), b);}
-inline Expr max(const Expr &a, float b) {return max(a, Expr(b));}
+inline Expr max(float a, Expr b) {return max(Expr(a), std::move(b));}
+inline Expr max(Expr a, float b) {return max(std::move(a), Expr(b));}
 
 /** Returns an expression representing the greater of an expressions
  * vector, after doing any necessary type coersion using
  * \ref Internal::match_types. Vectorizes cleanly on most platforms
  * (with the exception of integer types on x86 without SSE4).
- * The expressions are folded from right ie. max(.., max(.., ..)). 
+ * The expressions are folded from right ie. max(.., max(.., ..)).
  * The arguments can be any mix of types but must all be convertible to Expr. */
 template<typename A, typename B, typename C, typename... Rest,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Rest...>::value>::type* = nullptr>
-inline Expr max(const A &a, const B &b, const C &c, Rest&&... rest) {
-    return max(a, max(b, c, std::forward<Rest>(rest)...));
+inline Expr max(A &&a, B &&b, C &&c, Rest&&... rest) {
+    return max(std::forward<A>(a), max(std::forward<B>(b), std::forward<C>(c), std::forward<Rest>(rest)...));
 }
 
 inline Expr min(Expr a, Expr b) {
     user_assert(a.defined() && b.defined())
         << "min of undefined Expr\n";
     Internal::match_types(a, b);
-    return Internal::Min::make(a, b);
+    return Internal::Min::make(std::move(a), std::move(b));
 }
 
 /** Returns an expression representing the lesser of an expression
@@ -709,10 +738,11 @@ inline Expr min(Expr a, Expr b) {
  * expression. Errors if the integer is not representable as that
  * type. Vectorizes cleanly on most platforms (with the exception of
  * integer types on x86 without SSE4). */
-inline Expr min(const Expr &a, int b) {
+inline Expr min(Expr a, int b) {
     user_assert(a.defined()) << "max of undefined Expr\n";
-    Internal::check_representable(a.type(), b);
-    return Internal::Min::make(a, Internal::make_const(a.type(), b));
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::Min::make(std::move(a), Internal::make_const(t, b));
 }
 
 /** Returns an expression representing the lesser of a constant
@@ -720,14 +750,15 @@ inline Expr min(const Expr &a, int b) {
  * the expression. Errors if the integer is not representable as that
  * type. Vectorizes cleanly on most platforms (with the exception of
  * integer types on x86 without SSE4). */
-inline Expr min(int a, const Expr &b) {
+inline Expr min(int a, Expr b) {
     user_assert(b.defined()) << "max of undefined Expr\n";
-    Internal::check_representable(b.type(), a);
-    return Internal::Min::make(Internal::make_const(b.type(), a), b);
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::Min::make(Internal::make_const(t, a), std::move(b));
 }
 
-inline Expr min(float a, const Expr &b) {return min(Expr(a), b);}
-inline Expr min(const Expr &a, float b) {return min(a, Expr(b));}
+inline Expr min(float a, Expr b) {return min(Expr(a), std::move(b));}
+inline Expr min(Expr a, float b) {return min(std::move(a), Expr(b));}
 
 /** Returns an expression representing the lesser of an expressions
  * vector, after doing any necessary type coersion using
@@ -737,41 +768,41 @@ inline Expr min(const Expr &a, float b) {return min(a, Expr(b));}
  * The arguments can be any mix of types but must all be convertible to Expr. */
 template<typename A, typename B, typename C, typename... Rest,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Rest...>::value>::type* = nullptr>
-inline Expr min(const A &a, const B &b, const C &c, Rest&&... rest) {
-    return min(a, min(b, c, std::forward<Rest>(rest)...));
+inline Expr min(A &&a, B &&b, C &&c, Rest&&... rest) {
+    return min(std::forward<A>(a), min(std::forward<B>(b), std::forward<C>(c), std::forward<Rest>(rest)...));
 }
 
 /** Operators on floats treats those floats as Exprs. Making these
  * explicit prevents implicit float->int casts that might otherwise
  * occur. */
 // @{
-inline Expr operator+(const Expr &a, float b) {return a + Expr(b);}
-inline Expr operator+(float a, const Expr &b) {return Expr(a) + b;}
-inline Expr operator-(const Expr &a, float b) {return a - Expr(b);}
-inline Expr operator-(float a, const Expr &b) {return Expr(a) - b;}
-inline Expr operator*(const Expr &a, float b) {return a * Expr(b);}
-inline Expr operator*(float a, const Expr &b) {return Expr(a) * b;}
-inline Expr operator/(const Expr &a, float b) {return a / Expr(b);}
-inline Expr operator/(float a, const Expr &b) {return Expr(a) / b;}
-inline Expr operator%(const Expr &a, float b) {return a % Expr(b);}
-inline Expr operator%(float a, const Expr &b) {return Expr(a) % b;}
-inline Expr operator>(const Expr &a, float b) {return a > Expr(b);}
-inline Expr operator>(float a, const Expr &b) {return Expr(a) > b;}
-inline Expr operator<(const Expr &a, float b) {return a < Expr(b);}
-inline Expr operator<(float a, const Expr &b) {return Expr(a) < b;}
-inline Expr operator>=(const Expr &a, float b) {return a >= Expr(b);}
-inline Expr operator>=(float a, const Expr &b) {return Expr(a) >= b;}
-inline Expr operator<=(const Expr &a, float b) {return a <= Expr(b);}
-inline Expr operator<=(float a, const Expr &b) {return Expr(a) <= b;}
-inline Expr operator==(const Expr &a, float b) {return a == Expr(b);}
-inline Expr operator==(float a, const Expr &b) {return Expr(a) == b;}
-inline Expr operator!=(const Expr &a, float b) {return a != Expr(b);}
-inline Expr operator!=(float a, const Expr &b) {return Expr(a) != b;}
+inline Expr operator+(Expr a, float b) {return std::move(a) + Expr(b);}
+inline Expr operator+(float a, Expr b) {return Expr(a) + std::move(b);}
+inline Expr operator-(Expr a, float b) {return std::move(a) - Expr(b);}
+inline Expr operator-(float a, Expr b) {return Expr(a) - std::move(b);}
+inline Expr operator*(Expr a, float b) {return std::move(a) * Expr(b);}
+inline Expr operator*(float a, Expr b) {return Expr(a) * std::move(b);}
+inline Expr operator/(Expr a, float b) {return std::move(a) / Expr(b);}
+inline Expr operator/(float a, Expr b) {return Expr(a) / std::move(b);}
+inline Expr operator%(Expr a, float b) {return std::move(a) % Expr(b);}
+inline Expr operator%(float a, Expr b) {return Expr(a) % std::move(b);}
+inline Expr operator>(Expr a, float b) {return std::move(a) > Expr(b);}
+inline Expr operator>(float a, Expr b) {return Expr(a) > std::move(b);}
+inline Expr operator<(Expr a, float b) {return std::move(a) < Expr(b);}
+inline Expr operator<(float a, Expr b) {return Expr(a) < std::move(b);}
+inline Expr operator>=(Expr a, float b) {return std::move(a) >= Expr(b);}
+inline Expr operator>=(float a, Expr b) {return Expr(a) >= std::move(b);}
+inline Expr operator<=(Expr a, float b) {return std::move(a) <= Expr(b);}
+inline Expr operator<=(float a, Expr b) {return Expr(a) <= std::move(b);}
+inline Expr operator==(Expr a, float b) {return std::move(a) == Expr(b);}
+inline Expr operator==(float a, Expr b) {return Expr(a) == std::move(b);}
+inline Expr operator!=(Expr a, float b) {return std::move(a) != Expr(b);}
+inline Expr operator!=(float a, Expr b) {return Expr(a) != std::move(b);}
 // @}
 
 /** Clamps an expression to lie within the given bounds. The bounds
  * are type-cast to match the expression. Vectorizes as well as min/max. */
-inline Expr clamp(const Expr &a, const Expr &min_val, const Expr &max_val) {
+inline Expr clamp(Expr a, Expr min_val, Expr max_val) {
     user_assert(a.defined() && min_val.defined() && max_val.defined())
         << "clamp of undefined Expr\n";
     Expr n_min_val = lossless_cast(a.type(), min_val);
@@ -780,14 +811,14 @@ inline Expr clamp(const Expr &a, const Expr &min_val, const Expr &max_val) {
     Expr n_max_val = lossless_cast(a.type(), max_val);
     user_assert(n_max_val.defined())
         << "clamp with possibly out of range maximum bound: " << max_val << "\n";
-    return Internal::Max::make(Internal::Min::make(a, n_max_val), n_min_val);
+    return Internal::Max::make(Internal::Min::make(std::move(a), std::move(n_max_val)), std::move(n_min_val));
 }
 
 /** Returns the absolute value of a signed integer or floating-point
  * expression. Vectorizes cleanly. Unlike in C, abs of a signed
  * integer returns an unsigned integer of the same bit width. This
  * means that abs of the most negative integer doesn't overflow. */
-inline Expr abs(const Expr &a) {
+inline Expr abs(Expr a) {
     user_assert(a.defined())
         << "abs of undefined Expr\n";
     Type t = a.type();
@@ -796,7 +827,7 @@ inline Expr abs(const Expr &a) {
         return a;
     }
     return Internal::Call::make(t.with_code(t.is_int() ? Type::UInt : t.code()),
-                                Internal::Call::abs, {a}, Internal::Call::PureIntrinsic);
+                                Internal::Call::abs, {std::move(a)}, Internal::Call::PureIntrinsic);
 }
 
 /** Return the absolute difference between two values. Vectorizes
@@ -811,12 +842,12 @@ inline Expr absd(Expr a, Expr b) {
 
     if (t.is_float()) {
         // Floats can just use abs.
-        return abs(a - b);
+        return abs(std::move(a) - std::move(b));
     }
 
     // The argument may be signed, but the return type is unsigned.
     return Internal::Call::make(t.with_code(t.is_int() ? Type::UInt : t.code()),
-                                Internal::Call::absd, {a, b},
+                                Internal::Call::absd, {std::move(a), std::move(b)},
                                 Internal::Call::PureIntrinsic);
 }
 
@@ -828,15 +859,15 @@ inline Expr select(Expr condition, Expr true_value, Expr false_value) {
 
     if (as_const_int(condition)) {
         // Why are you doing this? We'll preserve the select node until constant folding for you.
-        condition = cast(Bool(), condition);
+        condition = cast(Bool(), std::move(condition));
     }
 
     // Coerce int literals to the type of the other argument
     if (as_const_int(true_value)) {
-        true_value = cast(false_value.type(), true_value);
+        true_value = cast(false_value.type(), std::move(true_value));
     }
     if (as_const_int(false_value)) {
-        false_value = cast(true_value.type(), false_value);
+        false_value = cast(true_value.type(), std::move(false_value));
     }
 
     user_assert(condition.type().is_bool())
@@ -848,7 +879,7 @@ inline Expr select(Expr condition, Expr true_value, Expr false_value) {
         << "  " << true_value << " has type " << true_value.type() << "\n"
         << "  " << false_value << " has type " << false_value.type() << "\n";
 
-    return Internal::Select::make(condition, true_value, false_value);
+    return Internal::Select::make(std::move(condition), std::move(true_value), std::move(false_value));
 }
 
 /** A multi-way variant of select similar to a switch statement in C,
@@ -857,8 +888,8 @@ inline Expr select(Expr condition, Expr true_value, Expr false_value) {
  * final value if all conditions are false. */
 template<typename... Args,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Args...>::value>::type* = nullptr>
-inline Expr select(const Expr &c0, const Expr &v0, const Expr &c1, const Expr &v1, Args&&... args) {
-    return select(c0, v0, select(c1, v1, std::forward<Args>(args)...));
+inline Expr select(Expr c0, Expr v0, Expr c1, Expr v1, Args&&... args) {
+    return select(std::move(c0), std::move(v0), select(std::move(c1), std::move(v1), std::forward<Args>(args)...));
 }
 
 // TODO: Implement support for *_f16 external functions in various backends.
@@ -867,96 +898,84 @@ inline Expr select(const Expr &c0, const Expr &v0, const Expr &c1, const Expr &v
 /** Return the sine of a floating-point expression. If the argument is
  * not floating-point, it is cast to Float(32). Does not vectorize
  * well. */
-inline Expr sin(const Expr &x) {
+inline Expr sin(Expr x) {
     user_assert(x.defined()) << "sin of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "sin_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "sin_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
-        return Internal::Call::make(Float(32), "sin_f32", {cast<float>(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(64), "sin_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "sin_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "sin_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 /** Return the arcsine of a floating-point expression. If the argument
  * is not floating-point, it is cast to Float(32). Does not vectorize
  * well. */
-inline Expr asin(const Expr &x) {
+inline Expr asin(Expr x) {
     user_assert(x.defined()) << "asin of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "asin_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "asin_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
-        return Internal::Call::make(Float(32), "asin_f32", {cast<float>(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(64), "asin_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "asin_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "asin_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 /** Return the cosine of a floating-point expression. If the argument
  * is not floating-point, it is cast to Float(32). Does not vectorize
  * well. */
-inline Expr cos(const Expr &x) {
+inline Expr cos(Expr x) {
     user_assert(x.defined()) << "cos of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "cos_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "cos_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
-        return Internal::Call::make(Float(32), "cos_f32", {cast<float>(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(64), "cos_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "cos_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "cos_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 /** Return the arccosine of a floating-point expression. If the
  * argument is not floating-point, it is cast to Float(32). Does not
  * vectorize well. */
-inline Expr acos(const Expr &x) {
+inline Expr acos(Expr x) {
     user_assert(x.defined()) << "acos of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "acos_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "acos_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
-        return Internal::Call::make(Float(32), "acos_f32", {cast<float>(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(64), "acos_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "acos_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "acos_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 /** Return the tangent of a floating-point expression. If the argument
  * is not floating-point, it is cast to Float(32). Does not vectorize
  * well. */
-inline Expr tan(const Expr &x) {
+inline Expr tan(Expr x) {
     user_assert(x.defined()) << "tan of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "tan_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "tan_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
-        return Internal::Call::make(Float(32), "tan_f32", {cast<float>(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(64), "tan_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "tan_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "tan_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 /** Return the arctangent of a floating-point expression. If the
  * argument is not floating-point, it is cast to Float(32). Does not
  * vectorize well. */
-inline Expr atan(const Expr &x) {
+inline Expr atan(Expr x) {
     user_assert(x.defined()) << "atan of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "atan_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "atan_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
-        return Internal::Call::make(Float(32), "atan_f32", {cast<float>(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(64), "atan_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "atan_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "atan_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
@@ -968,136 +987,120 @@ inline Expr atan2(Expr y, Expr x) {
 
     if (y.type() == Float(64)) {
         x = cast<double>(x);
-        return Internal::Call::make(Float(64), "atan2_f64", {y, x}, Internal::Call::PureExtern);
-    }
-    else if (y.type() == Float(16)) {
+        return Internal::Call::make(Float(64), "atan2_f64", {std::move(y), std::move(x)}, Internal::Call::PureExtern);
+    } else if (y.type() == Float(16)) {
         x = cast<float16_t>(x);
-        return Internal::Call::make(Float(16), "atan2_f16", {y, x}, Internal::Call::PureExtern);
-    }
-    else {
+        return Internal::Call::make(Float(16), "atan2_f16", {std::move(y), std::move(x)}, Internal::Call::PureExtern);
+    } else {
         y = cast<float>(y);
         x = cast<float>(x);
-        return Internal::Call::make(Float(32), "atan2_f32", {y, x}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(32), "atan2_f32", {std::move(y), std::move(x)}, Internal::Call::PureExtern);
     }
 }
 
 /** Return the hyperbolic sine of a floating-point expression.  If the
  *  argument is not floating-point, it is cast to Float(32). Does not
  *  vectorize well. */
-inline Expr sinh(const Expr &x) {
+inline Expr sinh(Expr x) {
     user_assert(x.defined()) << "sinh of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "sinh_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "sinh_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
-        return Internal::Call::make(Float(32), "sinh_f32", {cast<float>(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(64), "sinh_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "sinh_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "sinh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 /** Return the hyperbolic arcsinhe of a floating-point expression.  If
  * the argument is not floating-point, it is cast to Float(32). Does
  * not vectorize well. */
-inline Expr asinh(const Expr &x) {
+inline Expr asinh(Expr x) {
     user_assert(x.defined()) << "asinh of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "asinh_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if(x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "asinh_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
-        return Internal::Call::make(Float(32), "asinh_f32", {cast<float>(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(64), "asinh_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "asinh_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "asinh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 /** Return the hyperbolic cosine of a floating-point expression.  If
  * the argument is not floating-point, it is cast to Float(32). Does
  * not vectorize well. */
-inline Expr cosh(const Expr &x) {
+inline Expr cosh(Expr x) {
     user_assert(x.defined()) << "cosh of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "cosh_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "cosh_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
-        return Internal::Call::make(Float(32), "cosh_f32", {cast<float>(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(64), "cosh_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "cosh_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "cosh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 /** Return the hyperbolic arccosine of a floating-point expression.
  * If the argument is not floating-point, it is cast to
  * Float(32). Does not vectorize well. */
-inline Expr acosh(const Expr &x) {
+inline Expr acosh(Expr x) {
     user_assert(x.defined()) << "acosh of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "acosh_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "acosh_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
-        return Internal::Call::make(Float(32), "acosh_f32", {cast<float>(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(64), "acosh_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "acosh_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "acosh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 /** Return the hyperbolic tangent of a floating-point expression.  If
  * the argument is not floating-point, it is cast to Float(32). Does
  * not vectorize well. */
-inline Expr tanh(const Expr &x) {
+inline Expr tanh(Expr x) {
     user_assert(x.defined()) << "tanh of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "tanh_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "tanh_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
-        return Internal::Call::make(Float(32), "tanh_f32", {cast<float>(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(64), "tanh_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "tanh_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "tanh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 /** Return the hyperbolic arctangent of a floating-point expression.
  * If the argument is not floating-point, it is cast to
  * Float(32). Does not vectorize well. */
-inline Expr atanh(const Expr &x) {
+inline Expr atanh(Expr x) {
     user_assert(x.defined()) << "atanh of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "atanh_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "atanh_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
-        return Internal::Call::make(Float(32), "atanh_f32", {cast<float>(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(64), "atanh_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "atanh_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "atanh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 /** Return the square root of a floating-point expression. If the
  * argument is not floating-point, it is cast to Float(32). Typically
  * vectorizes cleanly. */
-inline Expr sqrt(const Expr &x) {
+inline Expr sqrt(Expr x) {
     user_assert(x.defined()) << "sqrt of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "sqrt_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "sqrt_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
-        return Internal::Call::make(Float(32), "sqrt_f32", {cast<float>(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(64), "sqrt_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "sqrt_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "sqrt_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 /** Return the square root of the sum of the squares of two
  * floating-point expressions. If the argument is not floating-point,
  * it is cast to Float(32). Vectorizes cleanly. */
-inline Expr hypot(const Expr &x, const Expr &y) {
-    return sqrt(x*x + y*y);
+inline Expr hypot(Expr x, Expr y) {
+    return sqrt(x * x + y * y);
 }
 
 /** Return the exponential of a floating-point expression. If the
@@ -1107,16 +1110,14 @@ inline Expr hypot(const Expr &x, const Expr &y) {
  * vectorizable, does the right thing for extremely small or extremely
  * large inputs, and is accurate up to the last bit of the
  * mantissa. Vectorizes cleanly. */
-inline Expr exp(const Expr &x) {
+inline Expr exp(Expr x) {
     user_assert(x.defined()) << "exp of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "exp_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "exp_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
-        return Internal::Call::make(Float(32), "exp_f32", {cast<float>(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(64), "exp_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "exp_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "exp_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
@@ -1127,16 +1128,14 @@ inline Expr exp(const Expr &x) {
  * vectorizable, does the right thing for inputs <= 0 (returns -inf or
  * nan), and is accurate up to the last bit of the
  * mantissa. Vectorizes cleanly. */
-inline Expr log(const Expr &x) {
+inline Expr log(Expr x) {
     user_assert(x.defined()) << "log of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "log_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "log_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
-        return Internal::Call::make(Float(32), "log_f32", {cast<float>(x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(Float(64), "log_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "log_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "log_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
@@ -1150,43 +1149,41 @@ inline Expr pow(Expr x, Expr y) {
     user_assert(x.defined() && y.defined()) << "pow of undefined Expr\n";
 
     if (const int64_t *i = as_const_int(y)) {
-        return raise_to_integer_power(x, *i);
+        return raise_to_integer_power(std::move(x), *i);
     }
 
     if (x.type() == Float(64)) {
-        y = cast<double>(y);
-        return Internal::Call::make(Float(64), "pow_f64", {x, y}, Internal::Call::PureExtern);
-    }
-    else if (x.type() == Float(16)) {
-         y = cast<float16_t>(y);
-        return Internal::Call::make(Float(16), "pow_f16", {x, y}, Internal::Call::PureExtern);
-    }
-    else {
-        x = cast<float>(x);
-        y = cast<float>(y);
-        return Internal::Call::make(Float(32), "pow_f32", {x, y}, Internal::Call::PureExtern);
+        y = cast<double>(std::move(y));
+        return Internal::Call::make(Float(64), "pow_f64", {std::move(x), std::move(y)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        y = cast<float16_t>(std::move(y));
+        return Internal::Call::make(Float(16), "pow_f16", {std::move(x), std::move(y)}, Internal::Call::PureExtern);
+    } else {
+        x = cast<float>(std::move(x));
+        y = cast<float>(std::move(y));
+        return Internal::Call::make(Float(32), "pow_f32", {std::move(x), std::move(y)}, Internal::Call::PureExtern);
     }
 }
 
 /** Evaluate the error function erf. Only available for
  * Float(32). Accurate up to the last three bits of the
  * mantissa. Vectorizes cleanly. */
-inline Expr erf(const Expr &x) {
+inline Expr erf(Expr x) {
     user_assert(x.defined()) << "erf of undefined Expr\n";
     user_assert(x.type() == Float(32)) << "erf only takes float arguments\n";
-    return Internal::halide_erf(x);
+    return Internal::halide_erf(std::move(x));
 }
 
 /** Fast approximate cleanly vectorizable log for Float(32). Returns
  * nonsense for x <= 0.0f. Accurate up to the last 5 bits of the
  * mantissa. Vectorizes cleanly. */
-EXPORT Expr fast_log(const Expr &x);
+EXPORT Expr fast_log(Expr x);
 
 /** Fast approximate cleanly vectorizable exp for Float(32). Returns
  * nonsense for inputs that would overflow or underflow. Typically
  * accurate up to the last 5 bits of the mantissa. Gets worse when
  * approaching overflow. Vectorizes cleanly. */
-EXPORT Expr fast_exp(const Expr &x);
+EXPORT Expr fast_exp(Expr x);
 
 /** Fast approximate cleanly vectorizable pow for Float(32). Returns
  * nonsense for x < 0.0f. Accurate up to the last 5 bits of the
@@ -1194,45 +1191,45 @@ EXPORT Expr fast_exp(const Expr &x);
  * overflow. Vectorizes cleanly. */
 inline Expr fast_pow(Expr x, Expr y) {
     if (const int64_t *i = as_const_int(y)) {
-        return raise_to_integer_power(x, *i);
+        return raise_to_integer_power(std::move(x), *i);
     }
 
-    x = cast<float>(x);
-    y = cast<float>(y);
-    return select(x == 0.0f, 0.0f, fast_exp(fast_log(x) * y));
+    x = cast<float>(std::move(x));
+    y = cast<float>(std::move(y));
+    return select(x == 0.0f, 0.0f, fast_exp(fast_log(std::move(x)) * std::move(y)));
 }
 
 /** Fast approximate inverse for Float(32). Corresponds to the rcpps
  * instruction on x86, and the vrecpe instruction on ARM. Vectorizes
  * cleanly. */
-inline Expr fast_inverse(const Expr &x) {
+inline Expr fast_inverse(Expr x) {
     user_assert(x.type() == Float(32)) << "fast_inverse only takes float arguments\n";
-    return Internal::Call::make(x.type(), "fast_inverse_f32", {x}, Internal::Call::PureExtern);
+    Type t = x.type();
+    return Internal::Call::make(t, "fast_inverse_f32", {std::move(x)}, Internal::Call::PureExtern);
 }
 
 /** Fast approximate inverse square root for Float(32). Corresponds to
  * the rsqrtps instruction on x86, and the vrsqrte instruction on
  * ARM. Vectorizes cleanly. */
-inline Expr fast_inverse_sqrt(const Expr &x) {
+inline Expr fast_inverse_sqrt(Expr x) {
     user_assert(x.type() == Float(32)) << "fast_inverse_sqrt only takes float arguments\n";
-    return Internal::Call::make(x.type(), "fast_inverse_sqrt_f32", {x}, Internal::Call::PureExtern);
+    Type t = x.type();
+    return Internal::Call::make(t, "fast_inverse_sqrt_f32", {std::move(x)}, Internal::Call::PureExtern);
 }
 
 /** Return the greatest whole number less than or equal to a
  * floating-point expression. If the argument is not floating-point,
  * it is cast to Float(32). The return value is still in floating
  * point, despite being a whole number. Vectorizes cleanly. */
-inline Expr floor(const Expr &x) {
+inline Expr floor(Expr x) {
     user_assert(x.defined()) << "floor of undefined Expr\n";
     if (x.type().element_of() == Float(64)) {
-        return Internal::Call::make(x.type(), "floor_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type().element_of() == Float(16)) {
-        return Internal::Call::make(Float(16), "floor_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
+        return Internal::Call::make(x.type(), "floor_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type().element_of() == Float(16)) {
+        return Internal::Call::make(Float(16), "floor_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
         Type t = Float(32, x.type().lanes());
-        return Internal::Call::make(t, "floor_f32", {cast(t, x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(t, "floor_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
@@ -1240,17 +1237,15 @@ inline Expr floor(const Expr &x) {
  * floating-point expression. If the argument is not floating-point,
  * it is cast to Float(32). The return value is still in floating
  * point, despite being a whole number. Vectorizes cleanly. */
-inline Expr ceil(const Expr &x) {
+inline Expr ceil(Expr x) {
     user_assert(x.defined()) << "ceil of undefined Expr\n";
     if (x.type().element_of() == Float(64)) {
-        return Internal::Call::make(x.type(), "ceil_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type().element_of() == Float(16)) {
-        return Internal::Call::make(Float(16), "ceil_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
+        return Internal::Call::make(x.type(), "ceil_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type().element_of() == Float(16)) {
+        return Internal::Call::make(Float(16), "ceil_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
         Type t = Float(32, x.type().lanes());
-        return Internal::Call::make(t, "ceil_f32", {cast(t, x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(t, "ceil_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
@@ -1259,65 +1254,59 @@ inline Expr ceil(const Expr &x) {
  * is still in floating point, despite being a whole number. On ties, we
  * follow IEEE754 conventions and round to the nearest even number. Vectorizes
  * cleanly. */
-inline Expr round(const Expr &x) {
+inline Expr round(Expr x) {
     user_assert(x.defined()) << "round of undefined Expr\n";
     if (x.type().element_of() == Float(64)) {
-        return Internal::Call::make(Float(64), "round_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type().element_of() == Float(16)) {
-        return Internal::Call::make(Float(16), "round_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
+        return Internal::Call::make(Float(64), "round_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type().element_of() == Float(16)) {
+        return Internal::Call::make(Float(16), "round_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
         Type t = Float(32, x.type().lanes());
-        return Internal::Call::make(t, "round_f32", {cast(t, x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(t, "round_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 /** Return the integer part of a floating-point expression. If the argument is
  * not floating-point, it is cast to Float(32). The return value is still in
  * floating point, despite being a whole number. Vectorizes cleanly. */
-inline Expr trunc(const Expr &x) {
+inline Expr trunc(Expr x) {
     user_assert(x.defined()) << "trunc of undefined Expr\n";
     if (x.type().element_of() == Float(64)) {
-        return Internal::Call::make(Float(64), "trunc_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type().element_of() == Float(16)) {
-        return Internal::Call::make(Float(16), "trunc_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
+        return Internal::Call::make(Float(64), "trunc_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type().element_of() == Float(16)) {
+        return Internal::Call::make(Float(16), "trunc_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
         Type t = Float(32, x.type().lanes());
-        return Internal::Call::make(t, "trunc_f32", {cast(t, x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(t, "trunc_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 /** Returns true if the argument is a Not a Number (NaN). Requires a
   * floating point argument.  Vectorizes cleanly. */
-inline Expr is_nan(const Expr &x) {
+inline Expr is_nan(Expr x) {
     user_assert(x.defined()) << "is_nan of undefined Expr\n";
     user_assert(x.type().is_float()) << "is_nan only works for float";
     Type t = Bool(x.type().lanes());
     if (x.type().element_of() == Float(64)) {
-        return Internal::Call::make(t, "is_nan_f64", {x}, Internal::Call::PureExtern);
-    }
-    else if (x.type().element_of() == Float(64)) {
-        return Internal::Call::make(t, "is_nan_f16", {x}, Internal::Call::PureExtern);
-    }
-    else {
+        return Internal::Call::make(t, "is_nan_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type().element_of() == Float(64)) {
+        return Internal::Call::make(t, "is_nan_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
         Type ft = Float(32, x.type().lanes());
-        return Internal::Call::make(t, "is_nan_f32", {cast(ft, x)}, Internal::Call::PureExtern);
+        return Internal::Call::make(t, "is_nan_f32", {cast(ft, std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 /** Return the fractional part of a floating-point expression. If the argument
  *  is not floating-point, it is cast to Float(32). The return value has the
  *  same sign as the original expression. Vectorizes cleanly. */
-inline Expr fract(const Expr &x) {
+inline Expr fract(Expr x) {
     user_assert(x.defined()) << "fract of undefined Expr\n";
     return x - trunc(x);
 }
 
 /** Reinterpret the bits of one value as another type. */
-inline Expr reinterpret(Type t, const Expr &e) {
+inline Expr reinterpret(Type t, Expr e) {
     user_assert(e.defined()) << "reinterpret of undefined Expr\n";
     int from_bits = e.type().bits() * e.type().lanes();
     int to_bits = t.bits() * t.lanes();
@@ -1326,11 +1315,11 @@ inline Expr reinterpret(Type t, const Expr &e) {
         << " which has " << from_bits
         << " bits, to type " << t
         << " which has " << to_bits << " bits\n";
-    return Internal::Call::make(t, Internal::Call::reinterpret, {e}, Internal::Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::reinterpret, {std::move(e)}, Internal::Call::PureIntrinsic);
 }
 
 template<typename T>
-inline Expr reinterpret(const Expr &e) {
+inline Expr reinterpret(Expr e) {
     return reinterpret(type_of<T>(), e);
 }
 
@@ -1350,7 +1339,8 @@ inline Expr operator&(Expr x, Expr y) {
     if (y.type() != x.type()) {
         y = reinterpret(x.type(), y);
     }
-    return Internal::Call::make(x.type(), Internal::Call::bitwise_and, {x, y}, Internal::Call::PureIntrinsic);
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::bitwise_and, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
 
 /** Return the bitwise or of two expressions (which need not have the
@@ -1369,7 +1359,8 @@ inline Expr operator|(Expr x, Expr y) {
     if (y.type() != x.type()) {
         y = reinterpret(x.type(), y);
     }
-    return Internal::Call::make(x.type(), Internal::Call::bitwise_or, {x, y}, Internal::Call::PureIntrinsic);
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::bitwise_or, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
 
 /** Return the bitwise exclusive or of two expressions (which need not
@@ -1388,15 +1379,17 @@ inline Expr operator^(Expr x, Expr y) {
     if (y.type() != x.type()) {
         y = reinterpret(x.type(), y);
     }
-    return Internal::Call::make(x.type(), Internal::Call::bitwise_xor, {x, y}, Internal::Call::PureIntrinsic);
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::bitwise_xor, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
 
 /** Return the bitwise not of an expression. */
-inline Expr operator~(const Expr &x) {
+inline Expr operator~(Expr x) {
     user_assert(x.defined()) << "bitwise not of undefined Expr\n";
     user_assert(x.type().is_int() || x.type().is_uint())
         << "Argument to bitwise not must be an integer or unsigned integer";
-    return Internal::Call::make(x.type(), Internal::Call::bitwise_not, {x}, Internal::Call::PureIntrinsic);
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::bitwise_not, {std::move(x)}, Internal::Call::PureIntrinsic);
 }
 
 /** Shift the bits of an integer value left. This is actually less
@@ -1412,15 +1405,18 @@ inline Expr operator<<(Expr x, Expr y) {
     user_assert(!x.type().is_float()) << "First argument to shift left is a float: " << x << "\n";
     user_assert(!y.type().is_float()) << "Second argument to shift left is a float: " << y << "\n";
     Internal::match_types(x, y);
-    return Internal::Call::make(x.type(), Internal::Call::shift_left, {x, y}, Internal::Call::PureIntrinsic);
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::shift_left, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
-inline Expr operator<<(const Expr &x, int y) {
-    Internal::check_representable(x.type(), y);
-    return x << Internal::make_const(x.type(), y);
+inline Expr operator<<(Expr x, int y) {
+    Type t = x.type();
+    Internal::check_representable(t, y);
+    return std::move(x) << Internal::make_const(t, y);
 }
-inline Expr operator<<(int x, const Expr &y) {
-    Internal::check_representable(y.type(), x);
-    return Internal::make_const(y.type(), x) << y;
+inline Expr operator<<(int x, Expr y) {
+    Type t = y.type();
+    Internal::check_representable(t, x);
+    return Internal::make_const(t, x) << std::move(y);
 }
 // @}
 
@@ -1438,15 +1434,18 @@ inline Expr operator>>(Expr x, Expr y) {
     user_assert(!x.type().is_float()) << "First argument to shift right is a float: " << x << "\n";
     user_assert(!y.type().is_float()) << "Second argument to shift right is a float: " << y << "\n";
     Internal::match_types(x, y);
-    return Internal::Call::make(x.type(), Internal::Call::shift_right, {x, y}, Internal::Call::PureIntrinsic);
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::shift_right, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
-inline Expr operator>>(const Expr &x, int y) {
-    Internal::check_representable(x.type(), y);
-    return x >> Internal::make_const(x.type(), y);
+inline Expr operator>>(Expr x, int y) {
+    Type t = x.type();
+    Internal::check_representable(t, y);
+    return std::move(x) >> Internal::make_const(t, y);
 }
-inline Expr operator>>(int x, const Expr &y) {
-    Internal::check_representable(y.type(), x);
-    return Internal::make_const(y.type(), x) >> y;
+inline Expr operator>>(int x, Expr y) {
+    Type t = y.type();
+    Internal::check_representable(t, x);
+    return Internal::make_const(t, x) >> std::move(y);
 }
 // @}
 
@@ -1528,10 +1527,10 @@ inline Expr lerp(Expr zero_val, Expr one_val, Expr weight) {
     // alpha). lerp(0, cast<float>(x), alpha) is also allowed and will
     // produce a float result.
     if (as_const_int(zero_val)) {
-        zero_val = cast(one_val.type(), zero_val);
+        zero_val = cast(one_val.type(), std::move(zero_val));
     }
     if (as_const_int(one_val)) {
-        one_val = cast(zero_val.type(), one_val);
+        one_val = cast(zero_val.type(), std::move(one_val));
     }
 
     user_assert(zero_val.type() == one_val.type())
@@ -1552,32 +1551,36 @@ inline Expr lerp(Expr zero_val, Expr one_val, Expr weight) {
                 << *const_weight << ", which is not in the range [0.0, 1.0].\n";
         }
     }
-    return Internal::Call::make(zero_val.type(), Internal::Call::lerp,
-                                {zero_val, one_val, weight},
+    Type t = zero_val.type();
+    return Internal::Call::make(t, Internal::Call::lerp,
+                                {std::move(zero_val), std::move(one_val), std::move(weight)},
                                 Internal::Call::PureIntrinsic);
 }
 
 /** Count the number of set bits in an expression. */
-inline Expr popcount(const Expr &x) {
+inline Expr popcount(Expr x) {
     user_assert(x.defined()) << "popcount of undefined Expr\n";
-    return Internal::Call::make(x.type(), Internal::Call::popcount,
-                                {x}, Internal::Call::PureIntrinsic);
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::popcount,
+                                {std::move(x)}, Internal::Call::PureIntrinsic);
 }
 
 /** Count the number of leading zero bits in an expression. The result is
  *  undefined if the value of the expression is zero. */
-inline Expr count_leading_zeros(const Expr &x) {
+inline Expr count_leading_zeros(Expr x) {
     user_assert(x.defined()) << "count leading zeros of undefined Expr\n";
-    return Internal::Call::make(x.type(), Internal::Call::count_leading_zeros,
-                                {x}, Internal::Call::PureIntrinsic);
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::count_leading_zeros,
+                                {std::move(x)}, Internal::Call::PureIntrinsic);
 }
 
 /** Count the number of trailing zero bits in an expression. The result is
  *  undefined if the value of the expression is zero. */
-inline Expr count_trailing_zeros(const Expr &x) {
+inline Expr count_trailing_zeros(Expr x) {
     user_assert(x.defined()) << "count trailing zeros of undefined Expr\n";
-    return Internal::Call::make(x.type(), Internal::Call::count_trailing_zeros,
-                                {x}, Internal::Call::PureIntrinsic);
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::count_trailing_zeros,
+                                {std::move(x)}, Internal::Call::PureIntrinsic);
 }
 
 /** Divide two integers, rounding towards zero. This is the typical
@@ -1589,12 +1592,13 @@ inline Expr div_round_to_zero(Expr x, Expr y) {
     user_assert(y.defined()) << "div_round_to_zero of undefined divisor\n";
     Internal::match_types(x, y);
     if (x.type().is_uint()) {
-        return x / y;
+        return std::move(x) / std::move(y);
     }
     user_assert(x.type().is_int()) << "First argument to div_round_to_zero is not an integer: " << x << "\n";
     user_assert(y.type().is_int()) << "Second argument to div_round_to_zero is not an integer: " << y << "\n";
-    return Internal::Call::make(x.type(), Internal::Call::div_round_to_zero,
-                                {x, y},
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::div_round_to_zero,
+                                {std::move(x), std::move(y)},
                                 Internal::Call::PureIntrinsic);
 }
 
@@ -1608,12 +1612,13 @@ inline Expr mod_round_to_zero(Expr x, Expr y) {
     user_assert(y.defined()) << "mod_round_to_zero of undefined divisor\n";
     Internal::match_types(x, y);
     if (x.type().is_uint()) {
-        return x % y;
+        return std::move(x) % std::move(y);
     }
     user_assert(x.type().is_int()) << "First argument to mod_round_to_zero is not an integer: " << x << "\n";
     user_assert(y.type().is_int()) << "Second argument to mod_round_to_zero is not an integer: " << y << "\n";
-    return Internal::Call::make(x.type(), Internal::Call::mod_round_to_zero,
-                                {x, y},
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::mod_round_to_zero,
+                                {std::move(x), std::move(y)},
                                 Internal::Call::PureIntrinsic);
 }
 
@@ -1646,7 +1651,7 @@ inline Expr mod_round_to_zero(Expr x, Expr y) {
  *
  * This function vectorizes cleanly.
  */
-inline Expr random_float(const Expr &seed = Expr()) {
+inline Expr random_float(Expr seed = Expr()) {
     // Random floats get even IDs
     static std::atomic<int> counter;
     int id = (counter++)*2;
@@ -1656,7 +1661,7 @@ inline Expr random_float(const Expr &seed = Expr()) {
         user_assert(seed.type() == Int(32))
             << "The seed passed to random_float must have type Int(32), but instead is "
             << seed << " of type " << seed.type() << "\n";
-        args.push_back(seed);
+        args.push_back(std::move(seed));
     }
     args.push_back(id);
 
@@ -1668,7 +1673,7 @@ inline Expr random_float(const Expr &seed = Expr()) {
 
 /** Return a random variable representing a uniformly distributed
  * unsigned 32-bit integer. See \ref random_float. Vectorizes cleanly. */
-inline Expr random_uint(const Expr &seed = Expr()) {
+inline Expr random_uint(Expr seed = Expr()) {
     // Random ints get odd IDs
     static std::atomic<int> counter;
     int id = (counter++)*2 + 1;
@@ -1678,7 +1683,7 @@ inline Expr random_uint(const Expr &seed = Expr()) {
         user_assert(seed.type() == Int(32) || seed.type() == UInt(32))
             << "The seed passed to random_int must have type Int(32) or UInt(32), but instead is "
             << seed << " of type " << seed.type() << "\n";
-        args.push_back(seed);
+        args.push_back(std::move(seed));
     }
     args.push_back(id);
 
@@ -1688,8 +1693,8 @@ inline Expr random_uint(const Expr &seed = Expr()) {
 
 /** Return a random variable representing a uniformly distributed
  * 32-bit integer. See \ref random_float. Vectorizes cleanly. */
-inline Expr random_int(const Expr &seed = Expr()) {
-    return cast<int32_t>(random_uint(seed));
+inline Expr random_int(Expr seed = Expr()) {
+    return cast<int32_t>(random_uint(std::move(seed)));
 }
 
 // Secondary args to print can be Exprs or const char *
@@ -1704,8 +1709,8 @@ inline NO_INLINE void collect_print_args(std::vector<Expr> &args, const char *ar
 }
 
 template<typename ...Args>
-inline NO_INLINE void collect_print_args(std::vector<Expr> &args, const Expr &arg, Args&&... more_args) {
-    args.push_back(arg);
+inline NO_INLINE void collect_print_args(std::vector<Expr> &args, Expr arg, Args&&... more_args) {
+    args.push_back(std::move(arg));
     collect_print_args(args, std::forward<Args>(more_args)...);
 }
 }
@@ -1718,8 +1723,8 @@ inline NO_INLINE void collect_print_args(std::vector<Expr> &args, const Expr &ar
 EXPORT Expr print(const std::vector<Expr> &values);
 
 template <typename... Args>
-inline NO_INLINE Expr print(const Expr &a, Args&&... args) {
-    std::vector<Expr> collected_args = {a};
+inline NO_INLINE Expr print(Expr a, Args&&... args) {
+    std::vector<Expr> collected_args = {std::move(a)};
     Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
     return print(collected_args);
 }
@@ -1728,13 +1733,13 @@ inline NO_INLINE Expr print(const Expr &a, Args&&... args) {
 /** Create an Expr that prints whenever it is evaluated, provided that
  * the condition is true. */
 // @{
-EXPORT Expr print_when(const Expr &condition, const std::vector<Expr> &values);
+EXPORT Expr print_when(Expr condition, const std::vector<Expr> &values);
 
 template<typename ...Args>
-inline NO_INLINE Expr print_when(const Expr &condition, const Expr &a, Args&&... args) {
-    std::vector<Expr> collected_args = {a};
+inline NO_INLINE Expr print_when(Expr condition, Expr a, Args&&... args) {
+    std::vector<Expr> collected_args = {std::move(a)};
     Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
-    return print_when(condition, collected_args);
+    return print_when(std::move(condition), collected_args);
 }
 
 // @}
@@ -1760,13 +1765,13 @@ inline NO_INLINE Expr print_when(const Expr &condition, const Expr &a, Args&&...
  * will allow the optimizer to assume positive, nonzero values for y.
  */
 // @{
-EXPORT Expr require(const Expr &condition, const std::vector<Expr> &values);
+EXPORT Expr require(Expr condition, const std::vector<Expr> &values);
 
 template<typename ...Args>
-inline NO_INLINE Expr require(const Expr &condition, const Expr &value, Args&&... args) {
-    std::vector<Expr> collected_args = {value};
+inline NO_INLINE Expr require(Expr condition, Expr value, Args&&... args) {
+    std::vector<Expr> collected_args = {std::move(value)};
     Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
-    return require(condition, collected_args);
+    return require(std::move(condition), collected_args);
 }
 
 // @}
@@ -1802,7 +1807,7 @@ inline Expr undef() {
 }
 
 namespace Internal {
-EXPORT Expr memoize_tag_helper(const Expr &result, const std::vector<Expr> &cache_key_values);
+EXPORT Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_values);
 }  // namespace Internal
 
 /** Control the values used in the memoization cache key for memoize.
@@ -1833,9 +1838,9 @@ EXPORT Expr memoize_tag_helper(const Expr &result, const std::vector<Expr> &cach
  * on the digest. */
 // @{
 template<typename ...Args>
-inline NO_INLINE Expr memoize_tag(const Expr &result, Args&&... args) {
+inline NO_INLINE Expr memoize_tag(Expr result, Args&&... args) {
     std::vector<Expr> collected_args{std::forward<Args>(args)...};
-    return Internal::memoize_tag_helper(result, collected_args);
+    return Internal::memoize_tag_helper(std::move(result), collected_args);
 }
 // @}
 
@@ -1852,16 +1857,18 @@ inline NO_INLINE Expr memoize_tag(const Expr &result, Args&&... args) {
  * use the boundary condition helpers in the BoundaryConditions
  * namespace instead.
  */
-inline Expr likely(const Expr &e) {
-    return Internal::Call::make(e.type(), Internal::Call::likely,
-                                {e}, Internal::Call::PureIntrinsic);
+inline Expr likely(Expr e) {
+    Type t = e.type();
+    return Internal::Call::make(t, Internal::Call::likely,
+                                {std::move(e)}, Internal::Call::PureIntrinsic);
 }
 
 /** Equivalent to likely, but only triggers a loop partitioning if
  * found in an innermost loop. */
-inline Expr likely_if_innermost(const Expr &e) {
-    return Internal::Call::make(e.type(), Internal::Call::likely_if_innermost,
-                                {e}, Internal::Call::PureIntrinsic);
+inline Expr likely_if_innermost(Expr e) {
+    Type t = e.type();
+    return Internal::Call::make(t, Internal::Call::likely_if_innermost,
+                                {std::move(e)}, Internal::Call::PureIntrinsic);
 }
 
 
@@ -1869,8 +1876,8 @@ inline Expr likely_if_innermost(const Expr &e) {
  * type T clamping to the minimum and maximum values of the result
  * type. */
 template <typename T>
-Expr saturating_cast(const Expr &e) {
-    return saturating_cast(type_of<T>(), e);
+Expr saturating_cast(Expr e) {
+    return saturating_cast(type_of<T>(), std::move(e));
 }
 
 /** Cast an expression to a new type, clamping to the minimum and

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1196,7 +1196,7 @@ inline Expr fast_pow(Expr x, Expr y) {
 
     x = cast<float>(std::move(x));
     y = cast<float>(std::move(y));
-    return select(x == 0.0f, 0.0f, fast_exp(fast_log(std::move(x)) * std::move(y)));
+    return select(x == 0.0f, 0.0f, fast_exp(fast_log(x) * std::move(y)));
 }
 
 /** Fast approximate inverse for Float(32). Corresponds to the rcpps

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -398,7 +398,7 @@ public:
     MakeSimplifications(const vector<Simplification> &s) : simplifications(s) {}
 
     using IRMutator::mutate;
-    Expr mutate(Expr e) {
+    Expr mutate(const Expr &e) {
         for (auto const &s : simplifications) {
             if (e.same_as(s.old_expr)) {
                 return mutate(s.likely_value);

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -191,7 +191,7 @@ public:
     }
 
 #if LOG_EXPR_MUTATIONS
-    Expr mutate(Expr e) {
+    Expr mutate(const Expr &e) {
         const std::string spaces(debug_indent, ' ');
         debug(1) << spaces << "Simplifying Expr: " << e << "\n";
         debug_indent++;
@@ -207,7 +207,7 @@ public:
 #endif
 
 #if LOG_STMT_MUTATIONS
-    Stmt mutate(Stmt s) {
+    Stmt mutate(const Stmt &s) {
         const std::string spaces(debug_indent, ' ');
         debug(1) << spaces << "Simplifying Stmt: " << s << "\n";
         debug_indent++;
@@ -4769,7 +4769,7 @@ private:
             // the warning, because the assertion is generated internally
             // by Halide and is expected to always fail.
             const Call *call = a->message.as<Call>();
-            const bool const_false_conditions_expected = 
+            const bool const_false_conditions_expected =
                 call && call->name == "halide_error_specialize_fail";
             if (!const_false_conditions_expected) {
                 user_warning << "This pipeline is guaranteed to fail an assertion at runtime: \n"

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -4883,8 +4883,8 @@ private:
         // Rewrite Lets inside an evaluate as LetStmts outside the Evaluate.
         vector<pair<string, Expr>> lets;
         while (const Let *let = value.as<Let>()) {
-            value = let->body;
             lets.push_back({let->name, let->value});
+            value = let->body;
         }
 
         if (value.same_as(op->value)) {

--- a/src/SimplifySpecializations.cpp
+++ b/src/SimplifySpecializations.cpp
@@ -33,7 +33,7 @@ class SimplifyUsingFact : public IRMutator {
 public:
     using IRMutator::mutate;
 
-    Expr mutate(Expr e) {
+    Expr mutate(const Expr &e) {
         if (e.type().is_bool()) {
             if (equal(fact, e) ||
                 can_prove(!fact || e)) {

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -33,7 +33,7 @@ public:
 
     using IRMutator::mutate;
 
-    Expr mutate(Expr e) {
+    Expr mutate(const Expr &e) {
         map<Expr, CacheEntry, ExprCompare>::iterator iter = cache.find(e);
         if (iter == cache.end()) {
             // Not in the cache, call the base class version.

--- a/src/Substitute.cpp
+++ b/src/Substitute.cpp
@@ -114,7 +114,7 @@ public:
 
     using IRMutator::mutate;
 
-    Expr mutate(Expr e) {
+    Expr mutate(const Expr &e) {
         if (equal(e, find)) {
             return replacement;
         } else {
@@ -165,9 +165,12 @@ public:
 
     using IRGraphMutator::mutate;
 
-    Expr mutate(Expr e) {
-        if (e.same_as(find)) return replace;
-        return IRGraphMutator::mutate(e);
+    Expr mutate(const Expr &e) {
+        if (e.same_as(find)) {
+            return replace;
+        } else {
+            return IRGraphMutator::mutate(e);
+        }
     }
 
     GraphSubstituteExpr(const Expr &find, const Expr &replace) : find(find), replace(replace) {}

--- a/src/UnifyDuplicateLets.cpp
+++ b/src/UnifyDuplicateLets.cpp
@@ -19,7 +19,7 @@ class UnifyDuplicateLets : public IRMutator {
 public:
     using IRMutator::mutate;
 
-    Expr mutate(Expr e) {
+    Expr mutate(const Expr &e) {
 
         if (e.defined()) {
             map<Expr, string, IRDeepCompare>::iterator iter = scope.find(e);
@@ -32,7 +32,7 @@ public:
             expr = Expr();
         }
         stmt = Stmt();
-        return expr;
+        return std::move(expr);
     }
 
 protected:

--- a/test/correctness/fuzz_simplify.cpp
+++ b/test/correctness/fuzz_simplify.cpp
@@ -68,7 +68,7 @@ Expr random_leaf(Type T, bool overflow_undef = false, bool imm_only = false) {
 Expr random_expr(Type T, int depth, bool overflow_undef = false);
 
 Expr random_condition(Type T, int depth, bool maybe_scalar) {
-    typedef Expr (*make_bin_op_fn)(const Expr &, const Expr &);
+    typedef Expr (*make_bin_op_fn)(Expr, Expr);
     static make_bin_op_fn make_bin_op[] = {
         EQ::make,
         NE::make,
@@ -90,7 +90,7 @@ Expr random_condition(Type T, int depth, bool maybe_scalar) {
 }
 
 Expr random_expr(Type T, int depth, bool overflow_undef) {
-    typedef Expr (*make_bin_op_fn)(const Expr &, const Expr &);
+    typedef Expr (*make_bin_op_fn)(Expr, Expr);
     static make_bin_op_fn make_bin_op[] = {
         Add::make,
         Sub::make,


### PR DESCRIPTION
Two changes:

1) Use 32 free bits in the IRNode to store the IRNodeType, so that it
can be gotten at by a load instead of having to call a virtual function

2) Change things to a style where any function that's going to make a
copy of an Expr takes it by value, and then does a std::move internally
at its last use. This avoids a bunch of atomic ops and conditional
branches in caller code in the case where you're passing in an rvalue.

With these changes, lowering local laplacian gets about 12% faster (1.5s
-> 1.33s). Most of the win is from change 1

These are being done in advance of a planned change to simplify the
simplifier to be more concise and use less stack space, so hopefully the
fact that this represents a partial reversion of #1810 won't bite us.