### PR TITLE
Fixed bug in CSE: will now ignore non-pure (side-effecty) Calls.

### DIFF
--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -60,9 +60,7 @@ bool should_extract(Expr e) {
     }
 
     if (const Call *a = e.as<Call>()) {
-        if( (a->call_type == Call::Extern) ||
-            (a->call_type == Call::ExternCPlusPlus) ||
-            (a->call_type == Call::Intrinsic) ){
+        if (!a->is_pure()) {
             //non-pure Calls may have side-effects, thus
             //may not be re-ordered or reduced in number.
             return false;

--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -20,8 +20,9 @@ namespace {
 // Some expressions are not worth lifting out into lets, even if they
 // occur redundantly many times. They may also be illegal to lift out
 // (e.g. calls with side-effects).
-// This list should mirror the list in the simplifier for lets,
-// otherwise they'll just fight with each other pointlessly.
+// This list should at least avoid lifting the same cases as that of the
+// simplifier for lets, otherwise CSE and the simplifier will fight each 
+// other pointlessly.
 bool should_extract(Expr e) {
     if (is_const(e)) {
         return false;


### PR DESCRIPTION
See issue #2052.

CSE should ignore non-pure Calls, because they may have side-effects. Added a simple fix and a test case in the internal CSE test. If the fix is removed, the test fails.