### PR TITLE
Tighten up some Generator assumptions

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2230,7 +2230,7 @@ class SimpleGeneratorFactory;
 
 class GeneratorBase : public NamesInterface, public GeneratorContext {
 public:
-    GeneratorParam<Target> target{ "target", Halide::get_host_target() };
+    GeneratorParam<Target> target{ "target", Target() };
 
     struct EmitOptions {
         bool emit_o, emit_h, emit_cpp, emit_assembly, emit_bitcode, emit_stmt, emit_stmt_html, emit_static_library, emit_cpp_stub;


### PR DESCRIPTION
Previously, the Generator class sorta-assumed it could be created with
a GeneratorContext (thus lazy-initing value_tracker and externs_map,
and defaulting Target to host); in practice, this is never the case
(aside from some internal-testing code inside Generator itself), and
attempting to use a Generator in this way is untested and possibly
buggy. This removes code for lazy-initing and adds asserts that verify
that a Generator always is created with a GeneratorContext.