### PR TITLE
Allow LLVM targets to run custom bitcode optimization passes.

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1038,6 +1038,10 @@ void CodeGen_LLVM::optimize_module() {
 #endif
     b.LoopVectorize = true;
     b.SLPVectorize = true;
+    if (TM) {
+        TM->adjustPassManager(b);
+    }
+
     b.populateFunctionPassManager(function_pass_manager);
     b.populateModulePassManager(module_pass_manager);
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1039,13 +1039,9 @@ void CodeGen_LLVM::optimize_module() {
     b.LoopVectorize = true;
     b.SLPVectorize = true;
 
-#if LLVM_VERSION >= 39
-    if (TM) {
 #if LLVM_VERSION >= 50
+    if (TM) {
         TM->adjustPassManager(b);
-#else
-        TM->addEarlyAsPossiblePasses(b);
-#endif
     }
 #endif
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1038,9 +1038,16 @@ void CodeGen_LLVM::optimize_module() {
 #endif
     b.LoopVectorize = true;
     b.SLPVectorize = true;
+
+#if LLVM_VERSION >= 39
     if (TM) {
+#if LLVM_VERSION >= 50
         TM->adjustPassManager(b);
+#else
+        TM->addEarlyAsPossiblePasses(b);
+#endif
     }
+#endif
 
     b.populateFunctionPassManager(function_pass_manager);
     b.populateModulePassManager(module_pass_manager);


### PR DESCRIPTION
 Presently, only Hexagon, AMDGPU & NVPTX implement the adjustPassManager method of LLVMTargetMachine