### PR TITLE
Allow creating & using Generators directly

### DIFF
--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -158,13 +158,13 @@ public:
                 .vectorize(x, 2*vec, TailStrategy::RoundUp)
                 .fold_storage(y, 2);
         }
-        Func(output).compute_at(output_compute_at)
+        output.compute_at(output_compute_at)
             .vectorize(x)
             .unroll(y)
             .reorder(c, x, y)
             .unroll(c);
         if (use_hexagon) {
-            Func(output).hexagon();
+            output.hexagon();
             for (Func f : intermediates) {
                 f.align_storage(x, vec);
             }

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -323,7 +323,7 @@ Func CameraPipe::build() {
 
     Func denoised = hot_pixel_suppression(shifted);
     Func deinterleaved = deinterleave(denoised);
-    auto demosaiced = Demosaic::apply(*this, deinterleaved);
+    auto demosaiced = apply<Demosaic>(deinterleaved);
     Func corrected = color_correct(demosaiced->output);
     Func processed = apply_curve(corrected);
 

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -374,9 +374,9 @@ Func CameraPipe::build() {
         .unroll(c)
         .parallel(yo);
 
-    demosaiced->intermed_compute_at.set(LoopLevel(processed, yi));
-    demosaiced->intermed_store_at.set(LoopLevel(processed, yo));
-    demosaiced->output_compute_at.set(LoopLevel(processed, x));
+    demosaiced->intermed_compute_at.set({processed, yi});
+    demosaiced->intermed_store_at.set({processed, yo});
+    demosaiced->output_compute_at.set({processed, x});
 
     if (get_target().features_any_of({Target::HVX_64, Target::HVX_128})) {
         processed.hexagon();

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -3,9 +3,178 @@
 
 namespace {
 
+using std::vector;
+
 using namespace Halide;
 
-using Scheduler = std::function<void(Func processed)>;
+// Shared variables
+Var x, y, c, yi, yo, yii, xi;
+
+// Average two positive values rounding up
+Expr avg(Expr a, Expr b) {
+    Type wider = a.type().with_bits(a.type().bits() * 2);
+    return cast(a.type(), (cast(wider, a) + b + 1)/2);
+}
+
+Func interleave_x(Func a, Func b) {
+    Func out;
+    out(x, y) = select((x%2)==0, a(x/2, y), b(x/2, y));
+    return out;
+}
+
+Func interleave_y(Func a, Func b) {
+    Func out;
+    out(x, y) = select((y%2)==0, a(x, y/2), b(x, y/2));
+    return out;
+}
+
+class Demosaic : public Halide::Generator<Demosaic> {
+public:
+    ScheduleParam<LoopLevel> intermed_compute_at{"intermed_compute_at"};
+    ScheduleParam<LoopLevel> intermed_store_at{"intermed_store_at"};
+    ScheduleParam<LoopLevel> output_compute_at{"output_compute_at"};
+
+    // Inputs and outputs
+    Input<Func> deinterleaved{ "deinterleaved", Int(16), 3 };
+    Output<Func> output{ "output", Int(16), 3 };
+
+    // Defines outputs using inputs
+    void generate() {
+        // These are the values we already know from the input
+        // x_y = the value of channel x at a site in the input of channel y
+        // gb refers to green sites in the blue rows
+        // gr refers to green sites in the red rows
+
+        // Give more convenient names to the four channels we know
+        Func r_r, g_gr, g_gb, b_b;
+
+        g_gr(x, y) = deinterleaved(x, y, 0);
+        r_r(x, y)  = deinterleaved(x, y, 1);
+        b_b(x, y)  = deinterleaved(x, y, 2);
+        g_gb(x, y) = deinterleaved(x, y, 3);
+
+        // These are the ones we need to interpolate
+        Func b_r, g_r, b_gr, r_gr, b_gb, r_gb, r_b, g_b;
+
+        // First calculate green at the red and blue sites
+
+        // Try interpolating vertically and horizontally. Also compute
+        // differences vertically and horizontally. Use interpolation in
+        // whichever direction had the smallest difference.
+        Expr gv_r  = avg(g_gb(x, y-1), g_gb(x, y));
+        Expr gvd_r = absd(g_gb(x, y-1), g_gb(x, y));
+        Expr gh_r  = avg(g_gr(x+1, y), g_gr(x, y));
+        Expr ghd_r = absd(g_gr(x+1, y), g_gr(x, y));
+
+        g_r(x, y)  = select(ghd_r < gvd_r, gh_r, gv_r);
+
+        Expr gv_b  = avg(g_gr(x, y+1), g_gr(x, y));
+        Expr gvd_b = absd(g_gr(x, y+1), g_gr(x, y));
+        Expr gh_b  = avg(g_gb(x-1, y), g_gb(x, y));
+        Expr ghd_b = absd(g_gb(x-1, y), g_gb(x, y));
+
+        g_b(x, y)  = select(ghd_b < gvd_b, gh_b, gv_b);
+
+        // Next interpolate red at gr by first interpolating, then
+        // correcting using the error green would have had if we had
+        // interpolated it in the same way (i.e. add the second derivative
+        // of the green channel at the same place).
+        Expr correction;
+        correction = g_gr(x, y) - avg(g_r(x, y), g_r(x-1, y));
+        r_gr(x, y) = correction + avg(r_r(x-1, y), r_r(x, y));
+
+        // Do the same for other reds and blues at green sites
+        correction = g_gr(x, y) - avg(g_b(x, y), g_b(x, y-1));
+        b_gr(x, y) = correction + avg(b_b(x, y), b_b(x, y-1));
+
+        correction = g_gb(x, y) - avg(g_r(x, y), g_r(x, y+1));
+        r_gb(x, y) = correction + avg(r_r(x, y), r_r(x, y+1));
+
+        correction = g_gb(x, y) - avg(g_b(x, y), g_b(x+1, y));
+        b_gb(x, y) = correction + avg(b_b(x, y), b_b(x+1, y));
+
+        // Now interpolate diagonally to get red at blue and blue at
+        // red. Hold onto your hats; this gets really fancy. We do the
+        // same thing as for interpolating green where we try both
+        // directions (in this case the positive and negative diagonals),
+        // and use the one with the lowest absolute difference. But we
+        // also use the same trick as interpolating red and blue at green
+        // sites - we correct our interpolations using the second
+        // derivative of green at the same sites.
+
+        correction = g_b(x, y)  - avg(g_r(x, y), g_r(x-1, y+1));
+        Expr rp_b  = correction + avg(r_r(x, y), r_r(x-1, y+1));
+        Expr rpd_b = absd(r_r(x, y), r_r(x-1, y+1));
+
+        correction = g_b(x, y)  - avg(g_r(x-1, y), g_r(x, y+1));
+        Expr rn_b  = correction + avg(r_r(x-1, y), r_r(x, y+1));
+        Expr rnd_b = absd(r_r(x-1, y), r_r(x, y+1));
+
+        r_b(x, y)  = select(rpd_b < rnd_b, rp_b, rn_b);
+
+        // Same thing for blue at red
+        correction = g_r(x, y)  - avg(g_b(x, y), g_b(x+1, y-1));
+        Expr bp_r  = correction + avg(b_b(x, y), b_b(x+1, y-1));
+        Expr bpd_r = absd(b_b(x, y), b_b(x+1, y-1));
+
+        correction = g_r(x, y)  - avg(g_b(x+1, y), g_b(x, y-1));
+        Expr bn_r  = correction + avg(b_b(x+1, y), b_b(x, y-1));
+        Expr bnd_r = absd(b_b(x+1, y), b_b(x, y-1));
+
+        b_r(x, y)  =  select(bpd_r < bnd_r, bp_r, bn_r);
+
+        // Resulting color channels
+        Func r, g, b;
+
+        // Interleave the resulting channels
+        r = interleave_y(interleave_x(r_gr, r_r),
+                         interleave_x(r_b, r_gb));
+        g = interleave_y(interleave_x(g_gr, g_r),
+                         interleave_x(g_b, g_gb));
+        b = interleave_y(interleave_x(b_gr, b_r),
+                         interleave_x(b_b, b_gb));
+
+        output(x, y, c) = select(c == 0, r(x, y),
+                                 c == 1, g(x, y),
+                                         b(x, y));
+
+        // These are the stencil stages we want to schedule
+        // separately. Everything else we'll just inline.
+        intermediates.push_back(g_r);
+        intermediates.push_back(g_b);
+    }
+
+    void schedule() {
+        int vec = get_target().natural_vector_size(UInt(16));
+        bool use_hexagon = get_target().features_any_of({Target::HVX_64, Target::HVX_128});
+        if (get_target().has_feature(Target::HVX_64)) {
+            vec = 32;
+        } else if (get_target().has_feature(Target::HVX_128)) {
+            vec = 64;
+        }
+        for (Func f : intermediates) {
+            f.compute_at(intermed_compute_at)
+                .store_at(intermed_store_at)
+                .vectorize(x, 2*vec, TailStrategy::RoundUp)
+                .fold_storage(y, 2);
+        }
+        Func(output).compute_at(output_compute_at)
+            .vectorize(x)
+            .unroll(y)
+            .reorder(c, x, y)
+            .unroll(c);
+        if (use_hexagon) {
+            Func(output).hexagon();
+            for (Func f : intermediates) {
+                f.align_storage(x, vec);
+            }
+        }
+    }
+
+private:
+    // Intermediate stencil stages to schedule
+    vector<Func> intermediates;
+};
 
 class CameraPipe : public Halide::Generator<CameraPipe> {
 public:
@@ -25,50 +194,27 @@ public:
     Func build();
 
 private:
-    Expr avg(Expr a, Expr b);
+
     Func hot_pixel_suppression(Func input);
-    Func interleave_x(Func a, Func b);
-    Func interleave_y(Func a, Func b);
     Func deinterleave(Func raw);
-    std::pair<Func, Scheduler> demosaic(Func deinterleaved);
     Func apply_curve(Func input);
     Func color_correct(Func input);
-
-    Var x, y, c, yi, yo, yii, xi;
 };
-
-// Average two positive values rounding up
-Expr CameraPipe::avg(Expr a, Expr b) {
-    Type wider = a.type().with_bits(a.type().bits() * 2);
-    return cast(a.type(), (cast(wider, a) + b + 1)/2);
-}
 
 Func CameraPipe::hot_pixel_suppression(Func input) {
 
     Expr a = max(input(x - 2, y), input(x + 2, y),
                  input(x, y - 2), input(x, y + 2));
 
-    Func denoised("denoised");
+    Func denoised;
     denoised(x, y) = clamp(input(x, y), 0, a);
 
     return denoised;
 }
 
-Func CameraPipe::interleave_x(Func a, Func b) {
-    Func out;
-    out(x, y) = select((x%2)==0, a(x/2, y), b(x/2, y));
-    return out;
-}
-
-Func CameraPipe::interleave_y(Func a, Func b) {
-    Func out;
-    out(x, y) = select((y%2)==0, a(x, y/2), b(x, y/2));
-    return out;
-}
-
 Func CameraPipe::deinterleave(Func raw) {
     // Deinterleave the color channels
-    Func deinterleaved("deinterleaved");
+    Func deinterleaved;
 
     deinterleaved(x, y, c) = select(c == 0, raw(2*x, 2*y),
                                     c == 1, raw(2*x+1, 2*y),
@@ -77,135 +223,6 @@ Func CameraPipe::deinterleave(Func raw) {
     return deinterleaved;
 }
 
-std::pair<Func, Scheduler> CameraPipe::demosaic(Func deinterleaved) {
-    // These are the values we already know from the input
-    // x_y = the value of channel x at a site in the input of channel y
-    // gb refers to green sites in the blue rows
-    // gr refers to green sites in the red rows
-
-    // Give more convenient names to the four channels we know
-    Func r_r("r_r"), g_gr("g_gr"), g_gb("g_gb"), b_b("b_b");
-    g_gr(x, y) = deinterleaved(x, y, 0);
-    r_r(x, y)  = deinterleaved(x, y, 1);
-    b_b(x, y)  = deinterleaved(x, y, 2);
-    g_gb(x, y) = deinterleaved(x, y, 3);
-
-    // These are the ones we need to interpolate
-    Func b_r("b_r"), g_r("g_r"), b_gr("b_gr"), r_gr("r_gr");
-    Func b_gb("b_gb"), r_gb("r_gb"), r_b("r_b"), g_b("g_b");
-
-    // First calculate green at the red and blue sites
-
-    // Try interpolating vertically and horizontally. Also compute
-    // differences vertically and horizontally. Use interpolation in
-    // whichever direction had the smallest difference.
-    Expr gv_r  = avg(g_gb(x, y-1), g_gb(x, y));
-    Expr gvd_r = absd(g_gb(x, y-1), g_gb(x, y));
-    Expr gh_r  = avg(g_gr(x+1, y), g_gr(x, y));
-    Expr ghd_r = absd(g_gr(x+1, y), g_gr(x, y));
-
-    g_r(x, y)  = select(ghd_r < gvd_r, gh_r, gv_r);
-
-    Expr gv_b  = avg(g_gr(x, y+1), g_gr(x, y));
-    Expr gvd_b = absd(g_gr(x, y+1), g_gr(x, y));
-    Expr gh_b  = avg(g_gb(x-1, y), g_gb(x, y));
-    Expr ghd_b = absd(g_gb(x-1, y), g_gb(x, y));
-
-    g_b(x, y)  = select(ghd_b < gvd_b, gh_b, gv_b);
-
-    // Next interpolate red at gr by first interpolating, then
-    // correcting using the error green would have had if we had
-    // interpolated it in the same way (i.e. add the second derivative
-    // of the green channel at the same place).
-    Expr correction;
-    correction = g_gr(x, y) - avg(g_r(x, y), g_r(x-1, y));
-    r_gr(x, y) = correction + avg(r_r(x-1, y), r_r(x, y));
-
-    // Do the same for other reds and blues at green sites
-    correction = g_gr(x, y) - avg(g_b(x, y), g_b(x, y-1));
-    b_gr(x, y) = correction + avg(b_b(x, y), b_b(x, y-1));
-
-    correction = g_gb(x, y) - avg(g_r(x, y), g_r(x, y+1));
-    r_gb(x, y) = correction + avg(r_r(x, y), r_r(x, y+1));
-
-    correction = g_gb(x, y) - avg(g_b(x, y), g_b(x+1, y));
-    b_gb(x, y) = correction + avg(b_b(x, y), b_b(x+1, y));
-
-    // Now interpolate diagonally to get red at blue and blue at
-    // red. Hold onto your hats; this gets really fancy. We do the
-    // same thing as for interpolating green where we try both
-    // directions (in this case the positive and negative diagonals),
-    // and use the one with the lowest absolute difference. But we
-    // also use the same trick as interpolating red and blue at green
-    // sites - we correct our interpolations using the second
-    // derivative of green at the same sites.
-
-    correction = g_b(x, y)  - avg(g_r(x, y), g_r(x-1, y+1));
-    Expr rp_b  = correction + avg(r_r(x, y), r_r(x-1, y+1));
-    Expr rpd_b = absd(r_r(x, y), r_r(x-1, y+1));
-
-    correction = g_b(x, y)  - avg(g_r(x-1, y), g_r(x, y+1));
-    Expr rn_b  = correction + avg(r_r(x-1, y), r_r(x, y+1));
-    Expr rnd_b = absd(r_r(x-1, y), r_r(x, y+1));
-
-    r_b(x, y)  = select(rpd_b < rnd_b, rp_b, rn_b);
-
-
-    // Same thing for blue at red
-    correction = g_r(x, y)  - avg(g_b(x, y), g_b(x+1, y-1));
-    Expr bp_r  = correction + avg(b_b(x, y), b_b(x+1, y-1));
-    Expr bpd_r = absd(b_b(x, y), b_b(x+1, y-1));
-
-    correction = g_r(x, y)  - avg(g_b(x+1, y), g_b(x, y-1));
-    Expr bn_r  = correction + avg(b_b(x+1, y), b_b(x, y-1));
-    Expr bnd_r = absd(b_b(x+1, y), b_b(x, y-1));
-
-    b_r(x, y)  =  select(bpd_r < bnd_r, bp_r, bn_r);
-
-    // Interleave the resulting channels
-    Func r = interleave_y(interleave_x(r_gr, r_r),
-                          interleave_x(r_b, r_gb));
-    Func g = interleave_y(interleave_x(g_gr, g_r),
-                          interleave_x(g_b, g_gb));
-    Func b = interleave_y(interleave_x(b_gr, b_r),
-                          interleave_x(b_b, b_gb));
-
-    Func output("output");
-    output(x, y, c) = select(c == 0, r(x, y),
-                                 c == 1, g(x, y),
-                                 b(x, y));
-
-    Scheduler scheduler = [=](Func processed) mutable {
-        assert(g_r.defined());
-        int vec = get_target().natural_vector_size(UInt(16));
-        if (get_target().has_feature(Target::HVX_64)) {
-            vec = 32;
-        } else if (get_target().has_feature(Target::HVX_128)) {
-            vec = 64;
-        }
-        assert(processed.defined());
-        g_r.compute_at(processed, yi)
-            .store_at(processed, yo)
-            .vectorize(x, 2*vec, TailStrategy::RoundUp)
-            .fold_storage(y, 2);
-        g_b.compute_at(processed, yi)
-            .store_at(processed, yo)
-            .vectorize(x, 2*vec, TailStrategy::RoundUp)
-            .fold_storage(y, 2);
-        output.compute_at(processed, x)
-            .vectorize(x)
-            .unroll(y)
-            .reorder(c, x, y)
-            .unroll(c);
-
-        if (get_target().features_any_of({Target::HVX_64, Target::HVX_128})) {
-            g_r.align_storage(x, vec);
-            g_b.align_storage(x, vec);
-        }
-    };
-
-    return {output, scheduler};
-}
 
 
 Func CameraPipe::color_correct(Func input) {
@@ -219,7 +236,7 @@ Func CameraPipe::color_correct(Func input) {
     matrix(x, y) = cast<int16_t>(val * 256.0f); // Q8.8 fixed point
     matrix.compute_root();
 
-    Func corrected("corrected");
+    Func corrected;
     Expr ir = cast<int32_t>(input(x, y, 0));
     Expr ig = cast<int32_t>(input(x, y, 1));
     Expr ib = cast<int32_t>(input(x, y, 2));
@@ -277,7 +294,7 @@ Func CameraPipe::apply_curve(Func input) {
 
     curve.compute_root(); // It's a LUT, compute it once ahead of time.
 
-    Func curved("curved");
+    Func curved;
 
     if (lutResample == 1) {
         // Use clamp to restrict size of LUT as allocated by compute_root
@@ -306,9 +323,8 @@ Func CameraPipe::build() {
 
     Func denoised = hot_pixel_suppression(shifted);
     Func deinterleaved = deinterleave(denoised);
-    Func demosaiced; Scheduler demosaiced_scheduler;
-    std::tie(demosaiced, demosaiced_scheduler) = demosaic(deinterleaved);
-    Func corrected = color_correct(demosaiced);
+    auto demosaiced = Demosaic::apply(*this, deinterleaved);
+    Func corrected = color_correct(demosaiced->output);
     Func processed = apply_curve(corrected);
 
     // Schedule
@@ -358,7 +374,9 @@ Func CameraPipe::build() {
         .unroll(c)
         .parallel(yo);
 
-    demosaiced_scheduler(processed);
+    demosaiced->intermed_compute_at.set(LoopLevel(processed, yi));
+    demosaiced->intermed_store_at.set(LoopLevel(processed, yo));
+    demosaiced->output_compute_at.set(LoopLevel(processed, x));
 
     if (get_target().features_any_of({Target::HVX_64, Target::HVX_128})) {
         processed.hexagon();

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2702,6 +2702,8 @@ public:
         return std::unique_ptr<T>(t);
     }
 
+    using Internal::GeneratorBase::apply;
+
     template <typename... Args>
     void apply(const Args &...args) {
         static_assert(has_generate_method<T>::value && has_schedule_method<T>::value, 

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -454,6 +454,7 @@ private:
 
     template <typename T2, typename std::enable_if<std::is_convertible<T2, T>::value>::type * = nullptr>
     HALIDE_ALWAYS_INLINE void typed_setter_impl(const T2 &value, const char * msg) {
+        check_value_writable();
         // Arithmetic types must roundtrip losslessly.
         if (!std::is_same<T, T2>::value &&
             std::is_arithmetic<T>::value &&
@@ -604,6 +605,14 @@ class GeneratorParam_Enum : public GeneratorParamImpl<T> {
 public:
     GeneratorParam_Enum(const std::string &name, const T &value, const std::map<std::string, T> &enum_map)
         : GeneratorParamImpl<T>(name, value), enum_map(enum_map) {}
+
+    // define a "set" that takes our specific enum (but don't hide the inherited virtual functions)
+    using GeneratorParamImpl<T>::set;
+
+    template <typename T2 = T, typename std::enable_if<!std::is_same<T2, Type>::value>::type * = nullptr>
+    void set(const T &e) {
+        this->set_impl(e);        
+    }
 
     void set_from_string(const std::string &new_value_string) override {
         auto it = enum_map.find(new_value_string);
@@ -2673,12 +2682,30 @@ protected:
                                 Internal::Introspection::get_introspection_helper<T>()) {}
 
 public:
-    static std::unique_ptr<Internal::GeneratorBase> create(const Halide::GeneratorContext &context) {
+    static std::unique_ptr<T> create(const Halide::GeneratorContext &context) {
         // We must have an object of type T (not merely GeneratorBase) to call a protected method,
         // because CRTP is a weird beast.
         T *t = new T;
         t->init_from_context(context);
-        return std::unique_ptr<Internal::GeneratorBase>(t);
+        return std::unique_ptr<T>(t);
+    }
+
+    // TODO: this method name is terrible, surely we can do better
+    template <typename... Args>
+    void generate_with_inputs(const Args &...args) {
+        static_assert(has_generate_method<T>::value && has_schedule_method<T>::value, 
+            "generate_with_inputs() is not supported for old-style Generators.");
+        set_inputs(args...);
+        call_generate();
+        call_schedule();
+    }
+
+    // TODO: this method name is ok but not greate
+    template <typename... Args>
+    static std::unique_ptr<T> apply(const Halide::GeneratorContext &context, const Args &...args) {
+        auto t = create(context);
+        t->generate_with_inputs(args...);
+        return t;
     }
 
 private:
@@ -2769,6 +2796,7 @@ protected:
     void call_schedule() override {
         this->call_schedule_impl();
     }
+
 private:
     friend void ::Halide::Internal::generator_test();
     friend class Internal::SimpleGeneratorFactory;

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2157,11 +2157,10 @@ public:
         return T::create(*this);
     }
 
-    // TODO: this method name is ok but not great
     template <typename T, typename... Args>
     std::unique_ptr<T> apply(const Args &...args) {
         auto t = this->create<T>();
-        t->generate_with_inputs(args...);
+        t->apply(args...);
         return t;
     }
 
@@ -2703,11 +2702,10 @@ public:
         return std::unique_ptr<T>(t);
     }
 
-    // TODO: this method name is terrible, surely we can do better
     template <typename... Args>
-    void generate_with_inputs(const Args &...args) {
+    void apply(const Args &...args) {
         static_assert(has_generate_method<T>::value && has_schedule_method<T>::value, 
-            "generate_with_inputs() is not supported for old-style Generators.");
+            "apply() is not supported for old-style Generators.");
         set_inputs(args...);
         call_generate();
         call_schedule();

--- a/test/correctness/inlined_generator.cpp
+++ b/test/correctness/inlined_generator.cpp
@@ -1,0 +1,86 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+void verify(const Buffer<int32_t> &img, float compiletime_factor, float runtime_factor, int runtime_offset) {
+    img.for_each_element([=](int x, int y, int c) {
+        int expected = (int32_t)(compiletime_factor * runtime_factor * c * (x > y ? x : y)) + runtime_offset;
+        int actual = img(x, y, c);
+        assert(expected == actual);
+    });
+}
+
+class Example : public Generator<Example> {
+public:
+    using Generator<Example>::Generator;
+
+    enum class SomeEnum { Foo, Bar };
+
+    GeneratorParam<float> compiletime_factor{ "compiletime_factor", 1, 0, 100 };
+
+    ScheduleParam<bool> vectorize{ "vectorize", true };
+
+    Input<float> runtime_factor{ "runtime_factor", 1.0 };
+    Input<int> runtime_offset{ "runtime_offset", 0 };
+
+    Output<Func> output{ "output", Int(32), 3 };
+
+    void generate() {
+        Func f;
+        f(x, y) = max(x, y);
+        output(x, y, c) = cast(output.type(), f(x, y) * c * compiletime_factor * runtime_factor + runtime_offset);
+    }
+
+    void schedule() {
+        output.bound(c, 0, 3).reorder(c, x, y).unroll(c);
+        output.specialize(vectorize).vectorize(x, natural_vector_size(output.type()));
+    }
+
+private:
+    Var x{"x"}, y{"y"}, c{"c"};
+};
+
+int main(int argc, char **argv) {
+    JITGeneratorContext context(get_target_from_environment());
+
+    const int kSize = 32;
+    const float kRuntimeFactor = 2.f;
+    const int kRuntimeOffset = 32;
+    {
+        // If you have a Generator in a visible translation unit (i.e.
+        // in the same source file, or visible via #include), you can
+        // use it directly, even if it's not registered: just call CLASSNAME::apply() 
+        // with a GeneratorContext, followed by values for all Inputs.
+        // (Note that this uses the default values for all GeneratorParams.)
+        auto gen = Example::apply(context, kRuntimeFactor, kRuntimeOffset);  // gen's type is std::unique_ptr<Example>
+        // Remember: ScheduleParams can be set at any time before lowering,
+        // so it's fine to set them here.
+        gen->vectorize.set(false);
+
+        Buffer<int32_t> img = gen->realize(kSize, kSize, 3);
+        verify(img, gen->compiletime_factor, kRuntimeFactor, kRuntimeOffset);
+    }
+
+    {
+        // If you need to set GeneratorParams, it's a bit trickier: 
+        // you must first create the Generator, then set the GeneratorParam(s),
+        // than call generate_with_inputs().
+        auto gen = Example::create(context);  // gen's type is std::unique_ptr<Example>
+
+        // GeneratorParams must be set before calling generate_with_inputs()
+        // (you'll assert-fail if you set them later).
+        gen->compiletime_factor.set(2.5f);
+        // ScheduleParams can be set before or after the call to generate_with_inputs().
+        gen->vectorize.set(false);
+
+        gen->generate_with_inputs(kRuntimeFactor, kRuntimeOffset);
+
+
+        Buffer<int32_t> img = gen->realize(kSize, kSize, 3);
+        verify(img, gen->compiletime_factor, kRuntimeFactor, kRuntimeOffset);
+    }
+
+    printf("Success!\n");
+    return 0;
+}
+

--- a/test/correctness/inlined_generator.cpp
+++ b/test/correctness/inlined_generator.cpp
@@ -64,16 +64,16 @@ int main(int argc, char **argv) {
     {
         // If you need to set GeneratorParams, it's a bit trickier: 
         // you must first create the Generator, then set the GeneratorParam(s),
-        // than call generate_with_inputs().
+        // than call apply().
         auto gen = context.create<Example>();  // gen's type is std::unique_ptr<Example>
 
-        // GeneratorParams must be set before calling generate_with_inputs()
+        // GeneratorParams must be set before calling apply()
         // (you'll assert-fail if you set them later).
         gen->compiletime_factor.set(2.5f);
-        // ScheduleParams can be set before or after the call to generate_with_inputs().
+        // ScheduleParams can be set before or after the call to apply().
         gen->vectorize.set(false);
 
-        gen->generate_with_inputs(kRuntimeFactor, kRuntimeOffset);
+        gen->apply(kRuntimeFactor, kRuntimeOffset);
 
 
         Buffer<int32_t> img = gen->realize(kSize, kSize, 3);

--- a/test/correctness/inlined_generator.cpp
+++ b/test/correctness/inlined_generator.cpp
@@ -41,7 +41,7 @@ private:
 };
 
 int main(int argc, char **argv) {
-    JITGeneratorContext context(get_target_from_environment());
+    JITGeneratorContext context(get_jit_target_from_environment());
 
     const int kSize = 32;
     const float kRuntimeFactor = 2.f;

--- a/test/correctness/inlined_generator.cpp
+++ b/test/correctness/inlined_generator.cpp
@@ -49,10 +49,10 @@ int main(int argc, char **argv) {
     {
         // If you have a Generator in a visible translation unit (i.e.
         // in the same source file, or visible via #include), you can
-        // use it directly, even if it's not registered: just call CLASSNAME::apply() 
-        // with a GeneratorContext, followed by values for all Inputs.
+        // use it directly, even if it's not registered: just call 
+        // GeneratorContext.apply<GenType>() with values for all Inputs.
         // (Note that this uses the default values for all GeneratorParams.)
-        auto gen = Example::apply(context, kRuntimeFactor, kRuntimeOffset);  // gen's type is std::unique_ptr<Example>
+        auto gen = context.apply<Example>(kRuntimeFactor, kRuntimeOffset);  // gen's type is std::unique_ptr<Example>
         // Remember: ScheduleParams can be set at any time before lowering,
         // so it's fine to set them here.
         gen->vectorize.set(false);
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
         // If you need to set GeneratorParams, it's a bit trickier: 
         // you must first create the Generator, then set the GeneratorParam(s),
         // than call generate_with_inputs().
-        auto gen = Example::create(context);  // gen's type is std::unique_ptr<Example>
+        auto gen = context.create<Example>();  // gen's type is std::unique_ptr<Example>
 
         // GeneratorParams must be set before calling generate_with_inputs()
         // (you'll assert-fail if you set them later).


### PR DESCRIPTION
This PR adds the minimal API necessary to allow for using Generators in
the same C++ translation unit as subcomponents of another pipeline,
without requiring the use of Stubs. This PR is not expected to be
accepted as-is, but rather as a proof-of-concept for adding this
functionality.

The major additions are Generator<T>::apply, which creates the
Generator, sets the Inputs, and calls the generate()/schedule()
methods; for cases where GeneratorParams need to be set, you can
instead use Generator<T>::create followed by
Generator<T>::generate_with_inputs.

Added a simple test (inlined_generator) for testing and as an example;
as a demonstration of the usefulness of this approach, also converted
the demosaic code in apps/camera_pipe to be in the form of a local
Generator (based largely on code from abadams@)

The goal of this change is to make it easier to use Generators as an
encapsulation layer in places where it isn’t convenient to do so right
now; e.g., in camera_pipe, we’d previously have had to move the
demosaicing code to another source file and access it via a Stub, which
is overhead that sometimes prevents a Generator-based approach from
being entertained at all.

I especially want comments on the need-to-set-GeneratorParam code flow,
and (of course) the methods that need better names…

(Note also that this branch includes the changes in PR #2064)