### PR TITLE
Hexagon: Expression Rearrangements for better instruction selection [absd, broadcasts]

### DIFF
--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -1834,6 +1834,19 @@ private:
                         // broadcasts produced in matches[0] * op->b. For eg:
                         // matches[0] = bc * wild_i16x, then simplify combines
                         // bc * op->b into a single expression.
+                        // Since the simplifier is used on the individual operands
+                        // after distributing the broadcast, the mutation does not
+                        // compete with the simplifier [the next mutation always occurs
+                        // on the simplified operands]. For eg:
+                        // Consider initial expression:
+                        //      ((v0 * bc(x) + v1 * bc(y)) + v2) * bc(z)
+                        // Mutation sequence:
+                        // Step 1:
+                        //      mutate((v0 * bc(x) + v1 * bc(y)) * bc(z) + v2 * bc(z))
+                        // Step 2:
+                        //      mutate((v0 * bc(x) + v1 * bc(y)) * bc(z)) + mutate(v2 * bc(z))
+                        // Step 3 [Result]:
+                        //      ((v0 * bc(x * z) + v1 * bc(y *z)) + v2 * bc(z))
                         expr = mutate(simplify(matches[0] * op->b) +
                                       simplify(matches[1] * op->b));
                         return;

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1757,6 +1757,16 @@ struct Test {
         check("vabsdiff(v*.h,v*.h)", hvx_width/2, absd(i16_1, i16_2));
         check("vabsdiff(v*.w,v*.w)", hvx_width/4, absd(i32_1, i32_2));
 
+        // Expression Rearrangements
+        check("vabs(v*.h)", hvx_width/1, absd(3*i16(u8_1), 5*i16(u8_2)));
+        check("vabs(v*.h)", hvx_width/1, absd(4*i16(u8_1) + i16(u8_2) + i16(u8_3), i16(u8_1) + 7*i16(u8_2) + 2*i16(u8_3)));
+        check("vmpa(v*.ub,r*.b)", hvx_width/1, 2*(i16(u8_1) + i16(u8_2)));
+        check("vmpa(v*.ub,r*.b)", hvx_width/1, 3*(4*i16(u8_1) + i16(u8_2)));
+        check("vmpa(v*.h,r*.b)", hvx_width/2, 5*(i32(i16_1) + 7*i32(i16_2)));
+        check("vmpa(v*.ub,r*.b)", hvx_width/1, 2*(i16(u8_1) - i16(u8_2)));
+        check("vmpa(v*.ub,r*.b)", hvx_width/1, 3*(4*i16(u8_1) - i16(u8_2)));
+        check("vmpa(v*.h,r*.b)", hvx_width/2, 5*(i32(i16_1) - 7*i32(i16_2)));
+
         check("vand(v*,v*)", hvx_width/1, u8_1 & u8_2);
         check("vand(v*,v*)", hvx_width/2, u16_1 & u16_2);
         check("vand(v*,v*)", hvx_width/4, u32_1 & u32_2);

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1758,8 +1758,6 @@ struct Test {
         check("vabsdiff(v*.w,v*.w)", hvx_width/4, absd(i32_1, i32_2));
 
         // Expression Rearrangements
-        check("vabs(v*.h)", hvx_width/1, absd(3*i16(u8_1), 5*i16(u8_2)));
-        check("vabs(v*.h)", hvx_width/1, absd(4*i16(u8_1) + i16(u8_2) + i16(u8_3), i16(u8_1) + 7*i16(u8_2) + 2*i16(u8_3)));
         check("vmpa(v*.ub,r*.b)", hvx_width/1, 2*(i16(u8_1) + i16(u8_2)));
         check("vmpa(v*.ub,r*.b)", hvx_width/1, 3*(4*i16(u8_1) + i16(u8_2)));
         check("vmpa(v*.h,r*.b)", hvx_width/2, 5*(i32(i16_1) + 7*i32(i16_2)));


### PR DESCRIPTION
Hexagon: Expression Rearrangements for better instruction selection [absd, broadcasts].
- Selecting abs instead of absd when both operands of absd have odd number of multiply adds.
- Distributing broadcasts over exprs. For eg: 2*(i16(u8_1) + i16(u8_2)) -> 2*i16(u8_1) + 2*i16(u8_2)