### PR TITLE
Forward-declare all handle types before any function prototypes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -866,9 +866,6 @@ GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_cleanup_on_error,$(GENER
 # https://github.com/halide/Halide/issues/2071
 GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_cxx_mangling,$(GENERATOR_AOTCPP_TESTS))
 
-# https://github.com/halide/Halide/issues/2081
-GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_cxx_mangling_define_extern,$(GENERATOR_AOTCPP_TESTS))
-
 # https://github.com/halide/Halide/issues/2075
 GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_embed_image,$(GENERATOR_AOTCPP_TESTS))
 

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1686,6 +1686,8 @@ void CodeGen_C::test() {
 #define HALIDE_FUNCTION_ATTRS
 #endif
 
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -139,6 +139,10 @@ protected:
     /** Track which handle types have been forward-declared already. */
     std::set<const halide_handle_cplusplus_type *> forward_declared;
 
+    /** If the Type is a handle type, emit a forward-declaration for it
+     * if we haven't already. */
+    void forward_declare_type(const Type &t);
+
     void set_name_mangling_mode(NameMangling mode);
 
     using IRPrinter::visit;

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -141,7 +141,7 @@ protected:
 
     /** If the Type is a handle type, emit a forward-declaration for it
      * if we haven't already. */
-    void forward_declare_type(const Type &t);
+    void forward_declare_type_if_needed(const Type &t);
 
     void set_name_mangling_mode(NameMangling mode);
 


### PR DESCRIPTION
Partial fix for https://github.com/halide/Halide/issues/2075, also fixes generator_aotcpp_cxx_mangling_define_extern