### PR TITLE
Fix C++ backend embedded-buffer generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -866,9 +866,6 @@ GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_cxx_mangling,$(GENERATOR
 GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_cxx_mangling_define_extern,$(GENERATOR_AOTCPP_TESTS))
 
 # https://github.com/halide/Halide/issues/2075
-GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_embed_image,$(GENERATOR_AOTCPP_TESTS))
-
-# https://github.com/halide/Halide/issues/2075
 GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_external_code,$(GENERATOR_AOTCPP_TESTS))
 
 # https://github.com/halide/Halide/issues/2076
@@ -877,10 +874,6 @@ GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_mandelbrot,$(GENERATOR_A
 # https://github.com/halide/Halide/issues/2076
 GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_memory_profiler_mandelbrot,$(GENERATOR_AOTCPP_TESTS))
 
-# https://github.com/halide/Halide/issues/2075
-GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_stubuser,$(GENERATOR_AOTCPP_TESTS))
-
-# https://github.com/halide/Halide/issues/2075
 # https://github.com/halide/Halide/issues/2078
 GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_tiled_blur,$(GENERATOR_AOTCPP_TESTS))
 

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -790,7 +790,7 @@ void CodeGen_C::compile(const Buffer<> &buffer) {
            << buffer.dimensions() << ", "
            << "const_cast<halide_dimension_t*>(" << name << "_buffer_shape)};\n";
 
-    // Make a global pointer to it. Note that the 
+    // Make a global pointer to it.
     stream << "static const halide_buffer_t * const " << name << "_buffer = &" << name << "_buffer_;\n";
 }
 


### PR DESCRIPTION
Partial fix for #2075:
-- The identifier should be a pointer-to-storage, not storage.
-- mark data, shape, and buffer itself as const (except for scalar buffers)
-- Note special-case for https://github.com/halide/Halide/issues/2099
-- drive-by prettyprint improvement (don't put all data on a single line)