### PR TITLE
include HalideGenerator.cmake needed by various apps

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -11,6 +11,8 @@ macro(add_if_have_libpng dirname)
   endif()
 endmacro()
 
+include(${CMAKE_SOURCE_DIR}/HalideGenerator.cmake)
+
 add_if_have_libpng(bilateral_grid)
 add_subdirectory(blur)
 add_subdirectory(c_backend)


### PR DESCRIPTION
I had to add this in order to get apps to build.

I can see this possibly being included by each individual app instead. Thoughts?