### PR TITLE
update GEMMGenerator to not modify GeneratorParam after build() (hitting a recent user_assert in Generator)

### DIFF
--- a/apps/linear_algebra/src/blas_l3_generators.cpp
+++ b/apps/linear_algebra/src/blas_l3_generators.cpp
@@ -36,19 +36,15 @@ class GEMMGenerator :
         const int vec = natural_vector_size(a_.type());
         const int s = vec * 2;
 
-        ImageParam A_in, B_in;
+        ImageParam A_in = A_;
+        ImageParam B_in = B_;
 
         // If they're both transposed, then reverse the order and transpose the result instead.
-        bool transpose_AB = false;
-        if ((bool)transpose_A_ && (bool)transpose_B_) {
-            A_in = B_;
-            B_in = A_;
-            transpose_A_.set(false);
-            transpose_B_.set(false);
-            transpose_AB = true;
-        } else {
-            A_in = A_;
-            B_in = B_;
+        const bool transpose_AB = (bool)transpose_A_ && (bool)transpose_B_;
+        const bool transpose_A = !transpose_AB && (bool)transpose_A_;
+        const bool transpose_B = !transpose_AB && (bool)transpose_B_;
+        if (transpose_AB) {
+          std::swap(A_in, B_in);
         }
 
         Var i, j, ii, ji, jii, iii, io, jo, t;
@@ -59,7 +55,7 @@ class GEMMGenerator :
         Func A("A"), B("B"), Btmp("Btmp"), As("As"), Atmp("Atmp");
         Atmp(i, j) = BoundaryConditions::constant_exterior(A_in, cast<T>(0))(i, j);
 
-        if (transpose_A_) {
+        if (transpose_A) {
             As(i, j, io) = Atmp(j, io*s + i);
         } else {
             As(i, j, io) = Atmp(io*s + i, j);
@@ -68,7 +64,7 @@ class GEMMGenerator :
         A(i, j) = As(i % s, j, i / s);
 
         Btmp(i, j) = B_in(i, j);
-        if (transpose_B_) {
+        if (transpose_B) {
             B(i, j) = Btmp(j, i);
         } else {
             B(i, j) = Btmp(i, j);
@@ -129,7 +125,7 @@ class GEMMGenerator :
         Atmp.compute_at(As, io)
             .vectorize(i).unroll(j);
 
-        if (transpose_B_) {
+        if (transpose_B) {
             B.compute_at(result, t)
                 .tile(i, j, ii, ji, 8, 8)
                 .vectorize(ii).unroll(ji);

--- a/apps/linear_algebra/src/blas_l3_generators.cpp
+++ b/apps/linear_algebra/src/blas_l3_generators.cpp
@@ -44,7 +44,7 @@ class GEMMGenerator :
         const bool transpose_A = !transpose_AB && (bool)transpose_A_;
         const bool transpose_B = !transpose_AB && (bool)transpose_B_;
         if (transpose_AB) {
-          std::swap(A_in, B_in);
+            std::swap(A_in, B_in);
         }
 
         Var i, j, ii, ji, jii, iii, io, jo, t;


### PR DESCRIPTION
before changes, was failing with
```
Error:
The GeneratorParam transpose_A cannot be written after build() or generate() is called.
Aborted
```
looks like this was added 2 months ago
https://github.com/halide/Halide/blob/df0d2b89aaa45e5b15f82dfd9376b2fe9789e843/src/Generator.cpp#L992

builds fine now and `blas_test` passes for me.