### PR TITLE
Expose 'target' in C codegen and remove duplicated 'target' in derive…

### DIFF
--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -41,6 +41,9 @@ public:
     /** Emit the declarations contained in the module as C code. */
     void compile(const Module &module);
 
+    /** The target we're generating code for */
+    const Target &get_target() const { return target; }
+
     EXPORT static void test();
 
 protected:

--- a/src/CodeGen_Metal_Dev.h
+++ b/src/CodeGen_Metal_Dev.h
@@ -81,7 +81,6 @@ protected:
     std::ostringstream src_stream;
     std::string cur_kernel_name;
     CodeGen_Metal_C metal_c;
-    Target target;
 };
 
 }}

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -647,8 +647,10 @@ void CodeGen_OpenCL_Dev::init_module() {
     src_stream.str("");
     src_stream.clear();
 
+    const Target &target = clc.get_target();
+
     // This identifies the program as OpenCL C (as opposed to SPIR).
-    src_stream << "/*OpenCL C*/\n";
+    src_stream << "/*OpenCL C " << target.to_string() << "*/\n";
 
     src_stream << "#pragma OPENCL FP_CONTRACT ON\n";
 

--- a/src/CodeGen_OpenCL_Dev.h
+++ b/src/CodeGen_OpenCL_Dev.h
@@ -83,7 +83,6 @@ protected:
     std::ostringstream src_stream;
     std::string cur_kernel_name;
     CodeGen_OpenCL_C clc;
-    Target target;
 };
 
 }}


### PR DESCRIPTION
…d codegen(s).

- This fixes the uninitialized target issue in OpenCL C codegen.