### PR TITLE
require() should emit assertions

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -696,6 +696,9 @@ private:
             // Probably more conservative than necessary
             Expr equivalent_select = Select::make(op->args[0], op->args[1], op->args[2]);
             equivalent_select.accept(this);
+        } else if (op->is_intrinsic(Call::require)) {
+            assert(op->args.size() == 3);
+            op->args[1].accept(this);
         } else if (op->is_intrinsic(Call::shift_left) ||
                    op->is_intrinsic(Call::shift_right) ||
                    op->is_intrinsic(Call::bitwise_and)) {

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1962,6 +1962,10 @@ void CodeGen_C::visit(const Call *op) {
         close_scope("if " + cond_id + " else");
 
         rhs << result_id;
+    } else if (op->is_intrinsic(Call::require)) {
+        internal_assert(op->args.size() == 3);
+        create_assertion(op->args[0], op->args[2]);
+        rhs << print_expr(op->args[1]);
     } else if (op->is_intrinsic(Call::abs)) {
         internal_assert(op->args.size() == 1);
         Expr a0 = op->args[0];

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -166,7 +166,11 @@ public:
                 // a bitwidth that matches the other vectors in use; EliminateBoolVectors
                 // could be used for this with a bit of work.
                 vector_types_used.insert(UInt(8).with_lanes(e.type().lanes()));
-            } else {
+            } else if (!e.type().is_handle()) {
+                // Vector-handle types can be seen when processing (e.g.)
+                // require() statements that are vectorized, but they
+                // will all be scalarized away prior to use, so don't emit
+                // them.
                 vector_types_used.insert(e.type());
             }
         }
@@ -1965,8 +1969,12 @@ void CodeGen_C::visit(const Call *op) {
         rhs << result_id;
     } else if (op->is_intrinsic(Call::require)) {
         internal_assert(op->args.size() == 3);
-        create_assertion(op->args[0], op->args[2]);
-        rhs << print_expr(op->args[1]);
+        if (op->args[0].type().is_vector()) {
+            rhs << print_scalarized_expr(op);
+        } else {
+            create_assertion(op->args[0], op->args[2]);
+            rhs << print_expr(op->args[1]);
+        }
     } else if (op->is_intrinsic(Call::abs)) {
         internal_assert(op->args.size() == 1);
         Expr a0 = op->args[0];

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2296,6 +2296,15 @@ void CodeGen_LLVM::visit(const Call *op) {
 
             value = phi;
         }
+    } else if (op->is_intrinsic(Call::require)) {
+        internal_assert(op->args.size() == 3);
+        Expr cond = op->args[0];
+        if (cond.type().is_vector()) {
+            scalarize(op);
+        } else {
+            create_assertion(codegen(cond), op->args[2]);
+            value = codegen(op->args[1]);
+        }
     } else if (op->is_intrinsic(Call::make_struct)) {
         if (op->type.is_vector()) {
             // Make a vector of pointers to distinct structs

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -816,6 +816,7 @@ Call::ConstString Call::bool_to_mask = "bool_to_mask";
 Call::ConstString Call::cast_mask = "cast_mask";
 Call::ConstString Call::select_mask = "select_mask";
 Call::ConstString Call::extract_mask_element = "extract_mask_element";
+Call::ConstString Call::require = "require";
 Call::ConstString Call::size_of_halide_buffer_t = "size_of_halide_buffer_t";
 
 Call::ConstString Call::buffer_get_min = "_halide_buffer_get_min";

--- a/src/IR.h
+++ b/src/IR.h
@@ -511,6 +511,7 @@ struct Call : public ExprNode<Call> {
         cast_mask,
         select_mask,
         extract_mask_element,
+        require,
         size_of_halide_buffer_t;
 
     // We also declare some symbolic names for some of the runtime

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -837,13 +837,9 @@ Expr require(Expr condition, const std::vector<Expr> &args) {
                              "halide_error_requirement_failed",
                              {stringify({condition}), combine_strings(args)},
                              Internal::Call::Extern);
-    // Just cast to the type expected by the success path: since the actual
-    // value will never be used in the failure branch, it doesn't really matter
-    // what it is, but the type must match.
-    Expr failure_value = cast(args[0].type(), requirement_failed_error);
     return Internal::Call::make(args[0].type(),
-                                Internal::Call::if_then_else,
-                                {likely(std::move(condition)), args[0], failure_value},
+                                Internal::Call::require,
+                                {likely(std::move(condition)), args[0], requirement_failed_error},
                                 Internal::Call::PureIntrinsic);
 }
 

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1771,7 +1771,8 @@ inline NO_INLINE Expr print_when(Expr condition, Expr a, Args&&... args) {
  * Note that this essentially *always* inserts a runtime check into the
  * generated code (except when the condition can be proven at compile time);
  * as such, it should be avoided inside inner loops, except for debugging
- * or testing purposes.
+ * or testing purposes. Note also that it does not vectorize cleanly (vector
+ * values will be scalarized for the check).
  *
  * However, using this to make assertions about (say) input values
  * can be useful, both in terms of correctness and (potentially) in terms

--- a/test/correctness/require.cpp
+++ b/test/correctness/require.cpp
@@ -4,51 +4,63 @@
 
 int error_occurred = false;
 void halide_error(void *ctx, const char *msg) {
-    printf("Saw Halide Error: %s\n", msg);
+    printf("Saw (Expected) Halide Error: %s\n", msg);
     error_occurred = true;
 }
 
 using namespace Halide;
 
-int main(int argc, char **argv) {
-    // Use something other than 'int' here to ensure that the return
-    // type of the error-handler path doesn't need to match the expr type
-    const float kPrime1 = 7829.f;
-    const float kPrime2 = 7919.f;
+static void test(int vector_width) { 
+    const int32_t kPrime1 = 7829;
+    const int32_t kPrime2 = 7919;
 
-    Buffer<float> result;
-    Param<float> p1, p2;
+    int32_t realize_width = vector_width ? vector_width : 1;
+
+    Buffer<int32_t> result;
+    Param<int32_t> p1, p2;
     Var x;
-    Func f;
-    f(x) = require((p1 + p2) == kPrime1, 
-                   (p1 + p2) * kPrime2,
-                   "The parameters should add to exactly", kPrime1, "but were", p1, p2);
+    Func s, f;
+    s(x) = p1 + p2;
+    f(x) = require(s(x) == kPrime1, 
+                   s(x) * kPrime2 + x,
+                   "The parameters should add to exactly", kPrime1, "but were", s(x), "for vector_width", vector_width);
+    if (vector_width) {
+        s.vectorize(x, vector_width).compute_root();
+        f.vectorize(x, vector_width);
+    }
     f.set_error_handler(&halide_error);
 
     // choose values that will fail
     p1.set(1);
     p2.set(2);
     error_occurred = false;
-    result = f.realize(1);
+    result = f.realize(realize_width);
     if (!error_occurred) {
-        printf("There should have been a requirement error\n");
-        return 1;
+        printf("There should have been a requirement error (vector_width = %d)\n", vector_width);
+        exit(1);
     }
-
 
     p1.set(1);
     p2.set(kPrime1-1);
     error_occurred = false;
-    result = f.realize(1);
+    result = f.realize(realize_width);
     if (error_occurred) {
-        printf("There should not have been a requirement error\n");
-        return 1;
+        printf("There should not have been a requirement error (vector_width = %d)\n", vector_width);
+        exit(1);
     }
-    if (result(0) != (kPrime1 * kPrime2)) {
-        printf("Unexpected value: %f\n", result(0));
-        return 1;
+    for (int i = 0; i < realize_width; ++i) {
+        const int32_t expected = (kPrime1 * kPrime2) + i;
+        const int32_t actual = result(i);
+        if (actual != expected) {
+            printf("Unexpected value at %d: actual=%d, expected=%d (vector_width = %d)\n", i, actual, expected, vector_width);
+            exit(1);
+        }
     }
+}
 
+int main(int argc, char **argv) {
+    test(0);
+    test(4);
     printf("Success!\n");
     return 0;
 

--- a/test/correctness/require.cpp
+++ b/test/correctness/require.cpp
@@ -22,15 +22,10 @@ int main(int argc, char **argv) {
     Func f;
     f(x) = require((p1 + p2) == kPrime1, 
                    (p1 + p2) * kPrime2,
-                   "The parameters should add to exactly", (kPrime1 * kPrime2), "but were", p1, p2);
+                   "The parameters should add to exactly", kPrime1, "but were", p1, p2);
     f.set_error_handler(&halide_error);
 
-    // It should be the case that the non-error path of the code
-    // assumes (p1 + p2) == kPrime1, and thus hardcodes the body to fill
-    // in the result to the constant kPrime1*kPrime2 (rather than
-    // actually computing the result at runtime).
-    // f.compile_to_assembly("require_.s", {p1, p2}, "require_body");
-
+    // choose values that will fail
     p1.set(1);
     p2.set(2);
     error_occurred = false;

--- a/test/error/require_fail.cpp
+++ b/test/error/require_fail.cpp
@@ -14,7 +14,8 @@ int main(int argc, char **argv) {
     Func f;
     f(x) = require((p1 + p2) == kPrime1, 
                    (p1 + p2) * kPrime2,
-                   "The parameters should add to exactly", (kPrime1 * kPrime2), "but were", p1, p2);
+                   "The parameters should add to exactly", kPrime1, "but were", p1, p2);
+    // choose values that will fail
     p1.set(1);
     p2.set(2);
     result = f.realize(1);

--- a/test/error/require_fail.cpp
+++ b/test/error/require_fail.cpp
@@ -1,0 +1,24 @@
+#include "Halide.h"
+#include <stdio.h>
+#include <memory>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    const int kPrime1 = 7829;
+    const int kPrime2 = 7919;
+
+    Buffer<int> result;
+    Param<int> p1, p2;
+    Var x;
+    Func f;
+    f(x) = require((p1 + p2) == kPrime1, 
+                   (p1 + p2) * kPrime2,
+                   "The parameters should add to exactly", (kPrime1 * kPrime2), "but were", p1, p2);
+    p1.set(1);
+    p2.set(2);
+    result = f.realize(1);
+
+    return 0;
+
+}


### PR DESCRIPTION
require() assumed that calls to halide_error() would never return; this is false, and as a result, 'failing' requires didn't actually fail when used in JIT mode without custom error handler. To accomplish this, Call:require was added as an intrinsic, so Codegen could do the right thing.

Note to reviewers: I modeled the handling of Call:require after Call::if_then_else, but I'm not sure about the usage in Bounds.cpp, nor am I sure whether there are other visitors/mutators that need attention.