### PR TITLE
More C++ Backend Fixes

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2572,7 +2572,7 @@ void CodeGen_C::visit(const Shuffle *op) {
     }
     ostringstream rhs;
     if (op->type.is_scalar()) {
-        rhs << src << "[" << op->indices[0] << "] /*shuft*/";
+        rhs << src << "[" << op->indices[0] << "]";
     } else {
         string indices_name = unique_name('_');
         do_indent();

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -106,6 +106,9 @@ protected:
     /** Bottleneck to allow customization of calls to generic Extern/PureExtern calls.  */
     virtual std::string print_extern_call(const Call *op);
 
+    /** Convert a vector Expr into a series of scalar Exprs, then reassemble into vector of original type.  */
+    std::string print_scalarized_expr(Expr e);
+
     /** Emit an SSA-style assignment, and set id to the freshly generated name. Return id. */
     std::string print_assignment(Type t, const std::string &rhs);
 


### PR DESCRIPTION
-- Add a generic "scalarize" function and use it for print_extern_call
-- always use temporaries for float constants
-- Shuffle has wrong assertion test for max-index upper bound
-- Shuffle didn't handle the result-is-scalar case correctly