### PR TITLE
Copy testsig* from /system/lib/rfsa/adsp to the app's device path

### DIFF
--- a/apps/HelloHexagon/Makefile
+++ b/apps/HelloHexagon/Makefile
@@ -51,7 +51,7 @@ run-%-android: $(BIN)/process-%-android
 	adb push $(BIN)/process-$*-android $(DEVICE_PATH)
 	adb push $(HEXAGON_RUNTIME_PATH)/bin/$*-android/libhalide_hexagon_host.so $(DEVICE_PATH)
 	adb push $(HEXAGON_RUNTIME_PATH)/bin/v60/signed_by_debug/libhalide_hexagon_remote_skel.so $(DEVICE_PATH)
-	adb shell cp /system/lib/rfsa/adsp/testsig* $(DEVICE_PATH)
+	adb shell cp /system/lib/rfsa/adsp/testsig* $(DEVICE_PATH) > /dev/null || true
 	adb shell chmod +x $(DEVICE_PATH)/process-$*-android
 	adb shell $(DEVICE_ENV) $(DEVICE_PATH)/process-$*-android cpu 10
 	adb shell $(DEVICE_ENV) $(DEVICE_PATH)/process-$*-android hvx64 10

--- a/apps/HelloHexagon/Makefile
+++ b/apps/HelloHexagon/Makefile
@@ -51,6 +51,7 @@ run-%-android: $(BIN)/process-%-android
 	adb push $(BIN)/process-$*-android $(DEVICE_PATH)
 	adb push $(HEXAGON_RUNTIME_PATH)/bin/$*-android/libhalide_hexagon_host.so $(DEVICE_PATH)
 	adb push $(HEXAGON_RUNTIME_PATH)/bin/v60/signed_by_debug/libhalide_hexagon_remote_skel.so $(DEVICE_PATH)
+	adb shell cp /system/lib/rfsa/adsp/testsig* $(DEVICE_PATH)
 	adb shell chmod +x $(DEVICE_PATH)/process-$*-android
 	adb shell $(DEVICE_ENV) $(DEVICE_PATH)/process-$*-android cpu 10
 	adb shell $(DEVICE_ENV) $(DEVICE_PATH)/process-$*-android hvx64 10

--- a/apps/hexagon_matmul/Makefile
+++ b/apps/hexagon_matmul/Makefile
@@ -51,6 +51,7 @@ run-%-android: $(BIN)/process-%-android
 	adb push $(BIN)/process-$*-android $(DEVICE_PATH)
 	adb push $(HEXAGON_RUNTIME_PATH)/bin/$*-android/libhalide_hexagon_host.so $(DEVICE_PATH)
 	adb push $(HEXAGON_RUNTIME_PATH)/bin/v60/signed_by_debug/libhalide_hexagon_remote_skel.so $(DEVICE_PATH)
+	adb shell cp /system/lib/rfsa/adsp/testsig* $(DEVICE_PATH)
 	adb shell chmod +x $(DEVICE_PATH)/process-$*-android
 	adb shell $(DEVICE_ENV) $(DEVICE_PATH)/process-$*-android cpu 10 1024 1024 1024
 	adb shell $(DEVICE_ENV) $(DEVICE_PATH)/process-$*-android hvx64 10 1024 1024 1024

--- a/apps/hexagon_matmul/Makefile
+++ b/apps/hexagon_matmul/Makefile
@@ -51,7 +51,7 @@ run-%-android: $(BIN)/process-%-android
 	adb push $(BIN)/process-$*-android $(DEVICE_PATH)
 	adb push $(HEXAGON_RUNTIME_PATH)/bin/$*-android/libhalide_hexagon_host.so $(DEVICE_PATH)
 	adb push $(HEXAGON_RUNTIME_PATH)/bin/v60/signed_by_debug/libhalide_hexagon_remote_skel.so $(DEVICE_PATH)
-	adb shell cp /system/lib/rfsa/adsp/testsig* $(DEVICE_PATH)
+	adb shell cp /system/lib/rfsa/adsp/testsig* $(DEVICE_PATH) > /dev/null || true
 	adb shell chmod +x $(DEVICE_PATH)/process-$*-android
 	adb shell $(DEVICE_ENV) $(DEVICE_PATH)/process-$*-android cpu 10 1024 1024 1024
 	adb shell $(DEVICE_ENV) $(DEVICE_PATH)/process-$*-android hvx64 10 1024 1024 1024


### PR DESCRIPTION
This PR makes it so testsigs (which are necessary on later Hexagon devices) still work after #2119.