### PR TITLE
Fix size-zero parallel for loops

### DIFF
--- a/src/runtime/thread_pool_common.h
+++ b/src/runtime/thread_pool_common.h
@@ -168,6 +168,11 @@ WEAK int halide_default_do_task(void *user_context, halide_task_t f, int idx,
 
 WEAK int halide_default_do_par_for(void *user_context, halide_task_t f,
                                    int min, int size, uint8_t *closure) {
+    // Our for loops are expected to gracefully handle sizes <= 0
+    if (size <= 0) {
+        return 0;
+    }
+
     // Grab the lock. If it hasn't been initialized yet, then the
     // field will be zero-initialized because it's a static global.
     halide_mutex_lock(&work_queue.mutex);


### PR DESCRIPTION
In our default thread-pool, the thread that claims the last loop
iteration from a job is responsible for popping it off the global work
queue. I found a case in the wild of a parallelized reduction over 0
things.

A job with zero things in it has no last loop iteration, so nobody was
popping it. The main thread thinks that the job was completed by someone
else and returns, and then a worker sees the job, which is now described
by a clobbered stack frame, so the worker then does arbitrary nonsense.

Our serial for loop codegen handles extents <= 0 gracefully, so I just
changed the parallel for loop handler to do that too.