### PR TITLE
Fixes to halide_image_io.h

### DIFF
--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -90,8 +90,8 @@ inline void convert(uint8_t in, uint64_t &out) {out = uint64_t(in) * 0x010101010
 inline void convert(uint8_t in, int16_t &out) {out = uint16_t(in) * 0x0101;}
 inline void convert(uint8_t in, int32_t &out) {out = uint32_t(in) * 0x01010101;}
 inline void convert(uint8_t in, int64_t &out) {out = uint64_t(in) * 0x0101010101010101LL;}
-inline void convert(uint8_t in, float &out) {out = (in + 128)/255.0f;}
-inline void convert(uint8_t in, double &out) {out = (in + 128)/255.0f;}
+inline void convert(uint8_t in, float &out) {out = in/255.0f;}
+inline void convert(uint8_t in, double &out) {out = in/255.0f;}
 
 // Convert from u16
 inline void convert(uint16_t in, bool &out) {out = in != 0;}
@@ -103,8 +103,8 @@ inline void convert(uint16_t in, int8_t &out) {out = in >> 8;}
 inline void convert(uint16_t in, int16_t &out) {out = in;}
 inline void convert(uint16_t in, int32_t &out) {out = uint32_t(in) * 0x00010001;}
 inline void convert(uint16_t in, int64_t &out) {out = uint64_t(in) * 0x0001000100010001LL;}
-inline void convert(uint16_t in, float &out) {out = (in + 32768)/65535.0f;}
-inline void convert(uint16_t in, double &out) {out = (in + 32768)/65535.0f;}
+inline void convert(uint16_t in, float &out) {out = in/65535.0f;}
+inline void convert(uint16_t in, double &out) {out = in/65535.0f;}
 
 
 inline bool ends_with_ignore_case(const std::string &ac, const std::string &bc) {

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -52,15 +52,14 @@ inline bool CheckReturn(bool condition, const char* fmt, ...) {
 inline void convert(bool in, uint8_t &out) {out = -int(in);}
 inline void convert(uint8_t in, uint8_t &out) {out = in;}
 inline void convert(uint16_t in, uint8_t &out) {
-    // We need to divide by 257 (not 256), but we can avoid division
-    // entirely using this approach (see http://research.swtch.com/divmult)
-    in = (uint32_t)(in) + (1 << 7);
-    out = ((in * 255 + 255) >> 16);
+    uint32_t tmp = (uint32_t)(in) + 0x80;
+    // Fast approximation of div-by-257: see http://research.swtch.com/divmult
+    out = ((tmp * 255 + 255) >> 16);
 }
-// TODO: the downshifts for 32 and 64 are slightly off, but are largely provided
-// so that all template instantiations will compile.
-inline void convert(uint32_t in, uint8_t &out) {out = in >> 24;}
-inline void convert(uint64_t in, uint8_t &out) {out = in >> 56;}
+inline void convert(uint32_t in, uint8_t &out) {out = (((uint64_t) in) + 0x00808080) / 0x01010101;}
+// uint64 -> 8 just discards the lower 32 bits:
+// if you were expecting more precision, well, sorry
+inline void convert(uint64_t in, uint8_t &out) {convert(uint32_t(in >> 32), out);}
 inline void convert(int8_t in, uint8_t &out) {convert((uint8_t)in, out);}
 inline void convert(int16_t in, uint8_t &out) {convert((uint16_t)in, out);}
 inline void convert(int32_t in, uint8_t &out) {convert((uint32_t)in, out);}

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -730,12 +730,16 @@ bool load_jpg(const std::string &filename, ImageType *im) {
         if (channels > 1) {
             for (int x = 0; x < im->width(); x++) {
                 for (int c = 0; c < channels; c++) {
-                    (*im)(x, y, c) = *src++;
+                    typename ImageType::ElemType out;
+                    Internal::convert(*src++, out);
+                    (*im)(x, y, c) = out;
                 }
             }
         } else {
             for (int x = 0; x < im->width(); x++) {
-                (*im)(x, y) = *src++;
+                typename ImageType::ElemType out;
+                Internal::convert(*src++, out);
+                (*im)(x, y) = out;
             }
         }
     }


### PR DESCRIPTION
-- JPEG case needed to use convert(), otherwise saving  non-uint8 images as JPEG produced garbage
-- improved rounding of the convert() functions (e.g. mul or div by 257 instead of 256); this may be overthinking it, but the extra overhead is unlikely to be meaningful here
-- added convert functions for bool and int64 types; these aren't likely to be very useful in practice, but it means we can instantiate compilable code for all of the supported Halide::Type C++ equivalents, and doesn't really cost us anything