### PR TITLE
Move CPP backend helpers into namespace

### DIFF
--- a/apps/c_backend/pipeline_generator.cpp
+++ b/apps/c_backend/pipeline_generator.cpp
@@ -14,7 +14,7 @@ public:
         Func f, g, h;
         f(x, y) = (input(clamp(x+2, 0, input.width()-1), clamp(y-2, 0, input.height()-1)) * 17)/13;
         h.define_extern("an_extern_stage", {f}, Int(16), 0, NameMangling::C);
-        g(x, y) = cast<uint16_t>(f(y, x) + f(x, y) + an_extern_func(x, y) + h());
+        g(x, y) = cast<uint16_t>(max(0, f(y, x) + f(x, y) + an_extern_func(x, y) + h()));
 
         f.compute_root().vectorize(x, 8);
         h.compute_root();


### PR DESCRIPTION
Some C++ environments apparently include "using std::max", etc, in some standard headers, leading to ambiguous-compilation-errors for calls to our "max" helpers. Deal with this evilness by moving all the little helper functions into an explicit namespace.