### PR TITLE
Ensure min() and max() are unambiguous in C++ backend

### DIFF
--- a/apps/c_backend/pipeline_generator.cpp
+++ b/apps/c_backend/pipeline_generator.cpp
@@ -14,7 +14,7 @@ public:
         Func f, g, h;
         f(x, y) = (input(clamp(x+2, 0, input.width()-1), clamp(y-2, 0, input.height()-1)) * 17)/13;
         h.define_extern("an_extern_stage", {f}, Int(16), 0, NameMangling::C);
-        g(x, y) = cast<uint16_t>(f(y, x) + f(x, y) + an_extern_func(x, y) + h());
+        g(x, y) = cast<uint16_t>(max(0, f(y, x) + f(x, y) + an_extern_func(x, y) + h()));
 
         f.compute_root().vectorize(x, 8);
         h.compute_root();

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -103,8 +103,9 @@ inline float neg_inf_f32() {return -INFINITY;}
 inline float inf_f32() {return INFINITY;}
 inline bool is_nan_f32(float x) {return x != x;}
 inline bool is_nan_f64(double x) {return x != x;}
+
 template<typename A, typename B> 
-A reinterpret(const B &b) { 
+inline A reinterpret(const B &b) { 
     #if __cplusplus >= 201103L
     static_assert(sizeof(A) == sizeof(B), "type size mismatch");
     #endif
@@ -112,13 +113,15 @@ A reinterpret(const B &b) {
     memcpy(&a, &b, sizeof(a)); 
     return a;
 }
-inline float float_from_bits(uint32_t bits) {return reinterpret<float, uint32_t>(bits);}
+inline float float_from_bits(uint32_t bits) {
+    return reinterpret<float, uint32_t>(bits);
+}
 
 template<typename T> 
-inline T max(const T &a, const T &b) {return (a > b) ? a : b;}
+inline T halide_cpp_max(const T &a, const T &b) {return (a > b) ? a : b;}
 
 template<typename T> 
-inline T min(const T &a, const T &b) {return (a < b) ? a : b;}
+inline T halide_cpp_min(const T &a, const T &b) {return (a < b) ? a : b;}
 
 template<typename A, typename B>
 const B &return_second(const A &a, const B &b) {
@@ -788,7 +791,7 @@ public:
     static Vec max(const Vec &a, const Vec &b) {
         Vec r(empty);
         for (size_t i = 0; i < Lanes; i++) {
-            r.elements[i] = ::max(a[i], b[i]);
+            r.elements[i] = ::halide_cpp_max(a[i], b[i]);
         }
         return r;
     }
@@ -796,7 +799,7 @@ public:
     static Vec min(const Vec &a, const Vec &b) {
         Vec r(empty);
         for (size_t i = 0; i < Lanes; i++) {
-            r.elements[i] = ::min(a[i], b[i]);
+            r.elements[i] = ::halide_cpp_min(a[i], b[i]);
         }
         return r;
     }
@@ -1094,7 +1097,7 @@ public:
     static Vec max(const Vec &a, const Vec &b) {
         Vec r(empty);
         for (size_t i = 0; i < Lanes; i++) {
-            r.native_vector[i] = ::max(a[i], b[i]);
+            r.native_vector[i] = ::halide_cpp_max(a[i], b[i]);
         }
         return r;
     }
@@ -1103,7 +1106,7 @@ public:
     static Vec min(const Vec &a, const Vec &b) {
         Vec r(empty);
         for (size_t i = 0; i < Lanes; i++) {
-            r.native_vector[i] = ::min(a[i], b[i]);
+            r.native_vector[i] = ::halide_cpp_min(a[i], b[i]);
         }
         return r;
     }
@@ -1755,7 +1758,7 @@ void CodeGen_C::visit(const Max *op) {
     // clang doesn't support the ternary operator on OpenCL style vectors.
     // See: https://bugs.llvm.org/show_bug.cgi?id=33103
     if (op->type.is_scalar()) {
-        print_expr(Call::make(op->type, "max", {op->a, op->b}, Call::Extern));
+        print_expr(Call::make(op->type, "::halide_cpp_max", {op->a, op->b}, Call::Extern));
     } else {
         ostringstream rhs;
         rhs << print_type(op->type) << "::max(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
@@ -1767,7 +1770,7 @@ void CodeGen_C::visit(const Min *op) {
     // clang doesn't support the ternary operator on OpenCL style vectors.
     // See: https://bugs.llvm.org/show_bug.cgi?id=33103
     if (op->type.is_scalar()) {
-        print_expr(Call::make(op->type, "min", {op->a, op->b}, Call::Extern));
+        print_expr(Call::make(op->type, "::halide_cpp_min", {op->a, op->b}, Call::Extern));
     } else {
         ostringstream rhs;
         rhs << print_type(op->type) << "::min(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -124,6 +124,25 @@ string simt_intrinsic(const string &name) {
 }
 }
 
+string CodeGen_Metal_Dev::CodeGen_Metal_C::print_extern_call(const Call *op) {
+    internal_assert(!function_takes_user_context(op->name));
+    vector<string> args(op->args.size());
+    for (size_t i = 0; i < op->args.size(); i++) {
+        args[i] = print_expr(op->args[i]);
+    }
+    ostringstream rhs;
+    rhs << op->name << "(" << with_commas(args) << ")";
+    return rhs.str();
+}
+
+void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Max *op) {
+    print_expr(Call::make(op->type, "max", {op->a, op->b}, Call::Extern));
+}
+
+void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Min *op) {
+    print_expr(Call::make(op->type, "min", {op->a, op->b}, Call::Extern));
+}
+
 void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Div *op) {
     int bits;
     if (is_const_power_of_two_integer(op->b, &bits)) {

--- a/src/CodeGen_Metal_Dev.h
+++ b/src/CodeGen_Metal_Dev.h
@@ -62,9 +62,12 @@ protected:
         std::string print_storage_type(Type type);
         std::string print_type_maybe_storage(Type type, bool storage, AppendSpaceIfNeeded space);
         std::string print_reinterpret(Type type, Expr e);
+        std::string print_extern_call(const Call *op);
 
         std::string get_memory_space(const std::string &);
 
+        void visit(const Min *);
+        void visit(const Max *);
         void visit(const Div *);
         void visit(const Mod *);
         void visit(const For *);

--- a/test/correctness/boundary_conditions.cpp
+++ b/test/correctness/boundary_conditions.cpp
@@ -376,7 +376,12 @@ int main(int argc, char **argv) {
 
     Halide::Internal::ThreadPool<bool> pool;
     std::vector<std::future<bool>> futures;
-    for (int vector_width = 1; vector_width <= 32; vector_width *= 2) {
+    int vector_width_max = 32;
+    if (target.has_feature(Target::Metal)) {
+        // https://github.com/halide/Halide/issues/2148
+        vector_width_max = 4;
+    }
+    for (int vector_width = 1; vector_width <= vector_width_max; vector_width *= 2) {
         std::cout << "Testing vector_width: " << vector_width << "\n";
         futures.push_back(pool.async(test_all, vector_width, target));
     }


### PR DESCRIPTION
Some C++ environments will do "using std::min (or max)" in common headers; rename the custom version the C++ backend emits to thwart errors.

Also, drive-by fix to the Metal backend for extern calls, which was broken by the recent vector change. (Apparently we don't test Metal on the buildbots?)