### PR TITLE
avoid ambiguity between std::min and Halide::min

### DIFF
--- a/src/Func.h
+++ b/src/Func.h
@@ -410,6 +410,14 @@ public:
     EXPORT Internal::Function function() const {return func;}
 };
 
+/** Explicit overloads of min and max for FuncRef. These exist to
+ * disambiguate calls to min on FuncRefs when a user has pulled both
+ * Halide::min and std::min into their namespace. */
+// @{
+inline Expr min(FuncRef a, FuncRef b) {return min(Expr(a), Expr(b));}
+inline Expr max(FuncRef a, FuncRef b) {return max(Expr(a), Expr(b));}
+// @}
+
 /** A fragment of front-end syntax of the form f(x, y, z)[index], where x, y,
  * z are Vars or Exprs. If could be the left hand side of an update
  * definition, or it could be a call to a function. We don't know

--- a/src/Func.h
+++ b/src/Func.h
@@ -414,8 +414,8 @@ public:
  * disambiguate calls to min on FuncRefs when a user has pulled both
  * Halide::min and std::min into their namespace. */
 // @{
-inline Expr min(FuncRef a, FuncRef b) {return min(Expr(a), Expr(b));}
-inline Expr max(FuncRef a, FuncRef b) {return max(Expr(a), Expr(b));}
+inline Expr min(FuncRef a, FuncRef b) {return min(Expr(std::move(a)), Expr(std::move(b)));}
+inline Expr max(FuncRef a, FuncRef b) {return max(Expr(std::move(a)), Expr(std::move(b)));}
 // @}
 
 /** A fragment of front-end syntax of the form f(x, y, z)[index], where x, y,


### PR DESCRIPTION
Avoids problems when people do:

using std::min;
using Halide::min;

It looks dumb when I write it like that, but the using std::min can be
buried in a header dependency somewhere.

This only happens because the stl has a templated min. Fortunately it
requires both template arguments to match, so we only have ambiguities
in cases where we call min/max on matching types that can both be cast
to Expr.

Note that this is mostly unrelated to the C-backend min/max namespace issues. This is a problem in the Halide source, not in the generated code.