### PR TITLE
Fixed Makefiles manually to get around linking errors when using an LLVM with terminfo.

### DIFF
--- a/apps/HelloHexagon/Makefile
+++ b/apps/HelloHexagon/Makefile
@@ -26,7 +26,7 @@ all: $(BIN)/process-host $(BIN)/process-arm-64-android $(BIN)/process-arm-32-and
 
 $(BIN)/pipeline: pipeline.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 $(BIN)/%/pipeline_cpu.o: $(BIN)/pipeline
 	@-mkdir -p $(BIN)/$*

--- a/apps/HelloHexagon/Makefile
+++ b/apps/HelloHexagon/Makefile
@@ -26,7 +26,7 @@ all: $(BIN)/process-host $(BIN)/process-arm-64-android $(BIN)/process-arm-32-and
 
 $(BIN)/pipeline: pipeline.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
 
 $(BIN)/%/pipeline_cpu.o: $(BIN)/pipeline
 	@-mkdir -p $(BIN)/$*

--- a/apps/HelloHexagon/Makefile
+++ b/apps/HelloHexagon/Makefile
@@ -26,7 +26,7 @@ all: $(BIN)/process-host $(BIN)/process-arm-64-android $(BIN)/process-arm-32-and
 
 $(BIN)/pipeline: pipeline.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
 
 $(BIN)/%/pipeline_cpu.o: $(BIN)/pipeline
 	@-mkdir -p $(BIN)/$*

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -4,7 +4,7 @@ all: $(BIN)/filter
 
 $(BIN)/bilateral_grid_exec: bilateral_grid_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
 
 $(BIN)/bilateral_grid.a: $(BIN)/bilateral_grid_exec
 	@-mkdir -p $(BIN)

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -4,7 +4,7 @@ all: $(BIN)/filter
 
 $(BIN)/bilateral_grid_exec: bilateral_grid_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 $(BIN)/bilateral_grid.a: $(BIN)/bilateral_grid_exec
 	@-mkdir -p $(BIN)

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -4,7 +4,7 @@ all: $(BIN)/filter
 
 $(BIN)/bilateral_grid_exec: bilateral_grid_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
 
 $(BIN)/bilateral_grid.a: $(BIN)/bilateral_grid_exec
 	@-mkdir -p $(BIN)

--- a/apps/blur/Makefile
+++ b/apps/blur/Makefile
@@ -4,7 +4,7 @@ all: $(BIN)/test
 
 $(BIN)/halide_blur_exec: halide_blur_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 $(BIN)/halide_blur.a: $(BIN)/halide_blur_exec
 	@-mkdir -p $(BIN)

--- a/apps/blur/Makefile
+++ b/apps/blur/Makefile
@@ -4,7 +4,7 @@ all: $(BIN)/test
 
 $(BIN)/halide_blur_exec: halide_blur_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
 
 $(BIN)/halide_blur.a: $(BIN)/halide_blur_exec
 	@-mkdir -p $(BIN)

--- a/apps/blur/Makefile
+++ b/apps/blur/Makefile
@@ -4,7 +4,7 @@ all: $(BIN)/test
 
 $(BIN)/halide_blur_exec: halide_blur_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
 
 $(BIN)/halide_blur.a: $(BIN)/halide_blur_exec
 	@-mkdir -p $(BIN)

--- a/apps/c_backend/Makefile
+++ b/apps/c_backend/Makefile
@@ -8,7 +8,7 @@ all: $(BIN)/test
 
 $(BIN)/pipeline_exec: pipeline_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
 
 $(BIN)/pipeline_native.a: $(BIN)/pipeline_exec
 	@-mkdir -p $(BIN)
@@ -21,9 +21,9 @@ $(BIN)/pipeline_c.cpp: $(BIN)/pipeline_exec
 $(BIN)/run: run.cpp $(BIN)/pipeline_c.cpp $(BIN)/pipeline_native.a
 	$(CXX) $(CXXFLAGS) -Wall -I$(BIN) $(filter-out %.h,$^) -o $@  $(LDFLAGS)
 
-$(BIN)/pipeline_cpp_exec: pipeline_cpp_generator.cpp $(GENERATOR_DEPS)
+$(BIN)/pipeline_cpp_exec: pipeline_cpp_generator.cpp $(GENERATOR_DEPS) $(LLVM_SYSTEM_LDFLAGS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 
 $(BIN)/pipeline_cpp_cpp.cpp: $(BIN)/pipeline_cpp_exec
 	@-mkdir -p $(BIN)

--- a/apps/c_backend/Makefile
+++ b/apps/c_backend/Makefile
@@ -8,7 +8,7 @@ all: $(BIN)/test
 
 $(BIN)/pipeline_exec: pipeline_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
 
 $(BIN)/pipeline_native.a: $(BIN)/pipeline_exec
 	@-mkdir -p $(BIN)
@@ -23,7 +23,7 @@ $(BIN)/run: run.cpp $(BIN)/pipeline_c.cpp $(BIN)/pipeline_native.a
 
 $(BIN)/pipeline_cpp_exec: pipeline_cpp_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
 
 $(BIN)/pipeline_cpp_cpp.cpp: $(BIN)/pipeline_cpp_exec
 	@-mkdir -p $(BIN)

--- a/apps/c_backend/Makefile
+++ b/apps/c_backend/Makefile
@@ -8,7 +8,7 @@ all: $(BIN)/test
 
 $(BIN)/pipeline_exec: pipeline_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 $(BIN)/pipeline_native.a: $(BIN)/pipeline_exec
 	@-mkdir -p $(BIN)
@@ -21,7 +21,7 @@ $(BIN)/pipeline_c.cpp: $(BIN)/pipeline_exec
 $(BIN)/run: run.cpp $(BIN)/pipeline_c.cpp $(BIN)/pipeline_native.a
 	$(CXX) $(CXXFLAGS) -Wall -I$(BIN) $(filter-out %.h,$^) -o $@  $(LDFLAGS)
 
-$(BIN)/pipeline_cpp_exec: pipeline_cpp_generator.cpp $(GENERATOR_DEPS) $(LLVM_SYSTEM_LDFLAGS)
+$(BIN)/pipeline_cpp_exec: pipeline_cpp_generator.cpp $(GENERATOR_DEPS) $(HALIDE_SYSTEM_LDFLAGS)
 	@-mkdir -p $(BIN)
 	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 

--- a/apps/c_backend/Makefile
+++ b/apps/c_backend/Makefile
@@ -21,9 +21,9 @@ $(BIN)/pipeline_c.cpp: $(BIN)/pipeline_exec
 $(BIN)/run: run.cpp $(BIN)/pipeline_c.cpp $(BIN)/pipeline_native.a
 	$(CXX) $(CXXFLAGS) -Wall -I$(BIN) $(filter-out %.h,$^) -o $@  $(LDFLAGS)
 
-$(BIN)/pipeline_cpp_exec: pipeline_cpp_generator.cpp $(GENERATOR_DEPS) $(HALIDE_SYSTEM_LDFLAGS)
+$(BIN)/pipeline_cpp_exec: pipeline_cpp_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 $(BIN)/pipeline_cpp_cpp.cpp: $(BIN)/pipeline_cpp_exec
 	@-mkdir -p $(BIN)

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -6,7 +6,7 @@ TIMING_ITERATIONS ?= 5
 
 $(BIN)/camera_pipe_exec: camera_pipe_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 $(BIN)/camera_pipe.a: $(BIN)/camera_pipe_exec
 	@-mkdir -p $(BIN)

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -6,7 +6,7 @@ TIMING_ITERATIONS ?= 5
 
 $(BIN)/camera_pipe_exec: camera_pipe_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
 
 $(BIN)/camera_pipe.a: $(BIN)/camera_pipe_exec
 	@-mkdir -p $(BIN)

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -6,7 +6,7 @@ TIMING_ITERATIONS ?= 5
 
 $(BIN)/camera_pipe_exec: camera_pipe_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
 
 $(BIN)/camera_pipe.a: $(BIN)/camera_pipe_exec
 	@-mkdir -p $(BIN)

--- a/apps/cuda_mat_mul/Makefile
+++ b/apps/cuda_mat_mul/Makefile
@@ -7,7 +7,7 @@ all: $(BIN)/runner
 
 $(BIN)/mat_mul_exec: mat_mul_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
 
 $(BIN)/mat_mul.a: $(BIN)/mat_mul_exec
 	@-mkdir -p $(BIN)

--- a/apps/cuda_mat_mul/Makefile
+++ b/apps/cuda_mat_mul/Makefile
@@ -7,7 +7,7 @@ all: $(BIN)/runner
 
 $(BIN)/mat_mul_exec: mat_mul_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 $(BIN)/mat_mul.a: $(BIN)/mat_mul_exec
 	@-mkdir -p $(BIN)

--- a/apps/cuda_mat_mul/Makefile
+++ b/apps/cuda_mat_mul/Makefile
@@ -7,7 +7,7 @@ all: $(BIN)/runner
 
 $(BIN)/mat_mul_exec: mat_mul_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
 
 $(BIN)/mat_mul.a: $(BIN)/mat_mul_exec
 	@-mkdir -p $(BIN)

--- a/apps/fft/Makefile
+++ b/apps/fft/Makefile
@@ -12,7 +12,7 @@ endif
 
 $(BIN)/bench_fft: main.cpp fft.cpp fft.h complex.h funct.h
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) main.cpp fft.cpp $(LIB_HALIDE) -o $@ $(LDFLAGS) $(LLVM_SHARED_LIBS)
+	$(CXX) $(CXXFLAGS) main.cpp fft.cpp $(LIB_HALIDE) -o $@ $(LDFLAGS) $(LLVM_SHARED_LIBS) $(LLVM_LDFLAGS)
 
 bench_16x16: $(BIN)/bench_fft
 	$(BIN)/bench_fft 16 16 $(BIN)/
@@ -28,7 +28,7 @@ bench_64x64: $(BIN)/bench_fft
 
 $(BIN)/fft_generator_exec: fft_generator.cpp fft.cpp fft.h $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
 
 # Generate four AOT compiled FFT variants. Forward versions have gain set to 1 / 256.0
 $(BIN)/fft_forward_r2c.a: $(BIN)/fft_generator_exec
@@ -49,7 +49,7 @@ $(BIN)/fft_inverse_c2c.a: $(BIN)/fft_generator_exec
 
 $(BIN)/fft_aot_test: fft_aot_test.cpp $(BIN)/fft_forward_r2c.a $(BIN)/fft_inverse_c2r.a $(BIN)/fft_forward_c2c.a $(BIN)/fft_inverse_c2c.a
 	@-mkdir -p $(BIN)
-	$(CXX) -I$(BIN) -I$(HALIDE_BIN_PATH)/include/ -std=c++11 $^ -o $@ $(LDFLAGS)
+	$(CXX) -I$(BIN) -I$(HALIDE_BIN_PATH)/include/ -std=c++11 $^ -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
 
 clean:
 	rm -rf $(BIN)

--- a/apps/fft/Makefile
+++ b/apps/fft/Makefile
@@ -12,7 +12,7 @@ endif
 
 $(BIN)/bench_fft: main.cpp fft.cpp fft.h complex.h funct.h
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) main.cpp fft.cpp $(LIB_HALIDE) -o $@ $(LDFLAGS) $(LLVM_SHARED_LIBS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) main.cpp fft.cpp $(LIB_HALIDE) -o $@ $(LDFLAGS) $(LLVM_SHARED_LIBS) $(HALIDE_SYSTEM_LDFLAGS)
 
 bench_16x16: $(BIN)/bench_fft
 	$(BIN)/bench_fft 16 16 $(BIN)/
@@ -28,7 +28,7 @@ bench_64x64: $(BIN)/bench_fft
 
 $(BIN)/fft_generator_exec: fft_generator.cpp fft.cpp fft.h $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 # Generate four AOT compiled FFT variants. Forward versions have gain set to 1 / 256.0
 $(BIN)/fft_forward_r2c.a: $(BIN)/fft_generator_exec
@@ -49,7 +49,7 @@ $(BIN)/fft_inverse_c2c.a: $(BIN)/fft_generator_exec
 
 $(BIN)/fft_aot_test: fft_aot_test.cpp $(BIN)/fft_forward_r2c.a $(BIN)/fft_inverse_c2r.a $(BIN)/fft_forward_c2c.a $(BIN)/fft_inverse_c2c.a
 	@-mkdir -p $(BIN)
-	$(CXX) -I$(BIN) -I$(HALIDE_BIN_PATH)/include/ -std=c++11 $^ -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) -I$(BIN) -I$(HALIDE_BIN_PATH)/include/ -std=c++11 $^ -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 clean:
 	rm -rf $(BIN)

--- a/apps/fft/Makefile
+++ b/apps/fft/Makefile
@@ -12,7 +12,7 @@ endif
 
 $(BIN)/bench_fft: main.cpp fft.cpp fft.h complex.h funct.h
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) main.cpp fft.cpp $(LIB_HALIDE) -o $@ $(LDFLAGS) $(LLVM_SHARED_LIBS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) main.cpp fft.cpp $(LIB_HALIDE) -o $@ $(LDFLAGS) $(LLVM_SHARED_LIBS) $(LLVM_SYSTEM_LDFLAGS)
 
 bench_16x16: $(BIN)/bench_fft
 	$(BIN)/bench_fft 16 16 $(BIN)/
@@ -28,7 +28,7 @@ bench_64x64: $(BIN)/bench_fft
 
 $(BIN)/fft_generator_exec: fft_generator.cpp fft.cpp fft.h $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
 
 # Generate four AOT compiled FFT variants. Forward versions have gain set to 1 / 256.0
 $(BIN)/fft_forward_r2c.a: $(BIN)/fft_generator_exec
@@ -49,7 +49,7 @@ $(BIN)/fft_inverse_c2c.a: $(BIN)/fft_generator_exec
 
 $(BIN)/fft_aot_test: fft_aot_test.cpp $(BIN)/fft_forward_r2c.a $(BIN)/fft_inverse_c2r.a $(BIN)/fft_forward_c2c.a $(BIN)/fft_inverse_c2c.a
 	@-mkdir -p $(BIN)
-	$(CXX) -I$(BIN) -I$(HALIDE_BIN_PATH)/include/ -std=c++11 $^ -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
+	$(CXX) -I$(BIN) -I$(HALIDE_BIN_PATH)/include/ -std=c++11 $^ -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
 
 clean:
 	rm -rf $(BIN)

--- a/apps/glsl/Makefile
+++ b/apps/glsl/Makefile
@@ -6,7 +6,7 @@ all: $(BIN)/opengl_test
 
 $(BIN)/halide_blur_glsl_exec: halide_blur_glsl_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 $(BIN)/halide_blur_glsl.a: $(BIN)/halide_blur_glsl_exec
 	@-mkdir -p $(BIN)
@@ -14,7 +14,7 @@ $(BIN)/halide_blur_glsl.a: $(BIN)/halide_blur_glsl_exec
 
 $(BIN)/halide_ycc_glsl_exec: halide_ycc_glsl_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 $(BIN)/halide_ycc_glsl.a: $(BIN)/halide_ycc_glsl_exec
 	@-mkdir -p $(BIN)

--- a/apps/glsl/Makefile
+++ b/apps/glsl/Makefile
@@ -6,7 +6,7 @@ all: $(BIN)/opengl_test
 
 $(BIN)/halide_blur_glsl_exec: halide_blur_glsl_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
 
 $(BIN)/halide_blur_glsl.a: $(BIN)/halide_blur_glsl_exec
 	@-mkdir -p $(BIN)
@@ -14,7 +14,7 @@ $(BIN)/halide_blur_glsl.a: $(BIN)/halide_blur_glsl_exec
 
 $(BIN)/halide_ycc_glsl_exec: halide_ycc_glsl_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
 
 $(BIN)/halide_ycc_glsl.a: $(BIN)/halide_ycc_glsl_exec
 	@-mkdir -p $(BIN)

--- a/apps/glsl/Makefile
+++ b/apps/glsl/Makefile
@@ -6,7 +6,7 @@ all: $(BIN)/opengl_test
 
 $(BIN)/halide_blur_glsl_exec: halide_blur_glsl_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
 
 $(BIN)/halide_blur_glsl.a: $(BIN)/halide_blur_glsl_exec
 	@-mkdir -p $(BIN)
@@ -14,7 +14,7 @@ $(BIN)/halide_blur_glsl.a: $(BIN)/halide_blur_glsl_exec
 
 $(BIN)/halide_ycc_glsl_exec: halide_ycc_glsl_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
 
 $(BIN)/halide_ycc_glsl.a: $(BIN)/halide_ycc_glsl_exec
 	@-mkdir -p $(BIN)

--- a/apps/hexagon_benchmarks/Makefile
+++ b/apps/hexagon_benchmarks/Makefile
@@ -38,7 +38,7 @@ DASH_D_DEFINES = $(patsubst %, -D%=1, $(UPPERCASE_FILTERS))
 
 $(BIN)/%_generator : %_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -O3 -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -O3 -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
 
 $(BIN)/%/conv3x3a16_cpu.o: $(BIN)/conv3x3_generator
 	@-mkdir -p $(BIN)/$*

--- a/apps/hexagon_benchmarks/Makefile
+++ b/apps/hexagon_benchmarks/Makefile
@@ -38,7 +38,7 @@ DASH_D_DEFINES = $(patsubst %, -D%=1, $(UPPERCASE_FILTERS))
 
 $(BIN)/%_generator : %_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -O3 -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -O3 -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 $(BIN)/%/conv3x3a16_cpu.o: $(BIN)/conv3x3_generator
 	@-mkdir -p $(BIN)/$*

--- a/apps/hexagon_benchmarks/Makefile
+++ b/apps/hexagon_benchmarks/Makefile
@@ -38,7 +38,7 @@ DASH_D_DEFINES = $(patsubst %, -D%=1, $(UPPERCASE_FILTERS))
 
 $(BIN)/%_generator : %_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -O3 -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -O3 -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
 
 $(BIN)/%/conv3x3a16_cpu.o: $(BIN)/conv3x3_generator
 	@-mkdir -p $(BIN)/$*

--- a/apps/hexagon_matmul/Makefile
+++ b/apps/hexagon_matmul/Makefile
@@ -26,7 +26,7 @@ all: $(BIN)/process-host $(BIN)/process-arm-64-android $(BIN)/process-arm-32-and
 
 $(BIN)/pipeline: pipeline.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 $(BIN)/%/pipeline_cpu.o: $(BIN)/pipeline
 	@-mkdir -p $(BIN)/$*

--- a/apps/hexagon_matmul/Makefile
+++ b/apps/hexagon_matmul/Makefile
@@ -26,7 +26,7 @@ all: $(BIN)/process-host $(BIN)/process-arm-64-android $(BIN)/process-arm-32-and
 
 $(BIN)/pipeline: pipeline.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
 
 $(BIN)/%/pipeline_cpu.o: $(BIN)/pipeline
 	@-mkdir -p $(BIN)/$*

--- a/apps/hexagon_matmul/Makefile
+++ b/apps/hexagon_matmul/Makefile
@@ -26,7 +26,7 @@ all: $(BIN)/process-host $(BIN)/process-arm-64-android $(BIN)/process-arm-32-and
 
 $(BIN)/pipeline: pipeline.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
 
 $(BIN)/%/pipeline_cpu.o: $(BIN)/pipeline
 	@-mkdir -p $(BIN)/$*

--- a/apps/interpolate/Makefile
+++ b/apps/interpolate/Makefile
@@ -6,7 +6,7 @@ CXXFLAGS += -g -Wall
 
 $(BIN)/interpolate: interpolate.cpp
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) interpolate.cpp $(LIB_HALIDE) -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS) $(LLVM_SHARED_LIBS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) interpolate.cpp $(LIB_HALIDE) -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS) $(LLVM_SHARED_LIBS) $(LLVM_SYSTEM_LDFLAGS)
 
 $(BIN)/out.png: $(BIN)/interpolate
 	@-mkdir -p $(BIN)

--- a/apps/interpolate/Makefile
+++ b/apps/interpolate/Makefile
@@ -6,7 +6,7 @@ CXXFLAGS += -g -Wall
 
 $(BIN)/interpolate: interpolate.cpp
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) interpolate.cpp $(LIB_HALIDE) -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS) $(LLVM_SHARED_LIBS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) interpolate.cpp $(LIB_HALIDE) -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS) $(LLVM_SHARED_LIBS) $(HALIDE_SYSTEM_LDFLAGS)
 
 $(BIN)/out.png: $(BIN)/interpolate
 	@-mkdir -p $(BIN)

--- a/apps/interpolate/Makefile
+++ b/apps/interpolate/Makefile
@@ -6,7 +6,7 @@ CXXFLAGS += -g -Wall
 
 $(BIN)/interpolate: interpolate.cpp
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) interpolate.cpp $(LIB_HALIDE) -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS) $(LLVM_SHARED_LIBS)
+	$(CXX) $(CXXFLAGS) interpolate.cpp $(LIB_HALIDE) -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS) $(LLVM_SHARED_LIBS) $(LLVM_LDFLAGS)
 
 $(BIN)/out.png: $(BIN)/interpolate
 	@-mkdir -p $(BIN)

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -6,7 +6,7 @@ all: $(BIN)/process
 
 $(BIN)/local_laplacian_exec: local_laplacian_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 $(BIN)/local_laplacian.a: $(BIN)/local_laplacian_exec
 	@-mkdir -p $(BIN)

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -6,7 +6,7 @@ all: $(BIN)/process
 
 $(BIN)/local_laplacian_exec: local_laplacian_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
 
 $(BIN)/local_laplacian.a: $(BIN)/local_laplacian_exec
 	@-mkdir -p $(BIN)

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -6,7 +6,7 @@ all: $(BIN)/process
 
 $(BIN)/local_laplacian_exec: local_laplacian_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(LLVM_LDFLAGS)
 
 $(BIN)/local_laplacian.a: $(BIN)/local_laplacian_exec
 	@-mkdir -p $(BIN)

--- a/apps/opengl_demo/Makefile
+++ b/apps/opengl_demo/Makefile
@@ -89,7 +89,7 @@ $(BIN)/sample_filter_opengl.o $(BIN)/sample_filter_opengl.h: $(BIN)/generate_sam
 
 $(BIN)/generate_sample_filter: sample_filter.cpp
 	@mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti -o $@ $^ $(HALIDE_TOOLS_DIR)/GenGen.cpp $(HALIDE_LIB_PATH) $(GENERATOR_LIBS)
+	$(CXX) $(CXXFLAGS) -fno-rtti -o $@ $^ $(HALIDE_TOOLS_DIR)/GenGen.cpp $(HALIDE_LIB_PATH) $(GENERATOR_LIBS) $(LLVM_LDFLAGS)
 
 #
 # Build in subdir using auto-dependency mechanism

--- a/apps/opengl_demo/Makefile
+++ b/apps/opengl_demo/Makefile
@@ -89,7 +89,7 @@ $(BIN)/sample_filter_opengl.o $(BIN)/sample_filter_opengl.h: $(BIN)/generate_sam
 
 $(BIN)/generate_sample_filter: sample_filter.cpp
 	@mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti -o $@ $^ $(HALIDE_TOOLS_DIR)/GenGen.cpp $(HALIDE_LIB_PATH) $(GENERATOR_LIBS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti -o $@ $^ $(HALIDE_TOOLS_DIR)/GenGen.cpp $(HALIDE_LIB_PATH) $(GENERATOR_LIBS) $(LLVM_SYSTEM_LDFLAGS)
 
 #
 # Build in subdir using auto-dependency mechanism

--- a/apps/opengl_demo/Makefile
+++ b/apps/opengl_demo/Makefile
@@ -89,7 +89,7 @@ $(BIN)/sample_filter_opengl.o $(BIN)/sample_filter_opengl.h: $(BIN)/generate_sam
 
 $(BIN)/generate_sample_filter: sample_filter.cpp
 	@mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) -fno-rtti -o $@ $^ $(HALIDE_TOOLS_DIR)/GenGen.cpp $(HALIDE_LIB_PATH) $(GENERATOR_LIBS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -fno-rtti -o $@ $^ $(HALIDE_TOOLS_DIR)/GenGen.cpp $(HALIDE_LIB_PATH) $(GENERATOR_LIBS) $(HALIDE_SYSTEM_LDFLAGS)
 
 #
 # Build in subdir using auto-dependency mechanism

--- a/apps/openglcompute/Makefile
+++ b/apps/openglcompute/Makefile
@@ -10,7 +10,7 @@ $(HALIDE_LIB): $(TOP)
 	$(MAKE) -C $(TOP)
 
 test_%: test_%.cpp
-	$(CXX) -std=c++11 -I ../../include/ $< -L ../../bin/ -lHalide -o $@ -g
+	$(CXX) -std=c++11 -I ../../include/ $< -L ../../bin/ -lHalide $(LLVM_LDFLAGS) -o $@ -g
 
 avg_filter_uint32t.o avg_filter_uint32t.h avg_filter_float.o avg_filter_float.h: test_oglc_avg
 	LD_LIBRARY_PATH=../../bin DYLD_LIBRARY_PATH=../../bin HL_TARGET=arm-32-android-armv7s-openglcompute ./$<

--- a/apps/openglcompute/Makefile
+++ b/apps/openglcompute/Makefile
@@ -10,7 +10,7 @@ $(HALIDE_LIB): $(TOP)
 	$(MAKE) -C $(TOP)
 
 test_%: test_%.cpp
-	$(CXX) -std=c++11 -I ../../include/ $< -L ../../bin/ -lHalide $(LLVM_SYSTEM_LDFLAGS) -o $@ -g
+	$(CXX) -std=c++11 -I ../../include/ $< -L ../../bin/ -lHalide $(HALIDE_SYSTEM_LDFLAGS) -o $@ -g
 
 avg_filter_uint32t.o avg_filter_uint32t.h avg_filter_float.o avg_filter_float.h: test_oglc_avg
 	LD_LIBRARY_PATH=../../bin DYLD_LIBRARY_PATH=../../bin HL_TARGET=arm-32-android-armv7s-openglcompute ./$<

--- a/apps/openglcompute/Makefile
+++ b/apps/openglcompute/Makefile
@@ -10,7 +10,7 @@ $(HALIDE_LIB): $(TOP)
 	$(MAKE) -C $(TOP)
 
 test_%: test_%.cpp
-	$(CXX) -std=c++11 -I ../../include/ $< -L ../../bin/ -lHalide $(LLVM_LDFLAGS) -o $@ -g
+	$(CXX) -std=c++11 -I ../../include/ $< -L ../../bin/ -lHalide $(LLVM_SYSTEM_LDFLAGS) -o $@ -g
 
 avg_filter_uint32t.o avg_filter_uint32t.h avg_filter_float.o avg_filter_float.h: test_oglc_avg
 	LD_LIBRARY_PATH=../../bin DYLD_LIBRARY_PATH=../../bin HL_TARGET=arm-32-android-armv7s-openglcompute ./$<

--- a/apps/resize/Makefile
+++ b/apps/resize/Makefile
@@ -8,7 +8,7 @@ BIN ?= bin
 
 $(BIN)/resize: ../../ resize.cpp
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) resize.cpp $(LIB_HALIDE) -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS) $(LLVM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) resize.cpp $(LIB_HALIDE) -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
 
 $(BIN)/out.png: $(BIN)/resize
 	@-mkdir -p $(BIN)

--- a/apps/resize/Makefile
+++ b/apps/resize/Makefile
@@ -8,7 +8,7 @@ BIN ?= bin
 
 $(BIN)/resize: ../../ resize.cpp
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) resize.cpp $(LIB_HALIDE) -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) resize.cpp $(LIB_HALIDE) -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 $(BIN)/out.png: $(BIN)/resize
 	@-mkdir -p $(BIN)

--- a/apps/resize/Makefile
+++ b/apps/resize/Makefile
@@ -8,7 +8,7 @@ BIN ?= bin
 
 $(BIN)/resize: ../../ resize.cpp
 	@-mkdir -p $(BIN)
-	$(CXX) $(CXXFLAGS) resize.cpp $(LIB_HALIDE) -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) resize.cpp $(LIB_HALIDE) -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS) $(LLVM_LDFLAGS)
 
 $(BIN)/out.png: $(BIN)/resize
 	@-mkdir -p $(BIN)

--- a/apps/simd_op_check/Makefile
+++ b/apps/simd_op_check/Makefile
@@ -37,7 +37,7 @@ $(BIN)/%/filters.h:
 
 $(BIN)/driver-%: driver.cpp $(BIN)/%/filters.h
 	@-mkdir -p $(BIN)/$*
-	$(CXX-$*) $(CXXFLAGS-$*) -I ../../include -O3 -I $(BIN)/$* driver.cpp $(BIN)/$*/test_*.o $(BIN)/$*/simd_op_check_runtime.o -o $@ $(LDFLAGS-$*) $(LLVM_LDFLAGS)
+	$(CXX-$*) $(CXXFLAGS-$*) -I ../../include -O3 -I $(BIN)/$* driver.cpp $(BIN)/$*/test_*.o $(BIN)/$*/simd_op_check_runtime.o -o $@ $(LDFLAGS-$*) $(LLVM_SYSTEM_LDFLAGS)
 
 clean:
 	rm -rf $(BIN)

--- a/apps/simd_op_check/Makefile
+++ b/apps/simd_op_check/Makefile
@@ -37,7 +37,7 @@ $(BIN)/%/filters.h:
 
 $(BIN)/driver-%: driver.cpp $(BIN)/%/filters.h
 	@-mkdir -p $(BIN)/$*
-	$(CXX-$*) $(CXXFLAGS-$*) -I ../../include -O3 -I $(BIN)/$* driver.cpp $(BIN)/$*/test_*.o $(BIN)/$*/simd_op_check_runtime.o -o $@ $(LDFLAGS-$*) $(LLVM_SYSTEM_LDFLAGS)
+	$(CXX-$*) $(CXXFLAGS-$*) -I ../../include -O3 -I $(BIN)/$* driver.cpp $(BIN)/$*/test_*.o $(BIN)/$*/simd_op_check_runtime.o -o $@ $(LDFLAGS-$*) $(HALIDE_SYSTEM_LDFLAGS)
 
 clean:
 	rm -rf $(BIN)

--- a/apps/simd_op_check/Makefile
+++ b/apps/simd_op_check/Makefile
@@ -37,7 +37,7 @@ $(BIN)/%/filters.h:
 
 $(BIN)/driver-%: driver.cpp $(BIN)/%/filters.h
 	@-mkdir -p $(BIN)/$*
-	$(CXX-$*) $(CXXFLAGS-$*) -I ../../include -O3 -I $(BIN)/$* driver.cpp $(BIN)/$*/test_*.o $(BIN)/$*/simd_op_check_runtime.o -o $@ $(LDFLAGS-$*)
+	$(CXX-$*) $(CXXFLAGS-$*) -I ../../include -O3 -I $(BIN)/$* driver.cpp $(BIN)/$*/test_*.o $(BIN)/$*/simd_op_check_runtime.o -o $@ $(LDFLAGS-$*) $(LLVM_LDFLAGS)
 
 clean:
 	rm -rf $(BIN)

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -28,7 +28,8 @@ GENERATOR_DEPS ?= $(HALIDE_BIN_PATH)/lib/libHalide.a $(HALIDE_BIN_PATH)/include/
 
 LLVM_CONFIG ?= llvm-config
 LLVM_VERSION_TIMES_10 = $(shell $(LLVM_CONFIG) --version | cut -b 1,3)
-LLVM_LDFLAGS = $(shell $(LLVM_CONFIG) --ldflags --system-libs)
+LLVM_SYSTEM_LDFLAGS = $(shell $(LLVM_CONFIG) --system-libs)
+LLVM_LDFLAGS = $(shell $(LLVM_CONFIG) --ldflags) $(LLVM_SYSTEM_LDFLAGS)
 
 LLVM_CONFIG ?= llvm-config
 LLVM_FULL_VERSION = $(shell $(LLVM_CONFIG) --version)

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -28,8 +28,8 @@ GENERATOR_DEPS ?= $(HALIDE_BIN_PATH)/lib/libHalide.a $(HALIDE_BIN_PATH)/include/
 
 LLVM_CONFIG ?= llvm-config
 LLVM_VERSION_TIMES_10 = $(shell $(LLVM_CONFIG) --version | cut -b 1,3)
-LLVM_SYSTEM_LDFLAGS = $(shell $(LLVM_CONFIG) --system-libs)
-LLVM_LDFLAGS = $(shell $(LLVM_CONFIG) --ldflags) $(LLVM_SYSTEM_LDFLAGS)
+HALIDE_SYSTEM_LDFLAGS = $(shell $(LLVM_CONFIG) --system-libs)
+LLVM_LDFLAGS = $(shell $(LLVM_CONFIG) --ldflags) $(HALIDE_SYSTEM_LDFLAGS)
 
 LLVM_CONFIG ?= llvm-config
 LLVM_FULL_VERSION = $(shell $(LLVM_CONFIG) --version)

--- a/apps/wavelet/Makefile
+++ b/apps/wavelet/Makefile
@@ -14,7 +14,7 @@ clean:
 $(BIN)/%_exec: %_generator.cpp $(GENERATOR_DEPS)
 	@echo Building Generator $(filter %_generator.cpp,$^)
 	@mkdir -p $(BIN)
-	@$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) $(LDFLAGS) -o $@
+	@$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) $(LDFLAGS) $(LLVM_LDFLAGS) -o $@
 
 # By default, %.a/.h are produced by executing %_exec
 $(BIN)/%.a $(BIN)/%.h: $(BIN)/%_exec

--- a/apps/wavelet/Makefile
+++ b/apps/wavelet/Makefile
@@ -14,7 +14,7 @@ clean:
 $(BIN)/%_exec: %_generator.cpp $(GENERATOR_DEPS)
 	@echo Building Generator $(filter %_generator.cpp,$^)
 	@mkdir -p $(BIN)
-	@$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) $(LDFLAGS) $(LLVM_LDFLAGS) -o $@
+	@$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS) -o $@
 
 # By default, %.a/.h are produced by executing %_exec
 $(BIN)/%.a $(BIN)/%.h: $(BIN)/%_exec

--- a/apps/wavelet/Makefile
+++ b/apps/wavelet/Makefile
@@ -14,7 +14,7 @@ clean:
 $(BIN)/%_exec: %_generator.cpp $(GENERATOR_DEPS)
 	@echo Building Generator $(filter %_generator.cpp,$^)
 	@mkdir -p $(BIN)
-	@$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) $(LDFLAGS) $(LLVM_SYSTEM_LDFLAGS) -o $@
+	@$(CXX) $(CXXFLAGS) -fno-rtti $(filter-out %.h,$^) $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS) -o $@
 
 # By default, %.a/.h are produced by executing %_exec
 $(BIN)/%.a $(BIN)/%.h: $(BIN)/%_exec


### PR DESCRIPTION
Regarding Issues:
#1112 
#2156 

This is not a complete fix: only the app Makefiles have been patched. Cmake should be done as well. I don't have a working CMake build to do and test that on.