### PR TITLE
Remove function visitor dimension check

### DIFF
--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -84,7 +84,7 @@ struct FunctionContents {
         }
 
         for (Parameter i : output_buffers) {
-            for (size_t j = 0; j < init_def.args().size() && j < 4; j++) {
+            for (size_t j = 0; j < init_def.args().size(); j++) {
                 if (i.min_constraint(j).defined()) {
                     i.min_constraint(j).accept(visitor);
                 }


### PR DESCRIPTION
We weren't visiting constraints on dimensions beyond the fourth,
probably because that used to be the limit on a buffer_t. Removed. Done
as a PR for testing in case I'm missing something.