### PR TITLE
Schedule tweak for more locality

### DIFF
--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -119,11 +119,10 @@ public:
                     .compute_root().reorder_storage(x, k, y)
                     .reorder(k, y).parallel(y, 8).vectorize(x, 8);
                 outGPyramid[j]
-                    .store_at(output, yo).compute_at(output, y)
+                    .store_at(output, yo).compute_at(outGPyramid[j-1], y).fold_storage(y, 8)
                     .vectorize(x, 8);
             }
-            outGPyramid[0]
-                .compute_at(output, y).vectorize(x, 8);
+            outGPyramid[0].compute_at(output, y).vectorize(x, 8);
             for (int j = 5; j < J; j++) {
                 inGPyramid[j].compute_root();
                 gPyramid[j].compute_root().parallel(k);


### PR DESCRIPTION
cascades the sliding window pyramid collapse instead of computing them
all at (output,y). Reduces runtime from 27ms to 21ms on my machine.