### PR TITLE
Grab-bag of halide_image_io cleanups

### DIFF
--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -8,6 +8,8 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <functional>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -194,12 +196,14 @@ template<> inline double convert(const int64_t &in) { return convert<double, uin
 template<> inline double convert(const float &in) { return (double) in; }
 template<> inline double convert(const double &in) { return in; }
 
-inline bool ends_with_ignore_case(const std::string &ac, const std::string &bc) {
-    if (ac.length() < bc.length()) { return false; }
-    std::string a = ac, b = bc;
-    std::transform(a.begin(), a.end(), a.begin(), ::tolower);
-    std::transform(b.begin(), b.end(), b.begin(), ::tolower);
-    return a.compare(a.length()-b.length(), b.length(), b) == 0;
+inline std::string get_lowercase_extension(const std::string &path) {
+    size_t last_dot = path.rfind('.');
+    if (last_dot == std::string::npos) {
+        return "";
+    }
+    std::string ext = path.substr(last_dot + 1);
+    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+    return ext;
 }
 
 inline bool is_little_endian() {
@@ -207,29 +211,62 @@ inline bool is_little_endian() {
     return ((char *) &value)[0] == 1;
 }
 
-inline void swap_endian_16(bool little_endian, uint16_t &value) {
-    if (little_endian) {
-        value = ((value & 0xff)<<8)|((value & 0xff00)>>8);
-    }
+inline uint16_t swap_endian_16(bool little_endian, uint16_t value) {
+    return (little_endian) ? ((value & 0xff)<<8)|((value & 0xff00)>>8) : value;
 }
 
 struct FileOpener {
-    FileOpener(const char* filename, const char* mode) : f(fopen(filename, mode)) {
+    FileOpener(const std::string &filename, const char* mode) : f(fopen(filename.c_str(), mode)) {
         // nothing
     }
+
     ~FileOpener() {
         if (f != nullptr) {
             fclose(f);
         }
     }
-    // read a line of data skipping lines that begin with '#"
-    char *readLine(char *buf, int maxlen) {
+
+    // read a line of data, skipping lines that begin with '#"
+    char *read_line(char *buf, int maxlen) {
         char *status;
         do {
             status = fgets(buf, maxlen, f);
         } while(status && buf[0] == '#');
         return(status);
     }
+
+    // call read_line and to a sscanf() on it
+    int scan_line(const char *fmt, ...) {
+        char buf[1024];
+        if (!read_line(buf, 1024)) {
+            return 0;
+        }
+        va_list args;
+        va_start(args, fmt);
+        int result = vsscanf(buf, fmt, args);
+        va_end(args);
+        return result;
+    }
+
+    bool read_bytes(uint8_t *data, size_t count) {
+        return fread(data, 1, count, f) == count;
+    }
+
+    template<typename T>
+    bool read_vector(std::vector<T> *v) {
+        return read_bytes((uint8_t *)v->data(), v->size() * sizeof(T));
+    }
+
+    bool write_bytes(const uint8_t *data, size_t count) {
+        return fwrite(data, 1, count, f) == count;
+    }
+
+    template<typename T>
+    bool write_vector(const std::vector<T> &v) {
+        return write_bytes((const uint8_t *)v.data(), v.size() * sizeof(T));
+    }
+
+
     FILE * const f;
 };
 
@@ -261,8 +298,7 @@ struct PngRowPointers {
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
 bool load_png(const std::string &filename, ImageType *im) {
 #ifdef HALIDE_NO_PNG
-    check(false, "png not supported in this build\n");
-    return false;
+    return check(false, "png not supported in this build");
 #else // HALIDE_NO_PNG
     using ElemType = typename ImageType::ElemType;
     png_byte header[8];
@@ -270,20 +306,32 @@ bool load_png(const std::string &filename, ImageType *im) {
     png_infop info_ptr;
 
     /* open file and test for it being a png */
-    Internal::FileOpener f(filename.c_str(), "rb");
-    if (!check(f.f != nullptr, "File %s could not be opened for reading\n", filename.c_str())) return false;
-    if (!check(fread(header, 1, 8, f.f) == 8, "File ended before end of header\n")) return false;
-    if (!check(!png_sig_cmp(header, 0, 8), "File %s is not recognized as a PNG file\n", filename.c_str())) return false;
+    Internal::FileOpener f(filename, "rb");
+    if (!check(f.f != nullptr, "File %s could not be opened for reading\n", filename.c_str())) {
+        return false;
+    }
+    if (!check(f.read_bytes(header, sizeof(header)), "File ended before end of header")) {
+        return false;
+    }
+    if (!check(!png_sig_cmp(header, 0, 8), "File %s is not recognized as a PNG file\n", filename.c_str())) {
+        return false;
+    }
 
     /* initialize stuff */
     png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
 
-    if (!check(png_ptr != nullptr, "png_create_read_struct failed\n")) return false;
+    if (!check(png_ptr != nullptr, "png_create_read_struct failed")) {
+        return false;
+    }
 
     info_ptr = png_create_info_struct(png_ptr);
-    if (!check(info_ptr != nullptr, "png_create_info_struct failed\n")) return false;
+    if (!check(info_ptr != nullptr, "png_create_info_struct failed")) {
+        return false;
+    }
 
-    if (!check(!setjmp(png_jmpbuf(png_ptr)), "Error during init_io\n")) return false;
+    if (!check(!setjmp(png_jmpbuf(png_ptr)), "Error during init_io")) {
+        return false;
+    }
 
     png_init_io(png_ptr, f.f);
     png_set_sig_bytes(png_ptr, 8);
@@ -310,12 +358,16 @@ bool load_png(const std::string &filename, ImageType *im) {
     png_read_update_info(png_ptr, info_ptr);
 
     // read the file
-    if (!check(!setjmp(png_jmpbuf(png_ptr)), "Error during read_image\n")) return false;
+    if (!check(!setjmp(png_jmpbuf(png_ptr)), "Error during read_image")) {
+        return false;
+    }
 
     Internal::PngRowPointers row_pointers(im->height(), png_get_rowbytes(png_ptr, info_ptr));
     png_read_image(png_ptr, row_pointers.p);
 
-    if (!check((bit_depth == 8) || (bit_depth == 16), "Can only handle 8-bit or 16-bit pngs\n")) return false;
+    if (!check((bit_depth == 8) || (bit_depth == 16), "Can only handle 8-bit or 16-bit pngs")) {
+        return false;
+    }
 
     // convert the data to ImageType::ElemType
 
@@ -356,8 +408,7 @@ bool load_png(const std::string &filename, ImageType *im) {
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
 bool save_png(ImageType &im, const std::string &filename) {
 #ifdef HALIDE_NO_PNG
-    check(false, "png not supported in this build\n");
-    return false;
+    return check(false, "png not supported in this build");
 #else // HALIDE_NO_PNG
     using ElemType = typename ImageType::ElemType;
     png_structp png_ptr;
@@ -367,7 +418,9 @@ bool save_png(ImageType &im, const std::string &filename) {
     im.copy_to_host();
 
     if (!check(im.channels() > 0 && im.channels() < 5,
-           "Can't write PNG files that have other than 1, 2, 3, or 4 channels\n")) return false;
+           "Can't write PNG files that have other than 1, 2, 3, or 4 channels")) {
+        return false;
+    }
 
     png_byte color_types[4] = {PNG_COLOR_TYPE_GRAY, PNG_COLOR_TYPE_GRAY_ALPHA,
                                PNG_COLOR_TYPE_RGB,  PNG_COLOR_TYPE_RGB_ALPHA
@@ -375,27 +428,34 @@ bool save_png(ImageType &im, const std::string &filename) {
     color_type = color_types[im.channels() - 1];
 
     // open file
-    Internal::FileOpener f(filename.c_str(), "wb");
-    if (!check(f.f != nullptr, "[write_png_file] File %s could not be opened for writing\n", filename.c_str())) return false;
+    Internal::FileOpener f(filename, "wb");
+    if (!check(f.f != nullptr, "[write_png_file] File %s could not be opened for writing\n", filename.c_str())) {
+        return false;
+    }
 
     // initialize stuff
     png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
-    if (!check(png_ptr != nullptr, "[write_png_file] png_create_write_struct failed\n")) return false;
+    if (!check(png_ptr != nullptr, "[write_png_file] png_create_write_struct failed")) {
+        return false;
+    }
 
     info_ptr = png_create_info_struct(png_ptr);
-    if (!check(info_ptr != nullptr, "[write_png_file] png_create_info_struct failed\n")) return false;
+    if (!check(info_ptr != nullptr, "[write_png_file] png_create_info_struct failed")) {
+        return false;
+    }
 
-    if (!check(!setjmp(png_jmpbuf(png_ptr)), "[write_png_file] Error during init_io\n")) return false;
+    if (!check(!setjmp(png_jmpbuf(png_ptr)), "[write_png_file] Error during init_io")) {
+        return false;
+    }
 
     png_init_io(png_ptr, f.f);
 
-    unsigned int bit_depth = 16;
-    if (sizeof(ElemType) == 1) {
-        bit_depth = 8;
-    }
+    constexpr unsigned int bit_depth = (sizeof(ElemType) == 1) ? 8 : 16;
 
     // write header
-    if (!check(!setjmp(png_jmpbuf(png_ptr)), "[write_png_file] Error during writing header\n")) return false;
+    if (!check(!setjmp(png_jmpbuf(png_ptr)), "[write_png_file] Error during writing header")) {
+        return false;
+    }
 
     png_set_IHDR(png_ptr, info_ptr, im.width(), im.height(),
                  bit_depth, color_type, PNG_INTERLACE_NONE,
@@ -433,18 +493,20 @@ bool save_png(ImageType &im, const std::string &filename) {
                 }
                 srcPtr += x_stride;
             }
-        } else {
-            if (!check(bit_depth == 8 || bit_depth == 16, "We only support saving 8- and 16-bit images.")) return false;
         }
     }
 
     // write data
-    if (!check(!setjmp(png_jmpbuf(png_ptr)), "[write_png_file] Error during writing bytes")) return false;
+    if (!check(!setjmp(png_jmpbuf(png_ptr)), "[write_png_file] Error during writing bytes")) {
+        return false;
+    }
 
     png_write_image(png_ptr, row_pointers.p);
 
     // finish write
-    if (!check(!setjmp(png_jmpbuf(png_ptr)), "[write_png_file] Error during end of write")) return false;
+    if (!check(!setjmp(png_jmpbuf(png_ptr)), "[write_png_file] Error during end of write")) {
+        return false;
+    }
 
     png_write_end(png_ptr, NULL);
 
@@ -459,37 +521,41 @@ bool load_pgm(const std::string &filename, ImageType *im) {
     using ElemType = typename ImageType::ElemType;
 
     /* open file and test for it being a pgm */
-    Internal::FileOpener f(filename.c_str(), "rb");
-    if (!check(f.f != nullptr, "File %s could not be opened for reading\n", filename.c_str())) return false;
+    Internal::FileOpener f(filename, "rb");
+    if (!check(f.f != nullptr, "File %s could not be opened for reading\n", filename.c_str())) {
+        return false;
+    }
 
     int width, height, maxval;
     char header[256];
-    char buf[1024];
     bool fmt_binary = false;
 
-    f.readLine(buf, 1024);
-    if (!check(sscanf(buf, "%255s", header) == 1, "Could not read PGM header\n")) return false;
-    if (header == std::string("P5") || header == std::string("p5"))
+    if (!check(f.scan_line("%255s", header) == 1, "Could not read PGM header")) {
+        return false;
+    }
+    if (header == std::string("P5") || header == std::string("p5")) {
         fmt_binary = true;
-    if (!check(fmt_binary, "Input is not binary PGM\n")) return false;
+    }
+    if (!check(fmt_binary, "Input is not binary PGM")) {
+        return false;
+    }
 
-    f.readLine(buf, 1024);
-    if (!check(sscanf(buf, "%d %d\n", &width, &height) == 2, "Could not read PGM width and height\n")) return false;
-    f.readLine(buf, 1024);
-    if (!check(sscanf(buf, "%d", &maxval) == 1, "Could not read PGM max value\n")) return false;
-
-    int bit_depth = 0;
-    if (maxval == 255) { bit_depth = 8; }
-    else if (maxval == 65535) { bit_depth = 16; }
-    else if (!check(false, "Invalid bit depth in PGM\n")) { return false; }
+    if (!check(f.scan_line("%d %d\n", &width, &height) == 2, "Could not read PGM width and height")) {
+        return false;
+    }
+    if (!check(f.scan_line("%d", &maxval) == 1, "Could not read PGM max value")) {
+        return false;
+    }
 
     // Graymap
     *im = ImageType(width, height);
 
     // convert the data to ImageType::ElemType
-    if (bit_depth == 8) {
+    if (maxval == 255) {
         std::vector<uint8_t> data(width*height);
-        if (!check(fread((void *) &data[0], sizeof(uint8_t), width*height, f.f) == (size_t) (width*height), "Could not read PGM 8-bit data\n")) return false;
+        if (!check(f.read_vector(&data), "Could not read PGM 8-bit data")) {
+            return false;
+        }
         ElemType *im_data = (ElemType*) im->data();
         uint8_t *p = &data[0];
         for (int y = 0; y < height; y++) {
@@ -497,19 +563,22 @@ bool load_pgm(const std::string &filename, ImageType *im) {
                 *im_data++ = Internal::convert<ElemType>(*p++);
             }
         }
-    } else if (bit_depth == 16) {
+    } else if (maxval == 65535) {
         bool little_endian = Internal::is_little_endian();
         std::vector<uint16_t> data(width*height);
-        if (!check(fread((void *) &data[0], sizeof(uint16_t), width*height, f.f) == (size_t) (width*height), "Could not read PGM 16-bit data\n")) return false;
+        if (!check(f.read_vector(&data), "Could not read PGM 16-bit data")) {
+            return false;
+        }
         ElemType *im_data = (ElemType*) im->data();
         uint16_t *p = &data[0];
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
-                uint16_t value = *p++;
-                Internal::swap_endian_16(little_endian, value);
+                uint16_t value = Internal::swap_endian_16(little_endian, *p++);
                 *im_data++ = Internal::convert<ElemType>(value);
             }
         }
+    } else {
+        return check(false, "Invalid bit depth in PGM\n");
     }
     (*im)(0,0,0) = (*im)(0,0,0);      /* Mark dirty inside read/write functions. */
 
@@ -519,18 +588,24 @@ bool load_pgm(const std::string &filename, ImageType *im) {
 // "im" is not const-ref because copy_to_host() is not const.
 // Optional channel parameter for specifying which color to save as a graymap
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
-bool save_pgm(ImageType &im, const std::string &filename, unsigned int channel = 0) {
+bool save_pgm_channel(ImageType &im, const std::string &filename, unsigned int channel) {
     using ElemType = typename ImageType::ElemType;
 
     im.copy_to_host();
 
-    unsigned int bit_depth = sizeof(ElemType) == 1 ? 8: 16;
+    constexpr unsigned int bit_depth = sizeof(ElemType) == 1 ? 8: 16;
     unsigned int num_channels = im.channels();
 
-    if (!check(channel >= 0, "Selected channel %d not available in image\n", channel)) return false;
-    if (!check(channel < num_channels, "Selected channel %d not available in image\n", channel)) return false;
-    Internal::FileOpener f(filename.c_str(), "wb");
-    if (!check(f.f != nullptr, "File %s could not be opened for writing\n", filename.c_str())) return false;
+    if (!check(channel >= 0, "Selected channel %d not available in image\n", channel)) {
+        return false;
+    }
+    if (!check(channel < num_channels, "Selected channel %d not available in image\n", channel)) {
+        return false;
+    }
+    Internal::FileOpener f(filename, "wb");
+    if (!check(f.f != nullptr, "File %s could not be opened for writing\n", filename.c_str())) {
+        return false;
+    }
     fprintf(f.f, "P5\n%d %d\n%d\n", im.width(), im.height(), (1<<bit_depth)-1);
     int width = im.width(), height = im.height();
 
@@ -542,7 +617,9 @@ bool save_pgm(ImageType &im, const std::string &filename, unsigned int channel =
                 *p++ = Internal::convert<uint8_t>(im(x, y, channel));
             }
         }
-        if (!check(fwrite((void *) &data[0], sizeof(uint8_t), width*height, f.f) == (size_t) (width*height), "Could not write PGM 8-bit data\n")) return false;
+        if (!check(f.write_vector(data), "Could not write PGM 8-bit data")) {
+            return false;
+        }
     } else if (bit_depth == 16) {
         bool little_endian = Internal::is_little_endian();
         std::vector<uint16_t> data(width*height);
@@ -550,11 +627,12 @@ bool save_pgm(ImageType &im, const std::string &filename, unsigned int channel =
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
                 uint16_t value = Internal::convert<uint16_t>(im(x, y, channel));
-                Internal::swap_endian_16(little_endian, value);
-                *p++ = value;
+                *p++ = Internal::swap_endian_16(little_endian, value);
             }
         }
-        if (!check(fwrite((void *) &data[0], sizeof(uint16_t), width*height, f.f) == (size_t) (width*height), "Could not write PGM 16-bit data\n")) return false;
+        if (!check(f.write_vector(data), "Could not write PGM 16-bit data")) {
+            return false;
+        }
     } else {
         return check(false, "We only support saving 8- and 16-bit images.");
     }
@@ -562,41 +640,50 @@ bool save_pgm(ImageType &im, const std::string &filename, unsigned int channel =
 }
 
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
+bool save_pgm(ImageType &im, const std::string &filename) {
+    return save_pgm_channel<ImageType, check>(im, filename, /* channel */ 0);
+}
+
+template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
 bool load_ppm(const std::string &filename, ImageType *im) {
     using ElemType = typename ImageType::ElemType;
 
     /* open file and test for it being a ppm */
-    Internal::FileOpener f(filename.c_str(), "rb");
-    if (!check(f.f != nullptr, "File %s could not be opened for reading\n", filename.c_str())) return false;
+    Internal::FileOpener f(filename, "rb");
+    if (!check(f.f != nullptr, "File %s could not be opened for reading\n", filename.c_str())) {
+        return false;
+    }
 
     int width, height, maxval;
     char header[256];
-    char buf[1024];
     bool fmt_binary = false;
 
-    f.readLine(buf, 1024);
-    if (!check(sscanf(buf, "%255s", header) == 1, "Could not read PPM header\n")) return false;
-    if (header == std::string("P6") || header == std::string("p6"))
+    if (!check(f.scan_line("%255s", header) == 1, "Could not read PPM header")) {
+        return false;
+    }
+    if (header == std::string("P6") || header == std::string("p6")) {
         fmt_binary = true;
-    if (!check(fmt_binary, "Input is not binary PPM\n")) return false;
+    }
+    if (!check(fmt_binary, "Input is not binary PPM")) {
+        return false;
+    }
 
-    f.readLine(buf, 1024);
-    if (!check(sscanf(buf, "%d %d\n", &width, &height) == 2, "Could not read PPM width and height\n")) return false;
-    f.readLine(buf, 1024);
-    if (!check(sscanf(buf, "%d", &maxval) == 1, "Could not read PPM max value\n")) return false;
+    if (!check(f.scan_line("%d %d\n", &width, &height) == 2, "Could not read PPM width and height")) {
+        return false;
+    }
+    if (!check(f.scan_line("%d", &maxval) == 1, "Could not read PPM max value")) {
+        return false;
+    }
 
-    int bit_depth = 0;
-    if (maxval == 255) { bit_depth = 8; }
-    else if (maxval == 65535) { bit_depth = 16; }
-    else if (!check(false, "Invalid bit depth in PPM\n")) { return false; }
-
-    int channels = 3;
+    constexpr int channels = 3;
     *im = ImageType(width, height, channels);
 
     // convert the data to ImageType::ElemType
-    if (bit_depth == 8) {
+    if (maxval == 255) {
         std::vector<uint8_t> data(width*height*3);
-        if (!check(fread((void *) &data[0], sizeof(uint8_t), width*height*3, f.f) == (size_t) (width*height*3), "Could not read PPM 8-bit data\n")) return false;
+        if (!check(f.read_vector(&data), "Could not read PPM 8-bit data")) {
+            return false;
+        }
         ElemType *im_data = (ElemType*) im->data();
         uint8_t *row = &data[0];
         for (int y = 0; y < height; y++) {
@@ -606,29 +693,29 @@ bool load_ppm(const std::string &filename, ImageType *im) {
                 im_data[(2*height+y)*width+x] = Internal::convert<ElemType>(*row++);
             }
         }
-    } else if (bit_depth == 16) {
+    } else if (maxval == 65535) {
         bool little_endian = Internal::is_little_endian();
         std::vector<uint16_t> data(width*height*3);
-        if (!check(fread((void *) &data[0], sizeof(uint16_t), width*height*3, f.f) == (size_t) (width*height*3), "Could not read PPM 16-bit data\n")) return false;
+        if (!check(f.read_vector(&data), "Could not read PPM 16-bit data")) {
+            return false;
+        }
         ElemType *im_data = (ElemType*) im->data();
         uint16_t *row = &data[0];
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
                 uint16_t value;
-                value = *row++;
-                Internal::swap_endian_16(little_endian, value);
+                value = Internal::swap_endian_16(little_endian, *row++);
                 im_data[(0*height+y)*width+x] = Internal::convert<ElemType>(value);
-                value = *row++;
-                Internal::swap_endian_16(little_endian, value);
+                value = Internal::swap_endian_16(little_endian, *row++);
                 im_data[(1*height+y)*width+x] = Internal::convert<ElemType>(value);
-                value = *row++;
-                Internal::swap_endian_16(little_endian, value);
+                value = Internal::swap_endian_16(little_endian, *row++);
                 im_data[(2*height+y)*width+x] = Internal::convert<ElemType>(value);
             }
         }
+    } else {
+        return check(false, "Invalid bit depth in PPM.");
     }
     (*im)(0,0,0) = (*im)(0,0,0);      /* Mark dirty inside read/write functions. */
-
     return true;
 }
 
@@ -637,16 +724,22 @@ template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
 bool save_ppm(ImageType &im, const std::string &filename) {
     using ElemType = typename ImageType::ElemType;
 
-    if (!check(im.channels() == 3, "save_ppm() requires a 3-channel image.\n")) { return false; }
+    if (!check(im.channels() == 3, "save_ppm() requires a 3-channel image.\n")) { 
+        return false; 
+    }
 
     im.copy_to_host();
 
-    unsigned int bit_depth = sizeof(ElemType) == 1 ? 8: 16;
+    constexpr unsigned int bit_depth = sizeof(ElemType) == 1 ? 8: 16;
 
-    Internal::FileOpener f(filename.c_str(), "wb");
-    if (!check(f.f != nullptr, "File %s could not be opened for writing\n", filename.c_str())) return false;
+    Internal::FileOpener f(filename, "wb");
+    if (!check(f.f != nullptr, "File %s could not be opened for writing\n", filename.c_str())) {
+        return false;
+    }
     fprintf(f.f, "P6\n%d %d\n%d\n", im.width(), im.height(), (1<<bit_depth)-1);
-    int width = im.width(), height = im.height(), channels = im.channels();
+    int width = im.width();
+    int height = im.height();
+    int channels = im.channels();
 
     if (bit_depth == 8) {
         std::vector<uint8_t> data(width*height*3);
@@ -669,7 +762,9 @@ bool save_ppm(ImageType &im, const std::string &filename) {
                 }
             }
         }
-        if (!check(fwrite((void *) &data[0], sizeof(uint8_t), width*height*3, f.f) == (size_t) (width*height*3), "Could not write PPM 8-bit data\n")) return false;
+        if (!check(f.write_vector(data), "Could not write PPM 8-bit data")) {
+            return false;
+        }
     } else if (bit_depth == 16) {
         bool little_endian = Internal::is_little_endian();
         std::vector<uint16_t> data(width*height*3);
@@ -679,14 +774,11 @@ bool save_ppm(ImageType &im, const std::string &filename) {
             for (int y = 0; y < height; y++) {
                 for (int x = 0; x < width; x++) {
                     uint16_t value0 = Internal::convert<uint16_t>(im(x, y, 0));
-                    Internal::swap_endian_16(little_endian, value0);
-                    *p++ = value0;
+                    *p++ = Internal::swap_endian_16(little_endian, value0);
                     uint16_t value1 = Internal::convert<uint16_t>(im(x, y, 1));
-                    Internal::swap_endian_16(little_endian, value1);
-                    *p++ = value1;
+                    *p++ = Internal::swap_endian_16(little_endian, value1);
                     uint16_t value2 = Internal::convert<uint16_t>(im(x, y, 2));
-                    Internal::swap_endian_16(little_endian, value2);
-                    *p++ = value2;
+                    *p++ = Internal::swap_endian_16(little_endian, value2);
                 }
             }
         } else {
@@ -694,13 +786,14 @@ bool save_ppm(ImageType &im, const std::string &filename) {
                 for (int x = 0; x < width; x++) {
                     for (int c = 0; c < channels; c++) {
                         uint16_t value = Internal::convert<uint16_t>(im(x, y, c));
-                        Internal::swap_endian_16(little_endian, value);
-                        *p++ = value;
+                        *p++ = Internal::swap_endian_16(little_endian, value);
                     }
                 }
             }
         }
-        if (!check(fwrite((void *) &data[0], sizeof(uint16_t), width*height*3, f.f) == (size_t) (width*height*3), "Could not write PPM 16-bit data\n")) return false;
+        if (!check(f.write_vector(data), "Could not write PPM 16-bit data")) {
+            return false;
+        }
     } else {
         return check(false, "We only support saving 8- and 16-bit images.");
     }
@@ -720,21 +813,19 @@ bool save_jpg(ImageType &im, const std::string &filename) {
         channels = im.channels();
     }
 
-    if (!check((im.dimensions() == 2 ||
-                im.dimensions() == 3) &&
-               (channels == 1 ||
-                channels == 3),
+    if (!check((im.dimensions() == 2 || im.dimensions() == 3) &&
+               (channels == 1 || channels == 3),
                "Can only save jpg images with 1 or 3 channels\n")) {
         return false;
     }
 
     // TODO: Make this an argument?
-    const int quality = 99;
+    constexpr int quality = 99;
 
     struct jpeg_compress_struct cinfo;
     struct jpeg_error_mgr jerr;
 
-    Internal::FileOpener f(filename.c_str(), "wb");
+    Internal::FileOpener f(filename, "wb");
     if (!check(f.f != nullptr,
                "File %s could not be opened for writing\n", filename.c_str())) {
         return false;
@@ -759,7 +850,6 @@ bool save_jpg(ImageType &im, const std::string &filename) {
     jpeg_start_compress(&cinfo, TRUE);
 
     std::vector<JSAMPLE> row(im.width() * channels);
-
     for (int y = 0; y < im.height(); y++) {
         JSAMPLE *dst = row.data();
         if (im.dimensions() == 2) {
@@ -795,7 +885,7 @@ bool load_jpg(const std::string &filename, ImageType *im) {
     struct jpeg_decompress_struct cinfo;
     struct jpeg_error_mgr jerr;
 
-    Internal::FileOpener f(filename.c_str(), "rb");
+    Internal::FileOpener f(filename, "rb");
     if (!check(f.f != nullptr,
                "File %s could not be opened for reading\n", filename.c_str())) {
         return false;
@@ -815,7 +905,6 @@ bool load_jpg(const std::string &filename, ImageType *im) {
         *im = ImageType(cinfo.output_width, cinfo.output_height);
     }
     std::vector<JSAMPLE> row(im->width() * channels);
-
     for (int y = 0; y < im->height(); y++) {
         JSAMPLE *src = row.data();
         jpeg_read_scanlines(&cinfo, &src, 1);
@@ -839,38 +928,57 @@ bool load_jpg(const std::string &filename, ImageType *im) {
 #endif
 }
 
+namespace Internal {
+
+template<typename ImageType, Internal::CheckFunc check>
+struct ImageIO {
+    std::function<bool(const std::string &, ImageType *)> load;
+    std::function<bool(ImageType &im, const std::string &)> save;
+};
+
+template<typename ImageType, Internal::CheckFunc check>
+bool find_imageio(const std::string &filename, ImageIO<ImageType, check> *result) {
+    const std::map<std::string, ImageIO<ImageType, check>> m = {
+        {"jpeg", {load_jpg<ImageType, check>, save_jpg<ImageType, check>}},
+        {"jpg", {load_jpg<ImageType, check>, save_jpg<ImageType, check>}},
+        {"pgm", {load_pgm<ImageType, check>, save_pgm<ImageType, check>}},
+        {"png", {load_png<ImageType, check>, save_png<ImageType, check>}},
+        {"ppm", {load_ppm<ImageType, check>, save_ppm<ImageType, check>}}
+    };
+    auto it = m.find(Internal::get_lowercase_extension(filename));
+    if (it != m.end()) {
+        *result = it->second;
+        return true;
+    }
+
+    std::string err = "unsupported file extension, supported are:";
+    for (auto &it : m) {
+        err += " " + it.first;
+    }
+    err += "\n";
+    return check(false, err.c_str());
+}
+
+}  // namespace Internal
 
 // Returns false upon failure.
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
 bool load(const std::string &filename, ImageType *im) {
-    if (Internal::ends_with_ignore_case(filename, ".png")) {
-        return load_png<ImageType, check>(filename, im);
-    } else if (Internal::ends_with_ignore_case(filename, ".jpg") ||
-               Internal::ends_with_ignore_case(filename, ".jpeg")) {
-        return load_jpg<ImageType, check>(filename, im);
-    } else if (Internal::ends_with_ignore_case(filename, ".pgm")) {
-        return load_pgm<ImageType, check>(filename, im);
-    } else if (Internal::ends_with_ignore_case(filename, ".ppm")) {
-        return load_ppm<ImageType, check>(filename, im);
-    } else {
-        return check(false, "[load] unsupported file extension (png|jpg|pgm|ppm supported)");
+    Internal::ImageIO<ImageType, check> imageio;
+    if (!Internal::find_imageio<ImageType, check>(filename, &imageio)) {
+        return false;
     }
+    return imageio.load(filename, im);
 }
+
 // Returns false upon failure.
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
 bool save(ImageType &im, const std::string &filename) {
-    if (Internal::ends_with_ignore_case(filename, ".png")) {
-        return save_png<ImageType, check>(im, filename);
-    } else if (Internal::ends_with_ignore_case(filename, ".jpg") ||
-               Internal::ends_with_ignore_case(filename, ".jpeg")) {
-        return save_jpg<ImageType, check>(im, filename);
-    } else if (Internal::ends_with_ignore_case(filename, ".pgm")) {
-        return save_pgm<ImageType, check>(im, filename);
-    } else if (Internal::ends_with_ignore_case(filename, ".ppm")) {
-        return save_ppm<ImageType, check>(im, filename);
-    } else {
-        return check(false, "[save] unsupported file extension (png|jpg|pgm|ppm supported)");
+    Internal::ImageIO<ImageType, check> imageio;
+    if (!Internal::find_imageio<ImageType, check>(filename, &imageio)) {
+        return false;
     }
+    return imageio.save(im, filename);
 }
 
 // Fancy wrapper to call load() with CheckFail, inferring the return type;


### PR DESCRIPTION
Mostly just stylistic and terseness.

-- change the load and save methods to be table-driven, to simplify future format support additions
-- all if statements are { enclosed in braces}, no single-liners
-- helper methods added to FileOpener to reduce error-prone boilerplate
-- some constant-at-compile-time code restructured to make it more obvious (eg constexpr)
-- swap_endian_16 returns result rather thanout-by-ref

(Side note: do we have any unit tests for PPM and/or PGM?)