### PR TITLE
Add Tools::ImageTypeConversion

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -371,9 +371,7 @@ public:
         return get()->for_each_value(std::forward<Fn>(f), (*std::forward<Args>(other_buffers).get())...); 
     }
 
-    static constexpr bool has_static_halide_type() {
-        return Runtime::Buffer<T>::has_static_halide_type();
-    }
+    static constexpr bool has_static_halide_type = Runtime::Buffer<T>::has_static_halide_type;
 
     static halide_type_t static_halide_type() {
         return Runtime::Buffer<T>::static_halide_type();

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -362,10 +362,14 @@ public:
     HALIDE_BUFFER_FORWARD(device_free)
     HALIDE_BUFFER_FORWARD(fill)
     HALIDE_BUFFER_FORWARD_CONST(for_each_element)
-    HALIDE_BUFFER_FORWARD(for_each_value)
 
 #undef HALIDE_BUFFER_FORWARD
 #undef HALIDE_BUFFER_FORWARD_CONST
+
+    template<typename Fn, typename ...Args>
+    void for_each_value(Fn &&f, Args... other_buffers) {
+        return get()->for_each_value(std::forward<Fn>(f), (*std::forward<Args>(other_buffers).get())...); 
+    }
 
     static constexpr bool has_static_halide_type() {
         return Runtime::Buffer<T>::has_static_halide_type();
@@ -382,6 +386,11 @@ public:
 
     Type type() const {
         return contents->buf.type();
+    }
+
+    template<typename T2>
+    Buffer<T2> as() const {
+        return Buffer<T2>(*this);
     }
 
     Buffer<T> copy() const {

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1291,11 +1291,11 @@ protected:
     friend class ::Halide::Stage;
 
     bool allow_synthetic_generator_params() const override {
-        return !T::has_static_halide_type();
+        return !T::has_static_halide_type;
     }
 
     std::string get_c_type() const override {
-        if (T::has_static_halide_type()) {
+        if (T::has_static_halide_type) {
             return "Halide::Internal::StubInputBuffer<" +
                 halide_type_to_c_type(T::static_halide_type()) +
                 ">";
@@ -1312,17 +1312,17 @@ protected:
 public:
     GeneratorInput_Buffer(const std::string &name)
         : Super(name, IOKind::Buffer,
-                T::has_static_halide_type() ? std::vector<Type>{ T::static_halide_type() } : std::vector<Type>{},
+                T::has_static_halide_type ? std::vector<Type>{ T::static_halide_type() } : std::vector<Type>{},
                 -1) {
     }
 
     GeneratorInput_Buffer(const std::string &name, const Type &t, int d = -1)
         : Super(name, IOKind::Buffer, {t}, d) {
-        static_assert(!T::has_static_halide_type(), "Cannot use pass a Type argument for a Buffer with a non-void static type");
+        static_assert(!T::has_static_halide_type, "Cannot use pass a Type argument for a Buffer with a non-void static type");
     }
 
     GeneratorInput_Buffer(const std::string &name, int d)
-        : Super(name, IOKind::Buffer, T::has_static_halide_type() ? std::vector<Type>{ T::static_halide_type() } : std::vector<Type>{}, d) {
+        : Super(name, IOKind::Buffer, T::has_static_halide_type ? std::vector<Type>{ T::static_halide_type() } : std::vector<Type>{}, d) {
     }
 
 
@@ -1806,15 +1806,15 @@ protected:
 protected:
     GeneratorOutput_Buffer(const std::string &name)
         : Super(name, IOKind::Buffer,
-                T::has_static_halide_type() ? std::vector<Type>{ T::static_halide_type() } : std::vector<Type>{},
+                T::has_static_halide_type ? std::vector<Type>{ T::static_halide_type() } : std::vector<Type>{},
                 -1) {
     }
 
     GeneratorOutput_Buffer(const std::string &name, const std::vector<Type> &t, int d = -1)
         : Super(name, IOKind::Buffer,
-                T::has_static_halide_type() ? std::vector<Type>{ T::static_halide_type() } : t,
+                T::has_static_halide_type ? std::vector<Type>{ T::static_halide_type() } : t,
                 d) {
-        if (T::has_static_halide_type()) {
+        if (T::has_static_halide_type) {
             user_assert(t.empty()) << "Cannot use pass a Type argument for a Buffer with a non-void static type\n";
         } else {
             user_assert(t.size() <= 1) << "Output<Buffer<>>(" << name << ") requires at most one Type, but has " << t.size() << "\n";
@@ -1823,11 +1823,11 @@ protected:
 
     GeneratorOutput_Buffer(const std::string &name, int d)
         : Super(name, IOKind::Buffer, std::vector<Type>{ T::static_halide_type() }, d) {
-        static_assert(T::has_static_halide_type(), "Must pass a Type argument for a Buffer with a static type of void");
+        static_assert(T::has_static_halide_type, "Must pass a Type argument for a Buffer with a static type of void");
     }
 
     NO_INLINE std::string get_c_type() const override {
-        if (T::has_static_halide_type()) {
+        if (T::has_static_halide_type) {
             return "Halide::Internal::StubOutputBuffer<" +
                 halide_type_to_c_type(T::static_halide_type()) +
                 ">";

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -130,13 +130,11 @@ class Buffer {
     using storage_T = typename std::conditional<std::is_pointer<T>::value, uint64_t, not_void_T>::type;
 
 public:
-    /** Return true if the Halide type is not void (or const void). */
-    static constexpr bool has_static_halide_type() {
-        return !T_is_void;
-    }
+    /** True if the Halide type is not void (or const void). */
+    static constexpr bool has_static_halide_type = !T_is_void;
 
     /** Get the Halide type of T. Callers should not use the result if
-     * has_static_halide_type() returns false. */
+     * has_static_halide_type is false. */
     static halide_type_t static_halide_type() {
         return halide_type_of<typename std::remove_cv<not_void_T>::type>();
     }

--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -4,13 +4,14 @@
 
 using namespace Halide;
 
-void test_round_trip(Buffer<uint8_t> buf, std::string format) {
+template<typename T>
+void test_round_trip(Buffer<T> buf, std::string format) {
     // Save it
     std::string filename = Internal::get_test_tmp_dir() + "test." + format;
     Tools::save_image(buf, filename);
 
     // Reload it
-    Buffer<uint8_t> reloaded = Tools::load_image(filename);
+    Buffer<T> reloaded = Tools::load_image(filename);
 
     Tools::save_image(reloaded, Internal::get_test_tmp_dir() + "test_reloaded." + format);
 
@@ -35,14 +36,15 @@ void test_round_trip(Buffer<uint8_t> buf, std::string format) {
 }
 
 // static -> static conversion test
-void test_convert_image_s2s(Buffer<uint8_t> buf) {
-    std::cout << "Testing static -> static image conversion\n";
+template<typename T>
+void test_convert_image_s2s(Buffer<T> buf) {
+    std::cout << "Testing static -> static image conversion for " << halide_type_of<T>() << "\n";
 
     // convert to float
     Buffer<float> buf_float = Tools::ImageTypeConversion::convert_image<float>(buf);
 
-    // convert back to uint8
-    Buffer<uint8_t> buf2 = Tools::ImageTypeConversion::convert_image<uint8_t>(buf_float);
+    // convert back to T
+    Buffer<T> buf2 = Tools::ImageTypeConversion::convert_image<T>(buf_float);
 
     // Check that they match (this conversion should be exact).
     RDom r(buf2);
@@ -55,16 +57,17 @@ void test_convert_image_s2s(Buffer<uint8_t> buf) {
 }
 
 // dynamic -> static conversion test
-void test_convert_image_d2s(Buffer<uint8_t> buf) {
-    std::cout << "Testing dynamic -> static image conversion\n";
+template<typename T>
+void test_convert_image_d2s(Buffer<T> buf) {
+    std::cout << "Testing dynamic -> static image conversion for " << halide_type_of<T>() << "\n";
 
     // convert to float
     Buffer<> buf_d(buf);
     Buffer<float> buf_float = Tools::ImageTypeConversion::convert_image<float>(buf_d);
 
-    // convert back to uint8
+    // convert back to T
     Buffer<> buf_float_d(buf_float);
-    Buffer<uint8_t> buf2 = Tools::ImageTypeConversion::convert_image<uint8_t>(buf_float_d);
+    Buffer<T> buf2 = Tools::ImageTypeConversion::convert_image<T>(buf_float_d);
 
     // Check that they match (this conversion should be exact).
     RDom r(buf2);
@@ -77,18 +80,19 @@ void test_convert_image_d2s(Buffer<uint8_t> buf) {
 }
 
 // static -> dynamic conversion test
-void test_convert_image_s2d(Buffer<uint8_t> buf) {
-    std::cout << "Testing static -> dynamic image conversion\n";
+template<typename T>
+void test_convert_image_s2d(Buffer<T> buf) {
+    std::cout << "Testing static -> dynamic image conversion for " << halide_type_of<T>() << "\n";
 
     // convert to float
     Buffer<> buf_float_d = Tools::ImageTypeConversion::convert_image(buf, halide_type_t(halide_type_float, 32));
     // This will do a runtime check
     Buffer<float> buf_float(buf_float_d);
 
-    // convert back to uint8
-    Buffer<> buf2_d = Tools::ImageTypeConversion::convert_image(buf_float, halide_type_t(halide_type_uint, 8));
+    // convert back to T
+    Buffer<> buf2_d = Tools::ImageTypeConversion::convert_image(buf_float, halide_type_of<T>());
     // This will do a runtime check
-    Buffer<uint8_t> buf2(buf2_d);
+    Buffer<T> buf2(buf2_d);
 
     // Check that they match (this conversion should be exact).
     RDom r(buf2);
@@ -101,18 +105,19 @@ void test_convert_image_s2d(Buffer<uint8_t> buf) {
 }
 
 // dynamic -> dynamic conversion test
+template<typename T>
 void test_convert_image_d2d(Buffer<> buf_d) {
-    std::cout << "Testing dynamic -> dynamic image conversion\n";
+    std::cout << "Testing dynamic -> dynamic image conversion for " << halide_type_of<T>() << "\n";
 
     // convert to float
     Buffer<> buf_float_d = Tools::ImageTypeConversion::convert_image(buf_d, halide_type_t(halide_type_float, 32));
 
-    // convert back to uint8
-    Buffer<> buf2_d = Tools::ImageTypeConversion::convert_image(buf_float_d, halide_type_t(halide_type_uint, 8));
+    // convert back to T
+    Buffer<> buf2_d = Tools::ImageTypeConversion::convert_image(buf_float_d, halide_type_of<T>());
 
     // These will do a runtime check
-    Buffer<uint8_t> buf(buf_d);
-    Buffer<uint8_t> buf2(buf2_d);
+    Buffer<T> buf(buf_d);
+    Buffer<T> buf2(buf2_d);
 
     // Check that they match (this conversion should be exact).
     RDom r(buf2);
@@ -142,23 +147,25 @@ Func make_noise(int depth) {
     return f;
 }
 
-int main(int argc, char **argv) {
+template<typename T>
+void do_test() {
     const int width = 1600;
     const int height = 1200;
 
     // Make some colored noise
     Func f;
     Var x, y, c;
-    f(x, y, c) = cast<uint8_t>(clamp(make_noise(10)(x, y, c), 0.0f, 1.0f) * 255.0f);
+    const float one = std::numeric_limits<T>::max();
+    f(x, y, c) = cast<T>(clamp(make_noise(10)(x, y, c), 0.0f, 1.0f) * one);
 
-    Buffer<uint8_t> color_buf = f.realize(width, height, 3);
+    Buffer<T> color_buf = f.realize(width, height, 3);
 
-    test_convert_image_s2s(color_buf);
-    test_convert_image_s2d(color_buf);
-    test_convert_image_d2s(color_buf);
-    test_convert_image_d2d(color_buf);
+    test_convert_image_s2s<T>(color_buf);
+    test_convert_image_s2d<T>(color_buf);
+    test_convert_image_d2s<T>(color_buf);
+    test_convert_image_d2d<T>(color_buf);
 
-    Buffer<uint8_t> luma_buf(width, height, 1);
+    Buffer<T> luma_buf(width, height, 1);
     luma_buf.copy_from(color_buf);
     luma_buf.slice(2, 0);
 
@@ -170,7 +177,10 @@ int main(int argc, char **argv) {
     formats.push_back("png");
 #endif
     for (std::string format : formats) {
-        std::cout << "Testing format: " << format << "\n";
+        if (format == "jpg" && halide_type_of<T>() != halide_type_t(halide_type_uint, 8)) {
+            continue;
+        }
+        std::cout << "Testing format: " << format << " for " << halide_type_of<T>() << "\n";
         if (format != "pgm") {
             // pgm really only supports gray images.
             test_round_trip(color_buf, format);
@@ -180,5 +190,11 @@ int main(int argc, char **argv) {
             test_round_trip(luma_buf, format);
         }
     }
+}
+
+int main(int argc, char **argv) {
+    do_test<uint8_t>();
+    do_test<uint16_t>();
     return 0;
 }
+

--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -1,11 +1,3 @@
-#ifdef _MSC_VER
-#include <stdio.h>
-int main(int argc, char **argv) {
-    printf("Skipping test on Windows\n");
-    return 0;
-}
-#else
-
 #include "Halide.h"
 #include "halide_image_io.h"
 #include "test/common/halide_test_dirs.h"
@@ -141,8 +133,15 @@ int main(int argc, char **argv) {
     luma_buf.copy_from(color_buf);
     luma_buf.slice(2, 0);
 
-    std::string formats[] = {"jpg", "png", "ppm"};
+    std::vector<std::string> formats = {"ppm"};
+#ifndef HALIDE_NO_JPEG
+    formats.push_back("jpg");
+#endif
+#ifndef HALIDE_NO_PNG
+    formats.push_back("png");
+#endif
     for (std::string format : formats) {
+        std::cout << "Testing format: " << format << "\n";
         test_round_trip(color_buf, format);
         if (format != "ppm") {
             // ppm really only supports RGB images.
@@ -151,5 +150,3 @@ int main(int argc, char **argv) {
     }
     return 0;
 }
-
-#endif

--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -36,6 +36,8 @@ void test_round_trip(Buffer<uint8_t> buf, std::string format) {
 
 // static -> static conversion test
 void test_convert_image_s2s(Buffer<uint8_t> buf) {
+    std::cout << "Testing static -> static image conversion\n";
+
     // convert to float
     Buffer<float> buf_float = Tools::ImageTypeConversion::convert_image<float>(buf);
 
@@ -54,6 +56,8 @@ void test_convert_image_s2s(Buffer<uint8_t> buf) {
 
 // static -> dynamic conversion test
 void test_convert_image_s2d(Buffer<uint8_t> buf) {
+    std::cout << "Testing static -> dynamic image conversion\n";
+
     // convert to float
     Buffer<> buf_float_d = Tools::ImageTypeConversion::convert_image(buf, halide_type_t(halide_type_float, 32));
     // This will do a runtime check
@@ -76,6 +80,8 @@ void test_convert_image_s2d(Buffer<uint8_t> buf) {
 
 // dynamic -> dynamic conversion test
 void test_convert_image_d2d(Buffer<> buf_d) {
+    std::cout << "Testing dynamic -> dynamic image conversion\n";
+
     // convert to float
     Buffer<> buf_float_d = Tools::ImageTypeConversion::convert_image(buf_d, halide_type_t(halide_type_float, 32));
 

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -1021,7 +1021,7 @@ struct ImageTypeConversion {
 
         // Call the appropriate static-to-static conversion routine
         // based on the desired dst type.
-        switch (Internal::halide_type_code(dst_type.code, dst_type.bits)) {
+        switch (Internal::halide_type_code((halide_type_code_t) dst_type.code, dst_type.bits)) {
             case Internal::halide_type_code(halide_type_float, 32): 
                 return convert_image<float>(src);
             case Internal::halide_type_code(halide_type_float, 64): 
@@ -1073,7 +1073,7 @@ struct ImageTypeConversion {
         // and call the static-to-dynamic variant of this method. (Note that
         // this forces instantiation of the complete any-to-any conversion
         // matrix of code.)
-        switch (Internal::halide_type_code(src_type.code, src_type.bits)) {
+        switch (Internal::halide_type_code((halide_type_code_t) src_type.code, src_type.bits)) {
             case Internal::halide_type_code(halide_type_float, 32): 
                 return convert_image(src.template as<float>(), dst_type);
             case Internal::halide_type_code(halide_type_float, 64): 


### PR DESCRIPTION
Add a suite of type-to-type conversion utilities to halide_image_io.h; this is an explicit variant of what is currently done implicitly inside the existing halide_image_io load/save functions, and is intended to allow for more future flexibility in the load/save functions.

