### PR TITLE
Rewrite halide_image_io

### DIFF
--- a/apps/bilateral_grid/filter.cpp
+++ b/apps/bilateral_grid/filter.cpp
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
     float r_sigma = (float) atof(argv[3]);
     int timing_iterations = atoi(argv[4]);
 
-    Buffer<float> input = load_image(argv[1]);
+    Buffer<float> input = load_and_convert_image(argv[1]);
     Buffer<float> output(input.width(), input.height(), 1);
 
     bilateral_grid(input, r_sigma, output);
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
     });
     printf("Time: %gms\n", min_t * 1e3);
 
-    save_image(output, argv[2]);
+    convert_and_save_image(output, argv[2]);
 
     return 0;
 }

--- a/apps/interpolate/interpolate.cpp
+++ b/apps/interpolate/interpolate.cpp
@@ -206,7 +206,7 @@ int main(int argc, char **argv) {
     // JIT compile the pipeline eagerly, so we don't interfere with timing
     normalize.compile_jit(target);
 
-    Buffer<float> in_png = Tools::load_image(argv[1]);
+    Buffer<float> in_png = Tools::load_and_convert_image(argv[1]);
     Buffer<float> out(in_png.width(), in_png.height(), 3);
     assert(in_png.channels() == 4);
     input.set(in_png);
@@ -218,7 +218,7 @@ int main(int argc, char **argv) {
     vector<Argument> args;
     args.push_back(input);
 
-    Tools::save_image(out, argv[2]);
+    Tools::convert_and_save_image(out, argv[2]);
 
     return 0;
 }

--- a/apps/local_laplacian/process.cpp
+++ b/apps/local_laplacian/process.cpp
@@ -17,7 +17,9 @@ int main(int argc, char **argv) {
         return 0;
     }
 
-    Buffer<uint16_t> input = load_image(argv[1]);
+    // Input may be a PNG8
+    Buffer<uint16_t> input = load_and_convert_image(argv[1]);
+
     int levels = atoi(argv[2]);
     float alpha = atof(argv[3]), beta = atof(argv[4]);
     Buffer<uint16_t> output(input.width(), input.height(), 3);

--- a/apps/wavelet/wavelet.cpp
+++ b/apps/wavelet/wavelet.cpp
@@ -33,7 +33,7 @@ T clamp(T x, T min, T max) {
 
 template<typename T>
 void save_untransformed(Buffer<T> t, const std::string& filename) {
-    save_image(t, filename);
+    convert_and_save_image(t, filename);
     printf("Saved %s\n", filename.c_str());
 }
 
@@ -46,7 +46,7 @@ void save_transformed(Buffer<T> t, const std::string& filename) {
             rearranged(x + t.width(), y, 0) = clamp(t(x, y, 1)*4.f + 0.5f, 0.0f, 1.0f);
         }
     }
-    save_image(rearranged, filename);
+    convert_and_save_image(rearranged, filename);
     printf("Saved %s\n", filename.c_str());
 }
 
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
     const std::string src_image = argv[1];
     const std::string dirname = argv[2];
 
-    Buffer<float> input = load_image(src_image);
+    Buffer<float> input = load_and_convert_image(src_image);
     Buffer<float> transformed(input.width()/2, input.height(), 2);
     Buffer<float> inverse_transformed(input.width(), input.height(), 1);
 

--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -7,7 +7,9 @@ using namespace Halide;
 template<typename T>
 void test_round_trip(Buffer<T> buf, std::string format) {
     // Save it
-    std::string filename = Internal::get_test_tmp_dir() + "test." + format;
+    std::ostringstream o;
+    o << Internal::get_test_tmp_dir() << "test_" << halide_type_of<T>() << "x" << buf.channels() << "." << format;
+    std::string filename = o.str();
     Tools::save_image(buf, filename);
 
     // Reload it
@@ -180,12 +182,13 @@ void do_test() {
         if (format == "jpg" && halide_type_of<T>() != halide_type_t(halide_type_uint, 8)) {
             continue;
         }
-        std::cout << "Testing format: " << format << " for " << halide_type_of<T>() << "\n";
         if (format != "pgm") {
+            std::cout << "Testing format: " << format << " for " << halide_type_of<T>() << "x3\n";
             // pgm really only supports gray images.
             test_round_trip(color_buf, format);
         }
         if (format != "ppm") {
+            std::cout << "Testing format: " << format << " for " << halide_type_of<T>() << "x1\n";
             // ppm really only supports RGB images.
             test_round_trip(luma_buf, format);
         }

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -320,14 +320,14 @@ void read_big_endian_row(const uint8_t *src, int y, ImageType *im) {
     const int width = im_typed.width();
     if (im_typed.dimensions() > 2) {
         const int channels = im_typed.channels();
-        for (int x = 0; x < width; x++) {
-            for (int c = 0; c < channels; c++) {
+        for (int x = im_typed.dim(0).min(); x < width; x++) {
+            for (int c = im_typed.dim(2).min(); c < channels; c++) {
                 im_typed(x, y, c) = read_big_endian<ElemType>(src);
                 src += sizeof(ElemType);
             }
         }
     } else {
-        for (int x = 0; x < width; x++) {
+        for (int x = im_typed.dim(0).min(); x < width; x++) {
             im_typed(x, y) = read_big_endian<ElemType>(src);
             src += sizeof(ElemType);
         }
@@ -342,14 +342,14 @@ void write_big_endian_row(const ImageType &im, int y, uint8_t *dst) {
     const int width = im_typed.width();
     if (im_typed.dimensions() > 2) {
         const int channels = im_typed.channels();
-        for (int x = 0; x < width; x++) {
-            for (int c = 0; c < channels; c++) {
+        for (int x = im_typed.dim(0).min(); x < width; x++) {
+            for (int c = im_typed.dim(2).min(); c < channels; c++) {
                 write_big_endian<ElemType>(im_typed(x, y, c), dst);
                 dst += sizeof(ElemType);
             }
         }
     } else {
-        for (int x = 0; x < width; x++) {
+        for (int x = im_typed.dim(0).min(); x < width; x++) {
             write_big_endian<ElemType>(im_typed(x, y), dst);
             dst += sizeof(ElemType);
         }
@@ -415,7 +415,7 @@ bool load_png(const std::string &filename, ImageType *im) {
         Internal::read_big_endian_row<uint16_t, ImageType>;
 
     std::vector<uint8_t> row(png_get_rowbytes(png_ptr, info_ptr));
-    for (int y = 0; y < height; ++y) {
+    for (int y = im->dim(1).min(); y < height; ++y) {
         png_read_row(png_ptr, row.data(), nullptr);
         copy_to_image(row.data(), y, im);
     }
@@ -497,7 +497,7 @@ bool save_png(ImageType &im, const std::string &filename) {
         Internal::write_big_endian_row<uint16_t, ImageType>;
 
     std::vector<uint8_t> row(png_get_rowbytes(png_ptr, info_ptr));
-    for (int y = 0; y < height; ++y) {
+    for (int y = im.dim(1).min(); y < height; ++y) {
         copy_from_image(im, y, row.data());
         png_write_row(png_ptr, row.data());
     }
@@ -567,7 +567,7 @@ bool load_pnm(const std::string &filename, int channels, ImageType *im) {
         Internal::read_big_endian_row<uint16_t, ImageType>;
 
     std::vector<uint8_t> row(width * channels * (bit_depth / 8));
-    for (int y = 0; y < height; ++y) {
+    for (int y = im->dim(1).min(); y < height; ++y) {
         if (!check(f.read_vector(&row), "Could not read data")) {
             return false;
         }
@@ -605,7 +605,7 @@ bool save_pnm(ImageType &im, const int channels, const std::string &filename) {
         Internal::write_big_endian_row<uint16_t, ImageType>;
 
     std::vector<uint8_t> row(width * channels * (bit_depth / 8));
-    for (int y = 0; y < height; ++y) {
+    for (int y = im.dim(1).min(); y < height; ++y) {
         copy_from_image(im, y, row.data());
         if (!check(f.write_vector(row), "Could not write data")) {
             return false;
@@ -686,7 +686,7 @@ bool load_jpg(const std::string &filename, ImageType *im) {
     auto copy_to_image = Internal::read_big_endian_row<uint8_t, ImageType>;
 
     std::vector<uint8_t> row(width * channels);
-    for (int y = 0; y < height; ++y) {
+    for (int y = im->dim(1).min(); y < height; ++y) {
         uint8_t *src = row.data();
         jpeg_read_scanlines(&cinfo, &src, 1);
         copy_to_image(row.data(), y, im);
@@ -743,7 +743,7 @@ bool save_jpg(ImageType &im, const std::string &filename) {
     auto copy_from_image = Internal::write_big_endian_row<uint8_t, ImageType>;
 
     std::vector<uint8_t> row(width * channels);
-    for (int y = 0; y < height; ++y) {
+    for (int y = im.dim(1).min(); y < height; ++y) {
         uint8_t *dst = row.data();
         copy_from_image(im, y, dst);
         jpeg_write_scanlines(&cinfo, &dst, 1);

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <functional>
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -24,24 +25,43 @@
 namespace Halide {
 namespace Tools {
 
+struct FormatInfo {
+    halide_type_t type;
+    int dimensions;
+
+    bool operator<(const FormatInfo &other) const {
+        if (type.code < other.type.code) {
+            return true;
+        } else if (type.code > other.type.code) {
+            return false;
+        }
+        if (type.bits < other.type.bits) {
+            return true;
+        } else if (type.bits > other.type.bits) {
+            return false;
+        }
+        if (type.lanes < other.type.lanes) {
+            return true;
+        } else if (type.lanes > other.type.lanes) {
+            return false;
+        }
+        return (dimensions < other.dimensions);
+    }
+};
+
 namespace Internal {
 
-typedef bool (*CheckFunc)(bool condition, const char* fmt, ...);
+typedef bool (*CheckFunc)(bool condition, const char* msg);
 
-inline bool CheckFail(bool condition, const char* fmt, ...) {
+inline bool CheckFail(bool condition, const char* msg) {
     if (!condition) {
-        char buffer[1024];
-        va_list args;
-        va_start(args, fmt);
-        vsnprintf(buffer, sizeof(buffer), fmt, args);
-        va_end(args);
-        fprintf(stderr, "%s", buffer);
+        fprintf(stderr, "%s\n", msg);
         exit(-1);
     }
     return condition;
 }
 
-inline bool CheckReturn(bool condition, const char* fmt, ...) {
+inline bool CheckReturn(bool condition, const char* msg) {
     return condition;
 }
 
@@ -196,23 +216,45 @@ template<> inline double convert(const int64_t &in) { return convert<double, uin
 template<> inline double convert(const float &in) { return (double) in; }
 template<> inline double convert(const double &in) { return in; }
 
+inline std::string to_lowercase(const std::string &s) {
+    std::string r = s;
+    std::transform(r.begin(), r.end(), r.begin(), ::tolower);
+    return r;
+}
+
 inline std::string get_lowercase_extension(const std::string &path) {
     size_t last_dot = path.rfind('.');
     if (last_dot == std::string::npos) {
         return "";
     }
-    std::string ext = path.substr(last_dot + 1);
-    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-    return ext;
+    return to_lowercase(path.substr(last_dot + 1));
 }
 
-inline bool is_little_endian() {
-    int value = 1;
-    return ((char *) &value)[0] == 1;
+template<typename ElemType>
+ElemType read_big_endian(const uint8_t *src);
+
+template<>
+inline uint8_t read_big_endian(const uint8_t *src) {
+    return *src;
 }
 
-inline uint16_t swap_endian_16(bool little_endian, uint16_t value) {
-    return (little_endian) ? ((value & 0xff)<<8)|((value & 0xff00)>>8) : value;
+template<>
+inline uint16_t read_big_endian(const uint8_t *src) {
+    return (((uint16_t) src[0]) << 8) | ((uint16_t) src[1]);
+}
+
+template<typename ElemType>
+void write_big_endian(const ElemType &src, uint8_t *dst);
+
+template<>
+inline void write_big_endian(const uint8_t &src, uint8_t *dst) {
+    *dst = src;
+}
+
+template<>
+inline void write_big_endian(const uint16_t &src, uint8_t *dst) {
+    dst[0] = src >> 8;
+    dst[1] = src & 0xff;
 }
 
 struct FileOpener {
@@ -270,66 +312,81 @@ struct FileOpener {
     FILE * const f;
 };
 
+// Read a row of ElemTypes from a byte buffer and copy them into a specific image row.
+// Multibyte elements are assumed to be big-endian.
+template<typename ElemType, typename ImageType>
+void read_big_endian_row(const uint8_t *src, int y, ImageType *im) {
+    auto im_typed = im->template as<ElemType>();
+    const int width = im_typed.width();
+    if (im_typed.dimensions() > 2) {
+        const int channels = im_typed.channels();
+        for (int x = 0; x < width; x++) {
+            for (int c = 0; c < channels; c++) {
+                im_typed(x, y, c) = read_big_endian<ElemType>(src);
+                src += sizeof(ElemType);
+            }
+        }
+    } else {
+        for (int x = 0; x < width; x++) {
+            im_typed(x, y) = read_big_endian<ElemType>(src);
+            src += sizeof(ElemType);
+        }
+    }
+}
+
+// Copy a row from an image into a byte buffer.
+// Multibyte elements are written in big-endian layout.
+template<typename ElemType, typename ImageType>
+void write_big_endian_row(const ImageType &im, int y, uint8_t *dst) {
+    auto im_typed = im.template as<ElemType>();
+    const int width = im_typed.width();
+    if (im_typed.dimensions() > 2) {
+        const int channels = im_typed.channels();
+        for (int x = 0; x < width; x++) {
+            for (int c = 0; c < channels; c++) {
+                write_big_endian<ElemType>(im_typed(x, y, c), dst);
+                dst += sizeof(ElemType);
+            }
+        }
+    } else {
+        for (int x = 0; x < width; x++) {
+            write_big_endian<ElemType>(im_typed(x, y), dst);
+            dst += sizeof(ElemType);
+        }
+    }
+}
+
 #ifndef HALIDE_NO_PNG
-struct PngRowPointers {
-    PngRowPointers(int height, int rowbytes) : p(new png_bytep[height]), height(height) {
-        if (p != nullptr) {
-            for (int y = 0; y < height; y++) {
-                p[y] = new png_byte[rowbytes];
-            }
-        }
-    }
-    ~PngRowPointers() {
-        if (p) {
-            for (int y = 0; y < height; y++) {
-                delete[] p[y];
-            }
-            delete[] p;
-        }
-    }
-    png_bytep* const p;
-    int const height;
-};
-#endif // HALIDE_NO_PNG
-
-}  // namespace Internal
-
 
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
 bool load_png(const std::string &filename, ImageType *im) {
-#ifdef HALIDE_NO_PNG
-    return check(false, "png not supported in this build");
-#else // HALIDE_NO_PNG
-    using ElemType = typename ImageType::ElemType;
-    png_byte header[8];
-    png_structp png_ptr;
-    png_infop info_ptr;
+    static_assert(!ImageType::has_static_halide_type, "");
 
     /* open file and test for it being a png */
     Internal::FileOpener f(filename, "rb");
-    if (!check(f.f != nullptr, "File %s could not be opened for reading\n", filename.c_str())) {
+    if (!check(f.f != nullptr, "File could not be opened for reading")) {
         return false;
     }
+    png_byte header[8];
     if (!check(f.read_bytes(header, sizeof(header)), "File ended before end of header")) {
         return false;
     }
-    if (!check(!png_sig_cmp(header, 0, 8), "File %s is not recognized as a PNG file\n", filename.c_str())) {
+    if (!check(!png_sig_cmp(header, 0, 8), "File is not recognized as a PNG file")) {
         return false;
     }
 
     /* initialize stuff */
-    png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
-
+    png_structp png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
     if (!check(png_ptr != nullptr, "png_create_read_struct failed")) {
         return false;
     }
 
-    info_ptr = png_create_info_struct(png_ptr);
+    png_infop info_ptr = png_create_info_struct(png_ptr);
     if (!check(info_ptr != nullptr, "png_create_info_struct failed")) {
         return false;
     }
 
-    if (!check(!setjmp(png_jmpbuf(png_ptr)), "Error during init_io")) {
+    if (!check(!setjmp(png_jmpbuf(png_ptr)), "Error loading PNG")) {
         return false;
     }
 
@@ -338,484 +395,332 @@ bool load_png(const std::string &filename, ImageType *im) {
 
     png_read_info(png_ptr, info_ptr);
 
-    int width = png_get_image_width(png_ptr, info_ptr);
-    int height = png_get_image_height(png_ptr, info_ptr);
-    int channels = png_get_channels(png_ptr, info_ptr);
-    int bit_depth = png_get_bit_depth(png_ptr, info_ptr);
+    const int width = png_get_image_width(png_ptr, info_ptr);
+    const int height = png_get_image_height(png_ptr, info_ptr);
+    const int channels = png_get_channels(png_ptr, info_ptr);
+    const int bit_depth = png_get_bit_depth(png_ptr, info_ptr);
 
-    // Expand low-bpp images to have only 1 pixel per byte (As opposed to tight packing)
-    if (bit_depth < 8) {
-        png_set_packing(png_ptr);
-    }
-
+    const halide_type_t im_type(halide_type_uint, bit_depth);
+    std::vector<int> im_dimensions = { width, height };
     if (channels != 1) {
-        *im = ImageType(width, height, channels);
-    } else {
-        *im = ImageType(width, height);
+        im_dimensions.push_back(channels);
     }
 
-    png_set_interlace_handling(png_ptr);
+    *im = ImageType(im_type, im_dimensions);
+
     png_read_update_info(png_ptr, info_ptr);
 
-    // read the file
-    if (!check(!setjmp(png_jmpbuf(png_ptr)), "Error during read_image")) {
-        return false;
-    }
+    auto copy_to_image = bit_depth == 8 ? 
+        Internal::read_big_endian_row<uint8_t, ImageType> :
+        Internal::read_big_endian_row<uint16_t, ImageType>;
 
-    Internal::PngRowPointers row_pointers(im->height(), png_get_rowbytes(png_ptr, info_ptr));
-    png_read_image(png_ptr, row_pointers.p);
-
-    if (!check((bit_depth == 8) || (bit_depth == 16), "Can only handle 8-bit or 16-bit pngs")) {
-        return false;
-    }
-
-    // convert the data to ImageType::ElemType
-
-    int64_t c_stride = (im->channels() == 1) ? 0 : ((&(*im)(0, 0, 1)) - (&(*im)(0, 0, 0)));
-    ElemType *ptr = (ElemType*)im->data();
-    if (bit_depth == 8) {
-        for (int y = 0; y < im->height(); y++) {
-            uint8_t *srcPtr = (uint8_t *)(row_pointers.p[y]);
-            for (int x = 0; x < im->width(); x++) {
-                for (int c = 0; c < im->channels(); c++) {
-                    ptr[c*c_stride] = Internal::convert<ElemType>(*srcPtr++);
-                }
-                ptr++;
-            }
-        }
-    } else if (bit_depth == 16) {
-        for (int y = 0; y < im->height(); y++) {
-            uint8_t *srcPtr = (uint8_t *)(row_pointers.p[y]);
-            for (int x = 0; x < im->width(); x++) {
-                for (int c = 0; c < im->channels(); c++) {
-                    uint16_t hi = (*srcPtr++) << 8;
-                    uint16_t lo = hi | (*srcPtr++);
-                    ptr[c*c_stride] = Internal::convert<ElemType>(lo);
-                }
-                ptr++;
-            }
-        }
+    std::vector<uint8_t> row(png_get_rowbytes(png_ptr, info_ptr));
+    for (int y = 0; y < height; ++y) {
+        png_read_row(png_ptr, row.data(), nullptr);
+        copy_to_image(row.data(), y, im);
     }
 
     png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
-
     im->set_host_dirty();
+
     return true;
-#endif // HALIDE_NO_PNG
+}
+
+inline const std::set<FormatInfo> &query_png() {
+    static std::set<FormatInfo> info = {
+        { halide_type_t(halide_type_uint, 8), 2 },
+        { halide_type_t(halide_type_uint, 16), 2 },
+        { halide_type_t(halide_type_uint, 8), 3 },
+        { halide_type_t(halide_type_uint, 16), 3 }
+    };
+    return info;
 }
 
 // "im" is not const-ref because copy_to_host() is not const.
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
 bool save_png(ImageType &im, const std::string &filename) {
-#ifdef HALIDE_NO_PNG
-    return check(false, "png not supported in this build");
-#else // HALIDE_NO_PNG
-    using ElemType = typename ImageType::ElemType;
-    png_structp png_ptr;
-    png_infop info_ptr;
-    png_byte color_type;
+    static_assert(!ImageType::has_static_halide_type, "");
 
     im.copy_to_host();
 
-    if (!check(im.channels() > 0 && im.channels() < 5,
+    const int width = im.width();
+    const int height = im.height();
+    const int channels = im.channels();
+
+    if (!check(channels >= 1 && channels <= 4,
            "Can't write PNG files that have other than 1, 2, 3, or 4 channels")) {
         return false;
     }
 
-    png_byte color_types[4] = {PNG_COLOR_TYPE_GRAY, PNG_COLOR_TYPE_GRAY_ALPHA,
-                               PNG_COLOR_TYPE_RGB,  PNG_COLOR_TYPE_RGB_ALPHA
-                              };
-    color_type = color_types[im.channels() - 1];
+    const png_byte color_types[4] = {
+        PNG_COLOR_TYPE_GRAY, 
+        PNG_COLOR_TYPE_GRAY_ALPHA,
+        PNG_COLOR_TYPE_RGB,
+        PNG_COLOR_TYPE_RGB_ALPHA
+    };
+    png_byte color_type = color_types[channels - 1];
 
     // open file
     Internal::FileOpener f(filename, "wb");
-    if (!check(f.f != nullptr, "[write_png_file] File %s could not be opened for writing\n", filename.c_str())) {
+    if (!check(f.f != nullptr, "[write_png_file] File could not be opened for writing")) {
         return false;
     }
 
     // initialize stuff
-    png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+    png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
     if (!check(png_ptr != nullptr, "[write_png_file] png_create_write_struct failed")) {
         return false;
     }
 
-    info_ptr = png_create_info_struct(png_ptr);
+    png_infop info_ptr = png_create_info_struct(png_ptr);
     if (!check(info_ptr != nullptr, "[write_png_file] png_create_info_struct failed")) {
         return false;
     }
 
-    if (!check(!setjmp(png_jmpbuf(png_ptr)), "[write_png_file] Error during init_io")) {
+    if (!check(!setjmp(png_jmpbuf(png_ptr)), "Error saving PNG")) {
         return false;
     }
 
     png_init_io(png_ptr, f.f);
 
-    constexpr unsigned int bit_depth = (sizeof(ElemType) == 1) ? 8 : 16;
+    const halide_type_t im_type = im.type();
+    const int bit_depth = im_type.bits;
 
-    // write header
-    if (!check(!setjmp(png_jmpbuf(png_ptr)), "[write_png_file] Error during writing header")) {
-        return false;
-    }
-
-    png_set_IHDR(png_ptr, info_ptr, im.width(), im.height(),
+    png_set_IHDR(png_ptr, info_ptr, width, height,
                  bit_depth, color_type, PNG_INTERLACE_NONE,
                  PNG_COMPRESSION_TYPE_BASE, PNG_FILTER_TYPE_BASE);
 
     png_write_info(png_ptr, info_ptr);
 
-    Internal::PngRowPointers row_pointers(im.height(), png_get_rowbytes(png_ptr, info_ptr));
+    auto copy_from_image = bit_depth == 8 ? 
+        Internal::write_big_endian_row<uint8_t, ImageType> :
+        Internal::write_big_endian_row<uint16_t, ImageType>;
 
-    // We don't require that the image type provided has any
-    // particular way to get at the strides, so take differences of
-    // addresses of pixels to compute them.
-    int64_t c_stride = (im.channels() == 1) ? 0 : ((&im(0, 0, 1)) - (&im(0, 0, 0)));
-    int64_t x_stride = (int)((&im(1, 0, 0)) - (&im(0, 0, 0)));
-    ElemType *srcPtr = (ElemType*)im.data();
-
-    for (int y = 0; y < im.height(); y++) {
-        uint8_t *dstPtr = (uint8_t *)(row_pointers.p[y]);
-        if (bit_depth == 16) {
-            // convert to uint16_t
-            for (int x = 0; x < im.width(); x++) {
-                for (int c = 0; c < im.channels(); c++) {
-                    uint16_t out = Internal::convert<uint16_t>(srcPtr[c*c_stride]);
-                    *dstPtr++ = out >> 8;
-                    *dstPtr++ = out & 0xff;
-                }
-                srcPtr += x_stride;
-            }
-        } else if (bit_depth == 8) {
-            // convert to uint8_t
-            for (int x = 0; x < im.width(); x++) {
-                for (int c = 0; c < im.channels(); c++) {
-                    uint8_t out = Internal::convert<uint8_t>(srcPtr[c*c_stride]);
-                    *dstPtr++ = out;
-                }
-                srcPtr += x_stride;
-            }
-        }
+    std::vector<uint8_t> row(png_get_rowbytes(png_ptr, info_ptr));
+    for (int y = 0; y < height; ++y) {
+        copy_from_image(im, y, row.data());
+        png_write_row(png_ptr, row.data());
     }
-
-    // write data
-    if (!check(!setjmp(png_jmpbuf(png_ptr)), "[write_png_file] Error during writing bytes")) {
-        return false;
-    }
-
-    png_write_image(png_ptr, row_pointers.p);
-
-    // finish write
-    if (!check(!setjmp(png_jmpbuf(png_ptr)), "[write_png_file] Error during end of write")) {
-        return false;
-    }
-
     png_write_end(png_ptr, NULL);
-
     png_destroy_write_struct(&png_ptr, &info_ptr);
 
     return true;
-#endif // HALIDE_NO_PNG
 }
 
-template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
-bool load_pgm(const std::string &filename, ImageType *im) {
-    using ElemType = typename ImageType::ElemType;
+#endif // not HALIDE_NO_PNG
 
-    /* open file and test for it being a pgm */
-    Internal::FileOpener f(filename, "rb");
-    if (!check(f.f != nullptr, "File %s could not be opened for reading\n", filename.c_str())) {
+template<Internal::CheckFunc check>
+bool read_pnm_header(Internal::FileOpener &f, const std::string &hdr_fmt, int *width, int *height, int *bit_depth) {
+    if (!check(f.f != nullptr, "File could not be opened for reading")) {
         return false;
     }
 
-    int width, height, maxval;
     char header[256];
-    bool fmt_binary = false;
-
-    if (!check(f.scan_line("%255s", header) == 1, "Could not read PGM header")) {
-        return false;
-    }
-    if (header == std::string("P5") || header == std::string("p5")) {
-        fmt_binary = true;
-    }
-    if (!check(fmt_binary, "Input is not binary PGM")) {
+    if (!check(f.scan_line("%255s", header) == 1, "Could not read header")) {
         return false;
     }
 
-    if (!check(f.scan_line("%d %d\n", &width, &height) == 2, "Could not read PGM width and height")) {
-        return false;
-    }
-    if (!check(f.scan_line("%d", &maxval) == 1, "Could not read PGM max value")) {
+    if (!check(to_lowercase(hdr_fmt) == to_lowercase(header), "Unexpected file header")) {
         return false;
     }
 
-    // Graymap
-    *im = ImageType(width, height);
+    if (!check(f.scan_line("%d %d\n", width, height) == 2, "Could not read width and height")) {
+        return false;
+    }
 
-    // convert the data to ImageType::ElemType
+    int maxval;
+    if (!check(f.scan_line("%d", &maxval) == 1, "Could not read max value")) {
+        return false;
+    }
     if (maxval == 255) {
-        std::vector<uint8_t> data(width*height);
-        if (!check(f.read_vector(&data), "Could not read PGM 8-bit data")) {
-            return false;
-        }
-        ElemType *im_data = (ElemType*) im->data();
-        uint8_t *p = &data[0];
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                *im_data++ = Internal::convert<ElemType>(*p++);
-            }
-        }
+        *bit_depth = 8;
     } else if (maxval == 65535) {
-        bool little_endian = Internal::is_little_endian();
-        std::vector<uint16_t> data(width*height);
-        if (!check(f.read_vector(&data), "Could not read PGM 16-bit data")) {
-            return false;
-        }
-        ElemType *im_data = (ElemType*) im->data();
-        uint16_t *p = &data[0];
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                uint16_t value = Internal::swap_endian_16(little_endian, *p++);
-                *im_data++ = Internal::convert<ElemType>(value);
-            }
-        }
+        *bit_depth = 16;
     } else {
-        return check(false, "Invalid bit depth in PGM\n");
+        return check(false, "Invalid bit depth");
     }
-    (*im)(0,0,0) = (*im)(0,0,0);      /* Mark dirty inside read/write functions. */
 
     return true;
 }
 
-// "im" is not const-ref because copy_to_host() is not const.
-// Optional channel parameter for specifying which color to save as a graymap
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
-bool save_pgm_channel(ImageType &im, const std::string &filename, unsigned int channel) {
-    using ElemType = typename ImageType::ElemType;
+bool load_pnm(const std::string &filename, int channels, ImageType *im) {
+    static_assert(!ImageType::has_static_halide_type, "");
 
-    im.copy_to_host();
+    const char *hdr_fmt = channels == 3 ? "P6" : "P5";
 
-    constexpr unsigned int bit_depth = sizeof(ElemType) == 1 ? 8: 16;
-    unsigned int num_channels = im.channels();
-
-    if (!check(channel >= 0, "Selected channel %d not available in image\n", channel)) {
-        return false;
-    }
-    if (!check(channel < num_channels, "Selected channel %d not available in image\n", channel)) {
-        return false;
-    }
-    Internal::FileOpener f(filename, "wb");
-    if (!check(f.f != nullptr, "File %s could not be opened for writing\n", filename.c_str())) {
-        return false;
-    }
-    fprintf(f.f, "P5\n%d %d\n%d\n", im.width(), im.height(), (1<<bit_depth)-1);
-    int width = im.width(), height = im.height();
-
-    if (bit_depth == 8) {
-        std::vector<uint8_t> data(width*height);
-        uint8_t *p = &data[0];
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                *p++ = Internal::convert<uint8_t>(im(x, y, channel));
-            }
-        }
-        if (!check(f.write_vector(data), "Could not write PGM 8-bit data")) {
-            return false;
-        }
-    } else if (bit_depth == 16) {
-        bool little_endian = Internal::is_little_endian();
-        std::vector<uint16_t> data(width*height);
-        uint16_t *p = &data[0];
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                uint16_t value = Internal::convert<uint16_t>(im(x, y, channel));
-                *p++ = Internal::swap_endian_16(little_endian, value);
-            }
-        }
-        if (!check(f.write_vector(data), "Could not write PGM 16-bit data")) {
-            return false;
-        }
-    } else {
-        return check(false, "We only support saving 8- and 16-bit images.");
-    }
-    return true;
-}
-
-template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
-bool save_pgm(ImageType &im, const std::string &filename) {
-    return save_pgm_channel<ImageType, check>(im, filename, /* channel */ 0);
-}
-
-template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
-bool load_ppm(const std::string &filename, ImageType *im) {
-    using ElemType = typename ImageType::ElemType;
-
-    /* open file and test for it being a ppm */
     Internal::FileOpener f(filename, "rb");
-    if (!check(f.f != nullptr, "File %s could not be opened for reading\n", filename.c_str())) {
+    int width, height, bit_depth;
+    if (!Internal::read_pnm_header<check>(f, hdr_fmt, &width, &height, &bit_depth)) {
         return false;
     }
 
-    int width, height, maxval;
-    char header[256];
-    bool fmt_binary = false;
+    const halide_type_t im_type(halide_type_uint, bit_depth);
+    std::vector<int> im_dimensions = { width, height };
+    if (channels > 1) {
+        im_dimensions.push_back(channels);
+    }
+    *im = ImageType(im_type, im_dimensions);
 
-    if (!check(f.scan_line("%255s", header) == 1, "Could not read PPM header")) {
-        return false;
-    }
-    if (header == std::string("P6") || header == std::string("p6")) {
-        fmt_binary = true;
-    }
-    if (!check(fmt_binary, "Input is not binary PPM")) {
-        return false;
-    }
+    auto copy_to_image = bit_depth == 8 ? 
+        Internal::read_big_endian_row<uint8_t, ImageType> :
+        Internal::read_big_endian_row<uint16_t, ImageType>;
 
-    if (!check(f.scan_line("%d %d\n", &width, &height) == 2, "Could not read PPM width and height")) {
-        return false;
-    }
-    if (!check(f.scan_line("%d", &maxval) == 1, "Could not read PPM max value")) {
-        return false;
-    }
-
-    constexpr int channels = 3;
-    *im = ImageType(width, height, channels);
-
-    // convert the data to ImageType::ElemType
-    if (maxval == 255) {
-        std::vector<uint8_t> data(width*height*3);
-        if (!check(f.read_vector(&data), "Could not read PPM 8-bit data")) {
+    std::vector<uint8_t> row(width * channels * (bit_depth / 8));
+    for (int y = 0; y < height; ++y) {
+        if (!check(f.read_vector(&row), "Could not read data")) {
             return false;
         }
-        ElemType *im_data = (ElemType*) im->data();
-        uint8_t *row = &data[0];
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                im_data[(0*height+y)*width+x] = Internal::convert<ElemType>(*row++);
-                im_data[(1*height+y)*width+x] = Internal::convert<ElemType>(*row++);
-                im_data[(2*height+y)*width+x] = Internal::convert<ElemType>(*row++);
-            }
-        }
-    } else if (maxval == 65535) {
-        bool little_endian = Internal::is_little_endian();
-        std::vector<uint16_t> data(width*height*3);
-        if (!check(f.read_vector(&data), "Could not read PPM 16-bit data")) {
-            return false;
-        }
-        ElemType *im_data = (ElemType*) im->data();
-        uint16_t *row = &data[0];
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                uint16_t value;
-                value = Internal::swap_endian_16(little_endian, *row++);
-                im_data[(0*height+y)*width+x] = Internal::convert<ElemType>(value);
-                value = Internal::swap_endian_16(little_endian, *row++);
-                im_data[(1*height+y)*width+x] = Internal::convert<ElemType>(value);
-                value = Internal::swap_endian_16(little_endian, *row++);
-                im_data[(2*height+y)*width+x] = Internal::convert<ElemType>(value);
-            }
-        }
-    } else {
-        return check(false, "Invalid bit depth in PPM.");
+        copy_to_image(row.data(), y, im);
     }
-    (*im)(0,0,0) = (*im)(0,0,0);      /* Mark dirty inside read/write functions. */
+    im->set_host_dirty();
+
     return true;
 }
 
-// "im" is not const-ref because copy_to_host() is not const.
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
-bool save_ppm(ImageType &im, const std::string &filename) {
-    using ElemType = typename ImageType::ElemType;
+bool save_pnm(ImageType &im, const int channels, const std::string &filename) {
+    static_assert(!ImageType::has_static_halide_type, "");
 
-    if (!check(im.channels() == 3, "save_ppm() requires a 3-channel image.\n")) { 
+    if (!check(im.channels() == channels, "Wrong number of channels")) { 
         return false; 
     }
 
     im.copy_to_host();
 
-    constexpr unsigned int bit_depth = sizeof(ElemType) == 1 ? 8: 16;
+    const halide_type_t im_type = im.type();
+    const int width = im.width();
+    const int height = im.height();
+    const int bit_depth = im_type.bits;
 
     Internal::FileOpener f(filename, "wb");
-    if (!check(f.f != nullptr, "File %s could not be opened for writing\n", filename.c_str())) {
+    if (!check(f.f != nullptr, "File could not be opened for writing")) {
         return false;
     }
-    fprintf(f.f, "P6\n%d %d\n%d\n", im.width(), im.height(), (1<<bit_depth)-1);
-    int width = im.width();
-    int height = im.height();
-    int channels = im.channels();
+    const char *hdr_fmt = channels == 3 ? "P6" : "P5";
+    fprintf(f.f, "%s\n%d %d\n%d\n", hdr_fmt, width, height, (1<<bit_depth)-1);
 
-    if (bit_depth == 8) {
-        std::vector<uint8_t> data(width*height*3);
-        uint8_t *p = &data[0];
-        // unroll inner loop for 3 channel RGB (common case)
-        if (channels == 3) {
-            for (int y = 0; y < height; y++) {
-                for (int x = 0; x < width; x++) {
-                    *p++ = Internal::convert<uint8_t>(im(x, y, 0));
-                    *p++ = Internal::convert<uint8_t>(im(x, y, 1));
-                    *p++ = Internal::convert<uint8_t>(im(x, y, 2));
-                }
-            }
-        } else {
-            for (int y = 0; y < height; y++) {
-                for (int x = 0; x < width; x++) {
-                    for (int c = 0; c < channels; c++) {
-                        *p++ = Internal::convert<uint8_t>(im(x, y, c));
-                    }
-                }
-            }
-        }
-        if (!check(f.write_vector(data), "Could not write PPM 8-bit data")) {
+    auto copy_from_image = bit_depth == 8 ? 
+        Internal::write_big_endian_row<uint8_t, ImageType> :
+        Internal::write_big_endian_row<uint16_t, ImageType>;
+
+    std::vector<uint8_t> row(width * channels * (bit_depth / 8));
+    for (int y = 0; y < height; ++y) {
+        copy_from_image(im, y, row.data());
+        if (!check(f.write_vector(row), "Could not write data")) {
             return false;
         }
-    } else if (bit_depth == 16) {
-        bool little_endian = Internal::is_little_endian();
-        std::vector<uint16_t> data(width*height*3);
-        uint16_t *p = &data[0];
-        // unroll inner loop for 3 channel RGB (common case)
-        if (channels == 3) {
-            for (int y = 0; y < height; y++) {
-                for (int x = 0; x < width; x++) {
-                    uint16_t value0 = Internal::convert<uint16_t>(im(x, y, 0));
-                    *p++ = Internal::swap_endian_16(little_endian, value0);
-                    uint16_t value1 = Internal::convert<uint16_t>(im(x, y, 1));
-                    *p++ = Internal::swap_endian_16(little_endian, value1);
-                    uint16_t value2 = Internal::convert<uint16_t>(im(x, y, 2));
-                    *p++ = Internal::swap_endian_16(little_endian, value2);
-                }
-            }
-        } else {
-            for (int y = 0; y < height; y++) {
-                for (int x = 0; x < width; x++) {
-                    for (int c = 0; c < channels; c++) {
-                        uint16_t value = Internal::convert<uint16_t>(im(x, y, c));
-                        *p++ = Internal::swap_endian_16(little_endian, value);
-                    }
-                }
-            }
-        }
-        if (!check(f.write_vector(data), "Could not write PPM 16-bit data")) {
-            return false;
-        }
-    } else {
-        return check(false, "We only support saving 8- and 16-bit images.");
     }
+
     return true;
 }
 
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
-bool save_jpg(ImageType &im, const std::string &filename) {
-#ifdef HALIDE_NO_JPEG
-    check(false, "jpg not supported in this build\n");
-    return false;
-#else
-    im.copy_to_host();
+bool load_pgm(const std::string &filename, ImageType *im) {
+    return Internal::load_pnm<ImageType, check>(filename, 1, im);
+}
 
-    int channels = 1;
-    if (im.dimensions() == 3) {
-        channels = im.channels();
+inline const std::set<FormatInfo> &query_pgm() {
+    static std::set<FormatInfo> info = {
+        { halide_type_t(halide_type_uint, 8), 2 },
+        { halide_type_t(halide_type_uint, 16), 2 }
+    };
+    return info;
+}
+
+// "im" is not const-ref because copy_to_host() is not const.
+template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
+bool save_pgm(ImageType &im, const std::string &filename) {
+    return Internal::save_pnm<ImageType, check>(im, 1, filename);
+}
+
+template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
+bool load_ppm(const std::string &filename, ImageType *im) {
+    return Internal::load_pnm<ImageType, check>(filename, 3, im);
+}
+
+inline const std::set<FormatInfo> &query_ppm() {
+    static std::set<FormatInfo> info = {
+        { halide_type_t(halide_type_uint, 8), 3 },
+        { halide_type_t(halide_type_uint, 16), 3 }
+    };
+    return info;
+}
+
+// "im" is not const-ref because copy_to_host() is not const.
+template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
+bool save_ppm(ImageType &im, const std::string &filename) {
+    return Internal::save_pnm<ImageType, check>(im, 3, filename);
+}
+
+#ifndef HALIDE_NO_JPEG
+
+template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
+bool load_jpg(const std::string &filename, ImageType *im) {
+    static_assert(!ImageType::has_static_halide_type, "");
+
+    Internal::FileOpener f(filename, "rb");
+    if (!check(f.f != nullptr, "File could not be opened for reading")) {
+        return false;
     }
 
-    if (!check((im.dimensions() == 2 || im.dimensions() == 3) &&
-               (channels == 1 || channels == 3),
-               "Can only save jpg images with 1 or 3 channels\n")) {
+    struct jpeg_decompress_struct cinfo;
+    struct jpeg_error_mgr jerr;
+    cinfo.err = jpeg_std_error(&jerr);
+    jpeg_create_decompress(&cinfo);
+    jpeg_stdio_src(&cinfo, f.f);
+    jpeg_read_header(&cinfo, TRUE);
+    jpeg_start_decompress(&cinfo);
+
+    const int width = cinfo.output_width;
+    const int height = cinfo.output_height;
+    const int channels = cinfo.output_components;
+
+    const halide_type_t im_type(halide_type_uint, 8);
+    std::vector<int> im_dimensions = { width, height };
+    if (channels > 1) {
+        im_dimensions.push_back(channels);
+    }
+    *im = ImageType(im_type, im_dimensions);
+
+    auto copy_to_image = Internal::read_big_endian_row<uint8_t, ImageType>;
+
+    std::vector<uint8_t> row(width * channels);
+    for (int y = 0; y < height; ++y) {
+        uint8_t *src = row.data();
+        jpeg_read_scanlines(&cinfo, &src, 1);
+        copy_to_image(row.data(), y, im);
+    }
+
+    jpeg_finish_decompress(&cinfo);
+    jpeg_destroy_decompress(&cinfo);
+
+    return true;
+}
+
+inline const std::set<FormatInfo> &query_jpg() {
+    static std::set<FormatInfo> info = {
+        { halide_type_t(halide_type_uint, 8), 2 },
+        { halide_type_t(halide_type_uint, 8), 3 },
+    };
+    return info;
+}
+
+template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
+bool save_jpg(ImageType &im, const std::string &filename) {
+    static_assert(!ImageType::has_static_halide_type, "");
+
+    im.copy_to_host();
+
+    const int width = im.width();
+    const int height = im.height();
+    const int channels = im.channels();
+    if (!check(channels == 1 || channels == 3, "Wrong number of channels")) {
+        return false;
+    }
+
+    Internal::FileOpener f(filename, "wb");
+    if (!check(f.f != nullptr, "File could not be opened for writing")) {
         return false;
     }
 
@@ -824,134 +729,64 @@ bool save_jpg(ImageType &im, const std::string &filename) {
 
     struct jpeg_compress_struct cinfo;
     struct jpeg_error_mgr jerr;
-
-    Internal::FileOpener f(filename, "wb");
-    if (!check(f.f != nullptr,
-               "File %s could not be opened for writing\n", filename.c_str())) {
-        return false;
-    }
-
     cinfo.err = jpeg_std_error(&jerr);
     jpeg_create_compress(&cinfo);
     jpeg_stdio_dest(&cinfo, f.f);
-
-    cinfo.image_width = im.width();
-    cinfo.image_height = im.height();
+    cinfo.image_width = width;
+    cinfo.image_height = height;
     cinfo.input_components = channels;
-    if (channels == 3) {
-        cinfo.in_color_space = JCS_RGB;
-    } else { // channels must be 1
-        cinfo.in_color_space = JCS_GRAYSCALE;
-    }
-
+    cinfo.in_color_space = (channels == 3) ? JCS_RGB : JCS_GRAYSCALE;
     jpeg_set_defaults(&cinfo);
     jpeg_set_quality(&cinfo, quality, TRUE);
-
     jpeg_start_compress(&cinfo, TRUE);
 
-    std::vector<JSAMPLE> row(im.width() * channels);
-    for (int y = 0; y < im.height(); y++) {
-        JSAMPLE *dst = row.data();
-        if (im.dimensions() == 2) {
-            for (int x = 0; x < im.width(); x++) {
-                *dst++ = Internal::convert<JSAMPLE>(im(x, y));
-            }
-        } else {
-            for (int x = 0; x < im.width(); x++) {
-                for (int c = 0; c < channels; c++) {
-                    *dst++ = Internal::convert<JSAMPLE>(im(x, y, c));
-                }
-            }
-        }
-        JSAMPROW row_ptr = row.data();
-        jpeg_write_scanlines(&cinfo, &row_ptr, 1);
+    auto copy_from_image = Internal::write_big_endian_row<uint8_t, ImageType>;
+
+    std::vector<uint8_t> row(width * channels);
+    for (int y = 0; y < height; ++y) {
+        uint8_t *dst = row.data();
+        copy_from_image(im, y, dst);
+        jpeg_write_scanlines(&cinfo, &dst, 1);
     }
 
     jpeg_finish_compress(&cinfo);
     jpeg_destroy_compress(&cinfo);
 
     return true;
-#endif
 }
 
-template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
-bool load_jpg(const std::string &filename, ImageType *im) {
-#ifdef HALIDE_NO_JPEG
-    check(false, "jpg not supported in this build\n");
-    return false;
-#else
-    using ElemType = typename ImageType::ElemType;
-
-    struct jpeg_decompress_struct cinfo;
-    struct jpeg_error_mgr jerr;
-
-    Internal::FileOpener f(filename, "rb");
-    if (!check(f.f != nullptr,
-               "File %s could not be opened for reading\n", filename.c_str())) {
-        return false;
-    }
-
-    cinfo.err = jpeg_std_error(&jerr);
-    jpeg_create_decompress(&cinfo);
-    jpeg_stdio_src(&cinfo, f.f);
-
-    jpeg_read_header(&cinfo, TRUE);
-    jpeg_start_decompress(&cinfo);
-
-    int channels = cinfo.output_components;
-    if (channels > 1) {
-        *im = ImageType(cinfo.output_width, cinfo.output_height, channels);
-    } else {
-        *im = ImageType(cinfo.output_width, cinfo.output_height);
-    }
-    std::vector<JSAMPLE> row(im->width() * channels);
-    for (int y = 0; y < im->height(); y++) {
-        JSAMPLE *src = row.data();
-        jpeg_read_scanlines(&cinfo, &src, 1);
-        if (channels > 1) {
-            for (int x = 0; x < im->width(); x++) {
-                for (int c = 0; c < channels; c++) {
-                    (*im)(x, y, c) = Internal::convert<ElemType>(*src++);
-                }
-            }
-        } else {
-            for (int x = 0; x < im->width(); x++) {
-                (*im)(x, y) = Internal::convert<ElemType>(*src++);
-            }
-        }
-    }
-
-    jpeg_finish_decompress(&cinfo);
-    jpeg_destroy_decompress(&cinfo);
-
-    return true;
-#endif
-}
-
-namespace Internal {
+#endif  // not HALIDE_NO_JPEG
 
 template<typename ImageType, Internal::CheckFunc check>
 struct ImageIO {
     std::function<bool(const std::string &, ImageType *)> load;
     std::function<bool(ImageType &im, const std::string &)> save;
+    std::function<const std::set<FormatInfo>&()> query;
 };
 
 template<typename ImageType, Internal::CheckFunc check>
 bool find_imageio(const std::string &filename, ImageIO<ImageType, check> *result) {
+    static_assert(!ImageType::has_static_halide_type, "");
+
     const std::map<std::string, ImageIO<ImageType, check>> m = {
-        {"jpeg", {load_jpg<ImageType, check>, save_jpg<ImageType, check>}},
-        {"jpg", {load_jpg<ImageType, check>, save_jpg<ImageType, check>}},
-        {"pgm", {load_pgm<ImageType, check>, save_pgm<ImageType, check>}},
-        {"png", {load_png<ImageType, check>, save_png<ImageType, check>}},
-        {"ppm", {load_ppm<ImageType, check>, save_ppm<ImageType, check>}}
+#ifndef HALIDE_NO_JPEG
+        {"jpeg", {load_jpg<ImageType, check>, save_jpg<ImageType, check>, query_jpg}},
+        {"jpg", {load_jpg<ImageType, check>, save_jpg<ImageType, check>, query_jpg}},
+#endif
+        {"pgm", {load_pgm<ImageType, check>, save_pgm<ImageType, check>, query_pgm}},
+#ifndef HALIDE_NO_PNG
+        {"png", {load_png<ImageType, check>, save_png<ImageType, check>, query_png}},
+#endif
+        {"ppm", {load_ppm<ImageType, check>, save_ppm<ImageType, check>, query_ppm}}
     };
-    auto it = m.find(Internal::get_lowercase_extension(filename));
+    std::string ext = Internal::get_lowercase_extension(filename);
+    auto it = m.find(ext);
     if (it != m.end()) {
         *result = it->second;
         return true;
     }
 
-    std::string err = "unsupported file extension, supported are:";
+    std::string err = "unsupported file extension \"" + ext + "\", supported are:";
     for (auto &it : m) {
         err += " " + it.first;
     }
@@ -968,6 +803,32 @@ struct ImageTypeWithElemType {
 // Must be constexpr to allow use in case clauses.
 inline constexpr int halide_type_code(halide_type_code_t code, int bits) {
     return (((int) code) << 8) | bits;
+}
+
+template<typename ImageType>
+FormatInfo best_save_format(const ImageType &im, const std::set<FormatInfo> &info) {
+    // A bit ad hoc, but will do for now:
+    // Perfect score is zero (exact match).
+    // The larger the score, the worse the match.
+    int best_score = 0x7fffffff;
+    FormatInfo best{};
+    const halide_type_t im_type = im.type();
+    const int im_dimensions = im.dimensions();
+    for (auto &f : info) {
+        int score = 0;
+        // If format has too-few dimensions, that's very bad.
+        score += std::abs(f.dimensions - im_dimensions) * 128;
+        // If format has too-few bits, that's pretty bad.
+        score += std::abs(f.type.bits - im_type.bits);
+        // If format has different code, that's a little bad.
+        score += (f.type.code != im_type.code) ? 1 : 0;
+        if (score < best_score) {
+            best_score = score;
+            best = f;
+        }
+    }
+
+    return best;
 }
 
 }  // namespace Internal
@@ -1144,24 +1005,66 @@ struct ImageTypeConversion {
     }
 };
 
+// Load the Image from the given file.
+// If output Image has a static type, and the loaded image cannot be stored
+// in such an image without losing data, fail.
 // Returns false upon failure.
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
 bool load(const std::string &filename, ImageType *im) {
-    Internal::ImageIO<ImageType, check> imageio;
-    if (!Internal::find_imageio<ImageType, check>(filename, &imageio)) {
+    using DynamicImageType = typename Internal::ImageTypeWithElemType<ImageType, void>::type;
+    Internal::ImageIO<DynamicImageType, check> imageio;
+    if (!Internal::find_imageio<DynamicImageType, check>(filename, &imageio)) {
         return false;
     }
-    return imageio.load(filename, im);
+    using DynamicImageType = typename Internal::ImageTypeWithElemType<ImageType, void>::type;
+    DynamicImageType im_d;
+    if (!imageio.load(filename, &im_d)) {
+        return false;
+    }
+    // Allow statically-typed images to be passed as the out-param, but do
+    // a runtime check to ensure
+    if (ImageType::has_static_halide_type) {
+        const halide_type_t expected_type = ImageType::static_halide_type();
+        if (!check(im_d.type() == expected_type, "Image loaded did not match the expected type")) {
+            return false;
+        }
+    }
+    *im = im_d.template as<typename ImageType::ElemType>();
+    return true;
 }
 
+// Save the Image in the format associated with the filename's extension.
+// If the format can't represent the Image without losing data, fail.
 // Returns false upon failure.
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
 bool save(ImageType &im, const std::string &filename) {
-    Internal::ImageIO<ImageType, check> imageio;
-    if (!Internal::find_imageio<ImageType, check>(filename, &imageio)) {
+    using DynamicImageType = typename Internal::ImageTypeWithElemType<ImageType, void>::type;
+    Internal::ImageIO<DynamicImageType, check> imageio;
+    if (!Internal::find_imageio<DynamicImageType, check>(filename, &imageio)) {
         return false;
     }
-    return imageio.save(im, filename);
+    if (!check(imageio.query().count({im.type(), im.dimensions()}), "Image cannot be saved in this format")) {
+        return false;
+    }
+
+    // Allow statically-typed images to be passed in, but quietly pass them on
+    // as dynamically-typed images.
+    auto im_d = im.template as<void>();
+    return imageio.save(im_d, filename);
+}
+
+// Return a set of FormatInfo structs that contain the legal type-and-dimensions
+// that can be saved in this format. Most applications won't ever need to use
+// this call. Returns false upon failure.
+template<typename ImageType, Internal::CheckFunc check = Internal::CheckReturn>
+bool save_query(const std::string &filename, std::set<FormatInfo> *info) {
+    using DynamicImageType = typename Internal::ImageTypeWithElemType<ImageType, void>::type;
+    Internal::ImageIO<DynamicImageType, check> imageio;
+    if (!Internal::find_imageio<DynamicImageType, check>(filename, &imageio)) {
+        return false;
+    }
+    *info = imageio.query();
+    return true;
 }
 
 // Fancy wrapper to call load() with CheckFail, inferring the return type;
@@ -1170,15 +1073,44 @@ bool save(ImageType &im, const std::string &filename) {
 //    Image im = load_image("filename");
 //
 // without bothering to check error results (all errors simply abort).
+//
+// Note that if the image being loaded doesn't match the static type and 
+// dimensions of of the image on the LHS, a runtime error will occur.
 class load_image {
 public:
     load_image(const std::string &f) : filename(f) {}
+
+    template<typename ImageType>
+    operator ImageType() {
+        using DynamicImageType = typename Internal::ImageTypeWithElemType<ImageType, void>::type;
+        DynamicImageType im_d;
+        (void) load<DynamicImageType, Internal::CheckFail>(filename, &im_d);
+        return im_d.template as<typename ImageType::ElemType>();
+    }
+
+private:
+  const std::string filename;
+};
+
+// Like load_image, but quietly convert the loaded image to the type of the LHS
+// if necessary, discarding information if necessary.
+class load_and_convert_image {
+public:
+    load_and_convert_image(const std::string &f) : filename(f) {}
+
     template<typename ImageType>
     inline operator ImageType() {
-        ImageType im;
-        (void) load<ImageType, Internal::CheckFail>(filename, &im);
-        return im;
+        using DynamicImageType = typename Internal::ImageTypeWithElemType<ImageType, void>::type;
+        DynamicImageType im_d;
+        (void) load<DynamicImageType, Internal::CheckFail>(filename, &im_d);
+        const halide_type_t expected_type = ImageType::static_halide_type();
+        if (im_d.type() == expected_type) {
+            return im_d.template as<typename ImageType::ElemType>();
+        } else {
+            return ImageTypeConversion::convert_image<typename ImageType::ElemType>(im_d);
+        }
     }
+
 private:
   const std::string filename;
 };
@@ -1188,9 +1120,31 @@ private:
 //    save_image(im, "filename");
 //
 // without bothering to check error results (all errors simply abort).
-template<typename ImageType>
+//
+// If the specified image file format cannot represent the image without
+// losing data (e.g, a float32 or 4-dimensional image saved as a JPEG),
+// a runtime error will occur.
+template<typename ImageType, Internal::CheckFunc check = Internal::CheckFail>
 void save_image(ImageType &im, const std::string &filename) {
-    (void) save<ImageType, Internal::CheckFail>(im, filename);
+    (void) save<ImageType, check>(im, filename);
+}
+
+// Like save_image, but quietly convert the saved image to a type that the 
+// specified image file format can hold, discarding information if necessary.
+// (Note that the input image is unaffected!)
+template<typename ImageType, Internal::CheckFunc check = Internal::CheckFail>
+void convert_and_save_image(ImageType &im, const std::string &filename) {
+    std::set<FormatInfo> info;
+    (void) save_query<ImageType, check>(filename, &info);
+    const FormatInfo best = Internal::best_save_format(im, info);
+    if (best.type == im.type() && best.dimensions == im.dimensions()) {
+        // It's an exact match, we can save as-is.
+        (void) save<ImageType, check>(im, filename);
+    } else {
+        using DynamicImageType = typename Internal::ImageTypeWithElemType<ImageType, void>::type;
+        DynamicImageType im_converted = ImageTypeConversion::convert_image(im, best.type);
+        (void) save<DynamicImageType, check>(im_converted, filename);
+    }
 }
 
 }  // namespace Tools


### PR DESCRIPTION
This is a fairly substantial rewrite of halide_image_io.

Previously, every load and save function did its best to satisfy the request: if the loaded file wasn't the type we needed, we quietly converted on the fly; similarly, if the saved format didn't support the type we used, we quietly converted on the fly. In both cases, we blithely discarded data without warning.

This changes the existing API to assume that Data Loss Is Bad, and thus, the existing load()/save()/load_image()/save_image() calls now fail if data loss is possible:

-- When loading, if the Buffer being loaded into has a static data type, we fail at runtime if that data type can't exactly represent the source file (e.g., loading a 16-bit PNG into Buffer<uint8_t>, or even an 8-bit PNG into a Buffer<uint16_t>); we don't attempt to do *any* conversion automatically, even "safe" conversions.

-- When saving, if the file format being saved into cannot represent the source Buffer's data type exactly, we fail at runtime (e.g., saving Buffer<uint16_t> to JPG, or Buffer<float> to PNG). Again, we don't attempt to do *any* conversions.

-- load_and_convert_image() and convert_and_save_image() have been added as a convenient interface to use ImageTypeConversion::convert_image() automatically when necessary. (The intent here is that data conversions during file operations should be explicit on the part of the coder.)

As part of this, I ended up basically rewriting much of the internals of the file, removing a lot of redundancy and preferring to use Buffer APIs directly rather than pointer manipulation. (Benchmarking showed a small performance penalty vs dancing on the buffers directly, but not by much.)





