### PR TITLE
Fix Buffer<>::embedded()

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1172,11 +1172,7 @@ public:
     Buffer<T, D> embedded(int d, int pos) const {
         assert(d >= 0 && d <= dimensions());
         Buffer<T, D> im(*this);
-        im.add_dimension();
-        im.translate(im.dimensions() - 1, pos);
-        for (int i = im.dimensions(); i > d; i--) {
-            im.transpose();
-        }
+        im.embed(d, pos);
         return im;
     }
 


### PR DESCRIPTION
It made an illegal call to transpose() with no args. Mimic slice/sliced() and just call embed() instead.