### PR TITLE
Travis: remove Makefile+HALIDE_SHARED_LIBRARY=1 combination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ env:
   # Each line in the ``env`` section represents a set of environment
   # variables passed to a build configuration
   #
-  # Test a mix of llvm versions, a mix of build systems, and a mix of shared vs static library
+  # Test a mix of llvm versions and a mix of build systems.
+  # Note that the Make build ignores the HALIDE_SHARED_LIBRARY option.
   # Don't build as a static library with cmake. It risks exceeding the travis memory limit.
   - LLVM_VERSION=3.7.1 BUILD_SYSTEM=MAKE CXX_=g++-4.8 CC_=gcc-4.8
   - LLVM_VERSION=3.8.1 BUILD_SYSTEM=MAKE CXX_=g++-4.8 CC_=gcc-4.8
-  - LLVM_VERSION=3.7.1 BUILD_SYSTEM=MAKE CXX_=g++-4.8 CC_=gcc-4.8 HALIDE_SHARED_LIBRARY=1
   - LLVM_VERSION=3.8.1 BUILD_SYSTEM=CMAKE CXX_=g++-4.8 CC_=gcc-4.8 HALIDE_SHARED_LIBRARY=1
 cache: apt
 # Note the commands below are written assuming Ubuntu 12.04LTS


### PR DESCRIPTION
AFAICT, the Makefile build completely ignores this symbol, so this step is 100% redundant.