### PR TITLE
Move test/generator externs into separate libs (vs aot_test code)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -110,11 +110,12 @@ include(../HalideGenerator.cmake)
 #   halide_define_aot_test(NAME <basename>
 #                       [GENERATED_FUNCTION <function name, including namespace]
 #                       [GENERATOR_HALIDE_TARGET Halide target, if not "host"]
-#                       [GENERATOR_ARGS extra generator args])
+#                       [GENERATOR_ARGS extra generator args]
+#                       [FILTER_DEPS extra libraries to be linked with AOT output])
 function(halide_define_aot_test NAME)
   set(options OMIT_DEFAULT_GENERATOR)
   set(oneValueArgs GENERATED_FUNCTION GENERATOR_NAME GENERATOR_HALIDE_TARGET)
-  set(multiValueArgs GENERATOR_ARGS STUB_DEPS)
+  set(multiValueArgs GENERATOR_ARGS STUB_DEPS FILTER_DEPS)
   cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   set(TARGET "generator_aot_${NAME}")
@@ -156,6 +157,10 @@ function(halide_define_aot_test NAME)
                            GENERATOR_ARGS "target=${args_GENERATOR_HALIDE_TARGET}" "${args_GENERATOR_ARGS}")
     halide_add_aot_library_dependency("${TARGET}" "${AOT_LIBRARY_TARGET}")
   endif()
+
+  foreach(F ${args_FILTER_DEPS})
+    target_link_libraries("${TARGET}" PRIVATE ${F})
+  endforeach()
 
 endfunction(halide_define_aot_test)
 
@@ -268,9 +273,17 @@ if (WITH_TEST_GENERATORS)
   halide_define_aot_test(user_context_insanity
                          GENERATOR_HALIDE_TARGET host-user_context)
 
+  add_library(cxx_mangling_externs 
+              "${CMAKE_CURRENT_SOURCE_DIR}/generator/cxx_mangling_externs.cpp")
+  if (NOT MSVC)
+    target_compile_options(cxx_mangling_externs PUBLIC "-std=c++11")
+  endif()
+
   halide_define_aot_test(cxx_mangling
                          GENERATOR_HALIDE_TARGET host-c_plus_plus_name_mangling
-                         GENERATED_FUNCTION HalideTest::AnotherNamespace::cxx_mangling)
+                         GENERATED_FUNCTION HalideTest::AnotherNamespace::cxx_mangling
+                         FILTER_DEPS cxx_mangling_externs)
+
   if (TARGET_PTX)
     halide_add_aot_test_dependency(cxx_mangling
                                  AOT_LIBRARY_TARGET cxx_mangling_gpu
@@ -332,9 +345,17 @@ if (WITH_TEST_GENERATORS)
                                  GENERATOR_TARGET blur2x2
                                  AOT_LIBRARY_TARGET blur2x2)
 
+  add_library(cxx_mangling_define_extern_externs 
+              "${CMAKE_CURRENT_SOURCE_DIR}/generator/cxx_mangling_define_extern_externs.cpp")
+  if (NOT MSVC)
+    target_compile_options(cxx_mangling_define_extern_externs PUBLIC "-std=c++11")
+  endif()
+  halide_add_aot_library_dependency(cxx_mangling_define_extern_externs cxx_mangling)
+
   halide_define_aot_test(cxx_mangling_define_extern
                          GENERATOR_HALIDE_TARGET host-c_plus_plus_name_mangling-user_context
-                         GENERATED_FUNCTION HalideTest::cxx_mangling_define_extern)
+                         GENERATED_FUNCTION HalideTest::cxx_mangling_define_extern
+                         FILTER_DEPS cxx_mangling_externs cxx_mangling_define_extern_externs)
   # The cxx_mangling library was already defined implicitly, above,
   # so just add a dependency on it
   halide_add_aot_library_dependency(generator_aot_cxx_mangling_define_extern cxx_mangling)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -350,6 +350,7 @@ if (WITH_TEST_GENERATORS)
   if (NOT MSVC)
     target_compile_options(cxx_mangling_define_extern_externs PUBLIC "-std=c++11")
   endif()
+  target_link_libraries(cxx_mangling_define_extern_externs PRIVATE cxx_mangling_externs)
   halide_add_aot_library_dependency(cxx_mangling_define_extern_externs cxx_mangling)
 
   halide_define_aot_test(cxx_mangling_define_extern

--- a/test/generator/cxx_mangling_aottest.cpp
+++ b/test/generator/cxx_mangling_aottest.cpp
@@ -10,19 +10,6 @@
 
 using namespace Halide::Runtime;
 
-int32_t extract_value_global(int32_t *arg) {
-    return *arg;
-}
-
-namespace HalideTest {
-
-int32_t extract_value_ns(const int32_t *arg) {
-    return *arg;
-}
-
-}
-
-
 namespace my_namespace {
 class my_class {public: int foo;};
 namespace my_subnamespace {

--- a/test/generator/cxx_mangling_define_extern_aottest.cpp
+++ b/test/generator/cxx_mangling_define_extern_aottest.cpp
@@ -7,37 +7,8 @@
 #include <string.h>
 
 #include "cxx_mangling_define_extern.h"
-#include "cxx_mangling.h"
 
 using namespace Halide::Runtime;
-
-int32_t extract_value_global(int32_t *arg) {
-    return *arg;
-}
-
-namespace HalideTest {
-
-int32_t extract_value_ns(const int32_t *arg) {
-    return *arg;
-}
-
-}
-
-namespace HalideTest {
-
-int cxx_mangling_1(void *ctx, halide_buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, halide_buffer_t *_f_buffer) {
-    return AnotherNamespace::cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, nullptr, nullptr, nullptr, _f_buffer);
-}
-
-int cxx_mangling_2(void *ctx, halide_buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, halide_buffer_t *_f_buffer) {
-    return AnotherNamespace::cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, nullptr, nullptr, nullptr, _f_buffer);
-}
-
-extern "C" int cxx_mangling_3(void *ctx, halide_buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, halide_buffer_t *_f_buffer) {
-    return AnotherNamespace::cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, nullptr, nullptr, nullptr, _f_buffer);
-}
-
-};
 
 int main(int argc, char **argv) {
     Buffer<uint8_t> input(100);

--- a/test/generator/cxx_mangling_define_extern_externs.cpp
+++ b/test/generator/cxx_mangling_define_extern_externs.cpp
@@ -1,0 +1,20 @@
+#include <cstdint>
+
+#include "cxx_mangling.h"
+
+// These are the define_extern functions referenced by cxx_mangling_define_extern_generator.cpp
+namespace HalideTest {
+
+int cxx_mangling_1(void *ctx, halide_buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, halide_buffer_t *_f_buffer) {
+    return AnotherNamespace::cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, nullptr, nullptr, nullptr, _f_buffer);
+}
+
+int cxx_mangling_2(void *ctx, halide_buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, halide_buffer_t *_f_buffer) {
+    return AnotherNamespace::cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, nullptr, nullptr, nullptr, _f_buffer);
+}
+
+extern "C" int cxx_mangling_3(void *ctx, halide_buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, halide_buffer_t *_f_buffer) {
+    return AnotherNamespace::cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, nullptr, nullptr, nullptr, _f_buffer);
+}
+
+};

--- a/test/generator/cxx_mangling_externs.cpp
+++ b/test/generator/cxx_mangling_externs.cpp
@@ -1,0 +1,15 @@
+#include <cstdint>
+
+// These are the HalideExtern functions referenced by cxx_mangling_generator.cpp
+int32_t extract_value_global(int32_t *arg) {
+    return *arg;
+}
+
+namespace HalideTest {
+
+int32_t extract_value_ns(const int32_t *arg) {
+    return *arg;
+}
+
+}
+


### PR DESCRIPTION
This makes it tractable to use Generators-with-extern-deps with the RunGen tool.