### PR TITLE
Rework RunGetStubs mechanism to be C++-name-mangling-friendly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -865,7 +865,6 @@ test_aotcpp_generators: $(GENERATOR_AOTCPP_TESTS)
 # not all will work directly (e.g. due to missing define_externs at link time), so we blacklist
 # those known to be broken for plausible reasons.
 GENERATOR_BUILD_RUNGEN_TESTS = $(GENERATOR_EXTERNAL_TEST_GENERATORS:$(ROOT_DIR)/test/generator/%_generator.cpp=$(FILTERS_DIR)/%.rungen)
-GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/cxx_mangling.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))
 GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/cxx_mangling_define_extern.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))
 GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/define_extern_opencl.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))
 GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/matlab.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))
@@ -1248,8 +1247,8 @@ $(BUILD_DIR)/RunGen.o: $(ROOT_DIR)/tools/RunGen.cpp $(RUNTIME_EXPORTED_INCLUDES)
 	@mkdir -p $(BUILD_DIR)
 	$(CXX) -c $< $(TEST_CXX_FLAGS) $(IMAGE_IO_CXX_FLAGS) -I$(INCLUDE_DIR) -I $(SRC_DIR)/runtime -I$(ROOT_DIR)/tools -o $@
 
-$(FILTERS_DIR)/%.rungen: $(BUILD_DIR)/RunGen.o $(BIN_DIR)/$(TARGET)/runtime.a $(ROOT_DIR)/tools/RunGenStubs.cpp $(FILTERS_DIR)/%.a 
-	$(CXX) -DHL_RUNGEN_FILTER=$* $^ $(TEST_LD_FLAGS) $(IMAGE_IO_LIBS) -o $@
+$(FILTERS_DIR)/%.rungen: $(BUILD_DIR)/RunGen.o $(BIN_DIR)/$(TARGET)/runtime.a $(ROOT_DIR)/tools/RunGenStubs.cpp $(FILTERS_DIR)/%.a
+	$(CXX) -std=c++11 -DHL_RUNGEN_FILTER_HEADER=\"$*.h\" -I$(FILTERS_DIR) $^ $(TEST_LD_FLAGS) $(IMAGE_IO_LIBS) -o $@
 
 RUNARGS ?=
 

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1583,6 +1583,23 @@ void CodeGen_C::compile(const LoweredFunc &f) {
         }
         stream << "\n";
     }
+
+    if (is_header() && f.linkage == LoweredFunc::ExternalPlusMetadata) {
+        // C syntax for function-that-returns-function-pointer is fun.
+        const string getter = R"INLINE_CODE(
+#ifdef HALIDE_GET_STANDARD_ARGV_FUNCTION
+inline int (*HALIDE_GET_STANDARD_ARGV_FUNCTION())(void**) {
+    return $NAME$_argv;
+}
+#endif
+#ifdef HALIDE_GET_STANDARD_METADATA_FUNCTION
+inline const struct halide_filter_metadata_t* (*HALIDE_GET_STANDARD_METADATA_FUNCTION())() {
+    return $NAME$_metadata;
+}
+#endif
+)INLINE_CODE";
+        stream << replace_all(getter, "$NAME$", f.name) << "\n\n";
+    }
 }
 
 void CodeGen_C::compile(const Buffer<> &buffer) {

--- a/tools/RunGenStubs.cpp
+++ b/tools/RunGenStubs.cpp
@@ -1,20 +1,17 @@
-#ifndef HL_RUNGEN_FILTER
-    #error "You must define HL_RUNGEN_FILTER"
+#define HALIDE_GET_STANDARD_ARGV_FUNCTION halide_rungen_redirect_argv_getter
+#define HALIDE_GET_STANDARD_METADATA_FUNCTION halide_rungen_redirect_metadata_getter
+
+#ifndef HL_RUNGEN_FILTER_HEADER
+    #error "You must define HL_RUNGEN_FILTER_HEADER"
 #endif
 
-#define HL_RUNGEN_NAME__(prefix, suffix) prefix##suffix
-#define HL_RUNGEN_NAME_(prefix, suffix) HL_RUNGEN_NAME__(prefix, suffix)
-#define HL_RUNGEN_NAME(suffix) HL_RUNGEN_NAME_(HL_RUNGEN_FILTER, suffix)
-
-struct halide_filter_metadata_t;
-
-extern "C" int HL_RUNGEN_NAME(_argv)(void **args);
-extern "C" const struct halide_filter_metadata_t *HL_RUNGEN_NAME(_metadata)();
+// This is legal C, as long as the macro expands to a single quoted (or <>-enclosed) string literal
+#include HL_RUNGEN_FILTER_HEADER
 
 extern "C" int halide_rungen_redirect_argv(void **args) {
-    return HL_RUNGEN_NAME(_argv)(args);
+    return halide_rungen_redirect_argv_getter()(args);
 }
 
 extern "C" const struct halide_filter_metadata_t *halide_rungen_redirect_metadata() {
-    return HL_RUNGEN_NAME(_metadata)();
+    return halide_rungen_redirect_metadata_getter()();
 }


### PR DESCRIPTION
Emitting a namespaced call in a way that is easy to both forward-declare and call properly is a bit painful; instead, have the header generation code emit optional getters for the argv and metadata function.  Enable the cxx_mangling test rungen as proof of concept.