### PR TITLE
Use CMake 3.1x's standard for requesting C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 project(Halide)
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1.3)
 
 find_package(LLVM REQUIRED CONFIG)
 
@@ -9,6 +9,11 @@ message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+# Require C++11 for everything.
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_MACOSX_RPATH ON)
 
@@ -96,7 +101,6 @@ function(halide_project name folder)
   add_executable("${name}" ${ARGN})
   if (MSVC)
   else()
-    target_compile_options("${name}" PUBLIC "-std=c++11") # Halide clients need C++11
     target_compile_options("${name}" PUBLIC "-fno-rtti")
   endif()
   target_link_libraries("${name}" PRIVATE Halide)

--- a/apps/bilateral_grid/CMakeLists.txt
+++ b/apps/bilateral_grid/CMakeLists.txt
@@ -9,4 +9,3 @@ halide_add_aot_library(bilateral_grid
 add_executable(filter filter.cpp)
 halide_add_aot_library_dependency(filter bilateral_grid)
 use_image_io(filter)
-target_compile_options(filter PRIVATE "-std=c++11")

--- a/apps/blur/CMakeLists.txt
+++ b/apps/blur/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(blur_test test.cpp)
 halide_add_aot_library_dependency(blur_test halide_blur)
 
 if (NOT MSVC)
-  target_compile_options(blur_test PRIVATE "-std=c++11" "-O2" "-msse2")
+  target_compile_options(blur_test PRIVATE "-O2" "-msse2")
   if (OPENMP_FOUND)
     target_compile_options(blur_test PRIVATE ${OpenMP_CXX_FLAGS})
     target_link_libraries(blur_test PRIVATE ${OpenMP_CXX_FLAGS})

--- a/apps/c_backend/CMakeLists.txt
+++ b/apps/c_backend/CMakeLists.txt
@@ -3,7 +3,6 @@ function(halide_add_aot_cpp_dependency TARGET AOT_LIBRARY_TARGET)
     add_dependencies("${TARGET}" "${AOT_LIBRARY_TARGET}.exec_generator")
 
     add_library(${AOT_LIBRARY_TARGET}.cpplib STATIC "${GENFILES_DIR}/${AOT_LIBRARY_TARGET}.cpp")
-    target_compile_options(${AOT_LIBRARY_TARGET}.cpplib PRIVATE "-std=c++11")
     target_link_libraries("${TARGET}" PRIVATE ${AOT_LIBRARY_TARGET}.cpplib)
     target_include_directories("${TARGET}" PRIVATE "${GENFILES_DIR}")
 endfunction(halide_add_aot_cpp_dependency)
@@ -38,12 +37,10 @@ halide_add_aot_library(pipeline_cpp_native
 
 # Final executable(s)
 add_executable(run_c_backend_and_native run.cpp)
-target_compile_options(run_c_backend_and_native PRIVATE "-std=c++11")
 halide_add_aot_cpp_dependency(run_c_backend_and_native pipeline_c)
 halide_add_aot_library_dependency(run_c_backend_and_native pipeline_native)
 
 add_executable(run_c_backend_and_native_cpp run_cpp.cpp)
-target_compile_options(run_c_backend_and_native_cpp PRIVATE "-std=c++11")
 halide_add_aot_cpp_dependency(run_c_backend_and_native_cpp pipeline_cpp_cpp)
 halide_add_aot_library_dependency(run_c_backend_and_native_cpp pipeline_cpp_native)
 

--- a/apps/camera_pipe/CMakeLists.txt
+++ b/apps/camera_pipe/CMakeLists.txt
@@ -12,9 +12,6 @@ FIND_PACKAGE(OpenMP)
 if (OPENMP_FOUND)
   target_compile_options(fcam PUBLIC "-fopenmp")
 endif()
-if (NOT MSVC)
-  target_compile_options(fcam PRIVATE "-std=c++11")
-endif()
 
 # Final executable
 add_executable(process process.cpp)
@@ -23,7 +20,7 @@ target_link_libraries(process PRIVATE ${curved_lib} fcam)
 use_image_io(process)
 
 if (NOT MSVC)
-  target_compile_options(process PRIVATE "-std=c++11" "-O2" "-msse2")
+  target_compile_options(process PRIVATE "-O2" "-msse2")
   if (OPENMP_FOUND)
     target_compile_options(process PRIVATE ${OpenMP_CXX_FLAGS})
     target_link_libraries(process PRIVATE ${OpenMP_CXX_FLAGS})

--- a/apps/glsl/CMakeLists.txt
+++ b/apps/glsl/CMakeLists.txt
@@ -19,7 +19,6 @@ if (OpenGL_FOUND)
     add_executable(opengl_test opengl_test.cpp)
     halide_add_aot_library_dependency(opengl_test halide_blur_glsl)
     halide_add_aot_library_dependency(opengl_test halide_ycc_glsl)
-    target_compile_options(opengl_test PRIVATE "-std=c++11")
 
     if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
         target_link_libraries(opengl_test PRIVATE pthread dl X11 GL)

--- a/apps/linear_algebra/benchmarks/CMakeLists.txt
+++ b/apps/linear_algebra/benchmarks/CMakeLists.txt
@@ -31,7 +31,6 @@ endif()
 add_executable(halide_benchmarks halide_benchmarks.cpp)
 target_include_directories(halide_benchmarks PRIVATE ${halide_blas_INCLUDE_DIRS})
 target_compile_definitions(halide_benchmarks PRIVATE -DUSE_HALIDE ${MISC_DEFINITIONS})
-target_compile_options(halide_benchmarks PRIVATE -std=c++11)
 target_link_libraries(halide_benchmarks PRIVATE halide_blas)
 list(APPEND BLAS_NAMES halide)
 
@@ -43,7 +42,7 @@ if (Eigen3_FOUND)
     eigen_benchmarks.cpp
   )
   target_compile_definitions(eigen_benchmarks PRIVATE -DEIGEN_DONT_PARALLELIZE ${MISC_DEFINITIONS})
-  target_compile_options(eigen_benchmarks PRIVATE -std=c++11 -Wno-error=unused-variable)
+  target_compile_options(eigen_benchmarks PRIVATE -Wno-error=unused-variable)
   target_link_libraries(eigen_benchmarks
     PRIVATE
       Eigen3::Eigen
@@ -66,7 +65,7 @@ else()
     )
     string(TOUPPER ${BLAS_VENDOR} DEFINE_SUFFIX)
     target_compile_definitions(${TARGET} PRIVATE -DUSE_${DEFINE_SUFFIX} ${MISC_DEFINITIONS})
-    target_compile_options(${TARGET} PRIVATE -std=c++11 -Wno-error=unused-variable)
+    target_compile_options(${TARGET} PRIVATE -Wno-error=unused-variable)
     target_link_libraries(${TARGET}
       PRIVATE
        ${BLAS_${NAME}_LIBRARY}

--- a/apps/linear_algebra/src/CMakeLists.txt
+++ b/apps/linear_algebra/src/CMakeLists.txt
@@ -7,7 +7,6 @@ halide_add_generator(blas_l3.generator SRCS blas_l3_generators.cpp)
 add_library(halide_blas
   halide_blas.cpp
 )
-target_compile_options(halide_blas PRIVATE -std=c++11)
 
 set(GENERATOR_OUTPUTS h static_library)
 set(GENERATOR_TARGET host-no_asserts-no_bounds_query)

--- a/apps/local_laplacian/CMakeLists.txt
+++ b/apps/local_laplacian/CMakeLists.txt
@@ -9,4 +9,3 @@ halide_add_aot_library(local_laplacian
 add_executable(ll_process process.cpp)
 halide_add_aot_library_dependency(ll_process local_laplacian)
 use_image_io(ll_process)
-target_compile_options(ll_process PRIVATE "-std=c++11")

--- a/apps/wavelet/CMakeLists.txt
+++ b/apps/wavelet/CMakeLists.txt
@@ -21,7 +21,7 @@ include_directories("${HALIDE_SRC_DIR}/include")
 include_directories("${HALIDE_SRC_DIR}/tools")
 
 add_executable(wavelet "${CMAKE_CURRENT_SOURCE_DIR}/wavelet.cpp")
-target_compile_options(wavelet PRIVATE "-std=c++11" "-fno-rtti")
+target_compile_options(wavelet PRIVATE "-fno-rtti")
 
 find_package(PNG)
 target_link_libraries(wavelet PRIVATE ${PNG_LIBRARIES})
@@ -42,7 +42,7 @@ foreach(GEN_SRC ${GENS})
     # GEN_EXECUTABLE := *.generator
     string(REPLACE "_generator.cpp" "" GEN_EXECUTABLE "${GEN_SRC}.generator")
     add_executable("${GEN_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/GenGen.cpp" "${GEN_SRC}")
-    target_compile_options("${GEN_EXECUTABLE}" PRIVATE "-std=c++11" "-fno-rtti")
+    target_compile_options("${GEN_EXECUTABLE}" PRIVATE "-fno-rtti")
     target_link_libraries("${GEN_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libHalide.a" z)
 
     halide_add_aot_library("${GEN_NAME}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -631,7 +631,6 @@ if (MSVC)
     target_compile_options(Halide PRIVATE "/Zc:sizedDealloc-")
   endif()
 else()
-  target_compile_options(Halide PUBLIC "-std=c++11") # Halide and its clients need to use C++11
   target_compile_options(Halide PUBLIC "-fno-rtti")
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -121,10 +121,6 @@ function(halide_define_aot_test NAME)
   set(TARGET "generator_aot_${NAME}")
 
   add_executable("${TARGET}" "${CMAKE_CURRENT_SOURCE_DIR}/generator/${NAME}_aottest.cpp")
-  if (MSVC)
-  else()
-    target_compile_options("${TARGET}" PUBLIC "-std=c++11") # HalideBuffer.h needs C++11
-  endif()
   target_include_directories("${TARGET}" PRIVATE "${CMAKE_SOURCE_DIR}/tools")
   target_include_directories("${TARGET}" PRIVATE "${CMAKE_SOURCE_DIR}/src/runtime")
   target_include_directories("${TARGET}" PRIVATE "${CMAKE_SOURCE_DIR}")
@@ -275,9 +271,6 @@ if (WITH_TEST_GENERATORS)
 
   add_library(cxx_mangling_externs 
               "${CMAKE_CURRENT_SOURCE_DIR}/generator/cxx_mangling_externs.cpp")
-  if (NOT MSVC)
-    target_compile_options(cxx_mangling_externs PUBLIC "-std=c++11")
-  endif()
 
   halide_define_aot_test(cxx_mangling
                          GENERATOR_HALIDE_TARGET host-c_plus_plus_name_mangling
@@ -347,9 +340,6 @@ if (WITH_TEST_GENERATORS)
 
   add_library(cxx_mangling_define_extern_externs 
               "${CMAKE_CURRENT_SOURCE_DIR}/generator/cxx_mangling_define_extern_externs.cpp")
-  if (NOT MSVC)
-    target_compile_options(cxx_mangling_define_extern_externs PUBLIC "-std=c++11")
-  endif()
   target_link_libraries(cxx_mangling_define_extern_externs PRIVATE cxx_mangling_externs)
   halide_add_aot_library_dependency(cxx_mangling_define_extern_externs cxx_mangling)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -11,6 +11,5 @@ target_compile_definitions(HalideToolsRunGen PUBLIC "-D_CRT_SECURE_NO_WARNINGS" 
 use_image_io(HalideToolsRunGen)
 if (MSVC)
 else()
-  target_compile_options(HalideToolsRunGen PUBLIC "-std=c++11") # Halide clients need C++11
   target_compile_options(HalideToolsRunGen PUBLIC "-fno-rtti")
 endif()

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -81,10 +81,6 @@ if (BUILD_AOT_TUTORIAL)
   target_include_directories(lesson_10_aot_compilation_run PRIVATE "${FILTER_DIR}")
   # Needed to find HalideBuffer.h
   target_include_directories(lesson_10_aot_compilation_run PRIVATE "${CMAKE_BINARY_DIR}/include")
-  # HalideBuffer.h requires C++11
-  if (NOT MSVC)
-    target_compile_options(lesson_10_aot_compilation_run PUBLIC "-std=c++11")
-  endif()
 
   if (NOT WIN32)
     target_link_libraries(lesson_10_aot_compilation_run PRIVATE dl pthread)


### PR DESCRIPTION
...rather than the scattered -std=c++11 (bracketed with MSVC checks) we used before. Note that this increases the CMake min version to 3.1.3.