### PR TITLE
Buffer::copy and Buffer::make_with_shape_of need to forward optional …

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -963,7 +963,7 @@ public:
      * original, with holes compacted away. */
     Buffer<T, D> copy(void *(*allocate_fn)(size_t) = nullptr,
                       void (*deallocate_fn)(void *) = nullptr) const {
-        Buffer<T, D> dst = make_with_shape_of(*this);
+        Buffer<T, D> dst = make_with_shape_of(*this, allocate_fn, deallocate_fn);
         dst.copy_from(*this);
         return dst;
     }
@@ -1420,7 +1420,7 @@ public:
         }
 
         Buffer<T, D> dst(nullptr, src.dimensions(), shape);
-        dst.allocate();
+        dst.allocate(allocate_fn, deallocate_fn);
 
         return dst;
     }


### PR DESCRIPTION
…allocate/deallocate fn args