### PR TITLE
Added print_loop_nest() to the supported calls on Generator outputs

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1648,6 +1648,7 @@ public:
     HALIDE_OUTPUT_FORWARD_CONST(outputs)
     HALIDE_OUTPUT_FORWARD(parallel)
     HALIDE_OUTPUT_FORWARD(prefetch)
+    HALIDE_OUTPUT_FORWARD(print_loop_nest)
     HALIDE_OUTPUT_FORWARD(rename)
     HALIDE_OUTPUT_FORWARD(reorder)
     HALIDE_OUTPUT_FORWARD(reorder_storage)


### PR DESCRIPTION
I don't know whether it was an intentional decision to not enable "print_loop_nest()" on Generator outputs, but it seemed like an oversight.