### PR TITLE
Give extern stages a Var::outermost loop

### DIFF
--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -76,6 +76,12 @@ EXPORT bool is_two(const Expr &e);
  * undefined Stmt, or as an Evaluate node of a constant) */
 EXPORT bool is_no_op(const Stmt &s);
 
+/** Does the expression
+ * 1) Take on the same value no matter where it appears in a Stmt, and
+ * 2) Evaluating it has no side-effects
+ */
+bool is_pure(const Expr &e);
+
 /** Construct an immediate of the given type from any numeric C++ type. */
 // @{
 EXPORT Expr make_const(Type t, int64_t val);

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -503,6 +503,11 @@ Stmt build_produce(Function f, const Target &target) {
         if (annotate.defined()) {
             check = Block::make(annotate, check);
         }
+
+        // Add the dummy outermost loop.
+        LoopLevel outermost(f, Var::outermost());
+        check = For::make(outermost.to_string(), 0, 1, ForType::Serial, DeviceAPI::None, check);
+
         return check;
     } else {
 

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -704,6 +704,9 @@ private:
         // Dig through any let statements
         vector<pair<string, Expr>> lets;
         while (const LetStmt *l = body.as<LetStmt>()) {
+            if (!is_pure(l->value)) {
+                break;
+            }
             lets.push_back({ l->name, l->value });
             body = l->body;
         }

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -710,6 +710,13 @@ private:
         vector<pair<string, Expr>> lets;
         while (const LetStmt *l = body.as<LetStmt>()) {
             if (!is_pure(l->value)) {
+                // The consumer of the Func we're injecting may be an
+                // extern stage, which shows up in the IR as a let
+                // stmt with a side-effecty RHS. We need to take care
+                // not to blow past it and risk injecting the producer
+                // *after* the consumer. In general it seems unwise to
+                // reorder the computation of a Func past something
+                // side-effecty, so we stop here.
                 break;
             }
             lets.push_back({ l->name, l->value });

--- a/test/correctness/extern_consumer.cpp
+++ b/test/correctness/extern_consumer.cpp
@@ -83,7 +83,8 @@ int main(int argc, char **argv) {
     args.push_back(extent);
     sink.define_extern("dump_to_file", args, Int(32), 0);
 
-    source.compute_root();
+    // Extern stages still have an outermost var.
+    source.compute_at(sink, Var::outermost());
 
     sink.compile_jit();
 


### PR DESCRIPTION
This allows scheduling other Funcs alongside them, and theoretically would let us specify that an extern stage should run on the other side of a device transition (e.g. Hexagon).

Most of the changed lines are code motion, because I needed to test if an Expr is pure outside of Simplify to fix an issue in ScheduleFunctions.