### PR TITLE
Opencl build error whitespace

### DIFF
--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -598,8 +598,8 @@ WEAK int halide_opencl_initialize_kernels(void *user_context, void **state_ptr, 
                                       NULL) == CL_SUCCESS) {
                 error(user_context) << "CL: clBuildProgram failed: "
                                     << get_opencl_error_name(err)
-                                    << "\nBuild Log:\n "
-                                    << buffer;
+                                    << "\nBuild Log:\n"
+                                    << buffer << "\n";
             } else {
                 error(user_context) << "clGetProgramBuildInfo failed";
             }


### PR DESCRIPTION
My halide_print accumulates characters until it sees a LF and then logs the accumulated characters at once. If it doesn’t get a trailing LF, the (potentially crucial) last reported line is not logged before halide_error aborts.