### PR TITLE
Fix include paths for Bazel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -957,7 +957,7 @@ $(BIN_DIR)/performance_%: $(ROOT_DIR)/test/performance/%.cpp $(BIN_DIR)/libHalid
 
 # Error tests that link against libHalide
 $(BIN_DIR)/error_%: $(ROOT_DIR)/test/error/%.cpp $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR)/Halide.h
-	$(CXX) $(TEST_CXX_FLAGS) $(OPTIMIZE) $< -I$(INCLUDE_DIR) $(TEST_LD_FLAGS) -o $@
+	$(CXX) $(TEST_CXX_FLAGS) -I$(ROOT_DIR) $(OPTIMIZE) $< -I$(INCLUDE_DIR) $(TEST_LD_FLAGS) -o $@
 
 $(BIN_DIR)/warning_%: $(ROOT_DIR)/test/warning/%.cpp $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR)/Halide.h
 	$(CXX) $(TEST_CXX_FLAGS) $(OPTIMIZE) $< -I$(INCLUDE_DIR) $(TEST_LD_FLAGS) -o $@

--- a/test/error/undefined_func_compile.cpp
+++ b/test/error/undefined_func_compile.cpp
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include "Halide.h"
 
-#include "../common/halide_test_dirs.h"
+#include "test/common/halide_test_dirs.h"
 
 using namespace Halide;
 

--- a/test/error/undefined_func_realize.cpp
+++ b/test/error/undefined_func_realize.cpp
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include "Halide.h"
 
-#include "../common/halide_test_dirs.h"
+#include "test/common/halide_test_dirs.h"
 
 using namespace Halide;
 

--- a/test/error/undefined_pipeline_compile.cpp
+++ b/test/error/undefined_pipeline_compile.cpp
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include "Halide.h"
 
-#include "../common/halide_test_dirs.h"
+#include "test/common/halide_test_dirs.h"
 
 using namespace Halide;
 


### PR DESCRIPTION
Bazel doesn't like relative include paths.