### PR TITLE
Add "makelib.sh" utility script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -903,8 +903,9 @@ build_tests: $(CORRECTNESS_TESTS:$(ROOT_DIR)/test/correctness/%.cpp=$(BIN_DIR)/c
 
 clean_generators:
 	rm -rf $(BIN_DIR)/*.generator
+	rm -rf $(BIN_DIR)/*/runtime.a
 	rm -rf $(FILTERS_DIR)
-	rm -rf $(BIN_DIR)/$(TARGET)/generator_*
+	rm -rf $(BIN_DIR)/*/generator_*
 	rm -rf $(BUILD_DIR)/*_generator.o
 	rm -f $(BUILD_DIR)/GenGen.o
 	rm -f $(BUILD_DIR)/RunGen.o
@@ -1040,7 +1041,7 @@ $(FILTERS_DIR)/cxx_mangling_externs.o: $(ROOT_DIR)/test/generator/cxx_mangling_e
 $(FILTERS_DIR)/cxx_mangling.a: $(BIN_DIR)/cxx_mangling.generator $(FILTERS_DIR)/cxx_mangling_externs.o
 	@mkdir -p $(@D)
 	$(CURDIR)/$< $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime-c_plus_plus_name_mangling -f "HalideTest::AnotherNamespace::cxx_mangling"
-	ar q $@ $(FILTERS_DIR)/cxx_mangling_externs.o
+	$(ROOT_DIR)/tools/makelib.sh $@ $@ $(FILTERS_DIR)/cxx_mangling_externs.o
 
 # Also build with a gpu target to ensure that the GPU-Host generation
 # code handles name mangling properly. (Note that we don't need to
@@ -1048,7 +1049,7 @@ $(FILTERS_DIR)/cxx_mangling.a: $(BIN_DIR)/cxx_mangling.generator $(FILTERS_DIR)/
 $(FILTERS_DIR)/cxx_mangling_gpu.a: $(BIN_DIR)/cxx_mangling.generator $(FILTERS_DIR)/cxx_mangling_externs.o
 	@mkdir -p $(@D)
 	$(CURDIR)/$< $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime-c_plus_plus_name_mangling-cuda -f "HalideTest::cxx_mangling_gpu"
-	ar q $@ $(FILTERS_DIR)/cxx_mangling_externs.o
+	$(ROOT_DIR)/tools/makelib.sh $@ $@ $(FILTERS_DIR)/cxx_mangling_externs.o
 
 $(FILTERS_DIR)/cxx_mangling_define_extern_externs.o: $(ROOT_DIR)/test/generator/cxx_mangling_define_extern_externs.cpp $(FILTERS_DIR)/cxx_mangling.h
 	@mkdir -p $(@D)
@@ -1057,7 +1058,7 @@ $(FILTERS_DIR)/cxx_mangling_define_extern_externs.o: $(ROOT_DIR)/test/generator/
 $(FILTERS_DIR)/cxx_mangling_define_extern.a: $(BIN_DIR)/cxx_mangling_define_extern.generator $(FILTERS_DIR)/cxx_mangling_define_extern_externs.o
 	@mkdir -p $(@D)
 	$(CURDIR)/$< $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime-c_plus_plus_name_mangling-user_context -f "HalideTest::cxx_mangling_define_extern"
-	ar q $@ $(FILTERS_DIR)/cxx_mangling_define_extern_externs.o
+	$(ROOT_DIR)/tools/makelib.sh $@ $@  $(FILTERS_DIR)/cxx_mangling_define_extern_externs.o
 
 # pyramid needs a custom arg
 $(FILTERS_DIR)/pyramid.a: $(BIN_DIR)/pyramid.generator

--- a/tools/makelib.sh
+++ b/tools/makelib.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# makelib.sh
+#
+# This is a script to allow combining a list of .a or .o
+# files into a single .a file; input .a are decomposed
+# into their component .o files. Ordering is maintained.
+# It is assumed there are no duplicates. (It's basically the subset
+# of libtool that we'd use, if libtool was reliably available everwhere.)
+#
+# $1 = Output file (always .a)
+# $2...$N = Input files (any mixture of .a or .o files)
+#
+# It is OK to have the same file as an input and output
+# (it will of course be overwritten).
+
+set -euo pipefail
+ORIG_WD=${PWD}
+
+# Output to temp file in case it's also in inputs
+OUTPUT_DIR=`mktemp -d`
+OUTPUT="${OUTPUT_DIR}/tmp.a"
+
+# $1 == destination .a
+# $2 == source .o or .a
+append_objects() {
+    # Since we are recursive, we need to do this at each level
+    set -euo pipefail
+    local EXT="${2##*.}"
+    if [[ ${EXT} == "o" ]]; then
+        ar qS ${1} ${2}
+    elif [[ ${EXT} == "a" ]]; then
+        local AR_TEMP=`mktemp -d`
+        cd ${AR_TEMP}
+        ar x ${2}
+        cd ${ORIG_WD}
+        # Iterate via 'ar t' rather than globbing what we extracted,
+        # so that we add in the same order.
+        local OBJ
+        for OBJ in `ar t ${2}`; do
+            if [[ "$OBJ" == */* ]]; then
+                echo "This tool does not support Archive files with partial or absolute paths" > /dev/stderr
+                exit 1
+            fi
+            if [[ ${OBJ} != "__.SYMDEF" && ${OBJ} != "SORTED" ]]; then
+                $(append_objects ${1} ${AR_TEMP}/${OBJ})
+            fi
+        done
+        rm -rf ${AR_TEMP}
+    else
+        echo ${2} is neither .o nor .a > /dev/stderr
+        exit 1
+    fi
+}
+
+for INPUT_ in ${@:2}; do
+    # Inputs might be relative; convert to an absolute path
+    # for ease of use with ar. Since OSX doesn't have a realpath
+    # available, we'll have to fake it: if the path doesn't begin
+    # with '/', assume it's relative and prepend PWD.
+    INPUT=`[[ $INPUT_ = /* ]] && echo "${INPUT_}" || echo "${PWD}/${INPUT_#./}"`
+    $(append_objects ${OUTPUT} ${INPUT})
+done
+
+ranlib ${OUTPUT}
+mv -f ${OUTPUT} $1
+
+rm -r ${OUTPUT_DIR}


### PR DESCRIPTION
Some Generator-related rules could be made simpler if we could reliably combine .a files; libtool does this, but is not reliably available on all systems. This adds a simple bash script that allows combining of an arbitrary list of .a and .o files into a single .a file, and modifies the Makefile to make use of it in a few places.

Also, drive-by fix to the clean_generators target.