### PR TITLE
Add an assert that catches null host fields

### DIFF
--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -535,7 +535,7 @@ Stmt add_image_checks(Stmt s,
         }
 
         // For the buffers used on host, check the host field is non-null
-        Expr host_ptr = Variable::make(Handle(), name);
+        Expr host_ptr = Variable::make(Handle(), name, image, param, ReductionDomain());
         if (used_on_host) {
             Expr error = Call::make(Int(32), "halide_error_host_is_null",
                                     {error_name}, Call::Extern);

--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -20,28 +20,59 @@ public:
         Buffer<> image;
         Parameter param;
         Type type;
-        int dimensions;
-        Result() : dimensions(0) {}
+        int dimensions {0};
+        bool used_on_host {false};
     };
 
     map<string, Result> buffers;
+    bool in_device_loop = false;
 
     using IRGraphVisitor::visit;
+
+    void visit(const For *op) {
+        op->min.accept(this);
+        op->extent.accept(this);
+        bool old = in_device_loop;
+        if (op->device_api != DeviceAPI::None &&
+            op->device_api != DeviceAPI::Host) {
+            in_device_loop = true;
+        }
+        op->body.accept(this);
+        in_device_loop = old;
+    }
 
     void visit(const Call *op) {
         IRGraphVisitor::visit(op);
         if (op->image.defined()) {
-            Result r;
+            Result &r = buffers[op->name];
             r.image = op->image;
             r.type = op->type.element_of();
             r.dimensions = (int)op->args.size();
-            buffers[op->name] = r;
+            r.used_on_host = r.used_on_host || (!in_device_loop);
         } else if (op->param.defined()) {
-            Result r;
+            Result &r = buffers[op->name];
             r.param = op->param;
             r.type = op->type.element_of();
             r.dimensions = (int)op->args.size();
-            buffers[op->name] = r;
+            r.used_on_host = r.used_on_host || (!in_device_loop);
+        }
+    }
+
+    void visit(const Provide *op) {
+        IRGraphVisitor::visit(op);
+        if (op->values.size() == 1) {
+            auto it = buffers.find(op->name);
+            if (it != buffers.end() && !in_device_loop) {
+                it->second.used_on_host = true;
+            }
+        } else {
+            for (size_t i = 0; i < op->values.size(); i++) {
+                string name = op->name + "." + std::to_string(i);
+                auto it = buffers.find(name);
+                if (it != buffers.end() && !in_device_loop) {
+                    it->second.used_on_host = true;
+                }
+            }
         }
     }
 
@@ -53,6 +84,7 @@ public:
             r.param = op->param;
             r.type = op->param.type();
             r.dimensions = op->param.dimensions();
+            r.used_on_host = false;
             buffers[op->param.name()] = r;
         }
     }
@@ -70,8 +102,7 @@ Stmt add_image_checks(Stmt s,
 
     // First hunt for all the referenced buffers
     FindBuffers finder;
-    s.accept(&finder);
-    map<string, FindBuffers::Result> bufs = finder.buffers;
+    map<string, FindBuffers::Result> &bufs = finder.buffers;
 
     // Add the output buffer(s).
     for (Function f : outputs) {
@@ -88,6 +119,10 @@ Stmt add_image_checks(Stmt s,
         }
     }
 
+    // Add the input buffer(s) and annotate which output buffers are
+    // used on host.
+    s.accept(&finder);
+
     Scope<Interval> empty_scope;
     map<string, Box> boxes = boxes_touched(s, empty_scope, fb);
 
@@ -103,6 +138,7 @@ Stmt add_image_checks(Stmt s,
     vector<Stmt> asserts_proposed;
     vector<Stmt> asserts_elem_size;
     vector<Stmt> asserts_host_alignment;
+    vector<Stmt> asserts_host_non_null;
     vector<Stmt> buffer_rewrites;
 
     // Inject the code that conditionally returns if we're in inference mode
@@ -143,6 +179,7 @@ Stmt add_image_checks(Stmt s,
         Parameter &param = buf.second.param;
         Type type = buf.second.type;
         int dimensions = buf.second.dimensions;
+        bool used_on_host = buf.second.used_on_host;
 
         // Detect if this is one of the outputs of a multi-output pipeline.
         bool is_output_buffer = false;
@@ -496,10 +533,22 @@ Stmt add_image_checks(Stmt s,
             // Check the var passed in equals the constrained version (when not in inference mode)
             asserts_constrained.push_back(AssertStmt::make(var == constrained_var, error));
         }
+
+        // For the buffers used on host, check the host field is non-null
+        Expr host_ptr = Variable::make(Handle(), name);
+        if (used_on_host) {
+            Expr error = Call::make(Int(32), "halide_error_host_is_null",
+                                    {error_name}, Call::Extern);
+            Expr check = (host_ptr != make_zero(host_ptr.type()));
+            if (touched.maybe_unused()) {
+                check = !touched.used || check;
+            }
+            asserts_host_non_null.push_back(AssertStmt::make(check, error));
+        }
+
+        // and check alignment of the host field
         if (param.defined() && param.host_alignment() != param.type().bytes()) {
-            string host_name = name;
             int alignment_required = param.host_alignment();
-            Expr host_ptr = Variable::make(Handle(), host_name);
             Expr u64t_host_ptr = reinterpret<uint64_t>(host_ptr);
             Expr align_condition = (u64t_host_ptr % alignment_required) == 0;
             Expr error = Call::make(Int(32), "halide_error_unaligned_host_ptr",
@@ -508,8 +557,11 @@ Stmt add_image_checks(Stmt s,
         }
     }
 
-    // Inject the code that check for the alignment of the host pointers.
+    // Inject the code that checks the host pointers.
     if (!no_asserts) {
+        for (size_t i = asserts_host_non_null.size(); i > 0; i--) {
+            s = Block::make(asserts_host_non_null[i-1], s);
+        }
         for (size_t i = asserts_host_alignment.size(); i > 0; i--) {
             s = Block::make(asserts_host_alignment[i-1], s);
         }

--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -20,8 +20,8 @@ public:
         Buffer<> image;
         Parameter param;
         Type type;
-        int dimensions {0};
-        bool used_on_host {false};
+        int dimensions{0};
+        bool used_on_host{false};
     };
 
     map<string, Result> buffers;

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -833,6 +833,12 @@ enum halide_error_code_t {
      * to see more details. */
     halide_error_code_device_detach_native_failed = -33,
 
+    /** The host field on an input or output was null, the device
+     * field was not zero, and the pipeline tries to use the buffer on
+     * the host. You may be passing a GPU-only buffer to a pipeline
+     * which is scheduled to use it on the CPU. */
+    halide_error_code_host_is_null = -34,
+
 };
 
 /** Halide calls the functions below on various error conditions. The
@@ -889,6 +895,7 @@ extern int halide_error_buffer_argument_is_null(void *user_context, const char *
 extern int halide_error_debug_to_file_failed(void *user_context, const char *func,
                                              const char *filename, int error_code);
 extern int halide_error_unaligned_host_ptr(void *user_context, const char *func_name, int alignment);
+extern int halide_error_host_is_null(void *user_context, const char *func_name);
 extern int halide_error_failed_to_upgrade_buffer_t(void *user_context,
                                                    const char *input_name,
                                                    const char *reason);

--- a/src/runtime/errors.cpp
+++ b/src/runtime/errors.cpp
@@ -202,6 +202,13 @@ WEAK int halide_error_unaligned_host_ptr(void *user_context, const char *func,
     return halide_error_code_unaligned_host_ptr;
 }
 
+WEAK int halide_error_host_is_null(void *user_context, const char *func) {
+    error(user_context)
+        << "The host pointer of " << func
+        << " is null, but the pipeline will access it on the host.";
+    return halide_error_code_host_is_null;
+}
+
 WEAK int halide_error_bad_fold(void *user_context, const char *func_name, const char *var_name,
                                const char *loop_name) {
     error(user_context)

--- a/src/runtime/runtime_api.cpp
+++ b/src/runtime/runtime_api.cpp
@@ -67,6 +67,7 @@ extern "C" __attribute__((used)) void *halide_runtime_api_functions[] = {
     (void *)&halide_error_explicit_bounds_too_small,
     (void *)&halide_error_extern_stage_failed,
     (void *)&halide_error_fold_factor_too_small,
+    (void *)&halide_error_host_is_null,
     (void *)&halide_error_out_of_memory,
     (void *)&halide_error_param_too_large_f64,
     (void *)&halide_error_param_too_large_i64,

--- a/test/error/null_host_field.cpp
+++ b/test/error/null_host_field.cpp
@@ -1,0 +1,34 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+int main(int argc, char **argv) {
+    Func f;
+    Var x, y;
+    ImageParam in(UInt(8), 2);
+
+    // Give the input a device field (to get past bounds query checks)
+    // but no host field. If not for the assert failure, we'd segfault
+    // (which isn't accepted as correct behavior from the testing
+    // infrastructure).
+    Buffer<uint8_t> param_buf(10, 10);
+    param_buf.raw_buffer()->device = 3;
+    param_buf.raw_buffer()->device_interface = (halide_device_interface_t *)(3);
+    param_buf.raw_buffer()->host = nullptr;
+
+    f(x, y) = in(x, y);
+    f.compute_root();
+
+    in.set(param_buf);
+    Buffer<uint8_t> result = f.realize(10, 10);
+
+    // Avoid a freak-out in the destructor of param_buf.
+    param_buf.raw_buffer()->device = 0;
+    param_buf.raw_buffer()->device_interface = 0;
+
+    printf("I should not have reached here\n");
+
+    return 0;
+}


### PR DESCRIPTION
Currently if the device field is non-zero but the host field is null,
and the pipeline gets used on the host at all, then we just segfault
nastily.