### PR TITLE
Add a reusable set of Generator rules for Make

### DIFF
--- a/HalideGenerator.mk
+++ b/HalideGenerator.mk
@@ -1,0 +1,163 @@
+# ------------------------------------------------------------------------------
+#
+# General rules for building Generators. These are targeted at the
+# Generators in test/generator, but can (and should) be generalized elsewhere.
+#
+# These variables are chosen to allow for Target-Specific Variable Values to 
+# override part(s) of the Generator ruleset, without having to make error-prone
+# near-duplicates of the build rules for things that need minor customization.
+#
+# To use:
+# -- Use vpath to specify the directories containing your _generator.cpp files:
+# 
+#   vpath %_generator.cpp dir1/,dir2/,etc
+#
+# -- define the variables listed as "must-define" below
+# -- include this file
+#
+#
+# For every foo_generator.cpp file found, we produce:
+# -- foo.generator (the compiled Generator executable)
+# -- foo.a (the AOT-compiled output of the Generator)
+# -- foo.h (the corresponding header file)
+# -- foo.cpp (the C++ version of the output of the Generator)
+# -- foo.rungen (foo.a linked with the RunGen wrapper)
+#
+#
+# You can customize various settings by adding target-specific variable definitions,
+# e.g. to specify that foo should be built with user_context and cuda, use
+#
+#   $(GENERATOR_FILTERS_DIR)/foo.a: GENERATOR_EXTRA_FEATURES=user_context-cuda
+
+
+# Note that several of these need SECONDEXPANSION enabled to work.
+.SECONDEXPANSION:
+
+# These are the variables you *must* define
+CXX                           ?= error-must-define-CXX
+GENERATOR_HALIDE_INCLUDES_DIR ?= error-must-define-GENERATOR_HALIDE_INCLUDES_DIR
+GENERATOR_HALIDE_TOOLS_DIR    ?= error-must-define-GENERATOR_HALIDE_TOOLS_DIR
+GENERATOR_LIBHALIDE_PATH      ?= error-must-define-GENERATOR_LIBHALIDE_PATH
+GENERATOR_TARGET 	          ?= error-must-define-GENERATOR_TARGET
+GENERATOR_BIN_DIR 	          ?= error-must-define-GENERATOR_BIN_DIR
+
+GENERATOR_BUILD_DIR   		  = $(GENERATOR_BIN_DIR)/build
+GENERATOR_FILTERS_DIR 		  = $(GENERATOR_BIN_DIR)/$(GENERATOR_TARGET)/build
+
+GENERATOR_CXX_FLAGS           ?=
+GENERATOR_GENERATOR_LD_FLAGS  ?=
+
+GENERATOR_HALIDE_H_PATH       ?= $(GENERATOR_HALIDE_INCLUDES_DIR)/Halide.h
+
+GENERATOR_IMAGE_IO_LIBS       ?= 
+GENERATOR_IMAGE_IO_CXX_FLAGS  ?= -DHALIDE_NO_PNG -DHALIDE_NO_JPEG
+
+# Default features to add to the Generator's Halide target.
+GENERATOR_EXTRA_FEATURES ?=
+
+# Default function name for Generator AOT rules (empty = based on Generator name).
+GENERATOR_FUNCNAME ?= $(notdir $*)
+
+# Default Generator args for Generator AOT rules (if any)
+GENERATOR_ARGS ?=
+
+# Generator name to use (empty = assume only one Generator present)
+GENERATOR_GENERATOR_NAME ?=
+
+# Extra deps that are required when building the Generator itself (if any)
+GENERATOR_GENERATOR_DEPS ?=
+
+# Extra deps that are required when linking the filter (if any).
+GENERATOR_FILTER_DEPS ?=
+
+# The Generator to use to produce a target; usually %.generator,
+# but can vary when we produces multiple different filters
+# from the same Generator (by changing target, generator_args, etc)
+GENERATOR_GENERATOR_EXECUTABLE=$(GENERATOR_BIN_DIR)/$*.generator
+
+GENERATOR_RUNTIME_LIB = $(GENERATOR_FILTERS_DIR)/runtime.a
+
+# ------------------------------------------------------------------------------
+
+$(GENERATOR_BUILD_DIR)/GenGen.o: $(GENERATOR_HALIDE_TOOLS_DIR)/GenGen.cpp $(GENERATOR_HALIDE_INCLUDES_DIR)/Halide.h
+	@mkdir -p $(@D)
+	$(CXX) -c $< $(GENERATOR_CXX_FLAGS) -I$(GENERATOR_HALIDE_INCLUDES_DIR) -o $@
+
+# ------------------------------------------------------------------------------
+
+# By default, %.generator is produced by building %_generator.cpp & linking with GenGen.cpp
+$(GENERATOR_BUILD_DIR)/%_generator.o: %_generator.cpp $(GENERATOR_HALIDE_INCLUDES_DIR)/Halide.h
+	@mkdir -p $(@D)
+	$(CXX) $(GENERATOR_CXX_FLAGS) -I$(GENERATOR_HALIDE_INCLUDES_DIR) -I$(GENERATOR_FILTERS_DIR) -c $< -o $@
+
+$(GENERATOR_BIN_DIR)/%.generator: $(GENERATOR_BUILD_DIR)/GenGen.o $(GENERATOR_LIBHALIDE_PATH) $(GENERATOR_HALIDE_H_PATH) $(GENERATOR_BUILD_DIR)/%_generator.o $$(GENERATOR_GENERATOR_DEPS)
+	@mkdir -p $(@D)
+	$(CXX) $(filter %.cpp %.o %.a,$^) $(GENERATOR_GENERATOR_LD_FLAGS) -o $@
+
+# Don't automatically delete Generators, since we may invoke the same one multiple
+# times with different arguments.
+# (Really, .SECONDARY is what we want, but it won't accept wildcards)
+.PRECIOUS: $(GENERATOR_BIN_DIR)/%.generator
+
+GENERATOR_TARGET_WITH_FEATURES ?= $(GENERATOR_TARGET)-no_runtime$(if $(GENERATOR_EXTRA_FEATURES),-,)$(GENERATOR_EXTRA_FEATURES)
+
+# By default, %.a/.h/.cpp are produced by executing %.generator. Runtimes are not included in these.
+$(GENERATOR_FILTERS_DIR)/%.a: $$(GENERATOR_GENERATOR_EXECUTABLE) $$(GENERATOR_FILTER_DEPS)
+	@mkdir -p $(@D)
+	$< -e static_library,h,cpp -g "$(GENERATOR_GENERATOR_NAME)" -f "$(GENERATOR_FUNCNAME)" -n $* -o $(GENERATOR_FILTERS_DIR) target=$(GENERATOR_TARGET_WITH_FEATURES) $(GENERATOR_ARGS)
+	if [ -n "$(GENERATOR_FILTER_DEPS)" ]; then $(GENERATOR_HALIDE_TOOLS_DIR)/makelib.sh $@ $@ $(GENERATOR_FILTER_DEPS); fi
+
+$(GENERATOR_FILTERS_DIR)/%.h: $(GENERATOR_FILTERS_DIR)/%.a
+	@ # @echo $@ produced implicitly by $^
+
+$(GENERATOR_FILTERS_DIR)/%.cpp: $(GENERATOR_FILTERS_DIR)/%.a
+	@ # @echo $@ produced implicitly by $^
+
+$(GENERATOR_FILTERS_DIR)/%.stub.h: $(GENERATOR_BIN_DIR)/%.generator
+	@mkdir -p $(@D)
+	$< -n $* -o $(GENERATOR_FILTERS_DIR) -e cpp_stub
+
+# ------------------------------------------------------------------------------
+# Make an empty generator for generating runtimes.
+$(GENERATOR_BIN_DIR)/runtime.rgenerator: $(GENERATOR_BUILD_DIR)/GenGen.o $(GENERATOR_LIBHALIDE_PATH) $(GENERATOR_HALIDE_H_PATH)
+	@mkdir -p $(@D)
+	$(CXX) $(filter-out %.h,$^) $(GENERATOR_GENERATOR_LD_FLAGS) -o $@
+
+# Generate a standalone runtime for a given target string
+# Note that this goes into GENERATOR_FILTERS_DIR, but we define the rule
+# this way so that things downstream can just depend on the right path to
+# force generation of custom runtimes.
+$(GENERATOR_BIN_DIR)/%/build/runtime.a: $(GENERATOR_BIN_DIR)/runtime.rgenerator
+	@mkdir -p $(@D)
+	$< -r runtime -o $(@D) target=$*
+
+# ------------------------------------------------------------------------------
+
+# Rules for the "RunGen" utility, which lets most Generators run via
+# standard command-line tools.
+
+$(GENERATOR_BUILD_DIR)/RunGen.o: $(GENERATOR_HALIDE_TOOLS_DIR)/RunGen.cpp $(GENERATOR_HALIDE_INCLUDES_DIR)/HalideRuntime.h
+	@mkdir -p $(@D)
+	$(CXX) -c $< $(GENERATOR_CXX_FLAGS) $(GENERATOR_IMAGE_IO_CXX_FLAGS) -I$(GENERATOR_HALIDE_INCLUDES_DIR) -I$(GENERATOR_HALIDE_TOOLS_DIR) -o $@
+
+$(GENERATOR_BIN_DIR)/%.rungen: $(GENERATOR_BUILD_DIR)/RunGen.o $(GENERATOR_FILTERS_DIR)/runtime.a $(GENERATOR_HALIDE_TOOLS_DIR)/RunGenStubs.cpp $(GENERATOR_FILTERS_DIR)/%.a
+	$(CXX) -std=c++11 -DHL_RUNGEN_FILTER_HEADER=\"$*.h\" -I$(GENERATOR_FILTERS_DIR) $^ $(GENERATOR_IMAGE_IO_CXX_FLAGS) $(GENERATOR_IMAGE_IO_LIBS) -o $@
+
+# Don't automatically delete RunGen, since we may invoke the same one multiple times with different arguments.
+# (Really, .SECONDARY is what we want, but it won't accept wildcards)
+.PRECIOUS: $(GENERATOR_BIN_DIR)/%.rungen
+
+RUNARGS ?=
+
+$(GENERATOR_BIN_DIR)/%.run: $(GENERATOR_BIN_DIR)/%.rungen
+	$< $(RUNARGS)
+
+clean_generators:
+	rm -f $(GENERATOR_BUILD_DIR)/GenGen.o
+	rm -f $(GENERATOR_BUILD_DIR)/RunGen.o
+	rm -rf $(GENERATOR_BIN_DIR)/$(GENERATOR_TARGET)/generator_*
+	rm -rf $(GENERATOR_BIN_DIR)/*.generator
+	rm -rf $(GENERATOR_BIN_DIR)/*.rungen
+	rm -rf $(GENERATOR_BIN_DIR)/*/build/runtime.a
+	rm -rf $(GENERATOR_BUILD_DIR)/*_generator.o
+	rm -rf $(GENERATOR_FILTERS_DIR)

--- a/Makefile
+++ b/Makefile
@@ -969,7 +969,7 @@ GENERATOR_GENERATOR_LD_FLAGS = $(TEST_LD_FLAGS)
 GENERATOR_IMAGE_IO_LIBS      ?= $(IMAGE_IO_LIBS)
 GENERATOR_IMAGE_IO_CXX_FLAGS ?= $(IMAGE_IO_CXX_FLAGS)
 
-include HalideGenerator.mk
+include $(ROOT_DIR)/HalideGenerator.mk
 
 # ------------------------------------------------------------------------------
 

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -1,26 +1,30 @@
 include ../support/Makefile.inc
 
-all: $(BIN)/filter
+GENERATOR_BIN_DIR = $(BIN)
+GENERATOR_TARGET = $(HL_TARGET)
 
-$(BIN)/bilateral_grid_exec: bilateral_grid_generator.cpp $(GENERATOR_DEPS)
-	@mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
+GENERATOR_GENERATOR_LD_FLAGS = $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
+GENERATOR_CXX_FLAGS = $(CXXFLAGS)
+GENERATOR_HALIDE_TOOLS_DIR = $(HALIDE_SRC_PATH)/tools
+GENERATOR_HALIDE_INCLUDES_DIR = $(HALIDE_SRC_PATH)/include
+GENERATOR_LIBHALIDE_PATH = $(LIB_HALIDE)
 
-$(BIN)/bilateral_grid.a: $(BIN)/bilateral_grid_exec
-	@mkdir -p $(@D)
-	$^ -o $(BIN)  target=$(HL_TARGET)
+include ../../HalideGenerator.mk
 
-$(BIN)/viz/bilateral_grid.a: $(BIN)/bilateral_grid_exec
-	@mkdir -p $(@D)
-	@mkdir -p $(@D)
-	$^ -o $(BIN)/viz target=$(HL_TARGET)-trace_loads-trace_stores-trace_realizations
+all: $(BIN)/filter $(BIN)/out.png $(BIN)/filter_viz 
 
-$(BIN)/filter: $(BIN)/bilateral_grid.a filter.cpp
+# Same Generator, different features
+$(GENERATOR_FILTERS_DIR)/bilateral_grid_viz.a: GENERATOR_GENERATOR_EXECUTABLE=$(GENERATOR_BIN_DIR)/bilateral_grid.generator
+$(GENERATOR_FILTERS_DIR)/bilateral_grid_viz.a: GENERATOR_FEATURES=trace_loads-trace_stores-trace_realizations
+$(GENERATOR_FILTERS_DIR)/bilateral_grid_viz.a: GENERATOR_FUNCNAME=bilateral_grid
+
+$(BIN)/filter: filter.cpp $(GENERATOR_FILTERS_DIR)/bilateral_grid.a $(GENERATOR_RUNTIME_LIB)
 	@mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) -O3 -ffast-math -Wall -Werror -I$(BIN) filter.cpp $(BIN)/bilateral_grid.a -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
-$(BIN)/filter_viz: $(BIN)/viz/bilateral_grid.a filter.cpp
+	$(CXX) $(CXXFLAGS) -O3 -ffast-math -Wall -Werror -I$(GENERATOR_FILTERS_DIR) $^ -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
+
+$(BIN)/filter_viz: filter.cpp $(GENERATOR_FILTERS_DIR)/bilateral_grid_viz.a $(GENERATOR_RUNTIME_LIB)
 	@mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) -O3 -ffast-math -Wall -Werror -I$(BIN)/viz filter.cpp $(BIN)/viz/bilateral_grid.a -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -O3 -ffast-math -Wall -Werror -I$(GENERATOR_FILTERS_DIR) $^ -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
 
 $(BIN)/bilateral_grid.mp4: $(BIN)/filter_viz viz.sh
 	@mkdir -p $(@D)

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -17,15 +17,15 @@ CXX ?= g++
 GXX ?= g++
 
 CFLAGS += -I $(HALIDE_BIN_PATH)/include/ -I $(HALIDE_SRC_PATH)/tools/ -I $(HALIDE_SRC_PATH)/apps/support/
-CXXFLAGS += -std=c++11 -I $(HALIDE_BIN_PATH)/include/ -I $(HALIDE_SRC_PATH)/tools/ -I $(HALIDE_SRC_PATH)/apps/support/
+CXXFLAGS += -std=c++11 -I $(HALIDE_BIN_PATH)/include/ -I $(HALIDE_SRC_PATH)/tools/ -I $(HALIDE_SRC_PATH)/apps/support/ -fno-rtti 
 
 ifeq ($(UNAME), Darwin)
 CXXFLAGS += -fvisibility=hidden
 endif
 
 LIB_HALIDE = $(HALIDE_BIN_PATH)/lib/libHalide.a
-
-GENERATOR_DEPS ?= $(HALIDE_BIN_PATH)/lib/libHalide.a $(HALIDE_BIN_PATH)/include/Halide.h $(HALIDE_SRC_PATH)/tools/GenGen.cpp
+LIBHALIDE_DEPS = $(LIB_HALIDE) $(HALIDE_BIN_PATH)/include/Halide.h
+GENERATOR_DEPS ?= $(LIBHALIDE_DEPS) $(HALIDE_SRC_PATH)/tools/GenGen.cpp
 
 LLVM_CONFIG ?= llvm-config
 LLVM_VERSION_TIMES_10 = $(shell $(LLVM_CONFIG) --version | cut -b 1,3)
@@ -76,21 +76,3 @@ endif
 ifneq (, $(findstring metal,$(HL_TARGET)))
   LDFLAGS += -framework Metal -framework Foundation
 endif
-
-$(BIN)/RunGen.o: $(HALIDE_SRC_PATH)/tools/RunGen.cpp
-	@mkdir -p $(@D)
-	@$(CXX) -c $< $(CXXFLAGS) $(IMAGE_IO_CXX_FLAGS) -I$(BIN) -o $@
-
-# Really, .SECONDARY is what we want, but it won't accept wildcards
-.PRECIOUS: $(BIN)/%.rungen
-$(BIN)/%.rungen: $(BIN)/%.a $(BIN)/RunGen.o $(HALIDE_SRC_PATH)/tools/RunGenStubs.cpp
-	$(CXX) $(CXXFLAGS) -DHL_RUNGEN_FILTER=$* $^ -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
-
-RUNARGS ?=
-
-# Pseudo target that allows us to build-and-run in one step, e.g.
-#
-#     make foo.run RUNARGS='input=a output=baz'
-#
-$(BIN)/%.run: $(BIN)/%.rungen
-	@$(CURDIR)/$< $(RUNARGS)


### PR DESCRIPTION
This is an attempt to add a standard set of Make rules to build Generators, hopefully simplifying Generator usage in Makefiles.

The idea is that we have rules to convert a "_generator.cpp" file into:

  - foo.generator (the compiled Generator executable)
  - foo.a (the AOT-compiled output of the Generator)
  - foo.h (the corresponding header file)
  - foo.cpp (the C++ version of the output of the Generator)
  - foo.rungen (foo.a linked with the RunGen wrapper)

You use these rules by using the `vpath` directive to indicate the directory(s) you want to search for the source files, defining a few variables, then including HalideGenerator.mk.

In addition to all of test/generator, I also converted apps/bilateral_grid to use this rule.

I'm not 100% happy with this -- it's not as elegant or as clean as I'd like -- but I'm not sure that a perfectly elegant/clean solution is possible with standard Make, and while these rules don't dramatically reduce the *size* of the downstream Makefile, I do think they make maintenance and readability easier. That said, this change definitely warrants a lot of opinions on whether it's making things better or worse, so please chime in.

If we like this, additional steps to take would be
  - Add HalideGenerator.mk to the distrib/ folder, so that downstream users can rely on the ruleset
  - Convert the rest of the apps/ to use these rules
