### PR TITLE
Change sliding window to use likely_if_innermost

### DIFF
--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -233,11 +233,11 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
 
             Expr new_min, new_max;
             if (can_slide_up) {
-                new_min = select(loop_var_expr <= loop_min, min_required, likely(prev_max_plus_one));
+                new_min = select(loop_var_expr <= loop_min, min_required, likely_if_innermost(prev_max_plus_one));
                 new_max = max_required;
             } else {
                 new_min = min_required;
-                new_max = select(loop_var_expr <= loop_min, max_required, likely(prev_min_minus_one));
+                new_max = select(loop_var_expr <= loop_min, max_required, likely_if_innermost(prev_min_minus_one));
             }
 
             Expr early_stages_min_required = new_min;


### PR DESCRIPTION
In practice this means that in line-buffered pipelines loops over y
don't get partitioned on the y axis, which has two key benefits:

- The warm-up code in the y axis now gets partitioned in x, making
boundary conditions cost less.
- smaller binaries
- faster compile times

On local_laplacian and HDR+ this saves a bunch of code size and compile
time with no measurable performance difference. On camera_pipe this
seems to be a minor performance win.