### PR TITLE
use correctly typed sse intrinsics in tutorial

### DIFF
--- a/tutorial/lesson_09_update_definitions.cpp
+++ b/tutorial/lesson_09_update_definitions.cpp
@@ -854,7 +854,7 @@ int main(int argc, char **argv) {
                         __m128i minimum_storage, maximum_storage;
 
                         // The pure step for the maximum is a vector of zeros
-                        maximum_storage = (__m128i)_mm_setzero_ps();
+                        maximum_storage = _mm_setzero_si128();
 
                         // The update step for maximum
                         for (int max_y = y - 2; max_y <= y + 2; max_y++) {
@@ -870,8 +870,8 @@ int main(int argc, char **argv) {
                         // The pure step for the minimum is a vector of
                         // ones. Create it by comparing something to
                         // itself.
-                        minimum_storage = (__m128i)_mm_cmpeq_ps(_mm_setzero_ps(),
-                                                                _mm_setzero_ps());
+                        minimum_storage = _mm_cmpeq_epi32(_mm_setzero_si128(),
+                                                          _mm_setzero_si128());
 
                         // The update step for minimum.
                         for (int min_y = y - 2; min_y <= y + 2; min_y++) {


### PR DESCRIPTION
Directly casting from __m128 to __m128i triggers a compile error in msvc. One option is to use _mm_castps_si128(), the other is to use the correct integer intrinsics from the get go.