### PR TITLE
replace code that relies on cpp14 features

### DIFF
--- a/test/common/check_call_graphs.h
+++ b/test/common/check_call_graphs.h
@@ -82,7 +82,7 @@ inline int check_call_graphs(CallGraphs &result, CallGraphs &expected) {
     return 0;
 }
 
-inline int check_image(const Halide::Buffer<int> &im, const std::function<int(int,int)> &func) {
+inline int check_image2(const Halide::Buffer<int> &im, const std::function<int(int,int)> &func) {
     for (int y = 0; y < im.height(); y++) {
         for (int x = 0; x < im.width(); x++) {
             int correct = func(x, y);
@@ -96,7 +96,7 @@ inline int check_image(const Halide::Buffer<int> &im, const std::function<int(in
     return 0;
 }
 
-inline int check_image(const Halide::Buffer<int> &im, const std::function<int(int,int,int)> &func) {
+inline int check_image3(const Halide::Buffer<int> &im, const std::function<int(int,int,int)> &func) {
     for (int z = 0; z < im.channels(); z++) {
         for (int y = 0; y < im.height(); y++) {
             for (int x = 0; x < im.width(); x++) {
@@ -110,6 +110,20 @@ inline int check_image(const Halide::Buffer<int> &im, const std::function<int(in
         }
     }
     return 0;
+}
+
+template <typename F>
+inline auto // SFINAE: returns int if F has arity of 2
+check_image(const Halide::Buffer<int> &im, F func) -> decltype(std::declval<F>()(0, 0), int())
+{
+    return check_image2(im, func);
+}
+
+template <typename F>
+inline auto // SFINAE: returns int if F has arity of 3
+check_image(const Halide::Buffer<int> &im, F func) -> decltype(std::declval<F>()(0, 0, 0), int())
+{
+    return check_image3(im, func);
 }
 
 #endif

--- a/test/opengl/testing.h
+++ b/test/opengl/testing.h
@@ -15,8 +15,8 @@ bool neq(T a, T b, T tol) {
 }
 
 // Check 3-dimension buffer
-template <typename T>
-bool check_result(const Halide::Buffer<T> &buf, T tol, std::function<T(int x, int y, int c)> f) {
+template <typename T, typename F>
+auto check_result(const Halide::Buffer<T> &buf, T tol, F f) -> decltype(std::declval<F>()(0, 0, 0), bool()) {
     class err : std::exception {
     public:
         static void vector(const std::vector<T> &v) {
@@ -54,8 +54,8 @@ bool check_result(const Halide::Buffer<T> &buf, T tol, std::function<T(int x, in
 }
 
 // Check 2-dimension buffer
-template <typename T>
-bool check_result(const Halide::Buffer<T> &buf, T tol, std::function<T(int x, int y)> f) {
+template <typename T, typename F>
+auto check_result(const Halide::Buffer<T> &buf, T tol, F f) -> decltype(std::declval<F>()(0, 0), bool()) {
     class err : std::exception {};
     try {
         buf.for_each_element([&](int x, int y) {


### PR DESCRIPTION
These features are only available from C++14 onwards:

1. Default argument in lambda expression.
2. `std::function` constructor checks function signature.

Since Halide makefiles explicitly selects C++11 as standard, C++14 elements ought to be removed.