### PR TITLE
Error if an extern func has itself as an argument

### DIFF
--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -91,6 +91,8 @@ struct FunctionContents {
         if (!extern_function_name.empty()) {
             for (ExternFuncArgument i : extern_arguments) {
                 if (i.is_func()) {
+                    user_assert(i.func.get() != this)
+                        << "Extern Func has itself as an argument";
                     i.func->accept(visitor);
                 } else if (i.is_expr()) {
                     i.expr.accept(visitor);

--- a/test/error/extern_func_self_argument.cpp
+++ b/test/error/extern_func_self_argument.cpp
@@ -1,0 +1,18 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+extern "C"
+int extern_func() {
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    Func f("f");
+
+    f.define_extern("extern_func", {f}, Int(32), 2);
+    f.infer_arguments();
+
+    printf("There should have been an error\n");
+    return 0;
+}


### PR DESCRIPTION
Patched from PR#2263: This is a bit of an an edge case, but I found that if an extern Func definition includes itself as one of the ExternFuncArguments (e.g. f.define_extern("extern_func", {f}, Int(32), 2);), it goes into infinite recusion in infer_arguments() and segfaults from stack overflow. This PR avoids that by showing an error message instead.
