### PR TITLE
Add HL_WINDOWS_TMP_DIR env var

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -295,6 +295,15 @@ namespace {
 // should be valid and writable in all versions of Windows that
 // we support for compilation purposes.
 std::string get_windows_tmp_dir() {
+    // Allow overriding of the tmpdir on Windows via an env var;
+    // some Windows configs can (apparently) lock down AppData/Local/Temp
+    // via policy, making various things break. (Note that this is intended
+    // to be a short-lived workaround; we would prefer to be able to avoid
+    // requiring this sort of band-aid if possible.)
+    std::string tmp_dir = get_env_variable("HL_WINDOWS_TMP_DIR");
+    if (!tmp_dir.empty()) {
+        return tmp_dir;
+    }
     char local_app_data_path[MAX_PATH];
     DWORD ret = SHGetFolderPathA(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, local_app_data_path);
     internal_assert(ret == 0) << "Unable to get Local AppData folder.";


### PR DESCRIPTION
This is a Windows-specific env var to allow overriding the /tmp-equivalent directory. (Issue #2262)