### PR TITLE
Enable warnings-as-errors by default on Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,11 +139,9 @@ if (NOT MSVC)
   endif()
 else()
   add_compile_options(/W3)
-  message(WARNING "WARNINGS_AS_ERROR is currently ignored for MSVC")
-  # TODO: Uncomment below and remove above warning once we can build without warnings
-  #if (WARNINGS_AS_ERRORS)
-  #  add_compile_options(/WX)
-  #endif()
+  if (WARNINGS_AS_ERRORS)
+    add_compile_options(/WX)
+  endif()
 endif()
 
 # Look for OpenMP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ if (NOT MSVC)
   endif()
 else()
   add_compile_options(/W3)
+  add_compile_options(/wd4018)  # diable "signed/unsigned mismatch"
   if (WARNINGS_AS_ERRORS)
     add_compile_options(/WX)
   endif()


### PR DESCRIPTION
As of right now, the tree builds cleanly on Windows this way (pending buildbot verification): let's flip this switch to keep it that way.