### PR TITLE
Refactor create_halide_config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1558,11 +1558,11 @@ ifeq ($(UNAME), Darwin)
 	install_name_tool -id $(PREFIX)/lib/libHalide.$(SHARED_EXT) $(PREFIX)/lib/libHalide.$(SHARED_EXT)
 endif
 
-$(BUILD_DIR)/halide_config.bzl: $(ROOT_DIR)/bazel/create_halide_config.sh
+$(BUILD_DIR)/halide_config.%: $(ROOT_DIR)/bazel/create_halide_config.sh
 	@mkdir -p $(@D)
-	$< > $@
+	$< $* > $@
 
-$(DISTRIB_DIR)/halide.tgz: $(LIB_DIR)/libHalide.a $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR)/Halide.h $(RUNTIME_EXPORTED_INCLUDES) $(ROOT_DIR)/bazel/* $(BUILD_DIR)/halide_config.bzl
+$(DISTRIB_DIR)/halide.tgz: $(LIB_DIR)/libHalide.a $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR)/Halide.h $(RUNTIME_EXPORTED_INCLUDES) $(ROOT_DIR)/bazel/* $(BUILD_DIR)/halide_config.bzl $(BUILD_DIR)/halide_config.cmake
 	mkdir -p $(DISTRIB_DIR)/include $(DISTRIB_DIR)/bin $(DISTRIB_DIR)/lib $(DISTRIB_DIR)/tutorial $(DISTRIB_DIR)/tutorial/images $(DISTRIB_DIR)/tools $(DISTRIB_DIR)/tutorial/figures
 	cp $(BIN_DIR)/libHalide.$(SHARED_EXT) $(DISTRIB_DIR)/bin
 	cp $(LIB_DIR)/libHalide.a $(DISTRIB_DIR)/lib
@@ -1589,7 +1589,7 @@ $(DISTRIB_DIR)/halide.tgz: $(LIB_DIR)/libHalide.a $(BIN_DIR)/libHalide.$(SHARED_
 	cp $(ROOT_DIR)/bazel/halide.bzl $(DISTRIB_DIR)
 	cp $(ROOT_DIR)/bazel/README_bazel.md $(DISTRIB_DIR)
 	cp $(ROOT_DIR)/bazel/WORKSPACE $(DISTRIB_DIR)
-	cp $(BUILD_DIR)/halide_config.bzl $(DISTRIB_DIR)
+	cp $(BUILD_DIR)/halide_config.* $(DISTRIB_DIR)
 	ln -sf $(DISTRIB_DIR) halide
 	tar -czf $(DISTRIB_DIR)/halide.tgz \
 		halide/bin \

--- a/Makefile
+++ b/Makefile
@@ -1562,7 +1562,7 @@ $(BUILD_DIR)/halide_config.%: $(ROOT_DIR)/bazel/create_halide_config.sh
 	@mkdir -p $(@D)
 	$< $* > $@
 
-$(DISTRIB_DIR)/halide.tgz: $(LIB_DIR)/libHalide.a $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR)/Halide.h $(RUNTIME_EXPORTED_INCLUDES) $(ROOT_DIR)/bazel/* $(BUILD_DIR)/halide_config.bzl $(BUILD_DIR)/halide_config.cmake
+$(DISTRIB_DIR)/halide.tgz: $(LIB_DIR)/libHalide.a $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR)/Halide.h $(RUNTIME_EXPORTED_INCLUDES) $(ROOT_DIR)/bazel/* $(BUILD_DIR)/halide_config.bzl
 	mkdir -p $(DISTRIB_DIR)/include $(DISTRIB_DIR)/bin $(DISTRIB_DIR)/lib $(DISTRIB_DIR)/tutorial $(DISTRIB_DIR)/tutorial/images $(DISTRIB_DIR)/tools $(DISTRIB_DIR)/tutorial/figures
 	cp $(BIN_DIR)/libHalide.$(SHARED_EXT) $(DISTRIB_DIR)/bin
 	cp $(LIB_DIR)/libHalide.a $(DISTRIB_DIR)/lib

--- a/bazel/create_halide_config.sh
+++ b/bazel/create_halide_config.sh
@@ -1,15 +1,24 @@
-#!/bin/bash -x
-set -e
+#!/bin/bash
+set -eu
 
 # We need to capture the system libraries that we'll need to link 
-# against, so that downstream consumers of our Bazel rules don't
+# against, so that downstream consumers of our build rules don't
 # have to guess what's necessary on their system; call
 # llvm-config and capture the result in a Skylark macro that
 # we include in our distribution.
 LLVM_SYSTEM_LIBS=`${LLVM_CONFIG} --system-libs | sed -e 's/[\/&]/\\&/g'`
 
+if [[ $1 == "bzl" ]]; then
+
 cat <<multiline_literal_EOF
 # Machine-Generated: Do Not Edit
-def halide_config_linkopts():
+def halide_system_libs():
   return "${LLVM_SYSTEM_LIBS}"
 multiline_literal_EOF
+
+else
+
+echo "create_halide_config does not understand \"$1\"" > /dev/stderr
+exit 1
+
+fi

--- a/bazel/halide.bzl
+++ b/bazel/halide.bzl
@@ -1,4 +1,4 @@
-load("@halide//:halide_config.bzl", "halide_config_linkopts")
+load("@halide//:halide_config.bzl", "halide_system_libs")
 
 def halide_language_copts():
   _common_opts = [
@@ -56,7 +56,7 @@ def halide_language_linkopts():
           _osx_opts,
       "//conditions:default":
           _linux_opts,
-  }) + halide_config_linkopts().split(" ")
+  }) + halide_system_libs().split(" ")
 
 
 def halide_runtime_linkopts():


### PR DESCRIPTION
Generalize it a bit to allow for emitting a similar helper for CMake; rename the Bazel helper function to be more accurate.