### PR TITLE
Check for null buffer pointers and report a better error.

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -850,6 +850,10 @@ enum halide_error_code_t {
     /** Buffer has both host and device dirty bits set, which violates
      * a Halide invariant. */
     halide_error_code_host_and_device_dirty = -37,
+
+    /** The halide_buffer_t * passed to a halide runtime routine is
+     * nullptr and this is not allowed. */
+    halide_error_code_buffer_is_null = -38,
 };
 
 /** Halide calls the functions below on various error conditions. The
@@ -925,6 +929,7 @@ extern int halide_error_specialize_fail(void *user_context, const char *message)
 extern int halide_error_no_device_interface(void *user_context);
 extern int halide_error_device_interface_no_device(void *user_context);
 extern int halide_error_host_and_device_dirty(void *user_context);
+extern int halide_error_buffer_is_null(void *user_context, const char *routine);
 
 // @}
 

--- a/src/runtime/errors.cpp
+++ b/src/runtime/errors.cpp
@@ -272,4 +272,9 @@ WEAK int halide_error_host_and_device_dirty(void *user_context) {
     return halide_error_code_host_and_device_dirty;
 }
 
+WEAK int halide_error_buffer_is_null(void *user_context, const char *routine) {
+    error(user_context) << "Buffer pointer passed to " << routine << " is null.\n";
+    return halide_error_code_buffer_is_null;
+}
+
 }  // extern "C"


### PR DESCRIPTION
This is fairly easy to do and seems worthwhile to more quickly isolate crashes in the wild. (There's an argument that a null pointer SEGV is easier to debug if there's a good stack trace but that seems rare relative to reporting an error message.)

Remove extraneous null buffer handling code from halide_device_sync as
it did not work anyway. (Making it sync all devices requires
registering each device_interface which has been used, which is
perhaps possible, though seems like too much work for something noone
uses.)