### PR TITLE
More/better fixes for disabled GPU targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1048,6 +1048,7 @@ $(FILTERS_DIR)/cxx_mangling.a: $(BIN_DIR)/cxx_mangling.generator $(FILTERS_DIR)/
 	$(CURDIR)/$< $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime-c_plus_plus_name_mangling -f "HalideTest::AnotherNamespace::cxx_mangling"
 	$(ROOT_DIR)/tools/makelib.sh $@ $@ $(FILTERS_DIR)/cxx_mangling_externs.o
 
+ifneq ($(TEST_CUDA), )
 # Also build with a gpu target to ensure that the GPU-Host generation
 # code handles name mangling properly. (Note that we don't need to
 # run this code, just check for link errors.)
@@ -1055,6 +1056,7 @@ $(FILTERS_DIR)/cxx_mangling_gpu.a: $(BIN_DIR)/cxx_mangling.generator $(FILTERS_D
 	@mkdir -p $(@D)
 	$(CURDIR)/$< $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime-c_plus_plus_name_mangling-cuda -f "HalideTest::cxx_mangling_gpu"
 	$(ROOT_DIR)/tools/makelib.sh $@ $@ $(FILTERS_DIR)/cxx_mangling_externs.o
+endif
 
 $(FILTERS_DIR)/cxx_mangling_define_extern_externs.o: $(ROOT_DIR)/test/generator/cxx_mangling_define_extern_externs.cpp $(FILTERS_DIR)/cxx_mangling.h
 	@mkdir -p $(@D)
@@ -1128,11 +1130,16 @@ $(FILTERS_DIR)/matlab.a: $(BIN_DIR)/matlab.generator
 # TODO(srj): we really want to say "anything that depends on tiled_blur.a also depends on blur2x2.a";
 # is there a way to specify that in Make?
 $(BIN_DIR)/$(TARGET)/generator_aot_tiled_blur: $(FILTERS_DIR)/blur2x2.a
+ifneq ($(TEST_CUDA), )
 $(BIN_DIR)/$(TARGET)/generator_aot_cxx_mangling: $(FILTERS_DIR)/cxx_mangling_gpu.a
+endif
 $(BIN_DIR)/$(TARGET)/generator_aot_cxx_mangling_define_extern: $(FILTERS_DIR)/cxx_mangling.a
 
 $(BIN_DIR)/$(TARGET)/generator_aotcpp_tiled_blur: $(FILTERS_DIR)/blur2x2.cpp
-$(BIN_DIR)/$(TARGET)/generator_aotcpp_cxx_mangling: $(FILTERS_DIR)/cxx_mangling_gpu.cpp $(FILTERS_DIR)/cxx_mangling_externs.o
+ifneq ($(TEST_CUDA), )
+$(BIN_DIR)/$(TARGET)/generator_aotcpp_cxx_mangling: $(FILTERS_DIR)/cxx_mangling_gpu.cpp
+endif
+$(BIN_DIR)/$(TARGET)/generator_aotcpp_cxx_mangling: $(FILTERS_DIR)/cxx_mangling_externs.o
 $(BIN_DIR)/$(TARGET)/generator_aotcpp_cxx_mangling_define_extern: $(FILTERS_DIR)/cxx_mangling.cpp $(FILTERS_DIR)/cxx_mangling_externs.o $(FILTERS_DIR)/cxx_mangling_define_extern_externs.o
 
 $(BUILD_DIR)/stubuser_generator.o: $(FILTERS_DIR)/stubtest.stub.h

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -278,9 +278,21 @@ if (WITH_TEST_GENERATORS)
                                  AOT_LIBRARY_TARGET cxx_mangling_gpu
                                  GENERATED_FUNCTION HalideTest::cxx_mangling_gpu
                                  GENERATOR_HALIDE_TARGET host-c_plus_plus_name_mangling-cuda)
+  endif()
 
+  # gpu_object_lifetime can build with a variety of GPU targets (or none).
+  if(TARGET_PTX)
     halide_define_aot_test(gpu_object_lifetime
                            GENERATOR_HALIDE_TARGET host-cuda-debug)
+  elif(TARGET_OPENCL)
+    halide_define_aot_test(gpu_object_lifetime
+                           GENERATOR_HALIDE_TARGET host-opencl-debug)
+  elif(TARGET_METAL)
+    halide_define_aot_test(gpu_object_lifetime
+                           GENERATOR_HALIDE_TARGET host-metal-debug)
+  else()
+    halide_define_aot_test(gpu_object_lifetime
+                           GENERATOR_HALIDE_TARGET host-debug)
   endif()
 
   halide_define_aot_test(pyramid

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -284,10 +284,10 @@ if (WITH_TEST_GENERATORS)
   if(TARGET_PTX)
     halide_define_aot_test(gpu_object_lifetime
                            GENERATOR_HALIDE_TARGET host-cuda-debug)
-  elif(TARGET_OPENCL)
+  elseif(TARGET_OPENCL)
     halide_define_aot_test(gpu_object_lifetime
                            GENERATOR_HALIDE_TARGET host-opencl-debug)
-  elif(TARGET_METAL)
+  elseif(TARGET_METAL)
     halide_define_aot_test(gpu_object_lifetime
                            GENERATOR_HALIDE_TARGET host-metal-debug)
   else()

--- a/test/generator/cxx_mangling_aottest.cpp
+++ b/test/generator/cxx_mangling_aottest.cpp
@@ -6,7 +6,7 @@
 #include <string.h>
 
 #include "cxx_mangling.h"
-#ifdef WITH_PTX
+#ifdef TEST_CUDA
 #include "cxx_mangling_gpu.h"
 #endif
 
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
     std::string *string_ptr = nullptr;
     const std::string *const_string_ptr = nullptr;
 
-#ifdef WITH_PTX
+#ifdef TEST_CUDA
     // Don't bother calling this (we haven't linked in the CUDA support it needs),
     // just force a reference to ensure it is linked in.
     int (*f)(halide_buffer_t *,
@@ -64,6 +64,8 @@ int main(int argc, char **argv) {
              halide_buffer_t *) = HalideTest::cxx_mangling_gpu;
 
     printf("HalideTest::cxx_mangling is at: %p\n", (void*) f);
+#else
+    printf("TEST_CUDA is disabled, skipping cxx_mangling_gpu test.\n");
 #endif
 
     my_namespace::my_class mc;

--- a/test/generator/gpu_object_lifetime_aottest.cpp
+++ b/test/generator/gpu_object_lifetime_aottest.cpp
@@ -27,6 +27,17 @@ void my_halide_print(void *user_context, const char *str) {
 }
 
 int main(int argc, char **argv) {
+
+#if defined(TEST_CUDA)
+    printf("TEST_CUDA enabled for gpu_object_lifetime testing...\n");
+#elif defined(TEST_OPENCL)
+    printf("TEST_OPENCL enabled for gpu_object_lifetime testing...\n");
+#elif defined(TEST_METAL)
+    printf("TEST_METAL enabled for gpu_object_lifetime testing...\n");
+#else
+    printf("No GPU features enabled for gpu_object_lifetime testing!\n");
+#endif
+
     halide_set_custom_print(&my_halide_print);
 
     // Run the whole program several times.


### PR DESCRIPTION
-- Only build/link cxx_mangling_gpu in Makefile if TEST_CUDA is enabled
-- gpu_object_lifetime in CMake should allow for multiple GPU backends
-- cxx_mangling_aottest.cpp should use TEST_CUDA rather than WITH_PTX
-- Add status messages to cxx_mangling_aottest and gpu_object_lifetime to indicate which (if any) GPU backend is being tested

(attn: @mkbosmans)