### PR TITLE
Add caveat to halide_benchmark.h, plus device_sync() wrappers

### DIFF
--- a/src/Tuple.h
+++ b/src/Tuple.h
@@ -107,6 +107,22 @@ public:
         user_assert(e.size() > 0) << "Realizations must have at least one element\n";
     }
 
+    /** Call device_sync() for all Buffers in the Realization. 
+     * If one of the calls returns an error, subsequent Buffers won't have
+     * device_sync called; thus callers should consider a nonzero return
+     * code to mean that potentially all of the Buffers are in an indeterminate
+     * state of sync.
+     * Calling this explicitly should rarely be necessary, except for profiling. */
+    int device_sync(void *ctx = nullptr) {
+        for (auto &b : images) {
+            int result = b.device_sync(ctx);
+            if (result != 0) {
+                return result;
+            }
+        }
+        return 0; 
+    }
+
 };
 
 /** Equivalents of some standard operators for tuples. */

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1183,6 +1183,15 @@ typedef struct halide_buffer_t {
         return host + index * type.bytes();
     }
 
+    /** Attempt to call device_sync for the buffer. If the buffer 
+     * has no device_interface (or no device_sync), this is a quiet no-op. 
+     * Calling this explicitly should rarely be necessary, except for profiling. */
+    HALIDE_ALWAYS_INLINE int device_sync(void *ctx = nullptr) {
+        if (device_interface && device_interface->device_sync) {
+            return device_interface->device_sync(ctx, this);
+        }
+        return 0;
+    }
 #endif
 } halide_buffer_t;
 

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1186,7 +1186,7 @@ typedef struct halide_buffer_t {
     /** Attempt to call device_sync for the buffer. If the buffer 
      * has no device_interface (or no device_sync), this is a quiet no-op. 
      * Calling this explicitly should rarely be necessary, except for profiling. */
-    HALIDE_ALWAYS_INLINE int device_sync(void *ctx = nullptr) {
+    HALIDE_ALWAYS_INLINE int device_sync(void *ctx = NULL) {
         if (device_interface && device_interface->device_sync) {
             return device_interface->device_sync(ctx, this);
         }

--- a/tools/halide_benchmark.h
+++ b/tools/halide_benchmark.h
@@ -11,6 +11,14 @@ namespace Tools {
 // how many times the operation is run for each time measurement, the
 // result is the minimum over a number of samples runs. The result is the
 // amount of time in seconds for one iteration.
+//
+// IMPORTANT NOTE: Using this tool for timing GPU code may be misleading,
+// as it does not account for time needed to synchronize to/from the GPU;
+// if the callback doesn't include calls to device_sync(), the reported
+// time may only be that to queue the requests; if the callback *does*
+// include calls to device_sync(), it might exaggerate the sync overhead
+// for real-world use. For now, callers using this to benchmark GPU
+// code should measure with extreme caution.
 
 template <typename F>
 double benchmark(int samples, int iterations, F op) {


### PR DESCRIPTION
Add warning about using the benchmark() function for GPU code, as naive use can give misleading results. Also add convenience wrappers to halide_buffer_t and Realization.