### PR TITLE
Define and enforce EXPORT for gcc/clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ HEXAGON_CXX_FLAGS=$(if $(WITH_HEXAGON), -DWITH_HEXAGON=1, )
 HEXAGON_LLVM_CONFIG_LIB=$(if $(WITH_HEXAGON), hexagon, )
 
 CXX_WARNING_FLAGS = -Wall -Werror -Wno-unused-function -Wcast-qual -Wignored-qualifiers -Wno-comment -Wsign-compare -Wno-unknown-warning-option -Wno-psabi
-CXX_FLAGS = $(CXX_WARNING_FLAGS) -fno-rtti -Woverloaded-virtual $(FPIC) $(OPTIMIZE) -fno-omit-frame-pointer -DCOMPILING_HALIDE
+CXX_FLAGS = $(CXX_WARNING_FLAGS) -fno-rtti -Woverloaded-virtual $(FPIC) $(OPTIMIZE) -fno-omit-frame-pointer -DCOMPILING_HALIDE -fvisibility=hidden
 
 CXX_FLAGS += $(LLVM_CXX_FLAGS)
 CXX_FLAGS += $(PTX_CXX_FLAGS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -525,6 +525,9 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
 )
 # Define Halide_SHARED or Halide_STATIC depending on library type
 target_compile_definitions(Halide PRIVATE "-DHalide_${HALIDE_LIBRARY_TYPE}")
+# Default to not exporting symbols from libHalide
+set_target_properties(Halide PROPERTIES CXX_VISIBILITY_PRESET hidden)
+set_target_properties(Halide PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
 # Ensure that these tools are build first
 add_dependencies(Halide
   binary2cpp

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -733,48 +733,48 @@ bool Shuffle::is_extract_element() const {
 }
 
 
-template<> void ExprNode<IntImm>::accept(IRVisitor *v) const { v->visit((const IntImm *)this); }
-template<> void ExprNode<UIntImm>::accept(IRVisitor *v) const { v->visit((const UIntImm *)this); }
-template<> void ExprNode<FloatImm>::accept(IRVisitor *v) const { v->visit((const FloatImm *)this); }
-template<> void ExprNode<StringImm>::accept(IRVisitor *v) const { v->visit((const StringImm *)this); }
-template<> void ExprNode<Cast>::accept(IRVisitor *v) const { v->visit((const Cast *)this); }
-template<> void ExprNode<Variable>::accept(IRVisitor *v) const { v->visit((const Variable *)this); }
-template<> void ExprNode<Add>::accept(IRVisitor *v) const { v->visit((const Add *)this); }
-template<> void ExprNode<Sub>::accept(IRVisitor *v) const { v->visit((const Sub *)this); }
-template<> void ExprNode<Mul>::accept(IRVisitor *v) const { v->visit((const Mul *)this); }
-template<> void ExprNode<Div>::accept(IRVisitor *v) const { v->visit((const Div *)this); }
-template<> void ExprNode<Mod>::accept(IRVisitor *v) const { v->visit((const Mod *)this); }
-template<> void ExprNode<Min>::accept(IRVisitor *v) const { v->visit((const Min *)this); }
-template<> void ExprNode<Max>::accept(IRVisitor *v) const { v->visit((const Max *)this); }
-template<> void ExprNode<EQ>::accept(IRVisitor *v) const { v->visit((const EQ *)this); }
-template<> void ExprNode<NE>::accept(IRVisitor *v) const { v->visit((const NE *)this); }
-template<> void ExprNode<LT>::accept(IRVisitor *v) const { v->visit((const LT *)this); }
-template<> void ExprNode<LE>::accept(IRVisitor *v) const { v->visit((const LE *)this); }
-template<> void ExprNode<GT>::accept(IRVisitor *v) const { v->visit((const GT *)this); }
-template<> void ExprNode<GE>::accept(IRVisitor *v) const { v->visit((const GE *)this); }
-template<> void ExprNode<And>::accept(IRVisitor *v) const { v->visit((const And *)this); }
-template<> void ExprNode<Or>::accept(IRVisitor *v) const { v->visit((const Or *)this); }
-template<> void ExprNode<Not>::accept(IRVisitor *v) const { v->visit((const Not *)this); }
-template<> void ExprNode<Select>::accept(IRVisitor *v) const { v->visit((const Select *)this); }
-template<> void ExprNode<Load>::accept(IRVisitor *v) const { v->visit((const Load *)this); }
-template<> void ExprNode<Ramp>::accept(IRVisitor *v) const { v->visit((const Ramp *)this); }
-template<> void ExprNode<Broadcast>::accept(IRVisitor *v) const { v->visit((const Broadcast *)this); }
-template<> void ExprNode<Call>::accept(IRVisitor *v) const { v->visit((const Call *)this); }
-template<> void ExprNode<Shuffle>::accept(IRVisitor *v) const { v->visit((const Shuffle *)this); }
-template<> void ExprNode<Let>::accept(IRVisitor *v) const { v->visit((const Let *)this); }
-template<> void StmtNode<LetStmt>::accept(IRVisitor *v) const { v->visit((const LetStmt *)this); }
-template<> void StmtNode<AssertStmt>::accept(IRVisitor *v) const { v->visit((const AssertStmt *)this); }
-template<> void StmtNode<ProducerConsumer>::accept(IRVisitor *v) const { v->visit((const ProducerConsumer *)this); }
-template<> void StmtNode<For>::accept(IRVisitor *v) const { v->visit((const For *)this); }
-template<> void StmtNode<Store>::accept(IRVisitor *v) const { v->visit((const Store *)this); }
-template<> void StmtNode<Provide>::accept(IRVisitor *v) const { v->visit((const Provide *)this); }
-template<> void StmtNode<Allocate>::accept(IRVisitor *v) const { v->visit((const Allocate *)this); }
-template<> void StmtNode<Free>::accept(IRVisitor *v) const { v->visit((const Free *)this); }
-template<> void StmtNode<Realize>::accept(IRVisitor *v) const { v->visit((const Realize *)this); }
-template<> void StmtNode<Block>::accept(IRVisitor *v) const { v->visit((const Block *)this); }
-template<> void StmtNode<IfThenElse>::accept(IRVisitor *v) const { v->visit((const IfThenElse *)this); }
-template<> void StmtNode<Evaluate>::accept(IRVisitor *v) const { v->visit((const Evaluate *)this); }
-template<> void StmtNode<Prefetch>::accept(IRVisitor *v) const { v->visit((const Prefetch *)this); }
+template<> EXPORT void ExprNode<IntImm>::accept(IRVisitor *v) const { v->visit((const IntImm *)this); }
+template<> EXPORT void ExprNode<UIntImm>::accept(IRVisitor *v) const { v->visit((const UIntImm *)this); }
+template<> EXPORT void ExprNode<FloatImm>::accept(IRVisitor *v) const { v->visit((const FloatImm *)this); }
+template<> EXPORT void ExprNode<StringImm>::accept(IRVisitor *v) const { v->visit((const StringImm *)this); }
+template<> EXPORT void ExprNode<Cast>::accept(IRVisitor *v) const { v->visit((const Cast *)this); }
+template<> EXPORT void ExprNode<Variable>::accept(IRVisitor *v) const { v->visit((const Variable *)this); }
+template<> EXPORT void ExprNode<Add>::accept(IRVisitor *v) const { v->visit((const Add *)this); }
+template<> EXPORT void ExprNode<Sub>::accept(IRVisitor *v) const { v->visit((const Sub *)this); }
+template<> EXPORT void ExprNode<Mul>::accept(IRVisitor *v) const { v->visit((const Mul *)this); }
+template<> EXPORT void ExprNode<Div>::accept(IRVisitor *v) const { v->visit((const Div *)this); }
+template<> EXPORT void ExprNode<Mod>::accept(IRVisitor *v) const { v->visit((const Mod *)this); }
+template<> EXPORT void ExprNode<Min>::accept(IRVisitor *v) const { v->visit((const Min *)this); }
+template<> EXPORT void ExprNode<Max>::accept(IRVisitor *v) const { v->visit((const Max *)this); }
+template<> EXPORT void ExprNode<EQ>::accept(IRVisitor *v) const { v->visit((const EQ *)this); }
+template<> EXPORT void ExprNode<NE>::accept(IRVisitor *v) const { v->visit((const NE *)this); }
+template<> EXPORT void ExprNode<LT>::accept(IRVisitor *v) const { v->visit((const LT *)this); }
+template<> EXPORT void ExprNode<LE>::accept(IRVisitor *v) const { v->visit((const LE *)this); }
+template<> EXPORT void ExprNode<GT>::accept(IRVisitor *v) const { v->visit((const GT *)this); }
+template<> EXPORT void ExprNode<GE>::accept(IRVisitor *v) const { v->visit((const GE *)this); }
+template<> EXPORT void ExprNode<And>::accept(IRVisitor *v) const { v->visit((const And *)this); }
+template<> EXPORT void ExprNode<Or>::accept(IRVisitor *v) const { v->visit((const Or *)this); }
+template<> EXPORT void ExprNode<Not>::accept(IRVisitor *v) const { v->visit((const Not *)this); }
+template<> EXPORT void ExprNode<Select>::accept(IRVisitor *v) const { v->visit((const Select *)this); }
+template<> EXPORT void ExprNode<Load>::accept(IRVisitor *v) const { v->visit((const Load *)this); }
+template<> EXPORT void ExprNode<Ramp>::accept(IRVisitor *v) const { v->visit((const Ramp *)this); }
+template<> EXPORT void ExprNode<Broadcast>::accept(IRVisitor *v) const { v->visit((const Broadcast *)this); }
+template<> EXPORT void ExprNode<Call>::accept(IRVisitor *v) const { v->visit((const Call *)this); }
+template<> EXPORT void ExprNode<Shuffle>::accept(IRVisitor *v) const { v->visit((const Shuffle *)this); }
+template<> EXPORT void ExprNode<Let>::accept(IRVisitor *v) const { v->visit((const Let *)this); }
+template<> EXPORT void StmtNode<LetStmt>::accept(IRVisitor *v) const { v->visit((const LetStmt *)this); }
+template<> EXPORT void StmtNode<AssertStmt>::accept(IRVisitor *v) const { v->visit((const AssertStmt *)this); }
+template<> EXPORT void StmtNode<ProducerConsumer>::accept(IRVisitor *v) const { v->visit((const ProducerConsumer *)this); }
+template<> EXPORT void StmtNode<For>::accept(IRVisitor *v) const { v->visit((const For *)this); }
+template<> EXPORT void StmtNode<Store>::accept(IRVisitor *v) const { v->visit((const Store *)this); }
+template<> EXPORT void StmtNode<Provide>::accept(IRVisitor *v) const { v->visit((const Provide *)this); }
+template<> EXPORT void StmtNode<Allocate>::accept(IRVisitor *v) const { v->visit((const Allocate *)this); }
+template<> EXPORT void StmtNode<Free>::accept(IRVisitor *v) const { v->visit((const Free *)this); }
+template<> EXPORT void StmtNode<Realize>::accept(IRVisitor *v) const { v->visit((const Realize *)this); }
+template<> EXPORT void StmtNode<Block>::accept(IRVisitor *v) const { v->visit((const Block *)this); }
+template<> EXPORT void StmtNode<IfThenElse>::accept(IRVisitor *v) const { v->visit((const IfThenElse *)this); }
+template<> EXPORT void StmtNode<Evaluate>::accept(IRVisitor *v) const { v->visit((const Evaluate *)this); }
+template<> EXPORT void StmtNode<Prefetch>::accept(IRVisitor *v) const { v->visit((const Prefetch *)this); }
 
 Call::ConstString Call::debug_to_file = "debug_to_file";
 Call::ConstString Call::reinterpret = "reinterpret";

--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -6,6 +6,9 @@ namespace Internal {
 using std::pair;
 using std::vector;
 
+IRMutator::~IRMutator() {
+}
+
 Expr IRMutator::mutate(const Expr &e) {
     if (e.defined()) {
         e.accept(this);

--- a/src/IRMutator.h
+++ b/src/IRMutator.h
@@ -23,6 +23,7 @@ namespace Internal {
  */
 class IRMutator : public IRVisitor {
 public:
+    EXPORT virtual ~IRMutator();
 
     /** This is the main interface for using a mutator. Also call
      * these in your subclass to mutate sub-expressions and

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -103,6 +103,9 @@ ostream &operator<<(ostream &stream, const LoopLevel &loop_level) {
 
 namespace Internal {
 
+IRPrinter::~IRPrinter() {
+}
+
 void IRPrinter::test() {
     Type i32 = Int(32);
     Type f32 = Float(32);

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -69,6 +69,8 @@ EXPORT std::ostream &operator<<(std::ostream &stream, const NameMangling &);
  */
 class IRPrinter : public IRVisitor {
 public:
+    EXPORT virtual ~IRPrinter();
+
     /** Construct an IRPrinter pointed at a given output stream
      * (e.g. std::cout, or a std::ofstream) */
     EXPORT IRPrinter(std::ostream &);

--- a/src/Util.h
+++ b/src/Util.h
@@ -19,15 +19,16 @@
 #include <string>
 #include <cstring>
 
-// by default, the symbol EXPORT does nothing. In windows dll builds we can define it to __declspec(dllexport)
-#if defined(_WIN32) && defined(Halide_SHARED)
+#ifndef EXPORT
+#if defined(_MSC_VER)
 #ifdef Halide_EXPORTS
 #define EXPORT __declspec(dllexport)
 #else
 #define EXPORT __declspec(dllimport)
 #endif
 #else
-#define EXPORT
+#define EXPORT __attribute__((visibility("default")))
+#endif
 #endif
 
 // If we're in user code, we don't want certain functions to be inlined.

--- a/test/correctness/c_function.cpp
+++ b/test/correctness/c_function.cpp
@@ -3,10 +3,6 @@
 
 using namespace Halide;
 
-// NB: You must compile with -rdynamic for llvm to be able to find the appropriate symbols
-// This is not supported by the C backend.
-
-// On windows, you need to use declspec to do the same.
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else

--- a/test/correctness/c_function.cpp
+++ b/test/correctness/c_function.cpp
@@ -3,6 +3,10 @@
 
 using namespace Halide;
 
+// NB: You must compile with -rdynamic for llvm to be able to find the appropriate symbols
+// This is not supported by the C backend.     
+      
+// On windows, you need to use declspec to do the same.       
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else


### PR DESCRIPTION
At present we only define EXPORT for Win32 (because we have to); this PR proposes to also define it for GCC/Clang and default visibility to hidden; the motivation here is to catch missing/wrong EXPORT settings on ~all systems, rather than waiting for Windows buildbots to catch them.  

(In theory, this could also make libHalide.so load faster; in practice, that's not likely important, and even if it was, we'd probably also have to hide all the exported LLVM symbols for that to matter.)  

(Added some EXPORT cruft that Clang really wanted.)  