### PR TITLE
Patch to replace print to vprint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,6 +361,7 @@ SOURCE_FILES = \
   RemoveDeadAllocations.cpp \
   RemoveTrivialForLoops.cpp \
   RemoveUndef.cpp \
+  ReplacePrints.cpp \
   Schedule.cpp \
   ScheduleFunctions.cpp \
   ScheduleParam.cpp \
@@ -499,6 +500,7 @@ HEADER_FILES = \
   RemoveDeadAllocations.h \
   RemoveTrivialForLoops.h \
   RemoveUndef.h \
+  ReplacePrints.h \
   Schedule.h \
   ScheduleFunctions.h \
   ScheduleParam.h \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -356,6 +356,7 @@ set(HEADER_FILES
   RemoveDeadAllocations.h
   RemoveTrivialForLoops.h
   RemoveUndef.h
+  ReplacePrints.h
   Schedule.h
   ScheduleFunctions.h
   ScheduleParam.h
@@ -499,6 +500,7 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   RemoveDeadAllocations.cpp
   RemoveTrivialForLoops.cpp
   RemoveUndef.cpp
+  ReplacePrints.cpp
   Schedule.cpp
   ScheduleFunctions.cpp
   ScheduleParam.cpp

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -40,6 +40,7 @@
 #include "RemoveDeadAllocations.h"
 #include "RemoveTrivialForLoops.h"
 #include "RemoveUndef.h"
+#include "ReplacePrints.h"
 #include "ScheduleFunctions.h"
 #include "SelectGPUAPI.h"
 #include "SkipStages.h"
@@ -251,6 +252,9 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
     s = unroll_loops(s);
     s = simplify(s);
     debug(2) << "Lowering after unrolling:\n" << s << "\n\n";
+
+    debug(1) << "Replacing Prints...\n";
+    s = replace_prints(s, t);
 
     debug(1) << "Vectorizing...\n";
     s = vectorize_loops(s, t);

--- a/src/ReplacePrints.cpp
+++ b/src/ReplacePrints.cpp
@@ -1,0 +1,58 @@
+#include <algorithm>
+
+#include "IRMutator.h"
+#include "ReplacePrints.h"
+
+namespace Halide {
+namespace Internal {
+
+namespace {
+
+class ReplacePrint : public IRMutator {
+
+    const Target &target;
+    bool in_hexagon;
+    bool in_vectorized;
+    using IRMutator::visit;
+
+    void visit(const Call *op) {
+        if(op->name == "halide_print" && in_hexagon && in_vectorized) {
+            debug(1) << "Found print_halide for vectorized schedule for Hexagon: " << op->name << "\n";
+            expr = Call::make(Int(32), "halide_vprint", op->args, Internal::Call::Extern);
+        }
+        else {
+            debug(1) << "No halide_print found....Continue" << "\n";
+            IRMutator::visit(op);
+        }
+    }
+  
+    void visit(const For *for_loop) {
+        bool old_in_hexagon = in_hexagon;
+        if (for_loop->device_api == DeviceAPI::Hexagon) {
+            in_hexagon = true;
+        }
+
+        if (for_loop->for_type == ForType::Vectorized) {
+            in_vectorized = true;
+        }
+
+        IRMutator::visit(for_loop);
+
+        if (for_loop->device_api == DeviceAPI::Hexagon) {
+            in_hexagon = old_in_hexagon;
+        }
+    }
+
+public:
+    ReplacePrint(const Target &t) : target(t), in_hexagon(false), in_vectorized(false) {}    
+
+};
+
+} // Anonymous namespace
+
+Stmt replace_prints(Stmt s, const Target &t) {
+    return ReplacePrint(t).mutate(s);
+}
+
+}
+}

--- a/src/ReplacePrints.h
+++ b/src/ReplacePrints.h
@@ -1,0 +1,23 @@
+#ifndef HALIDE_REPLACE_PRINTS_H
+#define HALIDE_REPLACE_PRINTS_H
+
+/** \file
+ * Defines the lowering pass that vectorizes loops marked as such
+ */
+
+#include "IR.h"
+#include "Target.h"
+
+namespace Halide {
+namespace Internal {
+
+/** Take a statement with for loops marked for vectorization, and turn
+ * them into single statements that operate on vectors. The loops in
+ * question must have constant extent.
+ */
+Stmt replace_prints(Stmt s, const Target &t);
+
+}
+}
+
+#endif

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -68,6 +68,7 @@ struct buffer_t;
  */
 // @{
 extern void halide_print(void *user_context, const char *);
+extern void halide_vprint(void *user_context, const char *);
 extern void halide_default_print(void *user_context, const char *);
 typedef void (*halide_print_t)(void *, const char *);
 extern halide_print_t halide_set_custom_print(halide_print_t print);

--- a/src/runtime/hexagon_remote/Makefile
+++ b/src/runtime/hexagon_remote/Makefile
@@ -35,6 +35,8 @@ HEXAGON_ELFSIGNER ?= ${HEXAGON_SDK_ROOT}/tools/elfsigner/elfsigner.py
 # Some SDK versions use "inc/", some use "incs/"
 HEXAGON_SDK_INCLUDES ?= "${HEXAGON_SDK_ROOT}/incs"
 
+HEXAGON_QDEBUG_INCLUDES ?= "${HEXAGON_SDK_ROOT}/libs/qdebug/inc"
+
 # Some SDK versions use "lib/", some use "libs/"
 HEXAGON_SDK_LIBS ?= "${HEXAGON_SDK_ROOT}/libs"
 
@@ -96,7 +98,11 @@ bin/%/thread_pool.o: thread_pool.cpp
 
 bin/%/halide_remote.o: halide_remote.cpp dlib.h
 	mkdir -p $(@D)
-	$(CXX-$*) $(CCFLAGS-$*) -fPIC -c halide_remote.cpp -o $@
+	$(CXX-$*) $(CCFLAGS-$*) -fPIC -c halide_remote.cpp -I ${HEXAGON_QDEBUG_INCLUDES} -o $@
+
+bin/%/qdebug_dump_reg_asm.o: qdebug_asm.h qdebug_dump_reg_asm.S
+	mkdir -p $(@D)
+	$(CXX-$*) $(CCFLAGS-$*) -fPIC -c qdebug_dump_reg_asm.S -I ${HEXAGON_QDEBUG_INCLUDES} -o $@
 
 bin/%/dlib.o: dlib.cpp dlib.h
 	mkdir -p $(@D)
@@ -123,11 +129,11 @@ bin/%/log.o: log.cpp
 	$(CXX-$*) $(CCFLAGS-$*) -fPIC -c log.cpp -o $@
 
 # Build rules for the hexagon implementation.
-bin/%/libhalide_hexagon_remote_skel.so: bin/%/halide_remote.o bin/%/halide_hexagon_remote_skel.o bin/%/thread_pool.o bin/%/nearbyint.o bin/%/c11_stubs.o bin/%/log.o bin/%/dlib.o
+bin/%/libhalide_hexagon_remote_skel.so: bin/%/halide_remote.o bin/%/qdebug_dump_reg_asm.o bin/%/halide_hexagon_remote_skel.o bin/%/thread_pool.o bin/%/nearbyint.o bin/%/c11_stubs.o bin/%/log.o bin/%/dlib.o
 	mkdir -p $(@D)
 	$(CC-$*) -m$* -mG0lib -G0 -fpic -shared -lc $^ -Wl,-soname=libhalide_hexagon_remote_skel.so -Wl,--no-threads -o $@ \
 	-Wl,-Bsymbolic -Wl,--wrap=malloc -Wl,--wrap=calloc -Wl,--wrap=free \
-	-Wl,--wrap=realloc -Wl,--wrap=memalign -Wl,--wrap=__stack_chk_fail
+	-Wl,--wrap=realloc -Wl,--wrap=memalign -Wl,--wrap=__stack_chk_fail -Wl,--whole-archive libqdebug.a
 
 bin/%/signed_by_debug/libhalide_hexagon_remote_skel.so: bin/%/libhalide_hexagon_remote_skel.so
 	mkdir -p $(@D)

--- a/src/runtime/hexagon_remote/halide_remote.cpp
+++ b/src/runtime/hexagon_remote/halide_remote.cpp
@@ -25,6 +25,12 @@ typedef halide_hexagon_remote_scalar_t scalar_t;
 
 extern "C" {
 
+void qdebug_dump_reg_asm();
+
+void halide_vprint(void *user_context, const char *str) {
+    qdebug_dump_reg_asm();
+}
+
 // This is a basic implementation of the Halide runtime for Hexagon.
 void halide_print(void *user_context, const char *str) {
     if (str) {

--- a/src/runtime/hexagon_remote/qdebug_dump_reg_asm.S
+++ b/src/runtime/hexagon_remote/qdebug_dump_reg_asm.S
@@ -1,0 +1,51 @@
+/**=============================================================================
+
+ @file
+ qdebug_dump_reg_asm.h
+
+ @brief
+ An assembly file illustrating some of the ways the QD macros may be used to
+ display or process register contents.
+
+ Copyright (c) 2017 Qualcomm Technologies Incorporated.
+ All Rights Reserved Qualcomm Proprietary
+
+ Export of this technology or software is regulated by the U.S.
+ Government. Diversion contrary to U.S. law prohibited.
+
+ All ideas, data and information contained in or disclosed by
+ this document are confidential and proprietary information of
+ Qualcomm Technologies Incorporated and all rights therein are expressly reserved.
+ By accepting this material the recipient agrees that this material
+ and the information contained therein are held in confidence and in
+ trust and will not be used, copied, reproduced in whole or in part,
+ nor its contents revealed in any manner to others without the express
+ written permission of Qualcomm Technologies Incorporated.
+
+ =============================================================================**/
+
+#include "qdebug_asm.h"
+
+	.text
+   .p2align 4                         
+   .globl test           
+   .type       test, @function
+test:
+	{ r0 = add(r0,r0) }
+	{ JUMPR R31 }
+
+   .size       test, .-test
+ 
+   .text
+   .p2align 4                         
+   .globl qdebug_dump_reg_asm           
+   .type       qdebug_dump_reg_asm, @function
+qdebug_dump_reg_asm:
+   {
+   ALLOCFRAME(#(8*8 + 2*8)) // r + p
+   }
+   QD print_u8 V_all
+   {
+   DEALLOC_RETURN
+   }
+   .size       qdebug_dump_reg_asm, .-qdebug_dump_reg_asm


### PR DESCRIPTION
This patch replaces print with vprint.
vprint is used to dump HVX register contents
if a schedule is vectorized and run on Hexagon.