### PR TITLE
A min reduction over infinities should be infinity

### DIFF
--- a/src/Type.cpp
+++ b/src/Type.cpp
@@ -36,9 +36,9 @@ Halide::Expr Type::max() const {
         if (bits() == 16) {
             return Internal::FloatImm::make(*this, 65504.0);
         } else if (bits() == 32) {
-            return Internal::FloatImm::make(*this, FLT_MAX);
+            return Internal::FloatImm::make(*this, std::numeric_limits<float>::infinity());
         } else if (bits() == 64) {
-            return Internal::FloatImm::make(*this, DBL_MAX);
+            return Internal::FloatImm::make(*this, std::numeric_limits<double>::infinity());
         } else {
             internal_error
                 << "Unknown float type: " << (*this) << "\n";
@@ -60,9 +60,9 @@ Halide::Expr Type::min() const {
         if (bits() == 16) {
             return Internal::FloatImm::make(*this, -65504.0);
         } else if (bits() == 32) {
-            return Internal::FloatImm::make(*this, -FLT_MAX);
+            return Internal::FloatImm::make(*this, -std::numeric_limits<float>::infinity());
         } else if (bits() == 64) {
-            return Internal::FloatImm::make(*this, -DBL_MAX);
+            return Internal::FloatImm::make(*this, -std::numeric_limits<double>::infinity());
         } else {
             internal_error
                 << "Unknown float type: " << (*this) << "\n";

--- a/src/Type.h
+++ b/src/Type.h
@@ -424,10 +424,12 @@ struct Type {
     EXPORT bool is_min(int64_t) const;
     // @}
 
-    /** Return an expression which is the maximum value of this type */
+    /** Return an expression which is the maximum value of this type.
+     * Returns infinity for types which can represent it. */
     EXPORT Expr max() const;
 
-    /** Return an expression which is the minimum value of this type */
+    /** Return an expression which is the minimum value of this type.
+     * Returns -infinity for types which can represent it. */
     EXPORT Expr min() const;
 };
 

--- a/test/correctness/inline_reduction.cpp
+++ b/test/correctness/inline_reduction.cpp
@@ -151,6 +151,30 @@ int main(int argc, char **argv) {
         return -1;
     }
 
+    // Check that min of a bunch of infinities is infinity
+    const float inf_f32 = std::numeric_limits<float>::infinity();
+    const double inf_f64 = std::numeric_limits<double>::infinity();
+    result_f32 = evaluate<float>(minimum(RDom(0, 10) * inf_f32));
+    if (result_f32 != inf_f32) {
+        printf("minimum is %f instead of infinity\n", result_f32);
+        return -1;
+    }
+    result_f64 = evaluate<double>(minimum(RDom(0, 10) * Expr(inf_f64)));
+    if (result_f64 != inf_f64) {
+        printf("minimum is %f instead of infinity\n", result_f64);
+        return -1;
+    }
+    result_f32 = evaluate<float>(maximum(RDom(0, 10) * -inf_f32));
+    if (result_f32 != -inf_f32) {
+        printf("minimum is %f instead of -infinity\n", result_f32);
+        return -1;
+    }
+    result_f64 = evaluate<double>(maximum(RDom(0, 10) * Expr(-inf_f64)));
+    if (result_f64 != -inf_f64) {
+        printf("minimum is %f instead of -infinity\n", result_f64);
+        return -1;
+    }
+
     printf("Success!\n");
     return 0;
 

--- a/test/correctness/inline_reduction.cpp
+++ b/test/correctness/inline_reduction.cpp
@@ -154,24 +154,24 @@ int main(int argc, char **argv) {
     // Check that min of a bunch of infinities is infinity
     const float inf_f32 = std::numeric_limits<float>::infinity();
     const double inf_f64 = std::numeric_limits<double>::infinity();
-    result_f32 = evaluate<float>(minimum(RDom(0, 10) * inf_f32));
+    result_f32 = evaluate<float>(minimum(RDom(1, 10) * inf_f32));
     if (result_f32 != inf_f32) {
         printf("minimum is %f instead of infinity\n", result_f32);
         return -1;
     }
-    result_f64 = evaluate<double>(minimum(RDom(0, 10) * Expr(inf_f64)));
+    result_f64 = evaluate<double>(minimum(RDom(1, 10) * Expr(inf_f64)));
     if (result_f64 != inf_f64) {
         printf("minimum is %f instead of infinity\n", result_f64);
         return -1;
     }
-    result_f32 = evaluate<float>(maximum(RDom(0, 10) * -inf_f32));
+    result_f32 = evaluate<float>(maximum(RDom(1, 10) * -inf_f32));
     if (result_f32 != -inf_f32) {
-        printf("minimum is %f instead of -infinity\n", result_f32);
+        printf("maximum is %f instead of -infinity\n", result_f32);
         return -1;
     }
-    result_f64 = evaluate<double>(maximum(RDom(0, 10) * Expr(-inf_f64)));
+    result_f64 = evaluate<double>(maximum(RDom(1, 10) * Expr(-inf_f64)));
     if (result_f64 != -inf_f64) {
-        printf("minimum is %f instead of -infinity\n", result_f64);
+        printf("maximum is %f instead of -infinity\n", result_f64);
         return -1;
     }
 

--- a/test/correctness/saturating_casts.cpp
+++ b/test/correctness/saturating_casts.cpp
@@ -15,11 +15,23 @@ typedef Expr (*cast_maker_t)(Expr);
 
 template <typename source_t, typename target_t>
 void test_saturating() {
-    source_t source_min = std::numeric_limits<source_t>::lowest();
-    source_t source_max = std::numeric_limits<source_t>::max();
+    source_t source_min, source_max;
+    if (std::numeric_limits<source_t>::has_infinity) {
+        source_max = std::numeric_limits<source_t>::infinity();
+        source_min = -source_max;
+    } else {
+        source_min = std::numeric_limits<source_t>::lowest();
+        source_max = std::numeric_limits<source_t>::max();
+    }
 
-    target_t target_min = std::numeric_limits<target_t>::lowest();
-    target_t target_max = std::numeric_limits<target_t>::max();
+    target_t target_min, target_max;
+    if (std::numeric_limits<target_t>::has_infinity) {
+        target_max = std::numeric_limits<target_t>::infinity();
+        target_min = -target_max;
+    } else {
+        target_min = std::numeric_limits<target_t>::lowest();
+        target_max = std::numeric_limits<target_t>::max();
+    }
 
     Buffer<source_t> in(7);
     in(0) = (source_t)0;


### PR DESCRIPTION
This bug hit someone using infinity in a meaningful way in a float
pipeline.