### PR TITLE
EXPORT macro hygiene

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -17,18 +17,6 @@
 
 #include "HalideRuntime.h"
 
-#ifndef EXPORT
-#if defined(_WIN32) && defined(Halide_SHARED)
-#ifdef Halide_EXPORTS
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT __declspec(dllimport)
-#endif
-#else
-#define EXPORT
-#endif
-#endif
-
 #ifdef _MSC_VER
 #define HALIDE_ALLOCA _alloca
 #else

--- a/src/runtime/hexagon_remote/sim_host.cpp
+++ b/src/runtime/hexagon_remote/sim_host.cpp
@@ -10,9 +10,9 @@
 #include "sim_protocol.h"
 
 #ifdef _MSC_VER
-#define HALIDE_EXPORT __declspec(dllexport)
+#define DLLEXPORT __declspec(dllexport)
 #else
-#define HALIDE_EXPORT
+#define DLLEXPORT
 #endif
 
 typedef unsigned int handle_t;
@@ -341,7 +341,7 @@ std::mutex mutex;
 
 extern "C" {
 
-HALIDE_EXPORT
+DLLEXPORT
 int halide_hexagon_remote_initialize_kernels_v3(const unsigned char *code, int codeLen, handle_t *module_ptr) {
     std::lock_guard<std::mutex> guard(mutex);
 
@@ -362,7 +362,7 @@ int halide_hexagon_remote_initialize_kernels_v3(const unsigned char *code, int c
     return ret;
 }
 
-HALIDE_EXPORT
+DLLEXPORT
 int halide_hexagon_remote_get_symbol_v4(handle_t module_ptr, const char* name, int nameLen, handle_t* sym) {
     std::lock_guard<std::mutex> guard(mutex);
 
@@ -377,7 +377,7 @@ int halide_hexagon_remote_get_symbol_v4(handle_t module_ptr, const char* name, i
     return *sym != 0 ? 0 : -1;
 }
 
-HALIDE_EXPORT
+DLLEXPORT
 int halide_hexagon_remote_run(handle_t module_ptr, handle_t function,
                               const host_buffer *input_buffersPtrs, int input_buffersLen,
                               host_buffer *output_buffersPtrs, int output_buffersLen,
@@ -434,7 +434,7 @@ int halide_hexagon_remote_run(handle_t module_ptr, handle_t function,
     return ret;
 }
 
-HALIDE_EXPORT
+DLLEXPORT
 int halide_hexagon_remote_release_kernels_v2(handle_t module_ptr) {
     std::lock_guard<std::mutex> guard(mutex);
 
@@ -457,15 +457,15 @@ int halide_hexagon_remote_release_kernels_v2(handle_t module_ptr) {
     return send_message(Message::ReleaseKernels, {static_cast<int>(module_ptr), use_dlopenbuf});
 }
 
-HALIDE_EXPORT
+DLLEXPORT
 void halide_hexagon_host_malloc_init() {
 }
 
-HALIDE_EXPORT
+DLLEXPORT
 void halide_hexagon_host_malloc_deinit() {
 }
 
-HALIDE_EXPORT
+DLLEXPORT
 void *halide_hexagon_host_malloc(size_t x) {
     // Allocate enough space for aligning the pointer we return.
     const size_t alignment = 4096;
@@ -480,12 +480,12 @@ void *halide_hexagon_host_malloc(size_t x) {
     return ptr;
 }
 
-HALIDE_EXPORT
+DLLEXPORT
 void halide_hexagon_host_free(void *ptr) {
     free(((void**)ptr)[-1]);
 }
 
-HALIDE_EXPORT
+DLLEXPORT
 int halide_hexagon_remote_poll_profiler_state(int *func, int *threads) {
     // The stepping code periodically grabs the remote value of
     // current_func for us.

--- a/test/generator/matlab_aottest.cpp
+++ b/test/generator/matlab_aottest.cpp
@@ -8,9 +8,9 @@
 // Provide a simple mock implementation of matlab's API so we can test the mexFunction.
 
 #ifdef _WIN32
-#define EXPORT __declspec(dllexport)
+#define DLLEXPORT __declspec(dllexport)
 #else
-#define EXPORT
+#define DLLEXPORT
 #endif
 
 enum mxClassID {

--- a/test/generator/matlab_aottest.cpp
+++ b/test/generator/matlab_aottest.cpp
@@ -62,57 +62,57 @@ public:
 
 extern "C" {
 
-EXPORT int mexWarnMsgTxt(const char *msg) {
+DLLEXPORT int mexWarnMsgTxt(const char *msg) {
     // Don't bother with the varargs.
     printf("%s\n", msg);
     return 0;
 }
 
-EXPORT size_t mxGetNumberOfDimensions_730(const mxArray *a) {
+DLLEXPORT size_t mxGetNumberOfDimensions_730(const mxArray *a) {
     return a->get_number_of_dimensions();
 }
 
-EXPORT int mxGetNumberOfDimensions_700(const mxArray *a) {
+DLLEXPORT int mxGetNumberOfDimensions_700(const mxArray *a) {
     return (int) a->get_number_of_dimensions();
 }
 
-EXPORT const size_t *mxGetDimensions_730(const mxArray *a) {
+DLLEXPORT const size_t *mxGetDimensions_730(const mxArray *a) {
     return a->get_dimensions();
 }
 
-EXPORT const int *mxGetDimensions_700(const mxArray *a) {
+DLLEXPORT const int *mxGetDimensions_700(const mxArray *a) {
     assert(sizeof(size_t) == sizeof(int));
     return reinterpret_cast<const int *>(a->get_dimensions());
 }
 
-EXPORT mxClassID mxGetClassID(const mxArray *a) {
+DLLEXPORT mxClassID mxGetClassID(const mxArray *a) {
     return a->get_class_id();
 }
 
-EXPORT void *mxGetData(const mxArray *a) {
+DLLEXPORT void *mxGetData(const mxArray *a) {
     return const_cast<mxArray *>(a)->get_data();
 }
 
-EXPORT size_t mxGetElementSize(const mxArray *a) {
+DLLEXPORT size_t mxGetElementSize(const mxArray *a) {
     return a->get_element_size();
 }
 
 // We only support real, numeric classes in this mock implementation.
-EXPORT bool mxIsNumeric(const mxArray *a) {
+DLLEXPORT bool mxIsNumeric(const mxArray *a) {
     return true;
 }
-EXPORT bool mxIsLogical(const mxArray *a) {
+DLLEXPORT bool mxIsLogical(const mxArray *a) {
     return false;
 }
-EXPORT bool mxIsComplex(const mxArray *a) {
+DLLEXPORT bool mxIsComplex(const mxArray *a) {
     return false;
 }
 
-EXPORT double mxGetScalar(const mxArray *a) {
+DLLEXPORT double mxGetScalar(const mxArray *a) {
     return a->get_scalar();
 }
 
-EXPORT mxArray *mxCreateNumericMatrix_730(size_t M, size_t N, mxClassID type, mxComplexity complexity) {
+DLLEXPORT mxArray *mxCreateNumericMatrix_730(size_t M, size_t N, mxClassID type, mxComplexity complexity) {
     assert(complexity == mxREAL);
     switch (type) {
     case mxSINGLE_CLASS: return new mxArrayImpl<float>(M, N);
@@ -121,7 +121,7 @@ EXPORT mxArray *mxCreateNumericMatrix_730(size_t M, size_t N, mxClassID type, mx
     }
 }
 
-EXPORT mxArray *mxCreateNumericMatrix_700(int M, int N, mxClassID type, mxComplexity complexity) {
+DLLEXPORT mxArray *mxCreateNumericMatrix_700(int M, int N, mxClassID type, mxComplexity complexity) {
     return mxCreateNumericMatrix_730(M, N, type, complexity);
 }
 

--- a/test/performance/fast_pow.cpp
+++ b/test/performance/fast_pow.cpp
@@ -6,17 +6,16 @@
 using namespace Halide;
 using namespace Halide::Tools;
 
-// 32-bit windows defines powf as a macro, which won't work for us.
 #ifdef _WIN32
-extern "C" __declspec(dllexport) float pow_ref(float x, float y) {
-    return pow(x, y);
-}
+#define DLLEXPORT __declspec(dllexport)
 #else
-extern "C" float pow_ref(float x, float y) {
-    return powf(x, y);
-}
+#define DLLEXPORT
 #endif
 
+// powf() is a macro in some environments, so always wrap it
+extern "C" DLLEXPORT float pow_ref(float x, float y) {
+    return powf(x, y);
+}
 HalideExtern_2(float, pow_ref, float, float);
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Minor changes to achieve consistency:

-- Remove apparently-unsed #define EXPORT in HalideBuffer.h
-- Rename HALIDE_EXPORT -> DLLEXPORT macro in sim_host.cpp to match convention used elsewhere
-- Rename EXPORT -> DLLEXPORT macro in matlab_aottest.cpp to match convention used elsewhere