### PR TITLE
Fix mingw linking errors on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ UNAME = $(shell uname)
 
 ifeq ($(OS), Windows_NT)
     # assume we are building for the MinGW environment
-    LIBDL =
+    LIBDL=-luuid -lole32
     SHARED_EXT=dll
     FPIC=
 else


### PR DESCRIPTION
Add `-luuid` and `-lole32` to the Windows linker flags in Makefile to bring in the libraries that define several symbols including `FOLDERID_LocalAppData` and `_imp__CoTaskMemFree`.

Addresses issue https://github.com/halide/Halide/issues/2306