### PR TITLE
Rework and simplify the Generator creation code

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -502,6 +502,13 @@ void StubEmitter::emit() {
     stream << indent() << "#include \"Halide.h\"\n";
     stream << "\n";
 
+    stream << "namespace halide_register_generator {\n";
+    stream << "namespace " << generator_registered_name << " {\n";
+    stream << "extern std::unique_ptr<Halide::Internal::GeneratorBase> factory(const Halide::GeneratorContext& context);\n";
+    stream << "}  // namespace halide_register_generator\n";
+    stream << "}  // namespace " << generator_registered_name << "\n";
+    stream << "\n";
+
     for (const auto &ns : namespaces) {
         stream << indent() << "namespace " << ns << " {\n";
     }
@@ -543,7 +550,7 @@ void StubEmitter::emit() {
     indent_level--;
     stream << indent() << ")\n";
     indent_level++;
-    stream << indent() << ": GeneratorStub(context, &factory, params.to_string_map(), {\n";
+    stream << indent() << ": GeneratorStub(context, halide_register_generator::" << generator_registered_name << "::factory, params.to_string_map(), {\n";
     indent_level++;
     for (size_t i = 0; i < inputs.size(); ++i) {
         stream << indent() << "to_stub_input_vector(inputs." << inputs[i]->name() << ")";
@@ -692,16 +699,6 @@ void StubEmitter::emit() {
     stream << "\n";
 
     indent_level--;
-    stream << indent() << "private:\n";
-    indent_level++;
-    stream << indent() << "static std::unique_ptr<Halide::Internal::GeneratorBase> factory(const GeneratorContext& context, const std::map<std::string, std::string>& params) {\n";
-    indent_level++;
-    stream << indent() << "return Halide::Internal::GeneratorRegistry::create(\"" << generator_registered_name << "\", context, params);\n";
-    indent_level--;
-    stream << indent() << "};\n";
-    stream << "\n";
-
-    indent_level--;
     stream << indent() << "};\n";
     stream << "\n";
 
@@ -717,7 +714,8 @@ GeneratorStub::GeneratorStub(const GeneratorContext &context,
                              GeneratorFactory generator_factory,
                              const std::map<std::string, std::string> &generator_params,
                              const std::vector<std::vector<Internal::StubInput>> &inputs)
-    : generator(generator_factory(context, generator_params)) {
+    : generator(generator_factory(context)) {
+    generator->set_generator_and_schedule_param_values(generator_params);
     generator->set_inputs_vector(inputs);
     generator->call_generate();
 }
@@ -952,7 +950,7 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
         if (emit_options.emit_cpp_stub) {
             // When generating cpp_stub, we ignore all generator args passed in, and supply a fake Target.
             // (Note that "JITGeneratorContext" is misleading, since we're actually doing AOT here, but it does exactly what we need)
-            auto gen = GeneratorRegistry::create(generator_name, JITGeneratorContext(Target()), {});
+            auto gen = GeneratorRegistry::create(generator_name, JITGeneratorContext(Target()));
             auto stub_file_path = base_path + get_extension(".stub.h", emit_options);
             gen->emit_cpp_stub(stub_file_path);
         }
@@ -966,7 +964,8 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
                     sub_generator_args.erase("target");
                     // Must re-create each time since each instance will have a different Target.
                     // (Note that "JITGeneratorContext" is misleading, since we're actually doing AOT here, but it does exactly what we need)
-                    auto gen = GeneratorRegistry::create(generator_name, JITGeneratorContext(target), sub_generator_args);
+                    auto gen = GeneratorRegistry::create(generator_name, JITGeneratorContext(target));
+                    gen->set_generator_and_schedule_param_values(sub_generator_args);
                     return gen->build_module(name);
                 };
             if (targets.size() > 1 || !emit_options.substitutions.empty()) {
@@ -1014,13 +1013,13 @@ GeneratorRegistry &GeneratorRegistry::get_registry() {
 
 /* static */
 void GeneratorRegistry::register_factory(const std::string &name,
-                                         std::unique_ptr<GeneratorFactory> factory) {
+                                         GeneratorFactory generator_factory) {
     user_assert(is_valid_name(name)) << "Invalid Generator name: " << name;
     GeneratorRegistry &registry = get_registry();
     std::lock_guard<std::mutex> lock(registry.mutex);
     internal_assert(registry.factories.find(name) == registry.factories.end())
         << "Duplicate Generator name: " << name;
-    registry.factories[name] = std::move(factory);
+    registry.factories[name] = generator_factory;
 }
 
 /* static */
@@ -1034,8 +1033,7 @@ void GeneratorRegistry::unregister_factory(const std::string &name) {
 
 /* static */
 std::unique_ptr<GeneratorBase> GeneratorRegistry::create(const std::string &name,
-                                                         const GeneratorContext &context,
-                                                         const std::map<std::string, std::string> &params) {
+                                                         const GeneratorContext &context) {
     GeneratorRegistry &registry = get_registry();
     std::lock_guard<std::mutex> lock(registry.mutex);
     auto it = registry.factories.find(name);
@@ -1048,7 +1046,7 @@ std::unique_ptr<GeneratorBase> GeneratorRegistry::create(const std::string &name
         }
         user_error << o.str();
     }
-    std::unique_ptr<GeneratorBase> g = it->second->create(context, params);
+    std::unique_ptr<GeneratorBase> g = it->second(context);
     internal_assert(g != nullptr);
     return g;
 }
@@ -1274,6 +1272,7 @@ Internal::ScheduleParamBase &GeneratorBase::find_schedule_param_by_name(const st
 
 void GeneratorBase::set_generator_names(const std::string &registered_name, const std::string &stub_name) {
     user_assert(is_valid_name(registered_name)) << "Invalid Generator name: " << registered_name;
+    internal_assert(!registered_name.empty() && !stub_name.empty());
     internal_assert(generator_registered_name.empty() && generator_stub_name.empty());
     generator_registered_name = registered_name;
     generator_stub_name = stub_name;

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -503,7 +503,7 @@ void StubEmitter::emit() {
     stream << "\n";
 
     stream << "namespace halide_register_generator {\n";
-    stream << "namespace " << generator_registered_name << " {\n";
+    stream << "namespace " << generator_registered_name << "_ns {\n";
     stream << "extern std::unique_ptr<Halide::Internal::GeneratorBase> factory(const Halide::GeneratorContext& context);\n";
     stream << "}  // namespace halide_register_generator\n";
     stream << "}  // namespace " << generator_registered_name << "\n";
@@ -550,7 +550,7 @@ void StubEmitter::emit() {
     indent_level--;
     stream << indent() << ")\n";
     indent_level++;
-    stream << indent() << ": GeneratorStub(context, halide_register_generator::" << generator_registered_name << "::factory, params.to_string_map(), {\n";
+    stream << indent() << ": GeneratorStub(context, halide_register_generator::" << generator_registered_name << "_ns::factory, params.to_string_map(), {\n";
     indent_level++;
     for (size_t i = 0; i < inputs.size(); ++i) {
         stream << indent() << "to_stub_input_vector(inputs." << inputs[i]->name() << ")";

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -3000,12 +3000,12 @@ namespace halide_register_generator {
 #define _HALIDE_REGISTER_GENERATOR_IMPL(GEN_CLASS_NAME, GEN_REGISTRY_NAME, FULLY_QUALIFIED_STUB_NAME) \
     namespace halide_register_generator { \
         struct halide_global_ns; \
-        namespace GEN_REGISTRY_NAME { \
+        namespace GEN_REGISTRY_NAME##_ns { \
             std::unique_ptr<Halide::Internal::GeneratorBase> factory(const Halide::GeneratorContext& context) { \
                 return GEN_CLASS_NAME::create(context, #GEN_REGISTRY_NAME, #FULLY_QUALIFIED_STUB_NAME); \
             } \
         } \
-        static auto reg_##GEN_REGISTRY_NAME = Halide::Internal::RegisterGenerator(#GEN_REGISTRY_NAME, GEN_REGISTRY_NAME::factory); \
+        static auto reg_##GEN_REGISTRY_NAME = Halide::Internal::RegisterGenerator(#GEN_REGISTRY_NAME, GEN_REGISTRY_NAME##_ns::factory); \
     } \
     static_assert(std::is_same<::halide_register_generator::halide_global_ns, halide_register_generator::halide_global_ns>::value, \
                  "HALIDE_REGISTER_GENERATOR must be used at global scope");

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2299,6 +2299,10 @@ struct NoRealizations<T, Args...> {
 class GeneratorStub;
 class SimpleGeneratorFactory;
 
+// Note that these functions must never return null:
+// if they cannot return a valid Generator, they must assert-fail.
+using GeneratorFactory = std::function<std::unique_ptr<GeneratorBase>(const GeneratorContext&)>;
+
 class GeneratorBase : public NamesInterface, public GeneratorContext {
 public:
     GeneratorParam<Target> target{ "target", Target() };
@@ -2408,6 +2412,7 @@ public:
 protected:
     EXPORT GeneratorBase(size_t size, const void *introspection_helper);
     EXPORT void init_from_context(const Halide::GeneratorContext &context);
+    EXPORT void set_generator_names(const std::string &registered_name, const std::string &stub_name);
 
     EXPORT virtual Pipeline build_pipeline() = 0;
     EXPORT virtual void call_generate() = 0;
@@ -2528,8 +2533,6 @@ private:
     EXPORT Func get_first_output();
     EXPORT Func get_output(const std::string &n);
     EXPORT std::vector<Func> get_output_vector(const std::string &n);
-
-    EXPORT void set_generator_names(const std::string &registered_name, const std::string &stub_name);
 
     EXPORT void set_inputs_vector(const std::vector<std::vector<StubInput>> &inputs);
 
@@ -2676,50 +2679,18 @@ private:
     void operator=(GeneratorBase&& that) = delete;
 };
 
-class GeneratorFactory {
-public:
-    virtual ~GeneratorFactory() {}
-    // Note that this method must never return null:
-    // if it cannot return a valid Generator, it should assert-fail.
-    virtual std::unique_ptr<GeneratorBase> create(const GeneratorContext &context,
-                                                  const std::map<std::string, std::string> &params) const = 0;
-};
-
-using GeneratorCreateFunc = std::function<std::unique_ptr<Internal::GeneratorBase>(const GeneratorContext &context)>;
-
-class SimpleGeneratorFactory : public GeneratorFactory {
-public:
-    SimpleGeneratorFactory(GeneratorCreateFunc create_func, const std::string &registered_name, const std::string &stub_name)
-        : create_func(create_func), generator_registered_name(registered_name), generator_stub_name(stub_name) {
-        internal_assert(create_func != nullptr);
-    }
-
-    std::unique_ptr<Internal::GeneratorBase> create(const GeneratorContext &context,
-                                                    const std::map<std::string, std::string> &params) const override {
-        auto g = create_func(context);
-        internal_assert(g.get() != nullptr);
-        g->set_generator_names(generator_registered_name, generator_stub_name);
-        g->set_generator_and_schedule_param_values(params);
-        return g;
-    }
-private:
-    const GeneratorCreateFunc create_func;
-    const std::string generator_registered_name, generator_stub_name;
-};
-
 class GeneratorRegistry {
 public:
-    EXPORT static void register_factory(const std::string &name, std::unique_ptr<GeneratorFactory> factory);
+    EXPORT static void register_factory(const std::string &name, GeneratorFactory generator_factory);
     EXPORT static void unregister_factory(const std::string &name);
     EXPORT static std::vector<std::string> enumerate();
     // Note that this method will never return null:
     // if it cannot return a valid Generator, it should assert-fail.
     EXPORT static std::unique_ptr<GeneratorBase> create(const std::string &name,
-                                                        const GeneratorContext &context,
-                                                        const std::map<std::string, std::string> &params);
+                                                        const GeneratorContext &context);
 
 private:
-    using GeneratorFactoryMap = std::map<const std::string, std::unique_ptr<GeneratorFactory>>;
+    using GeneratorFactoryMap = std::map<const std::string, GeneratorFactory>;
 
     GeneratorFactoryMap factories;
     std::mutex mutex;
@@ -2744,9 +2715,18 @@ public:
     static std::unique_ptr<T> create(const Halide::GeneratorContext &context) {
         // We must have an object of type T (not merely GeneratorBase) to call a protected method,
         // because CRTP is a weird beast.
-        T *t = new T;
-        t->init_from_context(context);
-        return std::unique_ptr<T>(t);
+        auto g = std::unique_ptr<T>(new T());
+        g->init_from_context(context);
+        return g;
+    }
+
+    // This is public but intended only for use by the HALIDE_REGISTER_GENERATOR() macro.
+    static std::unique_ptr<T> create(const Halide::GeneratorContext &context,
+                                     const std::string &registered_name, 
+                                     const std::string &stub_name) {
+        auto g = create(context);
+        g->set_generator_names(registered_name, stub_name);
+        return g;
     }
 
     using Internal::GeneratorBase::apply;
@@ -2865,17 +2845,10 @@ private:
 
 namespace Internal {
 
-template <class GeneratorClass>
 class RegisterGenerator {
 public:
-    RegisterGenerator(const char* registered_name) {
-        std::unique_ptr<Internal::SimpleGeneratorFactory> f(new Internal::SimpleGeneratorFactory(GeneratorClass::create, registered_name, registered_name));
-        Internal::GeneratorRegistry::register_factory(registered_name, std::move(f));
-    }
-
-    RegisterGenerator(const char* registered_name, const char* stub_name) {
-        std::unique_ptr<Internal::SimpleGeneratorFactory> f(new Internal::SimpleGeneratorFactory(GeneratorClass::create, registered_name, stub_name));
-        Internal::GeneratorRegistry::register_factory(registered_name, std::move(f));
+    RegisterGenerator(const char* registered_name, GeneratorFactory generator_factory) {
+        Internal::GeneratorRegistry::register_factory(registered_name, generator_factory);
     }
 };
 
@@ -2939,8 +2912,6 @@ public:
     virtual ~GeneratorStub() {}
 
 protected:
-    typedef std::function<std::unique_ptr<GeneratorBase>(const GeneratorContext&, const std::map<std::string, std::string>&)> GeneratorFactory;
-
     EXPORT GeneratorStub(const GeneratorContext &context,
                   GeneratorFactory generator_factory,
                   const std::map<std::string, std::string> &generator_params,
@@ -3029,7 +3000,12 @@ namespace halide_register_generator {
 #define _HALIDE_REGISTER_GENERATOR_IMPL(GEN_CLASS_NAME, GEN_REGISTRY_NAME, FULLY_QUALIFIED_STUB_NAME) \
     namespace halide_register_generator { \
         struct halide_global_ns; \
-        static auto reg_##GEN_REGISTRY_NAME = Halide::Internal::RegisterGenerator<GEN_CLASS_NAME>(#GEN_REGISTRY_NAME, #FULLY_QUALIFIED_STUB_NAME); \
+        namespace GEN_REGISTRY_NAME { \
+            std::unique_ptr<Halide::Internal::GeneratorBase> factory(const Halide::GeneratorContext& context) { \
+                return GEN_CLASS_NAME::create(context, #GEN_REGISTRY_NAME, #FULLY_QUALIFIED_STUB_NAME); \
+            } \
+        } \
+        static auto reg_##GEN_REGISTRY_NAME = Halide::Internal::RegisterGenerator(#GEN_REGISTRY_NAME, GEN_REGISTRY_NAME::factory); \
     } \
     static_assert(std::is_same<::halide_register_generator::halide_global_ns, halide_register_generator::halide_global_ns>::value, \
                  "HALIDE_REGISTER_GENERATOR must be used at global scope");


### PR DESCRIPTION
-- replace the GeneratorFactory interface-object with a std::function
-- HALIDE_REGISTER_GENERATOR now implements the (now-simplified) GeneratorFactory function
-- move the GeneratorParam stuff out of the factory (it can always be applied aftr creation)
-- have Stubs bind directly to a GeneratorFactory via extern reference, rather than looking up in the registry (this simplifies some linkage issues in obscure cases with Stubs in some build systems)