### PR TITLE
Add missing test/generator tests to CMake (v2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,16 @@ else()
   endif()
 endif()
 
+# These tools are needed by several subdirectories
+add_executable(build_halide_h tools/build_halide_h.cpp)
+add_executable(binary2cpp tools/binary2cpp.cpp)
+if (MSVC)
+  # disable irrelevant "POSIX name" warnings
+  target_compile_options(build_halide_h PUBLIC /wd4996)
+  target_compile_options(binary2cpp PUBLIC /wd4996)
+endif()
+
+
 # Look for OpenMP
 find_package(OpenMP QUIET)
 if (OPENMP_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,14 +1,5 @@
 include(CheckCXXCompilerFlag)
 
-add_executable(build_halide_h ../tools/build_halide_h.cpp)
-add_executable(binary2cpp ../tools/binary2cpp.cpp)
-
-if (MSVC)
-  # disable irrelevant warnings
-  target_compile_options(build_halide_h PUBLIC /wd4996)
-  target_compile_options(binary2cpp PUBLIC /wd4996)
-endif()
-
 if (MSVC)
   # -g produces dwarf debugging info, which is not useful on windows
   #  (and fails to compile due to llvm bug 15393)
@@ -533,6 +524,11 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
 )
 # Define Halide_SHARED or Halide_STATIC depending on library type
 target_compile_definitions(Halide PRIVATE "-DHalide_${HALIDE_LIBRARY_TYPE}")
+# Ensure that these tools are build first
+add_dependencies(Halide
+  binary2cpp
+  build_halide_h
+)
 
 if (WIN32 AND NOT MSVC)
   set_target_properties(Halide PROPERTIES LINK_FLAGS "-Wl,--export-all-symbols")
@@ -651,8 +647,3 @@ if (NOT MSVC)
   string(REPLACE " " "" EXTRA_LIBS "${EXTRA_LIBS}")
   target_link_libraries(Halide PUBLIC ${EXTRA_LIBS})
 endif()
-
-add_dependencies(Halide
-  binary2cpp
-  build_halide_h
-)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -221,6 +221,34 @@ if (WITH_TEST_GENERATORS)
   add_test_generator(user_context)
   add_test_generator(user_context_insanity)
   add_test_generator(variable_num_threads)
+  add_test_generator(old_buffer_t)
+  add_test_generator(output_assign)
+  add_test_generator(external_code)
+
+  # Define a nontrivial depedency for external_code.generator
+  set(EC32 "${PROJECT_BINARY_DIR}/${PROJECT_NAME}.build/external_code_extern_bitcode_32")
+  add_custom_command(OUTPUT "${EC32}.bc"
+                     DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/generator/external_code_extern.cpp"
+                     COMMAND ${CLANG} ${CXX_WARNING_FLAGS} -O3 -c -m32 -target le32-unknown-nacl-unknown -emit-llvm "${CMAKE_CURRENT_SOURCE_DIR}/generator/external_code_extern.cpp" -o "${EC32}.bc")
+  add_custom_command(OUTPUT "${EC32}.cpp"
+                     DEPENDS "${EC32}.bc"
+                     COMMAND binary2cpp external_code_extern_bitcode_32 < "${EC32}.bc" > "${EC32}.cpp")
+
+  set(EC64 "${PROJECT_BINARY_DIR}/${PROJECT_NAME}.build/external_code_extern_bitcode_64")
+  add_custom_command(OUTPUT "${EC64}.bc"
+                     DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/generator/external_code_extern.cpp"
+                     COMMAND ${CLANG} ${CXX_WARNING_FLAGS} -O3 -c -m64 -target le64-unknown-unknown-unknown -emit-llvm "${CMAKE_CURRENT_SOURCE_DIR}/generator/external_code_extern.cpp" -o "${EC64}.bc")
+  add_custom_command(OUTPUT "${EC64}.cpp"
+                     DEPENDS "${EC64}.bc"
+                     COMMAND binary2cpp external_code_extern_bitcode_64 < "${EC64}.bc" > "${EC64}.cpp")
+
+  set(ECCPP "${PROJECT_BINARY_DIR}/${PROJECT_NAME}.build/external_code_extern_cpp_source")
+  add_custom_command(OUTPUT "${ECCPP}.cpp"
+                     DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/generator/external_code_extern.cpp"
+                     COMMAND binary2cpp external_code_extern_cpp_source < "${CMAKE_CURRENT_SOURCE_DIR}/generator/external_code_extern.cpp" > "${ECCPP}.cpp")
+
+  add_library(external_code_generator_deps "${EC32}.cpp" "${EC64}.cpp" "${ECCPP}.cpp")
+  target_link_libraries(external_code.generator PRIVATE external_code_generator_deps)
 
   # ------ Generator tests for just-in-time mode: ------
   halide_define_jit_test(example
@@ -251,6 +279,9 @@ if (WITH_TEST_GENERATORS)
   halide_define_aot_test(memory_profiler_mandelbrot)
   halide_define_aot_test(stubuser)
   halide_define_aot_test(variable_num_threads)
+  halide_define_aot_test(old_buffer_t)
+  halide_define_aot_test(output_assign)
+  halide_define_aot_test(external_code)
 
   # Tests that require nonstandard targets, namespaces, args, etc.
   halide_define_aot_test(matlab


### PR DESCRIPTION
Revised attempt at PR#2302 that shouldn't cause Windows build failures.