### PR TITLE
Use a Builder-type model to make using inlined Generators more pleasing

### DIFF
--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -323,7 +323,10 @@ Func CameraPipe::build() {
 
     Func denoised = hot_pixel_suppression(shifted);
     Func deinterleaved = deinterleave(denoised);
-    auto demosaiced = apply<Demosaic>(deinterleaved);
+    auto demosaiced = create<Demosaic>()
+        // TODO: uncomment this when auto_schedule is added
+        // .set_generator_param("auto_schedule", auto_schedule)
+        .apply(deinterleaved);
     Func corrected = color_correct(demosaiced->output);
     Func processed = apply_curve(corrected);
 

--- a/test/correctness/inlined_generator.cpp
+++ b/test/correctness/inlined_generator.cpp
@@ -65,15 +65,10 @@ int main(int argc, char **argv) {
         // If you need to set GeneratorParams, it's a bit trickier: 
         // you must first create the Generator, then set the GeneratorParam(s),
         // than call apply().
-        auto gen = context.create<Example>();  // gen's type is std::unique_ptr<Example>
-
-        // GeneratorParams must be set before calling apply()
-        // (you'll assert-fail if you set them later).
-        gen->compiletime_factor.set(2.5f);
-        // ScheduleParams can be set before or after the call to apply().
-        gen->vectorize.set(false);
-
-        gen->apply(kRuntimeFactor, kRuntimeOffset);
+        auto gen = context.create<Example>()
+            .set_generator_param("compiletime_factor", 2.5f)
+            .set_schedule_param("vectorize", false)
+            .apply(kRuntimeFactor, kRuntimeOffset);
 
 
         Buffer<int32_t> img = gen->realize(kSize, kSize, 3);


### PR DESCRIPTION
Existing syntax was functional but awkward; something more pleaseant is essential for using auto_schedule. See example in camera_pipe_generator.cpp here for expected usage.