### PR TITLE
Work around LLVM breakage

### DIFF
--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -246,14 +246,17 @@ void CodeGen_X86::visit(const Cast *op) {
          i16((wild_i32x_ * wild_i32x_) / 65536)},
         {Target::FeatureEnd, true, UInt(16, 8), 0, "llvm.x86.sse2.pmulhu.w",
          u16((wild_u32x_ * wild_u32x_) / 65536)},
-// TODO: recent builds of LLVM removed these intrinsics; in theory LLVM IR 
-// will natively support them, but in practice they aren't being generated.
-// Disabling temporarily to get buildbots unstuck.
-// See https://github.com/halide/Halide/issues/2342
 #if LLVM_VERSION < 60
+        // Older LLVM versions support this as an intrinsic
         {Target::FeatureEnd, true, UInt(8, 16), 0, "llvm.x86.sse2.pavg.b",
          u8(((wild_u16x_ + wild_u16x_) + 1) / 2)},
         {Target::FeatureEnd, true, UInt(16, 8), 0, "llvm.x86.sse2.pavg.w",
+         u16(((wild_u32x_ + wild_u32x_) + 1) / 2)},
+#else
+        // LLVM 6.0+ require using helpers from x86.ll
+        {Target::FeatureEnd, true, UInt(8, 16), 0, "pavgb",
+         u8(((wild_u16x_ + wild_u16x_) + 1) / 2)},
+        {Target::FeatureEnd, true, UInt(16, 8), 0, "pavgw",
          u16(((wild_u32x_ + wild_u32x_) + 1) / 2)},
 #endif
         {Target::FeatureEnd, false, Int(16, 8), 0, "packssdwx8",

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -246,6 +246,10 @@ void CodeGen_X86::visit(const Cast *op) {
          i16((wild_i32x_ * wild_i32x_) / 65536)},
         {Target::FeatureEnd, true, UInt(16, 8), 0, "llvm.x86.sse2.pmulhu.w",
          u16((wild_u32x_ * wild_u32x_) / 65536)},
+// TODO: recent builds of LLVM removed these intrinsics; in theory LLVM IR 
+// will natively support them, but in practice they aren't being generated.
+// Disabling temporarily to get buildbots unstuck.
+// See https://github.com/halide/Halide/issues/2342
 #if LLVM_VERSION < 60
         {Target::FeatureEnd, true, UInt(8, 16), 0, "llvm.x86.sse2.pavg.b",
          u8(((wild_u16x_ + wild_u16x_) + 1) / 2)},

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -246,10 +246,12 @@ void CodeGen_X86::visit(const Cast *op) {
          i16((wild_i32x_ * wild_i32x_) / 65536)},
         {Target::FeatureEnd, true, UInt(16, 8), 0, "llvm.x86.sse2.pmulhu.w",
          u16((wild_u32x_ * wild_u32x_) / 65536)},
+#if LLVM_VERSION < 60
         {Target::FeatureEnd, true, UInt(8, 16), 0, "llvm.x86.sse2.pavg.b",
          u8(((wild_u16x_ + wild_u16x_) + 1) / 2)},
         {Target::FeatureEnd, true, UInt(16, 8), 0, "llvm.x86.sse2.pavg.w",
          u16(((wild_u32x_ + wild_u32x_) + 1) / 2)},
+#endif
         {Target::FeatureEnd, false, Int(16, 8), 0, "packssdwx8",
          i16_sat(wild_i32x_)},
         {Target::FeatureEnd, false, Int(8, 16), 0, "packsswbx16",

--- a/src/runtime/x86.ll
+++ b/src/runtime/x86.ll
@@ -1,3 +1,24 @@
+; Note that this is only used for LLVM 6.0+
+define weak_odr <16 x i8>  @pavgb(<16 x i8> %a, <16 x i8> %b) nounwind alwaysinline {
+  %1 = zext <16 x i8> %a to <16 x i32>
+  %2 = zext <16 x i8> %b to <16 x i32>
+  %3 = add nuw nsw <16 x i32> %1, <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
+  %4 = add nuw nsw <16 x i32> %3, %2
+  %5 = lshr <16 x i32> %4, <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
+  %6 = trunc <16 x i32> %5 to <16 x i8>
+  ret <16 x i8> %6
+}
+
+; Note that this is only used for LLVM 6.0+
+define weak_odr <8 x i16>  @pavgw(<8 x i16> %a, <8 x i16> %b) nounwind alwaysinline {
+  %1 = zext <8 x i16> %a to <8 x i32>
+  %2 = zext <8 x i16> %b to <8 x i32>
+  %3 = add nuw nsw <8 x i32> %1, <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
+  %4 = add nuw nsw <8 x i32> %3, %2
+  %5 = lshr <8 x i32> %4, <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
+  %6 = trunc <8 x i32> %5 to <8 x i16>
+  ret <8 x i16> %6
+}
 
 declare <16 x i8> @llvm.x86.sse2.packsswb.128(<8 x i16>, <8 x i16>)
 declare <16 x i8> @llvm.x86.sse2.packuswb.128(<8 x i16>, <8 x i16>)

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -219,7 +219,7 @@ struct Test {
             bool found_it = false;
 
             std::ostringstream msg;
-            msg << op << " did not generate. Instead we got:\n";
+            msg << op << " did not generate for target=" << target.to_string() << ". Instead we got:\n";
 
             string line;
             while (getline(asm_file, line)) {
@@ -361,10 +361,16 @@ struct Test {
             check("sqrtps", 2*w, sqrt(f32_2));
             check("maxps", 2*w, max(f32_1, f32_2));
             check("minps", 2*w, min(f32_1, f32_2));
+// TODO: recent builds of LLVM removed these intrinsics; in theory LLVM IR 
+// will natively support them, but in practice they aren't being generated.
+// Disabling temporarily to get buildbots unstuck.
+// See https://github.com/halide/Halide/issues/2342.
+#if LLVM_VERSION < 60
             check("pavgb", 8*w, u8((u16(u8_1) + u16(u8_2) + 1)/2));
             check("pavgb", 8*w, u8((u16(u8_1) + u16(u8_2) + 1)>>1));
             check("pavgw", 4*w, u16((u32(u16_1) + u32(u16_2) + 1)/2));
             check("pavgw", 4*w, u16((u32(u16_1) + u32(u16_2) + 1)>>1));
+#endif
             check("pmaxsw", 4*w, max(i16_1, i16_2));
             check("pminsw", 4*w, min(i16_1, i16_2));
             check("pmaxub", 8*w, max(u8_1, u8_2));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -361,16 +361,10 @@ struct Test {
             check("sqrtps", 2*w, sqrt(f32_2));
             check("maxps", 2*w, max(f32_1, f32_2));
             check("minps", 2*w, min(f32_1, f32_2));
-// TODO: recent builds of LLVM removed these intrinsics; in theory LLVM IR 
-// will natively support them, but in practice they aren't being generated.
-// Disabling temporarily to get buildbots unstuck.
-// See https://github.com/halide/Halide/issues/2342.
-#if LLVM_VERSION < 60
             check("pavgb", 8*w, u8((u16(u8_1) + u16(u8_2) + 1)/2));
             check("pavgb", 8*w, u8((u16(u8_1) + u16(u8_2) + 1)>>1));
             check("pavgw", 4*w, u16((u32(u16_1) + u32(u16_2) + 1)/2));
             check("pavgw", 4*w, u16((u32(u16_1) + u32(u16_2) + 1)>>1));
-#endif
             check("pmaxsw", 4*w, max(i16_1, i16_2));
             check("pminsw", 4*w, min(i16_1, i16_2));
             check("pmaxub", 8*w, max(u8_1, u8_2));


### PR DESCRIPTION
Report: "LLVM removed some intrinsics in order for them to be lowered to LLVM IR instead (which seems to natively support it now)"