### PR TITLE
CMake: prefer configure_file() to file(COPY)

### DIFF
--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -8,9 +8,9 @@ include_directories("${CMAKE_BINARY_DIR}/tools")
 check_cxx_compiler_flag("-Wno-unused-but-set-variable" SUPPORT_NO_UNUSED_BUT_SET_VARIABLE)
 
 file(GLOB IMAGES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/images" "${CMAKE_CURRENT_SOURCE_DIR}/images/*.png")
+file(MAKE_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/images")
 foreach(FILE ${IMAGES})
-  message("Copying ${FILE} -> ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/images")
-  file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/images/${FILE}" DESTINATION "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/images")
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/images/${FILE}" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/images/" COPYONLY)
 endforeach()
 
 function(add_tutorial source_file)


### PR DESCRIPTION
This eliminates redundant copies at CMake configure time.