### PR TITLE
Improve simplify for likely() and require()

### DIFF
--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -3964,6 +3964,7 @@ private:
             return;
         }
 
+        const Call *c;
         if (is_one(a)) {
             expr = make_zero(a.type());
         } else if (is_zero(a)) {
@@ -3985,6 +3986,9 @@ private:
             expr = NE::make(n->a, n->b);
         } else if (const Broadcast *n = a.as<Broadcast>()) {
             expr = mutate(Broadcast::make(!n->value, n->lanes));
+        } else if ((c = a.as<Call>()) != nullptr && c->is_intrinsic(Call::likely)) {
+            // !likely(e) -> likely(!e)
+            expr = likely(mutate(Not::make(c->args[0])));
         } else if (a.same_as(op->a)) {
             expr = op;
         } else {
@@ -4585,7 +4589,19 @@ private:
             } else {
                 expr = op;
             }
-
+        } else if (op->is_intrinsic(Call::require)) {
+            Expr cond = mutate(op->args[0]);
+            if (can_prove(cond)) {
+                expr = mutate(op->args[1]);
+            } else {
+                if (can_prove(!cond)) {
+                    // (We could simplify this to avoid evaluating the provably-false
+                    // expression, but since this is a degenerate condition, don't bother.)
+                    user_warning << "This pipeline is guaranteed to fail a require() expression at runtime: \n"
+                                 << Expr(op) << "\n";
+                }
+                IRMutator::visit(op);
+            }
         } else {
             IRMutator::visit(op);
         }
@@ -5302,7 +5318,16 @@ Stmt simplify_exprs(Stmt s) {
 bool can_prove(Expr e) {
     internal_assert(e.type().is_bool())
         << "Argument to can_prove is not a boolean Expr: " << e << "\n";
-    return is_one(simplify(e));
+    e = simplify(e);
+    // likely(const-bool) is deliberately left unsimplified, because
+    // things like max(likely(1), x) are meaningful, but we do want to
+    // have can_prove(likely(1)) return true.
+    if (const Call *c = e.as<Call>()) {
+        if (c->is_intrinsic(Call::likely)) {
+            e = c->args[0];
+        }
+    }
+    return is_one(e);
 }
 
 namespace {
@@ -6380,6 +6405,27 @@ void check_boolean() {
         Expr nasty = ((((((((((((((((((((((((((((((((((((((((((((b[0] && b[1]) || (b[2] && b[1])) || b[0]) || b[2]) || b[0]) || b[2]) && ((b[0] && b[6]) || (b[2] && b[6]))) || b[0]) || b[2]) || b[0]) || b[2]) && ((b[0] && b[3]) || (b[2] && b[3]))) || b[0]) || b[2]) || b[0]) || b[2]) && ((b[0] && b[7]) || (b[2] && b[7]))) || b[0]) || b[2]) || b[0]) || b[2]) && ((b[0] && b[4]) || (b[2] && b[4]))) || b[0]) || b[2]) || b[0]) || b[2]) && ((b[0] && b[8]) || (b[2] && b[8]))) || b[0]) || b[2]) || b[0]) || b[2]) && ((b[0] && b[5]) || (b[2] && b[5]))) || b[0]) || b[2]) || b[0]) || b[2]) && ((b[0] && b[10]) || (b[2] && b[10]))) || b[0]) || b[2]) || b[0]) || b[2]) && ((b[0] && b[9]) || (b[2] && b[9]))) || b[0]) || b[2]);
         check(nasty, b[0] || b[2]);
     }
+
+    {
+        // verify that likely(const-bool) is *not* simplified.
+        check(likely(t), likely(t));
+        check(likely(f), likely(f));
+
+        // verify that !likely(e) -> likely(!e)
+        check(!likely(t), likely(f));
+        check(!likely(f), likely(t));
+        check(!likely(x == 2), likely(x != 2));
+
+        // can_prove(likely(const-true)) = true
+        // can_prove(!likely(const-false)) = true
+        internal_assert(can_prove(likely(t)));
+        internal_assert(can_prove(!likely(f)));
+
+        // unprovable cases
+        internal_assert(!can_prove(likely(f)));
+        internal_assert(!can_prove(!likely(t)));
+        internal_assert(!can_prove(!likely(x == 2)));
+    }
 }
 
 void check_math() {
@@ -6832,6 +6878,14 @@ void simplify_test() {
     check(max(x * 4, y - 3) - max(x * 4 + 63, y), clamp(y - x * 4 + (-3), 0, 60) + (-63));
     check(max(x * 4 + 63, y) - max(y - 3, x * 4), 3 - clamp(y - x * 4 + (-63), -60, 0));
     check(max(y - 3, x * 4) - max(y, x * 4 + 63), -63 - clamp(x * 4 - y + 3, -60, 0));
+
+    // Check that provably-true require() expressions are simplified away
+    {
+        Expr result(42);
+
+        check(require(Expr(1) > Expr(0), result, "error"), result);
+        check(require(x == x, result, "error"), result);
+    }
 
     std::cout << "Simplify test passed" << std::endl;
 }

--- a/test/warning/require_const_false.cpp
+++ b/test/warning/require_const_false.cpp
@@ -1,0 +1,30 @@
+#include "Halide.h"
+#include <stdio.h>
+#include <memory>
+
+using namespace Halide;
+
+void halide_error(void *ctx, const char *msg) {
+    printf("Saw (Expected) Halide Error: %s\n", msg);
+}
+
+int main(int argc, char **argv) {
+    const int kPrime1 = 7829;
+    const int kPrime2 = 7919;
+
+    Buffer<int> result;
+    Var x;
+    Func f;
+    // choose values that will simplify the require() condition to const-false
+    Expr p1 = 1;
+    Expr p2 = 2;
+    f(x) = require((p1 + p2) == kPrime1, 
+                   (p1 + p2) * kPrime2,
+                   "The parameters should add to exactly", kPrime1, "but were", p1, p2);
+    f.set_error_handler(&halide_error);
+    result = f.realize(1);
+
+    return 0;
+
+}
+


### PR DESCRIPTION
Changes:
- Simplify !likely(e) -> likely(!e)
- can_prove(likely(1)) now returns true
- require(1, a, b) -> a
- require(0, a, b) -> emits "Warning, this will always fail at runtime"