### PR TITLE
Add optional `target` parameter to `Buffer::device_wrap_native`.

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -472,8 +472,8 @@ public:
     }
 
     /** Wrap a native handle, using the given device API. */
-    int device_wrap_native(const DeviceAPI &d, uint64_t handle) {
-        return contents->buf.device_wrap_native(get_device_interface_for_device_api(d), handle);
+    int device_wrap_native(const DeviceAPI &d, uint64_t handle, const Target &t = get_jit_target_from_environment()) {
+        return contents->buf.device_wrap_native(get_device_interface_for_device_api(d, t), handle);
     }
 
 };

--- a/test/opengl/rewrap_texture.cpp
+++ b/test/opengl/rewrap_texture.cpp
@@ -55,12 +55,12 @@ int main() {
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
     // wrapping a texture should work
-    out2.device_wrap_native(DeviceAPI::GLSL, texture_id);
+    out2.device_wrap_native(DeviceAPI::GLSL, texture_id, target);
     g.realize(out2, target);
     out2.device_detach_native();
 
     // re-wrapping the texture should not abort
-    out3.device_wrap_native(DeviceAPI::GLSL, texture_id);
+    out3.device_wrap_native(DeviceAPI::GLSL, texture_id, target);
     g.realize(out3, target);
     out3.device_detach_native();
 


### PR DESCRIPTION
Old signature:

```cpp
    int device_wrap_native(const DeviceAPI &d, uint64_t handle)
```
New signature:

```cpp
    int device_wrap_native(const DeviceAPI &d, uint64_t handle, const Target &t = get_jit_target_from_environment())
```

This parallels the existing optional `target` parameter of `Buffer::device_malloc` and `Buffer::copy_to_device`: https://github.com/halide/Halide/blob/5345ec10554ed1cbda0dd0916e207eb1490d7e76/src/Buffer.h#L460 https://github.com/halide/Halide/blob/5345ec10554ed1cbda0dd0916e207eb1490d7e76/src/Buffer.h#L470

This of course makes it possible to use a target defined in the application rather than only the environment target.

...which makes it possible to modify the `opengl_rewrap_target` test so that it doesn't fail mysteriously even though all other opengl tests pass even if you don't have HL_JIT_TARGET set to include opengl.  (Don't ask how long it took me to track down why that was the only failing test!)