### PR TITLE
Drop support for LLVM 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ install:
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/${CC} 20
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/${CXX} 20
   # Download the right llvm release
-  - wget http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-  - tar xvf clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-  - sudo mv clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-14.04 /usr/local/llvm
+  - wget http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8.tar.xz
+  - tar xvf clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8.tar.xz
+  - sudo mv clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8 /usr/local/llvm
   # Get libpng for the tutorials and apps
   - sudo apt-get -y --force-yes install libpng-dev
   # For generating docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ env:
     #
     # Test a mix of llvm versions, a mix of build systems, and a mix of shared vs static library
     # Don't build as a static library with cmake. It risks exceeding the travis memory limit.
-    - LLVM_VERSION=3.7.1 BUILD_SYSTEM=MAKE CXX_=g++-4.8 CC_=gcc-4.8
-    - LLVM_VERSION=3.8.1 BUILD_SYSTEM=MAKE CXX_=g++-4.8 CC_=gcc-4.8
-    - LLVM_VERSION=3.8.1 BUILD_SYSTEM=CMAKE CXX_=g++-4.8 CC_=gcc-4.8 HALIDE_SHARED_LIBRARY=1
+    - LLVM_VERSION=3.9.1 BUILD_SYSTEM=MAKE CXX_=g++-4.8 CC_=gcc-4.8
+    - LLVM_VERSION=4.0.1 BUILD_SYSTEM=MAKE CXX_=g++-4.8 CC_=gcc-4.8
+    - LLVM_VERSION=4.0.1 BUILD_SYSTEM=CMAKE CXX_=g++-4.8 CC_=gcc-4.8 HALIDE_SHARED_LIBRARY=1
 cache: apt
 dist: trusty
 # Note the commands below are written assuming Ubuntu 12.04LTS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,10 +74,10 @@ check_tool_exists(clang "${CLANG}")
 
 # Check reported LLVM version
 if (NOT "${LLVM_VERSION}" MATCHES "^[0-9][0-9]$")
-  message(FATAL_ERROR "LLVM_VERSION not specified correctly. Must be <major><minor> E.g. LLVM 3.7 is \"37\"")
+  message(FATAL_ERROR "LLVM_VERSION not specified correctly. Must be <major><minor> E.g. LLVM 3.9 is \"39\"")
 endif()
-if (LLVM_VERSION LESS 37)
-  message(FATAL_ERROR "LLVM version must be 3.7 or newer")
+if (LLVM_VERSION LESS 39)
+  message(FATAL_ERROR "LLVM version must be 3.9 or newer")
 endif()
 
 function(check_llvm_target TARGET HAS_TARGET)

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,7 @@ LLVM_CXX_FLAGS += -DLLVM_VERSION=$(LLVM_VERSION_TIMES_10)
 # value.
 WITH_X86 ?= $(findstring x86, $(LLVM_COMPONENTS))
 WITH_ARM ?= $(findstring arm, $(LLVM_COMPONENTS))
-ifneq (,$(findstring $(LLVM_VERSION_TIMES_10), 39 40 50 60))
 WITH_HEXAGON ?= $(findstring hexagon, $(LLVM_COMPONENTS))
-else
-WITH_HEXAGON ?=
-endif
 WITH_MIPS ?= $(findstring mips, $(LLVM_COMPONENTS))
 WITH_AARCH64 ?= $(findstring aarch64, $(LLVM_COMPONENTS))
 WITH_POWERPC ?= $(findstring powerpc, $(LLVM_COMPONENTS))
@@ -1554,7 +1550,7 @@ $(BUILD_DIR)/clang_ok:
 	@exit 1
 endif
 
-ifneq (,$(findstring $(LLVM_VERSION_TIMES_10), 37 38 39 40 50 60))
+ifneq (,$(findstring $(LLVM_VERSION_TIMES_10), 39 40 50 60))
 LLVM_OK=yes
 endif
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If you wish to use cmake to build Halide, the build procedure is:
 
     % mkdir cmake_build
     % cd cmake_build
-    % cmake -DLLVM_DIR=/path-to-llvm-build/lib/cmake/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_VERSION=37 /path/to/halide
+    % cmake -DLLVM_DIR=/path-to-llvm-build/lib/cmake/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_VERSION=39 /path/to/halide
     % make -j8
 
 LLVM_DIR should be the folder in the LLVM installation or build tree that contains LLVMConfig.cmake.
@@ -121,7 +121,7 @@ To configure and build Halide:
 
     % mkdir C:\Code\halide-build
     % cd C:\Code\halide-build
-    % cmake -DLLVM_DIR=../llvm-install/lib/cmake/llvm -DLLVM_VERSION=37 -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 14 Win64" ../halide
+    % cmake -DLLVM_DIR=../llvm-install/lib/cmake/llvm -DLLVM_VERSION=39 -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 14 Win64" ../halide
     % MSBuild.exe /m /t:Build /p:Configuration=Release .\ALL_BUILD.vcxproj
 
 #### Building Halide and LLVM on Windows using mingw

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -710,9 +710,7 @@ void CodeGen_ARM::visit(const Store *op) {
         if (target.bits == 32) {
             instr << "llvm.arm.neon.vst"
                   << num_vecs
-#if LLVM_VERSION > 37
-                   << ".p0i8"
-#endif
+                  << ".p0i8"
                   << ".v"
                   << intrin_type.lanes()
                   << (t.is_float() ? 'f' : 'i')

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -417,10 +417,7 @@ void get_target_options(const llvm::Module &module, llvm::TargetOptions &options
     options.UseInitArray = false;
     options.FloatABIType =
         use_soft_float_abi ? llvm::FloatABI::Soft : llvm::FloatABI::Hard;
-    #if LLVM_VERSION >= 39
-    // Not supported by older linkers
     options.RelaxELFRelocations = false;
-    #endif
 }
 
 

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -448,7 +448,7 @@ std::unique_ptr<llvm::TargetMachine> make_target_machine(const llvm::Module &mod
     const llvm::Target *target = llvm::TargetRegistry::lookupTarget(module.getTargetTriple(), error_string);
     if (!target) {
         std::cout << error_string << std::endl;
-#if LLVM_VERSION < 50
+#if LLVM_VERSION < 60
         llvm::TargetRegistry::printRegisteredTargetsForVersion();
 #else
         llvm::TargetRegistry::printRegisteredTargetsForVersion(llvm::outs());

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -11,17 +11,9 @@ namespace llvm {
 class Value;
 class Module;
 class Function;
-#if LLVM_VERSION >= 39
 class IRBuilderDefaultInserter;
-#else
-template<bool> class IRBuilderDefaultInserter;
-#endif
 class ConstantFolder;
-#if LLVM_VERSION >= 39
 template<typename, typename> class IRBuilder;
-#else
-template<bool, typename, typename> class IRBuilder;
-#endif
 class LLVMContext;
 class Type;
 class StructType;
@@ -132,11 +124,7 @@ protected:
     std::unique_ptr<llvm::Module> module;
     llvm::Function *function;
     llvm::LLVMContext *context;
-#if LLVM_VERSION >= 39
     llvm::IRBuilder<llvm::ConstantFolder, llvm::IRBuilderDefaultInserter> *builder;
-#else
-    llvm::IRBuilder<true, llvm::ConstantFolder, llvm::IRBuilderDefaultInserter<true>> *builder;
-#endif
     llvm::Value *value;
     llvm::MDNode *very_likely_branch;
     std::vector<LoweredArgument> current_function_args;

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -10,11 +10,7 @@
 // This is declared in NVPTX.h, which is not exported. Ugly, but seems better than
 // hardcoding a path to the .h file.
 #ifdef WITH_PTX
-#if LLVM_VERSION >= 39
 namespace llvm { FunctionPass *createNVVMReflectPass(const StringMap<int>& Mapping); }
-#else
-namespace llvm { ModulePass *createNVVMReflectPass(const StringMap<int>& Mapping); }
-#endif
 #endif
 
 namespace Halide {
@@ -397,10 +393,6 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     }
     function_pass_manager.doFinalization();
     module_pass_manager.run(*module);
-
-    #if LLVM_VERSION < 38
-    ostream.flush();
-    #endif
 
     if (debug::debug_level() >= 2) {
         dump();

--- a/src/CodeGen_X86.h
+++ b/src/CodeGen_X86.h
@@ -39,8 +39,6 @@ protected:
     void visit(const Add *);
     void visit(const Sub *);
     void visit(const Cast *);
-    void visit(const Min *);
-    void visit(const Max *);
     void visit(const GT *);
     void visit(const LT *);
     void visit(const LE *);

--- a/src/Float16.cpp
+++ b/src/Float16.cpp
@@ -270,11 +270,7 @@ float16_t float16_t::mod(float16_t denominator, RoundingMode roundingMode) const
     // FIXME: Ignoring possible exceptions
     // LLVM removed the rounding mode as the operation is always exact.
     // TODO: change float16_t::mod to no take a rounding mode.
-    #if LLVM_VERSION < 38
-    result.mod(rhsAPF, getLLVMAPFRoundingMode(roundingMode));
-    #else
     result.mod(rhsAPF);
-    #endif
     return toFP16(result);
 }
 

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -869,9 +869,7 @@ private:
     void load_and_parse_object_file(const std::string &binary) {
         llvm::object::ObjectFile *obj = nullptr;
 
-        // Open the object file in question. The API to do this keeps changing.
-        #if LLVM_VERSION >= 39
-
+        // Open the object file in question.
         llvm::Expected<llvm::object::OwningBinary<llvm::object::ObjectFile>> maybe_obj =
             llvm::object::ObjectFile::createObjectFile(binary);
 
@@ -882,19 +880,6 @@ private:
         }
 
         obj = maybe_obj.get().getBinary();
-
-        #else
-
-        llvm::ErrorOr<llvm::object::OwningBinary<llvm::object::ObjectFile>> maybe_obj =
-            llvm::object::ObjectFile::createObjectFile(binary);
-
-        if (!maybe_obj) {
-            debug(1) << "Failed to load binary:" << binary << "\n";
-            return;
-        }
-
-        obj = maybe_obj.get().getBinary();
-        #endif
 
         if (obj) {
             working = true;

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -285,11 +285,7 @@ void JITModule::compile_module(std::unique_ptr<llvm::Module> m, const string &fu
 
     TargetMachine *tm = engine_builder.selectTarget();
     internal_assert(tm) << error_string << "\n";
-    #if LLVM_VERSION == 37
-    DataLayout target_data_layout(*(tm->getDataLayout()));
-    #else
     DataLayout target_data_layout(tm->createDataLayout());
-    #endif
     if (initial_module_data_layout != target_data_layout) {
         internal_error << "Warning: data layout mismatch between module ("
                        << initial_module_data_layout.getStringRepresentation()

--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -1,8 +1,8 @@
 #ifndef HALIDE_LLVM_HEADERS_H
 #define HALIDE_LLVM_HEADERS_H
 
-#if LLVM_VERSION < 37
-#error "Compiling Halide requires LLVM 3.7 or newer"
+#if LLVM_VERSION < 39
+#error "Compiling Halide requires LLVM 3.9 or newer"
 #endif
 
 // This seems to be required by some LLVM header, which is likely an LLVM bug.
@@ -55,9 +55,7 @@
 #include <llvm/Object/ArchiveWriter.h>
 #include <llvm/Object/ObjectFile.h>
 
-#if LLVM_VERSION >= 39
 #include <llvm/Transforms/Scalar/GVN.h>
-#endif
 
 #if LLVM_VERSION >= 40
 #include <llvm/Transforms/IPO/AlwaysInliner.h>

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -40,11 +40,7 @@ void emit_file(llvm::Module &module, Internal::LLVMOStream& out, llvm::TargetMac
     auto target_machine = Internal::make_target_machine(module);
     internal_assert(target_machine.get()) << "Could not allocate target machine!\n";
 
-    #if LLVM_VERSION == 37
-    llvm::DataLayout target_data_layout(*(target_machine->getDataLayout()));
-    #else
     llvm::DataLayout target_data_layout(target_machine->createDataLayout());
-    #endif
     if (!(target_data_layout == module.getDataLayout())) {
         internal_error << "Warning: module's data layout does not match target machine's\n"
                        << target_data_layout.getStringRepresentation() << "\n"
@@ -211,7 +207,6 @@ void create_static_library(const std::vector<std::string> &src_files_in, const T
 
     SetCwd set_cwd(src_dir);
 
-#if LLVM_VERSION >= 39
     std::vector<llvm::NewArchiveMember> new_members;
     for (auto &src : src_files) {
         llvm::Expected<llvm::NewArchiveMember> new_member =
@@ -224,37 +219,15 @@ void create_static_library(const std::vector<std::string> &src_files_in, const T
         }
         new_members.push_back(std::move(*new_member));
     }
-#elif LLVM_VERSION == 38
-    std::vector<llvm::NewArchiveIterator> new_members;
-    for (auto &src : src_files) {
-        new_members.push_back(llvm::NewArchiveIterator(src));
-    }
-#else
-    std::vector<llvm::NewArchiveIterator> new_members;
-    for (auto &src : src_files) {
-        new_members.push_back(llvm::NewArchiveIterator(src, src));
-    }
-#endif
 
     const bool write_symtab = true;
     const auto kind = Internal::get_triple_for_target(target).isOSDarwin()
         ? llvm::object::Archive::K_BSD
         : llvm::object::Archive::K_GNU;
-#if LLVM_VERSION == 37
-    auto result = llvm::writeArchive(dst_file, new_members,
-                       write_symtab, kind,
-                       deterministic);
-#elif LLVM_VERSION == 38
-    const bool thin = false;
-    auto result = llvm::writeArchive(dst_file, new_members,
-                       write_symtab, kind,
-                       deterministic, thin);
-#else
     const bool thin = false;
     auto result = llvm::writeArchive(dst_file, new_members,
                        write_symtab, kind,
                        deterministic, thin, nullptr);
-#endif
 #if LLVM_VERSION >= 60
     internal_assert(!result) << "Failed to write archive: " << dst_file
         << ", reason: " << result << "\n";

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -261,11 +261,7 @@ llvm::DataLayout get_data_layout_for_target(Target target) {
             if (target.os == Target::IOS) {
                 return llvm::DataLayout("e-m:o-i64:64-i128:128-n32:64-S128");
             } else {
-                #if LLVM_VERSION < 39
-                return llvm::DataLayout("e-m:e-i64:64-i128:128-n32:64-S128");
-                #else
                 return llvm::DataLayout("e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128");
-                #endif
             }
         }
     } else if (target.arch == Target::MIPS) {
@@ -423,14 +419,8 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t)
 
     // Link them all together
     for (size_t i = 1; i < modules.size(); i++) {
-        #if LLVM_VERSION >= 38
         bool failed = llvm::Linker::linkModules(*modules[0],
                                                 std::move(modules[i]));
-        #else
-        bool failed = llvm::Linker::LinkModules(modules[0].get(),
-                                                modules[i].release());
-        #endif
-
         if (failed) {
             internal_error << "Failure linking initial modules\n";
         }
@@ -982,12 +972,7 @@ void add_bitcode_to_module(llvm::LLVMContext *context, llvm::Module &module,
     llvm::StringRef sb = llvm::StringRef((const char *)&bitcode[0], bitcode.size());
     std::unique_ptr<llvm::Module> add_in = parse_bitcode_file(sb, context, name.c_str());
 
-    #if LLVM_VERSION >= 38
     bool failed = llvm::Linker::linkModules(module, std::move(add_in));
-    #else
-    bool failed = llvm::Linker::LinkModules(&module, add_in.release());
-    #endif
-
     if (failed) {
         internal_error << "Failure linking in additional module: " << name << "\n";
     }


### PR DESCRIPTION
With final release of LLVM 5.0, we should drop support for older versions to simplify internal code; with this PR, we would support 3.9, 4.0, 5.0, trunk.

This revises Travis to test 3.9 and 4.0. (Note that buildbot will need https://github.com/halide/build_bot/pull/3 to land to remove testing of 3.8; this PR is guaranteed to fail until then.)

https://github.com/halide/Halide/issues/2356