### PR TITLE
Throw an assertion for unused custom wrapper

### DIFF
--- a/src/WrapCalls.cpp
+++ b/src/WrapCalls.cpp
@@ -1,4 +1,5 @@
 #include "WrapCalls.h"
+#include "FindCalls.h"
 
 #include <set>
 
@@ -47,6 +48,13 @@ void insert_func_wrapper_helper(map<FunctionPtr, SubstitutionMap> &func_wrappers
         }
     }
     wrappers_map[wrapped_func] = wrapper;
+}
+
+void validate_custom_wrapper(const string &wrapped_func, const Function &in_func) {
+    map<string, Function> callees = find_direct_calls(in_func);
+    user_assert(callees.count(wrapped_func))
+        << wrapped_func << ".in(" << in_func.name() << ") was called but "
+        << wrapped_func << " is never used in " << in_func.name() << "\n";
 }
 
 } // anonymous namespace
@@ -124,6 +132,7 @@ map<string, Function> wrap_func_calls(const map<string, Function> &env) {
                              << " -> " << Function(wrapper).name() << "] since it's not in the pipeline\n";
                     continue;
                 }
+                validate_custom_wrapper(wrapped_fname, env.find(in_func)->second);
                 insert_func_wrapper_helper(func_wrappers_map,
                                            wrapped_env[in_func].get_contents(),
                                            wrapped_func,

--- a/src/WrapCalls.cpp
+++ b/src/WrapCalls.cpp
@@ -50,11 +50,11 @@ void insert_func_wrapper_helper(map<FunctionPtr, SubstitutionMap> &func_wrappers
     wrappers_map[wrapped_func] = wrapper;
 }
 
-void validate_custom_wrapper(const string &wrapped_func, const Function &in_func) {
+void validate_custom_wrapper(Function in_func, Function wrapped, Function wrapper) {
     map<string, Function> callees = find_direct_calls(in_func);
-    user_assert(callees.count(wrapped_func))
-        << wrapped_func << ".in(" << in_func.name() << ") was called but "
-        << wrapped_func << " is never used in " << in_func.name() << "\n";
+    user_assert(callees.count(wrapper.name()))
+        << wrapped.name() << ".in(" << in_func.name() << ") was called but \""
+        << wrapped.name() << "\" is never used in \"" << in_func.name() << "\"\n";
 }
 
 } // anonymous namespace
@@ -63,6 +63,7 @@ map<string, Function> wrap_func_calls(const map<string, Function> &env) {
     map<string, Function> wrapped_env;
 
     map<FunctionPtr, SubstitutionMap> func_wrappers_map; // In Func -> [wrapped Func -> wrapper]
+    set<string> global_wrappers;
 
     for (const auto &iter : env) {
         wrapped_env.emplace(iter.first, iter.second);
@@ -86,6 +87,7 @@ map<string, Function> wrap_func_calls(const map<string, Function> &env) {
             FunctionPtr wrapper = iter.second;
 
             if (in_func.empty()) { // Global wrapper
+                global_wrappers.insert(Function(wrapper).name());
                 for (const auto &wrapped_env_iter : wrapped_env) {
                     in_func = wrapped_env_iter.first;
                     if ((wrapped_fname == in_func) ||
@@ -132,7 +134,6 @@ map<string, Function> wrap_func_calls(const map<string, Function> &env) {
                              << " -> " << Function(wrapper).name() << "] since it's not in the pipeline\n";
                     continue;
                 }
-                validate_custom_wrapper(wrapped_fname, env.find(in_func)->second);
                 insert_func_wrapper_helper(func_wrappers_map,
                                            wrapped_env[in_func].get_contents(),
                                            wrapped_func,
@@ -146,6 +147,19 @@ map<string, Function> wrap_func_calls(const map<string, Function> &env) {
         const auto &substitutions = func_wrappers_map[iter.second.get_contents()];
         if (!substitutions.empty()) {
             iter.second.substitute_calls(substitutions);
+        }
+    }
+
+    // Assert that the custom wrappers are actually used, i.e. if f.in(g) is
+    // called, but 'f' is never called inside 'g', this will throw a user error.
+    // Perform the check after the wrapper substitution to handle multi-fold
+    // wrappers, e.g. f.in(g).in(g).
+    for (const auto &iter : wrapped_env) {
+        const auto &substitutions = func_wrappers_map[iter.second.get_contents()];
+        for (const auto &pair : substitutions) {
+            if (global_wrappers.find(Function(pair.second).name()) == global_wrappers.end()) {
+                validate_custom_wrapper(iter.second, Function(pair.first), Function(pair.second));
+            }
         }
     }
 

--- a/src/WrapCalls.cpp
+++ b/src/WrapCalls.cpp
@@ -53,8 +53,8 @@ void insert_func_wrapper_helper(map<FunctionPtr, SubstitutionMap> &func_wrappers
 void validate_custom_wrapper(Function in_func, Function wrapped, Function wrapper) {
     map<string, Function> callees = find_direct_calls(in_func);
     user_assert(callees.count(wrapper.name()))
-        << wrapped.name() << ".in(" << in_func.name() << ") was called but \""
-        << wrapped.name() << "\" is never used in \"" << in_func.name() << "\"\n";
+        << "Wrapper for \"" << wrapped.name() << "\" in \"" << in_func.name()
+        << "\" was created but is never used inside \"" << in_func.name() << "\"\n";
 }
 
 } // anonymous namespace

--- a/src/WrapCalls.cpp
+++ b/src/WrapCalls.cpp
@@ -53,8 +53,9 @@ void insert_func_wrapper_helper(map<FunctionPtr, SubstitutionMap> &func_wrappers
 void validate_custom_wrapper(Function in_func, Function wrapped, Function wrapper) {
     map<string, Function> callees = find_direct_calls(in_func);
     user_assert(callees.count(wrapper.name()))
-        << "Wrapper for \"" << wrapped.name() << "\" in \"" << in_func.name()
-        << "\" was created but is never used inside \"" << in_func.name() << "\"\n";
+        << "Cannot wrap \"" << wrapped.name() << "\" in \"" << in_func.name()
+        << "\" because \"" << in_func.name() << "\" does not call \""
+        << wrapped.name() << "\"\n";
 }
 
 } // anonymous namespace

--- a/test/error/wrapper_never_used.cpp
+++ b/test/error/wrapper_never_used.cpp
@@ -1,0 +1,21 @@
+#include "Halide.h"
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+int main() {
+    Var x("x"), y("y");
+    Func f("f"), g("g"), h("h");
+    f(x, y) = x + y;
+    g(x, y) = 5;
+    h(x, y) = f(x, y) + g(x, y);
+
+    f.compute_root();
+    f.in(g).compute_root();
+
+    // This should cause an error since f.in(g) was called but 'f' is
+    // never used in 'g'.
+    h.realize(5, 5);
+
+    return 0;
+}


### PR DESCRIPTION
If `f.in(g)` is called, but `f` is never actually called inside `g`, this will throw user error.