### PR TITLE
Allow Input<> to be used for Generators with build()

### DIFF
--- a/apps/HelloAndroidCamera2/jni/deinterleave_generator.cpp
+++ b/apps/HelloAndroidCamera2/jni/deinterleave_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class Deinterleave : public Halide::Generator<Deinterleave> {
 public:
-    ImageParam uvInterleaved{ UInt(8), 2, "uvInterleaved" };
+    Input<Buffer<uint8_t>> uvInterleaved{"uvInterleaved" , 2};
 
     Func build() {
         Var x, y;

--- a/apps/HelloAndroidCamera2/jni/edge_detect_generator.cpp
+++ b/apps/HelloAndroidCamera2/jni/edge_detect_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class EdgeDetect : public Halide::Generator<EdgeDetect> {
 public:
-    ImageParam input{ UInt(8), 2, "input" };
+    Input<Buffer<uint8_t>> input{"input" , 2};
 
     Func build() {
         Var x, y;

--- a/apps/bilateral_grid/bilateral_grid_generator.cpp
+++ b/apps/bilateral_grid/bilateral_grid_generator.cpp
@@ -7,8 +7,8 @@ public:
     GeneratorParam<bool>  auto_schedule{"auto_schedule", false};
     GeneratorParam<int>   s_sigma{"s_sigma", 8};
 
-    ImageParam            input{Float(32), 2, "input"};
-    Param<float>          r_sigma{"r_sigma"};
+    Input<Buffer<float>>  input{"input", 2};
+    Input<float>          r_sigma{"r_sigma"};
 
     Func build() {
         Var x("x"), y("y"), z("z"), c("c");

--- a/apps/blur/halide_blur_generator.cpp
+++ b/apps/blur/halide_blur_generator.cpp
@@ -29,7 +29,7 @@ public:
     GeneratorParam<int> tile_x{"tile_x", 32}; // X tile.
     GeneratorParam<int> tile_y{"tile_y", 8};  // Y tile.
 
-    ImageParam input{UInt(16), 2, "input"};
+    Input<Buffer<uint16_t>> input{"input", 2};
 
     Func build() {
         Func blur_x("blur_x"), blur_y("blur_y");

--- a/apps/c_backend/pipeline_cpp_generator.cpp
+++ b/apps/c_backend/pipeline_cpp_generator.cpp
@@ -50,7 +50,7 @@ HalideExtern_2(int, an_extern_c_func, int, float);
 
 class PipelineCpp : public Halide::Generator<PipelineCpp> {
 public:
-    ImageParam input{UInt(16), 2, "input"};
+    Input<Buffer<uint16_t>> input{"input", 2};
 
     Func build() {
         Func f;

--- a/apps/c_backend/pipeline_generator.cpp
+++ b/apps/c_backend/pipeline_generator.cpp
@@ -7,12 +7,12 @@ HalideExtern_2(int, an_extern_func, int, int);
 
 class Pipeline : public Halide::Generator<Pipeline> {
 public:
-    ImageParam input{UInt(16), 2, "input"};
+    Input<Buffer<uint16_t>> input{"input", 2};
     Func build() {
         Var x, y;
 
         Func f, g, h;
-        f(x, y) = (input(clamp(x+2, 0, input.width()-1), clamp(y-2, 0, input.height()-1)) * 17)/13;
+        f(x, y) = (input(clamp(x+2, 0, input.dim(0).extent()-1), clamp(y-2, 0, input.dim(1).extent()-1)) * 17)/13;
         h.define_extern("an_extern_stage", {f}, Int(16), 0, NameMangling::C);
         g(x, y) = cast<uint16_t>(max(0, f(y, x) + f(x, y) + an_extern_func(x, y) + h()));
 

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -189,14 +189,14 @@ public:
     GeneratorParam<bool>  auto_schedule{"auto_schedule", false};
     GeneratorParam<Type> result_type{"result_type", UInt(8)};
 
-    ImageParam input{UInt(16), 2, "input"};
-    ImageParam matrix_3200{Float(32), 2, "matrix_3200"};
-    ImageParam matrix_7000{Float(32), 2, "matrix_7000"};
-    Param<float> color_temp{"color_temp"};
-    Param<float> gamma{"gamma"};
-    Param<float> contrast{"contrast"};
-    Param<int> blackLevel{"blackLevel"};
-    Param<int> whiteLevel{"whiteLevel"};
+    Input<Buffer<uint16_t>> input{"input", 2};
+    Input<Buffer<float>> matrix_3200{"matrix_3200", 2};
+    Input<Buffer<float>> matrix_7000{"matrix_7000", 2};
+    Input<float> color_temp{"color_temp"};
+    Input<float> gamma{"gamma"};
+    Input<float> contrast{"contrast"};
+    Input<int> blackLevel{"blackLevel"};
+    Input<int> whiteLevel{"whiteLevel"};
 
     Func build();
 

--- a/apps/conv_layer/conv_layer_generator.cpp
+++ b/apps/conv_layer/conv_layer_generator.cpp
@@ -8,9 +8,9 @@ class ConvolutionLayer : public Halide::Generator<ConvolutionLayer> {
 public:
     GeneratorParam<bool>  auto_schedule{"auto_schedule", false};
 
-    ImageParam            input{Float(32), 4, "input"};
-    ImageParam            filter{Float(32), 4, "filter"};
-    ImageParam            bias{Float(32), 1, "bias"};
+    Input<Buffer<float>>  input{"input", 4};
+    Input<Buffer<float>>  filter{"filter", 4};
+    Input<Buffer<float>>  bias{"bias", 1};
 
     Func build() {
         /* THE ALGORITHM */

--- a/apps/cuda_mat_mul/mat_mul_generator.cpp
+++ b/apps/cuda_mat_mul/mat_mul_generator.cpp
@@ -8,8 +8,8 @@ class MatMul : public Halide::Generator<MatMul> {
 public:
 
     GeneratorParam<int>   size {"size", 1024};
-    ImageParam            A {Float(32), 2, "A"};
-    ImageParam            B {Float(32), 2, "B"};
+    Input<Buffer<float>>  A{"A", 2};
+    Input<Buffer<float>>  B{"B", 2};
 
     Func build() {
         Var x("x"), y("y");

--- a/apps/glsl/halide_blur_glsl_generator.cpp
+++ b/apps/glsl/halide_blur_glsl_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class HalideBlurGLSL : public Halide::Generator<HalideBlurGLSL> {
 public:
-    ImageParam input8{UInt(8), 3, "input8"};
+    Input<Buffer<uint8_t>> input8{"input8", 3};
     Func build() {
         assert(get_target().has_feature(Target::OpenGL));
 
@@ -13,8 +13,8 @@ public:
 
         // The algorithm
         Func input;
-        input(x,y,c) = cast<float>(input8(clamp(x, input8.left(), input8.right()),
-                                          clamp(y, input8.top(), input8.bottom()), c)) / 255.f;
+        input(x,y,c) = cast<float>(input8(clamp(x, input8.dim(0).min(), input8.dim(0).max()),
+                                          clamp(y, input8.dim(1).min(), input8.dim(1).max()), c)) / 255.f;
         blur_x(x, y, c) = (input(x, y, c) + input(x+1, y, c) + input(x+2, y, c)) / 3;
         blur_y(x, y, c) = (blur_x(x, y, c) + blur_x(x, y+1, c) + blur_x(x, y+2, c)) / 3;
         out(x, y, c) = cast<uint8_t>(blur_y(x, y, c) * 255.f);

--- a/apps/glsl/halide_ycc_glsl_generator.cpp
+++ b/apps/glsl/halide_ycc_glsl_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class RgbToYcc : public Halide::Generator<RgbToYcc> {
 public:
-    ImageParam input8{UInt(8), 3, "input8"};
+    Input<Buffer<uint8_t>> input8{"input8", 3};
     Func build() {
         assert(get_target().has_feature(Target::OpenGL));
         Func out("out");

--- a/apps/lens_blur/lens_blur_generator.cpp
+++ b/apps/lens_blur/lens_blur_generator.cpp
@@ -8,18 +8,18 @@ using namespace Halide;
 
 class LensBlur : public Halide::Generator<LensBlur> {
 public:
-    GeneratorParam<bool>  auto_schedule{"auto_schedule", false};
+    GeneratorParam<bool>    auto_schedule{"auto_schedule", false};
 
-    ImageParam            left_im{UInt(8), 3, "left_im"};
-    ImageParam            right_im{UInt(8), 3, "right_im"};
+    Input<Buffer<uint8_t>>  left_im{"left_im", 3};
+    Input<Buffer<uint8_t>>  right_im{"right_im", 3};
     // The number of displacements to consider
-    Param<int>       slices{"slices", 32, 1, 64};
+    Input<int>              slices{"slices", 32, 1, 64};
     // The depth to focus on
-    Param<int>       focus_depth{"focus_depth", 13, 1, 32};
+    Input<int>              focus_depth{"focus_depth", 13, 1, 32};
     // The increase in blur radius with misfocus depth
-    Param<float>     blur_radius_scale{"blur_radius_scale", 0.5f, 0.0f, 1.0f};
+    Input<float>            blur_radius_scale{"blur_radius_scale", 0.5f, 0.0f, 1.0f};
     // The number of samples of the aperture to use
-    Param<int>       aperture_samples{"aperture_samples", 32, 1, 64};
+    Input<int>              aperture_samples{"aperture_samples", 32, 1, 64};
 
     Func build() {
         /* THE ALGORITHM */
@@ -55,7 +55,7 @@ public:
         cost_pyramid_push[0](x, y, z, c) =
             select(c == 0, cost(x, y, z) * cost_confidence(x, y), cost_confidence(x, y));
 
-        Expr w = left_im.width(), h = left_im.height();
+        Expr w = left_im.dim(0).extent(), h = left_im.dim(1).extent();
         for (int i = 1; i < 8; i++) {
             cost_pyramid_push[i](x, y, z, c) = downsample(cost_pyramid_push[i-1])(x, y, z, c);
             w /= 2;

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -6,13 +6,13 @@ constexpr int maxJ = 20;
 
 class LocalLaplacian : public Halide::Generator<LocalLaplacian> {
 public:
-    GeneratorParam<bool>  auto_schedule{"auto_schedule", false};
-    GeneratorParam<int>   pyramid_levels{"pyramid_levels", 8, 1, maxJ};
+    GeneratorParam<bool>    auto_schedule{"auto_schedule", false};
+    GeneratorParam<int>     pyramid_levels{"pyramid_levels", 8, 1, maxJ};
 
-    ImageParam            input{UInt(16), 3, "input"};
-    Param<int>            levels{"levels"};
-    Param<float>          alpha{"alpha"};
-    Param<float>          beta{"beta"};
+    Input<Buffer<uint16_t>> input{"input", 3};
+    Input<int>              levels{"levels"};
+    Input<float>            alpha{"alpha"};
+    Input<float>            beta{"beta"};
 
     Func build() {
         /* THE ALGORITHM */

--- a/apps/nl_means/nl_means_generator.cpp
+++ b/apps/nl_means/nl_means_generator.cpp
@@ -8,10 +8,10 @@ class NonLocalMeans : public Halide::Generator<NonLocalMeans> {
 public:
     GeneratorParam<bool>  auto_schedule{"auto_schedule", false};
 
-    ImageParam            input{Float(32), 3, "input"};
-    Param<int>            patch_size{"patch_size"};
-    Param<int>            search_area{"search_area"};
-    Param<float>          sigma{"sigma"};
+    Input<Buffer<float>>  input{"input", 3};
+    Input<int>            patch_size{"patch_size"};
+    Input<int>            search_area{"search_area"};
+    Input<float>          sigma{"sigma"};
 
     Func build() {
         /* THE ALGORITHM */

--- a/apps/wavelet/daubechies_x_generator.cpp
+++ b/apps/wavelet/daubechies_x_generator.cpp
@@ -8,7 +8,7 @@ Halide::Var x("x"), y("y"), c("c");
 
 class daubechies_x : public Halide::Generator<daubechies_x> {
 public:
-    ImageParam in_{ Float(32), 2, "in" };
+    Input<Buffer<float>> in_{"in" , 2};
 
     Func build() {
         Func in = Halide::BoundaryConditions::repeat_edge(in_);

--- a/apps/wavelet/haar_x_generator.cpp
+++ b/apps/wavelet/haar_x_generator.cpp
@@ -8,7 +8,7 @@ Halide::Var x("x"), y("y"), c("c");
 
 class haar_x : public Halide::Generator<haar_x> {
 public:
-    ImageParam in_{ Float(32), 2, "in" };
+    Input<Buffer<float>> in_{"in" , 2};
 
     Func build() {
         Func in = Halide::BoundaryConditions::repeat_edge(in_);

--- a/apps/wavelet/inverse_daubechies_x_generator.cpp
+++ b/apps/wavelet/inverse_daubechies_x_generator.cpp
@@ -8,7 +8,7 @@ Halide::Var x("x"), y("y"), c("c");
 
 class inverse_daubechies_x : public Halide::Generator<inverse_daubechies_x> {
 public:
-    ImageParam in_{ Float(32), 3, "in" };
+    Input<Buffer<float>> in_{"in" , 3};
 
     Func build() {
         Func in = Halide::BoundaryConditions::repeat_edge(in_);

--- a/apps/wavelet/inverse_haar_x_generator.cpp
+++ b/apps/wavelet/inverse_haar_x_generator.cpp
@@ -8,7 +8,7 @@ Halide::Var x("x"), y("y"), c("c");
 
 class inverse_haar_x : public Halide::Generator<inverse_haar_x> {
 public:
-    ImageParam in_{ Float(32), 3, "in" };
+    Input<Buffer<float>> in_{"in" , 3};
 
     Func build() {
         Func in = Halide::BoundaryConditions::repeat_edge(in_);

--- a/test/generator/acquire_release_generator.cpp
+++ b/test/generator/acquire_release_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class AcquireRelease : public Halide::Generator<AcquireRelease> {
 public:
-    ImageParam input{ Float(32), 2, "input" };
+    Input<Buffer<float>> input{"input", 2};
 
     Func build() {
         Var x("x"), y("y");

--- a/test/generator/argvcall_generator.cpp
+++ b/test/generator/argvcall_generator.cpp
@@ -4,8 +4,8 @@ namespace {
 
 class ArgvCall : public Halide::Generator<ArgvCall> {
 public:
-    Param<float> f1{ "f1", 1.0 };
-    Param<float> f2{ "f2", 1.0 };
+    Input<float> f1{ "f1", 1.0 };
+    Input<float> f2{ "f2", 1.0 };
 
     Func build() {
         Var x, y, c;

--- a/test/generator/embed_image_generator.cpp
+++ b/test/generator/embed_image_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class EmbedImage : public Halide::Generator<EmbedImage> {
 public:
-    ImageParam input{ Float(32), 3, "input" };
+    Input<Buffer<float>> input{"input", 3};
 
     Func build() {
         Buffer<float> matrix(3, 3);

--- a/test/generator/error_codes_generator.cpp
+++ b/test/generator/error_codes_generator.cpp
@@ -4,8 +4,8 @@ namespace {
 
 class ErrorCodes : public Halide::Generator<ErrorCodes> {
 public:
-    ImageParam input { Int(32), 2, "input" };
-    Param<int> f_explicit_bound {"f_explicit_bound", 1, 0, 64};
+    Input<Buffer<int32_t>> input{ "input", 2};
+    Input<int>             f_explicit_bound{"f_explicit_bound", 1, 0, 64};
 
 
     Func build() {

--- a/test/generator/gpu_only_generator.cpp
+++ b/test/generator/gpu_only_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class GpuOnly : public Halide::Generator<GpuOnly> {
 public:
-    ImageParam input{ Int(32), 2, "input" };
+    Input<Buffer<int32_t>> input{"input", 2};
 
     Func build() {
         Var x("x"), y("y");

--- a/test/generator/mandelbrot_generator.cpp
+++ b/test/generator/mandelbrot_generator.cpp
@@ -33,15 +33,15 @@ Expr magnitude(Complex a) { return (a * conjugate(a)).real(); }
 
 class Mandelbrot : public Generator<Mandelbrot> {
 public:
-    Param<float> x_min{"x_min"};
-    Param<float> x_max{"x_max"};
-    Param<float> y_min{"y_min"};
-    Param<float> y_max{"y_max"};
-    Param<float> c_real{"c_real"};
-    Param<float> c_imag{"c_imag"};
-    Param<int> iters{"iters"};
-    Param<int> w{"w"};
-    Param<int> h{"h"};
+    Input<float> x_min{"x_min"};
+    Input<float> x_max{"x_max"};
+    Input<float> y_min{"y_min"};
+    Input<float> y_max{"y_max"};
+    Input<float> c_real{"c_real"};
+    Input<float> c_imag{"c_imag"};
+    Input<int>   iters{"iters"};
+    Input<int>   w{"w"};
+    Input<int>   h{"h"};
 
     Func build() {
         Var x, y, z;

--- a/test/generator/matlab_generator.cpp
+++ b/test/generator/matlab_generator.cpp
@@ -6,9 +6,9 @@ namespace {
 
 class Matlab : public Halide::Generator<Matlab> {
 public:
-    ImageParam input{Float(32), 2, "input"};
-    Param<float> scale{"scale"};
-    Param<bool> negate{"negate"};
+    Input<Buffer<float>> input{"input", 2};
+    Input<float>         scale{"scale"};
+    Input<bool>          negate{"negate"};
 
     Func build() {
         Var x, y;

--- a/test/generator/memory_profiler_mandelbrot_generator.cpp
+++ b/test/generator/memory_profiler_mandelbrot_generator.cpp
@@ -33,15 +33,15 @@ Expr magnitude(Complex a) { return (a * conjugate(a)).real(); }
 
 class Mandelbrot : public Generator<Mandelbrot> {
 public:
-    Param<float> x_min{"x_min"};
-    Param<float> x_max{"x_max"};
-    Param<float> y_min{"y_min"};
-    Param<float> y_max{"y_max"};
-    Param<float> c_real{"c_real"};
-    Param<float> c_imag{"c_imag"};
-    Param<int> iters{"iters"};
-    Param<int> w{"w"};
-    Param<int> h{"h"};
+    Input<float> x_min{"x_min"};
+    Input<float> x_max{"x_max"};
+    Input<float> y_min{"y_min"};
+    Input<float> y_max{"y_max"};
+    Input<float> c_real{"c_real"};
+    Input<float> c_imag{"c_imag"};
+    Input<int>   iters{"iters"};
+    Input<int>   w{"w"};
+    Input<int>   h{"h"};
 
     Func build() {
         target.set(get_target().with_feature(Target::Profile));

--- a/test/generator/old_buffer_t_generator.cpp
+++ b/test/generator/old_buffer_t_generator.cpp
@@ -5,9 +5,9 @@
 // bounds inference does something, and with an extern definition.
 class OldBufferT : public Halide::Generator<OldBufferT> {
 public:
-    ImageParam in1 {Int(32), 2, "in1"};
-    ImageParam in2 {Int(32), 2, "in2"};
-    Param<int> scalar_param {"scalar_param", 1, 0, 64};
+    Input<Buffer<int32_t>> in1{"in1", 2};
+    Input<Buffer<int32_t>> in2{"in2", 2};
+    Input<int>             scalar_param{"scalar_param", 1, 0, 64};
 
     Func build() {
         Func f, g;

--- a/test/generator/user_context_generator.cpp
+++ b/test/generator/user_context_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class UserContext : public Halide::Generator<UserContext> {
 public:
-    ImageParam input{ Float(32), 2, "input" };
+    Input<Buffer<float>> input{"input", 2};
 
     Func build() {
         Var x, y;

--- a/test/generator/user_context_insanity_generator.cpp
+++ b/test/generator/user_context_insanity_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class UserContextInsanity : public Halide::Generator<UserContextInsanity> {
 public:
-    ImageParam input{ Float(32), 2, "input" };
+    Input<Buffer<float>> input{"input", 2};
 
     Func build() {
         Var x, y;


### PR DESCRIPTION
Up to now, we have explicitly disallowed using the Input<> syntax for Generators that used build() [rather than generate()+schedule()]; this was done in the (misguided) thought that it would encourage conversion of Generators to the newer syntax. 

As it turns out, it actually *discouraged* said conversion, as it didn't allow for incremental changes to be made.

This PR changes that, in an effort to enable and encourage incremental conversion:
- You now may freely use Input<> in any Generator, whether it uses build() or generate().
- However, you may not mix Param/ImageParam and Input<> in the same Generator.
- All Generators in Halide have been converted to use Input<> rather than Param/ImageParam.
- It is still legal to use Param/ImageParam in Generators; however, they are now marked as deprecated when used as member variables of a Generator.