### PR TITLE
Catch mismatched dimensionality call to extern Funcs

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -223,7 +223,7 @@ std::pair<int, int> Func::add_implicit_vars(vector<Var> &args) const {
         }
     }
 
-    if (func.has_pure_definition() && args.size() != (size_t)dimensions()) {
+    if (defined() && args.size() != (size_t)dimensions()) {
         user_error << "Func \"" << name() << "\" was called with "
                    << args.size() << " arguments, but was defined with " << dimensions() << "\n";
     }
@@ -253,7 +253,7 @@ std::pair<int, int> Func::add_implicit_vars(vector<Expr> &args) const {
         }
     }
 
-    if (func.has_pure_definition() && args.size() != (size_t)dimensions()) {
+    if (defined() && args.size() != (size_t)dimensions()) {
         user_error << "Func \"" << name() << "\" was called with "
                    << args.size() << " arguments, but was defined with " << dimensions() << "\n";
     }

--- a/test/error/wrong_dimensionality_extern_stage.cpp
+++ b/test/error/wrong_dimensionality_extern_stage.cpp
@@ -1,0 +1,15 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Func f, g;
+    Var x, y;
+
+    g.define_extern("foo", {}, UInt(16), 3);
+
+    // Show throw an error immediately because g was defined with 3 dimensions.
+    f(x, y) = cast<float>(g(x, y));
+
+    return 0;
+}


### PR DESCRIPTION
Previously produced an inscrutable error from the middle of bounds
inference. Now caught in the front-end.