### PR TITLE
Enable naming dimensions of extern stages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,6 +379,7 @@ SOURCE_FILES = \
   RemoveUndef.cpp \
   Schedule.cpp \
   ScheduleFunctions.cpp \
+  ScheduleParam.cpp \
   SelectGPUAPI.cpp \
   Simplify.cpp \
   SimplifySpecializations.cpp \
@@ -522,6 +523,7 @@ HEADER_FILES = \
   RemoveUndef.h \
   Schedule.h \
   ScheduleFunctions.h \
+  ScheduleParam.h \
   Scope.h \
   SelectGPUAPI.h \
   Simplify.h \
@@ -1179,6 +1181,9 @@ $(BIN_DIR)/stubuser.generator: $(BUILD_DIR)/stubtest_generator.o
 # stubtest has input and output funcs with undefined types and array sizes; this is fine for stub
 # usage (the types can be inferred), but for AOT compilation, we must make the types
 # concrete via generator args.
+#
+# Also note that setting 'vectorize=true' is redundant (that's the default), but verifies
+# that setting ScheduleParam via generator_args works properly.
 STUBTEST_GENERATOR_ARGS=\
     untyped_buffer_input.type=uint8 untyped_buffer_input.dim=3 \
 	simple_input.type=float32 \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -356,6 +356,7 @@ set(HEADER_FILES
   RemoveUndef.h
   Schedule.h
   ScheduleFunctions.h
+  ScheduleParam.h
   Scope.h
   SelectGPUAPI.h
   Simplify.h
@@ -505,6 +506,7 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   RemoveUndef.cpp
   Schedule.cpp
   ScheduleFunctions.cpp
+  ScheduleParam.cpp
   SelectGPUAPI.cpp
   Simplify.cpp
   SimplifySpecializations.cpp

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -162,14 +162,13 @@ bool Func::is_extern() const {
 void Func::define_extern(const std::string &function_name,
                          const std::vector<ExternFuncArgument> &args,
                          const std::vector<Type> &types,
-                         int dimensionality,
+                         const std::vector<Var> &arguments,
                          NameMangling mangling,
                          DeviceAPI device_api,
                          bool uses_old_buffer_t) {
-    vector<string> dim_names(dimensionality);
-    // Use _0, _1, _2 etc for the storage dimensions
-    for (int i = 0; i < dimensionality; i++) {
-        dim_names[i] = Var::implicit(i).name();
+    vector<string> dim_names(arguments.size());
+    for (size_t i = 0; i < arguments.size(); i++) {
+        dim_names[i] = arguments[i].name();
     }
     func.define_extern(function_name, args, types, dim_names,
                        mangling, device_api, uses_old_buffer_t);

--- a/src/Func.h
+++ b/src/Func.h
@@ -954,8 +954,9 @@ public:
                               int dimensionality,
                               NameMangling mangling,
                               bool uses_old_buffer_t) {
-        define_extern(function_name, params, std::vector<Type>{t},
-                      dimensionality, mangling, DeviceAPI::Host, uses_old_buffer_t);
+        define_extern(function_name, params, t,
+                      Internal::make_argument_list(dimensionality),
+                      mangling, uses_old_buffer_t);
     }
 
     EXPORT void define_extern(const std::string &function_name,
@@ -965,8 +966,9 @@ public:
                               NameMangling mangling = NameMangling::Default,
                               DeviceAPI device_api = DeviceAPI::Host,
                               bool uses_old_buffer_t = false) {
-        define_extern(function_name, params, std::vector<Type>{t},
-                      dimensionality, mangling, device_api, uses_old_buffer_t);
+        define_extern(function_name, params, t,
+                      Internal::make_argument_list(dimensionality),
+                      mangling, device_api, uses_old_buffer_t);
     }
 
     EXPORT void define_extern(const std::string &function_name,
@@ -975,14 +977,58 @@ public:
                               int dimensionality,
                               NameMangling mangling,
                               bool uses_old_buffer_t) {
-      define_extern(function_name, params, types,
-                    dimensionality, mangling, DeviceAPI::Host, uses_old_buffer_t);
+        define_extern(function_name, params, types,
+                      Internal::make_argument_list(dimensionality),
+                      mangling, uses_old_buffer_t);
     }
 
     EXPORT void define_extern(const std::string &function_name,
                               const std::vector<ExternFuncArgument> &params,
                               const std::vector<Type> &types,
                               int dimensionality,
+                              NameMangling mangling = NameMangling::Default,
+                              DeviceAPI device_api = DeviceAPI::Host,
+                              bool uses_old_buffer_t = false) {
+        define_extern(function_name, params, types,
+                      Internal::make_argument_list(dimensionality),
+                      mangling, device_api, uses_old_buffer_t);
+    }
+
+    EXPORT void define_extern(const std::string &function_name,
+                              const std::vector<ExternFuncArgument> &params,
+                              Type t,
+                              const std::vector<Var> &arguments,
+                              NameMangling mangling,
+                              bool uses_old_buffer_t) {
+        define_extern(function_name, params, std::vector<Type>{t},
+                      arguments, mangling, uses_old_buffer_t);
+    }
+
+    EXPORT void define_extern(const std::string &function_name,
+                              const std::vector<ExternFuncArgument> &params,
+                              Type t,
+                              const std::vector<Var> &arguments,
+                              NameMangling mangling = NameMangling::Default,
+                              DeviceAPI device_api = DeviceAPI::Host,
+                              bool uses_old_buffer_t = false) {
+        define_extern(function_name, params, std::vector<Type>{t},
+                      arguments, mangling, device_api, uses_old_buffer_t);
+    }
+
+    EXPORT void define_extern(const std::string &function_name,
+                              const std::vector<ExternFuncArgument> &params,
+                              const std::vector<Type> &types,
+                              const std::vector<Var> &arguments,
+                              NameMangling mangling,
+                              bool uses_old_buffer_t) {
+      define_extern(function_name, params, types,
+                    arguments, mangling, DeviceAPI::Host, uses_old_buffer_t);
+    }
+
+    EXPORT void define_extern(const std::string &function_name,
+                              const std::vector<ExternFuncArgument> &params,
+                              const std::vector<Type> &types,
+                              const std::vector<Var> &arguments,
                               NameMangling mangling = NameMangling::Default,
                               DeviceAPI device_api = DeviceAPI::Host,
                               bool uses_old_buffer_t = false);

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -989,6 +989,22 @@ public:
         : substitutions(substitutions) {}
 };
 
+class SubstituteScheduleParamExprs : public IRMutator2 {
+    using IRMutator2::visit;
+
+    Expr visit(const Variable *v) override {
+        Expr expr = IRMutator2::visit(v);
+        if (v->param.defined() && v->param.is_bound_before_lowering()) {
+            expr = mutate(v->param.scalar_expr());
+        }
+        return expr;
+    }
+
+public:
+    SubstituteScheduleParamExprs() = default;
+};
+
+
 } // anonymous namespace
 
 Function &Function::substitute_calls(const map<FunctionPtr, FunctionPtr> &substitutions) {
@@ -1005,6 +1021,12 @@ Function &Function::substitute_calls(const Function &orig, const Function &subst
     map<FunctionPtr, FunctionPtr> substitutions;
     substitutions.emplace(orig.get_contents(), substitute.get_contents());
     return substitute_calls(substitutions);
+}
+
+Function &Function::substitute_schedule_param_exprs() {
+    SubstituteScheduleParamExprs sub_schedule_params;
+    contents->mutate(&sub_schedule_params);
+    return *this;
 }
 
 // Deep copy an entire Function DAG.

--- a/src/Function.h
+++ b/src/Function.h
@@ -321,6 +321,10 @@ public:
     EXPORT Function &substitute_calls(const Function &orig, const Function &substitute);
     // @}
 
+    /** Find all Vars that are placeholders for ScheduleParams and substitute in
+     * the corresponding constant value. */
+    EXPORT Function &substitute_schedule_param_exprs();
+
     /** Return true iff the name matches one of the Function's pure args. */
     EXPORT bool is_pure_arg(const std::string &name) const;
 };

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -212,12 +212,14 @@ public:
                 const std::string &generator_registered_name,
                 const std::string &generator_stub_name,
                 const std::vector<Internal::GeneratorParamBase *>& generator_params,
+                const std::vector<Internal::ScheduleParamBase *>& schedule_params,
                 const std::vector<Internal::GeneratorInputBase *>& inputs,
                 const std::vector<Internal::GeneratorOutputBase *>& outputs)
         : stream(dest),
           generator_registered_name(generator_registered_name),
           generator_stub_name(generator_stub_name),
           generator_params(select_generator_params(generator_params)),
+          schedule_params(schedule_params),
           inputs(inputs),
           outputs(outputs) {
        namespaces = split_string(generator_stub_name, "::");
@@ -239,6 +241,8 @@ private:
     std::string class_name;
     std::vector<std::string> namespaces;
     const std::vector<Internal::GeneratorParamBase *> generator_params;
+    const std::vector<Internal::GeneratorParamBase *> schedule_params_old;
+    const std::vector<Internal::ScheduleParamBase *> schedule_params;
     const std::vector<Internal::GeneratorInputBase *> inputs;
     const std::vector<Internal::GeneratorOutputBase *> outputs;
     int indent_level{0};
@@ -261,6 +265,7 @@ private:
 
     void emit_inputs_struct();
     void emit_generator_params_struct();
+    void emit_schedule_params_setters();
 };
 
 std::string StubEmitter::indent() {
@@ -329,6 +334,31 @@ void StubEmitter::emit_generator_params_struct() {
 
     indent_level--;
     stream << indent() << "};\n";
+    stream << "\n";
+}
+
+void StubEmitter::emit_schedule_params_setters() {
+    stream << indent() << "// set_schedule_param methods\n";
+    stream << indent() << "template <typename T>\n";
+    stream << indent() << "inline " << class_name << " &set_schedule_param(const std::string &name, const T &value) {\n";
+    indent_level++;
+    stream << indent() << "(void) GeneratorStub::set_schedule_param(name, value);\n";
+    stream << indent() << "return *this;\n";
+    indent_level--;
+    stream << indent() << "}\n";
+
+    const auto &v = schedule_params;
+    if (!v.empty()) {
+        for (auto *p : v) {
+            std::string c_type = p->is_looplevel_param() ? "LoopLevel" : halide_type_to_c_type(p->scalar_type());
+            stream << indent() << "inline " << class_name << " &set_" << p->name() << "(const " << c_type << " &value) {\n";
+            indent_level++;
+            stream << indent() << "this->" << p->name() << ".set(value);\n";
+            stream << indent() << "return *this;\n";
+            indent_level--;
+            stream << indent() << "}\n";
+        }
+    }
     stream << "\n";
 }
 
@@ -473,6 +503,15 @@ void StubEmitter::emit() {
         stream << indent() << out.ctype << " " << out.name << ";\n";
     }
 
+    if (!schedule_params.empty()) {
+        stream << "\n";
+        stream << indent() << "// ScheduleParams\n";
+        for (auto *p : schedule_params) {
+            std::string c_type = p->is_looplevel_param() ? "LoopLevel" : halide_type_to_c_type(p->scalar_type());
+            stream << indent() << "ScheduleParam<" <<c_type << "> " << p->name() << ";\n";
+        }
+    }
+
     stream << "\n";
     stream << indent() << "// The Target used\n";
     stream << indent() << "Target target;\n";
@@ -570,6 +609,9 @@ void StubEmitter::emit() {
     for (const auto &out : out_info) {
         stream << indent() << "self." << out.name << ",\n";
     }
+    for (auto *p : schedule_params) {
+        stream << indent() << "self." << p->name() << ",\n";
+    }
     stream << indent() << "self.get_target()\n";
     indent_level--;
     stream << indent() << "};\n";
@@ -607,8 +649,19 @@ void StubEmitter::emit() {
     stream << indent() << "}\n";
     stream << "\n";
 
-    stream << indent() << class_name << "() {}\n";
+    if (!schedule_params.empty()) {
+        stream << indent() << "NO_INLINE " << class_name << "() :\n";
+        indent_level++;
+        for (auto *sp : schedule_params) {
+            std::string comma = sp != schedule_params.back() ? "," : "";
+            stream << indent() << sp->name() << "(\"" << sp->name() << "\")" << comma << "\n";
+        }
+        indent_level--;
+        stream << indent() << "{}\n";
 
+    } else {
+        stream << indent() << class_name << "() {}\n";
+    }
     stream << "\n";
 
     stream << indent() << "NO_INLINE " << class_name << "(\n";
@@ -627,6 +680,9 @@ void StubEmitter::emit() {
     }
     indent_level--;
     stream << indent() << "})\n";
+    for (auto *sp : schedule_params) {
+        stream << indent() << ", " << sp->name() << "(get_schedule_param(\"" << sp->name() << "\"))\n";
+    }
     for (const auto &out : out_info) {
         stream << indent() << ", " << out.name << "(" << out.getter << ")\n";
     }
@@ -657,10 +713,15 @@ void StubEmitter::emit() {
     stream << indent() << "}\n";
     stream << "\n";
 
+    emit_schedule_params_setters();
+
     stream << indent() << "// move constructor\n";
     stream << indent() << class_name << "("<< class_name << "&& that)\n";
     indent_level++;
     stream << indent() << ": GeneratorStub(std::move(that))\n";
+    for (auto *sp : schedule_params) {
+        stream << indent() << ", " << sp->name() << "(std::move(that." << sp->name() << "))\n";
+    }
     for (const auto &out : out_info) {
         stream << indent() << ", " << out.name << "(std::move(that." << out.name << "))\n";
     }
@@ -673,12 +734,22 @@ void StubEmitter::emit() {
     stream << indent() << class_name << "& operator=("<< class_name << "&& that) {\n";
     indent_level++;
     stream << indent() << "GeneratorStub::operator=(std::move(that));\n";
+    for (auto *sp : schedule_params) {
+        stream << indent() << sp->name() << " = std::move(that." << sp->name() << ");\n";
+    }
     for (const auto &out : out_info) {
         stream << indent() << out.name << " = std::move(that." << out.name << ");\n";
     }
     stream << indent() << "return *this;\n";
     indent_level--;
     stream << indent() << "}\n";
+    stream << "\n";
+
+    stream << indent() << "// ScheduleParams(s)\n";
+    for (auto *sp : schedule_params) {
+        std::string c_type = sp->is_looplevel_param() ? "LoopLevel" : halide_type_to_c_type(sp->scalar_type());
+        stream << indent() << "ScheduleParam<" << c_type << "> " << sp->name() << ";\n";
+    }
     stream << "\n";
 
     stream << indent() << "// Output(s)\n";
@@ -720,7 +791,7 @@ GeneratorStub::GeneratorStub(const GeneratorContext &context,
                              const GeneratorParamsMap &generator_params,
                              const std::vector<std::vector<Internal::StubInput>> &inputs)
     : generator(generator_factory(context)) {
-    generator->set_generator_param_values(generator_params);
+    generator->set_generator_and_schedule_param_values(generator_params);
     generator->set_inputs_vector(inputs);
     generator->call_generate();
 }
@@ -961,7 +1032,7 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
                     sub_generator_args.erase("target");
                     // Must re-create each time since each instance will have a different Target.
                     auto gen = GeneratorRegistry::create(generator_name, GeneratorContext(target));
-                    gen->set_generator_param_values(sub_generator_args);
+                    gen->set_generator_and_schedule_param_values(sub_generator_args);
                     return gen->build_module(name);
                 };
             if (targets.size() > 1 || !emit_options.substitutions.empty()) {
@@ -1158,6 +1229,19 @@ GeneratorBase::ParamInfo::ParamInfo(GeneratorBase *generator, const size_t size)
     for (auto &g : owned_synthetic_params) {
         g->generator = generator;
     }
+
+    std::vector<void *> vs = ObjectInstanceRegistry::instances_in_range(
+        generator, size, ObjectInstanceRegistry::ScheduleParam);
+    for (auto v : vs) {
+        auto *param = static_cast<ScheduleParamBase*>(v);
+        internal_assert(param != nullptr);
+        user_assert(!param->name().empty()) << "ScheduleParams must have explicit names when used in Generators.";
+        user_assert(is_valid_name(param->name())) << "Invalid ScheduleParam name: " << param->name();
+        user_assert(!names.count(param->name())) << "Duplicate ScheduleParam name: " << param->name();
+        names.insert(param->name());
+        schedule_params.push_back(param);
+        schedule_params_by_name[param->name()] = param;
+    }
 }
 
 GeneratorBase::ParamInfo &GeneratorBase::param_info() {
@@ -1214,7 +1298,7 @@ Internal::GeneratorParamBase &GeneratorBase::find_generator_param_by_name(const 
     return *it->second;
 }
 
-void GeneratorBase::set_generator_param_values(const GeneratorParamsMap &params) {
+void GeneratorBase::set_generator_and_schedule_param_values(const GeneratorParamsMap &params) {
     ParamInfo &pi = param_info();
     for (auto &key_value : params) {
         auto gp = pi.generator_params_by_name.find(key_value.first);
@@ -1230,8 +1314,29 @@ void GeneratorBase::set_generator_param_values(const GeneratorParamsMap &params)
             }
             continue;
         }
-        user_error << "Generator has no GeneratorParam named: " << key_value.first << "\n";
+        auto sp = pi.schedule_params_by_name.find(key_value.first);
+        if (sp != pi.schedule_params_by_name.end()) {
+            if (sp->second->is_looplevel_param()) {
+                if (!key_value.second.string_value.empty()) {
+                    sp->second->set_from_string(key_value.second.string_value);
+                } else {
+                    sp->second->set(key_value.second.loop_level);
+                }
+            } else {
+                sp->second->set_from_string(key_value.second.string_value);
+            }
+            continue;
+        }
+        user_error << "Generator has no GeneratorParam or ScheduleParam named: " << key_value.first << "\n";
     }
+}
+
+Internal::ScheduleParamBase &GeneratorBase::find_schedule_param_by_name(const std::string &name) {
+    ParamInfo &pi = param_info();
+    auto it = pi.schedule_params_by_name.find(name);
+    user_assert(it != pi.schedule_params_by_name.end()) << "Generator has no ScheduleParam named: " << name << "\n";
+    internal_assert(it->second != nullptr);
+    return *it->second;
 }
 
 void GeneratorBase::set_generator_names(const std::string &registered_name, const std::string &stub_name) {
@@ -1448,7 +1553,7 @@ void GeneratorBase::emit_cpp_stub(const std::string &stub_file_path) {
     advance_phase(ScheduleCalled);
     ParamInfo &pi = param_info();
     std::ofstream file(stub_file_path);
-    StubEmitter emit(file, generator_registered_name, generator_stub_name, pi.generator_params, pi.filter_inputs, pi.filter_outputs);
+    StubEmitter emit(file, generator_registered_name, generator_stub_name, pi.generator_params, pi.schedule_params, pi.filter_inputs, pi.filter_outputs);
     emit.emit();
 }
 
@@ -1789,6 +1894,10 @@ void generator_test() {
             GeneratorParam<float> gp1{"gp1", 1.f};
             GeneratorParam<uint64_t> gp2{"gp2", 2};
 
+            ScheduleParam<int> sp0{"sp0", 100};
+            ScheduleParam<float> sp1{"sp1", 101.f};
+            ScheduleParam<uint64_t> sp2{"sp2", 102};
+
             Input<int> input{"input"};
             Output<Func> output{"output", Int(32), 1};
 
@@ -1800,7 +1909,9 @@ void generator_test() {
                 output(x) = input + gp0;
             }
             void schedule() {
-                // empty
+                // internal_assert(sp0 == 200);
+                // internal_assert(sp1 == 201.f);
+                // internal_assert(sp2 == (uint64_t) 202);
             }
         };
 
@@ -1808,8 +1919,9 @@ void generator_test() {
         tester.init_from_context(context);
         internal_assert(tester.phase == GeneratorBase::Created);
 
-        // Verify that calling GeneratorParam::set() works.
+        // Verify that calling GeneratorParam::set() and ScheduleParam::set() works.
         tester.gp0.set(1);
+        tester.sp0.set(200);
 
         tester.set_inputs_vector({{StubInput(42)}});
         internal_assert(tester.phase == GeneratorBase::InputsSet);
@@ -1818,12 +1930,14 @@ void generator_test() {
 
         // Also ok to call in this phase.
         tester.gp1.set(2.f);
+        tester.sp1.set(201.f);
 
         tester.call_generate();
         internal_assert(tester.phase == GeneratorBase::GenerateCalled);
 
         // tester.set_inputs_vector({{StubInput(44)}});  // This will assert-fail.
         // tester.gp2.set(2);  // This will assert-fail.
+        tester.sp2.set(202);  // OK to set ScheduleParams after generate(), but not after schedule()
 
         tester.call_schedule();
         internal_assert(tester.phase == GeneratorBase::ScheduleCalled);
@@ -1831,6 +1945,55 @@ void generator_test() {
         // tester.set_inputs_vector({{StubInput(45)}});  // This will assert-fail.
         // tester.gp2.set(2);  // This will assert-fail.
         // tester.sp2.set(202);  // This will assert-fail.
+    }
+
+    // Verify that set_schedule_param<T>
+    // works properly, even if the specific subtype of Generator is not known.
+    {
+        class Tester : public Generator<Tester> {
+        public:
+            GeneratorParam<int> gp0{"gp0", 0};
+            GeneratorParam<float> gp1{"gp1", 1.f};
+            GeneratorParam<uint64_t> gp2{"gp2", 2};
+
+            ScheduleParam<int> sp0{"sp0", 100};
+            ScheduleParam<float> sp1{"sp1", 101.f};
+            ScheduleParam<uint64_t> sp2{"sp2", 102};
+
+            Input<int> input{"input"};
+            Output<Func> output{"output", Int(32), 1};
+
+            void generate() {
+                internal_assert(gp0 == 0);
+                internal_assert(gp1 == 1.f);
+                internal_assert(gp2 == (uint64_t) 2);
+                Var x;
+                output(x) = input + gp0;
+            }
+            void schedule() {
+                // internal_assert(sp0 == 200);
+                // internal_assert(sp1 == 201.f);
+                // internal_assert(sp2 == (uint64_t) 202);
+            }
+        };
+
+        Tester tester_instance;
+        tester_instance.init_from_context(context);
+        // Use a base-typed reference to verify the code below doesn't know about subtype
+        GeneratorBase &tester = tester_instance;
+
+        // Verify that calling GeneratorParam::set() and ScheduleParam::set() works.
+        tester.set_schedule_param("sp0", 200);
+
+        tester.set_inputs_vector({{StubInput(42)}});
+
+        tester.set_schedule_param("sp1", 201.f);
+
+        tester.call_generate();
+
+        tester.set_schedule_param("sp2", 202);
+
+        tester.call_schedule();
     }
 
     // Verify that the Generator's internal phase actually prevents unsupported
@@ -1842,12 +2005,19 @@ void generator_test() {
             GeneratorParam<float> gp1{"gp1", 1.f};
             GeneratorParam<uint64_t> gp2{"gp2", 2};
 
+            ScheduleParam<int> sp0{"sp0", 100};
+            ScheduleParam<float> sp1{"sp1", 101.f};
+            ScheduleParam<uint64_t> sp2{"sp2", 102};
+
             Input<int> input{"input"};
 
             Func build() {
                 internal_assert(gp0 == 1);
                 internal_assert(gp1 == 2.f);
                 internal_assert(gp2 == (uint64_t) 2);  // unchanged
+                // internal_assert(sp0 == 200);
+                // internal_assert(sp1 == 201.f);
+                // internal_assert(sp2 == (uint64_t) 102);
                 Var x;
                 Func output;
                 output(x) = input + gp0;
@@ -1859,8 +2029,9 @@ void generator_test() {
         tester.init_from_context(context);
         internal_assert(tester.phase == GeneratorBase::Created);
 
-        // Verify that calling GeneratorParam::set() works.
+        // Verify that calling GeneratorParam::set() and ScheduleParam::set() works.
         tester.gp0.set(1);
+        tester.sp0.set(200);
 
         // set_inputs_vector() can't be called on an old-style Generator;
         // that's OK, since we can skip from Created -> GenerateCalled anyway
@@ -1871,6 +2042,7 @@ void generator_test() {
 
         // Also ok to call in this phase.
         tester.gp1.set(2.f);
+        tester.sp1.set(201.f);
 
         tester.build_pipeline();
         internal_assert(tester.phase == GeneratorBase::ScheduleCalled);

--- a/src/InferArguments.cpp
+++ b/src/InferArguments.cpp
@@ -85,6 +85,7 @@ private:
 
     void include_parameter(Parameter p) {
         if (!p.defined()) return;
+        if (p.is_bound_before_lowering()) return;
         if (already_have(p.name())) return;
 
         Expr def, min, max;

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -99,6 +99,10 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
     for (auto &iter : env) {
         iter.second.lock_loop_levels();
     }
+    // Ensure that all ScheduleParams become well-defined constant Exprs.
+    for (auto &f : env) {
+        f.second.substitute_schedule_param_exprs();
+    }
 
     // Substitute in wrapper Funcs
     env = wrap_func_calls(env);

--- a/src/ObjectInstanceRegistry.h
+++ b/src/ObjectInstanceRegistry.h
@@ -27,7 +27,8 @@ public:
         GeneratorParam,
         GeneratorInput,
         GeneratorOutput,
-        FilterParam
+        FilterParam,
+        ScheduleParam
     };
 
     /** Add an instance to the registry. The size may be 0 for Param Kinds,

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -27,9 +27,11 @@ struct ParameterContents {
     const bool is_buffer;
     const bool is_explicit_name;
     const bool is_registered;
-    ParameterContents(Type t, bool b, int d, const std::string &n, bool e, bool r)
+    const bool is_bound_before_lowering;
+    ParameterContents(Type t, bool b, int d, const std::string &n, bool e, bool r, bool is_bound_before_lowering)
         : type(t), dimensions(d), name(n), buffer(Buffer<>()), data(0),
-          host_alignment(t.bytes()), is_buffer(b), is_explicit_name(e), is_registered(r) {
+          host_alignment(t.bytes()), is_buffer(b), is_explicit_name(e), is_registered(r),
+          is_bound_before_lowering(is_bound_before_lowering) {
 
         min_constraint.resize(dimensions);
         extent_constraint.resize(dimensions);
@@ -76,7 +78,7 @@ Parameter::Parameter() : contents(nullptr) {
 }
 
 Parameter::Parameter(Type t, bool is_buffer, int d) :
-    contents(new ParameterContents(t, is_buffer, d, unique_name('p'), false, true)) {
+    contents(new ParameterContents(t, is_buffer, d, unique_name('p'), false, true, false)) {
     internal_assert(is_buffer || d == 0) << "Scalar parameters should be zero-dimensional";
     // Note that is_registered is always true here; this is just using a parallel code structure for clarity.
     if (contents.defined() && contents->is_registered) {
@@ -84,8 +86,8 @@ Parameter::Parameter(Type t, bool is_buffer, int d) :
     }
 }
 
-Parameter::Parameter(Type t, bool is_buffer, int d, const std::string &name, bool is_explicit_name, bool register_instance) :
-    contents(new ParameterContents(t, is_buffer, d, name, is_explicit_name, register_instance)) {
+Parameter::Parameter(Type t, bool is_buffer, int d, const std::string &name, bool is_explicit_name, bool register_instance, bool is_bound_before_lowering) :
+    contents(new ParameterContents(t, is_buffer, d, name, is_explicit_name, register_instance, is_bound_before_lowering)) {
     internal_assert(is_buffer || d == 0) << "Scalar parameters should be zero-dimensional";
     if (contents.defined() && contents->is_registered) {
         ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::FilterParam, this, nullptr);
@@ -145,6 +147,11 @@ bool Parameter::is_explicit_name() const {
 bool Parameter::is_buffer() const {
     check_defined();
     return contents->is_buffer;
+}
+
+bool Parameter::is_bound_before_lowering() const {
+    check_defined();
+    return contents->is_bound_before_lowering;
 }
 
 Expr Parameter::scalar_expr() const {

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -48,7 +48,7 @@ public:
      * ObjectInstanceRegistry. */
     EXPORT Parameter(Type t, bool is_buffer, int dimensions,
                      const std::string &name, bool is_explicit_name = false,
-                     bool register_instance = true);
+                     bool register_instance = true, bool is_bound_before_lowering = false);
 
     /** Copy ctor, operator=, and dtor, needed for ObjectRegistry accounting. */
     EXPORT Parameter(const Parameter&);
@@ -66,6 +66,11 @@ public:
 
     /** Return true iff the name was explicitly specified */
     EXPORT bool is_explicit_name() const;
+
+    /** Return true iff this Parameter is expected to be replaced with a
+     * constant at the start of lowering, and thus should not be used to
+     * infer arguments */
+    EXPORT bool is_bound_before_lowering() const;
 
     /** Does this parameter refer to a buffer/image? */
     EXPORT bool is_buffer() const;

--- a/src/PrintLoopNest.cpp
+++ b/src/PrintLoopNest.cpp
@@ -174,6 +174,11 @@ string print_loop_nest(const vector<Function> &output_funcs) {
         iter.second.lock_loop_levels();
     }
 
+    // Ensure that all ScheduleParams become well-defined constant Exprs.
+    for (auto &f : env) {
+        f.second.substitute_schedule_param_exprs();
+    }
+
     // Substitute in wrapper Funcs
     env = wrap_func_calls(env);
 

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -14,12 +14,14 @@
 namespace Halide {
 
 class Func;
+template <typename T> class ScheduleParam;
 struct VarOrRVar;
 
 namespace Internal {
 class Function;
 struct FunctionContents;
 struct LoopLevelContents;
+class ScheduleParamBase;
 }  // namespace Internal
 
 /** Different ways to handle a tail case in a split when the
@@ -136,6 +138,9 @@ enum class PrefetchBoundStrategy {
  \endcode
  */
 class LoopLevel {
+    template <typename T> friend class ScheduleParam;
+    friend class ::Halide::Internal::ScheduleParamBase;
+
     Internal::IntrusivePtr<Internal::LoopLevelContents> contents;
 
     explicit LoopLevel(Internal::IntrusivePtr<Internal::LoopLevelContents> c) : contents(c) {}

--- a/src/ScheduleParam.cpp
+++ b/src/ScheduleParam.cpp
@@ -1,0 +1,47 @@
+#include "ScheduleParam.h"
+#include "ObjectInstanceRegistry.h"
+
+namespace Halide {
+namespace Internal {
+
+ScheduleParamBase::ScheduleParamBase(const Type &t, const std::string &name, bool is_explicit_name)
+    : sp_name(name),
+      type(t),
+      scalar_parameter(t, /*is_buffer*/ false, 0, is_explicit_name ? name + ".schedule_param_param" : "",
+          is_explicit_name, /*register_instance*/ false, /*is_bound_before_lowering*/ true),
+      scalar_expr(Variable::make(t, scalar_parameter.name() + ".schedule_param_var", scalar_parameter)),
+      loop_level() {
+    ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::ScheduleParam, this, nullptr);
+}
+
+// Just the default copy ctor, except we must call register_instance to avoid unpleasantries later
+ScheduleParamBase::ScheduleParamBase(const ScheduleParamBase &that)
+    : sp_name(that.sp_name),
+      type(that.type),
+      scalar_parameter(that.scalar_parameter),
+      scalar_expr(that.scalar_expr),
+      loop_level(that.loop_level) {
+    ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::ScheduleParam, this, nullptr);
+}
+
+ScheduleParamBase &ScheduleParamBase::operator=(const ScheduleParamBase &that) {
+    if (this != &that) {
+        // You can only assign SP's of the same type.
+        internal_assert(type == that.type);
+        // You can only assign SP's of the same name.
+        internal_assert(sp_name == that.sp_name);
+        sp_name = that.sp_name;
+        type = that.type;
+        scalar_parameter = that.scalar_parameter;
+        scalar_expr = that.scalar_expr;
+        loop_level = that.loop_level;
+    }
+    return *this;
+}
+
+ScheduleParamBase::~ScheduleParamBase() {
+    ObjectInstanceRegistry::unregister_instance(this);
+}
+
+}
+}

--- a/src/ScheduleParam.h
+++ b/src/ScheduleParam.h
@@ -1,0 +1,240 @@
+#ifndef HALIDE_SCHEDULE_PARAM_H
+#define HALIDE_SCHEDULE_PARAM_H
+
+#include <type_traits>
+
+#include "IR.h"
+#include "ObjectInstanceRegistry.h"
+
+/** \file
+ *
+ * Classes for declaring scalar parameters to halide pipelines
+ */
+
+namespace Halide {
+
+namespace Internal {
+
+class GeneratorBase;
+
+class ScheduleParamBase {
+public:
+    const std::string &name() const {
+        return sp_name;
+    }
+
+    bool is_looplevel_param() const {
+        return type == Handle();
+    }
+
+    const Type &scalar_type() const {
+        internal_assert(!is_looplevel_param());
+        return type;
+    }
+
+    operator Expr() const {
+        user_assert(!is_looplevel_param()) << "Only scalar ScheduleParams can be converted to Expr.";
+        return scalar_expr;
+    }
+
+    operator LoopLevel() const {
+        user_assert(is_looplevel_param()) << "Only ScheduleParam<LoopLevel> can be converted to LoopLevel.";
+        return loop_level;
+    }
+
+    // overload the set() function to call the right virtual method based on type.
+    // This allows us to attempt to set a ScheduleParam via a
+    // plain C++ type, even if we don't know the specific templated
+    // subclass. Attempting to set the wrong type will assert.
+    //
+    // It's always a bit iffy to use macros for this, but IMHO it clarifies the situation here.
+#define HALIDE_SCHEDULE_PARAM_TYPED_SETTER(TYPE) \
+    virtual void set(const TYPE &new_value) = 0;
+
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(bool)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(int8_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(int16_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(int32_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(int64_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(uint8_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(uint16_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(uint32_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(uint64_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(float)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(double)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(LoopLevel)
+
+#undef HALIDE_SCHEDULE_PARAM_TYPED_SETTER
+
+protected:
+    friend class GeneratorBase;
+
+    std::string sp_name;
+    Type type;
+    Internal::Parameter scalar_parameter;
+    Expr scalar_expr;
+    LoopLevel loop_level;
+
+    EXPORT ScheduleParamBase(const Type &t, const std::string &name, bool is_explicit_name);
+    EXPORT virtual ~ScheduleParamBase();
+
+    // This is provided only for GeneratorBase; other code should not need to use it.
+    virtual void set_from_string(const std::string &new_value_string) = 0;
+
+    EXPORT explicit ScheduleParamBase(const ScheduleParamBase &);
+    EXPORT ScheduleParamBase &operator=(const ScheduleParamBase &);
+};
+
+}  // namespace Internal
+
+// This is strictly some syntactic sugar to suppress certain compiler warnings.
+template<typename FROM, typename TO>
+struct Convert {
+    template <typename TO2 = TO, typename std::enable_if<!std::is_same<TO2, bool>::value>::type * = nullptr>
+    inline static TO2 value(const FROM &from) { return static_cast<TO2>(from); }
+
+    template <typename TO2 = TO, typename std::enable_if<std::is_same<TO2, bool>::value>::type * = nullptr>
+    inline static TO2 value(const FROM &from) { return from != 0; }
+};
+
+/** A ScheduleParam is a "Param" that can contain a scalar Expr or a LoopLevel;
+ * unlike Param<>, its value cannot be set at runtime. All ScheduleParam values
+ * are finalized just before lowering, and must translate into a constant scalar
+ * value (or a well-defined LoopLevel) at that point. The value of
+ * should be bound to an actual value of type T using the set method
+ * before you realize the function uses this. If you're statically
+ * compiling, this param should *not* appear in the argument list.
+ */
+template <typename T>
+class ScheduleParam : public Internal::ScheduleParamBase {
+    using ScheduleParamBase = Internal::ScheduleParamBase;
+
+    template <typename T2 = T,
+              typename std::enable_if<std::is_arithmetic<T2>::value>::type * = nullptr>
+    static Type get_param_type() {
+        return type_of<T>();
+    }
+
+    template <typename T2 = T,
+              typename std::enable_if<!std::is_arithmetic<T2>::value>::type * = nullptr>
+    static Type get_param_type() {
+        return Handle();
+    }
+
+    template <typename T2, typename std::enable_if<std::is_arithmetic<T>::value &&
+                                                   std::is_convertible<T2, T>::value>::type * = nullptr>
+    HALIDE_ALWAYS_INLINE void typed_setter_impl(const T2 &value, const char *type) {
+        // Arithmetic types must roundtrip losslessly.
+        if (!std::is_same<T, T2>::value &&
+            std::is_arithmetic<T>::value &&
+            std::is_arithmetic<T2>::value) {
+            const T t = Convert<T2, T>::value(value);
+            const T2 t2 = Convert<T, T2>::value(t);
+            if (t2 != value) {
+                user_error << "The ScheduleParam " << name() << " cannot be set with a value of type " << type << ".\n";
+            }
+        }
+        scalar_parameter.set_scalar<T>(Convert<T2, T>::value(value));
+    }
+
+    template <typename T2, typename std::enable_if<std::is_same<T2, LoopLevel>::value>::type * = nullptr>
+    HALIDE_ALWAYS_INLINE void typed_setter_impl(const LoopLevel &value, const char *msg) {
+        user_assert(is_looplevel_param()) << "Only ScheduleParam<LoopLevel> can be set withLoopLevel.";
+        loop_level.set(value);
+    }
+
+    template <typename T2, typename std::enable_if<!std::is_convertible<T2, T>::value>::type * = nullptr>
+    HALIDE_ALWAYS_INLINE void typed_setter_impl(const T2 &value, const char *type) {
+        user_error << "The ScheduleParam " << name() << " cannot be set with a value of type " << type << ".\n";
+    }
+
+    template <typename T2 = T,
+              typename std::enable_if<std::is_same<T2, LoopLevel>::value>::type * = nullptr>
+    NO_INLINE void set_from_string_impl(const std::string &new_value_string) {
+        if (new_value_string == "root") {
+            set(LoopLevel::root());
+        } else if (new_value_string == "inline") {
+            set(LoopLevel::inlined());
+        } else {
+            user_error << "Unable to parse " << name() << ": " << new_value_string;
+        }
+    }
+
+    template <typename T2 = T,
+              typename std::enable_if<std::is_same<T2, bool>::value>::type * = nullptr>
+    NO_INLINE void set_from_string_impl(const std::string &new_value_string) {
+        if (new_value_string == "true") {
+            set(true);
+        } else if (new_value_string == "false") {
+            set(false);
+        } else {
+            user_error << "Unable to parse " << name() << ": " << new_value_string;
+        }
+    }
+
+    template <typename T2 = T,
+              typename std::enable_if<std::is_arithmetic<T2>::value && !std::is_same<T2, bool>::value>::type * = nullptr>
+    NO_INLINE void set_from_string_impl(const std::string &new_value_string) {
+        std::istringstream iss(new_value_string);
+        T t;
+        iss >> t;
+        user_assert(!iss.fail() && iss.get() == EOF) << "Unable to parse " << name() << ": " << new_value_string;
+        set(t);
+    }
+
+protected:
+    void set_from_string(const std::string &new_value_string) override {
+        set_from_string_impl(new_value_string);
+    }
+
+public:
+    ScheduleParam() : ScheduleParamBase(get_param_type(), "", false) {}
+
+    explicit ScheduleParam(const std::string &name) : ScheduleParamBase(get_param_type(), name, true) {}
+
+    ScheduleParam(const std::string &name, const T &value) : ScheduleParamBase(get_param_type(), name, true) {
+        set(value);
+    }
+
+    // TODO hide?
+    explicit ScheduleParam(const ScheduleParamBase &that) : ScheduleParamBase(that) {}
+
+#define HALIDE_SCHEDULE_PARAM_TYPED_SETTER(TYPE) \
+    void set(const TYPE &new_value) override { typed_setter_impl<TYPE>(new_value, #TYPE); }
+
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(bool)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(int8_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(int16_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(int32_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(int64_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(uint8_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(uint16_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(uint32_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(uint64_t)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(float)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(double)
+    HALIDE_SCHEDULE_PARAM_TYPED_SETTER(LoopLevel)
+
+#undef HALIDE_SCHEDULE_PARAM_TYPED_SETTER
+
+    // Note that we deliberately do not provide a way to retrieve the non-Expr value
+    // of ScheduleParam: this is because the value is probably inaccurate at the point
+    // you'd be tempted to examine it, since it won't be finalized until the start of lowering.
+    // Here's the code that we'd use to do so, if we find we need to:
+
+    // template <typename T2 = T,
+    //           typename std::enable_if<std::is_arithmetic<T2>::value>::type * = nullptr>
+    // operator T() const {
+    //     return scalar_parameter.get_scalar<T>();
+    // }
+
+    // template <typename T2 = T,
+    //           typename std::enable_if<std::is_same<T2, LoopLevel>::value>::type * = nullptr>
+    // operator T() const {
+    //     return loop_level;
+    // }
+};
+
+}  // namespace Halide
+
+#endif

--- a/src/Var.cpp
+++ b/src/Var.cpp
@@ -18,4 +18,16 @@ bool Var::is_implicit(const std::string &name) {
         name.find_first_not_of("0123456789", 1) == std::string::npos;
 }
 
+namespace Internal {
+
+std::vector<Var> make_argument_list(int dimensionality) {
+    std::vector<Var> args(dimensionality);
+    for (int i = 0; i < dimensionality; i++) {
+        args[i] = Var::implicit(i);
+    }
+    return args;
+}
+
+}
+
 }

--- a/src/Var.h
+++ b/src/Var.h
@@ -176,6 +176,14 @@ EXPORT extern Var _;
 EXPORT extern Var _0, _1, _2, _3, _4, _5, _6, _7, _8, _9;
 // @}
 
+namespace Internal {
+
+/** Make a list of unique arguments for definitions with unnamed
+    arguments. */
+EXPORT std::vector<Var> make_argument_list(int dimensionality);
+
+}
+
 }
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -113,7 +113,7 @@ if (WITH_TEST_GENERATORS)
     endif()
 
     add_test("${TARGET}"
-             GROUPS test_generator run_tests)
+             GROUPS test_generators run_tests)
   endfunction(halide_define_aot_test)
 
   # Find all the files of form "foo_generator.cpp" in test/generator
@@ -294,6 +294,9 @@ if (WITH_TEST_GENERATORS)
   # stubtest has input and output funcs with undefined types; this is fine for stub
   # usage (the types can be inferred), but for AOT compilation, we must make the types
   # concrete via generator args.
+  #
+  # Also note that setting 'vectorize=true' is redundant (that's the default), but verifies
+  # that setting ScheduleParam via generator_args works properly.
   set(STUBTEST_GENERATOR_ARGS
       untyped_buffer_input.type=uint8 untyped_buffer_input.dim=3
       simple_input.type=float32

--- a/test/correctness/deferred_loop_level.cpp
+++ b/test/correctness/deferred_loop_level.cpp
@@ -3,9 +3,9 @@
 using namespace Halide;
 using namespace Halide::Internal;
 
-class CheckLoopLevels : public IRVisitor {
+class CheckScheduleParams : public IRVisitor {
 public:
-    CheckLoopLevels(const std::string &inner_loop_level,
+    CheckScheduleParams(const std::string &inner_loop_level,
                         const std::string &outer_loop_level) :
         inner_loop_level(inner_loop_level), outer_loop_level(outer_loop_level) {}
 
@@ -69,7 +69,7 @@ struct Test {
         Buffer<float> result = outer.realize(1, 1, 1);
 
         Module m = outer.compile_to_module({outer.infer_arguments()});
-        CheckLoopLevels c(inner_loop_level, outer_loop_level);
+        CheckScheduleParams c(inner_loop_level, outer_loop_level);
         m.functions().front().body.accept(&c);
     }
 };

--- a/test/correctness/extern_producer.cpp
+++ b/test/correctness/extern_producer.cpp
@@ -100,9 +100,9 @@ int main(int argc, char **argv) {
         Func source;
         source.define_extern("make_data",
                              std::vector<ExternFuncArgument>(),
-                             Float(32), 2);
+                             Float(32), {x, y});
         // Row stride should be 128B/32-element aligned.
-        source.align_storage(_0, 32);
+        source.align_storage(x, 32);
         Func sink;
         sink(x, y) = source(x, y) - sin(x + y);
 
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
         types.push_back(Float(32));
         multi.define_extern("make_data_multi",
                             std::vector<ExternFuncArgument>(),
-                            types, 2);
+                            types, {x, y});
         Func sink_multi;
         sink_multi(x, y) = multi(x, y)[0] - sin(x + y) +
                 multi(x, y)[1] - cos(x + y);

--- a/test/correctness/extern_reorder_storage.cpp
+++ b/test/correctness/extern_reorder_storage.cpp
@@ -1,0 +1,60 @@
+#include "Halide.h"
+#include <stdio.h>
+
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+// An extern stage that translates.
+extern "C" DLLEXPORT int copy_and_check_strides(halide_buffer_t *in, halide_buffer_t *out) {
+    if (in->is_bounds_query()) {
+        for (int i = 0; i < 2; i++) {
+	    in->dim[i].min = out->dim[i].min;
+	    in->dim[i].extent = out->dim[i].extent;
+	}
+    } else if (!out->is_bounds_query()) {
+        // Check that the storage has been reordered.
+        assert(out->dim[0].stride > out->dim[1].stride);
+        Halide::Runtime::Buffer<uint8_t> out_buf(*out);
+        out_buf.copy_from(Halide::Runtime::Buffer<uint8_t>(*in));
+    }
+
+    return 0;
+}
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Var x, y;
+
+    const int W = 30, H = 20;
+    Buffer<uint8_t> input_buffer(W, H);
+    for (int i = 0; i < H; i++) {
+        for (int j = 0; j < W; j++) {
+            input_buffer(j, i) = i + j;
+        }
+    }
+
+    // Define a pipeline that uses an input image in an extern stage
+    // only and do bounds queries.
+    ImageParam input(UInt(8), 2);
+    Func f, g;
+
+    f.define_extern("copy_and_check_strides", {input}, UInt(8), {x, y});
+    g(x, y) = f(x, y);
+
+    f.compute_root().reorder_storage(y, x);
+    
+    input.set(input_buffer);
+    Buffer<uint8_t> output = g.realize(W, H);
+    for (int i = 0; i < H; i++) {
+        for (int j = 0; j < W; j++) {
+            assert(output(j, i) == i + j);
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/inlined_generator.cpp
+++ b/test/correctness/inlined_generator.cpp
@@ -17,7 +17,8 @@ public:
     enum class SomeEnum { Foo, Bar };
 
     GeneratorParam<float> compiletime_factor{ "compiletime_factor", 1, 0, 100 };
-    GeneratorParam<bool> vectorize{ "vectorize", true };
+
+    ScheduleParam<bool> vectorize{ "vectorize", true };
 
     Input<float> runtime_factor{ "runtime_factor", 1.0 };
     Input<int> runtime_offset{ "runtime_offset", 0 };
@@ -52,6 +53,9 @@ int main(int argc, char **argv) {
         // GeneratorContext.apply<GenType>() with values for all Inputs.
         // (Note that this uses the default values for all GeneratorParams.)
         auto gen = context.apply<Example>(kRuntimeFactor, kRuntimeOffset);  // gen's type is std::unique_ptr<Example>
+        // Remember: ScheduleParams can be set at any time before lowering,
+        // so it's fine to set them here.
+        gen->vectorize.set(false);
 
         Buffer<int32_t> img = gen->realize(kSize, kSize, 3);
         verify(img, gen->compiletime_factor, kRuntimeFactor, kRuntimeOffset);
@@ -66,6 +70,8 @@ int main(int argc, char **argv) {
         // GeneratorParams must be set before calling apply()
         // (you'll assert-fail if you set them later).
         gen->compiletime_factor.set(2.5f);
+        // ScheduleParams can be set before or after the call to apply().
+        gen->vectorize.set(false);
 
         gen->apply(kRuntimeFactor, kRuntimeOffset);
 

--- a/test/correctness/schedule_param.cpp
+++ b/test/correctness/schedule_param.cpp
@@ -1,0 +1,100 @@
+#include <stdio.h>
+#include "Halide.h"
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+// Deliberately odd number
+constexpr int kExpectedVectorWidth = 17;
+
+class CheckScheduleParams : public IRVisitor {
+private:
+    using IRVisitor::visit;
+
+    std::string inside_for_loop;
+
+    void visit(const Ramp *op) {
+        IRVisitor::visit(op);
+        assert(is_const(op->lanes, kExpectedVectorWidth));
+    }
+
+    void visit(const For *op) {
+        if (op->name == "f.s0.x.x") {
+            assert(op->for_type == ForType::Serial);
+            assert(inside_for_loop == "g.s0.y");
+        } else if (op->name == "f.s0.y") {
+            assert(op->for_type == ForType::Serial);
+            assert(inside_for_loop == "g.s0.y");
+        } else if (op->name == "g.s0.x") {
+            assert(op->for_type == ForType::Serial);
+            assert(inside_for_loop == "g.s0.y");
+        } else if (op->name == "g.s0.y") {
+            assert(op->for_type == ForType::Parallel);
+            assert(inside_for_loop == "");
+        } else {
+            assert(0);
+        }
+
+        std::string old_for_loop = inside_for_loop;
+        inside_for_loop = op->name;
+        IRVisitor::visit(op);
+        inside_for_loop = old_for_loop;
+    }
+
+    void visit(const Store *op) {
+        IRVisitor::visit(op);
+        if (op->name == "f") {
+            assert(inside_for_loop == "f.s0.x.x");
+        } else if (op->name == "g") {
+            assert(inside_for_loop == "g.s0.x");
+        } else {
+            assert(0);
+        }
+    }
+};
+
+int main(int argc, char **argv) {
+
+    ScheduleParam<LoopLevel> compute_at;
+    ScheduleParam<int> vector_width;
+
+    compute_at.set(LoopLevel::root());  // this value will not be used
+    vector_width.set(kExpectedVectorWidth - 1);  // this value will not be used
+
+    Var x("x"), y("y"), yi("yi");
+    Func f("f"), g("g");
+
+    f(x, y) = x + y;
+    g(x, y) = f(x, y);
+
+    f.compute_at(compute_at).vectorize(x, vector_width);
+    g.parallel(y);
+
+    // We can set the ScheduleParam values any time before lowering.
+
+    // Copied ScheduleParams should still refer to the same underlying reference,
+    // so setting the copy should be equivalent to setting the original.
+    ScheduleParam<LoopLevel> compute_at_alias(compute_at);  // testing copy ctor
+    ScheduleParam<int> vector_width_alias(vector_width);
+
+    compute_at_alias.set(LoopLevel::inlined());  // this value will not be used
+    vector_width_alias.set(kExpectedVectorWidth + 1);  // this value will not be used
+
+    ScheduleParam<LoopLevel> compute_at_alias2;
+    ScheduleParam<int> vector_width_alias2;
+    compute_at_alias2 = compute_at_alias;  // testing operator=
+    vector_width_alias2 = vector_width_alias;
+
+    // Should be equivalent to setting the original values
+    compute_at_alias2.set(LoopLevel(g, y));
+    vector_width_alias2.set(kExpectedVectorWidth);
+
+    // Lower it and inspect the IR to verify that the values we set
+    // for vector width and for compute/store_at were used.
+    Module m = g.compile_to_module({g.infer_arguments()});
+    CheckScheduleParams c;
+    m.functions().front().body.accept(&c);
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/generator/example_generator.cpp
+++ b/test/generator/example_generator.cpp
@@ -17,15 +17,16 @@ enum SomeEnum { Foo, Bar };
 // Note the inheritance using the Curiously Recurring Template Pattern
 class Example : public Halide::Generator<Example> {
 public:
-    // GeneratorParamss, Inputs, and Outputs are (by convention)
+    // GeneratorParams, ScheduleParams, Inputs, and Outputs are (by convention)
     // always public and always declared at the top of the Generator,
     // in the order
     //    GeneratorParam(s)
+    //    ScheduleParam(s)
     //    Input(s)
     //    Output(s)
     //
     // Note that the Inputs will appear in the C function
-    // call in the order they are declared. (GeneratorParams
+    // call in the order they are declared. (GeneratorParams and ScheduleParams
     // are always referenced by name, not position, so their order is irrelevant.)
     //
     // All Input variants declared as Generator members must have explicit
@@ -43,8 +44,8 @@ public:
                                      { { "foo", Foo },
                                        { "bar", Bar } } };
     // ...or bools: {default}
-    GeneratorParam<bool> vectorize{ "vectorize", true };
-    GeneratorParam<bool> parallelize{ "parallelize", true };
+    ScheduleParam<bool> vectorize{ "vectorize", true };
+    ScheduleParam<bool> parallelize{ "parallelize", true };
 
     // These are bad names that will produce errors at build time:
     // GeneratorParam<bool> badname{ " flag", true };
@@ -85,13 +86,16 @@ public:
         // here; this produces the width of the SIMD vector being targeted
         // divided by the width of the data type.
         const int v = natural_vector_size(output.type());
-        if (parallelize && vectorize) {
-            output.parallel(y).vectorize(x, v);
-        } else if (parallelize) {
-            output.parallel(y);
-        } else if (vectorize) {
-            output.vectorize(x, v);
-        }
+        output
+            .specialize(parallelize && vectorize)
+            .parallel(y)
+            .vectorize(x, v);
+        output
+            .specialize(parallelize)
+            .parallel(y);
+        output
+            .specialize(vectorize)
+            .vectorize(x, v);
     }
 
 private:

--- a/test/generator/stubtest_generator.cpp
+++ b/test/generator/stubtest_generator.cpp
@@ -25,7 +25,8 @@ public:
                                       BagType::Paper,
                                       { { "paper", BagType::Paper },
                                         { "plastic", BagType::Plastic } } };
-    GeneratorParam<bool> vectorize{ "vectorize", true };
+
+    ScheduleParam<bool> vectorize{ "vectorize", true };
     GeneratorParam<LoopLevel> intermediate_level{ "intermediate_level", LoopLevel::root() };
 
     Input<Buffer<uint8_t>> typed_buffer_input{ "typed_buffer_input", 3 };

--- a/test/generator/stubuser_generator.cpp
+++ b/test/generator/stubuser_generator.cpp
@@ -47,7 +47,6 @@ public:
         StubTest::GeneratorParams gp;
         gp.untyped_buffer_output_type = int32_buffer_output.type();
         gp.intermediate_level.set(LoopLevel(calculated_output, Var("y")));
-        gp.vectorize = true;
 
         // Stub outputs that are Output<Buffer> (rather than Output<Func>)
         // can really only be assigned to another Output<Buffer>; this is
@@ -60,6 +59,10 @@ public:
 
         const float kOffset = 2.f;
         calculated_output(x, y, c) = cast<uint8_t>(out.tuple_output(x, y, c)[1] + kOffset);
+
+        // Stub outputs also may contain ScheduleParams, which we may set as
+        // we see fit.
+        out.vectorize.set(true);
     }
 };
 


### PR DESCRIPTION
This PR makes it possible to name the dimensions of extern stages, which makes it easier to use storage scheduling directives on them.