### PR TITLE
Remove OpenGL test env-var dependency

### DIFF
--- a/test/opengl/rewrap_texture.cpp
+++ b/test/opengl/rewrap_texture.cpp
@@ -28,6 +28,7 @@ int main() {
 
     // This test must be run with an OpenGL target.
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
+    setenv("HL_JIT_TARGET", target.to_string().c_str(), true); // Buffer::device_wrap_native gets the target from environment
 
     const int width = 255;
     const int height = 10;


### PR DESCRIPTION
Earlier PR #1537 (merged) intended to obviate the need for the build/test harness to set environment variables in order to run the OpenGL and RenderScript tests.

However, for OpenGL, one test slipped through the cracks:  as discussed in  #2353, `Buffer::device_wrap_native` always gets the target from HL_JIT_TARGET, so despite #1537 the env-var needs to be set.   Without setting it, the test fails:

    Assertion failed: (device_interface), function device_wrap_native, file include/Halide.h, line 4962.

This PR has a simple one-line workaround:  it sets HL_JIT_TARGET from within the test before the calls to `device_wrap_native`:

```cpp
    setenv("HL_JIT_TARGET", target.to_string().c_str(), true); // Buffer::device_wrap_native gets the target from environment
```
  
That achieves the goal of #1537 (pending whatever solution may come out of #2353).
