### PR TITLE
Make Generator::schedule() optional

### DIFF
--- a/apps/HelloAndroidCamera2/jni/deinterleave_generator.cpp
+++ b/apps/HelloAndroidCamera2/jni/deinterleave_generator.cpp
@@ -4,8 +4,9 @@ namespace {
 
 class Deinterleave : public Halide::Generator<Deinterleave> {
 public:
-    Input<Buffer<uint8_t>> uvInterleaved{"uvInterleaved" , 2};
-    Output<Buffer<uint8_t>> result{"result", 2};
+    Input<Buffer<uint8_t>> uvInterleaved{"uvInterleaved", 2};
+    // There is no way to declare a Buffer<Tuple>, so we must use Output<Func> instead
+    Output<Func> result{"result", { UInt(8), UInt(8) }, 2};
 
     void generate() {
         Var x, y;

--- a/apps/HelloAndroidCamera2/jni/deinterleave_generator.cpp
+++ b/apps/HelloAndroidCamera2/jni/deinterleave_generator.cpp
@@ -5,11 +5,11 @@ namespace {
 class Deinterleave : public Halide::Generator<Deinterleave> {
 public:
     Input<Buffer<uint8_t>> uvInterleaved{"uvInterleaved" , 2};
+    Output<Buffer<uint8_t>> result{"result", 2};
 
-    Func build() {
+    void generate() {
         Var x, y;
 
-        Func result("result");
         result(x, y) = { uvInterleaved(2 * x, y), uvInterleaved(2 * x + 1, y) };
 
         // CPU schedule:
@@ -23,8 +23,6 @@ public:
         uvInterleaved.dim(0).set_stride(Expr());
         result.specialize(uvInterleaved.dim(0).stride() == 1);
         result.specialize(uvInterleaved.dim(0).stride() == -1);
-
-        return result;
     }
 };
 

--- a/apps/HelloAndroidCamera2/jni/edge_detect_generator.cpp
+++ b/apps/HelloAndroidCamera2/jni/edge_detect_generator.cpp
@@ -4,9 +4,10 @@ namespace {
 
 class EdgeDetect : public Halide::Generator<EdgeDetect> {
 public:
-    Input<Buffer<uint8_t>> input{"input" , 2};
+    Input<Buffer<uint8_t>>  input{"input" , 2};
+    Output<Buffer<uint8_t>> result{"result", 2};
 
-    Func build() {
+    void generate() {
         Var x, y;
 
         Func clamped = Halide::BoundaryConditions::repeat_edge(input);
@@ -26,7 +27,6 @@ public:
         grad_mag(x, y) = (gx(x, y) * gx(x, y) + gy(x, y) * gy(x, y));
 
         // Draw the result
-        Func result;
         result(x, y) = cast<uint8_t>(clamp(grad_mag(x, y), 0, 255));
 
         // CPU schedule:
@@ -41,8 +41,6 @@ public:
         input.dim(0).set_stride(Expr());
         result.specialize(input.dim(0).stride() == 1);
         result.specialize(input.dim(0).stride() == -1);
-
-        return result;
     }
 };
 

--- a/apps/bilateral_grid/bilateral_grid_generator.cpp
+++ b/apps/bilateral_grid/bilateral_grid_generator.cpp
@@ -10,7 +10,9 @@ public:
     Input<Buffer<float>>  input{"input", 2};
     Input<float>          r_sigma{"r_sigma"};
 
-    Func build() {
+    Output<Buffer<float>> bilateral_grid{"bilateral_grid", 2};
+
+    void generate() {
         Var x("x"), y("y"), z("z"), c("c");
 
         // Add a boundary condition
@@ -62,7 +64,6 @@ public:
                       lerp(blury(xi, yi+1, zi+1, c), blury(xi+1, yi+1, zi+1, c), xf), yf), zf);
 
         // Normalize
-        Func bilateral_grid("bilateral_grid");
         bilateral_grid(x, y) = interpolated(x, y, 0)/interpolated(x, y, 1);
 
         if (auto_schedule) {
@@ -114,8 +115,6 @@ public:
             blury.compute_root().reorder(c, x, y, z).parallel(z).vectorize(x, 8).unroll(c);
             bilateral_grid.compute_root().parallel(y).vectorize(x, 8);
         }
-
-        return bilateral_grid;
     }
 };
 

--- a/apps/blur/halide_blur_generator.cpp
+++ b/apps/blur/halide_blur_generator.cpp
@@ -29,10 +29,11 @@ public:
     GeneratorParam<int> tile_x{"tile_x", 32}; // X tile.
     GeneratorParam<int> tile_y{"tile_y", 8};  // Y tile.
 
-    Input<Buffer<uint16_t>> input{"input", 2};
+    Input<Buffer<uint16_t>>  input{"input", 2};
+    Output<Buffer<uint16_t>> blur_y{"blur_y", 2};
 
-    Func build() {
-        Func blur_x("blur_x"), blur_y("blur_y");
+    void generate() {
+        Func blur_x("blur_x");
         Var x("x"), y("y"), xi("xi"), yi("yi");
 
         // The algorithm
@@ -80,8 +81,6 @@ public:
             blur_y.split(y, y, yi, 8).parallel(y).vectorize(x, 8);
             blur_x.store_at(blur_y, y).compute_at(blur_y, yi).vectorize(x, 8);
         }
-
-        return blur_y;
     }
 };
 

--- a/apps/c_backend/pipeline_cpp_generator.cpp
+++ b/apps/c_backend/pipeline_cpp_generator.cpp
@@ -50,10 +50,10 @@ HalideExtern_2(int, an_extern_c_func, int, float);
 
 class PipelineCpp : public Halide::Generator<PipelineCpp> {
 public:
-    Input<Buffer<uint16_t>> input{"input", 2};
+    Input<Buffer<uint16_t>>  input{"input", 2};
+    Output<Buffer<uint16_t>> output{"output", 2};
 
-    Func build() {
-        Func f;
+    void generate() {
         Var x, y;
 
         assert(get_target().has_feature(Target::CPlusPlusMangling));
@@ -77,9 +77,7 @@ public:
 
         add_all_the_things += an_extern_c_func(cast<int32_t>(input(x, y)), cast<float>(x + y));
 
-        f(x, y) = cast<uint16_t>(add_all_the_things);
-
-        return f;
+        output(x, y) = cast<uint16_t>(add_all_the_things);
     }
 };
 

--- a/apps/c_backend/pipeline_generator.cpp
+++ b/apps/c_backend/pipeline_generator.cpp
@@ -8,18 +8,18 @@ HalideExtern_2(int, an_extern_func, int, int);
 class Pipeline : public Halide::Generator<Pipeline> {
 public:
     Input<Buffer<uint16_t>> input{"input", 2};
-    Func build() {
+    Output<Buffer<uint16_t>> output{"output", 2};
+
+    void generate() {
         Var x, y;
 
-        Func f, g, h;
+        Func f, h;
         f(x, y) = (input(clamp(x+2, 0, input.dim(0).extent()-1), clamp(y-2, 0, input.dim(1).extent()-1)) * 17)/13;
         h.define_extern("an_extern_stage", {f}, Int(16), 0, NameMangling::C);
-        g(x, y) = cast<uint16_t>(max(0, f(y, x) + f(x, y) + an_extern_func(x, y) + h()));
+        output(x, y) = cast<uint16_t>(max(0, f(y, x) + f(x, y) + an_extern_func(x, y) + h()));
 
         f.compute_root().vectorize(x, 8);
         h.compute_root();
-
-        return g;
     }
 };
 

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -198,7 +198,9 @@ public:
     Input<int> blackLevel{"blackLevel"};
     Input<int> whiteLevel{"whiteLevel"};
 
-    Func build();
+    Output<Buffer<uint8_t>> processed{"processed", 3};
+
+    void generate();
 
 private:
 
@@ -325,7 +327,7 @@ Func CameraPipe::apply_curve(Func input) {
     return curved;
 }
 
-Func CameraPipe::build() {
+void CameraPipe::generate() {
     // shift things inwards to give us enough padding on the
     // boundaries so that we don't need to check bounds. We're going
     // to make a 2560x1920 output image, just like the FCam pipe, so
@@ -335,12 +337,16 @@ Func CameraPipe::build() {
     shifted(x, y) = cast<int16_t>(input(x+16, y+12));
 
     Func denoised = hot_pixel_suppression(shifted);
+
     Func deinterleaved = deinterleave(denoised);
+
     auto demosaiced = create<Demosaic>();
     demosaiced->auto_schedule.set(auto_schedule);
     demosaiced->apply(deinterleaved);
+
     Func corrected = color_correct(demosaiced->output);
-    Func processed = apply_curve(corrected);
+
+    processed(x, y, c) = apply_curve(corrected)(x, y, c);
 
     Pipeline p(processed);
 
@@ -365,16 +371,16 @@ Func CameraPipe::build() {
 
     } else {
 
-        Expr out_width = processed.output_buffer().width();
-        Expr out_height = processed.output_buffer().height();
+        Expr out_width = processed.width();
+        Expr out_height = processed.height();
         // In HVX 128, we need 2 threads to saturate HVX with work,
         //and in HVX 64 we need 4 threads, and on other devices,
         // we might need many threads.
         Expr strip_size;
         if (get_target().has_feature(Target::HVX_128)) {
-            strip_size = processed.output_buffer().dim(1).extent() / 2;
+            strip_size = processed.dim(1).extent() / 2;
         } else if (get_target().has_feature(Target::HVX_64)) {
-            strip_size = processed.output_buffer().dim(1).extent() / 4;
+            strip_size = processed.dim(1).extent() / 4;
         } else {
             strip_size = 32;
         }
@@ -428,8 +434,6 @@ Func CameraPipe::build() {
             .bound(x, 0, ((out_width)/(2*vec))*(2*vec))
             .bound(y, 0, (out_height/strip_size)*strip_size);
     } 
-
-    return processed;
 };
 
 }  // namespace

--- a/apps/glsl/halide_blur_glsl_generator.cpp
+++ b/apps/glsl/halide_blur_glsl_generator.cpp
@@ -4,11 +4,12 @@ namespace {
 
 class HalideBlurGLSL : public Halide::Generator<HalideBlurGLSL> {
 public:
-    Input<Buffer<uint8_t>> input8{"input8", 3};
-    Func build() {
+    Input<Buffer<uint8_t>>  input8{"input8", 3};
+    Output<Buffer<uint8_t>> blur_filter{"blur_filter", 3};
+    void generate() {
         assert(get_target().has_feature(Target::OpenGL));
 
-        Func blur_x("blur_x"), blur_y("blur_y"), out("blur_filter");
+        Func blur_x("blur_x"), blur_y("blur_y");
         Var x("x"), y("y"), c("c");
 
         // The algorithm
@@ -17,14 +18,12 @@ public:
                                           clamp(y, input8.dim(1).min(), input8.dim(1).max()), c)) / 255.f;
         blur_x(x, y, c) = (input(x, y, c) + input(x+1, y, c) + input(x+2, y, c)) / 3;
         blur_y(x, y, c) = (blur_x(x, y, c) + blur_x(x, y+1, c) + blur_x(x, y+2, c)) / 3;
-        out(x, y, c) = cast<uint8_t>(blur_y(x, y, c) * 255.f);
+        blur_filter(x, y, c) = cast<uint8_t>(blur_y(x, y, c) * 255.f);
 
         // Schedule for GLSL
         input8.dim(2).set_bounds(0, 3);
-        out.bound(c, 0, 3);
-        out.glsl(x, y, c);
-
-        return out;
+        blur_filter.bound(c, 0, 3);
+        blur_filter.glsl(x, y, c);
     }
 };
 

--- a/apps/glsl/halide_ycc_glsl_generator.cpp
+++ b/apps/glsl/halide_ycc_glsl_generator.cpp
@@ -4,10 +4,10 @@ namespace {
 
 class RgbToYcc : public Halide::Generator<RgbToYcc> {
 public:
-    Input<Buffer<uint8_t>> input8{"input8", 3};
-    Func build() {
+    Input<Buffer<uint8_t>>  input8{"input8", 3};
+    Output<Buffer<uint8_t>> out{"out", 3};
+    void generate() {
         assert(get_target().has_feature(Target::OpenGL));
-        Func out("out");
         Var x("x"), y("y"), c("c");
 
         // The algorithm
@@ -33,8 +33,6 @@ public:
         input8.dim(2).set_bounds(0, 3);
         out.bound(c, 0, 3);
         out.glsl(x, y, c);
-
-        return out;
     }
 };
 

--- a/apps/lens_blur/lens_blur_generator.cpp
+++ b/apps/lens_blur/lens_blur_generator.cpp
@@ -21,7 +21,9 @@ public:
     // The number of samples of the aperture to use
     Input<int>              aperture_samples{"aperture_samples", 32, 1, 64};
 
-    Func build() {
+    Output<Buffer<float>>   final{"final", 3};
+
+    void generate() {
         /* THE ALGORITHM */
         Expr maximum_blur_radius =
             cast<int>(max(slices - focus_depth, focus_depth) * blur_radius_scale);
@@ -149,7 +151,6 @@ public:
         output(x, y, c) += sample_weight(x, y, s) * input_with_alpha(sample_x, sample_y, c);
 
         // Normalize
-        Func final;
         final(x, y, c) = output(x, y, c) / output(x, y, 3);
 
         /* THE SCHEDULE */
@@ -266,8 +267,6 @@ public:
             sample_weight.compute_at(output, x).unroll(x);
             sample_locations.compute_at(output, x).vectorize(x);
         }
-
-        return final;
     }
 private:
     Var x, y, z, c;

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -14,7 +14,9 @@ public:
     Input<float>            alpha{"alpha"};
     Input<float>            beta{"beta"};
 
-    Func build() {
+    Output<Buffer<uint16_t>> output{"output", 3};
+
+    void generate() {
         /* THE ALGORITHM */
         const int J = pyramid_levels;
 
@@ -82,7 +84,6 @@ public:
         float eps = 0.01f;
         color(x, y, c) = outGPyramid[0](x, y) * (floating(x, y, c)+eps) / (gray(x, y)+eps);
 
-        Func output("local_laplacian");
         // Convert back to 16-bit
         output(x, y, c) = cast<uint16_t>(clamp(color(x, y, c), 0.0f, 1.0f) * 65535.0f);
 
@@ -144,7 +145,6 @@ public:
                 outGPyramid[j].compute_root();
             }
         }
-        return output;
     }
 private:
     Var x, y, c, k;

--- a/apps/nl_means/nl_means_generator.cpp
+++ b/apps/nl_means/nl_means_generator.cpp
@@ -13,7 +13,9 @@ public:
     Input<int>            search_area{"search_area"};
     Input<float>          sigma{"sigma"};
 
-    Func build() {
+    Output<Buffer<float>> non_local_means{"non_local_means", 3};
+
+    void generate() {
         /* THE ALGORITHM */
 
         // This implements the basic description of non-local means found at
@@ -62,14 +64,13 @@ public:
         Func non_local_means_sum("non_local_means_sum");
         non_local_means_sum(x, y, c) += w(x, y, s_dom.x, s_dom.y) * clamped_with_alpha(x + s_dom.x, y + s_dom.y, c);
 
-        Func non_local_means("non_local_means");
         non_local_means(x, y, c) =
             clamp(non_local_means_sum(x, y, c) / non_local_means_sum(x, y, 3), 0.0f, 1.0f);
 
         /* THE SCHEDULE */
 
         // Require 3 channels for output
-        non_local_means.output_buffer().dim(2).set_bounds(0, 3);
+        non_local_means.dim(2).set_bounds(0, 3);
 
         Var tx("tx"), ty("ty"), xi("xi"), yi("yi");
 
@@ -133,8 +134,6 @@ public:
             blur_d.compute_at(non_local_means_sum, x)
                 .vectorize(x, 8);
         }
-
-        return non_local_means;
     }
 };
 

--- a/apps/wavelet/Makefile
+++ b/apps/wavelet/Makefile
@@ -5,7 +5,7 @@ BIN ?= bin
 # If HL_TARGET isn't set, use host
 HL_TARGET ?= host
 
-all: $(BIN)/wavelet
+all: test
 
 clean:
 	@rm -rf $(BIN)

--- a/apps/wavelet/daubechies_x_generator.cpp
+++ b/apps/wavelet/daubechies_x_generator.cpp
@@ -9,16 +9,15 @@ Halide::Var x("x"), y("y"), c("c");
 class daubechies_x : public Halide::Generator<daubechies_x> {
 public:
     Input<Buffer<float>> in_{"in" , 2};
+    Output<Buffer<float>> out_{"out" , 3};
 
-    Func build() {
+    void generate() {
         Func in = Halide::BoundaryConditions::repeat_edge(in_);
 
-        Func out("out");
-        out(x, y, c) = select(c == 0,
+        out_(x, y, c) = select(c == 0,
                               D0*in(2*x-1, y) + D1*in(2*x, y) + D2*in(2*x+1, y) + D3*in(2*x+2, y),
                               D3*in(2*x-1, y) - D2*in(2*x, y) + D1*in(2*x+1, y) - D0*in(2*x+2, y));
-        out.unroll(c, 2);
-        return out;
+        out_.unroll(c, 2);
     }
 };
 

--- a/apps/wavelet/haar_x_generator.cpp
+++ b/apps/wavelet/haar_x_generator.cpp
@@ -9,16 +9,15 @@ Halide::Var x("x"), y("y"), c("c");
 class haar_x : public Halide::Generator<haar_x> {
 public:
     Input<Buffer<float>> in_{"in" , 2};
+    Output<Buffer<float>> out_{"out" , 3};
 
-    Func build() {
+    void generate() {
         Func in = Halide::BoundaryConditions::repeat_edge(in_);
 
-        Func out("out");
-        out(x, y, c) = select(c == 0,
+        out_(x, y, c) = select(c == 0,
                               (in(2*x, y) + in(2*x+1, y)),
                               (in(2*x, y) - in(2*x+1, y)))/2;
-        out.unroll(c, 2);
-        return out;
+        out_.unroll(c, 2);
     }
 };
 

--- a/apps/wavelet/inverse_daubechies_x_generator.cpp
+++ b/apps/wavelet/inverse_daubechies_x_generator.cpp
@@ -9,16 +9,15 @@ Halide::Var x("x"), y("y"), c("c");
 class inverse_daubechies_x : public Halide::Generator<inverse_daubechies_x> {
 public:
     Input<Buffer<float>> in_{"in" , 3};
+    Output<Buffer<float>> out_{"out" , 2};
 
-    Func build() {
+    void generate() {
         Func in = Halide::BoundaryConditions::repeat_edge(in_);
 
-        Func out("out");
-        out(x, y) = select(x%2 == 0,
+        out_(x, y) = select(x%2 == 0,
                            D2*in(x/2, y, 0) + D1*in(x/2, y, 1) + D0*in(x/2+1, y, 0) + D3*in(x/2+1, y, 1),
                            D3*in(x/2, y, 0) - D0*in(x/2, y, 1) + D1*in(x/2+1, y, 0) - D2*in(x/2+1, y, 1));
-        out.unroll(x, 2);
-        return out;
+        out_.unroll(x, 2);
     }
 };
 

--- a/apps/wavelet/inverse_haar_x_generator.cpp
+++ b/apps/wavelet/inverse_haar_x_generator.cpp
@@ -9,16 +9,15 @@ Halide::Var x("x"), y("y"), c("c");
 class inverse_haar_x : public Halide::Generator<inverse_haar_x> {
 public:
     Input<Buffer<float>> in_{"in" , 3};
+    Output<Buffer<float>> out_{"out" , 2};
 
-    Func build() {
+    void generate() {
         Func in = Halide::BoundaryConditions::repeat_edge(in_);
 
-        Func out("out");
-        out(x, y) = select(x%2 == 0,
+        out_(x, y) = select(x%2 == 0,
                            in(x/2, y, 0) + in(x/2, y, 1),
                            in(x/2, y, 0) - in(x/2, y, 1));
-        out.unroll(x, 2);
-        return out;
+        out_.unroll(x, 2);
     }
 };
 

--- a/test/generator/acquire_release_generator.cpp
+++ b/test/generator/acquire_release_generator.cpp
@@ -4,21 +4,20 @@ namespace {
 
 class AcquireRelease : public Halide::Generator<AcquireRelease> {
 public:
-    Input<Buffer<float>> input{"input", 2};
+    Input<Buffer<float>>  input{"input", 2};
+    Output<Buffer<float>> output{"output", 2};
 
-    Func build() {
+    void generate() {
         Var x("x"), y("y");
-        Func f("f");
 
-        f(x, y) = input(x, y) * 2.0f + 1.0f;
+        output(x, y) = input(x, y) * 2.0f + 1.0f;
 
         // Use the GPU for this f if a GPU is available.
         Target target = get_target();
         if (target.has_gpu_feature()) {
             Var bx("bx"), by("by"), tx("tx"), ty("ty");
-            f.gpu_tile(x, y, bx, by, tx, ty, 16, 16).compute_root();
+            output.gpu_tile(x, y, bx, by, tx, ty, 16, 16).compute_root();
         }
-        return f;
     }
 };
 

--- a/test/generator/argvcall_generator.cpp
+++ b/test/generator/argvcall_generator.cpp
@@ -7,18 +7,18 @@ public:
     Input<float> f1{ "f1", 1.0 };
     Input<float> f2{ "f2", 1.0 };
 
-    Func build() {
+    Output<Buffer<int32_t>> output{ "output", 3 };
+
+    void generate() {
         Var x, y, c;
-        Func f("f"), g("g");
+        Func f("f");
 
         f(x, y) = max(x, y);
-        g(x, y, c) = cast<int32_t>(f(x, y) * c * f1 / f2);
+        output(x, y, c) = cast<int32_t>(f(x, y) * c * f1 / f2);
 
-        g.bound(c, 0, 3).reorder(c, x, y).unroll(c);
+        output.bound(c, 0, 3).reorder(c, x, y).unroll(c);
 
-        g.vectorize(x, natural_vector_size<float>());
-
-        return g;
+        output.vectorize(x, natural_vector_size<float>());
     }
 };
 

--- a/test/generator/buildmethod_aottest.cpp
+++ b/test/generator/buildmethod_aottest.cpp
@@ -1,0 +1,31 @@
+#include "HalideRuntime.h"
+#include "HalideBuffer.h"
+
+#include <math.h>
+#include <stdio.h>
+
+#include "buildmethod.h"
+
+using namespace Halide::Runtime;
+
+const int kSize = 32;
+
+void verify(const Buffer<int32_t> &img, float compiletime_factor, float runtime_factor) {
+    img.for_each_element([=](int x, int y, int c) {
+        int expected = (int32_t)(compiletime_factor * runtime_factor * c * (x > y ? x : y));
+        int actual = img(x, y, c);
+        assert(expected == actual);
+    });
+}
+
+int main(int argc, char **argv) {
+  Buffer<int32_t> output(kSize, kSize, 3);
+
+  const float compiletime_factor = 1.0f;
+
+  buildmethod(3.3245f, output);
+  verify(output, compiletime_factor, 3.3245f);
+
+  printf("Success!\n");
+  return 0;
+}

--- a/test/generator/buildmethod_generator.cpp
+++ b/test/generator/buildmethod_generator.cpp
@@ -1,0 +1,26 @@
+#include "Halide.h"
+
+namespace {
+
+// This Generator exists solely to verify that old-style generators (using the 
+// build() method, rather than generate()/schedule()) still work. Do not
+// convert it to new-style until/unless we decide to entirely remove support
+// for those Generators.
+class BuildMethod : public Halide::Generator<BuildMethod> {
+public:
+    GeneratorParam<float> compiletime_factor{ "compiletime_factor", 1, 0, 100 };
+
+    Input<float> runtime_factor{ "runtime_factor", 1.0 };
+
+    Func build() {
+        Var x, y, c;
+
+        Func g;
+        g(x, y, c) = cast<int32_t>(max(x, y) * c * compiletime_factor * runtime_factor);
+        return g;
+    }
+};
+
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(BuildMethod, buildmethod)

--- a/test/generator/can_use_target_generator.cpp
+++ b/test/generator/can_use_target_generator.cpp
@@ -4,13 +4,13 @@ namespace {
 
 class CanUseTarget : public Halide::Generator<CanUseTarget> {
 public:
+    Output<Buffer<uint32_t>> output{"output", 2};
+
     // Current really just a placeholder: can_use_target_aottest.cpp just
     // needs to test the runtime itself, not the generator function.
-    Func build() {
+    void generate() {
         Var x, y;
-        Func f("f");
-        f(x, y) = cast<uint32_t>((int32_t)0xdeadbeef);
-        return f;
+        output(x, y) = cast<uint32_t>((int32_t)0xdeadbeef);
     }
 };
 

--- a/test/generator/cleanup_on_error_generator.cpp
+++ b/test/generator/cleanup_on_error_generator.cpp
@@ -4,7 +4,9 @@ namespace {
 
 class CleanupOnError : public Halide::Generator<CleanupOnError> {
 public:
-    Func build() {
+    Output<Buffer<int32_t>> output{"output", 1};
+
+    void generate() {
         Var x;
 
         // This allocation is going to succeed
@@ -29,10 +31,7 @@ public:
 
         g.compute_root();
 
-        Func h;
-        h(x) = g(x) + 1;
-
-        return h;
+        output(x) = g(x) + 1;
     }
 };
 

--- a/test/generator/embed_image_generator.cpp
+++ b/test/generator/embed_image_generator.cpp
@@ -4,9 +4,10 @@ namespace {
 
 class EmbedImage : public Halide::Generator<EmbedImage> {
 public:
-    Input<Buffer<float>> input{"input", 3};
+    Input<Buffer<float>>  input{"input", 3};
+    Output<Buffer<float>> output{"output", 3};
 
-    Func build() {
+    void generate() {
         Buffer<float> matrix(3, 3);
 
         for (int i = 0; i < 3; i++) {
@@ -17,11 +18,9 @@ public:
         // Make the matrix a flip-channels-and-multiply-by-0.5 so that this is easy to test
         matrix(2, 0) = matrix(1, 1) = matrix(0, 2) = 0.5f;
 
-        Func f;
         Var x, y, c;
         RDom j(0, 3);
-        f(x, y, c) = sum(matrix(j, c) * input(x, y, j));
-        return f;
+        output(x, y, c) = sum(matrix(j, c) * input(x, y, j));
     }
 };
 

--- a/test/generator/error_codes_generator.cpp
+++ b/test/generator/error_codes_generator.cpp
@@ -4,19 +4,17 @@ namespace {
 
 class ErrorCodes : public Halide::Generator<ErrorCodes> {
 public:
-    Input<Buffer<int32_t>> input{ "input", 2};
-    Input<int>             f_explicit_bound{"f_explicit_bound", 1, 0, 64};
+    Input<Buffer<int32_t>>  input{ "input", 2};
+    Input<int>              f_explicit_bound{"f_explicit_bound", 1, 0, 64};
 
+    Output<Buffer<int32_t>> output{"output", 2};
 
-    Func build() {
+    void generate() {
         target.set(get_target().without_feature(Target::LargeBuffers));
-        Func f;
         Var x, y;
 
-        f(x, y) = input(x, y);
-        f.bound(x, 0, f_explicit_bound);
-
-        return f;
+        output(x, y) = input(x, y);
+        output.bound(x, 0, f_explicit_bound);
     }
 };
 

--- a/test/generator/float16_t_generator.cpp
+++ b/test/generator/float16_t_generator.cpp
@@ -2,13 +2,13 @@
 
 class Float16T : public Halide::Generator<Float16T> {
 public:
-    Func build() {
+    Output<Buffer<int32_t>> output{"output", 1};
+
+    void generate() {
         // Currently the float16 aot test just exercises the
         // runtime. More interesting code may go here in the future.
         Var x;
-        Func f;
-        f(x) = x;
-        return f;
+        output(x) = x;
     }
 };
 

--- a/test/generator/gpu_object_lifetime_generator.cpp
+++ b/test/generator/gpu_object_lifetime_generator.cpp
@@ -4,19 +4,18 @@ namespace {
 
 class GpuObjectLifetime : public Halide::Generator<GpuObjectLifetime> {
 public:
-    Func build() {
+    Output<Buffer<int32_t>> output{"output", 1};
+
+    void generate() {
         Var x;
 
-        Func f;
-        f(x) = x;
+        output(x) = x;
 
         Target target = get_target();
         if (target.has_gpu_feature()) {
             Var xo, xi;
-            f.gpu_tile(x, xo, xi, 16);
+            output.gpu_tile(x, xo, xi, 16);
         }
-
-        return f;
     }
 };
 

--- a/test/generator/gpu_only_generator.cpp
+++ b/test/generator/gpu_only_generator.cpp
@@ -6,19 +6,19 @@ class GpuOnly : public Halide::Generator<GpuOnly> {
 public:
     Input<Buffer<int32_t>> input{"input", 2};
 
-    Func build() {
+    Output<Buffer<int32_t>>  output{"output", 2};
+
+    void generate() {
         Var x("x"), y("y");
 
         // Create a simple pipeline that scales pixel values by 2.
-        Func f("f");
-        f(x, y) = input(x, y) * 2;
+        output(x, y) = input(x, y) * 2;
 
         Target target = get_target();
         if (target.has_gpu_feature()) {
             Var xo, yo, xi, yi;
-            f.gpu_tile(x, y, xo, yo, xi, yi, 16, 16);
+            output.gpu_tile(x, y, xo, yo, xi, yi, 16, 16);
         }
-        return f;
     }
 };
 

--- a/test/generator/image_from_array_generator.cpp
+++ b/test/generator/image_from_array_generator.cpp
@@ -4,12 +4,12 @@ namespace {
 
 class ImageFromArray : public Halide::Generator<ImageFromArray> {
 public:
-   Func build() {
+    Output<Buffer<int32_t>> output{"output", 1};
+
+    void generate() {
         // Currently the test just exercises halide_image.h.
         Var x;
-        Func f;
-        f(x) = x;
-        return f;
+        output(x) = x;
     }
 };
 

--- a/test/generator/mandelbrot_generator.cpp
+++ b/test/generator/mandelbrot_generator.cpp
@@ -43,7 +43,9 @@ public:
     Input<int>   w{"w"};
     Input<int>   h{"h"};
 
-    Func build() {
+    Output<Buffer<int32_t>> count{"count", 2};
+
+    void generate() {
         Var x, y, z;
 
         Complex initial(lerp(x_min, x_max, cast<float>(x) / w),
@@ -56,7 +58,6 @@ public:
         mandelbrot(x, y, t) = current * current + c;
 
         // How many iterations until something escapes a circle of radius 2?
-        Func count;
         Tuple escape = argmin(magnitude(mandelbrot(x, y, t)) < 4);
 
         // If it never escapes, use the value 0
@@ -66,8 +67,6 @@ public:
         mandelbrot.compute_at(count, xo);
 
         count.tile(x, y, xo, yo, xi, yi, 8, 8).parallel(yo).vectorize(xi, 4).unroll(xi).unroll(yi, 2);
-
-        return count;
     }
 private:
     // Declared as a member variable to verify that Funcs-as-members won't cause

--- a/test/generator/matlab_generator.cpp
+++ b/test/generator/matlab_generator.cpp
@@ -6,15 +6,15 @@ namespace {
 
 class Matlab : public Halide::Generator<Matlab> {
 public:
-    Input<Buffer<float>> input{"input", 2};
-    Input<float>         scale{"scale"};
-    Input<bool>          negate{"negate"};
+    Input<Buffer<float>>  input{"input", 2};
+    Input<float>          scale{"scale"};
+    Input<bool>           negate{"negate"};
 
-    Func build() {
+    Output<Buffer<float>> output{"output", 2};
+
+    void generate() {
         Var x, y;
-        Func f("f");
-        f(x, y) = input(x, y) * scale * select(negate, -1.0f, 1.0f);
-        return f;
+        output(x, y) = input(x, y) * scale * select(negate, -1.0f, 1.0f);
     }
 };
 

--- a/test/generator/memory_profiler_mandelbrot_generator.cpp
+++ b/test/generator/memory_profiler_mandelbrot_generator.cpp
@@ -43,7 +43,9 @@ public:
     Input<int>   w{"w"};
     Input<int>   h{"h"};
 
-    Func build() {
+    Output<Buffer<int32_t>> count{"count", 2};
+
+    void generate() {
         target.set(get_target().with_feature(Target::Profile));
 
         Var x, y, z;
@@ -59,7 +61,6 @@ public:
         mandelbrot(x, y, t) = current * current + c;
 
         // How many iterations until something escapes a circle of radius 2?
-        Func count;
         Tuple escape = argmin(magnitude(mandelbrot(x, y, t)) < 4);
 
         // If it never escapes, use the value 0
@@ -69,8 +70,6 @@ public:
         mandelbrot.compute_at(count, xo);
 
         count.tile(x, y, xo, yo, xi, yi, 8, 8).parallel(yo).vectorize(xi, 4).unroll(xi).unroll(yi, 2);
-
-        return count;
     }
 };
 

--- a/test/generator/multitarget_generator.cpp
+++ b/test/generator/multitarget_generator.cpp
@@ -4,15 +4,15 @@ namespace {
 
 class Multitarget : public Halide::Generator<Multitarget> {
 public:
-    Func build() {
+    Output<Buffer<uint32_t>> output{"output", 2};
+
+    void generate() {
         Var x, y; 
-        Func f("f");
         if (get_target().has_feature(Target::Debug)) {
-            f(x, y) = cast<uint32_t>((int32_t)0xdeadbeef);
+            output(x, y) = cast<uint32_t>((int32_t)0xdeadbeef);
         } else {
-            f(x, y) = cast<uint32_t>((int32_t)0xf00dcafe);
+            output(x, y) = cast<uint32_t>((int32_t)0xf00dcafe);
         }
-        return f;
     }
 };
 

--- a/test/generator/old_buffer_t_generator.cpp
+++ b/test/generator/old_buffer_t_generator.cpp
@@ -9,7 +9,9 @@ public:
     Input<Buffer<int32_t>> in2{"in2", 2};
     Input<int>             scalar_param{"scalar_param", 1, 0, 64};
 
-    Func build() {
+    Output<Buffer<int32_t>>  output{"output", 2};
+ 
+    void generate() {
         Func f, g;
         Var x, y;
         f(x, y) = in1(x-1, y-1) + in1(x+1, y+3) + in2(x, y) + scalar_param;
@@ -23,7 +25,12 @@ public:
         g.define_extern("extern_stage", {in2, f}, Int(32), 2,
                         NameMangling::Default,
                         true /* uses old buffer_t */);
-        return g;
+
+        // TODO(srj): this compute_root() is necessary only due to
+        // https://github.com/halide/Halide/issues/2386 -- remove when fixed
+        g.compute_root();
+
+        output(x, y) = g(x, y);
     }
 };
 

--- a/test/generator/rdom_input_generator.cpp
+++ b/test/generator/rdom_input_generator.cpp
@@ -4,20 +4,19 @@ namespace {
 
 class RDomInput : public Halide::Generator<RDomInput> {
 public:
-    Input<Buffer<uint8_t>> input{"input", 2};
+    Input<Buffer<uint8_t>>  input{"input", 2};
+    Output<Buffer<uint8_t>> output{"output", 2};
 
-    Func build() {
+    void generate() {
         RDom r(input);
 
         // Note: this is terrible way to process all the pixels
         // in an image: do not imitate this code. It exists solely
         // to verify that RDom() accepts an Input<Buffer<>> as well a
         // plain Buffer<>.
-        Func output;
         Var x, y;
         output(x, y) = cast<uint8_t>(0);
         output(r.x, r.y) += input(r.x, r.y) ^ cast<uint8_t>(0xff);
-        return output;
     }
 };
 

--- a/test/generator/user_context_generator.cpp
+++ b/test/generator/user_context_generator.cpp
@@ -4,26 +4,24 @@ namespace {
 
 class UserContext : public Halide::Generator<UserContext> {
 public:
-    Input<Buffer<float>> input{"input", 2};
+    Input<Buffer<float>>  input{"input", 2};
+    Output<Buffer<float>> output{"output", 2};
 
-    Func build() {
+    void generate() {
         Var x, y;
 
         Func g;
         g(x, y) = input(x, y) * 2;
         g.compute_root();
 
-        Func f;
-        f(x, y) = g(x, y);
+        output(x, y) = g(x, y);
 
-        f.parallel(y);
-        f.trace_stores();
+        output.parallel(y);
+        output.trace_stores();
 
         // This test won't work in the profiler, because the profiler
         // insists on calling malloc with nullptr user context.
         target.set(get_target().without_feature(Target::Profile));
-
-        return f;
     }
 };
 

--- a/test/generator/user_context_insanity_generator.cpp
+++ b/test/generator/user_context_insanity_generator.cpp
@@ -4,21 +4,20 @@ namespace {
 
 class UserContextInsanity : public Halide::Generator<UserContextInsanity> {
 public:
-    Input<Buffer<float>> input{"input", 2};
+    Input<Buffer<float>>  input{"input", 2};
+    Output<Buffer<float>> output{"output", 2};
 
-    Func build() {
+    void generate() {
         Var x, y;
 
         Func g;
         g(x, y) = input(x, y) * 2;
         g.compute_root();
 
-        Func f;
-        f(x, y) = g(x, y);
+        output(x, y) = g(x, y);
 
-        f.parallel(y);
-        f.trace_stores();
-        return f;
+        output.parallel(y);
+        output.trace_stores();
     }
 };
 

--- a/test/generator/variable_num_threads_generator.cpp
+++ b/test/generator/variable_num_threads_generator.cpp
@@ -4,15 +4,14 @@ namespace {
 
 class VariableNumThreads : public Halide::Generator<VariableNumThreads> {
 public:
-    Func build() {
+    Output<Buffer<float>> output{"output", 2};
+
+    void generate() {
         // A job with lots of nested parallelism
-        Func f;
         Var x, y;
 
-        f(x, y) = sqrt(sqrt(x*y));
-        f.parallel(x).parallel(y);
-
-        return f;
+        output(x, y) = sqrt(sqrt(x*y));
+        output.parallel(x).parallel(y);
     }
 };
 

--- a/tutorial/lesson_15_generators.cpp
+++ b/tutorial/lesson_15_generators.cpp
@@ -34,24 +34,23 @@ public:
     Input<uint8_t> offset{"offset"};
     Input<Buffer<uint8_t>> input{"input", 2};
 
+    // We also declare the Outputs as public member variables.
+    Output<Buffer<uint8_t>> brighter{"brighter", 2};
+
     // Typically you declare your Vars at this scope as well, so that
     // they can be used in any helper methods you add later.
     Var x, y;
 
     // We then define a method that constructs and return the Halide
     // pipeline:
-    Func build() {
-        // Define the Func.
-        Func brighter;
+    void generate() {
+        // In lesson 10, here is where we called
+        // Func::compile_to_file. In a Generator, we just need to
+        // define the Output(s) representing the output of the pipeline.
         brighter(x, y) = input(x, y) + offset;
 
         // Schedule it.
         brighter.vectorize(x, 16).parallel(y);
-
-        // In lesson 10, here is where we called
-        // Func::compile_to_file. In a Generator, we just need to
-        // return the Func representing the output of the pipeline.
-        return brighter;
     }
 };
 
@@ -94,19 +93,19 @@ public:
              { "cw",   Rotation::Clockwise },
              { "ccw",  Rotation::CounterClockwise }}};
 
-    // Halide::Type is supported as though it was an enum. It's most
-    // useful for customizing the type of input or output image
-    // params.
-    GeneratorParam<Halide::Type> output_type{"output_type", Int(32)};
-
     // We'll use the same Inputs as before:
     Input<uint8_t> offset{"offset"};
     Input<Buffer<uint8_t>> input{"input", 2};
 
+    // And a similar Output. Note that we don't specify a type for the Buffer:
+    // at compile-time, we must specify an explicit type via the "output.type"
+    // GeneratorParam (which is implicitly defined for this Output).
+    Output<Buffer<>> output{"output", 2};
+
     // And we'll declare our Vars here as before.
     Var x, y;
 
-    Func build() {
+    void generate() {
         // Define the Func. We'll use the compile-time scale factor as
         // well as the runtime offset param.
         Func brighter;
@@ -131,8 +130,7 @@ public:
         }
 
         // We'll then cast to the desired output type.
-        Func output;
-        output(x, y) = cast(output_type, rotated(x, y));
+        output(x, y) = cast(output.type(), rotated(x, y));
 
         // The structure of the pipeline depended on the generator
         // params. So will the schedule.
@@ -142,7 +140,7 @@ public:
         // provide a helper called "natural_vector_size" which will
         // pick a reasonable factor for you given the type and the
         // target you're compiling to.
-        output.vectorize(x, natural_vector_size(output_type));
+        output.vectorize(x, natural_vector_size(output.type()));
 
         // Now we'll possibly parallelize it:
         if (parallel) {
@@ -157,8 +155,6 @@ public:
                 .compute_at(output, y)
                 .vectorize(x, natural_vector_size(rotated.output_types()[0]));
         }
-
-        return output;
     }
 
 };

--- a/tutorial/lesson_15_generators_usage.sh
+++ b/tutorial/lesson_15_generators_usage.sh
@@ -124,13 +124,13 @@ check_file_exists my_first_generator.stmt
 # The second generator has generator params, which can be specified on
 # the command-line after the target. Let's compile a few different variants:
 ./lesson_15_generate -g my_second_generator -f my_second_generator_1 -o . \
-target=host parallel=false scale=3.0 rotation=ccw output_type=uint16
+target=host parallel=false scale=3.0 rotation=ccw output.type=uint16
 
 ./lesson_15_generate -g my_second_generator -f my_second_generator_2 -o . \
-target=host scale=9.0 rotation=ccw output_type=float32
+target=host scale=9.0 rotation=ccw output.type=float32
 
 ./lesson_15_generate -g my_second_generator -f my_second_generator_3 -o . \
-target=host parallel=false output_type=float64
+target=host parallel=false output.type=float64
 
 check_file_exists my_second_generator_1.a
 check_file_exists my_second_generator_1.h

--- a/tutorial/lesson_16_rgb_generate.cpp
+++ b/tutorial/lesson_16_rgb_generate.cpp
@@ -52,12 +52,14 @@ public:
     // brightening.
     Input<uint8_t> offset{"offset"};
 
+    // Declare our outputs
+    Output<Buffer<uint8_t>> brighter{"brighter", 3};
+
     // Declare our Vars
     Var x, y, c;
 
-    Func build() {
+    void generate() {
         // Define the Func.
-        Func brighter("brighter");
         brighter(x, y, c) = input(x, y, c) + offset;
 
         // Schedule it.
@@ -126,7 +128,7 @@ public:
                 .dim(0).set_stride(3) // stride in dimension 0 (x) is three
                 .dim(2).set_stride(1); // stride in dimension 2 (c) is one
 
-            brighter.output_buffer()
+            brighter
                 .dim(0).set_stride(3)
                 .dim(2).set_stride(1);
 
@@ -137,7 +139,7 @@ public:
             // and unrolled.
 
             input.dim(2).set_bounds(0, 3); // Dimension 2 (c) starts at 0 and has extent 3.
-            brighter.output_buffer().dim(2).set_bounds(0, 3);
+            brighter.dim(2).set_bounds(0, 3);
 
             // Move the loop over color channels innermost and unroll
             // it.
@@ -157,7 +159,7 @@ public:
                                              // undefined Expr to mean
                                              // there is no constraint.
 
-            brighter.output_buffer().dim(0).set_stride(Expr());
+            brighter.dim(0).set_stride(Expr());
 
         } else if (layout == Layout::Specialized) {
             // We can accept any memory layout with good performance
@@ -170,7 +172,7 @@ public:
                                              // mean there is no
                                              // constraint.
 
-            brighter.output_buffer().dim(0).set_stride(Expr());
+            brighter.dim(0).set_stride(Expr());
 
             // The we construct boolean Exprs that detect at runtime
             // whether we're planar or interleaved. The conditions
@@ -184,11 +186,11 @@ public:
                  input.dim(2).extent() == 3);
 
             Expr output_is_planar =
-                (brighter.output_buffer().dim(0).stride() == 1);
+                (brighter.dim(0).stride() == 1);
             Expr output_is_interleaved =
-                (brighter.output_buffer().dim(0).stride() == 3 &&
-                 brighter.output_buffer().dim(2).stride() == 1 &&
-                 brighter.output_buffer().dim(2).extent() == 3);
+                (brighter.dim(0).stride() == 3 &&
+                 brighter.dim(2).stride() == 1 &&
+                 brighter.dim(2).extent() == 3);
 
             // We can then use Func::specialize to write a schedule
             // that switches at runtime to specialized code based on a
@@ -219,8 +221,6 @@ public:
             // memory layouts are known, you probably want to use
             // set_stride and set_extent instead.
         }
-
-        return brighter;
     }
 };
 


### PR DESCRIPTION
This officially makes it legal to simply omit the schedule() method from a new-style Generator:

- The advent of late-bound ScheduleParams means that having a separable schedule() method isn't as essential for componentized Generators as it was when this design was first envisioned.
- While a separable schedule() method may prove useful for auto-scheduling, that isn't the case just yet, and (ironically) the presence of this method is serving to hamper conversion of Generators to new-style due to confusion.
- Some existing Generators 'converted' to new-style by putting in an empty schedule() method, putting all the scheduling in the generate() method.

Converted all existing test/generator code to use generate() rather than build() (except for one new test which is explicitly meant to ensure that build()-style still works, as we aren't dropping support for them until all downstream users can be converted).

Note that if a schedule() method is present, it will still be called (so nothing will break from this).

(If this PR is approved, subsequent PRs will convert all remaining Generators in the Halide repo to be new-style, except of course for the one compatibility test.)


