### PR TITLE
Change get_device_interface_for_device_api so it does not require target

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -473,6 +473,7 @@ public:
 
     /** Wrap a native handle, using the given device API. */
     int device_wrap_native(const DeviceAPI &d, uint64_t handle) {
+        user_assert(d != DeviceAPI::Default_GPU) << "Cannot pass DeviceAPI::Default_GPU to device_wrap_native.\n";
         return contents->buf.device_wrap_native(get_device_interface_for_device_api(d), handle);
     }
 

--- a/src/DeviceInterface.cpp
+++ b/src/DeviceInterface.cpp
@@ -41,7 +41,7 @@ const halide_device_interface_t *get_device_interface_for_device_api(const Devic
 
     const struct halide_device_interface_t *(*fn)();
 
-    Target gpu_runtime_target;
+    Target gpu_runtime_target = get_host_target();
     std::string name;
     if (d == DeviceAPI::Metal) {
         name = "metal";
@@ -62,6 +62,10 @@ const halide_device_interface_t *get_device_interface_for_device_api(const Devic
         return nullptr;
     }
 
+    // Note that the debug feature is only used the first time
+    // this routine is called as there can only only be one
+    // version of the runtime at once. (I.e. the GPU runtimes
+    // are cached globally inside JITModule.cpp.)
     if (t.has_feature(Target::Debug)) {
         gpu_runtime_target.set_feature(Target::Debug);
     }

--- a/src/DeviceInterface.cpp
+++ b/src/DeviceInterface.cpp
@@ -40,22 +40,33 @@ const halide_device_interface_t *get_device_interface_for_device_api(const Devic
     }
 
     const struct halide_device_interface_t *(*fn)();
+
+    Target gpu_runtime_target;
     std::string name;
     if (d == DeviceAPI::Metal) {
         name = "metal";
+        gpu_runtime_target.set_feature(Target::Metal);
     } else if (d == DeviceAPI::OpenCL) {
         name = "opencl";
+        gpu_runtime_target.set_feature(Target::OpenCL);
     } else if (d == DeviceAPI::CUDA) {
         name = "cuda";
+        gpu_runtime_target.set_feature(Target::CUDA);
     } else if (d == DeviceAPI::OpenGLCompute) {
         name = "openglcompute";
+        gpu_runtime_target.set_feature(Target::OpenGLCompute);
     } else if (d == DeviceAPI::GLSL) {
         name = "opengl";
+        gpu_runtime_target.set_feature(Target::OpenGL);
     } else {
         return nullptr;
     }
 
-    if (lookup_runtime_routine("halide_" + name + "_device_interface", t, fn)) {
+    if (t.has_feature(Target::Debug)) {
+        gpu_runtime_target.set_feature(Target::Debug);
+    }
+
+      if (lookup_runtime_routine("halide_" + name + "_device_interface", gpu_runtime_target, fn)) {
         return (*fn)();
     } else {
         return nullptr;


### PR DESCRIPTION
passed in to contain the GPU API being requested. Only uses the
passed in target to resolve the default GPU API and to get the debug
flag now.