### PR TITLE
Allow to `Buffer::device_wrap_native` to get DeviceAPI from target

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -476,6 +476,17 @@ public:
         return contents->buf.device_wrap_native(get_device_interface_for_device_api(d), handle);
     }
 
+    /** Wrap a native handle, using the device API that is the default for the given Target. */
+    int device_wrap_native(const Target &t, uint64_t handle) {
+        return contents->buf.device_wrap_native(get_default_device_interface_for_target(t), handle);
+    }
+
+    /** Wrap a native handle, using the device API that is the default from the environment. */
+    int device_wrap_native(uint64_t handle) {
+        const Target &t = get_jit_target_from_environment();
+        return contents->buf.device_wrap_native(get_default_device_interface_for_target(t), handle);
+    }
+
 };
 
 }

--- a/test/opengl/rewrap_texture.cpp
+++ b/test/opengl/rewrap_texture.cpp
@@ -55,12 +55,12 @@ int main() {
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
     // wrapping a texture should work
-    out2.device_wrap_native(DeviceAPI::GLSL, texture_id);
+    out2.device_wrap_native(target, texture_id);
     g.realize(out2, target);
     out2.device_detach_native();
 
     // re-wrapping the texture should not abort
-    out3.device_wrap_native(DeviceAPI::GLSL, texture_id);
+    out3.device_wrap_native(target, texture_id);
     g.realize(out3, target);
     out3.device_detach_native();
 


### PR DESCRIPTION
As per discussion in #2389 and earlier in #2353, this allows a client that has a target with the desired device feature set to use that target as the parameter to `Buffer::device_wrap_native`.

Added signatures:
```cpp
int device_wrap_native(const Target &t, uint64_t handle);
int device_wrap_native(uint64_t handle);  // defaults from environment
```
parallel to:
```cpp
int copy_to_device(const Target &t = get_jit_target_from_environment());
int device_malloc(const Target &t = get_jit_target_from_environment());
```

This would obviate #2385, offering a cleaner solution.