### PR TITLE
Add sanity/safety tests to Buffer::device_xxx methods

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -453,29 +453,40 @@ public:
 
     /** Copy to the GPU, using the device API that is the default for the given Target. */
     int copy_to_device(const Target &t = get_jit_target_from_environment()) {
+        assert_device_api_and_target_correctness(DeviceAPI::Default_GPU, t);
         return contents->buf.copy_to_device(get_default_device_interface_for_target(t));
     }
 
     /** Copy to the GPU, using the given device API */
     int copy_to_device(const DeviceAPI &d, const Target &t = get_jit_target_from_environment()) {
+        assert_device_api_and_target_correctness(d, t);
         return contents->buf.copy_to_device(get_device_interface_for_device_api(d, t));
     }
 
     /** Allocate on the GPU, using the device API that is the default for the given Target. */
     int device_malloc(const Target &t = get_jit_target_from_environment()) {
+        assert_device_api_and_target_correctness(DeviceAPI::Default_GPU, t);
         return contents->buf.device_malloc(get_default_device_interface_for_target(t));
     }
 
     /** Allocate storage on the GPU, using the given device API */
     int device_malloc(const DeviceAPI &d, const Target &t = get_jit_target_from_environment()) {
+        assert_device_api_and_target_correctness(d, t);
         return contents->buf.device_malloc(get_device_interface_for_device_api(d, t));
     }
 
     /** Wrap a native handle, using the given device API. */
     int device_wrap_native(const DeviceAPI &d, uint64_t handle, const Target &t = get_jit_target_from_environment()) {
         user_assert(d != DeviceAPI::Default_GPU) << "Cannot pass DeviceAPI::Default_GPU to device_wrap_native.\n";
-        user_assert(target_supports_device_api(t, d)) << "DeviceAPI " << d << " not supported by target " << t.to_string() << "\n";
+        assert_device_api_and_target_correctness(d, t);
         return contents->buf.device_wrap_native(get_device_interface_for_device_api(d, t), handle);
+    }
+
+    private:
+
+    void assert_device_api_and_target_correctness(const DeviceAPI &d, const Target &t) {
+        user_assert(device_api_enabled_in_target(d, t)) << "DeviceAPI " << d << " not enabled in target " << t.to_string() << "\n";
+        user_assert(device_api_available(d, t)) << ((d == DeviceAPI::Default_GPU) ? "Default " : "") << "DeviceAPI " << d << " (target " << t.to_string() << ") not available in compiled Halide library\n";
     }
 
 };

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -473,6 +473,8 @@ public:
 
     /** Wrap a native handle, using the given device API. */
     int device_wrap_native(const DeviceAPI &d, uint64_t handle, const Target &t = get_jit_target_from_environment()) {
+        user_assert(d != DeviceAPI::Default_GPU) << "Cannot pass DeviceAPI::Default_GPU to device_wrap_native.\n";
+        user_assert(target_supports_device_api(t, d)) << "DeviceAPI " << d << " not supported by target " << t.to_string() << "\n";
         return contents->buf.device_wrap_native(get_device_interface_for_device_api(d, t), handle);
     }
 

--- a/src/DeviceInterface.cpp
+++ b/src/DeviceInterface.cpp
@@ -72,7 +72,7 @@ const halide_device_interface_t *get_device_interface_for_device_api(const Devic
     }
 }
 
-bool target_supports_device_api(const Target &target, const DeviceAPI &d)
+bool device_api_enabled_in_target(const DeviceAPI &d, const Target &target)
 {
     switch (d) {
         case DeviceAPI::Metal:         return target.has_feature(Target::Metal);
@@ -86,7 +86,7 @@ bool target_supports_device_api(const Target &target, const DeviceAPI &d)
 
 DeviceAPI get_default_device_api_for_target(const Target &target) {
     for (DeviceAPI d : default_device_api_order) {
-        if (target_supports_device_api(target, d)) {
+        if (device_api_enabled_in_target(d, target)) {
             return d;
         }
     }

--- a/src/DeviceInterface.h
+++ b/src/DeviceInterface.h
@@ -22,6 +22,10 @@ EXPORT const halide_device_interface_t *get_default_device_interface_for_target(
 EXPORT const halide_device_interface_t *get_device_interface_for_device_api(const DeviceAPI &d,
                                                                             const Target &t = get_jit_target_from_environment());
 
+/** Returns true if the given target supports the given given device api.
+ * Returns false for DefaultAPI::Default_GPU, None, or Host. */
+EXPORT bool target_supports_device_api(const Target &t, const DeviceAPI &d);
+
 /** Get the specific DeviceAPI that Halide would select when presented
  * with DeviceAPI::Default_GPU for a given target. If no suitable api
  * is enabled in the target, returns DeviceAPI::Host. */

--- a/src/DeviceInterface.h
+++ b/src/DeviceInterface.h
@@ -18,9 +18,17 @@ EXPORT const halide_device_interface_t *get_default_device_interface_for_target(
 
 /** Gets the appropriate halide_device_interface_t * for a
  * DeviceAPI. Returns null if that device API is not enabled in the
- * target, or if the argument is None or Host. */
+ * target, or if the argument is None or Host, or if halide was not
+ * compiled with support for that device. */
 EXPORT const halide_device_interface_t *get_device_interface_for_device_api(const DeviceAPI &d,
                                                                             const Target &t = get_jit_target_from_environment());
+
+/** Returns true if the given device api & target are available in the
+ * current Halide library; Equavlent to
+ * get_device_interface_for_device_api(d, t) returning non-null. */
+EXPORT inline bool device_api_available(const DeviceAPI &d, const Target &t = get_jit_target_from_environment()) {
+    return get_device_interface_for_device_api(d,t) != nullptr;
+}
 
 /** Returns true if the given device api is enabled in the given target.
  * Returns true for DeviceAPI::Default_GPU if the target supports any

--- a/src/DeviceInterface.h
+++ b/src/DeviceInterface.h
@@ -22,9 +22,10 @@ EXPORT const halide_device_interface_t *get_default_device_interface_for_target(
 EXPORT const halide_device_interface_t *get_device_interface_for_device_api(const DeviceAPI &d,
                                                                             const Target &t = get_jit_target_from_environment());
 
-/** Returns true if the given target supports the given given device api.
- * Returns false for DefaultAPI::Default_GPU, None, or Host. */
-EXPORT bool target_supports_device_api(const Target &t, const DeviceAPI &d);
+/** Returns true if the given device api is enabled in the given target.
+ * Returns true for DeviceAPI::Default_GPU if the target supports any
+ * device.  Returns false for DeviceAPI::None or Host. */
+EXPORT bool device_api_enabled_in_target(const DeviceAPI &d, const Target &t = get_jit_target_from_environment());
 
 /** Get the specific DeviceAPI that Halide would select when presented
  * with DeviceAPI::Default_GPU for a given target. If no suitable api


### PR DESCRIPTION
As per the discussion in #2389, this PR adds an assertion that the device isn't Default_GPU and that it's supported by the given target.

As part of that added a utility method `target_supports_device_api(t, d)`.

Possibly that method itself may be useful elsewhere instead of checking get_device_interface_for_device_api(d, t) == nullptr
