### PR TITLE
Disable LICM for OpenGL

### DIFF
--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -293,7 +293,10 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
 
     debug(1) << "Simplifying...\n";
     s = common_subexpression_elimination(s);
-    s = loop_invariant_code_motion(s);
+
+    if (!t.has_feature(Target::OpenGL)) { // LICM currently creates invalid OpenGL shaders
+        s = loop_invariant_code_motion(s);
+    }
 
     if (t.has_feature(Target::OpenGL)) {
         debug(1) << "Detecting varying attributes...\n";


### PR DESCRIPTION
Many of the OpenGL tests currently fail in master with invalid shaders.   Git bisect identified the problem as 931f6b582323c04d75fe1bd5d55a07c75226d29d, which added LICM.   So the quick fix is to skip LICM for OpenGL targets.

cc @shoaibkamil 
