### PR TITLE
Disable LICM for OpenGL loops

### DIFF
--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -116,6 +116,10 @@ class LICM : public IRMutator {
         if (old_in_gpu_loop && in_gpu_loop) {
             // Don't lift lets to in-between gpu blocks/threads
             IRMutator::visit(op);
+        } else if (op->device_api == DeviceAPI::GLSL ||
+                   op->device_api == DeviceAPI::OpenGLCompute) {
+            // Don't lift anything out of OpenGL loops
+            IRMutator::visit(op);
         } else {
 
             // Lift invariants


### PR DESCRIPTION
Alternative to #2393.  This disables LICM only for loops that will run in OpenGL (as opposed to turning it off anytime the target includes OpenGL).

CC @ronen 