### PR TITLE
Add auto_schedule_outputs() wrapper method to Generator

### DIFF
--- a/apps/bilateral_grid/bilateral_grid_generator.cpp
+++ b/apps/bilateral_grid/bilateral_grid_generator.cpp
@@ -78,9 +78,9 @@ public:
             blurx.estimate(z, 0, 12);
             blury.estimate(z, 0, 12);
             bilateral_grid.estimate(x, 0, 1536).estimate(y, 0, 2560);
-            // Auto schedule the pipeline
-            Pipeline p(bilateral_grid);
-            p.auto_schedule(get_target());
+            // Auto schedule the pipeline: this calls auto_schedule() for
+            // all of the Outputs in this Generator
+            auto_schedule_outputs();
         } else if (get_target().has_gpu_feature()) {
             Var xi("xi"), yi("yi"), zi("zi");
 

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -367,7 +367,9 @@ void CameraPipe::generate() {
             .estimate(x, 0, 2592)
             .estimate(y, 0, 1968); 
 
-        p.auto_schedule(get_target());
+        // Auto schedule the pipeline: this calls auto_schedule() for
+        // all of the Outputs in this Generator
+        auto_schedule_outputs();
 
     } else {
 

--- a/apps/conv_layer/conv_layer_generator.cpp
+++ b/apps/conv_layer/conv_layer_generator.cpp
@@ -52,9 +52,9 @@ public:
                 .estimate(z, 0, 64)
                 .estimate(n, 0, 4);
 
-            // Auto-schedule the pipeline
-            Pipeline p(f_ReLU);
-            p.auto_schedule(target);
+            // Auto schedule the pipeline: this calls auto_schedule() for
+            // all of the Outputs in this Generator
+            auto_schedule_outputs();
 
         } /*else if (get_target().has_gpu_feature()) {
             // TODO: Turn off the manual GPU schedule for now.

--- a/apps/lens_blur/lens_blur_generator.cpp
+++ b/apps/lens_blur/lens_blur_generator.cpp
@@ -171,9 +171,9 @@ public:
             final.estimate(x, 0, 1536)
                 .estimate(y, 0, 2560)
                 .estimate(c, 0, 3);
-            // Auto schedule the pipeline
-            Pipeline p(final);
-            p.auto_schedule(get_target());
+            // Auto schedule the pipeline: this calls auto_schedule() for
+            // all of the Outputs in this Generator
+            auto_schedule_outputs();
         } else if (get_target().has_gpu_feature()) {
             // Manual GPU schedule
             Var xi("xi"), yi("yi"), zi("zi");

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -102,9 +102,9 @@ public:
             output.estimate(x, 0, 1536)
                 .estimate(y, 0, 2560)
                 .estimate(c, 0, 3);
-            // Auto schedule the pipeline
-            Pipeline p(output);
-            p.auto_schedule(get_target());
+            // Auto schedule the pipeline: this calls auto_schedule() for
+            // all of the Outputs in this Generator
+            auto_schedule_outputs();
         } else if (get_target().has_gpu_feature()) {
             // gpu schedule
             remap.compute_root();

--- a/apps/nl_means/nl_means_generator.cpp
+++ b/apps/nl_means/nl_means_generator.cpp
@@ -87,9 +87,9 @@ public:
             non_local_means.estimate(x, 0, 614)
                 .estimate(y, 0, 1024)
                 .estimate(c, 0, 3);
-            // Auto-schedule the pipeline
-            Pipeline p(non_local_means);
-            p.auto_schedule(get_target());
+            // Auto schedule the pipeline: this calls auto_schedule() for
+            // all of the Outputs in this Generator
+            auto_schedule_outputs();
         } /*else if (get_target().has_gpu_feature()) {
             // TODO: the GPU schedule is currently using to much shared memory
             // because the simplifier can't simplify the expr (it can't cancel

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1422,6 +1422,14 @@ Pipeline GeneratorBase::get_pipeline() {
     return pipeline;
 }
 
+std::string GeneratorBase::auto_schedule_outputs(const MachineParams &arch_params) {
+    return get_pipeline().auto_schedule(get_target(), arch_params);
+}
+
+std::string GeneratorBase::auto_schedule_outputs() {
+    return get_pipeline().auto_schedule(get_target());
+}
+
 Module GeneratorBase::build_module(const std::string &function_name,
                                    const LoweredFunc::LinkageType linkage_type) {
     Pipeline pipeline = build_pipeline();

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2439,6 +2439,12 @@ public:
     // calling from generate() as long as all Outputs have been defined.)
     EXPORT Pipeline get_pipeline();
 
+    /** Generate a schedule for the Generator's pipeline. */
+    //@{
+    EXPORT std::string auto_schedule_outputs(const MachineParams &arch_params);
+    EXPORT std::string auto_schedule_outputs();
+    //@}
+
     // Return a map in which to register external code this Generator requires
     // at link time.
     EXPORT std::shared_ptr<ExternsMap> get_externs_map() const override;


### PR DESCRIPTION
This is cleaner and less error-prone for Generators that use Output<> (rather than unnamed outputs from a build() method), as no outputs can be inadvertently left out.