### PR TITLE
Disallow target mutation in generate()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1094,6 +1094,11 @@ $(FILTERS_DIR)/pyramid.a: $(BIN_DIR)/pyramid.generator
 	@mkdir -p $(@D)
 	$(CURDIR)/$< -g pyramid -f pyramid $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime levels=10
 
+# memory_profiler_mandelbrot need profiler set
+$(FILTERS_DIR)/memory_profiler_mandelbrot.a: $(BIN_DIR)/memory_profiler_mandelbrot.generator
+	@mkdir -p $(@D)
+	$(CURDIR)/$< -g memory_profiler_mandelbrot -f memory_profiler_mandelbrot $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime-profile
+
 METADATA_TESTER_GENERATOR_ARGS=\
 	input.type=uint8 input.dim=3 \
 	type_only_input_buffer.dim=3 \

--- a/apps/linear_algebra/Makefile
+++ b/apps/linear_algebra/Makefile
@@ -32,7 +32,7 @@ ATLAS_LIBS ?= -lcblas
 # this provides a slight build speed increase (since we don't have to redundantly
 # include the runtime code in each generator) with the extra complication that we
 # must explicitly build and link the halide runtime separately.
-HL_TARGET_NR = $(HL_TARGET)-no_runtime
+HL_TARGET_NR = $(HL_TARGET)-no_runtime-no_asserts-no_bounds_query
 
 KERNELS = \
 	scopy_impl \

--- a/apps/linear_algebra/src/blas_l1_generators.cpp
+++ b/apps/linear_algebra/src/blas_l1_generators.cpp
@@ -45,6 +45,9 @@ class AXPYGenerator :
     }
 
     void generate() {
+        assert(get_target().has_feature(Target::NoAsserts));
+        assert(get_target().has_feature(Target::NoBoundsQuery));
+
         const int vec_size = vectorize_? natural_vector_size(type_of<T>()): 1;
         Expr size = x_.width();
         Expr size_vecs = (size / vec_size) * vec_size;
@@ -92,6 +95,9 @@ class DotGenerator :
     Output<Buffer<T>> result_ = {"result", 1};
 
     void generate() {
+        assert(get_target().has_feature(Target::NoAsserts));
+        assert(get_target().has_feature(Target::NoBoundsQuery));
+
         const int vec_size = vectorize_? natural_vector_size(type_of<T>()): 1;
         Expr size = x_.width();
         Expr size_vecs = size / vec_size;
@@ -144,6 +150,9 @@ class AbsSumGenerator :
     Output<Buffer<T>> result_ = {"result", 1};
 
     void generate() {
+        assert(get_target().has_feature(Target::NoAsserts));
+        assert(get_target().has_feature(Target::NoBoundsQuery));
+
         const int vec_size = vectorize_? natural_vector_size(type_of<T>()): 1;
         Expr size = x_.width();
         Expr size_vecs = size / vec_size;

--- a/apps/linear_algebra/src/blas_l1_generators.cpp
+++ b/apps/linear_algebra/src/blas_l1_generators.cpp
@@ -17,8 +17,6 @@ class AXPYGenerator :
     template<typename T2> using Input = typename Base::template Input<T2>;
     template<typename T2> using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> assertions_enabled_ = {"assertions_enabled", false};
-    GeneratorParam<bool> use_fma_ = {"use_fma", false};
     GeneratorParam<bool> vectorize_ = {"vectorize", true};
     GeneratorParam<int>  block_size_ = {"block_size", 1024};
     GeneratorParam<bool> scale_x_ = {"scale_x", true};
@@ -30,18 +28,6 @@ class AXPYGenerator :
     Input<Buffer<T>> y_ = {"y", 1};
 
     Output<Buffer<T>> result_ = {"result", 1};
-
-    void SetupTarget() {
-        if (!assertions_enabled_) {
-            target.set(get_target()
-                       .with_feature(Target::NoAsserts)
-                       .with_feature(Target::NoBoundsQuery));
-        }
-
-        if (use_fma_) {
-            target.set(get_target().with_feature(Target::FMA));
-        }
-    }
 
     void Schedule(Func result, Expr width) {
         Var i("i"), o("o");
@@ -59,8 +45,6 @@ class AXPYGenerator :
     }
 
     void generate() {
-        SetupTarget();
-
         const int vec_size = vectorize_? natural_vector_size(type_of<T>()): 1;
         Expr size = x_.width();
         Expr size_vecs = (size / vec_size) * vec_size;
@@ -98,8 +82,6 @@ class DotGenerator :
     template<typename T2> using Input = typename Base::template Input<T2>;
     template<typename T2> using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> assertions_enabled_ = {"assertions_enabled", false};
-    GeneratorParam<bool> use_fma_ = {"use_fma", false};
     GeneratorParam<bool> vectorize_ = {"vectorize", true};
     GeneratorParam<bool> parallel_ = {"parallel", true};
     GeneratorParam<int>  block_size_ = {"block_size", 1024};
@@ -109,21 +91,7 @@ class DotGenerator :
 
     Output<Buffer<T>> result_ = {"result", 1};
 
-    void SetupTarget() {
-        if (!assertions_enabled_) {
-            target.set(get_target()
-                       .with_feature(Target::NoAsserts)
-                       .with_feature(Target::NoBoundsQuery));
-        }
-
-        if (use_fma_) {
-            target.set(get_target().with_feature(Target::FMA));
-        }
-    }
-
     void generate() {
-        SetupTarget();
-
         const int vec_size = vectorize_? natural_vector_size(type_of<T>()): 1;
         Expr size = x_.width();
         Expr size_vecs = size / vec_size;
@@ -167,8 +135,6 @@ class AbsSumGenerator :
     template<typename T2> using Input = typename Base::template Input<T2>;
     template<typename T2> using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> assertions_enabled_ = {"assertions_enabled", false};
-    GeneratorParam<bool> use_fma_ = {"use_fma", false};
     GeneratorParam<bool> vectorize_ = {"vectorize", true};
     GeneratorParam<bool> parallel_ = {"parallel", true};
     GeneratorParam<int>  block_size_ = {"block_size", 1024};
@@ -177,21 +143,7 @@ class AbsSumGenerator :
 
     Output<Buffer<T>> result_ = {"result", 1};
 
-    void SetupTarget() {
-        if (!assertions_enabled_) {
-            target.set(get_target()
-                       .with_feature(Target::NoAsserts)
-                       .with_feature(Target::NoBoundsQuery));
-        }
-
-        if (use_fma_) {
-            target.set(get_target().with_feature(Target::FMA));
-        }
-    }
-
     void generate() {
-        SetupTarget();
-
         const int vec_size = vectorize_? natural_vector_size(type_of<T>()): 1;
         Expr size = x_.width();
         Expr size_vecs = size / vec_size;

--- a/apps/linear_algebra/src/blas_l2_generators.cpp
+++ b/apps/linear_algebra/src/blas_l2_generators.cpp
@@ -17,7 +17,6 @@ class GEMVGenerator :
     template<typename T2> using Input = typename Base::template Input<T2>;
     template<typename T2> using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> assertions_enabled_ = {"assertions_enabled", false};
     GeneratorParam<bool> vectorize_ = {"vectorize", true};
     GeneratorParam<bool> parallel_ = {"parallel", true};
     GeneratorParam<int>  block_size_ = {"block_size", 1 << 8};
@@ -32,17 +31,7 @@ class GEMVGenerator :
 
     Output<Buffer<T>> output_ = {"output", 1};
 
-    void SetupTarget() {
-        if (!assertions_enabled_) {
-            target.set(get_target()
-                       .with_feature(Target::NoAsserts)
-                       .with_feature(Target::NoBoundsQuery));
-        }
-    }
-
     void generate() {
-        SetupTarget();
-
         const int vec_size = vectorize_? natural_vector_size(type_of<T>()): 1;
         const int unroll_size = 4;
 
@@ -186,7 +175,6 @@ class GERGenerator :
     template<typename T2> using Input = typename Base::template Input<T2>;
     template<typename T2> using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> assertions_enabled_ = {"assertions_enabled", false};
     GeneratorParam<bool> vectorize_ = {"vectorize", true};
     GeneratorParam<bool> parallel_ = {"parallel", true};
     GeneratorParam<int>  block_size_ = {"block_size", 1 << 5};
@@ -199,17 +187,7 @@ class GERGenerator :
 
     Output<Buffer<T>> result_ = {"result", 2};
 
-    void SetupTarget() {
-        if (!assertions_enabled_) {
-            target.set(get_target()
-                       .with_feature(Target::NoAsserts)
-                       .with_feature(Target::NoBoundsQuery));
-        }
-    }
-
     void generate() {
-        SetupTarget();
-
         const int vec_size = vectorize_? natural_vector_size(type_of<T>()): 1;
         const int unroll_size = 4;
 

--- a/apps/linear_algebra/src/blas_l2_generators.cpp
+++ b/apps/linear_algebra/src/blas_l2_generators.cpp
@@ -32,6 +32,9 @@ class GEMVGenerator :
     Output<Buffer<T>> output_ = {"output", 1};
 
     void generate() {
+        assert(get_target().has_feature(Target::NoAsserts));
+        assert(get_target().has_feature(Target::NoBoundsQuery));
+
         const int vec_size = vectorize_? natural_vector_size(type_of<T>()): 1;
         const int unroll_size = 4;
 
@@ -188,6 +191,9 @@ class GERGenerator :
     Output<Buffer<T>> result_ = {"result", 2};
 
     void generate() {
+        assert(get_target().has_feature(Target::NoAsserts));
+        assert(get_target().has_feature(Target::NoBoundsQuery));
+
         const int vec_size = vectorize_? natural_vector_size(type_of<T>()): 1;
         const int unroll_size = 4;
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -990,19 +990,17 @@ GeneratorParamBase::GeneratorParamBase(const std::string &name) : name(name) {
 GeneratorParamBase::~GeneratorParamBase() { ObjectInstanceRegistry::unregister_instance(this); }
 
 void GeneratorParamBase::check_value_readable() const {
-    user_assert(generator && generator->phase >= GeneratorBase::GenerateCalled)  << "The GeneratorParam " << name << " cannot be read before build() or generate() is called.\n";
+    user_assert(generator && generator->phase >= GeneratorBase::GenerateCalled)  << "The GeneratorParam \"" << name << "\" cannot be read before build() or generate() is called.\n";
 }
 
 void GeneratorParamBase::check_value_writable() const {
     // Allow writing when no Generator is set, to avoid having to special-case ctor initing code
     if (!generator) return;
-    // Special-case for legacy: allow 'target' to be writable. Yikes.
-    if (name == "target") return;
-    user_assert(generator->phase < GeneratorBase::GenerateCalled)  << "The GeneratorParam " << name << " cannot be written after build() or generate() is called.\n";
+    user_assert(generator->phase < GeneratorBase::GenerateCalled)  << "The GeneratorParam \"" << name << "\" cannot be written after build() or generate() is called.\n";
 }
 
 void GeneratorParamBase::fail_wrong_type(const char *type) {
-    user_error << "The GeneratorParam " << name << " cannot be set with a value of type " << type << ".\n";
+    user_error << "The GeneratorParam \"" << name << "\" cannot be set with a value of type " << type << ".\n";
 }
 
 /* static */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -224,7 +224,6 @@ if (WITH_TEST_GENERATORS)
   halide_define_aot_test(gpu_only)
   halide_define_aot_test(image_from_array)
   halide_define_aot_test(mandelbrot)
-  halide_define_aot_test(memory_profiler_mandelbrot)
   halide_define_aot_test(stubuser)
   halide_define_aot_test(variable_num_threads)
   halide_define_aot_test(old_buffer_t)
@@ -234,6 +233,9 @@ if (WITH_TEST_GENERATORS)
   # Tests that require nonstandard targets, namespaces, args, etc.
   halide_define_aot_test(matlab
                          HALIDE_TARGET_FEATURES matlab)
+
+  halide_define_aot_test(memory_profiler_mandelbrot
+                         HALIDE_TARGET_FEATURES profile)
 
   halide_define_aot_test(multitarget
                          HALIDE_TARGET host,host-debug

--- a/test/generator/error_codes_generator.cpp
+++ b/test/generator/error_codes_generator.cpp
@@ -10,7 +10,7 @@ public:
     Output<Buffer<int32_t>> output{"output", 2};
 
     void generate() {
-        target.set(get_target().without_feature(Target::LargeBuffers));
+        assert(!get_target().has_feature(Target::LargeBuffers));
         Var x, y;
 
         output(x, y) = input(x, y);

--- a/test/generator/memory_profiler_mandelbrot_generator.cpp
+++ b/test/generator/memory_profiler_mandelbrot_generator.cpp
@@ -46,7 +46,7 @@ public:
     Output<Buffer<int32_t>> count{"count", 2};
 
     void generate() {
-        target.set(get_target().with_feature(Target::Profile));
+        assert(get_target().has_feature(Target::Profile));
 
         Var x, y, z;
 

--- a/test/generator/user_context_generator.cpp
+++ b/test/generator/user_context_generator.cpp
@@ -21,7 +21,7 @@ public:
 
         // This test won't work in the profiler, because the profiler
         // insists on calling malloc with nullptr user context.
-        target.set(get_target().without_feature(Target::Profile));
+        assert(!get_target().has_feature(Target::Profile));
     }
 };
 


### PR DESCRIPTION
We had grandfathered in the ability to mutate the 'target' GeneratorParam at the start of build()/generate() because of some pre-existing usage; we're removing that ability because downstream usage is getting fixed, and allowing target to mutate is weird and bad; in essentially every case, setting the correct target in the build files is appropriate.