### PR TITLE
Ignore LargeBuffers for non-64-bit targets

### DIFF
--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -351,7 +351,7 @@ Stmt add_image_checks(Stmt s,
             // And that no product of extents overflows 2^31 - 1. This
             // second test is likely only needed if a fuse directive
             // is used in the schedule to combine multiple extents,
-            // but it is here for extra safety. On targets with the
+            // but it is here for extra safety. On 64-bit targets with the
             // LargeBuffers feature, the maximum size is 2^63 - 1.
             Expr max_size = make_const(UInt(64), t.maximum_buffer_size());
             Expr max_extent = make_const(UInt(64), 0x7fffffff);

--- a/src/CodeGen_Posix.cpp
+++ b/src/CodeGen_Posix.cpp
@@ -90,7 +90,7 @@ CodeGen_Posix::Allocation CodeGen_Posix::create_allocation(const std::string &na
         stack_bytes = constant_bytes;
 
         if (stack_bytes > target.maximum_buffer_size()) {
-            const string str_max_size = target.has_feature(Target::LargeBuffers) ? "2^63 - 1" : "2^31 - 1";
+            const string str_max_size = target.use_large_buffers() ? "2^63 - 1" : "2^31 - 1";
             user_error << "Total size for allocation " << name << " is constant but exceeds " << str_max_size << ".";
         } else if (!can_allocation_fit_on_stack(stack_bytes)) {
             stack_bytes = 0;

--- a/src/CodeGen_Posix.cpp
+++ b/src/CodeGen_Posix.cpp
@@ -90,7 +90,7 @@ CodeGen_Posix::Allocation CodeGen_Posix::create_allocation(const std::string &na
         stack_bytes = constant_bytes;
 
         if (stack_bytes > target.maximum_buffer_size()) {
-            const string str_max_size = target.use_large_buffers() ? "2^63 - 1" : "2^31 - 1";
+            const string str_max_size = target.has_large_buffers() ? "2^63 - 1" : "2^31 - 1";
             user_error << "Total size for allocation " << name << " is constant but exceeds " << str_max_size << ".";
         } else if (!can_allocation_fit_on_stack(stack_bytes)) {
             stack_bytes = 0;

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -52,7 +52,7 @@ private:
     Expr flatten_args(const string &name, const vector<Expr> &args,
                       const Buffer<> &buf, const Parameter &param) {
         bool internal = realizations.contains(name);
-        Expr idx = target.use_large_buffers() ? make_zero(Int(64)) : 0;
+        Expr idx = target.has_large_buffers() ? make_zero(Int(64)) : 0;
         vector<Expr> mins(args.size()), strides(args.size());
 
         for (size_t i = 0; i < args.size(); i++) {
@@ -65,7 +65,7 @@ private:
             // strategy makes sense when we expect x to cancel with
             // something in xmin.  We use this for internal allocations
             for (size_t i = 0; i < args.size(); i++) {
-                if (target.use_large_buffers()) {
+                if (target.has_large_buffers()) {
                     idx += cast<int64_t>(args[i] - mins[i]) * cast<int64_t>(strides[i]);
                 } else {
                     idx += (args[i] - mins[i]) * strides[i];
@@ -77,9 +77,9 @@ private:
             // will be pulled outside the inner loop. We use this for
             // external buffers, where the mins and strides are likely
             // to be symbolic
-            Expr base = target.use_large_buffers() ? make_zero(Int(64)) : 0;
+            Expr base = target.has_large_buffers() ? make_zero(Int(64)) : 0;
             for (size_t i = 0; i < args.size(); i++) {
-                if (target.use_large_buffers()) {
+                if (target.has_large_buffers()) {
                     idx += cast<int64_t>(args[i]) * cast<int64_t>(strides[i]);
                     base += cast<int64_t>(mins[i]) * cast<int64_t>(strides[i]);
                 } else {

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -52,7 +52,7 @@ private:
     Expr flatten_args(const string &name, const vector<Expr> &args,
                       const Buffer<> &buf, const Parameter &param) {
         bool internal = realizations.contains(name);
-        Expr idx = target.has_feature(Target::LargeBuffers) ? make_zero(Int(64)) : 0;
+        Expr idx = target.use_large_buffers() ? make_zero(Int(64)) : 0;
         vector<Expr> mins(args.size()), strides(args.size());
 
         for (size_t i = 0; i < args.size(); i++) {
@@ -65,7 +65,7 @@ private:
             // strategy makes sense when we expect x to cancel with
             // something in xmin.  We use this for internal allocations
             for (size_t i = 0; i < args.size(); i++) {
-                if (target.has_feature(Target::LargeBuffers)) {
+                if (target.use_large_buffers()) {
                     idx += cast<int64_t>(args[i] - mins[i]) * cast<int64_t>(strides[i]);
                 } else {
                     idx += (args[i] - mins[i]) * strides[i];
@@ -77,9 +77,9 @@ private:
             // will be pulled outside the inner loop. We use this for
             // external buffers, where the mins and strides are likely
             // to be symbolic
-            Expr base = target.has_feature(Target::LargeBuffers) ? make_zero(Int(64)) : 0;
+            Expr base = target.use_large_buffers() ? make_zero(Int(64)) : 0;
             for (size_t i = 0; i < args.size(); i++) {
-                if (target.has_feature(Target::LargeBuffers)) {
+                if (target.use_large_buffers()) {
                     idx += cast<int64_t>(args[i]) * cast<int64_t>(strides[i]);
                     base += cast<int64_t>(mins[i]) * cast<int64_t>(strides[i]);
                 } else {

--- a/src/Target.h
+++ b/src/Target.h
@@ -290,7 +290,7 @@ struct Target {
     }
 
     /** Return true iff 64 bits and has_feature(LargeBuffers). */
-    bool use_large_buffers() const {
+    bool has_large_buffers() const {
         return bits == 64 && has_feature(LargeBuffers);
     }
 
@@ -298,7 +298,7 @@ struct Target {
      * Target. This is 2^31 - 1 except on 64-bit targets when the LargeBuffers
      * feature is enabled, which expands the maximum to 2^63 - 1. */
     int64_t maximum_buffer_size() const {
-        if (use_large_buffers()) {
+        if (has_large_buffers()) {
             return (((uint64_t)1) << 63) - 1;
         } else {
             return (((uint64_t)1) << 31) - 1;

--- a/src/Target.h
+++ b/src/Target.h
@@ -289,11 +289,16 @@ struct Target {
         return natural_vector_size(type_of<data_t>());
     }
 
+    /** Return true iff 64 bits and has_feature(LargeBuffers). */
+    bool use_large_buffers() const {
+        return bits == 64 && has_feature(LargeBuffers);
+    }
+
     /** Return the maximum buffer size in bytes supported on this
-     * Target. This is 2^31 - 1 except when the LargeBuffers feature
-     * is enabled, which expands the maximum to 2^63 - 1. */
+     * Target. This is 2^31 - 1 except on 64-bit targets when the LargeBuffers
+     * feature is enabled, which expands the maximum to 2^63 - 1. */
     int64_t maximum_buffer_size() const {
-        if (bits == 64 && has_feature(LargeBuffers)) {
+        if (use_large_buffers()) {
             return (((uint64_t)1) << 63) - 1;
         } else {
             return (((uint64_t)1) << 31) - 1;

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1040,7 +1040,7 @@ typedef enum halide_target_feature_t {
 
     halide_target_feature_c_plus_plus_mangling = 30, ///< Generate C++ mangled names for result function, et al
 
-    halide_target_feature_large_buffers = 31, ///< Enable 64-bit buffer indexing to support buffers > 2GB.
+    halide_target_feature_large_buffers = 31, ///< Enable 64-bit buffer indexing to support buffers > 2GB. Ignored if bits != 64.
 
     halide_target_feature_hvx_64 = 32, ///< Enable HVX 64 byte mode.
     halide_target_feature_hvx_128 = 33, ///< Enable HVX 128 byte mode.


### PR DESCRIPTION
Uniformly ignore LargeBuffers if target's bit depth != 64 (only offender was StorageFlattening.cpp). Add use_large_buffers() as helper function to make this easier.