### PR TITLE
Better error messages for device_api to device interface failures.

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -453,22 +453,22 @@ public:
 
     /** Copy to the GPU, using the device API that is the default for the given Target. */
     int copy_to_device(const Target &t = get_jit_target_from_environment()) {
-        return contents->buf.copy_to_device(get_default_device_interface_for_target(t));
+        return copy_to_device(DeviceAPI::Default_GPU, t);
     }
 
     /** Copy to the GPU, using the given device API */
     int copy_to_device(const DeviceAPI &d, const Target &t = get_jit_target_from_environment()) {
-        return contents->buf.copy_to_device(get_device_interface_for_device_api(d, t));
+        return contents->buf.copy_to_device(get_device_interface_for_device_api(d, t, "Buffer::copy_to_device"));
     }
 
     /** Allocate on the GPU, using the device API that is the default for the given Target. */
     int device_malloc(const Target &t = get_jit_target_from_environment()) {
-        return contents->buf.device_malloc(get_default_device_interface_for_target(t));
+        return device_malloc(DeviceAPI::Default_GPU, t);
     }
 
     /** Allocate storage on the GPU, using the given device API */
     int device_malloc(const DeviceAPI &d, const Target &t = get_jit_target_from_environment()) {
-        return contents->buf.device_malloc(get_device_interface_for_device_api(d, t));
+        return contents->buf.device_malloc(get_device_interface_for_device_api(d, t, "Buffer::device_malloc"));
     }
 
     /** Wrap a native handle, using the given device API.
@@ -477,7 +477,7 @@ public:
      * resolves to and it is clearer and more reliable to pass the
      * resolved DeviceAPI explicitly. */
     int device_wrap_native(const DeviceAPI &d, uint64_t handle, const Target &t = get_jit_target_from_environment()) {
-        return contents->buf.device_wrap_native(get_device_interface_for_device_api(d, t), handle);
+        return contents->buf.device_wrap_native(get_device_interface_for_device_api(d, t, "Buffer::device_wrap_native"), handle);
     }
 
 };

--- a/src/DeviceInterface.cpp
+++ b/src/DeviceInterface.cpp
@@ -30,13 +30,18 @@ bool lookup_runtime_routine(const std::string &name,
 
 }
 
-const halide_device_interface_t *get_default_device_interface_for_target(const Target &t) {
-    return get_device_interface_for_device_api(DeviceAPI::Default_GPU, t);
-}
-
-const halide_device_interface_t *get_device_interface_for_device_api(const DeviceAPI &d, const Target &t) {
-    if (d == DeviceAPI::Default_GPU) {
-        return get_device_interface_for_device_api(get_default_device_api_for_target(t), t);
+const halide_device_interface_t *get_device_interface_for_device_api(DeviceAPI d, const Target &t,
+                                                                     const char *error_site) {
+  
+  if (d == DeviceAPI::Default_GPU) {
+        d = get_default_device_api_for_target(t);
+        if (d == DeviceAPI::Host) {
+            if (error_site) {
+                user_error << "get_device_interface_for_device_api called from " << error_site <<
+                  " requested a default GPU but no GPU feature is specified in target (" << t.to_string() << ").\n";
+            }
+            return nullptr;
+        }
     }
 
     const struct halide_device_interface_t *(*fn)();
@@ -52,12 +57,28 @@ const halide_device_interface_t *get_device_interface_for_device_api(const Devic
     } else if (d == DeviceAPI::GLSL) {
         name = "opengl";
     } else {
+        if (error_site) {
+            user_error << "get_device_interface_for_device_api called from " << error_site <<
+                " requested unknown DeviceAPI (" << (int)d << ").\n";
+        }
+        return nullptr;
+    }
+
+    if (!t.supports_device_api(d)) {
+        if (error_site) {
+            user_error << "get_device_interface_for_device_api called from " << error_site <<
+                " DeviceAPI (" << name << ") is not supported by target (" << t.to_string() << ").\n";
+        }
         return nullptr;
     }
 
     if (lookup_runtime_routine("halide_" + name + "_device_interface", t, fn)) {
         return (*fn)();
     } else {
+        if (error_site) {
+              user_error << "get_device_interface_for_device_api called from " << error_site <<
+                  " cannot find runtime or device interface symbol for " << name << ".\n";
+        }
         return nullptr;
     }
 }

--- a/src/DeviceInterface.h
+++ b/src/DeviceInterface.h
@@ -9,18 +9,17 @@
 
 namespace Halide {
 
-/** Get the appropriate halide_device_interface_t * for a
- * target. Corresponds to the device interface that would be used for
- * DeviceAPI::Default_GPU. Creates a GPU runtime module for the target
- * if necessary. Returns nullptr if no device APIs are enabled in the
- * target. */
-EXPORT const halide_device_interface_t *get_default_device_interface_for_target(const Target &t);
-
 /** Gets the appropriate halide_device_interface_t * for a
- * DeviceAPI. Returns null if that device API is not enabled in the
- * target, or if the argument is None or Host. */
-EXPORT const halide_device_interface_t *get_device_interface_for_device_api(const DeviceAPI &d,
-                                                                            const Target &t = get_jit_target_from_environment());
+ * DeviceAPI. If error_site is non-null, e.g. the name of the routine
+ * calling get_device_interface_for_device_api, a user_error is
+ * reported if the requested device API is not enabled in or supported
+ * by the target, Halide has been compiled without this device API, or
+ * the device API is None or Host or a bad value. The error_site
+ * argument is printed in the error message. If error_site is null,
+ * this routine returns nullptr instead of calling user_error. */
+EXPORT const halide_device_interface_t *get_device_interface_for_device_api(DeviceAPI d,
+                                                                            const Target &t = get_jit_target_from_environment(),
+                                                                            const char *error_site = nullptr);
 
 /** Get the specific DeviceAPI that Halide would select when presented
  * with DeviceAPI::Default_GPU for a given target. If no suitable api

--- a/test/error/bad_device_api.cpp
+++ b/test/error/bad_device_api.cpp
@@ -1,0 +1,13 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Target t("host");
+    (void)get_device_interface_for_device_api((DeviceAPI)-1, t, "Bad DeviceAPI");
+    
+    printf("I should not have reached here\n");
+
+    return 0;
+}

--- a/test/error/device_target_mismatch.cpp
+++ b/test/error/device_target_mismatch.cpp
@@ -1,0 +1,13 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Target t("host");
+    (void)get_device_interface_for_device_api(DeviceAPI::CUDA, t, "Device Target Mistmatch Test");
+    
+    printf("I should not have reached here\n");
+
+    return 0;
+}

--- a/test/error/implicit_args.cpp
+++ b/test/error/implicit_args.cpp
@@ -4,7 +4,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-        Var x("x"), y("y"), z("z");
+    Var x("x"), y("y"), z("z");
 
     Func f("f"), g("g"), h("h");
 

--- a/test/error/implicit_args.cpp
+++ b/test/error/implicit_args.cpp
@@ -4,7 +4,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-   	Var x("x"), y("y"), z("z");
+        Var x("x"), y("y"), z("z");
 
     Func f("f"), g("g"), h("h");
 

--- a/test/error/no_default_device.cpp
+++ b/test/error/no_default_device.cpp
@@ -1,0 +1,13 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Target t("host");
+    (void)get_device_interface_for_device_api(DeviceAPI::Default_GPU, t, "No Default Device Test");
+    
+    printf("I should not have reached here\n");
+
+    return 0;
+}


### PR DESCRIPTION
This will help users recognize and fix argument errors around device
API and the target it is paired with. In particular, requesting a
default GPU without specifying one in the target is a common
error. This is currently only wired up to report errors when used
through Halide::Buffer, but that is the common case. (Use of
error_site is both to help pin down where the error occurred and to give
a parameter that preserves the current behavior of returning nullptr
as it is likely some code depends on that.)

Add tests for errors. (Couldn't figure out an easy way to test missing
the runtime so that is not covered.)

Tab cleanup in unrelated file (implicit_args.cpp)

(This is an alternative to https://github.com/halide/Halide/pull/2392 .)