### PR TITLE
.h files for multitargets didn't include legacy buffer_t wrapper decl…

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -582,6 +582,8 @@ void compile_multitarget(const std::string &fn_name,
     if (!output_files.c_header_name.empty()) {
         Module header_module(fn_name, base_target);
         header_module.append(LoweredFunc(fn_name, base_target_args, {}, LoweredFunc::ExternalPlusMetadata));
+        // Add a wrapper to accept old buffer_ts
+        add_legacy_wrapper(header_module, header_module.functions().back());
         Outputs header_out = Outputs().c_header(output_files.c_header_name);
         futures.emplace_back(pool.async([](Module m, Outputs o) {
             debug(1) << "compile_multitarget: c_header_name " << o.c_header_name << "\n";


### PR DESCRIPTION
…arations

The wrapper functions were present in the code, but omitted from the .h that we emit in this case.