### PR TITLE
Add .mat support

### DIFF
--- a/src/runtime/write_debug_image.cpp
+++ b/src/runtime/write_debug_image.cpp
@@ -1,26 +1,45 @@
 #include "HalideRuntime.h"
 
-// Use TIFF because it meets the following criteria:
-// - Supports uncompressed data
-// - Supports 3D images as well as 2D
-// - Supports floating-point samples
-// - Supports an arbitrary number of channels
-// - Can be written with a reasonable amount of code in the runtime.
-//   (E.g. this file instead of linking in another lib)
+// We support three formats, tiff, mat, and tmp.
+//
+// All formats support arbitrary types, and are easy to write in a
+// small amount of code.
+//
+// TIFF:
+// - 2/3-D only
+// - Readable by the most tools
+// mat:
+// - Abitrary dimensionality, type
+// - Readable by matlab, ImageStack, and many other tools
+// tmp:
+// - Dirt simple, easy to roll your own parser
+// - Readable by ImageStack only
+// - Will probably be deprecated in favor of .mat soon
 //
 // It would be nice to use a format that web browsers read and display
 // directly, but those formats don't tend to satisfy the above goals.
 
 namespace Halide { namespace Runtime { namespace Internal {
 
-// See "type_code" in DebugToFile.cpp
+// Mappings from the type_code passed in to the type codes of the
+// formats. See "type_code" in DebugToFile.cpp
+
 // TIFF sample type values are:
 //     1 => Unsigned int
 //     2 => Signed int
 //     3 => Floating-point
-
 WEAK int16_t pixel_type_to_tiff_sample_type[] = {
-  3, 3, 1, 2, 1, 2, 1, 2, 1, 2
+    // float, double, uint8, int8, ... uint64, int64
+    3, 3, 1, 2, 1, 2, 1, 2, 1, 2
+};
+
+// See the .mat level 5 documentation for matlab class codes.
+WEAK uint8_t pixel_type_to_matlab_class_code[] = {
+    7, 6, 9, 8, 11, 10, 13, 12, 15, 14
+};
+
+WEAK uint8_t pixel_type_to_matlab_type_code[] = {
+    7, 9, 2, 1, 4, 3, 6, 5, 13, 12
 };
 
 #pragma pack(push)
@@ -71,30 +90,16 @@ struct halide_tiff_header {
 
 #pragma pack(pop)
 
-WEAK bool has_tiff_extension(const char *filename) {
-    const char *f = filename;
-
-    while (*f != '\0') f++;
-    while (f != filename && *f != '.') f--;
-
-    if (*f != '.') return false;
-    f++;
-
-    if (*f != 't' && *f != 'T') return false;
-    f++;
-
-    if (*f != 'i' && *f != 'I') return false;
-    f++;
-
-    if (*f != 'f' && *f != 'F') return false;
-    f++;
-
-    if (*f == '\0') return true;
-
-    if (*f != 'f' && *f != 'F') return false;
-    f++;
-
-    return *f == '\0';
+WEAK bool ends_with(const char *filename, const char *suffix) {
+    const char *f = filename, *s = suffix;
+    while (*f) f++;
+    while (*s) s++;
+    while (s != suffix && f != filename) {
+        if (*f != *s) return false;
+        f--;
+        s--;
+    }
+    return *f == *s;
 }
 
 }}} // namespace Halide::Runtime::Internal
@@ -110,7 +115,7 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
     halide_copy_to_host(user_context, buf);
 
     void *f = fopen(filename, "wb");
-    if (!f) return -1;
+    if (!f) return -2;
 
     size_t elts = 1;
     halide_dimension_t shape[4];
@@ -125,7 +130,9 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
     }
     int32_t bytes_per_element = buf->type.bytes();
 
-    if (has_tiff_extension(filename)) {
+    uint32_t final_padding_bytes = 0;
+
+    if (ends_with(filename, ".tiff") || ends_with(filename, ".tif")) {
         int32_t channels;
         int32_t width = shape[0].extent;
         int32_t height = shape[1].extent;
@@ -182,7 +189,7 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
 
         if (!fwrite((void *)(&header), sizeof(header), 1, f)) {
             fclose(f);
-            return -2;
+            return -3;
         }
 
         if (channels > 1) {
@@ -191,7 +198,7 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
             for (int32_t i = 0; i < channels; i++) {
                 if (!fwrite((void*)(&offset), 4, 1, f)) {
                     fclose(f);
-                    return -2;
+                    return -4;
                 }
                 offset += shape[0].extent * shape[1].extent * depth * bytes_per_element;
             }
@@ -199,9 +206,84 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
             for (int32_t i = 0; i < channels; i++) {
                 if (!fwrite((void*)(&count), 4, 1, f)) {
                     fclose(f);
-                    return -2;
+                    return -5;
                 }
             }
+        }
+    } else if (ends_with(filename, ".mat")) {
+        // Construct a name for the array from the filename
+        const char *start, *end;
+        for (end = filename; *end; end++);
+        for (; *end != '.'; end--);
+        for (start = end; start != filename && start[-1] != '/'; start--);
+        uint32_t name_size = (uint32_t)(end - start);
+        char array_name[256];
+        char *dst = array_name;
+        while (start != end) {
+            *dst++ = *start++;
+        }
+        while (dst < array_name + sizeof(array_name)) {
+            *dst++ = 0;
+        }
+
+        uint32_t padded_name_size = (name_size + 7) & ~7;
+
+        char header[129] =
+            "MATLAB 5.0 MAT-file, produced by Halide                         "
+            "                                                            \000\001IM";
+
+        fwrite(header, 128, 1, f);
+
+        size_t payload_bytes = buf->size_in_bytes();
+
+        // level 5 .mat files have a size limit
+        if ((uint64_t)payload_bytes >> 32) {
+            halide_error(user_context, "Can't debug_to_file to a .mat file greater than 4GB\n");
+            return -6;
+        }
+
+        int padded_dimensions = (buf->dimensions + 1) & ~1;
+
+        uint32_t tags[] = {
+            // This is a matrix
+            14, 40 + padded_dimensions * 4 + padded_name_size + (uint32_t)payload_bytes,
+            // The element type
+            6, 8, pixel_type_to_matlab_class_code[type_code], 1,
+            // The shape
+            5, buf->dimensions * 4};
+
+        if (!fwrite(&tags, sizeof(tags), 1, f)) {
+            fclose(f);
+            return -7;
+        }
+
+        int extents[] = {shape[0].extent, shape[1].extent, shape[2].extent, shape[3].extent};
+        if (!fwrite(&extents, padded_dimensions * 4, 1, f)) {
+            fclose(f);
+            return -8;
+        }
+
+        // The name
+        uint32_t name_header[2] = {1, name_size};
+        if (!fwrite(&name_header, sizeof(name_header), 1, f)) {
+            fclose(f);
+            return -9;
+        }
+
+        if (!fwrite(array_name, padded_name_size, 1, f)) {
+            fclose(f);
+            return -10;
+        }
+
+        final_padding_bytes = 7 - ((payload_bytes - 1) & 7);
+
+        // Payload header
+        uint32_t payload_header[2] = {
+            pixel_type_to_matlab_type_code[type_code], payload_bytes
+        };
+        if (!fwrite(payload_header, sizeof(payload_header), 1, f)) {
+            fclose(f);
+            return -11;
         }
     } else {
         int32_t header[] = {shape[0].extent,
@@ -211,7 +293,7 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
                             type_code};
         if (!fwrite((void *)(&header[0]), sizeof(header), 1, f)) {
             fclose(f);
-            return -2;
+            return -12;
         }
     }
 
@@ -235,7 +317,7 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
                         counter = 0;
                         if (!fwrite((void *)temp, max_elts * bytes_per_element, 1, f)) {
                             fclose(f);
-                            return -1;
+                            return -13;
                         }
                     }
                 }
@@ -245,9 +327,22 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
     if (counter > 0) {
         if (!fwrite((void *)temp, counter * bytes_per_element, 1, f)) {
             fclose(f);
-            return -1;
+            return -14;
         }
     }
+
+    const uint64_t zero = 0;
+    if (final_padding_bytes) {
+        if (final_padding_bytes > sizeof(zero)) {
+            halide_error(user_context, "Unexpectedly large final_padding_bytes");
+            return -15;
+        }
+        if (!fwrite(&zero, final_padding_bytes, 1, f)) {
+            fclose(f);
+            return -16;
+        }
+    }
+
     fclose(f);
 
     return 0;

--- a/test/correctness/debug_to_file.cpp
+++ b/test/correctness/debug_to_file.cpp
@@ -1,4 +1,8 @@
 #include "Halide.h"
+// Avoid the need to link this test to libjpeg and libpng
+#define HALIDE_NO_JPEG
+#define HALIDE_NO_PNG
+#include "halide_image_io.h"
 #include <stdio.h>
 
 #include "test/common/halide_test_dirs.h"
@@ -7,107 +11,92 @@ using namespace Halide;
 
 int main(int argc, char **argv) {
 
-    std::string f_tmp = Internal::get_test_tmp_dir() + "f.tmp";
-    std::string g_tmp = Internal::get_test_tmp_dir() + "g.tmp";
-    std::string h_tmp = Internal::get_test_tmp_dir() + "h.tmp";
+    std::string f_mat = Internal::get_test_tmp_dir() + "f.mat";
+    std::string g_mat = Internal::get_test_tmp_dir() + "g.mat";
+    std::string h_mat = Internal::get_test_tmp_dir() + "h.mat";
 
-    Internal::ensure_no_file_exists(f_tmp);
-    Internal::ensure_no_file_exists(g_tmp);
-    Internal::ensure_no_file_exists(h_tmp);
+    Internal::ensure_no_file_exists(f_mat);
+    Internal::ensure_no_file_exists(g_mat);
+    Internal::ensure_no_file_exists(h_mat);
 
     {
         Func f, g, h, j;
-        Var x, y;
-        f(x, y) = x + y;
-        g(x, y) = cast<float>(f(x, y) + f(x+1, y));
-        h(x, y) = f(x, y) + g(x, y);
+        Var x, y, z;
+        f(x, y, z) = cast<int32_t>(x + y + z);
+        g(x, y) = cast<float>(f(x, y, 0) + f(x+1, y, 1));
+        h(x, y) = cast<double>(f(x, y, -1) + g(x, y));
 
         Target target = get_jit_target_from_environment();
         if (target.has_gpu_feature()) {
             Var xi, yi;
-            f.compute_root().gpu_tile(x, y, xi, yi, 1, 1).debug_to_file(f_tmp);
-            g.compute_root().gpu_tile(x, y, xi, yi, 1, 1).debug_to_file(g_tmp);
-            h.compute_root().gpu_tile(x, y, xi, yi, 1, 1).debug_to_file(h_tmp);
+            f.compute_root().gpu_tile(x, y, xi, yi, 1, 1).debug_to_file(f_mat);
+            g.compute_root().gpu_tile(x, y, xi, yi, 1, 1).debug_to_file(g_mat);
+            h.compute_root().gpu_tile(x, y, xi, yi, 1, 1).debug_to_file(h_mat);
         } else {
-            f.compute_root().debug_to_file(f_tmp);
-            g.compute_root().debug_to_file(g_tmp);
-            h.compute_root().debug_to_file(h_tmp);
+            f.compute_root().debug_to_file(f_mat);
+            g.compute_root().debug_to_file(g_mat);
+            h.compute_root().debug_to_file(h_mat);
         }
 
-        Buffer<float> im = h.realize(10, 10, target);
+        Buffer<double> im = h.realize(10, 10, target);
     }
 
-    Internal::assert_file_exists(f_tmp);
-    Internal::assert_file_exists(g_tmp);
-    Internal::assert_file_exists(h_tmp);
+    {
+        Internal::assert_file_exists(f_mat);
+        Internal::assert_file_exists(g_mat);
+        Internal::assert_file_exists(h_mat);
 
-    FILE *f = fopen(f_tmp.c_str(), "rb");
-    FILE *g = fopen(g_tmp.c_str(), "rb");
-    FILE *h = fopen(h_tmp.c_str(), "rb");
-    assert(f && g && h);
+        Buffer<int32_t> f = Tools::load_image(f_mat);
+        assert(f.dimensions() == 3 &&
+               f.dim(0).extent() == 11 &&
+               f.dim(1).extent() == 10 &&
+               f.dim(2).extent() == 3);
 
-    int header[5];
-    assert(fread((void *)(&header[0]), 4, 5, f) == 5);
-    assert(header[0] == 11);
-    assert(header[1] == 10);
-    assert(header[2] == 1);
-    assert(header[3] == 1);
-    assert(header[4] == 7);
+        for (int z = 0; z < 3; z++) {
+            for (int y = 0; y < 10; y++) {
+                for (int x = 0; x < 11; x++) {
+                    int32_t val = f(x, y, z);
+                    // The min coord gets lost on debug_to_file, so f should be shifted up by one.
+                    if (val != x + y + z - 1) {
+                        printf("f(%d, %d, %d) = %d instead of %d\n", x, y, z, val, x+y);
+                        return -1;
+                    }
+                }
+            }
+        }
 
-    int32_t f_data[11*10];
-    assert(fread((void *)(&f_data[0]), 4, 11*10, f) == 11*10);
-    for (int y = 0; y < 10; y++) {
-        for (int x = 0; x < 11; x++) {
-            int32_t val = f_data[y*11+x];
-            if (val != x+y) {
-                printf("f_data[%d, %d] = %d instead of %d\n", x, y, val, x+y);
-                return -1;
+        Buffer<float> g = Tools::load_image(g_mat);
+        assert(g.dimensions() == 2 &&
+               g.dim(0).extent() == 10 &&
+               g.dim(1).extent() == 10);
+
+        for (int y = 0; y < 10; y++) {
+            for (int x = 0; x < 10; x++) {
+                float val = g(x, y);
+                float correct = (float)(f(x, y, 1) + f(x + 1, y, 2));
+                if (val != correct) {
+                    printf("g(%d, %d) = %f instead of %f\n", x, y, val, correct);
+                    return -1;
+                }
+            }
+        }
+
+        Buffer<double> h = Tools::load_image(h_mat);
+        assert(h.dimensions() == 2 &&
+               h.dim(0).extent() == 10 &&
+               h.dim(1).extent() == 10);
+
+        for (int y = 0; y < 10; y++) {
+            for (int x = 0; x < 10; x++) {
+                float val = h(x, y);
+                float correct = f(x, y, 0) + g(x, y);
+                if (val != correct) {
+                    printf("h(%d, %d) = %f instead of %f\n", x, y, val, correct);
+                    return -1;
+                }
             }
         }
     }
-    fclose(f);
-
-    assert(fread((void *)(&header[0]), 4, 5, g) == 5);
-    assert(header[0] == 10);
-    assert(header[1] == 10);
-    assert(header[2] == 1);
-    assert(header[3] == 1);
-    assert(header[4] == 0);
-
-    float g_data[10*10];
-    assert(fread((void *)(&g_data[0]), 4, 10*10, g) == 10*10);
-    for (int y = 0; y < 10; y++) {
-        for (int x = 0; x < 10; x++) {
-            float val = g_data[y*10+x];
-            float correct = (float)(f_data[y*11+x] + f_data[y*11+x+1]);
-            if (val != correct) {
-                printf("g_data[%d, %d] = %f instead of %f\n", x, y, val, correct);
-                return -1;
-            }
-        }
-    }
-    fclose(g);
-
-    assert(fread((void *)(&header[0]), 4, 5, h) == 5);
-    assert(header[0] == 10);
-    assert(header[1] == 10);
-    assert(header[2] == 1);
-    assert(header[3] == 1);
-    assert(header[4] == 0);
-
-    float h_data[10*10];
-    assert(fread((void *)(&h_data[0]), 4, 10*10, h) == 10*10);
-    for (int y = 0; y < 10; y++) {
-        for (int x = 0; x < 10; x++) {
-            float val = h_data[y*10+x];
-            float correct = f_data[y*11+x] + g_data[y*10+x];
-            if (val != correct) {
-                printf("h_data[%d, %d] = %f instead of %f\n", x, y, val, correct);
-                return -1;
-            }
-        }
-    }
-    fclose(h);
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/debug_to_file.cpp
+++ b/test/correctness/debug_to_file.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
         Var x, y, z;
         f(x, y, z) = cast<int32_t>(x + y + z);
         g(x, y) = cast<float>(f(x, y, 0) + f(x+1, y, 1));
-        h(x, y) = cast<double>(f(x, y, -1) + g(x, y));
+        h(x, y) = cast<int32_t>(f(x, y, -1) + g(x, y));
 
         Target target = get_jit_target_from_environment();
         if (target.has_gpu_feature()) {
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
             h.compute_root().debug_to_file(h_mat);
         }
 
-        Buffer<double> im = h.realize(10, 10, target);
+        Buffer<int32_t> im = h.realize(10, 10, target);
     }
 
     {
@@ -81,17 +81,17 @@ int main(int argc, char **argv) {
             }
         }
 
-        Buffer<double> h = Tools::load_image(h_mat);
+        Buffer<int32_t> h = Tools::load_image(h_mat);
         assert(h.dimensions() == 2 &&
                h.dim(0).extent() == 10 &&
                h.dim(1).extent() == 10);
 
         for (int y = 0; y < 10; y++) {
             for (int x = 0; x < 10; x++) {
-                float val = h(x, y);
-                float correct = f(x, y, 0) + g(x, y);
+                int32_t val = h(x, y);
+                int32_t correct = f(x, y, 0) + g(x, y);
                 if (val != correct) {
-                    printf("h(%d, %d) = %f instead of %f\n", x, y, val, correct);
+                    printf("h(%d, %d) = %d instead of %d\n", x, y, val, correct);
                     return -1;
                 }
             }

--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -181,7 +181,7 @@ void do_test() {
     luma_buf.copy_from(color_buf);
     luma_buf.slice(2, 0);
 
-    std::vector<std::string> formats = {"ppm","pgm","tmp"};
+    std::vector<std::string> formats = {"ppm","pgm","tmp","mat"};
 #ifndef HALIDE_NO_JPEG
     formats.push_back("jpg");
 #endif
@@ -218,4 +218,3 @@ int main(int argc, char **argv) {
     do_test<uint16_t>();
     return 0;
 }
-

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -292,24 +292,33 @@ struct FileOpener {
         return result;
     }
 
-    bool read_bytes(uint8_t *data, size_t count) {
+    bool read_bytes(void *data, size_t count) {
         return fread(data, 1, count, f) == count;
+    }
+
+    template<typename T, size_t N>
+    bool read_array(T (&data)[N]) {
+        return read_bytes(&data[0], sizeof(T) * N);
     }
 
     template<typename T>
     bool read_vector(std::vector<T> *v) {
-        return read_bytes((uint8_t *)v->data(), v->size() * sizeof(T));
+        return read_bytes(v->data(), v->size() * sizeof(T));
     }
 
-    bool write_bytes(const uint8_t *data, size_t count) {
+    bool write_bytes(const void *data, size_t count) {
         return fwrite(data, 1, count, f) == count;
     }
 
     template<typename T>
     bool write_vector(const std::vector<T> &v) {
-        return write_bytes((const uint8_t *)v.data(), v.size() * sizeof(T));
+        return write_bytes(v.data(), v.size() * sizeof(T));
     }
 
+    template<typename T, size_t N>
+    bool write_array(const T (&data)[N]) {
+        return write_bytes(&data[0], sizeof(T) * N);
+    }
 
     FILE * const f;
 };
@@ -374,7 +383,7 @@ bool load_png(const std::string &filename, ImageType *im) {
         return false;
     }
     png_byte header[8];
-    if (!check(f.read_bytes(header, sizeof(header)), "File ended before end of header")) {
+    if (!check(f.read_array(header), "File ended before end of header")) {
         return false;
     }
     if (!check(!png_sig_cmp(header, 0, 8), "File is not recognized as a PNG file")) {
@@ -820,7 +829,7 @@ bool load_tmp(const std::string &filename, ImageType *im) {
     }
 
     int32_t header[5];
-    if (!check(f.read_bytes((uint8_t*) &header[0], sizeof(header)), "Count not read .tmp header")) {
+    if (!check(f.read_array(header), "Count not read .tmp header")) {
         return false;
     }
 
@@ -838,9 +847,7 @@ bool load_tmp(const std::string &filename, ImageType *im) {
         return false;
     }
 
-    const size_t elem_size = (im_type.bits / 8);
-    size_t count = elem_size * im->number_of_elements();
-    if (!check(f.read_bytes(im->raw_buffer()->host, count), "Count not read .tmp payload")) {
+    if (!check(f.read_bytes(im->begin(), im->size_in_bytes()), "Count not read .tmp payload")) {
         return false;
     }
 
@@ -863,6 +870,26 @@ inline const std::set<FormatInfo> &query_tmp() {
       { halide_type_t(halide_type_int, 64), 4 },
     };
     return info;
+}
+
+template<typename ImageType, CheckFunc check = CheckReturn>
+bool write_planar_payload(ImageType &im, FileOpener &f) {
+    if (im.dimensions() == 0 || buffer_is_compact_planar(im)) {
+        // Contiguous buffer! Write it all in one swell foop.
+        if (!check(f.write_bytes(im.begin(), im.size_in_bytes()), "Count not write .tmp payload")) {
+            return false;
+        }
+    } else {
+        // We have to do this the hard way.
+        int d = im.dimensions() - 1;
+        for (int i = im.dim(d).min(); i <= im.dim(d).max(); i++) {
+            ImageType slice = im.sliced(d, i);
+            if (!write_planar_payload(slice, f)) {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 // ".tmp" is a file format used by the ImageStack tool (see https://github.com/abadams/ImageStack)
@@ -891,43 +918,369 @@ bool save_tmp(ImageType &im, const std::string &filename) {
     if (!check(f.f != nullptr, "File could not be opened for writing")) {
         return false;
     }
-    if (!check(f.write_bytes((uint8_t*) &header[0], sizeof(header)), "Could not write .tmp header")) {
+    if (!check(f.write_array(header), "Could not write .tmp header")) {
         return false;
     }
 
-    const halide_type_t im_type = im.type();
-    const size_t elem_size = (im_type.bits / 8);
-    if (buffer_is_compact_planar(im)) {
-        // Contiguous buffer! Write it all in one swell foop.
-        size_t count = elem_size * im.number_of_elements();
-        if (!check(f.write_bytes(im.raw_buffer()->host, count), "Count not write .tmp payload")) {
-            return false;
-        }
-    } else {
-        // We have to do this the hard way.
-        const uint8_t *base = im.raw_buffer()->host;
-        for (int i3 = im.dim(3).min(); i3 <= im.dim(3).max(); i3++) {
-            for (int i2 = im.dim(2).min(); i2 <= im.dim(2).max(); i2++) {
-                for (int i1 = im.dim(1).min(); i1 <= im.dim(1).max(); i1++) {
-                    for (int i0 = im.dim(0).min(); i0 <= im.dim(0).max(); i0++) {
-                        const size_t offset =
-                            (i0 - im.dim(0).min()) * im.dim(0).stride() +
-                            (i1 - im.dim(1).min()) * im.dim(1).stride() +
-                            (i2 - im.dim(2).min()) * im.dim(2).stride() +
-                            (i3 - im.dim(3).min()) * im.dim(3).stride();
-                        const uint8_t *elem = base + offset * elem_size;
-                        if (!check(f.write_bytes(elem, elem_size), "Count not write .tmp payload")) {
-                            return false;
-                        }
-                    }
-                }
-            }
-        }
+    if (!write_planar_payload<ImageType, check>(im, f)) {
+        return false;
     }
-
 
     return true;
 }
+
+
+// ".mat" is the matlab level 5 format documented here:
+// http://www.mathworks.com/help/pdf_doc/matlab/matfile_format.pdf
+
+
+enum MatlabTypeCode {
+    miINT8 = 1,
+    miUINT8 = 2,
+    miINT16 = 3,
+    miUINT16 = 4,
+    miINT32 = 5,
+    miUINT32 = 6,
+    miSINGLE = 7,
+    miDOUBLE = 9,
+    miINT64 = 12,
+    miUINT64 = 13,
+    miMATRIX = 14,
+    miCOMPRESSED = 15,
+    miUTF8 = 16,
+    miUTF16 = 17,
+    miUTF32 = 18
+};
+
+enum MatlabClassCode {
+    mxCHAR_CLASS = 3,
+    mxDOUBLE_CLASS = 6,
+    mxSINGLE_CLASS = 7,
+    mxINT8_CLASS = 8,
+    mxUINT8_CLASS = 9,
+    mxINT16_CLASS = 10,
+    mxUINT16_CLASS = 11,
+    mxINT32_CLASS = 12,
+    mxUINT32_CLASS = 13,
+    mxINT64_CLASS = 14,
+    mxUINT64_CLASS = 15
+};
+
+template<typename ImageType, CheckFunc check = CheckReturn>
+bool load_mat(const std::string &filename, ImageType *im) {
+    static_assert(!ImageType::has_static_halide_type, "");
+
+    FileOpener f(filename, "rb");
+    if (!check(f.f != nullptr, "File could not be opened for reading")) {
+        return false;
+    }
+
+    uint8_t header[128];
+    if (!check(f.read_array(header), "Could not read .mat header\n")) {
+        return false;
+    }
+
+    // Matrix header
+    uint32_t matrix_header[2];
+    if (!check(f.read_array(matrix_header), "Could not read .mat header\n")) {
+        return false;
+    }
+    if (!check(matrix_header[0] == miMATRIX, "Could not parse this .mat file: bad matrix header\n")) {
+        return false;
+    }
+
+    // Array flags
+    uint32_t flags[4];
+    if (!check(f.read_array(flags), "Could not read .mat header\n")) {
+        return false;
+    }
+    if (!check(flags[0] == miUINT32 && flags[1] == 8, "Could not parse this .mat file: bad flags\n")) {
+        return false;
+    }
+
+    // Shape
+    uint32_t shape_header[2];
+    if (!check(f.read_array(shape_header), "Could not read .mat header\n")) {
+        return false;
+    }
+    if (!check(shape_header[0] == miINT32, "Could not parse this .mat file: bad shape header\n")) {
+        return false;
+    }
+    int dims = shape_header[1]/4;
+    std::vector<int> extents(dims);
+    if (!check(f.read_vector(&extents), "Could not read .mat header\n")) {
+        return false;
+    }
+    if (dims & 1) {
+        uint32_t padding;
+        if (!check(f.read_bytes(&padding, 4), "Could not read .mat header\n")) {
+            return false;
+        }
+    }
+
+    // Skip over the name
+    uint32_t name_header[2];
+    if (!check(f.read_array(name_header), "Could not read .mat header\n")) {
+        return false;
+    }
+
+    if (name_header[0] >> 16) {
+        // Name must be fewer than 4 chars, and so the whole name
+        // field was stored packed into 8 bytes
+    } else {
+        if (!check(name_header[0] == miINT8, "Could not parse this .mat file: bad name header\n")) {
+            return false;
+        }
+        std::vector<uint64_t> scratch((name_header[1] + 7) / 8);
+        if (!check(f.read_vector(&scratch), "Could not read .mat header\n")) {
+            return false;
+        }
+    }
+
+    // Payload header
+    uint32_t payload_header[2];
+    if (!check(f.read_array(payload_header), "Could not read .mat header\n")) {
+        return false;
+    }
+    halide_type_t type;
+    switch (payload_header[0]) {
+    case miINT8:
+        type = halide_type_of<int8_t>();
+        break;
+    case miINT16:
+        type = halide_type_of<int16_t>();
+        break;
+    case miINT32:
+        type = halide_type_of<int32_t>();
+        break;
+    case miINT64:
+        type = halide_type_of<int64_t>();
+        break;
+    case miUINT8:
+        type = halide_type_of<uint8_t>();
+        break;
+    case miUINT16:
+        type = halide_type_of<uint16_t>();
+        break;
+    case miUINT32:
+        type = halide_type_of<uint32_t>();
+        break;
+    case miUINT64:
+        type = halide_type_of<uint64_t>();
+        break;
+    case miSINGLE:
+        type = halide_type_of<float>();
+        break;
+    case miDOUBLE:
+        type = halide_type_of<double>();
+        break;
+    }
+
+    *im = ImageType(type, extents);
+
+    // This should never fail unless the default Buffer<> constructor behavior changes.
+    if (!check(buffer_is_compact_planar(*im), "load_mat() requires compact planar images")) {
+        return false;
+    }
+
+    if (!check(f.read_bytes(im->begin(), im->size_in_bytes()), "Count not read .tmp payload")) {
+        return false;
+    }
+
+    im->set_host_dirty();
+    return true;
+}
+
+inline const std::set<FormatInfo> &query_mat() {
+    // MAT files must have at least 2 dimensions, but there's no upper
+    // bound. Our support arbitrarily stops at 16 dimensions.
+    static std::set<FormatInfo> info = []() {
+        std::set<FormatInfo> s;
+        for (int i = 2; i < 16; i++) {
+            s.insert({ halide_type_t(halide_type_float, 32), i });
+            s.insert({ halide_type_t(halide_type_float, 64), i });
+            s.insert({ halide_type_t(halide_type_uint, 8), i });
+            s.insert({ halide_type_t(halide_type_int, 8), i });
+            s.insert({ halide_type_t(halide_type_uint, 16), i });
+            s.insert({ halide_type_t(halide_type_int, 16), i });
+            s.insert({ halide_type_t(halide_type_uint, 32), i });
+            s.insert({ halide_type_t(halide_type_int, 32), i });
+            s.insert({ halide_type_t(halide_type_uint, 64), i });
+            s.insert({ halide_type_t(halide_type_int, 64), i });
+        }
+        return s;
+    }();
+    return info;
+}
+
+template<typename ImageType, CheckFunc check = CheckReturn>
+bool save_mat(ImageType &im, const std::string &filename) {
+    static_assert(!ImageType::has_static_halide_type, "");
+
+    im.copy_to_host();
+
+    uint32_t class_code = 0, type_code = 0;
+    switch (im.raw_buffer()->type.code) {
+    case halide_type_int:
+        switch (im.raw_buffer()->type.bits) {
+        case 8:
+            class_code = mxINT8_CLASS;
+            type_code = miINT8;
+            break;
+        case 16:
+            class_code = mxINT16_CLASS;
+            type_code = miINT16;
+            break;
+        case 32:
+            class_code = mxINT32_CLASS;
+            type_code = miINT32;
+            break;
+        case 64:
+            class_code = mxINT64_CLASS;
+            type_code = miINT64;
+            break;
+        default:
+            check(false, "unreachable");
+        };
+        break;
+    case halide_type_uint:
+        switch (im.raw_buffer()->type.bits) {
+        case 8:
+            class_code = mxUINT8_CLASS;
+            type_code = miUINT8;
+            break;
+        case 16:
+            class_code = mxUINT16_CLASS;
+            type_code = miUINT16;
+            break;
+        case 32:
+            class_code = mxUINT32_CLASS;
+            type_code = miUINT32;
+            break;
+        case 64:
+            class_code = mxUINT64_CLASS;
+            type_code = miUINT64;
+            break;
+        default:
+            check(false, "unreachable");
+        };
+        break;
+    case halide_type_float:
+        switch (im.raw_buffer()->type.bits) {
+        case 32:
+            class_code = mxSINGLE_CLASS;
+            type_code = miSINGLE;
+            break;
+        case 64:
+            class_code = mxDOUBLE_CLASS;
+            type_code = miDOUBLE;
+            break;
+        default:
+            check(false, "unreachable");
+        };
+        break;
+    case halide_type_handle:
+        check(false, "unreachable");
+    }
+
+
+    FileOpener f(filename, "wb");
+    if (!check(f.f != nullptr, "File could not be opened for writing")) {
+        return false;
+    }
+
+    // Pick a name for the array
+    size_t idx = filename.rfind('.');
+    std::string name = filename.substr(0, idx);
+    idx = filename.rfind('/');
+    if (idx != std::string::npos) {
+        name = name.substr(idx+1);
+    }
+
+    uint32_t name_size = (int)name.size();
+    while (name.size() & 0x7) name += '\0';
+
+    char header[128] = "MATLAB 5.0 MAT-file, produced by Halide";
+    int len = strlen(header);
+    memset(header + len, ' ', sizeof(header) - len);
+
+    // Version
+    *((uint16_t *)(header + 124)) = 0x0100;
+
+    // Endianness check
+    header[126] = 'I';
+    header[127] = 'M';
+
+    uint64_t payload_bytes = im.number_of_elements();
+
+    if (!check((payload_bytes >> 32) == 0, "Buffer too large to save as .mat")) {
+        return false;
+    }
+
+    // Matrix header
+    uint32_t matrix_header[2] = {
+        miMATRIX, 16 + 24 + 8 + (uint32_t)name.size() + 8 + (uint32_t)payload_bytes
+    };
+
+    // Array flags
+    uint32_t flags[4] = {
+        miUINT32, 8, class_code, 1
+    };
+
+    // Shape
+    int32_t shape[2] = {
+        miINT32, im.dimensions() * 4,
+    };
+    std::vector<int> extents(im.dimensions());
+    for (int d = 0; d < im.dimensions(); d++) {
+        extents[d] = im.dim(d).extent();
+    }
+    if (extents.size() & 1) {
+        extents.push_back(0);
+    }
+
+    // Name
+    uint32_t name_header[2] = {
+        miINT8, name_size
+    };
+
+    uint32_t padding_bytes = 7 - ((payload_bytes - 1) & 7);
+
+    // Payload header
+    uint32_t payload_header[2] = {
+        type_code, (uint32_t)payload_bytes
+    };
+
+    bool success =
+        f.write_array(header) &&
+        f.write_array(matrix_header) &&
+        f.write_array(flags) &&
+        f.write_array(shape) &&
+        f.write_vector(extents) &&
+        f.write_array(name_header) &&
+        f.write_bytes(&name[0], name.size()) &&
+        f.write_array(payload_header);
+
+    if (!check(success, "Could not write .mat header")) {
+        return false;
+    }
+
+    if (!write_planar_payload<ImageType, check>(im, f)) {
+        return false;
+    }
+
+    // Padding
+    if (!check(padding_bytes < 8, "Too much padding!\n")) {
+        return false;
+    }
+    uint64_t padding = 0;
+    if (!f.write_bytes(&padding, padding_bytes)) {
+        return false;
+    }
+
+    return true;
+}
+
 
 template<typename ImageType, Internal::CheckFunc check>
 struct ImageIO {
@@ -950,7 +1303,8 @@ bool find_imageio(const std::string &filename, ImageIO<ImageType, check> *result
         {"png", {load_png<ImageType, check>, save_png<ImageType, check>, query_png}},
 #endif
         {"ppm", {load_ppm<ImageType, check>, save_ppm<ImageType, check>, query_ppm}},
-        {"tmp", {load_tmp<ImageType, check>, save_tmp<ImageType, check>, query_tmp}}
+        {"tmp", {load_tmp<ImageType, check>, save_tmp<ImageType, check>, query_tmp}},
+        {"mat", {load_mat<ImageType, check>, save_mat<ImageType, check>, query_mat}}
     };
     std::string ext = Internal::get_lowercase_extension(filename);
     auto it = m.find(ext);

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -1083,7 +1083,7 @@ bool load_mat(const std::string &filename, ImageType *im) {
         return false;
     }
 
-    if (!check(f.read_bytes(im->begin(), im->size_in_bytes()), "Count not read .tmp payload")) {
+    if (!check(f.read_bytes(im->begin(), im->size_in_bytes()), "Could not read .tmp payload")) {
         return false;
     }
 


### PR DESCRIPTION
This is the matlab level 5 format. It's not what matlab currently writes
(unless you set a flag), but matlab (and octave, and scipy, and
imagestack, ...) will be able to read it for the forseeable future, so
it's a good format for dumping things.

It's a fairly simple format, and it has also been added to ImageStack
already, so we should be able to just deprecate .tmp at some point if we
merge this.

TODO: Once HalideTraceDump is in, add .mat as a format option