### PR TITLE
Respect minimum alignment in the cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -545,6 +545,8 @@ HEADERS = $(HEADER_FILES:%.h=$(SRC_DIR)/%.h)
 
 RUNTIME_CPP_COMPONENTS = \
   aarch64_cpu_features \
+  alignment_128 \
+  alignment_32 \
   android_clock \
   android_host_cpu_count \
   android_io \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,8 @@ endif()
 
 set(RUNTIME_CPP
   aarch64_cpu_features
+  alignment_128
+  alignment_32
   android_clock
   android_host_cpu_count
   android_io

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -69,6 +69,8 @@ std::unique_ptr<llvm::Module> parse_bitcode_file(llvm::StringRef buf, llvm::LLVM
     DECLARE_INITMOD(mod ## _ll)
 
 // Universal CPP Initmods. Please keep sorted alphabetically.
+DECLARE_CPP_INITMOD(alignment_128)
+DECLARE_CPP_INITMOD(alignment_32)
 DECLARE_CPP_INITMOD(android_clock)
 DECLARE_CPP_INITMOD(android_host_cpu_count)
 DECLARE_CPP_INITMOD(android_io)
@@ -731,6 +733,14 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_cache(c, bits_64, debug));
             }
             modules.push_back(get_initmod_to_string(c, bits_64, debug));
+
+            if (t.arch == Target::Hexagon ||
+                t.has_feature(Target::HVX_64) ||
+                t.has_feature(Target::HVX_128)) {
+                modules.push_back(get_initmod_alignment_128(c, bits_64, debug));
+            } else {
+                modules.push_back(get_initmod_alignment_32(c, bits_64, debug));
+            }
 
             modules.push_back(get_initmod_device_interface(c, bits_64, debug));
             modules.push_back(get_initmod_metadata(c, bits_64, debug));

--- a/src/runtime/alignment_128.cpp
+++ b/src/runtime/alignment_128.cpp
@@ -1,0 +1,11 @@
+#include "runtime_internal.h"
+
+namespace Halide {
+namespace Runtime {
+namespace Internal {
+
+WEAK __attribute__((always_inline)) int halide_get_minimum_alignment() {
+    return 128;
+}
+
+}}}

--- a/src/runtime/alignment_128.cpp
+++ b/src/runtime/alignment_128.cpp
@@ -4,7 +4,7 @@ namespace Halide {
 namespace Runtime {
 namespace Internal {
 
-WEAK __attribute__((always_inline)) int halide_get_minimum_alignment() {
+WEAK __attribute__((always_inline)) int halide_malloc_alignment() {
     return 128;
 }
 

--- a/src/runtime/alignment_32.cpp
+++ b/src/runtime/alignment_32.cpp
@@ -1,0 +1,11 @@
+#include "runtime_internal.h"
+
+namespace Halide {
+namespace Runtime {
+namespace Internal {
+
+WEAK __attribute__((always_inline)) int halide_get_minimum_alignment() {
+    return 32;
+}
+
+}}}

--- a/src/runtime/alignment_32.cpp
+++ b/src/runtime/alignment_32.cpp
@@ -4,7 +4,7 @@ namespace Halide {
 namespace Runtime {
 namespace Internal {
 
-WEAK __attribute__((always_inline)) int halide_get_minimum_alignment() {
+WEAK __attribute__((always_inline)) int halide_malloc_alignment() {
     return 32;
 }
 

--- a/src/runtime/cache.cpp
+++ b/src/runtime/cache.cpp
@@ -102,7 +102,7 @@ struct CacheBlockHeader {
 // the hash entry.
 WEAK __attribute((always_inline)) size_t header_bytes() {
     size_t s = sizeof(CacheBlockHeader);
-    size_t mask = halide_get_minimum_alignment() - 1;
+    size_t mask = halide_malloc_alignment() - 1;
     return (s + mask) & ~mask;
 }
 

--- a/src/runtime/cache.cpp
+++ b/src/runtime/cache.cpp
@@ -3,13 +3,6 @@
 #include "printer.h"
 #include "scoped_mutex_lock.h"
 
-// This is temporary code. In particular, the hash table is stupid and
-// currently thread safety is accomplished via large granularity spin
-// locks. It is mainly intended to prove the programming model and
-// runtime interface for memoization. We'll improve the implementation
-// later. In the meantime, on some platforms it can be replaced by a
-// platform specific LRU cache such as libcache from Apple.
-
 namespace Halide { namespace Runtime { namespace Internal {
 
 #define CACHE_DEBUGGING 0
@@ -72,14 +65,6 @@ WEAK bool buffer_has_shape(const halide_buffer_t *buf, const halide_dimension_t 
     return true;
 }
 
-// Each host block has extra space to store a header just before the contents.
-// 16 is chosen to keep that alignment.
-// The header holds the cache key hash and pointer to the hash entry.
-//
-// This is an optimization the number of cycles it takes for the cache
-// to operate.
-const size_t extra_bytes_host_bytes = 16;
-
 struct CacheEntry {
     CacheEntry *next;
     CacheEntry *more_recent;
@@ -110,8 +95,19 @@ struct CacheBlockHeader {
     uint32_t hash;
 };
 
+// Each host block has extra space to store a header just before the
+// contents. This block must respect the same alignment as
+// halide_malloc, because it offsets the return value from
+// halide_malloc. The header holds the cache key hash and pointer to
+// the hash entry.
+WEAK __attribute((always_inline)) size_t header_bytes() {
+    size_t s = sizeof(CacheBlockHeader);
+    size_t mask = halide_get_minimum_alignment() - 1;
+    return (s + mask) & ~mask;
+}
+
 WEAK CacheBlockHeader *get_pointer_to_header(uint8_t * host) {
-    return (CacheBlockHeader *)(host - extra_bytes_host_bytes);
+    return (CacheBlockHeader *)(host - header_bytes());
 }
 
 WEAK bool CacheEntry::init(const uint8_t *cache_key, size_t cache_key_size,
@@ -395,8 +391,7 @@ WEAK int halide_memoization_cache_lookup(void *user_context, const uint8_t *cach
     for (int32_t i = 0; i < tuple_count; i++) {
         halide_buffer_t *buf = tuple_buffers[i];
 
-        // See documentation on extra_bytes_host_bytes
-        buf->host = ((uint8_t *)halide_malloc(user_context, buf->size_in_bytes() + extra_bytes_host_bytes));
+        buf->host = ((uint8_t *)halide_malloc(user_context, buf->size_in_bytes() + header_bytes()));
         if (buf->host == NULL) {
             for (int32_t j = i; j > 0; j--) {
                 halide_free(user_context, get_pointer_to_header(tuple_buffers[j - 1]->host));
@@ -404,7 +399,7 @@ WEAK int halide_memoization_cache_lookup(void *user_context, const uint8_t *cach
             }
             return -1;
         }
-        buf->host += extra_bytes_host_bytes;
+        buf->host += header_bytes();
         CacheBlockHeader *header = get_pointer_to_header(buf->host);
         header->hash = h;
         header->entry = NULL;

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -8,7 +8,7 @@ extern void free(void *);
 
 WEAK void *halide_default_malloc(void *user_context, size_t x) {
     // Allocate enough space for aligning the pointer we return.
-    const size_t alignment = halide_get_minimum_alignment();
+    const size_t alignment = halide_malloc_alignment();
     void *orig = malloc(x + alignment);
     if (orig == NULL) {
         // Will result in a failed assertion and a call to halide_error

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -1,4 +1,5 @@
 #include "HalideRuntime.h"
+#include "runtime_internal.h"
 
 extern "C" {
 
@@ -7,7 +8,7 @@ extern void free(void *);
 
 WEAK void *halide_default_malloc(void *user_context, size_t x) {
     // Allocate enough space for aligning the pointer we return.
-    const size_t alignment = 128;
+    const size_t alignment = halide_get_minimum_alignment();
     void *orig = malloc(x + alignment);
     if (orig == NULL) {
         // Will result in a failed assertion and a call to halide_error

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -217,6 +217,8 @@ __attribute__((always_inline)) T reinterpret(const U &x) {
     return ret;
 }
 
+extern WEAK __attribute__((always_inline)) int halide_get_minimum_alignment();
+
 }}}
 
 using namespace Halide::Runtime::Internal;

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -217,7 +217,7 @@ __attribute__((always_inline)) T reinterpret(const U &x) {
     return ret;
 }
 
-extern WEAK __attribute__((always_inline)) int halide_get_minimum_alignment();
+extern WEAK __attribute__((always_inline)) int halide_malloc_alignment();
 
 }}}
 


### PR DESCRIPTION
and make is possible to vary aligmnent per target

Alignment is selected via a runtime module containing an always-inline
function that returns the alignment. It gets constant-folded into its
uses.

Should fix #2422 