### PR TITLE
Autoscheduler bugfix: inlining trivial Funcs into extern Funcs.

### DIFF
--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -3138,9 +3138,17 @@ bool inline_all_trivial_functions(const vector<Function> &outputs,
             for (int j = i + 1; j < (int)order.size() - (int)outputs.size(); ++j) {
                 internal_assert(order[i] != order[j]);
                 Function f2 = env.at(order[j]);
-                debug(5) << "Inline trivial function \"" << f1.name()
-                         << "\" inside \"" << f2.name() << "\"\n";
-                inline_function(f2, f1);
+
+                if( f2.has_extern_definition() &&  !f1.is_wrapper() ) {
+                    debug(5) << "Skip inlining of function \"" << f1.name()
+                             << "\" inside \"" << f2.name() << "\", because "
+                             << "non-wrapper functions cannot be inlined inside "
+                             << "extern functions.\n";
+                } else {
+                    debug(5) << "Inline trivial function \"" << f1.name()
+                             << "\" inside \"" << f2.name() << "\"\n";
+                    inline_function(f2, f1);
+                }
             }
         }
     }

--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -3139,7 +3139,7 @@ bool inline_all_trivial_functions(const vector<Function> &outputs,
                 internal_assert(order[i] != order[j]);
                 Function f2 = env.at(order[j]);
 
-                if( f2.has_extern_definition() &&  !f1.is_wrapper() ) {
+                if (f2.has_extern_definition() &&  !f1.is_wrapper()) {
                     debug(5) << "Skip inlining of function \"" << f1.name()
                              << "\" inside \"" << f2.name() << "\", because "
                              << "non-wrapper functions cannot be inlined inside "

--- a/test/auto_schedule/extern.cpp
+++ b/test/auto_schedule/extern.cpp
@@ -33,7 +33,9 @@ extern "C" DLLEXPORT int translate(buffer_t *in, int dx, int dy, buffer_t *out) 
 
 using namespace Halide;
 
-int main(int argc, char **argv) {
+// Test a pipe with several extern-defined Funcs.
+void test_case_1() {
+
     ImageParam input(UInt(8), 2);
     Var x("x"), y("y");
     Func f0("f0");
@@ -69,6 +71,46 @@ int main(int argc, char **argv) {
 
     // Inspect the schedule
     g.print_loop_nest();
+
+}
+
+// Test with an extern Func which consumes a trivial Func; autoscheduler
+// should not attempt to inline into the extern consumer.
+void test_case_2() {
+
+    ImageParam input(UInt(8), 2);
+    Var x("x"), y("y");
+    Func f0("f0"), f1("f1"), f2("f2"), g("g");
+
+    f0(x, y) = input(x, y) * 2;
+
+    // make f1, which is not a wrapper, but is trivial to inline
+    // into the next extern Func (because print() has no cost)
+    f1(x, y) = print( f0(x, y) );
+
+    f2.define_extern("translate", {f1, Expr(0), Expr(0)}, UInt(8), 2);
+
+    g(x, y) = f2(x, y);
+
+    g.estimate(x, 0, 10).estimate(y, 0, 10);
+    input.dim(0).set_bounds_estimate(0, 10);
+    input.dim(1).set_bounds_estimate(0, 10);
+
+    // Auto-schedule the pipeline
+    Target target = get_jit_target_from_environment();
+    Pipeline p(g);
+
+    p.auto_schedule(target);
+
+    // Inspect the schedule
+    g.print_loop_nest();
+
+}
+
+int main(int argc, char **argv) {
+
+    test_case_1();
+    test_case_2();
 
     printf("Success!\n");
     return 0;

--- a/test/auto_schedule/extern.cpp
+++ b/test/auto_schedule/extern.cpp
@@ -35,7 +35,6 @@ using namespace Halide;
 
 // Test a pipe with several extern-defined Funcs.
 void test_case_1() {
-
     ImageParam input(UInt(8), 2);
     Var x("x"), y("y");
     Func f0("f0");
@@ -71,22 +70,20 @@ void test_case_1() {
 
     // Inspect the schedule
     g.print_loop_nest();
-
 }
 
 // Test with an extern Func which consumes a trivial Func; autoscheduler
 // should not attempt to inline into the extern consumer.
 void test_case_2() {
-
     ImageParam input(UInt(8), 2);
     Var x("x"), y("y");
     Func f0("f0"), f1("f1"), f2("f2"), g("g");
 
     f0(x, y) = input(x, y) * 2;
 
-    // make f1, which is not a wrapper, but is trivial to inline
+    // Create f1, which is not a wrapper, but is trivial to inline
     // into the next extern Func (because print() has no cost)
-    f1(x, y) = print( f0(x, y) );
+    f1(x, y) = print(f0(x, y));
 
     f2.define_extern("translate", {f1, Expr(0), Expr(0)}, UInt(8), 2);
 
@@ -104,11 +101,9 @@ void test_case_2() {
 
     // Inspect the schedule
     g.print_loop_nest();
-
 }
 
 int main(int argc, char **argv) {
-
     test_case_1();
     test_case_2();
 


### PR DESCRIPTION
The autoscheduler can fail if it encounters a "trivial func" (func for which inlining is equal or cheaper than the lowest possible memory cost) which is consumed by an extern func. It will try to inline the trivial Func into the extern Func, which is illegal.

This PR adds a test exposing the problem, and consecutively a fix.