### PR TITLE
"align_storage" only overrides strides instead of both extents and strides

### DIFF
--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -118,6 +118,11 @@ private:
             shader_scope_realizations.pop(op->name);
         }
 
+        // The allocation bounds of the function taken into account of
+        // the align_storage directives. It is only used to determine the
+        // host allocation size and the strides in buffer_t objects (which
+        // also affects the device allocation in some backends).
+        vector<Expr> allocation_bounds(extents.size());
         vector<int> storage_permutation;
         {
             auto iter = env.find(op->name);
@@ -131,7 +136,9 @@ private:
                         storage_permutation.push_back((int)j);
                         Expr alignment = storage_dims[i].alignment;
                         if (alignment.defined()) {
-                            extents[j] = ((extents[j] + alignment - 1)/alignment)*alignment;
+                            allocation_bounds[j] = ((extents[j] + alignment - 1)/alignment)*alignment;
+                        } else {
+                            allocation_bounds[j] = extents[j];
                         }
                     }
                 }
@@ -173,13 +180,13 @@ private:
         stmt = LetStmt::make(op->name + ".buffer", builder.build(), stmt);
 
         // Make the allocation node
-        stmt = Allocate::make(op->name, op->types[0], extents, condition, stmt);
+        stmt = Allocate::make(op->name, op->types[0], allocation_bounds, condition, stmt);
 
         // Compute the strides
         for (int i = (int)op->bounds.size()-1; i > 0; i--) {
             int prev_j = storage_permutation[i-1];
             int j = storage_permutation[i];
-            Expr stride = stride_var[prev_j] * extent_var[prev_j];
+            Expr stride = stride_var[prev_j] * allocation_bounds[prev_j];
             stmt = LetStmt::make(stride_name[j], stride, stmt);
         }
 

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -118,11 +118,11 @@ private:
             shader_scope_realizations.pop(op->name);
         }
 
-        // The allocation bounds of the function taken into account of
+        // The allocation extents of the function taken into account of
         // the align_storage directives. It is only used to determine the
         // host allocation size and the strides in buffer_t objects (which
         // also affects the device allocation in some backends).
-        vector<Expr> allocation_bounds(extents.size());
+        vector<Expr> allocation_extents(extents.size());
         vector<int> storage_permutation;
         {
             auto iter = env.find(op->name);
@@ -136,9 +136,9 @@ private:
                         storage_permutation.push_back((int)j);
                         Expr alignment = storage_dims[i].alignment;
                         if (alignment.defined()) {
-                            allocation_bounds[j] = ((extents[j] + alignment - 1)/alignment)*alignment;
+                            allocation_extents[j] = ((extents[j] + alignment - 1)/alignment)*alignment;
                         } else {
-                            allocation_bounds[j] = extents[j];
+                            allocation_extents[j] = extents[j];
                         }
                     }
                 }
@@ -180,13 +180,13 @@ private:
         stmt = LetStmt::make(op->name + ".buffer", builder.build(), stmt);
 
         // Make the allocation node
-        stmt = Allocate::make(op->name, op->types[0], allocation_bounds, condition, stmt);
+        stmt = Allocate::make(op->name, op->types[0], allocation_extents, condition, stmt);
 
         // Compute the strides
         for (int i = (int)op->bounds.size()-1; i > 0; i--) {
             int prev_j = storage_permutation[i-1];
             int j = storage_permutation[i];
-            Expr stride = stride_var[prev_j] * allocation_bounds[prev_j];
+            Expr stride = stride_var[prev_j] * allocation_extents[prev_j];
             stmt = LetStmt::make(stride_name[j], stride, stmt);
         }
 

--- a/test/correctness/extern_producer.cpp
+++ b/test/correctness/extern_producer.cpp
@@ -24,6 +24,7 @@ int round_down(int x, int m) {
 
 // Imagine that this loads from a file, or tiled storage. Here we'll just fill in the data using sinf.
 extern "C" DLLEXPORT int make_data(halide_buffer_t *out) {
+    static int desired_row_extent = 0;
     if (out->is_bounds_query()) {
         // Bounds query mode. To make life interesting, let's add some
         // arbitrary constraints on what we can produce.
@@ -33,6 +34,7 @@ extern "C" DLLEXPORT int make_data(halide_buffer_t *out) {
         max_plus_one = round_up(max_plus_one, 10);
         out->dim[0].min = round_down(out->dim[0].min, 10);
         out->dim[0].extent = max_plus_one - out->dim[0].min;
+        desired_row_extent = out->dim[0].extent;
 
         // There must be at least 40 scanlines.
         if (out->dim[1].extent < 40) {
@@ -44,6 +46,10 @@ extern "C" DLLEXPORT int make_data(halide_buffer_t *out) {
     assert(out->type == halide_type_of<float>());
     assert(out->dimensions == 2);
     assert(out->dim[0].stride == 1);
+    // Check that the row stride is 128B/32-element aligned.
+    assert(out->dim[1].stride == (out->dim[1].stride)/32*32);
+    // Check that the row extent is not changed due to alignment.
+    assert(out->dim[0].extent == desired_row_extent);
     printf("Generating data over [%d %d] x [%d %d]\n",
            out->dim[0].min, out->dim[0].min + out->dim[0].extent,
            out->dim[1].min, out->dim[1].min + out->dim[1].extent);
@@ -88,53 +94,60 @@ extern "C" DLLEXPORT int make_data_multi(halide_buffer_t *out1, halide_buffer_t 
 }
 
 int main(int argc, char **argv) {
-    Func source;
-    source.define_extern("make_data",
-                         std::vector<ExternFuncArgument>(),
-                         Float(32), 2);
-    Func sink;
     Var x, y;
-    sink(x, y) = source(x, y) - sin(x + y);
-
     Var xi, yi;
-    sink.tile(x, y, xi, yi, 32, 32);
+    {
+        Func source;
+        source.define_extern("make_data",
+                             std::vector<ExternFuncArgument>(),
+                             Float(32), 2);
+        // Row stride should be 128B/32-element aligned.
+        source.align_storage(Var("e0"), 32);
+        Func sink;
+        sink(x, y) = source(x, y) - sin(x + y);
 
-    // Compute the source per tile of sink
-    source.compute_at(sink, x);
+        sink.tile(x, y, xi, yi, 32, 32);
 
-    Buffer<float> output = sink.realize(100, 100);
+        // Compute the source per tile of sink
+        source.compute_at(sink, x);
 
-    // Should be all zeroes.
-    RDom r(output);
-    float error = evaluate_may_gpu<float>(sum(abs(output(r.x, r.y))));
-    if (error != 0) {
-        printf("Something went wrong\n");
-        return -1;
+        Buffer<float> output = sink.realize(100, 100);
+
+        // Should be all zeroes.
+        RDom r(output);
+        float error = evaluate_may_gpu<float>(sum(abs(output(r.x, r.y))));
+        if (error != 0) {
+            printf("Something went wrong\n");
+            return -1;
+        }
     }
 
-    Func multi;
-    std::vector<Type> types;
-    types.push_back(Float(32));
-    types.push_back(Float(32));
-    multi.define_extern("make_data_multi",
-                        std::vector<ExternFuncArgument>(),
-                        types, 2);
-    Func sink_multi;
-    sink_multi(x, y) = multi(x, y)[0] - sin(x + y) +
-                       multi(x, y)[1] - cos(x + y);
+    {
+        Func multi;
+        std::vector<Type> types;
+        types.push_back(Float(32));
+        types.push_back(Float(32));
+        multi.define_extern("make_data_multi",
+                            std::vector<ExternFuncArgument>(),
+                            types, 2);
+        Func sink_multi;
+        sink_multi(x, y) = multi(x, y)[0] - sin(x + y) +
+                multi(x, y)[1] - cos(x + y);
 
-    sink_multi.tile(x, y, xi, yi, 32, 32);
+        sink_multi.tile(x, y, xi, yi, 32, 32);
 
-    // Compute the source per tile of sink
-    multi.compute_at(sink_multi, x);
+        // Compute the source per tile of sink
+        multi.compute_at(sink_multi, x);
 
-    Buffer<float> output_multi = sink_multi.realize(100, 100);
+        Buffer<float> output_multi = sink_multi.realize(100, 100);
 
-    // Should be all zeroes.
-    float error_multi = evaluate<float>(sum(abs(output_multi(r.x, r.y))));
-    if (error_multi != 0) {
-        printf("Something went wrong in multi case\n");
-        return -1;
+        // Should be all zeroes.
+        RDom r(output_multi);
+        float error_multi = evaluate<float>(sum(abs(output_multi(r.x, r.y))));
+        if (error_multi != 0) {
+            printf("Something went wrong in multi case\n");
+            return -1;
+        }
     }
 
     printf("Success!\n");


### PR DESCRIPTION
This helps to avoid over-computation in the extern stage when using
the "align_storage" directive.