### PR TITLE
Generator cleanup

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1084,17 +1084,18 @@ GeneratorBase::ParamInfo::ParamInfo(GeneratorBase *generator, const size_t size)
     }
 
     const auto add_synthetic_params = [this](GIOBase *gio) {
-        if (!gio->allow_synthetic_generator_params()) {
-            return;
-        }
         const std::string &n = gio->name();
         if (gio->kind() != IOKind::Scalar) {
-            owned_synthetic_params.emplace_back(new GeneratorParam_Synthetic<Type>(n + ".type", *gio, GeneratorParam_Synthetic<Type>::Type));
-            generator_params.push_back(owned_synthetic_params.back().get());
-            owned_synthetic_params.emplace_back(new GeneratorParam_Synthetic<int>(n + ".dim", *gio, GeneratorParam_Synthetic<int>::Dim));
-            generator_params.push_back(owned_synthetic_params.back().get());
+            if (!gio->types_defined()) {
+                owned_synthetic_params.emplace_back(new GeneratorParam_Synthetic<Type>(n + ".type", *gio, GeneratorParam_Synthetic<Type>::Type));
+                generator_params.push_back(owned_synthetic_params.back().get());
+            }
+            if (!gio->dims_defined()) {
+                owned_synthetic_params.emplace_back(new GeneratorParam_Synthetic<int>(n + ".dim", *gio, GeneratorParam_Synthetic<int>::Dim));
+                generator_params.push_back(owned_synthetic_params.back().get());
+            }
         }
-        if (gio->is_array()) {
+        if (gio->is_array() && !gio->array_size_defined()) {
             owned_synthetic_params.emplace_back(new GeneratorParam_Synthetic<size_t>(n + ".size", *gio, GeneratorParam_Synthetic<size_t>::ArraySize));
             generator_params.push_back(owned_synthetic_params.back().get());
         }

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -7,7 +7,7 @@ enum class SomeEnum { Foo,
 
 class MetadataTester : public Halide::Generator<MetadataTester> {
 public:
-    Input<Func> input{ "input", Int(16), 2 };  // must be overridden to {UInt(8), 3}
+    Input<Func> input{ "input" };  // must be overridden to {UInt(8), 3}
     Input<Buffer<uint8_t>> typed_input_buffer{ "typed_input_buffer", 3 };
     Input<Buffer<>> type_only_input_buffer{ "type_only_input_buffer", UInt(8) };  // must be overridden to dim=3
     Input<Buffer<>> dim_only_input_buffer{ "dim_only_input_buffer", 3 };  // must be overridden to type=UInt(8)
@@ -39,7 +39,7 @@ public:
     Input<int32_t[2]> array2_i32{ "array2_i32", 32, -32, 127 };
     Input<void *[]> array_h{ "array_h", nullptr };  // must be overridden to size=2
 
-    Output<Func> output{ "output", {Int(16), UInt(8)}, 2 };  // must be overridden to {{Float(32), Float(32)}, 3}
+    Output<Func> output{ "output" };  // must be overridden to {{Float(32), Float(32)}, 3}
     Output<Buffer<float>> typed_output_buffer{ "typed_output_buffer", 3 };
     Output<Buffer<float>> type_only_output_buffer{ "type_only_output_buffer" };  // untyped outputs can have type and/or dimensions inferred
     Output<Buffer<>> dim_only_output_buffer{ "dim_only_output_buffer", 3 };  // untyped outputs can have type and/or dimensions inferred
@@ -52,7 +52,7 @@ public:
     void generate() {
         Var x, y, c;
 
-        // These should both be zero; they are here to exercise the operator[] overloads
+        // These should all be zero; they are here to exercise the operator[] overloads
         Expr zero1 = array_input[1](x, y, c) - array_input[0](x, y, c);
         Expr zero2 = array_i32[1] - array_i32[0];
 


### PR DESCRIPTION
-- only provide synthetic generatorparams for values that aren't explicitly defined
-- add static_assert for Input/Output<Buffer<>[]>; it's not currently supported but failed in weird ways
-- drive-by cleanup of Input/Output<Buffer<>> T -> TBase checking which wasn't really right
-- allow declaring Output<Func> without a type or dim