### PR TITLE
Documentation fix:  buffer_t -> halide_buffer_t

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -893,7 +893,7 @@ public:
         decref();
     }
 
-    /** Get a pointer to the raw buffer_t this wraps. */
+    /** Get a pointer to the raw halide_buffer_t this wraps. */
     // @{
     halide_buffer_t *raw_buffer() {
         return &buf;


### PR DESCRIPTION
The description refers to `buffer_t`, but the method now returns `halide_buffer_t`.