### PR TITLE
Remove the SFINAE cruft from Generator

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1357,12 +1357,12 @@ Pipeline GeneratorBase::build_pipeline() {
 
     // Call the build() method: if it returns an undefined Func(), assume that
     // it's the default (legacy) version and we should call generate()/schedule()
-    // instead. Note that we must advance the phase to 'GenerateCalled' to allow
-    // real build() methods to access GeneratorParams; we must then explicitly
-    // reset the phase back to InputsSet if the build() method is fake and we need
-    // to call generate()/schedule().
+    // instead. Note that we must advance the phase to allow real build() methods
+    // to access GeneratorParams; we must then explicitly reset the phase back to
+    // what it was if the build() method is fake and we need to call generate()/schedule().
     Phase prev_phase = phase;
     advance_phase(GenerateCalled);
+    advance_phase(ScheduleCalled);
     Func f = build();
     if (f.defined()) {
         ParamInfo &pi = param_info();

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2817,7 +2817,7 @@ public:
     template <typename... Args>
     void apply(const Args &...args) {
         set_inputs(args...);
-        (void) get_pipeline();
+        build_pipeline();
     }
 
 private:

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2462,22 +2462,22 @@ public:
     EXPORT std::string auto_schedule_outputs();
     //@}
 
+    EXPORT virtual Func build();
+
 protected:
     EXPORT GeneratorBase(size_t size, const void *introspection_helper);
     EXPORT void set_generator_names(const std::string &registered_name, const std::string &stub_name);
 
-    EXPORT virtual Pipeline build_pipeline() = 0;
-    EXPORT virtual void call_generate() = 0;
-    EXPORT virtual void call_schedule() = 0;
+    EXPORT Pipeline build_pipeline();
+    EXPORT void call_generate();
+    EXPORT void call_schedule();
+
+    EXPORT virtual void generate();
+    EXPORT virtual void schedule();
 
     EXPORT void track_parameter_values(bool include_outputs);
 
-    EXPORT void pre_build();
-    EXPORT void post_build();
-    EXPORT void pre_generate();
-    EXPORT void post_generate();
-    EXPORT void pre_schedule();
-    EXPORT void post_schedule();
+    EXPORT void init_input_output_internals();
 
     template<typename T>
     using Input = GeneratorInput<T>;
@@ -2562,7 +2562,7 @@ private:
 
     mutable std::shared_ptr<ExternsMap> externs_map;
 
-    bool inputs_set{false};
+    bool inputs_set{false}, outputs_set{false};
     std::string generator_registered_name, generator_stub_name;
     Pipeline pipeline;
 
@@ -2816,114 +2816,8 @@ public:
 
     template <typename... Args>
     void apply(const Args &...args) {
-        static_assert(has_generate_method<T>::value && has_schedule_method<T>::value,
-            "apply() is not supported for old-style Generators.");
         set_inputs(args...);
-        call_generate();
-        call_schedule();
-    }
-
-private:
-
-    // std::is_member_function_pointer will fail if there is no member of that name,
-    // so we use a little SFINAE to detect if there are method-shaped members.
-    template<typename>
-    struct type_sink { typedef void type; };
-
-    template<typename T2, typename = void>
-    struct has_generate_method : std::false_type {};
-
-    template<typename T2>
-    struct has_generate_method<T2, typename type_sink<decltype(std::declval<T2>().generate())>::type> : std::true_type {};
-
-    template<typename T2, typename = void>
-    struct has_schedule_method : std::false_type {};
-
-    template<typename T2>
-    struct has_schedule_method<T2, typename type_sink<decltype(std::declval<T2>().schedule())>::type> : std::true_type {};
-
-    template <typename T2 = T,
-              typename std::enable_if<!has_generate_method<T2>::value>::type * = nullptr>
-
-    // Implementations for build_pipeline_impl(), specialized on whether we
-    // have build() or generate()/schedule() methods.
-
-    // MSVC apparently has some weirdness with the usual sfinae tricks
-    // for detecting method-shaped things, so we can't actually use
-    // the helpers above outside of static_assert. Instead we make as
-    // many overloads as we can exist, and then use C++'s preference
-    // for treating a 0 as an int rather than a double to choose one
-    // of them.
-    Pipeline build_pipeline_impl(double) {
-        static_assert(!has_schedule_method<T2>::value, "The schedule() method is ignored if you define a build() method; use generate() instead.");
-        pre_build();
-        Pipeline p = ((T *)this)->build();
-        post_build();
-        return p;
-    }
-
-    template <typename T2 = T,
-              typename = decltype(std::declval<T2>().generate())>
-    Pipeline build_pipeline_impl(int) {
-        ((T *)this)->call_generate_impl(0);
-        ((T *)this)->call_schedule_impl(0, 0);
-        return get_pipeline();
-    }
-
-    // Implementations for call_generate_impl(), specialized on whether we
-    // have build() or generate()/schedule() methods.
-
-    void call_generate_impl(double) {
-        user_error << "Unimplemented";
-    }
-
-    template <typename T2 = T,
-              typename = decltype(std::declval<T2>().generate())>
-    void call_generate_impl(int) {
-        T *t = (T*)this;
-        static_assert(std::is_void<decltype(t->generate())>::value, "generate() must return void");
-        pre_generate();
-        t->generate();
-        post_generate();
-    }
-
-    // Implementations for call_schedule_impl(), specialized on whether we
-    // have build() or generate()/schedule() methods.
-
-    void call_schedule_impl(double, double) {
-        user_error << "Unimplemented";
-    }
-
-    template<typename T2 = T,
-             typename = decltype(std::declval<T2>().generate())>
-    void call_schedule_impl(double, int) {
-        // Generator has a generate() method but no schedule() method. This is ok. Just advance the phase.
-        pre_schedule();
-        post_schedule();
-    }
-
-    template<typename T2 = T,
-             typename = decltype(std::declval<T2>().generate()),
-             typename = decltype(std::declval<T2>().schedule())>
-    void call_schedule_impl(int, int) {
-        T *t = (T*)this;
-        static_assert(std::is_void<decltype(t->schedule())>::value, "schedule() must return void");
-        pre_schedule();
-        t->schedule();
-        post_schedule();
-    }
-
-protected:
-    Pipeline build_pipeline() override {
-        return this->build_pipeline_impl(0);
-    }
-
-    void call_generate() override {
-        this->call_generate_impl(0);
-    }
-
-    void call_schedule() override {
-        this->call_schedule_impl(0, 0);
+        (void) get_pipeline();
     }
 
 private:

--- a/test/generator/buildmethod_generator.cpp
+++ b/test/generator/buildmethod_generator.cpp
@@ -9,6 +9,7 @@ namespace {
 class BuildMethod : public Halide::Generator<BuildMethod> {
 public:
     GeneratorParam<float> compiletime_factor{ "compiletime_factor", 1, 0, 100 };
+    ScheduleParam<int> vectorize{ "vectorize", 1 };
 
     ImageParam input{Halide::Float(32), 3, "input"};
     Param<float> runtime_factor{ "runtime_factor", 1.0 };
@@ -18,6 +19,7 @@ public:
 
         Func g;
         g(x, y, c) = cast<int32_t>(input(x, y, c) * compiletime_factor * runtime_factor);
+        g.vectorize(x, natural_vector_size<int32_t>() * vectorize);
         return g;
     }
 };


### PR DESCRIPTION
Replace the flaky SFINAE nonsense for build()/generate()/schedule() with plain old virtual methods.

The one gotcha here is that build()-returning-Pipeline isn't supported anymore. That's not a problem, though, since using Output<> is a cleaner way to do the same thing, and no instances of build()-returning-Pipeline exist in Halide. (There are a handful downstream that I should be able to convert with trivial effort, but this probably shouldn't land until we're sure we won't break downstream users.)