### PR TITLE
In Bazel+CMake rules, log extra_output locations

### DIFF
--- a/apps/bazeldemo/BUILD
+++ b/apps/bazeldemo/BUILD
@@ -2,7 +2,8 @@ load("@halide//:halide.bzl", "halide_library")
 
 halide_library(
   name="bazeldemo",
-  srcs=["bazeldemo_generator.cpp"]
+  srcs=["bazeldemo_generator.cpp"],
+  extra_outputs=["stmt"],
 )
 
 cc_binary(

--- a/apps/bilateral_grid/CMakeLists.txt
+++ b/apps/bilateral_grid/CMakeLists.txt
@@ -10,6 +10,7 @@ foreach(AUTO_SCHEDULE false true)
     endif()
     halide_library_from_generator(${LIB}
                                   GENERATOR bilateral_grid.generator
-                                  GENERATOR_ARGS auto_schedule=${AUTO_SCHEDULE})
+                                  GENERATOR_ARGS auto_schedule=${AUTO_SCHEDULE}
+                                  EXTRA_OUTPUTS stmt assembly)
     target_link_libraries(bilateral_grid_process PRIVATE ${LIB})
 endforeach()

--- a/bazel/halide.bzl
+++ b/bazel/halide.bzl
@@ -380,6 +380,16 @@ def _gengen_impl(ctx):
     input_manifests = None
     hexagon_code_signer = ""
 
+  progress_message = "Executing generator %s with target (%s) args (%s)." % (
+      ctx.attr.generator_closure.generator_name,
+       ",".join(halide_target),
+       ctx.attr.halide_generator_args)
+  for o in outputs:
+    s = o.path
+    if s.endswith(".h") or s.endswith(".a") or s.endswith(".lib"):
+      continue
+    progress_message += "\nEmitting extra Halide output: %s" % s
+
   env = {
       "HL_DEBUG_CODEGEN": str(ctx.attr.debug_codegen_level),
       "HL_HEXAGON_CODE_SIGNER": hexagon_code_signer,

--- a/halide.cmake
+++ b/halide.cmake
@@ -557,6 +557,15 @@ function(_halide_add_exec_generator_target EXEC_TARGET)
   set(multiValueArgs OUTPUTS GENERATOR_ARGS)
   cmake_parse_arguments(args "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
+  set(EXTRA_OUTPUTS_COMMENT )
+  foreach(OUTPUT ${args_OUTPUTS})
+    if((${OUTPUT} MATCHES "^.*\\.h$") OR (${OUTPUT} MATCHES "^.*${CMAKE_STATIC_LIBRARY_SUFFIX}$"))
+      # Ignore
+    else()
+      set(EXTRA_OUTPUTS_COMMENT "${EXTRA_OUTPUTS_COMMENT}\nEmitting extra Halide output: ${OUTPUT}")
+    endif()
+  endforeach()
+
   add_custom_target(${EXEC_TARGET} DEPENDS ${args_OUTPUTS})
 
   # As of CMake 3.x, add_custom_command() recognizes executable target names in its COMMAND.
@@ -564,6 +573,7 @@ function(_halide_add_exec_generator_target EXEC_TARGET)
     OUTPUT ${args_OUTPUTS}
     DEPENDS ${args_GENERATOR_BINARY}
     COMMAND ${args_GENERATOR_BINARY} ${args_GENERATOR_ARGS}
+    COMMENT "${EXTRA_OUTPUTS_COMMENT}"
   )
   foreach(OUT ${args_OUTPUTS})
     set_source_files_properties(${OUT} PROPERTIES GENERATED TRUE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -326,7 +326,8 @@ if (WITH_TEST_GENERATORS)
   halide_library_from_generator(metadata_tester_ucon
                                 GENERATOR metadata_tester.generator
                                 HALIDE_TARGET_FEATURES user_context
-                                GENERATOR_ARGS "${MDTEST_GEN_ARGS}")
+                                GENERATOR_ARGS "${MDTEST_GEN_ARGS}"
+                                EXTRA_OUTPUTS stmt assembly)
   target_link_libraries(generator_aot_metadata_tester PUBLIC metadata_tester_ucon)
 
   halide_define_aot_test(tiled_blur)


### PR DESCRIPTION
This makes it easier for newcomers to find the extra build artifacts (e.g. .stmt, .schedule). Also add some usage.