### PR TITLE
halide.bzl improvements

### DIFF
--- a/bazel/halide.bzl
+++ b/bazel/halide.bzl
@@ -289,6 +289,8 @@ def _config_settings(halide_target):
   return ["@halide//:%s" % s for (s, _) in _config_setting_names_and_cpus(halide_target)]
 
 
+# The second argument is True if there is a separate file generated
+# for each subtarget of a multitarget output, False if not.
 _output_extensions = {
     "static_library": ("a", False),
     "o": ("o", False),
@@ -350,17 +352,17 @@ def _gengen_impl(ctx):
           ctx.attr.outputs).values()
   ]
 
+  leafname = ctx.attr.filename.split('/')[-1]
   arguments = ["-o", outputs[0].dirname]
   if ctx.attr.generate_runtime:
-    arguments += ["-r", ctx.attr.filename]
+    arguments += ["-r", leafname]
     if len(halide_target) > 1:
       fail("Only one halide_target allowed here")
     if ctx.attr.halide_function_name:
       fail("halide_function_name not allowed here")
   else:
     arguments += ["-g", ctx.attr.generator_closure.generator_name]
-    if ctx.attr.filename:
-      arguments += ["-n", ctx.attr.filename]
+    arguments += ["-n", leafname]
     if ctx.attr.halide_function_name:
       arguments += ["-f", ctx.attr.halide_function_name]
 
@@ -405,10 +407,7 @@ def _gengen_impl(ctx):
       input_manifests=input_manifests,
       inputs=additional_inputs,
       outputs=outputs,
-      progress_message="Executing generator %s with target (%s) args (%s)..." %
-      (ctx.attr.generator_closure.generator_name,
-       ",".join(halide_target),
-       ctx.attr.halide_generator_args)
+      progress_message=progress_message
   )
 
 
@@ -529,16 +528,12 @@ def _define_halide_library_runtime(halide_target_features = []):
   condition_deps = {}
   for base_target, _, _, _ in _HALIDE_TARGET_CONFIG_INFO:
     settings = _config_settings(base_target)
-    if base_target == "armeabi-32-android":
-      # For armeabi-32-android, just generate an arm-32-android runtime
-      halide_target = "arm-32-android"
-    else:
-      halide_target = base_target
-    sub_name = (target_name + "_" +
-                _halide_target_to_bazel_rule_name(base_target))
+    # For armeabi-32-android, just generate an arm-32-android runtime
+    halide_target = "arm-32-android" if base_target == "armeabi-32-android" else base_target
+    halide_target_name = _halide_target_to_bazel_rule_name(base_target);
     _gengen(
-        name=sub_name,
-        filename=sub_name,
+        name="%s_%s" % (halide_target_name, target_name),
+        filename="%s/%s" % (halide_target_name, target_name),
         generate_runtime=True,
         generator_closure="halide_library_runtime.generator_closure",
         halide_target=["-".join([halide_target] + _discard_useless_features(halide_target_features))],
@@ -553,7 +548,7 @@ def _define_halide_library_runtime(halide_target_features = []):
         ]
     )
     for s in settings:
-      condition_deps[s] = [":%s.o" % sub_name]
+      condition_deps[s] = ["%s/%s.o" % (halide_target_name, target_name)]
 
   native.cc_library(
       name=target_name,
@@ -672,7 +667,7 @@ def halide_library_from_generator(name,
                                   deps=[],
                                   extra_outputs=[],
                                   function_name=None,
-                                  generator_args="",
+                                  generator_args=[],
                                   halide_target_features=[],
                                   halide_target_map=halide_library_default_target_map(),
                                   hexagon_code_signer=None,
@@ -685,6 +680,10 @@ def halide_library_from_generator(name,
 
   if namespace:
     function_name = "%s::%s" % (namespace, function_name)
+
+  # For generator_args, we support both arrays of strings, and space separated strings
+  if type(generator_args) != type(""):
+    generator_args = " ".join(generator_args);
 
   # Escape backslashes and double quotes.
   generator_args = generator_args.replace("\\", '\\\\"').replace('"', '\\"')
@@ -701,20 +700,21 @@ def halide_library_from_generator(name,
   if "cpp" in extra_outputs:
     fail("halide_library('%s') doesn't support 'cpp' in extra_outputs; please depend on '%s_cc' instead." % (name, name))
 
-  outputs = ["static_library"] + extra_outputs
   generator_closure = "%s_closure" % generator
 
+  outputs = ["static_library", "h"] + extra_outputs
+
   condition_deps = {}
+  condition_hdrs = {}
   for base_target, _, _, _ in _HALIDE_TARGET_CONFIG_INFO:
     multitarget = _select_multitarget(
         base_target=base_target,
         halide_target_features=full_halide_target_features,
         halide_target_map=halide_target_map)
-    arch = _halide_target_to_bazel_rule_name(base_target)
-    sub_name = "%s_%s" % (name, arch)
+    base_target_name = _halide_target_to_bazel_rule_name(base_target)
     _gengen(
-        name=sub_name,
-        filename=sub_name,
+        name="%s_%s" % (base_target_name, name),
+        filename="%s/%s" % (base_target_name, name),
         halide_generator_args=generator_args,
         generator_closure=generator_closure,
         halide_target=multitarget,
@@ -727,51 +727,50 @@ def halide_library_from_generator(name,
         hexagon_code_signer=hexagon_code_signer,
         tags=["manual"] + tags,
         outputs=outputs)
-    libname = "halide_internal_%s_%s" % (name, arch)
+    libname = "halide_internal_%s_%s" % (name, base_target_name)
     native.cc_library(
         name=libname,
-        srcs=[":%s.a" % sub_name],
+        srcs=["%s/%s.a" % (base_target_name, name)],
+        hdrs=["%s/%s.h" % (base_target_name, name)],
         tags=["manual"] + tags,
         visibility=["//visibility:private"])
-    settings = _config_settings(base_target)
-    for s in settings:
-      condition_deps[s] = _HALIDE_RUNTIME_OVERRIDES.get(base_target, []) + [":%s" % libname]
+    for s in _config_settings(base_target):
+      condition_deps[s] = [":%s" % libname]
+      condition_hdrs[s] = ["%s/%s.h" % (base_target_name, name)]
 
-  # Note that we always build the .h file using the first entry in
-  # the _HALIDE_TARGET_CONFIG_INFO table.
-  header_target = _select_multitarget(
-      base_target=_HALIDE_TARGET_CONFIG_INFO[0][0],
-      halide_target_features=full_halide_target_features,
-      halide_target_map=halide_target_map)
-  if len(header_target) > 1:
-    # This can happen if someone uses halide_target_map
-    # to force everything to be multitarget. In that
-    # case, just use the first entry.
-    header_target = [header_target[0]]
-
-  outputs = ["h"]
-  _gengen(
+  # Copy the header file so that include paths are correct
+  native.genrule(
       name="%s_h" % name,
-      filename=name,
-      halide_generator_args=generator_args,
-      generator_closure=generator_closure,
-      halide_target=header_target,
-      halide_function_name=function_name,
-      outputs=outputs,
-      tags=tags)
-
+      srcs=select(condition_hdrs),
+      outs=["%s.h" % name],
+      cmd="for i in $(SRCS); do cp $$i $(@D); done",
+      tags=tags,
+      visibility=visibility
+  )
   # Create a _cc target for (unusual) applications that want C++ source output;
   # we don't support this via extra_outputs=["cpp"] because it can end up being
   # compiled by Bazel, producing duplicate symbols; also, targets that want this
   # sometimes want to compile it via a separate tool (e.g., XCode to produce
   # certain bitcode variants). Note that this deliberately does not produce
   # a cc_library() output.
+
+  # Use a canonical target to build CC, regardless of config detected
+  cc_target = _select_multitarget(
+      base_target=_HALIDE_TARGET_CONFIG_INFO[0][0],
+      halide_target_features=full_halide_target_features,
+      halide_target_map=halide_target_map)
+  if len(cc_target) > 1:
+    # This can happen if someone uses halide_target_map
+    # to force everything to be multitarget. In that
+    # case, just use the first entry.
+    cc_target = [cc_target[0]]
+
   _gengen(
       name="%s_cc" % name,
       filename=name,
       halide_generator_args=generator_args,
       generator_closure=generator_closure,
-      halide_target=header_target,
+      halide_target=cc_target,
       halide_function_name=function_name,
       outputs=["cpp"],
       tags=["manual"] + tags)
@@ -846,7 +845,7 @@ def halide_library(name,
                    extra_outputs=[],  # "stmt" and/or "assembly" are useful for debugging
                    filter_deps=[],
                    function_name=None,
-                   generator_args="",
+                   generator_args=[],
                    generator_deps=[],
                    generator_name=None,
                    halide_target_features=[],


### PR DESCRIPTION
- allow generator_args to be an array-of-string instead of a string
- rework the way .h files are generated to be a bit more compile-time-efficient