### PR TITLE
Wrap "use std::string" in namespaces

### DIFF
--- a/test/correctness/func_clone.cpp
+++ b/test/correctness/func_clone.cpp
@@ -4,6 +4,8 @@
 #include <stdio.h>
 #include <map>
 
+namespace {
+
 using std::map;
 using std::string;
 
@@ -339,6 +341,8 @@ int clone_on_clone_test() {
     }
     return 0;
 }
+
+}  // namespace
 
 int main(int argc, char **argv) {
     printf("Running calling clone no op test\n");

--- a/test/correctness/func_wrapper.cpp
+++ b/test/correctness/func_wrapper.cpp
@@ -4,6 +4,8 @@
 #include <stdio.h>
 #include <map>
 
+namespace {
+
 using std::map;
 using std::string;
 
@@ -569,6 +571,8 @@ int multi_folds_wrapper_test() {
     }
     return 0;
 }
+
+}  // namespace
 
 int main(int argc, char **argv) {
     printf("Running calling wrap no op test\n");

--- a/test/correctness/host_alignment.cpp
+++ b/test/correctness/host_alignment.cpp
@@ -3,6 +3,8 @@
 #include <map>
 #include <string>
 
+namespace {
+
 using std::vector;
 using std::map;
 using std::string;
@@ -84,6 +86,8 @@ int count_host_alignment_asserts(Func f, std::map<string, int> m) {
     s.accept(&c);
     return c.count;
 }
+
+}  // namespace
 
 int main(int argc, char **argv) {
     Var x, y, c;

--- a/test/correctness/image_wrapper.cpp
+++ b/test/correctness/image_wrapper.cpp
@@ -4,6 +4,8 @@
 #include <stdio.h>
 #include <map>
 
+namespace {
+
 using std::map;
 using std::string;
 
@@ -622,6 +624,8 @@ int multi_folds_wrapper_test() {
     }
     return 0;
 }
+
+}  // namespace
 
 int main(int argc, char **argv) {
     printf("Running calling wrap no op test\n");

--- a/test/correctness/likely.cpp
+++ b/test/correctness/likely.cpp
@@ -1,6 +1,8 @@
 #include "Halide.h"
 #include <stdio.h>
 
+namespace {
+
 using namespace Halide;
 using namespace Halide::Internal;
 using std::string;
@@ -78,6 +80,8 @@ void count_sin_calls(Func g, int correct) {
     g.add_custom_lowering_pass(new CheckSinCount(correct));
     g.compile_to_module(g.infer_arguments());
 }
+
+}  // namespace
 
 int main(int argc, char **argv) {
     Func f;

--- a/test/correctness/predicated_store_load.cpp
+++ b/test/correctness/predicated_store_load.cpp
@@ -7,6 +7,8 @@
 
 #include "test/common/check_call_graphs.h"
 
+namespace {
+
 using std::map;
 using std::vector;
 using std::string;
@@ -387,6 +389,8 @@ int vectorized_predicated_load_const_index_test() {
     }
     return 0;
 }
+
+}  // namespace
 
 int main(int argc, char **argv) {
 

--- a/test/correctness/rfactor.cpp
+++ b/test/correctness/rfactor.cpp
@@ -4,6 +4,8 @@
 #include <stdio.h>
 #include <map>
 
+namespace {
+
 using std::map;
 using std::string;
 
@@ -1030,6 +1032,8 @@ int self_assignment_rfactor_test() {
     }
     return 0;
 }
+
+}  // namespace
 
 int main(int argc, char **argv) {
     printf("Running self assignment rfactor test\n");

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -11,6 +11,8 @@
 using namespace Halide;
 using namespace Halide::ConciseCasts;
 
+namespace {
+
 // This tests that we can correctly generate all the simd ops
 using std::vector;
 using std::string;
@@ -2091,6 +2093,8 @@ check("v*.w += vrmpy(v*.b,v*.b)", hvx_width, i32_1 + i32(i8_1)*i8_1 + i32(i8_2)*
         return success;
     }
 };
+
+}  // namespace
 
 int main(int argc, char **argv) {
     Test test;

--- a/test/correctness/tracing_stack.cpp
+++ b/test/correctness/tracing_stack.cpp
@@ -13,6 +13,9 @@
 #include <string>
 
 using namespace Halide;
+
+namespace {
+
 using std::stack;
 using std::string;
 
@@ -59,6 +62,7 @@ void signal_handler(int signum) {
     exit(0);
 }
 
+}  // namespace
 
 int main(int argc, char **argv) {
 

--- a/test/generator/memory_profiler_mandelbrot_aottest.cpp
+++ b/test/generator/memory_profiler_mandelbrot_aottest.cpp
@@ -10,6 +10,9 @@
 #include "memory_profiler_mandelbrot.h"
 
 using namespace Halide::Runtime;
+
+namespace {
+
 using std::map;
 using std::string;
 
@@ -31,8 +34,6 @@ const int x_niters = (width + tile_x - 1)/tile_x;
 const int mandelbrot_n_mallocs = 2 * y_niters * x_niters * num_launcher_tasks;
 const uint64_t mandelbrot_heap_per_iter = 2*tile_x*tile_y*4*(iters+1); // Heap per iter for one task
 const uint64_t mandelbrot_heap_total = mandelbrot_heap_per_iter * y_niters * x_niters * num_launcher_tasks;
-
-int stack_size = vectorize*sizeof(uint8_t) + vectorize*sizeof(int32_t);
 
 void validate(halide_profiler_state *s) {
     for (halide_profiler_pipeline_stats *p = s->pipelines; p;
@@ -67,6 +68,8 @@ int launcher_task(void *user_context, int index, uint8_t *closure) {
 
     return 0;
 }
+
+}  // namespace
 
 int main(int argc, char **argv) {
     // Hijack halide's runtime to run a bunch of instances of this function


### PR DESCRIPTION
Putting "use std::string" in the global namespace can cause compilation problems in some *cough* environments. Wrap the uses inside test/ in namespace to mitigate this.