### PR TITLE
IRGraphVisitor cleanup

### DIFF
--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -234,10 +234,7 @@ public:
         }
 
         // Visit the children if we haven't been here before.
-        if (!visited.count(e.get())) {
-            visited.insert(e.get());
-            e.accept(this);
-        }
+        IRGraphVisitor::include(e);
     }
 };
 

--- a/src/IRVisitor.cpp
+++ b/src/IRVisitor.cpp
@@ -239,22 +239,16 @@ void IRVisitor::visit(const Shuffle *op) {
 }
 
 void IRGraphVisitor::include(const Expr &e) {
-    if (visited.count(e.get())) {
-        return;
-    } else {
+    if (!visited.count(e.get())) {
         visited.insert(e.get());
         e.accept(this);
-        return;
     }
 }
 
 void IRGraphVisitor::include(const Stmt &s) {
-    if (visited.count(s.get())) {
-        return;
-    } else {
+    if (!visited.count(s.get())) {
         visited.insert(s.get());
         s.accept(this);
-        return;
     }
 }
 

--- a/src/IRVisitor.h
+++ b/src/IRVisitor.h
@@ -80,6 +80,7 @@ protected:
     EXPORT virtual void include(const Stmt &);
     // @}
 
+private:
     /** The nodes visited so far */
     std::set<const IRNode *> visited;
 


### PR DESCRIPTION
- "visited" should be private
- restructure conditionals in include() to be less weird
- ComputeUseCounts should just call IRGraphVisitor::include() rather than duplicating it inline