### PR TITLE
Regularize Parameter getters

### DIFF
--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -433,13 +433,13 @@ Stmt add_image_checks(Stmt s,
                 // constrained to match the first output.
 
                 if (param.defined()) {
-                    user_assert(!param.extent_constraint(i).defined() &&
-                                !param.min_constraint(i).defined())
+                    user_assert(!param.get_extent_constraint(i).defined() &&
+                                !param.get_min_constraint(i).defined())
                         << "Can't constrain the min or extent of an output buffer beyond the "
                         << "first. They are implicitly constrained to have the same min and extent "
                         << "as the first output buffer.\n";
 
-                    stride_constrained = param.stride_constraint(i);
+                    stride_constrained = param.get_stride_constraint(i);
                 } else if (image.defined() && (int)i < image.dimensions()) {
                     stride_constrained = image.dim(i).stride();
                 }
@@ -462,9 +462,9 @@ Stmt add_image_checks(Stmt s,
                 extent_constrained = image.dim(i).extent();
                 min_constrained = image.dim(i).min();
             } else if (param.defined()) {
-                stride_constrained = param.stride_constraint(i);
-                extent_constrained = param.extent_constraint(i);
-                min_constrained = param.min_constraint(i);
+                stride_constrained = param.get_stride_constraint(i);
+                extent_constrained = param.get_extent_constraint(i);
+                min_constrained = param.get_min_constraint(i);
             }
 
             if (stride_constrained.defined()) {
@@ -548,8 +548,8 @@ Stmt add_image_checks(Stmt s,
         }
 
         // and check alignment of the host field
-        if (param.defined() && param.host_alignment() != param.type().bytes()) {
-            int alignment_required = param.host_alignment();
+        if (param.defined() && param.get_host_alignment() != param.type().bytes()) {
+            int alignment_required = param.get_host_alignment();
             Expr u64t_host_ptr = reinterpret<uint64_t>(host_ptr);
             Expr align_condition = (u64t_host_ptr % alignment_required) == 0;
             Expr error = Call::make(Int(32), "halide_error_unaligned_host_ptr",

--- a/src/AlignLoads.cpp
+++ b/src/AlignLoads.cpp
@@ -85,7 +85,7 @@ private:
         int aligned_offset = 0;
         bool known_alignment = false;
         int base_alignment =
-            op->param.defined() ? op->param.host_alignment() : required_alignment;
+            op->param.defined() ? op->param.get_host_alignment() : required_alignment;
         if (base_alignment % required_alignment == 0) {
             // We know the base is aligned. Try to find out the offset
             // of the ramp base from an aligned offset.

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -822,8 +822,8 @@ public:
                 Expr extent = Variable::make(Int(32), buffer_name + ".extent." + std::to_string(d), buf);
 
                 // Respect any output min and extent constraints
-                Expr min_constraint = buf.min_constraint(d);
-                Expr extent_constraint = buf.extent_constraint(d);
+                Expr min_constraint = buf.get_min_constraint(d);
+                Expr extent_constraint = buf.get_extent_constraint(d);
 
                 if (min_constraint.defined()) {
                     min = min_constraint;

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1922,7 +1922,7 @@ void CodeGen_LLVM::codegen_predicated_vector_store(const Store *op) {
         // is aligned to at least the native vector width. However, we may be able to do
         // better than just assuming that it is unaligned.
         if (is_external && op->param.defined()) {
-            int host_alignment = op->param.host_alignment();
+            int host_alignment = op->param.get_host_alignment();
             alignment = gcd(alignment, host_alignment);
         }
 
@@ -2009,7 +2009,7 @@ Value *CodeGen_LLVM::codegen_dense_vector_load(const Load *load, Value *vpred) {
     // is aligned to at least native vector width. However, we may be able to do
     // better than just assuming that it is unaligned.
     if (is_external && load->param.defined()) {
-        int host_alignment = load->param.host_alignment();
+        int host_alignment = load->param.get_host_alignment();
         alignment = gcd(alignment, host_alignment);
     }
 
@@ -3150,7 +3150,7 @@ void CodeGen_LLVM::visit(const Store *op) {
             // is aligned to at least the native vector width. However, we may be able to do
             // better than just assuming that it is unaligned.
             if (is_external && op->param.defined()) {
-                int host_alignment = op->param.host_alignment();
+                int host_alignment = op->param.get_host_alignment();
                 alignment = gcd(alignment, host_alignment);
             }
 

--- a/src/Dimension.cpp
+++ b/src/Dimension.cpp
@@ -32,11 +32,11 @@ Expr Dimension::max() const {
 }
 
 Expr Dimension::min_estimate() const {
-    return param.min_constraint_estimate(d);
+    return param.get_min_constraint_estimate(d);
 }
 
 Expr Dimension::extent_estimate() const {
-    return param.extent_constraint_estimate(d);
+    return param.get_extent_constraint_estimate(d);
 }
 
 Expr Dimension::stride() const {

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -108,14 +108,14 @@ struct FunctionContents {
 
         for (Parameter i : output_buffers) {
             for (size_t j = 0; j < init_def.args().size(); j++) {
-                if (i.min_constraint(j).defined()) {
-                    i.min_constraint(j).accept(visitor);
+                if (i.get_min_constraint(j).defined()) {
+                    i.get_min_constraint(j).accept(visitor);
                 }
-                if (i.stride_constraint(j).defined()) {
-                    i.stride_constraint(j).accept(visitor);
+                if (i.get_stride_constraint(j).defined()) {
+                    i.get_stride_constraint(j).accept(visitor);
                 }
-                if (i.extent_constraint(j).defined()) {
-                    i.extent_constraint(j).accept(visitor);
+                if (i.get_extent_constraint(j).defined()) {
+                    i.get_extent_constraint(j).accept(visitor);
                 }
             }
         }

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -192,12 +192,12 @@ void ValueTracker::track_values(const std::string &name, const std::vector<Expr>
 std::vector<Expr> parameter_constraints(const Parameter &p) {
     internal_assert(p.defined());
     std::vector<Expr> values;
-    values.push_back(Expr(p.host_alignment()));
+    values.push_back(Expr(p.get_host_alignment()));
     if (p.is_buffer()) {
         for (int i = 0; i < p.dimensions(); ++i) {
-            values.push_back(p.min_constraint(i));
-            values.push_back(p.extent_constraint(i));
-            values.push_back(p.stride_constraint(i));
+            values.push_back(p.get_min_constraint(i));
+            values.push_back(p.get_extent_constraint(i));
+            values.push_back(p.get_stride_constraint(i));
         }
     } else {
         values.push_back(p.get_min_value());

--- a/src/InferArguments.cpp
+++ b/src/InferArguments.cpp
@@ -110,9 +110,9 @@ private:
             visit_expr(max);
         } else {
             for (int i = 0; i < p.dimensions(); i++) {
-                visit_expr(p.min_constraint(i));
-                visit_expr(p.extent_constraint(i));
-                visit_expr(p.stride_constraint(i));
+                visit_expr(p.get_min_constraint(i));
+                visit_expr(p.get_extent_constraint(i));
+                visit_expr(p.get_stride_constraint(i));
             }
         }
     }

--- a/src/InjectOpenGLIntrinsics.cpp
+++ b/src/InjectOpenGLIntrinsics.cpp
@@ -58,8 +58,8 @@ private:
             // value of c dimension for ImageParams accessed by GLSL-based filters.
             if (call->param.defined()) {
                 bool const_min_constraint =
-                    call->param.min_constraint(2).defined() &&
-                    is_const(call->param.min_constraint(2));
+                    call->param.get_min_constraint(2).defined() &&
+                    is_const(call->param.get_min_constraint(2));
                 user_assert(const_min_constraint)
                     << "GLSL: Requires minimum for c-dimension set to constant "
                     << "for ImageParam '" << args[0] << "'. "

--- a/src/OutputImageParam.cpp
+++ b/src/OutputImageParam.cpp
@@ -30,7 +30,7 @@ const Dimension OutputImageParam::dim(int i) const {
 }
 
 int OutputImageParam::host_alignment() const {
-    return param.host_alignment();
+    return param.get_host_alignment();
 }
 
 OutputImageParam &OutputImageParam::set_host_alignment(int bytes) {

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -254,37 +254,37 @@ void Parameter::set_host_alignment(int bytes) {
     contents->host_alignment = bytes;
 }
 
-Expr Parameter::min_constraint(int dim) const {
+Expr Parameter::get_min_constraint(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
     return contents->min_constraint[dim];
 }
 
-Expr Parameter::extent_constraint(int dim) const {
+Expr Parameter::get_extent_constraint(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
     return contents->extent_constraint[dim];
 }
 
-Expr Parameter::stride_constraint(int dim) const {
+Expr Parameter::get_stride_constraint(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
     return contents->stride_constraint[dim];
 }
 
-Expr Parameter::min_constraint_estimate(int dim) const {
+Expr Parameter::get_min_constraint_estimate(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
     return contents->min_constraint_estimate[dim];
 }
 
-Expr Parameter::extent_constraint_estimate(int dim) const {
+Expr Parameter::get_extent_constraint_estimate(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
     return contents->extent_constraint_estimate[dim];
 }
 
-int Parameter::host_alignment() const {
+int Parameter::get_host_alignment() const {
     check_is_buffer();
     return contents->host_alignment;
 }

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -130,12 +130,12 @@ public:
     EXPORT void set_min_constraint_estimate(int dim, Expr min);
     EXPORT void set_extent_constraint_estimate(int dim, Expr extent);
     EXPORT void set_host_alignment(int bytes);
-    EXPORT Expr min_constraint(int dim) const;
-    EXPORT Expr extent_constraint(int dim) const;
-    EXPORT Expr stride_constraint(int dim) const;
-    EXPORT Expr min_constraint_estimate(int dim) const;
-    EXPORT Expr extent_constraint_estimate(int dim) const;
-    EXPORT int host_alignment() const;
+    EXPORT Expr get_min_constraint(int dim) const;
+    EXPORT Expr get_extent_constraint(int dim) const;
+    EXPORT Expr get_stride_constraint(int dim) const;
+    EXPORT Expr get_min_constraint_estimate(int dim) const;
+    EXPORT Expr get_extent_constraint_estimate(int dim) const;
+    EXPORT int get_host_alignment() const;
     //@}
 
     /** Get and set constraints for scalar parameters. These are used

--- a/src/RegionCosts.cpp
+++ b/src/RegionCosts.cpp
@@ -28,8 +28,8 @@ class FindImageInputs : public IRVisitor {
             // Call to an ImageParam
             if (call->param.defined() && (seen_image_param.count(call->name) == 0)) {
                 for (int i = 0; i < call->param.dimensions(); ++i) {
-                    const Expr &min = call->param.min_constraint_estimate(i);
-                    const Expr &extent = call->param.extent_constraint_estimate(i);
+                    const Expr &min = call->param.get_min_constraint_estimate(i);
+                    const Expr &extent = call->param.get_extent_constraint_estimate(i);
 
                     user_assert(min.defined())
                         << "AutoSchedule: Estimate of the min value of ImageParam \""


### PR DESCRIPTION
Some of the getters in Internal::Parameter are prefixed with "get_", and others are not. This regularizes by adding "get_" to all of the settable non-boolean properties. (Alternately, we could remove all the "get_" prefixes too....)