### PR TITLE
Add parallel and prefetch scheduling options to hexagon_benchmarks

### DIFF
--- a/apps/hexagon_benchmarks/Makefile
+++ b/apps/hexagon_benchmarks/Makefile
@@ -38,81 +38,85 @@ LINK_OBJS += $(patsubst %,$(BIN)/$$*/%_cpu.o, $(FILTERS))
 UPPERCASE_FILTERS = $(shell echo $(FILTERS) | tr '[:lower:]' '[:upper:]')
 DASH_D_DEFINES = $(patsubst %, -D%=1, $(UPPERCASE_FILTERS))
 
+PARALLEL_SCHED ?= false
+PREFETCH_SCHED ?= false
+SCHEDULING_OPTS = use_parallel_sched=${PARALLEL_SCHED} use_prefetch_sched=${PREFETCH_SCHED}
+
 $(BIN)/%.generator : %_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -O3 -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 $(BIN)/%/conv3x3a16_cpu.o: $(BIN)/conv3x3.generator
 	@mkdir -p $(@D)
-	$^ -g conv3x3 -o $(BIN)/$* -e o,h -f conv3x3a16_cpu target=$* accumulator_type=int16
+	$^ -g conv3x3 -o $(BIN)/$* -e o,h -f conv3x3a16_cpu target=$* accumulator_type=int16 ${SCHEDULING_OPTS}
 
 $(BIN)/%/conv3x3a16_hvx64.o: $(BIN)/conv3x3.generator
 	@mkdir -p $(@D)
-	$^ -g conv3x3 -o $(BIN)/$* -e o,h -f conv3x3a16_hvx64 target=$*-hvx_64 accumulator_type=int16
+	$^ -g conv3x3 -o $(BIN)/$* -e o,h -f conv3x3a16_hvx64 target=$*-hvx_64 accumulator_type=int16 ${SCHEDULING_OPTS}
 
 $(BIN)/%/conv3x3a16_hvx128.o: $(BIN)/conv3x3.generator
 	@mkdir -p $(@D)
-	$^ -g conv3x3 -o $(BIN)/$* -e o,h -f conv3x3a16_hvx128 target=$*-hvx_128 accumulator_type=int16
+	$^ -g conv3x3 -o $(BIN)/$* -e o,h -f conv3x3a16_hvx128 target=$*-hvx_128 accumulator_type=int16 ${SCHEDULING_OPTS}
 
 $(BIN)/%/dilate3x3_cpu.o: $(BIN)/dilate3x3.generator
 	@mkdir -p $(@D)
-	$^ -g dilate3x3 -o $(BIN)/$* -e o,h -f dilate3x3_cpu target=$*
+	$^ -g dilate3x3 -o $(BIN)/$* -e o,h -f dilate3x3_cpu target=$* ${SCHEDULING_OPTS}
 
 $(BIN)/%/dilate3x3_hvx64.o: $(BIN)/dilate3x3.generator
 	@mkdir -p $(@D)
-	$^ -g dilate3x3 -o $(BIN)/$* -e o,h -f dilate3x3_hvx64 target=$*-hvx_64
+	$^ -g dilate3x3 -o $(BIN)/$* -e o,h -f dilate3x3_hvx64 target=$*-hvx_64 ${SCHEDULING_OPTS}
 
 $(BIN)/%/dilate3x3_hvx128.o: $(BIN)/dilate3x3.generator
 	@mkdir -p $(@D)
-	$^ -g dilate3x3 -o $(BIN)/$* -e o,h -f dilate3x3_hvx128 target=$*-hvx_128
+	$^ -g dilate3x3 -o $(BIN)/$* -e o,h -f dilate3x3_hvx128 target=$*-hvx_128 ${SCHEDULING_OPTS}
 
 $(BIN)/%/median3x3_cpu.o: $(BIN)/median3x3.generator
 	@mkdir -p $(@D)
-	$^ -g median3x3 -o $(BIN)/$* -e o,h -f median3x3_cpu target=$*
+	$^ -g median3x3 -o $(BIN)/$* -e o,h -f median3x3_cpu target=$* ${SCHEDULING_OPTS}
 
 $(BIN)/%/median3x3_hvx64.o: $(BIN)/median3x3.generator
 	@mkdir -p $(@D)
-	$^ -g median3x3 -o $(BIN)/$* -e o,h -f median3x3_hvx64 target=$*-hvx_64
+	$^ -g median3x3 -o $(BIN)/$* -e o,h -f median3x3_hvx64 target=$*-hvx_64 ${SCHEDULING_OPTS}
 
 $(BIN)/%/median3x3_hvx128.o: $(BIN)/median3x3.generator
 	@mkdir -p $(@D)
-	$^ -g median3x3 -o $(BIN)/$* -e o,h -f median3x3_hvx128 target=$*-hvx_128
+	$^ -g median3x3 -o $(BIN)/$* -e o,h -f median3x3_hvx128 target=$*-hvx_128 ${SCHEDULING_OPTS}
 
 $(BIN)/%/gaussian5x5_cpu.o: $(BIN)/gaussian5x5.generator
 	@mkdir -p $(@D)
-	$^ -g gaussian5x5 -o $(BIN)/$* -e o,h -f gaussian5x5_cpu target=$*
+	$^ -g gaussian5x5 -o $(BIN)/$* -e o,h -f gaussian5x5_cpu target=$* ${SCHEDULING_OPTS}
 
 $(BIN)/%/gaussian5x5_hvx64.o: $(BIN)/gaussian5x5.generator
 	@mkdir -p $(@D)
-	$^ -g gaussian5x5 -o $(BIN)/$* -e o,h -f gaussian5x5_hvx64 target=$*-hvx_64
+	$^ -g gaussian5x5 -o $(BIN)/$* -e o,h -f gaussian5x5_hvx64 target=$*-hvx_64 ${SCHEDULING_OPTS}
 
 $(BIN)/%/gaussian5x5_hvx128.o: $(BIN)/gaussian5x5.generator
 	@mkdir -p $(@D)
-	$^ -g gaussian5x5 -o $(BIN)/$* -e o,h -f gaussian5x5_hvx128 target=$*-hvx_128
+	$^ -g gaussian5x5 -o $(BIN)/$* -e o,h -f gaussian5x5_hvx128 target=$*-hvx_128 ${SCHEDULING_OPTS}
 
 $(BIN)/%/sobel_cpu.o: $(BIN)/sobel.generator
 	@mkdir -p $(@D)
-	$^ -g sobel -o $(BIN)/$* -e o,h -f sobel_cpu target=$*
+	$^ -g sobel -o $(BIN)/$* -e o,h -f sobel_cpu target=$* ${SCHEDULING_OPTS}
 
 $(BIN)/%/sobel_hvx64.o: $(BIN)/sobel.generator
 	@mkdir -p $(@D)
-	$^ -g sobel -o $(BIN)/$* -e o,h -f sobel_hvx64 target=$*-hvx_64
+	$^ -g sobel -o $(BIN)/$* -e o,h -f sobel_hvx64 target=$*-hvx_64 ${SCHEDULING_OPTS}
 
 $(BIN)/%/sobel_hvx128.o: $(BIN)/sobel.generator
 	@mkdir -p $(@D)
-	$^ -g sobel -o $(BIN)/$* -e o,h -f sobel_hvx128 target=$*-hvx_128
+	$^ -g sobel -o $(BIN)/$* -e o,h -f sobel_hvx128 target=$*-hvx_128 ${SCHEDULING_OPTS}
 
 $(BIN)/%/conv3x3a32_cpu.o: $(BIN)/conv3x3.generator
 	@mkdir -p $(@D)
-	$^ -g conv3x3 -o $(BIN)/$* -e o,h -f conv3x3a32_cpu target=$* accumulator_type=int32
+	$^ -g conv3x3 -o $(BIN)/$* -e o,h -f conv3x3a32_cpu target=$* accumulator_type=int32 ${SCHEDULING_OPTS}
 
 $(BIN)/%/conv3x3a32_hvx64.o: $(BIN)/conv3x3.generator
 	@mkdir -p $(@D)
-	$^ -g conv3x3 -o $(BIN)/$* -e o,h -f conv3x3a32_hvx64 target=$*-hvx_64 accumulator_type=int32
+	$^ -g conv3x3 -o $(BIN)/$* -e o,h -f conv3x3a32_hvx64 target=$*-hvx_64 accumulator_type=int32 ${SCHEDULING_OPTS}
 
 $(BIN)/%/conv3x3a32_hvx128.o: $(BIN)/conv3x3.generator
 	@mkdir -p $(@D)
-	$^ -g conv3x3 -o $(BIN)/$* -e o,h -f conv3x3a32_hvx128 target=$*-hvx_128 accumulator_type=int32
+	$^ -g conv3x3 -o $(BIN)/$* -e o,h -f conv3x3a32_hvx128 target=$*-hvx_128 accumulator_type=int32 ${SCHEDULING_OPTS}
 
 $(BIN)/%/filters.a : $(OBJS)
 	ar q $(BIN)/$*/filters.a $^

--- a/apps/hexagon_benchmarks/Makefile
+++ b/apps/hexagon_benchmarks/Makefile
@@ -38,8 +38,8 @@ LINK_OBJS += $(patsubst %,$(BIN)/$$*/%_cpu.o, $(FILTERS))
 UPPERCASE_FILTERS = $(shell echo $(FILTERS) | tr '[:lower:]' '[:upper:]')
 DASH_D_DEFINES = $(patsubst %, -D%=1, $(UPPERCASE_FILTERS))
 
-PARALLEL_SCHED ?= false
-PREFETCH_SCHED ?= false
+PARALLEL_SCHED ?= true
+PREFETCH_SCHED ?= true
 SCHEDULING_OPTS = use_parallel_sched=${PARALLEL_SCHED} use_prefetch_sched=${PREFETCH_SCHED}
 
 $(BIN)/%.generator : %_generator.cpp $(GENERATOR_DEPS)

--- a/apps/hexagon_benchmarks/conv3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/conv3x3_generator.cpp
@@ -51,11 +51,11 @@ public:
                 .tile(x, y, xi, yi, vector_size, 4, TailStrategy::RoundUp)
                 .vectorize(xi)
                 .unroll(yi);
-            if (use_parallel_sched) {
-                output.parallel(y);
-            }
             if (use_prefetch_sched) {
                 output.prefetch(input, y, 2);
+            }
+            if (use_parallel_sched) {
+                output.parallel(y);
             }
         } else {
             const int vector_size = natural_vector_size<uint8_t>();

--- a/apps/hexagon_benchmarks/conv3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/conv3x3_generator.cpp
@@ -55,7 +55,8 @@ public:
                 output.prefetch(input, y, 2);
             }
             if (use_parallel_sched) {
-                output.parallel(y);
+                Var yo;
+                output.split(y, yo, y, 128).parallel(yo);
             }
         } else {
             const int vector_size = natural_vector_size<uint8_t>();

--- a/apps/hexagon_benchmarks/conv3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/conv3x3_generator.cpp
@@ -11,6 +11,9 @@ public:
     // Outputs an 8 bit image; one channel.
     Output<Buffer<uint8_t>> output{"output", 2};
 
+    GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", false};
+    GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", false};
+
     void generate() {
         bounded_input(x, y) = BoundaryConditions::repeat_edge(input)(x, y);
 
@@ -48,6 +51,12 @@ public:
                 .tile(x, y, xi, yi, vector_size, 4, TailStrategy::RoundUp)
                 .vectorize(xi)
                 .unroll(yi);
+            if (use_parallel_sched) {
+                output.parallel(y);
+            }
+            if (use_prefetch_sched) {
+                output.prefetch(input, y, 2);
+            }
         } else {
             const int vector_size = natural_vector_size<uint8_t>();
             output

--- a/apps/hexagon_benchmarks/conv3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/conv3x3_generator.cpp
@@ -11,8 +11,8 @@ public:
     // Outputs an 8 bit image; one channel.
     Output<Buffer<uint8_t>> output{"output", 2};
 
-    GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", false};
-    GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", false};
+    GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", true};
+    GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", true};
 
     void generate() {
         bounded_input(x, y) = BoundaryConditions::repeat_edge(input)(x, y);

--- a/apps/hexagon_benchmarks/dilate3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/dilate3x3_generator.cpp
@@ -48,7 +48,8 @@ public:
                 output.prefetch(input, y, 2);
             }
             if (use_parallel_sched) {
-                output.parallel(y);
+                Var yo;
+                output.split(y, yo, y, 128).parallel(yo);
             }
         } else {
             const int vector_size = natural_vector_size<uint8_t>();

--- a/apps/hexagon_benchmarks/dilate3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/dilate3x3_generator.cpp
@@ -44,11 +44,11 @@ public:
                 .tile(x, y, xi, yi, vector_size, 4)
                 .vectorize(xi)
                 .unroll(yi);
-            if (use_parallel_sched) {
-                output.parallel(y);
-            }
             if (use_prefetch_sched) {
                 output.prefetch(input, y, 2);
+            }
+            if (use_parallel_sched) {
+                output.parallel(y);
             }
         } else {
             const int vector_size = natural_vector_size<uint8_t>();

--- a/apps/hexagon_benchmarks/dilate3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/dilate3x3_generator.cpp
@@ -9,8 +9,8 @@ public:
     // Outputs an 8 bit image; one channel.
     Output<Buffer<uint8_t>> output{"output", 2};
 
-    GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", false};
-    GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", false};
+    GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", true};
+    GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", true};
 
     void generate() {
         bounded_input(x, y) = BoundaryConditions::repeat_edge(input)(x, y);

--- a/apps/hexagon_benchmarks/dilate3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/dilate3x3_generator.cpp
@@ -9,6 +9,9 @@ public:
     // Outputs an 8 bit image; one channel.
     Output<Buffer<uint8_t>> output{"output", 2};
 
+    GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", false};
+    GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", false};
+
     void generate() {
         bounded_input(x, y) = BoundaryConditions::repeat_edge(input)(x, y);
         max_y(x, y) = max(bounded_input(x, y-1), bounded_input(x, y), bounded_input(x, y+1));
@@ -41,6 +44,12 @@ public:
                 .tile(x, y, xi, yi, vector_size, 4)
                 .vectorize(xi)
                 .unroll(yi);
+            if (use_parallel_sched) {
+                output.parallel(y);
+            }
+            if (use_prefetch_sched) {
+                output.prefetch(input, y, 2);
+            }
         } else {
             const int vector_size = natural_vector_size<uint8_t>();
             output

--- a/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
+++ b/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
@@ -7,6 +7,9 @@ public:
     Input<Buffer<uint8_t>> input{"input", 2};
     Output<Buffer<uint8_t>> output{"output", 2};
 
+    GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", false};
+    GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", false};
+
     void generate() {
         bounded_input(x, y) = BoundaryConditions::repeat_edge(input)(x, y);
 
@@ -48,6 +51,12 @@ public:
                 .tile(x, y, x, y, xi, yi, vector_size, 4, TailStrategy::RoundUp)
                 .vectorize(xi)
                 .unroll(yi);
+            if (use_parallel_sched) {
+                output.parallel(y);
+            }
+            if (use_prefetch_sched) {
+                output.prefetch(input, y, 2);
+            }
         } else {
             const int vector_size = natural_vector_size<uint8_t>();
             output

--- a/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
+++ b/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
@@ -55,7 +55,8 @@ public:
                 output.prefetch(input, y, 2);
             }
             if (use_parallel_sched) {
-                output.parallel(y);
+                Var yo;
+                output.split(y, yo, y, 128).parallel(yo);
             }
         } else {
             const int vector_size = natural_vector_size<uint8_t>();

--- a/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
+++ b/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
@@ -7,8 +7,8 @@ public:
     Input<Buffer<uint8_t>> input{"input", 2};
     Output<Buffer<uint8_t>> output{"output", 2};
 
-    GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", false};
-    GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", false};
+    GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", true};
+    GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", true};
 
     void generate() {
         bounded_input(x, y) = BoundaryConditions::repeat_edge(input)(x, y);

--- a/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
+++ b/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
@@ -51,11 +51,11 @@ public:
                 .tile(x, y, x, y, xi, yi, vector_size, 4, TailStrategy::RoundUp)
                 .vectorize(xi)
                 .unroll(yi);
-            if (use_parallel_sched) {
-                output.parallel(y);
-            }
             if (use_prefetch_sched) {
                 output.prefetch(input, y, 2);
+            }
+            if (use_parallel_sched) {
+                output.parallel(y);
             }
         } else {
             const int vector_size = natural_vector_size<uint8_t>();

--- a/apps/hexagon_benchmarks/median3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/median3x3_generator.cpp
@@ -55,11 +55,11 @@ public:
                 .tile(x, y, xi, yi, vector_size, 4)
                 .vectorize(xi)
                 .unroll(yi);
-            if (use_parallel_sched) {
-                output.parallel(y);
-            }
             if (use_prefetch_sched) {
                 output.prefetch(input, y, 2);
+            }
+            if (use_parallel_sched) {
+                output.parallel(y);
             }
         } else {
             const int vector_size = natural_vector_size<uint8_t>();

--- a/apps/hexagon_benchmarks/median3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/median3x3_generator.cpp
@@ -14,8 +14,8 @@ public:
     // Outputs an 8 bit image; one channel.
     Output<Buffer<uint8_t>> output{"output", 2};
 
-    GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", false};
-    GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", false};
+    GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", true};
+    GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", true};
 
     void generate() {
         bounded_input(x, y) = BoundaryConditions::repeat_edge(input)(x, y);

--- a/apps/hexagon_benchmarks/median3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/median3x3_generator.cpp
@@ -59,7 +59,8 @@ public:
                 output.prefetch(input, y, 2);
             }
             if (use_parallel_sched) {
-                output.parallel(y);
+                Var yo;
+                output.split(y, yo, y, 128).parallel(yo);
             }
         } else {
             const int vector_size = natural_vector_size<uint8_t>();

--- a/apps/hexagon_benchmarks/median3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/median3x3_generator.cpp
@@ -14,6 +14,9 @@ public:
     // Outputs an 8 bit image; one channel.
     Output<Buffer<uint8_t>> output{"output", 2};
 
+    GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", false};
+    GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", false};
+
     void generate() {
         bounded_input(x, y) = BoundaryConditions::repeat_edge(input)(x, y);
         max_y(x,y) = max(bounded_input(x ,y-1), bounded_input(x, y), bounded_input(x, y+1));
@@ -52,6 +55,12 @@ public:
                 .tile(x, y, xi, yi, vector_size, 4)
                 .vectorize(xi)
                 .unroll(yi);
+            if (use_parallel_sched) {
+                output.parallel(y);
+            }
+            if (use_prefetch_sched) {
+                output.prefetch(input, y, 2);
+            }
         } else {
             const int vector_size = natural_vector_size<uint8_t>();
             output

--- a/apps/hexagon_benchmarks/sobel_generator.cpp
+++ b/apps/hexagon_benchmarks/sobel_generator.cpp
@@ -7,6 +7,9 @@ public:
     Input<Buffer<uint8_t>> input{"input", 2};
     Output<Buffer<uint8_t>> output{"output", 2};
 
+    GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", false};
+    GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", false};
+
     void generate() {
         bounded_input(x, y) = BoundaryConditions::repeat_edge(input)(x, y);
 
@@ -46,6 +49,12 @@ public:
                 .tile(x, y, xi, yi, vector_size, 4, TailStrategy::RoundUp)
                 .vectorize(xi)
                 .unroll(yi);
+            if (use_parallel_sched) {
+                output.parallel(y);
+            }
+            if (use_prefetch_sched) {
+                output.prefetch(input, y, 2);
+            }
         } else {
             const int vector_size = natural_vector_size<uint8_t>();
             output

--- a/apps/hexagon_benchmarks/sobel_generator.cpp
+++ b/apps/hexagon_benchmarks/sobel_generator.cpp
@@ -53,7 +53,8 @@ public:
                 output.prefetch(input, y, 2);
             }
             if (use_parallel_sched) {
-                output.parallel(y);
+                Var yo;
+                output.split(y, yo, y, 128).parallel(yo);
             }
         } else {
             const int vector_size = natural_vector_size<uint8_t>();

--- a/apps/hexagon_benchmarks/sobel_generator.cpp
+++ b/apps/hexagon_benchmarks/sobel_generator.cpp
@@ -49,11 +49,11 @@ public:
                 .tile(x, y, xi, yi, vector_size, 4, TailStrategy::RoundUp)
                 .vectorize(xi)
                 .unroll(yi);
-            if (use_parallel_sched) {
-                output.parallel(y);
-            }
             if (use_prefetch_sched) {
                 output.prefetch(input, y, 2);
+            }
+            if (use_parallel_sched) {
+                output.parallel(y);
             }
         } else {
             const int vector_size = natural_vector_size<uint8_t>();

--- a/apps/hexagon_benchmarks/sobel_generator.cpp
+++ b/apps/hexagon_benchmarks/sobel_generator.cpp
@@ -7,8 +7,8 @@ public:
     Input<Buffer<uint8_t>> input{"input", 2};
     Output<Buffer<uint8_t>> output{"output", 2};
 
-    GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", false};
-    GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", false};
+    GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", true};
+    GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", true};
 
     void generate() {
         bounded_input(x, y) = BoundaryConditions::repeat_edge(input)(x, y);


### PR DESCRIPTION
Parallel and prefetch are off by default, and constructed to be
easily runnable with environment variables.

PARALLEL_SCHED=true PREFETCH_SCHED=true make run-arm-64-android