### PR TITLE
Change non-local means benchmark to use one iteration instead of 10

### DIFF
--- a/apps/nl_means/process.cpp
+++ b/apps/nl_means/process.cpp
@@ -33,13 +33,13 @@ int main(int argc, char **argv) {
             input.width(), input.height(), patch_size, search_area, sigma);
 
     // Manually-tuned version
-    double min_t_manual = benchmark(timing_iterations, 10, [&]() {
+    double min_t_manual = benchmark(timing_iterations, 1, [&]() {
         nl_means(input, patch_size, search_area, sigma, output);
     });
     printf("Manually-tuned time: %gms\n", min_t_manual * 1e3);
 
     // Auto-scheduled version
-    double min_t_auto = benchmark(timing_iterations, 10, [&]() {
+    double min_t_auto = benchmark(timing_iterations, 1, [&]() {
         nl_means_auto_schedule(input, patch_size, search_area, sigma, output);
     });
     printf("Auto-scheduled time: %gms\n", min_t_auto * 1e3);


### PR DESCRIPTION
This makes the non-local means benchmark take <10 seconds, down from about a minute. Hopefully this will noticeably speed up the build bots (test_apps is currently one of the longest steps, taking around 20 minutes).