### PR TITLE
Don't return references to temporary objects

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1309,6 +1309,28 @@ public:
     }
 };
 
+// When forwarding methods to ImageParam, Func, etc., we must take
+// care with the return types: many of the methods return a reference-to-self
+// (e.g., ImageParam&); since we create temporaries for most of these forwards,
+// returning a ref will crater because it refers to a now-defunct section of the
+// stack. Happily, simply removing the reference is solves this, since all of the
+// types in question satisfy the property of copies referring to the same underlying
+// structure (returning references is just an optimization). Since this is verbose
+// and used in several places, we'll use a helper macro:
+#define HALIDE_FORWARD_METHOD(Class, Method)                                \
+    template<typename ...Args>                                              \
+    inline auto Method(Args&&... args) ->                                   \
+        typename std::remove_reference<decltype(std::declval<Class>().Method(std::forward<Args>(args)...))>::type { \
+        return ((Class) *this).Method(std::forward<Args>(args)...);          \
+    }
+
+#define HALIDE_FORWARD_METHOD_CONST(Class, Method)                          \
+    template<typename ...Args>                                              \
+    inline auto Method(Args&&... args) const ->                             \
+        typename std::remove_reference<decltype(std::declval<Class>().Method(std::forward<Args>(args)...))>::type { \
+        return ((Class) *this).Method(std::forward<Args>(args)...);          \
+    }
+
 template<typename T>
 class GeneratorInput_Buffer : public GeneratorInputImpl<T, Func> {
 private:
@@ -1392,38 +1414,21 @@ public:
         return ImageParam(this->parameter(), Func(*this));
     }
 
-#define HALIDE_INPUT_FORWARD(method)                                       \
-    template<typename ...Args>                                              \
-    inline auto method(Args&&... args) ->                                   \
-        decltype(std::declval<ImageParam>().method(std::forward<Args>(args)...)) {\
-        return ((ImageParam) *this).method(std::forward<Args>(args)...);          \
-    }
-
-#define HALIDE_INPUT_FORWARD_CONST(method)                                 \
-    template<typename ...Args>                                              \
-    inline auto method(Args&&... args) const ->                             \
-        decltype(std::declval<ImageParam>().method(std::forward<Args>(args)...)) {\
-        return ((ImageParam) *this).method(std::forward<Args>(args)...);          \
-    }
-
     /** Forward methods to the ImageParam. */
     // @{
-    HALIDE_INPUT_FORWARD(dim)
-    HALIDE_INPUT_FORWARD_CONST(dim)
-    HALIDE_INPUT_FORWARD_CONST(host_alignment)
-    HALIDE_INPUT_FORWARD(set_host_alignment)
-    HALIDE_INPUT_FORWARD_CONST(dimensions)
-    HALIDE_INPUT_FORWARD_CONST(left)
-    HALIDE_INPUT_FORWARD_CONST(right)
-    HALIDE_INPUT_FORWARD_CONST(top)
-    HALIDE_INPUT_FORWARD_CONST(bottom)
-    HALIDE_INPUT_FORWARD_CONST(width)
-    HALIDE_INPUT_FORWARD_CONST(height)
-    HALIDE_INPUT_FORWARD_CONST(channels)
+    HALIDE_FORWARD_METHOD(ImageParam, dim)
+    HALIDE_FORWARD_METHOD_CONST(ImageParam, dim)
+    HALIDE_FORWARD_METHOD_CONST(ImageParam, host_alignment)
+    HALIDE_FORWARD_METHOD(ImageParam, set_host_alignment)
+    HALIDE_FORWARD_METHOD_CONST(ImageParam, dimensions)
+    HALIDE_FORWARD_METHOD_CONST(ImageParam, left)
+    HALIDE_FORWARD_METHOD_CONST(ImageParam, right)
+    HALIDE_FORWARD_METHOD_CONST(ImageParam, top)
+    HALIDE_FORWARD_METHOD_CONST(ImageParam, bottom)
+    HALIDE_FORWARD_METHOD_CONST(ImageParam, width)
+    HALIDE_FORWARD_METHOD_CONST(ImageParam, height)
+    HALIDE_FORWARD_METHOD_CONST(ImageParam, channels)
     // }@
-
-#undef HALIDE_INPUT_FORWARD
-#undef HALIDE_INPUT_FORWARD_CONST
 };
 
 
@@ -1512,33 +1517,22 @@ public:
         return Func(*this).in(others);
     }
 
-#define HALIDE_INPUT_FORWARD_CONST(method)                                   \
-    template<typename ...Args>                                               \
-    inline auto method(Args&&... args) const ->                              \
-        decltype(std::declval<Func>().method(std::forward<Args>(args)...)) { \
-        user_assert(this->funcs().size() == 1) << "Use operator[] to access the Func you want"; \
-        return Func(*this).method(std::forward<Args>(args)...);              \
-    }
-
     /** Forward const methods to the underlying Func. (Non-const methods
      * aren't available for Input<Func>.) */
     // @{
-    HALIDE_INPUT_FORWARD_CONST(args)
-    HALIDE_INPUT_FORWARD_CONST(defined)
-    HALIDE_INPUT_FORWARD_CONST(has_update_definition)
-    HALIDE_INPUT_FORWARD_CONST(num_update_definitions)
-    HALIDE_INPUT_FORWARD_CONST(output_types)
-    HALIDE_INPUT_FORWARD_CONST(outputs)
-    HALIDE_INPUT_FORWARD_CONST(rvars)
-    HALIDE_INPUT_FORWARD_CONST(update_args)
-    HALIDE_INPUT_FORWARD_CONST(update_value)
-    HALIDE_INPUT_FORWARD_CONST(update_values)
-    HALIDE_INPUT_FORWARD_CONST(value)
-    HALIDE_INPUT_FORWARD_CONST(values)
+    HALIDE_FORWARD_METHOD_CONST(Func, args)
+    HALIDE_FORWARD_METHOD_CONST(Func, defined)
+    HALIDE_FORWARD_METHOD_CONST(Func, has_update_definition)
+    HALIDE_FORWARD_METHOD_CONST(Func, num_update_definitions)
+    HALIDE_FORWARD_METHOD_CONST(Func, output_types)
+    HALIDE_FORWARD_METHOD_CONST(Func, outputs)
+    HALIDE_FORWARD_METHOD_CONST(Func, rvars)
+    HALIDE_FORWARD_METHOD_CONST(Func, update_args)
+    HALIDE_FORWARD_METHOD_CONST(Func, update_value)
+    HALIDE_FORWARD_METHOD_CONST(Func, update_values)
+    HALIDE_FORWARD_METHOD_CONST(Func, value)
+    HALIDE_FORWARD_METHOD_CONST(Func, values)
     // }@
-
-#undef HALIDE_INPUT_FORWARD
-#undef HALIDE_INPUT_FORWARD_CONST
 };
 
 
@@ -1739,73 +1733,66 @@ namespace Internal {
 
 
 class GeneratorOutputBase : public GIOBase {
+    NO_INLINE operator Func() const {
+        internal_assert(kind() != IOKind::Scalar);
+        internal_assert(exprs_.empty());
+        user_assert(funcs_.size() == 1) << "Use [] to access individual Funcs in Output<Func[]>";
+        return funcs_[0];
+    }
+
 public:
-#define HALIDE_OUTPUT_FORWARD(method)                                       \
-    template<typename ...Args>                                              \
-    inline auto method(Args&&... args) ->                                   \
-        decltype(std::declval<Func>().method(std::forward<Args>(args)...)) {\
-        return get_func_ref().method(std::forward<Args>(args)...);          \
-    }
-
-#define HALIDE_OUTPUT_FORWARD_CONST(method)                                 \
-    template<typename ...Args>                                              \
-    inline auto method(Args&&... args) const ->                             \
-        decltype(std::declval<Func>().method(std::forward<Args>(args)...)) {\
-        return get_func_ref().method(std::forward<Args>(args)...);          \
-    }
-
     /** Forward schedule-related methods to the underlying Func. */
     // @{
-    HALIDE_OUTPUT_FORWARD(align_bounds)
-    HALIDE_OUTPUT_FORWARD(align_storage)
-    HALIDE_OUTPUT_FORWARD_CONST(args)
-    HALIDE_OUTPUT_FORWARD(bound)
-    HALIDE_OUTPUT_FORWARD(bound_extent)
-    HALIDE_OUTPUT_FORWARD(compute_at)
-    HALIDE_OUTPUT_FORWARD(compute_inline)
-    HALIDE_OUTPUT_FORWARD(compute_root)
-    HALIDE_OUTPUT_FORWARD(define_extern)
-    HALIDE_OUTPUT_FORWARD_CONST(defined)
-    HALIDE_OUTPUT_FORWARD(estimate)
-    HALIDE_OUTPUT_FORWARD(fold_storage)
-    HALIDE_OUTPUT_FORWARD(fuse)
-    HALIDE_OUTPUT_FORWARD(glsl)
-    HALIDE_OUTPUT_FORWARD(gpu)
-    HALIDE_OUTPUT_FORWARD(gpu_blocks)
-    HALIDE_OUTPUT_FORWARD(gpu_single_thread)
-    HALIDE_OUTPUT_FORWARD(gpu_threads)
-    HALIDE_OUTPUT_FORWARD(gpu_tile)
-    HALIDE_OUTPUT_FORWARD_CONST(has_update_definition)
-    HALIDE_OUTPUT_FORWARD(hexagon)
-    HALIDE_OUTPUT_FORWARD(in)
-    HALIDE_OUTPUT_FORWARD(memoize)
-    HALIDE_OUTPUT_FORWARD_CONST(num_update_definitions)
-    HALIDE_OUTPUT_FORWARD_CONST(output_types)
-    HALIDE_OUTPUT_FORWARD_CONST(outputs)
-    HALIDE_OUTPUT_FORWARD(parallel)
-    HALIDE_OUTPUT_FORWARD(prefetch)
-    HALIDE_OUTPUT_FORWARD(print_loop_nest)
-    HALIDE_OUTPUT_FORWARD(rename)
-    HALIDE_OUTPUT_FORWARD(reorder)
-    HALIDE_OUTPUT_FORWARD(reorder_storage)
-    HALIDE_OUTPUT_FORWARD_CONST(rvars)
-    HALIDE_OUTPUT_FORWARD(serial)
-    HALIDE_OUTPUT_FORWARD(shader)
-    HALIDE_OUTPUT_FORWARD(specialize)
-    HALIDE_OUTPUT_FORWARD(specialize_fail)
-    HALIDE_OUTPUT_FORWARD(split)
-    HALIDE_OUTPUT_FORWARD(store_at)
-    HALIDE_OUTPUT_FORWARD(store_root)
-    HALIDE_OUTPUT_FORWARD(tile)
-    HALIDE_OUTPUT_FORWARD(trace_stores)
-    HALIDE_OUTPUT_FORWARD(unroll)
-    HALIDE_OUTPUT_FORWARD(update)
-    HALIDE_OUTPUT_FORWARD_CONST(update_args)
-    HALIDE_OUTPUT_FORWARD_CONST(update_value)
-    HALIDE_OUTPUT_FORWARD_CONST(update_values)
-    HALIDE_OUTPUT_FORWARD_CONST(value)
-    HALIDE_OUTPUT_FORWARD_CONST(values)
-    HALIDE_OUTPUT_FORWARD(vectorize)
+    HALIDE_FORWARD_METHOD(Func, align_bounds)
+    HALIDE_FORWARD_METHOD(Func, align_storage)
+    HALIDE_FORWARD_METHOD_CONST(Func, args)
+    HALIDE_FORWARD_METHOD(Func, bound)
+    HALIDE_FORWARD_METHOD(Func, bound_extent)
+    HALIDE_FORWARD_METHOD(Func, compute_at)
+    HALIDE_FORWARD_METHOD(Func, compute_inline)
+    HALIDE_FORWARD_METHOD(Func, compute_root)
+    HALIDE_FORWARD_METHOD(Func, define_extern)
+    HALIDE_FORWARD_METHOD_CONST(Func, defined)
+    HALIDE_FORWARD_METHOD(Func, estimate)
+    HALIDE_FORWARD_METHOD(Func, fold_storage)
+    HALIDE_FORWARD_METHOD(Func, fuse)
+    HALIDE_FORWARD_METHOD(Func, glsl)
+    HALIDE_FORWARD_METHOD(Func, gpu)
+    HALIDE_FORWARD_METHOD(Func, gpu_blocks)
+    HALIDE_FORWARD_METHOD(Func, gpu_single_thread)
+    HALIDE_FORWARD_METHOD(Func, gpu_threads)
+    HALIDE_FORWARD_METHOD(Func, gpu_tile)
+    HALIDE_FORWARD_METHOD_CONST(Func, has_update_definition)
+    HALIDE_FORWARD_METHOD(Func, hexagon)
+    HALIDE_FORWARD_METHOD(Func, in)
+    HALIDE_FORWARD_METHOD(Func, memoize)
+    HALIDE_FORWARD_METHOD_CONST(Func, num_update_definitions)
+    HALIDE_FORWARD_METHOD_CONST(Func, output_types)
+    HALIDE_FORWARD_METHOD_CONST(Func, outputs)
+    HALIDE_FORWARD_METHOD(Func, parallel)
+    HALIDE_FORWARD_METHOD(Func, prefetch)
+    HALIDE_FORWARD_METHOD(Func, print_loop_nest)
+    HALIDE_FORWARD_METHOD(Func, rename)
+    HALIDE_FORWARD_METHOD(Func, reorder)
+    HALIDE_FORWARD_METHOD(Func, reorder_storage)
+    HALIDE_FORWARD_METHOD_CONST(Func, rvars)
+    HALIDE_FORWARD_METHOD(Func, serial)
+    HALIDE_FORWARD_METHOD(Func, shader)
+    HALIDE_FORWARD_METHOD(Func, specialize)
+    HALIDE_FORWARD_METHOD(Func, specialize_fail)
+    HALIDE_FORWARD_METHOD(Func, split)
+    HALIDE_FORWARD_METHOD(Func, store_at)
+    HALIDE_FORWARD_METHOD(Func, store_root)
+    HALIDE_FORWARD_METHOD(Func, tile)
+    HALIDE_FORWARD_METHOD(Func, trace_stores)
+    HALIDE_FORWARD_METHOD(Func, unroll)
+    HALIDE_FORWARD_METHOD(Func, update)
+    HALIDE_FORWARD_METHOD_CONST(Func, update_args)
+    HALIDE_FORWARD_METHOD_CONST(Func, update_value)
+    HALIDE_FORWARD_METHOD_CONST(Func, update_values)
+    HALIDE_FORWARD_METHOD_CONST(Func, value)
+    HALIDE_FORWARD_METHOD_CONST(Func, values)
+    HALIDE_FORWARD_METHOD(Func, vectorize)
     // }@
 
 #undef HALIDE_OUTPUT_FORWARD
@@ -1838,20 +1825,6 @@ protected:
     }
 
     EXPORT void check_value_writable() const override;
-
-    NO_INLINE Func &get_func_ref() {
-        internal_assert(kind() != IOKind::Scalar);
-        internal_assert(exprs_.empty());
-        user_assert(funcs_.size() == 1) << "Use [] to access individual Funcs in Output<Func[]>";
-        return funcs_[0];
-    }
-
-    NO_INLINE const Func &get_func_ref() const {
-        internal_assert(kind() != IOKind::Scalar);
-        internal_assert(exprs_.empty());
-        user_assert(funcs_.size() == 1) << "Use [] to access individual Funcs in Output<Func[]>";
-        return funcs_[0];
-    }
 };
 
 template<typename T>
@@ -2063,38 +2036,21 @@ public:
         return this->funcs_.at(0).output_buffer();
     }
 
-#define HALIDE_OUTPUT_FORWARD(method)                                       \
-    template<typename ...Args>                                              \
-    inline auto method(Args&&... args) ->                                   \
-        decltype(std::declval<OutputImageParam>().method(std::forward<Args>(args)...)) {\
-        return ((OutputImageParam) *this).method(std::forward<Args>(args)...);          \
-    }
-
-#define HALIDE_OUTPUT_FORWARD_CONST(method)                                 \
-    template<typename ...Args>                                              \
-    inline auto method(Args&&... args) const ->                             \
-        decltype(std::declval<OutputImageParam>().method(std::forward<Args>(args)...)) {\
-        return ((OutputImageParam) *this).method(std::forward<Args>(args)...);          \
-    }
-
     /** Forward methods to the OutputImageParam. */
     // @{
-    HALIDE_OUTPUT_FORWARD(dim)
-    HALIDE_OUTPUT_FORWARD_CONST(dim)
-    HALIDE_OUTPUT_FORWARD_CONST(host_alignment)
-    HALIDE_OUTPUT_FORWARD(set_host_alignment)
-    HALIDE_OUTPUT_FORWARD_CONST(dimensions)
-    HALIDE_OUTPUT_FORWARD_CONST(left)
-    HALIDE_OUTPUT_FORWARD_CONST(right)
-    HALIDE_OUTPUT_FORWARD_CONST(top)
-    HALIDE_OUTPUT_FORWARD_CONST(bottom)
-    HALIDE_OUTPUT_FORWARD_CONST(width)
-    HALIDE_OUTPUT_FORWARD_CONST(height)
-    HALIDE_OUTPUT_FORWARD_CONST(channels)
+    HALIDE_FORWARD_METHOD(OutputImageParam, dim)
+    HALIDE_FORWARD_METHOD_CONST(OutputImageParam, dim)
+    HALIDE_FORWARD_METHOD_CONST(OutputImageParam, host_alignment)
+    HALIDE_FORWARD_METHOD(OutputImageParam, set_host_alignment)
+    HALIDE_FORWARD_METHOD_CONST(OutputImageParam, dimensions)
+    HALIDE_FORWARD_METHOD_CONST(OutputImageParam, left)
+    HALIDE_FORWARD_METHOD_CONST(OutputImageParam, right)
+    HALIDE_FORWARD_METHOD_CONST(OutputImageParam, top)
+    HALIDE_FORWARD_METHOD_CONST(OutputImageParam, bottom)
+    HALIDE_FORWARD_METHOD_CONST(OutputImageParam, width)
+    HALIDE_FORWARD_METHOD_CONST(OutputImageParam, height)
+    HALIDE_FORWARD_METHOD_CONST(OutputImageParam, channels)
     // }@
-
-#undef HALIDE_OUTPUT_FORWARD
-#undef HALIDE_OUTPUT_FORWARD_CONST
 };
 
 


### PR DESCRIPTION
The method-forwarding code in Generator could blithely return references to temporary objects on the stack. This was bad. Fix, and consolidate redundant method-forwarding macros while we're at it.