### PR TITLE
Minor Visitor/Mutator cleanup

### DIFF
--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -377,26 +377,6 @@ void IRMutator::visit(const Shuffle *op) {
 }
 
 
-Stmt IRGraphMutator::mutate(const Stmt &s) {
-    auto iter = stmt_replacements.find(s);
-    if (iter != stmt_replacements.end()) {
-        return iter->second;
-    }
-    Stmt new_s = IRMutator::mutate(s);
-    stmt_replacements[s] = new_s;
-    return new_s;
-}
-
-Expr IRGraphMutator::mutate(const Expr &e) {
-    auto iter = expr_replacements.find(e);
-    if (iter != expr_replacements.end()) {
-        return iter->second;
-    }
-    Expr new_e = IRMutator::mutate(e);
-    expr_replacements[e] = new_e;
-    return new_e;
-}
-
 IRMutator2::~IRMutator2() {
 }
 

--- a/src/IRMutator.h
+++ b/src/IRMutator.h
@@ -92,24 +92,6 @@ protected:
 };
 
 
-/**
- * Deprecated for new use: please use IRGraphMutator2 instead.
- * Existing usage of IRGraphMutator will be migrated to IRGraphMutator2 and
- * this class will be removed.
- *
- * A mutator that caches and reapplies previously-done mutations, so
- * that it can handle graphs of IR that have not had CSE done to
- * them. */
-class IRGraphMutator : public IRMutator {
-protected:
-    std::map<Expr, Expr, ExprCompare> expr_replacements;
-    std::map<Stmt, Stmt, Stmt::Compare> stmt_replacements;
-
-public:
-    EXPORT Stmt mutate(const Stmt &s);
-    EXPORT Expr mutate(const Expr &e);
-};
-
 /** A base class for passes over the IR which modify it
  * (e.g. replacing a variable with a value (Substitute.h), or
  * constant-folding).
@@ -132,7 +114,10 @@ public:
     EXPORT virtual Expr mutate(const Expr &expr);
     EXPORT virtual Stmt mutate(const Stmt &stmt);
 
-public:
+protected:
+    // ExprNode<> and StmtNode<> are allowed to call visit (to implement mutate_expr/mutate_stmt())
+    template<typename T> friend struct ExprNode;
+    template<typename T> friend struct StmtNode;
 
     EXPORT virtual Expr visit(const IntImm *);
     EXPORT virtual Expr visit(const UIntImm *);

--- a/src/IRVisitor.h
+++ b/src/IRVisitor.h
@@ -22,6 +22,11 @@ namespace Internal {
 class IRVisitor {
 public:
     EXPORT virtual ~IRVisitor();
+protected:
+    // ExprNode<> and StmtNode<> are allowed to call visit (to implement accept())
+    template<typename T> friend struct ExprNode;
+    template<typename T> friend struct StmtNode;
+
     EXPORT virtual void visit(const IntImm *);
     EXPORT virtual void visit(const UIntImm *);
     EXPORT virtual void visit(const FloatImm *);
@@ -84,53 +89,52 @@ private:
     /** The nodes visited so far */
     std::set<const IRNode *> visited;
 
-public:
-
+protected:
     /** These methods should call 'include' on the children to only
      * visit them if they haven't been visited already. */
     // @{
-    EXPORT virtual void visit(const IntImm *);
-    EXPORT virtual void visit(const UIntImm *);
-    EXPORT virtual void visit(const FloatImm *);
-    EXPORT virtual void visit(const StringImm *);
-    EXPORT virtual void visit(const Cast *);
-    EXPORT virtual void visit(const Variable *);
-    EXPORT virtual void visit(const Add *);
-    EXPORT virtual void visit(const Sub *);
-    EXPORT virtual void visit(const Mul *);
-    EXPORT virtual void visit(const Div *);
-    EXPORT virtual void visit(const Mod *);
-    EXPORT virtual void visit(const Min *);
-    EXPORT virtual void visit(const Max *);
-    EXPORT virtual void visit(const EQ *);
-    EXPORT virtual void visit(const NE *);
-    EXPORT virtual void visit(const LT *);
-    EXPORT virtual void visit(const LE *);
-    EXPORT virtual void visit(const GT *);
-    EXPORT virtual void visit(const GE *);
-    EXPORT virtual void visit(const And *);
-    EXPORT virtual void visit(const Or *);
-    EXPORT virtual void visit(const Not *);
-    EXPORT virtual void visit(const Select *);
-    EXPORT virtual void visit(const Load *);
-    EXPORT virtual void visit(const Ramp *);
-    EXPORT virtual void visit(const Broadcast *);
-    EXPORT virtual void visit(const Call *);
-    EXPORT virtual void visit(const Let *);
-    EXPORT virtual void visit(const LetStmt *);
-    EXPORT virtual void visit(const AssertStmt *);
-    EXPORT virtual void visit(const ProducerConsumer *);
-    EXPORT virtual void visit(const For *);
-    EXPORT virtual void visit(const Store *);
-    EXPORT virtual void visit(const Provide *);
-    EXPORT virtual void visit(const Allocate *);
-    EXPORT virtual void visit(const Free *);
-    EXPORT virtual void visit(const Realize *);
-    EXPORT virtual void visit(const Block *);
-    EXPORT virtual void visit(const IfThenElse *);
-    EXPORT virtual void visit(const Evaluate *);
-    EXPORT virtual void visit(const Shuffle *);
-    EXPORT virtual void visit(const Prefetch *);
+    EXPORT void visit(const IntImm *) override;
+    EXPORT void visit(const UIntImm *) override;
+    EXPORT void visit(const FloatImm *) override;
+    EXPORT void visit(const StringImm *) override;
+    EXPORT void visit(const Cast *) override;
+    EXPORT void visit(const Variable *) override;
+    EXPORT void visit(const Add *) override;
+    EXPORT void visit(const Sub *) override;
+    EXPORT void visit(const Mul *) override;
+    EXPORT void visit(const Div *) override;
+    EXPORT void visit(const Mod *) override;
+    EXPORT void visit(const Min *) override;
+    EXPORT void visit(const Max *) override;
+    EXPORT void visit(const EQ *) override;
+    EXPORT void visit(const NE *) override;
+    EXPORT void visit(const LT *) override;
+    EXPORT void visit(const LE *) override;
+    EXPORT void visit(const GT *) override;
+    EXPORT void visit(const GE *) override;
+    EXPORT void visit(const And *) override;
+    EXPORT void visit(const Or *) override;
+    EXPORT void visit(const Not *) override;
+    EXPORT void visit(const Select *) override;
+    EXPORT void visit(const Load *) override;
+    EXPORT void visit(const Ramp *) override;
+    EXPORT void visit(const Broadcast *) override;
+    EXPORT void visit(const Call *) override;
+    EXPORT void visit(const Let *) override;
+    EXPORT void visit(const LetStmt *) override;
+    EXPORT void visit(const AssertStmt *) override;
+    EXPORT void visit(const ProducerConsumer *) override;
+    EXPORT void visit(const For *) override;
+    EXPORT void visit(const Store *) override;
+    EXPORT void visit(const Provide *) override;
+    EXPORT void visit(const Allocate *) override;
+    EXPORT void visit(const Free *) override;
+    EXPORT void visit(const Realize *) override;
+    EXPORT void visit(const Block *) override;
+    EXPORT void visit(const IfThenElse *) override;
+    EXPORT void visit(const Evaluate *) override;
+    EXPORT void visit(const Shuffle *) override;
+    EXPORT void visit(const Prefetch *) override;
     // @}
 };
 


### PR DESCRIPTION
- IRVisitor / IRMutator visit() methods should be protected, not public
- IRGraphVisitor is completely unused and not part of the public or internal interface to Halide, so just delete it
- add some 'override' annotation where appropriate