### PR TITLE
Hex dma

### DIFF
--- a/apps/hexagon_dma/mock_dma_implementation.cpp
+++ b/apps/hexagon_dma/mock_dma_implementation.cpp
@@ -9,94 +9,194 @@
 #include "HalideRuntime.h"
 #include "../../src/runtime/mini_hexagon_dma.h"
 
+#include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
 #include <memory.h>
 
-t_StDmaWrapper_DmaTransferSetup* dmaTransferParm;
+//Mock Global Descriptor
+typedef struct stDescriptor {
+  struct {
+      uintptr_t DesPointer    : 32;   // for chain to next "desc" or NULL to terminate the chain
+      uint32 DstPixFmt        :  3;
+      uint32 DstIsUbwc        :  1;
+      uint32 SrcPixFmt        :  3;
+      uint32 SrcIsUbwc        :  1;
+      uint32 DstIsTcm         :  1;
+      uint32 _unused0         :  3;
+      uint32 SrcIsTcm         :  1;
+      uint32 _unused1         :  3;
+      uint32 DstPixPadding    :  1;
+      uint32 _unused2         :  3;
+      uint32 SrcPixPadding    :  1;
+      uint32 _unused3         : 11;
+      uint32 FrmHeight        : 16;
+      uint32 FrmWidth         : 16;
+      uint32 RoiY             : 16;
+      uint32 RoiX             : 16;
+    } stWord0;
+    struct {
+      uint32 RoiH             : 16;
+      uint32 RoiW             : 16;
+      uintptr_t SrcFrmBaseAddr: 32;
+      uint32 SrcRoiStartAddr  : 32;
+      uint32 SrcRoiStride     : 16;
+      uint32 _unused0         : 16;
+    } stWord1;
+    struct {
+      uintptr_t DstFrmBaseAddr: 32;
+      uint32 DstRoiStartAddr  : 32;
+      uint32 DstRoiStride     : 16;
+      uint32 Flush            :  1;
+      uint32 _unused0         : 15;
+      uint32 _unused1         : 32;
+    } stWord2;
+    struct {
+      uint32 reserved0        : 32;
+      uint32 reserved1        : 32;
+      uint32 reserved2        : 32;
+//    uint32 reserved3        : 32;
+      uint32 ubwc_stat_pointer  : 32;// use reserved3 for gralloc ubwc_stat_pointer
+    } stWord3;
+} t_StHwDescriptor;
 
+typedef struct {
+     int x; //in case we want to keep a count
+     t_StHwDescriptor *ptr;
+} dma_handle_t;
 
+void* HAP_cache_lock(unsigned int size, void** paddr_ptr) {
+    void * alloc = 0;
+    if (size != 0) {
+        alloc = malloc(size);
+    }
+    return alloc;
+}
+
+int HAP_cache_unlock(void* vaddr_ptr) {
+    if (vaddr_ptr != 0) {
+        free(vaddr_ptr);
+        return 0;
+    }
+    return 1;
+}
 
 t_DmaWrapper_DmaEngineHandle hDmaWrapper_AllocDma(void) {
-
-    char* a = (char *)malloc(sizeof(char));
-    return (void *)a;
+    dma_handle_t* handle = (dma_handle_t*)malloc(sizeof(dma_handle_t));
+    handle->ptr = NULL;
+    return (void *)handle;
 }
 
-int32 nDmaWrapper_FreeDma(t_DmaWrapper_DmaEngineHandle hDmaHandle) {
-
-    char *a = (char *)hDmaHandle;
-    free(a);
+int32 nDmaWrapper_FreeDma(t_DmaWrapper_DmaEngineHandle dma_handle) {
+    dma_handle_t *desc = (dma_handle_t *)dma_handle;
+    assert(desc->ptr == NULL);
+    free(desc);
     return 0;
 }
 
-int32 nDmaWrapper_Move(t_DmaWrapper_DmaEngineHandle hDmaHandle) {
+int32 nDmaWrapper_Move(t_DmaWrapper_DmaEngineHandle handle) {
 
-    if (hDmaHandle != 0) {
-        unsigned char* host_addr = (unsigned char*) dmaTransferParm->pFrameBuf;
-        unsigned char* dest_addr = (unsigned char*) dmaTransferParm->pTcmDataBuf;
+    t_StHwDescriptor *desc = 0;
+    if(handle != 0) {
+        dma_handle_t* dma_handle = (dma_handle_t *)handle;
+        desc = dma_handle->ptr;
 
-        int x = dmaTransferParm->u16RoiX;
-        int y = dmaTransferParm->u16RoiY;
-        int w = dmaTransferParm->u16RoiW;
-        int h = dmaTransferParm->u16RoiH;
-
-        for (int xii=0;xii<h;xii++) {
-            for (int yii=0;yii<w;yii++) {
-                int xin = xii*w;
-                int yin = yii;
-                int RoiOffset = x+y*dmaTransferParm->u16FrameW;
-                int xout = xii*dmaTransferParm->u16FrameW;
-                int yout = yii;
-                dest_addr[yin+xin] = host_addr[RoiOffset + yout + xout];
+        while (desc != NULL) {
+            unsigned char* host_addr = reinterpret_cast<unsigned char *>(desc->stWord1.SrcFrmBaseAddr);
+            unsigned char* dest_addr = reinterpret_cast<unsigned char *>(desc->stWord2.DstFrmBaseAddr);
+            int x = desc->stWord0.RoiX;
+            int y = desc->stWord0.RoiY;
+            int w = desc->stWord1.RoiW;
+            int h = desc->stWord1.RoiH;
+            for (int xii=0;xii<h;xii++) {
+                for (int yii=0;yii<w;yii++) {
+                    int xin = xii*desc->stWord2.DstRoiStride;
+                    int yin = yii;
+                    int RoiOffset = x+y*desc->stWord1.SrcRoiStride;
+                    int xout = xii*desc->stWord0.FrmHeight;
+                    int yout = yii;
+                    dest_addr[yin+xin] = host_addr[RoiOffset + yout + xout];
+                }
             }
+            desc = reinterpret_cast<t_StHwDescriptor*>(desc->stWord0.DesPointer);
         }
     }
-    dmaTransferParm = 0;
     return 0;
 }
 
-int32 nDmaWrapper_Wait(t_DmaWrapper_DmaEngineHandle hDmaHandle) {
+int32 nDmaWrapper_Wait(t_DmaWrapper_DmaEngineHandle dma_handle) {
     return 0;
 }
 
-int32 nDmaWrapper_FinishFrame(t_DmaWrapper_DmaEngineHandle hDmaHandle) {
+int32 nDmaWrapper_FinishFrame(t_DmaWrapper_DmaEngineHandle dma_handle) {
+    dma_handle_t *desc = (dma_handle_t *)dma_handle;
+    //remove the association from descriptor
+    desc->ptr = NULL;
     return 0;
 }
 
-int32 nDmaWrapper_GetRecommendedWalkSize(t_eDmaFmt eFmtId, bool bIsUbwc,
-                                         t_StDmaWrapper_RoiAlignInfo* pStWalkSize) {
-    // for raw, mimic with NV12 linear, alignment is (W=256, H=1)
-    pStWalkSize->u16H = align(pStWalkSize->u16H, 1);
-    pStWalkSize->u16W = align(pStWalkSize->u16W, 1);
+int32 nDmaWrapper_GetRecommendedWalkSize(t_eDmaFmt fmt, bool is_ubwc,
+                                         t_StDmaWrapper_RoiAlignInfo* walk_size) {
+    walk_size->u16H = align(walk_size->u16H, 1);
+    walk_size->u16W = align(walk_size->u16W, 1);
     return 0;
 }
 
-int32 nDmaWrapper_GetRecommendedIntermBufStride(t_eDmaFmt eFmtId,
-                                                t_StDmaWrapper_RoiAlignInfo* pStRoiSize,
-                                                 bool bIsUbwc) {
-    return align(pStRoiSize->u16W, 256);
-
+int32 nDmaWrapper_GetRecommendedIntermBufStride(t_eDmaFmt fmt,
+                                                t_StDmaWrapper_RoiAlignInfo* roi_size,
+                                                 bool is_ubwc) {
+    return align(roi_size->u16W, 256);
 }
 
-int32 nDmaWrapper_DmaTransferSetup(t_DmaWrapper_DmaEngineHandle hDmaHandle, t_StDmaWrapper_DmaTransferSetup* stpDmaTransferParm) {
+int32 nDmaWrapper_DmaTransferSetup(t_DmaWrapper_DmaEngineHandle handle, t_StDmaWrapper_DmaTransferSetup* dma_transfer_parm) {
 
-    dmaTransferParm = stpDmaTransferParm;
+    if (handle == 0)
+        return 1;
+
+    if (dma_transfer_parm->pDescBuf == NULL)
+        return 1;
+
+    //Add it to the linked list of dma_handle->ptr
+    dma_handle_t *dma_handle = (dma_handle_t *)handle;
+    t_StHwDescriptor *temp = dma_handle->ptr;
+    t_StHwDescriptor *desc = (t_StHwDescriptor *)dma_transfer_parm->pDescBuf;
+    desc->stWord0.DesPointer  = 0;
+
+    if (temp != NULL) {
+        while (temp->stWord0.DesPointer != 0) {
+            temp =  reinterpret_cast<t_StHwDescriptor *>(temp->stWord0.DesPointer);
+        }
+        temp->stWord0.DesPointer =  reinterpret_cast<uintptr_t>(desc);
+    } else {
+        dma_handle->ptr = desc;
+    }
+
+    desc->stWord0.DstIsUbwc = dma_transfer_parm->bIsFmtUbwc;
+    desc->stWord0.DstIsTcm = (dma_transfer_parm->eTransferType == eDmaWrapper_DdrToL2) ? 1 : 0;
+    desc->stWord0.FrmHeight = dma_transfer_parm->u16FrameH;
+    desc->stWord0.FrmWidth = dma_transfer_parm->u16FrameW;
+    desc->stWord0.RoiX = dma_transfer_parm->u16RoiX;
+    desc->stWord0.RoiY = dma_transfer_parm->u16RoiY;
+    desc->stWord1.RoiH = dma_transfer_parm->u16RoiH;
+    desc->stWord1.RoiW = dma_transfer_parm->u16RoiW;
+    desc->stWord1.SrcRoiStride = dma_transfer_parm->u16FrameStride;
+    desc->stWord2.DstRoiStride = dma_transfer_parm->u16RoiStride;
+    desc->stWord2.DstFrmBaseAddr = reinterpret_cast<uintptr_t>(dma_transfer_parm->pTcmDataBuf);
+    desc->stWord1.SrcFrmBaseAddr  = reinterpret_cast<uintptr_t>(dma_transfer_parm->pFrameBuf);
     return 0;
+
 }
 
-int32 nDmaWrapper_GetDescbuffsize(t_eDmaFmt *aeFmtId, uint16 nsize) {
+int32 nDmaWrapper_GetDescbuffsize(t_eDmaFmt *fmt, uint16 nsize) {
 
     int32 i, yuvformat=0,desc_size;
     for (i=0;i<nsize;i++) {
-        if ((aeFmtId[i]==eDmaFmt_NV12)||(aeFmtId[i]==eDmaFmt_TP10)||
-            (aeFmtId[i]==eDmaFmt_NV124R)||(aeFmtId[i]==eDmaFmt_P010)) {
+        if ((fmt[i]==eDmaFmt_NV12)||(fmt[i]==eDmaFmt_TP10)||
+            (fmt[i]==eDmaFmt_NV124R)||(fmt[i]==eDmaFmt_P010)) {
             yuvformat += 1;
         }
     }
     desc_size = (nsize+yuvformat)*64;
     return desc_size;
 }
-
-
-
 

--- a/apps/hexagon_dma/mock_dma_implementation.cpp
+++ b/apps/hexagon_dma/mock_dma_implementation.cpp
@@ -38,13 +38,13 @@ typedef struct stDescriptor {
     struct {
       uint32 RoiH             : 16;
       uint32 RoiW             : 16;
-      uintptr_t SrcFrmBaseAddr: 32;
+      uintptr_t SrcFrmBaseAddr;
       uint32 SrcRoiStartAddr  : 32;
       uint32 SrcRoiStride     : 16;
       uint32 _unused0         : 16;
     } stWord1;
     struct {
-      uintptr_t DstFrmBaseAddr: 32;
+      uintptr_t DstFrmBaseAddr;
       uint32 DstRoiStartAddr  : 32;
       uint32 DstRoiStride     : 16;
       uint32 Flush            :  1;
@@ -113,7 +113,7 @@ int32 nDmaWrapper_Move(t_DmaWrapper_DmaEngineHandle handle) {
                     int xin = xii*desc->stWord2.DstRoiStride;
                     int yin = yii;
                     int RoiOffset = x+y*desc->stWord1.SrcRoiStride;
-                    int xout = xii*desc->stWord0.FrmHeight;
+                    int xout = xii*desc->stWord0.FrmWidth;
                     int yout = yii;
                     dest_addr[yin+xin] = host_addr[RoiOffset + yout + xout];
                 }

--- a/apps/hexagon_dma/mock_dma_implementation.cpp
+++ b/apps/hexagon_dma/mock_dma_implementation.cpp
@@ -17,7 +17,7 @@
 //Mock Global Descriptor
 typedef struct stDescriptor {
   struct {
-      uintptr_t DesPointer    : 32;   // for chain to next "desc" or NULL to terminate the chain
+      uintptr_t DesPointer    ;   // for chain to next "desc" or NULL to terminate the chain
       uint32 DstPixFmt        :  3;
       uint32 DstIsUbwc        :  1;
       uint32 SrcPixFmt        :  3;
@@ -38,26 +38,14 @@ typedef struct stDescriptor {
     struct {
       uint32 RoiH             : 16;
       uint32 RoiW             : 16;
-      uintptr_t SrcFrmBaseAddr;
-      uint32 SrcRoiStartAddr  : 32;
       uint32 SrcRoiStride     : 16;
-      uint32 _unused0         : 16;
-    } stWord1;
-    struct {
-      uintptr_t DstFrmBaseAddr;
-      uint32 DstRoiStartAddr  : 32;
       uint32 DstRoiStride     : 16;
-      uint32 Flush            :  1;
-      uint32 _unused0         : 15;
-      uint32 _unused1         : 32;
-    } stWord2;
-    struct {
-      uint32 reserved0        : 32;
-      uint32 reserved1        : 32;
-      uint32 reserved2        : 32;
-//    uint32 reserved3        : 32;
+      uintptr_t SrcFrmBaseAddr;
+      uintptr_t DstFrmBaseAddr;
+      uint32 SrcRoiStartAddr  : 32;
+      uint32 DstRoiStartAddr  : 32;
       uint32 ubwc_stat_pointer  : 32;// use reserved3 for gralloc ubwc_stat_pointer
-    } stWord3;
+    } stWord1;
 } t_StHwDescriptor;
 
 typedef struct {
@@ -103,14 +91,14 @@ int32 nDmaWrapper_Move(t_DmaWrapper_DmaEngineHandle handle) {
 
         while (desc != NULL) {
             unsigned char* host_addr = reinterpret_cast<unsigned char *>(desc->stWord1.SrcFrmBaseAddr);
-            unsigned char* dest_addr = reinterpret_cast<unsigned char *>(desc->stWord2.DstFrmBaseAddr);
+            unsigned char* dest_addr = reinterpret_cast<unsigned char *>(desc->stWord1.DstFrmBaseAddr);
             int x = desc->stWord0.RoiX;
             int y = desc->stWord0.RoiY;
             int w = desc->stWord1.RoiW;
             int h = desc->stWord1.RoiH;
             for (int xii=0;xii<h;xii++) {
                 for (int yii=0;yii<w;yii++) {
-                    int xin = xii*desc->stWord2.DstRoiStride;
+                    int xin = xii*desc->stWord1.DstRoiStride;
                     int yin = yii;
                     int RoiOffset = x+y*desc->stWord1.SrcRoiStride;
                     int xout = xii*desc->stWord0.FrmWidth;
@@ -180,8 +168,8 @@ int32 nDmaWrapper_DmaTransferSetup(t_DmaWrapper_DmaEngineHandle handle, t_StDmaW
     desc->stWord1.RoiH = dma_transfer_parm->u16RoiH;
     desc->stWord1.RoiW = dma_transfer_parm->u16RoiW;
     desc->stWord1.SrcRoiStride = dma_transfer_parm->u16FrameStride;
-    desc->stWord2.DstRoiStride = dma_transfer_parm->u16RoiStride;
-    desc->stWord2.DstFrmBaseAddr = reinterpret_cast<uintptr_t>(dma_transfer_parm->pTcmDataBuf);
+    desc->stWord1.DstRoiStride = dma_transfer_parm->u16RoiStride;
+    desc->stWord1.DstFrmBaseAddr = reinterpret_cast<uintptr_t>(dma_transfer_parm->pTcmDataBuf);
     desc->stWord1.SrcFrmBaseAddr  = reinterpret_cast<uintptr_t>(dma_transfer_parm->pFrameBuf);
     return 0;
 

--- a/apps/hexagon_dma/mock_dma_implementation.cpp
+++ b/apps/hexagon_dma/mock_dma_implementation.cpp
@@ -13,15 +13,7 @@
 #include <memory.h>
 
 t_StDmaWrapper_DmaTransferSetup* dmaTransferParm;
-typedef struct desc_data {
-    void* descriptor;
-    bool used;
-    unsigned int size;
-    struct desc_data* next;
-} desc_pool_t;
 
-typedef desc_pool_t* pdesc_pool;
-static pdesc_pool dma_desc_pool = NULL;
 
 
 t_DmaWrapper_DmaEngineHandle hDmaWrapper_AllocDma(void) {
@@ -105,67 +97,6 @@ int32 nDmaWrapper_GetDescbuffsize(t_eDmaFmt *aeFmtId, uint16 nsize) {
     return desc_size;
 }
 
-void* desc_pool_get (unsigned int size) {
 
-   /* if pool empty
-    * get locked cache    --> multiple of 128B (cache line size) and each "desc" is 64B
-    * add new "desc" into pool
-    * get "desc" from pool
-    * mark "desc" used
-    * return "desc" */
-
-    pdesc_pool temp = dma_desc_pool;
-    pdesc_pool prev = NULL;
-    if (temp != NULL) {
-        if (!temp->used) {
-            temp->used = true;
-            return (void*) temp->descriptor;
-        }
-        prev = temp;
-        temp=temp->next;
-    }
-
-    temp = (pdesc_pool) malloc(sizeof(desc_pool_t));
-    //allocate descriptor
-    char* desc = (char*)malloc(size);
-    *desc = 'a';
-    temp->descriptor = (void *)desc;
-    temp->size = size;
-    temp->used = true;
-    if (prev != NULL) {
-        prev->next = temp;
-    } else if (dma_desc_pool == NULL) {
-        dma_desc_pool = temp;
-    }
-
-    return (void*) temp->descriptor;
-}
-
-int desc_pool_put (void *desc) {
-    /*find "desc"
-    put "desc" into pool
-    mark "desc" free*/
-
-    pdesc_pool temp = dma_desc_pool;
-
-    while (temp != NULL) {
-        if (temp->descriptor == desc) {
-            temp->used = false;
-            return 0;
-        }
-        temp=temp->next;
-    }
-    return -1;
-}
-
-void desc_pool_free () {
-    pdesc_pool temp = dma_desc_pool;
-    while (temp != NULL) {
-        pdesc_pool temp2 = temp;
-        temp=temp->next;
-        free(temp2->descriptor);
-        free(temp2);
-    }
-}
 
 

--- a/apps/hexagon_dma/mock_dma_implementation.cpp
+++ b/apps/hexagon_dma/mock_dma_implementation.cpp
@@ -5,148 +5,167 @@
  * This file is need only if there is no hexagon SDK support or NO hexagon DMA support, in either csae we replace
  * the DMA operations with normal memory operations */
 
+#include "pipeline.h"
 #include "HalideRuntime.h"
 #include "../../src/runtime/mini_hexagon_dma.h"
 
 #include <stdlib.h>
 #include <memory.h>
 
-typedef struct dma_dummy_lib {
-    int width;
-    void* host_address;
-} t_dma_dummy_lib;
+t_StDmaWrapper_DmaTransferSetup* dmaTransferParm;
+typedef struct desc_data {
+    void* descriptor;
+    bool used;
+    unsigned int size;
+    struct desc_data* next;
+} desc_pool_t;
 
-int dma_is_dma_driver_ready() {
-    return QURT_EOK;
+typedef desc_pool_t* pdesc_pool;
+static pdesc_pool dma_desc_pool = NULL;
+
+
+t_DmaWrapper_DmaEngineHandle hDmaWrapper_AllocDma(void) {
+
+    char* a = (char *)malloc(sizeof(char));
+    return (void *)a;
 }
 
-int dma_get_format_alignment(t_eDmaFmt eFmt, bool is_ubwc, t_dma_pix_align_info& pix_align) {
-    int nRet = 0;
-    pix_align.u16H = 16;
-    pix_align.u16W = 128;
-    return nRet;
+int32 nDmaWrapper_FreeDma(t_DmaWrapper_DmaEngineHandle hDmaHandle) {
+
+    char *a = (char *)hDmaHandle;
+    free(a);
+    return 0;
 }
 
-uintptr_t dma_lookup_physical_address(uintptr_t addr) {
-    return addr;
-}
+int32 nDmaWrapper_Move(t_DmaWrapper_DmaEngineHandle hDmaHandle) {
 
-int dma_get_min_roi_size(t_eDmaFmt eFmt, bool isUbwc, t_dma_pix_align_info& pix_align) {
-    int nRet = 0;
-    pix_align.u16H = 16;
-    pix_align.u16W = 128;
-    return nRet;
-}
+    if (hDmaHandle != 0) {
+        unsigned char* host_addr = (unsigned char*) dmaTransferParm->pFrameBuf;
+        unsigned char* dest_addr = (unsigned char*) dmaTransferParm->pTcmDataBuf;
 
-void* dma_allocate_dma_engine() {
-    t_dma_dummy_lib* dma_handle = NULL;
-    dma_handle = (t_dma_dummy_lib *)malloc(sizeof(t_dma_dummy_lib));
-    return (void*)dma_handle;
-}
+        int x = dmaTransferParm->u16RoiX;
+        int y = dmaTransferParm->u16RoiY;
+        int w = dmaTransferParm->u16RoiW;
+        int h = dmaTransferParm->u16RoiH;
 
-qurt_size_t dma_get_descriptor_size(t_eDmaFmt* fmt_type, int ncomponents, int nfolds) {
-    qurt_size_t region_tcm_desc_size = 0;
-    if (fmt_type != NULL) {
-        region_tcm_desc_size = align(64, 0x1000);
-    }
-    return region_tcm_desc_size;
-}
-
-int dma_get_stride(t_eDmaFmt fmt_type, bool is_ubwc, t_dma_pix_align_info roi_dims) {
-    int stride = roi_dims.u16W;
-    return stride;
-}
-
-int dma_get_mem_pool_id(qurt_mem_pool_t *mem_pool) {
-    int nRet = 0;
-    *mem_pool = 1;
-    return nRet;
-}
-
-int dma_allocate_cache(qurt_mem_pool_t pool_tcm, qurt_size_t tcm_size,
-                            uintptr_t* region_tcm, uintptr_t* tcm_vaddr) {
-    unsigned char* buf_vaddr;
-    buf_vaddr = (unsigned char*) malloc(tcm_size*sizeof(unsigned char*));
-    if (region_tcm != 0) {
-        *region_tcm = (uintptr_t) buf_vaddr;
-    }
-    memset(buf_vaddr, 0, tcm_size*sizeof(unsigned char*));
-    uintptr_t buf_addr = (uintptr_t) buf_vaddr;
-    *tcm_vaddr = buf_addr;
-    return QURT_EOK;
-}
-
-int dma_unlock_cache(uintptr_t tcm_buf_vaddr, qurt_size_t region_tcm_size) {
-    int nRet  = QURT_EOK;
-    //do nothing
-    return nRet;
-}
-
-int dma_prepare_for_transfer(t_dma_prepare_params param) {
-    int nRet  = QURT_EOK;
-    t_dma_dummy_lib* dma_handle = (t_dma_dummy_lib*) param.handle;
-    if (dma_handle != 0) {
-        dma_handle->host_address = (void*) param.host_address;
-        dma_handle->width = param.frame_width;
-    }
-    //do Nothing
-    return nRet;
-}
-
-int dma_wait(void* handle) {
-    int nRet = QURT_EOK;
-    //do nothing
-    return nRet;
-}
-
-int dma_move_data(t_dma_move_params param) {
-    int nRet = QURT_EOK;
-    t_dma_dummy_lib* dma_handle = (t_dma_dummy_lib*) param.handle;
-
-    if (dma_handle != 0) {
-        unsigned char* host_addr = (unsigned char*) dma_handle->host_address;
-        unsigned char* dest_addr = (unsigned char*) param.ping_buffer;
-        int x = param.xoffset;
-        int y = param.yoffset;
-        int w = param.roi_width;
-        int h = param.roi_height;
-        unsigned int offset_buf = param.offset;
         for (int xii=0;xii<h;xii++) {
             for (int yii=0;yii<w;yii++) {
                 int xin = xii*w;
                 int yin = yii;
-                int RoiOffset = x+y*dma_handle->width;
-                int xout = xii*dma_handle->width;
+                int RoiOffset = x+y*dmaTransferParm->u16FrameW;
+                int xout = xii*dmaTransferParm->u16FrameW;
                 int yout = yii;
-                dest_addr[offset_buf+yin+xin] =  host_addr[RoiOffset + yout + xout ] ;
+                dest_addr[yin+xin] = host_addr[RoiOffset + yout + xout];
             }
         }
     }
-    return nRet;
+    dmaTransferParm = 0;
+    return 0;
 }
 
-int dma_free_dma_engine(void* handle) {
-    int nRet  = QURT_EOK;
-    t_dma_dummy_lib* dma_handle = (t_dma_dummy_lib*)handle;
-    if (dma_handle != 0) {
-        free(dma_handle);
+int32 nDmaWrapper_Wait(t_DmaWrapper_DmaEngineHandle hDmaHandle) {
+    return 0;
+}
+
+int32 nDmaWrapper_FinishFrame(t_DmaWrapper_DmaEngineHandle hDmaHandle) {
+    return 0;
+}
+
+int32 nDmaWrapper_GetRecommendedWalkSize(t_eDmaFmt eFmtId, bool bIsUbwc,
+                                         t_StDmaWrapper_RoiAlignInfo* pStWalkSize) {
+    // for raw, mimic with NV12 linear, alignment is (W=256, H=1)
+    pStWalkSize->u16H = align(pStWalkSize->u16H, 1);
+    pStWalkSize->u16W = align(pStWalkSize->u16W, 1);
+    return 0;
+}
+
+int32 nDmaWrapper_GetRecommendedIntermBufStride(t_eDmaFmt eFmtId,
+                                                t_StDmaWrapper_RoiAlignInfo* pStRoiSize,
+                                                 bool bIsUbwc) {
+    return align(pStRoiSize->u16W, 256);
+
+}
+
+int32 nDmaWrapper_DmaTransferSetup(t_DmaWrapper_DmaEngineHandle hDmaHandle, t_StDmaWrapper_DmaTransferSetup* stpDmaTransferParm) {
+
+    dmaTransferParm = stpDmaTransferParm;
+    return 0;
+}
+
+int32 nDmaWrapper_GetDescbuffsize(t_eDmaFmt *aeFmtId, uint16 nsize) {
+
+    int32 i, yuvformat=0,desc_size;
+    for (i=0;i<nsize;i++) {
+        if ((aeFmtId[i]==eDmaFmt_NV12)||(aeFmtId[i]==eDmaFmt_TP10)||
+            (aeFmtId[i]==eDmaFmt_NV124R)||(aeFmtId[i]==eDmaFmt_P010)) {
+            yuvformat += 1;
+        }
     }
-    return nRet;
+    desc_size = (nsize+yuvformat)*64;
+    return desc_size;
 }
 
-int dma_finish_frame(void* handle) {
-    int nRet  = QURT_EOK;
-    //do nothing
-    return nRet;
+void* desc_pool_get (unsigned int size) {
+
+   /* if pool empty
+    * get locked cache    --> multiple of 128B (cache line size) and each "desc" is 64B
+    * add new "desc" into pool
+    * get "desc" from pool
+    * mark "desc" used
+    * return "desc" */
+
+    pdesc_pool temp = dma_desc_pool;
+    pdesc_pool prev = NULL;
+    if (temp != NULL) {
+        if (!temp->used) {
+            temp->used = true;
+            return (void*) temp->descriptor;
+        }
+        prev = temp;
+        temp=temp->next;
+    }
+
+    temp = (pdesc_pool) malloc(sizeof(desc_pool_t));
+    //allocate descriptor
+    char* desc = (char*)malloc(size);
+    *desc = 'a';
+    temp->descriptor = (void *)desc;
+    temp->size = size;
+    temp->used = true;
+    if (prev != NULL) {
+        prev->next = temp;
+    } else if (dma_desc_pool == NULL) {
+        dma_desc_pool = temp;
+    }
+
+    return (void*) temp->descriptor;
 }
 
-unsigned int dma_get_thread_id() {
-    static int i=0;
-    i++;
-    return i;
+int desc_pool_put (void *desc) {
+    /*find "desc"
+    put "desc" into pool
+    mark "desc" free*/
+
+    pdesc_pool temp = dma_desc_pool;
+
+    while (temp != NULL) {
+        if (temp->descriptor == desc) {
+            temp->used = false;
+            return 0;
+        }
+        temp=temp->next;
+    }
+    return -1;
 }
 
-void dma_delete_mem_region(uintptr_t cache_mem) {
-    unsigned char* temp =(unsigned char*)(cache_mem);
-    free(temp);
+void desc_pool_free () {
+    pdesc_pool temp = dma_desc_pool;
+    while (temp != NULL) {
+        pdesc_pool temp2 = temp;
+        temp=temp->next;
+        free(temp2->descriptor);
+        free(temp2);
+    }
 }
+
+

--- a/src/runtime/hexagon_dma.cpp
+++ b/src/runtime/hexagon_dma.cpp
@@ -272,6 +272,8 @@ WEAK int halide_hexagon_dma_copy_to_host(void *user_context, struct halide_buffe
         return halide_error_code_copy_to_host_failed; 
     }
 
+    debug(user_context) << "Hexagon:" << dev->dma_engine << "move\n" ;
+
     nRet = nDmaWrapper_Move(dev->dma_engine);
     if (nRet != QURT_EOK) {
         debug(user_context) << "Hexagon: DMA Tranfer Error" << "\n";

--- a/src/runtime/hexagon_dma.cpp
+++ b/src/runtime/hexagon_dma.cpp
@@ -49,7 +49,7 @@ static void* desc_pool_get (void) {
     pdesc_pool prev = NULL;
 
     //Walk the list
-    if (temp != NULL) {
+    while (temp != NULL) {
         if (!temp->used) {
             temp->used = true;
             return (void*) temp->descriptor;
@@ -244,6 +244,8 @@ WEAK int halide_hexagon_dma_copy_to_host(void *user_context, struct halide_buffe
     int roi_stride = nDmaWrapper_GetRecommendedIntermBufStride(eDmaFmt_RawData, &stWalkSize, false);
     int roi_width = stWalkSize.u16W;
     int roi_height = stWalkSize.u16H;
+    // DMA driver Expect the Stride to be 256 Byte Aligned
+    halide_assert(user_context,(buf->dim[1].stride== roi_stride));
 
     dev->desc_addr = desc_pool_get();
 

--- a/src/runtime/mini_hexagon_dma.h
+++ b/src/runtime/mini_hexagon_dma.h
@@ -19,16 +19,16 @@ typedef unsigned long addr_t;
 typedef unsigned int qurt_size_t;
 typedef unsigned int qurt_mem_pool_t;
 
-  __inline static int align(int x,int a) {
+__inline static int align(int x,int a) {
     return ( (x+a-1) & (~(a-1)) );    
-  } 
+} 
 
-  enum { QURT_EOK = 0 };
+enum { QURT_EOK = 0 };
 
-  /*!
-   * Format IDs
-   */
-  typedef enum {
+/*!
+ * Format IDs
+ */
+typedef enum {
     eDmaFmt_RawData,
     eDmaFmt_NV12,
     eDmaFmt_NV12_Y,
@@ -44,7 +44,7 @@ typedef unsigned int qurt_mem_pool_t;
     eDmaFmt_NV124R_UV,
     eDmaFmt_Invalid,
     eDmaFmt_MAX,
-  } t_eDmaFmt;
+} t_eDmaFmt;
 
   /*!
    * DMA status
@@ -56,48 +56,48 @@ typedef unsigned int qurt_mem_pool_t;
    * Transfer type
    */
   typedef enum eDmaWrapper_TransationType {
-      //! DDR to L2 transfer
-      eDmaWrapper_DdrToL2,
-      //! L2 to DDR transfer
-      eDmaWrapper_L2ToDdr,
+    //! DDR to L2 transfer
+    eDmaWrapper_DdrToL2,
+    //! L2 to DDR transfer
+    eDmaWrapper_L2ToDdr,
   } t_eDmaWrapper_TransationType;
 
   /*!
    * Roi Properties
    */
   typedef struct stDmaWrapper_Roi {
-      //! ROI x position in pixels
-      uint16 u16X;
-      //! ROI y position in pixels
-      uint16 u16Y;
-      //! ROI width in pixels
-      uint16 u16W;
-      //! ROI height in pixels
-      uint16 u16H;
+    //! ROI x position in pixels
+    uint16 u16X;
+    //! ROI y position in pixels
+    uint16 u16Y;
+    //! ROI width in pixels
+    uint16 u16W;
+    //! ROI height in pixels
+    uint16 u16H;
   } t_StDmaWrapper_Roi;
 
   /*!
    * Frame Properties
    */
   typedef struct stDmaWrapper_FrameProp {
-      //! Starting physical address to buffer
-      addr_t aAddr;
-      //! Frame height in pixels
-      uint16 u16H;
-      //! Frame width in pixels
-      uint16 u16W;
-      //! Frame stride in pixels
-      uint16 u16Stride;
+    //! Starting physical address to buffer
+    addr_t aAddr;
+    //! Frame height in pixels
+    uint16 u16H;
+    //! Frame width in pixels
+    uint16 u16W;
+    //! Frame stride in pixels
+    uint16 u16Stride;
   } t_StDmaWrapper_FrameProp;
 
   /*!
    * Roi alignment
    */
   typedef struct stDmaWrapper_RoiAlignInfo {
-      //! ROI width in pixels
-      uint16 u16W;
-      //! ROI height in pixels
-      uint16 u16H;
+    //! ROI width in pixels
+    uint16 u16W;
+    //! ROI height in pixels
+    uint16 u16H;
   } t_StDmaWrapper_RoiAlignInfo;
 
   /*!
@@ -105,36 +105,53 @@ typedef unsigned int qurt_mem_pool_t;
    */
 
   typedef struct stDmaWrapper_DmaTransferSetup {
-      //! Format
-      t_eDmaFmt eFmt;
-       bool bIsFmtUbwc;
-      //! Frame Width in pixels
-      uint16 u16FrameW;
-      //! Frame height in pixels
-      uint16 u16FrameH;
-       //! Frame stride in pixels
-       uint16 u16FrameStride;
-      //! ROI x position in pixels
-      uint16 u16RoiX;
-      //! ROI y position in pixels
-      uint16 u16RoiY;
-      //! ROI width in pixels
-      uint16 u16RoiW;
-      //! ROI height in pixels
-      uint16 u16RoiH;
-       //! ROI stride in pixels
-       uint16 u16RoiStride;
-      //! Should the intermediate buffer be padded. This only apply for 8bit format sucha NV12, NV12-4R
-      bool bUse16BitPaddingInL2;
-      //! Virtual address of the HW descriptor buffer (must be locked in the L2$).
-       void* pDescBuf;
-      //! Virtual address of the TCM pixeldata buffer (must be locked in the L2$).
-       void*  pTcmDataBuf;
-      //! Virtual address of the DDR Frame buffer .
-       void*  pFrameBuf;
-      //! TransferType: eDmaWrapper_DdrToL2 (Read from DDR), eDmaWrapper_L2ToDDR (Write to DDR);
-       t_eDmaWrapper_TransationType eTransferType;
+    //! Format
+    t_eDmaFmt eFmt;
+    bool bIsFmtUbwc;
+    //! Frame Width in pixels
+    uint16 u16FrameW;
+    //! Frame height in pixels
+    uint16 u16FrameH;
+    //! Frame stride in pixels
+    uint16 u16FrameStride;
+    //! ROI x position in pixels
+    uint16 u16RoiX;
+    //! ROI y position in pixels
+    uint16 u16RoiY;
+    //! ROI width in pixels
+    uint16 u16RoiW;
+    //! ROI height in pixels
+    uint16 u16RoiH;
+    //! ROI stride in pixels
+    uint16 u16RoiStride;
+    //! Should the intermediate buffer be padded. This only apply for 8bit format sucha NV12, NV12-4R
+    bool bUse16BitPaddingInL2;
+    //! Virtual address of the HW descriptor buffer (must be locked in the L2$).
+    void* pDescBuf;
+    //! Virtual address of the TCM pixeldata buffer (must be locked in the L2$).
+    void*  pTcmDataBuf;
+    //! Virtual address of the DDR Frame buffer .
+    void*  pFrameBuf;
+    //! TransferType: eDmaWrapper_DdrToL2 (Read from DDR), eDmaWrapper_L2ToDDR (Write to DDR);
+    t_eDmaWrapper_TransationType eTransferType;
   } t_StDmaWrapper_DmaTransferSetup;
+
+  /*!
+   * @brief  API for Cache Allocation
+   * @description Abstraction for allocation of memory in cache and lock
+   *
+   * @return NULL or Memory
+   */
+  void* HAP_cache_lock(unsigned int size, void** paddr_ptr);
+
+
+  /*!
+   * @brief  API for Free
+   * @description Abstraction for deallocation of memory and unlock cache
+   *
+   * @return void
+   */
+  int HAP_cache_unlock(void* vaddr_ptr);
 
   /*!
    * Handle for wrapper DMA engine

--- a/src/runtime/mini_hexagon_dma.h
+++ b/src/runtime/mini_hexagon_dma.h
@@ -137,30 +137,6 @@ typedef unsigned int qurt_mem_pool_t;
   } t_StDmaWrapper_DmaTransferSetup;
 
   /*!
-   * @brief      Allocated a DMA Descriptor
-   * @description Maintain a pool of descriptors
-   *
-   * @return      Descriptor
-   */
-  void* desc_pool_get (unsigned int size);
-
-  /*!
-   * @brief       Put back DMA escriptor
-   * @description Frees a descriptor and return it to the pool of descriptors
-   *
-   * @return      Success
-   */
-  int desc_pool_put (void *desc);
-
-  /*!
-   * @brief     Frees the pool of descriptor
-   * @description Traverses through the list once release is called
-   *
-   * @return      None
-   */
-  void desc_pool_free ();
-
-  /*!
    * Handle for wrapper DMA engine
    */
   typedef void* t_DmaWrapper_DmaEngineHandle;

--- a/src/runtime/mini_hexagon_dma.h
+++ b/src/runtime/mini_hexagon_dma.h
@@ -11,6 +11,11 @@
 extern "C" {
 #endif
 
+typedef uint16_t uint16;
+typedef uint32_t uint32;
+typedef int32_t int32;
+typedef unsigned long addr_t;
+
 typedef unsigned int qurt_size_t;
 typedef unsigned int qurt_mem_pool_t;
 
@@ -41,160 +46,271 @@ typedef unsigned int qurt_mem_pool_t;
     eDmaFmt_MAX,
   } t_eDmaFmt;
 
-  /**
-   * Params needed for Prepare for transfer
+  /*!
+   * DMA status
+   * Currently not use, for future development
    */
-  typedef struct {
-    void* handle;
-    uintptr_t host_address;
-    int frame_width;
-    int frame_height;
-    int frame_stride;
-    int roi_width;
-    int roi_height;
-    int luma_stride;
-    int chroma_stride;
-    bool read;
-    t_eDmaFmt chroma_type;
-    t_eDmaFmt luma_type;
-    int ncomponents;
-    bool padding;
-    bool is_ubwc;
-    int num_folds;
-    uintptr_t desc_address;
-    int desc_size;
-  } t_dma_prepare_params;
+  typedef void* t_stDmaWrapperDmaStats;
 
-  /**
-   * Params needed to move data
+  /*!
+   * Transfer type
    */
-  typedef struct {
-    void* handle;
-    int xoffset;
-    int yoffset;
-    int roi_width;
-    int roi_height;
-    int offset;
-    int l2_chroma_offset;
-    int ncomponents;
-    uintptr_t ping_buffer;
-  } t_dma_move_params;
+  typedef enum eDmaWrapper_TransationType {
+      //! DDR to L2 transfer
+      eDmaWrapper_DdrToL2,
+      //! L2 to DDR transfer
+      eDmaWrapper_L2ToDdr,
+  } t_eDmaWrapper_TransationType;
 
-  /**
-   * Params for alignment of roi and frame
+  /*!
+   * Roi Properties
    */
-  typedef struct {
-    int u16W;
-    int u16H;
-  } t_dma_pix_align_info;
+  typedef struct stDmaWrapper_Roi {
+      //! ROI x position in pixels
+      uint16 u16X;
+      //! ROI y position in pixels
+      uint16 u16Y;
+      //! ROI width in pixels
+      uint16 u16W;
+      //! ROI height in pixels
+      uint16 u16H;
+  } t_StDmaWrapper_Roi;
 
-  /**
-   * Check for DMA Driver Availability
-   * out: ERR if not available
+  /*!
+   * Frame Properties
    */
-  int dma_is_dma_driver_ready();
+  typedef struct stDmaWrapper_FrameProp {
+      //! Starting physical address to buffer
+      addr_t aAddr;
+      //! Frame height in pixels
+      uint16 u16H;
+      //! Frame width in pixels
+      uint16 u16W;
+      //! Frame stride in pixels
+      uint16 u16Stride;
+  } t_StDmaWrapper_FrameProp;
 
-  /**
-   * Get Format Alignment
-   * desc: check if the frame is aligned */
-  int dma_get_format_alignment(t_eDmaFmt fmt, bool is_ubwc, t_dma_pix_align_info &pix_align);
-
-
-  /**
-   * dma_lookup_physical_address
-   * desc: look up the physical address
+  /*!
+   * Roi alignment
    */
-  uintptr_t dma_lookup_physical_address(uintptr_t vaddr);
+  typedef struct stDmaWrapper_RoiAlignInfo {
+      //! ROI width in pixels
+      uint16 u16W;
+      //! ROI height in pixels
+      uint16 u16H;
+  } t_StDmaWrapper_RoiAlignInfo;
 
-  /**
-   *  Get Minimum ROI Size
-   * desc: check if roi size is aligned
+  /*!
+   * DmaTransferSetup Properties
    */
-  int dma_get_min_roi_size(t_eDmaFmt fmt, bool is_ubwc, t_dma_pix_align_info &pix_align);
 
-  /**
-   *  Allocate DMA Engine
-   * allocate dma engtines
-   */
-  void* dma_allocate_dma_engine();
+  typedef struct stDmaWrapper_DmaTransferSetup {
+      //! Format
+      t_eDmaFmt eFmt;
+       bool bIsFmtUbwc;
+      //! Frame Width in pixels
+      uint16 u16FrameW;
+      //! Frame height in pixels
+      uint16 u16FrameH;
+       //! Frame stride in pixels
+       uint16 u16FrameStride;
+      //! ROI x position in pixels
+      uint16 u16RoiX;
+      //! ROI y position in pixels
+      uint16 u16RoiY;
+      //! ROI width in pixels
+      uint16 u16RoiW;
+      //! ROI height in pixels
+      uint16 u16RoiH;
+       //! ROI stride in pixels
+       uint16 u16RoiStride;
+      //! Should the intermediate buffer be padded. This only apply for 8bit format sucha NV12, NV12-4R
+      bool bUse16BitPaddingInL2;
+      //! Virtual address of the HW descriptor buffer (must be locked in the L2$).
+       void* pDescBuf;
+      //! Virtual address of the TCM pixeldata buffer (must be locked in the L2$).
+       void*  pTcmDataBuf;
+      //! Virtual address of the DDR Frame buffer .
+       void*  pFrameBuf;
+      //! TransferType: eDmaWrapper_DdrToL2 (Read from DDR), eDmaWrapper_L2ToDDR (Write to DDR);
+       t_eDmaWrapper_TransationType eTransferType;
+  } t_StDmaWrapper_DmaTransferSetup;
 
-  /**
-   * Get Descriptor Size
-   * get the descriptor size
+  /*!
+   * @brief      Allocated a DMA Descriptor
+   * @description Maintain a pool of descriptors
+   *
+   * @return      Descriptor
    */
-  qurt_size_t dma_get_descriptor_size(t_eDmaFmt* fmtType, int ncomponents, int nfolds);
+  void* desc_pool_get (unsigned int size);
 
-  /**
-   * Get Stride
-   * get luma and chroma stride from dma 
+  /*!
+   * @brief       Put back DMA escriptor
+   * @description Frees a descriptor and return it to the pool of descriptors
+   *
+   * @return      Success
    */
-  int dma_get_stride(t_eDmaFmt, bool is_ubwc, t_dma_pix_align_info roi_dims);
+  int desc_pool_put (void *desc);
 
-  /**
-   * Get Memory Pool ID
-   * qurt call for alloxation of l2 cache
+  /*!
+   * @brief     Frees the pool of descriptor
+   * @description Traverses through the list once release is called
+   *
+   * @return      None
    */
-  int dma_get_mem_pool_id(qurt_mem_pool_t* pool_tcm);
+  void desc_pool_free ();
 
-  /**
-   * Allocate and lock Cache for DMA
-   * allocate and lock cache for tcm and descriptors
+  /*!
+   * Handle for wrapper DMA engine
    */
-  int dma_allocate_cache(qurt_mem_pool_t pool_tcm, qurt_size_t tcm_size, uintptr_t* region_tcm, \
-                         uintptr_t* tcm_vaddr);
+  typedef void* t_DmaWrapper_DmaEngineHandle;
 
-  /**
-   * dma_prepare_for_transfer
-   * prepare dma for tramsfer
+  /*!
+   * @brief       Allocates a DMA Engine to be used
+   *
+   * @description Allocates a DMA Engine to be used by using the default
+   *              wait type (polling).
+   *
+   * @return      Success: Engine's DMA Handle
+   * @n           Failure: NULL
    */
-  // TODO: Really not a pointer?
-  int dma_prepare_for_transfer(t_dma_prepare_params params);
+  extern t_DmaWrapper_DmaEngineHandle hDmaWrapper_AllocDma(void);
 
-  /**
-   * dma_wait
-   * Blocks new ops till other DMA operations are finished
-   * in:dma_handle
-   * need to sync with the dma 
+  /*!
+   * @brief       Frees a DMA Engine
+   *
+   * @description Frees a DMA Engine that was previously allocated by AllocDma().
+   *
+   * @input       hDmaHandle - Engine's DMA Handle
+   *
+   * @return      Success: OK
+   * @n           Failure: ERR
    */
-  int dma_wait(void* handle);
+  extern int32 nDmaWrapper_FreeDma(t_DmaWrapper_DmaEngineHandle hDmaHandle);
 
-  /**
-   * DMA Move Data
-   * actual DMA data transfer
+  /*!
+   * @brief       Starts a transfer request on the DMA engine
+   *
+   * @description Starts a transfer on the provided DMA engine. The transfer is based
+   *              on descriptors constructed in earlier nDmaWrapper_Prepare() and
+   *              nDmaWrapper_Update() calls.
+   *
+   * @input       hDmaHandle - Engine's DMA Handle
+   *
+   * @return      Success: OK
+   * @n           Failure: ERR
    */
-  // TODO: Really not a pointer?
-  int dma_move_data(t_dma_move_params params);
+  extern int32 nDmaWrapper_Move(t_DmaWrapper_DmaEngineHandle hDmaHandle);
 
-  /**
-   * Unlock Cache for DMA
-   * unlock cache 
+  /*!
+   * @brief       Waits for all outstanding transfers on the DMA to complete
+   *
+   * @description Blocks until all outstanding transfers on the DMA are complete.
+   *              The wait type is based on the type specified when allocating the
+   *              engine.
+   *
+   * @input       hDmaHandle - Engine's DMA Handle
+   *
+   * @return      Success: OK
+   * @n           Failure: ERR
    */
-  int dma_unlock_cache(uintptr_t cache_addr, qurt_size_t cache_size);
+  extern int32 nDmaWrapper_Wait(t_DmaWrapper_DmaEngineHandle hDmaHandle);
 
-  /**
-   *  dma_free_dma_engine
-   * Free DMA
+  /*!
+   * @brief       Cleans up all transfers and flushes DMA buffers
+   *
+   * @description This call flushes the DMA buffers.
+   *              Blocks until the flush of the DMA is complete.
+   *
+   * @input       hDmaHandle - Engine's DMA Handle
+   *
+   * @return      Success: OK
+   * @n           Failure: ERR
    */
-  int dma_free_dma_engine(void* handle);
+  extern int32 nDmaWrapper_FinishFrame(t_DmaWrapper_DmaEngineHandle hDmaHandle);
 
-  /**
-   *  dma_finish_frame
-   * signal the end of frame
+  /*!
+   * @brief       Get the recommended walk ROI width and height
+   *
+   * @description Get the recommended walk ROI width and height that should
+   *              be used if walking the entire frame. The ROI returned is always
+   *              in terms of frame dimensions. This function is different from
+   *              nDmaWrapper_GetRecommendedRoi() as coordinates are not used.
+   *
+   * @input       eFmtId - Format ID
+   * @input       bIsUbwc - Is the format UBWC (TRUE/FALSE)
+   * @inout       pStWalkSize - Initial walk size, will be overwritten with
+   *                            the recommended walk size to align with DMA
+   *                            requirements
+   *
+   * @return      Success: OK
+   * @n           Failure: ERR
    */
-  int dma_finish_frame(void* handle);
+  extern int32 nDmaWrapper_GetRecommendedWalkSize(t_eDmaFmt eFmtId, bool bIsUbwc,
+                                                  t_StDmaWrapper_RoiAlignInfo* pStWalkSize);
 
-  /**
-   *  dma_delete_mem_region
-   * in: qurt_mem_region_t
-   * do the deletion
+  /*!
+   * @brief       Get the HW descriptor buffer size per DMA engine
+   *
+   * @description Calculates the HW descriptor buffer size based
+   *              on the formats that will be used with the engine.
+   *
+   * @input       aeFmtId - Array of format IDs, such as eDmaFmt_NV12, eDmaFmt_NV12_Y,
+   *                        eDmaFmt_NV12_UV etc..
+   * @input       nsize - Number of format IDs provided
+   *
+   * @return      Descriptor buffer size in bytes
    */
-  void dma_delete_mem_region(uintptr_t tcm_reg);
+  extern int32 nDmaWrapper_GetDescbuffsize(t_eDmaFmt *aeFmtId, uint16 nsize);
 
-  /**
-   * dma_get_thread_id
-   * out: unsigned int
+  /*!
+   * @brief       Get the recommended intermediate buffer stride.
+   *
+   * @description Get the recommended (minimum) intermediate buffer stride for the
+   *              L2 Cache that is used transfer data from/to DDR. The stride is
+   *              greater than or equal to the width and must be a multiple of 256.
+   *
+   * @input       eFmtId - Format ID
+   * @input         pStRoiSize - The ROI that will be used (should be aligned with
+   *                           the DMA requirements for the format)
+   * @input         bIsUbwc - Is the format UBWC (TRUE/FALSE)
+   *
+   * @return      Success: The intermediate buffer stride in pixels
+   * @n           Failure: ERR
    */
-  unsigned int dma_get_thread_id();
+  extern int32 nDmaWrapper_GetRecommendedIntermBufStride(t_eDmaFmt eFmtId,
+                                                         t_StDmaWrapper_RoiAlignInfo* pStRoiSize,
+                                                         bool bIsUbwc);
+
+  /*!
+   * @brief       Dma transfer parameters per HW descriptor
+   *
+   * @description Setup Dma transfer parameters required to be ready to make DMA transfer.
+   *              call this API multiple to create a descriptor link list
+   *
+   * @input       hDmaHandle - Wrapper's DMA Handle. Represents
+   *                  t_StDmaWrapper_DmaEngine.
+   * @input       stpDmaTransferParm - Dma Transfer parameters. Each element describes
+   *                  complete Frame/ROI details for this Dma transfer
+   *
+   * @return      Success: OK
+   *              Failure: ERR
+   */
+  extern int32 nDmaWrapper_DmaTransferSetup(t_DmaWrapper_DmaEngineHandle hDmaHandle, t_StDmaWrapper_DmaTransferSetup* stpDmaTransferParm);
+
+  /** @example dma_memcpy.c
+   *  Copies one region of memory to another.
+   *  @example dma_memcpy.h
+   *  @example dma_memcpy_test.c
+   */
+
+  /** @example dma_blend.c
+   *  DMA Blend App. Will read 2 frames from DDR, blend them and output
+   *  the result to DDR.
+   *  @example dma_blend.h
+   *  @example dma_blend_test.c
+   */
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
1. Removed the Shim file and moved the DMA code to mock DMA driver
2. Modified hexagon_dma.cpp to invoke the actual DMA Driver APIs 
3. replaced _Prepare() and _Update() with _DmaTransferSetup() API to make the DMA driver call Halide friendly 

Note: We are seeing a segmentation fault when the Width is not a multiple of 256, and the fault is coming from code outside of hexagon DMA 