### PR TITLE
allow build to proceed when llvm-config --system-libs is empty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ if("${HALIDE_SYSTEM_LIBS}" STREQUAL "")
   # It's theoretically possible that this could be legitimately empty,
   # but in practice that doesn't really happen, so we'll assume it means we
   # aren't configured correctly.
-  message(FATAL_ERROR "'llvm-config --system-libs' is empty; this is probably wrong.")
+  message(WARNING "'llvm-config --system-libs' is empty; this is possibly wrong.")
 endif()
 
 # Check LLVM

--- a/halide.cmake
+++ b/halide.cmake
@@ -618,7 +618,7 @@ if("${HALIDE_SYSTEM_LIBS}" STREQUAL "")
   if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/halide_config.cmake")
     include("${CMAKE_CURRENT_LIST_DIR}/halide_config.cmake")
   else()
-    message(FATAL_ERROR "HALIDE_SYSTEM_LIBS is not set and we could not find halide_config.cmake")
+    message(WARNING "HALIDE_SYSTEM_LIBS is not set and we could not find halide_config.cmake")
   endif()
 endif()
 


### PR DESCRIPTION
Changed .cmake files since newer versions of llvm appear to normally have the --system-libs option empty which prevented me from proceeding with the build. Works for llvm-4.0. 