### PR TITLE
Faster skip stages2

### DIFF
--- a/src/HalideFooter.h
+++ b/src/HalideFooter.h
@@ -9,3 +9,5 @@
 #undef internal_assert
 #undef halide_runtime_error
 #undef EXPORT
+#undef TICK
+#undef TOCK

--- a/src/HalideFooter.h
+++ b/src/HalideFooter.h
@@ -9,5 +9,3 @@
 #undef internal_assert
 #undef halide_runtime_error
 #undef EXPORT
-#undef TICK
-#undef TOCK

--- a/src/SkipStages.cpp
+++ b/src/SkipStages.cpp
@@ -10,6 +10,8 @@
 #include "Simplify.h"
 #include "Substitute.h"
 
+#include <iterator>
+
 namespace Halide {
 namespace Internal {
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -435,13 +435,13 @@ struct TickStackEntry {
 
 vector<TickStackEntry> tick_stack;
 
-void tick_impl(const char *file, int line) {
+void halide_tic_impl(const char *file, int line) {
     string f = file;
     f = split_string(f, "/").back();
     tick_stack.push_back({std::chrono::high_resolution_clock::now(), f, line});
 }
 
-void tock_impl(const char *file, int line) {
+void halide_toc_impl(const char *file, int line) {
     auto t1 = tick_stack.back();
     auto t2 = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> diff = t2 - t1.time;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <string>
 #include <iomanip>
+#include <chrono>
 
 #ifdef _MSC_VER
 #include <io.h>
@@ -424,6 +425,33 @@ bool mul_would_overflow(int bits, int64_t a, int64_t b) {
         // 64-bit overflow.
         return ab < min_val || ab > max_val || (ab / a != b);
     }
+}
+
+struct TickStackEntry {
+    std::chrono::time_point<std::chrono::high_resolution_clock> time;
+    string file;
+    int line;
+};
+
+vector<TickStackEntry> tick_stack;
+
+void tick_impl(const char *file, int line) {
+    string f = file;
+    f = split_string(f, "/").back();
+    tick_stack.push_back({std::chrono::high_resolution_clock::now(), f, line});
+}
+
+void tock_impl(const char *file, int line) {
+    auto t1 = tick_stack.back();
+    auto t2 = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> diff = t2 - t1.time;
+    tick_stack.pop_back();
+    for (size_t i = 0; i < tick_stack.size(); i++) {
+        debug(0) << "  ";
+    }
+    string f = file;
+    f = split_string(f, "/").back();
+    debug(0) << t1.file << ":" << t1.line << " ... " << f << ":" << line << " : " << diff.count() * 1000 << " ms\n";
 }
 
 }

--- a/src/Util.h
+++ b/src/Util.h
@@ -321,18 +321,22 @@ using make_index_sequence = make_integer_sequence<size_t, N>;
 
 #endif
 
-// Helpers for timing blocks of code. Put 'TICK;' at the start and
-// 'TOCK;' at the end. Timing is reported at the tock via
+// Helpers for timing blocks of code. Put 'TIC;' at the start and
+// 'TOC;' at the end. Timing is reported at the toc via
 // debug(0). The calls can be nested and will pretty-print
 // appropriately. Took this idea from matlab via Jon Barron.
 //
 // Note that this uses global state internally, and is not thread-safe
 // at all. Only use it for single-threaded debugging sessions.
 
-void tick_impl(const char *file, int line);
-void tock_impl(const char *file, int line);
-#define TICK tick_impl(__FILE__, __LINE__)
-#define TOCK tock_impl(__FILE__, __LINE__)
+void halide_tic_impl(const char *file, int line);
+void halide_toc_impl(const char *file, int line);
+#define HALIDE_TIC Halide::Internal::halide_tic_impl(__FILE__, __LINE__)
+#define HALIDE_TOC Halide::Internal::halide_toc_impl(__FILE__, __LINE__)
+#ifdef COMPILING_HALIDE
+#define TIC HALIDE_TIC
+#define TOC HALIDE_TOC
+#endif
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Util.h
+++ b/src/Util.h
@@ -321,6 +321,19 @@ using make_index_sequence = make_integer_sequence<size_t, N>;
 
 #endif
 
+// Helpers for timing blocks of code. Put 'TICK;' at the start and
+// 'TOCK;' at the end. Timing is reported at the tock via
+// debug(0). The calls can be nested and will pretty-print
+// appropriately. Took this idea from matlab via Jon Barron.
+//
+// Note that this uses global state internally, and is not thread-safe
+// at all. Only use it for single-threaded debugging sessions.
+
+void tick_impl(const char *file, int line);
+void tock_impl(const char *file, int line);
+#define TICK tick_impl(__FILE__, __LINE__)
+#define TOCK tock_impl(__FILE__, __LINE__)
+
 }  // namespace Internal
 }  // namespace Halide
 


### PR DESCRIPTION
Mostly in the case where no stages are skipped. It does a single pass
over the IR looking for candidates instead of one pass per Func.

On local laplacian this reduces stage skipping from 11ms to 0.13ms

Also included the timing helpers I wrote to make timing this sort of
thing inside the compiler easier.

Built on top of PR #2528