### PR TITLE
Print submodules in stmt and HTML files

### DIFF
--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -55,7 +55,11 @@ ostream &operator<<(ostream &stream, const Buffer<> &buffer) {
 }
 
 ostream &operator<<(ostream &stream, const Module &m) {
-    stream << "Target = " << m.target().to_string() << "\n";
+    for (const auto &s : m.submodules()) {
+        stream << s << "\n";
+    }
+
+    stream << "module name=" << m.name() << ", target=" << m.target().to_string() << "\n";
     for (const auto &b : m.buffers()) {
         stream << b << "\n";
     }

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -63,6 +63,12 @@ EXPORT std::ostream &operator<<(std::ostream &stream, const ForType &);
 /** Emit a halide name mangling value in a human readable format */
 EXPORT std::ostream &operator<<(std::ostream &stream, const NameMangling &);
 
+/** Emit a halide LoweredFunc in a human readable format */
+EXPORT std::ostream &operator<<(std::ostream &stream, const LoweredFunc &);
+
+/** Emit a halide linkage value in a human readable format */
+EXPORT std::ostream &operator<<(std::ostream &stream, const LoweredFunc::LinkageType &);
+
 /** An IRVisitor that emits IR to the given output stream in a human
  * readable form. Can be subclassed if you want to modify the way in
  * which it prints.

--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -632,6 +632,36 @@ public:
         stream << close_div();
     }
 
+    void print(const Module& m) {
+        scope.push(m.name(), unique_id());
+        for (const auto &s : m.submodules()) {
+            print(s);
+        }
+
+        int id = unique_id();
+        stream << open_expand_button(id);
+        stream << open_div("Module");
+        stream << open_span("Matched");
+        stream << keyword("module") << " name=" << m.name() << ", target=" << m.target().to_string();
+        stream << close_span();
+        stream << close_expand_button();
+        stream << " " << matched("{");
+
+        stream << open_div("ModuleBody Indent", id);
+
+        for (const auto &b : m.buffers()) {
+            print(b);
+        }
+        for (const auto &f : m.functions()) {
+            print(f);
+        }
+
+        stream << close_div();
+        stream << matched("}");
+        stream << close_div();
+        scope.pop(m.name());
+    }
+
     StmtToHtml(string filename) : id_count(0), context_stack(1, 0) {
         stream.open(filename.c_str());
         stream << "<head>";
@@ -700,12 +730,7 @@ void print_to_html(string filename, Stmt s) {
 
 void print_to_html(string filename, const Module &m) {
     StmtToHtml sth(filename);
-    for (const auto &b : m.buffers()) {
-        sth.print(b);
-    }
-    for (const auto &f : m.functions()) {
-        sth.print(f);
-    }
+    sth.print(m);
 }
 
 }


### PR DESCRIPTION
Currently, when outputting a stmt or HTML file, submodules are gone, having been resolved to the appropriate blobs. This PR fixes that, so the stmt and HTML file have the contents of the submodules prior to resolving them.