### PR TITLE
Expose source code locations for Func definitions

### DIFF
--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -136,6 +136,10 @@ public:
         vector<vector<CondValue>> compute_exprs_helper(const Definition& def, bool is_update) {
             vector<vector<CondValue>> result(2); // <args, values>
 
+            if (!def.defined()) {
+                return result;
+            }
+
             // Default case (no specialization)
             vector<Expr> predicates = def.split_predicate();
             for (const ReductionVariable &rv : def.schedule().rvars()) {

--- a/src/Definition.cpp
+++ b/src/Definition.cpp
@@ -3,6 +3,7 @@
 #include "IR.h"
 #include "IROperator.h"
 #include "IRMutator.h"
+#include "Introspection.h"
 #include "Definition.h"
 #include "Var.h"
 
@@ -20,6 +21,7 @@ struct DefinitionContents {
     std::vector<Expr> values, args;
     StageSchedule stage_schedule;
     std::vector<Specialization> specializations;
+    std::string source_location;
 
     DefinitionContents() : is_init(true), predicate(const_true()) {}
 
@@ -78,7 +80,7 @@ EXPORT void destroy<DefinitionContents>(const DefinitionContents *d) {
     delete d;
 }
 
-Definition::Definition() : contents(new DefinitionContents) {}
+Definition::Definition() : contents(nullptr) {}
 
 Definition::Definition(const IntrusivePtr<DefinitionContents> &ptr) : contents(ptr) {
     internal_assert(ptr.defined())
@@ -91,6 +93,7 @@ Definition::Definition(const std::vector<Expr> &args, const std::vector<Expr> &v
     contents->is_init = is_init;
     contents->values = values;
     contents->args = args;
+    contents->source_location = Introspection::get_source_location();
     if (rdom.defined()) {
         contents->predicate = rdom.predicate();
         for (size_t i = 0; i < rdom.domain().size(); i++) {
@@ -108,6 +111,7 @@ Definition Definition::get_copy() const {
     copy.contents->values = contents->values;
     copy.contents->args = contents->args;
     copy.contents->stage_schedule = contents->stage_schedule.get_copy();
+    copy.contents->source_location = contents->source_location;
 
     // Deep-copy specializations
     for (const Specialization &s : contents->specializations) {
@@ -118,6 +122,10 @@ Definition Definition::get_copy() const {
         copy.contents->specializations.push_back(std::move(s_copy));
     }
     return copy;
+}
+
+bool Definition::defined() const {
+    return contents.defined();
 }
 
 bool Definition::is_init() const {
@@ -176,6 +184,10 @@ std::vector<Specialization> &Definition::specializations() {
 
 const std::vector<Specialization> &Definition::specializations() const {
     return contents->specializations;
+}
+
+std::string Definition::source_location() const {
+    return contents->source_location;
 }
 
 const Specialization &Definition::add_specialization(Expr condition) {

--- a/src/Definition.cpp
+++ b/src/Definition.cpp
@@ -193,10 +193,12 @@ std::string Definition::source_location() const {
 const Specialization &Definition::add_specialization(Expr condition) {
     Specialization s;
     s.condition = condition;
+    s.definition.contents = new DefinitionContents;
     s.definition.contents->is_init = contents->is_init;
     s.definition.contents->predicate = contents->predicate;
     s.definition.contents->values = contents->values;
     s.definition.contents->args   = contents->args;
+    s.definition.contents->source_location = contents->source_location;
 
     // The sub-schedule inherits everything about its parent except for its specializations.
     s.definition.contents->stage_schedule = contents->stage_schedule.get_copy();

--- a/src/Definition.cpp
+++ b/src/Definition.cpp
@@ -105,7 +105,7 @@ Definition::Definition(const std::vector<Expr> &args, const std::vector<Expr> &v
 Definition Definition::get_copy() const {
     internal_assert(contents.defined()) << "Cannot copy undefined Definition\n";
 
-    Definition copy;
+    Definition copy(new DefinitionContents);
     copy.contents->is_init = contents->is_init;
     copy.contents->predicate = contents->predicate;
     copy.contents->values = contents->values;

--- a/src/Definition.h
+++ b/src/Definition.h
@@ -47,7 +47,7 @@ public:
     EXPORT Definition(const std::vector<Expr> &args, const std::vector<Expr> &values,
                       const ReductionDomain &rdom, bool is_init);
 
-    /** Construct an empty Definition. By default, it is a init definition. */
+    /** Construct an undefined Definition object. */
     EXPORT Definition();
 
     /** Return a copy of this Definition. */
@@ -57,6 +57,9 @@ public:
     bool same_as(const Definition &other) const {
         return contents.same_as(other.contents);
     }
+
+    /** Definition objects are nullable. Does this definition exist? */
+    EXPORT bool defined() const;
 
     /** Is this an init definition; otherwise it's an update definition */
     EXPORT bool is_init() const;
@@ -107,6 +110,11 @@ public:
     EXPORT const Specialization &add_specialization(Expr condition);
     // @}
 
+    /** Attempt to get the source file and line where this definition
+     * was made using DWARF introspection. Returns an empty string if
+     * no debug symbols were found or the debug symbols were not
+     * understood. Works on OS X and Linux only. */
+    EXPORT std::string source_location() const;
 };
 
 struct Specialization {

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1732,6 +1732,14 @@ Stage &Stage::prefetch(const Internal::Parameter &param, VarOrRVar var, Expr off
     return *this;
 }
 
+/** Attempt to get the source file and line where this stage was
+ * defined by parsing the process's own debug symbols. Returns an
+ * empty string if no debug symbols were found or the debug
+ * symbols were not understood. Works on OS X and Linux only. */
+std::string Stage::source_location() const {
+    return definition.source_location();
+}
+
 void Func::invalidate_cache() {
     if (pipeline_.defined()) {
         pipeline_.invalidate_cache();
@@ -2860,6 +2868,11 @@ Pipeline Func::pipeline() {
 
 vector<Argument> Func::infer_arguments() const {
     return Pipeline(*this).infer_arguments();
+}
+
+std::string Func::source_location() const {
+    user_assert(defined()) << "A Func with no definition has no source_location\n";
+    return func.definition().source_location();
 }
 
 Module Func::compile_to_module(const vector<Argument> &args, const std::string &fn_name, const Target &target) {

--- a/src/Func.h
+++ b/src/Func.h
@@ -298,6 +298,12 @@ public:
         return prefetch(image.parameter(), var, offset, strategy);
     }
     // @}
+
+    /** Attempt to get the source file and line where this stage was
+     * defined by parsing the process's own debug symbols. Returns an
+     * empty string if no debug symbols were found or the debug
+     * symbols were not understood. Works on OS X and Linux only. */
+    EXPORT std::string source_location() const;
 };
 
 // For backwards compatibility, keep the ScheduleHandle name.
@@ -2056,6 +2062,10 @@ public:
      \endcode
      */
     EXPORT std::vector<Argument> infer_arguments() const;
+
+    /** Get the source location of the pure definition of this
+     * Func. See Stage::source_location() */
+    EXPORT std::string source_location() const;
 };
 
 namespace Internal {

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -702,10 +702,13 @@ void Function::define_extern(const std::string &function_name,
     }
 
     // Make some synthetic var names for scheduling purposes (e.g. reorder_storage).
-    auto &pure_def_args = contents->init_def.args();
+    vector<Expr> pure_def_args;
     while ((int)pure_def_args.size() < dimensionality) {
         pure_def_args.push_back(Var(unique_name('e')));
     }
+    ReductionDomain rdom;
+    contents->init_def = Definition(pure_def_args, {}, rdom, true);
+
     // Reset the storage dims to match the pure args
     vector<string> arg_names = this->args();
     contents->func_schedule.storage_dims().clear();
@@ -713,6 +716,7 @@ void Function::define_extern(const std::string &function_name,
         StorageDim sd {arg_names[i]};
         contents->func_schedule.storage_dims().push_back(sd);
     }
+
 }
 
 void Function::accept(IRVisitor *visitor) const {

--- a/src/Function.h
+++ b/src/Function.h
@@ -144,7 +144,7 @@ public:
     EXPORT const Definition &definition() const;
 
     /** Get the pure arguments. */
-    EXPORT const std::vector<std::string> args() const;
+    EXPORT const std::vector<std::string> &args() const;
 
     /** Get the dimensionality. */
     EXPORT int dimensions() const;
@@ -157,7 +157,8 @@ public:
     /** Get the types of the outputs. */
     EXPORT const std::vector<Type> &output_types() const;
 
-    /** Get the right-hand-side of the pure definition. */
+    /** Get the right-hand-side of the pure definition. Returns an
+     * empty vector if there is no pure definition. */
     EXPORT const std::vector<Expr> &values() const;
 
     /** Does this function have a pure definition? */
@@ -232,7 +233,7 @@ public:
     EXPORT void define_extern(const std::string &function_name,
                               const std::vector<ExternFuncArgument> &args,
                               const std::vector<Type> &types,
-                              int dimensionality,
+                              const std::vector<std::string> &dims,
                               NameMangling mangling,
                               DeviceAPI device_api,
                               bool uses_old_buffer_t);

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1096,7 +1096,7 @@ bool validate_schedule(Function f, Stmt s, const Target &target, bool is_output,
     }
 
     // Emit a warning if only some of the steps have been scheduled.
-    bool any_scheduled = f.definition().schedule().touched();
+    bool any_scheduled = f.has_pure_definition() && f.definition().schedule().touched();
     for (const Definition &r : f.updates()) {
         any_scheduled = any_scheduled || r.schedule().touched();
     }
@@ -1118,7 +1118,9 @@ bool validate_schedule(Function f, Stmt s, const Target &target, bool is_output,
     // If the func is scheduled on the gpu, check that the relevant
     // api is enabled in the target.
     vector<Definition> definitions;
-    definitions.push_back(f.definition());
+    if (f.has_pure_definition()) {
+        definitions.push_back(f.definition());
+    }
     for (const Definition &def : f.updates()) {
         definitions.push_back(def);
     }

--- a/src/SimplifySpecializations.cpp
+++ b/src/SimplifySpecializations.cpp
@@ -122,6 +122,8 @@ vector<Definition> propagate_specialization_in_definition(Definition &def, const
         const EQ *eq = c.as<EQ>();
         const Variable *var = eq ? eq->a.as<Variable>() : c.as<Variable>();
 
+        internal_assert(s_def.defined());
+
         vector<Definition> s_result = propagate_specialization_in_definition(s_def, name);
 
         if (var && eq) {
@@ -156,7 +158,9 @@ vector<Definition> propagate_specialization_in_definition(Definition &def, const
 void simplify_specializations(map<string, Function> &env) {
     for (auto &iter : env) {
         Function &func = iter.second;
-        propagate_specialization_in_definition(func.definition(), func.name());
+        if (func.definition().defined()) {
+            propagate_specialization_in_definition(func.definition(), func.name());
+        }
     }
 }
 

--- a/test/correctness/extern_producer.cpp
+++ b/test/correctness/extern_producer.cpp
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
                              std::vector<ExternFuncArgument>(),
                              Float(32), 2);
         // Row stride should be 128B/32-element aligned.
-        source.align_storage(Var("e0"), 32);
+        source.align_storage(_0, 32);
         Func sink;
         sink(x, y) = source(x, y) - sin(x + y);
 

--- a/test/correctness/introspection.cpp
+++ b/test/correctness/introspection.cpp
@@ -1,6 +1,8 @@
 #include "Halide.h"
 #include <stdio.h>
 
+using namespace Halide;
+
 // The check has to go in the Halide namespace, because get_source_location looks for the first thing outside of it
 namespace Halide {
 void check(const void *var, const std::string &type,
@@ -180,6 +182,21 @@ int main(int argc, char **argv) {
     check(&SomeStruct::static_member_double_array[5], "double", "SomeStruct::static_member_double_array[5]", __FILE__, __LINE__);
 
     check(&SomeStruct::substruct.a, "int", "SomeStruct::substruct.a", __FILE__, __LINE__);
+
+    // Check that we can query front-end objects for their source locations
+    {
+        std::string loc;
+        Func f;
+        Var x;
+        f(x) = x;
+        loc = std::string(__FILE__) + ":" + std::to_string(__LINE__ - 1);
+        assert(f.source_location() == loc);
+
+        f(x) += 1;
+        loc = std::string(__FILE__) + ":" + std::to_string(__LINE__ - 1);
+        assert(f.update().source_location() == loc);
+    }
+
 
     printf("Success!\n");
 


### PR DESCRIPTION
Feature request from some Stanford hardware folks, in order to be able
to report better debug info from their backends. The task of actually
plumbing the source location from the Definition object down to their
backend is yet to be done. It can be accessed via the FunctionPtr on a
Call node. We should possibly preserve it in some other way after
storage flattening (Maybe on ProducerConsumer nodes?)

It may also be interesting to expose this to tracing or the profiler.

@rdaly525 @jeffsetter