### PR TITLE
Revise the run_tests, test_correctness, etc targets in CMake for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,13 +217,16 @@ foreach (build_config Debug Release RelWithDebInfo MinSizeRel)
   endforeach()
 endforeach()
 
-function(define_group GROUP)
+function(define_test_group GROUP)
   if(TARGET "${GROUP}")
     message(FATAL_ERROR "Group ${GROUP} is already defined.")    
   endif()
   add_custom_target("${GROUP}")
   set_target_properties("${GROUP}" PROPERTIES EXCLUDE_FROM_ALL TRUE)
 endfunction()
+
+define_test_group(build_tests)
+define_test_group(run_tests)
 
 # Make a target that aggregates a number of other targets;
 # this can be used to group builds (e.g. "build_tests")
@@ -241,74 +244,59 @@ endfunction()
 # TODO(srj): add test_bazel variant
 # TODO(srj): add test_python variant
 # TODO(srj): add test_apps variant
-function(add_to_group GROUP TARGET)
-  set(options BUILD EXECUTE)
+function(add_test TARGET)
+  set(options EXPECT_FAILURE)
   set(oneValueArgs WORKING_DIRECTORY)
-  set(multiValueArgs )
+  set(multiValueArgs GROUPS)
   cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-  if(NOT TARGET "${GROUP}")
-    define_group("${GROUP}")
-  endif()
-  if (${args_EXECUTE})
-    # Execute the target (e.g. for a test_foo target)
-    set(NAME "_execute_${TARGET}")
-    get_target_property(TARGET_TYPE "${TARGET}" TYPE)
-    if("${TARGET_TYPE}" STREQUAL "EXECUTABLE")
-      add_custom_target("${NAME}" 
-                         COMMAND "${TARGET}"
-                         WORKING_DIRECTORY ${args_WORKING_DIRECTORY}
-                         COMMENT "Executing ${TARGET}"
-                         DEPENDS "${TARGET}")
-    elseif("${TARGET_TYPE}" STREQUAL "UTILITY")
-      # It's probably a custom target or a group: just depend on it.
-      add_custom_target("${NAME}" 
-                         DEPENDS "${TARGET}")
-    else()
-      message(FATAL_ERROR "add_to_group(): unsupported type ${TARGET_TYPE} for ${TARGET}")
+  foreach(GROUP ${args_GROUPS})
+    if(NOT TARGET "${GROUP}")
+      define_test_group("${GROUP}")
     endif()
-  elseif(${args_BUILD})
-    # Just depend on the target (e.g. for a build_foo target)
-    set(NAME "_build_${TARGET}")
-    add_custom_target("${NAME}" 
-                       DEPENDS "${TARGET}")
+  endforeach()
+
+  set(BUILD_NAME "${TARGET}")
+  # add_custom_target("${BUILD_NAME}" DEPENDS "${TARGET}")
+  set_target_properties("${BUILD_NAME}" PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  add_dependencies(build_tests "${BUILD_NAME}")
+
+  set(EXEC_NAME "run_${TARGET}")
+  get_target_property(TARGET_TYPE "${TARGET}" TYPE)
+  if("${TARGET_TYPE}" STREQUAL "EXECUTABLE")
+    if(${args_EXPECT_FAILURE})
+      set(COMMAND "${CMAKE_SOURCE_DIR}/test/common/expect_failure.sh" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TARGET}")
+    else()
+      set(COMMAND "${TARGET}")
+    endif()
+    add_custom_target("${EXEC_NAME}" 
+                     COMMAND ${COMMAND}
+                     WORKING_DIRECTORY ${args_WORKING_DIRECTORY}
+                     COMMENT "Executing ${TARGET}"
+                     DEPENDS "${TARGET}")
+  elseif("${TARGET_TYPE}" STREQUAL "UTILITY")
+    # It's probably a custom target or a group: just depend on it.
+    add_custom_target("${EXEC_NAME}" DEPENDS "${TARGET}")
   else()
-    message(FATAL_ERROR "add_to_group() requires BUILD or EXECUTE")
+    message(FATAL_ERROR "add_test(): unsupported type ${TARGET_TYPE} for ${TARGET}")
   endif()
-  set_target_properties("${NAME}" PROPERTIES EXCLUDE_FROM_ALL TRUE)
-  add_dependencies("${GROUP}" "${NAME}")
+  set_target_properties("${EXEC_NAME}" PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  foreach(GROUP ${args_GROUPS})
+    add_dependencies("${GROUP}" "${EXEC_NAME}")
+  endforeach()
+
 endfunction()
 
 # Only groups that are defined in *this file* will have projects reliably
 # defined for them in MSVC builds; pre-define the targets we want to be available
 # here to ensure that happens.
-define_group(build_tests)
-define_group(test_auto_schedule)
-define_group(test_correctness)
-define_group(test_error)
-define_group(test_generator)
-define_group(test_internal)
-define_group(test_opengl)
-define_group(test_performance)
-define_group(test_tutorials)
-define_group(test_warning)
-
-define_group(run_tests)
-if(WITH_TESTS)
-  add_to_group(run_tests test_correctness BUILD)
-  add_to_group(run_tests test_error BUILD)
-  add_to_group(run_tests test_generator BUILD)
-  add_to_group(run_tests test_internal BUILD)
-  add_to_group(run_tests test_warning BUILD)
-endif()
-if(WITH_TUTORIALS)
-  add_to_group(run_tests test_tutorials BUILD)
-endif()
-
-# TODO(srj): these need to be run one-at-a-time, without any -j option,
-# otherwise we can get false slowdown failures.
-# add_to_group(run_tests test_performance BUILD)
-# add_to_group(run_tests test_auto_schedule BUILD)
-
+define_test_group(test_auto_schedule)
+define_test_group(test_correctness)
+define_test_group(test_error)
+define_test_group(test_generator)
+define_test_group(test_opengl)
+define_test_group(test_performance)
+define_test_group(test_tutorials)
+define_test_group(test_warning)
 
 add_subdirectory(src)
 option(WITH_TESTS "Build tests" ON)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,8 +96,6 @@ if (WITH_TEST_GENERATORS)
 
     set(TARGET "generator_aot_${NAME}")
     add_executable("${TARGET}" "${GEN_TEST_DIR}/${NAME}_aottest.cpp")
-    add_test("${TARGET}"
-             GROUPS test_generators run_tests)
     target_include_directories("${TARGET}" PRIVATE 
                                "${CMAKE_SOURCE_DIR}/tools" 
                                "${CMAKE_SOURCE_DIR}" 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,9 +9,9 @@ option(WITH_TEST_AUTO_SCHEDULE "Build auto_schedule tests" ON)
 
 if (WITH_TEST_INTERNAL)
   message(STATUS "Internal tests enabled")
-  halide_project(_test_internal internal internal.cpp)
-  add_to_group(build_internal _test_internal BUILD)
-  add_to_group(test_internal _test_internal EXECUTE)
+  halide_project(test_internal internal internal.cpp)
+  add_test(test_internal
+           GROUPS run_tests)
 else()
   message(WARNING "Internal tests disabled")
 endif()
@@ -31,23 +31,28 @@ function(tests folder)
   foreach(file ${TESTS})
     string(REPLACE ".cpp" "" name "${file}")
 
-    set(TARGET "build_${folder}_${name}")
-    halide_project("${TARGET}" "${folder}" "${folder}/${file}")
+    set(TARGET "${folder}_${name}")
     list(APPEND TEST_NAMES "${TARGET}")
+
+    halide_project("${TARGET}" "${folder}" "${folder}/${file}")
     target_include_directories("${TARGET}" PRIVATE "${CMAKE_SOURCE_DIR}")
     target_compile_definitions("${TARGET}"  PRIVATE "-DLLVM_VERSION=${LLVM_VERSION}")
 
-    add_to_group(build_tests "${TARGET}" BUILD)
-    if("${folder}" STREQUAL "error")
-      set(EXPECT_FAILURE "${CMAKE_CURRENT_SOURCE_DIR}/common/expect_failure.sh")
-      add_custom_target("${folder}_${name}"
-                        COMMAND "${EXPECT_FAILURE}" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TARGET}"
-                        DEPENDS "${TARGET}")
-      add_dependencies("${folder}_${name}" "${TARGET}")
+    set(GROUPS "test_${folder}")
+    if("${folder}" STREQUAL "performance" OR "${folder}" STREQUAL "auto_schedule")
+      # These shouldn't be part of run_tests, since they must be run with -j for timing purposes
     else()
-      add_to_group(${folder}_${name} "${TARGET}" EXECUTE)
+      list(APPEND GROUPS run_tests)
     endif()
-    add_to_group(test_${folder} "${folder}_${name}" EXECUTE)
+    if("${folder}" STREQUAL "error")
+      add_test("${TARGET}"
+               GROUPS ${GROUPS}
+               EXPECT_FAILURE)
+    else()
+      add_test("${TARGET}"
+               GROUPS ${GROUPS})
+    endif()
+
   endforeach()
   set(TEST_NAMES "${TEST_NAMES}" PARENT_SCOPE)
 endfunction(tests)
@@ -57,7 +62,7 @@ if (WITH_TEST_AUTO_SCHEDULE)
 endif()
 if (WITH_TEST_CORRECTNESS)
   tests(correctness)
-  halide_use_image_io(build_correctness_image_io)
+  halide_use_image_io(correctness_image_io)
   test_plain_c_includes()
 endif()
 if (WITH_TEST_ERROR)
@@ -90,10 +95,7 @@ if (WITH_TEST_GENERATORS)
     cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     set(TARGET "generator_aot_${NAME}")
-
     add_executable("${TARGET}" "${GEN_TEST_DIR}/${NAME}_aottest.cpp")
-    add_to_group(build_tests "${TARGET}" BUILD)
-    add_to_group(test_generator "${TARGET}" EXECUTE)
     target_include_directories("${TARGET}" PRIVATE 
                                "${CMAKE_SOURCE_DIR}/tools" 
                                "${CMAKE_SOURCE_DIR}" 
@@ -109,6 +111,9 @@ if (WITH_TEST_GENERATORS)
                              FILTER_DEPS "${args_FILTER_DEPS}")
       target_link_libraries("${TARGET}" PUBLIC "${NAME}")
     endif()
+
+    add_test("${TARGET}"
+             GROUPS test_generator run_tests)
   endfunction(halide_define_aot_test)
 
   # Find all the files of form "foo_generator.cpp" in test/generator
@@ -171,12 +176,11 @@ if (WITH_TEST_GENERATORS)
   file(GLOB JITTEST_SRCS RELATIVE "${GEN_TEST_DIR}" "${GEN_TEST_DIR}/*_jittest.cpp")
   foreach(FILE ${JITTEST_SRCS})
     string(REPLACE "_jittest.cpp" "" NAME "${FILE}")
-    halide_project("generator_jit_${NAME}"
-                   "generator"
-                   "${GEN_TEST_DIR}/${FILE}")
-    target_link_libraries("generator_jit_${NAME}" PRIVATE "${NAME}.generator")
-    add_to_group(build_tests "generator_jit_${NAME}" BUILD)
-    add_to_group(test_generator "generator_jit_${NAME}" EXECUTE)
+    set(TARGET "generator_jit_${NAME}")
+    halide_project("${TARGET}" "generator" "${GEN_TEST_DIR}/${FILE}")
+    target_link_libraries("${TARGET}" PRIVATE "${NAME}.generator")
+    add_test("${TARGET}"
+             GROUPS test_generator run_tests)
   endforeach()
 
   # ------ Generator tests for ahead-of-time mode: ------

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -21,8 +21,9 @@ function(add_tutorial source_file)
 
   string(REPLACE ".cpp" "" name ${source_file})
   halide_project(${name} "tutorials" ${source_file})
-  add_to_group(test_tutorials "${name}" EXECUTE
-               WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+  add_test("${name}"
+           GROUPS test_tutorials
+           WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
   target_include_directories(${name} PRIVATE "${CMAKE_SOURCE_DIR}/tools")
   if (SUPPORT_NO_UNUSED_BUT_SET_VARIABLE)
     target_compile_options(${name} PRIVATE "-Wno-unused-but-set-variable")


### PR DESCRIPTION
As it turns out, the equivalence of certain CMake features between Makefile targets and MSVC targets is not exactly as advertised.

(Note that test_error still doesn't work properly for MSVC since it relies on a bash script; that will be fixed separately)