### PR TITLE
Turn on PCH for g++ builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -718,6 +718,8 @@ endif
 $(INCLUDE_DIR)/Halide.h: $(HEADERS) $(SRC_DIR)/HalideFooter.h $(BIN_DIR)/build_halide_h
 	@mkdir -p $(@D)
 	$(BIN_DIR)/build_halide_h $(HEADERS) $(SRC_DIR)/HalideFooter.h > $(INCLUDE_DIR)/Halide.h
+	# Also generate a precompiled version in the same folder so that anything compiled with a compatible set of flags can use it
+	$(CXX) -std=c++11 $(TEST_CXX_FLAGS) -I$(ROOT_DIR) $(OPTIMIZE) -x c++-header $(INCLUDE_DIR)/Halide.h -o $(INCLUDE_DIR)/Halide.h.gch
 
 $(INCLUDE_DIR)/HalideRuntime%: $(SRC_DIR)/runtime/HalideRuntime%
 	echo Copying $<


### PR DESCRIPTION
If a precompiled header of the form Halide.h.gch exists in the same place as Halide.h, g++ will prefer it, provided all warning and optimization flags match. This speeds up building correctness argmax by 1 second (from 3s to 2s at O3, from 2s to 1s at O0).

clang will silently ignore it. It needs a more invasive set of flags to use PCH (the consumers have to opt-in).