### PR TITLE
Handle case where an embedded buffer in JIT compilation is not vector aligned.

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1998,9 +1998,14 @@ Value *CodeGen_LLVM::codegen_dense_vector_load(const Load *load, Value *vpred) {
     // If it is an external buffer, then we cannot assume that the host pointer
     // is aligned to at least native vector width. However, we may be able to do
     // better than just assuming that it is unaligned.
-    if (is_external && load->param.defined()) {
-        int host_alignment = load->param.host_alignment();
-        alignment = gcd(alignment, host_alignment);
+    if (is_external) {
+        if (load->param.defined()) {
+            int host_alignment = load->param.host_alignment();
+            alignment = gcd(alignment, host_alignment);
+        } else if (get_target().has_feature(Target::JIT) && load->image.defined()) {
+            // If we're JITting, use the actual pointer value to determine alignment for embedded buffers.
+            alignment = gcd(alignment, (int)(((uintptr_t)load->image.raw_buffer()->host) & ~(int)0));
+        }
     }
 
     // For dense vector loads wider than the native vector

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2004,7 +2004,7 @@ Value *CodeGen_LLVM::codegen_dense_vector_load(const Load *load, Value *vpred) {
             alignment = gcd(alignment, host_alignment);
         } else if (get_target().has_feature(Target::JIT) && load->image.defined()) {
             // If we're JITting, use the actual pointer value to determine alignment for embedded buffers.
-          alignment = gcd(alignment, (int)(((uintptr_t)load->image.data()) & ~(int)0));
+            alignment = gcd(alignment, (int)(((uintptr_t)load->image.data()) & std::numeric_limits<int>::max()));
         }
     }
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2004,7 +2004,7 @@ Value *CodeGen_LLVM::codegen_dense_vector_load(const Load *load, Value *vpred) {
             alignment = gcd(alignment, host_alignment);
         } else if (get_target().has_feature(Target::JIT) && load->image.defined()) {
             // If we're JITting, use the actual pointer value to determine alignment for embedded buffers.
-            alignment = gcd(alignment, (int)(((uintptr_t)load->image.raw_buffer()->host) & ~(int)0));
+          alignment = gcd(alignment, (int)(((uintptr_t)load->image.data()) & ~(int)0));
         }
     }
 

--- a/test/correctness/non_vector_aligned_embeded_buffer.cpp
+++ b/test/correctness/non_vector_aligned_embeded_buffer.cpp
@@ -1,0 +1,21 @@
+#include "Halide.h"
+#include <iostream>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    char storage[5 * sizeof(int32_t)]{0};
+    char *ptr = storage;
+    ptr += sizeof(int32_t);
+    Buffer<int32_t> foo((int32_t *)(ptr), 4);
+
+    Func f;
+    Var x;
+
+    f(x) = foo(x);
+    f.vectorize(x, 4);
+    f.output_buffer().dim(0).set_min(0);
+    auto result = f.realize(4);
+
+    return 0;
+}


### PR DESCRIPTION
Fixes issue https://github.com/halide/Halide/issues/2478 .

Add a test for non-vector aligned embdedded buffers.

(Open question as to whether this works correctly for AOT embedded
buffers for sufficiently long vectors, but there are no bug reports as
yet.)