### PR TITLE
Fix build against gcc 5.4

### DIFF
--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -6,6 +6,9 @@ namespace Internal {
 using std::pair;
 using std::vector;
 
+IRMutator::IRMutator() {
+}
+
 IRMutator::~IRMutator() {
 }
 
@@ -376,6 +379,9 @@ void IRMutator::visit(const Shuffle *op) {
     }
 }
 
+
+IRMutator2::IRMutator2() {
+}
 
 IRMutator2::~IRMutator2() {
 }

--- a/src/IRMutator.h
+++ b/src/IRMutator.h
@@ -28,6 +28,7 @@ namespace Internal {
  */
 class IRMutator : public IRVisitor {
 public:
+    EXPORT IRMutator();
     EXPORT virtual ~IRMutator();
 
     /** This is the main interface for using a mutator. Also call
@@ -105,6 +106,7 @@ protected:
  */
 class IRMutator2 {
 public:
+    EXPORT IRMutator2();
     EXPORT virtual ~IRMutator2();
 
     /** This is the main interface for using a mutator. Also call

--- a/src/IRVisitor.cpp
+++ b/src/IRVisitor.cpp
@@ -6,6 +6,9 @@ namespace Internal {
 IRVisitor::~IRVisitor() {
 }
 
+IRVisitor::IRVisitor() {
+}
+
 void IRVisitor::visit(const IntImm *) {
 }
 

--- a/src/IRVisitor.h
+++ b/src/IRVisitor.h
@@ -21,6 +21,7 @@ namespace Internal {
  */
 class IRVisitor {
 public:
+    EXPORT IRVisitor();
     EXPORT virtual ~IRVisitor();
 protected:
     // ExprNode<> and StmtNode<> are allowed to call visit (to implement accept())


### PR DESCRIPTION
When building against gcc 5.4. link error occurs:

CMakeFiles/build_correctness_func_clone.dir/correctness/func_clone.cpp.o:
In function `Halide::Internal::IRVisitor::IRVisitor()':
func_clone.cpp:(.text._ZN6Halide8Internal9IRVisitorC2Ev[_ZN6Halide8Internal9IRVisitorC5Ev]+0x9):
  undefined reference to `vtable for Halide::Internal::IRVisitor'

The reason is the compiler selected to generate a default constructor of
IRVisitor/... inside func_clone.cpp.o because we did not provide one.
But it does not generates a vtable for IRVisitor/... in func_clone.cpp.o
I don't know why the compiler optimize away the vtable.

The way to fix the issue is to explicitly define the constructor.
So there will be only one constructor inside libHalide.so and
func_clone.cpp.o will not contain IRVisitor::IRVisitor(), just simply
linked the constructor inside libHalide.so