### PR TITLE
Simplify test_apps rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1460,64 +1460,27 @@ time_compilation_opengl_%: $(BIN_DIR)/opengl_%
 time_compilation_generator_%: $(BIN_DIR)/%.generator
 	$(TIME_COMPILATION) compile_times_generator.csv make -f $(THIS_MAKEFILE) $(@:time_compilation_generator_%=$(FILTERS_DIR)/%.a)
 
+TEST_APPS=\
+	HelloMatlab \
+	bilateral_grid \
+	blur \
+	c_backend \
+	conv_layer \
+	fft \
+	interpolate \
+	lens_blur \
+	linear_algebra \
+	local_laplacian \
+	nl_means \
+	resize \
+	wavelet \
+
 .PHONY: test_apps
-test_apps: $(LIB_DIR)/libHalide.a $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR)/Halide.h $(RUNTIME_EXPORTED_INCLUDES)
-	mkdir -p apps
-	# Make a local copy of the apps if we're building out-of-tree,
-	# because the app Makefiles are written to build in-tree
-	if [ "$(ROOT_DIR)" != "$(CURDIR)" ]; then \
-	  echo "Building out-of-tree, so making local copy of apps"; \
-	  cp -r $(ROOT_DIR)/apps/bilateral_grid \
-	        $(ROOT_DIR)/apps/conv_layer \
-	        $(ROOT_DIR)/apps/lens_blur \
-	        $(ROOT_DIR)/apps/local_laplacian \
-	        $(ROOT_DIR)/apps/nl_means \
-	        $(ROOT_DIR)/apps/interpolate \
-	        $(ROOT_DIR)/apps/blur \
-	        $(ROOT_DIR)/apps/wavelet \
-	        $(ROOT_DIR)/apps/c_backend \
-	        $(ROOT_DIR)/apps/HelloMatlab \
-	        $(ROOT_DIR)/apps/fft \
-	        $(ROOT_DIR)/apps/linear_algebra \
-	        $(ROOT_DIR)/apps/linear_blur \
-	        $(ROOT_DIR)/apps/resize \
-	        $(ROOT_DIR)/apps/images \
-	        $(ROOT_DIR)/apps/support \
-                apps; \
-	  cp -r $(ROOT_DIR)/tools .; \
-	fi
-	make -C apps/bilateral_grid clean  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/bilateral_grid bin/out.png  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/conv_layer clean  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/conv_layer run  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/lens_blur clean  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/lens_blur bin/out.png  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/local_laplacian clean  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/local_laplacian bin/out.png  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/nl_means clean  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/nl_means bin/out.png  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/interpolate clean  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/interpolate bin/out.png  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/blur clean  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/blur bin/test  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	apps/blur/bin/test
-	make -C apps/wavelet clean  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/wavelet test  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/c_backend clean  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/c_backend test  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/fft bench_16x16  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/fft bench_32x32  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/fft bench_48x48  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	cd apps/HelloMatlab; HALIDE_PATH=$(CURDIR) HALIDE_CXX="$(CXX)" ./run_blur.sh
-	# Only test the linear algebra app if cblas.h exists in the expected place
-	if [ -f /usr/include/cblas.h ]; then \
-	  make -C apps/linear_algebra clean HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR) ; \
-	  make -C apps/linear_algebra test HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR) ; \
-	fi
-	make -C apps/linear_blur clean HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR) ; \
-	make -C apps/linear_blur test HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR) ; \
-	make -C apps/resize clean  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
-	make -C apps/resize all  HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR)
+test_apps: distrib
+	@for APP in $(TEST_APPS); do \
+		echo Testing app $${APP}... ; \
+		make -C $(ROOT_DIR)/apps/$${APP} test HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR) BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP} || exit 1 ; \
+	done
 
 # Bazel depends on the distrib archive being built
 .PHONY: test_bazel

--- a/apps/HelloMatlab/Makefile
+++ b/apps/HelloMatlab/Makefile
@@ -1,0 +1,7 @@
+include ../support/Makefile.inc
+
+BIN ?= bin
+
+test:
+	./run_blur.sh
+

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -35,3 +35,5 @@ $(BIN)/out.png: $(BIN)/filter
 
 clean:
 	rm -rf $(BIN)
+
+test: $(BIN)/out.png

--- a/apps/blur/Makefile
+++ b/apps/blur/Makefile
@@ -25,3 +25,6 @@ $(BIN)/test: $(BIN)/halide_blur.a test.cpp
 
 clean:
 	rm -rf $(BIN)
+
+test: $(BIN)/test
+	$(BIN)/test

--- a/apps/conv_layer/Makefile
+++ b/apps/conv_layer/Makefile
@@ -26,3 +26,5 @@ run: $(BIN)/process
 
 clean:
 	rm -rf $(BIN)
+
+test: run

--- a/apps/fft/Makefile
+++ b/apps/fft/Makefile
@@ -58,3 +58,9 @@ fft_aot_test: $(BIN)/fft_aot_test
 	$(BIN)/fft_aot_test
 
 all: fft_aot_test bench_16x16 bench_32x32 bench_48x48 bench_64x64
+
+# Ensure these are run sequentially and not in parallel
+test: $(BIN)/bench_fft
+	$(BIN)/bench_fft 16 16 $(BIN)/
+	$(BIN)/bench_fft 32 32 $(BIN)/
+	$(BIN)/bench_fft 48 48 $(BIN)/

--- a/apps/interpolate/Makefile
+++ b/apps/interpolate/Makefile
@@ -14,3 +14,5 @@ $(BIN)/out.png: $(BIN)/interpolate
 
 clean:
 	rm -rf $(BIN)
+
+test: $(BIN)/out.png

--- a/apps/lens_blur/Makefile
+++ b/apps/lens_blur/Makefile
@@ -26,3 +26,5 @@ $(BIN)/out.png: $(BIN)/process
 
 clean:
 	rm -rf $(BIN)
+
+test: $(BIN)/out.png

--- a/apps/linear_algebra/Makefile
+++ b/apps/linear_algebra/Makefile
@@ -1,6 +1,6 @@
 include ../support/Makefile.inc
 
-BIN = bin
+BIN ?= bin
 BUILD = $(BIN)/build
 CXXFLAGS += -O3 -fopenmp -Wall -march=native
 HL_TARGET ?= host
@@ -71,11 +71,16 @@ BENCHMARKS = \
 all: $(BENCHMARKS)
 	make run_benchmarks
 
+ifneq ("$(wildcard /usr/include/cblas.h)","")
 test: $(BIN)/test_halide_blas
 	$(BIN)/test_halide_blas
+else
+test:
+	@echo /usr/include/cblas.h not found: skipping linear_algebra tests...
+endif
 
 clean:
-	rm -rf bin
+	rm -rf $(BIN)
 
 KERNEL_HEADERS = $(KERNELS:%=$(BUILD)/halide_%.h)
 KERNEL_OBJECTS = $(KERNELS:%=$(BUILD)/halide_%.o) $(BUILD)/halide_runtime.o

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -42,3 +42,6 @@ $(BIN)/local_laplacian.mp4: $(BIN)/process_viz ../../bin/HalideTraceViz
 
 clean:
 	rm -rf $(BIN)
+
+
+test: $(BIN)/out.png

--- a/apps/nl_means/Makefile
+++ b/apps/nl_means/Makefile
@@ -26,3 +26,5 @@ $(BIN)/out.png: $(BIN)/process
 
 clean:
 	rm -rf $(BIN)
+
+test: $(BIN)/out.png

--- a/apps/resize/Makefile
+++ b/apps/resize/Makefile
@@ -69,3 +69,6 @@ $(BIN)/out_%_down.png: $(BIN)/resize
 
 clean:
 	rm -rf $(BIN)
+
+
+test: all


### PR DESCRIPTION
- Ensure that all of the apps have a 'test' build rule and just use it in a data driven loop.
- We don't need to make a local copy of the apps folder: ever since the apps Makefiles were revised to uniformly go into a bin/ folder, we can support in-tree builds by just prepending ROOT_DIR and setting BIN appropriately. (Note that we build into a subdir of the toplevel 'bin' directory rather than the per-directory bin dirs in this case.)
- Don't use 'make clean' for all of these targets; when testing on the buildbots, there is nothing to clean