### PR TITLE
CMake finds unlinked Homebrew `openblas` installs

### DIFF
--- a/apps/linear_algebra/CMakeLists.txt
+++ b/apps/linear_algebra/CMakeLists.txt
@@ -12,6 +12,7 @@ find_path(CBLAS_INCLUDE_DIR
     /usr/local/include
     /usr/include/atlas
     /usr/local/include/atlas
+    /usr/local/opt/openblas/include # enables openblas-via-homebrew-on-mac
 )
 set(CBLAS_FOUND false)
 if (NOT CBLAS_INCLUDE_DIR MATCHES "-NOTFOUND")


### PR DESCRIPTION
A Mac build environment may have `openblas` installed through Homebrew; if it does, the Homebrew installation is by default “unlinked,” due to [conflicts with Apple’s headers](https://github.com/Homebrew/homebrew-core/blob/30abddeed8f2b8d6e3d7b5ee313ddcd2c8ff1671/Formula/openblas.rb#L16-L17). Adding an explicit search path for the unlinked `openblas` installation allows it to be picked up by `cmake` and used accordingly.