### PR TITLE
Remove dubious lack-of-assert

### DIFF
--- a/src/InjectHostDevBufferCopies.cpp
+++ b/src/InjectHostDevBufferCopies.cpp
@@ -220,7 +220,6 @@ class InjectBufferCopiesForSingleBuffer : public IRMutator2 {
 
         DeviceAPI touching_device = DeviceAPI::None;
         for (DeviceAPI d : finder.devices_touched) {
-            if (d == DeviceAPI::Host) continue;
             internal_assert(touching_device == DeviceAPI::None)
                 << "Buffer " << buffer << " was touched on multiple devices within a single leaf Stmt!\n";
             touching_device = d;


### PR DESCRIPTION
I encountered a bad schedule that didn't throw an error due to this continue. I can't see why this continue statement is there. Opening a PR to see if the buildbots agree with me.