### PR TITLE
Metal: pre-create pipeline states

### DIFF
--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -512,9 +512,7 @@ WEAK int halide_metal_initialize_kernels(void *user_context, void **state_ptr, c
             (*state)->pipeline_states[i] = pipeline_state;
 
             release_ns_object(function);
-            objc_msgSend(function, sel_getUid("retain"));
         }
-        release_ns_object(func_names);
 
         #ifdef DEBUG_RUNTIME
         uint64_t t_after_compile = halide_current_time_ns(user_context);
@@ -594,18 +592,19 @@ WEAK int halide_metal_device_release(void *user_context) {
                 release_ns_object(state->library);
                 state->library = NULL;
             }
-            for (size_t i=0; i<state->num_functions; i++) {
-                debug(user_context) << "Metal - Releasing: pipeline_state " << state->pipeline_states[i] << "\n";
-                release_ns_object(state->pipeline_states[i]);
-                free(state->function_names[i]);
+            if (state->pipeline_states) {
+                for (size_t i=0; i<state->num_functions; i++) {
+                    debug(user_context) << "Metal - Releasing: pipeline_state " << state->pipeline_states[i] << "\n";
+                    release_ns_object(state->pipeline_states[i]);
+                    free(state->function_names[i]);
+                }
+                free(state->pipeline_states);
+                state->pipeline_states = NULL;
             }
+
             if (state->function_names) {
                 free(state->function_names);
                 state->function_names = NULL;
-            }
-            if (state->pipeline_states) {
-                free(state->pipeline_states);
-                state->pipeline_states = NULL;
             }
             state->num_functions = 0;
             state = state->next;

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -850,9 +850,6 @@ WEAK int halide_metal_run(void *user_context,
 
     commit_command_buffer(command_buffer);
 
-    //release_ns_object(pipeline_state);
-    //release_ns_object(function);
-
     #ifdef DEBUG_RUNTIME
     uint64_t t_after = halide_current_time_ns(user_context);
     debug(user_context) << "Time for halide_metal_device_run: " << (t_after - t_before) / 1.0e6 << " ms\n";

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -504,7 +504,7 @@ WEAK int halide_metal_initialize_kernels(void *user_context, void **state_ptr, c
                 return -1;
             }
 
-            debug(user_context) << "Metal - Allocating - pipeline_state\n";
+            debug(user_context) << "Metal - Allocating: pipeline_state\n";
             mtl_compute_pipeline_state *pipeline_state = new_compute_pipeline_state_with_function(metal_context.device, function);
             if (pipeline_state == 0) {
                 error(user_context) << "Metal: Could not allocate pipeline state.\n";

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -736,20 +736,9 @@ WEAK int halide_metal_run(void *user_context,
     halide_assert(user_context, state_ptr);
     module_state *state = (module_state*)state_ptr;
 
-    //mtl_function *function = new_function_with_name(state->library, entry_name, strlen(entry_name));
-    //if (function == 0) {
-        //error(user_context) << "Metal: Could not get function " << entry_name << "from Metal library.\n";
-        //return -1;
-    //}
-
-    //mtl_compute_pipeline_state *pipeline_state = new_compute_pipeline_state_with_function(metal_context.device, function);
-    //if (pipeline_state == 0) {
-        //error(user_context) << "Metal: Could not allocate pipeline state.\n";
-        //release_ns_object(function);
-        //return -1;
-    //}
     mtl_compute_pipeline_state *pipeline_state = NULL;
     for (size_t i=0; i<state->num_functions; i++) {
+        // TODO(shoaibkamil): we could probably speed this up by skipping "kernel__"
         if (strcmp(state->function_names[i], entry_name) == 0) {
             pipeline_state = state->pipeline_states[i];
             debug(user_context) << "Found pipeline state for " << entry_name << ": " << pipeline_state << "\n";

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -605,12 +605,10 @@ WEAK int halide_metal_device_release(void *user_context) {
                 }
                 free(state->pipeline_states);
                 state->pipeline_states = NULL;
-            }
-
-            if (state->function_names) {
                 free(state->function_names);
                 state->function_names = NULL;
             }
+
             state->num_functions = 0;
             state = state->next;
         }
@@ -738,7 +736,8 @@ WEAK int halide_metal_run(void *user_context,
 
     mtl_compute_pipeline_state *pipeline_state = NULL;
     for (size_t i=0; i<state->num_functions; i++) {
-        // TODO(shoaibkamil): we could probably speed this up by skipping "kernel__"
+        // TODO(shoaibkamil): we could probably speed this up by skipping "kernel_", but that would
+        // require making sure GPU kernels always have that naming pattern
         if (strcmp(state->function_names[i], entry_name) == 0) {
             pipeline_state = state->pipeline_states[i];
             debug(user_context) << "Found pipeline state for " << entry_name << ": " << pipeline_state << "\n";

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -796,8 +796,6 @@ WEAK int halide_metal_run(void *user_context,
             args_buffer = new_buffer(metal_context.device, total_args_size);
             if (args_buffer == 0) {
                 error(user_context) << "Metal: Could not allocate arguments buffer.\n";
-                //release_ns_object(pipeline_state);
-                //release_ns_object(function);
                 return -1;
             }
             args_ptr = (char *)buffer_contents(args_buffer);

--- a/test/common/gpu_object_lifetime_tracker.h
+++ b/test/common/gpu_object_lifetime_tracker.h
@@ -21,7 +21,7 @@ class GpuObjectLifetimeTracker {
             is_global(is_global), total_created(0), live_count(0) {}
     };
 
-    std::array<ObjectType, 13> object_types = {{
+    std::array<ObjectType, 14> object_types = {{
         // OpenCL objects
         {"clCreateContext", "clReleaseContext", true},
         {"clCreateCommandQueue", "clReleaseCommandQueue", true},
@@ -40,6 +40,7 @@ class GpuObjectLifetimeTracker {
         {"Allocating: MTLCreateSystemDefaultDevice", "Releasing: MTLCreateSystemDefaultDevice", true},
         {"Allocating: new_command_queue", "Releasing: new_command_queue"},
         {"Allocating: new_library_with_source", "Releasing: new_library_with_source"},
+        {"Allocating: pipeline_state", "Releasing: pipeline_state"},
 
         // Hexagon objects
         {"halide_remote_load_library", "halide_remote_release_library"},


### PR DESCRIPTION
This PR creates `MTLComputePipelineState` objects for each function in a Halide Metal library in `halide_metal_initialize_kernels()`.  Previously, these objects were created for each kernel launch in `halide_metal_run()`, but according to the [Metal Best Practices Guide ](https://developer.apple.com/library/content/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/PersistentObjects.html#//apple_ref/doc/uid/TP40016642-CH4-SW1), the `MTLComputePipelineState` objects can be created once and reused.  We pay a greater cost at initialization time, but the cost is amortized across multiple calls to the kernel.

For an unscientific example, we can run a test with the debug runtime and just compare (average) reported times for `halide_metal_run()`:

On master:
```
$ HL_JIT_TARGET=host-metal-debug  make -j5 performance_wrap 2>&1| grep run | awk '{sum += $4} END {print sum/NR}'
0.0455317
```

With this branch:
```
$ HL_JIT_TARGET=host-metal-debug  make -j5 performance_wrap 2>&1| grep run | awk '{sum += $4} END {print sum/NR}'
0.0243639
```

I *believe* I'm correctly managing Objective C memory, but please take a look at that in particular in this code.

CC @zvookin @slomp 