### PR TITLE
Remove python bindings for long-deprecated gpu functions

### DIFF
--- a/python_bindings/python/Func_gpu.h
+++ b/python_bindings/python/Func_gpu.h
@@ -124,25 +124,6 @@ FuncOrStage &func_gpu_tile7(FuncOrStage &that, hh::VarOrRVar x, hh::VarOrRVar y,
     return that.gpu_tile(x, y, z, tx, ty, tx, x_size, y_size, z_size, hh::TailStrategy::Auto, device_api);
 }
 
-// Will be deprecated
-template <typename FuncOrStage>
-FuncOrStage &func_gpu_tile8(FuncOrStage &that, hh::VarOrRVar x, int x_size,
-                            hh::DeviceAPI device_api) {
-    return that.gpu_tile(x, x_size, hh::TailStrategy::Auto, device_api);
-}
-template <typename FuncOrStage>
-FuncOrStage &func_gpu_tile9(FuncOrStage &that, hh::VarOrRVar x, hh::VarOrRVar y,
-                            int x_size, int y_size,
-                            hh::DeviceAPI device_api) {
-    return that.gpu_tile(x, y, x_size, y_size, hh::TailStrategy::Auto, device_api);
-}
-template <typename FuncOrStage>
-FuncOrStage &func_gpu_tile10(FuncOrStage &that, hh::VarOrRVar x, hh::VarOrRVar y, hh::VarOrRVar z,
-                            int x_size, int y_size, int z_size,
-                            hh::DeviceAPI device_api) {
-    return that.gpu_tile(x, y, z, x_size, y_size, z_size, hh::TailStrategy::Auto, device_api);
-}
-
 /// Define all gpu related methods
 template <typename FuncOrStage>
 void defineFuncOrStageGpuMethods(bp::class_<FuncOrStage> &func_or_stage_class) {
@@ -278,25 +259,6 @@ void defineFuncOrStageGpuMethods(bp::class_<FuncOrStage> &func_or_stage_class) {
              (bp::arg("self"),
               bp::arg("x"), bp::arg("y"), bp::arg("z"),
               bp::arg("tx"), bp::arg("ty"), bp::arg("tz"),
-              bp::arg("x_size"), bp::arg("y_size"), bp::arg("z_size"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>())
-
-        // Will be deprecated
-        .def("gpu_tile", &func_gpu_tile8<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("x"), bp::arg("x_size"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>())
-        .def("gpu_tile", &func_gpu_tile9<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("x"), bp::arg("y"),
-              bp::arg("x_size"), bp::arg("y_size"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>())
-        .def("gpu_tile", &func_gpu_tile10<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("x"), bp::arg("y"), bp::arg("z"),
               bp::arg("x_size"), bp::arg("y_size"), bp::arg("z_size"),
               bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
              bp::return_internal_reference<1>());

--- a/python_bindings/python/Var.cpp
+++ b/python_bindings/python/Var.cpp
@@ -105,13 +105,6 @@ void defineVar() {
                          .def("expr", &var_as_expr, p::arg("self"),  //operator Expr() const
                               "A Var can be treated as an Expr of type Int(32)")
 
-                         .def("gpu_blocks", &Var::gpu_blocks,  // no args
-                              "Vars to use for scheduling producer/consumer pairs on the gpu.")
-                         .staticmethod("gpu_blocks")
-                         .def("gpu_threads", &Var::gpu_threads,  // no args
-                              "Vars to use for scheduling producer/consumer pairs on the gpu.")
-                         .staticmethod("gpu_threads")
-
                          .def("outermost", &Var::outermost,  // no args
                               "A Var that represents the location outside the outermost loop.")
                          .staticmethod("outermost")


### PR DESCRIPTION
We haven't decided to remove them from C++ yet, but we should go ahead and remove them from Python since usage is small