### PR TITLE
Fix camera_pipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1465,6 +1465,7 @@ TEST_APPS=\
 	HelloMatlab \
 	bilateral_grid \
 	blur \
+	camera_pipe \
 	c_backend \
 	conv_layer \
 	fft \

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -37,3 +37,5 @@ $(BIN)/camera_pipe.mp4: $(BIN)/viz/process viz.sh $(HALIDE_TRACE_VIZ) ../../bin/
 
 clean:
 	rm -rf $(BIN)
+
+test: $(BIN)/out.png

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -30,9 +30,9 @@ Func interleave_y(Func a, Func b) {
 
 class Demosaic : public Halide::Generator<Demosaic> {
 public:
-    GeneratorParam<LoopLevel> intermed_compute_at{"intermed_compute_at"};
-    GeneratorParam<LoopLevel> intermed_store_at{"intermed_store_at"};
-    GeneratorParam<LoopLevel> output_compute_at{"output_compute_at"};
+    GeneratorParam<LoopLevel> intermed_compute_at{"intermed_compute_at", LoopLevel::inlined()};
+    GeneratorParam<LoopLevel> intermed_store_at{"intermed_store_at", LoopLevel::inlined()};
+    GeneratorParam<LoopLevel> output_compute_at{"output_compute_at", LoopLevel::inlined()};
 
     // Inputs and outputs
     Input<Func> deinterleaved{ "deinterleaved", Int(16), 3 };
@@ -220,7 +220,7 @@ Func CameraPipe::hot_pixel_suppression(Func input) {
 
 Func CameraPipe::deinterleave(Func raw) {
     // Deinterleave the color channels
-    Func deinterleaved;
+    Func deinterleaved("deinterleaved");
 
     deinterleaved(x, y, c) = select(c == 0, raw(2*x, 2*y),
                                     c == 1, raw(2*x+1, 2*y),
@@ -344,12 +344,8 @@ void CameraPipe::generate() {
 
     processed(x, y, c) = apply_curve(corrected)(x, y, c);
 
-    Pipeline p(processed);
-
     // Schedule
     if (auto_schedule) {
-        Pipeline p(processed);
-
         input.dim(0).set_bounds_estimate(0, 2592);
         input.dim(1).set_bounds_estimate(0, 1968);
 

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -495,9 +495,15 @@ private:
     }
 
     template <typename T2, typename std::enable_if<std::is_same<T, T2>::value &&
-                                                   (std::is_same<T, MachineParams>::value || std::is_same<T, LoopLevel>::value)>::type * = nullptr>
-    HALIDE_ALWAYS_INLINE void typed_setter_impl(const T2 &value, const char *msg) {
+                                                   std::is_same<T, MachineParams>::value>::type * = nullptr>
+    HALIDE_ALWAYS_INLINE void typed_setter_impl(const MachineParams &value, const char *msg) {
         value_ = value;
+    }
+
+    template <typename T2, typename std::enable_if<std::is_same<T, T2>::value &&
+                                                   std::is_same<T, LoopLevel>::value>::type * = nullptr>
+    HALIDE_ALWAYS_INLINE void typed_setter_impl(const LoopLevel &value, const char *msg) {
+        value_.set(value);
     }
 };
 


### PR DESCRIPTION
- GeneratorParam<LoopLevel>::set() was wrong
- GeneratorParam<LoopLevel> instances need default values
- remove spurious Pipeline declarations that were holdover from the before-time
- Add camera_pipe to test_apps