### PR TITLE
Enable OpenCL half support

### DIFF
--- a/python_bindings/src/PyTarget.cpp
+++ b/python_bindings/src/PyTarget.cpp
@@ -141,6 +141,7 @@ void define_target() {
         .value("CUDACapability61", Target::Feature::CUDACapability61)
         .value("OpenCL", Target::Feature::OpenCL)
         .value("CLDoubles", Target::Feature::CLDoubles)
+        .value("CLHalf", Target::Feature::CLHalf)
         .value("OpenGL", Target::Feature::OpenGL)
         .value("OpenGLCompute", Target::Feature::OpenGLCompute)
         .value("UserContext", Target::Feature::UserContext)

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -718,6 +718,37 @@ void CodeGen_OpenCL_Dev::init_module() {
                    << "#define atanh_f64 atanh\n";
     }
 
+    if (target.has_feature(Target::CLHalf)) {
+        src_stream << "#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n"
+                   << "inline half half_from_bits(unsigned short x) {return as_half(x);}\n"
+                   << "inline half nan_f16() { return nan((unsigned short)0); }\n"
+                   << "inline half neg_inf_f16() { return -INFINITY; }\n"
+                   << "inline half inf_f16() { return INFINITY; }\n"
+                   << "bool is_nan_f16(half x) {return x != x; }\n"
+                   << "#define sqrt_f16 sqrt\n"
+                   << "#define sin_f16 sin\n"
+                   << "#define cos_f16 cos\n"
+                   << "#define exp_f16 exp\n"
+                   << "#define log_f16 log\n"
+                   << "#define abs_f16 fabs\n"
+                   << "#define floor_f16 floor\n"
+                   << "#define ceil_f16 ceil\n"
+                   << "#define round_f16 round\n"
+                   << "#define trunc_f16 trunc\n"
+                   << "#define pow_f16 pow\n"
+                   << "#define asin_f16 asin\n"
+                   << "#define acos_f16 acos\n"
+                   << "#define tan_f16 tan\n"
+                   << "#define atan_f16 atan\n"
+                   << "#define atan2_f16 atan2\n"
+                   << "#define sinh_f16 sinh\n"
+                   << "#define asinh_f16 asinh\n"
+                   << "#define cosh_f16 cosh\n"
+                   << "#define acosh_f16 acosh\n"
+                   << "#define tanh_f16 tanh\n"
+                   << "#define atanh_f16 atanh\n";
+    }
+
     src_stream << '\n';
 
     // Add at least one kernel to avoid errors on some implementations for functions

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1307,7 +1307,7 @@ inline Expr is_nan(Expr x) {
     Type t = Bool(x.type().lanes());
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(t, "is_nan_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type().element_of() == Float(64)) {
+    } else if (x.type().element_of() == Float(16)) {
         return Internal::Call::make(t, "is_nan_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
         Type ft = x.type().with_code(Type::Float);

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -237,6 +237,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"cuda_capability_61", Target::CUDACapability61},
     {"opencl", Target::OpenCL},
     {"cl_doubles", Target::CLDoubles},
+    {"cl_half", Target::CLHalf},
     {"opengl", Target::OpenGL},
     {"openglcompute", Target::OpenGLCompute},
     {"user_context", Target::UserContext},

--- a/src/Target.h
+++ b/src/Target.h
@@ -59,6 +59,7 @@ struct Target {
         CUDACapability61 = halide_target_feature_cuda_capability61,
         OpenCL = halide_target_feature_opencl,
         CLDoubles = halide_target_feature_cl_doubles,
+        CLHalf = halide_target_feature_cl_half,
         OpenGL = halide_target_feature_opengl,
         OpenGLCompute = halide_target_feature_openglcompute,
         UserContext = halide_target_feature_user_context,

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1071,7 +1071,8 @@ typedef enum halide_target_feature_t {
     halide_target_feature_cuda_capability61 = 46,  ///< Enable CUDA compute capability 6.1 (Pascal)
     halide_target_feature_hvx_v65 = 47, ///< Enable Hexagon v65 architecture.
     halide_target_feature_hvx_v66 = 48, ///< Enable Hexagon v66 architecture.
-    halide_target_feature_end = 49, ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
+    halide_target_feature_cl_half = 49,  ///< Enable half support on OpenCL targets
+    halide_target_feature_end = 50, ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 
 /** This function is called internally by Halide in some situations to determine


### PR DESCRIPTION
- Add a new 'cl_half' target feature to enable OCL half support.
- Define math functions for f16.
- Fix a minor issue in is_nan implementation on half.
- Enable python support as well.