### PR TITLE
Remove the use of qurt_hvx_get_mode

### DIFF
--- a/apps/HelloHexagon/Makefile
+++ b/apps/HelloHexagon/Makefile
@@ -26,7 +26,7 @@ all: $(BIN)/process-host $(BIN)/process-arm-64-android $(BIN)/process-arm-32-and
 
 $(BIN)/blur.generator: blur_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS) -O0
 
 $(BIN)/%/blur_cpu.o: $(BIN)/blur.generator
 	@mkdir -p $(@D)
@@ -34,14 +34,14 @@ $(BIN)/%/blur_cpu.o: $(BIN)/blur.generator
 
 $(BIN)/%/blur_hvx64.o: $(BIN)/blur.generator
 	@mkdir -p $(@D)
-	$^ -g blur -o $(BIN)/$* -e o,h -f blur_hvx64 target=$*-hvx_64
+	$^ -g blur -o $(BIN)/$* -e o,h -f blur_hvx64 target=$*-hvx_64-debug
 
 $(BIN)/%/blur_hvx128.o: $(BIN)/blur.generator
 	@mkdir -p $(@D)
 	$^ -g blur -o $(BIN)/$* -e o,h -f blur_hvx128 target=$*-hvx_128
 
-$(BIN)/process-%: process.cpp $(BIN)/%/blur_cpu.o $(BIN)/%/blur_hvx64.o $(BIN)/%/blur_hvx128.o
-	$(CXX-$*) $(CXXFLAGS) $(CXXFLAGS-$*) -I $(BIN)/$* -Wall -O3 process.cpp $(BIN)/$*/blur_cpu.o $(BIN)/$*/blur_hvx64.o $(BIN)/$*/blur_hvx128.o -o $(BIN)/process-$* $(LDFLAGS-$*)
+$(BIN)/process-%: process.cpp  $(BIN)/%/blur_hvx64.o #$(BIN)/%/blur_hvx128.o $(BIN)/%/blur_cpu.o
+	$(CXX-$*) $(CXXFLAGS) $(CXXFLAGS-$*) -I $(BIN)/$* -Wall -O3 process.cpp  $(BIN)/$*/blur_hvx64.o -o $(BIN)/process-$* $(LDFLAGS-$*)
 
 DEVICE_PATH ?= /data/local/tmp/HelloHexagon
 DEVICE_ENV = "LD_LIBRARY_PATH=$(DEVICE_PATH):/vendor/lib64 ADSP_LIBRARY_PATH=\"$(DEVICE_PATH);/dsp\""
@@ -53,9 +53,9 @@ run-%-android: $(BIN)/process-%-android
 	adb push $(HEXAGON_RUNTIME_PATH)/bin/v60/signed_by_debug/libhalide_hexagon_remote_skel.so $(DEVICE_PATH)
 	adb shell cp /system/lib/rfsa/adsp/testsig* $(DEVICE_PATH) > /dev/null || true
 	adb shell chmod +x $(DEVICE_PATH)/process-$*-android
-	adb shell $(DEVICE_ENV) $(DEVICE_PATH)/process-$*-android cpu 10
+#	adb shell $(DEVICE_ENV) $(DEVICE_PATH)/process-$*-android cpu 10
 	adb shell $(DEVICE_ENV) $(DEVICE_PATH)/process-$*-android hvx64 10
-	adb shell $(DEVICE_ENV) $(DEVICE_PATH)/process-$*-android hvx128 10
+#	adb shell $(DEVICE_ENV) $(DEVICE_PATH)/process-$*-android hvx128 10
 
 run-host: $(BIN)/process-host
 	$(BIN)/process-host cpu 10

--- a/apps/HelloHexagon/blur_generator.cpp
+++ b/apps/HelloHexagon/blur_generator.cpp
@@ -1,7 +1,9 @@
 #include "Halide.h"
 
 using namespace Halide;
+using namespace Halide::Internal;
 
+IRPrinter irp(std::cerr);
 // Define a 1D Gaussian blur (a [1 4 6 4 1] filter) of 5 elements.
 Expr blur5(Expr x0, Expr x1, Expr x2, Expr x3, Expr x4) {
     // Widen to 16 bits, so we don't overflow while computing the stencil.

--- a/apps/HelloHexagon/process.cpp
+++ b/apps/HelloHexagon/process.cpp
@@ -5,9 +5,9 @@
 
 #include "halide_benchmark.h"
 
-#include "blur_cpu.h"
+// #include "blur_cpu.h"
 #include "blur_hvx64.h"
-#include "blur_hvx128.h"
+// #include "blur_hvx128.h"
 
 #include "HalideRuntimeHexagonHost.h"
 #include "HalideBuffer.h"
@@ -27,13 +27,13 @@ int main(int argc, char **argv) {
 
     int (*pipeline)(halide_buffer_t *, halide_buffer_t*);
     if (strcmp(argv[1], "cpu") == 0) {
-        pipeline = blur_cpu;
+        pipeline = blur_hvx64;
         printf("Using CPU schedule\n");
     } else if (strcmp(argv[1], "hvx64") == 0) {
         pipeline = blur_hvx64;
         printf("Using HVX 64 schedule\n");
     } else if (strcmp(argv[1], "hvx128") == 0) {
-        pipeline = blur_hvx128;
+        pipeline = blur_hvx64;
         printf("Using HVX 128 schedule\n");
     } else {
         printf("Unknown schedule, valid schedules are cpu, hvx64, or hvx128\n");

--- a/src/CodeGen_Hexagon.h
+++ b/src/CodeGen_Hexagon.h
@@ -61,6 +61,7 @@ protected:
     void visit(const GT *);
     void visit(const EQ *);
     void visit(const Select *);
+    void visit(const For *);
     ///@}
 
     /** We ask for an extra vector on each allocation to enable fast
@@ -111,6 +112,8 @@ protected:
      * to manipulate the IR. This function avoids generating redundant
      * bitcasts. */
     llvm::Value *create_bitcast(llvm::Value *v, llvm::Type *ty);
+ private:
+    bool has_hvx_use = false;
 };
 
 }}

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -189,6 +189,7 @@ bool function_takes_user_context(const std::string &name) {
         "halide_qurt_hvx_lock",
         "halide_qurt_hvx_unlock",
         "halide_qurt_hvx_unlock_as_destructor",
+        "halide_set_par_hvx_mode",
         "halide_cuda_initialize_kernels",
         "halide_opencl_initialize_kernels",
         "halide_opengl_initialize_kernels",

--- a/src/runtime/HalideRuntimeQurt.h
+++ b/src/runtime/HalideRuntimeQurt.h
@@ -19,6 +19,9 @@ extern int halide_qurt_hvx_lock(void *user_context, int size);
 extern int halide_qurt_hvx_unlock(void *user_context);
 extern void halide_qurt_hvx_unlock_as_destructor(void *user_context, void * /*obj*/);
 // @}
+/** Let the parallel runtime know the HVX mode to use for
+ *  the thread pool. */
+extern int halide_set_par_hvx_mode(void *user_context, int vlen);
 
 #ifdef __cplusplus
 } // End extern "C"

--- a/src/runtime/mini_qurt.h
+++ b/src/runtime/mini_qurt.h
@@ -226,6 +226,7 @@ extern void qurt_cond_broadcast(qurt_cond_t *cond);
 extern void qurt_cond_wait(qurt_cond_t *cond, qurt_mutex_t *mutex);
 
 typedef enum {
+    QURT_HVX_MODE_UNKNOWN = -1,
     QURT_HVX_MODE_64B = 0,      /**< HVX mode of 64 bytes */
     QURT_HVX_MODE_128B = 1      /**< HVX mode of 128 bytes */
 } qurt_hvx_mode_t;

--- a/src/runtime/qurt_thread_pool.cpp
+++ b/src/runtime/qurt_thread_pool.cpp
@@ -131,24 +131,25 @@ WEAK int halide_do_par_for(void *user_context,
         qurt_mutex_init(mutex);
     }
 
-    wrapped_closure c = {closure, master_thread_mode};
+    // wrapped_closure c = {closure, master_thread_mode};
 
     // Set the desired number of threads based on the current HVX
     // mode.
     int old_num_threads =
-        halide_set_num_threads((c.hvx_mode == QURT_HVX_MODE_128B) ? 2 : 4);
+        halide_set_num_threads(// (c.hvx_mode == QURT_HVX_MODE_128B) ? 2 : 
+                               4);
     // We're about to acquire the thread-pool lock, so we must drop
     // the hvx context lock, even though we'll likely reacquire it
     // immediately to do some work on this thread.
     // Do this only if we locked in an HVX mode in the first place.
-    if (c.hvx_mode != QURT_HVX_MODE_UNKNOWN) {
-        qurt_hvx_unlock();
-    }
-    int ret = halide_default_do_par_for(user_context, task, min, size, (uint8_t *)&c);
+    // if (c.hvx_mode != QURT_HVX_MODE_UNKNOWN) {
+    qurt_hvx_unlock();
+    // }
+    int ret = halide_default_do_par_for(user_context, task, min, size, (uint8_t *)&closure);
 
-    if (c.hvx_mode != -1) {
-        qurt_hvx_lock((qurt_hvx_mode_t)c.hvx_mode);
-    }
+    // if (c.hvx_mode != -1) {
+    //     qurt_hvx_lock((qurt_hvx_mode_t)c.hvx_mode);
+    // }
 
     // Set the desired number of threads back to what it was, in case
     // we're a 128 job and we were sharing the machine with a 64 job.
@@ -159,18 +160,18 @@ WEAK int halide_do_par_for(void *user_context,
 WEAK int halide_do_task(void *user_context, halide_task_t f,
                         int idx, uint8_t *closure) {
     // Dig the appropriate hvx mode out of the wrapped closure and lock it.
-    wrapped_closure *c = (wrapped_closure *)closure;
+    // wrapped_closure *c = (wrapped_closure *)closure;
     // We don't own the thread-pool lock here, so we can safely
     // acquire the hvx context lock (if needed) to run some code.
 
-    if (c->hvx_mode != QURT_HVX_MODE_UNKNOWN) {
-        qurt_hvx_lock((qurt_hvx_mode_t)c->hvx_mode);
-        int ret = f(user_context, idx, c->closure);
-        qurt_hvx_unlock();
-        return ret;
-    } else {
-        return f(user_context, idx, c->closure);
-    }
+    // if (c->hvx_mode != QURT_HVX_MODE_UNKNOWN) {
+    //     qurt_hvx_lock((qurt_hvx_mode_t)c->hvx_mode);
+    //     int ret = f(user_context, idx, c->closure);
+    //     qurt_hvx_unlock();
+    //     return ret;
+    // } else {
+    return f(user_context, idx, closure);
+    // }
 }
 namespace {
 __attribute__((destructor))

--- a/src/runtime/runtime_api.cpp
+++ b/src/runtime/runtime_api.cpp
@@ -161,6 +161,7 @@ extern "C" __attribute__((used)) void *halide_runtime_api_functions[] = {
     (void *)&halide_qurt_hvx_lock,
     (void *)&halide_qurt_hvx_unlock,
     (void *)&halide_qurt_hvx_unlock_as_destructor,
+    (void *)&halide_set_par_hvx_mode,
     (void *)&halide_release_jit_module,
     (void *)&halide_set_custom_can_use_target_features,
     (void *)&halide_set_custom_do_par_for,


### PR DESCRIPTION
On newer Snapdragon targets, the way for a thread to get
HVX 64B or 128B mode has changed. This means that we can
no longer use qurt_hvx_get_mode() inside qurt_thread_pool to
know in what mode the threads in the thread pool should lock
HVX. This patch adds a new function set_par_hvx_mode that
bakes in a call into every pipelines that uses HVX and parallel
that tells the runtime what mode the master thread is going
to be using. The paralle runtime "remembers" this and uses
this mode for the worker threads in the thread pool.

@dsharletg : PTAL