### PR TITLE
Enable naming dimensions of extern stages

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -162,14 +162,13 @@ bool Func::is_extern() const {
 void Func::define_extern(const std::string &function_name,
                          const std::vector<ExternFuncArgument> &args,
                          const std::vector<Type> &types,
-                         int dimensionality,
+                         const std::vector<Var> &arguments,
                          NameMangling mangling,
                          DeviceAPI device_api,
                          bool uses_old_buffer_t) {
-    vector<string> dim_names(dimensionality);
-    // Use _0, _1, _2 etc for the storage dimensions
-    for (int i = 0; i < dimensionality; i++) {
-        dim_names[i] = Var::implicit(i).name();
+    vector<string> dim_names(arguments.size());
+    for (size_t i = 0; i < arguments.size(); i++) {
+        dim_names[i] = arguments[i].name();
     }
     func.define_extern(function_name, args, types, dim_names,
                        mangling, device_api, uses_old_buffer_t);

--- a/src/Func.h
+++ b/src/Func.h
@@ -954,8 +954,9 @@ public:
                               int dimensionality,
                               NameMangling mangling,
                               bool uses_old_buffer_t) {
-        define_extern(function_name, params, std::vector<Type>{t},
-                      dimensionality, mangling, DeviceAPI::Host, uses_old_buffer_t);
+        define_extern(function_name, params, t,
+                      Internal::make_argument_list(dimensionality),
+                      mangling, uses_old_buffer_t);
     }
 
     EXPORT void define_extern(const std::string &function_name,
@@ -965,8 +966,9 @@ public:
                               NameMangling mangling = NameMangling::Default,
                               DeviceAPI device_api = DeviceAPI::Host,
                               bool uses_old_buffer_t = false) {
-        define_extern(function_name, params, std::vector<Type>{t},
-                      dimensionality, mangling, device_api, uses_old_buffer_t);
+        define_extern(function_name, params, t,
+                      Internal::make_argument_list(dimensionality),
+                      mangling, device_api, uses_old_buffer_t);
     }
 
     EXPORT void define_extern(const std::string &function_name,
@@ -975,14 +977,58 @@ public:
                               int dimensionality,
                               NameMangling mangling,
                               bool uses_old_buffer_t) {
-      define_extern(function_name, params, types,
-                    dimensionality, mangling, DeviceAPI::Host, uses_old_buffer_t);
+        define_extern(function_name, params, types,
+                      Internal::make_argument_list(dimensionality),
+                      mangling, uses_old_buffer_t);
     }
 
     EXPORT void define_extern(const std::string &function_name,
                               const std::vector<ExternFuncArgument> &params,
                               const std::vector<Type> &types,
                               int dimensionality,
+                              NameMangling mangling = NameMangling::Default,
+                              DeviceAPI device_api = DeviceAPI::Host,
+                              bool uses_old_buffer_t = false) {
+        define_extern(function_name, params, types,
+                      Internal::make_argument_list(dimensionality),
+                      mangling, device_api, uses_old_buffer_t);
+    }
+
+    EXPORT void define_extern(const std::string &function_name,
+                              const std::vector<ExternFuncArgument> &params,
+                              Type t,
+                              const std::vector<Var> &arguments,
+                              NameMangling mangling,
+                              bool uses_old_buffer_t) {
+        define_extern(function_name, params, std::vector<Type>{t},
+                      arguments, mangling, uses_old_buffer_t);
+    }
+
+    EXPORT void define_extern(const std::string &function_name,
+                              const std::vector<ExternFuncArgument> &params,
+                              Type t,
+                              const std::vector<Var> &arguments,
+                              NameMangling mangling = NameMangling::Default,
+                              DeviceAPI device_api = DeviceAPI::Host,
+                              bool uses_old_buffer_t = false) {
+        define_extern(function_name, params, std::vector<Type>{t},
+                      arguments, mangling, device_api, uses_old_buffer_t);
+    }
+
+    EXPORT void define_extern(const std::string &function_name,
+                              const std::vector<ExternFuncArgument> &params,
+                              const std::vector<Type> &types,
+                              const std::vector<Var> &arguments,
+                              NameMangling mangling,
+                              bool uses_old_buffer_t) {
+      define_extern(function_name, params, types,
+                    arguments, mangling, DeviceAPI::Host, uses_old_buffer_t);
+    }
+
+    EXPORT void define_extern(const std::string &function_name,
+                              const std::vector<ExternFuncArgument> &params,
+                              const std::vector<Type> &types,
+                              const std::vector<Var> &arguments,
                               NameMangling mangling = NameMangling::Default,
                               DeviceAPI device_api = DeviceAPI::Host,
                               bool uses_old_buffer_t = false);

--- a/src/Var.cpp
+++ b/src/Var.cpp
@@ -18,4 +18,16 @@ bool Var::is_implicit(const std::string &name) {
         name.find_first_not_of("0123456789", 1) == std::string::npos;
 }
 
+namespace Internal {
+
+std::vector<Var> make_argument_list(int dimensionality) {
+    std::vector<Var> args(dimensionality);
+    for (int i = 0; i < dimensionality; i++) {
+        args[i] = Var::implicit(i);
+    }
+    return args;
+}
+
+}
+
 }

--- a/src/Var.h
+++ b/src/Var.h
@@ -176,6 +176,14 @@ EXPORT extern Var _;
 EXPORT extern Var _0, _1, _2, _3, _4, _5, _6, _7, _8, _9;
 // @}
 
+namespace Internal {
+
+/** Make a list of unique arguments for definitions with unnamed
+    arguments. */
+EXPORT std::vector<Var> make_argument_list(int dimensionality);
+
+}
+
 }
 
 #endif

--- a/test/correctness/extern_producer.cpp
+++ b/test/correctness/extern_producer.cpp
@@ -100,9 +100,9 @@ int main(int argc, char **argv) {
         Func source;
         source.define_extern("make_data",
                              std::vector<ExternFuncArgument>(),
-                             Float(32), 2);
+                             Float(32), {x, y});
         // Row stride should be 128B/32-element aligned.
-        source.align_storage(_0, 32);
+        source.align_storage(x, 32);
         Func sink;
         sink(x, y) = source(x, y) - sin(x + y);
 
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
         types.push_back(Float(32));
         multi.define_extern("make_data_multi",
                             std::vector<ExternFuncArgument>(),
-                            types, 2);
+                            types, {x, y});
         Func sink_multi;
         sink_multi(x, y) = multi(x, y)[0] - sin(x + y) +
                 multi(x, y)[1] - cos(x + y);

--- a/test/correctness/extern_reorder_storage.cpp
+++ b/test/correctness/extern_reorder_storage.cpp
@@ -1,0 +1,60 @@
+#include "Halide.h"
+#include <stdio.h>
+
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+// An extern stage that translates.
+extern "C" DLLEXPORT int copy_and_check_strides(halide_buffer_t *in, halide_buffer_t *out) {
+    if (in->is_bounds_query()) {
+        for (int i = 0; i < 2; i++) {
+	    in->dim[i].min = out->dim[i].min;
+	    in->dim[i].extent = out->dim[i].extent;
+	}
+    } else if (!out->is_bounds_query()) {
+        // Check that the storage has been reordered.
+        assert(out->dim[0].stride > out->dim[1].stride);
+        Halide::Runtime::Buffer<uint8_t> out_buf(*out);
+        out_buf.copy_from(Halide::Runtime::Buffer<uint8_t>(*in));
+    }
+
+    return 0;
+}
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Var x, y;
+
+    const int W = 30, H = 20;
+    Buffer<uint8_t> input_buffer(W, H);
+    for (int i = 0; i < H; i++) {
+        for (int j = 0; j < W; j++) {
+            input_buffer(j, i) = i + j;
+        }
+    }
+
+    // Define a pipeline that uses an input image in an extern stage
+    // only and do bounds queries.
+    ImageParam input(UInt(8), 2);
+    Func f, g;
+
+    f.define_extern("copy_and_check_strides", {input}, UInt(8), {x, y});
+    g(x, y) = f(x, y);
+
+    f.compute_root().reorder_storage(y, x);
+    
+    input.set(input_buffer);
+    Buffer<uint8_t> output = g.realize(W, H);
+    for (int i = 0; i < H; i++) {
+        for (int j = 0; j < W; j++) {
+            assert(output(j, i) == i + j);
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
This PR makes it possible to name the dimensions of extern stages, which makes it easier to use storage scheduling directives on them.