### PR TITLE
hexagon-lldb: Add "./" to shared libraries names given to dlopenbuf

### DIFF
--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -206,7 +206,7 @@ WEAK int halide_hexagon_initialize_kernels(void *user_context, void **state_ptr,
     // Initialize the runtime, if necessary.
     if (!shared_runtime) {
         debug(user_context) << "    Initializing shared runtime\n";
-        const char soname[] = "libhalide_shared_runtime.so";
+        const char soname[] = "./libhalide_shared_runtime.so";
         debug(user_context) << "    halide_remote_load_library(" << soname << ") -> ";
         result = remote_load_library(soname, sizeof(soname), runtime, runtime_size, &shared_runtime);
         poll_log(user_context);
@@ -240,7 +240,7 @@ WEAK int halide_hexagon_initialize_kernels(void *user_context, void **state_ptr,
     if (!(*state)->module) {
         static int unique_id = 0;
         stringstream soname(user_context);
-        soname << "libhalide_kernels" << unique_id++ << ".so";
+        soname << "./libhalide_kernels" << unique_id++ << ".so";
         debug(user_context) << "    halide_remote_load_library(" << soname.str() << ") -> ";
         halide_hexagon_handle_t module = 0;
         result = remote_load_library(soname.str(), soname.size() + 1, code, code_size, &module);

--- a/src/runtime/hexagon_remote/host_shim.cpp
+++ b/src/runtime/hexagon_remote/host_shim.cpp
@@ -40,7 +40,7 @@ int halide_hexagon_remote_initialize_kernels_v3(const unsigned char *code, int c
     // previously opened library.
     static int unique_id = 0;
     char soname[256];
-    sprintf(soname, "libhalide_kernels%04d.so", __sync_fetch_and_add(&unique_id, 1));
+    sprintf(soname, "./libhalide_kernels%04d.so", __sync_fetch_and_add(&unique_id, 1));
 
     return halide_hexagon_remote_load_library(soname, strlen(soname) + 1, code, codeLen, module_ptr);
 }


### PR DESCRIPTION
This fix makes it possible to use hexagon-lldb on target to debug
code in libhalide_kernels*.so & libhalide_shared_runtime.so.

By convention, to debug shared libraries (located via search path),
lldb needs the library names returned from the dynamic loader to
begin with "./" which it replaces with directories in the search
path.  This is handled correctly by libraries opened via dlopen but
not by dlopenbuf.

The workaround is to explicitly add a beginning "./" to the
dlopenbuf library names.  A bug has also been opened to correct the
behavior of dlopenbuf so this workaround will eventually not
be needed.