### PR TITLE
Add assert failures for scheduling undefined Funcs

### DIFF
--- a/src/Func.h
+++ b/src/Func.h
@@ -70,6 +70,7 @@ public:
     Stage(Internal::Definition d, const std::string &n, const std::vector<Var> &args,
           const Internal::FuncSchedule &func_s)
             : definition(d), stage_name(n), dim_vars(args), func_schedule(func_s) {
+        user_assert(definition.defined()) << "Func " << n << " is not defined.";
         internal_assert(definition.args().size() == dim_vars.size());
         definition.schedule().touched() = true;
     }
@@ -77,6 +78,7 @@ public:
     Stage(Internal::Definition d, const std::string &n, const std::vector<std::string> &args,
           const Internal::FuncSchedule &func_s)
             : definition(d), stage_name(n), func_schedule(func_s) {
+        user_assert(definition.defined()) << "Func " << n << " is not defined.";
         definition.schedule().touched() = true;
 
         std::vector<Var> dim_vars(args.size());


### PR DESCRIPTION
A large class of scheduling operations would previously just segfault if you called them on undefined Funcs, eg

    Func f;
    f.parallel(x);   // crash!

This inserts a couple of assertions to make the failure much kinder and more helpful.