### PR TITLE
Fix python errors and logging

### DIFF
--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -35,7 +35,7 @@ PY_OBJS=$(PY_SRCS:$(ROOT_DIR)/python/%.cpp=$(BIN)/py_%.o)
 NUMPY_SRCS=$(shell ls $(ROOT_DIR)/halide_numpy/*.cpp)
 NUMPY_OBJS=$(NUMPY_SRCS:$(ROOT_DIR)/halide_numpy/%.cpp=$(BIN)/numpy_%.o)
 
-$(BIN)/halide.so: $(PY_SRCS) $(PY_OBJS) $(NUMPY_SRCS) $(NUMPY_OBJS)
+$(BIN)/halide.so: $(PY_SRCS) $(PY_OBJS) $(NUMPY_SRCS) $(NUMPY_OBJS)  $(HALIDE_DISTRIB_PATH)/lib/libHalide.a
 	@mkdir -p $(@D)
 	$(CXX) $(PY_OBJS) $(NUMPY_OBJS) $(LDFLAGS) $(HALIDE_DISTRIB_PATH)/lib/libHalide.a -shared -o $@
 

--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -2,6 +2,57 @@
 
 from halide import *
 
+def test_compiletime_error():
+
+    x = Var('x')
+    y = Var('y')
+    f = Func('f')
+    f[x, y] = cast(UInt(16), x + y)
+    # Deliberate type-mismatch error
+    buf = Buffer(UInt(8), 2, 2)
+    try:
+        f.realize(buf)
+    except RuntimeError as e:
+        print('Saw expected exception (%s)' % str(e))
+    else:
+        assert False, 'Did not see expected exception!'
+
+def test_runtime_error():
+
+    x = Var('x')
+    f = Func('f')
+    f[x] = cast(UInt(8), x)
+    f.bound(x, 0, 1)
+    # Deliberate runtime error
+    buf = Buffer(UInt(8), 10)
+    try:
+        f.realize(buf)
+    except RuntimeError as e:
+        print('Saw expected exception (%s)' % str(e))
+    else:
+        assert False, 'Did not see expected exception!'
+
+    return
+
+def test_print_expr():
+    x = Var('x')
+    f = Func('f')
+    f[x] = print_expr(cast(UInt(8), x), 'is what', 'the', 1, 'and', 3.1415, 'saw')
+    buf = Buffer(UInt(8), 1)
+    f.realize(buf)
+
+    return
+
+def test_print_when():
+
+    x = Var('x')
+    f = Func('f')
+    f[x] = print_when(x == 3, cast(UInt(8), x*x), 'is result at', x)
+    buf = Buffer(UInt(8), 10)
+    f.realize(buf)
+
+    return
+
 def test_types():
 
     t0 = Int(32)
@@ -289,6 +340,10 @@ def test_imageparam_bug():
 
 if __name__ == "__main__":
 
+    test_compiletime_error()
+    test_runtime_error()
+    test_print_expr()
+    test_print_when()
     test_imageparam_bug()
     test_param_bug()
     test_float_or_int()

--- a/python_bindings/python/IROperator.cpp
+++ b/python_bindings/python/IROperator.cpp
@@ -147,28 +147,40 @@ h::Expr select9(h::Expr c1, h::Expr v1,
                      c10, v10, default_val);
 }
 
-h::Expr print_when0(h::Expr condition, p::tuple values_passed) {
-    const size_t num_values = p::len(values_passed);
-    std::vector<h::Expr> values;
-    values.reserve(num_values);
+std::vector<h::Expr> tuple_to_exprs(p::tuple t) {
+    const size_t c = p::len(t);
+    std::vector<h::Expr> exprs;
+    exprs.reserve(c);
 
-    for (size_t i = 0; i < num_values; i += 1) {
-        p::object o = values_passed[i];
-        p::extract<h::Expr &> expr_extract(o);
-
+    for (size_t i = 0; i < c; i += 1) {
+        p::object o = t[i];
+        h::Expr e;
+        p::extract<h::Expr> expr_extract(o);
         if (expr_extract.check()) {
-            values.push_back(expr_extract());
+            e = expr_extract();
         } else {
-            for (size_t j = 0; j < num_values; j += 1) {
-                p::object o = values_passed[j];
-                const std::string o_str = p::extract<std::string>(p::str(o));
-                printf("print_when values[%lu] == %s\n", j, o_str.c_str());
+            // Python 'str' is not implicitly convertible to Expr,
+            // but in this context we want to explicitly check and convert.
+            p::extract<std::string> string_extract(o);
+            if (string_extract.check()) {
+                e = h::Expr(string_extract());
+            } else {
+              const std::string o_str = p::extract<std::string>(p::str(o));
+              throw std::invalid_argument("The value '" + o_str + "' is not convertible to Expr.");
             }
-            throw std::invalid_argument("print_when only handles a list/tuple of (convertible to) Expr.");
         }
+        exprs.push_back(e);
     }
+    return exprs;
+}
 
-    return h::print_when(condition, values);
+p::object print_expr(p::tuple args, p::dict kwargs) {
+    return p::object(h::print(tuple_to_exprs(args)));
+}
+
+p::object print_when(p::tuple args, p::dict kwargs) {
+    h::Expr condition = p::extract<h::Expr>(args[0]);
+    return p::object(h::print_when(condition, tuple_to_exprs(p::extract<p::tuple>(args.slice(1, p::_)))));
 }
 
 h::Expr random_float0() {
@@ -490,8 +502,18 @@ void define_operators() {
     p::def("cast", &cast0, p::args("t", "e"),
            "Cast an expression to a new type.");
 
-    p::def("print_when", &print_when0, (p::arg("condition"), p::arg("values")),
-           "Create an Expr that prints whenever it is evaluated, provided that the condition is true.");
+    p::def("print_when", p::raw_function(&print_when, 2));
+           // TODO(srj): apparently you cannot specify a docstring with raw_function().
+           // "Create an Expr that prints whenever it is evaluated, provided that the condition is true.");
+
+    // We call this "print_expr" rather than "print" to avoid
+    // conflicts with Python's build-in "print()" function, in
+    // case users import all of the Halide bindings.
+    p::def("print_expr", p::raw_function(&print_expr, 1));
+           // TODO(srj): apparently you cannot specify a docstring with raw_function().
+           // "Create an Expr that prints out its value whenever it is "
+           // "evaluated. It also prints out everything else in the arguments "
+           // "list, separated by spaces. This can include string literals.");
 
     p::def("lerp", &h::lerp, p::args("zero_val", "one_val", "weight"),
            "Linear interpolate between the two values according to a weight.\n"


### PR DESCRIPTION
- Halide errors turn into Python exceptions (both compile and runtime)
- properly implement print and print_when and connect them to Python stdout
- add tests as appropriate