### PR TITLE
Add HL_HEXAGON_DUMP_BITCODE environment variable

### DIFF
--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -962,6 +962,14 @@ Buffer<uint8_t> compile_module_to_hexagon_shared_object(const Module &device_cod
         debug(0) << assembly.c_str() << "\n";
     }
 
+    // Write intermediate bitcode to disk if requested.
+    std::string bitcode_dump_path = get_env_variable("HL_HEXAGON_DUMP_BITCODE");
+    if (!bitcode_dump_path.empty()) {
+        auto fd_ostream = make_raw_fd_ostream(bitcode_dump_path);
+        compile_llvm_module_to_llvm_bitcode(*llvm_module, *fd_ostream);
+        debug(0) << "Wrote Hexagon device bitcode to " << bitcode_dump_path;
+    }
+
     auto obj = Elf::Object::parse_object(object.data(), object.size());
     internal_assert(obj);
 

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -963,6 +963,8 @@ Buffer<uint8_t> compile_module_to_hexagon_shared_object(const Module &device_cod
     }
 
     // Write intermediate bitcode to disk if requested.
+    // TODO: We really need something better than this. This won't
+    // work in non-trivial JIT or AOT programs.
     std::string bitcode_dump_path = get_env_variable("HL_HEXAGON_DUMP_BITCODE");
     if (!bitcode_dump_path.empty()) {
         auto fd_ostream = make_raw_fd_ostream(bitcode_dump_path);

--- a/src/LLVM_Output.h
+++ b/src/LLVM_Output.h
@@ -52,7 +52,7 @@ EXPORT void compile_llvm_module_to_llvm_assembly(llvm::Module &module, Internal:
  * all modes (equivalent to the ar -D option).
  */
 EXPORT void create_static_library(const std::vector<std::string> &src_files, const Target &target,
-                           const std::string &dst_file, bool deterministic = true);
+                                  const std::string &dst_file, bool deterministic = true);
 }
 
 #endif


### PR DESCRIPTION
This is not something that will really work in very many use cases, but it's enough to help debug many of the correctness tests, and not having this has caused a lot of pain.