### PR TITLE
Insert one more explicit cast to deal with “int-> uint32_t” issue

### DIFF
--- a/src/runtime/write_debug_image.cpp
+++ b/src/runtime/write_debug_image.cpp
@@ -294,7 +294,7 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
 
         // Payload header
         uint32_t payload_header[2] = {
-            pixel_type_to_matlab_type_code[type_code], payload_bytes
+            pixel_type_to_matlab_type_code[type_code], (int32_t)payload_bytes
         };
         if (!f.write(payload_header, sizeof(payload_header))) {
             return -11;


### PR DESCRIPTION
… this is another instance of the bug addressed in https://github.com/halide/Halide/commit/b1cfc23db88d230e914bd9624ab3523b8dc85a77