### PR TITLE
Revert "Fix python errors and logging"

### DIFF
--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -35,7 +35,7 @@ PY_OBJS=$(PY_SRCS:$(ROOT_DIR)/python/%.cpp=$(BIN)/py_%.o)
 NUMPY_SRCS=$(shell ls $(ROOT_DIR)/halide_numpy/*.cpp)
 NUMPY_OBJS=$(NUMPY_SRCS:$(ROOT_DIR)/halide_numpy/%.cpp=$(BIN)/numpy_%.o)
 
-$(BIN)/halide.so: $(PY_SRCS) $(PY_OBJS) $(NUMPY_SRCS) $(NUMPY_OBJS)  $(HALIDE_DISTRIB_PATH)/lib/libHalide.a
+$(BIN)/halide.so: $(PY_SRCS) $(PY_OBJS) $(NUMPY_SRCS) $(NUMPY_OBJS)
 	@mkdir -p $(@D)
 	$(CXX) $(PY_OBJS) $(NUMPY_OBJS) $(LDFLAGS) $(HALIDE_DISTRIB_PATH)/lib/libHalide.a -shared -o $@
 

--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -2,57 +2,6 @@
 
 from halide import *
 
-def test_compiletime_error():
-
-    x = Var('x')
-    y = Var('y')
-    f = Func('f')
-    f[x, y] = cast(UInt(16), x + y)
-    # Deliberate type-mismatch error
-    buf = Buffer(UInt(8), 2, 2)
-    try:
-        f.realize(buf)
-    except RuntimeError as e:
-        print('Saw expected exception (%s)' % str(e))
-    else:
-        assert False, 'Did not see expected exception!'
-
-def test_runtime_error():
-
-    x = Var('x')
-    f = Func('f')
-    f[x] = cast(UInt(8), x)
-    f.bound(x, 0, 1)
-    # Deliberate runtime error
-    buf = Buffer(UInt(8), 10)
-    try:
-        f.realize(buf)
-    except RuntimeError as e:
-        print('Saw expected exception (%s)' % str(e))
-    else:
-        assert False, 'Did not see expected exception!'
-
-    return
-
-def test_print_expr():
-    x = Var('x')
-    f = Func('f')
-    f[x] = print_expr(cast(UInt(8), x), 'is what', 'the', 1, 'and', 3.1415, 'saw')
-    buf = Buffer(UInt(8), 1)
-    f.realize(buf)
-
-    return
-
-def test_print_when():
-
-    x = Var('x')
-    f = Func('f')
-    f[x] = print_when(x == 3, cast(UInt(8), x*x), 'is result at', x)
-    buf = Buffer(UInt(8), 10)
-    f.realize(buf)
-
-    return
-
 def test_types():
 
     t0 = Int(32)
@@ -340,10 +289,6 @@ def test_imageparam_bug():
 
 if __name__ == "__main__":
 
-    test_compiletime_error()
-    test_runtime_error()
-    test_print_expr()
-    test_print_when()
     test_imageparam_bug()
     test_param_bug()
     test_float_or_int()

--- a/python_bindings/python/Error.cpp
+++ b/python_bindings/python/Error.cpp
@@ -8,43 +8,34 @@
 namespace h = Halide;
 namespace p = boost::python;
 
-namespace {
-
-void halide_python_error(void *, const char *msg) {
-    throw h::Error(msg);
-}
-
-void halide_python_print(void *, const char *msg) {
-    PySys_WriteStdout("%s", msg);
-}
-
-class HalidePythonCompileTimeErrorReporter : public h::CompileTimeErrorReporter {
-public:
-    void warning(const char* msg) {
-        PySys_WriteStdout("%s", msg);
-    }
-
-    void error(const char* msg) {
-        throw h::Error(msg);
-        // This method must not return!
-    }
-};
-
 void translate_error(h::Error const &e) {
-    PyErr_SetString(PyExc_RuntimeError, e.what());
+    // Use the Python 'C' API to set up an exception object
+    PyErr_SetString(PyExc_RuntimeError,
+                    (std::string("Halide Error: ") + e.what()).c_str());
 }
 
-}  // namespace
+void translate_runtime_error(h::RuntimeError const &e) {
+    // Use the Python 'C' API to set up an exception object
+    PyErr_SetString(PyExc_RuntimeError,
+                    (std::string("Halide RuntimeError: ") + e.what()).c_str());
+}
+
+void translate_compile_error(h::CompileError const &e) {
+    // Use the Python 'C' API to set up an exception object
+    PyErr_SetString(PyExc_RuntimeError,
+                    (std::string("Halide CompileError: ") + e.what()).c_str());
+}
+
+void translate_internal_error(h::InternalError const &e) {
+    // Use the Python 'C' API to set up an exception object
+    PyErr_SetString(PyExc_RuntimeError,
+                    (std::string("Halide InternalError: ") + e.what()).c_str());
+}
 
 void define_error() {
+    // Might create linking problems, if Param.cpp is not included in the python library
     p::register_exception_translator<h::Error>(&translate_error);
-
-    static HalidePythonCompileTimeErrorReporter reporter;
-    set_custom_compile_time_error_reporter(&reporter);
-
-    Halide::Internal::JITHandlers handlers;
-    handlers.custom_error = halide_python_error;
-    handlers.custom_print = halide_python_print;
-    Halide::Internal::JITSharedRuntime::set_default_handlers(handlers);
+    p::register_exception_translator<h::RuntimeError>(&translate_runtime_error);
+    p::register_exception_translator<h::CompileError>(&translate_compile_error);
+    p::register_exception_translator<h::InternalError>(&translate_internal_error);
 }
-


### PR DESCRIPTION
Reverts halide/Halide#2620

Apparently `raw_function()` isn't available in all versions of boost.python we are compiling under (I foolishly landed this during our buildbot outage thinking it was low risk); reverting to unblock buildbots.