### PR TITLE
Fix python errors and logging (take 2)

### DIFF
--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -35,7 +35,7 @@ PY_OBJS=$(PY_SRCS:$(ROOT_DIR)/python/%.cpp=$(BIN)/py_%.o)
 NUMPY_SRCS=$(shell ls $(ROOT_DIR)/halide_numpy/*.cpp)
 NUMPY_OBJS=$(NUMPY_SRCS:$(ROOT_DIR)/halide_numpy/%.cpp=$(BIN)/numpy_%.o)
 
-$(BIN)/halide.so: $(PY_SRCS) $(PY_OBJS) $(NUMPY_SRCS) $(NUMPY_OBJS)
+$(BIN)/halide.so: $(PY_SRCS) $(PY_OBJS) $(NUMPY_SRCS) $(NUMPY_OBJS)  $(HALIDE_DISTRIB_PATH)/lib/libHalide.a
 	@mkdir -p $(@D)
 	$(CXX) $(PY_OBJS) $(NUMPY_OBJS) $(LDFLAGS) $(HALIDE_DISTRIB_PATH)/lib/libHalide.a -shared -o $@
 

--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -1,6 +1,69 @@
 #!/usr/bin/python3
 
 from halide import *
+from contextlib import redirect_stdout
+import io, sys
+
+def test_compiletime_error():
+
+    x = Var('x')
+    y = Var('y')
+    f = Func('f')
+    f[x, y] = cast(UInt(16), x + y)
+    # Deliberate type-mismatch error
+    buf = Buffer(UInt(8), 2, 2)
+    try:
+        f.realize(buf)
+    except RuntimeError as e:
+        print('Saw expected exception (%s)' % str(e))
+    else:
+        assert False, 'Did not see expected exception!'
+
+def test_runtime_error():
+
+    x = Var('x')
+    f = Func('f')
+    f[x] = cast(UInt(8), x)
+    f.bound(x, 0, 1)
+    # Deliberate runtime error
+    buf = Buffer(UInt(8), 10)
+    try:
+        f.realize(buf)
+    except RuntimeError as e:
+        print('Saw expected exception (%s)' % str(e))
+    else:
+        assert False, 'Did not see expected exception!'
+
+    return
+
+def test_print_expr():
+    x = Var('x')
+    f = Func('f')
+    f[x] = print_expr(cast(UInt(8), x), 'is what', 'the', 1, 'and', 3.1415, 'saw')
+    buf = Buffer(UInt(8), 1)
+    output = io.StringIO()
+    with redirect_stdout(output):
+        f.realize(buf)
+        expected = '0 is what the 1 and 3.141500 saw\n'
+        actual = output.getvalue()
+        assert expected == actual, "Expected: %s, Actual: %s" % (expected, actual)
+
+    return
+
+def test_print_when():
+
+    x = Var('x')
+    f = Func('f')
+    f[x] = print_when(x == 3, cast(UInt(8), x*x), 'is result at', x)
+    buf = Buffer(UInt(8), 10)
+    output = io.StringIO()
+    with redirect_stdout(output):
+        f.realize(buf)
+        expected = '9 is result at 3\n'
+        actual = output.getvalue()
+        assert expected == actual, "Expected: %s, Actual: %s" % (expected, actual)
+
+    return
 
 def test_types():
 
@@ -289,6 +352,10 @@ def test_imageparam_bug():
 
 if __name__ == "__main__":
 
+    test_compiletime_error()
+    test_runtime_error()
+    test_print_expr()
+    test_print_when()
     test_imageparam_bug()
     test_param_bug()
     test_float_or_int()

--- a/python_bindings/python/IROperator.cpp
+++ b/python_bindings/python/IROperator.cpp
@@ -109,8 +109,8 @@ std::vector<h::Expr> tuple_to_exprs(p::tuple t) {
             if (string_extract.check()) {
                 e = h::Expr(string_extract());
             } else {
-              const std::string o_str = p::extract<std::string>(p::str(o));
-              throw std::invalid_argument("The value '" + o_str + "' is not convertible to Expr.");
+                const std::string o_str = p::extract<std::string>(p::str(o));
+                throw std::invalid_argument("The value '" + o_str + "' is not convertible to Expr.");
             }
         }
         exprs.push_back(e);
@@ -158,11 +158,11 @@ h::Expr memoize_tag0(h::Expr result, const std::vector<h::Expr> &cache_key_value
 // probably augment docstrings that use this appropriately.
 template <class F>
 p::object def_raw(const char *name, F f, size_t min_args, const char *docstring) {
-  p::object o = p::raw_function(f, min_args);
-  p::def(name, o);
-  // Must call setattr *after* def
-  p::setattr(o, "__doc__", p::str(docstring));
-  return o;
+    p::object o = p::raw_function(f, min_args);
+    p::def(name, o);
+    // Must call setattr *after* def
+    p::setattr(o, "__doc__", p::str(docstring));
+    return o;
 }
 
 }  // namespace

--- a/python_bindings/python/IROperator.cpp
+++ b/python_bindings/python/IROperator.cpp
@@ -1,12 +1,16 @@
 #include "IROperator.h"
 
 #include <boost/python.hpp>
+// Some versions of Boost don't include raw_function in python.hpp
+#include <boost/python/raw_function.hpp>
 #include <string>
 
 #include "Halide.h"
 
 namespace h = Halide;
 namespace p = boost::python;
+
+namespace {
 
 h::Expr reinterpret0(h::Type t, h::Expr e) {
     return h::reinterpret(t, e);
@@ -86,89 +90,41 @@ h::Expr select6(h::Expr c1, h::Expr v1,
                      c6, v6,
                      c7, v7, default_val);
 }
-h::Expr select7(h::Expr c1, h::Expr v1,
-                h::Expr c2, h::Expr v2,
-                h::Expr c3, h::Expr v3,
-                h::Expr c4, h::Expr v4,
-                h::Expr c5, h::Expr v5,
-                h::Expr c6, h::Expr v6,
-                h::Expr c7, h::Expr v7,
-                h::Expr c8, h::Expr v8,
-                h::Expr default_val) {
-    return h::select(c1, v1,
-                     c2, v2,
-                     c3, v3,
-                     c4, v4,
-                     c5, v5,
-                     c6, v6,
-                     c7, v7,
-                     c8, v8, default_val);
-}
-h::Expr select8(h::Expr c1, h::Expr v1,
-                h::Expr c2, h::Expr v2,
-                h::Expr c3, h::Expr v3,
-                h::Expr c4, h::Expr v4,
-                h::Expr c5, h::Expr v5,
-                h::Expr c6, h::Expr v6,
-                h::Expr c7, h::Expr v7,
-                h::Expr c8, h::Expr v8,
-                h::Expr c9, h::Expr v9,
-                h::Expr default_val) {
-    return h::select(c1, v1,
-                     c2, v2,
-                     c3, v3,
-                     c4, v4,
-                     c5, v5,
-                     c6, v6,
-                     c7, v7,
-                     c8, v8,
-                     c9, v9, default_val);
-}
-h::Expr select9(h::Expr c1, h::Expr v1,
-                h::Expr c2, h::Expr v2,
-                h::Expr c3, h::Expr v3,
-                h::Expr c4, h::Expr v4,
-                h::Expr c5, h::Expr v5,
-                h::Expr c6, h::Expr v6,
-                h::Expr c7, h::Expr v7,
-                h::Expr c8, h::Expr v8,
-                h::Expr c9, h::Expr v9,
-                h::Expr c10, h::Expr v10,
-                h::Expr default_val) {
-    return h::select(c1, v1,
-                     c2, v2,
-                     c3, v3,
-                     c4, v4,
-                     c5, v5,
-                     c6, v6,
-                     c7, v7,
-                     c8, v8,
-                     c9, v9,
-                     c10, v10, default_val);
-}
 
-h::Expr print_when0(h::Expr condition, p::tuple values_passed) {
-    const size_t num_values = p::len(values_passed);
-    std::vector<h::Expr> values;
-    values.reserve(num_values);
+std::vector<h::Expr> tuple_to_exprs(p::tuple t) {
+    const size_t c = p::len(t);
+    std::vector<h::Expr> exprs;
+    exprs.reserve(c);
 
-    for (size_t i = 0; i < num_values; i += 1) {
-        p::object o = values_passed[i];
-        p::extract<h::Expr &> expr_extract(o);
-
+    for (size_t i = 0; i < c; i += 1) {
+        p::object o = t[i];
+        h::Expr e;
+        p::extract<h::Expr> expr_extract(o);
         if (expr_extract.check()) {
-            values.push_back(expr_extract());
+            e = expr_extract();
         } else {
-            for (size_t j = 0; j < num_values; j += 1) {
-                p::object o = values_passed[j];
-                const std::string o_str = p::extract<std::string>(p::str(o));
-                printf("print_when values[%lu] == %s\n", j, o_str.c_str());
+            // Python 'str' is not implicitly convertible to Expr,
+            // but in this context we want to explicitly check and convert.
+            p::extract<std::string> string_extract(o);
+            if (string_extract.check()) {
+                e = h::Expr(string_extract());
+            } else {
+              const std::string o_str = p::extract<std::string>(p::str(o));
+              throw std::invalid_argument("The value '" + o_str + "' is not convertible to Expr.");
             }
-            throw std::invalid_argument("print_when only handles a list/tuple of (convertible to) Expr.");
         }
+        exprs.push_back(e);
     }
+    return exprs;
+}
 
-    return h::print_when(condition, values);
+p::object print_expr(p::tuple args, p::dict kwargs) {
+    return p::object(h::print(tuple_to_exprs(args)));
+}
+
+p::object print_when(p::tuple args, p::dict kwargs) {
+    h::Expr condition = p::extract<h::Expr>(args[0]);
+    return p::object(h::print_when(condition, tuple_to_exprs(p::extract<p::tuple>(args.slice(1, p::_)))));
 }
 
 h::Expr random_float0() {
@@ -194,6 +150,22 @@ h::Expr undef0(h::Type type) {
 h::Expr memoize_tag0(h::Expr result, const std::vector<h::Expr> &cache_key_values) {
     return h::memoize_tag(result, cache_key_values);
 }
+
+// p::def() doesn't allow specifying a docstring with raw_function();
+// this is some simple sugar to allow for it.
+// TODO: unfortunately, using raw_function() means that we don't get
+// any free type info about the Python prototype look; we should
+// probably augment docstrings that use this appropriately.
+template <class F>
+p::object def_raw(const char *name, F f, size_t min_args, const char *docstring) {
+  p::object o = p::raw_function(f, min_args);
+  p::def(name, o);
+  // Must call setattr *after* def
+  p::setattr(o, "__doc__", p::str(docstring));
+  return o;
+}
+
+}  // namespace
 
 void define_operators() {
     // defined in IROperator.h
@@ -490,8 +462,17 @@ void define_operators() {
     p::def("cast", &cast0, p::args("t", "e"),
            "Cast an expression to a new type.");
 
-    p::def("print_when", &print_when0, (p::arg("condition"), p::arg("values")),
-           "Create an Expr that prints whenever it is evaluated, provided that the condition is true.");
+    def_raw("print_when", print_when, 2,
+           "Create an Expr that prints whenever it is evaluated, "
+           "provided that the condition is true.");
+
+    // We call this "print_expr" rather than "print" to avoid
+    // conflicts with Python's build-in "print()" function, in
+    // case users import all of the Halide bindings.
+    def_raw("print_expr", print_expr, 1,
+           "Create an Expr that prints out its value whenever it is "
+           "evaluated. It also prints out everything else in the arguments "
+           "list, separated by spaces. This can include string literals.");
 
     p::def("lerp", &h::lerp, p::args("zero_val", "one_val", "weight"),
            "Linear interpolate between the two values according to a weight.\n"


### PR DESCRIPTION
- Halide errors turn into Python exceptions (both compile and runtime)
- properly implement print and print_when and connect them to Python stdout
- add tests as appropriate