### PR TITLE
Adds new helper method to a Halide buffer

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -363,7 +363,7 @@ public:
     HALIDE_BUFFER_FORWARD(deallocate)
     HALIDE_BUFFER_FORWARD(device_deallocate)
     HALIDE_BUFFER_FORWARD(device_free)
-    HALIDE_BUFFER_FORWARD(all)
+    HALIDE_BUFFER_FORWARD(all_equal)
     HALIDE_BUFFER_FORWARD(fill)
     HALIDE_BUFFER_FORWARD_CONST(for_each_element)
 

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -363,6 +363,7 @@ public:
     HALIDE_BUFFER_FORWARD(deallocate)
     HALIDE_BUFFER_FORWARD(device_deallocate)
     HALIDE_BUFFER_FORWARD(device_free)
+    HALIDE_BUFFER_FORWARD(all)
     HALIDE_BUFFER_FORWARD(fill)
     HALIDE_BUFFER_FORWARD_CONST(for_each_element)
 

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1610,6 +1610,12 @@ public:
     }
     // @}
 
+    bool all(not_void_T val) {
+        bool all_equal = true;
+        for_each_value([&](T v) {all_equal &= v == val;});
+        return all_equal;
+    }    
+    
     void fill(not_void_T val) {
         set_host_dirty();
         for_each_value([=](T &v) {v = val;});

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1610,12 +1610,13 @@ public:
     }
     // @}
 
+    /** Tests that all values in this buffer are equal to val. */
     bool all_equal(not_void_T val) {
         bool all_equal = true;
         for_each_value([&](T v) {all_equal &= v == val;});
         return all_equal;
     }    
-    
+
     void fill(not_void_T val) {
         set_host_dirty();
         for_each_value([=](T &v) {v = val;});

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1610,7 +1610,7 @@ public:
     }
     // @}
 
-    bool all(not_void_T val) {
+    bool all_equal(not_void_T val) {
         bool all_equal = true;
         for_each_value([&](T v) {all_equal &= v == val;});
         return all_equal;

--- a/test/correctness/halide_buffer.cpp
+++ b/test/correctness/halide_buffer.cpp
@@ -36,6 +36,8 @@ int main(int argc, char **argv) {
 
         a.fill(1.0f);
 
+        assert(a.all(1.0f));
+
         b.fill([&](int x, int y, int c) {
             return x + 100.0f * y + 100000.0f * c;
         });

--- a/test/correctness/halide_buffer.cpp
+++ b/test/correctness/halide_buffer.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
 
         a.fill(1.0f);
 
-        assert(a.all(1.0f));
+        assert(a.all_equal(1.0f));
 
         b.fill([&](int x, int y, int c) {
             return x + 100.0f * y + 100000.0f * c;


### PR DESCRIPTION
Adds a method to the Buffer class to easily check if all elements in a buffer are set to a specific value. 

The motivation for the change is that I often find myself checking the contents of a Halide buffer in tests. I have a helper function to do the comparison but it would be cleaner/easier to just have a method on the buffer.