### PR TITLE
Update import/naming convention for Python bindings

### DIFF
--- a/python_bindings/apps/bilateral_grid.py
+++ b/python_bindings/apps/bilateral_grid.py
@@ -6,67 +6,67 @@ Bilateral histogram.
 from __future__ import print_function
 from __future__ import division
 
-from halide import *
+import halide as hl
 
 import numpy as np
 from scipy.misc import imread, imsave
 import os.path
 
-int_t = Int(32)
-float_t = Float(32)
+int_t = hl.Int(32)
+float_t = hl.Float(32)
 
 
 def get_bilateral_grid(input, r_sigma, s_sigma):
 
-    x = Var('x')
-    y = Var('y')
-    z = Var('z')
-    c = Var('c')
-    xi = Var("xi")
-    yi = Var("yi")
-    zi = Var("zi")
+    x = hl.Var('x')
+    y = hl.Var('y')
+    z = hl.Var('z')
+    c = hl.Var('c')
+    xi = hl.Var("xi")
+    yi = hl.Var("yi")
+    zi = hl.Var("zi")
 
     # Add a boundary condition
-    clamped = Func('clamped')
-    clamped[x, y] = input[clamp(x, 0, input.width()-1),
-                          clamp(y, 0, input.height()-1)]
+    clamped = hl.Func('clamped')
+    clamped[x, y] = input[hl.clamp(x, 0, input.width()-1),
+                          hl.clamp(y, 0, input.height()-1)]
 
     # Construct the bilateral grid
-    r = RDom(0, s_sigma, 0, s_sigma, 'r')
+    r = hl.RDom(0, s_sigma, 0, s_sigma, 'r')
     val = clamped[x * s_sigma + r.x - s_sigma//2, y * s_sigma + r.y - s_sigma//2]
-    val = clamp(val, 0.0, 1.0)
-    #zi = cast(int_t, val * (1.0/r_sigma) + 0.5)
-    zi = cast(int_t, (val / r_sigma) + 0.5)
-    histogram = Func('histogram')
+    val = hl.clamp(val, 0.0, 1.0)
+    #zi = hl.cast(int_t, val * (1.0/r_sigma) + 0.5)
+    zi = hl.cast(int_t, (val / r_sigma) + 0.5)
+    histogram = hl.Func('histogram')
     histogram[x, y, z, c] = 0.0
-    histogram[x, y, zi, c] += select(c == 0, val, 1.0)
+    histogram[x, y, zi, c] += hl.select(c == 0, val, 1.0)
 
     # Blur the histogram using a five-tap filter
-    blurx, blury, blurz = Func('blurx'), Func('blury'), Func('blurz')
+    blurx, blury, blurz = hl.Func('blurx'), hl.Func('blury'), hl.Func('blurz')
     blurz[x, y, z, c] = histogram[x, y, z-2, c] + histogram[x, y, z-1, c]*4 + histogram[x, y, z, c]*6 + histogram[x, y, z+1, c]*4 + histogram[x, y, z+2, c]
     blurx[x, y, z, c] = blurz[x-2, y, z, c] + blurz[x-1, y, z, c]*4 + blurz[x, y, z, c]*6 + blurz[x+1, y, z, c]*4 + blurz[x+2, y, z, c]
     blury[x, y, z, c] = blurx[x, y-2, z, c] + blurx[x, y-1, z, c]*4 + blurx[x, y, z, c]*6 + blurx[x, y+1, z, c]*4 + blurx[x, y+2, z, c]
 
     # Take trilinear samples to compute the output
-    val = clamp(clamped[x, y], 0.0, 1.0)
+    val = hl.clamp(clamped[x, y], 0.0, 1.0)
     zv = val / r_sigma
-    zi = cast(int_t, zv)
+    zi = hl.cast(int_t, zv)
     zf = zv - zi
-    xf = cast(float_t, x % s_sigma) / s_sigma
-    yf = cast(float_t, y % s_sigma) / s_sigma
+    xf = hl.cast(float_t, x % s_sigma) / s_sigma
+    yf = hl.cast(float_t, y % s_sigma) / s_sigma
     xi = x/s_sigma
     yi = y/s_sigma
-    interpolated = Func('interpolated')
-    interpolated[x, y, c] = lerp(lerp(lerp(blury[xi, yi, zi, c], blury[xi+1, yi, zi, c], xf),
-                                      lerp(blury[xi, yi+1, zi, c], blury[xi+1, yi+1, zi, c], xf), yf),
-                                 lerp(lerp(blury[xi, yi, zi+1, c], blury[xi+1, yi, zi+1, c], xf),
-                                      lerp(blury[xi, yi+1, zi+1, c], blury[xi+1, yi+1, zi+1, c], xf), yf), zf)
+    interpolated = hl.Func('interpolated')
+    interpolated[x, y, c] = hl.lerp(hl.lerp(hl.lerp(blury[xi, yi, zi, c], blury[xi+1, yi, zi, c], xf),
+                                      hl.lerp(blury[xi, yi+1, zi, c], blury[xi+1, yi+1, zi, c], xf), yf),
+                                 hl.lerp(hl.lerp(blury[xi, yi, zi+1, c], blury[xi+1, yi, zi+1, c], xf),
+                                      hl.lerp(blury[xi, yi+1, zi+1, c], blury[xi+1, yi+1, zi+1, c], xf), yf), zf)
 
     # Normalize
-    bilateral_grid = Func('bilateral_grid')
+    bilateral_grid = hl.Func('bilateral_grid')
     bilateral_grid[x, y] = interpolated[x, y, 0]/interpolated[x, y, 1]
 
-    target = get_target_from_environment()
+    target = hl.get_target_from_environment()
     if target.has_gpu_feature():
     #if True:
         # GPU schedule
@@ -97,12 +97,12 @@ def get_bilateral_grid(input, r_sigma, s_sigma):
 
 def generate_compiled_file(bilateral_grid):
 
-    target = get_target_from_environment()
+    target = hl.get_target_from_environment()
     # Need to copy the filter executable from the C++ apps/bilateral_grid folder to run this.
     # (after making it of course)
     arguments = ArgumentsVector()
-    arguments.append(Argument('r_sigma', InputScalar, Float(32), 0))
-    arguments.append(Argument('input', InputBuffer, UInt(16), 2))
+    arguments.append(Argument('r_sigma', InputScalar, hl.Float(32), 0))
+    arguments.append(Argument('input', InputBuffer, hl.UInt(16), 2))
     bilateral_grid.compile_to_file("bilateral_grid",
                                    arguments,
                                    "bilateral_grid",
@@ -133,11 +133,11 @@ def filter_test_image(bilateral_grid, input):
 
     # preparing input and output memory buffers (numpy ndarrays)
     input_data = get_input_data()
-    input_image = Buffer(input_data)
+    input_image = hl.Buffer(input_data)
     input.set(input_image)
 
     output_data = np.empty(input_data.shape, dtype=input_data.dtype, order="F")
-    output_image = Buffer(output_data)
+    output_image = hl.Buffer(output_data)
 
     if False:
         print("input_image", input_image)
@@ -160,8 +160,8 @@ def filter_test_image(bilateral_grid, input):
 
 def main():
 
-    input = ImageParam(float_t, 2, 'input')
-    r_sigma = Param(float_t, 'r_sigma', 0.1) # Value needed if not generating an executable
+    input = hl.ImageParam(float_t, 2, 'input')
+    r_sigma = hl.Param(float_t, 'r_sigma', 0.1) # Value needed if not generating an executable
     s_sigma = 8 # This is passed during code generation in the C++ version
 
     #print("r_sigma", r_sigma)

--- a/python_bindings/apps/blur.py
+++ b/python_bindings/apps/blur.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from halide import *
+import halide as hl
 
 import numpy as np
 from scipy.misc import imread, imsave
@@ -7,25 +7,25 @@ import os.path
 
 def get_blur(input):
 
-    assert type(input) == ImageParam
+    assert type(input) == hl.ImageParam
     assert input.dimensions() == 2
 
-    x, y = Var("x"), Var("y")
+    x, y = hl.Var("x"), hl.Var("y")
 
-    clamped_input = repeat_edge(input)
+    clamped_input = hl.repeat_edge(input)
 
-    input_uint16 = Func("input_uint16")
-    input_uint16[x,y] = cast(UInt(16), clamped_input[x,y])
+    input_uint16 = hl.Func("input_uint16")
+    input_uint16[x,y] = hl.cast(hl.UInt(16), clamped_input[x,y])
     ci = input_uint16
 
-    blur_x = Func("blur_x")
-    blur_y = Func("blur_y")
+    blur_x = hl.Func("blur_x")
+    blur_y = hl.Func("blur_y")
 
     blur_x[x,y] = (ci[x,y]+ci[x+1,y]+ci[x+2,y])/3
-    blur_y[x,y] = cast(UInt(8), (blur_x[x,y]+blur_x[x,y+1]+blur_x[x,y+2])/3)
+    blur_y[x,y] = hl.cast(hl.UInt(8), (blur_x[x,y]+blur_x[x,y+1]+blur_x[x,y+2])/3)
 
     # schedule
-    xi, yi = Var("xi"), Var("yi")
+    xi, yi = hl.Var("xi"), hl.Var("yi")
     blur_y.tile(x, y, xi, yi, 8, 4).parallel(y).vectorize(xi, 8)
     blur_x.compute_at(blur_y, x).vectorize(x, 8)
 
@@ -48,17 +48,17 @@ def get_input_data():
 def main():
 
     # define and compile the function
-    input = ImageParam(UInt(8), 2, "input_param")
+    input = hl.ImageParam(hl.UInt(8), 2, "input_param")
     blur = get_blur(input)
     blur.compile_jit()
 
     # preparing input and output memory buffers (numpy ndarrays)
     input_data = get_input_data()
-    input_image = Buffer(input_data)
+    input_image = hl.Buffer(input_data)
     input.set(input_image)
 
     output_data = np.empty(input_data.shape, dtype=input_data.dtype, order="F")
-    output_image = Buffer(output_data)
+    output_image = hl.Buffer(output_data)
 
     print("input_image", input_image)
     print("output_image", output_image)

--- a/python_bindings/apps/erode.py
+++ b/python_bindings/apps/erode.py
@@ -3,7 +3,7 @@
 Erode application using Python Halide bindings
 """
 
-from halide import *
+import halide as hl
 
 import numpy as np
 from scipy.misc import imread, imsave
@@ -14,19 +14,19 @@ def get_erode(input):
     Erode on 5x5 stencil, first erode x then erode y.
     """
 
-    x = Var("x")
-    y = Var("y")
-    c = Var("c")
-    input_clamped = Func("input_clamped")
-    erode_x = Func("erode_x")
-    erode_y = Func("erode_y")
+    x = hl.Var("x")
+    y = hl.Var("y")
+    c = hl.Var("c")
+    input_clamped = hl.Func("input_clamped")
+    erode_x = hl.Func("erode_x")
+    erode_y = hl.Func("erode_y")
 
-    input_clamped[x,y,c] = input[clamp(x,cast(Int(32),0),cast(Int(32),input.width()-1)),
-                                 clamp(y,cast(Int(32),0),cast(Int(32),input.height()-1)), c]
-    erode_x[x,y,c] = min(min(min(min(input_clamped[x-2,y,c],input_clamped[x-1,y,c]),input_clamped[x,y,c]),input_clamped[x+1,y,c]),input_clamped[x+2,y,c])
-    erode_y[x,y,c] = min(min(min(min(erode_x[x,y-2,c],erode_x[x,y-1,c]),erode_x[x,y,c]),erode_x[x,y+1,c]),erode_x[x,y+2,c])
+    input_clamped[x,y,c] = input[hl.clamp(x,hl.cast(hl.Int(32),0),hl.cast(hl.Int(32),input.width()-1)),
+                                 hl.clamp(y,hl.cast(hl.Int(32),0),hl.cast(hl.Int(32),input.height()-1)), c]
+    erode_x[x,y,c] = hl.min(hl.min(hl.min(hl.min(input_clamped[x-2,y,c],input_clamped[x-1,y,c]),input_clamped[x,y,c]),input_clamped[x+1,y,c]),input_clamped[x+2,y,c])
+    erode_y[x,y,c] = hl.min(hl.min(hl.min(hl.min(erode_x[x,y-2,c],erode_x[x,y-1,c]),erode_x[x,y,c]),erode_x[x,y+1,c]),erode_x[x,y+2,c])
 
-    yi = Var("yi")
+    yi = hl.Var("yi")
 
     # CPU Schedule
     erode_x.compute_root().split(y, y, yi, 8).parallel(y)
@@ -51,17 +51,17 @@ def get_input_data():
 def main():
 
     # define and compile the function
-    input = ImageParam(UInt(8), 3, "input")
+    input = hl.ImageParam(hl.UInt(8), 3, "input")
     erode = get_erode(input)
     erode.compile_jit()
 
     # preparing input and output memory buffers (numpy ndarrays)
     input_data = get_input_data()
-    input_image = Buffer(input_data)
+    input_image = hl.Buffer(input_data)
     input.set(input_image)
 
     output_data = np.empty(input_data.shape, dtype=input_data.dtype, order="F")
-    output_image = Buffer(output_data)
+    output_image = hl.Buffer(output_data)
 
     print("input_image", input_image)
     print("output_image", output_image)

--- a/python_bindings/apps/interpolate.py
+++ b/python_bindings/apps/interpolate.py
@@ -7,46 +7,46 @@ from __future__ import print_function
 from __future__ import division
 
 import time, sys
-from halide import *
+import halide as hl
 
 from datetime import datetime
 from scipy.misc import imread, imsave
 import numpy as np
 import os.path
 
-int_t = Int(32)
-float_t = Float(32)
+int_t = hl.Int(32)
+float_t = hl.Float(32)
 
 def get_interpolate(input, levels):
     """
     Build function, schedules it, and invokes jit compiler
-    :return: halide.Func
+    :return: halide.hl.Func
     """
 
     # THE ALGORITHM
 
-    downsampled = [Func('downsampled%d'%i) for i in range(levels)]
-    downx = [Func('downx%d'%l) for l in range(levels)]
-    interpolated = [Func('interpolated%d'%i) for i in range(levels)]
-#     level_widths = [Param(int_t,'level_widths%d'%i) for i in range(levels)]
-#     level_heights = [Param(int_t,'level_heights%d'%i) for i in range(levels)]
-    upsampled = [Func('upsampled%d'%l) for l in range(levels)]
-    upsampledx = [Func('upsampledx%d'%l) for l in range(levels)]
-    x = Var('x')
-    y = Var('y')
-    c = Var('c')
+    downsampled = [hl.Func('downsampled%d'%i) for i in range(levels)]
+    downx = [hl.Func('downx%d'%l) for l in range(levels)]
+    interpolated = [hl.Func('interpolated%d'%i) for i in range(levels)]
+#     level_widths = [hl.Param(int_t,'level_widths%d'%i) for i in range(levels)]
+#     level_heights = [hl.Param(int_t,'level_heights%d'%i) for i in range(levels)]
+    upsampled = [hl.Func('upsampled%d'%l) for l in range(levels)]
+    upsampledx = [hl.Func('upsampledx%d'%l) for l in range(levels)]
+    x = hl.Var('x')
+    y = hl.Var('y')
+    c = hl.Var('c')
 
-    clamped = Func('clamped')
-    clamped[x, y, c] = input[clamp(x, 0, input.width()-1), clamp(y, 0, input.height()-1), c]
+    clamped = hl.Func('clamped')
+    clamped[x, y, c] = input[hl.clamp(x, 0, input.width()-1), hl.clamp(y, 0, input.height()-1), c]
 
     # This triggers a bug in llvm 3.3 (3.2 and trunk are fine), so we
     # rewrite it in a way that doesn't trigger the bug. The rewritten
     # form assumes the input alpha is zero or one.
-    # downsampled[0][x, y, c] = select(c < 3, clamped[x, y, c] * clamped[x, y, 3], clamped[x, y, 3])
+    # downsampled[0][x, y, c] = hl.select(c < 3, clamped[x, y, c] * clamped[x, y, 3], clamped[x, y, 3])
     downsampled[0][x,y,c] = clamped[x, y, c] * clamped[x, y, 3]
 
     for l in range(1, levels):
-        prev = Func()
+        prev = hl.Func()
         prev = downsampled[l-1]
 
         if l == 4:
@@ -56,7 +56,7 @@ def get_interpolate(input, levels):
             # pixels off each edge.
             w = input.width()/(1 << l)
             h = input.height()/(1 << l)
-            prev = lambda3D(x, y, c, prev[clamp(x, 0, w), clamp(y, 0, h), c])
+            prev = hl.lambda3D(x, y, c, prev[hl.clamp(x, 0, w), hl.clamp(y, 0, h), c])
 
         downx[l][x,y,c] = (prev[x*2-1,y,c] + 2.0 * prev[x*2,y,c] + prev[x*2+1,y,c]) * 0.25
         downsampled[l][x,y,c] = (downx[l][x,y*2-1,c] + 2.0 * downx[l][x,y*2,c] + downx[l][x,y*2+1,c]) * 0.25
@@ -68,10 +68,10 @@ def get_interpolate(input, levels):
         upsampled[l][x,y,c] = (upsampledx[l][x, y/2, c] + upsampledx[l][x, (y+1)/2, c]) / 2.0
         interpolated[l][x,y,c] = downsampled[l][x,y,c] + (1.0 - downsampled[l][x,y,3]) * upsampled[l][x,y,c]
 
-    normalize = Func('normalize')
+    normalize = hl.Func('normalize')
     normalize[x,y,c] = interpolated[0][x, y, c] / interpolated[0][x, y, 3]
 
-    final = Func('final')
+    final = hl.Func('final')
     final[x,y,c] = normalize[x,y,c]
 
     print("Finished function setup.")
@@ -79,7 +79,7 @@ def get_interpolate(input, levels):
     # THE SCHEDULE
 
     sched = 2
-    target = get_target_from_environment()
+    target = hl.get_target_from_environment()
     if target.has_gpu_feature():
         sched = 4
     else:
@@ -103,7 +103,7 @@ def get_interpolate(input, levels):
 
     elif sched == 2:
         print("Flat schedule with parallelization + vectorization")
-        xi, yi = Var('xi'), Var('yi')
+        xi, yi = hl.Var('xi'), hl.Var('yi')
         clamped.compute_root().parallel(y).bound(c, 0, 4).reorder(c, x, y).reorder_storage(c, x, y).vectorize(c, 4)
         for l in range(1, levels - 1):
             if l > 0:
@@ -120,7 +120,7 @@ def get_interpolate(input, levels):
         print("Flat schedule with vectorization sometimes.")
         for l in range(levels):
             if l + 4 < levels:
-                yo, yi = Var('yo'), Var('yi')
+                yo, yi = hl.Var('yo'), hl.Var('yi')
                 downsampled[l].compute_root().vectorize(x, 4)
                 interpolated[l].compute_root().vectorize(x, 4)
             else:
@@ -134,7 +134,7 @@ def get_interpolate(input, levels):
 
         # Some gpus don't have enough memory to process the entire
         # image, so we process the image in tiles.
-        yo, yi, xo, xi, ci = Var('yo'), Var('yi'), Var('xo'), Var("ci")
+        yo, yi, xo, xi, ci = hl.Var('yo'), hl.Var('yi'), hl.Var('xo'), hl.Var("ci")
         final.reorder(c, x, y).bound(c, 0, 3).vectorize(x, 4)
         final.tile(x, y, xo, yo, xi, yi, input.width()/4, input.height()/4)
         normalize.compute_at(final, xo).reorder(c, x, y).gpu_tile(x, y, xi, yi, 16, 16, GPU_Default).unroll(c)
@@ -172,7 +172,7 @@ def get_input_data():
 
 def main():
 
-    input = ImageParam(float_t, 3, "input")
+    input = hl.ImageParam(float_t, 3, "input")
     levels = 10
 
     interpolate = get_interpolate(input, levels)
@@ -180,7 +180,7 @@ def main():
     # preparing input and output memory buffers (numpy ndarrays)
     input_data = get_input_data()
     assert input_data.shape[2] == 4
-    input_image = Buffer(input_data)
+    input_image = hl.Buffer(input_data)
     input.set(input_image)
 
     input_width, input_height = input_data.shape[:2]
@@ -190,7 +190,7 @@ def main():
     t1 = datetime.now()
     print('Interpolated in %.5f secs' % (t1-t0).total_seconds())
 
-    output_data = buffer_to_ndarray(output_image)
+    output_data = hl.buffer_to_ndarray(output_image)
 
     # save results
     input_path = "interpolate_input.png"

--- a/python_bindings/apps/local_laplacian.py
+++ b/python_bindings/apps/local_laplacian.py
@@ -5,7 +5,7 @@ Local Laplacian, see e.g. Aubry et al 2011, "Fast and Robust Pyramid-based Image
 
 from __future__ import division # if running with python2
 
-from halide import *
+import halide as hl
 
 import numpy as np
 from scipy.misc import imread, imsave
@@ -13,18 +13,18 @@ from scipy.misc import imread, imsave
 import os.path
 
 
-int_t = Int(32)
-float_t = Float(32)
+int_t = hl.Int(32)
+float_t = hl.Float(32)
 
 def get_local_laplacian(input, levels, alpha, beta, J=8):
     downsample_counter=[0]
     upsample_counter=[0]
 
-    x = Var('x')
-    y = Var('y')
+    x = hl.Var('x')
+    y = hl.Var('y')
 
     def downsample(f):
-        downx, downy = Func('downx%d'%downsample_counter[0]), Func('downy%d'%downsample_counter[0])
+        downx, downy = hl.Func('downx%d'%downsample_counter[0]), hl.Func('downy%d'%downsample_counter[0])
         downsample_counter[0] += 1
 
         downx[x,y,c] = (f[2*x-1,y,c] + 3.0*(f[2*x,y,c]+f[2*x+1,y,c]) + f[2*x+2,y,c])/8.0
@@ -33,7 +33,7 @@ def get_local_laplacian(input, levels, alpha, beta, J=8):
         return downy
 
     def upsample(f):
-        upx, upy = Func('upx%d'%upsample_counter[0]), Func('upy%d'%upsample_counter[0])
+        upx, upy = hl.Func('upx%d'%upsample_counter[0]), hl.Func('upy%d'%upsample_counter[0])
         upsample_counter[0] += 1
 
         upx[x,y,c] = 0.25 * f[(x//2) - 1 + 2*(x%2),y,c] + 0.75 * f[x//2,y,c]
@@ -42,7 +42,7 @@ def get_local_laplacian(input, levels, alpha, beta, J=8):
         return upy
 
     def downsample2D(f):
-        downx, downy = Func('downx%d'%downsample_counter[0]), Func('downy%d'%downsample_counter[0])
+        downx, downy = hl.Func('downx%d'%downsample_counter[0]), hl.Func('downy%d'%downsample_counter[0])
         downsample_counter[0] += 1
 
         downx[x,y] = (f[2*x-1,y] + 3.0*(f[2*x,y]+f[2*x+1,y]) + f[2*x+2,y])/8.0
@@ -51,7 +51,7 @@ def get_local_laplacian(input, levels, alpha, beta, J=8):
         return downy
 
     def upsample2D(f):
-        upx, upy = Func('upx%d'%upsample_counter[0]), Func('upy%d'%upsample_counter[0])
+        upx, upy = hl.Func('upx%d'%upsample_counter[0]), hl.Func('upy%d'%upsample_counter[0])
         upsample_counter[0] += 1
 
         upx[x,y] = 0.25 * f[(x//2) - 1 + 2*(x%2),y] + 0.75 * f[x//2,y]
@@ -62,82 +62,82 @@ def get_local_laplacian(input, levels, alpha, beta, J=8):
     # THE ALGORITHM
 
     # loop variables
-    c = Var('c')
-    k = Var('k')
+    c = hl.Var('c')
+    k = hl.Var('k')
 
     # Make the remapping function as a lookup table.
-    remap = Func('remap')
-    fx = cast(float_t, x/256.0)
+    remap = hl.Func('remap')
+    fx = hl.cast(float_t, x/256.0)
     #remap[x] = alpha*fx*exp(-fx*fx/2.0)
-    remap[x] = alpha*fx*exp(-fx*fx/2.0)
+    remap[x] = alpha*fx*hl.exp(-fx*fx/2.0)
 
     # Convert to floating point
-    floating = Func('floating')
-    floating[x,y,c] = cast(float_t, input[x,y,c]) / 65535.0
+    floating = hl.Func('floating')
+    floating[x,y,c] = hl.cast(float_t, input[x,y,c]) / 65535.0
 
     # Set a boundary condition
-    clamped = Func('clamped')
-    clamped[x,y,c] = floating[clamp(x, 0, input.width()-1), clamp(y, 0, input.height()-1), c]
+    clamped = hl.Func('clamped')
+    clamped[x,y,c] = floating[hl.clamp(x, 0, input.width()-1), hl.clamp(y, 0, input.height()-1), c]
 
     # Get the luminance channel
-    gray = Func('gray')
+    gray = hl.Func('gray')
     gray[x,y] = 0.299*clamped[x,y,0] + 0.587*clamped[x,y,1] + 0.114*clamped[x,y,2]
 
     # Make the processed Gaussian pyramid.
-    gPyramid = [Func('gPyramid%d'%i) for i in range(J)]
+    gPyramid = [hl.Func('gPyramid%d'%i) for i in range(J)]
     # Do a lookup into a lut with 256 entires per intensity level
     level = k / (levels - 1)
-    idx = gray[x,y]*cast(float_t, levels-1)*256.0
-    idx = clamp(cast(int_t, idx), 0, (levels-1)*256)
+    idx = gray[x,y]*hl.cast(float_t, levels-1)*256.0
+    idx = hl.clamp(hl.cast(int_t, idx), 0, (levels-1)*256)
     gPyramid[0][x,y,k] = beta*(gray[x, y] - level) + level + remap[idx - 256*k]
     for j in range(1,J):
         gPyramid[j][x,y,k] = downsample(gPyramid[j-1])[x,y,k]
 
     # Get its laplacian pyramid
-    lPyramid = [Func('lPyramid%d'%i) for i in range(J)]
+    lPyramid = [hl.Func('lPyramid%d'%i) for i in range(J)]
     lPyramid[J-1] = gPyramid[J-1]
     for j in range(J-1)[::-1]:
         lPyramid[j][x,y,k] = gPyramid[j][x,y,k] - upsample(gPyramid[j+1])[x,y,k]
 
     # Make the Gaussian pyramid of the input
-    inGPyramid = [Func('inGPyramid%d'%i) for i in range(J)]
+    inGPyramid = [hl.Func('inGPyramid%d'%i) for i in range(J)]
     inGPyramid[0] = gray
     for j in range(1,J):
         inGPyramid[j][x,y] = downsample2D(inGPyramid[j-1])[x,y]
 
     # Make the laplacian pyramid of the output
-    outLPyramid = [Func('outLPyramid%d'%i) for i in range(J)]
+    outLPyramid = [hl.Func('outLPyramid%d'%i) for i in range(J)]
     for j in range(J):
         # Split input pyramid value into integer and floating parts
-        level = inGPyramid[j][x,y]*cast(float_t, levels-1)
-        li = clamp(cast(int_t, level), 0, levels-2)
-        lf = level - cast(float_t, li)
+        level = inGPyramid[j][x,y]*hl.cast(float_t, levels-1)
+        li = hl.clamp(hl.cast(int_t, level), 0, levels-2)
+        lf = level - hl.cast(float_t, li)
         # Linearly interpolate between the nearest processed pyramid levels
         outLPyramid[j][x,y] = (1.0-lf)*lPyramid[j][x,y,li] + lf*lPyramid[j][x,y,li+1]
 
     # Make the Gaussian pyramid of the output
-    outGPyramid = [Func('outGPyramid%d'%i) for i in range(J)]
+    outGPyramid = [hl.Func('outGPyramid%d'%i) for i in range(J)]
     outGPyramid[J-1] = outLPyramid[J-1]
     for j in range(J-1)[::-1]:
         outGPyramid[j][x,y] = upsample2D(outGPyramid[j+1])[x,y] + outLPyramid[j][x,y]
 
     # Reintroduce color (Connelly: use eps to avoid scaling up noise w/ apollo3.png input)
-    color = Func('color')
+    color = hl.Func('color')
     eps = 0.01
     color[x,y,c] = outGPyramid[0][x,y] * (clamped[x,y,c] + eps) / (gray[x,y] + eps)
 
-    output = Func('local_laplacian')
+    output = hl.Func('local_laplacian')
     # Convert back to 16-bit
-    output[x,y,c] = cast(UInt(16), clamp(color[x,y,c], 0.0, 1.0) * 65535.0)
+    output[x,y,c] = hl.cast(hl.UInt(16), hl.clamp(color[x,y,c], 0.0, 1.0) * 65535.0)
 
     # THE SCHEDULE
     remap.compute_root()
 
-    target = get_target_from_environment()
+    target = hl.get_target_from_environment()
     if target.has_gpu_feature():
         # GPU Schedule
         print ("Compiling for GPU")
-        xi, yi = Var("xi"), Var("yi")
+        xi, yi = hl.Var("xi"), hl.Var("yi")
         output.compute_root().gpu_tile(x, y, 32, 32, GPU_Default)
         for j in range(J):
             blockw = 32
@@ -178,8 +178,8 @@ def generate_compiled_file(local_laplacian):
     arguments.append(Argument('levels', False, int_t))
     arguments.append(Argument('alpha', False, float_t))
     arguments.append(Argument('beta', False, float_t))
-    arguments.append(Argument('input', True, UInt(16)))
-    target = get_target_from_environment()
+    arguments.append(Argument('input', True, hl.UInt(16)))
+    target = hl.get_target_from_environment()
     local_laplacian.compile_to_file("local_laplacian", arguments, "local_laplacian", target)
     print("Generated compiled file for local_laplacian function.")
     return
@@ -206,11 +206,11 @@ def filter_test_image(local_laplacian, input):
 
     # preparing input and output memory buffers (numpy ndarrays)
     input_data = get_input_data()
-    input_image = Buffer(input_data)
+    input_image = hl.Buffer(input_data)
     input.set(input_image)
 
     output_data = np.empty(input_data.shape, dtype=input_data.dtype, order="F")
-    output_image = Buffer(output_data)
+    output_image = hl.Buffer(output_data)
 
     if False:
         print("input_image", input_image)
@@ -232,14 +232,14 @@ def filter_test_image(local_laplacian, input):
 
 def main():
 
-    input = ImageParam(UInt(16), 3, 'input')
+    input = hl.ImageParam(hl.UInt(16), 3, 'input')
 
     # number of intensity levels
-    levels = Param(int_t, 'levels', 8)
+    levels = hl.Param(int_t, 'levels', 8)
 
     #Parameters controlling the filter
-    alpha = Param(float_t, 'alpha', 1.0/7.0)
-    beta = Param(float_t, 'beta', 1.0)
+    alpha = hl.Param(float_t, 'alpha', 1.0/7.0)
+    beta = hl.Param(float_t, 'beta', 1.0)
 
     local_laplacian = get_local_laplacian(input, levels, alpha, beta)
 

--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -1,17 +1,17 @@
 #!/usr/bin/python3
 
-from halide import *
+import halide as hl
 from contextlib import redirect_stdout
 import io, sys
 
 def test_compiletime_error():
 
-    x = Var('x')
-    y = Var('y')
-    f = Func('f')
-    f[x, y] = cast(UInt(16), x + y)
+    x = hl.Var('x')
+    y = hl.Var('y')
+    f = hl.Func('f')
+    f[x, y] = hl.cast(hl.UInt(16), x + y)
     # Deliberate type-mismatch error
-    buf = Buffer(UInt(8), 2, 2)
+    buf = hl.Buffer(hl.UInt(8), 2, 2)
     try:
         f.realize(buf)
     except RuntimeError as e:
@@ -21,12 +21,12 @@ def test_compiletime_error():
 
 def test_runtime_error():
 
-    x = Var('x')
-    f = Func('f')
-    f[x] = cast(UInt(8), x)
+    x = hl.Var('x')
+    f = hl.Func('f')
+    f[x] = hl.cast(hl.UInt(8), x)
     f.bound(x, 0, 1)
     # Deliberate runtime error
-    buf = Buffer(UInt(8), 10)
+    buf = hl.Buffer(hl.UInt(8), 10)
     try:
         f.realize(buf)
     except RuntimeError as e:
@@ -37,10 +37,10 @@ def test_runtime_error():
     return
 
 def test_print_expr():
-    x = Var('x')
-    f = Func('f')
-    f[x] = print_expr(cast(UInt(8), x), 'is what', 'the', 1, 'and', 3.1415, 'saw')
-    buf = Buffer(UInt(8), 1)
+    x = hl.Var('x')
+    f = hl.Func('f')
+    f[x] = hl.print(hl.cast(hl.UInt(8), x), 'is what', 'the', 1, 'and', 3.1415, 'saw')
+    buf = hl.Buffer(hl.UInt(8), 1)
     output = io.StringIO()
     with redirect_stdout(output):
         f.realize(buf)
@@ -52,10 +52,10 @@ def test_print_expr():
 
 def test_print_when():
 
-    x = Var('x')
-    f = Func('f')
-    f[x] = print_when(x == 3, cast(UInt(8), x*x), 'is result at', x)
-    buf = Buffer(UInt(8), 10)
+    x = hl.Var('x')
+    f = hl.Func('f')
+    f[x] = hl.print_when(x == 3, hl.cast(hl.UInt(8), x*x), 'is result at', x)
+    buf = hl.Buffer(hl.UInt(8), 10)
     output = io.StringIO()
     with redirect_stdout(output):
         f.realize(buf)
@@ -67,29 +67,29 @@ def test_print_when():
 
 def test_types():
 
-    t0 = Int(32)
-    t1 = Int(16)
+    t0 = hl.Int(32)
+    t1 = hl.Int(16)
 
     assert t0 != t1
     assert t0.is_float() == False
     assert t1.is_float() == False
 
-    print("Int(32) type:", Int(32))
-    print("Int(16) type:", Int(16))
+    print("hl.Int(32) type:", hl.Int(32))
+    print("hl.Int(16) type:", hl.Int(16))
 
     return
 
 def test_basics():
 
-    input = ImageParam(UInt(16), 2, 'input')
-    x, y = Var('x'), Var('y')
+    input = hl.ImageParam(hl.UInt(16), 2, 'input')
+    x, y = hl.Var('x'), hl.Var('y')
 
-    blur_x = Func('blur_x')
-    blur_xx = Func('blur_xx')
-    blur_y = Func('blur_y')
+    blur_x = hl.Func('blur_x')
+    blur_xx = hl.Func('blur_xx')
+    blur_y = hl.Func('blur_y')
 
-    yy = cast(Int(32), 1)
-    assert yy.type() == Int(32)
+    yy = hl.cast(hl.Int(32), 1)
+    assert yy.type() == hl.Int(32)
     print("yy type:", yy.type())
 
     z = x + 1
@@ -120,7 +120,7 @@ def test_basics():
     print("ping 1")
     blur_y[x,y] = (blur_x[x,y]+blur_x[x,y+1]+blur_x[x,y+2])/3
 
-    xi, yi = Var('xi'), Var('yi')
+    xi, yi = hl.Var('xi'), hl.Var('yi')
     print("ping 2")
     blur_y.tile(x, y, xi, yi, 8, 4).parallel(y).vectorize(xi, 8)
     blur_x.compute_at(blur_y, x).vectorize(x, 8)
@@ -134,19 +134,19 @@ def test_basics():
 
 def test_basics2():
 
-    input = ImageParam(Float(32), 3, 'input')
-    r_sigma = Param(Float(32), 'r_sigma', 0.1) # Value needed if not generating an executable
+    input = hl.ImageParam(hl.Float(32), 3, 'input')
+    r_sigma = hl.Param(hl.Float(32), 'r_sigma', 0.1) # Value needed if not generating an executable
     s_sigma = 8 # This is passed during code generation in the C++ version
 
-    x = Var('x')
-    y = Var('y')
-    z = Var('z')
-    c = Var('c')
+    x = hl.Var('x')
+    y = hl.Var('y')
+    z = hl.Var('z')
+    c = hl.Var('c')
 
     # Add a boundary condition
-    clamped = Func('clamped')
-    clamped[x, y] = input[clamp(x, 0, input.width()-1),
-                          clamp(y, 0, input.height()-1),0]
+    clamped = hl.Func('clamped')
+    clamped[x, y] = input[hl.clamp(x, 0, input.width()-1),
+                          hl.clamp(y, 0, input.height()-1),0]
 
     if True:
         print("s_sigma", s_sigma)
@@ -168,21 +168,21 @@ def test_basics2():
         print("(x * (8 * 4)).type()", (x * (8 * 4)).type())
 
 
-    assert (x * 8).type() == Int(32)
-    assert (x * 8 * 4).type() == Int(32) # yes this did fail at some point
-    assert ((x * 8) / 4).type() == Int(32)
-    assert (x * (8 / 4)).type() == Float(32) # under python3 division rules
-    assert (x * (8 // 4)).type() == Int(32)
-    #assert (x * 8 // 4).type() == Int(32) # not yet implemented
+    assert (x * 8).type() == hl.Int(32)
+    assert (x * 8 * 4).type() == hl.Int(32) # yes this did fail at some point
+    assert ((x * 8) / 4).type() == hl.Int(32)
+    assert (x * (8 / 4)).type() == hl.Float(32) # under python3 division rules
+    assert (x * (8 // 4)).type() == hl.Int(32)
+    #assert (x * 8 // 4).type() == hl.Int(32) # not yet implemented
 
 
     # Construct the bilateral grid
-    r = RDom(0, s_sigma, 0, s_sigma, 'r')
+    r = hl.RDom(0, s_sigma, 0, s_sigma, 'r')
     val0 = clamped[x * s_sigma, y * s_sigma]
-    val00 = clamped[x * s_sigma * cast(Int(32), 1), y * s_sigma * cast(Int(32), 1)]
+    val00 = clamped[x * s_sigma * hl.cast(hl.Int(32), 1), y * s_sigma * hl.cast(hl.Int(32), 1)]
     #val1 = clamped[x * s_sigma - s_sigma/2, y * s_sigma - s_sigma/2] # should fail
-    val22 = clamped[x * s_sigma - cast(Int(32), s_sigma//2),
-                    y * s_sigma - cast(Int(32), s_sigma//2)]
+    val22 = clamped[x * s_sigma - hl.cast(hl.Int(32), s_sigma//2),
+                    y * s_sigma - hl.cast(hl.Int(32), s_sigma//2)]
     val2 = clamped[x * s_sigma - s_sigma//2, y * s_sigma - s_sigma//2]
     val3 = clamped[x * s_sigma + r.x - s_sigma//2, y * s_sigma + r.y - s_sigma//2]
 
@@ -191,31 +191,31 @@ def test_basics2():
 
 def test_basics3():
 
-    input = ImageParam(Float(32), 3, 'input')
-    r_sigma = Param(Float(32), 'r_sigma', 0.1) # Value needed if not generating an executable
+    input = hl.ImageParam(hl.Float(32), 3, 'input')
+    r_sigma = hl.Param(hl.Float(32), 'r_sigma', 0.1) # Value needed if not generating an executable
     s_sigma = 8 # This is passed during code generation in the C++ version
 
-    x = Var('x')
-    y = Var('y')
-    z = Var('z')
-    c = Var('c')
+    x = hl.Var('x')
+    y = hl.Var('y')
+    z = hl.Var('z')
+    c = hl.Var('c')
 
     # Add a boundary condition
-    clamped = Func('clamped')
-    clamped[x, y] = input[clamp(x, 0, input.width()-1),
-                          clamp(y, 0, input.height()-1),0]
+    clamped = hl.Func('clamped')
+    clamped[x, y] = input[hl.clamp(x, 0, input.width()-1),
+                          hl.clamp(y, 0, input.height()-1),0]
 
     # Construct the bilateral grid
-    r = RDom(0, s_sigma, 0, s_sigma, 'r')
+    r = hl.RDom(0, s_sigma, 0, s_sigma, 'r')
     val = clamped[x * s_sigma + r.x - s_sigma//2, y * s_sigma + r.y - s_sigma//2]
-    val = clamp(val, 0.0, 1.0)
-    #zi = cast(Int(32), val * (1.0/r_sigma) + 0.5)
-    zi = cast(Int(32), (val / r_sigma) + 0.5)
-    histogram = Func('histogram')
+    val = hl.clamp(val, 0.0, 1.0)
+    #zi = hl.cast(hl.Int(32), val * (1.0/r_sigma) + 0.5)
+    zi = hl.cast(hl.Int(32), (val / r_sigma) + 0.5)
+    histogram = hl.Func('histogram')
     histogram[x, y, z, c] = 0.0
 
-    ss = select(c == 0, val, 1.0)
-    print("select(c == 0, val, 1.0)", ss)
+    ss = hl.select(c == 0, val, 1.0)
+    print("hl.select(c == 0, val, 1.0)", ss)
     left = histogram[x, y, zi, c]
     print("histogram[x, y, zi, c]", histogram[x, y, zi, c])
     print("histogram[x, y, zi, c]", left)
@@ -228,8 +228,8 @@ def test_basics3():
 
 def test_float_or_int():
 
-    x = Var('x')
-    i, f =  Int(32), Float(32)
+    x = hl.Var('x')
+    i, f =  hl.Int(32), hl.Float(32)
 
     assert ((x//2) - 1 + 2*(x%2)).type() == i
     assert ((x/2) - 1 + 2*(x%2)).type() == i
@@ -241,16 +241,16 @@ def test_float_or_int():
     assert (2*(x%2)).type() == i
     assert ((x//2) - 1 + 2*(x%2)).type() == i
 
-    assert type(x) == Var
+    assert type(x) == hl.Var
     assert (x.expr()).type() == i
-    assert (Expr(2.0)).type() == f
-    assert (Expr(2)).type() == i
+    assert (hl.Expr(2.0)).type() == f
+    assert (hl.Expr(2)).type() == i
     assert (x + 2).type() == i
     assert (2 + x).type() == i
-    assert (Expr(2) + Expr(3)).type() == i
-    assert (Expr(2.0) + Expr(3)).type() == f
-    assert (Expr(2) + 3.0).type() == f
-    assert (Expr(2) + 3).type() == i
+    assert (hl.Expr(2) + hl.Expr(3)).type() == i
+    assert (hl.Expr(2.0) + hl.Expr(3)).type() == f
+    assert (hl.Expr(2) + 3.0).type() == f
+    assert (hl.Expr(2) + 3).type() == i
     assert (x.expr() + 2).type() == i # yes this failed at some point
     assert (2 + x.expr()).type() == i
     assert (2 * (x + 2)).type() == i # yes this failed at some point
@@ -269,14 +269,14 @@ def test_float_or_int():
 
 def test_operator_order():
 
-    x = Var('x')
-    f = Func('f')
+    x = hl.Var('x')
+    f = hl.Func('f')
     x + 1
     1 + x
     print("x", x, ", x + 1", x + 1, ", 1 + x", 1 + x)
     f[x] = x ** 2
     f[x] + 1
-    Expr(1) + f[x]
+    hl.Expr(1) + f[x]
     1 + f[x]
 
     return
@@ -309,16 +309,16 @@ def test_image_to_ndarray():
 
     import numpy
 
-    i0 = Image(Float(32), 50, 50)
-    assert i0.type() == Float(32)
+    i0 = Image(hl.Float(32), 50, 50)
+    assert i0.type() == hl.Float(32)
 
     a0 = image_to_ndarray(i0)
     print("a0.shape", a0.shape)
     print("a0.dtype", a0.dtype)
     assert a0.dtype == numpy.float32
 
-    i1 = Image(Int(16), 50, 50)
-    assert i1.type() == Int(16)
+    i1 = Image(hl.Int(16), 50, 50)
+    assert i1.type() == hl.Int(16)
     i1[24, 24] = 42
     assert i1(24, 24) == 42
 
@@ -333,19 +333,19 @@ def test_image_to_ndarray():
 def test_param_bug():
     "see https://github.com/rodrigob/Halide/issues/1"
 
-    p1 = Param(UInt(8), "p1", 0)
-    p2 = Param(UInt(8), "p2")
-    p3 = Param(UInt(8), 42)
+    p1 = hl.Param(hl.UInt(8), "p1", 0)
+    p2 = hl.Param(hl.UInt(8), "p2")
+    p3 = hl.Param(hl.UInt(8), 42)
 
     return
 
 def test_imageparam_bug():
     "see https://github.com/rodrigob/Halide/issues/2"
 
-    x = Var("x")
-    y = Var("y")
-    fx = Func("fx")
-    input = ImageParam(UInt(8), 1, "input")
+    x = hl.Var("x")
+    y = hl.Var("y")
+    fx = hl.Func("fx")
+    input = hl.ImageParam(hl.UInt(8), 1, "input")
     fx[x, y] = input[y]
 
     return

--- a/python_bindings/correctness/compile_to.py
+++ b/python_bindings/correctness/compile_to.py
@@ -2,12 +2,12 @@
 
 import os.path
 
-import halide as h
+import halide as hl
 
 def main():
-    x = h.Var("x")
+    x = hl.Var("x")
 
-    f = h.Func("f")
+    f = hl.Func("f")
 
     f[x] = 100 * x
 

--- a/python_bindings/correctness/extern.py
+++ b/python_bindings/correctness/extern.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from halide import *
+import halide as hl
 import numpy as np
 
 
@@ -14,23 +14,23 @@ def test_extern():
     print("TODO: test_extern not yet implemented in Python; skipping...")
     return 0
 
-    x = Var("x")
+    x = hl.Var("x")
 
     data = np.random.random(10).astype(np.float64)
     expected_result = np.sort(data)
     output_data = np.empty(10, dtype=np.float64)
 
-    sort_func = Func("extern_sort_func")
+    sort_func = hl.Func("extern_sort_func")
     # gsl_sort,
     # see http://www.gnu.org/software/gsl/manual/html_node/Sorting-vectors.html#Sorting-vectors
 
-    input = ImageParam(Float(64), 1, "input_data")
+    input = hl.ImageParam(hl.Float(64), 1, "input_data")
 
-    p1 = ExternFuncArgument(input) # data
+    p1 = hl.ExternFuncArgument(input) # data
     params = [p1]
 
-    output_types = TypesVector()
-    output_types.append(Int(32))
+    output_types = hl.TypesVector()
+    output_types.append(hl.Int(32))
 
     dimensionality = 1
 

--- a/python_bindings/correctness/rdom.py
+++ b/python_bindings/correctness/rdom.py
@@ -1,18 +1,18 @@
 #!/usr/bin/python3
 
-import halide as h
+import halide as hl
 
 def test_rdom():
-    x = h.Var("x")
-    y = h.Var("y")
+    x = hl.Var("x")
+    y = hl.Var("y")
 
-    diagonal = h.Func("diagonal")
+    diagonal = hl.Func("diagonal")
     diagonal[x, y] = 1
 
     domain_width = 10
     domain_height = 10
 
-    r = h.RDom(0, domain_width, 0, domain_height)
+    r = hl.RDom(0, domain_width, 0, domain_height)
     r.where(r.x <= r.y)
 
     diagonal[r.x, r.y] = 2

--- a/python_bindings/src/PyIROperator.cpp
+++ b/python_bindings/src/PyIROperator.cpp
@@ -118,7 +118,7 @@ std::vector<h::Expr> tuple_to_exprs(p::tuple t) {
     return exprs;
 }
 
-p::object print_expr(p::tuple args, p::dict kwargs) {
+p::object print(p::tuple args, p::dict kwargs) {
     return p::object(h::print(tuple_to_exprs(args)));
 }
 
@@ -466,10 +466,7 @@ void define_operators() {
            "Create an Expr that prints whenever it is evaluated, "
            "provided that the condition is true.");
 
-    // We call this "print_expr" rather than "print" to avoid
-    // conflicts with Python's build-in "print()" function, in
-    // case users import all of the Halide bindings.
-    def_raw("print_expr", print_expr, 1,
+    def_raw("print", print, 1,
            "Create an Expr that prints out its value whenever it is "
            "evaluated. It also prints out everything else in the arguments "
            "list, separated by spaces. This can include string literals.");

--- a/python_bindings/tutorial/lesson_01_basics.py
+++ b/python_bindings/tutorial/lesson_01_basics.py
@@ -23,21 +23,21 @@
 # We'll also include stdio for printf.
 #include <stdio.h>
 
-import halide as h
+import halide as hl
 
 def main():
 
     # This program defines a single-stage imaging pipeline that
     # outputs a grayscale diagonal gradient.
 
-    # A 'Func' object represents a pipeline stage. It's a pure
+    # A 'hl.Func' object represents a pipeline stage. It's a pure
     # function that defines what value each pixel should have. You
     # can think of it as a computed image.
-    gradient = h.Func("gradient")
+    gradient = hl.Func("gradient")
 
-    # Var objects are names to use as variables in the definition of
-    # a Func. They have no meaning by themselves.
-    x, y = h.Var("x"), h.Var("y")
+    # hl.Var objects are names to use as variables in the definition of
+    # a hl.Func. They have no meaning by themselves.
+    x, y = hl.Var("x"), hl.Var("y")
 
     # We typically use Vars named 'x' and 'y' to correspond to the x
     # and y axes of an image, and we write them in that order. If
@@ -45,17 +45,17 @@ def main():
     # then x is the column index, and y is the row index.
 
     # Funcs are defined at any integer coordinate of its variables as
-    # an Expr in terms of those variables and other functions.
-    # Here, we'll define an Expr which has the value x + y. Vars have
+    # an hl.Expr in terms of those variables and other functions.
+    # Here, we'll define an hl.Expr which has the value x + y. Vars have
     # appropriate operator overloading so that expressions like
-    # 'x + y' become 'Expr' objects.
+    # 'x + y' become 'hl.Expr' objects.
     e = x + y
-    assert type(e) == h.Expr
+    assert type(e) == hl.Expr
 
-    # Now we'll add a definition for the Func object. At pixel x, y,
-    # the image will have the value of the Expr e. On the left hand
-    # side we have the Func we're defining and some Vars. On the right
-    # hand side we have some Expr object that uses those same Vars.
+    # Now we'll add a definition for the hl.Func object. At pixel x, y,
+    # the image will have the value of the hl.Expr e. On the left hand
+    # side we have the hl.Func we're defining and some Vars. On the right
+    # hand side we have some hl.Expr object that uses those same Vars.
     gradient[x, y] = e
 
     # This is the same as writing:
@@ -63,27 +63,27 @@ def main():
     #   gradient[x, y] = x + y
     #
     # which is the more common form, but we are showing the
-    # intermediate Expr here for completeness.
+    # intermediate hl.Expr here for completeness.
 
-    # That line of code defined the Func, but it didn't actually
+    # That line of code defined the hl.Func, but it didn't actually
     # compute the output image yet. At this stage it's just Funcs,
     # Exprs, and Vars in memory, representing the structure of our
     # imaging pipeline. We're meta-programming. This C++ program is
     # constructing a Halide program in memory. Actually computing
     # pixel data comes next.
 
-    # Now we 'realize' the Func, which JIT compiles some code that
+    # Now we 'realize' the hl.Func, which JIT compiles some code that
     # implements the pipeline we've defined, and then runs it.  We
     # also need to tell Halide the domain over which to evaluate the
-    # Func, which determines the range of x and y above, and the
+    # hl.Func, which determines the range of x and y above, and the
     # resolution of the output image. Halide.h also provides a basic
     # templatized image type we can use. We'll make an 800 x 600
     # image.
     output = gradient.realize(800, 600)
-    assert type(output) == h.Buffer_int32
+    assert type(output) == hl.Buffer_int32
 
-    # Halide does type inference for you. Var objects represent
-    # 32-bit integers, so the Expr object 'x + y' also represents a
+    # Halide does type inference for you. hl.Var objects represent
+    # 32-bit integers, so the hl.Expr object 'x + y' also represents a
     # 32-bit integer, and so 'gradient' defines a 32-bit image, and
     # so we got a 32-bit signed integer image out when we call
     # 'realize'. Halide types and type-casting rules are equivalent
@@ -93,7 +93,7 @@ def main():
     # expecting:
     for j in range(output.height()):
         for i in range(output.width()):
-            # We can access a pixel of an Buffer object using similar
+            # We can access a pixel of an hl.Buffer object using similar
             # syntax to defining and using functions.
             if (output(i, j) != i + j):
                 print("Something went wrong!\n"
@@ -102,8 +102,8 @@ def main():
                 return -1
 
 
-    # Everything worked! We defined a Func, then called 'realize' on
-    # it to generate and run machine code that produced a Buffer.
+    # Everything worked! We defined a hl.Func, then called 'realize' on
+    # it to generate and run machine code that produced a hl.Buffer.
     print("Success!")
 
     return 0

--- a/python_bindings/tutorial/lesson_02_input_image.py
+++ b/python_bindings/tutorial/lesson_02_input_image.py
@@ -18,7 +18,7 @@
 # The only Halide header file you need is Halide.h. It includes all of Halide.
 #include "Halide.h"
 
-import halide as h
+import halide as hl
 import numpy as np
 from scipy.misc import imread, imsave
 import os.path
@@ -33,17 +33,17 @@ def main():
     input_data = imread(image_path)
     assert input_data.dtype == np.uint8
 
-    # We create a Buffer object to wrap the numpy array
-    input = h.Buffer(input_data)
+    # We create a hl.Buffer object to wrap the numpy array
+    input = hl.Buffer(input_data)
 
-    # Next we define our Func object that represents our one pipeline
+    # Next we define our hl.Func object that represents our one pipeline
     # stage.
-    brighter = h.Func("brighter")
+    brighter = hl.Func("brighter")
 
-    # Our Func will have three arguments, representing the position
+    # Our hl.Func will have three arguments, representing the position
     # in the image and the color channel. Halide treats color
     # channels as an extra dimension of the image.
-    x, y, c = h.Var("x"), h.Var("y"), h.Var("c")
+    x, y, c = hl.Var("x"), hl.Var("y"), hl.Var("c")
 
     # Normally we'd probably write the whole function definition on
     # one line. Here we'll break it apart so we can explain what
@@ -51,10 +51,10 @@ def main():
 
     # For each pixel of the input image.
     value = input[x, y, c]
-    assert type(value) == h.Expr
+    assert type(value) == hl.Expr
 
     # Cast it to a floating point value.
-    value = h.cast(h.Float(32), value)
+    value = hl.cast(hl.Float(32), value)
 
     # Multiply it by 1.5 to brighten it. Halide represents real
     # numbers as floats, not doubles, so we stick an 'f' on the end
@@ -62,43 +62,43 @@ def main():
     value = value * 1.5
 
     # Clamp it to be less than 255, so we don't get overflow when we
-    # cast it back to an 8-bit unsigned int.
-    value = h.min(value, 255.0)
+    # hl.cast it back to an 8-bit unsigned int.
+    value = hl.min(value, 255.0)
 
     # Cast it back to an 8-bit unsigned integer.
-    value = h.cast(h.UInt(8), value)
+    value = hl.cast(hl.UInt(8), value)
 
     # Define the function.
     brighter[x, y, c] = value
 
     # The equivalent one-liner to all of the above is:
     #
-    # brighter(x, y, c) = h.cast<uint8_t>(min(input(x, y, c) * 1.5f, 255))
-    # brighter[x, y, c] = h.cast(h.UInt(8), min(input[x, y, c] * 1.5, 255))
+    # brighter(x, y, c) = hl.cast<uint8_t>(hl.min(input(x, y, c) * 1.5f, 255))
+    # brighter[x, y, c] = hl.cast(hl.UInt(8), hl.min(input[x, y, c] * 1.5, 255))
     #
     # In the shorter version:
-    # - I skipped the cast to float, because multiplying by 1.5f does
+    # - I skipped the hl.cast to float, because multiplying by 1.5f does
     #   that automatically.
-    # - I also used integer constants in clamp, because they get cast
+    # - I also used integer constants in hl.clamp, because they get hl.cast
     #   to match the type of the first argument.
-    # - I left the h. off clamp. It's unnecessary due to Koenig
+    # - I left the h. off hl.clamp. It's unnecessary due to Koenig
     #   lookup.
 
     # Remember. All we've done so far is build a representation of a
     # Halide program in memory. We haven't actually processed any
     # pixels yet. We haven't even compiled that Halide program yet.
 
-    # So now we'll realize the Func. The size of the output image
+    # So now we'll realize the hl.Func. The size of the output image
     # should match the size of the input image. If we just wanted to
     # brighten a portion of the input image we could request a
     # smaller size. If we request a larger size Halide will throw an
     # error at runtime telling us we're trying to read out of bounds
     # on the input image.
     output_image = brighter.realize(input.width(), input.height(), input.channels())
-    assert type(output_image) == h.Buffer_uint8
+    assert type(output_image) == hl.Buffer_uint8
 
     # Save the output for inspection. It should look like a bright parrot.
-    output_data = h.buffer_to_ndarray(output_image)
+    output_data = hl.buffer_to_ndarray(output_image)
     #print("output_data", output_data)
     #print("output_data.shape", output_data.shape)
     imsave("brighter.png", output_data)

--- a/python_bindings/tutorial/lesson_03_debugging_1.py
+++ b/python_bindings/tutorial/lesson_03_debugging_1.py
@@ -21,7 +21,7 @@
 
 # This time we'll just import the entire Halide namespace
 #using namespace Halide
-from halide import *
+import halide as hl
 
 def main():
 
@@ -31,10 +31,10 @@ def main():
     # This lesson will be about debugging, but unfortunately in C++,
     # objects don't know their own names, which makes it hard for us
     # to understand the generated code. To get around this, you can
-    # pass a string to the Func and Var constructors to give them a
+    # pass a string to the hl.Func and hl.Var constructors to give them a
     # name for debugging purposes.
-    gradient = Func("gradient")
-    x, y = Var("x"), Var("y")
+    gradient = hl.Func("gradient")
+    x, y = hl.Var("x"), hl.Var("y")
     gradient[x, y] = x + y
 
     # Realize the function to produce an output image. We'll keep it

--- a/python_bindings/tutorial/lesson_04_debugging_2.py
+++ b/python_bindings/tutorial/lesson_04_debugging_2.py
@@ -19,12 +19,12 @@
 #include "Halide.h"
 #include <stdio.h>
 #using namespace Halide
-from halide import *
+import halide as hl
 
 def main():
 
-    gradient = Func("gradient")
-    x, y = Var("x"), Var("y")
+    gradient = hl.Func("gradient")
+    x, y = hl.Var("x"), hl.Var("y")
 
     # We'll define our gradient function as before.
     gradient[x, y] = x + y
@@ -43,7 +43,7 @@ def main():
     # Now that we can snoop on what Halide is doing, let's try our
     # first scheduling primitive. We'll make a new version of
     # gradient that processes each scanline in parallel.
-    parallel_gradient = Func("parallel_gradient")
+    parallel_gradient = hl.Func("parallel_gradient")
     parallel_gradient[x, y] = x + y
 
     # We'll also trace this function.

--- a/python_bindings/tutorial/lesson_05_scheduling_1.py
+++ b/python_bindings/tutorial/lesson_05_scheduling_1.py
@@ -2,7 +2,7 @@
 # Halide tutorial lesson 5
 
 # This lesson demonstrates how to manipulate the order in which you
-# evaluate pixels in a Func, including vectorization,
+# evaluate pixels in a hl.Func, including vectorization,
 # parallelization, unrolling, and tiling.
 
 # This lesson can be built by invoking the command:
@@ -21,9 +21,7 @@
 #include "Halide.h"
 #include <stdio.h>
 #using namespace Halide
-from halide import *
-
-min_, max_ = __builtins__.min, __builtins__.max
+import halide as hl
 
 def main():
 
@@ -31,11 +29,11 @@ def main():
     # several different ways, and see what order pixels are computed
     # in.
 
-    x, y = Var("x"), Var ("y")
+    x, y = hl.Var("x"), hl.Var ("y")
 
     # First we observe the default ordering.
     if True:
-        gradient = Func("gradient")
+        gradient = hl.Func("gradient")
         gradient[x, y] = x + y
         gradient.trace_stores()
 
@@ -71,7 +69,7 @@ def main():
 
     # Reorder variables.
     if True:
-        gradient = Func("gradient_col_major")
+        gradient = hl.Func("gradient_col_major")
         print("x, y", x, y)
         gradient[x, y] = x + y
         gradient.trace_stores()
@@ -107,13 +105,13 @@ def main():
 
     # Split a variable into two.
     if True:
-        gradient = Func("gradient_split")
+        gradient = hl.Func("gradient_split")
         gradient[x, y] = x + y
         gradient.trace_stores()
 
         # The most powerful primitive scheduling operation you can do
         # to a var is to split it into inner and outer sub-variables:
-        x_outer, x_inner = Var("x_outer"), Var("x_inner")
+        x_outer, x_inner = hl.Var("x_outer"), hl.Var("x_inner")
         gradient.split(x, x_outer, x_inner, 2)
 
         # This breaks the loop over x into two nested loops: an outer
@@ -150,7 +148,7 @@ def main():
 
     # Fuse two variables into one.
     if True:
-        gradient = Func("gradient_fused")
+        gradient = hl.Func("gradient_fused")
         gradient[x, y] = x + y
 
         # The opposite of splitting is 'fusing'. Fusing two variables
@@ -159,7 +157,7 @@ def main():
         # splitting, but it also sees use (as we'll see later in this
         # lesson). Like splitting, fusing by itself doesn't change
         # the order of evaluation.
-        fused = Var("fused")
+        fused = hl.Var("fused")
         gradient.fuse(x, y, fused)
 
         print("Evaluating gradient with x and y fused")
@@ -180,7 +178,7 @@ def main():
 
     # Evaluating in tiles.
     if True:
-        gradient = Func("gradient_tiled")
+        gradient = hl.Func("gradient_tiled")
         gradient[x, y] = x + y
         gradient.trace_stores()
 
@@ -194,7 +192,7 @@ def main():
         # good for performance if neighboring pixels use overlapping
         # input data, for example in a blur. We can express a tiled
         # traversal like so:
-        x_outer, x_inner, y_outer, y_inner = Var(), Var(), Var(), Var()
+        x_outer, x_inner, y_outer, y_inner = hl.Var(), hl.Var(), hl.Var(), hl.Var()
         gradient.split(x, x_outer, x_inner, 2)
         gradient.split(y, y_outer, y_inner, 2)
         gradient.reorder(x_inner, y_inner, x_outer, y_outer)
@@ -223,7 +221,7 @@ def main():
 
     # Evaluating in vectors.
     if True:
-        gradient = Func("gradient_in_vectors")
+        gradient = hl.Func("gradient_in_vectors")
         gradient[x, y] = x + y
         gradient.trace_stores()
 
@@ -234,7 +232,7 @@ def main():
         # single vectorized computation. This time we'll split by a
         # factor of four, because on X86 we can use SSE to compute in
         # 4-wide vectors.
-        x_outer, x_inner = Var("x_outer"), Var("x_inner")
+        x_outer, x_inner = hl.Var("x_outer"), hl.Var("x_inner")
         gradient.split(x, x_outer, x_inner, 4)
         gradient.vectorize(x_inner)
 
@@ -287,7 +285,7 @@ def main():
 
     # Unrolling a loop.
     if True:
-        gradient = Func("gradient_in_vectors")
+        gradient = hl.Func("gradient_in_vectors")
         gradient[x, y] = x + y
         gradient.trace_stores()
 
@@ -297,7 +295,7 @@ def main():
         # we expressed vectorizing. We split a dimension and then
         # fully unroll the loop of the inner variable. Unrolling
         # doesn't change the order in which things are evaluated.
-        x_outer, x_inner = Var("x_outer"), Var("x_inner")
+        x_outer, x_inner = hl.Var("x_outer"), hl.Var("x_inner")
         gradient.split(x, x_outer, x_inner, 2)
         gradient.unroll(x_inner)
 
@@ -332,7 +330,7 @@ def main():
 
     # Splitting by factors that don't divide the extent.
     if True:
-        gradient = Func("gradient_split_5x4")
+        gradient = hl.Func("gradient_split_5x4")
         gradient[x, y] = x + y
         gradient.trace_stores()
 
@@ -343,7 +341,7 @@ def main():
         # split by a factor of two again, but now we'll evaluate
         # gradient over a 5x4 box instead of the 4x4 box we've been
         # using.
-        x_outer, x_inner = Var("x_outer"), Var("x_inner")
+        x_outer, x_inner = hl.Var("x_outer"), hl.Var("x_inner")
         gradient.split(x, x_outer, x_inner, 2)
 
         print("Evaluating gradient over a 5x4 box with x split by two ")
@@ -356,7 +354,7 @@ def main():
                     xx = x_outer * 2
                     # Before we add x_inner, make sure we don't
                     # evaluate points outside of the 5x4 box. We'll
-                    # clamp x to be at most 3 (5 minus the split
+                    # hl.clamp x to be at most 3 (5 minus the split
                     # factor).
                     if xx > 3:
                         xx = 3
@@ -382,7 +380,7 @@ def main():
         #
         # x_outer runs from 0 to (x_extent + factor - 1)/factor
         # x_inner runs from 0 to factor
-        # x = min(x_outer * factor, x_extent - factor) + x_inner + x_min
+        # x = hl.min(x_outer * factor, x_extent - factor) + x_inner + x_min
         #
         # In our example, x_min was 0, x_extent was 5, and factor was 2.
 
@@ -407,20 +405,20 @@ def main():
         # often gives poor performance compared to fusing the
         # parallel variables into a single parallel for loop.
 
-        gradient = Func("gradient_fused_tiles")
+        gradient = hl.Func("gradient_fused_tiles")
         gradient[x, y] = x + y
         gradient.trace_stores()
 
         # First we'll tile, then we'll fuse the tile indices and
         # parallelize across the combination.
-        x_outer, y_outer = Var("x_outer"), Var("y_outer")
-        x_inner, y_inner = Var("x_inner"), Var("y_inner")
-        tile_index = Var("tile_index")
+        x_outer, y_outer = hl.Var("x_outer"), hl.Var("y_outer")
+        x_inner, y_inner = hl.Var("x_inner"), hl.Var("y_inner")
+        tile_index = hl.Var("tile_index")
         gradient.tile(x, y, x_outer, y_outer, x_inner, y_inner, 2, 2)
         gradient.fuse(x_outer, y_outer, tile_index)
         gradient.parallel(tile_index)
 
-        # The scheduling calls all return a reference to the Func, so
+        # The scheduling calls all return a reference to the hl.Func, so
         # you can also chain them together into a single statement to
         # make things slightly clearer:
         #
@@ -457,13 +455,13 @@ def main():
     # Putting it all together.
     if True:
         # Are you ready? We're going to use all of the features above now.
-        gradient_fast = Func("gradient_fast")
+        gradient_fast = hl.Func("gradient_fast")
         gradient_fast[x, y] = x + y
 
         # We'll process 256x256 tiles in parallel.
-        x_outer, y_outer = Var("x_outer"), Var("y_outer")
-        x_inner, y_inner = Var("x_inner"), Var("y_inner")
-        tile_index = Var("tile_index")
+        x_outer, y_outer = hl.Var("x_outer"), hl.Var("y_outer")
+        x_inner, y_inner = hl.Var("x_inner"), hl.Var("y_inner")
+        tile_index = hl.Var("tile_index")
         gradient_fast \
             .tile(x, y, x_outer, y_outer, x_inner, y_inner, 256, 256) \
             .fuse(x_outer, y_outer, tile_index) \
@@ -474,8 +472,8 @@ def main():
         # express this is to recursively tile again within each tile
         # into 4x2 subtiles, then vectorize the subtiles across x and
         # unroll them across y:
-        x_inner_outer, y_inner_outer = Var("x_inner_outer"), Var("y_inner_outer")
-        x_vectors, y_pairs = Var("x_vectors"), Var("y_pairs")
+        x_inner_outer, y_inner_outer = hl.Var("x_inner_outer"), hl.Var("y_inner_outer")
+        x_vectors, y_pairs = hl.Var("x_vectors"), hl.Var("y_pairs")
         gradient_fast \
             .tile(x_inner, y_inner, x_inner_outer, y_inner_outer, x_vectors, y_pairs, 4, 2) \
             .vectorize(x_vectors) \
@@ -501,14 +499,14 @@ def main():
             for y_inner_outer in range(256//2):
                 for x_inner_outer in range(256//4):
                     # We're vectorized across x
-                    xx = min_(x_outer * 256, 800-256) + x_inner_outer*4
+                    xx = min(x_outer * 256, 800-256) + x_inner_outer*4
                     x_vec = [xx + 0,
                                     xx + 1,
                                     xx + 2,
                                     xx + 3]
 
                     # And we unrolled across y
-                    y_base = min_(y_outer * 256, 600-256) + y_inner_outer*2
+                    y_base = min(y_outer * 256, 600-256) + y_inner_outer*2
 
                     if True:
                         # y_pairs = 0

--- a/python_bindings/tutorial/lesson_06_realizing_over_shifted_domains.py
+++ b/python_bindings/tutorial/lesson_06_realizing_over_shifted_domains.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 # Halide tutorial lesson 6.
 
-# This lesson demonstrates how to evaluate a Func over a domain that
+# This lesson demonstrates how to evaluate a hl.Func over a domain that
 # does not start at (0, 0).
 
 # This lesson can be built by invoking the command:
@@ -21,7 +21,7 @@
 #include <stdio.h>
 
 #using namespace Halide
-from halide import *
+import halide as hl
 
 def main():
 
@@ -31,8 +31,8 @@ def main():
     # domains that do not start at the origin.
 
     # We define our familiar gradient function.
-    gradient = Func ("gradient")
-    x, y = Var("x"), Var("y")
+    gradient = hl.Func ("gradient")
+    x, y = hl.Var("x"), hl.Var("y")
     gradient[x, y] = x + y
 
     # And turn on tracing so we can see how it is being evaluated.
@@ -53,9 +53,9 @@ def main():
     # What if we're managing memory carefully and don't want Halide
     # to allocate a new image for us? We can call realize another
     # way. We can pass it an image we would like it to fill in. The
-    # following evaluates our Func into an existing image:
+    # following evaluates our hl.Func into an existing image:
     print("Evaluating gradient from (0, 0) to (7, 7)")
-    result = Buffer(Int(32), 8, 8)
+    result = hl.Buffer(hl.Int(32), 8, 8)
     gradient.realize(result)
 
     # Let's check it did what we expect:
@@ -73,7 +73,7 @@ def main():
     # from (100, 50) to (104, 56) inclusive.
 
     # We start by creating an image that represents that rectangle:
-    shifted = Buffer(Int(32), 5, 7) # In the constructor we tell it the size.
+    shifted = hl.Buffer(hl.Int(32), 5, 7) # In the constructor we tell it the size.
     shifted.set_min(100, 50) # Then we tell it the top-left corner.
 
     print("Evaluating gradient from (100, 50) to (104, 56)")
@@ -93,11 +93,11 @@ def main():
 
 
 
-    # The image 'shifted' stores the value of our Func over a domain
+    # The image 'shifted' stores the value of our hl.Func over a domain
     # that starts at (100, 50), so asking for shifted(0, 0) would in
     # fact read out-of-bounds and probably crash.
 
-    # What if we want to evaluate our Func over some region that
+    # What if we want to evaluate our hl.Func over some region that
     # isn't rectangular? Too bad. Halide only does rectangles :)
 
     print("Success!")

--- a/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
+++ b/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
@@ -20,7 +20,7 @@
 #include <stdio.h>
 
 #using namespace Halide
-from halide import *
+import halide as hl
 
 # Support code for loading pngs.
 #include "image_io.h"
@@ -30,7 +30,7 @@ import os.path
 
 def main():
     # First we'll declare some Vars to use below.
-    x, y, c = Var("x"), Var("y"), Var("c")
+    x, y, c = hl.Var("x"), hl.Var("y"), hl.Var("c")
 
     image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/rgb.png")
 
@@ -38,28 +38,28 @@ def main():
     # first horizontally, and then vertically.
     if True:
         # Take a color 8-bit input
-        input = Buffer(imread(image_path))
-        assert input.type() == UInt(8)
+        input = hl.Buffer(imread(image_path))
+        assert input.type() == hl.UInt(8)
 
         # Upgrade it to 16-bit, so we can do math without it overflowing.
-        input_16 = Func("input_16")
-        input_16[x, y, c] = cast(UInt(16), input[x, y, c])
+        input_16 = hl.Func("input_16")
+        input_16[x, y, c] = hl.cast(hl.UInt(16), input[x, y, c])
 
         # Blur it horizontally:
-        blur_x = Func("blur_x")
+        blur_x = hl.Func("blur_x")
         blur_x[x, y, c] = (input_16[x - 1, y, c] + 2 * input_16[x, y, c] + input_16[x + 1, y, c]) / 4
 
         # Blur it vertically:
-        blur_y = Func("blur_y")
+        blur_y = hl.Func("blur_y")
         blur_y[x, y, c] = (blur_x[x, y - 1, c] + 2 * blur_x[x, y, c] + blur_x[x, y + 1, c]) / 4
 
         # Convert back to 8-bit.
-        output = Func("output")
-        output[x, y, c] = cast(UInt(8), blur_y[x, y, c])
+        output = hl.Func("output")
+        output[x, y, c] = hl.cast(hl.UInt(8), blur_y[x, y, c])
 
-        # Each Func in this pipeline calls a previous one using
+        # Each hl.Func in this pipeline calls a previous one using
         # familiar function call syntax (we've overloaded operator()
-        # on Func objects). A Func may call any other Func that has
+        # on hl.Func objects). A hl.Func may call any other hl.Func that has
         # been given a definition. This restriction prevents
         # pipelines with loops in them. Halide pipelines are always
         # feed-forward graphs of Funcs.
@@ -86,7 +86,7 @@ def main():
         # over a domain shifted inwards by one pixel, we won't be
         # asking the Halide routine to read out of bounds. We saw how
         # to do this in the previous lesson:
-        result = Buffer(UInt(8), input.width() - 2, input.height() - 2, 3)
+        result = hl.Buffer(hl.UInt(8), input.width() - 2, input.height() - 2, 3)
         result.set_min(1, 1)
         output.realize(result)
 
@@ -94,7 +94,7 @@ def main():
         # parrot, and it should be two pixels narrower and two pixels
         # shorter than the input image.
 
-        result_data = buffer_to_ndarray(result)
+        result_data = hl.buffer_to_ndarray(result)
         print("result.shape", result_data.shape)
 
         imsave("blurry_parrot_1.png", result_data)
@@ -108,21 +108,21 @@ def main():
     # The same pipeline, with a boundary condition on the input.
     if True:
         # Take a color 8-bit input
-        input = Buffer(imread(image_path))
-        assert input.type() == UInt(8)
+        input = hl.Buffer(imread(image_path))
+        assert input.type() == hl.UInt(8)
 
-        # This time, we'll wrap the input in a Func that prevents
+        # This time, we'll wrap the input in a hl.Func that prevents
         # reading out of bounds:
-        clamped = Func("clamped")
+        clamped = hl.Func("clamped")
 
         # Define an expression that clamps x to lie within the the
         # range [0, input.width()-1].
-        clamped_x = clamp(x, 0, input.width() - 1)
-        # Similarly clamp y.
-        clamped_y = clamp(y, 0, input.height() - 1)
+        clamped_x = hl.clamp(x, 0, input.width() - 1)
+        # Similarly hl.clamp y.
+        clamped_y = hl.clamp(y, 0, input.height() - 1)
         # Load from input at the clamped coordinates. This means that
-        # no matter how we evaluated the Func 'clamped', we'll never
-        # read out of bounds on the input. This is a clamp-to-edge
+        # no matter how we evaluated the hl.Func 'clamped', we'll never
+        # read out of bounds on the input. This is a hl.clamp-to-edge
         # style boundary condition, and is the simplest boundary
         # condition to express in Halide.
         clamped[x, y, c] = input[clamped_x, clamped_y, c]
@@ -131,32 +131,32 @@ def main():
         # using a helper function from the BoundaryConditions
         # namespace like so:
         #
-        # clamped = BoundaryConditions::repeat_edge(input)
+        # clamped = BoundaryConditions::hl.repeat_edge(input)
         #
         # These are important to use for other boundary conditions,
         # because they are expressed in the way that Halide can best
         # understand and optimize.
 
         # Upgrade it to 16-bit, so we can do math without it
-        # overflowing. This time we'll refer to our new Func
+        # overflowing. This time we'll refer to our new hl.Func
         # 'clamped', instead of referring to the input image
         # directly.
-        input_16 = Func("input_16")
-        input_16[x, y, c] = cast(UInt(16), clamped[x, y, c])
+        input_16 = hl.Func("input_16")
+        input_16[x, y, c] = hl.cast(hl.UInt(16), clamped[x, y, c])
 
         # The rest of the pipeline will be the same...
 
         # Blur it horizontally:
-        blur_x = Func("blur_x")
+        blur_x = hl.Func("blur_x")
         blur_x[x, y, c] = (input_16[x - 1, y, c] + 2 * input_16[x, y, c] + input_16[x + 1, y, c]) / 4
 
         # Blur it vertically:
-        blur_y = Func("blur_y")
+        blur_y = hl.Func("blur_y")
         blur_y[x, y, c] = (blur_x[x, y - 1, c] + 2 * blur_x[x, y, c] + blur_x[x, y + 1, c]) / 4
 
         # Convert back to 8-bit.
-        output = Func("output")
-        output[x, y, c] = cast(UInt(8), blur_y[x, y, c])
+        output = hl.Func("output")
+        output[x, y, c] = hl.cast(hl.UInt(8), blur_y[x, y, c])
 
         # This time it's safe to evaluate the output over the some
         # domain as the input, because we have a boundary condition.
@@ -165,7 +165,7 @@ def main():
         # Save the result. It should look like a slightly blurry
         # parrot, but this time it will be the same size as the
         # input.
-        result_data = buffer_to_ndarray(result)
+        result_data = hl.buffer_to_ndarray(result)
         print("result.shape", result_data.shape)
 
         imsave("blurry_parrot_2.png", result_data)

--- a/python_bindings/tutorial/lesson_08_scheduling_2.py
+++ b/python_bindings/tutorial/lesson_08_scheduling_2.py
@@ -20,24 +20,24 @@
 #include <stdio.h>
 
 #using namespace Halide
-from halide import *
+import halide as hl
 import numpy as np
 import math
 
 def main():
     # First we'll declare some Vars to use below.
-    x, y = Var("x"), Var("y")
+    x, y = hl.Var("x"), hl.Var("y")
 
     # Let's examine various scheduling options for a simple two stage
     # pipeline. We'll start with the default schedule:
     if True:
         print("="*50)
-        producer, consumer = Func("producer_default"), Func("consumer_default")
+        producer, consumer = hl.Func("producer_default"), hl.Func("consumer_default")
 
         # The first stage will be some simple pointwise math similar
         # to our familiar gradient function. The value at position x,
         # y is the sqrt of product of x and y.
-        producer[x, y] = sqrt(x * y)
+        producer[x, y] = hl.sqrt(x * y)
 
         # Now we'll add a second stage which adds together multiple
         # points in the first stage.
@@ -93,8 +93,8 @@ def main():
     if True:
         print("="*50)
         # Start with the same function definitions:
-        producer, consumer = Func("producer_root"), Func("consumer_root")
-        producer[x, y] = sqrt(x * y)
+        producer, consumer = hl.Func("producer_root"), hl.Func("consumer_root")
+        producer[x, y] = hl.sqrt(x * y)
         consumer[x, y] = (producer[x, y] +
                           producer[x, y+1] +
                           producer[x+1, y] +
@@ -192,8 +192,8 @@ def main():
     if True:
         print("="*50)
         # Start with the same function definitions:
-        producer, consumer = Func("producer_y"), Func("consumer_y")
-        producer[x, y] = sqrt(x * y)
+        producer, consumer = hl.Func("producer_y"), hl.Func("consumer_y")
+        producer[x, y] = hl.sqrt(x * y)
         consumer[x, y] = (producer[x, y] +
                           producer[x, y+1] +
                           producer[x+1, y] +
@@ -269,8 +269,8 @@ def main():
     # which we actually compute it. This unlocks a few optimizations.
     if True:
         print("="*50)
-        producer, consumer = Func("producer_store_root_compute_y"), Func("consumer_store_root_compute_y")
-        producer[x, y] = sqrt(x * y)
+        producer, consumer = hl.Func("producer_store_root_compute_y"), hl.Func("consumer_store_root_compute_y")
+        producer[x, y] = hl.sqrt(x * y)
         consumer[x, y] = (producer[x, y] +
                           producer[x, y+1] +
                           producer[x+1, y] +
@@ -387,8 +387,8 @@ def main():
     # moving the computation into the innermost loop:
     if True:
         print("="*50)
-        producer, consumer = Func("producer_store_root_compute_x"), Func("consumer_store_root_compute_x")
-        producer[x, y] = sqrt(x * y)
+        producer, consumer = hl.Func("producer_store_root_compute_x"), hl.Func("consumer_store_root_compute_x")
+        producer[x, y] = hl.sqrt(x * y)
         consumer[x, y] = (producer[x, y] +
                           producer[x, y+1] +
                           producer[x+1, y] +
@@ -474,8 +474,8 @@ def main():
     # respect to those. We'll use this to express fusion in tiles:
     if True:
         print("="*50)
-        producer, consumer = Func("producer_tile"), Func("consumer_tile")
-        producer[x, y] = sqrt(x * y)
+        producer, consumer = hl.Func("producer_tile"), hl.Func("consumer_tile")
+        producer[x, y] = hl.sqrt(x * y)
         consumer[x, y] = (producer[x, y] +
                           producer[x, y+1] +
                           producer[x+1, y] +
@@ -483,8 +483,8 @@ def main():
 
 
         # Tile the consumer using 2x2 tiles.
-        x_outer, y_outer = Var("x_outer"), Var("y_outer")
-        x_inner, y_inner = Var("x_inner"), Var("y_inner")
+        x_outer, y_outer = hl.Var("x_outer"), hl.Var("y_outer")
+        x_inner, y_inner = hl.Var("x_inner"), hl.Var("y_inner")
         consumer.tile(x, y, x_outer, y_outer, x_inner, y_inner, 2, 2)
 
         # Compute the producer per tile of the consumer
@@ -558,15 +558,15 @@ def main():
     # in Halide.
     if True:
         print("="*50)
-        producer, consumer = Func("producer_mixed"), Func("consumer_mixed")
-        producer[x, y] = sqrt(x * y)
+        producer, consumer = hl.Func("producer_mixed"), hl.Func("consumer_mixed")
+        producer[x, y] = hl.sqrt(x * y)
         consumer[x, y] = (producer[x, y] +
                           producer[x, y+1] +
                           producer[x+1, y] +
                           producer[x+1, y+1])
 
         # Split the y coordinate of the consumer into strips of 16 scanlines:
-        yo, yi = Var("yo"), Var("yi")
+        yo, yi = hl.Var("yo"), hl.Var("yi")
         consumer.split(y, yo, yi, 16)
         # Compute the strips using a thread pool and a task queue.
         consumer.parallel(yo)

--- a/python_bindings/tutorial/lesson_09_update_definitions.py
+++ b/python_bindings/tutorial/lesson_09_update_definitions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 # Halide tutorial lesson 9
 
-# This lesson demonstrates how to define a Func in multiple passes, including scattering.
+# This lesson demonstrates how to define a hl.Func in multiple passes, including scattering.
 
 # This lesson can be built by invoking the command:
 #    make tutorial_lesson_09_update_definitions
@@ -29,7 +29,7 @@
 from datetime import datetime
 
 #using namespace Halide
-from halide import *
+import halide as hl
 
 # Support code for loading pngs.
 #include "image_io.h"
@@ -37,11 +37,9 @@ from scipy.misc import imread
 import numpy as np
 import os.path
 
-min_, max_ = __builtins__.min, __builtins__.max
-
 def main():
     # Declare some Vars to use below.
-    x, y = Var ("x"), Var ("y")
+    x, y = hl.Var ("x"), hl.Var ("y")
 
     # Load a grayscale image to use as an input.
     image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/gray.png")
@@ -50,14 +48,14 @@ def main():
          # making the image smaller to go faster
         input_data = input_data[:160, :150]
     assert input_data.dtype == np.uint8
-    input = Buffer(input_data)
+    input = hl.Buffer(input_data)
 
-    # You can define a Func in multiple passes. Let's see a toy
+    # You can define a hl.Func in multiple passes. Let's see a toy
     # example first.
     if True:
         # The first definition must be one like we have seen already
-        # - a mapping from Vars to an Expr:
-        f = Func("f")
+        # - a mapping from Vars to an hl.Expr:
+        f = hl.Func("f")
         f[x, y] = x + y
         # We call this first definition the "pure" definition.
 
@@ -85,7 +83,7 @@ def main():
         # can recursively refer to other values in the same row.
         f[0, y] = f[0, y] / f[3, y]
 
-        # The general rule is: Each Var used in an update definition
+        # The general rule is: Each hl.Var used in an update definition
         # must appear unadorned in the same position as in the pure
         # definition in all references to the function on the left-
         # and right-hand sides. So the following definitions are
@@ -109,7 +107,7 @@ def main():
         # For each realization of f, each step runs in its entirety
         # before the next one begins. Let's trace the loads and
         # stores for a simpler example:
-        g = Func("g")
+        g = hl.Func("g")
         g[x, y] = x + y   # Pure definition
         g[2, 1] = 42      # First update definition
         g[x, 0] = g[x, 1] # Second update definition
@@ -138,7 +136,7 @@ def main():
     # Putting update passes inside loops.
     if True:
         # Starting with this pure definition:
-        f = Func("f")
+        f = hl.Func("f")
         f[x, y] = x + y
 
         # Say we want an update that squares the first fifty rows. We
@@ -158,7 +156,7 @@ def main():
         # But it's more manageable and more flexible to put the loop
         # in the generated code. We do this by defining a "reduction
         # domain" and using it inside an update definition:
-        r = RDom(0, 50)
+        r = hl.RDom(0, 50)
         f[x, r] = f[x, r] * f[x, r]
         halide_result = f.realize(100, 100)
 
@@ -198,13 +196,13 @@ def main():
         # there. The classic example is computing a histogram. The
         # natural way to do it is to iterate over the input image,
         # updating histogram buckets. Here's how you do that in Halide:
-        histogram = Func("histogram")
+        histogram = hl.Func("histogram")
 
         # Histogram buckets start as zero.
         histogram[x] = 0
 
         # Define a multi-dimensional reduction domain over the input image:
-        r = RDom(0, input.width(), 0, input.height())
+        r = hl.RDom(0, input.width(), 0, input.height())
 
         # For every point in the reduction domain, increment the
         # histogram bucket corresponding to the intensity of the
@@ -244,7 +242,7 @@ def main():
         # that in a later lesson.
 
         # Consider the definition:
-        f = Func("x")
+        f = hl.Func("x")
         f[x, y] = x*y
         # Set the second row to equal the first row.
         f[x, 1] = f[x, 0]
@@ -257,7 +255,7 @@ def main():
         # and parallelizes the pure definition only.
         f.vectorize(x, 4).parallel(y)
 
-        # We use Func::update(int) to get a handle to an update step
+        # We use hl.Func::update(int) to get a handle to an update step
         # for the purposes of scheduling. The following line
         # vectorizes the first update step across x. We can't do
         # anything with y for this update step, because it doesn't
@@ -266,7 +264,7 @@ def main():
 
         # Now we parallelize the second update step in chunks of size
         # 4.
-        yo, yi = Var("yo"), Var("yi")
+        yo, yi = hl.Var("yo"), hl.Var("yi")
         f.update(1).split(y, yo, yi, 4).parallel(yo)
 
         halide_result = f.realize(16, 16)
@@ -316,7 +314,7 @@ def main():
 
 
 
-    # That covers how to schedule the variables within a Func that
+    # That covers how to schedule the variables within a hl.Func that
     # uses update steps, but what about producer-consumer
     # relationships that involve compute_at and store_at? Let's
     # examine a reduction as a producer, in a producer-consumer pair.
@@ -326,7 +324,7 @@ def main():
         # for them does the closest thing possible. It computes them
         # in the innermost loop of their consumer. Consider this
         # trivial example:
-        producer, consumer = Func("producer"), Func("consumer")
+        producer, consumer = hl.Func("producer"), hl.Func("consumer")
         producer[x] = x*17
         producer[x] += 1
         consumer[x] = 2 * producer[x]
@@ -363,7 +361,7 @@ def main():
     if True:
         if True:
             # Case 1: The consumer references the producer in the pure step only.
-            producer, consumer = Func("producer"), Func("consumer")
+            producer, consumer = hl.Func("producer"), hl.Func("consumer")
             # The producer is pure.
             producer[x] = x*17
             consumer[x] = 2 * producer[x]
@@ -420,7 +418,7 @@ def main():
 
         if True:
             # Case 2: The consumer references the producer in the update step only
-            producer, consumer = Func("producer"), Func("consumer")
+            producer, consumer = hl.Func("producer"), hl.Func("consumer")
             producer[x] = x * 17
             consumer[x] = x
             consumer[x] += producer[x]
@@ -435,8 +433,8 @@ def main():
             #
             # producer.compute_at(consumer.update(0), x).
             #
-            # Scheduling is done with respect to Vars of a Func, and
-            # the Vars of a Func are shared across the pure and
+            # Scheduling is done with respect to Vars of a hl.Func, and
+            # the Vars of a hl.Func are shared across the pure and
             # update steps.
 
             halide_result = consumer.realize(10)
@@ -470,7 +468,7 @@ def main():
         if True:
             # Case 3: The consumer references the producer in
             # multiple steps that share common variables
-            producer, consumer = Func("producer"), Func("consumer")
+            producer, consumer = hl.Func("producer"), hl.Func("consumer")
             producer[x] = x * 17
             consumer[x] = producer[x] * x
             consumer[x] += producer[x]
@@ -514,7 +512,7 @@ def main():
         if True:
             # Case 4: The consumer references the producer in
             # multiple steps that do not share common variables
-            producer, consumer = Func("producer"), Func("consumer")
+            producer, consumer = hl.Func("producer"), hl.Func("consumer")
             producer[x, y] = x*y
             consumer[x, y] = x + y
             consumer[x, 0] = producer[x, x-1]
@@ -529,12 +527,12 @@ def main():
             # Let's say we really really want producer to be
             # compute_at the inner loops of both consumer update
             # steps. Halide doesn't allow multiple different
-            # schedules for a single Func, but we can work around it
+            # schedules for a single hl.Func, but we can work around it
             # by making two wrappers around producer, and scheduling
             # those instead:
 
             # Attempt 2:
-            producer_wrapper_1, producer_wrapper_2, consumer_2 = Func(), Func(), Func()
+            producer_wrapper_1, producer_wrapper_2, consumer_2 = hl.Func(), hl.Func(), hl.Func()
             producer_wrapper_1[x, y] = producer[x, y]
             producer_wrapper_2[x, y] = producer[x, y]
 
@@ -590,12 +588,12 @@ def main():
             # We are not just restricted to scheduling producers at
             # the loops over the pure variables of the consumer. If a
             # producer is only used within a loop over a reduction
-            # domain (RDom) variable, we can also schedule the
+            # domain (hl.RDom) variable, we can also schedule the
             # producer there.
 
-            producer, consumer = Func("producer"), Func("consumer")
+            producer, consumer = hl.Func("producer"), hl.Func("consumer")
 
-            r = RDom(0, 5)
+            r = hl.RDom(0, 5)
             producer[x] = x * 17
             consumer[x] = x + 10
             consumer[x] += r + producer[x + r]
@@ -636,22 +634,22 @@ def main():
         # The default schedule for a reduction is a good one for
         # convolution-like operations. For example, the following
         # computes a 5x5 box-blur of our grayscale test image with a
-        # clamp-to-edge boundary condition:
+        # hl.clamp-to-edge boundary condition:
 
         # First add the boundary condition.
-        clamped = repeat_edge(input)
+        clamped = hl.repeat_edge(input)
 
         # Define a 5x5 box that starts at (-2, -2)
-        r = RDom(-2, 5, -2, 5)
+        r = hl.RDom(-2, 5, -2, 5)
 
         # Compute the 5x5 sum around each pixel.
-        local_sum = Func("local_sum")
+        local_sum = hl.Func("local_sum")
         local_sum[x, y] = 0 # Compute the sum as a 32-bit integer
         local_sum[x, y] += clamped[x + r.x, y + r.y]
 
         # Divide the sum by 25 to make it an average
-        blurry = Func("blurry")
-        blurry[x, y] = cast(UInt(8), local_sum[x, y] / 25)
+        blurry = hl.Func("blurry")
+        blurry[x, y] = hl.cast(hl.UInt(8), local_sum[x, y] / 25)
 
         halide_result = blurry.realize(input.width(), input.height())
 
@@ -665,7 +663,7 @@ def main():
         #cast_to_uint8 = lambda x_: np.array([x_], dtype=np.uint8)[0]
         local_sum = np.empty((1), dtype=np.int32)
 
-        c_result = Buffer(UInt(8), input.width(), input.height())
+        c_result = hl.Buffer(hl.UInt(8), input.width(), input.height())
         for yy in range(input.height()):
             for xx in range(input.width()):
                 # FIXME this loop is quite slow
@@ -675,14 +673,14 @@ def main():
                 for r_y in range(-2, 2+1):
                     for r_x in range(-2, 2+1):
                         # The clamping has been inlined into the update step.
-                        clamped_x = min_(max_(xx + r_x, 0), input.width()-1)
-                        clamped_y = min_(max_(yy + r_y, 0), input.height()-1)
+                        clamped_x = min(max(xx + r_x, 0), input.width()-1)
+                        clamped_y = min(max(yy + r_y, 0), input.height()-1)
                         local_sum[0] += input(clamped_x, clamped_y)
 
                 # Pure step of blurry
                 #c_result(x, y) = (uint8_t)(local_sum[0] / 25)
                 #c_result[xx, yy] = cast_to_uint8(local_sum[0] / 25)
-                c_result[xx, yy] = int(local_sum[0] / 25) # cast done internally
+                c_result[xx, yy] = int(local_sum[0] / 25) # hl.cast done internally
 
         # Check the results match
         for yy in range(input.height()):
@@ -700,12 +698,12 @@ def main():
         # Halide.h, which compute small reductions and schedule them
         # innermost into their consumer. The most useful one is
         # "sum".
-        f1 = Func ("f1")
-        r = RDom (0, 100)
-        f1[x] = sum(r + x) * 7
+        f1 = hl.Func ("f1")
+        r = hl.RDom (0, 100)
+        f1[x] = hl.sum(r + x) * 7
 
-        # Sum creates a small anonymous Func to do the reduction. It's equivalent to:
-        f2, anon = Func("f2"), Func("anon")
+        # Sum creates a small anonymous hl.Func to do the reduction. It's equivalent to:
+        f2, anon = hl.Func("f2"), hl.Func("anon")
         anon[x] = 0
         anon[x] += r + x
         f2[x] = anon[x] * 7
@@ -747,25 +745,25 @@ def main():
     if False: # non-sense to port SSE code to python, skipping this test
 
         # Other reduction helpers include "product", "minimum",
-        # "maximum", "argmin", and "argmax". Using argmin and argmax
+        # "maximum", "hl.argmin", and "argmax". Using hl.argmin and argmax
         # requires understanding tuples, which come in a later
         # lesson. Let's use minimum and maximum to compute the local
         # spread of our grayscale image.
 
         # First, add a boundary condition to the input.
-        clamped = Func("clamped")
-        x_clamped = clamp(x, 0, input.width()-1)
-        y_clamped = clamp(y, 0, input.height()-1)
+        clamped = hl.Func("clamped")
+        x_clamped = hl.clamp(x, 0, input.width()-1)
+        y_clamped = hl.clamp(y, 0, input.height()-1)
         clamped[x, y] = input[x_clamped, y_clamped]
 
-        box = RDom(-2, 5, -2, 5)
+        box = hl.RDom(-2, 5, -2, 5)
         # Compute the local maximum minus the local minimum:
-        spread = Func("spread")
+        spread = hl.Func("spread")
         spread[x, y] = (maximum(clamped(x + box.x, y + box.y)) -
                         minimum(clamped(x + box.x, y + box.y)))
 
         # Compute the result in strips of 32 scanlines
-        yo, yi = Var("yo"), Var("yi")
+        yo, yi = hl.Var("yo"), hl.Var("yi")
         spread.split(y, yo, yi, 32).parallel(yo)
 
         # Vectorize across x within the strips. This implicitly
@@ -790,7 +788,7 @@ def main():
         #ifdef __SSE2__
 
         # Don't include the time required to allocate the output buffer.
-        c_result = Buffer(UInt(8), input.width(), input.height())
+        c_result = hl.Buffer(hl.UInt(8), input.width(), input.height())
 
         #ifdef _OPENMP
         t1 = datetime.now()
@@ -801,7 +799,7 @@ def main():
             pass
             # #pragma omp parallel for
             # for yo in range((input.height() + 31)/32):
-            #     y_base = min(yo * 32, input.height() - 32)
+            #     y_base = hl.min(yo * 32, input.height() - 32)
             #
             #     # Compute clamped in a circular buffer of size 8
             #     # (smallest power of two greater than 5). Each thread
@@ -826,19 +824,19 @@ def main():
             #
             #             # Figure out which row of the input we're reading
             #             # from by clamping the y coordinate:
-            #             int clamped_y = std::min(std::max(cy, 0), input.height()-1)
+            #             int clamped_y = std::hl.min(std::hl.max(cy, 0), input.height()-1)
             #             uint8_t *input_row = &input(0, clamped_y)
             #
             #             # Fill it in with the padding.
             #             for (int x = -2 x < input.width() + 2 ):
-            #                 int clamped_x = std::min(std::max(x, 0), input.width()-1)
+            #                 int clamped_x = std::hl.min(std::hl.max(x, 0), input.width()-1)
             #                 *clamped_row++ = input_row[clamped_x]
             #
             #
             #
             #         # Now iterate over vectors of x for the pure step of the output.
             #         for (int x_vec = 0 x_vec < (input.width() + 15)/16 x_vec++) {
-            #             int x_base = std::min(x_vec * 16, input.width() - 16)
+            #             int x_base = std::hl.min(x_vec * 16, input.width() - 16)
             #
             #             # Allocate storage for the minimum and maximum
             #             # helpers. One vector is enough.

--- a/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
+++ b/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
@@ -34,16 +34,16 @@
 #include "Halide.h"
 #include <stdio.h>
 #using namespace Halide
-from halide import *
+import halide as hl
 
 def main():
 
     # We'll define a simple one-stage pipeline:
-    brighter = Func("brighter")
-    x, y = Var("x"), Var("y")
+    brighter = hl.Func("brighter")
+    x, y = hl.Var("x"), hl.Var("y")
 
     # The pipeline will depend on one scalar parameter.
-    offset = Param(UInt(8), name="offset")
+    offset = hl.Param(hl.UInt(8), name="offset")
 
     # And take one grayscale 8-bit input buffer. The first
     # constructor argument gives the type of a pixel, and the second
@@ -51,15 +51,15 @@ def main():
     # channels!). For a grayscale image this is two for a color
     # image it's three. Currently, four dimensions is the maximum for
     # inputs and outputs.
-    input = ImageParam(UInt(8), 2)
+    input = hl.ImageParam(hl.UInt(8), 2)
 
     # If we were jit-compiling, these would just be an int and a
-    # Buffer, but because we want to compile the pipeline once and
+    # hl.Buffer, but because we want to compile the pipeline once and
     # have it work for any value of the parameter, we need to make a
-    # Param object, which can be used like an Expr, and an ImageParam
-    # object, which can be used like a Buffer.
+    # hl.Param object, which can be used like an hl.Expr, and an hl.ImageParam
+    # object, which can be used like a hl.Buffer.
 
-    # Define the Func.
+    # Define the hl.Func.
     brighter[x, y] = input[x, y] + offset
 
     # Schedule it.

--- a/python_bindings/tutorial/lesson_11_cross_compilation.py
+++ b/python_bindings/tutorial/lesson_11_cross_compilation.py
@@ -20,21 +20,21 @@
 #include "Halide.h"
 #include <stdio.h>
 #using namespace Halide
-from halide import *
+import halide as hl
 from struct import unpack
 
 def main():
 
     # We'll define the simple one-stage pipeline that we used in lesson 10.
-    brighter = Func("brighter")
-    x, y = Var("x"), Var("y")
+    brighter = hl.Func("brighter")
+    x, y = hl.Var("x"), hl.Var("y")
 
     # Declare the arguments.
-    offset = Param(UInt(8))
-    input = ImageParam(UInt(8), 2)
+    offset = hl.Param(hl.UInt(8))
+    input = hl.ImageParam(hl.UInt(8), 2)
     args = [input, offset]
 
-    # Define the Func.
+    # Define the hl.Func.
     brighter[x, y] = input[x, y] + offset
 
     # Schedule it.
@@ -57,9 +57,9 @@ def main():
 
     if create_android:
         # Let's use this to compile a 32-bit arm android version of this code:
-        target = Target()
-        target.os = TargetOS.Android  # The operating system
-        target.arch = TargetArch.ARM  # The CPU architecture
+        target = hl.Target()
+        target.os = hl.TargetOS.Android  # The operating system
+        target.arch = hl.TargetArch.ARM  # The CPU architecture
         target.bits = 32              # The bit-width of the architecture
         arm_features = []             # A list of features to set
         target.set_features(arm_features)
@@ -68,11 +68,11 @@ def main():
 
     if create_windows:
         # And now a Windows object file for 64-bit x86 with AVX and SSE 4.1:
-        target = Target()
-        target.os = TargetOS.Windows
-        target.arch = TargetArch.X86
+        target = hl.Target()
+        target.os = hl.TargetOS.Windows
+        target.arch = hl.TargetArch.X86
         target.bits = 64
-        target.set_features([TargetFeature.AVX, TargetFeature.SSE41])
+        target.set_features([hl.TargetFeature.AVX, hl.TargetFeature.SSE41])
         brighter.compile_to_file("lesson_11_x86_64_windows", args, "lesson_11_x86_64_windows", target)
 
     if create_ios:
@@ -82,11 +82,11 @@ def main():
         # this using the target features field.  Support for Apple's
         # 64-bit ARM processors is very new in llvm, and still somewhat
         # flaky.
-        target = Target()
-        target.os = TargetOS.IOS
-        target.arch = TargetArch.ARM
+        target = hl.Target()
+        target.os = hl.TargetOS.IOS
+        target.arch = hl.TargetArch.ARM
         target.bits = 32
-        target.set_features([TargetFeature.ARMv7s])
+        target.set_features([hl.TargetFeature.ARMv7s])
         brighter.compile_to_file("lesson_11_arm_32_ios", args, "lesson_11_arm_32_ios", target)
 
 

--- a/python_bindings/tutorial/lesson_12_using_the_gpu.py
+++ b/python_bindings/tutorial/lesson_12_using_the_gpu.py
@@ -20,7 +20,7 @@
 #include "Halide.h"
 #include <stdio.h>
 #using namespace Halide
-from halide import *
+import halide as hl
 
 # Include some support code for loading pngs.
 #include "image_io.h"
@@ -33,7 +33,7 @@ from datetime import datetime
 
 
 # Define some Vars to use.
-x, y, c, i, ii, xi, yi = Var("x"), Var("y"), Var("c"), Var("i"), Var("ii"), Var("xi"), Var("yi")
+x, y, c, i, ii, xi, yi = hl.Var("x"), hl.Var("y"), hl.Var("c"), hl.Var("i"), hl.Var("ii"), hl.Var("xi"), hl.Var("yi")
 
 # We're going to want to schedule a pipeline in several ways, so we
 # define the pipeline in a class so that we can recreate it several
@@ -42,13 +42,13 @@ class MyPipeline:
 
     def __init__(self, input):
 
-        assert type(input) == Buffer_uint8
+        assert type(input) == hl.Buffer_uint8
 
-        self.lut = Func("lut")
-        self.padded = Func("padded")
-        self.padded16 = Func("padded16")
-        self.sharpen = Func("sharpen")
-        self.curved = Func("curved")
+        self.lut = hl.Func("lut")
+        self.padded = hl.Func("padded")
+        self.padded16 = hl.Func("padded16")
+        self.sharpen = hl.Func("sharpen")
+        self.curved = hl.Func("curved")
         self.input = input
 
 
@@ -56,14 +56,14 @@ class MyPipeline:
         # and then applies a look-up-table (LUT).
 
         # First we'll define the LUT. It will be a gamma curve.
-        self.lut[i] = cast(UInt(8), clamp(pow(i / 255.0, 1.2) * 255.0, 0, 255))
+        self.lut[i] = hl.cast(hl.UInt(8), hl.clamp(pow(i / 255.0, 1.2) * 255.0, 0, 255))
 
         # Augment the input with a boundary condition.
-        self.padded[x, y, c] = input[clamp(x, 0, input.width()-1),
-                                clamp(y, 0, input.height()-1), c]
+        self.padded[x, y, c] = input[hl.clamp(x, 0, input.width()-1),
+                                hl.clamp(y, 0, input.height()-1), c]
 
         # Cast it to 16-bit to do the math.
-        self.padded16[x, y, c] = cast(UInt(16), self.padded[x, y, c])
+        self.padded16[x, y, c] = hl.cast(hl.UInt(16), self.padded[x, y, c])
 
         # Next we sharpen it with a five-tap filter.
         self.sharpen[x, y, c] = (self.padded16[x, y, c] * 2-
@@ -90,7 +90,7 @@ class MyPipeline:
 
         # Look-up-tables don't vectorize well, so just parallelize
         # curved in slices of 16 scanlines.
-        yo, yi = Var("yo"), Var("yi")
+        yo, yi = hl.Var("yo"), hl.Var("yi")
         self.curved.split(y, yo, yi, 16) \
               .parallel(yo)
 
@@ -104,7 +104,7 @@ class MyPipeline:
         self.sharpen.vectorize(x, 8)
 
         # Compute the padded input at the same granularity as the
-        # sharpen. We'll leave the cast to 16-bit inlined into
+        # sharpen. We'll leave the hl.cast to 16-bit inlined into
         # sharpen.
         self.padded.store_at(self.curved, yo) \
             .compute_at(self.curved, yi)
@@ -122,7 +122,7 @@ class MyPipeline:
     # Now a schedule that uses CUDA or OpenCL.
     def schedule_for_gpu(self):
         # We make the decision about whether to use the GPU for each
-        # Func independently. If you have one Func computed on the
+        # hl.Func independently. If you have one hl.Func computed on the
         # CPU, and the next computed on the GPU, Halide will do the
         # copy-to-gpu under the hood. For this pipeline, there's no
         # reason to use the CPU for any of the stages. Halide will
@@ -136,7 +136,7 @@ class MyPipeline:
         # Let's compute the look-up-table using the GPU in 16-wide
         # one-dimensional thread blocks. First we split the index
         # into blocks of size 16:
-        block, thread = Var("block"), Var("thread")
+        block, thread = hl.Var("block"), hl.Var("thread")
         self.lut.split(i, block, thread, 16)
         # Then we tell cuda that our Vars 'block' and 'thread'
         # correspond to CUDA's notions of blocks and threads, or
@@ -149,7 +149,7 @@ class MyPipeline:
 
         # lut.gpu_tile(i, ii, 16)
 
-        # Func::gpu_tile method is similar to Func::tile, except that
+        # hl.Func::gpu_tile method is similar to hl.Func::tile, except that
         # it also specifies that the tile coordinates correspond to
         # GPU blocks, and the coordinates within each tile correspond
         # to GPU threads.
@@ -171,8 +171,8 @@ class MyPipeline:
         # We'll leave sharpen as inlined into curved.
 
         # Compute the padded input as needed per GPU block, storing the
-        # intermediate result in shared memory. Var::gpu_blocks, and
-        # Var::gpu_threads exist to help you schedule producers within
+        # intermediate result in shared memory. hl.Var::gpu_blocks, and
+        # hl.Var::gpu_threads exist to help you schedule producers within
         # GPU threads and blocks.
         self.padded.compute_at(self.curved, x)
 
@@ -181,14 +181,14 @@ class MyPipeline:
         self.padded.gpu_threads(x, y)
 
         # JIT-compile the pipeline for the GPU. CUDA or OpenCL are
-        # not enabled by default. We have to construct a Target
+        # not enabled by default. We have to construct a hl.Target
         # object, enable one of them, and then pass that target
         # object to compile_jit. Otherwise your CPU will very slowly
         # pretend it's a GPU, and use one thread per output pixel.
 
         # Start with a target suitable for the machine you're running
         # this on.
-        target = get_host_target()
+        target = hl.get_host_target()
 
         # Then enable OpenCL or CUDA.
         #use_opencl = False
@@ -198,12 +198,12 @@ class MyPipeline:
             # performance than CUDA, even with NVidia's drivers, because
             # NVidia's open source LLVM backend doesn't seem to do all
             # the same optimizations their proprietary compiler does.
-            target.set_feature(TargetFeature.OpenCL)
+            target.set_feature(hl.TargetFeature.OpenCL)
             print("(Using OpenCL)")
         else:
             # Uncomment the next line and comment out the line above to
             # try CUDA instead.
-            target.set_feature(TargetFeature.CUDA)
+            target.set_feature(hl.TargetFeature.CUDA)
             print("(Using CUDA)")
 
         # If you want to see all of the OpenCL or CUDA API calls done
@@ -211,14 +211,14 @@ class MyPipeline:
         # flag. This is helpful for figuring out which stages are
         # slow, or when CPU -> GPU copies happen. It hurts
         # performance though, so we'll leave it commented out.
-        # target.set_feature(TargetFeature.Debug)
+        # target.set_feature(hl.TargetFeature.Debug)
 
         self.curved.compile_jit(target)
 
     def test_performance(self):
         # Test the performance of the scheduled MyPipeline.
 
-        output = Buffer(UInt(8),
+        output = hl.Buffer(hl.UInt(8),
                         self.input.width(),
                         self.input.height(),
                         self.input.channels())
@@ -250,11 +250,11 @@ class MyPipeline:
 
     def test_correctness(self, reference_output):
 
-        assert type(reference_output) == Buffer_uint8
+        assert type(reference_output) == hl.Buffer_uint8
         output = self.curved.realize(self.input.width(),
                                      self.input.height(),
                                      self.input.channels())
-        assert type(output) == Buffer_uint8
+        assert type(output) == hl.Buffer_uint8
 
         # Check against the reference output.
         for c in range(self.input.channels()):
@@ -276,10 +276,10 @@ def main():
     # Load an input image.
     image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/rgb.png")
     input_data = imread(image_path)
-    input = Buffer(input_data)
+    input = hl.Buffer(input_data)
 
     # Allocated an image that will store the correct output
-    reference_output = Buffer(UInt(8), input.width(), input.height(), input.channels())
+    reference_output = hl.Buffer(hl.UInt(8), input.width(), input.height(), input.channels())
 
     print("Testing performance on CPU:")
     p1 = MyPipeline(input)

--- a/python_bindings/tutorial/lesson_13_tuples.py
+++ b/python_bindings/tutorial/lesson_13_tuples.py
@@ -18,49 +18,43 @@
 # in a shell with the current directory at the top of the halide
 # source tree.
 
-#include "Halide.h"
-#include <stdio.h>
-#include <algorithm>
-#using namespace Halide
-from halide import *
+import halide as hl
 
 import numpy
 import math
-
-min_, max_ = __builtins__.min, __builtins__.max
 
 def main():
 
     # So far Funcs (such as the one below) have evaluated to a single
     # scalar value for each point in their domain.
-    single_valued = Func()
-    x, y = Var("x"), Var("y")
+    single_valued = hl.Func()
+    x, y = hl.Var("x"), hl.Var("y")
     single_valued[x, y] = x + y
 
-    # One way to write a Func that returns a collection of values is
+    # One way to write a hl.Func that returns a collection of values is
     # to add an additional dimension which indexes that
     # collection. This is how we typically deal with color. For
-    # example, the Func below represents a collection of three values
+    # example, the hl.Func below represents a collection of three values
     # for every x, y coordinate indexed by c.
-    color_image = Func()
-    c = Var("c")
-    color_image[x, y, c] = select(c == 0, 245, # Red value
+    color_image = hl.Func()
+    c = hl.Var("c")
+    color_image[x, y, c] = hl.select(c == 0, 245, # Red value
                                   c == 1, 42,  # Green value
                                   132)        # Blue value
 
     # This method is often convenient because it makes it easy to
-    # operate on this Func in a way that treats each item in the
+    # operate on this hl.Func in a way that treats each item in the
     # collection equally:
-    brighter = Func()
+    brighter = hl.Func()
     brighter[x, y, c] = color_image[x, y, c] + 10
 
     # However this method is also inconvenient for three reasons.
     #
     # 1) Funcs are defined over an infinite domain, so users of this
-    # Func can for example access color_image(x, y, -17), which is
+    # hl.Func can for example access color_image(x, y, -17), which is
     # not a meaningful value and is probably indicative of a bug.
     #
-    # 2) It requires a select, which can impact performance if not
+    # 2) It requires a hl.select, which can impact performance if not
     # bounded and unrolled:
     # brighter.bound(c, 0, 3).unroll(c)
     #
@@ -71,31 +65,31 @@ def main():
 
     # It is also possible to represent a collection of values as a
     # collection of Funcs:
-    func_array = [Func() for i in range(3)]
+    func_array = [hl.Func() for i in range(3)]
     func_array[0][x, y] = x + y
-    func_array[1][x, y] = sin(x)
-    func_array[2][x, y] = cos(y)
+    func_array[1][x, y] = hl.sin(x)
+    func_array[2][x, y] = hl.cos(y)
 
     # This method avoids the three problems above, but introduces a
     # new annoyance. Because these are separate Funcs, it is
     # difficult to schedule them so that they are all computed
     # together inside a single loop over x, y.
 
-    # A third alternative is to define a Func as evaluating to a
-    # Tuple instead of an Expr. A Tuple is a fixed-size collection of
+    # A third alternative is to define a hl.Func as evaluating to a
+    # Tuple instead of an hl.Expr. A Tuple is a fixed-size collection of
     # Exprs which may have different type. The following function
     # evaluates to an integer value (x+y), and a floating point value
-    # (sin(x*y)).
-    multi_valued = Func("multi_valued")
-    multi_valued[x, y] = (x + y, sin(x * y))
+    # (hl.sin(x*y)).
+    multi_valued = hl.Func("multi_valued")
+    multi_valued[x, y] = (x + y, hl.sin(x * y))
 
-    # Realizing a tuple-valued Func returns a collection of
+    # Realizing a tuple-valued hl.Func returns a collection of
     # Buffers. We call this a Realization. It's equivalent to a
-    # std::vector of Buffer/Image objects:
+    # std::vector of hl.Buffer/Image objects:
     if True:
         (im1, im2) = multi_valued.realize(80, 60)
-        assert type(im1) is Buffer_int32
-        assert type(im2) is Buffer_float32
+        assert type(im1) is hl.Buffer_int32
+        assert type(im2) is hl.Buffer_float32
         assert im1(30, 40) == 30 + 40
         assert numpy.isclose(im2(30, 40), math.sin(30 * 40))
 
@@ -113,7 +107,7 @@ def main():
                 multi_valued_1[xx + 60*yy] = math.sin(xx*yy)
 
 
-    # When compiling ahead-of-time, a Tuple-valued Func evaluates
+    # When compiling ahead-of-time, a Tuple-valued hl.Func evaluates
     # into multiple distinct output buffer_t structs. These appear in
     # order at the end of the function signature:
     # int multi_valued(...input buffers and params..., buffer_t *output_1, buffer_t *output_2)
@@ -122,22 +116,22 @@ def main():
     # Tuple constructor as we did above. Perhaps more elegantly, you
     # can also take advantage of C++11 initializer lists and just
     # enclose your Exprs in braces:
-    multi_valued_2 = Func("multi_valued_2")
-    multi_valued_2[x, y] = (x + y, sin(x * y))
+    multi_valued_2 = hl.Func("multi_valued_2")
+    multi_valued_2[x, y] = (x + y, hl.sin(x * y))
 
-    # Calls to a multi-valued Func cannot be treated as Exprs. The
+    # Calls to a multi-valued hl.Func cannot be treated as Exprs. The
     # following is a syntax error:
-    # Func consumer
+    # hl.Func consumer
     # consumer[x, y] = multi_valued_2[x, y] + 10
 
     # Instead you must index the returned object with square brackets
     # to retrieve the individual Exprs:
     integer_part = multi_valued_2[x, y][0]
     floating_part = multi_valued_2[x, y][1]
-    assert type(integer_part) is FuncTupleElementRef
-    assert type(floating_part) is FuncTupleElementRef
+    assert type(integer_part) is hl.FuncTupleElementRef
+    assert type(floating_part) is hl.FuncTupleElementRef
 
-    consumer = Func()
+    consumer = hl.Func()
     consumer[x, y] = (integer_part + 10, floating_part + 10.0)
 
     # Tuple reductions.
@@ -147,25 +141,25 @@ def main():
         # its domain. The simplest example is an argmax.
 
         # First we create an Image to take the argmax over.
-        input_func = Func()
-        input_func[x] = sin(x)
+        input_func = hl.Func()
+        input_func[x] = hl.sin(x)
         input = input_func.realize(100)
-        assert type(input) is Buffer_float32
+        assert type(input) is hl.Buffer_float32
 
         # Then we defined a 2-valued Tuple which tracks the maximum value
         # its index.
-        arg_max = Func()
+        arg_max = hl.Func()
 
         # Pure definition.
         # (using [()] for zero-dimensional Funcs is a convention of this python interface)
         arg_max[()] = (0, input(0))
 
         # Update definition.
-        r = RDom(1, 99)
+        r = hl.RDom(1, 99)
         old_index = arg_max[()][0]
         old_max   = arg_max[()][1]
-        new_index = select(old_max > input[r], r, old_index)
-        new_max   = max(input[r], old_max)
+        new_index = hl.select(old_max > input[r], r, old_index)
+        new_max   = hl.max(input[r], old_max)
         arg_max[()] = (new_index, new_max)
 
         # The equivalent C++ is:
@@ -175,11 +169,11 @@ def main():
             old_index = arg_max_0
             old_max = arg_max_1
             new_index = r if (old_max > input(r)) else old_index
-            new_max = max_(input(r), old_max)
+            new_max = max(input(r), old_max)
             # In a tuple update definition, all loads and computation
             # are done before any stores, so that all Tuple elements
             # are updated atomically with respect to recursive calls
-            # to the same Func.
+            # to the same hl.Func.
             arg_max_0 = new_index
             arg_max_1 = new_max
 
@@ -189,13 +183,13 @@ def main():
         if True:
             (r0, r1) = arg_max.realize()
 
-            assert type(r0) is Buffer_int32
-            assert type(r1) is Buffer_float32
+            assert type(r0) is hl.Buffer_int32
+            assert type(r1) is hl.Buffer_float32
             assert arg_max_0 == r0(0)
             assert numpy.isclose(arg_max_1, r1(0))
 
 
-        # Halide provides argmax and argmin as built-in reductions
+        # Halide provides argmax and hl.argmin as built-in reductions
         # similar to sum, product, maximum, and minimum. They return
         # a Tuple consisting of the point in the reduction domain
         # corresponding to that value, and the value itself. In the
@@ -213,8 +207,8 @@ def main():
 
             def __init__(self, r, i=None):
                 if type(r) is float and type(i) is float:
-                    self.real = Expr(r)
-                    self.imag = Expr(i)
+                    self.real = hl.Expr(r)
+                    self.imag = hl.Expr(i)
                 elif i is not None:
                     self.real = r
                     self.imag = i
@@ -253,18 +247,18 @@ def main():
 
 
         # Let's use the Complex struct to compute a Mandelbrot set.
-        mandelbrot = Func()
+        mandelbrot = hl.Func()
 
         # The initial complex value corresponding to an x, y coordinate
-        # in our Func.
+        # in our hl.Func.
         initial = Complex(x/15.0 - 2.5, y/6.0 - 2.0)
 
         # Pure definition.
-        t = Var("t")
+        t = hl.Var("t")
         mandelbrot[x, y, t] = Complex(0.0, 0.0)
 
         # We'll use an update definition to take 12 steps.
-        r = RDom(1, 12)
+        r = hl.RDom(1, 12)
         current = Complex(mandelbrot[x, y, r-1])
 
         # The following line uses the complex multiplication and
@@ -273,24 +267,24 @@ def main():
 
         # We'll use another tuple reduction to compute the iteration
         # number where the value first escapes a circle of radius 4.
-        # This can be expressed as an argmin of a boolean - we want
+        # This can be expressed as an hl.argmin of a boolean - we want
         # the index of the first time the given boolean expression is
         # false (we consider false to be less than true).  The argmax
         # would return the index of the first time the expression is
         # true.
 
         escape_condition = Complex(mandelbrot[x, y, r]).magnitude() < 16.0
-        first_escape = argmin(escape_condition)
+        first_escape = hl.argmin(escape_condition)
         assert type(first_escape) is tuple
-        # We only want the index, not the value, but argmin returns
-        # both, so we'll index the argmin Tuple expression using
-        # square brackets to get the Expr representing the index.
-        escape = Func()
+        # We only want the index, not the value, but hl.argmin returns
+        # both, so we'll index the hl.argmin Tuple expression using
+        # square brackets to get the hl.Expr representing the index.
+        escape = hl.Func()
         escape[x, y] = first_escape[0]
 
         # Realize the pipeline and print the result as ascii art.
         result = escape.realize(61, 25)
-        assert type(result) is Buffer_int32
+        assert type(result) is hl.Buffer_int32
         code = " .:-~*={&%#@"
         for yy in range(result.height()):
             for xx in range(result.width()):

--- a/python_bindings/tutorial/lesson_14_types.py
+++ b/python_bindings/tutorial/lesson_14_types.py
@@ -17,14 +17,11 @@
 # in a shell with the current directory at the top of the halide
 # source tree.
 
-#include "Halide.h"
-#include <stdio.h>
-#using namespace Halide
-from halide import *
+import halide as hl
 
 # This function is used to demonstrate generic code at the end of
 # this lesson.
-#Expr average(Expr a, Expr b)
+#hl.Expr average(hl.Expr a, hl.Expr b)
 
 def main():
 
@@ -36,59 +33,59 @@ def main():
     # following array contains all the legal types.
 
     valid_halide_types = [
-        UInt(8), UInt(16), UInt(32), UInt(64),
-        Int(8), Int(16), Int(32), Int(64),
-        Float(32), Float(64), Handle() ]
+        hl.UInt(8), hl.UInt(16), hl.UInt(32), hl.UInt(64),
+        hl.Int(8), hl.Int(16), hl.Int(32), hl.Int(64),
+        hl.Float(32), hl.Float(64), hl.Handle() ]
 
 
     # Constructing and inspecting types.
     if True:
         # You can programmatically examine the properties of a Halide
         # type. This is useful when you write a C++ function that has
-        # Expr arguments and you wish to check their types:
-        assert UInt(8).bits() == 8
-        assert Int(8).is_int()
+        # hl.Expr arguments and you wish to check their types:
+        assert hl.UInt(8).bits() == 8
+        assert hl.Int(8).is_int()
 
 
         # You can also programmatically construct Types as a function of other Types.
-        t = UInt(8)
+        t = hl.UInt(8)
         t = t.with_bits(t.bits() * 2)
-        assert t == UInt(16)
+        assert t == hl.UInt(16)
 
         # Or construct a Type from a C++ scalar type
-        #assert type_of<float>() == Float(32)
+        #assert type_of<float>() == hl.Float(32)
 
         # The Type struct is also capable of representing vector types,
         # but this is reserved for Halide's internal use. You should
-        # vectorize code by using Func::vectorize, not by attempting to
+        # vectorize code by using hl.Func::vectorize, not by attempting to
         # construct vector expressions directly. You may encounter vector
         # types if you programmatically manipulate lowered Halide code,
-        # but this is an advanced topic (see Func::add_custom_lowering_pass).
+        # but this is an advanced topic (see hl.Func::add_custom_lowering_pass).
 
-        # You can query any Halide Expr for its type. An Expr
-        # representing a Var has type Int(32):
-        x = Var("x")
-        assert Expr(x).type() == Int(32)
+        # You can query any Halide hl.Expr for its type. An hl.Expr
+        # representing a hl.Var has type hl.Int(32):
+        x = hl.Var("x")
+        assert hl.Expr(x).type() == hl.Int(32)
 
-        # Most transcendental functions in Halide cast their inputs to a
-        # Float(32) and return a Float(32):
-        assert sin(x).type() == Float(32)
+        # Most transcendental functions in Halide hl.cast their inputs to a
+        # hl.Float(32) and return a hl.Float(32):
+        assert hl.sin(x).type() == hl.Float(32)
 
-        # You can cast an Expr from one Type to another using the cast operator:
-        assert cast(UInt(8), x).type() == UInt(8)
+        # You can hl.cast an hl.Expr from one Type to another using the hl.cast operator:
+        assert hl.cast(hl.UInt(8), x).type() == hl.UInt(8)
 
         # This also comes in a template form that takes a C++ type.
-        #assert cast<uint8_t>(x).type() == UInt(8)
+        #assert hl.cast<uint8_t>(x).type() == hl.UInt(8)
 
-        # You can also query any defined Func for the types it produces.
-        f1 = Func("f1")
-        f1[x] = cast(UInt(8), x)
-        assert f1.output_types()[0] == UInt(8)
+        # You can also query any defined hl.Func for the types it produces.
+        f1 = hl.Func("f1")
+        f1[x] = hl.cast(hl.UInt(8), x)
+        assert f1.output_types()[0] == hl.UInt(8)
 
-        f2 = Func("f2")
-        f2[x] = (x, sin(x))
-        assert f2.output_types()[0] == Int(32) and \
-               f2.output_types()[1] == Float(32)
+        f2 = hl.Func("f2")
+        f2[x] = (x, hl.sin(x))
+        assert f2.output_types()[0] == hl.Int(32) and \
+               f2.output_types()[1] == hl.Float(32)
 
 
 
@@ -98,106 +95,106 @@ def main():
         # '*', etc), Halide uses a system of type promotion
         # rules. These differ to C's rules. To demonstrate these
         # we'll make some Exprs of each type.
-        x = Var("x")
-        u8 = cast(UInt(8), x)
-        u16 = cast(UInt(16), x)
-        u32 = cast(UInt(32), x)
-        u64 = cast(UInt(64), x)
-        s8 = cast(Int(8), x)
-        s16 = cast(Int(16), x)
-        s32 = cast(Int(32), x)
-        s64 = cast(Int(64), x)
-        f32 = cast(Float(32), x)
-        f64 = cast(Float(64), x)
+        x = hl.Var("x")
+        u8 = hl.cast(hl.UInt(8), x)
+        u16 = hl.cast(hl.UInt(16), x)
+        u32 = hl.cast(hl.UInt(32), x)
+        u64 = hl.cast(hl.UInt(64), x)
+        s8 = hl.cast(hl.Int(8), x)
+        s16 = hl.cast(hl.Int(16), x)
+        s32 = hl.cast(hl.Int(32), x)
+        s64 = hl.cast(hl.Int(64), x)
+        f32 = hl.cast(hl.Float(32), x)
+        f64 = hl.cast(hl.Float(64), x)
 
         # The rules are as follows, and are applied in the order they are
         # written below.
 
-        # 1) It is an error to cast or use arithmetic operators on Exprs of type Handle().
+        # 1) It is an error to hl.cast or use arithmetic operators on Exprs of type hl.Handle().
 
         # 2) If the types are the same, then no type conversions occur.
         for t in valid_halide_types:
             # Skip the handle type.
             if t.is_handle():
                 continue
-            e = cast(t, x)
+            e = hl.cast(t, x)
             assert (e + e).type() == e.type()
 
 
         # 3) If one type is a float but the other is not, then the
         # non-float argument is promoted to a float (possibly causing a
         # loss of precision for large integers).
-        assert (u8 + f32).type() == Float(32)
-        assert (f32 + s64).type() == Float(32)
-        assert (u16 + f64).type() == Float(64)
-        assert (f64 + s32).type() == Float(64)
+        assert (u8 + f32).type() == hl.Float(32)
+        assert (f32 + s64).type() == hl.Float(32)
+        assert (u16 + f64).type() == hl.Float(64)
+        assert (f64 + s32).type() == hl.Float(64)
 
         # 4) If both types are float, then the narrower argument is
         # promoted to the wider bit-width.
-        assert (f64 + f32).type() == Float(64)
+        assert (f64 + f32).type() == hl.Float(64)
 
         # The rules above handle all the floating-point cases. The
         # following three rules handle the integer cases.
 
         # 5) If one of the expressions is an integer constant, then it is
         # coerced to the type of the other expression.
-        assert (u32 + 3).type() == UInt(32)
-        assert (3 + s16).type() == Int(16)
+        assert (u32 + 3).type() == hl.UInt(32)
+        assert (3 + s16).type() == hl.Int(16)
 
         # If this rule would cause the integer to overflow, then Halide
         # will trigger an error, e.g. uncommenting the following line
         # will cause this program to terminate with an error.
-        # Expr bad = u8 + 257
+        # hl.Expr bad = u8 + 257
 
         # 6) If both types are unsigned integers, or both types are
         # signed integers, then the narrower argument is promoted to
         # wider type.
-        assert (u32 + u8).type() == UInt(32)
-        assert (s16 + s64).type() == Int(64)
+        assert (u32 + u8).type() == hl.UInt(32)
+        assert (s16 + s64).type() == hl.Int(64)
 
         # 7) If one type is signed and the other is unsigned, both
         # arguments are promoted to a signed integer with the greater of
         # the two bit widths.
-        assert (u8 + s32).type() == Int(32)
-        assert (u32 + s8).type() == Int(32)
+        assert (u8 + s32).type() == hl.Int(32)
+        assert (u32 + s8).type() == hl.Int(32)
 
         # Note that this may silently overflow the unsigned type in the
         # case where the bit widths are the same.
-        assert (u32 + s32).type() == Int(32)
+        assert (u32 + s32).type() == hl.Int(32)
 
         if False: # evaluate<X> not yet exposed to python
-            # When an unsigned Expr is converted to a wider signed type in
+            # When an unsigned hl.Expr is converted to a wider signed type in
             # this way, it is first widened to a wider unsigned type
             # (zero-extended), and then reinterpreted as a signed
-            # integer. I.e. casting the UInt(8) value 255 to an Int(32)
+            # integer. I.e. casting the hl.UInt(8) value 255 to an hl.Int(32)
             # produces 255, not -1.
-            #int32_t result32 = evaluate<int>(cast<int32_t>(cast<uint8_t>(255)))
+            #int32_t result32 = evaluate<int>(hl.cast<int32_t>(hl.cast<uint8_t>(255)))
             assert result32 == 255
 
             # When a signed type is explicitly converted to a wider unsigned
-            # type with the cast operator (the type promotion rules will
+            # type with the hl.cast operator (the type promotion rules will
             # never do this automatically), it is first converted to the
             # wider signed type (sign-extended), and then reinterpreted as
-            # an unsigned integer. I.e. casting the Int(8) value -1 to a
-            # UInt(16) produces 65535, not 255.
-            #uint16_t result16 = evaluate<uint16_t>(cast<uint16_t>(cast<int8_t>(-1)))
+            # an unsigned integer. I.e. casting the hl.Int(8) value -1 to a
+            # hl.UInt(16) produces 65535, not 255.
+            #uint16_t result16 = evaluate<uint16_t>(hl.cast<uint16_t>(hl.cast<int8_t>(-1)))
             assert result16 == 65535
 
 
-    # The type Handle().
+    # The type hl.Handle().
     if True:
-        # Handle is used to represent opaque pointers. Applying
-        # type_of to any pointer type will return Handle()
+        # hl.Handle is used to represent opaque pointers. Applying
+        # type_of to any pointer type will return hl.Handle()
 
-        #assert type_of<void *>() == Handle()
-        #assert type_of<const char * const **>() == Handle()
+        #assert type_of<void *>() == hl.Handle()
+        #assert type_of<const char * const **>() == hl.Handle()
         # (not clear what the proper python version would be)
 
         # Handles are always stored as 64-bit, regardless of the compilation
         # target.
-        assert Handle().bits() == 64
+        assert hl.Handle().bits() == 64
 
-        # The main use of an Expr of type Handle is to pass
+        # The main use of an hl.Expr of type hl.Handle is to pass
         # it through Halide to other external code.
 
 
@@ -209,10 +206,10 @@ def main():
         # modify the types dynamically at C++ runtime instead. The
         # function defined below averages two expressions of any
         # equal numeric type.
-        x = Var("x")
-        assert average(cast(Float(32), x), 3.0).type() == Float(32)
-        assert average(x, 3).type() == Int(32)
-        assert average(cast(UInt(8), x), cast(UInt(8), 3)).type() == UInt(8)
+        x = hl.Var("x")
+        assert average(hl.cast(hl.Float(32), x), 3.0).type() == hl.Float(32)
+        assert average(x, 3).type() == hl.Int(32)
+        assert average(hl.cast(hl.UInt(8), x), hl.cast(hl.UInt(8), 3)).type() == hl.UInt(8)
 
 
     print("Success!")
@@ -222,14 +219,14 @@ def main():
 
 def average(a, b):
 
-    if type(a) is not Expr:
-        a = Expr(a)
+    if type(a) is not hl.Expr:
+        a = hl.Expr(a)
 
-    if type(b) is not Expr:
-        b = Expr(b)
+    if type(b) is not hl.Expr:
+        b = hl.Expr(b)
 
 
-    "Expr average(Expr a, Expr b)"
+    "hl.Expr average(hl.Expr a, hl.Expr b)"
     # Types must match.
     assert a.type() == b.type()
 
@@ -244,9 +241,9 @@ def average(a, b):
     # wider type to avoid overflow.
     narrow = a.type()
     wider = narrow.with_bits(narrow.bits() * 2)
-    a = cast(wider, a)
-    b = cast(wider, b)
-    return cast(narrow, (a + b)/2)
+    a = hl.cast(wider, a)
+    b = hl.cast(wider, b)
+    return hl.cast(narrow, (a + b)/2)
 
 
 


### PR DESCRIPTION
Previously we used a mix of importing everything into the global namespace, or using 'h' or 'halide' as aliases for the module; we now settle on the two-letter convention common in Python, using 'hl' for our alias.