### PR TITLE
Make all_equal a const method.

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -382,7 +382,7 @@ public:
     HALIDE_BUFFER_FORWARD(deallocate)
     HALIDE_BUFFER_FORWARD(device_deallocate)
     HALIDE_BUFFER_FORWARD(device_free)
-    HALIDE_BUFFER_FORWARD(all_equal)
+    HALIDE_BUFFER_FORWARD_CONST(all_equal)
     HALIDE_BUFFER_FORWARD(fill)
     HALIDE_BUFFER_FORWARD_CONST(for_each_element)
 

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1689,9 +1689,9 @@ public:
     // @}
 
     /** Tests that all values in this buffer are equal to val. */
-    bool all_equal(not_void_T val) {
+    bool all_equal(not_void_T val) const{
         bool all_equal = true;
-        for_each_value([&](T v) {all_equal &= v == val;});
+        for_each_element([&](const int *pos) {all_equal &= (*this)(pos) == val;});
         return all_equal;
     }    
 


### PR DESCRIPTION
Makes all_equal a const method.

The lack of const did not sit well with me, this changes that method to const by using the `for_each_element` method instead of `for_each_value`.