### PR TITLE
Add #defines based on the target to generator header

### DIFF
--- a/test/generator/gpu_only_aottest.cpp
+++ b/test/generator/gpu_only_aottest.cpp
@@ -12,6 +12,29 @@
 #include "gpu_only.h"
 using namespace Halide::Runtime;
 
+#if defined(TEST_OPENCL)
+
+#if !defined(HALIDE_TARGET_FEATURE_OPENCL)
+#error "TEST_OPENCL defined but HALIDE_TARGET_FEATURE_OPENCL was not defined"
+#endif
+
+#elif defined(TEST_CUDA)
+
+#if !defined(HALIDE_TARGET_FEATURE_CUDA)
+#error "TEST_CUDA defined but HALIDE_TARGET_FEATURE_CUDA was not defined"
+#endif
+
+#else
+
+#if defined(HALIDE_TARGET_FEATURE_OPENCL)
+#error "TEST_OPENCL defined but HALIDE_TARGET_FEATURE_OPENCL was not defined"
+#endif
+#if defined(HALIDE_TARGET_FEATURE_CUDA)
+#error "TEST_CUDA defined but HALIDE_TARGET_FEATURE_CUDA was not defined"
+#endif
+
+#endif
+
 int main(int argc, char **argv) {
 #if defined(TEST_OPENCL) || defined(TEST_CUDA)
     const int W = 32, H = 32;

--- a/test/generator/gpu_only_aottest.cpp
+++ b/test/generator/gpu_only_aottest.cpp
@@ -15,22 +15,22 @@ using namespace Halide::Runtime;
 #if defined(TEST_OPENCL)
 
 #if !defined(HALIDE_TARGET_FEATURE_OPENCL)
-#error "TEST_OPENCL defined but HALIDE_TARGET_FEATURE_OPENCL was not defined"
+#error "TEST_OPENCL defined but HALIDE_TARGET_FEATURE_OPENCL not defined"
 #endif
 
 #elif defined(TEST_CUDA)
 
 #if !defined(HALIDE_TARGET_FEATURE_CUDA)
-#error "TEST_CUDA defined but HALIDE_TARGET_FEATURE_CUDA was not defined"
+#error "TEST_CUDA defined but HALIDE_TARGET_FEATURE_CUDA not defined"
 #endif
 
 #else
 
 #if defined(HALIDE_TARGET_FEATURE_OPENCL)
-#error "TEST_OPENCL defined but HALIDE_TARGET_FEATURE_OPENCL was not defined"
+#error "TEST_OPENCL not defined but HALIDE_TARGET_FEATURE_OPENCL defined"
 #endif
 #if defined(HALIDE_TARGET_FEATURE_CUDA)
-#error "TEST_CUDA defined but HALIDE_TARGET_FEATURE_CUDA was not defined"
+#error "TEST_CUDA not defined but HALIDE_TARGET_FEATURE_CUDA defined"
 #endif
 
 #endif


### PR DESCRIPTION
This PR adds #define flags to generated headers based on the target. This makes it possible to tell at compile time what target features are available in a host application. The defines that get added are:

- `HALIDE_TARGET_ARCH_x`
- `HALIDE_TARGET_OS_x`
- `HALIDE_TARGET_BITS_x`
- `HALIDE_TARGET_FEATURE_x` (one for each target feature.)

In all cases, x is the uppercase version of the string used to represent that target feature.