### PR TITLE
Fix a few minor ClangTidy warnings

### DIFF
--- a/src/RealizationOrder.h
+++ b/src/RealizationOrder.h
@@ -29,7 +29,7 @@ class Function;
  * the realization order and the fused groups in that order.
  */
 std::pair<std::vector<std::string>, std::vector<std::vector<std::string>>> realization_order(
-    const std::vector<Function> &output, std::map<std::string, Function> &env);
+    const std::vector<Function> &outputs, std::map<std::string, Function> &env);
 
 }
 }

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -169,8 +169,8 @@ public:
 
     /** Identify the loop nest corresponding to some dimension of some function */
     // @{
-    EXPORT LoopLevel(const Internal::Function &f, VarOrRVar v, int stage_level = -1);
-    EXPORT LoopLevel(const Func &f, VarOrRVar v, int stage_level = -1);
+    EXPORT LoopLevel(const Internal::Function &f, VarOrRVar v, int stage_index = -1);
+    EXPORT LoopLevel(const Func &f, VarOrRVar v, int stage_index = -1);
     // @}
 
     /** Construct an undefined LoopLevel. Calling any method on an undefined

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -2159,7 +2159,7 @@ Stmt schedule_functions(const vector<Function> &outputs,
         }
 
         if ((funcs.size() == 1) &&
-            (funcs[0].has_extern_definition() || (funcs[0].definition().schedule().fused_pairs().size() == 0))) {
+            (funcs[0].has_extern_definition() || (funcs[0].definition().schedule().fused_pairs().empty()))) {
             // There is only one function in the group and either there is
             // no loop fusion among its definition or the function is
             // an extern function


### PR DESCRIPTION
- Mismatched prototype arg names
- prefer .empty() to .size() == 0