### PR TITLE
Add #defines indicating the header is present

### DIFF
--- a/src/runtime/HalideRuntimeCuda.h
+++ b/src/runtime/HalideRuntimeCuda.h
@@ -11,6 +11,8 @@ extern "C" {
  *  Routines specific to the Halide Cuda runtime.
  */
 
+#define HALIDE_RUNTIME_CUDA
+
 extern const struct halide_device_interface_t *halide_cuda_device_interface();
 
 /** These are forward declared here to allow clients to override the

--- a/src/runtime/HalideRuntimeHexagonHost.h
+++ b/src/runtime/HalideRuntimeHexagonHost.h
@@ -11,6 +11,8 @@ extern "C" {
  *  Routines specific to the Halide Hexagon host-side runtime.
  */
 
+#define HALIDE_RUNTIME_HEXAGON
+
 typedef int halide_hexagon_handle_t;
 
 extern const struct halide_device_interface_t *halide_hexagon_device_interface();

--- a/src/runtime/HalideRuntimeMetal.h
+++ b/src/runtime/HalideRuntimeMetal.h
@@ -11,6 +11,8 @@ extern "C" {
  *  Routines specific to the Halide Metal runtime.
  */
 
+#define HALIDE_RUNTIME_METAL
+
 extern const struct halide_device_interface_t *halide_metal_device_interface();
 
 /** These are forward declared here to allow clients to override the

--- a/src/runtime/HalideRuntimeOpenCL.h
+++ b/src/runtime/HalideRuntimeOpenCL.h
@@ -11,6 +11,8 @@ extern "C" {
  *  Routines specific to the Halide OpenCL runtime.
  */
 
+#define HALIDE_RUNTIME_OPENCL
+
 extern const struct halide_device_interface_t *halide_opencl_device_interface();
 
 /** These are forward declared here to allow clients to override the

--- a/src/runtime/HalideRuntimeOpenGL.h
+++ b/src/runtime/HalideRuntimeOpenGL.h
@@ -11,6 +11,8 @@ extern "C" {
  *  Routines specific to the Halide OpenGL runtime.
  */
 
+#define HALIDE_RUNTIME_OPENGL
+
 extern const struct halide_device_interface_t *halide_opengl_device_interface();
 
 /** These are forward declared here to allow clients to override the

--- a/src/runtime/HalideRuntimeOpenGLCompute.h
+++ b/src/runtime/HalideRuntimeOpenGLCompute.h
@@ -11,6 +11,8 @@ extern "C" {
  *  Routines specific to the Halide OpenGL Compute runtime.
  */
 
+#define HALIDE_RUNTIME_OPENGLCOMPUTE
+
 extern const struct halide_device_interface_t *halide_openglcompute_device_interface();
 
 /** These are forward declared here to allow clients to override the

--- a/test/generator/gpu_only_aottest.cpp
+++ b/test/generator/gpu_only_aottest.cpp
@@ -12,6 +12,29 @@
 #include "gpu_only.h"
 using namespace Halide::Runtime;
 
+#if defined(TEST_OPENCL)
+
+#if !defined(HALIDE_RUNTIME_OPENCL)
+#error "TEST_OPENCL defined but HALIDE_RUNTIME_OPENCL not defined"
+#endif
+
+#elif defined(TEST_CUDA)
+
+#if !defined(HALIDE_RUNTIME_CUDA)
+#error "TEST_CUDA defined but HALIDE_RUNTIME_CUDA not defined"
+#endif
+
+#else
+
+#if defined(HALIDE_RUNTIME_OPENCL)
+#error "TEST_OPENCL not defined but HALIDE_RUNTIME_OPENCL defined"
+#endif
+#if defined(HALIDE_RUNTIME_CUDA)
+#error "TEST_CUDA not defined but HALIDE_RUNTIME_CUDA defined"
+#endif
+
+#endif
+
 int main(int argc, char **argv) {
 #if defined(TEST_OPENCL) || defined(TEST_CUDA)
     const int W = 32, H = 32;


### PR DESCRIPTION
This allows code including a pipeline to determine if the runtime is present at compile time.