### PR TITLE
Update Python bindings for Type

### DIFF
--- a/python_bindings/correctness/type.py
+++ b/python_bindings/correctness/type.py
@@ -1,0 +1,91 @@
+import halide as hl
+
+def test_type():
+    t1 = hl.Type()
+    assert t1.code() == hl.TypeCode.Handle
+    assert t1.bits() == 0
+    assert t1.lanes() == 0
+
+    t1 = hl.Type(hl.TypeCode.Int, 32, 1)
+    t2 = hl.Int(32)
+    assert t1 == t2
+    assert t2.code() == hl.TypeCode.Int
+    assert t2.bits() == 32
+    assert t2.lanes() == 1
+    assert t2.bytes() == 4
+
+    t1 = t2.with_code(hl.TypeCode.UInt)
+    assert t1 == hl.UInt(32)
+
+    t1 = t2.with_bits(16)
+    assert t1 == hl.Int(16)
+    assert t1 != t2
+
+    t1 = t2.with_lanes(8)
+    assert t1 == hl.Int(32, 8)
+    assert t1 != t2
+    assert t1.element_of() == hl.Int(32)
+
+    b1 = hl.Bool()
+    f32 = hl.Float(32)
+    h64 = hl.Handle()
+    i32 = hl.Int(32)
+    u32 = hl.UInt(32)
+    vi32x8 = hl.Int(32, 8)
+    u64 = hl.UInt(64)
+    i64 = hl.Int(64)
+
+    assert b1.is_bool()
+    assert f32.is_float()
+    assert h64.is_handle()
+    assert i32.is_int()
+    assert u32.is_uint()
+    assert i64.is_int()
+    assert u64.is_uint()
+
+    assert not vi32x8.is_scalar()
+    assert vi32x8.is_vector()
+
+    h2 = hl.Handle()
+    assert h64.same_handle_type(h2)
+
+    assert b1 < f32
+    assert not f32 < b1
+
+    assert f32.can_represent(b1)
+    assert not b1.can_represent(f32)
+
+    assert b1.max() == 1
+    assert b1.min() == 0
+    assert i32.max() == 2147483647
+    assert i32.min() == -2147483648
+
+    assert not b1.is_max(2)
+    assert b1.is_max(1)
+    assert b1.is_min(0)
+    assert not b1.is_min(-1)
+
+    assert i32.is_max(2147483647)
+    assert i32.is_min(-2147483648)
+
+    assert not u32.is_max(4294967296)
+    assert u32.is_max(4294967295)
+    assert u32.is_min(0)
+    assert not u32.is_min(-1)
+    assert not u32.is_min(1)
+
+    assert i64.is_max(9223372036854775807)
+    assert i64.is_min(-9223372036854775808)
+
+    # Python doesn't have unsigned integers, so we can't really express this value.
+    # assert u64.is_max(0xFFFFFFFFFFFFFFFF)
+    assert u64.is_min(0)
+
+    # repr() and str()
+    assert str(i32) == "int32"
+    assert repr(i32) == "<halide.Type int32>"
+    assert str(vi32x8) == "int32x8"
+    assert repr(vi32x8) == "<halide.Type int32x8>"
+
+if __name__ == "__main__":
+    test_type()

--- a/python_bindings/src/PyExpr.cpp
+++ b/python_bindings/src/PyExpr.cpp
@@ -34,12 +34,8 @@ std::vector<h::Expr> python_tuple_to_expr_vector(const p::object &obj) {
 }
 
 std::string expr_repr(const h::Expr &expr) {
-    std::string repr;
-    boost::format f("<halide.Expr of type '%s(%i)'>");
-
-    const h::Type &t = expr.type();
-    repr = boost::str(f % type_code_to_string(t) % t.bits());
-    return repr;
+    boost::format f("<halide.Expr of type %s>");
+    return boost::str(f % halide_type_to_string(expr.type()));
 }
 
 h::Expr *expr_from_var_constructor(h::Var &var) {

--- a/python_bindings/src/PyType.cpp
+++ b/python_bindings/src/PyType.cpp
@@ -14,6 +14,8 @@ using Halide::Int;
 using Halide::Type;
 using Halide::UInt;
 
+namespace py = boost::python;
+
 namespace {
 
 Halide::Type make_handle(int lanes) {
@@ -57,9 +59,6 @@ std::string halide_type_to_string(const Halide::Type &type) {
 }
 
 void define_type() {
-    using Halide::Type;
-    namespace p = boost::python;
-
     bool (Type::*can_represent_method)(Type) const = &Type::can_represent;
     // Python doesn't have unsigned integers -- all integers are signed --
     // so we'll never see anything that can usefully be routed to the uint64_t
@@ -67,8 +66,8 @@ void define_type() {
     bool (Type::*is_max_i)(int64_t) const = &Type::is_max;
     bool (Type::*is_min_i)(int64_t) const = &Type::is_min;
 
-    boost::python::class_<Type>("Type")
-        .def(boost::python::init<halide_type_code_t, int, int>())
+    py::class_<Type>("Type")
+        .def(py::init<halide_type_code_t, int, int>())
         .def("bytes", &Type::bytes)
         .def("code", &Type::code)
         .def("bits", &Type::bits)
@@ -85,9 +84,9 @@ void define_type() {
         .def("is_uint", &Type::is_uint)
         .def("is_handle", &Type::is_handle)
         .def("same_handle_type", &Type::same_handle_type)
-        .def(boost::python::self == boost::python::self)
-        .def(boost::python::self != boost::python::self)
-        .def(boost::python::self < boost::python::self)
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+        .def(py::self < py::self)
         .def("element_of", &Type::element_of)
         .def("can_represent", can_represent_method)
         .def("is_max", is_max_i)
@@ -98,13 +97,13 @@ void define_type() {
         .def("__str__", &halide_type_to_string)
     ;
 
-    boost::python::def("Int", Int, (boost::python::arg("bits"), boost::python::arg("lanes") = 1));
-    boost::python::def("UInt", UInt, (boost::python::arg("bits"), boost::python::arg("lanes") = 1));
-    boost::python::def("Float", Float, (boost::python::arg("bits"), boost::python::arg("lanes") = 1));
-    boost::python::def("Bool", Bool, (boost::python::arg("lanes") = 1));
-    boost::python::def("Handle", make_handle, (boost::python::arg("lanes") = 1));
+    py::def("Int", Int, (py::arg("bits"), py::arg("lanes") = 1));
+    py::def("UInt", UInt, (py::arg("bits"), py::arg("lanes") = 1));
+    py::def("Float", Float, (py::arg("bits"), py::arg("lanes") = 1));
+    py::def("Bool", Bool, (py::arg("lanes") = 1));
+    py::def("Handle", make_handle, (py::arg("lanes") = 1));
 
-    boost::python::enum_<halide_type_code_t>("TypeCode")
+    py::enum_<halide_type_code_t>("TypeCode")
         .value("Int", Type::Int)
         .value("UInt", Type::UInt)
         .value("Float", Type::Float)

--- a/python_bindings/src/PyType.cpp
+++ b/python_bindings/src/PyType.cpp
@@ -7,111 +7,107 @@
 
 #include "Halide.h"
 
-namespace h = Halide;
+using Halide::Bool;
+using Halide::Float;
+using Halide::Handle;
+using Halide::Int;
+using Halide::Type;
+using Halide::UInt;
 
-std::string type_code_to_string(const h::Type &t) {
-    std::string code_string = "unknown";
-    switch (t.code()) {
-    case h::Type::UInt:
-        code_string = "UInt";
-        break;
-
-    case h::Type::Int:
-        code_string = "Int";
-        break;
-
-    case h::Type::Float:
-        code_string = "Float";
-        break;
-
-    case h::Type::Handle:
-        code_string = "Handle";
-        break;
-
-    default:
-        code_string = "unknown";
-    }
-
-    return code_string;
-}
+namespace {
 
 Halide::Type make_handle(int lanes) {
-    return Halide::Handle(lanes, nullptr);
+    return Handle(lanes, nullptr);
 }
 
-std::string type_repr(const h::Type &t) {
-    auto message_format = boost::format("<halide.Type code '%s' with %i bits and %i lanes>");
+std::string type_repr(const Type &t) {
+    return boost::str(boost::format("<halide.Type %s>") % halide_type_to_string(t));
+}
 
-    return boost::str(message_format % type_code_to_string(t) % t.bits() % t.lanes());
+}  // namespace
+
+std::string halide_type_to_string(const Halide::Type &type) {
+    std::ostringstream stream;
+    if (type.code() == halide_type_uint && type.bits() == 1) {
+        stream << "bool";
+    } else {
+        switch (type.code()) {
+        case halide_type_int:
+            stream << "int";
+            break;
+        case halide_type_uint:
+            stream << "uint";
+            break;
+        case halide_type_float:
+            stream << "float";
+            break;
+        case halide_type_handle:
+            stream << "handle";
+            break;
+        default:
+            stream << "#unknown";
+            break;
+        }
+        stream << std::to_string(type.bits());
+    }
+    if (type.lanes() > 1) {
+        stream << "x" + std::to_string(type.lanes());
+    }
+    return stream.str();
 }
 
 void define_type() {
-
     using Halide::Type;
     namespace p = boost::python;
 
-    bool (Type::*can_represent_other_type)(Type) const = &Type::can_represent;
+    bool (Type::*can_represent_method)(Type) const = &Type::can_represent;
+    // Python doesn't have unsigned integers -- all integers are signed --
+    // so we'll never see anything that can usefully be routed to the uint64_t
+    // overloads of these methods.
+    bool (Type::*is_max_i)(int64_t) const = &Type::is_max;
+    bool (Type::*is_min_i)(int64_t) const = &Type::is_min;
 
-    p::class_<Type>("Type",
-                    "Default constructor initializes everything to predictable-but-unlikely values",
-                    p::no_init)
-        .def(p::init<halide_type_code_t, int, int>(p::args("code", "bits", "lanes")))
-        .def(p::init<h::Type>(p::args("that"), "Copy constructor"))
+    boost::python::class_<Type>("Type")
+        .def(boost::python::init<halide_type_code_t, int, int>())
+        .def("bytes", &Type::bytes)
+        .def("code", &Type::code)
+        .def("bits", &Type::bits)
+        .def("lanes", &Type::lanes)
+        .def("with_code", &Type::with_code)
+        .def("with_bits", &Type::with_bits)
+        .def("with_lanes", &Type::with_lanes)
 
-        .def("bits", &Type::bits,
-             "The number of bits of precision of a single scalar value of this type.")
-        .def("bytes", &Type::bytes,
-             "The number of bytes required to store a single scalar value of this type. Ignores vector lanes.")
-        .def("lanes", &Type::lanes,
-             "How many elements (if a vector type). Should be 1 for scalar types.")
-        .def("is_bool", &Type::is_bool, p::arg("self"),
-             "Is this type boolean (represented as UInt(1))?")
-        .def("is_vector", &Type::is_vector, p::arg("self"),
-             "Is this type a vector type? (lanes > 1)")
-        .def("is_scalar", &Type::is_scalar, p::arg("self"),
-             "Is this type a scalar type? (lanes == 1)")
-        .def("is_float", &Type::is_float, p::arg("self"),
-             "Is this type a floating point type (float or double).")
-        .def("is_int", &Type::is_int, p::arg("self"),
-             "Is this type a signed integer type?")
-        .def("is_uint", &Type::is_uint, p::arg("self"),
-             "Is this type an unsigned integer type?")
-        .def("is_handle", &Type::is_handle, p::arg("self"),
-             "Is this type an opaque handle type (void *)")
-        .def(p::self == p::self)
-        .def(p::self != p::self)
-        .def("with_lanes", &Type::with_lanes, p::args("self", "w"),
-             "Produce a copy of this type, with 'lanes' vector lanes")
-        .def("with_bits", &Type::with_bits, p::args("self", "w"),
-             "Produce a copy of this type, with 'bits' bits")
-        .def("element_of", &Type::element_of, p::arg("self"),
-             "Produce the type of a single element of this vector type")
-        .def("can_represent", can_represent_other_type, p::arg("other"),
-             "Can this type represent all values of another type?")
-        .def("max", &Type::max, p::arg("self"),
-             "Return an expression which is the maximum value of this type")
-        .def("min", &Type::min, p::arg("self"),
-             "Return an expression which is the minimum value of this type")
-        .def("__repr__", &type_repr, p::arg("self"),
-             "Return a string containing a printable representation of a Type object.");
+        .def("is_bool", &Type::is_bool)
+        .def("is_vector", &Type::is_vector)
+        .def("is_scalar", &Type::is_scalar)
+        .def("is_float", &Type::is_float)
+        .def("is_int", &Type::is_int)
+        .def("is_uint", &Type::is_uint)
+        .def("is_handle", &Type::is_handle)
+        .def("same_handle_type", &Type::same_handle_type)
+        .def(boost::python::self == boost::python::self)
+        .def(boost::python::self != boost::python::self)
+        .def(boost::python::self < boost::python::self)
+        .def("element_of", &Type::element_of)
+        .def("can_represent", can_represent_method)
+        .def("is_max", is_max_i)
+        .def("is_min", is_min_i)
+        .def("max", &Type::max)
+        .def("min", &Type::min)
+        .def("__repr__", &type_repr)
+        .def("__str__", &halide_type_to_string)
+    ;
 
-    p::def("Int", h::Int,
-           (p::arg("bits"), p::arg("lanes") = 1),
-           "Constructing an signed integer type");
+    boost::python::def("Int", Int, (boost::python::arg("bits"), boost::python::arg("lanes") = 1));
+    boost::python::def("UInt", UInt, (boost::python::arg("bits"), boost::python::arg("lanes") = 1));
+    boost::python::def("Float", Float, (boost::python::arg("bits"), boost::python::arg("lanes") = 1));
+    boost::python::def("Bool", Bool, (boost::python::arg("lanes") = 1));
+    boost::python::def("Handle", make_handle, (boost::python::arg("lanes") = 1));
 
-    p::def("UInt", h::UInt,
-           (p::arg("bits"), p::arg("lanes") = 1),
-           "Constructing an unsigned integer type");
-
-    p::def("Float", h::Float,
-           (p::arg("bits"), p::arg("lanes") = 1),
-           "Constructing a floating-point type");
-
-    p::def("Bool", h::Bool,
-           (p::arg("lanes") = 1),
-           "Construct a boolean type");
-
-    p::def("Handle", make_handle,
-           (p::arg("lanes") = 1),
-           "Construct a handle type");
+    boost::python::enum_<halide_type_code_t>("TypeCode")
+        .value("Int", Type::Int)
+        .value("UInt", Type::UInt)
+        .value("Float", Type::Float)
+        .value("Handle", Type::Handle);
+        // don't export_values(): we don't want the enums in the halide module
 }

--- a/python_bindings/src/PyType.h
+++ b/python_bindings/src/PyType.h
@@ -1,15 +1,10 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYTYPE_H
 #define HALIDE_PYTHON_BINDINGS_PYTYPE_H
 
-#include <string>
-
-namespace Halide {
-struct Type;  // forward declaration
-}
+#include "Halide.h"
 
 void define_type();
 
-std::string type_repr(const Halide::Type &t);  // helper function
-std::string type_code_to_string(const Halide::Type &t);
+std::string halide_type_to_string(const Halide::Type &type);
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYTYPE_H


### PR DESCRIPTION
Bring Python bindings for Halide::Type 100% up to date, with complete tests for all binding bits.