### PR TITLE
Remove spurious warning when shifting by (bits - 1).

### DIFF
--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -4303,9 +4303,6 @@ private:
                     } else {
                         return mutate(Div::make(a, b));
                     }
-                } else {
-                    user_warning << "Cannot replace bit shift with arithmetic "
-                                 << "operator (integer overflow).\n";
                 }
             }
 


### PR DESCRIPTION
We had a user encounter this warning when shifting a 16-bit integer by 15. This seems like it should be fine to do, and the code works as intended (even though we can't rewrite to a mul/div like we want to here).

We should maybe warn when the shift is >= bits (rather than >= bits - 1) instead of removing the warning entirely. However, this same user also had a case that did exactly this, and this warning did *not* fire, so something else is going on there.