### PR TITLE
Major namespace refactoring of python_bindings

### DIFF
--- a/python_bindings/src/PyArgument.cpp
+++ b/python_bindings/src/PyArgument.cpp
@@ -1,36 +1,29 @@
 #include "PyArgument.h"
 
-#include <boost/python.hpp>
-#include <string>
-
-#include "Halide.h"
-
-namespace h = Halide;
+namespace Halide {
+namespace PythonBindings {
 
 void define_argument() {
-    using Halide::Argument;
-    namespace p = boost::python;
-
     auto argument_class =
-        p::class_<Argument>("Argument",
+        py::class_<Argument>("Argument",
                             "A struct representing an argument to a halide-generated function. "
                             "Used for specifying the function signature of generated code.",
-                            p::init<>(p::arg("self")));
+                            py::init<>(py::arg("self")));
 
     argument_class
-        .def(p::init<std::string, Argument::Kind, h::Type, uint8_t, h::Expr, h::Expr, h::Expr>(
-            (p::arg("self"), p::arg("name"), p::arg("kind"), p::arg("type"), p::arg("dimensions"),
-             p::arg("default"), p::arg("min"), p::arg("max"))))
-        .def(p::init<std::string, Argument::Kind, h::Type, uint8_t, h::Expr>(
-            (p::arg("self"), p::arg("name"), p::arg("kind"), p::arg("type"), p::arg("dimensions"),
-             p::arg("default"))))
-        .def(p::init<std::string, Argument::Kind, h::Type, uint8_t>(
-            (p::arg("self"), p::arg("name"), p::arg("kind"), p::arg("type"), p::arg("dimensions"))));
+        .def(py::init<std::string, Argument::Kind, Type, uint8_t, Expr, Expr, Expr>(
+            (py::arg("self"), py::arg("name"), py::arg("kind"), py::arg("type"), py::arg("dimensions"),
+             py::arg("default"), py::arg("min"), py::arg("max"))))
+        .def(py::init<std::string, Argument::Kind, Type, uint8_t, Expr>(
+            (py::arg("self"), py::arg("name"), py::arg("kind"), py::arg("type"), py::arg("dimensions"),
+             py::arg("default"))))
+        .def(py::init<std::string, Argument::Kind, Type, uint8_t>(
+            (py::arg("self"), py::arg("name"), py::arg("kind"), py::arg("type"), py::arg("dimensions"))));
 
     argument_class
         .def_readonly("name", &Argument::name, "The name of the argument.");
 
-    p::enum_<Argument::Kind>("ArgumentKind")
+    py::enum_<Argument::Kind>("ArgumentKind")
         .value("InputScalar", Argument::Kind::InputScalar)
         .value("InputBuffer", Argument::Kind::InputBuffer)
         .value("OutputBuffer", Argument::Kind::OutputBuffer)
@@ -64,10 +57,13 @@ void define_argument() {
         .def_readonly("max", &Argument::max);
 
     argument_class
-        .def("is_buffer", &Argument::is_buffer, p::arg("self"),
+        .def("is_buffer", &Argument::is_buffer, py::arg("self"),
              "An argument is either a primitive type (for parameters), or a buffer pointer. "
              "If 'is_buffer' is true, then 'type' should be ignored.")
-        .def("is_scalar", &Argument::is_scalar, p::arg("self"))
-        .def("is_input", &Argument::is_input, p::arg("self"))
-        .def("is_output", &Argument::is_output, p::arg("self"));
+        .def("is_scalar", &Argument::is_scalar, py::arg("self"))
+        .def("is_input", &Argument::is_input, py::arg("self"))
+        .def("is_output", &Argument::is_output, py::arg("self"));
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyArgument.h
+++ b/python_bindings/src/PyArgument.h
@@ -1,6 +1,14 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYARGUMENT_H
 #define HALIDE_PYTHON_BINDINGS_PYARGUMENT_H
 
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
 void define_argument();
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYARGUMENT_H

--- a/python_bindings/src/PyBinaryOperators.h
+++ b/python_bindings/src/PyBinaryOperators.h
@@ -1,19 +1,19 @@
 #ifndef HALIDE_PYTHON_BINDINGS_add_binary_operators_H
 #define HALIDE_PYTHON_BINDINGS_add_binary_operators_H
 
-#include <boost/python/operators.hpp>
-#include <boost/python/self.hpp>
+#include "PyHalide.h"
 
-#include "Halide.h"
+namespace Halide {
+namespace PythonBindings {
 
 // Note that we deliberately produce different semantics for division in Python3:
 // to match Halide C++ division semantics, a signed-integer division is always
 // a floordiv rather than a truediv.
 template <typename A, typename B>
 auto floordiv(A a, B b) -> decltype(a / b) {
-    static_assert(std::is_same<decltype(a / b), Halide::Expr>::value,
-                  "We expect all operator// overloads to produce Halide::Expr");
-    Halide::Expr e = a / b;
+    static_assert(std::is_same<decltype(a / b), Expr>::value,
+                  "We expect all operator// overloads to produce Expr");
+    Expr e = a / b;
     if (e.type().is_float()) {
         e = Halide::floor(e);
     }
@@ -22,59 +22,56 @@ auto floordiv(A a, B b) -> decltype(a / b) {
 
 template <typename T, typename PythonClass>
 void add_binary_operators_with(PythonClass &class_instance) {
-    using namespace boost::python;
-
     using wrapped_t = typename PythonClass::wrapped_type;
 
-    // <boost/python/operators.hpp> lists all operators
     class_instance
-        .def(self + other<T>())
-        .def(other<T>() + self)
+        .def(py::self + py::other<T>())
+        .def(py::other<T>() + py::self)
 
-        .def(self - other<T>())
-        .def(other<T>() - self)
+        .def(py::self - py::other<T>())
+        .def(py::other<T>() - py::self)
 
-        .def(self * other<T>())
-        .def(other<T>() * self)
+        .def(py::self * py::other<T>())
+        .def(py::other<T>() * py::self)
 
-        .def(self / other<T>())
-        .def(other<T>() / self)
+        .def(py::self / py::other<T>())
+        .def(py::other<T>() / py::self)
 
-        .def(self % other<T>())
-        .def(other<T>() % self)
+        .def(py::self % py::other<T>())
+        .def(py::other<T>() % py::self)
 
-        .def(pow(self, other<T>()))
-        .def(pow(other<T>(), self))
+        .def(pow(py::self, py::other<T>()))
+        .def(pow(py::other<T>(), py::self))
 
-        .def(self & other<T>())  // and
-        .def(other<T>() & self)
+        .def(py::self & py::other<T>())  // and
+        .def(py::other<T>() & py::self)
 
-        .def(self | other<T>())  // or
-        .def(other<T>() | self)
+        .def(py::self | py::other<T>())  // or
+        .def(py::other<T>() | py::self)
 
-        .def(self < other<T>())
-        .def(other<T>() < self)
+        .def(py::self < py::other<T>())
+        .def(py::other<T>() < py::self)
 
-        .def(self <= other<T>())
-        .def(other<T>() <= self)
+        .def(py::self <= py::other<T>())
+        .def(py::other<T>() <= py::self)
 
-        .def(self == other<T>())
-        .def(other<T>() == self)
+        .def(py::self == py::other<T>())
+        .def(py::other<T>() == py::self)
 
-        .def(self != other<T>())
-        .def(other<T>() != self)
+        .def(py::self != py::other<T>())
+        .def(py::other<T>() != py::self)
 
-        .def(self > other<T>())
-        .def(other<T>() > self)
+        .def(py::self > py::other<T>())
+        .def(py::other<T>() > py::self)
 
-        .def(self >= other<T>())
-        .def(other<T>() >= self)
+        .def(py::self >= py::other<T>())
+        .def(py::other<T>() >= py::self)
 
-        .def(self >> other<T>())
-        .def(other<T>() >> self)
+        .def(py::self >> py::other<T>())
+        .def(py::other<T>() >> py::self)
 
-        .def(self << other<T>())
-        .def(other<T>() << self)
+        .def(py::self << py::other<T>())
+        .def(py::other<T>() << py::self)
 
         .def("__floordiv__", &floordiv<wrapped_t, T>)
         .def("__floordiv__", &floordiv<T, wrapped_t>)
@@ -84,8 +81,6 @@ void add_binary_operators_with(PythonClass &class_instance) {
 
 template <typename PythonClass>
 void add_binary_operators(PythonClass &class_instance) {
-    using namespace boost::python;
-
     using wrapped_t = typename PythonClass::wrapped_type;
 
     // The order of definitions matters.
@@ -95,14 +90,16 @@ void add_binary_operators(PythonClass &class_instance) {
     add_binary_operators_with<int>(class_instance);
 
     // Define unary operators
-    // <boost/python/operators.hpp> lists all operators
     class_instance
-        .def(-self)  // neg
-        //.def(+self) // pos
-        .def(~self)  // invert
-        //.def(abs(self))
-        //.def(!!self) // nonzero
+        .def(-py::self)  // neg
+        //.def(+py::self) // pos
+        .def(~py::self)  // invert
+        //.def(abs(py::self))
+        //.def(!!py::self) // nonzero
         ;
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_add_binary_operators_H

--- a/python_bindings/src/PyBoundaryConditions.cpp
+++ b/python_bindings/src/PyBoundaryConditions.cpp
@@ -1,48 +1,43 @@
 #include "PyBoundaryConditions.h"
 
 #include <algorithm>
-#include <boost/python.hpp>
-#include <boost/python/stl_iterator.hpp>
-#include <string>
-#include <vector>
 
-#include "Halide.h"
+namespace Halide {
+namespace PythonBindings {
 
-namespace h = Halide;
 namespace hb = Halide::BoundaryConditions;
-namespace p = boost::python;
 
 template <typename T, typename S>
-inline std::pair<T, S> to_pair(const p::object &iterable) {
-    return std::pair<T, S>(p::extract<T>(iterable[0]), p::extract<T>(iterable[1]));
+inline std::pair<T, S> to_pair(const py::object &iterable) {
+    return std::pair<T, S>(py::extract<T>(iterable[0]), py::extract<T>(iterable[1]));
 }
 
 template <typename T>
-inline std::vector<T> to_vector(const p::object &iterable) {
-    return std::vector<T>(p::stl_input_iterator<T>(iterable), p::stl_input_iterator<T>());
+inline std::vector<T> to_vector(const py::object &iterable) {
+    return std::vector<T>(py::stl_input_iterator<T>(iterable), py::stl_input_iterator<T>());
 }
 
-std::vector<std::pair<h::Expr, h::Expr>> inline pyobject_to_bounds(const p::object &pybounds) {
-    std::vector<p::object> intermediate = to_vector<p::object>(pybounds);
-    std::vector<std::pair<h::Expr, h::Expr>> result(intermediate.size());
-    std::transform(intermediate.begin(), intermediate.end(), result.begin(), to_pair<h::Expr, h::Expr>);
+std::vector<std::pair<Expr, Expr>> inline pyobject_to_bounds(const py::object &pybounds) {
+    std::vector<py::object> intermediate = to_vector<py::object>(pybounds);
+    std::vector<std::pair<Expr, Expr>> result(intermediate.size());
+    std::transform(intermediate.begin(), intermediate.end(), result.begin(), to_pair<Expr, Expr>);
     return result;
 }
 
 namespace {
 
 template <typename T>
-h::Func constant_exterior0(T func_like, h::Expr value) {
+Func constant_exterior0(T func_like, Expr value) {
     return hb::constant_exterior(func_like, value);
 }
 
-h::Func constant_exterior_bounds(h::Func func, h::Expr value, p::object bounds_) {
+Func constant_exterior_bounds(Func func, Expr value, py::object bounds_) {
     return hb::constant_exterior(func, value, pyobject_to_bounds(bounds_));
 }
 
 template <typename T = void, typename... Types>
 void def_constant_exterior_for_image() {
-    p::def("constant_exterior", &constant_exterior0<h::Buffer<T>>, p::args("source", "value"));
+    py::def("constant_exterior", &constant_exterior0<Buffer<T>>, py::args("source", "value"));
     def_constant_exterior_for_image<Types...>();  // recursive call
 }
 
@@ -56,17 +51,17 @@ void def_constant_exterior_for_image<void>() {  // end of recursion
 namespace {
 
 template <typename T>
-h::Func repeat_edge0(T func_like) {
+Func repeat_edge0(T func_like) {
     return hb::repeat_edge(func_like);
 }
 
-h::Func repeat_edge_bounds(h::Func func, p::object bounds_) {
+Func repeat_edge_bounds(Func func, py::object bounds_) {
     return hb::repeat_edge(func, pyobject_to_bounds(bounds_));
 }
 
 template <typename T = void, typename... Types>
 void def_repeat_edge_for_image() {
-    p::def("repeat_edge", &repeat_edge0<h::Buffer<T>>, p::args("source"));
+    py::def("repeat_edge", &repeat_edge0<Buffer<T>>, py::args("source"));
     def_repeat_edge_for_image<Types...>();  // recursive call
 }
 
@@ -80,17 +75,17 @@ void def_repeat_edge_for_image<void>() {  // end of recursion
 namespace {
 
 template <typename T>
-h::Func repeat_image0(T func_like) {
+Func repeat_image0(T func_like) {
     return hb::repeat_image(func_like);
 }
 
-h::Func repeat_image_bounds(h::Func func, p::object bounds_) {
+Func repeat_image_bounds(Func func, py::object bounds_) {
     return hb::repeat_image(func, pyobject_to_bounds(bounds_));
 }
 
 template <typename T = void, typename... Types>
 void def_repeat_image_for_image() {
-    p::def("repeat_image", &repeat_image0<h::Buffer<T>>, p::args("source"));
+    py::def("repeat_image", &repeat_image0<Buffer<T>>, py::args("source"));
     def_repeat_image_for_image<Types...>();  // recursive call
 }
 
@@ -104,17 +99,17 @@ void def_repeat_image_for_image<void>() {  // end of recursion
 namespace {
 
 template <typename T>
-h::Func mirror_image0(T func_like) {
+Func mirror_image0(T func_like) {
     return hb::mirror_image(func_like);
 }
 
-h::Func mirror_image_bounds(h::Func func, p::object bounds_) {
+Func mirror_image_bounds(Func func, py::object bounds_) {
     return hb::mirror_image(func, pyobject_to_bounds(bounds_));
 }
 
 template <typename T = void, typename... Types>
 void def_mirror_image_for_image() {
-    p::def("mirror_image", &mirror_image0<h::Buffer<T>>, p::args("source"));
+    py::def("mirror_image", &mirror_image0<Buffer<T>>, py::args("source"));
     def_mirror_image_for_image<Types...>();  // recursive call
 }
 
@@ -128,17 +123,17 @@ void def_mirror_image_for_image<void>() {  // end of recursion
 namespace {
 
 template <typename T>
-h::Func mirror_interior0(T func_like) {
+Func mirror_interior0(T func_like) {
     return hb::mirror_interior(func_like);
 }
 
-h::Func mirror_interior_bounds(h::Func func, p::object bounds_) {
+Func mirror_interior_bounds(Func func, py::object bounds_) {
     return hb::mirror_interior(func, pyobject_to_bounds(bounds_));
 }
 
 template <typename T = void, typename... Types>
 void def_mirror_interior_for_image() {
-    p::def("mirror_interior", &mirror_interior0<h::Buffer<T>>, p::args("source"));
+    py::def("mirror_interior", &mirror_interior0<Buffer<T>>, py::args("source"));
     def_mirror_interior_for_image<Types...>();  // recursive call
 }
 
@@ -152,7 +147,7 @@ void def_mirror_interior_for_image<void>() {  // end of recursion
 void define_boundary_conditions() {
     // constant_exterior
 
-    p::def("constant_exterior", &constant_exterior0<h::ImageParam>, p::args("source", "value"),
+    py::def("constant_exterior", &constant_exterior0<ImageParam>, py::args("source", "value"),
            "Impose a boundary condition such that a given expression is returned "
            "everywhere outside the boundary. Generally the expression will be a "
            "constant, though the code currently allows accessing the arguments  "
@@ -163,16 +158,17 @@ void define_boundary_conditions() {
            "(This is similar to setting GL_TEXTURE_WRAP_* to GL_CLAMP_TO_BORDER  "
            " and putting value in the border of the texture.) ");
 
+    // TODO: need int64, uint64, bool
     def_constant_exterior_for_image<
-        boost::uint8_t, boost::uint16_t, boost::uint32_t,
-        boost::int8_t, boost::int16_t, boost::int32_t,
+        uint8_t, uint16_t, uint32_t,
+        int8_t, int16_t, int32_t,
         float, double>();
 
-    p::def("constant_exterior", &constant_exterior_bounds, p::args("source", "value", "bounds"));
+    py::def("constant_exterior", &constant_exterior_bounds, py::args("source", "value", "bounds"));
 
     // repeat_edge
 
-    p::def("repeat_edge", &repeat_edge0<h::ImageParam>, p::args("source"),
+    py::def("repeat_edge", &repeat_edge0<ImageParam>, py::args("source"),
            "Impose a boundary condition such that the nearest edge sample is returned "
            "everywhere outside the given region.\n\n"
            "An ImageParam, Buffer<T>, or similar can be passed instead of a Func. If this "
@@ -181,15 +177,15 @@ void define_boundary_conditions() {
            "(This is similar to setting GL_TEXTURE_WRAP_* to GL_CLAMP_TO_EDGE.)");
 
     def_repeat_edge_for_image<
-        boost::uint8_t, boost::uint16_t, boost::uint32_t,
-        boost::int8_t, boost::int16_t, boost::int32_t,
+        uint8_t, uint16_t, uint32_t,
+        int8_t, int16_t, int32_t,
         float, double>();
 
-    p::def("repeat_edge", &repeat_edge_bounds, p::args("source", "bounds"));
+    py::def("repeat_edge", &repeat_edge_bounds, py::args("source", "bounds"));
 
     // repeat_image
 
-    p::def("repeat_image", &repeat_image0<h::ImageParam>, p::args("source"),
+    py::def("repeat_image", &repeat_image0<ImageParam>, py::args("source"),
            "Impose a boundary condition such that the entire coordinate space is "
            "tiled with copies of the image abutted against each other.\n\n"
            "An ImageParam, Buffer<T>, or similar can be passed instead of a Func. If this "
@@ -198,15 +194,15 @@ void define_boundary_conditions() {
            "(This is similar to setting GL_TEXTURE_WRAP_* to GL_REPEAT.)");
 
     def_repeat_image_for_image<
-        boost::uint8_t, boost::uint16_t, boost::uint32_t,
-        boost::int8_t, boost::int16_t, boost::int32_t,
+        uint8_t, uint16_t, uint32_t,
+        int8_t, int16_t, int32_t,
         float, double>();
 
-    p::def("repeat_image", &repeat_image_bounds, p::args("source", "bounds"));
+    py::def("repeat_image", &repeat_image_bounds, py::args("source", "bounds"));
 
     // mirror_image
 
-    p::def("mirror_image", &mirror_image0<h::ImageParam>, p::args("source"),
+    py::def("mirror_image", &mirror_image0<ImageParam>, py::args("source"),
            "Impose a boundary condition such that the entire coordinate space is "
            "tiled with copies of the image abutted against each other, but mirror "
            "them such that adjacent edges are the same.\n\n"
@@ -216,15 +212,15 @@ void define_boundary_conditions() {
            "(This is similar to setting GL_TEXTURE_WRAP_* to GL_MIRRORED_REPEAT.)");
 
     def_mirror_image_for_image<
-        boost::uint8_t, boost::uint16_t, boost::uint32_t,
-        boost::int8_t, boost::int16_t, boost::int32_t,
+        uint8_t, uint16_t, uint32_t,
+        int8_t, int16_t, int32_t,
         float, double>();
 
-    p::def("mirror_image", &mirror_image_bounds, p::args("source", "bounds"));
+    py::def("mirror_image", &mirror_image_bounds, py::args("source", "bounds"));
 
     // mirror_interior
 
-    p::def("mirror_interior", &mirror_interior0<h::ImageParam>, p::args("source"),
+    py::def("mirror_interior", &mirror_interior0<ImageParam>, py::args("source"),
            "Impose a boundary condition such that the entire coordinate space is "
            "tiled with copies of the image abutted against each other, but mirror "
            "them such that adjacent edges are the same and then overlap the edges.\n\n"
@@ -235,9 +231,12 @@ void define_boundary_conditions() {
            "(I do not believe there is a direct GL_TEXTURE_WRAP_* equivalent for this.)");
 
     def_mirror_interior_for_image<
-        boost::uint8_t, boost::uint16_t, boost::uint32_t,
-        boost::int8_t, boost::int16_t, boost::int32_t,
+        uint8_t, uint16_t, uint32_t,
+        int8_t, int16_t, int32_t,
         float, double>();
 
-    p::def("mirror_interior", &mirror_interior_bounds, p::args("source", "bounds"));
+    py::def("mirror_interior", &mirror_interior_bounds, py::args("source", "bounds"));
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyBoundaryConditions.h
+++ b/python_bindings/src/PyBoundaryConditions.h
@@ -1,6 +1,14 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYBOUNDARYCONDITIONS_H
 #define HALIDE_PYTHON_BINDINGS_PYBOUNDARYCONDITIONS_H
 
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
 void define_boundary_conditions();
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYBOUNDARYCONDITIONS_H

--- a/python_bindings/src/PyBuffer.cpp
+++ b/python_bindings/src/PyBuffer.cpp
@@ -1,16 +1,7 @@
 #include "PyBuffer.h"
 
-#include <boost/cstdint.hpp>
-#include <boost/format.hpp>
-#include <boost/functional/hash/hash.hpp>
-#include <boost/mpl/list.hpp>
-#include <boost/python.hpp>
 #include <functional>
-#include <string>
 #include <unordered_map>
-#include <vector>
-
-#include "Halide.h"
 
 #include "PyFunc.h"
 #include "PyType.h"
@@ -24,8 +15,8 @@
 #endif
 #endif  // USE_NUMPY
 
-namespace h = Halide;
-namespace p = boost::python;
+namespace Halide {
+namespace PythonBindings {
 
 #ifdef USE_NUMPY
 #ifdef USE_BOOST_NUMPY
@@ -36,46 +27,46 @@ namespace bn = Halide::numpy;
 #endif  // USE_NUMPY
 
 template <typename Ret, typename T, typename... Args>
-Ret buffer_call_operator(h::Buffer<T> &that, Args... args) {
+Ret buffer_call_operator(Buffer<T> &that, Args... args) {
     return that(args...);
 }
 
 template <typename T>
-h::Expr buffer_call_operator_tuple(h::Buffer<T> &that, p::tuple &args_passed) {
-    std::vector<h::Expr> expr_args;
-    for (ssize_t i = 0; i < p::len(args_passed); i++) {
-        expr_args.push_back(p::extract<h::Expr>(args_passed[i]));
+Expr buffer_call_operator_tuple(Buffer<T> &that, py::tuple &args_passed) {
+    std::vector<Expr> expr_args;
+    for (ssize_t i = 0; i < py::len(args_passed); i++) {
+        expr_args.push_back(py::extract<Expr>(args_passed[i]));
     }
     return that(expr_args);
 }
 
 template <typename T>
-T buffer_to_setitem_operator0(h::Buffer<T> &that, int x, T value) {
+T buffer_to_setitem_operator0(Buffer<T> &that, int x, T value) {
     return that(x) = value;
 }
 
 template <typename T>
-T buffer_to_setitem_operator1(h::Buffer<T> &that, int x, int y, T value) {
+T buffer_to_setitem_operator1(Buffer<T> &that, int x, int y, T value) {
     return that(x, y) = value;
 }
 
 template <typename T>
-T buffer_to_setitem_operator2(h::Buffer<T> &that, int x, int y, int z, T value) {
+T buffer_to_setitem_operator2(Buffer<T> &that, int x, int y, int z, T value) {
     return that(x, y, z) = value;
 }
 
 template <typename T>
-T buffer_to_setitem_operator3(h::Buffer<T> &that, int x, int y, int z, int w, T value) {
+T buffer_to_setitem_operator3(Buffer<T> &that, int x, int y, int z, int w, T value) {
     return that(x, y, z, w) = value;
 }
 
 template <typename T>
-T buffer_to_setitem_operator4(h::Buffer<T> &that, p::tuple &args_passed, T value) {
+T buffer_to_setitem_operator4(Buffer<T> &that, py::tuple &args_passed, T value) {
     std::vector<int> int_args;
-    const size_t args_len = p::len(args_passed);
+    const size_t args_len = py::len(args_passed);
     for (size_t i = 0; i < args_len; i += 1) {
-        p::object o = args_passed[i];
-        p::extract<int> int32_extract(o);
+        py::object o = args_passed[i];
+        py::extract<int> int32_extract(o);
 
         if (int32_extract.check()) {
             int_args.push_back(int32_extract());
@@ -84,8 +75,8 @@ T buffer_to_setitem_operator4(h::Buffer<T> &that, p::tuple &args_passed, T value
 
     if (int_args.size() != args_len) {
         for (size_t j = 0; j < args_len; j += 1) {
-            p::object o = args_passed[j];
-            const std::string o_str = p::extract<std::string>(p::str(o));
+            py::object o = args_passed[j];
+            const std::string o_str = py::extract<std::string>(py::str(o));
             printf("buffer_to_setitem_operator4 args_passed[%lu] == %s\n", j, o_str.c_str());
         }
         throw std::invalid_argument("buffer_to_setitem_operator4 only handles "
@@ -110,139 +101,148 @@ T buffer_to_setitem_operator4(h::Buffer<T> &that, p::tuple &args_passed, T value
 }
 
 template <typename T>
-const T *buffer_data(const h::Buffer<T> &buffer) {
+const T *buffer_data(const Buffer<T> &buffer) {
     return buffer.data();
 }
 
 template <typename T>
-void buffer_set_min1(h::Buffer<T> &im, int m0) {
+void buffer_set_min1(Buffer<T> &im, int m0) {
     im.set_min(m0);
 }
 
 template <typename T>
-void buffer_set_min2(h::Buffer<T> &im, int m0, int m1) {
+void buffer_set_min2(Buffer<T> &im, int m0, int m1) {
     im.set_min(m0, m1);
 }
 
 template <typename T>
-void buffer_set_min3(h::Buffer<T> &im, int m0, int m1, int m2) {
+void buffer_set_min3(Buffer<T> &im, int m0, int m1, int m2) {
     im.set_min(m0, m1, m2);
 }
 
 template <typename T>
-void buffer_set_min4(h::Buffer<T> &im, int m0, int m1, int m2, int m3) {
+void buffer_set_min4(Buffer<T> &im, int m0, int m1, int m2, int m3) {
     im.set_min(m0, m1, m2, m3);
 }
 
-template <typename T>
-std::string buffer_repr(const h::Buffer<T> &buffer) {
-    std::string repr;
+// Standard stream output for halide_dimension_t
+std::ostream &operator<<(std::ostream &stream, const halide_dimension_t &d) {
+    stream << "[" << d.min << "," << d.extent << "," << d.stride << "]";
+    return stream;
+}
 
-    h::Type t = halide_type_of<T>();
-    std::string suffix = "_???";
-    if (t.is_float()) {
-        suffix = "_float";
-    } else if (t.is_int()) {
-        suffix = "_int";
-    } else if (t.is_uint()) {
-        suffix = "_uint";
-    } else if (t.is_bool()) {
-        suffix = "_bool";
-    } else if (t.is_handle()) {
-        suffix = "_handle";
+// Standard stream output for vector<halide_dimension_t>
+std::ostream &operator<<(std::ostream &stream, const std::vector<halide_dimension_t> &shape) {
+    stream << "[";
+    bool need_comma = false;
+    for (auto &d : shape) {
+        if (need_comma) {
+            stream << ',';
+        }
+        stream << d;
+        need_comma = true;
     }
+    stream << "]";
+    return stream;
+}
 
-    boost::format f("<halide.Buffer%s%i; element_size %i bytes; "
-                    "extent (%i %i %i %i); min (%i %i %i %i); stride (%i %i %i %i)>");
-
-    repr = boost::str(f % suffix % t.bits() % t.bytes() % buffer.extent(0) % buffer.extent(1) % buffer.extent(2) % buffer.extent(3) % buffer.min(0) % buffer.min(1) % buffer.min(2) % buffer.min(3) % buffer.stride(0) % buffer.stride(1) % buffer.stride(2) % buffer.stride(3));
-
-    return repr;
+// Given a Buffer<>, return its shape in the form of a vector<halide_dimension_t>.
+// (Oddly, Buffer<> has no API to do this directly.)
+std::vector<halide_dimension_t> get_buffer_shape(const Buffer<> &b) {
+    std::vector<halide_dimension_t> s;
+    for (int i = 0; i < b.dimensions(); ++i) {
+        s.push_back(b.raw_buffer()->dim[i]);
+    }
+    return s;
 }
 
 template <typename T>
-boost::python::object get_type_function_wrapper() {
-    std::function<h::Type(h::Buffer<T> &)> return_type_func =
-        [&](h::Buffer<T> &that) -> h::Type { return halide_type_of<T>(); };
-    auto call_policies = p::default_call_policies();
-    typedef boost::mpl::vector<h::Type, h::Buffer<T> &> func_sig;
-    return p::make_function(return_type_func, call_policies, p::arg("self"), func_sig());
+std::string buffer_repr(const Buffer<T> &buffer) {
+    std::ostringstream o;
+    o << "<halide.Buffer<" << halide_type_to_string(buffer.type()) << "> shape:" << get_buffer_shape(buffer) << ">";
+    return o.str();
 }
 
 template <typename T>
-void buffer_copy_to_host(h::Buffer<T> &im) {
+py::object get_type_function_wrapper() {
+    std::function<Type(Buffer<T> &)> return_type_func =
+        [&](Buffer<T> &that) -> Type { return halide_type_of<T>(); };
+    auto call_policies = py::default_call_policies();
+    typedef boost::mpl::vector<Type, Buffer<T> &> func_sig;
+    return py::make_function(return_type_func, call_policies, py::arg("self"), func_sig());
+}
+
+template <typename T>
+void buffer_copy_to_host(Buffer<T> &im) {
     im.copy_to_host();
 }
 
 template <typename T>
-void buffer_set_host_dirty(h::Buffer<T> &im, bool value) {
+void buffer_set_host_dirty(Buffer<T> &im, bool value) {
     im.set_host_dirty(value);
 }
 
 template <typename T>
-int buffer_channels(h::Buffer<T> &im) {
+int buffer_channels(Buffer<T> &im) {
     return im.channels();
 }
 
 template <typename T>
-int buffer_width(h::Buffer<T> &im) {
+int buffer_width(Buffer<T> &im) {
     return im.width();
 }
 
 template <typename T>
-int buffer_height(h::Buffer<T> &im) {
+int buffer_height(Buffer<T> &im) {
     return im.height();
 }
 
 template <typename T>
-int buffer_dimensions(h::Buffer<T> &im) {
+int buffer_dimensions(Buffer<T> &im) {
     return im.dimensions();
 }
 
 template <typename T>
-int buffer_left(h::Buffer<T> &im) {
+int buffer_left(Buffer<T> &im) {
     return im.left();
 }
 
 template <typename T>
-int buffer_right(h::Buffer<T> &im) {
+int buffer_right(Buffer<T> &im) {
     return im.right();
 }
 
 template <typename T>
-int buffer_top(h::Buffer<T> &im) {
+int buffer_top(Buffer<T> &im) {
     return im.top();
 }
 
 template <typename T>
-int buffer_bottom(h::Buffer<T> &im) {
+int buffer_bottom(Buffer<T> &im) {
     return im.bottom();
 }
 
 template <typename T>
-int buffer_stride(h::Buffer<T> &im, int d) {
+int buffer_stride(Buffer<T> &im, int d) {
     return im.stride(d);
 }
 
 template <typename T>
-int buffer_min(h::Buffer<T> &im, int d) {
+int buffer_min(Buffer<T> &im, int d) {
     return im.min(d);
 }
 
 template <typename T>
-int buffer_extent(h::Buffer<T> &im, int d) {
+int buffer_extent(Buffer<T> &im, int d) {
     return im.extent(d);
 }
 
 
 
 template <typename T>
-void define_buffer_impl(const std::string suffix, const h::Type type) {
-    using h::Buffer;
-    using h::Expr;
-
+void define_buffer_impl(const std::string suffix, const Type type) {
     auto buffer_class =
-        p::class_<Buffer<T>>(
+        py::class_<Buffer<T>>(
             ("Buffer" + suffix).c_str(),
             "A reference-counted handle on a dense multidimensional array "
             "containing scalar values of type T. Can be directly accessed and "
@@ -251,103 +251,103 @@ void define_buffer_impl(const std::string suffix, const h::Type type) {
             "the color channel. In general we store color images in "
             "color-planes, as opposed to packed RGB, because this tends to "
             "vectorize more cleanly.",
-            p::init<>(p::arg("self"), "Construct an undefined buffer handle"));
+            py::init<>(py::arg("self"), "Construct an undefined buffer handle"));
 
     // Constructors
     buffer_class
-        .def(p::init<int>(
-            p::args("self", "x"),
+        .def(py::init<int>(
+            py::args("self", "x"),
             "Allocate an buffer with the given dimensions."))
 
-        .def(p::init<int, int>(
-            p::args("self", "x", "y"),
+        .def(py::init<int, int>(
+            py::args("self", "x", "y"),
             "Allocate an buffer with the given dimensions."))
 
-        .def(p::init<int, int, int>(
-            p::args("self", "x", "y", "z"),
+        .def(py::init<int, int, int>(
+            py::args("self", "x", "y", "z"),
             "Allocate an buffer with the given dimensions."))
 
-        .def(p::init<int, int, int, int>(
-            p::args("self", "x", "y", "z", "w"),
+        .def(py::init<int, int, int, int>(
+            py::args("self", "x", "y", "z", "w"),
             "Allocate an buffer with the given dimensions."))
 
-        .def(p::init<h::Realization &>(
-            p::args("self", "r"),
+        .def(py::init<Realization &>(
+            py::args("self", "r"),
             "Wrap a single-element realization in an Buffer object."))
 
-        .def(p::init<halide_buffer_t>(
-            p::args("self", "b"),
+        .def(py::init<halide_buffer_t>(
+            py::args("self", "b"),
             "Wrap a halide_buffer_t in an Buffer object, so that we can access its pixels."));
 
     buffer_class
-        .def("__repr__", buffer_repr<T>, p::arg("self"));
+        .def("__repr__", buffer_repr<T>, py::arg("self"));
 
     buffer_class
-        .def("data", buffer_data<T>, p::arg("self"),
-             p::return_value_policy<p::return_opaque_pointer>(),  // not sure this will do what we want
+        .def("data", buffer_data<T>, py::arg("self"),
+             py::return_value_policy<py::return_opaque_pointer>(),  // not sure this will do what we want
              "Get a pointer to the element at the min location.")
 
-        .def("copy_to_host", buffer_copy_to_host<T>, p::arg("self"),
+        .def("copy_to_host", buffer_copy_to_host<T>, py::arg("self"),
              "Manually copy-back data to the host, if it's on a device. ")
         .def("set_host_dirty", buffer_set_host_dirty<T>,
-             (p::arg("self"), p::arg("dirty") = true),
+             (py::arg("self"), py::arg("dirty") = true),
              "Mark the buffer as dirty-on-host. ")
         .def("type", get_type_function_wrapper<T>(),
              "Return Type instance for the data type of the buffer.")
-        .def("channels", buffer_channels<T>, p::arg("self"),
+        .def("channels", buffer_channels<T>, py::arg("self"),
              "Get the extent of dimension 2, which by convention we use as"
              "the number of color channels (often 3). Unlike extent(2), "
              "returns one if the buffer has fewer than three dimensions.")
-        .def("dimensions", buffer_dimensions<T>, p::arg("self"),
+        .def("dimensions", buffer_dimensions<T>, py::arg("self"),
              "Get the dimensionality of the data. Typically two for grayscale images, and three for color images.")
-        .def("stride", buffer_stride<T>, p::args("self", "dim"),
+        .def("stride", buffer_stride<T>, py::args("self", "dim"),
              "Get the number of elements in the buffer between two adjacent "
              "elements in the given dimension. For example, the stride in "
              "dimension 0 is usually 1, and the stride in dimension 1 is "
              "usually the extent of dimension 0. This is not necessarily true though.")
-        .def("extent", buffer_extent<T>, p::args("self", "dim"),
+        .def("extent", buffer_extent<T>, py::args("self", "dim"),
              "Get the size of a dimension.")
-        .def("min", buffer_min<T>, p::args("self", "dim"),
+        .def("min", buffer_min<T>, py::args("self", "dim"),
              "Get the min coordinate of a dimension. The top left of the "
              "buffer represents this point in a function that was realized "
              "into this buffer.");
 
     buffer_class
         .def("set_min", buffer_set_min1<T>,
-             p::args("self", "m0"),
+             py::args("self", "m0"),
              "Set the coordinates corresponding to the host pointer.")
         .def("set_min", buffer_set_min2<T>,
-             p::args("self", "m0", "m1"),
+             py::args("self", "m0", "m1"),
              "Set the coordinates corresponding to the host pointer.")
         .def("set_min", buffer_set_min3<T>,
-             p::args("self", "m0", "m1", "m2"),
+             py::args("self", "m0", "m1", "m2"),
              "Set the coordinates corresponding to the host pointer.")
         .def("set_min", buffer_set_min4<T>,
-             p::args("self", "m0", "m1", "m2", "m3"),
+             py::args("self", "m0", "m1", "m2", "m3"),
              "Set the coordinates corresponding to the host pointer.");
 
     buffer_class
-        .def("width", buffer_width<T>, p::arg("self"),
+        .def("width", buffer_width<T>, py::arg("self"),
              "Get the extent of dimension 0, which by convention we use as "
              "the width of the image. Unlike extent(0), returns one if the "
              "buffer is zero-dimensional.")
-        .def("height", buffer_height<T>, p::arg("self"),
+        .def("height", buffer_height<T>, py::arg("self"),
              "Get the extent of dimension 1, which by convention we use as "
              "the height of the image. Unlike extent(1), returns one if the "
              "buffer has fewer than two dimensions.")
-        .def("left", buffer_left<T>, p::arg("self"),
+        .def("left", buffer_left<T>, py::arg("self"),
              "Get the minimum coordinate in dimension 0, which by convention "
              "is the coordinate of the left edge of the image. Returns zero "
              "for zero-dimensional images.")
-        .def("right", buffer_right<T>, p::arg("self"),
+        .def("right", buffer_right<T>, py::arg("self"),
              "Get the maximum coordinate in dimension 0, which by convention "
              "is the coordinate of the right edge of the image. Returns zero "
              "for zero-dimensional images.")
-        .def("top", buffer_top<T>, p::arg("self"),
+        .def("top", buffer_top<T>, py::arg("self"),
              "Get the minimum coordinate in dimension 1, which by convention "
              "is the top of the image. Returns zero for zero- or "
              "one-dimensional images.")
-        .def("bottom", buffer_bottom<T>, p::arg("self"),
+        .def("bottom", buffer_bottom<T>, py::arg("self"),
              "Get the maximum coordinate in dimension 1, which by convention "
              "is the bottom of the image. Returns zero for zero- or "
              "one-dimensional images.");
@@ -358,102 +358,102 @@ void define_buffer_impl(const std::string suffix, const h::Type type) {
     // Access operators (to Expr, and to actual value)
     buffer_class
         .def("__getitem__", buffer_call_operator<Expr, T, Expr>,
-             p::args("self", "x"),
+             py::args("self", "x"),
              get_item_doc);
     buffer_class
         .def("__getitem__", buffer_call_operator<Expr, T, Expr, Expr>,
-             p::args("self", "x", "y"),
+             py::args("self", "x", "y"),
              get_item_doc);
     buffer_class
         .def("__getitem__", buffer_call_operator<Expr, T, Expr, Expr, Expr>,
-             p::args("self", "x", "y", "z"),
+             py::args("self", "x", "y", "z"),
              get_item_doc)
         .def("__getitem__", buffer_call_operator<Expr, T, Expr, Expr, Expr, Expr>,
-             p::args("self", "x", "y", "z", "w"),
+             py::args("self", "x", "y", "z", "w"),
              get_item_doc)
         .def("__getitem__", buffer_call_operator_tuple<T>,
-             p::args("self", "tuple"),
+             py::args("self", "tuple"),
              get_item_doc)
         // Note that we return copy values (not references like in the C++ API)
         .def("__getitem__", buffer_call_operator<T, T>,
-             p::arg("self"),
+             py::arg("self"),
              "Assuming this buffer is zero-dimensional, get its value")
         .def("__call__", buffer_call_operator<T, T, int>,
-             p::args("self", "x"),
+             py::args("self", "x"),
              "Assuming this buffer is one-dimensional, get the value of the element at position x")
         .def("__call__", buffer_call_operator<T, T, int, int>,
-             p::args("self", "x", "y"),
+             py::args("self", "x", "y"),
              "Assuming this buffer is two-dimensional, get the value of the element at position (x, y)")
         .def("__call__", buffer_call_operator<T, T, int, int, int>,
-             p::args("self", "x", "y", "z"),
+             py::args("self", "x", "y", "z"),
              "Assuming this buffer is three-dimensional, get the value of the element at position (x, y, z)")
         .def("__call__", buffer_call_operator<T, T, int, int, int, int>,
-             p::args("self", "x", "y", "z", "w"),
+             py::args("self", "x", "y", "z", "w"),
              "Assuming this buffer is four-dimensional, get the value of the element at position (x, y, z, w)")
 
-        .def("__setitem__", buffer_to_setitem_operator0<T>, p::args("self", "x", "value"),
+        .def("__setitem__", buffer_to_setitem_operator0<T>, py::args("self", "x", "value"),
              "Assuming this buffer is one-dimensional, set the value of the element at position x")
-        .def("__setitem__", buffer_to_setitem_operator1<T>, p::args("self", "x", "y", "value"),
+        .def("__setitem__", buffer_to_setitem_operator1<T>, py::args("self", "x", "y", "value"),
              "Assuming this buffer is two-dimensional, set the value of the element at position (x, y)")
-        .def("__setitem__", buffer_to_setitem_operator2<T>, p::args("self", "x", "y", "z", "value"),
+        .def("__setitem__", buffer_to_setitem_operator2<T>, py::args("self", "x", "y", "z", "value"),
              "Assuming this buffer is three-dimensional, set the value of the element at position (x, y, z)")
-        .def("__setitem__", buffer_to_setitem_operator3<T>, p::args("self", "x", "y", "z", "w", "value"),
+        .def("__setitem__", buffer_to_setitem_operator3<T>, py::args("self", "x", "y", "z", "w", "value"),
              "Assuming this buffer is four-dimensional, set the value of the element at position (x, y, z, w)")
-        .def("__setitem__", buffer_to_setitem_operator4<T>, p::args("self", "tuple", "value"),
+        .def("__setitem__", buffer_to_setitem_operator4<T>, py::args("self", "tuple", "value"),
              "Assuming this buffer is one to four-dimensional, "
              "set the value of the element at position indicated by tuple (x, y, z, w)");
 
-    p::implicitly_convertible<Buffer<T>, h::Argument>();
+    py::implicitly_convertible<Buffer<T>, Argument>();
 }
 
-p::object buffer_to_python_object(const h::Buffer<> &im) {
+py::object buffer_to_python_object(const Buffer<> &im) {
     PyObject *obj = nullptr;
-    if (im.type() == h::UInt(8)) {
-        p::manage_new_object::apply<h::Buffer<uint8_t> *>::type converter;
-        obj = converter(new h::Buffer<uint8_t>(im));
-    } else if (im.type() == h::UInt(16)) {
-        p::manage_new_object::apply<h::Buffer<uint16_t> *>::type converter;
-        obj = converter(new h::Buffer<uint16_t>(im));
-    } else if (im.type() == h::UInt(32)) {
-        p::manage_new_object::apply<h::Buffer<uint32_t> *>::type converter;
-        obj = converter(new h::Buffer<uint32_t>(im));
-    } else if (im.type() == h::UInt(64)) {
-        p::manage_new_object::apply<h::Buffer<uint64_t> *>::type converter;
-        obj = converter(new h::Buffer<uint64_t>(im));
-    } else if (im.type() == h::Int(8)) {
-        p::manage_new_object::apply<h::Buffer<int8_t> *>::type converter;
-        obj = converter(new h::Buffer<int8_t>(im));
-    } else if (im.type() == h::Int(16)) {
-        p::manage_new_object::apply<h::Buffer<int16_t> *>::type converter;
-        obj = converter(new h::Buffer<int16_t>(im));
-    } else if (im.type() == h::Int(32)) {
-        p::manage_new_object::apply<h::Buffer<int32_t> *>::type converter;
-        obj = converter(new h::Buffer<int32_t>(im));
-    } else if (im.type() == h::Int(64)) {
-        p::manage_new_object::apply<h::Buffer<int64_t> *>::type converter;
-        obj = converter(new h::Buffer<int64_t>(im));
-    } else if (im.type() == h::Float(32)) {
-        p::manage_new_object::apply<h::Buffer<float> *>::type converter;
-        obj = converter(new h::Buffer<float>(im));
-    } else if (im.type() == h::Float(64)) {
-        p::manage_new_object::apply<h::Buffer<double> *>::type converter;
-        obj = converter(new h::Buffer<double>(im));
+    if (im.type() == UInt(8)) {
+        py::manage_new_object::apply<Buffer<uint8_t> *>::type converter;
+        obj = converter(new Buffer<uint8_t>(im));
+    } else if (im.type() == UInt(16)) {
+        py::manage_new_object::apply<Buffer<uint16_t> *>::type converter;
+        obj = converter(new Buffer<uint16_t>(im));
+    } else if (im.type() == UInt(32)) {
+        py::manage_new_object::apply<Buffer<uint32_t> *>::type converter;
+        obj = converter(new Buffer<uint32_t>(im));
+    } else if (im.type() == UInt(64)) {
+        py::manage_new_object::apply<Buffer<uint64_t> *>::type converter;
+        obj = converter(new Buffer<uint64_t>(im));
+    } else if (im.type() == Int(8)) {
+        py::manage_new_object::apply<Buffer<int8_t> *>::type converter;
+        obj = converter(new Buffer<int8_t>(im));
+    } else if (im.type() == Int(16)) {
+        py::manage_new_object::apply<Buffer<int16_t> *>::type converter;
+        obj = converter(new Buffer<int16_t>(im));
+    } else if (im.type() == Int(32)) {
+        py::manage_new_object::apply<Buffer<int32_t> *>::type converter;
+        obj = converter(new Buffer<int32_t>(im));
+    } else if (im.type() == Int(64)) {
+        py::manage_new_object::apply<Buffer<int64_t> *>::type converter;
+        obj = converter(new Buffer<int64_t>(im));
+    } else if (im.type() == Float(32)) {
+        py::manage_new_object::apply<Buffer<float> *>::type converter;
+        obj = converter(new Buffer<float>(im));
+    } else if (im.type() == Float(64)) {
+        py::manage_new_object::apply<Buffer<double> *>::type converter;
+        obj = converter(new Buffer<double>(im));
     } else {
         throw std::invalid_argument("buffer_to_python_object received an Buffer of unsupported type.");
     }
 
-    return p::object(p::handle<>(obj));
+    return py::object(py::handle<>(obj));
 }
 
-h::Buffer<> python_object_to_buffer(p::object obj) {
-    p::extract<h::Buffer<uint8_t>> buffer_extract_uint8(obj);
-    p::extract<h::Buffer<uint16_t>> buffer_extract_uint16(obj);
-    p::extract<h::Buffer<uint32_t>> buffer_extract_uint32(obj);
-    p::extract<h::Buffer<int8_t>> buffer_extract_int8(obj);
-    p::extract<h::Buffer<int16_t>> buffer_extract_int16(obj);
-    p::extract<h::Buffer<int32_t>> buffer_extract_int32(obj);
-    p::extract<h::Buffer<float>> buffer_extract_float(obj);
-    p::extract<h::Buffer<double>> buffer_extract_double(obj);
+Buffer<> python_object_to_buffer(py::object obj) {
+    py::extract<Buffer<uint8_t>> buffer_extract_uint8(obj);
+    py::extract<Buffer<uint16_t>> buffer_extract_uint16(obj);
+    py::extract<Buffer<uint32_t>> buffer_extract_uint32(obj);
+    py::extract<Buffer<int8_t>> buffer_extract_int8(obj);
+    py::extract<Buffer<int16_t>> buffer_extract_int16(obj);
+    py::extract<Buffer<int32_t>> buffer_extract_int32(obj);
+    py::extract<Buffer<float>> buffer_extract_float(obj);
+    py::extract<Buffer<double>> buffer_extract_double(obj);
 
     if (buffer_extract_uint8.check()) {
         return buffer_extract_uint8();
@@ -474,44 +474,44 @@ h::Buffer<> python_object_to_buffer(p::object obj) {
     } else {
         throw std::invalid_argument("python_object_to_buffer received an object that is not an Buffer<T>");
     }
-    return h::Buffer<>();
+    return Buffer<>();
 }
 
 #ifdef USE_NUMPY
 
-bn::dtype type_to_dtype(const h::Type &t) {
-    if (t == h::UInt(8)) return bn::dtype::get_builtin<uint8_t>();
-    if (t == h::UInt(16)) return bn::dtype::get_builtin<uint16_t>();
-    if (t == h::UInt(32)) return bn::dtype::get_builtin<uint32_t>();
-    if (t == h::UInt(64)) return bn::dtype::get_builtin<uint64_t>();
-    if (t == h::Int(8)) return bn::dtype::get_builtin<int8_t>();
-    if (t == h::Int(16)) return bn::dtype::get_builtin<int16_t>();
-    if (t == h::Int(32)) return bn::dtype::get_builtin<int32_t>();
-    if (t == h::Int(64)) return bn::dtype::get_builtin<int64_t>();
-    if (t == h::Float(32)) return bn::dtype::get_builtin<float>();
-    if (t == h::Float(64)) return bn::dtype::get_builtin<double>();
+bn::dtype type_to_dtype(const Type &t) {
+    if (t == UInt(8)) return bn::dtype::get_builtin<uint8_t>();
+    if (t == UInt(16)) return bn::dtype::get_builtin<uint16_t>();
+    if (t == UInt(32)) return bn::dtype::get_builtin<uint32_t>();
+    if (t == UInt(64)) return bn::dtype::get_builtin<uint64_t>();
+    if (t == Int(8)) return bn::dtype::get_builtin<int8_t>();
+    if (t == Int(16)) return bn::dtype::get_builtin<int16_t>();
+    if (t == Int(32)) return bn::dtype::get_builtin<int32_t>();
+    if (t == Int(64)) return bn::dtype::get_builtin<int64_t>();
+    if (t == Float(32)) return bn::dtype::get_builtin<float>();
+    if (t == Float(64)) return bn::dtype::get_builtin<double>();
     throw std::runtime_error("type_to_dtype received a Halide::Type with no known numpy dtype equivalent");
     return bn::dtype::get_builtin<uint8_t>();
 }
 
-h::Type dtype_to_type(const bn::dtype &t) {
-    if (t == bn::dtype::get_builtin<uint8_t>()) return h::UInt(8);
-    if (t == bn::dtype::get_builtin<uint16_t>()) return h::UInt(16);
-    if (t == bn::dtype::get_builtin<uint32_t>()) return h::UInt(32);
-    if (t == bn::dtype::get_builtin<uint64_t>()) return h::UInt(64);
-    if (t == bn::dtype::get_builtin<int8_t>()) return h::Int(8);
-    if (t == bn::dtype::get_builtin<int16_t>()) return h::Int(16);
-    if (t == bn::dtype::get_builtin<int32_t>()) return h::Int(32);
-    if (t == bn::dtype::get_builtin<int64_t>()) return h::Int(64);
-    if (t == bn::dtype::get_builtin<float>()) return h::Float(32);
-    if (t == bn::dtype::get_builtin<double>()) return h::Float(64);
+Type dtype_to_type(const bn::dtype &t) {
+    if (t == bn::dtype::get_builtin<uint8_t>()) return UInt(8);
+    if (t == bn::dtype::get_builtin<uint16_t>()) return UInt(16);
+    if (t == bn::dtype::get_builtin<uint32_t>()) return UInt(32);
+    if (t == bn::dtype::get_builtin<uint64_t>()) return UInt(64);
+    if (t == bn::dtype::get_builtin<int8_t>()) return Int(8);
+    if (t == bn::dtype::get_builtin<int16_t>()) return Int(16);
+    if (t == bn::dtype::get_builtin<int32_t>()) return Int(32);
+    if (t == bn::dtype::get_builtin<int64_t>()) return Int(64);
+    if (t == bn::dtype::get_builtin<float>()) return Float(32);
+    if (t == bn::dtype::get_builtin<double>()) return Float(64);
     throw std::runtime_error("dtype_to_type received a numpy type with no known Halide type equivalent");
-    return h::Type();
+    return Type();
 }
 
 /// Will create a Halide::Buffer object pointing to the array data
-p::object ndarray_to_buffer(bn::ndarray &array) {
-    h::Type t = dtype_to_type(array.get_dtype());
+py::object ndarray_to_buffer(bn::ndarray &array) {
+    Type t = dtype_to_type(array.get_dtype());
     const int dims = array.get_nd();
     void *host = reinterpret_cast<void *>(array.get_data());
     halide_dimension_t *shape =
@@ -522,11 +522,11 @@ p::object ndarray_to_buffer(bn::ndarray &array) {
         shape[i].stride = array.strides(i) / t.bytes();
     }
 
-    return buffer_to_python_object(h::Buffer<>(t, host, dims, shape));
+    return buffer_to_python_object(Buffer<>(t, host, dims, shape));
 }
 
-bn::ndarray buffer_to_ndarray(p::object buffer_object) {
-    h::Buffer<> im = python_object_to_buffer(buffer_object);
+bn::ndarray buffer_to_ndarray(py::object buffer_object) {
+    Buffer<> im = python_object_to_buffer(buffer_object);
 
     if (im.data() == nullptr) {
         throw std::invalid_argument("Can't create a numpy array from a Buffer with a null host pointer");
@@ -550,122 +550,125 @@ bn::ndarray buffer_to_ndarray(p::object buffer_object) {
 
 struct BufferFactory {
     template <typename T, typename... Args>
-    static p::object create_buffer_object(Args... args) {
-        typedef h::Buffer<T> BufferType;
-        typedef typename p::manage_new_object::apply<BufferType *>::type converter_t;
+    static py::object create_buffer_object(Args... args) {
+        typedef Buffer<T> BufferType;
+        typedef typename py::manage_new_object::apply<BufferType *>::type converter_t;
         converter_t converter;
         PyObject *obj = converter(new BufferType(args...));
-        return p::object(p::handle<>(obj));
+        return py::object(py::handle<>(obj));
     }
 
     template <typename... Args>
-    static p::object create_buffer_impl(h::Type t, Args... args) {
-        if (t == h::UInt(8)) return create_buffer_object<uint8_t>(args...);
-        if (t == h::UInt(16)) return create_buffer_object<uint16_t>(args...);
-        if (t == h::UInt(32)) return create_buffer_object<uint32_t>(args...);
-        if (t == h::UInt(64)) return create_buffer_object<uint64_t>(args...);
-        if (t == h::Int(8)) return create_buffer_object<int8_t>(args...);
-        if (t == h::Int(16)) return create_buffer_object<int16_t>(args...);
-        if (t == h::Int(32)) return create_buffer_object<int32_t>(args...);
-        if (t == h::Int(64)) return create_buffer_object<int64_t>(args...);
-        if (t == h::Float(32)) return create_buffer_object<float>(args...);
-        if (t == h::Float(64)) return create_buffer_object<double>(args...);
+    static py::object create_buffer_impl(Type t, Args... args) {
+        if (t == UInt(8)) return create_buffer_object<uint8_t>(args...);
+        if (t == UInt(16)) return create_buffer_object<uint16_t>(args...);
+        if (t == UInt(32)) return create_buffer_object<uint32_t>(args...);
+        if (t == UInt(64)) return create_buffer_object<uint64_t>(args...);
+        if (t == Int(8)) return create_buffer_object<int8_t>(args...);
+        if (t == Int(16)) return create_buffer_object<int16_t>(args...);
+        if (t == Int(32)) return create_buffer_object<int32_t>(args...);
+        if (t == Int(64)) return create_buffer_object<int64_t>(args...);
+        if (t == Float(32)) return create_buffer_object<float>(args...);
+        if (t == Float(64)) return create_buffer_object<double>(args...);
         throw std::invalid_argument("BufferFactory::create_buffer_impl received type not handled");
-        return p::object();
+        return py::object();
     }
 
-    static p::object create_buffer0(h::Type type) {
+    static py::object create_buffer0(Type type) {
         return create_buffer_impl(type);
     }
 
-    static p::object create_buffer1(h::Type type, int x) {
+    static py::object create_buffer1(Type type, int x) {
         return create_buffer_impl(type, x);
     }
 
-    static p::object create_buffer2(h::Type type, int x, int y) {
+    static py::object create_buffer2(Type type, int x, int y) {
         return create_buffer_impl(type, x, y);
     }
 
-    static p::object create_buffer3(h::Type type, int x, int y, int z) {
+    static py::object create_buffer3(Type type, int x, int y, int z) {
         return create_buffer_impl(type, x, y, z);
     }
 
-    static p::object create_buffer4(h::Type type, int x, int y, int z, int w) {
+    static py::object create_buffer4(Type type, int x, int y, int z, int w) {
         return create_buffer_impl(type, x, y, z, w);
     }
 
-    static p::object create_buffer_from_realization(h::Type type, h::Realization &r) {
+    static py::object create_buffer_from_realization(Type type, Realization &r) {
         return create_buffer_impl(type, r);
     }
 
-    static p::object create_buffer_from_buffer(halide_buffer_t b) {
+    static py::object create_buffer_from_buffer(halide_buffer_t b) {
         return create_buffer_impl(b.type, b);
     }
 };
 
 void define_buffer() {
-    define_buffer_impl<uint8_t>("_uint8", h::UInt(8));
-    define_buffer_impl<uint16_t>("_uint16", h::UInt(16));
-    define_buffer_impl<uint32_t>("_uint32", h::UInt(32));
-    define_buffer_impl<uint64_t>("_uint64", h::UInt(64));
+    define_buffer_impl<uint8_t>("_uint8", UInt(8));
+    define_buffer_impl<uint16_t>("_uint16", UInt(16));
+    define_buffer_impl<uint32_t>("_uint32", UInt(32));
+    define_buffer_impl<uint64_t>("_uint64", UInt(64));
 
-    define_buffer_impl<int8_t>("_int8", h::Int(8));
-    define_buffer_impl<int16_t>("_int16", h::Int(16));
-    define_buffer_impl<int32_t>("_int32", h::Int(32));
-    define_buffer_impl<int64_t>("_int64", h::Int(64));
+    define_buffer_impl<int8_t>("_int8", Int(8));
+    define_buffer_impl<int16_t>("_int16", Int(16));
+    define_buffer_impl<int32_t>("_int32", Int(32));
+    define_buffer_impl<int64_t>("_int64", Int(64));
 
-    define_buffer_impl<float>("_float32", h::Float(32));
-    define_buffer_impl<double>("_float64", h::Float(64));
+    define_buffer_impl<float>("_float32", Float(32));
+    define_buffer_impl<double>("_float64", Float(64));
 
     // "Buffer" will look like a class, but instead it will be simply a factory method
-    p::def("Buffer", &BufferFactory::create_buffer0,
-           p::args("type"),
+    py::def("Buffer", &BufferFactory::create_buffer0,
+           py::args("type"),
            "Construct a zero-dimensional buffer of type T");
-    p::def("Buffer", &BufferFactory::create_buffer1,
-           p::args("type", "x"),
+    py::def("Buffer", &BufferFactory::create_buffer1,
+           py::args("type", "x"),
            "Construct a one-dimensional buffer of type T");
-    p::def("Buffer", &BufferFactory::create_buffer2,
-           p::args("type", "x", "y"),
+    py::def("Buffer", &BufferFactory::create_buffer2,
+           py::args("type", "x", "y"),
            "Construct a two-dimensional buffer of type T");
-    p::def("Buffer", &BufferFactory::create_buffer3,
-           p::args("type", "x", "y", "z"),
+    py::def("Buffer", &BufferFactory::create_buffer3,
+           py::args("type", "x", "y", "z"),
            "Construct a three-dimensional buffer of type T");
-    p::def("Buffer", &BufferFactory::create_buffer4,
-           p::args("type", "x", "y", "z", "w"),
+    py::def("Buffer", &BufferFactory::create_buffer4,
+           py::args("type", "x", "y", "z", "w"),
            "Construct a four-dimensional buffer of type T");
 
-    p::def("Buffer", &BufferFactory::create_buffer_from_realization,
-           p::args("type", "r"),
-           p::with_custodian_and_ward_postcall<0, 2>(),  // the realization reference count is increased
+    py::def("Buffer", &BufferFactory::create_buffer_from_realization,
+           py::args("type", "r"),
+           py::with_custodian_and_ward_postcall<0, 2>(),  // the realization reference count is increased
            "Wrap a single-element realization in an Buffer object of type T.");
 
-    p::def("Buffer", &BufferFactory::create_buffer_from_buffer,
-           p::args("b"),
-           p::with_custodian_and_ward_postcall<0, 2>(),  // the buffer_t reference count is increased
+    py::def("Buffer", &BufferFactory::create_buffer_from_buffer,
+           py::args("b"),
+           py::with_custodian_and_ward_postcall<0, 2>(),  // the buffer_t reference count is increased
            "Wrap a halide_buffer_t in an Buffer object, so that we can access its pixels.");
 
 #ifdef USE_NUMPY
     bn::initialize();
 
-    p::def("ndarray_to_buffer", &ndarray_to_buffer,
-           p::args("array"),
-           p::with_custodian_and_ward_postcall<0, 1>(),  // the array reference count is increased
+    py::def("ndarray_to_buffer", &ndarray_to_buffer,
+           py::args("array"),
+           py::with_custodian_and_ward_postcall<0, 1>(),  // the array reference count is increased
            "Converts a numpy array into a Halide::Buffer."
            "Will take into account the array size, dimensions, and type."
            "Created Buffer refers to the array data (no copy).");
 
-    p::def("Buffer", &ndarray_to_buffer,
-           p::args("array"),
-           p::with_custodian_and_ward_postcall<0, 1>(),  // the array reference count is increased
+    py::def("Buffer", &ndarray_to_buffer,
+           py::args("array"),
+           py::with_custodian_and_ward_postcall<0, 1>(),  // the array reference count is increased
            "Wrap numpy array in a Halide::Buffer."
            "Will take into account the array size, dimensions, and type."
            "Created Buffer refers to the array data (no copy).");
 
-    p::def("buffer_to_ndarray", &buffer_to_ndarray,
-           p::args("buffer"),
-           p::with_custodian_and_ward_postcall<0, 1>(),  // the buffer reference count is increased
+    py::def("buffer_to_ndarray", &buffer_to_ndarray,
+           py::args("buffer"),
+           py::with_custodian_and_ward_postcall<0, 1>(),  // the buffer reference count is increased
            "Creates a numpy array from a Halide::Buffer."
            "Will take into account the Buffer size, dimensions, and type."
            "Created ndarray refers to the Buffer data (no copy).");
 #endif  // USE_NUMPY
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyBuffer.h
+++ b/python_bindings/src/PyBuffer.h
@@ -1,12 +1,16 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYBUFFER_H
 #define HALIDE_PYTHON_BINDINGS_PYBUFFER_H
 
-#include <boost/python.hpp>
+#include "PyHalide.h"
 
-#include "Halide.h"
+namespace Halide {
+namespace PythonBindings {
 
 void define_buffer();
-boost::python::object buffer_to_python_object(const Halide::Buffer<> &);
-Halide::Buffer<> python_object_to_buffer(boost::python::object);
+py::object buffer_to_python_object(const Buffer<> &);
+Buffer<> python_object_to_buffer(py::object);
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYBUFFER_H

--- a/python_bindings/src/PyError.cpp
+++ b/python_bindings/src/PyError.cpp
@@ -1,43 +1,38 @@
 #include "PyError.h"
 
-#include <boost/python.hpp>
-#include <string>
-
-#include "Halide.h"
-
-namespace h = Halide;
-namespace p = boost::python;
+namespace Halide {
+namespace PythonBindings {
 
 namespace {
 
 void halide_python_error(void *, const char *msg) {
-    throw h::Error(msg);
+    throw Error(msg);
 }
 
 void halide_python_print(void *, const char *msg) {
     PySys_WriteStdout("%s", msg);
 }
 
-class HalidePythonCompileTimeErrorReporter : public h::CompileTimeErrorReporter {
+class HalidePythonCompileTimeErrorReporter : public CompileTimeErrorReporter {
 public:
     void warning(const char* msg) {
         PySys_WriteStdout("%s", msg);
     }
 
     void error(const char* msg) {
-        throw h::Error(msg);
+        throw Error(msg);
         // This method must not return!
     }
 };
 
-void translate_error(h::Error const &e) {
+void translate_error(Error const &e) {
     PyErr_SetString(PyExc_RuntimeError, e.what());
 }
 
 }  // namespace
 
 void define_error() {
-    p::register_exception_translator<h::Error>(&translate_error);
+    py::register_exception_translator<Error>(&translate_error);
 
     static HalidePythonCompileTimeErrorReporter reporter;
     set_custom_compile_time_error_reporter(&reporter);
@@ -47,4 +42,7 @@ void define_error() {
     handlers.custom_print = halide_python_print;
     Halide::Internal::JITSharedRuntime::set_default_handlers(handlers);
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide
 

--- a/python_bindings/src/PyError.h
+++ b/python_bindings/src/PyError.h
@@ -1,6 +1,14 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYERROR_H
 #define HALIDE_PYTHON_BINDINGS_PYERROR_H
 
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
 void define_error();
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYERROR_H

--- a/python_bindings/src/PyExpr.cpp
+++ b/python_bindings/src/PyExpr.cpp
@@ -1,51 +1,45 @@
 #include "PyExpr.h"
 
-#include <boost/format.hpp>
-#include <boost/python.hpp>
-#include <string>
 
-#include "Halide.h"
-
-#include "PyType.h"
 #include "PyBinaryOperators.h"
+#include "PyType.h"
 
-namespace h = Halide;
-namespace p = boost::python;
+namespace Halide {
+namespace PythonBindings {
 
-p::object expr_vector_to_python_tuple(const std::vector<h::Expr> &t) {
+py::object expr_vector_to_python_tuple(const std::vector<Expr> &t) {
     if (t.size() == 1) {
-        return p::object(t[0]);
+        return py::object(t[0]);
     } else {
-        p::list elts;
-        for (const h::Expr &e : t) {
+        py::list elts;
+        for (const Expr &e : t) {
             elts.append(e);
         }
-        return p::tuple(elts);
+        return py::tuple(elts);
     }
 }
 
-std::vector<h::Expr> python_tuple_to_expr_vector(const p::object &obj) {
-    p::extract<h::Expr> expr_extract(obj);
+std::vector<Expr> python_tuple_to_expr_vector(const py::object &obj) {
+    py::extract<Expr> expr_extract(obj);
     if (expr_extract.check()) {
         return { expr_extract() };
     } else {
-        return python_collection_to_vector<h::Expr>(obj);
+        return python_collection_to_vector<Expr>(obj);
     }
 }
 
-std::string expr_repr(const h::Expr &expr) {
-    boost::format f("<halide.Expr of type %s>");
-    return boost::str(f % halide_type_to_string(expr.type()));
+std::string expr_repr(const Expr &expr) {
+    std::ostringstream o;
+    o << "<halide.Expr of type " << halide_type_to_string(expr.type()) << ">";
+    return o.str();
 }
 
-h::Expr *expr_from_var_constructor(h::Var &var) {
-    return new h::Expr(var);
+Expr *expr_from_var_constructor(Var &var) {
+    return new Expr(var);
 }
 
 void define_expr() {
-    using Halide::Expr;
-
-    auto expr_class = p::class_<Expr>("Expr",
+    auto expr_class = py::class_<Expr>("Expr",
                                       "An expression or fragment of Halide code.\n"
                                       "One can explicitly coerce most types to Expr via the Expr(x) constructor."
                                       "The following operators are implemented over Expr, and also other types"
@@ -66,38 +60,41 @@ void define_expr() {
 
                           // constructor priority order is reverse from implicitly_convertible
                           // it important to declare int after float, after double.
-                          .def(p::init<const h::Internal::BaseExprNode *>(p::arg("self")))
-                          .def(p::init<double>(p::arg("self"), "Make an expression representing a const 32-bit float double. "
+                          .def(py::init<const Internal::BaseExprNode *>(py::arg("self")))
+                          .def(py::init<double>(py::arg("self"), "Make an expression representing a const 32-bit float double. "
                                                                "Also emits a warning due to truncation."))
-                          .def(p::init<float>(p::arg("self"), "Make an expression representing a const 32-bit float (i.e. a FloatImm)"))
-                          .def(p::init<int>(p::arg("self"), "Make an expression representing a const 32-bit int (i.e. an IntImm)"))
-                          .def(p::init<std::string>(p::arg("self"), "Make an expression representing a const string (i.e. a StringImm)"))
+                          .def(py::init<float>(py::arg("self"), "Make an expression representing a const 32-bit float (i.e. a FloatImm)"))
+                          .def(py::init<int>(py::arg("self"), "Make an expression representing a const 32-bit int (i.e. an IntImm)"))
+                          .def(py::init<std::string>(py::arg("self"), "Make an expression representing a const string (i.e. a StringImm)"))
                           .def("__init__",
-                               p::make_constructor(&expr_from_var_constructor, p::default_call_policies(),
-                                                   p::arg("var")),
+                               py::make_constructor(&expr_from_var_constructor, py::default_call_policies(),
+                                                   py::arg("var")),
                                "Cast a Var into an Expr")
 
-                          .def("type", &Expr::type, p::arg("self"),
+                          .def("type", &Expr::type, py::arg("self"),
                                "Get the type of this expression")
-                          .def("__repr__", &expr_repr, p::arg("self"));
+                          .def("__repr__", &expr_repr, py::arg("self"));
     ;
 
     add_binary_operators(expr_class);
 
     // implicitly_convertible declaration order matters,
     // int should be tried before float convertion
-    p::implicitly_convertible<int, h::Expr>();
-    p::implicitly_convertible<float, h::Expr>();
-    p::implicitly_convertible<double, h::Expr>();
+    py::implicitly_convertible<int, Expr>();
+    py::implicitly_convertible<float, Expr>();
+    py::implicitly_convertible<double, Expr>();
 
-    p::enum_<h::DeviceAPI>("DeviceAPI")
-        .value("None", h::DeviceAPI::None)
-        .value("Host", h::DeviceAPI::Host)
-        .value("Default_GPU", h::DeviceAPI::Default_GPU)
-        .value("CUDA", h::DeviceAPI::CUDA)
-        .value("OpenCL", h::DeviceAPI::OpenCL)
-        .value("GLSL", h::DeviceAPI::GLSL)
-        .value("OpenGLCompute", h::DeviceAPI::OpenGLCompute)
-        .value("Metal", h::DeviceAPI::Metal)
-        .value("Hexagon", h::DeviceAPI::Hexagon);
+    py::enum_<DeviceAPI>("DeviceAPI")
+        .value("None", DeviceAPI::None)
+        .value("Host", DeviceAPI::Host)
+        .value("Default_GPU", DeviceAPI::Default_GPU)
+        .value("CUDA", DeviceAPI::CUDA)
+        .value("OpenCL", DeviceAPI::OpenCL)
+        .value("GLSL", DeviceAPI::GLSL)
+        .value("OpenGLCompute", DeviceAPI::OpenGLCompute)
+        .value("Metal", DeviceAPI::Metal)
+        .value("Hexagon", DeviceAPI::Hexagon);
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyExpr.h
+++ b/python_bindings/src/PyExpr.h
@@ -1,23 +1,26 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYEXPR_H
 #define HALIDE_PYTHON_BINDINGS_PYEXPR_H
 
-#include <boost/python.hpp>
-#include <vector>
+#include "PyHalide.h"
 
-#include "Halide.h"
+namespace Halide {
+namespace PythonBindings {
 
 void define_expr();
 
-boost::python::object expr_vector_to_python_tuple(const std::vector<Halide::Expr> &t);
-std::vector<Halide::Expr> python_tuple_to_expr_vector(const boost::python::object &obj);
+py::object expr_vector_to_python_tuple(const std::vector<Expr> &t);
+std::vector<Expr> python_tuple_to_expr_vector(const py::object &obj);
 
 template <typename T>
-std::vector<T> python_collection_to_vector(const boost::python::object &obj) {
+std::vector<T> python_collection_to_vector(const py::object &obj) {
     std::vector<T> result;
-    for (ssize_t i = 0; i < boost::python::len(obj); i++) {
-        result.push_back(boost::python::extract<T>(obj[i]));
+    for (ssize_t i = 0; i < py::len(obj); i++) {
+        result.push_back(py::extract<T>(obj[i]));
     }
     return result;
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYEXPR_H

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -1,12 +1,5 @@
 #include "PyFunc.h"
 
-#include <boost/python.hpp>
-#include <boost/format.hpp>
-#include <string>
-#include <vector>
-
-#include "Halide.h"
-
 #include "PyBinaryOperators.h"
 #include "PyBuffer.h"
 #include "PyExpr.h"
@@ -15,124 +8,124 @@
 #include "PyFunc_VarOrRVar.h"
 #include "PyFunc_gpu.h"
 
-namespace h = Halide;
-namespace p = boost::python;
+namespace Halide {
+namespace PythonBindings {
 
-p::object realization_to_python_object(const h::Realization &r) {
+py::object realization_to_python_object(const Realization &r) {
     if (r.size() == 1) {
         return buffer_to_python_object(r[0]);
     } else {
-        p::list elts;
+        py::list elts;
         for (size_t i = 0; i < r.size(); i++) {
             elts.append(buffer_to_python_object(r[i]));
         }
-        return p::tuple(elts);
+        return py::tuple(elts);
     }
 }
 
-h::Realization python_object_to_realization(p::object obj) {
-    std::vector<h::Buffer<>> buffers;
-    p::extract<p::tuple> tuple_extract(obj);
+Realization python_object_to_realization(py::object obj) {
+    std::vector<Buffer<>> buffers;
+    py::extract<py::tuple> tuple_extract(obj);
     if (tuple_extract.check()) {
-        p::tuple tup = tuple_extract();
-        for (ssize_t i = 0; i < p::len(tup); i++) {
+        py::tuple tup = tuple_extract();
+        for (ssize_t i = 0; i < py::len(tup); i++) {
             buffers.push_back(python_object_to_buffer(tup[i]));
         }
     } else {
         buffers.push_back(python_object_to_buffer(obj));
     }
-    return h::Realization(buffers);
+    return Realization(buffers);
 }
 
 template <typename... Args>
-p::object func_realize(h::Func &f, Args... args) {
+py::object func_realize(Func &f, Args... args) {
     return realization_to_python_object(f.realize(args...));
 }
 
 template <typename... Args>
-void func_realize_into(h::Func &f, Args... args) {
+void func_realize_into(Func &f, Args... args) {
     f.realize(args...);
 }
 
 template <typename... Args>
-void func_realize_tuple(h::Func &f, p::tuple obj, Args... args) {
+void func_realize_tuple(Func &f, py::tuple obj, Args... args) {
     f.realize(python_object_to_realization(obj), args...);
 }
 
-void func_compile_jit0(h::Func &that) {
+void func_compile_jit0(Func &that) {
     that.compile_jit();
 }
 
-void func_compile_jit1(h::Func &that, const h::Target &target = h::get_target_from_environment()) {
+void func_compile_jit1(Func &that, const Target &target = get_target_from_environment()) {
     that.compile_jit(target);
 }
 
-void func_compile_to_bitcode0(h::Func &that, const std::string &filename,
-                              p::list args,
+void func_compile_to_bitcode0(Func &that, const std::string &filename,
+                              py::list args,
                               const std::string fn_name = "",
-                              const h::Target &target = h::get_target_from_environment()) {
-    auto args_vec = python_collection_to_vector<h::Argument>(args);
+                              const Target &target = get_target_from_environment()) {
+    auto args_vec = python_collection_to_vector<Argument>(args);
     that.compile_to_bitcode(filename, args_vec, fn_name, target);
 }
 
 BOOST_PYTHON_FUNCTION_OVERLOADS(func_compile_to_bitcode0_overloads, func_compile_to_bitcode0, 3, 5)
 
-void func_compile_to_object0(h::Func &that, const std::string &filename,
-                             p::list args,
+void func_compile_to_object0(Func &that, const std::string &filename,
+                             py::list args,
                              const std::string fn_name = "",
-                             const h::Target &target = h::get_target_from_environment()) {
-    auto args_vec = python_collection_to_vector<h::Argument>(args);
+                             const Target &target = get_target_from_environment()) {
+    auto args_vec = python_collection_to_vector<Argument>(args);
     that.compile_to_object(filename, args_vec, fn_name, target);
 }
 
 BOOST_PYTHON_FUNCTION_OVERLOADS(func_compile_to_object0_overloads, func_compile_to_object0, 3, 5)
 
-void func_compile_to_header0(h::Func &that, const std::string &filename,
-                             p::list args,
+void func_compile_to_header0(Func &that, const std::string &filename,
+                             py::list args,
                              const std::string fn_name = "",
-                             const h::Target &target = h::get_target_from_environment()) {
-    auto args_vec = python_collection_to_vector<h::Argument>(args);
+                             const Target &target = get_target_from_environment()) {
+    auto args_vec = python_collection_to_vector<Argument>(args);
     that.compile_to_header(filename, args_vec, fn_name, target);
 }
 
 BOOST_PYTHON_FUNCTION_OVERLOADS(func_compile_to_header0_overloads, func_compile_to_header0, 3, 5)
 
-void func_compile_to_assembly0(h::Func &that, const std::string &filename,
-                               p::list args,
+void func_compile_to_assembly0(Func &that, const std::string &filename,
+                               py::list args,
                                const std::string fn_name = "",
-                               const h::Target &target = h::get_target_from_environment()) {
-    auto args_vec = python_collection_to_vector<h::Argument>(args);
+                               const Target &target = get_target_from_environment()) {
+    auto args_vec = python_collection_to_vector<Argument>(args);
     that.compile_to_assembly(filename, args_vec, fn_name, target);
 }
 
 BOOST_PYTHON_FUNCTION_OVERLOADS(func_compile_to_assembly0_overloads, func_compile_to_assembly0, 3, 5)
 
-void func_compile_to_c0(h::Func &that, const std::string &filename,
-                        p::list args,
+void func_compile_to_c0(Func &that, const std::string &filename,
+                        py::list args,
                         const std::string fn_name = "",
-                        const h::Target &target = h::get_target_from_environment()) {
-    auto args_vec = python_collection_to_vector<h::Argument>(args);
+                        const Target &target = get_target_from_environment()) {
+    auto args_vec = python_collection_to_vector<Argument>(args);
     that.compile_to_c(filename, args_vec, fn_name, target);
 }
 
 BOOST_PYTHON_FUNCTION_OVERLOADS(func_compile_to_c0_overloads, func_compile_to_c0, 3, 5)
 
-void func_compile_to_file0(h::Func &that, const std::string &filename_prefix,
-                           p::list args,
+void func_compile_to_file0(Func &that, const std::string &filename_prefix,
+                           py::list args,
                            const std::string fn_name = "",
-                           const h::Target &target = h::get_target_from_environment()) {
-    auto args_vec = python_collection_to_vector<h::Argument>(args);
+                           const Target &target = get_target_from_environment()) {
+    auto args_vec = python_collection_to_vector<Argument>(args);
     that.compile_to_file(filename_prefix, args_vec, fn_name, target);
 }
 
 BOOST_PYTHON_FUNCTION_OVERLOADS(func_compile_to_file0_overloads, func_compile_to_file0, 3, 5)
 
-void func_compile_to_lowered_stmt0(h::Func &that,
+void func_compile_to_lowered_stmt0(Func &that,
                                    const std::string &filename,
-                                   p::list args,
-                                   h::StmtOutputFormat fmt = h::Text,
-                                   const h::Target &target = h::get_target_from_environment()) {
-    auto args_vec = python_collection_to_vector<h::Argument>(args);
+                                   py::list args,
+                                   StmtOutputFormat fmt = Text,
+                                   const Target &target = get_target_from_environment()) {
+    auto args_vec = python_collection_to_vector<Argument>(args);
     that.compile_to_lowered_stmt(filename, args_vec, fmt, target);
 }
 
@@ -141,77 +134,72 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(func_compile_to_lowered_stmt0_overloads, func_co
 // parallel, vectorize, unroll, tile, and reorder methods are shared with Stage class
 // and thus defined as template functions in the header
 
-h::Func &func_store_at0(h::Func &that, h::Func f, h::Var var) {
+Func &func_store_at0(Func &that, Func f, Var var) {
     return that.store_at(f, var);
 }
 
-h::Func &func_store_at1(h::Func &that, h::Func f, h::RVar var) {
+Func &func_store_at1(Func &that, Func f, RVar var) {
     return that.store_at(f, var);
 }
 
-h::Func &func_compute_at0(h::Func &that, h::Func f, h::Var var) {
+Func &func_compute_at0(Func &that, Func f, Var var) {
     return that.compute_at(f, var);
 }
 
-h::Func &func_compute_at1(h::Func &that, h::Func f, h::RVar var) {
+Func &func_compute_at1(Func &that, Func f, RVar var) {
     return that.compute_at(f, var);
 }
 
-h::FuncRef func_getitem_operator(h::Func &func, p::object arg) {
+FuncRef func_getitem_operator(Func &func, py::object arg) {
     return func(python_tuple_to_expr_vector(arg));
 }
 
-h::Stage func_setitem_operator(h::Func &func, p::object lhs, p::object rhs) {
+Stage func_setitem_operator(Func &func, py::object lhs, py::object rhs) {
     return (func(python_tuple_to_expr_vector(lhs)) =
-                h::Tuple(python_tuple_to_expr_vector(rhs)));
+                Tuple(python_tuple_to_expr_vector(rhs)));
 }
 
-std::string func_repr(const h::Func &func) {
-    std::string repr;
-    boost::format f("<halide.Func '%s'>");
-    repr = boost::str(f % func.name());
-    return repr;
+std::string func_repr(const Func &func) {
+    std::ostringstream o;
+    o << "<halide.Func '" << func.name() << "'>";
+    return o.str();
 }
 
-void func_define_extern0(h::Func &that,
+void func_define_extern0(Func &that,
                          const std::string &function_name,
-                         p::list params,
-                         h::Type output_type,
+                         py::list params,
+                         Type output_type,
                          int dimensionality) {
-    auto params_vec = python_collection_to_vector<h::ExternFuncArgument>(params);
+    auto params_vec = python_collection_to_vector<ExternFuncArgument>(params);
     return that.define_extern(function_name, params_vec, output_type, dimensionality);
 }
 
-void func_define_extern1(h::Func &that,
+void func_define_extern1(Func &that,
                          const std::string &function_name,
-                         p::list params,
-                         p::list types,
+                         py::list params,
+                         py::list types,
                          int dimensionality) {
-    auto params_vec = python_collection_to_vector<h::ExternFuncArgument>(params);
-    auto types_vec = python_collection_to_vector<h::Type>(types);
+    auto params_vec = python_collection_to_vector<ExternFuncArgument>(params);
+    auto types_vec = python_collection_to_vector<Type>(types);
     return that.define_extern(function_name, params_vec, types_vec, dimensionality);
 }
 
-p::tuple func_output_types(h::Func &func) {
-    p::list elts;
-    for (h::Type t : func.output_types()) {
+py::tuple func_output_types(Func &func) {
+    py::list elts;
+    for (Type t : func.output_types()) {
         elts.append(t);
     }
-    return p::tuple(elts);
+    return py::tuple(elts);
 }
 
 void define_func() {
-
-    using Halide::Func;
-    using namespace func_and_stage_implementation_details;
-
-    p::enum_<h::StmtOutputFormat>("StmtOutputFormat")
-        .value("Text", h::StmtOutputFormat::Text)
-        .value("HTML", h::StmtOutputFormat::HTML)
+    py::enum_<StmtOutputFormat>("StmtOutputFormat")
+        .value("Text", StmtOutputFormat::Text)
+        .value("HTML", StmtOutputFormat::HTML)
         .export_values();
 
     auto func_class =
-        p::class_<Func>("Func",
+        py::class_<Func>("Func",
                         "A halide function. This class represents one stage in a Halide"
                         "pipeline, and is the unit by which we schedule things. By default"
                         "they are aggressively inlined, so you are encouraged to make lots"
@@ -222,13 +210,13 @@ void define_func() {
                         "                 name, and define it to return the given expression (which may\n"
                         "                 not contain free variables).\n"
                         "  Func(name)  -- Declare a new undefined function with the given name",
-                        p::init<>(p::arg("self")))
-            .def(p::init<std::string>(p::arg("self")))
-            .def(p::init<h::Expr>(p::arg("self")));
+                        py::init<>(py::arg("self")))
+            .def(py::init<std::string>(py::arg("self")))
+            .def(py::init<Expr>(py::arg("self")));
 
     func_class
         .def("allow_race_conditions", &Func::allow_race_conditions,
-             p::return_internal_reference<1>(),
+             py::return_internal_reference<1>(),
              "Specify that race conditions are permitted for this Func, "
              "which enables parallelizing over RVars even when Halide cannot "
              "prove that it is safe to do so. Use this with great caution, "
@@ -245,93 +233,93 @@ void define_func() {
 
     func_class
         .def("realize", &func_realize<>,
-             p::args("self"),
+             py::args("self"),
              realize_doc)
-        .def("realize", &func_realize<h::Target>,
-             p::args("self", "target"),
+        .def("realize", &func_realize<Target>,
+             py::args("self", "target"),
              realize_doc)
         .def("realize", &func_realize<int>,
-             p::args("self", "x"),
+             py::args("self", "x"),
              realize_doc)
-        .def("realize", &func_realize<int, h::Target>,
-             p::args("self", "x", "target"),
+        .def("realize", &func_realize<int, Target>,
+             py::args("self", "x", "target"),
              realize_doc)
         .def("realize", &func_realize<int, int>,
-             p::args("self", "x", "y"),
+             py::args("self", "x", "y"),
              realize_doc)
-        .def("realize", &func_realize<int, int, h::Target>,
-             p::args("self", "x", "y", "target"),
+        .def("realize", &func_realize<int, int, Target>,
+             py::args("self", "x", "y", "target"),
              realize_doc)
         .def("realize", &func_realize<int, int, int>,
-             p::args("self", "x", "y", "z"),
+             py::args("self", "x", "y", "z"),
              realize_doc)
-        .def("realize", &func_realize<int, int, int, h::Target>,
-             p::args("self", "x", "y", "z", "target"),
+        .def("realize", &func_realize<int, int, int, Target>,
+             py::args("self", "x", "y", "z", "target"),
              realize_doc)
         .def("realize", &func_realize<int, int, int, int>,
-             p::args("self", "x", "y", "z", "w"),
+             py::args("self", "x", "y", "z", "w"),
              realize_doc)
-        .def("realize", &func_realize<int, int, int, int, h::Target>,
-             p::args("self", "x", "y", "z", "w", "target"),
+        .def("realize", &func_realize<int, int, int, int, Target>,
+             py::args("self", "x", "y", "z", "w", "target"),
              realize_doc)
-        .def("realize", &func_realize_into<h::Buffer<uint8_t>>,
-             p::args("self", "output"),
+        .def("realize", &func_realize_into<Buffer<uint8_t>>,
+             py::args("self", "output"),
              realize_into_doc)
-        .def("realize", &func_realize_into<h::Buffer<uint8_t>, h::Target>,
-             p::args("self", "output", "target"),
+        .def("realize", &func_realize_into<Buffer<uint8_t>, Target>,
+             py::args("self", "output", "target"),
              realize_into_doc)
-        .def("realize", &func_realize_into<h::Buffer<uint16_t>>,
-             p::args("self", "output"),
+        .def("realize", &func_realize_into<Buffer<uint16_t>>,
+             py::args("self", "output"),
              realize_into_doc)
-        .def("realize", &func_realize_into<h::Buffer<uint16_t>, h::Target>,
-             p::args("self", "output", "target"),
+        .def("realize", &func_realize_into<Buffer<uint16_t>, Target>,
+             py::args("self", "output", "target"),
              realize_into_doc)
-        .def("realize", &func_realize_into<h::Buffer<uint32_t>>,
-             p::args("self", "output"),
+        .def("realize", &func_realize_into<Buffer<uint32_t>>,
+             py::args("self", "output"),
              realize_into_doc)
-        .def("realize", &func_realize_into<h::Buffer<uint32_t>, h::Target>,
-             p::args("self", "output", "target"),
+        .def("realize", &func_realize_into<Buffer<uint32_t>, Target>,
+             py::args("self", "output", "target"),
              realize_into_doc)
-        .def("realize", &func_realize_into<h::Buffer<int8_t>>,
-             p::args("self", "output"),
+        .def("realize", &func_realize_into<Buffer<int8_t>>,
+             py::args("self", "output"),
              realize_into_doc)
-        .def("realize", &func_realize_into<h::Buffer<int8_t>, h::Target>,
-             p::args("self", "output", "target"),
+        .def("realize", &func_realize_into<Buffer<int8_t>, Target>,
+             py::args("self", "output", "target"),
              realize_into_doc)
-        .def("realize", &func_realize_into<h::Buffer<int16_t>>,
-             p::args("self", "output"),
+        .def("realize", &func_realize_into<Buffer<int16_t>>,
+             py::args("self", "output"),
              realize_into_doc)
-        .def("realize", &func_realize_into<h::Buffer<int16_t>, h::Target>,
-             p::args("self", "output", "target"),
+        .def("realize", &func_realize_into<Buffer<int16_t>, Target>,
+             py::args("self", "output", "target"),
              realize_into_doc)
-        .def("realize", &func_realize_into<h::Buffer<int32_t>>,
-             p::args("self", "output"),
+        .def("realize", &func_realize_into<Buffer<int32_t>>,
+             py::args("self", "output"),
              realize_into_doc)
-        .def("realize", &func_realize_into<h::Buffer<int32_t>, h::Target>,
-             p::args("self", "output", "target"),
+        .def("realize", &func_realize_into<Buffer<int32_t>, Target>,
+             py::args("self", "output", "target"),
              realize_into_doc)
-        .def("realize", &func_realize_into<h::Buffer<float>>,
-             p::args("self", "output"),
+        .def("realize", &func_realize_into<Buffer<float>>,
+             py::args("self", "output"),
              realize_into_doc)
-        .def("realize", &func_realize_into<h::Buffer<float>, h::Target>,
-             p::args("self", "output", "target"),
+        .def("realize", &func_realize_into<Buffer<float>, Target>,
+             py::args("self", "output", "target"),
              realize_into_doc)
-        .def("realize", &func_realize_into<h::Buffer<double>>,
-             p::args("self", "output"),
+        .def("realize", &func_realize_into<Buffer<double>>,
+             py::args("self", "output"),
              realize_into_doc)
-        .def("realize", &func_realize_into<h::Buffer<double>, h::Target>,
-             p::args("self", "output", "target"),
+        .def("realize", &func_realize_into<Buffer<double>, Target>,
+             py::args("self", "output", "target"),
              realize_into_doc)
         .def("realize", &func_realize_tuple<>,
-             p::args("self", "output"),
+             py::args("self", "output"),
              realize_into_doc)
-        .def("realize", &func_realize_tuple<h::Target>,
-             p::args("self", "output", "target"),
+        .def("realize", &func_realize_tuple<Target>,
+             py::args("self", "output", "target"),
              realize_into_doc);
 
     func_class.def("compile_to_bitcode", &func_compile_to_bitcode0,
                    func_compile_to_bitcode0_overloads(
-                       p::args("self", "filename", "args", "fn_name", "target"),
+                       py::args("self", "filename", "args", "fn_name", "target"),
                        "Statically compile this function to llvm bitcode, with the "
                        "given filename (which should probably end in .bc), type "
                        "signature, and C function name (which defaults to the same name "
@@ -339,7 +327,7 @@ void define_func() {
 
     func_class.def("compile_to_object", &func_compile_to_object0,
                    func_compile_to_object0_overloads(
-                       p::args("self", "filename", "args", "fn_name", "target"),
+                       py::args("self", "filename", "args", "fn_name", "target"),
                        "Statically compile this function to an object file, with the "
                        "given filename (which should probably end in .o or .obj), type "
                        "signature, and C function name (which defaults to the same name "
@@ -348,7 +336,7 @@ void define_func() {
 
     func_class.def("compile_to_header", &func_compile_to_header0,
                    func_compile_to_header0_overloads(
-                       p::args("self", "filename", "args", "fn_name", "target"),
+                       py::args("self", "filename", "args", "fn_name", "target"),
                        "Emit a header file with the given filename for this "
                        "function. The header will define a function with the type "
                        "signature given by the second argument, and a name given by the "
@@ -359,7 +347,7 @@ void define_func() {
 
     func_class.def("compile_to_assembly", &func_compile_to_assembly0,
                    func_compile_to_assembly0_overloads(
-                       p::args("self", "filename", "args", "fn_name", "target"),
+                       py::args("self", "filename", "args", "fn_name", "target"),
                        " Statically compile this function to text assembly equivalent "
                        " to the object file generated by compile_to_object. This is "
                        " useful for checking what Halide is producing without having to "
@@ -368,7 +356,7 @@ void define_func() {
 
     func_class.def("compile_to_c", &func_compile_to_c0,
                    func_compile_to_c0_overloads(
-                       p::args("self", "filename", "args", "fn_name", "target"),
+                       py::args("self", "filename", "args", "fn_name", "target"),
                        "Statically compile this function to C source code. This is "
                        "useful for providing fallback code paths that will compile on "
                        "many platforms. Vectorization will fail, and parallelization "
@@ -377,20 +365,20 @@ void define_func() {
     func_class.def("compile_to_file",
                    &func_compile_to_file0,
                    func_compile_to_file0_overloads(
-                       p::args("self", "filename_prefix", "args", "fn_name", "target"),
+                       py::args("self", "filename_prefix", "args", "fn_name", "target"),
                        "Compile to object file and header pair, with the given arguments. "
                        "The name defaults to the same name as the Halide Func."));
 
-    func_class.def("compile_jit", &func_compile_jit1, p::args("self", "target"),
+    func_class.def("compile_jit", &func_compile_jit1, py::args("self", "target"),
                    "Eagerly jit compile the function to machine code. This "
                    "normally happens on the first call to realize. If you're "
                    "running your halide pipeline inside time-sensitive code and "
                    "wish to avoid including the time taken to compile a pipeline, "
                    "then you can call this ahead of time. Returns the raw function "
                    "pointer to the compiled pipeline.")
-        .def("compile_jit", &func_compile_jit0, p::arg("self"));
+        .def("compile_jit", &func_compile_jit0, py::arg("self"));
 
-    func_class.def("debug_to_file", &Func::debug_to_file, p::args("self", "filename"),
+    func_class.def("debug_to_file", &Func::debug_to_file, py::args("self", "filename"),
                    "When this function is compiled, include code that dumps its values "
                    "to a file after it is realized, for the purpose of debugging. "
                    "The file covers the realized extent at the point in the schedule that "
@@ -400,87 +388,87 @@ void define_func() {
 
     func_class.def("compile_to_lowered_stmt", &func_compile_to_lowered_stmt0,
                    func_compile_to_lowered_stmt0_overloads(
-                       p::args("self", "filename", "args", "fmt", "target"),
+                       py::args("self", "filename", "args", "fmt", "target"),
                        "Write out an internal representation of lowered code. Useful "
                        "for analyzing and debugging scheduling. Can emit html or plain text."));
 
-    func_class.def("print_loop_nest", &Func::print_loop_nest, p::arg("self"),
+    func_class.def("print_loop_nest", &Func::print_loop_nest, py::arg("self"),
                    "Write out the loop nests specified by the schedule for this "
                    "Function. Helpful for understanding what a schedule is doing.");
 
-    func_class.def("name", &Func::name, p::arg("self"),
-                   p::return_value_policy<p::copy_const_reference>(),
+    func_class.def("name", &Func::name, py::arg("self"),
+                   py::return_value_policy<py::copy_const_reference>(),
                    "The name of this function, either given during construction, or automatically generated.");
 
-    func_class.def("args", &Func::args, p::arg("self"),
+    func_class.def("args", &Func::args, py::arg("self"),
                    "Get the pure arguments.");
 
-    func_class.def("value", &Func::value, p::arg("self"),
+    func_class.def("value", &Func::value, py::arg("self"),
                    "The right-hand-side value of the pure definition of this "
                    "function. Causes an error if there's no pure definition, or if "
                    "the function is defined to return multiple values.");
 
-    func_class.def("values", &Func::values, p::arg("self"),
+    func_class.def("values", &Func::values, py::arg("self"),
                    "The values returned by this function. An error if the function "
                    "has not been been defined. Returns a tuple with one element for "
                    "functions defined to return a single value.");
 
-    func_class.def("defined", &Func::defined, p::arg("self"),
+    func_class.def("defined", &Func::defined, py::arg("self"),
                    "Does this function have at least a pure definition.");
 
-    func_class.def("update_args", &Func::update_args, (p::arg("self"), p::arg("idx") = 0),
-                   p::return_value_policy<p::copy_const_reference>(),
+    func_class.def("update_args", &Func::update_args, (py::arg("self"), py::arg("idx") = 0),
+                   py::return_value_policy<py::copy_const_reference>(),
                    "Get the left-hand-side of the update definition. An empty "
                    "vector if there's no update definition. If there are "
                    "multiple update definitions for this function, use the "
                    "argument to select which one you want.");
 
-    func_class.def("update_value", &Func::update_value, (p::arg("self"), p::arg("idx") = 0),
+    func_class.def("update_value", &Func::update_value, (py::arg("self"), py::arg("idx") = 0),
                    "Get the right-hand-side of an update definition. An error if "
                    "there's no update definition. If there are multiple "
                    "update definitions for this function, use the argument to "
                    "select which one you want.");
 
-    func_class.def("update_values", &Func::update_values, (p::arg("self"), p::arg("idx") = 0),
+    func_class.def("update_values", &Func::update_values, (py::arg("self"), py::arg("idx") = 0),
                    "Get the right-hand-side of an update definition for "
                    "functions that returns multiple values. An error if there's no "
                    "update definition. Returns a Tuple with one element for "
                    "functions that return a single value.");
 
-    func_class.def("rvars", &Func::rvars, (p::arg("self"), p::arg("idx") = 0),
+    func_class.def("rvars", &Func::rvars, (py::arg("self"), py::arg("idx") = 0),
                    "Get the reduction variables for an update definition, if there is one.");
 
     func_class
-        .def("has_update_definition", &Func::has_update_definition, p::arg("self"),
+        .def("has_update_definition", &Func::has_update_definition, py::arg("self"),
              "Does this function have at least one update definition?")
-        .def("num_update_definitions", &Func::num_update_definitions, p::arg("self"),
+        .def("num_update_definitions", &Func::num_update_definitions, py::arg("self"),
              "How many update definitions does this function have?");
 
-    func_class.def("is_extern", &Func::is_extern, p::arg("self"),
+    func_class.def("is_extern", &Func::is_extern, py::arg("self"),
                    "Is this function an external stage? That is, was it defined "
                    "using define_extern?");
 
     func_class.def("define_extern", &func_define_extern0,
-                   p::args("self", "function_name", "params", "output_type", "dimensionality"),
+                   py::args("self", "function_name", "params", "output_type", "dimensionality"),
                    "Add an extern definition for this Func. This lets you define a "
                    "Func that represents an external pipeline stage. You can, for "
                    "example, use it to wrap a call to an extern library such as "
                    "fftw.")
         .def("define_extern", &func_define_extern1,
-             p::args("self", "function_name", "params", "output_types", "dimensionality"));
+             py::args("self", "function_name", "params", "output_types", "dimensionality"));
 
-    func_class.def("output_types", &func_output_types, p::arg("self"),
+    func_class.def("output_types", &func_output_types, py::arg("self"),
                    "Get the types of the outputs of this Func.");
 
-    func_class.def("outputs", &Func::outputs, p::arg("self"),
+    func_class.def("outputs", &Func::outputs, py::arg("self"),
                    "Get the number of outputs of this Func. Corresponds to the "
                    "size of the Tuple this Func was defined to return.");
 
-    func_class.def("extern_function_name", &Func::extern_function_name, p::arg("self"),
-                   p::return_value_policy<p::copy_const_reference>(),
+    func_class.def("extern_function_name", &Func::extern_function_name, py::arg("self"),
+                   py::return_value_policy<py::copy_const_reference>(),
                    "Get the name of the extern function called for an extern definition.");
 
-    func_class.def("dimensions", &Func::dimensions, p::arg("self"),
+    func_class.def("dimensions", &Func::dimensions, py::arg("self"),
                    "The dimensionality (number of arguments) of this function. Zero if the function is not yet defined.");
 
     func_class.def("__getitem__", &func_getitem_operator,
@@ -503,49 +491,49 @@ void define_func() {
 
     // FIXME should share these definitions with Stage instead of having copy and paste code
 
-    func_class.def("split", &func_split<Func>, p::args("self", "old", "outer", "inner", "factor"),
-                   p::return_internal_reference<1>(),
+    func_class.def("split", &func_split<Func>, py::args("self", "old", "outer", "inner", "factor"),
+                   py::return_internal_reference<1>(),
                    "Split a dimension into inner and outer subdimensions with the "
                    "given names, where the inner dimension iterates from 0 to "
                    "factor-1. The inner and outer subdimensions can then be dealt "
                    "with using the other scheduling calls. It's ok to reuse the old "
                    "variable name as either the inner or outer variable.")
-        .def("fuse", &Func::fuse, p::args("self", "inner", "outer", "fused"),
-             p::return_internal_reference<1>(),
+        .def("fuse", &Func::fuse, py::args("self", "inner", "outer", "fused"),
+             py::return_internal_reference<1>(),
              "Join two dimensions into a single fused dimenion. The fused "
              "dimension covers the product of the extents of the inner and "
              "outer dimensions given.")
-        .def("serial", &Func::serial, p::args("self", "var"),
-             p::return_internal_reference<1>(),
+        .def("serial", &Func::serial, py::args("self", "var"),
+             py::return_internal_reference<1>(),
              "Mark a dimension to be traversed serially. This is the default.");
 
-    func_class.def("parallel", &func_parallel0<Func>, p::args("self", "var"),
-                   p::return_internal_reference<1>(),
+    func_class.def("parallel", &func_parallel0<Func>, py::args("self", "var"),
+                   py::return_internal_reference<1>(),
                    "Mark a dimension (Var instance) to be traversed in parallel.")
-        .def("parallel", &func_parallel1<Func>, p::args("self", "var", "factor"),
-             p::return_internal_reference<1>());
+        .def("parallel", &func_parallel1<Func>, py::args("self", "var", "factor"),
+             py::return_internal_reference<1>());
 
-    func_class.def("vectorize", &func_vectorize1<Func>, p::args("self", "var", "factor"),
-                   p::return_internal_reference<1>(),
+    func_class.def("vectorize", &func_vectorize1<Func>, py::args("self", "var", "factor"),
+                   py::return_internal_reference<1>(),
                    "Split a dimension (Var instance) by the given int factor, then vectorize the "
                    "inner dimension. This is how you vectorize a loop of unknown "
                    "size. The variable to be vectorized should be the innermost "
                    "one. After this call, var refers to the outer dimension of the "
                    "split.")
-        .def("vectorize", &func_vectorize0<Func>, p::args("self", "var"),
-             p::return_internal_reference<1>());
+        .def("vectorize", &func_vectorize0<Func>, py::args("self", "var"),
+             py::return_internal_reference<1>());
 
-    func_class.def("unroll", &func_unroll1<Func>, p::args("self", "var", "factor"),
-                   p::return_internal_reference<1>(),
+    func_class.def("unroll", &func_unroll1<Func>, py::args("self", "var", "factor"),
+                   py::return_internal_reference<1>(),
                    "Split a dimension by the given factor, then unroll the inner "
                    "dimension. This is how you unroll a loop of unknown size by "
                    "some constant factor. After this call, var refers to the outer "
                    "dimension of the split.")
-        .def("unroll", &func_unroll0<Func>, p::args("self", "var"),
-             p::return_internal_reference<1>());
+        .def("unroll", &func_unroll0<Func>, py::args("self", "var"),
+             py::return_internal_reference<1>());
 
-    func_class.def("bound", &Func::bound, p::args("self", "var", "min", "extent"),
-                   p::return_internal_reference<1>(),
+    func_class.def("bound", &Func::bound, py::args("self", "var", "min", "extent"),
+                   py::return_internal_reference<1>(),
                    "Statically declare that the range over which a function should "
                    "be evaluated is given by the second and third arguments. This "
                    "can let Halide perform some optimizations. E.g. if you know "
@@ -555,33 +543,33 @@ void define_func() {
                    "more of this function than the bounds you have stated, a "
                    "runtime error will occur when you try to run your pipeline. ");
 
-    func_class.def("tile", &func_tile0<Func>, p::args("self", "x", "y", "xo", "yo", "xi", "yi", "xfactor", "yfactor"),
-                   p::return_internal_reference<1>(),
+    func_class.def("tile", &func_tile0<Func>, py::args("self", "x", "y", "xo", "yo", "xi", "yi", "xfactor", "yfactor"),
+                   py::return_internal_reference<1>(),
                    "Split two dimensions at once by the given factors, and then "
                    "reorder the resulting dimensions to be xi, yi, xo, yo from "
                    "innermost outwards. This gives a tiled traversal.");
 
-    func_class.def("tile", &func_tile1<Func>, p::args("self", "x", "y", "xi", "yi", "xfactor", "yfactor"),
-                   p::return_internal_reference<1>(),
+    func_class.def("tile", &func_tile1<Func>, py::args("self", "x", "y", "xi", "yi", "xfactor", "yfactor"),
+                   py::return_internal_reference<1>(),
                    "A shorter form of tile, which reuses the old variable names as the new outer dimensions");
 
-    func_class.def("reorder", &func_reorder0<Func, p::tuple>, p::args("self", "vars"),
-                   p::return_internal_reference<1>(),
+    func_class.def("reorder", &func_reorder0<Func, py::tuple>, py::args("self", "vars"),
+                   py::return_internal_reference<1>(),
                    "Reorder variables to have the given nesting order, "
                    "from innermost out")
-        .def("reorder", &func_reorder0<Func, p::list>, p::args("self", "vars"),
-             p::return_internal_reference<1>(),
+        .def("reorder", &func_reorder0<Func, py::list>, py::args("self", "vars"),
+             py::return_internal_reference<1>(),
              "Reorder variables to have the given nesting order, "
              "from innermost out")
-        .def("reorder", &func_reorder1<Func>, (p::arg("self"), p::arg("v0"), p::arg("v1") = p::object(),
-                                               p::arg("v2") = p::object(), p::arg("v3") = p::object(),
-                                               p::arg("v4") = p::object(), p::arg("v5") = p::object()),
-             p::return_internal_reference<1>(),
+        .def("reorder", &func_reorder1<Func>, (py::arg("self"), py::arg("v0"), py::arg("v1") = py::object(),
+                                               py::arg("v2") = py::object(), py::arg("v3") = py::object(),
+                                               py::arg("v4") = py::object(), py::arg("v5") = py::object()),
+             py::return_internal_reference<1>(),
              "Reorder variables to have the given nesting order, "
              "from innermost out");
 
-    func_class.def("rename", &Func::rename, p::args("self", "old_name", "new_name"),
-                   p::return_internal_reference<1>(),
+    func_class.def("rename", &Func::rename, py::args("self", "old_name", "new_name"),
+                   py::return_internal_reference<1>(),
                    "Rename a dimension. Equivalent to split with a inner size of one.");
 
     const std::string reorder_storage_doc =
@@ -598,74 +586,74 @@ void define_func() {
         "If you leave out some dimensions, those remain in the same "
         "positions in the nesting order while the specified variables "
         "are reordered around them.";
-    func_class.def("reorder_storage", &func_reorder_storage0<Func, p::tuple>, p::args("self", "dims"),
-                   p::return_internal_reference<1>(), reorder_storage_doc.c_str())
-        .def("reorder_storage", &func_reorder_storage0<Func, p::list>, p::args("self", "dims"),
-             p::return_internal_reference<1>(), reorder_storage_doc.c_str())
-        .def("reorder_storage", &func_reorder_storage1<Func>, (p::arg("self"), p::arg("v0"), p::arg("v1"),
-                                                               p::arg("v2") = p::object(), p::arg("v3") = p::object(),
-                                                               p::arg("v4") = p::object(), p::arg("v5") = p::object()),
-             p::return_internal_reference<1>(), reorder_storage_doc.c_str());
+    func_class.def("reorder_storage", &func_reorder_storage0<Func, py::tuple>, py::args("self", "dims"),
+                   py::return_internal_reference<1>(), reorder_storage_doc.c_str())
+        .def("reorder_storage", &func_reorder_storage0<Func, py::list>, py::args("self", "dims"),
+             py::return_internal_reference<1>(), reorder_storage_doc.c_str())
+        .def("reorder_storage", &func_reorder_storage1<Func>, (py::arg("self"), py::arg("v0"), py::arg("v1"),
+                                                               py::arg("v2") = py::object(), py::arg("v3") = py::object(),
+                                                               py::arg("v4") = py::object(), py::arg("v5") = py::object()),
+             py::return_internal_reference<1>(), reorder_storage_doc.c_str());
 
-    func_class.def("compute_at", &func_compute_at0, p::args("self", "f", "var"),
-                   p::return_internal_reference<1>(),
+    func_class.def("compute_at", &func_compute_at0, py::args("self", "f", "var"),
+                   py::return_internal_reference<1>(),
                    "Compute this function as needed for each unique value of the "
                    "given var (can be a Var or an RVar) for the given calling function f.")
-        .def("compute_at", &func_compute_at1, p::args("self", "f", "var"),
-             p::return_internal_reference<1>());
+        .def("compute_at", &func_compute_at1, py::args("self", "f", "var"),
+             py::return_internal_reference<1>());
 
-    func_class.def("compute_root", &Func::compute_root, p::arg("self"),
-                   p::return_internal_reference<1>(),
+    func_class.def("compute_root", &Func::compute_root, py::arg("self"),
+                   py::return_internal_reference<1>(),
                    "Compute all of this function once ahead of time.");
 
-    func_class.def("store_at", &func_store_at0, p::args("self", "f", "var"),
-                   p::return_internal_reference<1>(),
+    func_class.def("store_at", &func_store_at0, py::args("self", "f", "var"),
+                   py::return_internal_reference<1>(),
                    "Allocate storage for this function within f's loop over "
                    "var (can be a Var or an RVar). Scheduling storage is optional, and can be used to "
                    "separate the loop level at which storage occurs from the loop "
                    "level at which computation occurs to trade off between locality "
                    "and redundant work.")
-        .def("store_at", &func_store_at1, p::args("self", "f", "var"),
-             p::return_internal_reference<1>());
+        .def("store_at", &func_store_at1, py::args("self", "f", "var"),
+             py::return_internal_reference<1>());
 
-    func_class.def("store_root", &Func::store_root, p::arg("self"),
-                   p::return_internal_reference<1>(),
+    func_class.def("store_root", &Func::store_root, py::arg("self"),
+                   py::return_internal_reference<1>(),
                    "Equivalent to Func.store_at, but schedules storage outside the outermost loop.");
 
-    func_class.def("compute_inline", &Func::compute_inline, p::arg("self"),
-                   p::return_internal_reference<1>(),
+    func_class.def("compute_inline", &Func::compute_inline, py::arg("self"),
+                   py::return_internal_reference<1>(),
                    "Aggressively inline all uses of this function. This is the "
                    "default schedule, so you're unlikely to need to call this. For "
                    "a reduction, that means it gets computed as close to the "
                    "innermost loop as possible.");
 
-    func_class.def("update", &Func::update, (p::arg("self"), p::arg("idx") = 0),
+    func_class.def("update", &Func::update, (py::arg("self"), py::arg("idx") = 0),
                    "Get a handle on the update step of a reduction for the "
                    "purposes of scheduling it. Only the pure dimensions of the "
                    "update step can be meaningfully manipulated (see RDom).");
 
-    func_class.def("function", &Func::function, p::arg("self"),
+    func_class.def("function", &Func::function, py::arg("self"),
                    "Get a handle on the internal halide function that this Func represents. "
                    "Useful if you want to do introspection on Halide functions.")
-        .def("trace_loads", &Func::trace_loads, p::arg("self"),
-             p::return_internal_reference<1>(),
+        .def("trace_loads", &Func::trace_loads, py::arg("self"),
+             py::return_internal_reference<1>(),
              "Trace all loads from this Func by emitting calls to "
              "halide_trace. If the Func is inlined, this has no effect.")
-        .def("trace_stores", &Func::trace_stores, p::arg("self"),
-             p::return_internal_reference<1>(),
+        .def("trace_stores", &Func::trace_stores, py::arg("self"),
+             py::return_internal_reference<1>(),
              "Trace all stores to the buffer backing this Func by emitting "
              "calls to halide_trace. If the Func is inlined, this call has no effect.")
-        .def("trace_realizations", &Func::trace_realizations, p::arg("self"),
-             p::return_internal_reference<1>(),
+        .def("trace_realizations", &Func::trace_realizations, py::arg("self"),
+             py::return_internal_reference<1>(),
              "Trace all realizations of this Func by emitting calls to halide_trace.");
 
-    func_class.def("specialize", &Func::specialize, p::args("self", "condition"),
+    func_class.def("specialize", &Func::specialize, py::args("self", "condition"),
                    "Specialize a Func. This creates a special-case version of the "
                    "Func where the given condition is true. The most effective "
                    "conditions are those of the form param == value, and boolean "
                    "Params. See C++ documentation for more details.");
 
-    func_class.def("__repr__", &func_repr, p::arg("self"));
+    func_class.def("__repr__", &func_repr, py::arg("self"));
 
     define_func_gpu_methods(func_class);
 
@@ -673,3 +661,6 @@ void define_func() {
     define_var_or_rvar();
     define_func_ref();
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyFunc.h
+++ b/python_bindings/src/PyFunc.h
@@ -1,87 +1,78 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYFUNC_H
 #define HALIDE_PYTHON_BINDINGS_PYFUNC_H
 
-#include <boost/python.hpp>
-#include <boost/python/tuple.hpp>
-#include <string>
-#include <vector>
+#include "PyHalide.h"
 
-#include "Halide.h"
+namespace Halide {
+namespace PythonBindings {
 
 void define_func();
 
-namespace func_and_stage_implementation_details {
-// These are methods shared with Stage
-
-// we use hh and bp to avoid collisions with h, b used in the rest of the code
-namespace hh = Halide;
-namespace bp = boost::python;
-
 template <typename FuncOrStage>
-FuncOrStage &func_parallel0(FuncOrStage &that, hh::VarOrRVar var) {
+FuncOrStage &func_parallel0(FuncOrStage &that, VarOrRVar var) {
     return that.parallel(var);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_parallel1(FuncOrStage &that, hh::VarOrRVar var, int factor) {
+FuncOrStage &func_parallel1(FuncOrStage &that, VarOrRVar var, int factor) {
     return that.parallel(var, factor);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_split(FuncOrStage &that, hh::VarOrRVar var, hh::VarOrRVar outer, hh::VarOrRVar inner, int factor) {
+FuncOrStage &func_split(FuncOrStage &that, VarOrRVar var, VarOrRVar outer, VarOrRVar inner, int factor) {
     return that.split(var, outer, inner, factor);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_vectorize0(FuncOrStage &that, hh::VarOrRVar var) {
+FuncOrStage &func_vectorize0(FuncOrStage &that, VarOrRVar var) {
     return that.vectorize(var);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_vectorize1(FuncOrStage &that, hh::VarOrRVar var, int factor) {
+FuncOrStage &func_vectorize1(FuncOrStage &that, VarOrRVar var, int factor) {
     return that.vectorize(var, factor);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_unroll0(FuncOrStage &that, hh::VarOrRVar var) {
+FuncOrStage &func_unroll0(FuncOrStage &that, VarOrRVar var) {
     return that.unroll(var);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_unroll1(FuncOrStage &that, hh::VarOrRVar var, int factor) {
+FuncOrStage &func_unroll1(FuncOrStage &that, VarOrRVar var, int factor) {
     return that.unroll(var, factor);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_tile0(FuncOrStage &that, hh::VarOrRVar x, hh::VarOrRVar y,
-                        hh::VarOrRVar xo, hh::VarOrRVar yo,
-                        hh::VarOrRVar xi, hh::VarOrRVar yi,
-                        hh::Expr xfactor, hh::Expr yfactor) {
+FuncOrStage &func_tile0(FuncOrStage &that, VarOrRVar x, VarOrRVar y,
+                        VarOrRVar xo, VarOrRVar yo,
+                        VarOrRVar xi, VarOrRVar yi,
+                        Expr xfactor, Expr yfactor) {
     return that.tile(x, y, xo, yo, xi, yi, xfactor, yfactor);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_tile1(FuncOrStage &that, hh::VarOrRVar x, hh::VarOrRVar y,
-                        hh::VarOrRVar xi, hh::VarOrRVar yi,
-                        hh::Expr xfactor, hh::Expr yfactor) {
+FuncOrStage &func_tile1(FuncOrStage &that, VarOrRVar x, VarOrRVar y,
+                        VarOrRVar xi, VarOrRVar yi,
+                        Expr xfactor, Expr yfactor) {
     return that.tile(x, y, xi, yi, xfactor, yfactor);
 }
 
 template <typename FuncOrStage, typename PythonIterable>
 FuncOrStage &func_reorder0(FuncOrStage &that, PythonIterable args_passed) {
-    std::vector<hh::VarOrRVar> var_or_rvar_args;
+    std::vector<VarOrRVar> var_or_rvar_args;
 
-    const size_t args_len = bp::len(args_passed);
+    const size_t args_len = py::len(args_passed);
     for (size_t i = 0; i < args_len; i += 1) {
-        bp::object o = args_passed[i];
-        bp::extract<hh::VarOrRVar> var_or_rvar_extract(o);
+        py::object o = args_passed[i];
+        py::extract<VarOrRVar> var_or_rvar_extract(o);
 
         if (var_or_rvar_extract.check()) {
             var_or_rvar_args.push_back(var_or_rvar_extract());
         } else {
             for (size_t j = 0; j < args_len; j += 1) {
-                bp::object o = args_passed[j];
-                const std::string o_str = bp::extract<std::string>(bp::str(o));
+                py::object o = args_passed[j];
+                const std::string o_str = py::extract<std::string>(py::str(o));
                 printf("Func::reorder args_passed[%lu] == %s\n", j, o_str.c_str());
             }
             throw std::invalid_argument("Func::reorder() only handles a list of (convertible to) VarOrRVar.");
@@ -92,33 +83,33 @@ FuncOrStage &func_reorder0(FuncOrStage &that, PythonIterable args_passed) {
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_reorder1(FuncOrStage &that, bp::object v0,
-                           bp::object v1, bp::object v2, bp::object v3, bp::object v4, bp::object v5) {
-    bp::list args_list;
-    for (const bp::object &v : { v0, v1, v2, v3, v4, v5 }) {
+FuncOrStage &func_reorder1(FuncOrStage &that, py::object v0,
+                           py::object v1, py::object v2, py::object v3, py::object v4, py::object v5) {
+    py::list args_list;
+    for (const py::object &v : { v0, v1, v2, v3, v4, v5 }) {
         if (not v.is_none()) {
             args_list.append(v);
         }
     }
 
-    return func_reorder0<FuncOrStage, bp::list>(that, args_list);
+    return func_reorder0<FuncOrStage, py::list>(that, args_list);
 }
 
 template <typename FuncOrStage, typename PythonIterable>
 FuncOrStage &func_reorder_storage0(FuncOrStage &that, PythonIterable args_passed) {
-    std::vector<hh::Var> var_args;
+    std::vector<Var> var_args;
 
-    const size_t args_len = bp::len(args_passed);
+    const size_t args_len = py::len(args_passed);
     for (size_t i = 0; i < args_len; i += 1) {
-        bp::object o = args_passed[i];
-        bp::extract<hh::Var &> var_extract(o);
+        py::object o = args_passed[i];
+        py::extract<Var &> var_extract(o);
 
         if (var_extract.check()) {
             var_args.push_back(var_extract());
         } else {
             for (size_t j = 0; j < args_len; j += 1) {
-                bp::object o = args_passed[j];
-                const std::string o_str = bp::extract<std::string>(bp::str(o));
+                py::object o = args_passed[j];
+                const std::string o_str = py::extract<std::string>(py::str(o));
                 printf("Func::reorder_storage args_passed[%lu] == %s\n", j, o_str.c_str());
             }
             throw std::invalid_argument("Func::reorder_storage() only handles a list of (convertible to) Var.");
@@ -129,19 +120,20 @@ FuncOrStage &func_reorder_storage0(FuncOrStage &that, PythonIterable args_passed
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_reorder_storage1(FuncOrStage &that, bp::object v0,
-                                   bp::object v1, bp::object v2,
-                                   bp::object v3, bp::object v4, bp::object v5) {
-    bp::list args_list;
-    for (const bp::object &v : { v0, v1, v2, v3, v4, v5 }) {
+FuncOrStage &func_reorder_storage1(FuncOrStage &that, py::object v0,
+                                   py::object v1, py::object v2,
+                                   py::object v3, py::object v4, py::object v5) {
+    py::list args_list;
+    for (const py::object &v : { v0, v1, v2, v3, v4, v5 }) {
         if (not v.is_none()) {
             args_list.append(v);
         }
     }
 
-    return func_reorder_storage0<FuncOrStage, bp::list>(that, args_list);
+    return func_reorder_storage0<FuncOrStage, py::list>(that, args_list);
 }
 
-}  // namespace func_and_stage_implementation_details
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYFUNC_H

--- a/python_bindings/src/PyFunc_Ref.cpp
+++ b/python_bindings/src/PyFunc_Ref.cpp
@@ -1,15 +1,9 @@
 #include "PyFunc_Ref.h"
 
-#include <boost/python.hpp>
-#include <string>
-#include <vector>
-
-#include "Halide.h"
-
 #include "PyBinaryOperators.h"
 
-namespace h = Halide;
-namespace p = boost::python;
+namespace Halide {
+namespace PythonBindings {
 
 template <typename A, typename B>
 A &iadd_func(A a, B b) {
@@ -39,38 +33,36 @@ A &idiv_func(A a, B b) {
 }
 
 void define_func_tuple_element_ref() {
-    using Halide::FuncTupleElementRef;
-
     auto func_tuple_element_ref_class =
-        p::class_<FuncTupleElementRef>("FuncTupleElementRef",
+        py::class_<FuncTupleElementRef>("FuncTupleElementRef",
                                        "A fragment of front-end syntax of the form f(x, y, z)[index], where x, "
                                        "y, z are Vars or Exprs. It could be the left-hand side of an update "
                                        "definition, or it could be a call to a function. We don't know "
                                        "until we see how this object gets used.",
-                                       p::no_init)
+                                       py::no_init)
 
-            .def("__iadd__", &iadd_func<FuncTupleElementRef &, h::Expr>, p::args("self", "expr"),
-                 p::return_internal_reference<1>(),
+            .def("__iadd__", &iadd_func<FuncTupleElementRef &, Expr>, py::args("self", "expr"),
+                 py::return_internal_reference<1>(),
                  "Define a stage that adds the given expression to Tuple component 'idx' "
                  "of this Func. The other Tuple components are unchanged. If the expression "
                  "refers to some RDom, this performs a sum reduction of the expression over "
                  "the domain. The function must already have an initial definition.")
-            .def("__isub__", &isub_func<FuncTupleElementRef &, h::Expr>, p::args("self", "expr"),
-                 p::return_internal_reference<1>(),
+            .def("__isub__", &isub_func<FuncTupleElementRef &, Expr>, py::args("self", "expr"),
+                 py::return_internal_reference<1>(),
                  "Define a stage that adds the negative of the given expression to Tuple "
                  "component 'idx' of this Func. The other Tuple components are unchanged. "
                  "If the expression refers to some RDom, this performs a sum reduction of "
                  "the negative of the expression over the domain. The function must already "
                  "have an initial definition.")
-            .def("__imul__", &imul_func<FuncTupleElementRef &, h::Expr>, p::args("self", "expr"),
-                 p::return_internal_reference<1>(),
+            .def("__imul__", &imul_func<FuncTupleElementRef &, Expr>, py::args("self", "expr"),
+                 py::return_internal_reference<1>(),
                  "Define a stage that multiplies Tuple component 'idx' of this Func by "
                  "the given expression. The other Tuple components are unchanged. If the "
                  "expression refers to some RDom, this performs a product reduction of "
                  "the expression over the domain. The function must already have an "
                  "initial definition.")
-            .def("__idiv__", &idiv_func<FuncTupleElementRef &, h::Expr>, p::args("self", "expr"),
-                 p::return_internal_reference<1>(),
+            .def("__idiv__", &idiv_func<FuncTupleElementRef &, Expr>, py::args("self", "expr"),
+                 py::return_internal_reference<1>(),
                  "Define a stage that divides Tuple component 'idx' of this Func by "
                  "the given expression. The other Tuple components are unchanged. "
                  "If the expression refers to some RDom, this performs a product "
@@ -83,43 +75,41 @@ void define_func_tuple_element_ref() {
 
     add_binary_operators_with<FuncTupleElementRef>(func_tuple_element_ref_class);
 
-    // h::Expr has empty constructor, thus self does the job
-    // h::Expr will "eat" int and float arguments via implicit conversion
-    add_binary_operators_with<h::Expr>(func_tuple_element_ref_class);
+    // Expr has empty constructor, thus self does the job
+    // Expr will "eat" int and float arguments via implicit conversion
+    add_binary_operators_with<Expr>(func_tuple_element_ref_class);
 
-    p::implicitly_convertible<FuncTupleElementRef, h::Expr>();
+    py::implicitly_convertible<FuncTupleElementRef, Expr>();
 }
 
 void define_func_ref_expr_class() {
-    using Halide::FuncRef;
-
     auto func_ref_expr_class =
-        p::class_<FuncRef>("FuncRef",
+        py::class_<FuncRef>("FuncRef",
                            "A fragment of front-end syntax of the form f(x, y, z), where x, y, "
                            "z are Vars or Exprs. If could be the left hand side of a definition or an "
                            "update definition, or it could be a call to a function. We don't know "
                            "until we see how this object gets used. ",
-                           p::no_init)
-            .def("__iadd__", &iadd_func<FuncRef &, h::Expr>, p::args("self", "expr"),
-                 p::return_internal_reference<1>(),
+                           py::no_init)
+            .def("__iadd__", &iadd_func<FuncRef &, Expr>, py::args("self", "expr"),
+                 py::return_internal_reference<1>(),
                  "Define a stage that adds the given expression to this Func. If the "
                  "expression refers to some RDom, this performs a sum reduction of the "
                  "expression over the domain. If the function does not already have a "
                  "pure definition, this sets it to zero.")
-            .def("__isub__", &isub_func<FuncRef &, h::Expr>, p::args("self", "expr"),
-                 p::return_internal_reference<1>(),
+            .def("__isub__", &isub_func<FuncRef &, Expr>, py::args("self", "expr"),
+                 py::return_internal_reference<1>(),
                  "Define a stage that adds the negative of the given expression to this "
                  "Func. If the expression refers to some RDom, this performs a sum reduction "
                  "of the negative of the expression over the domain. If the function does "
                  "not already have a pure definition, this sets it to zero.")
-            .def("__imul__", &imul_func<FuncRef &, h::Expr>, p::args("self", "expr"),
-                 p::return_internal_reference<1>(),
+            .def("__imul__", &imul_func<FuncRef &, Expr>, py::args("self", "expr"),
+                 py::return_internal_reference<1>(),
                  "Define a stage that multiplies this Func by the given expression. If the "
                  "expression refers to some RDom, this performs a product reduction of the "
                  "expression over the domain. If the function does not already have a pure "
                  "definition, this sets it to 1.")
-            .def("__idiv__", &idiv_func<FuncRef &, h::Expr>, p::args("self", "expr"),
-                 p::return_internal_reference<1>(),
+            .def("__idiv__", &idiv_func<FuncRef &, Expr>, py::args("self", "expr"),
+                 py::return_internal_reference<1>(),
                  "Define a stage that divides this Func by the given expression. "
                  "If the expression refers to some RDom, this performs a product "
                  "reduction of the inverse of the expression over the domain. If the "
@@ -138,18 +128,21 @@ void define_func_ref_expr_class() {
 
     add_binary_operators_with<FuncRef>(func_ref_expr_class);
 
-    // h::Expr has empty constructor, thus self does the job
-    // h::Expr will "eat" int and float arguments via implicit conversion
-    add_binary_operators_with<h::Expr>(func_ref_expr_class);
+    // Expr has empty constructor, thus self does the job
+    // Expr will "eat" int and float arguments via implicit conversion
+    add_binary_operators_with<Expr>(func_ref_expr_class);
 
-    p::implicitly_convertible<FuncRef, h::Expr>();
+    py::implicitly_convertible<FuncRef, Expr>();
 }
 
 void define_func_ref() {
     // only defined so that boost::python knows about these class,
     // not (yet) meant to be created or manipulated by the user
-    p::class_<h::Internal::Function> dummy("InternalFunction", p::no_init);
+    py::class_<Internal::Function> dummy("InternalFunction", py::no_init);
 
     define_func_tuple_element_ref();
     define_func_ref_expr_class();
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyFunc_Ref.h
+++ b/python_bindings/src/PyFunc_Ref.h
@@ -1,6 +1,14 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYFUNC_REF_H
 #define HALIDE_PYTHON_BINDINGS_PYFUNC_REF_H
 
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
 void define_func_ref();
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYFUNC_REF_H

--- a/python_bindings/src/PyFunc_Stage.cpp
+++ b/python_bindings/src/PyFunc_Stage.cpp
@@ -1,109 +1,105 @@
 #include "PyFunc_Stage.h"
 
-#include <boost/python.hpp>
-
-#include "Halide.h"
-
 #include "PyFunc.h"
 #include "PyFunc_gpu.h"
 
-namespace h = Halide;
-namespace p = boost::python;
+namespace Halide {
+namespace PythonBindings {
 
 void define_stage() {
-    using Halide::Stage;
-    using namespace func_and_stage_implementation_details;
-
     // only defined so that boost::python knows about these classes,
     // not (yet) meant to be created or manipulated by the user
     auto stage_class =
-        p::class_<Stage>("Stage", p::no_init)
-            .def("dump_argument_list", &Stage::dump_argument_list, p::arg("self"),
+        py::class_<Stage>("Stage", py::no_init)
+            .def("dump_argument_list", &Stage::dump_argument_list, py::arg("self"),
                  "Return a string describing the current var list taking into "
                  "account all the splits, reorders, and tiles.")
-            .def("name", &Stage::name, p::arg("self"),
+            .def("name", &Stage::name, py::arg("self"),
                  "Return the name of this stage, e.g. \"f.update(2)\"")
-            .def("allow_race_conditions", &Stage::allow_race_conditions, p::arg("self"),
-                 p::return_internal_reference<1>());
+            .def("allow_race_conditions", &Stage::allow_race_conditions, py::arg("self"),
+                 py::return_internal_reference<1>());
 
     // Scheduling calls that control how the domain of this stage is traversed.
     // "See the documentation for Func for the meanings."
 
     stage_class
-        .def("split", &func_split<Stage>, p::args("self", "old", "outer", "inner", "factor"),
-             p::return_internal_reference<1>(),
+        .def("split", &func_split<Stage>, py::args("self", "old", "outer", "inner", "factor"),
+             py::return_internal_reference<1>(),
              "Split a dimension into inner and outer subdimensions with the "
              "given names, where the inner dimension iterates from 0 to "
              "factor-1. The inner and outer subdimensions can then be dealt "
              "with using the other scheduling calls. It's ok to reuse the old "
              "variable name as either the inner or outer variable.")
-        .def("fuse", &Stage::fuse, p::args("self", "inner", "outer", "fused"),
-             p::return_internal_reference<1>(),
+        .def("fuse", &Stage::fuse, py::args("self", "inner", "outer", "fused"),
+             py::return_internal_reference<1>(),
              "Join two dimensions into a single fused dimenion. The fused "
              "dimension covers the product of the extents of the inner and "
              "outer dimensions given.")
-        .def("serial", &Stage::serial, p::args("self", "var"),
-             p::return_internal_reference<1>(),
+        .def("serial", &Stage::serial, py::args("self", "var"),
+             py::return_internal_reference<1>(),
              "Mark a dimension to be traversed serially. This is the default.");
 
-    stage_class.def("parallel", &func_parallel0<Stage>, p::args("self", "var"),
-                    p::return_internal_reference<1>(),
+    stage_class.def("parallel", &func_parallel0<Stage>, py::args("self", "var"),
+                    py::return_internal_reference<1>(),
                     "Mark a dimension (Var instance) to be traversed in parallel.")
-        .def("parallel", &func_parallel1<Stage>, p::args("self", "var", "factor"),
-             p::return_internal_reference<1>());
+        .def("parallel", &func_parallel1<Stage>, py::args("self", "var", "factor"),
+             py::return_internal_reference<1>());
 
-    stage_class.def("vectorize", &func_vectorize1<Stage>, p::args("self", "var", "factor"),
-                    p::return_internal_reference<1>(),
+    stage_class.def("vectorize", &func_vectorize1<Stage>, py::args("self", "var", "factor"),
+                    py::return_internal_reference<1>(),
                     "Split a dimension (Var instance) by the given int factor, then vectorize the "
                     "inner dimension. This is how you vectorize a loop of unknown "
                     "size. The variable to be vectorized should be the innermost "
                     "one. After this call, var refers to the outer dimension of the "
                     "split.")
-        .def("vectorize", &func_vectorize0<Stage>, p::args("self", "var"),
-             p::return_internal_reference<1>());
+        .def("vectorize", &func_vectorize0<Stage>, py::args("self", "var"),
+             py::return_internal_reference<1>());
 
-    stage_class.def("unroll", &func_unroll1<Stage>, p::args("self", "var", "factor"),
-                    p::return_internal_reference<1>(),
+    stage_class.def("unroll", &func_unroll1<Stage>, py::args("self", "var", "factor"),
+                    py::return_internal_reference<1>(),
                     "Split a dimension by the given factor, then unroll the inner "
                     "dimension. This is how you unroll a loop of unknown size by "
                     "some constant factor. After this call, var refers to the outer "
                     "dimension of the split.")
-        .def("unroll", &func_unroll0<Stage>, p::args("self", "var"),
-             p::return_internal_reference<1>());
+        .def("unroll", &func_unroll0<Stage>, py::args("self", "var"),
+             py::return_internal_reference<1>());
 
-    stage_class.def("tile", &func_tile0<Stage>, p::args("self", "x", "y", "xo", "yo", "xi", "yi", "xfactor", "yfactor"),
-                    p::return_internal_reference<1>(),
+    stage_class.def("tile", &func_tile0<Stage>, py::args("self", "x", "y", "xo", "yo", "xi", "yi", "xfactor", "yfactor"),
+                    py::return_internal_reference<1>(),
                     "Split two dimensions at once by the given factors, and then "
                     "reorder the resulting dimensions to be xi, yi, xo, yo from "
                     "innermost outwards. This gives a tiled traversal.")
-        .def("tile", &func_tile1<Stage>, p::args("self", "x", "y", "xi", "yi", "xfactor", "yfactor"),
-             p::return_internal_reference<1>(),
+        .def("tile", &func_tile1<Stage>, py::args("self", "x", "y", "xi", "yi", "xfactor", "yfactor"),
+             py::return_internal_reference<1>(),
              "A shorter form of tile, which reuses the old variable names as the new outer dimensions");
 
-    stage_class.def("reorder", &func_reorder0<Stage, p::tuple>, p::args("self", "vars"),
-                    p::return_internal_reference<1>(),
+    stage_class.def("reorder", &func_reorder0<Stage, py::tuple>, py::args("self", "vars"),
+                    py::return_internal_reference<1>(),
                     "Reorder variables to have the given nesting order, "
                     "from innermost out")
-        .def("reorder", &func_reorder0<Stage, p::list>, p::args("self", "vars"),
-             p::return_internal_reference<1>(),
+        .def("reorder", &func_reorder0<Stage, py::list>, py::args("self", "vars"),
+             py::return_internal_reference<1>(),
              "Reorder variables to have the given nesting order, "
              "from innermost out")
-        .def("reorder", &func_reorder1<Stage>, (p::arg("self"), p::arg("v0"), p::arg("v1") = p::object(),
-                                                p::arg("v2") = p::object(), p::arg("v3") = p::object(),
-                                                p::arg("v4") = p::object(), p::arg("v5") = p::object()),
-             p::return_internal_reference<1>(),
+        .def("reorder", &func_reorder1<Stage>, (py::arg("self"), py::arg("v0"), py::arg("v1") = py::object(),
+                                                py::arg("v2") = py::object(), py::arg("v3") = py::object(),
+                                                py::arg("v4") = py::object(), py::arg("v5") = py::object()),
+             py::return_internal_reference<1>(),
              "Reorder variables to have the given nesting order, "
              "from innermost out");
 
-    stage_class.def("rename", &Stage::rename, p::args("self", "old_name", "new_name"),
-                    p::return_internal_reference<1>(),
+    stage_class.def("rename", &Stage::rename, py::args("self", "old_name", "new_name"),
+                    py::return_internal_reference<1>(),
                     "Rename a dimension. Equivalent to split with a inner size of one.");
 
-    stage_class.def("specialize", &Stage::specialize, p::args("self", "condition"),
+    stage_class.def("specialize", &Stage::specialize, py::args("self", "condition"),
                     "Specialize a Func (Stage). This creates a special-case version of the "
                     "Func where the given condition is true. The most effective "
                     "conditions are those of the form param == value, and boolean "
                     "Params. See C++ documentation for more details.");
 
-    define_func_or_stage_gpu_methods<h::Stage>(stage_class);
+    define_func_or_stage_gpu_methods<Stage>(stage_class);
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyFunc_Stage.h
+++ b/python_bindings/src/PyFunc_Stage.h
@@ -1,6 +1,14 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYFUNC_STAGE_H
 #define HALIDE_PYTHON_BINDINGS_PYFUNC_STAGE_H
 
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
 void define_stage();
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYFUNC_STAGE_H

--- a/python_bindings/src/PyFunc_VarOrRVar.cpp
+++ b/python_bindings/src/PyFunc_VarOrRVar.cpp
@@ -1,29 +1,25 @@
 #include "PyFunc_VarOrRVar.h"
 
-#include <boost/python.hpp>
-#include <string>
-#include <vector>
-
-#include "Halide.h"
+namespace Halide {
+namespace PythonBindings {
 
 void define_var_or_rvar() {
-    using Halide::VarOrRVar;
-    namespace h = Halide;
-    namespace p = boost::python;
-
-    p::class_<VarOrRVar>("VarOrRVar",
+    py::class_<VarOrRVar>("VarOrRVar",
                          "A class that can represent Vars or RVars. "
                          "Used for reorder calls which can accept a mix of either.",
-                         p::init<std::string, bool>(p::args("self", "n", "r")))
-        .def(p::init<h::Var>(p::args("self", "v")))
-        .def(p::init<h::RVar>(p::args("self", "r")))
-        .def(p::init<h::RDom>(p::args("self", "r")))
-        .def("name", &VarOrRVar::name, p::arg("self"), p::return_value_policy<p::copy_const_reference>())
+                         py::init<std::string, bool>(py::args("self", "n", "r")))
+        .def(py::init<Var>(py::args("self", "v")))
+        .def(py::init<RVar>(py::args("self", "r")))
+        .def(py::init<RDom>(py::args("self", "r")))
+        .def("name", &VarOrRVar::name, py::arg("self"), py::return_value_policy<py::copy_const_reference>())
         .def_readonly("var", &VarOrRVar::var)
         .def_readonly("rvar", &VarOrRVar::rvar)
         .def_readonly("is_rvar", &VarOrRVar::is_rvar);
 
-    p::implicitly_convertible<h::Var, VarOrRVar>();
-    p::implicitly_convertible<h::RVar, VarOrRVar>();
-    p::implicitly_convertible<h::RDom, VarOrRVar>();
+    py::implicitly_convertible<Var, VarOrRVar>();
+    py::implicitly_convertible<RVar, VarOrRVar>();
+    py::implicitly_convertible<RDom, VarOrRVar>();
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyFunc_VarOrRVar.h
+++ b/python_bindings/src/PyFunc_VarOrRVar.h
@@ -1,6 +1,14 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYFUNC_VARORRVAR_H
 #define HALIDE_PYTHON_BINDINGS_PYFUNC_VARORRVAR_H
 
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
 void define_var_or_rvar();
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYFUNC_VARORRVAR_H

--- a/python_bindings/src/PyFunc_gpu.cpp
+++ b/python_bindings/src/PyFunc_gpu.cpp
@@ -1,14 +1,11 @@
 #include "PyFunc_gpu.h"
 
-#include <boost/python.hpp>
+namespace Halide {
+namespace PythonBindings {
 
-#include "Halide.h"
-
-namespace h = Halide;
-namespace p = boost::python;
-
-void define_func_gpu_methods(p::class_<h::Func> &func_class) {
-    using namespace func_and_stage_implementation_details;
-
-    define_func_or_stage_gpu_methods<h::Func>(func_class);
+void define_func_gpu_methods(py::class_<Func> &func_class) {
+    define_func_or_stage_gpu_methods<Func>(func_class);
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyFunc_gpu.h
+++ b/python_bindings/src/PyFunc_gpu.h
@@ -1,137 +1,131 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYFUNC_GPU_H
 #define HALIDE_PYTHON_BINDINGS_PYFUNC_GPU_H
 
-#include <boost/python.hpp>
+#include "PyHalide.h"
 
-#include "Halide.h"
+namespace Halide {
+namespace PythonBindings {
 
 /// Define all gpu related methods
-void define_func_gpu_methods(boost::python::class_<Halide::Func> &func_class);
-
-namespace func_and_stage_implementation_details {
-// These are methods shared with Stage
-
-// we use hh and bp to avoid colisions with h, b used in the rest of the code
-namespace hh = Halide;
-namespace bp = boost::python;
+void define_func_gpu_methods(py::class_<Func> &func_class);
 
 template <typename FuncOrStage>
-FuncOrStage &func_gpu_threads0(FuncOrStage &that, hh::VarOrRVar thread_x, hh::DeviceAPI device_api) {
+FuncOrStage &func_gpu_threads0(FuncOrStage &that, VarOrRVar thread_x, DeviceAPI device_api) {
     return that.gpu_threads(thread_x, device_api);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_gpu_threads1(FuncOrStage &that, hh::VarOrRVar thread_x, hh::VarOrRVar thread_y, hh::DeviceAPI device_api) {
+FuncOrStage &func_gpu_threads1(FuncOrStage &that, VarOrRVar thread_x, VarOrRVar thread_y, DeviceAPI device_api) {
     return that.gpu_threads(thread_x, thread_y, device_api);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_gpu_threads2(FuncOrStage &that, hh::VarOrRVar thread_x, hh::VarOrRVar thread_y, hh::VarOrRVar thread_z, hh::DeviceAPI device_api) {
+FuncOrStage &func_gpu_threads2(FuncOrStage &that, VarOrRVar thread_x, VarOrRVar thread_y, VarOrRVar thread_z, DeviceAPI device_api) {
     return that.gpu_threads(thread_x, thread_y, thread_z, device_api);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_gpu_blocks0(FuncOrStage &that, hh::VarOrRVar block_x, hh::DeviceAPI device_api) {
+FuncOrStage &func_gpu_blocks0(FuncOrStage &that, VarOrRVar block_x, DeviceAPI device_api) {
     return that.gpu_blocks(block_x, device_api);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_gpu_blocks1(FuncOrStage &that, hh::VarOrRVar block_x, hh::VarOrRVar block_y, hh::DeviceAPI device_api) {
+FuncOrStage &func_gpu_blocks1(FuncOrStage &that, VarOrRVar block_x, VarOrRVar block_y, DeviceAPI device_api) {
     return that.gpu_blocks(block_x, block_y, device_api);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_gpu_blocks2(FuncOrStage &that, hh::VarOrRVar block_x, hh::VarOrRVar block_y, hh::VarOrRVar block_z, hh::DeviceAPI device_api) {
+FuncOrStage &func_gpu_blocks2(FuncOrStage &that, VarOrRVar block_x, VarOrRVar block_y, VarOrRVar block_z, DeviceAPI device_api) {
     return that.gpu_blocks(block_x, block_y, block_z, device_api);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_gpu0(FuncOrStage &that, hh::VarOrRVar block_x, hh::VarOrRVar thread_x,
-                       hh::DeviceAPI device_api) {
+FuncOrStage &func_gpu0(FuncOrStage &that, VarOrRVar block_x, VarOrRVar thread_x,
+                       DeviceAPI device_api) {
     return that.gpu(block_x, thread_x, device_api);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_gpu1(FuncOrStage &that, hh::VarOrRVar block_x, hh::VarOrRVar block_y,
-                       hh::VarOrRVar thread_x, hh::VarOrRVar thread_y,
-                       hh::DeviceAPI device_api) {
+FuncOrStage &func_gpu1(FuncOrStage &that, VarOrRVar block_x, VarOrRVar block_y,
+                       VarOrRVar thread_x, VarOrRVar thread_y,
+                       DeviceAPI device_api) {
     return that.gpu(block_x, block_y, thread_x, thread_y, device_api);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_gpu2(FuncOrStage &that, hh::VarOrRVar block_x, hh::VarOrRVar block_y, hh::VarOrRVar block_z,
-                       hh::VarOrRVar thread_x, hh::VarOrRVar thread_y, hh::VarOrRVar thread_z,
-                       hh::DeviceAPI device_api) {
+FuncOrStage &func_gpu2(FuncOrStage &that, VarOrRVar block_x, VarOrRVar block_y, VarOrRVar block_z,
+                       VarOrRVar thread_x, VarOrRVar thread_y, VarOrRVar thread_z,
+                       DeviceAPI device_api) {
     return that.gpu(block_x, block_y, block_z, thread_x, thread_y, thread_z, device_api);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_gpu_tile0(FuncOrStage &that, hh::VarOrRVar x, hh::VarOrRVar bx,
-                            hh::Var tx, int x_size, hh::DeviceAPI device_api) {
-    return that.gpu_tile(x, bx, tx, x_size, hh::TailStrategy::Auto, device_api);
+FuncOrStage &func_gpu_tile0(FuncOrStage &that, VarOrRVar x, VarOrRVar bx,
+                            Var tx, int x_size, DeviceAPI device_api) {
+    return that.gpu_tile(x, bx, tx, x_size, TailStrategy::Auto, device_api);
 }
 template <typename FuncOrStage>
-FuncOrStage &func_gpu_tile1(FuncOrStage &that, hh::VarOrRVar x, hh::VarOrRVar bx,
-                            hh::RVar tx, int x_size, hh::DeviceAPI device_api) {
-    return that.gpu_tile(x, bx, tx, x_size, hh::TailStrategy::Auto, device_api);
-}
-
-template <typename FuncOrStage>
-FuncOrStage &func_gpu_tile2(FuncOrStage &that, hh::VarOrRVar x, hh::VarOrRVar tx,
-                            int x_size, hh::DeviceAPI device_api) {
-    return that.gpu_tile(x, tx, x_size, hh::TailStrategy::Auto, device_api);
+FuncOrStage &func_gpu_tile1(FuncOrStage &that, VarOrRVar x, VarOrRVar bx,
+                            RVar tx, int x_size, DeviceAPI device_api) {
+    return that.gpu_tile(x, bx, tx, x_size, TailStrategy::Auto, device_api);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_gpu_tile3(FuncOrStage &that, hh::VarOrRVar x, hh::VarOrRVar y,
-                            hh::VarOrRVar bx, hh::VarOrRVar by,
-                            hh::VarOrRVar tx, hh::VarOrRVar ty,
+FuncOrStage &func_gpu_tile2(FuncOrStage &that, VarOrRVar x, VarOrRVar tx,
+                            int x_size, DeviceAPI device_api) {
+    return that.gpu_tile(x, tx, x_size, TailStrategy::Auto, device_api);
+}
+
+template <typename FuncOrStage>
+FuncOrStage &func_gpu_tile3(FuncOrStage &that, VarOrRVar x, VarOrRVar y,
+                            VarOrRVar bx, VarOrRVar by,
+                            VarOrRVar tx, VarOrRVar ty,
                             int x_size, int y_size,
-                            hh::DeviceAPI device_api) {
-    return that.gpu_tile(x, y, bx, by, tx, ty, x_size, y_size, hh::TailStrategy::Auto, device_api);
+                            DeviceAPI device_api) {
+    return that.gpu_tile(x, y, bx, by, tx, ty, x_size, y_size, TailStrategy::Auto, device_api);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_gpu_tile4(FuncOrStage &that, hh::VarOrRVar x, hh::VarOrRVar y,
-                            hh::VarOrRVar tx, hh::Var ty,
+FuncOrStage &func_gpu_tile4(FuncOrStage &that, VarOrRVar x, VarOrRVar y,
+                            VarOrRVar tx, Var ty,
                             int x_size, int y_size,
-                            hh::DeviceAPI device_api) {
-    return that.gpu_tile(x, y, tx, ty, x_size, y_size, hh::TailStrategy::Auto, device_api);
+                            DeviceAPI device_api) {
+    return that.gpu_tile(x, y, tx, ty, x_size, y_size, TailStrategy::Auto, device_api);
 }
 template <typename FuncOrStage>
-FuncOrStage &func_gpu_tile5(FuncOrStage &that, hh::VarOrRVar x, hh::VarOrRVar y,
-                            hh::VarOrRVar tx, hh::RVar ty,
+FuncOrStage &func_gpu_tile5(FuncOrStage &that, VarOrRVar x, VarOrRVar y,
+                            VarOrRVar tx, RVar ty,
                             int x_size, int y_size,
-                            hh::DeviceAPI device_api) {
-    return that.gpu_tile(x, y, tx, ty, x_size, y_size, hh::TailStrategy::Auto, device_api);
+                            DeviceAPI device_api) {
+    return that.gpu_tile(x, y, tx, ty, x_size, y_size, TailStrategy::Auto, device_api);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_gpu_tile6(FuncOrStage &that, hh::VarOrRVar x, hh::VarOrRVar y, hh::VarOrRVar z,
-                            hh::VarOrRVar bx, hh::VarOrRVar by, hh::VarOrRVar bz,
-                            hh::VarOrRVar tx, hh::VarOrRVar ty, hh::VarOrRVar tz,
+FuncOrStage &func_gpu_tile6(FuncOrStage &that, VarOrRVar x, VarOrRVar y, VarOrRVar z,
+                            VarOrRVar bx, VarOrRVar by, VarOrRVar bz,
+                            VarOrRVar tx, VarOrRVar ty, VarOrRVar tz,
                             int x_size, int y_size, int z_size,
-                            hh::DeviceAPI device_api) {
-    return that.gpu_tile(x, y, z, bx, by, bz, tx, ty, tz, x_size, y_size, z_size, hh::TailStrategy::Auto, device_api);
+                            DeviceAPI device_api) {
+    return that.gpu_tile(x, y, z, bx, by, bz, tx, ty, tz, x_size, y_size, z_size, TailStrategy::Auto, device_api);
 }
 
 template <typename FuncOrStage>
-FuncOrStage &func_gpu_tile7(FuncOrStage &that, hh::VarOrRVar x, hh::VarOrRVar y, hh::VarOrRVar z,
-                            hh::VarOrRVar tx, hh::VarOrRVar ty, hh::VarOrRVar tz,
+FuncOrStage &func_gpu_tile7(FuncOrStage &that, VarOrRVar x, VarOrRVar y, VarOrRVar z,
+                            VarOrRVar tx, VarOrRVar ty, VarOrRVar tz,
                             int x_size, int y_size, int z_size,
-                            hh::DeviceAPI device_api) {
-    return that.gpu_tile(x, y, z, tx, ty, tx, x_size, y_size, z_size, hh::TailStrategy::Auto, device_api);
+                            DeviceAPI device_api) {
+    return that.gpu_tile(x, y, z, tx, ty, tx, x_size, y_size, z_size, TailStrategy::Auto, device_api);
 }
 
 /// Define all gpu related methods
 template <typename FuncOrStage>
-void define_func_or_stage_gpu_methods(bp::class_<FuncOrStage> &func_or_stage_class) {
+void define_func_or_stage_gpu_methods(py::class_<FuncOrStage> &func_or_stage_class) {
     func_or_stage_class
         .def("gpu_threads", &func_gpu_threads2<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("thread_x"), bp::arg("thread_y"), bp::arg("thread_z"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>(),
+             (py::arg("self"),
+              py::arg("thread_x"), py::arg("thread_y"), py::arg("thread_z"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>(),
              "Tell Halide that the following dimensions correspond to GPU "
              "thread indices. This is useful if you compute a producer "
              "function within the block indices of a consumer function, and "
@@ -139,21 +133,21 @@ void define_func_or_stage_gpu_methods(bp::class_<FuncOrStage> &func_or_stage_cla
              "threads. If the selected target is not an appropriate GPU, this "
              "just marks those dimensions as parallel.")
         .def("gpu_threads", &func_gpu_threads1<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("thread_x"), bp::arg("thread_y"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>())
+             (py::arg("self"),
+              py::arg("thread_x"), py::arg("thread_y"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>())
         .def("gpu_threads", &func_gpu_threads0<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("thread_x"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>());
+             (py::arg("self"),
+              py::arg("thread_x"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>());
 
     func_or_stage_class
         .def("gpu_single_thread", &FuncOrStage::gpu_single_thread,
-             (bp::arg("self"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>(),
+             (py::arg("self"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>(),
              "Tell Halide to run this stage using a single gpu thread and "
              "block. This is not an efficient use of your GPU, but it can be "
              "useful to avoid copy-back for intermediate update stages that "
@@ -161,108 +155,110 @@ void define_func_or_stage_gpu_methods(bp::class_<FuncOrStage> &func_or_stage_cla
 
     func_or_stage_class
         .def("gpu_blocks", &func_gpu_blocks2<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("block_x"), bp::arg("block_y"), bp::arg("block_z"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>(),
+             (py::arg("self"),
+              py::arg("block_x"), py::arg("block_y"), py::arg("block_z"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>(),
              "Tell Halide that the following dimensions correspond to GPU "
              "block indices. This is useful for scheduling stages that will "
              "run serially within each GPU block. If the selected target is "
              "not ptx, this just marks those dimensions as parallel.")
         .def("gpu_blocks", &func_gpu_blocks1<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("block_x"), bp::arg("block_y"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>())
+             (py::arg("self"),
+              py::arg("block_x"), py::arg("block_y"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>())
         .def("gpu_blocks", &func_gpu_blocks0<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("block_x"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>());
+             (py::arg("self"),
+              py::arg("block_x"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>());
 
     func_or_stage_class
         .def("gpu", &func_gpu2<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("block_x"), bp::arg("block_y"), bp::arg("block_z"),
-              bp::arg("thread_x"), bp::arg("thread_y"), bp::arg("thread_z"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>(),
+             (py::arg("self"),
+              py::arg("block_x"), py::arg("block_y"), py::arg("block_z"),
+              py::arg("thread_x"), py::arg("thread_y"), py::arg("thread_z"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>(),
              "Tell Halide that the following dimensions correspond to GPU "
              "block indices and thread indices. If the selected target is not "
              "ptx, these just mark the given dimensions as parallel. The "
              "dimensions are consumed by this call, so do all other "
              "unrolling, reordering, etc first.")
         .def("gpu", &func_gpu1<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("block_x"), bp::arg("block_y"),
-              bp::arg("thread_x"), bp::arg("thread_y"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>())
+             (py::arg("self"),
+              py::arg("block_x"), py::arg("block_y"),
+              py::arg("thread_x"), py::arg("thread_y"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>())
         .def("gpu", &func_gpu0<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("block_x"), bp::arg("thread_x"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>());
+             (py::arg("self"),
+              py::arg("block_x"), py::arg("thread_x"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>());
 
     func_or_stage_class
         .def("gpu_tile", &func_gpu_tile0<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("x"), bp::arg("bx"), bp::arg("tx"), bp::arg("x_size"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>(),
+             (py::arg("self"),
+              py::arg("x"), py::arg("bx"), py::arg("tx"), py::arg("x_size"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>(),
              "Short-hand for tiling a domain and mapping the tile indices "
              "to GPU block indices and the coordinates within each tile to "
              "GPU thread indices. Consumes the variables given, so do all "
              "other scheduling first.")
         .def("gpu_tile", &func_gpu_tile1<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("x"), bp::arg("bx"), bp::arg("tx"), bp::arg("x_size"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>())
+             (py::arg("self"),
+              py::arg("x"), py::arg("bx"), py::arg("tx"), py::arg("x_size"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>())
         .def("gpu_tile", &func_gpu_tile2<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("x"), bp::arg("tx"), bp::arg("x_size"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>())
+             (py::arg("self"),
+              py::arg("x"), py::arg("tx"), py::arg("x_size"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>())
         .def("gpu_tile", &func_gpu_tile3<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("x"), bp::arg("y"),
-              bp::arg("bx"), bp::arg("by"),
-              bp::arg("tx"), bp::arg("ty"),
-              bp::arg("x_size"), bp::arg("y_size"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>())
+             (py::arg("self"),
+              py::arg("x"), py::arg("y"),
+              py::arg("bx"), py::arg("by"),
+              py::arg("tx"), py::arg("ty"),
+              py::arg("x_size"), py::arg("y_size"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>())
         .def("gpu_tile", &func_gpu_tile4<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("x"), bp::arg("y"),
-              bp::arg("tx"), bp::arg("ty"),
-              bp::arg("x_size"), bp::arg("y_size"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>())
+             (py::arg("self"),
+              py::arg("x"), py::arg("y"),
+              py::arg("tx"), py::arg("ty"),
+              py::arg("x_size"), py::arg("y_size"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>())
         .def("gpu_tile", &func_gpu_tile5<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("x"), bp::arg("y"),
-              bp::arg("tx"), bp::arg("ty"),
-              bp::arg("x_size"), bp::arg("y_size"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>())
+             (py::arg("self"),
+              py::arg("x"), py::arg("y"),
+              py::arg("tx"), py::arg("ty"),
+              py::arg("x_size"), py::arg("y_size"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>())
         .def("gpu_tile", &func_gpu_tile6<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("x"), bp::arg("y"), bp::arg("z"),
-              bp::arg("bx"), bp::arg("by"), bp::arg("bz"),
-              bp::arg("tx"), bp::arg("ty"), bp::arg("tz"),
-              bp::arg("x_size"), bp::arg("y_size"), bp::arg("z_size"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>())
+             (py::arg("self"),
+              py::arg("x"), py::arg("y"), py::arg("z"),
+              py::arg("bx"), py::arg("by"), py::arg("bz"),
+              py::arg("tx"), py::arg("ty"), py::arg("tz"),
+              py::arg("x_size"), py::arg("y_size"), py::arg("z_size"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>())
         .def("gpu_tile", &func_gpu_tile7<FuncOrStage>,
-             (bp::arg("self"),
-              bp::arg("x"), bp::arg("y"), bp::arg("z"),
-              bp::arg("tx"), bp::arg("ty"), bp::arg("tz"),
-              bp::arg("x_size"), bp::arg("y_size"), bp::arg("z_size"),
-              bp::arg("device_api") = hh::DeviceAPI::Default_GPU),
-             bp::return_internal_reference<1>());
+             (py::arg("self"),
+              py::arg("x"), py::arg("y"), py::arg("z"),
+              py::arg("tx"), py::arg("ty"), py::arg("tz"),
+              py::arg("x_size"), py::arg("y_size"), py::arg("z_size"),
+              py::arg("device_api") = DeviceAPI::Default_GPU),
+             py::return_internal_reference<1>());
 }
 
-}  // namespace func_and_stage_implementation_details
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYFUNC_GPU_H

--- a/python_bindings/src/PyFunction.cpp
+++ b/python_bindings/src/PyFunction.cpp
@@ -1,23 +1,17 @@
 #include "PyFunction.h"
 
-#include <boost/python.hpp>
-#include <vector>
-
-#include "Halide.h"
+namespace Halide {
+namespace PythonBindings {
 
 void define_extern_func_argument() {
-    using Halide::ExternFuncArgument;
-    namespace h = Halide;
-    namespace p = boost::python;
-
-    p::class_<ExternFuncArgument>("ExternFuncArgument",
+    py::class_<ExternFuncArgument>("ExternFuncArgument",
                                   "An argument to an extern-defined Func. May be a Function, Buffer, "
                                   "ImageParam or Expr.",
-                                  p::no_init)
-        .def(p::init<h::Buffer<>>(p::args("self", "b")))
-        .def(p::init<h::Expr>(p::args("self", "e")))
-        .def(p::init<int>(p::args("self", "e")))
-        .def(p::init<float>(p::args("self", "e")))
+                                  py::no_init)
+        .def(py::init<Buffer<>>(py::args("self", "b")))
+        .def(py::init<Expr>(py::args("self", "e")))
+        .def(py::init<int>(py::args("self", "e")))
+        .def(py::init<float>(py::args("self", "e")))
 
         .def_readwrite("arg_type", &ExternFuncArgument::arg_type)
         .def_readwrite("buffer", &ExternFuncArgument::buffer)
@@ -29,3 +23,6 @@ void define_extern_func_argument() {
         .def("is_image_param", &ExternFuncArgument::is_image_param)
         .def("defined", &ExternFuncArgument::defined);
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyFunction.h
+++ b/python_bindings/src/PyFunction.h
@@ -1,6 +1,14 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYFUNCTION_H
 #define HALIDE_PYTHON_BINDINGS_PYFUNCTION_H
 
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
 void define_extern_func_argument();
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYFUNCTION_H

--- a/python_bindings/src/PyHalide.cpp
+++ b/python_bindings/src/PyHalide.cpp
@@ -1,4 +1,3 @@
-#include <boost/python.hpp>
 
 #include "PyArgument.h"
 #include "PyBoundaryConditions.h"
@@ -17,6 +16,8 @@
 #include "PyVar.h"
 
 BOOST_PYTHON_MODULE(halide) {
+    using namespace Halide::PythonBindings;
+
     define_argument();
     define_boundary_conditions();
     define_buffer();

--- a/python_bindings/src/PyHalide.h
+++ b/python_bindings/src/PyHalide.h
@@ -1,0 +1,30 @@
+#ifndef HALIDE_PYTHON_BINDINGS_PYHALIDE_H
+#define HALIDE_PYTHON_BINDINGS_PYHALIDE_H
+
+// Include all Boost.Python headers here
+#include <boost/python.hpp>
+#include <boost/python/operators.hpp>
+#include <boost/python/raw_function.hpp>
+#include <boost/python/self.hpp>
+#include <boost/python/stl_iterator.hpp>
+#include <boost/python/tuple.hpp>
+
+// Some very-commonly-used headers here, to simplify things.
+// (<string> must come after the boost headers in some configs.)
+#include <iostream>
+#include <string>
+#include <vector>
+
+// Everyone needs Halide.h
+#include "Halide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
+namespace py = boost::python;
+
+}  // namespace PythonBindings
+}  // namespace Halide
+
+
+#endif  // HALIDE_PYTHON_BINDINGS_PYHALIDE_H

--- a/python_bindings/src/PyIROperator.cpp
+++ b/python_bindings/src/PyIROperator.cpp
@@ -1,88 +1,81 @@
 #include "PyIROperator.h"
 
-#include <boost/python.hpp>
-// Some versions of Boost don't include raw_function in python.hpp
-#include <boost/python/raw_function.hpp>
-#include <string>
-
-#include "Halide.h"
-
-namespace h = Halide;
-namespace p = boost::python;
+namespace Halide {
+namespace PythonBindings {
 
 namespace {
 
-h::Expr reinterpret0(h::Type t, h::Expr e) {
-    return h::reinterpret(t, e);
+Expr reinterpret0(Type t, Expr e) {
+    return reinterpret(t, e);
 }
 
-h::Expr cast0(h::Type t, h::Expr e) {
+Expr cast0(Type t, Expr e) {
     return Halide::cast(t, e);
 }
 
-h::Expr select0(h::Expr condition, h::Expr true_value, h::Expr false_value) {
-    return h::select(condition, true_value, false_value);
+Expr select0(Expr condition, Expr true_value, Expr false_value) {
+    return select(condition, true_value, false_value);
 }
 
-h::Expr select1(h::Expr c1, h::Expr v1,
-                h::Expr c2, h::Expr v2,
-                h::Expr default_val) {
-    return h::select(c1, v1,
+Expr select1(Expr c1, Expr v1,
+                Expr c2, Expr v2,
+                Expr default_val) {
+    return select(c1, v1,
                      c2, v2, default_val);
 }
-h::Expr select2(h::Expr c1, h::Expr v1,
-                h::Expr c2, h::Expr v2,
-                h::Expr c3, h::Expr v3,
-                h::Expr default_val) {
-    return h::select(c1, v1,
+Expr select2(Expr c1, Expr v1,
+                Expr c2, Expr v2,
+                Expr c3, Expr v3,
+                Expr default_val) {
+    return select(c1, v1,
                      c2, v2,
                      c3, v3, default_val);
 }
-h::Expr select3(h::Expr c1, h::Expr v1,
-                h::Expr c2, h::Expr v2,
-                h::Expr c3, h::Expr v3,
-                h::Expr c4, h::Expr v4,
-                h::Expr default_val) {
-    return h::select(c1, v1,
+Expr select3(Expr c1, Expr v1,
+                Expr c2, Expr v2,
+                Expr c3, Expr v3,
+                Expr c4, Expr v4,
+                Expr default_val) {
+    return select(c1, v1,
                      c2, v2,
                      c3, v3,
                      c4, v4, default_val);
 }
-h::Expr select4(h::Expr c1, h::Expr v1,
-                h::Expr c2, h::Expr v2,
-                h::Expr c3, h::Expr v3,
-                h::Expr c4, h::Expr v4,
-                h::Expr c5, h::Expr v5,
-                h::Expr default_val) {
-    return h::select(c1, v1,
+Expr select4(Expr c1, Expr v1,
+                Expr c2, Expr v2,
+                Expr c3, Expr v3,
+                Expr c4, Expr v4,
+                Expr c5, Expr v5,
+                Expr default_val) {
+    return select(c1, v1,
                      c2, v2,
                      c3, v3,
                      c4, v4,
                      c5, v5, default_val);
 }
-h::Expr select5(h::Expr c1, h::Expr v1,
-                h::Expr c2, h::Expr v2,
-                h::Expr c3, h::Expr v3,
-                h::Expr c4, h::Expr v4,
-                h::Expr c5, h::Expr v5,
-                h::Expr c6, h::Expr v6,
-                h::Expr default_val) {
-    return h::select(c1, v1,
+Expr select5(Expr c1, Expr v1,
+                Expr c2, Expr v2,
+                Expr c3, Expr v3,
+                Expr c4, Expr v4,
+                Expr c5, Expr v5,
+                Expr c6, Expr v6,
+                Expr default_val) {
+    return select(c1, v1,
                      c2, v2,
                      c3, v3,
                      c4, v4,
                      c5, v5,
                      c6, v6, default_val);
 }
-h::Expr select6(h::Expr c1, h::Expr v1,
-                h::Expr c2, h::Expr v2,
-                h::Expr c3, h::Expr v3,
-                h::Expr c4, h::Expr v4,
-                h::Expr c5, h::Expr v5,
-                h::Expr c6, h::Expr v6,
-                h::Expr c7, h::Expr v7,
-                h::Expr default_val) {
-    return h::select(c1, v1,
+Expr select6(Expr c1, Expr v1,
+                Expr c2, Expr v2,
+                Expr c3, Expr v3,
+                Expr c4, Expr v4,
+                Expr c5, Expr v5,
+                Expr c6, Expr v6,
+                Expr c7, Expr v7,
+                Expr default_val) {
+    return select(c1, v1,
                      c2, v2,
                      c3, v3,
                      c4, v4,
@@ -91,25 +84,25 @@ h::Expr select6(h::Expr c1, h::Expr v1,
                      c7, v7, default_val);
 }
 
-std::vector<h::Expr> tuple_to_exprs(p::tuple t) {
-    const size_t c = p::len(t);
-    std::vector<h::Expr> exprs;
+std::vector<Expr> tuple_to_exprs(py::tuple t) {
+    const size_t c = py::len(t);
+    std::vector<Expr> exprs;
     exprs.reserve(c);
 
     for (size_t i = 0; i < c; i += 1) {
-        p::object o = t[i];
-        h::Expr e;
-        p::extract<h::Expr> expr_extract(o);
+        py::object o = t[i];
+        Expr e;
+        py::extract<Expr> expr_extract(o);
         if (expr_extract.check()) {
             e = expr_extract();
         } else {
             // Python 'str' is not implicitly convertible to Expr,
             // but in this context we want to explicitly check and convert.
-            p::extract<std::string> string_extract(o);
+            py::extract<std::string> string_extract(o);
             if (string_extract.check()) {
-                e = h::Expr(string_extract());
+                e = Expr(string_extract());
             } else {
-                const std::string o_str = p::extract<std::string>(p::str(o));
+                const std::string o_str = py::extract<std::string>(py::str(o));
                 throw std::invalid_argument("The value '" + o_str + "' is not convertible to Expr.");
             }
         }
@@ -118,50 +111,50 @@ std::vector<h::Expr> tuple_to_exprs(p::tuple t) {
     return exprs;
 }
 
-p::object print(p::tuple args, p::dict kwargs) {
-    return p::object(h::print(tuple_to_exprs(args)));
+py::object print(py::tuple args, py::dict kwargs) {
+    return py::object(print(tuple_to_exprs(args)));
 }
 
-p::object print_when(p::tuple args, p::dict kwargs) {
-    h::Expr condition = p::extract<h::Expr>(args[0]);
-    return p::object(h::print_when(condition, tuple_to_exprs(p::extract<p::tuple>(args.slice(1, p::_)))));
+py::object print_when(py::tuple args, py::dict kwargs) {
+    Expr condition = py::extract<Expr>(args[0]);
+    return py::object(print_when(condition, tuple_to_exprs(py::extract<py::tuple>(args.slice(1, py::_)))));
 }
 
-h::Expr random_float0() {
-    return h::random_float();
+Expr random_float0() {
+    return random_float();
 }
 
-h::Expr random_float1(h::Expr seed) {
-    return h::random_float(seed);
+Expr random_float1(Expr seed) {
+    return random_float(seed);
 }
 
-h::Expr random_int0() {
-    return h::random_int();
+Expr random_int0() {
+    return random_int();
 }
 
-h::Expr random_int1(h::Expr seed) {
-    return h::random_int(seed);
+Expr random_int1(Expr seed) {
+    return random_int(seed);
 }
 
-h::Expr undef0(h::Type type) {
-    return h::undef(type);
+Expr undef0(Type type) {
+    return undef(type);
 }
 
-h::Expr memoize_tag0(h::Expr result, const std::vector<h::Expr> &cache_key_values) {
-    return h::memoize_tag(result, cache_key_values);
+Expr memoize_tag0(Expr result, const std::vector<Expr> &cache_key_values) {
+    return memoize_tag(result, cache_key_values);
 }
 
-// p::def() doesn't allow specifying a docstring with raw_function();
+// py::def() doesn't allow specifying a docstring with raw_function();
 // this is some simple sugar to allow for it.
 // TODO: unfortunately, using raw_function() means that we don't get
 // any free type info about the Python prototype look; we should
 // probably augment docstrings that use this appropriately.
 template <class F>
-p::object def_raw(const char *name, F f, size_t min_args, const char *docstring) {
-    p::object o = p::raw_function(f, min_args);
-    p::def(name, o);
+py::object def_raw(const char *name, F f, size_t min_args, const char *docstring) {
+    py::object o = py::raw_function(f, min_args);
+    py::def(name, o);
     // Must call setattr *after* def
-    p::setattr(o, "__doc__", p::str(docstring));
+    py::setattr(o, "__doc__", py::str(docstring));
     return o;
 }
 
@@ -170,103 +163,103 @@ p::object def_raw(const char *name, F f, size_t min_args, const char *docstring)
 void define_operators() {
     // defined in IROperator.h
 
-    h::Expr (*max_exprs)(h::Expr, h::Expr) = &h::max;
-    h::Expr (*max_expr_int)(h::Expr, int) = &h::max;
-    h::Expr (*max_int_expr)(int, h::Expr) = &h::max;
+    Expr (*max_exprs)(Expr, Expr) = &max;
+    Expr (*max_expr_int)(Expr, int) = &max;
+    Expr (*max_int_expr)(int, Expr) = &max;
 
-    h::Expr (*min_exprs)(h::Expr, h::Expr) = &h::min;
-    h::Expr (*min_expr_int)(h::Expr, int) = &h::min;
-    h::Expr (*min_int_expr)(int, h::Expr) = &h::min;
+    Expr (*min_exprs)(Expr, Expr) = &min;
+    Expr (*min_expr_int)(Expr, int) = &min;
+    Expr (*min_int_expr)(int, Expr) = &min;
 
-    p::def("max", max_exprs,
-           p::args("a", "b"),
+    py::def("max", max_exprs,
+           py::args("a", "b"),
            "Returns an expression representing the greater of the two "
            "arguments, after doing any necessary type coercion using "
            "Internal::match_types. Vectorizes cleanly on most platforms "
            "(with the exception of integer types on x86 without SSE4).");
 
-    p::def("max", max_expr_int,
-           p::args("a", "b"),
+    py::def("max", max_expr_int,
+           py::args("a", "b"),
            "Returns an expression representing the greater of an expression"
            " and a constant integer.  The integer is coerced to the type of the"
            " expression. Errors if the integer is not representable as that"
            " type. Vectorizes cleanly on most platforms (with the exception of"
            " integer types on x86 without SSE4).");
 
-    p::def("max", max_int_expr,
-           p::args("a", "b"),
+    py::def("max", max_int_expr,
+           py::args("a", "b"),
            "Returns an expression representing the greater of a constant"
            " integer and an expression. The integer is coerced to the type of"
            " the expression. Errors if the integer is not representable as that"
            " type. Vectorizes cleanly on most platforms (with the exception of"
            " integer types on x86 without SSE4).");
 
-    p::def("min", min_exprs,
-           p::args("a", "b"),
+    py::def("min", min_exprs,
+           py::args("a", "b"),
            "Returns an expression representing the greater of the two "
            "arguments, after doing any necessary type coercion using "
            "Internal::match_types. Vectorizes cleanly on most platforms "
            "(with the exception of integer types on x86 without SSE4).");
 
-    p::def("min", min_expr_int,
-           p::args("a", "b"),
+    py::def("min", min_expr_int,
+           py::args("a", "b"),
            "Returns an expression representing the lesser of an expression"
            " and a constant integer.  The integer is coerced to the type of the"
            " expression. Errors if the integer is not representable as that"
            " type. Vectorizes cleanly on most platforms (with the exception of"
            " integer types on x86 without SSE4).");
 
-    p::def("min", min_int_expr,
-           p::args("a", "b"),
+    py::def("min", min_int_expr,
+           py::args("a", "b"),
            "Returns an expression representing the lesser of a constant"
            " integer and an expression. The integer is coerced to the type of"
            " the expression. Errors if the integer is not representable as that"
            " type. Vectorizes cleanly on most platforms (with the exception of"
            " integer types on x86 without SSE4).");
 
-    p::def("clamp", &h::clamp,
-           p::args("a", "min_val", "max_val"),
+    py::def("clamp", &clamp,
+           py::args("a", "min_val", "max_val"),
            "Clamps an expression to lie within the given bounds. The bounds "
            "are type-cast to match the expression. Vectorizes as well as min/max.");
 
-    p::def("abs", &h::abs, p::args("a"),
+    py::def("abs", &abs, py::args("a"),
            "Returns the absolute value of a signed integer or floating-point "
            "expression. Vectorizes cleanly. Unlike in C, abs of a signed "
            "integer returns an unsigned integer of the same bit width. This "
            "means that abs of the most negative integer doesn't overflow.");
 
-    p::def("absd", &h::absd, p::args("a", "b"),
+    py::def("absd", &absd, py::args("a", "b"),
            "Return the absolute difference between two values. Vectorizes "
            "cleanly. Returns an unsigned value of the same bit width. There are "
            "various ways to write this yourself, but they contain numerous "
            "gotchas and don't always compile to good code, so use this instead.");
 
-    p::def("select", &select0, p::args("condition", "true_value", "false_value"),
+    py::def("select", &select0, py::args("condition", "true_value", "false_value"),
            "Returns an expression similar to the ternary operator in C, except "
            "that it always evaluates all arguments. If the first argument is "
            "true, then return the second, else return the third. Typically "
            "vectorizes cleanly, but benefits from SSE41 or newer on x86.");
 
-    p::def("select", &select1, p::args("c1", "v1", "c2", "v2", "default_val"),
+    py::def("select", &select1, py::args("c1", "v1", "c2", "v2", "default_val"),
            "A multi-way variant of select similar to a switch statement in C, "
            "which can accept multiple conditions and values in pairs. Evaluates "
            "to the first value for which the condition is true. Returns the "
            "final value if all conditions are false.");
 
-    p::def("select", &select2, p::args(
+    py::def("select", &select2, py::args(
                                    "c1", "v1",
                                    "c2", "v2",
                                    "c3", "v3",
                                    "default_val"));
 
-    p::def("select", &select3, p::args(
+    py::def("select", &select3, py::args(
                                    "c1", "v1",
                                    "c2", "v2",
                                    "c3", "v3",
                                    "c4", "v4",
                                    "default_val"));
 
-    p::def("select", &select4, p::args(
+    py::def("select", &select4, py::args(
                                    "c1", "v1",
                                    "c2", "v2",
                                    "c3", "v3",
@@ -274,7 +267,7 @@ void define_operators() {
                                    "c5", "v5",
                                    "default_val"));
 
-    p::def("select", &select5, p::args(
+    py::def("select", &select5, py::args(
                                    "c1", "v1",
                                    "c2", "v2",
                                    "c3", "v3",
@@ -283,7 +276,7 @@ void define_operators() {
                                    "c6", "v6",
                                    "default_val"));
 
-    p::def("select", &select6, p::args(
+    py::def("select", &select6, py::args(
                                    "c1", "v1",
                                    "c2", "v2",
                                    "c3", "v3",
@@ -294,77 +287,77 @@ void define_operators() {
                                    "default_val"));
 
     // sin, cos, tan @{
-    p::def("sin", &h::sin, p::args("x"),
+    py::def("sin", &sin, py::args("x"),
            "Return the sine of a floating-point expression. If the argument is "
            "not floating-point, it is cast to Float(32). Does not vectorize well.");
 
-    p::def("asin", &h::asin, p::args("x"),
+    py::def("asin", &asin, py::args("x"),
            "Return the arcsine of a floating-point expression. If the argument is "
            "not floating-point, it is cast to Float(32). Does not vectorize well.");
 
-    p::def("cos", &h::cos, p::args("x"),
+    py::def("cos", &cos, py::args("x"),
            "Return the cosine of a floating-point expression. If the argument is "
            "not floating-point, it is cast to Float(32). Does not vectorize well.");
 
-    p::def("acos", &h::acos, p::args("x"),
+    py::def("acos", &acos, py::args("x"),
            "Return the arccosine of a floating-point expression. If the argument is "
            "not floating-point, it is cast to Float(32). Does not vectorize well.");
 
-    p::def("tan", &h::tan, p::args("x"),
+    py::def("tan", &tan, py::args("x"),
            "Return the tangent of a floating-point expression. If the argument is "
            "not floating-point, it is cast to Float(32). Does not vectorize well.");
 
-    p::def("atan", &h::atan, p::args("x"),
+    py::def("atan", &atan, py::args("x"),
            "Return the arctangent of a floating-point expression. If the argument is "
            "not floating-point, it is cast to Float(32). Does not vectorize well.");
 
-    p::def("atan", &h::atan2, p::args("x", "y"),
+    py::def("atan", &atan2, py::args("x", "y"),
            "Return the arctangent of a floating-point expression. If the argument is "
            "not floating-point, it is cast to Float(32). Does not vectorize well.");
 
-    p::def("atan2", &h::atan2, p::args("x", "y"),
+    py::def("atan2", &atan2, py::args("x", "y"),
            "Return the arctangent of a floating-point expression. If the argument is "
            "not floating-point, it is cast to Float(32). Does not vectorize well.");
     // @}
 
     // sinh, cosh, tanh @{
-    p::def("sinh", &h::sinh, p::args("x"),
+    py::def("sinh", &sinh, py::args("x"),
            "Return the hyperbolic sine of a floating-point expression. If the argument is "
            "not floating-point, it is cast to Float(32). Does not vectorize well.");
 
-    p::def("asinh", &h::asinh, p::args("x"),
+    py::def("asinh", &asinh, py::args("x"),
            "Return the hyperbolic arcsine of a floating-point expression. If the argument is "
            "not floating-point, it is cast to Float(32). Does not vectorize well.");
 
-    p::def("cosh", &h::cosh, p::args("x"),
+    py::def("cosh", &cosh, py::args("x"),
            "Return the hyperbolic cosine of a floating-point expression. If the argument is "
            "not floating-point, it is cast to Float(32). Does not vectorize well.");
 
-    p::def("acosh", &h::acosh, p::args("x"),
+    py::def("acosh", &acosh, py::args("x"),
            "Return the hyperbolic arccosine of a floating-point expression. If the argument is "
            "not floating-point, it is cast to Float(32). Does not vectorize well.");
 
-    p::def("tanh", &h::tanh, p::args("x"),
+    py::def("tanh", &tanh, py::args("x"),
            "Return the hyperbolic tangent of a floating-point expression. If the argument is "
            "not floating-point, it is cast to Float(32). Does not vectorize well.");
 
-    p::def("atanh", &h::atanh, p::args("x"),
+    py::def("atanh", &atanh, py::args("x"),
            "Return the hyperbolic arctangent of a floating-point expression. If the argument is "
            "not floating-point, it is cast to Float(32). Does not vectorize well.");
     // @}
 
-    p::def("sqrt", &h::sqrt, p::args("x"),
+    py::def("sqrt", &sqrt, py::args("x"),
            "Return the square root of a floating-point expression. "
            "If the argument is not floating-point, it is cast to Float(32). "
            "Typically vectorizes cleanly.");
 
-    p::def("hypot", &h::hypot, p::args("x"),
+    py::def("hypot", &hypot, py::args("x"),
            "Return the square root of the sum of the squares of two "
            "floating-point expressions. "
            "If the argument is not floating-point, it is cast to Float(32). "
            "Vectorizes cleanly.");
 
-    p::def("exp", &h::exp, p::args("x"),
+    py::def("exp", &exp, py::args("x"),
            "Return the exponential of a floating-point expression. If the "
            "argument is not floating-point, it is cast to Float(32). For "
            "Float(64) arguments, this calls the system exp function, and does "
@@ -373,7 +366,7 @@ void define_operators() {
            "large inputs, and is accurate up to the last bit of the "
            "mantissa. Vectorizes cleanly.");
 
-    p::def("log", &h::log, p::args("x"),
+    py::def("log", &log, py::args("x"),
            "Return the logarithm of a floating-point expression. If the "
            "argument is not floating-point, it is cast to Float(32). For "
            "Float(64) arguments, this calls the system log function, and does "
@@ -382,7 +375,7 @@ void define_operators() {
            "nan), and is accurate up to the last bit of the "
            "mantissa. Vectorizes cleanly.");
 
-    p::def("pow", &h::pow, p::args("x"),
+    py::def("pow", &pow, py::args("x"),
            "Return one floating point expression raised to the power of "
            "another. The type of the result is given by the type of the first "
            "argument. If the first argument is not a floating-point type, it is "
@@ -390,76 +383,76 @@ void define_operators() {
            "accurate up to the last few bits of the mantissa. Gets worse when "
            "approaching overflow. Vectorizes cleanly.");
 
-    p::def("erf", &h::erf, p::args("x"),
+    py::def("erf", &erf, py::args("x"),
            "Evaluate the error function erf. Only available for "
            "Float(32). Accurate up to the last three bits of the "
            "mantissa. Vectorizes cleanly.");
 
-    p::def("fast_log", &h::fast_log, p::args("x"),
+    py::def("fast_log", &fast_log, py::args("x"),
            "Fast approximate cleanly vectorizable log for Float(32). Returns "
            "nonsense for x <= 0.0f. Accurate up to the last 5 bits of the "
            "mantissa. Vectorizes cleanly.");
 
-    p::def("fast_exp", &h::fast_exp, p::args("x"),
+    py::def("fast_exp", &fast_exp, py::args("x"),
            "Fast approximate cleanly vectorizable exp for Float(32). Returns "
            "nonsense for inputs that would overflow or underflow. Typically "
            "accurate up to the last 5 bits of the mantissa. Gets worse when "
            "approaching overflow. Vectorizes cleanly.");
 
-    p::def("fast_pow", &h::fast_pow, p::args("x"),
+    py::def("fast_pow", &fast_pow, py::args("x"),
            "Fast approximate cleanly vectorizable pow for Float(32). Returns "
            "nonsense for x < 0.0f. Accurate up to the last 5 bits of the "
            "mantissa for typical exponents. Gets worse when approaching "
            "overflow. Vectorizes cleanly.");
 
-    p::def("fast_inverse", &h::fast_inverse, p::args("x"),
+    py::def("fast_inverse", &fast_inverse, py::args("x"),
            "Fast approximate inverse for Float(32). Corresponds to the rcpps "
            "instruction on x86, and the vrecpe instruction on ARM. "
            "Vectorizes cleanly.");
 
-    p::def("fast_inverse_sqrt", &h::fast_inverse_sqrt, p::args("x"),
+    py::def("fast_inverse_sqrt", &fast_inverse_sqrt, py::args("x"),
            "Fast approximate inverse square root for Float(32). Corresponds to "
            "the rsqrtps instruction on x86, and the vrsqrte instruction on "
            "ARM. Vectorizes cleanly.");
 
-    p::def("floor", &h::floor, p::args("x"),
+    py::def("floor", &floor, py::args("x"),
            "Return the greatest whole number less than or equal to a floating-point expression. "
            "If the argument is not floating-point, it is cast to Float(32). "
            "The return value is still in floating point, despite being a whole number. "
            "Vectorizes cleanly");
 
-    p::def("ceil", &h::ceil, p::args("x"),
+    py::def("ceil", &ceil, py::args("x"),
            "Return the least whole number less than or equal to a floating-point expression. "
            "If the argument is not floating-point, it is cast to Float(32). "
            "The return value is still in floating point, despite being a whole number. "
            "Vectorizes cleanly");
 
-    p::def("round", &h::round, p::args("x"),
+    py::def("round", &round, py::args("x"),
            "Return the whole number closest to a floating-point expression. "
            "If the argument is not floating-point, it is cast to Float(32). "
            "The return value is still in floating point, despite being a whole number. "
            "Vectorizes cleanly");
 
-    p::def("trunc", &h::trunc, p::args("x"),
+    py::def("trunc", &trunc, py::args("x"),
            "Return the integer part of a floating-point expression. "
            "If the argument is not floating-point, it is cast to Float(32). "
            "The return value is still in floating point, despite being a whole number. "
            "Vectorizes cleanly");
 
-    p::def("fract", &h::fract, p::args("x"),
+    py::def("fract", &fract, py::args("x"),
            "Return the fractional part of a floating-point expression. "
            "If the argument is not floating-point, it is cast to Float(32). "
            "The return value is in floating point, even when it is a whole number. "
            "Vectorizes cleanly");
 
-    p::def("is_nan", &h::is_nan, p::args("x"),
+    py::def("is_nan", &is_nan, py::args("x"),
            "Returns true if the argument is a Not a Number (NaN). "
            "Requires a floating point argument.  Vectorizes cleanly.");
 
-    p::def("reinterpret", &reinterpret0, p::args("t, e"),
+    py::def("reinterpret", &reinterpret0, py::args("t, e"),
            "Reinterpret the bits of one value as another type.");
 
-    p::def("cast", &cast0, p::args("t", "e"),
+    py::def("cast", &cast0, py::args("t", "e"),
            "Cast an expression to a new type.");
 
     def_raw("print_when", print_when, 2,
@@ -471,7 +464,7 @@ void define_operators() {
            "evaluated. It also prints out everything else in the arguments "
            "list, separated by spaces. This can include string literals.");
 
-    p::def("lerp", &h::lerp, p::args("zero_val", "one_val", "weight"),
+    py::def("lerp", &lerp, py::args("zero_val", "one_val", "weight"),
            "Linear interpolate between the two values according to a weight.\n"
            "\\param zero_val The result when weight is 0\n"
            "\\param one_val The result when weight is 1\n"
@@ -511,18 +504,18 @@ void define_operators() {
            "Generally, lerp will vectorize as if it were an operation on a type "
            "twice the bit size of the inferred type for x and y. ");
 
-    p::def("popcount", &h::popcount, p::args("x"),
+    py::def("popcount", &popcount, py::args("x"),
            "Count the number of set bits in an expression.");
 
-    p::def("count_leading_zeros", &h::count_leading_zeros, p::args("x"),
+    py::def("count_leading_zeros", &count_leading_zeros, py::args("x"),
            "Count the number of leading zero bits in an expression. The result is "
            "undefined if the value of the expression is zero.");
 
-    p::def("count_trailing_zeros", &h::count_trailing_zeros, p::args("x"),
+    py::def("count_trailing_zeros", &count_trailing_zeros, py::args("x"),
            "Count the number of trailing zero bits in an expression. The result is "
            "undefined if the value of the expression is zero.");
 
-    p::def("random_float", &random_float1, p::args("seed"),
+    py::def("random_float", &random_float1, py::args("seed"),
            "Return a random variable representing a uniformly distributed "
            "float in the half-open interval [0.0f, 1.0f). For random numbers of "
            "other types, use lerp with a random float as the last parameter.\n"
@@ -550,14 +543,14 @@ void define_operators() {
            "elements.\n"
 
            "This function vectorizes cleanly.");
-    p::def("random_float", &random_float0);  // no args
+    py::def("random_float", &random_float0);  // no args
 
-    p::def("random_int", &random_int1, p::args("seed"),
+    py::def("random_int", &random_int1, py::args("seed"),
            "Return a random variable representing a uniformly distributed "
            "32-bit integer. See \\ref random_float. Vectorizes cleanly.");
-    p::def("random_int", &random_int0);  // no args
+    py::def("random_int", &random_int0);  // no args
 
-    p::def("undef", &undef0, p::args("type"),
+    py::def("undef", &undef0, py::args("type"),
            "Return an undef value of the given type. Halide skips stores that "
            "depend on undef values, so you can use this to mean \"do not modify "
            "this memory location\". This is an escape hatch that can be used for "
@@ -576,7 +569,7 @@ void define_operators() {
            "Use this feature with great caution, as you can use it to load from "
            "uninitialized memory.\n");
 
-    p::def("memoize_tag", &memoize_tag0, p::args("result", "cache_key_values"),
+    py::def("memoize_tag", &memoize_tag0, py::args("result", "cache_key_values"),
            "Control the values used in the memoization cache key for memoize. "
            "Normally parameters and other external dependencies are "
            "automatically inferred and added to the cache key. The memoize_tag "
@@ -608,7 +601,7 @@ void define_operators() {
     //template<typename ...Args>
     //Expr memoize_tag(Expr result, Args... args)
 
-    p::def("likely", &h::likely, p::args("e"),
+    py::def("likely", &likely, py::args("e"),
            "Expressions tagged with this intrinsic are considered to be part "
            "of the steady state of some loop with a nasty beginning and end "
            "(e.g. a boundary condition). When Halide encounters likely "
@@ -622,3 +615,6 @@ void define_operators() {
            "use the boundary condition helpers in the BoundaryConditions "
            "namespace instead. ");
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyIROperator.h
+++ b/python_bindings/src/PyIROperator.h
@@ -1,6 +1,14 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYIROPERATOR_H
 #define HALIDE_PYTHON_BINDINGS_PYIROPERATOR_H
 
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
 void define_operators();
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYIROPERATOR_H

--- a/python_bindings/src/PyInlineReductions.cpp
+++ b/python_bindings/src/PyInlineReductions.cpp
@@ -1,94 +1,92 @@
 #include "PyInlineReductions.h"
 
-#include <boost/python.hpp>
-#include <string>
-
-#include "Halide.h"
 
 #include "PyExpr.h"
 
+namespace Halide {
+namespace PythonBindings {
 
-namespace h = Halide;
-namespace p = boost::python;
-
-h::Expr sum0(h::Expr e, const std::string name) {
-    return h::sum(e, name);
+Expr sum0(Expr e, const std::string name) {
+    return sum(e, name);
 }
 
-h::Expr sum1(h::RDom r, h::Expr e, const std::string name) {
-    return h::sum(r, e, name);
+Expr sum1(RDom r, Expr e, const std::string name) {
+    return sum(r, e, name);
 }
 
-h::Expr product0(h::Expr e, const std::string name) {
-    return h::product(e, name);
+Expr product0(Expr e, const std::string name) {
+    return product(e, name);
 }
 
-h::Expr product1(h::RDom r, h::Expr e, const std::string name) {
-    return h::product(r, e, name);
+Expr product1(RDom r, Expr e, const std::string name) {
+    return product(r, e, name);
 }
 
-h::Expr maximum0(h::Expr e, const std::string name) {
-    return h::maximum(e, name);
+Expr maximum0(Expr e, const std::string name) {
+    return maximum(e, name);
 }
 
-h::Expr maximum1(h::RDom r, h::Expr e, const std::string name) {
-    return h::maximum(r, e, name);
+Expr maximum1(RDom r, Expr e, const std::string name) {
+    return maximum(r, e, name);
 }
 
-h::Expr minimum0(h::Expr e, const std::string name) {
-    return h::minimum(e, name);
+Expr minimum0(Expr e, const std::string name) {
+    return minimum(e, name);
 }
 
-h::Expr minimum1(h::RDom r, h::Expr e, const std::string name) {
-    return h::minimum(r, e, name);
+Expr minimum1(RDom r, Expr e, const std::string name) {
+    return minimum(r, e, name);
 }
 
-p::object argmin0(h::Expr e, const std::string name) {
-    return expr_vector_to_python_tuple(h::argmin(e, name).as_vector());
+py::object argmin0(Expr e, const std::string name) {
+    return expr_vector_to_python_tuple(argmin(e, name).as_vector());
 }
 
-p::object argmin1(h::RDom r, h::Expr e, const std::string name) {
-    return expr_vector_to_python_tuple(h::argmin(r, e, name).as_vector());
+py::object argmin1(RDom r, Expr e, const std::string name) {
+    return expr_vector_to_python_tuple(argmin(r, e, name).as_vector());
 }
 
-p::object argmax0(h::Expr e, const std::string name) {
-    return expr_vector_to_python_tuple(h::argmin(e, name).as_vector());
+py::object argmax0(Expr e, const std::string name) {
+    return expr_vector_to_python_tuple(argmin(e, name).as_vector());
 }
 
-p::object argmax1(h::RDom r, h::Expr e, const std::string name) {
-    return expr_vector_to_python_tuple(h::argmax(r, e, name).as_vector());
+py::object argmax1(RDom r, Expr e, const std::string name) {
+    return expr_vector_to_python_tuple(argmax(r, e, name).as_vector());
 }
 
 void define_inline_reductions() {
     // Defines some inline reductions: sum, product, minimum, maximum.
 
-    p::def("sum", &sum0, (p::arg("e"), p::arg("name") = "sum"),
+    py::def("sum", &sum0, (py::arg("e"), py::arg("name") = "sum"),
            "An inline reduction.");
-    p::def("sum", &sum1, (p::arg("r"), p::arg("e"), p::arg("name") = "sum"),
-           "An inline reduction.");
-
-    p::def("product", &product0, (p::arg("e"), p::arg("name") = "product"),
-           "An inline reduction.");
-    p::def("product", &product1, (p::arg("r"), p::arg("e"), p::arg("name") = "product"),
+    py::def("sum", &sum1, (py::arg("r"), py::arg("e"), py::arg("name") = "sum"),
            "An inline reduction.");
 
-    p::def("maximum", &maximum0, (p::arg("e"), p::arg("name") = "maximum"),
+    py::def("product", &product0, (py::arg("e"), py::arg("name") = "product"),
            "An inline reduction.");
-    p::def("maximum", &maximum1, (p::arg("r"), p::arg("e"), p::arg("name") = "maximum"),
-           "An inline reduction.");
-
-    p::def("minimum", &minimum0, (p::arg("e"), p::arg("name") = "minimum"),
-           "An inline reduction.");
-    p::def("minimum", &minimum1, (p::arg("r"), p::arg("e"), p::arg("name") = "minimum"),
+    py::def("product", &product1, (py::arg("r"), py::arg("e"), py::arg("name") = "product"),
            "An inline reduction.");
 
-    p::def("argmin", &argmin0, (p::arg("e"), p::arg("name") = "argmin"),
+    py::def("maximum", &maximum0, (py::arg("e"), py::arg("name") = "maximum"),
            "An inline reduction.");
-    p::def("argmin", &argmin1, (p::arg("r"), p::arg("e"), p::arg("name") = "argmin"),
+    py::def("maximum", &maximum1, (py::arg("r"), py::arg("e"), py::arg("name") = "maximum"),
            "An inline reduction.");
 
-    p::def("argmax", &argmax0, (p::arg("e"), p::arg("name") = "argmax"),
+    py::def("minimum", &minimum0, (py::arg("e"), py::arg("name") = "minimum"),
            "An inline reduction.");
-    p::def("argmax", &argmax1, (p::arg("r"), p::arg("e"), p::arg("name") = "argmax"),
+    py::def("minimum", &minimum1, (py::arg("r"), py::arg("e"), py::arg("name") = "minimum"),
+           "An inline reduction.");
+
+    py::def("argmin", &argmin0, (py::arg("e"), py::arg("name") = "argmin"),
+           "An inline reduction.");
+    py::def("argmin", &argmin1, (py::arg("r"), py::arg("e"), py::arg("name") = "argmin"),
+           "An inline reduction.");
+
+    py::def("argmax", &argmax0, (py::arg("e"), py::arg("name") = "argmax"),
+           "An inline reduction.");
+    py::def("argmax", &argmax1, (py::arg("r"), py::arg("e"), py::arg("name") = "argmax"),
            "An inline reduction.");
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyInlineReductions.h
+++ b/python_bindings/src/PyInlineReductions.h
@@ -1,6 +1,14 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYINLINEREDUCTIONS_H
 #define HALIDE_PYTHON_BINDINGS_PYINLINEREDUCTIONS_H
 
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
 void define_inline_reductions();
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYINLINEREDUCTIONS_H

--- a/python_bindings/src/PyLambda.cpp
+++ b/python_bindings/src/PyLambda.cpp
@@ -1,32 +1,29 @@
 #include "PyLambda.h"
 
-#include <boost/python.hpp>
+namespace Halide {
+namespace PythonBindings {
 
-#include "Halide.h"
-
-namespace h = Halide;
-
-h::Func lambda0D(h::Expr e) {
+Func lambda0D(Expr e) {
     return lambda(e);
 }
 
-h::Func lambda1D(h::Var x, h::Expr e) {
+Func lambda1D(Var x, Expr e) {
     return lambda(x, e);
 }
 
-h::Func lambda2D(h::Var x, h::Var y, h::Expr e) {
+Func lambda2D(Var x, Var y, Expr e) {
     return lambda(x, y, e);
 }
 
-h::Func lambda3D(h::Var x, h::Var y, h::Var z, h::Expr e) {
+Func lambda3D(Var x, Var y, Var z, Expr e) {
     return lambda(x, y, z, e);
 }
 
-h::Func lambda4D(h::Var x, h::Var y, h::Var z, h::Var w, h::Expr e) {
+Func lambda4D(Var x, Var y, Var z, Var w, Expr e) {
     return lambda(x, y, z, w, e);
 }
 
-h::Func lambda5D(h::Var x, h::Var y, h::Var z, h::Var w, h::Var v, h::Expr e) {
+Func lambda5D(Var x, Var y, Var z, Var w, Var v, Expr e) {
     return lambda(x, y, z, w, v, e);
 }
 
@@ -34,40 +31,43 @@ h::Func lambda5D(h::Var x, h::Var y, h::Var z, h::Var w, h::Var v, h::Expr e) {
 /// See test/lambda.cpp for example usage.
 /// lambda is a python keyword so we used lambda0D, lambda1D, ... lambda5D instead.
 void define_lambda() {
-    namespace p = boost::python;
 
-    p::def("lambda0D", &lambda0D, p::arg("e"),
+
+    py::def("lambda0D", &lambda0D, py::arg("e"),
            "Create a zero-dimensional halide function that returns the given "
            "expression. The function may have more dimensions if the expression "
            "contains implicit arguments.");
 
-    p::def("lambda1D", &lambda1D, p::args("x", "e"),
+    py::def("lambda1D", &lambda1D, py::args("x", "e"),
            "Create a 1-D halide function in the first argument that returns "
            "the second argument. The function may have more dimensions if the "
            "expression contains implicit arguments and the list of Var "
            "arguments contains a placeholder (\"_\").");
 
-    p::def("lambda2D", &lambda2D, p::args("x", "y", "e"),
+    py::def("lambda2D", &lambda2D, py::args("x", "y", "e"),
            "Create a 2-D halide function in the first two arguments that "
            "returns the last argument. The function may have more dimensions if "
            "the expression contains implicit arguments and the list of Var "
            "arguments contains a placeholder (\"_\").");
 
-    p::def("lambda3D", &lambda3D, p::args("x", "y", "z", "e"),
+    py::def("lambda3D", &lambda3D, py::args("x", "y", "z", "e"),
            "Create a 3-D halide function in the first three arguments that "
            "returns the last argument.  The function may have more dimensions "
            "if the expression contains implicit arguments and the list of Var "
            "arguments contains a placeholder (\"_\").");
 
-    p::def("lambda4D", &lambda4D, p::args("x", "y", "z", "w", "e"),
+    py::def("lambda4D", &lambda4D, py::args("x", "y", "z", "w", "e"),
            "Create a 4-D halide function in the first four arguments that "
            "returns the last argument. The function may have more dimensions if "
            "the expression contains implicit arguments and the list of Var "
            "arguments contains a placeholder (\"_\").");
 
-    p::def("lambda5D", &lambda5D, p::args("x", "y", "z", "w", "v", "e"),
+    py::def("lambda5D", &lambda5D, py::args("x", "y", "z", "w", "v", "e"),
            "Create a 5-D halide function in the first five arguments that "
            "returns the last argument. The function may have more dimensions if "
            "the expression contains implicit arguments and the list of Var "
            "arguments contains a placeholder (\"_\").");
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyLambda.h
+++ b/python_bindings/src/PyLambda.h
@@ -1,6 +1,14 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYLAMBDA_H
 #define HALIDE_PYTHON_BINDINGS_PYLAMBDA_H
 
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
 void define_lambda();
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYLAMBDA_H

--- a/python_bindings/src/PyParam.h
+++ b/python_bindings/src/PyParam.h
@@ -1,6 +1,14 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYPARAM_H
 #define HALIDE_PYTHON_BINDINGS_PYPARAM_H
 
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
 void define_param();
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYPARAM_H

--- a/python_bindings/src/PyRDom.cpp
+++ b/python_bindings/src/PyRDom.cpp
@@ -1,69 +1,62 @@
 #include "PyRDom.h"
 
-#include <boost/python.hpp>
-#include <string>
-
-#include "Halide.h"
-
 #include "PyBinaryOperators.h"
 
-namespace h = Halide;
-namespace p = boost::python;
+namespace Halide {
+namespace PythonBindings {
 
 void define_rvar() {
-    using Halide::RVar;
-
-    auto rvar_class = p::class_<RVar>("RVar",
+    auto rvar_class = py::class_<RVar>("RVar",
                                       "A reduction variable represents a single dimension of a reduction "
                                       "domain (RDom). Don't construct them directly, instead construct an "
                                       "RDom, and use RDom::operator[] to get at the variables. For "
                                       "single-dimensional reduction domains, you can just cast a "
                                       "single-dimensional RDom to an RVar.",
-                                      p::init<>(p::args("self"), "An empty reduction variable."))
-                          .def(p::init<std::string>(p::args("self", "name"), "Construct an RVar with the given name"))
+                                      py::init<>(py::args("self"), "An empty reduction variable."))
+                          .def(py::init<std::string>(py::args("self", "name"), "Construct an RVar with the given name"))
 
-                          .def(p::init<h::Internal::ReductionDomain, int>(
-                              p::args("self", "domain", "index"),
+                          .def(py::init<Internal::ReductionDomain, int>(
+                              py::args("self", "domain", "index"),
                               "Construct a reduction variable with the given name and "
                               "bounds. Must be a member of the given reduction domain."))
 
-                          .def("min", &RVar::min, p::arg("self"),
+                          .def("min", &RVar::min, py::arg("self"),
                                "The minimum value that this variable will take on")
-                          .def("extent", &RVar::extent, p::arg("self"),
+                          .def("extent", &RVar::extent, py::arg("self"),
                                "The number that this variable will take on. "
                                "The maximum value of this variable will be min() + extent() - 1")
 
-                          .def("domain", &RVar::domain, p::arg("self"),
+                          .def("domain", &RVar::domain, py::arg("self"),
                                "The reduction domain this is associated with.")
 
-                          .def("name", &RVar::name, p::arg("self"),
-                               p::return_value_policy<p::copy_const_reference>(),
+                          .def("name", &RVar::name, py::arg("self"),
+                               py::return_value_policy<py::copy_const_reference>(),
                                "The name of this reduction variable");
 
-    p::implicitly_convertible<RVar, h::Expr>();
+    py::implicitly_convertible<RVar, Expr>();
 
     add_binary_operators(rvar_class);  // define operators with int, rvars, and exprs
-    add_binary_operators_with<h::Expr>(rvar_class);
+    add_binary_operators_with<Expr>(rvar_class);
 }
 
-h::RDom *RDom_constructor0(p::tuple args, std::string name = "") {
-    const size_t args_len = p::len(args);
+RDom *RDom_constructor0(py::tuple args, std::string name = "") {
+    const size_t args_len = py::len(args);
     if ((args_len % 2) != 0) {
         throw std::invalid_argument("RDom constructor expects an even number of Expr inputs");
     }
 
-    std::vector<h::Expr> exprs;
+    std::vector<Expr> exprs;
 
     for (size_t i = 0; i < args_len; i += 1) {
-        p::object o = args[i];
-        p::extract<h::Expr> expr_extract(o);
+        py::object o = args[i];
+        py::extract<Expr> expr_extract(o);
 
         if (expr_extract.check()) {
             exprs.push_back(expr_extract());
         } else {
             for (size_t j = 0; j < args_len; j += 1) {
-                p::object o = args[j];
-                const std::string o_str = p::extract<std::string>(p::str(o));
+                py::object o = args[j];
+                const std::string o_str = py::extract<std::string>(py::str(o));
                 printf("RDom constructor args_passed[%lu] == %s\n", j, o_str.c_str());
             }
             throw std::invalid_argument("RDom constructor only handles a list of (convertible to) Expr.");
@@ -71,63 +64,61 @@ h::RDom *RDom_constructor0(p::tuple args, std::string name = "") {
     }
 
     assert((exprs.size() % 2) == 0);
-    std::vector<std::pair<h::Expr, h::Expr>> ranges;
+    std::vector<std::pair<Expr, Expr>> ranges;
     for (size_t i = 0; i < exprs.size(); i += 2) {
         ranges.push_back({ exprs[i], exprs[i + 1] });
     }
 
-    return new h::RDom(ranges, name);
+    return new RDom(ranges, name);
 }
 
-h::RDom *RDom_constructor1(h::Expr min0, h::Expr extent0,
+RDom *RDom_constructor1(Expr min0, Expr extent0,
                            std::string name = "") {
-    std::vector<std::pair<h::Expr, h::Expr>> ranges;
+    std::vector<std::pair<Expr, Expr>> ranges;
     ranges.push_back({ min0, extent0 });
-    return new h::RDom(ranges, name);
+    return new RDom(ranges, name);
 }
 
-h::RDom *RDom_constructor2(h::Expr min0, h::Expr extent0,
-                           h::Expr min1, h::Expr extent1,
+RDom *RDom_constructor2(Expr min0, Expr extent0,
+                           Expr min1, Expr extent1,
                            std::string name = "") {
-    std::vector<std::pair<h::Expr, h::Expr>> ranges;
+    std::vector<std::pair<Expr, Expr>> ranges;
     ranges.push_back({ min0, extent0 });
     ranges.push_back({ min1, extent1 });
-    return new h::RDom(ranges, name);
+    return new RDom(ranges, name);
 }
 
-h::RDom *RDom_constructor3(h::Expr min0, h::Expr extent0,
-                           h::Expr min1, h::Expr extent1,
-                           h::Expr min2, h::Expr extent2,
+RDom *RDom_constructor3(Expr min0, Expr extent0,
+                           Expr min1, Expr extent1,
+                           Expr min2, Expr extent2,
                            std::string name = "") {
-    std::vector<std::pair<h::Expr, h::Expr>> ranges;
+    std::vector<std::pair<Expr, Expr>> ranges;
     ranges.push_back({ min0, extent0 });
     ranges.push_back({ min1, extent1 });
     ranges.push_back({ min2, extent2 });
-    return new h::RDom(ranges, name);
+    return new RDom(ranges, name);
 }
 
-h::RDom *RDom_constructor4(h::Expr min0, h::Expr extent0,
-                           h::Expr min1, h::Expr extent1,
-                           h::Expr min2, h::Expr extent2,
-                           h::Expr min3, h::Expr extent3,
+RDom *RDom_constructor4(Expr min0, Expr extent0,
+                           Expr min1, Expr extent1,
+                           Expr min2, Expr extent2,
+                           Expr min3, Expr extent3,
                            std::string name = "") {
-    std::vector<std::pair<h::Expr, h::Expr>> ranges;
+    std::vector<std::pair<Expr, Expr>> ranges;
     ranges.push_back({ min0, extent0 });
     ranges.push_back({ min1, extent1 });
     ranges.push_back({ min2, extent2 });
     ranges.push_back({ min3, extent3 });
-    return new h::RDom(ranges, name);
+    return new RDom(ranges, name);
 }
 
 void define_rdom() {
-    using Halide::RDom;
-
     define_rvar();
 
     // only defined so that python knows what to do with it, not meant to be used by user
-    p::class_<h::Internal::ReductionDomain> dummy("_ReductionDomain", p::no_init);
+    py::class_<Internal::ReductionDomain> dummy("_ReductionDomain", py::no_init);
 
-    auto rdom_class = p::class_<RDom>("RDom",
+    auto rdom_class = py::class_<RDom>("RDom",
                                       "A multi-dimensional domain over which to iterate. "
                                       "Used when defining functions with update definitions.\n"
                                       "See apps/bilateral_grid.py for an example of a reduction.\n\n"
@@ -140,59 +131,59 @@ void define_rdom() {
                                       "  RDom(Buffer|ImageParam)                    -- Iterate over all points in the domain\n"
                                       "The following global functions can be used for inline reductions::\n\n"
                                       "    minimum, maximum, product, sum",
-                                      p::init<>(p::arg("self"), "Construct an undefined reduction domain."))
-                          .def(p::init<h::Buffer<>>(p::args("self", "buffer"),
+                                      py::init<>(py::arg("self"), "Construct an undefined reduction domain."))
+                          .def(py::init<Buffer<>>(py::args("self", "buffer"),
                                                    "Construct a reduction domain that iterates over all points in "
                                                    "a given Buffer, Image, or ImageParam. "
                                                    "Has the same dimensionality as the argument."))
-                          .def(p::init<h::OutputImageParam>(p::args("self", "image_param"),
+                          .def(py::init<OutputImageParam>(py::args("self", "image_param"),
                                                       "Construct a reduction domain that iterates over all points in "
                                                       "a given Buffer, Image, or ImageParam. "
                                                       "Has the same dimensionality as the argument."))
-                          .def(p::init<h::Internal::ReductionDomain>(
-                              p::args("self", "domain"),
+                          .def(py::init<Internal::ReductionDomain>(
+                              py::args("self", "domain"),
                               "Construct a reduction domain that wraps an Internal ReductionDomain object."))
                           .def("__init__",
-                               p::make_constructor(&RDom_constructor0, p::default_call_policies(),
-                                                   (p::arg("ranges"), p::arg("name") = "")),
+                               py::make_constructor(&RDom_constructor0, py::default_call_policies(),
+                                                   (py::arg("ranges"), py::arg("name") = "")),
                                "Construct a multi-dimensional reduction domain with the given name. "
                                "If the name is left blank, a unique one is auto-generated.")
                           .def("__init__",
-                               p::make_constructor(&RDom_constructor1, p::default_call_policies(),
-                                                   (p::args("min0", "extent0"),
-                                                    p::arg("name") = "")),
+                               py::make_constructor(&RDom_constructor1, py::default_call_policies(),
+                                                   (py::args("min0", "extent0"),
+                                                    py::arg("name") = "")),
                                "Construct a multi-dimensional reduction domain with the given name. "
                                "If the name is left blank, a unique one is auto-generated.")
                           .def("__init__",
-                               p::make_constructor(&RDom_constructor2, p::default_call_policies(),
-                                                   (p::args("min0", "extent0", "min1", "extent1"),
-                                                    p::arg("name") = "")),
+                               py::make_constructor(&RDom_constructor2, py::default_call_policies(),
+                                                   (py::args("min0", "extent0", "min1", "extent1"),
+                                                    py::arg("name") = "")),
                                "Construct a multi-dimensional reduction domain with the given name. "
                                "If the name is left blank, a unique one is auto-generated.")
                           .def("__init__",
-                               p::make_constructor(&RDom_constructor3, p::default_call_policies(),
-                                                   (p::args("min0", "extent0", "min1", "extent1",
+                               py::make_constructor(&RDom_constructor3, py::default_call_policies(),
+                                                   (py::args("min0", "extent0", "min1", "extent1",
                                                             "min2", "extent2"),
-                                                    p::arg("name") = "")),
+                                                    py::arg("name") = "")),
                                "Construct a multi-dimensional reduction domain with the given name. "
                                "If the name is left blank, a unique one is auto-generated.")
                           .def("__init__",
-                               p::make_constructor(&RDom_constructor4, p::default_call_policies(),
-                                                   (p::args("min0", "extent0", "min1", "extent1",
+                               py::make_constructor(&RDom_constructor4, py::default_call_policies(),
+                                                   (py::args("min0", "extent0", "min1", "extent1",
                                                             "min2", "extent2"),
-                                                    p::arg("name") = "")),
+                                                    py::arg("name") = "")),
                                "Construct a multi-dimensional reduction domain with the given name. "
                                "If the name is left blank, a unique one is auto-generated.")
 
-                          .def("domain", &RDom::domain, p::arg("self"),
+                          .def("domain", &RDom::domain, py::arg("self"),
                                "Get at the internal reduction domain object that this wraps.")
-                          .def("defined", &RDom::defined, p::arg("self"),
+                          .def("defined", &RDom::defined, py::arg("self"),
                                "Check if this reduction domain is non-NULL")
-                          .def("same_as", &RDom::same_as, p::args("self", "other"),
+                          .def("same_as", &RDom::same_as, py::args("self", "other"),
                                "Compare two reduction domains for equality of reference")
-                          .def("dimensions", &RDom::dimensions, p::arg("self"),
+                          .def("dimensions", &RDom::dimensions, py::arg("self"),
                                "Get the dimensionality of a reduction domain")
-                          .def("where", &RDom::where, p::args("self", "predicate"),
+                          .def("where", &RDom::where, py::args("self", "predicate"),
                                "Add a predicate to the RDom. An RDom may have multiple"
                                "predicates associated with it. An update definition that uses"
                                "an RDom only iterates over the subset points in the domain for"
@@ -221,9 +212,12 @@ void define_rdom() {
                           .def_readonly("z", &RDom::z)
                           .def_readonly("w", &RDom::w);
 
-    p::implicitly_convertible<RDom, h::Expr>();
-    p::implicitly_convertible<RDom, h::RVar>();
+    py::implicitly_convertible<RDom, Expr>();
+    py::implicitly_convertible<RDom, RVar>();
 
     add_binary_operators(rdom_class);  // define operators with int, rdom and exprs
-    add_binary_operators_with<h::Expr>(rdom_class);
+    add_binary_operators_with<Expr>(rdom_class);
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyRDom.h
+++ b/python_bindings/src/PyRDom.h
@@ -1,6 +1,14 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYRDOM_H
 #define HALIDE_PYTHON_BINDINGS_PYRDOM_H
 
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
 void define_rdom();
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYRDOM_H

--- a/python_bindings/src/PyTarget.cpp
+++ b/python_bindings/src/PyTarget.cpp
@@ -1,18 +1,7 @@
 #include "PyTarget.h"
 
-#include <boost/format.hpp>
-#include <boost/python.hpp>
-
-#include <string>
-#include <vector>
-
-#include "Halide.h"
-
-using Halide::DeviceAPI;
-using Halide::Target;
-using Halide::Type;
-
-namespace py = boost::python;
+namespace Halide {
+namespace PythonBindings {
 
 namespace {
 
@@ -51,7 +40,9 @@ struct PythonListToVectorConverter {
 };
 
 std::string target_repr(const Target &t) {
-    return boost::str(boost::format("<halide.Target %s>") % t.to_string());
+    std::ostringstream o;
+    o << "<halide.Target " << t.to_string() << ">";
+    return o.str();
 }
 
 }  // namespace
@@ -171,8 +162,11 @@ void define_target() {
 
     py::def("validate_target_string", &Target::validate_target_string);
 
-    py::def("get_host_target", &Halide::get_host_target);
-    py::def("get_target_from_environment", &Halide::get_target_from_environment);
-    py::def("get_jit_target_from_environment", &Halide::get_jit_target_from_environment);
-    py::def("target_feature_for_device_api", &Halide::target_feature_for_device_api);
+    py::def("get_host_target", &get_host_target);
+    py::def("get_target_from_environment", &get_target_from_environment);
+    py::def("get_jit_target_from_environment", &get_jit_target_from_environment);
+    py::def("target_feature_for_device_api", &target_feature_for_device_api);
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyTarget.h
+++ b/python_bindings/src/PyTarget.h
@@ -1,6 +1,14 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYTARGET_H
 #define HALIDE_PYTHON_BINDINGS_PYTARGET_H
 
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
 void define_target();
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYTARGET_H

--- a/python_bindings/src/PyType.cpp
+++ b/python_bindings/src/PyType.cpp
@@ -1,34 +1,23 @@
 #include "PyType.h"
 
-#include <boost/format.hpp>
-#include <boost/python.hpp>
-#include <string>
-#include <vector>
-
-#include "Halide.h"
-
-using Halide::Bool;
-using Halide::Float;
-using Halide::Handle;
-using Halide::Int;
-using Halide::Type;
-using Halide::UInt;
-
-namespace py = boost::python;
+namespace Halide {
+namespace PythonBindings {
 
 namespace {
 
-Halide::Type make_handle(int lanes) {
+Type make_handle(int lanes) {
     return Handle(lanes, nullptr);
 }
 
 std::string type_repr(const Type &t) {
-    return boost::str(boost::format("<halide.Type %s>") % halide_type_to_string(t));
+    std::ostringstream o;
+    o << "<halide.Type " << halide_type_to_string(t) << ">";
+    return o.str();
 }
 
 }  // namespace
 
-std::string halide_type_to_string(const Halide::Type &type) {
+std::string halide_type_to_string(const Type &type) {
     std::ostringstream stream;
     if (type.code() == halide_type_uint && type.bits() == 1) {
         stream << "bool";
@@ -110,3 +99,6 @@ void define_type() {
         .value("Handle", Type::Handle);
         // don't export_values(): we don't want the enums in the halide module
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyType.h
+++ b/python_bindings/src/PyType.h
@@ -1,10 +1,16 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYTYPE_H
 #define HALIDE_PYTHON_BINDINGS_PYTYPE_H
 
-#include "Halide.h"
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
 
 void define_type();
 
-std::string halide_type_to_string(const Halide::Type &type);
+std::string halide_type_to_string(const Type &type);
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYTYPE_H

--- a/python_bindings/src/PyVar.cpp
+++ b/python_bindings/src/PyVar.cpp
@@ -1,23 +1,16 @@
 #include "PyVar.h"
 
-#include <boost/format.hpp>
-#include <boost/python.hpp>
-#include <string>
-
-#include "Halide.h"
-
 #include "PyBinaryOperators.h"
 
-using Halide::Expr;
-using Halide::Var;
-
-namespace py = boost::python;
+namespace Halide {
+namespace PythonBindings {
 
 namespace {
 
 std::string var_repr(const Var &var) {
-    boost::format f("<halide.Var '%s'>");
-    return boost::str(f % var.name());
+    std::ostringstream o;
+    o << "<halide.Var '" << var.name() << "'>";
+    return o.str();
 }
 
 }  // namespace
@@ -74,3 +67,6 @@ void define_var() {
     py::scope().attr("_8") = py::object(Halide::_8);
     py::scope().attr("_9") = py::object(Halide::_9);
 }
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyVar.h
+++ b/python_bindings/src/PyVar.h
@@ -1,6 +1,14 @@
 #ifndef HALIDE_PYTHON_BINDINGS_PYVAR_H
 #define HALIDE_PYTHON_BINDINGS_PYVAR_H
 
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
 void define_var();
+
+}  // namespace PythonBindings
+}  // namespace Halide
 
 #endif  // HALIDE_PYTHON_BINDINGS_PYVAR_H


### PR DESCRIPTION
Major restructuring of code in preparation for PyBind11 experiment; this is a large but mostly mechanical restructuring:

- move all code into Halide::PythonBindings namespace
- use 'py' everywhere as alias for boost::python
- remove explicit 'h::' and 'Halide::' prefixing almost everywhere
- remove almost all use of Boost (aside from Boost.Python); in particular, boost::format and boost::str [Note that there is some use of boost::mpl left for numpy use]
- add 'PyHalide.h' to consolidate some includes and definitions
- add a few drive-by TODO comments where I happened to notice the need