### PR TITLE
Try making the auto scheduler tests non-parallel...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -837,7 +837,7 @@ test_tutorial: $(TUTORIALS:$(ROOT_DIR)/tutorial/%.cpp=tutorial_%)
 test_valgrind: $(CORRECTNESS_TESTS:$(ROOT_DIR)/test/correctness/%.cpp=valgrind_%)
 test_avx512: $(CORRECTNESS_TESTS:$(ROOT_DIR)/test/correctness/%.cpp=avx512_%)
 test_opengl: $(OPENGL_TESTS:$(ROOT_DIR)/test/opengl/%.cpp=opengl_%)
-test_auto_schedule: $(AUTO_SCHEDULE_TESTS:$(ROOT_DIR)/test/auto_schedule/%.cpp=auto_schedule_%)
+test_auto_schedule: $(AUTO_SCHEDULE_TESTS:$(ROOT_DIR)/test/auto_schedule/%.cpp=auto_schedule_%) .NOTPARALLEL
 
 # There are three types of tests for generators:
 # 1) Externally-written aot-based tests


### PR DESCRIPTION
...  so they don't fail as often with the -j flag. Haven't tested it extensively and would love
input from someone who knows this better than I.