### PR TITLE
X86 Runtime: AVX2 implementation of saturated truncate functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -644,6 +644,7 @@ RUNTIME_LL_COMPONENTS = \
   win32_math \
   x86 \
   x86_avx \
+  x86_avx2 \
   x86_sse41
 
 RUNTIME_EXPORTED_INCLUDES = $(INCLUDE_DIR)/HalideRuntime.h \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,7 @@ set (RUNTIME_LL
   win32_math
   x86
   x86_avx
+  x86_avx2
   x86_sse41
 )
 
@@ -239,7 +240,7 @@ foreach (i ${RUNTIME_HEADER_FILES})
   list(APPEND INITIAL_MODULES "${INITMOD_PREFIX}${SYM_NAME}.cpp")
 endforeach()
 
-# The externally-visible header files that go into making Halide.h. 
+# The externally-visible header files that go into making Halide.h.
 # Don't include anything here that includes llvm headers.
 set(HEADER_FILES
   AddImageChecks.h

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -219,7 +219,7 @@ void CodeGen_X86::visit(const Cast *op) {
     };
 
     static Pattern patterns[] = {
-        {Target::FeatureEnd, true, Int(8, 32), 0, "llvm.x86.avx2.padds.b",
+        {Target::AVX2, true, Int(8, 32), 0, "llvm.x86.avx2.padds.b",
          i8_sat(wild_i16x_ + wild_i16x_)},
         {Target::FeatureEnd, true, Int(8, 16), 0, "llvm.x86.sse2.padds.b",
          i8_sat(wild_i16x_ + wild_i16x_)},

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -219,6 +219,8 @@ void CodeGen_X86::visit(const Cast *op) {
     };
 
     static Pattern patterns[] = {
+        {Target::FeatureEnd, true, Int(8, 32), 0, "llvm.x86.avx2.padds.b",
+         i8_sat(wild_i16x_ + wild_i16x_)},
         {Target::FeatureEnd, true, Int(8, 16), 0, "llvm.x86.sse2.padds.b",
          i8_sat(wild_i16x_ + wild_i16x_)},
         {Target::FeatureEnd, true, Int(8, 16), 0, "llvm.x86.sse2.psubs.b",
@@ -259,10 +261,16 @@ void CodeGen_X86::visit(const Cast *op) {
         {Target::FeatureEnd, true, UInt(16, 8), 0, "pavgw",
          u16(((wild_u32x_ + wild_u32x_) + 1) / 2)},
 #endif
+        {Target::AVX2, false, Int(16, 16), 0, "packssdwx16",
+         i16_sat(wild_i32x_)},
         {Target::FeatureEnd, false, Int(16, 8), 0, "packssdwx8",
          i16_sat(wild_i32x_)},
+        {Target::AVX2, false, Int(8, 32), 0, "packsswbx32",
+         i8_sat(wild_i16x_)},
         {Target::FeatureEnd, false, Int(8, 16), 0, "packsswbx16",
          i8_sat(wild_i16x_)},
+        {Target::AVX2, false, UInt(8, 32), 0, "packuswbx32",
+         u8_sat(wild_i16x_)},
         {Target::FeatureEnd, false, UInt(8, 16), 0, "packuswbx16",
          u8_sat(wild_i16x_)},
         {Target::SSE41, false, UInt(16, 8), 0, "packusdwx8",

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -181,11 +181,13 @@ DECLARE_LL_INITMOD(ptx_compute_35)
 #endif  // WITH_PTX
 
 #ifdef WITH_X86
+DECLARE_LL_INITMOD(x86_avx2)
 DECLARE_LL_INITMOD(x86_avx)
 DECLARE_LL_INITMOD(x86)
 DECLARE_LL_INITMOD(x86_sse41)
 DECLARE_CPP_INITMOD(x86_cpu_features)
 #else
+DECLARE_NO_INITMOD(x86_avx2)
 DECLARE_NO_INITMOD(x86_avx)
 DECLARE_NO_INITMOD(x86)
 DECLARE_NO_INITMOD(x86_sse41)
@@ -794,6 +796,9 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
             }
             if (t.has_feature(Target::AVX)) {
                 modules.push_back(get_initmod_x86_avx_ll(c));
+            }
+            if (t.has_feature(Target::AVX2)) {
+                modules.push_back(get_initmod_x86_avx2_ll(c));
             }
             if (t.has_feature(Target::Profile)) {
                 modules.push_back(get_initmod_profiler_inlined(c, bits_64, debug));

--- a/src/runtime/x86_avx2.ll
+++ b/src/runtime/x86_avx2.ll
@@ -1,0 +1,23 @@
+define weak_odr <16 x i16>  @packssdwx16(<16 x i32> %arg) nounwind alwaysinline {
+  %1 = shufflevector <16 x i32> %arg, <16 x i32> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 8, i32 9, i32 10, i32 11>
+  %2 = shufflevector <16 x i32> %arg, <16 x i32> undef, <8 x i32> <i32 4, i32 5, i32 6, i32 7, i32 12, i32 13, i32 14, i32 15>
+  %3 = tail call <16 x i16> @llvm.x86.avx2.packssdw(<8 x i32> %1, <8 x i32> %2)
+  ret <16 x i16> %3
+}
+declare <16 x i16> @llvm.x86.avx2.packssdw(<8 x i32>, <8 x i32>)
+
+define weak_odr <32 x i8> @packuswbx32(<32 x i16> %arg) nounwind alwaysinline {
+ %1 = shufflevector <32 x i16> %arg, <32 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
+ %2 = shufflevector <32 x i16> %arg, <32 x i16> undef, <16 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+ %3 = call <32 x i8> @llvm.x86.avx2.packuswb(<16 x i16> %1, <16 x i16> %2)
+ ret <32 x i8> %3
+}
+declare <32 x i8> @llvm.x86.avx2.packuswb(<16 x i16>, <16 x i16>)
+
+define weak_odr <32 x i8> @packsswbx32(<32 x i16> %arg) nounwind alwaysinline {
+ %1 = shufflevector <32 x i16> %arg, <32 x i16> undef, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
+ %2 = shufflevector <32 x i16> %arg, <32 x i16> undef, <16 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+ %3 = call <32 x i8> @llvm.x86.avx2.packsswb(<16 x i16> %1, <16 x i16> %2)
+ ret <32 x i8> %3
+}
+declare <32 x i8> @llvm.x86.avx2.packsswb(<16 x i16>, <16 x i16>)

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -429,7 +429,7 @@ struct Test {
             check(use_avx512_skylake ? "vpmullq" : "pmuludq", w, u64_1 * u64_2);
 
             const char *check_suffix = "";
-            if (w > 3)
+            if (use_avx2 && w > 3)
                 check_suffix = "*ymm";
             check(std::string("packssdw") + check_suffix, 4*w, i16_sat(i32_1));
             check(std::string("packsswb") + check_suffix, 8*w, i8_sat(i16_1));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -428,9 +428,12 @@ struct Test {
             check("psubq", w, i64_1 - i64_2);
             check(use_avx512_skylake ? "vpmullq" : "pmuludq", w, u64_1 * u64_2);
 
-            check("packssdw", 4*w, i16_sat(i32_1));
-            check("packsswb", 8*w, i8_sat(i16_1));
-            check("packuswb", 8*w, u8_sat(i16_1));
+            const char *check_suffix = "";
+            if (w > 3)
+                check_suffix = "*ymm";
+            check(std::string("packssdw") + check_suffix, 4*w, i16_sat(i32_1));
+            check(std::string("packsswb") + check_suffix, 8*w, i8_sat(i16_1));
+            check(std::string("packuswb") + check_suffix, 8*w, u8_sat(i16_1));
         }
 
         // SSE 3
@@ -562,7 +565,7 @@ struct Test {
         if (use_avx2) {
             check("vpaddb*ymm", 32, u8_1 + u8_2);
             check("vpsubb*ymm", 32, u8_1 - u8_2);
-            check("vpaddsb", 32, i8_sat(i16(i8_1) + i16(i8_2)));
+            check("vpaddsb*ymm", 32, i8_sat(i16(i8_1) + i16(i8_2)));
             check("vpsubsb", 32, i8_sat(i16(i8_1) - i16(i8_2)));
             check("vpaddusb", 32, u8(min(u16(u8_1) + u16(u8_2), max_u8)));
             check("vpsubusb", 32, u8(max(i16(u8_1) - i16(u8_2), 0)));
@@ -597,10 +600,6 @@ struct Test {
             check("vpaddq*ymm", 8, i64_1 + i64_2);
             check("vpsubq*ymm", 8, i64_1 - i64_2);
             check(use_avx512_skylake ? "vpmullq" : "vpmuludq", 8, u64_1 * u64_2);
-
-            check("vpackssdw", 16, i16_sat(i32_1));
-            check("vpacksswb", 32, i8_sat(i16_1));
-            check("vpackuswb", 32, u8_sat(i16_1));
 
             check("vpabsb", 32, abs(i8_1));
             check("vpabsw", 16, abs(i16_1));


### PR DESCRIPTION
Create the AVX2 runtime container and add implementations of saturated
truncate functions.