### PR TITLE
Allow Buffer::copy() to work to/from Buffer<void>

### DIFF
--- a/src/Bounds.h
+++ b/src/Bounds.h
@@ -59,8 +59,8 @@ struct Box {
 
     size_t size() const {return bounds.size();}
     bool empty() const {return bounds.empty();}
-    Interval &operator[](int i) {return bounds[i];}
-    const Interval &operator[](int i) const {return bounds[i];}
+    Interval &operator[](size_t i) {return bounds[i];}
+    const Interval &operator[](size_t i) const {return bounds[i];}
     void resize(size_t sz) {bounds.resize(sz);}
     void push_back(const Interval &i) {bounds.push_back(i);}
 

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1564,9 +1564,10 @@ public:
             swaps.pop_back();
         }
 
-        // Use src's runtime type, and make dst a Buffer<void>, to allow
+        // Use an explicit runtime type, and make dst a Buffer<void>, to allow
         // using this method with Buffer<void> for either src or dst.
-        Buffer<> dst(src.type(), nullptr, src.dimensions(), shape);
+        const halide_type_t dst_type = T_is_void ? src.type() : halide_type_of<not_void_T>();
+        Buffer<> dst(dst_type, nullptr, src.dimensions(), shape);
         dst.allocate(allocate_fn, deallocate_fn);
 
         return dst;

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -173,7 +173,7 @@ private:
     struct DevRefCountCropped : DeviceRefCount {
         Buffer<T, D> cropped_from;
         DevRefCountCropped(const Buffer<T, D> &cropped_from) : cropped_from(cropped_from) {
-            ownership = BufferDeviceOwnership::Cropped; 
+            ownership = BufferDeviceOwnership::Cropped;
         }
     };
 
@@ -371,7 +371,7 @@ private:
 
     /** Crop a single dimension without handling device allocation. */
     void crop_host(int d, int min, int extent) {
-        // TODO(abadams|zvookin): these asserts fail on correctness_autotune_bug 
+        // TODO(abadams|zvookin): these asserts fail on correctness_autotune_bug
         // due to unsafe crop in Func::infer_input_bounds. See comment at Func.cpp:2834.
         // Should either fix that or kill the asserts and document the routine accordingly.
         //        assert(dim(d).min() <= min);
@@ -1564,7 +1564,9 @@ public:
             swaps.pop_back();
         }
 
-        Buffer<T, D> dst(nullptr, src.dimensions(), shape);
+        // Use src's runtime type, and make dst a Buffer<void>, to allow
+        // using this method with Buffer<void> for either src or dst.
+        Buffer<> dst(src.type(), nullptr, src.dimensions(), shape);
         dst.allocate(allocate_fn, deallocate_fn);
 
         return dst;
@@ -1693,7 +1695,7 @@ public:
         bool all_equal = true;
         for_each_element([&](const int *pos) {all_equal &= (*this)(pos) == val;});
         return all_equal;
-    }    
+    }
 
     void fill(not_void_T val) {
         set_host_dirty();

--- a/test/correctness/halide_buffer.cpp
+++ b/test/correctness/halide_buffer.cpp
@@ -128,6 +128,22 @@ int main(int argc, char **argv) {
         });
     }
 
+    {
+        // Check that copy() works to/from Buffer<void>
+        Buffer<int> a(2, 2);
+        a.fill(42);
+
+        Buffer<> b = a.copy();
+        assert(b.as<int>().all_equal(42));
+
+        Buffer<int> c = b.copy();
+        assert(c.all_equal(42));
+
+        // This will fail at runtime, as c and d do not have identical types
+        // Buffer<uint8_t> d = c.copy();
+        // assert(d.all_equal(42));
+    }
+
     printf("Success!\n");
     return 0;
 }


### PR DESCRIPTION
make_with_shape_of() required the src and dst to be strongly typed, but there's no reason to do so; being able to copy to/from a Buffer<void> is fine as long as runtime types match.

Also, did unrelated drive-by fix in Bounds.h to fix an int-vs-size_t compiler warning for some configurations.