### PR TITLE
Add a 'test_python3' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1533,7 +1533,17 @@ test_python: distrib
 		-f $(ROOT_DIR)/python_bindings/Makefile \
 		test \
 		HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
-		BIN=$(CURDIR)/$(BIN_DIR)/python_bindings
+		BIN=$(CURDIR)/$(BIN_DIR)/python_bindings \
+		PYTHON=python
+
+.PHONY: test_python3
+test_python3: distrib
+	make -C $(ROOT_DIR)/python_bindings \
+		-f $(ROOT_DIR)/python_bindings/Makefile \
+		test \
+		HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
+		BIN=$(CURDIR)/$(BIN_DIR)/python3_bindings \
+		PYTHON=python3
 
 # It's just for compiling the runtime, so earlier clangs *might* work,
 # but best to peg it to the minimum llvm version.


### PR DESCRIPTION
With this change:
- test_python builds and tests against 'python' (v2.x on ~all posixy systems)
- test_python builds and tests against 'python3' (v3.x)

Previously our tests were generally python3 only; we need both.