### PR TITLE
posix_io outputs to stdout instead of stderr (Issue #2686)

### DIFF
--- a/src/runtime/posix_io.cpp
+++ b/src/runtime/posix_io.cpp
@@ -3,7 +3,7 @@
 extern "C" {
 
 WEAK void halide_default_print(void *user_context, const char *str) {
-    write(STDERR_FILENO, str, strlen(str));
+    write(STDOUT_FILENO, str, strlen(str));
 }
 
 }


### PR DESCRIPTION
Attempt to unify halide_print() output to stdout (or equivalent) everywhere.