### PR TITLE
Ensure that Buffer::AllocationHeader runs all ctors

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -193,6 +193,7 @@ private:
             int new_count = --(alloc->ref_count);
             if (new_count == 0) {
                 void (*fn)(void *) = alloc->deallocate_fn;
+                alloc->~AllocationHeader();
                 fn(alloc);
             }
             buf.host = nullptr;


### PR DESCRIPTION
We allocate this via calling alloc-fn, casting to the right type, then setting the field values; if std::atomic<int> has internal fields other than the `int`, they might not get inited properly. Use placement-new to fix this.

(I don't know of any actual malfunction this is causing, it was just potentially-wrong by inspection)