### PR TITLE
Fix pybind's buffer-info lifetime management

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -104,6 +104,9 @@ public:
 
     typedef T ElemType;
 
+    // This is virtual solely to make some of the Python bindings easier to manage.
+    virtual ~Buffer() {}
+
     /** Make a null Buffer, which points to no Runtime::Buffer */
     Buffer() {}
 

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -104,7 +104,8 @@ public:
 
     typedef T ElemType;
 
-    // This is virtual solely to make some of the Python bindings easier to manage.
+    // This class isn't final (and is subclassed from the Python binding
+    // code, at least) so it needs a virtual dtor.
     virtual ~Buffer() {}
 
     /** Make a null Buffer, which points to no Runtime::Buffer */


### PR DESCRIPTION
The previous pybind code didn't properly manage the lifetime of Python buffer objects when used to construct a Buffer in a shared way. We now use a PyBind alias object for buffers to ensure the lifetime is managed properly.