### PR TITLE
Add move ctor/op= for Parameter

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -418,8 +418,12 @@ protected:
     void fail_wrong_type(const char *type);
 
 private:
-    explicit GeneratorParamBase(const GeneratorParamBase &) = delete;
+    // No copy
+    GeneratorParamBase(const GeneratorParamBase &) = delete;
     void operator=(const GeneratorParamBase &) = delete;
+    // No move
+    GeneratorParamBase(GeneratorParamBase&&) = delete;
+    void operator=(GeneratorParamBase&&) = delete;
 
     // Generator which owns this GeneratorParam. Note that this will be null
     // initially; the GeneratorBase itself will set this field when it initially
@@ -1248,8 +1252,12 @@ protected:
 private:
     template<typename T> friend class GeneratorParam_Synthetic;
 
-    explicit GIOBase(const GIOBase &) = delete;
+    // No copy
+    GIOBase(const GIOBase &) = delete;
     void operator=(const GIOBase &) = delete;
+    // No move
+    GIOBase(GIOBase&&) = delete;
+    void operator=(GIOBase&&) = delete;
 };
 
 template<>

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -98,6 +98,17 @@ Parameter::Parameter(const Parameter& that) : contents(that.contents) {
     }
 }
 
+Parameter::Parameter(Parameter&& that) {
+    bool that_registered = that.contents.defined() && that.contents->is_registered;
+    if (that_registered) {
+        ObjectInstanceRegistry::unregister_instance(&that);
+    }
+    std::swap(contents, that.contents);
+    if (that_registered) {
+        ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::FilterParam, this, nullptr);
+    }
+}
+
 Parameter& Parameter::operator=(const Parameter& that) {
     bool was_registered = contents.defined() && contents->is_registered;
     contents = that.contents;
@@ -112,6 +123,20 @@ Parameter& Parameter::operator=(const Parameter& that) {
         // Parameter p = make_interesting_parameter();
         // p = Parameter();
         ObjectInstanceRegistry::unregister_instance(this);
+    }
+    return *this;
+}
+
+Parameter& Parameter::operator=(Parameter&& that) {
+    bool this_registered = contents.defined() && contents->is_registered;
+    bool that_registered = that.contents.defined() && that.contents->is_registered;
+    std::swap(contents, that.contents);
+    if (that_registered && !this_registered) {
+        ObjectInstanceRegistry::unregister_instance(&that);
+        ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::FilterParam, this, nullptr);
+    } else if (!that_registered && this_registered) {
+        ObjectInstanceRegistry::unregister_instance(this);
+        ObjectInstanceRegistry::register_instance(&that, 0, ObjectInstanceRegistry::FilterParam, this, nullptr);
     }
     return *this;
 }

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -50,9 +50,11 @@ public:
                      const std::string &name, bool is_explicit_name = false,
                      bool register_instance = true);
 
-    /** Copy ctor, operator=, and dtor, needed for ObjectRegistry accounting. */
+    /** Copy+Move ctor, operator=, and dtor, needed for ObjectRegistry accounting. */
     Parameter(const Parameter&);
     Parameter& operator=(const Parameter&);
+    Parameter(Parameter&&);
+    Parameter& operator=(Parameter&&);
     ~Parameter();
 
     /** Get the type of this parameter */


### PR DESCRIPTION
The implicitly-define move ctor for Parameter didn't handle object instance registry tracking, which is must do. (Other usages should never be copyable or movable; move ops were deleted to ensure this.)