### PR TITLE
Fix minor clang-tidy warnings

### DIFF
--- a/src/Expr.h
+++ b/src/Expr.h
@@ -99,10 +99,10 @@ struct IRNode {
 };
 
 template<>
-inline RefCount &ref_count<IRNode>(const IRNode *n) {return n->ref_count;}
+inline RefCount &ref_count<IRNode>(const IRNode *t) {return t->ref_count;}
 
 template<>
-inline void destroy<IRNode>(const IRNode *n) {delete n;}
+inline void destroy<IRNode>(const IRNode *t) {delete t;}
 
 /** IR nodes are split into expressions and statements. These are
    similar to expressions and statements in C - expressions

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1385,8 +1385,8 @@ GIOBase::GIOBase(size_t array_size,
                  const std::string &name,
                  IOKind kind,
                  const std::vector<Type> &types,
-                 int dimensions)
-    : array_size_(array_size), name_(name), kind_(kind), types_(types), dims_(dimensions) {
+                 int dims)
+    : array_size_(array_size), name_(name), kind_(kind), types_(types), dims_(dims) {
 }
 
 GIOBase::~GIOBase() {

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -119,13 +119,13 @@ struct ModuleContents {
 };
 
 template<>
-RefCount &ref_count<ModuleContents>(const ModuleContents *f) {
-    return f->ref_count;
+RefCount &ref_count<ModuleContents>(const ModuleContents *t) {
+    return t->ref_count;
 }
 
 template<>
-void destroy<ModuleContents>(const ModuleContents *f) {
-    delete f;
+void destroy<ModuleContents>(const ModuleContents *t) {
+    delete t;
 }
 
 LoweredFunc::LoweredFunc(const std::string &name,

--- a/src/Module.h
+++ b/src/Module.h
@@ -120,7 +120,7 @@ public:
 
     /** Compile a halide Module to variety of outputs, depending on
      * the fields set in output_files. */
-    void compile(const Outputs &output_files) const;
+    void compile(const Outputs &output_files_arg) const;
 
     /** Compile a halide Module to in-memory object code. Currently
      * only supports LLVM based compilation, but should be extended to


### PR DESCRIPTION
Various declaration-vs-definition-names-differ warnings to silence downstream nags