### PR TITLE
Revise GeneratorParam<LoopLevel>::set() work for both before-and-after generate() usage

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -480,42 +480,52 @@ public:
 protected:
     virtual void set_impl(const T &new_value) { check_value_writable(); value_ = new_value; }
 
-private:
+    // Needs to be protected to allow GeneratorParam<LoopLevel>::set() override
     T value_;
 
-    template <typename T2, typename std::enable_if<std::is_convertible<T2, T>::value &&
-                                                  !std::is_same<T2, MachineParams>::value &&
-                                                  !std::is_same<T2, LoopLevel>::value>::type * = nullptr>
-    HALIDE_ALWAYS_INLINE void typed_setter_impl(const T2 &value, const char * msg) {
-        check_value_writable();
-        // Arithmetic types must roundtrip losslessly.
-        if (!std::is_same<T, T2>::value &&
-            std::is_arithmetic<T>::value &&
-            std::is_arithmetic<T2>::value) {
-            const T t = Convert<T2, T>::value(value);
-            const T2 t2 = Convert<T, T2>::value(t);
-            if (t2 != value) {
-                fail_wrong_type(msg);
-            }
-        }
-        value_ = Convert<T2, T>::value(value);
-    }
-
-    template <typename T2, typename std::enable_if<!std::is_convertible<T2, T>::value>::type * = nullptr>
-    HALIDE_ALWAYS_INLINE void typed_setter_impl(const T2 &, const char *msg) {
+private:
+    // If FROM->T is not legal, fail
+    template <typename FROM, typename std::enable_if<
+        !std::is_convertible<FROM, T>::value
+    >::type * = nullptr>
+    HALIDE_ALWAYS_INLINE void typed_setter_impl(const FROM &, const char *msg) {
         fail_wrong_type(msg);
     }
 
-    template <typename T2, typename std::enable_if<std::is_same<T, T2>::value &&
-                                                   std::is_same<T, MachineParams>::value>::type * = nullptr>
-    HALIDE_ALWAYS_INLINE void typed_setter_impl(const MachineParams &value, const char *msg) {
+    // If FROM and T are identical, just assign
+    template <typename FROM, typename std::enable_if<
+        std::is_same<FROM, T>::value
+    >::type * = nullptr>
+    HALIDE_ALWAYS_INLINE void typed_setter_impl(const FROM &value, const char * msg) {
+        check_value_writable();
         value_ = value;
     }
 
-    template <typename T2, typename std::enable_if<std::is_same<T, T2>::value &&
-                                                   std::is_same<T, LoopLevel>::value>::type * = nullptr>
-    HALIDE_ALWAYS_INLINE void typed_setter_impl(const LoopLevel &value, const char *msg) {
-        value_.set(value);
+    // If both FROM->T and T->FROM are legal, ensure it's lossless
+    template <typename FROM, typename std::enable_if<
+        !std::is_same<FROM, T>::value &&
+        std::is_convertible<FROM, T>::value &&
+        std::is_convertible<T, FROM>::value
+    >::type * = nullptr>
+    HALIDE_ALWAYS_INLINE void typed_setter_impl(const FROM &value, const char * msg) {
+        check_value_writable();
+        const T t = Convert<FROM, T>::value(value);
+        const FROM value2 = Convert<T, FROM>::value(t);
+        if (value2 != value) {
+            fail_wrong_type(msg);
+        }
+        value_ = t;
+    }
+
+    // If FROM->T is legal but T->FROM is not, just assign
+    template <typename FROM, typename std::enable_if<
+        !std::is_same<FROM, T>::value &&
+        std::is_convertible<FROM, T>::value &&
+        !std::is_convertible<T, FROM>::value
+    >::type * = nullptr>
+    HALIDE_ALWAYS_INLINE void typed_setter_impl(const FROM &value, const char * msg) {
+        check_value_writable();
+        value_ = value;
     }
 };
 
@@ -575,6 +585,26 @@ public:
 class GeneratorParam_LoopLevel : public GeneratorParamImpl<LoopLevel> {
 public:
     GeneratorParam_LoopLevel(const std::string &name, const LoopLevel &value) : GeneratorParamImpl<LoopLevel>(name, value) {}
+
+    void set(const LoopLevel &value) override {
+        // Don't call check_value_writable(): It's OK to set a LoopLevel after generate().
+        // check_value_writable();
+
+        // This looks odd, but is deliberate:
+
+        // First, mutate the existing contents to match the value passed in,
+        // so that any existing usage of the LoopLevel now uses the newer value.
+        // (Strictly speaking, this is really only necessary if this method
+        // is called after generate(): before generate(), there is no usage
+        // to be concerned with.)
+        value_.set(value);
+
+        // Then, reset the value itself so that it points to the same LoopLevelContents
+        // as the value passed in. (Strictly speaking, this is really only
+        // useful if this method is called before generate(): afterwards, it's
+        // too late to alter the code to refer to a different LoopLevelContents.)
+        value_ = value;
+    }
 
     void set_from_string(const std::string &new_value_string) override {
         if (new_value_string == "root") {

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -586,6 +586,8 @@ class GeneratorParam_LoopLevel : public GeneratorParamImpl<LoopLevel> {
 public:
     GeneratorParam_LoopLevel(const std::string &name, const LoopLevel &value) : GeneratorParamImpl<LoopLevel>(name, value) {}
 
+    using GeneratorParamImpl<LoopLevel>::set;
+
     void set(const LoopLevel &value) override {
         // Don't call check_value_writable(): It's OK to set a LoopLevel after generate().
         // check_value_writable();

--- a/test/correctness/loop_level_generator_param.cpp
+++ b/test/correctness/loop_level_generator_param.cpp
@@ -1,0 +1,171 @@
+#include "Halide.h"
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+namespace {
+
+// Remove any "$[0-9]+" patterns in the string.
+std::string strip_uniquified_names(const std::string &str) {
+    size_t pos = 0;
+    std::string result = str;
+    while ((pos = result.find("$", pos)) != std::string::npos) {
+        int digits = 0;
+        while (pos+digits+1 < result.size() && isdigit(result[pos+digits+1])) {
+            digits++;
+        }
+        if (digits > 0) {
+            result.replace(pos, 1 + digits, "");
+        }
+        pos += 1;
+    }
+    return result;
+}
+
+class CheckLoopLevels : public IRVisitor {
+public:
+    static void lower_and_check(Func outer, const std::string &inner_loop_level, const std::string &outer_loop_level) {
+        Module m = outer.compile_to_module({outer.infer_arguments()});
+        CheckLoopLevels c(inner_loop_level, outer_loop_level);
+        m.functions().front().body.accept(&c);
+    }
+
+private:
+    CheckLoopLevels(const std::string &inner_loop_level, const std::string &outer_loop_level) :
+        inner_loop_level(inner_loop_level), outer_loop_level(outer_loop_level) {}
+
+    using IRVisitor::visit;
+
+    const std::string inner_loop_level, outer_loop_level;
+    std::string inside_for_loop;
+
+    void visit(const For *op) override {
+        std::string old_for_loop = inside_for_loop;
+        inside_for_loop = strip_uniquified_names(op->name);
+        IRVisitor::visit(op);
+        inside_for_loop = old_for_loop;
+    }
+
+    void visit(const Call *op) override {
+        IRVisitor::visit(op);
+        if (op->name == "sin_f32") {
+            _halide_user_assert(inside_for_loop == inner_loop_level)
+                << "call sin_f32: expected " << inner_loop_level << ", actual: " << inside_for_loop;
+        } else if (op->name == "cos_f32") {
+            _halide_user_assert(inside_for_loop == outer_loop_level)
+                << "call cos_f32: expected " << outer_loop_level << ", actual: " << inside_for_loop;
+        }
+    }
+
+    void visit(const Store *op) override {
+        IRVisitor::visit(op);
+        std::string op_name = strip_uniquified_names(op->name);
+        if (op_name == "inner") {
+            _halide_user_assert(inside_for_loop == inner_loop_level)
+                << "inside_for_loop: expected " << inner_loop_level << ", actual: " << inside_for_loop;
+        } else if (op_name == "outer") {
+            _halide_user_assert(inside_for_loop == outer_loop_level)
+                << "inside_for_loop: expected " << outer_loop_level << ", actual: " << inside_for_loop;
+        } else {
+            _halide_user_assert(0) << "store at: " << op_name << " inside_for_loop: " << inside_for_loop;
+        }
+    }
+};
+
+Var x{"x"};
+
+class Example : public Generator<Example> {
+public:
+    GeneratorParam<LoopLevel> inner_compute_at{ "inner_compute_at", LoopLevel::inlined() };
+    Output<Func> inner{ "inner", Int(32), 1 };
+
+    void generate() {
+        // Use sin() as a proxy for verifying compute_at, since it won't
+        // ever be generated incidentally by the lowering code as part of
+        // general code structure.
+        inner(x) = cast(inner.type(), trunc(sin(x) * 1000.0f));
+    }
+
+    void schedule() {
+        inner.compute_at(inner_compute_at);
+    }
+};
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    GeneratorContext context(get_jit_target_from_environment());
+
+    {
+        // Call GeneratorParam<LoopLevel>::set() with 'root' *before* generate(), then never modify again.
+        auto gen = context.create<Example>();
+        gen->inner_compute_at.set(LoopLevel::root());
+        gen->apply();
+
+        Func outer;
+        outer(x) = gen->inner(x) + trunc(cos(x) * 1000.0f);
+
+        CheckLoopLevels::lower_and_check(outer,
+            /* inner loop level */ "inner.s0.x",
+            /* outer loop level */ "outer.s0.x");
+    }
+
+    {
+        // Call GeneratorParam<LoopLevel>::set() *before* generate() with undefined Looplevel;
+        // then modify that LoopLevel after generate() but before lowering
+        LoopLevel inner_compute_at;  // undefined: must set before lowering
+        auto gen = context.create<Example>();
+        gen->inner_compute_at.set(inner_compute_at);
+        gen->apply();
+
+        Func outer;
+        outer(x) = gen->inner(x) + trunc(cos(x) * 1000.0f);
+
+        inner_compute_at.set({outer, x});
+
+        CheckLoopLevels::lower_and_check(outer,
+            /* inner loop level */ "outer.s0.x",
+            /* outer loop level */ "outer.s0.x");
+    }
+
+    {
+        // Call GeneratorParam<LoopLevel>::set() *after* generate()
+        auto gen = context.create<Example>();
+        gen->apply();
+
+        Func outer;
+        outer(x) = gen->inner(x) + trunc(cos(x) * 1000.0f);
+
+        gen->inner_compute_at.set({outer, x});
+
+        CheckLoopLevels::lower_and_check(outer,
+            /* inner loop level */ "outer.s0.x",
+            /* outer loop level */ "outer.s0.x");
+    }
+
+    {
+        // And now, a case that doesn't work:
+        // - Call GeneratorParam<LoopLevel>::set() *after* generate()
+        // - Then call set(), again, on the local LoopLevel passed previously
+        // As expected, the second set() will have no effect.
+        auto gen = context.create<Example>();
+        gen->apply();
+
+        Func outer;
+        outer(x) = gen->inner(x) + trunc(cos(x) * 1000.0f);
+
+        LoopLevel inner_compute_at(LoopLevel::root());
+        gen->inner_compute_at.set(inner_compute_at);
+
+        // This has no effect. (If it did, the inner loop level below would be outer.s0.x)
+        inner_compute_at.set({outer, x});
+
+        CheckLoopLevels::lower_and_check(outer,
+            /* inner loop level */ "inner.s0.x",
+            /* outer loop level */ "outer.s0.x");
+    }
+
+    printf("Success!\n");
+    return 0;
+}
+

--- a/test/correctness/loop_level_generator_param.cpp
+++ b/test/correctness/loop_level_generator_param.cpp
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
         gen->inner_compute_at.set(LoopLevel::root());
         gen->apply();
 
-        Func outer;
+        Func outer("outer");
         outer(x) = gen->inner(x) + trunc(cos(x) * 1000.0f);
 
         CheckLoopLevels::lower_and_check(outer,
@@ -118,7 +118,7 @@ int main(int argc, char **argv) {
         gen->inner_compute_at.set(inner_compute_at);
         gen->apply();
 
-        Func outer;
+        Func outer("outer");
         outer(x) = gen->inner(x) + trunc(cos(x) * 1000.0f);
 
         inner_compute_at.set({outer, x});
@@ -133,7 +133,7 @@ int main(int argc, char **argv) {
         auto gen = context.create<Example>();
         gen->apply();
 
-        Func outer;
+        Func outer("outer");
         outer(x) = gen->inner(x) + trunc(cos(x) * 1000.0f);
 
         gen->inner_compute_at.set({outer, x});
@@ -151,7 +151,7 @@ int main(int argc, char **argv) {
         auto gen = context.create<Example>();
         gen->apply();
 
-        Func outer;
+        Func outer("outer");
         outer(x) = gen->inner(x) + trunc(cos(x) * 1000.0f);
 
         LoopLevel inner_compute_at(LoopLevel::root());


### PR DESCRIPTION
A much-simpler alternative to PR#2720. Note that the interesting change is really all in the override to set() in GeneratorParam_LoopLevel (the changes to the base class implementation are just drive-by simplification to make that override a bit easier to reason about).