### PR TITLE
Add Hexagon DMA app (rebase of hex-dma on new master).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -578,6 +578,7 @@ RUNTIME_CPP_COMPONENTS = \
   gcd_thread_pool \
   gpu_device_selection \
   hexagon_cpu_features \
+  hexagon_dma \
   hexagon_host \
   ios_io \
   linux_clock \
@@ -651,6 +652,7 @@ RUNTIME_LL_COMPONENTS = \
 
 RUNTIME_EXPORTED_INCLUDES = $(INCLUDE_DIR)/HalideRuntime.h \
                             $(INCLUDE_DIR)/HalideRuntimeCuda.h \
+                            $(INCLUDE_DIR)/HalideRuntimeHexagonDma.h \
                             $(INCLUDE_DIR)/HalideRuntimeHexagonHost.h \
                             $(INCLUDE_DIR)/HalideRuntimeOpenCL.h \
                             $(INCLUDE_DIR)/HalideRuntimeOpenGL.h \
@@ -998,7 +1000,7 @@ $(BIN_DIR)/correctness_plain_c_includes: $(ROOT_DIR)/test/correctness/plain_c_in
 	$(CXX) -x c -Wall -Werror -I$(ROOT_DIR) $(OPTIMIZE_FOR_BUILD_TIME) $< -I$(ROOT_DIR)/src/runtime -o $@
 
 # Note that this test must *not* link in either libHalide, or a Halide runtime;
-# this test should be usable without either. 
+# this test should be usable without either.
 $(BIN_DIR)/correctness_halide_buffer: $(ROOT_DIR)/test/correctness/halide_buffer.cpp $(INCLUDE_DIR)/HalideBuffer.h $(RUNTIME_EXPORTED_INCLUDES)
 	$(CXX) $(TEST_CXX_FLAGS) $(OPTIMIZE_FOR_BUILD_TIME) $< -I$(INCLUDE_DIR) -o $@
 
@@ -1379,8 +1381,8 @@ $(BIN_DIR)/tutorial_lesson_21_auto_scheduler_generate: $(ROOT_DIR)/tutorial/less
 	-I$(INCLUDE_DIR) $(TEST_LD_FLAGS) $(IMAGE_IO_LIBS) -o $@
 
 # The values in MachineParams are:
-# - the maximum level of parallelism available, 
-# - the size of the last-level cache (in KB), 
+# - the maximum level of parallelism available,
+# - the size of the last-level cache (in KB),
 # - the ratio between the cost of a miss at the last level cache and the cost
 #   of arithmetic on the target architecture
 # ...in that order.

--- a/apps/hexagon_dma/Makefile
+++ b/apps/hexagon_dma/Makefile
@@ -1,0 +1,45 @@
+# Ensure that make with no arguments makes the right thing
+all:
+
+include ../support/Makefile.inc
+
+# This app requires a separate toolchain to be built from the Android NDK,
+# using the make-standalone-toolchain.sh script:
+#$ build/tools/make-standalone-toolchain.sh --arch=arm64 --platform=android-21 --install-dir=$ANDROID_ARM64_TOOLCHAIN
+#$ build/tools/make-standalone-toolchain.sh --arch=arm --platform=android-21 --install-dir=$ANDROID_ARM_TOOLCHAIN
+CXX-host ?= $(CXX)
+CXX-arm-64-android ?= $(ANDROID_ARM64_TOOLCHAIN)/bin/aarch64-linux-android-c++
+CXX-arm-32-android ?= $(ANDROID_ARM_TOOLCHAIN)/bin/arm-linux-androideabi-c++
+CXX-arm-64-profile-android ?= $(CXX-arm-64-android)
+CXX-arm-32-profile-android ?= $(CXX-arm-32-android)
+
+CXXFLAGS-host ?=
+CXXFLAGS-arm-64-android ?=
+CXXFLAGS-arm-32-android ?=
+
+LDFLAGS-host ?= -lpthread -ldl -lm
+LDFLAGS-arm-64-android ?= -llog -fPIE -pie
+LDFLAGS-arm-32-android ?= -llog -fPIE -pie
+LDFLAGS-arm-64-profile-android ?= -llog -fPIE -pie
+LDFLAGS-arm-32-profile-android ?= -llog -fPIE -pie
+
+BIN ?= bin
+
+all: $(BIN)/process-host
+
+$(BIN)/pipeline: pipeline.cpp $(GENERATOR_DEPS)
+	@mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
+
+$(BIN)/%/pipeline.o: $(BIN)/pipeline
+	@mkdir -p $(@D)
+	$^ -g dma_pipeline -o $(BIN)/$* -e o,h -f pipeline target=$*-hexagon_dma
+
+$(BIN)/process-%: process.cpp $(BIN)/%/pipeline.o mock_dma_implementation.cpp
+	$(CXX-$*) $(CXXFLAGS) $(CXXFLAGS-$*) -I $(BIN)/$* -Wall -O3 process.cpp mock_dma_implementation.cpp $(BIN)/$*/pipeline.o -o $(BIN)/process-$* $(LDFLAGS-$*)
+
+run-host: $(BIN)/process-host
+	$(BIN)/process-host 2048 1024
+
+clean:
+	rm -rf $(BIN)

--- a/apps/hexagon_dma/mock_dma_implementation.cpp
+++ b/apps/hexagon_dma/mock_dma_implementation.cpp
@@ -1,0 +1,198 @@
+/**
+ * This file is a duplicate of the actual hexagon_dma_device_shim.cpp used to call the DMA driver functions
+ * The definitions in this file a week reference so that these will be called only in case of unavailability of
+ * actual DMA functions.
+ * This file is need only if there is no hexagon SDK support or NO hexagon DMA support, in either csae we replace
+ * the DMA operations with normal memory operations */
+
+#include "pipeline.h"
+#include "HalideRuntime.h"
+#include "../../src/runtime/mini_hexagon_dma.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <memory.h>
+
+//Mock Global Descriptor
+typedef struct stDescriptor {
+  struct {
+      uintptr_t DesPointer    ;   // for chain to next "desc" or NULL to terminate the chain
+      uint32 DstPixFmt        :  3;
+      uint32 DstIsUbwc        :  1;
+      uint32 SrcPixFmt        :  3;
+      uint32 SrcIsUbwc        :  1;
+      uint32 DstIsTcm         :  1;
+      uint32 _unused0         :  3;
+      uint32 SrcIsTcm         :  1;
+      uint32 _unused1         :  3;
+      uint32 DstPixPadding    :  1;
+      uint32 _unused2         :  3;
+      uint32 SrcPixPadding    :  1;
+      uint32 _unused3         : 11;
+      uint32 FrmHeight        : 16;
+      uint32 FrmWidth         : 16;
+      uint32 RoiY             : 16;
+      uint32 RoiX             : 16;
+    } stWord0;
+    struct {
+      uint32 RoiH             : 16;
+      uint32 RoiW             : 16;
+      uint32 SrcRoiStride     : 16;
+      uint32 DstRoiStride     : 16;
+      uintptr_t SrcFrmBaseAddr;
+      uintptr_t DstFrmBaseAddr;
+      uint32 SrcRoiStartAddr  : 32;
+      uint32 DstRoiStartAddr  : 32;
+      uint32 ubwc_stat_pointer  : 32;// use reserved3 for gralloc ubwc_stat_pointer
+    } stWord1;
+} t_StHwDescriptor;
+
+typedef struct {
+     int x; //in case we want to keep a count
+     t_StHwDescriptor *ptr;
+} dma_handle_t;
+
+void* HAP_cache_lock(unsigned int size, void** paddr_ptr) {
+    void * alloc = 0;
+    if (size != 0) {
+        alloc = malloc(size);
+    }
+    return alloc;
+}
+
+int HAP_cache_unlock(void* vaddr_ptr) {
+    if (vaddr_ptr != 0) {
+        free(vaddr_ptr);
+        return 0;
+    }
+    return 1;
+}
+
+t_DmaWrapper_DmaEngineHandle hDmaWrapper_AllocDma(void) {
+    dma_handle_t* handle = (dma_handle_t*)malloc(sizeof(dma_handle_t));
+    handle->ptr = NULL;
+    return (void *)handle;
+}
+
+int32 nDmaWrapper_FreeDma(t_DmaWrapper_DmaEngineHandle dma_handle) {
+    dma_handle_t *desc = (dma_handle_t *)dma_handle;
+    assert(desc->ptr == NULL);
+    free(desc);
+    return 0;
+}
+
+int32 nDmaWrapper_Move(t_DmaWrapper_DmaEngineHandle handle) {
+
+    t_StHwDescriptor *desc = 0;
+    if(handle != 0) {
+        dma_handle_t* dma_handle = (dma_handle_t *)handle;
+        desc = dma_handle->ptr;
+
+        while (desc != NULL) {
+            unsigned char* host_addr = reinterpret_cast<unsigned char *>(desc->stWord1.SrcFrmBaseAddr);
+            unsigned char* dest_addr = reinterpret_cast<unsigned char *>(desc->stWord1.DstFrmBaseAddr);
+ 
+// Helpful debug code.
+#if 0
+            printf("Processing descriptor %p -- host_addr: %p dest_addr: %p ROI: (X: %u, Y: %u, W: %u, H: %u) SrcRoiStride: %u, DstRoiStride %u, FrmWidth %u.\n",
+                   desc, host_addr, dest_addr, desc->stWord0.RoiX, desc->stWord0.RoiY, desc->stWord1.RoiW, desc->stWord1.RoiH,
+                   desc->stWord1.SrcRoiStride, desc->stWord1.DstRoiStride, desc->stWord0.FrmWidth);
+#endif
+
+            int x = desc->stWord0.RoiX;
+            int y = desc->stWord0.RoiY;
+            int w = desc->stWord1.RoiW;
+            int h = desc->stWord1.RoiH;
+            for (int yii=0;yii<h;yii++) {
+              for (int xii=0;xii<w;xii++) {
+                    int yin = yii * desc->stWord1.DstRoiStride;
+                    int xin = xii;
+                    int RoiOffset = x + y * desc->stWord1.SrcRoiStride;
+                    int xout = xii;
+                    int yout = yii * desc->stWord0.FrmWidth;
+                    dest_addr[yin+xin] = host_addr[RoiOffset + yout + xout];
+                }
+            }
+            desc = reinterpret_cast<t_StHwDescriptor*>(desc->stWord0.DesPointer);
+        }
+    }
+    return 0;
+}
+
+int32 nDmaWrapper_Wait(t_DmaWrapper_DmaEngineHandle dma_handle) {
+    return 0;
+}
+
+int32 nDmaWrapper_FinishFrame(t_DmaWrapper_DmaEngineHandle dma_handle) {
+    dma_handle_t *desc = (dma_handle_t *)dma_handle;
+    //remove the association from descriptor
+    desc->ptr = NULL;
+    return 0;
+}
+
+int32 nDmaWrapper_GetRecommendedWalkSize(t_eDmaFmt fmt, bool is_ubwc,
+                                         t_StDmaWrapper_RoiAlignInfo* walk_size) {
+    walk_size->u16H = align(walk_size->u16H, 1);
+    walk_size->u16W = align(walk_size->u16W, 1);
+    return 0;
+}
+
+int32 nDmaWrapper_GetRecommendedIntermBufStride(t_eDmaFmt fmt,
+                                                t_StDmaWrapper_RoiAlignInfo* roi_size,
+                                                 bool is_ubwc) {
+    return align(roi_size->u16W, 256);
+}
+
+int32 nDmaWrapper_DmaTransferSetup(t_DmaWrapper_DmaEngineHandle handle, t_StDmaWrapper_DmaTransferSetup* dma_transfer_parm) {
+
+    if (handle == 0)
+        return 1;
+
+    if (dma_transfer_parm->pDescBuf == NULL)
+        return 1;
+
+    //Add it to the linked list of dma_handle->ptr
+    dma_handle_t *dma_handle = (dma_handle_t *)handle;
+    t_StHwDescriptor *temp = dma_handle->ptr;
+    t_StHwDescriptor *desc = (t_StHwDescriptor *)dma_transfer_parm->pDescBuf;
+    desc->stWord0.DesPointer  = 0;
+
+    if (temp != NULL) {
+        while (temp->stWord0.DesPointer != 0) {
+            temp =  reinterpret_cast<t_StHwDescriptor *>(temp->stWord0.DesPointer);
+        }
+        temp->stWord0.DesPointer =  reinterpret_cast<uintptr_t>(desc);
+    } else {
+        dma_handle->ptr = desc;
+    }
+
+    desc->stWord0.DstIsUbwc = dma_transfer_parm->bIsFmtUbwc;
+    desc->stWord0.DstIsTcm = (dma_transfer_parm->eTransferType == eDmaWrapper_DdrToL2) ? 1 : 0;
+    desc->stWord0.FrmHeight = dma_transfer_parm->u16FrameH;
+    desc->stWord0.FrmWidth = dma_transfer_parm->u16FrameW;
+    desc->stWord0.RoiX = dma_transfer_parm->u16RoiX;
+    desc->stWord0.RoiY = dma_transfer_parm->u16RoiY;
+    desc->stWord1.RoiH = dma_transfer_parm->u16RoiH;
+    desc->stWord1.RoiW = dma_transfer_parm->u16RoiW;
+    desc->stWord1.SrcRoiStride = dma_transfer_parm->u16FrameStride;
+    desc->stWord1.DstRoiStride = dma_transfer_parm->u16RoiStride;
+    desc->stWord1.DstFrmBaseAddr = reinterpret_cast<uintptr_t>(dma_transfer_parm->pTcmDataBuf);
+    desc->stWord1.SrcFrmBaseAddr  = reinterpret_cast<uintptr_t>(dma_transfer_parm->pFrameBuf);
+    return 0;
+
+}
+
+int32 nDmaWrapper_GetDescbuffsize(t_eDmaFmt *fmt, uint16 nsize) {
+
+    int32 i, yuvformat=0,desc_size;
+    for (i=0;i<nsize;i++) {
+        if ((fmt[i]==eDmaFmt_NV12)||(fmt[i]==eDmaFmt_TP10)||
+            (fmt[i]==eDmaFmt_NV124R)||(fmt[i]==eDmaFmt_P010)) {
+            yuvformat += 1;
+        }
+    }
+    desc_size = (nsize+yuvformat)*64;
+    return desc_size;
+}
+

--- a/apps/hexagon_dma/pipeline.cpp
+++ b/apps/hexagon_dma/pipeline.cpp
@@ -1,0 +1,37 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+class DmaPipeline : public Generator<DmaPipeline> {
+public:
+    Input<Buffer<uint8_t>> input{"input", 2};
+    Output<Buffer<uint8_t>> output{"output", 2};
+
+    void generate() {
+        Var x{"x"}, y{"y"};
+
+        // We need a wrapper for the output so we can schedule the
+        // multiply update in tiles.
+        Func copy("copy");
+        copy(x, y) = input(x, y);
+
+        output(x, y) = copy(x, y) * 2;
+
+        Var tx("tx"), ty("ty");
+
+        // Break the output into tiles.
+        const int tile_width = 64;
+        const int tile_height = 32;
+        output.compute_root()
+            .tile(x, y, tx, ty, x, y, tile_width, tile_height, TailStrategy::RoundUp);
+
+        // Schedule the copy to be computed at tiles with a
+        // circular buffer of two tiles.
+        copy.compute_at(output, tx)
+            .store_root()
+            .fold_storage(x, tile_width * 2)
+            .copy_to_host();
+    }
+};
+
+HALIDE_REGISTER_GENERATOR(DmaPipeline, dma_pipeline)

--- a/apps/hexagon_dma/process.cpp
+++ b/apps/hexagon_dma/process.cpp
@@ -1,0 +1,77 @@
+#include <stdio.h>
+#include <memory.h>
+#include <assert.h>
+#include <stdlib.h>
+
+#include "halide_benchmark.h"
+
+#include "pipeline.h"
+
+#include "HalideRuntimeHexagonDma.h"
+#include "HalideBuffer.h"
+
+int main(int argc, char **argv) {
+    if (argc < 3) {
+        printf("Usage: %s width height\n", argv[0]);
+        return 0;
+    }
+
+    const int width = atoi(argv[1]);
+    const int height = atoi(argv[2]);
+
+    // Fill the input buffer with random data. This is just a plain
+    // old memory buffer.
+    uint8_t *memory_to_dma_from = (uint8_t*)malloc(width * height);
+    for (int i = 0; i < width * height; i++) {
+        memory_to_dma_from[i] = (uint8_t)rand();
+    }
+
+    Halide::Runtime::Buffer<uint8_t> input_validation(memory_to_dma_from, width, height);
+    Halide::Runtime::Buffer<uint8_t> input(nullptr, width, height);
+
+    // TODO: We shouldn't need to allocate a host buffer here, but the
+    // current implementation of cropping + halide_buffer_copy needs
+    // it to work correctly.
+    input.allocate();
+
+    // Give the input the buffer we want to DMA from.
+    input.device_wrap_native(halide_hexagon_dma_device_interface(),
+                             reinterpret_cast<uint64_t>(memory_to_dma_from));
+    input.set_device_dirty();
+
+    // In order to actually do a DMA transfer, we need to allocate a
+    // DMA engine.
+    void *dma_engine = nullptr;
+    halide_hexagon_dma_allocate_engine(nullptr, &dma_engine);
+
+    // We then need to prepare for copying to host. Attempting to copy
+    // to host without doing this is an error.
+    halide_hexagon_dma_prepare_for_copy_to_host(nullptr, input, dma_engine);
+
+    Halide::Runtime::Buffer<uint8_t> output(width, height);
+
+    int result = pipeline(input, output);
+    if (result != 0) {
+        printf("pipeline failed! %d\n", result);
+    }
+
+    // Validate that the algorithm did what we expect.
+    output.for_each_element([&](int x, int y) {
+        uint8_t correct = input_validation(x, y) * 2;
+        if (correct != output(x, y)) {
+            printf("Mismatch at %d %d: %d != %d\n", x, y, correct, output(x, y));
+            abort();
+        }
+    });
+
+    halide_hexagon_dma_unprepare(nullptr, input);
+
+    // We're done with the DMA engine, release it. This would also be
+    // done automatically by device_free.
+    halide_hexagon_dma_deallocate_engine(nullptr, dma_engine);
+
+    free(memory_to_dma_from);
+
+    printf("Success!\n");
+    return 0;
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ set(RUNTIME_CPP
   gcd_thread_pool
   gpu_device_selection
   hexagon_cpu_features
+  hexagon_dma
   hexagon_host
   ios_io
   linux_clock

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -83,6 +83,7 @@ DECLARE_CPP_INITMOD(fake_thread_pool)
 DECLARE_CPP_INITMOD(float16_t)
 DECLARE_CPP_INITMOD(gcd_thread_pool)
 DECLARE_CPP_INITMOD(gpu_device_selection)
+DECLARE_CPP_INITMOD(hexagon_dma)
 DECLARE_CPP_INITMOD(hexagon_host)
 DECLARE_CPP_INITMOD(ios_io)
 DECLARE_CPP_INITMOD(linux_clock)
@@ -891,6 +892,9 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
         if (t.arch != Target::Hexagon && t.features_any_of({Target::HVX_64, Target::HVX_128})) {
             modules.push_back(get_initmod_module_jit_ref_count(c, bits_64, debug));
             modules.push_back(get_initmod_hexagon_host(c, bits_64, debug));
+        }
+        if (t.has_feature(Target::HexagonDma)) {
+            modules.push_back(get_initmod_hexagon_dma(c, bits_64, debug));
         }
     }
 

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -248,6 +248,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"mingw", Target::MinGW},
     {"c_plus_plus_name_mangling", Target::CPlusPlusMangling},
     {"large_buffers", Target::LargeBuffers},
+    {"hexagon_dma", Target::HexagonDma},
     {"hvx_64", Target::HVX_64},
     {"hvx_128", Target::HVX_128},
     {"hvx_v62", Target::HVX_v62},

--- a/src/Target.h
+++ b/src/Target.h
@@ -70,6 +70,7 @@ struct Target {
         MinGW = halide_target_feature_mingw,
         CPlusPlusMangling = halide_target_feature_c_plus_plus_mangling,
         LargeBuffers = halide_target_feature_large_buffers,
+        HexagonDma = halide_target_feature_hexagon_dma,
         HVX_64 = halide_target_feature_hvx_64,
         HVX_128 = halide_target_feature_hvx_128,
         HVX_v62 = halide_target_feature_hvx_v62,

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1072,7 +1072,9 @@ typedef enum halide_target_feature_t {
     halide_target_feature_hvx_v65 = 47, ///< Enable Hexagon v65 architecture.
     halide_target_feature_hvx_v66 = 48, ///< Enable Hexagon v66 architecture.
     halide_target_feature_cl_half = 49,  ///< Enable half support on OpenCL targets
-    halide_target_feature_end = 50, ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
+    halide_target_feature_hexagon_dma = 50, ///< Enable Hexagon DMA buffers.
+
+    halide_target_feature_end = 51, ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 
 /** This function is called internally by Halide in some situations to determine

--- a/src/runtime/HalideRuntimeHexagonDma.h
+++ b/src/runtime/HalideRuntimeHexagonDma.h
@@ -1,0 +1,49 @@
+#ifndef HALIDE_HALIDERUNTIMEHEXAGONDMA_H
+#define HALIDE_HALIDERUNTIMEHEXAGONDMA_H
+
+#include "HalideRuntime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \file
+ *  Routines specific to the Halide Hexagon host-side runtime.
+ */
+
+extern const struct halide_device_interface_t *halide_hexagon_dma_device_interface();
+
+/** The device handle for Hexagon is simply a pointer and size, stored
+ * in the dev field of the buffer_t. If the buffer is allocated in a
+ * particular way (ion_alloc), the buffer will be shared with Hexagon
+ * (not copied). The device field of the buffer_t must be NULL when this
+ * routine is called. This call can fail due to running out of memory
+ * or being passed an invalid device handle. The device and host
+ * dirty bits are left unmodified. */
+extern int halide_hexagon_dma_device_wrap_native(void *user_context, struct halide_buffer_t *buf,
+                                                 uint64_t mem);
+
+/** Disconnect this halide_buffer_t from the device handle it was
+ * previously wrapped around. Should only be called for a
+ * halide_buffer_t that halide_hexagon_wrap_device_handle was
+ * previously called on. Frees any storage associated with the binding
+ * of the halide_buffer_t and the device handle, but does not free the
+ * device handle. The device field of the halide_buffer_t will be NULL
+ * on return. */
+extern int halide_hexagon_dma_device_detach_native(void *user_context, struct halide_buffer_t *buf);
+
+/** Before a buffer can be used in a copy operation (i.e. a DMA
+ * operation), it must have a DMA engine allocated. */
+///@{
+extern int halide_hexagon_dma_allocate_engine(void *user_context, void ** dma_engine);
+extern int halide_hexagon_dma_deallocate_engine(void *user_context, void *dma_engine);
+extern int halide_hexagon_dma_prepare_for_copy_to_host(void *user_context, struct halide_buffer_t *buf,
+                                                       void *dma_engine);
+extern int halide_hexagon_dma_unprepare(void *user_context, struct halide_buffer_t *buf);
+///@}
+
+#ifdef __cplusplus
+} // End extern "C"
+#endif
+
+#endif // HALIDE_HALIDERUNTIMEHEXAGONDMA_H

--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -610,9 +610,7 @@ WEAK int halide_device_release_crop(void *user_context,
         ScopedMutexLock lock(&device_copy_mutex);
         const struct halide_device_interface_t *interface = buf->device_interface;
         int result = interface->impl->device_release_crop(user_context, buf);
-        buf->device = 0;
         interface->impl->release_module();
-        buf->device_interface = NULL;
         return result;
     }
     return 0;

--- a/src/runtime/hexagon_dma.cpp
+++ b/src/runtime/hexagon_dma.cpp
@@ -1,0 +1,535 @@
+#include "runtime_internal.h"
+#include "device_buffer_utils.h"
+#include "device_interface.h"
+#include "HalideRuntimeHexagonDma.h"
+#include "printer.h"
+#include "mini_hexagon_dma.h"
+
+namespace Halide { namespace Runtime { namespace Internal { namespace HexagonDma {
+
+extern WEAK halide_device_interface_t hexagon_dma_device_interface;
+
+struct dma_device_handle {
+    uint8_t *buffer;
+    int offset_x;
+    int offset_y;
+    void *dma_engine;
+    int frame_width;
+    int frame_height;
+    int frame_stride;
+    void *desc_addr;
+};
+
+dma_device_handle *malloc_device_handle() {
+    dma_device_handle *dev = (dma_device_handle *)malloc(sizeof(dma_device_handle));
+    dev->buffer = 0;
+    dev->offset_x = 0;
+    dev->offset_y = 0;
+    dev->dma_engine = 0;
+    dev->frame_width = 0;
+    dev->frame_height = 0;
+    dev->frame_stride = 0;
+    dev->desc_addr = 0;
+    return dev;
+}
+
+typedef struct desc_pool {
+    void* descriptor;
+    bool used;
+    struct desc_pool* next;
+} desc_pool_t;
+
+typedef desc_pool_t* pdesc_pool;
+static pdesc_pool dma_desc_pool = NULL;
+#define descriptor_size 64
+
+static void* desc_pool_get (void) {
+
+    pdesc_pool temp = dma_desc_pool;
+    pdesc_pool prev = NULL;
+
+    //Walk the list
+    while (temp != NULL) {
+        if (!temp->used) {
+            temp->used = true;
+            return (void*) temp->descriptor;
+        }
+        prev = temp;
+        temp=temp->next;
+    }
+
+    // If we are still here that means temp was null.
+    // We have to allocate two descriptors here
+    temp = (pdesc_pool) malloc(sizeof(desc_pool_t));
+    uint8_t* desc = (uint8_t *)HAP_cache_lock(sizeof(char)*descriptor_size*2, NULL);
+    temp->descriptor = (void *)desc;
+    temp->used = true;
+    temp->next = (pdesc_pool) malloc(sizeof(desc_pool_t));
+    //hard coding bytes here
+    (temp->next)->descriptor = (void *)(desc+descriptor_size);
+    (temp->next)->used = false;
+    (temp->next)->next = NULL;
+
+    if (prev != NULL) {
+        prev->next = temp;
+    } else if (dma_desc_pool == NULL) {
+        dma_desc_pool = temp;
+    }
+    return (void*) temp->descriptor;
+}
+
+/*find "desc"
+ put "desc" into pool
+ mark "desc" free*/
+static int desc_pool_put (void *desc) {
+    pdesc_pool temp = dma_desc_pool;
+    while (temp != NULL) {
+        if (temp->descriptor == desc) {
+            temp->used = false;
+        }
+        temp=temp->next;
+    }
+    return -1;
+}
+//2 descriptor at a time
+static void desc_pool_free () {
+    pdesc_pool temp = dma_desc_pool;
+    while (temp != NULL) {
+        pdesc_pool temp2 = temp;
+        temp=temp->next;
+        if (temp2->descriptor != NULL) {
+            HAP_cache_unlock(temp2->descriptor);
+        }
+        free(temp2);
+        temp2 = temp;
+        if (temp != NULL) {
+            temp=temp->next;
+            free(temp2);
+        }
+    }
+}
+
+}}}}  // namespace Halide::Runtime::Internal::HexagonDma
+
+using namespace Halide::Runtime::Internal::HexagonDma;
+
+extern "C" {
+
+WEAK int halide_hexagon_dma_device_malloc(void *user_context, halide_buffer_t *buf) {
+    debug(user_context)
+        << "Hexagon: halide_hexagon_dma_device_malloc (user_context: " << user_context
+        << ", buf: " << buf << ")\n";
+
+    if (buf->device) {
+        return halide_error_code_success;
+    }
+
+    size_t size = buf->size_in_bytes();
+    halide_assert(user_context, size != 0);
+
+    void *mem = halide_malloc(user_context, size);
+    if (!mem) {
+        error(user_context) << "halide_malloc failed\n";
+        return halide_error_code_out_of_memory;
+    }
+
+    int err = halide_hexagon_dma_device_wrap_native(user_context, buf,
+                                                    reinterpret_cast<uint64_t>(mem));
+    if (err != 0) {
+        halide_free(user_context, mem);
+        return halide_error_code_device_malloc_failed;
+    }
+
+    return halide_error_code_success;
+}
+
+WEAK int halide_hexagon_dma_device_free(void *user_context, halide_buffer_t* buf) {
+    debug(user_context)
+        << "Hexagon: halide_hexagon_dma_device_free (user_context: " << user_context
+        << ", buf: " << buf << ")\n";
+
+    dma_device_handle *dev = (dma_device_handle *)buf->device;
+    void *mem = dev->buffer;
+    halide_hexagon_dma_device_detach_native(user_context, buf);
+
+    halide_free(user_context, mem);
+
+    // This is to match what the default implementation of halide_device_free does.
+    buf->set_device_dirty(false);
+    return halide_error_code_success;
+}
+
+WEAK int halide_hexagon_dma_allocate_engine(void *user_context, void **dma_engine) {
+    debug(user_context)
+        << "Hexagon: halide_hexagon_dma_allocate_engine (user_context: " << user_context << ")\n";
+
+    halide_assert(user_context, dma_engine);
+
+    debug(user_context) << "    dma_allocate_dma_engine -> ";
+    *dma_engine = (void *)hDmaWrapper_AllocDma();
+    debug(user_context) << "        " << dma_engine << "\n";
+    if (!*dma_engine) {
+        error(user_context) << "dma_allocate_dma_engine failed.\n";
+        return halide_error_code_generic_error;
+    }
+
+    return halide_error_code_success;
+}
+
+WEAK int halide_hexagon_dma_deallocate_engine(void *user_context, void *dma_engine) {
+    debug(user_context)
+        << "Hexagon: halide_hexagon_dma_deallocate_engine (user_context: " << user_context
+        << ", dma_engine: " << dma_engine << ")\n";
+
+
+    debug(user_context) << "    dma_free_dma_engine\n";
+    nDmaWrapper_FreeDma((t_DmaWrapper_DmaEngineHandle)dma_engine);
+    return halide_error_code_success;
+}
+
+WEAK int halide_hexagon_dma_prepare_for_copy_to_host(void *user_context, struct halide_buffer_t *buf,
+                                                     void *dma_engine) {
+    debug(user_context)
+        << "Hexagon: halide_hexagon_dma_allocate_engine (user_context: " << user_context
+        << ", buf: " << buf << ", dma_engine: " << dma_engine << ")\n";
+
+    dma_device_handle *dev = reinterpret_cast<dma_device_handle *>(buf->device);
+    dev->dma_engine = dma_engine;
+    return halide_error_code_success;
+}
+
+WEAK int halide_hexagon_dma_unprepare(void *user_context, struct halide_buffer_t *buf) {
+    debug(user_context)
+        << "Hexagon: halide_hexagon_dma_deallocate_engine (user_context: " << user_context
+        << ", buf: " << buf << ")\n";
+
+    halide_assert(user_context, buf->device_interface == halide_hexagon_dma_device_interface());
+    halide_assert(user_context, buf->device);
+
+    dma_device_handle *dev = reinterpret_cast<dma_device_handle *>(buf->device);
+
+    debug(user_context) << "   dma_finish_frame -> ";
+    int err = nDmaWrapper_FinishFrame(dev->dma_engine);
+    desc_pool_free();
+    debug(user_context) << "        " << err << "\n";
+    if (err != 0) {
+        error(user_context) << "dma_finish_frame failed.\n";
+        return halide_error_code_generic_error;
+    }
+
+    return halide_error_code_success;
+}
+
+WEAK int halide_hexagon_dma_buffer_copy(void *user_context, struct halide_buffer_t *src,
+                                        const struct halide_device_interface_t *dst_device_interface,
+                                        struct halide_buffer_t *dst) {
+    // We only handle copies to hexagon_dma or to host
+    // TODO: does device to device via DMA make sense?
+    halide_assert(user_context, dst_device_interface == NULL ||
+                  dst_device_interface == &hexagon_dma_device_interface);
+
+    if (src->device_dirty() &&
+        src->device_interface != &hexagon_dma_device_interface) {
+        halide_assert(user_context, dst_device_interface == &hexagon_dma_device_interface);
+        // If the source is not hexagon_dma or host memory, ask the source
+        // device interface to copy to dst host memory first.
+        int err = src->device_interface->impl->buffer_copy(user_context, src, NULL, dst);
+        if (err) {
+            return err;
+        }
+        // Now just copy from src to host
+        src = dst;
+    }
+
+    bool from_host = !src->device_dirty() && src->host != NULL;
+    bool to_host = !dst_device_interface;
+
+    halide_assert(user_context, from_host || src->device);
+    halide_assert(user_context, to_host || dst->device);
+
+    // For now only copy device to host.
+    // TODO: Figure out which other paths can be supported.
+    halide_assert(user_context, !from_host && to_host);
+
+    debug(user_context)
+        << "Hexagon: halide_hexagon_dma_buffer_copy (user_context: " << user_context
+        << ", src: " << src << ", dst: " << dst << ")\n";
+
+    dma_device_handle *dev = (dma_device_handle *)src->device;
+
+    debug(user_context) << "Hexagon dev handle: buffer: " << dev->buffer << " dev offset (" << dev->offset_x << ", " << dev->offset_y << ") frame_width: " << dev->frame_width << " frame_height: " << dev->frame_height << " frame_stride: " << dev->frame_stride << " desc_addr: " << dev->desc_addr << "\n";
+
+#if 0 // Seems useful, but this flattens the mins
+    device_copy c = make_buffer_copy(src, from_host, dst, to_host);
+#endif
+
+    t_StDmaWrapper_RoiAlignInfo stWalkSize = {dst->dim[0].extent, dst->dim[1].extent};
+    int nRet = nDmaWrapper_GetRecommendedWalkSize(eDmaFmt_RawData, false, &stWalkSize);
+    int roi_stride = dst->dim[1].stride; // nDmaWrapper_GetRecommendedIntermBufStride(eDmaFmt_RawData, &stWalkSize, false);
+    int roi_width = stWalkSize.u16W;
+    int roi_height = stWalkSize.u16H;
+    // DMA driver Expect the Stride to be 256 Byte Aligned
+    halide_assert(user_context, (roi_stride % 256) == 0);
+
+    // This assert fails. The entire desc_addr concept needs to be removed
+    // as the state can likely only exist per call.
+    //    halide_assert(user_context, dev->desc_addr == 0);
+    dev->desc_addr = desc_pool_get();
+
+    t_StDmaWrapper_DmaTransferSetup stDmaTransferParm;
+    stDmaTransferParm.eFmt = eDmaFmt_RawData;
+    stDmaTransferParm.u16FrameW = dev->frame_width;
+    stDmaTransferParm.u16FrameH = dev->frame_height;
+    stDmaTransferParm.u16FrameStride = dev->frame_stride;
+    stDmaTransferParm.u16RoiW = roi_width;
+    stDmaTransferParm.u16RoiH = roi_height;
+    stDmaTransferParm.u16RoiStride = roi_stride;
+    stDmaTransferParm.bUse16BitPaddingInL2 = false;
+    stDmaTransferParm.pDescBuf = dev->desc_addr;
+
+    stDmaTransferParm.pTcmDataBuf = reinterpret_cast<void *>(dst->host);
+    stDmaTransferParm.pFrameBuf = dev->buffer;
+    stDmaTransferParm.eTransferType = eDmaWrapper_DdrToL2;
+
+    stDmaTransferParm.u16RoiX = dev->offset_x + dst->dim[0].min;
+    stDmaTransferParm.u16RoiY = dev->offset_y + dst->dim[1].min;
+    
+    debug(user_context) << "Hexagon: " << dev->dma_engine << " transfer: " << stDmaTransferParm.pDescBuf << "\n" ;
+    nRet = nDmaWrapper_DmaTransferSetup(dev->dma_engine, &stDmaTransferParm);
+    if (nRet != QURT_EOK) {
+        debug(user_context) << "Hexagon: DMA Transfer Error: " << nRet << "\n"; 
+        return halide_error_code_device_buffer_copy_failed; 
+    }
+
+    debug(user_context) << "Hexagon: " << dev->dma_engine << " move\n" ;
+
+    nRet = nDmaWrapper_Move(dev->dma_engine);
+    if (nRet != QURT_EOK) {
+        debug(user_context) << "Hexagon: nDmaWrapper_Move error: " << nRet << "\n";
+        return halide_error_code_device_buffer_copy_failed;
+    }
+    nRet = nDmaWrapper_Wait(dev->dma_engine);
+    if (nRet != QURT_EOK) {
+        debug(user_context) << "Hexagon: nDmaWrapper_Wait error: " << nRet << "\n";
+        return halide_error_code_device_buffer_copy_failed;
+    }
+    nRet = nDmaWrapper_FinishFrame(dev->dma_engine);
+    if (nRet != QURT_EOK) {
+        debug(user_context) << "Hexagon: nDmaWrapper_FinishFrame error: " << nRet << "\n";
+        return halide_error_code_device_buffer_copy_failed;
+    }
+    
+    return halide_error_code_success;
+}
+
+WEAK int halide_hexagon_dma_copy_to_device(void *user_context, halide_buffer_t* buf) {
+    int err = halide_hexagon_dma_device_malloc(user_context, buf);
+    if (err) {
+        return err;
+    }
+
+    // TODO: Implement this with dma_move_data.
+    error(user_context) << "haldie_hexagon_dma_copy_to_device not implemented.\n";
+    return halide_error_code_copy_to_device_failed;
+}
+
+WEAK int halide_hexagon_dma_copy_to_host(void *user_context, struct halide_buffer_t *buf) {
+    debug(user_context)
+        << "Hexagon: halide_hexagon_dma_copy_to_host (user_context: " << user_context
+        << ", buf: " << buf << ")\n";
+
+    halide_assert(user_context, buf->host && buf->device);
+    dma_device_handle *dev = (dma_device_handle *)buf->device;
+
+    t_StDmaWrapper_RoiAlignInfo stWalkSize = {buf->dim[0].extent, buf->dim[1].extent};
+    int nRet = nDmaWrapper_GetRecommendedWalkSize(eDmaFmt_RawData, false, &stWalkSize);
+    int roi_stride = nDmaWrapper_GetRecommendedIntermBufStride(eDmaFmt_RawData, &stWalkSize, false);
+    int roi_width = stWalkSize.u16W;
+    int roi_height = stWalkSize.u16H;
+    // DMA driver Expect the Stride to be 256 Byte Aligned
+    halide_assert(user_context,(buf->dim[1].stride== roi_stride));
+
+    // This assert fails. The entire desc_addr concept needs to be removed
+    // as the state can likely only exist per call.
+    //    halide_assert(user_context, dev->desc_addr == 0);
+    dev->desc_addr = desc_pool_get();
+
+    t_StDmaWrapper_DmaTransferSetup stDmaTransferParm;
+    stDmaTransferParm.eFmt = eDmaFmt_RawData;
+    stDmaTransferParm.u16FrameW = dev->frame_width;
+    stDmaTransferParm.u16FrameH = dev->frame_height;
+    stDmaTransferParm.u16FrameStride = dev->frame_stride;
+    stDmaTransferParm.u16RoiW = roi_width;
+    stDmaTransferParm.u16RoiH = roi_height;
+    stDmaTransferParm.u16RoiStride = roi_stride;
+    stDmaTransferParm.bUse16BitPaddingInL2 = false;
+    stDmaTransferParm.pDescBuf = dev->desc_addr;
+
+    stDmaTransferParm.pTcmDataBuf = reinterpret_cast<void *>(buf->host);
+    stDmaTransferParm.pFrameBuf = dev->buffer;
+    stDmaTransferParm.eTransferType = eDmaWrapper_DdrToL2;
+
+    stDmaTransferParm.u16RoiX = dev->offset_x;
+    stDmaTransferParm.u16RoiY = dev->offset_y;
+
+    debug(user_context) << "Hexagon:" << dev->dma_engine << "transfer" << stDmaTransferParm.pDescBuf << "\n" ;
+    nRet = nDmaWrapper_DmaTransferSetup(dev->dma_engine, &stDmaTransferParm);
+    if (nRet != QURT_EOK) {
+        debug(user_context) << "Hexagon: DMA Transfer Error" << "\n"; 
+        return halide_error_code_copy_to_host_failed; 
+    }
+
+    debug(user_context) << "Hexagon:" << dev->dma_engine << "move\n" ;
+
+    nRet = nDmaWrapper_Move(dev->dma_engine);
+    if (nRet != QURT_EOK) {
+        debug(user_context) << "Hexagon: DMA Transfer Error" << "\n";
+        return halide_error_code_copy_to_host_failed;
+    }
+    
+    return halide_error_code_success;
+}
+
+WEAK int halide_hexagon_dma_device_crop(void *user_context,
+                                        const struct halide_buffer_t *src,
+                                        struct halide_buffer_t *dst) {
+    debug(user_context)
+        << "Hexagon: halide_hexagon_dma_device_crop\n";
+
+    dst->device_interface = src->device_interface;
+
+    const dma_device_handle *src_dev = (dma_device_handle *)src->device;
+    dma_device_handle *dst_dev = malloc_device_handle();
+    dst_dev->buffer = src_dev->buffer;
+    // TODO: It's messy to have both this offset and the buffer mins,
+    // try to reduce complexity here.
+    dst_dev->offset_x = src_dev->offset_x + dst->dim[0].min - src->dim[0].min;
+    dst_dev->offset_y = src_dev->offset_y + dst->dim[1].min - src->dim[1].min;
+    dst_dev->dma_engine = src_dev->dma_engine;
+
+    return halide_error_code_success;
+}
+
+WEAK int halide_hexagon_dma_device_release_crop(void *user_context,
+                                                struct halide_buffer_t *buf) {
+    debug(user_context)
+        << "Hexagon: halide_hexagon_dma_device_release_crop\n";
+
+    free((dma_device_handle *)buf->device);
+    buf->device = 0;
+
+    return halide_error_code_success;
+}
+
+WEAK int halide_hexagon_dma_device_sync(void *user_context, struct halide_buffer_t *buf) {
+    debug(user_context)
+        << "Hexagon: halide_hexagon_dma_device_sync (user_context: " << user_context << ")\n";
+
+    dma_device_handle *dev = (dma_device_handle *)buf->device;
+    halide_assert(user_context, dev->dma_engine);
+    int err = nDmaWrapper_Wait(dev->dma_engine);
+    desc_pool_put(dev->desc_addr);
+
+    // This likely needs to be here, but the entire desc_addr concept
+    // needs to be removed as the state can likely only exist per
+    // call.
+    // dev->desc_addr = 0;
+    
+    if (err != 0) {
+        error(user_context) << "dma_wait failed (" << err << ")\n";
+        return halide_error_code_device_sync_failed;
+    }
+
+    return halide_error_code_success;
+}
+
+WEAK int halide_hexagon_dma_device_wrap_native(void *user_context, struct halide_buffer_t *buf,
+                                               uint64_t handle) {
+    halide_assert(user_context, buf->device == 0);
+    if (buf->device != 0) {
+        return halide_error_code_device_wrap_native_failed;
+    }
+
+    buf->device_interface = &hexagon_dma_device_interface;
+    buf->device_interface->impl->use_module();
+
+    dma_device_handle *dev = malloc_device_handle();
+    halide_assert(user_context, dev);
+    dev->buffer = reinterpret_cast<uint8_t*>(handle);
+    dev->dma_engine = 0;
+    dev->frame_width = buf->dim[0].extent;
+    dev->frame_height = buf->dim[1].extent;
+    dev->frame_stride = buf->dim[1].stride;
+    buf->device = reinterpret_cast<uint64_t>(dev);
+    return halide_error_code_success;
+}
+
+WEAK int halide_hexagon_dma_device_detach_native(void *user_context, struct halide_buffer_t *buf) {
+    if (buf->device == 0) {
+        return NULL;
+    }
+    halide_assert(user_context, buf->device_interface == &hexagon_dma_device_interface);
+
+    dma_device_handle *dev = (dma_device_handle *)buf->device;
+    free(dev);
+
+    buf->device_interface->impl->release_module();
+    buf->device = 0;
+    buf->device_interface = NULL;
+    return halide_error_code_success;
+}
+
+WEAK int halide_hexagon_dma_device_and_host_malloc(void *user_context, struct halide_buffer_t *buf) {
+    return halide_default_device_and_host_malloc(user_context, buf, &hexagon_dma_device_interface);
+}
+
+WEAK int halide_hexagon_dma_device_and_host_free(void *user_context, struct halide_buffer_t *buf) {
+    return halide_default_device_and_host_free(user_context, buf, &hexagon_dma_device_interface);
+}
+
+WEAK const halide_device_interface_t *halide_hexagon_dma_device_interface() {
+    return &hexagon_dma_device_interface;
+}
+
+WEAK int halide_hexagon_dma_device_release(void *user_context) { return 0; }
+
+} // extern "C" linkage
+
+namespace Halide { namespace Runtime { namespace Internal { namespace HexagonDma {
+
+WEAK halide_device_interface_impl_t hexagon_dma_device_interface_impl = {
+    halide_use_jit_module,
+    halide_release_jit_module,
+    halide_hexagon_dma_device_malloc,
+    halide_hexagon_dma_device_free,
+    halide_hexagon_dma_device_sync,
+    halide_hexagon_dma_device_release,
+    halide_hexagon_dma_copy_to_host,
+    halide_hexagon_dma_copy_to_device,
+    halide_hexagon_dma_device_and_host_malloc,
+    halide_hexagon_dma_device_and_host_free,
+    halide_hexagon_dma_buffer_copy,
+    halide_hexagon_dma_device_crop,
+    halide_hexagon_dma_device_release_crop,
+    halide_hexagon_dma_device_wrap_native,
+    halide_hexagon_dma_device_detach_native,
+};
+
+WEAK halide_device_interface_t hexagon_dma_device_interface = {
+    halide_device_malloc,
+    halide_device_free,
+    halide_device_sync,
+    halide_device_release,
+    halide_copy_to_host,
+    halide_copy_to_device,
+    halide_device_and_host_malloc,
+    halide_device_and_host_free,
+    halide_buffer_copy,
+    halide_device_crop,
+    halide_device_release_crop,
+    halide_device_wrap_native,
+    halide_device_detach_native,
+    &hexagon_dma_device_interface_impl
+};
+
+}}}} // namespace Halide::Runtime::Internal::HexagonDma

--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -669,37 +669,6 @@ WEAK int halide_hexagon_device_and_host_free(void *user_context, struct halide_b
     return 0;
 }
 
-WEAK int halide_hexagon_device_crop(void *user_context, const struct halide_buffer_t *src,
-                                    struct halide_buffer_t *dst) {
-    debug(user_context) << "halide_hexagon_device_crop called.\n";
-
-    // Pointer arithmetic works fine.
-    int64_t offset = 0;
-    for (int i = 0; i < src->dimensions; i++) {
-        offset += (dst->dim[i].min - src->dim[i].min) * src->dim[i].stride;
-    }
-    offset *= src->type.bytes();
-
-    ion_device_handle *src_handle = (ion_device_handle *)src->device;
-    ion_device_handle *dst_handle = (ion_device_handle *)malloc(sizeof(ion_device_handle));
-    if (!dst_handle) {
-        return halide_error_code_out_of_memory;
-    }
-    
-    dst_handle->buffer = (uint8_t *)src_handle->buffer + offset;
-    dst_handle->size = src_handle->size - offset;
-    dst->device = reinterpret<uint64_t>(dst_handle);
-    dst->device_interface = src->device_interface;
-    dst->set_device_dirty(src->device_dirty());
-    return 0;
-}
-
-WEAK int halide_hexagon_device_release_crop(void *user_context, struct halide_buffer_t *dst) {
-    debug(user_context) << "halide_hexagon_release_crop called\n";
-    free((ion_device_handle *)dst->device);
-    return 0;
-}
-
 WEAK int halide_hexagon_power_hvx_on(void *user_context) {
     int result = init_hexagon_runtime(user_context);
     if (result != 0) return result;
@@ -843,8 +812,8 @@ WEAK halide_device_interface_impl_t hexagon_device_interface_impl = {
     halide_hexagon_device_and_host_malloc,
     halide_hexagon_device_and_host_free,
     halide_default_buffer_copy,
-    halide_hexagon_device_crop,
-    halide_hexagon_device_release_crop,
+    halide_default_device_crop,
+    halide_default_device_release_crop,
     halide_default_device_wrap_native,
     halide_default_device_detach_native,
 };

--- a/src/runtime/mini_hexagon_dma.h
+++ b/src/runtime/mini_hexagon_dma.h
@@ -1,0 +1,312 @@
+/**
+ * This file has the necessary structures and APIs for Initiating, executing and finishing a Hexagon DMA transfer
+ * The functions in this header file are the interfacing functions between Halide runtime and the Hexagon DMA driver
+ * The functions in this file lead to the hexagon DMA driver calls in case of availability of DMA driver and hexagon DMA tools
+ * In case of un availabilty of hexagon SDK tools and DMA drivers these function while mimic DMA with dummy transfers  */
+
+#ifndef _DMA_DEVICE_SHIM_H_
+#define _DMA_DEVICE_SHIM_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef uint16_t uint16;
+typedef uint32_t uint32;
+typedef int32_t int32;
+typedef unsigned long addr_t;
+
+typedef unsigned int qurt_size_t;
+typedef unsigned int qurt_mem_pool_t;
+
+__inline static int align(int x,int a) {
+    return ( (x+a-1) & (~(a-1)) );    
+} 
+
+enum { QURT_EOK = 0 };
+
+/*!
+ * Format IDs
+ */
+typedef enum {
+    eDmaFmt_RawData,
+    eDmaFmt_NV12,
+    eDmaFmt_NV12_Y,
+    eDmaFmt_NV12_UV,
+    eDmaFmt_P010,
+    eDmaFmt_P010_Y,
+    eDmaFmt_P010_UV,
+    eDmaFmt_TP10,
+    eDmaFmt_TP10_Y,
+    eDmaFmt_TP10_UV,
+    eDmaFmt_NV124R,
+    eDmaFmt_NV124R_Y,
+    eDmaFmt_NV124R_UV,
+    eDmaFmt_Invalid,
+    eDmaFmt_MAX,
+} t_eDmaFmt;
+
+  /*!
+   * DMA status
+   * Currently not use, for future development
+   */
+  typedef void* t_stDmaWrapperDmaStats;
+
+  /*!
+   * Transfer type
+   */
+  typedef enum eDmaWrapper_TransationType {
+    //! DDR to L2 transfer
+    eDmaWrapper_DdrToL2,
+    //! L2 to DDR transfer
+    eDmaWrapper_L2ToDdr,
+  } t_eDmaWrapper_TransationType;
+
+  /*!
+   * Roi Properties
+   */
+  typedef struct stDmaWrapper_Roi {
+    //! ROI x position in pixels
+    uint16 u16X;
+    //! ROI y position in pixels
+    uint16 u16Y;
+    //! ROI width in pixels
+    uint16 u16W;
+    //! ROI height in pixels
+    uint16 u16H;
+  } t_StDmaWrapper_Roi;
+
+  /*!
+   * Frame Properties
+   */
+  typedef struct stDmaWrapper_FrameProp {
+    //! Starting physical address to buffer
+    addr_t aAddr;
+    //! Frame height in pixels
+    uint16 u16H;
+    //! Frame width in pixels
+    uint16 u16W;
+    //! Frame stride in pixels
+    uint16 u16Stride;
+  } t_StDmaWrapper_FrameProp;
+
+  /*!
+   * Roi alignment
+   */
+  typedef struct stDmaWrapper_RoiAlignInfo {
+    //! ROI width in pixels
+    uint16 u16W;
+    //! ROI height in pixels
+    uint16 u16H;
+  } t_StDmaWrapper_RoiAlignInfo;
+
+  /*!
+   * DmaTransferSetup Properties
+   */
+
+  typedef struct stDmaWrapper_DmaTransferSetup {
+    //! Format
+    t_eDmaFmt eFmt;
+    bool bIsFmtUbwc;
+    //! Frame Width in pixels
+    uint16 u16FrameW;
+    //! Frame height in pixels
+    uint16 u16FrameH;
+    //! Frame stride in pixels
+    uint16 u16FrameStride;
+    //! ROI x position in pixels
+    uint16 u16RoiX;
+    //! ROI y position in pixels
+    uint16 u16RoiY;
+    //! ROI width in pixels
+    uint16 u16RoiW;
+    //! ROI height in pixels
+    uint16 u16RoiH;
+    //! ROI stride in pixels
+    uint16 u16RoiStride;
+    //! Should the intermediate buffer be padded. This only apply for 8bit format sucha NV12, NV12-4R
+    bool bUse16BitPaddingInL2;
+    //! Virtual address of the HW descriptor buffer (must be locked in the L2$).
+    void* pDescBuf;
+    //! Virtual address of the TCM pixeldata buffer (must be locked in the L2$).
+    void*  pTcmDataBuf;
+    //! Virtual address of the DDR Frame buffer .
+    void*  pFrameBuf;
+    //! TransferType: eDmaWrapper_DdrToL2 (Read from DDR), eDmaWrapper_L2ToDDR (Write to DDR);
+    t_eDmaWrapper_TransationType eTransferType;
+  } t_StDmaWrapper_DmaTransferSetup;
+
+  /*!
+   * @brief  API for Cache Allocation
+   * @description Abstraction for allocation of memory in cache and lock
+   *
+   * @return NULL or Memory
+   */
+  void* HAP_cache_lock(unsigned int size, void** paddr_ptr);
+
+
+  /*!
+   * @brief  API for Free
+   * @description Abstraction for deallocation of memory and unlock cache
+   *
+   * @return void
+   */
+  int HAP_cache_unlock(void* vaddr_ptr);
+
+  /*!
+   * Handle for wrapper DMA engine
+   */
+  typedef void* t_DmaWrapper_DmaEngineHandle;
+
+  /*!
+   * @brief       Allocates a DMA Engine to be used
+   *
+   * @description Allocates a DMA Engine to be used by using the default
+   *              wait type (polling).
+   *
+   * @return      Success: Engine's DMA Handle
+   * @n           Failure: NULL
+   */
+  extern t_DmaWrapper_DmaEngineHandle hDmaWrapper_AllocDma(void);
+
+  /*!
+   * @brief       Frees a DMA Engine
+   *
+   * @description Frees a DMA Engine that was previously allocated by AllocDma().
+   *
+   * @input       hDmaHandle - Engine's DMA Handle
+   *
+   * @return      Success: OK
+   * @n           Failure: ERR
+   */
+  extern int32 nDmaWrapper_FreeDma(t_DmaWrapper_DmaEngineHandle hDmaHandle);
+
+  /*!
+   * @brief       Starts a transfer request on the DMA engine
+   *
+   * @description Starts a transfer on the provided DMA engine. The transfer is based
+   *              on descriptors constructed in earlier nDmaWrapper_Prepare() and
+   *              nDmaWrapper_Update() calls.
+   *
+   * @input       hDmaHandle - Engine's DMA Handle
+   *
+   * @return      Success: OK
+   * @n           Failure: ERR
+   */
+  extern int32 nDmaWrapper_Move(t_DmaWrapper_DmaEngineHandle hDmaHandle);
+
+  /*!
+   * @brief       Waits for all outstanding transfers on the DMA to complete
+   *
+   * @description Blocks until all outstanding transfers on the DMA are complete.
+   *              The wait type is based on the type specified when allocating the
+   *              engine.
+   *
+   * @input       hDmaHandle - Engine's DMA Handle
+   *
+   * @return      Success: OK
+   * @n           Failure: ERR
+   */
+  extern int32 nDmaWrapper_Wait(t_DmaWrapper_DmaEngineHandle hDmaHandle);
+
+  /*!
+   * @brief       Cleans up all transfers and flushes DMA buffers
+   *
+   * @description This call flushes the DMA buffers.
+   *              Blocks until the flush of the DMA is complete.
+   *
+   * @input       hDmaHandle - Engine's DMA Handle
+   *
+   * @return      Success: OK
+   * @n           Failure: ERR
+   */
+  extern int32 nDmaWrapper_FinishFrame(t_DmaWrapper_DmaEngineHandle hDmaHandle);
+
+  /*!
+   * @brief       Get the recommended walk ROI width and height
+   *
+   * @description Get the recommended walk ROI width and height that should
+   *              be used if walking the entire frame. The ROI returned is always
+   *              in terms of frame dimensions. This function is different from
+   *              nDmaWrapper_GetRecommendedRoi() as coordinates are not used.
+   *
+   * @input       eFmtId - Format ID
+   * @input       bIsUbwc - Is the format UBWC (TRUE/FALSE)
+   * @inout       pStWalkSize - Initial walk size, will be overwritten with
+   *                            the recommended walk size to align with DMA
+   *                            requirements
+   *
+   * @return      Success: OK
+   * @n           Failure: ERR
+   */
+  extern int32 nDmaWrapper_GetRecommendedWalkSize(t_eDmaFmt eFmtId, bool bIsUbwc,
+                                                  t_StDmaWrapper_RoiAlignInfo* pStWalkSize);
+
+  /*!
+   * @brief       Get the HW descriptor buffer size per DMA engine
+   *
+   * @description Calculates the HW descriptor buffer size based
+   *              on the formats that will be used with the engine.
+   *
+   * @input       aeFmtId - Array of format IDs, such as eDmaFmt_NV12, eDmaFmt_NV12_Y,
+   *                        eDmaFmt_NV12_UV etc..
+   * @input       nsize - Number of format IDs provided
+   *
+   * @return      Descriptor buffer size in bytes
+   */
+  extern int32 nDmaWrapper_GetDescbuffsize(t_eDmaFmt *aeFmtId, uint16 nsize);
+
+  /*!
+   * @brief       Get the recommended intermediate buffer stride.
+   *
+   * @description Get the recommended (minimum) intermediate buffer stride for the
+   *              L2 Cache that is used transfer data from/to DDR. The stride is
+   *              greater than or equal to the width and must be a multiple of 256.
+   *
+   * @input       eFmtId - Format ID
+   * @input         pStRoiSize - The ROI that will be used (should be aligned with
+   *                           the DMA requirements for the format)
+   * @input         bIsUbwc - Is the format UBWC (TRUE/FALSE)
+   *
+   * @return      Success: The intermediate buffer stride in pixels
+   * @n           Failure: ERR
+   */
+  extern int32 nDmaWrapper_GetRecommendedIntermBufStride(t_eDmaFmt eFmtId,
+                                                         t_StDmaWrapper_RoiAlignInfo* pStRoiSize,
+                                                         bool bIsUbwc);
+
+  /*!
+   * @brief       Dma transfer parameters per HW descriptor
+   *
+   * @description Setup Dma transfer parameters required to be ready to make DMA transfer.
+   *              call this API multiple to create a descriptor link list
+   *
+   * @input       hDmaHandle - Wrapper's DMA Handle. Represents
+   *                  t_StDmaWrapper_DmaEngine.
+   * @input       stpDmaTransferParm - Dma Transfer parameters. Each element describes
+   *                  complete Frame/ROI details for this Dma transfer
+   *
+   * @return      Success: OK
+   *              Failure: ERR
+   */
+  extern int32 nDmaWrapper_DmaTransferSetup(t_DmaWrapper_DmaEngineHandle hDmaHandle, t_StDmaWrapper_DmaTransferSetup* stpDmaTransferParm);
+
+  /** @example dma_memcpy.c
+   *  Copies one region of memory to another.
+   *  @example dma_memcpy.h
+   *  @example dma_memcpy_test.c
+   */
+
+  /** @example dma_blend.c
+   *  DMA Blend App. Will read 2 frames from DDR, blend them and output
+   *  the result to DDR.
+   *  @example dma_blend.h
+   *  @example dma_blend_test.c
+   */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/runtime/mini_qurt.h
+++ b/src/runtime/mini_qurt.h
@@ -10,6 +10,7 @@ enum { QURT_EOK = 0 };
 
 extern "C" {
 typedef unsigned int qurt_thread_t;
+
 /*
    Macros for QuRT thread attributes.
  */
@@ -233,5 +234,8 @@ typedef enum {
 extern int qurt_hvx_lock(qurt_hvx_mode_t lock_mode);
 extern int qurt_hvx_unlock(void);
 extern int qurt_hvx_get_mode(void);
+
+typedef unsigned int qurt_size_t;
+typedef unsigned int qurt_mem_pool_t;
 
 }

--- a/src/runtime/qurt_hvx.cpp
+++ b/src/runtime/qurt_hvx.cpp
@@ -24,6 +24,7 @@ WEAK int halide_qurt_hvx_lock(void *user_context, int size) {
         error(user_context) << "qurt_hvx_lock failed\n";
         return -1;
     }
+
     return 0;
 }
 


### PR DESCRIPTION
1.	The test is for a simple, synchronous, DMA tiling example, using cross buffer copy (as described in step 1 of 5)
	a.	As a device standalone, for linear data only, with strict buffer boundary and alignment conditions
	b.	Exercised on x86, hex-sim, and HW targets
2.	There are caveats for HW targets, w.r.t working with locked L2$, using a temporary workaround
	a.	Calling to allocate locked L2$ within hexagon_dma.cpp
	b.	And after the tile DMA transfer to locked L2$ buffer, copy to destination buffer for Halide to process
	c.	The above explicit locked L2$ and copy steps will be removed when implicit locked L2$ allocation support from Halide is added
3.	This code requires the mutex init fix, which is  included, from a separate PR (open for review) on branch hex-dma-qurt-mutex-init
	a. Note that this mutex init fix will be superceded by Google's pending solution that may be delivered as part of the async PR  
	b. This mutex init fix is verified on all hexagon targets except 8996, as commented in the code

Note:

1. The changes in this PR is mainly to update DMA integration progress and not for merging with master until 
   the issue with halide_mutex_init()is resolved
2. We have an investigation pending on 8996 regarding the halide_mutex_init() invocation in workqueue constructor  