### PR TITLE
reschedule ger

### DIFF
--- a/apps/linear_algebra/Makefile
+++ b/apps/linear_algebra/Makefile
@@ -2,7 +2,7 @@ include ../support/Makefile.inc
 
 BIN ?= bin
 BUILD = $(BIN)/build
-CXXFLAGS += -O3 -fopenmp -Wall -march=native
+CXXFLAGS += -O3 -Wall -march=native -I /opt/local/include
 HL_TARGET ?= host
 LIBHALIDE_BLAS = $(BIN)/libhalide_blas.a
 HALIDEBLAS_FLAGS ?= -DUSE_HALIDE
@@ -12,7 +12,7 @@ EIGEN_INCLUDES ?= -I/usr/include/eigen3
 CBLAS_LIBS ?= -lblas
 CBLAS_FLAGS ?= -DUSE_CBLAS
 OPENBLAS_FLAGS ?= -DUSE_OPENBLAS
-OPENBLAS_LIBS ?= -lopenblas
+OPENBLAS_LIBS ?= -L/opt/local/lib -lopenblas
 
 # ATLAS should be built and installed locally to get the best performance.
 # It is designed to automatically tune its performance to your machine during
@@ -251,27 +251,27 @@ $(BUILD)/halide_dasum.o $(BUILD)/halide_dasum.h: $(BUILD)/blas_l1.generator
 
 $(BUILD)/halide_sgemv_notrans.o $(BUILD)/halide_sgemv_notrans.h: $(BUILD)/blas_l2.generator
 	$< -g sgemv -f halide_sgemv_notrans -o $(BUILD) -e $(EMIT_OPTIONS) \
-	target=$(HL_TARGET_NR) parallel=false vectorize=true transpose=false
+	target=$(HL_TARGET_NR) parallel=true vectorize=true transpose=false
 
 $(BUILD)/halide_dgemv_notrans.o $(BUILD)/halide_dgemv_notrans.h: $(BUILD)/blas_l2.generator
 	$< -g dgemv -f halide_dgemv_notrans -o $(BUILD) -e $(EMIT_OPTIONS) \
-	target=$(HL_TARGET_NR) parallel=false vectorize=true transpose=false
+	target=$(HL_TARGET_NR) parallel=true vectorize=true transpose=false
 
 $(BUILD)/halide_sgemv_trans.o $(BUILD)/halide_sgemv_trans.h: $(BUILD)/blas_l2.generator
 	$< -g sgemv -f halide_sgemv_trans -o $(BUILD) -e $(EMIT_OPTIONS) \
-	target=$(HL_TARGET_NR) parallel=false vectorize=true transpose=true
+	target=$(HL_TARGET_NR) parallel=true vectorize=true transpose=true
 
 $(BUILD)/halide_dgemv_trans.o $(BUILD)/halide_dgemv_trans.h: $(BUILD)/blas_l2.generator
 	$< -g dgemv -f halide_dgemv_trans -o $(BUILD) -e $(EMIT_OPTIONS) \
-	target=$(HL_TARGET_NR) parallel=false vectorize=true transpose=true
+	target=$(HL_TARGET_NR) parallel=true vectorize=true transpose=true
 
 $(BUILD)/halide_sger_impl.o $(BUILD)/halide_sger_impl.h: $(BUILD)/blas_l2.generator
 	$< -g sger -f halide_sger_impl -o $(BUILD) -e $(EMIT_OPTIONS) \
-	target=$(HL_TARGET_NR) parallel=false vectorize=true
+	target=$(HL_TARGET_NR) parallel=true vectorize=true
 
 $(BUILD)/halide_dger_impl.o $(BUILD)/halide_dger_impl.h: $(BUILD)/blas_l2.generator
 	$< -g dger -f halide_dger_impl -o $(BUILD) -e $(EMIT_OPTIONS) \
-	target=$(HL_TARGET_NR) parallel=false vectorize=true
+	target=$(HL_TARGET_NR) parallel=true vectorize=true
 
 $(BUILD)/halide_sgemm_notrans.o $(BUILD)/halide_sgemm_notrans.h: $(BUILD)/blas_l3.generator
 	$< -g sgemm -f halide_sgemm_notrans -o $(BUILD) -e $(EMIT_OPTIONS) \

--- a/apps/linear_algebra/src/halide_blas.h
+++ b/apps/linear_algebra/src/halide_blas.h
@@ -70,11 +70,11 @@ inline int halide_dgemv(bool trans, double a, halide_buffer_t *A, halide_buffer_
 }
 
 inline int halide_sger(float a, halide_buffer_t *x, halide_buffer_t *y, halide_buffer_t *A) {
-    return halide_sger_impl(a, x, y, A, A);
+    return halide_sger_impl(a, x, y, A);
 }
 
 inline int halide_dger(float a, halide_buffer_t *x, halide_buffer_t *y, halide_buffer_t *A) {
-    return halide_dger_impl(a, x, y, A, A);
+    return halide_dger_impl(a, x, y, A);
 }
 
 inline int halide_sgemm(bool transA, bool transB, float a, halide_buffer_t *A, halide_buffer_t *B, float b, halide_buffer_t *C) {


### PR DESCRIPTION
Change ger to be in-place, and simplify the schedule.

Performance now closer to openblas for me on the larger sizes, and is
much faster on the smaller sizes. Rightmost column is proportional to
flops
```
  Halide      sger      32            0.081833             13.2953
  Halide      sger      64            0.226842             18.6209
  Halide      sger     128            1.073608             15.4991
  Halide      sger     288            7.498786             11.1378
  Halide      sger     544           29.680935             10.0072
  Halide      sger    1056          121.922739             9.16357
  Halide      sger    2080         1147.310148             3.77453
OpenBLAS      sger      32           35.603869           0.0305585
OpenBLAS      sger      64           68.888618           0.0613164
OpenBLAS      sger     128           43.106477            0.386021
OpenBLAS      sger     288           92.307125            0.904806
OpenBLAS      sger     544          186.297631             1.59435
OpenBLAS      sger    1056          363.545260              3.0732
OpenBLAS      sger    2080         1035.606023             4.18167
```