### PR TITLE
Allow python generator stubs to work with "partial new-style" Generators

### DIFF
--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -84,11 +84,11 @@ $(BIN)/PyStubImpl.o: $(ROOT_DIR)/stub/PyStubImpl.cpp $(HALIDE_DISTRIB_PATH)/incl
 	$(CXX) $(CCFLAGS) -c $< -o $@
 
 # Produce a Python extension for the generator by compiling PyStub.cpp
-# (with HALIDE_PYSTUB_GENERATOR_NAME defined to the Generator's build name), 
+# (with HALIDE_PYSTUB_GENERATOR_NAME defined to the Generator's build name),
 # and linking with the generator's .o file, PyStubImpl.o, plus the same libHalide
-# being used by halide.so. 
+# being used by halide.so.
 #
-# You can optionally also define HALIDE_PYSTUB_MODULE_NAME if you want the Python 
+# You can optionally also define HALIDE_PYSTUB_MODULE_NAME if you want the Python
 # module name to be something other than the Generator build name.
 $(BIN)/%_PyStub.o: $(ROOT_DIR)/stub/PyStub.cpp
 	@mkdir -p $(@D)
@@ -98,7 +98,7 @@ $(BIN)/%.so: $(BIN)/%_PyStub.o $(BIN)/PyStubImpl.o $(BIN)/%_generator.o $(LIBHAL
 	@mkdir -p $(@D)
 	$(CXX) $^ $(LDFLAGS) -shared -o $@
 
-test_correctness_pystub: $(BIN)/simplestub.so $(BIN)/complexstub.so 
+test_correctness_pystub: $(BIN)/simplestub.so $(BIN)/complexstub.so $(BIN)/buildmethod.so $(BIN)/partialbuildmethod.so $(BIN)/nobuildmethod.so
 
 APPS = $(shell ls $(ROOT_DIR)/apps/*.py)
 CORRECTNESS = $(shell ls $(ROOT_DIR)/correctness/*.py)

--- a/python_bindings/correctness/buildmethod_generator.cpp
+++ b/python_bindings/correctness/buildmethod_generator.cpp
@@ -1,0 +1,30 @@
+#include "Halide.h"
+
+namespace {
+
+// This Generator exists solely to verify that old-style generators (using the
+// Param/ImageParam/build() method, rather than
+// Input<>/Output<>/generate()/schedule()) still work.
+//
+// Do not convert it to new-style until/unless we decide to entirely remove
+// support for those Generators.
+class BuildMethod : public Halide::Generator<BuildMethod> {
+ public:
+  GeneratorParam<float> compiletime_factor{"compiletime_factor", 1, 0, 100};
+
+  ImageParam input{Halide::Float(32), 2, "input"};
+  Param<float> runtime_factor{"runtime_factor", 1.0};
+
+  Func build() {
+    Var x, y;
+
+    Func g;
+    g(x, y) =
+        cast<int32_t>(input(x, y) * compiletime_factor * runtime_factor);
+    return g;
+  }
+};
+
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(BuildMethod, buildmethod)

--- a/python_bindings/correctness/nobuildmethod_generator.cpp
+++ b/python_bindings/correctness/nobuildmethod_generator.cpp
@@ -1,0 +1,25 @@
+#include "Halide.h"
+
+namespace {
+
+// This Generator exists solely to compare the output with BuildMethod and PartialBuildMethod.
+class NoBuildMethod : public Halide::Generator<NoBuildMethod> {
+ public:
+  GeneratorParam<float> compiletime_factor{"compiletime_factor", 1, 0, 100};
+
+  Input<Buffer<float>> input{"input", 2};
+  Input<float> runtime_factor{"runtime_factor", 1.0};
+
+  Output<Buffer<int32_t>> output{"output", 2};
+
+  void generate() {
+    Var x, y;
+
+    output(x, y) =
+        cast<int32_t>(input(x, y) * compiletime_factor * runtime_factor);
+  }
+};
+
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(NoBuildMethod, nobuildmethod)

--- a/python_bindings/correctness/partialbuildmethod_generator.cpp
+++ b/python_bindings/correctness/partialbuildmethod_generator.cpp
@@ -1,0 +1,30 @@
+#include "Halide.h"
+
+namespace {
+
+// This Generator exists solely to verify that partially converted old-style
+// generators -- which use Input<> rather than Param/ImageParam, but *don't* use
+// Output<>/generate() -- still work.
+//
+// Do not convert it to new-style until/unless we decide to entirely remove
+// support for those Generators.
+class PartialBuildMethod : public Halide::Generator<PartialBuildMethod> {
+ public:
+  GeneratorParam<float> compiletime_factor{"compiletime_factor", 1, 0, 100};
+
+  Input<Buffer<float>> input{"input", 2};
+  Input<float> runtime_factor{"runtime_factor", 1.0};
+
+  Func build() {
+    Var x, y;
+
+    Func g;
+    g(x, y) =
+        cast<int32_t>(input(x, y) * compiletime_factor * runtime_factor);
+    return g;
+  }
+};
+
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(PartialBuildMethod, partialbuildmethod)

--- a/python_bindings/correctness/pystub.py
+++ b/python_bindings/correctness/pystub.py
@@ -2,14 +2,19 @@ from __future__ import print_function
 from __future__ import division
 
 import halide as hl
+
 import simplestub
 # test alternate-but-legal syntax
 from complexstub import generate as complexstub
 
+import buildmethod
+import partialbuildmethod
+import nobuildmethod
+
 def _realize_and_check(f, offset = 0):
     b = hl.Buffer(hl.Float(32), [2, 2])
     f.realize(b)
-    
+
     assert b[0, 0] == 3.5 + offset + 123
     assert b[0, 1] == 4.5 + offset + 123
     assert b[1, 0] == 4.5 + offset + 123
@@ -154,7 +159,7 @@ def test_complexstub():
     float_arg = 1.25
     int_arg = 33
 
-    r = complexstub(target, 
+    r = complexstub(target,
                     typed_buffer_input=constant_image,
                     untyped_buffer_input=constant_image,
                     simple_input=input,
@@ -166,11 +171,11 @@ def test_complexstub():
 
     # return value is a tuple; unpack separately to avoid
     # making the callsite above unreadable
-    (simple_output, 
-        tuple_output, 
-        array_output, 
-        typed_buffer_output, 
-        untyped_buffer_output, 
+    (simple_output,
+        tuple_output,
+        array_output,
+        typed_buffer_output,
+        untyped_buffer_output,
         static_compiled_buffer_output) = r
 
     b = simple_output.realize(32, 32, 3, target)
@@ -237,7 +242,54 @@ def test_complexstub():
                 assert expected == actual, "Expected %s Actual %s" % (expected, actual)
 
 
+def test_buildmethod():
+    x, y, c = hl.Var(), hl.Var(), hl.Var()
+    target = hl.get_jit_target_from_environment()
+
+    b_in = hl.Buffer(hl.Float(32), [2, 2])
+    b_in.fill(123)
+
+    b_out = hl.Buffer(hl.Int(32), [2, 2])
+
+    try:
+        f = buildmethod.generate(target, b_in, 1)
+    except RuntimeError as e:
+        assert "Generators that use ImageParam/Param (instead of Input<>) are not supported in the Python bindings." in str(e)
+    else:
+        assert False, 'Did not see expected exception!'
+
+def test_partialbuildmethod():
+    x, y, c = hl.Var(), hl.Var(), hl.Var()
+    target = hl.get_jit_target_from_environment()
+
+    b_in = hl.Buffer(hl.Float(32), [2, 2])
+    b_in.fill(123)
+
+    b_out = hl.Buffer(hl.Int(32), [2, 2])
+
+    f = partialbuildmethod.generate(target, b_in, 1.0)
+    f.realize(b_out)
+
+    assert b_out.all_equal(123)
+
+def test_nobuildmethod():
+    x, y, c = hl.Var(), hl.Var(), hl.Var()
+    target = hl.get_jit_target_from_environment()
+
+    b_in = hl.Buffer(hl.Float(32), [2, 2])
+    b_in.fill(123)
+
+    b_out = hl.Buffer(hl.Int(32), [2, 2])
+
+    f = nobuildmethod.generate(target, b_in, 1.0)
+    f.realize(b_out)
+
+    assert b_out.all_equal(123)
+
 if __name__ == "__main__":
     test_simplestub()
     test_looplevel()
     test_complexstub()
+    test_buildmethod()
+    test_partialbuildmethod()
+    test_nobuildmethod()

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -65,6 +65,8 @@ py::object generate_impl(FactoryFunc factory, const GeneratorContext &context, p
         return factory(context);
     });
     auto names = stub.get_names();
+    _halide_user_assert(!(names.inputs.empty() && names.outputs.empty()))
+        << "Generators that use ImageParam/Param (instead of Input<>) are not supported in the Python bindings.";
     std::map<std::string, size_t> input_name_to_pos;
     for (size_t i = 0; i < names.inputs.size(); ++i) {
         input_name_to_pos[names.inputs[i]] = i;
@@ -113,9 +115,8 @@ py::object generate_impl(FactoryFunc factory, const GeneratorContext &context, p
             << "Generator Input named '" << names.inputs[i] << "' was not specified.";
     }
 
-    stub.generate(generator_params, inputs);
+    const std::vector<std::vector<Func>> outputs =  stub.generate(generator_params, inputs);
 
-    const std::vector<std::vector<Func>> outputs = stub.get_all_outputs();
     py::tuple py_outputs(outputs.size());
     for (size_t i = 0; i < outputs.size(); i++) {
         py::object o;

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -648,12 +648,34 @@ GeneratorStub::GeneratorStub(const GeneratorContext &context,
     generate(generator_params, inputs);
 }
 
-void GeneratorStub::generate(const GeneratorParamsMap &generator_params,
-                             const std::vector<std::vector<Internal::StubInput>> &inputs) {
+// Return a vector of all Outputs of this Generator; non-array outputs are returned
+// as a vector-of-size-1. This method is primarily useful for code that needs
+// to iterate through the outputs of unknown, arbitrary Generators (e.g.,
+// the Python bindings).
+std::vector<std::vector<Func>> GeneratorStub::generate(const GeneratorParamsMap &generator_params,
+                                                       const std::vector<std::vector<Internal::StubInput>> &inputs) {
     generator->set_generator_param_values(generator_params);
     generator->set_inputs_vector(inputs);
-    generator->call_generate();
-    generator->call_schedule();
+    Pipeline p = generator->build_pipeline();
+
+    std::vector<std::vector<Func>> v;
+    GeneratorBase::ParamInfo &pi = generator->param_info();
+    if (!pi.filter_outputs.empty()) {
+      for (auto output : pi.filter_outputs) {
+          const std::string &name = output->name();
+          if (output->is_array()) {
+              v.push_back(get_array_output(name));
+          } else {
+              v.push_back(std::vector<Func>{get_output(name)});
+          }
+      }
+    } else {
+      // Generators with build() method can't have Output<>, hence can't have array outputs
+      for (auto output : p.outputs()) {
+          v.push_back(std::vector<Func>{output});
+      }
+    }
+    return v;
 }
 
 GeneratorStub::Names GeneratorStub::get_names() const {
@@ -1119,21 +1141,6 @@ std::vector<Func> GeneratorBase::get_array_output(const std::string &n) {
         user_assert(f.defined()) << "Output " << n << " was not fully defined.\n";
     }
     return output->funcs();
-}
-
-std::vector<std::vector<Func>> GeneratorBase::get_all_outputs() {
-    std::vector<std::vector<Func>> v;
-    check_min_phase(GenerateCalled);
-    ParamInfo &pi = param_info();
-    for (auto output : pi.filter_outputs) {
-        const std::string &name = output->name();
-        if (output->is_array()) {
-            v.push_back(get_array_output(name));
-        } else {
-            v.push_back(std::vector<Func>{get_output(name)});
-        }
-    }
-    return v;
 }
 
 // Find output by name. If not found, assert-fail. Never returns null.

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2773,12 +2773,6 @@ private:
     // this method never returns undefined Funcs.
     std::vector<Func> get_array_output(const std::string &n);
 
-    // Return a vector of all Outputs of this Generator; non-array outputs are returned
-    // as a vector-of-size-1. This method is primarily useful for code that needs
-    // to iterate through the outputs of unknown, arbitrary Generators (e.g.,
-    // the Python bindings).
-    std::vector<std::vector<Func>> get_all_outputs();
-
     void set_inputs_vector(const std::vector<std::vector<StubInput>> &inputs);
 
     static void check_input_is_singular(Internal::GeneratorInputBase *in);
@@ -3150,7 +3144,7 @@ public:
                          GeneratorFactory generator_factory,
                          const GeneratorParamsMap &generator_params,
                          const std::vector<std::vector<Internal::StubInput>> &inputs);
-    void generate(const GeneratorParamsMap &generator_params,
+    std::vector<std::vector<Func>> generate(const GeneratorParamsMap &generator_params,
                          const std::vector<std::vector<Internal::StubInput>> &inputs);
 
     // Output(s)
@@ -3166,10 +3160,6 @@ public:
 
     std::vector<Func> get_array_output(const std::string &n) const {
         return generator->get_array_output(n);
-    }
-
-    std::vector<std::vector<Func>> get_all_outputs() const {
-        return generator->get_all_outputs();
     }
 
     static std::vector<StubInput> to_stub_input_vector(const Expr &e) {


### PR DESCRIPTION
It turns out to be trivial to allow the Python stub bindings to support Generators that use Input<> (instead of ImageParam/Param), but still use build() (rather than Output<>+generate()). So, let's support that. Added tests to verified that new and partial-new Generators work in Python, and that old-style ones fail quickly and predictably.