### PR TITLE
Add stub support for synthetic GeneratorParams

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1237,6 +1237,7 @@ $(BIN_DIR)/stubuser.generator: $(BUILD_DIR)/stubtest_generator.o
 # concrete via generator args.
 STUBTEST_GENERATOR_ARGS=\
     untyped_buffer_input.type=uint8 untyped_buffer_input.dim=3 \
+	untyped_buffer_output.type=float32 \
 	simple_input.type=float32 \
 	array_input.type=float32 array_input.size=2 \
 	int_arg.size=2 \

--- a/python_bindings/correctness/complexstub_generator.cpp
+++ b/python_bindings/correctness/complexstub_generator.cpp
@@ -17,7 +17,6 @@ Halide::Buffer<Type> make_image(int extra) {
 
 class ComplexStub : public Halide::Generator<ComplexStub> {
 public:
-    GeneratorParam<Type> untyped_buffer_output_type{ "untyped_buffer_output_type", Float(32) };
     GeneratorParam<bool> vectorize{ "vectorize", true };
     GeneratorParam<LoopLevel> intermediate_level{ "intermediate_level", LoopLevel::root() };
 
@@ -39,11 +38,7 @@ public:
     void generate() {
         simple_output(x, y, c) = cast<float>(simple_input(x, y, c));
         typed_buffer_output(x, y, c) = cast<float>(typed_buffer_input(x, y, c));
-        // Note that if we are being invoked via a Stub, "untyped_buffer_output.type()" will
-        // assert-fail, because there is no type constraint set: the type
-        // will end up as whatever we infer from the values put into it. We'll use an
-        // explicit GeneratorParam to allow us to set it.
-        untyped_buffer_output(x, y, c) = cast(untyped_buffer_output_type, untyped_buffer_input(x, y, c));
+        untyped_buffer_output(x, y, c) = cast(untyped_buffer_output.type(), untyped_buffer_input(x, y, c));
 
         // Gratuitous intermediate for the purpose of exercising
         // GeneratorParam<LoopLevel>

--- a/python_bindings/correctness/pystub.py
+++ b/python_bindings/correctness/pystub.py
@@ -9,7 +9,7 @@ from complexstub import generate as complexstub
 def _realize_and_check(f, offset = 0):
     b = hl.Buffer(hl.Float(32), [2, 2])
     f.realize(b)
-    
+
     assert b[0, 0] == 3.5 + offset + 123
     assert b[0, 1] == 4.5 + offset + 123
     assert b[1, 0] == 4.5 + offset + 123
@@ -154,23 +154,23 @@ def test_complexstub():
     float_arg = 1.25
     int_arg = 33
 
-    r = complexstub(target, 
+    r = complexstub(target,
                     typed_buffer_input=constant_image,
                     untyped_buffer_input=constant_image,
                     simple_input=input,
                     array_input=[ input, input ],
                     float_arg=float_arg,
                     int_arg=[ int_arg, int_arg ],
-                    untyped_buffer_output_type="uint8",
+                    untyped_buffer_output__type="uint8",
                     vectorize=True)
 
     # return value is a tuple; unpack separately to avoid
     # making the callsite above unreadable
-    (simple_output, 
-        tuple_output, 
-        array_output, 
-        typed_buffer_output, 
-        untyped_buffer_output, 
+    (simple_output,
+        tuple_output,
+        array_output,
+        typed_buffer_output,
+        untyped_buffer_output,
         static_compiled_buffer_output) = r
 
     b = simple_output.realize(32, 32, 3, target)

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -86,6 +86,12 @@ py::object generate_impl(FactoryFunc factory, const GeneratorContext &context, p
         // vector. If not, stick it in the GeneratorParamsMap (if it's invalid,
         // an error will be reported further downstream).
         std::string key = kw.first.cast<std::string>();
+        // 'synthetic' GeneratorParams (e.g., some_buffer.type) have a period
+        // in the name, which isn't legal syntax for a Python named argument.
+        // Since GeneratorParams explicitly forbid a double-underscore as part of a legal
+        // name, we'll use that as a substitute, to allow these to be specified
+        // in Python (thus, "some_buffer.type" -> "some_buffer__type")
+        key = Internal::replace_all(key, "__", ".");
         py::handle value = kw.second;
         auto it = input_name_to_pos.find(key);
         if (it != input_name_to_pos.end()) {

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -250,7 +250,6 @@ private:
             if (p->name == "target" ||
                 p->name == "auto_schedule" ||
                 p->name == "machine_params") continue;
-            if (p->is_synthetic_param()) continue;
             out.push_back(p);
         }
         return out;
@@ -271,6 +270,15 @@ std::string StubEmitter::indent() {
     return o.str();
 }
 
+std::string gp_name(Internal::GeneratorParamBase *gp) {
+    // 'synthetic' GeneratorParams (e.g., some_buffer.type) have a period
+    // in the name, which isn't legal syntax for a C++ struct member.
+    // Since GeneratorParams explicitly forbid a double-underscore as part of a legal
+    // name, we'll use that as a substitute, to allow these to be specified
+    // in the struct (thus, "some_buffer.type" -> "some_buffer__type")
+    return replace_all(gp->name, ".", "__");
+}
+
 void StubEmitter::emit_generator_params_struct() {
     const auto &v = generator_params;
     std::string name = "GeneratorParams";
@@ -278,7 +286,7 @@ void StubEmitter::emit_generator_params_struct() {
     indent_level++;
     if (!v.empty()) {
         for (auto p : v) {
-            stream << indent() << p->get_c_type() << " " << p->name << "{ " << p->get_default_value() << " };\n";
+            stream << indent() << p->get_c_type() << " " << gp_name(p) << "{ " << p->get_default_value() << " };\n";
         }
         stream << "\n";
     }
@@ -291,7 +299,7 @@ void StubEmitter::emit_generator_params_struct() {
         indent_level++;
         std::string comma = "";
         for (auto p : v) {
-            stream << indent() << comma << p->get_c_type() << " " << p->name << "\n";
+            stream << indent() << comma << p->get_c_type() << " " << gp_name(p) << "\n";
             comma = ", ";
         }
         indent_level--;
@@ -299,7 +307,7 @@ void StubEmitter::emit_generator_params_struct() {
         indent_level++;
         comma = "";
         for (auto p : v) {
-            stream << indent() << comma << p->name << "(" << p->name << ")\n";
+            stream << indent() << comma << gp_name(p) << "(" << gp_name(p) << ")\n";
             comma = ", ";
         }
         indent_level--;
@@ -316,9 +324,9 @@ void StubEmitter::emit_generator_params_struct() {
     for (auto p : v) {
         stream << indent() << comma << "{\"" << p->name << "\", ";
         if (p->is_looplevel_param()) {
-            stream << p->name << "}\n";
+            stream << gp_name(p) << "}\n";
         } else {
-            stream << p->call_to_string(p->name) << "}\n";
+            stream << p->call_to_string(gp_name(p)) << "}\n";
         }
         comma = ", ";
     }
@@ -1161,7 +1169,10 @@ void GeneratorBase::set_generator_param_values(const GeneratorParamsMap &params)
                     gp->second->set(key_value.second.loop_level);
                 }
             } else {
-                gp->second->set_from_string(key_value.second.string_value);
+                // If string is empty, just ignore and don't try to set
+                if (!key_value.second.string_value.empty()) {
+                    gp->second->set_from_string(key_value.second.string_value);
+                }
             }
             continue;
         }
@@ -1423,9 +1434,9 @@ bool GIOBase::array_size_defined() const {
 }
 
 size_t GIOBase::array_size() const {
-    internal_assert(array_size_defined()) << "ArraySize is unspecified for " << name()
-        << "; you need to explicit set it via the resize() method or by setting "
-        << name() << ".size = value in your build rules.";
+    user_assert(array_size_defined()) << "ArraySize is unspecified for " << name()
+        << "; you need to explicitly set it by calling the resize() method or by specifying "
+        << name() << ".size=value in your build rules.";
     return (size_t) array_size_;
 }
 
@@ -1446,7 +1457,9 @@ bool GIOBase::types_defined() const {
 }
 
 const std::vector<Type> &GIOBase::types() const {
-    internal_assert(types_defined()) << "Type is unspecified for " << name() << "\n";
+    user_assert(types_defined()) << "Type is unspecified for " << name()
+        << "; you need to explicitly set it by specifying "
+        << name() << ".type=value in your build rules.";
     return types_;
 }
 
@@ -1460,6 +1473,9 @@ bool GIOBase::dims_defined() const {
 }
 
 int GIOBase::dims() const {
+    user_assert(dims_defined()) << "Dimensions are unspecified for " << name()
+        << "; you need to explicitly set this by specifying "
+        << name() << ".dim=value in your build rules.";
     internal_assert(dims_defined()) << "Dimensions unspecified for " << name() << "\n";
     return dims_;
 }

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2337,18 +2337,33 @@ public:
     }
 
     std::string get_default_value() const override {
-        internal_error;
-        return std::string();
+        if (which == Dim || which == ArraySize) {
+            return "-1";
+        } else {
+            // There is no "undefined" Halide::Type, but Handle is
+            // essentially invalid here, so we'll use it as a placeholder
+            return "Halide::Handle()";
+        }
     }
 
     std::string call_to_string(const std::string &v) const override {
-        internal_error;
-        return std::string();
+        std::ostringstream oss;
+        if (which == Dim || which == ArraySize) {
+            // return an empty string if the default value wasn't overridden.
+            oss << "(" << v << " < 0 ? std::string() : std::to_string(" << v << "))";
+        } else {
+            // return an empty string if the default value wasn't overridden.
+            oss << "(" << v << ".is_handle() ? std::string() : Halide::Internal::halide_type_to_enum_string(" + v + "))";
+        }
+        return oss.str();
     }
 
     std::string get_c_type() const override {
-        internal_error;
-        return std::string();
+        if (which == Dim || which == ArraySize) {
+            return "int";
+        } else {
+            return "Type";
+        }
     }
 
     bool is_synthetic_param() const override {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,9 +96,9 @@ if (WITH_TEST_GENERATOR)
 
     set(TARGET "generator_aot_${NAME}")
     add_executable("${TARGET}" "${GEN_TEST_DIR}/${NAME}_aottest.cpp")
-    target_include_directories("${TARGET}" PRIVATE 
-                               "${CMAKE_SOURCE_DIR}/tools" 
-                               "${CMAKE_SOURCE_DIR}" 
+    target_include_directories("${TARGET}" PRIVATE
+                               "${CMAKE_SOURCE_DIR}/tools"
+                               "${CMAKE_SOURCE_DIR}"
                                "${CMAKE_SOURCE_DIR}/src/runtime")
 
     if (NOT ${args_OMIT_DEFAULT_GENERATOR})
@@ -194,9 +194,9 @@ if (WITH_TEST_GENERATOR)
   #   set(TARGET )
 
   #   add_executable("generator_aot_${NAME}" "${GEN_TEST_DIR}/${FILE}")
-  #   target_include_directories("generator_aot_${NAME}" PRIVATE 
-  #                              "${CMAKE_SOURCE_DIR}" 
-  #                              "${CMAKE_SOURCE_DIR}/tools" 
+  #   target_include_directories("generator_aot_${NAME}" PRIVATE
+  #                              "${CMAKE_SOURCE_DIR}"
+  #                              "${CMAKE_SOURCE_DIR}/tools"
   #                              "${CMAKE_SOURCE_DIR}/src/runtime")
 
   #   if (NOT ${args_OMIT_DEFAULT_GENERATOR})
@@ -252,7 +252,7 @@ if (WITH_TEST_GENERATOR)
   halide_define_aot_test(user_context_insanity
                          HALIDE_TARGET_FEATURES user_context)
 
-  add_library(cxx_mangling_externs 
+  add_library(cxx_mangling_externs
               "${GEN_TEST_DIR}/cxx_mangling_externs.cpp")
 
   halide_define_aot_test(cxx_mangling
@@ -296,6 +296,7 @@ if (WITH_TEST_GENERATOR)
   # concrete via generator args.
   set(STUBTEST_GENERATOR_ARGS
       untyped_buffer_input.type=uint8 untyped_buffer_input.dim=3
+      untyped_buffer_output.type=float32
       simple_input.type=float32
       array_input.type=float32 array_input.size=2
       int_arg.size=2
@@ -342,7 +343,7 @@ if (WITH_TEST_GENERATOR)
   halide_library_from_generator(blur2x2)
   target_link_libraries(generator_aot_tiled_blur PUBLIC blur2x2)
 
-  add_library(cxx_mangling_define_extern_externs 
+  add_library(cxx_mangling_define_extern_externs
               "${GEN_TEST_DIR}/cxx_mangling_define_extern_externs.cpp")
   target_link_libraries(cxx_mangling_define_extern_externs PUBLIC cxx_mangling_externs cxx_mangling)
 

--- a/test/generator/stubtest_generator.cpp
+++ b/test/generator/stubtest_generator.cpp
@@ -19,7 +19,6 @@ Halide::Buffer<Type> make_image(int extra) {
 
 class StubTest : public Halide::Generator<StubTest> {
 public:
-    GeneratorParam<Type> untyped_buffer_output_type{ "untyped_buffer_output_type", Float(32) };
     GeneratorParam<float> float_param{ "float_param", 3.1415926535f };
     GeneratorParam<BagType> bag_type{ "bag_type",
                                       BagType::Paper,
@@ -46,11 +45,7 @@ public:
     void generate() {
         simple_output(x, y, c) = cast<float>(simple_input(x, y, c));
         typed_buffer_output(x, y, c) = cast<float>(typed_buffer_input(x, y, c));
-        // Note that if we are being invoked via a Stub, "untyped_buffer_output.type()" will
-        // assert-fail, because there is no type constraint set: the type
-        // will end up as whatever we infer from the values put into it. We'll use an
-        // explicit GeneratorParam to allow us to set it.
-        untyped_buffer_output(x, y, c) = cast(untyped_buffer_output_type, untyped_buffer_input(x, y, c));
+        untyped_buffer_output(x, y, c) = cast(untyped_buffer_output.type(), untyped_buffer_input(x, y, c));
 
         // Gratuitous intermediate for the purpose of exercising
         // GeneratorParam<LoopLevel>

--- a/test/generator/stubtest_jittest.cpp
+++ b/test/generator/stubtest_jittest.cpp
@@ -63,6 +63,7 @@ int main(int argc, char **argv) {
     // Pass in a set of GeneratorParams: even though we aren't customizing
     // the values, we can set the LoopLevel values after-the-fact.
     StubTest::GeneratorParams gp;
+    gp.untyped_buffer_output__type = Float(32);
     auto gen = StubTest::generate(
         GeneratorContext(get_jit_target_from_environment()),
         // Use aggregate-initialization syntax to fill in an Inputs struct.

--- a/test/generator/stubuser_generator.cpp
+++ b/test/generator/stubuser_generator.cpp
@@ -45,7 +45,7 @@ public:
         inputs.int_arg = { int_arg };
 
         StubTest::GeneratorParams gp;
-        gp.untyped_buffer_output_type = int32_buffer_output.type();
+        gp.untyped_buffer_output__type = int32_buffer_output.type();
         gp.intermediate_level.set(LoopLevel(calculated_output, Var("y")));
         gp.vectorize = true;
 


### PR DESCRIPTION
For things like Input<Buffer<>> {"inputname"} (where there is no static type), we synthesize GeneratorParams of the form inputname.type (or inputname.dim, or inputname.size, in the case of buffer-dimensions or arraysize). These were settable from the build system, but not from stub usage (in either C++ or Python); this PR remedies that deficit and puts allows Stubs to set these. (Ditto for Outputs.)

Note that the syntax of "name.type" (using a dot) prevents us from using the same name in C++ structs or in Python named-arg calls; since a double-underscore is illegal in GeneratorParam names, we use that as a substitute in these contexts. (Note to reviewers: I'm not entirely happy with this nomenclature, and open for better suggestions.)