### PR TITLE
Verify that Python stubs work only with new-style Generators

### DIFF
--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -84,11 +84,11 @@ $(BIN)/PyStubImpl.o: $(ROOT_DIR)/stub/PyStubImpl.cpp $(HALIDE_DISTRIB_PATH)/incl
 	$(CXX) $(CCFLAGS) -c $< -o $@
 
 # Produce a Python extension for the generator by compiling PyStub.cpp
-# (with HALIDE_PYSTUB_GENERATOR_NAME defined to the Generator's build name), 
+# (with HALIDE_PYSTUB_GENERATOR_NAME defined to the Generator's build name),
 # and linking with the generator's .o file, PyStubImpl.o, plus the same libHalide
-# being used by halide.so. 
+# being used by halide.so.
 #
-# You can optionally also define HALIDE_PYSTUB_MODULE_NAME if you want the Python 
+# You can optionally also define HALIDE_PYSTUB_MODULE_NAME if you want the Python
 # module name to be something other than the Generator build name.
 $(BIN)/%_PyStub.o: $(ROOT_DIR)/stub/PyStub.cpp
 	@mkdir -p $(@D)
@@ -98,7 +98,7 @@ $(BIN)/%.so: $(BIN)/%_PyStub.o $(BIN)/PyStubImpl.o $(BIN)/%_generator.o $(LIBHAL
 	@mkdir -p $(@D)
 	$(CXX) $^ $(LDFLAGS) -shared -o $@
 
-test_correctness_pystub: $(BIN)/simplestub.so $(BIN)/complexstub.so 
+test_correctness_pystub: $(BIN)/simplestub.so $(BIN)/complexstub.so $(BIN)/buildmethod.so $(BIN)/partialbuildmethod.so $(BIN)/nobuildmethod.so
 
 APPS = $(shell ls $(ROOT_DIR)/apps/*.py)
 CORRECTNESS = $(shell ls $(ROOT_DIR)/correctness/*.py)

--- a/python_bindings/correctness/buildmethod_generator.cpp
+++ b/python_bindings/correctness/buildmethod_generator.cpp
@@ -1,0 +1,30 @@
+#include "Halide.h"
+
+namespace {
+
+// This Generator exists solely to test old-style generators (using the
+// Param/ImageParam/build() method, rather than
+// Input<>/Output<>/generate()/schedule()).
+//
+// Do not convert it to new-style until/unless we decide to entirely remove
+// support for those Generators.
+class BuildMethod : public Halide::Generator<BuildMethod> {
+ public:
+  GeneratorParam<float> compiletime_factor{"compiletime_factor", 1, 0, 100};
+
+  ImageParam input{Halide::Float(32), 2, "input"};
+  Param<float> runtime_factor{"runtime_factor", 1.0};
+
+  Func build() {
+    Var x, y;
+
+    Func g;
+    g(x, y) =
+        cast<int32_t>(input(x, y) * compiletime_factor * runtime_factor);
+    return g;
+  }
+};
+
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(BuildMethod, buildmethod)

--- a/python_bindings/correctness/nobuildmethod_generator.cpp
+++ b/python_bindings/correctness/nobuildmethod_generator.cpp
@@ -1,0 +1,25 @@
+#include "Halide.h"
+
+namespace {
+
+// This Generator exists solely to compare the output with BuildMethod and PartialBuildMethod.
+class NoBuildMethod : public Halide::Generator<NoBuildMethod> {
+ public:
+  GeneratorParam<float> compiletime_factor{"compiletime_factor", 1, 0, 100};
+
+  Input<Buffer<float>> input{"input", 2};
+  Input<float> runtime_factor{"runtime_factor", 1.0};
+
+  Output<Buffer<int32_t>> output{"output", 2};
+
+  void generate() {
+    Var x, y;
+
+    output(x, y) =
+        cast<int32_t>(input(x, y) * compiletime_factor * runtime_factor);
+  }
+};
+
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(NoBuildMethod, nobuildmethod)

--- a/python_bindings/correctness/partialbuildmethod_generator.cpp
+++ b/python_bindings/correctness/partialbuildmethod_generator.cpp
@@ -1,0 +1,30 @@
+#include "Halide.h"
+
+namespace {
+
+// This Generator exists solely to test converted old-style
+// generators -- which use Input<> rather than Param/ImageParam, but *don't* use
+// Output<>/generate().
+//
+// Do not convert it to new-style until/unless we decide to entirely remove
+// support for those Generators.
+class PartialBuildMethod : public Halide::Generator<PartialBuildMethod> {
+ public:
+  GeneratorParam<float> compiletime_factor{"compiletime_factor", 1, 0, 100};
+
+  Input<Buffer<float>> input{"input", 2};
+  Input<float> runtime_factor{"runtime_factor", 1.0};
+
+  Func build() {
+    Var x, y;
+
+    Func g;
+    g(x, y) =
+        cast<int32_t>(input(x, y) * compiletime_factor * runtime_factor);
+    return g;
+  }
+};
+
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(PartialBuildMethod, partialbuildmethod)

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2773,12 +2773,6 @@ private:
     // this method never returns undefined Funcs.
     std::vector<Func> get_array_output(const std::string &n);
 
-    // Return a vector of all Outputs of this Generator; non-array outputs are returned
-    // as a vector-of-size-1. This method is primarily useful for code that needs
-    // to iterate through the outputs of unknown, arbitrary Generators (e.g.,
-    // the Python bindings).
-    std::vector<std::vector<Func>> get_all_outputs();
-
     void set_inputs_vector(const std::vector<std::vector<StubInput>> &inputs);
 
     static void check_input_is_singular(Internal::GeneratorInputBase *in);
@@ -3150,7 +3144,7 @@ public:
                          GeneratorFactory generator_factory,
                          const GeneratorParamsMap &generator_params,
                          const std::vector<std::vector<Internal::StubInput>> &inputs);
-    void generate(const GeneratorParamsMap &generator_params,
+    std::vector<std::vector<Func>> generate(const GeneratorParamsMap &generator_params,
                          const std::vector<std::vector<Internal::StubInput>> &inputs);
 
     // Output(s)
@@ -3166,10 +3160,6 @@ public:
 
     std::vector<Func> get_array_output(const std::string &n) const {
         return generator->get_array_output(n);
-    }
-
-    std::vector<std::vector<Func>> get_all_outputs() const {
-        return generator->get_all_outputs();
     }
 
     static std::vector<StubInput> to_stub_input_vector(const Expr &e) {
@@ -3193,7 +3183,7 @@ public:
     }
 
     struct Names {
-        std::vector<std::string> generator_params, inputs, outputs;
+        std::vector<std::string> generator_params, filter_params, inputs, outputs;
     };
     Names get_names() const;
 


### PR DESCRIPTION
Revised version of https://github.com/halide/Halide/pull/2768, but explicitly forbidding 'old' and 'partial-new' Generators for now.