### PR TITLE
Finish the Python bindings for Func

### DIFF
--- a/python_bindings/correctness/compile_to.py
+++ b/python_bindings/correctness/compile_to.py
@@ -33,6 +33,9 @@ def main():
     assert os.path.isfile("f_all.h")
     assert os.path.isfile("f_all.o")
 
+    f.compile_to(hl.Outputs(stmt_html_name="f.html"), args, "f")
+    assert os.path.isfile("f.html")
+
     return 0
 
 if __name__ == "__main__":

--- a/python_bindings/src/PyEnums.cpp
+++ b/python_bindings/src/PyEnums.cpp
@@ -27,6 +27,14 @@ void define_enums(py::module &m) {
         .value("AlignEnd", LoopAlignStrategy::AlignEnd)
     ;
 
+    py::enum_<MemoryType>(m, "MemoryType")
+        .value("Auto", MemoryType::Auto)
+        .value("Heap", MemoryType::Heap)
+        .value("Stack", MemoryType::Stack)
+        .value("Register", MemoryType::Register)
+        .value("GPUShared", MemoryType::GPUShared)
+    ;
+
     py::enum_<NameMangling>(m, "NameMangling")
         .value("Default", NameMangling::Default)
         .value("C", NameMangling::C)

--- a/python_bindings/src/PyExternFuncArgument.cpp
+++ b/python_bindings/src/PyExternFuncArgument.cpp
@@ -11,6 +11,7 @@ void define_extern_func_argument(py::module &m) {
         .def(py::init<int>())
         .def(py::init<float>())
         // for implicitly_convertible
+        .def(py::init([](const Func &f) -> ExternFuncArgument { return f; }))
         .def(py::init([](const Param<> &p) -> ExternFuncArgument { return p; }))
         .def(py::init([](const ImageParam &im) -> ExternFuncArgument { return im; }))
         .def(py::init([](const OutputImageParam &im) -> ExternFuncArgument { return im; }))
@@ -23,6 +24,7 @@ void define_extern_func_argument(py::module &m) {
     ;
 
     py::implicitly_convertible<Expr, ExternFuncArgument>();
+    py::implicitly_convertible<Func, ExternFuncArgument>();
     py::implicitly_convertible<Buffer<>, ExternFuncArgument>();
     py::implicitly_convertible<Param<>, ExternFuncArgument>();
     py::implicitly_convertible<ImageParam, ExternFuncArgument>();

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -68,7 +68,7 @@ void define_func(py::module &m) {
     // - custom_lowering_passes()
 
     // Not supported yet, because we want to think about how to expose runtime
-    // overloads in Python:
+    // overrides in Python (https://github.com/halide/Halide/issues/2790):
     // - set_error_handler()
     // - set_custom_trace()
     // - set_custom_print()

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -58,10 +58,26 @@ void define_func(py::module &m) {
         .def(py::init<>())
     ;
 
+    // Deliberately not supported, because they don't seem to make sense for Python:
+    // - set_custom_allocator()
+    // - set_custom_do_task()
+    // - set_custom_do_par_for()
+    // - jit_handlers()
+    // - add_custom_lowering_pass()
+    // - clear_custom_lowering_passes()
+    // - custom_lowering_passes()
+
+    // Not supported yet, because we want to think about how to expose runtime
+    // overloads in Python:
+    // - set_error_handler()
+    // - set_custom_trace()
+    // - set_custom_print()
+
     auto func_class = py::class_<Func>(m, "Func")
         .def(py::init<>())
         .def(py::init<std::string>())
         .def(py::init<Expr>())
+        .def(py::init([](Buffer<> &b) -> Func { return Func(b); }))
 
         // for implicitly_convertible
         .def(py::init([](const ImageParam &im) -> Func { return im; }))
@@ -77,50 +93,72 @@ void define_func(py::module &m) {
 
         .def("realize", [](Func &f, std::vector<int32_t> sizes, const Target &target, const ParamMap &param_map) -> py::object {
             return realization_to_object(f.realize(sizes, target, param_map));
-        }, py::arg("sizes"), py::arg("target") = Target(), py::arg("param_map") = ParamMap())
+        }, py::arg("sizes") = std::vector<int32_t>{}, py::arg("target") = Target(), py::arg("param_map") = ParamMap())
 
-        .def("realize", [](Func &f, const Target &target, const ParamMap &param_map) -> py::object {
-            return realization_to_object(f.realize(target, param_map));
-        }, py::arg("target") = Target(), py::arg("param_map") = ParamMap())
-
+        // TODO: deprecate in favor of std::vector<int32_t> size version?
         .def("realize", [](Func &f, int x_size, const Target &target, const ParamMap &param_map) -> py::object {
             return realization_to_object(f.realize(x_size, target, param_map));
         }, py::arg("x_size"), py::arg("target") = Target(), py::arg("param_map") = ParamMap())
 
+        // TODO: deprecate in favor of std::vector<int32_t> size version?
         .def("realize", [](Func &f, int x_size, int y_size, const Target &target, const ParamMap &param_map) -> py::object {
             return realization_to_object(f.realize(x_size, y_size, target, param_map));
         }, py::arg("x_size"), py::arg("y_size"), py::arg("target") = Target(), py::arg("param_map") = ParamMap())
 
+        // TODO: deprecate in favor of std::vector<int32_t> size version?
         .def("realize", [](Func &f, int x_size, int y_size, int z_size, const Target &target, const ParamMap &param_map) -> py::object {
             return realization_to_object(f.realize(x_size, y_size, z_size, target, param_map));
         }, py::arg("x_size"), py::arg("y_size"), py::arg("z_size"), py::arg("target") = Target(), py::arg("param_map") = ParamMap())
 
+        // TODO: deprecate in favor of std::vector<int32_t> size version?
         .def("realize", [](Func &f, int x_size, int y_size, int z_size, int w_size, const Target &target, const ParamMap &param_map) -> py::object {
             return realization_to_object(f.realize(x_size, y_size, z_size, w_size, target, param_map));
         }, py::arg("x_size"), py::arg("y_size"), py::arg("z_size"), py::arg("w_size"), py::arg("target") = Target(), py::arg("param_map") = ParamMap())
 
+        .def("defined", &Func::defined)
         .def("name", &Func::name)
-
+        .def("dimensions", &Func::dimensions)
+        .def("args", &Func::args)
+        .def("value", &Func::value)
+        .def("values", [](Func &func) -> py::tuple {
+            return to_python_tuple(func.values());
+        })
+        .def("defined", &Func::defined)
+        .def("outputs", &Func::outputs)
         .def("output_types", &Func::output_types)
 
-        .def("bound", &Func::bound)
+        .def("bound", &Func::bound, py::arg("var"), py::arg("min"), py::arg("extent"))
 
-        .def("reorder_storage", (Func &(Func::*)(const std::vector<Var> &)) &Func::reorder_storage, py::arg("dims"))
+        .def("reorder_storage", (Func &(Func::*)(const std::vector<Var> &)) &Func::reorder_storage,
+            py::arg("dims"))
         .def("reorder_storage", [](Func &func, py::args args) -> Func & {
             return func.reorder_storage(args_to_vector<Var>(args));
         })
 
-        .def("compute_at", (Func &(Func::*)(Func, Var)) &Func::compute_at)
-        .def("compute_at", (Func &(Func::*)(Func, RVar)) &Func::compute_at)
-        .def("compute_at", (Func &(Func::*)(LoopLevel)) &Func::compute_at)
+        .def("compute_at", (Func &(Func::*)(Func, Var)) &Func::compute_at,
+            py::arg("f"), py::arg("var"))
+        .def("compute_at", (Func &(Func::*)(Func, RVar)) &Func::compute_at,
+            py::arg("f"), py::arg("var"))
+        .def("compute_at", (Func &(Func::*)(LoopLevel)) &Func::compute_at,
+            py::arg("loop_level"))
 
+        .def("store_at", (Func &(Func::*)(Func, Var)) &Func::store_at,
+            py::arg("f"), py::arg("var"))
+        .def("store_at", (Func &(Func::*)(Func, RVar)) &Func::store_at,
+            py::arg("f"), py::arg("var"))
+        .def("store_at", (Func &(Func::*)(LoopLevel)) &Func::store_at,
+            py::arg("loop_level"))
 
-        .def("store_at", (Func &(Func::*)(Func, Var)) &Func::store_at)
-        .def("store_at", (Func &(Func::*)(Func, RVar)) &Func::store_at)
-        .def("store_at", (Func &(Func::*)(LoopLevel)) &Func::store_at)
-
+        .def("memoize", &Func::memoize)
+        .def("compute_inline", &Func::compute_inline)
         .def("compute_root", &Func::compute_root)
         .def("store_root", &Func::store_root)
+
+        .def("store_in", &Func::store_in,
+            py::arg("memory_type"))
+
+        .def("compile_to", &Func::compile_to,
+            py::arg("outputs"), py::arg("arguments"), py::arg("fn_name"), py::arg("target") = get_target_from_environment())
 
         .def("compile_to_bitcode",
             (void (Func::*)(const std::string &, const std::vector<Argument> &, const std::string &, const Target &target)) &Func::compile_to_bitcode,
@@ -168,17 +206,34 @@ void define_func(py::module &m) {
         .def("compile_to_multitarget_static_library", &Func::compile_to_multitarget_static_library,
             py::arg("filename_prefix"), py::arg("arguments"), py::arg("targets"))
 
+        // TODO: useless until Module is defined.
         .def("compile_to_module", &Func::compile_to_module,
             py::arg("arguments"), py::arg("fn_name") = "", py::arg("target") = get_target_from_environment())
 
         .def("compile_jit", &Func::compile_jit, py::arg("target") = get_jit_target_from_environment())
 
+        .def("has_update_definition", &Func::has_update_definition)
+        .def("num_update_definitions", &Func::num_update_definitions)
+
         .def("update", &Func::update, py::arg("idx") = 0)
+        .def("update_args", &Func::update_args, py::arg("idx") = 0)
+        .def("update_value", &Func::update_value, py::arg("idx") = 0)
+        .def("update_value", &Func::update_value, py::arg("idx") = 0)
+        .def("update_values", [](Func &func, int idx) -> py::tuple {
+            return to_python_tuple(func.update_values(idx));
+        }, py::arg("idx") = 0)
+        .def("rvars", &Func::rvars, py::arg("idx") = 0)
 
         .def("trace_loads", &Func::trace_loads)
         .def("trace_stores", &Func::trace_stores)
         .def("trace_realizations", &Func::trace_realizations)
         .def("print_loop_nest", &Func::print_loop_nest)
+
+        // TODO: also provide to-array versions to avoid requiring filesystem usage
+        .def("debug_to_file", &Func::debug_to_file)
+
+        .def("is_extern", &Func::is_extern)
+        .def("extern_function_name", &Func::extern_function_name)
 
         .def("define_extern", (void (Func::*)(const std::string &, const std::vector<ExternFuncArgument> &,
                 const std::vector<Type> &, const std::vector<Var> &, NameMangling, DeviceAPI, bool)) &Func::define_extern,
@@ -240,6 +295,48 @@ void define_func(py::module &m) {
         .def("infer_input_bounds", [](Func &f, std::vector<Buffer<>> buffer, const ParamMap &param_map) -> void {
             f.infer_input_bounds(Realization(buffer), param_map);
         }, py::arg("dst"), py::arg("param_map") = ParamMap())
+
+        .def("in", (Func (Func::*)(const Func &)) &Func::in, py::arg("f"))
+        .def("in", (Func (Func::*)(const std::vector<Func> &fs)) &Func::in, py::arg("fs"))
+        .def("in", (Func (Func::*)()) &Func::in)
+
+        .def("clone_in", (Func (Func::*)(const Func &)) &Func::clone_in, py::arg("f"))
+        .def("clone_in", (Func (Func::*)(const std::vector<Func> &fs)) &Func::clone_in, py::arg("fs"))
+
+        .def("copy_to_device", &Func::copy_to_device,
+            py::arg("device_api") = DeviceAPI::Default_GPU)
+        .def("copy_to_host", &Func::copy_to_host)
+
+        .def("estimate", &Func::estimate,
+            py::arg("var"), py::arg("min"), py::arg("extent"))
+
+        .def("align_bounds", &Func::align_bounds,
+            py::arg("var"), py::arg("modulus"), py::arg("remainder") = 0)
+
+        .def("bound_extent", &Func::bound_extent,
+            py::arg("var"), py::arg("extent"))
+
+        .def("gpu_lanes", &Func::gpu_lanes,
+            py::arg("thread_x"), py::arg("device_api") = DeviceAPI::Default_GPU)
+
+        .def("shader", &Func::shader,
+            py::arg("x"), py::arg("y"), py::arg("c"), py::arg("device_api"))
+
+        .def("glsl", &Func::glsl,
+            py::arg("x"), py::arg("y"), py::arg("c"))
+
+        .def("align_storage", &Func::align_storage,
+            py::arg("dim"), py::arg("alignment"))
+
+        .def("fold_storage", &Func::fold_storage,
+            py::arg("dim"), py::arg("extent"), py::arg("fold_forward") = true)
+
+        .def("compute_with", (Func &(Func::*)(LoopLevel, const std::vector<std::pair<VarOrRVar, LoopAlignStrategy>> &)) &Func::compute_with,
+            py::arg("loop_level"), py::arg("align"))
+        .def("compute_with", (Func &(Func::*)(LoopLevel, LoopAlignStrategy)) &Func::compute_with,
+            py::arg("loop_level"), py::arg("align") = LoopAlignStrategy::Auto)
+
+        .def("infer_arguments", &Func::infer_arguments)
 
         .def("__repr__", [](const Func &func) -> std::string {
             std::ostringstream o;

--- a/python_bindings/src/PyHalide.cpp
+++ b/python_bindings/src/PyHalide.cpp
@@ -12,6 +12,7 @@
 #include "PyImageParam.h"
 #include "PyInlineReductions.h"
 #include "PyLambda.h"
+#include "PyOutputs.h"
 #include "PyParam.h"
 #include "PyRDom.h"
 #include "PyTarget.h"
@@ -36,6 +37,7 @@ PYBIND11_MODULE(halide, m) {
     define_extern_func_argument(m);
     define_var(m);
     define_rdom(m);
+    define_outputs(m);
     define_func(m);
     define_inline_reductions(m);
     define_lambda(m);

--- a/python_bindings/src/PyOutputs.cpp
+++ b/python_bindings/src/PyOutputs.cpp
@@ -1,0 +1,58 @@
+#include "PyOutputs.h"
+
+namespace Halide {
+namespace PythonBindings {
+
+void define_outputs(py::module &m) {
+    auto outputs_class = py::class_<Outputs>(m, "Outputs")
+        .def(py::init<>())
+        .def(py::init([](const std::string &object_name,
+                         const std::string &assembly_name,
+                         const std::string &bitcode_name,
+                         const std::string &llvm_assembly_name,
+                         const std::string &c_header_name,
+                         const std::string &c_source_name,
+                         const std::string &stmt_name,
+                         const std::string &stmt_html_name,
+                         const std::string &static_library_name,
+                         const std::string &schedule_name) -> Outputs {
+            Outputs o;
+            o.object_name = object_name;
+            o.assembly_name = assembly_name;
+            o.bitcode_name = bitcode_name;
+            o.llvm_assembly_name = llvm_assembly_name;
+            o.c_header_name = c_header_name;
+            o.c_source_name = c_source_name;
+            o.stmt_name = stmt_name;
+            o.stmt_html_name = stmt_html_name;
+            o.static_library_name = static_library_name;
+            o.schedule_name = schedule_name;
+            return o;
+        }),
+            py::arg("object_name") = "",
+            py::arg("assembly_name") = "",
+            py::arg("bitcode_name") = "",
+            py::arg("llvm_assembly_name") = "",
+            py::arg("c_header_name") = "",
+            py::arg("c_source_name") = "",
+            py::arg("stmt_name") = "",
+            py::arg("stmt_html_name") = "",
+            py::arg("static_library_name") = "",
+            py::arg("schedule_name") = ""
+        )
+        .def_readwrite("object_name", &Outputs::object_name)
+        .def_readwrite("assembly_name", &Outputs::assembly_name)
+        .def_readwrite("bitcode_name", &Outputs::bitcode_name)
+        .def_readwrite("llvm_assembly_name", &Outputs::llvm_assembly_name)
+        .def_readwrite("c_header_name", &Outputs::c_header_name)
+        .def_readwrite("c_source_name", &Outputs::c_source_name)
+        .def_readwrite("stmt_name", &Outputs::stmt_name)
+        .def_readwrite("stmt_html_name", &Outputs::stmt_html_name)
+        .def_readwrite("static_library_name", &Outputs::static_library_name)
+        .def_readwrite("schedule_name", &Outputs::schedule_name)
+    ;
+
+}
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyOutputs.h
+++ b/python_bindings/src/PyOutputs.h
@@ -1,0 +1,14 @@
+#ifndef HALIDE_PYTHON_BINDINGS_PYOUTPUTS_H
+#define HALIDE_PYTHON_BINDINGS_PYOUTPUTS_H
+
+#include "PyHalide.h"
+
+namespace Halide {
+namespace PythonBindings {
+
+void define_outputs(py::module &m);
+
+}  // namespace PythonBindings
+}  // namespace Halide
+
+#endif  // HALIDE_PYTHON_BINDINGS_PYOUTPUTS_H

--- a/python_bindings/todo.txt
+++ b/python_bindings/todo.txt
@@ -6,6 +6,7 @@
 - All docstrings have been removed; if we re-add them, we should find a way to import them from Doxygen output to ensure they are fresh.
 - Tutorials are incomplete and need lots of love.
 - Many error messages need to be made more informative. Many exceptions are of incorrect type.
+- Some hooks to override runtime functions (e.g. Func::set_error_handler) aren't yet implemented.
 
 - Wrappers Missing Entirely:
     - ConciseCasts
@@ -14,20 +15,20 @@
     - Float16 [possible via numpy?]
     - Generator
     - Module
-    - Outputs
     - Pipeline
 - Wrappers Incomplete, Tests Incomplete:
-    - Func
     - ParamMap
 - Wrappers Believed To Be Complete, But Tests Incomplete:
     - Buffer
     - ExternFuncArgument
+    - Func
     - FuncRef
     - FuncTupleElementRef
     - ImageParam
     - InlineReductions
     - IROperator
     - LoopLevel
+    - Outputs
     - OutputImageParam
     - RDom
     - RVar


### PR DESCRIPTION
- Note that this implements ~all of the public Func methods but leaves them largely untested
- Things that seemed inappropriate for a Python API (e.g. custom malloc handlers) were omitted and noted
- A few things that override runtime functionality were deliberately left out for now (e.g. custom error handler), even though the implementation is simple, mainly because I want us to think a bit more about whether 'runtime' functions in Python need to be handled specially.