### PR TITLE
Minor Module API cleanup

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -426,7 +426,7 @@ void Module::compile(const Outputs &output_files_arg) const {
     }
 }
 
-Outputs compile_standalone_runtime(const Outputs &output_files, Target t) {
+Outputs compile_standalone_runtime(const Outputs &output_files, const Target &t) {
     Module empty("standalone_runtime", t.without_feature(Target::NoRuntime).without_feature(Target::JIT));
     // For runtime, it only makes sense to output object files or static_library, so ignore
     // everything else.
@@ -435,9 +435,7 @@ Outputs compile_standalone_runtime(const Outputs &output_files, Target t) {
     return actual_outputs;
 }
 
-void compile_standalone_runtime(const std::string &object_filename, Target t) {
-    compile_standalone_runtime(Outputs().object(object_filename), t);
-}
+namespace Internal {
 
 void compile_multitarget(const std::string &fn_name,
                          const Outputs &output_files,
@@ -640,5 +638,7 @@ void compile_multitarget(const std::string &fn_name,
         create_static_library(temp_dir.files(), base_target, output_files.static_library_name);
     }
 }
+
+}  // namespace Internal
 
 }  // namespace Halide

--- a/src/Module.h
+++ b/src/Module.h
@@ -146,24 +146,23 @@ public:
 /** Link a set of modules together into one module. */
 Module link_modules(const std::string &name, const std::vector<Module> &modules);
 
-/** Create an object file containing the Halide runtime for a given
- * target. For use with Target::NoRuntime. */
-void compile_standalone_runtime(const std::string &object_filename, Target t);
-
 /** Create an object and/or static library file containing the Halide runtime for a given
  * target. For use with Target::NoRuntime. Return an Outputs with just the actual
  * outputs filled in (typically, object_name and/or static_library_name).
  */
-Outputs compile_standalone_runtime(const Outputs &output_files, Target t);
+Outputs compile_standalone_runtime(const Outputs &output_files, const Target &t);
 
-typedef std::function<Module(const std::string &, const Target &)> ModuleProducer;
+namespace Internal {
+
+using ModuleProducer = std::function<Module(const std::string &, const Target &)>;
 
 void compile_multitarget(const std::string &fn_name,
                          const Outputs &output_files,
                          const std::vector<Target> &targets,
                          ModuleProducer module_producer,
                          const std::map<std::string, std::string> &suffixes = {});
+}  // namespace Internal
 
-}
+}  // namespace Halide
 
 #endif

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -2112,7 +2112,7 @@ int main(int argc, char **argv) {
     bool success = test.test_all();
 
     // Compile a runtime for this target, for use in the static test.
-    compile_standalone_runtime(test.output_directory + "simd_op_check_runtime.o", test.target);
+    compile_standalone_runtime(Outputs().object(test.output_directory + "simd_op_check_runtime.o"), test.target);
 
     if (!success) {
         return -1;


### PR DESCRIPTION
- Remove the non-Outputs wrapper of compile_standalone_runtime(); it's used in exactly one place and doesn't pay for itself.
- Move compile_multitarget() to Internal; it's a weird API that isn't currently used externally and needs some thought if we want to expose it, so let's declare it Internal for now. (Not that this will keep anyone from using it, but at least we can say they weren't warned.)

Of course, this still leaves Module in the somewhat unsatisfying state of being a 'public' API class that exposes a non-public class (Internal::LoweredFunc) as part of its public API. Not sure of a simple fix for that.