### PR TITLE
Move LinkageType into public Halide namespace

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1445,7 +1445,7 @@ void CodeGen_C::compile(const Module &input) {
         ExternCallPrototypes e;
         for (const auto &f : input.functions()) {
             f.body.accept(&e);
-            if (f.linkage == LoweredFunc::Internal) {
+            if (f.linkage == LinkageType::Internal) {
                 // We can't tell at the call site if a LoweredFunc is intended to be internal
                 // or not, so mark them explicitly.
                 e.set_internal_linkage(f.name);
@@ -1473,7 +1473,7 @@ void CodeGen_C::compile(const Module &input) {
 
 void CodeGen_C::compile(const LoweredFunc &f) {
     // Don't put non-external function declarations in headers.
-    if (is_header() && f.linkage == LoweredFunc::Internal) {
+    if (is_header() && f.linkage == LinkageType::Internal) {
         return;
     }
 
@@ -1508,7 +1508,7 @@ void CodeGen_C::compile(const LoweredFunc &f) {
     }
 
     // Emit the function prototype
-    if (f.linkage == LoweredFunc::Internal) {
+    if (f.linkage == LinkageType::Internal) {
         // If the function isn't public, mark it static.
         stream << "static ";
     }
@@ -1562,7 +1562,7 @@ void CodeGen_C::compile(const LoweredFunc &f) {
         stream << "}\n";
     }
 
-    if (is_header() && f.linkage == LoweredFunc::ExternalPlusMetadata) {
+    if (is_header() && f.linkage == LinkageType::ExternalPlusMetadata) {
         // Emit the argv version
         stream << "int " << simple_name << "_argv(void **args) HALIDE_FUNCTION_ATTRS;\n";
 
@@ -1578,7 +1578,7 @@ void CodeGen_C::compile(const LoweredFunc &f) {
         stream << "\n";
     }
 
-    if (is_header() && f.linkage == LoweredFunc::ExternalPlusMetadata) {
+    if (is_header() && f.linkage == LinkageType::ExternalPlusMetadata) {
         // C syntax for function-that-returns-function-pointer is fun.
         const string getter = R"INLINE_CODE(
 
@@ -2637,7 +2637,7 @@ void CodeGen_C::test() {
     s = LetStmt::make("buf", Call::make(Handle(), Call::buffer_get_host, {buf}, Call::Extern), s);
 
     Module m("", get_host_target());
-    m.append(LoweredFunc("test1", args, s, LoweredFunc::External));
+    m.append(LoweredFunc("test1", args, s, LinkageType::External));
 
     ostringstream source;
     {

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -134,15 +134,15 @@ using std::stack;
 namespace {
 
 // Get the LLVM linkage corresponding to a Halide linkage type.
-llvm::GlobalValue::LinkageTypes llvm_linkage(LoweredFunc::LinkageType t) {
+llvm::GlobalValue::LinkageTypes llvm_linkage(LinkageType t) {
     // TODO(dsharlet): For some reason, marking internal functions as
     // private linkage on OSX is causing some of the static tests to
     // fail. Figure out why so we can remove this.
     return llvm::GlobalValue::ExternalLinkage;
 
     switch (t) {
-    case LoweredFunc::ExternalPlusMetadata:
-    case LoweredFunc::External:
+    case LinkageType::ExternalPlusMetadata:
+    case LinkageType::External:
         return llvm::GlobalValue::ExternalLinkage;
     default:
         return llvm::GlobalValue::PrivateLinkage;
@@ -447,7 +447,7 @@ struct MangledNames {
 };
 
 MangledNames get_mangled_names(const std::string &name,
-                               LoweredFunc::LinkageType linkage,
+                               LinkageType linkage,
                                NameMangling mangling,
                                const std::vector<LoweredArgument> &args,
                                const Target &target) {
@@ -458,7 +458,7 @@ MangledNames get_mangled_names(const std::string &name,
     names.argv_name = names.simple_name + "_argv";
     names.metadata_name = names.simple_name + "_metadata";
 
-    if (linkage != LoweredFunc::Internal &&
+    if (linkage != LinkageType::Internal &&
         ((mangling == NameMangling::Default &&
           target.has_feature(Target::CPlusPlusMangling)) ||
          mangling == NameMangling::CPlusPlus)) {
@@ -540,7 +540,7 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
 
         // If the Func is externally visible, also create the argv wrapper and metadata.
         // (useful for calling from JIT and other machine interfaces).
-        if (f.linkage == LoweredFunc::ExternalPlusMetadata) {
+        if (f.linkage == LinkageType::ExternalPlusMetadata) {
             llvm::Function *wrapper = add_argv_wrapper(names.argv_name);
             llvm::Function *metadata_getter = embed_metadata_getter(names.metadata_name,
                 names.simple_name, f.args, input.get_metadata_name_map());
@@ -567,7 +567,7 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
 }
 
 
-void CodeGen_LLVM::begin_func(LoweredFunc::LinkageType linkage, const std::string& name,
+void CodeGen_LLVM::begin_func(LinkageType linkage, const std::string& name,
                               const std::string& extern_name, const std::vector<LoweredArgument>& args) {
     current_function_args = args;
 
@@ -677,7 +677,7 @@ void CodeGen_LLVM::compile_func(const LoweredFunc &f, const std::string &simple_
 
     // If building with MSAN, ensure that calls to halide_msan_annotate_buffer_is_initialized()
     // happen for every output buffer if the function succeeds.
-    if (f.linkage != LoweredFunc::Internal &&
+    if (f.linkage != LinkageType::Internal &&
         target.has_feature(Target::MSAN)) {
         llvm::Function *annotate_buffer_fn =
             module->getFunction("halide_msan_annotate_buffer_is_initialized_as_destructor");
@@ -2549,7 +2549,7 @@ void CodeGen_LLVM::visit(const Call *op) {
             llvm::Function *sub_fn = module->getFunction(sub_fn_name);
             if (!sub_fn) {
                 extern_sub_fn_name = get_mangled_names(sub_fn_name,
-                                                       LoweredFunc::External,
+                                                       LinkageType::External,
                                                        NameMangling::Default,
                                                        current_function_args,
                                                        get_target()).extern_name;

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -86,7 +86,7 @@ protected:
      * call to end_func with the same arguments, to generate the
      * appropriate cleanup code. */
     // @{
-    virtual void begin_func(LoweredFunc::LinkageType linkage, const std::string &simple_name,
+    virtual void begin_func(LinkageType linkage, const std::string &simple_name,
                             const std::string &extern_name, const std::vector<LoweredArgument> &args);
     virtual void end_func(const std::vector<LoweredArgument> &args);
     // @}

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1362,7 +1362,7 @@ Pipeline GeneratorBase::get_pipeline() {
 }
 
 Module GeneratorBase::build_module(const std::string &function_name,
-                                   const LoweredFunc::LinkageType linkage_type) {
+                                   const LinkageType linkage_type) {
     std::string auto_schedule_result;
     Pipeline pipeline = build_pipeline();
     if (get_auto_schedule()) {

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2601,7 +2601,7 @@ public:
     // Call build() and produce a Module for the result.
     // If function_name is empty, generator_name() will be used for the function.
     Module build_module(const std::string &function_name = "",
-                        const LoweredFunc::LinkageType linkage_type = LoweredFunc::ExternalPlusMetadata);
+                        const LinkageType linkage_type = LinkageType::ExternalPlusMetadata);
 
     /**
      * set_inputs is a variadic wrapper around set_inputs_vector, which makes usage much simpler

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -794,7 +794,7 @@ class InjectHexagonRpc : public IRMutator2 {
             }
             args.push_back(arg);
         }
-        device_code.append(LoweredFunc(hex_name, args, body, LoweredFunc::ExternalPlusMetadata));
+        device_code.append(LoweredFunc(hex_name, args, body, LinkageType::ExternalPlusMetadata));
 
         // Generate a call to hexagon_device_run.
         std::vector<Expr> arg_sizes;

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -269,15 +269,15 @@ ostream &operator <<(ostream &stream, const LoweredFunc &function) {
 }
 
 
-std::ostream &operator<<(std::ostream &stream, const LoweredFunc::LinkageType &type) {
+std::ostream &operator<<(std::ostream &stream, const LinkageType &type) {
     switch (type) {
-    case LoweredFunc::ExternalPlusMetadata:
+    case LinkageType::ExternalPlusMetadata:
         stream << "external_plus_metadata";
         break;
-    case LoweredFunc::External:
+    case LinkageType::External:
         stream << "external";
         break;
-    case LoweredFunc::Internal:
+    case LinkageType::Internal:
         stream << "internal";
         break;
     }

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -70,7 +70,7 @@ std::ostream &operator<<(std::ostream &stream, const NameMangling &);
 std::ostream &operator<<(std::ostream &stream, const LoweredFunc &);
 
 /** Emit a halide linkage value in a human readable format */
-std::ostream &operator<<(std::ostream &stream, const LoweredFunc::LinkageType &);
+std::ostream &operator<<(std::ostream &stream, const LinkageType &);
 
 /** An IRVisitor that emits IR to the given output stream in a human
  * readable form. Can be subclassed if you want to modify the way in

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -74,7 +74,7 @@ using std::vector;
 using std::map;
 
 Module lower(const vector<Function> &output_funcs, const string &pipeline_name, const Target &t,
-             const vector<Argument> &args, const Internal::LoweredFunc::LinkageType linkage_type,
+             const vector<Argument> &args, const LinkageType linkage_type,
              const vector<IRMutator2 *> &custom_passes) {
     std::vector<std::string> namespaces;
     std::string simple_pipeline_name = extract_namespaces(pipeline_name, namespaces);
@@ -449,7 +449,7 @@ Stmt lower_main_stmt(const std::vector<Function> &output_funcs, const std::strin
         }
     }
 
-    Module module = lower(output_funcs, pipeline_name, t, args, Internal::LoweredFunc::External, custom_passes);
+    Module module = lower(output_funcs, pipeline_name, t, args, LinkageType::External, custom_passes);
 
     return module.functions().front().body;
 }

--- a/src/Lower.h
+++ b/src/Lower.h
@@ -27,7 +27,7 @@ class IRMutator2;
  * Stmt. Multiple LoweredFuncs are added to support legacy buffer_t
  * calling convention. */
 Module lower(const std::vector<Function> &output_funcs, const std::string &pipeline_name, const Target &t,
-                    const std::vector<Argument> &args, const Internal::LoweredFunc::LinkageType linkage_type,
+                    const std::vector<Argument> &args, const LinkageType linkage_type,
                     const std::vector<IRMutator2 *> &custom_passes = std::vector<IRMutator2 *>());
 
 /** Given a halide function with a schedule, create a statement that

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -200,7 +200,7 @@ Internal::LoweredFunc Module::get_function_by_name(const std::string &name) cons
         }
     }
     user_error << "get_function_by_name: function " << name << " not found.\n";
-    return Internal::LoweredFunc("", std::vector<Argument>{}, {}, LoweredFunc::External);
+    return Internal::LoweredFunc("", std::vector<Argument>{}, {}, LinkageType::External);
 }
 
 void Module::append(const Buffer<> &buffer) {
@@ -605,7 +605,7 @@ void compile_multitarget(const std::string &fn_name,
         }
 
         Module wrapper_module(fn_name, wrapper_target);
-        wrapper_module.append(LoweredFunc(fn_name, base_target_args, wrapper_body, LoweredFunc::ExternalPlusMetadata));
+        wrapper_module.append(LoweredFunc(fn_name, base_target_args, wrapper_body, LinkageType::ExternalPlusMetadata));
 
         // Add a wrapper to accept old buffer_ts
         add_legacy_wrapper(wrapper_module, wrapper_module.functions().back());
@@ -620,7 +620,7 @@ void compile_multitarget(const std::string &fn_name,
 
     if (!output_files.c_header_name.empty()) {
         Module header_module(fn_name, base_target);
-        header_module.append(LoweredFunc(fn_name, base_target_args, {}, LoweredFunc::ExternalPlusMetadata));
+        header_module.append(LoweredFunc(fn_name, base_target_args, {}, LinkageType::ExternalPlusMetadata));
         // Add a wrapper to accept old buffer_ts
         add_legacy_wrapper(header_module, header_module.functions().back());
         Outputs header_out = Outputs().c_header(output_files.c_header_name);

--- a/src/Module.h
+++ b/src/Module.h
@@ -17,7 +17,8 @@
 
 namespace Halide {
 
-/** Type of linkage a function can have. */
+/** Type of linkage a function in a lowered Halide module can have. 
+    Also controls whether auxiliary functions and metadata are generated. */
 enum class LinkageType {
     External, ///< Visible externally.
     ExternalPlusMetadata, ///< Visible externally. Argument metadata and an argv wrapper are also generated.

--- a/src/Module.h
+++ b/src/Module.h
@@ -16,6 +16,14 @@
 #include "Target.h"
 
 namespace Halide {
+
+/** Type of linkage a function can have. */
+enum class LinkageType {
+    External, ///< Visible externally.
+    ExternalPlusMetadata, ///< Visible externally. Argument metadata and an argv wrapper are also generated.
+    Internal, ///< Not visible externally, similar to 'static' linkage in C.
+};
+
 namespace Internal {
 
 /** Definition of an argument to a LoweredFunc. This is similar to
@@ -45,13 +53,6 @@ struct LoweredFunc {
 
     /** Body of this function. */
     Stmt body;
-
-    /** Type of linkage a function can have. */
-    enum LinkageType {
-        External, ///< Visible externally.
-        ExternalPlusMetadata, ///< Visible externally. Argument metadata and an argv wrapper are also generated.
-        Internal, ///< Not visible externally, similar to 'static' linkage in C.
-    };
 
     /** The linkage of this function. */
     LinkageType linkage;

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -323,7 +323,7 @@ vector<Argument> Pipeline::infer_arguments() {
 Module Pipeline::compile_to_module(const vector<Argument> &args,
                                    const string &fn_name,
                                    const Target &target,
-                                   const Internal::LoweredFunc::LinkageType linkage_type) {
+                                   const LinkageType linkage_type) {
     user_assert(defined()) << "Can't compile undefined Pipeline.\n";
 
     for (Function f : contents->outputs) {

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -201,7 +201,7 @@ public:
     Module compile_to_module(const std::vector<Argument> &args,
                              const std::string &fn_name,
                              const Target &target = get_target_from_environment(),
-                             const Internal::LoweredFunc::LinkageType linkage_type = Internal::LoweredFunc::ExternalPlusMetadata);
+                             const LinkageType linkage_type = LinkageType::ExternalPlusMetadata);
 
    /** Eagerly jit compile the function to machine code. This
      * normally happens on the first call to realize. If you're

--- a/src/WrapExternStages.cpp
+++ b/src/WrapExternStages.cpp
@@ -111,7 +111,7 @@ class WrapExternStages : public IRMutator2 {
 
         // Add the wrapper to the module
         debug(2) << "Wrapped extern call to " << op->name << ":\n" << body << "\n\n";
-        LoweredFunc wrapper(wrapper_name, args, body, LoweredFunc::Internal, NameMangling::C);
+        LoweredFunc wrapper(wrapper_name, args, body, LinkageType::Internal, NameMangling::C);
         module.append(wrapper);
 
         // Return the name
@@ -240,7 +240,7 @@ void add_legacy_wrapper(Module module, const LoweredFunc &fn) {
 
     // Add the wrapper to the module.
     debug(2) << "Added legacy wrapper for " << fn.name << ":\n" << body << "\n\n";
-    LoweredFunc wrapper(name, args, body, LoweredFunc::External, NameMangling::Default);
+    LoweredFunc wrapper(name, args, body, LinkageType::External, NameMangling::Default);
     module.append(wrapper);
 }
 


### PR DESCRIPTION
Since it's necessary for a public API (Pipeline::compile_to_module), it should be in a public namespace rather than Internal.