### PR TITLE
GeneratorParam<int8|uint8> should be parsed as ints, not chars

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1815,6 +1815,10 @@ void generator_test() {
             GeneratorParam<uint64_t> gp2{"gp2", 2};
             GeneratorParam<uint8_t> gp_uint8{"gp_uint8", 65};
             GeneratorParam<int8_t> gp_int8{"gp_int8", 66};
+            GeneratorParam<char> gp_char{"gp_char", 97};
+            GeneratorParam<signed char> gp_schar{"gp_schar", 98};
+            GeneratorParam<unsigned char> gp_uchar{"gp_uchar", 99};
+            GeneratorParam<bool> gp_bool{"gp_bool", true};
 
             Input<int> input{"input"};
 
@@ -1824,6 +1828,10 @@ void generator_test() {
                 internal_assert(gp2 == (uint64_t) 2);  // unchanged
                 internal_assert(gp_uint8 == 67);
                 internal_assert(gp_int8 == 68);
+                internal_assert(gp_bool == false);
+                internal_assert(gp_char == 107);
+                internal_assert(gp_schar == 108);
+                internal_assert(gp_uchar == 109);
                 Var x;
                 Func output;
                 output(x) = input + gp0;
@@ -1848,9 +1856,13 @@ void generator_test() {
         // Also ok to call in this phase.
         tester.gp1.set(2.f);
 
-        // Verify that 8-bit GP values are parsed as integers, not chars.
+        // Verify that 8-bit non-boolean GP values are parsed as integers, not chars.
         tester.gp_int8.set_from_string("68");
         tester.gp_uint8.set_from_string("67");
+        tester.gp_char.set_from_string("107");
+        tester.gp_schar.set_from_string("108");
+        tester.gp_uchar.set_from_string("109");
+        tester.gp_bool.set_from_string("false");
 
         tester.build_pipeline();
         internal_assert(tester.phase == GeneratorBase::ScheduleCalled);

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1813,6 +1813,8 @@ void generator_test() {
             GeneratorParam<int> gp0{"gp0", 0};
             GeneratorParam<float> gp1{"gp1", 1.f};
             GeneratorParam<uint64_t> gp2{"gp2", 2};
+            GeneratorParam<uint8_t> gp_uint8{"gp_uint8", 65};
+            GeneratorParam<int8_t> gp_int8{"gp_int8", 66};
 
             Input<int> input{"input"};
 
@@ -1820,6 +1822,8 @@ void generator_test() {
                 internal_assert(gp0 == 1);
                 internal_assert(gp1 == 2.f);
                 internal_assert(gp2 == (uint64_t) 2);  // unchanged
+                internal_assert(gp_uint8 == 67);
+                internal_assert(gp_int8 == 68);
                 Var x;
                 Func output;
                 output(x) = input + gp0;
@@ -1843,6 +1847,10 @@ void generator_test() {
 
         // Also ok to call in this phase.
         tester.gp1.set(2.f);
+
+        // Verify that 8-bit GP values are parsed as integers, not chars.
+        tester.gp_int8.set_from_string("68");
+        tester.gp_uint8.set_from_string("67");
 
         tester.build_pipeline();
         internal_assert(tester.phase == GeneratorBase::ScheduleCalled);

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -675,7 +675,14 @@ public:
     void set_from_string(const std::string &new_value_string) override {
         std::istringstream iss(new_value_string);
         T t;
-        iss >> t;
+        // int8 and uint8 should be parsed as integers, not chars.
+        if (sizeof(T) == sizeof(char)) {
+            int i;
+            iss >> i;
+            t = (T) i;
+        } else {
+            iss >> t;
+        }
         user_assert(!iss.fail() && iss.get() == EOF) << "Unable to parse: " << new_value_string;
         this->set(t);
     }

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -675,8 +675,10 @@ public:
     void set_from_string(const std::string &new_value_string) override {
         std::istringstream iss(new_value_string);
         T t;
-        // int8 and uint8 should be parsed as integers, not chars.
-        if (sizeof(T) == sizeof(char)) {
+        // All one-byte ints int8 and uint8 should be parsed as integers, not chars --
+        // including 'char' itself. (Note that sizeof(bool) is often-but-not-always-1,
+        // so be sure to exclude that case.)
+        if (sizeof(T) == sizeof(char) && !std::is_same<T, bool>::value) {
             int i;
             iss >> i;
             t = (T) i;


### PR DESCRIPTION
Setting these from a Build/Make file parsed the input string as a single char, not int, leading to amusing failures.