### PR TITLE
Disable Warning C4800 in MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,7 @@ else()
   add_compile_options(/wd4018)  # disable "signed/unsigned mismatch"
   add_compile_options(/wd4503)  # disable "decorated name length exceeded, name was truncated"
   add_compile_options(/wd4267)  # disable "conversion from 'size_t' to 'int', possible loss of data"
+  add_compile_options(/wd4800)  # forcing value to bool 'true' or 'false' (performance warning)
   if (WARNINGS_AS_ERRORS)
     add_compile_options(/WX)
   endif()


### PR DESCRIPTION
This is the infamous "forcing value to bool 'true' or 'false' (performance warning)" oddness.

This warning is no longer emitted by VC2017, so by leaving it in, we're getting warnings (-as-errors) that only repeat in VC2015. Even in VC2015, it's basically a giant pile of low-information noise that only causes weird Windows-specific breakages.

See https://developercommunity.visualstudio.com/content/problem/78259/visual-studio-2017-no-longer-generates-a-c4800-war.html for more info.