### PR TITLE
Add support for array-of-Buffer in Input<> and Output<>

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1161,7 +1161,6 @@ $(FILTERS_DIR)/alias_with_offset_42.a: $(BIN_DIR)/alias.generator
 
 METADATA_TESTER_GENERATOR_ARGS=\
 	input.type=uint8 input.dim=3 \
-	type_only_input_buffer.dim=3 \
 	dim_only_input_buffer.type=uint8 \
 	untyped_input_buffer.type=uint8 untyped_input_buffer.dim=3 \
 	output.type=float32,float32 output.dim=3 \
@@ -1173,6 +1172,18 @@ METADATA_TESTER_GENERATOR_ARGS=\
 	array_i16.size=2 \
 	array_i32.size=2 \
 	array_h.size=2 \
+	buffer_array_input2.dim=3 \
+	buffer_array_input3.type=float32 \
+	buffer_array_input4.dim=3 \
+	buffer_array_input4.type=float32 \
+	buffer_array_input5.size=2 \
+	buffer_array_input6.size=2 \
+	buffer_array_input6.dim=3 \
+	buffer_array_input7.size=2 \
+	buffer_array_input7.type=float32 \
+	buffer_array_input8.size=2 \
+	buffer_array_input8.dim=3 \
+	buffer_array_input8.type=float32 \
 	array_outputs.size=2 \
 	array_outputs7.size=2 \
 	array_outputs8.size=2 \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ UNAME = $(shell uname)
 
 ifeq ($(OS), Windows_NT)
     # assume we are building for the MinGW environment
-    COMMON_LD_FLAGS=-luuid -lole32 -lpthread -lz
+    COMMON_LD_FLAGS=-luuid -lole32 -lpthread -lz, -Wl,--stack,8388608
     SHARED_EXT=dll
     FPIC=
 else

--- a/Makefile
+++ b/Makefile
@@ -1173,7 +1173,10 @@ METADATA_TESTER_GENERATOR_ARGS=\
 	array_i16.size=2 \
 	array_i32.size=2 \
 	array_h.size=2 \
-	array_outputs.size=2
+	array_outputs.size=2 \
+	array_outputs7.size=2 \
+	array_outputs8.size=2 \
+	array_outputs9.size=2
 
 # metadata_tester is built with and without user-context
 $(FILTERS_DIR)/metadata_tester.a: $(BIN_DIR)/metadata_tester.generator

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ UNAME = $(shell uname)
 
 ifeq ($(OS), Windows_NT)
     # assume we are building for the MinGW environment
-    COMMON_LD_FLAGS=-luuid -lole32 -lpthread -lz, -Wl,--stack,8388608
+    COMMON_LD_FLAGS=-luuid -lole32 -lpthread -lz -Wl,--stack,8388608
     SHARED_EXT=dll
     FPIC=
 else

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -425,9 +425,12 @@ void StubEmitter::emit() {
     for (auto output : outputs) {
         std::string c_type = output->get_c_type();
         std::string getter;
-        if (output->is_array()) getter = "get_array_output";
-        else if (c_type == "Func") getter = "get_output";
-        else getter = "get_output_buffer<" + c_type + ">";
+        const bool is_func = (c_type == "Func");
+        if (output->is_array()) {
+            getter = is_func ? "get_array_output" : "get_array_output_buffer<" + c_type + ">";
+        } else {
+            getter = is_func ? "get_output" : "get_output_buffer<" + c_type + ">";
+        }
         out_info.push_back({
             output->name(),
             output->is_array() ? "std::vector<" + c_type + ">" : c_type,
@@ -1233,9 +1236,11 @@ void GeneratorBase::track_parameter_values(bool include_outputs) {
     ParamInfo &pi = param_info();
     for (auto input : pi.filter_inputs) {
         if (input->kind() == IOKind::Buffer) {
-            Parameter p = input->parameter();
-            // This must use p.name(), *not* input->name()
-            get_value_tracker()->track_values(p.name(), parameter_constraints(p));
+            internal_assert(!input->parameters_.empty());
+            for (auto &p : input->parameters_) {
+                // This must use p.name(), *not* input->name()
+                get_value_tracker()->track_values(p.name(), parameter_constraints(p));
+            }
         }
     }
     if (include_outputs) {
@@ -1612,7 +1617,7 @@ void GeneratorInputBase::set_def_min_max() {
 }
 
 Parameter GeneratorInputBase::parameter() const {
-    internal_assert(parameters_.size() == 1);
+    user_assert(!this->is_array()) << "Cannot call the parameter() on Input<[]> " << name() << "; use an explicit subscript operator instead.";
     return parameters_.at(0);
 }
 
@@ -1625,9 +1630,12 @@ void GeneratorInputBase::verify_internals() const {
 }
 
 void GeneratorInputBase::init_internals() {
-    user_assert(array_size_defined()) << "ArraySize is not defined for Input " << name() << "; you may need to specify a GeneratorParam.\n";
-    user_assert(types_defined()) << "Type is not defined for Input " << name() << "; you may need to specify a GeneratorParam.\n";
-    user_assert(dims_defined()) << "Dimensions is not defined for Input " << name() << "; you may need to specify a GeneratorParam.\n";
+    user_assert(array_size_defined()) << "ArraySize is not defined for Input "
+        << name() << "; you may need to specify '" << name() << ".size' as a GeneratorParam.\n";
+    user_assert(types_defined()) << "Type is not defined for Input "
+        << name() << "; you may need to specify '" << name() << ".type' as a GeneratorParam.\n";
+    user_assert(dims_defined()) << "Dimensions are not defined for Input "
+        << name() << "; you may need to specify '" << name() << ".dim' as a GeneratorParam.\n";
 
     parameters_.clear();
     exprs_.clear();

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1617,7 +1617,7 @@ void GeneratorInputBase::set_def_min_max() {
 }
 
 Parameter GeneratorInputBase::parameter() const {
-    user_assert(!this->is_array()) << "Cannot call the parameter() on Input<[]> " << name() << "; use an explicit subscript operator instead.";
+    user_assert(!this->is_array()) << "Cannot call the parameter() method on Input<[]> " << name() << "; use an explicit subscript operator instead.";
     return parameters_.at(0);
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -308,7 +308,6 @@ if (WITH_TEST_GENERATOR)
   # Tests that require additional dependencies, args, etc
   set(MDTEST_GEN_ARGS
       input.type=uint8 input.dim=3
-      type_only_input_buffer.dim=3
       dim_only_input_buffer.type=uint8
       untyped_input_buffer.type=uint8 untyped_input_buffer.dim=3
       output.type=float32,float32 output.dim=3
@@ -320,6 +319,18 @@ if (WITH_TEST_GENERATOR)
       array_i16.size=2
       array_i32.size=2
       array_h.size=2
+      buffer_array_input2.dim=3
+      buffer_array_input3.type=float32
+      buffer_array_input4.dim=3
+      buffer_array_input4.type=float32
+      buffer_array_input5.size=2
+      buffer_array_input6.size=2
+      buffer_array_input6.dim=3
+      buffer_array_input7.size=2
+      buffer_array_input7.type=float32
+      buffer_array_input8.size=2
+      buffer_array_input8.dim=3
+      buffer_array_input8.type=float32
       array_outputs.size=2
       array_outputs7.size=2
       array_outputs8.size=2

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,9 +96,9 @@ if (WITH_TEST_GENERATOR)
 
     set(TARGET "generator_aot_${NAME}")
     add_executable("${TARGET}" "${GEN_TEST_DIR}/${NAME}_aottest.cpp")
-    target_include_directories("${TARGET}" PRIVATE 
-                               "${CMAKE_SOURCE_DIR}/tools" 
-                               "${CMAKE_SOURCE_DIR}" 
+    target_include_directories("${TARGET}" PRIVATE
+                               "${CMAKE_SOURCE_DIR}/tools"
+                               "${CMAKE_SOURCE_DIR}"
                                "${CMAKE_SOURCE_DIR}/src/runtime")
 
     if (NOT ${args_OMIT_DEFAULT_GENERATOR})
@@ -194,9 +194,9 @@ if (WITH_TEST_GENERATOR)
   #   set(TARGET )
 
   #   add_executable("generator_aot_${NAME}" "${GEN_TEST_DIR}/${FILE}")
-  #   target_include_directories("generator_aot_${NAME}" PRIVATE 
-  #                              "${CMAKE_SOURCE_DIR}" 
-  #                              "${CMAKE_SOURCE_DIR}/tools" 
+  #   target_include_directories("generator_aot_${NAME}" PRIVATE
+  #                              "${CMAKE_SOURCE_DIR}"
+  #                              "${CMAKE_SOURCE_DIR}/tools"
   #                              "${CMAKE_SOURCE_DIR}/src/runtime")
 
   #   if (NOT ${args_OMIT_DEFAULT_GENERATOR})
@@ -252,7 +252,7 @@ if (WITH_TEST_GENERATOR)
   halide_define_aot_test(user_context_insanity
                          HALIDE_TARGET_FEATURES user_context)
 
-  add_library(cxx_mangling_externs 
+  add_library(cxx_mangling_externs
               "${GEN_TEST_DIR}/cxx_mangling_externs.cpp")
 
   halide_define_aot_test(cxx_mangling
@@ -321,6 +321,9 @@ if (WITH_TEST_GENERATOR)
       array_i32.size=2
       array_h.size=2
       array_outputs.size=2
+      array_outputs7.size=2
+      array_outputs8.size=2
+      array_outputs9.size=2
   )
   halide_define_aot_test(metadata_tester
                          GENERATOR_ARGS "${MDTEST_GEN_ARGS}")
@@ -342,7 +345,7 @@ if (WITH_TEST_GENERATOR)
   halide_library_from_generator(blur2x2)
   target_link_libraries(generator_aot_tiled_blur PUBLIC blur2x2)
 
-  add_library(cxx_mangling_define_extern_externs 
+  add_library(cxx_mangling_define_extern_externs
               "${GEN_TEST_DIR}/cxx_mangling_define_extern_externs.cpp")
   target_link_libraries(cxx_mangling_define_extern_externs PUBLIC cxx_mangling_externs cxx_mangling)
 

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -757,6 +757,114 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           nullptr,
           nullptr,
           nullptr,
+        },
+        {
+          "array_outputs4_0",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "array_outputs4_1",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "array_outputs5_0",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "array_outputs5_1",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "array_outputs6_0",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "array_outputs6_1",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "array_outputs7_0",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "array_outputs7_1",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "array_outputs8_0",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "array_outputs8_1",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "array_outputs9_0",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "array_outputs9_1",
+          halide_argument_kind_output_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
         }
     };
     const int kExpectedArgumentCount = (int)sizeof(kExpectedArguments) / sizeof(kExpectedArguments[0]);
@@ -793,6 +901,12 @@ int main(int argc, char **argv) {
     Buffer<float> output_array[2] = {{kSize, kSize, 3}, {kSize, kSize, 3}};
     Buffer<float> output_array2[4] = {{kSize, kSize, 3}, {kSize, kSize, 3}, {kSize, kSize, 3}, {kSize, kSize, 3}};
     Buffer<float> output_array3[2] = {Buffer<float>{1}, Buffer<float>{1}};
+    Buffer<float> output_array4[2] = {{kSize, kSize, 3}, {kSize, kSize, 3}};
+    Buffer<float> output_array5[2] = {{kSize, kSize, 3}, {kSize, kSize, 3}};
+    Buffer<float> output_array6[2] = {{kSize, kSize, 3}, {kSize, kSize, 3}};
+    Buffer<float> output_array7[2] = {{kSize, kSize, 3}, {kSize, kSize, 3}};
+    Buffer<float> output_array8[2] = {{kSize, kSize, 3}, {kSize, kSize, 3}};
+    Buffer<float> output_array9[2] = {{kSize, kSize, 3}, {kSize, kSize, 3}};
 
     result = metadata_tester(
         input,             // Input<Func>
@@ -832,7 +946,13 @@ int main(int argc, char **argv) {
         output_scalar,     // Output<float>
         output_array[0], output_array[1],   // Output<Func[]>
         output_array2[0], output_array2[1], output_array2[2], output_array2[3], // Output<Func[2]>(Tuple)
-        output_array3[0], output_array3[1]  // Output<float[2]>
+        output_array3[0], output_array3[1],  // Output<float[2]>
+        output_array4[0], output_array4[1],  // Output<Buffer<float>[2]>
+        output_array5[0], output_array5[1],  // Output<Buffer<float>[2]>
+        output_array6[0], output_array6[1],  // Output<Buffer<float>[2]>
+        output_array7[0], output_array7[1],  // Output<Buffer<float>[2]>
+        output_array8[0], output_array8[1],  // Output<Buffer<float>[2]>
+        output_array9[0], output_array9[1]   // Output<Buffer<float>[2]>
     );
     EXPECT_EQ(0, result);
 
@@ -875,7 +995,13 @@ int main(int argc, char **argv) {
         output_scalar,     // Output<float>
         output_array[0], output_array[1],    // Output<Func[]>
         output_array2[0], output_array2[1], output_array2[2], output_array2[3], // Output<Func[2]>(Tuple)
-        output_array3[0], output_array3[1]  // Output<float[2]>
+        output_array3[0], output_array3[1],  // Output<float[2]>
+        output_array4[0], output_array4[1],  // Output<Buffer<float>[2]>
+        output_array5[0], output_array5[1],  // Output<Buffer<float>[2]>
+        output_array6[0], output_array6[1],  // Output<Buffer<float>[2]>
+        output_array7[0], output_array7[1],  // Output<Buffer<float>[2]>
+        output_array8[0], output_array8[1],  // Output<Buffer<float>[2]>
+        output_array9[0], output_array9[1]   // Output<Buffer<float>[2]>
     );
     EXPECT_EQ(0, result);
 

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -300,15 +300,6 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           nullptr,
         },
         {
-          "type_only_input_buffer",
-          halide_argument_kind_input_buffer,
-          3,
-          halide_type_t(halide_type_uint, 8),
-          nullptr,
-          nullptr,
-          nullptr,
-        },
-        {
           "dim_only_input_buffer",
           halide_argument_kind_input_buffer,
           3,
@@ -624,6 +615,150 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           nullptr,
         },
         {
+          "buffer_array_input1_0",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_array_input1_1",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_array_input2_0",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_array_input2_1",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_array_input3_0",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_array_input3_1",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_array_input4_0",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_array_input4_1",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_array_input5_0",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_array_input5_1",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_array_input6_0",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_array_input6_1",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_array_input7_0",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_array_input7_1",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_array_input8_0",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_array_input8_1",
+          halide_argument_kind_input_buffer,
+          3,
+          halide_type_t(halide_type_float, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
           "output.0",
           halide_argument_kind_output_buffer,
           3,
@@ -890,6 +1025,7 @@ int main(int argc, char **argv) {
     int result;
 
     Buffer<uint8_t> input = make_image<uint8_t>();
+    Buffer<float> input_array[2] = {make_image<float>(), make_image<float>()};
 
     Buffer<float> output0(kSize, kSize, 3);
     Buffer<float> output1(kSize, kSize, 3);
@@ -911,7 +1047,6 @@ int main(int argc, char **argv) {
     result = metadata_tester(
         input,             // Input<Func>
         input,             // Input<Buffer<uint8_t>>
-        input,             // Input<Buffer<>>(uint8)
         input,             // Input<Buffer<>>(3)
         input,             // Input<Buffer<>>
         false,             // Input<bool>
@@ -938,6 +1073,14 @@ int main(int argc, char **argv) {
         0, 0,              // Input<int32_t[]>
         0, 0,              // Input<int32_t[2]>
         nullptr, nullptr,  // Input<void*[]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
         output0, output1,  // Output<Tuple(Func, Func)>
         typed_output_buffer,    // Output<Buffer<float>>(3)
         type_only_output_buffer,    // Output<Buffer<float>>
@@ -960,7 +1103,6 @@ int main(int argc, char **argv) {
         user_context,
         input,             // Input<Func>
         input,             // Input<Buffer<uint8_t>>
-        input,             // Input<Buffer<>>(uint8)
         input,             // Input<Buffer<>>(3)
         input,             // Input<Buffer<>>
         false,             // Input<bool>
@@ -987,6 +1129,14 @@ int main(int argc, char **argv) {
         0, 0,              // Input<int32_t[]>
         0, 0,              // Input<int32_t[2]>
         nullptr, nullptr,  // Input<void*[]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_array[0], input_array[1],  // Input<Buffer<float>[2]>
         output0, output1,  // Output<Tuple(Func, Func)>
         typed_output_buffer,    // Output<Buffer<float>>(3)
         type_only_output_buffer,    // Output<Buffer<float>>

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -9,7 +9,6 @@ class MetadataTester : public Halide::Generator<MetadataTester> {
 public:
     Input<Func> input{ "input" };  // must be overridden to {UInt(8), 3}
     Input<Buffer<uint8_t>> typed_input_buffer{ "typed_input_buffer", 3 };
-    Input<Buffer<>> type_only_input_buffer{ "type_only_input_buffer", UInt(8) };  // must be overridden to dim=3
     Input<Buffer<>> dim_only_input_buffer{ "dim_only_input_buffer", 3 };  // must be overridden to type=UInt(8)
     Input<Buffer<>> untyped_input_buffer{ "untyped_input_buffer" };  // must be overridden to {UInt(8), 3}
     Input<bool> b{ "b", true };
@@ -39,6 +38,16 @@ public:
     Input<int32_t[2]> array2_i32{ "array2_i32", 32, -32, 127 };
     Input<void *[]> array_h{ "array_h", nullptr };  // must be overridden to size=2
 
+    Input<Buffer<float>[2]> buffer_array_input1{ "buffer_array_input1", 3 };
+    Input<Buffer<float>[2]> buffer_array_input2{ "buffer_array_input2" }; // buffer_array_input2.dim must be set
+    Input<Buffer<>[2]> buffer_array_input3{ "buffer_array_input3", 3 }; // buffer_array_input2.type must be set
+    Input<Buffer<>[2]> buffer_array_input4{ "buffer_array_input4" }; // dim and type must be set
+    // .size must be specified for all of these
+    Input<Buffer<float>[]> buffer_array_input5{ "buffer_array_input5", 3 };
+    Input<Buffer<float>[]> buffer_array_input6{ "buffer_array_input6" }; // buffer_array_input2.dim must be set
+    Input<Buffer<>[]> buffer_array_input7{ "buffer_array_input7", 3 }; // buffer_array_input2.type must be set
+    Input<Buffer<>[]> buffer_array_input8{ "buffer_array_input8" }; // dim and type must be set
+
     Output<Func> output{ "output" };  // must be overridden to {{Float(32), Float(32)}, 3}
     Output<Buffer<float>> typed_output_buffer{ "typed_output_buffer", 3 };
     Output<Buffer<float>> type_only_output_buffer{ "type_only_output_buffer" };  // untyped outputs can have type and/or dimensions inferred
@@ -65,11 +74,23 @@ public:
         Expr zero1 = array_input[1](x, y, c) - array_input[0](x, y, c);
         Expr zero2 = array_i32[1] - array_i32[0];
 
+        Expr bzero1 = buffer_array_input1[1](x, y, c) - buffer_array_input1[0](x, y, c);
+        Expr bzero2 = buffer_array_input2[1](x, y, c) - buffer_array_input2[0](x, y, c);
+        Expr bzero3 = buffer_array_input3[1](x, y, c) - buffer_array_input3[0](x, y, c);
+        Expr bzero4 = buffer_array_input4[1](x, y, c) - buffer_array_input4[0](x, y, c);
+        Expr bzero5 = buffer_array_input5[1](x, y, c) - buffer_array_input5[0](x, y, c);
+        Expr bzero6 = buffer_array_input6[1](x, y, c) - buffer_array_input6[0](x, y, c);
+        Expr bzero7 = buffer_array_input7[1](x, y, c) - buffer_array_input7[0](x, y, c);
+        Expr bzero8 = buffer_array_input8[1](x, y, c) - buffer_array_input8[0](x, y, c);
+
+
+        Expr zero = zero1 + zero2 + bzero1 + bzero2 + bzero3 + bzero4 + bzero5 + bzero6 + bzero7 + bzero8;
+
         assert(output.types().size() == 2);
         Type output_type = output.types().at(0);
 
         Func f1("f1"), f2("f2");
-        f1(x, y, c) = cast(output_type, input(x, y, c) + zero1 + zero2);
+        f1(x, y, c) = cast(output_type, input(x, y, c) + zero);
         f2(x, y, c) = cast<float>(f1(x, y, c) + 1);
 
         Func t1("t1");

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -49,6 +49,15 @@ public:
     Output<Func[2]> array_outputs2{ "array_outputs2", { Float(32), Float(32) }, 3 };
     Output<float[2]> array_outputs3{ "array_outputs3" };
 
+    Output<Buffer<float>[2]> array_outputs4{ "array_outputs4", 3 };
+    Output<Buffer<float>[2]> array_outputs5{ "array_outputs5" };  // dimensions will be inferred by usage
+    Output<Buffer<>[2]> array_outputs6{ "array_outputs6" };  // dimensions and type will be inferred by usage
+
+    // .size must be specified for all of these
+    Output<Buffer<float>[]> array_outputs7{ "array_outputs7", 3 };
+    Output<Buffer<float>[]> array_outputs8{ "array_outputs8" };
+    Output<Buffer<>[]> array_outputs9{ "array_outputs9" };
+
     void generate() {
         Var x, y, c;
 
@@ -80,6 +89,12 @@ public:
             array_outputs2[i] = z1;
             array_outputs3[i]() = 42.f;
 
+            array_outputs4[i](x, y, c) = cast<float>(x + y + c + (int) i);
+            array_outputs5[i](x, y, c) = cast<float>(x + y + c + (int) i);
+            array_outputs6[i](x, y, c) = cast<float>(x + y + c + (int) i);
+            array_outputs7[i](x, y, c) = cast<float>(x + y + c + (int) i);
+            array_outputs8[i](x, y, c) = cast<float>(x + y + c + (int) i);
+            array_outputs9[i](x, y, c) = cast<float>(x + y + c + (int) i);
 
             // Verify compute_with works for Output<Func>
             array_outputs2[i].compute_with(array_outputs[i], x);

--- a/test/generator/stubtest_aottest.cpp
+++ b/test/generator/stubtest_aottest.cpp
@@ -50,14 +50,18 @@ int main(int argc, char **argv) {
     Buffer<float> array_input1 = make_image<float>(1);
     Buffer<float> typed_buffer_output(kSize, kSize, 3);
     Buffer<float> untyped_buffer_output(kSize, kSize, 3);
+    Buffer<uint8_t> array_buffer_input0 = make_image<uint8_t>(0);
+    Buffer<uint8_t> array_buffer_input1 = make_image<uint8_t>(1);
     Buffer<float> simple_output(kSize, kSize, 3);
     Buffer<float> tuple_output0(kSize, kSize, 3), tuple_output1(kSize, kSize, 3);
     Buffer<int16_t> array_output0(kSize, kSize), array_output1(kSize, kSize);
     Buffer<uint8_t> static_compiled_buffer_output(kSize, kSize, 3);
+    Buffer<uint8_t> array_buffer_output0(kSize, kSize, 3), array_buffer_output1(kSize, kSize, 3);
 
     stubtest(
         buffer_input,
         buffer_input,
+        array_buffer_input0, array_buffer_input1,
         simple_input,
         array_input0, array_input1,
         1.25f,
@@ -68,7 +72,8 @@ int main(int argc, char **argv) {
         array_output0, array_output1,
         typed_buffer_output,
         untyped_buffer_output,
-        static_compiled_buffer_output
+        static_compiled_buffer_output,
+        array_buffer_output0, array_buffer_output1
     );
 
     verify(buffer_input, 1.f, 0, typed_buffer_output);
@@ -80,6 +85,8 @@ int main(int argc, char **argv) {
     verify(array_input0, 1.0f, 33, array_output0);
     verify(array_input1, 1.0f, 66, array_output1);
     verify(buffer_input, 1.0f, 42, static_compiled_buffer_output);
+    verify(array_buffer_input0, 1.f, 1, array_buffer_output0);
+    verify(array_buffer_input1, 1.f, 2, array_buffer_output1);
 
     printf("Success!\n");
     return 0;

--- a/test/generator/stubtest_generator.cpp
+++ b/test/generator/stubtest_generator.cpp
@@ -30,6 +30,7 @@ public:
 
     Input<Buffer<uint8_t>> typed_buffer_input{ "typed_buffer_input", 3 };
     Input<Buffer<>> untyped_buffer_input{ "untyped_buffer_input" };
+    Input<Buffer<uint8_t>[2]> array_buffer_input{ "array_buffer_input", 3 };
     Input<Func> simple_input{ "simple_input", 3 };  // require a 3-dimensional Func but leave Type unspecified
     Input<Func[]> array_input{ "array_input", 3 };  // require a 3-dimensional Func but leave Type and ArraySize unspecified
     // Note that Input<Func> does not (yet) support Tuples
@@ -42,6 +43,7 @@ public:
     Output<Buffer<float>> typed_buffer_output{ "typed_buffer_output" };
     Output<Buffer<>> untyped_buffer_output{ "untyped_buffer_output" };
     Output<Buffer<uint8_t>> static_compiled_buffer_output{ "static_compiled_buffer_output", 3 };
+    Output<Buffer<uint8_t>[2]> array_buffer_output{ "array_buffer_output", 3 };
 
     void generate() {
         simple_output(x, y, c) = cast<float>(simple_input(x, y, c));
@@ -51,6 +53,10 @@ public:
         // will end up as whatever we infer from the values put into it. We'll use an
         // explicit GeneratorParam to allow us to set it.
         untyped_buffer_output(x, y, c) = cast(untyped_buffer_output_type, untyped_buffer_input(x, y, c));
+
+        for (int i = 0; i < 2; ++i) {
+            array_buffer_output[i](x, y, c) = array_buffer_input[i](x, y,c) + 1 + i;
+        }
 
         // Gratuitous intermediate for the purpose of exercising
         // GeneratorParam<LoopLevel>

--- a/test/generator/stubtest_jittest.cpp
+++ b/test/generator/stubtest_jittest.cpp
@@ -69,6 +69,7 @@ int main(int argc, char **argv) {
         {
             buffer_input,  // typed_buffer_input
             buffer_input,  // untyped_buffer_input
+            { buffer_input, buffer_input },
             Func(simple_input),
             { Func(array_input[0]), Func(array_input[1]) },
             1.25f,
@@ -105,6 +106,12 @@ int main(int argc, char **argv) {
     Realization static_compiled_buffer_output_realized = gen.static_compiled_buffer_output.realize(kSize, kSize, 3);
     Buffer<uint8_t> b2 = static_compiled_buffer_output_realized;
     verify(buffer_input, 1.f, 42, b2);
+
+    for (int i = 0; i < 2; ++i) {
+        Realization array_buffer_output_realized = gen.array_buffer_output[i].realize(kSize, kSize, 3);
+        Buffer<uint8_t> b2 = array_buffer_output_realized;
+        verify(buffer_input, 1.f, 1 + i, b2);
+    }
 
     printf("Success!\n");
     return 0;

--- a/test/generator/stubuser_aottest.cpp
+++ b/test/generator/stubuser_aottest.cpp
@@ -52,11 +52,13 @@ int main(int argc, char **argv) {
   Buffer<uint8_t> calculated_output(kSize, kSize, 3);
   Buffer<float> float32_buffer_output(kSize, kSize, 3);
   Buffer<> int32_buffer_output(halide_type_t(halide_type_int, 32), kSize, kSize, 3);
+  Buffer<uint8_t> array_test_output(kSize, kSize, 3);
 
-  stubuser(input, calculated_output, float32_buffer_output, int32_buffer_output);
+  stubuser(input, calculated_output, float32_buffer_output, int32_buffer_output, array_test_output);
   verify(input, kFloatArg, kIntArg, kOffset, calculated_output);
   verify(input, 1.f, 0, 0.f, float32_buffer_output);
   verify<uint8_t, int32_t>(input, 1.f, 0, 0.f, int32_buffer_output);
+  verify(input, 1.f, 0, 2, array_test_output);
 
   printf("Success!\n");
   return 0;

--- a/test/generator/stubuser_generator.cpp
+++ b/test/generator/stubuser_generator.cpp
@@ -27,6 +27,7 @@ public:
     Output<Buffer<uint8_t>> calculated_output{"calculated_output" };
     Output<Buffer<float>> float32_buffer_output{"float32_buffer_output" };
     Output<Buffer<int32_t>> int32_buffer_output{"int32_buffer_output" };
+    Output<Buffer<uint8_t>> array_test_output{"array_test_output" };
 
     void generate() {
         Var x{"x"}, y{"y"}, c{"c"};
@@ -39,6 +40,7 @@ public:
         StubTest::Inputs inputs;
         inputs.typed_buffer_input = constant_image;
         inputs.untyped_buffer_input = input;
+        inputs.array_buffer_input = { input, input };
         inputs.simple_input = input;
         inputs.array_input = { input };
         inputs.float_arg = 1.234f;
@@ -57,6 +59,7 @@ public:
 
         float32_buffer_output = out.typed_buffer_output;
         int32_buffer_output = out.untyped_buffer_output;
+        array_test_output = out.array_buffer_output[1];
 
         const float kOffset = 2.f;
         calculated_output(x, y, c) = cast<uint8_t>(out.tuple_output(x, y, c)[1] + kOffset);


### PR DESCRIPTION
This had been unsupported in new-style Generators, mainly because it wasn't clear there was demand for it, so we never got around to implementing it; now it's clear there is demand for it, and support is pretty simple, so we're adding it.