### PR TITLE
Allow the Python module name to be customized via preprocessor

### DIFF
--- a/python_bindings/src/PyHalide.cpp
+++ b/python_bindings/src/PyHalide.cpp
@@ -24,7 +24,11 @@
 #include "PyType.h"
 #include "PyVar.h"
 
-PYBIND11_MODULE(halide, m) {
+#ifndef HALIDE_PYBIND_MODULE_NAME
+  #define HALIDE_PYBIND_MODULE_NAME halide
+#endif
+
+PYBIND11_MODULE(HALIDE_PYBIND_MODULE_NAME, m) {
     using namespace Halide::PythonBindings;
 
     // Order of definitions matters somewhat:


### PR DESCRIPTION
At least one downstream environment may want us to wrap Python .so files with a .py file; this allows us to rename the extension module at build time, to avoid module name collisions.