### PR TITLE
HalideTraceViz cleanup

### DIFF
--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -21,11 +21,15 @@ $(BIN)/viz/bilateral_grid.a: $(BIN)/bilateral_grid.generator
 $(BIN)/filter: $(BIN)/bilateral_grid.a $(BIN)/bilateral_grid_auto_schedule.a filter.cpp
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -O3 -ffast-math -Wall -Werror -I$(BIN) filter.cpp $(BIN)/bilateral_grid.a $(BIN)/bilateral_grid_auto_schedule.a -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
-$(BIN)/filter_viz: $(BIN)/viz/bilateral_grid.a filter.cpp
+
+$(BIN)/filter_viz: $(BIN)/viz/bilateral_grid.a filter.cpp ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -DNO_AUTO_SCHEDULE -O3 -ffast-math -Wall -Werror -I$(BIN)/viz filter.cpp $(BIN)/viz/bilateral_grid.a -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
 
-$(BIN)/bilateral_grid.mp4: $(BIN)/filter_viz viz.sh
+../../bin/HalideTraceViz: ../../util/HalideTraceViz.cpp
+	$(MAKE) -C ../../ bin/HalideTraceViz
+
+$(BIN)/bilateral_grid.mp4: $(BIN)/filter_viz viz.sh ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
 	bash viz.sh $(BIN)
 
@@ -37,3 +41,6 @@ clean:
 	rm -rf $(BIN)
 
 test: $(BIN)/out.png
+
+viz: $(BIN)/bilateral_grid.mp4
+	mplayer $^

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -29,7 +29,7 @@ $(BIN)/viz/process: process.cpp $(BIN)/viz/camera_pipe.a
 $(BIN)/out.png: $(BIN)/process
 	$(BIN)/process $(IMAGES)/bayer_raw.png 3700 2.0 50 1.0 $(TIMING_ITERATIONS) $@ $(BIN)/h_auto.png
 
-../../bin/HalideTraceViz:
+../../bin/HalideTraceViz: ../../util/HalideTraceViz.cpp
 	$(MAKE) -C ../../ bin/HalideTraceViz
 
 $(BIN)/camera_pipe.mp4: $(BIN)/viz/process viz.sh $(HALIDE_TRACE_VIZ) ../../bin/HalideTraceViz
@@ -39,3 +39,6 @@ clean:
 	rm -rf $(BIN)
 
 test: $(BIN)/out.png
+
+viz: $(BIN)/camera_pipe.mp4
+	mplayer $^

--- a/apps/camera_pipe/viz.sh
+++ b/apps/camera_pipe/viz.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-export HL_TRACE=3
 export HL_TRACE_FILE=/dev/stdout
 export HL_NUMTHREADS=4
-rm -f $1/camera_pipe.avi
+rm -f $1/camera_pipe.mp4
 $1/viz/process ../images/bayer_small.png 3700 1.8 50 1 $1/out.png |
 ../../bin/HalideTraceViz --timestep 1000 --size 1920 1080 \
 --strides 1 0 0 1 --gray --max 1024 \

--- a/apps/camera_pipe/viz.sh
+++ b/apps/camera_pipe/viz.sh
@@ -2,7 +2,7 @@
 export HL_TRACE_FILE=/dev/stdout
 export HL_NUMTHREADS=4
 rm -f $1/camera_pipe.mp4
-$1/viz/process ../images/bayer_small.png 3700 1.8 50 1 $1/out.png |
+$1/viz/process ../images/bayer_small.png 3700 1.8 50 1 1 $1/out.png |
 ../../bin/HalideTraceViz --timestep 1000 --size 1920 1080 \
 --strides 1 0 0 1 --gray --max 1024 \
 --move 10 348 --func input \

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -33,15 +33,17 @@ $(BIN)/process_viz: process.cpp $(BIN)/viz/local_laplacian.a
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -DNO_AUTO_SCHEDULE -I$(BIN)/viz -Wall -O3 $^ -o $@ $(LDFLAGS) $(IMAGE_IO_FLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS)
 
-../../bin/HalideTraceViz:
+../../bin/HalideTraceViz: ../../util/HalideTraceViz.cpp
 	$(MAKE) -C ../../ bin/HalideTraceViz
 
 $(BIN)/local_laplacian.mp4: $(BIN)/process_viz ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
-	bash viz.sh
+	bash viz.sh $(BIN)
 
 clean:
 	rm -rf $(BIN)
 
-
 test: $(BIN)/out.png
+
+viz: $(BIN)/local_laplacian.mp4
+	mplayer $^


### PR DESCRIPTION
- don't crash if a label's framecount is <= 0
- better parsing of int and float values for fast-failure, plus recognizing hex ints
- use std::vector<> instead of new[] for buffer allocations and for stride arrays
- printf -> iostream
- minor code style fixes
- add 'make viz' targets to the apps that use HalideTraceViz

Note to reviewers: camera_pipe.mp4 seems to be empty and useless (at least on my OSX machine) both before and after this PR, so something is amiss there. Since the brokenness seems unchanged, it should probably be investigated separately.