### PR TITLE
swap from CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,10 @@
 project(Halide)
 cmake_minimum_required(VERSION 3.2)
 
+set(HALIDE_BASE_DIR   "${CMAKE_CURRENT_SOURCE_DIR}")
+
 set(CPACK_PACKAGE_VENDOR "Halide")
-set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.txt")
+set(CPACK_RESOURCE_FILE_LICENSE "${HALIDE_BASE_DIR}/LICENSE.txt")
 set(CPACK_MONOLITHIC_INSTALL OFF)
 if (WIN32)
   set(CPACK_GENERATOR "ZIP")
@@ -186,8 +188,8 @@ function(halide_project name folder)
     endif()
   endif()
   target_link_libraries("${name}" PRIVATE Halide ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
-  target_include_directories("${name}" PRIVATE "${CMAKE_SOURCE_DIR}/src")
-  target_include_directories("${name}" PRIVATE "${CMAKE_SOURCE_DIR}/tools")
+  target_include_directories("${name}" PRIVATE "${HALIDE_BASE_DIR}/src")
+  target_include_directories("${name}" PRIVATE "${HALIDE_BASE_DIR}/tools")
   set_target_properties("${name}" PROPERTIES FOLDER "${folder}")
   if (MSVC)
     target_link_libraries("${name}" PRIVATE Kernel32)
@@ -241,7 +243,7 @@ endif()
 # For in-tree builds, we need to set the input variables for halide.cmake
 # to specific values, rather than relying on HALIDE_DISTRIB_DIR to be set correctly.
 set(HALIDE_INCLUDE_DIR "${CMAKE_BINARY_DIR}/include")
-set(HALIDE_TOOLS_DIR "${CMAKE_SOURCE_DIR}/tools")
+set(HALIDE_TOOLS_DIR "${HALIDE_BASE_DIR}/tools")
 set(HALIDE_COMPILER_LIB Halide)
 set(HALIDE_DISTRIB_DIR "/bad-path")
 include(halide.cmake)
@@ -314,7 +316,7 @@ function(add_test TARGET)
   get_target_property(TARGET_TYPE "${TARGET}" TYPE)
   if("${TARGET_TYPE}" STREQUAL "EXECUTABLE")
     if(${args_EXPECT_FAILURE})
-      set(COMMAND "${CMAKE_SOURCE_DIR}/test/common/expect_failure.sh" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TARGET}")
+      set(COMMAND "${HALIDE_BASE_DIR}/test/common/expect_failure.sh" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TARGET}")
     else()
       set(COMMAND "${TARGET}")
     endif()
@@ -380,7 +382,7 @@ find_package(Doxygen)
     message(FATAL_ERROR "Could not find Doxygen. Either install it or set WITH_DOCS to OFF")
   endif()
 
-  configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in ${CMAKE_BINARY_DIR}/Doxyfile @ONLY)
+  configure_file(${HALIDE_BASE_DIR}/Doxyfile.in ${CMAKE_BINARY_DIR}/Doxyfile @ONLY)
   # Note documentation is not built by default, the user needs to build the "doc" target
   add_custom_target(doc
     COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/Doxyfile
@@ -427,27 +429,27 @@ foreach(F mex_halide.m
           halide_image.h
           halide_image_io.h
           halide_image_info.h)
-  install(FILES "${CMAKE_SOURCE_DIR}/tools/${F}"
+  install(FILES "${HALIDE_BASE_DIR}/tools/${F}"
           DESTINATION tools)
 endforeach()
 
 # ---- README
-file(GLOB FILES "${CMAKE_SOURCE_DIR}/*.md")
+file(GLOB FILES "${HALIDE_BASE_DIR}/*.md")
 install(FILES ${FILES}
         DESTINATION .)
 
 # ---- Bazel
-file(GLOB FILES "${CMAKE_SOURCE_DIR}/bazel/*")
+file(GLOB FILES "${HALIDE_BASE_DIR}/bazel/*")
 install(FILES ${FILES}
         DESTINATION .)
 
 # ---- CMake
-file(GLOB FILES "${CMAKE_SOURCE_DIR}/*.cmake")
+file(GLOB FILES "${HALIDE_BASE_DIR}/*.cmake")
 install(FILES ${FILES}
         DESTINATION .)
 
 # ---- halide_config
-file(GLOB FILES "${CMAKE_SOURCE_DIR}/tools/halide_config.*.tpl")
+file(GLOB FILES "${HALIDE_BASE_DIR}/tools/halide_config.*.tpl")
 foreach(F ${FILES})
   get_filename_component(FNAME "${F}" NAME)  # Extract filename
   string(REGEX REPLACE "\\.tpl$" "" FNAME "${FNAME}")  # Strip .tpl extension

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories("${CMAKE_BINARY_DIR}/include")
-include_directories("${CMAKE_SOURCE_DIR}/tools")
+include_directories("${HALIDE_TOOLS_DIR}")
 
 if (MSVC)
     # Sample apps, so we can disable some of the more pedantic warnings


### PR DESCRIPTION
Tried adding Halide as a CMake subdirectory, 

```
add_subdirectory(thirdparty/Halide)
```
it ended up looking for files in the wrong places! It was using [${CMAKE_SOURCE_DIR}](https://cmake.org/cmake/help/latest/variable/CMAKE_SOURCE_DIR.html), which is the path to the top level of the current CMake source tree. 

It should be using [${CMAKE_CURRENT_SOURCE_DIR}](https://cmake.org/cmake/help/latest/variable/CMAKE_CURRENT_SOURCE_DIR.html) which is the directory containing the CMakeLists.txt thats currently being processed.
