### PR TITLE
Speed up IRGraphVisitor

### DIFF
--- a/src/IRVisitor.cpp
+++ b/src/IRVisitor.cpp
@@ -242,15 +242,17 @@ void IRVisitor::visit(const Shuffle *op) {
 }
 
 void IRGraphVisitor::include(const Expr &e) {
-    if (!visited.count(e.get())) {
-        visited.insert(e.get());
+    auto r = visited.insert(e.get());
+    if (r.second) {
+        // Was newly inserted
         e.accept(this);
     }
 }
 
 void IRGraphVisitor::include(const Stmt &s) {
-    if (!visited.count(s.get())) {
-        visited.insert(s.get());
+    auto r = visited.insert(s.get());
+    if (r.second) {
+        // Was newly inserted
         s.accept(this);
     }
 }


### PR DESCRIPTION
Don't call count(); instead, just call insert(), and check the function result see if the insertion was new. On an extremely gnarly case inside Google (where the set could get into hundreds-of-thousands) this shaved over 1% off of the entire pipeline compile time.

(Interestingly, moving from set to unordered_set didn't make any difference; it may be that an unordered_set using a carefully chosen hash function might be a further win.)