### PR TITLE
Various minor TraceViz code tweaks

### DIFF
--- a/apps/local_laplacian/viz.sh
+++ b/apps/local_laplacian/viz.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 export HL_TRACE_FILE=/dev/stdout
 export HL_NUM_THREADS=4
+rm -f bin/local_laplacian.mp4
 make bin/process_viz && \
 ./bin/process_viz ../images/rgb_small.png 4 1 1 0 ./bin/out_small.png | \
 ../../bin/HalideTraceViz \

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -794,11 +794,12 @@ int run(int argc, char **argv) {
         case halide_trace_end_produce:
         case halide_trace_consume:
         case halide_trace_end_consume:
-            break;
+        // Note that you can get nested pipeline begin/end events when you trace
+        // something that has extern stages that are also Halide-being-traced;
+        // these should just be ignored.
         case halide_trace_begin_pipeline:
         case halide_trace_end_pipeline:
-            std::cerr << "Misplaced tracing event: " << p.event << "\n";
-            exit(-1);
+            break;
         default:
             std::cerr << "Unknown tracing event code: " << p.event << "\n";
             exit(-1);

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -49,9 +49,23 @@ std::ostream &operator<<(std::ostream &stream, const vector<int> &v) {
     return stream;
 }
 
+std::ostream &operator<<(std::ostream &stream, const vector<pair<int, int>> &v) {
+    stream << "[ ";
+    bool need_comma = false;
+    for (auto &pt : v) {
+        if (need_comma) {
+            stream << ", ";
+        }
+        stream << "(" << pt.first << "," << pt.second << ")";
+        need_comma = true;
+    }
+    stream << " ]";
+    return stream;
+}
+
 // A struct specifying a text label that will appear on the screen at some point.
 struct Label {
-    const char *text;
+    string text;
     int x, y, n;
 };
 
@@ -62,14 +76,14 @@ struct FuncInfo {
 
     // Configuration for how the func should be drawn
     struct Config {
-        float zoom = 0;
+        float zoom = 1.f;
         int load_cost = 0;
-        int store_cost = 0;
-        int dims = 0;
+        int store_cost = 1;
+        int dims = 2;
         int x, y = 0;
-        vector<int> x_stride, y_stride;
-        int color_dim = 0;
-        float min = 0.0f, max = 0.0f;
+        vector<pair<int, int>> strides = { {1, 0}, {0, 1} };
+        int color_dim = -1;
+        float min = 0.f, max = 1.f;
         vector<Label> labels;
         bool blank_on_end_realization = false;
         uint32_t uninitialized_memory_color = 0xff000000;
@@ -85,8 +99,7 @@ struct FuncInfo {
                     " load cost: " << load_cost << "\n" <<
                     " store cost: " << store_cost << "\n" <<
                     " x: " << x << " y: " << y << "\n" <<
-                    " x_stride: " << x_stride << "\n" <<
-                    " y_stride: " << y_stride << "\n";
+                    " strides: " << strides << "\n";
         }
     } config;
 
@@ -184,18 +197,16 @@ void composite(uint8_t *a, uint8_t *b, uint8_t *dst) {
 static constexpr int FONT_W = 12;
 static constexpr int FONT_H = 32;
 
-void draw_text(const char *text, int x, int y, uint32_t color, uint32_t *dst, int dst_width, int dst_height) {
+void draw_text(const std::string &text, int x, int y, uint32_t color, uint32_t *dst, int dst_width, int dst_height) {
     // The font array contains 96 characters of FONT_W * FONT_H letters.
     assert(inconsolata_raw_len == 96 * FONT_W * FONT_H);
 
     // Drop any alpha component of color
     color &= 0xffffff;
 
-    for (int c = 0; ; c++) {
-        int chr = text[c];
-        if (chr == 0) {
-            return;
-        }
+    int c = -1;
+    for (int chr : text) {
+        ++c;
 
         // We only handle a subset of ascii
         if (chr < 32 || chr > 127) {
@@ -355,13 +366,15 @@ void fill_realization(uint32_t *image, int image_width, int image_height, uint32
     } else {
         int min = p.get_coord(current_dimension * 2 + 0);
         int extent = p.get_coord(current_dimension * 2 + 1);
-        x_off += fi.config.x_stride[current_dimension] * min;
-        y_off += fi.config.y_stride[current_dimension] * min;
+        const auto &pt = fi.config.strides[current_dimension];
+        x_off += pt.first * min;
+        y_off += pt.second * min;
         for (int i = min; i < min + extent; i++) {
             fill_realization(image, image_width, image_height, color, fi, p,
                 current_dimension + 1, x_off, y_off);
-            x_off += fi.config.x_stride[current_dimension];
-            y_off += fi.config.y_stride[current_dimension];
+            const auto &pt = fi.config.strides[current_dimension];
+            x_off += pt.first;
+            y_off += pt.second;
         }
     }
 }
@@ -404,19 +417,8 @@ int run(int argc, char **argv) {
     int timestep = 10000;
     int hold_frames = 250;
 
+    // The struct's default values are what we want
     FuncInfo::Config config;
-    config.x = config.y = 0;
-    config.zoom = 1;
-    config.color_dim = -1;
-    config.min = 0;
-    config.max = 1;
-    config.store_cost = 1;
-    config.load_cost = 0;
-    config.blank_on_end_realization = false;
-    config.dims = 2;
-    config.x_stride = { 1, 0 };
-    config.y_stride = { 0, 1 };
-    config.uninitialized_memory_color = 255 << 24;
 
     vector<pair<int, int>> pos_stack;
 
@@ -492,11 +494,10 @@ int run(int argc, char **argv) {
                     break;
                 }
                 expect(i + 2 < argc, i);
-                if (config.x_stride.size() <= config.dims) config.x_stride.resize(config.dims+1, 0);
-                if (config.y_stride.size() <= config.dims) config.y_stride.resize(config.dims+1, 0);
-                config.x_stride[config.dims] = parse_int(argv[++i]);
-                config.y_stride[config.dims] = parse_int(argv[++i]);
-                config.dims++;
+                if (config.strides.size() <= config.dims) config.strides.resize(config.dims+1, {0, 0});
+                int x = parse_int(argv[++i]);
+                int y = parse_int(argv[++i]);
+                config.strides[config.dims++] = {x, y};
             }
         } else if (next == "--label") {
             expect(i + 3 < argc, i);
@@ -629,6 +630,7 @@ int run(int argc, char **argv) {
             pipeline_info[p.id] = {p.func(), p.id};
             continue;
         } else if (p.event == halide_trace_end_pipeline) {
+            assert(pipeline_info.count(p.parent_id));
             pipeline_info.erase(p.parent_id);
             continue;
         }
@@ -638,10 +640,12 @@ int run(int argc, char **argv) {
         if (p.event == halide_trace_begin_realization ||
             p.event == halide_trace_produce ||
             p.event == halide_trace_consume) {
+            assert(!pipeline_info.count(p.id));
             pipeline_info[p.id] = pipeline;
         } else if (p.event == halide_trace_end_realization ||
                    p.event == halide_trace_end_produce ||
                    p.event == halide_trace_end_consume) {
+            assert(pipeline_info.count(p.parent_id));
             pipeline_info.erase(p.parent_id);
         }
 
@@ -710,8 +714,9 @@ int run(int argc, char **argv) {
                     const float z = fi.config.zoom;
                     for (int d = 0; d < fi.config.dims; d++) {
                         int a = p.get_coord(d * p.type.lanes + lane);
-                        x += z * fi.config.x_stride[d] * a;
-                        y += z * fi.config.y_stride[d] * a;
+                        const auto &pt = fi.config.strides[d];
+                        x += z * pt.first * a;
+                        y += z * pt.second * a;
                     }
 
                     // The box to draw must be entirely on-screen
@@ -789,9 +794,11 @@ int run(int argc, char **argv) {
         case halide_trace_end_produce:
         case halide_trace_consume:
         case halide_trace_end_consume:
+            break;
         case halide_trace_begin_pipeline:
         case halide_trace_end_pipeline:
-            break;
+            std::cerr << "Misplaced tracing event: " << p.event << "\n";
+            exit(-1);
         default:
             std::cerr << "Unknown tracing event code: " << p.event << "\n";
             exit(-1);

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -62,7 +62,7 @@ struct FuncInfo {
 
     // Configuration for how the func should be drawn
     struct Config {
-        int zoom = 0;
+        float zoom = 0;
         int load_cost = 0;
         int store_cost = 0;
         int dims = 0;
@@ -278,7 +278,7 @@ Funcs.
      screen. This is the default
 
  --zoom factor: Each value of a Func will draw as a factor x factor
-     box in the output.
+     box in the output. Fractional values are allowed.
 
  --load time: Each load from a Func costs the given number of ticks.
 
@@ -378,7 +378,7 @@ int parse_int(const char *str) {
     return (int) result;
 }
 
-int parse_float(const char *str) {
+float parse_float(const char *str) {
     char *endptr = nullptr;
     errno = 0;
     float result = strtof(str, &endptr);
@@ -476,7 +476,7 @@ int run(int argc, char **argv) {
             config.blank_on_end_realization = false;
         } else if (next == "--zoom") {
             expect(i + 1 < argc, i);
-            config.zoom = parse_int(argv[++i]);
+            config.zoom = parse_float(argv[++i]);
         } else if (next == "--load") {
             expect(i + 1 < argc, i);
             config.load_cost = parse_int(argv[++i]);
@@ -707,11 +707,11 @@ int run(int argc, char **argv) {
                     // Compute the screen-space x, y coord to draw this.
                     int x = fi.config.x;
                     int y = fi.config.y;
-                    const int z = fi.config.zoom;
+                    const float z = fi.config.zoom;
                     for (int d = 0; d < fi.config.dims; d++) {
                         int a = p.get_coord(d * p.type.lanes + lane);
-                        x += fi.config.zoom * fi.config.x_stride[d] * a;
-                        y += fi.config.zoom * fi.config.y_stride[d] * a;
+                        x += z * fi.config.x_stride[d] * a;
+                        y += z * fi.config.y_stride[d] * a;
                     }
 
                     // The box to draw must be entirely on-screen


### PR DESCRIPTION
These are all minor but worthwhile; offering as a separate PR in order to make some future PRs less noisy. Changes:

-- Labels use std::string instead of char*
-- keep strides as a single vector<pair<int, int>> instead of two separate vectors
-- some extra assertions and error checking
-- The Config struct now initializes to the proper default values rather than useless values which we immediately replace
-- local_laplacian doesn't fail if the mp4 already exists

(Note that this is built on top of https://github.com/halide/Halide/pull/2826 and includes those changes)