### PR TITLE
Add msan_annotate_is_initialized() to printer::str()

### DIFF
--- a/src/runtime/printer.h
+++ b/src/runtime/printer.h
@@ -102,6 +102,9 @@ public:
     // Use it like a stringstream.
     const char *str() {
         if (buf) {
+            if (type == StringStreamPrinter) {
+                msan_annotate_is_initialized();
+            }
             return buf;
         } else {
             return allocation_error();


### PR DESCRIPTION
When using printer in stringstream mode, we never marked the data as inited-for-msan when just grabbing the str; this could lead to erroneous MSAN failures when profiling is enabled.