### PR TITLE
Use add_trace_tag() to allow sending opcodes to HalideTraceViz

### DIFF
--- a/apps/bilateral_grid/bilateral_grid_generator.cpp
+++ b/apps/bilateral_grid/bilateral_grid_generator.cpp
@@ -114,6 +114,37 @@ public:
             blury.compute_root().reorder(c, x, y, z).parallel(z).vectorize(x, 8).unroll(c);
             bilateral_grid.compute_root().parallel(y).vectorize(x, 8);
         }
+
+        /* Optional tags to specify layout for HalideTraceViz */
+        input
+            .add_trace_tag("move 100 300");
+
+        histogram
+            .add_trace_tag("strides 1 0 0 1 40 0")
+            .add_trace_tag("zoom 3")
+            .add_trace_tag("max 32")
+            .add_trace_tag("move 550 100");
+
+        blurz
+            .add_trace_tag("strides 1 0 0 1 40 0")
+            .add_trace_tag("zoom 3")
+            .add_trace_tag("max 512")
+            .add_trace_tag("move 550 300");
+
+        blurx
+            .add_trace_tag("strides 1 0 0 1 40 0")
+            .add_trace_tag("zoom 3")
+            .add_trace_tag("max 8192")
+            .add_trace_tag("move 550 500");
+
+        blury
+            .add_trace_tag("strides 1 0 0 1 40 0")
+            .add_trace_tag("zoom 3")
+            .add_trace_tag("max 131072")
+            .add_trace_tag("move 550 700");
+
+        bilateral_grid
+            .add_trace_tag("move 1564 300");
     }
 };
 

--- a/apps/bilateral_grid/viz.sh
+++ b/apps/bilateral_grid/viz.sh
@@ -4,15 +4,6 @@ export HL_NUMTHREADS=4
 rm -f $1/bilateral_grid.mp4
 make $1/filter_viz && \
 $1/filter_viz ../images/gray_small.png $1/out_small.png 0.2 0 | \
-../../bin/HalideTraceViz --timestep 1000 --size 1920 1080 \
---gray --strides 1 0 0 1 \
---max 1 --move 100 300 --func input \
---strides 1 0 0 1 40 0 --zoom 3 \
---max 32 --move 550 100 --func histogram \
---max 512 --down 200 --func blurz \
---max 8192 --down 200 --func blurx \
---max 131072 --down 200 --func blury \
---strides 1 0 0 1 --zoom 1 \
---max 1 --move 1564 300 --func bilateral_grid | \
+../../bin/HalideTraceViz --timestep 1000 --size 1920 1080 | \
 avconv -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 $1/bilateral_grid.mp4
 #mplayer -demuxer rawvideo -rawvideo w=1920:h=1080:format=rgba:fps=30 -idle -fixed-vo -

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -141,7 +141,65 @@ public:
                 outGPyramid[j].compute_root();
             }
         }
+
+        /* Optional tags to specify layout for HalideTraceViz */
+        input
+            .add_trace_tag("rgb 2")
+            .add_trace_tag("max 65535")
+            .add_trace_tag("move 30 100")
+            .add_trace_tag("label");
+
+        output
+            .add_trace_tag("rgb 2")
+            .add_trace_tag("max 65535")
+            .add_trace_tag("move 1700 100")
+            .add_trace_tag("label");
+
+        gray
+            .add_trace_tag("store 5")
+            .add_trace_tag("move 370 100")
+            .add_trace_tag("label 'input pyramid'");
+
+        for (int i = 0; i < pyramid_levels; ++i) {
+            int y = 100;
+            for (int j = 0; j < i; ++j) {
+                y += 500 >> j;
+            }
+            if (i > 0) {
+                int x = 370;
+                int store_cost = 1 << (i + 1);
+                inGPyramid[i]
+                    .add_trace_tag("move " + std::to_string(x) + " " + std::to_string(y))
+                    .add_trace_tag("store " + std::to_string(store_cost));
+            }
+            if (i > 0) {
+                int x = 720;
+                int store_cost = 1 << i;
+                if (i == 1) {
+                    gPyramid[i]
+                        .add_trace_tag("move " + std::to_string(x) + " " + std::to_string(100))
+                        .add_trace_tag("label 'differently curved intermediate pyramids'");
+                }
+                gPyramid[i]
+                    .add_trace_tag("strides 1 0 0 1 200 0")
+                    .add_trace_tag("move " + std::to_string(x) + " " + std::to_string(y))
+                    .add_trace_tag("store " + std::to_string(store_cost));
+            }
+            {
+                int x = 1500;
+                int store_cost = (1 << i) * 10;
+                if (i == 0) {
+                    outGPyramid[i]
+                        .add_trace_tag("move " + std::to_string(x) + " " + std::to_string(100))
+                        .add_trace_tag("label 'output pyramids'");
+                }
+                outGPyramid[i]
+                    .add_trace_tag("move " + std::to_string(x) + " " + std::to_string(y))
+                    .add_trace_tag("store " + std::to_string(store_cost));
+            }
+        }
     }
+
 private:
     Var x, y, c, k;
 

--- a/apps/local_laplacian/viz.sh
+++ b/apps/local_laplacian/viz.sh
@@ -5,34 +5,6 @@ rm -f bin/local_laplacian.mp4
 make bin/process_viz && \
 ./bin/process_viz ../images/rgb_small.png 4 1 1 0 ./bin/out_small.png | \
 ../../bin/HalideTraceViz \
---size 1920 1080 --timestep 3000 \
---rgb 2 --max 65535 --strides 1 0 0 1 0 0 \
---move 30 100 --func input \
---move 1700 32 --label local_laplacian "output" 10 \
---move 1700 100 --func local_laplacian \
---gray --max 1 --strides 1 0 0 1 \
---move 280 32 --label gray "input pyramid" 10 \
---move 370 100 --store 5  --func gray \
---down 470  --store 4  --func inGPyramid[1] \
---down 250  --store 8  --func inGPyramid[2] \
---down 125  --store 16 --func inGPyramid[3] \
---down 62   --store 32 --func inGPyramid[4] \
---down 31   --store 64 --func inGPyramid[5] \
---move 680 32 --label gPyramid[1] "differently-curved intermediate pyramids" 10 \
---strides 1 0 0 1 200 0 \
---move 720 100 --store 1 --func gPyramid[0] \
---down 470  --store 2  --func gPyramid[1] \
---down 250  --store 4  --func gPyramid[2] \
---down 125  --store 8  --func gPyramid[3] \
---down 62   --store 16 --func gPyramid[4] \
---down 31   --store 32 --func gPyramid[5] \
---move 1500 32 --label outGPyramid[5] "output pyramid" 10 \
---strides 1 0 0 1 \
---move 1500 100 --store 10 --func outGPyramid[0] \
---down 470  --store 20  --func outGPyramid[1] \
---down 250  --store 40  --func outGPyramid[2] \
---down 125  --store 80  --func outGPyramid[3] \
---down 62   --store 160 --func outGPyramid[4] \
---down 31   --store 320 --func outGPyramid[5] |\
+--size 1920 1080 --timestep 3000 |\
 avconv -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 ./bin/local_laplacian.mp4
 #mplayer -demuxer rawvideo -rawvideo w=1920:h=1080:format=rgba:fps=30 -idle -fixed-vo -

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1560,6 +1560,7 @@ public:
     HALIDE_FORWARD_METHOD_CONST(ImageParam, height)
     HALIDE_FORWARD_METHOD_CONST(ImageParam, channels)
     HALIDE_FORWARD_METHOD_CONST(ImageParam, trace_loads)
+    HALIDE_FORWARD_METHOD_CONST(ImageParam, add_trace_tag)
     // }@
 };
 
@@ -1883,6 +1884,7 @@ protected:
 public:
     /** Forward schedule-related methods to the underlying Func. */
     // @{
+    HALIDE_FORWARD_METHOD(Func, add_trace_tag)
     HALIDE_FORWARD_METHOD(Func, align_bounds)
     HALIDE_FORWARD_METHOD(Func, align_storage)
     HALIDE_FORWARD_METHOD_CONST(Func, args)

--- a/src/ImageParam.cpp
+++ b/src/ImageParam.cpp
@@ -87,4 +87,10 @@ void ImageParam::trace_loads() {
     func.trace_loads();
 }
 
+ImageParam &ImageParam::add_trace_tag(const std::string &trace_tag) {
+    internal_assert(func.defined());
+    func.add_trace_tag(trace_tag);
+    return *this;
+}
+
 }

--- a/src/ImageParam.h
+++ b/src/ImageParam.h
@@ -131,6 +131,9 @@ public:
 
     /** Trace all loads from this ImageParam by emitting calls to halide_trace. */
     void trace_loads();
+
+    /** Add a trace tag to this ImageParam's Func. */
+    ImageParam &add_trace_tag(const std::string &trace_tag);
 };
 
 }

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -35,31 +35,8 @@ using std::queue;
 using std::array;
 using std::pair;
 
-std::ostream &operator<<(std::ostream &stream, const vector<int> &v) {
-    stream << "[ ";
-    bool need_comma = false;
-    for (int i : v) {
-        if (need_comma) {
-            stream << ", ";
-        }
-        stream << i;
-        need_comma = true;
-    }
-    stream << " ]";
-    return stream;
-}
-
-std::ostream &operator<<(std::ostream &stream, const vector<pair<int, int>> &v) {
-    stream << "[ ";
-    bool need_comma = false;
-    for (auto &pt : v) {
-        if (need_comma) {
-            stream << ", ";
-        }
-        stream << "(" << pt.first << "," << pt.second << ")";
-        need_comma = true;
-    }
-    stream << " ]";
+std::ostream &operator<<(std::ostream &stream, const pair<int, int> &pt) {
+    stream << "(" << pt.first << "," << pt.second << ")";
     return stream;
 }
 
@@ -68,6 +45,26 @@ struct Label {
     string text;
     int x, y, n;
 };
+
+std::ostream &operator<<(std::ostream &stream, const Label &label) {
+    stream << "text=\"" << label.text << " @ " << label.x << " " << label.y << " n=" << label.n;
+    return stream;
+}
+
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const vector<T> &v) {
+    stream << "[ ";
+    bool need_comma = false;
+    for (const T &t : v) {
+        if (need_comma) {
+            stream << ", ";
+        }
+        stream << t;
+        need_comma = true;
+    }
+    stream << " ]";
+    return stream;
+}
 
 // A struct specifying how a single Func will get visualized.
 struct FuncInfo {
@@ -88,7 +85,7 @@ struct FuncInfo {
         bool blank_on_end_realization = false;
         uint32_t uninitialized_memory_color = 0xff000000;
 
-        void dump(const char *name) {
+        void dump(const string &name) const {
             std::cerr <<
                     "Func " << name << ":\n" <<
                     " min: " << min << " max: " << max << "\n" <<
@@ -99,7 +96,8 @@ struct FuncInfo {
                     " load cost: " << load_cost << "\n" <<
                     " store cost: " << store_cost << "\n" <<
                     " x: " << x << " y: " << y << "\n" <<
-                    " strides: " << strides << "\n";
+                    " strides: " << strides << "\n" <<
+                    " labels: " << labels << "\n";
         }
     } config;
 
@@ -197,7 +195,7 @@ void composite(uint8_t *a, uint8_t *b, uint8_t *dst) {
 static constexpr int FONT_W = 12;
 static constexpr int FONT_H = 32;
 
-void draw_text(const std::string &text, int x, int y, uint32_t color, uint32_t *dst, int dst_width, int dst_height) {
+void draw_text(const string &text, int x, int y, uint32_t color, uint32_t *dst, int dst_width, int dst_height) {
     // The font array contains 96 characters of FONT_W * FONT_H letters.
     assert(inconsolata_raw_len == 96 * FONT_W * FONT_H);
 
@@ -403,12 +401,7 @@ float parse_float(const char *str) {
     return result;
 }
 
-int run(int argc, char **argv) {
-    if (argc == 1) {
-        usage();
-        return 0;
-    }
-
+struct Params {
     // State that determines how different funcs get drawn
     int frame_width = 1920, frame_height = 1080;
     float decay_factor[2] = {1, 2};
@@ -417,125 +410,262 @@ int run(int argc, char **argv) {
     int timestep = 10000;
     int hold_frames = 250;
 
-    // The struct's default values are what we want
-    FuncInfo::Config config;
+    void parse_one(const string &func_name, int argc, char **argv) {
+        do_parse(argc, argv, func_name);
+    }
 
-    vector<pair<int, int>> pos_stack;
-
-    // Parse command line args
-    int i = 1;
-    while (i < argc) {
-        string next = argv[i];
-        if (next == "--size") {
-            expect(i + 2 < argc, i);
-            frame_width = parse_int(argv[++i]);
-            frame_height = parse_int(argv[++i]);
-        } else if (next == "--func") {
-            expect(i + 1 < argc, i);
-            const char *func = argv[++i];
-            FuncInfo &fi = func_info[func];
-            fi.config.labels.swap(config.labels);
-            fi.config = config;
-            fi.config.dump(func);
-            fi.configured = true;
-        } else if (next == "--min") {
-            expect(i + 1 < argc, i);
-            config.min = parse_float(argv[++i]);
-        } else if (next == "--max") {
-            expect(i + 1 < argc, i);
-            config.max = parse_float(argv[++i]);
-        } else if (next == "--move") {
-            expect(i + 2 < argc, i);
-            config.x = parse_int(argv[++i]);
-            config.y = parse_int(argv[++i]);
-        } else if (next == "--left") {
-            expect(i + 1 < argc, i);
-            config.x -= parse_int(argv[++i]);
-        } else if (next == "--right") {
-            expect(i + 1 < argc, i);
-            config.x += parse_int(argv[++i]);
-        } else if (next == "--up") {
-            expect(i + 1 < argc, i);
-            config.y -= parse_int(argv[++i]);
-        } else if (next == "--down") {
-            expect(i + 1 < argc, i);
-            config.y += parse_int(argv[++i]);
-        } else if (next == "--push") {
-            pos_stack.push_back({config.x, config.y});
-        } else if (next == "--pop") {
-            expect(!pos_stack.empty(), i);
-            config.x = pos_stack.back().first;
-            config.y = pos_stack.back().second;
-            pos_stack.pop_back();
-        } else if (next == "--rgb") {
-            expect(i + 1 < argc, i);
-            config.color_dim = parse_int(argv[++i]);
-        } else if (next == "--gray") {
-            config.color_dim = -1;
-        } else if (next == "--blank") {
-            config.blank_on_end_realization = true;
-        } else if (next == "--no-blank") {
-            config.blank_on_end_realization = false;
-        } else if (next == "--zoom") {
-            expect(i + 1 < argc, i);
-            config.zoom = parse_float(argv[++i]);
-        } else if (next == "--load") {
-            expect(i + 1 < argc, i);
-            config.load_cost = parse_int(argv[++i]);
-        } else if (next == "--store") {
-            expect(i + 1 < argc, i);
-            config.store_cost = parse_int(argv[++i]);
-        } else if (next == "--strides") {
-            config.dims = 0;
-            while (i + 1 < argc) {
-                const char *next_arg = argv[i + 1];
-                if (next_arg[0] == '-' &&
-                    next_arg[1] == '-') {
+    void split_and_parse_one(const string &func_name, const string &trace_tag) {
+        // Do a simplistic split into argc/argv,
+        // with limited support for 'quoted strings'.
+        // TODO: allow for escapes via \, and maybe for "quoted strings".
+        vector<string> storage;
+        int delimiter = 0;
+        storage.push_back("");
+        enum {
+            Undecided,
+            ParsingNormal,
+            ParsingQuoted,
+        } state = Undecided;
+        for (int c : trace_tag) {
+            if (isspace(c)) {
+                switch(state) {
+                case Undecided:
+                    // leading spaces, just skip them
+                    break;
+                case ParsingNormal:
+                    // Finish this entry
+                    storage.push_back("");
+                    state = Undecided;
+                    break;
+                case ParsingQuoted:
+                    // Just add the spaces inside the quoted string.
+                    storage.back().push_back(c);
                     break;
                 }
-                expect(i + 2 < argc, i);
-                if (config.strides.size() <= config.dims) config.strides.resize(config.dims+1, {0, 0});
-                int x = parse_int(argv[++i]);
-                int y = parse_int(argv[++i]);
-                config.strides[config.dims++] = {x, y};
+            } else if (c == '\'') {
+                switch(state) {
+                case Undecided:
+                    // Start parsing a quoted string
+                    state = ParsingQuoted;
+                    break;
+                case ParsingNormal:
+                    // Single-quote inside a space-delimited block.
+                    // Could assert-fail? But let's just add it.
+                    storage.back().push_back(c);
+                    break;
+                case ParsingQuoted:
+                    // Finish this entry
+                    storage.push_back("");
+                    state = Undecided;
+                    break;
+                }
+            } else {
+                switch(state) {
+                case Undecided:
+                    // Start parsing non-quoted string
+                    state = ParsingNormal;
+                    // fall thru
+                case ParsingNormal:
+                case ParsingQuoted:
+                    // Continue parsing string
+                    storage.back().push_back(c);
+                    break;
+                }
             }
-        } else if (next == "--label") {
-            expect(i + 3 < argc, i);
-            char *func = argv[++i];
-            char *text = argv[++i];
-            int n = parse_int(argv[++i]);
-            Label l = {text, config.x, config.y, n};
-            func_info[func].config.labels.push_back(l);
-        } else if (next == "--timestep") {
-            expect(i + 1 < argc, i);
-            timestep = parse_int(argv[++i]);
-        } else if (next == "--decay") {
-            expect(i + 2 < argc, i);
-            decay_factor[0] = parse_float(argv[++i]);
-            decay_factor[1] = parse_float(argv[++i]);
-        } else if (next == "--hold") {
-            expect(i + 1 < argc, i);
-            hold_frames = parse_int(argv[++i]);
-        } else if (next == "--uninit") {
-            expect(i + 3 < argc, i);
-            int r = parse_int(argv[++i]);
-            int g = parse_int(argv[++i]);
-            int b = parse_int(argv[++i]);
-            config.uninitialized_memory_color = (255 << 24) | ((b & 255) << 16) | ((g & 255) << 8) | (r & 255);
-        } else {
-            expect(false, i);
         }
-        i++;
+        if (storage.back().empty()) {
+            storage.pop_back();
+        }
+        vector<char *> argv;
+        for (string &s : storage) {
+            argv.push_back(const_cast<char *>(s.c_str()));
+        }
+        parse_one(func_name, (int) argv.size(), argv.data());
     }
+
+    void parse_flags(int argc, char **argv) {
+        do_parse(argc, argv, /*func_name*/ "");
+    }
+
+private:
+    void do_parse(int argc, char **argv, const string &func_name) {
+        FuncInfo::Config config;
+        if (!func_name.empty()) {
+            config = func_info[func_name].config;
+        }
+
+        const bool expect_flags = func_name.empty();
+        vector<pair<int, int>> pos_stack;
+
+        int i = 0;
+        while (i < argc) {
+            char *p = argv[i];
+            if (expect_flags) {
+                // Everything should start with --
+                if (p[0] != '-' || p[1] != '-') {
+                    expect(false, i);
+                }
+                p += 2;
+            }
+            string next = p;
+            if (next == "size") {
+                expect(i + 2 < argc, i);
+                frame_width = parse_int(argv[++i]);
+                frame_height = parse_int(argv[++i]);
+            } else if (next == "func") {
+                if (!func_name.empty()) {
+                    std::cerr << "Warning, the 'func' param is only supported as a command-line flag; ignoring\n";
+                    return;
+                }
+                expect(i + 1 < argc, i);
+                const char *func = argv[++i];
+                FuncInfo &fi = func_info[func];
+                fi.config.labels.swap(config.labels);
+                fi.config = config;
+                fi.configured = true;
+            } else if (next == "min") {
+                expect(i + 1 < argc, i);
+                config.min = parse_float(argv[++i]);
+            } else if (next == "max") {
+                expect(i + 1 < argc, i);
+                config.max = parse_float(argv[++i]);
+            } else if (next == "move") {
+                expect(i + 2 < argc, i);
+                config.x = parse_int(argv[++i]);
+                config.y = parse_int(argv[++i]);
+            } else if (next == "left") {
+                expect(i + 1 < argc, i);
+                config.x -= parse_int(argv[++i]);
+            } else if (next == "right") {
+                expect(i + 1 < argc, i);
+                config.x += parse_int(argv[++i]);
+            } else if (next == "up") {
+                expect(i + 1 < argc, i);
+                config.y -= parse_int(argv[++i]);
+            } else if (next == "down") {
+                expect(i + 1 < argc, i);
+                config.y += parse_int(argv[++i]);
+            } else if (next == "push") {
+                pos_stack.push_back({config.x, config.y});
+            } else if (next == "pop") {
+                expect(!pos_stack.empty(), i);
+                config.x = pos_stack.back().first;
+                config.y = pos_stack.back().second;
+                pos_stack.pop_back();
+            } else if (next == "rgb") {
+                expect(i + 1 < argc, i);
+                config.color_dim = parse_int(argv[++i]);
+            } else if (next == "gray") {
+                config.color_dim = -1;
+            } else if (next == "blank") {
+                config.blank_on_end_realization = true;
+            } else if (next == "no-blank") {
+                config.blank_on_end_realization = false;
+            } else if (next == "zoom") {
+                expect(i + 1 < argc, i);
+                config.zoom = parse_float(argv[++i]);
+            } else if (next == "load") {
+                expect(i + 1 < argc, i);
+                config.load_cost = parse_int(argv[++i]);
+            } else if (next == "store") {
+                expect(i + 1 < argc, i);
+                config.store_cost = parse_int(argv[++i]);
+            } else if (next == "strides") {
+                config.dims = 0;
+                while (i + 1 < argc) {
+                    const char *next_arg = argv[i + 1];
+                    if (expect_flags &&
+                        next_arg[0] == '-' &&
+                        next_arg[1] == '-') {
+                        break;
+                    }
+                    expect(i + 2 < argc, i);
+                    if (config.strides.size() <= config.dims) config.strides.resize(config.dims+1, {0, 0});
+                    int x = parse_int(argv[++i]);
+                    int y = parse_int(argv[++i]);
+                    config.strides[config.dims++] = {x, y};
+                }
+            } else if (next == "label") {
+                // 'label' is slightly different between the tag version
+                // and the flag version, because (unlike every other flag),
+                // the --label flag doesn't apply to the 'current' func,
+                // but rather, takes an explicit func name.
+                // TODO: should we revise that flag to bring it in line with the others?
+                if (!func_name.empty()) {
+                    string text = func_name;
+                    int n = 0;
+                    // For tags, don't specify the funcname (it's redundant),
+                    // and allow the text and timing args to be optional.
+                    if (i + 1 < argc) {
+                        text = argv[++i];
+                    }
+                    if (i + 1 < argc) {
+                        n = parse_int(argv[++i]);
+                    }
+                    Label l = {text, config.x, config.y, n};
+                    // Always apply to the current config
+                    config.labels.push_back(l);
+                } else {
+                    expect(i + 3 < argc, i);
+                    const char *func = argv[++i];
+                    const char *text = argv[++i];
+                    int n = parse_int(argv[++i]);
+                    Label l = {text, config.x, config.y, n};
+                    // Always apply to this func's config, regardless of 'current'
+                    func_info[func].config.labels.push_back(l);
+                }
+            } else if (next == "timestep") {
+                expect(i + 1 < argc, i);
+                timestep = parse_int(argv[++i]);
+            } else if (next == "decay") {
+                expect(i + 2 < argc, i);
+                decay_factor[0] = parse_float(argv[++i]);
+                decay_factor[1] = parse_float(argv[++i]);
+            } else if (next == "hold") {
+                expect(i + 1 < argc, i);
+                hold_frames = parse_int(argv[++i]);
+            } else if (next == "uninit") {
+                expect(i + 3 < argc, i);
+                int r = parse_int(argv[++i]);
+                int g = parse_int(argv[++i]);
+                int b = parse_int(argv[++i]);
+                config.uninitialized_memory_color = (255 << 24) | ((b & 255) << 16) | ((g & 255) << 8) | (r & 255);
+            } else {
+                if (expect_flags) {
+                    expect(false, i);
+                } else {
+                    std::cerr << "Warning, ignoring unknown param '" << next << "'\n";
+                    return;
+                }
+            }
+            i++;
+        }
+
+        if (!func_name.empty()) {
+            func_info[func_name].config = config;
+            func_info[func_name].configured = true;
+        }
+    }
+};
+
+int run(int argc, char **argv) {
+    if (argc == 1) {
+        usage();
+        return 0;
+    }
+
+    Params params;
+    params.parse_flags(argc-1, argv+1);
 
     // halide_clock counts halide events. video_clock counts how many
     // of these events have been output. When halide_clock gets ahead
     // of video_clock, we emit a new frame.
     size_t halide_clock = 0, video_clock = 0;
+    bool func_info_dumped = false;
 
     // There are three layers - image data, an animation on top of
     // it, and text labels. These layers get composited.
-    const int frame_elems = frame_width * frame_height;
+    const int frame_elems = params.frame_width * params.frame_height;
     std::vector<uint32_t> image(frame_elems, 0),
                           anim(frame_elems, 0),
                           anim_decay(frame_elems, 0),
@@ -554,8 +684,8 @@ int run(int argc, char **argv) {
     for (;;) {
         // Hold for some number of frames once the trace has finished.
         if (end_counter) {
-            halide_clock += timestep;
-            if (end_counter == (size_t)hold_frames) {
+            halide_clock += params.timestep;
+            if (end_counter == (size_t)params.hold_frames) {
                 break;
             }
         }
@@ -586,11 +716,11 @@ int run(int argc, char **argv) {
                     return -1;
                 }
 
-                video_clock += timestep;
+                video_clock += params.timestep;
 
                 // Decay the anim_decay
-                if (decay_factor[1] != 1) {
-                    const uint32_t inv_d1 = (1 << 24) / decay_factor[1];
+                if (params.decay_factor[1] != 1) {
+                    const uint32_t inv_d1 = (1 << 24) / params.decay_factor[1];
                     for (int i = 0; i < frame_elems; i++) {
                         uint32_t color = anim_decay[i];
                         uint32_t rgb = color & 0x00ffffff;
@@ -602,7 +732,7 @@ int run(int argc, char **argv) {
                 }
 
                 // Also decay the anim
-                const uint32_t inv_d0 = (1 << 24) / decay_factor[0];
+                const uint32_t inv_d0 = (1 << 24) / params.decay_factor[0];
                 for (int i = 0; i < frame_elems; i++) {
                     uint32_t color = anim[i];
                     uint32_t rgb = color & 0x00ffffff;
@@ -633,6 +763,22 @@ int run(int argc, char **argv) {
             assert(pipeline_info.count(p.parent_id));
             pipeline_info.erase(p.parent_id);
             continue;
+        } else if (p.event == halide_trace_tag) {
+            // If there are trace tags, they will come immediately after the pipeline's
+            // halide_trace_begin_pipeline but before any realizations.
+            params.split_and_parse_one(p.func(), p.trace_tag());
+            continue;
+        }
+
+        if (!func_info_dumped) {
+            // dump after any tags are processed
+            for (const auto &p : params.func_info) {
+                const auto &fi = p.second;
+                if (fi.configured) {
+                    fi.config.dump(p.first);
+                }
+            }
+            func_info_dumped = true;
         }
 
         PipelineInfo pipeline = pipeline_info[p.parent_id];
@@ -651,18 +797,18 @@ int run(int argc, char **argv) {
 
         string qualified_name = pipeline.name + ":" + p.func();
 
-        if (func_info.find(qualified_name) == func_info.end()) {
-            if (func_info.find(p.func()) != func_info.end()) {
-                func_info[qualified_name] = func_info[p.func()];
-                func_info.erase(p.func());
+        if (params.func_info.find(qualified_name) == params.func_info.end()) {
+            if (params.func_info.find(p.func()) != params.func_info.end()) {
+                params.func_info[qualified_name] = params.func_info[p.func()];
+                params.func_info.erase(p.func());
             } else {
-                std::cerr << "Warning: ignoring func " << qualified_name << " event " << p.event << "\n";
-                std::cerr << "Parent event " << p.parent_id << " " << pipeline.name << "\n";
+                std::cerr << "Warning: ignoring func " << qualified_name << " event " << p.event << "\n"
+                          << "Parent event " << p.parent_id << " " << pipeline.name << "\n";
             }
         }
 
         // Draw the event
-        FuncInfo &fi = func_info[qualified_name];
+        FuncInfo &fi = params.func_info[qualified_name];
         if (!fi.configured) continue;
 
         if (fi.stats.first_draw_time == 0) {
@@ -674,16 +820,16 @@ int run(int argc, char **argv) {
             fi.stats.qualified_name = qualified_name;
         }
 
-        int frames_since_first_draw = (halide_clock - fi.stats.first_draw_time) / timestep;
+        int frames_since_first_draw = (halide_clock - fi.stats.first_draw_time) / params.timestep;
 
         for (size_t i = 0; i < fi.config.labels.size(); i++) {
             const Label &label = fi.config.labels[i];
             if (frames_since_first_draw <= label.n) {
-                uint32_t color = ((1 + frames_since_first_draw) * 255) / std::min(1, label.n);
+                uint32_t color = ((1 + frames_since_first_draw) * 255) / std::max(1, label.n);
                 if (color > 255) color = 255;
                 color *= 0x10101;
 
-                draw_text(label.text, label.x, label.y, color, text.data(), frame_width, frame_height);
+                draw_text(label.text, label.x, label.y, color, text.data(), params.frame_width, params.frame_height);
             }
         }
 
@@ -720,10 +866,10 @@ int run(int argc, char **argv) {
                     }
 
                     // The box to draw must be entirely on-screen
-                    if (y < 0 || y >= frame_height ||
-                        x < 0 || x >= frame_width ||
-                        y + z - 1 < 0 || y + z - 1 >= frame_height ||
-                        x + z - 1 < 0 || x + z - 1 >= frame_width) {
+                    if (y < 0 || y >= params.frame_height ||
+                        x < 0 || x >= params.frame_width ||
+                        y + z - 1 < 0 || y + z - 1 >= params.frame_height ||
+                        x + z - 1 < 0 || x + z - 1 >= params.frame_width) {
                         continue;
                     }
 
@@ -741,7 +887,7 @@ int run(int argc, char **argv) {
                         update_image = true;
                         // Get the old color, in case we're only
                         // updating one of the color channels.
-                        image_color = image[frame_width * y + x];
+                        image_color = image[params.frame_width * y + x];
 
                         double value = p.get_value_as<double>(lane);
 
@@ -768,7 +914,7 @@ int run(int argc, char **argv) {
                     // Draw the pixel
                     for (int dy = 0; dy < fi.config.zoom; dy++) {
                         for (int dx = 0; dx < fi.config.zoom; dx++) {
-                            int px = frame_width * (y + dy) + x + dx;
+                            int px = params.frame_width * (y + dy) + x + dx;
                             anim[px] = color;
                             if (update_image) {
                                 image[px] = image_color;
@@ -781,11 +927,11 @@ int run(int argc, char **argv) {
         }
         case halide_trace_begin_realization:
             fi.stats.num_realizations++;
-            fill_realization(image.data(), frame_width, frame_height, fi.config.uninitialized_memory_color, fi, p);
+            fill_realization(image.data(), params.frame_width, params.frame_height, fi.config.uninitialized_memory_color, fi, p);
             break;
         case halide_trace_end_realization:
             if (fi.config.blank_on_end_realization) {
-                fill_realization(image.data(), frame_width, frame_height, 0, fi, p);
+                fill_realization(image.data(), params.frame_width, params.frame_height, 0, fi, p);
             }
             break;
         case halide_trace_produce:
@@ -799,6 +945,7 @@ int run(int argc, char **argv) {
         // these should just be ignored.
         case halide_trace_begin_pipeline:
         case halide_trace_end_pipeline:
+        case halide_trace_tag:
             break;
         default:
             std::cerr << "Unknown tracing event code: " << p.event << "\n";
@@ -807,21 +954,21 @@ int run(int argc, char **argv) {
 
     }
 
-    std::cerr << "Total number of Funcs: " << func_info.size() << "\n";
+    std::cerr << "Total number of Funcs: " << params.func_info.size() << "\n";
 
     // Print stats about the Func gleaned from the trace.
-    vector<std::pair<std::string, FuncInfo> > funcs;
-    for (std::pair<std::string, FuncInfo> p : func_info) {
+    vector<std::pair<string, FuncInfo> > funcs;
+    for (std::pair<string, FuncInfo> p : params.func_info) {
         funcs.push_back(p);
     }
     struct by_first_packet_idx {
-        bool operator()(const std::pair<std::string, FuncInfo> &a,
-                        const std::pair<std::string, FuncInfo> &b) const {
+        bool operator()(const std::pair<string, FuncInfo> &a,
+                        const std::pair<string, FuncInfo> &b) const {
             return a.second.stats.first_packet_idx < b.second.stats.first_packet_idx;
         }
     };
     std::sort(funcs.begin(), funcs.end(), by_first_packet_idx());
-    for (std::pair<std::string, FuncInfo> p : funcs) {
+    for (std::pair<string, FuncInfo> p : funcs) {
         p.second.stats.report();
     }
 

--- a/util/HalideTraceViz.md
+++ b/util/HalideTraceViz.md
@@ -1,0 +1,98 @@
+HalideTraceViz accepts Halide-generated binary tracing packets from stdin, and
+outputs them as raw 8-bit rgba32 pixel values to stdout. You should pipe the
+output of HalideTraceViz into a video encoder or player.
+
+E.g. to encode a video:
+
+```
+HL_TARGET=host-trace_stores-trace_loads-trace_realizations <command to make
+pipeline> && \
+HL_TRACE_FILE=/dev/stdout <command to run pipeline> | \
+HalideTraceViz -s 1920 1080 -t 10000 <the -f args> | \
+avconv -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 output.avi
+```
+
+To just watch the trace instead of encoding a video replace the last line with
+something like:
+
+```
+mplayer -demuxer rawvideo -rawvideo w=1920:h=1080:format=rgba:fps=30 -idle -fixed-vo -
+```
+
+The arguments to HalideTraceViz specify how to lay out and render the Funcs of
+interest. It acts like a stateful drawing API. The following parameters should
+be set zero or one times:
+
+`--size width height` The size of the output frames. Defaults to 1920x1080.
+
+`--timestep timestep` How many Halide computations should be covered by each
+frame. Defaults to 10000.
+
+`--decay A B` How quickly should the yellow and blue highlights decay over time.
+This is a two-stage exponential decay with a knee in it. A controls the rate at
+which they decay while a value is in the process of being computed, and B
+controls the rate at which they decay over time after the corresponding value
+has finished being computed. 1 means never decay, 2 means halve in opacity every
+frame, and 256 or larger means instant decay. The default values for A and B are
+1 and 2 respectively, which means that the highlight holds while the value is
+being computed, and then decays slowly.
+
+`--hold frames` How many frames to output after the end of the trace. Defaults
+to 250.
+
+The following parameters can be set once per Func. With the exception of `--label`,
+they continue to take effect for all subsequently defined Funcs.
+
+`--min` The minimum value taken on by a Func. Maps to black.
+
+`--max` The maximum value taken on by a Func. Maps to white.
+
+`--rgb dim` Render Funcs as rgb, with the dimension dim indexing the color
+channels.
+
+`--gray` Render Funcs as grayscale.
+
+`--blank` Specify that the output occupied by a Func should be set to black on
+its end-realization event.
+
+`--no-blank` The opposite of `--blank`. Leaves the Func's values on the screen.
+This is the default.
+
+`--zoom factor` Each value of a Func will draw as a factor x factor box in the
+output. Fractional values are allowed.
+
+`--load time` Each load from a Func costs the given number of ticks.
+
+`--store time` Each store to a Func costs the given number of ticks.
+
+`--move x y` Sets the position on the screen corresponding to the Func's 0, 0
+coordinate.
+
+`--left dx` Moves the currently set position leftward by the given amount.
+
+`--right dx` Moves the currently set position rightward by the given amount.
+
+`--up dy` Moves the currently set position upward by the given amount.
+
+`--down dy` Moves the currently set position downward by the given amount.
+
+`--push` Copies the currently set position onto a stack of positions.
+
+`--pop` Sets the current position to the value most-recently pushed, and removes
+it from the stack.
+
+`--strides ...` Specifies the matrix that maps the coordinates of the Func to
+screen pixels. Specified column major. For example, `--strides 1 0 0 1 0 0`
+specifies that the Func has three dimensions where the first one maps to
+screen-space x coordinates, the second one maps to screen-space y coordinates,
+and the third one does not affect screen-space coordinates.
+
+`--uninit r g b` Specifies the on-screen color corresponding to uninitialized
+memory. Defaults to black.
+
+`--func name` Mark a Func to be visualized. Uses the currently set values of the
+parameters above to specify how.
+
+`--label func label n` When the named Func is first touched, the label appears
+with its bottom left corner at the current coordinates and fades in over n
+frames.


### PR DESCRIPTION
This uses the trace_tag functionality to allow customizing the output of HalideTraceViz via annotations in the Halide code (in addition to, or instead of, command-line flags to the HalideTraceViz app).

This PR exposes the flag language in a more-or-less identical form (except for `--label`, which was an awkward fit as-is); as such, it doesn't offer a huge improvement on the status quo (except perhaps for reducing bitrot from e.g. Func name changes); however, the driving impetus is to use this mechanism to augment the flag language with higher-level operations, to allow for rudimentary auto-layout options for visualizations, with the goal that a future workflow will involve simply running HalideTraceViz in 'auto' mode, then perhaps adding trace_tags to tweak or improve the display as necessary.

As proof-of-concept, it converts apps/bilateral_grid and apps/local_laplacian to use trace_tags instead of command-line args. (We may or may not want those changes to land as part of this PR.)

Notes:
- The existing flag vocabulary builds up a working global state during the parse, and each `--func` flag captures a snapshot of that. The trace-tag approach, on the other hand, starts 'fresh' for each Func; this means that defaults can always be assumed for each Func, which means that flags can sometimes be omitted (but also that they are sometimes repeated). It also means that `--up` `--down` `--push` and `--pop` aren't very useful (though they are still supported).
- The tags we send are currently more or less identical to the existing flag set, with the `--` prefix removed. Should we add a prefix convention so that HalideTraceViz can determine whether a given tag is intended for it or not? (e.g. `tv:move 100 200` rather than just `move 100 200`) That would allow HTV to distinguish between "unknown tag to ignore" vs "known tag with bad data that should be an error".
- Tags that apply to global settings (e.g. `--size`, `--timestep`) currently can be applied to any/all Funcs, in which case the last one wins; this is a bit unsatisfying. Should they be restricted to (say) outputs only? Should they be forbidden? Should there be another mechanism for them?
- The `--move` (etc) flags all take absolute positions, which is awkward since it assumes/requires a particular output size; it might be useful to add the "percent" option (that was present in a separate PR) to allow specifying layout tweaks that are more resolution-indepdendent. (Alternately, we could declare that all positioning are assuming a certain output, eg 1080p, and scale accordingly for other sizes).
- This PR also includes from minor drive-by fixes to using trace_tag with `Input` and `Output`.
