### PR TITLE
Various test fixes

### DIFF
--- a/test/correctness/compute_with.cpp
+++ b/test/correctness/compute_with.cpp
@@ -4,6 +4,8 @@
 #include <stdio.h>
 #include <map>
 
+namespace {
+
 using std::map;
 using std::string;
 
@@ -1161,6 +1163,8 @@ int nested_compute_with_test() {
     }
     return 0;
 }
+
+}  // namespace
 
 int main(int argc, char **argv) {
     printf("Running split reorder test\n");

--- a/test/correctness/interleave.cpp
+++ b/test/correctness/interleave.cpp
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
         define(g(x), g_def);
         std::vector<Expr> h_def;
         for (int i = 0; i < elements; i++) {
-            h_def.push_back(select(x % 2 == 0, 1.0f/element(f(x/2), i), element(g(x/2), i)*17.0f));
+            h_def.push_back(select(x % 2 == 0, element(f(x/2), i), element(g(x/2), i)*17.0f));
             g_def.push_back(cos(x + i));
         }
         define(h(x), h_def);
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
         for (int i = 0; i < elements; i++) {
             Buffer<float> result = results[i];
             for (int x = 0; x < 16; x++) {
-                float correct = ((x % 2) == 0) ? (1.0f/(sinf(x/2 + i))) : (cosf(x/2 + i)*17.0f);
+                float correct = ((x % 2) == 0) ? ((sinf(x/2 + i))) : (cosf(x/2 + i)*17.0f);
                 float delta = result(x) - correct;
                 if (delta > 0.01 || delta < -0.01) {
                     printf("result(%d) = %f instead of %f\n", x, result(x), correct);

--- a/test/correctness/mul_div_mod.cpp
+++ b/test/correctness/mul_div_mod.cpp
@@ -315,7 +315,7 @@ bool mul(int vector_width, ScheduleVariant scheduling, const Target &target) {
             T1 ai = a(i, j);
             T2 bi = b(i, j);
             RT ri = r(i, j);
-            RT correct = RT(ai)*RT(bi);
+            RT correct = BIG(ai)*BIG(bi);
             if (correct != ri && (ecount++) < 10) {
                 std::cerr << ai << "*" << bi << " -> " << ri << " != " << correct << "\n";
                 success = false;
@@ -404,7 +404,7 @@ bool div_mod(int vector_width, ScheduleVariant scheduling, const Target &target)
             T qi = q(i, j);
             T ri = r(i, j);
 
-            if (qi*bi + ri != ai && (ecount++) < 10) {
+            if (BIG(qi)*BIG(bi) + ri != ai && (ecount++) < 10) {
                 std::cerr << "(a/b)*b + a%b != a; a, b = " << (int64_t)ai
                           << ", " << (int64_t)bi
                           << "; q, r = " << (int64_t)qi
@@ -522,7 +522,7 @@ bool test_mul(int vector_width, ScheduleVariant scheduling, Target target) {
     // multiplications, but it covers all of the special cases we
     // have in Halide.
     success &= mul<uint16_t, uint32_t, uint32_t, uint64_t>(vector_width, scheduling, target);
-    success &= mul<int16_t, int32_t, int32_t, uint64_t>(vector_width, scheduling, target);
+    success &= mul<int16_t, int32_t, int32_t, int64_t>(vector_width, scheduling, target);
     success &= mul<uint16_t, int32_t, int32_t, uint64_t>(vector_width, scheduling, target);
 
     return success;

--- a/test/correctness/oddly_sized_output.cpp
+++ b/test/correctness/oddly_sized_output.cpp
@@ -5,6 +5,8 @@ using namespace Halide;
 
 int main(int argc, char **argv) {
     Buffer<int> input(87, 93);
+    input.fill(0);
+
     Func f;
     Var x, y;
     f(x, y) = input(x, y)*2;

--- a/test/correctness/partition_loops.cpp
+++ b/test/correctness/partition_loops.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[]) {
     for (int y = 0; y < input.height(); y++) {
         for (int x = 0; x < input.width(); x++) {
             for (int c = 0; c < input.channels(); c++) {
-                float correct = (input(2*x, y, 2) < x + y) ? x + y : y + c;
+                float correct = (input(std::min(2*x, input.width()-1), y, 2) < x + y) ? x + y : y + c;
                 if (im(x, y, c) != correct) {
                     printf("im(%d, %d, %d) = %f instead of %f\n",
                            x, y, c, im(x, y, c), correct);

--- a/test/correctness/vector_math.cpp
+++ b/test/correctness/vector_math.cpp
@@ -127,7 +127,9 @@ bool test(int lanes, int seed) {
     Buffer<A> input(W+16, H+16);
     for (int y = 0; y < H+16; y++) {
         for (int x = 0; x < W+16; x++) {
-            input(x, y) = (A)(dis(rng)*0.125 + 1.0);
+            // We must ensure that the result of casting is not out-of-range:
+            // float->int casts are UB if the result doesn't fit.
+            input(x, y) = (A)(dis(rng)*0.0625 + 1.0);
             if ((A)(-1) < 0) {
                 input(x, y) -= 10;
             }


### PR DESCRIPTION
From getting them building elsewhere, some of which are UBSan failures:
- ensure that 'using std::whatever' is always in a namespace, never at global scope
- doing an out-of-range float->char cast is UB, and the compiler is allowed to generate wrong code in that case. (Ask me how I know.)
- Fill in some Buffers to avoid random data causing signed-int-overflow errors
- Avoid float-divide-by-zero in some test data; even though it's legal, our handling of non-finite numbers makes it problematic
- Accessing Buffers out of bounds is bad. Don't do that.
- Tweak muldivmod to avoid integer overflow.