### PR TITLE
Remove UB from add_custom_lowering_pass

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -3037,7 +3037,7 @@ void Func::set_custom_print(void (*cust_print)(void *, const char *)) {
     pipeline().set_custom_print(cust_print);
 }
 
-void Func::add_custom_lowering_pass(IRMutator2 *pass, void (*deleter)(IRMutator2 *)) {
+void Func::add_custom_lowering_pass(IRMutator2 *pass, std::function<void()> deleter) {
     pipeline().add_custom_lowering_pass(pass, deleter);
 }
 

--- a/src/Func.h
+++ b/src/Func.h
@@ -1030,15 +1030,13 @@ public:
         // cast it to a deleter that takes a IRMutator2 *. The custom
         // deleter lives in user code, so that deletion is on the same
         // heap as construction (I hate Windows).
-        void (*deleter)(Internal::IRMutator2 *) =
-            (void (*)(Internal::IRMutator2 *))(&delete_lowering_pass<T>);
-        add_custom_lowering_pass(pass, deleter);
+        add_custom_lowering_pass(pass, [pass]() { delete_lowering_pass<T>(pass); });
     }
 
     /** Add a custom pass to be used during lowering, with the
      * function that will be called to delete it also passed in. Set
      * it to nullptr if you wish to retain ownership of the object. */
-    void add_custom_lowering_pass(Internal::IRMutator2 *pass, void (*deleter)(Internal::IRMutator2 *));
+    void add_custom_lowering_pass(Internal::IRMutator2 *pass, std::function<void()> deleter);
 
     /** Remove all previously-set custom lowering passes */
     void clear_custom_lowering_passes();

--- a/src/Func.h
+++ b/src/Func.h
@@ -1027,9 +1027,8 @@ public:
     template<typename T>
     void add_custom_lowering_pass(T *pass) {
         // Template instantiate a custom deleter for this type, then
-        // cast it to a deleter that takes a IRMutator2 *. The custom
-        // deleter lives in user code, so that deletion is on the same
-        // heap as construction (I hate Windows).
+        // wrap in a lambda. The custom deleter lives in user code, so
+        // that deletion is on the same heap as construction (I hate Windows).
         add_custom_lowering_pass(pass, [pass]() { delete_lowering_pass<T>(pass); });
     }
 

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -105,7 +105,7 @@ struct PipelineContents {
         invalidate_cache();
         for (size_t i = 0; i < custom_lowering_passes.size(); i++) {
             if (custom_lowering_passes[i].deleter) {
-                custom_lowering_passes[i].deleter(custom_lowering_passes[i].pass);
+                custom_lowering_passes[i].deleter();
             }
         }
         custom_lowering_passes.clear();
@@ -507,7 +507,7 @@ const std::map<std::string, JITExtern> &Pipeline::get_jit_externs() {
     return contents->jit_externs;
 }
 
-void Pipeline::add_custom_lowering_pass(IRMutator2 *pass, void (*deleter)(IRMutator2 *)) {
+void Pipeline::add_custom_lowering_pass(IRMutator2 *pass, std::function<void()> deleter) {
     user_assert(defined()) << "Pipeline is undefined\n";
     contents->invalidate_cache();
     CustomLoweringPass p = {pass, deleter};
@@ -767,7 +767,7 @@ void Pipeline::prepare_jit_call_arguments(RealizationArg &outputs, const Target 
             debug(1) << "JIT output buffer @ " << (const void *)buf << ", " << buf->host << "\n";
         }
     }
-    
+
 }
 
 std::vector<JITModule>
@@ -1055,7 +1055,7 @@ void Pipeline::infer_input_bounds(RealizationArg outputs, const ParamMap &param_
     }
 }
 
-void Pipeline::infer_input_bounds(int x_size, int y_size, int z_size, int w_size, 
+void Pipeline::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
                                   const ParamMap &param_map) {
     user_assert(defined()) << "Can't infer input bounds on an undefined Pipeline.\n";
 

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -368,9 +368,8 @@ public:
     template<typename T>
     void add_custom_lowering_pass(T *pass) {
         // Template instantiate a custom deleter for this type, then
-        // cast it to a deleter that takes a IRMutator2 *. The custom
-        // deleter lives in user code, so that deletion is on the same
-        // heap as construction (I hate Windows).
+        // wrap in a lambda. The custom deleter lives in user code, so
+        // that deletion is on the same heap as construction (I hate Windows).
         add_custom_lowering_pass(pass, [pass]() { delete_lowering_pass<T>(pass); });
     }
 


### PR DESCRIPTION
Casting the deleter function to a different function type, then calling it, produces UB warnings from UBSan. Rework to use a no-arg std::function for the deleter, and wrap up the necessary deletion in a lambda to avoid the casting.

(Why aren't the custom lowering passes just passed in via unique_ptr or shared_ptr?)