### PR TITLE
Modify test/performance to use get_test_tmp_dir()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1025,7 +1025,7 @@ $(BIN_DIR)/correctness_image_io: $(ROOT_DIR)/test/correctness/image_io.cpp $(BIN
 	$(CXX) $(TEST_CXX_FLAGS) $(IMAGE_IO_CXX_FLAGS) -I$(ROOT_DIR) $(OPTIMIZE_FOR_BUILD_TIME) $< -I$(INCLUDE_DIR) $(TEST_LD_FLAGS) $(IMAGE_IO_LIBS) -o $@
 
 $(BIN_DIR)/performance_%: $(ROOT_DIR)/test/performance/%.cpp $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR)/Halide.h
-	$(CXX) $(TEST_CXX_FLAGS) $(OPTIMIZE) $< -I$(INCLUDE_DIR) $(TEST_LD_FLAGS) -o $@
+	$(CXX) $(TEST_CXX_FLAGS) $(OPTIMIZE) $< -I$(INCLUDE_DIR) -I$(ROOT_DIR) $(TEST_LD_FLAGS) -o $@
 
 # Error tests that link against libHalide
 $(BIN_DIR)/error_%: $(ROOT_DIR)/test/error/%.cpp $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR)/Halide.h

--- a/test/performance/block_transpose.cpp
+++ b/test/performance/block_transpose.cpp
@@ -1,6 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 #include "halide_benchmark.h"
+#include "test/common/halide_test_dirs.h"
 #include <memory>
 
 using namespace Halide;
@@ -34,17 +35,17 @@ Buffer<uint16_t> test_transpose(int mode) {
         case scalar_trans:
             block_transpose.compute_at(output, x).unroll(x).unroll(y);
             algorithm = "Scalar transpose";
-            output.compile_to_assembly("scalar_transpose.s", std::vector<Argument>());
+            output.compile_to_assembly(Internal::get_test_tmp_dir() + "scalar_transpose.s", std::vector<Argument>());
             break;
         case vec_y_trans:
             block_transpose.compute_at(output, x).vectorize(y).unroll(x);
             algorithm = "Transpose vectorized in y";
-            output.compile_to_assembly("fast_transpose_y.s", std::vector<Argument>());
+            output.compile_to_assembly(Internal::get_test_tmp_dir() + "fast_transpose_y.s", std::vector<Argument>());
             break;
         case vec_x_trans:
             block_transpose.compute_at(output, x).vectorize(x).unroll(y);
             algorithm = "Transpose vectorized in x";
-            output.compile_to_assembly("fast_transpose_x.s", std::vector<Argument>());
+            output.compile_to_assembly(Internal::get_test_tmp_dir() + "fast_transpose_x.s", std::vector<Argument>());
             break;
     }
 
@@ -84,17 +85,17 @@ Buffer<uint16_t> test_transpose_wrap(int mode) {
         case scalar_trans:
             block = block_transpose.in(output).reorder_storage(y, x).compute_at(output, x).unroll(x).unroll(y);
             algorithm = "Scalar transpose";
-            output.compile_to_assembly("scalar_transpose.s", std::vector<Argument>());
+            output.compile_to_assembly(Internal::get_test_tmp_dir() + "scalar_transpose.s", std::vector<Argument>());
             break;
         case vec_y_trans:
             block = block_transpose.in(output).reorder_storage(y, x).compute_at(output, x).vectorize(y).unroll(x);
             algorithm = "Transpose vectorized in y";
-            output.compile_to_assembly("fast_transpose_y.s", std::vector<Argument>());
+            output.compile_to_assembly(Internal::get_test_tmp_dir() + "fast_transpose_y.s", std::vector<Argument>());
             break;
         case vec_x_trans:
             block = block_transpose.in(output).reorder_storage(y, x).compute_at(output, x).vectorize(x).unroll(y);
             algorithm = "Transpose vectorized in x";
-            output.compile_to_assembly("fast_transpose_x.s", std::vector<Argument>());
+            output.compile_to_assembly(Internal::get_test_tmp_dir() + "fast_transpose_x.s", std::vector<Argument>());
             break;
     }
 

--- a/test/performance/clamped_vector_load.cpp
+++ b/test/performance/clamped_vector_load.cpp
@@ -2,6 +2,7 @@
 #include <cstdio>
 #include <algorithm>
 #include "halide_benchmark.h"
+#include "test/common/halide_test_dirs.h"
 
 using namespace Halide;
 using namespace Halide::Tools;
@@ -13,7 +14,7 @@ Buffer<uint16_t> output;
 #define MAX 1020
 
 double test(Func f, bool test_correctness = true) {
-    f.compile_to_assembly(f.name() + ".s", {input}, f.name());
+    f.compile_to_assembly(Internal::get_test_tmp_dir() + f.name() + ".s", {input}, f.name());
     f.compile_jit();
     f.realize(output);
 
@@ -72,7 +73,7 @@ int main(int argc, char **argv) {
         f(x, y) = g(x, y) * 3 + g(x+1, y);
 
         f.vectorize(x, 8);
-        f.compile_to_lowered_stmt("debug_clamped_vector_load.stmt", f.infer_arguments());
+        f.compile_to_lowered_stmt(Internal::get_test_tmp_dir() + "debug_clamped_vector_load.stmt", f.infer_arguments());
 
         t_clamped = test(f);
     }

--- a/test/performance/memcpy.cpp
+++ b/test/performance/memcpy.cpp
@@ -2,6 +2,7 @@
 #include "halide_benchmark.h"
 #include <cstdio>
 #include <chrono>
+#include "test/common/halide_test_dirs.h"
 
 using namespace Halide;
 using namespace Halide::Tools;
@@ -14,7 +15,7 @@ int main(int argc, char **argv) {
 
     dst.vectorize(x, 32, TailStrategy::GuardWithIf);
 
-    dst.compile_to_assembly("halide_memcpy.s", {src}, "halide_memcpy");
+    dst.compile_to_assembly(Internal::get_test_tmp_dir() + "halide_memcpy.s", {src}, "halide_memcpy");
     dst.compile_jit();
 
     const int32_t buffer_size = 12345678;


### PR DESCRIPTION
This allows us to run more easily in Blaze/Bazel environments, where working directories are not writable, and running with a custom working directory is inconvenient. (It also conforms with all other tests which made this change long ago)