### PR TITLE
Fix more UB

### DIFF
--- a/src/Type.cpp
+++ b/src/Type.cpp
@@ -159,10 +159,10 @@ bool Type::can_represent(uint64_t x) const {
 
 bool Type::can_represent(double x) const {
     if (is_int()) {
-        int64_t i = x;
+        int64_t i = Internal::safe_numeric_cast<int64_t>(x);
         return (x >= min_int(bits())) && (x <= max_int(bits())) && (x == (double)i);
     } else if (is_uint()) {
-        uint64_t u = x;
+        uint64_t u = Internal::safe_numeric_cast<uint64_t>(x);
         return (x >= 0) && (x <= max_uint(bits())) && (x == (double)u);
     } else if (is_float()) {
         switch (bits()) {

--- a/src/Util.h
+++ b/src/Util.h
@@ -18,6 +18,7 @@
 #include <vector>
 #include <string>
 #include <cstring>
+#include <limits>
 
 #ifndef HALIDE_EXPORT
 #if defined(_MSC_VER)
@@ -49,6 +50,22 @@
 
 namespace Halide {
 namespace Internal {
+
+/** out-of-range casts of float -> nonfloat are UB; this clamps
+ * the float to a legal range in situations where the conversion isn't
+ * statically known to be safe. */
+template<typename DST, typename SRC>
+DST safe_numeric_cast(SRC s) {
+    if (std::is_floating_point<SRC>::value && std::is_integral<DST>::value) {
+        if (s < (SRC) std::numeric_limits<DST>::min()) {
+          return std::numeric_limits<DST>::min();
+      }
+        if (s > (SRC) std::numeric_limits<DST>::max()) {
+          return std::numeric_limits<DST>::max();
+        }
+    }
+    return (DST) s;
+}
 
 /** An aggressive form of reinterpret cast used for correct type-punning. */
 template<typename DstType, typename SrcType>

--- a/src/Util.h
+++ b/src/Util.h
@@ -59,7 +59,7 @@ DST safe_numeric_cast(SRC s) {
     if (std::is_floating_point<SRC>::value && std::is_integral<DST>::value) {
         if (s < (SRC) std::numeric_limits<DST>::min()) {
           return std::numeric_limits<DST>::min();
-      }
+        }
         if (s > (SRC) std::numeric_limits<DST>::max()) {
           return std::numeric_limits<DST>::max();
         }

--- a/test/correctness/saturating_casts.cpp
+++ b/test/correctness/saturating_casts.cpp
@@ -13,6 +13,14 @@ using namespace Halide::ConciseCasts;
 
 typedef Expr (*cast_maker_t)(Expr);
 
+// Local alias for terseness. This must be used any time the
+// cast could be a float->int conversion that might not fit in the destination.
+template<typename DST, typename SRC>
+DST safe_cast(SRC s) {
+    return Internal::safe_numeric_cast<DST, SRC>(s);
+}
+
+
 template <typename source_t, typename target_t>
 void test_saturating() {
     source_t source_min, source_max;
@@ -38,11 +46,11 @@ void test_saturating() {
     in(1) = (source_t)1;
     // This can intentionally change the value if source_t is unsigned
     in(2) = (source_t)-1;
-    in(3) = (source_t)source_max;
-    in(4) = (source_t)source_min;
+    in(3) = safe_cast<source_t>(source_max);
+    in(4) = safe_cast<source_t>(source_min);
     // These two can intentionally change the value if source_t is smaller than target_t
-    in(5) = (source_t)target_min;
-    in(6) = (source_t)target_max;
+    in(5) = safe_cast<source_t>(target_min);
+    in(6) = safe_cast<source_t>(target_max);
 
     Var x;
     Func f;
@@ -70,8 +78,8 @@ void test_saturating() {
         } else if (source_signed == target_signed) {
             if (sizeof(source_t) > sizeof(target_t)) {
                 correct_result = (target_t)std::min(std::max(in(i),
-                                                             (source_t)target_min),
-                                                    (source_t)target_max);
+                                                             safe_cast<source_t>(target_min)),
+                                                    safe_cast<source_t>(target_max));
             } else {
                 correct_result = (target_t)in(i);
             }
@@ -79,13 +87,13 @@ void test_saturating() {
             if (source_signed) {
                 source_t val = std::max(in(i), (source_t)0);
                 if (sizeof(source_t) > sizeof(target_t)) {
-                    correct_result = (target_t)std::min(val, (source_t)target_max);
+                    correct_result = (target_t)std::min(val, safe_cast<source_t>(target_max));
                 } else {
                     correct_result = (target_t)val;
                 }
             } else {
                 if (sizeof(source_t) >= sizeof(target_t)) {
-                    correct_result = (target_t)std::min(in(i), (source_t)target_max);
+                    correct_result = (target_t)std::min(in(i), safe_cast<source_t>(target_max));
                 } else { // dest is signed, but larger so unsigned source_t guaranteed to fit
                     correct_result = std::min((target_t)in(i), target_max);
                 }
@@ -137,11 +145,11 @@ void test_concise(cast_maker_t cast_maker, bool saturating) {
     in(1) = (source_t)1;
     // This can intentionally change the value if source_t is unsigned
     in(2) = (source_t)-1;
-    in(3) = (source_t)source_max;
-    in(4) = (source_t)source_min;
+    in(3) = source_max;
+    in(4) = source_min;
     // These two can intentionally change the value if source_t is smaller than target_t
-    in(5) = (source_t)target_min;
-    in(6) = (source_t)target_max;
+    in(5) = safe_cast<source_t>(target_min);
+    in(6) = safe_cast<source_t>(target_max);
 
     Var x;
     Func f;
@@ -158,8 +166,8 @@ void test_concise(cast_maker_t cast_maker, bool saturating) {
         target_t correct_result;
         if (saturating) {
             if (source_floating) {
-                source_t bounded_lower = std::max(in(i), (source_t)target_min);
-                if (bounded_lower >= (source_t)target_max) {
+                source_t bounded_lower = std::max(in(i), safe_cast<source_t>(target_min));
+                if (bounded_lower >= safe_cast<source_t>(target_max)) {
                     correct_result = target_max;
                 } else {
                     correct_result = (target_t)bounded_lower;
@@ -167,8 +175,8 @@ void test_concise(cast_maker_t cast_maker, bool saturating) {
             } else if (source_signed == target_signed) {
                 if (sizeof(source_t) > sizeof(target_t)) {
                     correct_result = (target_t)std::min(std::max(in(i),
-                                                                 (source_t)target_min),
-                                                        (source_t)target_max);
+                                                                 safe_cast<source_t>(target_min)),
+                                                        safe_cast<source_t>(target_max));
                 } else {
                   correct_result = (target_t)in(i);
                 }
@@ -176,13 +184,13 @@ void test_concise(cast_maker_t cast_maker, bool saturating) {
                 if (source_signed) {
                     source_t val = std::max(in(i), (source_t)0);
                     if (sizeof(source_t) > sizeof(target_t)) {
-                        correct_result = (target_t)std::min(val, (source_t)target_max);
+                        correct_result = (target_t)std::min(val, safe_cast<source_t>(target_max));
                     } else {
                         correct_result = (target_t)val;
                     }
                 } else {
                     if (sizeof(source_t) >= sizeof(target_t)) {
-                        correct_result = (target_t)std::min(in(i), (source_t)target_max);
+                        correct_result = (target_t)std::min(in(i), safe_cast<source_t>(target_max));
                     } else { // dest is signed, but larger so unsigned source_t guaranteed to fit
                         correct_result = std::min((target_t)in(i), target_max);
                     }

--- a/test/performance/const_division.cpp
+++ b/test/performance/const_division.cpp
@@ -1,6 +1,7 @@
 #include "Halide.h"
 #include <cstdio>
 #include <cstdint>
+#include <random>
 #include "halide_benchmark.h"
 
 using namespace Halide;
@@ -104,8 +105,9 @@ bool test(int w, bool div) {
 }
 
 int main(int argc, char **argv) {
-
-    srand(time(nullptr));
+    int seed = argc > 1 ? atoi(argv[1]) : time(nullptr);
+    rng.seed(seed);
+    std::cout << "const_division test seed: " << seed << std::endl;
 
     bool success = true;
     for (int i = 0; i < 2; i++) {

--- a/test/performance/const_division.cpp
+++ b/test/performance/const_division.cpp
@@ -6,6 +6,10 @@
 using namespace Halide;
 using namespace Halide::Tools;
 
+// Use std::mt19937 instead of rand() to ensure consistent behavior on all systems.
+// Note that this returns an unsigned result of at-least-32 bits.
+std::mt19937 rng(0);
+
 template<typename T>
 bool test(int w, bool div) {
     Func f, g, h;
@@ -33,7 +37,7 @@ bool test(int w, bool div) {
 
     for (int y = 0; y < num_vals; y++) {
         for (int x = 0; x < input.width(); x++) {
-            uint32_t bits = rand() ^ (rand() << 16);
+            uint32_t bits = (uint32_t) rng();
             input(x, y) = (T)bits;
         }
     }

--- a/test/performance/thread_safe_jit.cpp
+++ b/test/performance/thread_safe_jit.cpp
@@ -49,10 +49,10 @@ void separate_func_per_thread_executor(int index) {
     for (int i = 0; i < 10; i++) {
        Buffer<int32_t> result = test.f.realize(10);
         for (int j = 0; j < 10; j++) {
-            int32_t left = (j - 1) * bufs[index](std::min(std::max(0, j - 1), 9)) + 75 * index;
-            int32_t middle = j * bufs[index](std::min(std::max(0, j), 9)) + 75 * index;
-            int32_t right = (j + 1) * bufs[index](std::min(std::max(0, j + 1), 9)) + 75 * index;
-            assert(result(j) == left + middle + right);
+            int64_t left = ((j - 1) * (int64_t) bufs[index](std::min(std::max(0, j - 1), 9)) + index * 75);
+            int64_t middle = (j * (int64_t) bufs[index](std::min(std::max(0, j), 9)) + index * 75);
+            int64_t right = ((j + 1) * (int64_t) bufs[index](std::min(std::max(0, j + 1), 9)) + index * 75);
+            assert(result(j) == (int32_t) (left + middle + right));
         }
     }
 }

--- a/test/performance/vectorize.cpp
+++ b/test/performance/vectorize.cpp
@@ -30,7 +30,7 @@ bool test(int vec_width) {
     Buffer<A> input(W, H+20);
     for (int y = 0; y < H+20; y++) {
         for (int x = 0; x < W; x++) {
-            input(x, y) = (A)((rand() & 0xffff)*0.125 + 1.0);
+            input(x, y) = Internal::safe_numeric_cast<A>((rand() & 0xffff)*0.125 + 1.0);
         }
     }
 


### PR DESCRIPTION
- Casting float->int is UB if the value won't fit in the destination; this fixes more cases found by running under UBSan.
- const_division had a left-shift-out-of-bounds UB to generated random numbers; 'fixed' by replacing with std::mt19937, which is more stable for tests anyway
- thread_safe_jit can overflow the int32 used for some calculations; int64 needed for intermediates