### PR TITLE
Allow for compact-planar images with non-increasing strides

### DIFF
--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -198,6 +198,13 @@ void do_test() {
             Buffer<T> cb4 = color_buf.embedded(color_buf.dimensions(), 0);
             std::cout << "Testing format: " << format << " for " << halide_type_of<T>() << "x4\n";
             test_round_trip(cb4, format);
+
+            // Here we add two dimensions, both with extent one
+            Buffer<T> lb4 = luma_buf.embedded(luma_buf.dimensions(), 0);
+            lb4 = lb4.embedded(lb4.dimensions(), 0);
+            std::cout << "Testing format: " << format << " for " << halide_type_of<T>() << "x4\n";
+            test_round_trip(lb4, format);
+
             continue;
         }
         if (format != "pgm") {

--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -199,11 +199,12 @@ void do_test() {
             std::cout << "Testing format: " << format << " for " << halide_type_of<T>() << "x4\n";
             test_round_trip(cb4, format);
 
-            // Here we add two dimensions, both with extent one
-            Buffer<T> lb4 = luma_buf.embedded(luma_buf.dimensions(), 0);
-            lb4 = lb4.embedded(lb4.dimensions(), 0);
+            // Here we test matching strides
+            Buffer<T> funky_buf = f.realize(10, 10, 1, 3);
+            funky_buf.fill(42);
+
             std::cout << "Testing format: " << format << " for " << halide_type_of<T>() << "x4\n";
-            test_round_trip(lb4, format);
+            test_round_trip(funky_buf, format);
 
             continue;
         }

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -815,11 +815,10 @@ bool buffer_is_compact_planar(ImageType &im) {
         if (im.dim(d-1).stride() > im.dim(d).stride()) {
             return false;
         }
-        // strides can only match if both strides are 1
+        // Strides can only match if the previous dimension has extent 1
         // (this can happen when artificially adding dimension(s), e.g.
         // to write a .tmp file)
-        if (im.dim(d-1).stride() == im.dim(d).stride() &&
-            !(im.dim(d-1).extent() == 1 && im.dim(d).extent() == 1)) {
+        if (im.dim(d-1).stride() == im.dim(d).stride() && im.dim(d-1).extent() != 1) {
             return false;
         }
     }

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -812,7 +812,14 @@ bool buffer_is_compact_planar(ImageType &im) {
         return false;
     }
     for (int d = 1; d < im.dimensions(); ++d) {
-        if (im.dim(d-1).stride() >= im.dim(d).stride()) {
+        if (im.dim(d-1).stride() > im.dim(d).stride()) {
+            return false;
+        }
+        // strides can only match if both strides are 1
+        // (this can happen when artificially adding dimension(s), e.g.
+        // to write a .tmp file)
+        if (im.dim(d-1).stride() == im.dim(d).stride() &&
+            !(im.dim(d-1).extent() == 1 && im.dim(d).extent() == 1)) {
             return false;
         }
     }


### PR DESCRIPTION
this can happen when artificially adding dimension(s) of extent 1, e.g. to write a .tmp file, which requires exactly 4 dimensions