### PR TITLE
Add a few missing pieces for add_trace_tag()

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1560,6 +1560,7 @@ public:
     HALIDE_FORWARD_METHOD_CONST(ImageParam, height)
     HALIDE_FORWARD_METHOD_CONST(ImageParam, channels)
     HALIDE_FORWARD_METHOD_CONST(ImageParam, trace_loads)
+    HALIDE_FORWARD_METHOD_CONST(ImageParam, add_trace_tag)
     // }@
 };
 
@@ -1883,6 +1884,7 @@ protected:
 public:
     /** Forward schedule-related methods to the underlying Func. */
     // @{
+    HALIDE_FORWARD_METHOD(Func, add_trace_tag)
     HALIDE_FORWARD_METHOD(Func, align_bounds)
     HALIDE_FORWARD_METHOD(Func, align_storage)
     HALIDE_FORWARD_METHOD_CONST(Func, args)

--- a/src/ImageParam.cpp
+++ b/src/ImageParam.cpp
@@ -87,4 +87,10 @@ void ImageParam::trace_loads() {
     func.trace_loads();
 }
 
+ImageParam &ImageParam::add_trace_tag(const std::string &trace_tag) {
+    internal_assert(func.defined());
+    func.add_trace_tag(trace_tag);
+    return *this;
+}
+
 }

--- a/src/ImageParam.h
+++ b/src/ImageParam.h
@@ -131,6 +131,9 @@ public:
 
     /** Trace all loads from this ImageParam by emitting calls to halide_trace. */
     void trace_loads();
+
+    /** Add a trace tag to this ImageParam's Func. */
+    ImageParam &add_trace_tag(const std::string &trace_tag);
 };
 
 }

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -434,7 +434,6 @@ int run(int argc, char **argv) {
             FuncInfo &fi = func_info[func];
             fi.config.labels.swap(config.labels);
             fi.config = config;
-            fi.config.dump(func);
             fi.configured = true;
         } else if (next == "--min") {
             expect(i + 1 < argc, i);

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -35,31 +35,8 @@ using std::queue;
 using std::array;
 using std::pair;
 
-std::ostream &operator<<(std::ostream &stream, const vector<int> &v) {
-    stream << "[ ";
-    bool need_comma = false;
-    for (int i : v) {
-        if (need_comma) {
-            stream << ", ";
-        }
-        stream << i;
-        need_comma = true;
-    }
-    stream << " ]";
-    return stream;
-}
-
-std::ostream &operator<<(std::ostream &stream, const vector<pair<int, int>> &v) {
-    stream << "[ ";
-    bool need_comma = false;
-    for (auto &pt : v) {
-        if (need_comma) {
-            stream << ", ";
-        }
-        stream << "(" << pt.first << "," << pt.second << ")";
-        need_comma = true;
-    }
-    stream << " ]";
+std::ostream &operator<<(std::ostream &stream, const pair<int, int> &pt) {
+    stream << "(" << pt.first << "," << pt.second << ")";
     return stream;
 }
 
@@ -68,6 +45,26 @@ struct Label {
     string text;
     int x, y, n;
 };
+
+std::ostream &operator<<(std::ostream &stream, const Label &label) {
+    stream << "text=\"" << label.text << " @ " << label.x << " " << label.y << " n=" << label.n;
+    return stream;
+}
+
+template<typename T>
+std::ostream &operator<<(std::ostream &stream, const vector<T> &v) {
+    stream << "[ ";
+    bool need_comma = false;
+    for (const T &t : v) {
+        if (need_comma) {
+            stream << ", ";
+        }
+        stream << t;
+        need_comma = true;
+    }
+    stream << " ]";
+    return stream;
+}
 
 // A struct specifying how a single Func will get visualized.
 struct FuncInfo {
@@ -88,7 +85,7 @@ struct FuncInfo {
         bool blank_on_end_realization = false;
         uint32_t uninitialized_memory_color = 0xff000000;
 
-        void dump(const char *name) {
+        void dump(const string &name) const {
             std::cerr <<
                     "Func " << name << ":\n" <<
                     " min: " << min << " max: " << max << "\n" <<
@@ -99,7 +96,8 @@ struct FuncInfo {
                     " load cost: " << load_cost << "\n" <<
                     " store cost: " << store_cost << "\n" <<
                     " x: " << x << " y: " << y << "\n" <<
-                    " strides: " << strides << "\n";
+                    " strides: " << strides << "\n" <<
+                    " labels: " << labels << "\n";
         }
     } config;
 
@@ -532,6 +530,7 @@ int run(int argc, char **argv) {
     // of these events have been output. When halide_clock gets ahead
     // of video_clock, we emit a new frame.
     size_t halide_clock = 0, video_clock = 0;
+    bool func_info_dumped = false;
 
     // There are three layers - image data, an animation on top of
     // it, and text labels. These layers get composited.
@@ -633,6 +632,22 @@ int run(int argc, char **argv) {
             assert(pipeline_info.count(p.parent_id));
             pipeline_info.erase(p.parent_id);
             continue;
+        } else if (p.event == halide_trace_tag) {
+            // If there are trace tags, they will come immediately after the pipeline's
+            // halide_trace_begin_pipeline but before any realizations.
+            std::cerr << "Ignoring trace_tag: (" << p.trace_tag() << ")\n";
+            continue;
+        }
+
+        if (!func_info_dumped) {
+            // dump after any tags are handled
+            for (const auto &p : func_info) {
+                const auto &fi = p.second;
+                if (fi.configured) {
+                    fi.config.dump(p.first);
+                }
+            }
+            func_info_dumped = true;
         }
 
         PipelineInfo pipeline = pipeline_info[p.parent_id];
@@ -679,7 +694,7 @@ int run(int argc, char **argv) {
         for (size_t i = 0; i < fi.config.labels.size(); i++) {
             const Label &label = fi.config.labels[i];
             if (frames_since_first_draw <= label.n) {
-                uint32_t color = ((1 + frames_since_first_draw) * 255) / std::min(1, label.n);
+                uint32_t color = ((1 + frames_since_first_draw) * 255) / std::max(1, label.n);
                 if (color > 255) color = 255;
                 color *= 0x10101;
 
@@ -799,6 +814,7 @@ int run(int argc, char **argv) {
         // these should just be ignored.
         case halide_trace_begin_pipeline:
         case halide_trace_end_pipeline:
+        case halide_trace_tag:
             break;
         default:
             std::cerr << "Unknown tracing event code: " << p.event << "\n";


### PR DESCRIPTION
- ImageParam and Input<Buffer> need forwarding methods
- Tracing.cpp didn't handle trace_all_loads and could have duplicates emitted, and didn't handle all Call nodes correctly
- HalideTraceViz: process (but ignore) trace_tag nodes; dump the trace_tag to output; drive-by cleanup to emit Labels in verbose mode; drive-by fix to text fade-in calculation time

(split from #2838 as some of the details of that are still under debate)