### PR TITLE
Handle buffers that are both read and written.

### DIFF
--- a/src/Closure.cpp
+++ b/src/Closure.cpp
@@ -41,8 +41,8 @@ void Closure::found_buffer_ref(const string &name, Type type,
         debug(3) << "Adding buffer " << name << " to closure\n";
         Buffer &ref = buffers[name];
         ref.type = type.element_of(); // TODO: Validate type is the same as existing refs?
-        ref.read = read;
-        ref.write = written;
+        ref.read = ref.read || read;
+        ref.write = ref.write || written;
 
         // If reading an image/buffer, compute the size.
         if (image.defined()) {


### PR DESCRIPTION
At least one user of this class assumes that it's possible for a buffer
in the scope to be both read and written:

https://github.com/halide/Halide/blob/80a48bf501e53f6f6e6b419ba60dc4839f2862e1/src/HexagonOffload.cpp#L821

However, currently the last access always wins.