### PR TITLE
Add Target::NoLegacyWrapper feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1132,10 +1132,10 @@ $(FILTERS_DIR)/cxx_mangling_define_extern.a: $(BIN_DIR)/cxx_mangling_define_exte
 	$(CURDIR)/$< -g cxx_mangling_define_extern $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime-c_plus_plus_name_mangling-user_context -f "HalideTest::cxx_mangling_define_extern"
 	$(ROOT_DIR)/tools/makelib.sh $@ $@  $(FILTERS_DIR)/cxx_mangling_define_extern_externs.o
 
-# pyramid needs a custom arg
+# pyramid needs a custom arg. Also uses no_legacy_wrapper just to ensure we have test coverage for it.
 $(FILTERS_DIR)/pyramid.a: $(BIN_DIR)/pyramid.generator
 	@mkdir -p $(@D)
-	$(CURDIR)/$< -g pyramid -f pyramid $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime levels=10
+	$(CURDIR)/$< -g pyramid -f pyramid $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime-no_legacy_wrapper levels=10
 
 # memory_profiler_mandelbrot need profiler set
 $(FILTERS_DIR)/memory_profiler_mandelbrot.a: $(BIN_DIR)/memory_profiler_mandelbrot.generator

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -218,14 +218,16 @@ CodeGen_C::CodeGen_C(ostream &s, Target t, OutputKind output_kind, const std::st
                << "// Metadata describing the arguments to the generated function.\n"
                << "// Used to construct calls to the _argv version of the function.\n"
                << "struct halide_filter_metadata_t;\n"
-               << "\n"
-               << "// The legacy buffer type. Do not use in new code.\n"
-               << "struct buffer_t;\n"
                << "\n";
         // We just forward declared the following types:
         forward_declared.insert(type_of<halide_buffer_t *>().handle_type);
         forward_declared.insert(type_of<halide_filter_metadata_t *>().handle_type);
-        forward_declared.insert(type_of<buffer_t *>().handle_type);
+        if (!t.has_feature(Target::NoLegacyWrapper)) {
+            stream << "// The legacy buffer type. Do not use in new code.\n"
+                   << "struct buffer_t;\n"
+                   << "\n";
+            forward_declared.insert(type_of<buffer_t *>().handle_type);
+        }
     } else {
         // Include declarations of everything generated C source might want
         stream

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -744,7 +744,9 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
             modules.push_back(get_initmod_device_interface(c, bits_64, debug));
             modules.push_back(get_initmod_metadata(c, bits_64, debug));
             modules.push_back(get_initmod_float16_t(c, bits_64, debug));
-            modules.push_back(get_initmod_old_buffer_t(c, bits_64, debug));
+            if (!t.has_feature(Target::NoLegacyWrapper)) {
+                modules.push_back(get_initmod_old_buffer_t(c, bits_64, debug));
+            }
             modules.push_back(get_initmod_errors(c, bits_64, debug));
 
             // MIPS doesn't support the atomics the profiler requires.

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -265,6 +265,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"trace_stores", Target::TraceStores},
     {"trace_realizations", Target::TraceRealizations},
     {"strict_float", Target::StrictFloat},
+    {"no_legacy_wrapper", Target::NoLegacyWrapper},
 };
 
 bool lookup_feature(const std::string &tok, Target::Feature &result) {

--- a/src/Target.h
+++ b/src/Target.h
@@ -87,6 +87,7 @@ struct Target {
         TraceStores = halide_target_feature_trace_stores,
         TraceRealizations = halide_target_feature_trace_realizations,
         StrictFloat = halide_target_feature_strict_float,
+        NoLegacyWrapper = halide_target_feature_no_legacy_wrapper,
         FeatureEnd = halide_target_feature_end
     };
     Target() : os(OSUnknown), arch(ArchUnknown), bits(0) {}

--- a/src/WrapExternStages.cpp
+++ b/src/WrapExternStages.cpp
@@ -159,6 +159,10 @@ void wrap_legacy_extern_stages(Module m) {
 }
 
 void add_legacy_wrapper(Module module, const LoweredFunc &fn) {
+    if (module.target().has_feature(Target::NoLegacyWrapper)) {
+        return;
+    }
+
     // Build the arguments to the wrapper function
     vector<LoweredArgument> args;
     vector<Stmt> upgrades, downgrades;

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1107,7 +1107,8 @@ typedef enum halide_target_feature_t {
     halide_target_feature_hvx_v66 = 48, ///< Enable Hexagon v66 architecture.
     halide_target_feature_cl_half = 49,  ///< Enable half support on OpenCL targets
     halide_target_feature_strict_float = 50, ///< Turn off all non-IEEE floating-point optimization. Currently applies only to LLVM targets.
-    halide_target_feature_end = 51, ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
+    halide_target_feature_no_legacy_wrapper = 51,  ///< Don't emit legacy wrapper code for buffer_t (vs halide_buffer_t) when AOT-compiled.
+    halide_target_feature_end = 52, ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 
 /** This function is called internally by Halide in some situations to determine

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -285,7 +285,9 @@ if (WITH_TEST_GENERATOR)
                            HALIDE_TARGET_FEATURES debug)
   # endif()
 
+  # pyramid needs a custom arg. Also uses no_legacy_wrapper just to ensure we have test coverage for it.
   halide_define_aot_test(pyramid
+                         HALIDE_TARGET_FEATURES no_legacy_wrapper
                          GENERATOR_ARGS levels=10)
 
   halide_define_aot_test(msan


### PR DESCRIPTION
This is a feature that disables generating the classic 'buffer_t' wrapper code for AOT compilation; while this code is fairly harmless and is usually just dead-stripped away, it can be useful for easily verifying whether a large codebase still depends on the wrappers. (As such, it may be overkill for actual submission to Halide; I needed it for my own purposes, so thought I'd offer it here in case it is useful to others.)

(Note that I'd prefer to invert the sense of the flag, and make 'generate wrappers' as an opt-in rather than opt-out, but it's not clear how much downstream code this would break in the short term.)