### PR TITLE
Split NO_INLINE in two

### DIFF
--- a/python_bindings/src/PyScheduleMethods.h
+++ b/python_bindings/src/PyScheduleMethods.h
@@ -8,7 +8,7 @@ namespace PythonBindings {
 
 // Methods that are defined on both Func and Stage.
 template <typename PythonClass>
-NO_INLINE void add_schedule_methods(PythonClass &class_instance) {
+HALIDE_NEVER_INLINE void add_schedule_methods(PythonClass &class_instance) {
     using T = typename PythonClass::type;
 
     class_instance

--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -56,7 +56,7 @@ inline const Func &func_like_to_func(const Func &func) {
 }
 
 template <typename T>
-inline NO_INLINE Func func_like_to_func(const T &func_like) {
+inline HALIDE_NO_USER_CODE_INLINE Func func_like_to_func(const T &func_like) {
     return lambda(_, func_like(_));
 }
 
@@ -87,7 +87,7 @@ Func constant_exterior(const Func &source, Expr value,
                        const std::vector<std::pair<Expr, Expr>> &bounds);
 
 template <typename T>
-inline NO_INLINE Func constant_exterior(const T &func_like, Tuple value) {
+inline HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, Tuple value) {
     std::vector<std::pair<Expr, Expr>> object_bounds;
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.push_back({ Expr(func_like.dim(i).min()), Expr(func_like.dim(i).extent()) });
@@ -96,13 +96,13 @@ inline NO_INLINE Func constant_exterior(const T &func_like, Tuple value) {
     return constant_exterior(Internal::func_like_to_func(func_like), value, object_bounds);
 }
 template <typename T>
-inline NO_INLINE Func constant_exterior(const T &func_like, Expr value) {
+inline HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, Expr value) {
     return constant_exterior(func_like, Tuple(value));
 }
 
 template <typename T, typename ...Bounds,
           typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type* = nullptr>
-inline NO_INLINE Func constant_exterior(const T &func_like, Tuple value,
+inline HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, Tuple value,
                                         Bounds&&... bounds) {
     std::vector<std::pair<Expr, Expr>> collected_bounds;
     ::Halide::Internal::collect_paired_args(collected_bounds, std::forward<Bounds>(bounds)...);
@@ -110,7 +110,7 @@ inline NO_INLINE Func constant_exterior(const T &func_like, Tuple value,
 }
 template <typename T, typename ...Bounds,
           typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type* = nullptr>
-inline NO_INLINE Func constant_exterior(const T &func_like, Expr value,
+inline HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, Expr value,
                                         Bounds&&... bounds) {
     return constant_exterior(func_like, Tuple(value), std::forward<Bounds>(bounds)...);
 }
@@ -133,7 +133,7 @@ Func repeat_edge(const Func &source,
                  const std::vector<std::pair<Expr, Expr>> &bounds);
 
 template <typename T>
-inline NO_INLINE Func repeat_edge(const T &func_like) {
+inline HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like) {
     std::vector<std::pair<Expr, Expr>> object_bounds;
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.push_back({ Expr(func_like.dim(i).min()), Expr(func_like.dim(i).extent()) });
@@ -145,7 +145,7 @@ inline NO_INLINE Func repeat_edge(const T &func_like) {
 
 template <typename T, typename ...Bounds,
           typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type* = nullptr>
-inline NO_INLINE Func repeat_edge(const T &func_like, Bounds&&... bounds) {
+inline HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like, Bounds&&... bounds) {
     std::vector<std::pair<Expr, Expr>> collected_bounds;
     ::Halide::Internal::collect_paired_args(collected_bounds, std::forward<Bounds>(bounds)...);
     return repeat_edge(Internal::func_like_to_func(func_like), collected_bounds);
@@ -169,7 +169,7 @@ Func repeat_image(const Func &source,
                   const std::vector<std::pair<Expr, Expr>> &bounds);
 
 template <typename T>
-inline NO_INLINE Func repeat_image(const T &func_like) {
+inline HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like) {
     std::vector<std::pair<Expr, Expr>> object_bounds;
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.push_back({ Expr(func_like.dim(i).min()), Expr(func_like.dim(i).extent()) });
@@ -180,7 +180,7 @@ inline NO_INLINE Func repeat_image(const T &func_like) {
 
 template <typename T, typename ...Bounds,
           typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type* = nullptr>
-inline NO_INLINE Func repeat_image(const T &func_like, Bounds&&... bounds) {
+inline HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like, Bounds&&... bounds) {
     std::vector<std::pair<Expr, Expr>> collected_bounds;
     ::Halide::Internal::collect_paired_args(collected_bounds, std::forward<Bounds>(bounds)...);
     return repeat_image(Internal::func_like_to_func(func_like), collected_bounds);
@@ -204,7 +204,7 @@ Func mirror_image(const Func &source,
                   const std::vector<std::pair<Expr, Expr>> &bounds);
 
 template <typename T>
-inline NO_INLINE Func mirror_image(const T &func_like) {
+inline HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like) {
     std::vector<std::pair<Expr, Expr>> object_bounds;
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.push_back({ Expr(func_like.dim(i).min()), Expr(func_like.dim(i).extent()) });
@@ -215,7 +215,7 @@ inline NO_INLINE Func mirror_image(const T &func_like) {
 
 template <typename T, typename ...Bounds,
           typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type* = nullptr>
-inline NO_INLINE Func mirror_image(const T &func_like, Bounds&&... bounds) {
+inline HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like, Bounds&&... bounds) {
     std::vector<std::pair<Expr, Expr>> collected_bounds;
     ::Halide::Internal::collect_paired_args(collected_bounds, std::forward<Bounds>(bounds)...);
     return mirror_image(Internal::func_like_to_func(func_like), collected_bounds);
@@ -242,7 +242,7 @@ Func mirror_interior(const Func &source,
                      const std::vector<std::pair<Expr, Expr>> &bounds);
 
 template <typename T>
-inline NO_INLINE Func mirror_interior(const T &func_like) {
+inline HALIDE_NO_USER_CODE_INLINE Func mirror_interior(const T &func_like) {
     std::vector<std::pair<Expr, Expr>> object_bounds;
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.push_back({ Expr(func_like.dim(i).min()), Expr(func_like.dim(i).extent()) });
@@ -253,7 +253,7 @@ inline NO_INLINE Func mirror_interior(const T &func_like) {
 
 template <typename T, typename ...Bounds,
           typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type* = nullptr>
-inline NO_INLINE Func mirror_interior(const T &func_like, Bounds&&... bounds) {
+inline HALIDE_NO_USER_CODE_INLINE Func mirror_interior(const T &func_like, Bounds&&... bounds) {
     std::vector<std::pair<Expr, Expr>> collected_bounds;
     ::Halide::Internal::collect_paired_args(collected_bounds, std::forward<Bounds>(bounds)...);
     return mirror_interior(Internal::func_like_to_func(func_like), collected_bounds);

--- a/src/Error.h
+++ b/src/Error.h
@@ -149,7 +149,7 @@ class Voidifier {
 // N.B. Any function that might throw a user_assert or user_error may
 // not be inlined into the user's code, or the line number will be
 // misattributed to Halide.h. Either make such functions internal to
-// libHalide, or mark them as NO_INLINE.
+// libHalide, or mark them as HALIDE_NO_USER_CODE_INLINE.
 
 }
 

--- a/src/Func.h
+++ b/src/Func.h
@@ -331,7 +331,7 @@ public:
     Stage &reorder(const std::vector<VarOrRVar> &vars);
 
     template <typename... Args>
-    NO_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Stage &>::type
+    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Stage &>::type
     reorder(VarOrRVar x, VarOrRVar y, Args&&... args) {
         std::vector<VarOrRVar> collected_args{x, y, std::forward<Args>(args)...};
         return reorder(collected_args);
@@ -660,7 +660,7 @@ public:
 
     /** Construct a new Func to wrap a Buffer. */
     template<typename T>
-    NO_INLINE explicit Func(Buffer<T> &im) : Func() {
+    HALIDE_NO_USER_CODE_INLINE explicit Func(Buffer<T> &im) : Func() {
         (*this)(_) = im(_);
     }
 
@@ -1231,7 +1231,7 @@ public:
     FuncRef operator()(std::vector<Var>) const;
 
     template <typename... Args>
-    NO_INLINE typename std::enable_if<Internal::all_are_convertible<Var, Args...>::value, FuncRef>::type
+    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<Var, Args...>::value, FuncRef>::type
     operator()(Args&&... args) const {
         std::vector<Var> collected_args{std::forward<Args>(args)...};
         return this->operator()(collected_args);
@@ -1248,7 +1248,7 @@ public:
     FuncRef operator()(std::vector<Expr>) const;
 
     template <typename... Args>
-    NO_INLINE typename std::enable_if<Internal::all_are_convertible<Expr, Args...>::value, FuncRef>::type
+    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<Expr, Args...>::value, FuncRef>::type
     operator()(Expr x, Args&&... args) const {
         std::vector<Expr> collected_args{x, std::forward<Args>(args)...};
         return (*this)(collected_args);
@@ -1516,7 +1516,7 @@ public:
     Func &reorder(const std::vector<VarOrRVar> &vars);
 
     template <typename... Args>
-    NO_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Func &>::type
+    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Func &>::type
     reorder(VarOrRVar x, VarOrRVar y, Args&&... args) {
         std::vector<VarOrRVar> collected_args{x, y, std::forward<Args>(args)...};
         return reorder(collected_args);
@@ -1903,7 +1903,7 @@ public:
 
     Func &reorder_storage(Var x, Var y);
     template <typename... Args>
-    NO_INLINE typename std::enable_if<Internal::all_are_convertible<Var, Args...>::value, Func &>::type
+    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<Var, Args...>::value, Func &>::type
     reorder_storage(Var x, Var y, Args&&... args) {
         std::vector<Var> collected_args{x, y, std::forward<Args>(args)...};
         return reorder_storage(collected_args);
@@ -2328,7 +2328,7 @@ inline void assign_results(Realization &r, int idx, First first, Second second, 
  * expression. This can be thought of as a scalar version of
  * \ref Func::realize */
 template<typename T>
-NO_INLINE T evaluate(Expr e) {
+HALIDE_NO_USER_CODE_INLINE T evaluate(Expr e) {
     user_assert(e.type() == type_of<T>())
         << "Can't evaluate expression "
         << e << " of type " << e.type()
@@ -2341,7 +2341,7 @@ NO_INLINE T evaluate(Expr e) {
 
 /** JIT-compile and run enough code to evaluate a Halide Tuple. */
 template <typename First, typename... Rest>
-NO_INLINE void evaluate(Tuple t, First first, Rest&&... rest) {
+HALIDE_NO_USER_CODE_INLINE void evaluate(Tuple t, First first, Rest&&... rest) {
     Internal::check_types<First, Rest...>(t, 0);
 
     Func f;
@@ -2371,7 +2371,7 @@ inline void schedule_scalar(Func f) {
  * specifies one.
  */
 template<typename T>
-NO_INLINE T evaluate_may_gpu(Expr e) {
+HALIDE_NO_USER_CODE_INLINE T evaluate_may_gpu(Expr e) {
     user_assert(e.type() == type_of<T>())
         << "Can't evaluate expression "
         << e << " of type " << e.type()
@@ -2387,7 +2387,7 @@ NO_INLINE T evaluate_may_gpu(Expr e) {
  *  use GPU if jit target from environment specifies one. */
 // @{
 template <typename First, typename... Rest>
-NO_INLINE void evaluate_may_gpu(Tuple t, First first, Rest&&... rest) {
+HALIDE_NO_USER_CODE_INLINE void evaluate_may_gpu(Tuple t, First first, Rest&&... rest) {
     Internal::check_types<First, Rest...>(t, 0);
 
     Func f;

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -329,7 +329,7 @@ void StubEmitter::emit_generator_params_struct() {
         stream << "\n";
     }
 
-    stream << indent() << "inline NO_INLINE Halide::Internal::GeneratorParamsMap to_generator_params_map() const {\n";
+    stream << indent() << "inline HALIDE_NO_USER_CODE_INLINE Halide::Internal::GeneratorParamsMap to_generator_params_map() const {\n";
     indent_level++;
     stream << indent() << "return {\n";
     indent_level++;
@@ -578,7 +578,7 @@ void StubEmitter::emit() {
     stream << indent() << "};\n";
     stream << "\n";
 
-    stream << indent() << "NO_INLINE static Outputs generate(\n";
+    stream << indent() << "HALIDE_NO_USER_CODE_INLINE static Outputs generate(\n";
     indent_level++;
     stream << indent() << "const GeneratorContext& context,\n";
     stream << indent() << "const Inputs& inputs,\n";

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -285,7 +285,7 @@ public:
 std::vector<Expr> parameter_constraints(const Parameter &p);
 
 template <typename T>
-NO_INLINE std::string enum_to_string(const std::map<std::string, T> &enum_map, const T& t) {
+HALIDE_NO_USER_CODE_INLINE std::string enum_to_string(const std::map<std::string, T> &enum_map, const T& t) {
     for (auto key_value : enum_map) {
         if (t == key_value.second) {
             return key_value.first;
@@ -804,7 +804,7 @@ public:
 
         // TODO: since we generate the enums, we could probably just use a vector (or array!) rather than a map,
         // since we can ensure that the enum values are a nice tight range.
-        oss << "inline NO_INLINE const std::map<Enum_" << this->name << ", std::string>& Enum_" << this->name << "_map() {\n";
+        oss << "inline HALIDE_NO_USER_CODE_INLINE const std::map<Enum_" << this->name << ", std::string>& Enum_" << this->name << "_map() {\n";
         oss << "  static const std::map<Enum_" << this->name << ", std::string> m = {\n";
         for (auto key_value : enum_map) {
             oss << "    { Enum_" << this->name << "::" << key_value.first << ", \"" << key_value.first << "\"},\n";
@@ -1095,7 +1095,7 @@ class StubInputBuffer {
 
     Parameter parameter_;
 
-    NO_INLINE explicit StubInputBuffer(const Parameter &p) : parameter_(p) {
+    HALIDE_NO_USER_CODE_INLINE explicit StubInputBuffer(const Parameter &p) : parameter_(p) {
         // Create an empty 1-element buffer with the right runtime typing and dimensions,
         // which we'll use only to pass to can_convert_from() to verify this
         // Parameter is compatible with our constraints.
@@ -1104,7 +1104,7 @@ class StubInputBuffer {
     }
 
     template<typename T2>
-    NO_INLINE static Parameter parameter_from_buffer(const Buffer<T2> &b) {
+    HALIDE_NO_USER_CODE_INLINE static Parameter parameter_from_buffer(const Buffer<T2> &b) {
         user_assert((Buffer<T>::can_convert_from(b)));
         Parameter p(b.type(), true, b.dimensions());
         p.set_buffer(b);
@@ -1872,7 +1872,7 @@ namespace Internal {
 class GeneratorOutputBase : public GIOBase {
 protected:
     template<typename T2, typename std::enable_if<std::is_same<T2, Func>::value>::type * = nullptr>
-    NO_INLINE T2 as() const {
+    HALIDE_NO_USER_CODE_INLINE T2 as() const {
         static_assert(std::is_same<T2, Func>::value, "Only Func allowed here");
         internal_assert(kind() != IOKind::Scalar);
         internal_assert(exprs_.empty());
@@ -2060,7 +2060,7 @@ class GeneratorOutput_Buffer : public GeneratorOutputImpl<T> {
 private:
     using Super = GeneratorOutputImpl<T>;
 
-    NO_INLINE void assign_from_func(const Func &f) {
+    HALIDE_NO_USER_CODE_INLINE void assign_from_func(const Func &f) {
         this->check_value_writable();
 
         internal_assert(f.defined());
@@ -2106,7 +2106,7 @@ protected:
         user_assert(t.empty()) << "You cannot specify a Type argument for Output<Buffer<>>\n";
     }
 
-    NO_INLINE std::string get_c_type() const override {
+    HALIDE_NO_USER_CODE_INLINE std::string get_c_type() const override {
         if (TBase::has_static_halide_type) {
             return "Halide::Internal::StubOutputBuffer<" +
                 halide_type_to_c_type(TBase::static_halide_type()) +
@@ -2117,7 +2117,7 @@ protected:
     }
 
     template<typename T2, typename std::enable_if<!std::is_same<T2, Func>::value>::type * = nullptr>
-    NO_INLINE T2 as() const {
+    HALIDE_NO_USER_CODE_INLINE T2 as() const {
         return (T2) *this;
     }
 
@@ -2130,7 +2130,7 @@ public:
     // using it in a Pipeline might change the dev field so it is currently
     // not considered const. We should consider how this really ought to work.
     template<typename T2>
-    NO_INLINE GeneratorOutput_Buffer<T> &operator=(Buffer<T2> &buffer) {
+    HALIDE_NO_USER_CODE_INLINE GeneratorOutput_Buffer<T> &operator=(Buffer<T2> &buffer) {
         this->check_value_writable();
 
         user_assert(T::can_convert_from(buffer))
@@ -2199,7 +2199,7 @@ class GeneratorOutput_Func : public GeneratorOutputImpl<T> {
 private:
     using Super = GeneratorOutputImpl<T>;
 
-    NO_INLINE Func &get_assignable_func_ref(size_t i) {
+    HALIDE_NO_USER_CODE_INLINE Func &get_assignable_func_ref(size_t i) {
         internal_assert(this->exprs_.empty() && this->funcs_.size() > i);
         return this->funcs_.at(i);
     }

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1721,17 +1721,17 @@ inline Expr random_int(Expr seed = Expr()) {
 
 // Secondary args to print can be Exprs or const char *
 namespace Internal {
-inline NO_INLINE void collect_print_args(std::vector<Expr> &args) {
+inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &args) {
 }
 
 template<typename ...Args>
-inline NO_INLINE void collect_print_args(std::vector<Expr> &args, const char *arg, Args&&... more_args) {
+inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &args, const char *arg, Args&&... more_args) {
     args.push_back(Expr(std::string(arg)));
     collect_print_args(args, std::forward<Args>(more_args)...);
 }
 
 template<typename ...Args>
-inline NO_INLINE void collect_print_args(std::vector<Expr> &args, Expr arg, Args&&... more_args) {
+inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &args, Expr arg, Args&&... more_args) {
     args.push_back(std::move(arg));
     collect_print_args(args, std::forward<Args>(more_args)...);
 }
@@ -1745,7 +1745,7 @@ inline NO_INLINE void collect_print_args(std::vector<Expr> &args, Expr arg, Args
 Expr print(const std::vector<Expr> &values);
 
 template <typename... Args>
-inline NO_INLINE Expr print(Expr a, Args&&... args) {
+inline HALIDE_NO_USER_CODE_INLINE Expr print(Expr a, Args&&... args) {
     std::vector<Expr> collected_args = {std::move(a)};
     Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
     return print(collected_args);
@@ -1758,7 +1758,7 @@ inline NO_INLINE Expr print(Expr a, Args&&... args) {
 Expr print_when(Expr condition, const std::vector<Expr> &values);
 
 template<typename ...Args>
-inline NO_INLINE Expr print_when(Expr condition, Expr a, Args&&... args) {
+inline HALIDE_NO_USER_CODE_INLINE Expr print_when(Expr condition, Expr a, Args&&... args) {
     std::vector<Expr> collected_args = {std::move(a)};
     Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
     return print_when(std::move(condition), collected_args);
@@ -1791,7 +1791,7 @@ inline NO_INLINE Expr print_when(Expr condition, Expr a, Args&&... args) {
 Expr require(Expr condition, const std::vector<Expr> &values);
 
 template<typename ...Args>
-inline NO_INLINE Expr require(Expr condition, Expr value, Args&&... args) {
+inline HALIDE_NO_USER_CODE_INLINE Expr require(Expr condition, Expr value, Args&&... args) {
     std::vector<Expr> collected_args = {std::move(value)};
     Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
     return require(std::move(condition), collected_args);
@@ -1861,7 +1861,7 @@ Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_values);
  * on the digest. */
 // @{
 template<typename ...Args>
-inline NO_INLINE Expr memoize_tag(Expr result, Args&&... args) {
+inline HALIDE_NO_USER_CODE_INLINE Expr memoize_tag(Expr result, Args&&... args) {
     std::vector<Expr> collected_args{std::forward<Args>(args)...};
     return Internal::memoize_tag_helper(std::move(result), collected_args);
 }

--- a/src/ImageParam.h
+++ b/src/ImageParam.h
@@ -59,7 +59,7 @@ public:
      */
     // @{
     template <typename... Args>
-    NO_INLINE Expr operator()(Args&&... args) const {
+    HALIDE_NO_USER_CODE_INLINE Expr operator()(Args&&... args) const {
         return func(std::forward<Args>(args)...);
     }
     Expr operator()(std::vector<Expr>) const;

--- a/src/Param.h
+++ b/src/Param.h
@@ -171,7 +171,7 @@ public:
     /** Get the current value of this parameter. Only meaningful when jitting.
         Asserts if type does not exactly match the Parameter's type. */
     template<typename T2 = not_void_T>
-    NO_INLINE T2 get() const {
+    HALIDE_NO_USER_CODE_INLINE T2 get() const {
         return param.scalar<T2>();
     }
 
@@ -179,7 +179,7 @@ public:
         Asserts if type is not losslessly-convertible to Parameter's type. */
     // @{
     template <typename SOME_TYPE, typename T2 = T, typename std::enable_if<!std::is_void<T2>::value>::type * = nullptr>
-    NO_INLINE void set(const SOME_TYPE &val) {
+    HALIDE_NO_USER_CODE_INLINE void set(const SOME_TYPE &val) {
         user_assert(Internal::IsRoundtrippable<T>::value(val))
             << "The value " << val << " cannot be losslessly converted to type " << type();
         param.set_scalar<T>(val);
@@ -189,7 +189,7 @@ public:
     // not compiletime). Note that this actually works fine for all Params; we specialize
     // it just to reduce code size for the common case of T != void.
     template <typename SOME_TYPE, typename T2 = T, typename std::enable_if<std::is_void<T2>::value>::type * = nullptr>
-    NO_INLINE void set(const SOME_TYPE &val) {
+    HALIDE_NO_USER_CODE_INLINE void set(const SOME_TYPE &val) {
     #define HALIDE_HANDLE_TYPE_DISPATCH(CODE, BITS, TYPE) \
         case halide_type_code(CODE, BITS): \
             user_assert(Internal::IsRoundtrippable<TYPE>::value(val)) \

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -73,7 +73,7 @@ public:
     /** If the parameter is a scalar parameter, get its currently
      * bound value. Only relevant when jitting */
     template<typename T>
-    NO_INLINE T scalar() const {
+    HALIDE_NO_USER_CODE_INLINE T scalar() const {
         // Allow scalar<uint64_t>() for all Handle types
         user_assert(type() == type_of<T>() || (type().is_handle() && type_of<T>() == UInt(64)))
             << "Can't get Param<" << type()
@@ -88,7 +88,7 @@ public:
     /** If the parameter is a scalar parameter, set its current
      * value. Only relevant when jitting */
     template<typename T>
-    NO_INLINE void set_scalar(T val) {
+    HALIDE_NO_USER_CODE_INLINE void set_scalar(T val) {
         // Allow set_scalar<uint64_t>() for all Handle types
         user_assert(type() == type_of<T>() || (type().is_handle() && type_of<T>() == UInt(64)))
             << "Can't set Param<" << type()
@@ -98,7 +98,7 @@ public:
 
     /** If the parameter is a scalar parameter, set its current
      * value. Only relevant when jitting */
-    NO_INLINE void set_scalar(const Type &val_type, halide_scalar_value_t val) {
+    HALIDE_NO_USER_CODE_INLINE void set_scalar(const Type &val_type, halide_scalar_value_t val) {
         user_assert(type() == val_type || (type().is_handle() && val_type == UInt(64)))
             << "Can't set Param<" << type()
             << "> to scalar of type " << val_type << "\n";

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -70,7 +70,7 @@ public:
         template<typename T, int D>
         RealizationArg(Runtime::Buffer<T, D> &dst) : buf(dst.raw_buffer()) { }
         template <typename T>
-        NO_INLINE RealizationArg(Buffer<T> &dst) : buf(dst.raw_buffer()) { }
+        HALIDE_NO_USER_CODE_INLINE RealizationArg(Buffer<T> &dst) : buf(dst.raw_buffer()) { }
         template<typename T, typename ...Args,
                  typename = typename std::enable_if<Internal::all_are_convertible<Buffer<>, Args...>::value>::type>
             RealizationArg(Buffer<T> &a, Args&&... args) {

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -184,7 +184,7 @@ class RDom {
     void initialize_from_ranges(const std::vector<std::pair<Expr, Expr>> &ranges, std::string name = "");
 
     template <typename... Args>
-    NO_INLINE void initialize_from_ranges(std::vector<std::pair<Expr, Expr>> &ranges, Expr min, Expr extent, Args&&... args) {
+    HALIDE_NO_USER_CODE_INLINE void initialize_from_ranges(std::vector<std::pair<Expr, Expr>> &ranges, Expr min, Expr extent, Args&&... args) {
         ranges.push_back({ min, extent });
         initialize_from_ranges(ranges, std::forward<Args>(args)...);
     }
@@ -196,12 +196,12 @@ public:
     /** Construct a multi-dimensional reduction domain with the given name. If the name
      * is left blank, a unique one is auto-generated. */
     // @{
-    NO_INLINE RDom(const std::vector<std::pair<Expr, Expr>> &ranges, std::string name = "") {
+    HALIDE_NO_USER_CODE_INLINE RDom(const std::vector<std::pair<Expr, Expr>> &ranges, std::string name = "") {
         initialize_from_ranges(ranges, name);
     }
 
     template <typename... Args>
-    NO_INLINE RDom(Expr min, Expr extent, Args&&... args) {
+    HALIDE_NO_USER_CODE_INLINE RDom(Expr min, Expr extent, Args&&... args) {
         // This should really just be a delegating constructor, but I couldn't make
         // that work with variadic template unpacking in visual studio 2013
         std::vector<std::pair<Expr, Expr>> ranges;
@@ -216,7 +216,7 @@ public:
     RDom(const Buffer<> &);
     RDom(const OutputImageParam &);
     template<typename T>
-    NO_INLINE RDom(const Buffer<T> &im) : RDom(Buffer<>(im)) {}
+    HALIDE_NO_USER_CODE_INLINE RDom(const Buffer<T> &im) : RDom(Buffer<>(im)) {}
     // @}
 
     /** Construct a reduction domain that wraps an Internal ReductionDomain object. */

--- a/src/Tuple.h
+++ b/src/Tuple.h
@@ -48,7 +48,7 @@ public:
     //@}
 
     /** Construct a Tuple from a vector of Exprs */
-    explicit NO_INLINE Tuple(const std::vector<Expr> &e) : exprs(e) {
+    explicit HALIDE_NO_USER_CODE_INLINE Tuple(const std::vector<Expr> &e) : exprs(e) {
         user_assert(e.size() > 0) << "Tuples must have at least one element\n";
     }
 

--- a/src/Util.h
+++ b/src/Util.h
@@ -20,6 +20,8 @@
 #include <cstring>
 #include <limits>
 
+#include "runtime/HalideRuntime.h"
+
 #ifndef HALIDE_EXPORT
 #if defined(_MSC_VER)
 #ifdef Halide_EXPORTS
@@ -34,13 +36,9 @@
 
 // If we're in user code, we don't want certain functions to be inlined.
 #if defined(COMPILING_HALIDE) || defined(BUILDING_PYTHON)
-#define NO_INLINE
+#define HALIDE_NO_USER_CODE_INLINE
 #else
-#ifdef _WIN32
-#define NO_INLINE __declspec(noinline)
-#else
-#define NO_INLINE __attribute__((noinline))
-#endif
+#define HALIDE_NO_USER_CODE_INLINE HALIDE_NEVER_INLINE
 #endif
 
 // On windows, Halide needs a larger stack than the default MSVC provides
@@ -181,13 +179,13 @@ T fold_right(const std::vector<T> &vec, Fn f) {
 }
 
 template <typename T1, typename T2, typename T3, typename T4 >
-inline NO_INLINE void collect_paired_args(std::vector<std::pair<T1, T2>> &collected_args,
+inline HALIDE_NO_USER_CODE_INLINE void collect_paired_args(std::vector<std::pair<T1, T2>> &collected_args,
                                      const T3 &a1, const T4 &a2) {
     collected_args.push_back(std::pair<T1, T2>(a1, a2));
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename ...Args>
-inline NO_INLINE void collect_paired_args(std::vector<std::pair<T1, T2>> &collected_args,
+inline HALIDE_NO_USER_CODE_INLINE void collect_paired_args(std::vector<std::pair<T1, T2>> &collected_args,
                                    const T3 &a1, const T4 &a2, Args&&... args) {
     collected_args.push_back(std::pair<T1, T2>(a1, a2));
     collect_paired_args(collected_args, std::forward<Args>(args)...);

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -23,8 +23,10 @@ extern "C" {
 // it is not necessary, and may produce warnings for some build configurations.
 #ifdef _MSC_VER
 #define HALIDE_ALWAYS_INLINE __forceinline
+#define HALIDE_NEVER_INLINE __declspec(noinline)
 #else
 #define HALIDE_ALWAYS_INLINE __attribute__((always_inline)) inline
+#define HALIDE_NEVER_INLINE __attribute__((noinline))
 #endif
 
 /** \file


### PR DESCRIPTION
The current NO_INLINE macro actually means "don't inline if we are in user code, but if we are compiling Halide, do whatever".

This PR adds a new HALIDE_NEVER_INLINE macro, which is the opposite of HALIDE_ALWAYS_INLINE: it never inlines code, period. (It is meant to be useful in header-only libraries like halide_image_io.h, where being able to specify some functions as never-inline can be a useful hint to the compiler.)

The existing NO_INLINE macro is renamed to HALIDE_NO_USER_CODE_INLINE to more accurately reflect its meaning (and to give a HALIDE_ prefix to it, which it should have always had).