### PR TITLE
Fix multiple definitions in fast synchronization

### DIFF
--- a/apps/hexagon_benchmarks/adb_run_on_device.sh
+++ b/apps/hexagon_benchmarks/adb_run_on_device.sh
@@ -17,20 +17,23 @@ BIN=bin
 APP_TARGET=arm-64-android
 
 # Build the app.
-make clean bin/${APP_TARGET}/process
+make bin/${APP_TARGET}/process
 
 # Make a folder on device for the app and our dependencies.
-adb shell mkdir -p ${DEVICE_PATH}
+if [ $? == 0 ]
+then
+    adb shell mkdir -p ${DEVICE_PATH}
 
 # Push the Hexagon runtime to $DEVICE_PATH.
-adb push ${HEXAGON_RUNTIME_PATH}/bin/${APP_TARGET}/libhalide_hexagon_host.so ${DEVICE_PATH}
-adb push ${HEXAGON_RUNTIME_PATH}/bin/v60/signed_by_debug/libhalide_hexagon_remote_skel.so ${DEVICE_PATH}
+    adb push ${HEXAGON_RUNTIME_PATH}/bin/${APP_TARGET}/libhalide_hexagon_host.so ${DEVICE_PATH}
+    adb push ${HEXAGON_RUNTIME_PATH}/bin/v60/signed_by_debug/libhalide_hexagon_remote_skel.so ${DEVICE_PATH}
 
 # If there's a testsig installed in the usual location, copy it to
 # $DEVICE_PATH so it is visible to our modified $ASDP_LIBRARY_PATH.
-adb shell cp /system/lib/rfsa/adsp/testsig* ${DEVICE_PATH} > /dev/null || true
+    adb shell cp /system/lib/rfsa/adsp/testsig* ${DEVICE_PATH} > /dev/null || true
 
 # Push and run the app!
-adb push ${BIN}/${APP_TARGET}/process ${DEVICE_PATH}
-adb shell chmod +x ${DEVICE_PATH}/process
-adb shell ${DEVICE_ENV} ${DEVICE_PATH}/process
+    adb push ${BIN}/${APP_TARGET}/process ${DEVICE_PATH}
+    adb shell chmod +x ${DEVICE_PATH}/process
+    adb shell ${DEVICE_ENV} ${DEVICE_PATH}/process
+fi

--- a/apps/hexagon_benchmarks/adb_run_on_device.sh
+++ b/apps/hexagon_benchmarks/adb_run_on_device.sh
@@ -17,7 +17,7 @@ BIN=bin
 APP_TARGET=arm-64-android
 
 # Build the app.
-make bin/${APP_TARGET}/process
+make clean bin/${APP_TARGET}/process
 
 # Make a folder on device for the app and our dependencies.
 adb shell mkdir -p ${DEVICE_PATH}

--- a/src/runtime/synchronization_common.h
+++ b/src/runtime/synchronization_common.h
@@ -224,9 +224,9 @@ public:
     }
 };
 
-word_lock::word_lock() : state(0) { }
+WEAK word_lock::word_lock() : state(0) { }
 
-void word_lock::lock_full() {
+WEAK void word_lock::lock_full() {
     spin_control spinner;
     uintptr_t expected;
     atomic_load_relaxed(&state, &expected);
@@ -273,7 +273,7 @@ void word_lock::lock_full() {
     }
 }
 
-void word_lock::unlock_full() {
+WEAK void word_lock::unlock_full() {
     uintptr_t expected;
     atomic_load_relaxed(&state, &expected);
 
@@ -417,7 +417,7 @@ static inline uintptr_t addr_hash(uintptr_t addr, uint32_t bits) {
     }
 }
 
-hash_bucket &lock_bucket(uintptr_t addr) {
+WEAK hash_bucket &lock_bucket(uintptr_t addr) {
     uintptr_t hash = addr_hash(addr, HASH_TABLE_BITS);
 
     check_hash(hash);
@@ -437,7 +437,7 @@ struct bucket_pair {
     bucket_pair(hash_bucket &from, hash_bucket &to) : from(from), to(to) { }
 };
 
-bucket_pair lock_bucket_pair(uintptr_t addr_from, uintptr_t addr_to) {
+WEAK bucket_pair lock_bucket_pair(uintptr_t addr_from, uintptr_t addr_to) {
     // TODO: if resizing is implemented, loop, etc.
     uintptr_t hash_from = addr_hash(addr_from, HASH_TABLE_BITS);
     uintptr_t hash_to = addr_hash(addr_to, HASH_TABLE_BITS);
@@ -466,7 +466,7 @@ bucket_pair lock_bucket_pair(uintptr_t addr_from, uintptr_t addr_to) {
     }
 }
 
-void unlock_bucket_pair(bucket_pair &buckets) {
+WEAK void unlock_bucket_pair(bucket_pair &buckets) {
   // In the lock routine, the buckets are locked smaller hash index first.
   // Here we reverse this ordering by comparing the pointers. This works
   // since the pointers are obtained by indexing an array with the hash
@@ -489,10 +489,10 @@ struct validate_action {
   __attribute__((always_inline)) validate_action() : unpark_one(false), invalid_unpark_info(0) { }
 };
 
-bool parking_control_validate(void *control, validate_action &action) { return true; };
-void parking_control_before_sleep(void *control) { };
-uintptr_t parking_control_unpark(void *control, int unparked, bool more_waiters) { return 0; };
-void parking_control_requeue_callback(void *control, const validate_action &action, bool one_to_wake, bool some_requeued) { };
+WEAK bool parking_control_validate(void *control, validate_action &action) { return true; };
+WEAK void parking_control_before_sleep(void *control) { };
+WEAK uintptr_t parking_control_unpark(void *control, int unparked, bool more_waiters) { return 0; };
+WEAK void parking_control_requeue_callback(void *control, const validate_action &action, bool one_to_wake, bool some_requeued) { };
 
 struct parking_control {
     bool (*validate)(void *control, validate_action &action);
@@ -506,7 +506,7 @@ struct parking_control {
 };
 
 // TODO: Do we need a park_result thing here?
-uintptr_t park(uintptr_t addr, parking_control &control) {
+WEAK uintptr_t park(uintptr_t addr, parking_control &control) {
     queue_data queue_data;
 
     hash_bucket &bucket = lock_bucket(addr);
@@ -537,7 +537,7 @@ uintptr_t park(uintptr_t addr, parking_control &control) {
     // TODO: handling timeout.
 }
 
-uintptr_t unpark_one(uintptr_t addr, parking_control &control) {
+WEAK uintptr_t unpark_one(uintptr_t addr, parking_control &control) {
     hash_bucket &bucket = lock_bucket(addr);
 
     queue_data **data_location = &bucket.head;
@@ -588,7 +588,7 @@ uintptr_t unpark_one(uintptr_t addr, parking_control &control) {
     return 0;
 }
 
-uintptr_t unpark_all(uintptr_t addr, uintptr_t unpark_info) {
+WEAK uintptr_t unpark_all(uintptr_t addr, uintptr_t unpark_info) {
     hash_bucket &bucket = lock_bucket(addr);
 
     queue_data **data_location = &bucket.head;
@@ -654,7 +654,7 @@ uintptr_t unpark_all(uintptr_t addr, uintptr_t unpark_info) {
     return waiters;
 }
 
-int unpark_requeue(uintptr_t addr_from, uintptr_t addr_to, parking_control &control, uintptr_t unpark_info) {
+WEAK int unpark_requeue(uintptr_t addr_from, uintptr_t addr_to, parking_control &control, uintptr_t unpark_info) {
     bucket_pair buckets = lock_bucket_pair(addr_from, addr_to);
 
     validate_action action;
@@ -735,7 +735,7 @@ struct mutex_parking_control : parking_control {
 };
 
 // Only used in parking -- lock_full.
-bool mutex_parking_control_validate(void *control, validate_action &action) {
+WEAK bool mutex_parking_control_validate(void *control, validate_action &action) {
     mutex_parking_control *mutex_control = (mutex_parking_control *)control;
 
     uintptr_t result;
@@ -744,7 +744,7 @@ bool mutex_parking_control_validate(void *control, validate_action &action) {
 }
 
 // Only used in unparking -- unlock_full.
-uintptr_t mutex_parking_control_unpark(void *control, int unparked, bool more_waiters) {
+WEAK uintptr_t mutex_parking_control_unpark(void *control, int unparked, bool more_waiters) {
     mutex_parking_control *mutex_control = (mutex_parking_control *)control;
 
     // TODO: consider handling fairness.
@@ -754,7 +754,7 @@ uintptr_t mutex_parking_control_unpark(void *control, int unparked, bool more_wa
     return 0;
 }
 
-mutex_parking_control::mutex_parking_control(uintptr_t *lock_state)
+WEAK mutex_parking_control::mutex_parking_control(uintptr_t *lock_state)
     : lock_state(lock_state) {
     validate = mutex_parking_control_validate;
     unpark = mutex_parking_control_unpark;
@@ -865,7 +865,7 @@ struct signal_parking_control : parking_control {
     signal_parking_control(uintptr_t *cond_state, fast_mutex *mutex);
 };
 
-uintptr_t signal_parking_control_unpark(void *control, int unparked, bool more_waiters) {
+WEAK uintptr_t signal_parking_control_unpark(void *control, int unparked, bool more_waiters) {
     signal_parking_control *signal_control = (signal_parking_control *)control;
 
     if (!more_waiters) {
@@ -880,7 +880,7 @@ uintptr_t signal_parking_control_unpark(void *control, int unparked, bool more_w
 #endif
 }
 
-signal_parking_control::signal_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
+WEAK signal_parking_control::signal_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
     : cond_state(cond_state), mutex(mutex) {
     unpark = signal_parking_control_unpark;
 }
@@ -892,7 +892,7 @@ struct broadcast_parking_control : parking_control {
     broadcast_parking_control(uintptr_t *cond_state, fast_mutex *mutex);
 };
 
-bool broadcast_parking_control_validate(void *control, validate_action &action) {
+WEAK bool broadcast_parking_control_validate(void *control, validate_action &action) {
     broadcast_parking_control *broadcast_control = (broadcast_parking_control *)control;
 
     uintptr_t val;
@@ -912,7 +912,7 @@ bool broadcast_parking_control_validate(void *control, validate_action &action) 
     return true;
 }
 
-void broadcast_parking_control_requeue_callback(void *control, const validate_action &action, bool one_to_wake, bool some_requeued) {
+WEAK void broadcast_parking_control_requeue_callback(void *control, const validate_action &action, bool one_to_wake, bool some_requeued) {
     broadcast_parking_control *broadcast_control = (broadcast_parking_control *)control;
 
     if (action.unpark_one && some_requeued) {
@@ -920,7 +920,7 @@ void broadcast_parking_control_requeue_callback(void *control, const validate_ac
     }
 }
 
-broadcast_parking_control::broadcast_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
+WEAK broadcast_parking_control::broadcast_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
     : cond_state(cond_state), mutex(mutex) {
     validate = broadcast_parking_control_validate;
     requeue_callback = broadcast_parking_control_requeue_callback;
@@ -933,7 +933,7 @@ struct wait_parking_control : parking_control {
     wait_parking_control(uintptr_t *cond_state, fast_mutex *mutex);
 };
 
-bool wait_parking_control_validate(void *control, validate_action &action) {
+WEAK bool wait_parking_control_validate(void *control, validate_action &action) {
     wait_parking_control *wait_control = (wait_parking_control *)control;
 
     uintptr_t val;
@@ -951,13 +951,13 @@ bool wait_parking_control_validate(void *control, validate_action &action) {
     return true;
 }
 
-void wait_parking_control_before_sleep(void *control) {
+WEAK void wait_parking_control_before_sleep(void *control) {
     wait_parking_control *wait_control = (wait_parking_control *)control;
 
     wait_control->mutex->unlock();
 }
 
-uintptr_t wait_parking_control_unpark(void *control, int unparked, bool more_waiters) {
+WEAK uintptr_t wait_parking_control_unpark(void *control, int unparked, bool more_waiters) {
     wait_parking_control *wait_control = (wait_parking_control *)control;
 
     if (!more_waiters) {
@@ -967,7 +967,7 @@ uintptr_t wait_parking_control_unpark(void *control, int unparked, bool more_wai
     return 0;
 }
 
-wait_parking_control::wait_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
+WEAK wait_parking_control::wait_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
     : cond_state(cond_state), mutex(mutex) {
     validate = wait_parking_control_validate;
     before_sleep = wait_parking_control_before_sleep;


### PR DESCRIPTION
apps/hexagon_benchmarks puts multiple filters together into one archive before linking. This results in a "multiple definitions" problem affecting functions in synchronization_common.h (fast synchronization) because they aren't weak.