### PR TITLE
Bounds calculations needs to understand strict_float

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -840,7 +840,8 @@ private:
                 interval.max = Interval::pos_inf;
             }
         } else if (op->is_intrinsic(Call::likely) ||
-                   op->is_intrinsic(Call::likely_if_innermost)) {
+                   op->is_intrinsic(Call::likely_if_innermost) ||
+                   op->is_intrinsic(Call::strict_float)) {
             assert(op->args.size() == 1);
             op->args[0].accept(this);
         } else if (op->is_intrinsic(Call::return_second)) {
@@ -1604,6 +1605,7 @@ private:
                 const Call *call = c.as<Call>();
                 if (call && (call->is_intrinsic(Call::likely) ||
                              call->is_intrinsic(Call::likely_if_innermost))) {
+                    // TODO: does this also need to handle Call::strict_float?
                     c = call->args[0];
                 }
                 const LT *lt = c.as<LT>();
@@ -1632,6 +1634,7 @@ private:
                         // to the condition is probably unnecessary,
                         // which means the mins/maxes below should
                         // probably just be the LHS.
+                        // TODO: does this also need to handle Call::strict_float?
                         Interval likely_i = i;
                         if (call && call->is_intrinsic(Call::likely)) {
                             likely_i.min = likely(i.min);
@@ -1663,6 +1666,7 @@ private:
                     } else if (var_b && scope.contains(var_b->name)) {
                         Interval i = scope.get(var_b->name);
 
+                        // TODO: does this also need to handle Call::strict_float?
                         Interval likely_i = i;
                         if (call && call->is_intrinsic(Call::likely)) {
                             likely_i.min = likely(i.min);

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1604,8 +1604,8 @@ private:
                 Expr c = op->condition;
                 const Call *call = c.as<Call>();
                 if (call && (call->is_intrinsic(Call::likely) ||
-                             call->is_intrinsic(Call::likely_if_innermost))) {
-                    // TODO: does this also need to handle Call::strict_float?
+                             call->is_intrinsic(Call::likely_if_innermost) ||
+                             call->is_intrinsic(Call::strict_float))) {
                     c = call->args[0];
                 }
                 const LT *lt = c.as<LT>();
@@ -1634,7 +1634,6 @@ private:
                         // to the condition is probably unnecessary,
                         // which means the mins/maxes below should
                         // probably just be the LHS.
-                        // TODO: does this also need to handle Call::strict_float?
                         Interval likely_i = i;
                         if (call && call->is_intrinsic(Call::likely)) {
                             likely_i.min = likely(i.min);
@@ -1666,7 +1665,6 @@ private:
                     } else if (var_b && scope.contains(var_b->name)) {
                         Interval i = scope.get(var_b->name);
 
-                        // TODO: does this also need to handle Call::strict_float?
                         Interval likely_i = i;
                         if (call && call->is_intrinsic(Call::likely)) {
                             likely_i.min = likely(i.min);

--- a/test/correctness/strict_float_bounds.cpp
+++ b/test/correctness/strict_float_bounds.cpp
@@ -1,0 +1,28 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Target t = get_jit_target_from_environment().with_feature(Target::StrictFloat);
+
+    Var x;
+    ImageParam   input(Float(32), 1);
+    Param<float> f_param;
+
+    Buffer<float> input_buffer(1);
+    input_buffer.fill(2.5f);
+
+    Func output;
+    output(x) = input(x + cast<int>(f_param));
+
+    input.set(input_buffer);
+    f_param.set(0.0f);
+    // This test verifies that this realize() doesn't explode in bounds infererence
+    // with "unbounded access of input"
+    Buffer<float> result = output.realize(1, t);
+    assert(result(0) == 2.5f);
+
+    printf("Success!\n");
+
+    return 0;
+}


### PR DESCRIPTION
Bounds(Call) assumes the worst for calls it doesn't know about, so strict_float(foo) becomes (neg_inf, pos_inf) rather than (foo, foo) (a la 'likely'), exploding bounds checking.

Note 1: this needs a test to be written; I haven't done so yet because I'm puzzled as to how this isn't covered in our existing tests (it was found inside Google code).

Note 2: it's possible that some of the other 'likely' special cases need special-casing here too; I'm not familiar enough with the Bounds code to have decided whether that's the case or not. (The fix "as-is" here fixes the cases I know about.)