### PR TITLE
Plumb alignment of closure params to AlignLoads

### DIFF
--- a/src/AlignLoads.cpp
+++ b/src/AlignLoads.cpp
@@ -21,7 +21,10 @@ namespace {
 // intended vector out of the aligned vector.
 class AlignLoads : public IRMutator2 {
 public:
-    AlignLoads(int alignment) : required_alignment(alignment) {}
+    AlignLoads(int alignment, const Scope<ModulusRemainder>& alignment_info)
+        : required_alignment(alignment) {
+        this->alignment_info.set_containing_scope(&alignment_info);
+    }
 
 private:
     // The desired alignment of a vector load.
@@ -170,8 +173,8 @@ private:
 
 }  // namespace
 
-Stmt align_loads(Stmt s, int alignment) {
-    return AlignLoads(alignment).mutate(s);
+Stmt align_loads(Stmt s, int alignment, const Scope<ModulusRemainder>& alignment_info) {
+  return AlignLoads(alignment, alignment_info).mutate(s);
 }
 
 }

--- a/src/AlignLoads.cpp
+++ b/src/AlignLoads.cpp
@@ -174,7 +174,7 @@ private:
 }  // namespace
 
 Stmt align_loads(Stmt s, int alignment, const Scope<ModulusRemainder>& alignment_info) {
-  return AlignLoads(alignment, alignment_info).mutate(s);
+    return AlignLoads(alignment, alignment_info).mutate(s);
 }
 
 }

--- a/src/AlignLoads.h
+++ b/src/AlignLoads.h
@@ -7,6 +7,9 @@
  */
 #include "IR.h"
 #include "Target.h"
+#include "Scope.h"
+#include "ModulusRemainder.h"
+
 namespace Halide {
 namespace Internal {
 
@@ -14,7 +17,7 @@ namespace Internal {
  * be aligned to instead load aligned vectors that cover the original
  * load, and then slice the original load out of the aligned
  * vectors. */
-Stmt align_loads(Stmt s, int alignment);
+Stmt align_loads(Stmt s, int alignment, const Scope<ModulusRemainder>& alignment_info);
 
 }
 }

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -316,7 +316,7 @@ void CodeGen_Hexagon::compile_func(const LoweredFunc &f,
     #endif
 
     debug(1) << "Aligning loads for HVX....\n";
-    body = align_loads(body, target.natural_vector_size(Int(8)));
+    body = align_loads(body, target.natural_vector_size(Int(8)), alignment_info);
     body = common_subexpression_elimination(body);
     // Don't simplify here, otherwise it will re-collapse the loads we
     // want to carry across loop iterations.


### PR DESCRIPTION
This helps more things align. This always would have been helpful, but it's more important now that LICM often lifts strides into lets outside of device loops.