### PR TITLE
Convert camera_pipe to use HalideTraceConfig struct

### DIFF
--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -1,5 +1,6 @@
 #include "Halide.h"
 #include <stdint.h>
+#include "halide_trace_config.h"
 
 namespace {
 
@@ -180,6 +181,19 @@ public:
                     f.align_storage(x, vec);
                 }
             }
+        }
+
+        /* Optional tags to specify layout for HalideTraceViz */
+        Halide::Trace::FuncConfig cfg;
+        cfg.pos = { 860, 340 - 220 };
+        cfg.max = 1024;
+        for (Func f : intermediates) {
+            std::string label = f.name();
+            std::replace(label.begin(), label.end(), '_', '@');
+            cfg.pos.y += 220;
+            cfg.labels = { { label, cfg.pos } };
+            f.add_trace_tag(cfg.to_trace_tag());
+
         }
     }
 
@@ -468,6 +482,44 @@ void CameraPipe::generate() {
             .bound(c, 0, 3)
             .bound(x, 0, ((out_width)/(2*vec))*(2*vec))
             .bound(y, 0, (out_height/strip_size)*strip_size);
+
+        /* Optional tags to specify layout for HalideTraceViz */
+        {
+            Halide::Trace::FuncConfig cfg;
+            cfg.max = 1024;
+            cfg.pos = { 10, 348 };
+            input.add_trace_tag(cfg.to_trace_tag());
+
+            cfg.pos = { 305, 360 };
+            denoised.add_trace_tag(cfg.to_trace_tag());
+
+            cfg.pos = { 580, 120 };
+            const int y_offset = 220;
+            cfg.strides = {{1, 0}, {0, 1}, {0, y_offset}};
+            cfg.labels = {
+                { "gr", {cfg.pos.x, cfg.pos.y + 0 * y_offset} },
+                { "r",  {cfg.pos.x, cfg.pos.y + 1 * y_offset} },
+                { "b",  {cfg.pos.x, cfg.pos.y + 2 * y_offset} },
+                { "gb", {cfg.pos.x, cfg.pos.y + 3 * y_offset} },
+            };
+            deinterleaved.add_trace_tag(cfg.to_trace_tag());
+
+            cfg.color_dim = 2;
+            cfg.strides = {{1, 0}, {0, 1}, {0, 0}};
+            cfg.pos = { 1140, 360 };
+            cfg.labels = { { "demosaiced", cfg.pos } };
+            processed.add_trace_tag(cfg.to_trace_tag());
+
+            cfg.pos = { 1400, 360 };
+            cfg.labels = { { "color-corrected", cfg.pos } };
+            corrected.add_trace_tag(cfg.to_trace_tag());
+
+            cfg.max = 256;
+            cfg.pos = { 1660, 360 };
+            cfg.labels = { { "gamma-corrected", cfg.pos } };
+            curved.add_trace_tag(cfg.to_trace_tag());
+
+        }
     }
 };
 

--- a/apps/camera_pipe/viz.sh
+++ b/apps/camera_pipe/viz.sh
@@ -3,34 +3,6 @@ export HL_TRACE_FILE=/dev/stdout
 export HL_NUMTHREADS=4
 rm -f $1/camera_pipe.mp4
 $1/viz/process ../images/bayer_small.png 3700 1.8 50 1 1 $1/out.png |
-../../bin/HalideTraceViz --timestep 1000 --size 1920 1080 \
---strides 1 0 0 1 --gray --max 1024 \
---move 10 348 --func input \
---label input input 10 \
---move 305 360 --func denoised \
---label denoised denoised 10 \
---strides 1 0 0 1 0 220 \
---move 580 120 --func deinterleaved \
---label deinterleaved "gr" 10 \
---down 220 --label deinterleaved "r" 10 \
---down 220 --label deinterleaved "b" 10 \
---down 220 --label deinterleaved "gb" 10 \
---strides 1 0 0 1 \
---move 720 120 --func r_gr --label r_gr "r@gr" 10 \
---right 140 --func g_gr --label g_gr "g@gr" 10 \
---right 140 --func b_gr --label b_gr "b@gr" 10 \
---move 720 340 --func r_r --label r_r "r@r" 10 \
---right 140 --func g_r --label g_r "g@r" 10 \
---right 140 --func b_r --label b_r "b@r" 10 \
---move 720 560 --func r_b --label r_b "r@b" 10 \
---right 140 --func g_b --label g_b "g@b" 10 \
---right 140 --func b_b --label b_b "b@b" 10 \
---move 720 870 --func r_gb --label r_gb "r@gb" 10 \
---right 140 --func g_gb --label g_gb "g@gb" 10 \
---right 140 --func b_gb --label b_gb "b@gb" 10 \
---strides 1 0 0 1 0 0 --rgb 2 \
---move 1140 360 --func output --label output "demosaiced" 10 \
---move 1400 360 --func corrected --label corrected "color-corrected" 10 \
---max 256 --move 1660 360 --func curved --label curved "gamma-corrected" 10 |\
+../../bin/HalideTraceViz --timestep 1000 --size 1920 1080 |\
 avconv -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 $1/camera_pipe.mp4
 #mplayer -demuxer rawvideo -rawvideo w=1920:h=1080:format=rgba:fps=30 -idle -fixed-vo -


### PR DESCRIPTION
Done mainly as a proof-of-concept to further flush out work needing to be done; not sure if we should land this, because if we do, we'll have no remaining usage of most of the flags args (aside from --timestamp, --size and a few others), and they will inevitably bitrot. (OTOH, maybe we're better off doing this conversion and removing the flags support? Opinions welcome.)