### PR TITLE
Add trace_tag for 'global' visualization params

### DIFF
--- a/apps/bilateral_grid/bilateral_grid_generator.cpp
+++ b/apps/bilateral_grid/bilateral_grid_generator.cpp
@@ -148,6 +148,20 @@ public:
             cfg.pos.y = 700;
             blury.add_trace_tag(cfg.to_trace_tag());
         }
+        {
+            // GlobalConfig applies to the entire visualization pipeline;
+            // you can set this tag on any Func that is realized, but only
+            // the last one seen will be used. (Since the tags are emitted in
+            // an arbitrary order, emitting only one such tag is the best practice).
+            // Note also that since the global settings are often context-dependent
+            // (eg the output size and timestep may vary depending on the
+            // input data), it's often more useful to specify these on the
+            // command line.
+            Halide::Trace::GlobalConfig global_cfg;
+            global_cfg.timestep = 1000;
+
+            bilateral_grid.add_trace_tag(global_cfg.to_trace_tag());
+        }
     }
 };
 

--- a/apps/bilateral_grid/viz.sh
+++ b/apps/bilateral_grid/viz.sh
@@ -4,6 +4,6 @@ export HL_NUMTHREADS=4
 rm -f $1/bilateral_grid.mp4
 make $1/filter_viz && \
 $1/filter_viz ../images/gray_small.png $1/out_small.png 0.2 0 | \
-../../bin/HalideTraceViz --timestep 1000 --size 1920 1080 | \
+../../bin/HalideTraceViz --size 1920 1080 | \
 avconv -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 $1/bilateral_grid.mp4
 #mplayer -demuxer rawvideo -rawvideo w=1920:h=1080:format=rgba:fps=30 -idle -fixed-vo -


### PR DESCRIPTION
This allows us to set (e.g.) timestep or framesize via trace_tags in the code, rather than command-line flags.

Note that this is of limited use at present, as the existing flags tend to be sensitive to input data and thus may be better specified on the command line; however, this provides a good mechanism to specify future params related to automatic layout.