### PR TITLE
Tweak HTV to render 1d and 0d Funcs properly

### DIFF
--- a/apps/camera_pipe/viz.sh
+++ b/apps/camera_pipe/viz.sh
@@ -16,6 +16,7 @@ $1/viz/process ../images/bayer_small.png 3700 1.8 50 1 1 $1/out.png |
 --down 220 --label deinterleaved "b" 10 \
 --down 220 --label deinterleaved "gb" 10 \
 --strides 1 0 0 1 \
+--move 580 1000 --func curve --label curve "tone curve LUT" 10 \
 --move 720 120 --func r_gr --label r_gr "r@gr" 10 \
 --right 140 --func g_gr --label g_gr "g@gr" 10 \
 --right 140 --func b_gr --label b_gr "b@gr" 10 \

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -165,6 +165,17 @@ public:
             gray.add_trace_tag(cfg.to_trace_tag());
         }
 
+        {
+            // This is positioned a little awkwardly, but is useful
+            // to show how the LUT is accessed (and to verify that 1d Funcs
+            // render properly in visualizer)
+            Halide::Trace::FuncConfig cfg;
+            cfg.pos.x = 1000;
+            cfg.pos.y = 32;
+            cfg.labels = { { "remap LUT", {1000, 32} } };
+            remap.add_trace_tag(cfg.to_trace_tag());
+        }
+
         for (int i = 0; i < pyramid_levels; ++i) {
             int y = 100;
             for (int j = 0; j < i; ++j) {

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -165,17 +165,6 @@ public:
             gray.add_trace_tag(cfg.to_trace_tag());
         }
 
-        {
-            // This is positioned a little awkwardly, but is useful
-            // to show how the LUT is accessed (and to verify that 1d Funcs
-            // render properly in visualizer)
-            Halide::Trace::FuncConfig cfg;
-            cfg.pos.x = 1000;
-            cfg.pos.y = 32;
-            cfg.labels = { { "remap LUT", {1000, 32} } };
-            remap.add_trace_tag(cfg.to_trace_tag());
-        }
-
         for (int i = 0; i < pyramid_levels; ++i) {
             int y = 100;
             for (int j = 0; j < i; ++j) {

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -677,7 +677,11 @@ int run(int argc, char **argv) {
                 fi.stats.observe_load(p);
             }
 
-            // zero- or one-dimensional Funcs can have dimensions < strides
+            // zero- or one-dimensional Funcs can have dimensions < strides.size().
+            // This may seem confusing, so keep in mind:
+            // fi.config.strides are provided by the --stride flag, so it can contain anything; i
+            // if you don't specify them at all, they default to {{1,0},{0,1} (aka size=2).
+            // So if we have excess strides, just ignore them.
             const int dims = std::min(p.dimensions/p.type.lanes, (int) fi.config.strides.size());
             for (int lane = 0; lane < p.type.lanes; lane++) {
                 // Compute the screen-space x, y coord to draw this.


### PR DESCRIPTION
Add a visualization for the remap LUT in local_laplacian to test/demonstrate. (I verified locally the 0d Funcs also work, but am not including a demonstration.)