### PR TITLE
Remove unaligned-access in HalideTraceUtils

### DIFF
--- a/util/HalideTraceUtils.h
+++ b/util/HalideTraceUtils.h
@@ -77,7 +77,9 @@ struct Packet : public halide_trace_packet_t {
         // 'val' may not be aligned: memcpy it to an aligned local
         // so that value_as<>() won't complain under sanitizers.
         halide_scalar_value_t aligned_value;
-        memcpy(&aligned_value, val, sizeof(aligned_value));
+        // Only copy the number of bytes in the type: the stream isn't guaranteed
+        // to be padded to sizeof(halide_scalar_value_t).
+        memcpy(&aligned_value, val, type.bits / 8);
         return value_as<T>(type, aligned_value);
     }
 

--- a/util/HalideTraceUtils.h
+++ b/util/HalideTraceUtils.h
@@ -3,27 +3,27 @@
 
 #include "HalideRuntime.h"
 #include <stdio.h>
+#include <cstring>
 
 namespace Halide {
 namespace Internal {
 
 void bad_type_error(halide_type_t type);
 
-// Simple conversion.
+// Simple conversion. Note: assume that 'value' is aligned properly.
 template<typename T>
-T value_as(halide_type_t type, const halide_scalar_value_t* value) {
-    const halide_scalar_value_t *v = (const halide_scalar_value_t *)value;
+T value_as(halide_type_t type, const halide_scalar_value_t& value) {
     switch (type.code) {
     case halide_type_int:
         switch (type.bits) {
         case 8:
-            return (T) v->u.i8;
+            return (T) value.u.i8;
         case 16:
-            return (T) v->u.i16;
+            return (T) value.u.i16;
         case 32:
-            return (T) v->u.i32;
+            return (T) value.u.i32;
         case 64:
-            return (T) v->u.i64;
+            return (T) value.u.i64;
         default:
             bad_type_error(type);
         }
@@ -31,15 +31,15 @@ T value_as(halide_type_t type, const halide_scalar_value_t* value) {
     case halide_type_uint:
         switch (type.bits) {
         case 1:
-            return (T) v->u.b;
+            return (T) value.u.b;
         case 8:
-            return (T) v->u.u8;
+            return (T) value.u.u8;
         case 16:
-            return (T) v->u.u16;
+            return (T) value.u.u16;
         case 32:
-            return (T) v->u.u32;
+            return (T) value.u.u32;
         case 64:
-            return (T) v->u.u64;
+            return (T) value.u.u64;
         default:
             bad_type_error(type);
         }
@@ -47,9 +47,9 @@ T value_as(halide_type_t type, const halide_scalar_value_t* value) {
     case halide_type_float:
         switch (type.bits) {
         case 32:
-            return (T) v->u.f32;
+            return (T) value.u.f32;
         case 64:
-            return (T) v->u.f64;
+            return (T) value.u.f64;
         default:
             bad_type_error(type);
         }
@@ -74,7 +74,11 @@ struct Packet : public halide_trace_packet_t {
     template<typename T>
     T get_value_as(int idx) const {
         const uint8_t *val = (const uint8_t *)(value()) + idx * type.bytes();
-        return value_as<T>(type, (const halide_scalar_value_t *)val);
+        // 'val' may not be aligned: memcpy it to an aligned local
+        // so that value_as<>() won't complain under sanitizers.
+        halide_scalar_value_t aligned_value;
+        memcpy(&aligned_value, val, sizeof(aligned_value));
+        return value_as<T>(type, aligned_value);
     }
 
     // Grab a packet from stdin. Returns false when stdin closes.


### PR DESCRIPTION
UBSan (etc) will rightly complain that value_as<>() does unaligned loads from the scalar union; have the caller memcpy to a local to avoid this. Also, drive-by change from const-ptr to const-ref.