### PR TITLE
Rework FuncConfig to allow merging/optional fields

### DIFF
--- a/apps/camera_pipe/viz.sh
+++ b/apps/camera_pipe/viz.sh
@@ -2,36 +2,12 @@
 export HL_TRACE_FILE=/dev/stdout
 export HL_NUMTHREADS=4
 rm -f $1/camera_pipe.mp4
+# Do trivial partial-overrides of trace settings via flags
+# (--zoom and --rlabel) just to demonstrate that it works.
 $1/viz/process ../images/bayer_small.png 3700 1.8 50 1 1 $1/out.png |
 ../../bin/HalideTraceViz --timestep 1000 --size 1920 1080 \
---strides 1 0 0 1 --gray --max 1024 \
---move 10 348 --func input \
---label input input 10 \
---move 305 360 --func denoised \
---label denoised denoised 10 \
---strides 1 0 0 1 0 220 \
---move 580 120 --func deinterleaved \
---label deinterleaved "gr" 10 \
---down 220 --label deinterleaved "r" 10 \
---down 220 --label deinterleaved "b" 10 \
---down 220 --label deinterleaved "gb" 10 \
---strides 1 0 0 1 \
---move 580 1000 --func curve --label curve "tone curve LUT" 10 \
---move 720 120 --func r_gr --label r_gr "r@gr" 10 \
---right 140 --func g_gr --label g_gr "g@gr" 10 \
---right 140 --func b_gr --label b_gr "b@gr" 10 \
---move 720 340 --func r_r --label r_r "r@r" 10 \
---right 140 --func g_r --label g_r "g@r" 10 \
---right 140 --func b_r --label b_r "b@r" 10 \
---move 720 560 --func r_b --label r_b "r@b" 10 \
---right 140 --func g_b --label g_b "g@b" 10 \
---right 140 --func b_b --label b_b "b@b" 10 \
---move 720 870 --func r_gb --label r_gb "r@gb" 10 \
---right 140 --func g_gb --label g_gb "g@gb" 10 \
---right 140 --func b_gb --label b_gb "b@gb" 10 \
---strides 1 0 0 1 0 0 --rgb 2 \
---move 1140 360 --func output --label output "demosaiced" 10 \
---move 1400 360 --func corrected --label corrected "color-corrected" 10 \
---max 256 --move 1660 360 --func curved --label curved "gamma-corrected" 10 |\
+--zoom 4 --func sharpen_strength_x32 \
+--rlabel curve "tone curve LUT" 0 0 10 \
+|\
 avconv -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 $1/camera_pipe.mp4
 #mplayer -demuxer rawvideo -rawvideo w=1920:h=1080:format=rgba:fps=30 -idle -fixed-vo -

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -176,7 +176,6 @@ public:
                 Halide::Trace::FuncConfig cfg;
                 cfg.pos = {x, y};
                 cfg.store_cost = store_cost;
-                cfg.auto_label = false;
                 inGPyramid[i].add_trace_tag(cfg.to_trace_tag());
             }
             if (i > 0) {
@@ -186,7 +185,6 @@ public:
                 cfg.strides = {{1, 0}, {0, 1}, {200, 0}};
                 cfg.pos = {x, y};
                 cfg.store_cost = store_cost;
-                cfg.auto_label = false;
                 if (i == 1) {
                     cfg.labels = { { "differently curved intermediate pyramids" } };
                     cfg.pos = {x, 100};
@@ -199,7 +197,6 @@ public:
                 Halide::Trace::FuncConfig cfg;
                 cfg.pos = {x, y};
                 cfg.store_cost = store_cost;
-                cfg.auto_label = false;
                 if (i == 0) {
                     cfg.labels = { { "output pyramids" } };
                     cfg.pos = {x, 100};

--- a/tools/halide_trace_config.h
+++ b/tools/halide_trace_config.h
@@ -133,8 +133,8 @@ struct FuncConfig {
 
     // The position on the screen corresponding to the Func's 0, 0 coordinate.
     //
-    // Valid values: pos.x >= 0, pos.y >= 0
-    Point pos = { -1, -1 };
+    // Valid values: pos.x and pos.y > std::numeric_limits<int>::lowest()
+    Point pos = { std::numeric_limits<int>::lowest(), std::numeric_limits<int>::lowest() };
 
     // Specifies the matrix that maps the coordinates of the
     // Func to screen pixels. Specified column major. For example,
@@ -191,8 +191,8 @@ struct FuncConfig {
         if (from.zoom >= 0.f) this->zoom = from.zoom;
         if (from.load_cost >= 0) this->load_cost = from.load_cost;
         if (from.store_cost > 0) this->store_cost = from.store_cost;
-        if (from.pos.x > 0) this->pos.x = from.pos.x;
-        if (from.pos.y > 0) this->pos.y = from.pos.y;
+        if (from.pos.x > std::numeric_limits<int>::lowest()) this->pos.x = from.pos.x;
+        if (from.pos.y > std::numeric_limits<int>::lowest()) this->pos.y = from.pos.y;
         if (!from.strides.empty()) this->strides = from.strides;
         if (from.color_dim >= -1) this->color_dim = from.color_dim;
         if (!std::isnan(from.min)) this->min = from.min;

--- a/tools/halide_trace_config.h
+++ b/tools/halide_trace_config.h
@@ -1,8 +1,10 @@
 #ifndef HALIDE_TRACE_CONFIG_H
 #define HALIDE_TRACE_CONFIG_H
 
+#include <cmath>
 #include <functional>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -101,21 +103,104 @@ struct Label {
     }
 };
 
-// Configuration for how a func should be rendered in HalideTraceViz
+// Configuration for how a func should be rendered in HalideTraceViz.
 struct FuncConfig {
-    float zoom = 1.f;
-    int load_cost = 0;
-    int store_cost = 1;
-    Point pos;
-    std::vector<Point> strides = { {1, 0}, {0, 1} };
-    int color_dim = -1;
-    float min = 0.f, max = 1.f;
+    // Note that every field in this struct is initialized to a value which
+    // means "no value specified"; this is allows us to merge configs
+    // from several sources (auto-layout, embedded trace-tags, and command-line)
+    // in a way that we can selectively add or override some-but-not-all configuration
+    // values (e.g., use auto-layout's positioning, but customizing labels
+    // and changing rgb vs gray rendering). In all cases, if a field is
+    // the initial "no value specified" value at rendering time, HalideTraceViz
+    // will choose a reasonable value for that field.
+
+    // Each value of a Func will draw as a zoom x zoom
+    // box in the output. Fractional values are allowed.
+    //
+    // Valid values: 0.0 < zoom <= HUGEVAL or so
+    float zoom = -1.f;
+
+    // Each load from a Func costs the given number of ticks.
+    // Legal values are 0.0 < zoom <= 1000 or so
+    //
+    // Valid values: load_cost >= 0
+    int load_cost = -1;
+
+    // Each store to a Func costs the given number of ticks.
+    //
+    // Valid values: store_cost >= 0
+    int store_cost = -1;
+
+    // The position on the screen corresponding to the Func's 0, 0 coordinate.
+    //
+    // Valid values: pos.x >= 0, pos.y >= 0
+    Point pos = { -1, -1 };
+
+    // Specifies the matrix that maps the coordinates of the
+    // Func to screen pixels. Specified column major. For example,
+    // { {1, 0}, {0, 1}, {0, 0} } specifies that the Func has three
+    // dimensions where the first one maps to screen-space x
+    // coordinates, the second one maps to screen-space y coordinates,
+    // and the third one does not affect screen-space coordinates.
+    //
+    // Valid values: strize.size() > 0
+    std::vector<Point> strides;
+
+    // Specify the dimension to use for rendering the color channels of the Func.
+    //
+    // Valid values: color_dim == -1 -> render as grayscale
+    //               color_dim >= 0  -> render as RGB using that dimension as color channel
+    int color_dim = -2;
+
+    // The minimum value taken on by a Func; maps to black.
+    // TODO: this doesn't give enough range to allow for the full range of int64 or uint64. Do we care?
+    //
+    // Valid values: min-of-type <= min <= max-of-type
+    double min = std::numeric_limits<double>::quiet_NaN();
+
+    // The maximum value taken on by a Func; maps to white.
+    // TODO: this doesn't give enough range to allow for the full range of int64 or uint64. Do we care?
+    //
+    // Valid values: min-of-type <= min <= max-of-type
+    double max = std::numeric_limits<double>::quiet_NaN();
+
     // Label(s) to be rendered with the Func. The Label's position
     // is an offset from the Func's position, so (0, 0) means render
     // at the top-left of the Func itself.
+    //
+    // Valid values: Any
     std::vector<Label> labels;
-    bool blank_on_end_realization = false;
-    uint32_t uninitialized_memory_color = 0xff000000;
+
+    // If blank_on_end_realization > 0, the output occupied by a Func will be set to
+    // black on its end-realization event; if blank_on_end_realization == 0, the
+    // Func's values will be left on the screen.
+    //
+    // Valid values: 0 or 1.
+    int blank_on_end_realization = -1;
+
+    // Specifies the on-screen color corresponding to uninitialized memory,
+    // in 0x00BBGGRR format.
+    //
+    // Valid values: Any uint32 with 0x00 in the upper 8 bits.
+    uint32_t uninitialized_memory_color = 0xFFFFFFFF;
+
+    // For each field in 'from':
+    // -- if it has a well-defined value, replace the corresponding field in 'this'
+    // -- if it does not have a well-defined value, leave untouched the corresponding field in 'this'
+    void merge_from(const FuncConfig &from) {
+        if (from.zoom >= 0.f) this->zoom = from.zoom;
+        if (from.load_cost >= 0) this->load_cost = from.load_cost;
+        if (from.store_cost > 0) this->store_cost = from.store_cost;
+        if (from.pos.x > 0) this->pos.x = from.pos.x;
+        if (from.pos.y > 0) this->pos.y = from.pos.y;
+        if (!from.strides.empty()) this->strides = from.strides;
+        if (from.color_dim >= -1) this->color_dim = from.color_dim;
+        if (!std::isnan(from.min)) this->min = from.min;
+        if (!std::isnan(from.max)) this->max = from.max;
+        if (!from.labels.empty()) this->labels = from.labels;
+        if (from.blank_on_end_realization >= 0) this->blank_on_end_realization = from.blank_on_end_realization;
+        if (!(from.uninitialized_memory_color & 0xff000000)) this->uninitialized_memory_color = from.uninitialized_memory_color;
+    }
 
     static std::string tag_start_text() {
         return std::string("htv_func_config:");

--- a/tools/halide_trace_config.h
+++ b/tools/halide_trace_config.h
@@ -114,7 +114,6 @@ struct FuncConfig {
     // is an offset from the Func's position, so (0, 0) means render
     // at the top-left of the Func itself.
     std::vector<Label> labels;
-    bool auto_label = true;  // if there are no labels, add one matching the func name
     bool blank_on_end_realization = false;
     uint32_t uninitialized_memory_color = 0xff000000;
 
@@ -137,7 +136,6 @@ struct FuncConfig {
             << "  color_dim: " << color_dim << "\n"
             << "  min: " << min << " max: " << max << "\n"
             << "  labels: " << labels << "\n"
-            << "  auto_label: " << auto_label << "\n"
             << "  blank: " << blank_on_end_realization << "\n"
             << "  uninit: " << uninitialized_memory_color << "\n";
     }
@@ -157,7 +155,6 @@ struct FuncConfig {
             << config.min << " "
             << config.max << " "
             << config.labels << " "
-            << config.auto_label << " "
             << config.blank_on_end_realization << " "
             << config.uninitialized_memory_color;
         return os;
@@ -176,7 +173,6 @@ struct FuncConfig {
             >> config.min
             >> config.max
             >> config.labels
-            >> config.auto_label
             >> config.blank_on_end_realization
             >> config.uninitialized_memory_color;
         if (start_text != tag_start_text()) {

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -381,7 +381,6 @@ void process_args(int argc, char **argv, GlobalConfig &global, map<string, FuncI
             FuncInfo &fi = func_info[func];
             fi.config.labels.swap(config.labels);
             fi.config = config;
-            fi.config.auto_label = false;
             fi.configured = true;
         } else if (next == "--min") {
             expect(i + 1 < argc, i);
@@ -665,9 +664,6 @@ int run(int argc, char **argv) {
 
         if (fi.stats.first_draw_time < 0) {
             fi.stats.first_draw_time = halide_clock;
-            if (fi.config.labels.empty() && fi.config.auto_label) {
-                fi.config.labels.push_back({p.func()});
-            }
             for (const auto &label : fi.config.labels) {
                 // Convert offset to absolute position before enqueuing
                 Label l = label;

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -396,6 +396,7 @@ FuncConfig fix_func_config_defaults(const FuncConfig &cfg) {
     safe.blank_on_end_realization = 0;
     safe.uninitialized_memory_color = 0x00000000;
     safe.merge_from(cfg);
+    safe,uninitialized_memory_color |= 0xff000000;
     return safe;
 }
 
@@ -528,7 +529,7 @@ void process_args(int argc, char **argv, GlobalConfig &global, map<string, FuncI
             int r = parse_int(argv[++i]);
             int g = parse_int(argv[++i]);
             int b = parse_int(argv[++i]);
-            config.uninitialized_memory_color = (255 << 24) | ((b & 255) << 16) | ((g & 255) << 8) | (r & 255);
+            config.uninitialized_memory_color = ((b & 255) << 16) | ((g & 255) << 8) | (r & 255);
         } else {
             expect(false, i);
         }

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -19,6 +19,7 @@ typedef int64_t ssize_t;
 #endif
 #include <string>
 #include <list>
+#include <set>
 
 #include "inconsolata.h"
 #include "HalideRuntime.h"
@@ -39,6 +40,7 @@ using std::queue;
 using std::array;
 using std::pair;
 using std::list;
+using std::set;
 
 // A struct specifying how a single Func will get visualized.
 struct FuncInfo {
@@ -276,7 +278,10 @@ Funcs.
      appears with its bottom left corner at the current coordinates
      and fades in over n frames.
 
-)USAGE";
+ --rlabel func label dx dy n: Like "--label", but relative to the Func's
+     position, using dx and dy as an offset.
+
+))USAGE";
 }
 
 // If the condition is false, print usage and exit with error.
@@ -347,6 +352,18 @@ float parse_float(const char *str) {
     return result;
 }
 
+double parse_double(const char *str) {
+    char *endptr = nullptr;
+    errno = 0;
+    double result = strtod(str, &endptr);
+    if (errno == ERANGE || str == endptr) {
+        std::cerr << "Unable to parse '" << str << "' as a double\n";
+        usage();
+        exit(-1);
+    }
+    return result;
+}
+
 void do_decay(int decay_factor, std::vector<uint32_t> &storage) {
     if (decay_factor != 1) {
         const uint32_t inv_d1 = (1 << 24) / std::max(1, decay_factor);
@@ -361,11 +378,32 @@ void do_decay(int decay_factor, std::vector<uint32_t> &storage) {
     }
 }
 
+// Given a FuncConfig, check each field for "use some reasonable default"
+// value and fill in something reasonable.
+FuncConfig fix_func_config_defaults(const FuncConfig &cfg) {
+    // Make a FuncConfig with 'safe' defaults for everything,
+    // then merge the existing cfg into it.
+    FuncConfig safe;
+    safe.zoom = 1.f;
+    safe.load_cost = 0;
+    safe.store_cost = 1;
+    safe.pos = {0, 0};
+    safe.strides = { {1, 0}, {0, 1} };
+    safe.color_dim = -1;
+    safe.min = 0.0;
+    safe.max = 1.0;
+    safe.labels = {};
+    safe.blank_on_end_realization = 0;
+    safe.uninitialized_memory_color = 0x00000000;
+    safe.merge_from(cfg);
+    return safe;
+}
+
 void process_args(int argc, char **argv, GlobalConfig &global, map<string, FuncInfo> &func_info) {
     // The struct's default values are what we want
     FuncConfig config;
-
     vector<Point> pos_stack;
+    set<string> labels_seen;
 
     // Parse command line args
     int i = 1;
@@ -379,15 +417,14 @@ void process_args(int argc, char **argv, GlobalConfig &global, map<string, FuncI
             expect(i + 1 < argc, i);
             const char *func = argv[++i];
             FuncInfo &fi = func_info[func];
-            fi.config.labels.swap(config.labels);
-            fi.config = config;
+            fi.config.merge_from(config);
             fi.configured = true;
         } else if (next == "--min") {
             expect(i + 1 < argc, i);
-            config.min = parse_float(argv[++i]);
+            config.min = parse_double(argv[++i]);
         } else if (next == "--max") {
             expect(i + 1 < argc, i);
-            config.max = parse_float(argv[++i]);
+            config.max = parse_double(argv[++i]);
         } else if (next == "--move") {
             expect(i + 2 < argc, i);
             config.pos.x = parse_int(argv[++i]);
@@ -416,9 +453,9 @@ void process_args(int argc, char **argv, GlobalConfig &global, map<string, FuncI
         } else if (next == "--gray") {
             config.color_dim = -1;
         } else if (next == "--blank") {
-            config.blank_on_end_realization = true;
+            config.blank_on_end_realization = 1;
         } else if (next == "--no-blank") {
-            config.blank_on_end_realization = false;
+            config.blank_on_end_realization = 0;
         } else if (next == "--zoom") {
             expect(i + 1 < argc, i);
             config.zoom = parse_float(argv[++i]);
@@ -451,6 +488,30 @@ void process_args(int argc, char **argv, GlobalConfig &global, map<string, FuncI
             // the --label flag has always expected an absolute position,
             // so convert it to an offset.
             Point offset = { config.pos.x - fi.config.pos.x, config.pos.y - fi.config.pos.y };
+            if (!labels_seen.count(func)) {
+                // If there is at least one --label specified for a Func,
+                // it overrides the entire previous set of labels, rather
+                // than simply appending.
+                fi.config.labels.clear();
+                labels_seen.insert(func);
+            }
+            fi.config.labels.push_back({text, offset, n});
+        } else if (next == "--rlabel") {
+            expect(i + 5 < argc, i);
+            char *func = argv[++i];
+            char *text = argv[++i];
+            int dx = parse_int(argv[++i]);
+            int dy = parse_int(argv[++i]);
+            int n = parse_int(argv[++i]);
+            FuncInfo &fi = func_info[func];
+            Point offset = { dx, dy };
+            if (!labels_seen.count(func)) {
+                // If there is at least one --label specified for a Func,
+                // it overrides the entire previous set of labels, rather
+                // than simply appending.
+                fi.config.labels.clear();
+                labels_seen.insert(func);
+            }
             fi.config.labels.push_back({text, offset, n});
         } else if (next == "--timestep") {
             expect(i + 1 < argc, i);
@@ -617,6 +678,11 @@ int run(int argc, char **argv) {
             // this allows us to override trace-tag specifications
             // via the commandline, which is handy for experimentations.
             process_args(argc, argv, global, func_info);
+
+            // Ensure that all FuncConfigs have reasonable values.
+            for (auto &p : func_info) {
+                p.second.config = fix_func_config_defaults(p.second.config);
+            }
 
             // allocate the buffers after all tags and flags are processed
             buffers.resize(global.frame_size);
@@ -791,7 +857,7 @@ int run(int argc, char **argv) {
             fill_realization(buffers.image.data(), global.frame_size, fi.config.uninitialized_memory_color, fi, p);
             break;
         case halide_trace_end_realization:
-            if (fi.config.blank_on_end_realization) {
+            if (fi.config.blank_on_end_realization > 0) {
                 fill_realization(buffers.image.data(), global.frame_size, 0, fi, p);
             }
             break;


### PR DESCRIPTION
The goal here is to allow some-but-not-all fields in FuncConfig to be specified, so that we can override some-but-not-all aspects of a visualization.

As it is, this means you can specify a FuncConfig via a trace-tag, then tweak/override values via --flag values without having to rebuild/rerun the Halide generation code.

This will become especially useful after auto-layout for visualizers is put into place, as that will allow you to just use auto-layout to get a rough visualization, and then (if desired) tweak it piece-by-piece (by adding trace-tag and/or --flags) to get a pleasing layout.

Note that I implemented the structs by using 'magic invalid values'; a perhaps-cleaner-but-more-expensive approach would be to have each field allocated by std::unique_ptr, with nullptr meaning "not set"; I rejected that because it makes setting each field considerably more awkward.

(To the Googlers watching: yes, mergeable-structs-with-optional-fields sounds a lot like protobufs; no, we're not bringing in protobufs just to accomplish this.)