### PR TITLE
initialize unique_name_counters to zero

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -101,7 +101,11 @@ namespace {
 // will get suffixes that falsely hint that they are not.
 
 const int num_unique_name_counters = (1 << 14);
-std::atomic<int> unique_name_counters[num_unique_name_counters];
+
+// We want to init these to zero, but cannot use = {0} because that
+// would invoke a (deleted) copy ctor; this syntax should force
+// the correct behavior.
+std::atomic<int> unique_name_counters[num_unique_name_counters] = {};
 
 int unique_count(size_t h) {
     h = h & (num_unique_name_counters - 1);


### PR DESCRIPTION
If I read the spec correctly, std::atomic<> default ctor doesn't promise any initialization; if we leave these as-is, we can get different uniquenames from build to build, leading to trivially differing build results that upset some build correctness checks.