### PR TITLE
Add an auto-layout mode to HalideTraceViz

### DIFF
--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -44,3 +44,10 @@ test: $(BIN)/out.png
 
 viz: $(BIN)/bilateral_grid.mp4
 	mplayer $^
+
+$(BIN)/viz_auto.mp4: $(BIN)/filter_viz ../support/viz_auto.sh ../../bin/HalideTraceViz
+	@mkdir -p $(@D)
+	bash ../support/viz_auto.sh "$(BIN)/filter_viz $(IMAGES)/gray_small.png $(BIN)/out_small.png 0.2 0" ../../bin/HalideTraceViz $@
+
+viz_auto: $(BIN)/viz_auto.mp4
+	mplayer $^

--- a/apps/blur/Makefile
+++ b/apps/blur/Makefile
@@ -10,6 +10,10 @@ $(BIN)/%/halide_blur.a: $(BIN)/halide_blur.generator
 	@mkdir -p $(@D)
 	$^ -g halide_blur -o $(BIN)/$* target=$(HL_TARGET)
 
+$(BIN)/%/halide_blur_viz.a: $(BIN)/halide_blur.generator
+	@mkdir -p $(@D)
+	$^ -g halide_blur -o $(BIN)/$* target=$(HL_TARGET)-trace_loads-trace_stores-trace_realizations
+
 # g++ on OS X might actually be system clang without openmp
 CXX_VERSION=$(shell $(CXX) --version)
 ifeq (,$(findstring clang,$(CXX_VERSION)))
@@ -23,8 +27,23 @@ $(BIN)/%/test: $(BIN)/%/halide_blur.a test.cpp
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS-$*) $(OPENMP_FLAGS) -Wall -O2 -I$(BIN)/$* test.cpp $(BIN)/$*/halide_blur.a -o $@ $(LDFLAGS-$*)
 
+# -O2 is faster than -O3 for this app (O3 unrolls too much)
+$(BIN)/%/test_viz: $(BIN)/%/halide_blur_viz.a test.cpp
+	@mkdir -p $(@D)
+	$(CXX-$*) $(CXXFLAGS-$*) $(OPENMP_FLAGS) -Wall -O2 -I$(BIN)/$* test.cpp $(BIN)/$*/halide_blur.a -o $@ $(LDFLAGS-$*)
+
 clean:
 	rm -rf $(BIN)
 
 test: $(BIN)/host/test
 	$(BIN)/host/test
+
+../../bin/HalideTraceViz: ../../util/HalideTraceViz.cpp
+	$(MAKE) -C ../../ bin/HalideTraceViz
+
+$(BIN)/viz_auto.mp4: $(BIN)/host/test ../support/viz_auto.sh ../../bin/HalideTraceViz
+	@mkdir -p $(@D)
+	bash ../support/viz_auto.sh "$(BIN)/host/test --small" ../../bin/HalideTraceViz $@
+
+viz_auto: $(BIN)/viz_auto.mp4
+	mplayer $^

--- a/apps/blur/test.cpp
+++ b/apps/blur/test.cpp
@@ -157,14 +157,20 @@ Buffer<uint16_t> blur_halide(Buffer<uint16_t> in) {
 }
 
 int main(int argc, char **argv) {
-#ifndef HALIDE_RUNTIME_HEXAGON
-    const int width = 6408;
-    const int height = 4802;
-#else
+    bool small = false;
+#ifdef HALIDE_RUNTIME_HEXAGON
     // The Hexagon simulator can't allocate as much memory as the above wants.
-    const int width = 648;
-    const int height = 482;
+    small = true;
 #endif
+
+    for (int i = 1; i < argc; ++i) {
+        if (!strcmp(argv[i], "--small")) {
+            small = true;
+        }
+    }
+
+    const int width = small ? 648 : 6408;
+    const int height = small ? 482 : 4802;
     Buffer<uint16_t> input(width, height);
 
     for (int y = 0; y < input.height(); y++) {

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -42,3 +42,10 @@ test: $(BIN)/out.png
 
 viz: $(BIN)/camera_pipe.mp4
 	mplayer $^
+
+$(BIN)/viz_auto.mp4: $(BIN)/viz/process ../support/viz_auto.sh ../../bin/HalideTraceViz
+	@mkdir -p $(@D)
+	bash ../support/viz_auto.sh "$(BIN)/viz/process $(IMAGES)/bayer_small.png 3700 1.8 50 1 1 $(BIN)/out.png" ../../bin/HalideTraceViz $@
+
+viz_auto: $(BIN)/viz_auto.mp4
+	mplayer $^

--- a/apps/fft/Makefile
+++ b/apps/fft/Makefile
@@ -64,3 +64,13 @@ test: $(BIN)/bench_fft
 	$(BIN)/bench_fft 16 16 $(BIN)/
 	$(BIN)/bench_fft 32 32 $(BIN)/
 	$(BIN)/bench_fft 48 48 $(BIN)/
+
+../../bin/HalideTraceViz: ../../util/HalideTraceViz.cpp
+	$(MAKE) -C ../../ bin/HalideTraceViz
+
+$(BIN)/viz_auto.mp4: $(BIN)/fft_aot_test ../support/viz_auto.sh ../../bin/HalideTraceViz
+	@mkdir -p $(@D)
+	bash ../support/viz_auto.sh "$(BIN)/fft_aot_test" ../../bin/HalideTraceViz $@
+
+viz_auto: $(BIN)/viz_auto.mp4
+	mplayer $^

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -47,3 +47,10 @@ test: $(BIN)/out.png
 
 viz: $(BIN)/local_laplacian.mp4
 	mplayer $^
+
+$(BIN)/viz_auto.mp4: $(BIN)/process_viz ../support/viz_auto.sh ../../bin/HalideTraceViz
+	@mkdir -p $(@D)
+	bash ../support/viz_auto.sh "$(BIN)/process_viz $(IMAGES)/rgb_small.png 4 1 1 0 $(BIN)/out_small.png" ../../bin/HalideTraceViz $@
+
+viz_auto: $(BIN)/viz_auto.mp4
+	mplayer $^

--- a/apps/resize/Makefile
+++ b/apps/resize/Makefile
@@ -72,3 +72,18 @@ clean:
 
 
 test: all
+
+
+../../bin/HalideTraceViz: ../../util/HalideTraceViz.cpp
+	$(MAKE) -C ../../ bin/HalideTraceViz
+
+$(BIN)/viz_auto.mp4: $(BIN)/resize ../support/viz_auto.sh ../../bin/HalideTraceViz
+	@mkdir -p $(@D)
+	bash ../support/viz_auto.sh "$(BIN)/resize $(IMAGES)/rgb_small.png \
+	/tmp/foo.png \
+	-i box \
+	-t uint8 \
+	-f 0.5" ../../bin/HalideTraceViz $@
+
+viz_auto: $(BIN)/viz_auto.mp4
+	mplayer $^

--- a/apps/support/viz_auto.sh
+++ b/apps/support/viz_auto.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# $1 = filter cmd to run, including args
+# $2 = HalideTraceViz executable
+# $3 = path to output mp4
+
+rm -rf "$3"
+
+# Use a named pipe for the $1 -> HTV pipe, just in case
+# the exe in $1 writes any random output to stdout.
+PIPE=/tmp/halide_viz_auto_pipe
+rm -rf $PIPE
+mkfifo $PIPE
+
+HL_TRACE_FILE=${PIPE} HL_NUMTHREADS=8 $1 &
+
+"$2" --auto_layout --size 1920 1080 0<${PIPE} | \
+avconv -y -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 "$3"
+#mplayer -demuxer rawvideo -rawvideo w=1920:h=1080:format=rgba:fps=30 -idle -fixed-vo -

--- a/tools/halide_trace_config.h
+++ b/tools/halide_trace_config.h
@@ -43,6 +43,23 @@ inline std::string unescape_spaces(const std::string &str) {
     return replace_all(str, "\\x20", " ");
 }
 
+inline std::ostream &operator<<(std::ostream &os, const halide_type_t &t) {
+    os << (int) t.code << " " << (int) t.bits << " " << t.lanes;
+    return os;
+}
+
+
+inline std::istream &operator>>(std::istream &is, halide_type_t &t) {
+    // type.code is an enum; type.bits is a uint8 and might be read as char.
+    int type_code, type_bits;
+    is >> type_code
+       >> type_bits
+       >> t.lanes;
+    t.code = (halide_type_code_t) type_code;
+    t.bits = (uint8_t) type_bits;
+    return is;
+}
+
 template<typename T>
 std::ostream &operator<<(std::ostream &os, const std::vector<T> &v) {
     os << v.size() << " ";
@@ -311,6 +328,18 @@ struct GlobalConfig {
     // How many Halide computations should be covered by each frame.
     int timestep = 10000;
 
+    // If true, automatically layout every realized func we see, in left-to-right,
+    // top-to-bottom order as they are first touched.
+    bool auto_layout = false;
+
+    // If doing auto-layout, divide the frame into this many rows and columns,
+    // filling in each cell in left-to-right, top-to-bottom order. If either
+    // value is -1, calculate a cell size based on the number of boxes touched.
+    Point auto_layout_grid = { -1, -1 };
+
+    // If doing auto-layout, the padding to use between each cell.
+    Point auto_layout_pad = { 32, 32 };
+
     static std::string tag_start_text() {
         return std::string("htv_global_config:");
     }
@@ -320,12 +349,16 @@ struct GlobalConfig {
     }
 
     void dump(std::ostream &os) const {
-        os << "Global:\n"
+        os << std::boolalpha
+            << "Global:\n"
             << "  frame_size: " << frame_size << "\n"
             << "  decay_factor_during_compute: " << decay_factor_during_compute << "\n"
             << "  decay_factor_after_compute: " << decay_factor_after_compute << "\n"
             << "  hold_frames: " << hold_frames << "\n"
-            << "  timestep: " << timestep << "\n";
+            << "  timestep: " << timestep << "\n"
+            << "  auto_layout: " << auto_layout << "\n"
+            << "  auto_layout_grid: " << auto_layout_grid << "\n"
+            << "  auto_layout_pad: " << auto_layout_grid << "\n";
     }
 
     friend std::ostream &operator<<(std::ostream &os, const GlobalConfig &config) {
@@ -338,7 +371,10 @@ struct GlobalConfig {
             << config.decay_factor_during_compute << " "
             << config.decay_factor_after_compute << " "
             << config.hold_frames << " "
-            << config.timestep;
+            << config.timestep << " "
+            << config.auto_layout << " "
+            << config.auto_layout_grid << " "
+            << config.auto_layout_pad;
         return os;
     }
 
@@ -350,7 +386,10 @@ struct GlobalConfig {
             >> config.decay_factor_during_compute
             >> config.decay_factor_after_compute
             >> config.hold_frames
-            >> config.timestep;
+            >> config.timestep
+            >> config.auto_layout
+            >> config.auto_layout_grid
+            >> config.auto_layout_pad;
         if (start_text != tag_start_text()) {
             is.setstate(std::ios::failbit);
         }
@@ -377,6 +416,85 @@ struct GlobalConfig {
     }
 };
 
+// We don't use halide_dimension_t here because we don't want stride.
+struct Range {
+    int min = 0, extent = 0;
+
+    Range() = default;
+    Range(int min, int extent) : min(min), extent(extent) {}
+
+    friend std::ostream &operator<<(std::ostream &os, const Range &dim) {
+        os << dim.min << " " << dim.extent;
+        return os;
+    }
+
+    friend std::istream &operator>>(std::istream &is, Range &dim) {
+        is >> dim.min >> dim.extent;
+        return is;
+    }
+};
+
+// TODO name is terrible
+struct FuncTypeAndDim {
+    std::vector<halide_type_t> types;
+    std::vector<Range> dims;
+
+    static std::string tag_start_text() {
+        return std::string("func_type_and_dim:");
+    }
+
+    static bool match(const std::string &trace_tag) {
+        return trace_tag.find(tag_start_text()) == 0;
+    }
+
+    void dump(std::ostream &os, const std::string &name) const {
+        static const char * const type_name[4] = { "int", "uint", "float", "handle" };
+        os << "FuncTypeAndDim: " << name << "\n";
+        os << "  types:";
+        for (const auto &type : types) {
+            os << " " << type_name[type.code & 3] << (int) type.bits;
+            if (type.lanes > 1) {
+                os << 'x' << type.lanes;
+            }
+        }
+        os << "\n";
+        os << "  dims: " << dims << "\n";
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, const FuncTypeAndDim &types_and_ranges) {
+        os << tag_start_text()
+           << " " << types_and_ranges.types
+           << " " << types_and_ranges.dims;
+        return os;
+    }
+
+    friend std::istream &operator>>(std::istream &is, FuncTypeAndDim &types_and_ranges) {
+        std::string start_text;
+        is >> start_text
+           >> types_and_ranges.types
+           >> types_and_ranges.dims;
+        if (start_text != tag_start_text()) {
+            is.setstate(std::ios::failbit);
+        }
+        return is;
+    }
+
+    std::string to_trace_tag() const {
+        std::ostringstream os;
+        os << *this;
+        return os.str();
+    }
+
+    FuncTypeAndDim() = default;
+
+    explicit FuncTypeAndDim(const std::string &trace_tag, ErrorFunc error = default_error) {
+        std::istringstream is(trace_tag);
+        is >> *this;
+        if (is.fail() || is.get() != EOF) {
+            error("FuncTypeAndDim trace_tag parsing error");
+        }
+    }
+};
 
 }  // namespace Trace
 }  // namespace Halide


### PR DESCRIPTION
This PR probably needs more work and cleanup, but is good enough to start getting comments and feedback on. The general idea is that
(1) Tracing.cpp now adds trace-tags that contain the type info and dimensions/extent of all Funcs touched (dimensions are a conservative guess based on calling boxes_touched())
(2) HTV now has an `--auto_layout` flag that, when set, attempts to lay out all touched funcs in a way that isn't crazy: in the order touched, in a set of left-to-right/top-to-bottom squares, roughly maximizing space used, zooming as it sees fit, adding labels, etc.
(3) By default, any trace-tags that are specified in Halide code (or on the command line) override the auto-layout flag; this is useful in that you can use it to start with auto-layout, then gradually tweak it to a pleasing layout by adding tags (e.g. if you want to use it for a presentation). OTOH, if you use `--auto_layout` on a pipeline that already is tweaked, you can get bizarre results (cf camera_pipe for an example); you can pass the flag `--ignore_tags` to have auto layout ignore any custom tags and just use pure auto layout.
(4) Added a `viz_auto` shell and makefile usage to a handful of apps; that said, I think the better longterm usage for autolayout is more likely to be by breaking HTV up into library form and integrating it into the RunGen utility.
(5) Doesn't deal with Tuple-valued Funcs well (known existing limitation of HTV); hasn't been tested with define_extern() yet so might be broken there.

Aside from commenting on the code, feel free to pull and try it on various pipelines; feedback on improving the layout is welcome. (Just keep in mind that this autolayout algo isn't intended to be aesthetically pleasing; it's intended soley to quickly lay out things in a way that makes visualization of code patterns comprehensible to a typical Halide coder. If we can also make it pretty, that's nice too, of course.)