### PR TITLE
Change MAX_THREADS back to 64

### DIFF
--- a/src/runtime/posix_threads.cpp
+++ b/src/runtime/posix_threads.cpp
@@ -2,7 +2,7 @@
 #include "runtime_internal.h"
 
 // TODO: consider getting rid of this
-#define MAX_THREADS 256
+#define MAX_THREADS 64
 
 extern "C" {
 

--- a/src/runtime/qurt_threads.cpp
+++ b/src/runtime/qurt_threads.cpp
@@ -2,7 +2,7 @@
 #include "mini_qurt.h"
 
 // TODO: consider getting rid of this
-#define MAX_THREADS 256
+#define MAX_THREADS 64
 
 using namespace Halide::Runtime::Internal::Qurt;
 

--- a/src/runtime/synchronization_common.h
+++ b/src/runtime/synchronization_common.h
@@ -382,7 +382,6 @@ struct hash_bucket {
 // which cannot be lowered for Mac OS due to MachO. A better
 // solution is desired of course.
 #define HASH_TABLE_BITS (sizeof(unsigned int) * 8 - __builtin_clz(MAX_THREADS * LOAD_FACTOR) - 1)
-static_assert(HASH_TABLE_BITS==8,"sdf");
 struct hash_table {
     hash_bucket buckets[MAX_THREADS * LOAD_FACTOR];
 };

--- a/src/runtime/synchronization_common.h
+++ b/src/runtime/synchronization_common.h
@@ -48,7 +48,7 @@ __attribute__((always_inline)) bool cas_strong_sequentially_consistent_helper(ui
  __attribute__((always_inline)) bool atomic_cas_strong_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
      return cas_strong_sequentially_consistent_helper(addr, expected, desired);
 }
-      
+
 __attribute__((always_inline)) bool atomic_cas_weak_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
      return cas_strong_sequentially_consistent_helper(addr, expected, desired);
 }
@@ -95,7 +95,7 @@ __attribute__((always_inline))  uintptr_t atomic_and_fetch_release(uintptr_t *ad
 __attribute__((always_inline)) bool atomic_cas_strong_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
     return __atomic_compare_exchange(addr, expected, desired, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
 }
-      
+
 __attribute__((always_inline)) bool atomic_cas_weak_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
     return __atomic_compare_exchange(addr, expected, desired, true, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
 }
@@ -135,7 +135,7 @@ __attribute__((always_inline)) void atomic_thread_fence_acquire() {
 #endif
 
 }
- 
+
 class spin_control {
     int spin_count;
 
@@ -372,7 +372,7 @@ struct queue_data {
 
 struct hash_bucket {
     word_lock mutex;
-    
+
     queue_data *head; // Is this queue_data or thread_data?
     queue_data *tail; // Is this queue_data or thread_data?
 };
@@ -381,14 +381,15 @@ struct hash_bucket {
 // a class with a constructor is used, clang generates a COMDAT
 // which cannot be lowered for Mac OS due to MachO. A better
 // solution is desired of course.
-#define HASH_TABLE_BITS 10
+#define HASH_TABLE_BITS (sizeof(unsigned int) * 8 - __builtin_clz(MAX_THREADS * LOAD_FACTOR) - 1)
+static_assert(HASH_TABLE_BITS==8,"sdf");
 struct hash_table {
     hash_bucket buckets[MAX_THREADS * LOAD_FACTOR];
 };
 WEAK char table_storage[sizeof(hash_table)];
-#define table (*(hash_table *)table_storage) 
+#define table (*(hash_table *)table_storage)
 
-inline void check_hash(uintptr_t hash) {
+__attribute__((always_inline)) void check_hash(uintptr_t hash) {
     halide_assert(NULL, hash < sizeof(table.buckets)/sizeof(table.buckets[0]));
 }
 
@@ -783,7 +784,7 @@ class fast_mutex {
                 atomic_load_relaxed(&state, &expected);
                 continue;
             }
-            
+
             // Mark mutex as having parked threads if not already done.
             if ((expected & parked_bit) == 0) {
                 uintptr_t desired = expected | parked_bit;

--- a/src/runtime/windows_threads.cpp
+++ b/src/runtime/windows_threads.cpp
@@ -2,7 +2,7 @@
 #include "runtime_internal.h"
 
 // TODO: consider getting rid of this
-#define MAX_THREADS 256
+#define MAX_THREADS 64
 
 extern "C" {
 
@@ -107,7 +107,7 @@ struct thread_parker {
         EnterCriticalSection(&critical_section);
         while (should_park) {
             SleepConditionVariableCS(&condvar, &critical_section, -1);
-        } 
+        }
         LeaveCriticalSection(&critical_section);
     }
 


### PR DESCRIPTION
It was bumped to 256 by the fast-sync changes, but since we still pre-emptively fill up a threadpool with number-of-available cores, this can cause a jump in threads allocated on some higher-end systems, leading to pointless memory pressure. Let's move the limit back to where it was for now; we can bump it back up after we're confident we have appropriate checks in place everywhere donwstream.