### PR TITLE
Add support for ThreadSanitizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,18 @@ ifneq ($(TEST_CUDA), )
 TEST_CXX_FLAGS += -DTEST_CUDA
 endif
 
+# TODO: this is horrible hackery; we should really add the relevant
+# support libs for the sanitizer(s) as weak symbols in Codegen_LLVM
+ifneq (,$(findstring tsan,$(HL_TARGET)))
+TEST_LD_FLAGS += -fsanitize=thread
+GEN_AOT_LD_FLAGS += -fsanitize=thread
+endif
+
+ifneq (,$(findstring tsan,$(HL_JIT_TARGET)))
+TEST_LD_FLAGS += -fsanitize=thread
+GEN_AOT_LD_FLAGS += -fsanitize=thread
+endif
+
 # Compiling the tutorials requires libpng
 LIBPNG_LIBS_DEFAULT = $(shell libpng-config --ldflags)
 LIBPNG_CXX_FLAGS ?= $(shell libpng-config --cflags)

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1071,6 +1071,14 @@ void CodeGen_LLVM::optimize_module() {
     }
 #endif
 
+    if (get_target().has_feature(Target::TSAN)) {
+        auto addThreadSanitizerPass = [](const PassManagerBuilder &builder, legacy::PassManagerBase &pm) {
+            pm.add(createThreadSanitizerPass());
+        };
+        b.addExtension(PassManagerBuilder::EP_OptimizerLast, addThreadSanitizerPass);
+        b.addExtension(PassManagerBuilder::EP_EnabledOnOptLevel0, addThreadSanitizerPass);
+    }
+
     b.populateFunctionPassManager(function_pass_manager);
     b.populateModulePassManager(module_pass_manager);
 

--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -46,6 +46,7 @@
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/Utils/ModuleUtils.h>
 #include <llvm/Transforms/Utils/SymbolRewriter.h>
+#include <llvm/Transforms/Instrumentation.h>
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -257,6 +257,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"fuzz_float_stores", Target::FuzzFloatStores},
     {"soft_float_abi", Target::SoftFloatABI},
     {"msan", Target::MSAN},
+    {"tsan", Target::TSAN},
     {"avx512", Target::AVX512},
     {"avx512_knl", Target::AVX512_KNL},
     {"avx512_skylake", Target::AVX512_Skylake},
@@ -294,6 +295,9 @@ Target get_jit_target_from_environment() {
 #if defined(__has_feature)
 #if __has_feature(memory_sanitizer)
     host.set_feature(Target::MSAN);
+#endif
+#if __has_feature(thread_sanitizer)
+    host.set_feature(Target::TSAN);
 #endif
 #endif
     string target = Internal::get_env_variable("HL_JIT_TARGET");

--- a/src/Target.h
+++ b/src/Target.h
@@ -79,6 +79,7 @@ struct Target {
         FuzzFloatStores = halide_target_feature_fuzz_float_stores,
         SoftFloatABI = halide_target_feature_soft_float_abi,
         MSAN = halide_target_feature_msan,
+        TSAN = halide_target_feature_tsan,
         AVX512 = halide_target_feature_avx512,
         AVX512_KNL = halide_target_feature_avx512_knl,
         AVX512_Skylake = halide_target_feature_avx512_skylake,

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1105,7 +1105,8 @@ typedef enum halide_target_feature_t {
     halide_target_feature_cl_half = 49,  ///< Enable half support on OpenCL targets
     halide_target_feature_strict_float = 50, ///< Turn off all non-IEEE floating-point optimization. Currently applies only to LLVM targets.
     halide_target_feature_legacy_buffer_wrappers = 51,  ///< Emit legacy wrapper code for buffer_t (vs halide_buffer_t) when AOT-compiled.
-    halide_target_feature_end = 52, ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
+    halide_target_feature_tsan = 52, ///< Enable hooks for TSAN support.
+    halide_target_feature_end = 53 ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 
 /** This function is called internally by Halide in some situations to determine


### PR DESCRIPTION
Add Target::TSAN and support for it. Unlike the previous MSAN support, though, this actually just adds the ThreadSanitizer LLVM pass at the right spot, meaning that (in theory) both Halide-generated code *and* our runtime code should be TSAN-checked.

Still experimenting, but if this pans out, it should allow us to replace the previous MSAN hackery (mark buffers as touched) with "real" MSAN checking (which will be many times slower of course, but that's OK).

Also would allow adding ASan (and maybe UBSan, though it's not clear if C++ undefined behavior warnings are useful or interesting to us...)