### PR TITLE
Revert "msvc: fix static build."

### DIFF
--- a/src/Util.h
+++ b/src/Util.h
@@ -24,14 +24,10 @@
 
 #ifndef HALIDE_EXPORT
 #if defined(_MSC_VER)
-#ifdef Halide_SHARED
 #ifdef Halide_EXPORTS
 #define HALIDE_EXPORT __declspec(dllexport)
 #else
 #define HALIDE_EXPORT __declspec(dllimport)
-#endif
-#else
-#define HALIDE_EXPORT
 #endif
 #else
 #define HALIDE_EXPORT


### PR DESCRIPTION
Reverts halide/Halide#2902

This has broken the Win64 builds; we didn't notice because the Windows buildbots were down. Please feel free to re-submit after testing.