### PR TITLE
widen trace-packet dimensions in VectorizeLoops, not trace_helper

### DIFF
--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -18,7 +18,7 @@ struct TraceEventBuilder {
     vector<Expr> coordinates;
     Type type;
     enum halide_trace_event_code_t event;
-    Expr parent_id, value_index, dimensions;
+    Expr parent_id, value_index;
 
     Expr build() {
         Expr values = Call::make(type_of<void *>(), Call::make_struct,

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -502,6 +502,11 @@ class VectorSubs : public IRMutator2 {
             // records the number of vector lanes in the type being
             // stored.
             new_args[5] = max_lanes;
+            // One of the arguments to the trace helper
+            // records the number entries in the coordinates (which we just widened)
+            if (max_lanes > 1) {
+                new_args[9] = new_args[9] * max_lanes;
+            }
             return Call::make(op->type, Call::trace, new_args, op->call_type);
         } else {
             // Widen the args to have the same lanes as the max lanes found

--- a/src/runtime/tracing.cpp
+++ b/src/runtime/tracing.cpp
@@ -391,9 +391,6 @@ WEAK int halide_trace_helper(void *user_context,
     event.event = (halide_trace_event_code_t)code;
     event.parent_id = parent_id;
     event.value_index = value_index;
-    if (event.type.lanes > 1) {
-        dimensions *= event.type.lanes;
-    }
     event.dimensions = dimensions;
     halide_msan_annotate_memory_is_initialized(user_context, &event, sizeof(event));
     halide_msan_annotate_memory_is_initialized(user_context, value, type_lanes * ((type_bits + 7) / 8));


### PR DESCRIPTION
In theory these should be equivalent, but moving the adjustment to where the rest of the call the trace is mutated is more sensible