### PR TITLE
VectorizeLoops needs to specialize Call::trace even more

### DIFF
--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -30,6 +30,9 @@ struct TraceEventBuilder {
             idx = 0;
         }
 
+        // Note: if these arguments are changed in any meaningful way,
+        // VectorizeLoops will likely need attention; it does nontrivial
+        // special-casing of this call to get appropriate results.
         vector<Expr> args = {Expr(func),
                              values, coords,
                              (int)type.code(), (int)type.bits(), (int)type.lanes(),
@@ -200,7 +203,6 @@ private:
             builder.func = op->name;
             builder.parent_id = Variable::make(Int(32), "pipeline.trace_id");
             builder.event = halide_trace_begin_realization;
-
             for (size_t i = 0; i < op->bounds.size(); i++) {
                 builder.coordinates.push_back(op->bounds[i].min);
                 builder.coordinates.push_back(op->bounds[i].extent);
@@ -208,9 +210,11 @@ private:
 
             // Begin realization returns a unique token to pass to further trace calls affecting this buffer.
             Expr call_before = builder.build();
+
             builder.event = halide_trace_end_realization;
             builder.parent_id = Variable::make(Int(32), op->name + ".trace_id");
             Expr call_after = builder.build();
+
             Stmt new_body = op->body;
             new_body = Block::make(new_body, Evaluate::make(call_after));
             new_body = LetStmt::make(op->name + ".trace_id", call_before, new_body);

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -482,30 +482,63 @@ class VectorSubs : public IRMutator2 {
         if (!changed) {
             return op;
         } else if (op->name == Call::trace) {
-            // Call::trace vectorizes uniquely, because we want a
-            // single trace call for the entire vector, instead of
-            // scalarizing the call and tracing each element.
-            for (size_t i = 1; i <= 2; i++) {
-                // Each struct should be a struct-of-vectors, not a
-                // vector of distinct structs.
-                const Call *call = new_args[i].as<Call>();
-                internal_assert(call && call->is_intrinsic(Call::make_struct));
-                // Widen the call args to have the same lanes as the max lanes found
-                vector<Expr> call_args(call->args.size());
-                for (size_t i = 0; i < call_args.size(); i++) {
-                    call_args[i] = widen(call->args[i], max_lanes);
+            const int64_t *event = as_const_int(op->args[6]);
+            internal_assert(event != nullptr);
+            if (*event == halide_trace_begin_realization || *event == halide_trace_end_realization) {
+                // Call::trace vectorizes uniquely for begin/end realization, because the coordinates
+                // for these are actually min/extent pairs; we need to maintain the proper dimensionality
+                // count and instead aggregate the widened values into a single pair.
+                for (size_t i = 1; i <= 2; i++) {
+                    const Call *call = new_args[i].as<Call>();
+                    internal_assert(call && call->is_intrinsic(Call::make_struct));
+                    if (i == 1) {
+                        // values should always be empty for these events
+                        internal_assert(call->args.empty());
+                        continue;
+                    }
+                    vector<Expr> call_args(call->args.size());
+                    for (size_t j = 0; j < call_args.size(); j += 2) {
+                        Expr min_v = widen(call->args[j], max_lanes);
+                        Expr extent_v = widen(call->args[j+1], max_lanes);
+                        Expr min_scalar = extract_lane(min_v, 0);
+                        Expr max_scalar = min_scalar + extract_lane(extent_v, 0);
+                        for (int k = 1; k < max_lanes; ++k) {
+                            Expr min_k = extract_lane(min_v, k);
+                            Expr extent_k = extract_lane(extent_v, k);
+                            min_scalar = min(min_scalar, min_k);
+                            max_scalar = max(max_scalar, min_k + extent_k);
+                        }
+                        call_args[j] = min_scalar;
+                        call_args[j+1] = max_scalar - min_scalar;
+                    }
+                    new_args[i] = Call::make(call->type.element_of(), Call::make_struct, call_args, Call::Intrinsic);
                 }
-                new_args[i] = Call::make(call->type.element_of(), Call::make_struct,
-                                         call_args, Call::Intrinsic);
-            }
-            // One of the arguments to the trace helper
-            // records the number of vector lanes in the type being
-            // stored.
-            new_args[5] = max_lanes;
-            // One of the arguments to the trace helper
-            // records the number entries in the coordinates (which we just widened)
-            if (max_lanes > 1) {
-                new_args[9] = new_args[9] * max_lanes;
+            } else {
+                // Call::trace vectorizes uniquely, because we want a
+                // single trace call for the entire vector, instead of
+                // scalarizing the call and tracing each element.
+                for (size_t i = 1; i <= 2; i++) {
+                    // Each struct should be a struct-of-vectors, not a
+                    // vector of distinct structs.
+                    const Call *call = new_args[i].as<Call>();
+                    internal_assert(call && call->is_intrinsic(Call::make_struct));
+                    // Widen the call args to have the same lanes as the max lanes found
+                    vector<Expr> call_args(call->args.size());
+                    for (size_t j = 0; j < call_args.size(); j++) {
+                        call_args[j] = widen(call->args[j], max_lanes);
+                    }
+                    new_args[i] = Call::make(call->type.element_of(), Call::make_struct,
+                                             call_args, Call::Intrinsic);
+                }
+                // One of the arguments to the trace helper
+                // records the number of vector lanes in the type being
+                // stored.
+                new_args[5] = max_lanes;
+                // One of the arguments to the trace helper
+                // records the number entries in the coordinates (which we just widened)
+                if (max_lanes > 1) {
+                    new_args[9] = new_args[9] * max_lanes;
+                }
             }
             return Call::make(op->type, Call::trace, new_args, op->call_type);
         } else {


### PR DESCRIPTION
begin/end_realization events got vectorized in a way that increased the number of dimensions by the vector width in a bizarre way, e.g. if the realization was sum(vectorize(4)), a 1-dimensional realization would emit a 4d begin_realization, with the data in the form (min0..3, extent...3). Code downstream (e.g. HTV) could probably recognize and deal with this situation but it seems better to try to handle it here.