### PR TITLE
Improve Generator error messages

### DIFF
--- a/python_bindings/correctness/pystub.py
+++ b/python_bindings/correctness/pystub.py
@@ -114,7 +114,7 @@ def test_simplestub():
         # Bad gp name
         f = simplestub.generate(target, b_in, float_arg=3.5, offset=k, func_input=f_in, nonexistent_generator_param="wat")
     except RuntimeError as e:
-        assert "Generator has no GeneratorParam named: nonexistent_generator_param" in str(e)
+        assert "Generator simplestub has no GeneratorParam named: nonexistent_generator_param" in str(e)
     else:
         assert False, 'Did not see expected exception!'
 

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1241,11 +1241,13 @@ public:
     IOKind kind() const;
 
     bool types_defined() const;
-    const std::vector<Type> &types() const;
-    Type type() const;
+    // non-const because Type may be lazily updated if initially unspecified
+    const std::vector<Type> &types();
+    Type type();
 
     bool dims_defined() const;
-    int dims() const;
+    // non-const because Type may be lazily updated if initially unspecified
+    int dims();
 
     const std::vector<Func> &funcs() const;
     const std::vector<Expr> &exprs() const;
@@ -1281,10 +1283,11 @@ protected:
 
     std::string array_name(size_t i) const;
 
-    virtual void verify_internals() const;
+    virtual void verify_internals();
 
     void check_matching_array_size(size_t size);
-    void check_matching_type_and_dim(const std::vector<Type> &t, int d);
+    void check_matching_types(const std::vector<Type> &t);
+    void check_matching_dims(int d);
 
     template<typename ElemType>
     const std::vector<ElemType> &get_values() const;
@@ -1337,7 +1340,7 @@ protected:
 
     virtual void set_def_min_max();
 
-    void verify_internals() const override;
+    void verify_internals() override;
 
     friend class StubEmitter;
 

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1291,6 +1291,8 @@ protected:
 
     virtual void check_value_writable() const = 0;
 
+    virtual const char *input_or_output() const = 0;
+
 private:
     template<typename T> friend class GeneratorParam_Synthetic;
 
@@ -1342,6 +1344,8 @@ protected:
     virtual std::string get_c_type() const = 0;
 
     void check_value_writable() const override;
+
+    const char *input_or_output() const override { return "Input"; }
 
     void estimate_impl(Var var, Expr min, Expr extent);
 };
@@ -1966,6 +1970,8 @@ protected:
     }
 
     void check_value_writable() const override;
+
+    const char *input_or_output() const override { return "Output"; }
 };
 
 template<typename T>

--- a/test/generator/stubtest_generator.cpp
+++ b/test/generator/stubtest_generator.cpp
@@ -47,6 +47,7 @@ public:
 
     void generate() {
         simple_output(x, y, c) = cast<float>(simple_input(x, y, c));
+
         typed_buffer_output(x, y, c) = cast<float>(typed_buffer_input(x, y, c));
         // Note that if we are being invoked via a Stub, "untyped_buffer_output.type()" will
         // assert-fail, because there is no type constraint set: the type
@@ -65,6 +66,10 @@ public:
         tuple_output(x, y, c) = Tuple(
                 intermediate(x, y, c),
                 intermediate(x, y, c) + int_arg[0]);
+        // Verify that Output::type() and ::dims() are well-defined after we define the Func
+        assert(tuple_output.types()[0] == Float(32));
+        assert(tuple_output.types()[1] == Float(32));
+        assert(tuple_output.dims() == 3);
 
         array_output.resize(array_input.size());
         for (size_t i = 0; i < array_input.size(); ++i) {


### PR DESCRIPTION
- If a bad GeneratorParam is specified, name the Generator for which it failed
- if a synthetic param is specified that isn't settable (ie a .type for which one is concretely specified), give an error message indicating it isn't settable, rather than that it is "missing"