### PR TITLE
Bounds for popc/clz/ctz needs to be scalar

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -896,8 +896,8 @@ private:
                    op->is_intrinsic(Call::count_leading_zeros) ||
                    op->is_intrinsic(Call::count_trailing_zeros)) {
             internal_assert(op->args.size() == 1);
-            interval = Interval(make_zero(op->type),
-                                make_const(op->type, op->args[0].type().bits()));
+            interval = Interval(make_zero(op->type.element_of()),
+                                make_const(op->type.element_of(), op->args[0].type().bits()));
         } else if (op->is_intrinsic(Call::memoize_expr)) {
             internal_assert(op->args.size() >= 1);
             op->args[0].accept(this);

--- a/test/correctness/popc_clz_ctz_bounds.cpp
+++ b/test/correctness/popc_clz_ctz_bounds.cpp
@@ -49,7 +49,9 @@ int main(int argc, char **argv) {
                      mapping(count_leading_zeros(in(x))),
                      mapping(count_trailing_zeros(in(x))));
 
-        if (vectorize) f.vectorize(x, 8);
+        if (vectorize) {
+            f.vectorize(x, 8);
+        }
 
         std::mt19937 rng(0);
         Buffer<uint8_t> data(16);

--- a/test/correctness/popc_clz_ctz_bounds.cpp
+++ b/test/correctness/popc_clz_ctz_bounds.cpp
@@ -43,6 +43,12 @@ int main(int argc, char **argv) {
     }
 
     for (int vectorize = 0; vectorize <= 1; vectorize++) {
+        if (vectorize && get_jit_target_from_environment().arch != Target::X86) {
+            // Not all architectures support vectorized popc/ctz/clz operations,
+            // and will fail at LLVM time. Skipping for non-x86 for now.
+            continue;
+        }
+
         Var x;
         Func f;
         f(x) = Tuple(mapping(popcount(in(x))),


### PR DESCRIPTION
Downstream code will fail if it encounters vector values in Intervals (eg BoundSmallAllocations); the code added in https://github.com/halide/Halide/pull/2896 needs to ensure the interval created is scalar.