### PR TITLE
Make types(), dim(), etc const again

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1492,7 +1492,7 @@ bool GIOBase::types_defined() const {
     return !types_.empty();
 }
 
-const std::vector<Type> &GIOBase::types() {
+const std::vector<Type> &GIOBase::types() const {
     // If types aren't defined, but we have one Func that is,
     // we probably just set an Output<Func> and should propagate the types.
     if (!types_defined()) {
@@ -1506,7 +1506,7 @@ const std::vector<Type> &GIOBase::types() {
     return types_;
 }
 
-Type GIOBase::type() {
+Type GIOBase::type() const {
     const auto &t = types();
     internal_assert(t.size() == 1) << "Expected types_.size() == 1, saw " << t.size() << " for " << name() << "\n";
     return t.at(0);
@@ -1516,7 +1516,7 @@ bool GIOBase::dims_defined() const {
     return dims_ != -1;
 }
 
-int GIOBase::dims() {
+int GIOBase::dims() const {
     // If types aren't defined, but we have one Func that is,
     // we probably just set an Output<Func> and should propagate the types.
     if (!dims_defined()) {
@@ -1584,7 +1584,7 @@ std::string GIOBase::array_name(size_t i) const {
 
 // If our type(s) are defined, ensure it matches the ones passed in, asserting if not.
 // If our type(s) are not defined, just set to the ones passed in.
-void GIOBase::check_matching_types(const std::vector<Type> &t) {
+void GIOBase::check_matching_types(const std::vector<Type> &t) const {
     if (types_defined()) {
         user_assert(types().size() == t.size()) << "Type mismatch for " << name() << ": expected " << types().size() << " types but saw " << t.size();
         for (size_t i = 0; i < t.size(); ++i) {
@@ -1597,7 +1597,7 @@ void GIOBase::check_matching_types(const std::vector<Type> &t) {
 
 // If our dims are defined, ensure it matches the one passed in, asserting if not.
 // If our dims are not defined, just set to the one passed in.
-void GIOBase::check_matching_dims(int d) {
+void GIOBase::check_matching_dims(int d) const {
     internal_assert(d >= 0);
     if (dims_defined()) {
         user_assert(dims() == d) << "Dimensions mismatch for " << name() << ": expected " << dims() << " saw " << d;
@@ -1606,7 +1606,7 @@ void GIOBase::check_matching_dims(int d) {
     }
 }
 
-void GIOBase::check_matching_array_size(size_t size) {
+void GIOBase::check_matching_array_size(size_t size) const {
     if (array_size_defined()) {
         user_assert(array_size() == size) << "ArraySize mismatch for " << name() << ": expected " << array_size() << " saw " << size;
     } else {

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1241,13 +1241,11 @@ public:
     IOKind kind() const;
 
     bool types_defined() const;
-    // non-const because Type may be lazily updated if initially unspecified
-    const std::vector<Type> &types();
-    Type type();
+    const std::vector<Type> &types() const;
+    Type type() const;
 
     bool dims_defined() const;
-    // non-const because Type may be lazily updated if initially unspecified
-    int dims();
+    int dims() const;
 
     const std::vector<Func> &funcs() const;
     const std::vector<Expr> &exprs() const;
@@ -1262,13 +1260,13 @@ protected:
 
     friend class GeneratorBase;
 
-    int array_size_;           // always 1 if is_array() == false.
+    mutable int array_size_;   // always 1 if is_array() == false.
                                // -1 if is_array() == true but unspecified.
 
     const std::string name_;
     const IOKind kind_;
-    std::vector<Type> types_;  // empty if type is unspecified
-    int dims_;           // -1 if dim is unspecified
+    mutable std::vector<Type> types_;  // empty if type is unspecified
+    mutable int dims_;                 // -1 if dim is unspecified
 
     // Exactly one of these will have nonzero length
     std::vector<Func> funcs_;
@@ -1285,9 +1283,9 @@ protected:
 
     virtual void verify_internals();
 
-    void check_matching_array_size(size_t size);
-    void check_matching_types(const std::vector<Type> &t);
-    void check_matching_dims(int d);
+    void check_matching_array_size(size_t size) const;
+    void check_matching_types(const std::vector<Type> &t) const;
+    void check_matching_dims(int d) const;
 
     template<typename ElemType>
     const std::vector<ElemType> &get_values() const;


### PR DESCRIPTION
These were de-constifying recently, but downstream code relies on them being const. Use mutable fields instead.