### PR TITLE
Fix JIT-only ASAN crash

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1072,7 +1072,7 @@ void CodeGen_LLVM::optimize_module() {
 #endif
 
     if (get_target().has_feature(Target::ASAN)) {
-      auto addAddressSanitizerPasses = [](const PassManagerBuilder &builder, legacy::PassManagerBase &pm) {
+        auto addAddressSanitizerPasses = [](const PassManagerBuilder &builder, legacy::PassManagerBase &pm) {
             constexpr bool compile_kernel = false;   // always false for user code
             constexpr bool recover = false;          // -fsanitize-recover, always false here
 


### PR DESCRIPTION
The default of use_globals_gc = true for the ASAN ModulePass can be crashy when combined with JIT, and is pointless for Halide (since none of the globals we produce are ever visible to any GC).