### PR TITLE
 Fix portability issues in HTV

### DIFF
--- a/apps/auto_viz/Makefile
+++ b/apps/auto_viz/Makefile
@@ -61,6 +61,7 @@ test: all
 
 $(BIN)/viz_%.mp4: $(BIN)/auto_viz_demo ../support/viz_auto.sh ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
+	export HL_AVCONV
 	bash ../support/viz_auto.sh \
 		"$< $(IMAGES)/rgb_small.png /tmp/$*.png -s $* -f 0.5 " \
 		"../../bin/HalideTraceViz --auto_layout" \
@@ -70,4 +71,4 @@ $(BIN)/viz_%.mp4: $(BIN)/auto_viz_demo ../support/viz_auto.sh ../../bin/HalideTr
 # make viz_lessnaive
 # make viz_complex
 viz_%: $(BIN)/viz_%.mp4
-	mplayer $^
+	$(HL_VIDEOPLAYER) $^

--- a/apps/auto_viz/Makefile
+++ b/apps/auto_viz/Makefile
@@ -61,8 +61,7 @@ test: all
 
 $(BIN)/viz_%.mp4: $(BIN)/auto_viz_demo ../support/viz_auto.sh ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
-	export HL_AVCONV
-	bash ../support/viz_auto.sh \
+	HL_AVCONV=$(HL_AVCONV) bash ../support/viz_auto.sh \
 		"$< $(IMAGES)/rgb_small.png /tmp/$*.png -s $* -f 0.5 " \
 		"../../bin/HalideTraceViz --auto_layout" \
 		$@

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -31,8 +31,7 @@ $(BIN)/filter_viz: $(BIN)/viz/bilateral_grid.a filter.cpp ../../bin/HalideTraceV
 
 $(BIN)/bilateral_grid.mp4: $(BIN)/filter_viz viz.sh ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
-	export HL_AVCONV
-	bash viz.sh $(BIN)
+	HL_AVCONV=$(HL_AVCONV) bash viz.sh $(BIN)
 
 $(BIN)/out.png: $(BIN)/filter
 	@mkdir -p $(@D)
@@ -48,8 +47,7 @@ viz: $(BIN)/bilateral_grid.mp4
 
 $(BIN)/viz_auto.mp4: $(BIN)/filter_viz ../support/viz_auto.sh ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
-	export HL_AVCONV
-	bash ../support/viz_auto.sh "$(BIN)/filter_viz $(IMAGES)/gray_small.png $(BIN)/out_small.png 0.2 0" ../../bin/HalideTraceViz $@
+	HL_AVCONV=$(HL_AVCONV) bash ../support/viz_auto.sh "$(BIN)/filter_viz $(IMAGES)/gray_small.png $(BIN)/out_small.png 0.2 0" ../../bin/HalideTraceViz $@
 
 viz_auto: $(BIN)/viz_auto.mp4
 	$(HL_VIDEOPLAYER) $^

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -31,6 +31,7 @@ $(BIN)/filter_viz: $(BIN)/viz/bilateral_grid.a filter.cpp ../../bin/HalideTraceV
 
 $(BIN)/bilateral_grid.mp4: $(BIN)/filter_viz viz.sh ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
+	export HL_AVCONV
 	bash viz.sh $(BIN)
 
 $(BIN)/out.png: $(BIN)/filter
@@ -43,11 +44,12 @@ clean:
 test: $(BIN)/out.png
 
 viz: $(BIN)/bilateral_grid.mp4
-	mplayer $^
+	$(HL_VIDEOPLAYER) $^
 
 $(BIN)/viz_auto.mp4: $(BIN)/filter_viz ../support/viz_auto.sh ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
+	export HL_AVCONV
 	bash ../support/viz_auto.sh "$(BIN)/filter_viz $(IMAGES)/gray_small.png $(BIN)/out_small.png 0.2 0" ../../bin/HalideTraceViz $@
 
 viz_auto: $(BIN)/viz_auto.mp4
-	mplayer $^
+	$(HL_VIDEOPLAYER) $^

--- a/apps/bilateral_grid/viz.sh
+++ b/apps/bilateral_grid/viz.sh
@@ -5,5 +5,5 @@ rm -f $1/bilateral_grid.mp4
 make $1/filter_viz && \
 $1/filter_viz ../images/gray_small.png $1/out_small.png 0.2 0 | \
 ../../bin/HalideTraceViz --size 1920 1080 | \
-avconv -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 $1/bilateral_grid.mp4
+${HL_AVCONV} -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 $1/bilateral_grid.mp4
 #mplayer -demuxer rawvideo -rawvideo w=1920:h=1080:format=rgba:fps=30 -idle -fixed-vo -

--- a/apps/bilateral_grid/viz.sh
+++ b/apps/bilateral_grid/viz.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+echo HL_AVCONV is ${HL_AVCONV}
 export HL_TRACE_FILE=/dev/stdout
 export HL_NUMTHREADS=4
 rm -f $1/bilateral_grid.mp4

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -33,6 +33,7 @@ $(BIN)/out.png: $(BIN)/process
 	$(MAKE) -C ../../ bin/HalideTraceViz
 
 $(BIN)/camera_pipe.mp4: $(BIN)/viz/process viz.sh $(HALIDE_TRACE_VIZ) ../../bin/HalideTraceViz
+	export HL_AVCONV
 	bash viz.sh $(BIN)
 
 clean:
@@ -41,11 +42,12 @@ clean:
 test: $(BIN)/out.png
 
 viz: $(BIN)/camera_pipe.mp4
-	mplayer $^
+	$(HL_VIDEOPLAYER) $^
 
 $(BIN)/viz_auto.mp4: $(BIN)/viz/process ../support/viz_auto.sh ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
+	export HL_AVCONV
 	bash ../support/viz_auto.sh "$(BIN)/viz/process $(IMAGES)/bayer_small.png 3700 1.8 50 1 1 $(BIN)/out.png" ../../bin/HalideTraceViz $@
 
 viz_auto: $(BIN)/viz_auto.mp4
-	mplayer $^
+	$(HL_VIDEOPLAYER) $^

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -33,8 +33,7 @@ $(BIN)/out.png: $(BIN)/process
 	$(MAKE) -C ../../ bin/HalideTraceViz
 
 $(BIN)/camera_pipe.mp4: $(BIN)/viz/process viz.sh $(HALIDE_TRACE_VIZ) ../../bin/HalideTraceViz
-	export HL_AVCONV
-	bash viz.sh $(BIN)
+	HL_AVCONV=$(HL_AVCONV) bash viz.sh $(BIN)
 
 clean:
 	rm -rf $(BIN)
@@ -46,8 +45,7 @@ viz: $(BIN)/camera_pipe.mp4
 
 $(BIN)/viz_auto.mp4: $(BIN)/viz/process ../support/viz_auto.sh ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
-	export HL_AVCONV
-	bash ../support/viz_auto.sh "$(BIN)/viz/process $(IMAGES)/bayer_small.png 3700 1.8 50 1 1 $(BIN)/out.png" ../../bin/HalideTraceViz $@
+	HL_AVCONV=$(HL_AVCONV) bash ../support/viz_auto.sh "$(BIN)/viz/process $(IMAGES)/bayer_small.png 3700 1.8 50 1 1 $(BIN)/out.png" ../../bin/HalideTraceViz $@
 
 viz_auto: $(BIN)/viz_auto.mp4
 	$(HL_VIDEOPLAYER) $^

--- a/apps/camera_pipe/viz.sh
+++ b/apps/camera_pipe/viz.sh
@@ -9,5 +9,5 @@ $1/viz/process ../images/bayer_small.png 3700 1.8 50 1 1 $1/out.png |
 --zoom 4 --func sharpen_strength_x32 \
 --rlabel curve "tone curve LUT" 0 0 10 \
 |\
-avconv -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 $1/camera_pipe.mp4
+${HL_AVCONV} -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 $1/camera_pipe.mp4
 #mplayer -demuxer rawvideo -rawvideo w=1920:h=1080:format=rgba:fps=30 -idle -fixed-vo -

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -38,8 +38,7 @@ $(BIN)/process_viz: process.cpp $(BIN)/viz/local_laplacian.a
 
 $(BIN)/local_laplacian.mp4: $(BIN)/process_viz ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
-	export HL_AVCONV
-	bash viz.sh $(BIN)
+	HL_AVCONV=$(HL_AVCONV) bash viz.sh $(BIN)
 
 clean:
 	rm -rf $(BIN)
@@ -51,8 +50,7 @@ viz: $(BIN)/local_laplacian.mp4
 
 $(BIN)/viz_auto.mp4: $(BIN)/process_viz ../support/viz_auto.sh ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
-	export HL_AVCONV
-	bash ../support/viz_auto.sh "$(BIN)/process_viz $(IMAGES)/rgb_small.png 4 1 1 0 $(BIN)/out_small.png" ../../bin/HalideTraceViz $@
+	HL_AVCONV=$(HL_AVCONV) bash ../support/viz_auto.sh "$(BIN)/process_viz $(IMAGES)/rgb_small.png 4 1 1 0 $(BIN)/out_small.png" ../../bin/HalideTraceViz $@
 
 viz_auto: $(BIN)/viz_auto.mp4
 	$(HL_VIDEOPLAYER) $^

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -38,6 +38,7 @@ $(BIN)/process_viz: process.cpp $(BIN)/viz/local_laplacian.a
 
 $(BIN)/local_laplacian.mp4: $(BIN)/process_viz ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
+	export HL_AVCONV
 	bash viz.sh $(BIN)
 
 clean:
@@ -46,11 +47,12 @@ clean:
 test: $(BIN)/out.png
 
 viz: $(BIN)/local_laplacian.mp4
-	mplayer $^
+	$(HL_VIDEOPLAYER) $^
 
 $(BIN)/viz_auto.mp4: $(BIN)/process_viz ../support/viz_auto.sh ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
+	export HL_AVCONV
 	bash ../support/viz_auto.sh "$(BIN)/process_viz $(IMAGES)/rgb_small.png 4 1 1 0 $(BIN)/out_small.png" ../../bin/HalideTraceViz $@
 
 viz_auto: $(BIN)/viz_auto.mp4
-	mplayer $^
+	$(HL_VIDEOPLAYER) $^

--- a/apps/local_laplacian/viz.sh
+++ b/apps/local_laplacian/viz.sh
@@ -6,5 +6,5 @@ make bin/process_viz && \
 ./bin/process_viz ../images/rgb_small.png 4 1 1 0 ./bin/out_small.png | \
 ../../bin/HalideTraceViz \
 --size 1920 1080 --timestep 3000 | \
-avconv -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 ./bin/local_laplacian.mp4
+${HL_AVCONV} -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 ./bin/local_laplacian.mp4
 #mplayer -demuxer rawvideo -rawvideo w=1920:h=1080:format=rgba:fps=30 -idle -fixed-vo -

--- a/apps/resize/Makefile
+++ b/apps/resize/Makefile
@@ -81,10 +81,11 @@ test: all
 
 $(BIN)/viz_auto_%.mp4: $(BIN)/resize ../support/viz_auto.sh ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
+	export HL_AVCONV
 	bash ../support/viz_auto.sh \
 		"$(BIN)/resize $(IMAGES)/rgb_small.png /tmp/$*.png -p 0 -b 1 -i $* -t float32 -f 0.5" \
 		"../../bin/HalideTraceViz --timestep 1000" \
 		$@
 
 viz_auto_%: $(BIN)/viz_auto_%.mp4
-	mplayer $^
+	$(HL_VIDEOPLAYER) $^

--- a/apps/resize/Makefile
+++ b/apps/resize/Makefile
@@ -81,8 +81,7 @@ test: all
 
 $(BIN)/viz_auto_%.mp4: $(BIN)/resize ../support/viz_auto.sh ../../bin/HalideTraceViz
 	@mkdir -p $(@D)
-	export HL_AVCONV
-	bash ../support/viz_auto.sh \
+	HL_AVCONV=$(HL_AVCONV) bash ../support/viz_auto.sh \
 		"$(BIN)/resize $(IMAGES)/rgb_small.png /tmp/$*.png -p 0 -b 1 -i $* -t float32 -f 0.5" \
 		"../../bin/HalideTraceViz --timestep 1000" \
 		$@

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -123,3 +123,10 @@ RUNARGS ?=
 #
 $(BIN)/%.run: $(BIN)/%.rungen
 	@$(CURDIR)/$< $(RUNARGS)
+
+# Utility to convert raw video -> h264. HL_AVCONV=ffmpeg will work too.
+HL_AVCONV ?= avconv
+
+# Utility to show h264 video
+HL_VIDEOPLAYER ?= mplayer
+

--- a/apps/support/viz_auto.sh
+++ b/apps/support/viz_auto.sh
@@ -14,6 +14,5 @@ mkfifo $PIPE
 
 HL_TRACE_FILE=${PIPE} HL_NUMTHREADS=8 $1 &
 
-$2 --auto_layout --size 1920 1080 --ignore_tags 0<${PIPE} | \
-avconv -y -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 "$3"
-#mplayer -demuxer rawvideo -rawvideo w=1920:h=1080:format=rgba:fps=30 -idle -fixed-vo -
+$2 --auto_layout --ignore_tags 0<${PIPE} | \
+${HL_AVCONV} -y -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 "$3"

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstring>
 #include <iostream>
 #include <list>
 #include <map>


### PR DESCRIPTION
- include <cstring> for memcpy
- std::istream doesn't always understand 'nan'
- Use env vars to allow redirecting avconv and mplayer to other similar utilities (e.g. ffmpeg/mpv)