### PR TITLE
Make prefetch works with specialize

### DIFF
--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -463,7 +463,10 @@ Stmt Realize::make(const std::string &name, const std::vector<Type> &types, Memo
     return node;
 }
 
-Stmt Prefetch::make(const std::string &name, const std::vector<Type> &types, const Region &bounds, Parameter param) {
+Stmt Prefetch::make(const std::string &name, const std::vector<Type> &types,
+                    const Region &bounds,
+                    const PrefetchDirective &prefetch,
+                    Expr condition, Stmt body) {
     for (size_t i = 0; i < bounds.size(); i++) {
         internal_assert(bounds[i].min.defined()) << "Prefetch of undefined\n";
         internal_assert(bounds[i].extent.defined()) << "Prefetch of undefined\n";
@@ -471,12 +474,17 @@ Stmt Prefetch::make(const std::string &name, const std::vector<Type> &types, con
         internal_assert(bounds[i].extent.type().is_scalar()) << "Prefetch of vector size\n";
     }
     internal_assert(!types.empty()) << "Prefetch has empty type\n";
+    internal_assert(body.defined()) << "Prefetch of undefined\n";
+    internal_assert(condition.defined()) << "Prefetch with undefined condition\n";
+    internal_assert(condition.type().is_bool()) << "Prefetch condition is not boolean\n";
 
     Prefetch *node = new Prefetch;
     node->name = name;
     node->types = types;
     node->bounds = bounds;
-    node->param = std::move(param);
+    node->prefetch = prefetch;
+    node->condition = condition;
+    node->body = body;
     return node;
 }
 
@@ -543,7 +551,7 @@ Expr Call::make(Type type, const std::string &name, const std::vector<Expr> &arg
                 Buffer<> image, Parameter param) {
     if (name == Call::prefetch && call_type == Call::Intrinsic) {
         internal_assert(args.size() % 2 == 0)
-            << "Number of args to a prefetch call should be even: {base, offset, extent0, min0, ...}\n";
+            << "Number of args to a prefetch call should be even: {base, offset, extent0, stride0, extent1, stride1, ...}\n";
     }
     for (size_t i = 0; i < args.size(); i++) {
         internal_assert(args[i].defined()) << "Call of undefined\n";

--- a/src/IR.h
+++ b/src/IR.h
@@ -735,12 +735,15 @@ struct Prefetch : public StmtNode<Prefetch> {
     std::string name;
     std::vector<Type> types;
     Region bounds;
+    PrefetchDirective prefetch;
+    Expr condition;
 
-    /** If it's a prefetch load from an image parameter, this points to that. */
-    Parameter param;
+    Stmt body;
 
     static Stmt make(const std::string &name, const std::vector<Type> &types,
-                     const Region &bounds, Parameter param = Parameter());
+                     const Region &bounds,
+                     const PrefetchDirective &prefetch,
+                     Expr condition, Stmt body);
 
     static const IRNodeType _node_type = IRNodeType::Prefetch;
 };

--- a/src/IREquality.cpp
+++ b/src/IREquality.cpp
@@ -511,14 +511,20 @@ void IRComparer::visit(const Shuffle *op) {
 }
 
 void IRComparer::visit(const Prefetch *op) {
-    const Prefetch *s = expr.as<Prefetch>();
+    const Prefetch *s = stmt.as<Prefetch>();
 
     compare_names(s->name, op->name);
+    compare_scalar(s->types.size(), op->types.size());
     compare_scalar(s->bounds.size(), op->bounds.size());
+    for (size_t i = 0; (result == Equal) && (i < s->types.size()); i++) {
+        compare_types(s->types[i], op->types[i]);
+    }
     for (size_t i = 0; (result == Equal) && (i < s->bounds.size()); i++) {
         compare_expr(s->bounds[i].min, op->bounds[i].min);
         compare_expr(s->bounds[i].extent, op->bounds[i].extent);
     }
+    compare_expr(s->condition, op->condition);
+    compare_stmt(s->body, op->body);
 }
 
 } // namespace

--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -315,16 +315,21 @@ void IRMutator::visit(const Realize *op) {
 }
 
 void IRMutator::visit(const Prefetch *op) {
+    Stmt body = mutate(op->body);
+    Expr condition = mutate(op->condition);
+
     Region new_bounds;
     bool bounds_changed;
 
     // Mutate the bounds
     std::tie(new_bounds, bounds_changed) = mutate_region(this, op->bounds);
 
-    if (!bounds_changed) {
+    if (!bounds_changed &&
+        body.same_as(op->body) &&
+        condition.same_as(op->condition)) {
         stmt = op;
     } else {
-        stmt = Prefetch::make(op->name, op->types, new_bounds, op->param);
+        stmt = Prefetch::make(op->name, op->types, new_bounds, op->prefetch, std::move(condition), std::move(body));
     }
 }
 
@@ -638,16 +643,21 @@ Stmt IRMutator2::visit(const Realize *op) {
 }
 
 Stmt IRMutator2::visit(const Prefetch *op) {
+    Stmt body = mutate(op->body);
+    Expr condition = mutate(op->condition);
+
     Region new_bounds;
     bool bounds_changed;
 
     // Mutate the bounds
     std::tie(new_bounds, bounds_changed) = mutate_region(this, op->bounds);
 
-    if (!bounds_changed) {
+    if (!bounds_changed &&
+        body.same_as(op->body) &&
+        condition.same_as(op->condition)) {
         return op;
     }
-    return Prefetch::make(op->name, op->types, new_bounds, op->param);
+    return Prefetch::make(op->name, op->types, new_bounds, op->prefetch, std::move(condition), std::move(body));
 }
 
 Stmt IRMutator2::visit(const Block *op) {

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -721,6 +721,12 @@ void IRPrinter::visit(const Realize *op) {
 
 void IRPrinter::visit(const Prefetch *op) {
     do_indent();
+    const bool has_cond = !is_one(op->condition);
+    if (has_cond) {
+        stream << "if (" << op->condition << ") {\n";
+        indent += 2;
+        do_indent();
+    }
     stream << "prefetch " << op->name << "(";
     for (size_t i = 0; i < op->bounds.size(); i++) {
         stream << "[";
@@ -731,6 +737,12 @@ void IRPrinter::visit(const Prefetch *op) {
         if (i < op->bounds.size() - 1) stream << ", ";
     }
     stream << ")\n";
+    if (has_cond) {
+        indent -= 2;
+        do_indent();
+        stream << "}\n";
+    }
+    print(op->body);
 }
 
 void IRPrinter::visit(const Block *op) {

--- a/src/IRVisitor.cpp
+++ b/src/IRVisitor.cpp
@@ -214,6 +214,8 @@ void IRVisitor::visit(const Prefetch *op) {
         op->bounds[i].min.accept(this);
         op->bounds[i].extent.accept(this);
     }
+    op->condition.accept(this);
+    op->body.accept(this);
 }
 
 void IRVisitor::visit(const Block *op) {
@@ -449,6 +451,8 @@ void IRGraphVisitor::visit(const Prefetch *op) {
         include(op->bounds[i].min);
         include(op->bounds[i].extent);
     }
+    include(op->condition);
+    include(op->body);
 }
 
 void IRGraphVisitor::visit(const Block *op) {

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -151,7 +151,6 @@ private:
             return Prefetch::make(op->name, op->types, new_bounds, op->prefetch, condition, std::move(body));
         }
 
-        // TODO(psuriana): How do you handle no bounds?
         if (!body.same_as(op->body)) {
             return Prefetch::make(op->name, op->types, op->bounds, op->prefetch, op->condition, std::move(body));
         } else {

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -63,45 +63,15 @@ public:
 class InjectPrefetch : public IRMutator2 {
 public:
     InjectPrefetch(const map<string, Function> &e, const map<string, Box> &buffers)
-        : env(e), external_buffers(buffers), current_func(nullptr), stage(-1) { }
+        : env(e), external_buffers(buffers) {}
 
 private:
     const map<string, Function> &env;
     const map<string, Box> &external_buffers;
-    const Function *current_func;
-    int stage;
     Scope<Box> buffer_bounds;
 
 private:
     using IRMutator2::visit;
-
-    const vector<PrefetchDirective> &get_prefetch_list(const string &loop_name) {
-        if (!current_func || !starts_with(loop_name, current_func->name() + ".s" + std::to_string(stage))) {
-            vector<string> v = split_string(loop_name, ".");
-            internal_assert(v.size() > 2);
-            const string &func_name = v[0];
-
-            // Get the stage index
-            stage = -1;
-            internal_assert(v[1].substr(0, 1) == "s");
-            {
-                string str = v[1].substr(1, v[1].size() - 1);
-                bool has_only_digits = (str.find_first_not_of("0123456789") == string::npos);
-                internal_assert(has_only_digits);
-                stage = atoi(str.c_str());
-            }
-            internal_assert(stage >= 0);
-
-            const auto &it = env.find(func_name);
-            internal_assert(it != env.end());
-
-            current_func = &it->second;
-            internal_assert(stage <= (int)current_func->updates().size());
-        }
-
-        const Definition &def = get_stage_definition(*current_func, stage);
-        return def.schedule().prefetches();
-    }
 
     Box get_buffer_bounds(string name, int dims) {
         if (buffer_bounds.contains(name)) {
@@ -129,39 +99,97 @@ private:
         return IRMutator2::visit(op);
     }
 
-    Stmt add_prefetch(string buf_name, const Parameter &param, const Box &box, Stmt body) {
-        // Construct the region to be prefetched.
-        Region bounds;
-        for (size_t i = 0; i < box.size(); i++) {
-            Expr extent = box[i].max - box[i].min + 1;
-            bounds.push_back(Range(box[i].min, extent));
+    Stmt visit(const Prefetch *op) override {
+        Stmt body = mutate(op->body);
+
+        const PrefetchDirective &p = op->prefetch;
+        Expr loop_var = Variable::make(Int(32), p.var);
+
+        // Add loop variable + prefetch offset to interval scope for box computation
+        Expr fetch_at = loop_var + p.offset;
+        map<string, Box> boxes_rw = boxes_touched(LetStmt::make(p.var, fetch_at, body));
+
+        // TODO(psuriana): Only prefetch the newly accessed data. We
+        // should subtract the box accessed during previous iteration
+        // from the one accessed during this iteration.
+
+        // TODO(psuriana): Add a new PrefetchBoundStrategy::ShiftInwards
+        // that shifts the base address of the prefetched box so that
+        // the box is completely within the bounds.
+        const auto &b = boxes_rw.find(p.name);
+        if (b != boxes_rw.end()) {
+            Box prefetch_box = b->second;
+            // Only prefetch the region that is in bounds.
+            Box bounds = get_buffer_bounds(b->first, b->second.size());
+            internal_assert(prefetch_box.size() == bounds.size());
+
+            if (p.strategy == PrefetchBoundStrategy::Clamp) {
+                prefetch_box = box_intersection(prefetch_box, bounds);
+            } else if (p.strategy == PrefetchBoundStrategy::GuardWithIf) {
+                Expr predicate = prefetch_box.used.defined() ? prefetch_box.used : const_true();
+                for (size_t i = 0; i < bounds.size(); ++i) {
+                    predicate = predicate && (prefetch_box[i].min >= bounds[i].min) &&
+                                (prefetch_box[i].max <= bounds[i].max);
+                }
+                prefetch_box.used = simplify(predicate);
+            } else {
+                internal_assert(p.strategy == PrefetchBoundStrategy::NonFaulting);
+                // Assume the prefetch won't fault when accessing region
+                // outside the bounds.
+            }
+
+            // Construct the region to be prefetched.
+            Region new_bounds;
+            for (size_t i = 0; i < prefetch_box.size(); i++) {
+                Expr extent = prefetch_box[i].max - prefetch_box[i].min + 1;
+                new_bounds.push_back(Range(simplify(prefetch_box[i].min), simplify(extent)));
+            }
+            Expr condition = op->condition;
+            if (prefetch_box.maybe_unused()) {
+                condition = simplify(prefetch_box.used && condition);
+            }
+            return Prefetch::make(op->name, op->types, new_bounds, op->prefetch, condition, std::move(body));
         }
 
-        Stmt prefetch;
-        if (param.defined()) {
-            prefetch = Prefetch::make(buf_name, {param.type()}, bounds, param);
+        // TODO(psuriana): How do you handle no bounds?
+        if (!body.same_as(op->body)) {
+            return Prefetch::make(op->name, op->types, op->bounds, op->prefetch, op->condition, std::move(body));
         } else {
-            const auto &it = env.find(buf_name);
-            internal_assert(it != env.end());
-            prefetch = Prefetch::make(buf_name, it->second.output_types(), bounds);
+            return op;
         }
+    }
+};
 
-        if (box.maybe_unused()) {
-            prefetch = IfThenElse::make(box.used, prefetch);
+class InjectDefEmptyPrefetch : public IRMutator2 {
+public:
+    InjectDefEmptyPrefetch(const map<string, Function> &e, const string &prefix,
+                           const vector<PrefetchDirective> &prefetches)
+        : env(e), prefix(prefix), prefetch_list(prefetches) {}
+
+private:
+    const map<string, Function> &env;
+    const string &prefix;
+    const vector<PrefetchDirective> &prefetch_list;
+
+    using IRMutator2::visit;
+
+    Stmt add_empty_prefetch(const string &loop_var, PrefetchDirective p, Stmt body) {
+        debug(5) << "...Injecting empty prefetch for " << loop_var << "\n";
+        p.var = loop_var;
+        internal_assert(body.defined());
+        if (p.param.defined()) {
+            return Prefetch::make(p.name, {p.param.type()}, Region(), p, const_true(), body);
+        } else {
+            const auto &it = env.find(p.name);
+            internal_assert(it != env.end());
+            return Prefetch::make(p.name, it->second.output_types(), Region(), p, const_true(), body);
         }
-        return Block::make({prefetch, body});
     }
 
     Stmt visit(const For *op) override {
-        const Function *old_func = current_func;
-        int old_stage = stage;
-
-        const vector<PrefetchDirective> &prefetch_list = get_prefetch_list(op->name);
-
-        Expr loop_var = Variable::make(Int(32), op->name);
         Stmt body = mutate(op->body);
 
-        if (!prefetch_list.empty()) {
+        if (!prefetch_list.empty() && starts_with(op->name, prefix)) {
             // If there are multiple prefetches of the same Func or ImageParam,
             // use the most recent one
             set<string> seen;
@@ -172,40 +200,7 @@ private:
                 }
                 seen.insert(p.name);
 
-                // Add loop variable + prefetch offset to interval scope for box computation
-                Expr fetch_at = loop_var + p.offset;
-                map<string, Box> boxes_rw = boxes_touched(LetStmt::make(op->name, fetch_at, body));
-
-                // TODO(psuriana): Only prefetch the newly accessed data. We
-                // should subtract the box accessed during previous iteration
-                // from the one accessed during this iteration.
-
-                // TODO(psuriana): Add a new PrefetchBoundStrategy::ShiftInwards
-                // that shifts the base address of the prefetched box so that
-                // the box is completely within the bounds.
-                const auto &b = boxes_rw.find(p.name);
-                if (b != boxes_rw.end()) {
-                    Box prefetch_box = b->second;
-                    // Only prefetch the region that is in bounds.
-                    Box bounds = get_buffer_bounds(b->first, b->second.size());
-                    internal_assert(prefetch_box.size() == bounds.size());
-
-                    if (p.strategy == PrefetchBoundStrategy::Clamp) {
-                        prefetch_box = box_intersection(prefetch_box, bounds);
-                    } else if (p.strategy == PrefetchBoundStrategy::GuardWithIf) {
-                        Expr predicate = prefetch_box.used.defined() ? prefetch_box.used : const_true();
-                        for (size_t i = 0; i < bounds.size(); ++i) {
-                            predicate = predicate && (prefetch_box[i].min >= bounds[i].min) &&
-                                        (prefetch_box[i].max <= bounds[i].max);
-                        }
-                        prefetch_box.used = simplify(predicate);
-                    } else {
-                        internal_assert(p.strategy == PrefetchBoundStrategy::NonFaulting);
-                        // Assume the prefetch won't fault when accessing region
-                        // outside the bounds.
-                    }
-                    body = add_prefetch(b->first, p.param, prefetch_box, body);
-                }
+                body = add_empty_prefetch(op->name, p, body);
             }
         }
 
@@ -215,9 +210,6 @@ private:
         } else {
             stmt = op;
         }
-
-        current_func = old_func;
-        stage = old_stage;
         return stmt;
     }
 };
@@ -339,6 +331,13 @@ public:
 };
 
 } // anonymous namespace
+
+Stmt inject_def_empty_prefetch(Stmt s, const map<string, Function> &env,
+                               const string &prefix,
+                               const vector<PrefetchDirective> &prefetches) {
+    Stmt stmt = InjectDefEmptyPrefetch(env, prefix, prefetches).mutate(s);
+    return stmt;
+}
 
 Stmt inject_prefetch(Stmt s, const map<string, Function> &env) {
     CollectExternalBufferBounds finder;

--- a/src/Prefetch.h
+++ b/src/Prefetch.h
@@ -16,8 +16,8 @@ namespace Halide {
 namespace Internal {
 
 Stmt inject_def_empty_prefetch(Stmt s, const std::map<std::string, Function> &env,
-                              const std::string &prefix,
-                              const std::vector<PrefetchDirective> &prefetches);
+                               const std::string &prefix,
+                               const std::vector<PrefetchDirective> &prefetches);
 Stmt inject_prefetch(Stmt s, const std::map<std::string, Function> &env);
 
 /** Reduce a multi-dimensional prefetch into a prefetch of lower dimension

--- a/src/Prefetch.h
+++ b/src/Prefetch.h
@@ -9,11 +9,15 @@
 #include <map>
 
 #include "IR.h"
+#include "Schedule.h"
 #include "Target.h"
 
 namespace Halide {
 namespace Internal {
 
+Stmt inject_def_empty_prefetch(Stmt s, const std::map<std::string, Function> &env,
+                              const std::string &prefix,
+                              const std::vector<PrefetchDirective> &prefetches);
 Stmt inject_prefetch(Stmt s, const std::map<std::string, Function> &env);
 
 /** Reduce a multi-dimensional prefetch into a prefetch of lower dimension

--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -83,25 +83,22 @@ class SplitTuples : public IRMutator2 {
     }
 
     Stmt visit(const Prefetch *op) override {
-        Stmt stmt;
-        if (!op->param.defined() && (op->types.size() > 1)) {
+        if (!op->prefetch.param.defined() && (op->types.size() > 1)) {
+            Stmt body = mutate(op->body);
             // Split the prefetch from a multi-dimensional halide tuple to
             // prefetches of each tuple element. Keep only prefetches of
             // elements that are actually used in the loop body.
             const auto &indices = func_value_indices.find(op->name);
             internal_assert(indices != func_value_indices.end());
 
-            auto it = indices->second.begin();
-            internal_assert((*it) < (int)op->types.size());
-            stmt = Prefetch::make(op->name + "." + std::to_string(*it), {op->types[(*it)]}, op->bounds);
-            for (++it; it != indices->second.end(); ++it) {
-                internal_assert((*it) < (int)op->types.size());
-                stmt = Block::make(stmt, Prefetch::make(op->name + "." + std::to_string(*it), {op->types[(*it)]}, op->bounds));
+            for (const auto &idx : indices->second) {
+                internal_assert(idx < (int)op->types.size());
+                body = Prefetch::make(op->name + "." + std::to_string(idx), {op->types[(idx)]}, op->bounds, op->prefetch, op->condition, body);
             }
+            return body;
         } else {
-            stmt = IRMutator2::visit(op);
+            return IRMutator2::visit(op);
         }
-        return stmt;
     }
 
     Expr visit(const Call *op) override {

--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -495,7 +495,15 @@ private:
             if (i < op->bounds.size() - 1) stream << ", ";
         }
         stream << matched(")");
+        if (!is_one(op->condition)) {
+            stream << " " << keyword("if") << " ";
+            print(op->condition);
+        }
         stream << close_span();
+
+        stream << open_div("PrefetchBody");
+        print(op->body);
+        stream << close_div();
     }
 
     // To avoid generating ridiculously deep DOMs, we flatten blocks here.

--- a/test/correctness/prefetch.cpp
+++ b/test/correctness/prefetch.cpp
@@ -1,0 +1,120 @@
+#include "Halide.h"
+
+#include <stdio.h>
+#include <map>
+
+namespace {
+
+using std::map;
+using std::pair;
+using std::string;
+using std::vector;
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+class CollectPrefetches : public IRVisitor {
+private:
+    using IRVisitor::visit;
+
+    void visit(const Call *op) {
+        if (op->is_intrinsic(Call::prefetch)) {
+            prefetches.push_back(op->args);
+        }
+    }
+
+public:
+    vector<vector<Expr>> prefetches;
+};
+
+int test1() {
+    Func f("f"), g("g");
+    Var x("x");
+
+    f(x) = x;
+    g(x) = f(0) + f(7);
+
+    f.compute_root();
+    g.prefetch(f, x, 8);
+
+    Module m = g.compile_to_module({});
+    CollectPrefetches collect;
+    m.functions()[0].body.accept(&collect);
+
+    vector<vector<Expr>> expected = {{Variable::make(Handle(), f.name()) , 0, 1, 8}};
+    if (collect.prefetches.size() != expected.size()) {
+        std::cout << "Expect " << expected.size() << " prefetches instead of "
+                  << collect.prefetches.size() << "\n";
+        return -1;
+    }
+    for (size_t i = 0; i < expected.size(); ++i) {
+        if (expected[i].size() != collect.prefetches[i].size()) {
+            std::cout << "Expect prefetch args of size " << expected[i].size()
+                      << ", got " << collect.prefetches[i].size() << " instead\n";
+            return -1;
+        }
+        for (size_t j = 0; j < expected[i].size(); ++j) {
+            if (!equal(expected[i][j], collect.prefetches[i][j])) {
+                std::cout << "Expect \"" << expected[i][j] << "\", got \""
+                          << collect.prefetches[i][j] << " instead\n";
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
+
+int test2() {
+    Param<bool> p;
+
+    Func f("f"), g("g");
+    Var x("x");
+
+    f(x) = x;
+    g(x) = f(0) + f(7);
+
+    f.compute_root();
+    g.specialize(p).prefetch(f, x, 8);
+
+    Module m = g.compile_to_module({p});
+    CollectPrefetches collect;
+    m.functions()[0].body.accept(&collect);
+
+    vector<vector<Expr>> expected = {{Variable::make(Handle(), f.name()) , 0, 1, 8}};
+    if (collect.prefetches.size() != expected.size()) {
+        std::cout << "Expect " << expected.size() << " prefetches instead of "
+                  << collect.prefetches.size() << "\n";
+        return -1;
+    }
+    for (size_t i = 0; i < expected.size(); ++i) {
+        if (expected[i].size() != collect.prefetches[i].size()) {
+            std::cout << "Expect prefetch args of size " << expected[i].size()
+                      << ", got " << collect.prefetches[i].size() << " instead\n";
+            return -1;
+        }
+        for (size_t j = 0; j < expected[i].size(); ++j) {
+            if (!equal(expected[i][j], collect.prefetches[i][j])) {
+                std::cout << "Expect \"" << expected[i][j] << "\", got \""
+                          << collect.prefetches[i][j] << " instead\n";
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    printf("Running prefetch test1\n");
+    if (test1() != 0) {
+        return -1;
+    }
+    printf("Running prefetch test2\n");
+    if (test2() != 0) {
+        return -1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Add a pass that injects an "empty" prefetch node during ScheduleFunctions to make prefetch works with specialization. The actual region to be prefetched is determined in later steps. 