### PR TITLE
Allow "trace_all" as synonym for trace_loads|trace_stores|trace_realizations (Issue #2914)

### DIFF
--- a/apps/auto_viz/Makefile
+++ b/apps/auto_viz/Makefile
@@ -8,7 +8,7 @@ complex_up complex_down
 LIBRARIES = $(foreach V,$(VARIANTS),$(BIN)/auto_viz_demo_$(V).a)
 OUTPUTS = $(foreach V,$(VARIANTS),$(BIN)/out_$(V).png)
 
-TRACE_TARGET=$(HL_TARGET)-trace_loads-trace_stores-trace_realizations
+TRACE_TARGET=$(HL_TARGET)-trace_all
 
 all: $(OUTPUTS)
 

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -16,7 +16,7 @@ $(BIN)/bilateral_grid_auto_schedule.a: $(BIN)/bilateral_grid.generator
 
 $(BIN)/viz/bilateral_grid.a: $(BIN)/bilateral_grid.generator
 	@mkdir -p $(@D)
-	$^ -g bilateral_grid -o $(BIN)/viz target=$(HL_TARGET)-trace_loads-trace_stores-trace_realizations
+	$^ -g bilateral_grid -o $(BIN)/viz target=$(HL_TARGET)-trace_all
 
 $(BIN)/filter: $(BIN)/bilateral_grid.a $(BIN)/bilateral_grid_auto_schedule.a filter.cpp
 	@mkdir -p $(@D)

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -18,7 +18,7 @@ $(BIN)/camera_pipe_auto_schedule.a: $(BIN)/camera_pipe.generator
 
 $(BIN)/viz/camera_pipe.a: $(BIN)/camera_pipe.generator
 	@mkdir -p $(@D)
-	$^ -g camera_pipe -o $(BIN)/viz target=$(HL_TARGET)-trace_loads-trace_stores-trace_realizations
+	$^ -g camera_pipe -o $(BIN)/viz target=$(HL_TARGET)-trace_all
 
 $(BIN)/process: process.cpp $(BIN)/camera_pipe.a $(BIN)/camera_pipe_auto_schedule.a
 	$(CXX) $(CXXFLAGS) -Wall -O3 -I$(BIN) $^ -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -27,7 +27,7 @@ $(BIN)/out.png: $(BIN)/process
 # Build rules for generating a visualization of the pipeline using HalideTraceViz
 $(BIN)/viz/local_laplacian.a: $(BIN)/local_laplacian.generator
 	@mkdir -p $(@D)
-	$^ -g local_laplacian -o $(BIN)/viz target=$(HL_TARGET)-trace_loads-trace_stores-trace_realizations pyramid_levels=6
+	$^ -g local_laplacian -o $(BIN)/viz target=$(HL_TARGET)-trace_all pyramid_levels=6
 
 $(BIN)/process_viz: process.cpp $(BIN)/viz/local_laplacian.a
 	@mkdir -p $(@D)

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -363,6 +363,9 @@ bool merge_string(Target &t, const std::string &target) {
         } else if (lookup_feature(tok, feature)) {
             t.set_feature(feature);
             features_specified = true;
+        } else if (tok == "trace_all") {
+            t.set_features({Target::TraceLoads, Target::TraceStores, Target::TraceRealizations});
+            features_specified = true;
         } else {
             return false;
         }
@@ -480,6 +483,11 @@ std::string Target::to_string() const {
         if (has_feature(feature_entry.second)) {
             result += "-" + feature_entry.first;
         }
+    }
+    // Use has_feature() multiple times (rather than features_any_of())
+    // to avoid constructing a temporary vector for this rather-common call.
+    if (has_feature(Target::TraceLoads) && has_feature(Target::TraceStores) && has_feature(Target::TraceRealizations)) {
+        result = Internal::replace_all(result, "trace_loads-trace_realizations-trace_stores", "trace_all");
     }
     return result;
 }

--- a/test/correctness/target.cpp
+++ b/test/correctness/target.cpp
@@ -189,6 +189,17 @@ int main(int argc, char **argv) {
        return -1;
     }
 
+    t1 = Target("x86-64-linux-trace_all");
+    ts = t1.to_string();
+    if (!t1.features_all_of({Target::TraceLoads, Target::TraceStores, Target::TraceRealizations})) {
+       printf("trace_all failure: %s\n", ts.c_str());
+       return -1;
+    }
+    if (ts != "x86-64-linux-trace_all") {
+       printf("trace_all to_string failure: %s\n", ts.c_str());
+       return -1;
+    }
+
     printf("Success!\n");
     return 0;
 }

--- a/tutorial/figures/generate_figures_17.sh
+++ b/tutorial/figures/generate_figures_17.sh
@@ -17,7 +17,7 @@ mkdir -p tmp
 rm lesson_17_*.mp4
 
 # Grab a trace
-HL_JIT_TARGET=host-trace_loads-trace_stores-trace_realizations \
+HL_JIT_TARGET=host-trace_all \
 HL_TRACE_FILE=$(pwd)/tmp/trace.bin \
 make -C ../.. tutorial_lesson_17_predicated_rdom
 ls tmp/trace.bin

--- a/tutorial/figures/generate_figures_18.sh
+++ b/tutorial/figures/generate_figures_18.sh
@@ -7,7 +7,7 @@ rm -rf tmp
 mkdir -p tmp
 
 # Grab a trace
-HL_JIT_TARGET=host-trace_loads-trace_stores-trace_realizations \
+HL_JIT_TARGET=host-trace_all \
 HL_TRACE_FILE=$(pwd)/tmp/trace.bin \
 make -C ../.. tutorial_lesson_18_parallel_associative_reductions
 ls tmp/trace.bin

--- a/tutorial/figures/generate_figures_19.sh
+++ b/tutorial/figures/generate_figures_19.sh
@@ -7,7 +7,7 @@ rm -rf tmp
 mkdir -p tmp
 
 # Grab a trace
-HL_JIT_TARGET=host-trace_stores-trace_loads-trace_realizations \
+HL_JIT_TARGET=host-trace_all \
 HL_TRACE_FILE=$(pwd)/tmp/trace.bin \
 make -C ../.. tutorial_lesson_19_staging_func_or_image_param
 ls tmp/trace.bin

--- a/tutorial/figures/generate_figures_5.sh
+++ b/tutorial/figures/generate_figures_5.sh
@@ -15,7 +15,7 @@ rm -rf tmp
 mkdir -p tmp
 
 # grab a trace
-HL_JIT_TARGET=host-trace_stores-trace_loads-trace_realizations HL_TRACE_FILE=$(pwd)/tmp/trace.bin make -C ../.. tutorial_lesson_05_scheduling_1
+HL_JIT_TARGET=host-trace_all HL_TRACE_FILE=$(pwd)/tmp/trace.bin make -C ../.. tutorial_lesson_05_scheduling_1
 ls tmp/trace.bin
 
 # row major

--- a/tutorial/figures/generate_figures_8.sh
+++ b/tutorial/figures/generate_figures_8.sh
@@ -15,7 +15,7 @@ rm -rf tmp
 mkdir -p tmp
 
 # grab a trace
-HL_JIT_TARGET=host-trace_stores-trace_loads-trace_realizations HL_TRACE_FILE=$(pwd)/tmp/trace.bin make -C ../.. tutorial_lesson_08_scheduling_2
+HL_JIT_TARGET=host-trace_all HL_TRACE_FILE=$(pwd)/tmp/trace.bin make -C ../.. tutorial_lesson_08_scheduling_2
 ls tmp/trace.bin
 
 cat tmp/trace.bin | ../../bin/HalideTraceViz \

--- a/tutorial/figures/generate_figures_9.sh
+++ b/tutorial/figures/generate_figures_9.sh
@@ -15,7 +15,7 @@ rm -rf tmp
 mkdir -p tmp
 
 # grab a trace
-HL_JIT_TARGET=host-trace_stores-trace_loads-trace_realizations HL_TRACE_FILE=$(pwd)/tmp/trace.bin make -C ../.. tutorial_lesson_09_update_definitions
+HL_JIT_TARGET=host-trace_all HL_TRACE_FILE=$(pwd)/tmp/trace.bin make -C ../.. tutorial_lesson_09_update_definitions
 ls tmp/trace.bin
 
 cat tmp/trace.bin | ../../bin/HalideTraceViz \

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -286,7 +286,7 @@ stdout. You should pipe the output of HalideTraceViz into a video
 encoder or player.
 
 E.g. to encode a video:
- HL_TARGET=host-trace_stores-trace_loads-trace_realizations <command to make pipeline> && \
+ HL_TARGET=host-trace_all <command to make pipeline> && \
  HL_TRACE_FILE=/dev/stdout <command to run pipeline> | \
  HalideTraceViz -s 1920 1080 -t 10000 <the -f args> | \
  avconv -f rawvideo -pix_fmt bgr32 -s 1920x1080 -i /dev/stdin -c:v h264 output.avi


### PR DESCRIPTION
It's common to set all three in tandem, so, for terseness:

- when creating Target from string, if "trace_all" is a feature, apply trace_loads|trace_stores|trace_realizations
- when creating string from Target, if trace_loads|trace_stores|trace_realizations are all set, replace with "trace_all"

(Should we be terser and just use "trace" instead of "trace_all"?)