### PR TITLE
Fix benign race in halide_upgrade_buffer_t

### DIFF
--- a/src/WrapExternStages.cpp
+++ b/src/WrapExternStages.cpp
@@ -89,8 +89,9 @@ class WrapExternStages : public IRMutator2 {
                 // Make the call to upgrade old buffer
                 // fields into the original new
                 // buffer. Important for bounds queries.
+                const int bounds_query_only = a.kind == Argument::InputBuffer ? 1 : 0;
                 Expr upgrade_call = Call::make(Int(32), "halide_upgrade_buffer_t",
-                                               {a.name, old_buffer_var, new_buffer_var},
+                                               {a.name, old_buffer_var, new_buffer_var, bounds_query_only},
                                                Call::Extern);
                 upgrades.push_back(make_checked_call(upgrade_call));
                 call_args.push_back(old_buffer_var);
@@ -214,8 +215,9 @@ void add_legacy_wrapper(Module module, const LoweredFunc &fn) {
             // Make the call to upgrade old buffer
             // fields into the original new
             // buffer. Important for bounds queries.
+            const int bounds_query_only = 0;
             Expr upgrade_call = Call::make(Int(32), "halide_upgrade_buffer_t",
-                                           {arg.name, old_buffer_var, new_buffer_var},
+                                           {arg.name, old_buffer_var, new_buffer_var, bounds_query_only},
                                            Call::Extern);
             upgrades.push_back(make_checked_call(upgrade_call));
 

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1348,12 +1348,14 @@ typedef struct buffer_t {
 #endif // BUFFER_T_DEFINED
 
 /** Copies host pointer, mins, extents, strides, and device state from
- * an old-style buffer_t into a new-style halide_buffer_t. The
- * dimensions and type fields of the new buffer_t should already be
- * set. Returns an error code if the upgrade could not be
- * performed. */
+ * an old-style buffer_t into a new-style halide_buffer_t. If bounds_query_only is nonzero,
+ * the copy is only done if the old_buf has null host and dev (ie, a bounds query is being
+ * performed); otherwise new_buf is left untouched. (This is used for input buffers to avoid
+ * benign data races.) The dimensions and type fields of the new buffer_t should already be
+ * set. Returns an error code if the upgrade could not be performed. */
 extern int halide_upgrade_buffer_t(void *user_context, const char *name,
-                                   const buffer_t *old_buf, halide_buffer_t *new_buf);
+                                   const buffer_t *old_buf, halide_buffer_t *new_buf,
+                                   int bounds_query_only);
 
 /** Copies the host pointer, mins, extents, strides, and device state
  * from a halide_buffer_t to a buffer_t. Also sets elem_size. Useful

--- a/src/runtime/old_buffer_t.cpp
+++ b/src/runtime/old_buffer_t.cpp
@@ -34,15 +34,29 @@ WEAK int guess_type_and_dimensionality(void *user_context, buffer_t *old_buf, ha
 extern "C" {
 
 WEAK int halide_upgrade_buffer_t(void *user_context, const char *name,
-                                 const buffer_t *old_buf, halide_buffer_t *new_buf) {
-    if ((old_buf->host || old_buf->dev) &&
-        (old_buf->elem_size != new_buf->type.bytes())) {
-        // Unless we're doing a bounds query, we expect the elem_size to match the type.
-        stringstream sstr(user_context);
-        sstr << "buffer has incorrect elem_size (" << old_buf->elem_size << ") "
-             << "for expected type (" << new_buf->type << ")";
-        return halide_error_failed_to_upgrade_buffer_t(user_context, name, sstr.str());
+                                 const buffer_t *old_buf, halide_buffer_t *new_buf,
+                                 int bounds_query_only) {
+    if (old_buf->host || old_buf->dev) {
+        if (old_buf->elem_size != new_buf->type.bytes()) {
+            // If we're not doing a bounds query, we expect the elem_size to match the type.
+            stringstream sstr(user_context);
+            sstr << "buffer has incorrect elem_size (" << old_buf->elem_size << ") "
+                 << "for expected type (" << new_buf->type << ")";
+            return halide_error_failed_to_upgrade_buffer_t(user_context, name, sstr.str());
+        }
+        if (bounds_query_only) {
+            // Don't update.
+            if (new_buf->host != old_buf->host) {
+                // This should never happen, but if it does, we have a logic error in
+                // wrapper generation: since we already have the upgrade overhead, let's
+                // check and fail loudly rather than just have something weird happen.
+                return halide_error_failed_to_upgrade_buffer_t(user_context, name,
+                    "Internal error: buffer host mismatch in halide_upgrade_buffer_t.");
+            }
+            return 0;
+        }
     }
+
     new_buf->host = old_buf->host;
     if (old_buf->dev) {
         old_dev_wrapper *wrapper = (old_dev_wrapper *)(old_buf->dev);
@@ -107,7 +121,7 @@ WEAK int halide_copy_to_host_legacy(void *user_context, struct buffer_t *old_buf
     halide_dimension_t shape[4];
     new_buf.dim = shape;
     int err = guess_type_and_dimensionality(user_context, old_buf, &new_buf);
-    err = err || halide_upgrade_buffer_t(user_context, "", old_buf, &new_buf);
+    err = err || halide_upgrade_buffer_t(user_context, "", old_buf, &new_buf, /*bounds_query_only*/ 0);
     err = err || halide_copy_to_host(user_context, &new_buf);
     err = err || halide_downgrade_buffer_t_device_fields(user_context, "", &new_buf, old_buf);
     return err;
@@ -119,7 +133,7 @@ WEAK int halide_copy_to_device_legacy(void *user_context, struct buffer_t *old_b
     halide_dimension_t shape[4];
     new_buf.dim = shape;
     int err = guess_type_and_dimensionality(user_context, old_buf, &new_buf);
-    err = err || halide_upgrade_buffer_t(user_context, "", old_buf, &new_buf);
+    err = err || halide_upgrade_buffer_t(user_context, "", old_buf, &new_buf, /*bounds_query_only*/ 0);
     err = err || halide_copy_to_device(user_context, &new_buf, device_interface);
     err = err || halide_downgrade_buffer_t_device_fields(user_context, "", &new_buf, old_buf);
     return err;
@@ -130,7 +144,7 @@ WEAK int halide_device_sync_legacy(void *user_context, struct buffer_t *old_buf)
     halide_dimension_t shape[4];
     new_buf.dim = shape;
     int err = guess_type_and_dimensionality(user_context, old_buf, &new_buf);
-    err = err || halide_upgrade_buffer_t(user_context, "", old_buf, &new_buf);
+    err = err || halide_upgrade_buffer_t(user_context, "", old_buf, &new_buf, /*bounds_query_only*/ 0);
     err = err || halide_device_sync(user_context, &new_buf);
     err = err || halide_downgrade_buffer_t_device_fields(user_context, "", &new_buf, old_buf);
     return err;
@@ -142,7 +156,7 @@ WEAK int halide_device_malloc_legacy(void *user_context, struct buffer_t *old_bu
     halide_dimension_t shape[4];
     new_buf.dim = shape;
     int err = guess_type_and_dimensionality(user_context, old_buf, &new_buf);
-    err = err || halide_upgrade_buffer_t(user_context, "", old_buf, &new_buf);
+    err = err || halide_upgrade_buffer_t(user_context, "", old_buf, &new_buf, /*bounds_query_only*/ 0);
     err = err || halide_device_malloc(user_context, &new_buf, device_interface);
     err = err || halide_downgrade_buffer_t_device_fields(user_context, "", &new_buf, old_buf);
     return err;
@@ -153,7 +167,7 @@ WEAK int halide_device_free_legacy(void *user_context, struct buffer_t *old_buf)
     halide_dimension_t shape[4];
     new_buf.dim = shape;
     int err = guess_type_and_dimensionality(user_context, old_buf, &new_buf);
-    err = err || halide_upgrade_buffer_t(user_context, "", old_buf, &new_buf);
+    err = err || halide_upgrade_buffer_t(user_context, "", old_buf, &new_buf, /*bounds_query_only*/ 0);
     err = err || halide_device_free(user_context, &new_buf);
     err = err || halide_downgrade_buffer_t_device_fields(user_context, "", &new_buf, old_buf);
     return err;


### PR DESCRIPTION
If you have a define_extern that uses the legacy_buffer_t wrappers, and that extern is inside a parallel loop, there is a benign race condition: the input buffer(s) are always 'upgraded' at the end (in case the call is a bounds query). This causes a benign data race in the non-bounds-query case since another thread can be reading from the input buffer at the same time. The fix: when generating the wrapper for define_extern, only upgrade input buffers if it is known to be a bounds query.