### PR TITLE
Relax the condition for eliminating host allocation in inject_host_dev_buffer_copies.

### DIFF
--- a/src/InjectHostDevBufferCopies.cpp
+++ b/src/InjectHostDevBufferCopies.cpp
@@ -569,7 +569,7 @@ class InjectBufferCopies : public IRMutator2 {
             Expr condition = op->condition;
             if (finder.devices_touched.size() == 1 &&
                 !touched_on_host) {
-                // Only touched on one device, and never passed to an extern stage.
+                // Only touched on one device.
                 condition = const_false();
                 // There's no host allocation, so substitute any
                 // references to it (e.g. the one in the make_buffer

--- a/src/InjectHostDevBufferCopies.cpp
+++ b/src/InjectHostDevBufferCopies.cpp
@@ -568,8 +568,7 @@ class InjectBufferCopies : public IRMutator2 {
 
             Expr condition = op->condition;
             if (finder.devices_touched.size() == 1 &&
-                !touched_on_host &&
-                !finder.touched_by_extern) {
+                !touched_on_host) {
                 // Only touched on one device, and never passed to an extern stage.
                 condition = const_false();
                 // There's no host allocation, so substitute any

--- a/test/correctness/extern_producer.cpp
+++ b/test/correctness/extern_producer.cpp
@@ -64,27 +64,6 @@ extern "C" DLLEXPORT int make_data(halide_buffer_t *out) {
     return 0;
 }
 
-extern "C" DLLEXPORT int make_data_on_device(halide_buffer_t *out) {
-    if (!out->is_bounds_query()) {
-        assert(out->host);
-        assert(out->type == halide_type_of<float>());
-        assert(out->dimensions == 2);
-        printf("Generating data over [%d %d] x [%d %d]\n",
-               out->dim[0].min, out->dim[0].min + out->dim[0].extent,
-               out->dim[1].min, out->dim[1].min + out->dim[1].extent);
-        for (int y = 0; y < out->dim[1].extent; y++) {
-          float *dst = (float *)out->host + y * out->dim[1].stride;
-          for (int x = 0; x < out->dim[0].extent; x++) {
-            int x_coord = x + out->dim[0].min;
-            int y_coord = y + out->dim[1].min;
-            dst[x] = x_coord + y_coord;
-          }
-        }
-        return 0;
-    }
-    return 0;
-}
-
 // Imagine that this loads from a file, or tiled storage. Here we'll just fill in the data using sinf.
 extern "C" DLLEXPORT int make_data_multi(halide_buffer_t *out1, halide_buffer_t *out2) {
     if (!out1->host || !out2->host) {
@@ -117,7 +96,6 @@ extern "C" DLLEXPORT int make_data_multi(halide_buffer_t *out1, halide_buffer_t 
 int main(int argc, char **argv) {
     Var x, y;
     Var xi, yi;
-#if 0
     {
         Func source;
         source.define_extern("make_data",
@@ -168,31 +146,6 @@ int main(int argc, char **argv) {
         float error_multi = evaluate<float>(sum(abs(output_multi(r.x, r.y))));
         if (error_multi != 0) {
             printf("Something went wrong in multi case\n");
-            return -1;
-        }
-    }
-#endif
-    {
-        Func source("source");
-        source.define_extern("make_data_on_device",
-                             std::vector<ExternFuncArgument>(),
-                             Float(32), {x, y});
-        Func sink("sink");
-        sink(x, y) = source(x, y) - (x + y);
-
-        sink.gpu_tile(x, y, xi, yi, 32, 32);
-
-        // Compute the source per tile of sink
-        source.compute_root();
-
-        Buffer<float> output = sink.realize(100, 100);
-
-        // Should be all zeroes.
-        RDom r(output);
-        float error = evaluate_may_gpu<float>(sum(abs(output(r.x, r.y))));
-        if (error != 0) {
-            printf("error=%f\n", error);
-            printf("Something went wrong\n");
             return -1;
         }
     }

--- a/test/correctness/extern_stage_on_device.cpp
+++ b/test/correctness/extern_stage_on_device.cpp
@@ -1,0 +1,91 @@
+#include "Halide.h"
+#include "HalideRuntime.h"
+#include "HalideRuntimeCuda.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+// An extern stage implemented by a Halide pipeline running
+// either on host or device. The outer Halide filter muster
+// to override "device_api" parameter of Func::define_extern
+// when using the extern_stage on device.
+extern "C" DLLEXPORT int extern_stage(int extern_on_device,
+                                      int outer_filter_on_device,
+                                      halide_buffer_t *out) {
+    if (!out->is_bounds_query()) {
+        if (extern_on_device > 0 && outer_filter_on_device > 0) {
+          // If both the extern and the outer filter are on running on
+          // device, the host allocation can be null and the device
+          // allocation need to be allocated by the outer filter.
+          assert(out->host == nullptr);
+          assert(out->device != 0);
+        } else {
+          assert(out->host);
+        }
+        assert(out->type == halide_type_of<int32_t>());
+        assert(out->dimensions == 2);
+        printf("Generating data over [%d %d] x [%d %d]\n",
+               out->dim[0].min, out->dim[0].min + out->dim[0].extent,
+               out->dim[1].min, out->dim[1].min + out->dim[1].extent);
+        Var x, y;
+        Var xi, yi;
+        Func f("f");
+        f(x, y) = x + y;
+
+        if (extern_on_device > 0) {
+            f.gpu_tile(x, y, xi, yi, 32, 32);
+        }
+        f.realize(out);
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    Var x, y;
+    Var xi, yi;
+
+    for (int extern_on_device = 0; extern_on_device <= 1; ++extern_on_device)
+        for (int sink_on_device = 0; sink_on_device <= 1; ++sink_on_device) {
+        Func source("source");
+        std::vector<ExternFuncArgument> args;
+        args.push_back(extern_on_device);
+        args.push_back(sink_on_device);
+        source.define_extern("extern_stage",
+                             args,
+                             Int(32),
+                             {x, y},
+                             NameMangling::Default,
+                             extern_on_device ? Halide::DeviceAPI::CUDA : Halide::DeviceAPI::Host);
+
+        Func sink("sink");
+        sink(x, y) = source(x, y) - (x + y);
+
+        source.compute_root();
+        sink.compute_root();
+        if (sink_on_device > 0) {
+            sink.gpu_tile(x, y, xi, yi, 32, 32);
+        }
+
+        Buffer<int32_t> output = sink.realize(100, 100);
+
+        // Should be all zeroes.
+        RDom r(output);
+        uint32_t error = evaluate_may_gpu<uint32_t>(sum(abs(output(r.x, r.y))));
+        if (error != 0) {
+            printf("Something went wrong when "
+                   "extern_on_device=%d, sink_on_device=%d \n",
+                   extern_on_device, sink_on_device);
+            return -1;
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+
+}

--- a/test/correctness/extern_stage_on_device.cpp
+++ b/test/correctness/extern_stage_on_device.cpp
@@ -12,8 +12,8 @@ using namespace Halide;
 #endif
 
 // An extern stage implemented by a Halide pipeline running
-// either on host or device. The outer Halide filter muster
-// to override "device_api" parameter of Func::define_extern
+// either on host or device. The outer Halide filter must
+// override the "device_api" parameter of Func::define_extern
 // when using the extern_stage on device.
 extern "C" DLLEXPORT int extern_stage(int extern_on_device,
                                       int outer_filter_on_device,
@@ -21,8 +21,8 @@ extern "C" DLLEXPORT int extern_stage(int extern_on_device,
     if (!out->is_bounds_query()) {
         if (extern_on_device > 0 && outer_filter_on_device > 0) {
             // If both the extern and the outer filter are on running on
-            // device, the host allocation can be null and the device
-            // allocation need to be allocated by the outer filter.
+            // device, the host allocation shall be null and the device
+            // allocation must exist before entering the extern stage.
             assert(out->host == nullptr);
             assert(out->device != 0);
         } else {

--- a/test/correctness/extern_stage_on_device.cpp
+++ b/test/correctness/extern_stage_on_device.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
     Var xi, yi;
 
     for (int extern_on_device : {0, 1} ) {
-        zfor (int sink_on_device : {0, 1} ) {
+        for (int sink_on_device : {0, 1} ) {
             Func source("source");
             std::vector<ExternFuncArgument> args;
             args.push_back(extern_on_device);


### PR DESCRIPTION
The `!finder.touched_by_extern` clause seem unnecessary now because `finder.devices_touched` already tracks DeviceAPI of the extern definition. This clause now prevents the host allocation elimination if a buffer is only touched an extern definition and a normal definition with the same DeviceAPI.