### PR TITLE
adjust for API changes in LLVM

### DIFF
--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -378,7 +378,11 @@ void emit_file(const llvm::Module &module_in, Internal::LLVMOStream& out, llvm::
     target_machine->Options.MCOptions.AsmVerbose = true;
 
     // Ask the target to add backend passes as necessary.
+#if LLVM_VERSION < 70
     target_machine->addPassesToEmitFile(pass_manager, out, file_type);
+#else
+    target_machine->addPassesToEmitFile(pass_manager, out, nullptr, file_type);
+#endif
 
     pass_manager.run(*module);
 }


### PR DESCRIPTION
addPassesToEmitFile has an extra parameter now for DWO output.  Adjust the call
accordingly.