### PR TITLE
Better pattern matching of truncating multiplies on Hexagon

### DIFF
--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -171,6 +171,77 @@ Expr wild_i16x = Variable::make(Type(Type::Int, 16, 0), "*");
 Expr wild_i32x = Variable::make(Type(Type::Int, 32, 0), "*");
 Expr wild_i64x = Variable::make(Type(Type::Int, 64, 0), "*");
 
+// Check if a pattern with flags 'flags' is supported on the target.
+bool check_pattern_target(int flags, const Target &target) {
+    if ((flags & (Pattern::v62orLater)) &&
+        !target.features_any_of({Target::HVX_v62, Target::HVX_v65, Target::HVX_v66})) {
+        return false;
+    }
+    if ((flags & (Pattern::v65orLater)) &&
+        !target.features_any_of({Target::HVX_v65, Target::HVX_v66})) {
+        return false;
+    }
+    if ((flags & (Pattern::v66orLater)) &&
+        !target.features_any_of({Target::HVX_v66})) {
+        return false;
+    }
+    return true;
+}
+
+bool process_match_flags(vector<Expr> &matches, int flags) {
+    // The Pattern::Narrow*Op* flags are ordered such that the operand
+    // corresponds to the bit (with operand 0 corresponding to the least
+    // significant bit), so we can check for them all in a loop.
+    for (size_t i = 0; i < matches.size(); i++) {
+        Type t = matches[i].type();
+        Type target_t = t.with_bits(t.bits()/2);
+        if (flags & (Pattern::NarrowOp0 << i)) {
+            matches[i] = lossless_cast(target_t, matches[i]);
+        } else if (flags & (Pattern::NarrowUnsignedOp0 << i)) {
+            matches[i] = lossless_cast(target_t.with_code(Type::UInt), matches[i]);
+        }
+        if (!matches[i].defined()) return false;
+    }
+
+    for (size_t i = Pattern::BeginExactLog2Op; i < Pattern::EndExactLog2Op; i++) {
+        // This flag is mainly to capture shifts. When the operand of a div or
+        // mul is a power of 2, we can use a shift instead.
+        if (flags & (Pattern::ExactLog2Op1 << (i - Pattern::BeginExactLog2Op))) {
+            int pow;
+            if (is_const_power_of_two_integer(matches[i], &pow)) {
+                matches[i] = cast(matches[i].type().with_lanes(1), pow);
+            } else {
+                return false;
+            }
+        }
+    }
+
+    for (size_t i = Pattern::BeginDeinterleaveOp; i < Pattern::EndDeinterleaveOp; i++) {
+        if (flags & (Pattern::DeinterleaveOp0 << (i - Pattern::BeginDeinterleaveOp))) {
+            internal_assert(matches[i].type().is_vector());
+            matches[i] = native_deinterleave(matches[i]);
+        }
+    }
+    if (flags & Pattern::SwapOps01) {
+        internal_assert(matches.size() >= 2);
+        std::swap(matches[0], matches[1]);
+    }
+    if (flags & Pattern::SwapOps12) {
+        internal_assert(matches.size() >= 3);
+        std::swap(matches[1], matches[2]);
+    }
+    return true;
+}
+
+Expr replace_pattern(Expr x, const vector<Expr> &matches, const Pattern &p) {
+    x = Call::make(x.type(), p.intrin, matches, Call::PureExtern);
+    if (p.flags & Pattern::InterleaveResult) {
+        // The pattern wants us to interleave the result.
+        x = native_interleave(x);
+    }
+    return x;
+}
+
 // Attempt to apply one of the patterns to x. If a match is
 // successful, the expression is replaced with a call using the
 // matched operands. Prior to substitution, the matches are mutated
@@ -179,16 +250,9 @@ Expr apply_patterns(Expr x, const vector<Pattern> &patterns, const Target &targe
     debug(3) << "apply_patterns " << x << "\n";
     vector<Expr> matches;
     for (const Pattern &p : patterns) {
-
-        if ((p.flags & (Pattern::v62orLater)) &&
-            !target.features_any_of({Target::HVX_v62, Target::HVX_v65, Target::HVX_v66}))
+        if (!check_pattern_target(p.flags, target)) {
             continue;
-        if ((p.flags & (Pattern::v65orLater)) &&
-            !target.features_any_of({Target::HVX_v65, Target::HVX_v66}))
-            continue;
-        if ((p.flags & (Pattern::v66orLater)) &&
-            !target.features_any_of({Target::HVX_v66}))
-            continue;
+        }
 
         if (expr_match(p.pattern, x, matches)) {
             debug(3) << "matched " << p.pattern << "\n";
@@ -197,62 +261,16 @@ Expr apply_patterns(Expr x, const vector<Pattern> &patterns, const Target &targe
                 debug(3) << i << "\n";
             }
 
-            // The Pattern::Narrow*Op* flags are ordered such that
-            // the operand corresponds to the bit (with operand 0
-            // corresponding to the least significant bit), so we
-            // can check for them all in a loop.
-            bool is_match = true;
-            for (size_t i = 0; i < matches.size() && is_match; i++) {
-                Type t = matches[i].type();
-                Type target_t = t.with_bits(t.bits()/2);
-                if (p.flags & (Pattern::NarrowOp0 << i)) {
-                    matches[i] = lossless_cast(target_t, matches[i]);
-                } else if (p.flags & (Pattern::NarrowUnsignedOp0 << i)) {
-                    matches[i] = lossless_cast(target_t.with_code(Type::UInt), matches[i]);
-                }
-                if (!matches[i].defined()) is_match = false;
+            if (!process_match_flags(matches, p.flags)) {
+                continue;
             }
-            if (!is_match) continue;
 
-            for (size_t i = Pattern::BeginExactLog2Op; i < Pattern::EndExactLog2Op && is_match; i++) {
-                // This flag is mainly to capture shifts. When the
-                // operand of a div or mul is a power of 2, we can use
-                // a shift instead.
-                if (p.flags & (Pattern::ExactLog2Op1 << (i - Pattern::BeginExactLog2Op))) {
-                    int pow;
-                    if (is_const_power_of_two_integer(matches[i], &pow)) {
-                        matches[i] = cast(matches[i].type().with_lanes(1), pow);
-                    } else {
-                        is_match = false;
-                    }
-                }
-            }
-            if (!is_match) continue;
-
-            for (size_t i = Pattern::BeginDeinterleaveOp; i < Pattern::EndDeinterleaveOp; i++) {
-                if (p.flags &
-                    (Pattern::DeinterleaveOp0 << (i - Pattern::BeginDeinterleaveOp))) {
-                    internal_assert(matches[i].type().is_vector());
-                    matches[i] = native_deinterleave(matches[i]);
-                }
-            }
-            if (p.flags & Pattern::SwapOps01) {
-                internal_assert(matches.size() >= 2);
-                std::swap(matches[0], matches[1]);
-            }
-            if (p.flags & Pattern::SwapOps12) {
-                internal_assert(matches.size() >= 3);
-                std::swap(matches[1], matches[2]);
-            }
             // Mutate the operands with the given mutator.
             for (Expr &op : matches) {
                 op = op_mutator->mutate(op);
             }
-            x = Call::make(x.type(), p.intrin, matches, Call::PureExtern);
-            if (p.flags & Pattern::InterleaveResult) {
-                // The pattern wants us to interleave the result.
-                x = native_interleave(x);
-            }
+
+            x = replace_pattern(x, matches, p);
             debug(3) << "rewrote to: " << x << "\n";
             return x;
         }
@@ -724,6 +742,23 @@ private:
     }
 
     Expr visit(const Cast *op) override {
+        static const vector<Pattern> trunc_mpy = {
+            // Multiply keep high half
+            { "halide.hexagon.trunc_mpy.vw.vw", i32((wild_i64x*wild_i64x)/wild_i64), Pattern::NarrowOps },
+
+            // Scalar multiply keep high half, with multiplication by 2.
+            { "halide.hexagon.trunc_satw_mpy2.vh.h", i16_sat((wild_i32x*bc(wild_i32))/wild_i32), Pattern::NarrowOps },
+            { "halide.hexagon.trunc_satw_mpy2.vh.h", i16_sat((bc(wild_i32)*wild_i32x)/wild_i32), Pattern::NarrowOps | Pattern::SwapOps01 },
+
+            // Scalar and vector multiply keep high half, with multiplication by 2, and rounding.
+            { "halide.hexagon.trunc_satw_mpy2_rnd.vh.h", i16_sat((wild_i32x*bc(wild_i32) + wild_i32)/wild_i32), Pattern::NarrowOps },
+            { "halide.hexagon.trunc_satw_mpy2_rnd.vh.h", i16_sat((bc(wild_i32)*wild_i32x + wild_i32)/wild_i32), Pattern::NarrowOps | Pattern::SwapOps01 },
+            { "halide.hexagon.trunc_satw_mpy2_rnd.vh.vh", i16_sat((wild_i32x*wild_i32x + wild_i32)/wild_i32), Pattern::NarrowOps },
+            { "halide.hexagon.trunc_satdw_mpy2_rnd.vw.vw", i32_sat((wild_i64x*wild_i64x + wild_i64)/wild_i64), Pattern::NarrowOps },
+
+            // Vector multiply keep high half, with multiplicatoin by 2.
+            { "halide.hexagon.trunc_satdw_mpy2.vw.vw", i32_sat((wild_i64x*wild_i64x)/wild_i64), Pattern::NarrowOps },
+        };
 
         static const vector<Pattern> casts = {
             // Averaging
@@ -759,20 +794,6 @@ private:
             { "halide.hexagon.trunc_satb_rnd.vh",  i8_sat((wild_i32x + 128)/256), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
             { "halide.hexagon.trunc_satuh_rnd.vw", u16_sat((wild_i64x + 32768)/65536), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
             { "halide.hexagon.trunc_sath_rnd.vw",  i16_sat((wild_i64x + 32768)/65536), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
-
-            // Multiply keep high half
-            { "halide.hexagon.trunc_mpy.vw.vw", i32((wild_i64x*wild_i64x)/Expr(static_cast<int64_t>(1) << 32)), Pattern::NarrowOps },
-
-            // Scalar multiply keep high half, with multiplication by 2.
-            { "halide.hexagon.trunc_satw_mpy2.vh.h", i16_sat((wild_i32x*bc(wild_i32))/32768), Pattern::NarrowOps },
-            { "halide.hexagon.trunc_satw_mpy2.vh.h", i16_sat((bc(wild_i32)*wild_i32x)/32768), Pattern::NarrowOps | Pattern::SwapOps01 },
-            { "halide.hexagon.trunc_satw_mpy2_rnd.vh.h", i16_sat((wild_i32x*bc(wild_i32) + 16384)/32768), Pattern::NarrowOps },
-            { "halide.hexagon.trunc_satw_mpy2_rnd.vh.h", i16_sat((bc(wild_i32)*wild_i32x + 16384)/32768), Pattern::NarrowOps | Pattern::SwapOps01 },
-
-            // Vector multiply keep high half, with multiplication by 2.
-            { "halide.hexagon.trunc_satw_mpy2_rnd.vh.vh", i16_sat((wild_i32x*wild_i32x + 16384)/32768), Pattern::NarrowOps },
-            { "halide.hexagon.trunc_satdw_mpy2.vw.vw", i32_sat((wild_i64x*wild_i64x)/Expr(static_cast<int64_t>(1) << 31)), Pattern::NarrowOps },
-            { "halide.hexagon.trunc_satdw_mpy2_rnd.vw.vw", i32_sat((wild_i64x*wild_i64x + (1 << 30))/Expr(static_cast<int64_t>(1) << 31)), Pattern::NarrowOps },
 
             // Saturating narrowing casts
             { "halide.hexagon.trunc_satub_shr.vh.h", u8_sat(wild_i16x >> wild_i16), Pattern::DeinterleaveOp0 },
@@ -859,6 +880,64 @@ private:
 
         if (op->type.is_vector()) {
             Expr cast = op;
+            vector<Expr> matches;
+            for (const Pattern &p : trunc_mpy) {
+                if (!check_pattern_target(p.flags, target)) {
+                    continue;
+                }
+
+                if (expr_match(p.pattern, cast, matches)) {
+                    int log2_denominator = 0;
+                    if (matches.size() == 4) {
+                        // Rounding patterns have 4 operands, with the rounding
+                        // in the 3rd operand and the denominator in the 4th.
+                        if (!is_const_power_of_two_integer(matches[3], &log2_denominator)) {
+                            continue;
+                        }
+                        if (!can_prove(matches[2] * 2 == i64(1) << log2_denominator)) {
+                            continue;
+                        }
+                    } else {
+                        // The non-rounding patterns have the denominator in the 3rd operand.
+                        if (!is_const_power_of_two_integer(matches[2], &log2_denominator)) {
+                            continue;
+                        }
+                    }
+                    // Drop the divisor and the rounding.
+                    matches.resize(2);
+
+                    // If the power of 2 is not exactly 2^(bits of the result
+                    // type), we need to scale up the operand accordingly.
+                    int shift = cast.type().bits() - log2_denominator;
+                    if (p.intrin.find("mpy2") != std::string::npos) {
+                        // Account for a built-in factor of 2.
+                        shift -= 1;
+                    }
+
+                    // We need to build the scale into one of the operands,
+                    // which must be a constant.
+                    if (is_const(matches[0])) {
+                        matches[0] = simplify(matches[0] * (1 << shift));
+                    } else {
+                        // Just assume this is a constant. If it is, this will
+                        // work correctly. If not, we will probably fail to
+                        // satisfy the match flags, but it also might work...
+                        matches[1] = simplify(matches[1] * (1 << shift));
+                    }
+
+                    if (!process_match_flags(matches, p.flags)) {
+                        continue;
+                    }
+
+                    // Mutate the operands with the given mutator.
+                    for (Expr &op : matches) {
+                        op = mutate(op);
+                    }
+
+                    cast = replace_pattern(cast, matches, p);
+                    return cast;
+                }
+            }
 
             Expr new_expr = apply_patterns(cast, casts, target, this);
             if (!new_expr.same_as(cast)) {
@@ -867,7 +946,6 @@ private:
 
             // If we didn't find a pattern, try using one of the
             // rewrites above.
-            vector<Expr> matches;
             for (auto i : cast_rewrites) {
                 if (expr_match(i.first, cast, matches)) {
                     debug(3) << "rewriting cast to: " << i.first << " from " << cast << "\n";

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -930,8 +930,10 @@ private:
                         matches[0] = simplify(matches[0] * (1 << shift));
                     } else {
                         // Just assume this is a constant. If it is, this will
-                        // work correctly. If not, we will probably fail to
-                        // satisfy the match flags, but it also might work...
+                        // work correctly (will simplify only if it doesn't
+                        // overflow the narrower type). If not, we will probably
+                        // fail to satisfy the match flags, but it also might
+                        // work...
                         matches[1] = simplify(matches[1] * (1 << shift));
                     }
 

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -4849,6 +4849,9 @@ private:
             if (propagate_indeterminate_expression(a, b, op->type, &expr)) {
                 return expr;
             }
+            if (is_zero(b)) {
+                return a;
+            }
 
             int64_t ib = 0;
             if (const_int(b, &ib) || const_uint(b, (uint64_t *)(&ib))) {

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1851,15 +1851,29 @@ struct Test {
         check("v*.w += vmpy(v*.h,r*.h)", hvx_width/1, i32_1 + i32(i16_1)*32767);
         check("v*.w += vmpy(v*.h,r*.h)", hvx_width/1, i32_1 + 32767*i32(i16_1));
 
-        check("vmpy(v*.h,v*.h):<<1:rnd:sat", hvx_width/2, i16_sat((i32(i16_1)*i32(i16_2) + 16384)/32768));
-        check("vmpy(v*.h,r*.h):<<1:sat", hvx_width/2, i16_sat((i32(i16_1)*32767)/32768));
-        check("vmpy(v*.h,r*.h):<<1:sat", hvx_width/2, i16_sat((32767*i32(i16_1))/32768));
-        check("vmpy(v*.h,r*.h):<<1:rnd:sat", hvx_width/2, i16_sat((i32(i16_1)*32767 + 16384)/32768));
-        check("vmpy(v*.h,r*.h):<<1:rnd:sat", hvx_width/2, i16_sat((32767*i32(i16_1) + 16384)/32768));
+        for (int factor : {1, 2}) {
+            check("vmpy(v*.h,v*.h):<<1:rnd:sat", hvx_width/2, i16_sat((i32(i16_1)*i32(i16_2 * factor) + 16384)/32768));
 
-        check("vmpyo(v*.w,v*.h)", hvx_width/4, i32((i64(i32_1)*i64(i32_2))/(i64(1) << 32)));
-        check("vmpyo(v*.w,v*.h):<<1:sat", hvx_width/4, i32_sat((i64(i32_1)*i64(i32_2))/(i64(1) << 31)));
-        check("vmpyo(v*.w,v*.h):<<1:rnd:sat", hvx_width/4, i32_sat((i64(i32_1)*i64(i32_2) + (1 << 30))/(i64(1) << 31)));
+            check("vmpyo(v*.w,v*.h)", hvx_width/4, i32((i64(i32_1)*i64(i32_2))/(i64(1) << 32)));
+            check("vmpyo(v*.w,v*.h):<<1:sat", hvx_width/4, i32_sat((i64(i32_1)*i64(i32_2))/(i64(1) << 31)));
+            check("vmpyo(v*.w,v*.h):<<1:rnd:sat", hvx_width/4, i32_sat((i64(i32_1)*i64(i32_2) + (1 << 30))/(i64(1) << 31)));
+        }
+
+        for (int scalar : {32766, 32767}) {
+            check("vmpy(v*.h,r*.h):<<1:sat", hvx_width/2, i16_sat((i32(i16_1)*scalar)/32768));
+            check("vmpy(v*.h,r*.h):<<1:sat", hvx_width/2, i16_sat((scalar*i32(i16_1))/32768));
+            check("vmpy(v*.h,r*.h):<<1:rnd:sat", hvx_width/2, i16_sat((i32(i16_1)*scalar + 16384)/32768));
+            check("vmpy(v*.h,r*.h):<<1:rnd:sat", hvx_width/2, i16_sat((scalar*i32(i16_1) + 16384)/32768));
+        }
+
+        for (int scalar : {std::numeric_limits<int>::max() - 1, std::numeric_limits<int>::max()}) {
+            check("vmpyo(v*.w,v*.h)", hvx_width/4, i32((i64(i32_1)*scalar)/(i64(1) << 32)));
+            check("vmpyo(v*.w,v*.h)", hvx_width/4, i32((scalar*i64(i32_2))/(i64(1) << 32)));
+            check("vmpyo(v*.w,v*.h):<<1:sat", hvx_width/4, i32_sat((i64(i32_1)*scalar)/(i64(1) << 31)));
+            check("vmpyo(v*.w,v*.h):<<1:sat", hvx_width/4, i32_sat((scalar*i64(i32_2))/(i64(1) << 31)));
+            check("vmpyo(v*.w,v*.h):<<1:rnd:sat", hvx_width/4, i32_sat((i64(i32_1)*scalar + (1 << 30))/(i64(1) << 31)));
+            check("vmpyo(v*.w,v*.h):<<1:rnd:sat", hvx_width/4, i32_sat((scalar*i64(i32_2) + (1 << 30))/(i64(1) << 31)));
+        }
 
         check("vmpa(v*.ub,r*.b)", hvx_width/1, i16(u8_1)*127 + i16(u8_2)*-128);
         check("vmpa(v*.ub,r*.b)", hvx_width/1, i16(u8_1)*127 + 126*i16(u8_2));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1854,9 +1854,9 @@ struct Test {
         for (int factor : {1, 2}) {
             check("vmpy(v*.h,v*.h):<<1:rnd:sat", hvx_width/2, i16_sat((i32(i16_1)*i32(i16_2 * factor) + 16384)/32768));
 
-            check("vmpyo(v*.w,v*.h)", hvx_width/4, i32((i64(i32_1)*i64(i32_2))/(i64(1) << 32)));
-            check("vmpyo(v*.w,v*.h):<<1:sat", hvx_width/4, i32_sat((i64(i32_1)*i64(i32_2))/(i64(1) << 31)));
-            check("vmpyo(v*.w,v*.h):<<1:rnd:sat", hvx_width/4, i32_sat((i64(i32_1)*i64(i32_2) + (1 << 30))/(i64(1) << 31)));
+            check("vmpyo(v*.w,v*.h)", hvx_width/4, i32((i64(i32_1)*i64(i32_2 * factor))/(i64(1) << 32)));
+            check("vmpyo(v*.w,v*.h):<<1:sat", hvx_width/4, i32_sat((i64(i32_1 * factor)*i64(i32_2))/(i64(1) << 31)));
+            check("vmpyo(v*.w,v*.h):<<1:rnd:sat", hvx_width/4, i32_sat((i64(i32_1)*i64(i32_2 * factor) + (1 << 30))/(i64(1) << 31)));
         }
 
         for (int scalar : {32766, 32767}) {


### PR DESCRIPTION
These rules were brittle, expressions of the form `((x*2*N) + 16384) / 32768)` would fail to match the intended pattern because the simplifier would cancel the factor of 2 from the expression. These new rules are more robust. 

This should enable fixing some issues with simplifier rules in #2845.

This PR also adds simplifications for shifts by zero.