### PR TITLE
Fixed to embed()/slice() and friends

### DIFF
--- a/python_bindings/src/PyBuffer.cpp
+++ b/python_bindings/src/PyBuffer.cpp
@@ -353,7 +353,7 @@ void define_buffer(py::module &m) {
 
         .def("embed", [](Buffer<> &b, int d) -> void {
             b.embed(d);
-        }, py::arg("dimension")
+        }, py::arg("dimension"))
         .def("embedded", [](Buffer<> &b, int d) -> Buffer<> {
             return b.embedded(d);
         }, py::arg("dimension"))

--- a/python_bindings/src/PyBuffer.cpp
+++ b/python_bindings/src/PyBuffer.cpp
@@ -351,12 +351,26 @@ void define_buffer(py::module &m) {
             return b.embedded(d, pos);
         }, py::arg("dimension"), py::arg("pos"))
 
+        .def("embed", [](Buffer<> &b, int d) -> void {
+            b.embed(d);
+        }, py::arg("dimension")
+        .def("embedded", [](Buffer<> &b, int d) -> Buffer<> {
+            return b.embedded(d);
+        }, py::arg("dimension"))
+
         .def("slice", [](Buffer<> &b, int d, int pos) -> void {
             b.slice(d, pos);
         }, py::arg("dimension"), py::arg("pos"))
         .def("sliced", [](Buffer<> &b, int d, int pos) -> Buffer<> {
             return b.sliced(d, pos);
         }, py::arg("dimension"), py::arg("pos"))
+
+        .def("slice", [](Buffer<> &b, int d) -> void {
+            b.slice(d);
+        }, py::arg("dimension"))
+        .def("sliced", [](Buffer<> &b, int d) -> Buffer<> {
+            return b.sliced(d);
+        }, py::arg("dimension"))
 
         .def("translate", [](Buffer<> &b, int d, int dx) -> void {
             b.translate(d, dx);

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1266,10 +1266,16 @@ public:
         return im;
     }
 
+    /** Make a lower-dimensional image that refers to one slice of this
+     * image at the dimension's minimum. */
+    inline Buffer<T, D> sliced(int d) const {
+        return sliced(d, dim(d).min());
+    }
+
     /** Slice an image in-place */
     void slice(int d, int pos) {
         assert(d >= 0 && d <= dimensions());
-        // assert(pos >= dim(d).min() && pos <= dim(d).max());
+        assert(pos >= dim(d).min() && pos <= dim(d).max());
         device_deallocate();
         buf.dimensions--;
         int shift = pos - buf.dim[d].min;
@@ -1283,6 +1289,11 @@ public:
         buf.dim[buf.dimensions] = {0, 0, 0};
     }
 
+    /** Slice an image in-place at the dimension's minimum. */
+    inline void slice(int d) {
+        slice(d, dim(d).min());
+    }
+
     /** Make a new image that views this image as a single slice in a
      * higher-dimensional space. The new dimension has extent one and
      * the given min. This operation is the opposite of slice. As an
@@ -1293,8 +1304,7 @@ public:
      &im(x, y, c) == &im2(x, 17, y, c);
      \endcode
      */
-    Buffer<T, D> embedded(int d, int pos) const {
-        assert(d >= 0 && d <= dimensions());
+    Buffer<T, D> embedded(int d, int pos = 0) const {
         Buffer<T, D> im(*this);
         im.embed(d, pos);
         return im;
@@ -1302,7 +1312,7 @@ public:
 
     /** Embed an image in-place, increasing the
      * dimensionality. */
-    void embed(int d, int pos) {
+    void embed(int d, int pos = 0) {
         assert(d >= 0 && d <= dimensions());
         add_dimension();
         translate(dimensions() - 1, pos);

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1258,8 +1258,7 @@ public:
         std::swap(buf.dim[d1], buf.dim[d2]);
     }
 
-    /** Make a lower-dimensional image that refers to one slice of this
-     * image. */
+    /** Make a lower-dimensional image that refers to one slice of this image. */
     Buffer<T, D> sliced(int d, int pos) const {
         Buffer<T, D> im = *this;
         im.slice(d, pos);

--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -179,7 +179,7 @@ void do_test() {
 
     Buffer<T> luma_buf(width, height, 1);
     luma_buf.copy_from(color_buf);
-    luma_buf.slice(2, 0);
+    luma_buf.slice(2);
 
     std::vector<std::string> formats = {"ppm","pgm","tmp","mat"};
 #ifndef HALIDE_NO_JPEG
@@ -195,7 +195,7 @@ void do_test() {
         if (format == "tmp") {
             // .tmp only supports exactly-4-dimensions, so handle it separately.
             // (Add a dimension to make it 4-dimensional)
-            Buffer<T> cb4 = color_buf.embedded(color_buf.dimensions(), 0);
+            Buffer<T> cb4 = color_buf.embedded(color_buf.dimensions());
             std::cout << "Testing format: " << format << " for " << halide_type_of<T>() << "x4\n";
             test_round_trip(cb4, format);
 

--- a/tools/RunGen.cpp
+++ b/tools/RunGen.cpp
@@ -595,7 +595,7 @@ Buffer<> adjust_buffer_dims(const std::string &title, const std::string &name, c
         }
         auto old_shape = get_shape(b);
         while (b.dimensions() > dims_needed) {
-            b = b.sliced(dims_needed, 0);
+            b = b.sliced(dims_needed);
         }
         info() << "Shape for " << name << " changed: " << old_shape << " -> " << get_shape(b);
     } else if (dims_actual < dims_needed) {


### PR DESCRIPTION
- Add overloads for slice()/sliced() that default 'pos' to min-of-that-dimension
- Add overloads for embed()/embedded() that default 'pos' to zero
- slice() now asserts that the pos is within that dimensions valid range [the lack of this assert did actually bite me in real code]
- Adjust a few uses of these calls to skip the now-defaulted arg where it makes sense