### PR TITLE
Changes to make vmlal.* work

### DIFF
--- a/src/CodeGen_ARM.h
+++ b/src/CodeGen_ARM.h
@@ -34,6 +34,7 @@ protected:
     void visit(const Store *);
     void visit(const Load *);
     void visit(const Call *);
+    void visit(const Broadcast *);
     // @}
 
     /** Various patterns to peephole match against */

--- a/src/CodeGen_ARM.h
+++ b/src/CodeGen_ARM.h
@@ -34,7 +34,6 @@ protected:
     void visit(const Store *);
     void visit(const Load *);
     void visit(const Call *);
-    void visit(const Broadcast *);
     // @}
 
     /** Various patterns to peephole match against */


### PR DESCRIPTION
These are changes in CodeGen_ARM.cpp to catch the pattern `broadcast(widen(scalar))` and flip their order to `widen(broadcast(scalar))` so that LLVM generate the correct `vmlal.*` instructions. 

Please refer to https://github.com/halide/Halide/issues/2997