### PR TITLE
Switch to the large code model (fPIC vs fpic)

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -448,7 +448,8 @@ std::unique_ptr<llvm::TargetMachine> make_target_machine(const llvm::Module &mod
         llvm::TargetRegistry::printRegisteredTargetsForVersion(llvm::outs());
 #endif
     }
-    internal_assert(llvm_target) << "Could not create LLVM target for " << module.getTargetTriple() << "\n";
+    auto triple = llvm::Triple(module.getTargetTriple());
+    internal_assert(llvm_target) << "Could not create LLVM target for " << triple.str() << "\n";
 
     llvm::TargetOptions options;
     std::string mcpu = "";
@@ -462,7 +463,9 @@ std::unique_ptr<llvm::TargetMachine> make_target_machine(const llvm::Module &mod
 #if LLVM_VERSION < 60
                                                 llvm::CodeModel::Default,
 #else
-                                                llvm::CodeModel::Large,
+                                                (triple.isArch64Bit() ?
+                                                 llvm::CodeModel::Large :
+                                                 llvm::CodeModel::Small),
 #endif
                                                 llvm::CodeGenOpt::Aggressive));
 }

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -462,7 +462,7 @@ std::unique_ptr<llvm::TargetMachine> make_target_machine(const llvm::Module &mod
 #if LLVM_VERSION < 60
                                                 llvm::CodeModel::Default,
 #else
-                                                llvm::CodeModel::Small,
+                                                llvm::CodeModel::Large,
 #endif
                                                 llvm::CodeGenOpt::Aggressive));
 }


### PR DESCRIPTION
This is more likely to work in every compilation environment. Makes zero difference to the assembly generated by local laplacian, and thus no performance difference. Similarly makes zero performance difference in other performance canaries I've tested (fft, performance_inner_loop_parallel).