### PR TITLE
Add unit test for NotImplementedError from Python extension.

### DIFF
--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -129,8 +129,9 @@ $(BIN)/ext/%.so: $(BIN)/%.py.o $(BIN)/%.o
 
 # TODO: In the optimal case, we'd do %.run on all our generators. Unfortunately,
 # every generator needs its own settings. See https://github.com/halide/Halide/issues/2977.
-.PHONY: test_correctness_addconstant_test test_correctness_pystub
+.PHONY: test_correctness_bit_test test_correctness_addconstant_test test_correctness_pystub
 test_correctness_addconstant_test: addconstant.run ;
+test_correctness_bit_test: bit.run ;
 test_correctness_pystub: $(BIN)/simplestub.so $(BIN)/complexstub.so $(BIN)/buildmethod.so $(BIN)/partialbuildmethod.so $(BIN)/nobuildmethod.so
 
 APPS = $(shell ls $(ROOT_DIR)/apps/*.py)

--- a/python_bindings/correctness/bit_generator.cpp
+++ b/python_bindings/correctness/bit_generator.cpp
@@ -4,8 +4,9 @@ using namespace Halide;
 
 class BitGenerator : public Halide::Generator<BitGenerator> {
 public:
-    Input<bool> bit_constant{"constant_uint1"};
     Input<Buffer<bool>> bit_input{"input_uint1", 1};
+    Input<bool> bit_constant{"constant_uint1"};
+
     Output<Buffer<bool>> bit_output{"output_uint1", 1};
 
     Var x, y, z;

--- a/python_bindings/correctness/bit_generator.cpp
+++ b/python_bindings/correctness/bit_generator.cpp
@@ -1,0 +1,21 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+class BitGenerator : public Halide::Generator<BitGenerator> {
+public:
+    Input<bool> bit_constant{"constant_uint1"};
+    Input<Buffer<bool>> bit_input{"input_uint1", 1};
+    Output<Buffer<bool>> bit_output{"output_uint1", 1};
+
+    Var x, y, z;
+
+    void generate() {
+        bit_output(x) = bit_input(x) + bit_constant;
+    }
+
+    void schedule() {
+    }
+};
+
+HALIDE_REGISTER_GENERATOR(BitGenerator, bit)

--- a/python_bindings/correctness/bit_test.py
+++ b/python_bindings/correctness/bit_test.py
@@ -13,7 +13,7 @@ def test():
 
     try:
         bit.bit(
-            bool_constant, input_u1, output_u1
+            input_u1, bool_constant, output_u1
         )
     except NotImplementedError:
         pass  # OK - that's what we expected.

--- a/python_bindings/correctness/bit_test.py
+++ b/python_bindings/correctness/bit_test.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+
+import addconstant
+import array
+import bit
+import sys
+
+
+def test():
+    bool_constant = True
+    input_u1 = array.array('B', [0, 1, 0, 1])
+    output_u1 = array.array('B', [0, 1, 0, 1])
+
+    try:
+        bit.bit(
+            bool_constant, input_u1, output_u1
+        )
+    except NotImplementedError:
+        pass  # OK - that's what we expected.
+    else:
+        print("Expected Exception not raised.", file=sys.stderr)
+        exit(1)
+
+
+if __name__ == "__main__":
+    if "darwin" in sys.platform:
+        # Don't run this test on Mac OS X.  It causes sporadic errors of the form
+        # "dyld: termination function 0x108fa45b0 not in mapped image bit.so".
+        # TODO: investigate why this is the case.
+        pass
+    else:
+        test()


### PR DESCRIPTION
Test that if we try to call a function that operates on bit arrays, we always get NotImplementedError.

This is based on https://github.com/halide/Halide/pull/2975 and won't work without it. Also it's currently disabled on Mac, because of https://github.com/halide/Halide/pull/3010#issuecomment-393945790