### PR TITLE
Clone of Add unit test for NotImplementedError from Python extension. #3017

### DIFF
--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -98,6 +98,8 @@ $(BIN)/%.so: $(BIN)/%_PyStub.o $(BIN)/PyStubImpl.o $(BIN)/%_generator.o $(LIBHAL
 	@mkdir -p $(@D)
 	$(CXX) $^ $(LDFLAGS) -shared -o $@
 
+.PHONY: test_correctness_bit_test test_correctness_pystub
+test_correctness_bit_test: bit.run ;
 test_correctness_pystub: $(BIN)/simplestub.so $(BIN)/complexstub.so $(BIN)/buildmethod.so $(BIN)/partialbuildmethod.so $(BIN)/nobuildmethod.so
 
 APPS = $(shell ls $(ROOT_DIR)/apps/*.py)

--- a/python_bindings/correctness/bit_generator.cpp
+++ b/python_bindings/correctness/bit_generator.cpp
@@ -1,0 +1,21 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+class BitGenerator : public Halide::Generator<BitGenerator> {
+public:
+    Input<bool> bit_constant{"constant_uint1"};
+    Input<Buffer<bool>> bit_input{"input_uint1", 1};
+    Output<Buffer<bool>> bit_output{"output_uint1", 1};
+
+    Var x, y, z;
+
+    void generate() {
+        bit_output(x) = bit_input(x) + bit_constant;
+    }
+
+    void schedule() {
+    }
+};
+
+HALIDE_REGISTER_GENERATOR(BitGenerator, bit)

--- a/python_bindings/correctness/bit_test.py
+++ b/python_bindings/correctness/bit_test.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+
+import addconstant
+import array
+import bit
+import sys
+
+
+def test():
+    bool_constant = True
+    input_u1 = array.array('B', [0, 1, 0, 1])
+    output_u1 = array.array('B', [0, 1, 0, 1])
+
+    try:
+        bit.bit(
+            bool_constant, input_u1, output_u1
+        )
+    except NotImplementedError:
+        pass  # OK - that's what we expected.
+    else:
+        print("Expected Exception not raised.", file=sys.stderr)
+        exit(1)
+
+
+if __name__ == "__main__":
+    if "darwin" in sys.platform:
+        # Don't run this test on Mac OS X.  It causes sporadic errors of the form
+        # "dyld: termination function 0x108fa45b0 not in mapped image bit.so".
+        # TODO: investigate why this is the case.
+        pass
+    else:
+        test()


### PR DESCRIPTION
Test that if we try to call a function that operates on bit
arrays, we always get NotImplementedError.

This is based on https://github.com/halide/Halide/pull/2975.