### PR TITLE
Disallow unsafe Buffer::crop calls()

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -198,6 +198,14 @@ public:
 
     template<typename ...Args,
              typename = typename std::enable_if<Internal::all_ints_and_optional_name<Args...>::value>::type>
+    explicit Buffer(Type t,
+                    Internal::add_const_if_T_is_const<T, void> *data,
+                    const std::vector<int> &sizes,
+                    const std::string &name = "") :
+        Buffer(Runtime::Buffer<T>(t, data, sizes, name)) {}
+
+    template<typename ...Args,
+             typename = typename std::enable_if<Internal::all_ints_and_optional_name<Args...>::value>::type>
     explicit Buffer(T *data,
                     int first, Args&&... rest) :
         Buffer(Runtime::Buffer<T>(data, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2875,9 +2875,8 @@ void Func::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
             im.add_dimension();
             // buf.host is going to be wrong no matter what, so don't
             // bother adjusting it.
-            auto dim = im.raw_buffer()->dim[im.dimensions()-1];
-            dim.min = 0;
-            dim.extent = s;
+            im.raw_buffer()->dim[im.dimensions()-1].min = 0;
+            im.raw_buffer()->dim[im.dimensions()-1].extent = s;
         }
         outputs[i] = std::move(im);
     }

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2863,17 +2863,10 @@ void Func::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
                               const ParamMap &param_map) {
     user_assert(defined()) << "Can't infer input bounds on an undefined Func.\n";
     vector<Buffer<>> outputs(func.outputs());
-    int sizes[] = {x_size, y_size, z_size, w_size};
     for (size_t i = 0; i < outputs.size(); i++) {
         // We're not actually going to read from these outputs, so
-        // make the allocation tiny, then expand them with unsafe
-        // cropping.
-        Buffer<> im = Buffer<>::make_scalar(func.output_types()[i]);
-        for (int s : sizes) {
-            if (!s) break;
-            im.add_dimension();
-            im.crop(im.dimensions()-1, 0, s);
-        }
+        // make the host allocation null.
+        Buffer<> im = Buffer<>(func.output_types()[i], nullptr, {x_size, y_size, z_size, w_size});
         outputs[i] = std::move(im);
     }
     Realization r(outputs);

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2863,10 +2863,22 @@ void Func::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
                               const ParamMap &param_map) {
     user_assert(defined()) << "Can't infer input bounds on an undefined Func.\n";
     vector<Buffer<>> outputs(func.outputs());
+    int sizes[] = {x_size, y_size, z_size, w_size};
     for (size_t i = 0; i < outputs.size(); i++) {
         // We're not actually going to read from these outputs, so
-        // make the host allocation null.
-        Buffer<> im = Buffer<>(func.output_types()[i], nullptr, {x_size, y_size, z_size, w_size});
+        // make the allocation tiny, then "expand" them by directly manipulating
+        // the halide_buffer_t fields. (We can't use crop because it explicitly
+        // disallows expanding the fields in this unsafe manner.)
+        Buffer<> im = Buffer<>::make_scalar(func.output_types()[i]);
+        for (int s : sizes) {
+            if (!s) break;
+            im.add_dimension();
+            // buf.host is going to be wrong no matter what, so don't
+            // bother adjusting it.
+            auto dim = im.raw_buffer()->dim[im.dimensions()-1];
+            dim.min = 0;
+            dim.extent = s;
+        }
         outputs[i] = std::move(im);
     }
     Realization r(outputs);

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -378,8 +378,8 @@ private:
         // TODO(abadams|zvookin): these asserts fail on correctness_autotune_bug
         // due to unsafe crop in Func::infer_input_bounds. See comment at Func.cpp:2834.
         // Should either fix that or kill the asserts and document the routine accordingly.
-        //        assert(dim(d).min() <= min);
-        //        assert(dim(d).max() >= min + extent - 1);
+       assert(dim(d).min() <= min);
+       assert(dim(d).max() >= min + extent - 1);
         int shift = min - dim(d).min();
         if (buf.host != nullptr) {
             buf.host += shift * dim(d).stride() * type().bytes();
@@ -1108,8 +1108,9 @@ public:
     }
 
     /** Make an image that refers to a sub-range of this image along
-     * the given dimension. Does not assert the crop region is within
-     * the existing bounds. */
+     * the given dimension. Asserts that the crop region is within
+     * the existing bounds: you cannot "crop outwards", even if you know there
+     * is valid Buffer storage (e.g. because you already cropped inwards). */
     Buffer<T, D> cropped(int d, int min, int extent) const {
         // Make a fresh copy of the underlying buffer (but not a fresh
         // copy of the allocation, if there is one).
@@ -1141,8 +1142,9 @@ public:
     }
 
     /** Make an image that refers to a sub-rectangle of this image along
-     * the first N dimensions. Does not assert the crop region is within
-     * the existing bounds. The cropped image drops any device handle. */
+     * the first N dimensions. Asserts that the crop region is within
+     * the existing bounds. The cropped image may drop any device handle
+     * if the device_interface cannot accomplish the crop in-place. */
     Buffer<T, D> cropped(const std::vector<std::pair<int, int>> &rect) const {
         // Make a fresh copy of the underlying buffer (but not a fresh
         // copy of the allocation, if there is one).


### PR DESCRIPTION
Previously we explicitly allowed crop() calls that expanded the Buffer, as the implementation of Func::infer_input_bounds() relied upon it. This is a dangerous and bad idea. Add assertion-checks that require crop() goes inward, and fix the implementation of Func::infer_input_bounds() to not rely upon the previous behavior.