### PR TITLE
Fixing prefetch bugs

### DIFF
--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -156,9 +156,9 @@ private:
             return Prefetch::make(op->name, op->types, op->bounds, op->prefetch, op->condition, std::move(body));
         } else if (op->bounds.empty()) {
             // Remove the Prefetch IR since it is prefetching an empty region
-            std::cerr << "Warning: Removing prefetch of " << p.name
-                      << " within loop nest of " << p.var << " (offset: "
-                      << p.offset << ") since it is not used at all.\n";
+            user_warning << "Removing prefetch of " << p.name
+                         << " within loop nest of " << p.var << " (offset: "
+                         << p.offset << ") since it is not used at all.\n";
             return body;
         } else {
             return op;

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -148,11 +148,15 @@ private:
             if (prefetch_box.maybe_unused()) {
                 condition = simplify(prefetch_box.used && condition);
             }
+            internal_assert(!new_bounds.empty());
             return Prefetch::make(op->name, op->types, new_bounds, op->prefetch, condition, std::move(body));
         }
 
         if (!body.same_as(op->body)) {
             return Prefetch::make(op->name, op->types, op->bounds, op->prefetch, op->condition, std::move(body));
+        } else if (op->bounds.empty()) {
+            // Remove the Prefetch IR since it is prefetching an empty region
+            return body;
         } else {
             return op;
         }

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -156,6 +156,9 @@ private:
             return Prefetch::make(op->name, op->types, op->bounds, op->prefetch, op->condition, std::move(body));
         } else if (op->bounds.empty()) {
             // Remove the Prefetch IR since it is prefetching an empty region
+            std::cerr << "Warning: Removing prefetch of " << p.name
+                      << " within loop nest of " << p.var << " (offset: "
+                      << p.offset << ") since it is not used at all.\n";
             return body;
         } else {
             return op;

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -25,6 +25,7 @@ using std::map;
 using std::pair;
 using std::set;
 using std::string;
+using std::tuple;
 using std::vector;
 
 namespace {
@@ -910,6 +911,13 @@ private:
 
         Stmt body = for_loop->body;
 
+        // Dig through any placeholder prefetches
+        vector<tuple<string, vector<Type>, PrefetchDirective>> placeholder_prefetches;
+        while (const Prefetch *p = body.as<Prefetch>()) {
+            placeholder_prefetches.push_back(std::make_tuple(p->name, p->types, p->prefetch));
+            body = p->body;
+        }
+
         // Dig through any let statements
         vector<pair<string, Expr>> lets;
         while (const LetStmt *l = body.as<LetStmt>()) {
@@ -968,6 +976,16 @@ private:
         // Reinstate the let statements
         for (size_t i = lets.size(); i > 0; i--) {
             body = LetStmt::make(lets[i - 1].first, lets[i - 1].second, body);
+        }
+
+        // Reinstate the placeholder prefetches
+        for (size_t i = placeholder_prefetches.size(); i > 0; i--) {
+            body = Prefetch::make(std::get<0>(placeholder_prefetches[i - 1]),
+                                  std::get<1>(placeholder_prefetches[i - 1]),
+                                  Region(),
+                                  std::get<2>(placeholder_prefetches[i - 1]),
+                                  const_true(),
+                                  body);
         }
 
         if (body.same_as(for_loop->body)) {
@@ -1596,6 +1614,13 @@ private:
 
         Stmt body = for_loop->body;
 
+        // Dig through any placeholder prefetches
+        vector<tuple<string, vector<Type>, PrefetchDirective>> placeholder_prefetches;
+        while (const Prefetch *p = body.as<Prefetch>()) {
+            placeholder_prefetches.push_back(std::make_tuple(p->name, p->types, p->prefetch));
+            body = p->body;
+        }
+
         // Dig through any let statements
         vector<pair<string, Expr>> lets;
         while (const LetStmt *l = body.as<LetStmt>()) {
@@ -1622,6 +1647,16 @@ private:
         // Reinstate the let statements
         for (size_t i = lets.size(); i > 0; i--) {
             body = LetStmt::make(lets[i - 1].first, lets[i - 1].second, body);
+        }
+
+        // Reinstate the placeholder prefetches
+        for (size_t i = placeholder_prefetches.size(); i > 0; i--) {
+            body = Prefetch::make(std::get<0>(placeholder_prefetches[i - 1]),
+                                  std::get<1>(placeholder_prefetches[i - 1]),
+                                  Region(),
+                                  std::get<2>(placeholder_prefetches[i - 1]),
+                                  const_true(),
+                                  body);
         }
 
         if (body.same_as(for_loop->body)) {

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -5698,6 +5698,17 @@ private:
         return stmt;
     }
 
+    Stmt visit(const Prefetch *op) override {
+        Stmt stmt = IRMutator2::visit(op);
+
+        const Prefetch *p = stmt.as<Prefetch>();
+        if (is_zero(p->condition)) {
+            // Predicate is always false
+            return p->body;
+        } else {
+            return stmt;
+        }
+    }
 
     Stmt visit(const For *op) override {
         Expr new_min = mutate(op->min);


### PR DESCRIPTION
Add simplifier to remove Prefetch IR when the predicate is always false. Also remove the Prefetch IR, if during `inject_prefetch`, the region being prefetched is empty. 

During `schedule_functions`, placeholder prefetches need to be peeled off; otherwise, the prefetch will end fail to account of function calls by the producer computed within that loop level. 