### PR TITLE
Use llvm::CodeModel::Small on macOS/iOS/tvOS

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -463,7 +463,9 @@ std::unique_ptr<llvm::TargetMachine> make_target_machine(const llvm::Module &mod
 #if LLVM_VERSION < 60
                                                 llvm::CodeModel::Default,
 #else
-                                                (triple.isArch64Bit() ?
+                                                // macOS et al seem to trigger various dyld errors
+                                                // with llvm::CodeModel::Large
+                                                (triple.isArch64Bit() && !triple.isOSDarwin() ?
                                                  llvm::CodeModel::Large :
                                                  llvm::CodeModel::Small),
 #endif

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -463,9 +463,12 @@ std::unique_ptr<llvm::TargetMachine> make_target_machine(const llvm::Module &mod
 #if LLVM_VERSION < 60
                                                 llvm::CodeModel::Default,
 #else
-                                                // macOS et al seem to trigger various dyld errors
+                                                // Many OSs trigger dyld errors
                                                 // with llvm::CodeModel::Large
-                                                (triple.isArch64Bit() && !triple.isOSDarwin() && !triple.isAndroid() ?
+                                                (triple.isArch64Bit() &&
+                                                 !triple.isOSDarwin() &&
+                                                 !triple.isAndroid() &&
+                                                 !(triple.isAArch64() && triple.isOSLinux()) ?
                                                  llvm::CodeModel::Large :
                                                  llvm::CodeModel::Small),
 #endif

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -465,7 +465,7 @@ std::unique_ptr<llvm::TargetMachine> make_target_machine(const llvm::Module &mod
 #else
                                                 // macOS et al seem to trigger various dyld errors
                                                 // with llvm::CodeModel::Large
-                                                (triple.isArch64Bit() && !triple.isOSDarwin() ?
+                                                (triple.isArch64Bit() && !triple.isOSDarwin() && !triple.isAndroid() ?
                                                  llvm::CodeModel::Large :
                                                  llvm::CodeModel::Small),
 #endif


### PR DESCRIPTION
Using llvm::CodeModel::Large triggers various dyld errors.  This fixes errors introduced by #3008.