### PR TITLE
Support user_context in Python extensions

### DIFF
--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -109,14 +109,21 @@ $(BIN)/runtime.gen: $(HALIDE_PATH)/tools/GenGen.cpp $(LIBHALIDE)
 	@mkdir -p $(@D)
 	$(CXX) $(CCFLAGS) $(LDFLAGS) $^ -o $@
 
-# Make the generator generate a Python extension:
-$(BIN)/%.py.c $(BIN)/%.cpp $(BIN)/%.h: $(BIN)/%.gen
-	$< -e h,cpp,py.c -g $(notdir $(basename $<)) -o $(BIN) target=host-no_runtime
-
 # Generate a runtime:
 $(BIN)/runtime.a: $(BIN)/runtime.gen
 	@mkdir -p $(@D)
 	$< -r runtime -o $(BIN) target=host
+
+# Which target features to use for which test targets.
+target_features_addconstant=-legacy_buffer_wrappers-no_runtime
+target_features_bit=-no_runtime
+target_features_user_context=-user_context-legacy_buffer_wrappers-no_runtime
+
+# Make the generator generate a Python extension:
+$(BIN)/%.py.c $(BIN)/%.cpp $(BIN)/%.h: $(BIN)/%.gen
+	LD_LIBRARY_PATH=$(HALIDE_DISTRIB_PATH)/bin $< -e h,cpp,py.c \
+	    -g $(notdir $(basename $<)) -o $(BIN) \
+	    target=host$(target_features_$(notdir $(basename $<)))
 
 # Compile the generated Python extension(s):
 $(BIN)/%.o: $(BIN)/%.cpp
@@ -137,9 +144,10 @@ $(BIN)/ext/%.so: $(BIN)/%.py.o $(BIN)/%.o $(BIN)/runtime.a
 
 # TODO: In the optimal case, we'd do %.run on all our generators. Unfortunately,
 # every generator needs its own settings. See https://github.com/halide/Halide/issues/2977.
-.PHONY: test_correctness_bit_test test_correctness_addconstant_test test_correctness_pystub
+.PHONY: test_correctness_bit_test test_correctness_addconstant_test test_correctness_pystub test_correctness_user_context
 test_correctness_addconstant_test: addconstant.run ;
 test_correctness_bit_test: bit.run ;
+test_correctness_user_context_test: user_context.run ;
 test_correctness_pystub: $(BIN)/simplestub.so $(BIN)/complexstub.so $(BIN)/buildmethod.so $(BIN)/partialbuildmethod.so $(BIN)/nobuildmethod.so
 
 APPS = $(shell ls $(ROOT_DIR)/apps/*.py)

--- a/python_bindings/correctness/user_context_generator.cpp
+++ b/python_bindings/correctness/user_context_generator.cpp
@@ -1,0 +1,20 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+class UserContextGenerator : public Halide::Generator<UserContextGenerator> {
+public:
+    Input<uint8_t> constant{"constant"};
+    Output<Buffer<uint8_t>> output{"output", 1};
+
+    Var x;
+
+    void generate() {
+        output(x) = constant;
+    }
+
+    void schedule() {
+    }
+};
+
+HALIDE_REGISTER_GENERATOR(UserContextGenerator, user_context)

--- a/python_bindings/correctness/user_context_test.py
+++ b/python_bindings/correctness/user_context_test.py
@@ -1,0 +1,12 @@
+import array
+import user_context
+
+
+def test():
+    output = bytearray("\0\0\0\0", "ascii")
+    user_context.user_context(None, ord('q'), output)
+    assert output == bytearray("qqqq", "ascii")
+
+
+if __name__ == "__main__":
+    test()


### PR DESCRIPTION
This adds support for the implicit `__user_context` argument that gets added by Halide if "user_context" appears in target_features.

Since this adds a second handle type, we can now also add some testing for the legacy_buffer_wrappers disambiguation code, so do that, too.