### PR TITLE
Revert "Fixing prefetch bugs"

### DIFF
--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -148,18 +148,11 @@ private:
             if (prefetch_box.maybe_unused()) {
                 condition = simplify(prefetch_box.used && condition);
             }
-            internal_assert(!new_bounds.empty());
             return Prefetch::make(op->name, op->types, new_bounds, op->prefetch, condition, std::move(body));
         }
 
         if (!body.same_as(op->body)) {
             return Prefetch::make(op->name, op->types, op->bounds, op->prefetch, op->condition, std::move(body));
-        } else if (op->bounds.empty()) {
-            // Remove the Prefetch IR since it is prefetching an empty region
-            user_warning << "Removing prefetch of " << p.name
-                         << " within loop nest of " << p.var << " (offset: "
-                         << p.offset << ") since it is not used at all.\n";
-            return body;
         } else {
             return op;
         }

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -25,7 +25,6 @@ using std::map;
 using std::pair;
 using std::set;
 using std::string;
-using std::tuple;
 using std::vector;
 
 namespace {
@@ -911,13 +910,6 @@ private:
 
         Stmt body = for_loop->body;
 
-        // Dig through any placeholder prefetches
-        vector<tuple<string, vector<Type>, PrefetchDirective>> placeholder_prefetches;
-        while (const Prefetch *p = body.as<Prefetch>()) {
-            placeholder_prefetches.push_back(std::make_tuple(p->name, p->types, p->prefetch));
-            body = p->body;
-        }
-
         // Dig through any let statements
         vector<pair<string, Expr>> lets;
         while (const LetStmt *l = body.as<LetStmt>()) {
@@ -976,16 +968,6 @@ private:
         // Reinstate the let statements
         for (size_t i = lets.size(); i > 0; i--) {
             body = LetStmt::make(lets[i - 1].first, lets[i - 1].second, body);
-        }
-
-        // Reinstate the placeholder prefetches
-        for (size_t i = placeholder_prefetches.size(); i > 0; i--) {
-            body = Prefetch::make(std::get<0>(placeholder_prefetches[i - 1]),
-                                  std::get<1>(placeholder_prefetches[i - 1]),
-                                  Region(),
-                                  std::get<2>(placeholder_prefetches[i - 1]),
-                                  const_true(),
-                                  body);
         }
 
         if (body.same_as(for_loop->body)) {
@@ -1614,13 +1596,6 @@ private:
 
         Stmt body = for_loop->body;
 
-        // Dig through any placeholder prefetches
-        vector<tuple<string, vector<Type>, PrefetchDirective>> placeholder_prefetches;
-        while (const Prefetch *p = body.as<Prefetch>()) {
-            placeholder_prefetches.push_back(std::make_tuple(p->name, p->types, p->prefetch));
-            body = p->body;
-        }
-
         // Dig through any let statements
         vector<pair<string, Expr>> lets;
         while (const LetStmt *l = body.as<LetStmt>()) {
@@ -1647,16 +1622,6 @@ private:
         // Reinstate the let statements
         for (size_t i = lets.size(); i > 0; i--) {
             body = LetStmt::make(lets[i - 1].first, lets[i - 1].second, body);
-        }
-
-        // Reinstate the placeholder prefetches
-        for (size_t i = placeholder_prefetches.size(); i > 0; i--) {
-            body = Prefetch::make(std::get<0>(placeholder_prefetches[i - 1]),
-                                  std::get<1>(placeholder_prefetches[i - 1]),
-                                  Region(),
-                                  std::get<2>(placeholder_prefetches[i - 1]),
-                                  const_true(),
-                                  body);
         }
 
         if (body.same_as(for_loop->body)) {

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -5698,17 +5698,6 @@ private:
         return stmt;
     }
 
-    Stmt visit(const Prefetch *op) override {
-        Stmt stmt = IRMutator2::visit(op);
-
-        const Prefetch *p = stmt.as<Prefetch>();
-        if (is_zero(p->condition)) {
-            // Predicate is always false
-            return p->body;
-        } else {
-            return stmt;
-        }
-    }
 
     Stmt visit(const For *op) override {
         Expr new_min = mutate(op->min);

--- a/test/correctness/prefetch.cpp
+++ b/test/correctness/prefetch.cpp
@@ -101,55 +101,6 @@ int test2(const Target &t) {
     return 0;
 }
 
-int test3(const Target &t) {
-    Func f("f"), g("g"), h("h");
-    Var x("x"), xo("xo");
-
-    f(x) = x;
-    h(x) = f(x) + 1;
-    g(x) = h(0) + h(1);
-
-    f.compute_root();
-    g.split(x, xo, x, 32);
-    h.compute_at(g, xo);
-    g.prefetch(f, xo, 1);
-
-    Module m = g.compile_to_module({});
-    CollectPrefetches collect;
-    m.functions()[0].body.accept(&collect);
-
-    vector<vector<Expr>> expected = {{Variable::make(Handle(), f.name()) , 0, 1, get_stride(t, 4)}};
-    if (!check(expected, collect.prefetches)) {
-        return -1;
-    }
-    return 0;
-}
-
-int test4(const Target &t) {
-    Func f("f"), g("g"), h("h");
-    Var x("x");
-
-    f(x) = x;
-    h(x) = f(x) + 1;
-    g(x) = h(0) + h(1);
-
-    f.compute_root();
-    h.compute_root();
-    g.prefetch(f, x, 1);
-
-    Module m = g.compile_to_module({});
-    CollectPrefetches collect;
-    m.functions()[0].body.accept(&collect);
-
-    // There shouldn't be any prefetches since there is no call to 'f'
-    // within the loop nest of 'g'
-    vector<vector<Expr>> expected = {};
-    if (!check(expected, collect.prefetches)) {
-        return -1;
-    }
-    return 0;
-}
-
 }  // namespace
 
 int main(int argc, char **argv) {
@@ -161,14 +112,6 @@ int main(int argc, char **argv) {
     }
     printf("Running prefetch test2\n");
     if (test2(t) != 0) {
-        return -1;
-    }
-    printf("Running prefetch test3\n");
-    if (test3(t) != 0) {
-        return -1;
-    }
-    printf("Running prefetch test4\n");
-    if (test4(t) != 0) {
         return -1;
     }
 


### PR DESCRIPTION
Reverts halide/Halide#3033

Rolling this one back is probably a bad idea, given that it fixes a bug in prefetching, but the test is now broken. Opening the PR just to see if this heals the test.