### PR TITLE
Mark some Halider::Buffer() ctors explicit

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -443,6 +443,26 @@ private:
         }
     }
 
+    void init_from_legacy_buffer_t(const buffer_t &old_buf, halide_type_t t) {
+        if (!T_is_void) {
+            assert(static_halide_type() == t);
+        }
+        assert(old_buf.elem_size == t.bytes());
+        buf.host = old_buf.host;
+        buf.type = t;
+        int d;
+        for (d = 0; d < 4 && old_buf.extent[d]; d++);
+        buf.dimensions = d;
+        make_shape_storage();
+        for (int i = 0; i < d; i++) {
+            buf.dim[i].min = old_buf.min[i];
+            buf.dim[i].extent = old_buf.extent[i];
+            buf.dim[i].stride = old_buf.stride[i];
+        }
+        buf.set_host_dirty(old_buf.host_dirty);
+        assert(old_buf.dev == 0 && "Cannot construct a Halide::Runtime::Buffer from a legacy buffer_t with a device allocation. Use halide_upgrade_buffer_t to upgrade it to a halide_buffer_t first.");
+    }
+
 public:
 
     typedef T ElemType;
@@ -568,22 +588,16 @@ public:
         initialize_from_buffer(buf, ownership);
     }
 
-    /** Make a Buffer from a legacy buffer_t. */
+    /** Make a Buffer from a legacy buffer_t, with an explicit halide_type. */
+    explicit Buffer(const buffer_t &old_buf, halide_type_t t) {
+        init_from_legacy_buffer_t(old_buf, t);
+    }
+
+    /** Make a Buffer from a legacy buffer_t, which is assumed to match our static
+     * type. (Cannot use with Buffer<void>.) */
     explicit Buffer(const buffer_t &old_buf) {
-        assert(!T_is_void && old_buf.elem_size == static_halide_type().bytes());
-        buf.host = old_buf.host;
-        buf.type = static_halide_type();
-        int d;
-        for (d = 0; d < 4 && old_buf.extent[d]; d++);
-        buf.dimensions = d;
-        make_shape_storage();
-        for (int i = 0; i < d; i++) {
-            buf.dim[i].min = old_buf.min[i];
-            buf.dim[i].extent = old_buf.extent[i];
-            buf.dim[i].stride = old_buf.stride[i];
-        }
-        buf.set_host_dirty(old_buf.host_dirty);
-        assert(old_buf.dev == 0 && "Cannot construct a Halide::Runtime::Buffer from a legacy buffer_t with a device allocation. Use halide_upgrade_buffer_t to upgrade it to a halide_buffer_t first.");
+        static_assert(!T_is_void, "Cannot construct a Buffer<void> from a buffer_t without an explicit type.");
+        init_from_legacy_buffer_t(old_buf, static_halide_type());
     }
 
     /** Populate the fields of a legacy buffer_t using this

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -562,14 +562,14 @@ public:
     }
 
     /** Make a Buffer from a halide_buffer_t */
-    Buffer(const halide_buffer_t &buf,
+    explicit Buffer(const halide_buffer_t &buf,
            BufferDeviceOwnership ownership = BufferDeviceOwnership::Unmanaged) {
         assert(T_is_void || buf.type == static_halide_type());
         initialize_from_buffer(buf, ownership);
     }
 
     /** Make a Buffer from a legacy buffer_t. */
-    Buffer(const buffer_t &old_buf) {
+    explicit Buffer(const buffer_t &old_buf) {
         assert(!T_is_void && old_buf.elem_size == static_halide_type().bytes());
         buf.host = old_buf.host;
         buf.type = static_halide_type();


### PR DESCRIPTION
Buffer(buffer_t) and Buffer(halide_buffer_t) should be marked 'explicit' to avoid quiet auto-conversion; since these can fail with a runtime error if the argument's size/type is a mismatch with the Buffer<> static type declaration, this can quietly inject runtime failures when converting code to use Buffer<>.