### PR TITLE
Have host_malloc_deinit called by hexagon destructor:

### DIFF
--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -418,7 +418,6 @@ WEAK int halide_hexagon_device_release(void *user_context) {
         debug(user_context) << "        " << result << "\n";
         shared_runtime = 0;
     }
-    host_malloc_deinit();
 
     return 0;
 }
@@ -835,6 +834,7 @@ namespace {
 __attribute__((destructor))
 WEAK void halide_hexagon_cleanup() {
     halide_hexagon_device_release(NULL);
+    host_malloc_deinit();
 }
 }
 

--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -418,6 +418,7 @@ WEAK int halide_hexagon_device_release(void *user_context) {
         debug(user_context) << "        " << result << "\n";
         shared_runtime = 0;
     }
+    host_malloc_deinit();
 
     return 0;
 }


### PR DESCRIPTION
Destructor halide_hexagon_cleanup()  calls  halide_hexagon_device_release(NULL)
which calls to host_malloc_deinit (aka halide_hexagon_host_malloc_deinit)

Verified with print to logcat during testing, not included in this patch.