### PR TITLE
Preserve const-ness when casting pointers in HalideTraceViz.cpp

### DIFF
--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -817,8 +817,8 @@ struct Surface {
             *dst = o;
         } else {
             // TODO: this could be done using 64-bit ops more simply
-            uint8_t *a = (uint8_t*)under;
-            uint8_t *b = (uint8_t*)over;
+            const uint8_t *a = (const uint8_t*)under;
+            const uint8_t *b = (const uint8_t*)over;
             uint8_t *d = (uint8_t*)dst;
             d[0] = (alpha * b[0] + (255 - alpha) * a[0]) / 255;
             d[1] = (alpha * b[1] + (255 - alpha) * a[1]) / 255;


### PR DESCRIPTION
I get build errors on lines 820 and 821 of HalideTraceViz.cpp, pertaining to the loss of `const` qualifiers during the casts on [the relevant lines](https://github.com/halide/Halide/blob/6d246d9f6c0ab6e9b27a80d98452de96cc752a39/util/HalideTraceViz.cpp#L820-L821):

![screen shot 2018-06-18 at 9 07 30 pm](https://user-images.githubusercontent.com/378969/41570351-6fa8cc4a-733c-11e8-87db-50a62354f07d.jpg)

This change preserves the const-ness from the function’s parameters – making these pointers `const` should not have any effect on the functions’ operation as they are only read from and not written to.

[These additions](https://github.com/halide/Halide/pull/2901/files#diff-c331568fea1d179a7f31a0d643a48c8bR804) were part of [a recent overhaul of HalideTraceViz.cpp](https://github.com/halide/Halide/pull/2901).