### PR TITLE
Fix #3070

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -339,8 +339,10 @@ private:
 
         if (a.is_single_point(op->a) && b.is_single_point(op->b)) {
             interval = Interval::single_point(op);
+            return;
         } else if (a.is_single_point() && b.is_single_point()) {
             interval = Interval::single_point(a.min * b.min);
+            return;
         } else if (b.is_single_point()) {
             Expr e1 = a.has_lower_bound() ? a.min * b.min : a.min;
             Expr e2 = a.has_upper_bound() ? a.max * b.min : a.max;

--- a/test/correctness/bounds_of_multiply.cpp
+++ b/test/correctness/bounds_of_multiply.cpp
@@ -1,0 +1,33 @@
+// See https://github.com/halide/Halide/issues/3070
+
+#include <stdio.h>
+
+#include "Halide.h"
+
+using namespace Halide;
+
+template <typename T>
+void test() {
+    Param<T> bound;
+    ImageParam in(UInt(8), 1);
+    Var x;
+    Func f;
+
+    f(x) = in(clamp(x, 0, bound * 2 - 1));
+
+    Buffer<uint8_t> foo(10);
+    foo.fill(0);
+    in.set(foo);
+    bound.set(5);
+
+    auto result = f.realize(200);
+}
+
+int main(int argc, char **argv) {
+    printf("Trying int32_t\n");
+    test<int32_t>();
+    printf("Trying int16_t\n");
+    test<int16_t>();
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
The bounds of a multiply is just the multiply when there's only a single
point involved. No need to check for overflow.