### PR TITLE
Fix the type of an index variable

### DIFF
--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -2517,7 +2517,7 @@ void Partitioner::reorder_dims(Stage f_handle, int stage_num, Definition def,
                                map<string, Expr> strides, AutoSchedule &sched) {
     vector<Dim> &dims = def.schedule().dims();
     internal_assert(dims.size() > 1);
-    vector<pair<string, bool>> order;
+    vector<pair<string, int>> order;
 
     for (int d = 0; d < (int)dims.size() - 1; d++) {
         internal_assert(strides.find(dims[d].var) != strides.end());


### PR DESCRIPTION
On line 2583, the entry is pair<string, int>, but it gets pushed into a vector of pair<string, bool>.
The implicit conversion won't be caught by compiler.
On the other hand, using bool here is correct if there are only two variables, since bool can at least hold two different values.