### PR TITLE
Option to emit generator YAML metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 bazel-*
 bin/*
 python_bindings/bin/*
+build/
 build-64/*
 build-ios/*
 build-osx/*

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -262,6 +262,8 @@ class EmitterBase {
            namespaces.pop_back();
         }
         
+    public:
+        /// This is an ABC:
         virtual void emit() = 0;
         virtual ~EmitterBase() {}
         
@@ -276,6 +278,7 @@ class EmitterBase {
         const output_ptr_vec_t outputs;
         int indent_level{ 0 };
         
+    protected:
         param_ptr_vec_t select_generator_params(param_ptr_vec_t const& in) {
             param_ptr_vec_t out;
             for (auto p : in) {
@@ -289,6 +292,7 @@ class EmitterBase {
             return out;
         }
         
+    protected:
         /** Emit spaces according to the current indentation level */
         std::string indent();
 };

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -2,6 +2,8 @@
 #include <fstream>
 #include <set>
 
+#include "llvm/Support/YAMLTraits.h"
+
 #include "Generator.h"
 #include "Outputs.h"
 #include "Simplify.h"
@@ -326,6 +328,52 @@ class StubEmitter : public EmitterBase {
         void emit_generator_params_struct();
         
 };
+
+class YamlEmitter : EmitterBase {
+    
+    public:
+        using Super = EmitterBase;
+        using Super::param_ptr_vec_t;
+        using Super::input_ptr_vec_t;
+        using Super::output_ptr_vec_t;
+    
+    public:
+        virtual void emit() override;
+        YamlEmitter(std::ostream& dest,
+                    std::string const& generator_registered_name,
+                    std::string const& generator_stub_name,
+                    param_ptr_vec_t const& generator_params,
+                    input_ptr_vec_t const& inputs,
+                    output_ptr_vec_t const& outputs)
+            : Super(dest,
+                    generator_registered_name,
+                    generator_stub_name,
+                    generator_params,
+                    inputs, outputs) {}
+    
+    // private:
+    //
+    //     void emit_inputs_struct();
+    //     void emit_generator_params_struct();
+    
+};
+
+} /// namespace Internal
+} /// namespace Halide
+
+namespace llvm {
+    
+    namespace yaml {
+        
+        // template <>
+        // struct MappingTraits<THINGY>
+        
+    }
+    
+}
+
+namespace Halide {
+namespace Internal {
 
 std::string EmitterBase::indent() {
     std::ostringstream o;
@@ -724,6 +772,11 @@ void StubEmitter::emit() {
 
     stream << indent() << "#endif  // " << guard.str() << "\n";
 }
+
+void YamlEmitter::emit() {
+    /// INSERT YAML EMITTER BUSINESS HERE
+}
+
 
 GeneratorStub::GeneratorStub(const GeneratorContext &context,
                              GeneratorFactory generator_factory)

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -613,62 +613,70 @@ struct MappingTraits<input_ptr_t> {
     /// Traited YAML output-only serialization for Halide::Internal::GeneratorInputBase
     /// pointer types, as declared in Generator.h:
     
-    static const int default_array_size;
-    static const int default_dims;
+    static const int       default_array_size;
+    static const int       default_dims;
+    static const typevec_t default_types;
     
     static void mapping(IO& io, input_ptr_t& input) {
         std::string name                   = input->name();
         std::string c_type                 = input->get_c_type();
-          typevec_t types                  = input->types();
-               bool array_size_defined     = input->array_size_defined();
-               bool dims_defined           = input->dims_defined();
-                int array_size             = array_size_defined ? default_array_size
-                                                                :  static_cast<int>(
-                                                                   input->array_size());
-                int dims                   =       dims_defined ? default_dims
-                                                                :  input->dims();
+              bool array_size_defined      = output->array_size_defined();
+              bool dims_defined            = output->dims_defined();
+              bool types_defined           = output->types_defined();
+               int array_size              = array_size_defined ? static_cast<int>(
+                                                                   input->array_size())
+                                                                : default_array_size;
+               int dims                    =       dims_defined ?  input->dims()
+                                                                : default_dims;
+         typevec_t types                   =      types_defined ?  input->types()
+                                                                : default_types;
         
         io.mapRequired("name",               name);
         io.mapRequired("c_type",             c_type);
-        io.mapRequired("types",              types);
         io.mapOptional("array_size",         array_size,          default_array_size);
         io.mapOptional("dims",               dims,                default_dims);
+        io.mapOptional("types",              types,               default_types);
     }
 };
 
-int const MappingTraits<input_ptr_t>::default_array_size = int{ 0 };
-int const MappingTraits<input_ptr_t>::default_dims       = int{ 0 };
+      int const MappingTraits<input_ptr_t>::default_array_size = int{ 0 };
+      int const MappingTraits<input_ptr_t>::default_dims       = int{ 0 };
+typevec_t const MappingTraits<input_ptr_t>::default_types      = typevec_t{};
 
 template <>
 struct MappingTraits<output_ptr_t> {
     /// Traited YAML output-only serialization for Halide::Internal::GeneratorOutputBase
     /// pointer types, as declared in Generator.h:
     
-    static const int default_array_size;
-    static const int default_dims;
+    static const int       default_array_size;
+    static const int       default_dims;
+    static const typevec_t default_types;
     
     static void mapping(IO& io, output_ptr_t& output) {
         std::string name                    = output->name();
         std::string c_type                  = output->get_c_type();
-          typevec_t types                   = output->types();
                bool array_size_defined      = output->array_size_defined();
                bool dims_defined            = output->dims_defined();
-                int array_size              = array_size_defined ? default_array_size
-                                                                 :  static_cast<int>(
-                                                                    output->array_size());
-                int dims                    =       dims_defined ? default_dims
-                                                                 :  output->dims();
+               bool types_defined           = output->types_defined();
+                int array_size              = array_size_defined ? static_cast<int>(
+                                                                   output->array_size())
+                                                                 : default_array_size;
+                int dims                    =       dims_defined ? output->dims()
+                                                                 : default_dims;
+          typevec_t types                   =      types_defined ? output->types()
+                                                                 : default_types;
         
         io.mapRequired("name",                name);
         io.mapRequired("c_type",              c_type);
-        io.mapRequired("types",               types);
         io.mapOptional("array_size",          array_size,          default_array_size);
         io.mapOptional("dims",                dims,                default_dims);
+        io.mapOptional("types",               types,               default_types);
     }
 };
 
-int const MappingTraits<output_ptr_t>::default_array_size = int{ 0 };
-int const MappingTraits<output_ptr_t>::default_dims       = int{ 0 };
+      int const MappingTraits<output_ptr_t>::default_array_size = int{ 0 };
+      int const MappingTraits<output_ptr_t>::default_dims       = int{ 0 };
+typevec_t const MappingTraits<output_ptr_t>::default_types      = typevec_t{};
 
 using InputInfo = Halide::Internal::EmitterBase::InputInfo;
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -620,9 +620,9 @@ struct MappingTraits<input_ptr_t> {
     static void mapping(IO& io, input_ptr_t& input) {
         std::string name                   = input->name();
         std::string c_type                 = input->get_c_type();
-              bool array_size_defined      = output->array_size_defined();
-              bool dims_defined            = output->dims_defined();
-              bool types_defined           = output->types_defined();
+              bool array_size_defined      = input->array_size_defined();
+              bool dims_defined            = input->dims_defined();
+              bool types_defined           = input->types_defined();
                int array_size              = array_size_defined ? static_cast<int>(
                                                                    input->array_size())
                                                                 : default_array_size;

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -491,7 +491,7 @@ class YamlEmitter : public EmitterBase {
               youtput(llostream, nullptr, column_width) {}
     
     private:
-        mutable ostream_t llostream;
+        ostream_t llostream;
         mutable youtput_t youtput;
     
 };

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -483,6 +483,7 @@ namespace llvm {
                 io.mapRequired("lanes",             lanes);
                 io.mapRequired("typecode",          typecode);
             }
+            static const bool flow = true; /// print values inline
         };
         
         template <>

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -658,7 +658,7 @@ struct MappingTraits<input_ptr_t> {
     }
 };
 
-      int const MappingTraits<input_ptr_t>::default_array_size = int{ 0 };
+      int const MappingTraits<input_ptr_t>::default_array_size = int{ 1 };
       int const MappingTraits<input_ptr_t>::default_dims       = int{ 0 };
 typevec_t const MappingTraits<input_ptr_t>::default_types      = typevec_t{};
 
@@ -695,7 +695,7 @@ struct MappingTraits<output_ptr_t> {
     }
 };
 
-      int const MappingTraits<output_ptr_t>::default_array_size = int{ 0 };
+      int const MappingTraits<output_ptr_t>::default_array_size = int{ 1 };
       int const MappingTraits<output_ptr_t>::default_dims       = int{ 0 };
 typevec_t const MappingTraits<output_ptr_t>::default_types      = typevec_t{};
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -383,16 +383,32 @@ class YamlEmitter : EmitterBase {
 using llvm::yaml::MappingTraits;
 using llvm::yaml::IO;
 
-// LLVM_YAML_IS_SEQUENCE_VECTOR(std::string);
-#define FUCKYOU(string) (char const*)string
+template <typename T>
+using const_ptr = std::add_pointer_t<std::add_const_t<T>>;
 
 namespace llvm {
     
     namespace yaml {
         
-        using  param_ptr_t = Halide::Internal::GeneratorParamBase*;
-        using  input_ptr_t = Halide::Internal::GeneratorInputBase*;
-        using output_ptr_t = Halide::Internal::GeneratorOutputBase*;
+        using  param_ptr_t = const_ptr<Halide::Internal::GeneratorParamBase>;
+        using  input_ptr_t = const_ptr<Halide::Internal::GeneratorInputBase>;
+        using output_ptr_t = const_ptr<Halide::Internal::GeneratorOutputBase>;
+        
+    } /// namespace yaml
+
+} /// namespace llvm
+
+LLVM_YAML_STRONG_TYPEDEF(const_ptr<Halide::Internal::GeneratorParamBase>,     param_ptr_t);
+LLVM_YAML_STRONG_TYPEDEF(const_ptr<Halide::Internal::GeneratorInputBase>,     input_ptr_t);
+LLVM_YAML_STRONG_TYPEDEF(const_ptr<Halide::Internal::GeneratorOutputBase>,   output_ptr_t);
+
+LLVM_YAML_IS_SEQUENCE_VECTOR(param_ptr_t);
+LLVM_YAML_IS_SEQUENCE_VECTOR(input_ptr_t);
+LLVM_YAML_IS_SEQUENCE_VECTOR(output_ptr_t);
+
+namespace llvm {
+    
+    namespace yaml {
         
         template <>
         struct MappingTraits<param_ptr_t> {
@@ -426,8 +442,6 @@ namespace llvm {
     }
     
 }
-
-#undef FUCKYOU
 
 namespace Halide {
 namespace Internal {

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -397,25 +397,17 @@ namespace llvm {
         template <>
         struct MappingTraits<param_ptr_t> {
             static void mapping(IO& io, param_ptr_t& param) {
-                std::string name{ "name" };
-                std::string default_value{ "default_value" };
-                std::string c_type{ "c_type" };
-                std::string type_decls{ "type_decls" };
-                std::string is_synthetic{ "is_synthetic" };
-                std::string is_looplevel{ "is_looplevel" };
-                std::string call_to_string{ "call_to_string" };
+                io.mapRequired("name",               param->name);
+                io.mapRequired("default",            param->get_default_value());
+                io.mapRequired("c_type",             param->get_c_type());
+                io.mapRequired("type_decls",         param->get_type_decls());
+                io.mapRequired("is_synthetic",       param->is_synthetic_param());
                 
-                io.mapRequired(name.c_str(),               param->name);
-                io.mapRequired(default_value.c_str(),      param->get_default_value());
-                io.mapRequired(c_type.c_str(),             param->get_c_type());
-                io.mapRequired(type_decls.c_str(),         param->get_type_decls());
-                io.mapRequired(is_synthetic.c_str(),       param->is_synthetic_param());
+                bool is_looplevel = param->is_looplevel_param();
+                std::string call_to_string = is_looplevel ? "" : param->call_to_string(param->name);
                 
-                bool is_looplevel_value = param->is_looplevel_param();
-                std::string call_to_string_value = is_looplevel ? "" : param->call_to_string(param->name);
-                
-                io.mapRequired(is_looplevel.c_str(),       is_looplevel_value);
-                io.mapRequired(call_to_string.c_str(),     call_to_string_value);
+                io.mapRequired("is_looplevel",       is_looplevel);
+                io.mapRequired("call_to_string",     call_to_string);
             }
         };
         

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -43,6 +43,9 @@ LLVM_YAML_IS_SEQUENCE_VECTOR(param_ptr_t);
 LLVM_YAML_IS_SEQUENCE_VECTOR(input_ptr_t);
 LLVM_YAML_IS_SEQUENCE_VECTOR(output_ptr_t);
 
+/// We can also have a sequence of Halide Types:
+LLVM_YAML_IS_SEQUENCE_VECTOR(Halide::Type);
+
 namespace Halide {
 
 GeneratorContext::GeneratorContext(const Target &t, bool auto_schedule,
@@ -287,6 +290,7 @@ class EmitterBase {
         using  param_ptr_vec_t = std::vector<std::add_pointer_t<Internal::GeneratorParamBase>>;
         using  input_ptr_vec_t = std::vector<std::add_pointer_t<Internal::GeneratorInputBase>>;
         using output_ptr_vec_t = std::vector<std::add_pointer_t<Internal::GeneratorOutputBase>>;
+        using        typevec_t = std::vector<Halide::Type>;
         using     in_infovec_t = std::vector<InputInfo>;
         using    out_infovec_t = std::vector<OutputInfo>;
         using       out_info_t = std::tuple<out_infovec_t, bool>;
@@ -502,13 +506,17 @@ namespace llvm {
             }
         };
         
+        using typevec_t = Halide::Internal::EmitterBase::typevec_t;
+        
         template <>
         struct MappingTraits<input_ptr_t> {
             static void mapping(IO& io, input_ptr_t& input) {
                 std::string name                   = input->name();
+                  typevec_t types                  = input->types();
                 std::string c_type                 = input->get_c_type();
                 
                 io.mapRequired("name",             name);
+                io.mapRequired("types",            types);
                 io.mapRequired("c_type",           c_type);
             }
         };

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -414,7 +414,7 @@ class EmitterBase {
                 } else {
                     getter = is_func ?       "get_output" : "get_output_buffer";
                 }
-                getter += "<" + c_type + ">";
+                if (!is_func) { getter += "<" + c_type + ">"; }
                 outvec.push_back({ output->name(),
                                    output->is_array() ? "std::vector<" + c_type + ">" : c_type,
                   getter + "(\"" + output->name() + "\")" });

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -621,7 +621,7 @@ namespace llvm {
                  param_ptr_vec_t params            = yammitter.generator_params;
                  input_ptr_vec_t inputs            = yammitter.inputs;
                 output_ptr_vec_t outputs           = yammitter.outputs;
-                    in_infovec_t in_info           = yammitter.get_input_info();
+                    in_infovec_t input_info        = yammitter.get_input_info();
                    out_infovec_t out_info;
                             bool outs_all_funcs{ true };
                 std::tie(out_info, outs_all_funcs) = yammitter.get_output_info();
@@ -632,7 +632,7 @@ namespace llvm {
                 io.mapRequired("namespaces",         namespaces);
                 io.mapRequired("params",             params);
                 io.mapRequired("inputs",             inputs);
-                io.mapRequired("input_info",         in_info);
+                io.mapRequired("input_info",         input_info);
                 io.mapRequired("outputs",            outputs);
                 io.mapRequired("output_info",        out_info);
                 io.mapRequired("outputs_all_funcs",  outs_all_funcs);

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1,3 +1,4 @@
+
 #include <cmath>
 #include <fstream>
 #include <set>
@@ -390,9 +391,13 @@ namespace llvm {
     
     namespace yaml {
         
-        using  param_ptr_t = const_ptr<Halide::Internal::GeneratorParamBase>;
-        using  input_ptr_t = const_ptr<Halide::Internal::GeneratorInputBase>;
-        using output_ptr_t = const_ptr<Halide::Internal::GeneratorOutputBase>;
+        using  param_t = Halide::Internal::GeneratorParamBase;
+        using  input_t = Halide::Internal::GeneratorInputBase;
+        using output_t = Halide::Internal::GeneratorOutputBase;
+        
+        using  param_ptr_t = const_ptr<param_t>;
+        using  input_ptr_t = const_ptr<input_t>;
+        using output_ptr_t = const_ptr<output_t>;
         
     } /// namespace yaml
 
@@ -406,36 +411,49 @@ LLVM_YAML_IS_SEQUENCE_VECTOR(param_ptr_t);
 LLVM_YAML_IS_SEQUENCE_VECTOR(input_ptr_t);
 LLVM_YAML_IS_SEQUENCE_VECTOR(output_ptr_t);
 
+// LLVM_YAML_DECLARE_MAPPING_TRAITS(param_t);
+// LLVM_YAML_DECLARE_MAPPING_TRAITS(input_t);
+// LLVM_YAML_DECLARE_MAPPING_TRAITS(output_t);
+
+// LLVM_YAML_IS_STRING_MAP(std::string);
+
 namespace llvm {
     
     namespace yaml {
         
+        /// The first rule of the LLVM YAML interface is, you do not talk about const.
+        /// The second rule of the LLVM YAML interface is YOU DO NOT TALK ABOUT CONST
+        
         template <>
-        struct MappingTraits<param_ptr_t> {
-            static void mapping(IO& io, param_ptr_t& param) {
-                io.mapRequired("name",               param->name);
-                io.mapRequired("default",            param->get_default_value());
-                io.mapRequired("c_type",             param->get_c_type());
-                io.mapRequired("type_decls",         param->get_type_decls());
-                io.mapRequired("is_synthetic",       param->is_synthetic_param());
+        struct MappingTraits<param_t> {
+            static void mapping(IO& io,      param_t& param) {
+                std::string name                    = param.name;
+                std::string default_value           = param.get_default_value();
+                std::string c_type                  = param.get_c_type();
+                std::string type_decls              = param.get_type_decls();
+                       bool is_synthetic            = param.is_synthetic_param();
+                       bool is_looplevel            = param.is_looplevel_param();
+                std::string call_to_string          = is_looplevel ? "" : param.call_to_string(param.name);
                 
-                bool is_looplevel = param->is_looplevel_param();
-                std::string call_to_string = is_looplevel ? "" : param->call_to_string(param->name);
-                
-                io.mapRequired("is_looplevel",       is_looplevel);
-                io.mapRequired("call_to_string",     call_to_string);
+                io.mapRequired("name",              name);
+                io.mapRequired("default",           default_value);
+                io.mapRequired("c_type",            c_type);
+                io.mapRequired("type_decls",        type_decls);
+                io.mapRequired("is_synthetic",      is_synthetic);
+                io.mapRequired("is_looplevel",      is_looplevel);
+                io.mapRequired("call_to_string",    call_to_string);
             }
         };
         
         template <>
-        struct MappingTraits<input_ptr_t> {
-            static void mapping(IO& io, input_ptr_t& param) {
+        struct MappingTraits<input_t> {
+            static void mapping(IO& io, input_t& input) {
             }
         };
         
         template <>
-        struct MappingTraits<output_ptr_t> {
-            static void mapping(IO& io, output_ptr_t& param) {
+        struct MappingTraits<output_t> {
+            static void mapping(IO& io, output_t& output) {
             }
         };
         

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -67,7 +67,7 @@ LLVM_YAML_IS_SEQUENCE_VECTOR(Halide::Type);
 /// … and of YamlEmitters (which act as the top-level class
 /// capable of YAML output serialization in our traited heiarchy):
 
-LLVM_YAML_IS_SEQUENCE_VECTOR(Halide::Internal::YamlEmitter);
+LLVM_YAML_IS_SEQUENCE_VECTOR(Halide::Internal::YamlEmitter const);
 
 namespace Halide {
 

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -390,6 +390,7 @@ public:
 
 protected:
     friend class GeneratorBase;
+    friend class EmitterBase;
     friend class StubEmitter;
 
     void check_value_readable() const;
@@ -1340,6 +1341,7 @@ protected:
 
     void verify_internals() override;
 
+    friend class EmitterBase;
     friend class StubEmitter;
 
     virtual std::string get_c_type() const = 0;
@@ -1961,6 +1963,7 @@ protected:
     ~GeneratorOutputBase() override;
 
     friend class GeneratorBase;
+    friend class EmitterBase;
     friend class StubEmitter;
 
     void init_internals();

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2640,6 +2640,7 @@ public:
         bool emit_static_library{true};
         bool emit_cpp_stub{false};
         bool emit_schedule{false};
+        bool emit_yaml{false};
 
         // This is an optional map used to replace the default extensions generated for
         // a file: if an key matches an output extension, emit those files with the
@@ -2667,7 +2668,8 @@ public:
         return get_target().natural_vector_size<data_t>();
     }
 
-    void emit_cpp_stub(const std::string &stub_file_path);
+    void emit_cpp_stub(std::string const& stub_file_path);
+    void     emit_yaml(std::string const& yaml_file_path);
 
     // Call build() and produce a Module for the result.
     // If function_name is empty, generator_name() will be used for the function.

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -392,6 +392,7 @@ protected:
     friend class GeneratorBase;
     friend class EmitterBase;
     friend class StubEmitter;
+    friend class YamlEmitter;
 
     void check_value_readable() const;
     void check_value_writable() const;
@@ -399,6 +400,7 @@ protected:
     // All GeneratorParams are settable from string.
     virtual void set_from_string(const std::string &value_string) = 0;
 
+public:
     virtual std::string call_to_string(const std::string &v) const = 0;
     virtual std::string get_c_type() const = 0;
 
@@ -416,6 +418,7 @@ protected:
         return false;
     }
 
+protected:
     void fail_wrong_type(const char *type);
 
 private:
@@ -1343,6 +1346,7 @@ protected:
 
     friend class EmitterBase;
     friend class StubEmitter;
+    friend class YamlEmitter;
 
     virtual std::string get_c_type() const = 0;
 
@@ -1965,6 +1969,7 @@ protected:
     friend class GeneratorBase;
     friend class EmitterBase;
     friend class StubEmitter;
+    friend class YamlEmitter;
 
     void init_internals();
     void resize(size_t size);

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1348,8 +1348,10 @@ protected:
     friend class StubEmitter;
     friend class YamlEmitter;
 
+public:
     virtual std::string get_c_type() const = 0;
 
+protected:
     void check_value_writable() const override;
 
     const char *input_or_output() const override { return "Input"; }
@@ -1974,10 +1976,12 @@ protected:
     void init_internals();
     void resize(size_t size);
 
+public:
     virtual std::string get_c_type() const {
         return "Func";
     }
 
+protected:
     void check_value_writable() const override;
 
     const char *input_or_output() const override { return "Output"; }

--- a/src/Outputs.h
+++ b/src/Outputs.h
@@ -58,6 +58,10 @@ struct Outputs {
      * output is desired. */
     std::string schedule_name;
 
+   /** The name of the emitted YAML metadata file.. Empty if no YAML metadata
+    * output is desired. */
+   std::string yaml_name;
+
     /** Make a new Outputs struct that emits everything this one does
      * and also an object file with the given name. */
     Outputs object(const std::string &object_name) const {
@@ -145,6 +149,14 @@ struct Outputs {
         updated.schedule_name = schedule_name;
         return updated;
     }
+
+   /** Make a new Outputs struct that emits everything this one does
+    * and also an YAML metadata output file with the given name. */
+   Outputs yaml(const std::string &yaml_name) const {
+       Outputs updated = *this;
+       updated.yaml_name = yaml_name;
+       return updated;
+   }
 };
 
 }  // namespace Halide


### PR DESCRIPTION
Hi, I added an option to emit a bunch of the metadata relevant to a generator as a YAML file. It works as an emit option from `GenGen.cpp` and is currently correctly outputting some YAML from within the cmake build system. 

Why would anyone want this? I, personally, would like it, for the Python-based generator build system called [halogen](https://github.com/fish2000/halogen) that I am working on currently. But I am not the only one – in doing research for my halogen project, I found something called [ProxImaL](https://github.com/comp-imaging/ProxImaL), which was doing a very similar thing to halogen, wherein it was compiling, loading and on-the-fly executing a Halide C++ generator using [a Python idiom](https://github.com/comp-imaging/ProxImaL/blob/master/proximal/halide/halide.py).

The idea to do this metadata YAML emit thing came to me when I realized that the author(s) of ProxImaL were [manually parsing the Halide generator’s header file output](https://github.com/comp-imaging/ProxImaL/blob/2804c19e141b637a5fcbf92acdcae81cab4c6d1e/proximal/halide/halide.py#L378), in order to discern the parameters to construct a ctypes FFI call in Python. I had reached a similar point in my own code, where I was like, what to do? _There must be a better way_, I thought. And not finding one immediately handy, I wrote it.

I elected to use LLVM’s YAML I/O API – since Halide is based on LLVM, it was the least-dependency-encumbered way to go. I would have personally rather have found a way to emit JSON, but YAML is cool too; I tried to mimic Halide’s semantics and approaches in my additions whenever possible. Most of my changes are confined to `src/Generator.cpp` and are documented throughout with inline comments. The most intrusive change I elected to make was abstracting the `StubEmitter` class into an `EmitterBase` with an abstract virtual `void emit() const` method. `StubEmitter` now inherits from `EmitterBase`, as does the new `YamlEmitter` class. 

There is now a ton of `llvm::yaml`-related stuff in `src/Generator.cpp` now; I suspect that one of the larger objections to this PR will be to all of this; if given a bit of guidance from a senior Halide committer about how to do so, I would be happy to move the LLVM YAML-interfacing code somewhere else.

I have not yet written a test for it, either – I am not sure what the best approach would be in that case. In order of personal preference I could:
* Write a Python script that reads the YAML and checks it – such a script would require a Python installation and a YAML module (likely [PyYAML](https://pypi.org/project/PyYAML/)).
* Write a C++ test program that calls out to e.g. [yaml-cpp](https://github.com/jbeder/yaml-cpp) to ingest and inspect the LLVM-generated output – that would require the aforementioned library or some equivalent.
* Write a C++ test program that uses an alternative hierarchy of `struct`s and a parallel set of LLVM’s YAML I/O traits configured to mimic the current output-only trait scheme, for the purpose of reading and inspecting the current output – that would not have any dependencies but it would be the most bloated and fragile of the options (q.v. [inline notes](https://github.com/fish2000/Halide/blob/527bc2c839a564b92f902552c103162d4b673345/src/Generator.cpp#L514-L535) supra.)

I have also not yet squashed everything down – I am awaiting your feedback as to whether this feature is unwelcome or improper before I presume to proceed with it further. So, erm, yes! Do let me know if this is something people want, and I will put a good shine on it and push it up. 

Thanks!

-Alex