### PR TITLE
Allow declaring Output<Buffer<>> with tuples (Issue #2980)

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1277,9 +1277,12 @@ void GeneratorBase::track_parameter_values(bool include_outputs) {
                 internal_assert(!output->funcs().empty());
                 for (auto &f : output->funcs()) {
                     user_assert(f.defined()) << "Output " << output->name() << " is not fully defined.";
-                    Parameter p = f.output_buffer().parameter();
-                    // This must use p.name(), *not* output->name()
-                    get_value_tracker()->track_values(p.name(), parameter_constraints(p));
+                    auto output_buffers = f.output_buffers();
+                    for (auto &o : output_buffers) {
+                        Parameter p = o.parameter();
+                        // This must use p.name(), *not* output->name()
+                        get_value_tracker()->track_values(p.name(), parameter_constraints(p));
+                    }
                 }
             }
         }

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -53,6 +53,7 @@ public:
     Output<Buffer<float>> type_only_output_buffer{ "type_only_output_buffer" };  // untyped outputs can have type and/or dimensions inferred
     Output<Buffer<>> dim_only_output_buffer{ "dim_only_output_buffer", 3 };  // untyped outputs can have type and/or dimensions inferred
     Output<Buffer<>> untyped_output_buffer{ "untyped_output_buffer" };  // untyped outputs can have type and/or dimensions inferred
+    Output<Buffer<>> tupled_output_buffer{ "tupled_output_buffer", { Float(32), Int(32) }, 3 };
     Output<float> output_scalar{ "output_scalar" };
     Output<Func[]> array_outputs{ "array_outputs", Float(32), 3 };  // must be overridden to size=2
     Output<Func[2]> array_outputs2{ "array_outputs2", { Float(32), Float(32) }, 3 };
@@ -100,6 +101,7 @@ public:
         typed_output_buffer(x, y, c) = f1(x, y, c);
         type_only_output_buffer(x, y, c) = f1(x, y, c);
         dim_only_output_buffer(x, y, c) = f1(x, y, c);
+        tupled_output_buffer(x, y, c) = Tuple(f2(x, y, c), cast<int32_t>(f2(x, y, c) + 1.5f));
         // verify that we can assign a Func to an Output<Buffer<>>
         untyped_output_buffer = f2;
         output_scalar() = 1234.25f;

--- a/test/generator/stubtest_aottest.cpp
+++ b/test/generator/stubtest_aottest.cpp
@@ -50,6 +50,8 @@ int main(int argc, char **argv) {
     Buffer<float> array_input1 = make_image<float>(1);
     Buffer<float> typed_buffer_output(kSize, kSize, 3);
     Buffer<float> untyped_buffer_output(kSize, kSize, 3);
+    Buffer<float> tupled_output0(kSize, kSize, 3);
+    Buffer<int32_t> tupled_output1(kSize, kSize, 3);
     Buffer<uint8_t> array_buffer_input0 = make_image<uint8_t>(0);
     Buffer<uint8_t> array_buffer_input1 = make_image<uint8_t>(1);
     Buffer<float> simple_output(kSize, kSize, 3);
@@ -72,6 +74,7 @@ int main(int argc, char **argv) {
         array_output0, array_output1,
         typed_buffer_output,
         untyped_buffer_output,
+        tupled_output0, tupled_output1,
         static_compiled_buffer_output,
         array_buffer_output0, array_buffer_output1
     );
@@ -79,6 +82,8 @@ int main(int argc, char **argv) {
     verify(buffer_input, 1.f, 0, typed_buffer_output);
     verify(buffer_input, 1.f, 0, untyped_buffer_output);
     verify(simple_input, 1.f, 0, simple_output);
+    verify(simple_input, 1.f, 0, tupled_output0);
+    verify(simple_input, 1.f, 1, tupled_output1);
     verify(array_input0, 1.f, 0, simple_output);
     verify(array_input0, 1.25f, 0, tuple_output0);
     verify(array_input0, 1.25f, 33, tuple_output1);

--- a/test/generator/stubtest_generator.cpp
+++ b/test/generator/stubtest_generator.cpp
@@ -42,6 +42,7 @@ public:
     Output<Func[]> array_output{ "array_output", Int(16), 2};   // leave ArraySize unspecified
     Output<Buffer<float>> typed_buffer_output{ "typed_buffer_output" };
     Output<Buffer<>> untyped_buffer_output{ "untyped_buffer_output" };
+    Output<Buffer<>> tupled_output{ "tupled_output", { Float(32), Int(32) }, 3 };
     Output<Buffer<uint8_t>> static_compiled_buffer_output{ "static_compiled_buffer_output", 3 };
     Output<Buffer<uint8_t>[2]> array_buffer_output{ "array_buffer_output", 3 };
 
@@ -54,6 +55,8 @@ public:
         // will end up as whatever we infer from the values put into it. We'll use an
         // explicit GeneratorParam to allow us to set it.
         untyped_buffer_output(x, y, c) = cast(untyped_buffer_output_type, untyped_buffer_input(x, y, c));
+
+        tupled_output(x, y, c) = Tuple(simple_output(x, y, c), cast<int32_t>(simple_output(x, y, c)) + 1);
 
         for (int i = 0; i < 2; ++i) {
             array_buffer_output[i](x, y, c) = array_buffer_input[i](x, y,c) + 1 + i;

--- a/test/generator/stubuser_aottest.cpp
+++ b/test/generator/stubuser_aottest.cpp
@@ -53,12 +53,16 @@ int main(int argc, char **argv) {
   Buffer<float> float32_buffer_output(kSize, kSize, 3);
   Buffer<> int32_buffer_output(halide_type_t(halide_type_int, 32), kSize, kSize, 3);
   Buffer<uint8_t> array_test_output(kSize, kSize, 3);
+  Buffer<float> tupled_output0(kSize, kSize, 3);
+  Buffer<int32_t> tupled_output1(kSize, kSize, 3);
 
-  stubuser(input, calculated_output, float32_buffer_output, int32_buffer_output, array_test_output);
+  stubuser(input, calculated_output, float32_buffer_output, int32_buffer_output, array_test_output, tupled_output0, tupled_output1);
   verify(input, kFloatArg, kIntArg, kOffset, calculated_output);
   verify(input, 1.f, 0, 0.f, float32_buffer_output);
   verify<uint8_t, int32_t>(input, 1.f, 0, 0.f, int32_buffer_output);
   verify(input, 1.f, 0, 2, array_test_output);
+  verify(input, 1.f, 0, 0, tupled_output0);
+  verify(input, 1.f, 1, 0, tupled_output1);
 
   printf("Success!\n");
   return 0;

--- a/test/generator/stubuser_generator.cpp
+++ b/test/generator/stubuser_generator.cpp
@@ -28,6 +28,8 @@ public:
     Output<Buffer<float>> float32_buffer_output{"float32_buffer_output" };
     Output<Buffer<int32_t>> int32_buffer_output{"int32_buffer_output" };
     Output<Buffer<uint8_t>> array_test_output{"array_test_output" };
+    // We can infer the tupled-output-type from the Stub
+    Output<Buffer<>> tupled_output{ "tupled_output", 3 };
 
     void generate() {
         Var x{"x"}, y{"y"}, c{"c"};
@@ -60,6 +62,7 @@ public:
         float32_buffer_output = out.typed_buffer_output;
         int32_buffer_output = out.untyped_buffer_output;
         array_test_output = out.array_buffer_output[1];
+        tupled_output = out.tupled_output;
 
         const float kOffset = 2.f;
         calculated_output(x, y, c) = cast<uint8_t>(out.tuple_output(x, y, c)[1] + kOffset);


### PR DESCRIPTION
For AOT, this produces an output buffer for each tuple element.