### PR TITLE
Protect against NULL strings in printer as these occur in debugging.

### DIFF
--- a/src/runtime/printer.h
+++ b/src/runtime/printer.h
@@ -46,7 +46,7 @@ public:
     Printer &operator<<(const char *arg) {
         // Crashing on NULL here is a big debugging time sink.
         if (arg == NULL) {
-            dst = halide_string_to_string(dst, end, "<NULL STRING>");
+            dst = halide_string_to_string(dst, end, "<NULL>");
         } else {
             dst = halide_string_to_string(dst, end, arg);
         }

--- a/src/runtime/printer.h
+++ b/src/runtime/printer.h
@@ -44,7 +44,12 @@ public:
     }
 
     Printer &operator<<(const char *arg) {
-        dst = halide_string_to_string(dst, end, arg);
+        // Crashing on NULL here is a big debugging time sink.
+        if (arg == NULL) {
+            dst = halide_string_to_string(dst, end, "<NULL STRING>");
+        } else {
+            dst = halide_string_to_string(dst, end, arg);
+        }
         return *this;
     }
 


### PR DESCRIPTION
Having to protect against them is a hassle and I can't think of any case where the performance hit is worth worrying about.