### PR TITLE
Fix cast that does not result in a type change in OpenGL Compute backend.

### DIFF
--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -106,8 +106,8 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Cast *op) {
     if (map_type(op->type) == map_type(value_type)) {
         Expr value = op->value;
         if (value_type.code() == Type::Float) {
-            // float->int conversions may need explicit truncation if the
-            // integer types is embedded into floats.  (Note: overflows are
+            // float->int conversions may need explicit truncation if an
+            // integer type is embedded into a float. (Note: overflows are
             // considered undefined behavior, so we do nothing about values
             // that are out of range of the target type.)
             if (op->type.code() == Type::UInt) {

--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -103,7 +103,22 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Cast *op) {
     Type value_type = op->value.type();
     // If both types are represented by the same GLSL type, no explicit cast
     // is necessary.
-    if (map_type(op->type) != map_type(value_type)) {
+    if (map_type(op->type) == map_type(value_type)) {
+        Expr value = op->value;
+        if (value_type.code() == Type::Float) {
+            // float->int conversions may need explicit truncation if the
+            // integer types is embedded into floats.  (Note: overflows are
+            // considered undefined behavior, so we do nothing about values
+            // that are out of range of the target type.)
+            if (op->type.code() == Type::UInt) {
+                value = simplify(floor(value));
+            } else if (op->type.code() == Type::Int) {
+                value = simplify(trunc(value));
+            }
+        }
+        value.accept(this);
+        return;
+    } else {
         Type target_type = map_type(op->type);
         print_assignment(target_type, print_type(target_type) + "(" + print_expr(op->value) + ")");
     }

--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -354,8 +354,8 @@ void CodeGen_GLSL::visit(const Cast *op) {
     if (map_type(op->type) == map_type(value_type)) {
         Expr value = op->value;
         if (value_type.code() == Type::Float) {
-            // float->int conversions may need explicit truncation if the
-            // integer types is embedded into floats.  (Note: overflows are
+            // float->int conversions may need explicit truncation if an
+            // integer type is embedded into a float. (Note: overflows are
             // considered undefined behavior, so we do nothing about values
             // that are out of range of the target type.)
             if (op->type.code() == Type::UInt) {

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -195,9 +195,9 @@ public:
 
     /** Emit a Python extension glue .c file. */
     void compile_to_python_extension(const std::string &filename,
-				     const std::vector<Argument> &args,
-				     const std::string &fn_name,
-				     const Target &target = get_target_from_environment());
+                                     const std::vector<Argument> &args,
+                                     const std::string &fn_name,
+                                     const Target &target = get_target_from_environment());
 
     /** Write out an internal representation of lowered code. Useful
      * for analyzing and debugging scheduling. Can emit html or plain


### PR DESCRIPTION
Previously this resulted in a "BAD ID" being generated.

Unrelated tab fix.