### PR TITLE
Fix bugs in auto-scheduler string generator

### DIFF
--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -775,6 +775,9 @@ struct AutoSchedule {
     }
 
     friend std::ostream& operator<<(std::ostream &stream, const AutoSchedule &sched) {
+        stream << "// Delete this line if not using Generator\n";
+        stream << "Pipeline pipeline = get_pipeline();\n\n";
+
         for (const auto &iter : sched.internal_vars) {
             if (iter.second.is_rvar) {
                 stream << "RVar ";

--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -807,7 +807,7 @@ struct AutoSchedule {
             set<string> declared_rvars;
             for (size_t i = 0; i < func.updates().size(); ++i) {
                 const vector<ReductionVariable> &rvars = func.updates()[i].schedule().rvars();
-                const set<string> &var_list = sched.used_vars.at(func.name()).at(i);
+                const set<string> &var_list = sched.used_vars.at(func.name()).at(i+1);
                 for (size_t j = 0; j < rvars.size(); ++j) {
                     if ((var_list.find(rvars[j].var) == var_list.end()) ||
                         (declared_rvars.find(rvars[j].var) != declared_rvars.end())) {
@@ -2601,7 +2601,7 @@ void Partitioner::reorder_dims(Stage f_handle, int stage_num, Definition def,
     }
 
     internal_assert(!ordering.empty());
-    set<string> var_list;
+    set<string> var_list = {ordering[0].name()};
     string var_order = ordering[0].name();
     for (size_t o = 1; o < ordering.size(); o++) {
         var_order += ", " + ordering[o].name();


### PR DESCRIPTION
Added call to get_pipeline() to the str version since auto-sched is mostly called on a Generator. Fixed bugs in stage indexing when declaring the RVars used. (Fix bugs in #2824)