### PR TITLE
Fix D3D12 issues

### DIFF
--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -1061,8 +1061,6 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::add_kernel(Stmt s,
     }
 
     stream << "\n";
-
-    return;
 }
 
 void CodeGen_D3D12Compute_Dev::init_module() {

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -675,7 +675,8 @@ string CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::print_reinterpret_cast(
     cast_expr += "as";
     switch (type.code()) {
         case halide_type_uint :
-            cast_expr += "u";
+            cast_expr += "uint";
+            break;
         case halide_type_int :
             cast_expr += "int";
             break;
@@ -1090,7 +1091,7 @@ void CodeGen_D3D12Compute_Dev::init_module() {
         << "\n";
 
     // Write out the Halide math functions.
-    src_stream 
+    src_stream
              //<< "namespace {\n"   // HLSL does not support unnamed namespaces...
                #if DEBUG_TYPES
                << "#define  int8   int\n"

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -79,6 +79,9 @@ DECLARE_CPP_INITMOD(cuda)
 #ifdef WITH_D3D12
 DECLARE_LL_INITMOD(d3d12_abi_patch_64)
 DECLARE_CPP_INITMOD(d3d12compute)
+#else
+DECLARE_NO_INITMOD(d3d12_abi_patch_64)
+DECLARE_NO_INITMOD(d3d12compute)
 #endif
 DECLARE_CPP_INITMOD(destructors)
 DECLARE_CPP_INITMOD(device_interface)


### PR DESCRIPTION
- avoid the use of fallthru-without-break in CodeGen_D3D12Compute_Dev.cpp (some compiler settings assume this is an error, and the conventional equivalent is fine here)
- allow runtime linker to compile when WITH_D3D12 is not defined