### PR TITLE
Fix some pathological behavior in warp shuffles

### DIFF
--- a/src/LowerWarpShuffles.cpp
+++ b/src/LowerWarpShuffles.cpp
@@ -84,32 +84,40 @@ Expr reduce_expr(Expr e, Expr modulus, const Scope<Interval> &bounds) {
 
 
 // Substitute the gpu loop variables inwards to make future passes simpler
-class SubstituteInGPUVars : public IRMutator2 {
+class SubstituteInLaneVar : public IRMutator2 {
     using IRMutator2::visit;
 
     Scope<int> gpu_vars;
+    string lane_var;
 
-    Expr visit(const Let *op) override {
-        if (expr_uses_vars(op->value, gpu_vars) && is_pure(op->value)) {
-            return mutate(substitute(op->name, op->value, op->body));
+    template<typename LetStmtOrLet>
+    auto visit_let(const LetStmtOrLet *op) -> decltype(op->body) {
+        if (!lane_var.empty() && expr_uses_var(op->value, lane_var) && is_pure(op->value)) {
+            auto solved = solve_expression(simplify(op->value), lane_var);
+            if (solved.fully_solved) {
+                return mutate(substitute(op->name, solved.result, op->body));
+            } else {
+                return IRMutator2::visit(op);
+            }
         } else {
             return IRMutator2::visit(op);
         }
+    }
+
+    Expr visit(const Let *op) override {
+        return visit_let(op);
     }
 
     Stmt visit(const LetStmt *op) override {
-        if (expr_uses_vars(op->value, gpu_vars) && is_pure(op->value)) {
-            return mutate(substitute(op->name, op->value, op->body));
-        } else {
-            return IRMutator2::visit(op);
-        }
+        return visit_let(op);
     }
 
     Stmt visit(const For *op) override {
-        ScopedBinding<int> bind_if(op->for_type == ForType::GPUBlock ||
-                                   op->for_type == ForType::GPUThread ||
-                                   op->for_type == ForType::GPULane,
-                                   gpu_vars, op->name, 0);
+
+        if (op->for_type == ForType::GPULane) {
+            lane_var = op->name;
+        }
+
         return IRMutator2::visit(op);
     }
 };
@@ -286,13 +294,14 @@ public:
                 stride = s;
             }
 
-            internal_assert(stride.defined());
-
             // Check the striping pattern of this store corresponds to
             // any already discovered on previous stores.
             bool this_ok = (s.defined() &&
                             (can_prove(stride == s) &&
                              can_prove(reduce_expr(e / stride - var, warp_size, bounds) == 0)));
+
+            internal_assert(stride.defined());
+
             if (!this_ok) {
                 bad.push_back(e);
             }
@@ -795,8 +804,8 @@ class LowerWarpShufflesInEachKernel : public IRMutator2 {
 
 Stmt lower_warp_shuffles(Stmt s) {
     s = loop_invariant_code_motion(s);
-    s = SubstituteInGPUVars().mutate(s);
-    s = simplify_exprs(s);
+    s = SubstituteInLaneVar().mutate(s);
+    s = simplify(s);
     s = LowerWarpShufflesInEachKernel().mutate(s);
     return s;
 };

--- a/src/UnifyDuplicateLets.cpp
+++ b/src/UnifyDuplicateLets.cpp
@@ -67,10 +67,11 @@ protected:
         }
     }
 
-    Stmt visit(const LetStmt *op) override {
+    template<typename LetStmtOrLet>
+    auto visit_let(const LetStmtOrLet *op) -> decltype(op->body) {
         is_impure = false;
         Expr value = mutate(op->value);
-        Stmt body = op->body;
+        auto body = op->body;
 
         bool should_pop = false;
         bool should_erase = false;
@@ -99,8 +100,16 @@ protected:
         if (value.same_as(op->value) && body.same_as(op->body)) {
             return op;
         } else {
-            return LetStmt::make(op->name, value, body);
+            return LetStmtOrLet::make(op->name, value, body);
         }
+    }
+
+    Expr visit(const Let *op) override {
+        return visit_let(op);
+    }
+
+    Stmt visit(const LetStmt *op) override {
+        return visit_let(op);
     }
 };
 

--- a/test/correctness/register_shuffle.cpp
+++ b/test/correctness/register_shuffle.cpp
@@ -7,13 +7,8 @@ int main(int argc, char **argv) {
 
     if (!t.features_any_of({Target::CUDACapability50,
                             Target::CUDACapability61})) {
-        if (t.has_feature(Target::CUDA)) {
-            // Optimistically turn on capability 5, otherwise this test will never run on the buildbots
-            t.set_feature(Target::CUDACapability50);
-        } else {
-            printf("This test requires cuda enabled with cuda capability 3.0 or greater\n");
-            return 0;
-        }
+        printf("This test requires cuda enabled with cuda capability 5.0 or greater\n");
+        return 0;
     }
 
     {


### PR DESCRIPTION
There was a combinatorial explosion caused by an unconditional substitution of gpu lane variables.