### PR TITLE
Add some HalideBuffer convenience methods (Issue #3113)

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1682,14 +1682,6 @@ public:
         return dst;
     }
 
-    /** Make a buffer with the same shape and type and memory nesting order as
-     * this buffer; this is syntactic sugar for the static make_with_shape_of method
-     * when src and dst types are identical. */
-    Buffer<T, D> make_with_shape_of(void *(*allocate_fn)(size_t) = nullptr,
-                                    void (*deallocate_fn)(void *) = nullptr) {
-        return make_with_shape_of(*this, allocate_fn, deallocate_fn);
-    }
-
 private:
 
     template<typename ...Args>

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -576,6 +576,13 @@ public:
         return (size_t)((const uint8_t *)end() - (const uint8_t *)begin());
     }
 
+    /** Reset the Buffer to be equivalent to a default-constructed Buffer
+     * of the same static type (if any); Buffer<void> will have its runtime
+     * type reset to uint8. The resulting buffer will have 0 dimensions and 1 element. */
+    void reset() {
+        *this = Buffer();
+    }
+
     Buffer() : shape() {
         buf.type = static_halide_type();
         make_shape_storage();
@@ -1098,9 +1105,10 @@ public:
      * or slice followed by copy to make a copy of only a portion of
      * the image. The new image uses the same memory layout as the
      * original, with holes compacted away. */
-    Buffer<T, D> copy(void *(*allocate_fn)(size_t) = nullptr,
+    template<typename T2 = T, int D2 = D>
+    Buffer<T2, D2> copy(void *(*allocate_fn)(size_t) = nullptr,
                       void (*deallocate_fn)(void *) = nullptr) const {
-        Buffer<T, D> dst = make_with_shape_of(*this, allocate_fn, deallocate_fn);
+        Buffer<T2, D2> dst = Buffer<T2, D2>::make_with_shape_of(*this, allocate_fn, deallocate_fn);
         dst.copy_from(*this);
         return dst;
     }
@@ -1672,6 +1680,14 @@ public:
         dst.allocate(allocate_fn, deallocate_fn);
 
         return dst;
+    }
+
+    /** Make a buffer with the same shape and type and memory nesting order as
+     * this buffer; this is syntactic sugar for the static make_with_shape_of method
+     * when src and dst types are identical. */
+    Buffer<T, D> make_with_shape_of(void *(*allocate_fn)(size_t) = nullptr,
+                                    void (*deallocate_fn)(void *) = nullptr) {
+        return make_with_shape_of(*this, allocate_fn, deallocate_fn);
     }
 
 private:

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -578,7 +578,7 @@ public:
 
     /** Reset the Buffer to be equivalent to a default-constructed Buffer
      * of the same static type (if any); Buffer<void> will have its runtime
-     * type reset to uint8. The resulting buffer will have 0 dimensions and 1 element. */
+     * type reset to uint8. */
     void reset() {
         *this = Buffer();
     }

--- a/test/correctness/halide_buffer.cpp
+++ b/test/correctness/halide_buffer.cpp
@@ -54,8 +54,12 @@ void test_copy(Buffer<float> a, Buffer<float> b) {
     check_equal(a_window, b_window);
 
     // Check copying from const to nonconst
-    Buffer<float> a_window_2 = b_window.copy<float>();
-    check_equal(a_window_2, b_window);
+    Buffer<float> a_window_nonconst = b_window.copy();
+    check_equal(a_window_nonconst, b_window);
+
+    // Check copying from const to const
+    Buffer<const float> a_window_const = b_window.copy();
+    check_equal(a_window_const, b_window);
 
     // You don't actually have to crop a.
     a.fill(1.0f);
@@ -206,25 +210,6 @@ int main(int argc, char **argv) {
         // the halide_buffer_t.
         for (size_t i = sizeof(halide_buffer_t); i < sizeof(buf); i++) {
             assert(!buf[i]);
-        }
-    }
-
-    {
-        // check make_with_shape_of()
-        Buffer<float> a = Buffer<float>::make_interleaved(100, 3, 80);
-        Buffer<float> b = a.make_with_shape_of(a);
-        Buffer<int> b_int = Buffer<int>::make_with_shape_of(a);
-
-        assert(a.dimensions() == 3);
-        assert(b.dimensions() == 3);
-        assert(b_int.dimensions() == 3);
-        for (int i = 0; i < 3; i++) {
-            assert(a.dim(i).min() == b.dim(i).min());
-            assert(a.dim(i).min() == b_int.dim(i).min());
-            assert(a.dim(i).extent() == b.dim(i).extent());
-            assert(a.dim(i).extent() == b_int.dim(i).extent());
-            assert(a.dim(i).stride() == b.dim(i).stride());
-            assert(a.dim(i).stride() == b_int.dim(i).stride());
         }
     }
 

--- a/test/correctness/halide_buffer.cpp
+++ b/test/correctness/halide_buffer.cpp
@@ -53,6 +53,10 @@ void test_copy(Buffer<float> a, Buffer<float> b) {
 
     check_equal(a_window, b_window);
 
+    // Check copying from const to nonconst
+    Buffer<float> a_window_2 = b_window.copy<float>();
+    check_equal(a_window_2, b_window);
+
     // You don't actually have to crop a.
     a.fill(1.0f);
     a.copy_from(b_window);
@@ -203,6 +207,50 @@ int main(int argc, char **argv) {
         for (size_t i = sizeof(halide_buffer_t); i < sizeof(buf); i++) {
             assert(!buf[i]);
         }
+    }
+
+    {
+        // check make_with_shape_of()
+        Buffer<float> a = Buffer<float>::make_interleaved(100, 3, 80);
+        Buffer<float> b = a.make_with_shape_of(a);
+        Buffer<int> b_int = Buffer<int>::make_with_shape_of(a);
+
+        assert(a.dimensions() == 3);
+        assert(b.dimensions() == 3);
+        assert(b_int.dimensions() == 3);
+        for (int i = 0; i < 3; i++) {
+            assert(a.dim(i).min() == b.dim(i).min());
+            assert(a.dim(i).min() == b_int.dim(i).min());
+            assert(a.dim(i).extent() == b.dim(i).extent());
+            assert(a.dim(i).extent() == b_int.dim(i).extent());
+            assert(a.dim(i).stride() == b.dim(i).stride());
+            assert(a.dim(i).stride() == b_int.dim(i).stride());
+        }
+    }
+
+    {
+        // check reset()
+        Buffer<float> a(100, 3, 80);
+
+        assert(a.dimensions() == 3);
+        assert(a.number_of_elements() == 100 * 3 * 80);
+        assert(a.type() == halide_type_of<float>());
+
+        a.reset();
+        assert(a.dimensions() == 0);
+        assert(a.number_of_elements() == 1);
+        assert(a.type() == halide_type_of<float>());
+
+        Buffer<> b(halide_type_of<float>(), 10, 10);
+
+        assert(b.dimensions() == 2);
+        assert(b.number_of_elements() == 10 * 10);
+        assert(b.type() == halide_type_of<float>());
+
+        b.reset();
+        assert(b.dimensions() == 0);
+        assert(b.number_of_elements() == 1);
+        assert(b.type() == halide_type_of<uint8_t>());
     }
 
     printf("Success!\n");


### PR DESCRIPTION
- augment copy() to allow copying-to-a-different-type
- add nonstatic variant of make_with_shape_of()
- add reset()