### PR TITLE
Add a function to the device interface to query compute version

### DIFF
--- a/src/DeviceInterface.cpp
+++ b/src/DeviceInterface.cpp
@@ -32,7 +32,7 @@ bool lookup_runtime_routine(const std::string &name,
 
 const halide_device_interface_t *get_device_interface_for_device_api(DeviceAPI d, const Target &t,
                                                                      const char *error_site) {
-  
+
   if (d == DeviceAPI::Default_GPU) {
         d = get_default_device_api_for_target(t);
         if (d == DeviceAPI::Host) {

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -616,6 +616,13 @@ enum RuntimeKind {
     OpenGLCompute,
     Hexagon,
     D3D12Compute,
+    OpenCLDebug,
+    MetalDebug,
+    CUDADebug,
+    OpenGLDebug,
+    OpenGLComputeDebug,
+    HexagonDebug,
+    D3D12ComputeDebug,
     MaxRuntimeKind
 };
 
@@ -651,36 +658,57 @@ JITModule &make_module(llvm::Module *for_module, Target target,
         one_gpu.set_feature(Target::D3D12Compute, false);
         string module_name;
         switch (runtime_kind) {
-        case OpenCL:
+        case OpenCLDebug:
+            one_gpu.set_feature(Target::Debug);
+            module_name = "debug_";
+        case OpenCL: // fallthrough
             one_gpu.set_feature(Target::OpenCL);
-            module_name = "opencl";
+            module_name += "opencl";
             break;
-        case Metal:
+        case MetalDebug:
+            one_gpu.set_feature(Target::Debug);
+            module_name = "debug_";
+        case Metal: // fallthough
             one_gpu.set_feature(Target::Metal);
-            module_name = "metal";
+            module_name += "metal";
             load_metal();
             break;
-        case CUDA:
+        case CUDADebug:
+            one_gpu.set_feature(Target::Debug);
+            module_name = "debug_";
+        case CUDA: // fallthrough
             one_gpu.set_feature(Target::CUDA);
-            module_name = "cuda";
+            module_name += "cuda";
             break;
-        case OpenGL:
+        case OpenGLDebug:
+            one_gpu.set_feature(Target::Debug);
+            module_name = "debug_";
+        case OpenGL: // fallthrough
             one_gpu.set_feature(Target::OpenGL);
-            module_name = "opengl";
+            module_name += "opengl";
             load_opengl();
             break;
-        case OpenGLCompute:
+        case OpenGLComputeDebug:
+            one_gpu.set_feature(Target::Debug);
+            module_name = "debug_";
+        case OpenGLCompute: // fallthrough
             one_gpu.set_feature(Target::OpenGLCompute);
-            module_name = "openglcompute";
+            module_name += "openglcompute";
             load_opengl();
             break;
+        case HexagonDebug:
+            one_gpu.set_feature(Target::Debug);
+            module_name = "debug_";
         case Hexagon:
             one_gpu.set_feature(Target::HVX_64);
-            module_name = "hexagon";
+            module_name += "hexagon";
             break;
-        case D3D12Compute:
+        case D3D12ComputeDebug:
+            one_gpu.set_feature(Target::Debug);
+            module_name = "debug_";
+        case D3D12Compute: // fallthrough
             one_gpu.set_feature(Target::D3D12Compute);
-            module_name = "d3d12compute";
+            module_name += "d3d12compute";
             #if !defined(_WIN32)
                 internal_error << "JIT support for Direct3D 12 is only implemented on Windows 10 and above.\n";
             #endif
@@ -791,43 +819,50 @@ std::vector<JITModule> JITSharedRuntime::get(llvm::Module *for_module, const Tar
     // Add all requested GPU modules, each only depending on the main shared runtime.
     std::vector<JITModule> gpu_modules;
     if (target.has_feature(Target::OpenCL)) {
-        JITModule m = make_module(for_module, target, OpenCL, result, create);
+        auto kind = target.has_feature(Target::Debug) ? OpenCLDebug : OpenCL;
+        JITModule m = make_module(for_module, target, kind, result, create);
         if (m.compiled()) {
             result.push_back(m);
         }
     }
     if (target.has_feature(Target::Metal)) {
-        JITModule m = make_module(for_module, target, Metal, result, create);
+        auto kind = target.has_feature(Target::Debug) ? MetalDebug : Metal;
+        JITModule m = make_module(for_module, target, kind, result, create);
         if (m.compiled()) {
             result.push_back(m);
         }
     }
     if (target.has_feature(Target::CUDA)) {
-        JITModule m = make_module(for_module, target, CUDA, result, create);
+        auto kind = target.has_feature(Target::Debug) ? CUDADebug : CUDA;
+        JITModule m = make_module(for_module, target, kind, result, create);
         if (m.compiled()) {
             result.push_back(m);
         }
     }
     if (target.has_feature(Target::OpenGL)) {
-        JITModule m = make_module(for_module, target, OpenGL, result, create);
+        auto kind = target.has_feature(Target::Debug) ? OpenGLDebug : OpenGL;
+        JITModule m = make_module(for_module, target, kind, result, create);
         if (m.compiled()) {
             result.push_back(m);
         }
     }
     if (target.has_feature(Target::OpenGLCompute)) {
-        JITModule m = make_module(for_module, target, OpenGLCompute, result, create);
+        auto kind = target.has_feature(Target::Debug) ? OpenGLComputeDebug : OpenGLCompute;
+        JITModule m = make_module(for_module, target, kind, result, create);
         if (m.compiled()) {
             result.push_back(m);
         }
     }
     if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
-        JITModule m = make_module(for_module, target, Hexagon, result, create);
+        auto kind = target.has_feature(Target::Debug) ? HexagonDebug : Hexagon;
+        JITModule m = make_module(for_module, target, kind, result, create);
         if (m.compiled()) {
             result.push_back(m);
         }
     }
     if (target.has_feature(Target::D3D12Compute)) {
-        JITModule m = make_module(for_module, target, D3D12Compute, result, create);
+        auto kind = target.has_feature(Target::Debug) ? D3D12ComputeDebug : D3D12Compute;
+        JITModule m = make_module(for_module, target, kind, result, create);
         if (m.compiled()) {
             result.push_back(m);
         }

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -179,9 +179,7 @@ Target get_host_target() {
 
 namespace {
 
-Target::Feature calculate_host_cuda_capability() {
-    Target t = get_host_target();
-    t.set_feature(Target::CUDA);
+Target::Feature calculate_host_cuda_capability(Target t) {
     const auto *interface = get_device_interface_for_device_api(DeviceAPI::CUDA, t);
     internal_assert(interface->compute_capability);
     int major, minor;
@@ -203,8 +201,8 @@ Target::Feature calculate_host_cuda_capability() {
     }
 }
 
-Target::Feature get_host_cuda_capability() {
-    static Target::Feature cap = calculate_host_cuda_capability();
+Target::Feature get_host_cuda_capability(Target t) {
+    static Target::Feature cap = calculate_host_cuda_capability(t);
     return cap;
 }
 
@@ -414,7 +412,7 @@ bool merge_string(Target &t, const std::string &target) {
         !t.has_feature(Target::CUDACapability50) &&
         !t.has_feature(Target::CUDACapability61)) {
         // Detect host cuda capability
-        t.set_feature(get_host_cuda_capability());
+        t.set_feature(get_host_cuda_capability(t));
     }
 
     if (arch_specified && !bits_specified) {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -8,6 +8,7 @@
 #include "Error.h"
 #include "LLVM_Headers.h"
 #include "Util.h"
+#include "DeviceInterface.h"
 
 #if defined(__powerpc__) && defined(__linux__)
 // This uses elf.h and must be included after "LLVM_Headers.h", which
@@ -160,6 +161,8 @@ Target calculate_host_target() {
 #endif
 #endif
 
+    Target t(os, arch, bits, initial_features);
+
     return Target(os, arch, bits, initial_features);
 }
 
@@ -175,6 +178,35 @@ Target get_host_target() {
 }
 
 namespace {
+
+Target::Feature calculate_host_cuda_capability() {
+    Target t = get_host_target();
+    t.set_feature(Target::CUDA);
+    const auto *interface = get_device_interface_for_device_api(DeviceAPI::CUDA, t);
+    internal_assert(interface->compute_capability);
+    int major, minor;
+    int err = interface->compute_capability(nullptr, &major, &minor);
+    internal_assert(err == 0) << "Failed to query cuda compute capability\n";
+    int ver = major*10 + minor;
+    if (ver < 30) {
+        return Target::FeatureEnd;
+    } else if (ver < 32) {
+        return Target::CUDACapability30;
+    } else if (ver < 35) {
+        return Target::CUDACapability32;
+    } else if (ver < 50) {
+        return Target::CUDACapability35;
+    } else if (ver < 61) {
+        return Target::CUDACapability50;
+    } else {
+        return Target::CUDACapability61;
+    }
+}
+
+Target::Feature get_host_cuda_capability() {
+    static Target::Feature cap = calculate_host_cuda_capability();
+    return cap;
+}
 
 const std::map<std::string, Target::OS> os_name_map = {
     {"os_unknown", Target::OSUnknown},
@@ -334,6 +366,7 @@ bool merge_string(Target &t, const std::string &target) {
     tokens.push_back(rest);
 
     bool os_specified = false, arch_specified = false, bits_specified = false, features_specified = false;
+    bool is_host = false;
 
     for (size_t i = 0; i < tokens.size(); i++) {
         const string &tok = tokens[i];
@@ -344,6 +377,7 @@ bool merge_string(Target &t, const std::string &target) {
                 // "host" is now only allowed as the first token.
                 return false;
             }
+            is_host = true;
             t = get_host_target();
         } else if (tok == "32" || tok == "64" || tok == "0") {
             if (bits_specified) {
@@ -370,6 +404,17 @@ bool merge_string(Target &t, const std::string &target) {
         } else {
             return false;
         }
+    }
+
+    if (is_host &&
+        t.has_feature(Target::CUDA) &&
+        !t.has_feature(Target::CUDACapability30) &&
+        !t.has_feature(Target::CUDACapability32) &&
+        !t.has_feature(Target::CUDACapability35) &&
+        !t.has_feature(Target::CUDACapability50) &&
+        !t.has_feature(Target::CUDACapability61)) {
+        // Detect host cuda capability
+        t.set_feature(get_host_cuda_capability());
     }
 
     if (arch_specified && !bits_specified) {

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -568,6 +568,7 @@ struct halide_device_interface_t {
     int (*wrap_native)(void *user_context, struct halide_buffer_t *buf, uint64_t handle,
                        const struct halide_device_interface_t *device_interface);
     int (*detach_native)(void *user_context, struct halide_buffer_t *buf);
+    int (*compute_capability)(void *user_context, int *major, int *minor);
     const struct halide_device_interface_impl_t *impl;
 };
 

--- a/src/runtime/cuda.cpp
+++ b/src/runtime/cuda.cpp
@@ -690,12 +690,16 @@ WEAK int do_multidimensional_copy(void *user_context, const device_copy &c,
                             << " to " << (to_host ? "host" : "device") << ", "
                             << (void *)src << " -> " << (void *)dst << ", " << c.chunk_size << " bytes\n";
         if (!from_host && to_host) {
+            copy_name = "cuMemcpyDtoH";
             err = cuMemcpyDtoH((void *)dst, (CUdeviceptr)src, c.chunk_size);
         } else if (from_host && !to_host) {
+            copy_name = "cuMemcpyHtoD";
             err = cuMemcpyHtoD((CUdeviceptr)dst, (void *)src, c.chunk_size);
         } else if (!from_host && !to_host) {
+            copy_name = "cuMemcpyDtoD";
             err = cuMemcpyDtoD((CUdeviceptr)dst, (CUdeviceptr)src, c.chunk_size);
         } else if (dst != src) {
+            copy_name = "memcpy";
             // Could reach here if a user called directly into the
             // cuda API for a device->host copy on a source buffer
             // with device_dirty = false.

--- a/src/runtime/cuda_functions.h
+++ b/src/runtime/cuda_functions.h
@@ -26,6 +26,7 @@ CUDA_FN_3020(CUresult, cuCtxCreate, cuCtxCreate_v2, (CUcontext *pctx, unsigned i
 CUDA_FN_4000(CUresult, cuCtxDestroy, cuCtxDestroy_v2, (CUcontext pctx));
 CUDA_FN(CUresult, cuProfilerStop, ());
 CUDA_FN(CUresult, cuCtxGetApiVersion, (CUcontext ctx, unsigned int *version));
+CUDA_FN(CUresult, cuCtxGetDevice, (CUdevice *));
 CUDA_FN(CUresult, cuModuleLoadData, (CUmodule *module, const void *image));
 CUDA_FN(CUresult, cuModuleLoadDataEx, (CUmodule *module, const void *image, unsigned int numOptions, CUjit_option* options, void** optionValues));
 CUDA_FN(CUresult, cuModuleUnload, (CUmodule module));

--- a/src/runtime/d3d12compute.cpp
+++ b/src/runtime/d3d12compute.cpp
@@ -2841,7 +2841,7 @@ WEAK halide_device_interface_t d3d12compute_device_interface = {
     halide_device_release_crop,
     halide_device_wrap_native,
     halide_device_detach_native,
-    nullptr,
+    NULL,
     &d3d12compute_device_interface_impl
 };
 

--- a/src/runtime/d3d12compute.cpp
+++ b/src/runtime/d3d12compute.cpp
@@ -2631,7 +2631,7 @@ WEAK int halide_d3d12compute_device_and_host_malloc(void *user_context, struct h
     void *host = d3d12_malloc(buffer->size_in_bytes());
     buffer->host = (uint8_t*)host;
     dev_buffer->host_mirror = host;
-    debug(user_context) << TRACEINDENT 
+    debug(user_context) << TRACEINDENT
                         << "halide_d3d12compute_device_and_host_malloc"
                         << " device = " << (void*)buffer->device
                         << " d3d12_buffer = " << dev_buffer
@@ -2841,6 +2841,7 @@ WEAK halide_device_interface_t d3d12compute_device_interface = {
     halide_device_release_crop,
     halide_device_wrap_native,
     halide_device_detach_native,
+    nullptr,
     &d3d12compute_device_interface_impl
 };
 

--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -875,6 +875,7 @@ WEAK halide_device_interface_t hexagon_device_interface = {
     halide_device_release_crop,
     halide_device_wrap_native,
     halide_device_detach_native,
+    nullptr,
     &hexagon_device_interface_impl
 };
 

--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -875,7 +875,7 @@ WEAK halide_device_interface_t hexagon_device_interface = {
     halide_device_release_crop,
     halide_device_wrap_native,
     halide_device_detach_native,
-    nullptr,
+    NULL,
     &hexagon_device_interface_impl
 };
 

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -982,7 +982,7 @@ WEAK halide_device_interface_t metal_device_interface = {
     halide_device_release_crop,
     halide_device_wrap_native,
     halide_device_detach_native,
-    nullptr,
+    NULL,
     &metal_device_interface_impl
 };
 

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -982,6 +982,7 @@ WEAK halide_device_interface_t metal_device_interface = {
     halide_device_release_crop,
     halide_device_wrap_native,
     halide_device_detach_native,
+    nullptr,
     &metal_device_interface_impl
 };
 

--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -1332,7 +1332,7 @@ WEAK halide_device_interface_t opencl_device_interface = {
     halide_device_release_crop,
     halide_device_wrap_native,
     halide_device_detach_native,
-    nullptr,
+    NULL,
     &opencl_device_interface_impl
 };
 

--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -1332,6 +1332,7 @@ WEAK halide_device_interface_t opencl_device_interface = {
     halide_device_release_crop,
     halide_device_wrap_native,
     halide_device_detach_native,
+    nullptr,
     &opencl_device_interface_impl
 };
 

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -2073,6 +2073,7 @@ WEAK halide_device_interface_t opengl_device_interface = {
     halide_device_release_crop,
     halide_device_wrap_native,
     halide_device_detach_native,
+    nullptr,
     &opengl_device_interface_impl
 };
 

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -2073,7 +2073,7 @@ WEAK halide_device_interface_t opengl_device_interface = {
     halide_device_release_crop,
     halide_device_wrap_native,
     halide_device_detach_native,
-    nullptr,
+    NULL,
     &opengl_device_interface_impl
 };
 

--- a/src/runtime/openglcompute.cpp
+++ b/src/runtime/openglcompute.cpp
@@ -707,7 +707,7 @@ WEAK halide_device_interface_t openglcompute_device_interface = {
     halide_device_release_crop,
     halide_device_wrap_native,
     halide_device_detach_native,
-    nullptr,
+    NULL,
     &openglcompute_device_interface_impl
 };
 

--- a/src/runtime/openglcompute.cpp
+++ b/src/runtime/openglcompute.cpp
@@ -707,6 +707,7 @@ WEAK halide_device_interface_t openglcompute_device_interface = {
     halide_device_release_crop,
     halide_device_wrap_native,
     halide_device_detach_native,
+    nullptr,
     &openglcompute_device_interface_impl
 };
 

--- a/test/correctness/load_library.cpp
+++ b/test/correctness/load_library.cpp
@@ -60,6 +60,12 @@ void *my_get_library_symbol_impl(void *lib, const char *name) {
 }
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (!target.has_feature(Target::OpenCL)) {
+        printf("This test requires opencl");
+        return 0;
+    }
+
     // These calls are only available for AOT-compiled code:
     //
     //   halide_set_custom_get_symbol(my_get_symbol_impl);
@@ -77,7 +83,6 @@ int main(int argc, char **argv) {
     Var x, y, xi, yi;
     Func f;
     f(x, y) = cast<int32_t>(x + y);
-    Target target = get_jit_target_from_environment().with_feature(Target::OpenCL);
     f.gpu_tile(x, y, xi, yi, 8, 8, TailStrategy::Auto, DeviceAPI::OpenCL);
     f.set_error_handler(my_error_handler);
 


### PR DESCRIPTION
It's annoying that host-cuda generates code for lowest-common-denominator devices. In particular, this means that higher level features aren't tested on the buildbots, which have a range of cards.

This PR adds a device interface to query the compute version. Only implemented for cuda, but would clearly be useful for other backends too. I used it to turn on CUDACapability flags appropriately when target is something like "host-cuda".

This should reveal a breakage in the register_shuffle test on the bots, which I fix in #3172 

