### PR TITLE
Make bounds queries come in via a different entrypoint

### DIFF
--- a/apps/linear_algebra/src/blas_l1_generators.cpp
+++ b/apps/linear_algebra/src/blas_l1_generators.cpp
@@ -46,7 +46,6 @@ class AXPYGenerator :
 
     void generate() {
         assert(get_target().has_feature(Target::NoAsserts));
-        assert(get_target().has_feature(Target::NoBoundsQuery));
 
         const int vec_size = vectorize_? natural_vector_size(type_of<T>()): 1;
         Expr size = x_.width();
@@ -96,7 +95,6 @@ class DotGenerator :
 
     void generate() {
         assert(get_target().has_feature(Target::NoAsserts));
-        assert(get_target().has_feature(Target::NoBoundsQuery));
 
         const int vec_size = vectorize_? natural_vector_size(type_of<T>()): 1;
         Expr size = x_.width();
@@ -151,7 +149,6 @@ class AbsSumGenerator :
 
     void generate() {
         assert(get_target().has_feature(Target::NoAsserts));
-        assert(get_target().has_feature(Target::NoBoundsQuery));
 
         const int vec_size = vectorize_? natural_vector_size(type_of<T>()): 1;
         Expr size = x_.width();
@@ -191,4 +188,3 @@ HALIDE_REGISTER_GENERATOR(DotGenerator<float>, sdot)
 HALIDE_REGISTER_GENERATOR(DotGenerator<double>, ddot)
 HALIDE_REGISTER_GENERATOR(AbsSumGenerator<float>, sasum)
 HALIDE_REGISTER_GENERATOR(AbsSumGenerator<double>, dasum)
-

--- a/apps/linear_algebra/src/blas_l2_generators.cpp
+++ b/apps/linear_algebra/src/blas_l2_generators.cpp
@@ -33,7 +33,6 @@ class GEMVGenerator :
 
     void generate() {
         assert(get_target().has_feature(Target::NoAsserts));
-        assert(get_target().has_feature(Target::NoBoundsQuery));
 
         const int vec_size = vectorize_? natural_vector_size(type_of<T>()): 1;
         const int unroll_size = 4;

--- a/python_bindings/correctness/target.py
+++ b/python_bindings/correctness/target.py
@@ -86,14 +86,14 @@ def test_target():
 
     # with_feature
     t1 = hl.Target(hl.TargetOS.Linux, hl.TargetArch.X86, 32, [hl.TargetFeature.SSE41])
-    t2 = t1.with_feature(hl.TargetFeature.NoAsserts).with_feature(hl.TargetFeature.NoBoundsQuery)
+    t2 = t1.with_feature(hl.TargetFeature.NoAsserts)
     ts = t2.to_string()
-    assert ts == "x86-32-linux-no_asserts-no_bounds_query-sse41"
+    assert ts == "x86-32-linux-no_asserts-sse41"
 
     # without_feature
     t1 = hl.Target(hl.TargetOS.Linux, hl.TargetArch.X86, 32, [hl.TargetFeature.SSE41, hl.TargetFeature.NoAsserts])
-    # Note that NoBoundsQuery wasn't set here, so 'without' is a no-op
-    t2 = t1.without_feature(hl.TargetFeature.NoAsserts).without_feature(hl.TargetFeature.NoBoundsQuery)
+    # Note that AVX2 wasn't set here, so 'without' is a no-op
+    t2 = t1.without_feature(hl.TargetFeature.NoAsserts).without_feature(hl.TargetFeature.AVX2)
     ts = t2.to_string()
     assert ts == "x86-32-linux-sse41"
 

--- a/python_bindings/src/PyEnums.cpp
+++ b/python_bindings/src/PyEnums.cpp
@@ -86,7 +86,6 @@ void define_enums(py::module &m) {
         .value("JIT", Target::Feature::JIT)
         .value("Debug", Target::Feature::Debug)
         .value("NoAsserts", Target::Feature::NoAsserts)
-        .value("NoBoundsQuery", Target::Feature::NoBoundsQuery)
         .value("SSE41", Target::Feature::SSE41)
         .value("AVX", Target::Feature::AVX)
         .value("AVX2", Target::Feature::AVX2)

--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -98,7 +98,6 @@ Stmt add_image_checks(Stmt s,
                       const FuncValueBounds &fb) {
 
     bool no_asserts = t.has_feature(Target::NoAsserts);
-    bool no_bounds_query = t.has_feature(Target::NoBoundsQuery);
 
     // First hunt for all the referenced buffers
     FindBuffers finder;
@@ -142,7 +141,7 @@ Stmt add_image_checks(Stmt s,
     vector<Stmt> buffer_rewrites;
 
     // Inject the code that conditionally returns if we're in inference mode
-    Expr maybe_return_condition = const_false();
+    Expr any_bounds_query = const_false();
 
     // We're also going to apply the constraints to the required min
     // and extent. To do this we have to substitute all references to
@@ -249,7 +248,7 @@ Stmt add_image_checks(Stmt s,
                                      image, param, rdom);
         Expr inference_mode = Call::make(Bool(), Call::buffer_is_bounds_query,
                                          {handle}, Call::Extern);
-        maybe_return_condition = maybe_return_condition || inference_mode;
+        any_bounds_query = any_bounds_query || inference_mode;
 
         // Come up with a name to refer to this buffer in the error messages
         string error_name = (is_output_buffer ? "Output" : "Input");
@@ -618,15 +617,18 @@ Stmt add_image_checks(Stmt s,
         }
     }
 
-    // Inject the code that returns early for inference mode.
-    if (!no_bounds_query) {
-        s = IfThenElse::make(!maybe_return_condition, s);
+    // Make the pipeline code conditional on which entrypoint this
+    // Stmt ends up in.
+    Expr is_bounds_query_entrypoint = Variable::make(Bool(), "is_bounds_query_entrypoint");
+    Expr wrong_entrypoint_error = -12345; // TODO
+    s = Block::make(AssertStmt::make(is_bounds_query_entrypoint || !any_bounds_query, wrong_entrypoint_error), s);
 
-        // Inject the code that does the buffer rewrites for inference mode.
-        for (size_t i = buffer_rewrites.size(); i > 0; i--) {
-            s = Block::make(buffer_rewrites[i-1], s);
-        }
+    // Inject the code that does the buffer rewrites for inference mode.
+    Stmt rewrite_block = Evaluate::make(0);
+    for (size_t i = buffer_rewrites.size(); i > 0; i--) {
+        rewrite_block = Block::make(buffer_rewrites[i-1], rewrite_block);
     }
+    s = IfThenElse::make(is_bounds_query_entrypoint, rewrite_block, s);
 
     if (!no_asserts) {
         // Inject the code that checks the proposed sizes still pass the bounds checks

--- a/src/AddImageChecks.h
+++ b/src/AddImageChecks.h
@@ -27,7 +27,8 @@ Stmt add_image_checks(Stmt s,
                       const Target &t,
                       const std::vector<std::string> &order,
                       const std::map<std::string, Function> &env,
-                      const FuncValueBounds &fb);
+                      const FuncValueBounds &fb,
+                      const std::string &pipeline_name);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Argument.h
+++ b/src/Argument.h
@@ -53,16 +53,30 @@ struct Argument {
      * Note that type.lanes should always be 1 here. */
     Type type;
 
+    /** If this is a buffer parameter, is the buffer struct itself
+     * (not the data) const vs mutable. */
+    bool is_const;
+
     /** If this is a scalar parameter, then these are its default, min, max values.
      * By default, they are left unset, implying "no default, no min, no max". */
     Expr def, min, max;
 
-    Argument() : kind(InputScalar), dimensions(0) {}
-    Argument(const std::string &_name, Kind _kind, const Type &_type, int _dimensions,
-                Expr _def = Expr(),
-                Expr _min = Expr(),
-                Expr _max = Expr()) :
-        name(_name), kind(_kind), dimensions((uint8_t) _dimensions), type(_type), def(_def), min(_min), max(_max) {
+    Argument() : kind(InputScalar), dimensions(0), is_const(false) {}
+    Argument(const std::string &_name,
+             Kind _kind,
+             const Type &_type,
+             int _dimensions,
+             Expr _def = Expr(),
+             Expr _min = Expr(),
+             Expr _max = Expr()) :
+        name(_name),
+        kind(_kind),
+        dimensions((uint8_t) _dimensions),
+        type(_type),
+        is_const(false),
+        def(_def),
+        min(_min),
+        max(_max) {
         internal_assert(_dimensions >= 0 && _dimensions <= 255);
         user_assert(!(is_scalar() && dimensions != 0))
             << "Scalar Arguments must specify dimensions of 0";

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -665,7 +665,7 @@ public:
             }
 
             // Make the extern call
-            Expr e = func.make_call_to_extern_definition(bounds_inference_args, target);
+            Expr e = func.make_bounds_query_to_extern_definition(bounds_inference_args, target);
 
             // Check if it succeeded
             string result_name = unique_name('t');

--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -292,7 +292,13 @@ std::string cplusplus_function_mangled_name(const std::string &name, const std::
         result += "X";
     } else {
         for (const auto &arg : args) {
-            result += prev_decls.check_and_enter_type(mangle_type(arg.is_expr() ? arg.expr.type() : type_of<struct halide_buffer_t *>(), target, prev_decls));
+            if (arg.is_expr()) {
+                result += prev_decls.check_and_enter_type(mangle_type(arg.expr.type(), target, prev_decls));
+            } else if (arg.is_const) {
+                result += prev_decls.check_and_enter_type(mangle_type(type_of<const struct halide_buffer_t *>(), target, prev_decls));
+            } else {
+                result += prev_decls.check_and_enter_type(mangle_type(type_of<struct halide_buffer_t *>(), target, prev_decls));
+            }
         }
         // I think ending in a 'Z' only happens for nested function types, which never
         // occurs with Halide, but putting it in anyway per.
@@ -585,7 +591,13 @@ std::string cplusplus_function_mangled_name(const std::string &name, const std::
     }
 
     for (const auto &arg : args) {
-        result += mangle_type(arg.is_expr() ? arg.expr.type() : type_of<struct halide_buffer_t *>(), target, prevs);
+        if (arg.is_expr()) {
+            result += mangle_type(arg.expr.type(), target, prevs);
+        } else if (arg.is_const) {
+            result += mangle_type(type_of<const struct halide_buffer_t *>(), target, prevs);
+        } else {
+            result += mangle_type(type_of<struct halide_buffer_t *>(), target, prevs);
+        }
     }
 
     return result;

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1537,6 +1537,9 @@ void CodeGen_C::compile(const LoweredFunc &f) {
     stream << "int " << simple_name << "(";
     for (size_t i = 0; i < args.size(); i++) {
         if (args[i].is_buffer()) {
+            if (args[i].is_const) {
+                stream << "const ";
+            }
             stream << "struct halide_buffer_t *"
                    << print_name(args[i].name)
                    << "_buffer";

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1587,12 +1587,17 @@ void CodeGen_C::compile(const LoweredFunc &f) {
         stream << "}\n";
     }
 
-    if (is_header() && f.linkage == LinkageType::ExternalPlusMetadata) {
-        // Emit the argv version
-        stream << "int " << simple_name << "_argv(void **args) HALIDE_FUNCTION_ATTRS;\n";
-
-        // And also the metadata.
-        stream << "const struct halide_filter_metadata_t *" << simple_name << "_metadata() HALIDE_FUNCTION_ATTRS;\n";
+    if (is_header()) {
+        switch (f.linkage) {
+        case LinkageType::ExternalPlusMetadata:
+            stream << "const struct halide_filter_metadata_t *" << simple_name << "_metadata() HALIDE_FUNCTION_ATTRS;\n";
+        case LinkageType::ExternalPlusArgv: // fallthrough
+            stream << "int " << simple_name << "_argv(void **args) HALIDE_FUNCTION_ATTRS;\n";
+            break;
+        default:
+            // Other linkage types come with no extra declared functions.
+            break;
+        }
     }
 
     if (!namespaces.empty()) {

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -489,7 +489,7 @@ MangledNames get_mangled_names(const std::string &name,
                 mangle_args.push_back(ExternFuncArgument(make_zero(arg.type)));
             } else if (arg.kind == Argument::InputBuffer ||
                        arg.kind == Argument::OutputBuffer) {
-                mangle_args.push_back(ExternFuncArgument(Buffer<>()));
+                mangle_args.push_back(ExternFuncArgument(Buffer<>(), arg.is_const));
             }
         }
         names.extern_name = cplusplus_function_mangled_name(names.simple_name, namespaces, type_of<int>(), mangle_args, target);
@@ -562,7 +562,9 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
 
         // If the Func is externally visible, also create the argv wrapper and metadata.
         // (useful for calling from JIT and other machine interfaces).
-        if (f.linkage == LinkageType::ExternalPlusMetadata) {
+        if (f.linkage == LinkageType::ExternalPlusArgv) {
+            add_argv_wrapper(names.argv_name);
+        } else if (f.linkage == LinkageType::ExternalPlusMetadata) {
             llvm::Function *wrapper = add_argv_wrapper(names.argv_name);
             llvm::Function *metadata_getter = embed_metadata_getter(names.metadata_name,
                 names.simple_name, f.args, input.get_metadata_name_map());

--- a/src/Function.h
+++ b/src/Function.h
@@ -29,10 +29,14 @@ struct ExternFuncArgument {
     Expr expr;
     Internal::Parameter image_param;
 
+    // Only relevant for buffer args. Distinguishes between const
+    // halide_buffer_t * and halide_buffer_t *.
+    bool is_const = false;
+
     ExternFuncArgument(Internal::FunctionPtr f): arg_type(FuncArg), func(f) {}
 
     template<typename T>
-    ExternFuncArgument(Buffer<T> b): arg_type(BufferArg), buffer(b) {}
+    ExternFuncArgument(Buffer<T> b, bool is_const = false): arg_type(BufferArg), buffer(b), is_const(is_const) {}
     ExternFuncArgument(Expr e): arg_type(ExprArg), expr(e) {}
     ExternFuncArgument(int e): arg_type(ExprArg), expr(e) {}
     ExternFuncArgument(float e): arg_type(ExprArg), expr(e) {}
@@ -218,6 +222,11 @@ public:
      * function has no extern definition. */
     Expr make_call_to_extern_definition(const std::vector<Expr> &args,
                                         const Target &t) const;
+
+    /** Make a bounds query call node to the extern definition. An
+     * error if the function has no extern definition. */
+    Expr make_bounds_query_to_extern_definition(const std::vector<Expr> &args,
+                                                const Target &t) const;
 
     /** Check if the extern function being called expects the legacy
      * buffer_t type. */

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -283,6 +283,9 @@ std::ostream &operator<<(std::ostream &stream, const LinkageType &type) {
     case LinkageType::ExternalPlusMetadata:
         stream << "external_plus_metadata";
         break;
+    case LinkageType::ExternalPlusArgv:
+        stream << "external_plus_argv";
+        break;
     case LinkageType::External:
         stream << "external";
         break;

--- a/src/JITModule.h
+++ b/src/JITModule.h
@@ -63,11 +63,19 @@ struct JITModule {
      * a Halide Func compilation at all. */
     void *main_function() const;
 
+    /** A pointer to the raw halide bounds query entrypoint. It has
+     * the same true type as the main_function. */
+    void *bounds_query_function() const;
+
     /** Returns the Symbol structure for the routine documented in
      * main_function. Returning a Symbol allows access to the LLVM
      * type as well as the address. The address and type will be nullptr
      * if the module has not been compiled. */
     Symbol entrypoint_symbol() const;
+
+    /** Returns the Symbol structure for the routine documented in
+     * bounds_query_function. */
+    Symbol bounds_query_entrypoint_symbol() const;
 
     /** Returns the Symbol structure for the argv wrapper routine
      * corresponding to the entrypoint. The argv wrapper is callable
@@ -77,14 +85,19 @@ struct JITModule {
      * has not been compiled. */
     Symbol argv_entrypoint_symbol() const;
 
-    /** A slightly more type-safe wrapper around the raw halide
-     * module. Takes it arguments as an array of pointers that
+    /** Returns the Symbol structure for the argv wrapper routine
+        corresponding to the bounds query entrypoint. */
+    Symbol bounds_query_argv_entrypoint_symbol() const;
+
+    /** A slightly more type-safe wrapper around the raw halide module
+     * entrypoints. Takes it arguments as an array of pointers that
      * correspond to the arguments to \ref main_function . This will
-     * be nullptr for a JITModule which has not yet been compiled or one
-     * that is not a Halide Func compilation at all. */
+     * be nullptr for a JITModule which has not yet been compiled or
+     * one that is not a Halide Func compilation at all. */
     // @{
     typedef int (*argv_wrapper)(const void **args);
     argv_wrapper argv_function() const;
+    argv_wrapper bounds_query_argv_function() const;
     // @}
 
     /** Add another JITModule to the dependency chain. Dependencies

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -439,6 +439,13 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
             debug_arguments(&main_func);
         }
         result_module.append(main_func);
+
+        // Append a wrapper for this pipeline that accepts old buffer_ts
+        // and upgrades them. It will use the same name, so it will
+        // require C++ linkage. We don't need it when jitting.
+        if (!t.has_feature(Target::JIT)) {
+            add_legacy_wrapper(result_module, main_func);
+        }
     }
 
     if (bounds_query_stmt.defined()) {
@@ -457,13 +464,6 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
             debug_arguments(&bounds_query_func);
         }
         result_module.append(bounds_query_func);
-    }
-
-    // Append a wrapper for this pipeline that accepts old buffer_ts
-    // and upgrades them. It will use the same name, so it will
-    // require C++ linkage. We don't need it when jitting.
-    if (!t.has_feature(Target::JIT)) {
-        add_legacy_wrapper(result_module, main_func);
     }
 
     // Also append any wrappers for extern stages that expect the old buffer_t

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -152,7 +152,7 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
     // inference.
     debug(1) << "Adding checks for images\n";
     Stmt bounds_query;
-    s = add_image_checks(s, outputs, t, order, env, func_bounds);
+    s = add_image_checks(s, outputs, t, order, env, func_bounds, pipeline_name);
     debug(2) << "Lowering after injecting image checks:\n" << s << '\n';
 
     // This pass injects nested definitions of variable names, so we

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -625,8 +625,6 @@ void compile_multitarget(const std::string &fn_name,
 
         // Always build with NoRuntime: that's handled as a separate module.
         //
-        // Always build with NoBoundsQuery: underlying code will implement that (or not).
-        //
         // Always build *without* NoAsserts (ie, with Asserts enabled): that's the
         // only way to propagate a nonzero result code to our caller. (Note that this
         // does mean we get redundant check-for-null tests in the wrapper code for buffer_t*
@@ -634,7 +632,6 @@ void compile_multitarget(const std::string &fn_name,
         // at least for real-world code.)
         Target wrapper_target = base_target
             .with_feature(Target::NoRuntime)
-            .with_feature(Target::NoBoundsQuery)
             .without_feature(Target::NoAsserts);
 
         // If the base target specified the Matlab target, we want the Matlab target

--- a/src/Module.h
+++ b/src/Module.h
@@ -17,10 +17,11 @@
 
 namespace Halide {
 
-/** Type of linkage a function in a lowered Halide module can have. 
+/** Type of linkage a function in a lowered Halide module can have.
     Also controls whether auxiliary functions and metadata are generated. */
 enum class LinkageType {
     External, ///< Visible externally.
+    ExternalPlusArgv, ///< Visible externally. argv wrapper also generated
     ExternalPlusMetadata, ///< Visible externally. Argument metadata and an argv wrapper are also generated.
     Internal, ///< Not visible externally, similar to 'static' linkage in C.
 };

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -420,7 +420,7 @@ Stmt build_produce(const map<string, Function> &env, Function f, const Target &t
                             buf_name += "." + std::to_string(k);
                         }
                         buf_name += ".buffer";
-                        Expr buffer = Variable::make(type_of<struct halide_buffer_t *>(), buf_name);
+                        Expr buffer = Variable::make(type_of<const struct halide_buffer_t *>(), buf_name);
                         extern_call_args.push_back(buffer);
                         buffers_to_annotate.push_back({buffer, input.dimensions()});
                         buffers_contents_to_annotate.push_back(buffer);
@@ -468,7 +468,7 @@ Stmt build_produce(const map<string, Function> &env, Function f, const Target &t
                                                    args, Call::Extern);
 
                         string buf_name = input.name() + "." + std::to_string(k) + ".tmp_buffer";
-                        extern_call_args.push_back(Variable::make(type_of<struct halide_buffer_t *>(), buf_name));
+                        extern_call_args.push_back(Variable::make(type_of<const struct halide_buffer_t *>(), buf_name));
                         buffers_to_annotate.push_back({extern_call_args.back(), input.dimensions()});
                         buffers_contents_to_annotate.push_back(cropped_input);
                         lets.push_back({ buf_name, cropped_input });
@@ -478,13 +478,13 @@ Stmt build_produce(const map<string, Function> &env, Function f, const Target &t
                 Buffer<> b = arg.buffer;
                 Parameter p(b.type(), true, b.dimensions(), b.name());
                 p.set_buffer(b);
-                Expr buf = Variable::make(type_of<struct halide_buffer_t *>(), b.name() + ".buffer", p);
+                Expr buf = Variable::make(type_of<const struct halide_buffer_t *>(), b.name() + ".buffer", p);
                 extern_call_args.push_back(buf);
                 buffers_to_annotate.push_back({buf, b.dimensions()});
                 buffers_contents_to_annotate.push_back(buf);
             } else if (arg.is_image_param()) {
                 Parameter p = arg.image_param;
-                Expr buf = Variable::make(type_of<struct halide_buffer_t *>(), p.name() + ".buffer", p);
+                Expr buf = Variable::make(type_of<const struct halide_buffer_t *>(), p.name() + ".buffer", p);
                 extern_call_args.push_back(buf);
                 // Do not annotate ImageParams: both the buffer_t itself,
                 // and the contents it points to, should be filled by the caller;
@@ -509,7 +509,7 @@ Stmt build_produce(const map<string, Function> &env, Function f, const Target &t
                     buf_name += "." + std::to_string(j);
                 }
                 buf_name += ".buffer";
-                Expr buffer = Variable::make(type_of<struct halide_buffer_t *>(), buf_name);
+                Expr buffer = Variable::make(type_of<const struct halide_buffer_t *>(), buf_name);
                 extern_call_args.push_back(buffer);
                 // Since this is a temporary, internal-only buffer, make sure it's marked.
                 // (but not the contents! callee is expected to fill that in.)
@@ -553,7 +553,7 @@ Stmt build_produce(const map<string, Function> &env, Function f, const Target &t
                 output_buffer_t = Call::make(type_of<struct halide_buffer_t *>(), Call::buffer_crop, args, Call::Extern);
 
                 string buf_name = f.name() + "." + std::to_string(j) + ".tmp_buffer";
-                extern_call_args.push_back(Variable::make(type_of<struct halide_buffer_t *>(), buf_name));
+                extern_call_args.push_back(Variable::make(type_of<const struct halide_buffer_t *>(), buf_name));
                 // Since this is a temporary, internal-only buffer, make sure it's marked.
                 // (but not the contents! callee is expected to fill that in.)
                 buffers_to_annotate.push_back({extern_call_args.back(), f.dimensions()});

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -593,6 +593,7 @@ void target_test() {
     }
     for (int i = 0; i < (int)(Target::FeatureEnd); i++) {
         if (i == halide_target_feature_unused_23) continue;
+        if (i == halide_target_feature_unused_3) continue;
         internal_assert(t.has_feature((Target::Feature)i)) << "Feature " << i << " not in feature_names_map.\n";
     }
     std::cout << "Target test passed" << std::endl;

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -218,7 +218,6 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"jit", Target::JIT},
     {"debug", Target::Debug},
     {"no_asserts", Target::NoAsserts},
-    {"no_bounds_query", Target::NoBoundsQuery},
     {"sse41", Target::SSE41},
     {"avx", Target::AVX},
     {"avx2", Target::AVX2},
@@ -345,6 +344,8 @@ bool merge_string(Target &t, const std::string &target) {
                 return false;
             }
             t = get_host_target();
+        } else if (tok == "no_bounds_query") {
+            user_warning << "The no_bounds_query target flag is deprecated. Ignoring.";
         } else if (tok == "32" || tok == "64" || tok == "0") {
             if (bits_specified) {
                 return false;

--- a/src/Target.h
+++ b/src/Target.h
@@ -47,7 +47,6 @@ struct Target {
         JIT = halide_target_feature_jit,
         Debug = halide_target_feature_debug,
         NoAsserts = halide_target_feature_no_asserts,
-        NoBoundsQuery = halide_target_feature_no_bounds_query,
         SSE41 = halide_target_feature_sse41,
         AVX = halide_target_feature_avx,
         AVX2 = halide_target_feature_avx2,

--- a/src/Target.h
+++ b/src/Target.h
@@ -162,7 +162,7 @@ struct Target {
     }
 
     /** Return a copy of the target with the given feature set.
-     * This is convenient when enabling certain features (e.g. NoBoundsQuery)
+     * This is convenient when enabling certain features (e.g. NoAsserts)
      * in an initialization list, where the target to be mutated may be
      * a const reference. */
     Target with_feature(Feature f) const {
@@ -172,7 +172,7 @@ struct Target {
     }
 
     /** Return a copy of the target with the given feature cleared.
-     * This is convenient when disabling certain features (e.g. NoBoundsQuery)
+     * This is convenient when disabling certain features (e.g. NoAsserts)
      * in an initialization list, where the target to be mutated may be
      * a const reference. */
     Target without_feature(Feature f) const {

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1071,7 +1071,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_jit = 0,  ///< Generate code that will run immediately inside the calling process.
     halide_target_feature_debug = 1,  ///< Turn on debug info and output for runtime code.
     halide_target_feature_no_asserts = 2,  ///< Disable all runtime checks, for slightly tighter code.
-    halide_target_feature_no_bounds_query = 3, ///< Disable the bounds querying functionality.
+    halide_deprecated_target_feature_no_bounds_query = 3, ///< Deprecated. Has no effect.
 
     halide_target_feature_sse41 = 4,  ///< Use SSE 4.1 and earlier instructions. Only relevant on x86.
     halide_target_feature_avx = 5,  ///< Use AVX 1 instructions. Only relevant on x86.

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -984,6 +984,10 @@ enum halide_error_code_t {
 
     /** The dimensions field of a halide_buffer_t does not match the dimensions of that ImageParam. */
     halide_error_code_bad_dimensions = -43,
+
+    /** A halide_buffer_t * in bounds query mode was passed to a
+     * Halide routine not expecting it. */
+    halide_error_code_buffer_is_bounds_query = -44,
 };
 
 /** Halide calls the functions below on various error conditions. The
@@ -1062,6 +1066,7 @@ extern int halide_error_no_device_interface(void *user_context);
 extern int halide_error_device_interface_no_device(void *user_context);
 extern int halide_error_host_and_device_dirty(void *user_context);
 extern int halide_error_buffer_is_null(void *user_context, const char *routine);
+extern int halide_error_buffer_is_bounds_query(void *user_context, const char *routine, const char *buf_name);
 
 // @}
 

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1076,7 +1076,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_jit = 0,  ///< Generate code that will run immediately inside the calling process.
     halide_target_feature_debug = 1,  ///< Turn on debug info and output for runtime code.
     halide_target_feature_no_asserts = 2,  ///< Disable all runtime checks, for slightly tighter code.
-    halide_deprecated_target_feature_no_bounds_query = 3, ///< Deprecated. Has no effect.
+    halide_target_feature_unused_3 = 3, ///< Deprecated. Was no_bounds_query, which now has no effect.
 
     halide_target_feature_sse41 = 4,  ///< Use SSE 4.1 and earlier instructions. Only relevant on x86.
     halide_target_feature_avx = 5,  ///< Use AVX 1 instructions. Only relevant on x86.

--- a/src/runtime/errors.cpp
+++ b/src/runtime/errors.cpp
@@ -285,4 +285,12 @@ WEAK int halide_error_buffer_is_null(void *user_context, const char *routine) {
     return halide_error_code_buffer_is_null;
 }
 
+WEAK int halide_error_buffer_is_bounds_query(void *user_context, const char *routine, const char *arg_name) {
+    error(user_context) << "Buffer " << arg_name
+                        << " passed to " << routine << " is a bounds query buffer. "
+                        << "This form of bounds query has been deprecated. "
+                        << "Make the same call to " << routine << "_bounds_query instead.";
+    return halide_error_code_buffer_is_bounds_query;
+}
+
 }  // extern "C"

--- a/src/runtime/runtime_api.cpp
+++ b/src/runtime/runtime_api.cpp
@@ -62,6 +62,7 @@ extern "C" __attribute__((used)) void *halide_runtime_api_functions[] = {
     (void *)&halide_error_bad_type,
     (void *)&halide_error_bounds_inference_call_failed,
     (void *)&halide_error_buffer_allocation_too_large,
+    (void *)&halide_error_buffer_is_bounds_query,
     (void *)&halide_error_buffer_argument_is_null,
     (void *)&halide_error_buffer_extents_negative,
     (void *)&halide_error_buffer_extents_too_large,

--- a/test/correctness/extern_bounds_inference.cpp
+++ b/test/correctness/extern_bounds_inference.cpp
@@ -8,19 +8,20 @@
 #endif
 
 // An extern stage that translates.
-extern "C" DLLEXPORT int translate(halide_buffer_t *in, int dx, int dy, halide_buffer_t *out) {
+extern "C" DLLEXPORT int translate(const halide_buffer_t *in, int dx, int dy, halide_buffer_t *out) {
+    Halide::Runtime::Buffer<uint8_t> out_buf(*out);
+    out_buf.translate(dx, dy);
+    out_buf.copy_from(Halide::Runtime::Buffer<uint8_t>(*in));
+    return 0;
+}
 
+extern "C" DLLEXPORT int translate_bounds_query(halide_buffer_t *in, int dx, int dy, halide_buffer_t *out) {
     if (in->is_bounds_query()) {
         in->dim[0].min = out->dim[0].min + dx;
         in->dim[1].min = out->dim[1].min + dy;
         in->dim[0].extent = out->dim[0].extent;
         in->dim[1].extent = out->dim[1].extent;
-    } else {
-        Halide::Runtime::Buffer<uint8_t> out_buf(*out);
-        out_buf.translate(dx, dy);
-        out_buf.copy_from(Halide::Runtime::Buffer<uint8_t>(*in));
     }
-
     return 0;
 }
 

--- a/test/correctness/extern_consumer.cpp
+++ b/test/correctness/extern_consumer.cpp
@@ -16,22 +16,25 @@ int dump_to_file(halide_buffer_t *input, const char *filename,
                  int desired_min, int desired_extent,
                  halide_buffer_t *) {
     // Note the final output buffer argument is unused.
-    if (input->is_bounds_query()) {
-        // Request some range of the input buffer
-        input->dim[0].min = desired_min;
-        input->dim[0].extent = desired_extent;
-    } else {
-        FILE *f = fopen(filename, "w");
-        // Depending on the schedule, other consumers, etc, Halide may
-        // have evaluated more than we asked for, so don't assume that
-        // the min and extents match what we requested.
-        int *base = ((int *)input->host) - input->dim[0].min;
-        for (int i = desired_min; i < desired_min + desired_extent; i++) {
-            fprintf(f, "%d\n", base[i]);
-        }
-        fclose(f);
+    FILE *f = fopen(filename, "w");
+    // Depending on the schedule, other consumers, etc, Halide may
+    // have evaluated more than we asked for, so don't assume that
+    // the min and extents match what we requested.
+    int *base = ((int *)input->host) - input->dim[0].min;
+    for (int i = desired_min; i < desired_min + desired_extent; i++) {
+        fprintf(f, "%d\n", base[i]);
     }
+    fclose(f);
 
+    return 0;
+}
+
+extern "C" DLLEXPORT
+int dump_to_file_bounds_query(halide_buffer_t *input, const char *filename,
+                 int desired_min, int desired_extent,
+                 halide_buffer_t *) {
+    input->dim[0].min = desired_min;
+    input->dim[0].extent = desired_extent;
     return 0;
 }
 

--- a/test/correctness/extern_error.cpp
+++ b/test/correctness/extern_error.cpp
@@ -11,9 +11,14 @@ using namespace Halide;
 
 bool extern_error_called = false;
 extern "C" DLLEXPORT
-int extern_error(void *user_context, buffer_t *out) {
+int extern_error(void *user_context, halide_buffer_t *out) {
     extern_error_called = true;
     return -1;
+}
+
+extern "C" DLLEXPORT
+int extern_error_bounds_query(void *user_context, halide_buffer_t *out) {
+    return 0;
 }
 
 bool error_occurred = false;

--- a/test/correctness/extern_output_expansion.cpp
+++ b/test/correctness/extern_output_expansion.cpp
@@ -11,31 +11,34 @@
 extern "C" DLLEXPORT int extern_stage(halide_buffer_t *in, halide_buffer_t *out) {
     assert(in->type == halide_type_of<int>());
     assert(out->type == halide_type_of<int>());
-    if (in->host == nullptr || out->host == nullptr) {
-        // We require input size = output size, and just for fun,
-        // we'll require that the output size must be a multiple of 17
 
-        if (out->is_bounds_query()) {
-            out->dim[0].extent = ((out->dim[0].extent + 16)/17)*17;
-        }
-        if (in->is_bounds_query()) {
-            in->dim[0].extent = out->dim[0].extent;
-            in->dim[0].min = out->dim[0].min;
-        }
-
-    } else {
-        assert(out->dim[0].extent % 17 == 0);
-        printf("in: %d %d, out: %d %d\n",
-               in->dim[0].min, in->dim[0].extent,
-               out->dim[0].min, out->dim[0].extent);
-        int32_t *in_origin = (int32_t *)in->host - in->dim[0].min;
-        int32_t *out_origin = (int32_t *)out->host - out->dim[0].min;
-        for (int i = out->dim[0].min; i < out->dim[0].min + out->dim[0].extent; i++) {
-            out_origin[i] = in_origin[i] * i;
-        }
+    assert(out->dim[0].extent % 17 == 0);
+    printf("in: %d %d, out: %d %d\n",
+           in->dim[0].min, in->dim[0].extent,
+           out->dim[0].min, out->dim[0].extent);
+    int32_t *in_origin = (int32_t *)in->host - in->dim[0].min;
+    int32_t *out_origin = (int32_t *)out->host - out->dim[0].min;
+    for (int i = out->dim[0].min; i < out->dim[0].min + out->dim[0].extent; i++) {
+        out_origin[i] = in_origin[i] * i;
     }
     return 0;
 }
+
+
+extern "C" DLLEXPORT int extern_stage_bounds_query(halide_buffer_t *in, halide_buffer_t *out) {
+    // We require input size = output size, and just for fun,
+    // we'll require that the output size must be a multiple of 17
+
+    if (out->is_bounds_query()) {
+        out->dim[0].extent = ((out->dim[0].extent + 16)/17)*17;
+    }
+    if (in->is_bounds_query()) {
+        in->dim[0].extent = out->dim[0].extent;
+        in->dim[0].min = out->dim[0].min;
+    }
+    return 0;
+}
+
 
 using namespace Halide;
 

--- a/test/correctness/extern_sort.cpp
+++ b/test/correctness/extern_sort.cpp
@@ -12,19 +12,19 @@ using namespace Halide;
 
 // Use an extern stage to do a sort
 extern "C" DLLEXPORT int sort_buffer(halide_buffer_t *in, halide_buffer_t *out) {
-    if (in->is_bounds_query()) {
-        in->dim[0].min = out->dim[0].min;
-        in->dim[0].extent = out->dim[0].extent;
-    } else {
-        memcpy(out->host, in->host, out->dim[0].extent * out->type.bytes());
-        float *out_start = (float *)out->host;
-        float *out_end = out_start + out->dim[0].extent;
-        std::sort(out_start, out_end);
-        out->set_host_dirty();
-    }
+    memcpy(out->host, in->host, out->dim[0].extent * out->type.bytes());
+    float *out_start = (float *)out->host;
+    float *out_end = out_start + out->dim[0].extent;
+    std::sort(out_start, out_end);
+    out->set_host_dirty();
     return 0;
 }
 
+extern "C" DLLEXPORT int sort_buffer_bounds_query(halide_buffer_t *in, halide_buffer_t *out) {
+    in->dim[0].min = out->dim[0].min;
+    in->dim[0].extent = out->dim[0].extent;
+    return 0;
+}
 
 int main(int argc, char **argv) {
     Func data;

--- a/test/correctness/host_alignment.cpp
+++ b/test/correctness/host_alignment.cpp
@@ -79,7 +79,6 @@ void set_alignment_host_ptr(ImageParam &i, int align, std::map<string, int> &m) 
 
 int count_host_alignment_asserts(Func f, std::map<string, int> m) {
     Target t = get_jit_target_from_environment();
-    t.set_feature(Target::NoBoundsQuery);
     f.compute_root();
     Stmt s = Internal::lower_main_stmt({f.function()}, f.name(), t);
     CountHostAlignmentAsserts c(m);

--- a/test/correctness/interleave.cpp
+++ b/test/correctness/interleave.cpp
@@ -23,7 +23,6 @@ public:
 
 int count_interleaves(Func f) {
     Target t = get_jit_target_from_environment();
-    t.set_feature(Target::NoBoundsQuery);
     t.set_feature(Target::NoAsserts);
     f.compute_root();
     std::vector<Module> submodules;

--- a/test/correctness/multiple_outputs_extern.cpp
+++ b/test/correctness/multiple_outputs_extern.cpp
@@ -11,11 +11,48 @@ extern "C" DLLEXPORT int flip_x_and_sum(halide_buffer_t *in1, halide_buffer_t *i
     int min = out->dim[0].min;
     int max = out->dim[0].min + out->dim[0].extent - 1;
 
-    int extent = out->dim[0].extent;
     int flipped_min = -max;
     int flipped_max = -min;
 
-    if (in1->host == nullptr || in2->host == nullptr) {
+    assert(in1->type == halide_type_of<uint8_t>());
+    assert(in2->type == halide_type_of<int32_t>());
+    assert(out->type == halide_type_of<uint8_t>());
+
+    printf("Computing flip_x_and_sum over [%d %d]\n", min, max);
+
+    // Check the inputs are as large as we expected. They should
+    // be, if the above bounds inference code is right.
+    assert(in1->dim[0].min <= flipped_min &&
+           in1->dim[0].min + in1->dim[0].extent > flipped_max);
+    assert(in2->dim[0].min <= flipped_min &&
+           in2->dim[0].min + in2->dim[0].extent > flipped_max);
+
+    // Check the strides are what we want.
+    assert(in1->dim[0].stride == 1 && in2->dim[0].stride == 1 && out->dim[0].stride == 1);
+
+    // Get pointers to the origin from each of the inputs (because
+    // we're flipping about the origin)
+    uint8_t *dst = (uint8_t *)(out->host) - out->dim[0].min;
+    uint8_t *src1 = (uint8_t *)(in1->host) - in1->dim[0].min;
+    int *src2 = (int *)(in2->host) - in2->dim[0].min;
+
+    // Do the flip.
+    for (int i = min; i <= max; i++) {
+        dst[i] = src1[-i] + src2[-i];
+    }
+
+    return 0;
+}
+
+
+extern "C" DLLEXPORT int flip_x_and_sum_bounds_query(halide_buffer_t *in1, halide_buffer_t *in2, halide_buffer_t *out) {
+    if (in1->is_bounds_query() || in2->is_bounds_query()) {
+        int min = out->dim[0].min;
+        int max = out->dim[0].min + out->dim[0].extent - 1;
+
+        int extent = out->dim[0].extent;
+        int flipped_min = -max;
+
         // If any of the inputs have a null host pointer, we're in
         // bounds inference mode, and should mutate those input
         // buffers that have a null host pointer.
@@ -30,37 +67,11 @@ extern "C" DLLEXPORT int flip_x_and_sum(halide_buffer_t *in1, halide_buffer_t *i
         }
         // We don't mutate the output buffer, because we can handle
         // any size output.
-    } else {
-        assert(in1->type == halide_type_of<uint8_t>());
-        assert(in2->type == halide_type_of<int32_t>());
-        assert(out->type == halide_type_of<uint8_t>());
-
-        printf("Computing flip_x_and_sum over [%d %d]\n", min, max);
-
-        // Check the inputs are as large as we expected. They should
-        // be, if the above bounds inference code is right.
-        assert(in1->dim[0].min <= flipped_min &&
-               in1->dim[0].min + in1->dim[0].extent > flipped_max);
-        assert(in2->dim[0].min <= flipped_min &&
-               in2->dim[0].min + in2->dim[0].extent > flipped_max);
-
-        // Check the strides are what we want.
-        assert(in1->dim[0].stride == 1 && in2->dim[0].stride == 1 && out->dim[0].stride == 1);
-
-        // Get pointers to the origin from each of the inputs (because
-        // we're flipping about the origin)
-        uint8_t *dst = (uint8_t *)(out->host) - out->dim[0].min;
-        uint8_t *src1 = (uint8_t *)(in1->host) - in1->dim[0].min;
-        int *src2 = (int *)(in2->host) - in2->dim[0].min;
-
-        // Do the flip.
-        for (int i = min; i <= max; i++) {
-            dst[i] = src1[-i] + src2[-i];
-        }
     }
 
     return 0;
 }
+
 
 using namespace Halide;
 

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -80,7 +80,6 @@ struct Test {
 
     Test() {
         target = get_target_from_environment()
-            .with_feature(Target::NoBoundsQuery)
             .with_feature(Target::NoAsserts)
             .with_feature(Target::NoRuntime);
         use_avx512_knl = target.has_feature(Target::AVX512_KNL);
@@ -2136,6 +2135,8 @@ check("v*.w += vrmpy(v*.b,v*.b)", hvx_width, i32_1 + i32(i8_1)*i8_1 + i32(i8_2)*
 
 int main(int argc, char **argv) {
     Test test;
+
+    num_threads = 1;
 
     if (argc > 1) {
         test.filter = argv[1];

--- a/test/correctness/skip_stages_external_array_functions.cpp
+++ b/test/correctness/skip_stages_external_array_functions.cpp
@@ -12,16 +12,16 @@ using namespace Halide;
 int bounds_query_count[4];
 int call_count[4];
 extern "C" DLLEXPORT int call_counter(halide_buffer_t *input, int x, int idx, halide_buffer_t *output) {
-    if (input->is_bounds_query()) {
-        bounds_query_count[idx]++;
-        input->dim[0] = output->dim[0];
-        return 0;
-    }
     call_count[idx]++;
     for (int32_t i = 0; i < output->dim[0].extent; i++) {
         output->host[i] = input->host[i] + x;
     }
+    return 0;
+}
 
+extern "C" DLLEXPORT int call_counter_bounds_query(halide_buffer_t *input, int x, int idx, halide_buffer_t *output) {
+    bounds_query_count[idx]++;
+    input->dim[0] = output->dim[0];
     return 0;
 }
 

--- a/test/correctness/target.cpp
+++ b/test/correctness/target.cpp
@@ -94,17 +94,17 @@ int main(int argc, char **argv) {
 
     // with_feature
     t1 = Target(Target::Linux, Target::X86, 32, {Target::SSE41});
-    t2 = t1.with_feature(Target::NoAsserts).with_feature(Target::NoBoundsQuery);
+    t2 = t1.with_feature(Target::NoAsserts);
     ts = t2.to_string();
-    if (ts != "x86-32-linux-no_asserts-no_bounds_query-sse41") {
+    if (ts != "x86-32-linux-no_asserts-sse41") {
        printf("to_string failure: %s\n", ts.c_str());
        return -1;
     }
 
     // without_feature
     t1 = Target(Target::Linux, Target::X86, 32, {Target::SSE41, Target::NoAsserts});
-    // Note that NoBoundsQuery wasn't set here, so 'without' is a no-op
-    t2 = t1.without_feature(Target::NoAsserts).without_feature(Target::NoBoundsQuery);
+    // Note that AVX2 wasn't set here, so 'without' is a no-op
+    t2 = t1.without_feature(Target::NoAsserts).without_feature(Target::AVX2);
     ts = t2.to_string();
     if (ts != "x86-32-linux-sse41") {
        printf("to_string failure: %s\n", ts.c_str());

--- a/test/generator/cxx_mangling_define_extern_externs.cpp
+++ b/test/generator/cxx_mangling_define_extern_externs.cpp
@@ -5,16 +5,29 @@
 // These are the define_extern functions referenced by cxx_mangling_define_extern_generator.cpp
 namespace HalideTest {
 
-int cxx_mangling_1(void *ctx, halide_buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, halide_buffer_t *_f_buffer) {
+int cxx_mangling_1(void *ctx, const halide_buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, const halide_buffer_t *_f_buffer) {
     return AnotherNamespace::cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, nullptr, nullptr, nullptr, _f_buffer);
 }
 
-int cxx_mangling_2(void *ctx, halide_buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, halide_buffer_t *_f_buffer) {
+int cxx_mangling_2(void *ctx, const halide_buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, const halide_buffer_t *_f_buffer) {
     return AnotherNamespace::cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, nullptr, nullptr, nullptr, _f_buffer);
 }
 
-extern "C" int cxx_mangling_3(void *ctx, halide_buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, halide_buffer_t *_f_buffer) {
+extern "C" int cxx_mangling_3(void *ctx, const halide_buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, const halide_buffer_t *_f_buffer) {
     return AnotherNamespace::cxx_mangling(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, nullptr, nullptr, nullptr, _f_buffer);
 }
+
+int cxx_mangling_1_bounds_query(void *ctx, halide_buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, halide_buffer_t *_f_buffer) {
+    return AnotherNamespace::cxx_mangling_bounds_query(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, nullptr, nullptr, nullptr, _f_buffer);
+}
+
+int cxx_mangling_2_bounds_query(void *ctx, halide_buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, halide_buffer_t *_f_buffer) {
+    return AnotherNamespace::cxx_mangling_bounds_query(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, nullptr, nullptr, nullptr, _f_buffer);
+}
+
+extern "C" int cxx_mangling_3_bounds_query(void *ctx, halide_buffer_t *_input_buffer, int8_t _offset_i8, uint8_t _offset_u8, int16_t _offset_i16, uint16_t _offset_u16, int32_t _offset_i32, uint32_t _offset_u32, int64_t _offset_i64, uint64_t _offset_u64, bool _scale_direction, float _scale_f, double _scale_d, int32_t *_ptr, int32_t const *_const_ptr, void *_void_ptr, void const *_const_void_ptr, void *_string_ptr, void const *_const_string_ptr, halide_buffer_t *_f_buffer) {
+    return AnotherNamespace::cxx_mangling_bounds_query(_input_buffer, _offset_i8, _offset_u8, _offset_i16, _offset_u16, _offset_i32, _offset_u32, _offset_i64, _offset_u64, _scale_direction, _scale_f, _scale_d, _ptr, _const_ptr, _void_ptr, _const_void_ptr, _string_ptr, _const_string_ptr, nullptr, nullptr, nullptr, _f_buffer);
+}
+
 
 };

--- a/test/generator/msan_aottest.cpp
+++ b/test/generator/msan_aottest.cpp
@@ -21,15 +21,6 @@ using namespace Halide::Runtime;
 
 // Just copies in -> out.
 extern "C" int msan_extern_stage(halide_buffer_t *in, halide_buffer_t *out) {
-    if (in->is_bounds_query()) {
-        in->dim[0].extent = 4;
-        in->dim[1].extent = 4;
-        in->dim[2].extent = 3;
-        in->dim[0].min = 0;
-        in->dim[1].min = 0;
-        in->dim[2].min = 0;
-        return 0;
-    }
     if (!out->host) {
         fprintf(stderr, "msan_extern_stage failure\n");
         return -1;
@@ -41,6 +32,19 @@ extern "C" int msan_extern_stage(halide_buffer_t *in, halide_buffer_t *out) {
     out->set_host_dirty();
     return 0;
 }
+
+extern "C" int msan_extern_stage_bounds_query(halide_buffer_t *in, halide_buffer_t *out) {
+    if (in->is_bounds_query()) {
+        in->dim[0].extent = 4;
+        in->dim[1].extent = 4;
+        in->dim[2].extent = 3;
+        in->dim[0].min = 0;
+        in->dim[1].min = 0;
+        in->dim[2].min = 0;
+    }
+    return 0;
+}
+
 
 extern "C" void halide_error(void *user_context, const char *msg) {
     // Emitting "error.*:" to stdout or stderr will cause CMake to report the


### PR DESCRIPTION
We currently generate a single entrypoint which may or may not do a bounds query, mutating the buffer fields, depending on `buf->is_bounds_query()`:
```
int foo(halide_buffer_t *buf, ...)
```

This PR changes it to two entrypoints, one of which just does bounds queries, and one of which just runs the pipeline:
```
int foo(const halide_buffer_t *buf, ...)
int foo_bounds_query(halide_buffer_t *buf, ...)
```

The non-bounds-query version can therefore take const buffers, which simplifies things for people who don't care about the bounds query feature.

Some bounds inference code ends up duplicated across the two entrypoints, but much of the time the bounds query one will be dead-stripped, so this will probably reduce code size more than it grows it.

This PR also deprecates the no_bounds_query target feature, because it doesn't do anything particularly useful now. The main function has no bounds query code in it anyway. I preserved its numeric ID in HalideRuntime.h to avoid any weird version issues, but nuked the Target::NoBoundsQuery enum. Using it in a target string produces a deprecation warning.
