### PR TITLE
Add a division visitor method to SolveExpression.

### DIFF
--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -372,12 +372,6 @@ private:
         const Sub *sub_a = a.as<Sub>();
         const Mul *mul_a = a.as<Mul>();
 
-        if (b_uses_var && !a_uses_var) {
-            std::swap(a, b);
-            std::swap(a_uses_var, b_uses_var);
-            std::swap(a_failed, b_failed);
-        }
-
         Expr expr;
         if (a_uses_var && !b_uses_var) {
             if (add_a && !a_failed &&

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -348,6 +348,67 @@ private:
         return expr;
     }
 
+    Expr visit(const Div *op) override {
+        bool old_uses_var = uses_var;
+        uses_var = false;
+        bool old_failed = failed;
+        failed = false;
+        Expr a = mutate(op->a);
+        bool a_uses_var = uses_var;
+        bool a_failed = failed;
+
+        internal_assert(!is_const(op->a) || !a_uses_var)
+                << op->a << ", " << uses_var << "\n";
+
+        uses_var = false;
+        failed = false;
+        Expr b = mutate(op->b);
+        bool b_uses_var = uses_var;
+        bool b_failed = failed;
+        uses_var = old_uses_var || a_uses_var || b_uses_var;
+        failed = old_failed || a_failed || b_failed;
+
+        const Add *add_a = a.as<Add>();
+        const Sub *sub_a = a.as<Sub>();
+        const Mul *mul_a = a.as<Mul>();
+
+        if (b_uses_var && !a_uses_var) {
+            std::swap(a, b);
+            std::swap(a_uses_var, b_uses_var);
+            std::swap(a_failed, b_failed);
+        }
+
+        Expr expr;
+        if (a_uses_var && !b_uses_var) {
+            if (add_a && !a_failed &&
+                can_prove(add_a->a / b * b == add_a->a)) {
+                // (f(x) + a) / b -> f(x) / b + a / b
+                expr = mutate(simplify(add_a->a / b) + add_a->b / b);
+            } else if (sub_a && !a_failed &&
+                       can_prove(sub_a->a / b * b == sub_a->a)) {
+                // (f(x) - a) / b -> f(x) / b - a / b
+                expr = mutate(simplify(sub_a->a / b) - sub_a->b / b);
+            } else if (mul_a && !a_failed &&
+                       can_prove(mul_a->b / b * b == mul_a->b)) {
+                // (f(x) * a) / b -> f(x) * (a / b)
+                expr = mutate(mul_a->a * (mul_a->b / b));
+            }
+        } else if (is_const(a) && is_const(b)) {
+            // Do some constant-folding
+            expr = simplify(a / b);
+            internal_assert(!uses_var && !a_uses_var && !b_uses_var);
+        }
+
+        if (!expr.defined()) {
+            if (a.same_as(op->a) && b.same_as(op->b)) {
+                expr = op;
+            } else {
+                expr = a / b;
+            }
+        }
+        return expr;
+    }
+
     Expr visit(const Call *op) override {
         // Ignore likely intrinsics
         if (op->is_intrinsic(Call::likely) ||
@@ -1420,6 +1481,16 @@ void solve_test() {
     check_solve(5*y + 3*x == 2, ((x == ((2 - (5*y))/3)) && (((2 - (5*y)) % 3) == 0)));
     check_solve(min(min(z, x), min(x, y)), min(x, min(y, z)));
     check_solve(min(x + y, x + 5), x + min(y, 5));
+
+    // Check solver with expressions containing division
+    check_solve(x + (x*2) / 2, x*2);
+    check_solve(x + (x*2 + y) / 2, x*2 + (y / 2));
+    check_solve(x + (x*2 - y) / 2, x*2 - (y / 2)) ;
+    check_solve(x + (-(x*2) / 2), x*0 + 0);
+    check_solve(x + (-(x*2 + -3)) / 2, x*0 + 1);
+    check_solve(x + (z - (x*2 + -3)) / 2, x*0 + (z - (-3)) / 2);
+    check_solve(x + (y*16 + (z - (x * 2 + -1))) / 2,
+                (x * 0) + (((z - -1) + (y*16)) / 2));
 
     // A let statement
     check_solve(Let::make("z", 3 + 5*x, y + z < 8),

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -227,6 +227,7 @@ void check_algebra() {
     check((x / 3) / 4, x / 12);
     check((x*4)/2, x*2);
     check((x*2)/4, x/2);
+    check((x*(-4))/2, x*(-2));
     check((x*4 + y)/2, y/2 + x*2);
     check((y + x*4)/2, y/2 + x*2);
     check((x*4 - y)/2, (0 - y)/2 + x*2);


### PR DESCRIPTION
Trying to merge this into the new simplifier branch because this PR requires a simplification rule of 
`(x*-4)/2 -> x*(-2)` which is not implemented in the master branch.