### PR TITLE
Appease Coverity

### DIFF
--- a/src/OutputImageParam.h
+++ b/src/OutputImageParam.h
@@ -42,7 +42,7 @@ protected:
 public:
 
     /** Construct a null image parameter handle. */
-    OutputImageParam() {}
+    OutputImageParam() : kind(Argument::InputScalar) {}
 
     /** Get the name of this Param */
     const std::string &name() const;


### PR DESCRIPTION
Coverity (semi-rightly) complains that `kind` is not initialized by this constructor.  Setting it to the kind that is used for the default `Argument` constructor seems.