### PR TITLE
Hygiene: move nontrivial Target method bodies into .cpp file

### DIFF
--- a/python_bindings/src/PyTarget.cpp
+++ b/python_bindings/src/PyTarget.cpp
@@ -15,7 +15,7 @@ std::string target_repr(const Target &t) {
 
 void define_target(py::module &m) {
     // Disambiguate some ambigious methods
-    int (Target::*natural_vector_size_method)(Type) const = &Target::natural_vector_size;
+    int (Target::*natural_vector_size_method)(const Type &t) const = &Target::natural_vector_size;
     bool (Target::*supports_type1_method)(const Type &t) const = &Target::supports_type;
     bool (Target::*supports_type2_method)(const Type &t, DeviceAPI device) const = &Target::supports_type;
 

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -533,6 +533,71 @@ bool Target::supported() const {
     return !bad;
 }
 
+void Target::set_feature(Feature f, bool value) {
+    if (f == FeatureEnd) return;
+    user_assert(f < FeatureEnd) << "Invalid Target feature.\n";
+    features.set(f, value);
+}
+
+void Target::set_features(std::vector<Feature> features_to_set, bool value) {
+    for (Feature f : features_to_set) {
+        set_feature(f, value);
+    }
+}
+
+bool Target::has_feature(Feature f) const {
+    if (f == FeatureEnd) return true;
+    user_assert(f < FeatureEnd) << "Invalid Target feature.\n";
+    return features[f];
+}
+
+bool Target::features_any_of(std::vector<Feature> test_features) const {
+    for (Feature f : test_features) {
+        if (has_feature(f)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Target::features_all_of(std::vector<Feature> test_features) const {
+    for (Feature f : test_features) {
+        if (!has_feature(f)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+Target Target::with_feature(Feature f) const {
+    Target copy = *this;
+    copy.set_feature(f);
+    return copy;
+}
+
+Target Target::without_feature(Feature f) const {
+    Target copy = *this;
+    copy.set_feature(f, false);
+    return copy;
+}
+
+bool Target::has_gpu_feature() const {
+    return has_feature(CUDA) || has_feature(OpenCL) || has_feature(Metal) || has_feature(D3D12Compute);
+}
+
+bool Target::supports_type(const Type &t) const {
+    if (t.bits() == 64) {
+        if (t.is_float()) {
+            return !has_feature(Metal) &&
+                   !has_feature(D3D12Compute) &&
+                   (!has_feature(Target::OpenCL) || has_feature(Target::CLDoubles));
+        } else {
+            return !has_feature(Metal) && !has_feature(D3D12Compute);
+        }
+    }
+    return true;
+}
+
 bool Target::supports_type(const Type &t, DeviceAPI device) const {
     if (device == DeviceAPI::Default_GPU) {
         device = get_default_device_api_for_target(*this);
@@ -581,6 +646,56 @@ Target::Feature target_feature_for_device_api(DeviceAPI api) {
     case DeviceAPI::Hexagon:       return Target::HVX_128;
     case DeviceAPI::D3D12Compute:  return Target::D3D12Compute;
     default:                       return Target::FeatureEnd;
+    }
+}
+
+int Target::natural_vector_size(const Halide::Type &t) const {
+    user_assert(os != OSUnknown && arch != ArchUnknown && bits != 0)
+        << "natural_vector_size cannot be used on a Target with Unknown values.\n";
+
+    const bool is_integer = t.is_int() || t.is_uint();
+    const int data_size = t.bytes();
+
+    if (arch == Target::Hexagon) {
+        if (is_integer) {
+            // HVX is either 64 or 128 *byte* vector size.
+            if (has_feature(Halide::Target::HVX_128)) {
+                return 128 / data_size;
+            } else if (has_feature(Halide::Target::HVX_64)) {
+                return 64 / data_size;
+            } else {
+                user_error << "Target uses hexagon arch without hvx_128 or hvx_64 set.\n";
+                return 0;
+            }
+        } else {
+            // HVX does not have vector float instructions.
+            return 1;
+        }
+    } else if (arch == Target::X86) {
+        if (is_integer && (has_feature(Halide::Target::AVX512_Skylake) ||
+                           has_feature(Halide::Target::AVX512_Cannonlake))) {
+            // AVX512BW exists on Skylake and Cannonlake
+            return 64 / data_size;
+        } else if (t.is_float() && (has_feature(Halide::Target::AVX512) ||
+                                    has_feature(Halide::Target::AVX512_KNL) ||
+                                    has_feature(Halide::Target::AVX512_Skylake) ||
+                                    has_feature(Halide::Target::AVX512_Cannonlake))) {
+            // AVX512F is on all AVX512 architectures
+            return 64 / data_size;
+        } else if (has_feature(Halide::Target::AVX2)) {
+            // AVX2 uses 256-bit vectors for everything.
+            return 32 / data_size;
+        } else if (!is_integer && has_feature(Halide::Target::AVX)) {
+            // AVX 1 has 256-bit vectors for float, but not for
+            // integer instructions.
+            return 32 / data_size;
+        } else {
+            // SSE was all 128-bit. We ignore MMX.
+            return 16 / data_size;
+        }
+    } else {
+        // Assume 128-bit vectors on other targets.
+        return 16 / data_size;
     }
 }
 

--- a/src/Target.h
+++ b/src/Target.h
@@ -104,8 +104,8 @@ struct Target {
     Target() : os(OSUnknown), arch(ArchUnknown), bits(0) {}
     Target(OS o, Arch a, int b, std::vector<Feature> initial_features = std::vector<Feature>())
         : os(o), arch(a), bits(b) {
-        for (size_t i = 0; i < initial_features.size(); i++) {
-            set_feature(initial_features[i]);
+        for (const auto &f :initial_features) {
+            set_feature(f);
         }
     }
 
@@ -127,61 +127,27 @@ struct Target {
     /** Check if a target string is valid. */
     static bool validate_target_string(const std::string &s);
 
-    void set_feature(Feature f, bool value = true) {
-        if (f == FeatureEnd) return;
-        user_assert(f < FeatureEnd) << "Invalid Target feature.\n";
-        features.set(f, value);
-    }
+    void set_feature(Feature f, bool value = true);
 
-    void set_features(std::vector<Feature> features_to_set, bool value = true) {
-        for (Feature f : features_to_set) {
-            set_feature(f, value);
-        }
-    }
+    void set_features(std::vector<Feature> features_to_set, bool value = true);
 
-    bool has_feature(Feature f) const {
-        if (f == FeatureEnd) return true;
-        user_assert(f < FeatureEnd) << "Invalid Target feature.\n";
-        return features[f];
-    }
+    bool has_feature(Feature f) const;
 
-    bool features_any_of(std::vector<Feature> test_features) const {
-        for (Feature f : test_features) {
-            if (has_feature(f)) {
-                return true;
-            }
-        }
-        return false;
-    }
+    bool features_any_of(std::vector<Feature> test_features) const;
 
-    bool features_all_of(std::vector<Feature> test_features) const {
-        for (Feature f : test_features) {
-            if (!has_feature(f)) {
-                return false;
-            }
-        }
-        return true;
-    }
+    bool features_all_of(std::vector<Feature> test_features) const;
 
     /** Return a copy of the target with the given feature set.
      * This is convenient when enabling certain features (e.g. NoBoundsQuery)
      * in an initialization list, where the target to be mutated may be
      * a const reference. */
-    Target with_feature(Feature f) const {
-        Target copy = *this;
-        copy.set_feature(f);
-        return copy;
-    }
+    Target with_feature(Feature f) const;
 
     /** Return a copy of the target with the given feature cleared.
      * This is convenient when disabling certain features (e.g. NoBoundsQuery)
      * in an initialization list, where the target to be mutated may be
      * a const reference. */
-    Target without_feature(Feature f) const {
-        Target copy = *this;
-        copy.set_feature(f, false);
-        return copy;
-    }
+    Target without_feature(Feature f) const;
 
     /** Is a fully feature GPU compute runtime enabled? I.e. is
      * Func::gpu_tile and similar going to work? Currently includes
@@ -189,9 +155,7 @@ struct Target {
      * because it is not capable of gpgpu, and is not scheduled via
      * Func::gpu_tile.
      * TODO: Should OpenGLCompute be included here? */
-    bool has_gpu_feature() const {
-        return has_feature(CUDA) || has_feature(OpenCL) || has_feature(Metal) || has_feature(D3D12Compute);
-    }
+    bool has_gpu_feature() const;
 
     /** Does this target allow using a certain type. Generally all
      * types except 64-bit float and int/uint should be supported by
@@ -199,18 +163,7 @@ struct Target {
      *
      * It is likely better to call the version below which takes a DeviceAPI.
      */
-    bool supports_type(const Type &t) const {
-        if (t.bits() == 64) {
-            if (t.is_float()) {
-                return !has_feature(Metal) &&
-                       !has_feature(D3D12Compute) &&
-                       (!has_feature(Target::OpenCL) || has_feature(Target::CLDoubles));
-            } else {
-                return !has_feature(Metal) && !has_feature(D3D12Compute);
-            }
-        }
-        return true;
-    }
+    bool supports_type(const Type &t) const;
 
     /** Does this target allow using a certain type on a certain device.
      * This is the prefered version of this routine.
@@ -247,55 +200,7 @@ struct Target {
 
     /** Given a data type, return an estimate of the "natural" vector size
      * for that data type when compiling for this Target. */
-    int natural_vector_size(Halide::Type t) const {
-        user_assert(os != OSUnknown && arch != ArchUnknown && bits != 0)
-            << "natural_vector_size cannot be used on a Target with Unknown values.\n";
-
-        const bool is_integer = t.is_int() || t.is_uint();
-        const int data_size = t.bytes();
-
-        if (arch == Target::Hexagon) {
-            if (is_integer) {
-                // HVX is either 64 or 128 *byte* vector size.
-                if (has_feature(Halide::Target::HVX_128)) {
-                    return 128 / data_size;
-                } else if (has_feature(Halide::Target::HVX_64)) {
-                    return 64 / data_size;
-                } else {
-                    user_error << "Target uses hexagon arch without hvx_128 or hvx_64 set.\n";
-                    return 0;
-                }
-            } else {
-                // HVX does not have vector float instructions.
-                return 1;
-            }
-        } else if (arch == Target::X86) {
-            if (is_integer && (has_feature(Halide::Target::AVX512_Skylake) ||
-                               has_feature(Halide::Target::AVX512_Cannonlake))) {
-                // AVX512BW exists on Skylake and Cannonlake
-                return 64 / data_size;
-            } else if (t.is_float() && (has_feature(Halide::Target::AVX512) ||
-                                        has_feature(Halide::Target::AVX512_KNL) ||
-                                        has_feature(Halide::Target::AVX512_Skylake) ||
-                                        has_feature(Halide::Target::AVX512_Cannonlake))) {
-                // AVX512F is on all AVX512 architectures
-                return 64 / data_size;
-            } else if (has_feature(Halide::Target::AVX2)) {
-                // AVX2 uses 256-bit vectors for everything.
-                return 32 / data_size;
-            } else if (!is_integer && has_feature(Halide::Target::AVX)) {
-                // AVX 1 has 256-bit vectors for float, but not for
-                // integer instructions.
-                return 32 / data_size;
-            } else {
-                // SSE was all 128-bit. We ignore MMX.
-                return 16 / data_size;
-            }
-        } else {
-            // Assume 128-bit vectors on other targets.
-            return 16 / data_size;
-        }
-    }
+    int natural_vector_size(const Halide::Type &t) const;
 
     /** Given a data type, return an estimate of the "natural" vector size
      * for that data type when compiling for this Target. */


### PR DESCRIPTION
Not at all important, but some of these methods have grown pretty long over the years.