### PR TITLE
Revert "Ensure calls to codegen() are well-ordered"

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -403,10 +403,10 @@ void CodeGen_ARM::visit(const Mul *op) {
     }
 
     //
-    // Detect the cases where any of the operands has the pattern:
-    //      broadcast(widen(scalar))
+    // Detect the cases where any of the operands has the pattern: 
+    //      broadcast(widen(scalar)) 
     // and convert it to
-    //      widen(broadcast(scalar))
+    //      widen(broadcast(scalar)) 
     // to be able to generate vmlal.x instructions correctly from llvm.
     //
     if (op->type.is_int() || op->type.is_uint()) {
@@ -419,7 +419,7 @@ void CodeGen_ARM::visit(const Mul *op) {
         // If the pattern is there, and the cast is a widening cast
         if (cast_a && cast_a->value.type().bits() < op->type.bits()) {
             // generate a new Mul with flipped widen(broadcast(scalar))
-            Expr new_a = Cast::make(op->type,
+            Expr new_a = Cast::make(op->type, 
                                     Broadcast::make(cast_a->value, lanes));
             debug(4) << "Replaced: " << op->a << "\n  with: " << new_a << "\n";
             value = codegen(new_a * op->b);
@@ -431,7 +431,7 @@ void CodeGen_ARM::visit(const Mul *op) {
         const Broadcast *bcast_b = op->b.as<Broadcast>();
         const Cast *cast_b = bcast_b ? bcast_b->value.as<Cast>() : nullptr;
         if (cast_b && cast_b->value.type().bits() < op->type.bits()) {
-            Expr new_b = Cast::make(op->type,
+            Expr new_b = Cast::make(op->type, 
                                    Broadcast::make(cast_b->value, lanes));
             debug(4) << "Replaced: " << op->b << "\n  with: " << new_b << "\n";
             value = codegen(op->a * new_b);
@@ -517,10 +517,8 @@ void CodeGen_ARM::visit(const Min *op) {
         // Use a 2-wide vector instead
         Value *undef = UndefValue::get(f32x2);
         Constant *zero = ConstantInt::get(i32_t, 0);
-        Value *a = codegen(op->a);
-        Value *a_wide = builder->CreateInsertElement(undef, a, zero);
-        Value *b = codegen(op->b);
-        Value *b_wide = builder->CreateInsertElement(undef, b, zero);
+        Value *a_wide = builder->CreateInsertElement(undef, codegen(op->a), zero);
+        Value *b_wide = builder->CreateInsertElement(undef, codegen(op->b), zero);
         Value *wide_result;
         if (target.bits == 32) {
             wide_result = call_intrin(f32x2, 2, "llvm.arm.neon.vmins.v2f32", {a_wide, b_wide});
@@ -592,10 +590,8 @@ void CodeGen_ARM::visit(const Max *op) {
         // Use a 2-wide vector instead
         Value *undef = UndefValue::get(f32x2);
         Constant *zero = ConstantInt::get(i32_t, 0);
-        Value *a = codegen(op->a);
-        Value *a_wide = builder->CreateInsertElement(undef, a, zero);
-        Value *b = codegen(op->b);
-        Value *b_wide = builder->CreateInsertElement(undef, b, zero);
+        Value *a_wide = builder->CreateInsertElement(undef, codegen(op->a), zero);
+        Value *b_wide = builder->CreateInsertElement(undef, codegen(op->b), zero);
         Value *wide_result;
         if (target.bits == 32) {
             wide_result = call_intrin(f32x2, 2, "llvm.arm.neon.vmaxs.v2f32", {a_wide, b_wide});

--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -501,9 +501,7 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
 
         Constant *zero = ConstantInt::get(i32_t, 0);
         Value *zeros[] = {zero, zero};
-
-        // Order-of-evaluation is guaranteed to be in order in brace-init-lists,
-        // so the multiple calls to codegen here are fine
+        
         Value *launch_args[] = {
             get_user_context(),
             builder->CreateLoad(get_module_state(api_unique_name)),

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1248,44 +1248,38 @@ void CodeGen_LLVM::visit(const Variable *op) {
 }
 
 void CodeGen_LLVM::visit(const Add *op) {
-    Value *a = codegen(op->a);
-    Value *b = codegen(op->b);
     if (op->type.is_float()) {
-        value = builder->CreateFAdd(a, b);
+        value = builder->CreateFAdd(codegen(op->a), codegen(op->b));
     } else if (op->type.is_int() && op->type.bits() >= 32) {
         // We tell llvm integers don't wrap, so that it generates good
         // code for loop indices.
-        value = builder->CreateNSWAdd(a, b);
+        value = builder->CreateNSWAdd(codegen(op->a), codegen(op->b));
     } else {
-        value = builder->CreateAdd(a, b);
+        value = builder->CreateAdd(codegen(op->a), codegen(op->b));
     }
 }
 
 void CodeGen_LLVM::visit(const Sub *op) {
-    Value *a = codegen(op->a);
-    Value *b = codegen(op->b);
     if (op->type.is_float()) {
-        value = builder->CreateFSub(a, b);
+        value = builder->CreateFSub(codegen(op->a), codegen(op->b));
     } else if (op->type.is_int() && op->type.bits() >= 32) {
         // We tell llvm integers don't wrap, so that it generates good
         // code for loop indices.
-        value = builder->CreateNSWSub(a, b);
+        value = builder->CreateNSWSub(codegen(op->a), codegen(op->b));
     } else {
-        value = builder->CreateSub(a, b);
+        value = builder->CreateSub(codegen(op->a), codegen(op->b));
     }
 }
 
 void CodeGen_LLVM::visit(const Mul *op) {
-    Value *a = codegen(op->a);
-    Value *b = codegen(op->b);
     if (op->type.is_float()) {
-        value = builder->CreateFMul(a, b);
+        value = builder->CreateFMul(codegen(op->a), codegen(op->b));
     } else if (op->type.is_int() && op->type.bits() >= 32) {
         // We tell llvm integers don't wrap, so that it generates good
         // code for loop indices.
-        value = builder->CreateNSWMul(a, b);
+        value = builder->CreateNSWMul(codegen(op->a), codegen(op->b));
     } else {
-        value = builder->CreateMul(a, b);
+        value = builder->CreateMul(codegen(op->a), codegen(op->b));
     }
 }
 
@@ -1312,13 +1306,7 @@ void CodeGen_LLVM::visit(const Div *op) {
 
     int shift_amount;
     if (op->type.is_float()) {
-        // Don't call codegen() multiple times within an argument list:
-        // order-of-evaluation isn't guaranteed and can vary by compiler,
-        // leading to different LLVM IR ordering, which makes comparing
-        // output hard.
-        Value *a = codegen(op->a);
-        Value *b = codegen(op->b);
-        value = builder->CreateFDiv(a, b);
+        value = builder->CreateFDiv(codegen(op->a), codegen(op->b));
     } else if (is_const_power_of_two_integer(op->b, &shift_amount) &&
                (op->type.is_int() || op->type.is_uint())) {
         value = codegen(op->a >> shift_amount);
@@ -1478,6 +1466,7 @@ void CodeGen_LLVM::visit(const NE *op) {
 void CodeGen_LLVM::visit(const LT *op) {
     Value *a = codegen(op->a);
     Value *b = codegen(op->b);
+
     Halide::Type t = op->a.type();
     if (t.is_float()) {
         value = builder->CreateFCmpOLT(a, b);
@@ -1528,20 +1517,15 @@ void CodeGen_LLVM::visit(const GE *op) {
 }
 
 void CodeGen_LLVM::visit(const And *op) {
-    Value *a = codegen(op->a);
-    Value *b = codegen(op->b);
-    value = builder->CreateAnd(a, b);
+    value = builder->CreateAnd(codegen(op->a), codegen(op->b));
 }
 
 void CodeGen_LLVM::visit(const Or *op) {
-    Value *a = codegen(op->a);
-    Value *b = codegen(op->b);
-    value = builder->CreateOr(a, b);
+    value = builder->CreateOr(codegen(op->a), codegen(op->b));
 }
 
 void CodeGen_LLVM::visit(const Not *op) {
-    Value *a = codegen(op->a);
-    value = builder->CreateNot(a);
+    value = builder->CreateNot(codegen(op->a));
 }
 
 
@@ -1587,8 +1571,7 @@ Value *CodeGen_LLVM::codegen_buffer_pointer(Value *base_address, Halide::Type ty
     if (type.is_handle()) {
         return codegen_buffer_pointer(base_address, UInt(64, type.lanes()), index);
     } else {
-        Value *i = codegen(index);
-        return codegen_buffer_pointer(base_address, type, i);
+        return codegen_buffer_pointer(base_address, type, codegen(index));
     }
 }
 
@@ -1875,8 +1858,7 @@ llvm::Value *CodeGen_LLVM::create_broadcast(llvm::Value *v, int lanes) {
 }
 
 void CodeGen_LLVM::visit(const Broadcast *op) {
-    Value *v = codegen(op->value);
-    value = create_broadcast(v, op->lanes);
+    value = create_broadcast(codegen(op->value), op->lanes);
 }
 
 Value *CodeGen_LLVM::interleave_vectors(const std::vector<Value *> &vecs) {
@@ -2117,8 +2099,7 @@ void CodeGen_LLVM::codegen_predicated_vector_load(const Load *op) {
     const IntImm *stride = ramp ? ramp->stride.as<IntImm>() : nullptr;
 
     if (ramp && is_one(ramp->stride)) { // Dense vector load
-        Value *vpred = codegen(op->predicate);
-        value = codegen_dense_vector_load(op, vpred);
+        value = codegen_dense_vector_load(op, codegen(op->predicate));
     } else if (ramp && stride && stride->value == -1) {
         debug(4) << "Predicated dense vector load with stride -1\n\t" << Expr(op) << "\n";
         vector<int> indices(ramp->lanes);
@@ -2180,23 +2161,16 @@ void CodeGen_LLVM::visit(const Call *op) {
 
     } else if (op->is_intrinsic(Call::bitwise_and)) {
         internal_assert(op->args.size() == 2);
-        Value *a = codegen(op->args[0]);
-        Value *b = codegen(op->args[1]);
-        value = builder->CreateAnd(a, b);
+        value = builder->CreateAnd(codegen(op->args[0]), codegen(op->args[1]));
     } else if (op->is_intrinsic(Call::bitwise_xor)) {
         internal_assert(op->args.size() == 2);
-        Value *a = codegen(op->args[0]);
-        Value *b = codegen(op->args[1]);
-        value = builder->CreateXor(a, b);
+        value = builder->CreateXor(codegen(op->args[0]), codegen(op->args[1]));
     } else if (op->is_intrinsic(Call::bitwise_or)) {
         internal_assert(op->args.size() == 2);
-        Value *a = codegen(op->args[0]);
-        Value *b = codegen(op->args[1]);
-        value = builder->CreateOr(a, b);
+        value = builder->CreateOr(codegen(op->args[0]), codegen(op->args[1]));
     } else if (op->is_intrinsic(Call::bitwise_not)) {
         internal_assert(op->args.size() == 1);
-        Value *a = codegen(op->args[0]);
-        value = builder->CreateNot(a);
+        value = builder->CreateNot(codegen(op->args[0]));
     } else if (op->is_intrinsic(Call::reinterpret)) {
         internal_assert(op->args.size() == 1);
         Type dst = op->type;
@@ -2234,22 +2208,17 @@ void CodeGen_LLVM::visit(const Call *op) {
             }
 
         } else {
-            Value *a = codegen(op->args[0]);
-            value = builder->CreateBitCast(a, llvm_dst);
+            value = builder->CreateBitCast(codegen(op->args[0]), llvm_dst);
         }
     } else if (op->is_intrinsic(Call::shift_left)) {
         internal_assert(op->args.size() == 2);
-        Value *a = codegen(op->args[0]);
-        Value *b = codegen(op->args[1]);
-        value = builder->CreateShl(a, b);
+        value = builder->CreateShl(codegen(op->args[0]), codegen(op->args[1]));
     } else if (op->is_intrinsic(Call::shift_right)) {
         internal_assert(op->args.size() == 2);
-        Value *a = codegen(op->args[0]);
-        Value *b = codegen(op->args[1]);
         if (op->type.is_int()) {
-            value = builder->CreateAShr(a, b);
+            value = builder->CreateAShr(codegen(op->args[0]), codegen(op->args[1]));
         } else {
-            value = builder->CreateLShr(a, b);
+            value = builder->CreateLShr(codegen(op->args[0]), codegen(op->args[1]));
         }
     } else if (op->is_intrinsic(Call::abs)) {
 
@@ -2333,8 +2302,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         std::vector<llvm::Type*> arg_type(1);
         arg_type[0] = llvm_type_of(op->args[0].type());
         llvm::Function *fn = Intrinsic::getDeclaration(module.get(), Intrinsic::ctpop, arg_type);
-        Value *a = codegen(op->args[0]);
-        CallInst *call = builder->CreateCall(fn, a);
+        CallInst *call = builder->CreateCall(fn, codegen(op->args[0]));
         value = call;
     } else if (op->is_intrinsic(Call::count_leading_zeros) ||
                op->is_intrinsic(Call::count_trailing_zeros)) {
@@ -2395,8 +2363,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         if (cond.type().is_vector()) {
             scalarize(op);
         } else {
-            Value *c = codegen(cond);
-            create_assertion(c, op->args[2]);
+            create_assertion(codegen(cond), op->args[2]);
             value = codegen(op->args[1]);
         }
     } else if (op->is_intrinsic(Call::make_struct)) {
@@ -2505,10 +2472,10 @@ void CodeGen_LLVM::visit(const Call *op) {
                     call_args.push_back(codegen(op->args[i]));
                     dst = builder->CreateCall(append_string, call_args);
                 } else if (t.is_bool()) {
-                    Value *a = codegen(op->args[i]);
-                    Value *t = codegen(StringImm::make("true"));
-                    Value *f = codegen(StringImm::make("false"));
-                    call_args.push_back(builder->CreateSelect(a, t, f));
+                    call_args.push_back(builder->CreateSelect(
+                        codegen(op->args[i]),
+                        codegen(StringImm::make("true")),
+                        codegen(StringImm::make("false"))));
                     dst = builder->CreateCall(append_string, call_args);
                 } else if (t.is_int()) {
                     call_args.push_back(codegen(Cast::make(Int(64), op->args[i])));
@@ -2697,8 +2664,8 @@ void CodeGen_LLVM::visit(const Call *op) {
             if (!selected_value) {
                 selected_value = sub_fn.fn_ptr;
             } else {
-                Value *c = codegen(sub_fn.cond);
-                selected_value = builder->CreateSelect(c, sub_fn.fn_ptr, selected_value);
+                selected_value = builder->CreateSelect(codegen(sub_fn.cond),
+                                                       sub_fn.fn_ptr, selected_value);
             }
         }
         builder->CreateStore(selected_value, global);


### PR DESCRIPTION
Reverts halide/Halide#3212; we don't want it to land until Issue #3203 is resolved