### PR TITLE
Sync ScopedBinding<void> to the main template.

### DIFF
--- a/src/Scope.h
+++ b/src/Scope.h
@@ -307,13 +307,21 @@ struct ScopedBinding {
 
 template<>
 struct ScopedBinding<void> {
-    Scope<> &scope;
+    Scope<> *scope;
     std::string name;
-    ScopedBinding(Scope<> &scope, const std::string &name) : scope(scope), name(name) {
-        scope.push(name);
+    ScopedBinding(Scope<> &s, const std::string &n) : scope(&s), name(n) {
+        scope->push(name);
+    }
+    ScopedBinding(bool condition, Scope<> &s, const std::string &n) :
+        scope(condition ? &s : nullptr), name(n) {
+        if (condition) {
+            scope->push(name);
+        }
     }
     ~ScopedBinding() {
-        scope.pop(name);
+        if (scope) {
+            scope->pop(name);
+        }
     }
 };
 


### PR DESCRIPTION
Adds a constructor that allows to skip binding the name, which is
already present for other types, but not in the specialization for
void.