### PR TITLE
Incorrect acquire_context and release_context function names in test script

### DIFF
--- a/test/generator/acquire_release_aottest.cpp
+++ b/test/generator/acquire_release_aottest.cpp
@@ -179,13 +179,13 @@ void destroy_context() {
 // These functions replace the acquire/release implementation in src/runtime/cuda.cpp.
 // Since we don't parallelize access to the GPU in the schedule, we don't need synchronization
 // in our implementation of these functions.
-extern "C" int halide_acquire_cuda_context(void *user_context, CUcontext *ctx) {
+extern "C" int halide_cuda_acquire_context(void *user_context, CUcontext *ctx, bool create=true) {
     printf("Acquired CUDA context %p\n", cuda_ctx);
     *ctx = cuda_ctx;
     return 0;
 }
 
-extern "C" int halide_release_cuda_context(void *user_context) {
+extern "C" int halide_cuda_release_context(void *user_context) {
     printf("Releasing CUDA context %p\n", cuda_ctx);
     return 0;
 }


### PR DESCRIPTION
In `test/generator/acquire_release_aottest.cpp`, there are two functions:
1 - `halide_acquire_cuda_context(void *user_context, CUcontext *ctx)`
2 - `halide_release_cuda_context(void *user_context)`

I believe the purpose of these functions is to overwrite the behavior of functions with the same identifier defined in `src/runtime/cuda.cpp`. However, the functions in `cuda.cpp` differ in function name and arguments:
1 - `halide_cuda_acquire_context(void *user_context, CUcontext *ctx, bool create = true)`
2 - `halide_cuda_release_context(void *user_context)`

The problem should be fixed simply by changing the functions name and arguments in `acquire_release_aottest.cpp` to match those defined in `cuda.cpp`.