### PR TITLE
Move x86 to 64-byte alignment because of AVX-512.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -638,6 +638,7 @@ RUNTIME_CPP_COMPONENTS = \
   aarch64_cpu_features \
   alignment_128 \
   alignment_32 \
+  alignment_64 \
   android_clock \
   android_host_cpu_count \
   android_io \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ set(RUNTIME_CPP
   aarch64_cpu_features
   alignment_128
   alignment_32
+  alignment_64
   android_clock
   android_host_cpu_count
   android_io

--- a/src/runtime/alignment_64.cpp
+++ b/src/runtime/alignment_64.cpp
@@ -1,0 +1,11 @@
+#include "runtime_internal.h"
+
+namespace Halide {
+namespace Runtime {
+namespace Internal {
+
+WEAK __attribute__((always_inline)) int halide_malloc_alignment() {
+    return 64;
+}
+
+}}}


### PR DESCRIPTION
The comment in LLVM_Runtime_Linker.cpp explains the rationale. I'm open to discussion on trying to somehow dynamically decide the alignment size for x86, but chose to start with the simple reliable solution to prevent AVX 512 from crashing.

On my AVX 512 system, correctness_vectorized_reduction_bug crashes more than half the time without this fix. (And doesn't in 10 or 15 trials with the fix.)