### PR TITLE
Ignore function with empty pipeline bounds when creating partitioner

### DIFF
--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -1312,6 +1312,14 @@ Partitioner::Partitioner(const map<string, Box> &_pipeline_bounds,
     // Place each stage of a function in its own group. Each stage is
     // a node in the pipeline graph.
     for (const auto &f : dep_analysis.env) {
+        if (!pipeline_bounds.count(f.first)) {
+            // If a function does not have a pipeline bound (i.e. it can be
+            // statically proven that no one ever uses it), we should not
+            // consider it during the grouping.
+            debug(5) << "Creating partitioner: ignore function \"" << f.first
+                     << "\" since it has empty pipeline bounds\n";
+            continue;
+        }
         int num_stages = f.second.updates().size() + 1;
         for (int s = 0; s < num_stages; s++) {
             FStage stg(f.second, s);
@@ -3286,6 +3294,11 @@ set<string> get_unbounded_functions(const map<string, Box> &pipeline_bounds,
                                     const map<string, Function> &env) {
     set<string> unbounded;
     for (const auto &iter : env) {
+        if (!pipeline_bounds.count(iter.first)) {
+            debug(5) << "...Skip checking function \"" << iter.first
+                     << "\" since it does not have pipeline bounds\n";
+            continue;
+        }
         const Function &f = iter.second;
         if (!f.can_be_inlined() || used_by_extern_func(env, f)) {
             continue;

--- a/test/auto_schedule/unused_func.cpp
+++ b/test/auto_schedule/unused_func.cpp
@@ -1,0 +1,29 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Var x("x"), y("y");
+    Func f("f"), g("g"), h("h");
+
+    g(x) = x;
+    g(x) += 10;
+    h(x) = x*x;
+    f(x) = select(false, g(x + 1), h(x + 1));
+
+    f.estimate(x, 0, 256);
+
+    Target target = get_jit_target_from_environment();
+    Pipeline p(f);
+
+    p.auto_schedule(target);
+
+    // Inspect the schedule
+    f.print_loop_nest();
+
+    // Run the schedule
+    p.realize(256);
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
For cases, when it can be statically proven that a function will never be accessed, the pipeline bound of that function computed by the auto-scheduler will be empty. This will throw assertion errors, since the auto-scheduler assumes that each function within the environment should have a pipeline bound.  To fix this problem, during Partitioner creation, if it encounters function with no existing pipeline bounds, it will ignore the function since the function doesn't effect the grouping decision. 