### PR TITLE
Fix cases where halide_buffer_copy could copy to/from a NULL host pointer...

### DIFF
--- a/src/runtime/cuda.cpp
+++ b/src/runtime/cuda.cpp
@@ -678,8 +678,8 @@ WEAK int halide_cuda_device_malloc(void *user_context, halide_buffer_t *buf) {
 }
 
 namespace {
-WEAK int do_multidimensional_copy(void *user_context, const device_copy &c,
-                                  uint64_t src, uint64_t dst, int d, bool from_host, bool to_host) {
+WEAK int cuda_do_multidimensional_copy(void *user_context, const device_copy &c,
+                                       uint64_t src, uint64_t dst, int d, bool from_host, bool to_host) {
     if (d > MAX_COPY_DIMS) {
         error(user_context) << "Buffer has too many dimensions to copy to/from GPU\n";
         return -1;
@@ -712,7 +712,7 @@ WEAK int do_multidimensional_copy(void *user_context, const device_copy &c,
     } else {
         ssize_t src_off = 0, dst_off = 0;
         for (int i = 0; i < (int)c.extent[d-1]; i++) {
-            int err = do_multidimensional_copy(user_context, c, src + src_off, dst + dst_off, d - 1, from_host, to_host);
+            int err = cuda_do_multidimensional_copy(user_context, c, src + src_off, dst + dst_off, d - 1, from_host, to_host);
             dst_off += c.dst_stride_bytes[d-1];
             src_off += c.src_stride_bytes[d-1];
             if (err) {
@@ -769,7 +769,7 @@ WEAK int halide_cuda_buffer_copy(void *user_context, struct halide_buffer_t *src
         }
         #endif
 
-        err = do_multidimensional_copy(user_context, c, c.src + c.src_begin, c.dst, dst->dimensions, from_host, to_host);
+        err = cuda_do_multidimensional_copy(user_context, c, c.src + c.src_begin, c.dst, dst->dimensions, from_host, to_host);
 
         #ifdef DEBUG_RUNTIME
         uint64_t t_after = halide_current_time_ns(user_context);

--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -505,7 +505,8 @@ WEAK int halide_buffer_copy_already_locked(void *user_context, struct halide_buf
                                    (src->host == NULL || !src->host_dirty());
     const bool to_device = dst_device_interface != NULL;
     const bool to_host = dst_device_interface == NULL;
-    const bool from_host_valid = !src->device_dirty() || (src->device_interface == NULL);
+    const bool from_host_valid = src->host != NULL &&
+                                 (!src->device_dirty() || (src->device_interface == NULL));
     const bool from_host_exists = src->host != NULL;
     const bool to_host_exists = dst->host != NULL;
 

--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -779,10 +779,10 @@ WEAK int halide_opencl_device_malloc(void *user_context, halide_buffer_t* buf) {
 }
 
 namespace {
-WEAK int do_multidimensional_copy(void *user_context, ClContext &ctx,
-                                  const device_copy &c,
-                                  int64_t src_idx, int64_t dst_idx,
-                                  int d, bool from_host, bool to_host) {
+WEAK int opencl_do_multidimensional_copy(void *user_context, ClContext &ctx,
+                                         const device_copy &c,
+                                         int64_t src_idx, int64_t dst_idx,
+                                         int d, bool from_host, bool to_host) {
     if (d > MAX_COPY_DIMS) {
         error(user_context) << "Buffer has too many dimensions to copy to/from GPU\n";
         return -1;
@@ -820,7 +820,7 @@ WEAK int do_multidimensional_copy(void *user_context, ClContext &ctx,
     } else {
         ssize_t src_off = 0, dst_off = 0;
         for (int i = 0; i < (int)c.extent[d-1]; i++) {
-            int err = do_multidimensional_copy(user_context, ctx, c,
+            int err = opencl_do_multidimensional_copy(user_context, ctx, c,
                                                src_idx + src_off, dst_idx + dst_off,
                                                d - 1, from_host, to_host);
             dst_off += c.dst_stride_bytes[d-1];
@@ -879,7 +879,7 @@ WEAK int halide_opencl_buffer_copy(void *user_context, struct halide_buffer_t *s
         }
         #endif
 
-        err = do_multidimensional_copy(user_context, ctx, c, c.src_begin, 0, dst->dimensions, from_host, to_host);
+        err = opencl_do_multidimensional_copy(user_context, ctx, c, c.src_begin, 0, dst->dimensions, from_host, to_host);
 
         // The reads/writes above are all non-blocking, so empty the command
         // queue before we proceed so that other host code won't write


### PR DESCRIPTION
...where the case was valid by copying from the device allocation.

Add tests for these cases.

Change name of do_multidimensional_copy in opencl and cuda runtimes to
be unique to each runtime as the opencl runtime was calling the cuda
do_multidimensional_copy despite both being in anonymous namespaces
inside their respective files. Weak linking and C++ namespaces and our
unusual runtime linking and probably at least one bug somewhere caused
this to go badly. The failure required having both cuda and opencl in the target
at the same time.