### PR TITLE
Buffer<const T>::copy_from() should be illegal

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1135,6 +1135,7 @@ public:
     */
     template<typename T2, int D2>
     void copy_from(const Buffer<T2, D2> &other) {
+        static_assert(!std::is_const<T>::value, "Cannot call copy_from() on a Buffer<const T>");
         assert(!device_dirty() && "Cannot call Halide::Runtime::Buffer::copy_from on a device dirty destination.");
         assert(!other.device_dirty() && "Cannot call Halide::Runtime::Buffer::copy_from on a device dirty source.");
 
@@ -2197,7 +2198,7 @@ public:
      * bounds. Compared to doing the host pointer check directly,
      * this both adds clarity to code and will facilitate moving to
      * another representation for bounds query arguments. */
-    bool is_bounds_query() {
+    bool is_bounds_query() const {
         return buf.is_bounds_query();
     }
 


### PR DESCRIPTION
It should not be legal to call copy_from() on a Buffer with a const value type, but (thanks to explicit casting in the implementation which subverts the usual checks), it is. Added a static_cast() to prevent this.

Also, a drive-by fix to make is_bounds_query() a const method.