### PR TITLE
Buffer::fill() and similar should return ref-to-self

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -406,15 +406,38 @@ public:
     HALIDE_BUFFER_FORWARD(device_deallocate)
     HALIDE_BUFFER_FORWARD(device_free)
     HALIDE_BUFFER_FORWARD_CONST(all_equal)
-    HALIDE_BUFFER_FORWARD(fill)
-    HALIDE_BUFFER_FORWARD_CONST(for_each_element)
 
 #undef HALIDE_BUFFER_FORWARD
 #undef HALIDE_BUFFER_FORWARD_CONST
 
     template<typename Fn, typename ...Args>
-    void for_each_value(Fn &&f, Args... other_buffers) {
-        return get()->for_each_value(std::forward<Fn>(f), (*std::forward<Args>(other_buffers).get())...);
+    Buffer<T> &for_each_value(Fn &&f, Args... other_buffers) {
+        get()->for_each_value(std::forward<Fn>(f), (*std::forward<Args>(other_buffers).get())...);
+        return *this;
+    }
+
+    template<typename Fn, typename ...Args>
+    const Buffer<T> &for_each_value(Fn &&f, Args... other_buffers) const {
+        get()->for_each_value(std::forward<Fn>(f), (*std::forward<Args>(other_buffers).get())...);
+        return *this;
+    }
+
+    template<typename Fn>
+    Buffer<T> &for_each_element(Fn &&f) {
+        get()->for_each_element(std::forward<Fn>(f));
+        return *this;
+    }
+
+    template<typename Fn>
+    const Buffer<T> &for_each_element(Fn &&f) const {
+        get()->for_each_element(std::forward<Fn>(f));
+        return *this;
+    }
+
+    template<typename FnOrValue>
+    Buffer<T> &fill(FnOrValue &&f) {
+        get()->fill(std::forward<FnOrValue>(f));
+        return *this;
     }
 
     static constexpr bool has_static_halide_type = Runtime::Buffer<T>::has_static_halide_type;

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1135,6 +1135,7 @@ public:
     */
     template<typename T2, int D2>
     void copy_from(const Buffer<T2, D2> &other) {
+        static_assert(!std::is_const<T>::value, "Cannot call copy_from() on a Buffer<const T>");
         assert(!device_dirty() && "Cannot call Halide::Runtime::Buffer::copy_from on a device dirty destination.");
         assert(!other.device_dirty() && "Cannot call Halide::Runtime::Buffer::copy_from on a device dirty source.");
 
@@ -1818,9 +1819,10 @@ public:
         return all_equal;
     }
 
-    void fill(not_void_T val) {
+    Buffer<T, D> &fill(not_void_T val) {
         set_host_dirty();
         for_each_value([=](T &v) {v = val;});
+        return *this;
     }
 
 private:
@@ -1904,25 +1906,9 @@ private:
             }
         }
     }
-    // @}
 
-public:
-    /** Call a function on every value in the buffer, and the
-     * corresponding values in some number of other buffers of the
-     * same size. The function should take a reference, const
-     * reference, or value of the correct type for each buffer. This
-     * effectively lifts a function of scalars to an element-wise
-     * function of buffers. This produces code that the compiler can
-     * autovectorize. This is slightly cheaper than for_each_element,
-     * because it does not need to track the coordinates.
-     *
-     * Note that constness of Buffers is preserved: a const Buffer<T> (for either
-     * 'this' or the other-buffers arguments) will allow mutation of the
-     * buffer contents, while a Buffer<const T> will not. Attempting to specify
-     * a mutable reference for the lambda argument of a Buffer<const T>
-     * will result in a compilation error. */
     template<typename Fn, typename ...Args, int N = sizeof...(Args) + 1>
-    void for_each_value(Fn &&f, Args&&... other_buffers) const {
+    void for_each_value_impl(Fn &&f, Args&&... other_buffers) const {
         for_each_value_task_dim<N> *t =
             (for_each_value_task_dim<N> *)HALIDE_ALLOCA((dimensions()+1) * sizeof(for_each_value_task_dim<N>));
         for (int i = 0; i <= dimensions(); i++) {
@@ -1973,6 +1959,38 @@ public:
             for_each_value_helper<false>(f, dimensions() - 1, t, begin(), (other_buffers.begin())...);
         }
     }
+    // @}
+
+public:
+    /** Call a function on every value in the buffer, and the
+     * corresponding values in some number of other buffers of the
+     * same size. The function should take a reference, const
+     * reference, or value of the correct type for each buffer. This
+     * effectively lifts a function of scalars to an element-wise
+     * function of buffers. This produces code that the compiler can
+     * autovectorize. This is slightly cheaper than for_each_element,
+     * because it does not need to track the coordinates.
+     *
+     * Note that constness of Buffers is preserved: a const Buffer<T> (for either
+     * 'this' or the other-buffers arguments) will allow mutation of the
+     * buffer contents, while a Buffer<const T> will not. Attempting to specify
+     * a mutable reference for the lambda argument of a Buffer<const T>
+     * will result in a compilation error. */
+    // @{
+    template<typename Fn, typename ...Args, int N = sizeof...(Args) + 1>
+    HALIDE_ALWAYS_INLINE
+    const Buffer<T, D> &for_each_value(Fn &&f, Args&&... other_buffers) const {
+        for_each_value_impl(f, std::forward<Args>(other_buffers)...);
+        return *this;
+    }
+
+    template<typename Fn, typename ...Args, int N = sizeof...(Args) + 1>
+    HALIDE_ALWAYS_INLINE
+    Buffer<T, D> &for_each_value(Fn &&f, Args&&... other_buffers) {
+        for_each_value_impl(f, std::forward<Args>(other_buffers)...);
+        return *this;
+    }
+    // @}
 
 private:
 
@@ -2096,8 +2114,19 @@ private:
         assert(dims >= args);
         for_each_element_variadic(0, args - 1, t, std::forward<Fn>(f));
     }
-public:
 
+    template<typename Fn>
+    void for_each_element_impl(Fn &&f) const {
+        for_each_element_task_dim *t =
+            (for_each_element_task_dim *)HALIDE_ALLOCA(dimensions() * sizeof(for_each_element_task_dim));
+        for (int i = 0; i < dimensions(); i++) {
+            t[i].min = dim(i).min();
+            t[i].max = dim(i).max();
+        }
+        for_each_element(0, dimensions(), t, std::forward<Fn>(f));
+    }
+
+public:
     /** Call a function at each site in a buffer. This is likely to be
      * much slower than using Halide code to populate a buffer, but is
      * convenient for tests. If the function has more arguments than the
@@ -2154,16 +2183,21 @@ public:
      \endcode
 
     */
+    // @{
     template<typename Fn>
-    void for_each_element(Fn &&f) const {
-        for_each_element_task_dim *t =
-            (for_each_element_task_dim *)HALIDE_ALLOCA(dimensions() * sizeof(for_each_element_task_dim));
-        for (int i = 0; i < dimensions(); i++) {
-            t[i].min = dim(i).min();
-            t[i].max = dim(i).max();
-        }
-        for_each_element(0, dimensions(), t, std::forward<Fn>(f));
+    HALIDE_ALWAYS_INLINE
+    const Buffer<T, D> &for_each_element(Fn &&f) const {
+        for_each_element_impl(f);
+        return *this;
     }
+
+    template<typename Fn>
+    HALIDE_ALWAYS_INLINE
+    Buffer<T, D> &for_each_element(Fn &&f) {
+        for_each_element_impl(f);
+        return *this;
+    }
+    // @}
 
 private:
     template<typename Fn>
@@ -2187,17 +2221,17 @@ public:
      * stored to the coordinate corresponding to the arguments. */
     template<typename Fn,
              typename = typename std::enable_if<!std::is_arithmetic<typename std::decay<Fn>::type>::value>::type>
-    void fill(Fn &&f) {
+    Buffer<T, D> &fill(Fn &&f) {
         // We'll go via for_each_element. We need a variadic wrapper lambda.
         FillHelper<Fn> wrapper(std::forward<Fn>(f), this);
-        for_each_element(wrapper);
+        return for_each_element(wrapper);
     }
 
     /** Check if an input buffer passed extern stage is a querying
      * bounds. Compared to doing the host pointer check directly,
      * this both adds clarity to code and will facilitate moving to
      * another representation for bounds query arguments. */
-    bool is_bounds_query() {
+    bool is_bounds_query() const {
         return buf.is_bounds_query();
     }
 

--- a/test/correctness/halide_buffer.cpp
+++ b/test/correctness/halide_buffer.cpp
@@ -336,6 +336,25 @@ int main(int argc, char **argv) {
         // c.for_each_value([&](int c_value, int a_value, int &b_value) { }, a_const, b_const);
     }
 
+    {
+        // Check initializing const buffers via return ref from fill(), etc
+        const int W = 5, H = 4;
+
+        const Buffer<const int> a = Buffer<int>(W, H).fill(1);
+        assert(a.all_equal(1));
+
+        const Buffer<const int> b = Buffer<int>(W, H).for_each_value([](int &value) { value = 2; });
+        assert(b.all_equal(2));
+
+        // for_each_element()'s callback doesn't get the Buffer itself, so we need a named temp here
+        auto c0 = Buffer<int>(W, H);
+        const Buffer<const int> c = c0.for_each_element([&](int x, int y) { c0(x, y) = 3; });
+        assert(c.all_equal(3));
+
+        const Buffer<const int> d = Buffer<int>(W, H).fill([](int x, int y) -> int { return 4; });
+        assert(d.all_equal(4));
+    }
+
     printf("Success!\n");
     return 0;
 }


### PR DESCRIPTION
This allows for somewhat easier initializing of `Buffer<const T>` via use of fill(), for_each_value(), etc while minimizing the use of named temporaries.

(Related: would it make sense to add a reference-to-self as a final argument to the callback for `for_each_element`?)