### PR TITLE
Re-enable addus/subus in simd_op_check

### DIFF
--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -309,18 +309,12 @@ struct Test {
             check("paddsb",  8*w, i8_sat(i16(i8_1) + i16(3)));
             check("psubsb",  8*w, i8_sat(i16(i8_1) - i16(i8_2)));
 
-            // TODO: re-enable after LLVM bug https://bugs.llvm.org/show_bug.cgi?id=38691
-            // is fixed.
-            std::cout << "Skipping tests for paddusb and psubusb\n";
-            // check("paddusb", 8*w, u8(min(u16(u8_1) + u16(u8_2), max_u8)));
-            // check("psubusb", 8*w, u8(max(i16(u8_1) - i16(u8_2), 0)));
+            check("paddusb", 8*w, u8(min(u16(u8_1) + u16(u8_2), max_u8)));
+            check("psubusb", 8*w, u8(max(i16(u8_1) - i16(u8_2), 0)));
             check("paddsw",  4*w, i16_sat(i32(i16_1) + i32(i16_2)));
             check("psubsw",  4*w, i16_sat(i32(i16_1) - i32(i16_2)));
-            // TODO: re-enable after LLVM bug https://bugs.llvm.org/show_bug.cgi?id=38691
-            // is fixed.
-            std::cout << "Skipping tests for paddusw and psubusw\n";
-            // check("paddusw", 4*w, u16(min(u32(u16_1) + u32(u16_2), max_u16)));
-            // check("psubusw", 4*w, u16(max(i32(u16_1) - i32(u16_2), 0)));
+            check("paddusw", 4*w, u16(min(u32(u16_1) + u32(u16_2), max_u16)));
+            check("psubusw", 4*w, u16(max(i32(u16_1) - i32(u16_2), 0)));
             check("pmulhw",  4*w, i16((i32(i16_1) * i32(i16_2)) / (256*256)));
             check("pmulhw",  4*w, i16((i32(i16_1) * i32(i16_2)) >> 16));
 
@@ -336,9 +330,9 @@ struct Test {
             check("pmulhuw", 4*w, i16_1 / 15);
 
 
-            // TODO: re-enable after LLVM bug https://bugs.llvm.org/show_bug.cgi?id=38691
+            // TODO: re-enable after LLVM bug https://bugs.llvm.org/show_bug.cgi?id=???
             // is fixed.
-            std::cout << "Skipping tests for pcmp*b and pcmp*w and pcmp*d\n";
+            std::cout << "Skipping tests for pcmp\n";
             // check("pcmp*b", 8*w, select(u8_1 == u8_2, u8(1), u8(2)));
             // check("pcmp*b", 8*w, select(u8_1 > u8_2, u8(1), u8(2)));
             // check("pcmp*w", 4*w, select(u16_1 == u16_2, u16(1), u16(2)));
@@ -572,20 +566,14 @@ struct Test {
             check("vpsubb*ymm", 32, u8_1 - u8_2);
             check("vpaddsb*ymm", 32, i8_sat(i16(i8_1) + i16(i8_2)));
             check("vpsubsb*ymm", 32, i8_sat(i16(i8_1) - i16(i8_2)));
-            // TODO: re-enable after LLVM bug https://bugs.llvm.org/show_bug.cgi?id=38691
-            // is fixed.
-            std::cout << "Skipping tests for vpaddusb*ymm and vpsubusb*ymm\n";
-            // check("vpaddusb*ymm", 32, u8(min(u16(u8_1) + u16(u8_2), max_u8)));
-            // check("vpsubusb*ymm", 32, u8(max(i16(u8_1) - i16(u8_2), 0)));
+            check("vpaddusb*ymm", 32, u8(min(u16(u8_1) + u16(u8_2), max_u8)));
+            check("vpsubusb*ymm", 32, u8(max(i16(u8_1) - i16(u8_2), 0)));
             check("vpaddw*ymm", 16, u16_1 + u16_2);
             check("vpsubw*ymm", 16, u16_1 - u16_2);
             check("vpaddsw*ymm", 16, i16_sat(i32(i16_1) + i32(i16_2)));
             check("vpsubsw*ymm", 16, i16_sat(i32(i16_1) - i32(i16_2)));
-            // TODO: re-enable after LLVM bug https://bugs.llvm.org/show_bug.cgi?id=38691
-            // is fixed.
-            std::cout << "Skipping tests for vpaddusw*ymm and vpsubusw*ymm\n";
-            // check("vpaddusw*ymm", 16, u16(min(u32(u16_1) + u32(u16_2), max_u16)));
-            // check("vpsubusw*ymm", 16, u16(max(i32(u16_1) - i32(u16_2), 0)));
+            check("vpaddusw*ymm", 16, u16(min(u32(u16_1) + u32(u16_2), max_u16)));
+            check("vpsubusw*ymm", 16, u16(max(i32(u16_1) - i32(u16_2), 0)));
             check("vpaddd*ymm", 8, i32_1 + i32_2);
             check("vpsubd*ymm", 8, i32_1 - i32_2);
             check("vpmulhw*ymm", 16, i16((i32(i16_1) * i32(i16_2)) / (256*256)));


### PR DESCRIPTION
Underlying bug in LLVM fixed in trunk.

Note that pcmp is still disabled due to related bug which is not yet fixed.