### PR TITLE
Add new simplifier rules to handle warp shuffle breakage

### DIFF
--- a/src/Simplify_Max.cpp
+++ b/src/Simplify_Max.cpp
@@ -127,6 +127,11 @@ Expr Simplify::visit(const Max *op, ConstBounds *bounds) {
                rewrite(max(y + x, x), max(y, 0) + x) ||
                rewrite(max(x + y, x), x + max(y, 0)) ||
 
+               rewrite(max((x*c0 + y)*c1, x*c2 + z), max(y*c1, z) + x*c2, c0 * c1 == c2) ||
+               rewrite(max((y + x*c0)*c1, x*c2 + z), max(y*c1, z) + x*c2, c0 * c1 == c2) ||
+               rewrite(max((x*c0 + y)*c1, z + x*c2), max(y*c1, z) + x*c2, c0 * c1 == c2) ||
+               rewrite(max((y + x*c0)*c1, z + x*c2), max(y*c1, z) + x*c2, c0 * c1 == c2) ||
+
                rewrite(max(max(x + y, z), x + w), max(x + max(y, w), z)) ||
                rewrite(max(max(z, x + y), x + w), max(x + max(y, w), z)) ||
                rewrite(max(max(x + y, z), w + x), max(x + max(y, w), z)) ||

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -130,6 +130,11 @@ Expr Simplify::visit(const Min *op, ConstBounds *bounds) {
                rewrite(min(y + x, x), min(y, 0) + x) ||
                rewrite(min(x + y, x), x + min(y, 0)) ||
 
+               rewrite(min((x*c0 + y)*c1, x*c2 + z), min(y*c1, z) + x*c2, c0 * c1 == c2) ||
+               rewrite(min((y + x*c0)*c1, x*c2 + z), min(y*c1, z) + x*c2, c0 * c1 == c2) ||
+               rewrite(min((x*c0 + y)*c1, z + x*c2), min(y*c1, z) + x*c2, c0 * c1 == c2) ||
+               rewrite(min((y + x*c0)*c1, z + x*c2), min(y*c1, z) + x*c2, c0 * c1 == c2) ||
+
                rewrite(min(min(x + y, z), x + w), min(x + min(y, w), z)) ||
                rewrite(min(min(z, x + y), x + w), min(x + min(y, w), z)) ||
                rewrite(min(min(x + y, z), w + x), min(x + min(y, w), z)) ||

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -745,6 +745,15 @@ void check_bounds() {
     check(max(min(x, 5), 1) == 3, x == 3);
     check(max(min(x, 5), 1) == 5, 5 <= x);
 
+    check(min((x*32 + y)*4, x*128 + 127), min(y*4, 127) + x*128);
+    check(min((x*32 + y)*4, x*128 + 4), (min(y, 1) + x*32)*4);
+    check(min((y + x*32)*4, x*128 + 127), min(y*4, 127) + x*128);
+    check(min((y + x*32)*4, x*128 + 4), (min(y, 1) + x*32)*4);
+    check(max((x*32 + y)*4, x*128 + 127), max(y*4, 127) + x*128);
+    check(max((x*32 + y)*4, x*128 + 4), (max(y, 1) + x*32)*4);
+    check(max((y + x*32)*4, x*128 + 127), max(y*4, 127) + x*128);
+    check(max((y + x*32)*4, x*128 + 4), (max(y, 1) + x*32)*4);
+
     {
         Expr one = 1;
         Expr three = 3;


### PR DESCRIPTION
The simultaneous merge of the new simplifier and using the host cuda capabilities broke the warp shuffles test in master. This adds a new simplifier rule to unbreak it.