### PR TITLE
Add FILTER environment variable for simd_op_check.

### DIFF
--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -2139,10 +2139,17 @@ check("v*.w += vrmpy(v*.b,v*.b)", hvx_width, i32_1 + i32(i8_1)*i8_1 + i32(i8_2)*
 int main(int argc, char **argv) {
     Test test;
 
+    // Check if we have a filter, from either the environment or command line.
+    const char* filter = getenv("FILTER");
     if (argc > 1) {
-        test.filter = argv[1];
+        filter = argv[1];
+    }
+
+    if (filter) {
+        test.filter = filter;
         num_threads = 1;
     }
+
 
     if (argc > 2) {
         // Don't forget: if you want to run the standard tests to a specific output


### PR DESCRIPTION
This makes it easier to debug simd_op_check test failures. Setting the command line can't be done from a make command, so this enables specifying a filter while still going through the makefile and without modifying/rebuilding the test.