### PR TITLE
Expand LLVM_CONFIG and CLANG for test_apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1639,7 +1639,7 @@ TEST_APPS=\
 test_apps: distrib
 	@for APP in $(TEST_APPS); do \
 		echo Testing app $${APP}... ; \
-		make -C $(ROOT_DIR)/apps/$${APP} test HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR) BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP} || exit 1 ; \
+		make -C $(ROOT_DIR)/apps/$${APP} test LLVM_CONFIG=$(realpath $(LLVM_CONFIG)) CLANG=$(realpath $(CLANG)) HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR) BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP} || exit 1 ; \
 	done
 
 # Bazel depends on the distrib archive being built


### PR DESCRIPTION
The test_apps target recursively calls sub-makefiles (which can change the WD), but the buildbots define LLVM_CONFIG and CLANG as relative paths, so these can become invalid when building apps. (Why this hasn't caused more failures in the past is a bit of a mystery.) Use $(realpath) to explicitly expand these vars for the sub-makefile calls to address this.