### PR TITLE
Revise apps/ to depend only on distrib/ folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,7 @@ foreach(F mex_halide.m
           halide_image.h
           halide_image_io.h
           halide_image_info.h
+          halide_malloc_trace.h
           halide_trace_config.h)
   install(FILES "${HALIDE_BASE_DIR}/tools/${F}"
           DESTINATION tools)

--- a/Makefile
+++ b/Makefile
@@ -935,6 +935,7 @@ clean:
 	rm -rf $(INCLUDE_DIR)
 	rm -rf $(DOC_DIR)
 	rm -rf $(DISTRIB_DIR)
+	rm -rf $(ROOT_DIR)/apps/*/bin
 
 .SECONDARY:
 
@@ -1639,7 +1640,10 @@ TEST_APPS=\
 test_apps: distrib
 	@for APP in $(TEST_APPS); do \
 		echo Testing app $${APP}... ; \
-		make -C $(ROOT_DIR)/apps/$${APP} test HALIDE_BIN_PATH=$(CURDIR) HALIDE_SRC_PATH=$(ROOT_DIR) BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP} || exit 1 ; \
+		make -C $(ROOT_DIR)/apps/$${APP} test \
+			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
+			BIN=$(ROOT_DIR)/apps/$${APP}/bin \
+			|| exit 1 ; \
 	done
 
 # Bazel depends on the distrib archive being built
@@ -1803,6 +1807,7 @@ install: $(LIB_DIR)/libHalide.a $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR
 	cp $(ROOT_DIR)/tools/halide_image.h $(PREFIX)/share/halide/tools
 	cp $(ROOT_DIR)/tools/halide_image_io.h $(PREFIX)/share/halide/tools
 	cp $(ROOT_DIR)/tools/halide_image_info.h $(PREFIX)/share/halide/tools
+	cp $(ROOT_DIR)/tools/halide_malloc_trace.h $(PREFIX)/share/halide/tools
 ifeq ($(UNAME), Darwin)
 	install_name_tool -id $(PREFIX)/lib/libHalide.$(SHARED_EXT) $(PREFIX)/lib/libHalide.$(SHARED_EXT)
 endif
@@ -1835,7 +1840,8 @@ $(DISTRIB_DIR)/halide.tgz: $(LIB_DIR)/libHalide.a \
 						   $(ROOT_DIR)/README*.md \
 						   $(ROOT_DIR)/bazel/* \
 						   $(BUILD_DIR)/halide_config.bzl \
-						   $(BUILD_DIR)/halide_config.cmake \
+               $(BUILD_DIR)/halide_config.cmake \
+               $(BUILD_DIR)/halide_config.make \
 						   $(ROOT_DIR)/halide.cmake
 	mkdir -p $(DISTRIB_DIR)/include \
 	         $(DISTRIB_DIR)/bin \
@@ -1864,6 +1870,7 @@ $(DISTRIB_DIR)/halide.tgz: $(LIB_DIR)/libHalide.a \
 	cp $(ROOT_DIR)/tools/halide_image.h $(DISTRIB_DIR)/tools
 	cp $(ROOT_DIR)/tools/halide_image_io.h $(DISTRIB_DIR)/tools
 	cp $(ROOT_DIR)/tools/halide_image_info.h $(DISTRIB_DIR)/tools
+	cp $(ROOT_DIR)/tools/halide_malloc_trace.h $(DISTRIB_DIR)/tools
 	cp $(ROOT_DIR)/tools/halide_trace_config.h $(DISTRIB_DIR)/tools
 	cp $(ROOT_DIR)/README*.md $(DISTRIB_DIR)
 	cp $(ROOT_DIR)/bazel/BUILD $(DISTRIB_DIR)
@@ -1890,6 +1897,7 @@ $(DISTRIB_DIR)/halide.tgz: $(LIB_DIR)/libHalide.a \
 		halide/tools/halide_image.h \
 		halide/tools/halide_image_io.h \
 		halide/tools/halide_image_info.h \
+		halide/tools/halide_malloc_trace.h \
 		halide/tools/halide_trace_config.h
 	rm -rf halide
 

--- a/apps/HelloMatlab/run_blur.m
+++ b/apps/HelloMatlab/run_blur.m
@@ -1,5 +1,5 @@
 % Add the path to mex_halide.m.
-addpath(fullfile(getenv('HALIDE_SRC_PATH'), 'tools'));
+addpath(fullfile(getenv('HALIDE_DISTRIB_PATH'), 'tools'));
 
 % Build the mex library from the blur generator.
 mex_halide('iir_blur.cpp', '-g', 'IirBlur');

--- a/apps/fft/Makefile
+++ b/apps/fft/Makefile
@@ -57,7 +57,7 @@ $(BIN)/fft_inverse_c2c.a: $(BIN)/fft.generator
 
 $(BIN)/fft_aot_test: fft_aot_test.cpp $(BIN)/fft_forward_r2c.a $(BIN)/fft_inverse_c2r.a $(BIN)/fft_forward_c2c.a $(BIN)/fft_inverse_c2c.a
 	@mkdir -p $(@D)
-	$(CXX) -I$(BIN) -I$(HALIDE_BIN_PATH)/include/ -std=c++11 $^ -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
+	$(CXX) -I$(BIN) -I$(HALIDE_DISTRIB_PATH)/include/ -std=c++11 $^ -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LDFLAGS)
 
 clean:
 	rm -rf $(BIN)

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -1,5 +1,4 @@
-HALIDE_BIN_PATH ?= ../..
-HALIDE_SRC_PATH ?= ../..
+HALIDE_DISTRIB_PATH ?= ../../distrib
 LDFLAGS ?=
 BIN ?= ./bin
 IMAGES ?= ../images
@@ -16,8 +15,8 @@ endif
 CXX ?= g++
 GXX ?= g++
 
-CFLAGS += -I $(HALIDE_BIN_PATH)/include/ -I $(HALIDE_SRC_PATH)/tools/ -I $(HALIDE_SRC_PATH)/apps/support/
-CXXFLAGS += -std=c++11 -I $(HALIDE_BIN_PATH)/include/ -I $(HALIDE_SRC_PATH)/tools/ -I $(HALIDE_SRC_PATH)/apps/support/
+CFLAGS += -I $(HALIDE_DISTRIB_PATH)/include/ -I $(HALIDE_DISTRIB_PATH)/tools/ -I $(HALIDE_DISTRIB_PATH)/apps/support/
+CXXFLAGS += -std=c++11 -I $(HALIDE_DISTRIB_PATH)/include/ -I $(HALIDE_DISTRIB_PATH)/tools/
 
 ifeq ($(UNAME), Darwin)
 CXXFLAGS += -fvisibility=hidden
@@ -39,12 +38,11 @@ LDFLAGS-host ?= $(LDFLAGS)
 LDFLAGS-arm-64-android ?= -llog -fPIE -pie
 LDFLAGS-arm-32-android ?= -llog -fPIE -pie
 
-LIB_HALIDE = $(HALIDE_BIN_PATH)/lib/libHalide.a
+LIB_HALIDE = $(HALIDE_DISTRIB_PATH)/lib/libHalide.a
 
-GENERATOR_DEPS ?= $(HALIDE_BIN_PATH)/lib/libHalide.a $(HALIDE_BIN_PATH)/include/Halide.h $(HALIDE_SRC_PATH)/tools/GenGen.cpp
+GENERATOR_DEPS ?= $(HALIDE_DISTRIB_PATH)/lib/libHalide.a $(HALIDE_DISTRIB_PATH)/include/Halide.h $(HALIDE_DISTRIB_PATH)/tools/GenGen.cpp
 
 LLVM_CONFIG ?= llvm-config
-LLVM_VERSION_TIMES_10 = $(shell $(LLVM_CONFIG) --version | cut -b 1,3)
 HALIDE_SYSTEM_LDFLAGS = $(shell $(LLVM_CONFIG) --link-static --system-libs)
 
 ifeq ($(UNAME), Linux)
@@ -106,13 +104,13 @@ ifneq (, $(findstring metal,$(HL_TARGET)))
   LDFLAGS += -framework Metal -framework Foundation
 endif
 
-$(BIN)/RunGen.o: $(HALIDE_SRC_PATH)/tools/RunGen.cpp
+$(BIN)/RunGen.o: $(HALIDE_DISTRIB_PATH)/tools/RunGen.cpp
 	@mkdir -p $(@D)
 	@$(CXX) -c $< $(CXXFLAGS) $(IMAGE_IO_CXX_FLAGS) -I$(BIN) -o $@
 
 # Really, .SECONDARY is what we want, but it won't accept wildcards
 .PRECIOUS: $(BIN)/%.rungen
-$(BIN)/%.rungen: $(BIN)/%.a $(BIN)/RunGen.o $(HALIDE_SRC_PATH)/tools/RunGenStubs.cpp
+$(BIN)/%.rungen: $(BIN)/%.a $(BIN)/RunGen.o $(HALIDE_DISTRIB_PATH)/tools/RunGenStubs.cpp
 	$(CXX) $(CXXFLAGS) -I$(BIN) -DHL_RUNGEN_FILTER_HEADER=\"$*.h\" $^ -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
 
 RUNARGS ?=

--- a/tools/halide_config.make.tpl
+++ b/tools/halide_config.make.tpl
@@ -1,0 +1,2 @@
+# Machine-Generated: Do Not Edit
+HALIDE_SYSTEM_LIBS=@HALIDE_SYSTEM_LIBS_RAW@

--- a/tools/mex_halide.m
+++ b/tools/mex_halide.m
@@ -19,8 +19,8 @@ function mex_halide( generator_filename, varargin )
 %
 % This script uses two environment variables that can optionally be
 % set or changed:
-%  - HALIDE_SRC_PATH: The path to the root directory of Halide. If
-%    unspecified, this defaults to '..' relative to mex_halide.m.
+%  - HALIDE_DISTRIB_PATH: The path to the distrib directory of Halide. If
+%    unspecified, this defaults to '../../distrib' relative to mex_halide.m.
 %  - HALIDE_CXX: The C++ compiler to use to build generators. The
 %    default is 'c++'.
 
@@ -50,18 +50,18 @@ function mex_halide( generator_filename, varargin )
     generator_args = strjoin(varargin);
     target = 'host-matlab';
 
-    if isempty(getenv('HALIDE_SRC_PATH'))
+    if isempty(getenv('HALIDE_DISTRIB_PATH'))
         % If the user has not set the halide path, get the path of
-        % this file (presumably in $HALIDE_SRC_PATH/tools/) and use
+        % this file (presumably in $HALIDE_DISTRIB_PATH/tools/) and use
         % that.
         [path, ~] = fileparts(mfilename('fullpath'));
-        halide_path = fullfile(path, '..');
-        setenv('HALIDE_SRC_PATH', halide_path);
+        halide_distrib_path = fullfile(path, '..');
+        setenv('HALIDE_DISTRIB_PATH', halide_distrib_path);
     end
-    halide_path = getenv('HALIDE_SRC_PATH');
+    halide_distrib_path = getenv('HALIDE_DISTRIB_PATH');
 
-    libhalide = fullfile(halide_path, 'bin', 'libHalide.so');
-    halide_include = fullfile(halide_path, 'include');
+    libhalide = fullfile(halide_distrib_path, 'bin', 'libHalide.so');
+    halide_include = fullfile(halide_distrib_path, 'include');
 
     if isempty(getenv('HALIDE_CXX'))
         % If the user has not set a compiler for Halide, use c++.
@@ -69,7 +69,7 @@ function mex_halide( generator_filename, varargin )
     end
     halide_cxx = getenv('HALIDE_CXX');
 
-    ld_library_path = fullfile(halide_path, 'bin');
+    ld_library_path = fullfile(halide_distrib_path, 'bin');
 
     % Build the command to build the generator.
     gen_bin = fullfile(temp, [function_name, '.generator']);


### PR DESCRIPTION
Up to now, the apps/ folders all got the privelege to look inside Halide; this revises them to depend only on the contents of the distrib/ folder, as should be the case for all 'normal' Halide-using apps. This patch mostly mimics the approach used by python_bindings/, which already has this assumption. Details include:
- Makefile.inc references HALIDE_DISTRIB_PATH rather than HALIDE_SRC_PATH/HALIDE_BIN_PATH
- having the test_apps target define HALIDE_DISTRIB_PATH instead of HALIDE_SRC_PATH/HALIDE_BIN_PATH
- moving the 'bin' dirs to be inside the apps/ subfolders (so that they are invariant whether built by test_apps or individually and making clean address them too
- Fixing some assumptions made in the matlab code
- adding tools/halide_malloc_trace.h to the distrib folder

This also adds a `halide_config.make` stub to the distrib folder (as we have already been doing for CMake and Bazel), so that we can hopefully remove the use of LLVM_CONFIG in the apps/ support as well. (I'm deliberately avoiding doing that in this PR in order to ensure that just the distrib-only change doesn't break anything on its own.)

@dsharletg -- I haven't (yet) tested the Matlab-specific changes; they probably could use a closer look from someone more familiar with that code (ie, you)