### PR TITLE
Hexagon Alignment Failures - modulus_remainder of vector

### DIFF
--- a/src/HexagonAlignment.h
+++ b/src/HexagonAlignment.h
@@ -32,6 +32,9 @@ public:
         const Ramp *ramp = index.as<Ramp>();
         if (ramp) {
             index = ramp->base;
+        } else if (index.type().is_vector()) {
+            debug(3) << "Is Unaligned\n";
+            return false;
         }
         // If this is a parameter, the base_alignment should be
         // host_alignment. Otherwise, this is an internal buffer,


### PR DESCRIPTION
@dsharletg @pranavb-ca @dpalermo PTAL.
I was getting the following failure for scatters on hexagon: "modulus_remainder of vector".
The patch resolves the error.
test/correctness/hexagon_scatter from https://github.com/halide/Halide/pull/3309 needs this patch for successful run without hvx_v65 target feature.