### PR TITLE
Rebuild FFT app when libHalide changes

### DIFF
--- a/apps/fft/Makefile
+++ b/apps/fft/Makefile
@@ -22,7 +22,7 @@ UNAME = $(shell uname)
 # 	LDFLAGS += -Wl,-stack_size -Wl,0x100000
 # endif
 
-$(BIN)/bench_fft: main.cpp fft.cpp fft.h complex.h funct.h
+$(BIN)/bench_fft: main.cpp fft.cpp fft.h complex.h funct.h $(LIB_HALIDE)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) main.cpp fft.cpp $(LIB_HALIDE) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 


### PR DESCRIPTION
In order to resolve buildbots not recompiling the FFT app, make it depend on libHalide.

Apps that use generators depend on `GENERATOR_DEPS` so are not afflicted by the non-recompilation problem.