### PR TITLE
Device buffer copy fixes

### DIFF
--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -465,7 +465,7 @@ WEAK int halide_buffer_copy_already_locked(void *user_context, struct halide_buf
     debug(user_context) << "halide_buffer_copy_already_locked called.\n";
     int err = 0;
 
-    if (dst->device_interface &&
+    if (dst_device_interface && dst->device_interface &&
         dst_device_interface != dst->device_interface) {
         halide_error(user_context, "halide_buffer_copy does not support switching device interfaces");
         return halide_error_code_incompatible_device_interface;
@@ -509,6 +509,10 @@ WEAK int halide_buffer_copy_already_locked(void *user_context, struct halide_buf
     const bool from_host_valid = from_host_exists &&
                                  (!src->device_dirty() || (src->device_interface == NULL));
     const bool to_host_exists = dst->host != NULL;
+
+    if (to_host && !to_host_exists) {
+        return halide_error_code_host_is_null;
+    }
 
     // If a device to device copy is requested, try to do it directly.
     err = halide_error_code_incompatible_device_interface;

--- a/test/correctness/device_buffer_copy.cpp
+++ b/test/correctness/device_buffer_copy.cpp
@@ -193,6 +193,19 @@ int main(int argc, char **argv) {
         }
     }
 
+    printf("Test copy device to host no dest host -- confirm error not segfault.\n");
+    {
+        Halide::Runtime::Buffer<int32_t> gpu_buf1 = make_gpu_buffer(hexagon_rpc);
+        assert(gpu_buf1.raw_buffer()->device_interface != nullptr);
+        halide_buffer_t no_host_dst = *gpu_buf1.raw_buffer();
+        no_host_dst.host = nullptr;
+
+        Halide::Runtime::Buffer<int32_t> gpu_buf2 = make_gpu_buffer(hexagon_rpc, 256000);
+        assert(gpu_buf2.raw_buffer()->device_interface != nullptr);
+
+        assert(gpu_buf1.raw_buffer()->device_interface->buffer_copy(nullptr, gpu_buf2, nullptr, &no_host_dst) == halide_error_code_host_is_null);
+    }
+
     // Test copying between different device APIs. Probably will not
     // run on test infrastructure as we do not configure more than one
     // GPU API at a time. For now, special case CUDA and OpenCL as these are
@@ -327,9 +340,22 @@ int main(int argc, char **argv) {
 
             for (int i = 0; i < 128; i++) {
                 for (int j = 0; j < 128; j++) {
-                    assert(gpu_buf1(i, j) == (i + j * 256 + 256000));
+                    assert(gpu_buf1(i, j) == (i + j * 256));
                 }
             }
+        }
+
+        printf("Test cross device copy device to host with no dest host.\n");
+        {
+            Halide::Runtime::Buffer<int32_t> gpu_buf1 = make_gpu_buffer(false, 0, DeviceAPI::CUDA);
+            assert(gpu_buf1.raw_buffer()->device_interface != nullptr);
+
+            Halide::Runtime::Buffer<int32_t> gpu_buf2 = make_gpu_buffer(false, 256000, DeviceAPI::OpenCL);
+            assert(gpu_buf2.raw_buffer()->device_interface != nullptr);
+            halide_buffer_t no_host_dst = *gpu_buf2.raw_buffer();
+            no_host_dst.host = nullptr;
+
+            assert(gpu_buf1.raw_buffer()->device_interface->buffer_copy(nullptr, gpu_buf1, nullptr, &no_host_dst) == halide_error_code_host_is_null);
         }
     }
     


### PR DESCRIPTION
Add tests for three cases and fix code to make them pass.

1) Copying from a device to the host side of a buffer with a different device interface. This could fail with an error indicating that it was trying to switch device interfaces on the destination buffer. This now works. (One test added, requires having two GPU APIS in HL_JIT_TARGET in order to run.)

2) Copying to the host side of a buffer with a null host pointer. This now returns an error instead of segfaulting. (Two tests added. One requires two GPU APIs and the other only one.)