### PR TITLE
Only emit default-values to metadata when defined

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -123,10 +123,10 @@ Outputs compute_outputs(const Target &target,
     return output_files;
 }
 
-Argument to_argument(const Internal::Parameter &param) {
+Argument to_argument(const Internal::Parameter &param, const Expr &default_value) {
     Expr def, min, max;
     if (!param.is_buffer()) {
-        def = param.scalar_expr();
+        def = default_value; // *not* param.scalar_expr();
         min = param.min_value();
         max = param.max_value();
     }
@@ -1421,11 +1421,11 @@ Module GeneratorBase::build_module(const std::string &function_name,
     ParamInfo &pi = param_info();
     std::vector<Argument> filter_arguments;
     for (auto rp : pi.filter_params) {
-        filter_arguments.push_back(to_argument(*rp));
+        filter_arguments.push_back(to_argument(*rp, rp->is_buffer() ? Expr() : rp->scalar_expr()));
     }
     for (auto input : pi.filter_inputs) {
         for (const auto &p : input->parameters_) {
-            filter_arguments.push_back(to_argument(p));
+            filter_arguments.push_back(to_argument(p, p.is_buffer() ? Expr() : input->get_def_expr()));
         }
     }
 
@@ -1672,6 +1672,10 @@ void GeneratorInputBase::check_value_writable() const {
 
 void GeneratorInputBase::set_def_min_max() {
     // nothing
+}
+
+Expr GeneratorInputBase::get_def_expr() const {
+    return Expr();
 }
 
 Parameter GeneratorInputBase::parameter() const {

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -323,6 +323,15 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           nullptr,
         },
         {
+          "no_default_value",
+          halide_argument_kind_input_scalar,
+          0,
+          halide_type_t(halide_type_int, 32),
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
           "b",
           halide_argument_kind_input_scalar,
           0,
@@ -498,7 +507,7 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           halide_argument_kind_input_scalar,
           0,
           halide_type_t(halide_type_int, 8),
-          make_scalar<int8_t>(0),
+          nullptr,
           nullptr,
           nullptr,
         },
@@ -507,7 +516,7 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           halide_argument_kind_input_scalar,
           0,
           halide_type_t(halide_type_int, 8),
-          make_scalar<int8_t>(0),
+          nullptr,
           nullptr,
           nullptr,
         },
@@ -516,7 +525,7 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           halide_argument_kind_input_scalar,
           0,
           halide_type_t(halide_type_int, 8),
-          make_scalar<int8_t>(0),
+          nullptr,
           nullptr,
           nullptr,
         },
@@ -525,7 +534,7 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           halide_argument_kind_input_scalar,
           0,
           halide_type_t(halide_type_int, 8),
-          make_scalar<int8_t>(0),
+          nullptr,
           nullptr,
           nullptr,
         },
@@ -1074,6 +1083,7 @@ int main(int argc, char **argv) {
         input,             // Input<Buffer<uint8_t>>
         input,             // Input<Buffer<>>(3)
         input,             // Input<Buffer<>>
+        0,                 // Input<i32>
         false,             // Input<bool>
         0,                 // Input<i8>
         0,                 // Input<i16>
@@ -1132,6 +1142,7 @@ int main(int argc, char **argv) {
         input,             // Input<Buffer<uint8_t>>
         input,             // Input<Buffer<>>(3)
         input,             // Input<Buffer<>>
+        0,                 // Input<i32>
         false,             // Input<bool>
         0,                 // Input<i8>
         0,                 // Input<i16>

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -11,6 +11,7 @@ public:
     Input<Buffer<uint8_t>> typed_input_buffer{ "typed_input_buffer", 3 };
     Input<Buffer<>> dim_only_input_buffer{ "dim_only_input_buffer", 3 };  // must be overridden to type=UInt(8)
     Input<Buffer<>> untyped_input_buffer{ "untyped_input_buffer" };  // must be overridden to {UInt(8), 3}
+    Input<int32_t> no_default_value{ "no_default_value" };
     Input<bool> b{ "b", true };
     Input<int8_t> i8{ "i8", 8, -8, 127 };
     Input<int16_t> i16{ "i16", 16, -16, 127 };


### PR DESCRIPTION
Our metadata format was designed to emit null fields for def/min/max of scalar values when said values aren't defined; in the case of Generators with Input<SomeScalar>, we were emitting a default of zero (rather than "no default") for the case of no-default-specified. This fixes the issue and updates the test.