### PR TITLE
Fix bugs with extern stages

### DIFF
--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -705,6 +705,7 @@ void Function::define_extern(const std::string &function_name,
     contents->extern_uses_old_buffer_t = use_old_buffer_t;
 
     std::vector<Expr> values;
+    contents->output_buffers.clear();
     for (size_t i = 0; i < types.size(); i++) {
         string buffer_name = name();
         if (types.size() > 1) {

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -419,6 +419,7 @@ Stmt build_produce(const map<string, Function> &env, Function f, const Target &t
         // extern function call.
         vector<pair<Expr, int>> buffers_to_annotate;
         vector<Expr> buffers_contents_to_annotate;
+        vector<pair<Expr, Expr>> cropped_buffers;
         for (const ExternFuncArgument &arg : args) {
             if (arg.is_expr()) {
                 extern_call_args.push_back(arg.expr);
@@ -482,6 +483,7 @@ Stmt build_produce(const map<string, Function> &env, Function f, const Target &t
                         extern_call_args.push_back(Variable::make(type_of<struct halide_buffer_t *>(), buf_name));
                         buffers_to_annotate.push_back({extern_call_args.back(), input.dimensions()});
                         buffers_contents_to_annotate.push_back(cropped_input);
+                        cropped_buffers.push_back({extern_call_args.back(), src_buffer});
                         lets.push_back({ buf_name, cropped_input });
                     }
                 }
@@ -512,7 +514,6 @@ Stmt build_produce(const map<string, Function> &env, Function f, const Target &t
         // ones already injected by allocation bounds inference. If
         // it's the output to the pipeline then it will similarly be
         // in the symbol table.
-        vector<pair<Expr, Expr>> cropped_buffers;
         if (!needs_crops && f.schedule().store_level() == f.schedule().compute_level()) {
             for (int j = 0; j < f.outputs(); j++) {
                 string buf_name = f.name();

--- a/test/generator/extern_output_aottest.cpp
+++ b/test/generator/extern_output_aottest.cpp
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "HalideBuffer.h"
+#include "extern_output.h"
+
+using namespace Halide::Runtime;
+
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+extern "C" DLLEXPORT
+int extern_stage(halide_buffer_t *input, int addend, halide_buffer_t *output) {
+    // Note the final output buffer argument is unused.
+    if (input->is_bounds_query()) {
+        for (int d = 0; d < 2; d++) {
+            // Request some range of the input buffer
+            input->dim[d].min = output->dim[d].min;
+            input->dim[d].extent = output->dim[d].extent;
+        }
+    } else if (!output->is_bounds_query()) {
+        int min_x = output->dim[0].min;
+        int max_x = min_x + output->dim[0].extent - 1;
+        int min_y = output->dim[1].min;
+        int max_y = min_y + output->dim[1].extent - 1;
+        for (int y = min_y; y <= max_y; y++) {
+            for (int x = min_x; x <= max_x; x++) {
+                int coords[2] = { x, y };
+                *(int *)output->address_of(coords) = *(int *)input->address_of(coords) + addend;
+            }
+        }
+    }
+
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    const int width = 100;
+    const int height = 200;
+    Buffer<int> input(width, height);
+    input.fill([](int x, int y) { return rand() % 256; });
+    int addend = 20;
+    Buffer<int> output(width, height);
+
+    extern_output(input, addend, output);
+
+    output.for_each_element([&](int x, int y) {
+        int correct = input(x, y) * 2 + addend;
+        int actual = output(x, y);
+        if (actual != correct) {
+            printf("output(%d, %d) = %d instead of %d %d\n",
+                   x, y, actual, correct, input(x, y));
+            exit(-1);
+        }
+    });
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/generator/extern_output_generator.cpp
+++ b/test/generator/extern_output_generator.cpp
@@ -1,0 +1,36 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+namespace {
+
+class ExternOutput : public Generator<ExternOutput> {
+    Input<Buffer<int>> input{ "input", 2 };
+    Input<int> addend{ "addend" };
+    Output<Buffer<int>> output{ "output", 2 };
+
+    Func work;
+    Var x, y;
+
+public:
+    void generate() {
+        work(x, y) = input(x, y) * 2;
+
+        std::vector<ExternFuncArgument> params = {work, addend};
+        std::vector<Type> types = {Int(32)};
+        std::vector<Var> args = {x, y};
+        output.define_extern("extern_stage", params, types, args);
+    }
+
+    void schedule() {
+        Var xo, yo;
+        output.tile(x, y, xo, yo, x, y, 16, 16)
+            .parallel(yo);
+
+        work.compute_at(output, xo);
+    }
+};
+
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(ExternOutput, extern_output)


### PR DESCRIPTION
This fixes a few bugs with extern stages:
- Extern stages used to generate two output buffers for each real output. This was never encountered because extern stages as an output buffer was not useful before #3352. Added a test covering this case.
- Only output crops were being retired. Retire both input and output crops.