### PR TITLE
Optional constraints for Input<Func> and Output<Func>

### DIFF
--- a/src/Dimension.cpp
+++ b/src/Dimension.cpp
@@ -71,8 +71,10 @@ Dimension Dimension::set_bounds_estimate(Expr min, Expr extent) {
     // (This matters mainly for OutputImageParams.)
     // Note that while it's possible/legal for a Dimension to have an undefined
     // Func, you shouldn't ever call set_bounds_estimate on such an instance.
-    internal_assert(f.defined());
-    f.estimate(f.args()[d], min, extent);
+    // (But don't fail: we might need to do this when using dimensions_and_alignment())
+    if (f.defined()) {
+        f.estimate(f.args()[d], min, extent);
+    }
     return *this;
 }
 

--- a/src/Dimension.h
+++ b/src/Dimension.h
@@ -11,6 +11,8 @@
 namespace Halide {
 namespace Internal {
 
+class DimensionsAndAlignment;
+
 class Dimension {
 public:
     /** Get an expression representing the minimum coordinates of this image
@@ -87,6 +89,7 @@ public:
 
 private:
     friend class ::Halide::OutputImageParam;
+    friend class ::Halide::Internal::DimensionsAndAlignment;
 
     /** Construct a Dimension representing dimension d of some
      * Internal::Parameter p. Only friends may construct

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1401,6 +1401,37 @@ Pipeline GeneratorBase::get_pipeline() {
     return pipeline;
 }
 
+void merge_aot_parameter(const Parameter &aot_param, Parameter* p) {
+    internal_assert(aot_param.dimensions() == p->dimensions());
+    for (int d = 0; d < p->dimensions(); d++) {
+        if (!p->min_constraint(d).same_as(aot_param.min_constraint(d))) {
+            debug(2) << "  Updating min_constraint(" << d << ") for " << p->name() << " -> " << aot_param.min_constraint(d) << "\n";
+            p->set_min_constraint(d, aot_param.min_constraint(d));
+        }
+        if (!p->extent_constraint(d).same_as(aot_param.extent_constraint(d))) {
+            debug(2) << "  Updating extent_constraint(" << d << ") for " << p->name() << " -> " << aot_param.extent_constraint(d) << "\n";
+            p->set_extent_constraint(d, aot_param.extent_constraint(d));
+        }
+        if (!p->stride_constraint(d).same_as(aot_param.stride_constraint(d))) {
+            debug(2) << "  Updating stride_constraint(" << d << ") for " << p->name() << " -> " << aot_param.stride_constraint(d) << "\n";
+            p->set_stride_constraint(d, aot_param.stride_constraint(d));
+        }
+        if (!p->min_constraint_estimate(d).same_as(aot_param.min_constraint_estimate(d))) {
+            debug(2) << "  Updating min_constraint_estimate(" << d << ") for " << p->name() << " -> " << aot_param.min_constraint_estimate(d) << "\n";
+            p->set_min_constraint_estimate(d, aot_param.min_constraint_estimate(d));
+        }
+        if (!p->extent_constraint_estimate(d).same_as(aot_param.extent_constraint_estimate(d))) {
+            debug(2) << "  Updating extent_constraint_estimate(" << d << ") for " << p->name() << " -> " << aot_param.extent_constraint_estimate(d) << "\n";
+            p->set_extent_constraint_estimate(d, aot_param.extent_constraint_estimate(d));
+        }
+    }
+    // alignment is an int, not an Expr
+    if (p->host_alignment() != aot_param.host_alignment()) {
+        debug(0) << "  Updating host_alignment() for " << p->name() << " -> " << aot_param.host_alignment() << "\n";
+        p->set_host_alignment(aot_param.host_alignment());
+    }
+}
+
 Module GeneratorBase::build_module(const std::string &function_name,
                                    const LinkageType linkage_type) {
     std::string auto_schedule_result;
@@ -1419,6 +1450,37 @@ Module GeneratorBase::build_module(const std::string &function_name,
     }
 
     ParamInfo &pi = param_info();
+
+    {
+        // If we had any Input<Func> or Output<Func> that had aot-only constraints
+        // placed upon them, update the Parameters now before we do anything else.
+        // (Some of this could be consolidated into the loops lower down, but doing it
+        // here makes the separation of issues more obvious.)
+        for (auto input : pi.filter_inputs) {
+            for (size_t i = 0; i < input->parameters_.size(); i++) {
+                auto &p = input->parameters_[i];
+                auto it = input->aot_parameters_.find(i);
+                if (it != input->aot_parameters_.end()) {
+                    debug(1) << "Updating dimensions_and_alignment() for input " << input->name() << "[" << i << "]\n";
+                    merge_aot_parameter(it->second, &p);
+                }
+            }
+        }
+
+        for (auto *output : pi.filter_outputs) {
+            for (size_t i = 0; i < output->funcs().size(); ++i) {
+                auto it = output->aot_parameters_.find(i);
+                if (it != output->aot_parameters_.end()) {
+                    debug(01) << "Updating dimensions_and_alignment() for output " << output->name() << "[" << i << "]\n";
+                    auto output_buffers = output->funcs()[i].function().output_buffers();
+                    for (auto &p : output_buffers) {
+                        merge_aot_parameter(it->second, &p);
+                    }
+                }
+            }
+        }
+    }
+
     std::vector<Argument> filter_arguments;
     for (auto rp : pi.filter_params) {
         filter_arguments.push_back(to_argument(*rp, rp->is_buffer() ? Expr() : rp->scalar_expr()));
@@ -1435,7 +1497,6 @@ Module GeneratorBase::build_module(const std::string &function_name,
         result.append(map_entry.second);
     }
 
-    auto outputs = pipeline.outputs();
     for (auto *output : pi.filter_outputs) {
         for (size_t i = 0; i < output->funcs().size(); ++i) {
             auto from = output->funcs()[i].name();
@@ -1646,6 +1707,17 @@ void GIOBase::check_matching_array_size(size_t size) const {
     } else {
         array_size_ = size;
     }
+}
+
+
+Parameter GIOBase::get_aot_parameter(int index) {
+    auto it = aot_parameters_.find(index);
+    if (it != aot_parameters_.end()) {
+        return it->second;
+    }
+    auto p = Parameter(type(), kind() != IOKind::Scalar, dims(), array_name(index), false);
+    aot_parameters_[index] = p;
+    return p;
 }
 
 GeneratorInputBase::GeneratorInputBase(size_t array_size,

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1213,6 +1213,38 @@ private:
     }
 };
 
+// TODO(srj): this name is terrible
+class DimensionsAndAlignment {
+public:
+    Dimension dim(int i) {
+        return Dimension(parameter_, i, Func());
+    }
+
+    const Dimension dim(int i) const {
+        return Dimension(parameter_, i, Func());
+    }
+
+    int host_alignment() const {
+        return parameter_.host_alignment();
+    }
+
+    void set_host_alignment(int bytes) {
+        parameter_.set_host_alignment(bytes);
+    }
+
+    int dimensions() const {
+        return parameter_.dimensions();
+    }
+
+private:
+    Parameter parameter_;
+
+    template<typename T> friend class GeneratorInput_Func;
+    template<typename T> friend class GeneratorOutput_Func;
+
+    explicit DimensionsAndAlignment(const Parameter &p) : parameter_(p) {}
+};
+
 /** GIOBase is the base class for all GeneratorInput<> and GeneratorOutput<>
  * instantiations; it is not part of the public API and should never be
  * used directly by user code.
@@ -1258,8 +1290,6 @@ protected:
             int dims);
     virtual ~GIOBase();
 
-    friend class GeneratorBase;
-
     mutable int array_size_;   // always 1 if is_array() == false.
                                // -1 if is_array() == true but unspecified.
 
@@ -1271,6 +1301,7 @@ protected:
     // Exactly one of these will have nonzero length
     std::vector<Func> funcs_;
     std::vector<Expr> exprs_;
+    std::map<int, Parameter> aot_parameters_;
 
     // Generator which owns this Input or Output. Note that this will be null
     // initially; the GeneratorBase itself will set this field when it initially
@@ -1294,7 +1325,10 @@ protected:
 
     virtual const char *input_or_output() const = 0;
 
+    Parameter get_aot_parameter(int index);
+
 private:
+    friend class GeneratorBase;
     template<typename T> friend class GeneratorParam_Synthetic;
 
     // No copy
@@ -1677,6 +1711,10 @@ public:
     HALIDE_FORWARD_METHOD_CONST(Func, value)
     HALIDE_FORWARD_METHOD_CONST(Func, values)
     // }@
+
+    DimensionsAndAlignment dimensions_and_alignment(int index = 0) {
+        return DimensionsAndAlignment(this->get_aot_parameter(index));
+    }
 };
 
 
@@ -2300,6 +2338,10 @@ public:
             f.estimate(var, min, extent);
         }
         return *this;
+    }
+
+    DimensionsAndAlignment dimensions_and_alignment(int index = 0) {
+        return DimensionsAndAlignment(this->get_aot_parameter(index));
     }
 };
 

--- a/test/generator/stubtest_aottest.cpp
+++ b/test/generator/stubtest_aottest.cpp
@@ -9,11 +9,11 @@ using Halide::Runtime::Buffer;
 const int kSize = 32;
 
 template<typename Type>
-Buffer<Type> make_image(int extra) {
-    Buffer<Type> im(kSize, kSize, 3);
+Buffer<Type> make_image(int extra, int channels = 3) {
+    Buffer<Type> im(kSize, kSize, channels);
     for (int x = 0; x < kSize; x++) {
         for (int y = 0; y < kSize; y++) {
-            for (int c = 0; c < 3; c++) {
+            for (int c = 0; c < channels; c++) {
                 im(x, y, c) = static_cast<Type>(x + y + c + extra);
             }
         }
@@ -44,17 +44,17 @@ void verify(const Buffer<InputType> &input, float float_arg, int int_arg, const 
 }
 
 int main(int argc, char **argv) {
-    Buffer<uint8_t> buffer_input = make_image<uint8_t>(0);
-    Buffer<float> simple_input = make_image<float>(0);
-    Buffer<float> array_input0 = make_image<float>(0);
-    Buffer<float> array_input1 = make_image<float>(1);
+    Buffer<uint8_t> buffer_input = make_image<uint8_t>(0, 5);
+    Buffer<float> simple_input = make_image<float>(0, 7);
+    Buffer<float> array_input0 = make_image<float>(0, 9);
+    Buffer<float> array_input1 = make_image<float>(1, 11);
     Buffer<float> typed_buffer_output(kSize, kSize, 3);
     Buffer<float> untyped_buffer_output(kSize, kSize, 3);
     Buffer<float> tupled_output0(kSize, kSize, 3);
     Buffer<int32_t> tupled_output1(kSize, kSize, 3);
     Buffer<uint8_t> array_buffer_input0 = make_image<uint8_t>(0);
     Buffer<uint8_t> array_buffer_input1 = make_image<uint8_t>(1);
-    Buffer<float> simple_output(kSize, kSize, 3);
+    Buffer<float> simple_output(kSize, kSize, 5);
     Buffer<float> tuple_output0(kSize, kSize, 3), tuple_output1(kSize, kSize, 3);
     Buffer<int16_t> array_output0(kSize, kSize), array_output1(kSize, kSize);
     Buffer<uint8_t> static_compiled_buffer_output(kSize, kSize, 3);

--- a/test/generator/stubtest_generator.cpp
+++ b/test/generator/stubtest_generator.cpp
@@ -88,6 +88,35 @@ public:
     void schedule() {
         intermediate.compute_at(intermediate_level);
         intermediate.specialize(vectorize).vectorize(x, natural_vector_size<float>());
+
+        typed_buffer_input.dim(2).set_bounds(0, 5);
+
+        // When AOT-compiling, set constraints on the Buffer for this input:
+        // - require that we have 7 'channels'
+        simple_input.dimensions_and_alignment().dim(2).set_bounds(0, 7);
+        // - require that the width is an even multiple of 32
+        simple_input.dimensions_and_alignment().dim(0).set_extent(
+            simple_input.dimensions_and_alignment().dim(0).extent()/32*32);
+
+        // Ditto for array inputs
+        for (size_t i = 0; i < array_input.size(); ++i) {
+            array_input.dimensions_and_alignment(i).dim(2).set_bounds(0, (int)(9 + i * 2));
+            array_input.dimensions_and_alignment(i).dim(0).set_extent(
+                array_input.dimensions_and_alignment(i).dim(0).extent()/32*32);
+        }
+
+        // Also set some constraints on Output<Func> for aot-only
+        // - require that we have 5 'channels'
+        simple_output.dimensions_and_alignment().dim(2).set_bounds(0, 5);
+        // - require that the width is an even multiple of 32
+        simple_output.dimensions_and_alignment().dim(0).set_extent(
+            simple_output.dimensions_and_alignment().dim(0).extent()/32*32);
+
+        // Ditto for array outputs
+        for (size_t i = 0; i < array_output.size(); ++i) {
+            array_output.dimensions_and_alignment(i).dim(0).set_extent(
+                array_output.dimensions_and_alignment(i).dim(0).extent()/32*32);
+        }
     }
 
 private:

--- a/test/generator/stubuser_generator.cpp
+++ b/test/generator/stubuser_generator.cpp
@@ -7,8 +7,8 @@ using StubNS1::StubNS2::StubTest;
 namespace {
 
 template<typename Type, int size = 32>
-Buffer<Type> make_image() {
-    Buffer<Type> im(size, size, 3);
+Buffer<Type> make_image(const std::string &name) {
+    Buffer<Type> im(size, size, 3, name);
     for (int x = 0; x < size; x++) {
         for (int y = 0; y < size; y++) {
             for (int c = 0; c < 3; c++) {
@@ -34,7 +34,7 @@ public:
     void generate() {
         Var x{"x"}, y{"y"}, c{"c"};
 
-        Buffer<uint8_t> constant_image = make_image<uint8_t>();
+        Buffer<uint8_t> constant_image = make_image<uint8_t>("constant_image");
 
         // We'll explicitly fill in the struct fields by name, just to show
         // it as an option. (Alternately, we could fill it in by using


### PR DESCRIPTION
This is a sketch of a possible way to address Issue #3306: `Input<Func>` and `Output<Func>` have a new method, `dimensions_and_alignment()`, which returns a struct that lets you get/set the min/extent/stride/host-alignment; these values are entirely ignored if the given Input/Output isn't AOT-compiled as a Buffer.

This works fine and I feel it's robust, but I'm not sure if this API is one I'm happy to support forever. That said, it would make it a lot easier to make composable Generators per the details in the issue.