### PR TITLE
Fix GLSL failures due to fix of #3221

### DIFF
--- a/apps/glsl/Makefile
+++ b/apps/glsl/Makefile
@@ -28,6 +28,8 @@ $(BIN)/opengl_test: opengl_test.cpp $(BIN)/halide_blur_glsl.a $(BIN)/halide_ycc_
 run: $(BIN)/opengl_test
 	LD_LIBRARY_PATH=../../bin $(BIN)/opengl_test
 
+test: run
+
 .PHONY: clean
 clean:
 	rm -rf $(BIN)

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -212,6 +212,12 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
     s = split_tuples(s, env);
     debug(2) << "Lowering after destructuring tuple-valued realizations:\n" << s << "\n\n";
 
+    // OpenGL relies on GPU var canonicalization occurring before
+    // storage flattening
+    debug(1) << "Canonicalizing GPU var names...\n";
+    s = canonicalize_gpu_vars(s);
+    debug(2) << "Lowering after canonicalizing GPU var names:\n" << s << '\n';
+
     debug(1) << "Performing storage flattening...\n";
     s = storage_flattening(s, outputs, env, t);
     debug(2) << "Lowering after storage flattening:\n" << s << "\n\n";
@@ -233,10 +239,6 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
         t.has_feature(Target::OpenGL) ||
         t.has_feature(Target::HexagonDma) ||
         (t.arch != Target::Hexagon && (t.features_any_of({Target::HVX_64, Target::HVX_128})))) {
-        debug(1) << "Canonicalizing GPU var names...\n";
-        s = canonicalize_gpu_vars(s);
-        debug(2) << "Lowering after canonicalizing GPU var names:\n" << s << '\n';
-
         debug(1) << "Selecting a GPU API for GPU loops...\n";
         s = select_gpu_api(s, t);
         debug(2) << "Lowering after selecting a GPU API:\n" << s << "\n\n";

--- a/test/correctness/gpu_bounds_inference_failure.cpp
+++ b/test/correctness/gpu_bounds_inference_failure.cpp
@@ -6,37 +6,38 @@ using namespace Halide;
 
 int main(int argc, char *argv[]) {
 
-  if (!t.has_feature(Target::CUDA)) {
-    printf("Not running test because cuda not enabled\n");
-  }
+    if (!t.has_feature(Target::CUDA)) {
+        printf("Not running test because cuda not enabled\n");
+        return 0;
+    }
 
-  Var x, y, p, d;
+    Var x, y, p, d;
 
-  Func f1, f2;
-  f1(x, y, p) = 0;
-  f2(x, y, p) = 0;
+    Func f1, f2;
+    f1(x, y, p) = 0;
+    f2(x, y, p) = 0;
 
-  RDom r(0, 10, 0, 10);
+    RDom r(0, 10, 0, 10);
 
-  Func b1, b2;
-  b1(p) = 0.f;
-  b1(p) += f1(r.x, r.y, p);
+    Func b1, b2;
+    b1(p) = 0.f;
+    b1(p) += f1(r.x, r.y, p);
 
-  b2(p) = 0.f;
-  b2(p) += f2(r.x, r.y, p);
+    b2(p) = 0.f;
+    b2(p) += f2(r.x, r.y, p);
 
-  Func d1, d2;
-  d1(p) = b1(p) - b2(p);
-  d2(p) = b2(p) - b1(p);
+    Func d1, d2;
+    d1(p) = b1(p) - b2(p);
+    d2(p) = b2(p) - b1(p);
 
-  Func result;
-  result(d, p) = select(d == 0, d1(p), d2(p));
+    Func result;
+    result(d, p) = select(d == 0, d1(p), d2(p));
 
-  d2.compute_root().gpu_blocks(p);
+    d2.compute_root().gpu_blocks(p);
 
-  // this used to cause an assertion error
-  result.compile_jit(Target("host-cuda"));
+    // this used to cause an assertion error
+    result.compile_jit(Target("host-cuda"));
 
-  printf("Success!\n");
-  return 0;
+    printf("Success!\n");
+    return 0;
 }

--- a/test/correctness/gpu_bounds_inference_failure.cpp
+++ b/test/correctness/gpu_bounds_inference_failure.cpp
@@ -6,6 +6,7 @@ using namespace Halide;
 
 int main(int argc, char *argv[]) {
 
+    Target t = get_jit_target_from_environment();
     if (!t.has_feature(Target::CUDA)) {
         printf("Not running test because cuda not enabled\n");
         return 0;

--- a/test/correctness/gpu_bounds_inference_failure.cpp
+++ b/test/correctness/gpu_bounds_inference_failure.cpp
@@ -6,6 +6,10 @@ using namespace Halide;
 
 int main(int argc, char *argv[]) {
 
+  if (!t.has_feature(Target::CUDA)) {
+    printf("Not running test because cuda not enabled\n");
+  }
+
   Var x, y, p, d;
 
   Func f1, f2;

--- a/test/correctness/gpu_bounds_inference_failure.cpp
+++ b/test/correctness/gpu_bounds_inference_failure.cpp
@@ -1,0 +1,36 @@
+// from issue #3221
+
+#include "Halide.h"
+
+int main(int argc, char *argv[]) {
+
+  Var x, y, p, d;
+
+  Func f1, f2;
+  f1(x, y, p) = 0;
+  f2(x, y, p) = 0;
+
+  RDom r(0, 10, 0, 10);
+
+  Func b1, b2;
+  b1(p) = 0.f;
+  b1(p) += f1(r.x, r.y, p);
+
+  b2(p) = 0.f;
+  b2(p) += f2(r.x, r.y, p);
+
+  Func d1, d2;
+  d1(p) = b1(p) - b2(p);
+  d2(p) = b2(p) - b1(p);
+
+  Func result;
+  result(d, p) = select(d == 0, d1(p), d2(p));
+
+  d2.compute_root().gpu_blocks(p);
+
+  // this used to cause an assertion error
+  result.compile_jit(Target("host-cuda"));
+
+  printf("Success!\n");
+  return 0;
+}

--- a/test/correctness/gpu_bounds_inference_failure.cpp
+++ b/test/correctness/gpu_bounds_inference_failure.cpp
@@ -2,6 +2,8 @@
 
 #include "Halide.h"
 
+using namespace Halide;
+
 int main(int argc, char *argv[]) {
 
   Var x, y, p, d;


### PR DESCRIPTION
Moving `canonicalize_gpu_vars` after storage flattening causes OpenGL to fail, since it relies on some transformations done during storage flattening.  This PR tries to resolve #3371 while preserving the fix to #3221 by moving canonicalization just before storage flattening.