### PR TITLE
expr_uses_var can early-out when the var is found

### DIFF
--- a/src/ExprUsesVar.h
+++ b/src/ExprUsesVar.h
@@ -19,6 +19,16 @@ class ExprUsesVars : public IRGraphVisitor {
     const Scope<T> &vars;
     Scope<Expr> scope;
 
+    void include(const Expr &e) override {
+        if (result) return;
+        IRGraphVisitor::include(e);
+    }
+
+    void include(const Stmt &s) override {
+        if (result) return;
+        IRGraphVisitor::include(s);
+    }
+
     void visit_name(const std::string &name) {
         if (vars.contains(name)) {
             result = true;


### PR DESCRIPTION
Speeds up local laplacian lowering by 5% or so.