### PR TITLE
Fix fold_storage when reorder_storage is used

### DIFF
--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -483,15 +483,10 @@ class AttemptStorageFoldingOfFunction : public IRMutator2 {
 
             // Find the StorageDim corresponding to dim.
             const std::vector<StorageDim>& storage_dims = func.schedule().storage_dims();
-            int storage_dim_idx = -1;
-            for (int i = 0; i < (int)storage_dims.size(); i++) {
-                if (func.args()[dim] == storage_dims[i].var) {
-                    storage_dim_idx = i;
-                    break;
-                }
-            }
-            internal_assert(0 <= storage_dim_idx && storage_dim_idx < (int)storage_dims.size());
-            const StorageDim &storage_dim = storage_dims[storage_dim_idx];
+            auto storage_dim_i = std::find_if(storage_dims.begin(), storage_dims.end(),
+                                              [&](const StorageDim& i) { return i.var == func.args()[dim]; });
+            internal_assert(storage_dim_i != storage_dims.end());
+            const StorageDim &storage_dim = *storage_dim_i;
 
             Expr explicit_factor;
             if (!is_pure(min) ||

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -484,7 +484,7 @@ class AttemptStorageFoldingOfFunction : public IRMutator2 {
             // Find the StorageDim corresponding to dim.
             const std::vector<StorageDim>& storage_dims = func.schedule().storage_dims();
             auto storage_dim_i = std::find_if(storage_dims.begin(), storage_dims.end(),
-                                              [&](const StorageDim& i) { return i.var == func.args()[dim]; });
+                                              [&](const StorageDim &i) { return i.var == func.args()[dim]; });
             internal_assert(storage_dim_i != storage_dims.end());
             const StorageDim &storage_dim = *storage_dim_i;
 

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -481,7 +481,17 @@ class AttemptStorageFoldingOfFunction : public IRMutator2 {
             Expr extent = Max::make(extent_initial, extent_steady);
             extent = simplify(common_subexpression_elimination(extent), true, bounds);
 
-            const StorageDim &storage_dim = func.schedule().storage_dims()[dim];
+            // Find the StorageDim corresponding to dim.
+            const std::vector<StorageDim>& storage_dims = func.schedule().storage_dims();
+            int storage_dim_idx = -1;
+            for (int i = 0; i < (int)storage_dims.size(); i++) {
+                if (func.args()[dim] == storage_dims[i].var) {
+                    storage_dim_idx = i;
+                    break;
+                }
+            }
+            internal_assert(0 <= storage_dim_idx && storage_dim_idx < (int)storage_dims.size());
+            const StorageDim &storage_dim = storage_dims[storage_dim_idx];
 
             Expr explicit_factor;
             if (!is_pure(min) ||

--- a/test/correctness/storage_folding.cpp
+++ b/test/correctness/storage_folding.cpp
@@ -365,12 +365,17 @@ int main(int argc, char **argv) {
 
     }
 
-    {
+    for (bool interleave : {false, true}) {
         Func f, g;
 
         f(x, y, c) = x;
         g(x, y, c) = f(x-1, y+1, c) + f(x, y-1, c);
         f.store_root().compute_at(g, y).fold_storage(y, 3);
+
+        if (interleave) {
+          f.reorder(c, x, y).reorder_storage(c, x, y);
+          g.reorder(c, x, y).reorder_storage(c, x, y);
+        }
 
         // Make sure we can explicitly fold something with an outer
         // loop.
@@ -379,7 +384,12 @@ int main(int argc, char **argv) {
 
         Buffer<int> im = g.realize(100, 1000, 3);
 
-        size_t expected_size = 101*3*sizeof(int) + sizeof(int);
+        size_t expected_size;
+        if (interleave) {
+            expected_size = 101*3*3*sizeof(int) + sizeof(int);
+        } else {
+            expected_size = 101*3*sizeof(int) + sizeof(int);
+        }
         if (custom_malloc_size == 0 || custom_malloc_size != expected_size) {
             printf("Scratch space allocated was %d instead of %d\n", (int)custom_malloc_size, (int)expected_size);
             return -1;

--- a/test/correctness/storage_folding.cpp
+++ b/test/correctness/storage_folding.cpp
@@ -373,8 +373,8 @@ int main(int argc, char **argv) {
         f.store_root().compute_at(g, y).fold_storage(y, 3);
 
         if (interleave) {
-          f.reorder(c, x, y).reorder_storage(c, x, y);
-          g.reorder(c, x, y).reorder_storage(c, x, y);
+            f.reorder(c, x, y).reorder_storage(c, x, y);
+            g.reorder(c, x, y).reorder_storage(c, x, y);
         }
 
         // Make sure we can explicitly fold something with an outer


### PR DESCRIPTION
Currently, fold_storage uses the dimension index to look up explicit folding information. However, reorder_storage changes the storage dimension ordering, leading to the explicit storage folding factor being used for the wrong dimension.