### PR TITLE
Explicitly prefer using OpenGL vendor libraries when available in CMake.

### DIFF
--- a/apps/glsl/CMakeLists.txt
+++ b/apps/glsl/CMakeLists.txt
@@ -3,6 +3,9 @@ if (WIN32)
     # TODO: Provide a version of halide_opengl_create_context for Windows
     return()
 endif()
+# Use vendor libraries even when legacy libs are also available
+# see: https://cmake.org/cmake/help/git-stage/policy/CMP0072.html
+set(OpenGL_GL_PREFERENCE GLVND)
 find_package(OpenGL)
 if (OpenGL_FOUND)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,6 +75,9 @@ if (WITH_TEST_PERFORMANCE)
   tests(performance)
 endif()
 if (WITH_TEST_OPENGL)
+  # Use vendor libraries even when legacy libs are also available
+  # see: https://cmake.org/cmake/help/git-stage/policy/CMP0072.html
+  set(OpenGL_GL_PREFERENCE GLVND)
   find_package(OpenGL)
   if (OpenGL_FOUND)
     tests(opengl)


### PR DESCRIPTION
CMake 3.11 and above prefer to use the vendor libraries, while 3.10 and below prefer the legacy libraries. Making the preference explicit also suppresses the warning produced by `find_package(OpenGL)`. When only one is available, it uses that one, regardless of the preference set.

We can also choose to use `LEGACY` instead of `GLVND`, if that's what you all prefer, but I think the preference should be set to suppress the warning.

See the following documentation: https://cmake.org/cmake/help/git-stage/policy/CMP0072.html