### PR TITLE
Fix for error in Metal compilation when vectors greater than four lanes are used.

### DIFF
--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -65,8 +65,6 @@ string CodeGen_Metal_Dev::CodeGen_Metal_C::print_type_maybe_storage(Type type, b
         case 2:
         case 3:
         case 4:
-        case 8:
-        case 16:
             oss << type.lanes();
             break;
         default:
@@ -236,6 +234,7 @@ string CodeGen_Metal_Dev::CodeGen_Metal_C::get_memory_space(const string &buf) {
 
 void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Load *op) {
     user_assert(is_one(op->predicate)) << "Predicated load is not supported inside Metal kernel.\n";
+    user_assert(op->type.lanes() <= 4) << "Vectorization by widths greater than 4 is not supported by Metal -- type is " << op->type << ".\n";
 
     // If we're loading a contiguous ramp, load from a vector type pointer.
     Expr ramp_base = is_ramp_one(op->index);
@@ -304,6 +303,7 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Load *op) {
 
 void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Store *op) {
     user_assert(is_one(op->predicate)) << "Predicated store is not supported inside Metal kernel.\n";
+    user_assert(op->value.type().lanes() <= 4) << "Vectorization by widths greater than 4 is not supported by Metal -- type is " << op->value.type() << ".\n";
 
     string id_value = print_expr(op->value);
     Type t = op->value.type();

--- a/test/error/metal_vector_too_large.cpp
+++ b/test/error/metal_vector_too_large.cpp
@@ -1,0 +1,21 @@
+#include "Halide.h"
+#include "test/common/halide_test_dirs.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    ImageParam input(UInt(16), 2, "input");
+    Func f("f");
+    Var x("x"), y("y");
+
+    f(x, y) = input(x, y) + 42;
+    f.vectorize(x ,16).gpu_blocks(y, DeviceAPI::Metal);
+
+    std::string test_object = Internal::get_test_tmp_dir() + "metal_vector_too_large.o";
+    Target mac_target("osx-metal");
+
+    f.compile_to_object(test_object, { input }, "f", mac_target);
+
+    return 0;
+}


### PR DESCRIPTION
(https://github.com/halide/Halide/issues/3372 ) PR turns this into an error and adds a test.