### PR TITLE
Changes for scatter-gather instructions on Hexagon

### DIFF
--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -2314,8 +2314,10 @@ Stmt vtmpy_generator(Stmt s) {
 
 Stmt scatter_gather_generator(Stmt s) {
     // Generate vscatter-vgather instruction if target >= v65
+    s = substitute_in_all_lets(s);
     s = ScatterGatherGenerator().mutate(s);
     s = SyncronizationBarriers().mutate(s);
+    s = common_subexpression_elimination(s);
     return s;
 }
 


### PR DESCRIPTION
1. Need to substitute let exprs for scatter_acc matching.
2. Pointer cast for buffer addresses for scatter-gathers.

@dsharletg @pranavb-ca @dpalermo Please review.