### PR TITLE
Remove assertion that every store level contains a compute level. Fix #3388

### DIFF
--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1021,9 +1021,8 @@ protected:
             _found_compute_level = true;
         }
 
-        if (store_level.match(for_loop->name)) {
+        if (_found_compute_level && store_level.match(for_loop->name)) {
             debug(3) << "Found store level at " << for_loop->name << "\n";
-            internal_assert(_found_compute_level) << "The compute loop level was not found within the store loop level!\n";
             body = build_realize_group(body);
             _found_store_level = true;
         }

--- a/test/correctness/compute_at_reordered_update_stage.cpp
+++ b/test/correctness/compute_at_reordered_update_stage.cpp
@@ -2,7 +2,9 @@
 
 using namespace Halide;
 
-int main(int argc, char* argv[]) {
+// Tests for regression detailed in https://github.com/halide/Halide/issues/3388
+
+int main(int argc, char *argv[]) {
     Func g;
 
     {
@@ -18,12 +20,11 @@ int main(int argc, char* argv[]) {
         f.store_at(g, x).compute_at(g, y);
     }
 
-    Target target = get_jit_target_from_environment();
-    Halide::Buffer<int> out = g.realize(10, 10, target);
+    Halide::Buffer<int> out = g.realize(10, 10);
 
-    for (int x = 0; x < out.width(); x++) {
-        for (int y = 0; y < out.height(); y++) {
-            const int actual = out(x,y);
+    for (int y = 0; y < out.height(); y++) {
+        for (int x = 0; x < out.width(); x++) {
+            const int actual = out(x, y);
             const int expected = x + y;
             if (actual != expected) {
                 printf("out(%d, %d) = %d instead of %d\n", x, y, actual, expected);

--- a/test/correctness/compute_at_update_stage.cpp
+++ b/test/correctness/compute_at_update_stage.cpp
@@ -1,0 +1,37 @@
+#include <Halide.h>
+
+using namespace Halide;
+
+int main(int argc, char* argv[]) {
+    Func g;
+
+    {
+        Func f;
+        Var x, y;
+
+        f(x, y) = x + y;
+
+        g(x, y) = 0;
+        g(x, y) += f(x, y);
+
+        g.update().reorder(y, x);
+        f.store_at(g, x).compute_at(g, y);
+    }
+
+    Target target = get_jit_target_from_environment();
+    Halide::Buffer<int> out = g.realize(10, 10, target);
+
+    for (int x = 0; x < out.width(); x++) {
+        for (int y = 0; y < out.height(); y++) {
+            const int actual = out(x,y);
+            const int expected = x + y;
+            if (actual != expected) {
+                printf("out(%d, %d) = %d instead of %d\n", x, y, actual, expected);
+                return -1;
+            }
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Also adds regression test in correctness to prevent issue from being
reintroduced. Store level can be a false positive if an earlier update
stage doesn't reference the injected function.