### PR TITLE
Make comparison functors const for C++17 compatibility

### DIFF
--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -495,7 +495,7 @@ private:
     // all loads or all slice_vectors.
     static void sort_mpy_exprs(vector<MulExpr> &mpys) {
         struct LoadCompare {
-            bool operator()(const MulExpr &m1, const MulExpr &m2) {
+            bool operator()(const MulExpr &m1, const MulExpr &m2) const {
                 if (!m1.first.defined() || !m2.first.defined()) {
                     return false;
                 }

--- a/test/generator/async_parallel_aottest.cpp
+++ b/test/generator/async_parallel_aottest.cpp
@@ -20,7 +20,7 @@ struct last_call {
     last_call *next;
     bool inited;
 
-    bool operator<(const last_call &rhs) {
+    bool operator<(const last_call &rhs) const {
         if (loc < rhs.loc) {
             return true;
         } else if (loc >= rhs.loc) {
@@ -146,7 +146,7 @@ int main(int argc, char **argv) {
         std::lock_guard<std::mutex> lock(watchdog_state_mutex);
         watchdog_done = true;
     }
-    
+
     watcher.join();
 
     std::cout << "Success!\n";


### PR DESCRIPTION
In libc++ under C++17, std::map, std::set, std::multimap and std::multiset require the key_compare’s operator() be const.