### PR TITLE
write_debug_image was wrong for TIFF

### DIFF
--- a/src/runtime/write_debug_image.cpp
+++ b/src/runtime/write_debug_image.cpp
@@ -9,7 +9,7 @@
 // - 2/3-D only
 // - Readable by the most tools
 // mat:
-// - Abitrary dimensionality, type
+// - Arbitrary dimensionality, type
 // - Readable by matlab, ImageStack, and many other tools
 // tmp:
 // - Dirt simple, easy to roll your own parser
@@ -216,7 +216,7 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
                 }
                 offset += shape[0].extent * shape[1].extent * depth * bytes_per_element;
             }
-            int32_t count = shape[0].extent * shape[1].extent * depth;
+            int32_t count = shape[0].extent * shape[1].extent * depth * bytes_per_element;
             for (int32_t i = 0; i < channels; i++) {
                 if (!f.write((void*)(&count), 4)) {
                     return -5;


### PR DESCRIPTION
StripByteCounts is a byte count, not an element count, thus it needs to be multiplied by bytes_per_element (so all TIFFs with > u8 size were wrong)