### PR TITLE
Add TIFF writing ability to halide_image_io.h

### DIFF
--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -37,10 +37,14 @@ $(BIN)/out.png: $(BIN)/filter
 	@mkdir -p $(@D)
 	$(BIN)/filter $(IMAGES)/gray.png $(BIN)/out.png 0.1 10
 
+$(BIN)/out.tiff: $(BIN)/filter
+	@mkdir -p $(@D)
+	$(BIN)/filter $(IMAGES)/gray.png $(BIN)/out.tiff 0.1 10
+
 clean:
 	rm -rf $(BIN)
 
-test: $(BIN)/out.png
+test: $(BIN)/out.png $(BIN)/out.tiff
 
 viz: $(BIN)/bilateral_grid.mp4
 	$(HL_VIDEOPLAYER) $^

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -24,6 +24,10 @@ $(BIN)/out.png: $(BIN)/process
 	@mkdir -p $(@D)
 	$(BIN)/process $(IMAGES)/rgb.png 8 1 1 10 $(BIN)/out.png
 
+$(BIN)/out.tiff: $(BIN)/process
+	@mkdir -p $(@D)
+	$(BIN)/process $(IMAGES)/rgb.png 8 1 1 10 $(BIN)/out.tiff
+
 # Build rules for generating a visualization of the pipeline using HalideTraceViz
 $(BIN)/viz/local_laplacian.a: $(BIN)/local_laplacian.generator
 	@mkdir -p $(@D)
@@ -43,7 +47,7 @@ $(BIN)/local_laplacian.mp4: $(BIN)/process_viz ../../bin/HalideTraceViz
 clean:
 	rm -rf $(BIN)
 
-test: $(BIN)/out.png
+test: $(BIN)/out.png $(BIN)/out.tiff
 
 viz: $(BIN)/local_laplacian.mp4
 	$(HL_VIDEOPLAYER) $^

--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -12,6 +12,9 @@ void test_round_trip(Buffer<T> buf, std::string format) {
     std::string filename = o.str();
     Tools::save_image(buf, filename);
 
+    // TIFF is write-only for now.
+    if (format == "tiff") return;
+
     // Reload it
     Buffer<T> reloaded = Tools::load_image(filename);
 
@@ -179,7 +182,7 @@ void do_test() {
     luma_buf.copy_from(color_buf);
     luma_buf.slice(2);
 
-    std::vector<std::string> formats = {"ppm","pgm","tmp","mat"};
+    std::vector<std::string> formats = {"ppm","pgm","tmp","mat","tiff"};
 #ifndef HALIDE_NO_JPEG
     formats.push_back("jpg");
 #endif


### PR DESCRIPTION
Simple approach based directly on runtime/write_debug_image.cpp. No ability to load TIFF is attempted. Add some (very) basic testing .