### PR TITLE
Fix minor clang-tidy issues

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -117,10 +117,16 @@ public:
 
     // This class isn't final (and is subclassed from the Python binding
     // code, at least) so it needs a virtual dtor.
-    virtual ~Buffer() {}
+    virtual ~Buffer() = default;
 
     /** Make a null Buffer, which points to no Runtime::Buffer */
-    Buffer() {}
+    Buffer() = default;
+
+     /** Trivial copy constructor. */
+    Buffer(const Buffer &that) = default;
+
+     /** Trivial copy assignment operator. */
+    Buffer &operator=(const Buffer &that) = default;
 
     /** Make a Buffer from a Buffer of a different type */
     template<typename T2>

--- a/src/Type.h
+++ b/src/Type.h
@@ -297,6 +297,9 @@ struct Type {
     /** Trivial copy constructor. */
     Type(const Type &that) = default;
 
+    /** Trivial copy assignment operator. */
+    Type &operator=(const Type &that) = default;
+
     /** Type is a wrapper around halide_type_t with more methods for use
      * inside the compiler. This simply constructs the wrapper around
      * the runtime value. */


### PR DESCRIPTION
- Type.h: If you define a copy ctor, you should also define operator= (even if it's just =default)
- Buffer.h: If you define a dtor, you should also define the copy ctor (even if it's just =default)
- prefer =default to {} for bodies