### PR TITLE
Temporarily disable correctness_convolution for Feature::Metal

### DIFF
--- a/test/correctness/convolution.cpp
+++ b/test/correctness/convolution.cpp
@@ -69,7 +69,8 @@ int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
 
     if (target.has_feature(Target::Metal)) {
-        printf("Temporarily skipping correctness_convolution with Metal.\n");
+        // See issue https://github.com/halide/Halide/issues/3408
+        printf("Temporarily skipping correctness_convolution with Metal: https://github.com/halide/Halide/issues/3408\n");
         return 0;
     }
 

--- a/test/correctness/convolution.cpp
+++ b/test/correctness/convolution.cpp
@@ -67,6 +67,12 @@ int main(int argc, char **argv) {
     blur2(x, y) = sum(tent(r.x, r.y) * input(x + r.x - 1, y + r.y - 1));
 
     Target target = get_jit_target_from_environment();
+
+    if (target.has_feature(Target::Metal)) {
+        printf("Temporarily skipping correctness_convolution with Metal.\n");
+        return 0;
+    }
+
     if (target.has_gpu_feature()) {
         Var xi("xi"), yi("yi");
 

--- a/test/correctness/parallel_gpu_nested.cpp
+++ b/test/correctness/parallel_gpu_nested.cpp
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
         return 0;
     }
 
-    if (target.has_feature(Target::Metal)) {
+    if (get_jit_target_from_environment().has_feature(Target::Metal)) {
         // See issue https://github.com/halide/Halide/issues/3408
         printf("Temporarily skipping correctness_parallel_gpu_nested with Metal: https://github.com/halide/Halide/issues/3408\n");
         return 0;

--- a/test/correctness/parallel_gpu_nested.cpp
+++ b/test/correctness/parallel_gpu_nested.cpp
@@ -9,6 +9,12 @@ int main(int argc, char **argv) {
         return 0;
     }
 
+    if (target.has_feature(Target::Metal)) {
+        // See issue https://github.com/halide/Halide/issues/3408
+        printf("Temporarily skipping correctness_parallel_gpu_nested with Metal: https://github.com/halide/Halide/issues/3408\n");
+        return 0;
+    }
+
     Var x, y, z;
     Func f;
 

--- a/tutorial/lesson_12_using_the_gpu.cpp
+++ b/tutorial/lesson_12_using_the_gpu.cpp
@@ -112,6 +112,12 @@ public:
             return false;
         }
 
+        if (target.has_feature(Target::Metal)) {
+            // See issue https://github.com/halide/Halide/issues/3408
+            printf("Temporarily skipping tutorial_lesson_12_using_the_gpu with Metal: https://github.com/halide/Halide/issues/3408\n");
+            return false;
+        }
+
         // If you want to see all of the OpenCL, Metal, CUDA or D3D 12 API
         // calls done by the pipeline, you can also enable the Debug flag.
         // This is helpful for figuring out which stages are slow, or when


### PR DESCRIPTION
A temporary workaround for the buildbot failure which is under investigation, to prevent some known failures from failing entire builds.