### PR TITLE
Drop Bazel testing from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ compiler:
   - gcc
 env:
   global:
-    - BAZEL_VERSION="0.6.1"
-    - JDK=openjdk8
     # The Travis Ubuntu Trusty environment we run in currently promises 2 cores,
     # so running lengthy make steps with -j2 is almost certainly a win.
     - MAKEFLAGS=-j2
@@ -30,8 +28,6 @@ before_install:
   - export CC=${CC_}
   - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test/
   - sudo apt-get update
-  - wget https://github.com/bazelbuild/bazel/releases/download/"${BAZEL_VERSION}"/bazel_"${BAZEL_VERSION}"-linux-x86_64.deb
-  - sudo dpkg -i bazel_"${BAZEL_VERSION}"-linux-x86_64.deb
 install:
   - sudo apt-get -y --force-yes install ${CXX} ${CC} libedit-dev
   # Make gcc4.8 the default gcc version

--- a/test/scripts/build_travis.sh
+++ b/test/scripts/build_travis.sh
@@ -34,10 +34,10 @@ if [ ${BUILD_SYSTEM} = 'CMAKE' ]; then
   # Build and run internal tests
   make ${MAKEFLAGS} Halide
   make ${MAKEFLAGS} test_internal
-  
+
   # Build the docs and run the tests
-  make doc 
-  make ${MAKEFLAGS} test_correctness 
+  make doc
+  make ${MAKEFLAGS} test_correctness
   make ${MAKEFLAGS} test_generator
 
 elif [ ${BUILD_SYSTEM} = 'MAKE' ]; then
@@ -49,18 +49,9 @@ elif [ ${BUILD_SYSTEM} = 'MAKE' ]; then
   make ${MAKEFLAGS}
 
   # Build the docs and run the tests
-  make doc 
-  make ${MAKEFLAGS} test_correctness 
+  make doc
+  make ${MAKEFLAGS} test_correctness
   make ${MAKEFLAGS} test_generator
-
-  # Build the distrib folder (needed for the Bazel build test)
-  make distrib
-
-  # Build our one-and-only Bazel test.
-  # --verbose_failures so failures are easier to figure out.
-  echo "Testing apps/bazeldemo..."
-  cd apps/bazeldemo
-  bazel build --verbose_failures :all
 
 else
   echo "Unexpected BUILD_SYSTEM: \"${BUILD_SYSTEM}\""


### PR DESCRIPTION
It's not in use by anyone and the version we test against is ancient. Better to drop it entirely and save build/test time.