### PR TITLE
Fix Metal crashes in Mojave

### DIFF
--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -813,6 +813,10 @@ WEAK int halide_metal_run(void *user_context,
 
     commit_command_buffer(command_buffer);
 
+    // We deliberately don't release the function here; this was causing
+    // crashes on Mojave (issues #3395 and #3408).
+    // We're still releasing the pipeline state object, as that seems to not
+    // cause zombied objects.
     release_ns_object(pipeline_state);
 
     #ifdef DEBUG_RUNTIME

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -710,6 +710,11 @@ WEAK int halide_metal_run(void *user_context,
         return -1;
     }
 
+    // Retaining the function appears to solve crashes outlined in #3395 and #3408.
+    // Using NSZombieEnabled=YES for debugging pointed to the function being zombied before use.
+    retain_ns_object((objc_id)function);
+
+
     mtl_compute_pipeline_state *pipeline_state = new_compute_pipeline_state_with_function(metal_context.device, function);
     if (pipeline_state == 0) {
         error(user_context) << "Metal: Could not allocate pipeline state.\n";

--- a/test/correctness/convolution.cpp
+++ b/test/correctness/convolution.cpp
@@ -67,13 +67,7 @@ int main(int argc, char **argv) {
     blur2(x, y) = sum(tent(r.x, r.y) * input(x + r.x - 1, y + r.y - 1));
 
     Target target = get_jit_target_from_environment();
-
-    if (target.has_feature(Target::Metal)) {
-        // See issue https://github.com/halide/Halide/issues/3408
-        printf("Temporarily skipping correctness_convolution with Metal: https://github.com/halide/Halide/issues/3408\n");
-        return 0;
-    }
-
+    
     if (target.has_gpu_feature()) {
         Var xi("xi"), yi("yi");
 

--- a/test/correctness/parallel_gpu_nested.cpp
+++ b/test/correctness/parallel_gpu_nested.cpp
@@ -9,12 +9,6 @@ int main(int argc, char **argv) {
         return 0;
     }
 
-    if (get_jit_target_from_environment().has_feature(Target::Metal)) {
-        // See issue https://github.com/halide/Halide/issues/3408
-        printf("Temporarily skipping correctness_parallel_gpu_nested with Metal: https://github.com/halide/Halide/issues/3408\n");
-        return 0;
-    }
-
     Var x, y, z;
     Func f;
 

--- a/tutorial/lesson_12_using_the_gpu.cpp
+++ b/tutorial/lesson_12_using_the_gpu.cpp
@@ -112,12 +112,6 @@ public:
             return false;
         }
 
-        if (target.has_feature(Target::Metal)) {
-            // See issue https://github.com/halide/Halide/issues/3408
-            printf("Temporarily skipping tutorial_lesson_12_using_the_gpu with Metal: https://github.com/halide/Halide/issues/3408\n");
-            return false;
-        }
-
         // If you want to see all of the OpenCL, Metal, CUDA or D3D 12 API
         // calls done by the pipeline, you can also enable the Debug flag.
         // This is helpful for figuring out which stages are slow, or when


### PR DESCRIPTION
Using `NSZombieEnabled=YES` points to the `MTLFunction` being freed before use; adding a `retain` appears to fix the issue.  This should fix #3395 and #3408.