### PR TITLE
Remove work_around_llvm_bugs for LLVM >= 7.0

### DIFF
--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -197,6 +197,7 @@ public:
         return result;
     }
 
+#if LLVM_VERSION < 70
     void work_around_llvm_bugs() {
 
         for (auto p : code_pages) {
@@ -231,6 +232,8 @@ public:
 #endif
         }
     }
+#endif
+
 };
 
 }
@@ -332,7 +335,9 @@ void JITModule::compile_module(std::unique_ptr<llvm::Module> m, const string &fu
 
     debug(2) << "Finalizing object\n";
     ee->finalizeObject();
+#if LLVM_VERSION < 70
     memory_manager->work_around_llvm_bugs();
+#endif
 
     // Do any target-specific post-compilation module meddling
     for (size_t i = 0; i < listeners.size(); i++) {


### PR DESCRIPTION
If I understand correctly, this should be fixed as of https://reviews.llvm.org/rL286032, which is in LLVM7 and trunk.

(Note that this doesn't fix the outstanding JIT crash on arm32+LLVM7, but is just a change I noticed while debugging it.)