### PR TITLE
Convert GPU thread barrier to an intrinsic.

### DIFF
--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -151,6 +151,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Evaluate *op)
     print_expr(op->value);
 }
 
+
 string CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::print_extern_call(const Call *op) {
     internal_assert(!function_takes_user_context(op->name));
 
@@ -251,6 +252,20 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Broadcast *op
     rhs << ")";
 
     print_assignment(op->type.with_lanes(op->lanes), rhs.str());
+}
+
+void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Call *op) {
+    if (op->is_intrinsic(Call::gpu_thread_barrier)) {
+        // Halide only ever needs threadgroup memory fences:
+        // NOTE(marcos): using "WithGroupSync" here just to be safe, as a
+        // simple "GroupMemoryBarrier" is probably too relaxed for Halide
+        // (also note we need to return an integer)
+        do_indent();
+        stream << "GroupMemoryBarrierWithGroupSync();\n";
+        print_assignment(op->type, "0");
+    } else {
+        CodeGen_C::visit(op);
+    }
 }
 
 namespace {
@@ -1138,16 +1153,6 @@ void CodeGen_D3D12Compute_Dev::init_module() {
                << "#define atanh_f32(x) (log_f32((1+x)/(1-x))/2) \n"
                << "#define fast_inverse_f32      rcp   \n"
                << "#define fast_inverse_sqrt_f32 rsqrt \n"
-             // Halide only ever needs threadgroup memory fences:
-             // NOTE(marcos): using "WithGroupSync" here just to be safe, as a
-             // simple "GroupMemoryBarrier" is probably too relaxed for Halide
-             // (also note we need to return an integer)
-               << "\n"
-               << "int halide_gpu_thread_barrier() \n"
-                  "{ \n"
-                  "  GroupMemoryBarrierWithGroupSync(); \n"
-                  "  return 0; \n"
-                  "} \n"
                << "\n";
              //<< "}\n"; // close namespace
 

--- a/src/CodeGen_D3D12Compute_Dev.h
+++ b/src/CodeGen_D3D12Compute_Dev.h
@@ -72,6 +72,7 @@ protected:
         void visit(const For *) override;
         void visit(const Ramp *op) override;
         void visit(const Broadcast *op) override;
+        void visit(const Call *op) override;
         void visit(const Load *op) override;
         void visit(const Store *op) override;
         void visit(const Select *op) override;

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -210,6 +210,16 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Broadcast *op) {
     print_assignment(op->type.with_lanes(op->lanes), rhs.str());
 }
 
+void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Call *op) {
+    if (op->is_intrinsic(Call::gpu_thread_barrier)) {
+        do_indent();
+        stream << "threadgroup_barrier(mem_flags::mem_threadgroup);\n";
+        print_assignment(op->type, "0");
+    } else {
+        CodeGen_C::visit(op);
+    }
+}
+
 namespace {
 
 // If e is a ramp expression with stride 1, return the base, otherwise undefined.
@@ -598,32 +608,30 @@ void CodeGen_Metal_Dev::init_module() {
                << "constexpr float nan_f32() { return as_type<float>(0x7fc00000); }\n" // Quiet NaN with minimum fractional value.
                << "constexpr float neg_inf_f32() { return float_from_bits(0xff800000); }\n"
                << "constexpr float inf_f32() { return float_from_bits(0x7f800000); }\n"
-               << "float fast_inverse_f32(float x) { return 1.0f / x; } \n"
-               << "#define sqrt_f32 sqrt \n"
-               << "#define sin_f32 sin \n"
-               << "#define cos_f32 cos \n"
-               << "#define exp_f32 exp \n"
-               << "#define log_f32 log \n"
-               << "#define abs_f32 fabs \n"
-               << "#define floor_f32 floor \n"
-               << "#define ceil_f32 ceil \n"
-               << "#define round_f32 round \n"
-               << "#define trunc_f32 trunc \n"
+               << "float fast_inverse_f32(float x) { return 1.0f / x; }\n"
+               << "#define sqrt_f32 sqrt\n"
+               << "#define sin_f32 sin\n"
+               << "#define cos_f32 cos\n"
+               << "#define exp_f32 exp\n"
+               << "#define log_f32 log\n"
+               << "#define abs_f32 fabs\n"
+               << "#define floor_f32 floor\n"
+               << "#define ceil_f32 ceil\n"
+               << "#define round_f32 round\n"
+               << "#define trunc_f32 trunc\n"
                << "#define pow_f32 pow\n"
-               << "#define asin_f32 asin \n"
-               << "#define acos_f32 acos \n"
-               << "#define tan_f32 tan \n"
-               << "#define atan_f32 atan \n"
+               << "#define asin_f32 asin\n"
+               << "#define acos_f32 acos\n"
+               << "#define tan_f32 tan\n"
+               << "#define atan_f32 atan\n"
                << "#define atan2_f32 atan2\n"
-               << "#define sinh_f32 sinh \n"
-               << "#define asinh_f32 asinh \n"
-               << "#define cosh_f32 cosh \n"
-               << "#define acosh_f32 acosh \n"
-               << "#define tanh_f32 tanh \n"
-               << "#define atanh_f32 atanh \n"
-               << "#define fast_inverse_sqrt_f32 rsqrt \n"
-               << "#define halide_gpu_thread_barrier() \\\n" // Must to be a #define as barriers in an inline function don't work
-               << "  (threadgroup_barrier(mem_flags::mem_threadgroup), 0)\n" // Halide only ever needs threadgroup (OpenCL "local") memory fences. (mem_threadgroup)
+               << "#define sinh_f32 sinh\n"
+               << "#define asinh_f32 asinh\n"
+               << "#define cosh_f32 cosh\n"
+               << "#define acosh_f32 acosh\n"
+               << "#define tanh_f32 tanh\n"
+               << "#define atanh_f32 atanh\n"
+               << "#define fast_inverse_sqrt_f32 rsqrt\n"
                << "}\n"; // close namespace
 
     // __shared always has address space threadgroup.

--- a/src/CodeGen_Metal_Dev.h
+++ b/src/CodeGen_Metal_Dev.h
@@ -73,6 +73,7 @@ protected:
         void visit(const For *) override;
         void visit(const Ramp *op) override;
         void visit(const Broadcast *op) override;
+        void visit(const Call *op) override;
         void visit(const Load *op) override;
         void visit(const Store *op) override;
         void visit(const Select *op) override;

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -203,6 +203,10 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Call *op) {
         ostringstream rhs;
         rhs << "abs_diff(" << print_expr(op->args[0]) << ", " << print_expr(op->args[1]) << ")";
         print_assignment(op->type, rhs.str());
+    } else if (op->is_intrinsic(Call::gpu_thread_barrier)) {
+        do_indent();
+        stream << "barrier(CLK_LOCAL_MEM_FENCE);\n";
+        print_assignment(op->type, "0");
     } else {
         CodeGen_C::visit(op);
     }
@@ -681,11 +685,7 @@ void CodeGen_OpenCL_Dev::init_module() {
                << "#define tanh_f32 tanh \n"
                << "#define atanh_f32 atanh \n"
                << "#define fast_inverse_f32 native_recip \n"
-               << "#define fast_inverse_sqrt_f32 native_rsqrt \n"
-               << "inline int halide_gpu_thread_barrier() {\n"
-               << "  barrier(CLK_LOCAL_MEM_FENCE);\n" // Halide only ever needs local memory fences.
-               << "  return 0;\n"
-               << "}\n";
+               << "#define fast_inverse_sqrt_f32 native_rsqrt \n";
 
     // __shared always has address space __local.
     src_stream << "#define __address_space___shared __local\n";

--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -129,9 +129,10 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Cast *op) {
 }
 
 void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Call *op) {
-    if (op->name == "halide_gpu_thread_barrier") {
+    if (op->is_intrinsic(Call::gpu_thread_barrier)) {
         do_indent();
         stream << "barrier();\n";
+        print_assignment(op->type, "0");
     } else {
         CodeGen_GLSLBase::visit(op);
     }

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -159,6 +159,17 @@ void CodeGen_PTX_Dev::init_module() {
     #endif
 }
 
+void CodeGen_PTX_Dev::visit(const Call *op) {
+    if (op->is_intrinsic(Call::gpu_thread_barrier)) {
+        llvm::Function *barrier0 = module->getFunction("llvm.nvvm.barrier0");
+        internal_assert(barrier0) << "Could not find PTX barrier intrinsic (llvm.nvvm.barrier0)\n";
+        builder->CreateCall(barrier0);
+        value = ConstantInt::get(i32_t, 0);
+    } else {
+        CodeGen_LLVM::visit(op);
+    }
+}
+
 string CodeGen_PTX_Dev::simt_intrinsic(const string &name) {
     if (ends_with(name, ".__thread_id_x")) {
         return "llvm.nvvm.read.ptx.sreg.tid.x";

--- a/src/CodeGen_PTX_Dev.h
+++ b/src/CodeGen_PTX_Dev.h
@@ -55,6 +55,7 @@ protected:
 
     /** Nodes for which we need to override default behavior for the GPU runtime */
     // @{
+    virtual void visit(const Call *) override;
     void visit(const For *) override;
     void visit(const Allocate *) override;
     void visit(const Free *) override;

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -69,8 +69,8 @@ class InjectThreadBarriers : public IRMutator2 {
 public:
     InjectThreadBarriers() : in_threads(false) {
         barrier =
-            Evaluate::make(Call::make(Int(32), "halide_gpu_thread_barrier",
-                                      vector<Expr>(), Call::Extern));
+            Evaluate::make(Call::make(Int(32), Call::gpu_thread_barrier,
+                                      vector<Expr>(), Call::Intrinsic));
     }
 };
 

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -911,6 +911,7 @@ Call::ConstString Call::strict_float = "strict_float";
 Call::ConstString Call::quiet_div = "quiet_div";
 Call::ConstString Call::quiet_mod = "quiet_mod";
 Call::ConstString Call::unsafe_promise_clamped = "unsafe_promise_clamped";
+Call::ConstString Call::gpu_thread_barrier = "gpu_thread_barrier";
 
 Call::ConstString Call::buffer_get_dimensions = "_halide_buffer_get_dimensions";
 Call::ConstString Call::buffer_get_min = "_halide_buffer_get_min";

--- a/src/IR.h
+++ b/src/IR.h
@@ -531,7 +531,8 @@ struct Call : public ExprNode<Call> {
         strict_float,
         quiet_div,
         quiet_mod,
-        unsafe_promise_clamped;
+        unsafe_promise_clamped,
+        gpu_thread_barrier;
 
     // We also declare some symbolic names for some of the runtime
     // functions that we want to construct Call nodes to here to avoid

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -1048,11 +1048,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_ptx_device(Target target, l
         if (!f.isDeclaration() && !f.hasFnAttribute(llvm::Attribute::NoInline)) {
             f.setLinkage(llvm::GlobalValue::AvailableExternallyLinkage);
         }
-
-        // Also mark the halide_gpu_thread_barrier as noduplicate.
-        if (f.getName() == "halide_gpu_thread_barrier") {
-            f.addFnAttr(llvm::Attribute::NoDuplicate);
-        }
     }
 
     llvm::Triple triple("nvptx64--");

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -460,7 +460,7 @@ public:
 protected:
     using IRVisitor::visit;
     void visit(const Call *op) override {
-        if (op->name == "halide_gpu_thread_barrier") {
+        if (op->is_intrinsic(Call::gpu_thread_barrier)) {
             result = true;
         } else {
             IRVisitor::visit(op);

--- a/src/runtime/ptx_dev.ll
+++ b/src/runtime/ptx_dev.ll
@@ -334,11 +334,6 @@ define weak_odr double @atanh_f64(double %x) nounwind uwtable readnone alwaysinl
        ret double %y
 }
 
-define weak_odr i32 @halide_gpu_thread_barrier() nounwind uwtable alwaysinline {
-       call void @llvm.nvvm.barrier0() nounwind
-       ret i32 0
-}
-
 define weak_odr i32 @halide_ptx_trap() nounwind uwtable alwaysinline {
        tail call void asm sideeffect "
        trap;

--- a/test/correctness/gpu_thread_barrier.cpp
+++ b/test/correctness/gpu_thread_barrier.cpp
@@ -14,7 +14,7 @@ protected:
     using IRVisitor::visit;
 
     void visit(const Call *op) override {
-        if (op->name == "halide_gpu_thread_barrier") {
+        if (op->is_intrinsic(Call::gpu_thread_barrier)) {
             count++;
         }
         IRVisitor::visit(op);


### PR DESCRIPTION
This cleans up the code a bit and removes the requirement of a runtime
routine being inlined in GPU kernel code in order for it to be
correct.

Fixes issue: https://github.com/halide/Halide/issues/3397 .