### PR TITLE
Make can_prove use CSE and trim dead lets

### DIFF
--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -283,7 +283,9 @@ bool can_prove(Expr e, const Scope<Interval> &bounds) {
 
     // When terms cancel, the simplifier doesn't always successfully
     // kill the dead lets.
-    while (const Let *l = e.as<Let>()) e = l->body;
+    while (const Let *l = e.as<Let>()) {
+        e = l->body;
+    }
 
     // Take a closer look at all failed proof attempts to hunt for
     // simplifier weaknesses


### PR DESCRIPTION
This makes it slightly more powerful. 

Also report the original unsimplified expression too when a proof fails so we know what original state got the simplifier stuck in a local minimum.