### PR TITLE
Make the autoscheduler machine params constants instead of Exprs

### DIFF
--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -1957,7 +1957,7 @@ Partitioner::GroupAnalysis Partitioner::analyze_group(const Group &g, bool show_
     bool model_reuse = false;
 
     // Linear dropoff
-    Expr load_slope = cast<float>(arch_params.balance) / arch_params.last_level_cache_size;
+    float load_slope = arch_params.balance / arch_params.last_level_cache_size;
     for (const auto &f_load : group_load_costs) {
         internal_assert(g.inlined.find(f_load.first) == g.inlined.end())
             << "Intermediates of inlined pure fuction \"" << f_load.first
@@ -3548,13 +3548,15 @@ string generate_schedules(const vector<Function> &outputs, const Target &target,
 }  // namespace Internal
 
 MachineParams MachineParams::generic() {
-    return MachineParams(16, 16 * 1024 * 1024, 40);
+    std::string params = Internal::get_env_variable("HL_MACHINE_PARAMS");
+    if (params.empty()) {
+        return MachineParams(16, 16 * 1024 * 1024, 40);
+    } else {
+        return MachineParams(params);
+    }
 }
 
 std::string MachineParams::to_string() const {
-    internal_assert(parallelism.type().is_int() &&
-                    last_level_cache_size.type().is_int() &&
-                    balance.type().is_int());
     std::ostringstream o;
     o << parallelism << "," << last_level_cache_size << "," << balance;
     return o.str();
@@ -3563,9 +3565,9 @@ std::string MachineParams::to_string() const {
 MachineParams::MachineParams(const std::string &s) {
     std::vector<std::string> v = Internal::split_string(s, ",");
     user_assert(v.size() == 3) << "Unable to parse MachineParams: " << s;
-    parallelism = Internal::string_to_int(v[0]);
-    last_level_cache_size = Internal::string_to_int(v[1]);
-    balance = Internal::string_to_int(v[2]);
+    parallelism = std::atoi(v[0].c_str());
+    last_level_cache_size = std::atoll(v[1].c_str());
+    balance = std::atof(v[2].c_str());
 }
 
 }  // namespace Halide

--- a/src/AutoSchedule.h
+++ b/src/AutoSchedule.h
@@ -15,14 +15,14 @@ namespace Halide {
  * code for. */
 struct MachineParams {
     /** Maximum level of parallelism avalaible. */
-    Expr parallelism;
-    /** Size of the last-level cache (in KB). */
-    Expr last_level_cache_size;
+    int parallelism;
+    /** Size of the last-level cache (in bytes). */
+    uint64_t last_level_cache_size;
     /** Indicates how much more expensive is the cost of a load compared to
      * the cost of an arithmetic operation at last level cache. */
-    Expr balance;
+    float balance;
 
-    explicit MachineParams(int32_t parallelism, int32_t llc, int32_t balance)
+    explicit MachineParams(int parallelism, uint64_t llc, float balance)
         : parallelism(parallelism), last_level_cache_size(llc), balance(balance) {}
 
     /** Default machine parameters for generic CPU architecture. */


### PR DESCRIPTION
There's no reason I could tell why these things should be Exprs. They're always constants.

Also restored ability to optionally set them via an environment variable.