### PR TITLE
Get OpenGLCompute backend to pass the math test by adding intrinsics.

### DIFF
--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -55,6 +55,11 @@ Type map_type(const Type &type) {
 }
 }  // namespace
 
+CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::CodeGen_OpenGLCompute_C(std::ostream &s, Target t)
+    : CodeGen_GLSLBase(s, t) {
+    builtin["trunc_f32"] = "trunc";
+}
+
 string CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::print_type(Type type, AppendSpaceIfNeeded space) {
     Type mapped_type = map_type(type);
     if (mapped_type.is_uint() && !mapped_type.is_bool()) {

--- a/src/CodeGen_OpenGLCompute_Dev.h
+++ b/src/CodeGen_OpenGLCompute_Dev.h
@@ -43,7 +43,7 @@ protected:
 
     class CodeGen_OpenGLCompute_C : public CodeGen_GLSLBase {
     public:
-        CodeGen_OpenGLCompute_C(std::ostream &s, Target t) : CodeGen_GLSLBase(s, t) {}
+        CodeGen_OpenGLCompute_C(std::ostream &s, Target t);
         void add_kernel(Stmt stmt,
                         const std::string &name,
                         const std::vector<DeviceArgument> &args);

--- a/src/CodeGen_OpenGL_Dev.h
+++ b/src/CodeGen_OpenGL_Dev.h
@@ -76,7 +76,6 @@ protected:
 
     void visit(const Shuffle *) override;
 
-private:
     std::map<std::string, std::string> builtin;
 };
 
@@ -84,7 +83,7 @@ private:
 /** Compile one statement into GLSL. */
 class CodeGen_GLSL : public CodeGen_GLSLBase {
 public:
-    CodeGen_GLSL(std::ostream &s, const Target &t) : CodeGen_GLSLBase(s, t) {}
+    CodeGen_GLSL(std::ostream &s, const Target &t);
 
     void add_kernel(Stmt stmt,
                     std::string name,

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -638,6 +638,8 @@ bool Target::supports_type(const Type &t) const {
     if (t.bits() == 64) {
         if (t.is_float()) {
             return !has_feature(Metal) &&
+                   !has_feature(OpenGL) &&
+                   !has_feature(OpenGLCompute) &&
                    !has_feature(D3D12Compute) &&
                    (!has_feature(Target::OpenCL) || has_feature(Target::CLDoubles));
         } else {

--- a/src/runtime/openglcompute.cpp
+++ b/src/runtime/openglcompute.cpp
@@ -772,8 +772,10 @@ WEAK int halide_openglcompute_initialize_kernels(void *user_context, void **stat
         const GLchar* sources = { src };
         const GLint sources_lengths = { (GLint) src_len };
 
+#ifdef DEBUG_RUNTIME
         print(user_context) << "Compute shader source for: " << kernel_name;
         halide_print(user_context, src);
+#endif
 
         global_state.ShaderSource(shader, 1, &sources, &sources_lengths);
         if (global_state.CheckAndReportError(user_context, "shader source")) { return -1; }

--- a/test/correctness/math.cpp
+++ b/test/correctness/math.cpp
@@ -31,7 +31,8 @@ bool relatively_equal(value_t a, value_t b, Target target) {
 
         // For HLSL, try again with a lower error threshold, as it might be using
         // fast but approximated trigonometric functions:
-        if (target.supports_device_api(DeviceAPI::D3D12Compute))
+        if (target.supports_device_api(DeviceAPI::D3D12Compute) ||
+            target.supports_device_api(DeviceAPI::OpenGLCompute))
         {
             // this threshold value has been empirically determined since there
             // is no clear documentation on the precision of these algorithms
@@ -79,6 +80,9 @@ uint32_t absd(uint32_t a, uint32_t b) { return a < b ? b - a : a - b; }
         test_##name(x) = name(in(x));                                   \
         if (target.has_gpu_feature()) {                                 \
             test_##name.gpu_tile(x, xi, 8);                             \
+        } if (target.has_feature(Target::OpenGLCompute)) {              \
+            test_##name.gpu_tile(x, xi, 8, TailStrategy::Auto,          \
+                                 DeviceAPI::OpenGLCompute);             \
         } else if (target.features_any_of({Target::HVX_64, Target::HVX_128})) { \
             test_##name.hexagon();                                      \
         }                                                               \
@@ -104,6 +108,9 @@ uint32_t absd(uint32_t a, uint32_t b) { return a < b ? b - a : a - b; }
         test_##name(x) = name(in(0, x), in(1, x));                                  \
         if (target.has_gpu_feature()) {                                             \
             test_##name.gpu_tile(x, xi, 8);                                         \
+        } if (target.has_feature(Target::OpenGLCompute)) {              \
+            test_##name.gpu_tile(x, xi, 8, TailStrategy::Auto,          \
+                                 DeviceAPI::OpenGLCompute);             \
         } else if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {     \
             test_##name.hexagon();                                                  \
         }                                                                           \


### PR DESCRIPTION
Requires refactoring a small amount of code so plain GLSL
and GLSL Compute Shaders can use different names for "trunc". (The
name "trunc" might actually work everywhere we care about now, but
there's no way to tell and I don't want to break anything that works
currently.)

Making it so Target doesn't claim GL backends support 64-bit float. It
is possible some implementations do, but our backends don't do
precision control, etc.

Modify correctness/math.cpp to work with OpenGLCompute.