### PR TITLE
Add Buffer::as_ptr() and as_ptr_const()

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1118,6 +1118,46 @@ public:
     }
     // @}
 
+    /** Return a typed pointer to this Buffer. Useful for safely converting
+     * a reference to a Buffer<void>* to a reference to, for example, a
+     * Buffer<const uint8_t>*, or converting a Buffer<T>* to Buffer<const T>*.
+     * Does a runtime assert if the source buffer type is void. */
+    template<typename T2, int D2 = D,
+             typename = typename std::enable_if<(D2 <= D)>::type>
+    HALIDE_ALWAYS_INLINE
+    Buffer<T2, D2> *as_ptr() & {
+        Buffer<T2, D>::assert_can_convert_from(*this);
+        return ((Buffer<T2, D2> *)this);
+    }
+
+    /** Return a const typed pointer to this Buffer. Useful for safely
+     * converting a const pointer to one Buffer type to a const
+     * pointer to another Buffer type. Does a runtime assert if the
+     * source buffer type is void. */
+    template<typename T2, int D2 = D,
+             typename = typename std::enable_if<(D2 <= D)>::type>
+    HALIDE_ALWAYS_INLINE
+    const Buffer<T2, D2> &as_ptr() const &  {
+        Buffer<T2, D>::assert_can_convert_from(*this);
+        return ((const Buffer<T2, D2> *)this);
+    }
+
+    /** as_ptr_const() is syntactic sugar for .as_ptr<const T>(), to avoid the need
+     * to recapitulate the type argument. */
+    // @{
+    HALIDE_ALWAYS_INLINE
+    Buffer<typename std::add_const<T>::type, D> *as_ptr_const() & {
+        // Note that we can skip the assert_can_convert_from(), since T -> const T
+        // conversion is always legal.
+        return ((Buffer<typename std::add_const<T>::type> *)this);
+    }
+
+    HALIDE_ALWAYS_INLINE
+    const Buffer<typename std::add_const<T>::type, D> *as_ptr_const() const & {
+        return ((const Buffer<typename std::add_const<T>::type> *)this);
+    }
+    // @}
+
     /** Conventional names for the first three dimensions. */
     // @{
     int width() const {

--- a/test/correctness/halide_buffer.cpp
+++ b/test/correctness/halide_buffer.cpp
@@ -399,6 +399,44 @@ int main(int argc, char **argv) {
         assert(b.dim(3).stride() == b2.dim(3).stride());
     }
 
+    {
+        // Check as() and as_ptr()
+        Buffer<> a(halide_type_of<int>(), 2, 2);
+
+        Buffer<int> a2 = a.as<int>();
+        Buffer<int> &a3 = a.as<int>();
+        const Buffer<int> &a4 = a.as<int>();
+
+        Buffer<int>* a5 = a.as_ptr<int>();
+        const Buffer<int>* a6 = a.as_ptr<int>();
+
+        // just to avoid unused-var warnings
+        (void) a2;
+        (void) a3;
+        (void) a4;
+        (void) a5;
+        (void) a6;
+    }
+
+    {
+        // Check as_const() and as_ptr_const()
+        Buffer<int> a(halide_type_of<int>(), 2, 2);
+
+        Buffer<const int> a2 = a.as_const();
+        Buffer<const int> &a3 = a.as_const();
+        const Buffer<const int> &a4 = a.as_const();
+
+        Buffer<const int>* a5 = a.as_ptr_const();
+        const Buffer<const int>* a6 = a.as_ptr_const();
+
+        // just to avoid unused-var warnings
+        (void) a2;
+        (void) a3;
+        (void) a4;
+        (void) a5;
+        (void) a6;
+    }
+
     printf("Success!\n");
     return 0;
 }


### PR DESCRIPTION
These are analogous to as() and as_const(), but return pointers rather than refs; this is useful for coding in C++ styles that require pointers for mutable references, when you have (eg)

    void DoSomethingWith(Buffer<const int> *input);

     Buffer<int> foo;
     DoSomethingWith(&foo);  // won't compile
     DoSomethingWith(foo.as_ptr<const int>());  // OK
     DoSomethingWith(foo.as_ptr_const());  // also OK

Note that I deliberately avoid as_const_ptr() as the name, as that would imply to me the pointer returned is always const, which isn't the case.

Also note that I'm deliberately avoiding rvalue overloads for this, as it's not clear to me that it's an interesting use case.