### PR TITLE
Refactor Argument, add ArgumentEstimates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,6 +354,7 @@ SOURCE_FILES = \
   AlignLoads.cpp \
   AllocationBoundsInference.cpp \
   ApplySplit.cpp \
+  Argument.cpp \
   AssociativeOpsTable.cpp \
   Associativity.cpp \
   AsyncProducers.cpp \

--- a/src/Argument.cpp
+++ b/src/Argument.cpp
@@ -1,0 +1,29 @@
+#include "Argument.h"
+
+namespace Halide {
+
+bool ArgumentEstimates::operator==(const ArgumentEstimates &rhs) const {
+    if (buffer_estimates.size() != rhs.buffer_estimates.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < buffer_estimates.size(); ++i) {
+        if (!buffer_estimates[i].min.same_as(rhs.buffer_estimates[i].min) ||
+            !buffer_estimates[i].extent.same_as(rhs.buffer_estimates[i].extent)) {
+            return false;
+        }
+    }
+    return scalar_def.same_as(rhs.scalar_def) &&
+           scalar_min.same_as(rhs.scalar_min) &&
+           scalar_max.same_as(rhs.scalar_max) &&
+           scalar_estimate.same_as(rhs.scalar_estimate);
+}
+
+Argument::Argument(const std::string &_name, Kind _kind, const Type &_type, int _dimensions, const ArgumentEstimates &argument_estimates) :
+    name(_name), kind(_kind), dimensions((uint8_t) _dimensions), type(_type), argument_estimates(argument_estimates) {
+    internal_assert(dimensions >= 0 && dimensions <= 255);
+    user_assert(!(is_scalar() && dimensions != 0)) << "Scalar Arguments must specify dimensions of 0";
+    user_assert(argument_estimates.buffer_estimates.size() == 0 ||
+                argument_estimates.buffer_estimates.size() == dimensions) << "buffer_estimates must match dimensionality for Argument " << name;
+}
+
+}  // namespace Halide

--- a/src/Argument.h
+++ b/src/Argument.h
@@ -14,6 +14,21 @@
 
 namespace Halide {
 
+struct ArgumentEstimates {
+    /** If this is a scalar argument, then these are its default, min, max, and estimated values.
+     * For buffer arguments, all should be undefined. */
+    Expr scalar_def, scalar_min, scalar_max, scalar_estimate;
+
+    /** If this is a buffer argument, these are the estimated min and extent for each dimension.
+     * If there are no estimates, buffer_estimates.size() can be zero; otherwise, it must always equal the dimensions */
+    struct MinAndExtent {
+        Expr min, extent;
+    };
+    std::vector<MinAndExtent> buffer_estimates;
+
+    bool operator==(const ArgumentEstimates &rhs) const;
+};
+
 /**
  * A struct representing an argument to a halide-generated
  * function. Used for specifying the function signature of
@@ -39,11 +54,11 @@ struct Argument {
         InputBuffer = halide_argument_kind_input_buffer,
         OutputBuffer = halide_argument_kind_output_buffer
     };
-    Kind kind;
+    Kind kind = InputScalar;
 
     /** If kind == InputBuffer|OutputBuffer, this is the dimensionality of the buffer.
      * If kind == InputScalar, this value is ignored (and should always be set to zero) */
-    uint8_t dimensions;
+    uint8_t dimensions = 0;
 
     /** If this is a scalar parameter, then this is its type.
      *
@@ -53,27 +68,14 @@ struct Argument {
      * Note that type.lanes should always be 1 here. */
     Type type;
 
-    /** If this is a scalar parameter, then these are its default, min, max values.
-     * By default, they are left unset, implying "no default, no min, no max". */
-    Expr def, min, max;
+    /* The estimates (if any) and default/min/max values (if any) for this Argument. */
+    ArgumentEstimates argument_estimates;
 
-    Argument() : kind(InputScalar), dimensions(0) {}
+    Argument() = default;
     Argument(const std::string &_name, Kind _kind, const Type &_type, int _dimensions,
-                Expr _def = Expr(),
-                Expr _min = Expr(),
-                Expr _max = Expr()) :
-        name(_name), kind(_kind), dimensions((uint8_t) _dimensions), type(_type), def(_def), min(_min), max(_max) {
-        internal_assert(_dimensions >= 0 && _dimensions <= 255);
-        user_assert(!(is_scalar() && dimensions != 0))
-            << "Scalar Arguments must specify dimensions of 0";
-        user_assert(!(is_buffer() && def.defined()))
-            << "Scalar default must not be defined for Buffer Arguments";
-        user_assert(!(is_buffer() && min.defined()))
-            << "Scalar min must not be defined for Buffer Arguments";
-        user_assert(!(is_buffer() && max.defined()))
-            << "Scalar max must not be defined for Buffer Arguments";
-    }
+             const ArgumentEstimates &argument_estimates);
 
+    // TODO: this should really be marked explicit
     template<typename T>
     Argument(Buffer<T> im) :
         name(im.name()),
@@ -92,9 +94,7 @@ struct Argument {
                kind == rhs.kind &&
                dimensions == rhs.dimensions &&
                type == rhs.type &&
-               def.same_as(rhs.def) &&
-               min.same_as(rhs.min) &&
-               max.same_as(rhs.max);
+               argument_estimates == rhs.argument_estimates;
     }
 };
 

--- a/src/Argument.h
+++ b/src/Argument.h
@@ -75,7 +75,9 @@ struct Argument {
     Argument(const std::string &_name, Kind _kind, const Type &_type, int _dimensions,
              const ArgumentEstimates &argument_estimates);
 
-    // TODO: this should really be marked explicit
+    // Not explicit, so that you can put Buffer in an argument list,
+    // to indicate that it shouldn't be baked into the object file,
+    // but instead received as an argument at runtime
     template<typename T>
     Argument(Buffer<T> im) :
         name(im.name()),

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -435,6 +435,7 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   AlignLoads.cpp
   AllocationBoundsInference.cpp
   ApplySplit.cpp
+  Argument.cpp
   AssociativeOpsTable.cpp
   Associativity.cpp
   AsyncProducers.cpp

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2712,10 +2712,10 @@ void CodeGen_C::visit(const Shuffle *op) {
 }
 
 void CodeGen_C::test() {
-    LoweredArgument buffer_arg("buf", Argument::OutputBuffer, Int(32), 3);
-    LoweredArgument float_arg("alpha", Argument::InputScalar, Float(32), 0);
-    LoweredArgument int_arg("beta", Argument::InputScalar, Int(32), 0);
-    LoweredArgument user_context_arg("__user_context", Argument::InputScalar, type_of<const void*>(), 0);
+    LoweredArgument buffer_arg("buf", Argument::OutputBuffer, Int(32), 3, ArgumentEstimates{});
+    LoweredArgument float_arg("alpha", Argument::InputScalar, Float(32), 0, ArgumentEstimates{});
+    LoweredArgument int_arg("beta", Argument::InputScalar, Int(32), 0, ArgumentEstimates{});
+    LoweredArgument user_context_arg("__user_context", Argument::InputScalar, type_of<const void*>(), 0, ArgumentEstimates{});
     vector<LoweredArgument> args = { buffer_arg, float_arg, int_arg, user_context_arg };
     Var x("x");
     Param<float> alpha("alpha");

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -962,22 +962,20 @@ llvm::Function *CodeGen_LLVM::embed_metadata_getter(const std::string &metadata_
         };
         Constant *type = ConstantStruct::get(type_t_type, type_fields);
 
-        Expr def = args[arg].def;
-        Expr min = args[arg].min;
-        Expr max = args[arg].max;
+        auto argument_estimates = args[arg].argument_estimates;
         if (args[arg].type.is_handle()) {
             // Handle values are always emitted into metadata as "undefined", regardless of
             // what sort of Expr is provided.
-            def = min = max = Expr();
+            argument_estimates = ArgumentEstimates{};
         }
         Constant *argument_fields[] = {
             create_string_constant(map_string(args[arg].name)),
             ConstantInt::get(i32_t, args[arg].kind),
             ConstantInt::get(i32_t, args[arg].dimensions),
             type,
-            embed_constant_expr(def),
-            embed_constant_expr(min),
-            embed_constant_expr(max)
+            embed_constant_expr(argument_estimates.scalar_def),
+            embed_constant_expr(argument_estimates.scalar_min),
+            embed_constant_expr(argument_estimates.scalar_max)
         };
         arguments_array_entries.push_back(ConstantStruct::get(argument_t_type, argument_fields));
     }

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -124,15 +124,11 @@ Outputs compute_outputs(const Target &target,
 }
 
 Argument to_argument(const Internal::Parameter &param, const Expr &default_value) {
-    Expr def, min, max;
-    if (!param.is_buffer()) {
-        def = default_value; // *not* param.scalar_expr();
-        min = param.min_value();
-        max = param.max_value();
-    }
+    ArgumentEstimates argument_estimates = param.get_argument_estimates();
+    argument_estimates.scalar_def = default_value;
     return Argument(param.name(),
         param.is_buffer() ? Argument::InputBuffer : Argument::InputScalar,
-        param.type(), param.dimensions(), def, min, max);
+        param.type(), param.dimensions(), argument_estimates);
 }
 
 Func make_param_func(const Parameter &p, const std::string &name) {

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -748,10 +748,10 @@ class InjectHexagonRpc : public IRMutator2 {
         for (const auto& i : c.buffers) {
             if (i.second.write) {
                 Argument::Kind kind = Argument::OutputBuffer;
-                output_buffers.push_back(LoweredArgument(i.first, kind, i.second.type, i.second.dimensions));
+                output_buffers.push_back(LoweredArgument(i.first, kind, i.second.type, i.second.dimensions, ArgumentEstimates{}));
             } else {
                 Argument::Kind kind = Argument::InputBuffer;
-                input_buffers.push_back(LoweredArgument(i.first, kind, i.second.type, i.second.dimensions));
+                input_buffers.push_back(LoweredArgument(i.first, kind, i.second.type, i.second.dimensions, ArgumentEstimates{}));
             }
 
             // Build a parameter to replace.
@@ -788,7 +788,7 @@ class InjectHexagonRpc : public IRMutator2 {
         args.insert(args.end(), input_buffers.begin(), input_buffers.end());
         args.insert(args.end(), output_buffers.begin(), output_buffers.end());
         for (const auto& i : c.vars) {
-            LoweredArgument arg(i.first, Argument::InputScalar, i.second, 0);
+            LoweredArgument arg(i.first, Argument::InputScalar, i.second, 0, ArgumentEstimates{});
             if (alignment_info.contains(i.first)) {
                 arg.alignment = alignment_info.get(i.first);
             }

--- a/src/InferArguments.cpp
+++ b/src/InferArguments.cpp
@@ -87,27 +87,33 @@ private:
         if (!p.defined()) return;
         if (already_have(p.name())) return;
 
-        Expr def, min, max;
+        ArgumentEstimates argument_estimates = p.get_argument_estimates();
         if (!p.is_buffer()) {
-            def = p.scalar_expr();
-            min = p.min_value();
-            max = p.max_value();
+            argument_estimates.scalar_def = p.scalar_expr();
+            argument_estimates.scalar_min = p.min_value();
+            argument_estimates.scalar_max = p.max_value();
+            argument_estimates.scalar_estimate = p.estimate();
         }
 
         InferredArgument a = {
             Argument(p.name(),
                      p.is_buffer() ? Argument::InputBuffer : Argument::InputScalar,
-                     p.type(), p.dimensions(), def, min, max),
+                     p.type(), p.dimensions(), argument_estimates),
             p,
             Buffer<>()};
         args.push_back(a);
 
         // Visit child expressions
-        if (!p.is_buffer()) {
-            visit_expr(def);
-            visit_expr(min);
-            visit_expr(max);
-        } else {
+        visit_expr(argument_estimates.scalar_def);
+        visit_expr(argument_estimates.scalar_min);
+        visit_expr(argument_estimates.scalar_max);
+        visit_expr(argument_estimates.scalar_estimate);
+        for (const auto &be : argument_estimates.buffer_estimates) {
+            visit_expr(be.min);
+            visit_expr(be.extent);
+        }
+
+        if (p.is_buffer()) {
             for (int i = 0; i < p.dimensions(); i++) {
                 visit_expr(p.min_constraint(i));
                 visit_expr(p.extent_constraint(i));
@@ -121,7 +127,7 @@ private:
         if (already_have(b.name())) return;
 
         InferredArgument a = {
-            Argument(b.name(), Argument::InputBuffer, b.type(), b.dimensions()),
+            Argument(b.name(), Argument::InputBuffer, b.type(), b.dimensions(), ArgumentEstimates{}),
             Parameter(),
             b};
         args.push_back(a);

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -369,7 +369,7 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
         for (Parameter buf : out.output_buffers()) {
             public_args.push_back(Argument(buf.name(),
                                            Argument::OutputBuffer,
-                                           buf.type(), buf.dimensions()));
+                                           buf.type(), buf.dimensions(), buf.get_argument_estimates()));
         }
     }
 

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -146,7 +146,7 @@ LoweredFunc::LoweredFunc(const std::string &name,
                          NameMangling name_mangling)
     : name(name), body(body), linkage(linkage), name_mangling(name_mangling) {
     for (const Argument &i : args) {
-        this->args.push_back(i);
+        this->args.push_back(LoweredArgument(i));
     }
 }
 

--- a/src/Module.h
+++ b/src/Module.h
@@ -17,7 +17,7 @@
 
 namespace Halide {
 
-/** Type of linkage a function in a lowered Halide module can have. 
+/** Type of linkage a function in a lowered Halide module can have.
     Also controls whether auxiliary functions and metadata are generated. */
 enum class LinkageType {
     External, ///< Visible externally.
@@ -35,12 +35,10 @@ struct LoweredArgument : public Argument {
      * argument. */
     ModulusRemainder alignment;
 
-    LoweredArgument() {}
-    LoweredArgument(const Argument &arg) : Argument(arg) {}
-    LoweredArgument(const std::string &_name, Kind _kind, const Type &_type, uint8_t _dimensions,
-                    Expr _def = Expr(),
-                    Expr _min = Expr(),
-                    Expr _max = Expr()) : Argument(_name, _kind, _type, _dimensions, _def, _min, _max) {}
+    LoweredArgument() = default;
+    explicit LoweredArgument(const Argument &arg) : Argument(arg) {}
+    LoweredArgument(const std::string &_name, Kind _kind, const Type &_type, uint8_t _dimensions, const ArgumentEstimates &argument_estimates)
+        : Argument(_name, _kind, _type, _dimensions, argument_estimates) {}
 };
 
 /** Definition of a lowered function. This object provides a concrete

--- a/src/OutputImageParam.cpp
+++ b/src/OutputImageParam.cpp
@@ -82,7 +82,7 @@ Internal::Parameter OutputImageParam::parameter() const {
 }
 
 OutputImageParam::operator Argument() const {
-    return Argument(name(), kind, type(), dimensions());
+    return Argument(name(), kind, type(), dimensions(), param.get_argument_estimates());
 }
 
 OutputImageParam::operator ExternFuncArgument() const {

--- a/src/Param.h
+++ b/src/Param.h
@@ -275,7 +275,7 @@ public:
      * statically compiling halide pipelines. */
     operator Argument() const {
         return Argument(name(), Argument::InputScalar, type(), 0,
-            param.scalar_expr(), param.min_value(), param.max_value());
+            param.get_argument_estimates());
     }
 
     const Internal::Parameter &parameter() const {

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -7,39 +7,31 @@
 namespace Halide {
 namespace Internal {
 
+struct BufferConstraint {
+    Expr min, extent, stride;
+    Expr min_estimate, extent_estimate;
+};
+
 struct ParameterContents {
     mutable RefCount ref_count;
     const Type type;
     const int dimensions;
     const std::string name;
-    const std::string handle_type;
     Buffer<> buffer;
     uint64_t data;
     int host_alignment;
-    std::vector<Expr> min_constraint;
-    std::vector<Expr> extent_constraint;
-    std::vector<Expr> stride_constraint;
-    std::vector<Expr> min_constraint_estimate;
-    std::vector<Expr> extent_constraint_estimate;
-    Expr min_value, max_value;
-    Expr estimate;
+    std::vector<BufferConstraint> buffer_constraints;
+    Expr scalar_min, scalar_max, scalar_estimate;
     const bool is_buffer;
 
     ParameterContents(Type t, bool b, int d, const std::string &n)
         : type(t), dimensions(d), name(n), buffer(Buffer<>()), data(0),
-          host_alignment(t.bytes()), is_buffer(b) {
-
-        min_constraint.resize(dimensions);
-        extent_constraint.resize(dimensions);
-        stride_constraint.resize(dimensions);
-        min_constraint_estimate.resize(dimensions);
-        extent_constraint_estimate.resize(dimensions);
-
+          host_alignment(t.bytes()), buffer_constraints(dimensions), is_buffer(b) {
         // stride_constraint[0] defaults to 1. This is important for
         // dense vectorization. You can unset it by setting it to a
         // null expression. (param.set_stride(0, Expr());)
         if (dimensions > 0) {
-            stride_constraint[0] = 1;
+            buffer_constraints[0].stride = 1;
         }
     }
 };
@@ -173,31 +165,31 @@ bool Parameter::defined() const {
 void Parameter::set_min_constraint(int dim, Expr e) {
     check_is_buffer();
     check_dim_ok(dim);
-    contents->min_constraint[dim] = e;
+    contents->buffer_constraints[dim].min = e;
 }
 
 void Parameter::set_extent_constraint(int dim, Expr e) {
     check_is_buffer();
     check_dim_ok(dim);
-    contents->extent_constraint[dim] = e;
+    contents->buffer_constraints[dim].extent = e;
 }
 
 void Parameter::set_stride_constraint(int dim, Expr e) {
     check_is_buffer();
     check_dim_ok(dim);
-    contents->stride_constraint[dim] = e;
+    contents->buffer_constraints[dim].stride = e;
 }
 
 void Parameter::set_min_constraint_estimate(int dim, Expr min) {
     check_is_buffer();
     check_dim_ok(dim);
-    contents->min_constraint_estimate[dim] = min;
+    contents->buffer_constraints[dim].min_estimate = min;
 }
 
 void Parameter::set_extent_constraint_estimate(int dim, Expr extent) {
     check_is_buffer();
     check_dim_ok(dim);
-    contents->extent_constraint_estimate[dim] = extent;
+    contents->buffer_constraints[dim].extent_estimate = extent;
 }
 
 void Parameter::set_host_alignment(int bytes) {
@@ -208,31 +200,31 @@ void Parameter::set_host_alignment(int bytes) {
 Expr Parameter::min_constraint(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
-    return contents->min_constraint[dim];
+    return contents->buffer_constraints[dim].min;
 }
 
 Expr Parameter::extent_constraint(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
-    return contents->extent_constraint[dim];
+    return contents->buffer_constraints[dim].extent;
 }
 
 Expr Parameter::stride_constraint(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
-    return contents->stride_constraint[dim];
+    return contents->buffer_constraints[dim].stride;
 }
 
 Expr Parameter::min_constraint_estimate(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
-    return contents->min_constraint_estimate[dim];
+    return contents->buffer_constraints[dim].min_estimate;
 }
 
 Expr Parameter::extent_constraint_estimate(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
-    return contents->extent_constraint_estimate[dim];
+    return contents->buffer_constraints[dim].extent_estimate;
 }
 
 int Parameter::host_alignment() const {
@@ -248,12 +240,12 @@ void Parameter::set_min_value(Expr e) {
             << " to have min value " << e
             << " of type " << e.type() << "\n";
     }
-    contents->min_value = e;
+    contents->scalar_min = e;
 }
 
 Expr Parameter::min_value() const {
     check_is_scalar();
-    return contents->min_value;
+    return contents->scalar_min;
 }
 
 void Parameter::set_max_value(Expr e) {
@@ -265,22 +257,22 @@ void Parameter::set_max_value(Expr e) {
             << " to have max value " << e
             << " of type " << e.type() << "\n";
     }
-    contents->max_value = e;
+    contents->scalar_max = e;
 }
 
 Expr Parameter::max_value() const {
     check_is_scalar();
-    return contents->max_value;
+    return contents->scalar_max;
 }
 
 void Parameter::set_estimate(Expr e) {
     check_is_scalar();
-    contents->estimate = e;
+    contents->scalar_estimate = e;
 }
 
 Expr Parameter::estimate() const {
     check_is_scalar();
-    return contents->estimate;
+    return contents->scalar_estimate;
 }
 
 void check_call_arg_types(const std::string &name, std::vector<Expr> *args, int dims) {

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -1,3 +1,4 @@
+#include "Argument.h"
 #include "IR.h"
 #include "IROperator.h"
 #include "ObjectInstanceRegistry.h"
@@ -274,6 +275,24 @@ Expr Parameter::estimate() const {
     check_is_scalar();
     return contents->scalar_estimate;
 }
+
+ArgumentEstimates Parameter::get_argument_estimates() const {
+    ArgumentEstimates argument_estimates;
+    if (!is_buffer()) {
+        argument_estimates.scalar_def = scalar_expr();
+        argument_estimates.scalar_min = min_value();
+        argument_estimates.scalar_max = max_value();
+        argument_estimates.scalar_estimate = estimate();
+    } else {
+        argument_estimates.buffer_estimates.resize(dimensions());
+        for (int i = 0; i < dimensions(); i++) {
+            argument_estimates.buffer_estimates[i].min = min_constraint_estimate(i);
+            argument_estimates.buffer_estimates[i].extent = extent_constraint_estimate(i);
+        }
+    }
+    return argument_estimates;
+}
+
 
 void check_call_arg_types(const std::string &name, std::vector<Expr> *args, int dims) {
     user_assert(args->size() == (size_t)dims)

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -10,6 +10,7 @@
 
 namespace Halide {
 
+struct ArgumentEstimates;
 class OutputImageParam;
 
 namespace Internal {
@@ -156,6 +157,9 @@ public:
     bool operator<(const Parameter &other) const {
         return contents < other.contents;
     }
+
+    /** Get the ArgumentEstimates appropriate for this Parameter. */
+    ArgumentEstimates get_argument_estimates() const;
 };
 
 /** Validate arguments to a call to a func, image or imageparam. */

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -92,7 +92,7 @@ struct PipelineContents {
 
     PipelineContents() :
         module("", Target()) {
-        user_context_arg.arg = Argument("__user_context", Argument::InputScalar, type_of<const void*>(), 0);
+        user_context_arg.arg = Argument("__user_context", Argument::InputScalar, type_of<const void*>(), 0, ArgumentEstimates{});
         user_context_arg.param = Parameter(Handle(), false, 0, "__user_context");
     }
 

--- a/src/WrapExternStages.cpp
+++ b/src/WrapExternStages.cpp
@@ -46,21 +46,21 @@ class WrapExternStages : public IRMutator2 {
                 Function f_arg(arg.func);
                 for (auto b : f_arg.output_buffers()) {
                     args.emplace_back(b.name(), Argument::InputBuffer,
-                                      b.type(), b.dimensions());
+                                      b.type(), b.dimensions(), b.get_argument_estimates());
                 }
             } else if (arg.arg_type == ExternFuncArgument::BufferArg) {
                 args.emplace_back(arg.buffer.name(), Argument::InputBuffer,
-                                  arg.buffer.type(), arg.buffer.dimensions());
+                                  arg.buffer.type(), arg.buffer.dimensions(), ArgumentEstimates{});
             } else if (arg.arg_type == ExternFuncArgument::ExprArg) {
                 args.emplace_back(unique_name('a'), Argument::InputScalar,
-                                  arg.expr.type(), 0);
+                                  arg.expr.type(), 0, ArgumentEstimates{});
             } else if (arg.arg_type == ExternFuncArgument::ImageParamArg) {
                 args.emplace_back(arg.image_param.name(), Argument::InputBuffer,
-                                  arg.image_param.type(), arg.image_param.dimensions());
+                                  arg.image_param.type(), arg.image_param.dimensions(), ArgumentEstimates{});
             }
         }
         for (auto b : f.output_buffers()) {
-            args.emplace_back(b.name(), Argument::OutputBuffer, b.type(), b.dimensions());
+            args.emplace_back(b.name(), Argument::OutputBuffer, b.type(), b.dimensions(), b.get_argument_estimates());
         }
 
         // Build the body of the wrapper.
@@ -178,7 +178,7 @@ void add_legacy_wrapper(Module module, const LoweredFunc &fn) {
             call_args.push_back(Variable::make(arg.type, arg.name));
         } else {
             // Buffer arguments become opaque pointers
-            args.emplace_back(arg.name, Argument::InputScalar, type_of<buffer_t *>(), 0);
+            args.emplace_back(arg.name, Argument::InputScalar, type_of<buffer_t *>(), 0, ArgumentEstimates{});
 
             string new_buffer_name = arg.name + ".upgraded";
             Expr new_buffer_var = Variable::make(type_of<struct halide_buffer_t *>(), new_buffer_name);

--- a/test/correctness/infer_arguments.cpp
+++ b/test/correctness/infer_arguments.cpp
@@ -61,35 +61,35 @@ int main(int argc, char **argv) {
 
         // All Scalar Arguments have a defined default when coming from
         // infer_arguments.
-        EXPECT(false, input1_arg.def.defined());
-        EXPECT(false, input2_arg.def.defined());
-        EXPECT(true, frac_arg.def.defined());
-        EXPECT(true, constant_expr_equals<float>(frac_arg.def, 22.5f));
-        EXPECT(true, height_arg.def.defined());
-        EXPECT(true, thresh_arg.def.defined());
-        EXPECT(true, width_arg.def.defined());
-        EXPECT(true, z_unsigned_arg.def.defined());
-        EXPECT(true, constant_expr_equals<uint64_t>(z_unsigned_arg.def, 0xdeadbeef));
+        EXPECT(false, input1_arg.argument_estimates.scalar_def.defined());
+        EXPECT(false, input2_arg.argument_estimates.scalar_def.defined());
+        EXPECT(true, frac_arg.argument_estimates.scalar_def.defined());
+        EXPECT(true, constant_expr_equals<float>(frac_arg.argument_estimates.scalar_def, 22.5f));
+        EXPECT(true, height_arg.argument_estimates.scalar_def.defined());
+        EXPECT(true, thresh_arg.argument_estimates.scalar_def.defined());
+        EXPECT(true, width_arg.argument_estimates.scalar_def.defined());
+        EXPECT(true, z_unsigned_arg.argument_estimates.scalar_def.defined());
+        EXPECT(true, constant_expr_equals<uint64_t>(z_unsigned_arg.argument_estimates.scalar_def, 0xdeadbeef));
 
-        EXPECT(false, input1_arg.min.defined());
-        EXPECT(false, input2_arg.min.defined());
-        EXPECT(true, frac_arg.min.defined());
-        EXPECT(true, constant_expr_equals<float>(frac_arg.min, 11.25f));
-        EXPECT(false, height_arg.min.defined());
-        EXPECT(false, thresh_arg.min.defined());
-        EXPECT(false, width_arg.min.defined());
-        EXPECT(true, z_unsigned_arg.min.defined());
-        EXPECT(true, constant_expr_equals<uint64_t>(z_unsigned_arg.min, 0x1));
+        EXPECT(false, input1_arg.argument_estimates.scalar_min.defined());
+        EXPECT(false, input2_arg.argument_estimates.scalar_min.defined());
+        EXPECT(true, frac_arg.argument_estimates.scalar_min.defined());
+        EXPECT(true, constant_expr_equals<float>(frac_arg.argument_estimates.scalar_min, 11.25f));
+        EXPECT(false, height_arg.argument_estimates.scalar_min.defined());
+        EXPECT(false, thresh_arg.argument_estimates.scalar_min.defined());
+        EXPECT(false, width_arg.argument_estimates.scalar_min.defined());
+        EXPECT(true, z_unsigned_arg.argument_estimates.scalar_min.defined());
+        EXPECT(true, constant_expr_equals<uint64_t>(z_unsigned_arg.argument_estimates.scalar_min, 0x1));
 
-        EXPECT(false, input1_arg.max.defined());
-        EXPECT(false, input2_arg.max.defined());
-        EXPECT(true, frac_arg.max.defined());
-        EXPECT(true, constant_expr_equals<float>(frac_arg.max, 1e30f));
-        EXPECT(false, height_arg.max.defined());
-        EXPECT(false, thresh_arg.max.defined());
-        EXPECT(false, width_arg.max.defined());
-        EXPECT(true, z_unsigned_arg.max.defined());
-        EXPECT(true, constant_expr_equals<uint64_t>(z_unsigned_arg.max, 0xf00dcafedeadbeef));
+        EXPECT(false, input1_arg.argument_estimates.scalar_max.defined());
+        EXPECT(false, input2_arg.argument_estimates.scalar_max.defined());
+        EXPECT(true, frac_arg.argument_estimates.scalar_max.defined());
+        EXPECT(true, constant_expr_equals<float>(frac_arg.argument_estimates.scalar_max, 1e30f));
+        EXPECT(false, height_arg.argument_estimates.scalar_max.defined());
+        EXPECT(false, thresh_arg.argument_estimates.scalar_max.defined());
+        EXPECT(false, width_arg.argument_estimates.scalar_max.defined());
+        EXPECT(true, z_unsigned_arg.argument_estimates.scalar_max.defined());
+        EXPECT(true, constant_expr_equals<uint64_t>(z_unsigned_arg.argument_estimates.scalar_max, 0xf00dcafedeadbeef));
 
         EXPECT(3, input1_arg.dimensions);
         EXPECT(2, input2_arg.dimensions);


### PR DESCRIPTION
This is a refactoring of Argument to move the auto-schedule estimates into it, as preparation for adding them to the generated Metadata. (There turned out to be substantial amounts of drive-by changes, but I think they are worthwhile.)

