### PR TITLE
Expand "name not in scope" debug info

### DIFF
--- a/src/Scope.h
+++ b/src/Scope.h
@@ -125,7 +125,7 @@ public:
             if (containing_scope) {
                 return containing_scope->get(name);
             } else {
-                internal_error << "Name not in Scope: " << name << "\n";
+                internal_error << "Name not in Scope: " << name << "\n" << *this << "\n";
             }
         }
         return iter->second.top();
@@ -137,7 +137,7 @@ public:
     T2 &ref(const std::string &name) {
         typename std::unordered_map<std::string, SmallStack<T>>::iterator iter = table.find(name);
         if (iter == table.end() || iter->second.empty()) {
-            internal_error << "Name not in Scope: " << name << "\n";
+            internal_error << "Name not in Scope: " << name << "\n" << *this << "\n";
         }
         return iter->second.top_ref();
     }
@@ -175,7 +175,7 @@ public:
      * same name in an outer scope) */
     void pop(const std::string &name) {
         typename std::unordered_map<std::string, SmallStack<T>>::iterator iter = table.find(name);
-        internal_assert(iter != table.end()) << "Name not in Scope: " << name << "\n";
+        internal_assert(iter != table.end()) << "Name not in Scope: " << name << "\n" << *this << "\n";
         iter->second.pop();
         if (iter->second.empty()) {
             table.erase(iter);
@@ -208,7 +208,9 @@ public:
             return iter->second;
         }
 
-        const T &value() {
+        template<typename T2 = T,
+                 typename = typename std::enable_if<!std::is_same<T2, void>::value>::type>
+        const T2 &value() {
             return iter->second.top_ref();
         }
     };
@@ -246,7 +248,9 @@ public:
             return iter->second;
         }
 
-        T &value() {
+        template<typename T2 = T,
+                 typename = typename std::enable_if<!std::is_same<T2, void>::value>::type>
+        T2 &value() {
             return iter->second.top_ref();
         }
     };


### PR DESCRIPTION
Many of the rogue `abort()` calls on Windows seem to be from failed Scope lookup during Generator compilation, which is odd, since (in theory) this code should be common across all platforms. Augment the assertion-failure code to dump the entire Scope chain out upon failure to help debug the situation. (Also: drive-by tweak to allow iterators to compile for `Scope<void>`)