### PR TITLE
Fix estimate metadata for Outputs

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2088,6 +2088,22 @@ Func &Func::estimate(Var var, Expr min, Expr extent) {
 
     Bound b = {var.name(), min, extent, Expr(), Expr()};
     func.schedule().estimates().push_back(b);
+
+    // Propagate the estimate into the Parameter as well, so that
+    // the values in the metadata will be correct.
+    const auto &arg_names = func.args();
+    int dim = -1;
+    for (size_t i = 0; i < arg_names.size(); ++i) {
+        if (arg_names[i] == var.name()) {
+            dim = i;
+            break;
+        }
+    }
+    internal_assert(dim >= 0);
+    for (auto param : func.output_buffers()) {
+        param.set_min_constraint_estimate(dim, min);
+        param.set_extent_constraint_estimate(dim, extent);
+    }
     return *this;
 }
 

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -912,7 +912,7 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           nullptr,
           nullptr,
           nullptr,
-          nullptr,
+          make_int64_array({10, 2592, 20, 1968, 0, 3}),
         },
         {
           "output.1",
@@ -923,7 +923,7 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           nullptr,
           nullptr,
           nullptr,
-          nullptr,
+          make_int64_array({10, 2592, 20, 1968, 0, 3}),
         },
         {
           "typed_output_buffer",
@@ -934,7 +934,7 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           nullptr,
           nullptr,
           nullptr,
-          nullptr,
+          make_int64_array({10, 2592, 20, 1968, NO_VALUE, NO_VALUE}),
         },
         {
           "type_only_output_buffer",

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -128,7 +128,7 @@ public:
         dim_only_output_buffer.compute_with(Func(typed_output_buffer), x);
 
         // Provide some bounds estimates for a Buffer input
-        typed_input_buffer.dim(0).set_bounds_estimate(0, 2592);
+        typed_input_buffer.estimate(Halide::_0, 0, 2592);
         typed_input_buffer.dim(1).set_bounds_estimate(42, 1968);
 
         // Provide some bounds estimates for a Func input
@@ -141,6 +141,16 @@ public:
         b.set_estimate(false);
         i8.set_estimate(3);
         f32.set_estimate(48.5f);
+
+        // Provide some bounds estimates for an Output<Func>
+        output
+            .estimate(x, 10, 2592)
+            .estimate(y, 20, 1968)
+            .estimate(c, 0, 3);
+
+        // Provide partial bounds estimates for an Output<Buffer>
+        typed_output_buffer.estimate(x, 10, 2592);
+        typed_output_buffer.dim(1).set_bounds_estimate(20, 1968);
     }
 
     void schedule() {


### PR DESCRIPTION
We needed to propagate estimates from the schedule into the Parameter as well; this happened elsewhere for Inputs but not for Outputs. Fixed, and added test cases which were (embarassingly) missing.