### PR TITLE
Add features to disable LLVM Loop Vectorization and Unrolling

### DIFF
--- a/halide.cmake
+++ b/halide.cmake
@@ -507,6 +507,8 @@ function(_halide_runtime_target_name HALIDE_TARGET OUTVAR)
         check_unsafe_promises
         hexagon_dma
         embed_bitcode
+        disable_llvm_loop_vectorize
+        disable_llvm_loop_unroll
       )
     # Synthesize a one-or-two-char abbreviation based on the feature's position
     # in the KNOWN_FEATURES list.

--- a/python_bindings/src/PyEnums.cpp
+++ b/python_bindings/src/PyEnums.cpp
@@ -140,6 +140,8 @@ void define_enums(py::module &m) {
         .value("CheckUnsafePromises", Target::Feature::CheckUnsafePromises)
         .value("HexagonDma", Target::Feature::HexagonDma)
         .value("EmbedBitcode", Target::Feature::EmbedBitcode)
+        .value("DisableLLVMLoopVectorize", Target::Feature::DisableLLVMLoopVectorize)
+        .value("DisableLLVMLoopUnroll", Target::Feature::DisableLLVMLoopUnroll)
         .value("FeatureEnd", Target::Feature::FeatureEnd);
 
     py::enum_<halide_type_code_t>(m, "TypeCode")

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1086,8 +1086,9 @@ void CodeGen_LLVM::optimize_module() {
     PassManagerBuilder b;
     b.OptLevel = 3;
     b.Inliner = createFunctionInliningPass(b.OptLevel, 0, false);
-    b.LoopVectorize = true;
-    b.SLPVectorize = true;
+    b.LoopVectorize = !get_target().has_feature(Target::DisableLLVMLoopVectorize);
+    b.DisableUnrollLoops = get_target().has_feature(Target::DisableLLVMLoopUnroll);
+    b.SLPVectorize = true;  // TODO: should this also be based on DisableLLVMLoopVectorize?
 
     if (TM) {
         TM->adjustPassManager(b);

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -306,6 +306,8 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"check_unsafe_promises", Target::CheckUnsafePromises},
     {"hexagon_dma", Target::HexagonDma},
     {"embed_bitcode", Target::EmbedBitcode},
+    {"disable_llvm_loop_vectorize", Target::DisableLLVMLoopVectorize},
+    {"disable_llvm_loop_unroll", Target::DisableLLVMLoopUnroll},
     // NOTE: When adding features to this map, be sure to update
     // PyEnums.cpp and halide.cmake as well.
 };

--- a/src/Target.h
+++ b/src/Target.h
@@ -101,6 +101,8 @@ struct Target {
         ASAN = halide_target_feature_asan,
         CheckUnsafePromises = halide_target_feature_check_unsafe_promises,
         EmbedBitcode = halide_target_feature_embed_bitcode,
+        DisableLLVMLoopVectorize = halide_target_feature_disable_llvm_loop_vectorize,
+        DisableLLVMLoopUnroll = halide_target_feature_disable_llvm_loop_unroll,
         FeatureEnd = halide_target_feature_end
     };
     Target() : os(OSUnknown), arch(ArchUnknown), bits(0) {}

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1287,7 +1287,9 @@ typedef enum halide_target_feature_t {
     halide_target_feature_check_unsafe_promises = 55, ///< Insert assertions for promises.
     halide_target_feature_hexagon_dma = 56, ///< Enable Hexagon DMA buffers.
     halide_target_feature_embed_bitcode = 57,  ///< Emulate clang -fembed-bitcode flag.
-    halide_target_feature_end = 58 ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
+    halide_target_feature_disable_llvm_loop_vectorize = 58,  ///< Disable loop vectorization in LLVM. (Ignored for non-LLVM targets.)
+    halide_target_feature_disable_llvm_loop_unroll = 59,  ///< Disable loop unrolling in LLVM. (Ignored for non-LLVM targets.)
+    halide_target_feature_end = 60 ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 
 /** This function is called internally by Halide in some situations to determine


### PR DESCRIPTION
There's some evidence that this increases compile time without improving code generation for *properly-scheduled* Halide code. Adding feature flags to allow opting out so that downstream code can experimentally disable it.