### PR TITLE
bound()/set_bounds() should also call estimate()/set_bounds_estimate()

### DIFF
--- a/src/Dimension.cpp
+++ b/src/Dimension.cpp
@@ -47,15 +47,19 @@ Expr Dimension::stride() const {
 
 Dimension Dimension::set_extent(Expr extent) {
     param.set_extent_constraint(d, extent);
-    // If we have an explicit bound on the extent, set that as the estimate as well.
-    param.set_extent_constraint_estimate(d, extent);
+    // Propagate constant bounds into estimates as well.
+    if (is_const(extent)) {
+        param.set_extent_constraint_estimate(d, extent);
+    }
     return *this;
 }
 
 Dimension Dimension::set_min(Expr min) {
     param.set_min_constraint(d, min);
-    // If we have an explicit bound on the min, set that as the estimate as well.
-    param.set_min_constraint_estimate(d, min);
+    // Propagate constant bounds into estimates as well.
+    if (is_const(min)) {
+        param.set_min_constraint_estimate(d, min);
+    }
     return *this;
 }
 

--- a/src/Dimension.cpp
+++ b/src/Dimension.cpp
@@ -47,11 +47,15 @@ Expr Dimension::stride() const {
 
 Dimension Dimension::set_extent(Expr extent) {
     param.set_extent_constraint(d, extent);
+    // If we have an explicit bound on the extent, set that as the estimate as well.
+    param.set_extent_constraint_estimate(d, extent);
     return *this;
 }
 
 Dimension Dimension::set_min(Expr min) {
     param.set_min_constraint(d, min);
+    // If we have an explicit bound on the min, set that as the estimate as well.
+    param.set_min_constraint_estimate(d, min);
     return *this;
 }
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2075,7 +2075,9 @@ Func &Func::bound(Var var, Expr min, Expr extent) {
     Bound b = {var.name(), min, extent, Expr(), Expr()};
     func.schedule().bounds().push_back(b);
 
-    // If we have an explicit bound on the min/extent, set those as estimates as well.
+    // Propagate constant bounds into estimates as well.
+    if (!is_const(min)) min = Expr();
+    if (!is_const(extent)) extent = Expr();
     estimate(var, min, extent);
 
     return *this;

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2074,6 +2074,10 @@ Func &Func::bound(Var var, Expr min, Expr extent) {
 
     Bound b = {var.name(), min, extent, Expr(), Expr()};
     func.schedule().bounds().push_back(b);
+
+    // If we have an explicit bound on the min/extent, set those as estimates as well.
+    estimate(var, min, extent);
+
     return *this;
 }
 
@@ -2101,8 +2105,12 @@ Func &Func::estimate(Var var, Expr min, Expr extent) {
     }
     internal_assert(dim >= 0);
     for (auto param : func.output_buffers()) {
-        param.set_min_constraint_estimate(dim, min);
-        param.set_extent_constraint_estimate(dim, extent);
+        if (min.defined()) {
+            param.set_min_constraint_estimate(dim, min);
+        }
+        if (extent.defined()) {
+            param.set_extent_constraint_estimate(dim, extent);
+        }
     }
     return *this;
 }

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -1,10 +1,9 @@
 #include "HalideRuntime.h"
 #include "HalideBuffer.h"
 
-#include <math.h>
-#include <stdio.h>
+#include <cmath>
 #include <iostream>
-#include <string.h>
+#include <string>
 #include <map>
 
 #include "metadata_tester.h"

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -14,91 +14,107 @@ using namespace Halide::Runtime;
 
 const int kSize = 32;
 
+inline std::ostream &operator<<(std::ostream &o, const halide_type_t &type) {
+    if (type.code == halide_type_uint && type.bits == 1) {
+        o << "bool";
+    } else {
+        assert(type.code >= 0 && type.code <= 3);
+        static const char * const names[4] = { "int", "uint", "float", "handle" };
+        o << names[type.code] << (int) type.bits;
+    }
+    if (type.lanes > 1) {
+        o << "x" << (int) type.lanes;
+    }
+    return o;
+}
+
+inline constexpr int halide_type_code(halide_type_code_t code, int bits) {
+    return (((int) code) << 8) | bits;
+}
+
+struct typed_scalar {
+    halide_type_t type;
+    halide_scalar_value_t value;
+
+    typed_scalar(const halide_type_t &t, const halide_scalar_value_t &v) : type(t), value(v) {}
+
+    bool operator==(const typed_scalar &that) const {
+        if (this->type != that.type) {
+            std::cerr << "Mismatched types\n";
+            exit(-1);
+        }
+        switch (halide_type_code((halide_type_code_t) type.code, type.bits)) {
+            case halide_type_code(halide_type_float, 32):  return value.u.f32 == that.value.u.f32;
+            case halide_type_code(halide_type_float, 64):  return value.u.f64 == that.value.u.f64;
+            case halide_type_code(halide_type_int, 8):     return value.u.i8 == that.value.u.i8;
+            case halide_type_code(halide_type_int, 16):    return value.u.i16 == that.value.u.i16;
+            case halide_type_code(halide_type_int, 32):    return value.u.i32 == that.value.u.i32;
+            case halide_type_code(halide_type_int, 64):    return value.u.i64 == that.value.u.i64;
+            case halide_type_code(halide_type_uint, 1):    return value.u.b == that.value.u.b;
+            case halide_type_code(halide_type_uint, 8):    return value.u.u8 == that.value.u.u8;
+            case halide_type_code(halide_type_uint, 16):   return value.u.u16 == that.value.u.u16;
+            case halide_type_code(halide_type_uint, 32):   return value.u.u32 == that.value.u.u32;
+            case halide_type_code(halide_type_uint, 64):   return value.u.u64 == that.value.u.u64;
+            case halide_type_code(halide_type_handle, 64): return value.u.handle == that.value.u.handle;
+            default:
+                std::cerr << "Unsupported type\n";
+                exit(-1);
+                break;
+        }
+    }
+
+    bool operator!=(const typed_scalar &that) const {
+        return !(*this == that);
+    }
+
+    friend std::ostream &operator<<(std::ostream &o, const typed_scalar &s) {
+        switch (halide_type_code((halide_type_code_t) s.type.code, s.type.bits)) {
+            case halide_type_code(halide_type_float, 32):  o << s.value.u.f32; break;
+            case halide_type_code(halide_type_float, 64):  o << s.value.u.f64; break;
+            case halide_type_code(halide_type_int, 8):     o << (int) s.value.u.i8; break;
+            case halide_type_code(halide_type_int, 16):    o << s.value.u.i16; break;
+            case halide_type_code(halide_type_int, 32):    o << s.value.u.i32; break;
+            case halide_type_code(halide_type_int, 64):    o << s.value.u.i64; break;
+            case halide_type_code(halide_type_uint, 1):    o << (s.value.u.b ? "true" : "false"); break;
+            case halide_type_code(halide_type_uint, 8):    o << (int) s.value.u.u8; break;
+            case halide_type_code(halide_type_uint, 16):   o << s.value.u.u16; break;
+            case halide_type_code(halide_type_uint, 32):   o << s.value.u.u32; break;
+            case halide_type_code(halide_type_uint, 64):   o << s.value.u.u64; break;
+            case halide_type_code(halide_type_handle, 64): o << (uint64_t) s.value.u.handle; break;
+            default:
+                std::cerr << "Unsupported type\n";
+                exit(-1);
+                break;
+        }
+        return o;
+    }
+};
+
 #define EXPECT_EQ(exp, act)                                                                                  \
     do {                                                                                                     \
         if ((exp) != (act)) {                                                                                \
-            fprintf(stderr, "%s == %s: Expected %f, Actual %f\n", #exp, #act, (double)(exp), (double)(act)); \
+            std::cerr << #exp << " == " << #act << ": Expected " << exp << ", Actual " << act << "\n";       \
             exit(-1);                                                                                        \
         }                                                                                                    \
     } while (0);
 
-#define EXPECT_STREQ(exp, act)                                                                       \
-    do {                                                                                             \
-        if (strcmp((exp), (act)) != 0) {                                                             \
-            fprintf(stderr, "%s == %s: Expected \"%s\", Actual \"%s\"\n", #exp, #act, (exp), (act)); \
-            exit(-1);                                                                                \
-        }                                                                                            \
+#define EXPECT_STREQ(exp, act) \
+    EXPECT_EQ(std::string(exp), std::string(act))
+
+#define EXPECT_TYPE_AND_SCALAR_EQ(etype, exp, atype, act) \
+    EXPECT_EQ(typed_scalar((etype), (exp)), typed_scalar((atype), (act)))
+
+#define EXPECT_TYPE_AND_SCALAR_PTR_EQ(etype, exp_ptr, atype, act_ptr)               \
+    do {                                                                            \
+        if ((exp_ptr) && (act_ptr)) {                                               \
+            EXPECT_TYPE_AND_SCALAR_EQ((etype), *(exp_ptr), (atype), *(act_ptr));    \
+        } else if (!(exp_ptr) && !(act_ptr)) {                                      \
+            EXPECT_EQ(etype, atype);                                                \
+        } else {                                                                    \
+            std::cerr << "One null, one non-null\n";                                \
+            exit(-1);                                                               \
+        }                                                                           \
     } while (0);
-
-#define EXPECT_SCALAR_UNION_EQ(code, bits, exp, act)                  \
-    do {                                                              \
-        if (!scalar_union_ptr_equal((code), (bits), (exp), (act))) {  \
-            fprintf(stderr, "%s == %s: did not match\n", #exp, #act); \
-            exit(-1);                                                 \
-        }                                                             \
-    } while (0);
-
-bool scalar_union_equal(int32_t type_code,
-                        int32_t type_bits,
-                        const halide_scalar_value_t &e,
-                        const halide_scalar_value_t &a) {
-    switch (type_code) {
-    case halide_type_int:
-        switch (type_bits) {
-        case 8:
-            return e.u.i8 == a.u.i8;
-        case 16:
-            return e.u.i16 == a.u.i16;
-        case 32:
-            return e.u.i32 == a.u.i32;
-        case 64:
-            return e.u.i64 == a.u.i64;
-        }
-    case halide_type_uint:
-        switch (type_bits) {
-        case 1:
-            return e.u.b == a.u.b;
-        case 8:
-            return e.u.u8 == a.u.u8;
-        case 16:
-            return e.u.u16 == a.u.u16;
-        case 32:
-            return e.u.u32 == a.u.u32;
-        case 64:
-            return e.u.u64 == a.u.u64;
-        }
-    case halide_type_float:
-        switch (type_bits) {
-        case 32:
-            return e.u.f32 == a.u.f32;
-        case 64:
-            return e.u.f64 == a.u.f64;
-        }
-    case halide_type_handle:
-        return e.u.handle == a.u.handle;
-    }
-    fprintf(stderr, "Unsupported type %d or size %d\n", type_code, type_bits);
-    exit(-1);
-}
-
-bool scalar_union_ptr_equal(int32_t type_code,
-                            int32_t type_bits,
-                            const halide_scalar_value_t *e,
-                            const halide_scalar_value_t *a) {
-    if (e) {
-        if (a) {
-            return scalar_union_equal(type_code, type_bits, *e, *a);
-        } else {
-            return false;
-        }
-    } else {
-        if (a) {
-            return false;
-        } else {
-            return true;
-        }
-    }
-}
 
 void match_argument(const halide_filter_argument_t &e, const halide_filter_argument_t &a) {
     EXPECT_STREQ(e.name, a.name);
@@ -107,15 +123,35 @@ void match_argument(const halide_filter_argument_t &e, const halide_filter_argum
     EXPECT_EQ(e.type.code, a.type.code);
     EXPECT_EQ(e.type.bits, a.type.bits);
     EXPECT_EQ(e.dimensions, a.dimensions);
-    EXPECT_SCALAR_UNION_EQ(e.type.code, e.type.bits, e.scalar_def, a.scalar_def);
-    EXPECT_SCALAR_UNION_EQ(e.type.code, e.type.bits, e.scalar_min, a.scalar_min);
-    EXPECT_SCALAR_UNION_EQ(e.type.code, e.type.bits, e.scalar_max, a.scalar_max);
-    EXPECT_SCALAR_UNION_EQ(e.type.code, e.type.bits, e.scalar_estimate, a.scalar_estimate);
-    if (e.buffer_estimates && a.buffer_estimates) {
+    EXPECT_TYPE_AND_SCALAR_PTR_EQ(e.type, e.scalar_def, a.type, a.scalar_def);
+    EXPECT_TYPE_AND_SCALAR_PTR_EQ(e.type, e.scalar_min, a.type, a.scalar_min);
+    EXPECT_TYPE_AND_SCALAR_PTR_EQ(e.type, e.scalar_max, a.type, a.scalar_max);
+    EXPECT_TYPE_AND_SCALAR_PTR_EQ(e.type, e.scalar_estimate, a.type, a.scalar_estimate);
+
+    // we want to treat
+    //      buffer_estimates == nullptr
+    // as equivalent to
+    //      buffer_estimates == { nullptr, nullptr, ... nullptr },
+    // so do a little pre-flighting to simplify things.
+
+    int64_t const* const* eb = e.buffer_estimates;
+    int64_t const* const* ab = a.buffer_estimates;
+    int e_null = 0, a_null = 0;
+    for (int i = 0; i < e.dimensions * 2; ++i) {
+        if (eb && !eb[i]) e_null++;
+        if (ab && !ab[i]) a_null++;
+    }
+    if (e_null == e.dimensions*2) eb = nullptr;
+    if (a_null == a.dimensions*2) ab = nullptr;
+
+    EXPECT_EQ((eb != nullptr), (ab != nullptr));
+    if (eb && ab) {
         for (int i = 0; i < e.dimensions * 2; ++i) {
-            EXPECT_SCALAR_UNION_EQ(halide_type_int, 64,
-                (const halide_scalar_value_t*) e.buffer_estimates[i],
-                (const halide_scalar_value_t*) a.buffer_estimates[i]);
+            EXPECT_TYPE_AND_SCALAR_PTR_EQ(
+                halide_type_t(halide_type_int, 64),
+                (const halide_scalar_value_t*) eb[i],
+                halide_type_t(halide_type_int, 64),
+                (const halide_scalar_value_t*) ab[i]);
         }
     }
 }
@@ -143,11 +179,11 @@ void verify(const Buffer<uint8_t> &input,
             const Buffer<float> &tupled_output_buffer0,
             const Buffer<int32_t> &tupled_output_buffer1) {
     if (output_scalar.dimensions() != 0) {
-        fprintf(stderr, "output_scalar should be zero-dimensional\n");
+        std::cerr << "output_scalar should be zero-dimensional\n";
         exit(-1);
     }
     if (output_scalar() != 1234.25f) {
-        fprintf(stderr, "output_scalar value is wrong (%f)\n", output_scalar());
+        std::cerr << "output_scalar value is wrong (" << output_scalar() << "\n";
         exit(-1);
     }
     for (int x = 0; x < kSize; x++) {
@@ -158,27 +194,27 @@ void verify(const Buffer<uint8_t> &input,
                 const float actual0 = output0(x, y, c);
                 const float actual1 = output1(x, y, c);
                 if (expected0 != actual0) {
-                    fprintf(stderr, "img0[%d, %d, %d] = %f, expected %f\n", x, y, c, (double)actual0, (double)expected0);
+                    std::cerr << "img0[" << x << "," << y << "," << c << "] = " << actual0 << ", expected " << expected0 << "\n";
                     exit(-1);
                 }
                 if (expected1 != actual1) {
-                    fprintf(stderr, "img1[%d, %d, %d] = %f, expected %f\n", x, y, c, (double)actual1, (double)expected1);
+                    std::cerr << "img1[" << x << "," << y << "," << c << "] = " << actual1 << ", expected " << expected1 << "\n";
                     exit(-1);
                 }
                 if (output_array0(x, y, c) != 1.5f) {
-                    fprintf(stderr, "output_array0[%d, %d, %d] = %f, expected %f\n", x, y, c, output_array0(x, y, c), 1.5f);
+                    std::cerr << "output_array0[" << x << "," << y << "," << c << "] = " << output_array0(x, y, c) << ", expected " << 1.5f << "\n";
                     exit(-1);
                 }
                 if (output_array1(x, y, c) != 3.0f) {
-                    fprintf(stderr, "output_array1[%d, %d, %d] = %f, expected %f\n", x, y, c, output_array1(x, y, c), 3.0f);
+                    std::cerr << "output_array1[" << x << "," << y << "," << c << "] = " << output_array1(x, y, c) << ", expected " << 2.0f << "\n";
                     exit(-1);
                 }
                 if (untyped_output_buffer(x, y, c) != expected1) {
-                    fprintf(stderr, "untyped_output_buffer[%d, %d, %d] = %f, expected %f\n", x, y, c, untyped_output_buffer(x, y, c), expected1);
+                    std::cerr << "untyped_output_buffer[" << x << "," << y << "," << c << "] = " << untyped_output_buffer(x, y, c) << ", expected " << expected1 << "\n";
                     exit(-1);
                 }
                 if (tupled_output_buffer0(x, y, c) != expected1) {
-                    fprintf(stderr, "tupled_output_buffer0[%d, %d, %d] = %f, expected %f\n", x, y, c, tupled_output_buffer0(x, y, c), expected1);
+                    std::cerr << "tupled_output_buffer0[" << x << "," << y << "," << c << "] = " << tupled_output_buffer0(x, y, c) << ", expected " << expected1 << "\n";
                     exit(-1);
                 }
             }
@@ -292,7 +328,7 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
     if (!strstr(md.target, "x86") &&
         !strstr(md.target, "powerpc") &&
         !strstr(md.target, "arm")) {
-        fprintf(stderr, "Expected x86 or arm, Actual %s\n", md.target);
+        std::cerr << "Expected x86 or arm, Actual " << md.target << "\n";
         exit(-1);
     }
 
@@ -945,7 +981,7 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           nullptr,
           nullptr,
           nullptr,
-          nullptr,
+          make_int64_array({NO_VALUE, NO_VALUE, 0, 32, 0, 3}),
         },
         {
           "dim_only_output_buffer",
@@ -1229,7 +1265,7 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
 
     const halide_filter_argument_t* expected = &kExpectedArguments[expect_ucon_at_0 ? 0 : 1];
     for (int i = 0; i < md.num_arguments; ++i) {
-        // fprintf(stdout, "checking arg %d %s\n", i, md.arguments[i].name);
+        // std::cout << "checking arg " << i << " " << md.arguments[i].name << "\n";
         match_argument(expected[i], md.arguments[i]);
     }
 
@@ -1395,16 +1431,16 @@ int main(int argc, char **argv) {
 
     check_metadata(*metadata_tester_metadata(), false);
     if (!strcmp(metadata_tester_metadata()->name, "metadata_tester_metadata")) {
-        fprintf(stderr, "Expected name %s\n", "metadata_tester_metadata");
+        std::cerr << "Expected name metadata_tester_metadata\n";
         exit(-1);
     }
 
     check_metadata(*metadata_tester_ucon_metadata(), true);
     if (!strcmp(metadata_tester_ucon_metadata()->name, "metadata_tester_ucon_metadata")) {
-        fprintf(stderr, "Expected name %s\n", "metadata_tester_ucon_metadata");
+        std::cerr << "Expected name metadata_tester_ucon_metadata\n";
         exit(-1);
     }
 
-    printf("Success!\n");
+    std::cout << "Success!\n";
     return 0;
 }

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -142,15 +142,20 @@ public:
         i8.set_estimate(3);
         f32.set_estimate(48.5f);
 
-        // Provide some bounds estimates for an Output<Func>
+        // Provide some bounds estimates for an Output<Func>.
+        // Note that calling bound() implicitly calls estimate() as well.
         output
             .estimate(x, 10, 2592)
             .estimate(y, 20, 1968)
-            .estimate(c, 0, 3);
+            .bound(c, 0, 3);
 
         // Provide partial bounds estimates for an Output<Buffer>
         typed_output_buffer.estimate(x, 10, 2592);
         typed_output_buffer.dim(1).set_bounds_estimate(20, 1968);
+
+        // Note that calling set_bounds()/bound() implicitly calls set_bounds_estimate()/estimate() as well.
+        type_only_output_buffer.dim(1).set_bounds(0, 32);
+        type_only_output_buffer.bound(c, 0, 3);
     }
 
     void schedule() {


### PR DESCRIPTION
Suggestion from @abadams: if we have hard boundaries, we should set the autoschedule estimate values to that as well.

(Lots of drive-by churn in the test that was updated, as the old version wouldn't show the values when mismatches were found, making debugging painful.)