### PR TITLE
Fix tail selection strategy in autoscheduler

### DIFF
--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -2389,6 +2389,9 @@ pair<VarOrRVar, VarOrRVar> Partitioner::split_dim(
 
     TailStrategy strategy = TailStrategy::Auto;
     if ((stage_num > 0) && !v.is_rvar) {
+        // TODO: It's safe to use RoundUp here if we know there are no
+        // loads from any input, but at this point we've lost track of
+        // loads from inputs that happen inside inlined Funcs.
         strategy = TailStrategy::GuardWithIf;
     }
 

--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -2386,28 +2386,10 @@ pair<VarOrRVar, VarOrRVar> Partitioner::split_dim(
     // care for the nested loops. If it is the update definition of the group output
     // however, we'd better make sure that no other member of the groups accesses
     // the inputs or outputs.
+
     TailStrategy strategy = TailStrategy::Auto;
     if ((stage_num > 0) && !v.is_rvar) {
-        if (!is_group_output) {
-            if (access_inputs_or_outputs(def, v, costs.inputs, outputs)) {
-                strategy = TailStrategy::GuardWithIf;
-            }
-        } else {
-            bool any_access_inputs_outputs = false;
-            for (const FStage &mem : g.members) {
-                if (mem.func.name() == f_handle.name()) {
-                    continue;
-                }
-                Definition mem_def = get_stage_definition(mem.func, mem.stage_num);
-                if (access_inputs_or_outputs(mem_def, v, costs.inputs, outputs)) {
-                    any_access_inputs_outputs = true;
-                    break;
-                }
-            }
-            if (any_access_inputs_outputs) {
-                strategy = TailStrategy::GuardWithIf;
-            }
-        }
+        strategy = TailStrategy::GuardWithIf;
     }
 
     f_handle.split(v, outer, inner, factor, strategy);

--- a/test/correctness/autoschedule_small_pure_update.cpp
+++ b/test/correctness/autoschedule_small_pure_update.cpp
@@ -1,0 +1,30 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Buffer<float> in(13, 17);
+    ImageParam in_param(Float(32), 2);
+
+    Func g, h;
+    Var x, y;
+
+    RDom r(0, 17);
+    g(x) += in_param(x, r);
+
+    h(x, y) = in_param(x, y) + g(x);
+
+    h.estimate(x, 0, 13).estimate(y, 0, 17);
+    in_param.dim(0).set_bounds_estimate(0, 13).dim(1).set_bounds_estimate(0, 17);
+
+    Pipeline p(h);
+    p.auto_schedule(Target("host"));
+
+    in_param.set(in);
+
+    // Ensure the autoscheduler doesn't try to RoundUp the pure loop
+    // in g's update definition.
+    p.realize(13, 17);
+
+    return 0;
+}


### PR DESCRIPTION
I encountered a bug where loads from inputs via a trivially inlined Func weren't discovered by the logic in the autoscheduler that decides if RoundUp is safe for a tail strategy.