### PR TITLE
Remove stale comment about halide_set_num_threads()

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -299,10 +299,6 @@ extern void halide_join_thread(struct halide_thread *);
  * n == 1 : use exactly one thread; this will always enforce serial execution
  * n > 1  : use a pool of exactly n threads.
  *
- * Note that the default iOS and OSX behavior will treat n > 1 like n == 0;
- * that is, any positive value other than 1 will use a system-determined number
- * of threads.
- *
  * (Note that this is only guaranteed when using the default implementations
  * of halide_do_par_for(); custom implementations may completely ignore values
  * passed to halide_set_num_threads().)


### PR DESCRIPTION
Trivial, but confuses users.  Now that macOS/iOS use pthreads, `halide_set_num_threads()` does indeed have an effect.