### PR TITLE
Make it possible to install an autoscheduler as a plugin

### DIFF
--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -150,11 +150,21 @@ vector<Func> Pipeline::outputs() const {
     return funcs;
 }
 
+std::function<string(Pipeline, const Target &, const MachineParams &)> Pipeline::custom_auto_scheduler;
+
 string Pipeline::auto_schedule(const Target &target, const MachineParams &arch_params) {
+    if (custom_auto_scheduler) {
+        return custom_auto_scheduler(*this, target, arch_params);
+    }
+
     user_assert(target.arch == Target::X86 || target.arch == Target::ARM ||
                 target.arch == Target::POWERPC || target.arch == Target::MIPS)
         << "Automatic scheduling is currently supported only on these architectures.";
     return generate_schedules(contents->outputs, target, arch_params);
+}
+
+void Pipeline::set_custom_auto_scheduler(std::function<string(Pipeline, const Target &, const MachineParams &)> auto_scheduler) {
+    Pipeline::custom_auto_scheduler = auto_scheduler;
 }
 
 Func Pipeline::get_func(size_t index) {

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -101,7 +101,9 @@ public:
     static std::vector<Internal::JITModule> make_externs_jit_module(const Target &target,
                                                                     std::map<std::string, JITExtern> &externs_in_out);
 
-public:
+    static std::function<std::string(Pipeline, const Target &, const MachineParams &)> custom_auto_scheduler;
+
+ public:
     /** Make an undefined Pipeline object. */
     Pipeline();
 
@@ -121,6 +123,11 @@ public:
     std::string auto_schedule(const Target &target,
                               const MachineParams &arch_params = MachineParams::generic());
     //@}
+
+    /** Globally set the autoscheduler method to use whenever
+     * autoscheduling any Pipeline. Uses the built-in autoscheduler if
+     * passed nullptr. */
+    static void set_custom_auto_scheduler(std::function<std::string(Pipeline, const Target &, const MachineParams &)> auto_scheduler);
 
     /** Return handle to the index-th Func within the pipeline based on the
      * topological order. */

--- a/test/correctness/custom_auto_scheduler.cpp
+++ b/test/correctness/custom_auto_scheduler.cpp
@@ -1,0 +1,36 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int call_count = 0;
+
+std::string inline_everything(Pipeline,
+                              const Target &,
+                              const MachineParams &) {
+    call_count++;
+    // Inlining everything is really easy.
+    return "";
+}
+
+int main(int argc, char **argv) {
+
+    // All pipelines built within this process should use my autoscheduler
+    Pipeline::set_custom_auto_scheduler(inline_everything);
+
+    Func f;
+    Var x;
+    f(x) = 3;
+    Pipeline(f).auto_schedule(Target("host"));
+
+    Func g;
+    g(x) = 3;
+    Pipeline(g).auto_schedule(Target("host"));
+
+    if (call_count != 2) {
+        printf("Should have called the custom autoscheduler twice. Instead called it %d times\n", call_count);
+        return -1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
The goal is to be able to apply new autoschedulers to existing generators by linking them in and having them install themselves in global constructors, or by writing a custom GenGen.cpp that installs one of your choice.