### PR TITLE
Fix some UBSan warnings

### DIFF
--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -5,6 +5,8 @@ IMAGES ?= ../images
 HL_TARGET ?= host
 UNAME ?= $(shell uname)
 
+SANITIZER_FLAGS ?=
+
 # This pulls in the definition of HALIDE_SYSTEM_LIBS
 include $(HALIDE_DISTRIB_PATH)/halide_config.make
 
@@ -19,7 +21,7 @@ CXX ?= g++
 GXX ?= g++
 
 CFLAGS += -I $(HALIDE_DISTRIB_PATH)/include/ -I $(HALIDE_DISTRIB_PATH)/tools/ -I $(HALIDE_DISTRIB_PATH)/apps/support/
-CXXFLAGS += -std=c++11 -I $(HALIDE_DISTRIB_PATH)/include/ -I $(HALIDE_DISTRIB_PATH)/tools/
+CXXFLAGS += -std=c++11 -I $(HALIDE_DISTRIB_PATH)/include/ -I $(HALIDE_DISTRIB_PATH)/tools/ $(SANITIZER_FLAGS)
 
 ifeq ($(UNAME), Darwin)
 CXXFLAGS += -fvisibility=hidden

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -1401,9 +1401,11 @@ struct NotOp {
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
     bool match(SpecificExpr e, MatcherState &state) const noexcept {
+        if (e.expr.node_type != IRNodeType::Not) {
+            return false;
+        }
         const Not &op = (const Not &)e.expr;
-        return (e.expr.node_type == IRNodeType::Not &&
-                a.template match<bound>(SpecificExpr{*op.a.get()}, state));
+        return (a.template match<bound>(SpecificExpr{*op.a.get()}, state));
     }
 
     template<uint32_t bound, typename A2>
@@ -1457,9 +1459,11 @@ struct SelectOp {
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
     bool match(SpecificExpr e, MatcherState &state) const noexcept {
+        if (e.expr.node_type != Select::_node_type) {
+            return false;
+        }
         const Select &op = (const Select &)e.expr;
-        return (e.expr.node_type == Select::_node_type &&
-                c.template match<bound>(SpecificExpr{*op.condition.get()}, state) &&
+        return (c.template match<bound>(SpecificExpr{*op.condition.get()}, state) &&
                 t.template match<bound | bindings<C>::mask>(SpecificExpr{*op.true_value.get()}, state) &&
                 f.template match<bound | bindings<C>::mask | bindings<T>::mask>(SpecificExpr{*op.false_value.get()}, state));
     }
@@ -1587,9 +1591,11 @@ struct RampOp {
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
     bool match(SpecificExpr e, MatcherState &state) const noexcept {
+        if (e.expr.node_type != Ramp::_node_type) {
+            return false;
+        }
         const Ramp &op = (const Ramp &)e.expr;
-        if (op.node_type == Ramp::_node_type &&
-            (lanes == op.type.lanes() || !known_lanes) &&
+        if ((lanes == op.type.lanes() || !known_lanes) &&
             a.template match<bound>(SpecificExpr{*op.base.get()}, state) &&
             b.template match<bound | bindings<A>::mask>(SpecificExpr{*op.stride.get()}, state)) {
             return true;
@@ -1658,9 +1664,11 @@ struct NegateOp {
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
     bool match(SpecificExpr e, MatcherState &state) const noexcept {
+        if (e.expr.node_type != Sub::_node_type) {
+            return false;
+        }
         const Sub &op = (const Sub &)e.expr;
-        return (op.node_type == Sub::_node_type &&
-                a.template match<bound>(SpecificExpr{*op.b.get()}, state) &&
+        return (a.template match<bound>(SpecificExpr{*op.b.get()}, state) &&
                 is_zero(op.a));
     }
 
@@ -1734,9 +1742,11 @@ struct CastOp {
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
     bool match(SpecificExpr e, MatcherState &state) const noexcept {
+        if (e.expr.node_type != Cast::_node_type) {
+            return false;
+        }
         const Cast &op = (const Cast &)e.expr;
-        return (op.node_type == Cast::_node_type &&
-                e.expr.type == t &&
+        return (e.expr.type == t &&
                 a.template match<bound>(SpecificExpr{*op.value.get()}, state));
     }
     template<uint32_t bound, typename A2>
@@ -1841,9 +1851,11 @@ struct Indeterminate {
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
     bool match(SpecificExpr e, MatcherState &state) const noexcept {
+        if (e.expr.node_type != Call::_node_type) {
+            return false;
+        }
         const Call &op = (const Call &)e.expr;
-        return (op.node_type == Call::_node_type &&
-                op.is_intrinsic(Call::indeterminate_expression));
+        return (op.is_intrinsic(Call::indeterminate_expression));
     }
 
     HALIDE_ALWAYS_INLINE
@@ -1874,9 +1886,11 @@ struct Overflow {
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
     bool match(SpecificExpr e, MatcherState &state) const noexcept {
+        if (e.expr.node_type != Call::_node_type) {
+            return false;
+        }
         const Call &op = (const Call &)e.expr;
-        return (op.node_type == Call::_node_type &&
-                op.is_intrinsic(Call::signed_integer_overflow));
+        return (op.is_intrinsic(Call::signed_integer_overflow));
     }
 
     HALIDE_ALWAYS_INLINE

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -39,6 +39,17 @@ void get_program_name(char *name, int32_t size) {
 }
 #endif
 
+namespace {
+
+template<typename T>
+inline T load_misaligned(const T *p) {
+    T result;
+    memcpy(&result, p, sizeof(T));
+    return result;
+}
+
+}
+
 class DebugSections {
 
     bool calibrated;
@@ -1458,7 +1469,7 @@ private:
                             } else if (payload && payload[0] == 0x03 && val == (sizeof(void *) + 1)) {
                                 // It's a global
                                 // payload + 1 is an address
-                                const void *addr = *((const void * const *)(payload + 1));
+                                const void *addr = load_misaligned((const void * const *)(payload + 1));
                                 gvar.addr = (uint64_t)(addr);
                             } else {
                                 // Some other format that we don't understand
@@ -1525,8 +1536,10 @@ private:
                                 // It's an array of addresses
                                 const void * const * ptr = (const void * const *)(debug_ranges.data() + val);
                                 const void * const * end = (const void * const *)(debug_ranges.data() + debug_ranges.size());
-                                while (ptr[0] && ptr < end-1) {
-                                    LiveRange r = {(uint64_t)ptr[0], (uint64_t)ptr[1]};
+                                // Note: might not be properly aligned; use memcpy to avoid
+                                // sanitizer warnings
+                                while (load_misaligned(ptr) && ptr < end-1) {
+                                    LiveRange r = {(uint64_t)load_misaligned(ptr), (uint64_t)load_misaligned(ptr+1)};
                                     r.pc_begin += compile_unit_base_pc;
                                     r.pc_end += compile_unit_base_pc;
                                     live_ranges.push_back(r);


### PR DESCRIPTION
Built and tested with -fsanitize=undefined; fixed a handful of technically-UB-but-no-big-deal issues reported:

- misaligned loads
- incorrect downcasting