### PR TITLE
Disallow copy ctor in various Scope utilities

### DIFF
--- a/src/Scope.h
+++ b/src/Scope.h
@@ -267,6 +267,10 @@ struct ScopedBinding {
             scope->pop(name);
         }
     }
+
+    // allow move but not copy
+    ScopedBinding(const ScopedBinding& that) = delete;
+    ScopedBinding(ScopedBinding&& that) = default;
 };
 
 template<>
@@ -287,6 +291,10 @@ struct ScopedBinding<void> {
             scope->pop(name);
         }
     }
+
+    // allow move but not copy
+    ScopedBinding(const ScopedBinding& that) = delete;
+    ScopedBinding(ScopedBinding&& that) = default;
 };
 
 }  // namespace Internal

--- a/src/Simplify_Internal.h
+++ b/src/Simplify_Internal.h
@@ -177,6 +177,10 @@ public:
 
         ScopedFact(Simplify *s) : simplify(s) {}
         ~ScopedFact();
+
+        // allow move but not copy
+        ScopedFact(const ScopedFact& that) = delete;
+        ScopedFact(ScopedFact&& that) = default;
     };
 
     // Tell the simplifier to learn from and exploit a boolean

--- a/src/Util.h
+++ b/src/Util.h
@@ -305,6 +305,9 @@ struct ScopedValue {
     ScopedValue(T &var, T new_value) : var(var), old_value(var) { var = new_value; }
     ~ScopedValue() { var = old_value; }
     operator T() const { return old_value; }
+    // allow move but not copy
+    ScopedValue(const ScopedValue& that) = delete;
+    ScopedValue(ScopedValue&& that) = default;
 };
 
 // Wrappers for some C++14-isms that are useful and trivially implementable


### PR DESCRIPTION
Classes like ScopedFact will misbehave if they are accidentally copied (rather than moved); delete the copy ctor and default the move ctor.

(Apparently VS2015 is copying ScopedFact when it could be moving it, which seems to be the cause of the debug-only crash; not sure if that's legal for C++11 or not, but this is a good fix in any event.)