### PR TITLE
Don't attempt to dlopen() empty strings

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -849,6 +849,7 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
     // It's possible that in the future loaded plugins might change
     // how arguments are parsed, so we handle those first.
     for (auto lib : split_string(flags_info["-p"], ",")) {
+        if (lib.empty()) continue;
 #ifdef _WIN32
         if (LoadLibrary(lib.c_str()) != nullptr) {
             cerr << "Failed to load: " << lib << "\n";

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -2,6 +2,9 @@
 #include <fstream>
 #include <set>
 
+#if defined(_MSC_VER) && !defined(NOMINMAX)
+#define NOMINMAX
+#endif
 #ifdef _WIN32
 #include <windows.h>
 #else

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -23,6 +23,9 @@
 #define CAN_GET_RUNNING_PROGRAM_NAME
 #include <linux/limits.h>  // For PATH_MAX
 #endif
+#if defined(_MSC_VER) && !defined(NOMINMAX)
+#define NOMINMAX
+#endif
 #ifdef _WIN32
 #include <windows.h>
 #include <Objbase.h>  // needed for CoCreateGuid


### PR DESCRIPTION
Apparently this is OK on Linux, but definitely not on OSX or elsewhere.