### PR TITLE
Grab bag of minor cleanups

### DIFF
--- a/apps/autoscheduler/AutoSchedule.cpp
+++ b/apps/autoscheduler/AutoSchedule.cpp
@@ -1,3 +1,21 @@
+/*
+    Env vars used (directly or indirectly):
+
+    TODO(someone): document all these
+
+    HL_AUTO_SCHEDULE_TIME_LIMIT
+    HL_BEAM_SIZE
+    HL_CYOS
+    HL_FEATURE_FILE -> output
+    HL_MACHINE_PARAMS
+    HL_PERMIT_FAILED_UNROLL
+    HL_RANDOM_DROPOUT
+    HL_SCHEDULE_FILE
+    HL_SEED
+    HL_USE_MANUAL_COST_MODEL
+    HL_WEIGHTS_DIR
+
+*/
 #include <set>
 #include <queue>
 #include <algorithm>
@@ -3924,6 +3942,16 @@ std::string generate_schedules_new(const std::vector<Function> &outputs,
 
     // Print out the schedule
     optimal->dump();
+
+    string schedule_file = get_env_variable("HL_SCHEDULE_FILE");
+    if (!schedule_file.empty()) {
+        debug(0) << "Writing schedule to " << schedule_file << "...\n";
+        std::ofstream f(schedule_file, std::ios_base::trunc);
+        f << "// --- BEGIN machine-generated schedule\n"
+          << optimal->schedule_source
+          << "// --- END machine-generated schedule\n";
+        f.close();
+    }
 
     // Print out the predicted runtime of each Func, so we can compare them to a profile
     // optimal->print_predicted_runtimes(params);

--- a/apps/autoscheduler/Makefile
+++ b/apps/autoscheduler/Makefile
@@ -43,7 +43,7 @@ $(BIN)/cost_model/%.a: $(BIN)/cost_model.generator
 # undefined rather than dependent on libHalide.so.
 $(BIN)/auto_schedule.so: AutoSchedule.cpp $(WEIGHT_OBJECTS) $(COST_MODEL_LIBS) $(GENERATOR_DEPS) $(BIN)/runtime.a
 	@mkdir -p $(@D)
-	$(CXX) -shared $(USE_DYNAMIC_LOOKUPS) -fPIC $(CXXFLAGS) -g -I $(BIN)/cost_model AutoSchedule.cpp $(WEIGHT_OBJECTS) $(COST_MODEL_LIBS) $(BIN)/runtime.a -O3 -o $@ $(HALIDE_SYSTEM_LIBS)
+	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC $(CXXFLAGS) -g -I $(BIN)/cost_model AutoSchedule.cpp $(WEIGHT_OBJECTS) $(COST_MODEL_LIBS) $(BIN)/runtime.a -O3 -o $@ $(HALIDE_SYSTEM_LIBS)
 
 $(BIN)/train_cost_model: train_cost_model.cpp ThroughputPredictorPipeline.h $(COST_MODEL_LIBS) $(WEIGHT_OBJECTS) $(BIN)/runtime.a
 	$(CXX) $(CXXFLAGS) -I $(BIN)/cost_model -O3 $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(USE_OPEN_MP)
@@ -52,11 +52,11 @@ $(BIN)/augment_sample: augment_sample.cpp
 	$(CXX) $< -O3 -o $@
 
 # A sample generator to autoschedule. Note that if it statically links
-# to libHalide, then it must be build with $(USE_DYNAMIC_LOOKUPS), or the
+# to libHalide, then it must be build with $(USE_EXPORT_DYNAMIC), or the
 # autoscheduler can't find the libHalide symbols that it needs.
 $(BIN)/demo.generator: demo_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) $(USE_DYNAMIC_LOOKUPS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
+	$(CXX) $(CXXFLAGS) $(USE_EXPORT_DYNAMIC) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
 # To use the autoscheduler, set a few environment variables and use the -p flag to the generator to load the autoscheduler as a plugin
 $(BIN)/demo.a: $(BIN)/demo.generator $(BIN)/auto_schedule.so

--- a/apps/autoscheduler/Makefile
+++ b/apps/autoscheduler/Makefile
@@ -78,7 +78,7 @@ demo: $(BIN)/demo.rungen
 
 # demonstrates an autotuning loop
 autotune: $(BIN)/demo.generator $(BIN)/augment_sample $(BIN)/train_cost_model autotune_loop.sh $(BIN)/auto_schedule.so
-	bash autotune_loop.sh
+	bash autotune_loop.sh $(BIN)/demo.generator demo x86-64-avx2
 
 clean:
 	rm -rf $(BIN)

--- a/apps/autoscheduler/augment_sample.cpp
+++ b/apps/autoscheduler/augment_sample.cpp
@@ -3,7 +3,7 @@
 
 int main(int argc, char **argv) {
     if (argc != 5) {
-        printf("Usage: record_runtime sample.bin runtime pipeline_id schedule_id\n");
+        printf("Usage: augment_sample sample.bin runtime pipeline_id schedule_id\n");
         return -1;
     }
 

--- a/apps/autoscheduler/autotune_loop.sh
+++ b/apps/autoscheduler/autotune_loop.sh
@@ -1,35 +1,76 @@
 # Build the generator to autotune. This script will be autotuning the
 # autoscheduler's cost model training pipeline, which is large enough
 # to be interesting.
-GENERATOR=./bin/demo.generator
-PIPELINE=demo
+if [ $# -ne 3 ]; then
+  echo "Usage: $0 /path/to/some.generator generatorname halide_target"
+  exit
+fi
 
-HL_TARGET=x86-64-avx2
+set -eu
+
+GENERATOR=${1}
+PIPELINE=${2}
+HL_TARGET=${3}
 
 # A batch of this many samples is built in parallel, and then
-# benchmarked serially. 
+# benchmarked serially.
 BATCH_SIZE=32
 
 # Build a single sample of the pipeline with a random schedule
 make_sample() {
     D=${1}
+    SEED=${2}
+    FNAME=${3}
     mkdir -p ${D}
     rm -f "${D}/sample.sample"
     if [[ $D == */0 ]]; then
         # Sample 0 in each batch is best effort beam search, with no randomness
-        HL_PERMIT_FAILED_UNROLL=1 HL_MACHINE_PARAMS=32,1,1 HL_SEED=${2} HL_FEATURE_FILE=${D}/sample.sample HL_WEIGHTS_DIR=${PWD}/weights HL_RANDOM_DROPOUT=100 HL_BEAM_SIZE=50 ${GENERATOR} -g ${PIPELINE} -o ${D} target=${HL_TARGET} auto_schedule=true -p bin/auto_schedule.so 2> ${D}/compile_log.txt
+        dropout=100
+        beam=50
     else
         # The other samples are random probes biased by the cost model
-        HL_PERMIT_FAILED_UNROLL=1 HL_MACHINE_PARAMS=32,1,1 HL_SEED=${2} HL_FEATURE_FILE=${D}/sample.sample HL_WEIGHTS_DIR=${PWD}/weights HL_RANDOM_DROPOUT=90 HL_BEAM_SIZE=1 ${GENERATOR} -g ${PIPELINE} -o ${D} target=${HL_TARGET} auto_schedule=true -p bin/auto_schedule.so 2> ${D}/compile_log.txt
+        dropout=90
+        beam=1
     fi
-    
-    c++ -std=c++11 -DHL_RUNGEN_FILTER_HEADER="\"${D}/${PIPELINE}.h\"" -I ../../include ../../tools/RunGenMain.cpp ../../tools/RunGenStubs.cpp  ${D}/*.a -o ${D}/bench -ljpeg -ldl -lpthread -lz -lpng    
+    HL_PERMIT_FAILED_UNROLL=1 \
+        HL_MACHINE_PARAMS=32,1,1 \
+        HL_SEED=${SEED} \
+        HL_SCHEDULE_FILE=${D}/schedule.txt \
+        HL_FEATURE_FILE=${D}/sample.sample \
+        HL_WEIGHTS_DIR=${PWD}/weights \
+        HL_RANDOM_DROPOUT=${dropout} \
+        HL_BEAM_SIZE=${beam} \
+        ${GENERATOR} \
+        -g ${PIPELINE} \
+        -f ${FNAME} \
+        -o ${D} \
+        target=${HL_TARGET} \
+        auto_schedule=true \
+        -p bin/auto_schedule.so \
+            2> ${D}/compile_log.txt
+
+    c++ \
+        -std=c++11 \
+        -DHL_RUNGEN_FILTER_HEADER="\"${D}/${FNAME}.h\"" \
+        -I ../../include \
+        ../../tools/RunGenMain.cpp \
+        ../../tools/RunGenStubs.cpp  \
+        ${D}/*.a \
+        -o ${D}/bench \
+        -ljpeg -ldl -lpthread -lz -lpng
 }
 
 # Benchmark one of the random samples
 benchmark_sample() {
     D=${1}
-    HL_NUM_THREADS=32 ${D}/bench --output_extents=estimate --default_input_buffers=random:0:estimate_then_auto --default_input_scalars=estimate --benchmarks=all --benchmark_min_time=1 | tee ${D}/bench.txt
+    HL_NUM_THREADS=32 \
+        ${D}/bench \
+        --output_extents=estimate \
+        --default_input_buffers=random:0:estimate_then_auto \
+        --default_input_scalars=estimate \
+        --benchmarks=all \
+        --benchmark_min_time=1 \
+            | tee ${D}/bench.txt
 
     # Add the runtime, pipeline id, and schedule id to the feature file
     R=$(cut -d' ' -f8 < ${D}/bench.txt)
@@ -45,22 +86,23 @@ for ((i=$((FIRST+1));i<1000000;i++)); do
     # Compile a batch of samples using the generator in parallel
     DIR=${PWD}/samples/batch_${i}
 
+    echo Compiling ${BATCH_SIZE} samples for batch_${i}...
     for ((b=0;b<${BATCH_SIZE};b++)); do
-        echo Compiling sample $b
         S=$(printf "%d%02d" $i $b)
-        make_sample "${DIR}/${b}" $S 1 &
+        FNAME=$(printf "%s_batch_%02d_sample_%02d" ${PIPELINE} $i $b)
+        make_sample "${DIR}/${b}" $S $FNAME &
     done
     wait
-    
+
     # benchmark them serially using rungen
     for ((b=0;b<${BATCH_SIZE};b++)); do
-        echo Benchmarking sample $b
         S=$(printf "%d%02d" $i $b)
         benchmark_sample "${DIR}/${b}" $S
     done
-    
+
     # retrain model weights on all samples seen so far
     echo Retraining model...
-    find samples | grep sample$ | HL_NUM_THREADS=32 HL_WEIGHTS_DIR=weights ./bin/train_cost_model 100
-    
+    find samples | grep sample$ | \
+        HL_NUM_THREADS=32 HL_WEIGHTS_DIR=weights HL_BEST_SCHEDULE_FILE=${PWD}/samples/best.txt ./bin/train_cost_model 100
+
 done

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -32,14 +32,14 @@ CXXFLAGS += -fvisibility=hidden
 endif
 
 ifeq ($(UNAME), Linux)
-USE_DYNAMIC_LOOKUPS=-rdynamic
+USE_EXPORT_DYNAMIC=-rdynamic
 USE_OPEN_MP=-fopenmp
 else
 ifeq ($(UNAME), Darwin)
-USE_DYNAMIC_LOOKUPS=-undefined dynamic_lookup
+USE_EXPORT_DYNAMIC=-undefined dynamic_lookup
 USE_OPEN_MP=
 else
-USE_DYNAMIC_LOOKUPS
+USE_EXPORT_DYNAMIC
 USE_OPEN_MP=
 endif
 endif

--- a/tools/RunGen.h
+++ b/tools/RunGen.h
@@ -1158,8 +1158,8 @@ public:
         out() << "Benchmark for " << md->name << " produces best case of " << result.wall_time << " sec/iter (over "
               << result.samples << " samples, "
               << result.iterations << " iterations, "
-              << "accuracy " << std::setprecision(2) << (result.accuracy * 100.0) << "%).\n"
-              << "Best output throughput is " << (megapixels_out() / result.wall_time) << " mpix/sec.\n";
+              << "accuracy " << std::setprecision(2) << (result.accuracy * 100.0) << "%); "
+              << "best throughput is " << (megapixels_out() / result.wall_time) << " mpix/sec.\n";
     }
 
     struct Output {


### PR DESCRIPTION
(These PR is a result of doing a walkthrough of apps/autoscheduler to be sure I understood the workflow, in anticipation of porting it to Google's internal build system; some of these are probably sensible changes, some are probably pointless nitpickery in code style, and some may actually be counterproductive. Happy to cherrypick any/all of these.)

- AutoSchedule: attempt listing all the env vars used. (Exact definitions needed for each.)
- AutoSchedule: dump the generated C++ schedule to HL_SCHEDULE_FILE, in addition to having it lumped in with the general log
- autotune_loop.sh and RunGen.h: make the benchmark/compile loop output a little less verbose
- autotune.sh: split insanely long lines into multilines
- autotune.sh: give each sample variant a unique function name, this allows us to skip some extra output and to distinguish variants later on more easily. (Not entirely sure about this one, TBH.)
- train_cost_mode: emit the best result in path-ish form as well, trim iteration output to a single line
- train_cost_mode: if HL_BEST_SCHEDULE_FILE is defined, emit the info about 'best schedule' to that file (as well as stdout); autotune_loop.sh defines this to be `samples/best.txt`, the goal here being that the 'best' is kept up to date in the samples folder
- autotuneloop.sh: make GENERATOR, PIPELINE, and HL_TARGET required script arguments