### PR TITLE
Reschedule test/performance/matrix_multiplication

### DIFF
--- a/test/performance/matrix_multiplication.cpp
+++ b/test/performance/matrix_multiplication.cpp
@@ -20,34 +20,46 @@ void simple_version(float* A, float *B, float *C, int width, int stride) {
 
 
 int main(int argc, char **argv) {
-    const int matrix_size = 992, block_size = 32;
+    const int matrix_size = 992;
 
     ImageParam A(type_of<float>(), 2);
     ImageParam B(type_of<float>(), 2);
 
-    Var x("x"), xi("xi"), xo("xo"), y("y"), yo("yo"), yi("yo"), yii("yii"), xii("xii");
+    Var x("x"), xi("xi"), xo("xo"), y("y"), yo("yo"), yi("yi"), yii("yii"), xii("xii");
     Func matrix_mul("matrix_mul");
 
     RDom k(0, matrix_size);
     RVar ki;
 
-    matrix_mul(x, y) = 0.0f;
     matrix_mul(x, y) += A(k, y) * B(x, k);
 
-    matrix_mul.vectorize(x, 8);
+    Func out;
+    out(x, y) = matrix_mul(x, y);
+
+    Var xy;
+
+    out.tile(x, y, xi, yi, 24, 32)
+        .fuse(x, y, xy).parallel(xy)
+        .split(yi, yi, yii, 4)
+        .vectorize(xi, 8)
+        .unroll(xi)
+        .unroll(yii);
+
+    matrix_mul.compute_at(out, yi)
+        .vectorize(x, 8).unroll(y);
 
     matrix_mul.update(0)
-        .split(x, x, xi, block_size).split(xi, xi, xii, 8)
-        .split(y, y, yi, block_size).split(yi, yi, yii, 4)
-        .split(k, k, ki, block_size)
-        .reorder(xii, yii, xi, ki, yi, k, x, y)
-        .parallel(y).vectorize(xii).unroll(xi).unroll(yii);
+        .reorder(x, y, k)
+        .vectorize(x, 8)
+        .unroll(x)
+        .unroll(y)
+        .unroll(k, 2);
 
-    matrix_mul
+    out
         .bound(x, 0, matrix_size)
         .bound(y, 0, matrix_size);
 
-    matrix_mul.compile_jit();
+    out.compile_jit();
 
     Buffer<float> mat_A(matrix_size, matrix_size);
     Buffer<float> mat_B(matrix_size, matrix_size);
@@ -64,10 +76,10 @@ int main(int argc, char **argv) {
     A.set(mat_A);
     B.set(mat_B);
 
-    matrix_mul.realize(output);
+    out.realize(output);
 
     double t = benchmark([&]() {
-        matrix_mul.realize(output);
+        out.realize(output);
     });
 
     // check results
@@ -75,7 +87,7 @@ int main(int argc, char **argv) {
     Buffer<float> output_halide(matrix_size, matrix_size);
 
     simple_version(mat_A.data(), mat_B.data(), output_ref.data(), mat_A.width(), mat_A.stride(1));
-    matrix_mul.realize(output_halide);
+    out.realize(output_halide);
 
     bool halide_correct = true;
     for (int iy = 0; iy < matrix_size && halide_correct; iy++) {
@@ -94,9 +106,8 @@ int main(int argc, char **argv) {
     // Uncomment to see the generated assembly.
     /*
     {
-        Target t = get_jit_target_from_environment();
-        t.set_feature(Target::NoAsserts);
-        matrix_mul.compile_to_assembly("/dev/stdout", matrix_mul.infer_arguments(), t);
+        Target t("host-no_asserts-no_runtime-no_bounds_query");
+        out.compile_to_assembly("/dev/stdout", matrix_mul.infer_arguments(), t);
     }
     */
 


### PR DESCRIPTION
Takes it from 368 Gflops to 1140 Gflops on my workstation. That second number is quite noisy because I have multiple sockets and we don't do anything special in the thread pool to pin threads to cores/sockets. Doing that gives you a boost on microbenchmarks where the same thread keeps processing the same data, but isn't really meaningful in most applications where there's no strong coupling between thread id and what's likely to be in-cache.

One important caveat: I found that this workload works best without hyperthreading, so I set HL_NUM_THREADS to be my number of physical cpu cores, not the number of logical cores.

Generated inner loop:

```

	vbroadcastss	-4(%r11,%r13), %ymm15
	vmovups	-64(%r12,%rcx), %ymm14
	vmovups	-32(%r12,%rcx), %ymm13
	vmovups	(%r12,%rcx), %ymm0
	vfmadd231ps	%ymm15, %ymm14, %ymm9 # ymm9 = (ymm14 * ymm15) + ymm9
	vfmadd231ps	%ymm13, %ymm15, %ymm8 # ymm8 = (ymm15 * ymm13) + ymm8
	vfmadd213ps	%ymm12, %ymm0, %ymm15 # ymm15 = (ymm0 * ymm15) + ymm12
	vbroadcastss	-4(%r9,%r13), %ymm12
	vfmadd231ps	%ymm12, %ymm14, %ymm7 # ymm7 = (ymm14 * ymm12) + ymm7
	vfmadd231ps	%ymm12, %ymm13, %ymm6 # ymm6 = (ymm13 * ymm12) + ymm6
	vfmadd231ps	%ymm12, %ymm0, %ymm5 # ymm5 = (ymm0 * ymm12) + ymm5
	vbroadcastss	-4(%r15,%r13), %ymm12
	vfmadd231ps	%ymm12, %ymm14, %ymm4 # ymm4 = (ymm14 * ymm12) + ymm4
	vfmadd231ps	%ymm12, %ymm13, %ymm3 # ymm3 = (ymm13 * ymm12) + ymm3
	vfmadd231ps	%ymm12, %ymm0, %ymm2 # ymm2 = (ymm0 * ymm12) + ymm2
	vbroadcastss	-4(%r8,%r13), %ymm12
	vfmadd213ps	%ymm11, %ymm12, %ymm14 # ymm14 = (ymm12 * ymm14) + ymm11
	vfmadd213ps	%ymm10, %ymm12, %ymm13 # ymm13 = (ymm12 * ymm13) + ymm10
	vfmadd231ps	%ymm12, %ymm0, %ymm1 # ymm1 = (ymm0 * ymm12) + ymm1
	vbroadcastss	(%r11,%r13), %ymm12
	vmovups	-64(%r12,%rsi), %ymm11
	vmovups	-32(%r12,%rsi), %ymm10
	vmovups	(%r12,%rsi), %ymm0
	vfmadd231ps	%ymm12, %ymm11, %ymm9 # ymm9 = (ymm11 * ymm12) + ymm9
	vfmadd231ps	%ymm12, %ymm10, %ymm8 # ymm8 = (ymm10 * ymm12) + ymm8
	vfmadd213ps	%ymm15, %ymm0, %ymm12 # ymm12 = (ymm0 * ymm12) + ymm15
	vbroadcastss	(%r9,%r13), %ymm15
	vfmadd231ps	%ymm15, %ymm11, %ymm7 # ymm7 = (ymm11 * ymm15) + ymm7
	vfmadd231ps	%ymm15, %ymm10, %ymm6 # ymm6 = (ymm10 * ymm15) + ymm6
	vfmadd231ps	%ymm15, %ymm0, %ymm5 # ymm5 = (ymm0 * ymm15) + ymm5
	vbroadcastss	(%r15,%r13), %ymm15
	vfmadd231ps	%ymm15, %ymm11, %ymm4 # ymm4 = (ymm11 * ymm15) + ymm4
	vfmadd231ps	%ymm15, %ymm10, %ymm3 # ymm3 = (ymm10 * ymm15) + ymm3
	vfmadd231ps	%ymm15, %ymm0, %ymm2 # ymm2 = (ymm0 * ymm15) + ymm2
	vbroadcastss	(%r8,%r13), %ymm15
	vfmadd213ps	%ymm14, %ymm15, %ymm11 # ymm11 = (ymm15 * ymm11) + ymm14
	vfmadd213ps	%ymm13, %ymm15, %ymm10 # ymm10 = (ymm15 * ymm10) + ymm13
	vfmadd231ps	%ymm15, %ymm0, %ymm1 # ymm1 = (ymm0 * ymm15) + ymm1
	addq	$8, %r13
	addq	%r10, %r12
	cmpq	$3968, %r13             # imm = 0xF80
	jne	.LBB1_2


```