### PR TITLE
More minor fixes

### DIFF
--- a/apps/autoscheduler/ThroughputPredictorPipeline.h
+++ b/apps/autoscheduler/ThroughputPredictorPipeline.h
@@ -402,6 +402,7 @@ class ThroughputPredictorPipeline {
         void send(const uint8_t *data, ssize_t len) {
             ssize_t sent = ::send(fd, data, len, 0);
             assert(sent == len);
+            (void) sent;
         }
 
         void recv(uint8_t *data, ssize_t len) {

--- a/apps/autoscheduler/train_cost_model.cpp
+++ b/apps/autoscheduler/train_cost_model.cpp
@@ -7,6 +7,8 @@
 
 #include "ThroughputPredictorPipeline.h"
 
+namespace {
+
 using std::vector;
 using std::string;
 using std::map;
@@ -215,6 +217,7 @@ map<int, PipelineSample> load_samples() {
     return result;
 }
 
+}  // namespace
 
 int main(int argc, char **argv) {
     auto samples = load_samples();


### PR DESCRIPTION
- avoid unused-var warning re: assert
- wrap using statements (and other internal stuff) in anon namespace
- convert the StateMap in AutoSchedule to wrap values in unique_ptr as temporary workaround for an apparent compiler bug