### PR TITLE
Rename auto_schedule.so -> libauto_schedule.so

### DIFF
--- a/apps/autoscheduler/Makefile
+++ b/apps/autoscheduler/Makefile
@@ -41,7 +41,7 @@ $(BIN)/cost_model/%.a: $(BIN)/cost_model.generator
 # It's important to use dynamic lookups for undefined symbols here: all of libHalide
 # is expected to be present (in the loading binary), so we explicitly make the symbols
 # undefined rather than dependent on libHalide.so.
-$(BIN)/auto_schedule.so: AutoSchedule.cpp $(WEIGHT_OBJECTS) $(COST_MODEL_LIBS) $(GENERATOR_DEPS) $(BIN)/runtime.a
+$(BIN)/libauto_schedule.so: AutoSchedule.cpp $(WEIGHT_OBJECTS) $(COST_MODEL_LIBS) $(GENERATOR_DEPS) $(BIN)/runtime.a
 	@mkdir -p $(@D)
 	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC $(CXXFLAGS) -g -I $(BIN)/cost_model AutoSchedule.cpp $(WEIGHT_OBJECTS) $(COST_MODEL_LIBS) $(BIN)/runtime.a -O3 -o $@ $(HALIDE_SYSTEM_LIBS)
 
@@ -59,14 +59,14 @@ $(BIN)/demo.generator: demo_generator.cpp $(GENERATOR_DEPS)
 	$(CXX) $(CXXFLAGS) $(USE_EXPORT_DYNAMIC) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
 # To use the autoscheduler, set a few environment variables and use the -p flag to the generator to load the autoscheduler as a plugin
-$(BIN)/demo.a: $(BIN)/demo.generator $(BIN)/auto_schedule.so
+$(BIN)/demo.a: $(BIN)/demo.generator $(BIN)/libauto_schedule.so
 	HL_MACHINE_PARAMS=32,1,1 HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=weights \
-	$(BIN)/demo.generator -g demo -o $(BIN) -f demo -e static_library,h target=$(HL_TARGET) auto_schedule=true -p $(BIN)/auto_schedule.so
+	$(BIN)/demo.generator -g demo -o $(BIN) -f demo -e static_library,h target=$(HL_TARGET) auto_schedule=true -p $(BIN)/libauto_schedule.so
 
 $(BIN)/demo.rungen: $(BIN)/demo.a $(BIN)/runtime.a
 	$(CXX) -std=c++11 -I $(BIN) -DHL_RUNGEN_FILTER_HEADER="\"demo.h\"" -I ../../include ../../tools/RunGenMain.cpp ../../tools/RunGenStubs.cpp  $(BIN)/demo.a -o $@ $(HALIDE_SYSTEM_LIBS) -lpng -ljpeg
 
-$(BIN)/test: test.cpp $(BIN)/auto_schedule.so
+$(BIN)/test: test.cpp $(BIN)/libauto_schedule.so
 	$(CXX) $(CXXFLAGS) -rdynamic $< -o $@ $(LDFLAGS) $(LIB_HALIDE) $(HALIDE_SYSTEM_LIBS)
 
 test: $(BIN)/test
@@ -77,7 +77,7 @@ demo: $(BIN)/demo.rungen
 	$(BIN)/demo.rungen --benchmarks=all --benchmark_min_time=1 --default_input_buffers=random:0:auto --output_extents=estimate --default_input_scalars=estimate
 
 # demonstrates an autotuning loop
-autotune: $(BIN)/demo.generator $(BIN)/augment_sample $(BIN)/train_cost_model autotune_loop.sh $(BIN)/auto_schedule.so
+autotune: $(BIN)/demo.generator $(BIN)/augment_sample $(BIN)/train_cost_model autotune_loop.sh $(BIN)/libauto_schedule.so
 	bash autotune_loop.sh $(BIN)/demo.generator demo x86-64-avx2
 
 clean:

--- a/apps/autoscheduler/autotune_loop.sh
+++ b/apps/autoscheduler/autotune_loop.sh
@@ -46,7 +46,7 @@ make_sample() {
         -o ${D} \
         target=${HL_TARGET} \
         auto_schedule=true \
-        -p bin/auto_schedule.so \
+        -p bin/libauto_schedule.so \
             2> ${D}/compile_log.txt
 
     c++ \

--- a/apps/autoscheduler/test.cpp
+++ b/apps/autoscheduler/test.cpp
@@ -5,7 +5,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (!dlopen("auto_schedule.so", RTLD_LAZY)) {
+    if (!dlopen("libauto_schedule.so", RTLD_LAZY)) {
         std::cerr << "Failed to load autoscheduler: " << dlerror() << "\n";
         return 1;
     }

--- a/apps/random_pipeline/Makefile
+++ b/apps/random_pipeline/Makefile
@@ -11,7 +11,7 @@ HL_USE_MANUAL_COST_MODEL ?= 0
 
 ifeq ($(NEW_AUTOSCHEDULER),1)
 ID = $(HL_TARGET)-new_autoscheduler/pipeline_$(PIPELINE_SEED)_$(PIPELINE_STAGES)/schedule_$(HL_SEED)_$(HL_RANDOM_DROPOUT)_$(HL_BEAM_SIZE)_$(HL_USE_MANUAL_COST_MODEL)
-GEN_GEN_ARGS = -p bin/auto_schedule.so
+GEN_GEN_ARGS = -p bin/libauto_schedule.so
 else
 ID = $(HL_TARGET)-new_autoscheduler/pipeline_$(PIPELINE_SEED)_$(PIPELINE_STAGES)/schedule_$(HL_SEED)_$(HL_RANDOM_DROPOUT)_$(HL_BEAM_SIZE)_$(HL_USE_MANUAL_COST_MODEL)
 GEN_GEN_ARGS =

--- a/apps/random_pipeline/bench_comparison.sh
+++ b/apps/random_pipeline/bench_comparison.sh
@@ -23,16 +23,16 @@ HL_TARGET=host HL_SEED=root PIPELINE_SEED=0 HL_RANDOM_DROPOUT=${RANDOM_DROPOUT} 
 for ((b=1;b<2;b++)); do
     echo Batch $b
     rm -f results/files_*.txt
-    
+
     # Build lots of pipelines
     for ((p=0;p<$PIPELINES;p++)); do
         P=$((b * $PIPELINES + p))
         STAGES=$(((P % 30) + 10))
         echo echo Building pipeline $P
         #echo "HL_TARGET=host HL_SEED=root PIPELINE_SEED=$P PIPELINE_STAGES=$STAGES HL_RANDOM_DROPOUT=${RANDOM_DROPOUT} HL_BEAM_SIZE=${BEAM_SIZE} make build 2>&1 | grep -v Nothing.to.be.done"
-        echo "HL_TARGET=host HL_SEED=0 PIPELINE_SEED=$P PIPELINE_STAGES=$STAGES HL_RANDOM_DROPOUT=${RANDOM_DROPOUT} HL_BEAM_SIZE=${BEAM_SIZE} make build 2>&1 | grep -v Nothing.to.be.done"        
+        echo "HL_TARGET=host HL_SEED=0 PIPELINE_SEED=$P PIPELINE_STAGES=$STAGES HL_RANDOM_DROPOUT=${RANDOM_DROPOUT} HL_BEAM_SIZE=${BEAM_SIZE} make build 2>&1 | grep -v Nothing.to.be.done"
         for prof in ""; do
-            for ((m=0;m<2;m++)); do 
+            for ((m=0;m<2;m++)); do
                 for ((s=0;s<$SCHEDULES;s++)); do
                     echo "NEW_AUTOSCHEDULER=1 HL_TARGET=host${prof} HL_SEED=$s PIPELINE_SEED=$P PIPELINE_STAGES=$STAGES HL_RANDOM_DROPOUT=${RANDOM_DROPOUT} HL_BEAM_SIZE=${BEAM_SIZE} HL_USE_MANUAL_COST_MODEL=${m} make build 2>&1 | grep -v Nothing.to.be.done"
                 done
@@ -51,13 +51,13 @@ for ((b=1;b<2;b++)); do
 
         F=bin/host/pipeline_${P}_${STAGES}/schedule_0_${RANDOM_DROPOUT}_${BEAM_SIZE}_0/times.txt
         if [ ! -f $F ]; then HL_TARGET=host HL_SEED=0 PIPELINE_SEED=$P PIPELINE_STAGES=$STAGES HL_RANDOM_DROPOUT=${RANDOM_DROPOUT} HL_BEAM_SIZE=${BEAM_SIZE} HL_USE_MANUAL_COST_MODEL=0 HL_NUM_THREADS=32 make bench 2>&1 | grep -v "Nothing to be done"; fi
-        
+
         grep '^Time' $F > /dev/null && echo $F >> results/files_master_${b}.txt
         for prof in ""; do
             for ((m=0;m<2;m++)); do
                 for ((s=0;s<$SCHEDULES;s++)); do
                     F=bin/host${prof}-new_autoscheduler/pipeline_${P}_${STAGES}/schedule_${s}_${RANDOM_DROPOUT}_${BEAM_SIZE}_${m}/times.txt
-                    if [ ! -f $F ]; then PLUGIN="-p bin/auto_schedule.so" HL_TARGET=host${prof} HL_SEED=$s PIPELINE_SEED=$P PIPELINE_STAGES=$STAGES HL_RANDOM_DROPOUT=${RANDOM_DROPOUT} HL_BEAM_SIZE=${BEAM_SIZE} HL_USE_MANUAL_COST_MODEL=${m} HL_NUM_THREADS=32 make bench 2>&1 | grep -v "Nothing to be done"; fi
+                    if [ ! -f $F ]; then PLUGIN="-p bin/libauto_schedule.so" HL_TARGET=host${prof} HL_SEED=$s PIPELINE_SEED=$P PIPELINE_STAGES=$STAGES HL_RANDOM_DROPOUT=${RANDOM_DROPOUT} HL_BEAM_SIZE=${BEAM_SIZE} HL_USE_MANUAL_COST_MODEL=${m} HL_NUM_THREADS=32 make bench 2>&1 | grep -v "Nothing to be done"; fi
 
                     grep '^Time' $F > /dev/null && echo $F >> results/files_${b}_${m}${prof}.txt
                 done
@@ -67,11 +67,11 @@ for ((b=1;b<2;b++)); do
 
     # Generate the success cases by taking the intersection of the results from the learned model and the manual model
     cat results/files_${b}_0.txt results/files_${b}_1.txt | sed "s/_..times.txt/_X\/times.txt/" | sort | uniq -d > results/files_common.txt
-    
+
     # Extract the runtimes
     echo "Extracting runtimes..."
     cat results/files_common.txt | sed "s/_X/_0/" | while read F; do grep '^Time' $F | cut -d: -f2 | cut -b2-; done > results/learned_runtimes_${b}.txt
-    cat results/files_common.txt | sed "s/_X/_1/" | while read F; do grep '^Time' $F | cut -d: -f2 | cut -b2-; done > results/manual_runtimes_${b}.txt    
+    cat results/files_common.txt | sed "s/_X/_1/" | while read F; do grep '^Time' $F | cut -d: -f2 | cut -b2-; done > results/manual_runtimes_${b}.txt
 
     # Extract the compute_root runtimes
     echo "Extracting compute_root runtimes..."
@@ -79,17 +79,17 @@ for ((b=1;b<2;b++)); do
 
     echo "Extracting master runtimes..."
     cat results/files_common.txt | sed "s/_X/_0/" | sed "s///" | while read F; do grep '^Time' $F | cut -d: -f2 | cut -b2-; done > results/master_runtimes_${b}.txt
-    
+
     # Extract the features
     echo "Extracting features..."
     cat results/files_common.txt | sed "s/_X/_0/" | while read F; do echo $(grep '^YYY' ${F/times/stderr} | cut -d' ' -f3-); done > results/features_${b}.txt
 
     # Extract failed proofs
     echo "Extracting any failed proofs..."
-    cat results/files_${b}_*.txt | while read F; do grep -A1 'Failed to prove' ${F/times/stderr}; done > results/failed_proofs_${b}.txt    
+    cat results/files_${b}_*.txt | while read F; do grep -A1 'Failed to prove' ${F/times/stderr}; done > results/failed_proofs_${b}.txt
 
     # Extract the cost according to the hand-designed model (just the sum of a few of the features)
     echo "Extracting costs..."
     cat results/files_common.txt | sed "s/_X/_0/" | while read F; do echo $(grep '^State with cost' ${F/times/stderr} | cut -d' ' -f4 | cut -d: -f1); done  > results/learned_costs_${b}.txt
-    cat results/files_common.txt | sed "s/_X/_1/" | while read F; do echo $(grep '^State with cost' ${F/times/stderr} | cut -d' ' -f4 | cut -d: -f1); done  > results/manual_costs_${b}.txt    
+    cat results/files_common.txt | sed "s/_X/_1/" | while read F; do echo $(grep '^State with cost' ${F/times/stderr} | cut -d' ' -f4 | cut -d: -f1); done  > results/manual_costs_${b}.txt
 done


### PR DESCRIPTION
For stupid reasons, it is much easier to build shared libs with names of the pattern libXYZ.so in google, because reasons. (I'm assuming no one else cares much about the specific name.)