### PR TITLE
Add error checking for the ifstream / ofstream calls in autoscheduler

### DIFF
--- a/apps/autoscheduler/AutoSchedule.cpp
+++ b/apps/autoscheduler/AutoSchedule.cpp
@@ -3375,6 +3375,7 @@ struct State {
             }
         }
         binfile.close();
+        internal_assert(!binfile.fail()) << "Failed to write " << feature_file;
     }
 
     bool calculate_cost(const FunctionDAG &dag, const MachineParams &params, ThroughputPredictorPipeline *throughput_predictor, bool verbose = false) {
@@ -4295,11 +4296,12 @@ std::string generate_schedules_new(const std::vector<Function> &outputs,
     string schedule_file = get_env_variable("HL_SCHEDULE_FILE");
     if (!schedule_file.empty()) {
         debug(0) << "Writing schedule to " << schedule_file << "...\n";
-        std::ofstream f(schedule_file, std::ios_base::trunc);
+        std::ofstream f(schedule_file);
         f << "// --- BEGIN machine-generated schedule\n"
           << optimal->schedule_source
           << "// --- END machine-generated schedule\n";
         f.close();
+        internal_assert(!f.fail()) << "Failed to write " << schedule_file;
     }
 
     // Print out the predicted runtime of each Func, so we can compare them to a profile

--- a/apps/autoscheduler/ThroughputPredictorPipeline.h
+++ b/apps/autoscheduler/ThroughputPredictorPipeline.h
@@ -42,15 +42,21 @@ Runtime::Buffer<float> buffer_from_file(const std::string &filename, const std::
     Runtime::Buffer<float> buf(shape);
     buf.fill(0.0f);
 
-    std::ifstream i(filename.c_str());
+    std::ifstream i(filename, std::ios_base::trunc | std::ios_base::binary);
     i.read((char *)(buf.data()), buf.size_in_bytes());
+    i.close();
+    // TODO: some existing weights are the wrong size (e.g. weights/head2_conv1_weight.data is currently
+    // 2496 bytes on disk but we request 2880 bytes here).
+    // assert(!i.fail());
 
     return buf;
 }
 
 void buffer_to_file(const Runtime::Buffer<float> &buf, const std::string &filename) {
-    std::ofstream o(filename.c_str());
+    std::ofstream o(filename, std::ios_base::trunc | std::ios_base::binary);
     o.write((const char *)(buf.data()), buf.size_in_bytes());
+    o.close();
+    assert(!o.fail());
 }
 
 struct Stats {

--- a/apps/autoscheduler/train_cost_model.cpp
+++ b/apps/autoscheduler/train_cost_model.cpp
@@ -73,6 +73,7 @@ map<int, PipelineSample> load_samples() {
         const size_t num_features = floats_read - 3;
         const size_t features_per_stage = 30 + 57 * 7;
         file.close();
+        assert(!file.fail());
 
         if (floats_read == scratch.size()) {
             std::cout << "Too-large sample: " << s << " " << floats_read << "\n";
@@ -215,6 +216,7 @@ map<int, PipelineSample> load_samples() {
             std::ofstream f(e, std::ios_base::trunc);
             f << o.str();
             f.close();
+            assert(!f.fail());
         }
     }
 


### PR DESCRIPTION
(Note that buffer_from_file() in TPP.h is commented out, as some of the weights/ files are the wrong size. Not sure of the right fix there; we should uncomment once the file is fixed.)