### PR TITLE
Rework RunGen registration model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1491,7 +1491,7 @@ $(FILTERS_DIR)/%.rungen: $(BUILD_DIR)/RunGenMain.o $(BIN_DIR)/$(TARGET)/runtime.
 		$(BUILD_DIR)/RunGenMain.o \
 		$(BIN_DIR)/$(TARGET)/runtime.a \
 		$(call alwayslink,$(FILTERS_DIR)/$*.rungenstubs.o) \
-		$(FILTERS_DIR)/%.a \
+		$(FILTERS_DIR)/$*.a \
 		$(GEN_AOT_LD_FLAGS) $(IMAGE_IO_LIBS) -o $@
 
 RUNARGS ?=

--- a/Makefile
+++ b/Makefile
@@ -1490,8 +1490,8 @@ $(FILTERS_DIR)/%.rungen: $(BUILD_DIR)/RunGenMain.o $(BIN_DIR)/$(TARGET)/runtime.
 	$(CXX) -std=c++11 -I$(FILTERS_DIR) \
 		$(BUILD_DIR)/RunGenMain.o \
 		$(BIN_DIR)/$(TARGET)/runtime.a \
-		$(FILTERS_DIR)/%.a \
 		$(call alwayslink,$(FILTERS_DIR)/$*.rungenstubs.o) \
+		$(FILTERS_DIR)/%.a \
 		$(GEN_AOT_LD_FLAGS) $(IMAGE_IO_LIBS) -o $@
 
 RUNARGS ?=
@@ -1509,12 +1509,12 @@ $(FILTERS_DIR)/multi_rungen: $(BUILD_DIR)/RunGenMain.o $(BIN_DIR)/$(TARGET)/runt
 	$(CXX) -std=c++11 -I$(FILTERS_DIR) \
 			$(BUILD_DIR)/RunGenMain.o \
 			$(BIN_DIR)/$(TARGET)/runtime.a \
-			$(FILTERS_DIR)/blur2x2.a \
-			$(FILTERS_DIR)/cxx_mangling.a \
-			$(FILTERS_DIR)/pyramid.a \
 			$(call alwayslink,$(FILTERS_DIR)/blur2x2.rungenstubs.o) \
 			$(call alwayslink,$(FILTERS_DIR)/cxx_mangling.rungenstubs.o) \
 			$(call alwayslink,$(FILTERS_DIR)/pyramid.rungenstubs.o) \
+			$(FILTERS_DIR)/blur2x2.a \
+			$(FILTERS_DIR)/cxx_mangling.a \
+			$(FILTERS_DIR)/pyramid.a \
 			$(GEN_AOT_LD_FLAGS) $(IMAGE_IO_LIBS) -o $@
 
 $(BIN_DIR)/tutorial_%: $(ROOT_DIR)/tutorial/%.cpp $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR)/Halide.h

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -114,8 +114,8 @@ $(BIN)/%.rungen: $(BIN)/RunGenMain.o $(BIN)/%.a $(BIN)/%.rungenstubs.o
 	$(CXX) $(CXXFLAGS) -I$(BIN) \
 		-DHL_RUNGEN_FILTER_HEADER=\"$*.h\" \
 		$(BIN)/RunGenMain.o \
-		$(BIN)/$*.a \
 		$(call alwayslink,$(BIN)/$*.rungenstubs.o) \
+		$(BIN)/$*.a \
 		-o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
 
 RUNARGS ?=

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -90,14 +90,33 @@ ifneq (, $(findstring metal,$(HL_TARGET)))
   LDFLAGS += -framework Metal -framework Foundation
 endif
 
+ifeq ($(UNAME), Darwin)
+define alwayslink
+    -Wl,-force_load,$(1)
+endef
+else
+define alwayslink
+    -Wl,--whole-archive $(1) -Wl,-no-whole-archive
+endef
+endif
+
 $(BIN)/RunGenMain.o: $(HALIDE_DISTRIB_PATH)/tools/RunGenMain.cpp $(HALIDE_DISTRIB_PATH)/tools/RunGen.h
 	@mkdir -p $(@D)
 	@$(CXX) -c $< $(CXXFLAGS) $(IMAGE_IO_CXX_FLAGS) -I$(BIN) -o $@
 
+$(BIN)/%.rungenstubs.o: $(HALIDE_DISTRIB_PATH)/tools/RunGenStubs.cpp $(BIN)/%.a
+	@mkdir -p $(@D)
+	$(CXX) -c $< $(CXXFLAGS) -DHL_RUNGEN_FILTER_HEADER=\"$*.h\" -I$(BIN) -o $@
+
 # Really, .SECONDARY is what we want, but it won't accept wildcards
 .PRECIOUS: $(BIN)/%.rungen
-$(BIN)/%.rungen: $(BIN)/%.a $(BIN)/RunGenMain.o $(HALIDE_DISTRIB_PATH)/tools/RunGenStubs.cpp
-	$(CXX) $(CXXFLAGS) -I$(BIN) -DHL_RUNGEN_FILTER_HEADER=\"$*.h\" $^ -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
+$(BIN)/%.rungen: $(BIN)/RunGenMain.o $(BIN)/%.a $(BIN)/%.rungenstubs.o
+	$(CXX) $(CXXFLAGS) -I$(BIN) \
+		-DHL_RUNGEN_FILTER_HEADER=\"$*.h\" \
+		$(BIN)/RunGenMain.o \
+		$(BIN)/$*.a \
+		$(call alwayslink,$(BIN)/$*.rungenstubs.o) \
+		-o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
 
 RUNARGS ?=
 

--- a/tools/RunGen.h
+++ b/tools/RunGen.h
@@ -784,8 +784,8 @@ struct ArgData {
 class RunGen {
 public:
     RunGen(int (*halide_argv_call)(void **args),
-               const struct halide_filter_metadata_t *(*halide_metadata_call)()) :
-        halide_argv_call(halide_argv_call), md(halide_metadata_call()) {
+               const struct halide_filter_metadata_t *halide_metadata) :
+        halide_argv_call(halide_argv_call), md(halide_metadata) {
         if (md->version != halide_filter_metadata_t::VERSION) {
             fail() << "Unexpected metadata version " << md->version;
         }

--- a/tools/RunGenStubs.cpp
+++ b/tools/RunGenStubs.cpp
@@ -1,13 +1,36 @@
-#define HALIDE_GET_STANDARD_ARGV_FUNCTION halide_rungen_redirect_argv_getter
-#define HALIDE_GET_STANDARD_METADATA_FUNCTION halide_rungen_redirect_metadata_getter
+#define HALIDE_REGISTER_ARGV_AND_METADATA halide_rungen_register_argv_and_metadata
 
-// This is legal C, as long as the macro expands to a single quoted (or <>-enclosed) string literal
+extern "C" void halide_rungen_register_filter(
+    int (*filter_argv_call)(void **),
+    const struct halide_filter_metadata_t *filter_metadata,
+    void* registerer);
+
+// This is legal C, as long as the macro expands to a
+// single quoted (or <>-enclosed) string literal
 #include HL_RUNGEN_FILTER_HEADER
 
-extern "C" int halide_rungen_redirect_argv(void **args) {
-    return halide_rungen_redirect_argv_getter()(args);
-}
+/*
+    This relies on the filter library being linked in a way that doesn't
+    dead-strip "unused" initialization code; this may mean that you need to
+    explicitly link with with --whole-archive (or the equivalent) to ensure
+    that the registration code isn't omitted. Sadly, there's no portable way
+    to do this, so you may need to take care in your make/build/etc files:
 
-extern "C" const struct halide_filter_metadata_t *halide_rungen_redirect_metadata() {
-    return halide_rungen_redirect_metadata_getter()();
-}
+    Linux:      -Wl,--whole-archive "/path/to/library" -Wl,-no-whole-archive
+    Darwin/OSX: -Wl,-force_load,/path/to/library
+    VS2015 R2+: /WHOLEARCHIVE:/path/to/library.lib
+    Bazel:      alwayslink=1
+*/
+
+namespace {
+
+struct Registerer {
+    Registerer() {
+        halide_rungen_register_argv_and_metadata();
+    }
+};
+
+static Registerer registerer;
+
+}  // namespace
+


### PR DESCRIPTION
Expand to allow for multiple filters to link against RunGen at once, selecting via a flag; this is of limited use for routine purposes, but should give us greater flexibility when experimenting with multiple auto-scheduler models.