### PR TITLE
Fix HalideTraceViz on windows.

### DIFF
--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -12,6 +12,7 @@
 
 #ifdef _MSC_VER
 #include <io.h>
+#include <fcntl.h>
 #ifndef STDIN_FILENO
 #define STDIN_FILENO 0
 #endif
@@ -1410,6 +1411,11 @@ int main(int argc, char **argv) {
     FlagProcessor flag_processor = [argc, argv](VizState *state) -> void {
         process_args(argc, argv, state);
     };
+
+#ifdef _MSC_VER
+	_setmode(STDIN_FILENO, _O_BINARY);
+    _setmode(STDOUT_FILENO, _O_BINARY);
+#endif
 
     run(ignore_trace_tags, flag_processor);
 }

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -1413,7 +1413,7 @@ int main(int argc, char **argv) {
     };
 
 #ifdef _MSC_VER
-	_setmode(STDIN_FILENO, _O_BINARY);
+    _setmode(STDIN_FILENO, _O_BINARY);
     _setmode(STDOUT_FILENO, _O_BINARY);
 #endif
 


### PR DESCRIPTION
HalideTraceViz makes really trippy 80's style visualizations on windows.

![badviz](https://user-images.githubusercontent.com/1330470/50307472-c24bf580-0455-11e9-92be-2e326921b425.gif)

This is due to windows by default treating stdin/out as text files, switching them to binary fixes the issue.

![goodviz](https://user-images.githubusercontent.com/1330470/50307504-d8f24c80-0455-11e9-949c-a38ed55ab75b.gif)
