### PR TITLE
Reset unique name counters before the compilation of each target.

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -999,14 +999,15 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
             Outputs output_files = compute_outputs(targets[0], base_path, emit_options);
             auto module_producer = [&generator_name, &generator_args]
                 (const std::string &name, const Target &target) -> Module {
+                    // Reset the counters so the function/variable names look
+                    // more consistent for different targets.
+                    reset_unique_name_counters();
+
                     auto sub_generator_args = generator_args;
                     sub_generator_args.erase("target");
                     // Must re-create each time since each instance will have a different Target.
                     auto gen = GeneratorRegistry::create(generator_name, GeneratorContext(target));
                     gen->set_generator_param_values(sub_generator_args);
-                    // Reset the counters so the function/variable names look
-                    // more consistent for different targets.
-                    reset_unique_name_counters();
                     return gen->build_module(name);
                 };
             if (targets.size() > 1 || !emit_options.substitutions.empty()) {

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1004,6 +1004,9 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
                     // Must re-create each time since each instance will have a different Target.
                     auto gen = GeneratorRegistry::create(generator_name, GeneratorContext(target));
                     gen->set_generator_param_values(sub_generator_args);
+                    // Reset the counters so the function/variable names look
+                    // more consistent for different targets.
+                    reset_unique_name_counters();
                     return gen->build_module(name);
                 };
             if (targets.size() > 1 || !emit_options.substitutions.empty()) {

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1000,7 +1000,7 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
             auto module_producer = [&generator_name, &generator_args]
                 (const std::string &name, const Target &target) -> Module {
                     // Reset the counters so the function/variable names look
-                    // more consistent for different targets.
+                    // consistent for different targets.
                     reset_unique_name_counters();
 
                     auto sub_generator_args = generator_args;

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -317,7 +317,8 @@ std::string halide_type_to_c_type(const Type &t);
 
 /** generate_filter_main() is a convenient wrapper for GeneratorRegistry::create() +
  * compile_to_files(); it can be trivially wrapped by a "real" main() to produce a
- * command-line utility for ahead-of-time filter compilation. */
+ * command-line utility for ahead-of-time filter compilation.
+ * Note that this function is not thread-safe because it resets global states.*/
 int generate_filter_main(int argc, char **argv, std::ostream &cerr);
 
 // select_type<> is to std::conditional as switch is to if:

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -116,6 +116,11 @@ int unique_count(size_t h) {
 }
 }  // namespace
 
+void reset_unique_name_counters() {
+  for (int i = 0; i < num_unique_name_counters; ++i)
+    unique_name_counters[i].store(0);
+}
+
 // There are three possible families of names returned by the methods below:
 // 1) char pattern: (char that isn't '$') + number (e.g. v234)
 // 2) string pattern: (string without '$') + '$' + number (e.g. fr#nk82$42)

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -102,16 +102,12 @@ namespace {
 // hash collisions. This wouldn't break anything, but makes stmts
 // slightly confusing to read because names that are actually unique
 // will get suffixes that falsely hint that they are not.
-//
+const int num_unique_name_counters = (1 << 14);
+
 // Make it a thead_local variable to improve the thread-safety of
 // Generator.cpp in case each invocation of the generator wants to
 // reset the counters.
-thread_local const int num_unique_name_counters = (1 << 14);
-
-// We want to init these to zero, but cannot use = {0} because that
-// would invoke a (deleted) copy ctor; this syntax should force
-// the correct behavior.
-std::atomic<int> unique_name_counters[num_unique_name_counters] = {};
+thread_local int unique_name_counters[num_unique_name_counters] = {0};
 
 int unique_count(size_t h) {
     h = h & (num_unique_name_counters - 1);
@@ -121,7 +117,7 @@ int unique_count(size_t h) {
 
 void reset_unique_name_counters() {
   for (int i = 0; i < num_unique_name_counters; ++i)
-    unique_name_counters[i].store(0);
+    unique_name_counters[i] = 0;
 }
 
 // There are three possible families of names returned by the methods below:

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -102,8 +102,11 @@ namespace {
 // hash collisions. This wouldn't break anything, but makes stmts
 // slightly confusing to read because names that are actually unique
 // will get suffixes that falsely hint that they are not.
-
-const int num_unique_name_counters = (1 << 14);
+//
+// Make it a thead_local variable to improve the thread-safety of
+// Generator.cpp in case each invocation of the generator wants to
+// reset the counters.
+thread_local const int num_unique_name_counters = (1 << 14);
 
 // We want to init these to zero, but cannot use = {0} because that
 // would invoke a (deleted) copy ctor; this syntax should force

--- a/src/Util.h
+++ b/src/Util.h
@@ -135,6 +135,9 @@ std::string unique_name(char prefix);
 std::string unique_name(const std::string &prefix);
 // @}
 
+/** Reset the unique name counters to zeros. */
+void reset_unique_name_counters();
+
 /** Test if the first string starts with the second string */
 bool starts_with(const std::string &str, const std::string &prefix);
 


### PR DESCRIPTION
The PR makes the function/variable names look consistent during the compilation for different targets when using the multi-target AOT flow. It is for improving the debugging experience.