### PR TITLE
Store all the schedule features using an int64. This ensures that the…

### DIFF
--- a/apps/autoscheduler/Featurization.h
+++ b/apps/autoscheduler/Featurization.h
@@ -161,7 +161,7 @@ struct ScheduleFeatures {
 
     int64_t vector_size = 0; // The vectorization factor (#simd lanes) to be used to compute this stage. Wasted work if it's smaller than the stage's native vector size (which is in the pipeline features).
 
-    int native_vector_size = 0; // The native vector size for the narrowest type used.
+    int64_t native_vector_size = 0; // The native vector size for the narrowest type used.
 
     int64_t num_vectors = 0; // Number of vectors computed (Assuming sliding worked)
     int64_t num_scalars = 0; // Number of scalars computed (e.g. from tails of loops)


### PR DESCRIPTION
… number of features can still be correctly computed by dividing sizeof(ScheduleFeatures) by sizeof(int64).