### PR TITLE
Added a constructor for the pipeline feature class. I…

### DIFF
--- a/apps/autoscheduler/Featurization.h
+++ b/apps/autoscheduler/Featurization.h
@@ -132,10 +132,6 @@ struct PipelineFeatures {
 
 // The schedule-dependent portion of the featurization of a stage
 struct ScheduleFeatures {
-    ScheduleFeatures() {
-        std::memset(this, 0, sizeof(ScheduleFeatures));
-    }
-
     int64_t num_realizations = 0; // Product of outer loops at store_at site
     int64_t num_productions = 0;  // Product of outer loops at compute_at site
     int64_t points_computed_per_realization = 0; // Number of times the innermost stmt happens per store_at

--- a/apps/autoscheduler/Featurization.h
+++ b/apps/autoscheduler/Featurization.h
@@ -3,11 +3,16 @@
 
 #include <stdint.h>
 #include <iostream>
+#include <cstring>
 
 namespace Halide {
 namespace Internal {
 
 struct PipelineFeatures {
+    PipelineFeatures() {
+        std::memset(this, 0, sizeof(PipelineFeatures));
+    }
+
     // A featurization of the compute done by a Func, to
     // feed the neural network.
 
@@ -127,6 +132,10 @@ struct PipelineFeatures {
 
 // The schedule-dependent portion of the featurization of a stage
 struct ScheduleFeatures {
+    ScheduleFeatures() {
+        std::memset(this, 0, sizeof(ScheduleFeatures));
+    }
+
     int64_t num_realizations = 0; // Product of outer loops at store_at site
     int64_t num_productions = 0;  // Product of outer loops at compute_at site
     int64_t points_computed_per_realization = 0; // Number of times the innermost stmt happens per store_at


### PR DESCRIPTION
…'m getting some NaN when training a cost model for a long time. It's not clear yet if the NaNs come from the inputs or from the network itself, so I'm just making sure that the inputs are always initialized to rule this out.