### PR TITLE
Various minor fixes

### DIFF
--- a/apps/autoscheduler/AutoSchedule.cpp
+++ b/apps/autoscheduler/AutoSchedule.cpp
@@ -14,6 +14,7 @@
     HL_SEED
     HL_USE_MANUAL_COST_MODEL
     HL_WEIGHTS_DIR
+    HL_WEIGHTS_OUT_DIR
 
 */
 #include <set>
@@ -2647,7 +2648,11 @@ std::string generate_schedules_new(const std::vector<Function> &outputs,
         time_limit = atof(time_limit_str.c_str());
     }
 
-    string weights_dir = get_env_variable("HL_WEIGHTS_DIR");
+    string weights_in_dir = get_env_variable("HL_WEIGHTS_DIR");
+    string weights_out_dir = get_env_variable("HL_WEIGHTS_OUT_DIR");
+    if (weights_out_dir.empty()) {
+        weights_out_dir = weights_in_dir;
+    }
 
     string randomize_weights_str = get_env_variable("HL_RANDOMIZE_WEIGHTS");
     bool randomize_weights = randomize_weights_str == "1";
@@ -2672,7 +2677,7 @@ std::string generate_schedules_new(const std::vector<Function> &outputs,
 
     std::unique_ptr<CostModel> cost_model;
     if (get_env_variable("HL_USE_MANUAL_COST_MODEL") != "1") {
-        cost_model = CostModel::make_default(weights_dir, randomize_weights, weights_server_hostname, weights_server_port, weights_server_experiment_id);
+        cost_model = CostModel::make_default(weights_in_dir, weights_out_dir, randomize_weights, weights_server_hostname, weights_server_port, weights_server_experiment_id);
     }
 
     IntrusivePtr<State> optimal;

--- a/apps/autoscheduler/CostModel.h
+++ b/apps/autoscheduler/CostModel.h
@@ -13,7 +13,8 @@ public:
     virtual float backprop(const Halide::Runtime::Buffer<const float> &true_runtimes, float learning_rate) = 0;
     virtual void save_weights() = 0;
 
-    static std::unique_ptr<CostModel> make_default(const std::string &weights_dir = "",
+    static std::unique_ptr<CostModel> make_default(const std::string &weights_in_dir = "",
+                                                   const std::string &weights_out_dir = "",
                                                    bool randomize_weights = false,
                                                    const std::string &weights_server_hostname = "",
                                                    int weights_server_port = 0,

--- a/apps/autoscheduler/DefaultCostModel.cpp
+++ b/apps/autoscheduler/DefaultCostModel.cpp
@@ -82,20 +82,22 @@ class DefaultCostModel : public CostModel {
     Runtime::Buffer<double *> cost_ptrs;
     int cursor, num_stages, num_cores;
 
-    std::string weights_dir;
-    bool randomize_weights;
-    std::string weights_server_hostname;
-    int weights_server_port;
-    int weights_server_experiment_id;
+    const std::string weights_in_dir, weights_out_dir;
+    const bool randomize_weights;
+    const std::string weights_server_hostname;
+    const int weights_server_port;
+    const int weights_server_experiment_id;
 
  public:
 
-    DefaultCostModel(const std::string &weights_dir,
+    DefaultCostModel(const std::string &weights_in_dir,
+                     const std::string &weights_out_dir,
                      bool randomize_weights,
                      const std::string &weights_server_hostname,
                      int weights_server_port,
                      int weights_server_experiment_id) :
-        weights_dir(weights_dir),
+        weights_in_dir(weights_in_dir),
+        weights_out_dir(weights_out_dir),
         randomize_weights(randomize_weights),
         weights_server_hostname(weights_server_hostname),
         weights_server_port(weights_server_port),
@@ -198,7 +200,7 @@ class DefaultCostModel : public CostModel {
                 fastest_idx = i;
             }
         }
-        
+
         train_cost_model(num_stages,
                          cursor,
                          num_cores,
@@ -302,9 +304,9 @@ class DefaultCostModel : public CostModel {
 
     void load_weights() {
 
-        assert(!weights_dir.empty());
+        assert(!weights_in_dir.empty());
 
-        if (weights_dir.empty()) {
+        if (weights_in_dir.empty()) {
             weights.head1_filter = Runtime::Buffer<float>(weights_head1_conv1_weight, head1_channels, head1_w, head1_h);
             assert(weights_head1_conv1_weight_length == (int)weights.head1_filter.size_in_bytes());
 
@@ -323,14 +325,14 @@ class DefaultCostModel : public CostModel {
             weights.conv1_bias = Runtime::Buffer<float>(weights_trunk_conv1_bias, conv1_channels);
             assert(weights_trunk_conv1_bias_length == (int)weights.conv1_bias.size_in_bytes());
         } else {
-            weights.head1_filter = buffer_from_file(weights_dir + "/head1_conv1_weight.data", {head1_channels, head1_w, head1_h});
-            weights.head1_bias = buffer_from_file(weights_dir + "/head1_conv1_bias.data", {head1_channels});
+            weights.head1_filter = buffer_from_file(weights_in_dir + "/head1_conv1_weight.data", {head1_channels, head1_w, head1_h});
+            weights.head1_bias = buffer_from_file(weights_in_dir + "/head1_conv1_bias.data", {head1_channels});
 
-            weights.head2_filter = buffer_from_file(weights_dir + "/head2_conv1_weight.data", {head2_channels, head2_w});
-            weights.head2_bias = buffer_from_file(weights_dir + "/head2_conv1_bias.data", {head2_channels});
+            weights.head2_filter = buffer_from_file(weights_in_dir + "/head2_conv1_weight.data", {head2_channels, head2_w});
+            weights.head2_bias = buffer_from_file(weights_in_dir + "/head2_conv1_bias.data", {head2_channels});
 
-            weights.conv1_filter = buffer_from_file(weights_dir + "/trunk_conv1_weight.data", {conv1_channels, head1_channels + head2_channels});
-            weights.conv1_bias = buffer_from_file(weights_dir + "/trunk_conv1_bias.data", {conv1_channels});
+            weights.conv1_filter = buffer_from_file(weights_in_dir + "/trunk_conv1_weight.data", {conv1_channels, head1_channels + head2_channels});
+            weights.conv1_bias = buffer_from_file(weights_in_dir + "/trunk_conv1_bias.data", {conv1_channels});
         }
 
         if (randomize_weights) {
@@ -346,14 +348,14 @@ class DefaultCostModel : public CostModel {
     }
 
     void save_weights() {
-        if (weights_dir.empty()) return;
+        if (weights_out_dir.empty()) return;
 
-        buffer_to_file(weights.head1_filter, weights_dir + "/head1_conv1_weight.data");
-        buffer_to_file(weights.head1_bias, weights_dir + "/head1_conv1_bias.data");
-        buffer_to_file(weights.head2_filter, weights_dir + "/head2_conv1_weight.data");
-        buffer_to_file(weights.head2_bias, weights_dir + "/head2_conv1_bias.data");
-        buffer_to_file(weights.conv1_filter, weights_dir + "/trunk_conv1_weight.data");
-        buffer_to_file(weights.conv1_bias, weights_dir + "/trunk_conv1_bias.data");
+        buffer_to_file(weights.head1_filter, weights_out_dir + "/head1_conv1_weight.data");
+        buffer_to_file(weights.head1_bias, weights_out_dir + "/head1_conv1_bias.data");
+        buffer_to_file(weights.head2_filter, weights_out_dir + "/head2_conv1_weight.data");
+        buffer_to_file(weights.head2_bias, weights_out_dir + "/head2_conv1_bias.data");
+        buffer_to_file(weights.conv1_filter, weights_out_dir + "/trunk_conv1_weight.data");
+        buffer_to_file(weights.conv1_bias, weights_out_dir + "/trunk_conv1_bias.data");
     }
 
 
@@ -492,10 +494,11 @@ class DefaultCostModel : public CostModel {
 
 
 
-std::unique_ptr<CostModel> CostModel::make_default(const std::string &weights_dir,
+std::unique_ptr<CostModel> CostModel::make_default(const std::string &weights_in_dir,
+                                                   const std::string &weights_out_dir,
                                                    bool randomize_weights,
                                                    const std::string &weights_server_hostname,
                                                    int weights_server_port,
                                                    int weights_server_experiment_id) {
-    return std::unique_ptr<CostModel>(new DefaultCostModel(weights_dir, randomize_weights, weights_server_hostname, weights_server_port, weights_server_experiment_id));
+    return std::unique_ptr<CostModel>(new DefaultCostModel(weights_in_dir, weights_out_dir, randomize_weights, weights_server_hostname, weights_server_port, weights_server_experiment_id));
 }

--- a/apps/autoscheduler/augment_sample.cpp
+++ b/apps/autoscheduler/augment_sample.cpp
@@ -8,6 +8,10 @@ int main(int argc, char **argv) {
     }
 
     FILE *f = fopen(argv[1], "ab");
+    if (!f) {
+      fprintf(stderr, "Unable to open file: %s\n", argv[1]);
+      return -1;
+    }
 
     float r = atof(argv[2]) * 1000;
     int pid = atoi(argv[3]);

--- a/apps/autoscheduler/train_cost_model.cpp
+++ b/apps/autoscheduler/train_cost_model.cpp
@@ -72,6 +72,9 @@ map<int, PipelineSample> load_samples() {
     while (!std::cin.eof()) {
         string s;
         std::cin >> s;
+        if (s.empty()) {
+            continue;
+        }
         if (!ends_with(s, ".sample")) {
             std::cout << "Skipping file: " << s << "\n";
             continue;
@@ -262,12 +265,16 @@ int main(int argc, char **argv) {
 
     string randomize_weights_str = getenv_safe("HL_RANDOMIZE_WEIGHTS");
     bool randomize_weights = randomize_weights_str == "1";
-    string weights_dir = getenv_safe("HL_WEIGHTS_DIR");
+    string weights_in_dir = getenv_safe("HL_WEIGHTS_DIR");
+    string weights_out_dir = getenv_safe("HL_WEIGHTS_OUT_DIR");
+    if (weights_out_dir.empty()) {
+        weights_out_dir = weights_in_dir;
+    }
 
     // Iterate through the pipelines
     vector<std::unique_ptr<CostModel>> tpp;
     for (int i = 0; i < models; i++) {
-        tpp.emplace_back(CostModel::make_default(weights_dir, randomize_weights));
+        tpp.emplace_back(CostModel::make_default(weights_in_dir, weights_out_dir, randomize_weights));
     }
 
     int num_cores = atoi(getenv_safe("HL_NUM_THREADS").c_str());


### PR DESCRIPTION
- augment_sample: don't crash if file can't be opened for writing
- train_cost_model: quietly ignore empty inputs
- various: allow for optionally having a different directory for saving updated weights via the HL_WEIGHTS_OUT_DIR. (If omitted, assume out = in as is current).