### PR TITLE
Add code formatting and other cleanups. [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Halide
+
 Halide is a programming language designed to make it easier to write
 high-performance image processing code on modern machines. Halide
 currently targets:
@@ -35,17 +37,17 @@ Building Halide
 
 #### TL;DR
 
-Have llvm-6.0 or greater installed and run 'make' in the root
+Have llvm-6.0 or greater installed and run `make` in the root
 directory of the repository (where this README is).
 
 #### Acquiring LLVM
 
-Building halide requires at least llvm 6.0, along with the matching
-version of clang. llvm-config and clang must be somewhere in the
+Building Halide requires at least LLVM 6.0, along with the matching
+version of Clang. `llvm-config` and `clang` must be somewhere in the
 path. If your OS does not have packages for llvm-6.0, you can find
 binaries for it at http://llvm.org/releases/download.html. Download an
 appropriate package and then either install it, or at least put the
-bin subdirectory in your path. (This works well on OS X and Ubuntu.)
+`bin` subdirectory in your path. (This works well on OS X and Ubuntu.)
 
 If you want to build it yourself, first check it out from subversion:
 
@@ -67,14 +69,14 @@ then to point Halide to it:
 
 #### Building Halide with make
 
-With LLVM_CONFIG and CLANG set (or llvm-config and clang in your
-path), you should be able to just run 'make' in the root directory of
-the Halide source tree. 'make run_tests' will run the JIT test suite,
-and 'make test_apps' will make sure all the apps compile and run (but
+With `LLVM_CONFIG` and `CLANG` set (or `llvm-config` and `clang` in your
+path), you should be able to just run `make` in the root directory of
+the Halide source tree. `make run_tests` will run the JIT test suite,
+and `make test_apps` will make sure all the apps compile and run (but
 won't check their output).
 
-There is no 'make install' yet. If you want to make an install
-package, run 'make distrib'.
+There is no `make install` yet. If you want to make an install
+package, run `make distrib`.
 
 #### Building Halide out-of-tree with make
 
@@ -95,15 +97,15 @@ If you wish to use cmake to build Halide, the build procedure is:
     % cmake -DLLVM_DIR=/path-to-llvm-build/lib/cmake/llvm -DCMAKE_BUILD_TYPE=Release /path/to/halide
     % make -j8
 
-LLVM_DIR should be the folder in the LLVM installation or build tree that contains LLVMConfig.cmake.
+`LLVM_DIR` should be the folder in the LLVM installation or build tree that contains `LLVMConfig.cmake`.
 
 #### Building Halide and LLVM on Windows
 
 Acquire MSVC 2015 Update 3 or newer. Earlier versions may work but are
 not part of our tests. MSBuild and cmake should also be in your
 path. The instructions below assume Halide is checked out under
-C:/Code/Halide, and llvm (and clang) is checked out under
-C:/Code/llvm.
+`C:\Code\Halide`, and LLVM and Clang are checked out under
+`C:\Code\llvm`.
 
     % mkdir C:\Code\llvm-build
     % cd C:\Code\llvm-build
@@ -113,11 +115,11 @@ For a 32-bit build use:
 
     % cmake -DCMAKE_INSTALL_PREFIX=../llvm-install -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_TARGETS_TO_BUILD=X86;ARM;NVPTX;AArch64;Mips;Hexagon -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_BUILD_32_BITS=ON -DCMAKE_BUILD_TYPE=Release ../llvm -G "Visual Studio 14"
 
-Then build it like so
+Then build it like so:
 
     % MSBuild.exe /m /t:Build /p:Configuration=Release .\INSTALL.vcxproj
 
-You can substitute "Debug" for "Release" in both commands if you want a debug build.
+You can substitute `Debug` for `Release` in both commands if you want a debug build.
 
 To configure and build Halide:
 
@@ -143,20 +145,20 @@ run, and what the output was.
 Some useful environment variables
 =================================
 
-HL_TARGET=... will set Halide's AOT compilation target.
+`HL_TARGET=...` will set Halide's AOT compilation target.
 
-HL_JIT_TARGET=... will set Halide's JIT compilation target.
+`HL_JIT_TARGET=...` will set Halide's JIT compilation target.
 
-HL_DEBUG_CODEGEN=1 will print out pseudocode for what Halide is
+`HL_DEBUG_CODEGEN=1` will print out pseudocode for what Halide is
 compiling. Higher numbers will print more detail.
 
-HL_NUM_THREADS=... specifies the size of the thread pool. This has no
+`HL_NUM_THREADS=...` specifies the size of the thread pool. This has no
 effect on OS X or iOS, where we just use grand central dispatch.
 
-HL_TRACE_FILE=... specifies a binary target file to dump tracing data
-into (ignored unless at least one `trace_` feature is enabled in HL_TARGET or
-HL_JIT_TARGET). The output can be parsed programmatically by starting from the
-code in utils/HalideTraceViz.cpp
+`HL_TRACE_FILE=...` specifies a binary target file to dump tracing data
+into (ignored unless at least one `trace_` feature is enabled in `HL_TARGET` or
+`HL_JIT_TARGET`). The output can be parsed programmatically by starting from the
+code in `utils/HalideTraceViz.cpp`.
 
 
 Using Halide on OSX
@@ -358,7 +360,7 @@ Go to https://developer.qualcomm.com/software/hexagon-dsp-sdk/tools
   1. Select the Hexagon Series 600 Software and download the 3.0 version for Linux.
   2. untar the installer
   3. Run the extracted installer to install the Hexagon SDK and Hexagon Tools, selecting
-  Installation of Hexagon SDK into /location/of/SDK/Hexagon\_SDK/3.0 and the Hexagon tools into /location/of/SDK/Hexagon\_Tools/8.0
+  Installation of Hexagon SDK into `/location/of/SDK/Hexagon_SDK/3.0` and the Hexagon tools into `/location/of/SDK/Hexagon_Tools/8.0`
   4. Set an environment variable to point to the SDK installation location
 
     export SDK_LOC=/location/of/SDK


### PR DESCRIPTION
Additional cleanups:

* added a top-level heading for the project name to make it stand out in
  the README
* fixed capitalization when referring to project names rather than their
  binary or directory names
* replaced / (forward slash) with \ (backward slash) for sample Windows
  paths, and put them in code formatting as well
* removed escaping of underscores since code formatting avoids Markdown
  interpretation