### PR TITLE
CodeGen_LLVM::embed_constant_expr should simplify non-const exprs (Issue #3538)

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -936,7 +936,10 @@ Constant* CodeGen_LLVM::embed_constant_expr(Expr e, llvm::Type *t) {
     }
 
     internal_assert(!e.type().is_handle()) << "Should never see Handle types here.";
-    internal_assert(is_const(e)) << "Should never see Handle types here.";
+    if (!is_const(e)) {
+        e = simplify(e);
+        internal_assert(is_const(e)) << "Should only see constant values for estimates.";
+    }
 
     llvm::Value *val = codegen(e);
     llvm::Constant *constant = dyn_cast<llvm::Constant>(val);


### PR DESCRIPTION
Any Expr that can be constant-folded should be at that point.

cc @ongjunjie