### PR TITLE
Add autotune targets to other apps/ that can use it

### DIFF
--- a/apps/autoscheduler/autotune_loop.sh
+++ b/apps/autoscheduler/autotune_loop.sh
@@ -134,6 +134,13 @@ benchmark_sample() {
 # Don't clobber existing samples
 FIRST=$(ls -d ${SAMPLES}/batch_* 2>/dev/null | sed -e "s|.*/batch_||" | sort -n | tail -n1)
 
+if [ $(uname -s) = "Darwin" ]; then
+    LOCAL_CORES=`sysctl -n hw.ncpu`
+else
+    LOCAL_CORES=`nproc`
+fi
+echo Local number of cores detected as ${LOCAL_CORES}
+
 for ((i=$((FIRST+1));i<1000000;i++)); do
     # Compile a batch of samples using the generator in parallel
     DIR=${SAMPLES}/batch_${i}
@@ -142,13 +149,26 @@ for ((i=$((FIRST+1));i<1000000;i++)); do
     mkdir -p ${DIR}/weights_used/
     cp ${WEIGHTS}/* ${DIR}/weights_used/
 
-    echo Compiling ${BATCH_SIZE} samples for batch_${i}...
-    for ((b=0;b<${BATCH_SIZE};b++)); do
-        S=$(printf "%d%02d" $i $b)
-        FNAME=$(printf "%s_batch_%02d_sample_%02d" ${PIPELINE} $i $b)
-        make_sample "${DIR}/${b}" $S $FNAME &
+    # Do parallel compilation in batches, so that machines with fewer than BATCH_SIZE cores
+    # don't get swamped and timeout unnecessarily
+    GROUP_SIZE=${LOCAL_CORES}
+    if [[ ${GROUP_SIZE} -gt ${BATCH_SIZE} ]]; then
+        GROUP_SIZE=${BATCH_SIZE}
+    fi
+
+    for ((GROUP=0;GROUP<${BATCH_SIZE};GROUP+=${GROUP_SIZE})); do
+        LIMIT=$((GROUP+GROUP_SIZE))
+        if [[ ${LIMIT} -gt ${BATCH_SIZE} ]]; then
+            LIMIT=${BATCH_SIZE}
+        fi
+        echo Compiling samples ${GROUP}..$((LIMIT-1)) for batch_${i}...
+        for ((b=${GROUP};b<${LIMIT};b++)); do
+            S=$(printf "%d%02d" $i $b)
+            FNAME=$(printf "%s_batch_%02d_sample_%02d" ${PIPELINE} $i $b)
+            make_sample "${DIR}/${b}" $S $FNAME &
+        done
+        wait
     done
-    wait
 
     # benchmark them serially using rungen
     for ((b=0;b<${BATCH_SIZE};b++)); do

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -61,3 +61,11 @@ $(BIN)/viz_auto.mp4: $(BIN)/filter_viz ../support/viz_auto.sh ../../bin/HalideTr
 
 viz_auto: $(BIN)/viz_auto.mp4
 	$(HL_VIDEOPLAYER) $^
+
+autotune: $(BIN)/bilateral_grid.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BIN)/train_cost_model $(AUTOSCHED_BIN)/libauto_schedule.so $(AUTOSCHED_SRC)/autotune_loop.sh
+	bash $(AUTOSCHED_SRC)/autotune_loop.sh \
+		$(BIN)/bilateral_grid.generator \
+		bilateral_grid \
+		x86-64-avx2 \
+		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_BIN)

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -56,3 +56,11 @@ $(BIN)/viz_auto.mp4: $(BIN)/viz/process ../support/viz_auto.sh ../../bin/HalideT
 
 viz_auto: $(BIN)/viz_auto.mp4
 	$(HL_VIDEOPLAYER) $^
+
+autotune: $(BIN)/camera_pipe.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BIN)/train_cost_model $(AUTOSCHED_BIN)/libauto_schedule.so $(AUTOSCHED_SRC)/autotune_loop.sh
+	bash $(AUTOSCHED_SRC)/autotune_loop.sh \
+		$(BIN)/camera_pipe.generator \
+		camera_pipe \
+		x86-64-avx2 \
+		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_BIN)

--- a/apps/conv_layer/Makefile
+++ b/apps/conv_layer/Makefile
@@ -34,3 +34,11 @@ clean:
 	rm -rf $(BIN)
 
 test: run
+
+autotune: $(BIN)/conv_layer.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BIN)/train_cost_model $(AUTOSCHED_BIN)/libauto_schedule.so $(AUTOSCHED_SRC)/autotune_loop.sh
+	bash $(AUTOSCHED_SRC)/autotune_loop.sh \
+		$(BIN)/conv_layer.generator \
+		conv_layer \
+		x86-64-avx2 \
+		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_BIN)

--- a/apps/interpolate_generator/Makefile
+++ b/apps/interpolate_generator/Makefile
@@ -30,4 +30,10 @@ clean:
 test: $(BIN)/filter
 	$(BIN)/filter ../images/rgba.png $(BIN)/out.png
 
-
+autotune: $(BIN)/interpolate.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BIN)/train_cost_model $(AUTOSCHED_BIN)/libauto_schedule.so $(AUTOSCHED_SRC)/autotune_loop.sh
+	bash $(AUTOSCHED_SRC)/autotune_loop.sh \
+		$(BIN)/interpolate.generator \
+		interpolate \
+		x86-64-avx2 \
+		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_BIN)

--- a/apps/interpolate_generator/interpolate_generator.cpp
+++ b/apps/interpolate_generator/interpolate_generator.cpp
@@ -142,7 +142,7 @@ public:
                   .dim(2).set_bounds_estimate(0, 4);
             output_.dim(0).set_bounds_estimate(0, 1536)
                   .dim(1).set_bounds_estimate(0, 2560)
-                  .dim(2).set_bounds_estimate(0, 4);
+                  .dim(2).set_bounds_estimate(0, 3);
         }
     }
 };

--- a/apps/interpolate_generator/interpolate_generator.cpp
+++ b/apps/interpolate_generator/interpolate_generator.cpp
@@ -75,7 +75,7 @@ public:
 
                 cpu_wrapper
                     .reorder(c, x, y)
-                    .bound(c, 0, 3)
+                    .bound(c, 0, 4)
                     .tile(x, y, xo, yo, xi, yi, input_.width()/4, input_.height()/4)
                     .vectorize(xi, 8);
 
@@ -122,7 +122,7 @@ public:
                 }
                 normalize
                     .reorder(c, x, y)
-                    .bound(c, 0, 3)
+                    .bound(c, 0, 4)
                     .unroll(c)
                     .tile(x, y, xi, yi, 2, 2)
                     .unroll(xi)
@@ -139,10 +139,10 @@ public:
         {
             input_.dim(0).set_bounds_estimate(0, 1536)
                   .dim(1).set_bounds_estimate(0, 2560)
-                  .dim(2).set_bounds_estimate(0, 3);
+                  .dim(2).set_bounds_estimate(0, 4);
             output_.dim(0).set_bounds_estimate(0, 1536)
                   .dim(1).set_bounds_estimate(0, 2560)
-                  .dim(2).set_bounds_estimate(0, 3);
+                  .dim(2).set_bounds_estimate(0, 4);
         }
     }
 };

--- a/apps/lens_blur/Makefile
+++ b/apps/lens_blur/Makefile
@@ -34,3 +34,11 @@ clean:
 	rm -rf $(BIN)
 
 test: $(BIN)/out.png
+
+autotune: $(BIN)/lens_blur.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BIN)/train_cost_model $(AUTOSCHED_BIN)/libauto_schedule.so $(AUTOSCHED_SRC)/autotune_loop.sh
+	bash $(AUTOSCHED_SRC)/autotune_loop.sh \
+		$(BIN)/lens_blur.generator \
+		lens_blur \
+		x86-64-avx2 \
+		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_BIN)

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -64,3 +64,11 @@ $(BIN)/viz_auto.mp4: $(BIN)/process_viz ../support/viz_auto.sh ../../bin/HalideT
 
 viz_auto: $(BIN)/viz_auto.mp4
 	$(HL_VIDEOPLAYER) $^
+
+autotune: $(BIN)/local_laplacian.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BIN)/train_cost_model $(AUTOSCHED_BIN)/libauto_schedule.so $(AUTOSCHED_SRC)/autotune_loop.sh
+	bash $(AUTOSCHED_SRC)/autotune_loop.sh \
+		$(BIN)/local_laplacian.generator \
+		local_laplacian \
+		x86-64-avx2 \
+		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_BIN)

--- a/apps/mat_mul_generator/Makefile
+++ b/apps/mat_mul_generator/Makefile
@@ -30,4 +30,10 @@ clean:
 test: $(BIN)/filter
 	$(BIN)/filter
 
-
+autotune: $(BIN)/mat_mul.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BIN)/train_cost_model $(AUTOSCHED_BIN)/libauto_schedule.so $(AUTOSCHED_SRC)/autotune_loop.sh
+	bash $(AUTOSCHED_SRC)/autotune_loop.sh \
+		$(BIN)/mat_mul.generator \
+		mat_mul \
+		x86-64-avx2 \
+		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_BIN)

--- a/apps/max_filter/Makefile
+++ b/apps/max_filter/Makefile
@@ -30,4 +30,10 @@ clean:
 test: $(BIN)/filter
 	$(BIN)/filter ../images/rgb.png $(BIN)/out.tiff
 
-
+autotune: $(BIN)/max_filter.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BIN)/train_cost_model $(AUTOSCHED_BIN)/libauto_schedule.so $(AUTOSCHED_SRC)/autotune_loop.sh
+	bash $(AUTOSCHED_SRC)/autotune_loop.sh \
+		$(BIN)/max_filter.generator \
+		max_filter \
+		x86-64-avx2 \
+		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_BIN)

--- a/apps/nl_means/Makefile
+++ b/apps/nl_means/Makefile
@@ -34,3 +34,11 @@ clean:
 	rm -rf $(BIN)
 
 test: $(BIN)/out.png
+
+autotune: $(BIN)/nl_means.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BIN)/train_cost_model $(AUTOSCHED_BIN)/libauto_schedule.so $(AUTOSCHED_SRC)/autotune_loop.sh
+	bash $(AUTOSCHED_SRC)/autotune_loop.sh \
+		$(BIN)/nl_means.generator \
+		nl_means \
+		x86-64-avx2 \
+		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_BIN)

--- a/apps/stencil_chain/Makefile
+++ b/apps/stencil_chain/Makefile
@@ -34,3 +34,11 @@ clean:
 	rm -rf $(BIN)
 
 test: $(BIN)/out.png
+
+autotune: $(BIN)/stencil_chain.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BIN)/train_cost_model $(AUTOSCHED_BIN)/libauto_schedule.so $(AUTOSCHED_SRC)/autotune_loop.sh
+	bash $(AUTOSCHED_SRC)/autotune_loop.sh \
+		$(BIN)/stencil_chain.generator \
+		stencil_chain \
+		x86-64-avx2 \
+		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_BIN)

--- a/apps/unsharp/Makefile
+++ b/apps/unsharp/Makefile
@@ -31,3 +31,10 @@ test: $(BIN)/filter
 	$(BIN)/filter ../images/rgb.png $(BIN)/out.tiff
 
 
+autotune: $(BIN)/unsharp.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BIN)/train_cost_model $(AUTOSCHED_BIN)/libauto_schedule.so $(AUTOSCHED_SRC)/autotune_loop.sh
+	bash $(AUTOSCHED_SRC)/autotune_loop.sh \
+		$(BIN)/unsharp.generator \
+		unsharp \
+		x86-64-avx2 \
+		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_BIN)


### PR DESCRIPTION
NOTE: several of these reliably fail to compile within the 120-second timeout that is set by default, at least on my local machines:

- ~~interpolate_generator~~
- lens_blur
- local_laplacian
- ~~max_filter~~
- ~~stencil_chain~~

(However, those two local machines are a 12-core Linux box and a 4-core Macbook, so trying to build 32 at the same time is probably not helping. I may follow up with some tweakage to the autotune_loop.sh script to modify the number of parallel builds based on number of cores.)

UPDATE: with the tweaks just mentioned in place, now only two of them reliably time out for me; these are more complex pipelines so it might just be unavoidable for now.

I'm going to leave them in anyway (caveat emptor!) as they may be useful in helping profile speed issues in the autoscheduler.
