### PR TITLE
Track versions of the featurization.

### DIFF
--- a/apps/autoscheduler/AutoSchedule.h
+++ b/apps/autoscheduler/AutoSchedule.h
@@ -1,0 +1,17 @@
+#include "Halide.h"
+#include "CostModel.h"
+#include "FunctionDAG.h"
+#include "PerfectHashMap.h"
+
+namespace  Halide {
+namespace Internal {
+
+typedef PerfectHashMap<FunctionDAG::Node::Stage, ScheduleFeatures> StageMapOfScheduleFeatures;
+
+extern "C" {
+void find_and_apply_schedule(FunctionDAG& dag, const vector<Function> &outputs, const MachineParams &params,
+			     CostModel* cost_model, int beam_size, StageMapOfScheduleFeatures* schedule_features);
+}
+
+}
+}

--- a/apps/autoscheduler/Featurization.h
+++ b/apps/autoscheduler/Featurization.h
@@ -16,7 +16,9 @@ struct PipelineFeatures {
     static constexpr int num_features() {
         return sizeof(PipelineFeatures) / sizeof(int);
     }
-
+    static constexpr int version() {
+        return 1;
+    }
     // A featurization of the compute done by a Func, to
     // feed the neural network.
 
@@ -121,6 +123,9 @@ struct PipelineFeatures {
 struct ScheduleFeatures {
     static constexpr int num_features() {
         return sizeof(ScheduleFeatures) / sizeof(int64_t);
+    }
+    static constexpr int version() {
+        return 1;
     }
 
     int64_t num_realizations = 0; // Product of outer loops at store_at site


### PR DESCRIPTION
This helps manage the lifecycle of features extracted ahead of time, for example in order to build a training set for the cost model.