### PR TITLE
Handle NumPy's 'l' format in PyBuffer

### DIFF
--- a/python_bindings/correctness/buffer.py
+++ b/python_bindings/correctness/buffer.py
@@ -123,6 +123,11 @@ def test_float16():
     hl_img = hl.Buffer(array_in)
     array_out = np.array(hl_img, copy = False)
 
+def test_int64():
+    array_in = np.zeros((256, 256, 3), dtype=np.int64, order='F')
+    hl_img = hl.Buffer(array_in)
+    array_out = np.array(hl_img, copy = False)
+
 def test_make_interleaved():
     w = 7
     h = 13
@@ -227,5 +232,6 @@ if __name__ == "__main__":
     test_fill_all_equal()
     test_bufferinfo_sharing()
     test_float16()
+    test_int64()
     test_reorder()
 

--- a/python_bindings/src/PyBuffer.cpp
+++ b/python_bindings/src/PyBuffer.cpp
@@ -152,6 +152,12 @@ Type format_descriptor_to_type(const std::string &fd) {
 
     #undef HANDLE_BUFFER_TYPE
 
+    // The string 'l' corresponds to np.int_, which is essentially
+    // a C 'long'; return a 32 or 64 bit int as appropriate.
+    if (fd == "l") {
+      return sizeof(long) == 8 ? type_of<int64_t>() : type_of<int32_t>();
+    }
+
     throw py::value_error("Unsupported Buffer<> type.");
     return Type();
 }


### PR DESCRIPTION
Some versions of NumPy can pass 'l' (aka long) for int64 types; pybind11 doesn't handle this as an option, so add a special case to handle it.