### PR TITLE
Precompiled test headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -862,6 +862,7 @@ $(INCLUDE_DIR)/Halide.h: $(SRC_DIR)/../LICENSE.txt $(HEADERS) $(BIN_DIR)/build_h
 	# Also generate a precompiled version in the same folder so that anything compiled with a compatible set of flags can use it
 	@mkdir -p $(INCLUDE_DIR)/Halide.h.gch
 	$(CXX) -std=c++11 $(TEST_CXX_FLAGS) -I$(ROOT_DIR) $(OPTIMIZE) -x c++-header $(INCLUDE_DIR)/Halide.h -o $(INCLUDE_DIR)/Halide.h.gch/Halide.default.gch
+	$(CXX) -std=c++11 $(TEST_CXX_FLAGS) -I$(ROOT_DIR) $(OPTIMIZE_FOR_BUILD_TIME) -x c++-header $(INCLUDE_DIR)/Halide.h -o $(INCLUDE_DIR)/Halide.h.gch/Halide.test.gch
 
 $(INCLUDE_DIR)/HalideRuntime%: $(SRC_DIR)/runtime/HalideRuntime%
 	echo Copying $<
@@ -1126,12 +1127,8 @@ $(BIN_DIR)/test_internal: $(ROOT_DIR)/test/internal.cpp $(BIN_DIR)/libHalide.$(S
 	@mkdir -p $(@D)
 	$(CXX) $(TEST_CXX_FLAGS) $< -I$(SRC_DIR) $(TEST_LD_FLAGS) -o $@
 
-$(INCLUDE_DIR)/Halide.h.gch/Halide.correctness.gch: $(INCLUDE_DIR)/Halide.h
-	@mkdir -p $(@D)
-	$(CXX) -std=c++11 $(TEST_CXX_FLAGS) -I$(ROOT_DIR) $(OPTIMIZE_FOR_BUILD_TIME) -x c++-header $< -o $@
-
 # Correctness test that link against libHalide
-$(BIN_DIR)/correctness_%: $(ROOT_DIR)/test/correctness/%.cpp $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR)/Halide.h.gch/Halide.correctness.gch $(RUNTIME_EXPORTED_INCLUDES)
+$(BIN_DIR)/correctness_%: $(ROOT_DIR)/test/correctness/%.cpp $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR)/Halide.h $(RUNTIME_EXPORTED_INCLUDES)
 	@mkdir -p $(@D)
 	$(CXX) $(TEST_CXX_FLAGS) -I$(ROOT_DIR) $(OPTIMIZE_FOR_BUILD_TIME) $< -I$(INCLUDE_DIR) $(TEST_LD_FLAGS) -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -1133,7 +1133,7 @@ $(INCLUDE_DIR)/Halide.h.gch/Halide.correctness.gch: $(INCLUDE_DIR)/Halide.h
 # Correctness test that link against libHalide
 $(BIN_DIR)/correctness_%: $(ROOT_DIR)/test/correctness/%.cpp $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR)/Halide.h.gch/Halide.correctness.gch $(RUNTIME_EXPORTED_INCLUDES)
 	@mkdir -p $(@D)
-	$(CXX) $(TEST_CXX_FLAGS) -H -I$(ROOT_DIR) $(OPTIMIZE_FOR_BUILD_TIME) $< -I$(INCLUDE_DIR) $(TEST_LD_FLAGS) -o $@
+	$(CXX) $(TEST_CXX_FLAGS) -I$(ROOT_DIR) $(OPTIMIZE_FOR_BUILD_TIME) $< -I$(INCLUDE_DIR) $(TEST_LD_FLAGS) -o $@
 
 # Correctness tests that do NOT link against libHalide
 $(BIN_DIR)/correctness_plain_c_includes: $(ROOT_DIR)/test/correctness/plain_c_includes.c $(RUNTIME_EXPORTED_INCLUDES)

--- a/test/correctness/bool_compute_root_vectorize.cpp
+++ b/test/correctness/bool_compute_root_vectorize.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/bound.cpp
+++ b/test/correctness/bound.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/bound_small_allocations.cpp
+++ b/test/correctness/bound_small_allocations.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 Expr calc(Expr a) {

--- a/test/correctness/boundary_conditions.cpp
+++ b/test/correctness/boundary_conditions.cpp
@@ -1,8 +1,8 @@
+#include "Halide.h"
 #include <algorithm>
 #include <future>
-#include <stdio.h>
 
-#include "Halide.h"
+#include <cstdio>
 
 using namespace Halide;
 using namespace Halide::BoundaryConditions;

--- a/test/correctness/bounds.cpp
+++ b/test/correctness/bounds.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <iostream>
 
 using namespace Halide;

--- a/test/correctness/bounds_inference.cpp
+++ b/test/correctness/bounds_inference.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 using namespace Halide;
 
 int main(int argc, char **argv) {

--- a/test/correctness/bounds_inference_chunk.cpp
+++ b/test/correctness/bounds_inference_chunk.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/bounds_inference_complex.cpp
+++ b/test/correctness/bounds_inference_complex.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/bounds_inference_outer_split.cpp
+++ b/test/correctness/bounds_inference_outer_split.cpp
@@ -1,9 +1,9 @@
-// This was a failing case from https://github.com/halide/Halide/issues/1618
-
 #include "Halide.h"
 #include <stdio.h>
 using namespace Halide;
 using namespace Halide::Internal;
+
+// This was a failing case from https://github.com/halide/Halide/issues/1618
 
 class CheckAllocationSize : public IRVisitor {
 

--- a/test/correctness/bounds_of_multiply.cpp
+++ b/test/correctness/bounds_of_multiply.cpp
@@ -1,8 +1,7 @@
-// See https://github.com/halide/Halide/issues/3070
-
+#include "Halide.h"
 #include <stdio.h>
 
-#include "Halide.h"
+// See https://github.com/halide/Halide/issues/3070
 
 using namespace Halide;
 

--- a/test/correctness/buffer_t.cpp
+++ b/test/correctness/buffer_t.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/c_function.cpp
+++ b/test/correctness/c_function.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/cast.cpp
+++ b/test/correctness/cast.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/chunk.cpp
+++ b/test/correctness/chunk.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/chunk_sharing.cpp
+++ b/test/correctness/chunk_sharing.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/compute_at_reordered_update_stage.cpp
+++ b/test/correctness/compute_at_reordered_update_stage.cpp
@@ -1,4 +1,4 @@
-#include <Halide.h>
+#include "Halide.h"
 
 using namespace Halide;
 

--- a/test/correctness/computed_index.cpp
+++ b/test/correctness/computed_index.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 using namespace Halide;
 
 int main(int argc, char **argv) {

--- a/test/correctness/constant_expr.cpp
+++ b/test/correctness/constant_expr.cpp
@@ -1,6 +1,6 @@
+#include "Halide.h"
 #include <stdio.h>
 #include <limits>
-#include "Halide.h"
 
 #ifdef _MSC_VER
 #pragma warning(disable:4800)  // forcing value to bool 'true' or 'false'

--- a/test/correctness/constant_type.cpp
+++ b/test/correctness/constant_type.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/convolution.cpp
+++ b/test/correctness/convolution.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/convolution_multiple_kernels.cpp
+++ b/test/correctness/convolution_multiple_kernels.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/custom_allocator.cpp
+++ b/test/correctness/custom_allocator.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/deinterleave4.cpp
+++ b/test/correctness/deinterleave4.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/external_code.cpp
+++ b/test/correctness/external_code.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <fstream>
 #include <cassert>
 #include <iostream>

--- a/test/correctness/fibonacci.cpp
+++ b/test/correctness/fibonacci.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/func_lifetime.cpp
+++ b/test/correctness/func_lifetime.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <iostream>
 
 using namespace Halide;

--- a/test/correctness/func_lifetime_2.cpp
+++ b/test/correctness/func_lifetime_2.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <iostream>
 
 using namespace Halide;

--- a/test/correctness/fuzz_simplify.cpp
+++ b/test/correctness/fuzz_simplify.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <time.h>
 #include <random>
 

--- a/test/correctness/gameoflife.cpp
+++ b/test/correctness/gameoflife.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/gpu_bounds_inference_failure.cpp
+++ b/test/correctness/gpu_bounds_inference_failure.cpp
@@ -1,9 +1,8 @@
-// from issue #3221
-
 #include "Halide.h"
 
 using namespace Halide;
 
+// from issue #3221
 int main(int argc, char *argv[]) {
 
     Target t = get_jit_target_from_environment();

--- a/test/correctness/gpu_large_alloc.cpp
+++ b/test/correctness/gpu_large_alloc.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <algorithm>
 
 using namespace Halide;

--- a/test/correctness/heap_cleanup.cpp
+++ b/test/correctness/heap_cleanup.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <atomic>
 
 using namespace Halide;

--- a/test/correctness/hello_gpu.cpp
+++ b/test/correctness/hello_gpu.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <iostream>
 
 using namespace Halide;

--- a/test/correctness/histogram.cpp
+++ b/test/correctness/histogram.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/histogram_equalize.cpp
+++ b/test/correctness/histogram_equalize.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/implicit_args.cpp
+++ b/test/correctness/implicit_args.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/infer_arguments.cpp
+++ b/test/correctness/infer_arguments.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 using namespace Halide::Internal;

--- a/test/correctness/inline_reduction.cpp
+++ b/test/correctness/inline_reduction.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <algorithm>
 
 using namespace Halide;

--- a/test/correctness/input_image_bounds_check.cpp
+++ b/test/correctness/input_image_bounds_check.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 // This tests out-of-bounds reads from an input image
 

--- a/test/correctness/interleave_rgb.cpp
+++ b/test/correctness/interleave_rgb.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/interleave_x.cpp
+++ b/test/correctness/interleave_x.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/lambda.cpp
+++ b/test/correctness/lambda.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/load_library.cpp
+++ b/test/correctness/load_library.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/logical.cpp
+++ b/test/correctness/logical.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/loop_invariant_extern_calls.cpp
+++ b/test/correctness/loop_invariant_extern_calls.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/math.cpp
+++ b/test/correctness/math.cpp
@@ -1,6 +1,6 @@
+#include "Halide.h"
 #include <stdio.h>
 #include <math.h>
-#include "Halide.h"
 #include <iostream>
 #include <limits>
 

--- a/test/correctness/memoize.cpp
+++ b/test/correctness/memoize.cpp
@@ -1,8 +1,8 @@
+#include "Halide.h"
+#include "HalideRuntime.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "Halide.h"
-#include "HalideRuntime.h"
 
 using namespace Halide;
 

--- a/test/correctness/min_extent.cpp
+++ b/test/correctness/min_extent.cpp
@@ -1,7 +1,7 @@
 // Test whether min[] and extent[] of an ImageParam are correctly passed into
 // the filter.
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/mod.cpp
+++ b/test/correctness/mod.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/mul_div_mod.cpp
+++ b/test/correctness/mul_div_mod.cpp
@@ -1,6 +1,6 @@
-#include <stdio.h>
 #include "Halide.h"
 
+#include <stdio.h>
 #include <math.h>
 #include <algorithm>
 #include <future>

--- a/test/correctness/obscure_image_references.cpp
+++ b/test/correctness/obscure_image_references.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/out_constraint.cpp
+++ b/test/correctness/out_constraint.cpp
@@ -1,8 +1,9 @@
-// Verifies that constraints on the input ImageParam propagates to the output
-// function.
+#include "Halide.h"
+
 #include <iostream>
 
-#include "Halide.h"
+// Verifies that constraints on the input ImageParam propagates to the output
+// function.
 
 using namespace Halide;
 using namespace Halide::Internal;

--- a/test/correctness/parallel.cpp
+++ b/test/correctness/parallel.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/parallel_alloc.cpp
+++ b/test/correctness/parallel_alloc.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/parallel_fork.cpp
+++ b/test/correctness/parallel_fork.cpp
@@ -1,7 +1,7 @@
-#include <stdio.h>
 #include "Halide.h"
 #include "halide_benchmark.h"
 
+#include <stdio.h>
 #include <chrono>
 #include <thread>
 #include <atomic>

--- a/test/correctness/parallel_gpu_nested.cpp
+++ b/test/correctness/parallel_gpu_nested.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/parallel_nested.cpp
+++ b/test/correctness/parallel_nested.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/parallel_nested_1.cpp
+++ b/test/correctness/parallel_nested_1.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/parallel_reductions.cpp
+++ b/test/correctness/parallel_reductions.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/param.cpp
+++ b/test/correctness/param.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/param_map.cpp
+++ b/test/correctness/param_map.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <iostream>
 
 using namespace Halide;

--- a/test/correctness/partial_application.cpp
+++ b/test/correctness/partial_application.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/print.cpp
+++ b/test/correctness/print.cpp
@@ -1,8 +1,8 @@
+#include "Halide.h"
 #include <stdio.h>
 #include <string>
 #include <vector>
 #include <limits>
-#include "Halide.h"
 
 using namespace Halide;
 

--- a/test/correctness/python_extension_gen.cpp
+++ b/test/correctness/python_extension_gen.cpp
@@ -1,7 +1,7 @@
+#include "Halide.h"
+
 #include <stdio.h>
 #include <iostream>
-
-#include "Halide.h"
 
 #include "test/common/halide_test_dirs.h"
 

--- a/test/correctness/reduction_non_rectangular.cpp
+++ b/test/correctness/reduction_non_rectangular.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/reduction_schedule.cpp
+++ b/test/correctness/reduction_schedule.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <algorithm>
 
 using namespace Halide;

--- a/test/correctness/reduction_subregion.cpp
+++ b/test/correctness/reduction_subregion.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 // This test defines a reduction that writes to a large area, reads
 // from an even larger area, and then just realizes it over a smaller

--- a/test/correctness/reuse_stack_alloc.cpp
+++ b/test/correctness/reuse_stack_alloc.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/saturating_casts.cpp
+++ b/test/correctness/saturating_casts.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <iostream>
 #include <limits>
 

--- a/test/correctness/set_custom_trace.cpp
+++ b/test/correctness/set_custom_trace.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 using namespace Halide::Internal;

--- a/test/correctness/side_effects.cpp
+++ b/test/correctness/side_effects.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <math.h>
 
 using namespace Halide;

--- a/test/correctness/sliding_window.cpp
+++ b/test/correctness/sliding_window.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/split_fuse_rvar.cpp
+++ b/test/correctness/split_fuse_rvar.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <iostream>
 
 using namespace Halide;

--- a/test/correctness/split_reuse_inner_name_bug.cpp
+++ b/test/correctness/split_reuse_inner_name_bug.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/split_store_compute.cpp
+++ b/test/correctness/split_store_compute.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <algorithm>
 
 using namespace Halide;

--- a/test/correctness/storage_folding.cpp
+++ b/test/correctness/storage_folding.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/strict_float.cpp
+++ b/test/correctness/strict_float.cpp
@@ -1,9 +1,9 @@
+#include "Halide.h"
+
 #include <algorithm>
 #include <ios>
 #include <iostream>
 #include <iomanip>
-
-#include "Halide.h"
 
 using namespace Halide;
 

--- a/test/correctness/target.cpp
+++ b/test/correctness/target.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/tracing_stack.cpp
+++ b/test/correctness/tracing_stack.cpp
@@ -1,3 +1,4 @@
+#include "Halide.h"
 
 // This test demonstrates using tracing to give you something like a
 // stack trace in case of a crash (due to a compiler bug, or a bug in
@@ -6,7 +7,6 @@
 
 #if defined(__linux__) || defined(__APPLE__) || defined(__unix) || defined(__posix)
 
-#include "Halide.h"
 #include <stdio.h>
 #include <signal.h>
 #include <stack>

--- a/test/correctness/two_vector_args.cpp
+++ b/test/correctness/two_vector_args.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/unique_func_image.cpp
+++ b/test/correctness/unique_func_image.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/unrolled_reduction.cpp
+++ b/test/correctness/unrolled_reduction.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/unsafe_promises.cpp
+++ b/test/correctness/unsafe_promises.cpp
@@ -1,6 +1,6 @@
-#include <iostream>
-
 #include "Halide.h"
+
+#include <iostream>
 
 using namespace Halide;
 

--- a/test/correctness/update_chunk.cpp
+++ b/test/correctness/update_chunk.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/vector_bounds_inference.cpp
+++ b/test/correctness/vector_bounds_inference.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/vector_extern.cpp
+++ b/test/correctness/vector_extern.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "Halide.h"
+#include <stdio.h>
 #include <math.h>
 
 using namespace Halide;

--- a/test/correctness/vector_print_bug.cpp
+++ b/test/correctness/vector_print_bug.cpp
@@ -1,4 +1,3 @@
-
 #include "Halide.h"
 
 using namespace Halide;

--- a/test/correctness/vectorized_gpu_allocation.cpp
+++ b/test/correctness/vectorized_gpu_allocation.cpp
@@ -1,4 +1,4 @@
-#include <Halide.h>
+#include "Halide.h"
 
 using namespace Halide;
 


### PR DESCRIPTION
Building tests (eg. correctness) uses different flags than the default build and this invalidates the precompiled header (PCH) in those targets. This PR produces a test-compatible PCH alongside the default one and speeds up `build_tests` by almost 2x when using GCC.

Also moved `#include "Halide.h"` to the front of any test that includes it to be sure that the PCH will be used. Changed instances of `#include <Halide.h>` to use double quotes for consistency.