### PR TITLE
Added support for halide_hexagon_set_thread_priority()

### DIFF
--- a/src/runtime/HalideRuntimeHexagonHost.h
+++ b/src/runtime/HalideRuntimeHexagonHost.h
@@ -79,7 +79,7 @@ typedef enum halide_hexagon_power_mode_t {
  * @param mipsPerThread - mips requested per thread, to establish a minimal clock frequency per HW thread
  * @param mipsTotal - Total mips requested, to establish total number of MIPS required across all HW threads
  * @param set_bus_bw - Set to TRUE to request bus_bw
- * @param bwMeagabytesPerSec - Max bus BW requested (megabytes per second)
+ * @param bwMegabytesPerSec - Max bus BW requested (megabytes per second)
  * @param busbwUsagePercentage - Percentage of time during which bwBytesPerSec BW is required from the bus (0..100)
  * @param set_latency - Set to TRUE to set latency
  * @param latency - maximum hardware wakeup latency in microseconds.  The
@@ -111,6 +111,16 @@ typedef halide_hexagon_power_t halide_hvx_power_perf_t;
 // @{
 extern int halide_hexagon_set_performance_mode(void *user_context, halide_hexagon_power_mode_t mode);
 extern int halide_hexagon_set_performance(void *user_context, halide_hexagon_power_t *perf);
+// @}
+
+/** Set the priority for Hexagon threads.
+ * - Valid priority values range from 1 to 255
+ * - Smaller number for higher priority
+ * - The highest priority for a user thread is 1, 0 reserved for OS usage
+ * - If not set, Halide thread priority will default to 100
+ * - This should be called before running a pipeline. */
+// @{
+extern int halide_hexagon_set_thread_priority(void *user_context, int priority);
 // @}
 
 /** These are forward declared here to allow clients to override the

--- a/src/runtime/hexagon_remote/dlib.cpp
+++ b/src/runtime/hexagon_remote/dlib.cpp
@@ -508,6 +508,17 @@ void *mmap_dlsym(void *from, const char *name) {
     return (void *)dlib->get_symbol_addr(sym);
 }
 
+void *mmap_dlsym_libs(const char *name) {
+    void *S = halide_get_symbol(name);
+    for (dlib_t *i = loaded_libs; i && !S; i = i->next) {
+        // TODO: We really should only look in
+        // libraries with an soname that is marked
+        // DT_NEEDED in this library.
+        S = mmap_dlsym(i, name);
+    }
+    return S;
+}
+
 int mmap_dlclose(void *dlib) {
     // Remove this library from the list of loaded libs.
     if (loaded_libs == dlib) {

--- a/src/runtime/hexagon_remote/dlib.h
+++ b/src/runtime/hexagon_remote/dlib.h
@@ -10,6 +10,7 @@
 // dlopen/mmap_dlopen calls.
 void *mmap_dlopen(const void *code, size_t size);
 void *mmap_dlsym(void *dlib, const char *name);
+void *mmap_dlsym_libs(const char *name);
 int mmap_dlclose(void *dlib);
 
 #endif

--- a/src/runtime/hexagon_remote/halide_hexagon_remote.idl
+++ b/src/runtime/hexagon_remote/halide_hexagon_remote.idl
@@ -48,4 +48,6 @@ interface halide_hexagon_remote
                          in long set_latency,
                          in long latency);
 
+    // Set thread priority
+    long set_thread_priority(in long priority);
 };

--- a/src/runtime/hexagon_remote/halide_remote.cpp
+++ b/src/runtime/hexagon_remote/halide_remote.cpp
@@ -320,10 +320,53 @@ int halide_hexagon_remote_get_symbol_v4(handle_t module_ptr, const char* name, i
     return *sym_ptr != 0 ? 0 : -1;
 }
 
+// Thread priority for QURT threads
+// Negative: use the current default (don't explicitly reset it)
+// Positive: the priority needs to be set once the shared runtime is loaded
+int saved_thread_priority = -1;
+
+int halide_hexagon_remote_set_thread_priority(int priority) {
+    // Just save requested priority for now.  The priority can't actually
+    // be set in qurt_thread_pool until the shared runtime has been loaded.
+    saved_thread_priority = priority;
+    return 0;
+}
+
+int halide_hexagon_runtime_set_thread_priority(int priority) {
+    if (priority < 0) {
+        return 0;
+    }
+
+    // Find the halide_set_default_thread_priority function in the shared runtime,
+    // which we loaded with RTLD_GLOBAL.
+    void (*set_priority)(int) = NULL;
+    if (use_dlopenbuf()) {
+        set_priority = (void (*)(int)) halide_get_symbol("halide_set_default_thread_priority");
+    } else {
+        set_priority = (void (*)(int)) mmap_dlsym_libs("halide_set_default_thread_priority");
+    }
+
+    if (set_priority) {
+        set_priority(priority);
+    } else {
+        // This code being run is old, doesn't have set priority feature, do nothing.
+    }
+
+    return 0;
+}
+
 int halide_hexagon_remote_run_v2(handle_t module_ptr, handle_t function,
                                  const buffer *input_buffersPtrs, int input_buffersLen,
                                  buffer *output_buffersPtrs, int output_buffersLen,
                                  const scalar_t *scalars, int scalarsLen) {
+    if (saved_thread_priority > 0) {
+        // Existing thread
+        run_context.set_priority(saved_thread_priority);
+        // Future threads
+        halide_hexagon_runtime_set_thread_priority(saved_thread_priority);
+        saved_thread_priority = -1;   // Only do this once
+    }
+
     // Get a pointer to the argv version of the pipeline.
     pipeline_argv_t pipeline = reinterpret_cast<pipeline_argv_t>(function);
 

--- a/src/runtime/hexagon_remote/pipeline_context.h
+++ b/src/runtime/hexagon_remote/pipeline_context.h
@@ -76,6 +76,15 @@ public:
         free(stack);
     }
 
+    void set_priority(int priority) {
+        if (priority > 0xFF) {
+            priority = 0xFF;        // Clamp to max priority
+        } else if (priority <= 0) {
+            return;                 // Ignore settings of zero and below
+        }
+        qurt_thread_set_priority(thread, priority);
+    }
+
     int run(pipeline_argv_t function, void **args) {
         // get a lock and set up work for the worker.
         qurt_mutex_lock(&work_mutex);

--- a/src/runtime/mini_qurt.h
+++ b/src/runtime/mini_qurt.h
@@ -29,7 +29,7 @@ typedef unsigned int qurt_thread_t;
 #define QURT_THREAD_ATTR_TCB_PARTITION_RAM      0  /**< Creates threads in RAM/DDR. */
 #define QURT_THREAD_ATTR_TCB_PARTITION_TCM      1  /**< Creates threads in TCM. */
 #define QURT_THREAD_ATTR_TCB_PARTITION_DEFAULT  QURT_THREAD_ATTR_TCB_PARTITION_RAM  /**< Backward compatibility. */
-#define QURT_THREAD_ATTR_PRIORITY_DEFAULT       256  /**< */
+#define QURT_THREAD_ATTR_PRIORITY_DEFAULT       255  /**< */
 #define QURT_THREAD_ATTR_ASID_DEFAULT           0  /**< */
 #define QURT_THREAD_ATTR_AFFINITY_DEFAULT      (-1)  /**< */
 #define QURT_THREAD_ATTR_BUS_PRIO_DEFAULT       255  /**< */

--- a/src/runtime/qurt_threads.cpp
+++ b/src/runtime/qurt_threads.cpp
@@ -34,7 +34,23 @@ int halide_host_cpu_count() {
 
 #define STACK_SIZE 256*1024
 
+WEAK uint16_t halide_qurt_default_thread_priority = 100;
+
+WEAK void halide_set_default_thread_priority(int priority) {
+    if (priority > 0xFF) {
+        priority = 0xFF;        // Clamp to max priority
+    } else if (priority <= 0) {
+        return;                 // Ignore settings of zero and below
+    }
+    halide_qurt_default_thread_priority = priority;
+}
+
+WEAK int halide_get_default_thread_priority() {
+    return halide_qurt_default_thread_priority;
+}
+
 WEAK struct halide_thread *halide_spawn_thread(void (*f)(void *), void *closure) {
+    uint16_t priority = halide_get_default_thread_priority();;
     spawned_thread *t = (spawned_thread *)malloc(sizeof(spawned_thread));
     t->f = f;
     t->closure = closure;
@@ -44,7 +60,7 @@ WEAK struct halide_thread *halide_spawn_thread(void (*f)(void *), void *closure)
     qurt_thread_attr_init(&thread_attr);
     qurt_thread_attr_set_stack_addr(&thread_attr, t->stack);
     qurt_thread_attr_set_stack_size(&thread_attr, STACK_SIZE);
-    qurt_thread_attr_set_priority(&thread_attr, 255);
+    qurt_thread_attr_set_priority(&thread_attr, priority);
     qurt_thread_create(&t->handle.val, &thread_attr, &spawn_thread_helper, t);
     return (halide_thread *)t;
 }

--- a/src/runtime/runtime_api.cpp
+++ b/src/runtime/runtime_api.cpp
@@ -105,6 +105,7 @@ extern "C" __attribute__((used)) void *halide_runtime_api_functions[] = {
     (void *)&halide_hexagon_run,
     (void *)&halide_hexagon_set_performance,
     (void *)&halide_hexagon_set_performance_mode,
+    (void *)&halide_hexagon_set_thread_priority,
     (void *)&halide_hexagon_wrap_device_handle,
     (void *)&halide_int64_to_string,
     (void *)&halide_join_thread,


### PR DESCRIPTION
  - Added halide_hexagon_set_thread_priority IDL API to set the
    priority of threads created in the Halide runtime
  - Works similarly to halide_hexagon_set_performance[_mode]
  - A user would call halide_hexagon_set_thread_priority from the
    host app before dispatching a pipeline

    // Increase the default priority of Halide Hexagon threads
    halide_hexagon_set_thread_priority(NULL, 50);

  - Threads will be created with the previously specified priority
  - If not called, the default priority will be used
  - Compatible with old runtimes - priority won't be set w/ old
  - Set qurt_thread_pool.cpp priority default to 100 (to match master thread)
  - Limit priority range from 1 to 255
  - Also set priority on existing master thread
  - Update QURT_THREAD_ATTR_PRIORITY_DEFAULT to match v62 qthread.h
  - Added more documentation to HalideRuntimeHexagonHost.h

    /** Set the priority for Hexagon threads.
     * - Valid priority values range from 1 to 255
     * - Smaller number for higher priority
     * - The highest priority for a user thread is 1, 0 reserved for OS usage
     * - If not set, Halide thread priority will default to 100
     * - This should be called before running a pipeline. */
    // @{
    extern int halide_hexagon_set_thread_priority(void *user_context, int priority);
    // @}

  - Added mmap_dlsym_libs that will search the list of loaded libs as
    8996/sdm820 was failing to find halide_set_default_thread_priority
    using mmap_dlsym
  - For dlopenbuf platforms, using halide_get_symbol instead of dlsym
    directly in order to pick up Dillon's fallback technique of
    checking RTLD_SELF & RTLD_DEFAULT