### PR TITLE
Add autotune_classic.sh and support

### DIFF
--- a/apps/autoscheduler/autotune_classic.sh
+++ b/apps/autoscheduler/autotune_classic.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This is a trivial script to try running 'classic' autoscheduler
+# with the multiple variants of MachineParams used in the original paper;
+# all it does is disable benchmarking of non-classic variants, and run 'make test'
+# in the current directory repeatedly with different values (removing
+# any classic artifacts from bin to ensure a rebuild occurs).
+#
+# To use:
+# - cd to the dir of the app you want to bench
+# - run this script
+
+set -eu
+
+export HL_THREE_WAY_BENCH_SKIP_MANUAL=1
+export HL_THREE_WAY_BENCH_SKIP_AUTO_CLASSIC=0
+export HL_THREE_WAY_BENCH_SKIP_AUTO_NEW=1
+
+# Ensure that building the non-classic variants doesn't flood us with noise
+echo Prebuilding...
+make test &> /dev/null
+
+CORES=32
+for CACHE in 12000000 24000000 48000000; do
+    for BALANCE in 80 160 320; do
+        rm -f bin/*_classic_auto_schedule*
+
+        echo
+        echo Benchmarking with HL_MACHINE_PARAMS=${CORES},${CACHE},${BALANCE}...
+        HL_MACHINE_PARAMS=${CORES},${CACHE},${BALANCE} make test 2>/dev/null | grep ".*time:.*"
+    done
+done
+
+echo Done.

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -13,7 +13,7 @@ $(BIN)/bilateral_grid.a: $(BIN)/bilateral_grid.generator
 
 $(BIN)/bilateral_grid_classic_auto_schedule.a: $(BIN)/bilateral_grid.generator
 	@mkdir -p $(@D)
-	$< -g bilateral_grid -o $(BIN) -f bilateral_grid_classic_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true -e static_library,h,schedule
+	$< -g bilateral_grid -o $(BIN) -f bilateral_grid_classic_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true machine_params=$(HL_MACHINE_PARAMS) -e static_library,h,schedule
 
 $(BIN)/bilateral_grid_auto_schedule.a: $(BIN)/bilateral_grid.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -16,7 +16,7 @@ $(BIN)/camera_pipe.a: $(BIN)/camera_pipe.generator
 # TODO: this fails with an internal_assert failure in the classic AutoScheduler.
 # $(BIN)/camera_pipe_classic_auto_schedule.a: $(BIN)/camera_pipe.generator
 # 	@mkdir -p $(@D)
-# 	$< -g camera_pipe -o $(BIN) -f camera_pipe_classic_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
+# 	$< -g camera_pipe -o $(BIN) -f camera_pipe_classic_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true machine_params=$(HL_MACHINE_PARAMS)
 
 $(BIN)/camera_pipe_auto_schedule.a: $(BIN)/camera_pipe.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)

--- a/apps/conv_layer/Makefile
+++ b/apps/conv_layer/Makefile
@@ -15,7 +15,7 @@ $(BIN)/conv_layer.a: $(BIN)/conv_layer.generator
 
 $(BIN)/conv_layer_classic_auto_schedule.a: $(BIN)/conv_layer.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	$< -g conv_layer -f conv_layer_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true
+	$< -g conv_layer -f conv_layer_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true machine_params=$(HL_MACHINE_PARAMS)
 
 $(BIN)/conv_layer_auto_schedule.a: $(BIN)/conv_layer.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)

--- a/apps/fit_and_slice_3x4/Makefile
+++ b/apps/fit_and_slice_3x4/Makefile
@@ -13,7 +13,7 @@ $(BIN)/fit_and_slice_3x4.a: $(BIN)/fit_and_slice_3x4.generator
 
 $(BIN)/fit_and_slice_3x4_classic_auto_schedule.a: $(BIN)/fit_and_slice_3x4.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	$< -g fit_and_slice_3x4 -f fit_and_slice_3x4_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true
+	$< -g fit_and_slice_3x4 -f fit_and_slice_3x4_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true machine_params=$(HL_MACHINE_PARAMS)
 
 $(BIN)/fit_and_slice_3x4_auto_schedule.a: $(BIN)/fit_and_slice_3x4.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)

--- a/apps/harris/Makefile
+++ b/apps/harris/Makefile
@@ -13,7 +13,7 @@ $(BIN)/harris.a: $(BIN)/harris.generator
 
 $(BIN)/harris_classic_auto_schedule.a: $(BIN)/harris.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	$< -g harris -f harris_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true
+	$< -g harris -f harris_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true machine_params=$(HL_MACHINE_PARAMS)
 
 $(BIN)/harris_auto_schedule.a: $(BIN)/harris.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)

--- a/apps/hist/Makefile
+++ b/apps/hist/Makefile
@@ -13,7 +13,7 @@ $(BIN)/hist.a: $(BIN)/hist.generator
 
 $(BIN)/hist_classic_auto_schedule.a: $(BIN)/hist.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	$< -g hist -f hist_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true
+	$< -g hist -f hist_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true machine_params=$(HL_MACHINE_PARAMS)
 
 $(BIN)/hist_auto_schedule.a: $(BIN)/hist.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)

--- a/apps/iir_blur_generator/Makefile
+++ b/apps/iir_blur_generator/Makefile
@@ -13,7 +13,7 @@ $(BIN)/iir_blur.a: $(BIN)/iir_blur.generator
 
 $(BIN)/iir_blur_classic_auto_schedule.a: $(BIN)/iir_blur.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	$< -g iir_blur -f iir_blur_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true
+	$< -g iir_blur -f iir_blur_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true machine_params=$(HL_MACHINE_PARAMS)
 
 $(BIN)/iir_blur_auto_schedule.a: $(BIN)/iir_blur.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)

--- a/apps/interpolate_generator/Makefile
+++ b/apps/interpolate_generator/Makefile
@@ -13,7 +13,7 @@ $(BIN)/interpolate.a: $(BIN)/interpolate.generator
 
 $(BIN)/interpolate_classic_auto_schedule.a: $(BIN)/interpolate.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	$< -g interpolate -f interpolate_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true
+	$< -g interpolate -f interpolate_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true machine_params=$(HL_MACHINE_PARAMS)
 
 $(BIN)/interpolate_auto_schedule.a: $(BIN)/interpolate.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)

--- a/apps/lens_blur/Makefile
+++ b/apps/lens_blur/Makefile
@@ -15,7 +15,7 @@ $(BIN)/lens_blur.a: $(BIN)/lens_blur.generator
 
 $(BIN)/lens_blur_classic_auto_schedule.a: $(BIN)/lens_blur.generator
 	@-mkdir -p $(BIN)
-	$< -g lens_blur -o $(BIN) -f lens_blur_classic_auto_schedule target=$(HL_TARGET)-large_buffers-no_runtime auto_schedule=true
+	$< -g lens_blur -o $(BIN) -f lens_blur_classic_auto_schedule target=$(HL_TARGET)-large_buffers-no_runtime auto_schedule=true machine_params=$(HL_MACHINE_PARAMS)
 
 $(BIN)/lens_blur_auto_schedule.a: $(BIN)/lens_blur.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@-mkdir -p $(BIN)

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -15,7 +15,7 @@ $(BIN)/local_laplacian.a: $(BIN)/local_laplacian.generator
 
 $(BIN)/local_laplacian_classic_auto_schedule.a: $(BIN)/local_laplacian.generator
 	@mkdir -p $(@D)
-	$< -g local_laplacian -o $(BIN) -f local_laplacian_classic_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
+	$< -g local_laplacian -o $(BIN) -f local_laplacian_classic_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true machine_params=$(HL_MACHINE_PARAMS)
 
 $(BIN)/local_laplacian_auto_schedule.a: $(BIN)/local_laplacian.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)

--- a/apps/mat_mul_generator/Makefile
+++ b/apps/mat_mul_generator/Makefile
@@ -13,7 +13,7 @@ $(BIN)/mat_mul.a: $(BIN)/mat_mul.generator
 
 $(BIN)/mat_mul_classic_auto_schedule.a: $(BIN)/mat_mul.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	$< -g mat_mul -f mat_mul_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true
+	$< -g mat_mul -f mat_mul_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true machine_params=$(HL_MACHINE_PARAMS)
 
 $(BIN)/mat_mul_auto_schedule.a: $(BIN)/mat_mul.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)

--- a/apps/max_filter/Makefile
+++ b/apps/max_filter/Makefile
@@ -11,9 +11,9 @@ $(BIN)/max_filter.a: $(BIN)/max_filter.generator
 	@mkdir -p $(@D)
 	$< -g max_filter -f max_filter -o $(BIN) target=$(HL_TARGET) auto_schedule=false
 
-$(BIN)/max_filter_classic_auto_schedule.a: $(BIN)/max_filter.generator 
+$(BIN)/max_filter_classic_auto_schedule.a: $(BIN)/max_filter.generator
 	@mkdir -p $(@D)
-	$< -g max_filter -f max_filter_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true
+	$< -g max_filter -f max_filter_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true machine_params=$(HL_MACHINE_PARAMS)
 
 $(BIN)/max_filter_auto_schedule.a: $(BIN)/max_filter.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)

--- a/apps/nl_means/Makefile
+++ b/apps/nl_means/Makefile
@@ -15,7 +15,7 @@ $(BIN)/nl_means.a: $(BIN)/nl_means.generator
 
 $(BIN)/nl_means_classic_auto_schedule.a: $(BIN)/nl_means.generator
 	@-mkdir -p $(BIN)
-	$< -g nl_means -o $(BIN) -f nl_means_classic_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
+	$< -g nl_means -o $(BIN) -f nl_means_classic_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true machine_params=$(HL_MACHINE_PARAMS)
 
 $(BIN)/nl_means_auto_schedule.a: $(BIN)/nl_means.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@-mkdir -p $(BIN)

--- a/apps/stencil_chain/Makefile
+++ b/apps/stencil_chain/Makefile
@@ -15,7 +15,7 @@ $(BIN)/stencil_chain.a: $(BIN)/stencil_chain.generator
 
 $(BIN)/stencil_chain_classic_auto_schedule.a: $(BIN)/stencil_chain.generator
 	@mkdir -p $(@D)
-	$< -g stencil_chain -o $(BIN) -f stencil_chain_classic_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
+	$< -g stencil_chain -o $(BIN) -f stencil_chain_classic_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true machine_params=$(HL_MACHINE_PARAMS)
 
 $(BIN)/stencil_chain_auto_schedule.a: $(BIN)/stencil_chain.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)

--- a/apps/support/autoscheduler.inc
+++ b/apps/support/autoscheduler.inc
@@ -75,3 +75,9 @@ $(AUTOSCHED_BIN)/augment_sample: $(AUTOSCHED_SRC)/augment_sample.cpp
 	@mkdir -p $(@D)
 	$(CXX) $< -O3 -o $@
 
+
+# This is the value that machine_params defaults to if no custom value is specified;
+# see MachineParams::generic()
+HL_MACHINE_PARAMS ?= 32,25165824,160
+
+

--- a/apps/support/benchmark_util.h
+++ b/apps/support/benchmark_util.h
@@ -8,24 +8,29 @@ inline void three_way_bench(std::function<void()> manual,
                             std::function<void()> auto_new,
                             std::ostream& output = std::cout) {
 
+    const auto is_one = [](const char *key) -> bool {
+        const char *value = getenv(key);
+        return value && value[0] == '1' && value[1] == 0;
+    };
+
     Halide::Tools::BenchmarkConfig config;
     config.accuracy = 0.005;
 
     double t;
 
-    if (manual) {
+    if (manual && !is_one("HL_THREE_WAY_BENCH_SKIP_MANUAL")) {
         manual();
         t = Halide::Tools::benchmark(manual, config);
         output << "Manually-tuned time: " << t * 1e3 << " ms\n";
     }
 
-    if (auto_classic) {
+    if (auto_classic && !is_one("HL_THREE_WAY_BENCH_SKIP_AUTO_CLASSIC")) {
         auto_classic();
         t = Halide::Tools::benchmark(auto_classic, config);
         output << "Classic auto-scheduled time: " << t * 1e3 << " ms\n";
     }
 
-    if (auto_new) {
+    if (auto_new && !is_one("HL_THREE_WAY_BENCH_SKIP_AUTO_NEW")) {
         auto_new();
         t = Halide::Tools::benchmark(auto_new, config);
         output << "Auto-scheduled : " << t * 1e3 << " ms\n";

--- a/apps/unsharp/Makefile
+++ b/apps/unsharp/Makefile
@@ -13,7 +13,7 @@ $(BIN)/unsharp.a: $(BIN)/unsharp.generator
 
 $(BIN)/unsharp_classic_auto_schedule.a: $(BIN)/unsharp.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	$< -g unsharp -f unsharp_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true
+	$< -g unsharp -f unsharp_classic_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true machine_params=$(HL_MACHINE_PARAMS)
 
 $(BIN)/unsharp_auto_schedule.a: $(BIN)/unsharp.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)


### PR DESCRIPTION
This is a trivial script to try running 'classic' autoscheduler
with the multiple variants of MachineParams used in the original paper;
all it does is disable benchmarking of non-classic variants, and run 'make test'
in the current directory repeatedly with different values (removing
any classic artifacts from bin to ensure a rebuild occurs).