### PR TITLE
Revert "Update for trunk LLVM"

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1167,11 +1167,7 @@ void CodeGen_LLVM::optimize_module() {
 
     if (get_target().has_feature(Target::TSAN)) {
         auto addThreadSanitizerPass = [](const PassManagerBuilder &builder, legacy::PassManagerBase &pm) {
-#if LLVM_VERSION >= 80
-            pm.add(createThreadSanitizerLegacyPassPass());
-#else 
             pm.add(createThreadSanitizerPass());
-#endif
         };
         b.addExtension(PassManagerBuilder::EP_OptimizerLast, addThreadSanitizerPass);
         b.addExtension(PassManagerBuilder::EP_EnabledOnOptLevel0, addThreadSanitizerPass);

--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -44,9 +44,6 @@
 #include <llvm/Transforms/Utils/ModuleUtils.h>
 #include <llvm/Transforms/Utils/SymbolRewriter.h>
 #include <llvm/Transforms/Instrumentation.h>
-#if LLVM_VERSION >= 80
-#include <llvm/Transforms/Instrumentation/ThreadSanitizer.h>
-#endif
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"


### PR DESCRIPTION
Reverts halide/Halide#3564; apparently the underlying LLVM change was reverted or made moot.