### PR TITLE
HVX sysmon markers

### DIFF
--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -92,6 +92,7 @@ DECLARE_CPP_INITMOD(float16_t)
 DECLARE_CPP_INITMOD(gpu_device_selection)
 DECLARE_CPP_INITMOD(hexagon_dma)
 DECLARE_CPP_INITMOD(hexagon_host)
+DECLARE_CPP_INITMOD(hvx_sysmon)
 DECLARE_CPP_INITMOD(ios_io)
 DECLARE_CPP_INITMOD(linux_clock)
 DECLARE_CPP_INITMOD(linux_host_cpu_count)
@@ -863,6 +864,9 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 if (t.has_feature(Target::HVX_v65)) {
                     modules.push_back(get_initmod_qurt_hvx_vtcm(c, bits_64,
                                                                 debug));
+                }
+                if (t.has_feature(Target::HVX_sysmon)) {
+                    modules.push_back(get_initmod_hvx_sysmon(c, bits_64, debug));
                 }
 
             } else {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -288,6 +288,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"hvx_v65", Target::HVX_v65},
     {"hvx_v66", Target::HVX_v66},
     {"hvx_shared_object", Target::HVX_shared_object},
+    {"hvx_sysmon", Target::HVX_sysmon},
     {"fuzz_float_stores", Target::FuzzFloatStores},
     {"soft_float_abi", Target::SoftFloatABI},
     {"msan", Target::MSAN},

--- a/src/Target.h
+++ b/src/Target.h
@@ -84,6 +84,7 @@ struct Target {
         HVX_v65 = halide_target_feature_hvx_v65,
         HVX_v66 = halide_target_feature_hvx_v66,
         HVX_shared_object = halide_target_feature_hvx_use_shared_object,
+        HVX_sysmon = halide_target_feature_hvx_sysmon,
         FuzzFloatStores = halide_target_feature_fuzz_float_stores,
         SoftFloatABI = halide_target_feature_soft_float_abi,
         MSAN = halide_target_feature_msan,

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1285,7 +1285,8 @@ typedef enum halide_target_feature_t {
     halide_target_feature_embed_bitcode = 57,  ///< Emulate clang -fembed-bitcode flag.
     halide_target_feature_disable_llvm_loop_vectorize = 58,  ///< Disable loop vectorization in LLVM. (Ignored for non-LLVM targets.)
     halide_target_feature_disable_llvm_loop_unroll = 59,  ///< Disable loop unrolling in LLVM. (Ignored for non-LLVM targets.)
-    halide_target_feature_end = 60 ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
+    halide_target_feature_hvx_sysmon = 60, ///< Enable Hexagon sysmon markers.
+    halide_target_feature_end = 61 ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 
 /** This function is called internally by Halide in some situations to determine

--- a/src/runtime/hexagon_remote/sim_remote.cpp
+++ b/src/runtime/hexagon_remote/sim_remote.cpp
@@ -46,6 +46,11 @@ void log_printf(const char *fmt, ...) {
 
 extern "C" {
 
+void halide_sysmon_marker(uint32_t sysmon_id) {}
+void halide_sysmon_start(void) {}
+void halide_sysmon_stop(void) {}
+void halide_set_sysmon_marker(uint32_t marker) {}
+
 void halide_print(void *user_context, const char *str) {
     log_printf("%s", str);
 }

--- a/src/runtime/hvx_sysmon.cpp
+++ b/src/runtime/hvx_sysmon.cpp
@@ -1,0 +1,44 @@
+#include "runtime_internal.h"
+#include "HalideRuntimeQurt.h"
+
+extern "C" {
+__attribute__((weak)) void HP_profile(unsigned int marker, unsigned char enable);
+WEAK uint32_t halide_qurt_sysmon_enabled = 0;
+WEAK volatile uint32_t halide_qurt_sysmon_marker = 0;
+WEAK volatile uint32_t halide_sysmon_lock = 0;
+
+// Generate a sysmon marker with the specifid ID
+WEAK void halide_sysmon_marker(uint32_t next_marker) {
+    if (!halide_qurt_sysmon_enabled) {
+        return;
+    }
+    if (halide_qurt_sysmon_marker == next_marker) {
+        return;                         // Don't redundantly set marker
+    }
+
+    while (!__sync_bool_compare_and_swap(&halide_sysmon_lock, 0, 1)) { }
+    uint32_t last_marker = halide_qurt_sysmon_marker;   // Get value after lock
+    if (last_marker != next_marker) {   // Only change if we have a new ID
+        halide_qurt_sysmon_marker = next_marker;
+        if (last_marker != 0) {
+            HP_profile(last_marker, 0); // Stop last marker
+        }
+        if (next_marker != 0) {
+            HP_profile(next_marker, 1); // Start new marker
+        }
+    }
+    __sync_synchronize();
+    halide_sysmon_lock = 0;
+}
+
+WEAK void halide_sysmon_start(void) {
+    halide_qurt_sysmon_enabled = (HP_profile != NULL);
+}
+WEAK void halide_sysmon_stop(void) {
+    halide_sysmon_marker(0);
+    halide_qurt_sysmon_enabled = 0;
+}
+WEAK void halide_set_sysmon_marker(uint32_t marker) {
+    halide_qurt_sysmon_marker = marker;
+}
+}


### PR DESCRIPTION
When the hvx_sysmon target is specified, sysmon markers are added
to the generated code to help correlate between a given point in
the collected sysmon profile and the corresponding section in the
Halide source.  Markers are currently inserted at the:

  - entry of the Hexagon function
  - specified producer/consumer sites

using support routines in runtime/hexagon_remote/sim_remote.cpp &
runtime/hvx_sysmon.cpp.

Since these markers introduce a small amount of runtime overhead, the
max_depth is also specified to limit the depth of producers/consumers
that are tagged.  By default, the max_depth is set to 1.  The env var
HL_SYSMON_MAXDEPTH is provided to allow the user to increase the
amount of sysmon tracing.

For example, given the producers/consumers as seen in the camera_pipe
print_loop_nest() output:

     for __outermost in [0, 0]<Hexagon>:
       parallel v1.v4:
                   produce denoised:
                   consume denoised:
                     produce deinterleaved:
                     consume deinterleaved:
                       produce g_b:
                       consume g_b:
                         produce g_r:
                         consume g_r:
                             produce output:
                             consume output:
                               produce corrected:
                               consume corrected:

If max_depth is set to 1, markers will be generated for the
producer/consumer for denoised.  If max_depth is set to 2, we also get
markers for deinterleaved.  For max_depth 3, also g_b...and so on.

    export HL_TGT=hvx_128-hvx_sysmon
    env HL_SYSMON_MAXDEPTH=3 test-camera-android-128 ...
    ...
    Adding sysmon markers: max_depth(3)
    HVX sysmon_id:1 offload_rpc.curved.s0.__outermost
    HVX sysmon_id:2 consume:denoised
    HVX sysmon_id:3 produce:denoised
    HVX sysmon_id:4 produce:deinterleaved
    HVX sysmon_id:5 consume:deinterleaved
    HVX sysmon_id:6 produce:g_b
    HVX sysmon_id:7 consume:g_b

It is good to keep the max_depth to as small as possible since
increasing values will result in increasing levels of overhead:

    camera_pipe/SDM845:
       hvx_128                                  Halide:  8690us
       hvx_128-hxv_sysmon      max sysmon_id:3  Halide:  9586us
       + HL_SYSMON_MAXDEPTH=2  max sysmon_id:5  Halide: 10488us
       + HL_SYSMON_MAXDEPTH=3  max sysmon_id:7  Halide: 11335us
       + HL_SYSMON_MAXDEPTH=4  max sysmon_id:9  Halide: 12172us
       + HL_SYSMON_MAXDEPTH=5  max sysmon_id:11 Halide: 25774us
       + HL_SYSMON_MAXDEPTH=6  max sysmon_id:13 Halide: 36159us