### PR TITLE
Add crosscompile script for apps

### DIFF
--- a/apps/.gitignore
+++ b/apps/.gitignore
@@ -1,1 +1,2 @@
 samples/
+bin1/

--- a/apps/autoscheduler/AutoSchedule.cpp
+++ b/apps/autoscheduler/AutoSchedule.cpp
@@ -3116,6 +3116,7 @@ std::string generate_schedules_new(const std::vector<Function> &outputs,
     if (!beam_size_str.empty()) {
         beam_size = atoi(beam_size_str.c_str());
     }
+std::cerr<<"HEY MY BEAM SIZE IS "<<beam_size<<"\n";
 
     string time_limit_str = get_env_variable("HL_AUTO_SCHEDULE_TIME_LIMIT");
     double time_limit = 0;

--- a/apps/autoscheduler/AutoSchedule.cpp
+++ b/apps/autoscheduler/AutoSchedule.cpp
@@ -3116,7 +3116,6 @@ std::string generate_schedules_new(const std::vector<Function> &outputs,
     if (!beam_size_str.empty()) {
         beam_size = atoi(beam_size_str.c_str());
     }
-std::cerr<<"HEY MY BEAM SIZE IS "<<beam_size<<"\n";
 
     string time_limit_str = get_env_variable("HL_AUTO_SCHEDULE_TIME_LIMIT");
     double time_limit = 0;

--- a/apps/autoscheduler/Makefile
+++ b/apps/autoscheduler/Makefile
@@ -13,7 +13,7 @@ $(BIN)/demo.generator: demo_generator.cpp $(GENERATOR_DEPS)
 
 # To use the autoscheduler, set a few environment variables and use the -p flag to the generator to load the autoscheduler as a plugin
 $(BIN)/demo.a: $(BIN)/demo.generator $(AUTOSCHED_BIN)/libauto_schedule.so
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=weights \
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
 	$(BIN)/demo.generator -g demo -o $(BIN) -f demo target=$(HL_TARGET) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/demo.rungen: $(BIN)/RunGenMain.o $(BIN)/demo.registration.cpp $(BIN)/demo.a
@@ -30,7 +30,7 @@ autotune: $(BIN)/demo.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BIN)
 		$(BIN)/demo.generator \
 		demo \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)
 
 # Simple jit-based test
@@ -38,7 +38,7 @@ $(BIN)/test: test.cpp $(AUTOSCHED_BIN)/libauto_schedule.so
 	$(CXX) $(CXXFLAGS) $(USE_EXPORT_DYNAMIC) $< -o $@ $(LDFLAGS) $(LIB_HALIDE) $(HALIDE_SYSTEM_LIBS)
 
 test: $(BIN)/test
-	HL_WEIGHTS_DIR=weights LD_LIBRARY_PATH=$(BIN) $(BIN)/test
+	HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) LD_LIBRARY_PATH=$(BIN) $(BIN)/test
 
 clean:
 	rm -rf $(BIN)

--- a/apps/autoscheduler/cross_compile_everything.sh
+++ b/apps/autoscheduler/cross_compile_everything.sh
@@ -27,23 +27,23 @@ echo Using target ${HL_TARGET}
 
 # APPDIR;GENERATOR;SUBDIR;MANUAL;SUFFIX
 declare -a INFO=( \
-  "bgu;fit_and_slice_3x4;;" \
-  "bilateral_grid;bilateral_grid;;" \
-  "blur;halide_blur;${TARG}/;;" \
-  "burst_camera_pipe;burst_camera_pipe;;" \
-  "camera_pipe;camera_pipe;;" \
-  "conv_layer;conv_layer;;" \
-  "harris;harris;;" \
-  "hist;hist;;" \
-  "iir_blur_generator;iir_blur;;" \
-  "interpolate_generator;interpolate;;" \
-  "lens_blur;lens_blur;;" \
-  "local_laplacian;local_laplacian;;" \
-  "mat_mul_generator;mat_mul;;" \
-  "max_filter;max_filter;;" \
-  "nl_means;nl_means;;" \
-  "stencil_chain;stencil_chain;;" \
-  "unsharp;unsharp;;" \
+  # "bgu;fit_and_slice_3x4;;" \
+  # "bilateral_grid;bilateral_grid;;" \
+  # "blur;halide_blur;${TARG}/;;" \
+  # "burst_camera_pipe;burst_camera_pipe;;" \
+  # "camera_pipe;camera_pipe;;" \
+  # "conv_layer;conv_layer;;" \
+  # "harris;harris;;" \
+  # "hist;hist;;" \
+  # "iir_blur_generator;iir_blur;;" \
+  # "interpolate_generator;interpolate;;" \
+  # "lens_blur;lens_blur;;" \
+  # "local_laplacian;local_laplacian;;" \
+  # "mat_mul_generator;mat_mul;;" \
+  # "max_filter;max_filter;;" \
+  # "nl_means;nl_means;;" \
+  # "stencil_chain;stencil_chain;;" \
+  # "unsharp;unsharp;;" \
 )
 
 for i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
@@ -91,6 +91,14 @@ if [ "$1" = "generate" ]; then
         IFS=';' read -r -a fields <<< "${i}"
 
         APPDIR=${fields[0]}
+
+        rm -rf ${APPS_DIR}/${APPDIR}/bin ${APPS_DIR}/${APPDIR}/bin1
+    done
+
+    for i in ${INFO[@]}; do
+        IFS=';' read -r -a fields <<< "${i}"
+
+        APPDIR=${fields[0]}
         GENERATOR=${fields[1]}
         if [ ${#fields[@]} -le 2 ]; then
             SUBDIR=
@@ -110,8 +118,6 @@ if [ "$1" = "generate" ]; then
 
         mkdir -p ${DST_DIR}/${APPDIR}
         cd ${APPS_DIR}/${APPDIR}
-
-        rm -rf bin bin1
 
         wait_for_core
         # This is synchronous; must be sure it's build before firing off the invocations,

--- a/apps/autoscheduler/cross_compile_everything.sh
+++ b/apps/autoscheduler/cross_compile_everything.sh
@@ -25,6 +25,11 @@ TARG=${HL_TARGET:=arm-64-linux}
 
 echo Using target ${HL_TARGET}
 
+cd ${APPS_DIR}/autoscheduler
+
+# Make this first so subtasks won't get into contention over it
+make ../autoscheduler/bin/libauto_schedule.so
+
 # APPDIR;GENERATOR;SUBDIR;MANUAL;SUFFIX
 declare -a INFO=( \
   "bgu;fit_and_slice_3x4;;" \
@@ -69,11 +74,6 @@ if [ "$1" = "generate" ]; then
 
     echo Generating to ${DST_DIR}...
     mkdir -p ${DST_DIR}
-
-    cd ${APPS_DIR}/autoscheduler
-
-    # Make this first so subtasks won't get into contention over it
-    make ../autoscheduler/bin/libauto_schedule.so
 
     wait_for_core()
     {
@@ -188,9 +188,11 @@ elif [ "$1" = "reassemble" ]; then
         IFS=';' read -r -a fields <<< "${i}"
 
         APPDIR=${fields[0]}
+        GENERATOR=${fields[1]}
 
         rm -rf ${APPS_DIR}/${APPDIR}/bin
         mkdir -p ${APPS_DIR}/${APPDIR}/bin
+        touch ${APPS_DIR}/${APPDIR}/bin/${GENERATOR}.generator
     done
 
     for i in ${INFO[@]}; do
@@ -219,6 +221,7 @@ elif [ "$1" = "reassemble" ]; then
         cp ${SRC_DIR}/${APPDIR}/${GENERATOR}_classic_auto_schedule${SUFFIX}.{a,h,registration.cpp} ${DST_DIR}/
         cp ${SRC_DIR}/${APPDIR}/${GENERATOR}_beamsize${BEAMSIZE}_auto_schedule${SUFFIX}.{a,h,registration.cpp} ${DST_DIR}/
         for f in ${DST_DIR}/${GENERATOR}_beamsize${BEAMSIZE}_auto_schedule${SUFFIX}.*; do mv "$f" "${f/_beamsize${BEAMSIZE}_auto_schedule/_auto_schedule}"; done
+        touch ${DST_DIR}/*.{a,h,registration.cpp}
     done
 
 else

--- a/apps/autoscheduler/cross_compile_everything.sh
+++ b/apps/autoscheduler/cross_compile_everything.sh
@@ -27,23 +27,23 @@ echo Using target ${HL_TARGET}
 
 # APPDIR;GENERATOR;SUBDIR;MANUAL;SUFFIX
 declare -a INFO=( \
-  # "bgu;fit_and_slice_3x4;;" \
-  # "bilateral_grid;bilateral_grid;;" \
-  # "blur;halide_blur;${TARG}/;;" \
-  # "burst_camera_pipe;burst_camera_pipe;;" \
-  # "camera_pipe;camera_pipe;;" \
-  # "conv_layer;conv_layer;;" \
-  # "harris;harris;;" \
-  # "hist;hist;;" \
-  # "iir_blur_generator;iir_blur;;" \
-  # "interpolate_generator;interpolate;;" \
-  # "lens_blur;lens_blur;;" \
-  # "local_laplacian;local_laplacian;;" \
-  # "mat_mul_generator;mat_mul;;" \
-  # "max_filter;max_filter;;" \
-  # "nl_means;nl_means;;" \
-  # "stencil_chain;stencil_chain;;" \
-  # "unsharp;unsharp;;" \
+  "bgu;fit_and_slice_3x4;;" \
+  "bilateral_grid;bilateral_grid;;" \
+  "blur;halide_blur;${TARG}/;;" \
+  "burst_camera_pipe;burst_camera_pipe;;" \
+  "camera_pipe;camera_pipe;;" \
+  "conv_layer;conv_layer;;" \
+  "harris;harris;;" \
+  "hist;hist;;" \
+  "iir_blur_generator;iir_blur;;" \
+  "interpolate_generator;interpolate;;" \
+  "lens_blur;lens_blur;;" \
+  "local_laplacian;local_laplacian;;" \
+  "mat_mul_generator;mat_mul;;" \
+  "max_filter;max_filter;;" \
+  "nl_means;nl_means;;" \
+  "stencil_chain;stencil_chain;;" \
+  "unsharp;unsharp;;" \
 )
 
 for i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
@@ -93,6 +93,8 @@ if [ "$1" = "generate" ]; then
         APPDIR=${fields[0]}
 
         rm -rf ${APPS_DIR}/${APPDIR}/bin ${APPS_DIR}/${APPDIR}/bin1
+        mkdir -p ${APPS_DIR}/${APPDIR}/bin
+        mkdir -p ${APPS_DIR}/${APPDIR}/bin1
     done
 
     for i in ${INFO[@]}; do
@@ -117,6 +119,7 @@ if [ "$1" = "generate" ]; then
         fi
 
         mkdir -p ${DST_DIR}/${APPDIR}
+
         cd ${APPS_DIR}/${APPDIR}
 
         wait_for_core
@@ -124,8 +127,7 @@ if [ "$1" = "generate" ]; then
         # to avoid bg task contention
         echo Building ${APPDIR}/${GENERATOR}.generator...
         BIN=bin HL_TARGET=arm-64-linux make bin/${GENERATOR}.generator &> /dev/null
-        mkdir bin1
-        cp bin/${GENERATOR}.generator bin1/
+        cp --no-clobber bin/${GENERATOR}.generator bin1/
 
         wait_for_core
         echo Starting ${APPDIR}/${GENERATOR}${SUFFIX} 1...

--- a/apps/autoscheduler/cross_compile_everything.sh
+++ b/apps/autoscheduler/cross_compile_everything.sh
@@ -188,6 +188,15 @@ elif [ "$1" = "reassemble" ]; then
         IFS=';' read -r -a fields <<< "${i}"
 
         APPDIR=${fields[0]}
+
+        rm -rf ${APPS_DIR}/${APPDIR}/bin
+        mkdir -p ${APPS_DIR}/${APPDIR}/bin
+    done
+
+    for i in ${INFO[@]}; do
+        IFS=';' read -r -a fields <<< "${i}"
+
+        APPDIR=${fields[0]}
         GENERATOR=${fields[1]}
         if [ ${#fields[@]} -le 2 ]; then
             SUBDIR=
@@ -206,12 +215,10 @@ elif [ "$1" = "reassemble" ]; then
         fi
 
         DST_DIR=${APPS_DIR}/${APPDIR}/bin
-        rm -rf ${DST_DIR}
-        mkdir -p ${DST_DIR}
         cp ${SRC_DIR}/${APPDIR}/${GENERATOR}${MANUAL}${SUFFIX}*.{a,h,registration.cpp} ${DST_DIR}/
-        cp ${SRC_DIR}/${APPDIR}/${GENERATOR}_classic_auto_schedule${SUFFIX}.{a,h,registration.cpp} ${SCRIPT_DIR}/${APPDIR}/
-        cp ${SRC_DIR}/${APPDIR}/${GENERATOR}_beamsize${BEAMSIZE}_auto_schedule${SUFFIX}.{a,h,registration.cpp} ${DST_DIR}/${APPDIR}/
-        for f in ${DST_DIR}/${APPDIR}/_auto_schedule${SUFFIX}.*; do echo mv "$f" "${f/_beamsize${BEAMSIZE}_auto_schedule/_auto_schedule}"; done
+        cp ${SRC_DIR}/${APPDIR}/${GENERATOR}_classic_auto_schedule${SUFFIX}.{a,h,registration.cpp} ${DST_DIR}/
+        cp ${SRC_DIR}/${APPDIR}/${GENERATOR}_beamsize${BEAMSIZE}_auto_schedule${SUFFIX}.{a,h,registration.cpp} ${DST_DIR}/
+        for f in ${DST_DIR}/${GENERATOR}_beamsize${BEAMSIZE}_auto_schedule${SUFFIX}.*; do mv "$f" "${f/_beamsize${BEAMSIZE}_auto_schedule/_auto_schedule}"; done
     done
 
 else

--- a/apps/autoscheduler/cross_compile_everything.sh
+++ b/apps/autoscheduler/cross_compile_everything.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+
+# crosscompile all autotuned apps for arm-64-linux
+# autoscheduled get two variants, beamsize=1 and beamsize=32
+#
+# results are placed in bin/crosscompiled/*
+
+set -eu
+
+usage()
+{
+    echo "Usage: cross_compile_everything.sh generate [/path/to/output]"
+    echo "       cross_compile_everything.sh reassemble 32|1 [/path/to/input]"
+}
+
+if [ $# -eq 0 ]; then
+    usage
+    exit 1
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+APPS_DIR=${SCRIPT_DIR}/..
+
+TARG=${HL_TARGET:=arm-64-linux}
+
+echo Using target ${HL_TARGET}
+
+# APPDIR;GENERATOR;SUBDIR;MANUAL;SUFFIX
+declare -a INFO=( \
+  "bgu;fit_and_slice_3x4;;" \
+  "bilateral_grid;bilateral_grid;;" \
+  "blur;halide_blur;${TARG}/;;" \
+  "burst_camera_pipe;burst_camera_pipe;;" \
+  "camera_pipe;camera_pipe;;" \
+  "conv_layer;conv_layer;;" \
+  "harris;harris;;" \
+  "hist;hist;;" \
+  "iir_blur_generator;iir_blur;;" \
+  "interpolate_generator;interpolate;;" \
+  "lens_blur;lens_blur;;" \
+  "local_laplacian;local_laplacian;;" \
+  "mat_mul_generator;mat_mul;;" \
+  "max_filter;max_filter;;" \
+  "nl_means;nl_means;;" \
+  "stencil_chain;stencil_chain;;" \
+  "unsharp;unsharp;;" \
+)
+
+for i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+    INFO+=("resnet_50;resnet50block;;_manual;$i")
+done
+
+if [ "$1" = "generate" ]; then
+
+    export AUTOSCHED_WEIGHTS_DIR=${SCRIPT_DIR}/arm_weights
+
+    if [ $(uname -s) = "Darwin" ]; then
+        LOCAL_CORES=`sysctl -n hw.ncpu`
+    else
+        LOCAL_CORES=`nproc`
+    fi
+    echo Local number of cores detected as ${LOCAL_CORES}
+
+    if [ $# -ge 2 ]; then
+        DST_DIR=$2
+    else
+        DST_DIR=${SCRIPT_DIR}/bin/crosscompiled
+    fi
+
+    echo Generating to ${DST_DIR}...
+    mkdir -p ${DST_DIR}
+
+    cd ${APPS_DIR}/autoscheduler
+
+    # Make this first so subtasks won't get into contention over it
+    make ../autoscheduler/bin/libauto_schedule.so
+
+    wait_for_core()
+    {
+        while [[ 1 ]]; do
+            RUNNING=$(jobs -r | wc -l)
+            if [[ RUNNING -ge LOCAL_CORES ]]; then
+                sleep 1
+            else
+                break
+            fi
+        done
+    }
+
+    for i in ${INFO[@]}; do
+        IFS=';' read -r -a fields <<< "${i}"
+
+        APPDIR=${fields[0]}
+        GENERATOR=${fields[1]}
+        if [ ${#fields[@]} -le 2 ]; then
+            SUBDIR=
+        else
+            SUBDIR=${fields[2]}
+        fi
+        if [ ${#fields[@]} -le 3 ]; then
+            MANUAL=
+        else
+            MANUAL=${fields[3]}
+        fi
+        if [ ${#fields[@]} -le 4 ]; then
+            SUFFIX=
+        else
+            SUFFIX=${fields[4]}
+        fi
+
+        mkdir -p ${DST_DIR}/${APPDIR}
+        cd ${APPS_DIR}/${APPDIR}
+
+        rm -rf bin bin1
+
+        wait_for_core
+        # This is synchronous; must be sure it's build before firing off the invocations,
+        # to avoid bg task contention
+        echo Building ${APPDIR}/${GENERATOR}.generator...
+        BIN=bin HL_TARGET=arm-64-linux make bin/${GENERATOR}.generator &> /dev/null
+        mkdir bin1
+        cp bin/${GENERATOR}.generator bin/1
+
+        wait_for_core
+        echo Starting ${APPDIR}/${GENERATOR}${SUFFIX} 1...
+        BIN=bin HL_TARGET=arm-64-linux make bin/${SUBDIR}${GENERATOR}${MANUAL}${SUFFIX}.a &> /dev/null && \
+            echo Finishing ${APPDIR}/${GENERATOR} 1... && \
+            mv bin/${SUBDIR}${GENERATOR}${MANUAL}${SUFFIX}*.{a,h,registration.cpp} ${DST_DIR}/${APPDIR}/ &
+
+        wait_for_core
+        echo Starting ${APPDIR}/${GENERATOR}${SUFFIX} 2...
+        BIN=bin HL_TARGET=arm-64-linux make bin/${SUBDIR}${GENERATOR}_classic_auto_schedule${SUFFIX}.a &> /dev/null && \
+            echo Finishing ${APPDIR}/${GENERATOR} 2... && \
+            mv bin/${SUBDIR}${GENERATOR}_classic_auto_schedule${SUFFIX}.{a,h,registration.cpp} ${DST_DIR}/${APPDIR}/ &
+
+        # Emit beamsize=32 into normal bin, rename afterward
+        wait_for_core
+        echo Starting ${APPDIR}/${GENERATOR}${SUFFIX} 3...
+        BIN=bin HL_BEAM_SIZE=32 HL_TARGET=arm-64-linux make bin/${SUBDIR}${GENERATOR}_auto_schedule${SUFFIX}.a &> /dev/null && \
+            for f in bin/${SUBDIR}${GENERATOR}_auto_schedule${SUFFIX}.*; do mv "$f" "${f/_auto_schedule/_beamsize32_auto_schedule}"; done && \
+            echo Finishing ${APPDIR}/${GENERATOR} 3... && \
+            mv bin/${SUBDIR}${GENERATOR}_beamsize32_auto_schedule${SUFFIX}.{a,h,registration.cpp} ${DST_DIR}/${APPDIR}/ &
+
+        # Emit beamsize=1 into bin1, rename afterward
+        wait_for_core
+        echo Starting ${APPDIR}/${GENERATOR}${SUFFIX} 4...
+        BIN=bin1 HL_BEAM_SIZE=1 HL_TARGET=arm-64-linux make bin1/${SUBDIR}${GENERATOR}_auto_schedule${SUFFIX}.a &> /dev/null && \
+            for f in bin1/${SUBDIR}${GENERATOR}_auto_schedule${SUFFIX}.*; do mv "$f" "${f/_auto_schedule/_beamsize1_auto_schedule}"; done && \
+            echo Finishing ${APPDIR}/${GENERATOR} 4... && \
+            mv bin1/${SUBDIR}${GENERATOR}_beamsize1_auto_schedule${SUFFIX}.{a,h,registration.cpp} ${DST_DIR}/${APPDIR}/ &
+
+    done
+
+    wait
+
+    echo Done.
+
+elif [ "$1" = "reassemble" ]; then
+
+    if [ $# -ge 2 ]; then
+        BEAMSIZE=$2
+    else
+        usage
+        exit 1
+    fi
+
+    if [ $BEAMSIZE -ne 1 -a $BEAMSIZE -ne 32 ]; then
+        usage
+        exit 1
+    fi
+
+    if [ $# -ge 3 ]; then
+        SRC_DIR=$3
+    else
+        SRC_DIR=${SCRIPT_DIR}/bin/crosscompiled
+    fi
+    echo Reassembling from ${SRC_DIR}...
+
+    for i in ${INFO[@]}; do
+        IFS=';' read -r -a fields <<< "${i}"
+
+        APPDIR=${fields[0]}
+        GENERATOR=${fields[1]}
+        if [ ${#fields[@]} -le 2 ]; then
+            SUBDIR=
+        else
+            SUBDIR=${fields[2]}
+        fi
+        if [ ${#fields[@]} -le 3 ]; then
+            MANUAL=
+        else
+            MANUAL=${fields[3]}
+        fi
+        if [ ${#fields[@]} -le 4 ]; then
+            SUFFIX=
+        else
+            SUFFIX=${fields[4]}
+        fi
+
+        DST_DIR=${APPS_DIR}/${APPDIR}/bin
+        rm -rf ${DST_DIR}
+        mkdir -p ${DST_DIR}
+        cp ${SRC_DIR}/${APPDIR}/${GENERATOR}${MANUAL}${SUFFIX}*.{a,h,registration.cpp} ${DST_DIR}/
+        cp ${SRC_DIR}/${APPDIR}/${GENERATOR}_classic_auto_schedule${SUFFIX}.{a,h,registration.cpp} ${SCRIPT_DIR}/${APPDIR}/
+        cp ${SRC_DIR}/${APPDIR}/${GENERATOR}_beamsize${BEAMSIZE}_auto_schedule${SUFFIX}.{a,h,registration.cpp} ${DST_DIR}/${APPDIR}/
+        for f in ${DST_DIR}/${APPDIR}/_auto_schedule${SUFFIX}.*; do echo mv "$f" "${f/_beamsize${BEAMSIZE}_auto_schedule/_auto_schedule}"; done
+    done
+
+else
+    usage
+    exit 1
+fi
+

--- a/apps/autoscheduler/cross_compile_everything.sh
+++ b/apps/autoscheduler/cross_compile_everything.sh
@@ -119,7 +119,7 @@ if [ "$1" = "generate" ]; then
         echo Building ${APPDIR}/${GENERATOR}.generator...
         BIN=bin HL_TARGET=arm-64-linux make bin/${GENERATOR}.generator &> /dev/null
         mkdir bin1
-        cp bin/${GENERATOR}.generator bin/1
+        cp bin/${GENERATOR}.generator bin1/
 
         wait_for_core
         echo Starting ${APPDIR}/${GENERATOR}${SUFFIX} 1...

--- a/apps/autoscheduler/cross_compile_everything.sh
+++ b/apps/autoscheduler/cross_compile_everything.sh
@@ -127,7 +127,7 @@ if [ "$1" = "generate" ]; then
         # to avoid bg task contention
         echo Building ${APPDIR}/${GENERATOR}.generator...
         BIN=bin HL_TARGET=arm-64-linux make bin/${GENERATOR}.generator &> /dev/null
-        cp --no-clobber bin/${GENERATOR}.generator bin1/
+        cp -n bin/${GENERATOR}.generator bin1/
 
         wait_for_core
         echo Starting ${APPDIR}/${GENERATOR}${SUFFIX} 1...

--- a/apps/bgu/Makefile
+++ b/apps/bgu/Makefile
@@ -17,7 +17,7 @@ $(BIN)/fit_and_slice_3x4_classic_auto_schedule.a: $(BIN)/fit_and_slice_3x4.gener
 
 $(BIN)/fit_and_slice_3x4_auto_schedule.a: $(BIN)/fit_and_slice_3x4.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
 	$< -g fit_and_slice_3x4 -f fit_and_slice_3x4_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/process: process.cpp $(BIN)/fit_and_slice_3x4.a $(BIN)/fit_and_slice_3x4_auto_schedule.a $(BIN)/fit_and_slice_3x4_classic_auto_schedule.a
@@ -35,5 +35,5 @@ autotune: $(BIN)/fit_and_slice_3x4.generator $(AUTOSCHED_BIN)/augment_sample $(A
 		$(BIN)/fit_and_slice_3x4.generator \
 		fit_and_slice_3x4 \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -13,12 +13,12 @@ $(BIN)/bilateral_grid.a: $(BIN)/bilateral_grid.generator
 
 $(BIN)/bilateral_grid_classic_auto_schedule.a: $(BIN)/bilateral_grid.generator
 	@mkdir -p $(@D)
-	$< -g bilateral_grid -o $(BIN) -f bilateral_grid_classic_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true machine_params=$(HL_MACHINE_PARAMS) -e static_library,h,schedule
+	$< -g bilateral_grid -o $(BIN) -f bilateral_grid_classic_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true machine_params=$(HL_MACHINE_PARAMS) -e static_library,h,schedule,registration
 
 $(BIN)/bilateral_grid_auto_schedule.a: $(BIN)/bilateral_grid.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
-	$< -g bilateral_grid -o $(BIN) -f bilateral_grid_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so -e static_library,h,schedule
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
+	$< -g bilateral_grid -o $(BIN) -f bilateral_grid_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so -e static_library,h,schedule,registration
 
 $(BIN)/viz/bilateral_grid.a: $(BIN)/bilateral_grid.generator
 	@mkdir -p $(@D)
@@ -67,5 +67,5 @@ autotune: $(BIN)/bilateral_grid.generator $(AUTOSCHED_BIN)/augment_sample $(AUTO
 		$(BIN)/bilateral_grid.generator \
 		bilateral_grid \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)

--- a/apps/blur/Makefile
+++ b/apps/blur/Makefile
@@ -17,7 +17,7 @@ $(BIN)/%/halide_blur_classic_auto_schedule.a: $(BIN)/halide_blur.generator $(AUT
 
 $(BIN)/%/halide_blur_auto_schedule.a: $(BIN)/halide_blur.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
 	$< -g halide_blur -f halide_blur_auto_schedule -o $(BIN)/$* target=$(HL_TARGET) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 # g++ on OS X might actually be system clang without openmp
@@ -44,5 +44,5 @@ autotune: $(BIN)/halide_blur.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCH
 		$(BIN)/halide_blur.generator \
 		halide_blur \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)

--- a/apps/burst_camera_pipe/Makefile
+++ b/apps/burst_camera_pipe/Makefile
@@ -22,7 +22,7 @@ $(BIN)/burst_camera_pipe_classic_auto_schedule.a: $(BIN)/burst_camera_pipe.gener
 
 $(BIN)/burst_camera_pipe_auto_schedule.a: $(BIN)/burst_camera_pipe.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
 	$< -g burst_camera_pipe -f burst_camera_pipe_auto_schedule -o $(BIN) target=$(HL_TARGET_LARGE) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/process: process.cpp $(BIN)/burst_camera_pipe.a $(BIN)/burst_camera_pipe_classic_auto_schedule.a $(BIN)/burst_camera_pipe_auto_schedule.a
@@ -40,5 +40,5 @@ autotune: $(BIN)/burst_camera_pipe.generator $(AUTOSCHED_BIN)/augment_sample $(A
 		$(BIN)/burst_camera_pipe.generator \
 		burst_camera_pipe \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -11,7 +11,7 @@ $(BIN)/camera_pipe.generator: camera_pipe_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/camera_pipe.a: $(BIN)/camera_pipe.generator
 	@mkdir -p $(@D)
-	$< -g camera_pipe -o $(BIN) -f camera_pipe target=$(HL_TARGET) auto_schedule=false -e static_library,h,assembly,stmt
+	$< -g camera_pipe -o $(BIN) -f camera_pipe target=$(HL_TARGET) auto_schedule=false -e static_library,h,assembly,stmt,registration
 
 # TODO: this fails with an internal_assert failure in the classic AutoScheduler.
 # $(BIN)/camera_pipe_classic_auto_schedule.a: $(BIN)/camera_pipe.generator
@@ -20,8 +20,8 @@ $(BIN)/camera_pipe.a: $(BIN)/camera_pipe.generator
 
 $(BIN)/camera_pipe_auto_schedule.a: $(BIN)/camera_pipe.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
-	$< -g camera_pipe -o $(BIN) -f camera_pipe_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so -e static_library,h,assembly,stmt
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
+	$< -g camera_pipe -o $(BIN) -f camera_pipe_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so -e static_library,h,assembly,stmt,registration
 
 $(BIN)/viz/camera_pipe.a: $(BIN)/camera_pipe.generator
 	@mkdir -p $(@D)
@@ -62,5 +62,5 @@ autotune: $(BIN)/camera_pipe.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCH
 		$(BIN)/camera_pipe.generator \
 		camera_pipe \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)

--- a/apps/conv_layer/Makefile
+++ b/apps/conv_layer/Makefile
@@ -19,7 +19,7 @@ $(BIN)/conv_layer_classic_auto_schedule.a: $(BIN)/conv_layer.generator $(AUTOSCH
 
 $(BIN)/conv_layer_auto_schedule.a: $(BIN)/conv_layer.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
 	$< -g conv_layer -f conv_layer_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/process: process.cpp $(BIN)/conv_layer.a $(BIN)/conv_layer_auto_schedule.a $(BIN)/conv_layer_classic_auto_schedule.a
@@ -40,5 +40,5 @@ autotune: $(BIN)/conv_layer.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHE
 		$(BIN)/conv_layer.generator \
 		conv_layer \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)

--- a/apps/harris/Makefile
+++ b/apps/harris/Makefile
@@ -17,7 +17,7 @@ $(BIN)/harris_classic_auto_schedule.a: $(BIN)/harris.generator $(AUTOSCHED_BIN)/
 
 $(BIN)/harris_auto_schedule.a: $(BIN)/harris.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
 	$< -g harris -f harris_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/filter: filter.cpp $(BIN)/harris.a $(BIN)/harris_auto_schedule.a $(BIN)/harris_classic_auto_schedule.a
@@ -35,5 +35,5 @@ autotune: $(BIN)/harris.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BI
 		$(BIN)/harris.generator \
 		harris \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)

--- a/apps/hist/Makefile
+++ b/apps/hist/Makefile
@@ -17,7 +17,7 @@ $(BIN)/hist_classic_auto_schedule.a: $(BIN)/hist.generator $(AUTOSCHED_BIN)/liba
 
 $(BIN)/hist_auto_schedule.a: $(BIN)/hist.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
 	$< -g hist -f hist_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/filter: filter.cpp $(BIN)/hist.a $(BIN)/hist_auto_schedule.a $(BIN)/hist_classic_auto_schedule.a
@@ -35,6 +35,6 @@ autotune: $(BIN)/hist.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BIN)
 		$(BIN)/hist.generator \
 		hist \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)
 

--- a/apps/iir_blur_generator/Makefile
+++ b/apps/iir_blur_generator/Makefile
@@ -17,7 +17,7 @@ $(BIN)/iir_blur_classic_auto_schedule.a: $(BIN)/iir_blur.generator $(AUTOSCHED_B
 
 $(BIN)/iir_blur_auto_schedule.a: $(BIN)/iir_blur.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
 	$< -g iir_blur -f iir_blur_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/process: process.cpp $(BIN)/iir_blur.a $(BIN)/iir_blur_auto_schedule.a $(BIN)/iir_blur_classic_auto_schedule.a
@@ -35,5 +35,5 @@ autotune: $(BIN)/iir_blur.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_
 		$(BIN)/iir_blur.generator \
 		iir_blur \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)

--- a/apps/interpolate_generator/Makefile
+++ b/apps/interpolate_generator/Makefile
@@ -17,7 +17,7 @@ $(BIN)/interpolate_classic_auto_schedule.a: $(BIN)/interpolate.generator $(AUTOS
 
 $(BIN)/interpolate_auto_schedule.a: $(BIN)/interpolate.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
 	$< -g interpolate -f interpolate_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/filter: filter.cpp $(BIN)/interpolate.a $(BIN)/interpolate_auto_schedule.a $(BIN)/interpolate_classic_auto_schedule.a
@@ -35,5 +35,5 @@ autotune: $(BIN)/interpolate.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCH
 		$(BIN)/interpolate.generator \
 		interpolate \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)

--- a/apps/lens_blur/Makefile
+++ b/apps/lens_blur/Makefile
@@ -19,8 +19,8 @@ $(BIN)/lens_blur_classic_auto_schedule.a: $(BIN)/lens_blur.generator
 
 $(BIN)/lens_blur_auto_schedule.a: $(BIN)/lens_blur.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@-mkdir -p $(BIN)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
-	$< -g lens_blur -o $(BIN) -f lens_blur_auto_schedule target=$(HL_TARGET)-large_buffers-no_runtime auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so -e static_library,h,assembly,stmt
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
+	$< -g lens_blur -o $(BIN) -f lens_blur_auto_schedule target=$(HL_TARGET)-large_buffers-no_runtime auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so -e static_library,h,assembly,stmt,registration
 
 $(BIN)/process: process.cpp $(BIN)/lens_blur.a $(BIN)/lens_blur_classic_auto_schedule.a $(BIN)/lens_blur_auto_schedule.a
 	@-mkdir -p $(BIN)
@@ -40,5 +40,5 @@ autotune: $(BIN)/lens_blur.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED
 		$(BIN)/lens_blur.generator \
 		lens_blur \
 		x86-64-avx2-large_buffers \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -19,8 +19,8 @@ $(BIN)/local_laplacian_classic_auto_schedule.a: $(BIN)/local_laplacian.generator
 
 $(BIN)/local_laplacian_auto_schedule.a: $(BIN)/local_laplacian.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
-	$< -g local_laplacian -o $(BIN) -f local_laplacian_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so -e static_library,h,s,stmt
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
+	$< -g local_laplacian -o $(BIN) -f local_laplacian_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so -e static_library,h,s,stmt,registration
 
 $(BIN)/process: process.cpp $(BIN)/local_laplacian.a $(BIN)/local_laplacian_classic_auto_schedule.a $(BIN)/local_laplacian_auto_schedule.a
 	@mkdir -p $(@D)
@@ -70,5 +70,5 @@ autotune: $(BIN)/local_laplacian.generator $(AUTOSCHED_BIN)/augment_sample $(AUT
 		$(BIN)/local_laplacian.generator \
 		local_laplacian \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)

--- a/apps/mat_mul_generator/Makefile
+++ b/apps/mat_mul_generator/Makefile
@@ -17,7 +17,7 @@ $(BIN)/mat_mul_classic_auto_schedule.a: $(BIN)/mat_mul.generator $(AUTOSCHED_BIN
 
 $(BIN)/mat_mul_auto_schedule.a: $(BIN)/mat_mul.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
 	$< -g mat_mul -f mat_mul_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/filter: filter.cpp $(BIN)/mat_mul.a $(BIN)/mat_mul_auto_schedule.a $(BIN)/mat_mul_classic_auto_schedule.a
@@ -35,5 +35,5 @@ autotune: $(BIN)/mat_mul.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_B
 		$(BIN)/mat_mul.generator \
 		mat_mul \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)

--- a/apps/max_filter/Makefile
+++ b/apps/max_filter/Makefile
@@ -17,7 +17,7 @@ $(BIN)/max_filter_classic_auto_schedule.a: $(BIN)/max_filter.generator
 
 $(BIN)/max_filter_auto_schedule.a: $(BIN)/max_filter.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
 	$< -g max_filter -f max_filter_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/filter: filter.cpp $(BIN)/max_filter.a $(BIN)/max_filter_auto_schedule.a $(BIN)/max_filter_classic_auto_schedule.a
@@ -35,5 +35,5 @@ autotune: $(BIN)/max_filter.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHE
 		$(BIN)/max_filter.generator \
 		max_filter \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)

--- a/apps/nl_means/Makefile
+++ b/apps/nl_means/Makefile
@@ -19,7 +19,7 @@ $(BIN)/nl_means_classic_auto_schedule.a: $(BIN)/nl_means.generator
 
 $(BIN)/nl_means_auto_schedule.a: $(BIN)/nl_means.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@-mkdir -p $(BIN)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
 	$< -g nl_means -o $(BIN) -f nl_means_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/process: process.cpp $(BIN)/nl_means.a $(BIN)/nl_means_classic_auto_schedule.a $(BIN)/nl_means_auto_schedule.a
@@ -40,5 +40,5 @@ autotune: $(BIN)/nl_means.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_
 		$(BIN)/nl_means.generator \
 		nl_means \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)

--- a/apps/resnet_50/Makefile
+++ b/apps/resnet_50/Makefile
@@ -12,7 +12,7 @@ $(BIN)/resnet50block.generator: Resnet50BlockGenerator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/resnet50block_manual%.a: $(BIN)/resnet50block.generator
 	@mkdir -p $(@D)
-	$(BIN)/resnet50block.generator -g resnet50block -o $(BIN) -e static_library,h,stmt -f resnet50block_manual$* target=$(HL_TARGET) auto_schedule=false block_id=$*
+	$(BIN)/resnet50block.generator -g resnet50block -o $(BIN) -e static_library,h,stmt,registration -f resnet50block_manual$* target=$(HL_TARGET) auto_schedule=false block_id=$*
 
 $(BIN)/resnet50block_classic_auto_schedule%.a: $(BIN)/resnet50block.generator
 	@mkdir -p $(@D)
@@ -21,7 +21,7 @@ $(BIN)/resnet50block_classic_auto_schedule%.a: $(BIN)/resnet50block.generator
 # To use the autoscheduler, set a few environment variables and use the -p flag to the generator to load the autoscheduler as a plugin
 $(BIN)/resnet50block_auto_schedule%.a: $(BIN)/resnet50block.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
 	$(BIN)/resnet50block.generator -g resnet50block -o $(BIN) -f resnet50block_auto_schedule$* target=$(HL_TARGET) auto_schedule=true block_id=$* -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/pytorch_weights/ok:
@@ -57,6 +57,6 @@ autotune: $(BIN)/resnet50block.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOS
 		$(BIN)/resnet50block.generator \
 		resnet50block \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN) \
 		"${AUTOTUNE_ARG_SETS}"

--- a/apps/stencil_chain/Makefile
+++ b/apps/stencil_chain/Makefile
@@ -19,8 +19,8 @@ $(BIN)/stencil_chain_classic_auto_schedule.a: $(BIN)/stencil_chain.generator
 
 $(BIN)/stencil_chain_auto_schedule.a: $(BIN)/stencil_chain.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights HL_PERMIT_FAILED_UNROLL=1 \
-	$< -g stencil_chain -o $(BIN) -f stencil_chain_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so -e stmt,assembly,static_library,h
+	HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) HL_PERMIT_FAILED_UNROLL=1 \
+	$< -g stencil_chain -o $(BIN) -f stencil_chain_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so -e stmt,assembly,static_library,h,registration
 
 $(BIN)/process: process.cpp $(BIN)/stencil_chain.a $(BIN)/stencil_chain_classic_auto_schedule.a $(BIN)/stencil_chain_auto_schedule.a
 	@mkdir -p $(@D)
@@ -40,5 +40,5 @@ autotune: $(BIN)/stencil_chain.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOS
 		$(BIN)/stencil_chain.generator \
 		stencil_chain \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)

--- a/apps/support/autoscheduler.inc
+++ b/apps/support/autoscheduler.inc
@@ -1,6 +1,8 @@
 AUTOSCHED_SRC ?= ../autoscheduler
 AUTOSCHED_BIN ?= $(AUTOSCHED_SRC)/bin
 
+AUTOSCHED_WEIGHTS_DIR ?= $(AUTOSCHED_SRC)/weights
+
 AUTOSCHED_WEIGHT_OBJECTS=\
 $(AUTOSCHED_BIN)/weights_head1_conv1_weight.o \
 $(AUTOSCHED_BIN)/weights_head1_conv1_bias.o \
@@ -17,7 +19,7 @@ $(AUTOSCHED_BIN)/binary2cpp: ../../tools/binary2cpp.cpp
 
 $(AUTOSCHED_BIN)/weights_%.cpp: $(AUTOSCHED_BIN)/binary2cpp
 	@mkdir -p $(@D)
-	$(AUTOSCHED_BIN)/binary2cpp weights_$* < $(AUTOSCHED_SRC)/weights/$*.data > $@
+	$(AUTOSCHED_BIN)/binary2cpp weights_$* < $(AUTOSCHED_WEIGHTS_DIR)/$*.data > $@
 
 $(AUTOSCHED_BIN)/weights_%.o: $(AUTOSCHED_BIN)/weights_%.cpp
 	$(CXX) -c $< -o $@
@@ -39,11 +41,11 @@ $(AUTOSCHED_BIN)/cost_model.generator: $(AUTOSCHED_SRC)/cost_model_generator.cpp
 
 $(AUTOSCHED_BIN)/auto_schedule_runtime.a: $(AUTOSCHED_BIN)/cost_model.generator
 	@mkdir -p $(@D)
-	$^ -r auto_schedule_runtime -o $(AUTOSCHED_BIN) target=$(HL_TARGET)
+	$^ -r auto_schedule_runtime -o $(AUTOSCHED_BIN) target=host
 
 $(AUTOSCHED_BIN)/cost_model/%.a: $(AUTOSCHED_BIN)/cost_model.generator
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 $^ -g $* -o $(AUTOSCHED_BIN)/cost_model -f $* target=$(HL_TARGET)-no_runtime auto_schedule=false -e stmt,static_library,h,assembly
+	HL_PERMIT_FAILED_UNROLL=1 $^ -g $* -o $(AUTOSCHED_BIN)/cost_model -f $* target=host-no_runtime auto_schedule=false -e stmt,static_library,h,assembly
 
 # It's important to use dynamic lookups for undefined symbols here: all of libHalide
 # is expected to be present (in the loading binary), so we explicitly make the symbols

--- a/apps/unsharp/Makefile
+++ b/apps/unsharp/Makefile
@@ -17,7 +17,7 @@ $(BIN)/unsharp_classic_auto_schedule.a: $(BIN)/unsharp.generator $(AUTOSCHED_BIN
 
 $(BIN)/unsharp_auto_schedule.a: $(BIN)/unsharp.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/weights \
+	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_WEIGHTS_DIR) \
 	$< -g unsharp -f unsharp_auto_schedule -o $(BIN) target=$(HL_TARGET) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/filter: filter.cpp $(BIN)/unsharp.a $(BIN)/unsharp_auto_schedule.a $(BIN)/unsharp_classic_auto_schedule.a
@@ -36,5 +36,5 @@ autotune: $(BIN)/unsharp.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_B
 		$(BIN)/unsharp.generator \
 		unsharp \
 		x86-64-avx2 \
-		$(AUTOSCHED_SRC)/weights \
+		$(AUTOSCHED_WEIGHTS_DIR) \
 		$(AUTOSCHED_BIN)


### PR DESCRIPTION
Still doing some torture testing but this should be right: use `cross_compile_everything generate` to produce all the .a files to a specific dir, then (on the dest machine) use `cross_compile_everything reassemble` to copy the .a files to the correct bins. (Then you can `make test` as usual.)