### PR TITLE
Add handling of absd() in Bounds.cpp

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -960,6 +960,11 @@ private:
                 b.accept(this);
                 Interval b_interval = interval;
 
+                a_interval.min = simplify(a_interval.min);
+                a_interval.max = simplify(a_interval.max);
+                b_interval.min = simplify(b_interval.min);
+                b_interval.max = simplify(b_interval.max);
+
                 if (a_interval.is_bounded() && b_interval.is_bounded()) {
                     // Cast to 64-bit type to minimize cast-out-of-range issues;
                     // edge cases if the type is 64-bit in the first place are still


### PR DESCRIPTION
Formerly this defaulted to bounds-of-type, but that meant that widened expressions never attempted to use the known bounds of the narrow types (e.g. absd(i16(a), i16(b)) would assume [0,65535] even if a and b are known to be i8)

Also, drive-by addition of some debugging infrastructure for Bounds, disabled by default (ala EXPR_MUTATIONS in SImplify)