### PR TITLE
Add handling of absd() in Bounds.cpp

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -960,6 +960,11 @@ private:
                 b.accept(this);
                 Interval b_interval = interval;
 
+                a_interval.min = simplify(a_interval.min);
+                a_interval.max = simplify(a_interval.max);
+                b_interval.min = simplify(b_interval.min);
+                b_interval.max = simplify(b_interval.max);
+
                 if (a_interval.is_bounded() && b_interval.is_bounded()) {
                     // Cast to 64-bit type to minimize cast-out-of-range issues;
                     // edge cases if the type is 64-bit in the first place are still

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -974,10 +974,8 @@ private:
                 // absd() for int types will always produce a uint result
                 internal_assert(t.is_uint());
 
-                // Recover what the matched types for the args were
                 Expr a = op->args[0];
                 Expr b = op->args[1];
-                match_types(a, b);
                 internal_assert(a.type() == b.type());
 
                 a.accept(this);
@@ -986,19 +984,9 @@ private:
                 b.accept(this);
                 Interval b_interval = interval;
 
-                a_interval.min = simplify(a_interval.min);
-                a_interval.max = simplify(a_interval.max);
-                b_interval.min = simplify(b_interval.min);
-                b_interval.max = simplify(b_interval.max);
-
                 if (a_interval.is_bounded() && b_interval.is_bounded()) {
-                    // Cast to 64-bit type to minimize cast-out-of-range issues;
-                    // edge cases if the type is 64-bit in the first place are still
-                    // possible but we can live with those.
-                    Type wide_t = a.type().is_int() ? Int(64) : UInt(64);
-                    interval.max = cast(t, max(cast(wide_t, a_interval.max) - cast(wide_t, b_interval.min),
-                                           cast(wide_t, b_interval.max) - cast(wide_t, a_interval.min)));
                     interval.min = make_zero(t);
+                    interval.max = max(absd(a_interval.max, b_interval.min), absd(a_interval.min, b_interval.max));
                 } else {
                     bounds_of_type(t);
                 }

--- a/test/correctness/fuzz_simplify.cpp
+++ b/test/correctness/fuzz_simplify.cpp
@@ -91,6 +91,12 @@ Expr random_condition(Type T, int depth, bool maybe_scalar) {
     return make_bin_op[op](a, b);
 }
 
+Expr make_absd(Expr a, Expr b) {
+    // random_expr() assumes that the result type is the same as the input type,
+    // which isn't true for all absd variants, so force the issue.
+    return cast(a.type(), absd(a, b));
+}
+
 Expr random_expr(Type T, int depth, bool overflow_undef) {
     typedef Expr (*make_bin_op_fn)(Expr, Expr);
     static make_bin_op_fn make_bin_op[] = {
@@ -101,6 +107,7 @@ Expr random_expr(Type T, int depth, bool overflow_undef) {
         Max::make,
         Div::make,
         Mod::make,
+        make_absd
      };
 
     static make_bin_op_fn make_bool_bin_op[] = {


### PR DESCRIPTION
Formerly this defaulted to bounds-of-type, but that meant that widened expressions never attempted to use the known bounds of the narrow types (e.g. absd(i16(a), i16(b)) would assume [0,65535] even if a and b are known to be i8)

Also, drive-by addition of some debugging infrastructure for Bounds, disabled by default (ala EXPR_MUTATIONS in Simplify)
