### PR TITLE
Print llvm -time-passes statstics when JIT or AOT compile an LLVM module

### DIFF
--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -47,6 +47,9 @@
 #if LLVM_VERSION >= 90
 #include <llvm/Transforms/Instrumentation/ThreadSanitizer.h>
 #endif
+#if LLVM_VERSION >= 80
+#include <llvm/IR/PassTimingInfo.h>
+#endif
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -377,6 +377,10 @@ void emit_file(const llvm::Module &module_in, Internal::LLVMOStream& out, llvm::
 #endif
 
     pass_manager.run(*module);
+    // If -time-passes is in HL_LLVM_ARGS, this will print llvm passes time statstics otherwise its no-op.
+#if LLVM_VERSION >= 80
+    llvm::reportAndResetTimings();
+#endif
 }
 
 std::unique_ptr<llvm::Module> compile_module_to_llvm_module(const Module &module, llvm::LLVMContext &context) {


### PR DESCRIPTION
Print out LLVM passes timing statistics results when passing -time-passes to HL_LLVM_ARGS. If -time-passes isn't passed to cl::ParseCommandLineOptions this is no-op.