### PR TITLE
Block asserts into switch statements 

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -3719,12 +3719,77 @@ void CodeGen_LLVM::visit(const Store *op) {
             }
         }
     }
+}
 
+void CodeGen_LLVM::codegen_asserts(const vector<const AssertStmt *> &asserts) {
+    if (asserts.size() < 4) {
+        for (const auto *a : asserts) {
+            codegen(Stmt(a));
+        }
+        return;
+    }
+
+    // Mix all the conditions together into a bitmask
+
+    /*
+    Expr combined_condition = const_true();
+    Stmt body = Evaluate::make(0);
+    for (const auto *a : asserts) {
+        combined_condition = combined_condition && a->condition;
+        // Jam no-ops in between to stop this from happening recursively
+        body = Block::make(a, body);
+        body = Block::make(Evaluate::make(0), body);
+    }
+    combined_condition = simplify(common_subexpression_elimination(combined_condition));
+
+    // For now just use a parallel loop to get the body off into a separate function.
+    Stmt equiv = IfThenElse::make(!combined_condition, For::make(unique_name('t'), 0, 1, ForType::Parallel, DeviceAPI::Host, body));
+
+    debug(0) << equiv << "\n";
+    codegen(equiv);
+    */
+
+    internal_assert(asserts.size() <= 63);
+
+    Expr bitmask = cast<uint64_t>(1) << 63;
+    for (size_t i = 0; i < asserts.size(); i++) {
+        bitmask = bitmask | (cast<uint64_t>(!asserts[i]->condition) << i);
+    }
+
+    Expr switch_case = count_trailing_zeros(bitmask);
+
+    BasicBlock *no_errors_bb = BasicBlock::Create(*context, "no_errors_bb", function);
+
+    // Now switch on the bitmask to the correct failure
+    Expr case_idx = cast<int32_t>(count_trailing_zeros(bitmask));
+    auto *switch_inst = builder->CreateSwitch(codegen(case_idx), no_errors_bb, asserts.size(), very_likely_branch);
+    for (int i = 0; i < (int)asserts.size(); i++) {
+        BasicBlock *fail_bb = BasicBlock::Create(*context, "assert_failed", function);
+        switch_inst->addCase(ConstantInt::get(IntegerType::get(*context, 32), i), fail_bb);
+        builder->SetInsertPoint(fail_bb);
+        Value *v = codegen(asserts[i]->message);
+        builder->CreateRet(v);
+    }
+    builder->SetInsertPoint(no_errors_bb);
 }
 
 void CodeGen_LLVM::visit(const Block *op) {
-    codegen(op->first);
-    codegen(op->rest);
+    // Peel blocks of assertions with pure conditions
+    const AssertStmt *a = op->first.as<AssertStmt>();
+    if (a && is_pure(a->condition)) {
+        vector<const AssertStmt *> asserts;
+        asserts.push_back(a);
+        Stmt s = op->rest;
+        while ((op = s.as<Block>()) && (a = op->first.as<AssertStmt>()) && is_pure(a->condition) && asserts.size() < 63) {
+            asserts.push_back(a);
+            s = op->rest;
+        }
+        codegen_asserts(asserts);
+        codegen(s);
+    } else {
+        codegen(op->first);
+        codegen(op->rest);
+    }
 }
 
 void CodeGen_LLVM::visit(const Realize *op) {

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -261,6 +261,9 @@ protected:
     void create_assertion(llvm::Value *condition, Expr message, llvm::Value *error_code = nullptr);
     // @}
 
+    /** Codegen a block of asserts with pure conditions */
+    void codegen_asserts(const std::vector<const AssertStmt *> &asserts);
+
     /** Codegen a call to do_parallel_tasks */
     struct ParallelTask {
         Stmt body;


### PR DESCRIPTION
Moving buffer asserts into switch statements  blocks seems significantly speed up register allocation and coalescing. This reduces compile opt-pass time for resnet50 (autoschedule_with_convnets branch) from 268.5848 sec to 15 sec. 

$ run_performance_lots_of_inputs 
Before:
```
Compile time with 1 inputs = 0.534758 s
Compile time with 2 inputs = 0.078090 s
Compile time with 4 inputs = 0.113272 s                                                                            
Compile time with 8 inputs = 0.194721 s                                                                           
Compile time with 16 inputs = 0.401624 s                                                                             
Compile time with 32 inputs = 0.940241 s                                                                          
Compile time with 64 inputs = 2.707179 s                                                                             
Compile time with 128 inputs = 8.599611 s

```
$ run_performance_lots_of_inputs
After:
```
Compile time with 1 inputs = 0.523519 s
Compile time with 2 inputs = 0.083440 s
Compile time with 4 inputs = 0.125427 s
Compile time with 8 inputs = 0.258036 s
Compile time with 16 inputs = 0.487263 s
Compile time with 32 inputs = 1.036269 s
Compile time with 64 inputs = 2.339884 s
Compile time with 128 inputs = 5.862377 s
```

Resnet50 compile time before : 

```
===-------------------------------------------------------------------------===                                       
                      ... Pass execution timing report ...                                                             
===-------------------------------------------------------------------------===                                        
  Total Execution Time: 268.5848 seconds (270.2123 wall clock)                                                         
                                                                                                                       
   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---                                 
  224.7175 ( 84.1%)   0.6710 ( 50.7%)  225.3886 ( 83.9%)  226.9213 ( 84.0%)  Simple Register Coalescing                
  15.1290 (  5.7%)   0.2711 ( 20.5%)  15.4001 (  5.7%)  15.4697 (  5.7%)  Greedy Register Allocator


```
Resnet50 compile time after : 


```
===-------------------------------------------------------------------------===
                      ... Pass execution timing report ...
===-------------------------------------------------------------------------===
  Total Execution Time: 15.8371 seconds (15.8704 wall clock)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
   1.9074 ( 12.2%)   0.0634 ( 24.9%)   1.9708 ( 12.4%)   1.9764 ( 12.5%)  Greedy Register Allocator

```