### PR TITLE
Print Hexagon modules as pointers

### DIFF
--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -214,7 +214,7 @@ WEAK int halide_hexagon_initialize_kernels(void *user_context, void **state_ptr,
         result = remote_load_library(soname, sizeof(soname), runtime, runtime_size, &shared_runtime);
         poll_log(user_context);
         if (result == 0) {
-            debug(user_context) << "        " << shared_runtime << "\n";
+            debug(user_context) << "        " << (void *)(size_t)shared_runtime << "\n";
             halide_assert(user_context, shared_runtime != 0);
         } else {
             debug(user_context) << "        " << result << "\n";
@@ -222,7 +222,7 @@ WEAK int halide_hexagon_initialize_kernels(void *user_context, void **state_ptr,
             shared_runtime = 0;
         }
     } else {
-        debug(user_context) << "    re-using existing shared runtime " << shared_runtime << "\n";
+        debug(user_context) << "    re-using existing shared runtime " << (void *)(size_t)shared_runtime << "\n";
     }
 
     if (result != 0) {
@@ -249,14 +249,14 @@ WEAK int halide_hexagon_initialize_kernels(void *user_context, void **state_ptr,
         result = remote_load_library(soname.str(), soname.size() + 1, code, code_size, &module);
         poll_log(user_context);
         if (result == 0) {
-            debug(user_context) << "        " << module << "\n";
+            debug(user_context) << "        " << (void *)(size_t)module << "\n";
             (*state)->module = module;
         } else {
             debug(user_context) << "        " << result << "\n";
             error(user_context) << "Initialization of Hexagon kernels failed\n";
         }
     } else {
-        debug(user_context) << "    re-using existing module " << (*state)->module << "\n";
+        debug(user_context) << "    re-using existing module " << (void *)(size_t)(*state)->module << "\n";
     }
 
     #ifdef DEBUG_RUNTIME


### PR DESCRIPTION
This PR prints the module returned by the Hexagon remote side as pointers. This gives the base address of the module loaded in hexagon memory, which is useful for some debugging tools. Halide only cares about this value as a unique identifier, so this change doesn't matter much otherwise. Example output:

    Hexagon: halide_hexagon_initialize_kernels (user_context: 0x7ffd47314308, state_ptr: 0x7f49a1831000, *state_ptr: 0x0, code: 0x7f49a1832000, code_size: 12808), code: 0x7f49a1835220, code_size: 53848)
        Initializing shared runtime
        halide_remote_load_library(libhalide_shared_runtime.so) ->         0x658f0
        allocating module state -> 
            0x564ade1c4c70
        halide_remote_load_library(libhalide_kernels0.so) ->         0x83a68