### PR TITLE
Fix simplification of Halide::is_nan (Issue #3624)

### DIFF
--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -214,11 +214,11 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
             return absd(a, b);
         }
     } else if (op->call_type == Call::PureExtern &&
-               op->name == "is_nan_f32") {
+               (op->name == "is_nan_f16" || op->name == "is_nan_f32" || op->name == "is_nan_f64")) {
         Expr arg = mutate(op->args[0], nullptr);
         double f = 0.0;
         if (const_float(arg, &f)) {
-            return std::isnan(f);
+            return make_bool(std::isnan(f));
         } else if (arg.same_as(op->args[0])) {
             return op;
         } else {

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1535,6 +1535,17 @@ int main(int argc, char **argv) {
         check(require(x == x, result, "error"), result);
     }
 
+    // Check that is_nan() returns a boolean result for constant inputs
+    {
+        check(Halide::is_nan(cast<float16_t>(Expr(0.f))), const_false());
+        check(Halide::is_nan(Expr(0.f)), const_false());
+        check(Halide::is_nan(Expr(0.0)), const_false());
+
+        check(Halide::is_nan(Expr(cast<float16_t>(std::nanf("1")))), const_true());
+        check(Halide::is_nan(Expr(std::nanf("1"))), const_true());
+        check(Halide::is_nan(Expr(std::nan("1"))), const_true());
+    }
+
     printf("Success!\n");
 
     return 0;


### PR DESCRIPTION
- only float32 was handled
- return type for constants was int but should be bool