### PR TITLE
Partial revert of #3612

### DIFF
--- a/src/Inline.cpp
+++ b/src/Inline.cpp
@@ -154,7 +154,9 @@ class Inliner : public IRMutator {
         ScopedValue<int> old_found(found, 0);
         Stmt stmt = IRMutator::visit(op);
 
-        if (found > 1) {
+        // TODO: making this > 1 should be desirable,
+        // but explodes compiletimes in some situations.
+        if (found > 0) {
             stmt = common_subexpression_elimination(stmt);
         }
 
@@ -180,7 +182,9 @@ Stmt inline_function(Stmt s, Function f) {
 Expr inline_function(Expr e, Function f) {
     Inliner i(f);
     e = i.mutate(e);
-    if (i.found > 1) {
+    // TODO: making this > 1 should be desirable,
+    // but explodes compiletimes in some situations.
+    if (i.found > 0) {
         e = common_subexpression_elimination(e);
     }
     return e;


### PR DESCRIPTION
For reasons that aren't yet clear, this change causes some pipelines inside Google to explode in compiletime (so much so that they timeout and never complete). Would like to revert and re-examine the change in more detail before re-landing.

