### PR TITLE
Improve failure mode for Simplify(Div)

### DIFF
--- a/src/Simplify_Div.cpp
+++ b/src/Simplify_Div.cpp
@@ -25,7 +25,17 @@ Expr Simplify::visit(const Div *op, ExprInfo *bounds) {
             // denominator can sometimes collapse things to a
             // constant at this point.
             if (bounds->min == bounds->max) {
-                return make_const(op->type, bounds->min);
+                if (op->type.can_represent(bounds->min)) {
+                    return make_const(op->type, bounds->min);
+                } else {
+                    // Even though this is 'no-overflow-int', if the result
+                    // we calculate can't fit into the destination type,
+                    // we're better off returning an overflow condition than
+                    // a known-wrong value. (Note that no_overflow_int() should
+                    // only be true for signed integers.)
+                    internal_assert(op->type.is_int());
+                    return make_signed_integer_overflow(op->type);
+                }
             }
         }
         bounds->alignment = a_bounds.alignment / b_bounds.alignment;


### PR DESCRIPTION
There's a path in Simplify(Div) that checks for collapsing a bounded numerator by a constant(ish) denominator, and if the result has a single-point boundary, returns that as the constant value; however, it doesn't verify that the constant value actually fits into the result type, so you can get int64 values that are simply truncated to int32 results. This PR proposes to check for this and return signed_integer_overflow() in these cases.

I'm actually a little unsure as to whether this is the right thing or not: on the one hand, this path only occurs for `no_overflow_int` types, so it's arguable that the existing behavior is just fine; that said, I'd argue that if we can trivially detect and prove that an overflow will always occur, we're better off indicating it clearly rather than returning an arbitrary value. (I suppose it depends on whether `signed_integer_overflow` is expected to be in the legal set of values for a no-overflow-int, which is not entirely clear to me.)

(The motivation for this change is as a cheap way to detect a set of overflow conditions in bounds_of_expr_in_scope(), which was being addressed in a more heavyweight way in PR#3599.)

(On a related note: I was actually quite surprised to find that `make_const()` didn't do a `can_represent()` check internally; I presume this must be deliberate?)