### PR TITLE
Fix possible n^2 arg evaluation in Bounds::visit(Call)

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -919,22 +919,6 @@ private:
             return;
         }
 
-        // If the args are const we can return the call of those args
-        // for pure functions. For other types of functions, the same
-        // call in two different places might produce different
-        // results (e.g. during the update step of a reduction), so we
-        // can't move around call nodes.
-        std::vector<Expr> new_args(op->args.size());
-        bool const_args = true;
-        for (size_t i = 0; i < op->args.size() && const_args; i++) {
-            op->args[i].accept(this);
-            if (interval.is_single_point()) {
-                new_args[i] = interval.min;
-            } else {
-                const_args = false;
-            }
-        }
-
         Type t = op->type.element_of();
 
         if (t.is_handle()) {
@@ -942,14 +926,32 @@ private:
             return;
         }
 
-        if (const_args &&
-            !const_bound &&
-            (op->call_type == Call::PureExtern ||
-             op->call_type == Call::Image)) {
+        std::vector<Expr> new_args;  // Lazily computed only if needed
+        const auto has_const_args = [this, op](std::vector<Expr> *new_args) -> bool {
+            // If the args are const we can return the call of those args
+            // for pure functions. For other types of functions, the same
+            // call in two different places might produce different
+            // results (e.g. during the update step of a reduction), so we
+            // can't move around call nodes.
+            new_args->resize(op->args.size());
+            for (size_t i = 0; i < op->args.size(); i++) {
+                op->args[i].accept(this);
+                if (!interval.is_single_point()) {
+                    return false;
+                }
+                (*new_args)[i] = interval.min;
+            }
+            return true;
+        };
+
+        if (!const_bound &&
+            (op->call_type == Call::PureExtern || op->call_type == Call::Image) &&
+            has_const_args(&new_args)) {
             Expr call = Call::make(t, op->name, new_args, op->call_type,
                                    op->func, op->value_index, op->image, op->param);
             interval = Interval::single_point(call);
         } else if (op->is_intrinsic(Call::abs)) {
+            op->args[0].accept(this);
             Interval a = interval;
             interval.min = make_zero(t);
             if (a.is_bounded()) {
@@ -2749,6 +2751,32 @@ void bounds_test() {
     internal_assert(equal(simplify(r2[0].max), 19));
 
     boxes_touched_test();
+
+    // Check a deeply-nested bitwise expr to ensure it doesn't take n^2 time
+    // (this clause took ~30s on a typical laptop before the fix, ~10ms after)
+    {
+        using ConciseCasts::u8;
+        using ConciseCasts::u16;
+
+        Expr a = Variable::make(UInt(16), "t42");
+        Expr b = Variable::make(UInt(16), "t43");
+        Expr c = Variable::make(UInt(16), "t44");
+        Expr d = Variable::make(Int(32), "d");
+        Expr x = Variable::make(Int(32), "x");
+        Expr y = Variable::make(Int(32), "y");
+        Expr one_u8 = Expr((uint8_t) 1);
+        Expr one_u16 = Expr((uint16_t) 1);
+        Expr zero_u16 = Expr((uint16_t) 0);
+        Expr e1 = select(c >= Expr((uint16_t) 128), c - Expr((uint16_t) 128), c);
+        Expr e2 = Let::make("t44", (((((((((((((((((zero_u16 << one_u16) | u16((u8(d) & one_u8))) << one_u16)
+            | u16(((u8(d) >> one_u8) & one_u8))) << one_u16) | (u16(x) & one_u16)) << one_u16)
+            | (u16(y) & one_u16)) << one_u16) | (a & one_u16)) << one_u16) | (b & one_u16)) << one_u16)
+            | ((a >> one_u16) & one_u16)) << one_u16) | ((b >> one_u16) & one_u16)) >> one_u16), e1);
+        Expr e3 = Let::make("t43", u16(y) >> one_u16, e2);
+        Expr e4 = Let::make("t42", u16(x) >> one_u16, e3);
+
+        check_constant_bound(e4, make_const(UInt(16), 0), make_const(UInt(16), 65535));
+    }
 
     std::cout << "Bounds test passed" << std::endl;
 }


### PR DESCRIPTION
We could evaluate the args redundantly, due to the eager calculation of `new_args` in case it's a pure function call; for a deeply-nested Expr, this could end up with a meaningfully n^2 delay. We never noticed this before because the main candidates to be deeply nested were bitwise ops (which were previously eagerly simplified). Fortunately, fix is simple: rearrange the `new_args` calculation to be done only if we know the other criteria for a possible PureExtern/Image function are satisfied.