### PR TITLE
Extend registration mechanism to be extensible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1526,10 +1526,10 @@ $(FILTERS_DIR)/registration_test: $(ROOT_DIR)/test/generator/registration_test.c
 			$(FILTERS_DIR)/blur2x2.registration_extra.o \
 			$(FILTERS_DIR)/cxx_mangling.registration_extra.o \
 			$(FILTERS_DIR)/pyramid.registration_extra.o \
-			$(BIN_DIR)/$(TARGET)/runtime.a \
 			$(FILTERS_DIR)/blur2x2.a \
 			$(FILTERS_DIR)/cxx_mangling.a \
 			$(FILTERS_DIR)/pyramid.a \
+      $(BIN_DIR)/$(TARGET)/runtime.a \
 			$(GEN_AOT_LD_FLAGS) $(IMAGE_IO_LIBS) -o $@
 
 # Test RunGen itself

--- a/Makefile
+++ b/Makefile
@@ -1066,7 +1066,7 @@ GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/tiled_blur.rungen,$(
 GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/extern_output.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))
 GENERATOR_BUILD_RUNGEN_TESTS := $(GENERATOR_BUILD_RUNGEN_TESTS) \
 	$(FILTERS_DIR)/multi_rungen \
-	$(FILTERS_DIR)/multi_rungen2
+	$(FILTERS_DIR)/multi_rungen2 \
 	$(FILTERS_DIR)/rungen_test \
 	$(FILTERS_DIR)/registration_test
 

--- a/Makefile
+++ b/Makefile
@@ -1064,7 +1064,12 @@ GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/nested_externs.runge
 GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/old_buffer_t.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))
 GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/tiled_blur.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))
 GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/extern_output.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))
-GENERATOR_BUILD_RUNGEN_TESTS := $(GENERATOR_BUILD_RUNGEN_TESTS) $(FILTERS_DIR)/multi_rungen $(FILTERS_DIR)/multi_rungen2 $(FILTERS_DIR)/rungen_test $(FILTERS_DIR)/registration_test
+GENERATOR_BUILD_RUNGEN_TESTS := $(GENERATOR_BUILD_RUNGEN_TESTS) \
+	$(FILTERS_DIR)/multi_rungen \
+	$(FILTERS_DIR)/multi_rungen2
+	$(FILTERS_DIR)/rungen_test \
+	$(FILTERS_DIR)/registration_test
+
 test_rungen: $(GENERATOR_BUILD_RUNGEN_TESTS)
 	$(FILTERS_DIR)/rungen_test
 	$(FILTERS_DIR)/registration_test

--- a/Makefile
+++ b/Makefile
@@ -1515,11 +1515,11 @@ $(FILTERS_DIR)/%.run: $(FILTERS_DIR)/%.rungen
 
 $(FILTERS_DIR)/%.registration_extra.o: $(FILTERS_DIR)/%.registration.cpp
 	@mkdir -p $(@D)
-	$(CXX) -c $< $(TEST_CXX_FLAGS) -DHL_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC=halide_register_extra_key_value_pairs_$* -o $@
+	$(CXX) -c $< $(TEST_CXX_FLAGS) -DHALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC=halide_register_extra_key_value_pairs_$* -o $@
 
 # Test the registration mechanism, independent of RunGen.
 # Note that this depends on the registration_extra.o (rather than registration.o)
-# because it compiles with HL_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC defined.
+# because it compiles with HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC defined.
 $(FILTERS_DIR)/registration_test: $(ROOT_DIR)/test/generator/registration_test.cpp \
 														 $(BIN_DIR)/$(TARGET)/runtime.a \
 														 $(FILTERS_DIR)/blur2x2.registration_extra.o $(FILTERS_DIR)/blur2x2.a \

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -111,6 +111,7 @@ Outputs add_suffixes(const Outputs &in, const std::string &suffix) {
     if (!in.stmt_html_name.empty()) out.stmt_html_name = add_suffix(in.stmt_html_name, suffix);
     if (!in.schedule_name.empty()) out.schedule_name = add_suffix(in.schedule_name, suffix);
     if (!in.registration_name.empty()) out.registration_name = add_suffix(in.registration_name, suffix);
+
     return out;
 }
 
@@ -141,7 +142,8 @@ extern "C" {
 struct halide_filter_metadata_t;
 void halide_register_argv_and_metadata(
     int (*filter_argv_call)(void **),
-    const struct halide_filter_metadata_t *filter_metadata
+    const struct halide_filter_metadata_t *filter_metadata,
+    const char * const *extra_key_value_pairs
 );
 }
 
@@ -150,11 +152,19 @@ extern int $SHORTNAME$_argv(void **args);
 extern const struct halide_filter_metadata_t *$SHORTNAME$_metadata();
 $NSCLOSE$
 
+#ifdef HL_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
+extern "C" const char * const *HL_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC();
+#endif  // HL_REGISTER_EXTRA_KEY_VALUE_PAIRS
+
 namespace $NREGS$ {
 namespace {
 struct Registerer {
     Registerer() {
-        halide_register_argv_and_metadata(::$FULLNAME$_argv, ::$FULLNAME$_metadata());
+#ifdef HL_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
+        halide_register_argv_and_metadata(::$FULLNAME$_argv, ::$FULLNAME$_metadata(), HL_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC());
+#else
+        halide_register_argv_and_metadata(::$FULLNAME$_argv, ::$FULLNAME$_metadata(), nullptr);
+#endif  // HL_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
     }
 };
 static Registerer registerer;

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -152,19 +152,19 @@ extern int $SHORTNAME$_argv(void **args);
 extern const struct halide_filter_metadata_t *$SHORTNAME$_metadata();
 $NSCLOSE$
 
-#ifdef HL_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
+#ifdef HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
 extern "C" const char * const *HL_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC();
-#endif  // HL_REGISTER_EXTRA_KEY_VALUE_PAIRS
+#endif  // HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
 
 namespace $NREGS$ {
 namespace {
 struct Registerer {
     Registerer() {
-#ifdef HL_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
+#ifdef HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
         halide_register_argv_and_metadata(::$FULLNAME$_argv, ::$FULLNAME$_metadata(), HL_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC());
 #else
         halide_register_argv_and_metadata(::$FULLNAME$_argv, ::$FULLNAME$_metadata(), nullptr);
-#endif  // HL_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
+#endif  // HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
     }
 };
 static Registerer registerer;

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -153,7 +153,7 @@ extern const struct halide_filter_metadata_t *$SHORTNAME$_metadata();
 $NSCLOSE$
 
 #ifdef HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
-extern "C" const char * const *HL_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC();
+extern "C" const char * const *HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC();
 #endif  // HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
 
 namespace $NREGS$ {
@@ -161,7 +161,7 @@ namespace {
 struct Registerer {
     Registerer() {
 #ifdef HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
-        halide_register_argv_and_metadata(::$FULLNAME$_argv, ::$FULLNAME$_metadata(), HL_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC());
+        halide_register_argv_and_metadata(::$FULLNAME$_argv, ::$FULLNAME$_metadata(), HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC());
 #else
         halide_register_argv_and_metadata(::$FULLNAME$_argv, ::$FULLNAME$_metadata(), nullptr);
 #endif  // HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1647,6 +1647,22 @@ struct halide_filter_metadata_t {
     const char* name;
 };
 
+/** halide_register_argv_and_metadata() is a **user-defined** function that
+ * must be provided in order to use the registration.cc files produced
+ * by Generators when the 'registration' output is requested. Each registration.cc
+ * file provides a static initializer that calls this function with the given
+ * filter's argv-call variant, its metadata, and (optionally) and additional
+ * textual data that the build system chooses to tack on for its own purposes.
+ * Note that this will be called at static-initializer time (i.e., before
+ * main() is called), and in an unpredictable order. Note that extra_key_value_pairs
+ * may be nullptr; if it's not null, it's expected to be a null-terminated list
+ * of strings, with an even number of entries. */
+void halide_register_argv_and_metadata(
+    int (*filter_argv_call)(void **),
+    const struct halide_filter_metadata_t *filter_metadata,
+    const char * const *extra_key_value_pairs
+);
+
 /** The functions below here are relevant for pipelines compiled with
  * the -profile target flag, which runs a sampling profiler thread
  * alongside the pipeline. */

--- a/test/generator/registration_test.cpp
+++ b/test/generator/registration_test.cpp
@@ -1,0 +1,90 @@
+#include <iostream>
+#include <map>
+
+#include "HalideRuntime.h"
+
+#include "blur2x2.h"
+#include "cxx_mangling.h"
+#include "pyramid.h"
+
+namespace {
+
+void check(bool b, const char *msg = "Failure!") {
+  if (!b) {
+    std::cerr << msg << "\n";
+    exit(1);
+  }
+}
+
+struct Info {
+    int (*call)(void **);
+    const struct halide_filter_metadata_t *md;
+    const char * const *kv;
+};
+
+std::map<std::string, Info> seen_filters;
+
+extern "C" void halide_register_argv_and_metadata(
+    int (*filter_argv_call)(void **),
+    const struct halide_filter_metadata_t *filter_metadata,
+    const char * const *extra_key_value_pairs) {
+
+    seen_filters[filter_metadata->name] = Info{
+        filter_argv_call,
+        filter_metadata,
+        extra_key_value_pairs
+    };
+}
+
+extern "C" const char * const *halide_register_extra_key_value_pairs_blur2x2() {
+    return nullptr;
+}
+
+extern "C" const char * const *halide_register_extra_key_value_pairs_cxx_mangling() {
+    static const char* const r[4] = {
+        "key1", "value1",
+        nullptr, nullptr
+    };
+    return r;
+}
+
+extern "C" const char * const *halide_register_extra_key_value_pairs_pyramid() {
+    static const char* const r[6] = {
+        "key1", "value1",
+        "key2", "value2",
+        nullptr, nullptr
+    };
+    return r;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+
+  check(seen_filters.size() == 3);
+
+  check(seen_filters["blur2x2"].call == blur2x2_argv);
+  check(seen_filters["blur2x2"].md == blur2x2_metadata());
+  check(seen_filters["blur2x2"].kv == nullptr);
+
+  check(seen_filters["cxx_mangling"].call == HalideTest::AnotherNamespace::cxx_mangling_argv);
+  check(seen_filters["cxx_mangling"].md == HalideTest::AnotherNamespace::cxx_mangling_metadata());
+  check(seen_filters["cxx_mangling"].kv != nullptr);
+  check(seen_filters["cxx_mangling"].kv[0] == std::string("key1"));
+  check(seen_filters["cxx_mangling"].kv[1] == std::string("value1"));
+  check(seen_filters["cxx_mangling"].kv[2] == nullptr);
+  check(seen_filters["cxx_mangling"].kv[3] == nullptr);
+
+  check(seen_filters["pyramid"].call == pyramid_argv);
+  check(seen_filters["pyramid"].md == pyramid_metadata());
+  check(seen_filters["pyramid"].kv != nullptr);
+  check(seen_filters["pyramid"].kv[0] == std::string("key1"));
+  check(seen_filters["pyramid"].kv[1] == std::string("value1"));
+  check(seen_filters["pyramid"].kv[2] == std::string("key2"));
+  check(seen_filters["pyramid"].kv[3] == std::string("value2"));
+  check(seen_filters["pyramid"].kv[4] == nullptr);
+  check(seen_filters["pyramid"].kv[5] == nullptr);
+
+  std::cout << "Success!\n";
+  return 0;
+}

--- a/test/generator/registration_test.cpp
+++ b/test/generator/registration_test.cpp
@@ -22,14 +22,19 @@ struct Info {
     const char * const *kv;
 };
 
-std::map<std::string, Info> seen_filters;
+// We need to access this before main() is called, so use
+// a static initializer to avoid initization-order fiascos
+std::map<std::string, Info>& seen_filters() {
+  static std::map<std::string, Info> m;
+  return m;
+}
 
 extern "C" void halide_register_argv_and_metadata(
     int (*filter_argv_call)(void **),
     const struct halide_filter_metadata_t *filter_metadata,
     const char * const *extra_key_value_pairs) {
 
-    seen_filters[filter_metadata->name] = Info{
+    seen_filters()[filter_metadata->name] = Info{
         filter_argv_call,
         filter_metadata,
         extra_key_value_pairs
@@ -61,29 +66,29 @@ extern "C" const char * const *halide_register_extra_key_value_pairs_pyramid() {
 
 int main(int argc, char **argv) {
 
-  check(seen_filters.size() == 3);
+  check(seen_filters().size() == 3);
 
-  check(seen_filters["blur2x2"].call == blur2x2_argv);
-  check(seen_filters["blur2x2"].md == blur2x2_metadata());
-  check(seen_filters["blur2x2"].kv == nullptr);
+  check(seen_filters()["blur2x2"].call == blur2x2_argv);
+  check(seen_filters()["blur2x2"].md == blur2x2_metadata());
+  check(seen_filters()["blur2x2"].kv == nullptr);
 
-  check(seen_filters["cxx_mangling"].call == HalideTest::AnotherNamespace::cxx_mangling_argv);
-  check(seen_filters["cxx_mangling"].md == HalideTest::AnotherNamespace::cxx_mangling_metadata());
-  check(seen_filters["cxx_mangling"].kv != nullptr);
-  check(seen_filters["cxx_mangling"].kv[0] == std::string("key1"));
-  check(seen_filters["cxx_mangling"].kv[1] == std::string("value1"));
-  check(seen_filters["cxx_mangling"].kv[2] == nullptr);
-  check(seen_filters["cxx_mangling"].kv[3] == nullptr);
+  check(seen_filters()["cxx_mangling"].call == HalideTest::AnotherNamespace::cxx_mangling_argv);
+  check(seen_filters()["cxx_mangling"].md == HalideTest::AnotherNamespace::cxx_mangling_metadata());
+  check(seen_filters()["cxx_mangling"].kv != nullptr);
+  check(seen_filters()["cxx_mangling"].kv[0] == std::string("key1"));
+  check(seen_filters()["cxx_mangling"].kv[1] == std::string("value1"));
+  check(seen_filters()["cxx_mangling"].kv[2] == nullptr);
+  check(seen_filters()["cxx_mangling"].kv[3] == nullptr);
 
-  check(seen_filters["pyramid"].call == pyramid_argv);
-  check(seen_filters["pyramid"].md == pyramid_metadata());
-  check(seen_filters["pyramid"].kv != nullptr);
-  check(seen_filters["pyramid"].kv[0] == std::string("key1"));
-  check(seen_filters["pyramid"].kv[1] == std::string("value1"));
-  check(seen_filters["pyramid"].kv[2] == std::string("key2"));
-  check(seen_filters["pyramid"].kv[3] == std::string("value2"));
-  check(seen_filters["pyramid"].kv[4] == nullptr);
-  check(seen_filters["pyramid"].kv[5] == nullptr);
+  check(seen_filters()["pyramid"].call == pyramid_argv);
+  check(seen_filters()["pyramid"].md == pyramid_metadata());
+  check(seen_filters()["pyramid"].kv != nullptr);
+  check(seen_filters()["pyramid"].kv[0] == std::string("key1"));
+  check(seen_filters()["pyramid"].kv[1] == std::string("value1"));
+  check(seen_filters()["pyramid"].kv[2] == std::string("key2"));
+  check(seen_filters()["pyramid"].kv[3] == std::string("value2"));
+  check(seen_filters()["pyramid"].kv[4] == nullptr);
+  check(seen_filters()["pyramid"].kv[5] == nullptr);
 
   std::cout << "Success!\n";
   return 0;

--- a/test/generator/rungen_test.cpp
+++ b/test/generator/rungen_test.cpp
@@ -17,10 +17,12 @@ void check(bool b, const char *msg = "Failure!") {
 
 extern "C" void halide_register_argv_and_metadata(
     int (*filter_argv_call)(void **),
-    const struct halide_filter_metadata_t *filter_metadata) {
+    const struct halide_filter_metadata_t *filter_metadata,
+    const char * const *extra_key_value_pairs) {
 
     check(filter_argv_call == example_argv);
     check(filter_metadata == example_metadata());
+    check(extra_key_value_pairs == nullptr);
 }
 
 namespace {

--- a/tools/RunGenMain.cpp
+++ b/tools/RunGenMain.cpp
@@ -15,12 +15,14 @@ RegisteredFilter *registered_filters = nullptr;
 
 extern "C" void halide_register_argv_and_metadata(
     int (*filter_argv_call)(void **),
-    const struct halide_filter_metadata_t *filter_metadata) {
+    const struct halide_filter_metadata_t *filter_metadata,
+    const char * const *extra_key_value_pairs) {
 
     auto *rf = new RegisteredFilter();
     rf->next = registered_filters;
     rf->filter_argv_call = filter_argv_call;
     rf->filter_metadata = filter_metadata;
+    // RunGen ignores extra_key_value_pairs
     registered_filters = rf;
 }
 


### PR DESCRIPTION
This extends the registration mechanism for AOT-Generators to allow for a build system to add arbitrary additional text as part of the `halide_register_argv_and_metadata` call.