### PR TITLE
Bounds for shift_right with signed-ints was incorrect

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1055,11 +1055,31 @@ private:
                             equiv.accept(this);
                         }
                     } else if (op->is_intrinsic(Call::shift_right)) {
-                        if (a_interval.has_lower_bound() && b_interval.has_upper_bound()) {
-                            interval.min = a_interval.min >> b_interval.max;
-                        }
-                        if (a_interval.has_upper_bound() && b_interval.has_lower_bound()) {
-                            interval.max = a_interval.max >> b_interval.min;
+                        // shift_right(a, b) is UB for b < 0, so only try to improve on bounds-of-type
+                        // if we can prove b >= 0.
+                        if (b_interval.is_bounded() && (t.is_uint() || can_prove(b_interval.min >= 0))) {
+                            if (a_interval.has_lower_bound()) {
+                                if (t.is_uint() || can_prove(a_interval.min >= 0)) {
+                                    interval.min = a_interval.min >> b_interval.max;
+                                } else {
+                                    // if a < 0, the smallest value will be a >> b.min
+                                    // if a > 0, the smallest value will be a >> b.max
+                                    interval.min = a_interval.min >> select(a_interval.min < 0,
+                                                                            b_interval.min,
+                                                                            b_interval.max);
+                                }
+                            }
+                            if (a_interval.has_upper_bound()) {
+                                if (t.is_uint() || can_prove(a_interval.max >= 0)) {
+                                    interval.max = a_interval.max >> b_interval.min;
+                                } else {
+                                    // if a < 0, the largest value will be a >> b.max
+                                    // if a > 0, the largest value will be a >> b.min
+                                    interval.max = a_interval.max >> select(a_interval.max < 0,
+                                                                            b_interval.max,
+                                                                            b_interval.min);
+                                }
+                            }
                         }
                     } else if (op->is_intrinsic(Call::bitwise_and) &&
                                a_interval.has_upper_bound() &&
@@ -2477,6 +2497,11 @@ void check_constant_bound(Expr e, Expr correct_min, Expr correct_max) {
 }
 
 void constant_bound_test() {
+    {
+        Param<int16_t> a, b;
+        check_constant_bound(a >> b, make_const(Int(16), -32768), make_const(Int(16), 32767));
+    }
+
     {
         Param<int> x("x"), y("y");
         x.set_range(10, 20);

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1073,7 +1073,7 @@ private:
                                 } else {
                                     // if a < 0, the largest value will be a >> b.max
                                     // if a > 0, the largest value will be a >> b.min
-                                    interval.min = min(a_interval.max >> b_interval.max, a_interval.max >> b_interval.min);
+                                    interval.max = min(a_interval.max >> b_interval.max, a_interval.max >> b_interval.min);
                                 }
                             }
                         }

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1074,7 +1074,7 @@ private:
                                 } else {
                                     // if a < 0, the largest value will be a >> b.max
                                     // if a > 0, the largest value will be a >> b.min
-                                    interval.max = min(a_interval.max >> b_interval.max,
+                                    interval.max = max(a_interval.max >> b_interval.max,
                                                        a_interval.max >> b_interval.min);
                                 }
                             }
@@ -2744,11 +2744,10 @@ void bounds_test() {
     }
 
     {
-        Param<uint16_t> x("x"), y("y");
-        x.set_range(make_const(UInt(16), 16), make_const(UInt(16), 32));
-        y.set_range(make_const(UInt(16), 0), make_const(UInt(16), 4));
-
-        check_constant_bound((x >> y), make_const(UInt(16), 1), make_const(UInt(16), 32));
+        Param<int16_t> x("x"), y("y");
+        x.set_range(make_const(Int(16), -32), make_const(Int(16), -16));
+        y.set_range(make_const(Int(16), 0), make_const(Int(16), 4));
+        check_constant_bound((x >> y), make_const(Int(16), -32), make_const(Int(16), -1));
     }
 
     {

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1064,7 +1064,8 @@ private:
                                 } else {
                                     // if a < 0, the smallest value will be a >> b.min
                                     // if a > 0, the smallest value will be a >> b.max
-                                    interval.min = min(a_interval.min >> b_interval.min, a_interval.min >> b_interval.max);
+                                    interval.min = min(a_interval.min >> b_interval.min,
+                                                       a_interval.min >> b_interval.max);
                                 }
                             }
                             if (a_interval.has_upper_bound()) {
@@ -1073,7 +1074,8 @@ private:
                                 } else {
                                     // if a < 0, the largest value will be a >> b.max
                                     // if a > 0, the largest value will be a >> b.min
-                                    interval.max = min(a_interval.max >> b_interval.max, a_interval.max >> b_interval.min);
+                                    interval.max = min(a_interval.max >> b_interval.max,
+                                                       a_interval.max >> b_interval.min);
                                 }
                             }
                         }
@@ -2739,6 +2741,14 @@ void bounds_test() {
         Expr e = clamp(x/y, make_const(UInt(16), 0), make_const(UInt(16), 128));
         check(scope, e, make_const(UInt(16), 0), make_const(UInt(16), 5));
         check_constant_bound(scope, e, make_const(UInt(16), 0), make_const(UInt(16), 5));
+    }
+
+    {
+        Param<uint16_t> x("x"), y("y");
+        x.set_range(make_const(UInt(16), 16), make_const(UInt(16), 32));
+        y.set_range(make_const(UInt(16), 0), make_const(UInt(16), 4));
+
+        check_constant_bound((x >> y), make_const(UInt(16), 1), make_const(UInt(16), 32));
     }
 
     {

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1064,9 +1064,7 @@ private:
                                 } else {
                                     // if a < 0, the smallest value will be a >> b.min
                                     // if a > 0, the smallest value will be a >> b.max
-                                    interval.min = a_interval.min >> select(a_interval.min < 0,
-                                                                            b_interval.min,
-                                                                            b_interval.max);
+                                    interval.min = min(a_interval.min >> b_interval.min, a_interval.min >> b_interval.max);
                                 }
                             }
                             if (a_interval.has_upper_bound()) {
@@ -1075,9 +1073,7 @@ private:
                                 } else {
                                     // if a < 0, the largest value will be a >> b.max
                                     // if a > 0, the largest value will be a >> b.min
-                                    interval.max = a_interval.max >> select(a_interval.max < 0,
-                                                                            b_interval.max,
-                                                                            b_interval.min);
+                                    interval.min = min(a_interval.max >> b_interval.max, a_interval.max >> b_interval.min);
                                 }
                             }
                         }


### PR DESCRIPTION
The boundaries didn't take into account the differing behavior of signed values, so the constant bounds signed ints was wildly wrong in some cases (eg int16 >> int16 -> [-1, 0])