### PR TITLE
Revise Simplify for << and >> to forbid out-of-range constant shifts

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1058,20 +1058,22 @@ private:
                         // shift_right(a, b) is UB for b < 0, so only try to improve on bounds-of-type
                         // if we can prove b >= 0.
                         if (b_interval.is_bounded() && (t.is_uint() || can_prove(b_interval.min >= 0))) {
-                            if (a_interval.has_lower_bound()) {
+                            bool b_min_ok = (t.is_uint() || can_prove(b_interval.min >= 0)) && can_prove(b_interval.min < t.bits());
+                            bool b_max_ok = (t.is_uint() || can_prove(b_interval.max >= 0)) && can_prove(b_interval.max < t.bits());
+                            if (a_interval.has_lower_bound() && b_max_ok) {
                                 if (t.is_uint() || can_prove(a_interval.min >= 0)) {
                                     interval.min = a_interval.min >> b_interval.max;
-                                } else {
+                                } else if (b_min_ok) {
                                     // if a < 0, the smallest value will be a >> b.min
                                     // if a > 0, the smallest value will be a >> b.max
                                     interval.min = min(a_interval.min >> b_interval.min,
                                                        a_interval.min >> b_interval.max);
                                 }
                             }
-                            if (a_interval.has_upper_bound()) {
+                            if (a_interval.has_upper_bound() && b_min_ok) {
                                 if (t.is_uint() || can_prove(a_interval.max >= 0)) {
                                     interval.max = a_interval.max >> b_interval.min;
-                                } else {
+                                } else if (b_max_ok) {
                                     // if a < 0, the largest value will be a >> b.max
                                     // if a > 0, the largest value will be a >> b.min
                                     interval.max = max(a_interval.max >> b_interval.max,

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1043,10 +1043,10 @@ private:
                     if (op->is_intrinsic(Call::shift_left)) {
                         if (t.is_int() && t.bits() >= 32) {
                             // Overflow is UB
-                            if (a_interval.has_lower_bound() && b_interval.has_lower_bound() && can_prove(b_interval.min < t.bits())) {
+                            if (a_interval.has_lower_bound() && b_interval.has_lower_bound() && can_prove(b_interval.min >= 0 && b_interval.min < t.bits())) {
                                 interval.min = a_interval.min << b_interval.min;
                             }
-                            if (a_interval.has_upper_bound() && b_interval.has_upper_bound() && can_prove(b_interval.max < t.bits())) {
+                            if (a_interval.has_upper_bound() && b_interval.has_upper_bound() && can_prove(b_interval.max >= 0 && b_interval.max < t.bits())) {
                                 interval.max = a_interval.max << b_interval.max;
                             }
                         } else if (is_const(b)) {

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1043,10 +1043,10 @@ private:
                     if (op->is_intrinsic(Call::shift_left)) {
                         if (t.is_int() && t.bits() >= 32) {
                             // Overflow is UB
-                            if (a_interval.has_lower_bound() && b_interval.has_lower_bound()) {
+                            if (a_interval.has_lower_bound() && b_interval.has_lower_bound() && can_prove(b_interval.min < t.bits())) {
                                 interval.min = a_interval.min << b_interval.min;
                             }
-                            if (a_interval.has_upper_bound() && b_interval.has_upper_bound()) {
+                            if (a_interval.has_upper_bound() && b_interval.has_upper_bound() && can_prove(b_interval.max < t.bits())) {
                                 interval.max = a_interval.max << b_interval.max;
                             }
                         } else if (is_const(b)) {
@@ -1055,10 +1055,10 @@ private:
                             equiv.accept(this);
                         }
                     } else if (op->is_intrinsic(Call::shift_right)) {
-                        if (a_interval.has_lower_bound() && b_interval.has_upper_bound()) {
+                        if (a_interval.has_lower_bound() && b_interval.has_upper_bound() && can_prove(b_interval.max < t.bits())) {
                             interval.min = a_interval.min >> b_interval.max;
                         }
-                        if (a_interval.has_upper_bound() && b_interval.has_lower_bound()) {
+                        if (a_interval.has_upper_bound() && b_interval.has_lower_bound() && can_prove(b_interval.min < t.bits())) {
                             interval.max = a_interval.max >> b_interval.min;
                         }
                     } else if (op->is_intrinsic(Call::bitwise_and) &&

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -29,55 +29,39 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
             return a;
         }
 
-        int64_t ib = 0;
-        if (const_int(b, &ib) || const_uint(b, (uint64_t *)(&ib))) {
-            Type t = op->type;
+        const bool shift_left = op->is_intrinsic(Call::shift_left);
+        const Type t = op->type;
 
-            bool shift_left = op->is_intrinsic(Call::shift_left);
-            if (ib < 0) {
-                constexpr int64_t i64_max = std::numeric_limits<int64_t>::max();
-                if (t.is_int()) {
-                    shift_left = !shift_left;
-                    // Ensure that corner case of ib = lowest() doesn't negate into itself
-                    ib = -std::max(ib, -i64_max);
+        int64_t ib = 0;
+        uint64_t ub = 0;
+        if (const_int(b, &ib)) {
+            // LLVM shl and shr instructions produce poison for negative shifts,
+            // or for shifts >= typesize, so we will follow suit in our simplifier.
+            user_assert(ib >= 0) << "bitshift by a constant negative amount is not legal in Halide.";
+            user_assert(ib < t.bits()) << "bitshift by a constant amount >= the type size is not legal in Halide.";
+            if (ib < t.bits() - 1) {
+                b = make_const(t, 1LL << ib);
+                if (shift_left) {
+                    return mutate(Mul::make(a, b), bounds);
                 } else {
-                    // It's a uint > 2^63-1, so we're definitely shifting out-of-range;
-                    // just clip to a large-enough value value and fall thru.
-                    ib = i64_max;
+                    return mutate(Div::make(a, b), bounds);
+                }
+            } else {
+                // (1 << ib) will overflow into the sign bit, making decomposition into mul or div
+                // probelmatic, so just special-case them here.
+                if (shift_left) {
+                    return mutate(select((a & 1) != 0, make_const(t, 1LL << ib), make_zero(t)), bounds);
+                } else {
+                    return mutate(select(a < 0, make_const(t, -1), make_zero(t)), bounds);
                 }
             }
-
-            if (ib >= 0) {
-                assert(t.bits() <= 64);
-                int max_shift = t.bits() - 1;
-                if (t.is_int()) {
-                    // One less if there is a sign bit
-                    max_shift -= 1;
-                }
-                if (ib <= max_shift) {
-                    ib = 1LL << ib;
-                    b = make_const(t, ib);
-
-                    if (shift_left) {
-                        return mutate(Mul::make(a, b), bounds);
-                    } else {
-                        return mutate(Div::make(a, b), bounds);
-                    }
-                } else {
-                    // We know that all the meaningful bits will be shifted away;
-                    // just replace with a constant 0 or -1 if possible.
-                    if (shift_left) {
-                        return make_zero(t);
-                    } else {
-                        // shift-right-out-of-bounds -> zero for uint.
-                        if (t.is_uint()) {
-                            return make_zero(t);
-                        } else {
-                            // shift-right-out-of-bounds -> zero or -1 for int.
-                            return mutate(select(a < 0, make_const(t, -1), make_zero(t)), bounds);
-                        }
-                    }
-                }
+        } else if (const_uint(b, &ub)) {
+            user_assert(ub < (uint64_t) t.bits()) << "bitshift by a constant amount >= the type size is not legal in Halide.";
+            b = make_const(t, 1LL << ub);
+            if (shift_left) {
+                return mutate(Mul::make(a, b), bounds);
+            } else {
+                return mutate(Div::make(a, b), bounds);
             }
         }
 

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -40,7 +40,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
             user_assert(ib >= 0) << "bitshift by a constant negative amount is not legal in Halide.";
             user_assert(ib < t.bits()) << "bitshift by a constant amount >= the type size is not legal in Halide.";
             if (ib < t.bits() - 1) {
-                b = make_const(t, 1LL << ib);
+                b = make_const(t, ((int64_t) 1LL) << ib);
                 if (shift_left) {
                     return mutate(Mul::make(a, b), bounds);
                 } else {
@@ -50,14 +50,14 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
                 // (1 << ib) will overflow into the sign bit, making decomposition into mul or div
                 // probelmatic, so just special-case them here.
                 if (shift_left) {
-                    return mutate(select((a & 1) != 0, make_const(t, 1LL << ib), make_zero(t)), bounds);
+                    return mutate(select((a & 1) != 0, make_const(t, ((int64_t) 1LL) << ib), make_zero(t)), bounds);
                 } else {
                     return mutate(select(a < 0, make_const(t, -1), make_zero(t)), bounds);
                 }
             }
         } else if (const_uint(b, &ub)) {
             user_assert(ub < (uint64_t) t.bits()) << "bitshift by a constant amount >= the type size is not legal in Halide.";
-            b = make_const(t, 1LL << ub);
+            b = make_const(t, ((uint64_t) 1ULL) << ub);
             if (shift_left) {
                 return mutate(Mul::make(a, b), bounds);
             } else {

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1384,9 +1384,14 @@ void check_bitwise() {
     // Check bitshift operations
     check(cast(Int(16), x) << 10, cast(Int(16), x) * 1024);
     check(cast(Int(16), x) >> 10, cast(Int(16), x) / 1024);
-    check(cast(Int(16), x) << -10, cast(Int(16), x) / 1024);
-    // Correctly triggers a warning:
-    //check(cast(Int(16), x) << 20, cast(Int(16), x) << 20);
+
+    // Correctly triggers an error (shift by negative amount).
+    // check(cast(Int(16), x) << -10, 0);
+    // check(cast(Int(16), x) >> -10, 0);
+
+    // Correctly triggers an error (shift by >= type size).
+    // check(cast(Int(16), x) << 20, 0);
+    // check(cast(Int(16), x) >> 20, 0);
 
     // Check bitwise_and. (Added as result of a bug.)
     // TODO: more coverage of bitwise_and and bitwise_or.
@@ -1582,19 +1587,14 @@ int main(int argc, char **argv) {
         const Expr b = Expr(std::numeric_limits<int16_t>::max());
 
         check(a >> 14,  i16(-2));
-        check(b >> -14, i16(-16384));
         check(a << 14,  i16(0));
-        check(b << -14, i16(1));
-
         check(a >> 15,  i16(-1));
-        check(b >> -15, i16(0));
         check(a << 15,  i16(0));
-        check(b << -15, i16(0));
 
-        check(a >> b, i16(-1));
-        check(b >> a, i16(0));
-        check(a << b, i16(0));
-        check(b << a, i16(0));
+        check(b >> 14,  i16(1));
+        check(b << 14,  i16(-16384));
+        check(b >> 15,  i16(0));
+        check(b << 15,  i16(-32768));
     }
 
     {
@@ -1607,16 +1607,6 @@ int main(int argc, char **argv) {
         check(b >> 15, u16(1));
         check(a << 15, u16(0));
         check(b << 15, Expr((uint16_t) 0x8000));
-
-        check(a >> 16, u16(0));
-        check(b >> 16, u16(0));
-        check(a << 16, u16(0));
-        check(b << 16, u16(0));
-
-        check(a >> b, u16(0));
-        check(b >> b, u16(0));
-        check(a << b, u16(0));
-        check(b << b, u16(0));
     }
 
     {
@@ -1626,19 +1616,14 @@ int main(int argc, char **argv) {
         const Expr b = Expr(std::numeric_limits<int64_t>::max());
 
         check(a >> 62,  i64(-2));
-        check_is_sio(b >> -62);
         check_is_sio(a << 62);
-        check(b << -62, i64(1));
-
         check(a >> 63,  i64(-1));
-        check(b >> -63, i64(0));
         check(a << 63,  i64(0));
-        check(b << -63, i64(0));
 
-        check(a >> b, i64(-1));
-        check(b >> a, i64(0));
-        check(a << b, i64(0));
-        check(b << a, i64(0));
+        check(b >> 62,  i64(1));
+        check_is_sio(b << 62);
+        check(b >> 63,  i64(0));
+        check(b << 63,  Expr(std::numeric_limits<int64_t>::lowest()));
     }
 
     {
@@ -1651,16 +1636,6 @@ int main(int argc, char **argv) {
         check(b >> 63, u64(1));
         check(a << 63, u64(0));
         check(b << 63, Expr((uint64_t) 0x8000000000000000ULL));
-
-        check(a >> 64, u64(0));
-        check(b >> 64, u64(0));
-        check(a << 64, u64(0));
-        check(b << 64, u64(0));
-
-        check(a >> b, u64(0));
-        check(b >> b, u64(0));
-        check(a << b, u64(0));
-        check(b << b, u64(0));
     }
 
     printf("Success!\n");


### PR DESCRIPTION
Formerly we tried to handle negative shifts by flipping the operation, and out-of-range shifts by clipping to zero or -1. This isn't necessarily *wrong* -- these are UB in C++ (and poison-producing in LLVM) -- but I'd argue that if we can statically detect UB/poison values, we're better off producing a hard error at compile time.

See also https://github.com/halide/Halide/issues/3325