### PR TITLE
Improve handling of clz, ctz, popcount

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1156,10 +1156,10 @@ private:
                 // cast all ints to uint to simplify this.
                 cast(op->type.with_code(halide_type_uint), op->args[0]).accept(this);
                 Interval a = interval;
-                if (a.has_lower_bound() && can_prove(a.min != 0)) {
+                if (a.has_lower_bound()) {
                     max = cast(t, count_leading_zeros(a.min));
                 }
-                if (a.has_upper_bound() && can_prove(a.max != 0)) {
+                if (a.has_upper_bound()) {
                     min = cast(t, count_leading_zeros(a.max));
                 }
             }

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1154,7 +1154,7 @@ private:
             if (op->is_intrinsic(Call::count_leading_zeros)) {
                 // clz treats signed and unsigned ints the same way;
                 // cast all ints to uint to simplify this.
-                cast(t.with_code(halide_type_uint), op->args[0]).accept(this);
+                cast(op->type.with_code(halide_type_uint), op->args[0]).accept(this);
                 Interval a = interval;
                 if (a.has_lower_bound()) {
                     max = cast(t, count_leading_zeros(a.min));

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1156,10 +1156,10 @@ private:
                 // cast all ints to uint to simplify this.
                 cast(op->type.with_code(halide_type_uint), op->args[0]).accept(this);
                 Interval a = interval;
-                if (a.has_lower_bound()) {
+                if (a.has_lower_bound() && can_prove(a.min != 0)) {
                     max = cast(t, count_leading_zeros(a.min));
                 }
-                if (a.has_upper_bound()) {
+                if (a.has_upper_bound() && can_prove(a.max != 0)) {
                     min = cast(t, count_leading_zeros(a.max));
                 }
             }

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1148,8 +1148,22 @@ private:
                    op->is_intrinsic(Call::count_leading_zeros) ||
                    op->is_intrinsic(Call::count_trailing_zeros)) {
             internal_assert(op->args.size() == 1);
-            interval = Interval(make_zero(op->type.element_of()),
-                                make_const(op->type.element_of(), op->args[0].type().bits()));
+            const Type &t = op->type.element_of();
+            Expr min = make_zero(t);
+            Expr max = make_const(t, op->args[0].type().bits());
+            if (op->is_intrinsic(Call::count_leading_zeros)) {
+                // clz treats signed and unsigned ints the same way;
+                // cast all ints to uint to simplify this.
+                cast(t.with_code(halide_type_uint), op->args[0]).accept(this);
+                Interval a = interval;
+                if (a.has_lower_bound()) {
+                    max = cast(t, count_leading_zeros(a.min));
+                }
+                if (a.has_upper_bound()) {
+                    min = cast(t, count_leading_zeros(a.max));
+                }
+            }
+            interval = Interval(min, max);
         } else if (op->is_intrinsic(Call::memoize_expr)) {
             internal_assert(op->args.size() >= 1);
             op->args[0].accept(this);
@@ -2571,6 +2585,19 @@ void constant_bound_test() {
         check_constant_bound(e16, Int(16).min(), Int(16).max());
     }
 
+    {
+        using ConciseCasts::i16;
+        using ConciseCasts::i32;
+
+        Param<int32_t> x("x"), y("y");
+        x.set_range(2, 10);
+
+        check_constant_bound(count_leading_zeros(x), i32(28), i32(30));
+        check_constant_bound(count_leading_zeros(cast<int16_t>(x)), i16(12), i16(14));
+
+        check_constant_bound(count_leading_zeros(y), i32(0), i32(32));
+        check_constant_bound(count_leading_zeros(cast<int16_t>(y)), i16(0), i16(16));
+    }
 }
 
 void boxes_touched_test() {

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -119,13 +119,36 @@ inline float float_from_bits(uint32_t bits) {
 }
 
 template<typename T>
-inline uint8_t halide_count_leading_zeros(T v) {
-    int bits = sizeof(v) * 8;
-    while (v) {
-        v >>= 1;
-        bits--;
+inline int halide_popcount(T a) {
+    int bits_set = 0;
+    while (a != 0) {
+        bits_set += a & 1;
+        a >>= 1;
     }
-    return bits;
+    return bits_set;
+}
+
+template<typename T>
+inline int halide_count_leading_zeros(T a) {
+    int leading_zeros = 0;
+    int bit = sizeof(a) * 8 - 1;
+    while (bit >= 0 && (a & (1 << bit)) == 0) {
+        leading_zeros++;
+        bit--;
+    }
+    return leading_zeros;
+}
+
+template<typename T>
+inline int halide_count_trailing_zeros(T a) {
+    int trailing_zeros = 0;
+    constexpr int bits = sizeof(a) * 8;
+    int bit = 0;
+    while (bit < bits && (a & (1 << bit)) == 0) {
+        trailing_zeros++;
+        bit++;
+    }
+    return trailing_zeros;
 }
 
 template<typename T>
@@ -1956,10 +1979,16 @@ void CodeGen_C::visit(const Call *op) {
         string a0 = print_expr(op->args[0]);
         string a1 = print_expr(op->args[1]);
         rhs << a0 << " >> " << a1;
-    } else if (op->is_intrinsic(Call::count_leading_zeros)) {
+    } else if (op->is_intrinsic(Call::count_leading_zeros) ||
+               op->is_intrinsic(Call::count_trailing_zeros) ||
+               op->is_intrinsic(Call::popcount)) {
         internal_assert(op->args.size() == 1);
-        string a0 = print_expr(op->args[0]);
-        rhs << "halide_count_leading_zeros(" << a0 << ")";
+        if (op->args[0].type().is_vector()) {
+            rhs << print_scalarized_expr(op);
+        } else {
+            string a0 = print_expr(op->args[0]);
+            rhs << "halide_" << op->name << "(" << a0 << ")";
+        }
     } else if (op->is_intrinsic(Call::lerp)) {
         internal_assert(op->args.size() == 3);
         Expr e = lower_lerp(op->args[0], op->args[1], op->args[2]);

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -132,7 +132,7 @@ template<typename T>
 inline int halide_count_leading_zeros(T a) {
     int leading_zeros = 0;
     int bit = sizeof(a) * 8 - 1;
-    while (bit >= 0 && (a & (1 << bit)) == 0) {
+    while (bit >= 0 && (a & (((T)1) << bit)) == 0) {
         leading_zeros++;
         bit--;
     }
@@ -144,7 +144,7 @@ inline int halide_count_trailing_zeros(T a) {
     int trailing_zeros = 0;
     constexpr int bits = sizeof(a) * 8;
     int bit = 0;
-    while (bit < bits && (a & (1 << bit)) == 0) {
+    while (bit < bits && (a & (((T)1) << bit)) == 0) {
         trailing_zeros++;
         bit++;
     }

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1163,7 +1163,7 @@ void CodeGen_LLVM::optimize_module() {
 #if LLVM_VERSION >= 80
             pm.add(createThreadSanitizerLegacyPassPass());
 #else
-            pm.add(createThreadSanitizerPass());            
+            pm.add(createThreadSanitizerPass());
 #endif
         };
         b.addExtension(PassManagerBuilder::EP_OptimizerLast, addThreadSanitizerPass);
@@ -2427,8 +2427,8 @@ void CodeGen_LLVM::visit(const Call *op) {
                                                        (op->is_intrinsic(Call::count_leading_zeros)) ? Intrinsic::ctlz :
                                                        Intrinsic::cttz,
                                                        arg_type);
-        llvm::Value *zero_is_not_undef = llvm::ConstantInt::getFalse(*context);
-        llvm::Value *args[2] = { codegen(op->args[0]), zero_is_not_undef };
+        llvm::Value *is_zero_undef = llvm::ConstantInt::getFalse(*context);
+        llvm::Value *args[2] = { codegen(op->args[0]), is_zero_undef };
         CallInst *call = builder->CreateCall(fn, args);
         value = call;
     } else if (op->is_intrinsic(Call::return_second)) {

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1671,8 +1671,8 @@ inline Expr popcount(Expr x) {
                                 {std::move(x)}, Internal::Call::PureIntrinsic);
 }
 
-/** Count the number of leading zero bits in an expression. The result is
- *  undefined if the value of the expression is zero. */
+/** Count the number of leading zero bits in an expression. If the expression is
+ * zero, the result is the number of bits in the type. */
 inline Expr count_leading_zeros(Expr x) {
     user_assert(x.defined()) << "count leading zeros of undefined Expr\n";
     Type t = x.type();
@@ -1682,8 +1682,8 @@ inline Expr count_leading_zeros(Expr x) {
                                 {std::move(x)}, Internal::Call::PureIntrinsic);
 }
 
-/** Count the number of trailing zero bits in an expression. The result is
- *  undefined if the value of the expression is zero. */
+/** Count the number of trailing zero bits in an expression. If the expression is
+ * zero, the result is the number of bits in the type. */
 inline Expr count_trailing_zeros(Expr x) {
     user_assert(x.defined()) << "count trailing zeros of undefined Expr\n";
     Type t = x.type();

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -79,11 +79,11 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
                 // popcount *is* well-defined for ua = 0
                 r = popcount64(ua);
             } else if (op->is_intrinsic(Call::count_leading_zeros)) {
-                user_assert(ua != 0) << "The result of count_leading_zeros(x) is undefined for x = 0.";
-                r = clz64(ua) - (64 - bits);
+                // clz64() is undefined for 0, but Halide's count_leading_zeros defines clz(0) = bits
+                r = ua == 0 ? bits : (clz64(ua) - (64 - bits));
             } else /* if (op->is_intrinsic(Call::count_trailing_zeros)) */ {
-                user_assert(ua != 0) << "The result of count_trailing_zeros(x) is undefined for x = 0.";
-                r = ctz64(ua);
+                // ctz64() is undefined for 0, but Halide's count_trailing_zeros defines clz(0) = bits
+                r = ua == 0 ? bits : (ctz64(ua));
             }
             return make_const(op->type, r);
         }

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -15,7 +15,11 @@ namespace {
 // Consider moving these to (say) Util.h if we need them elsewhere.
 int popcount64(uint64_t x) {
 #ifdef _MSC_VER
-    return __popcnt64(x);
+    #if defined(_WIN64)
+        return __popcnt64(x);
+    #else
+        return __popcnt((uint32_t) (x >> 32)) + __popcnt((uint32_t) (x & 0xffffffff));
+    #endif
 #else
     static_assert(sizeof(unsigned long long) >= sizeof(uint64_t), "");
     return __builtin_popcountll(x);
@@ -26,8 +30,17 @@ int clz64(uint64_t x) {
     internal_assert(x != 0);
 #ifdef _MSC_VER
     unsigned long r = 0;
-    (void) _BitScanReverse64(&r, x);
-    return r;
+    #if defined(_WIN64)
+        return _BitScanReverse64(&r, x) ? (63 - r) : 64;
+    #else
+        if (_BitScanReverse(&r, (uint32_t) (x >> 32))) {
+            return (63 - (r + 32));
+        } else if (_BitScanReverse(&r, (uint32_t) (x & 0xffffffff))) {
+            return 63 - r;
+        } else {
+            return 64;
+        }
+    #endif
 #else
     static_assert(sizeof(unsigned long long) >= sizeof(uint64_t), "");
     constexpr int offset = (sizeof(unsigned long long) - sizeof(uint64_t)) * 8;
@@ -39,8 +52,17 @@ int ctz64(uint64_t x) {
     internal_assert(x != 0);
 #ifdef _MSC_VER
     unsigned long r = 0;
-    (void) _BitScanForward64(&r, x);
-    return r;
+    #if defined(_WIN64)
+        return _BitScanForward64(&r, x) ? r : 64;
+    #else
+        if (_BitScanForward(&r, (uint32_t) (x & 0xffffffff))) {
+            return r;
+        } else if (_BitScanForward(&r, (uint32_t) (x >> 32))) {
+            return r + 32;
+        } else {
+            return 64;
+        }
+    #endif
 #else
     static_assert(sizeof(unsigned long long) >= sizeof(uint64_t), "");
     return __builtin_ctzll(x);

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -1,5 +1,9 @@
 #include "Simplify_Internal.h"
 
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
 namespace Halide {
 namespace Internal {
 
@@ -7,17 +11,6 @@ using std::vector;
 using std::string;
 
 namespace {
-
-#ifdef _MSC_VER
-    unsigned char _BitScanForward64(unsigned long *index, unsigned __int64 mask);
-    #pragma intrinsic(_BitScanForward64)
-
-    unsigned char _BitScanReverse64(unsigned long *index, unsigned __int64 mask);
-    #pragma intrinsic(_BitScanReverse64)
-
-    unsigned __int64 __popcnt64(unsigned __int64 value);
-    #pragma intrinsic(__popcnt64)
-#endif
 
 // Consider moving these to (say) Util.h if we need them elsewhere.
 int popcount64(uint64_t x) {

--- a/test/correctness/popc_clz_ctz_bounds.cpp
+++ b/test/correctness/popc_clz_ctz_bounds.cpp
@@ -62,11 +62,7 @@ int main(int argc, char **argv) {
         std::mt19937 rng(0);
         Buffer<uint8_t> data(16);
         for (int32_t i = 0; i < 16; i++) {
-            // clz and ctz are undefined for zero values,
-            // so be sure to skip them in the test data.
-            do {
-                data(i) = rng();
-            } while (data(i) == 0);
+            data(i) = rng();
         }
         in.set(data);
 

--- a/test/correctness/popc_clz_ctz_bounds.cpp
+++ b/test/correctness/popc_clz_ctz_bounds.cpp
@@ -62,7 +62,11 @@ int main(int argc, char **argv) {
         std::mt19937 rng(0);
         Buffer<uint8_t> data(16);
         for (int32_t i = 0; i < 16; i++) {
-            data(i) = rng();
+            // clz and ctz are undefined for zero values,
+            // so be sure to skip them in the test data.
+            do {
+                data(i) = rng();
+            } while (data(i) == 0);
         }
         in.set(data);
 

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1378,6 +1378,24 @@ void check_overflow() {
     }
 }
 
+template<typename T>
+void check_clz(uint64_t value, uint64_t result) {
+    Expr x = Variable::make(halide_type_of<T>(), "x");
+    check(Let::make("x", cast<T>(Expr(value)), count_leading_zeros(x)), cast<T>(Expr(result)));
+}
+
+template<typename T>
+void check_ctz(uint64_t value, uint64_t result) {
+    Expr x = Variable::make(halide_type_of<T>(), "x");
+    check(Let::make("x", cast<T>(Expr(value)), count_trailing_zeros(x)), cast<T>(Expr(result)));
+}
+
+template<typename T>
+void check_popcount(uint64_t value, uint64_t result) {
+    Expr x = Variable::make(halide_type_of<T>(), "x");
+    check(Let::make("x", cast<T>(Expr(value)), popcount(x)), cast<T>(Expr(result)));
+}
+
 void check_bitwise() {
     Expr x = Var("x");
 
@@ -1396,6 +1414,33 @@ void check_bitwise() {
     // Check constant-folding of bitwise ops (and indirectly, reinterpret)
     check(Let::make(x.as<Variable>()->name, 5, (((~x) & 3) | 16) ^ 33), ((~5 & 3) | 16) ^ 33);
     check(Let::make(x.as<Variable>()->name, 5, (((~cast<uint8_t>(x)) & 3) | 16) ^ 33), make_const(UInt(8), ((~5 & 3) | 16) ^ 33));
+
+    check_clz<int8_t>(10, 4);
+    check_clz<int16_t>(10, 12);
+    check_clz<int32_t>(10, 28);
+    check_clz<int64_t>(10, 60);
+    check_clz<uint8_t>(10, 4);
+    check_clz<uint16_t>(10, 12);
+    check_clz<uint32_t>(10, 28);
+    check_clz<uint64_t>(10, 60);
+
+    check_ctz<int8_t>(64, 6);
+    check_ctz<int16_t>(64, 6);
+    check_ctz<int32_t>(64, 6);
+    check_ctz<int64_t>(64, 6);
+    check_ctz<uint8_t>(64, 6);
+    check_ctz<uint16_t>(64, 6);
+    check_ctz<uint32_t>(64, 6);
+    check_ctz<uint64_t>(64, 6);
+
+    check_popcount<int8_t>(0xa5, 4);
+    check_popcount<int16_t>(0xa5a5, 8);
+    check_popcount<int32_t>(0xa5a5a5a5, 16);
+    check_popcount<int64_t>(0xa5a5a5a5a5a5a5a5, 32);
+    check_popcount<uint8_t>(0xa5, 4);
+    check_popcount<uint16_t>(0xa5a5, 8);
+    check_popcount<uint32_t>(0xa5a5a5a5, 16);
+    check_popcount<uint64_t>(0xa5a5a5a5a5a5a5a5, 32);
 }
 
 void check_lets() {

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1423,6 +1423,7 @@ void check_bitwise() {
     check_clz<uint16_t>(10, 12);
     check_clz<uint32_t>(10, 28);
     check_clz<uint64_t>(10, 60);
+    check_clz<uint64_t>(10ULL << 32, 28);
 
     check_ctz<int8_t>(64, 6);
     check_ctz<int16_t>(64, 6);
@@ -1432,6 +1433,7 @@ void check_bitwise() {
     check_ctz<uint16_t>(64, 6);
     check_ctz<uint32_t>(64, 6);
     check_ctz<uint64_t>(64, 6);
+    check_ctz<uint64_t>(64ULL << 32, 38);
 
     check_popcount<int8_t>(0xa5, 4);
     check_popcount<int16_t>(0xa5a5, 8);


### PR DESCRIPTION
- Add special-casing of these to the Simplifier, so that constant values are simplified to constants
- Improve handling of bounds-calculation for clz to allow narrower min and max when the intervals are bounded