### PR TITLE
Fix require() for HVX backend

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1832,12 +1832,6 @@ void CodeGen_Hexagon::visit(const Call *op) {
             equiv.accept(this);
         }
         return;
-    } else if (op->is_intrinsic(Call::extract_mask_element)) {
-        internal_assert(op->args.size() == 2);
-        const int64_t *index = as_const_int(op->args[1]);
-        internal_assert(index);
-        value = codegen(Cast::make(Bool(), Shuffle::make_extract_element(op->args[0], *index)));
-        return;
     }
 
     if (op->is_intrinsic(Call::prefetch)) {

--- a/test/correctness/require.cpp
+++ b/test/correctness/require.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
         Var x;
         Func f;
         f(x) = require(x > 0, x);
-        f.vectorize(x, 8).hexagon();
+        f.vectorize(x, 32).hexagon();
 
         std::string object_name = Internal::get_test_tmp_dir() + "test_object_" + target.to_string();
         if (target.os == Target::Windows && !target.has_feature(Target::MinGW)) {


### PR DESCRIPTION
HVX (and possible OpenCL) have code to eliminate bool vectors by converting them into a mask; this breaks scalarizing require() if the condition is a vector, as it assumes the condition is still bool, vector or not. This just inserts a workaround to re-boolify the vector when scalarization is necessary.