### PR TITLE
Basic bfloat16 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -440,6 +440,7 @@ SOURCE_FILES = \
   LoopCarry.cpp \
   Lower.cpp \
   LowerWarpShuffles.cpp \
+  LowerBFloatMath.cpp \
   MatlabWrapper.cpp \
   Memoization.cpp \
   Module.cpp \
@@ -609,6 +610,7 @@ HEADER_FILES = \
   LLVM_Runtime_Linker.h \
   LoopCarry.h \
   Lower.h \
+  LowerBFloatMath.h \
   LowerWarpShuffles.h \
   MainPage.h \
   MatlabWrapper.h \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -352,6 +352,7 @@ set(HEADER_FILES
   LLVM_Runtime_Linker.h
   LoopCarry.h
   Lower.h
+  LowerBFloatMath.h
   LowerWarpShuffles.h
   MainPage.h
   MatlabWrapper.h
@@ -514,6 +515,7 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   LICM.cpp
   LoopCarry.cpp
   Lower.cpp
+  LowerBFloatMath.cpp
   LowerWarpShuffles.cpp
   MatlabWrapper.cpp
   Memoization.cpp

--- a/src/Float16.cpp
+++ b/src/Float16.cpp
@@ -1,4 +1,5 @@
 #include "Float16.h"
+#include "IRMutator.h"
 #include "Error.h"
 #include "Util.h"
 
@@ -15,8 +16,7 @@ static const uint16_t mantissa_mask = 0x03ff;
 
 // Conversion routines to and from float cribbed from Christian Rau's
 // half library (half.sourceforge.net)
-
-uint16_t float_to_half(float value) {
+uint16_t float_to_float16(float value) {
     // Start by copying over the sign bit
     uint16_t bits = std::signbit(value) << 15;
 
@@ -57,7 +57,7 @@ uint16_t float_to_half(float value) {
     return bits;
 }
 
-float half_to_float(const uint16_t& value) {
+float float16_to_float(const uint16_t& value) {
     // There aren't all that many float16_t values, so a few lookup tables suffice.
     static const uint32_t mantissa_table[2048] = {
         0x00000000, 0x33800000, 0x34000000, 0x34400000, 0x34800000, 0x34A00000, 0x34C00000, 0x34E00000,
@@ -336,24 +336,41 @@ float half_to_float(const uint16_t& value) {
     uint32_t bits = (mantissa_table[offset] + exponent_table[sign_and_exponent]);
     return reinterpret_bits<float>(bits);
 }
+
+// Similar routines for bfloat. It's somewhat simpler.
+uint16_t float_to_bfloat16(float f) {
+    uint16_t ret[2];
+    memcpy(ret, &f, sizeof(float));
+    // Assume little-endian floats
+    return ret[1];
+}
+
+float bfloat16_to_float(uint16_t b) {
+    // Assume little-endian floats
+    uint16_t bits[2] = {0, b};
+    float ret;
+    memcpy(&ret, bits, sizeof(float));
+    return ret;
+}
+
 }  // namespace Internal
 
 using namespace Halide::Internal;
 
-float16_t::float16_t(float value) : data(float_to_half(value)) {}
+float16_t::float16_t(float value) : data(float_to_float16(value)) {}
 
-float16_t::float16_t(double value) : data(float_to_half(value)) {}
+float16_t::float16_t(double value) : data(float_to_float16(value)) {}
 
-float16_t::float16_t(int value) : data(float_to_half(value)) {}
+float16_t::float16_t(int value) : data(float_to_float16(value)) {}
 
 float16_t::float16_t() : data(0) {}
 
 float16_t::operator float() const {
-    return half_to_float(data);
+    return float16_to_float(data);
 }
 
 float16_t::operator double() const {
-    return half_to_float(data);
+    return float16_to_float(data);
 }
 
 float16_t float16_t::make_from_bits(uint16_t bits) {
@@ -378,35 +395,35 @@ float16_t float16_t::make_nan() {
 }
 
 float16_t float16_t::operator-() const {
-    return float16_t(-half_to_float(data));
+    return float16_t(-float16_to_float(data));
 }
 
 float16_t float16_t::operator+(float16_t rhs) const {
-    return float16_t(half_to_float(data) + half_to_float(rhs.data));
+    return float16_t(float16_to_float(data) + float16_to_float(rhs.data));
 }
 
 float16_t float16_t::operator-(float16_t rhs) const {
-    return float16_t(half_to_float(data) - half_to_float(rhs.data));
+    return float16_t(float16_to_float(data) - float16_to_float(rhs.data));
 }
 
 float16_t float16_t::operator*(float16_t rhs) const {
-    return float16_t(half_to_float(data) * half_to_float(rhs.data));
+    return float16_t(float16_to_float(data) * float16_to_float(rhs.data));
 }
 
 float16_t float16_t::operator/(float16_t rhs) const {
-    return float16_t(half_to_float(data) / half_to_float(rhs.data));
+    return float16_t(float16_to_float(data) / float16_to_float(rhs.data));
 }
 
 bool float16_t::operator==(float16_t rhs) const {
-    return half_to_float(data) == half_to_float(rhs.data);
+    return float16_to_float(data) == float16_to_float(rhs.data);
 }
 
 bool float16_t::operator>(float16_t rhs) const {
-    return half_to_float(data) > half_to_float(rhs.data);
+    return float16_to_float(data) > float16_to_float(rhs.data);
 }
 
 bool float16_t::operator<(float16_t rhs) const {
-    return half_to_float(data) < half_to_float(rhs.data);
+    return float16_to_float(data) < float16_to_float(rhs.data);
 }
 
 bool float16_t::is_nan() const {
@@ -426,6 +443,96 @@ bool float16_t::is_zero() const {
 }
 
 uint16_t float16_t::to_bits() const {
+    return data;
+}
+
+
+bfloat16_t::bfloat16_t(float value) : data(float_to_bfloat16(value)) {}
+
+bfloat16_t::bfloat16_t(double value) : data(float_to_bfloat16(value)) {}
+
+bfloat16_t::bfloat16_t(int value) : data(float_to_bfloat16(value)) {}
+
+bfloat16_t::bfloat16_t() : data(0) {}
+
+bfloat16_t::operator float() const {
+    return bfloat16_to_float(data);
+}
+
+bfloat16_t::operator double() const {
+    return bfloat16_to_float(data);
+}
+
+bfloat16_t bfloat16_t::make_from_bits(uint16_t bits) {
+    bfloat16_t f;
+    f.data = bits;
+    return f;
+}
+
+bfloat16_t bfloat16_t::make_zero(bool positive) {
+    uint16_t bits = positive ? 0 : sign_mask;
+    return bfloat16_t::make_from_bits(bits);
+}
+
+bfloat16_t bfloat16_t::make_infinity(bool positive) {
+    uint16_t bits = exponent_mask | (positive ? 0 : sign_mask);
+    return bfloat16_t::make_from_bits(bits);
+}
+
+bfloat16_t bfloat16_t::make_nan() {
+    uint16_t bits = exponent_mask | mantissa_mask;
+    return bfloat16_t::make_from_bits(bits);
+}
+
+bfloat16_t bfloat16_t::operator-() const {
+    return bfloat16_t(-bfloat16_to_float(data));
+}
+
+bfloat16_t bfloat16_t::operator+(bfloat16_t rhs) const {
+    return bfloat16_t(bfloat16_to_float(data) + bfloat16_to_float(rhs.data));
+}
+
+bfloat16_t bfloat16_t::operator-(bfloat16_t rhs) const {
+    return bfloat16_t(bfloat16_to_float(data) - bfloat16_to_float(rhs.data));
+}
+
+bfloat16_t bfloat16_t::operator*(bfloat16_t rhs) const {
+    return bfloat16_t(bfloat16_to_float(data) * bfloat16_to_float(rhs.data));
+}
+
+bfloat16_t bfloat16_t::operator/(bfloat16_t rhs) const {
+    return bfloat16_t(bfloat16_to_float(data) / bfloat16_to_float(rhs.data));
+}
+
+bool bfloat16_t::operator==(bfloat16_t rhs) const {
+    return bfloat16_to_float(data) == bfloat16_to_float(rhs.data);
+}
+
+bool bfloat16_t::operator>(bfloat16_t rhs) const {
+    return bfloat16_to_float(data) > bfloat16_to_float(rhs.data);
+}
+
+bool bfloat16_t::operator<(bfloat16_t rhs) const {
+    return bfloat16_to_float(data) < bfloat16_to_float(rhs.data);
+}
+
+bool bfloat16_t::is_nan() const {
+    return ((data & exponent_mask) == exponent_mask) && (data & mantissa_mask);
+}
+
+bool bfloat16_t::is_infinity() const {
+    return ((data & exponent_mask) == exponent_mask) && !(data & mantissa_mask);
+}
+
+bool bfloat16_t::is_negative() const {
+    return data & sign_mask;
+}
+
+bool bfloat16_t::is_zero() const {
+    return !(data & ~sign_mask);
+}
+
+uint16_t bfloat16_t::to_bits() const {
     return data;
 }
 

--- a/src/Float16.h
+++ b/src/Float16.h
@@ -16,6 +16,11 @@ namespace Halide {
  * */
 struct float16_t {
 
+    static const int mantissa_bits = 10;
+    static const uint16_t sign_mask = 0x8000;
+    static const uint16_t exponent_mask = 0x7c00;
+    static const uint16_t mantissa_mask = 0x03ff;
+
     /// \name Constructors
     /// @{
 
@@ -40,12 +45,6 @@ struct float16_t {
     explicit operator float() const;
     /** Cast to double */
     explicit operator double() const;
-
-    // Be explicit about how the copy constructor is expected to behave
-    float16_t(const float16_t&) = default;
-
-    // Be explicit about how assignment is expected to behave
-    float16_t& operator=(const float16_t&) = default;
 
     /** \name Convenience "constructors"
      */
@@ -122,6 +121,123 @@ static_assert(sizeof(float16_t) == 2, "float16_t should occupy two bytes");
 template<>
 HALIDE_ALWAYS_INLINE halide_type_t halide_type_of<Halide::float16_t>() {
     return halide_type_t(halide_type_float, 16);
+}
+
+namespace Halide {
+
+/** Class that provides a type that implements half precision
+ *  floating point using the bfloat16 format.
+ *
+ *  This type is enforced to be 16-bits wide and maintains no state
+ *  other than the raw bits so that it can passed to code that checks
+ *  a type's size and used for buffer_t allocation. */
+struct bfloat16_t {
+
+    static const int mantissa_bits = 7;
+    static const uint16_t sign_mask = 0x8000;
+    static const uint16_t exponent_mask = 0x7f80;
+    static const uint16_t mantissa_mask = 0x007f;
+
+    /// \name Constructors
+    /// @{
+
+    /** Construct from a float, double, or int using
+     * round-to-nearest-ties-to-even. Out-of-range values become +/-
+     * infinity.
+     */
+    // @{
+    explicit bfloat16_t(float value);
+    explicit bfloat16_t(double value);
+    explicit bfloat16_t(int value);
+    // @}
+
+    /** Construct a bfloat16_t with the bits initialised to 0. This represents
+     * positive zero.*/
+    bfloat16_t();
+
+    /// @}
+
+    // Use explicit to avoid accidently raising the precision
+    /** Cast to float */
+    explicit operator float() const;
+    /** Cast to double */
+    explicit operator double() const;
+
+    /** \name Convenience "constructors"
+     */
+    /**@{*/
+
+    /** Get a new bfloat16_t that represents zero
+     * \param positive if true then returns positive zero otherwise returns
+     *        negative zero.
+     */
+    static bfloat16_t make_zero(bool positive);
+
+    /** Get a new float16_t that represents infinity
+     * \param positive if true then returns positive infinity otherwise returns
+     *        negative infinity.
+     */
+    static bfloat16_t make_infinity(bool positive);
+
+    /** Get a new bfloat16_t that represents NaN (not a number) */
+    static bfloat16_t make_nan();
+
+    /** Get a new bfloat16_t with the given raw bits
+     *
+     * \param bits The bits conformant to IEEE754 binary16
+     */
+    static bfloat16_t make_from_bits(uint16_t bits);
+
+    /**@}*/
+
+    /** Return a new bfloat16_t with a negated sign bit*/
+    bfloat16_t operator-() const;
+
+    /** Arithmetic operators. */
+    // @{
+    bfloat16_t operator+(bfloat16_t rhs) const;
+    bfloat16_t operator-(bfloat16_t rhs) const;
+    bfloat16_t operator*(bfloat16_t rhs) const;
+    bfloat16_t operator/(bfloat16_t rhs) const;
+    // @}
+
+    /** Comparison operators */
+    // @{
+    bool operator==(bfloat16_t rhs) const;
+    bool operator!=(bfloat16_t rhs) const { return !(*this == rhs); }
+    bool operator>(bfloat16_t rhs) const;
+    bool operator<(bfloat16_t rhs) const;
+    bool operator>=(bfloat16_t rhs) const { return (*this > rhs) || (*this == rhs); }
+    bool operator<=(bfloat16_t rhs) const { return (*this < rhs) || (*this == rhs); }
+    // @}
+
+    /** Properties */
+    // @{
+    bool is_nan() const;
+    bool is_infinity() const;
+    bool is_negative() const;
+    bool is_zero() const;
+    // @}
+
+    /** Returns the bits that represent this bfloat16_t.
+     *
+     *  An alternative method to access the bits is to cast a pointer
+     *  to this instance as a pointer to a uint16_t.
+     **/
+    uint16_t to_bits() const;
+
+private:
+    // The raw bits.
+    uint16_t data;
+};
+
+static_assert(sizeof(bfloat16_t) == 2, "bfloat16_t should occupy two bytes");
+
+}  // namespace Halide
+
+template<>
+HALIDE_ALWAYS_INLINE halide_type_t halide_type_of<Halide::bfloat16_t>() {
+    return halide_type_t(halide_type_bfloat, 16);
 }
 
 #endif

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -34,6 +34,9 @@ ostream &operator<<(ostream &out, const Type &type) {
             out << "(void *)";
         }
         break;
+    case Type::BFloat:
+        out << "bfloat";
+        break;
     }
     if (!type.is_handle()) {
         out << type.bits();

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -34,6 +34,7 @@
 #include "Inline.h"
 #include "LICM.h"
 #include "LoopCarry.h"
+#include "LowerBFloatMath.h"
 #include "LowerWarpShuffles.h"
 #include "Memoization.h"
 #include "PartitionLoops.h"
@@ -341,6 +342,10 @@ Module lower(const vector<Function> &output_funcs, const string &pipeline_name, 
     debug(1) << "Lowering unsafe promises...\n";
     s = lower_unsafe_promises(s, t);
     debug(2) << "Lowering after lowering unsafe promises:\n" << s << "\n\n";
+
+    debug(1) << "Emulating bfloat math...\n";
+    s = lower_bfloat_math(s);
+    debug(2) << "Lowering after emulating bfloat math:\n" << s << "\n\n";
 
     s = remove_dead_allocations(s);
     s = remove_trivial_for_loops(s);

--- a/src/LowerBFloatMath.cpp
+++ b/src/LowerBFloatMath.cpp
@@ -1,0 +1,112 @@
+#include "LowerBFloatMath.h"
+#include "IRMutator.h"
+#include "IROperator.h"
+
+namespace Halide {
+namespace Internal {
+
+namespace {
+class LowerBFloatMath : public IRMutator {
+public:
+    using IRMutator::mutate;
+
+    Expr mutate(const Expr &e) override {
+        Expr new_e = IRMutator::mutate(e);
+        if (e.type().is_bfloat()) {
+            Type expected = UInt(16, e.type().lanes());
+            internal_assert(new_e.type() == expected)
+                << "Did not successfully remove bfloat math: " << e << " -> " << new_e << "\n";
+        }
+        return new_e;
+    }
+
+protected:
+    using IRMutator::visit;
+
+    Expr bfloat_to_float(Expr e) {
+        e = cast(UInt(32, e.type().lanes()), e);
+        e = e << 16;
+        e = reinterpret(Float(32, e.type().lanes()), e);
+        return e;
+    }
+
+    Expr float_to_bfloat(Expr e) {
+        e = reinterpret(UInt(32, e.type().lanes()), e);
+        e = e >> 16;
+        e = cast(UInt(16, e.type().lanes()), e);
+        return e;
+    }
+
+    template<typename Op>
+    Expr visit_bin_op(const Op *op) {
+        Expr a = mutate(op->a);
+        Expr b = mutate(op->b);
+        if (op->type.is_bfloat()) {
+            a = bfloat_to_float(a);
+            b = bfloat_to_float(b);
+            return float_to_bfloat(Op::make(a, b));
+        } else {
+            return Op::make(a, b);
+        }
+    }
+
+    Expr visit(const Add *op) override { return visit_bin_op(op); }
+    Expr visit(const Sub *op) override { return visit_bin_op(op); }
+    Expr visit(const Mod *op) override { return visit_bin_op(op); }
+    Expr visit(const Mul *op) override { return visit_bin_op(op); }
+    Expr visit(const Div *op) override { return visit_bin_op(op); }
+    Expr visit(const LE *op) override { return visit_bin_op(op); }
+    Expr visit(const LT *op) override { return visit_bin_op(op); }
+    Expr visit(const GE *op) override { return visit_bin_op(op); }
+    Expr visit(const GT *op) override { return visit_bin_op(op); }
+    Expr visit(const Min *op) override { return visit_bin_op(op); }
+    Expr visit(const Max *op) override { return visit_bin_op(op); }
+
+    Expr visit(const FloatImm *op) override {
+        if (op->type.is_bfloat()) {
+            return Expr(bfloat16_t(op->value).to_bits());
+        } else {
+            return op;
+        }
+    }
+
+    Expr visit(const Cast *op) override {
+        if (op->type.is_bfloat()) {
+            // Cast via float
+            return float_to_bfloat(mutate(cast(Float(32, op->type.lanes()), op->value)));
+        } else if (op->value.type().is_bfloat()) {
+            return cast(op->type, bfloat_to_float(mutate(op->value)));
+        } else {
+            return IRMutator::visit(op);
+        }
+    }
+
+    Expr visit(const Load *op) override {
+        if (op->type.is_bfloat()) {
+            // Load as uint16_t then widen to float
+            Expr index = mutate(op->index);
+            return Load::make(op->type.with_code(Type::UInt), op->name, index,
+                              op->image, op->param, mutate(op->predicate), op->alignment);
+        } else {
+            return IRMutator::visit(op);
+        }
+    }
+
+    // TODO: Call args and return values
+
+    Stmt visit(const For *op) override {
+        // Check the device_api and only enter body if the device does
+        // not support bfloat16 math. Currently no devices support
+        // bfloat16 math, so we always enter the body.
+        return IRMutator::visit(op);
+    }
+};
+
+}  // anonymous namespace
+
+Stmt lower_bfloat_math(Stmt s) {
+    return LowerBFloatMath().mutate(s);
+}
+
+}  // namespace Internal
+}  // namespace Halide

--- a/src/LowerBFloatMath.h
+++ b/src/LowerBFloatMath.h
@@ -1,0 +1,19 @@
+#ifndef HALIDE_LOWER_BFLOAT_MATH_H
+#define HALIDE_LOWER_BFLOAT_MATH_H
+
+/** \file
+ * The lowering pass that removes/emulates bfloat math on targets that don't natively support it.
+ */
+
+#include "IR.h"
+
+namespace Halide {
+namespace Internal {
+
+/** Lower all bfloats and bfloat math to the floating point equivalent */
+Stmt lower_bfloat_math(Stmt);
+
+}
+}
+
+#endif

--- a/src/Type.h
+++ b/src/Type.h
@@ -164,6 +164,7 @@ HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(uint32_t);
 HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(int64_t);
 HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(uint64_t);
 HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(Halide::float16_t);
+HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(Halide::bfloat16_t);
 HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(float);
 HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(double);
 HALIDE_DECLARE_EXTERN_STRUCT_TYPE(buffer_t);
@@ -276,6 +277,7 @@ struct Type {
     static const halide_type_code_t Int = halide_type_int;
     static const halide_type_code_t UInt = halide_type_uint;
     static const halide_type_code_t Float = halide_type_float;
+    static const halide_type_code_t BFloat = halide_type_bfloat;
     static const halide_type_code_t Handle = halide_type_handle;
     // @}
 
@@ -361,7 +363,11 @@ struct Type {
 
     /** Is this type a floating point type (float or double). */
     HALIDE_ALWAYS_INLINE
-    bool is_float() const {return code() == Float;}
+    bool is_float() const {return code() == Float || code() == BFloat;}
+
+    /** Is this type a floating point type (float or double). */
+    HALIDE_ALWAYS_INLINE
+    bool is_bfloat() const {return code() == BFloat;}
 
     /** Is this type a signed integer type? */
     HALIDE_ALWAYS_INLINE
@@ -441,6 +447,11 @@ inline Type UInt(int bits, int lanes = 1) {
 /** Construct a floating-point type */
 inline Type Float(int bits, int lanes = 1) {
     return Type(Type::Float, bits, lanes);
+}
+
+/** Construct a floating-point type in the bfloat format. Only 16-bit currently supported. */
+inline Type BFloat(int bits, int lanes = 1) {
+    return Type(Type::BFloat, bits, lanes);
 }
 
 /** Construct a boolean type */

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -379,8 +379,9 @@ typedef enum halide_type_code_t
 {
     halide_type_int = 0,   //!< signed integers
     halide_type_uint = 1,  //!< unsigned integers
-    halide_type_float = 2, //!< floating point numbers
-    halide_type_handle = 3 //!< opaque pointer type (void *)
+    halide_type_float = 2, //!< IEEE floating point numbers
+    halide_type_handle = 3, //!< opaque pointer type (void *)
+    halide_type_bfloat = 4, //!< floating point numbers in the bfloat format
 } halide_type_code_t;
 
 // Note that while __attribute__ can go before or after the declaration,

--- a/test/correctness/float16_t.cpp
+++ b/test/correctness/float16_t.cpp
@@ -1,0 +1,42 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Var x;
+
+    Buffer<float16_t> in1 = lambda(x, cast<float16_t>(x) / 8).realize(128);
+    Buffer<bfloat16_t> in2 = lambda(x, cast<bfloat16_t>(x) / 8).realize(128);
+
+    in2.for_each_element([&](int i) {
+            bfloat16_t correct = Halide::bfloat16_t(i) / Halide::bfloat16_t(8.0f);
+            if (in2(i) != correct) {
+                printf("in2(%d) = %f instead of %f\n", i, float(in2(i)), float(correct));
+                abort();
+            }
+        });
+
+    Func wrap1, wrap2;
+    wrap1(x) = in1(x);
+    wrap2(x) = in2(x);
+
+    Func f;
+    f(x) = abs(sqrt(wrap1(x) * 4.0f) - sqrt(wrap2(x)) * 2.0f);
+
+    f.compute_root().vectorize(x, 16);
+    wrap1.compute_at(f, x).vectorize(x);
+    wrap2.compute_at(f, x).vectorize(x);
+
+    RDom r(0, 128);
+    Func g;
+    g() = maximum(cast<double>(f(r)));
+    g.compile_to_assembly("/dev/stdout", {in1, in2}, Target("host-no_asserts-no_bounds_query-no_runtime-disable_llvm_loop_unroll-disable_llvm_loop_vectorize"));
+    double d = evaluate<double>(g());
+    if (d != 0) {
+        printf("Should be zero: %f\n", d);
+        return -1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/float16_t.cpp
+++ b/test/correctness/float16_t.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
     RDom r(0, 128);
     Func g;
     g() = maximum(cast<double>(f(r)));
-    g.compile_to_assembly("/dev/stdout", {in1, in2}, Target("host-no_asserts-no_bounds_query-no_runtime-disable_llvm_loop_unroll-disable_llvm_loop_vectorize"));
+
     double d = evaluate<double>(g());
     if (d != 0) {
         printf("Should be zero: %f\n", d);

--- a/test/correctness/float16_t_comparison.cpp
+++ b/test/correctness/float16_t_comparison.cpp
@@ -11,15 +11,18 @@ void h_assert(bool condition, const char* msg) {
     }
 }
 
-int main() {
-    const float16_t one(1.0);
-    const float16_t onePointTwoFive(1.25);
+template<typename T>
+bool test() {
+    const T one(1.0);
+    const T onePointTwoFive(1.25);
 
     // Check the bits are how we expect before using
     // comparision operators
     h_assert(one.to_bits() != onePointTwoFive.to_bits(), "bits should be different");
-    h_assert(one.to_bits() == 0x3c00, "bit pattern for 1.0 is wrong");
-    h_assert(onePointTwoFive.to_bits() == 0x3d00, "bit pattern for 1.25 is wrong");
+    uint16_t bits = (T::exponent_mask >> 1) & T::exponent_mask;
+    h_assert(one.to_bits() == bits, "bit pattern for 1.0 is wrong");
+    bits |= 1 << (T::mantissa_bits - 2);
+    h_assert(onePointTwoFive.to_bits() == bits, "bit pattern for 1.25 is wrong");
 
     // Check comparision operators
     h_assert(!(one == onePointTwoFive), "comparision failed");
@@ -32,23 +35,23 @@ int main() {
     h_assert(one == one, "comparision failed");
 
     // Try with a negative number
-    const float16_t minusOne = -one;
+    const T minusOne = -one;
     h_assert(minusOne < one, "-1.0 should be < 1.0");
     h_assert(one > minusOne, "1.0 should be > -1.0");
 
     // NaN never compares equal to itself
-    const float16_t nanValue = float16_t::make_nan();
+    const T nanValue = T::make_nan();
     h_assert(nanValue != nanValue, "NaN must not compare equal to itself");
     h_assert(!(nanValue == nanValue), "NaN must not compare equal to itself");
 
     // +ve zero and -ve zero are comparable
-    const float16_t zeroP = float16_t::make_zero(/*positive=*/true);
-    const float16_t zeroN = float16_t::make_zero(/*positive=*/false);
+    const T zeroP = T::make_zero(/*positive=*/true);
+    const T zeroN = T::make_zero(/*positive=*/false);
     h_assert(zeroP == zeroN, "+0 and -0 should be treated as equal");
 
     // Infinities are comparable
-    const float16_t infinityP = float16_t::make_infinity(/*positive=*/true);
-    const float16_t infinityN = float16_t::make_infinity(/*positive=*/false);
+    const T infinityP = T::make_infinity(/*positive=*/true);
+    const T infinityN = T::make_infinity(/*positive=*/false);
     h_assert(infinityP > infinityN, "inf+ should be > inf-");
     h_assert(infinityN < infinityP, "inf- should be < inf+");
     h_assert(one < infinityP, "1.0 should be < inf+");
@@ -56,6 +59,12 @@ int main() {
     h_assert(one > infinityN, "1.0 should be > inf-");
     h_assert(minusOne > infinityN, "-1.0 should be > inf-");
 
+    return true;
+}
+
+int main() {
+    test<float16_t>();
+    test<bfloat16_t>();
     printf("Success!\n");
     return 0;
 }

--- a/test/correctness/float16_t_image_type.cpp
+++ b/test/correctness/float16_t_image_type.cpp
@@ -4,20 +4,21 @@
 
 using namespace Halide;
 
-int main() {
-    Halide::Buffer<float16_t> im(10, 3);
+template<typename T>
+bool test() {
+    Halide::Buffer<T> im(10, 3);
     im.set_min(4, -6);
 
     // Write a constant value and check we can read it back. Mostly
     // this checks the addressing math is doing the right thing for
     // float16_t.
     im.for_each_element([&](int x, int y) {
-            im(x, y) = float16_t(x + y / 8.0);
+            im(x, y) = T(x + y / 8.0);
         });
 
     if (im.size_in_bytes() != im.number_of_elements() * 2) {
         printf("Incorrect amount of memory allocated\n");
-        return -1;
+        return false;
     }
 
     for (int y = im.dim(1).min(); y <= im.dim(1).max(); y++) {
@@ -27,11 +28,19 @@ int main() {
             if (correct != actual) {
                 printf("im(%d, %d) = %f instead of %f\n",
                        x, y, actual, correct);
-                return -1;
+                return false;
             }
         }
     }
 
-    printf("Success!\n");
-    return 0;
+    return true;
+}
+
+int main() {
+    if (test<float16_t>() && test<bfloat16_t>()) {
+        printf("Success!\n");
+        return 0;
+    } else {
+        return -1;
+    }
 }

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -1192,7 +1192,7 @@ bool save_mat(ImageType &im, const std::string &filename) {
             check(false, "unreachable");
         };
         break;
-    case halide_type_handle:
+    default:
         check(false, "unreachable");
     }
 


### PR DESCRIPTION
Lowers to uint16s for all backends, with math done by temporarily placing the bits in the MSBs of a float.