### PR TITLE
Let generators compute a GCD target when multiple targets are passed to `-r`

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -988,7 +988,7 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
         std::string base_path = compute_base_path(output_dir, runtime_name, "");
 
         Target gcd_target = targets[0];
-        for (int i = 1; i < targets.size(); i++) {
+        for (size_t i = 1; i < targets.size(); i++) {
             if (!gcd_target.get_runtime_compatible_target(targets[i], gcd_target)) {
                 user_error << "Failed to find compatible runtime target for "
                            << gcd_target.to_string()

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -977,7 +977,7 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
     auto target_strings = split_string(generator_args["target"].string_value, ",");
     std::vector<Target> targets;
     for (const auto &s : target_strings) {
-        targets.push_back(Target(s));
+        targets.emplace_back(s);
     }
 
     if (!runtime_name.empty()) {

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -813,10 +813,17 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
         " -x  A comma separated list of file extension pairs to substitute during\n"
         "     file naming, in the form [.old=.new[,.old2=.new2]]\n"
         "\n"
-        " -p  A comma-separted list of shared libraries that will be loaded before the\n"
+        " -p  A comma-separated list of shared libraries that will be loaded before the\n"
         "     generator is run. Useful for custom auto-schedulers. The generator must\n"
         "     either be linked against a shared libHalide or compiled with -rdynamic\n"
-        "     so that references in the shared library to libHalide can resolve.\n";
+        "     so that references in the shared library to libHalide can resolve.\n"
+        "\n"
+        "-r   The name of a standalone runtime to generate. Only honors EMIT_OPTIONS 'o'\n"
+        "     and 'static_library'. When multiple targets are specified, it picks a\n"
+        "     runtime that is compatible with all of the targets, or fails if it cannot\n"
+        "     find one. Flags across all of the targets that do not affect runtime code\n"
+        "     generation, such as `no_asserts` and `no_runtime`, are ignored.\n"
+        ;
 
     std::map<std::string, std::string> flags_info = { { "-f", "" },
                                                       { "-g", "" },
@@ -855,7 +862,7 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
 
     // It's possible that in the future loaded plugins might change
     // how arguments are parsed, so we handle those first.
-    for (auto lib : split_string(flags_info["-p"], ",")) {
+    for (const auto &lib : split_string(flags_info["-p"], ",")) {
         if (lib.empty()) continue;
 #ifdef _WIN32
         if (LoadLibrary(lib.c_str()) != nullptr) {
@@ -885,7 +892,7 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
         // no longer infer the name when only one Generator is registered
         cerr << "Either -g <name> or -r must be specified; available Generators are:\n";
         if (!generator_names.empty()) {
-            for (auto name : generator_names) {
+            for (const auto &name : generator_names) {
                 cerr << "    " << name << "\n";
             }
         } else {

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -981,10 +981,6 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
     }
 
     if (!runtime_name.empty()) {
-        if (targets.size() != 1) {
-            cerr << "Only one target allowed here";
-            return 1;
-        }
         std::string base_path = compute_base_path(output_dir, runtime_name, "");
 
         Target gcd_target = targets[0];
@@ -995,6 +991,10 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
                            << " and "
                            << targets[i].to_string() << '\n';
             }
+        }
+
+        if (targets.size() > 1) {
+            debug(1) << "Building runtime for computed target: " << gcd_target.to_string() << "\n";
         }
 
         Outputs output_files = compute_outputs(gcd_target, base_path, emit_options);

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -986,8 +986,19 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
             return 1;
         }
         std::string base_path = compute_base_path(output_dir, runtime_name, "");
-        Outputs output_files = compute_outputs(targets[0], base_path, emit_options);
-        compile_standalone_runtime(output_files, targets[0]);
+
+        Target gcd_target = targets[0];
+        for (int i = 1; i < targets.size(); i++) {
+            if (!gcd_target.get_runtime_compatible_target(targets[i], gcd_target)) {
+                user_error << "Failed to find compatible runtime target for "
+                           << gcd_target.to_string()
+                           << " and "
+                           << targets[i].to_string() << '\n';
+            }
+        }
+
+        Outputs output_files = compute_outputs(gcd_target, base_path, emit_options);
+        compile_standalone_runtime(output_files, gcd_target);
     }
 
     if (!generator_name.empty()) {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -871,7 +871,7 @@ bool Target::get_runtime_compatible_target(const Target& other, Target &result) 
 }
 
 
-    namespace Internal {
+namespace Internal {
 
 void target_test() {
     Target t;

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -796,9 +796,9 @@ bool Target::get_runtime_compatible_target(const Target& other, Target &result) 
     // (b) must be included if both targets have the feature (intersection)
     // (c) must match across both targets; it is an error if one target has the feature and the other doesn't
     const std::array<Feature, 25> union_features = {
-            Debug, TSAN, ASAN, MSAN, CUDA, CUDACapability30, CUDACapability32, CUDACapability35, CUDACapability50,
-            CUDACapability61, OpenCL, OpenGL, OpenGLCompute, MinGW, Metal, HexagonDma, HVX_64, HVX_128, HVX_v62,
-            HVX_v65, HVX_v66, HVX_shared_object, D3D12Compute, NoNEON, SoftFloatABI
+            CUDA, CUDACapability30, CUDACapability32, CUDACapability35, CUDACapability50, CUDACapability61, OpenCL,
+            OpenGL, OpenGLCompute, MinGW, Metal, HexagonDma, HVX_64, HVX_128, HVX_v62, HVX_v65, HVX_v66,
+            HVX_shared_object, D3D12Compute, NoNEON
     };
 
     const std::array<Feature, 12> intersection_features = {
@@ -841,6 +841,7 @@ bool Target::get_runtime_compatible_target(const Target& other, Target &result) 
     // We merge the bits via bitwise or.
     Target output{os, arch, bits};
     output.features = ((features | other.features) & union_mask)
+            | ((features | other.features) & matching_mask)
             | ((features & other.features) & intersection_mask);
 
     if (!fixup_gcd_target(output)) {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -197,6 +197,8 @@ bool is_using_hexagon(const Target &t) {
            || t.has_feature(Target::HVX_v62)
            || t.has_feature(Target::HVX_v65)
            || t.has_feature(Target::HVX_v66)
+           || t.has_feature(Target::HexagonDma)
+           || t.has_feature(Target::HVX_shared_object)
            || t.arch == Target::Hexagon;
 }
 

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -165,9 +165,7 @@ Target calculate_host_target() {
 #endif
 #endif
 
-    Target t(os, arch, bits, initial_features);
-
-    return Target(os, arch, bits, initial_features);
+    return {os, arch, bits, initial_features};
 }
 
 }  // namespace
@@ -450,7 +448,7 @@ void bad_target_string(const std::string &target) {
     }
     separator = "";
     std::string oses;
-    for (auto os_entry : os_name_map) {
+    for (const auto &os_entry : os_name_map) {
         oses += separator + os_entry.first;
         separator = ", ";
     }
@@ -459,7 +457,7 @@ void bad_target_string(const std::string &target) {
     // assume the first line starts with "Features are ".
     int line_char_start = -(int)sizeof("Features are");
     std::string features;
-    for (auto feature_entry : feature_name_map) {
+    for (const auto &feature_entry : feature_name_map) {
         features += separator + feature_entry.first;
         if (features.length() - line_char_start > 70) {
             separator = "\n";
@@ -508,9 +506,7 @@ Target::Target(const std::string &target) {
     }
 }
 
-Target::Target(const char *s) {
-    *this = Target(std::string(s));
-}
+Target::Target(const char *s) : Target(std::string(s)) {}
 
 bool Target::validate_target_string(const std::string &s) {
     Target t;

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -192,8 +192,7 @@ int get_cuda_capability_lower_bound(const Target &t) {
 }
 
 int get_hvx_lower_bound(const Target &t) {
-    if (!t.has_feature(Target::HexagonDma) && t.arch != Target::Hexagon) {
-        // TODO: is this right? how do these options differ
+    if (!t.has_feature(Target::HVX_64) && !t.has_feature(Target::HVX_128)) {
         return 0;
     }
     if (t.has_feature(Target::HVX_v62)) {
@@ -205,8 +204,7 @@ int get_hvx_lower_bound(const Target &t) {
     if (t.has_feature(Target::HVX_v66)) {
         return 66;
     }
-    // TODO: Is there a lower HVX version, like 20 for CUDA?
-    return -1;
+    return 60;
 }
 
 }  // namespace
@@ -861,7 +859,8 @@ bool Target::get_runtime_compatible_target(const Target& other, Target &result) 
 
     // Pick tight lower bound for HVX version. Use fall-through to clear redundant features
     switch (get_hvx_lower_bound(result)) {
-        default: // no HexagonDMA feature; clear all capability flags
+        default: // not hexagon arch; clear all capability flags
+        case 60: result.features.reset(HVX_v62);
         case 62: result.features.reset(HVX_v65);
         case 65: result.features.reset(HVX_v66);
         case 66: break;

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -852,31 +852,32 @@ bool Target::get_runtime_compatible_target(const Target& other, Target &result) 
     // Union of features is computed through bitwise-or, and masked away by the features we care about
     // Intersection of features is computed through bitwise-and and masked away, too.
     // We merge the bits via bitwise or.
-    result = Target{os, arch, bits};
-    result.features = ((features | other.features) & union_mask)
+    Target output = Target{os, arch, bits};
+    output.features = ((features | other.features) & union_mask)
             | ((features | other.features) & matching_mask)
             | ((features & other.features) & intersection_mask);
 
     // Pick tight lower bound for CUDA capability. Use fall-through to clear redundant features
-    switch (get_cuda_capability_lower_bound(result)) {
+    switch (get_cuda_capability_lower_bound(output)) {
         default: // no CUDA feature; clear all capability flags
-        case 20: result.features.reset(CUDACapability30);
-        case 30: result.features.reset(CUDACapability32);
-        case 32: result.features.reset(CUDACapability35);
-        case 35: result.features.reset(CUDACapability50);
-        case 50: result.features.reset(CUDACapability61);
+        case 20: output.features.reset(CUDACapability30);
+        case 30: output.features.reset(CUDACapability32);
+        case 32: output.features.reset(CUDACapability35);
+        case 35: output.features.reset(CUDACapability50);
+        case 50: output.features.reset(CUDACapability61);
         case 61: break;
     }
 
     // Pick tight lower bound for HVX version. Use fall-through to clear redundant features
-    switch (get_hvx_lower_bound(result)) {
+    switch (get_hvx_lower_bound(output)) {
         default: // doesn't use hexagon; clear all capability flags
-        case 60: result.features.reset(HVX_v62);
-        case 62: result.features.reset(HVX_v65);
-        case 65: result.features.reset(HVX_v66);
+        case 60: output.features.reset(HVX_v62);
+        case 62: output.features.reset(HVX_v65);
+        case 65: output.features.reset(HVX_v66);
         case 66: break;
     }
 
+    result = output;
     return true;
 }
 

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -860,20 +860,20 @@ bool Target::get_runtime_compatible_target(const Target& other, Target &result) 
     // Pick tight lower bound for CUDA capability. Use fall-through to clear redundant features
     switch (get_cuda_capability_lower_bound(output)) {
         default: // no CUDA feature; clear all capability flags
-        case 20: output.features.reset(CUDACapability30);
-        case 30: output.features.reset(CUDACapability32);
-        case 32: output.features.reset(CUDACapability35);
-        case 35: output.features.reset(CUDACapability50);
-        case 50: output.features.reset(CUDACapability61);
+        case 20: output.features.reset(CUDACapability30); // fall-thru
+        case 30: output.features.reset(CUDACapability32); // fall-thru
+        case 32: output.features.reset(CUDACapability35); // fall-thru
+        case 35: output.features.reset(CUDACapability50); // fall-thru
+        case 50: output.features.reset(CUDACapability61); // fall-thru
         case 61: break;
     }
 
     // Pick tight lower bound for HVX version. Use fall-through to clear redundant features
     switch (get_hvx_lower_bound(output)) {
         default: // doesn't use hexagon; clear all capability flags
-        case 60: output.features.reset(HVX_v62);
-        case 62: output.features.reset(HVX_v65);
-        case 65: output.features.reset(HVX_v66);
+        case 60: output.features.reset(HVX_v62); // fall-thru
+        case 62: output.features.reset(HVX_v65); // fall-thru
+        case 65: output.features.reset(HVX_v66); // fall-thru
         case 66: break;
     }
 

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -191,8 +191,17 @@ int get_cuda_capability_lower_bound(const Target &t) {
     return 20;
 }
 
+bool is_using_hexagon(const Target &t) {
+    return t.has_feature(Target::HVX_64)
+           || t.has_feature(Target::HVX_128)
+           || t.has_feature(Target::HVX_v62)
+           || t.has_feature(Target::HVX_v65)
+           || t.has_feature(Target::HVX_v66)
+           || t.arch == Target::Hexagon;
+}
+
 int get_hvx_lower_bound(const Target &t) {
-    if (!t.has_feature(Target::HVX_64) && !t.has_feature(Target::HVX_128)) {
+    if (!is_using_hexagon(t)) {
         return 0;
     }
     if (t.has_feature(Target::HVX_v62)) {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -893,6 +893,36 @@ void target_test() {
         if (i == halide_target_feature_unused_23) continue;
         internal_assert(t.has_feature((Target::Feature)i)) << "Feature " << i << " not in feature_names_map.\n";
     }
+
+    // 3 targets: {A,B,C}. Want gcd(A,B)=C
+    std::vector<std::array<std::string, 3>> gcd_tests = {
+            {"x86-64-linux-sse41-fma", "x86-64-linux-sse41-fma", "x86-64-linux-sse41-fma"},
+            {"x86-64-linux-sse41-fma-no_asserts-no_runtime", "x86-64-linux-sse41-fma", "x86-64-linux-sse41-fma"},
+            {"x86-64-linux-avx2-sse41", "x86-64-linux-sse41-fma", "x86-64-linux-sse41"},
+            {"x86-64-linux-avx2-sse41", "x86-32-linux-sse41-fma", ""},
+            {"x86-64-linux-cuda", "x86-64-linux", "x86-64-linux-cuda"},
+            {"x86-64-linux-cuda-cuda_capability_50", "x86-64-linux-cuda", "x86-64-linux-cuda"},
+            {"x86-64-linux-cuda-cuda_capability_50", "x86-64-linux-cuda-cuda_capability_30", "x86-64-linux-cuda-cuda_capability_30"},
+            {"x86-64-linux-cuda", "x86-64-linux-opengl", "x86-64-linux-cuda-opengl"},
+            {"hexagon-32-qurt-hvx_v65", "hexagon-32-qurt-hvx_v62", "hexagon-32-qurt-hvx_v62"},
+            {"hexagon-32-qurt-hvx_v62", "hexagon-32-qurt", "hexagon-32-qurt"}
+    };
+
+    for (const auto &test : gcd_tests) {
+        Target result{};
+        Target a{test[0]};
+        Target b{test[1]};
+        if (a.get_runtime_compatible_target(b, result)) {
+            internal_assert(!test[2].empty() && result == Target{test[2]})
+                << "Targets " << a.to_string() << " and " << b.to_string() << " were computed to have gcd "
+                << result.to_string() << " but expected '" << test[2] << "'\n";
+        } else {
+            internal_assert(test[2].empty())
+                << "Targets " << a.to_string() << " and " << b.to_string() << " were computed to have no gcd "
+                << "but " << test[2] << " was expected.";
+        }
+    }
+
     std::cout << "Target test passed" << std::endl;
 }
 

--- a/src/Target.h
+++ b/src/Target.h
@@ -106,7 +106,7 @@ struct Target {
         FeatureEnd = halide_target_feature_end
     };
     Target() : os(OSUnknown), arch(ArchUnknown), bits(0) {}
-    Target(OS o, Arch a, int b, std::vector<Feature> initial_features = std::vector<Feature>())
+    Target(OS o, Arch a, int b, const std::vector<Feature> &initial_features = std::vector<Feature>())
         : os(o), arch(a), bits(b) {
         for (const auto &f :initial_features) {
             set_feature(f);

--- a/src/Target.h
+++ b/src/Target.h
@@ -189,6 +189,8 @@ struct Target {
       return !(*this == other);
     }
 
+    bool get_runtime_compatible_target(const Target& other, Target &result);
+
     /** Convert the Target into a string form that can be reconstituted
      * by merge_string(), which will always be of the form
      *
@@ -235,6 +237,8 @@ struct Target {
 private:
     /** A bitmask that stores the active features. */
     std::bitset<FeatureEnd> features;
+
+    static bool fixup_gcd_target(Target& target);
 };
 
 /** Return the target corresponding to the host machine. */

--- a/src/Target.h
+++ b/src/Target.h
@@ -246,8 +246,6 @@ struct Target {
 private:
     /** A bitmask that stores the active features. */
     std::bitset<FeatureEnd> features;
-
-    static bool fixup_gcd_target(Target& target);
 };
 
 /** Return the target corresponding to the host machine. */

--- a/src/Target.h
+++ b/src/Target.h
@@ -195,7 +195,7 @@ struct Target {
      * runtime when linking together multiple functions.
      * 
      * @param other The other target from which we compute the gcd target.
-     * @param[out] result The gcd target if we return true, otherwise unmodified.
+     * @param[out] result The gcd target if we return true, otherwise unmodified. Can be the same as *this.
      * @return Whether it was possible to find a compatible target (true) or not.
      */
     bool get_runtime_compatible_target(const Target& other, Target &result);

--- a/src/Target.h
+++ b/src/Target.h
@@ -189,6 +189,15 @@ struct Target {
       return !(*this == other);
     }
 
+    /**
+     * Create a "greatest common denominator" runtime target that is compatible with
+     * both this target and \p other. Used by generators to conveniently select a suitable
+     * runtime when linking together multiple functions.
+     * 
+     * @param other The other target from which we compute the gcd target.
+     * @param[out] result The gcd target if we return true, otherwise unmodified.
+     * @return Whether it was possible to find a compatible target (true) or not.
+     */
     bool get_runtime_compatible_target(const Target& other, Target &result);
 
     /** Convert the Target into a string form that can be reconstituted

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1206,6 +1206,8 @@ extern int halide_error_integer_division_by_zero(void *user_context);
 // @}
 
 /** Optional features a compilation Target can have.
+ * Be sure to keep this in sync with the Feature enum in Target.h and the implementation of
+ * get_runtime_compatible_target in Target.cpp if you add a new feature.
  */
 typedef enum halide_target_feature_t {
     halide_target_feature_jit = 0,  ///< Generate code that will run immediately inside the calling process.


### PR DESCRIPTION
Currently, generators support compiling Halide functions for multiple platform-compatible targets and automatically selecting the "best" one (in order) via runtime checks.

This PR extends a compatible behavior to the generator's runtime generation (via `-r`). Scripts that compile multiple functions into a single static library can now pass a comma-separated list of all the function targets to the generator and a "greatest common denominator" runtime will be selected.

This is a **draft** as there are certain target features that I'm not familiar with. I'm asking for some help deciding whether a GCD target should include a feature if _either_ source target has it (eg. `cuda`), only if _both_ have it (eg. `avx2`), or if it should be dropped (eg. `no_runtime`). The behavior does not change when a single runtime is specified, so tests are still needed, too.