### PR TITLE
Refactor is_parallel helper functions

### DIFF
--- a/src/Expr.h
+++ b/src/Expr.h
@@ -422,6 +422,19 @@ enum class ForType {
     GPULane,
 };
 
+/** Check if for_type executes for loop iterations in parallel and unordered. */
+inline bool is_unordered_parallel(ForType for_type) {
+    return (for_type == ForType::Parallel ||
+            for_type == ForType::GPUBlock ||
+            for_type == ForType::GPUThread);
+}
+
+/** Returns true if for_type executes for loop iterations is parallel. */
+inline bool is_parallel(ForType for_type) {
+    return (is_unordered_parallel(for_type) ||
+            for_type == ForType::Vectorized ||
+            for_type == ForType::GPULane);
+}
 
 /** A reference-counted handle to a statement node. */
 struct Stmt : public IRHandle {

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -429,7 +429,7 @@ inline bool is_unordered_parallel(ForType for_type) {
             for_type == ForType::GPUThread);
 }
 
-/** Returns true if for_type executes for loop iterations is parallel. */
+/** Returns true if for_type executes for loop iterations in parallel. */
 inline bool is_parallel(ForType for_type) {
     return (is_unordered_parallel(for_type) ||
             for_type == ForType::Vectorized ||

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -288,10 +288,7 @@ void Stage::set_dim_type(VarOrRVar var, ForType t) {
 
             // If it's an rvar and the for type is parallel, we need to
             // validate that this doesn't introduce a race condition.
-            if (!dims[i].is_pure() && var.is_rvar &&
-                (t == ForType::Vectorized || t == ForType::Parallel ||
-                 t == ForType::GPUBlock || t == ForType::GPUThread ||
-                 t == ForType::GPULane)) {
+            if (!dims[i].is_pure() && var.is_rvar && is_parallel(t)) {
                 user_assert(definition.schedule().allow_race_conditions())
                     << "In schedule for " << name()
                     << ", marking var " << var.name()

--- a/src/IR.h
+++ b/src/IR.h
@@ -692,10 +692,11 @@ struct For : public StmtNode<For> {
 
     static Stmt make(const std::string &name, Expr min, Expr extent, ForType for_type, DeviceAPI device_api, Stmt body);
 
+    bool is_unordered_parallel() const {
+        return Halide::Internal::is_unordered_parallel(for_type);
+    }
     bool is_parallel() const {
-        return (for_type == ForType::Parallel ||
-                for_type == ForType::GPUBlock ||
-                for_type == ForType::GPUThread);
+        return Halide::Internal::is_parallel(for_type);
     }
 
     static const IRNodeType _node_type = IRNodeType::For;

--- a/src/Inline.cpp
+++ b/src/Inline.cpp
@@ -40,7 +40,7 @@ void validate_schedule_inlined_function(Function f) {
 
     for (size_t i = 0; i < stage_s.dims().size(); i++) {
         Dim d = stage_s.dims()[i];
-        if (d.is_parallel()) {
+        if (d.is_unordered_parallel()) {
             user_error << "Cannot parallelize dimension "
                        << d.var << " of function "
                        << f.name() << " because the function is scheduled inline.\n";

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -252,7 +252,7 @@ private:
         // threads outside the loop, and increment it inside the
         // body.
         bool update_active_threads = (op->device_api == DeviceAPI::Hexagon ||
-                                      op->is_parallel());
+                                      op->is_unordered_parallel());
 
         if (update_active_threads) {
             body = Block::make({incr_active_threads(), body, decr_active_threads()});

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -293,10 +293,11 @@ struct Dim {
 
     bool is_pure() const {return (dim_type == PureVar) || (dim_type == PureRVar);}
     bool is_rvar() const {return (dim_type == PureRVar) || (dim_type == ImpureRVar);}
+    bool is_unordered_parallel() const {
+        return Halide::Internal::is_unordered_parallel(for_type);
+    }
     bool is_parallel() const {
-        return (for_type == ForType::Parallel ||
-                for_type == ForType::GPUBlock ||
-                for_type == ForType::GPUThread);
+        return Halide::Internal::is_parallel(for_type);
     }
 };
 

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1485,7 +1485,7 @@ private:
         // Since we are now in the lowering phase, we expect all LoopLevels to be locked;
         // thus any new ones we synthesize we must explicitly lock.
         loop_level.lock();
-        Site s = {f->is_parallel() || f->for_type == ForType::Vectorized, loop_level};
+        Site s = {f->is_parallel(), loop_level};
         sites.push_back(s);
         f->body.accept(this);
         sites.pop_back();


### PR DESCRIPTION
This PR does a small cleanup of code that checks if a loop is parallel:
- Adds `is_unordered_parallel` and `is_parallel` helper functions
- Renames existing `is_parallel` helper functions on `For` and `Dim` and adds `is_unordered_parallel`
- Possible small bug fix in ScheduleFunctions.cpp, was this check missing `ForType::GPULane`? @abadams