### PR TITLE
Fix LoadLibrary call to use UTF-8 instead of ANSI.

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -865,7 +865,17 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
     for (const auto &lib : split_string(flags_info["-p"], ",")) {
         if (lib.empty()) continue;
 #ifdef _WIN32
-        if (LoadLibrary(lib.c_str()) != nullptr) {
+        HMODULE loaded_lib;
+
+        {
+            int wide_len = MultiByteToWideChar(CP_UTF8, 0, lib.c_str(), -1, nullptr, 0);
+            auto *wide_lib = new wchar_t[wide_len];
+            MultiByteToWideChar(CP_UTF8, 0, lib.c_str(), -1, wide_lib, wide_len);
+            loaded_lib = LoadLibraryW(wide_lib);
+            delete[] wide_lib;
+        }
+
+        if (loaded_lib != nullptr) {
             cerr << "Failed to load: " << lib << "\n";
             return 1;
         }

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -865,17 +865,20 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
     for (const auto &lib : split_string(flags_info["-p"], ",")) {
         if (lib.empty()) continue;
 #ifdef _WIN32
-        HMODULE loaded_lib;
-
-        {
-            int wide_len = MultiByteToWideChar(CP_UTF8, 0, lib.c_str(), -1, nullptr, 0);
-            auto *wide_lib = new wchar_t[wide_len];
-            MultiByteToWideChar(CP_UTF8, 0, lib.c_str(), -1, wide_lib, wide_len);
-            loaded_lib = LoadLibraryW(wide_lib);
-            delete[] wide_lib;
+        int wide_len = MultiByteToWideChar(CP_UTF8, 0, lib.c_str(), -1, nullptr, 0);
+        if (wide_len < 1) {
+            cerr << "Failed to load: " << lib << " (unconvertible character)\n";
+            return 1;
         }
 
-        if (loaded_lib != nullptr) {
+        std::vector<wchar_t> wide_lib(wide_len);
+        wide_len = MultiByteToWideChar(CP_UTF8, 0, lib.c_str(), -1, wide_lib.data(), wide_len);
+        if (wide_len < 1) {
+            cerr << "Failed to load: " << lib << " (unconvertible character)\n";
+            return 1;
+        }
+
+        if (LoadLibraryW(wide_lib.data()) != nullptr) {
             cerr << "Failed to load: " << lib << "\n";
             return 1;
         }

--- a/src/runtime/windows_get_symbol.cpp
+++ b/src/runtime/windows_get_symbol.cpp
@@ -8,7 +8,7 @@ extern "C" {
 #define WIN32API __stdcall
 #endif
 
-WIN32API void *LoadLibraryW(const char *);
+WIN32API void *LoadLibraryA(const char *);
 WIN32API void *GetProcAddress(void *, const char *);
 WIN32API unsigned SetErrorMode(unsigned);
 #define SEM_FAILCRITICALERRORS 0x0001
@@ -21,20 +21,7 @@ WEAK void *halide_default_get_symbol(const char *name) {
 WEAK void *halide_default_load_library(const char *name) {
     // Suppress dialog windows during library open.
     unsigned old_mode = SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOOPENFILEERRORBOX);
-    int wide_len = MultiByteToWideChar(CP_UTF8, 0, name.c_str(), -1, nullptr, 0);
-    if (wide_len < 1) {
-        SetErrorMode(old_mode);
-        return nullptr;
-    }
-
-    std::vector<wchar_t> wide_lib(wide_len);
-    wide_len = MultiByteToWideChar(CP_UTF8, 0, lib.c_str(), -1, wide_lib.data(), wide_len);
-    if (wide_len < 1) {
-        SetErrorMode(old_mode);
-        return nullptr;
-    }
-
-    void *lib = LoadLibraryW(wide_lib.data());
+    void *lib = LoadLibraryA(name);
     SetErrorMode(old_mode);
     return lib;
 }

--- a/src/runtime/windows_get_symbol.cpp
+++ b/src/runtime/windows_get_symbol.cpp
@@ -8,7 +8,7 @@ extern "C" {
 #define WIN32API __stdcall
 #endif
 
-WIN32API void *LoadLibraryA(const char *);
+WIN32API void *LoadLibraryW(const char *);
 WIN32API void *GetProcAddress(void *, const char *);
 WIN32API unsigned SetErrorMode(unsigned);
 #define SEM_FAILCRITICALERRORS 0x0001
@@ -21,7 +21,20 @@ WEAK void *halide_default_get_symbol(const char *name) {
 WEAK void *halide_default_load_library(const char *name) {
     // Suppress dialog windows during library open.
     unsigned old_mode = SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOOPENFILEERRORBOX);
-    void *lib = LoadLibraryA(name);
+    int wide_len = MultiByteToWideChar(CP_UTF8, 0, name.c_str(), -1, nullptr, 0);
+    if (wide_len < 1) {
+        SetErrorMode(old_mode);
+        return nullptr;
+    }
+
+    std::vector<wchar_t> wide_lib(wide_len);
+    wide_len = MultiByteToWideChar(CP_UTF8, 0, lib.c_str(), -1, wide_lib.data(), wide_len);
+    if (wide_len < 1) {
+        SetErrorMode(old_mode);
+        return nullptr;
+    }
+
+    void *lib = LoadLibraryW(wide_lib.data());
     SetErrorMode(old_mode);
     return lib;
 }

--- a/tutorial/lesson_12_using_the_gpu.cpp
+++ b/tutorial/lesson_12_using_the_gpu.cpp
@@ -297,9 +297,9 @@ Target find_gpu_target() {
     // return target;
 
 #ifdef _WIN32
-    if (LoadLibrary("d3d12.dll") != NULL) {
+    if (LoadLibraryA("d3d12.dll") != nullptr) {
         target.set_feature(Target::D3D12Compute);
-    } else if (LoadLibrary("OpenCL.dll") != NULL) {
+    } else if (LoadLibraryA("OpenCL.dll") != nullptr) {
         target.set_feature(Target::OpenCL);
     }
 #elif __APPLE__


### PR DESCRIPTION
Addressing issue #3682, fixes the call to `LoadLibrary` to always use `LoadLibraryW` by converting UTF-8 to UTF-16 manually before call.