### PR TITLE
Add read_entire() and write_entire()

### DIFF
--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -1,4 +1,3 @@
-#include <fstream>
 #include <iostream>
 #include <memory>
 
@@ -998,14 +997,7 @@ Buffer<uint8_t> compile_module_to_hexagon_shared_object(const Module &device_cod
 
         debug(1) << "Signing Hexagon code: " << input.pathname() << " -> " << output.pathname() << "\n";
 
-        {
-            std::ofstream f(input.pathname(), std::ios::out|std::ios::binary);
-
-            f.write(shared_object.data(), shared_object.size());
-            f.flush();
-            internal_assert(f.good());
-            f.close();
-        }
+        write_entire(input.pathname(), shared_object);
 
         debug(1) << "Signing tool: (" << signer << ")\n";
         std::string cmd = signer + " " + input.pathname() + " " + output.pathname();
@@ -1014,16 +1006,7 @@ Buffer<uint8_t> compile_module_to_hexagon_shared_object(const Module &device_cod
             << "HL_HEXAGON_CODE_SIGNER failed: result = " << result
             << " for cmd (" << cmd << ")";
 
-        {
-            std::ifstream f(output.pathname(), std::ios::in|std::ios::binary);
-            f.seekg(0, std::ifstream::end);
-            size_t signed_size = f.tellg();
-            shared_object.resize(signed_size);
-            f.seekg(0, std::ifstream::beg);
-            f.read(shared_object.data(), shared_object.size());
-            internal_assert(f.good());
-            f.close();
-        }
+        shared_object = read_entire(output.pathname());
     }
 
     Halide::Buffer<uint8_t> result_buf(shared_object.size(), device_code.name());

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -997,7 +997,7 @@ Buffer<uint8_t> compile_module_to_hexagon_shared_object(const Module &device_cod
 
         debug(1) << "Signing Hexagon code: " << input.pathname() << " -> " << output.pathname() << "\n";
 
-        write_entire(input.pathname(), shared_object);
+        write_entire_file(input.pathname(), shared_object);
 
         debug(1) << "Signing tool: (" << signer << ")\n";
         std::string cmd = signer + " " + input.pathname() + " " + output.pathname();
@@ -1006,7 +1006,7 @@ Buffer<uint8_t> compile_module_to_hexagon_shared_object(const Module &device_cod
             << "HL_HEXAGON_CODE_SIGNER failed: result = " << result
             << " for cmd (" << cmd << ")";
 
-        shared_object = read_entire(output.pathname());
+        shared_object = read_entire_file(output.pathname());
     }
 
     Halide::Buffer<uint8_t> result_buf(shared_object.size(), device_code.name());

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -4,6 +4,7 @@
 #include "Introspection.h"
 #include <atomic>
 #include <chrono>
+#include <fstream>
 #include <iomanip>
 #include <map>
 #include <mutex>
@@ -409,6 +410,29 @@ std::string dir_make_temp() {
     internal_assert(result != nullptr) << "Unable to create temp directory.\n";
     return std::string(result);
     #endif
+}
+
+std::vector<char> read_entire(const std::string &pathname) {
+    std::ifstream f(pathname, std::ios::in|std::ios::binary);
+    std::vector<char> result;
+
+    f.seekg(0, std::ifstream::end);
+    size_t size = f.tellg();
+    result.resize(size);
+    f.seekg(0, std::ifstream::beg);
+    f.read(result.data(), result.size());
+    internal_assert(f.good()) << "Unable to read file: " << pathname;
+    f.close();
+    return result;
+}
+
+void write_entire(const std::string &pathname, const void *source, size_t source_len) {
+    std::ofstream f(pathname, std::ios::out|std::ios::binary);
+
+    f.write(reinterpret_cast<const char*>(source), source_len);
+    f.flush();
+    internal_assert(f.good()) << "Unable to write file: " << pathname;
+    f.close();
 }
 
 bool add_would_overflow(int bits, int64_t a, int64_t b) {

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -412,7 +412,7 @@ std::string dir_make_temp() {
     #endif
 }
 
-std::vector<char> read_entire(const std::string &pathname) {
+std::vector<char> read_entire_file(const std::string &pathname) {
     std::ifstream f(pathname, std::ios::in|std::ios::binary);
     std::vector<char> result;
 
@@ -426,7 +426,7 @@ std::vector<char> read_entire(const std::string &pathname) {
     return result;
 }
 
-void write_entire(const std::string &pathname, const void *source, size_t source_len) {
+void write_entire_file(const std::string &pathname, const void *source, size_t source_len) {
     std::ofstream f(pathname, std::ios::out|std::ios::binary);
 
     f.write(reinterpret_cast<const char*>(source), source_len);

--- a/src/Util.h
+++ b/src/Util.h
@@ -265,6 +265,19 @@ void dir_rmdir(const std::string &name);
 /** Wrapper for stat(). Asserts upon error. */
 FileStat file_stat(const std::string &name);
 
+/** Read the entire contents of a file into a vector<char>. The file
+ * is read in binary mode. Errors trigger an assertion failure. */
+std::vector<char> read_entire(const std::string &pathname);
+
+/** Create or replace the contents of a file with a given pointer-and-length
+ * of memory. If the file doesn't exist, it is created; if it does exist, it
+ * is completely overwritten. Any error triggers an assertion failure. */
+void write_entire(const std::string &pathname, const void *source, size_t source_len);
+
+inline void write_entire(const std::string &pathname, const std::vector<char> &source) {
+    write_entire(pathname, source.data(), source.size());
+}
+
 /** A simple utility class that creates a temporary file in its ctor and
  * deletes that file in its dtor; this is useful for temporary files that you
  * want to ensure are deleted when exiting a certain scope. Since this is essentially

--- a/src/Util.h
+++ b/src/Util.h
@@ -267,15 +267,15 @@ FileStat file_stat(const std::string &name);
 
 /** Read the entire contents of a file into a vector<char>. The file
  * is read in binary mode. Errors trigger an assertion failure. */
-std::vector<char> read_entire(const std::string &pathname);
+std::vector<char> read_entire_file(const std::string &pathname);
 
 /** Create or replace the contents of a file with a given pointer-and-length
  * of memory. If the file doesn't exist, it is created; if it does exist, it
  * is completely overwritten. Any error triggers an assertion failure. */
-void write_entire(const std::string &pathname, const void *source, size_t source_len);
+void write_entire_file(const std::string &pathname, const void *source, size_t source_len);
 
-inline void write_entire(const std::string &pathname, const std::vector<char> &source) {
-    write_entire(pathname, source.data(), source.size());
+inline void write_entire_file(const std::string &pathname, const std::vector<char> &source) {
+    write_entire_file(pathname, source.data(), source.size());
 }
 
 /** A simple utility class that creates a temporary file in its ctor and


### PR DESCRIPTION
Simple utility functions to slurp / spew the entire contents of a file; not much re-use in this PR but I'll need them elsewhere in the future, so this is intended to reduce future PR noise.