### PR TITLE
Move inject_profiling after bound_small_allocations

### DIFF
--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -312,12 +312,6 @@ Module lower(const vector<Function> &output_funcs,
     s = inject_early_frees(s);
     debug(2) << "Lowering after injecting early frees:\n" << s << "\n\n";
 
-    if (t.has_feature(Target::Profile)) {
-        debug(1) << "Injecting profiling...\n";
-        s = inject_profiling(s, pipeline_name);
-        debug(2) << "Lowering after injecting profiling:\n" << s << "\n\n";
-    }
-
     if (t.has_feature(Target::FuzzFloatStores)) {
         debug(1) << "Fuzzing floating point stores...\n";
         s = fuzz_float_stores(s);
@@ -327,6 +321,12 @@ Module lower(const vector<Function> &output_funcs,
     debug(1) << "Bounding small allocations...\n";
     s = bound_small_allocations(s);
     debug(2) << "Lowering after bounding small allocations:\n" << s << "\n\n";
+
+    if (t.has_feature(Target::Profile)) {
+        debug(1) << "Injecting profiling...\n";
+        s = inject_profiling(s, pipeline_name);
+        debug(2) << "Lowering after injecting profiling:\n" << s << "\n\n";
+    }
 
     if (t.has_feature(Target::CUDA)) {
         debug(1) << "Injecting warp shuffles...\n";


### PR DESCRIPTION
This fixes cases where an allocation are falsely reported as heap allocations, because small dynamic allocations become stack allocations after `bound_small_allocations`.