### PR TITLE
Sketch of float16 support for Generator (Issue #3709)

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -358,6 +358,8 @@ string type_to_c_type(Type type, bool include_space, bool c_plus_plus = true) {
             oss << "float";
         } else if (type.bits() == 64) {
             oss << "double";
+        } else if (type.bits() == 16) {
+            oss << "halide_float16_t";
         } else {
             user_error << "Can't represent a float with this many bits in C: " << type << "\n";
         }

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -760,6 +760,7 @@ const std::map<std::string, Type> &get_halide_type_enum_map() {
         {"uint8", UInt(8)},
         {"uint16", UInt(16)},
         {"uint32", UInt(32)},
+        {"float16", Float(16)},
         {"float32", Float(32)},
         {"float64", Float(64)}
     };

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1843,6 +1843,7 @@ using GeneratorInputImplBase =
     typename select_type<
         cond<has_static_halide_type_method<TBase>::value, GeneratorInput_Buffer<T>>,
         cond<std::is_same<TBase, Func>::value,            GeneratorInput_Func<T>>,
+        cond<std::is_same<TBase, float16_t>::value,       GeneratorInput_Arithmetic<T>>,
         cond<std::is_arithmetic<TBase>::value,            GeneratorInput_Arithmetic<T>>,
         cond<std::is_scalar<TBase>::value,                GeneratorInput_Scalar<T>>
     >::type;

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1531,6 +1531,20 @@ extern int halide_downgrade_buffer_t(void *user_context, const char *name,
 extern int halide_downgrade_buffer_t_device_fields(void *user_context, const char *name,
                                                    const halide_buffer_t *new_buf, buffer_t *old_buf);
 
+/** Class that provides a type that implements half precision
+ *  floating point (IEEE754 2008 binary16) in software.
+ *
+ *  This type is enforced to be 16-bits wide and maintains no state
+ *  other than the raw IEEE754 binary16 bits so that it can passed
+ *  to code that checks a type's size and used for buffer_t allocation.
+ *
+ * TODO: reconcile this with Halide::float16_t; this is a stub to allow for
+ * header generation
+ * */
+struct halide_float16_t {
+    uint16_t bits;
+};
+
 /** halide_scalar_value_t is a simple union able to represent all the well-known
  * scalar values in a filter argument. Note that it isn't tagged with a type;
  * you must ensure you know the proper type before accessing. Most user
@@ -1550,6 +1564,7 @@ struct halide_scalar_value_t {
         uint16_t u16;
         uint32_t u32;
         uint64_t u64;
+        halide_float16_t f16;
         float f32;
         double f64;
         void *handle;

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -2,6 +2,8 @@
 
 namespace {
 
+using Halide::float16_t;
+
 enum class SomeEnum { Foo,
                       Bar };
 
@@ -21,6 +23,8 @@ public:
     Input<uint16_t> u16{ "u16", 160, 16, 2550 };
     Input<uint32_t> u32{ "u32", 320, 32, 2550 };
     Input<uint64_t> u64{ "u64", 640, 64, 2550 };
+    // TODO: use numbers more interesting than zero
+    Input<float16_t> f16{ "f16", float16_t(0.f), float16_t(0.f), float16_t(0.f) };
     Input<float> f32{ "f32", 32.1234f, -3200.1234f, 3200.1234f };
     Input<double> f64{ "f64", 64.25f, -6400.25f, 6400.25f };
     Input<void *> h{ "h", nullptr };


### PR DESCRIPTION
Known to be incomplete:
- we need a little better support in HalideRuntime for a float16 type if we are going to allow for float16 inputs, etc (see TODOs in various places)
- this test now fails with a spurious `Buffer argument buffer_array_input1_0 is NULL`, which suggests that I've botched something or that the float16 argument is confusing the buffer-checking assertions. Haven't bothered investigating yet as I thought input from @JasperJenkins and @abadams would be useful.