### PR TITLE
Support Buffer<float16> in Generators (Issue #3709)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1307,6 +1307,7 @@ METADATA_TESTER_GENERATOR_ARGS=\
 	buffer_array_input8.size=2 \
 	buffer_array_input8.dim=3 \
 	buffer_array_input8.type=float32 \
+	buffer_f16_untyped.type=float16 \
 	array_outputs.size=2 \
 	array_outputs7.size=2 \
 	array_outputs8.size=2 \

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -760,6 +760,7 @@ const std::map<std::string, Type> &get_halide_type_enum_map() {
         {"uint8", UInt(8)},
         {"uint16", UInt(16)},
         {"uint32", UInt(32)},
+        {"float16", Float(16)},
         {"float32", Float(32)},
         {"float64", Float(64)}
     };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -336,6 +336,7 @@ if (WITH_TEST_GENERATOR)
       buffer_array_input8.size=2
       buffer_array_input8.dim=3
       buffer_array_input8.type=float32
+      buffer_f16_untyped.type=float16
       array_outputs.size=2
       array_outputs7.size=2
       array_outputs8.size=2

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -939,6 +939,28 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
           nullptr,
         },
         {
+          "buffer_f16_typed",
+          halide_argument_kind_input_buffer,
+          1,
+          halide_type_t(halide_type_float, 16),
+          nullptr,
+          nullptr,
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
+          "buffer_f16_untyped",
+          halide_argument_kind_input_buffer,
+          1,
+          halide_type_t(halide_type_float, 16),
+          nullptr,
+          nullptr,
+          nullptr,
+          nullptr,
+          nullptr,
+        },
+        {
           "output.0",
           halide_argument_kind_output_buffer,
           3,
@@ -1289,6 +1311,9 @@ int main(int argc, char **argv) {
 
     Buffer<uint8_t> input = make_image<uint8_t>();
     Buffer<float> input_array[2] = {make_image<float>(), make_image<float>()};
+    // TODO: there is no runtime type for float16, so we'll declare this using a halide_type_t
+    const halide_type_t halide_type_float16 = halide_type_t(halide_type_float, 16, 1);
+    Buffer<> input_f16 = Buffer<>(halide_type_float16, kSize);
 
     Buffer<float> output0(kSize, kSize, 3);
     Buffer<float> output1(kSize, kSize, 3);
@@ -1347,6 +1372,8 @@ int main(int argc, char **argv) {
         input_array[0], input_array[1],  // Input<Buffer<float>[2]>
         input_array[0], input_array[1],  // Input<Buffer<float>[2]>
         input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_f16,         // Input<Buffer<float16>>
+        input_f16,         // Input<Buffer<float16>>
         output0, output1,  // Output<Tuple(Func, Func)>
         typed_output_buffer,    // Output<Buffer<float>>(3)
         type_only_output_buffer,    // Output<Buffer<float>>
@@ -1406,6 +1433,8 @@ int main(int argc, char **argv) {
         input_array[0], input_array[1],  // Input<Buffer<float>[2]>
         input_array[0], input_array[1],  // Input<Buffer<float>[2]>
         input_array[0], input_array[1],  // Input<Buffer<float>[2]>
+        input_f16,         // Input<Buffer<float16>>
+        input_f16,         // Input<Buffer<float16>>
         output0, output1,  // Output<Tuple(Func, Func)>
         typed_output_buffer,    // Output<Buffer<float>>(3)
         type_only_output_buffer,    // Output<Buffer<float>>

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -2,6 +2,8 @@
 
 namespace {
 
+using Halide::float16_t;
+
 enum class SomeEnum { Foo,
                       Bar };
 
@@ -49,6 +51,9 @@ public:
     Input<Buffer<>[]> buffer_array_input7{ "buffer_array_input7", 3 }; // buffer_array_input2.type must be set
     Input<Buffer<>[]> buffer_array_input8{ "buffer_array_input8" }; // dim and type must be set
 
+    Input<Buffer<float16_t>> buffer_f16_typed{ "buffer_f16_typed", 1 };
+    Input<Buffer<>> buffer_f16_untyped{ "buffer_f16_untyped", 1 };
+
     Output<Func> output{ "output" };  // must be overridden to {{Float(32), Float(32)}, 3}
     Output<Buffer<float>> typed_output_buffer{ "typed_output_buffer", 3 };
     Output<Buffer<float>> type_only_output_buffer{ "type_only_output_buffer" };  // untyped outputs can have type and/or dimensions inferred
@@ -71,6 +76,8 @@ public:
 
     void generate() {
         Var x("x"), y("y"), c("c");
+
+        assert(buffer_f16_untyped.type() == Float(16));
 
         // These should all be zero; they are here to exercise the operator[] overloads
         Expr zero1 = array_input[1](x, y, c) - array_input[0](x, y, c);


### PR DESCRIPTION
Note that this should allow for Input<Buffer<float16>> and Output<Buffer<float16>>, but *not* Input<float16> or Output<float16>; those require a bit more work (see PR #3711)