### PR TITLE
fixed Makefile build for the latest LLVM/clang release (7.1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1811,6 +1811,10 @@ ifneq (,$(findstring clang version 7.0,$(CLANG_VERSION)))
 CLANG_OK=yes
 endif
 
+ifneq (,$(findstring clang version 7.1,$(CLANG_VERSION)))
+CLANG_OK=yes
+endif
+
 ifneq (,$(findstring clang version 8.0,$(CLANG_VERSION)))
 CLANG_OK=yes
 endif
@@ -1839,7 +1843,7 @@ $(BUILD_DIR)/clang_ok:
 	@exit 1
 endif
 
-ifneq (,$(findstring $(LLVM_VERSION_TIMES_10), 60 70 80 90))
+ifneq (,$(findstring $(LLVM_VERSION_TIMES_10), 60 70 71 80 90))
 LLVM_OK=yes
 endif
 


### PR DESCRIPTION
I decided to simply add more entries specific to 7.1, instead of fooling around with make's `findstring` and other text manipulation routines.