### PR TITLE
Silence irrelevant data race in Introspection.cpp

### DIFF
--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -2201,13 +2201,8 @@ private:
 };
 
 namespace {
-
 DebugSections *debug_sections = nullptr;
-
-#if __has_feature(thread_sanitizer)
 std::mutex get_variable_name_lock;
-#endif
-
 }
 
 bool dump_stack_frame() {
@@ -2219,19 +2214,15 @@ bool dump_stack_frame() {
 }
 
 std::string get_variable_name(const void *var, const std::string &expected_type) {
+    if (!debug_sections) return "";
+    if (!debug_sections->working) return "";
 
-#if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
     // At least one version of libc++ will report data races inside the regex
     // implementation if we call this from multiple threads at the same time
     // (e.g. from correctness_vector_width); this mutex serves more to silence
     // what is likely to be an irrelevant-to-us data race when using TSAN.
     std::lock_guard<std::mutex> lock(get_variable_name_lock);
-#endif
-#endif
 
-    if (!debug_sections) return "";
-    if (!debug_sections->working) return "";
     std::string name = debug_sections->get_stack_variable_name(var, expected_type);
     if (name.empty()) {
         // Maybe it's a member of a heap object.

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -15,6 +15,7 @@
 #include <execinfo.h>
 
 #include <regex>
+#include <mutex>
 
 using std::vector;
 using std::pair;
@@ -2200,7 +2201,13 @@ private:
 };
 
 namespace {
+
 DebugSections *debug_sections = nullptr;
+
+#if __has_feature(thread_sanitizer)
+std::mutex get_variable_name_lock;
+#endif
+
 }
 
 bool dump_stack_frame() {
@@ -2212,6 +2219,15 @@ bool dump_stack_frame() {
 }
 
 std::string get_variable_name(const void *var, const std::string &expected_type) {
+
+#if __has_feature(thread_sanitizer)
+    // At least one version of libc++ will report data races inside the regex
+    // implementation if we call this from multiple threads at the same time
+    // (e.g. from correctness_vector_width); this mutex serves more to silence
+    // what is likely to be an irrelevant-to-us data race when using TSAN.
+    std::lock_guard<std::mutex> lock(get_variable_name_lock);
+#endif
+
     if (!debug_sections) return "";
     if (!debug_sections->working) return "";
     std::string name = debug_sections->get_stack_variable_name(var, expected_type);

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -2220,12 +2220,14 @@ bool dump_stack_frame() {
 
 std::string get_variable_name(const void *var, const std::string &expected_type) {
 
+#if defined(__has_feature)
 #if __has_feature(thread_sanitizer)
     // At least one version of libc++ will report data races inside the regex
     // implementation if we call this from multiple threads at the same time
     // (e.g. from correctness_vector_width); this mutex serves more to silence
     // what is likely to be an irrelevant-to-us data race when using TSAN.
     std::lock_guard<std::mutex> lock(get_variable_name_lock);
+#endif
 #endif
 
     if (!debug_sections) return "";


### PR DESCRIPTION
At least one version of libc++ on Linux will report data races inside the std::regex implementation if we call get_variable_name() from multiple threads at the same time (e.g. from correctness_vector_width); it appears that the implementation details of std::regex have a "benign"* data race. Inserting a mutext when in TSAN mode to silence what is likely to be an irrelevant-to-us data race when using TSAN.

* There's no such thing as a benign data race, really, but this is one that's unlikely to be worth chasing down.