### PR TITLE
Refactor: Add convert_weak_to_strong()

### DIFF
--- a/src/LLVM_Runtime_Linker.h
+++ b/src/LLVM_Runtime_Linker.h
@@ -31,8 +31,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_ptx_device(Target, llvm::LL
 void add_bitcode_to_module(llvm::LLVMContext *context, llvm::Module &module,
                            const std::vector<uint8_t> &bitcode, const std::string &name);
 
-std::unique_ptr<llvm::Module> get_wasm_jit_module(const Target &t, llvm::LLVMContext *c);
-
 /** If the GlobalValue has weak linkage, convert to the equivalent non-weak linkage. */
 void convert_weak_to_strong(llvm::GlobalValue &gv);
 

--- a/src/LLVM_Runtime_Linker.h
+++ b/src/LLVM_Runtime_Linker.h
@@ -9,6 +9,7 @@
 #include <memory>
 
 namespace llvm {
+class GlobalValue;
 class Module;
 class LLVMContext;
 class Triple;
@@ -29,6 +30,11 @@ std::unique_ptr<llvm::Module> get_initial_module_for_ptx_device(Target, llvm::LL
 /** Link a block of llvm bitcode into an llvm module. */
 void add_bitcode_to_module(llvm::LLVMContext *context, llvm::Module &module,
                            const std::vector<uint8_t> &bitcode, const std::string &name);
+
+std::unique_ptr<llvm::Module> get_wasm_jit_module(const Target &t, llvm::LLVMContext *c);
+
+/** If the GlobalValue has weak linkage, convert to the equivalent non-weak linkage. */
+void convert_weak_to_strong(llvm::GlobalValue &gv);
 
 }  // namespace Internal
 }  // namespace Halide


### PR DESCRIPTION
Pre-emptive refactoring to make subsequent PR smaller, this pulls some logic from link_modules() into its own function, and adds handling for ExternalWeakLinkage.