### PR TITLE
added parallel build toggle for Halide when cmake generate its Visual Studio project

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -604,6 +604,8 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   ${INITIAL_MODULES}
 )
 
+target_compile_options(Halide PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/MP>)
+
 # Define Halide_SHARED or Halide_STATIC depending on library type
 target_compile_definitions(Halide PRIVATE "-DHalide_${HALIDE_LIBRARY_TYPE}")
 # Ensure that these tools are build first

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -607,7 +607,7 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
 # We could expose the /MP flag to all targets, but that might end up saturating the build
 # since multiple MSBuild projects might get built in parallel, each of which compiling their
 # source files in parallel; the Halide library itself is a "knot" point of the build graph,
-# so compiling its files in parrallel should not oversubscribe the system
+# so compiling its files in parallel should not oversubscribe the system
 target_compile_options(Halide PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/MP>)
 
 # Define Halide_SHARED or Halide_STATIC depending on library type

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -604,6 +604,10 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   ${INITIAL_MODULES}
 )
 
+# We could expose the /MP flag to all targets, but that might end up saturating the build
+# since multiple MSBuild projects might get built in parallel, each of which compiling their
+# source files in parallel; the Halide library itself is a "knot" point of the build graph,
+# so compiling its files in parrallel should not oversubscribe the system
 target_compile_options(Halide PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/MP>)
 
 # Define Halide_SHARED or Halide_STATIC depending on library type


### PR DESCRIPTION
(I would expose the flag to all targets, but that might saturate the build since multiple projects might get built in parallel; Halide itself is a knot point of the build, so compiling multiple files in parallel will not oversubscribe the system)