### PR TITLE
Grab Bag of minor changes

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -3111,8 +3111,8 @@ void Func::infer_input_bounds(Pipeline::RealizationArg outputs,
     pipeline().infer_input_bounds(std::move(outputs), param_map);
 }
 
-void *Func::compile_jit(const Target &target) {
-    return pipeline().compile_jit(target);
+void Func::compile_jit(const Target &target) {
+    pipeline().compile_jit(target);
 }
 
 Var _("_");

--- a/src/Func.h
+++ b/src/Func.h
@@ -940,11 +940,10 @@ public:
      * normally happens on the first call to realize. If you're
      * running your halide pipeline inside time-sensitive code and
      * wish to avoid including the time taken to compile a pipeline,
-     * then you can call this ahead of time. Returns the raw function
-     * pointer to the compiled pipeline. Default is to use the Target
+     * then you can call this ahead of time. Default is to use the Target
      * returned from Halide::get_jit_target_from_environment()
      */
-    void *compile_jit(const Target &target = get_jit_target_from_environment());
+    void compile_jit(const Target &target = get_jit_target_from_environment());
 
     /** Set the error handler function that be called in the case of
      * runtime errors during halide pipelines. If you are compiling

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -424,7 +424,8 @@ void JITModule::add_symbol_for_export(const std::string &name, const Symbol &ext
     jit_module->exports[name] = extern_symbol;
 }
 
-void JITModule::add_extern_for_export(const std::string &name, const ExternCFunction &extern_c_function) {
+JITModule::Symbol JITModule::add_extern_for_export(const std::string &name,
+                                                   const ExternCFunction &extern_c_function) {
     Symbol symbol;
     symbol.address = extern_c_function.address();
 
@@ -456,6 +457,7 @@ void JITModule::add_extern_for_export(const std::string &name, const ExternCFunc
 
     symbol.llvm_type = llvm::FunctionType::get(ret_type, llvm_arg_types, false);
     jit_module->exports[name] = symbol;
+    return symbol;
 }
 
 void JITModule::memoization_cache_set_size(int64_t size) const {

--- a/src/JITModule.h
+++ b/src/JITModule.h
@@ -100,8 +100,8 @@ struct JITModule {
      * depend on this one. This routine converts the ExternSignature
      * info into an LLVM type, which allows type safe linkage of
      * external routines. */
-    void add_extern_for_export(const std::string &name,
-                               const ExternCFunction &extern_c_function);
+    Symbol add_extern_for_export(const std::string &name,
+                                 const ExternCFunction &extern_c_function);
 
     /** Look up a symbol by name in this module or its dependencies. */
     Symbol find_symbol_by_name(const std::string &) const;

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -104,6 +104,8 @@ public:
 
     static std::function<std::string(Pipeline, const Target &, const MachineParams &)> custom_auto_scheduler;
 
+    int call_jit_code(const Target &target, const JITCallArgs &args);
+
  public:
     /** Make an undefined Pipeline object. */
     Pipeline();
@@ -256,11 +258,10 @@ public:
      * normally happens on the first call to realize. If you're
      * running your halide pipeline inside time-sensitive code and
      * wish to avoid including the time taken to compile a pipeline,
-     * then you can call this ahead of time. Returns the raw function
-     * pointer to the compiled pipeline. Default is to use the Target
+     * then you can call this ahead of time. Default is to use the Target
      * returned from Halide::get_jit_target_from_environment()
      */
-     void *compile_jit(const Target &target = get_jit_target_from_environment());
+     void compile_jit(const Target &target = get_jit_target_from_environment());
 
     /** Set the error handler function that be called in the case of
      * runtime errors during halide pipelines. If you are compiling

--- a/src/Target.h
+++ b/src/Target.h
@@ -193,7 +193,7 @@ struct Target {
      * Create a "greatest common denominator" runtime target that is compatible with
      * both this target and \p other. Used by generators to conveniently select a suitable
      * runtime when linking together multiple functions.
-     * 
+     *
      * @param other The other target from which we compute the gcd target.
      * @param[out] result The gcd target if we return true, otherwise unmodified. Can be the same as *this.
      * @return Whether it was possible to find a compatible target (true) or not.

--- a/src/Type.h
+++ b/src/Type.h
@@ -371,6 +371,10 @@ struct Type {
     HALIDE_ALWAYS_INLINE
     bool is_uint() const {return code() == UInt;}
 
+    /** Is this type an integer type of any sort? */
+    HALIDE_ALWAYS_INLINE
+    bool is_int_or_uint() const {return code() == Int || code() == UInt;}
+
     /** Is this type an opaque handle type (void *) */
     HALIDE_ALWAYS_INLINE
     bool is_handle() const {return code() == Handle;}

--- a/src/runtime/fake_thread_pool.cpp
+++ b/src/runtime/fake_thread_pool.cpp
@@ -82,8 +82,8 @@ WEAK void halide_shutdown_thread_pool() {
 }
 
 WEAK int halide_set_num_threads(int n) {
-    if (n < 0) {
-        halide_error(NULL, "halide_set_num_threads: must be >= 0.");
+    if (n != 1) {
+        halide_error(NULL, "halide_set_num_threads: only supports a value of 1 on this platform.");
     }
     return 1;
 }

--- a/test/correctness/parallel_fork.cpp
+++ b/test/correctness/parallel_fork.cpp
@@ -84,7 +84,7 @@ int main(int argc, char **argv) {
     });
     printf("Serial time %f for %d calls.\n", time, count);
     fflush(stdout);
-    
+
     call_count = 0;
     both = make(Parallel);
     im = both.realize(10, 10, 2);

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -2148,6 +2148,9 @@ check("v*.w += vrmpy(v*.b,v*.b)", hvx_width, i32_1 + i32(i8_1)*i8_1 + i32(i8_2)*
 int main(int argc, char **argv) {
     Test test;
 
+    printf("host is:      %s\n", get_host_target().to_string().c_str());
+    printf("HL_TARGET is: %s\n", get_target_from_environment().to_string().c_str());
+
     if (argc > 1) {
         test.filter = argv[1];
         num_threads = 1;

--- a/test/error/broken_promise.cpp
+++ b/test/error/broken_promise.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
     in.set(ten_bit_data);
     lut.set(ten_bit_lut);
 
-    auto result = f.realize(100, Target("host-check_unsafe_promises"));
+    auto result = f.realize(100, get_jit_target_from_environment().with_feature(Target::CheckUnsafePromises));
 
     std::cout << "Success!\n";
     return 0;


### PR DESCRIPTION
These are cleanups/refactors from the wasm branch that are relatively incidental; proposing to land them in master to reduce deltas from that branch:
- compile_jit() returns void rather than a void* (since not all JITs can easily return a real fn ptr here)
- add_extern_for_export() returns the Symbol it added
- JITCallArgs use new[] / delete[]
- replaced a stray std::cerr with debug(0)
- whitespace nits
- spelling nits
- fake_thread_pool only accepts setting num_threads to exactly 1
- add Type::is_int_or_uint()
- error_broken_promise should use get_jit_target_from_environment() instead of "host"
- simd_op_check logs the host and HL_TARGET values at the start (for ease of tracking down issues later on if failures occur)