### PR TITLE
Refactor HL_LLVM_ARGS parsing

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -60,34 +60,25 @@ CodeGen_Hexagon::CodeGen_Hexagon(Target t) : CodeGen_Posix(t) {
 }
 
 std::unique_ptr<llvm::Module> CodeGen_Hexagon::compile(const Module &module) {
-    auto llvm_module = CodeGen_Posix::compile(module);
-
-    // TODO: This should be set on the module itself, or some other
-    // safer way to pass this through to the target specific lowering
-    // passes. We set the option here (after the base class'
-    // implementation of compile) because it is the last
-    // Hexagon-specific code to run prior to invoking the target
-    // specific lowering in LLVM, minimizing the chances of the wrong
-    // flag being set for the wrong module.
-    static std::once_flag set_options_once;
-    std::call_once(set_options_once, []() {
-        cl::ParseEnvironmentOptions("halide-hvx-be", "HALIDE_LLVM_ARGS",
-                                    "Halide HVX internal compiler\n");
-
-        std::vector<const char *> options = {
-            "halide-hvx-be",
-            // Don't put small objects into .data sections, it causes
-            // issues with position independent code.
-            "-hexagon-small-data-threshold=0"
-        };
-        cl::ParseCommandLineOptions(options.size(), options.data());
-    });
-
     if (module.target().features_all_of({Halide::Target::HVX_128, Halide::Target::HVX_64})) {
         user_error << "Both HVX_64 and HVX_128 set at same time\n";
     }
+    return CodeGen_Posix::compile(module);
+}
 
-    return llvm_module;
+void CodeGen_Hexagon::set_llvm_command_line_options() const {
+    CodeGen_Posix::set_llvm_command_line_options();
+
+    // TODO: This should be set on the module itself, or some other
+    // safer way to pass this through to the target specific lowering
+    // passes.
+    const std::vector<const char *> options = {
+        "halide-hvx-backend",
+        // Don't put small objects into .data sections, it causes
+        // issues with position independent code.
+        "-hexagon-small-data-threshold=0"
+    };
+    cl::ParseCommandLineOptions(options.size(), options.data());
 }
 
 namespace {

--- a/src/CodeGen_Hexagon.h
+++ b/src/CodeGen_Hexagon.h
@@ -32,6 +32,7 @@ protected:
     int isa_version;
     bool use_soft_float_abi() const override;
     int native_vector_bits() const override;
+    void set_llvm_command_line_options() const override;
 
     llvm::Function *define_hvx_intrinsic(int intrin, Type ret_ty,
                                          const std::string &name,

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -100,6 +100,12 @@ protected:
     virtual bool use_soft_float_abi() const = 0;
     // @}
 
+    /** This is called by the compile() method before doing anything else;
+     * it is intended to give subclasses a chance to customize llvm command-line
+     * flags (via ParseCommandLineOptions() or ParseEnvironmentOptions()) if necessary.
+     * Overrides should always call the base method first. */
+    virtual void set_llvm_command_line_options() const;
+
     /** Should indexing math be promoted to 64-bit on platforms with
      * 64-bit pointers? */
     virtual bool promote_indices() const {return true;}

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -50,6 +50,19 @@ CodeGen_X86::CodeGen_X86(Target t) : CodeGen_Posix(complete_x86_target(t)) {
     user_assert(llvm_X86_enabled) << "llvm build not configured with X86 target enabled.\n";
 }
 
+void CodeGen_X86::set_llvm_command_line_options() const {
+    CodeGen_Posix::set_llvm_command_line_options();
+
+    // -enable-mssa-loop-dependency=1 can dramatically improve
+    // compiletime (with no downside in runtime). We are limiting
+    // this to the x86 backend for now.
+    const std::vector<const char *> options = {
+        "halide-x86-backend",
+        "-enable-mssa-loop-dependency=1"
+    };
+    cl::ParseCommandLineOptions(options.size(), options.data());
+}
+
 namespace {
 
 // i32(i16_a)*i32(i16_b) +/- i32(i16_c)*i32(i16_d) can be done by

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -53,12 +53,13 @@ CodeGen_X86::CodeGen_X86(Target t) : CodeGen_Posix(complete_x86_target(t)) {
 void CodeGen_X86::set_llvm_command_line_options() const {
     CodeGen_Posix::set_llvm_command_line_options();
 
-    // -enable-mssa-loop-dependency=1 can dramatically improve
-    // compiletime (with no downside in runtime). We are limiting
-    // this to the x86 backend for now.
+    // These flags can dramatically improve compiletime (with no downside in runtime).
+    // We are limiting this to the x86 backend for now.
     const std::vector<const char *> options = {
         "halide-x86-backend",
-        "-enable-mssa-loop-dependency=1"
+        "-enable-mssa-loop-dependency=1",
+        "-licm-mssa-optimization-cap=50",
+        "-max-acc-licm-promotion=20",
     };
     cl::ParseCommandLineOptions(options.size(), options.data());
 }

--- a/src/CodeGen_X86.h
+++ b/src/CodeGen_X86.h
@@ -27,6 +27,7 @@ protected:
     std::string mattrs() const override;
     bool use_soft_float_abi() const override;
     int native_vector_bits() const override;
+    void set_llvm_command_line_options() const override;
 
     int vector_lanes_for_slice(Type t) const;
 


### PR DESCRIPTION
Currently, we parse the HL_LLVM_ARGS environment variable exactly once (when we init LLVM). This proposes to refactor that to allow resetting the LLVM flags once per compile:

-- defines CodeGen_LLVM::set_llvm_command_line_options() as a virtual method; the default implementation resets all LLVM flags to their default values, then re-parses from HL_LLVM_ARGS as before

-- subclasses are allowed to override this to make additional settings; the existing usage in Codgen_Hexagon uses this approach now (instead of overriding `compile()`, and an override for Codegen_X86 was added to set `enable-mssa-loop-dependency=1`, which can improve compile time substantially in some cases (see @alinas for details)

That said: I'm not 100% satisfied with this approach, because it means we're relying on mutating LLVM flags (aka "global variables") to get the settings we want; if the Halide compiler is being used from multiple threads in the same process, you can guess what sorts of shenanigans could potentially ensue. (That said, the risk is small, because in practice, we ~never use the same process to generate different architectures in multiple threads... at least, so far.)

On the other hand, if we need to set things in LLVM that are only controllable via command-line flags, our options would seem to be:
(1) take this approach and hope things work
(2) restrict LLVM usage to a single thread at a time in Halide
(3) patch LLVM to allow the settings to be controlled per-LLVMContext

This PR is of course approach 1; it's not optimal, but it may be acceptable for the short term. Opinions welcome.