### PR TITLE
Silence warnings in Target::get_runtime_compatible_target()

### DIFF
--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -841,12 +841,16 @@ bool Target::get_runtime_compatible_target(const Target& other, Target &result) 
     }
 
     if (arch != other.arch || bits != other.bits || os != other.os) {
-        user_warning << "runtime targets must agree on platform (arch-bits-os)\n";
+        Internal::debug(1) << "runtime targets must agree on platform (arch-bits-os)\n"
+                           << "  this:  " << *this << "\n"
+                           << "  other: " << other << "\n";
         return false;
     }
 
     if ((features & matching_mask) != (other.features & matching_mask)) {
-        user_warning << "runtime targets must agree on SoftFloatABI, Debug, TSAN, ASAN, MSAN, HVX_64, HVX_128, MinGW, HexagonDma, and HVX_shared_object\n";
+        Internal::debug(1) << "runtime targets must agree on SoftFloatABI, Debug, TSAN, ASAN, MSAN, HVX_64, HVX_128, MinGW, HexagonDma, and HVX_shared_object\n"
+                           << "  this:  " << *this << "\n"
+                           << "  other: " << other << "\n";
         return false;
     }
 


### PR DESCRIPTION
We emit user_warnings when returning false, which generates useless and confusing warnings from test_internal. Convert to debug(1) output; the caller should be checking the result in any event.