### PR TITLE
is_monotonic() should not fail for Exprs with strings

### DIFF
--- a/src/Monotonic.cpp
+++ b/src/Monotonic.cpp
@@ -28,7 +28,9 @@ class MonotonicVisitor : public IRVisitor {
     }
 
     void visit(const StringImm *) override {
-        internal_error << "Monotonic on String\n";
+        // No: require() Exprs can includes Strings, which
+        // shouldn't affect the outcome. Just ignore them.
+        // internal_error << "Monotonic on String\n";
     }
 
     void visit(const Cast *op) override {

--- a/src/Monotonic.cpp
+++ b/src/Monotonic.cpp
@@ -28,9 +28,8 @@ class MonotonicVisitor : public IRVisitor {
     }
 
     void visit(const StringImm *) override {
-        // No: require() Exprs can includes Strings, which
-        // shouldn't affect the outcome. Just ignore them.
-        // internal_error << "Monotonic on String\n";
+        // require() Exprs can includes Strings.
+        result = Monotonic::Constant;
     }
 
     void visit(const Cast *op) override {
@@ -295,6 +294,12 @@ class MonotonicVisitor : public IRVisitor {
             op->is_intrinsic(Call::likely_if_innermost) ||
             op->is_intrinsic(Call::return_second)) {
             op->args.back().accept(this);
+            return;
+        }
+
+        if (op->is_intrinsic(Call::require)) {
+            // require() returns the value of the second arg in all non-failure cases
+            op->args[1].accept(this);
             return;
         }
 

--- a/test/correctness/require.cpp
+++ b/test/correctness/require.cpp
@@ -64,6 +64,35 @@ static void test(int vector_width) {
             exit(1);
         }
     }
+
+
+    ImageParam input(Int(32), 2);
+    Expr h = require(p1 == p2, p1);
+    Func clamped = BoundaryConditions::repeat_edge(input, 0, 64, 0, h);
+    clamped.set_error_handler(&halide_error);
+
+    Buffer<int32_t> input_buf(64, 64);
+    input_buf.fill(0);
+    input.set(input_buf);
+    p1.set(16);
+    p2.set(15);
+
+    error_occurred = false;
+    result = clamped.realize(64, 3);
+    if (!error_occurred) {
+        printf("There should have been a requirement error (vector_width = %d)\n", vector_width);
+        exit(1);
+    }
+
+    p1.set(16);
+    p2.set(16);
+
+    error_occurred = false;
+    result = clamped.realize(64, 3);
+    if (error_occurred) {
+        printf("There should NOT have been a requirement error (vector_width = %d)\n", vector_width);
+        exit(1);
+    }
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
require() Exprs can legitimately have these. Add a test case that would catch it.