### PR TITLE
Avoid possible UB in Simplify_Div

### DIFF
--- a/src/Simplify_Div.cpp
+++ b/src/Simplify_Div.cpp
@@ -63,6 +63,11 @@ Expr Simplify::visit(const Div *op, ExprInfo *bounds) {
                 return make_signed_integer_overflow(op->type);
             }
         }
+        // Code downstream can use min/max in calculated-but-unused arithmetic
+        // that can lead to UB (and thus, flaky failures under ASAN/UBSAN)
+        // if we leave them set to INT64_MAX/INT64_MIN; normalize to zero to avoid this.
+        if (!bounds->min_defined) bounds->min = 0;
+        if (!bounds->max_defined) bounds->max = 0;
         bounds->alignment = a_bounds.alignment / b_bounds.alignment;
         bounds->trim_bounds_using_alignment();
     }


### PR DESCRIPTION
If the div operation produces unbounded results, we can leave the bounds set with values of INT64_MAX or INT64_MIN; code downstream (eg Simplify_Add) can use these values in way that will cause overflow, and even though the resulting values are (apparently) never used, this triggers failures in UBSAN/ASAN builds. Neuter to zero for cleanliness.