### PR TITLE
Add check for the overflow in Python bindings

### DIFF
--- a/python_bindings/correctness/buffer.py
+++ b/python_bindings/correctness/buffer.py
@@ -222,6 +222,23 @@ def test_reorder():
     assert b.dim(2).stride() == b2.dim(2).stride()
     assert b.dim(3).stride() == b2.dim(3).stride()
 
+def test_overflow():
+    # size = INT_MAX
+    w_intmax = 0x7FFFFFFF
+
+    # When size == INT_MAX, we should not emit error
+    size_intmax = np.ndarray(dtype=np.uint8, shape=(w_intmax))
+    hl.Buffer(size_intmax)
+
+    # size = INT_MAX + 1
+    w_over_intmax = 0x7FFFFFFF + 1
+
+    # We should emit the error when the size > INT_MAX
+    size_over_intmax = np.ndarray(dtype=np.uint8, shape=(w_over_intmax))
+    try:
+        hl.Buffer(size_over_intmax)
+    except ValueError as e:
+        assert 'Out of range arguments to make_dim_vec.' in str(e)
 
 if __name__ == "__main__":
     test_make_interleaved()
@@ -234,4 +251,4 @@ if __name__ == "__main__":
     test_float16()
     test_int64()
     test_reorder()
-
+    test_overflow()

--- a/python_bindings/src/PyBuffer.cpp
+++ b/python_bindings/src/PyBuffer.cpp
@@ -231,7 +231,9 @@ class PyBuffer : public Buffer<> {
         std::vector<halide_dimension_t> dims;
         dims.reserve(info.ndim);
         for (int i = 0; i < info.ndim; i++) {
-            // TODO: check for ssize_t -> int32_t overflow
+            if (INT_MAX < info.shape[i] || INT_MAX < (info.strides[i] / t.bytes())) {
+                throw py::value_error("Out of range arguments to make_dim_vec.");
+            }
             dims.push_back({0, (int32_t) info.shape[i], (int32_t) (info.strides[i] / t.bytes())});
         }
         return dims;


### PR DESCRIPTION
Add check for ssize_t -> int32_t overflow. Add the corresponding test  to correctness/buffer.py.