### PR TITLE
Add some min/max simplifier rules

### DIFF
--- a/src/Simplify_Max.cpp
+++ b/src/Simplify_Max.cpp
@@ -113,6 +113,7 @@ Expr Simplify::visit(const Max *op, ExprInfo *bounds) {
              rewrite(max(min(max(x, y), z), y), max(min(x, z), y)) ||
              rewrite(max(min(max(y, x), z), y), max(y, min(x, z))) ||
              rewrite(max(max(x, c0), c1), max(x, fold(max(c0, c1)))) ||
+             rewrite(max(max(x, y) + c0, x), max(x, y + c0), c0 < 0) ||
 
              (no_overflow(op->type) &&
               (rewrite(max(x + c0, c1), max(x, fold(c1 - c0)) + c0) ||

--- a/src/Simplify_Max.cpp
+++ b/src/Simplify_Max.cpp
@@ -114,6 +114,9 @@ Expr Simplify::visit(const Max *op, ExprInfo *bounds) {
              rewrite(max(min(max(y, x), z), y), max(y, min(x, z))) ||
              rewrite(max(max(x, c0), c1), max(x, fold(max(c0, c1)))) ||
              rewrite(max(max(x, y) + c0, x), max(x, y + c0), c0 < 0) ||
+             rewrite(max(max(x, y) + c0, x), max(x, y) + c0, c0 > 0) ||
+             rewrite(max(max(y, x) + c0, x), max(y + c0, x), c0 < 0) ||
+             rewrite(max(max(y, x) + c0, x), max(y, x) + c0, c0 > 0) ||
 
              (no_overflow(op->type) &&
               (rewrite(max(x + c0, c1), max(x, fold(c1 - c0)) + c0) ||

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -113,6 +113,7 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
              rewrite(min(max(min(x, y), z), y), min(max(x, z), y)) ||
              rewrite(min(max(min(y, x), z), y), min(y, max(x, z))) ||
              rewrite(min(min(x, c0), c1), min(x, fold(min(c0, c1)))) ||
+             rewrite(min(min(x, y) + c0, x), min(x, y + c0), c0 > 0) ||
 
              // Canonicalize a clamp
              rewrite(min(max(x, c0), c1), max(min(x, c1), c0), c0 <= c1) ||

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -114,6 +114,9 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
              rewrite(min(max(min(y, x), z), y), min(y, max(x, z))) ||
              rewrite(min(min(x, c0), c1), min(x, fold(min(c0, c1)))) ||
              rewrite(min(min(x, y) + c0, x), min(x, y + c0), c0 > 0) ||
+             rewrite(min(min(x, y) + c0, x), min(x, y) + c0, c0 < 0) ||
+             rewrite(min(min(y, x) + c0, x), min(y + c0, x), c0 > 0) ||
+             rewrite(min(min(y, x) + c0, x), min(y, x) + c0, c0 < 0) ||
 
              // Canonicalize a clamp
              rewrite(min(max(x, c0), c1), max(min(x, c1), c0), c0 <= c1) ||

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -586,6 +586,16 @@ void check_bounds() {
     check(min(x, min(x, y)), min(x, y));
     check(min(y, min(x, y)), min(x, y));
 
+    check(min(min(x, y) + 1, x), min(y + 1, x));
+    check(min(min(x, y) - (-1), x), min(y + 1, x));
+    check(min(min(x, y) + (-1), x), min(min(x, y) + (-1), x));  // unchanged
+    check(min(min(x, y) - 1, x), min(min(x, y) + (-1), x));  // unchanged
+
+    check(max(max(x, y) - 1, x), max(y + (-1), x));
+    check(max(max(x, y) + (-1), x), max(y + (-1), x));
+    check(max(max(x, y) + 1, x), max(max(x, y) + 1, x));  // unchanged
+    check(max(max(x, y) - (-1), x), max(max(x, y) + 1, x));  // unchanged
+
     check(max(Expr(7), 3), 7);
     check(max(Expr(4.25f), 1.25f), 4.25f);
     check(max(broadcast(x, 4), broadcast(y, 4)),

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -588,13 +588,23 @@ void check_bounds() {
 
     check(min(min(x, y) + 1, x), min(y + 1, x));
     check(min(min(x, y) - (-1), x), min(y + 1, x));
-    check(min(min(x, y) + (-1), x), min(min(x, y) + (-1), x));  // unchanged
-    check(min(min(x, y) - 1, x), min(min(x, y) + (-1), x));  // unchanged
+    check(min(min(x, y) + (-1), x), min(x, y) + (-1));
+    check(min(min(x, y) - 1, x), min(x, y) + (-1));
+
+    check(min(min(y, x) + 1, x), min(y + 1, x));
+    check(min(min(y, x) - (-1), x), min(y + 1, x));
+    check(min(min(y, x) + (-1), x), min(x, y) + (-1));
+    check(min(min(y, x) - 1, x), min(x, y) + (-1));
 
     check(max(max(x, y) - 1, x), max(y + (-1), x));
     check(max(max(x, y) + (-1), x), max(y + (-1), x));
-    check(max(max(x, y) + 1, x), max(max(x, y) + 1, x));  // unchanged
-    check(max(max(x, y) - (-1), x), max(max(x, y) + 1, x));  // unchanged
+    check(max(max(x, y) + 1, x), max(x, y) + 1);
+    check(max(max(x, y) - (-1), x), max(x, y) + 1);
+
+    check(max(max(y, x) - 1, x), max(y + (-1), x));
+    check(max(max(y, x) + (-1), x), max(y + (-1), x));
+    check(max(max(y, x) + 1, x), max(x, y) + 1);
+    check(max(max(y, x) - (-1), x), max(x, y) + 1);
 
     check(max(Expr(7), 3), 7);
     check(max(Expr(4.25f), 1.25f), 4.25f);


### PR DESCRIPTION
- min(min(x,y)+c,x) -> min(x, y+c) [iff c > 0]
- max(max(x,y)-c,x) -> max(x, y-c) [iff c > 0]

This eliminates some very long nested min() expressions seen in https://github.com/halide/Halide/issues/3755.