### PR TITLE
Simplify boolean combinations of inequalities using min/max

### DIFF
--- a/src/Simplify_And.cpp
+++ b/src/Simplify_And.cpp
@@ -99,7 +99,12 @@ Expr Simplify::visit(const And *op, ExprInfo *bounds) {
         rewrite((x || y) && (x || z), x || (y && z)) ||
         rewrite((x || y) && (z || x), x || (y && z)) ||
         rewrite((y || x) && (x || z), x || (y && z)) ||
-        rewrite((y || x) && (z || x), x || (y && z))) {
+        rewrite((y || x) && (z || x), x || (y && z)) ||
+
+        rewrite(x < y && x < z, x < min(y, z)) ||
+        rewrite(y < x && z < x, max(y, z) < x) ||
+        rewrite(x <= y && x <= z, x <= min(y, z)) ||
+        rewrite(y <= x && z <= x, max(y, z) <= x)) {
 
         return mutate(std::move(rewrite.result), bounds);
     }

--- a/src/Simplify_Or.cpp
+++ b/src/Simplify_Or.cpp
@@ -102,7 +102,12 @@ Expr Simplify::visit(const Or *op, ExprInfo *bounds) {
         rewrite((x && y) || (x && z), x && (y || z)) ||
         rewrite((x && y) || (z && x), x && (y || z)) ||
         rewrite((y && x) || (x && z), x && (y || z)) ||
-        rewrite((y && x) || (z && x), x && (y || z))) {
+        rewrite((y && x) || (z && x), x && (y || z)) ||
+
+        rewrite(x < y || x < z, x < max(y, z)) ||
+        rewrite(y < x || z < x, min(y, z) < x) ||
+        rewrite(x <= y || x <= z, x <= max(y, z)) ||
+        rewrite(y <= x || z <= x, min(y, z) <= x)) {
 
         return mutate(std::move(rewrite.result), bounds);
     }

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1079,6 +1079,14 @@ void check_boolean() {
     check(x < 20 && x > 18, x < 20 && 18 < x);
     check(x > 18 && x < 20, 18 < x && x < 20);
 
+    check(x < y + 1 && x < y + 2 && x < y, x < y);
+    check(x < y + 1 && x < y - 2 && x < y, x < y + (-2));
+    check(x < y + 1 && x < y + z && x < y, x < min(z, 0) + y);
+
+    check(x < y + 1 || x < y + 2 || x < y, x < y + 2);
+    check(x < y + 1 || x < y - 2 || x < y, x < y + 1);
+    check(x < y + 1 || x < y + z || x < y, x < max(z, 1) + y);
+
     check(x <= 20 || x > 19, t);
     check(x > 19 || x <= 20, t);
     check(x <= 18 || x > 20, x <= 18 || 20 < x);


### PR DESCRIPTION
Spotted some dumb code in vectorized if conditions of the form `(x < y && x < y + 1 && x < y + 2 ...)`

I believe Dillon has complained about this in the past. Here are some new simplifier rules to clean it up a little.