### PR TITLE
Add missing critical point in Simplify_Div

### DIFF
--- a/src/Simplify_Cast.cpp
+++ b/src/Simplify_Cast.cpp
@@ -4,7 +4,9 @@ namespace Halide {
 namespace Internal {
 
 Expr Simplify::visit(const Cast *op, ExprInfo *bounds) {
-    // We don't try to reason about bounds through casts for now
+    // We generally don't track bounds through casts, with the
+    // exception of casts that constant-fold to a signed integer, so
+    // we don't need the bounds of the value.
     Expr value = mutate(op->value, nullptr);
 
     if (may_simplify(op->type) && may_simplify(op->value.type())) {

--- a/src/Simplify_Cast.cpp
+++ b/src/Simplify_Cast.cpp
@@ -30,12 +30,8 @@ Expr Simplify::visit(const Cast *op, ExprInfo *bounds) {
                    const_float(value, &f) &&
                    std::isfinite(f)) {
             // float -> int
-            int64_t v = safe_numeric_cast<int64_t>(f);
-            if (bounds) {
-                bounds->min_defined = bounds->max_defined = true;
-                bounds->min = bounds->max = v;
-            }
-            return IntImm::make(op->type, v);
+            // Recursively call mutate just to set the bounds
+            return mutate(IntImm::make(op->type, safe_numeric_cast<int64_t>(f)), bounds);
         } else if (op->type.is_uint() &&
                    const_float(value, &f) &&
                    std::isfinite(f)) {
@@ -48,11 +44,8 @@ Expr Simplify::visit(const Cast *op, ExprInfo *bounds) {
         } else if (op->type.is_int() &&
                    const_int(value, &i)) {
             // int -> int
-            if (bounds) {
-                bounds->min_defined = bounds->max_defined = true;
-                bounds->min = bounds->max = i;
-            }
-            return IntImm::make(op->type, i);
+            // Recursively call mutate just to set the bounds
+            return mutate(IntImm::make(op->type, i), bounds);
         } else if (op->type.is_uint() &&
                    const_int(value, &i)) {
             // int -> uint
@@ -64,12 +57,8 @@ Expr Simplify::visit(const Cast *op, ExprInfo *bounds) {
         } else if (op->type.is_int() &&
                    const_uint(value, &u)) {
             // uint -> int
-            int64_t v = safe_numeric_cast<int64_t>(u);
-            if (bounds) {
-                bounds->min_defined = bounds->max_defined = true;
-                bounds->min = bounds->max = v;
-            }
-            return IntImm::make(op->type, v);
+            // Recursively call mutate just to set the bounds
+            return mutate(IntImm::make(op->type, safe_numeric_cast<int64_t>(u)), bounds);
         } else if (op->type.is_uint() &&
                    const_uint(value, &u)) {
             // uint -> uint

--- a/src/Simplify_Cast.cpp
+++ b/src/Simplify_Cast.cpp
@@ -28,7 +28,12 @@ Expr Simplify::visit(const Cast *op, ExprInfo *bounds) {
                    const_float(value, &f) &&
                    std::isfinite(f)) {
             // float -> int
-            return IntImm::make(op->type, safe_numeric_cast<int64_t>(f));
+            int64_t v = safe_numeric_cast<int64_t>(f);
+            if (bounds) {
+                bounds->min_defined = bounds->max_defined = true;
+                bounds->min = bounds->max = v;
+            }
+            return IntImm::make(op->type, v);
         } else if (op->type.is_uint() &&
                    const_float(value, &f) &&
                    std::isfinite(f)) {
@@ -41,6 +46,10 @@ Expr Simplify::visit(const Cast *op, ExprInfo *bounds) {
         } else if (op->type.is_int() &&
                    const_int(value, &i)) {
             // int -> int
+            if (bounds) {
+                bounds->min_defined = bounds->max_defined = true;
+                bounds->min = bounds->max = i;
+            }
             return IntImm::make(op->type, i);
         } else if (op->type.is_uint() &&
                    const_int(value, &i)) {
@@ -53,7 +62,12 @@ Expr Simplify::visit(const Cast *op, ExprInfo *bounds) {
         } else if (op->type.is_int() &&
                    const_uint(value, &u)) {
             // uint -> int
-            return IntImm::make(op->type, safe_numeric_cast<int64_t>(u));
+            int64_t v = safe_numeric_cast<int64_t>(u);
+            if (bounds) {
+                bounds->min_defined = bounds->max_defined = true;
+                bounds->min = bounds->max = v;
+            }
+            return IntImm::make(op->type, v);
         } else if (op->type.is_uint() &&
                    const_uint(value, &u)) {
             // uint -> uint

--- a/src/Simplify_Div.cpp
+++ b/src/Simplify_Div.cpp
@@ -40,6 +40,14 @@ Expr Simplify::visit(const Div *op, ExprInfo *bounds) {
         const bool b_positive = b_bounds.min_defined && b_bounds.min > 0;
         const bool b_negative = b_bounds.max_defined && b_bounds.max < 0;
 
+        if ((b_positive && !b_bounds.max_defined) ||
+            (b_negative && !b_bounds.min_defined)) {
+            // Take limit as b -> +/- infinity
+            int64_t v = 0;
+            bounds->min = std::min(bounds->min, v);
+            bounds->max = std::max(bounds->max, v);
+        }
+
         bounds->min_defined = ((a_bounds.min_defined && b_positive) ||
                                (a_bounds.max_defined && b_negative));
         bounds->max_defined = ((a_bounds.max_defined && b_positive) ||

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1746,6 +1746,9 @@ int main(int argc, char **argv) {
         check(b << 63, Expr((uint64_t) 0x8000000000000000ULL));
     }
 
+    // Check a bounds-related fuzz tester failure found in issue https://github.com/halide/Halide/issues/3764
+    check(Let::make("b", 105, 336 / max(cast<int32_t>(cast<int16_t>(Variable::make(Int(32), "b"))), 38) + 29), 32);
+
     printf("Success!\n");
 
     return 0;


### PR DESCRIPTION
Fixes #3764 in two ways

- Adds a missing critical point to be considered in the simplify_div bounds logic (the limit as the denominator goes to +/- infinity is zero, provided the denominator is known to be positive or negative). 
- But the denominator shouldn't have been unbounded on one side, because it was the result of constant folding. Fix this by tracking bounds through casts of constants. 