### PR TITLE
Codegen_C: TypeInfoGatherer needs a few special cases

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -265,6 +265,7 @@ protected:
     }
 
     void visit(const Call *op) override {
+        include_type(op->type);
         if (op->is_intrinsic(Call::lerp)) {
             // lower_lerp() can synthesize wider vector types.
             // It's not safe to feed temporary Exprs into IRGraphVisitor


### PR DESCRIPTION
Broadcast, Cast, Ramp and some Calls can synthesize types that aren't in the struct; we have to handle these to get the right C++ types predeclared