### PR TITLE
Fix incorrect early-out in bounds of select

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -784,17 +784,9 @@ private:
     void visit(const Select *op) override {
         TRACK_BOUNDS_INTERVAL;
         op->true_value.accept(this);
-        if (!interval.is_bounded()) {
-            // Uses interval produced by op->true_value which might be half bound.
-            return;
-        }
         Interval a = interval;
 
         op->false_value.accept(this);
-        if (!interval.is_bounded()) {
-            // Uses interval produced by op->false_value which might be half bound.
-            return;
-        }
         Interval b = interval;
 
         op->condition.accept(this);
@@ -812,7 +804,9 @@ private:
 
         Type t = op->type.element_of();
 
-        if (a.min.same_as(b.min)) {
+        if (!a.has_lower_bound() || !b.has_lower_bound()) {
+            interval.min = Interval::neg_inf;
+        } else if (a.min.same_as(b.min)) {
             interval.min = a.min;
         } else if (cond.is_single_point()) {
             interval.min = select(cond.min, a.min, b.min);
@@ -840,7 +834,9 @@ private:
             interval.min = Let::make(b_var_name, b.min, interval.min);
         }
 
-        if (a.max.same_as(b.max)) {
+        if (!a.has_upper_bound() || !b.has_upper_bound()) {
+            interval.max = Interval::pos_inf;
+        } else if (a.max.same_as(b.max)) {
             interval.max = a.max;
         } else if (cond.is_single_point()) {
             interval.max = select(cond.min, a.max, b.max);
@@ -2511,9 +2507,11 @@ void check_constant_bound(Expr e, Expr correct_min, Expr correct_max) {
 }
 
 void constant_bound_test() {
+    using namespace ConciseCasts;
+
     {
         Param<int16_t> a, b;
-        check_constant_bound(a >> b, make_const(Int(16), -32768), make_const(Int(16), 32767));
+        check_constant_bound(a >> b, i16(-32768), i16(32767));
     }
 
     {
@@ -2572,8 +2570,6 @@ void constant_bound_test() {
     }
 
     {
-        using namespace ConciseCasts;
-
         Param<int8_t> i("i"), x("x"), y("y"), d("d");
         Expr cl = i16(i);
         Expr cr1 = i16(x);
@@ -2611,9 +2607,6 @@ void constant_bound_test() {
     }
 
     {
-        using ConciseCasts::i16;
-        using ConciseCasts::i32;
-
         Param<int32_t> x("x"), y("y");
         x.set_range(2, 10);
 
@@ -2668,6 +2661,8 @@ void boxes_touched_test() {
 } // anonymous namespace
 
 void bounds_test() {
+    using namespace Halide::ConciseCasts;
+
     constant_bound_test();
 
     Scope<Interval> scope;
@@ -2686,11 +2681,11 @@ void bounds_test() {
     check(scope, x/(x+y), Interval::neg_inf, Interval::pos_inf);
     check(scope, 11/(x+1), 1, 11);
     check(scope, Load::make(Int(8), "buf", x, Buffer<>(), Parameter(), const_true(), ModulusRemainder()),
-                 make_const(Int(8), -128), make_const(Int(8), 127));
+                 i8(-128), i8(127));
     check(scope, y + (Let::make("y", x+3, y - x + 10)), y + 3, y + 23); // Once again, we don't know that y is correlated with x
     check(scope, clamp(1/(x-2), x-10, x+10), -10, 20);
-    check(scope, cast<uint16_t>(x / 2), make_const(UInt(16), 0), make_const(UInt(16), 5));
-    check(scope, cast<uint16_t>((x + 10) / 2), make_const(UInt(16), 5), make_const(UInt(16), 10));
+    check(scope, cast<uint16_t>(x / 2), u16(0), u16(5));
+    check(scope, cast<uint16_t>((x + 10) / 2), u16(5), u16(10));
     check(scope, x < 20, make_bool(1), make_bool(1));
     check(scope, x < 5, make_bool(0), make_bool(1));
     check(scope, Broadcast::make(x >= 11, 3), make_bool(0), make_bool(0));
@@ -2714,34 +2709,34 @@ void bounds_test() {
     check(scope, Broadcast::make(3, 4), 3, 3);
 
     // Check some operations that may overflow
-    check(scope, (cast<uint8_t>(x)+250), make_const(UInt(8), 0), make_const(UInt(8), 255));
-    check(scope, (cast<uint8_t>(x)+10)*20, make_const(UInt(8), 0), make_const(UInt(8), 255));
-    check(scope, (cast<uint8_t>(x)+10)*(cast<uint8_t>(x)+5), make_const(UInt(8), 0), make_const(UInt(8), 255));
-    check(scope, (cast<uint8_t>(x)+10)-(cast<uint8_t>(x)+5), make_const(UInt(8), 0), make_const(UInt(8), 255));
+    check(scope, (cast<uint8_t>(x)+250), u8(0), u8(255));
+    check(scope, (cast<uint8_t>(x)+10)*20, u8(0), u8(255));
+    check(scope, (cast<uint8_t>(x)+10)*(cast<uint8_t>(x)+5), u8(0), u8(255));
+    check(scope, (cast<uint8_t>(x)+10)-(cast<uint8_t>(x)+5), u8(0), u8(255));
 
     // Check some operations that we should be able to prove do not overflow
-    check(scope, (cast<uint8_t>(x)+240), make_const(UInt(8), 240), make_const(UInt(8), 250));
-    check(scope, (cast<uint8_t>(x)+10)*10, make_const(UInt(8), 100), make_const(UInt(8), 200));
-    check(scope, (cast<uint8_t>(x)+10)*(cast<uint8_t>(x)), make_const(UInt(8), 0), make_const(UInt(8), 200));
-    check(scope, (cast<uint8_t>(x)+20)-(cast<uint8_t>(x)+5), make_const(UInt(8), 5), make_const(UInt(8), 25));
+    check(scope, (cast<uint8_t>(x)+240), u8(240), u8(250));
+    check(scope, (cast<uint8_t>(x)+10)*10, u8(100), u8(200));
+    check(scope, (cast<uint8_t>(x)+10)*(cast<uint8_t>(x)), u8(0), u8(200));
+    check(scope, (cast<uint8_t>(x)+20)-(cast<uint8_t>(x)+5), u8(5), u8(25));
 
     // Check some bitwise ops.
-    check(scope, (cast<uint8_t>(x) & cast<uint8_t>(7)), make_const(UInt(8), 0), make_const(UInt(8), 7));
-    check(scope, (cast<uint8_t>(3) & cast<uint8_t>(2)), make_const(UInt(8), 2), make_const(UInt(8), 2));
-    check(scope, (cast<uint8_t>(1) | cast<uint8_t>(2)), make_const(UInt(8), 3), make_const(UInt(8), 3));
-    check(scope, (cast<uint8_t>(3) ^ cast<uint8_t>(2)), make_const(UInt(8), 1), make_const(UInt(8), 1));
-    check(scope, (~cast<uint8_t>(3)), make_const(UInt(8), 0xfc), make_const(UInt(8), 0xfc));
-    check(scope, cast<uint8_t>(x + 5) & cast<uint8_t>(x + 3), make_const(UInt(8), 0), make_const(UInt(8), 13));
-    check(scope, cast<int8_t>(x - 5) & cast<int8_t>(x + 3), make_const(Int(8), 0), make_const(Int(8), 13));
-    check(scope, cast<int8_t>(2*x - 5) & cast<int8_t>(x - 3), make_const(Int(8), -128), make_const(Int(8), 15));
-    check(scope, cast<uint8_t>(x + 5) | cast<uint8_t>(x + 3), make_const(UInt(8), 5), make_const(UInt(8), 255));
-    check(scope, cast<int8_t>(x + 5) | cast<int8_t>(x + 3), make_const(Int(8), 3), make_const(Int(8), 127));
-    check(scope, ~cast<uint8_t>(x), make_const(UInt(8), -11), make_const(UInt(8), -1));
-    check(scope, (cast<uint8_t>(x) >> cast<uint8_t>(1)), make_const(UInt(8), 0), make_const(UInt(8), 5));
-    check(scope, (cast<uint8_t>(10) >> cast<uint8_t>(1)), make_const(UInt(8), 5), make_const(UInt(8), 5));
-    check(scope, (cast<uint8_t>(x + 3) << cast<uint8_t>(1)), make_const(UInt(8), 6), make_const(UInt(8), 26));
-    check(scope, (cast<uint8_t>(x + 3) << cast<uint8_t>(7)), make_const(UInt(8), 0), make_const(UInt(8), 255));  // Overflows
-    check(scope, (cast<uint8_t>(5) << cast<uint8_t>(1)), make_const(UInt(8), 10), make_const(UInt(8), 10));
+    check(scope, (cast<uint8_t>(x) & cast<uint8_t>(7)), u8(0), u8(7));
+    check(scope, (cast<uint8_t>(3) & cast<uint8_t>(2)), u8(2), u8(2));
+    check(scope, (cast<uint8_t>(1) | cast<uint8_t>(2)), u8(3), u8(3));
+    check(scope, (cast<uint8_t>(3) ^ cast<uint8_t>(2)), u8(1), u8(1));
+    check(scope, (~cast<uint8_t>(3)), u8(0xfc), u8(0xfc));
+    check(scope, cast<uint8_t>(x + 5) & cast<uint8_t>(x + 3), u8(0), u8(13));
+    check(scope, cast<int8_t>(x - 5) & cast<int8_t>(x + 3), i8(0), i8(13));
+    check(scope, cast<int8_t>(2*x - 5) & cast<int8_t>(x - 3), i8(-128), i8(15));
+    check(scope, cast<uint8_t>(x + 5) | cast<uint8_t>(x + 3), u8(5), u8(255));
+    check(scope, cast<int8_t>(x + 5) | cast<int8_t>(x + 3), i8(3), i8(127));
+    check(scope, ~cast<uint8_t>(x), u8(-11), u8(-1));
+    check(scope, (cast<uint8_t>(x) >> cast<uint8_t>(1)), u8(0), u8(5));
+    check(scope, (cast<uint8_t>(10) >> cast<uint8_t>(1)), u8(5), u8(5));
+    check(scope, (cast<uint8_t>(x + 3) << cast<uint8_t>(1)), u8(6), u8(26));
+    check(scope, (cast<uint8_t>(x + 3) << cast<uint8_t>(7)), u8(0), u8(255));  // Overflows
+    check(scope, (cast<uint8_t>(5) << cast<uint8_t>(1)), u8(10), u8(10));
     check(scope, (x << 12), 0, 10 << 12);
     check(scope, x & 4095, 0, 10); // LHS known to be positive
     check(scope, x & 123, 0, 10); // Doesn't have to be a precise bitmask
@@ -2749,44 +2744,58 @@ void bounds_test() {
 
     check(scope,
           cast<uint16_t>(clamp(cast<float>(x/y), 0.0f, 4095.0f)),
-          make_const(UInt(16), 0), make_const(UInt(16), 4095));
+          u16(0), u16(4095));
 
     check(scope,
           cast<uint8_t>(clamp(cast<uint16_t>(x/y), cast<uint16_t>(0), cast<uint16_t>(128))),
-          make_const(UInt(8), 0), make_const(UInt(8), 128));
+          u8(0), u8(128));
 
     Expr u8_1 = cast<uint8_t>(Load::make(Int(8), "buf", x, Buffer<>(), Parameter(), const_true(), ModulusRemainder()));
     Expr u8_2 = cast<uint8_t>(Load::make(Int(8), "buf", x + 17, Buffer<>(), Parameter(), const_true(), ModulusRemainder()));
     check(scope, cast<uint16_t>(u8_1) + cast<uint16_t>(u8_2),
-          make_const(UInt(16), 0), make_const(UInt(16), 255*2));
+          u16(0), u16(255*2));
 
     {
         Scope<Interval> scope;
         Expr x = Variable::make(UInt(16), "x");
         Expr y = Variable::make(UInt(16), "y");
-        scope.push("x", Interval(make_const(UInt(16), 0), make_const(UInt(16), 10)));
-        scope.push("y", Interval(make_const(UInt(16), 2), make_const(UInt(16), 4)));
+        scope.push("x", Interval(u16(0), u16(10)));
+        scope.push("y", Interval(u16(2), u16(4)));
 
-        Expr e = clamp(x/y, make_const(UInt(16), 0), make_const(UInt(16), 128));
-        check(scope, e, make_const(UInt(16), 0), make_const(UInt(16), 5));
-        check_constant_bound(scope, e, make_const(UInt(16), 0), make_const(UInt(16), 5));
+        Expr e = clamp(x/y, u16(0), u16(128));
+        check(scope, e, u16(0), u16(5));
+        check_constant_bound(scope, e, u16(0), u16(5));
     }
 
     {
         Param<int16_t> x("x"), y("y");
-        x.set_range(make_const(Int(16), -32), make_const(Int(16), -16));
-        y.set_range(make_const(Int(16), 0), make_const(Int(16), 4));
-        check_constant_bound((x >> y), make_const(Int(16), -32), make_const(Int(16), -1));
+        x.set_range(i16(-32), i16(-16));
+        y.set_range(i16(0), i16(4));
+        check_constant_bound((x >> y), i16(-32), i16(-1));
     }
 
     {
         Param<uint16_t> x("x"), y("y");
-        x.set_range(make_const(UInt(16), 10), make_const(UInt(16), 20));
-        y.set_range(make_const(UInt(16), 0), make_const(UInt(16), 30));
+        x.set_range(u16(10), u16(20));
+        y.set_range(u16(0), u16(30));
         Scope<Interval> scope;
-        scope.push("y", Interval(make_const(UInt(16), 2), make_const(UInt(16), 4)));
+        scope.push("y", Interval(u16(2), u16(4)));
 
-        check_constant_bound(scope, x + y, make_const(UInt(16), 12), make_const(UInt(16), 24));
+        check_constant_bound(scope, x + y, u16(12), u16(24));
+    }
+
+    {
+        Scope<Interval> scope;
+        Interval i = Interval::everything();
+        i.min = 17;
+        internal_assert(i.has_lower_bound());
+        internal_assert(!i.has_upper_bound());
+        scope.push("y", i);
+        Var x("x"), y("y");
+        check(scope, select(x == y*2, y, y - 10),
+              7, Interval::pos_inf);
+        check(scope, select(x == y*2, y - 10, y),
+              7, Interval::pos_inf);
     }
 
     vector<Expr> input_site_1 = {2*x};
@@ -2823,27 +2832,21 @@ void bounds_test() {
     // Check a deeply-nested bitwise expr to ensure it doesn't take n^2 time
     // (this clause took ~30s on a typical laptop before the fix, ~10ms after)
     {
-        using ConciseCasts::u8;
-        using ConciseCasts::u16;
-
         Expr a = Variable::make(UInt(16), "t42");
         Expr b = Variable::make(UInt(16), "t43");
         Expr c = Variable::make(UInt(16), "t44");
         Expr d = Variable::make(Int(32), "d");
         Expr x = Variable::make(Int(32), "x");
         Expr y = Variable::make(Int(32), "y");
-        Expr one_u8 = Expr((uint8_t) 1);
-        Expr one_u16 = Expr((uint16_t) 1);
-        Expr zero_u16 = Expr((uint16_t) 0);
         Expr e1 = select(c >= Expr((uint16_t) 128), c - Expr((uint16_t) 128), c);
-        Expr e2 = Let::make("t44", (((((((((((((((((zero_u16 << one_u16) | u16((u8(d) & one_u8))) << one_u16)
-            | u16(((u8(d) >> one_u8) & one_u8))) << one_u16) | (u16(x) & one_u16)) << one_u16)
-            | (u16(y) & one_u16)) << one_u16) | (a & one_u16)) << one_u16) | (b & one_u16)) << one_u16)
-            | ((a >> one_u16) & one_u16)) << one_u16) | ((b >> one_u16) & one_u16)) >> one_u16), e1);
-        Expr e3 = Let::make("t43", u16(y) >> one_u16, e2);
-        Expr e4 = Let::make("t42", u16(x) >> one_u16, e3);
+        Expr e2 = Let::make("t44", (((((((((((((((((u16(0) << u16(1)) | u16((u8(d) & u8(1)))) << u16(1))
+            | u16(((u8(d) >> u8(1)) & u8(1)))) << u16(1)) | (u16(x) & u16(1))) << u16(1))
+            | (u16(y) & u16(1))) << u16(1)) | (a & u16(1))) << u16(1)) | (b & u16(1))) << u16(1))
+            | ((a >> u16(1)) & u16(1))) << u16(1)) | ((b >> u16(1)) & u16(1))) >> u16(1)), e1);
+        Expr e3 = Let::make("t43", u16(y) >> u16(1), e2);
+        Expr e4 = Let::make("t42", u16(x) >> u16(1), e3);
 
-        check_constant_bound(e4, make_const(UInt(16), 0), make_const(UInt(16), 65535));
+        check_constant_bound(e4, u16(0), u16(65535));
     }
 
     std::cout << "Bounds test passed" << std::endl;


### PR DESCRIPTION
Spotted a fishy-looking early-out in the bounds of a select node. Adding a test revealed that it was in fact wrong.

As a drive-by cleanup, I also uniformly used ConciseCasts in the built-in test instead of a mix of ConciseCasts and make_const.