### PR TITLE
Fix bug in Func::infer_input_bounds()

### DIFF
--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -266,16 +266,15 @@ void define_func(py::module &m) {
         .def("output_buffer", &Func::output_buffer)
         .def("output_buffers", &Func::output_buffers)
 
-        .def("infer_input_bounds", (void (Func::*)(int, int, int, int, const ParamMap &)) &Func::infer_input_bounds,
-            py::arg("x_size") = 0, py::arg("y_size") = 0, py::arg("z_size") = 0, py::arg("w_size") = 0, py::arg("param_map") = ParamMap())
-
-        .def("infer_input_bounds", [](Func &f, Buffer<> buffer, const ParamMap &param_map) -> void {
-            f.infer_input_bounds(buffer, param_map);
-        }, py::arg("dst"), py::arg("param_map") = ParamMap())
-
-        .def("infer_input_bounds", [](Func &f, std::vector<Buffer<>> buffer, const ParamMap &param_map) -> void {
-            f.infer_input_bounds(Realization(buffer), param_map);
-        }, py::arg("dst"), py::arg("param_map") = ParamMap())
+        .def("infer_input_bounds", [](Func &f, Buffer<> output, const ParamMap &param_map) -> void {
+            f.infer_input_bounds(output, param_map);
+        }, py::arg("output"), py::arg("param_map") = ParamMap())
+        .def("infer_input_bounds", [](Func &f, const std::vector<int> &sizes, const ParamMap &param_map) -> void {
+            f.infer_input_bounds(sizes, param_map);
+        }, py::arg("sizes"), py::arg("param_map") = ParamMap())
+        .def("infer_input_bounds", [](Func &f, const std::vector<Buffer<>> &output, const ParamMap &param_map) -> void {
+            f.infer_input_bounds(Realization(output), param_map);
+        }, py::arg("output"), py::arg("param_map") = ParamMap())
 
         .def("in", (Func (Func::*)(const Func &)) &Func::in, py::arg("f"))
         .def("in", (Func (Func::*)(const std::vector<Func> &fs)) &Func::in, py::arg("fs"))

--- a/python_bindings/src/PyPipeline.cpp
+++ b/python_bindings/src/PyPipeline.cpp
@@ -117,16 +117,15 @@ void define_pipeline(py::module &m) {
             return realization_to_object(p.realize(x_size, y_size, z_size, w_size, target, param_map));
         }, py::arg("x_size"), py::arg("y_size"), py::arg("z_size"), py::arg("w_size"), py::arg("target") = Target(), py::arg("param_map") = ParamMap())
 
-        .def("infer_input_bounds", [](Pipeline &p, int x_size, int y_size, int z_size, int w_size, const ParamMap &param_map) -> void {
-            p.infer_input_bounds(x_size, y_size, z_size, w_size, param_map);
-        }, py::arg("x_size") = 0, py::arg("y_size") = 0, py::arg("z_size") = 0, py::arg("w_size") = 0, py::arg("param_map") = ParamMap())
-
         .def("infer_input_bounds", [](Pipeline &p, Buffer<> buffer, const ParamMap &param_map) -> void {
             p.infer_input_bounds(Realization(buffer), param_map);
-        }, py::arg("dst"), py::arg("param_map") = ParamMap())
-        .def("infer_input_bounds", [](Pipeline &p, std::vector<Buffer<>> buffers, const ParamMap &param_map) -> void {
+        }, py::arg("output"), py::arg("param_map") = ParamMap())
+        .def("infer_input_bounds", [](Pipeline &p, const std::vector<int> &sizes, const ParamMap &param_map) -> void {
+            p.infer_input_bounds(sizes, param_map);
+        }, py::arg("sizes") = std::vector<int>{}, py::arg("param_map") = ParamMap())
+        .def("infer_input_bounds", [](Pipeline &p, const std::vector<Buffer<>> &buffers, const ParamMap &param_map) -> void {
             p.infer_input_bounds(Realization(buffers), param_map);
-        }, py::arg("dst"), py::arg("param_map") = ParamMap())
+        }, py::arg("output"), py::arg("param_map") = ParamMap())
 
         .def("infer_arguments", [](Pipeline &p) -> std::vector<Argument> {
             return p.infer_arguments();

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2908,6 +2908,16 @@ void Func::infer_input_bounds(const std::vector<int> &sizes, const ParamMap &par
     infer_input_bounds(r, param_map);
 }
 
+void Func::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
+                                  const ParamMap &param_map) {
+    vector<int> sizes;
+    if (x_size) sizes.push_back(x_size);
+    if (y_size) sizes.push_back(y_size);
+    if (z_size) sizes.push_back(z_size);
+    if (w_size) sizes.push_back(w_size);
+    infer_input_bounds(sizes, param_map);
+}
+
 OutputImageParam Func::output_buffer() const {
     user_assert(defined())
         << "Can't access output buffer of undefined Func.\n";

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2897,12 +2897,11 @@ Realization Func::realize(const Target &target,
     return realize(std::vector<int>{}, target, param_map);
 }
 
-void Func::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
-                              const ParamMap &param_map) {
+void Func::infer_input_bounds(const std::vector<int> &sizes, const ParamMap &param_map) {
     user_assert(defined()) << "Can't infer input bounds on an undefined Func.\n";
     vector<Buffer<>> outputs(func.outputs());
     for (size_t i = 0; i < outputs.size(); i++) {
-        Buffer<> im(func.output_types()[i], nullptr, {x_size, y_size, z_size, w_size});
+        Buffer<> im(func.output_types()[i], nullptr, sizes);
         outputs[i] = std::move(im);
     }
     Realization r(outputs);

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2908,11 +2908,17 @@ void Func::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
         // the halide_buffer_t fields. (We can't use crop because it explicitly
         // disallows expanding the fields in this unsafe manner.)
         Buffer<> im = Buffer<>::make_scalar(func.output_types()[i]);
+        // Deallocate all storage and ensure that host is null; since
+        // we are diddling the dimensions below, the host ptr will no longer
+        // reflect the allocation described by the dimensions, which is usually
+        // fine, unless an extern function wants to try accessing that memory
+        // (kerblam) or JIT helper code that wants to copy data across a VM
+        // barrier (stompity stomp stomp).
+        im.deallocate();
+        im.raw_buffer()->host = nullptr;
         for (int s : sizes) {
             if (!s) break;
             im.add_dimension();
-            // buf.host is going to be wrong no matter what, so don't
-            // bother adjusting it.
             im.raw_buffer()->dim[im.dimensions()-1].min = 0;
             im.raw_buffer()->dim[im.dimensions()-1].extent = s;
         }

--- a/src/Func.h
+++ b/src/Func.h
@@ -797,15 +797,14 @@ public:
      ImageParam img(Int(32), 1);
      f(x) = img(x) + p;
 
-     Target t = get_jit_target_from_environment();
      Buffer<> in;
-     f.infer_input_bounds(10, 10, t, { { img, &in } });
+     f.infer_input_bounds({10, 10}, { { img, &in } });
      \endcode
      * On return, in will be an allocated buffer of the correct size
      * to evaulate f over a 10x10 region.
      */
     // @{
-    void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0,
+    void infer_input_bounds(const std::vector<int> &sizes = {},
                             const ParamMap &param_map = ParamMap::empty_map());
     void infer_input_bounds(Pipeline::RealizationArg outputs,
                             const ParamMap &param_map = ParamMap::empty_map());

--- a/src/Func.h
+++ b/src/Func.h
@@ -808,6 +808,10 @@ public:
                             const ParamMap &param_map = ParamMap::empty_map());
     void infer_input_bounds(Pipeline::RealizationArg outputs,
                             const ParamMap &param_map = ParamMap::empty_map());
+
+    HALIDE_ATTRIBUTE_DEPRECATED("infer_input_bounds(x, y, z, w) is deprecated; use the vector<int> version instead.")
+    void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0,
+                            const ParamMap &param_map = ParamMap::empty_map());
     // @}
 
     /** Statically compile this function to llvm bitcode, with the

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -1122,19 +1122,12 @@ void Pipeline::infer_input_bounds(RealizationArg outputs, const ParamMap &param_
     }
 }
 
-void Pipeline::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
-                                  const ParamMap &param_map) {
+void Pipeline::infer_input_bounds(const std::vector<int> &sizes, const ParamMap &param_map) {
     user_assert(defined()) << "Can't infer input bounds on an undefined Pipeline.\n";
-
-    vector<int> size;
-    if (x_size) size.push_back(x_size);
-    if (y_size) size.push_back(y_size);
-    if (z_size) size.push_back(z_size);
-    if (w_size) size.push_back(w_size);
 
     vector<Buffer<>> bufs;
     for (Type t : contents->outputs[0].output_types()) {
-        bufs.emplace_back(t, size);
+        bufs.emplace_back(t, sizes);
     }
     Realization r(bufs);
     infer_input_bounds(r, param_map);

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -1133,6 +1133,16 @@ void Pipeline::infer_input_bounds(const std::vector<int> &sizes, const ParamMap 
     infer_input_bounds(r, param_map);
 }
 
+void Pipeline::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
+                                  const ParamMap &param_map) {
+    vector<int> sizes;
+    if (x_size) sizes.push_back(x_size);
+    if (y_size) sizes.push_back(y_size);
+    if (z_size) sizes.push_back(z_size);
+    if (w_size) sizes.push_back(w_size);
+    infer_input_bounds(sizes, param_map);
+}
+
 void Pipeline::invalidate_cache() {
     if (defined()) {
         contents->invalidate_cache();

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -68,15 +68,23 @@ public:
         RealizationArg(Realization &r) : r(&r) { }
         RealizationArg(Realization &&r) : r(&r) { }
         RealizationArg(halide_buffer_t *buf) : buf(buf) { }
+
         template<typename T, int D>
         RealizationArg(Runtime::Buffer<T, D> &dst) : buf(dst.raw_buffer()) { }
+
         template <typename T>
         HALIDE_NO_USER_CODE_INLINE RealizationArg(Buffer<T> &dst) : buf(dst.raw_buffer()) { }
+
         template<typename T, typename ...Args,
                  typename = typename std::enable_if<Internal::all_are_convertible<Buffer<>, Args...>::value>::type>
-            RealizationArg(Buffer<T> &a, Args&&... args) {
+        RealizationArg(Buffer<T> &a, Args&&... args) {
             buffer_list.reset(new std::vector<Buffer<>>({a, args...}));
         }
+
+        RealizationArg(const std::vector<Buffer<>> &list) {
+            buffer_list.reset(new std::vector<Buffer<>>(list));
+        }
+
         RealizationArg(RealizationArg &&from) = default;
 
         size_t size() {
@@ -433,7 +441,7 @@ public:
      * of the appropriate size and binding them to the unbound
      * ImageParams. */
     // @{
-    void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0,
+    void infer_input_bounds(const std::vector<int> &sizes = {},
                             const ParamMap &param_map = ParamMap::empty_map());
     void infer_input_bounds(RealizationArg output,
                             const ParamMap &param_map = ParamMap::empty_map());

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -445,6 +445,9 @@ public:
                             const ParamMap &param_map = ParamMap::empty_map());
     void infer_input_bounds(RealizationArg output,
                             const ParamMap &param_map = ParamMap::empty_map());
+    HALIDE_ATTRIBUTE_DEPRECATED("infer_input_bounds(x, y, z, w) is deprecated; use the vector<int> version instead.")
+    void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0,
+                            const ParamMap &param_map = ParamMap::empty_map());
     // @}
 
     /** Infer the arguments to the Pipeline, sorted into a canonical order:

--- a/src/Tuple.h
+++ b/src/Tuple.h
@@ -102,7 +102,7 @@ public:
 
     /** Construct a Realization that refers to the buffers in an
      * existing vector of Buffer<> */
-    explicit Realization(std::vector<Buffer<>> &e) : images(e) {
+    explicit Realization(const std::vector<Buffer<>> &e) : images(e) {
         user_assert(e.size() > 0) << "Realizations must have at least one element\n";
     }
 

--- a/test/correctness/autotune_bug.cpp
+++ b/test/correctness/autotune_bug.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
         .reorder(y, x);
 
     blur_y.compile_jit();
-    blur_y.infer_input_bounds(AUTOTUNE_N);
+    blur_y.infer_input_bounds({AUTOTUNE_N});
     assert(in_img.get().data());
     blur_y.realize(AUTOTUNE_N);
 

--- a/test/correctness/bounds_of_monotonic_math.cpp
+++ b/test/correctness/bounds_of_monotonic_math.cpp
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
 
     f(x) = input(cast<int>(ceil(0.3f * ceil(0.4f * floor(x * 22.5f)))));
 
-    f.infer_input_bounds(10);
+    f.infer_input_bounds({10});
 
     Buffer<float> in = input.get();
 

--- a/test/correctness/extern_bounds_inference.cpp
+++ b/test/correctness/extern_bounds_inference.cpp
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
 
         f.define_extern("translate", args, UInt(8), 2);
 
-        f.infer_input_bounds(W, H);
+        f.infer_input_bounds({W, H});
 
         // Evaluating the output over [0, 29] x [0, 19] requires the input over [3, 32] x [7, 26]
         check(input, 3, W, 7, H);
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
         Var xi, yi;
         g.tile(x, y, xi, yi, 2, 4);
 
-        g.infer_input_bounds(W, H);
+        g.infer_input_bounds({W, H});
 
         check(input, 3, W + 5, 7, H + 10);
     }
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
         f2.compute_at(g, x);
         g.reorder(y, x).vectorize(y, 4);
 
-        g.infer_input_bounds(W, H);
+        g.infer_input_bounds({W, H});
 
         check(input, 3, W + 5, 7, H + 10);
     }

--- a/test/correctness/param_map.cpp
+++ b/test/correctness/param_map.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
     // Test bounds inference
     Buffer<uint8_t> in_bounds;
 
-    f.infer_input_bounds(20, 20, 0, 0, { { p_img, &in_bounds } });
+    f.infer_input_bounds({20, 20}, { { p_img, &in_bounds } });
 
     assert(in_bounds.defined());
     assert(in_bounds.dim(0).extent() == 20);

--- a/test/correctness/specialize.cpp
+++ b/test/correctness/specialize.cpp
@@ -226,7 +226,7 @@ int main(int argc, char **argv) {
         f.set_custom_trace(&my_trace);
 
         // Check bounds inference is still cool with widths < 8
-        f.infer_input_bounds(5);
+        f.infer_input_bounds({5});
         int m = im.get().min(0), e = im.get().extent(0);
         if (m != 0 || e != 5) {
             printf("min, extent = %d, %d instead of 0, 5\n", m, e);
@@ -265,7 +265,7 @@ int main(int argc, char **argv) {
         f.specialize(param);
 
         param.set(true);
-        f.infer_input_bounds(100);
+        f.infer_input_bounds({100});
         int m = im.get().min(0);
         if (m != 10) {
             printf("min %d instead of 10\n", m);
@@ -273,7 +273,7 @@ int main(int argc, char **argv) {
         }
         param.set(false);
         im.reset();
-        f.infer_input_bounds(100);
+        f.infer_input_bounds({100});
         m = im.get().min(0);
         if (m != -10) {
             printf("min %d instead of -10\n", m);
@@ -344,7 +344,7 @@ int main(int argc, char **argv) {
         f.specialize(cond).vectorize(x, 4);
 
         // Confirm that the unrolling applies to both cases using bounds inference:
-        f.infer_input_bounds(3, 1);
+        f.infer_input_bounds({3, 1});
 
         if (im.get().extent(0) != 3) {
             printf("extent(0) was supposed to be 3.\n");
@@ -465,7 +465,7 @@ int main(int argc, char **argv) {
         // depending on the param.
 
         p.set(100);
-        f.infer_input_bounds(10);
+        f.infer_input_bounds({10});
         int w = im.get().width();
         int h = im.get().height();
         if (w != 10 || h != 1) {
@@ -475,7 +475,7 @@ int main(int argc, char **argv) {
         im.reset();
 
         p.set(-100);
-        f.infer_input_bounds(10);
+        f.infer_input_bounds({10});
         w = im.get().width();
         h = im.get().height();
         if (w != 1 || h != 10) {
@@ -499,7 +499,7 @@ int main(int argc, char **argv) {
         // does when p is 100), we only access the first row of the
         // input, and bounds inference should recognize this.
         p.set(100);
-        f.infer_input_bounds(10);
+        f.infer_input_bounds({10});
         int w = im.get().width();
         int h = im.get().height();
         if (w != 10 || h != 1) {
@@ -514,7 +514,7 @@ int main(int argc, char **argv) {
         // are evaluated, so the image must be loaded over the full
         // square.
         p.set(-100);
-        f.infer_input_bounds(10);
+        f.infer_input_bounds({10});
         w = im.get().width();
         h = im.get().height();
         if (w != 10 || h != 10) {

--- a/test/correctness/unsafe_promises.cpp
+++ b/test/correctness/unsafe_promises.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
 
         f(x) = lut(unsafe_promise_clamped(in(x), Expr(), 99));
 
-        f.infer_input_bounds(10);
+        f.infer_input_bounds({10});
         Buffer<float> lut_bounds = lut.get();
 
         assert(lut_bounds.dim(0).min() == 0 && lut_bounds.dim(0).extent() == 100);
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
 
         f(x) = lut(unsafe_promise_clamped(in(x), 10, Expr()));
 
-        f.infer_input_bounds(10);
+        f.infer_input_bounds({10});
         Buffer<float> lut_bounds = lut.get();
 
         assert(lut_bounds.dim(0).min() == 10 && lut_bounds.dim(0).extent() == 246);

--- a/test/error/expanding_reduction.cpp
+++ b/test/error/expanding_reduction.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
 
     g(x, y) = f(x, y);
 
-    g.infer_input_bounds(100, 100);
+    g.infer_input_bounds({100, 100});
 
     Buffer<int> in(input.get());
     assert(in.height() == 102 && in.width() == 100);


### PR DESCRIPTION
It was doing some dancing on a halide_buffer_t and leaving the host storage in a state inconsistent with the dimensions; in most code this was harmless but in some situations (e.g. WebAssembly JIT mode) it can lead to amusing memory corruption.