### PR TITLE
Add option to disable PIC codegen

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -397,6 +397,8 @@ void get_target_options(const llvm::Module &module, llvm::TargetOptions &options
     get_md_bool(module.getModuleFlag("halide_use_soft_float_abi"), use_soft_float_abi);
     get_md_string(module.getModuleFlag("halide_mcpu"), mcpu);
     get_md_string(module.getModuleFlag("halide_mattrs"), mattrs);
+    bool disable_pic = false;
+    get_md_bool(module.getModuleFlag("halide_disable_pic"), disable_pic);
 
     bool per_instruction_fast_math_flags = false;
     get_md_bool(module.getModuleFlag("halide_per_instruction_fast_math_flags"), per_instruction_fast_math_flags);
@@ -437,6 +439,11 @@ void clone_target_options(const llvm::Module &from, llvm::Module &to) {
     if (get_md_string(from.getModuleFlag("halide_mattrs"), mattrs)) {
         to.addModuleFlag(llvm::Module::Warning, "halide_mattrs", llvm::MDString::get(context, mattrs));
     }
+
+    bool disable_pic = false;
+    if (get_md_bool(from.getModuleFlag("halide_disable_pic"), disable_pic)) {
+        to.addModuleFlag(llvm::Module::Warning, "halide_disable_pic", disable_pic ? 1 : 0);
+    }
 }
 
 std::unique_ptr<llvm::TargetMachine> make_target_machine(const llvm::Module &module) {
@@ -455,10 +462,13 @@ std::unique_ptr<llvm::TargetMachine> make_target_machine(const llvm::Module &mod
     std::string mattrs = "";
     get_target_options(module, options, mcpu, mattrs);
 
+    bool disable_pic = false;
+    get_md_bool(module.getModuleFlag("halide_disable_pic"), disable_pic);
+
     return std::unique_ptr<llvm::TargetMachine>(llvm_target->createTargetMachine(module.getTargetTriple(),
                                                 mcpu, mattrs,
                                                 options,
-                                                llvm::Reloc::PIC_,
+                                                disable_pic ? llvm::Reloc::Static : llvm::Reloc::PIC_,
 #ifdef HALIDE_USE_CODEMODEL_LARGE
                                                 llvm::CodeModel::Large,
 #else

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -510,7 +510,7 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
     module->addModuleFlag(llvm::Module::Warning, "halide_use_soft_float_abi", use_soft_float_abi() ? 1 : 0);
     module->addModuleFlag(llvm::Module::Warning, "halide_mcpu", MDString::get(*context, mcpu()));
     module->addModuleFlag(llvm::Module::Warning, "halide_mattrs", MDString::get(*context, mattrs()));
-    module->addModuleFlag(llvm::Module::Warning, "halide_disable_pic", disable_pic() ? 1 : 0);
+    module->addModuleFlag(llvm::Module::Warning, "halide_use_pic", use_pic() ? 1 : 0);
     module->addModuleFlag(llvm::Module::Warning, "halide_per_instruction_fast_math_flags", input.any_strict_float());
 
     internal_assert(module && context && builder)
@@ -4064,8 +4064,8 @@ std::pair<llvm::Function *, int> CodeGen_LLVM::find_vector_runtime_function(cons
     return { nullptr, 0 };
 }
 
-bool CodeGen_LLVM::disable_pic() const {
-    return false;
+bool CodeGen_LLVM::use_pic() const {
+    return true;
 }
 
 }  // namespace Internal

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -510,6 +510,7 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
     module->addModuleFlag(llvm::Module::Warning, "halide_use_soft_float_abi", use_soft_float_abi() ? 1 : 0);
     module->addModuleFlag(llvm::Module::Warning, "halide_mcpu", MDString::get(*context, mcpu()));
     module->addModuleFlag(llvm::Module::Warning, "halide_mattrs", MDString::get(*context, mattrs()));
+    module->addModuleFlag(llvm::Module::Warning, "halide_disable_pic", disable_pic() ? 1 : 0);
     module->addModuleFlag(llvm::Module::Warning, "halide_per_instruction_fast_math_flags", input.any_strict_float());
 
     internal_assert(module && context && builder)
@@ -4061,6 +4062,10 @@ std::pair<llvm::Function *, int> CodeGen_LLVM::find_vector_runtime_function(cons
     }
 
     return { nullptr, 0 };
+}
+
+bool CodeGen_LLVM::disable_pic() const {
+    return false;
 }
 
 }  // namespace Internal

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -98,6 +98,7 @@ protected:
     virtual std::string mcpu() const = 0;
     virtual std::string mattrs() const = 0;
     virtual bool use_soft_float_abi() const = 0;
+    virtual bool disable_pic() const;
     // @}
 
     /** Should indexing math be promoted to 64-bit on platforms with

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -98,7 +98,7 @@ protected:
     virtual std::string mcpu() const = 0;
     virtual std::string mattrs() const = 0;
     virtual bool use_soft_float_abi() const = 0;
-    virtual bool disable_pic() const;
+    virtual bool use_pic() const;
     // @}
 
     /** Should indexing math be promoted to 64-bit on platforms with


### PR DESCRIPTION
Currently, all of our LLVM backends generate position-independent code (llvm::Reloc::PIC_); the WebAssembly backend will need to be able to generate Static code in at least some situations, so this PR adds a way to accomplish that. (Adding here rather than in the webassembly branch to simplify downstream diffs.)

Note: I'm not wild about the 'disable_pic' nomenclature, but having one of our virtual methods return an LLVM enum value felt weird (might complicate includes), and having the default value be 'false' (to mirror use_soft_float_abi) seemed right. Open for better suggestions, of course.