### PR TITLE
Fix 3793

### DIFF
--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -179,7 +179,7 @@ public:
 class Replacer : public IRMutator {
 public:
     map<Expr, Expr, ExprCompare> replacements;
-    Replacer() {}
+    Replacer() = default;
     Replacer(const map<Expr, Expr, ExprCompare> &r) : replacements(r) {}
 
     using IRMutator::mutate;

--- a/src/EliminateBoolVectors.cpp
+++ b/src/EliminateBoolVectors.cpp
@@ -123,7 +123,10 @@ private:
     }
 
     Stmt visit(const Store *op) override {
-        Expr predicate = mutate(op->predicate);
+        Expr predicate = op->predicate;
+        if (!is_one(predicate)) {
+            predicate = mutate(predicate);
+        }
         Expr value = op->value;
         if (op->value.type().is_bool()) {
             Type ty = UInt(8, op->value.type().lanes());
@@ -138,6 +141,21 @@ private:
             return op;
         } else {
             return Store::make(op->name, value, index, op->param, predicate, op->alignment);
+        }
+    }
+
+    Expr visit(const Load *op) override {
+        Expr predicate = op->predicate;
+        if (!is_one(predicate)) {
+            predicate = mutate(predicate);
+        }
+        Expr index = mutate(op->index);
+        if (predicate.same_as(op->predicate) && index.same_as(op->index)) {
+            return op;
+        } else {
+            return Load::make(op->type, op->name, std::move(index),
+                              op->image, op->param, std::move(predicate),
+                              op->alignment);
         }
     }
 

--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -358,6 +358,8 @@ Stmt IRMutator::visit(const Acquire *op) {
 Stmt IRGraphMutator2::mutate(const Stmt &s) {
     auto p = stmt_replacements.emplace(s, Stmt());
     if (p.second) {
+        // N.B: Inserting into a map (as the recursive mutate call
+        // does), does not invalidate existing iterators.
         p.first->second = IRMutator::mutate(s);
     }
     return p.first->second;

--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -355,25 +355,20 @@ Stmt IRMutator::visit(const Acquire *op) {
     }
 }
 
-
 Stmt IRGraphMutator2::mutate(const Stmt &s) {
-    auto iter = stmt_replacements.find(s);
-    if (iter != stmt_replacements.end()) {
-        return iter->second;
+    auto p = stmt_replacements.emplace(s, Stmt());
+    if (p.second) {
+        p.first->second = IRMutator::mutate(s);
     }
-    Stmt new_s = IRMutator::mutate(s);
-    stmt_replacements[s] = new_s;
-    return new_s;
+    return p.first->second;
 }
 
 Expr IRGraphMutator2::mutate(const Expr &e) {
-    auto iter = expr_replacements.find(e);
-    if (iter != expr_replacements.end()) {
-        return iter->second;
+    auto p = expr_replacements.emplace(e, Expr());
+    if (p.second) {
+        p.first->second = IRMutator::mutate(e);
     }
-    Expr new_e = IRMutator::mutate(e);
-    expr_replacements[e] = new_e;
-    return new_e;
+    return p.first->second;
 }
 
 }  // namespace Internal

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -971,15 +971,6 @@ class SolveForInterval : public IRVisitor {
         }
     }
 
-    Expr let_or_subs(const std::string &name, Expr val, Expr body) {
-        const Variable *var = val.as<Variable>();
-        if (var && var->name == name) {
-            return body;
-        } else {
-            return Let::make(name, val, body);
-        }
-    }
-
     void visit(const LE *le) override {
         static string b_name = unique_name('b');
         static string c_name = unique_name('c');
@@ -1011,12 +1002,12 @@ class SolveForInterval : public IRVisitor {
             Expr c_var = Variable::make(c.type(), c_name);
             cached_solve((a <= c_var) && (b_var <= c_var || a >= b_var));
             if (result.has_lower_bound()) {
-                result.min = let_or_subs(b_name, b, result.min);
-                result.min = let_or_subs(c_name, c, result.min);
+                result.min = graph_substitute(b_name, b, result.min);
+                result.min = graph_substitute(c_name, c, result.min);
             }
             if (result.has_upper_bound()) {
-                result.max = let_or_subs(b_name, b, result.max);
-                result.max = let_or_subs(c_name, c, result.max);
+                result.max = graph_substitute(b_name, b, result.max);
+                result.max = graph_substitute(c_name, c, result.max);
             }
         } else if (const Min *min_a = le->a.as<Min>()) {
             // Rewrite (min(a, b) <= c) <==> (a <= c || (b <= c && a >= b))
@@ -1025,12 +1016,12 @@ class SolveForInterval : public IRVisitor {
             Expr c_var = Variable::make(c.type(), c_name);
             cached_solve((a <= c_var) || (b_var <= c_var && a >= b_var));
             if (result.has_lower_bound()) {
-                result.min = let_or_subs(b_name, b, result.min);
-                result.min = let_or_subs(c_name, c, result.min);
+                result.min = graph_substitute(b_name, b, result.min);
+                result.min = graph_substitute(c_name, c, result.min);
             }
             if (result.has_upper_bound()) {
-                result.max = let_or_subs(b_name, b, result.max);
-                result.max = let_or_subs(c_name, c, result.max);
+                result.max = graph_substitute(b_name, b, result.max);
+                result.max = graph_substitute(c_name, c, result.max);
             }
         } else {
             fail();
@@ -1065,12 +1056,12 @@ class SolveForInterval : public IRVisitor {
             Expr c_var = Variable::make(c.type(), c_name);
             cached_solve((a >= c_var) || (b_var >= c_var && a <= b_var));
             if (result.has_lower_bound()) {
-                result.min = let_or_subs(b_name, b, result.min);
-                result.min = let_or_subs(c_name, c, result.min);
+                result.min = graph_substitute(b_name, b, result.min);
+                result.min = graph_substitute(c_name, c, result.min);
             }
             if (result.has_upper_bound()) {
-                result.max = let_or_subs(b_name, b, result.max);
-                result.max = let_or_subs(c_name, c, result.max);
+                result.max = graph_substitute(b_name, b, result.max);
+                result.max = graph_substitute(c_name, c, result.max);
             }
         } else if (const Min *min_a = ge->a.as<Min>()) {
             // Rewrite (min(a, b) >= c) <==> (a >= c && (b >= c || a <= b))
@@ -1079,12 +1070,12 @@ class SolveForInterval : public IRVisitor {
             Expr c_var = Variable::make(c.type(), c_name);
             cached_solve((a >= c_var) && (b_var >= c_var || a <= b_var));
             if (result.has_lower_bound()) {
-                result.min = let_or_subs(b_name, b, result.min);
-                result.min = let_or_subs(c_name, c, result.min);
+                result.min = graph_substitute(b_name, b, result.min);
+                result.min = graph_substitute(c_name, c, result.min);
             }
             if (result.has_upper_bound()) {
-                result.max = let_or_subs(b_name, b, result.max);
-                result.max = let_or_subs(c_name, c, result.max);
+                result.max = graph_substitute(b_name, b, result.max);
+                result.max = graph_substitute(c_name, c, result.max);
             }
         } else {
             fail();
@@ -1478,7 +1469,7 @@ void solve_test() {
     Expr x = Variable::make(Int(32), "x");
     Expr y = Variable::make(Int(32), "y");
     Expr z = Variable::make(Int(32), "z");
-
+    /*
     // Check some simple cases
     check_solve(3 - 4*x, x*(-4) + 3);
     check_solve(min(5, x), min(x, 5));
@@ -1636,6 +1627,8 @@ void solve_test() {
         Expr test = (x <= min(max((y - min(((z*x) + t), t)), 1), 0));
         Interval result = solve_for_outer_interval(test, "z");
     }
+
+    */
 
     {
         // This case caused exponential behavior

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -971,6 +971,15 @@ class SolveForInterval : public IRVisitor {
         }
     }
 
+    Expr let_or_subs(const std::string &name, Expr val, Expr body) {
+        const Variable *var = val.as<Variable>();
+        if (var && var->name == name) {
+            return body;
+        } else {
+            return Let::make(name, val, body);
+        }
+    }
+
     void visit(const LE *le) override {
         static string b_name = unique_name('b');
         static string c_name = unique_name('c');
@@ -1001,13 +1010,13 @@ class SolveForInterval : public IRVisitor {
             Expr b_var = Variable::make(b.type(), b_name);
             Expr c_var = Variable::make(c.type(), c_name);
             cached_solve((a <= c_var) && (b_var <= c_var || a >= b_var));
-            if (result.has_upper_bound()) {
-                result.min = Let::make(b_name, b, result.min);
-                result.min = Let::make(c_name, c, result.min);
+            if (result.has_lower_bound()) {
+                result.min = let_or_subs(b_name, b, result.min);
+                result.min = let_or_subs(c_name, c, result.min);
             }
             if (result.has_upper_bound()) {
-                result.max = Let::make(b_name, b, result.max);
-                result.max = Let::make(c_name, c, result.max);
+                result.max = let_or_subs(b_name, b, result.max);
+                result.max = let_or_subs(c_name, c, result.max);
             }
         } else if (const Min *min_a = le->a.as<Min>()) {
             // Rewrite (min(a, b) <= c) <==> (a <= c || (b <= c && a >= b))
@@ -1016,12 +1025,12 @@ class SolveForInterval : public IRVisitor {
             Expr c_var = Variable::make(c.type(), c_name);
             cached_solve((a <= c_var) || (b_var <= c_var && a >= b_var));
             if (result.has_lower_bound()) {
-                result.min = Let::make(b_name, b, result.min);
-                result.min = Let::make(c_name, c, result.min);
+                result.min = let_or_subs(b_name, b, result.min);
+                result.min = let_or_subs(c_name, c, result.min);
             }
             if (result.has_upper_bound()) {
-                result.max = Let::make(b_name, b, result.max);
-                result.max = Let::make(c_name, c, result.max);
+                result.max = let_or_subs(b_name, b, result.max);
+                result.max = let_or_subs(c_name, c, result.max);
             }
         } else {
             fail();
@@ -1056,12 +1065,12 @@ class SolveForInterval : public IRVisitor {
             Expr c_var = Variable::make(c.type(), c_name);
             cached_solve((a >= c_var) || (b_var >= c_var && a <= b_var));
             if (result.has_lower_bound()) {
-                result.min = Let::make(b_name, b, result.min);
-                result.min = Let::make(c_name, c, result.min);
+                result.min = let_or_subs(b_name, b, result.min);
+                result.min = let_or_subs(c_name, c, result.min);
             }
             if (result.has_upper_bound()) {
-                result.max = Let::make(b_name, b, result.max);
-                result.max = Let::make(c_name, c, result.max);
+                result.max = let_or_subs(b_name, b, result.max);
+                result.max = let_or_subs(c_name, c, result.max);
             }
         } else if (const Min *min_a = ge->a.as<Min>()) {
             // Rewrite (min(a, b) >= c) <==> (a >= c && (b >= c || a <= b))
@@ -1070,12 +1079,12 @@ class SolveForInterval : public IRVisitor {
             Expr c_var = Variable::make(c.type(), c_name);
             cached_solve((a >= c_var) && (b_var >= c_var || a <= b_var));
             if (result.has_lower_bound()) {
-                result.min = Let::make(b_name, b, result.min);
-                result.min = Let::make(c_name, c, result.min);
+                result.min = let_or_subs(b_name, b, result.min);
+                result.min = let_or_subs(c_name, c, result.min);
             }
             if (result.has_upper_bound()) {
-                result.max = Let::make(b_name, b, result.max);
-                result.max = Let::make(c_name, c, result.max);
+                result.max = let_or_subs(b_name, b, result.max);
+                result.max = let_or_subs(c_name, c, result.max);
             }
         } else {
             fail();

--- a/src/Substitute.cpp
+++ b/src/Substitute.cpp
@@ -154,9 +154,9 @@ class GraphSubstitute : public IRGraphMutator2 {
     Expr visit(const Let *op) override {
         Expr new_value = mutate(op->value);
         if (op->name == var) {
-            return Let::make(op->name, new_value, op->value);
+            return Let::make(op->name, new_value, op->body);
         } else {
-            return Let::make(op->name, new_value, mutate(op->value));
+            return Let::make(op->name, new_value, mutate(op->body));
         }
     }
 

--- a/src/Substitute.cpp
+++ b/src/Substitute.cpp
@@ -151,6 +151,15 @@ class GraphSubstitute : public IRGraphMutator2 {
         }
     }
 
+    Expr visit(const Let *op) override {
+        Expr new_value = mutate(op->value);
+        if (op->name == var) {
+            return Let::make(op->name, new_value, op->value);
+        } else {
+            return Let::make(op->name, new_value, mutate(op->value));
+        }
+    }
+
 public:
 
     GraphSubstitute(const string &var, const Expr &value) : var(var), value(value) {}

--- a/test/correctness/fuzz_cse.cpp
+++ b/test/correctness/fuzz_cse.cpp
@@ -1,0 +1,103 @@
+#include "Halide.h"
+
+#include <time.h>
+
+using namespace Halide;
+using namespace Halide::Internal;
+using std::vector;
+
+std::mt19937 rng(0);
+
+Expr random_expr(int depth, vector<Expr> &exprs) {
+    if (depth <= 0) {
+        return (int)(rng() % 10 - 5);
+    }
+
+    if (!exprs.empty() && (rng() & 1)) {
+        // Reuse an existing expression
+        return exprs[rng() % exprs.size()];
+    }
+
+    Expr next;
+    switch (rng() % 9) {
+    case 0:
+        next = Var("x");
+        break;
+    case 1:
+        next = Var("y");
+        break;
+    case 2:
+        next = Var("z");
+        break;
+    case 3:
+        // Any binary op is equally good
+        next = random_expr(depth - 1, exprs);
+        next += random_expr(depth - 1, exprs);
+        break;
+    case 4:
+        {
+            Expr a = random_expr(depth - 2, exprs);
+            Expr b = random_expr(depth - 2, exprs);
+            Expr c = random_expr(depth - 2, exprs);
+            Expr d = random_expr(depth - 2, exprs);
+            next = select(a > b, c, d);
+            break;
+        }
+    case 5:
+        {
+            Expr a = random_expr(depth - 1, exprs);
+            Expr b = random_expr(depth - 1, exprs);
+            next = Let::make("x", a, b);
+            break;
+        }
+    case 6:
+        {
+            Expr a = random_expr(depth - 1, exprs);
+            Expr b = random_expr(depth - 1, exprs);
+            next = Let::make("y", a, b);
+            break;
+        }
+    case 7:
+        {
+            Expr a = random_expr(depth - 1, exprs);
+            Expr b = random_expr(depth - 1, exprs);
+            next = Let::make("z", a, b);
+            break;
+        }
+    default:
+        next = (int)(rng() % 10 - 5);
+    }
+    exprs.push_back(next);
+    return next;
+}
+
+int main(int argc, char **argv) {
+    int fuzz_seed = argc > 1 ? atoi(argv[1]) : time(nullptr);
+
+    for (int i = 0; i < 10000; i++) {
+        rng.seed(fuzz_seed);
+        vector<Expr> exprs;
+        Expr orig = random_expr(5, exprs);
+
+        Expr csed = common_subexpression_elimination(orig);
+
+        Expr check = (orig == csed);
+        check = Let::make("x", 1, check);
+        check = Let::make("y", 2, check);
+        check = Let::make("z", 3, check);
+        Stmt check_stmt = uniquify_variable_names(Evaluate::make(check));
+        check = check_stmt.as<Evaluate>()->value;
+
+        // Don't use can_prove, because it recursively calls cse, which just confuses matters.
+        if (!is_one(simplify(check))) {
+            std::cerr << "Mismatch with seed " << fuzz_seed << "\n"
+                      << "Original: " << orig << "\n"
+                      << "CSE: " << csed << "\n";
+            return -1;
+        }
+        fuzz_seed = rng();
+    }
+
+    std::cout << "Success!\n";
+    return 0;
+}


### PR DESCRIPTION
Make CSE work when there are repeated lets with the same name. E.g. pathological things like let (x = x + x) in (x + x) where both (x + x) instances are the same Expr node.

Removed any attempt to not deduplicate extern calls. The simplifier cancels and reorders them anyway, so we don't really provide any guarantees like that within a single Expr.

Also added a fuzzer for CSE, and fixed an Expr-side blowup in the solver (and an incorrect upper instead of lower!)