### PR TITLE
Simplify Interval.cpp

### DIFF
--- a/src/Interval.cpp
+++ b/src/Interval.cpp
@@ -1,93 +1,75 @@
 #include "Interval.h"
 #include "IREquality.h"
+#include "IRMatch.h"
 #include "IROperator.h"
 
 namespace Halide {
 namespace Internal {
 
+namespace {
+
+IRMatcher::Wild<0> x;
+IRMatcher::Wild<1> y;
+IRMatcher::WildConst<0> c0;
+IRMatcher::WildConst<1> c1;
+
+Expr make_max_helper(const Expr &a, const Expr &b) {
+    auto rewrite = IRMatcher::rewriter(IRMatcher::max(a, b), a.type());
+
+    if (rewrite(max(x, x), x) ||
+        rewrite(max(x, Interval::pos_inf), Interval::pos_inf) ||
+        rewrite(max(Interval::pos_inf, x), Interval::pos_inf) ||
+        rewrite(max(x, Interval::neg_inf), x) ||
+        rewrite(max(Interval::neg_inf, x), x) ||
+        rewrite(max(c0, c1), fold(max(c0, c1))) ||
+        rewrite(max(c0, x), max(x, c0)) ||
+        rewrite(max(max(x, c0), c1), max(x, fold(max(c0, c1)))) ||
+        rewrite(max(max(x, c0), y), max(max(x, y), c0)) ||
+        rewrite(max(x, max(y, c0)), max(max(x, y), c0)) ||
+        rewrite(max(max(x, y), x), a) ||
+        rewrite(max(max(x, y), y), a) ||
+        rewrite(max(x, max(x, y)), b) ||
+        rewrite(max(y, max(x, y)), b)) {
+        return rewrite.result;
+    } else {
+        return max(a, b);
+    }
+}
+
+Expr make_min_helper(const Expr &a, const Expr &b) {
+    auto rewrite = IRMatcher::rewriter(IRMatcher::min(a, b), a.type());
+
+    if (rewrite(min(x, x), x) ||
+        rewrite(min(x, Interval::pos_inf), x) ||
+        rewrite(min(Interval::pos_inf, x), x) ||
+        rewrite(min(x, Interval::neg_inf), Interval::neg_inf) ||
+        rewrite(min(Interval::neg_inf, x), Interval::neg_inf) ||
+        rewrite(min(c0, c1), fold(min(c0, c1))) ||
+        rewrite(min(c0, x), min(x, c0)) ||
+        rewrite(min(min(x, c0), c1), min(x, fold(min(c0, c1)))) ||
+        rewrite(min(min(x, c0), y), min(min(x, y), c0)) ||
+        rewrite(min(x, min(y, c0)), min(min(x, y), c0)) ||
+        rewrite(min(min(x, y), x), a) ||
+        rewrite(min(min(x, y), y), a) ||
+        rewrite(min(x, min(x, y)), b) ||
+        rewrite(min(y, min(x, y)), b)) {
+        return rewrite.result;
+    } else {
+        return min(a, b);
+    }
+}
+
+}
+
 // This is called repeatedly by bounds inference and the solver to
 // build large expressions, so we want to simplify eagerly to avoid
 // monster expressions.
-Expr Interval::make_max(Expr a, Expr b) {
-    if (a.same_as(b)) return a;
-
-    // Deal with infinities
-    if (a.same_as(Interval::pos_inf)) return a;
-    if (b.same_as(Interval::pos_inf)) return b;
-    if (a.same_as(Interval::neg_inf)) return b;
-    if (b.same_as(Interval::neg_inf)) return a;
-
-    // Deep equality
-    if (equal(a, b)) return a;
-
-    // Constant fold
-    const int64_t *ia = as_const_int(a);
-    const int64_t *ib = as_const_int(b);
-    const uint64_t *ua = as_const_uint(a);
-    const uint64_t *ub = as_const_uint(b);
-    const double *fa = as_const_float(a);
-    const double *fb = as_const_float(b);
-    if (ia && ib) return (*ia > *ib) ? a : b;
-    if (ua && ub) return (*ua > *ub) ? a : b;
-    if (fa && fb) return (*fa > *fb) ? a : b;
-
-    // Balance trees to the left, with constants pushed rightwards
-    const Max *ma = a.as<Max>();
-    const Max *mb = b.as<Max>();
-    if (mb && !ma && !(is_const(mb->a) && is_const(mb->b))) {
-        std::swap(ma, mb);
-        std::swap(a, b);
-    }
-    if (ma && is_const(ma->b) && is_const(b)) {
-        return Interval::make_max(ma->a, Interval::make_max(ma->b, b));
-    }
-    if (ma && (ma->a.same_as(b) || ma->b.same_as(b))) {
-        // b is already represented in a
-        return a;
-    }
-
-    return Max::make(a, b);
+Expr Interval::make_max(const Expr &a, const Expr &b) {
+    return make_max_helper(a, b);
 }
 
-Expr Interval::make_min(Expr a, Expr b) {
-    if (a.same_as(b)) return a;
-
-    // Deal with infinities
-    if (a.same_as(Interval::pos_inf)) return b;
-    if (b.same_as(Interval::pos_inf)) return a;
-    if (a.same_as(Interval::neg_inf)) return a;
-    if (b.same_as(Interval::neg_inf)) return b;
-
-    // Deep equality
-    if (equal(a, b)) return a;
-
-    // Constant fold
-    const int64_t *ia = as_const_int(a);
-    const int64_t *ib = as_const_int(b);
-    const uint64_t *ua = as_const_uint(a);
-    const uint64_t *ub = as_const_uint(b);
-    const double *fa = as_const_float(a);
-    const double *fb = as_const_float(b);
-    if (ia && ib) return (*ia > *ib) ? b : a;
-    if (ua && ub) return (*ua > *ub) ? b : a;
-    if (fa && fb) return (*fa > *fb) ? b : a;
-
-    // Balance trees to the left, with constants pushed rightwards
-    const Min *ma = a.as<Min>();
-    const Min *mb = b.as<Min>();
-    if (mb && !ma && !(is_const(mb->a) && is_const(mb->b))) {
-        std::swap(ma, mb);
-        std::swap(a, b);
-    }
-    if (ma && is_const(ma->b) && is_const(b)) {
-        return Interval::make_min(ma->a, Interval::make_min(ma->b, b));
-    }
-    if (ma && (ma->a.same_as(b) || ma->b.same_as(b))) {
-        // b is already represented in a
-        return a;
-    }
-
-    return Min::make(a, b);
+Expr Interval::make_min(const Expr &a, const Expr &b) {
+    return make_min_helper(a, b);
 }
 
 void Interval::include(const Interval &i) {
@@ -115,88 +97,6 @@ Interval Interval::make_intersection(const Interval &a, const Interval &b) {
 // accidentally doing arithmetic on them.
 Expr Interval::pos_inf = Variable::make(Handle(), "pos_inf");
 Expr Interval::neg_inf = Variable::make(Handle(), "neg_inf");
-
-namespace {
-void check(Interval result, Interval expected, int line) {
-    internal_assert(equal(result.min, expected.min) &&
-                    equal(result.max, expected.max))
-        << "Interval test on line " << line << " failed\n"
-        << "  Expected [" << expected.min << ", " << expected.max << "]\n"
-        << "  Got      [" << result.min << ", " << result.max << "]\n";
-}
-}  // namespace
-
-void interval_test() {
-    Interval e = Interval::everything();
-    Interval n = Interval::nothing();
-    Expr x = Variable::make(Int(32), "x");
-    Interval xp{x, Interval::pos_inf};
-    Interval xn{Interval::neg_inf, x};
-    Interval xx{x, x};
-
-    internal_assert(e.is_everything());
-    internal_assert(!e.has_upper_bound());
-    internal_assert(!e.has_lower_bound());
-    internal_assert(!e.is_empty());
-    internal_assert(!e.is_bounded());
-    internal_assert(!e.is_single_point());
-
-    internal_assert(!n.is_everything());
-    internal_assert(!n.has_upper_bound());
-    internal_assert(!n.has_lower_bound());
-    internal_assert(n.is_empty());
-    internal_assert(!n.is_bounded());
-    internal_assert(!n.is_single_point());
-
-    internal_assert(!xp.is_everything());
-    internal_assert(!xp.has_upper_bound());
-    internal_assert(xp.has_lower_bound());
-    internal_assert(!xp.is_empty());
-    internal_assert(!xp.is_bounded());
-    internal_assert(!xp.is_single_point());
-
-    internal_assert(!xn.is_everything());
-    internal_assert(xn.has_upper_bound());
-    internal_assert(!xn.has_lower_bound());
-    internal_assert(!xn.is_empty());
-    internal_assert(!xn.is_bounded());
-    internal_assert(!xn.is_single_point());
-
-    internal_assert(!xx.is_everything());
-    internal_assert(xx.has_upper_bound());
-    internal_assert(xx.has_lower_bound());
-    internal_assert(!xx.is_empty());
-    internal_assert(xx.is_bounded());
-    internal_assert(xx.is_single_point());
-
-    check(Interval::make_union(xp, xn), e, __LINE__);
-    check(Interval::make_union(e, xn), e, __LINE__);
-    check(Interval::make_union(xn, e), e, __LINE__);
-    check(Interval::make_union(xn, n), xn, __LINE__);
-    check(Interval::make_union(n, xp), xp, __LINE__);
-    check(Interval::make_union(xp, xp), xp, __LINE__);
-
-    check(Interval::make_intersection(xp, xn), Interval::single_point(x), __LINE__);
-    check(Interval::make_intersection(e, xn), xn, __LINE__);
-    check(Interval::make_intersection(xn, e), xn, __LINE__);
-    check(Interval::make_intersection(xn, n), n, __LINE__);
-    check(Interval::make_intersection(n, xp), n, __LINE__);
-    check(Interval::make_intersection(xp, xp), xp, __LINE__);
-
-    check(Interval::make_union({3, Interval::pos_inf}, {5, Interval::pos_inf}), {3, Interval::pos_inf}, __LINE__);
-    check(Interval::make_intersection({3, Interval::pos_inf}, {5, Interval::pos_inf}), {5, Interval::pos_inf}, __LINE__);
-
-    check(Interval::make_union({Interval::neg_inf, 3}, {Interval::neg_inf, 5}), {Interval::neg_inf, 5}, __LINE__);
-    check(Interval::make_intersection({Interval::neg_inf, 3}, {Interval::neg_inf, 5}), {Interval::neg_inf, 3}, __LINE__);
-
-    check(Interval::make_union({3, 4}, {9, 10}), {3, 10}, __LINE__);
-    check(Interval::make_intersection({3, 4}, {9, 10}), {9, 4}, __LINE__);
-
-    check(Interval::make_union({3, 9}, {4, 10}), {3, 10}, __LINE__);
-    check(Interval::make_intersection({3, 9}, {4, 10}), {4, 9}, __LINE__);
-
-    std::cout << "Interval test passed" << std::endl;
-}
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Interval.h
+++ b/src/Interval.h
@@ -74,10 +74,10 @@ struct Interval {
     static Interval make_intersection(const Interval &a, const Interval &b);
 
     /** An eagerly-simplifying max of two Exprs that respects infinities. */
-    static Expr make_max(Expr a, Expr b);
+    static Expr make_max(const Expr &a, const Expr &b);
 
     /** An eagerly-simplifying min of two Exprs that respects infinities. */
-    static Expr make_min(Expr a, Expr b);
+    static Expr make_min(const Expr &a, const Expr &b);
 
     bool operator==(const Interval &other) const {
         return (min.same_as(other.min)) && (max.same_as(other.max));

--- a/src/Interval.h
+++ b/src/Interval.h
@@ -84,8 +84,6 @@ struct Interval {
     }
 };
 
-void interval_test();
-
 }  // namespace Internal
 }  // namespace Halide
 

--- a/test/correctness/interval.cpp
+++ b/test/correctness/interval.cpp
@@ -1,0 +1,87 @@
+#include "Halide.h"
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+void check(Interval result, Interval expected, int line) {
+    if (!(equal(result.min, expected.min) &&
+          equal(result.max, expected.max))) {
+        std::cerr << "Interval test on line " << line << " failed\n"
+                  << "  Expected [" << expected.min << ", " << expected.max << "]\n"
+                  << "  Got      [" << result.min << ", " << result.max << "]\n";
+        exit(-1);
+    }
+}
+
+int main(int argc, char **argv) {
+    Interval e = Interval::everything();
+    Interval n = Interval::nothing();
+    Expr x = Variable::make(Int(32), "x");
+    Interval xp{x, Interval::pos_inf};
+    Interval xn{Interval::neg_inf, x};
+    Interval xx{x, x};
+
+    assert(e.is_everything());
+    assert(!e.has_upper_bound());
+    assert(!e.has_lower_bound());
+    assert(!e.is_empty());
+    assert(!e.is_bounded());
+    assert(!e.is_single_point());
+
+    assert(!n.is_everything());
+    assert(!n.has_upper_bound());
+    assert(!n.has_lower_bound());
+    assert(n.is_empty());
+    assert(!n.is_bounded());
+    assert(!n.is_single_point());
+
+    assert(!xp.is_everything());
+    assert(!xp.has_upper_bound());
+    assert(xp.has_lower_bound());
+    assert(!xp.is_empty());
+    assert(!xp.is_bounded());
+    assert(!xp.is_single_point());
+
+    assert(!xn.is_everything());
+    assert(xn.has_upper_bound());
+    assert(!xn.has_lower_bound());
+    assert(!xn.is_empty());
+    assert(!xn.is_bounded());
+    assert(!xn.is_single_point());
+
+    assert(!xx.is_everything());
+    assert(xx.has_upper_bound());
+    assert(xx.has_lower_bound());
+    assert(!xx.is_empty());
+    assert(xx.is_bounded());
+    assert(xx.is_single_point());
+
+    check(Interval::make_union(xp, xn), e, __LINE__);
+    check(Interval::make_union(e, xn), e, __LINE__);
+    check(Interval::make_union(xn, e), e, __LINE__);
+    check(Interval::make_union(xn, n), xn, __LINE__);
+    check(Interval::make_union(n, xp), xp, __LINE__);
+    check(Interval::make_union(xp, xp), xp, __LINE__);
+
+    check(Interval::make_intersection(xp, xn), Interval::single_point(x), __LINE__);
+    check(Interval::make_intersection(e, xn), xn, __LINE__);
+    check(Interval::make_intersection(xn, e), xn, __LINE__);
+    check(Interval::make_intersection(xn, n), n, __LINE__);
+    check(Interval::make_intersection(n, xp), n, __LINE__);
+    check(Interval::make_intersection(xp, xp), xp, __LINE__);
+
+    check(Interval::make_union({3, Interval::pos_inf}, {5, Interval::pos_inf}), {3, Interval::pos_inf}, __LINE__);
+    check(Interval::make_intersection({3, Interval::pos_inf}, {5, Interval::pos_inf}), {5, Interval::pos_inf}, __LINE__);
+
+    check(Interval::make_union({Interval::neg_inf, 3}, {Interval::neg_inf, 5}), {Interval::neg_inf, 5}, __LINE__);
+    check(Interval::make_intersection({Interval::neg_inf, 3}, {Interval::neg_inf, 5}), {Interval::neg_inf, 3}, __LINE__);
+
+    check(Interval::make_union({3, 4}, {9, 10}), {3, 10}, __LINE__);
+    check(Interval::make_intersection({3, 4}, {9, 10}), {9, 4}, __LINE__);
+
+    check(Interval::make_union({3, 9}, {4, 10}), {3, 10}, __LINE__);
+    check(Interval::make_intersection({3, 9}, {4, 10}), {4, 9}, __LINE__);
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/internal.cpp
+++ b/test/internal.cpp
@@ -35,7 +35,6 @@ int main(int argc, const char **argv) {
     cplusplus_mangle_test();
     is_monotonic_test();
     split_predicate_test();
-    interval_test();
     associativity_test();
     generator_test();
     propagate_estimate_test();


### PR DESCRIPTION
There was no reason for the test to be inside the compiler (didn't depend on things internal to the file), and the existing logic could more readably be expressed using a rewriter. It is after all an eager simplifier pass, so it should look the same.