### PR TITLE
add distrib to default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -825,7 +825,7 @@ endif
 endif
 
 .PHONY: all
-all: $(LIB_DIR)/libHalide.a $(BIN_DIR)/libHalide.$(SHARED_EXT) $(INCLUDE_DIR)/Halide.h $(RUNTIME_EXPORTED_INCLUDES) test_internal
+all: distrib test_internal
 
 $(BUILD_DIR)/llvm_objects/list: $(OBJECTS) $(INITIAL_MODULES)
 	# Determine the relevant object files from llvm with a dummy


### PR DESCRIPTION
Cleaning up a very minor annoyance in the makefile. Running make in the root dir is not enough to get the apps to compile, you need to do "make distrib". This is silly, because the default target builds almost everything necessary for make distrib anyway.