### PR TITLE
Add basic CTest support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,7 @@ define_test_group(run_tests)
 # TODO(srj): add test_avx512 variant
 # TODO(srj): add test_python variant
 # TODO(srj): add test_apps variant
-function(add_test TARGET)
+function(add_halide_test TARGET)
   set(options EXPECT_FAILURE)
   set(oneValueArgs WORKING_DIRECTORY)
   set(multiValueArgs GROUPS)
@@ -349,12 +349,13 @@ function(add_test TARGET)
     # It's probably a custom target or a group: just depend on it.
     add_custom_target("${EXEC_NAME}" DEPENDS "${TARGET}")
   else()
-    message(FATAL_ERROR "add_test(): unsupported type ${TARGET_TYPE} for ${TARGET}")
+    message(FATAL_ERROR "add_halide_test(): unsupported type ${TARGET_TYPE} for ${TARGET}")
   endif()
   set_target_properties("${EXEC_NAME}" PROPERTIES EXCLUDE_FROM_ALL TRUE)
   foreach(GROUP ${args_GROUPS})
     add_dependencies("${GROUP}" "${EXEC_NAME}")
   endforeach()
+  add_test(NAME ${TARGET} COMMAND ${COMMAND})
 
 endfunction()
 
@@ -374,6 +375,7 @@ add_subdirectory(src)
 option(WITH_TESTS "Build tests" ON)
 if (WITH_TESTS)
   message(STATUS "Building tests enabled")
+  enable_testing()
   add_subdirectory(test)
 else()
   message(STATUS "Building tests disabled")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ option(WITH_TEST_AUTO_SCHEDULE "Build auto_schedule tests" ON)
 if (WITH_TEST_INTERNAL)
   message(STATUS "Internal tests enabled")
   halide_project(test_internal internal internal.cpp)
-  add_test(test_internal
+  add_halide_test(test_internal
            GROUPS run_tests)
 else()
   message(WARNING "Internal tests disabled")
@@ -45,11 +45,11 @@ function(tests folder)
       list(APPEND GROUPS run_tests)
     endif()
     if("${folder}" STREQUAL "error")
-      add_test("${TARGET}"
+      add_halide_test("${TARGET}"
                GROUPS ${GROUPS}
                EXPECT_FAILURE)
     else()
-      add_test("${TARGET}"
+      add_halide_test("${TARGET}"
                GROUPS ${GROUPS})
     endif()
 
@@ -115,7 +115,7 @@ if (WITH_TEST_GENERATOR)
       target_link_libraries("${TARGET}" PUBLIC "${NAME}")
     endif()
 
-    add_test("${TARGET}"
+    add_halide_test("${TARGET}"
              GROUPS test_generator run_tests)
   endfunction(halide_define_aot_test)
 
@@ -182,7 +182,7 @@ if (WITH_TEST_GENERATOR)
     set(TARGET "generator_jit_${NAME}")
     halide_project("${TARGET}" "generator" "${GEN_TEST_DIR}/${FILE}")
     target_link_libraries("${TARGET}" PRIVATE "${NAME}.generator")
-    add_test("${TARGET}"
+    add_halide_test("${TARGET}"
              GROUPS test_generator run_tests)
   endforeach()
 

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -21,7 +21,7 @@ function(add_tutorial source_file)
 
   string(REPLACE ".cpp" "" name ${source_file})
   halide_project(${name} "tutorials" ${source_file})
-  add_test("${name}"
+  add_halide_test("${name}"
            GROUPS test_tutorial
            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
   target_include_directories(${name} PRIVATE "${CMAKE_SOURCE_DIR}/tools")


### PR DESCRIPTION
This is enough to use most CTest features and makes it easy
to parallelise tests or run only select tests.

A couple of examples:
```
cd build

# List all tests
ctest -N

# Run all tests whose name matches 'reduction' using 4 jobs
ctest -j4 -R 'reduction'
```

Signed-off-by: Kévin Petit <kpet@free.fr>