### PR TITLE
Remove -hexagon-small-data-threshold=0 hack (Issue #3739)

### DIFF
--- a/src/CodeGen_Hexagon.h
+++ b/src/CodeGen_Hexagon.h
@@ -16,8 +16,6 @@ public:
     /** Create a Hexagon code generator for the given Hexagon target. */
     CodeGen_Hexagon(Target);
 
-    std::unique_ptr<llvm::Module> compile(const Module &module) override;
-
 protected:
     void compile_func(const LoweredFunc &f,
                       const std::string &simple_name, const std::string &extern_name) override;


### PR DESCRIPTION
We believe this is no longer necessary for recent LLVM builds. https://github.com/halide/Halide/issues/3739