### PR TITLE
Allow building of the python bindings using cmake. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ check_llvm_target(NVPTX WITH_NVPTX)
 # AMDGPU target is WIP
 check_llvm_target(AMDGPU WITH_AMDGPU)
 
+option(WITH_PYTHON_BINDINGS "Include python bindings" OFF)
 option(TARGET_NATIVE_CLIENT "Include Native Client" OFF)
 option(TARGET_X86 "Include x86 target" ${WITH_X86})
 option(TARGET_ARM "Include ARM target" ${WITH_ARM})
@@ -492,3 +493,8 @@ add_custom_target(distrib
   COMMAND cmake -E rename "${CPACK_PACKAGE_VENDOR}.${CPACK_PACKAGE_EXT}" "${CPACK_PACKAGE_VENDOR}.${DISTRIB_PACKAGE_EXT}"
   BYPRODUCTS "${CPACK_PACKAGE_VENDOR}.${DISTRIB_PACKAGE_EXT}"
   USES_TERMINAL)
+
+if (WITH_PYTHON_BINDINGS)
+    add_subdirectory(python_bindings)
+endif()
+ 

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -1,0 +1,49 @@
+add_subdirectory(${PYBIND11_PATH} ${CMAKE_CURRENT_BINARY_DIR}/pybind)
+
+pybind11_add_module(HalidePython
+	src/PyArgument.cpp
+	src/PyBoundaryConditions.cpp
+	src/PyBuffer.cpp
+	src/PyConciseCasts.cpp
+	src/PyEnums.cpp
+	src/PyError.cpp
+	src/PyExpr.cpp
+	src/PyExternFuncArgument.cpp
+	src/PyFunc.cpp
+	src/PyFuncRef.cpp
+	src/PyHalide.cpp
+	src/PyImageParam.cpp
+	src/PyInlineReductions.cpp
+	src/PyIROperator.cpp
+	src/PyLambda.cpp
+	src/PyLoopLevel.cpp
+	src/PyMachineParams.cpp
+	src/PyModule.cpp
+	src/PyOutputs.cpp
+	src/PyParam.cpp
+	src/PyPipeline.cpp
+	src/PyRDom.cpp
+	src/PyStage.cpp
+	src/PyTarget.cpp
+	src/PyTuple.cpp
+	src/PyType.cpp
+	src/PyVar.cpp
+	src/PyVarOrRVar.cpp
+)
+
+add_definitions(-DHALIDE_PYSTUB_GENERATOR_NAME=Halide)
+
+target_include_directories(HalidePython PRIVATE "${HALIDE_INCLUDE_DIR}" "${HALIDE_TOOLS_DIR}")
+
+set_target_properties(HalidePython 
+	PROPERTIES 
+	OUTPUT_NAME "halide"
+	IMPORT_PREFIX "python_"
+)
+
+target_link_libraries(HalidePython PRIVATE ${HALIDE_COMPILER_LIB})
+
+install(TARGETS HalidePython
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION bin
+        ARCHIVE DESTINATION lib)


### PR DESCRIPTION
This is the bare minimum needed to build the bindings on windows, and does not integrate any of the testing suite. (although any tests I ran manually seem to pass successfully).

I don't have access to a working mac/linux build environment, so someone should probably run a sanity check before merging this PR. 

By default bindings are off (you can toggle with `WITH_PYTHON_BINDINGS`) when on, you need to manually point cmake to pybind by passing `-DPYBIND11_PATH=wherever_you_have_it` 