### PR TITLE
Disable UBSAN signed-integer-overflow warnings

### DIFF
--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -16,18 +16,6 @@
 namespace Halide {
 namespace Internal {
 
-// There is no __has_feature(undefined_sanitizer), so we use asan as
-// a proxy for detecting ubsan.
-#if defined(__has_feature)
-#if __has_feature(address_sanitizer)
-#define HALIDE_DISABLE_UBSAN  __attribute__((no_sanitize("undefined")))
-#endif
-#endif
-
-#ifndef HALIDE_DISABLE_UBSAN
-#define HALIDE_DISABLE_UBSAN
-#endif
-
 /** Does the first expression have the same structure as the second?
  * Variables in the first expression with the name * are interpreted
  * as wildcards, and their matching equivalent in the second
@@ -872,12 +860,11 @@ auto add(A a, B b) -> decltype(IRMatcher::operator+(a, b)) {return IRMatcher::op
 
 template<>
 HALIDE_ALWAYS_INLINE
-HALIDE_DISABLE_UBSAN
 int64_t constant_fold_bin_op<Add>(halide_type_t &t, int64_t a, int64_t b) noexcept {
     t.lanes |= ((t.bits >= 32) && add_would_overflow(t.bits, a, b)) ? MatcherState::signed_integer_overflow : 0;
     int dead_bits = 64 - t.bits;
     // Drop the high bits then sign-extend them back
-    return int64_t(uint64_t(a + b) << dead_bits) >> dead_bits;
+    return int64_t((uint64_t(a) + uint64_t(b)) << dead_bits) >> dead_bits;
 }
 
 template<>
@@ -905,12 +892,11 @@ auto sub(A a, B b) -> decltype(IRMatcher::operator-(a, b)) {return IRMatcher::op
 
 template<>
 HALIDE_ALWAYS_INLINE
-HALIDE_DISABLE_UBSAN
 int64_t constant_fold_bin_op<Sub>(halide_type_t &t, int64_t a, int64_t b) noexcept {
     t.lanes |= ((t.bits >= 32) && sub_would_overflow(t.bits, a, b)) ? MatcherState::signed_integer_overflow : 0;
     // Drop the high bits then sign-extend them back
     int dead_bits = 64 - t.bits;
-    return int64_t(uint64_t(a - b) << dead_bits) >> dead_bits;
+    return int64_t((uint64_t(a) - uint64_t(b)) << dead_bits) >> dead_bits;
 }
 
 template<>
@@ -939,12 +925,11 @@ auto mul(A a, B b) -> decltype(IRMatcher::operator*(a, b)) {return IRMatcher::op
 
 template<>
 HALIDE_ALWAYS_INLINE
-HALIDE_DISABLE_UBSAN
 int64_t constant_fold_bin_op<Mul>(halide_type_t &t, int64_t a, int64_t b) noexcept {
     t.lanes |= ((t.bits >= 32) && mul_would_overflow(t.bits, a, b)) ? MatcherState::signed_integer_overflow : 0;
     int dead_bits = 64 - t.bits;
     // Drop the high bits then sign-extend them back
-    return int64_t(uint64_t(a * b) << dead_bits) >> dead_bits;
+    return int64_t((uint64_t(a) * uint64_t(b)) << dead_bits) >> dead_bits;
 }
 
 template<>


### PR DESCRIPTION
some of the int64 constant-fold ops warn about possible signed-integer-overflow when run under UBSAN; disable the check for these.