### PR TITLE
Avoid initialization-order-fiasco with Halide::_

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -48,7 +48,9 @@ Func::Func(const string &name) : func(unique_name(name)) {}
 Func::Func() : func(make_entity_name(this, "Halide:.*:Func", 'f')) {}
 
 Func::Func(Expr e) : func(make_entity_name(this, "Halide:.*:Func", 'f')) {
-    (*this)(_) = e;
+    // Don't use Halide::_ (avoid initialization-order-fiasco)
+    Var underscore = Var("_");
+    (*this)(underscore) = e;
 }
 
 Func::Func(Function f) : func(f) {}
@@ -209,7 +211,9 @@ std::pair<int, int> Func::add_implicit_vars(vector<Var> &args) const {
     int count = 0;
     std::vector<Var>::iterator iter = args.begin();
 
-    while (iter != args.end() && !iter->same_as(_)) {
+    // Don't use Halide::_ (avoid initialization-order-fiasco)
+    Var underscore = Var("_");
+    while (iter != args.end() && !iter->same_as(underscore)) {
         iter++;
     }
     if (iter != args.end()) {
@@ -233,12 +237,14 @@ std::pair<int, int> Func::add_implicit_vars(vector<Var> &args) const {
 }
 
 std::pair<int, int> Func::add_implicit_vars(vector<Expr> &args) const {
+    // Don't use Halide::_ (avoid initialization-order-fiasco)
+    Var underscore = Var("_");
     int placeholder_pos = -1;
     int count = 0;
     std::vector<Expr>::iterator iter = args.begin();
     while (iter != args.end()) {
         const Variable *var = iter->as<Variable>();
-        if (var && var->name == _.name())
+        if (var && var->name == underscore.name())
             break;
         iter++;
     }

--- a/src/Func.h
+++ b/src/Func.h
@@ -684,7 +684,9 @@ public:
     /** Construct a new Func to wrap a Buffer. */
     template<typename T>
     HALIDE_NO_USER_CODE_INLINE explicit Func(Buffer<T> &im) : Func() {
-        (*this)(_) = im(_);
+        // Don't use Halide::_ (avoid initialization-order-fiasco)
+        Var underscore = Var("_");
+        (*this)(underscore) = im(underscore);
     }
 
     /** Evaluate this function over some rectangular domain and return


### PR DESCRIPTION
If you declare (say) a static ImageParam, that creates a Func internally, which can call Func methods that reference `Halide::_`, which might not be initialized yet. Use a local var of the same name to avoid possible UB.

Note that there may be other risky uses of `Halide::_`, `_0`, etc.: these are only the ones actually reported by UBSAN.

A better fix probably requires (eventually) eliminating these vars from our public API, and using `Var::implicit()` for `_0`, etc... adding some new API for `Halide::_`. (What would be an appropriate name for `Halide::_` ... perhaps `Var::inferred()`?)