### PR TITLE
Give the implicit vars unique types instead of state that needs to be initialized

### DIFF
--- a/python_bindings/src/PyVar.cpp
+++ b/python_bindings/src/PyVar.cpp
@@ -39,17 +39,17 @@ void define_var(py::module &m) {
 
     add_binary_operators_with<Expr>(var_class);
 
-    m.attr("_") = Halide::_;
-    m.attr("_0") = Halide::_0;
-    m.attr("_1") = Halide::_1;
-    m.attr("_2") = Halide::_2;
-    m.attr("_3") = Halide::_3;
-    m.attr("_4") = Halide::_4;
-    m.attr("_5") = Halide::_5;
-    m.attr("_6") = Halide::_6;
-    m.attr("_7") = Halide::_7;
-    m.attr("_8") = Halide::_8;
-    m.attr("_9") = Halide::_9;
+    m.attr("_") = Halide::Var(Halide::_);
+    m.attr("_0") = Halide::Var(Halide::_0);
+    m.attr("_1") = Halide::Var(Halide::_1);
+    m.attr("_2") = Halide::Var(Halide::_2);
+    m.attr("_3") = Halide::Var(Halide::_3);
+    m.attr("_4") = Halide::Var(Halide::_4);
+    m.attr("_5") = Halide::Var(Halide::_5);
+    m.attr("_6") = Halide::Var(Halide::_6);
+    m.attr("_7") = Halide::Var(Halide::_7);
+    m.attr("_8") = Halide::Var(Halide::_8);
+    m.attr("_9") = Halide::Var(Halide::_9);
 }
 
 }  // namespace PythonBindings

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -238,7 +238,7 @@ std::pair<int, int> Func::add_implicit_vars(vector<Expr> &args) const {
     std::vector<Expr>::iterator iter = args.begin();
     while (iter != args.end()) {
         const Variable *var = iter->as<Variable>();
-        if (var && var->name == _.name())
+        if (var && var->name == Var(_).name())
             break;
         iter++;
     }
@@ -3106,9 +3106,5 @@ void Func::infer_input_bounds(Pipeline::RealizationArg outputs,
 void Func::compile_jit(const Target &target) {
     pipeline().compile_jit(target);
 }
-
-Var _("_");
-Var _0("_0"), _1("_1"), _2("_2"), _3("_3"), _4("_4"),
-           _5("_5"), _6("_6"), _7("_7"), _8("_8"), _9("_9");
 
 }  // namespace Halide

--- a/src/Func.h
+++ b/src/Func.h
@@ -33,6 +33,8 @@ struct VarOrRVar {
     VarOrRVar(const Var &v) : var(v), is_rvar(false) {}
     VarOrRVar(const RVar &r) : rvar(r), is_rvar(true) {}
     VarOrRVar(const RDom &r) : rvar(RVar(r)), is_rvar(true) {}
+    template<int N>
+    VarOrRVar(const ImplicitVar<N> &u) : var(u), is_rvar(false) {}
 
     const std::string &name() const {
         if (is_rvar) return rvar.name();

--- a/src/Var.h
+++ b/src/Var.h
@@ -167,12 +167,40 @@ public:
     }
 };
 
+template<int N = -1>
+struct ImplicitVar {
+public:
+    Var to_var() const {
+        if (N >= 0) {
+            return Var::implicit(N);
+        } else {
+            return Var("_");
+        }
+    }
+
+    operator Var() const {
+        return to_var();
+    }
+    operator Expr() const {
+        return to_var();
+    }
+};
+
 /** A placeholder variable for infered arguments. See \ref Var::implicit */
-HALIDE_EXPORT extern Var _;
+static constexpr ImplicitVar<> _;
 
 /** The first ten implicit Vars for use in scheduling. See \ref Var::implicit */
 // @{
-HALIDE_EXPORT extern Var _0, _1, _2, _3, _4, _5, _6, _7, _8, _9;
+static constexpr ImplicitVar<0> _0;
+static constexpr ImplicitVar<1> _1;
+static constexpr ImplicitVar<2> _2;
+static constexpr ImplicitVar<3> _3;
+static constexpr ImplicitVar<4> _4;
+static constexpr ImplicitVar<5> _5;
+static constexpr ImplicitVar<6> _6;
+static constexpr ImplicitVar<7> _7;
+static constexpr ImplicitVar<8> _8;
+static constexpr ImplicitVar<9> _9;
 // @}
 
 namespace Internal {

--- a/src/Var.h
+++ b/src/Var.h
@@ -185,7 +185,7 @@ struct ImplicitVar {
     }
 };
 
-/** A placeholder variable for infered arguments. See \ref Var::implicit */
+/** A placeholder variable for inferred arguments. See \ref Var::implicit */
 static constexpr ImplicitVar<> _;
 
 /** The first ten implicit Vars for use in scheduling. See \ref Var::implicit */

--- a/src/Var.h
+++ b/src/Var.h
@@ -169,7 +169,6 @@ public:
 
 template<int N = -1>
 struct ImplicitVar {
-public:
     Var to_var() const {
         if (N >= 0) {
             return Var::implicit(N);


### PR DESCRIPTION
This makes the implicit var pieces of syntax (_*) stateless static constexpr things, instead of extern object instances. Should avoid the problems associated with exposing variables in a public API.

Alternative to #3807 