### PR TITLE
Add LLVM SCEV option

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1126,6 +1126,11 @@ void CodeGen_LLVM::optimize_module() {
     b.LoopVectorize = !get_target().has_feature(Target::DisableLLVMLoopVectorize);
     b.DisableUnrollLoops = get_target().has_feature(Target::DisableLLVMLoopUnroll);
     b.SLPVectorize = true;  // Note: SLP vectorization has no analogue in the Halide scheduling model
+#if LLVM_VERSION >= 90
+    // Clear ScEv info for all loops. This can reduce compile time for some
+    // complex schedules by a substantial amount (50% or more).
+    b.ForgetAllSCEVInLoopUnroll = true;
+#endif
 
     if (TM) {
         TM->adjustPassManager(b);

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1127,8 +1127,11 @@ void CodeGen_LLVM::optimize_module() {
     b.DisableUnrollLoops = get_target().has_feature(Target::DisableLLVMLoopUnroll);
     b.SLPVectorize = true;  // Note: SLP vectorization has no analogue in the Halide scheduling model
 #if LLVM_VERSION >= 90
-    // Clear ScEv info for all loops. This can reduce compile time for some
-    // complex schedules by a substantial amount (50% or more).
+    // Clear ScEv info for all loops. Certain Halide applications spend a very
+    // long time compiling in forgetLoop, and prefer to forget everything
+    // and rebuild SCEV (aka "Scalar Evolution") from scratch.
+    // Sample difference in compile time reduction at the time of this change was
+    // 21.04 -> 14.78 using current ToT release build. (See also https://reviews.llvm.org/rL358304)
     b.ForgetAllSCEVInLoopUnroll = true;
 #endif
 


### PR DESCRIPTION
From @alinas, this can reduce compile time for some complex schedules substantially. Requires LLVM9 >= r358304.

Background: Certain Halide applications spend a very long time compiling in forgetLoop, and prefer to forget everything and rebuild SCEV (aka "Scalar Evolution") from scratch. Sample difference in compile time reduction: 21.04 to 14.78 using current ToT release build.

See also https://reviews.llvm.org/rL358304