### PR TITLE
Add operator[] to RDom in the Python binding

### DIFF
--- a/python_bindings/correctness/rdom.py
+++ b/python_bindings/correctness/rdom.py
@@ -14,12 +14,13 @@ def test_rdom():
     r.where(r.x <= r.y)
 
     diagonal[r.x, r.y] += 2
+    diagonal[r[0], r[1]] += 2
     output = diagonal.realize(domain_width, domain_height)
     
     for iy in range(domain_height):
         for ix in range(domain_width):
             if ix <= iy:
-                assert output[ix, iy] == 3
+                assert output[ix, iy] == 5
             else:
                 assert output[ix, iy] == 1
 

--- a/python_bindings/src/PyRDom.cpp
+++ b/python_bindings/src/PyRDom.cpp
@@ -36,7 +36,8 @@ void define_rdom(py::module &m) {
         .def_readonly("x", &RDom::x)
         .def_readonly("y", &RDom::y)
         .def_readonly("z", &RDom::z)
-        .def_readonly("w", &RDom::w);
+        .def_readonly("w", &RDom::w)
+        .def("__getitem__", &RDom::operator[]);
 
     add_binary_operators_with<Expr>(rdom_class);
 }


### PR DESCRIPTION
operator[] of RDom is missing in the Python binding and I found it useful to have it.