### PR TITLE
Avoid link error in correctness_tracing

### DIFF
--- a/test/correctness/tracing.cpp
+++ b/test/correctness/tracing.cpp
@@ -1,6 +1,8 @@
 #include "Halide.h"
 #include <stdio.h>
 
+namespace {
+
 using namespace Halide;
 
 struct event {
@@ -112,6 +114,8 @@ int my_trace(void *user_context, const halide_trace_event_t *ev) {
     trace[n_trace++] = e;
     return n_trace;
 }
+
+}  // namespace
 
 int main(int argc, char **argv) {
     ImageParam input(Float(32), 1, "i");


### PR DESCRIPTION
The local name "trace" can apparently conflict with a symbol ncurses. Wrap everything in an anonymous namespace to avoid (which is a good practice anyway).