### PR TITLE
Revert "Add operator[] to RDom in the Python binding"

### DIFF
--- a/python_bindings/correctness/rdom.py
+++ b/python_bindings/correctness/rdom.py
@@ -14,13 +14,12 @@ def test_rdom():
     r.where(r.x <= r.y)
 
     diagonal[r.x, r.y] += 2
-    diagonal[r[0], r[1]] += 2
     output = diagonal.realize(domain_width, domain_height)
     
     for iy in range(domain_height):
         for ix in range(domain_width):
             if ix <= iy:
-                assert output[ix, iy] == 5
+                assert output[ix, iy] == 3
             else:
                 assert output[ix, iy] == 1
 

--- a/python_bindings/src/PyRDom.cpp
+++ b/python_bindings/src/PyRDom.cpp
@@ -36,8 +36,7 @@ void define_rdom(py::module &m) {
         .def_readonly("x", &RDom::x)
         .def_readonly("y", &RDom::y)
         .def_readonly("z", &RDom::z)
-        .def_readonly("w", &RDom::w)
-        .def("__getitem__", &RDom::operator[]);
+        .def_readonly("w", &RDom::w);
 
     add_binary_operators_with<Expr>(rdom_class);
 }


### PR DESCRIPTION
Reverts halide/Halide#3816

This has broken test_tutorial_lesson_13_tuples in the Python tests; we didn't notice it because the PR wasn't cloned and run with full tests.

(The nature of the fix required is not obvious to me, so I'm proposing to revert this to unbreak the tests; I encourage it to be re-added, but only after it's clear that `make test_python` is properly passing.)