### PR TITLE
JITModule::Symbol doesn't need llvm_type

### DIFF
--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -165,12 +165,13 @@ namespace {
 JITModule::Symbol compile_and_get_function(ExecutionEngine &ee, const string &name) {
     debug(2) << "JIT Compiling " << name << "\n";
     llvm::Function *fn = ee.FindFunctionNamed(name.c_str());
-    void *f = (void *)ee.getFunctionAddress(name);
+    internal_assert(fn->getName() == name);
+    void *f = (void *) ee.getFunctionAddress(name);
     if (!f) {
         internal_error << "Compiling " << name << " returned nullptr\n";
     }
 
-    JITModule::Symbol symbol(f, fn->getFunctionType());
+    JITModule::Symbol symbol(f);
 
     debug(2) << "Function " << name << " is at " << f << "\n";
 
@@ -436,36 +437,7 @@ void JITModule::add_symbol_for_export(const std::string &name, const Symbol &ext
 
 JITModule::Symbol JITModule::add_extern_for_export(const std::string &name,
                                                    const ExternCFunction &extern_c_function) {
-    Symbol symbol;
-    symbol.address = extern_c_function.address();
-
-    // Struct types are uniqued on the context, but the lookup API is only available
-    // on the Module, not the Context.
-    llvm::Module dummy_module("ThisIsRidiculous", jit_module->context);
-    llvm::Type *halide_buffer_t = dummy_module.getTypeByName("struct.halide_buffer_t");
-    if (halide_buffer_t == nullptr) {
-        halide_buffer_t = llvm::StructType::create(jit_module->context, "struct.halide_buffer_t");
-    }
-    llvm::Type *halide_buffer_t_star = llvm::PointerType::get(halide_buffer_t, 0);
-
-    llvm::Type *ret_type;
-    auto signature = extern_c_function.signature();
-    if (signature.is_void_return()) {
-        ret_type = llvm::Type::getVoidTy(jit_module->context);
-    } else {
-        ret_type = llvm_type_of(&jit_module->context, signature.ret_type());
-    }
-
-    std::vector<llvm::Type *> llvm_arg_types;
-    for (const Type &t : signature.arg_types()) {
-        if (t == type_of<struct halide_buffer_t *>()) {
-            llvm_arg_types.push_back(halide_buffer_t_star);
-        } else {
-            llvm_arg_types.push_back(llvm_type_of(&jit_module->context, t));
-        }
-    }
-
-    symbol.llvm_type = llvm::FunctionType::get(ret_type, llvm_arg_types, false);
+    Symbol symbol(extern_c_function.address());
     jit_module->exports[name] = symbol;
     return symbol;
 }

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -435,11 +435,10 @@ void JITModule::add_symbol_for_export(const std::string &name, const Symbol &ext
     jit_module->exports[name] = extern_symbol;
 }
 
-JITModule::Symbol JITModule::add_extern_for_export(const std::string &name,
-                                                   const ExternCFunction &extern_c_function) {
+void JITModule::add_extern_for_export(const std::string &name,
+                                      const ExternCFunction &extern_c_function) {
     Symbol symbol(extern_c_function.address());
     jit_module->exports[name] = symbol;
-    return symbol;
 }
 
 void JITModule::memoization_cache_set_size(int64_t size) const {

--- a/src/JITModule.h
+++ b/src/JITModule.h
@@ -34,10 +34,9 @@ struct JITModule {
     IntrusivePtr<JITModuleContents> jit_module;
 
     struct Symbol {
-        void *address;
-        llvm::Type *llvm_type;
-        Symbol() : address(nullptr), llvm_type(nullptr) {}
-        Symbol(void *address, llvm::Type *llvm_type) : address(address), llvm_type(llvm_type) {}
+        void *address = nullptr;
+        Symbol() : address(nullptr) {}
+        explicit Symbol(void *address) : address(address) {}
     };
 
     JITModule();

--- a/src/JITModule.h
+++ b/src/JITModule.h
@@ -35,13 +35,13 @@ struct JITModule {
 
     struct Symbol {
         void *address = nullptr;
-        Symbol() : address(nullptr) {}
+        Symbol() = default;
         explicit Symbol(void *address) : address(address) {}
     };
 
     JITModule();
     JITModule(const Module &m, const LoweredFunc &fn,
-                     const std::vector<JITModule> &dependencies = std::vector<JITModule>());
+              const std::vector<JITModule> &dependencies = std::vector<JITModule>());
     /** The exports map of a JITModule contains all symbols which are
      * available to other JITModules which depend on this one. For
      * runtime modules, this is all of the symbols exported from the
@@ -99,8 +99,8 @@ struct JITModule {
      * depend on this one. This routine converts the ExternSignature
      * info into an LLVM type, which allows type safe linkage of
      * external routines. */
-    Symbol add_extern_for_export(const std::string &name,
-                                 const ExternCFunction &extern_c_function);
+    void add_extern_for_export(const std::string &name,
+                               const ExternCFunction &extern_c_function);
 
     /** Look up a symbol by name in this module or its dependencies. */
     Symbol find_symbol_by_name(const std::string &) const;


### PR DESCRIPTION
We build and save the llvm FunctionType for each Symbol, but never actually use that type information anywhere. Stop doing that.