### PR TITLE
Bitwise ops type consistency.

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -247,8 +247,8 @@ Expr lower_euclidean_div(Expr a, Expr b) {
         */
 
         Expr r = a - q*b;
-        Expr bs = b >> (a.type().bits() - 1);
-        Expr rs = r >> (a.type().bits() - 1);
+        Expr bs = b >> cast(b.type(), (a.type().bits() - 1));
+        Expr rs = r >> cast(r.type(), (a.type().bits() - 1));
         q = q - (rs & bs) + (rs & ~bs);
         return common_subexpression_elimination(q);
     } else {
@@ -269,8 +269,8 @@ Expr lower_euclidean_mod(Expr a, Expr b) {
           r = r + sign_mask & abs(b);
         */
 
-        Expr sign_mask = r >> (a.type().bits()-1);
-        r += sign_mask & abs(b);
+        Expr sign_mask = r >> cast(r.type(), (a.type().bits()-1));
+        r += sign_mask & cast(sign_mask.type(), abs(b));
         return common_subexpression_elimination(r);
     } else {
         return r;

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -247,8 +247,8 @@ Expr lower_euclidean_div(Expr a, Expr b) {
         */
 
         Expr r = a - q*b;
-        Expr bs = b >> cast(b.type(), (a.type().bits() - 1));
-        Expr rs = r >> cast(r.type(), (a.type().bits() - 1));
+        Expr bs = b >> make_const(b.type(), (a.type().bits() - 1));
+        Expr rs = r >> make_const(r.type(), (a.type().bits() - 1));
         q = q - (rs & bs) + (rs & ~bs);
         return common_subexpression_elimination(q);
     } else {

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1447,7 +1447,7 @@ Expr CodeGen_LLVM::mulhi_shr(Expr a, Expr b, int shr) {
     Type wide_ty = ty.with_bits(ty.bits() * 2);
 
     Expr p_wide = cast(wide_ty, a) * cast(wide_ty, b);
-    return cast(ty, p_wide >> (shr + ty.bits()));
+    return cast(ty, p_wide >> make_const(p_wide.type(), (shr + ty.bits())));
 }
 
 Expr CodeGen_LLVM::sorted_avg(Expr a, Expr b) {
@@ -1474,7 +1474,7 @@ void CodeGen_LLVM::visit(const Div *op) {
         value = builder->CreateFDiv(a, b);
     } else if (is_const_power_of_two_integer(op->b, &shift_amount) &&
                (op->type.is_int() || op->type.is_uint())) {
-        value = codegen(op->a >> shift_amount);
+        value = codegen(op->a >> make_const(op->a.type(), shift_amount));
     } else if (const_int_divisor &&
                op->type.is_int() &&
                (op->type.bits() == 8 || op->type.bits() == 16 || op->type.bits() == 32) &&
@@ -1496,11 +1496,11 @@ void CodeGen_LLVM::visit(const Div *op) {
         Expr num = op->a;
 
         // Make an all-ones mask if the numerator is negative
-        Expr sign = num >> make_const(op->type, op->type.bits() - 1);
+        Expr sign = num >> make_const(num.type(), op->type.bits() - 1);
 
         // Flip the numerator bits if the mask is high.
         num = cast(num.type().with_code(Type::UInt), num);
-        num = num ^ sign;
+        num = num ^ cast(num.type(), sign);
 
         // Multiply and keep the high half of the
         // result, and then apply the shift.
@@ -1508,7 +1508,7 @@ void CodeGen_LLVM::visit(const Div *op) {
         num = mulhi_shr(num, mult, shift);
 
         // Maybe flip the bits back again.
-        num = num ^ sign;
+        num = cast(op->type, num ^ cast(num.type(), sign));
 
         value = codegen(num);
 

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -416,7 +416,7 @@ Expr CodeGen_X86::mulhi_shr(Expr a, Expr b, int shr) {
             p = i16(i32(a) * i32(b) / 65536);
         }
         if (shr) {
-            p = p >> shr;
+            p = p >> make_const(p.type(), shr);
         }
         return p;
     }

--- a/src/FastIntegerDivide.cpp
+++ b/src/FastIntegerDivide.cpp
@@ -159,7 +159,7 @@ Expr fast_integer_divide(Expr numerator, Expr denominator) {
         result = (cast(wide, mul) * numerator);
 
         if (t.bits() < 32) result = result / (1 << t.bits());
-        else result = result >> t.bits();
+        else result = result >> Internal::make_const(result.type(), t.bits());
 
         result = cast(t, result);
 
@@ -167,7 +167,7 @@ Expr fast_integer_divide(Expr numerator, Expr denominator) {
         result = result + (numerator - result)/2;
 
         // Do a final shift
-        result = result >> shift;
+        result = result >> cast(result.type(), shift);
 
 
     } else {
@@ -209,11 +209,11 @@ Expr fast_integer_divide(Expr numerator, Expr denominator) {
         // Multiply-keep-high-half
         result = (cast(wide, mul) * numerator);
         if (t.bits() < 32) result = result / (1 << t.bits());
-        else result = result >> t.bits();
+        else result = result >> Internal::make_const(result.type(), t.bits());
         result = cast(t, result);
 
         // Do the final shift
-        result = result >> shift;
+        result = result >> cast(result.type(), shift);
 
         // Maybe flip the bits again
         result = xsign ^ result;

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -441,7 +441,7 @@ void match_types(Expr &a, Expr &b) {
         << "Can't do arithmetic on opaque pointer types: "
         << a << ", " << b << "\n";
 
-    // First widen to match
+    // Broadcast scalar to match vector
     if (a.type().is_scalar() && b.type().is_vector()) {
         a = Broadcast::make(std::move(a), b.type().lanes());
     } else if (a.type().is_vector() && b.type().is_scalar()) {
@@ -452,7 +452,7 @@ void match_types(Expr &a, Expr &b) {
 
     Type ta = a.type(), tb = b.type();
 
-    // If type widening has made the types match no additional casts are needed
+    // If type broadcasting has made the types match no additional casts are needed
     if (ta == tb) return;
 
     if (!ta.is_float() && tb.is_float()) {
@@ -477,6 +477,47 @@ void match_types(Expr &a, Expr &b) {
         b = cast(Int(bits, lanes), std::move(b));
     } else {
         internal_error << "Could not match types: " << ta << ", " << tb << "\n";
+    }
+}
+
+void match_types_bitwise(Expr &x, Expr &y, const char *op_name) {
+    user_assert(x.defined() && y.defined()) << op_name << " of undefined Expr\n";
+    user_assert(x.type().is_int() || x.type().is_uint())
+      << "The first argument to " << op_name << " must be an integer or unsigned integer";
+    user_assert(y.type().is_int() || y.type().is_uint())
+      << "The second argument to " << op_name << " must be an integer or unsigned integer";
+
+    // Give explicit type to immediate constants in expression.
+    const IntImm *x_int_imm = x.as<IntImm>();
+    const IntImm *y_int_imm = y.as<IntImm>();
+    const UIntImm *x_uint_imm = x.as<UIntImm>();
+    const UIntImm *y_uint_imm = y.as<UIntImm>();
+    bool x_is_imm = x_int_imm || x_uint_imm;
+    bool y_is_imm = y_int_imm || y_uint_imm;
+    if (x_is_imm && !y_is_imm) {
+        x = cast(y.type().element_of(), x);
+    } else if (!x_is_imm && y_is_imm) {
+        y = cast(x.type().element_of(), y);
+    }
+
+    user_assert(y.type().is_int() == x.type().is_int()) << "Arguments to " << op_name
+      << " must be both be signed or both be unsigned.\n";
+
+    // Broadcast scalar to match vector
+    if (x.type().is_scalar() && y.type().is_vector()) {
+        x = Broadcast::make(std::move(x), y.type().lanes());
+    } else if (x.type().is_vector() && y.type().is_scalar()) {
+        y = Broadcast::make(std::move(y), x.type().lanes());
+    } else {
+        internal_assert(x.type().lanes() == y.type().lanes()) << "Can't match types of differing widths";
+    }
+
+    // Widen or narrow, then bitcast.
+    if (y.type().bits() != x.type().bits()) {
+        y = cast(y.type().with_bits(x.type().bits()), y);
+    }
+    if (y.type() != x.type()) {
+        y = reinterpret(x.type(), y);
     }
 }
 

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -486,20 +486,6 @@ void match_types_bitwise(Expr &x, Expr &y, const char *op_name) {
       << "The first argument to " << op_name << " must be an integer or unsigned integer";
     user_assert(y.type().is_int() || y.type().is_uint())
       << "The second argument to " << op_name << " must be an integer or unsigned integer";
-
-    // Give explicit type to immediate constants in expression.
-    const IntImm *x_int_imm = x.as<IntImm>();
-    const IntImm *y_int_imm = y.as<IntImm>();
-    const UIntImm *x_uint_imm = x.as<UIntImm>();
-    const UIntImm *y_uint_imm = y.as<UIntImm>();
-    bool x_is_imm = x_int_imm || x_uint_imm;
-    bool y_is_imm = y_int_imm || y_uint_imm;
-    if (x_is_imm && !y_is_imm) {
-        x = cast(y.type().element_of(), x);
-    } else if (!x_is_imm && y_is_imm) {
-        y = cast(x.type().element_of(), y);
-    }
-
     user_assert(y.type().is_int() == x.type().is_int()) << "Arguments to " << op_name
       << " must be both be signed or both be unsigned.\n";
 

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -512,12 +512,12 @@ void match_types_bitwise(Expr &x, Expr &y, const char *op_name) {
         internal_assert(x.type().lanes() == y.type().lanes()) << "Can't match types of differing widths";
     }
 
-    // Widen or narrow, then bitcast.
-    if (y.type().bits() != x.type().bits()) {
-        y = cast(y.type().with_bits(x.type().bits()), y);
-    }
-    if (y.type() != x.type()) {
-        y = reinterpret(x.type(), y);
+    // Cast to the wider type of the two. Already guaranteed to leave
+    // signed/unsigned on number of lanes unchanged.
+    if (x.type().bits() < y.type().bits()) {
+        x = cast(y.type(), x);
+    } else if (y.type().bits() < x.type().bits()) {
+        y = cast(x.type(), y);
     }
 }
 

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1435,31 +1435,82 @@ inline Expr reinterpret(Expr e) {
 }
 
 /** Return the bitwise and of two expressions (which need not have the
- * same type). The type of the result is the type of the first
- * argument. */
+ * same type).  The result type is the wider of the two expressions.
+ * Only integral types are allowed and both expressions must be signed
+ * or both must be unsigned. */
 inline Expr operator&(Expr x, Expr y) {
     match_types_bitwise(x, y, "bitwise and");
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::bitwise_and, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
 
+/** Return the bitwise and of an expression and an integer. The type
+ * of the result is the type of the expression argument. */
+// @{
+inline Expr operator&(Expr x, int y) {
+    Type t = x.type();
+    Internal::check_representable(t, y);
+    return Internal::Call::make(t, Internal::Call::bitwise_and, {std::move(x), Internal::make_const(t, y)}, Internal::Call::PureIntrinsic);
+}
+
+ inline Expr operator&(int x, Expr y) {
+    Type t = y.type();
+    Internal::check_representable(t, x);
+    return Internal::Call::make(t, Internal::Call::bitwise_and, {Internal::make_const(t, x), std::move(y)}, Internal::Call::PureIntrinsic);
+}
+// @}
+
 /** Return the bitwise or of two expressions (which need not have the
- * same type). The type of the result is the type of the first
- * argument. */
+ * same type).  The result type is the wider of the two expressions.
+ * Only integral types are allowed and both expressions must be signed
+ * or both must be unsigned. */
 inline Expr operator|(Expr x, Expr y) {
     match_types_bitwise(x, y, "bitwise or");
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::bitwise_or, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
 
-/** Return the bitwise exclusive or of two expressions (which need not
- * have the same type). The type of the result is the type of the
- * first argument. */
+/** Return the bitwise or of an expression and an integer. The type of
+ * the result is the type of the expression argument. */
+// @{
+inline Expr operator|(Expr x, int y) {
+    Type t = x.type();
+    Internal::check_representable(t, y);
+    return Internal::Call::make(t, Internal::Call::bitwise_or, {std::move(x), Internal::make_const(t, y)}, Internal::Call::PureIntrinsic);
+}
+
+inline Expr operator|(int x, Expr y) {
+    Type t = y.type();
+    Internal::check_representable(t, x);
+    return Internal::Call::make(t, Internal::Call::bitwise_or, {Internal::make_const(t, x), std::move(y)}, Internal::Call::PureIntrinsic);
+}
+// @}
+
+/** Return the bitwise xor of two expressions (which need not have the
+ * same type).  The result type is the wider of the two expressions.
+ * Only integral types are allowed and both expressions must be signed
+ * or both must be unsigned. */
 inline Expr operator^(Expr x, Expr y) {
     match_types_bitwise(x, y, "bitwise xor");
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::bitwise_xor, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
+
+/** Return the bitwise xor of an expression and an integer. The type
+ * of the result is the type of the expression argument. */
+// @{
+inline Expr operator^(Expr x, int y) {
+    Type t = x.type();
+    Internal::check_representable(t, y);
+    return Internal::Call::make(t, Internal::Call::bitwise_xor, {std::move(x), Internal::make_const(t, y)}, Internal::Call::PureIntrinsic);
+}
+
+inline Expr operator^(int x, Expr y) {
+    Type t = y.type();
+    Internal::check_representable(t, x);
+    return Internal::Call::make(t, Internal::Call::bitwise_xor, {Internal::make_const(t, x), std::move(y)}, Internal::Call::PureIntrinsic);
+}
+// @}
 
 /** Return the bitwise not of an expression. */
 inline Expr operator~(Expr x) {

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -167,7 +167,11 @@ Expr lossless_cast(Type t, Expr e);
  */
 void match_types(Expr &a, Expr &b);
 
-/** TODO: document this */
+/** Asserts that both expressions are integer types and are either
+ * both signed or both unsigned. If one argument is scalar and the
+ * other a vector, the scalar is broadcasted to have the same number
+ * of lanes as the vector. If one expression is of narrower type than
+ * the other, it is widened to the bit width of the wider. */
 void match_types_bitwise(Expr &a, Expr &b, const char *op_name);
 
 /** Halide's vectorizable transcendentals. */

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -167,6 +167,9 @@ Expr lossless_cast(Type t, Expr e);
  */
 void match_types(Expr &a, Expr &b);
 
+/** TODO: document this */
+void match_types_bitwise(Expr &a, Expr &b, const char *op_name);
+
 /** Halide's vectorizable transcendentals. */
 // @{
 Expr halide_log(Expr a);
@@ -1431,18 +1434,7 @@ inline Expr reinterpret(Expr e) {
  * same type). The type of the result is the type of the first
  * argument. */
 inline Expr operator&(Expr x, Expr y) {
-    user_assert(x.defined() && y.defined()) << "bitwise and of undefined Expr\n";
-    user_assert(x.type().is_int() || x.type().is_uint())
-        << "The first argument to bitwise and must be an integer or unsigned integer";
-    user_assert(y.type().is_int() || y.type().is_uint())
-        << "The second argument to bitwise and must be an integer or unsigned integer";
-    // First widen or narrow, then bitcast.
-    if (y.type().bits() != x.type().bits()) {
-        y = cast(y.type().with_bits(x.type().bits()), y);
-    }
-    if (y.type() != x.type()) {
-        y = reinterpret(x.type(), y);
-    }
+    match_types_bitwise(x, y, "bitwise and");
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::bitwise_and, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
@@ -1451,18 +1443,7 @@ inline Expr operator&(Expr x, Expr y) {
  * same type). The type of the result is the type of the first
  * argument. */
 inline Expr operator|(Expr x, Expr y) {
-    user_assert(x.defined() && y.defined()) << "bitwise or of undefined Expr\n";
-    user_assert(x.type().is_int() || x.type().is_uint())
-        << "The first argument to bitwise or must be an integer or unsigned integer";
-    user_assert(y.type().is_int() || y.type().is_uint())
-        << "The second argument to bitwise or must be an integer or unsigned integer";
-    // First widen or narrow, then bitcast.
-    if (y.type().bits() != x.type().bits()) {
-        y = cast(y.type().with_bits(x.type().bits()), y);
-    }
-    if (y.type() != x.type()) {
-        y = reinterpret(x.type(), y);
-    }
+    match_types_bitwise(x, y, "bitwise or");
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::bitwise_or, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
@@ -1471,18 +1452,7 @@ inline Expr operator|(Expr x, Expr y) {
  * have the same type). The type of the result is the type of the
  * first argument. */
 inline Expr operator^(Expr x, Expr y) {
-    user_assert(x.defined() && y.defined()) << "bitwise xor of undefined Expr\n";
-    user_assert(x.type().is_int() || x.type().is_uint())
-        << "The first argument to bitwise xor must be an integer or unsigned integer";
-    user_assert(y.type().is_int() || y.type().is_uint())
-        << "The second argument to bitwise xor must be an integer or unsigned integer";
-    // First widen or narrow, then bitcast.
-    if (y.type().bits() != x.type().bits()) {
-        y = cast(y.type().with_bits(x.type().bits()), y);
-    }
-    if (y.type() != x.type()) {
-        y = reinterpret(x.type(), y);
-    }
+    match_types_bitwise(x, y, "bitwise xor");
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::bitwise_xor, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
@@ -1505,10 +1475,7 @@ inline Expr operator~(Expr x) {
  * arguments must have integer type. */
 // @{
 inline Expr operator<<(Expr x, Expr y) {
-    user_assert(x.defined() && y.defined()) << "shift left of undefined Expr\n";
-    user_assert(!x.type().is_float()) << "First argument to shift left is a float: " << x << "\n";
-    user_assert(!y.type().is_float()) << "Second argument to shift left is a float: " << y << "\n";
-    Internal::match_types(x, y);
+    Internal::match_types_bitwise(x, y, "shift left");
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::shift_left, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
@@ -1534,10 +1501,7 @@ inline Expr operator<<(int x, Expr y) {
  * type. */
 // @{
 inline Expr operator>>(Expr x, Expr y) {
-    user_assert(x.defined() && y.defined()) << "shift right of undefined Expr\n";
-    user_assert(!x.type().is_float()) << "First argument to shift right is a float: " << x << "\n";
-    user_assert(!y.type().is_float()) << "Second argument to shift right is a float: " << y << "\n";
-    Internal::match_types(x, y);
+    Internal::match_types_bitwise(x, y, "shift right");
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::shift_right, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }

--- a/test/correctness/bitwise_ops.cpp
+++ b/test/correctness/bitwise_ops.cpp
@@ -121,7 +121,7 @@ int main(int argc, char **argv) {
     // bit shift on mixed types
     Func f9;
     Expr a32 = cast<int32_t>(input(x));
-    Expr b8  = min(31, cast<uint8_t>(input(x+1)));
+    Expr b8  = cast<int32_t>(min(31, cast<uint8_t>(input(x+1))));
     f9(x) = a32 >> b8;
     Buffer<int> im9 = f9.realize(128);
     for (int x = 0; x < 128; x++) {
@@ -149,6 +149,14 @@ int main(int argc, char **argv) {
             return -1;
         }
     }
+
+    // bitwise xor scalar/vector
+    Expr vec = cast(UInt(8).with_lanes(4), 42) ^ 3;
+    assert(vec.type().lanes() == 4);
+
+    // Ensure signedness is preserved.
+    Expr vec2 = cast(UInt(8).with_lanes(4), 42) & 3;
+    assert(vec.type().is_uint());
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/bitwise_ops.cpp
+++ b/test/correctness/bitwise_ops.cpp
@@ -139,7 +139,7 @@ int main(int argc, char **argv) {
     // bitwise and on mixed types
     Func f10;
     Expr a8 = cast<int8_t>(input(x));
-    f10(x) = a8 & 0xf0;
+    f10(x) = a8 & cast<int8_t>(0xf0);
     Buffer<int8_t> im10 = f10.realize(128);
     for (int x = 0; x < 128; x++) {
         int8_t correct = (int8_t)(input(x)) & 0xf0;

--- a/test/correctness/bitwise_ops.cpp
+++ b/test/correctness/bitwise_ops.cpp
@@ -158,6 +158,20 @@ int main(int argc, char **argv) {
     Expr vec2 = cast(UInt(8).with_lanes(4), 42) & 3;
     assert(vec.type().is_uint());
 
+    // Ensure that bitwise op is commutative re: type.  (This was not
+    // true at least for some time, which is problematic given that
+    // simplification and other things assume expressions can be
+    // reordered.)
+    {
+        Expr a = cast(UInt(8), 42);
+        Expr b = cast(UInt(16), 199);
+
+        Expr a_then_b = a ^ b;
+        Expr b_then_a = b ^ a;
+
+        assert(a_then_b.type() == b_then_a.type());
+    }
+
     printf("Success!\n");
     return 0;
 

--- a/test/correctness/print.cpp
+++ b/test/correctness/print.cpp
@@ -109,9 +109,9 @@ int main(int argc, char **argv) {
             n *= n;
             n *= n;
             n += 100;
-            int32_t hi = n >> 32;
-            int32_t lo = n & 0xffffffff;
-            args.push_back((cast<uint64_t>(hi) << 32) | lo);
+            uint64_t hi = n >> 32;
+            uint64_t lo = n & 0xffffffff;
+            args.push_back((Expr(hi) << 32) | Expr(lo));
             Expr dn = cast<double>((float)(n));
             args.push_back(dn);
         }


### PR DESCRIPTION
Our current type coercion for bitwise ops has a number of issues. It does not handle matching the number of lanes when a scalar and vector are paired and it is not commutative in terms of type width. It also did not handle mixture of signed and unsigned types well, possibly in ways that could result in errors constructing LLVM bitcode.

This PR fixes the above issues by making the operators require arguments that match in signed/unsigned sense, though constants will be made to match non-constant expressions so ```a & 127``` will get the type of ```a``` even though it may be unsigned and 127 would normally be an ```int``` or signed. Scalars are broadcasted to match a vector argument if needed. Logic for expanding bit width chooses the larger width.

Some fixes were required in the compiler and tests, though these were generally all compilation failures not result mismatches. The PR does change the semantics of the language slightly and will likely break some end user code. The current behavior for such code is questionable however and I believe there are cases where the compiler fails with an LLVM assertion instead of giving a clean error.