### PR TITLE
Set llvm::TargetOptions::UseInitArray = true

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -413,7 +413,7 @@ void get_target_options(const llvm::Module &module, llvm::TargetOptions &options
     options.GuaranteedTailCallOpt = false;
     options.StackAlignmentOverride = 0;
     options.FunctionSections = true;
-    options.UseInitArray = false;
+    options.UseInitArray = true;
     options.FloatABIType =
         use_soft_float_abi ? llvm::FloatABI::Soft : llvm::FloatABI::Hard;
     options.RelaxELFRelocations = false;


### PR DESCRIPTION
This causes llvm to put ctors into the `.init_array` section when possible (rather than the .ctors` section.

This can dramatically improve performance for some targets (esp aarch64) when the `lld` linker is used: older linkers (eg, gold) tend to do legacy conversion of .ctors to .init_array, but lld does not.

(It's not clear to me why we default this to false -- historical reasons? mistake? ignorance? -- or if there are any downsides to making this change.)