### PR TITLE
updating makefile to process newer ld trace output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -910,7 +910,7 @@ $(BUILD_DIR)/llvm_objects/list: $(OBJECTS) $(INITIAL_MODULES)
 	# object files in which archives it uses to resolve
 	# symbols. We only care about the libLLVM ones.
 	@mkdir -p $(@D)
-	$(CXX) -o /dev/null -shared $(OBJECTS) $(INITIAL_MODULES) -Wl,-t $(LLVM_STATIC_LIBS) $(LLVM_SYSTEM_LIBS) $(COMMON_LD_FLAGS) 2>&1| egrep "libLLVM" > $(BUILD_DIR)/llvm_objects/list.new
+	$(CXX) -o /dev/null -shared -Wl,-t -Wl,-t $(OBJECTS) $(INITIAL_MODULES) $(LLVM_STATIC_LIBS) $(LLVM_SYSTEM_LIBS) $(COMMON_LD_FLAGS) 2>&1 | egrep "libLLVM" | egrep ")" > $(BUILD_DIR)/llvm_objects/list.new
 	# if the list has changed since the previous build, or there
 	# is no list from a previous build, then delete any old object
 	# files and re-extract the required object files


### PR DESCRIPTION
ld as of version 2.32 no longer prints the members of an archive with a single `-t` flag. Now it must be passed twice. In addition, the new output format precedes lines of the form `(archive)object` with the archive on a single line regardless of whether any objects therein were used. This PR adjusts the command in the Makefile to adapt to this by passing the second `-t` flag (which will be redundant on earlier versions) and dropping lines that lack a closing parenthesis (of which there are none on earlier versions).

Thanks to @alexreinking for figuring this out.