### PR TITLE
Improve mlal codegen

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -228,6 +228,12 @@ CodeGen_ARM::CodeGen_ARM(Target target) : CodeGen_Posix(target) {
     negations.push_back(Pattern("vqneg.v4i32", "sqneg.v4i32", 4,  -max(wild_i32x_, -(0x7fffffff))));
 
     // Widening multiplies.
+    multiplies.push_back(Pattern("vmulls.v2i64", "smull.v2i64", 2,
+                                 wild_i64x_ * wild_i64x_,
+                                 Pattern::NarrowArgs));
+    multiplies.push_back(Pattern("vmullu.v2i64", "umull.v2i64", 2,
+                                 wild_u64x_ * wild_u64x_,
+                                 Pattern::NarrowArgs));
     multiplies.push_back(Pattern("vmulls.v4i32", "smull.v4i32", 4,
                                  wild_i32x_ * wild_i32x_,
                                  Pattern::NarrowArgs));

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -227,6 +227,7 @@ CodeGen_ARM::CodeGen_ARM(Target target) : CodeGen_Posix(target) {
     negations.push_back(Pattern("vqneg.v8i16", "sqneg.v8i16", 8,  -max(wild_i16x_, -32767)));
     negations.push_back(Pattern("vqneg.v4i32", "sqneg.v4i32", 4,  -max(wild_i32x_, -(0x7fffffff))));
 
+    // Widening multiplies.
     multiplies.push_back(Pattern("vmulls.v4i32", "smull.v4i32", 4,
                                  wild_i32x_ * wild_i32x_,
                                  Pattern::NarrowArgs));
@@ -383,6 +384,8 @@ void CodeGen_ARM::visit(const Mul *op) {
         return;
     }
 
+    // LLVM really struggles to generate mlal unless we generate mull intrinsics
+    // for the multiplication part first.
     for (size_t i = 0; i < multiplies.size() ; i++) {
         const Pattern &pattern = multiplies[i];
         //debug(4) << "Trying pattern: " << patterns[i].intrin << " " << patterns[i].pattern << "\n";

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -226,6 +226,19 @@ CodeGen_ARM::CodeGen_ARM(Target target) : CodeGen_Posix(target) {
     negations.push_back(Pattern("vqneg.v16i8", "sqneg.v16i8", 16, -max(wild_i8x_, -127)));
     negations.push_back(Pattern("vqneg.v8i16", "sqneg.v8i16", 8,  -max(wild_i16x_, -32767)));
     negations.push_back(Pattern("vqneg.v4i32", "sqneg.v4i32", 4,  -max(wild_i32x_, -(0x7fffffff))));
+
+    multiplies.push_back(Pattern("vmulls.v4i32", "smull.v4i32", 4,
+                                 wild_i32x_ * wild_i32x_,
+                                 Pattern::NarrowArgs));
+    multiplies.push_back(Pattern("vmullu.v4i32", "umull.v4i32", 4,
+                                 wild_u32x_ * wild_u32x_,
+                                 Pattern::NarrowArgs));
+    multiplies.push_back(Pattern("vmulls.v8i16", "smull.v8i16", 8,
+                                 wild_i16x_ * wild_i16x_,
+                                 Pattern::NarrowArgs));
+    multiplies.push_back(Pattern("vmullu.v8i16", "umull.v8i16", 8,
+                                 wild_u16x_ * wild_u16x_,
+                                 Pattern::NarrowArgs));
 }
 
 Value *CodeGen_ARM::call_pattern(const Pattern &p, Type t, const vector<Expr> &args) {
@@ -360,9 +373,55 @@ void CodeGen_ARM::visit(const Mul *op) {
         return;
     }
 
+    Type t = op->type;
+    vector<Expr> matches;
+
+    int shift_amount = 0;
+    if (is_const_power_of_two_integer(op->b, &shift_amount)) {
+        // Let LLVM handle these.
+        CodeGen_Posix::visit(op);
+        return;
+    }
+
+    for (size_t i = 0; i < multiplies.size() ; i++) {
+        const Pattern &pattern = multiplies[i];
+        //debug(4) << "Trying pattern: " << patterns[i].intrin << " " << patterns[i].pattern << "\n";
+        if (expr_match(pattern.pattern, op, matches)) {
+
+            //debug(4) << "Match!\n";
+            if (pattern.type == Pattern::Simple) {
+                value = call_pattern(pattern, t, matches);
+                return;
+            } else if (pattern.type == Pattern::NarrowArgs) {
+                Type narrow_t = t.with_bits(t.bits() / 2);
+                // Try to narrow all of the args.
+                bool all_narrow = true;
+                for (size_t i = 0; i < matches.size(); i++) {
+                    internal_assert(matches[i].type().bits() == t.bits());
+                    internal_assert(matches[i].type().lanes() == t.lanes());
+                    // debug(4) << "Attemping to narrow " << matches[i] << " to " << t << "\n";
+                    matches[i] = lossless_cast(narrow_t, matches[i]);
+                    if (!matches[i].defined()) {
+                        // debug(4) << "failed\n";
+                        all_narrow = false;
+                    } else {
+                        // debug(4) << "success: " << matches[i] << "\n";
+                        internal_assert(matches[i].type() == narrow_t);
+                    }
+                }
+
+                if (all_narrow) {
+                    value = call_pattern(pattern, t, matches);
+                    return;
+                }
+            }
+        }
+    }
+
     // Vector multiplies by 3, 5, 7, 9 should do shift-and-add or
     // shift-and-sub instead to reduce register pressure (the
     // shift is an immediate)
+    // TODO: Verify this is still good codegen.
     if (is_const(op->b, 3)) {
         value = codegen(op->a*2 + op->a);
         return;
@@ -375,67 +434,6 @@ void CodeGen_ARM::visit(const Mul *op) {
     } else if (is_const(op->b, 9)) {
         value = codegen(op->a*8 + op->a);
         return;
-    }
-
-    vector<Expr> matches;
-
-    int shift_amount = 0;
-    bool power_of_two = is_const_power_of_two_integer(op->b, &shift_amount);
-    if (power_of_two) {
-        for (size_t i = 0; i < left_shifts.size(); i++) {
-            const Pattern &pattern = left_shifts[i];
-            internal_assert(pattern.type == Pattern::LeftShift);
-            if (expr_match(pattern.pattern, op, matches)) {
-                llvm::Type *t_arg = llvm_type_of(matches[0].type());
-                llvm::Type *t_result = llvm_type_of(op->type);
-                Value *shift = nullptr;
-                if (target.bits == 32) {
-                    shift = ConstantInt::get(t_arg, shift_amount);
-                } else {
-                    shift = ConstantInt::get(i32_t, shift_amount);
-                }
-                value = call_pattern(pattern, t_result,
-                                     {codegen(matches[0]), shift});
-                return;
-            }
-        }
-    }
-
-    //
-    // Detect the cases where any of the operands has the pattern:
-    //      broadcast(widen(scalar))
-    // and convert it to
-    //      widen(broadcast(scalar))
-    // to be able to generate vmlal.x instructions correctly from llvm.
-    //
-    if (op->type.is_int() || op->type.is_uint()) {
-        // Check the first operand op->a for the pattern broadcast(widen(scalar))
-        //
-        const Broadcast *bcast_a = op->a.as<Broadcast>();
-        const Cast *cast_a = bcast_a ? bcast_a->value.as<Cast>() : nullptr;
-        const int lanes = op->type.lanes();
-
-        // If the pattern is there, and the cast is a widening cast
-        if (cast_a && cast_a->value.type().bits() < op->type.bits()) {
-            // generate a new Mul with flipped widen(broadcast(scalar))
-            Expr new_a = Cast::make(op->type,
-                                    Broadcast::make(cast_a->value, lanes));
-            debug(4) << "Replaced: " << op->a << "\n  with: " << new_a << "\n";
-            value = codegen(new_a * op->b);
-            return;
-        }
-
-        // Do the same for the second operand op->b
-        //
-        const Broadcast *bcast_b = op->b.as<Broadcast>();
-        const Cast *cast_b = bcast_b ? bcast_b->value.as<Cast>() : nullptr;
-        if (cast_b && cast_b->value.type().bits() < op->type.bits()) {
-            Expr new_b = Cast::make(op->type,
-                                   Broadcast::make(cast_b->value, lanes));
-            debug(4) << "Replaced: " << op->b << "\n  with: " << new_b << "\n";
-            value = codegen(op->a * new_b);
-            return;
-        }
     }
 
     CodeGen_Posix::visit(op);

--- a/src/CodeGen_ARM.h
+++ b/src/CodeGen_ARM.h
@@ -54,7 +54,7 @@ protected:
             intrin64("llvm.aarch64.neon." + i64),
             intrin_lanes(l), pattern(p), type(t) {}
     };
-    std::vector<Pattern> casts, left_shifts, averagings, negations;
+    std::vector<Pattern> casts, averagings, negations, multiplies;
 
     // Call an intrinsic as defined by a pattern. Dispatches to the
     // 32- or 64-bit name depending on the target's bit width.

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1017,19 +1017,22 @@ struct Test {
             }
 
             // VMLAL    I       -       Multiply Accumulate Long
-            check(arm32 ? "vmlal.s8"  : "smlal", 8*w, i16_1 + i16(i8_2)*i8_3);
+            // Try to trick LLVM into generating a zext instead of a sext by making
+            // LLVM think the operand never has a leading 1 bit. zext breaks LLVM's
+            // pattern matching of mlal.
+            check(arm32 ? "vmlal.s8"  : "smlal", 8*w, i16_1 + i16(i8_2 & 0x3)*i8_3);
             check(arm32 ? "vmlal.u8"  : "umlal", 8*w, u16_1 + u16(u8_2)*u8_3);
-            check(arm32 ? "vmlal.s16" : "smlal", 4*w, i32_1 + i32(i16_2)*i16_3);
+            check(arm32 ? "vmlal.s16" : "smlal", 4*w, i32_1 + i32(i16_2 & 0x3)*i16_3);
             check(arm32 ? "vmlal.u16" : "umlal", 4*w, u32_1 + u32(u16_2)*u16_3);
-            check(arm32 ? "vmlal.s32" : "smlal", 2*w, i64_1 + i64(i32_2)*i32_3);
+            check(arm32 ? "vmlal.s32" : "smlal", 2*w, i64_1 + i64(i32_2 & 0x3)*i32_3);
             check(arm32 ? "vmlal.u32" : "umlal", 2*w, u64_1 + u64(u32_2)*u32_3);
 
             // VMLSL    I       -       Multiply Subtract Long
-            check(arm32 ? "vmlsl.s8"  : "smlsl", 8*w, i16_1 - i16(i8_2)*i8_3);
+            check(arm32 ? "vmlsl.s8"  : "smlsl", 8*w, i16_1 - i16(i8_2 & 0x3)*i8_3);
             check(arm32 ? "vmlsl.u8"  : "umlsl", 8*w, u16_1 - u16(u8_2)*u8_3);
-            check(arm32 ? "vmlsl.s16" : "smlsl", 4*w, i32_1 - i32(i16_2)*i16_3);
+            check(arm32 ? "vmlsl.s16" : "smlsl", 4*w, i32_1 - i32(i16_2 & 0x3)*i16_3);
             check(arm32 ? "vmlsl.u16" : "umlsl", 4*w, u32_1 - u32(u16_2)*u16_3);
-            check(arm32 ? "vmlsl.s32" : "smlsl", 2*w, i64_1 - i64(i32_2)*i32_3);
+            check(arm32 ? "vmlsl.s32" : "smlsl", 2*w, i64_1 - i64(i32_2 & 0x3)*i32_3);
             check(arm32 ? "vmlsl.u32" : "umlsl", 2*w, u64_1 - u64(u32_2)*u32_3);
 
             // VMOV     X       F, D    Move Register or Immediate


### PR DESCRIPTION
Currently, very little code except for *exact* matches to https://github.com/earl/llvm-mirror/blob/master/test/CodeGen/AArch64/aarch64-smull.ll are generating mlal instructions. This PR makes LLVM more able to generate mlal by emulating Clang's arm_neon.h.