### PR TITLE
Fix cuda mat mul

### DIFF
--- a/src/Simplify_Max.cpp
+++ b/src/Simplify_Max.cpp
@@ -120,6 +120,11 @@ Expr Simplify::visit(const Max *op, ExprInfo *bounds) {
                rewrite(max(max(y, x) + c0, x), max(y + c0, x), c0 < 0) ||
                rewrite(max(max(y, x) + c0, x), max(y, x) + c0, c0 > 0) ||
 
+               rewrite(max(x, max(x, y) + c0), max(x, y + c0), c0 < 0) ||
+               rewrite(max(x, max(x, y) + c0), max(x, y) + c0, c0 > 0) ||
+               rewrite(max(x, max(y, x) + c0), max(x, y + c0), c0 < 0) ||
+               rewrite(max(x, max(y, x) + c0), max(x, y) + c0, c0 > 0) ||
+
                rewrite(max(x + c0, c1), max(x, fold(c1 - c0)) + c0) ||
 
                rewrite(max(x + c0, y + c1), max(x, y + fold(c1 - c0)) + c0, c1 > c0) ||

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -123,6 +123,11 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
                rewrite(min(min(y, x) + c0, x), min(y + c0, x), c0 > 0) ||
                rewrite(min(min(y, x) + c0, x), min(y, x) + c0, c0 < 0) ||
 
+               rewrite(min(x, min(x, y) + c0), min(x, y + c0), c0 > 0) ||
+               rewrite(min(x, min(x, y) + c0), min(x, y) + c0, c0 < 0) ||
+               rewrite(min(x, min(y, x) + c0), min(x, y + c0), c0 > 0) ||
+               rewrite(min(x, min(y, x) + c0), min(x, y) + c0, c0 < 0) ||
+
                rewrite(min(x + c0, c1), min(x, fold(c1 - c0)) + c0) ||
 
                rewrite(min(x + c0, y + c1), min(x, y + fold(c1 - c0)) + c0, c1 > c0) ||

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -618,6 +618,26 @@ void check_bounds() {
     check(max(max(y, x) + 1, x), max(x, y) + 1);
     check(max(max(y, x) - (-1), x), max(x, y) + 1);
 
+    check(min(x, min(x, y) + 1), min(y + 1, x));
+    check(min(x, min(x, y) - (-1)), min(y + 1, x));
+    check(min(x, min(x, y) + (-1)), min(x, y) + (-1));
+    check(min(x, min(x, y) - 1), min(x, y) + (-1));
+
+    check(min(x, min(y, x) + 1), min(y + 1, x));
+    check(min(x, min(y, x) - (-1)), min(y + 1, x));
+    check(min(x, min(y, x) + (-1)), min(x, y) + (-1));
+    check(min(x, min(y, x) - 1), min(x, y) + (-1));
+
+    check(max(x, max(x, y) - 1), max(y + (-1), x));
+    check(max(x, max(x, y) + (-1)), max(y + (-1), x));
+    check(max(x, max(x, y) + 1), max(x, y) + 1);
+    check(max(x, max(x, y) - (-1)), max(x, y) + 1);
+
+    check(max(x, max(y, x) - 1), max(y + (-1), x));
+    check(max(x, max(y, x) + (-1)), max(y + (-1), x));
+    check(max(x, max(y, x) + 1), max(x, y) + 1);
+    check(max(x, max(y, x) - (-1)), max(x, y) + 1);
+
     check(max(Expr(7), 3), 7);
     check(max(Expr(4.25f), 1.25f), 4.25f);
     check(max(broadcast(x, 4), broadcast(y, 4)),


### PR DESCRIPTION
apps/cuda_mat_mul wasn't working. The main cause is a bug in variable handling in warp shuffle lowering, but it also needs some new simplifier rules for things to work out in a way it can analyze. Lower warp shuffles is unfortunately a brittle pass.
