### PR TITLE
Simplify Emscripten config requirements for wasm branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,12 @@ else
 	EMCC_SIMD_OPT=0
 endif
 
+# We slurp in the default ~/.emscripten config file and make an altered version
+# with LLVM_ROOT pointing to the LLVM we are using, so that we can build with
+# the 'correct' version (ie the one that the rest of Halide is using) whether
+# or not ~/.emscripten has been edited correctly.
+EMCC_CONFIG=$(shell cat $(HOME)/.emscripten | grep -v LLVM_ROOT | tr '\n' ';')LLVM_ROOT='$(LLVM_BINDIR)'
+
 PTX_CXX_FLAGS=$(if $(WITH_PTX), -DWITH_PTX=1, )
 PTX_LLVM_CONFIG_LIB=$(if $(WITH_PTX), nvptx, )
 PTX_DEVICE_INITIAL_MODULES=$(if $(WITH_PTX), libdevice.compute_20.10.bc libdevice.compute_30.10.bc libdevice.compute_35.10.bc, )
@@ -1547,7 +1553,7 @@ GEN_AOT_LD_FLAGS_WASM := $(filter-out -lpthread,$(GEN_AOT_LD_FLAGS_WASM))
 $(BIN_DIR)/$(TARGET)/generator_aotwasm_%.js: $(ROOT_DIR)/test/generator/%_aottest.cpp $(FILTERS_DIR)/%.a $(FILTERS_DIR)/%.h $(RUNTIME_EXPORTED_INCLUDES) $(BIN_DIR)/$(TARGET)/runtime.a
 	@mkdir -p $(@D)
 	@# --source-map-base is just to silence an irrelevant warning from Emscripten
-	EMCC_WASM_BACKEND=1 $(EMCC) $(GEN_AOT_CXX_FLAGS_WASM) -s WASM=1 -s SIMD=$(EMCC_SIMD_OPT) -s EXIT_RUNTIME=1 -s ENVIRONMENT=shell --source-map-base . $(filter %.cpp %.o %.a,$^) $(GEN_AOT_INCLUDES) $(GEN_AOT_LD_FLAGS_WASM) -o $@
+	EMCC_WASM_BACKEND=1 EM_CONFIG="$(EMCC_CONFIG)" $(EMCC) $(GEN_AOT_CXX_FLAGS_WASM) -s WASM=1 -s SIMD=$(EMCC_SIMD_OPT) -s EXIT_RUNTIME=1 -s ENVIRONMENT=shell --source-map-base . $(filter %.cpp %.o %.a,$^) $(GEN_AOT_INCLUDES) $(GEN_AOT_LD_FLAGS_WASM) -o $@
 
 $(BIN_DIR)/$(TARGET)/generator_aotwasm_%.wasm: $(BIN_DIR)/$(TARGET)/generator_aotwasm_%.js
 	@# nothing

--- a/README_webassembly.md
+++ b/README_webassembly.md
@@ -77,7 +77,7 @@ If you want to test ahead-of-time code generation (and you almost certainly will
 
 - The simplest way to install is probably via the Emscripten emsdk (https://emscripten.org/docs/getting_started/downloads.html).
 
-- After installing Emscripten, be sure that it is configured to use the version of LLVM that you configured earlier, rather than its built-in version (which is an older version which won't work well with Halide); if you installed via `emsdk`, you need to edit `~/.emscripten` and set `LLVM_ROOT` to point at the LLVM you have built. (If you fail with errors like `WASM_BACKEND selected but could not find lld (wasm-ld)`, you forgot to do this step.)
+- The default Halide makefile sets a custom value for `EM_CONFIG` to ensure that we use the correct version of LLVM (i.e., the version used by the rest of Halide), rather than relying on `~/.emscripten` being set correctly. If you are using Emscripten in your own build system in conjunction with Halide, you'll probably need to edit your own `~/.emscripten` file to ensure that `LLVM_ROOT` points at the LLVM you built earlier (or pass a custom `--em-config` flag, or set the `EM_CONFIG` env var). If you fail with errors like `WASM_BACKEND selected but could not find lld (wasm-ld)`, you forgot to do this step.
 
 - Set `WASM_SHELL=/path/to/d8`
 


### PR DESCRIPTION
Formerly, a config file had to be edited correctly, or bad things happened. Now we set it correctly automatically.