### PR TITLE
Shift amount type change

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1047,7 +1047,7 @@ private:
                             }
                         } else if (is_const(b)) {
                             // We can normalize to multiplication
-                            Expr equiv = a * (1 << b);
+                            Expr equiv = a * (make_const(t, 1) << b);
                             equiv.accept(this);
                         }
                     } else if (op->is_intrinsic(Call::shift_right)) {
@@ -2529,7 +2529,8 @@ void constant_bound_test() {
     using namespace ConciseCasts;
 
     {
-        Param<int16_t> a, b;
+        Param<int16_t> a;
+        Param<uint16_t> b;
         check_constant_bound(a >> b, i16(-32768), i16(32767));
     }
 
@@ -2787,7 +2788,8 @@ void bounds_test() {
     }
 
     {
-        Param<int16_t> x("x"), y("y");
+        Param<int16_t> x("x");
+        Param<uint16_t> y("y");
         x.set_range(i16(-32), i16(-16));
         y.set_range(i16(0), i16(4));
         check_constant_bound((x >> y), i16(-32), i16(-1));

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2402,21 +2402,17 @@ void CodeGen_LLVM::visit(const Call *op) {
         }
     } else if (op->is_intrinsic(Call::shift_left)) {
         internal_assert(op->args.size() == 2);
+        internal_assert(op->args[0].type().bits() == op->args[1].type().bits());
         Value *a = codegen(op->args[0]);
         Value *b = codegen(op->args[1]);
-        if (op->args[0].type() != op->args[1].type()) {
-            llvm::Type *llvm_type_lhs = llvm_type_of(op->args[0].type());
-            b = builder->CreateBitCast(b, llvm_type_lhs);
-        }
+	internal_assert(a->getType() == b->getType()) << "LLVM type mismatch on (" << op->args[0] << ") << (" << op->args[1] << ").\n";
         value = builder->CreateShl(a, b);
     } else if (op->is_intrinsic(Call::shift_right)) {
         internal_assert(op->args.size() == 2);
+        internal_assert(op->args[0].type().bits() == op->args[1].type().bits());
         Value *a = codegen(op->args[0]);
         Value *b = codegen(op->args[1]);
-        if (op->args[0].type() != op->args[1].type()) {
-            llvm::Type *llvm_type_lhs = llvm_type_of(op->args[0].type());
-            b = builder->CreateBitCast(b, llvm_type_lhs);
-        }
+	internal_assert(a->getType() == b->getType()) << "LLVM type mismatch on (" << op->args[0] << ") >> (" << op->args[1] << ").\n";
         if (op->type.is_int()) {
             value = builder->CreateAShr(a, b);
         } else {

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2404,11 +2404,19 @@ void CodeGen_LLVM::visit(const Call *op) {
         internal_assert(op->args.size() == 2);
         Value *a = codegen(op->args[0]);
         Value *b = codegen(op->args[1]);
+        if (op->args[0].type() != op->args[1].type()) {
+            llvm::Type *llvm_type_lhs = llvm_type_of(op->args[0].type());
+            b = builder->CreateBitCast(b, llvm_type_lhs);
+        }
         value = builder->CreateShl(a, b);
     } else if (op->is_intrinsic(Call::shift_right)) {
         internal_assert(op->args.size() == 2);
         Value *a = codegen(op->args[0]);
         Value *b = codegen(op->args[1]);
+        if (op->args[0].type() != op->args[1].type()) {
+            llvm::Type *llvm_type_lhs = llvm_type_of(op->args[0].type());
+            b = builder->CreateBitCast(b, llvm_type_lhs);
+        }
         if (op->type.is_int()) {
             value = builder->CreateAShr(a, b);
         } else {

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2405,14 +2405,14 @@ void CodeGen_LLVM::visit(const Call *op) {
         internal_assert(op->args[0].type().bits() == op->args[1].type().bits());
         Value *a = codegen(op->args[0]);
         Value *b = codegen(op->args[1]);
-	internal_assert(a->getType() == b->getType()) << "LLVM type mismatch on (" << op->args[0] << ") << (" << op->args[1] << ").\n";
+        internal_assert(a->getType() == b->getType()) << "LLVM type mismatch on (" << op->args[0] << ") << (" << op->args[1] << ").\n";
         value = builder->CreateShl(a, b);
     } else if (op->is_intrinsic(Call::shift_right)) {
         internal_assert(op->args.size() == 2);
         internal_assert(op->args[0].type().bits() == op->args[1].type().bits());
         Value *a = codegen(op->args[0]);
         Value *b = codegen(op->args[1]);
-	internal_assert(a->getType() == b->getType()) << "LLVM type mismatch on (" << op->args[0] << ") >> (" << op->args[1] << ").\n";
+        internal_assert(a->getType() == b->getType()) << "LLVM type mismatch on (" << op->args[0] << ") >> (" << op->args[1] << ").\n";
         if (op->type.is_int()) {
             value = builder->CreateAShr(a, b);
         } else {

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -732,19 +732,19 @@ private:
             { "halide.hexagon.add_mpy.vw.vh.vuh",   wild_i32x + wild_i32x*wild_i32x, Pattern::ReinterleaveOp0 | Pattern::NarrowUnsignedOp1 | Pattern::NarrowOp2 | Pattern::SwapOps12 },
 
             // Shift-accumulates.
-            { "halide.hexagon.add_shr.vw.vw.w", wild_i32x + (wild_i32x >> bc(wild_i32)) },
-            { "halide.hexagon.add_shl.vw.vw.w", wild_i32x + (wild_i32x << bc(wild_i32)) },
+            { "halide.hexagon.add_shr.vw.vw.w", wild_i32x + (wild_i32x >> bc(wild_u32)) },
+            { "halide.hexagon.add_shl.vw.vw.w", wild_i32x + (wild_i32x << bc(wild_u32)) },
             { "halide.hexagon.add_shl.vw.vw.w", wild_u32x + (wild_u32x << bc(wild_u32)) },
             { "halide.hexagon.add_shr.vw.vw.w", wild_i32x + (wild_i32x/bc(wild_i32)), Pattern::ExactLog2Op2 },
             { "halide.hexagon.add_shl.vw.vw.w", wild_i32x + (wild_i32x*bc(wild_i32)), Pattern::ExactLog2Op2 },
             { "halide.hexagon.add_shl.vw.vw.w", wild_u32x + (wild_u32x*bc(wild_u32)), Pattern::ExactLog2Op2 },
             { "halide.hexagon.add_shl.vw.vw.w", wild_i32x + (bc(wild_i32)*wild_i32x), Pattern::ExactLog2Op1 | Pattern::SwapOps12 },
             { "halide.hexagon.add_shl.vw.vw.w", wild_u32x + (bc(wild_u32)*wild_u32x), Pattern::ExactLog2Op1 | Pattern::SwapOps12 },
-            { "halide.hexagon.add_shl.vh.vh.h", wild_i16x + (wild_i16x << bc(wild_i16)), Pattern::v65orLater },
+            { "halide.hexagon.add_shl.vh.vh.h", wild_i16x + (wild_i16x << bc(wild_u16)), Pattern::v65orLater },
             { "halide.hexagon.add_shl.vh.vh.h", wild_u16x + (wild_u16x << bc(wild_u16)), Pattern::v65orLater },
-            { "halide.hexagon.add_shl.vh.vh.h", wild_i16x + (bc(wild_i16) << wild_i16x), Pattern::SwapOps12 | Pattern::v65orLater },
+            { "halide.hexagon.add_shl.vh.vh.h", wild_i16x + (bc(wild_i16) << wild_u16x), Pattern::SwapOps12 | Pattern::v65orLater },
             { "halide.hexagon.add_shl.vh.vh.h", wild_u16x + (bc(wild_u16) << wild_u16x), Pattern::SwapOps12 | Pattern::v65orLater },
-            { "halide.hexagon.add_shr.vh.vh.h", wild_i16x + (wild_i16x >> bc(wild_i16)), Pattern::v65orLater },
+            { "halide.hexagon.add_shr.vh.vh.h", wild_i16x + (wild_i16x >> bc(wild_u16)), Pattern::v65orLater },
             { "halide.hexagon.add_shr.vh.vh.h", wild_i16x + (wild_i16x/bc(wild_i16)), Pattern::ExactLog2Op2 | Pattern::v65orLater },
             { "halide.hexagon.add_shl.vh.vh.h", wild_i16x + (wild_i16x*bc(wild_i16)), Pattern::ExactLog2Op2 | Pattern::v65orLater },
             { "halide.hexagon.add_shl.vh.vh.h", wild_u16x + (wild_u16x*bc(wild_u16)), Pattern::ExactLog2Op2 | Pattern::v65orLater },
@@ -876,9 +876,9 @@ private:
             { "halide.hexagon.trunc_sath_rnd.vw",  i16_sat((wild_i64x + 32768)/65536), Pattern::DeinterleaveOp0 | Pattern::NarrowOp0 },
 
             // Saturating narrowing casts
-            { "halide.hexagon.trunc_satub_shr.vh.h", u8_sat(wild_i16x >> wild_i16), Pattern::DeinterleaveOp0 },
-            { "halide.hexagon.trunc_satuh_shr.vw.w", u16_sat(wild_i32x >> wild_i32), Pattern::DeinterleaveOp0 },
-            { "halide.hexagon.trunc_sath_shr.vw.w",  i16_sat(wild_i32x >> wild_i32), Pattern::DeinterleaveOp0 },
+            { "halide.hexagon.trunc_satub_shr.vh.h", u8_sat(wild_i16x >> wild_u16), Pattern::DeinterleaveOp0 },
+            { "halide.hexagon.trunc_satuh_shr.vw.w", u16_sat(wild_i32x >> wild_u32), Pattern::DeinterleaveOp0 },
+            { "halide.hexagon.trunc_sath_shr.vw.w",  i16_sat(wild_i32x >> wild_u32), Pattern::DeinterleaveOp0 },
             { "halide.hexagon.trunc_satub_shr.vh.h", u8_sat(wild_i16x/wild_i16), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
             { "halide.hexagon.trunc_satuh_shr.vw.w", u16_sat(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
             { "halide.hexagon.trunc_sath_shr.vw.w",  i16_sat(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
@@ -909,7 +909,7 @@ private:
             { "halide.hexagon.packhi.vw", i16(wild_i32x/65536) },
 
             // Narrowing with shifting.
-            { "halide.hexagon.trunc_shr.vw.w",  i16(wild_i32x >> wild_i32), Pattern::DeinterleaveOp0 },
+            { "halide.hexagon.trunc_shr.vw.w",  i16(wild_i32x >> wild_u32), Pattern::DeinterleaveOp0 },
             { "halide.hexagon.trunc_shr.vw.w",  i16(wild_i32x/wild_i32), Pattern::DeinterleaveOp0 | Pattern::ExactLog2Op1 },
 
             // Narrowing casts. These may interleave later with trunc.

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1530,19 +1530,15 @@ inline Expr operator~(Expr x) {
  * arguments must have integer type. */
 // @{
 inline Expr operator<<(Expr x, Expr y) {
-    Internal::match_types_bitwise(x, y, "shift left");
+    Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), x.type().lanes()), y);
+    user_assert(unsigned_amount.defined()) << "In shift left expression:\n   (" << x << ") << (" << y << ")\nthe amount must be unsigned and sizeable to the same size as value.\n";
     Type t = x.type();
-    return Internal::Call::make(t, Internal::Call::shift_left, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::shift_left, {std::move(x), std::move(unsigned_amount)}, Internal::Call::PureIntrinsic);
 }
 inline Expr operator<<(Expr x, int y) {
-    Type t = x.type();
+    Type t = UInt(x.type().bits(), x.type().lanes());
     Internal::check_representable(t, y);
     return std::move(x) << Internal::make_const(t, y);
-}
-inline Expr operator<<(int x, Expr y) {
-    Type t = y.type();
-    Internal::check_representable(t, x);
-    return Internal::make_const(t, x) << std::move(y);
 }
 // @}
 
@@ -1556,19 +1552,15 @@ inline Expr operator<<(int x, Expr y) {
  * type. */
 // @{
 inline Expr operator>>(Expr x, Expr y) {
-    Internal::match_types_bitwise(x, y, "shift right");
+    Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), x.type().lanes()), y);
+    user_assert(unsigned_amount.defined()) << "In shift right expression\n    (" << x << ") >> (" << y << ")\nthe amount must be unsigned and sizeable to the same size as value.\n";
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::shift_right, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
 inline Expr operator>>(Expr x, int y) {
-    Type t = x.type();
+    Type t = UInt(x.type().bits(), x.type().lanes());
     Internal::check_representable(t, y);
     return std::move(x) >> Internal::make_const(t, y);
-}
-inline Expr operator>>(int x, Expr y) {
-    Type t = y.type();
-    Internal::check_representable(t, x);
-    return Internal::make_const(t, x) >> std::move(y);
 }
 // @}
 

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1531,7 +1531,7 @@ inline Expr operator~(Expr x) {
 // @{
 inline Expr operator<<(Expr x, Expr y) {
     Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), x.type().lanes()), y);
-    user_assert(unsigned_amount.defined()) << "In shift left expression:\n   (" << x << ") << (" << y << ")\nthe amount must be unsigned and sizeable to the same size as value.\n";
+    user_assert(unsigned_amount.defined()) << "In shift left expression:\n   (" << x << ") << (" << y << ")\nthe amount must be unsigned and losslessly castable to the same size as value.\n";
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::shift_left, {std::move(x), std::move(unsigned_amount)}, Internal::Call::PureIntrinsic);
 }
@@ -1553,7 +1553,7 @@ inline Expr operator<<(Expr x, int y) {
 // @{
 inline Expr operator>>(Expr x, Expr y) {
     Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), x.type().lanes()), y);
-    user_assert(unsigned_amount.defined()) << "In shift right expression\n    (" << x << ") >> (" << y << ")\nthe amount must be unsigned and sizeable to the same size as value.\n";
+    user_assert(unsigned_amount.defined()) << "In shift right expression\n    (" << x << ") >> (" << y << ")\nthe amount must be unsigned and losslessly castable to the same size as value.\n";
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::shift_right, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1530,7 +1530,7 @@ inline Expr operator~(Expr x) {
  * arguments must have integer type. */
 // @{
 inline Expr operator<<(Expr x, Expr y) {
-    Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), x.type().lanes()), y);
+    Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), y.type().lanes()), y);
     user_assert(unsigned_amount.defined()) << "In shift left expression:\n   (" << x << ") << (" << y << ")\nthe amount must be unsigned and losslessly castable to the same size as value.\n";
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::shift_left, {std::move(x), std::move(unsigned_amount)}, Internal::Call::PureIntrinsic);
@@ -1552,7 +1552,7 @@ inline Expr operator<<(Expr x, int y) {
  * type. */
 // @{
 inline Expr operator>>(Expr x, Expr y) {
-    Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), x.type().lanes()), y);
+    Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), y.type().lanes()), y);
     user_assert(unsigned_amount.defined()) << "In shift right expression\n    (" << x << ") >> (" << y << ")\nthe amount must be unsigned and losslessly castable to the same size as value.\n";
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::shift_right, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -128,36 +128,27 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
         const bool shift_left = op->is_intrinsic(Call::shift_left);
         const Type t = op->type;
 
-        int64_t ib = 0;
         uint64_t ub = 0;
-        if (const_int(b, &ib)) {
+        if (const_uint(b, &ub)) {
             // LLVM shl and shr instructions produce poison for negative shifts,
             // or for shifts >= typesize, so we will follow suit in our simplifier.
-            user_assert(ib >= 0) << "bitshift by a constant negative amount is not legal in Halide.";
-            user_assert(ib < t.bits()) << "bitshift by a constant amount >= the type size is not legal in Halide.";
-            if (ib < t.bits() - 1) {
-                b = make_const(t, ((int64_t) 1LL) << ib);
+          user_assert(ub < (uint64_t)t.bits()) << "bitshift by a constant amount >= the type size is not legal in Halide.";
+            if (a.type().is_uint() || ub < (uint64_t)t.bits() - 1) {
+                b = make_const(t, ((int64_t) 1LL) << ub);
                 if (shift_left) {
                     return mutate(Mul::make(a, b), bounds);
                 } else {
                     return mutate(Div::make(a, b), bounds);
                 }
             } else {
-                // (1 << ib) will overflow into the sign bit, making decomposition into mul or div
-                // probelmatic, so just special-case them here.
+                // For signed types, (1 << ub) will overflow into the sign bit while
+                // (-32768 >> ub) propagates the sign bit, making decomposition
+                // into mul or div probelmatic, so just special-case them here.
                 if (shift_left) {
-                    return mutate(select((a & 1) != 0, make_const(t, ((int64_t) 1LL) << ib), make_zero(t)), bounds);
+                    return mutate(select((a & 1) != 0, make_const(t, ((int64_t) 1LL) << ub), make_zero(t)), bounds);
                 } else {
                     return mutate(select(a < 0, make_const(t, -1), make_zero(t)), bounds);
                 }
-            }
-        } else if (const_uint(b, &ub)) {
-            user_assert(ub < (uint64_t) t.bits()) << "bitshift by a constant amount >= the type size is not legal in Halide.";
-            b = make_const(t, ((uint64_t) 1ULL) << ub);
-            if (shift_left) {
-                return mutate(Mul::make(a, b), bounds);
-            } else {
-                return mutate(Div::make(a, b), bounds);
             }
         }
 

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -132,7 +132,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
         if (const_uint(b, &ub)) {
             // LLVM shl and shr instructions produce poison for negative shifts,
             // or for shifts >= typesize, so we will follow suit in our simplifier.
-          user_assert(ub < (uint64_t)t.bits()) << "bitshift by a constant amount >= the type size is not legal in Halide.";
+            user_assert(ub < (uint64_t)t.bits()) << "bitshift by a constant amount >= the type size is not legal in Halide.";
             if (a.type().is_uint() || ub < (uint64_t)t.bits() - 1) {
                 b = make_const(t, ((int64_t) 1LL) << ub);
                 if (shift_left) {

--- a/src/Simplify_EQ.cpp
+++ b/src/Simplify_EQ.cpp
@@ -30,7 +30,7 @@ Expr Simplify::visit(const EQ *op, ExprInfo *bounds) {
         } else if (rewrite(x == 0, !x)) {
             return mutate(std::move(rewrite.result), bounds);
         } else if (rewrite(x == x, const_true(lanes))) {
-	    return rewrite.result;
+            return rewrite.result;
         } else if (a.same_as(op->a) && b.same_as(op->b)) {
             return op;
         } else {

--- a/test/auto_schedule/max_filter.cpp
+++ b/test/auto_schedule/max_filter.cpp
@@ -36,7 +36,7 @@ double run_test(bool auto_schedule) {
     vert_log(x, y, c, t) = input(x, y, c);
     RDom r(-radius, in.height() + radius, 1, slices-1);
     vert_log(x, r.x, c, r.y) = max(vert_log(x, r.x, c, r.y - 1),
-                                   vert_log(x, r.x + clamp((1<<(r.y-1)), 0, radius*2), c, r.y - 1));
+                                   vert_log(x, r.x + clamp((1 << cast<uint32_t>(r.y-1)), 0, radius*2), c, r.y - 1));
 
     // We're going to take a max filter of arbitrary diameter
     // by maxing two samples from its floor log 2 (e.g. maxing two
@@ -50,7 +50,7 @@ double run_test(bool auto_schedule) {
     // t is the blur radius
     Expr slice = clamp(slice_for_radius(t), 0, slices);
     Expr first_sample = vert_log(x, y - t, c, slice);
-    Expr second_sample = vert_log(x, y + t + 1 - clamp(1 << slice, 0, 2*radius), c, slice);
+    Expr second_sample = vert_log(x, y + t + 1 - clamp(1 << cast<uint32_t>(slice), 0, 2*radius), c, slice);
     vert(x, y, c, t) = max(first_sample, second_sample);
 
     Func filter_height;

--- a/test/correctness/bitwise_ops.cpp
+++ b/test/correctness/bitwise_ops.cpp
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
     // arithmetic shift right
     Func f8;
     Expr a = reinterpret<int>(input(x));
-    Expr b = reinterpret<int>(input(x+1));
+    Expr b = reinterpret<unsigned>(input(x+1));
     f8(x) = a >> (b & 0xf);
     Buffer<int> im8 = f8.realize(128);
     for (int x = 0; x < 128; x++) {
@@ -116,7 +116,6 @@ int main(int argc, char **argv) {
             return -1;
         }
     }
-
 
     // bit shift on mixed types
     Func f9;

--- a/test/correctness/left_shift_negative.cpp
+++ b/test/correctness/left_shift_negative.cpp
@@ -6,7 +6,7 @@ int main(int argc, char **argv) {
     Func f, g;
     Var x;
     f(x) = cast<int16_t>(-x);
-    g(x) = cast<int16_t>(x % 8);
+    g(x) = cast<uint16_t>(x % 8);
 
     f.compute_root();
     g.compute_root();


### PR DESCRIPTION
Per discussion with Dillon, this PR changes Halide to require shift amounts to be of unsigned type. The idea we'll added negative shifts in with defined behavior to reverse the direction of the shift.