### PR TITLE
Add types to left-shift and right-shift assertions

### DIFF
--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -207,6 +207,16 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Call *op) {
         do_indent();
         stream << "barrier(CLK_LOCAL_MEM_FENCE);\n";
         print_assignment(op->type, "0");
+    } else if (op->is_intrinsic(Call::shift_left) || op->is_intrinsic(Call::shift_right)) {
+        // Some OpenCL implementations forbid mixing signed-and-unsigned shift values;
+        // we enforce RHS as unsigned, so quietly cast it back to int if the LHS is int
+        if (op->args[0].type().is_int() && op->args[1].type().is_uint()) {
+            Type t = op->args[0].type().with_code(halide_type_int);
+            Expr e = Call::make(op->type, op->name, {op->args[0], cast(t, op->args[1])}, op->call_type);
+            e.accept(this);
+        } else {
+            CodeGen_C::visit(op);
+        }
     } else {
         CodeGen_C::visit(op);
     }

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1533,7 +1533,8 @@ inline Expr operator<<(Expr x, Expr y) {
     Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), y.type().lanes()), y);
     user_assert(unsigned_amount.defined())
         << "In shift left expression:\n"
-        << "   (" << x.type() << ")(" << x << ") << (" << y.type() << ")(" << y << ")\n"
+        << "   (" << x << ") << (" << y << ")\n"
+        << "   with types " << x.type() << " << " << y.type() << "\n"
         << "the RHS must be unsigned and losslessly castable to the same size as the LHS.\n";
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::shift_left, {std::move(x), std::move(unsigned_amount)}, Internal::Call::PureIntrinsic);
@@ -1558,7 +1559,8 @@ inline Expr operator>>(Expr x, Expr y) {
     Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), y.type().lanes()), y);
     user_assert(unsigned_amount.defined())
         << "In shift right expression:\n"
-        << "   (" << x.type() << ")(" << x << ") >> (" << y.type() << ")(" << y << ")\n"
+        << "   (" << x << ") >> (" << y << ")\n"
+        << "   with types " << x.type() << " >> " << y.type() << "\n"
         << "the RHS must be unsigned and losslessly castable to the same size as the LHS.\n";
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::shift_right, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1563,7 +1563,7 @@ inline Expr operator>>(Expr x, Expr y) {
         << "   with types " << x.type() << " >> " << y.type() << "\n"
         << "the RHS must be unsigned and losslessly castable to the same size as the LHS.\n";
     Type t = x.type();
-    return Internal::Call::make(t, Internal::Call::shift_right, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::shift_right, {std::move(x), std::move(unsigned_amount)}, Internal::Call::PureIntrinsic);
 }
 inline Expr operator>>(Expr x, int y) {
     Type t = UInt(x.type().bits(), x.type().lanes());

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1531,7 +1531,10 @@ inline Expr operator~(Expr x) {
 // @{
 inline Expr operator<<(Expr x, Expr y) {
     Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), y.type().lanes()), y);
-    user_assert(unsigned_amount.defined()) << "In shift left expression:\n   (" << x << ") << (" << y << ")\nthe amount must be unsigned and losslessly castable to the same size as value.\n";
+    user_assert(unsigned_amount.defined())
+        << "In shift left expression:\n"
+        << "   (" << x.type() << ")(" << x << ") << (" << y.type() << ")(" << y << ")\n"
+        << "the RHS must be unsigned and losslessly castable to the same size as the LHS.\n";
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::shift_left, {std::move(x), std::move(unsigned_amount)}, Internal::Call::PureIntrinsic);
 }
@@ -1553,7 +1556,10 @@ inline Expr operator<<(Expr x, int y) {
 // @{
 inline Expr operator>>(Expr x, Expr y) {
     Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), y.type().lanes()), y);
-    user_assert(unsigned_amount.defined()) << "In shift right expression\n    (" << x << ") >> (" << y << ")\nthe amount must be unsigned and losslessly castable to the same size as value.\n";
+    user_assert(unsigned_amount.defined())
+        << "In shift right expression:\n"
+        << "   (" << x.type() << ")(" << x << ") >> (" << y.type() << ")(" << y << ")\n"
+        << "the RHS must be unsigned and losslessly castable to the same size as the LHS.\n";
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::shift_right, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }


### PR DESCRIPTION
This makes debugging violations a bit easier.