### PR TITLE
Add 'make benchmark_apps'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1890,8 +1890,8 @@ TEST_APPS=\
 	HelloMatlab \
 	bilateral_grid \
 	blur \
-	camera_pipe \
 	c_backend \
+	camera_pipe \
 	conv_layer \
 	fft \
 	interpolate \
@@ -1899,17 +1899,43 @@ TEST_APPS=\
 	linear_algebra \
 	local_laplacian \
 	nl_means \
+	onnx \
 	resize \
-	stencil_chain \
-	wavelet \
 	resnet_50 \
-	onnx
+	stencil_chain \
+	wavelet
 
 .PHONY: test_apps
 test_apps: distrib
 	@for APP in $(TEST_APPS); do \
 		echo Testing app $${APP}... ; \
 		make -C $(ROOT_DIR)/apps/$${APP} test \
+			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
+			BIN=$(ROOT_DIR)/apps/$${APP}/bin \
+			|| exit 1 ; \
+	done
+
+BENCHMARK_APPS=\
+	bilateral_grid \
+	camera_pipe \
+	lens_blur \
+	local_laplacian \
+	nl_means \
+	stencil_chain
+
+.PHONY: benchmark_apps
+benchmark_apps: distrib
+	@for APP in $(BENCHMARK_APPS); do \
+		echo Building app $${APP}... ; \
+		make -C $(ROOT_DIR)/apps/$${APP} test \
+			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
+			BIN=$(ROOT_DIR)/apps/$${APP}/bin > /dev/null \
+			|| exit 1 ; \
+	done
+	@for APP in $(BENCHMARK_APPS); do \
+		echo ;\
+		echo Benchmarking app $${APP}... ; \
+		make -C $(ROOT_DIR)/apps/$${APP} benchmark \
 			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
 			BIN=$(ROOT_DIR)/apps/$${APP}/bin \
 			|| exit 1 ; \

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -55,3 +55,6 @@ $(BIN)/viz_auto.mp4: $(BIN)/filter_viz ../support/viz_auto.sh ../../bin/HalideTr
 
 viz_auto: $(BIN)/viz_auto.mp4
 	$(HL_VIDEOPLAYER) $^
+
+benchmark: $(BIN)/filter
+	@$(NICE_BENCH) $(BIN)/filter $(IMAGES)/gray.png $(BIN)/out.png 0.1 10

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -49,3 +49,6 @@ $(BIN)/viz_auto.mp4: $(BIN)/viz/process ../support/viz_auto.sh ../../bin/HalideT
 
 viz_auto: $(BIN)/viz_auto.mp4
 	$(HL_VIDEOPLAYER) $^
+
+benchmark: $(BIN)/process
+	@@$(NICE_BENCH) $(BIN)/process $(IMAGES)/bayer_raw.png 3700 2.0 50 1.0 $(TIMING_ITERATIONS) $(BIN)/out.png $(BIN)/h_auto.png

--- a/apps/camera_pipe/process.cpp
+++ b/apps/camera_pipe/process.cpp
@@ -28,9 +28,7 @@ int main(int argc, char **argv) {
     halide_enable_malloc_trace();
 #endif
 
-    fprintf(stderr, "input: %s\n", argv[1]);
     Buffer<uint16_t> input = load_and_convert_image(argv[1]);
-    fprintf(stderr, "       %d %d\n", input.width(), input.height());
     Buffer<uint8_t> output(((input.width() - 32)/32)*32, ((input.height() - 24)/32)*32, 3);
 
 #ifdef HL_MEMINFO
@@ -72,7 +70,7 @@ int main(int argc, char **argv) {
                         output);
             output.device_sync();
         });
-    fprintf(stderr, "Halide (manual):\t%gus\n", best * 1e6);
+    printf("Manually-tuned time: %gms\n", best * 1e3);
 
     #ifndef NO_AUTO_SCHEDULE
     best = benchmark(timing_iterations, 1, [&]() {
@@ -81,12 +79,10 @@ int main(int argc, char **argv) {
                                       output);
             output.device_sync();
         });
-    fprintf(stderr, "Halide (auto):\t%gus\n", best * 1e6);
+    printf("Auto-scheduled time: %gms\n", best * 1e3);
     #endif
 
-    fprintf(stderr, "output: %s\n", argv[7]);
     convert_and_save_image(output, argv[7]);
-    fprintf(stderr, "        %d %d\n", output.width(), output.height());
 
     return 0;
 }

--- a/apps/lens_blur/Makefile
+++ b/apps/lens_blur/Makefile
@@ -28,3 +28,6 @@ clean:
 	rm -rf $(BIN)
 
 test: $(BIN)/out.png
+
+benchmark: $(BIN)/process
+	@$(NICE_BENCH) $(BIN)/process $(IMAGES)/rgb_small.png 32 13 0.5 32 3 $(BIN)/out.png

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -58,3 +58,6 @@ $(BIN)/viz_auto.mp4: $(BIN)/process_viz ../support/viz_auto.sh ../../bin/HalideT
 
 viz_auto: $(BIN)/viz_auto.mp4
 	$(HL_VIDEOPLAYER) $^
+
+benchmark: $(BIN)/process
+	@$(NICE_BENCH) $(BIN)/process $(IMAGES)/rgb.png 8 1 1 10 $(BIN)/out.png

--- a/apps/nl_means/Makefile
+++ b/apps/nl_means/Makefile
@@ -28,3 +28,6 @@ clean:
 	rm -rf $(BIN)
 
 test: $(BIN)/out.png
+
+benchmark: $(BIN)/process
+	@$(NICE_BENCH) $(BIN)/process $(IMAGES)/rgb.png 7 7 0.12 10 $(BIN)/out.png

--- a/apps/nl_means/process.cpp
+++ b/apps/nl_means/process.cpp
@@ -29,8 +29,8 @@ int main(int argc, char **argv) {
 
     // Timing code
 
-    printf("Input size: %d by %d, patch size: %d, search area: %d, sigma: %f\n",
-            input.width(), input.height(), patch_size, search_area, sigma);
+    // printf("Input size: %d by %d, patch size: %d, search area: %d, sigma: %f\n",
+    //         input.width(), input.height(), patch_size, search_area, sigma);
 
     // Manually-tuned version
     double min_t_manual = benchmark(timing_iterations, 1, [&]() {

--- a/apps/stencil_chain/Makefile
+++ b/apps/stencil_chain/Makefile
@@ -28,3 +28,6 @@ clean:
 	rm -rf $(BIN)
 
 test: $(BIN)/out.png
+
+benchmark: $(BIN)/process
+	@$(NICE_BENCH) $(BIN)/process $(IMAGES)/rgb.png 10 $(BIN)/out.png

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -127,3 +127,7 @@ HL_AVCONV ?= avconv
 # Utility to show h264 video
 HL_VIDEOPLAYER ?= mplayer
 
+# 'nice' prefix to use when running benchmarks.
+# Default to empty; some users may want to increase priority via e.g. NICE_BENCH=sudo nice -n -10
+NICE_BENCH ?=
+


### PR DESCRIPTION
This adds a convenience target that builds and benchmarks a handful of apps that are likely to be of interest when evaluating performance; it also does some drive-by cleanup to remove noise from the apps output and make the output more uniform.

This will likely be followed up with more-detailed benchmark output (e.g. mpix/s, etc).
