### PR TITLE
Add `make benchmarks` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1899,8 +1899,8 @@ TEST_APPS=\
 	HelloMatlab \
 	bilateral_grid \
 	blur \
-	camera_pipe \
 	c_backend \
+	camera_pipe \
 	conv_layer \
 	fft \
 	interpolate \
@@ -1908,11 +1908,11 @@ TEST_APPS=\
 	linear_algebra \
 	local_laplacian \
 	nl_means \
+	onnx \
 	resize \
-	stencil_chain \
-	wavelet \
 	resnet_50 \
-	onnx
+	stencil_chain \
+	wavelet
 
 .PHONY: test_apps
 test_apps: distrib
@@ -1920,7 +1920,35 @@ test_apps: distrib
 		echo Testing app $${APP}... ; \
 		make -C $(ROOT_DIR)/apps/$${APP} test \
 			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
-			BIN=$(ROOT_DIR)/apps/$${APP}/bin \
+			BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin \
+			|| exit 1 ; \
+	done
+
+BENCHMARK_APPS=\
+	bilateral_grid \
+	camera_pipe \
+	lens_blur \
+	local_laplacian \
+	nl_means \
+	stencil_chain
+
+.PHONY: benchmark_apps
+benchmark_apps: distrib
+	@for APP in $(BENCHMARK_APPS); do \
+		echo Building $${APP}... ; \
+		$(MAKE) -C $(ROOT_DIR)/apps/$${APP} \
+		    $(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin/$${APP}.rungen \
+			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
+			BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin > /dev/null \
+			|| exit 1 ; \
+	done
+	@for APP in $(BENCHMARK_APPS); do \
+		echo ;\
+		echo Benchmarking $${APP}... ; \
+		make -C $(ROOT_DIR)/apps/$${APP} \
+			$${APP}.benchmark \
+			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
+			BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin \
 			|| exit 1 ; \
 	done
 

--- a/README_rungen.md
+++ b/README_rungen.md
@@ -199,19 +199,21 @@ especially for benchmarking.
 
 ## Benchmarking
 
-To run a benchmark, use the `--benchmark` flag:
+To run a benchmark, use the `--benchmarks=all` flag:
 
 ```
-# When you specify the --benchmark flag, outputs become optional.
-$ ./bin/local_laplacian.rungen --benchmark input=zero:[1920,1080,3] levels=8 alpha=1 beta=1
+$ ./bin/local_laplacian.rungen --benchmarks=all input=zero:[1920,1080,3] levels=8 alpha=1 beta=1 --output_extents=[100,200,3]
 Benchmark for local_laplacian produces best case of 0.0494629 sec/iter, over 3 blocks of 10 iterations.
 Best output throughput is 39.9802 mpix/sec.
 ```
 
-Note: this uses Halide's `halide_benchmark.h` to measure the execution time,
-which runs several consecutive sample sets (default=3) of multiple iterations
-(default=10) each, then chooses the best average time. You can use the
-`--benchmark_samples` and `--benchmark_iterations` to override these defaults.
+You can use `--default_input_buffers` and `--default_input_scalars` here as well:
+
+```
+$ ./bin/local_laplacian.rungen --benchmarks=all --default_input_buffers --default_input_scalars --output_extents=estimate
+Benchmark for local_laplacian produces best case of 0.0494629 sec/iter, over 3 blocks of 10 iterations.
+Best output throughput is 39.9802 mpix/sec.
+```
 
 Note: `halide_benchmark.h` is known to be inaccurate for GPU filters; see
 https://github.com/halide/Halide/issues/2278
@@ -222,8 +224,7 @@ To track memory usage, use the `--track_memory` flag, which measures the
 high-water-mark of CPU memory usage.
 
 ```
-# When you specify the --track_memory flag, outputs become optional.
-$ ./bin/local_laplacian.rungen --track_memory input=zero:[1920,1080,3] levels=8 alpha=1 beta=1
+$ ./bin/local_laplacian.rungen --track_memory input=zero:[1920,1080,3] levels=8 alpha=1 beta=1 --output_extents=[100,200,3]
 Maximum Halide memory: 82688420 bytes for output of 1.97754 mpix.
 ```
 

--- a/apps/bilateral_grid/bilateral_grid_generator.cpp
+++ b/apps/bilateral_grid/bilateral_grid_generator.cpp
@@ -66,18 +66,23 @@ public:
         // Normalize
         bilateral_grid(x, y) = interpolated(x, y, 0)/interpolated(x, y, 1);
 
+        /* ESTIMATES */
+        // (This can be useful in conjunction with RunGen and benchmarks as well
+        // as auto-schedule, so we do it in all cases.)
+        // Provide estimates on the input image
+        input.dim(0).set_bounds_estimate(0, 1536);
+        input.dim(1).set_bounds_estimate(0, 2560);
+        // Provide estimates on the parameters
+        r_sigma.set_estimate(0.1f);
+        // TODO: Compute estimates from the parameter values
+        histogram.estimate(z, -2, 16);
+        blurz.estimate(z, 0, 12);
+        blurx.estimate(z, 0, 12);
+        blury.estimate(z, 0, 12);
+        bilateral_grid.estimate(x, 0, 1536).estimate(y, 0, 2560);
+
         if (auto_schedule) {
-            // Provide estimates on the input image
-            input.dim(0).set_bounds_estimate(0, 1536);
-            input.dim(1).set_bounds_estimate(0, 2560);
-            // Provide estimates on the parameters
-            r_sigma.set_estimate(0.1f);
-            // TODO: Compute estimates from the parameter values
-            histogram.estimate(z, -2, 16);
-            blurz.estimate(z, 0, 12);
-            blurx.estimate(z, 0, 12);
-            blury.estimate(z, 0, 12);
-            bilateral_grid.estimate(x, 0, 1536).estimate(y, 0, 2560);
+            // nothing
         } else if (get_target().has_gpu_feature()) {
             Var xi("xi"), yi("yi"), zi("zi");
 

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -432,21 +432,29 @@ void CameraPipe::generate() {
 
     processed(x, y, c) = sharpen(curved)(x, y, c);
 
+    /* ESTIMATES */
+    // (This can be useful in conjunction with RunGen and benchmarks as well
+    // as auto-schedule, so we do it in all cases.)
+    input.dim(0).set_bounds_estimate(0, 2592);
+    input.dim(1).set_bounds_estimate(0, 1968);
+    matrix_3200.dim(0).set_bounds_estimate(0, 4);
+    matrix_3200.dim(1).set_bounds_estimate(0, 3);
+    matrix_7000.dim(0).set_bounds_estimate(0, 4);
+    matrix_7000.dim(1).set_bounds_estimate(0, 3);
+    color_temp.set_estimate(3700);
+    gamma.set_estimate(2.0);
+    contrast.set_estimate(50);
+    sharpen_strength.set_estimate(1.0);
+    blackLevel.set_estimate(25);
+    whiteLevel.set_estimate(1023);
+    processed
+        .estimate(c, 0, 3)
+        .estimate(x, 0, 2592)
+        .estimate(y, 0, 1968);
+
     // Schedule
     if (auto_schedule) {
-        input.dim(0).set_bounds_estimate(0, 2592);
-        input.dim(1).set_bounds_estimate(0, 1968);
-
-        matrix_3200.dim(0).set_bounds_estimate(0, 4);
-        matrix_3200.dim(1).set_bounds_estimate(0, 3);
-        matrix_7000.dim(0).set_bounds_estimate(0, 4);
-        matrix_7000.dim(1).set_bounds_estimate(0, 3);
-
-        processed
-            .estimate(c, 0, 3)
-            .estimate(x, 0, 2592)
-            .estimate(y, 0, 1968);
-
+        // nothing
     } else if (get_target().has_gpu_feature()) {
 
         // We can generate slightly better code if we know the output is even-sized

--- a/apps/lens_blur/lens_blur_generator.cpp
+++ b/apps/lens_blur/lens_blur_generator.cpp
@@ -151,24 +151,29 @@ public:
         // Normalize
         final(x, y, c) = output(x, y, c) / output(x, y, 3);
 
+        /* ESTIMATES */
+        // (This can be useful in conjunction with RunGen and benchmarks as well
+        // as auto-schedule, so we do it in all cases.)
+        // Provide estimates on the input image
+        left_im.dim(0).set_bounds_estimate(0, 1536);
+        left_im.dim(1).set_bounds_estimate(0, 2560);
+        left_im.dim(2).set_bounds_estimate(0, 3);
+        right_im.dim(0).set_bounds_estimate(0, 1536);
+        right_im.dim(1).set_bounds_estimate(0, 2560);
+        right_im.dim(2).set_bounds_estimate(0, 3);
+        // Provide estimates on the parameters
+        slices.set_estimate(32);
+        focus_depth.set_estimate(13);
+        blur_radius_scale.set_estimate(0.5f);
+        aperture_samples.set_estimate(32);
+        // Provide estimates on the pipeline output
+        final.estimate(x, 0, 1536)
+            .estimate(y, 0, 2560)
+            .estimate(c, 0, 3);
+
         /* THE SCHEDULE */
         if (auto_schedule) {
-            // Provide estimates on the input image
-            left_im.dim(0).set_bounds_estimate(0, 1536);
-            left_im.dim(1).set_bounds_estimate(0, 2560);
-            left_im.dim(2).set_bounds_estimate(0, 3);
-            right_im.dim(0).set_bounds_estimate(0, 1536);
-            right_im.dim(1).set_bounds_estimate(0, 2560);
-            right_im.dim(2).set_bounds_estimate(0, 3);
-            // Provide estimates on the parameters
-            slices.set_estimate(32);
-            focus_depth.set_estimate(13);
-            blur_radius_scale.set_estimate(0.5f);
-            aperture_samples.set_estimate(32);
-            // Provide estimates on the pipeline output
-            final.estimate(x, 0, 1536)
-                .estimate(y, 0, 2560)
-                .estimate(c, 0, 3);
+            // nothing
         } else if (get_target().has_gpu_feature()) {
             // Manual GPU schedule
             Var xi("xi"), yi("yi"), zi("zi");

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -87,10 +87,8 @@ public:
         // Convert back to 16-bit
         output(x, y, c) = cast<uint16_t>(clamp(color(x, y, c), 0.0f, 1.0f) * 65535.0f);
 
-        /* THE SCHEDULE */
-
-        // Provide estimates on the input image.
-        // (This can be useful in conjunction with RunGen as well
+        /* ESTIMATES */
+        // (This can be useful in conjunction with RunGen and benchmarks as well
         // as auto-schedule, so we do it in all cases.)
         input.dim(0).set_bounds_estimate(0, 1536);
         input.dim(1).set_bounds_estimate(0, 2560);
@@ -104,6 +102,7 @@ public:
               .estimate(y, 0, 2560)
               .estimate(c, 0, 3);
 
+        /* THE SCHEDULE */
         if (auto_schedule) {
             // Nothing.
         } else if (get_target().has_gpu_feature()) {

--- a/apps/nl_means/nl_means_generator.cpp
+++ b/apps/nl_means/nl_means_generator.cpp
@@ -72,19 +72,24 @@ public:
 
         Var tx("tx"), ty("ty"), xi("xi"), yi("yi");
 
+        /* ESTIMATES */
+        // (This can be useful in conjunction with RunGen and benchmarks as well
+        // as auto-schedule, so we do it in all cases.)
+        // Provide estimates on the input image
+        input.dim(0).set_bounds_estimate(0, 614);
+        input.dim(1).set_bounds_estimate(0, 1024);
+        input.dim(2).set_bounds_estimate(0, 3);
+        // Provide estimates on the parameters
+        patch_size.set_estimate(7);
+        search_area.set_estimate(7);
+        sigma.set_estimate(0.12f);
+        // Provide estimates on the output pipeline
+        non_local_means.estimate(x, 0, 614)
+            .estimate(y, 0, 1024)
+            .estimate(c, 0, 3);
+
         if (auto_schedule) {
-            // Provide estimates on the input image
-            input.dim(0).set_bounds_estimate(0, 614);
-            input.dim(1).set_bounds_estimate(0, 1024);
-            input.dim(2).set_bounds_estimate(0, 3);
-            // Provide estimates on the parameters
-            patch_size.set_estimate(7);
-            search_area.set_estimate(7);
-            sigma.set_estimate(0.12f);
-            // Provide estimates on the output pipeline
-            non_local_means.estimate(x, 0, 614)
-                .estimate(y, 0, 1024)
-                .estimate(c, 0, 3);
+            // nothing
         } /*else if (get_target().has_gpu_feature()) {
             // TODO: the GPU schedule is currently using to much shared memory
             // because the simplifier can't simplify the expr (it can't cancel

--- a/apps/stencil_chain/stencil_chain_generator.cpp
+++ b/apps/stencil_chain/stencil_chain_generator.cpp
@@ -33,7 +33,10 @@ public:
 
         output(x, y) = stages.back()(x, y);
 
-        if (auto_schedule) {
+        /* ESTIMATES */
+        // (This can be useful in conjunction with RunGen and benchmarks as well
+        // as auto-schedule, so we do it in all cases.)
+        {
             const int width = 1536;
             const int height = 2560;
             // Provide estimates on the input image
@@ -41,7 +44,11 @@ public:
             input.dim(1).set_bounds_estimate(0, height);
             // Provide estimates on the pipeline output
             output.estimate(x, 0, width)
-                .estimate(y, 0, height);
+                  .estimate(y, 0, height);
+        }
+
+        if (auto_schedule) {
+            // nothing
         } else {
             // CPU schedule. No fusion.
             Var yi, yo, xo, xi, t;

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -127,3 +127,5 @@ HL_AVCONV ?= avconv
 # Utility to show h264 video
 HL_VIDEOPLAYER ?= mplayer
 
+%.benchmark: $(BIN)/%.rungen
+	@$^ --benchmarks=all --default_input_buffers --default_input_scalars --output_extents=estimate --parsable_output

--- a/tools/RunGen.h
+++ b/tools/RunGen.h
@@ -885,9 +885,9 @@ public:
             switch (arg.metadata->kind) {
             case halide_argument_kind_input_scalar: {
                 if (!strcmp(arg.metadata->name, "__user_context")) {
-                  arg.scalar_value.u.handle = nullptr;
-                  info() << "Argument value for: __user_context is special-cased as: nullptr";
-                  break;
+                    arg.scalar_value.u.handle = nullptr;
+                    info() << "Argument value for: __user_context is special-cased as: nullptr";
+                    break;
                 }
                 std::vector<std::pair<const halide_scalar_value_t*, const char*>> values;
                 // If this gets any more complex, smarten it up, but for now,

--- a/tools/RunGenMain.cpp
+++ b/tools/RunGenMain.cpp
@@ -51,7 +51,8 @@ Arguments:
         some_int=42 some_float=3.1415
 
     You can also use the text `default` or `estimate` to use the default or
-    estimate value of the given input.
+    estimate value of the given input, respectively. (You can join these by
+    commas to give default-then-estimate or estimate-then-default behaviors.)
 
     Buffer inputs and outputs are specified by pathname:
 
@@ -103,7 +104,7 @@ Arguments:
         the --output_extents flag.)
 
         In place of [NUM,NUM,...] for boundary, you may specify 'estimate';
-        this will use the esimated bounds specified in the code.
+        this will use the estimated bounds specified in the code.
 
 Flags:
 
@@ -153,11 +154,16 @@ Flags:
 
     --default_input_buffers=VALUE:
         Specify the value for all otherwise-unspecified buffer inputs, in the
-        same syntax in use above.
+        same syntax in use above. If you omit =VALUE, "zero:auto" will be used.
 
     --default_input_scalars=VALUE:
         Specify the value for all otherwise-unspecified scalar inputs, in the
-        same syntax in use above.
+        same syntax in use above. If you omit =VALUE, "estimate,default"
+        will be used.
+
+    --parsable_output:
+        Final output is emitted in an easy-to-parse output (one value per line),
+        rather than easy-for-humans.
 
 Known Issues:
 
@@ -398,6 +404,15 @@ int main(int argc, char **argv) {
                     fail() << "Invalid value for flag: " << flag_name;
                 }
                 r.set_quiet(quiet);
+            } else if (flag_name == "parsable_output") {
+                if (flag_value.empty()) {
+                    flag_value = "true";
+                }
+                bool parsable_output;
+                if (!parse_scalar(flag_value, &parsable_output)) {
+                    fail() << "Invalid value for flag: " << flag_name;
+                }
+                r.set_parsable_output(parsable_output);
             } else if (flag_name == "describe") {
                 if (flag_value.empty()) {
                     flag_value = "true";
@@ -437,7 +452,7 @@ int main(int argc, char **argv) {
             } else if (flag_name == "default_input_scalars") {
                 default_input_scalars = flag_value;
                 if (default_input_scalars.empty()) {
-                    default_input_scalars = "default";
+                    default_input_scalars = "estimate,default";
                 }
             } else if (flag_name == "output_extents") {
                 user_specified_output_shape = flag_value;


### PR DESCRIPTION
Adds benchmarking to several of the apps, using RunGen's benchmarking capability:
- Some drive-by fixes to RunGen's code and README, which have bitrotted from underuse
- Add new output format for the benchmarks (via --parsable_output) to make output simpler to machine-parse (rather than relying on the human-readable output remaining unchanged forever)
- Ensured that all the Generators being benchmarked had proper estimates or defaults filled in, so we could use those values
- Drive-by fix to put the output of `make test_apps` into the correct build subtree when building out-of-tree