### PR TITLE
More apps/ Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1920,7 +1920,7 @@ test_apps: distrib
 		echo Testing app $${APP}... ; \
 		make -C $(ROOT_DIR)/apps/$${APP} test \
 			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
-			BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin \
+			BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin/$(TARGET) \
 			|| exit 1 ; \
 	done
 
@@ -1939,7 +1939,7 @@ benchmark_apps: distrib
 		$(MAKE) -C $(ROOT_DIR)/apps/$${APP} \
 		    $(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin/$${APP}.rungen \
 			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
-			BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin > /dev/null \
+			BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin/$(TARGET) > /dev/null \
 			|| exit 1 ; \
 	done
 	@for APP in $(BENCHMARK_APPS); do \
@@ -1948,7 +1948,7 @@ benchmark_apps: distrib
 		make -C $(ROOT_DIR)/apps/$${APP} \
 			$${APP}.benchmark \
 			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
-			BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin \
+			BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin/$(TARGET) \
 			|| exit 1 ; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -1920,7 +1920,8 @@ test_apps: distrib
 		echo Testing app $${APP}... ; \
 		make -C $(ROOT_DIR)/apps/$${APP} test \
 			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
-			BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin/$(TARGET) \
+			BIN_DIR=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin \
+			HL_TARGET=$(HL_TARGET) \
 			|| exit 1 ; \
 	done
 
@@ -1939,7 +1940,9 @@ benchmark_apps: distrib
 		$(MAKE) -C $(ROOT_DIR)/apps/$${APP} \
 		    $(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin/$${APP}.rungen \
 			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
-			BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin/$(TARGET) > /dev/null \
+			BIN_DIR=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin \
+			HL_TARGET=$(HL_TARGET) \
+			> /dev/null \
 			|| exit 1 ; \
 	done
 	@for APP in $(BENCHMARK_APPS); do \
@@ -1948,7 +1951,8 @@ benchmark_apps: distrib
 		make -C $(ROOT_DIR)/apps/$${APP} \
 			$${APP}.benchmark \
 			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
-			BIN=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin/$(TARGET) \
+			BIN_DIR=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin \
+			HL_TARGET=$(HL_TARGET) \
 			|| exit 1 ; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -1938,7 +1938,7 @@ benchmark_apps: distrib
 	@for APP in $(BENCHMARK_APPS); do \
 		echo Building $${APP}... ; \
 		$(MAKE) -C $(ROOT_DIR)/apps/$${APP} \
-		    $(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin/$${APP}.rungen \
+		    $(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin/$(HL_TARGET)/$${APP}.rungen \
 			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
 			BIN_DIR=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin \
 			HL_TARGET=$(HL_TARGET) \

--- a/apps/HelloMatlab/Makefile
+++ b/apps/HelloMatlab/Makefile
@@ -1,6 +1,5 @@
 include ../support/Makefile.inc
 
-BIN ?= bin
 
 test:
 	./run_blur.sh

--- a/apps/auto_viz/Makefile
+++ b/apps/auto_viz/Makefile
@@ -12,18 +12,18 @@ TRACE_TARGET=$(HL_TARGET)-trace_all
 
 all: $(OUTPUTS)
 
-$(BIN)/auto_viz_demo.generator: auto_viz_demo_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/auto_viz_demo.generator: auto_viz_demo_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/auto_viz_demo_%.a: $(BIN)/auto_viz_demo.generator
+$(BIN)/auto_viz_demo_%.a: $(GENERATOR_BIN)/auto_viz_demo.generator
 	@mkdir -p $(@D)
 	$^ -g auto_viz_demo -o $(@D) -f auto_viz_demo_$* \
 	target=$(TRACE_TARGET)-no_runtime \
 	schedule_type=$$(echo $* | cut -d_ -f1) \
 	upsample=$$(echo $* | cut -d_ -f2 | sed 's/up/true/;s/down/false/')
 
-$(BIN)/runtime.a: $(BIN)/auto_viz_demo.generator
+$(BIN)/runtime.a: $(GENERATOR_BIN)/auto_viz_demo.generator
 	@mkdir -p $(@D)
 	$^ -r runtime -o $(@D) target=$(TRACE_TARGET)
 

--- a/apps/auto_viz/Makefile
+++ b/apps/auto_viz/Makefile
@@ -18,14 +18,14 @@ $(BIN)/auto_viz_demo.generator: auto_viz_demo_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/auto_viz_demo_%.a: $(BIN)/auto_viz_demo.generator
 	@mkdir -p $(@D)
-	$^ -g auto_viz_demo -o $(BIN) -f auto_viz_demo_$* \
+	$^ -g auto_viz_demo -o $(@D) -f auto_viz_demo_$* \
 	target=$(TRACE_TARGET)-no_runtime \
 	schedule_type=$$(echo $* | cut -d_ -f1) \
 	upsample=$$(echo $* | cut -d_ -f2 | sed 's/up/true/;s/down/false/')
 
 $(BIN)/runtime.a: $(BIN)/auto_viz_demo.generator
 	@mkdir -p $(@D)
-	$^ -r runtime -o $(BIN) target=$(TRACE_TARGET)
+	$^ -r runtime -o $(@D) target=$(TRACE_TARGET)
 
 $(BIN)/auto_viz_demo: auto_viz_demo.cpp $(LIBRARIES) $(BIN)/runtime.a
 	@mkdir -p $(@D)

--- a/apps/autoscheduler/Makefile
+++ b/apps/autoscheduler/Makefile
@@ -4,14 +4,14 @@ include ../support/autoscheduler.inc
 # A sample generator to autoschedule. Note that if it statically links
 # to libHalide, then it must be build with $(USE_EXPORT_DYNAMIC), or the
 # autoscheduler can't find the libHalide symbols that it needs.
-$(BIN)/demo.generator: demo_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/demo.generator: demo_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $(USE_EXPORT_DYNAMIC) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
 # To use the autoscheduler, set a few environment variables and use the -p flag to the generator to load the autoscheduler as a plugin
-$(BIN)/demo.a: $(BIN)/demo.generator $(AUTOSCHED_BIN)/libauto_schedule.so
+$(BIN)/demo.a: $(GENERATOR_BIN)/demo.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=weights \
-	$(BIN)/demo.generator -g demo -o $(@D) -f demo target=$(HL_TARGET) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
+	$(GENERATOR_BIN)/demo.generator -g demo -o $(@D) -f demo target=$(HL_TARGET) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/demo.rungen: $(BIN)/RunGenMain.o $(BIN)/demo.registration.cpp $(BIN)/demo.a
 	$(CXX) -I $(BIN) $^ -o $@ $(HALIDE_SYSTEM_LIBS) $(IMAGE_IO_FLAGS)
@@ -22,9 +22,9 @@ demo: $(BIN)/demo.rungen
 
 # demonstrates an autotuning loop
 # (using $(AUTOSCHED_BIN) and $(AUTOSCHED_SRC) here seems overkill, but makes copy-n-paste elsewhere easier)
-autotune: $(BIN)/demo.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BIN)/train_cost_model $(AUTOSCHED_BIN)/libauto_schedule.so $(AUTOSCHED_SRC)/autotune_loop.sh
+autotune: $(GENERATOR_BIN)/demo.generator $(AUTOSCHED_BIN)/augment_sample $(AUTOSCHED_BIN)/train_cost_model $(AUTOSCHED_BIN)/libauto_schedule.so $(AUTOSCHED_SRC)/autotune_loop.sh
 	bash $(AUTOSCHED_SRC)/autotune_loop.sh \
-		$(BIN)/demo.generator \
+		$(GENERATOR_BIN)/demo.generator \
 		demo \
 		x86-64-avx2 \
 		$(AUTOSCHED_SRC)/weights \

--- a/apps/autoscheduler/Makefile
+++ b/apps/autoscheduler/Makefile
@@ -1,9 +1,6 @@
 include ../support/Makefile.inc
 include ../support/autoscheduler.inc
 
-BIN ?= bin
-HL_TARGET ?= host
-
 # A sample generator to autoschedule. Note that if it statically links
 # to libHalide, then it must be build with $(USE_EXPORT_DYNAMIC), or the
 # autoscheduler can't find the libHalide symbols that it needs.
@@ -14,7 +11,7 @@ $(BIN)/demo.generator: demo_generator.cpp $(GENERATOR_DEPS)
 # To use the autoscheduler, set a few environment variables and use the -p flag to the generator to load the autoscheduler as a plugin
 $(BIN)/demo.a: $(BIN)/demo.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=weights \
-	$(BIN)/demo.generator -g demo -o $(BIN) -f demo target=$(HL_TARGET) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
+	$(BIN)/demo.generator -g demo -o $(@D) -f demo target=$(HL_TARGET) auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/demo.rungen: $(BIN)/RunGenMain.o $(BIN)/demo.registration.cpp $(BIN)/demo.a
 	$(CXX) -I $(BIN) $^ -o $@ $(HALIDE_SYSTEM_LIBS) $(IMAGE_IO_FLAGS)

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -2,19 +2,19 @@ include ../support/Makefile.inc
 
 all: $(BIN)/filter
 
-$(BIN)/bilateral_grid.generator: bilateral_grid_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/bilateral_grid.generator: bilateral_grid_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/bilateral_grid.a: $(BIN)/bilateral_grid.generator
+$(BIN)/bilateral_grid.a: $(GENERATOR_BIN)/bilateral_grid.generator
 	@mkdir -p $(@D)
 	$^ -g bilateral_grid -o $(@D) -f bilateral_grid target=$(HL_TARGET) auto_schedule=false
 
-$(BIN)/bilateral_grid_auto_schedule.a: $(BIN)/bilateral_grid.generator
+$(BIN)/bilateral_grid_auto_schedule.a: $(GENERATOR_BIN)/bilateral_grid.generator
 	@mkdir -p $(@D)
 	$^ -g bilateral_grid -o $(@D) -f bilateral_grid_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true -e static_library,h,schedule
 
-$(BIN)/viz/bilateral_grid.a: $(BIN)/bilateral_grid.generator
+$(BIN)/viz/bilateral_grid.a: $(GENERATOR_BIN)/bilateral_grid.generator
 	@mkdir -p $(@D)
 	$^ -g bilateral_grid -o $(@D) target=$(HL_TARGET)-trace_all
 

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -8,15 +8,15 @@ $(BIN)/bilateral_grid.generator: bilateral_grid_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/bilateral_grid.a: $(BIN)/bilateral_grid.generator
 	@mkdir -p $(@D)
-	$^ -g bilateral_grid -o $(BIN) -f bilateral_grid target=$(HL_TARGET) auto_schedule=false
+	$^ -g bilateral_grid -o $(@D) -f bilateral_grid target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/bilateral_grid_auto_schedule.a: $(BIN)/bilateral_grid.generator
 	@mkdir -p $(@D)
-	$^ -g bilateral_grid -o $(BIN) -f bilateral_grid_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true -e static_library,h,schedule
+	$^ -g bilateral_grid -o $(@D) -f bilateral_grid_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true -e static_library,h,schedule
 
 $(BIN)/viz/bilateral_grid.a: $(BIN)/bilateral_grid.generator
 	@mkdir -p $(@D)
-	$^ -g bilateral_grid -o $(BIN)/viz target=$(HL_TARGET)-trace_all
+	$^ -g bilateral_grid -o $(@D) target=$(HL_TARGET)-trace_all
 
 $(BIN)/filter: $(BIN)/bilateral_grid.a $(BIN)/bilateral_grid_auto_schedule.a filter.cpp
 	@mkdir -p $(@D)

--- a/apps/blur/Makefile
+++ b/apps/blur/Makefile
@@ -2,11 +2,11 @@ include ../support/Makefile.inc
 
 all: $(BIN)/test
 
-$(BIN)/halide_blur.generator: halide_blur_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/halide_blur.generator: halide_blur_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/%/halide_blur.a: $(BIN)/halide_blur.generator
+$(BIN)/%/halide_blur.a: $(GENERATOR_BIN)/halide_blur.generator
 	@mkdir -p $(@D)
 	$^ -g halide_blur -o $(BIN)/$* target=$(HL_TARGET)
 

--- a/apps/c_backend/Makefile
+++ b/apps/c_backend/Makefile
@@ -12,11 +12,11 @@ $(BIN)/pipeline.generator: pipeline_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/pipeline_native.a: $(BIN)/pipeline.generator
 	@mkdir -p $(@D)
-	$^ -g pipeline -o $(BIN) -f pipeline_native -e static_library,h target=$(HL_TARGET)
+	$^ -g pipeline -o $(@D) -f pipeline_native -e static_library,h target=$(HL_TARGET)
 
 $(BIN)/pipeline_c.cpp: $(BIN)/pipeline.generator
 	@mkdir -p $(@D)
-	$^ -g pipeline -o $(BIN) -f pipeline_c -e cpp,h target=$(HL_TARGET)
+	$^ -g pipeline -o $(@D) -f pipeline_c -e cpp,h target=$(HL_TARGET)
 
 $(BIN)/run: run.cpp $(BIN)/pipeline_c.cpp $(BIN)/pipeline_native.a
 	$(CXX) $(CXXFLAGS) -Wall -I$(BIN) $(filter-out %.h,$^) -o $@  $(LDFLAGS)
@@ -27,11 +27,11 @@ $(BIN)/pipeline_cpp.generator: pipeline_cpp_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/pipeline_cpp_cpp.cpp: $(BIN)/pipeline_cpp.generator
 	@mkdir -p $(@D)
-	$^ -g pipeline_cpp -o $(BIN) -f pipeline_cpp_cpp -e cpp,h target=host-c_plus_plus_name_mangling
+	$^ -g pipeline_cpp -o $(@D) -f pipeline_cpp_cpp -e cpp,h target=host-c_plus_plus_name_mangling
 
 $(BIN)/pipeline_cpp_native.a: $(BIN)/pipeline_cpp.generator
 	@mkdir -p $(@D)
-	$^ -g pipeline_cpp -o $(BIN) -f pipeline_cpp_native -e static_library,h target=host-c_plus_plus_name_mangling
+	$^ -g pipeline_cpp -o $(@D) -f pipeline_cpp_native -e static_library,h target=host-c_plus_plus_name_mangling
 
 $(BIN)/run_cpp: run_cpp.cpp $(BIN)/pipeline_cpp_cpp.cpp $(BIN)/pipeline_cpp_native.a
 	$(CXX) $(CXXFLAGS) -Wall -I$(BIN) $(filter-out %.h,$^) -o $@  $(LDFLAGS)

--- a/apps/c_backend/Makefile
+++ b/apps/c_backend/Makefile
@@ -6,30 +6,30 @@ test: $(BIN)/run $(BIN)/run_cpp
 
 all: $(BIN)/test
 
-$(BIN)/pipeline.generator: pipeline_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/pipeline.generator: pipeline_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/pipeline_native.a: $(BIN)/pipeline.generator
+$(BIN)/pipeline_native.a: $(GENERATOR_BIN)/pipeline.generator
 	@mkdir -p $(@D)
 	$^ -g pipeline -o $(@D) -f pipeline_native -e static_library,h target=$(HL_TARGET)
 
-$(BIN)/pipeline_c.cpp: $(BIN)/pipeline.generator
+$(BIN)/pipeline_c.cpp: $(GENERATOR_BIN)/pipeline.generator
 	@mkdir -p $(@D)
 	$^ -g pipeline -o $(@D) -f pipeline_c -e cpp,h target=$(HL_TARGET)
 
 $(BIN)/run: run.cpp $(BIN)/pipeline_c.cpp $(BIN)/pipeline_native.a
 	$(CXX) $(CXXFLAGS) -Wall -I$(BIN) $(filter-out %.h,$^) -o $@  $(LDFLAGS)
 
-$(BIN)/pipeline_cpp.generator: pipeline_cpp_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/pipeline_cpp.generator: pipeline_cpp_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/pipeline_cpp_cpp.cpp: $(BIN)/pipeline_cpp.generator
+$(BIN)/pipeline_cpp_cpp.cpp: $(GENERATOR_BIN)/pipeline_cpp.generator
 	@mkdir -p $(@D)
 	$^ -g pipeline_cpp -o $(@D) -f pipeline_cpp_cpp -e cpp,h target=host-c_plus_plus_name_mangling
 
-$(BIN)/pipeline_cpp_native.a: $(BIN)/pipeline_cpp.generator
+$(BIN)/pipeline_cpp_native.a: $(GENERATOR_BIN)/pipeline_cpp.generator
 	@mkdir -p $(@D)
 	$^ -g pipeline_cpp -o $(@D) -f pipeline_cpp_native -e static_library,h target=host-c_plus_plus_name_mangling
 

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -4,19 +4,19 @@ all: $(BIN)/process
 
 TIMING_ITERATIONS ?= 5
 
-$(BIN)/camera_pipe.generator: camera_pipe_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/camera_pipe.generator: camera_pipe_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/camera_pipe.a: $(BIN)/camera_pipe.generator
+$(BIN)/camera_pipe.a: $(GENERATOR_BIN)/camera_pipe.generator
 	@mkdir -p $(@D)
 	$^ -g camera_pipe -o $(@D) -f camera_pipe target=$(HL_TARGET) auto_schedule=false
 
-$(BIN)/camera_pipe_auto_schedule.a: $(BIN)/camera_pipe.generator
+$(BIN)/camera_pipe_auto_schedule.a: $(GENERATOR_BIN)/camera_pipe.generator
 	@mkdir -p $(@D)
 	$^ -g camera_pipe -o $(@D) -f camera_pipe_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 
-$(BIN)/viz/camera_pipe.a: $(BIN)/camera_pipe.generator
+$(BIN)/viz/camera_pipe.a: $(GENERATOR_BIN)/camera_pipe.generator
 	@mkdir -p $(@D)
 	$^ -g camera_pipe -o $(@D) target=$(HL_TARGET)-trace_all
 

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -10,15 +10,15 @@ $(BIN)/camera_pipe.generator: camera_pipe_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/camera_pipe.a: $(BIN)/camera_pipe.generator
 	@mkdir -p $(@D)
-	$^ -g camera_pipe -o $(BIN) -f camera_pipe target=$(HL_TARGET) auto_schedule=false
+	$^ -g camera_pipe -o $(@D) -f camera_pipe target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/camera_pipe_auto_schedule.a: $(BIN)/camera_pipe.generator
 	@mkdir -p $(@D)
-	$^ -g camera_pipe -o $(BIN) -f camera_pipe_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
+	$^ -g camera_pipe -o $(@D) -f camera_pipe_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/viz/camera_pipe.a: $(BIN)/camera_pipe.generator
 	@mkdir -p $(@D)
-	$^ -g camera_pipe -o $(BIN)/viz target=$(HL_TARGET)-trace_all
+	$^ -g camera_pipe -o $(@D) target=$(HL_TARGET)-trace_all
 
 $(BIN)/process: process.cpp $(BIN)/camera_pipe.a $(BIN)/camera_pipe_auto_schedule.a
 	$(CXX) $(CXXFLAGS) -Wall -I$(BIN) $^ -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)

--- a/apps/conv_layer/Makefile
+++ b/apps/conv_layer/Makefile
@@ -2,15 +2,15 @@ include ../support/Makefile.inc
 
 all: $(BIN)/process
 
-$(BIN)/conv_layer.generator: conv_layer_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/conv_layer.generator: conv_layer_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 
-$(BIN)/conv_layer.a: $(BIN)/conv_layer.generator
+$(BIN)/conv_layer.a: $(GENERATOR_BIN)/conv_layer.generator
 	@-mkdir -p $(BIN)
 	$^ -g conv_layer -o $(@D) -f conv_layer target=$(HL_TARGET) auto_schedule=false
 
-$(BIN)/conv_layer_auto_schedule.a: $(BIN)/conv_layer.generator
+$(BIN)/conv_layer_auto_schedule.a: $(GENERATOR_BIN)/conv_layer.generator
 	@-mkdir -p $(BIN)
 	$^ -g conv_layer -o $(@D) -f conv_layer_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 

--- a/apps/conv_layer/Makefile
+++ b/apps/conv_layer/Makefile
@@ -1,7 +1,5 @@
 include ../support/Makefile.inc
 
-BIN ?= bin
-
 all: $(BIN)/process
 
 $(BIN)/conv_layer.generator: conv_layer_generator.cpp $(GENERATOR_DEPS)
@@ -10,11 +8,11 @@ $(BIN)/conv_layer.generator: conv_layer_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/conv_layer.a: $(BIN)/conv_layer.generator
 	@-mkdir -p $(BIN)
-	$^ -g conv_layer -o $(BIN) -f conv_layer target=$(HL_TARGET) auto_schedule=false
+	$^ -g conv_layer -o $(@D) -f conv_layer target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/conv_layer_auto_schedule.a: $(BIN)/conv_layer.generator
 	@-mkdir -p $(BIN)
-	$^ -g conv_layer -o $(BIN) -f conv_layer_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
+	$^ -g conv_layer -o $(@D) -f conv_layer_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/process: process.cpp $(BIN)/conv_layer.a $(BIN)/conv_layer_auto_schedule.a
 	@-mkdir -p $(BIN)

--- a/apps/cuda_mat_mul/Makefile
+++ b/apps/cuda_mat_mul/Makefile
@@ -9,11 +9,11 @@ LDFLAGS += -L $(CUDA_SDK)/lib64
 
 all: $(BIN)/runner
 
-$(BIN)/mat_mul.generator: mat_mul_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/mat_mul.generator: mat_mul_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/mat_mul.a: $(BIN)/mat_mul.generator
+$(BIN)/mat_mul.a: $(GENERATOR_BIN)/mat_mul.generator
 	@mkdir -p $(@D)
 	$^ -g mat_mul -o $(@D) target=host-cuda-cuda_capability_50 size=$(MATRIX_SIZE)
 

--- a/apps/cuda_mat_mul/Makefile
+++ b/apps/cuda_mat_mul/Makefile
@@ -1,6 +1,5 @@
 include ../support/Makefile.inc
 
-BIN ?= bin
 MATRIX_SIZE ?= 1024
 
 CUDA_SDK ?= /usr/local/cuda-8.0
@@ -16,7 +15,7 @@ $(BIN)/mat_mul.generator: mat_mul_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/mat_mul.a: $(BIN)/mat_mul.generator
 	@mkdir -p $(@D)
-	$^ -g mat_mul -o $(BIN) target=host-cuda-cuda_capability_50 size=$(MATRIX_SIZE)
+	$^ -g mat_mul -o $(@D) target=host-cuda-cuda_capability_50 size=$(MATRIX_SIZE)
 
 $(BIN)/runner: runner.cpp $(BIN)/mat_mul.a
 	@mkdir -p $(@D)

--- a/apps/fft/Makefile
+++ b/apps/fft/Makefile
@@ -1,7 +1,6 @@
 include ../support/Makefile.inc
 
 CXXFLAGS += -g -Wall
-BIN ?= bin
 
 .PHONY: clean
 
@@ -41,19 +40,19 @@ $(BIN)/fft.generator: fft_generator.cpp fft.cpp fft.h $(GENERATOR_DEPS)
 # Generate four AOT compiled FFT variants. Forward versions have gain set to 1 / 256.0
 $(BIN)/fft_forward_r2c.a: $(BIN)/fft.generator
 	@mkdir -p $(@D)
-	$^ -g fft -o $(BIN) -f fft_forward_r2c target=$(HL_TARGET) direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=real output_number_type=complex
+	$^ -g fft -o $(@D) -f fft_forward_r2c target=$(HL_TARGET) direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=real output_number_type=complex
 
 $(BIN)/fft_inverse_c2r.a: $(BIN)/fft.generator
 	@mkdir -p $(@D)
-	$^ -g fft -o $(BIN) -f fft_inverse_c2r target=$(HL_TARGET) direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=real
+	$^ -g fft -o $(@D) -f fft_inverse_c2r target=$(HL_TARGET) direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=real
 
 $(BIN)/fft_forward_c2c.a: $(BIN)/fft.generator
 	@mkdir -p $(@D)
-	$^ -g fft -o $(BIN) -f fft_forward_c2c target=$(HL_TARGET) direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=complex output_number_type=complex
+	$^ -g fft -o $(@D) -f fft_forward_c2c target=$(HL_TARGET) direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=complex output_number_type=complex
 
 $(BIN)/fft_inverse_c2c.a: $(BIN)/fft.generator
 	@mkdir -p $(@D)
-	$^ -g fft -o $(BIN) -f fft_inverse_c2c target=$(HL_TARGET) direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=complex
+	$^ -g fft -o $(@D) -f fft_inverse_c2c target=$(HL_TARGET) direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=complex
 
 $(BIN)/fft_aot_test: fft_aot_test.cpp $(BIN)/fft_forward_r2c.a $(BIN)/fft_inverse_c2r.a $(BIN)/fft_forward_c2c.a $(BIN)/fft_inverse_c2c.a
 	@mkdir -p $(@D)

--- a/apps/fft/Makefile
+++ b/apps/fft/Makefile
@@ -33,24 +33,24 @@ bench_48x48: $(BIN)/bench_fft
 bench_64x64: $(BIN)/bench_fft
 	$(BIN)/bench_fft 64 64 $(BIN)/
 
-$(BIN)/fft.generator: fft_generator.cpp fft.cpp fft.h $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/fft.generator: fft_generator.cpp fft.cpp fft.h $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
 # Generate four AOT compiled FFT variants. Forward versions have gain set to 1 / 256.0
-$(BIN)/fft_forward_r2c.a: $(BIN)/fft.generator
+$(BIN)/fft_forward_r2c.a: $(GENERATOR_BIN)/fft.generator
 	@mkdir -p $(@D)
 	$^ -g fft -o $(@D) -f fft_forward_r2c target=$(HL_TARGET) direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=real output_number_type=complex
 
-$(BIN)/fft_inverse_c2r.a: $(BIN)/fft.generator
+$(BIN)/fft_inverse_c2r.a: $(GENERATOR_BIN)/fft.generator
 	@mkdir -p $(@D)
 	$^ -g fft -o $(@D) -f fft_inverse_c2r target=$(HL_TARGET) direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=real
 
-$(BIN)/fft_forward_c2c.a: $(BIN)/fft.generator
+$(BIN)/fft_forward_c2c.a: $(GENERATOR_BIN)/fft.generator
 	@mkdir -p $(@D)
 	$^ -g fft -o $(@D) -f fft_forward_c2c target=$(HL_TARGET) direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=complex output_number_type=complex
 
-$(BIN)/fft_inverse_c2c.a: $(BIN)/fft.generator
+$(BIN)/fft_inverse_c2c.a: $(GENERATOR_BIN)/fft.generator
 	@mkdir -p $(@D)
 	$^ -g fft -o $(@D) -f fft_inverse_c2c target=$(HL_TARGET) direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=complex
 

--- a/apps/glsl/Makefile
+++ b/apps/glsl/Makefile
@@ -6,19 +6,19 @@ CXXFLAGS += -g -O0
 
 all: $(BIN)/opengl_test
 
-$(BIN)/halide_blur_glsl.generator: halide_blur_glsl_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/halide_blur_glsl.generator: halide_blur_glsl_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/halide_blur_glsl.a: $(BIN)/halide_blur_glsl.generator
+$(BIN)/halide_blur_glsl.a: $(GENERATOR_BIN)/halide_blur_glsl.generator
 	@mkdir -p $(@D)
 	$^ -g halide_blur_glsl -o $(@D) target=host-opengl-debug
 
-$(BIN)/halide_ycc_glsl.generator: halide_ycc_glsl_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/halide_ycc_glsl.generator: halide_ycc_glsl_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/halide_ycc_glsl.a: $(BIN)/halide_ycc_glsl.generator
+$(BIN)/halide_ycc_glsl.a: $(GENERATOR_BIN)/halide_ycc_glsl.generator
 	@mkdir -p $(@D)
 	$^ -g halide_ycc_glsl -o $(@D) target=host-opengl-debug
 

--- a/apps/glsl/Makefile
+++ b/apps/glsl/Makefile
@@ -12,7 +12,7 @@ $(BIN)/halide_blur_glsl.generator: halide_blur_glsl_generator.cpp $(GENERATOR_DE
 
 $(BIN)/halide_blur_glsl.a: $(BIN)/halide_blur_glsl.generator
 	@mkdir -p $(@D)
-	$^ -g halide_blur_glsl -o $(BIN) target=host-opengl-debug
+	$^ -g halide_blur_glsl -o $(@D) target=host-opengl-debug
 
 $(BIN)/halide_ycc_glsl.generator: halide_ycc_glsl_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
@@ -20,7 +20,7 @@ $(BIN)/halide_ycc_glsl.generator: halide_ycc_glsl_generator.cpp $(GENERATOR_DEPS
 
 $(BIN)/halide_ycc_glsl.a: $(BIN)/halide_ycc_glsl.generator
 	@mkdir -p $(@D)
-	$^ -g halide_ycc_glsl -o $(BIN) target=host-opengl-debug
+	$^ -g halide_ycc_glsl -o $(@D) target=host-opengl-debug
 
 $(BIN)/opengl_test: opengl_test.cpp $(BIN)/halide_blur_glsl.a $(BIN)/halide_ycc_glsl.a
 	$(CXX) $(CXXFLAGS) -I$(BIN) $^ -o $@ $(LDFLAGS) -L$(TOP)/bin $(PLATFORM_OPENGL_LDFLAGS)

--- a/apps/hexagon_benchmarks/Makefile
+++ b/apps/hexagon_benchmarks/Makefile
@@ -20,27 +20,27 @@ $(BIN)/%.generator : %_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/%/conv3x3a16.o: $(BIN)/conv3x3.generator
+$(BIN)/%/conv3x3a16.o: $(GENERATOR_BIN)/conv3x3.generator
 	@mkdir -p $(@D)
 	$^ -g conv3x3 -o $(BIN)/$* -e o,h -f conv3x3a16 target=$(HL_TARGET) accumulator_type=int16 ${SCHEDULING_OPTS}
 
-$(BIN)/%/dilate3x3.o: $(BIN)/dilate3x3.generator
+$(BIN)/%/dilate3x3.o: $(GENERATOR_BIN)/dilate3x3.generator
 	@mkdir -p $(@D)
 	$^ -g dilate3x3 -o $(BIN)/$* -e o,h -f dilate3x3 target=$(HL_TARGET) ${SCHEDULING_OPTS}
 
-$(BIN)/%/median3x3.o: $(BIN)/median3x3.generator
+$(BIN)/%/median3x3.o: $(GENERATOR_BIN)/median3x3.generator
 	@mkdir -p $(@D)
 	$^ -g median3x3 -o $(BIN)/$* -e o,h -f median3x3 target=$(HL_TARGET) ${SCHEDULING_OPTS}
 
-$(BIN)/%/gaussian5x5.o: $(BIN)/gaussian5x5.generator
+$(BIN)/%/gaussian5x5.o: $(GENERATOR_BIN)/gaussian5x5.generator
 	@mkdir -p $(@D)
 	$^ -g gaussian5x5 -o $(BIN)/$* -e o,h -f gaussian5x5 target=$(HL_TARGET) ${SCHEDULING_OPTS}
 
-$(BIN)/%/sobel.o: $(BIN)/sobel.generator
+$(BIN)/%/sobel.o: $(GENERATOR_BIN)/sobel.generator
 	@mkdir -p $(@D)
 	$^ -g sobel -o $(BIN)/$* -e o,h -f sobel target=$(HL_TARGET) ${SCHEDULING_OPTS}
 
-$(BIN)/%/conv3x3a32.o: $(BIN)/conv3x3.generator
+$(BIN)/%/conv3x3a32.o: $(GENERATOR_BIN)/conv3x3.generator
 	@mkdir -p $(@D)
 	$^ -g conv3x3 -o $(BIN)/$* -e o,h -f conv3x3a32 target=$(HL_TARGET) accumulator_type=int32 ${SCHEDULING_OPTS}
 

--- a/apps/hexagon_benchmarks/Makefile
+++ b/apps/hexagon_benchmarks/Makefile
@@ -1,6 +1,5 @@
 include ../support/Makefile.inc
 
-BIN ?= bin
 
 FILTERS ?= conv3x3a16 dilate3x3 median3x3 gaussian5x5 sobel conv3x3a32
 

--- a/apps/hexagon_dma/Makefile
+++ b/apps/hexagon_dma/Makefile
@@ -48,7 +48,6 @@ LDFLAGS-arm-64-profile-android ?= -llog -fPIE -pie
 LDFLAGS-arm-32-profile-android ?= -llog -fPIE -pie
 OPTION := none
 
-BIN ?= bin
 
 all: $(BIN)/process_yuv_linear_basic-host \
 	 $(BIN)/process_raw_linear_interleaved_basic-host \

--- a/apps/lens_blur/Makefile
+++ b/apps/lens_blur/Makefile
@@ -3,15 +3,15 @@ include ../support/Makefile.inc
 
 all: $(BIN)/process
 
-$(BIN)/lens_blur.generator: lens_blur_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/lens_blur.generator: lens_blur_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 
-$(BIN)/lens_blur.a: $(BIN)/lens_blur.generator
+$(BIN)/lens_blur.a: $(GENERATOR_BIN)/lens_blur.generator
 	@-mkdir -p $(BIN)
 	$^ -g lens_blur -o $(@D) -f lens_blur target=$(HL_TARGET) auto_schedule=false
 
-$(BIN)/lens_blur_auto_schedule.a: $(BIN)/lens_blur.generator
+$(BIN)/lens_blur_auto_schedule.a: $(GENERATOR_BIN)/lens_blur.generator
 	@-mkdir -p $(BIN)
 	$^ -g lens_blur -o $(@D) -f lens_blur_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 

--- a/apps/lens_blur/Makefile
+++ b/apps/lens_blur/Makefile
@@ -1,6 +1,5 @@
 include ../support/Makefile.inc
 
-BIN ?= bin
 
 all: $(BIN)/process
 
@@ -10,11 +9,11 @@ $(BIN)/lens_blur.generator: lens_blur_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/lens_blur.a: $(BIN)/lens_blur.generator
 	@-mkdir -p $(BIN)
-	$^ -g lens_blur -o $(BIN) -f lens_blur target=$(HL_TARGET) auto_schedule=false
+	$^ -g lens_blur -o $(@D) -f lens_blur target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/lens_blur_auto_schedule.a: $(BIN)/lens_blur.generator
 	@-mkdir -p $(BIN)
-	$^ -g lens_blur -o $(BIN) -f lens_blur_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
+	$^ -g lens_blur -o $(@D) -f lens_blur_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/process: process.cpp $(BIN)/lens_blur.a $(BIN)/lens_blur_auto_schedule.a
 	@-mkdir -p $(BIN)

--- a/apps/linear_algebra/Makefile
+++ b/apps/linear_algebra/Makefile
@@ -1,9 +1,7 @@
 include ../support/Makefile.inc
 
-BIN ?= bin
 BUILD = $(BIN)/build
 CXXFLAGS += -Wall -march=native -I /opt/local/include
-HL_TARGET ?= host
 LIBHALIDE_BLAS = $(BIN)/libhalide_blas.a
 HALIDEBLAS_FLAGS ?= -DUSE_HALIDE
 EMIT_OPTIONS = stmt,assembly,o,h

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -1,6 +1,5 @@
 include ../support/Makefile.inc
 
-BIN ?= bin
 
 all: $(BIN)/process
 
@@ -10,11 +9,11 @@ $(BIN)/local_laplacian.generator: local_laplacian_generator.cpp $(GENERATOR_DEPS
 
 $(BIN)/local_laplacian.a: $(BIN)/local_laplacian.generator
 	@mkdir -p $(@D)
-	$^ -g local_laplacian -o $(BIN) -f local_laplacian target=$(HL_TARGET) auto_schedule=false
+	$^ -g local_laplacian -o $(@D) -f local_laplacian target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/local_laplacian_auto_schedule.a: $(BIN)/local_laplacian.generator
 	@mkdir -p $(@D)
-	$^ -g local_laplacian -o $(BIN) -f local_laplacian_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
+	$^ -g local_laplacian -o $(@D) -f local_laplacian_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/process: process.cpp $(BIN)/local_laplacian.a $(BIN)/local_laplacian_auto_schedule.a
 	@mkdir -p $(@D)
@@ -31,7 +30,7 @@ $(BIN)/out.tiff: $(BIN)/process
 # Build rules for generating a visualization of the pipeline using HalideTraceViz
 $(BIN)/viz/local_laplacian.a: $(BIN)/local_laplacian.generator
 	@mkdir -p $(@D)
-	$^ -g local_laplacian -o $(BIN)/viz target=$(HL_TARGET)-trace_all pyramid_levels=6
+	$^ -g local_laplacian -o $(@D) target=$(HL_TARGET)-trace_all pyramid_levels=6
 
 $(BIN)/process_viz: process.cpp $(BIN)/viz/local_laplacian.a
 	@mkdir -p $(@D)

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -3,15 +3,15 @@ include ../support/Makefile.inc
 
 all: $(BIN)/process
 
-$(BIN)/local_laplacian.generator: local_laplacian_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/local_laplacian.generator: local_laplacian_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/local_laplacian.a: $(BIN)/local_laplacian.generator
+$(BIN)/local_laplacian.a: $(GENERATOR_BIN)/local_laplacian.generator
 	@mkdir -p $(@D)
 	$^ -g local_laplacian -o $(@D) -f local_laplacian target=$(HL_TARGET) auto_schedule=false
 
-$(BIN)/local_laplacian_auto_schedule.a: $(BIN)/local_laplacian.generator
+$(BIN)/local_laplacian_auto_schedule.a: $(GENERATOR_BIN)/local_laplacian.generator
 	@mkdir -p $(@D)
 	$^ -g local_laplacian -o $(@D) -f local_laplacian_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 
@@ -28,7 +28,7 @@ $(BIN)/out.tiff: $(BIN)/process
 	$(BIN)/process $(IMAGES)/rgb.png 8 1 1 10 $(BIN)/out.tiff
 
 # Build rules for generating a visualization of the pipeline using HalideTraceViz
-$(BIN)/viz/local_laplacian.a: $(BIN)/local_laplacian.generator
+$(BIN)/viz/local_laplacian.a: $(GENERATOR_BIN)/local_laplacian.generator
 	@mkdir -p $(@D)
 	$^ -g local_laplacian -o $(@D) target=$(HL_TARGET)-trace_all pyramid_levels=6
 

--- a/apps/nl_means/Makefile
+++ b/apps/nl_means/Makefile
@@ -3,15 +3,15 @@ include ../support/Makefile.inc
 
 all: $(BIN)/process
 
-$(BIN)/nl_means.generator: nl_means_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/nl_means.generator: nl_means_generator.cpp $(GENERATOR_DEPS)
 	@-mkdir -p $(BIN)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 
-$(BIN)/nl_means.a: $(BIN)/nl_means.generator
+$(BIN)/nl_means.a: $(GENERATOR_BIN)/nl_means.generator
 	@-mkdir -p $(BIN)
 	$^ -g nl_means -o $(@D) -f nl_means target=$(HL_TARGET) auto_schedule=false
 
-$(BIN)/nl_means_auto_schedule.a: $(BIN)/nl_means.generator
+$(BIN)/nl_means_auto_schedule.a: $(GENERATOR_BIN)/nl_means.generator
 	@-mkdir -p $(BIN)
 	$^ -g nl_means -o $(@D) -f nl_means_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 

--- a/apps/nl_means/Makefile
+++ b/apps/nl_means/Makefile
@@ -1,6 +1,5 @@
 include ../support/Makefile.inc
 
-BIN ?= bin
 
 all: $(BIN)/process
 
@@ -10,11 +9,11 @@ $(BIN)/nl_means.generator: nl_means_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/nl_means.a: $(BIN)/nl_means.generator
 	@-mkdir -p $(BIN)
-	$^ -g nl_means -o $(BIN) -f nl_means target=$(HL_TARGET) auto_schedule=false
+	$^ -g nl_means -o $(@D) -f nl_means target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/nl_means_auto_schedule.a: $(BIN)/nl_means.generator
 	@-mkdir -p $(BIN)
-	$^ -g nl_means -o $(BIN) -f nl_means_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
+	$^ -g nl_means -o $(@D) -f nl_means_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/process: process.cpp $(BIN)/nl_means.a $(BIN)/nl_means_auto_schedule.a
 	@-mkdir -p $(BIN)

--- a/apps/nn_ops/Makefile
+++ b/apps/nn_ops/Makefile
@@ -1,6 +1,5 @@
 include ../support/Makefile.inc
 
-BIN ?= bin
 
 all: $(BIN)/host/AveragePool $(BIN)/host/Convolution $(BIN)/host/DepthwiseConvolution $(BIN)/host/Im2col $(BIN)/host/MatrixMultiply $(BIN)/host/MaxPool
 

--- a/apps/nn_ops/Makefile
+++ b/apps/nn_ops/Makefile
@@ -3,11 +3,11 @@ include ../support/Makefile.inc
 
 all: $(BIN)/host/AveragePool $(BIN)/host/Convolution $(BIN)/host/DepthwiseConvolution $(BIN)/host/Im2col $(BIN)/host/MatrixMultiply $(BIN)/host/MaxPool
 
-$(BIN)/AveragePool.generator: AveragePool_generator.cpp common.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/AveragePool.generator: AveragePool_generator.cpp common.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/%/AveragePool.o: $(BIN)/AveragePool.generator
+$(BIN)/%/AveragePool.o: $(GENERATOR_BIN)/AveragePool.generator
 	@mkdir -p $(@D)
 	$^ -g AveragePool -o $(BIN)/$* -e o,h -f AveragePool target=$(HL_TARGET)
 
@@ -15,11 +15,11 @@ $(BIN)/%/AveragePool: AveragePool.cpp $(BIN)/%/AveragePool.o
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS) $(CXXFLAGS-$*) -I $(BIN)/$* -Wall AveragePool.cpp $(BIN)/$*/AveragePool.o -o $(BIN)/$*/AveragePool $(LDFLAGS-$*)
 
-$(BIN)/Convolution.generator: Convolution_generator.cpp common.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/Convolution.generator: Convolution_generator.cpp common.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/%/Convolution.o: $(BIN)/Convolution.generator
+$(BIN)/%/Convolution.o: $(GENERATOR_BIN)/Convolution.generator
 	@mkdir -p $(@D)
 	$^ -g Convolution -o $(BIN)/$* -e o,h -f Convolution target=$(HL_TARGET)
 
@@ -27,23 +27,23 @@ $(BIN)/%/Convolution: Convolution.cpp common_reference.cpp $(BIN)/%/Convolution.
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS) $(CXXFLAGS-$*) -I $(BIN)/$* -Wall Convolution.cpp common_reference.cpp $(BIN)/$*/Convolution.o -o $(BIN)/$*/Convolution $(LDFLAGS-$*)
 
-$(BIN)/DepthwiseConvolution.generator: DepthwiseConvolution_generator.cpp common.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/DepthwiseConvolution.generator: DepthwiseConvolution_generator.cpp common.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/%/DepthwiseConvolution_1.o: $(BIN)/DepthwiseConvolution.generator
+$(BIN)/%/DepthwiseConvolution_1.o: $(GENERATOR_BIN)/DepthwiseConvolution.generator
 	@mkdir -p $(@D)
 	$^ -g DepthwiseConvolution -o $(BIN)/$* -e o,h -f DepthwiseConvolution_1 target=$(HL_TARGET) depth_multiplier=1
 
-$(BIN)/%/DepthwiseConvolution_2.o: $(BIN)/DepthwiseConvolution.generator
+$(BIN)/%/DepthwiseConvolution_2.o: $(GENERATOR_BIN)/DepthwiseConvolution.generator
 	@mkdir -p $(@D)
 	$^ -g DepthwiseConvolution -o $(BIN)/$* -e o,h -f DepthwiseConvolution_2 target=$(HL_TARGET) depth_multiplier=2
 
-$(BIN)/%/DepthwiseConvolution_4.o: $(BIN)/DepthwiseConvolution.generator
+$(BIN)/%/DepthwiseConvolution_4.o: $(GENERATOR_BIN)/DepthwiseConvolution.generator
 	@mkdir -p $(@D)
 	$^ -g DepthwiseConvolution -o $(BIN)/$* -e o,h -f DepthwiseConvolution_4 target=$(HL_TARGET) depth_multiplier=4
 
-$(BIN)/%/DepthwiseConvolution_8.o: $(BIN)/DepthwiseConvolution.generator
+$(BIN)/%/DepthwiseConvolution_8.o: $(GENERATOR_BIN)/DepthwiseConvolution.generator
 	@mkdir -p $(@D)
 	$^ -g DepthwiseConvolution -o $(BIN)/$* -e o,h -f DepthwiseConvolution_8 target=$(HL_TARGET) depth_multiplier=8
 
@@ -51,11 +51,11 @@ $(BIN)/%/DepthwiseConvolution: DepthwiseConvolution.cpp common_reference.cpp $(B
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS) $(CXXFLAGS-$*) -I $(BIN)/$* -Wall DepthwiseConvolution.cpp common_reference.cpp $(BIN)/$*/DepthwiseConvolution_1.o $(BIN)/$*/DepthwiseConvolution_2.o $(BIN)/$*/DepthwiseConvolution_4.o $(BIN)/$*/DepthwiseConvolution_8.o -o $(BIN)/$*/DepthwiseConvolution $(LDFLAGS-$*)
 
-$(BIN)/Im2col.generator: Im2col_generator.cpp common.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/Im2col.generator: Im2col_generator.cpp common.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/%/Im2col.o: $(BIN)/Im2col.generator
+$(BIN)/%/Im2col.o: $(GENERATOR_BIN)/Im2col.generator
 	@mkdir -p $(@D)
 	$^ -g Im2col -o $(BIN)/$* -e o,h -f Im2col target=$(HL_TARGET)
 
@@ -63,11 +63,11 @@ $(BIN)/%/Im2col: Im2col.cpp $(BIN)/%/Im2col.o
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS) $(CXXFLAGS-$*) -I $(BIN)/$* -Wall Im2col.cpp $(BIN)/$*/Im2col.o -o $(BIN)/$*/Im2col $(LDFLAGS-$*)
 
-$(BIN)/MatrixMultiply.generator: MatrixMultiply_generator.cpp common.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/MatrixMultiply.generator: MatrixMultiply_generator.cpp common.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/%/MatrixMultiply.o: $(BIN)/MatrixMultiply.generator
+$(BIN)/%/MatrixMultiply.o: $(GENERATOR_BIN)/MatrixMultiply.generator
 	@mkdir -p $(@D)
 	$^ -g MatrixMultiply -o $(BIN)/$* -e o,h -f MatrixMultiply target=$(HL_TARGET)
 
@@ -75,11 +75,11 @@ $(BIN)/%/MatrixMultiply: MatrixMultiply.cpp common_reference.cpp $(BIN)/%/Matrix
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS) $(CXXFLAGS-$*) -I $(BIN)/$* -Wall MatrixMultiply.cpp common_reference.cpp $(BIN)/$*/MatrixMultiply.o -o $(BIN)/$*/MatrixMultiply $(LDFLAGS-$*)
 
-$(BIN)/MaxPool.generator: MaxPool_generator.cpp common.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/MaxPool.generator: MaxPool_generator.cpp common.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/%/MaxPool.o: $(BIN)/MaxPool.generator
+$(BIN)/%/MaxPool.o: $(GENERATOR_BIN)/MaxPool.generator
 	@mkdir -p $(@D)
 	$^ -g MaxPool -o $(BIN)/$* -e o,h -f MaxPool target=$(HL_TARGET)
 

--- a/apps/onnx/Makefile
+++ b/apps/onnx/Makefile
@@ -48,7 +48,7 @@ $(BIN)/onnx_converter_test: onnx_converter_test.cc $(ONNX_CONVERTER_LIB)
 	$(CXX) $(CXXFLAGS) $(USE_EXPORT_DYNAMIC) -I$(BIN) $< -o $@ $(LDFLAGS) $(ONNX_CONVERTER_LIB) $(LIB_HALIDE) $(HALIDE_SYSTEM_LIBS)
 
 
-$(BIN)/onnx_converter.generator : onnx_converter_generator.cc $(GENERATOR_DEPS) $(ONNX_CONVERTER_LIB)
+$(GENERATOR_BIN)/onnx_converter.generator : onnx_converter_generator.cc $(GENERATOR_DEPS) $(ONNX_CONVERTER_LIB)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -I$(BIN) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
@@ -58,7 +58,7 @@ $(BIN)/onnx_converter.generator : onnx_converter_generator.cc $(GENERATOR_DEPS) 
 #	curl -o $(@D)/mnist.tar.gz https://onnxzoo.blob.core.windows.net/models/opset_8/mnist/mnist.tar.gz
 #	tar xvzf $(@D)/mnist.tar.gz -C $(BIN)/onnx_model_zoo
 
-#$(BIN)/onnx_mnist_model.a : $(BIN)/onnx_converter.generator $(BIN)/onnx_model_zoo/mnist/model.onnx
+#$(BIN)/onnx_mnist_model.a : $(GENERATOR_BIN)/onnx_converter.generator $(BIN)/onnx_model_zoo/mnist/model.onnx
 #	@mkdir -p $(@D)
 #	$^ -g onnx_model_inference -o $(@D) -f onnx_model_inference target=$(HL_TARGET) model_file_path=$(BIN)/onnx_model_zoo/mnist/model.onnx
 
@@ -66,7 +66,7 @@ $(BIN)/test_model.onnx: test_model_proto.txt $(BIN)/onnx/onnx.proto
 	@mkdir -p $(@D)
 	cat $< | protoc --encode=onnx.ModelProto $(BIN)/onnx/onnx.proto > $@
 
-$(BIN)/test_model.a: $(BIN)/onnx_converter.generator $(BIN)/test_model.onnx
+$(BIN)/test_model.a: $(GENERATOR_BIN)/onnx_converter.generator $(BIN)/test_model.onnx
 	@mkdir -p $(@D)
 	$< -g onnx_model_generator -o $(@D) -f test_model target=$(HL_TARGET) model_file_path=$(BIN)/test_model.onnx
 

--- a/apps/onnx/Makefile
+++ b/apps/onnx/Makefile
@@ -1,8 +1,5 @@
 include ../support/Makefile.inc
 
-BIN ?= bin
-
-HL_TARGET ?= host
 
 PROTOC := $(shell which protoc)
 
@@ -63,7 +60,7 @@ $(BIN)/onnx_converter.generator : onnx_converter_generator.cc $(GENERATOR_DEPS) 
 
 #$(BIN)/onnx_mnist_model.a : $(BIN)/onnx_converter.generator $(BIN)/onnx_model_zoo/mnist/model.onnx
 #	@mkdir -p $(@D)
-#	$^ -g onnx_model_inference -o $(BIN) -f onnx_model_inference target=$(HL_TARGET) model_file_path=$(BIN)/onnx_model_zoo/mnist/model.onnx
+#	$^ -g onnx_model_inference -o $(@D) -f onnx_model_inference target=$(HL_TARGET) model_file_path=$(BIN)/onnx_model_zoo/mnist/model.onnx
 
 $(BIN)/test_model.onnx: test_model_proto.txt $(BIN)/onnx/onnx.proto
 	@mkdir -p $(@D)
@@ -71,7 +68,7 @@ $(BIN)/test_model.onnx: test_model_proto.txt $(BIN)/onnx/onnx.proto
 
 $(BIN)/test_model.a: $(BIN)/onnx_converter.generator $(BIN)/test_model.onnx
 	@mkdir -p $(@D)
-	$< -g onnx_model_generator -o $(BIN) -f test_model target=$(HL_TARGET) model_file_path=$(BIN)/test_model.onnx
+	$< -g onnx_model_generator -o $(@D) -f test_model target=$(HL_TARGET) model_file_path=$(BIN)/test_model.onnx
 
 $(BIN)/onnx_converter_generator_test: onnx_converter_generator_test.cc $(BIN)/test_model.a
 	@mkdir -p $(@D)

--- a/apps/opengl_demo/Makefile
+++ b/apps/opengl_demo/Makefile
@@ -46,7 +46,6 @@ GENERATOR_LIBS = -lHalide -lz -lcurses
 CXXFLAGS       = -std=c++11 -g -DDTX_FONT=\"$(DTX_FONT)\" $(HALIDE_INC_PATH)
 
 # Output directory.
-BIN ?= bin
 
 .PHONY: run clean
 
@@ -83,10 +82,10 @@ $(BIN)/main.o: \
 # depends on the halide filter source in sample_filter.cpp
 #
 $(BIN)/sample_filter_cpu.o $(BIN)/sample_filter_cpu.h: $(BIN)/sample_filter.generator
-	LD_LIBRARY_PATH=../../bin $(BIN)/sample_filter.generator -g sample_filter -e o,h,stmt -o $(BIN) -f sample_filter_cpu target=$(HL_TARGET)
+	LD_LIBRARY_PATH=../../bin $(BIN)/sample_filter.generator -g sample_filter -e o,h,stmt -o $(@D) -f sample_filter_cpu target=$(HL_TARGET)
 
 $(BIN)/sample_filter_opengl.o $(BIN)/sample_filter_opengl.h: $(BIN)/sample_filter.generator
-	LD_LIBRARY_PATH=../../bin $(BIN)/sample_filter.generator -g sample_filter -e o,h,stmt -o $(BIN) -f sample_filter_opengl target=host-opengl-debug
+	LD_LIBRARY_PATH=../../bin $(BIN)/sample_filter.generator -g sample_filter -e o,h,stmt -o $(@D) -f sample_filter_opengl target=host-opengl-debug
 
 $(BIN)/sample_filter.generator: sample_filter_generator.cpp
 	@mkdir -p $(@D)

--- a/apps/resize/Makefile
+++ b/apps/resize/Makefile
@@ -25,7 +25,7 @@ $(BIN)/resize.generator: resize_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/resize_%.a: $(BIN)/resize.generator
 	@mkdir -p $(@D)
-	$^ -g resize -o $(BIN) -f resize_$* \
+	$^ -g resize -o $(@D) -f resize_$* \
 	target=$(HL_TARGET)-no_runtime \
 	interpolation_type=$$(echo $* | cut -d_ -f1) \
 	input.type=$$(echo $* | cut -d_ -f2) \
@@ -33,7 +33,7 @@ $(BIN)/resize_%.a: $(BIN)/resize.generator
 
 $(BIN)/runtime.a: $(BIN)/resize.generator
 	@mkdir -p $(@D)
-	$^ -r runtime -o $(BIN) target=$(HL_TARGET)
+	$^ -r runtime -o $(@D) target=$(HL_TARGET)
 
 $(BIN)/resize: resize.cpp $(LIBRARIES) $(BIN)/runtime.a
 	@mkdir -p $(@D)

--- a/apps/resize/Makefile
+++ b/apps/resize/Makefile
@@ -19,11 +19,11 @@ OUTPUTS = $(foreach V,$(VARIANTS),$(BIN)/out_$(V).png)
 
 all: $(OUTPUTS)
 
-$(BIN)/resize.generator: resize_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/resize.generator: resize_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/resize_%.a: $(BIN)/resize.generator
+$(BIN)/resize_%.a: $(GENERATOR_BIN)/resize.generator
 	@mkdir -p $(@D)
 	$^ -g resize -o $(@D) -f resize_$* \
 	target=$(HL_TARGET)-no_runtime \
@@ -31,7 +31,7 @@ $(BIN)/resize_%.a: $(BIN)/resize.generator
 	input.type=$$(echo $* | cut -d_ -f2) \
 	upsample=$$(echo $* | cut -d_ -f3 | sed 's/up/true/;s/down/false/')
 
-$(BIN)/runtime.a: $(BIN)/resize.generator
+$(BIN)/runtime.a: $(GENERATOR_BIN)/resize.generator
 	@mkdir -p $(@D)
 	$^ -r runtime -o $(@D) target=$(HL_TARGET)
 

--- a/apps/resnet_50/Makefile
+++ b/apps/resnet_50/Makefile
@@ -1,6 +1,5 @@
 include ../support/Makefile.inc
 
-BIN ?= bin
 SEED = 123
 
 all: $(BIN)/process
@@ -16,7 +15,7 @@ $(BIN)/resnet50.generator: Resnet50Generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/resnet50.a: $(BIN)/resnet50.generator
 	@mkdir -p $(@D)
-	$^ -g resnet50 -o $(BIN) -f resnet50 target=$(HL_TARGET) auto_schedule=false
+	$^ -g resnet50 -o $(@D) -f resnet50 target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/process: process.cpp $(BIN)/resnet50.a
 	@mkdir -p $(@D)

--- a/apps/resnet_50/Makefile
+++ b/apps/resnet_50/Makefile
@@ -9,11 +9,11 @@ $(BIN)/pytorch_weights/ok:
 	python3 load_weights.py $(@D)
 	echo "ok" > $@
 
-$(BIN)/resnet50.generator: Resnet50Generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/resnet50.generator: Resnet50Generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/resnet50.a: $(BIN)/resnet50.generator
+$(BIN)/resnet50.a: $(GENERATOR_BIN)/resnet50.generator
 	@mkdir -p $(@D)
 	$^ -g resnet50 -o $(@D) -f resnet50 target=$(HL_TARGET) auto_schedule=false
 

--- a/apps/simd_op_check/Makefile
+++ b/apps/simd_op_check/Makefile
@@ -1,6 +1,5 @@
 CXX-host ?= c++
 
-BIN ?= bin
 
 OPTIMIZE ?= -O3
 

--- a/apps/stencil_chain/Makefile
+++ b/apps/stencil_chain/Makefile
@@ -1,6 +1,5 @@
 include ../support/Makefile.inc
 
-BIN ?= bin
 
 all: $(BIN)/process
 
@@ -10,11 +9,11 @@ $(BIN)/stencil_chain.generator: stencil_chain_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/stencil_chain.a: $(BIN)/stencil_chain.generator
 	@mkdir -p $(@D)
-	$^ -g stencil_chain -o $(BIN) -f stencil_chain target=$(HL_TARGET) auto_schedule=false
+	$^ -g stencil_chain -o $(@D) -f stencil_chain target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/stencil_chain_auto_schedule.a: $(BIN)/stencil_chain.generator
 	@mkdir -p $(@D)
-	$^ -g stencil_chain -o $(BIN) -f stencil_chain_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
+	$^ -g stencil_chain -o $(@D) -f stencil_chain_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/process: process.cpp $(BIN)/stencil_chain.a $(BIN)/stencil_chain_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/stencil_chain/Makefile
+++ b/apps/stencil_chain/Makefile
@@ -3,15 +3,15 @@ include ../support/Makefile.inc
 
 all: $(BIN)/process
 
-$(BIN)/stencil_chain.generator: stencil_chain_generator.cpp $(GENERATOR_DEPS)
+$(GENERATOR_BIN)/stencil_chain.generator: stencil_chain_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
-$(BIN)/stencil_chain.a: $(BIN)/stencil_chain.generator
+$(BIN)/stencil_chain.a: $(GENERATOR_BIN)/stencil_chain.generator
 	@mkdir -p $(@D)
 	$^ -g stencil_chain -o $(@D) -f stencil_chain target=$(HL_TARGET) auto_schedule=false
 
-$(BIN)/stencil_chain_auto_schedule.a: $(BIN)/stencil_chain.generator
+$(BIN)/stencil_chain_auto_schedule.a: $(GENERATOR_BIN)/stencil_chain.generator
 	@mkdir -p $(@D)
 	$^ -g stencil_chain -o $(@D) -f stencil_chain_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -1,9 +1,10 @@
 HALIDE_DISTRIB_PATH ?= ../../distrib
 LDFLAGS ?=
-BIN ?= ./bin
 IMAGES ?= ../images
-HL_TARGET ?= host
 UNAME ?= $(shell uname)
+
+HL_TARGET ?= host
+BIN ?= bin/$(HL_TARGET)
 
 SANITIZER_FLAGS ?=
 

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -3,8 +3,19 @@ LDFLAGS ?=
 IMAGES ?= ../images
 UNAME ?= $(shell uname)
 
+BIN_DIR ?= bin
 HL_TARGET ?= host
-BIN ?= bin/$(HL_TARGET)
+
+# Most build outputs go here, so that you can vary the test and/or benchmark output
+# easily by changing HL_TARGET and not have to worry about cleaning the output
+# (e.g. to add different GPU or SIMD features).
+BIN ?= $(BIN_DIR)/$(HL_TARGET)
+
+# GENERATOR_BIN is used mainly for Generators, which are always built
+# (and executed) on the host, regardless of the final target; this saves a bit
+# of recompile time (and disk space). (It would still provide correct results
+# if we output them to $(BIN), it would just be inefficient.)
+GENERATOR_BIN ?= $(BIN_DIR)/host
 
 SANITIZER_FLAGS ?=
 

--- a/apps/wavelet/Makefile
+++ b/apps/wavelet/Makefile
@@ -17,7 +17,7 @@ $(BIN)/%.a $(BIN)/%.h: $(BIN)/%.generator
 	@mkdir -p $(@D)
 	@$< -g $(notdir $*) -o $(@D) target=$(HL_TARGET)-no_runtime
 
-$(BIN)/runtime_$(HL_TARGET).a: $(BIN)/haar_x.generator
+$(BIN)/runtime_$(HL_TARGET).a: $(GENERATOR_BIN)/haar_x.generator
 	@echo Compiling Halide runtime for target $(HL_TARGET)
 	@mkdir -p $(@D)
 	@$< -r runtime_$(HL_TARGET) -o $(@D) target=$(HL_TARGET)

--- a/apps/wavelet/Makefile
+++ b/apps/wavelet/Makefile
@@ -1,10 +1,5 @@
 include ../support/Makefile.inc
 
-BIN ?= bin
-
-# If HL_TARGET isn't set, use host
-HL_TARGET ?= host
-
 all: test
 
 clean:
@@ -20,12 +15,12 @@ $(BIN)/%.generator: %_generator.cpp $(GENERATOR_DEPS)
 $(BIN)/%.a $(BIN)/%.h: $(BIN)/%.generator
 	@echo Running Generator $<
 	@mkdir -p $(@D)
-	@$< -g $(notdir $*) -o $(BIN) target=$(HL_TARGET)-no_runtime
+	@$< -g $(notdir $*) -o $(@D) target=$(HL_TARGET)-no_runtime
 
 $(BIN)/runtime_$(HL_TARGET).a: $(BIN)/haar_x.generator
 	@echo Compiling Halide runtime for target $(HL_TARGET)
 	@mkdir -p $(@D)
-	@$< -r runtime_$(HL_TARGET) -o $(BIN) target=$(HL_TARGET)
+	@$< -r runtime_$(HL_TARGET) -o $(@D) target=$(HL_TARGET)
 
 HL_MODULES = \
 	$(BIN)/daubechies_x.a \

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -169,8 +169,7 @@ string Pipeline::auto_schedule(const Target &target, const MachineParams &arch_p
     }
 
     user_assert(target.arch == Target::X86 || target.arch == Target::ARM ||
-                target.arch == Target::POWERPC || target.arch == Target::MIPS ||
-                target.arch == Target::WebAssembly)
+                target.arch == Target::POWERPC || target.arch == Target::MIPS)
         << "Automatic scheduling is currently supported only on these architectures.";
     return generate_schedules(contents->outputs, target, arch_params);
 }

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -169,7 +169,8 @@ string Pipeline::auto_schedule(const Target &target, const MachineParams &arch_p
     }
 
     user_assert(target.arch == Target::X86 || target.arch == Target::ARM ||
-                target.arch == Target::POWERPC || target.arch == Target::MIPS)
+                target.arch == Target::POWERPC || target.arch == Target::MIPS ||
+                target.arch == Target::WebAssembly)
         << "Automatic scheduling is currently supported only on these architectures.";
     return generate_schedules(contents->outputs, target, arch_params);
 }


### PR DESCRIPTION
For all the apps that use Makefile.inc:
- remove redundant conditional-defs of BIN and/or HL_TARGET
- build into bin/$HL_TARGET; this allows testing (and benchmarking) for different targets without needing to clean the output
- special-case Generators to always go into bin/host, since they are always host-only regardless of target
- use `$(@D)` for output-directory in many places where appropriate, instead of recapitulating $(BIN) or whatnot
