### PR TITLE
Add Buffer::copy_interleaved()

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -487,7 +487,11 @@ public:
     }
 
     Buffer<T> copy() const {
-        return Buffer<T>(std::move(contents->buf.copy()));
+        return Buffer<T>(std::move(contents->buf.as<T>().copy()));
+    }
+
+    Buffer<T> copy_interleaved() const {
+        return Buffer<T>(std::move(contents->buf.as<T>().copy_interleaved()));
     }
 
     template<typename T2>

--- a/test/correctness/interleave_rgb.cpp
+++ b/test/correctness/interleave_rgb.cpp
@@ -54,6 +54,16 @@ int main(int argc, char **argv) {
     if (!test_interleave<uint16_t>()) return -1;
     if (!test_interleave<uint32_t>()) return -1;
 
+    Buffer<int32_t> planar = Buffer<int32_t>(256, 128, 3);
+    planar.for_each_element([&](int x, int y, int c) { planar(x, y, c) = x * 3 + y * 5 + c * 7; });
+
+    Buffer<int32_t> interleaved = planar.copy_interleaved();
+    assert(interleaved.stride(0) == 3);
+    assert(interleaved.stride(2) == 1);
+    planar.for_each_element([&](int x, int y, int c) {
+        assert(planar(x, y, c) == interleaved(x, y, c));
+    });
+
     printf("Success!\n");
     return 0;
 }


### PR DESCRIPTION
Convenience function for when you have a non-interleaved source and need an interleaved copy, which happens often enough to be worthwhile. Also, a driveby fix to Halide::Buffer::copy(), which apparently wasn't ever being used for non-void Buffers.