### PR TITLE
Add 'const' to C++ backend var decls

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1898,7 +1898,7 @@ string CodeGen_C::print_assignment(Type t, const std::string &rhs) {
     if (cached == cache.end()) {
         id = unique_name('_');
         do_indent();
-        stream << print_type(t, AppendSpace) << id << " = " << rhs << ";\n";
+        stream << print_type(t, AppendSpace) << (output_kind == CPlusPlusImplementation ? "const " : "") << id << " = " << rhs << ";\n";
         cache[rhs] = id;
     } else {
         id = cached->second;


### PR DESCRIPTION
The code we generate is SSA so all declarations should (conceptually) be const; this is an experiment to see if this matters to codegen quality at all. (I would hope not, but it wouldn't be the first time a compiler has surprised me.)