### PR TITLE
Allow halide_print usage from the C++ backend

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2970,7 +2970,8 @@ int test1(struct halide_buffer_t *_buf_buffer, float _alpha, int32_t _beta, void
     char b0[1024];
     snprintf(b0, 1024, "%lld%s", (long long)(3), "\n");
     char const *_7 = b0;
-    int32_t _8 = halide_print(_ucon, _7);
+    halide_print(_ucon, _7);
+    int32_t _8 = 0;
     int32_t _9 = return_second(_8, 3);
     _5 = _9;
    } // if _6


### PR DESCRIPTION
It returns void, which conflicts with its declared IR. (We encountered this recently with msan helpers, and fixed those by making the msan functions actually return int... but as halide_print() is overridden many times downstream, including in third-party Halide users, it's arguably cleaner to just special-case it for the C++ backend.)