### PR TITLE
Augment apps benchmarking rules to work with wasm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,14 @@ else
 	EMCC_SIMD_OPT=0
 endif
 
+ifneq (,$(findstring node,$(WASM_SHELL)))
+	# If 'node' is anywhere in the string, assume Node
+	EMCC_ENVIRONMENT=node
+else
+	# assume d8
+	EMCC_ENVIRONMENT=shell
+endif
+
 # We slurp in the default ~/.emscripten config file and make an altered version
 # with LLVM_ROOT pointing to the LLVM we are using, so that we can build with
 # the 'correct' version (ie the one that the rest of Halide is using) whether
@@ -1571,7 +1579,7 @@ $(BIN_DIR)/$(TARGET)/generator_aotwasm_%.js: $(ROOT_DIR)/test/generator/%_aottes
 	@[[ "$(TARGET)" == "wasm-32-wasmrt"* ]] || (echo "HL_TARGET must begin with wasm-32-wasmrt" && exit 1)
 	@mkdir -p $(@D)
 	@# --source-map-base is just to silence an irrelevant warning from Emscripten
-	EMCC_WASM_BACKEND=1 EM_CONFIG="$(EMCC_CONFIG)" $(EMCC) $(GEN_AOT_CXX_FLAGS_WASM) -s WASM=1 -s SIMD=$(EMCC_SIMD_OPT) -s EXIT_RUNTIME=1 -s ENVIRONMENT=shell --source-map-base . $(filter %.cpp %.o %.a,$^) $(GEN_AOT_INCLUDES) $(GEN_AOT_LD_FLAGS_WASM) -o $@
+	EMCC_WASM_BACKEND=1 EM_CONFIG="$(EMCC_CONFIG)" $(EMCC) $(GEN_AOT_CXX_FLAGS_WASM) -s WASM=1 -s SIMD=$(EMCC_SIMD_OPT) -s EXIT_RUNTIME=1 -s ENVIRONMENT=$(EMCC_ENVIRONMENT) --source-map-base . $(filter %.cpp %.o %.a,$^) $(GEN_AOT_INCLUDES) $(GEN_AOT_LD_FLAGS_WASM) -o $@
 
 $(BIN_DIR)/$(TARGET)/generator_aotwasm_%.wasm: $(BIN_DIR)/$(TARGET)/generator_aotwasm_%.js
 	@# nothing

--- a/Makefile
+++ b/Makefile
@@ -1568,6 +1568,7 @@ GEN_AOT_LD_FLAGS_WASM := $(filter-out -ldl,$(GEN_AOT_LD_FLAGS_WASM))
 GEN_AOT_LD_FLAGS_WASM := $(filter-out -lpthread,$(GEN_AOT_LD_FLAGS_WASM))
 
 $(BIN_DIR)/$(TARGET)/generator_aotwasm_%.js: $(ROOT_DIR)/test/generator/%_aottest.cpp $(FILTERS_DIR)/%.a $(FILTERS_DIR)/%.h $(RUNTIME_EXPORTED_INCLUDES) $(BIN_DIR)/$(TARGET)/runtime.a
+	@[[ "$(TARGET)" == "wasm-32-wasmrt"* ]] || (echo "HL_TARGET must begin with wasm-32-wasmrt" && exit 1)
 	@mkdir -p $(@D)
 	@# --source-map-base is just to silence an irrelevant warning from Emscripten
 	EMCC_WASM_BACKEND=1 EM_CONFIG="$(EMCC_CONFIG)" $(EMCC) $(GEN_AOT_CXX_FLAGS_WASM) -s WASM=1 -s SIMD=$(EMCC_SIMD_OPT) -s EXIT_RUNTIME=1 -s ENVIRONMENT=shell --source-map-base . $(filter %.cpp %.o %.a,$^) $(GEN_AOT_INCLUDES) $(GEN_AOT_LD_FLAGS_WASM) -o $@
@@ -1941,12 +1942,16 @@ BENCHMARK_APPS=\
 	nl_means \
 	stencil_chain
 
+# TODO: we deliberately leave out the `|| exit 1` (for now) when *running*
+# the benchmarks, as some will currently crash at runtime when running in
+# wasm + wasm_simd128 due to a known bug in V8 v7.5
 .PHONY: benchmark_apps
 benchmark_apps: distrib
+	$(eval SUFFIX=$(if $(findstring wasm-32-wasmrt,$(HL_TARGET)),_wasm,))
 	@for APP in $(BENCHMARK_APPS); do \
-		echo Building $${APP}... ; \
+		echo Building $${APP} for ${HL_TARGET}... ; \
 		$(MAKE) -C $(ROOT_DIR)/apps/$${APP} \
-		    $(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin/$(HL_TARGET)/$${APP}.rungen \
+		    $(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin/$(HL_TARGET)/$${APP}.rungen${SUFFIX} \
 			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
 			BIN_DIR=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin \
 			HL_TARGET=$(HL_TARGET) \
@@ -1955,13 +1960,12 @@ benchmark_apps: distrib
 	done
 	@for APP in $(BENCHMARK_APPS); do \
 		echo ;\
-		echo Benchmarking $${APP}... ; \
+		echo Benchmarking $${APP} for ${HL_TARGET}... ; \
 		make -C $(ROOT_DIR)/apps/$${APP} \
-			$${APP}.benchmark \
+			$${APP}.benchmark${SUFFIX} \
 			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
 			BIN_DIR=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin \
-			HL_TARGET=$(HL_TARGET) \
-			|| exit 1 ; \
+			HL_TARGET=$(HL_TARGET) ; \
 	done
 
 .PHONY: test_python2

--- a/README_webassembly.md
+++ b/README_webassembly.md
@@ -99,6 +99,15 @@ The `test_performance` benchmarks are misleading (and thus useless) for Wasm, as
     $ HL_TARGET=wasm-32-wasmrt-wasm_simd128 make benchmark_apps
 ```
 
+Also note that if you run the above on a typical desktop system, you'll find the `host` benchmarks 10x faster (or more) the wasm; this is largely because your desktop likely has multiple cores (and is making use of them), while our Wasm generation doesn't yet support threading. For a fairer comparison, you can limit the maximum number of threads used by Halide by setting the `HL_NUM_THREADS` env var, e.g.
+
+```
+    # benchmark for whatever HL_TARGET is already set to (probably 'host'),
+    # ensuring that we never use more than one thread at a time (regardless of
+    # the number of CPU cores on the host).
+    $ HL_NUM_THREADS=1 make benchmark_apps
+```
+
 # Known Limitations And Caveats
 - We have only tested with EMCC_WASM_BACKEND=1; using the fastcomp backend could possibly be made to work, but we haven't attempted to do so and aren't planning on doing so in the forseeable future. (Patches to enable this would be considered.)
 - Using the JIT requires that we link the `wasm-ld` tool into libHalide; with some work this need could possibly be eliminated.

--- a/README_webassembly.md
+++ b/README_webassembly.md
@@ -83,6 +83,22 @@ If you want to test ahead-of-time code generation (and you almost certainly will
 
 - To run the AOT tests, set `HL_TARGET=wasm-32-wasmrt` and build the `test_aotwasm_generator` target. (Note that the normal AOT tests won't run usefully with this target, as extra logic to run under a wasm-enabled shell is required, and some tests are blacklisted.)
 
+# Running benchmarks
+
+The `test_performance` benchmarks are misleading (and thus useless) for Wasm, as they include JIT overhead as described elsewhere. Instead, you should use `make benchmark_apps`, which will build and run a handful of targets in the `apps/` folder using the standard Halide benchmarking utility. (It is smart enough to special-case when HL_TARGET is set to any `wasm-32-wasmrt` variant.)
+
+```
+    # benchmark for whatever HL_TARGET is already set to (probably 'host')
+    $ make benchmark_apps
+
+    # benchmark for baseline wasm
+    $ HL_TARGET=wasm-32-wasmrt make benchmark_apps
+
+    # benchmark for wasm with SIMD128 (note that some benchmarks will crash when
+    # running with V8 7.5x builds, due to apparently-known bugs)
+    $ HL_TARGET=wasm-32-wasmrt-wasm_simd128 make benchmark_apps
+```
+
 # Known Limitations And Caveats
 - We have only tested with EMCC_WASM_BACKEND=1; using the fastcomp backend could possibly be made to work, but we haven't attempted to do so and aren't planning on doing so in the forseeable future. (Patches to enable this would be considered.)
 - Using the JIT requires that we link the `wasm-ld` tool into libHalide; with some work this need could possibly be eliminated.

--- a/apps/blur/Makefile
+++ b/apps/blur/Makefile
@@ -26,6 +26,6 @@ $(BIN)/%/test: $(BIN)/%/halide_blur.a test.cpp
 clean:
 	rm -rf $(BIN)
 
-# Compile flags here only support 'host' at the moment
-test: $(BIN)/host/test
-	$(BIN)/host/test
+.PHONY: test
+test: $(BIN)/$(HL_TARGET)/test
+	$(BIN)/$(HL_TARGET)/test

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -209,8 +209,10 @@ endif
 
 ifneq (,$(findstring node,$(WASM_SHELL)))
 	EMCC_ENVIRONMENT=node
+	WASM_SHELL_ARG_SEP=
 else
 	EMCC_ENVIRONMENT=shell
+	WASM_SHELL_ARG_SEP="--"
 endif
 
 # We slurp in the default ~/.emscripten config file and make an altered version
@@ -254,4 +256,4 @@ $(BIN)/%.rungen_wasm: $(BIN)/%.rungen.js
 .PHONY: %.benchmark_wasm
 %.benchmark_wasm: $(BIN)/$(HL_TARGET)/%.rungen.js
 	@[[ "$(HL_TARGET)" == "wasm-32-wasmrt"* ]] || (echo "HL_TARGET must begin with wasm-32-wasmrt for target $@" && exit 1)
-	@cd $(<D); $(WASM_SHELL) $(<F) -- --benchmarks=all --default_input_buffers --default_input_scalars --output_extents=estimate --parsable_output
+	@cd $(<D); $(WASM_SHELL) $(<F) $(WASM_SHELL_ARG_SEP) --benchmarks=all --default_input_buffers --default_input_scalars --output_extents=estimate --parsable_output

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -207,7 +207,7 @@ else
 	EMCC_SIMD_OPT=0
 endif
 
-ifeq ($(WASM_SHELL),node)
+ifneq (,$(findstring node,$(WASM_SHELL)))
 	EMCC_ENVIRONMENT=node
 else
 	EMCC_ENVIRONMENT=shell

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -146,16 +146,29 @@ ifneq (, $(findstring metal,$(HL_TARGET)))
   LDFLAGS += -framework Metal -framework Foundation
 endif
 
+# Utility to convert raw video -> h264. HL_AVCONV=ffmpeg will work too.
+HL_AVCONV ?= avconv
+
+# Utility to show h264 video
+HL_VIDEOPLAYER ?= mplayer
+
+# ------- RunGen/Benchmark support
+
+# Really, .SECONDARY is what we want instead of .PRECIOUS (here and elsewhere),
+# but .SECONDARY doesn't accept wildcards
+.PRECIOUS: $(BIN)/%.registration.cpp
 $(BIN)/%.registration.cpp: $(BIN)/%.a
 	@echo $@ produced implicitly by $^
 
+.PRECIOUS: $(BIN)/%/RunGenMain.o
 $(BIN)/%/RunGenMain.o: $(HALIDE_DISTRIB_PATH)/tools/RunGenMain.cpp $(HALIDE_DISTRIB_PATH)/tools/RunGen.h
+	@[[ "$(HL_TARGET)" != "wasm-32-wasmrt"* ]] || (echo "HL_TARGET must NOT begin with wasm-32-wasmrt for target $@" && exit 1)
 	@mkdir -p $(@D)
-	$(CXX) -c $< $(CXXFLAGS) $(IMAGE_IO_CXX_FLAGS) -I$(BIN)/$* -o $@
+	$(CXX) -c $< $(CXXFLAGS) -fno-exceptions $(IMAGE_IO_CXX_FLAGS) -I$(BIN)/$* -o $@
 
-# Really, .SECONDARY is what we want, but it won't accept wildcards
 .PRECIOUS: $(BIN)/%.rungen
 $(BIN)/%.rungen: $(BIN)/%/RunGenMain.o $(BIN)/%.a $(BIN)/%.registration.cpp
+	@[[ "$(HL_TARGET)" != "wasm-32-wasmrt"* ]] || (echo "HL_TARGET must NOT begin with wasm-32-wasmrt for target $@" && exit 1)
 	$(CXX) $(CXXFLAGS) $^ -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
 
 RUNARGS ?=
@@ -164,18 +177,81 @@ RUNARGS ?=
 #
 #     make bin/host/foo.run RUNARGS='input=a output=baz'
 #
+.PHONY: $(BIN)/%.run
 $(BIN)/%.run: $(BIN)/%.rungen
 	@$(CURDIR)/$< $(RUNARGS)
 
 # Also allow 'foo.run' as a shortcut to mean host
+.PHONY: %.run
 %.run: $(BIN)/host/%.rungen
 	@$(CURDIR)/$< $(RUNARGS)
 
-# Utility to convert raw video -> h264. HL_AVCONV=ffmpeg will work too.
-HL_AVCONV ?= avconv
-
-# Utility to show h264 video
-HL_VIDEOPLAYER ?= mplayer
-
+.PHONY: %.benchmark
 %.benchmark: $(BIN)/$(HL_TARGET)/%.rungen
+	@[[ "$(HL_TARGET)" != "wasm-32-wasmrt"* ]] || (echo "HL_TARGET must NOT begin with wasm-32-wasmrt for target $@" && exit 1)
 	@$^ --benchmarks=all --default_input_buffers --default_input_scalars --output_extents=estimate --parsable_output
+
+# ------- wasm support
+
+# EMCC is the tool that invokes Emscripten
+EMCC ?= emcc
+
+# WASM_SHELL is the shell tool used to run AOT-compiled WebAssembly.
+# (Node could be used instead.)
+WASM_SHELL ?= d8
+
+ifneq (,$(findstring wasm_simd128,$(HL_TARGET)))
+	EMCC_SIMD_OPT=1
+	WASM_SHELL += --experimental-wasm-simd
+else
+	EMCC_SIMD_OPT=0
+endif
+
+ifeq ($(WASM_SHELL),node)
+	EMCC_ENVIRONMENT=node
+else
+	EMCC_ENVIRONMENT=shell
+endif
+
+# We slurp in the default ~/.emscripten config file and make an altered version
+# with LLVM_ROOT pointing to the LLVM we are using, so that we can build with
+# the 'correct' version (ie the one that the rest of Halide is using) whether
+# or not ~/.emscripten has been edited correctly.
+LLVM_CONFIG ?= llvm-config
+LLVM_BINDIR = $(shell $(LLVM_CONFIG) --bindir | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):/\/\1/g')
+EMCC_CONFIG = $(shell cat $(HOME)/.emscripten | grep -v LLVM_ROOT | tr '\n' ';')LLVM_ROOT='$(LLVM_BINDIR)'
+
+# Note that USE_LIBJPEG requires Emscripten 1.38.31 or later
+EMCC_OPTS = \
+	--source-map-base . \
+	-s ALLOW_MEMORY_GROWTH=1 \
+	-s ASSERTIONS=1 \
+	-s ENVIRONMENT=$(EMCC_ENVIRONMENT) \
+	-s EXIT_RUNTIME=1 \
+	-s FORCE_FILESYSTEM=1 \
+	-s SIMD=$(EMCC_SIMD_OPT) \
+	-s USE_LIBPNG=1 \
+	-s USE_LIBJPEG=1 \
+	-s WASM=1
+
+CXX-WASM = EMCC_WASM_BACKEND=1 EM_CONFIG="$(EMCC_CONFIG)" $(EMCC) $(EMCC_OPTS)
+
+.PRECIOUS: $(BIN)/%/RunGenMainWasm.o
+$(BIN)/%/RunGenMainWasm.o: $(HALIDE_DISTRIB_PATH)/tools/RunGenMain.cpp $(HALIDE_DISTRIB_PATH)/tools/RunGen.h
+	@[[ "$(HL_TARGET)" == "wasm-32-wasmrt"* ]] || (echo "HL_TARGET must begin with wasm-32-wasmrt" && exit 1)
+	@mkdir -p $(@D)
+	$(CXX-WASM) -c $< $(CXXFLAGS) -fno-exceptions -I$(BIN)/$* -o $@
+
+.PRECIOUS: $(BIN)/%.rungen.js
+$(BIN)/%.rungen.js: $(BIN)/%/RunGenMainWasm.o $(BIN)/%.a $(BIN)/%.registration.cpp
+	@[[ "$(HL_TARGET)" == "wasm-32-wasmrt"* ]] || (echo "HL_TARGET must begin with wasm-32-wasmrt for target $@" && exit 1)
+	$(CXX-WASM) $(CXXFLAGS) -g $^ -o $@
+
+.PHONY: $(BIN)/%.rungen_wasm
+$(BIN)/%.rungen_wasm: $(BIN)/%.rungen.js
+	# nothing
+
+.PHONY: %.benchmark_wasm
+%.benchmark_wasm: $(BIN)/$(HL_TARGET)/%.rungen.js
+	@[[ "$(HL_TARGET)" == "wasm-32-wasmrt"* ]] || (echo "HL_TARGET must begin with wasm-32-wasmrt for target $@" && exit 1)
+	@cd $(<D); $(WASM_SHELL) $(<F) -- --benchmarks=all --default_input_buffers --default_input_scalars --output_extents=estimate --parsable_output

--- a/tools/halide_benchmark.h
+++ b/tools/halide_benchmark.h
@@ -43,11 +43,13 @@ inline double benchmark_duration_seconds(
 // Emscripten's std::chrono::steady_clock and/or high_resolution_clock
 // can throw an exception (!) if the runtime doesn't have a truly
 // steady clock available. Advice from emscripten-discuss suggested
-// that performance.now() is the best bet, as it is milliseconds-since-page-load
-// (but returned as a double, with microseconds in the fractional portion).
-EM_JS(double, benchmark_now, (void), {
-    return performance.now();
-});
+// that emscripten_get_now() is the best bet, as it is milliseconds
+// (but returned as a double, with microseconds in the fractional portion),
+// using either performance.now() or performance.hrtime() depending on the
+// environment.
+inline double benchmark_now() {
+    return emscripten_get_now();
+}
 
 inline double benchmark_duration_seconds(double start, double end) {
     return (end - start) / 1000.0;


### PR DESCRIPTION
Added rules to apps/Makefile.inc to provide `benchmark_wasm` targets; the toplevel `make benchmark_apps` now knows how to sniff `HL_TARGET` and run these appropriately.