### PR TITLE
Fix exceptions test

### DIFF
--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -240,6 +240,10 @@ void Parameter::set_min_value(Expr e) {
             << " of type " << contents->type
             << " to have min value " << e
             << " of type " << e.type() << "\n";
+
+        user_assert(is_const(e))
+            << "Min value for parameter " << name()
+            << " must be constant: " << e << "\n";
     }
     contents->scalar_min = e;
 }
@@ -257,6 +261,10 @@ void Parameter::set_max_value(Expr e) {
             << " of type " << contents->type
             << " to have max value " << e
             << " of type " << e.type() << "\n";
+
+        user_assert(is_const(e))
+            << "Max value for parameter " << name()
+            << " must be constant: " << e << "\n";
     }
     contents->scalar_max = e;
 }

--- a/test/correctness/exception.cpp
+++ b/test/correctness/exception.cpp
@@ -81,33 +81,6 @@ int main(int argc, char **argv) {
     check_error(error);
     check_pure(f1);
 
-    // Now an error that won't trigger until we try to actually compile.
-    ImageParam im(Float(32), 1);
-    Func f2;
-    f2(x) = im(x) * 2.0f;
-    try {
-        error = false;
-        f2.realize(10);
-    } catch (const Halide::CompileError &e) {
-        error = true;
-        std::cout << "Expected compile error:\n" << e.what() << "\n";
-    }
-    check_error(error);
-    // Oops, forgot to bind im. Lets try again:
-    Buffer<float> an_image(10);
-    lambda(x, x*7.0f).realize(an_image);
-    im.set(an_image);
-    Buffer<float> result = f2.realize(10);
-    for (size_t i = 0; i < 10; i++) {
-        float correct = i * 14.0f;
-        if (result(i) != correct) {
-            std::cout << "result(" << i
-                      << ") = " << result(i)
-                      << " instead of " << correct << "\n";
-            return -1;
-        }
-    }
-
     // Now do some things that count as internal errors
     try {
         error = false;
@@ -129,26 +102,37 @@ int main(int argc, char **argv) {
     check_error(error);
 
     // Now some runtime errors
+    ImageParam im(Float(32), 1);
+    Func f2;
+    f2(x) = im(x) * 2.0f;
     try {
         error = false;
-        Func f3;
-        f3(x) = x;
-        f3.vectorize(x, 8);
-        Buffer<int> result = f3.realize(4);
+        f2.realize(10);
     } catch (const Halide::RuntimeError &e) {
         error = true;
         std::cout << "Expected runtime error:\n" << e.what() << "\n";
     }
     check_error(error);
+    // Oops, forgot to bind im. Lets try again:
+    Buffer<float> an_image(10);
+    lambda(x, x*7.0f).realize(an_image);
+    im.set(an_image);
+    Buffer<float> result = f2.realize(10);
+    for (size_t i = 0; i < 10; i++) {
+        float correct = i * 14.0f;
+        if (result(i) != correct) {
+            std::cout << "result(" << i
+                      << ") = " << result(i)
+                      << " instead of " << correct << "\n";
+            return -1;
+        }
+    }
 
     try {
         error = false;
-        Param<int> p_min, p_max;
         Param<int> p;
-        p.set_range(p_min, p_max);
+        p.set_range(0, 10);
         p.set(-4);
-        p_min.set(-3);
-        p_max.set(5);
         Func f4;
         f4(x) = p;
         f4.realize(10);


### PR DESCRIPTION
The exceptions test had rotted because we don't have any buildbots with WITH_EXCEPTIONS on.

1) CodeGen_LLVM assumes that the min and max values for parameters are constants (they get embedded in metadata), but this was not checked, resulting in an internal error instead of a user error

2) Realizing into a too-small image is soon to be not-an-error

3) Realizing into an unbound image param is now caught as a runtime error (passing null as a buffer_t arg)