### PR TITLE
Rungen binary size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1662,7 +1662,7 @@ test_generator_nested_externs:
 
 $(BUILD_DIR)/RunGenMain.o: $(ROOT_DIR)/tools/RunGenMain.cpp $(RUNTIME_EXPORTED_INCLUDES) $(ROOT_DIR)/tools/RunGen.h
 	@mkdir -p $(@D)
-	$(CXX) -c $< $(TEST_CXX_FLAGS) $(OPTIMIZE) $(IMAGE_IO_CXX_FLAGS) -I$(INCLUDE_DIR) -I $(SRC_DIR)/runtime -I$(ROOT_DIR)/tools -o $@
+	$(CXX) -c $< $(filter-out -g, $(TEST_CXX_FLAGS)) $(OPTIMIZE) $(IMAGE_IO_CXX_FLAGS) -I$(INCLUDE_DIR) -I $(SRC_DIR)/runtime -I$(ROOT_DIR)/tools -o $@
 
 $(FILTERS_DIR)/%.registration.o: $(FILTERS_DIR)/%.registration.cpp
 	@mkdir -p $(@D)

--- a/Makefile
+++ b/Makefile
@@ -1662,7 +1662,7 @@ test_generator_nested_externs:
 
 $(BUILD_DIR)/RunGenMain.o: $(ROOT_DIR)/tools/RunGenMain.cpp $(RUNTIME_EXPORTED_INCLUDES) $(ROOT_DIR)/tools/RunGen.h
 	@mkdir -p $(@D)
-	$(CXX) -c $< $(filter-out -g, $(TEST_CXX_FLAGS)) $(OPTIMIZE) $(IMAGE_IO_CXX_FLAGS) -I$(INCLUDE_DIR) -I $(SRC_DIR)/runtime -I$(ROOT_DIR)/tools -o $@
+	$(CXX) -c $< $(filter-out -g, $(TEST_CXX_FLAGS)) $(OPTIMIZE) -Os $(IMAGE_IO_CXX_FLAGS) -I$(INCLUDE_DIR) -I $(SRC_DIR)/runtime -I$(ROOT_DIR)/tools -o $@
 
 $(FILTERS_DIR)/%.registration.o: $(FILTERS_DIR)/%.registration.cpp
 	@mkdir -p $(@D)

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1966,8 +1966,6 @@ private:
     HALIDE_NEVER_INLINE
     static void for_each_value_helper(Fn &&f, int d, bool innermost_strides_are_one,
                                       const for_each_value_task_dim<sizeof...(Ptrs)> *t, Ptrs... ptrs) {
-        // When we hit a low dimensionality, switch from runtime
-        // recursion to template recursion.
         if (d == -1) {
             f((*ptrs)...);
         } else if (d == 0) {

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1848,15 +1848,9 @@ private:
 public:
 
     /** Get a pointer to the address of the min coordinate. */
-    // @{
-    T *data() {
+    T *data() const {
         return (T *)(this->buf.host);
     }
-
-    const T *data() const {
-        return (const T *)(this->buf.host);
-    }
-    // @}
 
     /** Access elements. Use im(...) to get a reference to an element,
      * and use &im(...) to get the address of an element. If you pass
@@ -1948,89 +1942,72 @@ private:
     // (all of different types), advance the pointers using the
     // strides.
     template<typename Ptr, typename ...Ptrs>
+    HALIDE_ALWAYS_INLINE
     static void advance_ptrs(const int *stride, Ptr *ptr, Ptrs... ptrs) {
         (*ptr) += *stride;
         advance_ptrs(stride + 1, ptrs...);
     }
 
+    HALIDE_ALWAYS_INLINE
     static void advance_ptrs(const int *) {}
 
     // Same as the above, but just increments the pointers.
     template<typename Ptr, typename ...Ptrs>
+    HALIDE_ALWAYS_INLINE
     static void increment_ptrs(Ptr *ptr, Ptrs... ptrs) {
         (*ptr)++;
         increment_ptrs(ptrs...);
     }
 
+    HALIDE_ALWAYS_INLINE
     static void increment_ptrs() {}
 
-    // Given a bunch of pointers to buffers of different types, read
-    // out their strides in the d'th dimension, and assert that their
-    // sizes match in that dimension.
-    template<typename T2, int D2, typename ...Args>
-    void extract_strides(int d, int *strides, const Buffer<T2, D2> &first, Args&&... rest) const {
-        assert(first.dimensions() == dimensions());
-        assert(first.dim(d).min() == dim(d).min() &&
-               first.dim(d).max() == dim(d).max());
-        *strides++ = first.dim(d).stride();
-        extract_strides(d, strides, std::forward<Args>(rest)...);
-    }
-
-    void extract_strides(int d, int *strides) const {}
-
-    // The template function that constructs the loop nest for for_each_value
-    template<int d, bool innermost_strides_are_one, typename Fn, typename... Ptrs>
-    static void for_each_value_helper(Fn &&f, const for_each_value_task_dim<sizeof...(Ptrs)> *t, Ptrs... ptrs) {
-        if (d == -1) {
-            f((*ptrs)...);
-        } else {
-            for (int i = t[d].extent; i != 0; i--) {
-                for_each_value_helper<(d >= 0 ? d - 1 : -1), innermost_strides_are_one>(f, t, ptrs...);
-                if (d == 0 && innermost_strides_are_one) {
-                    // It helps with auto-vectorization to statically
-                    // know the addresses are one apart in memory.
-                    increment_ptrs((&ptrs)...);
-                } else {
-                    advance_ptrs(t[d].stride, (&ptrs)...);
-                }
-            }
-        }
-    }
-
-    template<bool innermost_strides_are_one, typename Fn, typename... Ptrs>
-    static void for_each_value_helper(Fn &&f, int d, const for_each_value_task_dim<sizeof...(Ptrs)> *t, Ptrs... ptrs) {
+    template<typename Fn, typename... Ptrs>
+    HALIDE_NEVER_INLINE
+    static void for_each_value_helper(Fn &&f, int d, bool innermost_strides_are_one,
+                                      const for_each_value_task_dim<sizeof...(Ptrs)> *t, Ptrs... ptrs) {
         // When we hit a low dimensionality, switch from runtime
         // recursion to template recursion.
+        asm volatile ("# Hi");
         if (d == -1) {
-            for_each_value_helper<-1, innermost_strides_are_one>(f, t, ptrs...);
+            f((*ptrs)...);
         } else if (d == 0) {
-            for_each_value_helper<0, innermost_strides_are_one>(f, t, ptrs...);
-        } else if (d == 1) {
-            for_each_value_helper<1, innermost_strides_are_one>(f, t, ptrs...);
-        } else if (d == 2) {
-            for_each_value_helper<2, innermost_strides_are_one>(f, t, ptrs...);
+            if (innermost_strides_are_one) {
+                for (int i = t[0].extent; i != 0; i--) {
+                    f((*ptrs)...);
+                    increment_ptrs((&ptrs)...);
+                }
+            } else {
+                for (int i = t[0].extent; i != 0; i--) {
+                    f((*ptrs)...);
+                    advance_ptrs(t[0].stride, (&ptrs)...);
+                }
+            }
         } else {
             for (int i = t[d].extent; i != 0; i--) {
-                for_each_value_helper<innermost_strides_are_one>(f, d-1, t, ptrs...);
+                for_each_value_helper(f, d-1, innermost_strides_are_one, t, ptrs...);
                 advance_ptrs(t[d].stride, (&ptrs)...);
             }
         }
     }
 
-    template<typename Fn, typename ...Args, int N = sizeof...(Args) + 1>
-    void for_each_value_impl(Fn &&f, Args&&... other_buffers) const {
-        for_each_value_task_dim<N> *t =
-            (for_each_value_task_dim<N> *)HALIDE_ALLOCA((dimensions()+1) * sizeof(for_each_value_task_dim<N>));
-        for (int i = 0; i <= dimensions(); i++) {
-            for (int j = 0; j < N; j++) {
-                t[i].stride[j] = 0;
-            }
-            t[i].extent = 1;
-        }
+    template<int N>
+    HALIDE_NEVER_INLINE
+    static bool for_each_value_prep(for_each_value_task_dim<N> *t,
+                                    const halide_buffer_t **buffers) {
+        const int dimensions = buffers[0]->dimensions;
 
-        for (int i = 0; i < dimensions(); i++) {
-            extract_strides(i, t[i].stride, *this, std::forward<Args>(other_buffers)...);
-            t[i].extent = dim(i).extent();
+        // Extract the strides in all the dimensions
+        for (int i = 0; i < dimensions; i++) {
+            for (int j = 0; j < N; j++) {
+                assert(buffers[j]->dimensions == dimensions);
+                assert(buffers[j]->dim[i].extent == buffers[0]->dim[i].extent &&
+                       buffers[j]->dim[i].min == buffers[0]->dim[i].min);
+                const int s = buffers[j]->dim[i].stride;
+                t[i].stride[j] = s;
+            }
+            t[i].extent = buffers[0]->dim[i].extent;
+
             // Order the dimensions by stride, so that the traversal is cache-coherent.
             for (int j = i; j > 0 && t[j].stride[0] < t[j-1].stride[0]; j--) {
                 std::swap(t[j], t[j-1]);
@@ -2039,7 +2016,7 @@ private:
 
         // flatten dimensions where possible to make a larger inner
         // loop for autovectorization.
-        int d = dimensions();
+        int d = dimensions;
         for (int i = 1; i < d; i++) {
             bool flat = true;
             for (int j = 0; j < N; j++) {
@@ -2047,27 +2024,38 @@ private:
             }
             if (flat) {
                 t[i-1].extent *= t[i].extent;
-                for (int j = i; j < dimensions(); j++) {
+                for (int j = i; j < d; j++) {
                     t[j] = t[j+1];
                 }
                 i--;
                 d--;
+                t[d].extent = 1;
             }
         }
 
-        bool innermost_strides_are_one = false;
-        if (dimensions() > 0) {
-            innermost_strides_are_one = true;
-            for (int j = 0; j < N; j++) {
-                innermost_strides_are_one &= t[0].stride[j] == 1;
+        bool innermost_strides_are_one = true;
+        if (dimensions > 0) {
+            for (int i = 0; i < N; i++) {
+                innermost_strides_are_one &= (t[0].stride[i] == 1);
             }
         }
 
-        if (innermost_strides_are_one) {
-            for_each_value_helper<true>(f, dimensions() - 1, t, begin(), (other_buffers.begin())...);
-        } else {
-            for_each_value_helper<false>(f, dimensions() - 1, t, begin(), (other_buffers.begin())...);
-        }
+        return innermost_strides_are_one;
+    }
+
+    template<typename Fn, typename ...Args, int N = sizeof...(Args) + 1>
+    void for_each_value_impl(Fn &&f, Args&&... other_buffers) const {
+        Buffer<>::for_each_value_task_dim<N> *t =
+        (Buffer<>::for_each_value_task_dim<N> *)HALIDE_ALLOCA((dimensions()+1) * sizeof(for_each_value_task_dim<N>));
+        // Move the preparatory code into a non-templated helper to
+        // save code size.
+        const halide_buffer_t *buffers[] = {&buf, (&other_buffers.buf)...};
+        bool innermost_strides_are_one = Buffer<>::for_each_value_prep(t, buffers);
+
+        Buffer<>::for_each_value_helper(f, dimensions() - 1,
+                                        innermost_strides_are_one,
+                                        t,
+                                        data(), (other_buffers.data())...);
     }
     // @}
 

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1968,7 +1968,6 @@ private:
                                       const for_each_value_task_dim<sizeof...(Ptrs)> *t, Ptrs... ptrs) {
         // When we hit a low dimensionality, switch from runtime
         // recursion to template recursion.
-        asm volatile ("# Hi");
         if (d == -1) {
             f((*ptrs)...);
         } else if (d == 0) {


### PR DESCRIPTION
Get rungen binary size down to 1MB by optimizing for size, and moving some templated code in Runtime::Buffer into non-templated helper methods.