### PR TITLE
Add required sed to process msys2/mingw windows path slashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ LLVM_STATIC_LIBFILES = \
 	$(WEBASSEMBLY_LLVM_CONFIG_LIB) \
 	$(RISCV_LLVM_CONFIG_LIB)
 
-LLVM_STATIC_LIBS = -L $(LLVM_LIBDIR) $(shell $(LLVM_CONFIG) --link-static --libfiles $(LLVM_STATIC_LIBFILES))
+LLVM_STATIC_LIBS = -L $(LLVM_LIBDIR) $(shell $(LLVM_CONFIG) --link-static --libfiles $(LLVM_STATIC_LIBFILES) | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):/\/\1/g')
 
 ifneq ($(WITH_V8), )
 # TODO: apparently no llvm_config flag to get canonical paths to tools


### PR DESCRIPTION
Not sure why your builds are passing but I think those changes are really needed to fix msys2/mingw windows paths.
They are copy pasted from few lines above where llvm-config is called.
Blaming this line seems that it's a relatively recent merge from wasm changes.

Cheers!