### PR TITLE
Take padding bytes into consideration when writing .mat files

### DIFF
--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -1,3 +1,5 @@
+#include <fstream>
+
 #include "Halide.h"
 #include "halide_image_io.h"
 #include "test/common/halide_test_dirs.h"
@@ -224,8 +226,38 @@ void do_test() {
     }
 }
 
+void test_mat_header() {
+    // Test if the .mat file header writes the correct file size
+    std::ostringstream o;
+    Buffer<uint8_t> buf(15, 15);
+    buf.fill(42);
+    o << Internal::get_test_tmp_dir() << "test_mat_header.mat";
+    std::string filename = o.str();
+    Tools::save_image(buf, filename);
+    std::ifstream fs(filename.c_str(), std::ifstream::binary);
+    if (!fs) {
+        std::cout << "Cannot read " << filename << std::endl;
+        abort();
+    }
+    fs.seekg(0, fs.end);
+    // .mat file begins with a 128 bytes header and a 8 bytes 
+    // matrix tag, the second byte of the matrix describe
+    // the size of the rest of the file
+    uint32_t file_size = uint32_t((int)fs.tellg() - 128 - 8);
+    fs.seekg(128 + 4, fs.beg);
+    uint32_t stored_file_size = 0;
+    fs.read((char*)&stored_file_size, 4);
+    fs.close();
+    if (file_size != stored_file_size) {
+        std::cout << "Wrong file size written for " << filename << ". Expected " <<
+            file_size << ", got" << stored_file_size << std::endl;
+        abort();
+    } 
+}
+
 int main(int argc, char **argv) {
     do_test<uint8_t>();
     do_test<uint16_t>();
+    test_mat_header();
     return 0;
 }

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -1245,9 +1245,11 @@ bool save_mat(ImageType &im, const std::string &filename) {
     }
     int padded_dims = dims + (dims & 1);
 
+    uint32_t padding_bytes = 7 - ((payload_bytes - 1) & 7);
+
     // Matrix header
     uint32_t matrix_header[2] = {
-        miMATRIX, 40 + padded_dims * 4 + (uint32_t)name.size() + (uint32_t)payload_bytes
+        miMATRIX, 40 + padded_dims * 4 + (uint32_t)name.size() + (uint32_t)payload_bytes + padding_bytes
     };
 
     // Array flags
@@ -1274,8 +1276,6 @@ bool save_mat(ImageType &im, const std::string &filename) {
     uint32_t name_header[2] = {
         miINT8, name_size
     };
-
-    uint32_t padding_bytes = 7 - ((payload_bytes - 1) & 7);
 
     // Payload header
     uint32_t payload_header[2] = {


### PR DESCRIPTION
The current Tools::save_image() function has a bug when writing .mat files, when the array's size does not end at 64-bit boundary and requires padding. It does not take the padding bytes into consideration when computing file size, causing Matlab to fail the read the file (the round trip test in Halide is working fine since we ignore the file size). This patch fixes this and adds a test to check the file size.