### PR TITLE
Add GENERATOR_OUTPUTS var to apps/ Makefiles

### DIFF
--- a/apps/auto_viz/Makefile
+++ b/apps/auto_viz/Makefile
@@ -16,6 +16,7 @@ define GEN_RULES
 $$(BIN)/%/auto_viz_demo_$(1)_up.a: $$(GENERATOR_BIN)/auto_viz_demo.generator
 	@mkdir -p $$(@D)
 	$$^ -g auto_viz_demo -o $$(@D) -f auto_viz_demo_$(1)_up \
+		-e $$(GENERATOR_OUTPUTS) \
 		target=$$*-no_runtime-trace_all \
 		schedule_type=$$$$(echo $(1) | cut -d_ -f1) \
 		upsample=true
@@ -23,6 +24,7 @@ $$(BIN)/%/auto_viz_demo_$(1)_up.a: $$(GENERATOR_BIN)/auto_viz_demo.generator
 $$(BIN)/%/auto_viz_demo_$(1)_down.a: $$(GENERATOR_BIN)/auto_viz_demo.generator
 	@mkdir -p $$(@D)
 	$$^ -g auto_viz_demo -o $$(@D) -f auto_viz_demo_$(1)_down \
+		-e $$(GENERATOR_OUTPUTS) \
 		target=$$*-no_runtime-trace_all \
 		schedule_type=$$$$(echo $(1) | cut -d_ -f1) \
 		upsample=false

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -8,11 +8,11 @@ $(GENERATOR_BIN)/bilateral_grid.generator: bilateral_grid_generator.cpp $(GENERA
 
 $(BIN)/%/bilateral_grid.a: $(GENERATOR_BIN)/bilateral_grid.generator
 	@mkdir -p $(@D)
-	$^ -g bilateral_grid -o $(@D) -f bilateral_grid target=$* auto_schedule=false
+	$^ -g bilateral_grid -e $(GENERATOR_OUTPUTS) -o $(@D) -f bilateral_grid target=$* auto_schedule=false
 
 $(BIN)/%/bilateral_grid_auto_schedule.a: $(GENERATOR_BIN)/bilateral_grid.generator
 	@mkdir -p $(@D)
-	$^ -g bilateral_grid -o $(@D) -f bilateral_grid_auto_schedule target=$*-no_runtime auto_schedule=true -e static_library,h,schedule
+	$^ -g bilateral_grid -e $(GENERATOR_OUTPUTS) -o $(@D) -f bilateral_grid_auto_schedule target=$*-no_runtime auto_schedule=true -e static_library,h,schedule
 
 $(BIN)/%/filter: filter.cpp $(BIN)/%/bilateral_grid.a $(BIN)/%/bilateral_grid_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/blur/Makefile
+++ b/apps/blur/Makefile
@@ -8,7 +8,7 @@ $(GENERATOR_BIN)/halide_blur.generator: halide_blur_generator.cpp $(GENERATOR_DE
 
 $(BIN)/%/halide_blur.a: $(GENERATOR_BIN)/halide_blur.generator
 	@mkdir -p $(@D)
-	$^ -g halide_blur -o $(@D) target=$*
+	$^ -g halide_blur -e $(GENERATOR_OUTPUTS) -o $(@D) target=$*
 
 # g++ on OS X might actually be system clang without openmp
 CXX_VERSION=$(shell $(CXX) --version)

--- a/apps/c_backend/Makefile
+++ b/apps/c_backend/Makefile
@@ -12,7 +12,7 @@ $(GENERATOR_BIN)/pipeline.generator: pipeline_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/%/pipeline_native.a: $(GENERATOR_BIN)/pipeline.generator
 	@mkdir -p $(@D)
-	$^ -g pipeline -o $(@D) -f pipeline_native -e static_library,h target=$*
+	$^ -g pipeline -o $(@D) -f pipeline_native -e $(GENERATOR_OUTPUTS) target=$*
 
 $(BIN)/%/pipeline_c.cpp: $(GENERATOR_BIN)/pipeline.generator
 	@mkdir -p $(@D)
@@ -31,7 +31,7 @@ $(BIN)/%/pipeline_cpp_cpp.cpp: $(GENERATOR_BIN)/pipeline_cpp.generator
 
 $(BIN)/%/pipeline_cpp_native.a: $(GENERATOR_BIN)/pipeline_cpp.generator
 	@mkdir -p $(@D)
-	$^ -g pipeline_cpp -o $(@D) -f pipeline_cpp_native -e static_library,h target=host-c_plus_plus_name_mangling
+	$^ -g pipeline_cpp -o $(@D) -f pipeline_cpp_native -e $(GENERATOR_OUTPUTS) target=host-c_plus_plus_name_mangling
 
 $(BIN)/%/run_cpp: run_cpp.cpp $(BIN)/%/pipeline_cpp_cpp.cpp $(BIN)/%/pipeline_cpp_native.a
 	$(CXX) $(CXXFLAGS) -Wall -I$(BIN)/$* $(filter-out %.h,$^) -o $@  $(LDFLAGS)

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -10,11 +10,11 @@ $(GENERATOR_BIN)/camera_pipe.generator: camera_pipe_generator.cpp $(GENERATOR_DE
 
 $(BIN)/%/camera_pipe.a: $(GENERATOR_BIN)/camera_pipe.generator
 	@mkdir -p $(@D)
-	$^ -g camera_pipe -o $(@D) -f camera_pipe target=$* auto_schedule=false
+	$^ -g camera_pipe -e $(GENERATOR_OUTPUTS) -o $(@D) -f camera_pipe target=$* auto_schedule=false
 
 $(BIN)/%/camera_pipe_auto_schedule.a: $(GENERATOR_BIN)/camera_pipe.generator
 	@mkdir -p $(@D)
-	$^ -g camera_pipe -o $(@D) -f camera_pipe_auto_schedule target=$*-no_runtime auto_schedule=true
+	$^ -g camera_pipe -e $(GENERATOR_OUTPUTS) -o $(@D) -f camera_pipe_auto_schedule target=$*-no_runtime auto_schedule=true
 
 $(BIN)/%/process: process.cpp $(BIN)/%/camera_pipe.a $(BIN)/%/camera_pipe_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/conv_layer/Makefile
+++ b/apps/conv_layer/Makefile
@@ -8,11 +8,11 @@ $(GENERATOR_BIN)/conv_layer.generator: conv_layer_generator.cpp $(GENERATOR_DEPS
 
 $(BIN)/%/conv_layer.a: $(GENERATOR_BIN)/conv_layer.generator
 	@mkdir -p $(@D)
-	$^ -g conv_layer -o $(@D) -f conv_layer target=$* auto_schedule=false
+	$^ -g conv_layer -e $(GENERATOR_OUTPUTS) -o $(@D) -f conv_layer target=$* auto_schedule=false
 
 $(BIN)/%/conv_layer_auto_schedule.a: $(GENERATOR_BIN)/conv_layer.generator
 	@mkdir -p $(@D)
-	$^ -g conv_layer -o $(@D) -f conv_layer_auto_schedule target=$*-no_runtime auto_schedule=true
+	$^ -g conv_layer -e $(GENERATOR_OUTPUTS) -o $(@D) -f conv_layer_auto_schedule target=$*-no_runtime auto_schedule=true
 
 $(BIN)/%/process: process.cpp $(BIN)/%/conv_layer.a $(BIN)/%/conv_layer_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/cuda_mat_mul/Makefile
+++ b/apps/cuda_mat_mul/Makefile
@@ -15,7 +15,7 @@ $(GENERATOR_BIN)/mat_mul.generator: mat_mul_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/%/mat_mul.a: $(GENERATOR_BIN)/mat_mul.generator
 	@mkdir -p $(@D)
-	$^ -g mat_mul -o $(@D) target=host-cuda-cuda_capability_50 size=$(MATRIX_SIZE)
+	$^ -g mat_mul -e $(GENERATOR_OUTPUTS) -o $(@D) target=host-cuda-cuda_capability_50 size=$(MATRIX_SIZE)
 
 $(BIN)/%/runner: runner.cpp $(BIN)/%/mat_mul.a
 	@mkdir -p $(@D)

--- a/apps/fft/Makefile
+++ b/apps/fft/Makefile
@@ -40,19 +40,19 @@ $(GENERATOR_BIN)/fft.generator: fft_generator.cpp fft.cpp fft.h $(GENERATOR_DEPS
 # Generate four AOT compiled FFT variants. Forward versions have gain set to 1 / 256.0
 $(BIN)/%/fft_forward_r2c.a: $(GENERATOR_BIN)/fft.generator
 	@mkdir -p $(@D)
-	$^ -g fft -o $(@D) -f fft_forward_r2c target=$* direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=real output_number_type=complex
+	$^ -g fft -e $(GENERATOR_OUTPUTS) -o $(@D) -f fft_forward_r2c target=$* direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=real output_number_type=complex
 
 $(BIN)/%/fft_inverse_c2r.a: $(GENERATOR_BIN)/fft.generator
 	@mkdir -p $(@D)
-	$^ -g fft -o $(@D) -f fft_inverse_c2r target=$* direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=real
+	$^ -g fft -e $(GENERATOR_OUTPUTS) -o $(@D) -f fft_inverse_c2r target=$* direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=real
 
 $(BIN)/%/fft_forward_c2c.a: $(GENERATOR_BIN)/fft.generator
 	@mkdir -p $(@D)
-	$^ -g fft -o $(@D) -f fft_forward_c2c target=$* direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=complex output_number_type=complex
+	$^ -g fft -e $(GENERATOR_OUTPUTS) -o $(@D) -f fft_forward_c2c target=$* direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=complex output_number_type=complex
 
 $(BIN)/%/fft_inverse_c2c.a: $(GENERATOR_BIN)/fft.generator
 	@mkdir -p $(@D)
-	$^ -g fft -o $(@D) -f fft_inverse_c2c target=$* direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=complex
+	$^ -g fft -e $(GENERATOR_OUTPUTS) -o $(@D) -f fft_inverse_c2c target=$* direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=complex
 
 $(BIN)/%/fft_aot_test: fft_aot_test.cpp $(BIN)/%/fft_forward_r2c.a $(BIN)/%/fft_inverse_c2r.a $(BIN)/%/fft_forward_c2c.a $(BIN)/%/fft_inverse_c2c.a
 	@mkdir -p $(@D)

--- a/apps/glsl/Makefile
+++ b/apps/glsl/Makefile
@@ -12,7 +12,7 @@ $(GENERATOR_BIN)/halide_blur_glsl.generator: halide_blur_glsl_generator.cpp $(GE
 
 $(BIN)/%/halide_blur_glsl.a: $(GENERATOR_BIN)/halide_blur_glsl.generator
 	@mkdir -p $(@D)
-	$^ -g halide_blur_glsl -o $(@D) target=$*-opengl-debug
+	$^ -g halide_blur_glsl -e $(GENERATOR_OUTPUTS) -o $(@D) target=$*-opengl-debug
 
 $(GENERATOR_BIN)/halide_ycc_glsl.generator: halide_ycc_glsl_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
@@ -20,7 +20,7 @@ $(GENERATOR_BIN)/halide_ycc_glsl.generator: halide_ycc_glsl_generator.cpp $(GENE
 
 $(BIN)/%/halide_ycc_glsl.a: $(GENERATOR_BIN)/halide_ycc_glsl.generator
 	@mkdir -p $(@D)
-	$^ -g halide_ycc_glsl -o $(@D) target=$*-opengl-debug
+	$^ -g halide_ycc_glsl -e $(GENERATOR_OUTPUTS) -o $(@D) target=$*-opengl-debug
 
 $(BIN)/%/opengl_test: opengl_test.cpp $(BIN)/%/halide_blur_glsl.a $(BIN)/%/halide_ycc_glsl.a
 	@mkdir -p $(@D)

--- a/apps/lens_blur/Makefile
+++ b/apps/lens_blur/Makefile
@@ -9,11 +9,11 @@ $(GENERATOR_BIN)/lens_blur.generator: lens_blur_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/%/lens_blur.a: $(GENERATOR_BIN)/lens_blur.generator
 	@mkdir -p $(@D)
-	$^ -g lens_blur -o $(@D) -f lens_blur target=$* auto_schedule=false
+	$^ -g lens_blur -e $(GENERATOR_OUTPUTS) -o $(@D) -f lens_blur target=$* auto_schedule=false
 
 $(BIN)/%/lens_blur_auto_schedule.a: $(GENERATOR_BIN)/lens_blur.generator
 	@mkdir -p $(@D)
-	$^ -g lens_blur -o $(@D) -f lens_blur_auto_schedule target=$*-no_runtime auto_schedule=true
+	$^ -g lens_blur -e $(GENERATOR_OUTPUTS) -o $(@D) -f lens_blur_auto_schedule target=$*-no_runtime auto_schedule=true
 
 $(BIN)/%/process: process.cpp $(BIN)/%/lens_blur.a $(BIN)/%/lens_blur_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -9,11 +9,11 @@ $(GENERATOR_BIN)/local_laplacian.generator: local_laplacian_generator.cpp $(GENE
 
 $(BIN)/%/local_laplacian.a: $(GENERATOR_BIN)/local_laplacian.generator
 	@mkdir -p $(@D)
-	$^ -g local_laplacian -o $(@D) -f local_laplacian target=$* auto_schedule=false
+	$^ -g local_laplacian -e $(GENERATOR_OUTPUTS) -o $(@D) -f local_laplacian target=$* auto_schedule=false
 
 $(BIN)/%/local_laplacian_auto_schedule.a: $(GENERATOR_BIN)/local_laplacian.generator
 	@mkdir -p $(@D)
-	$^ -g local_laplacian -o $(@D) -f local_laplacian_auto_schedule target=$*-no_runtime auto_schedule=true
+	$^ -g local_laplacian -e $(GENERATOR_OUTPUTS) -o $(@D) -f local_laplacian_auto_schedule target=$*-no_runtime auto_schedule=true
 
 $(BIN)/%/process: process.cpp $(BIN)/%/local_laplacian.a $(BIN)/%/local_laplacian_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/nl_means/Makefile
+++ b/apps/nl_means/Makefile
@@ -9,11 +9,11 @@ $(GENERATOR_BIN)/nl_means.generator: nl_means_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/%/nl_means.a: $(GENERATOR_BIN)/nl_means.generator
 	@mkdir -p $(@D)
-	$^ -g nl_means -o $(@D) -f nl_means target=$* auto_schedule=false
+	$^ -g nl_means -e $(GENERATOR_OUTPUTS) -o $(@D) -f nl_means target=$* auto_schedule=false
 
 $(BIN)/%/nl_means_auto_schedule.a: $(GENERATOR_BIN)/nl_means.generator
 	@mkdir -p $(@D)
-	$^ -g nl_means -o $(@D) -f nl_means_auto_schedule target=$*-no_runtime auto_schedule=true
+	$^ -g nl_means -e $(GENERATOR_OUTPUTS) -o $(@D) -f nl_means_auto_schedule target=$*-no_runtime auto_schedule=true
 
 $(BIN)/%/process: process.cpp $(BIN)/%/nl_means.a $(BIN)/%/nl_means_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/stencil_chain/Makefile
+++ b/apps/stencil_chain/Makefile
@@ -9,11 +9,11 @@ $(GENERATOR_BIN)/stencil_chain.generator: stencil_chain_generator.cpp $(GENERATO
 
 $(BIN)/%/stencil_chain.a: $(GENERATOR_BIN)/stencil_chain.generator
 	@mkdir -p $(@D)
-	$^ -g stencil_chain -o $(@D) -f stencil_chain target=$* auto_schedule=false
+	$^ -g stencil_chain -e $(GENERATOR_OUTPUTS) -o $(@D) -f stencil_chain target=$* auto_schedule=false
 
 $(BIN)/%/stencil_chain_auto_schedule.a: $(GENERATOR_BIN)/stencil_chain.generator
 	@mkdir -p $(@D)
-	$^ -g stencil_chain -o $(@D) -f stencil_chain_auto_schedule target=$*-no_runtime auto_schedule=true
+	$^ -g stencil_chain -e $(GENERATOR_OUTPUTS) -o $(@D) -f stencil_chain_auto_schedule target=$*-no_runtime auto_schedule=true
 
 $(BIN)/%/process: process.cpp $(BIN)/%/stencil_chain.a $(BIN)/%/stencil_chain_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -20,6 +20,14 @@ GENERATOR_BIN ?= $(BIN)/host
 
 SANITIZER_FLAGS ?=
 
+# The outputs to produce when running a Generator (ie the args to the -e flag).
+# If -e is unspecified, Halide normally defaults to the equivalent of
+# `-e static_library,h,registration`; we add assembly and stmt to the 'default'
+# outputs for the apps, since it makes casual inspection of the Generator output
+# easier to inspect and experiment with. (Production build systems wouldn't
+# normally do this, as it would just waste cycles and storage.)
+GENERATOR_OUTPUTS ?= static_library,h,registration,stmt,assembly
+
 # This pulls in the definition of HALIDE_SYSTEM_LIBS and HALIDE_RTTI
 include $(HALIDE_DISTRIB_PATH)/halide_config.make
 


### PR DESCRIPTION
This gives a convenient bottleneck to customize the Generator output for (most) of the apps/ built via Makefiles; default to also generating .stmt and .s files, so that people examining apps/ output for benchmarking, learning, etc can see this output without having to do surgery in the Makefile.

(Note that some of the apps/ with Makefiles that are already heavily custom, e.g. the hexagon benchmarks, weren't touched by this. It would be nice to regularlize all the apps build files at some point in the future.)