### PR TITLE
Explicitly set SHELL=bash in Makefile.inc

### DIFF
--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -2,6 +2,7 @@ HALIDE_DISTRIB_PATH ?= ../../distrib
 LDFLAGS ?=
 IMAGES ?= ../images
 UNAME ?= $(shell uname)
+SHELL = bash
 
 BIN_DIR ?= bin
 


### PR DESCRIPTION
(0) Our main Makefile already defines this, so we already rely on bash
(1) The SHELL var isn't inherited by sub-makefiles
(2) apps/Makefile.inc relies on bash (vs plain sh) syntax
(3) Some of our buildbots don't define SHELL