### PR TITLE
define CLANG relative to LLVM_CONFIG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,6 @@ LLVM_COMPONENTS= $(shell $(LLVM_CONFIG) --components)
 LLVM_VERSION = $(shell $(LLVM_CONFIG) --version | cut -b 1-3)
 
 LLVM_FULL_VERSION = $(shell $(LLVM_CONFIG) --version)
-CLANG ?= clang
-CLANG_VERSION = $(shell $(CLANG) --version)
 LLVM_BINDIR = $(shell $(LLVM_CONFIG) --bindir | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):/\/\1/g')
 LLVM_LIBDIR = $(shell $(LLVM_CONFIG) --libdir | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):/\/\1/g')
 # Apparently there is no llvm_config flag to get canonical paths to tools,
@@ -71,6 +69,9 @@ LLVM_NM = $(LLVM_BINDIR)/llvm-nm
 LLVM_CXX_FLAGS = -std=c++11  $(filter-out -O% -g -fomit-frame-pointer -pedantic -W% -W, $(shell $(LLVM_CONFIG) --cxxflags | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):/\/\1/g;s/-D/ -D/g;s/-O/ -O/g')) -I$(LLVM_LLD_INCLUDE_DIR)
 OPTIMIZE ?= -O3
 OPTIMIZE_FOR_BUILD_TIME ?= -O0
+
+CLANG ?= $(LLVM_BINDIR)/clang
+CLANG_VERSION = $(shell $(CLANG) --version)
 
 SANITIZER_FLAGS ?=
 

--- a/README.md
+++ b/README.md
@@ -66,15 +66,13 @@ Then build it like so:
 then to point Halide to it:
 
     export LLVM_CONFIG=<path to llvm>/build/bin/llvm-config
-    export CLANG=<path to llvm>/build/bin/clang
 
 #### Building Halide with make
 
-With `LLVM_CONFIG` and `CLANG` set (or `llvm-config` and `clang` in your
-path), you should be able to just run `make` in the root directory of
-the Halide source tree. `make run_tests` will run the JIT test suite,
-and `make test_apps` will make sure all the apps compile and run (but
-won't check their output).
+With `LLVM_CONFIG` set (or `llvm-config` in your path), you should be
+able to just run `make` in the root directory of the Halide source tree.
+`make run_tests` will run the JIT test suite, and `make test_apps` will
+make sure all the apps compile and run (but won't check their output).
 
 There is no `make install` yet. If you want to make an install
 package, run `make distrib`.
@@ -357,7 +355,6 @@ Clang/LLVM instead of 5.0.
     cmake -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_TARGETS_TO_BUILD="X86;ARM;NVPTX;AArch64;Mips;PowerPC;Hexagon" -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_BUILD_TYPE=Release ..
     make -j8
     export LLVM_CONFIG=<path to llvm>/build/bin/llvm-config
-    export CLANG=<path to llvm>/build/bin/clang
 
 #### 2. Download and install the Hexagon SDK and version 8.0 Hexagon Tools
 Go to https://developer.qualcomm.com/software/hexagon-dsp-sdk/tools

--- a/test/opengl/vagrant/README.md
+++ b/test/opengl/vagrant/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This subdirectory (`Halide/test/opengl/vagrant`) provides the setup to build Halide and run the OpenGL tests headlessly on Ubuntu 14.04 and/or 16.04, running virtually under [vagrant](http://vagrantup.com) and [VirtualBox](https://www.virtualbox.org).  
+This subdirectory (`Halide/test/opengl/vagrant`) provides the setup to build Halide and run the OpenGL tests headlessly on Ubuntu 14.04 and/or 16.04, running virtually under [vagrant](http://vagrantup.com) and [VirtualBox](https://www.virtualbox.org).
 
 This is intended in particular for use by those who develop Halide's OpenGL back-end on OS X and need to test on Linux.
 
@@ -10,7 +10,7 @@ The `Vagrantfile` provisions with the necessary capabilities to build Halide and
 
 ## Quick instructions
 
-Presuming that you have [vagrant](http://vagrantup.com) and [VirtualBox](https://www.virtualbox.org) installed,  
+Presuming that you have [vagrant](http://vagrantup.com) and [VirtualBox](https://www.virtualbox.org) installed,
 
 ```
 $ cd Halide/test/opengl/vagrant
@@ -87,7 +87,7 @@ Nothing special here, just build normally, e.g.:
 vagrant@vagrant:~/halide_build$ make -j 3
 ```
 
-The machine is provisioned with environment variables `LLVM_CONFIG` and `CLANG` globally set appropriately.
+The machine is provisioned with environment variables `LLVM_CONFIG` globally set appropriately.
 
 #### 3. Build & run the OpenGL tests
 
@@ -105,4 +105,4 @@ vagrant@vagrant:~/halide_build$ make opengl_float_texture
 
 The machine is provisioned with environment variables `HL_TARGET` and `HL_JIT_TARGET` set to `host-opengl`.  You can of course override in your shell, e.g. if you want to use `host-opengl-debug`.
 
-The machine is provisioned with `lldb` installed in case you need to do some debugging.  Aside from that it's bare-bones; if you need anything else for your debugging or development you will need to `apt-get install` it.  
+The machine is provisioned with `lldb` installed in case you need to do some debugging.  Aside from that it's bare-bones; if you need anything else for your debugging or development you will need to `apt-get install` it.

--- a/test/scripts/build_travis.sh
+++ b/test/scripts/build_travis.sh
@@ -42,7 +42,6 @@ if [ ${BUILD_SYSTEM} = 'CMAKE' ]; then
 
 elif [ ${BUILD_SYSTEM} = 'MAKE' ]; then
   export LLVM_CONFIG=/usr/local/llvm/bin/llvm-config
-  export CLANG=/usr/local/llvm/bin/clang
   ${LLVM_CONFIG} --cxxflags --libdir --bindir
 
   # Build and run internal tests


### PR DESCRIPTION
For ~ever, we've required Makefile users to define CLANG as well as LLVM_CONFIG as env vars; in practice, CLANG should always point to the the one that could be deduced by LLVM_CONFIG. This changes the CLANG default value to that one (instead of 'system clang') and removes the recommendation that it be set. (You can still override CLANG if you really want to.)

If this is accepted, the buildbots will be subsequently updated to stop setting CLANG.

Note that I skipped tests/opengl/vagrant since it seems to be deliberately using ancient LLVM versions that we don't support anyway -- is it stale?

(Note that the CMake build rules were already doing it this way)