### PR TITLE
Remove extra instruction generated in OpenCL backend

### DIFF
--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -339,7 +339,6 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Store *op) {
                                   allocations.get(op->name).type == t);
 
         string id_index = print_expr(op->index);
-        string id_value = print_expr(op->value);
         do_indent();
 
         if (type_cast_needed) {


### PR DESCRIPTION
There seems to be an extra print_expr in OpenCL backend when processing Store. This patch removes that line. Sorry if the extra print is intentional.