### PR TITLE
Increase thread priority whenever halide_hexagon_remote_poll_profiler…

### DIFF
--- a/src/runtime/hexagon_remote/halide_remote.cpp
+++ b/src/runtime/hexagon_remote/halide_remote.cpp
@@ -450,6 +450,11 @@ int halide_hexagon_remote_release_library(handle_t module_ptr) {
 }
 
 int halide_hexagon_remote_poll_profiler_state(int *func, int *threads) {
+    // Increase the current thread priority to match working threads priorities,
+    // so profiler can access the remote state without extra latency.
+    qurt_thread_t current_thread_id = qurt_thread_get_id();
+    qurt_thread_set_priority(current_thread_id, 100);
+
     *func = halide_profiler_get_state()->current_func;
     *threads = halide_profiler_get_state()->active_threads;
     return 0;


### PR DESCRIPTION
…_state is called

Priority of the working threads (running on Hexagon) was recently increased to 100 (from 255). However, profiler thread which runs separately and requests state updates via RPC had lower priority (192), which led to the inaccurate profiling results. This PR increases priority of the thread to match priority of the working threads, so profiler thread has a better chance to run.