### PR TITLE
Fix floated pure stage

### DIFF
--- a/src/ApplySplit.h
+++ b/src/ApplySplit.h
@@ -1,3 +1,7 @@
+#include <utility>
+
+#include <utility>
+
 #ifndef APPLY_SPLIT_H
 #define APPLY_SPLIT_H
 
@@ -29,9 +33,9 @@ struct ApplySplitResult {
     enum Type {Substitution = 0, LetStmt, Predicate};
     Type type;
 
-    ApplySplitResult(const std::string &n, Expr val, Type t)
-        : name(n), value(val), type(t) {}
-    ApplySplitResult(Expr val) : name(""), value(val), type(Predicate) {}
+    ApplySplitResult(std::string n, Expr val, Type t)
+        : name(std::move(n)), value(std::move(val)), type(t) {}
+    ApplySplitResult(Expr val) : name(""), value(std::move(val)), type(Predicate) {}
 
     bool is_substitution() const {return (type == Substitution);}
     bool is_let() const {return (type == LetStmt);}
@@ -43,14 +47,13 @@ struct ApplySplitResult {
  * the definition (in ascending order of application), and let stmts which
  * defined the values of variables referred by the predicates and substitutions
  * (ordered from innermost to outermost let). */
-std::vector<ApplySplitResult> apply_split(
-    const Split &split, bool is_update, std::string prefix,
-    std::map<std::string, Expr> &dim_extent_alignment);
+std::vector <ApplySplitResult>
+apply_split(const Split &split, const std::string &prefix, std::map<std::string, Expr> &dim_extent_alignment);
 
 /** Compute the loop bounds of the new dimensions resulting from applying the
  * split schedules using the loop bounds of the old dimensions. */
 std::vector<std::pair<std::string, Expr>> compute_loop_bounds_after_split(
-    const Split &split, std::string prefix);
+    const Split &split, const std::string& prefix);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -453,7 +453,7 @@ bool apply_split(const Split &s, vector<ReductionVariable> &rvars,
 
         rvars.insert(it + 1, {s.outer, 0, simplify((old_extent - 1 + s.factor)/s.factor)});
 
-        vector<ApplySplitResult> splits_result = apply_split(s, true, "", dim_extent_alignment);
+        vector<ApplySplitResult> splits_result = apply_split(s, "", dim_extent_alignment);
         vector<pair<string, Expr>> bounds_let_stmts = compute_loop_bounds_after_split(s, "");
         apply_split_result(bounds_let_stmts, splits_result, predicates, args, values);
 
@@ -488,7 +488,7 @@ bool apply_fuse(const Split &s, vector<ReductionVariable> &rvars,
         iter_outer->extent = extent;
         rvars.erase(iter_inner);
 
-        vector<ApplySplitResult> splits_result = apply_split(s, true, "", dim_extent_alignment);
+        vector<ApplySplitResult> splits_result = apply_split(s, "", dim_extent_alignment);
         vector<pair<string, Expr>> bounds_let_stmts = compute_loop_bounds_after_split(s, "");
         apply_split_result(bounds_let_stmts, splits_result, predicates, args, values);
 
@@ -512,7 +512,7 @@ bool apply_purify(const Split &s, vector<ReductionVariable> &rvars,
                  << ", deleting it from the rvars list\n";
         rvars.erase(iter);
 
-        vector<ApplySplitResult> splits_result = apply_split(s, true, "", dim_extent_alignment);
+        vector<ApplySplitResult> splits_result = apply_split(s, "", dim_extent_alignment);
         vector<pair<string, Expr>> bounds_let_stmts = compute_loop_bounds_after_split(s, "");
         apply_split_result(bounds_let_stmts, splits_result, predicates, args, values);
 
@@ -532,7 +532,7 @@ bool apply_rename(const Split &s, vector<ReductionVariable> &rvars,
         debug(4) << "  Renaming " << iter->var << " into " << s.outer << "\n";
         iter->var = s.outer;
 
-        vector<ApplySplitResult> splits_result = apply_split(s, true, "", dim_extent_alignment);
+        vector<ApplySplitResult> splits_result = apply_split(s, "", dim_extent_alignment);
         vector<pair<string, Expr>> bounds_let_stmts = compute_loop_bounds_after_split(s, "");
         apply_split_result(bounds_let_stmts, splits_result, predicates, args, values);
 

--- a/src/PrintLoopNest.cpp
+++ b/src/PrintLoopNest.cpp
@@ -156,7 +156,7 @@ string print_loop_nest(const vector<Function> &output_funcs) {
 
     // Compute an environment
     map<string, Function> env;
-    for (Function f : output_funcs) {
+    for (const Function& f : output_funcs) {
         populate_environment(f, env);
     }
 
@@ -165,7 +165,7 @@ string print_loop_nest(const vector<Function> &output_funcs) {
     std::tie(outputs, env) = deep_copy(output_funcs, env);
 
     // Output functions should all be computed and stored at root.
-    for (Function f: outputs) {
+    for (const Function& f: outputs) {
         Func(f).compute_root().store_root();
     }
 
@@ -179,9 +179,7 @@ string print_loop_nest(const vector<Function> &output_funcs) {
 
     // Compute a realization order and determine group of functions which loops
     // are to be fused together
-    vector<string> order;
-    vector<vector<string>> fused_groups;
-    std::tie(order, fused_groups) = realization_order(outputs, env);
+    const auto &fused_groups = realization_order(outputs, env).second;
 
     // Try to simplify the RHS/LHS of a function definition by propagating its
     // specializations' conditions

--- a/src/RealizationOrder.cpp
+++ b/src/RealizationOrder.cpp
@@ -18,7 +18,7 @@ using std::vector;
 
 namespace {
 
-void find_fused_groups_dfs(const string& current,
+void find_fused_groups_dfs(const string &current,
                            const map<string, set<string>> &fuse_adjacency_list,
                            set<string> &visited,
                            vector<string> &group) {
@@ -59,7 +59,7 @@ find_fused_groups(const map<string, Function> &env,
     return {fused_groups, group_name};
 }
 
-void realization_order_dfs(const string& current,
+void realization_order_dfs(const string &current,
                            const map<string, vector<string>> &graph,
                            set<string> &visited,
                            set<string> &result_set,
@@ -278,7 +278,7 @@ pair<vector<string>, vector<vector<string>>> realization_order(
     vector<string> temp;
     set<string> result_set;
     set<string> visited;
-    for (const Function& f : outputs) {
+    for (const Function &f : outputs) {
         if (visited.find(f.name()) == visited.end()) {
             realization_order_dfs(f.name(), graph, visited, result_set, temp);
         }
@@ -337,7 +337,7 @@ vector<string> topological_order(const vector<Function> &outputs,
     vector<string> order;
     set<string> result_set;
     set<string> visited;
-    for (const Function& f : outputs) {
+    for (const Function &f : outputs) {
         if (visited.find(f.name()) == visited.end()) {
             realization_order_dfs(f.name(), graph, visited, result_set, order);
         }

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1383,8 +1383,8 @@ private:
             }
         }
 
-        bool some_updated = false;
-        for (size_t j = 0; j == 0 || some_updated; j++) {
+        bool some_updated = true;
+        for (size_t j = 0; some_updated; j++) {
             some_updated = false;
             for (auto iter = funcs.rbegin(); iter != funcs.rend(); iter++) {
                 const auto &f = *iter;

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1381,12 +1381,21 @@ private:
                                                                   replacements, add_lets);
                 producer = inject_stmt(producer, produceDef, f.definition().schedule().fuse_level().level);
             }
+        }
 
-            for (size_t j = 0; j < f.updates().size(); ++j) {
-                string defPrefix = f.name() + ".s" + std::to_string(j + 1) + ".";
-                const Definition &def = f.updates()[j];
-                const Stmt &updateDef = build_produce_definition(f, defPrefix, def, true, replacements, add_lets);
-                producer = inject_stmt(producer, updateDef, def.schedule().fuse_level().level);
+        bool some_updated = false;
+        for (size_t j = 0; j == 0 || some_updated; j++) {
+            some_updated = false;
+            for (auto iter = funcs.rbegin(); iter != funcs.rend(); iter++) {
+                const auto &f = *iter;
+
+                if (j < f.updates().size()) {
+                    string defPrefix = f.name() + ".s" + std::to_string(j + 1) + ".";
+                    const Definition &def = f.updates()[j];
+                    const Stmt &updateDef = build_produce_definition(f, defPrefix, def, true, replacements, add_lets);
+                    producer = inject_stmt(producer, updateDef, def.schedule().fuse_level().level);
+                    some_updated = true;
+                }
             }
         }
 

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -781,18 +781,29 @@ private:
 
 // Inject 'injected' into 'root' at 'level'.
 Stmt inject_stmt(Stmt root, Stmt injected, const LoopLevel &level) {
+    debug(3) << "[ROOT]\n" << root
+             << "[INJECTED]\n" << injected
+             << "[FUSE_LEVEL]\n" << level.to_string()
+             << " is_inlined=" << level.is_inlined()
+             << " is_root=" << level.is_root()
+             << "\n";
     if (!root.defined()) {
+        debug(3) << "[RESULT 0]\n" << injected << "\n\n";
         return injected;
     }
     if (!injected.defined()) {
+        debug(3) << "[RESULT 1]\n" << root << "\n\n";
         return root;
     }
     if (level.is_inlined() || level.is_root()) {
-        return Block::make(root, injected);
+        const Stmt &stmt = Block::make(root, injected);
+        debug(3) << "[RESULT 2]\n" << stmt << "\n\n";
+        return stmt;
     }
     InjectStmt injector(injected, level);
     root = injector.mutate(root);
     internal_assert(injector.found_level);
+    debug(3) << "[RESULT 3]\n" << root << "\n\n";
     return root;
 }
 

--- a/test/correctness/compute_with_bug.cpp
+++ b/test/correctness/compute_with_bug.cpp
@@ -1,0 +1,34 @@
+#include <cstdlib>
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Func f0{"f0"}, f1{"f1"}, cost{"cost"};
+    Var x;
+    f0(x) = x;
+    f1(x) = x;
+
+    RDom r(0, 100);
+    cost() = 0.f;
+    cost() += f0(r.x);
+    cost() += f1(r.x);
+
+    f0.compute_root();
+    f1.compute_root();
+
+    // Move the reductions into their own Funcs
+    Func cost_intm = cost.update(0).rfactor({});
+    Func cost_intm_1 = cost.update(1).rfactor({});
+
+    cost_intm.compute_root();
+    cost_intm_1.compute_root();
+
+    // Now that they're independent funcs, we can fuse the loops using compute_with
+    cost_intm.update().compute_with(cost_intm_1.update(), r.x);
+
+    Buffer<float> result = cost.realize();
+    const float expected_result = 9900.f; // 2 * sum(0..99)
+
+    return result(0) == expected_result ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test/correctness/compute_with_bug.cpp
+++ b/test/correctness/compute_with_bug.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <cstdlib>
 #include "Halide.h"
 
@@ -30,5 +31,11 @@ int main(int argc, char **argv) {
     Buffer<float> result = cost.realize();
     const float expected_result = 9900.f; // 2 * sum(0..99)
 
-    return result(0) == expected_result ? EXIT_SUCCESS : EXIT_FAILURE;
+    if (result(0) == expected_result) {
+        std::cout << "Success!\n";
+        return EXIT_SUCCESS;
+    }
+
+    std::cerr << "Error! Expected " << expected_result << " but pipeline returned " << result(0) << "\n";
+    return EXIT_FAILURE;
 }

--- a/test/correctness/compute_with_distant_updates.cpp
+++ b/test/correctness/compute_with_distant_updates.cpp
@@ -1,0 +1,88 @@
+#include <iostream>
+#include <cstdlib>
+#include "Halide.h"
+
+using namespace Halide;
+
+bool false_cycle() {
+    Func f{"f"}, g{"g"};
+    Var x{"x"}, y{"y"}, z{"z"};
+
+    f(x, y, z) = x * y * z;
+    f(x, y, z) += 1;
+
+    g(x, y, z) = sin(x + y + z);
+    g(x, y, z) += 1;
+
+    f.compute_root();
+    g.compute_root();
+
+    f.compute_with(g, y);
+    g.update(0).compute_with(f.update(0), z);
+
+    Func out{"out"};
+    out(x, y, z) = f(x, y, z) + g(x, y, z);
+
+    out.print_loop_nest();
+
+    return true;
+}
+
+bool distant_updates() {
+    Func f{"f"}, g{"g"};
+    Var x{"x"};
+
+    f(x) = x;
+    f(x) += 1; // 0
+    f(x) += 1; // 1
+    f(x) += 1; // 2
+    f(x) += 1; // 3
+    f(x) += 1; // 4
+    f(x) += 1; // 5
+    f(x) += 1; // 6
+    f(x) += 1; // 7
+    f(x) += 1; // 8
+
+    g(x) = x;
+    g(x) += 1; // 0
+    g(x) += 1; // 1
+    g(x) += 1; // 2
+    g(x) += 1; // 3
+    g(x) += 1; // 4
+    g(x) += 1; // 5
+    g(x) += 1; // 6
+    g(x) += 1; // 7
+    g(x) += 1; // 8
+
+    Func output{"output"};
+    output() = f(1) + g(1);
+
+    f.compute_root();
+    g.compute_root();
+
+    f.update(8).compute_with(g.update(2), x);
+
+    output.print_loop_nest();
+
+    Buffer<int> result = output.realize();
+    const int expected_result = 20;
+
+    bool succeeded = expected_result != result(0);
+    if (!succeeded) {
+        std::cerr << "Error! Expected " << expected_result << " but pipeline returned " << result(0) << "\n";
+    }
+
+    return succeeded;
+}
+
+int main(int argc, char **argv) {
+    bool succeeded = true;
+    succeeded &= false_cycle();
+    succeeded &= distant_updates();
+
+    if (succeeded) {
+        std::cout << "Success!" << std::endl;
+        return EXIT_SUCCESS;
+    }
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
Issue #3943 discovered that pure definitions for fused groups could be injected after an update definitions. This change ensures that all the pure definitions are injected before the `.update(0)` definitions, which are injected before the `.update(1)` definitions and so on.

I'm not sure this is actually right, but the tests are passing. The main issue is that this is now the first and only test case for compute_with behavior when applied to an update stage, rather than to a whole Func.