### PR TITLE
Marking IntrusivePtr move copy/assign as noexcept

### DIFF
--- a/src/IntrusivePtr.h
+++ b/src/IntrusivePtr.h
@@ -118,7 +118,7 @@ public:
     }
 
     HALIDE_ALWAYS_INLINE
-    IntrusivePtr(IntrusivePtr<T> &&other) noexcept: ptr(other.ptr) {
+    IntrusivePtr(IntrusivePtr<T> &&other) noexcept : ptr(other.ptr) {
         other.ptr = nullptr;
     }
 

--- a/src/IntrusivePtr.h
+++ b/src/IntrusivePtr.h
@@ -118,7 +118,7 @@ public:
     }
 
     HALIDE_ALWAYS_INLINE
-    IntrusivePtr(IntrusivePtr<T> &&other) : ptr(other.ptr) {
+    IntrusivePtr(IntrusivePtr<T> &&other) noexcept: ptr(other.ptr) {
         other.ptr = nullptr;
     }
 
@@ -134,7 +134,7 @@ public:
         return *this;
     }
 
-    IntrusivePtr<T> &operator=(IntrusivePtr<T> &&other) {
+    IntrusivePtr<T> &operator=(IntrusivePtr<T> &&other) noexcept {
         std::swap(ptr, other.ptr);
         return *this;
     }

--- a/src/Scope.h
+++ b/src/Scope.h
@@ -279,7 +279,7 @@ struct ScopedBinding {
 
     // allow move but not copy
     ScopedBinding(const ScopedBinding &that) = delete;
-    ScopedBinding(ScopedBinding &&that) :
+    ScopedBinding(ScopedBinding &&that) noexcept :
         scope(that.scope),
         name(std::move(that.name)) {
         // The move constructor must null out scope, so we don't try to pop it
@@ -311,7 +311,7 @@ struct ScopedBinding<void> {
 
     // allow move but not copy
     ScopedBinding(const ScopedBinding &that) = delete;
-    ScopedBinding(ScopedBinding &&that) :
+    ScopedBinding(ScopedBinding &&that) noexcept :
         scope(that.scope),
         name(std::move(that.name)) {
         // The move constructor must null out scope, so we don't try to pop it

--- a/src/Util.h
+++ b/src/Util.h
@@ -323,7 +323,7 @@ struct ScopedValue {
     operator T() const { return old_value; }
     // allow move but not copy
     ScopedValue(const ScopedValue& that) = delete;
-    ScopedValue(ScopedValue&& that) = default;
+    ScopedValue(ScopedValue&& that) noexcept = default;
 };
 
 // Wrappers for some C++14-isms that are useful and trivially implementable


### PR DESCRIPTION
This is a nasty C++ subtlety... custom move and copy constructors aren't `noexcept` without explicitly saying so. This means that inferred move constructors aren't `noexcept` either. Vectors of such classes will silently _copy_ upon expansion or transfer.

We should look around to see where else there might be similar issues.