### PR TITLE
Use default constructors where appropriate

### DIFF
--- a/apps/autoscheduler/AutoSchedule.cpp
+++ b/apps/autoscheduler/AutoSchedule.cpp
@@ -3288,13 +3288,13 @@ void find_and_apply_schedule(FunctionDAG& dag,
 
 // Intrusive shared ptr helpers.
 template<>
-RefCount &ref_count<Autoscheduler::LoopNest>(const Autoscheduler::LoopNest *t) {return t->ref_count;}
+RefCount &ref_count<Autoscheduler::LoopNest>(const Autoscheduler::LoopNest *t) noexcept {return t->ref_count;}
 
 template<>
 void destroy<Autoscheduler::LoopNest>(const Autoscheduler::LoopNest *t) {delete t;}
 
 template<>
-RefCount &ref_count<Autoscheduler::State>(const Autoscheduler::State *t) {return t->ref_count;}
+RefCount &ref_count<Autoscheduler::State>(const Autoscheduler::State *t) noexcept {return t->ref_count;}
 
 template<>
 void destroy<Autoscheduler::State>(const Autoscheduler::State *t) {delete t;}

--- a/apps/autoscheduler/FunctionDAG.h
+++ b/apps/autoscheduler/FunctionDAG.h
@@ -1533,7 +1533,7 @@ private:
 }
 
 template<>
-RefCount &ref_count<Autoscheduler::BoundContents>(const Autoscheduler::BoundContents *t) {return t->ref_count;}
+RefCount &ref_count<Autoscheduler::BoundContents>(const Autoscheduler::BoundContents *t) noexcept {return t->ref_count;}
 
 template<>
 void destroy<Autoscheduler::BoundContents>(const Autoscheduler::BoundContents *t) {

--- a/src/Associativity.h
+++ b/src/Associativity.h
@@ -65,7 +65,7 @@ struct AssociativeOp {
         std::string var;
         Expr expr;
 
-        Replacement() {}
+        Replacement() = default;
         Replacement(const std::string &var, Expr expr) : var(var), expr(expr) {}
 
         bool operator==(const Replacement &other) const {

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1620,7 +1620,7 @@ private:
         string var;
         int instance;
         VarInstance(const string &v, int i) : var(v), instance(i) {}
-        VarInstance() {};
+        VarInstance() = default;
 
         bool operator==(const VarInstance &other) const {
             return (var == other.var) && (instance == other.instance);

--- a/src/Bounds.h
+++ b/src/Bounds.h
@@ -53,7 +53,7 @@ struct Box {
     /** The bounds if it is touched. */
     std::vector<Interval> bounds;
 
-    Box() {}
+    Box() = default;
     Box(size_t sz) : bounds(sz) {}
     Box(const std::vector<Interval> &b) : bounds(b) {}
 

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -7,7 +7,7 @@ namespace Halide {
 namespace Internal {
 
 template<>
-RefCount &ref_count<BufferContents>(const BufferContents *c) {
+RefCount &ref_count<BufferContents>(const BufferContents *c) noexcept {
     return c->ref_count;
 }
 

--- a/src/Closure.h
+++ b/src/Closure.h
@@ -61,7 +61,7 @@ protected:
                           bool read, bool written, Halide::Buffer<> image);
 
 public:
-    Closure() {}
+    Closure() = default;
 
     /** Traverse a statement and find all references to external
      * symbols.

--- a/src/CodeGen_ARM.h
+++ b/src/CodeGen_ARM.h
@@ -46,7 +46,7 @@ protected:
                           NarrowArgs  ///< Match the pattern if the args can be losslessly narrowed
         };
         PatternType type;
-        Pattern() {}
+        Pattern() = default;
         Pattern(const std::string &i32, const std::string &i64, int l, Expr p, PatternType t = Simple) :
             intrin32("llvm.arm.neon." + i32),
             intrin64("llvm.aarch64.neon." + i64),

--- a/src/Definition.cpp
+++ b/src/Definition.cpp
@@ -71,7 +71,7 @@ struct DefinitionContents {
 };
 
 template<>
-RefCount &ref_count<DefinitionContents>(const DefinitionContents *d) {
+RefCount &ref_count<DefinitionContents>(const DefinitionContents *d) noexcept {
     return d->ref_count;
 }
 

--- a/src/Elf.h
+++ b/src/Elf.h
@@ -78,7 +78,7 @@ private:
     Visibility visibility = STV_DEFAULT;
 
 public:
-    Symbol() {}
+    Symbol() = default;
     Symbol(const std::string &name) : name(name) {}
 
     /** Accesses the name of this symbol. */
@@ -138,7 +138,7 @@ class Relocation {
     const Symbol *symbol = nullptr;
 
 public:
-    Relocation() {}
+    Relocation() = default;
     Relocation(uint32_t type, uint64_t offset, int64_t addend, const Symbol *symbol)
         : type(type), offset(offset), addend(addend), symbol(symbol) {}
 
@@ -224,7 +224,7 @@ private:
     RelocationList relocs;
 
 public:
-    Section() {}
+    Section() = default;
     Section(const std::string &name, Type type) : name(name), type(type) {}
 
     Section &set_name(const std::string &name) {
@@ -345,7 +345,7 @@ public:
  * specific aspects of linking. */
 class Linker {
 public:
-    virtual ~Linker() {}
+    virtual ~Linker() = default;
 
     virtual uint16_t get_machine() = 0;
     virtual uint32_t get_flags() = 0;
@@ -411,7 +411,7 @@ private:
     void operator = (const Object &);
 
 public:
-    Object() {}
+    Object() = default;
 
     Type get_type() const { return type; }
     uint16_t get_machine() const { return machine; }

--- a/src/Error.h
+++ b/src/Error.h
@@ -47,7 +47,7 @@ struct InternalError : public Error {
  */
 class CompileTimeErrorReporter {
 public:
-    virtual ~CompileTimeErrorReporter() {}
+    virtual ~CompileTimeErrorReporter() = default;
     virtual void warning(const char* msg) = 0;
     virtual void error(const char* msg) = 0;
 };
@@ -105,7 +105,7 @@ struct ErrorReport {
 // expression to void (to match the condition-is-false case).
 class Voidifier {
  public:
-  HALIDE_ALWAYS_INLINE Voidifier() {}
+  HALIDE_ALWAYS_INLINE Voidifier() = default;
   // This has to be an operator with a precedence lower than << but
   // higher than ?:
   HALIDE_ALWAYS_INLINE void operator&(ErrorReport&) {}

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -139,7 +139,7 @@ template<typename T>
 struct ExprNode : public BaseExprNode {
     void accept(IRVisitor *v) const override;
     Expr mutate_expr(IRMutator *v) const override;
-    ExprNode() noexcept : BaseExprNode(T::_node_type) {}
+    ExprNode() : BaseExprNode(T::_node_type) {}
     virtual ~ExprNode() = default;
 };
 
@@ -147,7 +147,7 @@ template<typename T>
 struct StmtNode : public BaseStmtNode {
     void accept(IRVisitor *v) const override;
     Stmt mutate_stmt(IRMutator *v) const override;
-    StmtNode() noexcept : BaseStmtNode(T::_node_type) {}
+    StmtNode() : BaseStmtNode(T::_node_type) {}
     virtual ~StmtNode() = default;
 };
 
@@ -289,6 +289,7 @@ struct StringImm : public ExprNode<StringImm> {
  * can treat it as a value type. */
 struct Expr : public Internal::IRHandle {
     /** Make an undefined expression */
+    HALIDE_ALWAYS_INLINE
     Expr() = default;
 
     /** Make an expression from a concrete expression node pointer (e.g. Add) */

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -80,7 +80,7 @@ struct IRNode {
      */
     virtual void accept(IRVisitor *v) const = 0;
     IRNode(IRNodeType t) : node_type(t) {}
-    virtual ~IRNode() {}
+    virtual ~IRNode() = default;
 
     /** These classes are all managed with intrusive reference
      * counting, so we also track a reference count. It's mutable
@@ -103,7 +103,7 @@ struct IRNode {
 };
 
 template<>
-inline RefCount &ref_count<IRNode>(const IRNode *t) {return t->ref_count;}
+inline RefCount &ref_count<IRNode>(const IRNode *t) noexcept {return t->ref_count;}
 
 template<>
 inline void destroy<IRNode>(const IRNode *t) {delete t;}
@@ -139,16 +139,16 @@ template<typename T>
 struct ExprNode : public BaseExprNode {
     void accept(IRVisitor *v) const override;
     Expr mutate_expr(IRMutator *v) const override;
-    ExprNode() : BaseExprNode(T::_node_type) {}
-    virtual ~ExprNode() {}
+    ExprNode() noexcept : BaseExprNode(T::_node_type) {}
+    virtual ~ExprNode() = default;
 };
 
 template<typename T>
 struct StmtNode : public BaseStmtNode {
     void accept(IRVisitor *v) const override;
     Stmt mutate_stmt(IRMutator *v) const override;
-    StmtNode() : BaseStmtNode(T::_node_type) {}
-    virtual ~StmtNode() {}
+    StmtNode() noexcept : BaseStmtNode(T::_node_type) {}
+    virtual ~StmtNode() = default;
 };
 
 /** IR nodes are passed around opaque handles to them. This is a
@@ -156,7 +156,7 @@ struct StmtNode : public BaseStmtNode {
    and dispatches visitors. */
 struct IRHandle : public IntrusivePtr<const IRNode> {
     HALIDE_ALWAYS_INLINE
-    IRHandle() : IntrusivePtr<const IRNode>() {}
+    IRHandle() = default;
 
     HALIDE_ALWAYS_INLINE
     IRHandle(const IRNode *p) : IntrusivePtr<const IRNode>(p) {}
@@ -289,8 +289,7 @@ struct StringImm : public ExprNode<StringImm> {
  * can treat it as a value type. */
 struct Expr : public Internal::IRHandle {
     /** Make an undefined expression */
-    HALIDE_ALWAYS_INLINE
-    Expr() : Internal::IRHandle() {}
+    Expr() = default;
 
     /** Make an expression from a concrete expression node pointer (e.g. Add) */
     HALIDE_ALWAYS_INLINE
@@ -438,7 +437,7 @@ inline bool is_parallel(ForType for_type) {
 
 /** A reference-counted handle to a statement node. */
 struct Stmt : public IRHandle {
-    Stmt() : IRHandle() {}
+    Stmt() = default;
     Stmt(const BaseStmtNode *n) : IRHandle(n) {}
 
     /** Override get() to return a BaseStmtNode * instead of an IRNode * */

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -163,7 +163,7 @@ FunctionContents *FunctionPtr::get() const {
 }
 
 template<>
-RefCount &ref_count<FunctionGroup>(const FunctionGroup *f) {
+RefCount &ref_count<FunctionGroup>(const FunctionGroup *f) noexcept {
     return f->ref_count;
 }
 

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -249,7 +249,7 @@ class ExtractSharedAllocations : public IRMutator {
     };
 
     struct AllocGroup {
-        AllocGroup() {}
+        AllocGroup() = default;
         AllocGroup(const SharedAllocation &alloc) : max_type_bytes(alloc.type.bytes()) {
             max_size_bytes = simplify(alloc.type.bytes() * alloc.size);
             group.push_back(alloc);

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -800,7 +800,7 @@ std::string halide_type_to_c_type(const Type &t) {
     return m.at(encode(t));
 }
 
-int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
+int generate_filter_main_inner(int argc, char **argv, std::ostream &cerr) {
     const char kUsage[] =
         "gengen \n"
         "  [-g GENERATOR_NAME] [-f FUNCTION_NAME] [-o OUTPUT_DIR] [-r RUNTIME_NAME]\n"
@@ -1062,6 +1062,21 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
 
     return 0;
 }
+
+#ifdef WITH_EXCEPTIONS
+int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
+    try {
+        return generate_filter_main_inner(argc, argv, cerr);
+    } catch (std::runtime_error &err) {
+        cerr << "Unhandled exception: " << err.what() << "\n";
+        return -1;
+    }
+}
+#else
+int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
+    return generate_filter_main_inner(argc, argv, cerr);
+}
+#endif
 
 GeneratorParamBase::GeneratorParamBase(const std::string &name) : name(name) {
     ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::GeneratorParam,

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1184,7 +1184,7 @@ class StubInputBuffer {
     }
 
 public:
-    StubInputBuffer() {}
+    StubInputBuffer() = default;
 
     // *not* explicit -- this ctor should only be used when you want
     // to pass a literal Buffer<> for a Stub Input; this Buffer<> will be
@@ -1203,7 +1203,7 @@ protected:
     Target get_target() const;
 
     explicit StubOutputBufferBase(const Func &f, std::shared_ptr<GeneratorBase> generator) : f(f), generator(generator) {}
-    StubOutputBufferBase() {}
+    StubOutputBufferBase() = default;
 
 public:
     Realization realize(std::vector<int32_t> sizes) {
@@ -1242,7 +1242,7 @@ class StubOutputBuffer : public StubOutputBufferBase {
     friend class GeneratorStub;
     explicit StubOutputBuffer(const Func &f, std::shared_ptr<GeneratorBase> generator) : StubOutputBufferBase(f, generator) {}
 public:
-    StubOutputBuffer() {}
+    StubOutputBuffer() = default;
 };
 
 // This is a union-like class that allows for convenient initialization of Stub Inputs
@@ -3259,7 +3259,7 @@ private:
 
     static GeneratorRegistry &get_registry();
 
-    GeneratorRegistry() {}
+    GeneratorRegistry() = default;
     GeneratorRegistry(const GeneratorRegistry &) = delete;
     void operator=(const GeneratorRegistry &) = delete;
 };

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -149,7 +149,7 @@ struct Pattern {
     Expr pattern;         // The pattern to match against
     int flags;
 
-    Pattern() {}
+    Pattern() = default;
     Pattern(const string &intrin, Expr p, int flags = 0)
         : intrin(intrin), pattern(p), flags(flags) {}
 };

--- a/src/IR.h
+++ b/src/IR.h
@@ -398,7 +398,7 @@ struct Free : public StmtNode<Free> {
  * (min + extent - 1) */
 struct Range {
     Expr min, extent;
-    Range() {}
+    Range() = default;
     Range(Expr min, Expr extent) : min(min), extent(extent) {
         internal_assert(min.type() == extent.type()) << "Region min and extent must have same type\n";
     }

--- a/src/IREquality.h
+++ b/src/IREquality.h
@@ -63,7 +63,7 @@ public:
         }
     }
 
-    IRCompareCache() {}
+    IRCompareCache() = default;
     IRCompareCache(int b) : bits(b), entries(static_cast<size_t>(1) << bits) {}
 };
 

--- a/src/ImageParam.h
+++ b/src/ImageParam.h
@@ -29,7 +29,7 @@ class ImageParam : public OutputImageParam {
 public:
 
     /** Construct a nullptr image parameter handle. */
-    ImageParam() : OutputImageParam() {}
+    ImageParam() = default;
 
     /** Construct an image parameter of the given type and
      * dimensionality, with an auto-generated unique name. */

--- a/src/IntrusivePtr.h
+++ b/src/IntrusivePtr.h
@@ -19,7 +19,7 @@ namespace Internal {
 class RefCount {
     std::atomic<int> count;
 public:
-    RefCount() : count(0) {}
+    RefCount() noexcept : count(0) {}
     int increment() {return ++count;} // Increment and return new value
     int decrement() {return --count;} // Decrement and return new value
     bool is_zero() const {return count == 0;}
@@ -36,11 +36,11 @@ public:
  * define something like this in MyClass.cpp (assuming MyClass has
  * a field: mutable RefCount ref_count):
  *
- * template<> RefCount &ref_count<MyClass>(const MyClass *c) {return c->ref_count;}
+ * template<> RefCount &ref_count<MyClass>(const MyClass *c) noexcept {return c->ref_count;}
  * template<> void destroy<MyClass>(const MyClass *c) {delete c;}
  */
 // @{
-template<typename T> RefCount &ref_count(const T *t);
+template<typename T> RefCount &ref_count(const T *t) noexcept;
 template<typename T> void destroy(const T *t);
 // @}
 
@@ -78,7 +78,7 @@ private:
     }
 
 protected:
-    T *ptr;
+    T *ptr = nullptr;
 
 public:
     /** Access the raw pointer in a variety of ways.
@@ -104,8 +104,7 @@ public:
     }
 
     HALIDE_ALWAYS_INLINE
-    IntrusivePtr() : ptr(nullptr) {
-    }
+    IntrusivePtr() = default;
 
     HALIDE_ALWAYS_INLINE
     IntrusivePtr(T *p) : ptr(p) {
@@ -113,7 +112,7 @@ public:
     }
 
     HALIDE_ALWAYS_INLINE
-    IntrusivePtr(const IntrusivePtr<T> &other) : ptr(other.ptr) {
+    IntrusivePtr(const IntrusivePtr<T> &other) noexcept : ptr(other.ptr) {
         incref(ptr);
     }
 

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -154,7 +154,7 @@ public:
 };
 
 template <>
-RefCount &ref_count<JITModuleContents>(const JITModuleContents *f) { return f->ref_count; }
+RefCount &ref_count<JITModuleContents>(const JITModuleContents *f) noexcept { return f->ref_count; }
 
 template <>
 void destroy<JITModuleContents>(const JITModuleContents *f) { delete f; }

--- a/src/LowerWarpShuffles.cpp
+++ b/src/LowerWarpShuffles.cpp
@@ -644,7 +644,7 @@ class LowerWarpShuffles : public IRMutator {
     }
 
 public:
-    LowerWarpShuffles() {}
+    LowerWarpShuffles() = default;
 };
 
 class HoistWarpShufflesFromSingleIfStmt : public IRMutator {

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -213,7 +213,7 @@ struct ModuleContents {
 };
 
 template<>
-RefCount &ref_count<ModuleContents>(const ModuleContents *t) {
+RefCount &ref_count<ModuleContents>(const ModuleContents *t) noexcept {
     return t->ref_count;
 }
 

--- a/src/ObjectInstanceRegistry.h
+++ b/src/ObjectInstanceRegistry.h
@@ -82,8 +82,8 @@ private:
     std::mutex mutex;
     std::map<uintptr_t, InstanceInfo> instances;
 
-    ObjectInstanceRegistry() {}
-    ObjectInstanceRegistry(ObjectInstanceRegistry &rhs);  // unimplemented
+    ObjectInstanceRegistry() = default;
+    ObjectInstanceRegistry(ObjectInstanceRegistry &rhs) = delete;
 };
 
 }  // namespace Internal

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -38,7 +38,7 @@ struct ParameterContents {
 };
 
 template<>
-RefCount &ref_count<Halide::Internal::ParameterContents>(const ParameterContents *p) {return p->ref_count;}
+RefCount &ref_count<Halide::Internal::ParameterContents>(const ParameterContents *p) noexcept {return p->ref_count;}
 
 template<>
 void destroy<Halide::Internal::ParameterContents>(const ParameterContents *p) {delete p;}

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -120,7 +120,7 @@ struct PipelineContents {
 
 namespace Internal {
 template<>
-RefCount &ref_count<PipelineContents>(const PipelineContents *p) {
+RefCount &ref_count<PipelineContents>(const PipelineContents *p) noexcept {
     return p->ref_count;
 }
 

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -191,7 +191,7 @@ class RDom {
 
 public:
     /** Construct an undefined reduction domain. */
-    RDom() {}
+    RDom() = default;
 
     /** Construct a multi-dimensional reduction domain with the given name. If the name
      * is left blank, a unique one is auto-generated. */

--- a/src/Reduction.cpp
+++ b/src/Reduction.cpp
@@ -130,7 +130,7 @@ struct ReductionDomainContents {
 };
 
 template<>
-RefCount &ref_count<Halide::Internal::ReductionDomainContents>(const ReductionDomainContents *p) {return p->ref_count;}
+RefCount &ref_count<Halide::Internal::ReductionDomainContents>(const ReductionDomainContents *p) noexcept {return p->ref_count;}
 
 template<>
 void destroy<Halide::Internal::ReductionDomainContents>(const ReductionDomainContents *p) {delete p;}

--- a/src/RegionCosts.h
+++ b/src/RegionCosts.h
@@ -25,7 +25,7 @@ struct Cost {
 
     Cost(int64_t arith, int64_t memory) : arith(arith), memory(memory) {}
     Cost(Expr arith, Expr memory) : arith(std::move(arith)), memory(std::move(memory)) {}
-    Cost() {}
+    Cost() = default;
 
     inline bool defined() const { return arith.defined() && memory.defined(); }
     void simplify();

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -41,7 +41,7 @@ struct LoopLevelContents {
 };
 
 template<>
-RefCount &ref_count<LoopLevelContents>(const LoopLevelContents *p) {
+RefCount &ref_count<LoopLevelContents>(const LoopLevelContents *p) noexcept {
     return p->ref_count;
 }
 
@@ -253,7 +253,7 @@ struct FuncScheduleContents {
 };
 
 template<>
-RefCount &ref_count<FuncScheduleContents>(const FuncScheduleContents *p) {
+RefCount &ref_count<FuncScheduleContents>(const FuncScheduleContents *p) noexcept {
     return p->ref_count;
 }
 
@@ -304,7 +304,7 @@ struct StageScheduleContents {
 };
 
 template<>
-RefCount &ref_count<StageScheduleContents>(const StageScheduleContents *p) {
+RefCount &ref_count<StageScheduleContents>(const StageScheduleContents *p) noexcept {
     return p->ref_count;
 }
 

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -325,7 +325,7 @@ struct FusedPair {
     size_t stage_2;
     std::string var_name;
 
-    FusedPair() {}
+    FusedPair() = default;
     FusedPair(const std::string &f1, size_t s1, const std::string &f2,
               size_t s2, const std::string &var)
         : func_1(f1), func_2(f2), stage_1(s1), stage_2(s2), var_name(var) {}

--- a/src/Scope.h
+++ b/src/Scope.h
@@ -25,10 +25,10 @@ class SmallStack {
 private:
     T _top;
     std::vector<T> _rest;
-    bool _empty;
+    bool _empty = true;
 
 public:
-    SmallStack() : _empty(true) {}
+    SmallStack() = default;
 
     void pop() {
         if (_rest.empty()) {

--- a/src/TrimNoOps.cpp
+++ b/src/TrimNoOps.cpp
@@ -330,7 +330,7 @@ public:
         containing_loops.push_back({v, i});
     }
 
-    SimplifyUsingBounds() {}
+    SimplifyUsingBounds() = default;
 };
 
 class TrimNoOps : public IRMutator {

--- a/src/Util.h
+++ b/src/Util.h
@@ -323,7 +323,7 @@ struct ScopedValue {
     operator T() const { return old_value; }
     // allow move but not copy
     ScopedValue(const ScopedValue& that) = delete;
-    ScopedValue(ScopedValue&& that) noexcept = default;
+    ScopedValue(ScopedValue&& that) = default;
 };
 
 // Wrappers for some C++14-isms that are useful and trivially implementable

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -1524,7 +1524,7 @@ WasmModuleContents::~WasmModuleContents() {
 
 
 template<>
-RefCount &ref_count<WasmModuleContents>(const WasmModuleContents *p) {
+RefCount &ref_count<WasmModuleContents>(const WasmModuleContents *p) noexcept {
     return p->ref_count;
 }
 


### PR DESCRIPTION
Also made the ref_count accessor no_except so that when it's defined in a different translation unit we don't falsely think incrementing a refcount might throw.

This removed most of the errors resulting from noexcept ScopedValues. The string move constructor is not noexcept though, so I had to remove noexcept from ScopedValue because we used `ScopedValue<string>` in a few places.

