### PR TITLE
Validating a pointer requires having the OpenCL API loaded

### DIFF
--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -231,6 +231,12 @@ WEAK bool validate_device_pointer(void *user_context, halide_buffer_t* buf, size
         return true;
     }
 
+    // We may call this in situations where we haven't loaded the
+    // OpenCL API yet.
+    if (!clGetMemObjectInfo) {
+        load_libopencl(user_context);
+    }
+
     cl_mem dev_ptr = ((device_handle *)buf->device)->mem;
     uint64_t offset = ((device_handle *)buf->device)->offset;
 


### PR DESCRIPTION
device_wrap_native, without debug, just sets device field appropriately and returns, so it doesn't need a CL context and it doesn't need to load libopencl. With debug on, it also validates the pointer for you, which still doesn't need a CL context, but which does require calling clGetMemObjectInfo, which may be a null function pointer if this is the first thing you've done with Halide's OpenCL runtime in the process.