### PR TITLE
Remove noise from halide.cmake output

### DIFF
--- a/halide.cmake
+++ b/halide.cmake
@@ -601,7 +601,9 @@ function(_halide_add_exec_generator_target EXEC_TARGET)
 
   set(EXTRA_OUTPUTS_COMMENT )
   foreach(OUTPUT ${args_OUTPUTS})
-    if((${OUTPUT} MATCHES "^.*\\.h$") OR (${OUTPUT} MATCHES "^.*${CMAKE_STATIC_LIBRARY_SUFFIX}$"))
+    if((${OUTPUT} MATCHES "^.*\\.h$")
+       OR (${OUTPUT} MATCHES "^.*${CMAKE_STATIC_LIBRARY_SUFFIX}$")
+       OR (${OUTPUT} MATCHES "^.*\\.registration\\.cpp$"))
       # Ignore
     else()
       set(EXTRA_OUTPUTS_COMMENT "${EXTRA_OUTPUTS_COMMENT}\nEmitting extra Halide output: ${OUTPUT}")


### PR DESCRIPTION
It emits "Emitting extra Halide output" for every registration.cpp file, but since these are now always emitted by default, this is incorrect and noisy.