### PR TITLE
Use dimensions to compute the size of the buffer for printout in CodeGen_C

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1812,7 +1812,7 @@ void CodeGen_C::compile(const Buffer<> &buffer) {
 
     // Figure out the offset of the last pixel.
     size_t num_elems = 1;
-    for (int d = 0; b.dim[d].extent; d++) {
+    for (int d = 0; d < b.dimensions; d++) {
         num_elems += b.dim[d].stride * (b.dim[d].extent - 1);
     }
 


### PR DESCRIPTION
It crashes for some of our internal tests, because computed size is incorrect and we try to access out of bounds (there is a chance that our buffers are somehow malformed and it breaks some assumptions here), but works fine when .dimensions is used.