### PR TITLE
Fix building tests with MSVC.

### DIFF
--- a/test/generator/cxx_mangling_aottest.cpp
+++ b/test/generator/cxx_mangling_aottest.cpp
@@ -4,6 +4,7 @@
 #include "HalideBuffer.h"
 #include <assert.h>
 #include <string.h>
+#include <string>
 
 #include "cxx_mangling.h"
 #ifdef TEST_CUDA

--- a/test/generator/cxx_mangling_define_extern_aottest.cpp
+++ b/test/generator/cxx_mangling_define_extern_aottest.cpp
@@ -4,7 +4,7 @@
 #include "HalideBuffer.h"
 
 #include <assert.h>
-#include <string.h>
+#include <string>
 
 #include "cxx_mangling_define_extern.h"
 

--- a/test/generator/mandelbrot_aottest.cpp
+++ b/test/generator/mandelbrot_aottest.cpp
@@ -1,4 +1,4 @@
-#include <math.h>
+#include <cmath>
 #include <string.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/test/generator/memory_profiler_mandelbrot_aottest.cpp
+++ b/test/generator/memory_profiler_mandelbrot_aottest.cpp
@@ -2,7 +2,7 @@
 #include <cstring>
 #include <string>
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 #include <stdio.h>
 
 #include "HalideRuntime.h"


### PR DESCRIPTION
The mangling tests were unhappy about <string> not being included.
The Mandelbrot tests were unhappy about doubles being stuffed into floats.