### PR TITLE
Hexagon: Fixes the slicing bounds for the last vector in interleave_vector func

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1070,7 +1070,7 @@ Value *CodeGen_Hexagon::shuffle_vectors(Value *a, Value *b,
             if (i + native_elements > result_elements) {
                 // This is the last vector, and it has a few extra
                 // elements. Slice it down.
-                ret_i = slice_vector(ret_i, 0, i + native_elements - result_elements);
+                ret_i = slice_vector(ret_i, 0, result_elements - i);
             }
             ret.push_back(ret_i);
         }

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -833,7 +833,7 @@ Value *CodeGen_Hexagon::interleave_vectors(const vector<llvm::Value *> &v) {
                 if ((i + native_elements)*2 > result_elements) {
                     // This is the last vector, and it has some extra
                     // elements. Slice it down.
-                    ret_i = slice_vector(ret_i, 0, (i + native_elements)*2 - result_elements);
+                    ret_i = slice_vector(ret_i, 0, result_elements - i*2);
                 }
                 ret.push_back(ret_i);
             }


### PR DESCRIPTION
@pranavb-ca @dpalermo @dsharletg I don't have a reproducer for this but seems like a trivial change.