### PR TITLE
Revise the API for intrinsic Call nodes to use an enum

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1661,8 +1661,8 @@ private:
                 // Ignore crops that apply to a different buffer than the one being looked for.
                 if (in_buf != nullptr && (in_buf->name == (func + ".buffer"))) {
                     internal_assert(mins_struct != nullptr && extents_struct != nullptr &&
-                                    mins_struct->name == Call::make_struct &&
-                                    extents_struct->name == Call::make_struct) << "BoxesTouched::box_from_extended_crop -- unexpected buffer_crop form.\n";
+                                    mins_struct->is_intrinsic(Call::make_struct) &&
+                                    extents_struct->is_intrinsic(Call::make_struct)) << "BoxesTouched::box_from_extended_crop -- unexpected buffer_crop form.\n";
                     b.resize(mins_struct->args.size());
                     b.used = const_true();
                     for (size_t i = 0; i < mins_struct->args.size(); i++) {

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1680,13 +1680,13 @@ void CodeGen_Hexagon::visit(const Call *op) {
     // Map Halide functions to Hexagon intrinsics, plus a boolean
     // indicating if the intrinsic has signed variants or not.
     static std::map<string, std::pair<string, bool>> functions = {
-        { Call::absd, { "halide.hexagon.absd", true } },
-        { Call::bitwise_and, { "halide.hexagon.and", false } },
-        { Call::bitwise_or, { "halide.hexagon.or", false } },
-        { Call::bitwise_xor, { "halide.hexagon.xor", false } },
-        { Call::bitwise_not, { "halide.hexagon.not", false } },
-        { Call::count_leading_zeros, { "halide.hexagon.clz", false } },
-        { Call::popcount, { "halide.hexagon.popcount", false } },
+        { Call::get_intrinsic_name(Call::absd), { "halide.hexagon.absd", true } },
+        { Call::get_intrinsic_name(Call::bitwise_and), { "halide.hexagon.and", false } },
+        { Call::get_intrinsic_name(Call::bitwise_or), { "halide.hexagon.or", false } },
+        { Call::get_intrinsic_name(Call::bitwise_xor), { "halide.hexagon.xor", false } },
+        { Call::get_intrinsic_name(Call::bitwise_not), { "halide.hexagon.not", false } },
+        { Call::get_intrinsic_name(Call::count_leading_zeros), { "halide.hexagon.clz", false } },
+        { Call::get_intrinsic_name(Call::popcount), { "halide.hexagon.popcount", false } },
     };
 
     if (is_native_interleave(op) || is_native_deinterleave(op)) {
@@ -1721,7 +1721,7 @@ void CodeGen_Hexagon::visit(const Call *op) {
                                 instr + type_suffix(op->args[0], b),
                                 {op->args[0], b});
             return;
-        } else if (op->is_intrinsic("dynamic_shuffle")) {
+        } else if (op->is_intrinsic(Call::dynamic_shuffle)) {
             internal_assert(op->args.size() == 4);
             const int64_t *min_index = as_const_int(op->args[2]);
             const int64_t *max_index = as_const_int(op->args[3]);
@@ -1821,7 +1821,7 @@ void CodeGen_Hexagon::visit(const Call *op) {
         return;
     }
 
-    if (op->is_intrinsic() && op->name == "gather") {
+    if (op->is_intrinsic(Call::gather)) {
         internal_assert(op->args.size() == 5);
         internal_assert(op->type.bits() == 16 || op->type.bits() == 32);
         int index_lanes = op->type.lanes();
@@ -1848,7 +1848,7 @@ void CodeGen_Hexagon::visit(const Call *op) {
             value = builder->CreateCall(fn, args);
         }
         return;
-    } else if (op->is_intrinsic() && (op->name == "scatter" || op->name == "scatter_acc")) {
+    } else if (op->is_intrinsic(Call::scatter) || op->is_intrinsic(Call::scatter_acc)) {
         internal_assert(op->args.size() == 4);
         internal_assert(op->type.bits() == 16 || op->type.bits() == 32);
         int index_lanes = op->type.lanes();
@@ -1874,7 +1874,7 @@ void CodeGen_Hexagon::visit(const Call *op) {
             value = builder->CreateCall(fn, args);
         }
         return;
-    } else if (op->is_intrinsic("scatter_release")) {
+    } else if (op->is_intrinsic(Call::scatter_release)) {
         internal_assert(op->args.size() == 1);
         Value *ptr = codegen(op->args[0]);
         llvm::Function *fn = module->getFunction("halide.hexagon.scatter.release");

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2464,7 +2464,7 @@ void CodeGen_LLVM::visit(const Call *op) {
                               Let::make(b_name, op->args[1],
                                         Select::make(a_var < b_var, b_var - a_var, a_var - b_var))));
         }
-    } else if (op->is_intrinsic("div_round_to_zero")) {
+    } else if (op->is_intrinsic(Call::div_round_to_zero)) {
         internal_assert(op->args.size() == 2);
         Value *a = codegen(op->args[0]);
         Value *b = codegen(op->args[1]);
@@ -2475,7 +2475,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         } else {
             internal_error << "div_round_to_zero of non-integer type.\n";
         }
-    } else if (op->is_intrinsic("mod_round_to_zero")) {
+    } else if (op->is_intrinsic(Call::mod_round_to_zero)) {
         internal_assert(op->args.size() == 2);
         Value *a = codegen(op->args[0]);
         Value *b = codegen(op->args[1]);

--- a/src/DeviceArgument.cpp
+++ b/src/DeviceArgument.cpp
@@ -53,11 +53,11 @@ void HostClosure::visit(const Call *op) {
         ref.type = op->type;
         // TODO: do we need to set ref.dimensions?
 
-        if (op->name == Call::glsl_texture_load ||
-            op->name == Call::image_load) {
+        if (op->is_intrinsic(Call::glsl_texture_load) ||
+            op->is_intrinsic(Call::image_load)) {
             ref.read = true;
-        } else if (op->name == Call::glsl_texture_store ||
-                   op->name == Call::image_store) {
+        } else if (op->is_intrinsic(Call::glsl_texture_store) ||
+                   op->is_intrinsic(Call::image_store)) {
             ref.write = true;
         }
 

--- a/src/EliminateBoolVectors.cpp
+++ b/src/EliminateBoolVectors.cpp
@@ -64,7 +64,7 @@ private:
     Expr visit(const GE *op) override { return visit_comparison(op); }
 
     template <typename T>
-    Expr visit_logical_binop(const T* op, const std::string& bitwise_op) {
+    Expr visit_logical_binop(const T* op, Call::IntrinsicOp bitwise_op) {
         Expr a = mutate(op->a);
         Expr b = mutate(op->b);
 

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -1380,15 +1380,15 @@ class EliminateInterleaves : public IRMutator {
         // These calls can have interleaves moved from operands to the
         // result...
         static const set<string> interleavable = {
-            Call::bitwise_and,
-            Call::bitwise_not,
-            Call::bitwise_xor,
-            Call::bitwise_or,
-            Call::shift_left,
-            Call::shift_right,
-            Call::abs,
-            Call::absd,
-            Call::select_mask
+            Call::get_intrinsic_name(Call::bitwise_and),
+            Call::get_intrinsic_name(Call::bitwise_not),
+            Call::get_intrinsic_name(Call::bitwise_xor),
+            Call::get_intrinsic_name(Call::bitwise_or),
+            Call::get_intrinsic_name(Call::shift_left),
+            Call::get_intrinsic_name(Call::shift_right),
+            Call::get_intrinsic_name(Call::abs),
+            Call::get_intrinsic_name(Call::absd),
+            Call::get_intrinsic_name(Call::select_mask)
         };
         if (interleavable.count(op->name) != 0) return true;
 

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -578,10 +578,88 @@ Expr Call::make(Function func, const std::vector<Expr> &args, int idx) {
                 func.get_contents(), idx, Buffer<>(), Parameter());
 }
 
+namespace {
+
+const char *const intrinsic_op_names[] = {
+    "abs",
+    "absd",
+    "alloca",
+    "bitwise_and",
+    "bitwise_not",
+    "bitwise_or",
+    "bitwise_xor",
+    "bool_to_mask",
+    "call_cached_indirect_function",
+    "cast_mask",
+    "count_leading_zeros",
+    "count_trailing_zeros",
+    "debug_to_file",
+    "div_round_to_zero",
+    "dynamic_shuffle",
+    "extract_mask_element",
+    "gather",
+    "glsl_texture_load",
+    "glsl_texture_store",
+    "glsl_varying",
+    "gpu_thread_barrier",
+    "if_then_else",
+    "if_then_else_mask",
+    "image_load",
+    "image_store",
+    "indeterminate_expression",
+    "lerp",
+    "likely",
+    "likely_if_innermost",
+    "make_struct",
+    "memoize_expr",
+    "mod_round_to_zero",
+    "mulhi_shr",
+    "popcount",
+    "prefetch",
+    "quiet_div",
+    "quiet_mod",
+    "random",
+    "register_destructor",
+    "reinterpret",
+    "require",
+    "require_mask",
+    "return_second",
+    "rewrite_buffer",
+    "scatter",
+    "scatter_acc",
+    "scatter_release",
+    "select_mask",
+    "shift_left",
+    "shift_right",
+    "signed_integer_overflow",
+    "size_of_halide_buffer_t",
+    "sorted_avg",
+    "strict_float",
+    "stringify",
+    "undef",
+    "unsafe_promise_clamped"
+};
+
+static_assert(sizeof(intrinsic_op_names)/sizeof(intrinsic_op_names[0]) == Call::IntrinsicOpCount, "intrinsic_op_names needs attention");
+
+
+}  // namespace
+
+const char *Call::get_intrinsic_name(IntrinsicOp op) {
+    return intrinsic_op_names[op];
+}
+
+Expr Call::make(Type type, Call::IntrinsicOp op, const std::vector<Expr> &args, CallType call_type,
+                FunctionPtr func, int value_index,
+                Buffer<> image, Parameter param) {
+    internal_assert(call_type == Call::Intrinsic || call_type == Call::PureIntrinsic);
+    return Call::make(type, intrinsic_op_names[op], args, call_type, func, value_index, image, param);
+}
+
 Expr Call::make(Type type, const std::string &name, const std::vector<Expr> &args, CallType call_type,
                 FunctionPtr func, int value_index,
                 Buffer<> image, Parameter param) {
-    if (name == Call::prefetch && call_type == Call::Intrinsic) {
+    if (name == intrinsic_op_names[Call::prefetch] && call_type == Call::Intrinsic) {
         internal_assert(args.size() % 2 == 0)
             << "Number of args to a prefetch call should be even: {base, offset, extent0, stride0, extent1, stride1, ...}\n";
     }
@@ -866,58 +944,6 @@ template<> Stmt StmtNode<Evaluate>::mutate_stmt(IRMutator *v) const { return v->
 template<> Stmt StmtNode<Prefetch>::mutate_stmt(IRMutator *v) const { return v->visit((const Prefetch *)this); }
 template<> Stmt StmtNode<Acquire>::mutate_stmt(IRMutator *v) const { return v->visit((const Acquire *)this); }
 template<> Stmt StmtNode<Fork>::mutate_stmt(IRMutator *v) const { return v->visit((const Fork *)this); }
-
-Call::ConstString Call::debug_to_file = "debug_to_file";
-Call::ConstString Call::reinterpret = "reinterpret";
-Call::ConstString Call::bitwise_and = "bitwise_and";
-Call::ConstString Call::bitwise_not = "bitwise_not";
-Call::ConstString Call::bitwise_xor = "bitwise_xor";
-Call::ConstString Call::bitwise_or = "bitwise_or";
-Call::ConstString Call::shift_left = "shift_left";
-Call::ConstString Call::shift_right = "shift_right";
-Call::ConstString Call::abs = "abs";
-Call::ConstString Call::absd = "absd";
-Call::ConstString Call::lerp = "lerp";
-Call::ConstString Call::random = "random";
-Call::ConstString Call::popcount = "popcount";
-Call::ConstString Call::count_leading_zeros = "count_leading_zeros";
-Call::ConstString Call::count_trailing_zeros = "count_trailing_zeros";
-Call::ConstString Call::undef = "undef";
-Call::ConstString Call::return_second = "return_second";
-Call::ConstString Call::if_then_else = "if_then_else";
-Call::ConstString Call::if_then_else_mask = "if_then_else_mask";
-Call::ConstString Call::glsl_texture_load = "glsl_texture_load";
-Call::ConstString Call::glsl_texture_store = "glsl_texture_store";
-Call::ConstString Call::glsl_varying = "glsl_varying";
-Call::ConstString Call::image_load = "image_load";
-Call::ConstString Call::image_store = "image_store";
-Call::ConstString Call::make_struct = "make_struct";
-Call::ConstString Call::stringify = "stringify";
-Call::ConstString Call::memoize_expr = "memoize_expr";
-Call::ConstString Call::alloca = "alloca";
-Call::ConstString Call::likely = "likely";
-Call::ConstString Call::likely_if_innermost = "likely_if_innermost";
-Call::ConstString Call::register_destructor = "register_destructor";
-Call::ConstString Call::div_round_to_zero = "div_round_to_zero";
-Call::ConstString Call::mod_round_to_zero = "mod_round_to_zero";
-Call::ConstString Call::call_cached_indirect_function = "call_cached_indirect_function";
-Call::ConstString Call::prefetch = "prefetch";
-Call::ConstString Call::signed_integer_overflow = "signed_integer_overflow";
-Call::ConstString Call::indeterminate_expression = "indeterminate_expression";
-Call::ConstString Call::bool_to_mask = "bool_to_mask";
-Call::ConstString Call::cast_mask = "cast_mask";
-Call::ConstString Call::select_mask = "select_mask";
-Call::ConstString Call::extract_mask_element = "extract_mask_element";
-Call::ConstString Call::require = "require";
-Call::ConstString Call::require_mask = "require_mask";
-Call::ConstString Call::size_of_halide_buffer_t = "size_of_halide_buffer_t";
-Call::ConstString Call::strict_float = "strict_float";
-Call::ConstString Call::quiet_div = "quiet_div";
-Call::ConstString Call::quiet_mod = "quiet_mod";
-Call::ConstString Call::unsafe_promise_clamped = "unsafe_promise_clamped";
-Call::ConstString Call::gpu_thread_barrier = "gpu_thread_barrier";
-Call::ConstString Call::mulhi_shr = "mulhi_shr";
-Call::ConstString Call::sorted_avg = "sorted_avg";
 
 Call::ConstString Call::buffer_get_dimensions = "_halide_buffer_get_dimensions";
 Call::ConstString Call::buffer_get_min = "_halide_buffer_get_min";

--- a/src/IR.h
+++ b/src/IR.h
@@ -496,58 +496,77 @@ struct Call : public ExprNode<Call> {
     // risking ambiguous initalization order; we use a typedef to simplify
     // declaration.
     typedef const char *const ConstString;
-    HALIDE_EXPORT static ConstString debug_to_file,
-        reinterpret,
-        bitwise_and,
-        bitwise_not,
-        bitwise_xor,
-        bitwise_or,
-        shift_left,
-        shift_right,
+
+    // enums for various well-known intrinsics. (It is not *required* that all
+    // intrinsics have an enum entry here, but as a matter of style, it is recommended.)
+    // Note that these are only used in the API; inside the node, they are translated
+    // into a name. (To recover the name, call get_intrinsic_name().)
+    //
+    // Please keep this list sorted alphabetically; the specific enum values
+    // are *not* guaranteed to be stable across time.
+    enum IntrinsicOp {
         abs,
         absd,
-        rewrite_buffer,
-        random,
-        lerp,
-        popcount,
+        alloca,
+        bitwise_and,
+        bitwise_not,
+        bitwise_or,
+        bitwise_xor,
+        bool_to_mask,
+        call_cached_indirect_function,
+        cast_mask,
         count_leading_zeros,
         count_trailing_zeros,
-        undef,
-        return_second,
-        if_then_else,
-        if_then_else_mask,
+        debug_to_file,
+        div_round_to_zero,
+        dynamic_shuffle,
+        extract_mask_element,
+        gather,
         glsl_texture_load,
         glsl_texture_store,
         glsl_varying,
+        gpu_thread_barrier,
+        if_then_else,
+        if_then_else_mask,
         image_load,
         image_store,
-        make_struct,
-        stringify,
-        memoize_expr,
-        alloca,
+        indeterminate_expression,
+        lerp,
         likely,
         likely_if_innermost,
-        register_destructor,
-        div_round_to_zero,
+        make_struct,
+        memoize_expr,
         mod_round_to_zero,
-        call_cached_indirect_function,
+        mulhi_shr, // Compute high_half(arg[0] * arg[1]) >> arg[3]. Note that this is a shift in addition to taking the upper half of multiply result. arg[3] must be an unsigned integer immediate.
+        popcount,
         prefetch,
-        signed_integer_overflow,
-        indeterminate_expression,
-        bool_to_mask,
-        cast_mask,
-        select_mask,
-        extract_mask_element,
-        require,
-        require_mask,
-        size_of_halide_buffer_t,
-        strict_float,
         quiet_div,
         quiet_mod,
+        random,
+        register_destructor,
+        reinterpret,
+        require,
+        require_mask,
+        return_second,
+        rewrite_buffer,
+        scatter,
+        scatter_acc,
+        scatter_release,
+        select_mask,
+        shift_left,
+        shift_right,
+        signed_integer_overflow,
+        size_of_halide_buffer_t,
+        sorted_avg, // Compute (arg[0] + arg[1]) / 2, assuming arg[0] < arg[1].
+        strict_float,
+        stringify,
+        undef,
         unsafe_promise_clamped,
-        gpu_thread_barrier,
-        mulhi_shr, // Compute high_half(arg[0] * arg[1]) >> arg[3]. Note that this is a shift in addition to taking the upper half of multiply result. arg[3] must be an unsigned integer immediate.
-        sorted_avg; // Compute (arg[0] + arg[1]) / 2, assuming arg[0] < arg[1].
+
+        IntrinsicOpCount // Sentinel: keep last.
+    };
+
+    static const char *get_intrinsic_name(IntrinsicOp op);
 
     // We also declare some symbolic names for some of the runtime
     // functions that we want to construct Call nodes to here to avoid
@@ -590,6 +609,10 @@ struct Call : public ExprNode<Call> {
     // pointer to that
     Parameter param;
 
+    static Expr make(Type type, IntrinsicOp op, const std::vector<Expr> &args, CallType call_type,
+                     FunctionPtr func = FunctionPtr(), int value_index = 0,
+                     Buffer<> image = Buffer<>(), Parameter param = Parameter());
+
     static Expr make(Type type, const std::string &name, const std::vector<Expr> &args, CallType call_type,
                      FunctionPtr func = FunctionPtr(), int value_index = 0,
                      Buffer<> image = Buffer<>(), Parameter param = Parameter());
@@ -624,8 +647,8 @@ struct Call : public ExprNode<Call> {
                 call_type == PureIntrinsic);
     }
 
-    bool is_intrinsic(ConstString intrin_name) const {
-        return is_intrinsic() && name == intrin_name;
+    bool is_intrinsic(IntrinsicOp op) const {
+        return is_intrinsic() && this->name == get_intrinsic_name(op);
     }
 
     bool is_extern() const {

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -1307,7 +1307,7 @@ constexpr uint32_t bitwise_or_reduce(uint32_t first, Args... rest) {
 template<typename... Args>
 struct Intrin {
     struct pattern_tag {};
-    Call::ConstString intrin;
+    Call::IntrinsicOp intrin;
     std::tuple<Args...> args;
 
     static constexpr uint32_t binds = bitwise_or_reduce((bindings<Args>::mask)...);
@@ -1373,7 +1373,7 @@ struct Intrin {
     constexpr static bool foldable = false;
 
     HALIDE_ALWAYS_INLINE
-    Intrin(Call::ConstString intrin, Args... args) noexcept : intrin(intrin), args(args...) {}
+    Intrin(Call::IntrinsicOp intrin, Args... args) noexcept : intrin(intrin), args(args...) {}
 };
 
 template<typename... Args>
@@ -1386,8 +1386,8 @@ std::ostream &operator<<(std::ostream &s, const Intrin<Args...> &op) {
 
 template<typename... Args>
 HALIDE_ALWAYS_INLINE
-auto intrin(Call::ConstString name, Args... args) noexcept -> Intrin<decltype(pattern_arg(args))...> {
-    return {name, pattern_arg(args)...};
+auto intrin(Call::IntrinsicOp intrinsic_op, Args... args) noexcept -> Intrin<decltype(pattern_arg(args))...> {
+    return {intrinsic_op, pattern_arg(args)...};
 }
 
 template<typename A>

--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -58,7 +58,7 @@ protected:
         std::vector<Expr> new_args = op->args;
 
         // Check to see if this call is a load
-        if (op->name == Call::glsl_texture_load) {
+        if (op->is_intrinsic(Call::glsl_texture_load)) {
             // Check if the texture coordinate arguments are linear wrt the GPU
             // loop variables
             internal_assert(loop_vars.size() > 0) << "No GPU loop variables found at texture load\n";
@@ -70,7 +70,7 @@ protected:
                     new_args[i] = tag_linear_expression(new_args[i]);
                 }
             }
-        } else if (op->name == Call::glsl_texture_store) {
+        } else if (op->is_intrinsic(Call::glsl_texture_store)) {
             // Check if the value expression is linear wrt the loop variables
             internal_assert(loop_vars.size() > 0) << "No GPU loop variables found at texture store\n";
 
@@ -390,7 +390,7 @@ public:
     using IRVisitor::visit;
 
     void visit(const Call *op) override {
-        if (op->name == Call::glsl_varying) {
+        if (op->is_intrinsic(Call::glsl_varying)) {
             std::string name = op->args[0].as<StringImm>()->value;
             varyings[name] = op->args[1];
         }
@@ -406,7 +406,7 @@ public:
     using IRMutator::visit;
 
     Expr visit(const Call *op) override {
-        if (op->name == Call::glsl_varying) {
+        if (op->is_intrinsic(Call::glsl_varying)) {
             // Replace the call expression with its wrapped argument expression
             return op->args[1];
         } else {
@@ -429,7 +429,7 @@ public:
     using IRMutator::visit;
 
     Expr visit(const Call *op) override {
-        if (op->name == Call::glsl_varying) {
+        if (op->is_intrinsic(Call::glsl_varying)) {
             // Replace the intrinsic tag wrapper with a variable the variable
             // name ends with the tag ".varying"
             std::string name = op->args[0].as<StringImm>()->value;
@@ -935,7 +935,7 @@ public:
 
         // Transform glsl_varying intrinsics into store operations to output the
         // vertex coordinate values.
-        if (op->name == Call::glsl_varying) {
+        if (op->is_intrinsic(Call::glsl_varying)) {
 
             // Construct an expression for the offset of the coordinate value in
             // terms of the current integer loop variables and the varying


### PR DESCRIPTION
...rather than a const-char*; this is a (mostly) source-code compatible change that is intended to remove the need to dllexport data members for Windows builds.

Note that as a drive-by change I regularized various calls to is_intrinsic() to use enums consistently, and added enums for some HVX intrinsics that were previously string-only.