### PR TITLE
Capture rval exprs by value in irmatcher

### DIFF
--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -200,24 +200,30 @@ struct SpecificExpr {
 
     constexpr static uint32_t binds = 0;
 
-    const BaseExprNode &expr;
+    Expr expr;
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
-        return equal(expr, e.expr);
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
+        return equal(*expr.get(), e);
     }
 
     HALIDE_ALWAYS_INLINE
     Expr make(MatcherState &state, halide_type_t type_hint) const {
-        return &expr;
+        return expr;
     }
 
     constexpr static bool foldable = false;
 };
 
 inline std::ostream &operator<<(std::ostream &s, SpecificExpr e) {
-    s << Expr(&e.expr);
+    s << e.expr;
     return s;
 }
 
@@ -229,9 +235,15 @@ struct WildConstInt {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
         static_assert(i >= 0 && i < max_wild, "Wild with out-of-range index");
-        const BaseExprNode *op = &e.expr;
+        const BaseExprNode *op = &e;
         if (op->node_type == IRNodeType::Broadcast) {
             op = ((const Broadcast *)op)->value.get();
         }
@@ -245,7 +257,7 @@ struct WildConstInt {
             state.get_bound_const(i, val, type);
             return op->type == type && value == val.u.i64;
         }
-        state.set_bound_const(i, value, e.expr.type);
+        state.set_bound_const(i, value, e.type);
         return true;
     }
 
@@ -279,9 +291,15 @@ struct WildConstUInt {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
         static_assert(i >= 0 && i < max_wild, "Wild with out-of-range index");
-        const BaseExprNode *op = &e.expr;
+        const BaseExprNode *op = &e;
         if (op->node_type == IRNodeType::Broadcast) {
             op = ((const Broadcast *)op)->value.get();
         }
@@ -295,7 +313,7 @@ struct WildConstUInt {
             state.get_bound_const(i, val, type);
             return op->type == type && value == val.u.u64;
         }
-        state.set_bound_const(i, value, e.expr.type);
+        state.set_bound_const(i, value, e.type);
         return true;
     }
 
@@ -329,10 +347,16 @@ struct WildConstFloat {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
         static_assert(i >= 0 && i < max_wild, "Wild with out-of-range index");
-        halide_type_t ty = e.expr.type;
-        const BaseExprNode *op = &e.expr;
+        halide_type_t ty = e.type;
+        const BaseExprNode *op = &e;
         if (op->node_type == IRNodeType::Broadcast) {
             op = ((const Broadcast *)op)->value.get();
         }
@@ -381,9 +405,15 @@ struct WildConst {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
         static_assert(i >= 0 && i < max_wild, "Wild with out-of-range index");
-        const BaseExprNode *op = &e.expr;
+        const BaseExprNode *op = &e;
         if (op->node_type == IRNodeType::Broadcast) {
             op = ((const Broadcast *)op)->value.get();
         }
@@ -430,11 +460,17 @@ struct Wild {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
         if (bound & binds) {
-            return equal(*state.get_binding(i), e.expr);
+            return equal(*state.get_binding(i), e);
         }
-        state.set_binding(i, e.expr);
+        state.set_binding(i, e);
         return true;
     }
 
@@ -488,9 +524,15 @@ struct Const {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
-        const BaseExprNode *op = &e.expr;
-        if (e.expr.node_type == IRNodeType::Broadcast) {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
+        const BaseExprNode *op = &e;
+        if (e.node_type == IRNodeType::Broadcast) {
             op = ((const Broadcast *)op)->value.get();
         }
         switch (op->node_type) {
@@ -552,7 +594,7 @@ Const pattern_arg(int64_t x) {
 }
 HALIDE_ALWAYS_INLINE
 const SpecificExpr pattern_arg(const Expr &e) {
-    return {*e.get()};
+    return {e};
 }
 
 inline std::ostream &operator<<(std::ostream &s, const Const &op) {
@@ -580,13 +622,19 @@ struct BinOp {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
-        if (e.expr.node_type != Op::_node_type) {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
+        if (e.node_type != Op::_node_type) {
             return false;
         }
-        const Op &op = (const Op &)e.expr;
-        return (a.template match<bound>(SpecificExpr{*op.a.get()}, state) &&
-                b.template match<bound | bindings<A>::mask>(SpecificExpr{*op.b.get()}, state));
+        const Op &op = (const Op &)e;
+        return (a.template match<bound>(*op.a.get(), state) &&
+                b.template match<bound | bindings<A>::mask>(*op.b.get(), state));
     }
 
     template<uint32_t bound, typename Op2, typename A2, typename B2>
@@ -683,13 +731,19 @@ struct CmpOp {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
-        if (e.expr.node_type != Op::_node_type) {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
+        if (e.node_type != Op::_node_type) {
             return false;
         }
-        const Op &op = (const Op &)e.expr;
-        return (a.template match<bound>(SpecificExpr{*op.a.get()}, state) &&
-                b.template match<bound | bindings<A>::mask>(SpecificExpr{*op.b.get()}, state));
+        const Op &op = (const Op &)e;
+        return (a.template match<bound>(*op.a.get(), state) &&
+                b.template match<bound | bindings<A>::mask>(*op.b.get(), state));
     }
 
     template<uint32_t bound, typename Op2, typename A2, typename B2>
@@ -1318,7 +1372,7 @@ struct Intrin {
     HALIDE_ALWAYS_INLINE
     bool match_args(int, const Call &c, MatcherState &state) const noexcept {
         using T = decltype(std::get<i>(args));
-        return (std::get<i>(args).template match<bound>(SpecificExpr{*c.args[i].get()}, state) &&
+        return (std::get<i>(args).template match<bound>(*c.args[i].get(), state) &&
                 match_args<i + 1, bound | bindings<T>::mask>(0, c, state));
     }
 
@@ -1330,11 +1384,17 @@ struct Intrin {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
-        if (e.expr.node_type != IRNodeType::Call) {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
+        if (e.node_type != IRNodeType::Call) {
             return false;
         }
-        const Call &c = (const Call &)e.expr;
+        const Call &c = (const Call &)e;
         return (c.is_intrinsic(intrin) && match_args<0, bound>(0, c, state));
     }
 
@@ -1399,12 +1459,18 @@ struct NotOp {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
-        if (e.expr.node_type != IRNodeType::Not) {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
+        if (e.node_type != IRNodeType::Not) {
             return false;
         }
-        const Not &op = (const Not &)e.expr;
-        return (a.template match<bound>(SpecificExpr{*op.a.get()}, state));
+        const Not &op = (const Not &)e;
+        return (a.template match<bound>(*op.a.get(), state));
     }
 
     template<uint32_t bound, typename A2>
@@ -1457,14 +1523,20 @@ struct SelectOp {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
-        if (e.expr.node_type != Select::_node_type) {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
+        if (e.node_type != Select::_node_type) {
             return false;
         }
-        const Select &op = (const Select &)e.expr;
-        return (c.template match<bound>(SpecificExpr{*op.condition.get()}, state) &&
-                t.template match<bound | bindings<C>::mask>(SpecificExpr{*op.true_value.get()}, state) &&
-                f.template match<bound | bindings<C>::mask | bindings<T>::mask>(SpecificExpr{*op.false_value.get()}, state));
+        const Select &op = (const Select &)e;
+        return (c.template match<bound>(*op.condition.get(), state) &&
+                t.template match<bound | bindings<C>::mask>(*op.true_value.get(), state) &&
+                f.template match<bound | bindings<C>::mask | bindings<T>::mask>(*op.false_value.get(), state));
     }
     template<uint32_t bound, typename C2, typename T2, typename F2>
     HALIDE_ALWAYS_INLINE
@@ -1518,11 +1590,17 @@ struct BroadcastOp {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
-        if (e.expr.node_type == Broadcast::_node_type) {
-            const Broadcast &op = (const Broadcast &)e.expr;
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
+        if (e.node_type == Broadcast::_node_type) {
+            const Broadcast &op = (const Broadcast &)e;
             if ((!known_lanes || lanes == op.lanes) &&
-                a.template match<bound>(SpecificExpr{*op.value.get()}, state)) {
+                a.template match<bound>(*op.value.get(), state)) {
                 return true;
             }
         }
@@ -1589,14 +1667,20 @@ struct RampOp {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
-        if (e.expr.node_type != Ramp::_node_type) {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
+        if (e.node_type != Ramp::_node_type) {
             return false;
         }
-        const Ramp &op = (const Ramp &)e.expr;
+        const Ramp &op = (const Ramp &)e;
         if ((lanes == op.type.lanes() || !known_lanes) &&
-            a.template match<bound>(SpecificExpr{*op.base.get()}, state) &&
-            b.template match<bound | bindings<A>::mask>(SpecificExpr{*op.stride.get()}, state)) {
+            a.template match<bound>(*op.base.get(), state) &&
+            b.template match<bound | bindings<A>::mask>(*op.stride.get(), state)) {
             return true;
         } else {
             return false;
@@ -1662,12 +1746,18 @@ struct NegateOp {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
-        if (e.expr.node_type != Sub::_node_type) {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
+        if (e.node_type != Sub::_node_type) {
             return false;
         }
-        const Sub &op = (const Sub &)e.expr;
-        return (a.template match<bound>(SpecificExpr{*op.b.get()}, state) &&
+        const Sub &op = (const Sub &)e;
+        return (a.template match<bound>(*op.b.get(), state) &&
                 is_zero(op.a));
     }
 
@@ -1740,13 +1830,19 @@ struct CastOp {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
-        if (e.expr.node_type != Cast::_node_type) {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
+        if (e.node_type != Cast::_node_type) {
             return false;
         }
-        const Cast &op = (const Cast &)e.expr;
-        return (e.expr.type == t &&
-                a.template match<bound>(SpecificExpr{*op.value.get()}, state));
+        const Cast &op = (const Cast &)e;
+        return (e.type == t &&
+                a.template match<bound>(*op.value.get(), state));
     }
     template<uint32_t bound, typename A2>
     HALIDE_ALWAYS_INLINE
@@ -1849,11 +1945,17 @@ struct Indeterminate {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
-        if (e.expr.node_type != Call::_node_type) {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
+        if (e.node_type != Call::_node_type) {
             return false;
         }
-        const Call &op = (const Call &)e.expr;
+        const Call &op = (const Call &)e;
         return (op.is_intrinsic(Call::indeterminate_expression));
     }
 
@@ -1884,11 +1986,17 @@ struct Overflow {
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE
-    bool match(SpecificExpr e, MatcherState &state) const noexcept {
-        if (e.expr.node_type != Call::_node_type) {
+    bool match(const SpecificExpr &e, MatcherState &state) const noexcept {
+        return match<bound>(*e.expr.get(), state);
+    }
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE
+    bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
+        if (e.node_type != Call::_node_type) {
             return false;
         }
-        const Call &op = (const Call &)e.expr;
+        const Call &op = (const Call &)e;
         return (op.is_intrinsic(Call::signed_integer_overflow));
     }
 


### PR DESCRIPTION
IRMatcher patterns captured referenced expressions without incrementing their ref count. This is not great for rval Exprs used in a pattern. Naively capturing them by value instead blows up runtime and code size because the SpecificExpr class, which is used to hold an Expr as a node in an IRMatcher pattern is also used by value to pass through expressions when matching. This PR uses const BaseExprNode & for that purpose instead, and converts an attempted match on a SpecificExpr to matching on the underlying const BaseExprNode & as early as possible in the matching tree using a new unwrap helper.