### PR TITLE
Add suffixes to integer constants in CodeGen_C

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2064,12 +2064,12 @@ void CodeGen_C::visit(const IntImm *op) {
     if (op->type == Int(32)) {
         id = std::to_string(op->value);
     } else {
-        print_assignment(op->type, "(" + print_type(op->type) + ")(" + std::to_string(op->value) + ")");
+        print_assignment(op->type, "(" + print_type(op->type) + ")(" + std::to_string(op->value) + "ll)");
     }
 }
 
 void CodeGen_C::visit(const UIntImm *op) {
-    print_assignment(op->type, "(" + print_type(op->type) + ")(" + std::to_string(op->value) + ")");
+    print_assignment(op->type, "(" + print_type(op->type) + ")(" + std::to_string(op->value) + "ull)");
 }
 
 void CodeGen_C::visit(const StringImm *op) {

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -39,6 +39,7 @@ const string headers =
     "#include <math.h>\n"
     "#include <float.h>\n"
     "#include <assert.h>\n"
+    "#include <limits.h>\n"
     "#include <string.h>\n"
     "#include <stdio.h>\n"
     "#include <stdint.h>\n";
@@ -194,6 +195,14 @@ public:
     }
 };
 } // namespace
+
+#if LONG_MAX == 0x7fffffff
+#define ADD_INT64_T_SUFFIX(x) x##ll
+#define ADD_UINT64_T_SUFFIX(x) x##ull
+#else
+#define ADD_INT64_T_SUFFIX(x) x##l
+#define ADD_UINT64_T_SUFFIX(x) x##ul
+#endif
 
 )INLINE_CODE";
 }  // namespace
@@ -2064,12 +2073,12 @@ void CodeGen_C::visit(const IntImm *op) {
     if (op->type == Int(32)) {
         id = std::to_string(op->value);
     } else {
-        print_assignment(op->type, "(" + print_type(op->type) + ")(" + std::to_string(op->value) + "ll)");
+        print_assignment(op->type, "(" + print_type(op->type) + ")(ADD_INT64_T_SUFFIX(" + std::to_string(op->value) + "))");
     }
 }
 
 void CodeGen_C::visit(const UIntImm *op) {
-    print_assignment(op->type, "(" + print_type(op->type) + ")(" + std::to_string(op->value) + "ull)");
+    print_assignment(op->type, "(" + print_type(op->type) + ")(ADD_UINT64_T_SUFFIX(" + std::to_string(op->value) + "))");
 }
 
 void CodeGen_C::visit(const StringImm *op) {

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -335,6 +335,7 @@ CodeGen_C::CodeGen_C(ostream &s, Target t, OutputKind output_kind, const std::st
             << halide_internal_runtime_header_HalideRuntime_h << '\n'
             << halide_internal_initmod_inlined_c << '\n';
         add_common_macros(stream);
+        stream << '\n';
     }
 
     // Throw in a default (empty) definition of HALIDE_FUNCTION_ATTRS
@@ -519,7 +520,7 @@ void CodeGen_C::add_common_macros(std::ostream &dest) {
 #define ADD_INT64_T_SUFFIX(x) x##ll
 #define ADD_UINT64_T_SUFFIX(x) x##ull
 #endif
-        )INLINE_CODE";
+)INLINE_CODE";
     dest << macros;
 }
 
@@ -2961,17 +2962,20 @@ void CodeGen_C::test() {
     m.append(LoweredFunc("test1", args, s, LinkageType::External));
 
     ostringstream source;
+    ostringstream macros;
     {
         CodeGen_C cg(source, Target("host"), CodeGen_C::CImplementation);
         cg.compile(m);
+        cg.add_common_macros(macros);
     }
 
     string src = source.str();
     string correct_source =
         headers +
         globals +
-        string((const char *)halide_internal_runtime_header_HalideRuntime_h) + '\n' +
-        string((const char *)halide_internal_initmod_inlined_c) + R"GOLDEN_CODE(
+        string((const char *) halide_internal_runtime_header_HalideRuntime_h) + '\n' +
+        string((const char *) halide_internal_initmod_inlined_c) + '\n' +
+        macros.str() + R"GOLDEN_CODE(
 #ifndef HALIDE_FUNCTION_ATTRS
 #define HALIDE_FUNCTION_ATTRS
 #endif

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -195,15 +195,6 @@ public:
     }
 };
 } // namespace
-
-#if LONG_MAX == 0x7fffffff
-#define ADD_INT64_T_SUFFIX(x) x##ll
-#define ADD_UINT64_T_SUFFIX(x) x##ull
-#else
-#define ADD_INT64_T_SUFFIX(x) x##l
-#define ADD_UINT64_T_SUFFIX(x) x##ul
-#endif
-
 )INLINE_CODE";
 }  // namespace
 
@@ -343,6 +334,7 @@ CodeGen_C::CodeGen_C(ostream &s, Target t, OutputKind output_kind, const std::st
             << globals
             << halide_internal_runtime_header_HalideRuntime_h << '\n'
             << halide_internal_initmod_inlined_c << '\n';
+        add_common_macros(stream);
     }
 
     // Throw in a default (empty) definition of HALIDE_FUNCTION_ATTRS
@@ -517,6 +509,19 @@ string type_to_c_type(Type type, bool include_space, bool c_plus_plus = true) {
 }
 
 }  // namespace
+
+void CodeGen_C::add_common_macros(std::ostream &dest) {
+    const char *macros = R"INLINE_CODE(
+#if defined __OPENCL_VERSION__
+#define ADD_INT64_T_SUFFIX(x) x##l
+#define ADD_UINT64_T_SUFFIX(x) x##ul
+#else
+#define ADD_INT64_T_SUFFIX(x) x##ll
+#define ADD_UINT64_T_SUFFIX(x) x##ull
+#endif
+        )INLINE_CODE";
+    dest << macros;
+}
 
 void CodeGen_C::add_vector_typedefs(const std::set<Type> &vector_types) {
     if (!vector_types.empty()) {

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -513,9 +513,14 @@ string type_to_c_type(Type type, bool include_space, bool c_plus_plus = true) {
 
 void CodeGen_C::add_common_macros(std::ostream &dest) {
     const char *macros = R"INLINE_CODE(
+// ll suffix in OpenCL is reserver for 128-bit integers.
 #if defined __OPENCL_VERSION__
 #define ADD_INT64_T_SUFFIX(x) x##l
 #define ADD_UINT64_T_SUFFIX(x) x##ul
+// HLSL doesn't have any suffixes.
+#elif defined HLSL_VERSION
+#define ADD_INT64_T_SUFFIX(x) x
+#define ADD_UINT64_T_SUFFIX(x) x
 #else
 #define ADD_INT64_T_SUFFIX(x) x##ll
 #define ADD_UINT64_T_SUFFIX(x) x##ull

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -46,6 +46,8 @@ public:
 
     static void test();
 
+    /**  Add common macros to be shared across all backends */
+    void add_common_macros(std::ostream &dest);
 protected:
 
     /** Emit a declaration. */

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -1158,6 +1158,8 @@ void CodeGen_D3D12Compute_Dev::init_module() {
 
     src_stream << '\n';
 
+    d3d12compute_c.add_common_macros(src_stream);
+
     cur_kernel_name = "";
 }
 

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -634,6 +634,8 @@ void CodeGen_Metal_Dev::init_module() {
                << "#define fast_inverse_sqrt_f32 rsqrt\n"
                << "}\n"; // close namespace
 
+    metal_c.add_common_macros(src_stream);
+
     // __shared always has address space threadgroup.
     src_stream << "#define __address_space___shared threadgroup\n";
 

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -759,6 +759,8 @@ void CodeGen_OpenCL_Dev::init_module() {
 
     src_stream << '\n';
 
+    clc.add_common_macros(src_stream);
+
     // Add at least one kernel to avoid errors on some implementations for functions
     // without any GPU schedules.
     src_stream << "__kernel void _at_least_one_kernel(int x) { }\n";

--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -342,6 +342,7 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::add_kernel(Stmt s,
 void CodeGen_OpenGLCompute_Dev::init_module() {
     src_stream.str("");
     src_stream.clear();
+    glc.add_common_macros(src_stream);
     cur_kernel_name = "";
 }
 

--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -105,6 +105,7 @@ void CodeGen_OpenGL_Dev::add_kernel(Stmt s, const string &name,
 void CodeGen_OpenGL_Dev::init_module() {
     src_stream.str("");
     src_stream.clear();
+    glc->add_common_macros(src_stream);
     cur_kernel_name = "";
 }
 


### PR DESCRIPTION
I think it should work without it most of the time, but we have some weird compiler which can't handle properly some of the generated statements, such as: 

int64_t const _200 = (int64_t)(-2147483648);

and will tell something like:

warning: this decimal constant is unsigned only in ISO C90

which means, if I understand correctly, that it treats 2147483648 as a signed int (and minus is just a unary operator), which won't fit into 32 bit and will overflow. If I add suffixes it works fine and I think it won't change anything for all other compilers (the value field in IntImm is always int64), so hopefully it's ok with you (if not maybe, we can conditionally add suffixes based on value itself?).
