### PR TITLE
Avoid cancelling denominators unless we know they're non-zero.

### DIFF
--- a/src/Simplify_Div.cpp
+++ b/src/Simplify_Div.cpp
@@ -80,6 +80,12 @@ Expr Simplify::visit(const Div *op, ExprInfo *bounds) {
         bounds->trim_bounds_using_alignment();
     }
 
+    bool denominator_non_zero =
+        ((b_bounds.min_defined && b_bounds.min > 0) ||
+         (b_bounds.max_defined && b_bounds.max < 0) ||
+         (b_bounds.alignment.remainder != 0));
+
+
     if (may_simplify(op->type)) {
 
         int lanes = op->type.lanes();
@@ -93,8 +99,9 @@ Expr Simplify::visit(const Div *op, ExprInfo *bounds) {
             rewrite(x / 1, x) ||
             (!op->type.is_float() &&
              rewrite(x / 0, IRMatcher::Indeterminate())) ||
-            rewrite(0 / x, 0) ||
-            rewrite(x / x, 1) ||
+            (denominator_non_zero &&
+             (rewrite(0 / x, 0) ||
+              rewrite(x / x, 1))) ||
             rewrite(c0 / c1, fold(c0 / c1))) {
             return rewrite.result;
         }

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -233,7 +233,9 @@ void check_algebra() {
 
     check(0/max(x, 1), 0);
     check(x/1, x);
-    check(x/x, 1);
+    check(max(x, 1)/(max(x, 1)), 1);
+    check(min(x, -1)/(min(x, -1)), 1);
+    check((x*2+1)/(x*2+1), 1);
     check((-1)/(x*2 + 1), select(x < 0, 1, -1));
     check(Expr(7)/3, 2);
     check(Expr(6.0f)/2.0f, 3.0f);


### PR DESCRIPTION
Fixes #4003