### PR TITLE
Add Target::TracePipeline feature flag

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2990,6 +2990,10 @@ public:
         get_pipeline().add_requirement(condition, std::forward<Args>(args)...);
     }
 
+    void trace_pipeline() {
+        get_pipeline().trace_pipeline();
+    }
+
 protected:
     GeneratorBase(size_t size, const void *introspection_helper);
     void set_generator_names(const std::string &registered_name, const std::string &stub_name);

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -84,6 +84,7 @@ Module lower(const vector<Function> &output_funcs,
              const vector<Argument> &args,
              const LinkageType linkage_type,
              const vector<Stmt> &requirements,
+             bool trace_pipeline,
              const vector<IRMutator *> &custom_passes) {
     std::vector<std::string> namespaces;
     std::string simple_pipeline_name = extract_namespaces(pipeline_name, namespaces);
@@ -140,7 +141,7 @@ Module lower(const vector<Function> &output_funcs,
     }
 
     debug(1) << "Injecting tracing...\n";
-    s = inject_tracing(s, pipeline_name, env, outputs, t);
+    s = inject_tracing(s, pipeline_name, trace_pipeline, env, outputs, t);
     debug(2) << "Lowering after injecting tracing:\n" << s << '\n';
 
     debug(1) << "Adding checks for parameters\n";
@@ -480,6 +481,7 @@ Stmt lower_main_stmt(const std::vector<Function> &output_funcs,
                      const std::string &pipeline_name,
                      const Target &t,
                      const std::vector<Stmt> &requirements,
+                     bool trace_pipeline,
                      const std::vector<IRMutator *> &custom_passes) {
     // We really ought to start applying for appellation d'origine contrôlée
     // status on types representing arguments in the Halide compiler.
@@ -491,7 +493,7 @@ Stmt lower_main_stmt(const std::vector<Function> &output_funcs,
         }
     }
 
-    Module module = lower(output_funcs, pipeline_name, t, args, LinkageType::External, requirements, custom_passes);
+    Module module = lower(output_funcs, pipeline_name, t, args, LinkageType::External, requirements, trace_pipeline, custom_passes);
 
     return module.functions().front().body;
 }

--- a/src/Lower.h
+++ b/src/Lower.h
@@ -32,6 +32,7 @@ Module lower(const std::vector<Function> &output_funcs,
              const std::vector<Argument> &args,
              const LinkageType linkage_type,
              const std::vector<Stmt> &requirements = std::vector<Stmt>(),
+             bool trace_pipeline = false,
              const std::vector<IRMutator *> &custom_passes = std::vector<IRMutator *>());
 
 /** Given a halide function with a schedule, create a statement that
@@ -43,6 +44,7 @@ Stmt lower_main_stmt(const std::vector<Function> &output_funcs,
                      const std::string &pipeline_name,
                      const Target &t,
                      const std::vector<Stmt> &requirements = std::vector<Stmt>(),
+                     bool trace_pipeline = false,
                      const std::vector<IRMutator *> &custom_passes = std::vector<IRMutator *>());
 
 void lower_test();

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -466,6 +466,9 @@ public:
      * in the order added. */
     void add_requirement(Expr condition, std::vector<Expr> &error);
 
+    /** Generate begin_pipeline and end_pipeline tracing calls for this pipeline. */
+    void trace_pipeline();
+
     template<typename ...Args>
     inline HALIDE_NO_USER_CODE_INLINE void add_requirement(Expr condition, Args&&... args) {
         std::vector<Expr> collected_args;

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -354,6 +354,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"trace_loads", Target::TraceLoads},
     {"trace_stores", Target::TraceStores},
     {"trace_realizations", Target::TraceRealizations},
+    {"trace_pipeline", Target::TracePipeline},
     {"d3d12compute", Target::D3D12Compute},
     {"strict_float", Target::StrictFloat},
     {"legacy_buffer_wrappers", Target::LegacyBufferWrappers},

--- a/src/Target.h
+++ b/src/Target.h
@@ -107,6 +107,7 @@ struct Target {
         TraceLoads = halide_target_feature_trace_loads,
         TraceStores = halide_target_feature_trace_stores,
         TraceRealizations = halide_target_feature_trace_realizations,
+        TracePipeline = halide_target_feature_trace_pipeline,
         D3D12Compute = halide_target_feature_d3d12compute,
         StrictFloat = halide_target_feature_strict_float,
         LegacyBufferWrappers = halide_target_feature_legacy_buffer_wrappers,

--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -321,7 +321,7 @@ public:
     RemoveRealizeOverOutput(const vector<Function> &o) : outputs(o) {}
 };
 
-Stmt inject_tracing(Stmt s, const string &pipeline_name,
+Stmt inject_tracing(Stmt s, const string &pipeline_name, bool trace_pipeline,
                     const map<string, Function> &env, const vector<Function> &outputs,
                     const Target &t) {
     Stmt original = s;
@@ -347,7 +347,7 @@ Stmt inject_tracing(Stmt s, const string &pipeline_name,
     // Strip off the dummy realize blocks
     s = RemoveRealizeOverOutput(outputs).mutate(s);
 
-    if (!s.same_as(original) || t.has_feature(Target::TracePipeline)) {
+    if (!s.same_as(original) || trace_pipeline || t.has_feature(Target::TracePipeline)) {
         // Add pipeline start and end events
         TraceEventBuilder builder;
         builder.func = pipeline_name;

--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -347,7 +347,7 @@ Stmt inject_tracing(Stmt s, const string &pipeline_name,
     // Strip off the dummy realize blocks
     s = RemoveRealizeOverOutput(outputs).mutate(s);
 
-    if (!s.same_as(original)) {
+    if (!s.same_as(original) || t.has_feature(Target::TracePipeline)) {
         // Add pipeline start and end events
         TraceEventBuilder builder;
         builder.func = pipeline_name;

--- a/src/Tracing.h
+++ b/src/Tracing.h
@@ -18,6 +18,7 @@ namespace Internal {
  * allocations. Should be done before storage flattening, but after
  * all bounds inference. */
 Stmt inject_tracing(Stmt, const std::string &pipeline_name,
+                    bool trace_pipeline,
                     const std::map<std::string, Function> &env,
                     const std::vector<Function> &outputs,
                     const Target &Target);

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1255,6 +1255,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_trace_loads, ///< Trace all loads done by the pipeline. Equivalent to calling Func::trace_loads on every non-inlined Func.
     halide_target_feature_trace_stores, ///< Trace all stores done by the pipeline. Equivalent to calling Func::trace_stores on every non-inlined Func.
     halide_target_feature_trace_realizations, ///< Trace all realizations done by the pipeline. Equivalent to calling Func::trace_realizations on every non-inlined Func.
+    halide_target_feature_trace_pipeline, ///< Trace the pipeline.
     halide_target_feature_cuda_capability61,  ///< Enable CUDA compute capability 6.1 (Pascal)
     halide_target_feature_hvx_v65, ///< Enable Hexagon v65 architecture.
     halide_target_feature_hvx_v66, ///< Enable Hexagon v66 architecture.

--- a/test/correctness/tracing.cpp
+++ b/test/correctness/tracing.cpp
@@ -115,10 +115,74 @@ int my_trace(void *user_context, const halide_trace_event_t *ev) {
     return n_trace;
 }
 
+bool check_trace_correct(event* correct_trace, int correct_trace_length) {
+    int n = n_trace > correct_trace_length ? n_trace : correct_trace_length;
+    for (int i = 0; i < n; i++) {
+        event recorded = {0};
+        if (i < n_trace) recorded = trace[i];
+        event correct = {0};
+        if (i < correct_trace_length) correct = correct_trace[i];
+
+        if (!events_match(recorded, correct)) {
+            constexpr int radius_max = 2;
+
+            // Uh oh. Maybe it's just a reordered load.
+            bool reordered = false;
+            for (int radius = 1; radius <= radius_max; ++radius) {
+                if (i >= radius &&
+                    events_match(recorded, correct_trace[i-radius]) &&
+                    recorded.event_type == 0 &&
+                    correct.event_type == 0) {
+                    // Phew.
+                    reordered = true;
+                    break;
+                }
+
+                if (i < correct_trace_length-radius &&
+                    events_match(recorded, correct_trace[i+radius]) &&
+                    recorded.event_type == 0 &&
+                    correct.event_type == 0) {
+                    // Phew.
+                    reordered = true;
+                    break;
+                }
+            }
+            if (reordered) {
+                continue;
+            }
+
+            printf("Traces differs at event %d:\n"
+                   "-------------------------------\n"
+                   "Correct trace:\n", i);
+            for (int j = 0; j < correct_trace_length; j++) {
+                if (j == i) printf(" ===> ");
+                print_event(correct_trace[j]);
+            }
+            printf("-------------------------------\n"
+                   "Trace encountered:\n");
+            for (int j = 0; j < n_trace; j++) {
+                if (j == i) printf(" ===> ");
+                print_event_source(trace[j]);
+            }
+            printf("-------------------------------\n");
+            return false;
+        }
+    }
+    return true;
+}
+
+void reset_trace() {
+    n_trace = 0;
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {
     ImageParam input(Float(32), 1, "i");
+
+    Buffer<float> input_buf(10);
+    input_buf.fill(0.f);
+    input.set(input_buf);
 
     Func f("f"), g("g");
     Var x;
@@ -126,25 +190,39 @@ int main(int argc, char **argv) {
     f(x) = g(x)[0] + g(x+1)[1] + input(x);
 
     f.vectorize(x, 4);
+    g.store_root().compute_at(f, x);
+    g.vectorize(x, 4);
+
+    f.set_custom_trace(&my_trace);
+
+    // Check that Target::TracePipeline works.
+    f.realize(10, get_jit_target_from_environment().with_feature(Target::TracePipeline));
+
+    // The golden trace, recorded when this test was written
+    event correct_pipeline_trace[] = {
+        {102, 0, 8, 3, 0, 0, 0, 0, {0, 0, 0, 0}, {0.000000f, 0.000000f, 0.000000f, 0.000000f}, ""},
+        {102, 1, 9, 3, 0, 0, 0, 0, {0, 0, 0, 0}, {0.000000f, 0.000000f, 0.000000f, 0.000000f}, ""},
+    };
+    if (!check_trace_correct(correct_pipeline_trace, 2)) {
+        return -1;
+    }
+
+
+    // Test a more interesting trace.
+    reset_trace();
+
+    g.add_trace_tag("g whiz");
+    g.trace_stores().trace_loads().trace_realizations();
+
     f.trace_stores();
     f.trace_realizations();
     f.add_trace_tag("arbitrary data on f");
     // All non-null characters are OK
     f.add_trace_tag("more:arbitrary \xff data on f?");
 
-    g.add_trace_tag("g whiz");
-    g.vectorize(x, 4);
-    g.store_root().compute_at(f, x);
-    g.trace_stores().trace_loads().trace_realizations();
-
     input.trace_loads();
 
-    Buffer<float> input_buf(10);
-    input_buf.fill(0.f);
-    input.set(input_buf);
-
-    f.set_custom_trace(&my_trace);
-    f.realize(10);
+    f.realize(10, get_jit_target_from_environment());
 
     // The golden trace, recorded when this test was written
     event correct_trace[] = {
@@ -197,58 +275,8 @@ int main(int argc, char **argv) {
     };
 
     int correct_trace_length = sizeof(correct_trace)/sizeof(correct_trace[0]);
-
-    int n = n_trace > correct_trace_length ? n_trace : correct_trace_length;
-    for (int i = 0; i < n; i++) {
-        event recorded = {0};
-        if (i < n_trace) recorded = trace[i];
-        event correct = {0};
-        if (i < correct_trace_length) correct = correct_trace[i];
-
-        if (!events_match(recorded, correct)) {
-            constexpr int radius_max = 2;
-
-            // Uh oh. Maybe it's just a reordered load.
-            bool reordered = false;
-            for (int radius = 1; radius <= radius_max; ++radius) {
-                if (i >= radius &&
-                    events_match(recorded, correct_trace[i-radius]) &&
-                    recorded.event_type == 0 &&
-                    correct.event_type == 0) {
-                    // Phew.
-                    reordered = true;
-                    break;
-                }
-
-                if (i < correct_trace_length-radius &&
-                    events_match(recorded, correct_trace[i+radius]) &&
-                    recorded.event_type == 0 &&
-                    correct.event_type == 0) {
-                    // Phew.
-                    reordered = true;
-                    break;
-                }
-            }
-            if (reordered) {
-                continue;
-            }
-
-            printf("Traces differs at event %d:\n"
-                   "-------------------------------\n"
-                   "Correct trace:\n", i);
-            for (int j = 0; j < correct_trace_length; j++) {
-                if (j == i) printf(" ===> ");
-                print_event(correct_trace[j]);
-            }
-            printf("-------------------------------\n"
-                   "Trace encountered:\n");
-            for (int j = 0; j < n_trace; j++) {
-                if (j == i) printf(" ===> ");
-                print_event_source(trace[j]);
-            }
-            printf("-------------------------------\n");
-            return -1;
-        }
+    if (!check_trace_correct(correct_trace, correct_trace_length)) {
+        return -1;
     }
 
     printf("Success!\n");

--- a/test/generator/user_context_generator.cpp
+++ b/test/generator/user_context_generator.cpp
@@ -17,7 +17,7 @@ public:
         output(x, y) = g(x, y);
 
         output.parallel(y);
-        output.trace_stores();
+        trace_pipeline();
 
         // This test won't work in the profiler, because the profiler
         // insists on calling malloc with nullptr user context.


### PR DESCRIPTION
This PR adds a `Target::TracePipeline` target feature flag. The motivation for this is that I would like to get a `halide_trace` call corresponding to the beginning and end of a pipeline, but no more than this. I don't think it is possible to do this because the next possible thing to trace is realizations, but if a pipeline contains multiple compute_root stages (or even outputs), the realizations are hard to predict and may not cover the whole pipeline.

I'm throwing this out there just as a suggestion for now. This PR doesn't have a lot of time invested in it, but, I really would like to get a way to get traces at the pipeline level somehow. The motivation for this is I want to generate android traces corresponding to *most* of our pipelines.