### PR TITLE
Fix CMake slowness for 'make distrib'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,17 +493,5 @@ foreach(F ${FILES})
           DESTINATION .)
 endforeach()
 
-if (NOT WIN32)
-  set(CPACK_PACKAGE_EXT "tar.gz")
-  set(DISTRIB_PACKAGE_EXT "tgz")
-else()
-  set(CPACK_PACKAGE_EXT "zip")
-  set(DISTRIB_PACKAGE_EXT ${CPACK_PACKAGE_EXT})
-endif()
-
 add_custom_target(distrib
-  COMMAND cmake --build . --config $<CONFIG> --target package
-  COMMAND cmake -E echo "${CPACK_PACKAGE_VENDOR}.${CPACK_PACKAGE_EXT} \"=>\" ${CPACK_PACKAGE_VENDOR}.${DISTRIB_PACKAGE_EXT}"
-  COMMAND cmake -E rename "${CPACK_PACKAGE_VENDOR}.${CPACK_PACKAGE_EXT}" "${CPACK_PACKAGE_VENDOR}.${DISTRIB_PACKAGE_EXT}"
-  BYPRODUCTS "${CPACK_PACKAGE_VENDOR}.${DISTRIB_PACKAGE_EXT}"
-  USES_TERMINAL)
+  COMMAND cmake -E echo "\\'make distrib\\' is not available under CMake. Use \\'make package\\' instead.")

--- a/test/scripts/build_travis.sh
+++ b/test/scripts/build_travis.sh
@@ -31,6 +31,10 @@ if [ ${BUILD_SYSTEM} = 'CMAKE' ]; then
         -G "Unix Makefiles" \
         ../
 
+  # Under CMake, 'make distrib' ignores -j, apparently because
+  # CPack invokes an external command. Workaround for now
+  # is to make all first, then make distrib.
+  make ${MAKEFLAGS}
   make ${MAKEFLAGS} distrib
   make ${MAKEFLAGS} test_internal
 

--- a/test/scripts/build_travis.sh
+++ b/test/scripts/build_travis.sh
@@ -31,11 +31,7 @@ if [ ${BUILD_SYSTEM} = 'CMAKE' ]; then
         -G "Unix Makefiles" \
         ../
 
-  # Under CMake, 'make distrib' ignores -j, apparently because
-  # CPack invokes an external command. Workaround for now
-  # is to make all first, then make distrib.
-  make ${MAKEFLAGS}
-  make ${MAKEFLAGS} distrib
+  make ${MAKEFLAGS} package
   make ${MAKEFLAGS} test_internal
 
   if [ ${HALIDE_SHARED_LIBRARY} = 'ON' ]; then


### PR DESCRIPTION
For posterity: invoking cmake on itself can force parallel builds to serialize, at least for some variants of CMake and make; this was being triggered by wrapper code that provided a `make distrib` target for CMake. It didn't seem obviously fixable, so we now just require CMake users to use `make package` instead, as that is the "magic" target that CPack provides/requires.