### PR TITLE
move add_common_macros to after the version directive in OpenGL Compute

### DIFF
--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -292,6 +292,7 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::add_kernel(Stmt s,
     } else {
         stream << "#version 430\n";
     }
+    add_common_macros(stream);
     stream << "float float_from_bits(int x) { return intBitsToFloat(int(x)); }\n";
 
     for (size_t i = 0; i < args.size(); i++) {
@@ -344,7 +345,6 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::add_kernel(Stmt s,
 void CodeGen_OpenGLCompute_Dev::init_module() {
     src_stream.str("");
     src_stream.clear();
-    glc.add_common_macros(src_stream);
     cur_kernel_name = "";
 }
 


### PR DESCRIPTION
GLSL "version" directive must be first statement.  "add_common_macros" added macros before the "version" directive in OpenGL compute, which causes the following error:

Could not compile shader:
0(14) : error C0204: version directive must be first statement and may not be repeated

This PR move "add_common_macros" to after generating "version" directive in OpenGLCompute.

