### PR TITLE
Give apps/autoscheduler its own logging function

### DIFF
--- a/apps/autoscheduler/ASLog.cpp
+++ b/apps/autoscheduler/ASLog.cpp
@@ -1,0 +1,21 @@
+#include "Halide.h"
+#include "ASLog.h"
+
+namespace Halide {
+namespace Internal {
+
+int aslog::aslog_level() {
+    static int cached_aslog_level = ([]() -> int {
+        // If HL_DEBUG_AUTOSCHEDULE is defined, use that value.
+        std::string lvl = get_env_variable("HL_DEBUG_AUTOSCHEDULE");
+        if (!lvl.empty()) {
+            return atoi(lvl.c_str());
+        }
+        // Otherwise, use HL_DEBUG_CODEGEN.
+        return debug::debug_level();
+    })();
+    return cached_aslog_level;
+}
+
+}  // namespace Internal
+}  // namespace Halide

--- a/apps/autoscheduler/ASLog.h
+++ b/apps/autoscheduler/ASLog.h
@@ -1,0 +1,29 @@
+#ifndef ASLOG_H
+#define ASLOG_H
+
+#include "Halide.h"
+
+namespace Halide {
+namespace Internal {
+
+class aslog {
+    const bool logging;
+
+public:
+    aslog(int verbosity) : logging(verbosity <= aslog_level()) {}
+
+    template<typename T>
+    aslog &operator<<(T&& x) {
+        if (logging) {
+            std::cerr << std::forward<T>(x);
+        }
+        return *this;
+    }
+
+    static int aslog_level();
+};
+
+}  // namespace Internal
+}  // namespace Halide
+
+#endif

--- a/apps/autoscheduler/DefaultCostModel.cpp
+++ b/apps/autoscheduler/DefaultCostModel.cpp
@@ -11,6 +11,7 @@
 #include <random>
 #include <string>
 
+#include "ASLog.h"
 #include "CostModel.h"
 #include "HalideBuffer.h"
 #include "NetworkSize.h"
@@ -42,6 +43,7 @@ extern "C" float weights_trunk_conv1_weight[];
 extern "C" int weights_trunk_conv1_weight_length;
 
 using namespace Halide;
+using Halide::Internal::aslog;
 
 Runtime::Buffer<float> buffer_from_file(const std::string &filename, const std::vector<int> &shape) {
     Runtime::Buffer<float> buf(shape);
@@ -53,7 +55,7 @@ Runtime::Buffer<float> buffer_from_file(const std::string &filename, const std::
     if (i.fail()) {
         auto seed = time(NULL);
         std::mt19937 rng((uint32_t) seed);
-        std::cerr << "Could not load buffer from file: " << filename << "\n Using random values with seed = " << seed << " instead.\n";
+        aslog(0) << "Could not load buffer from file: " << filename << "\n Using random values with seed = " << seed << " instead.\n";
         buf.for_each_value([&rng](float &f) {
                 f = ((float)rng()) / rng.max() - 0.5f;
             });
@@ -214,18 +216,18 @@ class DefaultCostModel : public CostModel {
             *(cost_ptrs(i)) = dst(i);
             if (std::isnan(dst(i))) {
                 any_nans = true;
-                std::cerr << "Prediction " << i << " is NaN. True runtime is " << true_runtimes(i) << "\n";
-                std::cerr << "Checking pipeline features for NaNs...\n";
+                aslog(0) << "Prediction " << i << " is NaN. True runtime is " << true_runtimes(i) << "\n";
+                aslog(0) << "Checking pipeline features for NaNs...\n";
                 pipeline_feat_queue.for_each_value([&](float f) { if (std::isnan(f)) abort(); });
-                std::cerr << "None found\n";
-                std::cerr << "Checking schedule features for NaNs...\n";
+                aslog(0) << "None found\n";
+                aslog(0) << "Checking schedule features for NaNs...\n";
                 schedule_feat_queue.for_each_value([&](float f) { if (std::isnan(f)) abort(); });
-                std::cerr << "None found\n";
-                std::cerr << "Checking network weights for NaNs...\n";
+                aslog(0) << "None found\n";
+                aslog(0) << "Checking network weights for NaNs...\n";
                 for_each_weight([&](const Runtime::Buffer<float> &buf) {
                         buf.for_each_value([&](float f) { if (std::isnan(f)) abort(); });
                     });
-                std::cerr << "None found\n";
+                aslog(0) << "None found\n";
             }
             assert(true_runtimes(i) > 0);
         }

--- a/apps/autoscheduler/Featurization.h
+++ b/apps/autoscheduler/Featurization.h
@@ -5,6 +5,8 @@
 #include <iostream>
 #include <cstring>
 
+#include "ASLog.h"
+
 namespace Halide {
 namespace Internal {
 
@@ -93,7 +95,7 @@ struct PipelineFeatures {
             if (!types_in_use[i]) continue;
 
 
-            std::cerr << "    Featurization for type " << type_names[i] << '\n'
+            aslog(0)  << "    Featurization for type " << type_names[i] << '\n'
                       << "     Op histogram:\n"
                       << "      Constant:   " << op_histogram[(int)OpType::Const][i] << '\n'
                       << "      Cast:       " << op_histogram[(int)OpType::Cast][i] << '\n'
@@ -298,7 +300,7 @@ struct ScheduleFeatures {
     double working_set_at_root = 0;
 
     void dump() const {
-        std::cerr << "    num_realizations:                      " << num_realizations << '\n'
+        aslog(0)  << "    num_realizations:                      " << num_realizations << '\n'
                   << "    num_productions:                       " << num_productions << '\n'
                   << "    points_computed_per_realization:       " << points_computed_per_realization << '\n'
                   << "    points_computed_per_production:        " << points_computed_per_production << '\n'

--- a/apps/autoscheduler/FunctionDAG.h
+++ b/apps/autoscheduler/FunctionDAG.h
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "Halide.h"
+#include "ASLog.h"
 #include "Errors.h"
 
 namespace Halide {
@@ -176,24 +177,24 @@ public:
 
     void dump(const char *prefix) const {
         if (count() > 1) {
-            debug(0) << prefix << count() << " x\n";
+            aslog(0) << prefix << count() << " x\n";
         }
         for (size_t i = 0; i < producer_storage_dims(); i++) {
-            debug(0) << prefix << "  [";
+            aslog(0) << prefix << "  [";
 
             for (size_t j = 0; j < consumer_loop_dims(); j++) {
                 const auto &c = (*this)(i, j);
                 if (!c.exists) {
-                    debug(0) << " _  ";
+                    aslog(0) << " _  ";
                 } else if (c.denominator == 1) {
-                    debug(0) << " " << c.numerator << "  ";
+                    aslog(0) << " " << c.numerator << "  ";
                 } else {
-                    debug(0) << c.numerator << "/" << c.denominator << " ";
+                    aslog(0) << c.numerator << "/" << c.denominator << " ";
                 }
             }
-            debug(0) << "]\n";
+            aslog(0) << "]\n";
         }
-        debug(0) << "\n";
+        aslog(0) << "\n";
     }
 };
 
@@ -296,11 +297,11 @@ struct BoundContents {
         for (int i = 0; i < layout->total_size; i++) {
             auto p = data()[i];
             if (p.max() < p.min()) {
-                debug(0) << "Bad bounds object:\n";
+                aslog(0) << "Bad bounds object:\n";
                 for (int j = 0; j < layout->total_size; j++) {
-                    if (i == j) debug(0) << "=> ";
-                    else debug(0) << "   ";
-                    debug(0) << j << ": " << data()[j].min() << ", " << data()[j].max() << "\n";
+                    if (i == j) aslog(0) << "=> ";
+                    else aslog(0) << "   ";
+                    aslog(0) << j << ": " << data()[j].min() << ", " << data()[j].max() << "\n";
                 }
                 internal_error << "Aborting";
             }
@@ -650,10 +651,10 @@ struct FunctionDAG {
                         }
                     }
                     internal_assert(consumer_dim >= 0) << "Could not find consumer loop variable: " << var->name << "\n";
-                    debug(2) << "Bound is affine: " << e << " == " << var->name << " * " << coeff << " + " << constant << "\n";
+                    aslog(2) << "Bound is affine: " << e << " == " << var->name << " * " << coeff << " + " << constant << "\n";
                 } else {
                     affine = false;
-                    debug(2) << "Bound is non-affine: " << e << "\n";
+                    aslog(2) << "Bound is non-affine: " << e << "\n";
                 }
             }
         };
@@ -1484,39 +1485,39 @@ struct FunctionDAG {
 
     void dump() const {
         for (const Node &n : nodes) {
-            debug(0) << "Node: " << n.func.name() << '\n'
+            aslog(0) << "Node: " << n.func.name() << '\n'
                      << "  Symbolic region required: \n";
             for (const Interval &i : n.region_required) {
-                debug(0) << "    " << i.min << ", " << i.max << '\n';
+                aslog(0) << "    " << i.min << ", " << i.max << '\n';
             }
-            debug(0) << "  Region computed: \n";
+            aslog(0) << "  Region computed: \n";
             for (const auto &i : n.region_computed) {
-                debug(0) << "    " << i.in.min << ", " << i.in.max << '\n';
+                aslog(0) << "    " << i.in.min << ", " << i.in.max << '\n';
             }
             for (size_t i = 0; i < n.stages.size(); i++) {
-                debug(0) << "  Stage " << i << ":\n";
+                aslog(0) << "  Stage " << i << ":\n";
                 for (const auto &l : n.stages[i].loop) {
-                    debug(0) << "    " << l.var << " " << l.min << " " << l.max << '\n';
+                    aslog(0) << "    " << l.var << " " << l.min << " " << l.max << '\n';
                 }
                 n.stages[i].features.dump();
             }
-            debug(0) << "  pointwise: " << n.is_pointwise
+            aslog(0) << "  pointwise: " << n.is_pointwise
                      << " boundary condition: " << n.is_boundary_condition
                      << " wrapper: " << n.is_wrapper
                      << " input: " << n.is_input
                      << " output: " << n.is_output << "\n";
         }
         for (const Edge &e : edges) {
-            debug(0) << "Edge: " << e.producer->func.name() << " -> " << e.consumer->name << '\n'
+            aslog(0) << "Edge: " << e.producer->func.name() << " -> " << e.consumer->name << '\n'
                      << "  Footprint: \n";
             int j = 0;
             for (const auto &i : e.bounds) {
-                debug(0) << "    Min " << j << ": " << i.first.expr << '\n';
-                debug(0) << "    Max " << j << ": " << i.second.expr << '\n';
+                aslog(0) << "    Min " << j << ": " << i.first.expr << '\n';
+                aslog(0) << "    Max " << j << ": " << i.second.expr << '\n';
                 j++;
             }
 
-            debug(0) << "  Load Jacobians:\n";
+            aslog(0) << "  Load Jacobians:\n";
             for (const auto &jac : e.load_jacobians) {
                 jac.dump("  ");
             }

--- a/apps/support/autoscheduler.inc
+++ b/apps/support/autoscheduler.inc
@@ -45,6 +45,7 @@ $(AUTOSCHED_BIN)/cost_model/%.a: $(AUTOSCHED_BIN)/cost_model.generator
 # is expected to be present (in the loading binary), so we explicitly make the symbols
 # undefined rather than dependent on libHalide.so.
 $(AUTOSCHED_BIN)/libauto_schedule.so: $(AUTOSCHED_SRC)/AutoSchedule.cpp \
+							$(AUTOSCHED_SRC)/ASLog.cpp \
 							$(AUTOSCHED_SRC)/DefaultCostModel.cpp \
 							$(AUTOSCHED_SRC)/FunctionDAG.h \
 							$(AUTOSCHED_SRC)/Featurization.h \
@@ -55,7 +56,7 @@ $(AUTOSCHED_BIN)/libauto_schedule.so: $(AUTOSCHED_SRC)/AutoSchedule.cpp \
 							$(GENERATOR_DEPS) \
 							$(AUTOSCHED_BIN)/auto_schedule_runtime.a
 	@mkdir -p $(@D)
-	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC $(CXXFLAGS) -g -I $(AUTOSCHED_BIN)/cost_model $(AUTOSCHED_SRC)/AutoSchedule.cpp $(AUTOSCHED_SRC)/DefaultCostModel.cpp $(AUTOSCHED_WEIGHT_OBJECTS) $(AUTOSCHED_COST_MODEL_LIBS) $(AUTOSCHED_BIN)/auto_schedule_runtime.a $(OPTIMIZE) -o $@ $(HALIDE_SYSTEM_LIBS)
+	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC $(CXXFLAGS) -g -I $(AUTOSCHED_BIN)/cost_model $(AUTOSCHED_SRC)/AutoSchedule.cpp $(AUTOSCHED_SRC)/ASLog.cpp $(AUTOSCHED_SRC)/DefaultCostModel.cpp $(AUTOSCHED_WEIGHT_OBJECTS) $(AUTOSCHED_COST_MODEL_LIBS) $(AUTOSCHED_BIN)/auto_schedule_runtime.a $(OPTIMIZE) -o $@ $(HALIDE_SYSTEM_LIBS)
 
 $(AUTOSCHED_BIN)/train_cost_model: $(AUTOSCHED_SRC)/train_cost_model.cpp \
 						 $(AUTOSCHED_SRC)/DefaultCostModel.cpp \


### PR DESCRIPTION
This replaces the use of `debug()` in apps/autoscheduler code with its own logger (named `aslog()` for now, short for auto-scheduler-log.)

The motivation here is to allow supressing of the autoscheduler log output without also having to supress normal codegen output.

aslog() has the same semantics as debug(), except that it preferentially tries to read from HL_DEBUG_AUTOSCHEDULE for a verbosity; if that isn't set, it falls back to the same value as HL_DEBUG_CODEGEN. (Thus, the autoschedule output can be suppressed by HL_DEBUG_AUTOSCHEDULE=-1.)

Note also that all use of std::cerr that was for anything other than a fatal error was converted to aslog(0).

And yes: "aslog" isn't a very good name; I'm happy to replace it with literally anything you'd like before submitting this :-)