### PR TITLE
Fix bug injected by https://github.com/halide/Halide/pull/4058

### DIFF
--- a/apps/autoscheduler/ASLog.cpp
+++ b/apps/autoscheduler/ASLog.cpp
@@ -1,8 +1,38 @@
-#include "Halide.h"
 #include "ASLog.h"
 
 namespace Halide {
 namespace Internal {
+
+namespace {
+
+std::string get_env_variable(char const *env_var_name) {
+    if (!env_var_name) {
+        return "";
+    }
+
+    #ifdef _MSC_VER
+    // call getenv_s without a buffer to determine the correct string length:
+    size_t length = 0;
+    if ((getenv_s(&length, NULL, 0, env_var_name) != 0) || (length == 0)) {
+        return "";
+    }
+    // call it again to retrieve the value of the environment variable;
+    // note that 'length' already accounts for the null-terminator
+    std::string lvl(length - 1, '@');
+    size_t read = 0;
+    if ((getenv_s(&read, &lvl[0], length, env_var_name) != 0) || (read != length)) {
+        return "";
+    }
+    return lvl;
+    #else
+    char *lvl = getenv(env_var_name);
+    if (lvl) return std::string(lvl);
+    #endif
+
+    return "";
+}
+
+}  // namespace
 
 int aslog::aslog_level() {
     static int cached_aslog_level = ([]() -> int {
@@ -12,7 +42,8 @@ int aslog::aslog_level() {
             return atoi(lvl.c_str());
         }
         // Otherwise, use HL_DEBUG_CODEGEN.
-        return debug::debug_level();
+        lvl = get_env_variable("HL_DEBUG_CODEGEN");
+        return !lvl.empty() ? atoi(lvl.c_str()) : 0;
     })();
     return cached_aslog_level;
 }

--- a/apps/autoscheduler/ASLog.h
+++ b/apps/autoscheduler/ASLog.h
@@ -1,7 +1,13 @@
 #ifndef ASLOG_H
 #define ASLOG_H
 
-#include "Halide.h"
+// This class is used by train_cost_model, which doesn't link to
+// libHalide, so (despite the namespace) we are better off not
+// including Halide.h, lest we reference something we won't have available 
+
+#include <cstdlib>
+#include <iostream>
+#include <utility>
 
 namespace Halide {
 namespace Internal {

--- a/apps/autoscheduler/train_cost_model.cpp
+++ b/apps/autoscheduler/train_cost_model.cpp
@@ -355,7 +355,9 @@ int main(int argc, char **argv) {
                 float badness = 0;
             } worst_inversion;
 
+#if defined(_OPENMP)
             #pragma omp parallel for
+#endif
             for (int model = 0; model < models; model++) {
                 for (int train = 0; train < 2; train++) {
                     auto &tp = tpp[model];

--- a/apps/support/autoscheduler.inc
+++ b/apps/support/autoscheduler.inc
@@ -59,6 +59,7 @@ $(AUTOSCHED_BIN)/libauto_schedule.so: $(AUTOSCHED_SRC)/AutoSchedule.cpp \
 	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC $(CXXFLAGS) -g -I $(AUTOSCHED_BIN)/cost_model $(AUTOSCHED_SRC)/AutoSchedule.cpp $(AUTOSCHED_SRC)/ASLog.cpp $(AUTOSCHED_SRC)/DefaultCostModel.cpp $(AUTOSCHED_WEIGHT_OBJECTS) $(AUTOSCHED_COST_MODEL_LIBS) $(AUTOSCHED_BIN)/auto_schedule_runtime.a $(OPTIMIZE) -o $@ $(HALIDE_SYSTEM_LIBS)
 
 $(AUTOSCHED_BIN)/train_cost_model: $(AUTOSCHED_SRC)/train_cost_model.cpp \
+						$(AUTOSCHED_SRC)/ASLog.cpp \
 						 $(AUTOSCHED_SRC)/DefaultCostModel.cpp \
 						 $(AUTOSCHED_SRC)/CostModel.h \
 						 $(AUTOSCHED_SRC)/NetworkSize.h \


### PR DESCRIPTION
train_cost_model needed ASLog.cpp, but since the former doesn't link to libHalide, the latter can't rely on it. (We didn't notice this because apps/autoscheduler isn't part of the normal build-and-test suite; I'll fix that in a followup PR.)

Also, drive-by fix to avoid unknown-pragma-warning-as-error in some recalcitrant compilers.