### PR TITLE
Zero out 'other' buffer in Buffer's move ctor/op=

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -675,9 +675,8 @@ public:
                                    dev_ref_count(other.dev_ref_count) {
         other.dev_ref_count = nullptr;
         other.alloc = nullptr;
-        other.buf.device = 0;
-        other.buf.device_interface = nullptr;
         move_shape_from(std::forward<Buffer<T, D>>(other));
+        memset(&other.buf, 0, sizeof(other.buf));
     }
 
     /** Move-construct a Buffer from a Buffer of different
@@ -690,9 +689,8 @@ public:
         assert_can_convert_from(other);
         other.dev_ref_count = nullptr;
         other.alloc = nullptr;
-        other.buf.device = 0;
-        other.buf.device_interface = nullptr;
         move_shape_from(std::forward<Buffer<T2, D2>>(other));
+        memset(&other.buf, 0, sizeof(other.buf));
     }
 
     /** Assign from another Buffer of possibly-different
@@ -742,9 +740,8 @@ public:
         other.dev_ref_count = nullptr;
         free_shape_storage();
         buf = other.buf;
-        other.buf.device = 0;
-        other.buf.device_interface = nullptr;
         move_shape_from(std::forward<Buffer<T2, D2>>(other));
+        memset(&other.buf, 0, sizeof(other.buf));
         return *this;
     }
 
@@ -757,9 +754,8 @@ public:
         other.dev_ref_count = nullptr;
         free_shape_storage();
         buf = other.buf;
-        other.buf.device = 0;
-        other.buf.device_interface = nullptr;
         move_shape_from(std::forward<Buffer<T, D>>(other));
+        memset(&other.buf, 0, sizeof(other.buf));
         return *this;
     }
 


### PR DESCRIPTION
move is allowed to leave the moved-from item in an unspecified state; we zero out the device fields but not the host fields, so code downstream could inadvertently use a 'stale' moved-from Buffer in a flaky way. This PR is an experiment to see if fully zeroing out the moved-from Buffer's halide_buffer_t will inject any failures.