### PR TITLE
Revert "Upgrade make files to understand LLVM 10+ (v2)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,19 +19,22 @@ include(CPack)
 
 find_package(Threads QUIET)
 
-# HALIDE_REQUIRE_LLVM_VERSION is expected to be major-version-times-10,
-# ignoring any patch (ie, HALIDE_REQUIRE_LLVM_VERSION=70 would match LLVM 7.0.x)
 if("${HALIDE_REQUIRE_LLVM_VERSION}" STREQUAL "")
   # Find any version present.
   find_package(LLVM REQUIRED CONFIG)
 else()
   # Find a specific version.
   string(REGEX REPLACE
-    "^([0-9]+)0$"
+    "^([0-9]+)([0-9])$"
     "\\1"
     MAJOR
     "${HALIDE_REQUIRE_LLVM_VERSION}")
-  set(MINOR 0)
+  string(REGEX REPLACE
+    "^([0-9]+)([0-9])$"
+    "\\2"
+    MINOR
+    "${HALIDE_REQUIRE_LLVM_VERSION}")
+  message("HALIDE_REQUIRE_LLVM_VERSION ${HALIDE_REQUIRE_LLVM_VERSION}")
   message("Looking for LLVM version ${MAJOR}.${MINOR}")
   find_package(LLVM "${MAJOR}.${MINOR}" REQUIRED CONFIG)
   if(NOT "${LLVM_VERSION_MAJOR}${LLVM_VERSION_MINOR}" STREQUAL "${MAJOR}${MINOR}")

--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,7 @@ WASM_SHELL ?= d8
 PREFIX ?= /usr/local
 LLVM_CONFIG ?= llvm-config
 LLVM_COMPONENTS= $(shell $(LLVM_CONFIG) --components)
-# Since LLVM5, the LLVM version always uses a major.zero.patch format
-# (ie there is no 'minor' version). We ignore the patch version and
-# just use the major version. For historical reasons, we continue to multiply
-# by 10, to avoid changing all the ifdefs in our code.
-LLVM_VERSION = $(shell $(LLVM_CONFIG) --version | sed 's/\([0-9][0-9]*\)\.0.*/\10/')
+LLVM_VERSION = $(shell $(LLVM_CONFIG) --version | sed 's/\([0-9][0-9]*\)\.\([0-9]\).*/\1.\2/')
 
 LLVM_FULL_VERSION = $(shell $(LLVM_CONFIG) --version)
 LLVM_BINDIR = $(shell $(LLVM_CONFIG) --bindir | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):/\/\1/g')
@@ -103,7 +99,9 @@ endif
 
 COMMON_LD_FLAGS += $(SANITIZER_FLAGS)
 
-LLVM_CXX_FLAGS += -DLLVM_VERSION=$(LLVM_VERSION)
+LLVM_VERSION_TIMES_10 = $(shell $(LLVM_CONFIG) --version | sed 's/\([0-9][0-9]*\)\.\([0-9]\).*/\1\2/')
+
+LLVM_CXX_FLAGS += -DLLVM_VERSION=$(LLVM_VERSION_TIMES_10)
 
 # All WITH_* flags are either empty or not-empty. They do not behave
 # like true/false values in most languages.  To turn one off, either
@@ -2062,7 +2060,7 @@ $(BUILD_DIR)/clang_ok:
 	@exit 1
 endif
 
-ifneq (,$(findstring $(LLVM_VERSION), 70 80 90 100))
+ifneq (,$(findstring $(LLVM_VERSION_TIMES_10), 70 71 80 90 100))
 LLVM_OK=yes
 endif
 

--- a/test/scripts/build_travis.sh
+++ b/test/scripts/build_travis.sh
@@ -15,7 +15,7 @@ fi
 
 if [ ${BUILD_SYSTEM} = 'CMAKE' ]; then
   : ${HALIDE_SHARED_LIBRARY:?"HALIDE_SHARED_LIBRARY must be set"}
-  LLVM_VERSION_NO_DOT="$( echo ${LLVM_VERSION} | sed 's/\([0-9][0-9]*\)\.0.*/\10/' )"
+  LLVM_VERSION_NO_DOT="$( echo ${LLVM_VERSION} | sed 's/\([0-9][0-9]*\)\.\([0-9]\).*/\1\2/' )"
   mkdir -p build/ && cd build/
   # Require a specific version of LLVM, just in case the Travis instance has
   # an older clang/llvm version present


### PR DESCRIPTION
Reverts halide/Halide#4022

Apparently LLVM 7.1 is a thing, despite documentation to the contrary