### PR TITLE
Rename Python's "in" methods to "in_", so that calls are not a syntax error

### DIFF
--- a/python_bindings/readme.md
+++ b/python_bindings/readme.md
@@ -20,6 +20,7 @@ in Python, only the second variant is provided.
 - No mechanism is provided for overriding any runtime functions from Python.
 - No mechanism is provided for supporting `Func::define_extern`.
 - `Buffer::for_each_value()` is hard to implement well in Python; it's omitted entirely for now.
+- `Func::in` and `ImageParam::in` are exposed as `Func.in_` and `ImageParam.in_`, since `in` is a reserved keyword in Python.
 
 ## Enhancements to the C++ API
 

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -277,9 +277,9 @@ void define_func(py::module &m) {
             f.infer_input_bounds(Realization(buffer), param_map);
         }, py::arg("dst"), py::arg("param_map") = ParamMap())
 
-        .def("in", (Func (Func::*)(const Func &)) &Func::in, py::arg("f"))
-        .def("in", (Func (Func::*)(const std::vector<Func> &fs)) &Func::in, py::arg("fs"))
-        .def("in", (Func (Func::*)()) &Func::in)
+        .def("in_", (Func (Func::*)(const Func &)) &Func::in, py::arg("f"))
+        .def("in_", (Func (Func::*)(const std::vector<Func> &fs)) &Func::in, py::arg("fs"))
+        .def("in_", (Func (Func::*)()) &Func::in)
 
         .def("clone_in", (Func (Func::*)(const Func &)) &Func::clone_in, py::arg("f"))
         .def("clone_in", (Func (Func::*)(const std::vector<Func> &fs)) &Func::clone_in, py::arg("fs"))

--- a/python_bindings/src/PyImageParam.cpp
+++ b/python_bindings/src/PyImageParam.cpp
@@ -73,9 +73,9 @@ void define_image_param(py::module &m) {
         .def("__getitem__", [](ImageParam &im, const std::vector<Var> &args) -> Expr {
             return im(args);
         })
-        .def("in", (Func (ImageParam::*)(const Func &)) &ImageParam::in)
-        .def("in", (Func (ImageParam::*)(const std::vector<Func> &)) &ImageParam::in)
-        .def("in", (Func (ImageParam::*)()) &ImageParam::in)
+        .def("in_", (Func (ImageParam::*)(const Func &)) &ImageParam::in)
+        .def("in_", (Func (ImageParam::*)(const std::vector<Func> &)) &ImageParam::in)
+        .def("in_", (Func (ImageParam::*)()) &ImageParam::in)
         .def("trace_loads", &ImageParam::trace_loads)
 
         .def("__repr__", [](const ImageParam &im) -> std::string {


### PR DESCRIPTION
The Python bindings expose `Func::in` and `ImageParam::in`, but these are currently not callable, because code like `f.in(g)` is not syntactical Python. (Technically, `in` can be called with circumlocutions like `getattr(f, 'in')(g)`.)

This patch suggests a fix by renaming `in` to `in_`, a common if somewhat inelegant way to deal with keyword conflicts. (Other suggestions welcome.)

The readme gets updated to reflect this change.