### PR TITLE
Don't declare all targets unsupported when LLVM < 9 is built with wasm

### DIFF
--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -626,7 +626,10 @@ bool Target::supported() const {
 #if !defined(WITH_HEXAGON)
     bad |= arch == Target::Hexagon;
 #endif
-#if !defined(WITH_WEBASSEMBLY)
+#if !defined(WITH_WEBASSEMBLY) || LLVM_VERSION < 90
+    // LLVM8 supports wasm, but there are fixes and improvements
+    // in trunk that may not be in 8 (or that we haven't tested with),
+    // so, for now, declare that wasm with LLVM < 9.0 is unsupported.
     bad |= arch == Target::WebAssembly;
 #endif
 #if !defined(WITH_RISCV)
@@ -646,12 +649,6 @@ bool Target::supported() const {
 #endif
 #if !defined(WITH_D3D12)
     bad |= has_feature(Target::D3D12Compute);
-#endif
-#if defined(WITH_WEBASSEMBLY) && LLVM_VERSION < 90
-    // LLVM8 supports wasm, but there are fixes and improvements
-    // in trunk that may not be in 8 (or that we haven't tested with),
-    // so, for now, declare that wasm with LLVM < 9.0 is unsupported.
-    bad = true;
 #endif
     return !bad;
 }


### PR DESCRIPTION
Oddly(?), #3732 added a compiler-conditional `bad = true` line to `Target::supported`. When `llvm-config` claims webassembly support, and the LLVM version is less than 9, `Target::supported` returns `false` for _all_ targets.

This does not seem right; in particular, the Python tests fail, because they check that the host target is supported.

This patch consolidates this case with the existing wasm check, simplifying the logic and declaring wasm targets but no others unsupported for LLVM < 9. This fixes the Python target tests for me with LLVM 7.1.