### PR TITLE
Rationalize API for setting autoscheduler estimates.

### DIFF
--- a/apps/autoscheduler/cost_model_generator.cpp
+++ b/apps/autoscheduler/cost_model_generator.cpp
@@ -73,31 +73,31 @@ struct ModelWeight<true> : public GeneratorInput<Buffer<float>> {
     void set_shape(int s0 = 0, int s1 = 0, int s2 = 0) {
         if (s0) {
             dim(0).set_bounds(0, s0);
-            dim(0).set_bounds_estimate(0, s0);
+            dim(0).set_estimate(0, s0);
             grad.dim(0).set_bounds(0, s0);
-            grad.dim(0).set_bounds_estimate(0, s0);
+            grad.dim(0).set_estimate(0, s0);
             grad.bound(grad.args()[0], 0, s0);
-            grad.estimate(grad.args()[0], 0, s0);
+            grad.set_estimate(grad.args()[0], 0, s0);
         }
         if (s1) {
             dim(1).set_bounds(0, s1);
-            dim(1).set_bounds_estimate(0, s1);
+            dim(1).set_estimate(0, s1);
             grad.dim(1).set_bounds(0, s1);
-            grad.dim(1).set_bounds_estimate(0, s1);
+            grad.dim(1).set_estimate(0, s1);
             grad.bound(grad.args()[1], 0, s1);
-            grad.estimate(grad.args()[1], 0, s1);
+            grad.set_estimate(grad.args()[1], 0, s1);
 
         }
         if (s2) {
             dim(2).set_bounds(0, s2);
-            dim(2).set_bounds_estimate(0, s2);
+            dim(2).set_estimate(0, s2);
             grad.dim(2).set_bounds(0, s2);
-            grad.dim(2).set_bounds_estimate(0, s2);
+            grad.dim(2).set_estimate(0, s2);
             grad.bound(grad.args()[2], 0, s2);
-            grad.estimate(grad.args()[2], 0, s2);
+            grad.set_estimate(grad.args()[2], 0, s2);
         }
         grad.dim(dimensions()).set_bounds(0, 4);
-        grad.dim(dimensions()).set_bounds_estimate(0, 4);
+        grad.dim(dimensions()).set_estimate(0, 4);
     }
 };
 
@@ -458,19 +458,12 @@ public:
         reference.set_estimate(0);
         batch_size.set_estimate(80);
         num_stages.set_estimate(13);
-        prediction_output.dim(0).set_bounds_estimate(0, 80);
+        prediction_output.set_estimates({{0, 80}});
         learning_rate.set_estimate(0.001f);
         timestep.set_estimate(37);
-        pipeline_features
-            .dim(0).set_bounds_estimate(0, head1_w)
-            .dim(1).set_bounds_estimate(0, head1_h)
-            .dim(2).set_bounds_estimate(0, 13);
-        schedule_features
-            .dim(0).set_bounds_estimate(0, 80)
-            .dim(1).set_bounds_estimate(0, head2_w)
-            .dim(2).set_bounds_estimate(0, 13);
-        true_runtime
-            .dim(0).set_bounds_estimate(0, 80);
+        pipeline_features.set_estimates({{0, head1_w}, {0, head1_h}, {0, 13}});
+        schedule_features.set_estimates({{0, 80}, {0, head2_w}, {0, 13}});
+        true_runtime.set_estimates({{0, 80}});
 
         // SCHEDULE
         if (training && !auto_schedule) {

--- a/apps/autoscheduler/test.cpp
+++ b/apps/autoscheduler/test.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
         g(x, y) = f(x, y) * 2 + 1;
         h(x, y) = g(x, y) * 2 + 1;
 
-        h.estimate(x, 0, 1000).estimate(y, 0, 1000);
+        h.set_estimate(x, 0, 1000).set_estimate(y, 0, 1000);
 
         Pipeline(h).auto_schedule(target, params);
     }
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
         }
         h(x, y) = e;
 
-        h.estimate(x, 0, 1000).estimate(y, 0, 1000);
+        h.set_estimate(x, 0, 1000).set_estimate(y, 0, 1000);
 
         Pipeline(h).auto_schedule(target, params);
     }
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
                    f(x-9, y+9) + f(x, y+9) + f(x+9, y-9));
 
 
-        h.estimate(x, 0, 2048).estimate(y, 0, 2048);
+        h.set_estimate(x, 0, 2048).set_estimate(y, 0, 2048);
 
         Pipeline(h).auto_schedule(target, params);
     }
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
                    f(x-1, y  ) + f(x, y  ) + f(x+1, y  ) +
                    f(x-1, y+1) + f(x, y+1) + f(x+1, y-1));
 
-        h.estimate(x, 0, 2048).estimate(y, 0, 2048);
+        h.set_estimate(x, 0, 2048).set_estimate(y, 0, 2048);
 
         Pipeline(h).auto_schedule(target, params);
     }
@@ -125,7 +125,7 @@ int main(int argc, char **argv) {
             }
             f[i](x, y) = e;
         }
-        f[N-1].estimate(x, 0, 2048).estimate(y, 0, 2048);
+        f[N-1].set_estimate(x, 0, 2048).set_estimate(y, 0, 2048);
 
         Pipeline(f[N-1]).auto_schedule(target, params);
     }
@@ -136,7 +136,7 @@ int main(int argc, char **argv) {
         Func f;
         f(x, y) = a(x) * b(y);
 
-        f.estimate(x, 0, 2048).estimate(y, 0, 2048);
+        f.set_estimate(x, 0, 2048).set_estimate(y, 0, 2048);
 
         Pipeline(f).auto_schedule(target, params);
     }
@@ -155,7 +155,7 @@ int main(int argc, char **argv) {
         expensive(x, y, k) = orig(x, y) * orig(x, y) + (x + orig(x, y)) * (1 + orig(x, y)) + sqrt(k + orig(x, y));
         downy(x, y, k) = expensive(x, 2*y - 1, k) + expensive(x, 2*y, k) + expensive(x, 2*y+1, k) + expensive(x, 2*y + 2, k);
         downx(x, y, k) = downy(2*x-1, y, k) + downy(2*x, y, k) + downy(2*x + 1, y, k) + downy(2*x + 2, y, k);
-        downx.estimate(x, 1, 1022).estimate(y, 1, 1022).estimate(k, 0, 256);
+        downx.set_estimate(x, 1, 1022).set_estimate(y, 1, 1022).set_estimate(k, 0, 256);
 
         Pipeline(downx).auto_schedule(target, params);
     }
@@ -174,7 +174,7 @@ int main(int argc, char **argv) {
         f(0, y) = 23.0f;
         g(x, y) = f(x - 1, y - 1) + f(x + 1, y + 1);
 
-        g.estimate(x, 1, 1022).estimate(y, 1, 1022);
+        g.set_estimate(x, 1, 1022).set_estimate(y, 1, 1022);
 
         Pipeline(g).auto_schedule(target, params);
     }
@@ -198,7 +198,7 @@ int main(int argc, char **argv) {
             after[i](x, y) = after[i-1](x, y) + 1;
         }
 
-        after[4].estimate(x, 0, 1024).estimate(y, 0, 1024);
+        after[4].set_estimate(x, 0, 1024).set_estimate(y, 0, 1024);
 
         Pipeline(after[4]).auto_schedule(target, params);
     }
@@ -219,7 +219,7 @@ int main(int argc, char **argv) {
         // everything into f_64_2 but this would vectorize fairly
         // narrowly, which is a waste of work for the first Func.
 
-        f_u64_2.estimate(x, 0, 1024 * 1024);
+        f_u64_2.set_estimate(x, 0, 1024 * 1024);
 
         Pipeline(f_u64_2).auto_schedule(target, params);
     }
@@ -238,7 +238,7 @@ int main(int argc, char **argv) {
         Func out("out");
         out(j, i) = c(j, i);
 
-        out.estimate(j, 0, 1024).estimate(i, 0, 1024);
+        out.set_estimate(j, 0, 1024).set_estimate(i, 0, 1024);
 
         Pipeline(out).auto_schedule(target, params);
     }
@@ -268,7 +268,7 @@ int main(int argc, char **argv) {
             p3[i](x, y) = p3[i-1](x, y) + 1;
         }
 
-        p3[N-1].estimate(x, 0, 1024).estimate(y, 0, 1024);
+        p3[N-1].set_estimate(x, 0, 1024).set_estimate(y, 0, 1024);
 
         Pipeline(p3[N-1]).auto_schedule(target, params);
     }
@@ -288,7 +288,7 @@ int main(int argc, char **argv) {
         Func out("out");
         out(x) = lut(clamp(idx(x), 0, 100000));
 
-        out.estimate(x, 0, 10);
+        out.set_estimate(x, 0, 10);
 
         Pipeline(out).auto_schedule(target, params);
     }
@@ -303,7 +303,7 @@ int main(int argc, char **argv) {
         g(x, y) = 0;
         g(x, y) += f(x, 1000*(y+r));
 
-        g.estimate(x, 0, 1000).estimate(y, 0, 1000);
+        g.set_estimate(x, 0, 1000).set_estimate(y, 0, 1000);
 
         Pipeline(g).auto_schedule(target, params);
     }
@@ -318,7 +318,7 @@ int main(int argc, char **argv) {
 
         h(x, y) += g(y + r.y, x + r.y);
 
-        h.estimate(x, 0, 1000).estimate(y, 0, 1000);
+        h.set_estimate(x, 0, 1000).set_estimate(y, 0, 1000);
 
         Pipeline(h).auto_schedule(target, params);
     }
@@ -335,8 +335,8 @@ int main(int argc, char **argv) {
         a(x, y) += in(x+r.x, y+r.y);
         b(x, y) += in(y+r.y, x+r.x);
 
-        a.estimate(x, 0, 1000).estimate(y, 0, 1000);
-        b.estimate(x, 0, 1000).estimate(y, 0, 1000);
+        a.set_estimate(x, 0, 1000).set_estimate(y, 0, 1000);
+        b.set_estimate(x, 0, 1000).set_estimate(y, 0, 1000);
 
         Pipeline({a, b}).auto_schedule(target, params);
 
@@ -349,7 +349,7 @@ int main(int argc, char **argv) {
         f(x, y) = im(x, y);
         g(x, y) = f(x, y);
 
-        g.estimate(x, 0, 1000).estimate(y, 0, 1000);
+        g.set_estimate(x, 0, 1000).set_estimate(y, 0, 1000);
         Pipeline(g).auto_schedule(target, params);
     }
 
@@ -359,7 +359,7 @@ int main(int argc, char **argv) {
         Func f("f");
         f(x, y) = im(x, y) * 7;
 
-        f.estimate(x, 0, 3).estimate(y, 0, 5);
+        f.set_estimate(x, 0, 3).set_estimate(y, 0, 5);
         Pipeline(f).auto_schedule(target, params);
     }
 
@@ -370,13 +370,13 @@ int main(int argc, char **argv) {
         Var z, w, t, u, v;
         f(x, y, z, w, t, u, v) = im(x, y, z, w, t, u, v) * 7;
 
-        f.estimate(x, 0, 8)
-            .estimate(y, 0, 9)
-            .estimate(z, 0, 10)
-            .estimate(w, 0, 5)
-            .estimate(t, 0, 3)
-            .estimate(u, 0, 2)
-            .estimate(v, 0, 6);
+        f.set_estimate(x, 0, 8)
+            .set_estimate(y, 0, 9)
+            .set_estimate(z, 0, 10)
+            .set_estimate(w, 0, 5)
+            .set_estimate(t, 0, 3)
+            .set_estimate(u, 0, 2)
+            .set_estimate(v, 0, 6);
         Pipeline(f).auto_schedule(target, params);
     }
 
@@ -394,8 +394,8 @@ int main(int argc, char **argv) {
         out1(x, y) = f(x, y) + g(x, y) + h(x, y);
         out2(x, y) = f(x, y) + g(x, y) + h(x, y);
 
-        out1.estimate(x, 0, 1000).estimate(y, 0, 1000);
-        out2.estimate(x, 0, 1000).estimate(y, 0, 1000);
+        out1.set_estimate(x, 0, 1000).set_estimate(y, 0, 1000);
+        out2.set_estimate(x, 0, 1000).set_estimate(y, 0, 1000);
         Pipeline({out1, out2}).auto_schedule(target, params);
 
     }
@@ -420,7 +420,7 @@ int main(int argc, char **argv) {
         Func g("output");
         // Access it in a way that makes it insane not to inline.
         g(x, y) = f[N-1](x, y) + f[0](clamp(cast<int>(sin(x) * 10000), 0, 100000), clamp(cast<int>(sin(x*y) * 10000), 0, 100000));
-        g.estimate(x, 0, 2048).estimate(y, 0, 2048);
+        g.set_estimate(x, 0, 2048).set_estimate(y, 0, 2048);
 
         Pipeline(g).auto_schedule(target, params);
     }
@@ -434,7 +434,7 @@ int main(int argc, char **argv) {
         g() += r;
         h(x, y) = g() + x + y;
 
-        h.estimate(x, 0, 1024).estimate(y, 0, 2048);
+        h.set_estimate(x, 0, 1024).set_estimate(y, 0, 2048);
         Pipeline(h).auto_schedule(target, params);
     }
 
@@ -449,7 +449,7 @@ int main(int argc, char **argv) {
 
         g(x, y) = f(x, y);
 
-        g.estimate(x, 0, 10).estimate(y, 0, 2048);
+        g.set_estimate(x, 0, 10).set_estimate(y, 0, 2048);
         Pipeline(g).auto_schedule(target, params);
     }
 
@@ -481,7 +481,7 @@ int main(int argc, char **argv) {
         Func out;
         out(x, y) = up[0](x, y);
 
-        out.estimate(x, 0, 2048).estimate(y, 0, 2048);
+        out.set_estimate(x, 0, 2048).set_estimate(y, 0, 2048);
         Pipeline(out).auto_schedule(target, params);
     }
 
@@ -499,7 +499,7 @@ int main(int argc, char **argv) {
         Func casted("casted");
         casted(x, y) = scan(x, y);
 
-        casted.estimate(x, 0, 2000).estimate(y, 0, 2000);
+        casted.set_estimate(x, 0, 2000).set_estimate(y, 0, 2000);
         Pipeline(casted).auto_schedule(target, params);
     }
 

--- a/apps/bilateral_grid/bilateral_grid_generator.cpp
+++ b/apps/bilateral_grid/bilateral_grid_generator.cpp
@@ -70,16 +70,15 @@ public:
         // (This can be useful in conjunction with RunGen and benchmarks as well
         // as auto-schedule, so we do it in all cases.)
         // Provide estimates on the input image
-        input.dim(0).set_bounds_estimate(0, 1536);
-        input.dim(1).set_bounds_estimate(0, 2560);
+        input.set_estimates({{0, 1536}, {0, 2560}});
         // Provide estimates on the parameters
         r_sigma.set_estimate(0.1f);
         // TODO: Compute estimates from the parameter values
-        histogram.estimate(z, -2, 16);
-        blurz.estimate(z, 0, 12);
-        blurx.estimate(z, 0, 12);
-        blury.estimate(z, 0, 12);
-        bilateral_grid.estimate(x, 0, 1536).estimate(y, 0, 2560);
+        histogram.set_estimate(z, -2, 16);
+        blurz.set_estimate(z, 0, 12);
+        blurx.set_estimate(z, 0, 12);
+        blury.set_estimate(z, 0, 12);
+        bilateral_grid.set_estimates({{0, 1536}, {0, 2560}});
 
         if (auto_schedule) {
             // nothing

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -435,22 +435,16 @@ void CameraPipe::generate() {
     /* ESTIMATES */
     // (This can be useful in conjunction with RunGen and benchmarks as well
     // as auto-schedule, so we do it in all cases.)
-    input.dim(0).set_bounds_estimate(0, 2592);
-    input.dim(1).set_bounds_estimate(0, 1968);
-    matrix_3200.dim(0).set_bounds_estimate(0, 4);
-    matrix_3200.dim(1).set_bounds_estimate(0, 3);
-    matrix_7000.dim(0).set_bounds_estimate(0, 4);
-    matrix_7000.dim(1).set_bounds_estimate(0, 3);
+    input.set_estimates({{0, 2592}, {0, 1968}});
+    matrix_3200.set_estimates({{0, 4}, {0, 3}});
+    matrix_7000.set_estimates({{0, 4}, {0, 3}});
     color_temp.set_estimate(3700);
     gamma.set_estimate(2.0);
     contrast.set_estimate(50);
     sharpen_strength.set_estimate(1.0);
     blackLevel.set_estimate(25);
     whiteLevel.set_estimate(1023);
-    processed
-        .estimate(c, 0, 3)
-        .estimate(x, 0, 2592)
-        .estimate(y, 0, 1968);
+    processed.set_estimates({{0, 2592}, {0, 1968}, {0, 3}});
 
     // Schedule
     if (auto_schedule) {

--- a/apps/conv_layer/conv_layer_generator.cpp
+++ b/apps/conv_layer/conv_layer_generator.cpp
@@ -32,23 +32,10 @@ public:
 
         if (auto_schedule) {
             // Provide estimates on the input image
-            input.dim(0).set_bounds_estimate(0, 131);
-            input.dim(1).set_bounds_estimate(0, 131);
-            input.dim(2).set_bounds_estimate(0, 64);
-            input.dim(3).set_bounds_estimate(0, 4);
-
-            filter.dim(0).set_bounds_estimate(0, 3);
-            filter.dim(1).set_bounds_estimate(0, 3);
-            filter.dim(2).set_bounds_estimate(0, 64);
-            filter.dim(3).set_bounds_estimate(0, 64);
-
-            bias.dim(0).set_bounds_estimate(0, 64);
-
-            // Provide estimates on the pipeline f_ReLU
-            f_ReLU.estimate(x, 0, 128)
-                .estimate(y, 0, 128)
-                .estimate(z, 0, 64)
-                .estimate(n, 0, 4);
+            input.set_estimates({{0, 131}, {0, 131}, {0, 64}, {0, 4}});
+            filter.set_estimates({{0, 3}, {0, 3}, {0, 64}, {0, 64}});
+            bias.set_estimates({{0, 64}});
+            f_ReLU.set_estimates({{0, 128}, {0, 128}, {0, 64}, {0, 4}});
 
         } /*else if (get_target().has_gpu_feature()) {
             // TODO: Turn off the manual GPU schedule for now.

--- a/apps/lens_blur/lens_blur_generator.cpp
+++ b/apps/lens_blur/lens_blur_generator.cpp
@@ -155,21 +155,15 @@ public:
         // (This can be useful in conjunction with RunGen and benchmarks as well
         // as auto-schedule, so we do it in all cases.)
         // Provide estimates on the input image
-        left_im.dim(0).set_bounds_estimate(0, 1536);
-        left_im.dim(1).set_bounds_estimate(0, 2560);
-        left_im.dim(2).set_bounds_estimate(0, 3);
-        right_im.dim(0).set_bounds_estimate(0, 1536);
-        right_im.dim(1).set_bounds_estimate(0, 2560);
-        right_im.dim(2).set_bounds_estimate(0, 3);
+        left_im.set_estimates({{0, 1536}, {0, 2560}, {0, 3}});
+        right_im.set_estimates({{0, 1536}, {0, 2560}, {0, 3}});
         // Provide estimates on the parameters
         slices.set_estimate(32);
         focus_depth.set_estimate(13);
         blur_radius_scale.set_estimate(0.5f);
         aperture_samples.set_estimate(32);
         // Provide estimates on the pipeline output
-        final.estimate(x, 0, 1536)
-            .estimate(y, 0, 2560)
-            .estimate(c, 0, 3);
+        final.set_estimates({{0, 1536}, {0, 2560}, {0, 3}});
 
         /* THE SCHEDULE */
         if (auto_schedule) {

--- a/apps/linear_blur/linear_blur_generator.cpp
+++ b/apps/linear_blur/linear_blur_generator.cpp
@@ -18,16 +18,8 @@ struct LinearBlur : public Halide::Generator<LinearBlur> {
         output(x, y, c) = srgb(x, y, c);
 
         if (auto_schedule) {
-            input.dim(0).set_bounds_estimate(0, 1536)
-                 .dim(1).set_bounds_estimate(0, 2560)
-                 .dim(2).set_bounds_estimate(0, 4);
-            output.estimate(x, 0, 1536)
-                  .estimate(y, 0, 2560)
-                  .estimate(c, 0, 4);
-            // TODO(srj): set_bounds_estimate should work for Output<Buffer<>>, but does not
-            // output.dim(0).set_bounds_estimate(0, 1536)
-            //       .dim(1).set_bounds_estimate(0, 2560)
-            //       .dim(2).set_bounds_estimate(0, 4);
+            input.set_estimates({{0, 1536}, {0, 2560}, {0, 4}});
+            output.set_estimates({{0, 1536}, {0, 2560}, {0, 4}});
         } else {
             assert(false && "non-auto_schedule not supported.");
             abort();

--- a/apps/linear_blur/linear_to_srgb_generator.cpp
+++ b/apps/linear_blur/linear_to_srgb_generator.cpp
@@ -21,15 +21,15 @@ struct LinearTosRGB : public Halide::Generator<LinearTosRGB> {
             const int W = 1536, H = 2560, C = 4;
             // Wart: Input<Func> are defined with Vars we don't know.
             // Might be x,y but might be _0,_1. Use the args() to work around.
-            linear.estimate(linear.args()[0], 0, W)
-                  .estimate(linear.args()[1], 0, H);
+            linear.set_estimate(linear.args()[0], 0, W)
+                  .set_estimate(linear.args()[1], 0, H);
             for (size_t i = 2; i < linear.args().size(); ++i) {
-                linear.estimate(linear.args()[i], 0, C);
+                linear.set_estimate(linear.args()[i], 0, C);
             }
-            srgb.estimate(x, 0, W)
-                .estimate(y, 0, H);
+            srgb.set_estimate(x, 0, W)
+                .set_estimate(y, 0, H);
             for (size_t i = 2; i < srgb.args().size(); ++i) {
-                srgb.estimate(srgb.args()[i], 0, C);
+                srgb.set_estimate(srgb.args()[i], 0, C);
             }
         } else {
             Var yi("yi");

--- a/apps/linear_blur/simple_blur_generator.cpp
+++ b/apps/linear_blur/simple_blur_generator.cpp
@@ -26,17 +26,17 @@ struct SimpleBlur : public Halide::Generator<SimpleBlur> {
             const int W = 1536, H = 2560, C = 4;
             // Wart: Input<Func> are defined with Vars we don't know.
             // Might be x,y but might be _0,_1. Use the args() to work around.
-            input.estimate(input.args()[0], 0, W)
-                 .estimate(input.args()[1], 0, H);
+            input.set_estimate(input.args()[0], 0, W)
+                 .set_estimate(input.args()[1], 0, H);
             for (size_t i = 2; i < input.args().size(); ++i) {
-                input.estimate(input.args()[i], 0, C);
+                input.set_estimate(input.args()[i], 0, C);
             }
             width.set_estimate(W);
             height.set_estimate(H);
-            output.estimate(x, 0, W)
-                  .estimate(y, 0, H);
+            output.set_estimate(x, 0, W)
+                  .set_estimate(y, 0, H);
             for (size_t i = 2; i < output.args().size(); ++i) {
-                output.estimate(output.args()[i], 0, C);
+                output.set_estimate(output.args()[i], 0, C);
             }
         } else {
             Var xi("xi"), yi("yi");

--- a/apps/linear_blur/srgb_to_linear_generator.cpp
+++ b/apps/linear_blur/srgb_to_linear_generator.cpp
@@ -21,15 +21,15 @@ struct sRGBToLinear : public Halide::Generator<sRGBToLinear> {
             const int W = 1536, H = 2560, C = 4;
             // Wart: Input<Func> are defined with Vars we don't know.
             // Might be x,y but might be _0,_1. Use the args() to work around.
-            srgb.estimate(srgb.args()[0], 0, W)
-                .estimate(srgb.args()[1], 0, H);
+            srgb.set_estimate(srgb.args()[0], 0, W)
+                .set_estimate(srgb.args()[1], 0, H);
             for (size_t i = 2; i < srgb.args().size(); ++i) {
-                srgb.estimate(srgb.args()[i], 0, C);
+                srgb.set_estimate(srgb.args()[i], 0, C);
             }
-            linear.estimate(x, 0, W)
-                  .estimate(y, 0, H);
+            linear.set_estimate(x, 0, W)
+                  .set_estimate(y, 0, H);
             for (size_t i = 2; i < linear.args().size(); ++i) {
-                linear.estimate(linear.args()[i], 0, C);
+                linear.set_estimate(linear.args()[i], 0, C);
             }
         } else {
             Var yi("yi");

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -90,17 +90,13 @@ public:
         /* ESTIMATES */
         // (This can be useful in conjunction with RunGen and benchmarks as well
         // as auto-schedule, so we do it in all cases.)
-        input.dim(0).set_bounds_estimate(0, 1536);
-        input.dim(1).set_bounds_estimate(0, 2560);
-        input.dim(2).set_bounds_estimate(0, 3);
+        input.set_estimates({{0, 1536}, {0, 2560}, {0, 3}});
         // Provide estimates on the parameters
         levels.set_estimate(8);
         alpha.set_estimate(1);
         beta.set_estimate(1);
         // Provide estimates on the pipeline output
-        output.estimate(x, 0, 1536)
-              .estimate(y, 0, 2560)
-              .estimate(c, 0, 3);
+        output.set_estimates({{0, 1536}, {0, 2560}, {0, 3}});
 
         /* THE SCHEDULE */
         if (auto_schedule) {

--- a/apps/nl_means/nl_means_generator.cpp
+++ b/apps/nl_means/nl_means_generator.cpp
@@ -76,17 +76,13 @@ public:
         // (This can be useful in conjunction with RunGen and benchmarks as well
         // as auto-schedule, so we do it in all cases.)
         // Provide estimates on the input image
-        input.dim(0).set_bounds_estimate(0, 614);
-        input.dim(1).set_bounds_estimate(0, 1024);
-        input.dim(2).set_bounds_estimate(0, 3);
+        input.set_estimates({{0, 614}, {0, 1024}, {0, 3}});
         // Provide estimates on the parameters
         patch_size.set_estimate(7);
         search_area.set_estimate(7);
         sigma.set_estimate(0.12f);
         // Provide estimates on the output pipeline
-        non_local_means.estimate(x, 0, 614)
-            .estimate(y, 0, 1024)
-            .estimate(c, 0, 3);
+        non_local_means.set_estimates({{0, 614}, {0, 1024}, {0, 3}});
 
         if (auto_schedule) {
             // nothing

--- a/apps/onnx/onnx_converter.cc
+++ b/apps/onnx/onnx_converter.cc
@@ -3456,7 +3456,7 @@ Halide::ImageParam encode_as_image_param(
                 throw std::invalid_argument("Invalid shape for input " + input.name());
             }
             result.dim(i).set_bounds(0, dim_val);
-            result.dim(i).set_bounds_estimate(0, dim_val);
+            result.dim(i).set_estimate(0, dim_val);
             shape->push_back(static_cast<int>(dim_val));
             stride = stride * dim_val;
         } else {
@@ -3475,7 +3475,7 @@ Halide::ImageParam encode_as_image_param(
             stride = stride * shape->back();
 
             // Dimension is unknown, just make a guess.
-            result.dim(i).set_bounds_estimate(0, 1000);
+            result.dim(i).set_estimate(0, 1000);
         }
     }
 
@@ -3607,10 +3607,10 @@ Model convert_model(const onnx::ModelProto &model) {
             const int64_t *dim_value = Halide::Internal::as_const_int(dims[i]);
             if (dim_value) {
                 int dim = static_cast<int>(*dim_value);
-                f.estimate(args[i], 0, dim);
+                f.set_estimate(args[i], 0, dim);
             } else {
                 // Dimension is unknown, make a guess
-                f.estimate(args[i], 0, 1000);
+                f.set_estimate(args[i], 0, 1000);
             }
         }
         result.outputs[output.name()] = t_out;

--- a/apps/stencil_chain/stencil_chain_generator.cpp
+++ b/apps/stencil_chain/stencil_chain_generator.cpp
@@ -40,11 +40,9 @@ public:
             const int width = 1536;
             const int height = 2560;
             // Provide estimates on the input image
-            input.dim(0).set_bounds_estimate(0, width);
-            input.dim(1).set_bounds_estimate(0, height);
+            input.set_estimates({{0, width}, {0, height}});
             // Provide estimates on the pipeline output
-            output.estimate(x, 0, width)
-                  .estimate(y, 0, height);
+            output.set_estimates({{0, width}, {0, height}});
         }
 
         if (auto_schedule) {

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -288,8 +288,10 @@ void define_func(py::module &m) {
             py::arg("device_api") = DeviceAPI::Default_GPU)
         .def("copy_to_host", &Func::copy_to_host)
 
-        .def("estimate", &Func::estimate,
+        .def("set_estimate", &Func::set_estimate,
             py::arg("var"), py::arg("min"), py::arg("extent"))
+        .def("set_estimates", &Func::set_estimates,
+            py::arg("estimates"))
 
         .def("align_bounds", &Func::align_bounds,
             py::arg("var"), py::arg("modulus"), py::arg("remainder") = 0)

--- a/python_bindings/src/PyImageParam.cpp
+++ b/python_bindings/src/PyImageParam.cpp
@@ -14,13 +14,11 @@ void define_image_param(py::module &m) {
         .def("stride", &Dimension::stride)
         .def("extent", &Dimension::extent)
         .def("max", &Dimension::max)
-        .def("min_estimate", &Dimension::min_estimate)
-        .def("extent_estimate", &Dimension::extent_estimate)
         .def("set_min", &Dimension::set_min, py::arg("min"))
         .def("set_extent", &Dimension::set_extent, py::arg("extent"))
         .def("set_stride", &Dimension::set_stride, py::arg("stride"))
         .def("set_bounds", &Dimension::set_bounds, py::arg("min"), py::arg("extent"))
-        .def("set_bounds_estimate", &Dimension::set_bounds_estimate, py::arg("min"), py::arg("extent"))
+        .def("set_estimate", &Dimension::set_estimate, py::arg("min"), py::arg("extent"))
         .def("dim", (Dimension (Dimension::*)(int)) &Dimension::dim, py::arg("dimension"), py::keep_alive<0, 1>())
     ;
 
@@ -32,6 +30,7 @@ void define_image_param(py::module &m) {
         .def("defined", &OutputImageParam::defined)
         .def("dim", (Dimension (OutputImageParam::*)(int)) &OutputImageParam::dim, py::arg("dimension"), py::keep_alive<0, 1>())
         .def("host_alignment", &OutputImageParam::host_alignment)
+        .def("set_estimates", &OutputImageParam::set_estimates, py::arg("estimates"))
         .def("set_host_alignment", &OutputImageParam::set_host_alignment)
         .def("dimensions", &OutputImageParam::dimensions)
         .def("left", &OutputImageParam::left)

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -165,7 +165,9 @@ py::object generate_impl(FactoryFunc factory, const GeneratorContext &context, p
         }
         py_outputs[i] = o;
     }
-    return py_outputs;
+    // An explicit "std::move" is needed here because there's
+    // an implicit tuple->object conversion that inhibits it otherwise.
+    return std::move(py_outputs);
 }
 
 void pystub_init(pybind11::module &m, FactoryFunc factory) {

--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -771,13 +771,10 @@ struct AutoSchedule {
     // function handle
     string get_func_handle(const string &name) const {
         size_t index = get_element(topological_order, name);
-        return "pipeline.get_func(" + std::to_string(index) + ")";
+        return "get_pipeline().get_func(" + std::to_string(index) + ")";
     }
 
     friend std::ostream& operator<<(std::ostream &stream, const AutoSchedule &sched) {
-        stream << "// Delete this line if not using Generator\n";
-        stream << "Pipeline pipeline = get_pipeline();\n\n";
-
         for (const auto &iter : sched.internal_vars) {
             if (iter.second.is_rvar) {
                 stream << "RVar ";
@@ -3514,9 +3511,6 @@ string generate_schedules(const vector<Function> &outputs, const Target &target,
     part.generate_cpu_schedule(target, sched);
 
     std::ostringstream oss;
-    oss << "// Target: " << target.to_string() << "\n";
-    oss << "// MachineParams: " << arch_params.to_string() << "\n";
-    oss << "\n";
     oss << sched;
     string sched_string = oss.str();
 

--- a/src/AutoScheduleUtils.cpp
+++ b/src/AutoScheduleUtils.cpp
@@ -262,8 +262,8 @@ void propagate_estimate_test() {
     p.set_estimate(10);
 
     ImageParam img(Int(32), 2);
-    img.dim(0).set_bounds_estimate(-3, 33);
-    img.dim(1).set_bounds_estimate(5, 55);
+    img.dim(0).set_estimate(-3, 33);
+    img.dim(1).set_estimate(5, 55);
 
     Var x("x"), y("y");
     check(p + x + y, x + y + 10);

--- a/src/Dimension.cpp
+++ b/src/Dimension.cpp
@@ -31,10 +31,12 @@ Expr Dimension::max() const {
     return min() + extent() - 1;
 }
 
+// DEPRECATED
 Expr Dimension::min_estimate() const {
     return param.min_constraint_estimate(d);
 }
 
+// DEPRECATED
 Expr Dimension::extent_estimate() const {
     return param.extent_constraint_estimate(d);
 }
@@ -72,15 +74,15 @@ Dimension Dimension::set_bounds(Expr min, Expr extent) {
     return set_min(min).set_extent(extent);
 }
 
-Dimension Dimension::set_bounds_estimate(Expr min, Expr extent) {
+Dimension Dimension::set_estimate(Expr min, Expr extent) {
     param.set_min_constraint_estimate(d, min);
     param.set_extent_constraint_estimate(d, extent);
     // Update the estimates on the linked Func as well.
     // (This matters mainly for OutputImageParams.)
     // Note that while it's possible/legal for a Dimension to have an undefined
-    // Func, you shouldn't ever call set_bounds_estimate on such an instance.
+    // Func, you shouldn't ever call set_estimate on such an instance.
     internal_assert(f.defined());
-    f.estimate(f.args()[d], min, extent);
+    f.set_estimate(f.args()[d], min, extent);
     return *this;
 }
 

--- a/src/Dimension.h
+++ b/src/Dimension.h
@@ -29,15 +29,6 @@ public:
      * given dimension */
     Expr stride() const;
 
-    /** Get the estimate of the minimum coordinate of this image parameter
-     * in the given dimension. Return an undefined expr if the estimate is
-     * never specified. */
-    Expr min_estimate() const;
-
-    /** Get the estimate of the extent of this image parameter in the given
-     * dimension. Return an undefined expr if the estimate is never specified. */
-    Expr extent_estimate() const;
-
     /** Set the min in a given dimension to equal the given
      * expression. Setting the mins to zero may simplify some
      * addressing math. */
@@ -76,8 +67,17 @@ public:
     Dimension set_bounds(Expr min, Expr extent);
 
     /** Set the min and extent estimates in one call. These values are only
-     * used by the auto-scheduler. */
-    Dimension set_bounds_estimate(Expr min, Expr extent);
+     * used by the auto-scheduler and/or the RunGen tool/ */
+    Dimension set_estimate(Expr min, Expr extent);
+
+   HALIDE_ATTRIBUTE_DEPRECATED("Use set_estimate() instead")
+   Dimension set_bounds_estimate(Expr min, Expr extent) { return set_estimate(min, extent); }
+
+   HALIDE_ATTRIBUTE_DEPRECATED("min_estimate() will be removed soon, do not use")
+   Expr min_estimate() const;
+
+   HALIDE_ATTRIBUTE_DEPRECATED("extent_estimate() will be removed soon, do not use")
+   Expr extent_estimate() const;
 
     /** Get a different dimension of the same buffer */
     // @{

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2074,12 +2074,12 @@ Func &Func::bound(Var var, Expr min, Expr extent) {
     // Propagate constant bounds into estimates as well.
     if (!is_const(min)) min = Expr();
     if (!is_const(extent)) extent = Expr();
-    estimate(var, min, extent);
+    set_estimate(var, min, extent);
 
     return *this;
 }
 
-Func &Func::estimate(Var var, Expr min, Expr extent) {
+Func &Func::set_estimate(Var var, Expr min, Expr extent) {
     invalidate_cache();
     bool found = func.is_pure_arg(var.name());
     user_assert(found)
@@ -2109,6 +2109,17 @@ Func &Func::estimate(Var var, Expr min, Expr extent) {
         if (extent.defined()) {
             param.set_extent_constraint_estimate(dim, extent);
         }
+    }
+    return *this;
+}
+
+Func &Func::set_estimates(const std::vector<std::pair<Expr, Expr>> &estimates) {
+    const std::vector<Var> a = args();
+    user_assert(estimates.size() == a.size())
+        << "Func " << name() << " has " << a.size() << " dimensions, "
+        << "but the estimates passed to set_estimates contains " << estimates.size() << " pairs.\n";
+    for (size_t i = 0; i < a.size(); i++) {
+        set_estimate(a[i], estimates[i].first, estimates[i].second);
     }
     return *this;
 }

--- a/src/Func.h
+++ b/src/Func.h
@@ -1465,7 +1465,16 @@ public:
      * generated schedules might break when the sizes of the dimensions are
      * very different from the estimates specified. These estimates are used
      * only by the auto scheduler if the function is a pipeline output. */
-    Func &estimate(Var var, Expr min, Expr extent);
+    Func &set_estimate(Var var, Expr min, Expr extent);
+
+    HALIDE_ATTRIBUTE_DEPRECATED("Use set_estimate() instead")
+    Func &estimate(Var var, Expr min, Expr extent) { return set_estimate(var, min, extent); }
+
+    /** Set (min, extent) estimates for all dimensions in the Func
+     * at once; this is equivalent to calling `set_estimate(args()[n], min, extent)`
+     * repeatedly, but slightly terser. The size of the estimates vector
+     * must match the dimensionality of the Func. */
+    Func &set_estimates(const std::vector<std::pair<Expr, Expr>> &estimates);
 
     /** Expand the region computed so that the min coordinates is
      * congruent to 'remainder' modulo 'modulus', and the extent is a

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1843,11 +1843,11 @@ void GeneratorInputBase::set_inputs(const std::vector<StubInput> &inputs) {
     verify_internals();
 }
 
-void GeneratorInputBase::estimate_impl(Var var, Expr min, Expr extent) {
+void GeneratorInputBase::set_estimate_impl(Var var, Expr min, Expr extent) {
     internal_assert(exprs_.empty() && funcs_.size() > 0 && parameters_.size() == funcs_.size());
     for (size_t i = 0; i < funcs_.size(); ++i) {
         Func &f = funcs_[i];
-        f.estimate(var, min, extent);
+        f.set_estimate(var, min, extent);
         // Propagate the estimate into the Parameter as well, just in case
         // we end up compiling this for toplevel.
         std::vector<Var> args = f.args();
@@ -1862,6 +1862,21 @@ void GeneratorInputBase::estimate_impl(Var var, Expr min, Expr extent) {
         Parameter &p = parameters_[i];
         p.set_min_constraint_estimate(dim, min);
         p.set_extent_constraint_estimate(dim, extent);
+    }
+}
+
+void GeneratorInputBase::set_estimates_impl(const std::vector<std::pair<Expr, Expr>> &estimates) {
+    internal_assert(exprs_.empty() && funcs_.size() > 0 && parameters_.size() == funcs_.size());
+    for (size_t i = 0; i < funcs_.size(); ++i) {
+        Func &f = funcs_[i];
+        f.set_estimates(estimates);
+        // Propagate the estimate into the Parameter as well, just in case
+        // we end up compiling this for toplevel.
+        for (size_t dim = 0; dim < estimates.size(); ++dim) {
+            Parameter &p = parameters_[i];
+            p.set_min_constraint_estimate(dim, estimates[dim].first);
+            p.set_extent_constraint_estimate(dim, estimates[dim].second);
+        }
     }
 }
 

--- a/src/OutputImageParam.cpp
+++ b/src/OutputImageParam.cpp
@@ -89,4 +89,15 @@ OutputImageParam::operator ExternFuncArgument() const {
     return param;
 }
 
+OutputImageParam &OutputImageParam::set_estimates(const std::vector<std::pair<Expr, Expr>> &estimates) {
+    const int d = dimensions();
+    user_assert((int) estimates.size() == d)
+        << "ImageParam " << name() << " has " << d << " dimensions, "
+        << "but the estimates passed to set_estimates contains " << estimates.size() << " pairs.\n";
+    for (int i = 0; i < d; i++) {
+        dim(i).set_estimate(estimates[i].first, estimates[i].second);
+    }
+    return *this;
+}
+
 }  // namespace Halide

--- a/src/OutputImageParam.h
+++ b/src/OutputImageParam.h
@@ -110,6 +110,12 @@ public:
     /** Using a param as the argument to an external stage treats it
      * as an Expr */
     operator ExternFuncArgument() const;
+
+    /** Set (min, extent) estimates for all dimensions in the ImageParam
+     * at once; this is equivalent to calling `dim(n).set_estimate(min, extent)`
+     * repeatedly, but slightly terser. The size of the estimates vector
+     * must match the dimensionality of the ImageParam. */
+    OutputImageParam &set_estimates(const std::vector<std::pair<Expr, Expr>> &estimates);
 };
 
 }  // namespace Halide

--- a/test/auto_schedule/cost_function.cpp
+++ b/test/auto_schedule/cost_function.cpp
@@ -31,7 +31,7 @@ int main(int argc, char **argv) {
     }
 
     // Provide estimates on the pipeline output
-    stencils[num_stencils - 1].estimate(x, 0, 6200).estimate(y, 0, 4600);
+    stencils[num_stencils - 1].set_estimate(x, 0, 6200).set_estimate(y, 0, 4600);
 
     // Auto-schedule the pipeline
     Target target = get_jit_target_from_environment();

--- a/test/auto_schedule/data_dependent.cpp
+++ b/test/auto_schedule/data_dependent.cpp
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
     g(x, y) = (f(x, y, input(x, y)%10) + f(x + 1, y, (input(x, y) - 1)%10))/2;
 
     // Provide estimates on the pipeline output
-    g.estimate(x, 0, input.width() - 1).estimate(y, 0, input.height());
+    g.set_estimate(x, 0, input.width() - 1).set_estimate(y, 0, input.height());
 
     // Auto-schedule the pipeline
     Target target = get_jit_target_from_environment();

--- a/test/auto_schedule/extern.cpp
+++ b/test/auto_schedule/extern.cpp
@@ -56,11 +56,10 @@ void test_case_1() {
     g(x, y) = f1(x, y) + f2(x, y);
 
     // Provide estimates on the pipeline output
-    g.estimate(x, 0, 1000).estimate(y, 0, 1000);
+    g.set_estimates({{0, 1000}, {0, 1000}});
 
     // Provide estimates on the ImageParam
-    input.dim(0).set_bounds_estimate(0, 1000);
-    input.dim(1).set_bounds_estimate(0, 1000);
+    input.set_estimates({{0, 1000}, {0, 1000}});
 
     // Auto-schedule the pipeline
     Target target = get_jit_target_from_environment();
@@ -89,9 +88,8 @@ void test_case_2() {
 
     g(x, y) = f2(x, y);
 
-    g.estimate(x, 0, 10).estimate(y, 0, 10);
-    input.dim(0).set_bounds_estimate(0, 10);
-    input.dim(1).set_bounds_estimate(0, 10);
+    g.set_estimates({{0, 10}, {0, 10}});
+    input.set_estimates({{0, 10}, {0, 10}});
 
     // Auto-schedule the pipeline
     Target target = get_jit_target_from_environment();
@@ -122,9 +120,8 @@ void test_case_3() {
 
     g(x, y) = f2(x, y);
 
-    g.estimate(x, 0, 10).estimate(y, 0, 10);
-    input.dim(0).set_bounds_estimate(0, 10);
-    input.dim(1).set_bounds_estimate(0, 10);
+    g.set_estimates({{0, 10}, {0, 10}});
+    input.set_estimates({{0, 10}, {0, 10}});
 
     // Auto-schedule the pipeline
     Target target = get_jit_target_from_environment();

--- a/test/auto_schedule/fibonacci.cpp
+++ b/test/auto_schedule/fibonacci.cpp
@@ -15,7 +15,7 @@ double run_test(bool auto_schedule) {
     g(x) = fib(x+10);
 
     // Provide estimates on the pipeline output
-    g.estimate(x, 0, 300);
+    g.set_estimate(x, 0, 300);
 
     Target target = get_jit_target_from_environment();
     Pipeline p(g);

--- a/test/auto_schedule/harris.cpp
+++ b/test/auto_schedule/harris.cpp
@@ -72,7 +72,7 @@ double run_test(bool auto_schedule) {
     Func shifted("shifted");
     shifted(x, y) = harris(x + 2, y + 2);
 
-    shifted.estimate(x, 0, W).estimate(y, 0, H);
+    shifted.set_estimates({{0, W}, {0, H}});
 
     Target target = get_jit_target_from_environment();
     Pipeline p(shifted);

--- a/test/auto_schedule/histogram.cpp
+++ b/test/auto_schedule/histogram.cpp
@@ -62,7 +62,7 @@ double run_test(bool auto_schedule) {
 
     if (auto_schedule) {
         // Provide estimates on the pipeline output
-        color.estimate(x, 0, 1920).estimate(y, 0, 1024).estimate(c, 0, 3);
+        color.set_estimates({{0, 1920}, {0, 1024}, {0, 3}});
         // Auto-schedule the pipeline
         p.auto_schedule(target);
     } else if (target.has_gpu_feature()) {

--- a/test/auto_schedule/iir.cpp
+++ b/test/auto_schedule/iir.cpp
@@ -87,9 +87,9 @@ double run_test(bool auto_schedule) {
 
     if (auto_schedule) {
         // Provide estimates on the pipeline output
-        blur.estimate(x, 0, W)
-            .estimate(y, 0, H)
-            .estimate(c, 0, 3);
+        blur.set_estimate(x, 0, W)
+            .set_estimate(y, 0, H)
+            .set_estimate(c, 0, 3);
         // Auto-schedule the pipeline
         p.auto_schedule(target);
     }

--- a/test/auto_schedule/interpolate.cpp
+++ b/test/auto_schedule/interpolate.cpp
@@ -75,10 +75,7 @@ int run_test(bool auto_schedule, int argc, char **argv) {
 
     Func normalize("normalize");
     normalize(x, y, c) = interpolated[0](x, y, c) / interpolated[0](x, y, 3);
-    normalize
-        .estimate(c, 0, 4)
-        .estimate(x, 0, in.width())
-        .estimate(y, 0, in.height());
+    normalize.set_estimates({{0, in.width()}, {0, in.height()}, {0, 4}});
 
     std::cout << "Finished function setup." << std::endl;
 

--- a/test/auto_schedule/large_window.cpp
+++ b/test/auto_schedule/large_window.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
     g(x, y) = sum(f(x + w.x, y + w.y), "sum2")/1024;
 
     // Provide estimates on the pipeline output
-    g.estimate(x, 0, input.width()).estimate(y, 0, input.height());
+    g.set_estimate(x, 0, input.width()).set_estimate(y, 0, input.height());
 
     // Pick a schedule
     Target target = get_jit_target_from_environment();

--- a/test/auto_schedule/mat_mul.cpp
+++ b/test/auto_schedule/mat_mul.cpp
@@ -38,7 +38,7 @@ double run_test(bool auto_schedule) {
 
     if (auto_schedule) {
         // Provide estimates on the pipeline output
-        out.estimate(x, 0, size).estimate(y, 0, size);
+        out.set_estimate(x, 0, size).set_estimate(y, 0, size);
         // Auto-schedule the pipeline
         p.auto_schedule(target);
     } else if (target.has_gpu_feature()) {

--- a/test/auto_schedule/max_filter.cpp
+++ b/test/auto_schedule/max_filter.cpp
@@ -68,9 +68,9 @@ double run_test(bool auto_schedule) {
     Var tx, xi;
     if (auto_schedule) {
         // Provide estimates on the pipeline output
-        final.estimate(x, 0, in.width())
-            .estimate(y, 0, in.height())
-            .estimate(c, 0, in.channels());
+        final.set_estimate(x, 0, in.width())
+            .set_estimate(y, 0, in.height())
+            .set_estimate(c, 0, in.channels());
         // Auto-schedule the pipeline
         p.auto_schedule(target);
     } else if (target.has_gpu_feature()) {

--- a/test/auto_schedule/multi_output.cpp
+++ b/test/auto_schedule/multi_output.cpp
@@ -25,8 +25,8 @@ int main(int argc, char **argv) {
     h(x, y) = (f(x, y) + f(x, y+1))/2;
 
     // Provide estimates on the pipeline output
-    g.estimate(x, 0, 1000).estimate(y, 0, 1000);
-    h.estimate(x, 0, 1000).estimate(y, 0, 1000);
+    g.set_estimate(x, 0, 1000).set_estimate(y, 0, 1000);
+    h.set_estimate(x, 0, 1000).set_estimate(y, 0, 1000);
 
     // Auto-schedule the pipeline
     std::vector<Func> outs;

--- a/test/auto_schedule/overlap.cpp
+++ b/test/auto_schedule/overlap.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
     }
 
     // Provide esitmates for pipeline outputs
-    up[num_levels - 1].estimate(x, 0, 1500).estimate(y, 0, 1500);
+    up[num_levels - 1].set_estimates({{0, 1500}, {0, 1500}});
 
     // Auto-schedule the pipeline
     Target target = get_jit_target_from_environment();

--- a/test/auto_schedule/param.cpp
+++ b/test/auto_schedule/param.cpp
@@ -14,11 +14,10 @@ void run_test_1() {
     g(x, y) = f(x + offset, y) + f(x - offset, y);
 
     // Provide estimates on the pipeline output
-    g.estimate(x, 0, 1000).estimate(y, 0, 1000);
+    g.set_estimates({{0, 1000}, {0, 1000}});
 
     // Provide estimates on the ImageParam
-    input.dim(0).set_bounds_estimate(0, 1000);
-    input.dim(1).set_bounds_estimate(0, 1000);
+    input.set_estimates({{0, 1000}, {0, 1000}});
 
     // Auto-schedule the pipeline
     Target target = get_jit_target_from_environment();
@@ -42,11 +41,10 @@ void run_test_2() {
     g(x, y) = f(x + offset, y) + f(x - offset, y);
 
     // Provide estimates on the pipeline output
-    g.estimate(x, 0, 1000).estimate(y, 0, 1000);
+    g.set_estimates({{0, 1000}, {0, 1000}});
 
     // Provide estimates on the ImageParam
-    input.dim(0).set_bounds_estimate(0, 1000);
-    input.dim(1).set_bounds_estimate(0, 1000);
+    input.set_estimates({{0, 1000}, {0, 1000}});
 
     // Auto-schedule the pipeline
     Target target = get_jit_target_from_environment();
@@ -70,14 +68,10 @@ void run_test_3() {
     output(x, y) = f(x + offset, y) + f(x - offset, y);
 
     // Provide estimates on the ImageParam
-    input.dim(0).set_bounds_estimate(0, 1000);
-    input.dim(1).set_bounds_estimate(0, 1000);
+    input.set_estimates({{0, 1000}, {0, 1000}});
 
     // Provide estimates on the pipeline output,
-    // via output_buffer().set_bounds_estimate()
-    // rather than .estimate()
-    output.output_buffer().dim(0).set_bounds_estimate(0, 1000);
-    output.output_buffer().dim(1).set_bounds_estimate(0, 1000);
+    output.set_estimates({{0, 1000}, {0, 1000}});
 
     // Auto-schedule the pipeline
     Target target = get_jit_target_from_environment();
@@ -103,46 +97,11 @@ void run_test_4() {
     output(x, y) = Tuple(f(x + offset, y), f(x - offset, y));
 
     // Provide estimates on the ImageParam
-    input.dim(0).set_bounds_estimate(0, 1000);
-    input.dim(1).set_bounds_estimate(0, 1000);
+    input.set_estimates({{0, 1000}, {0, 1000}});
 
     for (auto &output_buffer : output.output_buffers()) {
-        output_buffer.dim(0).set_bounds_estimate(0, 1000);
-        output_buffer.dim(1).set_bounds_estimate(0, 1000);
+        output_buffer.set_estimates({{0, 1000}, {0, 1000}});
     }
-
-    // Auto-schedule the pipeline
-    Target target = get_jit_target_from_environment();
-    Pipeline p(output);
-
-    p.auto_schedule(target);
-
-    // Inspect the schedule
-    output.print_loop_nest();
-}
-
-// Same as run_test_5, but with using both estimate() and set_bounds_estimate()
-// on different dimensions of the same output
-void run_test_5() {
-    Param<int> offset;
-    offset.set_estimate(1);
-    ImageParam input(UInt(8), 2);
-    Var x("x"), y("y");
-    Func f("f");
-    f(x, y) = input(x, y) * 2;
-
-    Func output("output");
-    output(x, y) = f(x + offset, y) + f(x - offset, y);
-
-    // Provide estimates on the ImageParam
-    input.dim(0).set_bounds_estimate(0, 1000);
-    input.dim(1).set_bounds_estimate(0, 1000);
-
-    // Provide estimates on the pipeline output,
-    // via output_buffer().set_bounds_estimate()
-    // rather than .estimate()
-    output.output_buffer().dim(0).set_bounds_estimate(0, 1000);
-    output.estimate(y, 0, 1000);
 
     // Auto-schedule the pipeline
     Target target = get_jit_target_from_environment();
@@ -163,8 +122,6 @@ int main(int argc, char **argv) {
     run_test_3();
     std::cout << "Test 4:" << std::endl;
     run_test_4();
-    std::cout << "Test 5:" << std::endl;
-    run_test_5();
     printf("Success!\n");
     return 0;
 }

--- a/test/auto_schedule/reorder.cpp
+++ b/test/auto_schedule/reorder.cpp
@@ -25,7 +25,7 @@ double run_test_1(bool auto_schedule) {
 
     if (auto_schedule) {
         // Provide estimates on the pipeline output
-        r.estimate(x, 0, 1024).estimate(y, 0, 1024).estimate(c, 0, 3);
+        r.set_estimates({{0, 1024}, {0, 1024}, {0, 3}});
         // Auto-schedule the pipeline
         p.auto_schedule(target);
     } else {
@@ -77,10 +77,7 @@ double run_test_2(bool auto_schedule) {
 
     if (auto_schedule) {
         // Provide estimates on the pipeline output
-        diff.estimate(x, 0, left_im.width()).
-             estimate(y, 0, left_im.height()).
-             estimate(z, 0, 32).
-             estimate(c, 0, 3);
+        diff.set_estimates({{0, left_im.width()}, {0, left_im.height()}, {0, 32}, {0, 3}});
         // Auto-schedule the pipeline
         p.auto_schedule(target);
     } else {
@@ -119,7 +116,7 @@ double run_test_3(bool auto_schedule) {
 
     if (auto_schedule) {
         // Provide estimates on the pipeline output
-        r.estimate(x, 0, 1024).estimate(y, 0, 1024).estimate(c, 0, 3);
+        r.set_estimates({{0, 1024}, {0, 1024}, {0, 3}});
         // Auto-schedule the pipeline
         p.auto_schedule(target);
     } else {

--- a/test/auto_schedule/tile_vs_inline.cpp
+++ b/test/auto_schedule/tile_vs_inline.cpp
@@ -26,9 +26,7 @@ int main(int argc, char **argv) {
                 + f(x+2, y, (y)%10, c);
 
     // Provide estimates on the pipeline output
-    g.estimate(x, 0, input.width() - 2)
-        .estimate(y, 0, input.height() - 2)
-        .estimate(c, 0, 3);
+    g.set_estimates({{0, input.width() - 2}, {0, input.height() - 2}, {0, 3}});
 
     // Auto-schedule the pipeline
     Target target = get_jit_target_from_environment();

--- a/test/auto_schedule/unbounded_nonpure.cpp
+++ b/test/auto_schedule/unbounded_nonpure.cpp
@@ -20,11 +20,10 @@ void run_test() {
     g(x, y) = f(cast<int>(Halide::sin(x)) + x, y);
 
     // Provide estimates on the pipeline output
-    g.estimate(x, 0, 1000).estimate(y, 0, 1000);
+    g.set_estimates({{0, 1000}, {0, 1000}});
 
     // Provide estimates on the ImageParam
-    input.dim(0).set_bounds_estimate(0, 1000);
-    input.dim(1).set_bounds_estimate(0, 1000);
+    input.set_estimates({{0, 1000}, {0, 1000}});
 
     // Auto-schedule the pipeline
     Target target = get_jit_target_from_environment();

--- a/test/auto_schedule/unsharp.cpp
+++ b/test/auto_schedule/unsharp.cpp
@@ -58,9 +58,7 @@ double run_test(bool auto_schedule) {
 
     if (auto_schedule) {
         // Provide estimates on the pipeline output
-        unsharp.estimate(x, 0, in.width())
-            .estimate(y, 0, in.height())
-            .estimate(c, 0, in.channels());
+        unsharp.set_estimates({{0, in.width()}, {0, in.height()}, {0, in.channels()}});
         // Auto-schedule the pipeline
         p.auto_schedule(target);
     } else if (target.has_gpu_feature()) {

--- a/test/auto_schedule/unused_func.cpp
+++ b/test/auto_schedule/unused_func.cpp
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
     h(x) = x*x;
     f(x) = select(false, g(x + 1), h(x + 1));
 
-    f.estimate(x, 0, 256);
+    f.set_estimates({{0, 256}});
 
     Target target = get_jit_target_from_environment();
     Pipeline p(f);

--- a/test/auto_schedule/vectorize_var_in_update.cpp
+++ b/test/auto_schedule/vectorize_var_in_update.cpp
@@ -32,8 +32,7 @@ int main(int argc, char **argv) {
     h(x, y) += g(r.x, r.y) + 3;
 
     // Provide estimates on the pipeline output
-    h.estimate(x, 0, 50);
-    h.estimate(y, 0, 50);
+    h.set_estimates({{0, 50}, {0, 50}});
 
     // Auto-schedule the pipeline
     Target target = get_jit_target_from_environment();

--- a/test/correctness/autoschedule_small_pure_update.cpp
+++ b/test/correctness/autoschedule_small_pure_update.cpp
@@ -14,8 +14,8 @@ int main(int argc, char **argv) {
 
     h(x, y) = in_param(x, y) + g(x);
 
-    h.estimate(x, 0, 13).estimate(y, 0, 17);
-    in_param.dim(0).set_bounds_estimate(0, 13).dim(1).set_bounds_estimate(0, 17);
+    h.set_estimates({{0, 13}, {0, 17}});
+    in_param.set_estimates({{0, 13}, {0, 17}});
 
     Pipeline p(h);
     p.auto_schedule(Target("host"));

--- a/test/error/auto_schedule_no_bounds.cpp
+++ b/test/error/auto_schedule_no_bounds.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
     g(x) = fib(x+10);
 
     // Provide estimates for pipeline output
-    g.estimate(x, 0, 50);
+    g.set_estimate(x, 0, 50);
 
     // Partially specify some schedules
     g.bound(x, 0, 100);

--- a/test/error/auto_schedule_no_parallel.cpp
+++ b/test/error/auto_schedule_no_parallel.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
     g(x) = fib(x+10);
 
     // Provide estimates for pipeline output
-    g.estimate(x, 0, 50);
+    g.set_estimate(x, 0, 50);
 
     // Partially specify some schedules
     g.parallel(x);

--- a/test/error/auto_schedule_no_reorder.cpp
+++ b/test/error/auto_schedule_no_reorder.cpp
@@ -14,8 +14,7 @@ int main(int argc, char **argv) {
     g(x, y) = f(x+10, y) + 2;
 
     // Provide estimates for pipeline output
-    g.estimate(x, 0, 50);
-    g.estimate(y, 0, 50);
+    g.set_estimates({{0, 50}, {0, 50}});
 
     // Partially specify some schedules
     g.reorder(y, x);

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -135,14 +135,14 @@ public:
         dim_only_output_buffer.compute_with(Func(typed_output_buffer), x);
 
         // Provide some bounds estimates for a Buffer input
-        typed_input_buffer.estimate(Halide::_0, 0, 2592);
-        typed_input_buffer.dim(1).set_bounds_estimate(42, 1968);
+        typed_input_buffer.set_estimate(Halide::_0, 0, 2592);
+        typed_input_buffer.dim(1).set_estimate(42, 1968);
 
         // Provide some bounds estimates for a Func input
         input
-            .estimate(Halide::_0, 10, 2592)
-            .estimate(Halide::_1, 20, 1968)
-            .estimate(Halide::_2, 0, 3);
+            .set_estimate(Halide::_0, 10, 2592)
+            .set_estimate(Halide::_1, 20, 1968)
+            .set_estimate(Halide::_2, 0, 3);
 
         // Provide some scalar estimates.
         b.set_estimate(false);
@@ -154,15 +154,15 @@ public:
         // Provide some bounds estimates for an Output<Func>.
         // Note that calling bound() implicitly calls estimate() as well.
         output
-            .estimate(x, 10, 2592)
-            .estimate(y, 20, 1968)
+            .set_estimate(x, 10, 2592)
+            .set_estimate(y, 20, 1968)
             .bound(c, 0, 3);
 
         // Provide partial bounds estimates for an Output<Buffer>
-        typed_output_buffer.estimate(x, 10, 2592);
-        typed_output_buffer.dim(1).set_bounds_estimate(20, 1968);
+        typed_output_buffer.set_estimate(x, 10, 2592);
+        typed_output_buffer.dim(1).set_estimate(20, 1968);
 
-        // Note that calling set_bounds()/bound() implicitly calls set_bounds_estimate()/estimate() as well.
+        // Note that calling set_bounds()/bound() implicitly calls set_estimate()/estimate() as well.
         type_only_output_buffer.dim(1).set_bounds(0, 32);
         type_only_output_buffer.bound(c, 0, 3);
     }

--- a/tutorial/lesson_21_auto_scheduler_generate.cpp
+++ b/tutorial/lesson_21_auto_scheduler_generate.cpp
@@ -76,24 +76,19 @@ public:
 
             // To provide estimates (min and extent values) for each dimension
             // of the input images ('input', 'filter', and 'bias'), we use the
-            // set_bounds_estimate() method. set_bounds_estimate() takes in
+            // set_estimates() method. set_estimates() takes in a list of
             // (min, extent) of the corresponding dimension as arguments.
-            input.dim(0).set_bounds_estimate(0, 1024);
-            input.dim(1).set_bounds_estimate(0, 1024);
-            input.dim(2).set_bounds_estimate(0, 3);
+            input.set_estimates({{0, 1024}, {0, 1024}, {0, 3}});
 
             // To provide estimates on the parameter values, we use the
             // set_estimate() method.
             factor.set_estimate(2.0f);
 
             // To provide estimates (min and extent values) for each dimension
-            // of pipeline outputs, we use the estimate() method. estimate()
-            // takes in (dim_name, min, extent) as arguments.
-            output1.estimate(x, 0, 1024)
-                   .estimate(y, 0, 1024);
-
-            output2.estimate(x, 0, 1024)
-                   .estimate(y, 0, 1024);
+            // of pipeline outputs, we use the set_estimates() method. set_estimates()
+            // takes in a list of (min, extent) for each dimension.
+            output1.set_estimates({{0, 1024}, {0, 1024}});
+            output2.set_estimates({{0, 1024}, {0, 1024}});
 
             // Technically, the estimate values can be anything, but the closer
             // they are to the actual use-case values, the better the generated


### PR DESCRIPTION
Fix https://github.com/halide/Halide/issues/3454:
- settles on `set_estimate()` as the one preferred API name; deprecate `estimate()` and `set_bounds_estimate()`
- deprecate `min_estimate()` and `extent_estimate()`, since they are unused and there weren't equivalent getters for ImageParam, Param, etc.
- Add `Func::set_estimates()` and `ImageParam::set_estimates()`, plus the equivalent Generator wrappers; these take a vector of Expr pairs, to allow setting the estimates for all dimensions at once. (In addition to being terser, this allows a quick fail if you don't set all of the dimensions.)
- Convert all extant use to use the new APIs; prefer to use `set_estimates()` rather than repeated calls to `set_estimate()` for reasons given above.