### PR TITLE
Add --estimate_all flag to RunGen

### DIFF
--- a/README_rungen.md
+++ b/README_rungen.md
@@ -130,6 +130,14 @@ Generator, and inits every element to zero:
 $ ./bin/local_laplacian.rungen --output_extents=[100,200,3] input=zero:[123,456,3] levels=8 alpha=1 beta=1 output=/tmp/out.png
 ```
 
+You can also specify arbitrary (nonzero) constants:
+
+```
+# Input is a 3-dimensional image with extent 123, 456, and 3,
+# filled with a constant value of 42
+$ ./bin/local_laplacian.rungen --output_extents=[100,200,3] input=constant:42:[123,456,3] levels=8 alpha=1 beta=1 output=/tmp/out.png
+```
+
 Similarly, you can create identity images where only the diagonal elements are
 1-s (rest are 0-s) by invoking `identity:[]`. Diagonal elements are defined as
 those whose first two coordinates are equal.

--- a/README_rungen.md
+++ b/README_rungen.md
@@ -197,6 +197,11 @@ highly recommended you do testing with the `--verbose` flag (which will log the
 calculated sizes) to reality-check that you are getting what you expect,
 especially for benchmarking.
 
+A common case (especially for benchmarking) is to specify using estimates for
+all inputs and outputs; for this, you can specify `--estimate_all`, which is
+just a shortcut for `--default_input_buffers=estimate_then_auto --default_input_scalars=estimate --output_extents=estimate`.
+
+
 ## Benchmarking
 
 To run a benchmark, use the `--benchmarks=all` flag:

--- a/apps/autoscheduler/Makefile
+++ b/apps/autoscheduler/Makefile
@@ -20,7 +20,7 @@ $(BIN)/%/demo.rungen: $(BIN)/%/RunGenMain.o $(BIN)/%/demo.registration.cpp $(BIN
 
 # demonstrates single-shot use of the autoscheduler
 demo: $(BIN)/$(HL_TARGET)/demo.rungen
-	$^ --benchmarks=all --benchmark_min_time=1 --default_input_buffers=random:0:auto --output_extents=estimate --default_input_scalars=estimate
+	$^ --benchmarks=all --benchmark_min_time=1 --estimate_all
 
 # demonstrates an autotuning loop
 # (using $(AUTOSCHED_BIN) and $(AUTOSCHED_SRC) here seems overkill, but makes copy-n-paste elsewhere easier)

--- a/apps/autoscheduler/autotune_loop.sh
+++ b/apps/autoscheduler/autotune_loop.sh
@@ -136,9 +136,7 @@ benchmark_sample() {
     HL_NUM_THREADS=32 \
         ${TIMEOUT_CMD} -k ${BENCHMARKING_TIMEOUT} ${BENCHMARKING_TIMEOUT} \
         ${D}/bench \
-        --output_extents=estimate \
-        --default_input_buffers=random:0:estimate_then_auto \
-        --default_input_scalars=estimate \
+        --estimate_all \
         --benchmarks=all \
             | tee ${D}/bench.txt || echo "Benchmarking failed or timed out for ${D}"
 

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -207,7 +207,7 @@ $(BIN)/%.run: $(BIN)/%.rungen
 .PHONY: %.benchmark
 %.benchmark: $(BIN)/$(HL_TARGET)/%.rungen
 	@[[ "$(HL_TARGET)" != "wasm-32-wasmrt"* ]] || (echo "HL_TARGET must NOT begin with wasm-32-wasmrt for target $@" && exit 1)
-	@$^ --benchmarks=all --default_input_buffers --default_input_scalars --output_extents=estimate --parsable_output
+	@$^ --benchmarks=all --estimate_all --parsable_output
 
 # ------- wasm support
 
@@ -274,4 +274,4 @@ $(BIN)/%.rungen_wasm: $(BIN)/%.rungen.js
 .PHONY: %.benchmark_wasm
 %.benchmark_wasm: $(BIN)/$(HL_TARGET)/%.rungen.js
 	@[[ "$(HL_TARGET)" == "wasm-32-wasmrt"* ]] || (echo "HL_TARGET must begin with wasm-32-wasmrt for target $@" && exit 1)
-	@cd $(<D); $(WASM_SHELL) $(<F) $(WASM_SHELL_ARG_SEP) --benchmarks=all --default_input_buffers --default_input_scalars --output_extents=estimate --parsable_output
+	@cd $(<D); $(WASM_SHELL) $(<F) $(WASM_SHELL_ARG_SEP) --benchmarks=all --estimate_all --parsable_output

--- a/tools/RunGenMain.cpp
+++ b/tools/RunGenMain.cpp
@@ -165,6 +165,17 @@ Flags:
         Final output is emitted in an easy-to-parse output (one value per line),
         rather than easy-for-humans.
 
+    --estimate_all:
+        Request that all inputs and outputs are based on estimate,
+        and fill buffers with random values. This is exactly equivalent to
+        specifying
+
+            --default_input_buffers=estimate_then_auto
+            --default_input_scalars=estimate
+            --output_extents=estimate
+
+        and is a convenience for automated benchmarking.
+
 Known Issues:
 
     * Filters running on GPU (vs CPU) have not been tested.
@@ -456,6 +467,14 @@ int main(int argc, char **argv) {
                 }
             } else if (flag_name == "output_extents") {
                 user_specified_output_shape = flag_value;
+            } else if (flag_name == "estimate_all") {
+                // Equivalent to:
+                // --default_input_buffers=random:0:estimate_then_auto
+                // --default_input_scalars=estimate
+                // --output_extents=estimate
+                default_input_buffers = "random:0:estimate_then_auto";
+                default_input_scalars = "estimate";
+                user_specified_output_shape = "estimate";
             } else {
                 usage(argv[0]);
                 fail() << "Unknown flag: " << flag_name;


### PR DESCRIPTION
Just some syntactic sugar for the common case of using estimates for all inputs and outputs.