### PR TITLE
Use zero-init instead of memset for other.buf in HalideBuffer.h

### DIFF
--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -45,7 +45,7 @@ GXX ?= g++
 OPTIMIZE ?= -O3
 
 CFLAGS += $(OPTIMIZE) -I $(HALIDE_DISTRIB_PATH)/include/ -I $(HALIDE_DISTRIB_PATH)/tools/ -I $(HALIDE_DISTRIB_PATH)/apps/support/
-CXXFLAGS += $(OPTIMIZE) -std=c++11 -I $(HALIDE_DISTRIB_PATH)/include/ -I $(HALIDE_DISTRIB_PATH)/tools/ $(SANITIZER_FLAGS) -Wall -Werror -Wno-unused-function -Wcast-qual -Wignored-qualifiers -Wno-comment -Wsign-compare -Wno-unknown-warning-option -Wno-psabi
+CXXFLAGS += $(OPTIMIZE) -std=c++11 -I $(HALIDE_DISTRIB_PATH)/include/ -I $(HALIDE_DISTRIB_PATH)/tools/ $(SANITIZER_FLAGS) -Wall -Werror -Wno-unused-function -Wcast-qual -Wignored-qualifiers -Wno-comment -Wsign-compare -Wno-psabi
 
 ifeq (0, $(HALIDE_RTTI))
 CXXFLAGS += -fno-rtti

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -676,7 +676,7 @@ public:
         other.dev_ref_count = nullptr;
         other.alloc = nullptr;
         move_shape_from(std::forward<Buffer<T, D>>(other));
-        memset(&other.buf, 0, sizeof(other.buf));
+        other.buf = halide_buffer_t();
     }
 
     /** Move-construct a Buffer from a Buffer of different
@@ -690,7 +690,7 @@ public:
         other.dev_ref_count = nullptr;
         other.alloc = nullptr;
         move_shape_from(std::forward<Buffer<T2, D2>>(other));
-        memset(&other.buf, 0, sizeof(other.buf));
+        other.buf = halide_buffer_t();
     }
 
     /** Assign from another Buffer of possibly-different
@@ -741,7 +741,7 @@ public:
         free_shape_storage();
         buf = other.buf;
         move_shape_from(std::forward<Buffer<T2, D2>>(other));
-        memset(&other.buf, 0, sizeof(other.buf));
+        other.buf = halide_buffer_t();
         return *this;
     }
 
@@ -755,7 +755,7 @@ public:
         free_shape_storage();
         buf = other.buf;
         move_shape_from(std::forward<Buffer<T, D>>(other));
-        memset(&other.buf, 0, sizeof(other.buf));
+        other.buf = halide_buffer_t();
         return *this;
     }
 


### PR DESCRIPTION
See https://github.com/halide/Halide/issues/4080

Also: drive-by removal of `-Wno-unknown-warning-option` since no compiler seems to actually understand it