### PR TITLE
Allow Input<SomeType*>::set_estimate()

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1871,7 +1871,18 @@ public:
         return ExternFuncArgument(this->exprs().at(0));
     }
 
-    template <typename T2 = T, typename std::enable_if<!std::is_array<T2>::value>::type * = nullptr>
+    template <typename T2 = T, typename std::enable_if<std::is_pointer<T2>::value>::type * = nullptr>
+    void set_estimate(const TBase &value) {
+        this->check_gio_access();
+        user_assert(value == nullptr) << "nullptr is the only valid estimate for Input<PointerType>";
+        Expr e = reinterpret(type_of<T2>(), cast<uint64_t>(0));
+        for (Parameter &p : this->parameters_) {
+            p.set_estimate(e);
+        }
+    }
+
+
+    template <typename T2 = T, typename std::enable_if<!std::is_array<T2>::value && !std::is_pointer<T2>::value>::type * = nullptr>
     void set_estimate(const TBase &value) {
         this->check_gio_access();
         Expr e = Expr(value);

--- a/test/generator/cxx_mangling_generator.cpp
+++ b/test/generator/cxx_mangling_generator.cpp
@@ -76,7 +76,28 @@ public:
     }
 
     void schedule() {
-        // nothing
+        input.set_estimates({{0, 100}});
+        offset_i8.set_estimate(0);
+        offset_u8.set_estimate(0);
+        offset_i16.set_estimate(0);
+        offset_u16.set_estimate(0);
+        offset_i32.set_estimate(0);
+        offset_u32.set_estimate(0);
+        offset_i64.set_estimate(0);
+        offset_u64.set_estimate(0);
+        scale_direction.set_estimate(1);
+        scale_f.set_estimate(0);
+        scale_d.set_estimate(0);
+        ptr.set_estimate(nullptr);
+        const_ptr.set_estimate(nullptr);
+        void_ptr.set_estimate(nullptr);
+        const_void_ptr.set_estimate(nullptr);
+        string_ptr.set_estimate(nullptr);
+        const_string_ptr.set_estimate(nullptr);
+        const_my_class_ptr.set_estimate(nullptr);
+        const_my_struct_ptr.set_estimate(nullptr);
+        const_my_union_ptr.set_estimate(nullptr);
+        output.set_estimates({{0, 100}});
     }
 };
 

--- a/test/generator/example_generator.cpp
+++ b/test/generator/example_generator.cpp
@@ -77,20 +77,25 @@ public:
     }
 
     void schedule() {
-        output
-            .bound(c, 0, channels)
-            .reorder(c, x, y)
-            .unroll(c);
-        // Note that we can use the Generator method natural_vector_size()
-        // here; this produces the width of the SIMD vector being targeted
-        // divided by the width of the data type.
-        const int v = natural_vector_size(output.type());
-        if (parallelize && vectorize) {
-            output.parallel(y).vectorize(x, v);
-        } else if (parallelize) {
-            output.parallel(y);
-        } else if (vectorize) {
-            output.vectorize(x, v);
+        runtime_factor.set_estimate(1);
+        output.set_estimates({{0, 32}, {0, 32}, {0, 3}});
+
+        if (!auto_schedule) {
+            output
+                .bound(c, 0, channels)
+                .reorder(c, x, y)
+                .unroll(c);
+            // Note that we can use the Generator method natural_vector_size()
+            // here; this produces the width of the SIMD vector being targeted
+            // divided by the width of the data type.
+            const int v = natural_vector_size(output.type());
+            if (parallelize && vectorize) {
+                output.parallel(y).vectorize(x, v);
+            } else if (parallelize) {
+                output.parallel(y);
+            } else if (vectorize) {
+                output.vectorize(x, v);
+            }
         }
     }
 


### PR DESCRIPTION
Previouslty this didn't compile. Add a wrapper that allows it to be set (but only allow nullptr as the estimate value for now).

Also, drive-by add of set_estimates calls to two Generators.