### PR TITLE
Fix comment on FFT App Generator file

### DIFF
--- a/apps/fft/fft_generator.cpp
+++ b/apps/fft/fft_generator.cpp
@@ -51,7 +51,7 @@ public:
 
     // Indicates forward or inverse Fourier transform --
     // "samples_to_frequency" maps to a forward FFT. (Other packages sometimes call this a sign of -1)
-    // "frequency_to_samples" maps to a forward FFT. (Other packages sometimes call this a sign of +1)
+    // "frequency_to_samples" maps to a backward FFT. (Other packages sometimes call this a sign of +1)
     GeneratorParam<FFTDirection> direction{"direction", FFTDirection::SamplesToFrequency,
         fft_direction_enum_map() };
 


### PR DESCRIPTION
Fix the comment that documents the direction of the FFT on generator file.