### PR TITLE
Pass $HALIDE_DISTRIB_PATH to autotune_loop.sh

### DIFF
--- a/apps/autoscheduler/Makefile
+++ b/apps/autoscheduler/Makefile
@@ -30,7 +30,8 @@ autotune: $(GENERATOR_BIN)/demo.generator $(AUTOSCHED_BIN)/featurization_to_samp
 		demo \
 		x86-64-avx2 \
 		$(AUTOSCHED_SRC)/weights \
-		$(AUTOSCHED_BIN)
+		$(AUTOSCHED_BIN) \
+		$(HALIDE_DISTRIB_PATH)
 
 $(BIN)/test_perfect_hash_map: test_perfect_hash_map.cpp PerfectHashMap.h
 	@mkdir -p $(@D)

--- a/apps/autoscheduler/autotune_loop.sh
+++ b/apps/autoscheduler/autotune_loop.sh
@@ -1,8 +1,8 @@
 # Build the generator to autotune. This script will be autotuning the
 # autoscheduler's cost model training pipeline, which is large enough
 # to be interesting.
-if [ $# -lt 5 -o $# -gt 6 ]; then
-  echo "Usage: $0 /path/to/some.generator generatorname halide_target weights_dir autoschedule_bin_dir [generator_args_sets]"
+if [ $# -lt 6 -o $# -gt 7 ]; then
+  echo "Usage: $0 /path/to/some.generator generatorname halide_target weights_dir autoschedule_bin_dir halide_distrib_path [generator_args_sets]"
   exit
 fi
 
@@ -16,12 +16,13 @@ PIPELINE=${2}
 HL_TARGET=${3}
 START_WEIGHTS_DIR=${4}
 AUTOSCHED_BIN=${5}
+HALIDE_DISTRIB_PATH=${6}
 
 # Read the generator-arg sets into an array. Each set is delimited
 # by space; multiple values within each set are are delimited with ;
 # e.g. "set1arg1=1;set1arg2=foo set2=bar set3arg1=3.14;set4arg2=42"
 if [ $# -ge 6 ]; then
-    IFS=' ' read -r -a GENERATOR_ARGS_SETS_ARRAY <<< "${6}"
+    IFS=' ' read -r -a GENERATOR_ARGS_SETS_ARRAY <<< "${7}"
 else
     declare -a GENERATOR_ARGS_SETS_ARRAY=
 fi

--- a/apps/autoscheduler/autotune_loop.sh
+++ b/apps/autoscheduler/autotune_loop.sh
@@ -21,7 +21,7 @@ HALIDE_DISTRIB_PATH=${6}
 # Read the generator-arg sets into an array. Each set is delimited
 # by space; multiple values within each set are are delimited with ;
 # e.g. "set1arg1=1;set1arg2=foo set2=bar set3arg1=3.14;set4arg2=42"
-if [ $# -ge 6 ]; then
+if [ $# -ge 7 ]; then
     IFS=' ' read -r -a GENERATOR_ARGS_SETS_ARRAY <<< "${7}"
 else
     declare -a GENERATOR_ARGS_SETS_ARRAY=


### PR DESCRIPTION
(This was correctly bound when doing `make test_apps` at toplevel, but not if doing `make autotune` from the apps/autoscheduler folder)