### PR TITLE
In RunGen::bounds_query_input_shapes(), use extent=1 instead of extent=0

### DIFF
--- a/tools/RunGen.h
+++ b/tools/RunGen.h
@@ -1322,8 +1322,8 @@ private:
                 filter_argv[arg.index] = const_cast<halide_scalar_value_t*>(&arg.scalar_value);
                 break;
             case halide_argument_kind_input_buffer:
-                // Make a Buffer<> that has the right dimension count and extent=0 for all of them
-                bounds_query_buffers[arg.index] = Buffer<>(arg.metadata->type, std::vector<int>(arg.metadata->dimensions, 0));
+                // Make a Buffer<> that has the right dimension count and extent=1 for all of them
+                bounds_query_buffers[arg.index] = Buffer<>(arg.metadata->type, std::vector<int>(arg.metadata->dimensions, 1));
                 filter_argv[arg.index] = bounds_query_buffers[arg.index].raw_buffer();
                 break;
             case halide_argument_kind_output_buffer:


### PR DESCRIPTION
Surprisingly, extent=0 actually worked in a surprising number of cases, but has pathological behavior for some constraints.