### PR TITLE
Change halide_toc_impl to use debug(1) instead of debug(0)

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -485,11 +485,11 @@ void halide_toc_impl(const char *file, int line) {
     std::chrono::duration<double> diff = t2 - t1.time;
     tick_stack.pop_back();
     for (size_t i = 0; i < tick_stack.size(); i++) {
-        debug(0) << "  ";
+        debug(1) << "  ";
     }
     string f = file;
     f = split_string(f, "/").back();
-    debug(0) << t1.file << ":" << t1.line << " ... " << f << ":" << line << " : " << diff.count() * 1000 << " ms\n";
+    debug(1) << t1.file << ":" << t1.line << " ... " << f << ":" << line << " : " << diff.count() * 1000 << " ms\n";
 }
 
 }  // namespace Internal


### PR DESCRIPTION
While handy for debugging, this means the autoscheduler currently spams stdout with timing info by default, which is puzzling to people not actually working on the autoscheduler.

(alternately: add debug-level option to HALIDE_TIC, or just comment out the calls to it in the autoscheduler)