### PR TITLE
Allow Target::has_feature() to operator on halide_target_feature_t

### DIFF
--- a/python_bindings/src/PyTarget.cpp
+++ b/python_bindings/src/PyTarget.cpp
@@ -37,7 +37,7 @@ void define_target(py::module &m) {
             .def("__str__", &Target::to_string)
             .def("to_string", &Target::to_string)
 
-            .def("has_feature", &Target::has_feature)
+            .def("has_feature", (bool (Target::*)(Target::Feature) const) &Target::has_feature)
             .def("features_any_of", &Target::features_any_of, py::arg("features"))
             .def("features_all_of", &Target::features_all_of, py::arg("features"))
 

--- a/src/Target.h
+++ b/src/Target.h
@@ -156,6 +156,10 @@ struct Target {
 
     bool has_feature(Feature f) const;
 
+    inline bool has_feature(halide_target_feature_t f) const {
+        return has_feature((Feature) f);
+    }
+
     bool features_any_of(std::vector<Feature> test_features) const;
 
     bool features_all_of(std::vector<Feature> test_features) const;


### PR DESCRIPTION
This is really a workaround to allow generated .schedule.h files to compile happily in all cases. A better long-term answer would be for those files to use the Target::Feature names (rather than the halide_target_feature_t names), but doing so will require an additional value->name map (which must be maintained and could get out of sync), so I'm reluctant to do that without a little more thought.