### PR TITLE
Avoid 64-bit overflow when tracking constant bounds in simplifier

### DIFF
--- a/src/Simplify_Add.cpp
+++ b/src/Simplify_Add.cpp
@@ -11,8 +11,19 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
     if (bounds && no_overflow_int(op->type)) {
         bounds->min_defined = a_bounds.min_defined && b_bounds.min_defined;
         bounds->max_defined = a_bounds.max_defined && b_bounds.max_defined;
-        bounds->min = a_bounds.min + b_bounds.min;
-        bounds->max = a_bounds.max + b_bounds.max;
+        if (add_would_overflow(64, a_bounds.min, b_bounds.min)) {
+            bounds->min_defined = false;
+            bounds->min = 0;
+        } else {
+            bounds->min = a_bounds.min + b_bounds.min;
+        }
+        if (add_would_overflow(64, a_bounds.max, b_bounds.max)) {
+            bounds->max_defined = false;
+            bounds->max = 0;
+        } else {
+            bounds->max = a_bounds.max + b_bounds.max;
+        }
+
         bounds->alignment = a_bounds.alignment + b_bounds.alignment;
         bounds->trim_bounds_using_alignment();
     }

--- a/src/Simplify_Sub.cpp
+++ b/src/Simplify_Sub.cpp
@@ -14,8 +14,18 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
         // remutate to recalculate the bounds.
         bounds->min_defined = a_bounds.min_defined && b_bounds.max_defined;
         bounds->max_defined = a_bounds.max_defined && b_bounds.min_defined;
-        bounds->min = a_bounds.min - b_bounds.max;
-        bounds->max = a_bounds.max - b_bounds.min;
+        if (sub_would_overflow(64, a_bounds.min, b_bounds.max)) {
+            bounds->min_defined = false;
+            bounds->min = 0;
+        } else {
+            bounds->min = a_bounds.min - b_bounds.max;
+        }
+        if (sub_would_overflow(64, a_bounds.max, b_bounds.min)) {
+            bounds->max_defined = false;
+            bounds->max = 0;
+        } else {
+            bounds->max = a_bounds.max - b_bounds.min;
+        }
         bounds->alignment = a_bounds.alignment - b_bounds.alignment;
         bounds->trim_bounds_using_alignment();
     }


### PR DESCRIPTION
These are no-overflow types, so treat such cases not as things that
overflow (in which an overflow in the upper bound would affect the lower
bound), but rather as things which still have upper/lower bounds that we
can no longer represent.

Fixes #4142 