### PR TITLE
Smarten UnrollLoops; remove HL_PERMIT_FAILED_UNROLL=1 defaults

### DIFF
--- a/apps/autoscheduler/Makefile
+++ b/apps/autoscheduler/Makefile
@@ -11,7 +11,7 @@ $(GENERATOR_BIN)/demo.generator: demo_generator.cpp $(GENERATOR_DEPS)
 # To use the autoscheduler, set a few environment variables and use the -p flag to the generator to load the autoscheduler as a plugin
 $(BIN)/%/demo.a: $(GENERATOR_BIN)/demo.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/baseline.weights \
+	HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/baseline.weights \
 	$(GENERATOR_BIN)/demo.generator -g demo -o $(@D) -f demo target=$* auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so
 
 $(BIN)/%/demo.rungen: $(BIN)/%/RunGenMain.o $(BIN)/%/demo.registration.cpp $(BIN)/%/demo.a
@@ -75,7 +75,7 @@ $(GENERATOR_BIN)/included_schedule_file_none.generator: included_schedule_file_g
 # the Generator so that it can skip producing other outputs.)
 $(BIN)/%/included_schedule_file.schedule.h: $(GENERATOR_BIN)/included_schedule_file_none.generator $(AUTOSCHED_BIN)/libauto_schedule.so
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/baseline.weights \
+	HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/baseline.weights \
 	$< -g included_schedule_file -o $(@D) -f included_schedule_file target=$* auto_schedule=true -p $(AUTOSCHED_BIN)/libauto_schedule.so -e schedule
 
 # Note that this depends on included_schedule_file.schedule.h rather than $(BIN)/%/included_schedule_file.schedule.h --

--- a/apps/autoscheduler/autotune_loop.sh
+++ b/apps/autoscheduler/autotune_loop.sh
@@ -100,8 +100,7 @@ make_featurization() {
         dropout=1  # 1% chance of operating entirely greedily
         beam=1
     fi
-    HL_PERMIT_FAILED_UNROLL=1 \
-        HL_SEED=${SEED} \
+    HL_SEED=${SEED} \
         HL_WEIGHTS_DIR=${WEIGHTS} \
         HL_RANDOM_DROPOUT=${dropout} \
         HL_BEAM_SIZE=${beam} \

--- a/apps/support/autoscheduler.inc
+++ b/apps/support/autoscheduler.inc
@@ -33,7 +33,7 @@ $(AUTOSCHED_BIN)/auto_schedule_runtime.a: $(AUTOSCHED_BIN)/cost_model.generator
 
 $(AUTOSCHED_BIN)/cost_model/%.a: $(AUTOSCHED_BIN)/cost_model.generator
 	@mkdir -p $(@D)
-	HL_PERMIT_FAILED_UNROLL=1 $^ -g $* -o $(AUTOSCHED_BIN)/cost_model -f $* target=$(HL_TARGET)-no_runtime auto_schedule=false -e stmt,static_library,h,assembly
+	$^ -g $* -o $(AUTOSCHED_BIN)/cost_model -f $* target=$(HL_TARGET)-no_runtime auto_schedule=false -e stmt,static_library,h,assembly
 
 # It's important to use dynamic lookups for undefined symbols here: all of libHalide
 # is expected to be present (in the loading binary), so we explicitly make the symbols

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -6,6 +6,7 @@
 #include "CSE.h"
 #include "Debug.h"
 #include "IREquality.h"
+#include "IRMutator.h"
 #include "IROperator.h"
 #include "IRPrinter.h"
 #include "Var.h"

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -819,19 +819,28 @@ Expr strided_ramp_base(Expr e, int stride) {
     return Expr();
 }
 
-Expr remove_likelies(Expr e) {
-    struct RemoveLikelies : public IRMutator {
-        using IRMutator::visit;
-        Expr visit(const Call *op) override {
-            if (op->is_intrinsic(Call::likely) ||
-                op->is_intrinsic(Call::likely_if_innermost)) {
-                return mutate(op->args[0]);
-            } else {
-                return IRMutator::visit(op);
-            }
+namespace {
+
+struct RemoveLikelies : public IRMutator {
+    using IRMutator::visit;
+    Expr visit(const Call *op) override {
+        if (op->is_intrinsic(Call::likely) ||
+            op->is_intrinsic(Call::likely_if_innermost)) {
+            return mutate(op->args[0]);
+        } else {
+            return IRMutator::visit(op);
         }
-    };
+    }
+};
+
+}  // namespace
+
+Expr remove_likelies(Expr e) {
     return RemoveLikelies().mutate(e);
+}
+
+Stmt remove_likelies(Stmt s) {
+    return RemoveLikelies().mutate(s);
 }
 
 }  // namespace Internal

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -819,6 +819,21 @@ Expr strided_ramp_base(Expr e, int stride) {
     return Expr();
 }
 
+Expr remove_likelies(Expr e) {
+    struct RemoveLikelies : public IRMutator {
+        using IRMutator::visit;
+        Expr visit(const Call *op) override {
+            if (op->is_intrinsic(Call::likely) ||
+                op->is_intrinsic(Call::likely_if_innermost)) {
+                return mutate(op->args[0]);
+            } else {
+                return IRMutator::visit(op);
+            }
+        }
+    };
+    return RemoveLikelies().mutate(e);
+}
+
 }  // namespace Internal
 
 Expr fast_log(Expr x) {

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -274,6 +274,10 @@ template<> inline double div_imp<double>(double a, double b) {
  * all calls to likely() and likely_if_innermost() removed. */
 Expr remove_likelies(Expr e);
 
+/** Return a Stmt that is identical to the input Stmt, but with
+ * all calls to likely() and likely_if_innermost() removed. */
+Stmt remove_likelies(Stmt s);
+
 } // namespace Internal
 
 /** Cast an expression to the halide type corresponding to the C++ type T. */

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -270,6 +270,10 @@ template<> inline double div_imp<double>(double a, double b) {
     return a/b;
 }
 
+/** Return an Expr that is identical to the input Expr, but with
+ * all calls to likely() and likely_if_innermost() removed. */
+Expr remove_likelies(Expr e);
+
 } // namespace Internal
 
 /** Cast an expression to the halide type corresponding to the C++ type T. */

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -77,20 +77,6 @@ class MarkClampedRampsAsLikely : public IRMutator {
     bool in_index = false;
 };
 
-// Remove any 'likely' intrinsics.
-class RemoveLikelyTags : public IRMutator {
-    using IRMutator::visit;
-
-    Expr visit(const Call *op) override {
-        if (op->is_intrinsic(Call::likely)) {
-            internal_assert(op->args.size() == 1);
-            return mutate(op->args[0]);
-        } else {
-            return IRMutator::visit(op);
-        }
-    }
-};
-
 // Check if an expression or statement uses a likely tag
 class HasLikelyTag : public IRVisitor {
 protected:
@@ -269,7 +255,7 @@ class FindSimplifications : public IRVisitor {
             // We should throw away the condition
             return;
         }
-        condition = RemoveLikelyTags().mutate(condition);
+        condition = remove_likelies(condition);
         Simplification s = {condition, old, likely_val, unlikely_val, true};
         if (s.condition.type().is_vector()) {
             s.condition = simplify(s.condition);
@@ -1070,7 +1056,7 @@ Stmt partition_loops(Stmt s) {
     } mutator;
     s = mutator.mutate(s);
 
-    s = RemoveLikelyTags().mutate(s);
+    s = remove_likelies(s);
     return s;
 }
 

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -302,20 +302,7 @@ bool can_prove(Expr e, const Scope<Interval> &bounds) {
     internal_assert(e.type().is_bool())
         << "Argument to can_prove is not a boolean Expr: " << e << "\n";
 
-    // Remove likelies
-    struct RemoveLikelies : public IRMutator {
-        using IRMutator::visit;
-        Expr visit(const Call *op) override {
-            if (op->is_intrinsic(Call::likely) ||
-                op->is_intrinsic(Call::likely_if_innermost)) {
-                return mutate(op->args[0]);
-            } else {
-                return IRMutator::visit(op);
-            }
-        }
-    };
-    e = RemoveLikelies().mutate(e);
-
+    e = remove_likelies(e);
     e = common_subexpression_elimination(e);
 
     Expr orig = e;

--- a/src/UnrollLoops.cpp
+++ b/src/UnrollLoops.cpp
@@ -72,6 +72,7 @@ class UnrollLoops : public IRMutator {
             if (e == nullptr && permit_failed_unroll) {
                 // Still no luck, but we're allowed to fail. Rewrite
                 // to a serial loop.
+                user_warning << "HL_PERMIT_FAILED_UNROLL is allowing us to unroll a non-constant loop into a serial loop. Did you mean to do this?\n";
                 body = mutate(body);
                 return For::make(for_loop->name, for_loop->min, for_loop->extent,
                                  ForType::Serial, for_loop->device_api, std::move(body));

--- a/src/UnrollLoops.cpp
+++ b/src/UnrollLoops.cpp
@@ -11,18 +11,6 @@ using std::pair;
 namespace Halide {
 namespace Internal {
 
-struct RemoveLikelies : public IRMutator {
-    using IRMutator::visit;
-    Expr visit(const Call *op) override {
-        if (op->is_intrinsic(Call::likely) ||
-            op->is_intrinsic(Call::likely_if_innermost)) {
-            return mutate(op->args[0]);
-        } else {
-            return IRMutator::visit(op);
-        }
-    }
-};
-
 class UnrollLoops : public IRMutator {
     using IRMutator::visit;
 
@@ -52,7 +40,7 @@ class UnrollLoops : public IRMutator {
                 for (auto it = lets.rbegin(); it != lets.rend(); it++) {
                     extent = graph_substitute(it->first, it->second, extent);
                 }
-                extent = RemoveLikelies().mutate(extent);
+                extent = remove_likelies(extent);
                 extent = simplify(common_subexpression_elimination(extent));
                 e = extent.as<IntImm>();
             }

--- a/src/UnrollLoops.cpp
+++ b/src/UnrollLoops.cpp
@@ -11,6 +11,18 @@ using std::pair;
 namespace Halide {
 namespace Internal {
 
+struct RemoveLikelies : public IRMutator {
+    using IRMutator::visit;
+    Expr visit(const Call *op) override {
+        if (op->is_intrinsic(Call::likely) ||
+            op->is_intrinsic(Call::likely_if_innermost)) {
+            return mutate(op->args[0]);
+        } else {
+            return IRMutator::visit(op);
+        }
+    }
+};
+
 class UnrollLoops : public IRMutator {
     using IRMutator::visit;
 
@@ -40,6 +52,7 @@ class UnrollLoops : public IRMutator {
                 for (auto it = lets.rbegin(); it != lets.rend(); it++) {
                     extent = graph_substitute(it->first, it->second, extent);
                 }
+                extent = RemoveLikelies().mutate(extent);
                 extent = simplify(common_subexpression_elimination(extent));
                 e = extent.as<IntImm>();
             }


### PR DESCRIPTION
Fix an issue where UnrollLoops failed to recognize a constant extent as such, then remove HL_PERMIT_FAILED_UNROLL=1 as the default in autoscheduler. (We think this should be (mostly) unnecessary in most cases, so we'll now issue a user-warning if we trigger it.)