### PR TITLE
Improve assertion in FunctionDAG

### DIFF
--- a/apps/autoscheduler/FunctionDAG.h
+++ b/apps/autoscheduler/FunctionDAG.h
@@ -893,7 +893,10 @@ struct FunctionDAG {
                 }
 
                 // We'll take any existing reordering, but won't handle existing splits
-                internal_assert(sched.splits().empty());
+                user_assert(sched.splits().empty())
+                    << "The Func \"" << consumer.name() << "\" has scheduling directive(s) "
+                    << "applied to it; you must remove these, or conditionalize them "
+                    << "using `if (!auto_schedule)`, to use the autoscheduler on this pipeline.";
                 stage.loop_nest_all_common_cases = true;
                 for (size_t i = 0; i < sched.dims().size(); i++) {
                     const auto &d = sched.dims()[i];


### PR DESCRIPTION
The failure mode for autoscheduling-a-func-with-a-schedule-on-it is currently inscrutable; change from an internal_assert to a user_assert with a more-helpful message.