### PR TITLE
Simplifications for unrolling sliding window

### DIFF
--- a/src/Simplify_Add.cpp
+++ b/src/Simplify_Add.cpp
@@ -73,12 +73,23 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
              rewrite(x + (y + c0), (x + y) + c0) ||
              rewrite((c0 - x) + c1, fold(c0 + c1) - x) ||
              rewrite((c0 - x) + y, (y - x) + c0) ||
+
              rewrite((x - y) + y, x) ||
              rewrite(x + (y - x), y) ||
+
+             rewrite(((x - y) + z) + y, x + z) ||
+             rewrite((z + (x - y)) + y, z + x) ||
+             rewrite(x + ((y - x) + z), y + z) ||
+             rewrite(x + (z + (y - x)), z + y) ||
+
              rewrite(x + (c0 - y), (x - y) + c0) ||
              rewrite((x - y) + (y - z), x - z) ||
              rewrite((x - y) + (z - x), z - y) ||
              rewrite(x + y*c0, x - y*(-c0), c0 < 0 && -c0 > 0) ||
+
+             rewrite(x + (y*c0 - z), x - y*(-c0) - z, c0 < 0 && -c0 > 0) ||
+             rewrite((y*c0 - z) + x, x - y*(-c0) - z, c0 < 0 && -c0 > 0) ||
+
              rewrite(x*c0 + y, y - x*(-c0), c0 < 0 && -c0 > 0 && !is_const(y)) ||
              rewrite(x*y + z*y, (x + z)*y) ||
              rewrite(x*y + y*z, (x + z)*y) ||

--- a/src/Simplify_Select.cpp
+++ b/src/Simplify_Select.cpp
@@ -106,6 +106,8 @@ Expr Simplify::visit(const Select *op, ExprInfo *bounds) {
 
              rewrite(select(x < y, x, y), min(x, y)) ||
              rewrite(select(x < y, y, x), max(x, y)) ||
+             rewrite(select(x < 0, x * y, 0), min(x, 0) * y) ||
+             rewrite(select(x < 0, 0, x * y), max(x, 0) * y) ||
 
              (no_overflow_int(op->type) &&
               (rewrite(select(x, y * c0, c1), select(x, y, fold(c1 / c0)) * c0, c1 % c0 == 0) ||

--- a/src/Simplify_Select.cpp
+++ b/src/Simplify_Select.cpp
@@ -76,6 +76,34 @@ Expr Simplify::visit(const Select *op, ExprInfo *bounds) {
              rewrite(select(x, z / y, w / y), select(x, z, w) / y) ||
              rewrite(select(x, z % y, w % y), select(x, z, w) % y) ||
 
+             rewrite(select(x, (y + z) + u, y + w), y + select(x, z + u, w)) ||
+             rewrite(select(x, (y + z) - u, y + w), y + select(x, z - u, w)) ||
+             rewrite(select(x, u + (y + z), y + w), y + select(x, u + z, w)) ||
+             rewrite(select(x, y + z, (y + w) + u), y + select(x, z, w + u)) ||
+             rewrite(select(x, y + z, (y + w) - u), y + select(x, z, w - u)) ||
+             rewrite(select(x, y + z, u + (y + w)), y + select(x, z, u + w)) ||
+
+             rewrite(select(x, (y + z) + u, w + y), y + select(x, z + u, w)) ||
+             rewrite(select(x, (y + z) - u, w + y), y + select(x, z - u, w)) ||
+             rewrite(select(x, u + (y + z), w + y), y + select(x, u + z, w)) ||
+             rewrite(select(x, y + z, (w + y) + u), y + select(x, z, w + u)) ||
+             rewrite(select(x, y + z, (w + y) - u), y + select(x, z, w - u)) ||
+             rewrite(select(x, y + z, u + (w + y)), y + select(x, z, u + w)) ||
+
+             rewrite(select(x, (z + y) + u, y + w), y + select(x, z + u, w)) ||
+             rewrite(select(x, (z + y) - u, y + w), y + select(x, z - u, w)) ||
+             rewrite(select(x, u + (z + y), y + w), y + select(x, u + z, w)) ||
+             rewrite(select(x, z + y, (y + w) + u), y + select(x, z, w + u)) ||
+             rewrite(select(x, z + y, (y + w) - u), y + select(x, z, w - u)) ||
+             rewrite(select(x, z + y, u + (y + w)), y + select(x, z, u + w)) ||
+
+             rewrite(select(x, (z + y) + u, w + y), select(x, z + u, w) + y) ||
+             rewrite(select(x, (z + y) - u, w + y), select(x, z - u, w) + y) ||
+             rewrite(select(x, u + (z + y), w + y), select(x, u + z, w) + y) ||
+             rewrite(select(x, z + y, (w + y) + u), select(x, z, w + u) + y) ||
+             rewrite(select(x, z + y, (w + y) - u), select(x, z, w - u) + y) ||
+             rewrite(select(x, z + y, u + (w + y)), select(x, z, u + w) + y) ||
+
              rewrite(select(x < y, x, y), min(x, y)) ||
              rewrite(select(x < y, y, x), max(x, y)) ||
 

--- a/src/Simplify_Sub.cpp
+++ b/src/Simplify_Sub.cpp
@@ -99,6 +99,10 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
              rewrite(((y + x) + z) - x, y + z) ||
              rewrite((z + (x + y)) - x, z + y) ||
              rewrite((z + (y + x)) - x, z + y) ||
+
+             rewrite((x - y) - (x + z), 0 - y - z) ||
+             rewrite((x - y) - (z + x), 0 - y - z) ||
+
              (no_overflow(op->type) &&
               (rewrite(max(x, y) - x, max(0, y - x)) ||
                rewrite(min(x, y) - x, min(0, y - x)) ||

--- a/src/Simplify_Sub.cpp
+++ b/src/Simplify_Sub.cpp
@@ -56,14 +56,16 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
              rewrite(select(x, y, z) - z, select(x, y - z, 0)) ||
              rewrite(y - select(x, y, z), select(x, 0, y - z)) ||
              rewrite(z - select(x, y, z), select(x, z - y, 0)) ||
+
              rewrite(select(x, y + w, z) - y, select(x, w, z - y)) ||
              rewrite(select(x, w + y, z) - y, select(x, w, z - y)) ||
              rewrite(select(x, y, z + w) - z, select(x, y - z, w)) ||
              rewrite(select(x, y, w + z) - z, select(x, y - z, w)) ||
-             rewrite(y - select(x, y + w, z), select(x, w, y - z)) ||
-             rewrite(y - select(x, w + y, z), select(x, w, y - z)) ||
-             rewrite(z - select(x, y, z + w), select(x, z - y, w)) ||
-             rewrite(z - select(x, y, w + z), select(x, z - y, w)) ||
+             rewrite(y - select(x, y + w, z), 0 - select(x, w, z - y)) ||
+             rewrite(y - select(x, w + y, z), 0 - select(x, w, z - y)) ||
+             rewrite(z - select(x, y, z + w), 0 - select(x, y - z, w)) ||
+             rewrite(z - select(x, y, w + z), 0 - select(x, y - z, w)) ||
+
              rewrite((x + y) - x, y) ||
              rewrite((x + y) - y, x) ||
              rewrite(x - (x + y), -y) ||

--- a/src/Simplify_Sub.cpp
+++ b/src/Simplify_Sub.cpp
@@ -56,6 +56,14 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
              rewrite(select(x, y, z) - z, select(x, y - z, 0)) ||
              rewrite(y - select(x, y, z), select(x, 0, y - z)) ||
              rewrite(z - select(x, y, z), select(x, z - y, 0)) ||
+             rewrite(select(x, y + w, z) - y, select(x, w, z - y)) ||
+             rewrite(select(x, w + y, z) - y, select(x, w, z - y)) ||
+             rewrite(select(x, y, z + w) - z, select(x, y - z, w)) ||
+             rewrite(select(x, y, w + z) - z, select(x, y - z, w)) ||
+             rewrite(y - select(x, y + w, z), select(x, w, y - z)) ||
+             rewrite(y - select(x, w + y, z), select(x, w, y - z)) ||
+             rewrite(z - select(x, y, z + w), select(x, z - y, w)) ||
+             rewrite(z - select(x, y, w + z), select(x, z - y, w)) ||
              rewrite((x + y) - x, y) ||
              rewrite((x + y) - y, x) ||
              rewrite(x - (x + y), -y) ||

--- a/src/UnrollLoops.cpp
+++ b/src/UnrollLoops.cpp
@@ -38,10 +38,11 @@ class UnrollLoops : public IRMutator {
                 // We're about to hard fail. Get really aggressive
                 // with the simplifier.
                 for (auto it = lets.rbegin(); it != lets.rend(); it++) {
-                    extent = graph_substitute(it->first, it->second, extent);
+                    extent = Let::make(it->first, it->second, extent);
                 }
                 extent = remove_likelies(extent);
-                extent = simplify(common_subexpression_elimination(extent));
+                extent = substitute_in_all_lets(extent);
+                extent = simplify(extent);
                 e = extent.as<IntImm>();
             }
 

--- a/test/correctness/sliding_window.cpp
+++ b/test/correctness/sliding_window.cpp
@@ -201,6 +201,26 @@ int main(int argc, char **argv) {
         }
     }
 
+    {
+        // Sliding with an unrolled producer
+        Var x, xi;
+        Func f, g;
+
+        f(x) = call_counter(x, 0) + x*x;
+        g(x) = f(x) + f(x-1);
+
+        g.split(x, x, xi, 10);
+        f.store_root().compute_at(g, x).unroll(x);
+
+        count = 0;
+        Buffer<int> im = g.realize(100);
+
+        if (count != 101) {
+            printf("f was called %d times instead of %d times\n", count, 101);
+            return -1;
+        }
+    }
+
     printf("Success!\n");
     return 0;
 }


### PR DESCRIPTION
Unrolling happens after sliding but before partitioning, so the extents of the unrolled loop are complex, but should have an upper bound that enables unrolling. It can be hard for the compiler to see this through all the selects. 

This PR makes things way more aggressive in the about-to-fail case in unrolling. It now exhaustively substitutes in everything for maximally aggressive simplification, and there are a bunch of new simplifier rules to help cancel things through select nodes. This exhaustive substitution is somewhat dangerous, but this is a case where the compiler is about to throw an error if it doesn't simplify down to almost a constant.