### PR TITLE
Restrict interleaving Hexagon pattern matches

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1690,9 +1690,7 @@ void CodeGen_Hexagon::visit(const Call *op) {
     };
 
     if (is_native_interleave(op) || is_native_deinterleave(op)) {
-        user_assert(op->type.lanes() % (native_vector_bits() * 2 / op->type.bits()) == 0)
-            << "Interleave or deinterleave will result in miscompilation, "
-            << "see https://github.com/halide/Halide/issues/1582\n" << Expr(op) << "\n";
+        internal_assert(op->type.lanes() % (native_vector_bits() * 2 / op->type.bits()) == 0);
     }
 
     if (starts_with(op->name, "halide.hexagon.")) {

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -246,6 +246,11 @@ Expr replace_pattern(Expr x, const vector<Expr> &matches, const Pattern &p) {
     return x;
 }
 
+bool is_double_vector(Expr x, const Target &target) {
+    int native_vector_bits = target.natural_vector_size(Int(8)) * 8;
+    return (x.type().lanes() / ( native_vector_bits / x.type().bits()) >= 2);
+}
+
 // Attempt to apply one of the patterns to x. If a match is
 // successful, the expression is replaced with a call using the
 // matched operands. Prior to substitution, the matches are mutated
@@ -257,6 +262,11 @@ Expr apply_patterns(Expr x, const vector<Pattern> &patterns, const Target &targe
         if (!check_pattern_target(p.flags, target)) {
             continue;
         }
+
+        // Don't apply pattern if it involves an
+        // interleave of less than double vector width.
+        if ((p.flags & Pattern::InterleaveResult) && !is_double_vector(x, target))
+            continue;
 
         if (expr_match(p.pattern, x, matches)) {
             debug(3) << "matched " << p.pattern << "\n";

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -274,8 +274,9 @@ Expr apply_patterns(Expr x, const vector<Pattern> &patterns, const Target &targe
                 continue;
             }
 
-            // Don't apply pattern if it does not involve an
-            // interleave of double vector width.
+            // Don't apply pattern if it involves an interleave,
+            // and is not a multiple of two vectors.
+            // See https://github.com/halide/Halide/issues/1582
             if ((p.flags & Pattern::InterleaveResult) && !is_double_vector(x, target)) {
                 continue;
             }

--- a/test/correctness/half_native_interleave.cpp
+++ b/test/correctness/half_native_interleave.cpp
@@ -1,0 +1,67 @@
+#include "Halide.h"
+#include <iostream>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // Generate random input.
+    const int W = 256;
+    Buffer<uint8_t> input(W);
+    for (int x = 0; x < W; x++) {
+        input(x) = rand() & 0xff;
+    }
+
+    Var x("x");
+    Func input_16("input_16"), product("product"), sum("sum"), diff("difference");
+    input_16(x) = cast<int16_t>(input(x));
+
+    product(x) = (input_16(x) * 2);
+    sum(x) = (input_16(x) + 2);
+    diff(x) = (input_16(x) - 2);
+
+    // Schedule.
+    Target target = get_jit_target_from_environment();
+    if (target.features_any_of({Target::HVX_64, Target::HVX_128})) {
+        // Vectorize by one vector width.
+        // Since the operations are widening ops,
+        // the operands are effectively half-vector width.
+        // The assertion referenced in issue below
+        // shouldn't be triggered:
+        // https://github.com/halide/Halide/issues/1582
+        product.hexagon().vectorize(x, 64);
+        sum.hexagon().vectorize(x, 64);
+        diff.hexagon().vectorize(x, 64);
+    } else {
+        product.vectorize(x, target.natural_vector_size<uint8_t>());
+        sum.vectorize(x, target.natural_vector_size<uint8_t>());
+        diff.vectorize(x, target.natural_vector_size<uint8_t>());
+    }
+
+    // Run the pipeline and verify the results are correct.
+    Buffer<int16_t> out_p = product.realize(W, target);
+    Buffer<int16_t> out_s = sum.realize(W, target);
+    Buffer<int16_t> out_d = diff.realize(W, target);
+
+    for (int x = 1; x < W-1; x++) {
+        int16_t correct_p = input(x) * 2;
+        int16_t correct_s = input(x) + 2;
+        int16_t correct_d = input(x) - 2;
+
+
+        if (out_p(x) != correct_p) {
+            std::cout << "out_p(" << x << ") = " << out_p(x) << " instead of " << correct_p << "\n";
+            return -1;
+        }
+        if (out_s(x) != correct_s) {
+            std::cout << "out_s(" << x << ") = " << out_s(x) << " instead of " << correct_s << "\n";
+            return -1;
+        }
+        if (out_d(x) != correct_d) {
+            std::cout << "out_d(" << x << ") = " << out_d(x) << " instead of " << correct_d << "\n";
+            return -1;
+        }
+    }
+
+    std::cout << "Success!\n";
+    return 0;
+}


### PR DESCRIPTION
This prevents matching interleaving hexagon patterns if the result can't be interleaved. Checks that the
op type is atleast 2 vector widths for widening ops.

Currently, compile-time assert is thrown in Codegen (see: https://github.com/halide/Halide/issues/1582) when the interleaved hexagon intrinsic op is not equal to two vector width. This is a recurring issue in widening ops, where the widening ops have to be vectorized by 2 * native vector width for valid codegen. This change lets the backend ISEL handle half-native vectors, instead of applying interleaved widening Hexagon intrinsics which the backend miscompiles.
@dsharletg PTAL