### PR TITLE
Remove HL_WEIGHTS_OUT_DIR

### DIFF
--- a/apps/autoscheduler/AutoSchedule.cpp
+++ b/apps/autoscheduler/AutoSchedule.cpp
@@ -51,10 +51,6 @@
   When training or schedule, read weights from this directory or file
   (if path ends in `.weights` it is written as a single file, otherwise a directory of files)
 
-  HL_WEIGHTS_OUT_DIR
-  When training, output updated weights here
-  (if path ends in `.weights` it is written as a single file, otherwise a directory of files)
-
   HL_NO_SUBTILING
   If set to 1, limits the search space to that of Mullapudi et al.
 
@@ -3223,10 +3219,7 @@ void generate_schedule(const std::vector<Function> &outputs,
     }
 
     string weights_in_path = get_env_variable("HL_WEIGHTS_DIR");
-    string weights_out_path = get_env_variable("HL_WEIGHTS_OUT_DIR");
-    if (weights_out_path.empty()) {
-        weights_out_path = weights_in_path;
-    }
+    string weights_out_path;  // deliberately empty
 
     string randomize_weights_str = get_env_variable("HL_RANDOMIZE_WEIGHTS");
     bool randomize_weights = randomize_weights_str == "1";

--- a/apps/autoscheduler/DefaultCostModel.cpp
+++ b/apps/autoscheduler/DefaultCostModel.cpp
@@ -301,18 +301,21 @@ class DefaultCostModel : public CostModel {
     }
 
     void save_weights() override {
-        if (weights_out_path.empty()) return;
+        if (weights_out_path.empty()) {
+            std::cerr << "Unable to save weights: no output path specified\n";
+            abort();
+        }
 
         if (ends_with(weights_out_path, ".weights")) {
             if (!weights.save_to_file(weights_out_path)) {
                 std::cerr << "Unable to save weights to file: " << weights_out_path << "\n";
-                assert(0);
+                abort();
             }
         } else {
             std::cerr << "Saving weights to a directory is deprecated; please convert to a .weights file\n";
             if (!weights.save_to_dir(weights_out_path)) {
                 std::cerr << "Unable to save weights to file: " << weights_out_path << "\n";
-                assert(0);
+                abort();
             }
         }
     }


### PR DESCRIPTION
It was only referenced in single-shot scheduling, but we shouldn't ever be saving from that path anyway (only from the retraining loop).

Also change save_weights() to fail with abort() if you try to save with an empty output path (rather than quietly doing nothing), and upgrade save failures from assert(0) to abort(), because that's not an error we want to risk eliding based on compiler settings.