### PR TITLE
Reorder hexagon intrinsic patterns

### DIFF
--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -417,19 +417,19 @@ private:
 
     Expr visit(const Mul *op) override {
         static const vector<Pattern> scalar_muls = {
+            // Multiplication by powers of 2.
+            { "halide.hexagon.shl.vub.ub", wild_u8x*bc(wild_u8), Pattern::ExactLog2Op1 },
+            { "halide.hexagon.shl.vuh.uh", wild_u16x*bc(wild_u16), Pattern::ExactLog2Op1 },
+            { "halide.hexagon.shl.vuw.uw", wild_u32x*bc(wild_u32), Pattern::ExactLog2Op1 },
+            { "halide.hexagon.shl.vb.b", wild_i8x*bc(wild_i8), Pattern::ExactLog2Op1 },
+            { "halide.hexagon.shl.vh.h", wild_i16x*bc(wild_i16), Pattern::ExactLog2Op1 },
+            { "halide.hexagon.shl.vw.w", wild_i32x*bc(wild_i32), Pattern::ExactLog2Op1 },
+            
             // Vector by scalar widening multiplies.
             { "halide.hexagon.mpy.vub.ub", wild_u16x*bc(wild_u16), Pattern::InterleaveResult | Pattern::NarrowOps },
             { "halide.hexagon.mpy.vub.b",  wild_i16x*bc(wild_i16), Pattern::InterleaveResult | Pattern::NarrowUnsignedOp0 | Pattern::NarrowOp1 },
             { "halide.hexagon.mpy.vuh.uh", wild_u32x*bc(wild_u32), Pattern::InterleaveResult | Pattern::NarrowOps },
             { "halide.hexagon.mpy.vh.h",   wild_i32x*bc(wild_i32), Pattern::InterleaveResult | Pattern::NarrowOps },
-
-            // Multiplication by powers of 2.
-            { "halide.hexagon.shl.vub.ub", wild_u8x*bc(wild_u8), Pattern::ExactLog2Op1 },
-            { "halide.hexagon.shl.vuh.uh", wild_u16x*bc(wild_u16), Pattern::ExactLog2Op1 },
-            { "halide.hexagon.shl.vuw.uw", wild_u32x*bc(wild_u32), Pattern::ExactLog2Op1 },
-            { "halide.hexagon.shl.vb.ub", wild_i8x*bc(wild_i8), Pattern::ExactLog2Op1 },
-            { "halide.hexagon.shl.vh.uh", wild_i16x*bc(wild_i16), Pattern::ExactLog2Op1 },
-            { "halide.hexagon.shl.vw.uw", wild_i32x*bc(wild_i32), Pattern::ExactLog2Op1 },
 
             // Non-widening scalar multiplication.
             { "halide.hexagon.mul.vh.b", wild_i16x*bc(wild_i16), Pattern::NarrowOp1 },


### PR DESCRIPTION
Try to pattern match Mul op with hexagon intrinsic patterns for multiplication by powers of 2, before
other scalar multiplication patterns. Presently for some cases, even if the scalar is a power of 2, the less efficient general scalar multiplication pattern is matched first. This change fixes that.