### PR TITLE
Remove min_iter and max_iter from benchmark & RunGen

### DIFF
--- a/tools/RunGen.h
+++ b/tools/RunGen.h
@@ -1208,9 +1208,7 @@ public:
         }
     }
 
-    void run_for_benchmark(double benchmark_min_time,
-                           uint64_t benchmark_min_iters,
-                           uint64_t benchmark_max_iters) {
+    void run_for_benchmark(double benchmark_min_time) {
         std::vector<void*> filter_argv = build_filter_argv();
 
         const auto benchmark_inner = [this, &filter_argv]() {
@@ -1226,8 +1224,6 @@ public:
         Halide::Tools::BenchmarkConfig config;
         config.min_time = benchmark_min_time;
         config.max_time = benchmark_min_time * 4;
-        config.min_iters = benchmark_min_iters;
-        config.max_iters = benchmark_max_iters;
         auto result = Halide::Tools::benchmark(benchmark_inner, config);
 
         if (!parsable_output) {

--- a/tools/halide_benchmark.h
+++ b/tools/halide_benchmark.h
@@ -89,8 +89,7 @@ inline double benchmark(uint64_t samples, uint64_t iterations, std::function<voi
 }
 
 // Benchmark the operation 'op': run the operation until at least min_time
-// has elapsed, with the constraint of at least min_iters and no more than
-// max_iters times; the number of iterations is expanded as we
+// has elapsed; the number of iterations is expanded as we
 // progress (based on initial runs of 'op') to minimize overhead. The time
 // reported will be that of the best single iteration.
 //
@@ -116,12 +115,6 @@ struct BenchmarkConfig {
     // Set an absolute upper time limit. Defaults to min_time * 4.
     double max_time{0.1 * 4};
 
-    // Run at least this many iterations per sample.
-    uint64_t min_iters{1};
-
-    // Run at most this many iterations over all samples.
-    uint64_t max_iters{kBenchmarkMaxIterations};
-
     // Terminate when the relative difference between the best runtime
     // seen and the third-best runtime seen is no more than
     // this. Controls accuracy. The closer to zero this gets the more
@@ -144,7 +137,7 @@ struct BenchmarkResult {
     uint64_t iterations;
 
     // Measured accuracy between the best and third-best result.
-    // Will be <= config.accuracy unless max_iters is exceeded.
+    // Will be <= config.accuracy unless max_time is exceeded.
     double accuracy;
 
     operator double() const { return wall_time; }
@@ -156,10 +149,6 @@ inline BenchmarkResult benchmark(std::function<void()> op, const BenchmarkConfig
     const double min_time = std::max(10 * 1e-6, config.min_time);
     const double max_time = std::max(config.min_time, config.max_time);
 
-    const uint64_t min_iters = std::min(std::max((uint64_t)1, config.min_iters),
-                                                                            kBenchmarkMaxIterations);
-    const uint64_t max_iters = std::min(
-            std::max(config.min_iters, config.max_iters), kBenchmarkMaxIterations);
     const double accuracy = 1.0 + std::min(std::max(0.001, config.accuracy), 0.1);
 
     // We will do (at least) kMinSamples samples; we will do additional
@@ -169,8 +158,8 @@ inline BenchmarkResult benchmark(std::function<void()> op, const BenchmarkConfig
     double times[kMinSamples + 1] = {0};
 
     double total_time = 0;
-    uint64_t iters_per_sample = min_iters;
-    while (result.iterations < max_iters) {
+    uint64_t iters_per_sample = 1;
+    for (;;) {
         result.samples = 0;
         result.iterations = 0;
         total_time = 0;
@@ -192,12 +181,11 @@ inline BenchmarkResult benchmark(std::function<void()> op, const BenchmarkConfig
 
     // - Keep taking samples until we are accurate enough (even if we run over min_time).
     // - If we are already accurate enough but have time remaining, keep taking samples.
-    // - No matter what, don't go over max_iters or max_time; this is important, in case
+    // - No matter what, don't go over max_time; this is important, in case
     // we happen to get faster results for the first samples, then happen to transition
     // to throttled-down CPU state.
     while ((times[0] * accuracy < times[kMinSamples - 1] || total_time < min_time) &&
-                 total_time < max_time &&
-                 result.iterations < max_iters) {
+                 total_time < max_time) {
         times[kMinSamples] = benchmark(1, iters_per_sample, op);
         result.samples++;
         result.iterations += iters_per_sample;


### PR DESCRIPTION
These aren't really that useful; min_time is usually the only knob of this sort that is interesting to fiddle with. Remove them entirely to simplify code and reduce the temptation to mess with them. (Some versions of gbenchmark don't support min_iter and max_iter at all, only min_time.)