### PR TITLE
Use zero-init instead of memset for PipelineFeatures

### DIFF
--- a/apps/autoscheduler/FunctionDAG.h
+++ b/apps/autoscheduler/FunctionDAG.h
@@ -1479,7 +1479,7 @@ struct FunctionDAG {
                 Definition def = node.func.definition();
                 if (stage_idx > 0) def = node.func.updates()[stage_idx - 1];
 
-                memset(&stage.features, 0, sizeof(stage.features));
+                stage.features = PipelineFeatures();
 
                 for (auto v : def.values()) {
                     featurizer.visit_store_args(node.func.name(), v.type(), def.args());


### PR DESCRIPTION
gcc will fail with -Werror=class-memaccess because PipelineFeatures is not TriviallyCopyable