### PR TITLE
Add GPU memory allocation cache to OpenCL backend.

### DIFF
--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -6,8 +6,6 @@
 #include "mini_cl.h"
 #include "scoped_mutex_lock.h"
 
-#include "runtime_internal.h"
-
 #define INLINE inline __attribute__((always_inline))
 
 namespace Halide { namespace Runtime { namespace Internal { namespace OpenCL {
@@ -829,7 +827,7 @@ WEAK int halide_opencl_device_malloc(void *user_context, halide_buffer_t* buf) {
     #ifdef DEBUG_RUNTIME
     uint64_t t_before = halide_current_time_ns(user_context);
     #endif
-    //cl_mem dev_ptr = 0;
+
     device_handle *dev_handle = NULL;
 
     FreeListItem *to_free = NULL;


### PR DESCRIPTION
Implementation was ported (copypasted) from CUDA backend.

Manual testing gives the following:
```(bash)
❯ HL_GPU_DEVICE=3 HL_JIT_TARGET=linux-64-x86-cuda ./bin/correctness_gpu_allocation_cache
Runtime with cache: 0.221619
Without cache: 1.515336
Success!

❯ HL_GPU_DEVICE=3 HL_JIT_TARGET=linux-64-x86-opencl ./bin/correctness_gpu_allocation_cache                                                                                                                         
Runtime with cache: 0.398104
Without cache: 1.661566
Success!
```

Implementation is not shiny because of code duplication. Also I found that there are very similar thing exists for HVX backend. Probably, Halide needs common interface for allocation caching.