### PR TITLE
clang-tidy: remove unused functions.

### DIFF
--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -275,15 +275,6 @@ struct StageBounds {
         return (f_stage < other.f_stage) ||
                ((f_stage == other.f_stage) && (bounds.size() < other.bounds.size()));
     }
-    friend std::ostream& operator<<(std::ostream &stream, const StageBounds &s) {
-        stream << "Stage: " << s.f_stage << "\n";
-        stream << "Bounds:\n";
-        for (const auto &iter : s.bounds) {
-            stream << "\t" << iter.first << " -> [" << iter.second.min << ", " << iter.second.max << "]\n";
-        }
-        stream << "\n";
-        return stream;
-    }
 };
 
 // Helper function to queue regions that need to be traversed. 'fs_bounds' is
@@ -2303,41 +2294,6 @@ string get_base_name(string name) {
         return name.substr(dot_pos + 1);
     }
     return name;
-}
-
-// Return true if any of the values or args in 'def' refers to any of
-// the inputs or outputs, with access function which depends on 'var'.
-bool access_inputs_or_outputs(Definition def, VarOrRVar var,
-                              const map<string, Type> &inputs,
-                              const vector<Function> &outputs) {
-    FindAllCalls find;
-    def.accept(&find);
-
-    for (size_t i = 0; i < find.call_args.size(); ++i) {
-        const string &func = find.call_args[i].first;
-        const vector<Expr> &args = find.call_args[i].second;
-
-        if (inputs.find(func) == inputs.end()) {
-            // Check if 'func' is an output
-            bool is_output =
-                std::find_if(outputs.begin(), outputs.end(),
-                            [&func](const Function &f) { return (f.name() == func);})
-                != outputs.end();
-            if (!is_output) {
-                // 'func' is neither an input or an output
-                continue;
-            }
-        }
-
-        // Check if any of the accesses to 'func' depends on 'var'
-        for (const auto &arg : args) {
-            if (expr_uses_var(arg, var.name())) {
-                return true;
-            }
-        }
-    }
-
-    return false;
 }
 
 pair<VarOrRVar, VarOrRVar> Partitioner::split_dim(

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -20,13 +20,6 @@ using std::vector;
 
 namespace {
 
-const Definition &get_stage_definition(const Function &f, int stage_num) {
-    if (stage_num == 0) {
-        return f.definition();
-    }
-    return f.update(stage_num - 1);
-}
-
 // Collect the bounds of all the externally referenced buffers in a stmt.
 class CollectExternalBufferBounds : public IRVisitor {
 public:

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -1469,7 +1469,7 @@ void solve_test() {
     Expr x = Variable::make(Int(32), "x");
     Expr y = Variable::make(Int(32), "y");
     Expr z = Variable::make(Int(32), "z");
-    /*
+
     // Check some simple cases
     check_solve(3 - 4*x, x*(-4) + 3);
     check_solve(min(5, x), min(x, 5));
@@ -1627,8 +1627,6 @@ void solve_test() {
         Expr test = (x <= min(max((y - min(((z*x) + t), t)), 1), 0));
         Interval result = solve_for_outer_interval(test, "z");
     }
-
-    */
 
     {
         // This case caused exponential behavior


### PR DESCRIPTION
also, drive-by uncommenting of accidentally-commented-out code in solve_test() (found by the above check)