### PR TITLE
Add proper error message when differentiating unbounded access

### DIFF
--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -485,7 +485,7 @@ void ReverseAccumulationVisitor::propagate_adjoints(
         for (int d = 0; d < (int)bounds.size(); d++) {
             user_assert(bounds[d].is_bounded()) << "Access to function or buffer " <<
                 it.first << " at dimension " << d << " is not bounded. " <<
-                "We can only differentiate bounded functions.\n";
+                "We can only differentiate bounded accesses.\n";
         }
     }
 

--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -480,6 +480,14 @@ void ReverseAccumulationVisitor::propagate_adjoints(
         output_box.push_back(Interval(p.first, p.second));
     }
     func_bounds = inference_bounds(output, output_box);
+    for (const auto &it : func_bounds) {
+        const Box &bounds = it.second;
+        for (int d = 0; d < (int)bounds.size(); d++) {
+            user_assert(bounds[d].is_bounded()) << "Access to function or buffer " <<
+                it.first << " at dimension " << d << " is not bounded. " <<
+                "We can only differentiate bounded functions.\n";
+        }
+    }
 
     // Create a stub for each function and each update to accumulate adjoints.
     for (int func_id = 0; func_id < (int) funcs.size(); func_id++) {

--- a/test/error/autodiff_unbounded.cpp
+++ b/test/error/autodiff_unbounded.cpp
@@ -1,0 +1,17 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Buffer<float> b(10);
+    Func f("f"), g("g");
+    Var x("x");
+    Buffer<int> h(10);
+    RDom r(h);
+
+    f(x) = b(clamp(x, 0, 10));
+    g() += f(h(r));
+    Derivative d = propagate_adjoints(g); // access to f is unbounded
+    return 0;
+}


### PR DESCRIPTION
This addresses https://github.com/halide/Halide/issues/4172 by emitting proper error messages when encountering unbounded access. 