### PR TITLE
Handful of minor clang-tidy fixes

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -154,13 +154,13 @@ llvm::GlobalValue::LinkageTypes llvm_linkage(LinkageType t) {
     // fail. Figure out why so we can remove this.
     return llvm::GlobalValue::ExternalLinkage;
 
-    switch (t) {
-    case LinkageType::ExternalPlusMetadata:
-    case LinkageType::External:
-        return llvm::GlobalValue::ExternalLinkage;
-    default:
-        return llvm::GlobalValue::PrivateLinkage;
-    }
+    // switch (t) {
+    // case LinkageType::ExternalPlusMetadata:
+    // case LinkageType::External:
+    //     return llvm::GlobalValue::ExternalLinkage;
+    // default:
+    //     return llvm::GlobalValue::PrivateLinkage;
+    // }
 }
 
 }
@@ -1177,7 +1177,7 @@ llvm::Function *CodeGen_LLVM::embed_metadata_getter(const std::string &metadata_
 
     llvm::FunctionType *func_t = llvm::FunctionType::get(metadata_t_type->getPointerTo(), false);
     llvm::Function *metadata_getter = llvm::Function::Create(func_t, llvm::GlobalValue::ExternalLinkage, metadata_name, module.get());
-    llvm::BasicBlock *block = llvm::BasicBlock::Create(module.get()->getContext(), "entry", metadata_getter);
+    llvm::BasicBlock *block = llvm::BasicBlock::Create(module->getContext(), "entry", metadata_getter);
     builder->SetInsertPoint(block);
     builder->CreateRet(metadata_storage);
     internal_assert(!verifyFunction(*metadata_getter, &llvm::errs()));
@@ -2105,7 +2105,7 @@ void CodeGen_LLVM::visit(const Load *op) {
                 value = builder->CreateInsertElement(value, val, lane);
                 ptr = builder->CreateInBoundsGEP(ptr, stride);
             }
-        } else if (false /* should_scalarize(op->index) */) {
+        } else if ((false)) {   /* should_scalarize(op->index) */
             // TODO: put something sensible in for
             // should_scalarize. Probably a good idea if there are no
             // loads in it, and it's all int32.

--- a/src/Func.h
+++ b/src/Func.h
@@ -621,7 +621,6 @@ public:
 };
 
 namespace Internal {
-struct ErrorBuffer;
 class IRMutator;
 }  // namespace Internal
 

--- a/src/JITModule.h
+++ b/src/JITModule.h
@@ -15,7 +15,6 @@
 
 namespace llvm {
 class Module;
-class Type;
 }
 
 namespace Halide {


### PR DESCRIPTION
- unreachable-code warning
- unnecessary 'get' call on smart ptr
- useless forward decls