### PR TITLE
Fix macro mis-usage in Codgen_Hexagon

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1381,7 +1381,7 @@ Value *CodeGen_Hexagon::vdelta(Value *lut, const vector<int> &indices) {
                 control_elements[i] = ConstantInt::get(i8_t, switches[i]);
             }
             Value *control = ConstantVector::get(control_elements);
-            Intrinsic::ID vdelta_id = IPICK(is_128B, reverse ? Intrinsic::hexagon_V6_vrdelta : Intrinsic::hexagon_V6_vdelta);
+            Intrinsic::ID vdelta_id = reverse ? IPICK(is_128B, Intrinsic::hexagon_V6_vrdelta) : IPICK(is_128B, Intrinsic::hexagon_V6_vdelta);
             return call_intrin_cast(lut_ty, vdelta_id, {lut, control});
         }
     }


### PR DESCRIPTION
The IPICK() macro token-pastes to the end of the argument; in this case using a ternary expression inside means that the i128 suffix is pasted to one but not both. This restructures the bad use case to avoid the badness.

(Found via inspection -- I don't know if this is causing an actual problem or not.)

(I will likely follow this up with a PR that restructures the code more broadly to make this sort of error harder, as well as compressing the instruction table.)