### PR TITLE
De-inline most of IROperator.h

### DIFF
--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <iostream>
 #include <sstream>
@@ -9,6 +10,7 @@
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "IRPrinter.h"
+#include "Util.h"
 #include "Var.h"
 
 namespace Halide {
@@ -17,6 +19,7 @@ namespace Halide {
 // into account. The high order terms come first. n is the number of
 // terms, which is the degree plus one.
 namespace {
+
 Expr evaluate_polynomial(const Expr &x, float *coeff, int n) {
     internal_assert(n >= 2);
 
@@ -46,6 +49,30 @@ Expr evaluate_polynomial(const Expr &x, float *coeff, int n) {
     } else {
         return odd_terms * std::move(x) + even_terms;
     }
+}
+
+Expr stringify(const std::vector<Expr> &args) {
+    if (args.empty()) {
+        return Expr("");
+    }
+
+    return Internal::Call::make(type_of<const char *>(), Internal::Call::stringify,
+                                args, Internal::Call::Intrinsic);
+}
+
+Expr combine_strings(const std::vector<Expr> &args) {
+    // Insert spaces between each expr.
+    std::vector<Expr> strings(args.size()*2);
+    for (size_t i = 0; i < args.size(); i++) {
+        strings[i*2] = args[i];
+        if (i < args.size() - 1) {
+            strings[i*2+1] = Expr(" ");
+        } else {
+            strings[i*2+1] = Expr("\n");
+        }
+    }
+
+    return stringify(strings);
 }
 
 }  // namespace
@@ -91,6 +118,8 @@ bool is_no_op(const Stmt &s) {
     return e && is_const(e->value);
 }
 
+namespace {
+
 class ExprIsPure : public IRVisitor {
     using IRVisitor::visit;
 
@@ -132,6 +161,8 @@ class ExprIsPure : public IRVisitor {
 public:
     bool result = true;
 };
+
+}  // namespace
 
 bool is_pure(const Expr &e) {
     ExprIsPure pure;
@@ -301,6 +332,7 @@ bool is_two(const Expr &e) {
 }
 
 namespace {
+
 template<typename T>
 Expr make_const_helper(Type t, T val) {
     if (t.is_vector()) {
@@ -316,6 +348,7 @@ Expr make_const_helper(Type t, T val) {
         return Expr();
     }
 }
+
 }  // namespace
 
 Expr make_const(Type t, int64_t val) {
@@ -844,6 +877,22 @@ Stmt remove_likelies(Stmt s) {
     return RemoveLikelies().mutate(s);
 }
 
+Expr requirement_failed_error(Expr condition, const std::vector<Expr> &args) {
+    return Internal::Call::make(Int(32),
+                                "halide_error_requirement_failed",
+                                {stringify({condition}), combine_strings(args)},
+                                Internal::Call::Extern);
+}
+
+Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_values) {
+    Type t = result.type();
+    std::vector<Expr> args;
+    args.push_back(std::move(result));
+    args.insert(args.end(), cache_key_values.begin(), cache_key_values.end());
+    return Internal::Call::make(t, Internal::Call::memoize_expr,
+                                args, Internal::Call::PureIntrinsic);
+}
+
 }  // namespace Internal
 
 Expr fast_log(Expr x) {
@@ -869,6 +918,8 @@ Expr fast_log(Expr x) {
     result = common_subexpression_elimination(result);
     return result;
 }
+
+namespace {
 
 // A vectorizable sine and cosine implementation. Based on syrah fast vector math
 // https://github.com/boulos/syrah/blob/master/src/include/syrah/FixedVectorMath.h#L55
@@ -909,6 +960,8 @@ Expr fast_sin_cos(Expr x_full, bool is_sin) {
     return select(flip_sign, -tri_func, tri_func);
 }
 
+}  // namespace
+
 Expr fast_sin(Expr x_full) {
     return fast_sin_cos(x_full, true);
 }
@@ -946,30 +999,6 @@ Expr fast_exp(Expr x_full) {
     return result;
 }
 
-Expr stringify(const std::vector<Expr> &args) {
-    if (args.empty()) {
-        return Expr("");
-    }
-
-    return Internal::Call::make(type_of<const char *>(), Internal::Call::stringify,
-                                args, Internal::Call::Intrinsic);
-}
-
-Expr combine_strings(const std::vector<Expr> &args) {
-    // Insert spaces between each expr.
-    std::vector<Expr> strings(args.size()*2);
-    for (size_t i = 0; i < args.size(); i++) {
-        strings[i*2] = args[i];
-        if (i < args.size() - 1) {
-            strings[i*2+1] = Expr(" ");
-        } else {
-            strings[i*2+1] = Expr("\n");
-        }
-    }
-
-    return stringify(strings);
-}
-
 Expr print(const std::vector<Expr> &args) {
     Expr combined_string = combine_strings(args);
 
@@ -993,15 +1022,6 @@ Expr print_when(Expr condition, const std::vector<Expr> &args) {
                                 Internal::Call::PureIntrinsic);
 }
 
-namespace Internal {
-Expr requirement_failed_error(Expr condition, const std::vector<Expr> &args) {
-    return Internal::Call::make(Int(32),
-                                "halide_error_requirement_failed",
-                                {stringify({condition}), combine_strings(args)},
-                                Internal::Call::Extern);
-}
-}
-
 Expr require(Expr condition, const std::vector<Expr> &args) {
     user_assert(condition.defined()) << "Require of undefined condition.\n";
     user_assert(condition.type().is_bool()) << "Require condition must be a boolean type.\n";
@@ -1014,19 +1034,6 @@ Expr require(Expr condition, const std::vector<Expr> &args) {
                                 {likely(std::move(condition)), args[0], std::move(err)},
                                 Internal::Call::PureIntrinsic);
 }
-
-namespace Internal {
-
-Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_values) {
-    Type t = result.type();
-    std::vector<Expr> args;
-    args.push_back(std::move(result));
-    args.insert(args.end(), cache_key_values.begin(), cache_key_values.end());
-    return Internal::Call::make(t, Internal::Call::memoize_expr,
-                                args, Internal::Call::PureIntrinsic);
-}
-
-}  // namespace Internal
 
 Expr saturating_cast(Type t, Expr e) {
     // For float to float, guarantee infinities are always pinned to range.
@@ -1066,7 +1073,6 @@ Expr saturating_cast(Type t, Expr e) {
 }
 
 Expr select(Expr condition, Expr true_value, Expr false_value) {
-
     if (as_const_int(condition)) {
         // Why are you doing this? We'll preserve the select node until constant folding for you.
         condition = cast(Bool(), std::move(condition));
@@ -1123,6 +1129,1035 @@ Expr unsafe_promise_clamped(Expr value, Expr min, Expr max) {
                                 Internal::Call::unsafe_promise_clamped,
                                 {value, n_min_val, n_max_val},
                                 Internal::Call::Intrinsic);
+}
+
+Expr operator+(Expr a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "operator+ of undefined Expr\n";
+    Internal::match_types(a, b);
+    return Internal::Add::make(std::move(a), std::move(b));
+}
+
+Expr operator+(Expr a, int b) {
+    user_assert(a.defined()) << "operator+ of undefined Expr\n";
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::Add::make(std::move(a), Internal::make_const(t, b));
+}
+
+Expr operator+(int a, Expr b) {
+    user_assert(b.defined()) << "operator+ of undefined Expr\n";
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::Add::make(Internal::make_const(t, a), std::move(b));
+}
+
+Expr &operator+=(Expr &a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "operator+= of undefined Expr\n";
+    Type t = a.type();
+    a = Internal::Add::make(std::move(a), cast(t, std::move(b)));
+    return a;
+}
+
+Expr operator-(Expr a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "operator- of undefined Expr\n";
+    Internal::match_types(a, b);
+    return Internal::Sub::make(std::move(a), std::move(b));
+}
+
+Expr operator-(Expr a, int b) {
+    user_assert(a.defined()) << "operator- of undefined Expr\n";
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::Sub::make(std::move(a), Internal::make_const(t, b));
+}
+
+Expr operator-(int a, Expr b) {
+    user_assert(b.defined()) << "operator- of undefined Expr\n";
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::Sub::make(Internal::make_const(t, a), std::move(b));
+}
+
+Expr operator-(Expr a) {
+    user_assert(a.defined()) << "operator- of undefined Expr\n";
+    Type t = a.type();
+    return Internal::Sub::make(Internal::make_zero(t), std::move(a));
+}
+
+Expr &operator-=(Expr &a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "operator-= of undefined Expr\n";
+    Type t = a.type();
+    a = Internal::Sub::make(std::move(a), cast(t, std::move(b)));
+    return a;
+}
+
+Expr operator*(Expr a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "operator* of undefined Expr\n";
+    Internal::match_types(a, b);
+    return Internal::Mul::make(std::move(a), std::move(b));
+}
+
+Expr operator*(const Expr &a, int b) {
+    user_assert(a.defined()) << "operator* of undefined Expr\n";
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::Mul::make(std::move(a), Internal::make_const(t, b));
+}
+
+Expr operator*(int a, Expr b) {
+    user_assert(b.defined()) << "operator* of undefined Expr\n";
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::Mul::make(Internal::make_const(t, a), std::move(b));
+}
+
+Expr &operator*=(Expr &a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "operator*= of undefined Expr\n";
+    Type t = a.type();
+    a = Internal::Mul::make(std::move(a), cast(t, std::move(b)));
+    return a;
+}
+
+Expr operator/(Expr a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "operator/ of undefined Expr\n";
+    Internal::match_types(a, b);
+    return Internal::Div::make(std::move(a), std::move(b));
+}
+
+Expr &operator/=(Expr &a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "operator/= of undefined Expr\n";
+    Type t = a.type();
+    a = Internal::Div::make(std::move(a), cast(t, std::move(b)));
+    return a;
+}
+
+Expr operator/(Expr a, int b) {
+    user_assert(a.defined()) << "operator/ of undefined Expr\n";
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::Div::make(std::move(a), Internal::make_const(t, b));
+}
+
+Expr operator/(int a, Expr b) {
+    user_assert(b.defined()) << "operator- of undefined Expr\n";
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::Div::make(Internal::make_const(t, a), std::move(b));
+}
+
+Expr operator%(Expr a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "operator% of undefined Expr\n";
+    user_assert(!Internal::is_zero(b)) << "operator% with constant 0 modulus\n";
+    Internal::match_types(a, b);
+    return Internal::Mod::make(std::move(a), std::move(b));
+}
+
+Expr operator%(Expr a, int b) {
+    user_assert(a.defined()) << "operator% of undefined Expr\n";
+    user_assert(b != 0) << "operator% with constant 0 modulus\n";
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::Mod::make(std::move(a), Internal::make_const(t, b));
+}
+
+Expr operator%(int a, const Expr &b) {
+    user_assert(b.defined()) << "operator% of undefined Expr\n";
+    user_assert(!Internal::is_zero(b)) << "operator% with constant 0 modulus\n";
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::Mod::make(Internal::make_const(t, a), std::move(b));
+}
+
+Expr operator>(Expr a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "operator> of undefined Expr\n";
+    Internal::match_types(a, b);
+    return Internal::GT::make(std::move(a), std::move(b));
+}
+
+Expr operator>(Expr a, int b) {
+    user_assert(a.defined()) << "operator> of undefined Expr\n";
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::GT::make(std::move(a), Internal::make_const(t, b));
+}
+
+Expr operator>(int a, Expr b) {
+    user_assert(b.defined()) << "operator> of undefined Expr\n";
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::GT::make(Internal::make_const(t, a), std::move(b));
+}
+
+Expr operator<(Expr a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "operator< of undefined Expr\n";
+    Internal::match_types(a, b);
+    return Internal::LT::make(std::move(a), std::move(b));
+}
+
+Expr operator<(Expr a, int b) {
+    user_assert(a.defined()) << "operator< of undefined Expr\n";
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::LT::make(std::move(a), Internal::make_const(t, b));
+}
+
+Expr operator<(int a, Expr b) {
+    user_assert(b.defined()) << "operator< of undefined Expr\n";
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::LT::make(Internal::make_const(t, a), std::move(b));
+}
+
+Expr operator<=(Expr a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "operator<= of undefined Expr\n";
+    Internal::match_types(a, b);
+    return Internal::LE::make(std::move(a), std::move(b));
+}
+
+Expr operator<=(Expr a, int b) {
+    user_assert(a.defined()) << "operator<= of undefined Expr\n";
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::LE::make(std::move(a), Internal::make_const(t, b));
+}
+
+Expr operator<=(int a, Expr b) {
+    user_assert(b.defined()) << "operator<= of undefined Expr\n";
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::LE::make(Internal::make_const(t, a), std::move(b));
+}
+
+Expr operator>=(Expr a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "operator>= of undefined Expr\n";
+    Internal::match_types(a, b);
+    return Internal::GE::make(std::move(a), std::move(b));
+}
+
+Expr operator>=(Expr a, int b) {
+    user_assert(a.defined()) << "operator>= of undefined Expr\n";
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::GE::make(a, Internal::make_const(t, b));
+}
+
+Expr operator>=(int a, Expr b) {
+    user_assert(b.defined()) << "operator>= of undefined Expr\n";
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::GE::make(Internal::make_const(t, a), b);
+}
+
+Expr operator==(Expr a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "operator== of undefined Expr\n";
+    Internal::match_types(a, b);
+    return Internal::EQ::make(std::move(a), std::move(b));
+}
+
+Expr operator==(Expr a, int b) {
+    user_assert(a.defined()) << "operator== of undefined Expr\n";
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::EQ::make(std::move(a), Internal::make_const(t, b));
+}
+
+Expr operator==(int a, Expr b) {
+    user_assert(b.defined()) << "operator== of undefined Expr\n";
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::EQ::make(Internal::make_const(t, a), std::move(b));
+}
+
+Expr operator!=(Expr a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "operator!= of undefined Expr\n";
+    Internal::match_types(a, b);
+    return Internal::NE::make(std::move(a), std::move(b));
+}
+
+Expr operator!=(Expr a, int b) {
+    user_assert(a.defined()) << "operator!= of undefined Expr\n";
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::NE::make(std::move(a), Internal::make_const(t, b));
+}
+
+Expr operator!=(int a, Expr b) {
+    user_assert(b.defined()) << "operator!= of undefined Expr\n";
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::NE::make(Internal::make_const(t, a), std::move(b));
+}
+
+Expr operator&&(Expr a, Expr b) {
+    Internal::match_types(a, b);
+    return Internal::And::make(std::move(a), std::move(b));
+}
+
+Expr operator&&(const Expr &a, bool b) {
+    internal_assert(a.defined()) << "operator&& of undefined Expr\n";
+    internal_assert(a.type().is_bool()) << "operator&& of Expr of type " << a.type() << "\n";
+    if (b) {
+        return a;
+    } else {
+        return Internal::make_zero(a.type());
+    }
+}
+
+Expr operator&&(bool a, const Expr &b) {
+    return std::move(b) && a;
+}
+
+Expr operator||(Expr a, Expr b) {
+    Internal::match_types(a, b);
+    return Internal::Or::make(std::move(a), std::move(b));
+}
+
+Expr operator||(const Expr &a, bool b) {
+    internal_assert(a.defined()) << "operator|| of undefined Expr\n";
+    internal_assert(a.type().is_bool()) << "operator|| of Expr of type " << a.type() << "\n";
+    if (b) {
+        return Internal::make_one(a.type());
+    } else {
+        return a;
+    }
+}
+
+Expr operator||(bool a, const Expr &b) {
+    return b || a;
+}
+
+Expr operator!(Expr a) {
+    return Internal::Not::make(std::move(a));
+}
+
+Expr max(Expr a, Expr b) {
+    user_assert(a.defined() && b.defined())
+        << "max of undefined Expr\n";
+    Internal::match_types(a, b);
+    return Internal::Max::make(std::move(a), std::move(b));
+}
+
+Expr max(Expr a, int b) {
+    user_assert(a.defined()) << "max of undefined Expr\n";
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::Max::make(std::move(a), Internal::make_const(t, b));
+}
+
+
+Expr max(int a, Expr b) {
+    user_assert(b.defined()) << "max of undefined Expr\n";
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::Max::make(Internal::make_const(t, a), std::move(b));
+}
+
+Expr min(Expr a, Expr b) {
+    user_assert(a.defined() && b.defined())
+        << "min of undefined Expr\n";
+    Internal::match_types(a, b);
+    return Internal::Min::make(std::move(a), std::move(b));
+}
+
+Expr min(Expr a, int b) {
+    user_assert(a.defined()) << "max of undefined Expr\n";
+    Type t = a.type();
+    Internal::check_representable(t, b);
+    return Internal::Min::make(std::move(a), Internal::make_const(t, b));
+}
+
+Expr min(int a, Expr b) {
+    user_assert(b.defined()) << "max of undefined Expr\n";
+    Type t = b.type();
+    Internal::check_representable(t, a);
+    return Internal::Min::make(Internal::make_const(t, a), std::move(b));
+}
+
+Expr cast(Type t, Expr a) {
+    user_assert(a.defined()) << "cast of undefined Expr\n";
+    if (a.type() == t) {
+        return a;
+    }
+
+    if (t.is_handle() && !a.type().is_handle()) {
+        user_error << "Can't cast \"" << a << "\" to a handle. "
+                   << "The only legal cast from scalar types to a handle is: "
+                   << "reinterpret(Handle(), cast<uint64_t>(" << a << "));\n";
+    } else if (a.type().is_handle() && !t.is_handle()) {
+        user_error << "Can't cast handle \"" << a << "\" to type " << t << ". "
+                   << "The only legal cast from handles to scalar types is: "
+                   << "reinterpret(UInt(64), " << a << ");\n";
+    }
+
+    // Fold constants early
+    if (const int64_t *i = as_const_int(a)) {
+        return Internal::make_const(t, *i);
+    }
+    if (const uint64_t *u = as_const_uint(a)) {
+        return Internal::make_const(t, *u);
+    }
+    if (const double *f = as_const_float(a)) {
+        return Internal::make_const(t, *f);
+    }
+
+    if (t.is_vector()) {
+        if (a.type().is_scalar()) {
+            return Internal::Broadcast::make(cast(t.element_of(), std::move(a)), t.lanes());
+        } else if (const Internal::Broadcast *b = a.as<Internal::Broadcast>()) {
+            internal_assert(b->lanes == t.lanes());
+            return Internal::Broadcast::make(cast(t.element_of(), b->value), t.lanes());
+        }
+    }
+    return Internal::Cast::make(t, std::move(a));
+}
+
+Expr clamp(Expr a, Expr min_val, Expr max_val) {
+    user_assert(a.defined() && min_val.defined() && max_val.defined())
+        << "clamp of undefined Expr\n";
+    Expr n_min_val = lossless_cast(a.type(), min_val);
+    user_assert(n_min_val.defined())
+        << "Type mismatch in call to clamp. First argument ("
+        << a << ") has type " << a.type() << ", but second argument ("
+        << min_val << ") has type " << min_val.type() << ". Use an explicit cast.\n";
+    Expr n_max_val = lossless_cast(a.type(), max_val);
+    user_assert(n_max_val.defined())
+        << "Type mismatch in call to clamp. First argument ("
+        << a << ") has type " << a.type() << ", but third argument ("
+        << max_val << ") has type " << max_val.type() << ". Use an explicit cast.\n";
+    return Internal::Max::make(Internal::Min::make(std::move(a), std::move(n_max_val)), std::move(n_min_val));
+}
+
+Expr abs(Expr a) {
+    user_assert(a.defined())
+        << "abs of undefined Expr\n";
+    Type t = a.type();
+    if (t.is_uint()) {
+        user_warning << "Warning: abs of an unsigned type is a no-op\n";
+        return a;
+    }
+    return Internal::Call::make(t.with_code(t.is_int() ? Type::UInt : t.code()),
+                                Internal::Call::abs, {std::move(a)}, Internal::Call::PureIntrinsic);
+}
+
+Expr absd(Expr a, Expr b) {
+    user_assert(a.defined() && b.defined()) << "absd of undefined Expr\n";
+    Internal::match_types(a, b);
+    Type t = a.type();
+
+    if (t.is_float()) {
+        // Floats can just use abs.
+        return abs(std::move(a) - std::move(b));
+    }
+
+    // The argument may be signed, but the return type is unsigned.
+    return Internal::Call::make(t.with_code(t.is_int() ? Type::UInt : t.code()),
+                                Internal::Call::absd, {std::move(a), std::move(b)},
+                                Internal::Call::PureIntrinsic);
+}
+
+Expr sin(Expr x) {
+    user_assert(x.defined()) << "sin of undefined Expr\n";
+    if (x.type() == Float(64)) {
+        return Internal::Call::make(Float(64), "sin_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "sin_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "sin_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr asin(Expr x) {
+    user_assert(x.defined()) << "asin of undefined Expr\n";
+    if (x.type() == Float(64)) {
+        return Internal::Call::make(Float(64), "asin_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "asin_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "asin_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr cos(Expr x) {
+    user_assert(x.defined()) << "cos of undefined Expr\n";
+    if (x.type() == Float(64)) {
+        return Internal::Call::make(Float(64), "cos_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "cos_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "cos_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr acos(Expr x) {
+    user_assert(x.defined()) << "acos of undefined Expr\n";
+    if (x.type() == Float(64)) {
+        return Internal::Call::make(Float(64), "acos_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "acos_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "acos_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr tan(Expr x) {
+    user_assert(x.defined()) << "tan of undefined Expr\n";
+    if (x.type() == Float(64)) {
+        return Internal::Call::make(Float(64), "tan_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "tan_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "tan_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr atan(Expr x) {
+    user_assert(x.defined()) << "atan of undefined Expr\n";
+    if (x.type() == Float(64)) {
+        return Internal::Call::make(Float(64), "atan_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "atan_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "atan_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr atan2(Expr y, Expr x) {
+    user_assert(x.defined() && y.defined()) << "atan2 of undefined Expr\n";
+
+    if (y.type() == Float(64)) {
+        x = cast<double>(x);
+        return Internal::Call::make(Float(64), "atan2_f64", {std::move(y), std::move(x)}, Internal::Call::PureExtern);
+    } else if (y.type() == Float(16)) {
+        x = cast<float16_t>(x);
+        return Internal::Call::make(Float(16), "atan2_f16", {std::move(y), std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        y = cast<float>(y);
+        x = cast<float>(x);
+        return Internal::Call::make(Float(32), "atan2_f32", {std::move(y), std::move(x)}, Internal::Call::PureExtern);
+    }
+}
+
+Expr sinh(Expr x) {
+    user_assert(x.defined()) << "sinh of undefined Expr\n";
+    if (x.type() == Float(64)) {
+        return Internal::Call::make(Float(64), "sinh_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "sinh_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "sinh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr asinh(Expr x) {
+    user_assert(x.defined()) << "asinh of undefined Expr\n";
+    if (x.type() == Float(64)) {
+        return Internal::Call::make(Float(64), "asinh_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "asinh_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "asinh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr cosh(Expr x) {
+    user_assert(x.defined()) << "cosh of undefined Expr\n";
+    if (x.type() == Float(64)) {
+        return Internal::Call::make(Float(64), "cosh_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "cosh_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "cosh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr acosh(Expr x) {
+    user_assert(x.defined()) << "acosh of undefined Expr\n";
+    if (x.type() == Float(64)) {
+        return Internal::Call::make(Float(64), "acosh_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "acosh_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "acosh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr tanh(Expr x) {
+    user_assert(x.defined()) << "tanh of undefined Expr\n";
+    if (x.type() == Float(64)) {
+        return Internal::Call::make(Float(64), "tanh_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "tanh_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "tanh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr atanh(Expr x) {
+    user_assert(x.defined()) << "atanh of undefined Expr\n";
+    if (x.type() == Float(64)) {
+        return Internal::Call::make(Float(64), "atanh_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "atanh_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "atanh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr sqrt(Expr x) {
+    user_assert(x.defined()) << "sqrt of undefined Expr\n";
+    if (x.type() == Float(64)) {
+        return Internal::Call::make(Float(64), "sqrt_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "sqrt_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "sqrt_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr hypot(Expr x, Expr y) {
+    return sqrt(x * x + y * y);
+}
+
+Expr exp(Expr x) {
+    user_assert(x.defined()) << "exp of undefined Expr\n";
+    if (x.type() == Float(64)) {
+        return Internal::Call::make(Float(64), "exp_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "exp_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "exp_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr log(Expr x) {
+    user_assert(x.defined()) << "log of undefined Expr\n";
+    if (x.type() == Float(64)) {
+        return Internal::Call::make(Float(64), "log_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        return Internal::Call::make(Float(16), "log_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        return Internal::Call::make(Float(32), "log_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr pow(Expr x, Expr y) {
+    user_assert(x.defined() && y.defined()) << "pow of undefined Expr\n";
+
+    if (const int64_t *i = as_const_int(y)) {
+        return raise_to_integer_power(std::move(x), *i);
+    }
+
+    if (x.type() == Float(64)) {
+        y = cast<double>(std::move(y));
+        return Internal::Call::make(Float(64), "pow_f64", {std::move(x), std::move(y)}, Internal::Call::PureExtern);
+    } else if (x.type() == Float(16)) {
+        y = cast<float16_t>(std::move(y));
+        return Internal::Call::make(Float(16), "pow_f16", {std::move(x), std::move(y)}, Internal::Call::PureExtern);
+    } else {
+        x = cast<float>(std::move(x));
+        y = cast<float>(std::move(y));
+        return Internal::Call::make(Float(32), "pow_f32", {std::move(x), std::move(y)}, Internal::Call::PureExtern);
+    }
+}
+
+Expr erf(Expr x) {
+    user_assert(x.defined()) << "erf of undefined Expr\n";
+    user_assert(x.type() == Float(32)) << "erf only takes float arguments\n";
+    return Internal::halide_erf(std::move(x));
+}
+
+Expr fast_pow(Expr x, Expr y) {
+    if (const int64_t *i = as_const_int(y)) {
+        return raise_to_integer_power(std::move(x), *i);
+    }
+
+    x = cast<float>(std::move(x));
+    y = cast<float>(std::move(y));
+    return select(x == 0.0f, 0.0f, fast_exp(fast_log(x) * std::move(y)));
+}
+
+Expr fast_inverse(Expr x) {
+    user_assert(x.type() == Float(32)) << "fast_inverse only takes float arguments\n";
+    Type t = x.type();
+    return Internal::Call::make(t, "fast_inverse_f32", {std::move(x)}, Internal::Call::PureExtern);
+}
+
+Expr fast_inverse_sqrt(Expr x) {
+    user_assert(x.type() == Float(32)) << "fast_inverse_sqrt only takes float arguments\n";
+    Type t = x.type();
+    return Internal::Call::make(t, "fast_inverse_sqrt_f32", {std::move(x)}, Internal::Call::PureExtern);
+}
+
+Expr floor(Expr x) {
+    user_assert(x.defined()) << "floor of undefined Expr\n";
+    Type t = x.type();
+    if (t.element_of() == Float(64)) {
+        return Internal::Call::make(t, "floor_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (t.element_of() == Float(16)) {
+        return Internal::Call::make(t, "floor_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        t = Float(32, t.lanes());
+        if (t.is_int() || t.is_uint()) {
+            // Already an integer
+            return cast(t, std::move(x));
+        } else {
+            return Internal::Call::make(t, "floor_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
+        }
+    }
+}
+
+Expr ceil(Expr x) {
+    user_assert(x.defined()) << "ceil of undefined Expr\n";
+    Type t = x.type();
+    if (t.element_of() == Float(64)) {
+        return Internal::Call::make(t, "ceil_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type().element_of() == Float(16)) {
+        return Internal::Call::make(t, "ceil_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        t = Float(32, t.lanes());
+        if (t.is_int() || t.is_uint()) {
+            // Already an integer
+            return cast(t, std::move(x));
+        } else {
+            return Internal::Call::make(t, "ceil_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
+        }
+    }
+}
+
+Expr round(Expr x) {
+    user_assert(x.defined()) << "round of undefined Expr\n";
+    Type t = x.type();
+    if (t.element_of() == Float(64)) {
+        return Internal::Call::make(t, "round_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (t.element_of() == Float(16)) {
+        return Internal::Call::make(t, "round_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        t = Float(32, t.lanes());
+        if (t.is_int() || t.is_uint()) {
+            // Already an integer
+            return cast(t, std::move(x));
+        } else {
+            return Internal::Call::make(t, "round_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
+        }
+    }
+}
+
+Expr trunc(Expr x) {
+    user_assert(x.defined()) << "trunc of undefined Expr\n";
+    Type t = x.type();
+    if (t.element_of() == Float(64)) {
+        return Internal::Call::make(t, "trunc_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (t.element_of() == Float(16)) {
+        return Internal::Call::make(t, "trunc_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        t = Float(32, t.lanes());
+        if (t.is_int() || t.is_uint()) {
+            // Already an integer
+            return cast(t, std::move(x));
+        } else {
+            return Internal::Call::make(t, "trunc_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
+        }
+    }
+}
+
+Expr is_nan(Expr x) {
+    user_assert(x.defined()) << "is_nan of undefined Expr\n";
+    user_assert(x.type().is_float()) << "is_nan only works for float";
+    Type t = Bool(x.type().lanes());
+    if (x.type().element_of() == Float(64)) {
+        return Internal::Call::make(t, "is_nan_f64", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (x.type().element_of() == Float(16)) {
+        return Internal::Call::make(t, "is_nan_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        Type ft = Float(32, t.lanes());
+        return Internal::Call::make(t, "is_nan_f32", {cast(ft, std::move(x))}, Internal::Call::PureExtern);
+    }
+}
+
+Expr fract(Expr x) {
+    user_assert(x.defined()) << "fract of undefined Expr\n";
+    return x - trunc(x);
+}
+
+Expr reinterpret(Type t, Expr e) {
+    user_assert(e.defined()) << "reinterpret of undefined Expr\n";
+    int from_bits = e.type().bits() * e.type().lanes();
+    int to_bits = t.bits() * t.lanes();
+    user_assert(from_bits == to_bits)
+        << "Reinterpret cast from type " << e.type()
+        << " which has " << from_bits
+        << " bits, to type " << t
+        << " which has " << to_bits << " bits\n";
+    return Internal::Call::make(t, Internal::Call::reinterpret, {std::move(e)}, Internal::Call::PureIntrinsic);
+}
+
+Expr operator&(Expr x, Expr y) {
+    match_types_bitwise(x, y, "bitwise and");
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::bitwise_and, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
+}
+
+Expr operator&(Expr x, int y) {
+    Type t = x.type();
+    Internal::check_representable(t, y);
+    return Internal::Call::make(t, Internal::Call::bitwise_and, {std::move(x), Internal::make_const(t, y)}, Internal::Call::PureIntrinsic);
+}
+
+Expr operator&(int x, Expr y) {
+    Type t = y.type();
+    Internal::check_representable(t, x);
+    return Internal::Call::make(t, Internal::Call::bitwise_and, {Internal::make_const(t, x), std::move(y)}, Internal::Call::PureIntrinsic);
+}
+
+Expr operator|(Expr x, Expr y) {
+    match_types_bitwise(x, y, "bitwise or");
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::bitwise_or, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
+}
+
+Expr operator|(Expr x, int y) {
+    Type t = x.type();
+    Internal::check_representable(t, y);
+    return Internal::Call::make(t, Internal::Call::bitwise_or, {std::move(x), Internal::make_const(t, y)}, Internal::Call::PureIntrinsic);
+}
+
+Expr operator|(int x, Expr y) {
+    Type t = y.type();
+    Internal::check_representable(t, x);
+    return Internal::Call::make(t, Internal::Call::bitwise_or, {Internal::make_const(t, x), std::move(y)}, Internal::Call::PureIntrinsic);
+}
+
+Expr operator^(Expr x, Expr y) {
+    match_types_bitwise(x, y, "bitwise xor");
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::bitwise_xor, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
+}
+
+Expr operator^(Expr x, int y) {
+    Type t = x.type();
+    Internal::check_representable(t, y);
+    return Internal::Call::make(t, Internal::Call::bitwise_xor, {std::move(x), Internal::make_const(t, y)}, Internal::Call::PureIntrinsic);
+}
+
+Expr operator^(int x, Expr y) {
+    Type t = y.type();
+    Internal::check_representable(t, x);
+    return Internal::Call::make(t, Internal::Call::bitwise_xor, {Internal::make_const(t, x), std::move(y)}, Internal::Call::PureIntrinsic);
+}
+
+Expr operator~(Expr x) {
+    user_assert(x.defined()) << "bitwise not of undefined Expr\n";
+    user_assert(x.type().is_int() || x.type().is_uint())
+        << "Argument to bitwise not must be an integer or unsigned integer";
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::bitwise_not, {std::move(x)}, Internal::Call::PureIntrinsic);
+}
+
+Expr operator<<(Expr x, Expr y) {
+    Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), y.type().lanes()), y);
+    user_assert(unsigned_amount.defined())
+        << "In shift left expression:\n"
+        << "   (" << x << ") << (" << y << ")\n"
+        << "   with types " << x.type() << " << " << y.type() << "\n"
+        << "the RHS must be unsigned and losslessly castable to the same size as the LHS.\n";
+
+    if (y.type().is_vector() && !x.type().is_vector()) {
+        x = Internal::Broadcast::make(x, y.type().lanes());
+    }
+
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::shift_left, {std::move(x), std::move(unsigned_amount)}, Internal::Call::PureIntrinsic);
+}
+
+Expr operator<<(Expr x, int y) {
+    Type t = UInt(x.type().bits(), x.type().lanes());
+    Internal::check_representable(t, y);
+    return std::move(x) << Internal::make_const(t, y);
+}
+
+Expr operator>>(Expr x, Expr y) {
+    Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), y.type().lanes()), y);
+    user_assert(unsigned_amount.defined())
+        << "In shift right expression:\n"
+        << "   (" << x << ") >> (" << y << ")\n"
+        << "   with types " << x.type() << " >> " << y.type() << "\n"
+        << "the RHS must be unsigned and losslessly castable to the same size as the LHS.\n";
+    if (y.type().is_vector() && !x.type().is_vector()) {
+        x = Internal::Broadcast::make(x, y.type().lanes());
+    }
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::shift_right, {std::move(x), std::move(unsigned_amount)}, Internal::Call::PureIntrinsic);
+}
+
+Expr operator>>(Expr x, int y) {
+    Type t = UInt(x.type().bits(), x.type().lanes());
+    Internal::check_representable(t, y);
+    return std::move(x) >> Internal::make_const(t, y);
+}
+
+Expr lerp(Expr zero_val, Expr one_val, Expr weight) {
+    user_assert(zero_val.defined()) << "lerp with undefined zero value";
+    user_assert(one_val.defined()) << "lerp with undefined one value";
+    user_assert(weight.defined()) << "lerp with undefined weight";
+
+    // We allow integer constants through, so that you can say things
+    // like lerp(0, cast<uint8_t>(x), alpha) and produce an 8-bit
+    // result. Note that lerp(0.0f, cast<uint8_t>(x), alpha) will
+    // produce an error, as will lerp(0.0f, cast<double>(x),
+    // alpha). lerp(0, cast<float>(x), alpha) is also allowed and will
+    // produce a float result.
+    if (as_const_int(zero_val)) {
+        zero_val = cast(one_val.type(), std::move(zero_val));
+    }
+    if (as_const_int(one_val)) {
+        one_val = cast(zero_val.type(), std::move(one_val));
+    }
+
+    user_assert(zero_val.type() == one_val.type())
+        << "Can't lerp between " << zero_val << " of type " << zero_val.type()
+        << " and " << one_val << " of different type " << one_val.type() << "\n";
+    user_assert((weight.type().is_uint() || weight.type().is_float()))
+        << "A lerp weight must be an unsigned integer or a float, but "
+        << "lerp weight " << weight << " has type " << weight.type() << ".\n";
+    user_assert((zero_val.type().is_float() || zero_val.type().lanes() <= 32))
+        << "Lerping between 64-bit integers is not supported\n";
+    // Compilation error for constant weight that is out of range for integer use
+    // as this seems like an easy to catch gotcha.
+    if (!zero_val.type().is_float()) {
+        const double *const_weight = as_const_float(weight);
+        if (const_weight) {
+            user_assert(*const_weight >= 0.0 && *const_weight <= 1.0)
+                << "Floating-point weight for lerp with integer arguments is "
+                << *const_weight << ", which is not in the range [0.0, 1.0].\n";
+        }
+    }
+    Type t = zero_val.type();
+    return Internal::Call::make(t, Internal::Call::lerp,
+                                {std::move(zero_val), std::move(one_val), std::move(weight)},
+                                Internal::Call::PureIntrinsic);
+}
+
+Expr popcount(Expr x) {
+    user_assert(x.defined()) << "popcount of undefined Expr\n";
+    Type t = x.type();
+    user_assert(t.is_uint() || t.is_int())
+        << "Argument to popcount must be an integer\n";
+    return Internal::Call::make(t, Internal::Call::popcount,
+                                {std::move(x)}, Internal::Call::PureIntrinsic);
+}
+
+Expr count_leading_zeros(Expr x) {
+    user_assert(x.defined()) << "count leading zeros of undefined Expr\n";
+    Type t = x.type();
+    user_assert(t.is_uint() || t.is_int())
+        << "Argument to count_leading_zeros must be an integer\n";
+    return Internal::Call::make(t, Internal::Call::count_leading_zeros,
+                                {std::move(x)}, Internal::Call::PureIntrinsic);
+}
+
+Expr count_trailing_zeros(Expr x) {
+    user_assert(x.defined()) << "count trailing zeros of undefined Expr\n";
+    Type t = x.type();
+    user_assert(t.is_uint() || t.is_int())
+        << "Argument to count_trailing_zeros must be an integer\n";
+    return Internal::Call::make(t, Internal::Call::count_trailing_zeros,
+                                {std::move(x)}, Internal::Call::PureIntrinsic);
+}
+
+Expr div_round_to_zero(Expr x, Expr y) {
+    user_assert(x.defined()) << "div_round_to_zero of undefined dividend\n";
+    user_assert(y.defined()) << "div_round_to_zero of undefined divisor\n";
+    Internal::match_types(x, y);
+    if (x.type().is_uint()) {
+        return std::move(x) / std::move(y);
+    }
+    user_assert(x.type().is_int()) << "First argument to div_round_to_zero is not an integer: " << x << "\n";
+    user_assert(y.type().is_int()) << "Second argument to div_round_to_zero is not an integer: " << y << "\n";
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::div_round_to_zero,
+                                {std::move(x), std::move(y)},
+                                Internal::Call::PureIntrinsic);
+}
+
+Expr mod_round_to_zero(Expr x, Expr y) {
+    user_assert(x.defined()) << "mod_round_to_zero of undefined dividend\n";
+    user_assert(y.defined()) << "mod_round_to_zero of undefined divisor\n";
+    Internal::match_types(x, y);
+    if (x.type().is_uint()) {
+        return std::move(x) % std::move(y);
+    }
+    user_assert(x.type().is_int()) << "First argument to mod_round_to_zero is not an integer: " << x << "\n";
+    user_assert(y.type().is_int()) << "Second argument to mod_round_to_zero is not an integer: " << y << "\n";
+    Type t = x.type();
+    return Internal::Call::make(t, Internal::Call::mod_round_to_zero,
+                                {std::move(x), std::move(y)},
+                                Internal::Call::PureIntrinsic);
+}
+
+Expr random_float(Expr seed) {
+    // Random floats get even IDs
+    static std::atomic<int> counter;
+    int id = (counter++)*2;
+
+    std::vector<Expr> args;
+    if (seed.defined()) {
+        user_assert(seed.type() == Int(32))
+            << "The seed passed to random_float must have type Int(32), but instead is "
+            << seed << " of type " << seed.type() << "\n";
+        args.push_back(std::move(seed));
+    }
+    args.push_back(id);
+
+    // This is (surprisingly) pure - it's a fixed psuedo-random
+    // function of its inputs.
+    return Internal::Call::make(Float(32), Internal::Call::random,
+                                args, Internal::Call::PureIntrinsic);
+}
+
+Expr random_uint(Expr seed) {
+    // Random ints get odd IDs
+    static std::atomic<int> counter;
+    int id = (counter++)*2 + 1;
+
+    std::vector<Expr> args;
+    if (seed.defined()) {
+        user_assert(seed.type() == Int(32) || seed.type() == UInt(32))
+            << "The seed passed to random_int must have type Int(32) or UInt(32), but instead is "
+            << seed << " of type " << seed.type() << "\n";
+        args.push_back(std::move(seed));
+    }
+    args.push_back(id);
+
+    return Internal::Call::make(UInt(32), Internal::Call::random,
+                                args, Internal::Call::PureIntrinsic);
+}
+
+Expr random_int(Expr seed) {
+    return cast<int32_t>(random_uint(std::move(seed)));
+}
+
+Expr likely(Expr e) {
+    Type t = e.type();
+    return Internal::Call::make(t, Internal::Call::likely,
+                                {std::move(e)}, Internal::Call::PureIntrinsic);
+}
+
+Expr likely_if_innermost(Expr e) {
+    Type t = e.type();
+    return Internal::Call::make(t, Internal::Call::likely_if_innermost,
+                                {std::move(e)}, Internal::Call::PureIntrinsic);
+}
+
+Expr strict_float(Expr e) {
+    Type t = e.type();
+    return Internal::Call::make(t, Internal::Call::strict_float,
+                                {std::move(e)}, Internal::Call::PureIntrinsic);
+}
+
+Expr undef(Type t) {
+    return Internal::Call::make(t, Internal::Call::undef,
+                                std::vector<Expr>(),
+                                Internal::Call::PureIntrinsic);
 }
 
 }  // namespace Halide

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -7,12 +7,10 @@
  * it more pleasant to work with Halide expressions.
  */
 
-#include <atomic>
 #include <cmath>
 
 #include "IR.h"
 #include "Tuple.h"
-#include "Util.h"
 
 namespace Halide {
 
@@ -278,6 +276,26 @@ Expr remove_likelies(Expr e);
  * all calls to likely() and likely_if_innermost() removed. */
 Stmt remove_likelies(Stmt s);
 
+// Secondary args to print can be Exprs or const char *
+inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &args) {
+}
+
+template<typename ...Args>
+inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &args, const char *arg, Args&&... more_args) {
+    args.push_back(Expr(std::string(arg)));
+    collect_print_args(args, std::forward<Args>(more_args)...);
+}
+
+template<typename ...Args>
+inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &args, Expr arg, Args&&... more_args) {
+    args.push_back(std::move(arg));
+    collect_print_args(args, std::forward<Args>(more_args)...);
+}
+
+Expr requirement_failed_error(Expr condition, const std::vector<Expr> &args);
+
+Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_values);
+
 } // namespace Internal
 
 /** Cast an expression to the halide type corresponding to the C++ type T. */
@@ -287,211 +305,95 @@ inline Expr cast(Expr a) {
 }
 
 /** Cast an expression to a new type. */
-inline Expr cast(Type t, Expr a) {
-    user_assert(a.defined()) << "cast of undefined Expr\n";
-    if (a.type() == t) {
-        return a;
-    }
-
-    if (t.is_handle() && !a.type().is_handle()) {
-        user_error << "Can't cast \"" << a << "\" to a handle. "
-                   << "The only legal cast from scalar types to a handle is: "
-                   << "reinterpret(Handle(), cast<uint64_t>(" << a << "));\n";
-    } else if (a.type().is_handle() && !t.is_handle()) {
-        user_error << "Can't cast handle \"" << a << "\" to type " << t << ". "
-                   << "The only legal cast from handles to scalar types is: "
-                   << "reinterpret(UInt(64), " << a << ");\n";
-    }
-
-    // Fold constants early
-    if (const int64_t *i = as_const_int(a)) {
-        return Internal::make_const(t, *i);
-    }
-    if (const uint64_t *u = as_const_uint(a)) {
-        return Internal::make_const(t, *u);
-    }
-    if (const double *f = as_const_float(a)) {
-        return Internal::make_const(t, *f);
-    }
-
-    if (t.is_vector()) {
-        if (a.type().is_scalar()) {
-            return Internal::Broadcast::make(cast(t.element_of(), std::move(a)), t.lanes());
-        } else if (const Internal::Broadcast *b = a.as<Internal::Broadcast>()) {
-            internal_assert(b->lanes == t.lanes());
-            return Internal::Broadcast::make(cast(t.element_of(), b->value), t.lanes());
-        }
-    }
-    return Internal::Cast::make(t, std::move(a));
-}
+Expr cast(Type t, Expr a);
 
 /** Return the sum of two expressions, doing any necessary type
  * coercion using \ref Internal::match_types */
-inline Expr operator+(Expr a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "operator+ of undefined Expr\n";
-    Internal::match_types(a, b);
-    return Internal::Add::make(std::move(a), std::move(b));
-}
+Expr operator+(Expr a, Expr b);
 
 /** Add an expression and a constant integer. Coerces the type of the
  * integer to match the type of the expression. Errors if the integer
  * cannot be represented in the type of the expression. */
 // @{
-inline Expr operator+(Expr a, int b) {
-    user_assert(a.defined()) << "operator+ of undefined Expr\n";
-    Type t = a.type();
-    Internal::check_representable(t, b);
-    return Internal::Add::make(std::move(a), Internal::make_const(t, b));
-}
+Expr operator+(Expr a, int b);
 
 /** Add a constant integer and an expression. Coerces the type of the
  * integer to match the type of the expression. Errors if the integer
  * cannot be represented in the type of the expression. */
-inline Expr operator+(int a, Expr b) {
-    user_assert(b.defined()) << "operator+ of undefined Expr\n";
-    Type t = b.type();
-    Internal::check_representable(t, a);
-    return Internal::Add::make(Internal::make_const(t, a), std::move(b));
-}
+Expr operator+(int a, Expr b);
 
 /** Modify the first expression to be the sum of two expressions,
  * without changing its type. This casts the second argument to match
  * the type of the first. */
-inline Expr &operator+=(Expr &a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "operator+= of undefined Expr\n";
-    Type t = a.type();
-    a = Internal::Add::make(std::move(a), cast(t, std::move(b)));
-    return a;
-}
+Expr &operator+=(Expr &a, Expr b);
 
 /** Return the difference of two expressions, doing any necessary type
  * coercion using \ref Internal::match_types */
-inline Expr operator-(Expr a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "operator- of undefined Expr\n";
-    Internal::match_types(a, b);
-    return Internal::Sub::make(std::move(a), std::move(b));
-}
+Expr operator-(Expr a, Expr b);
 
 /** Subtracts a constant integer from an expression. Coerces the type of the
  * integer to match the type of the expression. Errors if the integer
  * cannot be represented in the type of the expression. */
-inline Expr operator-(Expr a, int b) {
-    user_assert(a.defined()) << "operator- of undefined Expr\n";
-    Type t = a.type();
-    Internal::check_representable(t, b);
-    return Internal::Sub::make(std::move(a), Internal::make_const(t, b));
-}
+Expr operator-(Expr a, int b);
 
 /** Subtracts an expression from a constant integer. Coerces the type
  * of the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator-(int a, Expr b) {
-    user_assert(b.defined()) << "operator- of undefined Expr\n";
-    Type t = b.type();
-    Internal::check_representable(t, a);
-    return Internal::Sub::make(Internal::make_const(t, a), std::move(b));
-}
+Expr operator-(int a, Expr b);
 
 /** Return the negative of the argument. Does no type casting, so more
  * formally: return that number which when added to the original,
  * yields zero of the same type. For unsigned integers the negative is
  * still an unsigned integer. E.g. in UInt(8), the negative of 56 is
  * 200, because 56 + 200 == 0 */
-inline Expr operator-(Expr a) {
-    user_assert(a.defined()) << "operator- of undefined Expr\n";
-    Type t = a.type();
-    return Internal::Sub::make(Internal::make_zero(t), std::move(a));
-}
+Expr operator-(Expr a);
 
 /** Modify the first expression to be the difference of two expressions,
  * without changing its type. This casts the second argument to match
  * the type of the first. */
-inline Expr &operator-=(Expr &a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "operator-= of undefined Expr\n";
-    Type t = a.type();
-    a = Internal::Sub::make(std::move(a), cast(t, std::move(b)));
-    return a;
-}
+Expr &operator-=(Expr &a, Expr b);
 
 /** Return the product of two expressions, doing any necessary type
  * coercion using \ref Internal::match_types */
-inline Expr operator*(Expr a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "operator* of undefined Expr\n";
-    Internal::match_types(a, b);
-    return Internal::Mul::make(std::move(a), std::move(b));
-}
+Expr operator*(Expr a, Expr b);
 
 /** Multiply an expression and a constant integer. Coerces the type of the
  * integer to match the type of the expression. Errors if the integer
  * cannot be represented in the type of the expression. */
-inline Expr operator*(const Expr &a, int b) {
-    user_assert(a.defined()) << "operator* of undefined Expr\n";
-    Type t = a.type();
-    Internal::check_representable(t, b);
-    return Internal::Mul::make(std::move(a), Internal::make_const(t, b));
-}
+Expr operator*(const Expr &a, int b);
 
 /** Multiply a constant integer and an expression. Coerces the type of
  * the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator*(int a, Expr b) {
-    user_assert(b.defined()) << "operator* of undefined Expr\n";
-    Type t = b.type();
-    Internal::check_representable(t, a);
-    return Internal::Mul::make(Internal::make_const(t, a), std::move(b));
-}
+Expr operator*(int a, Expr b);
 
 /** Modify the first expression to be the product of two expressions,
  * without changing its type. This casts the second argument to match
  * the type of the first. */
-inline Expr &operator*=(Expr &a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "operator*= of undefined Expr\n";
-    Type t = a.type();
-    a = Internal::Mul::make(std::move(a), cast(t, std::move(b)));
-    return a;
-}
+Expr &operator*=(Expr &a, Expr b);
 
 /** Return the ratio of two expressions, doing any necessary type
  * coercion using \ref Internal::match_types. Note that signed integer
  * division in Halide rounds towards minus infinity, unlike C, which
  * rounds towards zero. */
-inline Expr operator/(Expr a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "operator/ of undefined Expr\n";
-    Internal::match_types(a, b);
-    return Internal::Div::make(std::move(a), std::move(b));
-}
+Expr operator/(Expr a, Expr b);
 
 /** Modify the first expression to be the ratio of two expressions,
  * without changing its type. This casts the second argument to match
  * the type of the first. Note that signed integer division in Halide
  * rounds towards minus infinity, unlike C, which rounds towards
  * zero. */
-inline Expr &operator/=(Expr &a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "operator/= of undefined Expr\n";
-    Type t = a.type();
-    a = Internal::Div::make(std::move(a), cast(t, std::move(b)));
-    return a;
-}
+Expr &operator/=(Expr &a, Expr b);
 
 /** Divides an expression by a constant integer. Coerces the type
  * of the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator/(Expr a, int b) {
-    user_assert(a.defined()) << "operator/ of undefined Expr\n";
-    Type t = a.type();
-    Internal::check_representable(t, b);
-    return Internal::Div::make(std::move(a), Internal::make_const(t, b));
-}
+Expr operator/(Expr a, int b);
 
 /** Divides a constant integer by an expression. Coerces the type
  * of the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator/(int a, Expr b) {
-    user_assert(b.defined()) << "operator- of undefined Expr\n";
-    Type t = b.type();
-    Internal::check_representable(t, a);
-    return Internal::Div::make(Internal::make_const(t, a), std::move(b));
-}
+Expr operator/(int a, Expr b);
 
 /** Return the first argument reduced modulo the second, doing any
  * necessary type coercion using \ref Internal::match_types. For
@@ -499,294 +401,156 @@ inline Expr operator/(int a, Expr b) {
  * second argument (unlike in C, where it matches the sign of the
  * first argument). For example, this means that x%2 is always either
  * zero or one, even if x is negative.*/
-inline Expr operator%(Expr a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "operator% of undefined Expr\n";
-    user_assert(!Internal::is_zero(b)) << "operator% with constant 0 modulus\n";
-    Internal::match_types(a, b);
-    return Internal::Mod::make(std::move(a), std::move(b));
-}
+Expr operator%(Expr a, Expr b);
 
 /** Mods an expression by a constant integer. Coerces the type
  * of the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator%(Expr a, int b) {
-    user_assert(a.defined()) << "operator% of undefined Expr\n";
-    user_assert(b != 0) << "operator% with constant 0 modulus\n";
-    Type t = a.type();
-    Internal::check_representable(t, b);
-    return Internal::Mod::make(std::move(a), Internal::make_const(t, b));
-}
+Expr operator%(Expr a, int b);
+
 /** Mods a constant integer by an expression. Coerces the type
  * of the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-inline Expr operator%(int a, const Expr &b) {
-    user_assert(b.defined()) << "operator% of undefined Expr\n";
-    user_assert(!Internal::is_zero(b)) << "operator% with constant 0 modulus\n";
-    Type t = b.type();
-    Internal::check_representable(t, a);
-    return Internal::Mod::make(Internal::make_const(t, a), std::move(b));
-}
+Expr operator%(int a, const Expr &b);
 
 /** Return a boolean expression that tests whether the first argument
  * is greater than the second, after doing any necessary type coercion
  * using \ref Internal::match_types */
-inline Expr operator>(Expr a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "operator> of undefined Expr\n";
-    Internal::match_types(a, b);
-    return Internal::GT::make(std::move(a), std::move(b));
-}
+Expr operator>(Expr a, Expr b);
 
 /** Return a boolean expression that tests whether an expression is
  * greater than a constant integer. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator>(Expr a, int b) {
-    user_assert(a.defined()) << "operator> of undefined Expr\n";
-    Type t = a.type();
-    Internal::check_representable(t, b);
-    return Internal::GT::make(std::move(a), Internal::make_const(t, b));
-}
+Expr operator>(Expr a, int b);
 
 /** Return a boolean expression that tests whether a constant integer is
  * greater than an expression. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator>(int a, Expr b) {
-    user_assert(b.defined()) << "operator> of undefined Expr\n";
-    Type t = b.type();
-    Internal::check_representable(t, a);
-    return Internal::GT::make(Internal::make_const(t, a), std::move(b));
-}
+Expr operator>(int a, Expr b);
 
 /** Return a boolean expression that tests whether the first argument
  * is less than the second, after doing any necessary type coercion
  * using \ref Internal::match_types */
-inline Expr operator<(Expr a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "operator< of undefined Expr\n";
-    Internal::match_types(a, b);
-    return Internal::LT::make(std::move(a), std::move(b));
-}
+Expr operator<(Expr a, Expr b);
 
 /** Return a boolean expression that tests whether an expression is
  * less than a constant integer. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator<(Expr a, int b) {
-    user_assert(a.defined()) << "operator< of undefined Expr\n";
-    Type t = a.type();
-    Internal::check_representable(t, b);
-    return Internal::LT::make(std::move(a), Internal::make_const(t, b));
-}
+Expr operator<(Expr a, int b);
 
 /** Return a boolean expression that tests whether a constant integer is
  * less than an expression. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator<(int a, Expr b) {
-    user_assert(b.defined()) << "operator< of undefined Expr\n";
-    Type t = b.type();
-    Internal::check_representable(t, a);
-    return Internal::LT::make(Internal::make_const(t, a), std::move(b));
-}
+Expr operator<(int a, Expr b);
 
 /** Return a boolean expression that tests whether the first argument
  * is less than or equal to the second, after doing any necessary type
  * coercion using \ref Internal::match_types */
-inline Expr operator<=(Expr a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "operator<= of undefined Expr\n";
-    Internal::match_types(a, b);
-    return Internal::LE::make(std::move(a), std::move(b));
-}
+Expr operator<=(Expr a, Expr b);
 
 /** Return a boolean expression that tests whether an expression is
  * less than or equal to a constant integer. Coerces the integer to
  * the type of the expression. Errors if the integer is not
  * representable in that type. */
-inline Expr operator<=(Expr a, int b) {
-    user_assert(a.defined()) << "operator<= of undefined Expr\n";
-    Type t = a.type();
-    Internal::check_representable(t, b);
-    return Internal::LE::make(std::move(a), Internal::make_const(t, b));
-}
+Expr operator<=(Expr a, int b);
 
 /** Return a boolean expression that tests whether a constant integer
  * is less than or equal to an expression. Coerces the integer to the
  * type of the expression. Errors if the integer is not representable
  * in that type. */
-inline Expr operator<=(int a, Expr b) {
-    user_assert(b.defined()) << "operator<= of undefined Expr\n";
-    Type t = b.type();
-    Internal::check_representable(t, a);
-    return Internal::LE::make(Internal::make_const(t, a), std::move(b));
-}
+Expr operator<=(int a, Expr b);
 
 /** Return a boolean expression that tests whether the first argument
  * is greater than or equal to the second, after doing any necessary
  * type coercion using \ref Internal::match_types */
-inline Expr operator>=(Expr a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "operator>= of undefined Expr\n";
-    Internal::match_types(a, b);
-    return Internal::GE::make(std::move(a), std::move(b));
-}
+Expr operator>=(Expr a, Expr b);
 
 /** Return a boolean expression that tests whether an expression is
  * greater than or equal to a constant integer. Coerces the integer to
  * the type of the expression. Errors if the integer is not
  * representable in that type. */
-inline Expr operator>=(Expr a, int b) {
-    user_assert(a.defined()) << "operator>= of undefined Expr\n";
-    Type t = a.type();
-    Internal::check_representable(t, b);
-    return Internal::GE::make(a, Internal::make_const(t, b));
-}
+Expr operator>=(Expr a, int b);
 
 /** Return a boolean expression that tests whether a constant integer
  * is greater than or equal to an expression. Coerces the integer to the
  * type of the expression. Errors if the integer is not representable
  * in that type. */
-inline Expr operator>=(int a, Expr b) {
-    user_assert(b.defined()) << "operator>= of undefined Expr\n";
-    Type t = b.type();
-    Internal::check_representable(t, a);
-    return Internal::GE::make(Internal::make_const(t, a), b);
-}
+Expr operator>=(int a, Expr b);
 
 /** Return a boolean expression that tests whether the first argument
  * is equal to the second, after doing any necessary type coercion
  * using \ref Internal::match_types */
-inline Expr operator==(Expr a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "operator== of undefined Expr\n";
-    Internal::match_types(a, b);
-    return Internal::EQ::make(std::move(a), std::move(b));
-}
+Expr operator==(Expr a, Expr b);
 
 /** Return a boolean expression that tests whether an expression is
  * equal to a constant integer. Coerces the integer to the type of the
  * expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator==(Expr a, int b) {
-    user_assert(a.defined()) << "operator== of undefined Expr\n";
-    Type t = a.type();
-    Internal::check_representable(t, b);
-    return Internal::EQ::make(std::move(a), Internal::make_const(t, b));
-}
+Expr operator==(Expr a, int b);
 
 /** Return a boolean expression that tests whether a constant integer
  * is equal to an expression. Coerces the integer to the type of the
  * expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator==(int a, Expr b) {
-    user_assert(b.defined()) << "operator== of undefined Expr\n";
-    Type t = b.type();
-    Internal::check_representable(t, a);
-    return Internal::EQ::make(Internal::make_const(t, a), std::move(b));
-}
+Expr operator==(int a, Expr b);
 
 /** Return a boolean expression that tests whether the first argument
  * is not equal to the second, after doing any necessary type coercion
  * using \ref Internal::match_types */
-inline Expr operator!=(Expr a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "operator!= of undefined Expr\n";
-    Internal::match_types(a, b);
-    return Internal::NE::make(std::move(a), std::move(b));
-}
+Expr operator!=(Expr a, Expr b);
 
 /** Return a boolean expression that tests whether an expression is
  * not equal to a constant integer. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator!=(Expr a, int b) {
-    user_assert(a.defined()) << "operator!= of undefined Expr\n";
-    Type t = a.type();
-    Internal::check_representable(t, b);
-    return Internal::NE::make(std::move(a), Internal::make_const(t, b));
-}
+Expr operator!=(Expr a, int b);
 
 /** Return a boolean expression that tests whether a constant integer
  * is not equal to an expression. Coerces the integer to the type of
  * the expression. Errors if the integer is not representable in that
  * type. */
-inline Expr operator!=(int a, Expr b) {
-    user_assert(b.defined()) << "operator!= of undefined Expr\n";
-    Type t = b.type();
-    Internal::check_representable(t, a);
-    return Internal::NE::make(Internal::make_const(t, a), std::move(b));
-}
+Expr operator!=(int a, Expr b);
 
 /** Returns the logical and of the two arguments */
-inline Expr operator&&(Expr a, Expr b) {
-    Internal::match_types(a, b);
-    return Internal::And::make(std::move(a), std::move(b));
-}
+Expr operator&&(Expr a, Expr b);
 
 /** Logical and of an Expr and a bool. Either returns the Expr or an
  * Expr representing false, depending on the bool. */
 // @{
-inline Expr operator&&(const Expr &a, bool b) {
-    internal_assert(a.defined()) << "operator&& of undefined Expr\n";
-    internal_assert(a.type().is_bool()) << "operator&& of Expr of type " << a.type() << "\n";
-    if (b) {
-        return a;
-    } else {
-        return Internal::make_zero(a.type());
-    }
-}
-inline Expr operator&&(bool a, const Expr &b) {
-    return std::move(b) && a;
-}
+Expr operator&&(const Expr &a, bool b);
+Expr operator&&(bool a, const Expr &b);
 // @}
 
 /** Returns the logical or of the two arguments */
-inline Expr operator||(Expr a, Expr b) {
-    Internal::match_types(a, b);
-    return Internal::Or::make(std::move(a), std::move(b));
-}
+Expr operator||(Expr a, Expr b);
 
 /** Logical or of an Expr and a bool. Either returns the Expr or an
  * Expr representing true, depending on the bool. */
 // @{
-inline Expr operator||(const Expr &a, bool b) {
-    internal_assert(a.defined()) << "operator|| of undefined Expr\n";
-    internal_assert(a.type().is_bool()) << "operator|| of Expr of type " << a.type() << "\n";
-    if (b) {
-        return Internal::make_one(a.type());
-    } else {
-        return a;
-    }
-}
-inline Expr operator||(bool a, const Expr &b) {
-    return b || a;
-}
+Expr operator||(const Expr &a, bool b);
+Expr operator||(bool a, const Expr &b);
 // @}
 
 
 /** Returns the logical not the argument */
-inline Expr operator!(Expr a) {
-    return Internal::Not::make(std::move(a));
-}
+Expr operator!(Expr a);
 
 /** Returns an expression representing the greater of the two
  * arguments, after doing any necessary type coercion using
  * \ref Internal::match_types. Vectorizes cleanly on most platforms
  * (with the exception of integer types on x86 without SSE4). */
-inline Expr max(Expr a, Expr b) {
-    user_assert(a.defined() && b.defined())
-        << "max of undefined Expr\n";
-    Internal::match_types(a, b);
-    return Internal::Max::make(std::move(a), std::move(b));
-}
+Expr max(Expr a, Expr b);
 
 /** Returns an expression representing the greater of an expression
  * and a constant integer.  The integer is coerced to the type of the
  * expression. Errors if the integer is not representable as that
  * type. Vectorizes cleanly on most platforms (with the exception of
  * integer types on x86 without SSE4). */
-inline Expr max(Expr a, int b) {
-    user_assert(a.defined()) << "max of undefined Expr\n";
-    Type t = a.type();
-    Internal::check_representable(t, b);
-    return Internal::Max::make(std::move(a), Internal::make_const(t, b));
-}
+Expr max(Expr a, int b);
 
 
 /** Returns an expression representing the greater of a constant
@@ -794,12 +558,7 @@ inline Expr max(Expr a, int b) {
  * the expression. Errors if the integer is not representable as that
  * type. Vectorizes cleanly on most platforms (with the exception of
  * integer types on x86 without SSE4). */
-inline Expr max(int a, Expr b) {
-    user_assert(b.defined()) << "max of undefined Expr\n";
-    Type t = b.type();
-    Internal::check_representable(t, a);
-    return Internal::Max::make(Internal::make_const(t, a), std::move(b));
-}
+Expr max(int a, Expr b);
 
 inline Expr max(float a, Expr b) {return max(Expr(a), std::move(b));}
 inline Expr max(Expr a, float b) {return max(std::move(a), Expr(b));}
@@ -816,36 +575,21 @@ inline Expr max(A &&a, B &&b, C &&c, Rest&&... rest) {
     return max(std::forward<A>(a), max(std::forward<B>(b), std::forward<C>(c), std::forward<Rest>(rest)...));
 }
 
-inline Expr min(Expr a, Expr b) {
-    user_assert(a.defined() && b.defined())
-        << "min of undefined Expr\n";
-    Internal::match_types(a, b);
-    return Internal::Min::make(std::move(a), std::move(b));
-}
+Expr min(Expr a, Expr b);
 
 /** Returns an expression representing the lesser of an expression
  * and a constant integer.  The integer is coerced to the type of the
  * expression. Errors if the integer is not representable as that
  * type. Vectorizes cleanly on most platforms (with the exception of
  * integer types on x86 without SSE4). */
-inline Expr min(Expr a, int b) {
-    user_assert(a.defined()) << "max of undefined Expr\n";
-    Type t = a.type();
-    Internal::check_representable(t, b);
-    return Internal::Min::make(std::move(a), Internal::make_const(t, b));
-}
+Expr min(Expr a, int b);
 
 /** Returns an expression representing the lesser of a constant
  * integer and an expression. The integer is coerced to the type of
  * the expression. Errors if the integer is not representable as that
  * type. Vectorizes cleanly on most platforms (with the exception of
  * integer types on x86 without SSE4). */
-inline Expr min(int a, Expr b) {
-    user_assert(b.defined()) << "max of undefined Expr\n";
-    Type t = b.type();
-    Internal::check_representable(t, a);
-    return Internal::Min::make(Internal::make_const(t, a), std::move(b));
-}
+Expr min(int a, Expr b);
 
 inline Expr min(float a, Expr b) {return min(Expr(a), std::move(b));}
 inline Expr min(Expr a, float b) {return min(std::move(a), Expr(b));}
@@ -892,58 +636,20 @@ inline Expr operator!=(float a, Expr b) {return Expr(a) != std::move(b);}
 
 /** Clamps an expression to lie within the given bounds. The bounds
  * are type-cast to match the expression. Vectorizes as well as min/max. */
-inline Expr clamp(Expr a, Expr min_val, Expr max_val) {
-    user_assert(a.defined() && min_val.defined() && max_val.defined())
-        << "clamp of undefined Expr\n";
-    Expr n_min_val = lossless_cast(a.type(), min_val);
-    user_assert(n_min_val.defined())
-        << "Type mismatch in call to clamp. First argument ("
-        << a << ") has type " << a.type() << ", but second argument ("
-        << min_val << ") has type " << min_val.type() << ". Use an explicit cast.\n";
-    Expr n_max_val = lossless_cast(a.type(), max_val);
-    user_assert(n_max_val.defined())
-        << "Type mismatch in call to clamp. First argument ("
-        << a << ") has type " << a.type() << ", but third argument ("
-        << max_val << ") has type " << max_val.type() << ". Use an explicit cast.\n";
-    return Internal::Max::make(Internal::Min::make(std::move(a), std::move(n_max_val)), std::move(n_min_val));
-}
+Expr clamp(Expr a, Expr min_val, Expr max_val);
 
 /** Returns the absolute value of a signed integer or floating-point
  * expression. Vectorizes cleanly. Unlike in C, abs of a signed
  * integer returns an unsigned integer of the same bit width. This
  * means that abs of the most negative integer doesn't overflow. */
-inline Expr abs(Expr a) {
-    user_assert(a.defined())
-        << "abs of undefined Expr\n";
-    Type t = a.type();
-    if (t.is_uint()) {
-        user_warning << "Warning: abs of an unsigned type is a no-op\n";
-        return a;
-    }
-    return Internal::Call::make(t.with_code(t.is_int() ? Type::UInt : t.code()),
-                                Internal::Call::abs, {std::move(a)}, Internal::Call::PureIntrinsic);
-}
+Expr abs(Expr a);
 
 /** Return the absolute difference between two values. Vectorizes
  * cleanly. Returns an unsigned value of the same bit width. There are
  * various ways to write this yourself, but they contain numerous
  * gotchas and don't always compile to good code, so use this
  * instead. */
-inline Expr absd(Expr a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "absd of undefined Expr\n";
-    Internal::match_types(a, b);
-    Type t = a.type();
-
-    if (t.is_float()) {
-        // Floats can just use abs.
-        return abs(std::move(a) - std::move(b));
-    }
-
-    // The argument may be signed, but the return type is unsigned.
-    return Internal::Call::make(t.with_code(t.is_int() ? Type::UInt : t.code()),
-                                Internal::Call::absd, {std::move(a), std::move(b)},
-                                Internal::Call::PureIntrinsic);
-}
+Expr absd(Expr a, Expr b);
 
 /** Returns an expression similar to the ternary operator in C, except
  * that it always evaluates all arguments. If the first argument is
@@ -986,210 +692,77 @@ inline Tuple tuple_select(const Expr &c0, const Tuple &v0, const Expr &c1, const
 /** Return the sine of a floating-point expression. If the argument is
  * not floating-point, it is cast to Float(32). Does not vectorize
  * well. */
-inline Expr sin(Expr x) {
-    user_assert(x.defined()) << "sin of undefined Expr\n";
-    if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "sin_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "sin_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        return Internal::Call::make(Float(32), "sin_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr sin(Expr x);
 
 /** Return the arcsine of a floating-point expression. If the argument
  * is not floating-point, it is cast to Float(32). Does not vectorize
  * well. */
-inline Expr asin(Expr x) {
-    user_assert(x.defined()) << "asin of undefined Expr\n";
-    if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "asin_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "asin_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        return Internal::Call::make(Float(32), "asin_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr asin(Expr x);
 
 /** Return the cosine of a floating-point expression. If the argument
  * is not floating-point, it is cast to Float(32). Does not vectorize
  * well. */
-inline Expr cos(Expr x) {
-    user_assert(x.defined()) << "cos of undefined Expr\n";
-    if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "cos_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "cos_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        return Internal::Call::make(Float(32), "cos_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr cos(Expr x);
 
 /** Return the arccosine of a floating-point expression. If the
  * argument is not floating-point, it is cast to Float(32). Does not
  * vectorize well. */
-inline Expr acos(Expr x) {
-    user_assert(x.defined()) << "acos of undefined Expr\n";
-    if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "acos_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "acos_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        return Internal::Call::make(Float(32), "acos_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr acos(Expr x);
 
 /** Return the tangent of a floating-point expression. If the argument
  * is not floating-point, it is cast to Float(32). Does not vectorize
  * well. */
-inline Expr tan(Expr x) {
-    user_assert(x.defined()) << "tan of undefined Expr\n";
-    if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "tan_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "tan_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        return Internal::Call::make(Float(32), "tan_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr tan(Expr x);
 
 /** Return the arctangent of a floating-point expression. If the
  * argument is not floating-point, it is cast to Float(32). Does not
  * vectorize well. */
-inline Expr atan(Expr x) {
-    user_assert(x.defined()) << "atan of undefined Expr\n";
-    if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "atan_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "atan_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        return Internal::Call::make(Float(32), "atan_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr atan(Expr x);
 
 /** Return the angle of a floating-point gradient. If the argument is
  * not floating-point, it is cast to Float(32). Does not vectorize
  * well. */
-inline Expr atan2(Expr y, Expr x) {
-    user_assert(x.defined() && y.defined()) << "atan2 of undefined Expr\n";
-
-    if (y.type() == Float(64)) {
-        x = cast<double>(x);
-        return Internal::Call::make(Float(64), "atan2_f64", {std::move(y), std::move(x)}, Internal::Call::PureExtern);
-    } else if (y.type() == Float(16)) {
-        x = cast<float16_t>(x);
-        return Internal::Call::make(Float(16), "atan2_f16", {std::move(y), std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        y = cast<float>(y);
-        x = cast<float>(x);
-        return Internal::Call::make(Float(32), "atan2_f32", {std::move(y), std::move(x)}, Internal::Call::PureExtern);
-    }
-}
+Expr atan2(Expr y, Expr x);
 
 /** Return the hyperbolic sine of a floating-point expression.  If the
  *  argument is not floating-point, it is cast to Float(32). Does not
  *  vectorize well. */
-inline Expr sinh(Expr x) {
-    user_assert(x.defined()) << "sinh of undefined Expr\n";
-    if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "sinh_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "sinh_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        return Internal::Call::make(Float(32), "sinh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr sinh(Expr x);
 
 /** Return the hyperbolic arcsinhe of a floating-point expression.  If
  * the argument is not floating-point, it is cast to Float(32). Does
  * not vectorize well. */
-inline Expr asinh(Expr x) {
-    user_assert(x.defined()) << "asinh of undefined Expr\n";
-    if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "asinh_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "asinh_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        return Internal::Call::make(Float(32), "asinh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr asinh(Expr x);
 
 /** Return the hyperbolic cosine of a floating-point expression.  If
  * the argument is not floating-point, it is cast to Float(32). Does
  * not vectorize well. */
-inline Expr cosh(Expr x) {
-    user_assert(x.defined()) << "cosh of undefined Expr\n";
-    if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "cosh_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "cosh_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        return Internal::Call::make(Float(32), "cosh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr cosh(Expr x);
 
 /** Return the hyperbolic arccosine of a floating-point expression.
  * If the argument is not floating-point, it is cast to
  * Float(32). Does not vectorize well. */
-inline Expr acosh(Expr x) {
-    user_assert(x.defined()) << "acosh of undefined Expr\n";
-    if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "acosh_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "acosh_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        return Internal::Call::make(Float(32), "acosh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr acosh(Expr x);
 
 /** Return the hyperbolic tangent of a floating-point expression.  If
  * the argument is not floating-point, it is cast to Float(32). Does
  * not vectorize well. */
-inline Expr tanh(Expr x) {
-    user_assert(x.defined()) << "tanh of undefined Expr\n";
-    if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "tanh_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "tanh_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        return Internal::Call::make(Float(32), "tanh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr tanh(Expr x);
 
 /** Return the hyperbolic arctangent of a floating-point expression.
  * If the argument is not floating-point, it is cast to
  * Float(32). Does not vectorize well. */
-inline Expr atanh(Expr x) {
-    user_assert(x.defined()) << "atanh of undefined Expr\n";
-    if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "atanh_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "atanh_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        return Internal::Call::make(Float(32), "atanh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr atanh(Expr x);
 
 /** Return the square root of a floating-point expression. If the
  * argument is not floating-point, it is cast to Float(32). Typically
  * vectorizes cleanly. */
-inline Expr sqrt(Expr x) {
-    user_assert(x.defined()) << "sqrt of undefined Expr\n";
-    if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "sqrt_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "sqrt_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        return Internal::Call::make(Float(32), "sqrt_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr sqrt(Expr x);
 
 /** Return the square root of the sum of the squares of two
  * floating-point expressions. If the argument is not floating-point,
  * it is cast to Float(32). Vectorizes cleanly. */
-inline Expr hypot(Expr x, Expr y) {
-    return sqrt(x * x + y * y);
-}
+Expr hypot(Expr x, Expr y);
 
 /** Return the exponential of a floating-point expression. If the
  * argument is not floating-point, it is cast to Float(32). For
@@ -1198,16 +771,7 @@ inline Expr hypot(Expr x, Expr y) {
  * vectorizable, does the right thing for extremely small or extremely
  * large inputs, and is accurate up to the last bit of the
  * mantissa. Vectorizes cleanly. */
-inline Expr exp(Expr x) {
-    user_assert(x.defined()) << "exp of undefined Expr\n";
-    if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "exp_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "exp_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        return Internal::Call::make(Float(32), "exp_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr exp(Expr x);
 
 /** Return the logarithm of a floating-point expression. If the
  * argument is not floating-point, it is cast to Float(32). For
@@ -1216,16 +780,7 @@ inline Expr exp(Expr x) {
  * vectorizable, does the right thing for inputs <= 0 (returns -inf or
  * nan), and is accurate up to the last bit of the
  * mantissa. Vectorizes cleanly. */
-inline Expr log(Expr x) {
-    user_assert(x.defined()) << "log of undefined Expr\n";
-    if (x.type() == Float(64)) {
-        return Internal::Call::make(Float(64), "log_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        return Internal::Call::make(Float(16), "log_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        return Internal::Call::make(Float(32), "log_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr log(Expr x);
 
 /** Return one floating point expression raised to the power of
  * another. The type of the result is given by the type of the first
@@ -1233,34 +788,12 @@ inline Expr log(Expr x) {
  * cast to Float(32). For Float(32), cleanly vectorizable, and
  * accurate up to the last few bits of the mantissa. Gets worse when
  * approaching overflow. Vectorizes cleanly. */
-inline Expr pow(Expr x, Expr y) {
-    user_assert(x.defined() && y.defined()) << "pow of undefined Expr\n";
-
-    if (const int64_t *i = as_const_int(y)) {
-        return raise_to_integer_power(std::move(x), *i);
-    }
-
-    if (x.type() == Float(64)) {
-        y = cast<double>(std::move(y));
-        return Internal::Call::make(Float(64), "pow_f64", {std::move(x), std::move(y)}, Internal::Call::PureExtern);
-    } else if (x.type() == Float(16)) {
-        y = cast<float16_t>(std::move(y));
-        return Internal::Call::make(Float(16), "pow_f16", {std::move(x), std::move(y)}, Internal::Call::PureExtern);
-    } else {
-        x = cast<float>(std::move(x));
-        y = cast<float>(std::move(y));
-        return Internal::Call::make(Float(32), "pow_f32", {std::move(x), std::move(y)}, Internal::Call::PureExtern);
-    }
-}
+Expr pow(Expr x, Expr y);
 
 /** Evaluate the error function erf. Only available for
  * Float(32). Accurate up to the last three bits of the
  * mantissa. Vectorizes cleanly. */
-inline Expr erf(Expr x) {
-    user_assert(x.defined()) << "erf of undefined Expr\n";
-    user_assert(x.type() == Float(32)) << "erf only takes float arguments\n";
-    return Internal::halide_erf(std::move(x));
-}
+Expr erf(Expr x);
 
 /** Fast vectorizable approximation to some trigonometric functions for Float(32).
  * Absolute approximation error is less than 1e-5. */
@@ -1284,165 +817,60 @@ Expr fast_exp(Expr x);
  * nonsense for x < 0.0f. Accurate up to the last 5 bits of the
  * mantissa for typical exponents. Gets worse when approaching
  * overflow. Vectorizes cleanly. */
-inline Expr fast_pow(Expr x, Expr y) {
-    if (const int64_t *i = as_const_int(y)) {
-        return raise_to_integer_power(std::move(x), *i);
-    }
-
-    x = cast<float>(std::move(x));
-    y = cast<float>(std::move(y));
-    return select(x == 0.0f, 0.0f, fast_exp(fast_log(x) * std::move(y)));
-}
+Expr fast_pow(Expr x, Expr y);
 
 /** Fast approximate inverse for Float(32). Corresponds to the rcpps
  * instruction on x86, and the vrecpe instruction on ARM. Vectorizes
  * cleanly. Note that this can produce slightly different results
  * across different implementations of the same architecture (e.g. AMD vs Intel),
  * even when strict_float is enabled. */
-inline Expr fast_inverse(Expr x) {
-    user_assert(x.type() == Float(32)) << "fast_inverse only takes float arguments\n";
-    Type t = x.type();
-    return Internal::Call::make(t, "fast_inverse_f32", {std::move(x)}, Internal::Call::PureExtern);
-}
+Expr fast_inverse(Expr x);
 
 /** Fast approximate inverse square root for Float(32). Corresponds to
  * the rsqrtps instruction on x86, and the vrsqrte instruction on
  * ARM. Vectorizes cleanly. Note that this can produce slightly different results
  * across different implementations of the same architecture (e.g. AMD vs Intel),
  * even when strict_float is enabled. */
-inline Expr fast_inverse_sqrt(Expr x) {
-    user_assert(x.type() == Float(32)) << "fast_inverse_sqrt only takes float arguments\n";
-    Type t = x.type();
-    return Internal::Call::make(t, "fast_inverse_sqrt_f32", {std::move(x)}, Internal::Call::PureExtern);
-}
+Expr fast_inverse_sqrt(Expr x);
 
 /** Return the greatest whole number less than or equal to a
  * floating-point expression. If the argument is not floating-point,
  * it is cast to Float(32). The return value is still in floating
  * point, despite being a whole number. Vectorizes cleanly. */
-inline Expr floor(Expr x) {
-    user_assert(x.defined()) << "floor of undefined Expr\n";
-    Type t = x.type();
-    if (t.element_of() == Float(64)) {
-        return Internal::Call::make(t, "floor_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (t.element_of() == Float(16)) {
-        return Internal::Call::make(t, "floor_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        t = Float(32, t.lanes());
-        if (t.is_int() || t.is_uint()) {
-            // Already an integer
-            return cast(t, std::move(x));
-        } else {
-            return Internal::Call::make(t, "floor_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
-        }
-    }
-}
+Expr floor(Expr x);
 
 /** Return the least whole number greater than or equal to a
  * floating-point expression. If the argument is not floating-point,
  * it is cast to Float(32). The return value is still in floating
  * point, despite being a whole number. Vectorizes cleanly. */
-inline Expr ceil(Expr x) {
-    user_assert(x.defined()) << "ceil of undefined Expr\n";
-    Type t = x.type();
-    if (t.element_of() == Float(64)) {
-        return Internal::Call::make(t, "ceil_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type().element_of() == Float(16)) {
-        return Internal::Call::make(t, "ceil_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        t = Float(32, t.lanes());
-        if (t.is_int() || t.is_uint()) {
-            // Already an integer
-            return cast(t, std::move(x));
-        } else {
-            return Internal::Call::make(t, "ceil_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
-        }
-    }
-}
+Expr ceil(Expr x);
 
 /** Return the whole number closest to a floating-point expression. If the
  * argument is not floating-point, it is cast to Float(32). The return value
  * is still in floating point, despite being a whole number. On ties, we
  * follow IEEE754 conventions and round to the nearest even number. Vectorizes
  * cleanly. */
-inline Expr round(Expr x) {
-    user_assert(x.defined()) << "round of undefined Expr\n";
-    Type t = x.type();
-    if (t.element_of() == Float(64)) {
-        return Internal::Call::make(t, "round_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (t.element_of() == Float(16)) {
-        return Internal::Call::make(t, "round_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        t = Float(32, t.lanes());
-        if (t.is_int() || t.is_uint()) {
-            // Already an integer
-            return cast(t, std::move(x));
-        } else {
-            return Internal::Call::make(t, "round_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
-        }
-    }
-}
+Expr round(Expr x);
 
 /** Return the integer part of a floating-point expression. If the argument is
  * not floating-point, it is cast to Float(32). The return value is still in
  * floating point, despite being a whole number. Vectorizes cleanly. */
-inline Expr trunc(Expr x) {
-    user_assert(x.defined()) << "trunc of undefined Expr\n";
-    Type t = x.type();
-    if (t.element_of() == Float(64)) {
-        return Internal::Call::make(t, "trunc_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (t.element_of() == Float(16)) {
-        return Internal::Call::make(t, "trunc_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        t = Float(32, t.lanes());
-        if (t.is_int() || t.is_uint()) {
-            // Already an integer
-            return cast(t, std::move(x));
-        } else {
-            return Internal::Call::make(t, "trunc_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
-        }
-    }
-}
+Expr trunc(Expr x);
 
 /** Returns true if the argument is a Not a Number (NaN). Requires a
   * floating point argument.  Vectorizes cleanly. */
-inline Expr is_nan(Expr x) {
-    user_assert(x.defined()) << "is_nan of undefined Expr\n";
-    user_assert(x.type().is_float()) << "is_nan only works for float";
-    Type t = Bool(x.type().lanes());
-    if (x.type().element_of() == Float(64)) {
-        return Internal::Call::make(t, "is_nan_f64", {std::move(x)}, Internal::Call::PureExtern);
-    } else if (x.type().element_of() == Float(16)) {
-        return Internal::Call::make(t, "is_nan_f16", {std::move(x)}, Internal::Call::PureExtern);
-    } else {
-        Type ft = Float(32, t.lanes());
-        return Internal::Call::make(t, "is_nan_f32", {cast(ft, std::move(x))}, Internal::Call::PureExtern);
-    }
-}
+Expr is_nan(Expr x);
 
 /** Return the fractional part of a floating-point expression. If the argument
  *  is not floating-point, it is cast to Float(32). The return value has the
  *  same sign as the original expression. Vectorizes cleanly. */
-inline Expr fract(Expr x) {
-    user_assert(x.defined()) << "fract of undefined Expr\n";
-    return x - trunc(x);
-}
+Expr fract(Expr x);
 
 /** Reinterpret the bits of one value as another type. */
-inline Expr reinterpret(Type t, Expr e) {
-    user_assert(e.defined()) << "reinterpret of undefined Expr\n";
-    int from_bits = e.type().bits() * e.type().lanes();
-    int to_bits = t.bits() * t.lanes();
-    user_assert(from_bits == to_bits)
-        << "Reinterpret cast from type " << e.type()
-        << " which has " << from_bits
-        << " bits, to type " << t
-        << " which has " << to_bits << " bits\n";
-    return Internal::Call::make(t, Internal::Call::reinterpret, {std::move(e)}, Internal::Call::PureIntrinsic);
-}
+Expr reinterpret(Type t, Expr e);
 
 template<typename T>
-inline Expr reinterpret(Expr e) {
+Expr reinterpret(Expr e) {
     return reinterpret(type_of<T>(), e);
 }
 
@@ -1450,88 +878,43 @@ inline Expr reinterpret(Expr e) {
  * same type).  The result type is the wider of the two expressions.
  * Only integral types are allowed and both expressions must be signed
  * or both must be unsigned. */
-inline Expr operator&(Expr x, Expr y) {
-    match_types_bitwise(x, y, "bitwise and");
-    Type t = x.type();
-    return Internal::Call::make(t, Internal::Call::bitwise_and, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
-}
+Expr operator&(Expr x, Expr y);
 
 /** Return the bitwise and of an expression and an integer. The type
  * of the result is the type of the expression argument. */
 // @{
-inline Expr operator&(Expr x, int y) {
-    Type t = x.type();
-    Internal::check_representable(t, y);
-    return Internal::Call::make(t, Internal::Call::bitwise_and, {std::move(x), Internal::make_const(t, y)}, Internal::Call::PureIntrinsic);
-}
-
- inline Expr operator&(int x, Expr y) {
-    Type t = y.type();
-    Internal::check_representable(t, x);
-    return Internal::Call::make(t, Internal::Call::bitwise_and, {Internal::make_const(t, x), std::move(y)}, Internal::Call::PureIntrinsic);
-}
+Expr operator&(Expr x, int y);
+Expr operator&(int x, Expr y);
 // @}
 
 /** Return the bitwise or of two expressions (which need not have the
  * same type).  The result type is the wider of the two expressions.
  * Only integral types are allowed and both expressions must be signed
  * or both must be unsigned. */
-inline Expr operator|(Expr x, Expr y) {
-    match_types_bitwise(x, y, "bitwise or");
-    Type t = x.type();
-    return Internal::Call::make(t, Internal::Call::bitwise_or, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
-}
+Expr operator|(Expr x, Expr y);
 
 /** Return the bitwise or of an expression and an integer. The type of
  * the result is the type of the expression argument. */
 // @{
-inline Expr operator|(Expr x, int y) {
-    Type t = x.type();
-    Internal::check_representable(t, y);
-    return Internal::Call::make(t, Internal::Call::bitwise_or, {std::move(x), Internal::make_const(t, y)}, Internal::Call::PureIntrinsic);
-}
-
-inline Expr operator|(int x, Expr y) {
-    Type t = y.type();
-    Internal::check_representable(t, x);
-    return Internal::Call::make(t, Internal::Call::bitwise_or, {Internal::make_const(t, x), std::move(y)}, Internal::Call::PureIntrinsic);
-}
+Expr operator|(Expr x, int y);
+Expr operator|(int x, Expr y);
 // @}
 
 /** Return the bitwise xor of two expressions (which need not have the
  * same type).  The result type is the wider of the two expressions.
  * Only integral types are allowed and both expressions must be signed
  * or both must be unsigned. */
-inline Expr operator^(Expr x, Expr y) {
-    match_types_bitwise(x, y, "bitwise xor");
-    Type t = x.type();
-    return Internal::Call::make(t, Internal::Call::bitwise_xor, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
-}
+Expr operator^(Expr x, Expr y);
 
 /** Return the bitwise xor of an expression and an integer. The type
  * of the result is the type of the expression argument. */
 // @{
-inline Expr operator^(Expr x, int y) {
-    Type t = x.type();
-    Internal::check_representable(t, y);
-    return Internal::Call::make(t, Internal::Call::bitwise_xor, {std::move(x), Internal::make_const(t, y)}, Internal::Call::PureIntrinsic);
-}
-
-inline Expr operator^(int x, Expr y) {
-    Type t = y.type();
-    Internal::check_representable(t, x);
-    return Internal::Call::make(t, Internal::Call::bitwise_xor, {Internal::make_const(t, x), std::move(y)}, Internal::Call::PureIntrinsic);
-}
+Expr operator^(Expr x, int y);
+Expr operator^(int x, Expr y);
 // @}
 
 /** Return the bitwise not of an expression. */
-inline Expr operator~(Expr x) {
-    user_assert(x.defined()) << "bitwise not of undefined Expr\n";
-    user_assert(x.type().is_int() || x.type().is_uint())
-        << "Argument to bitwise not must be an integer or unsigned integer";
-    Type t = x.type();
-    return Internal::Call::make(t, Internal::Call::bitwise_not, {std::move(x)}, Internal::Call::PureIntrinsic);
-}
+Expr operator~(Expr x);
 
 /** Shift the bits of an integer value left. This is actually less
  * efficient than multiplying by 2^n, because Halide's optimization
@@ -1541,26 +924,8 @@ inline Expr operator~(Expr x) {
  * type of the result is equal to the type of the first argument. Both
  * arguments must have integer type. */
 // @{
-inline Expr operator<<(Expr x, Expr y) {
-    Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), y.type().lanes()), y);
-    user_assert(unsigned_amount.defined())
-        << "In shift left expression:\n"
-        << "   (" << x << ") << (" << y << ")\n"
-        << "   with types " << x.type() << " << " << y.type() << "\n"
-        << "the RHS must be unsigned and losslessly castable to the same size as the LHS.\n";
-
-    if (y.type().is_vector() && !x.type().is_vector()) {
-        x = Internal::Broadcast::make(x, y.type().lanes());
-    }
-
-    Type t = x.type();
-    return Internal::Call::make(t, Internal::Call::shift_left, {std::move(x), std::move(unsigned_amount)}, Internal::Call::PureIntrinsic);
-}
-inline Expr operator<<(Expr x, int y) {
-    Type t = UInt(x.type().bits(), x.type().lanes());
-    Internal::check_representable(t, y);
-    return std::move(x) << Internal::make_const(t, y);
-}
+Expr operator<<(Expr x, Expr y);
+Expr operator<<(Expr x, int y);
 // @}
 
 /** Shift the bits of an integer value right. Does sign extension for
@@ -1572,24 +937,8 @@ inline Expr operator<<(Expr x, int y) {
  * the type of the first argument. Both arguments must have integer
  * type. */
 // @{
-inline Expr operator>>(Expr x, Expr y) {
-    Expr unsigned_amount = lossless_cast(UInt(x.type().bits(), y.type().lanes()), y);
-    user_assert(unsigned_amount.defined())
-        << "In shift right expression:\n"
-        << "   (" << x << ") >> (" << y << ")\n"
-        << "   with types " << x.type() << " >> " << y.type() << "\n"
-        << "the RHS must be unsigned and losslessly castable to the same size as the LHS.\n";
-    if (y.type().is_vector() && !x.type().is_vector()) {
-        x = Internal::Broadcast::make(x, y.type().lanes());
-    }
-    Type t = x.type();
-    return Internal::Call::make(t, Internal::Call::shift_right, {std::move(x), std::move(unsigned_amount)}, Internal::Call::PureIntrinsic);
-}
-inline Expr operator>>(Expr x, int y) {
-    Type t = UInt(x.type().bits(), x.type().lanes());
-    Internal::check_representable(t, y);
-    return std::move(x) >> Internal::make_const(t, y);
-}
+Expr operator>>(Expr x, Expr y);
+Expr operator>>(Expr x, int y);
 // @}
 
 /** Linear interpolate between the two values according to a weight.
@@ -1658,118 +1007,31 @@ inline Expr operator>>(Expr x, int y) {
  *
  * \endcode
  * */
-inline Expr lerp(Expr zero_val, Expr one_val, Expr weight) {
-    user_assert(zero_val.defined()) << "lerp with undefined zero value";
-    user_assert(one_val.defined()) << "lerp with undefined one value";
-    user_assert(weight.defined()) << "lerp with undefined weight";
-
-    // We allow integer constants through, so that you can say things
-    // like lerp(0, cast<uint8_t>(x), alpha) and produce an 8-bit
-    // result. Note that lerp(0.0f, cast<uint8_t>(x), alpha) will
-    // produce an error, as will lerp(0.0f, cast<double>(x),
-    // alpha). lerp(0, cast<float>(x), alpha) is also allowed and will
-    // produce a float result.
-    if (as_const_int(zero_val)) {
-        zero_val = cast(one_val.type(), std::move(zero_val));
-    }
-    if (as_const_int(one_val)) {
-        one_val = cast(zero_val.type(), std::move(one_val));
-    }
-
-    user_assert(zero_val.type() == one_val.type())
-        << "Can't lerp between " << zero_val << " of type " << zero_val.type()
-        << " and " << one_val << " of different type " << one_val.type() << "\n";
-    user_assert((weight.type().is_uint() || weight.type().is_float()))
-        << "A lerp weight must be an unsigned integer or a float, but "
-        << "lerp weight " << weight << " has type " << weight.type() << ".\n";
-    user_assert((zero_val.type().is_float() || zero_val.type().lanes() <= 32))
-        << "Lerping between 64-bit integers is not supported\n";
-    // Compilation error for constant weight that is out of range for integer use
-    // as this seems like an easy to catch gotcha.
-    if (!zero_val.type().is_float()) {
-        const double *const_weight = as_const_float(weight);
-        if (const_weight) {
-            user_assert(*const_weight >= 0.0 && *const_weight <= 1.0)
-                << "Floating-point weight for lerp with integer arguments is "
-                << *const_weight << ", which is not in the range [0.0, 1.0].\n";
-        }
-    }
-    Type t = zero_val.type();
-    return Internal::Call::make(t, Internal::Call::lerp,
-                                {std::move(zero_val), std::move(one_val), std::move(weight)},
-                                Internal::Call::PureIntrinsic);
-}
+Expr lerp(Expr zero_val, Expr one_val, Expr weight);
 
 /** Count the number of set bits in an expression. */
-inline Expr popcount(Expr x) {
-    user_assert(x.defined()) << "popcount of undefined Expr\n";
-    Type t = x.type();
-    user_assert(t.is_uint() || t.is_int())
-        << "Argument to popcount must be an integer\n";
-    return Internal::Call::make(t, Internal::Call::popcount,
-                                {std::move(x)}, Internal::Call::PureIntrinsic);
-}
+Expr popcount(Expr x);
 
 /** Count the number of leading zero bits in an expression. If the expression is
  * zero, the result is the number of bits in the type. */
-inline Expr count_leading_zeros(Expr x) {
-    user_assert(x.defined()) << "count leading zeros of undefined Expr\n";
-    Type t = x.type();
-    user_assert(t.is_uint() || t.is_int())
-        << "Argument to count_leading_zeros must be an integer\n";
-    return Internal::Call::make(t, Internal::Call::count_leading_zeros,
-                                {std::move(x)}, Internal::Call::PureIntrinsic);
-}
+Expr count_leading_zeros(Expr x);
 
 /** Count the number of trailing zero bits in an expression. If the expression is
  * zero, the result is the number of bits in the type. */
-inline Expr count_trailing_zeros(Expr x) {
-    user_assert(x.defined()) << "count trailing zeros of undefined Expr\n";
-    Type t = x.type();
-    user_assert(t.is_uint() || t.is_int())
-        << "Argument to count_trailing_zeros must be an integer\n";
-    return Internal::Call::make(t, Internal::Call::count_trailing_zeros,
-                                {std::move(x)}, Internal::Call::PureIntrinsic);
-}
+Expr count_trailing_zeros(Expr x);
 
 /** Divide two integers, rounding towards zero. This is the typical
  * behavior of most hardware architectures, which differs from
  * Halide's division operator, which is Euclidean (rounds towards
  * -infinity). */
-inline Expr div_round_to_zero(Expr x, Expr y) {
-    user_assert(x.defined()) << "div_round_to_zero of undefined dividend\n";
-    user_assert(y.defined()) << "div_round_to_zero of undefined divisor\n";
-    Internal::match_types(x, y);
-    if (x.type().is_uint()) {
-        return std::move(x) / std::move(y);
-    }
-    user_assert(x.type().is_int()) << "First argument to div_round_to_zero is not an integer: " << x << "\n";
-    user_assert(y.type().is_int()) << "Second argument to div_round_to_zero is not an integer: " << y << "\n";
-    Type t = x.type();
-    return Internal::Call::make(t, Internal::Call::div_round_to_zero,
-                                {std::move(x), std::move(y)},
-                                Internal::Call::PureIntrinsic);
-}
+Expr div_round_to_zero(Expr x, Expr y);
 
 /** Compute the remainder of dividing two integers, when division is
  * rounding toward zero. This is the typical behavior of most hardware
  * architectures, which differs from Halide's mod operator, which is
  * Euclidean (produces the remainder when division rounds towards
  * -infinity). */
-inline Expr mod_round_to_zero(Expr x, Expr y) {
-    user_assert(x.defined()) << "mod_round_to_zero of undefined dividend\n";
-    user_assert(y.defined()) << "mod_round_to_zero of undefined divisor\n";
-    Internal::match_types(x, y);
-    if (x.type().is_uint()) {
-        return std::move(x) % std::move(y);
-    }
-    user_assert(x.type().is_int()) << "First argument to mod_round_to_zero is not an integer: " << x << "\n";
-    user_assert(y.type().is_int()) << "Second argument to mod_round_to_zero is not an integer: " << y << "\n";
-    Type t = x.type();
-    return Internal::Call::make(t, Internal::Call::mod_round_to_zero,
-                                {std::move(x), std::move(y)},
-                                Internal::Call::PureIntrinsic);
-}
+Expr mod_round_to_zero(Expr x, Expr y);
 
 /** Return a random variable representing a uniformly distributed
  * float in the half-open interval [0.0f, 1.0f). For random numbers of
@@ -1800,70 +1062,15 @@ inline Expr mod_round_to_zero(Expr x, Expr y) {
  *
  * This function vectorizes cleanly.
  */
-inline Expr random_float(Expr seed = Expr()) {
-    // Random floats get even IDs
-    static std::atomic<int> counter;
-    int id = (counter++)*2;
-
-    std::vector<Expr> args;
-    if (seed.defined()) {
-        user_assert(seed.type() == Int(32))
-            << "The seed passed to random_float must have type Int(32), but instead is "
-            << seed << " of type " << seed.type() << "\n";
-        args.push_back(std::move(seed));
-    }
-    args.push_back(id);
-
-    // This is (surprisingly) pure - it's a fixed psuedo-random
-    // function of its inputs.
-    return Internal::Call::make(Float(32), Internal::Call::random,
-                                args, Internal::Call::PureIntrinsic);
-}
+Expr random_float(Expr seed = Expr());
 
 /** Return a random variable representing a uniformly distributed
  * unsigned 32-bit integer. See \ref random_float. Vectorizes cleanly. */
-inline Expr random_uint(Expr seed = Expr()) {
-    // Random ints get odd IDs
-    static std::atomic<int> counter;
-    int id = (counter++)*2 + 1;
-
-    std::vector<Expr> args;
-    if (seed.defined()) {
-        user_assert(seed.type() == Int(32) || seed.type() == UInt(32))
-            << "The seed passed to random_int must have type Int(32) or UInt(32), but instead is "
-            << seed << " of type " << seed.type() << "\n";
-        args.push_back(std::move(seed));
-    }
-    args.push_back(id);
-
-    return Internal::Call::make(UInt(32), Internal::Call::random,
-                                args, Internal::Call::PureIntrinsic);
-}
+Expr random_uint(Expr seed = Expr());
 
 /** Return a random variable representing a uniformly distributed
  * 32-bit integer. See \ref random_float. Vectorizes cleanly. */
-inline Expr random_int(Expr seed = Expr()) {
-    return cast<int32_t>(random_uint(std::move(seed)));
-}
-
-// Secondary args to print can be Exprs or const char *
-namespace Internal {
-inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &args) {
-}
-
-template<typename ...Args>
-inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &args, const char *arg, Args&&... more_args) {
-    args.push_back(Expr(std::string(arg)));
-    collect_print_args(args, std::forward<Args>(more_args)...);
-}
-
-template<typename ...Args>
-inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &args, Expr arg, Args&&... more_args) {
-    args.push_back(std::move(arg));
-    collect_print_args(args, std::forward<Args>(more_args)...);
-}
-}
-
+Expr random_int(Expr seed = Expr());
 
 /** Create an Expr that prints out its value whenever it is
  * evaluated. It also prints out everything else in the arguments
@@ -1923,11 +1130,6 @@ inline HALIDE_NO_USER_CODE_INLINE Expr require(Expr condition, Expr value, Args&
     Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
     return require(std::move(condition), collected_args);
 }
-
-namespace Internal {
-Expr requirement_failed_error(Expr condition, const std::vector<Expr> &args);
-}
-
 // @}
 
 /** Return an undef value of the given type. Halide skips stores that
@@ -1948,20 +1150,12 @@ Expr requirement_failed_error(Expr condition, const std::vector<Expr> &args);
  * Use this feature with great caution, as you can use it to load from
  * uninitialized memory.
  */
-inline Expr undef(Type t) {
-    return Internal::Call::make(t, Internal::Call::undef,
-                                std::vector<Expr>(),
-                                Internal::Call::PureIntrinsic);
-}
+Expr undef(Type t);
 
 template<typename T>
 inline Expr undef() {
     return undef(type_of<T>());
 }
-
-namespace Internal {
-Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_values);
-}  // namespace Internal
 
 /** Control the values used in the memoization cache key for memoize.
  * Normally parameters and other external dependencies are
@@ -2010,19 +1204,11 @@ inline HALIDE_NO_USER_CODE_INLINE Expr memoize_tag(Expr result, Args&&... args) 
  * use the boundary condition helpers in the BoundaryConditions
  * namespace instead.
  */
-inline Expr likely(Expr e) {
-    Type t = e.type();
-    return Internal::Call::make(t, Internal::Call::likely,
-                                {std::move(e)}, Internal::Call::PureIntrinsic);
-}
+Expr likely(Expr e);
 
 /** Equivalent to likely, but only triggers a loop partitioning if
  * found in an innermost loop. */
-inline Expr likely_if_innermost(Expr e) {
-    Type t = e.type();
-    return Internal::Call::make(t, Internal::Call::likely_if_innermost,
-                                {std::move(e)}, Internal::Call::PureIntrinsic);
-}
+Expr likely_if_innermost(Expr e);
 
 /** Cast an expression to the halide type corresponding to the C++
  * type T. As part of the cast, clamp to the minimum and maximum
@@ -2041,11 +1227,7 @@ Expr saturating_cast(Type t, Expr e);
  * all backends. (E.g. it is difficult to do this for C++ code
  * generation as it depends on the compiler flags used to compile the
  * generated code. */
-inline Expr strict_float(Expr e) {
-    Type t = e.type();
-    return Internal::Call::make(t, Internal::Call::strict_float,
-                                {std::move(e)}, Internal::Call::PureIntrinsic);
-}
+Expr strict_float(Expr e);
 
 /** Create an Expr that that promises another Expr is clamped but do
  * not generate code to check the assertion or modify the value. No


### PR DESCRIPTION
IROperator.h has way too much code in it; this moves almost all of the non-templated inline functions into IROperator.cpp (along with some drive-by anon-namespacing of internal functions). 

This is mostly just an attempt at hygiene, as ~none of these functions really needed to be inlined; that said, this does seem to produce a small but measurable improvement in compilation performance on my Linux box (recompiling libHalide.a from scratch drops to about 97% of user time).

Note that I didn't attempt to update any calling conventions; I suspect that updating various calls to pass Expr and/or Type by const-ref (rather than value) might be profitable.

