### PR TITLE
Python: import imread/imsave from imageio instead of scipy.misc

### DIFF
--- a/python_bindings/apps/bilateral_grid.py
+++ b/python_bindings/apps/bilateral_grid.py
@@ -8,7 +8,7 @@ from __future__ import division
 import halide as hl
 
 import numpy as np
-from scipy.misc import imread, imsave
+from imageio import imread, imsave
 import os.path
 
 def get_bilateral_grid(input, r_sigma, s_sigma):

--- a/python_bindings/apps/blur.py
+++ b/python_bindings/apps/blur.py
@@ -1,7 +1,7 @@
 import halide as hl
 
 import numpy as np
-from scipy.misc import imread, imsave
+from imageio import imread, imsave
 import os.path
 
 def get_blur(input):

--- a/python_bindings/apps/erode.py
+++ b/python_bindings/apps/erode.py
@@ -5,7 +5,7 @@ Erode application using Python Halide bindings
 import halide as hl
 
 import numpy as np
-from scipy.misc import imread, imsave
+from imageio import imread, imsave
 import os.path
 
 def get_erode(input):

--- a/python_bindings/apps/interpolate.py
+++ b/python_bindings/apps/interpolate.py
@@ -9,7 +9,7 @@ import time, sys
 import halide as hl
 
 from datetime import datetime
-from scipy.misc import imread, imsave
+from imageio import imread, imsave
 import numpy as np
 import os.path
 

--- a/python_bindings/apps/local_laplacian.py
+++ b/python_bindings/apps/local_laplacian.py
@@ -8,8 +8,7 @@ from __future__ import division
 import halide as hl
 
 import numpy as np
-from scipy.misc import imread, imsave
-
+from imageio import imread, imsave
 import os.path
 
 

--- a/python_bindings/tutorial/lesson_02_input_image.py
+++ b/python_bindings/tutorial/lesson_02_input_image.py
@@ -20,7 +20,7 @@
 
 import halide as hl
 import numpy as np
-from scipy.misc import imread, imsave
+from imageio import imread, imsave
 import os.path
 
 def main():

--- a/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
+++ b/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
@@ -24,8 +24,7 @@ import halide as hl
 
 # Support code for loading pngs.
 #include "image_io.h"
-from scipy.misc import imread, imsave
-
+from imageio import imread, imsave
 import os.path
 
 def main():

--- a/python_bindings/tutorial/lesson_09_update_definitions.py
+++ b/python_bindings/tutorial/lesson_09_update_definitions.py
@@ -33,7 +33,7 @@ import halide as hl
 
 # Support code for loading pngs.
 #include "image_io.h"
-from scipy.misc import imread
+from imageio import imread
 import numpy as np
 import os.path
 

--- a/python_bindings/tutorial/lesson_12_using_the_gpu.py
+++ b/python_bindings/tutorial/lesson_12_using_the_gpu.py
@@ -24,7 +24,7 @@ import halide as hl
 
 # Include some support code for loading pngs.
 #include "image_io.h"
-from scipy.misc import imread
+from imageio import imread
 import os.path
 
 # Include a clock to do performance testing.
@@ -218,7 +218,7 @@ class MyPipeline:
     def test_performance(self):
         # Test the performance of the scheduled MyPipeline.
 
-        output = hl.Buffer(hl.UInt(8), 
+        output = hl.Buffer(hl.UInt(8),
                         [self.input.width(), self.input.height(), self.input.channels()])
 
         # Run the filter once to initialize any GPU runtime state.


### PR DESCRIPTION
imread and imsave are deprecated and not present in current versions of scipy; using equivalent functions in imageio is the recommended replacement.