### PR TITLE
Don't call memset(0) on halide_buffer_t

### DIFF
--- a/src/PythonExtensionGen.cpp
+++ b/src/PythonExtensionGen.cpp
@@ -198,7 +198,7 @@ static __attribute__((unused)) int _convert_py_buffer_to_halide(
                      buf.len, buf.shape[0] * buf.strides[0]);
         return -1;
     }
-    memset(out, 0, sizeof(*out));
+    *out = halide_buffer_t();
     if (!buf.format) {
         out->type.code = halide_type_uint;
         out->type.bits = 8;


### PR DESCRIPTION
It's nontrivial enough to generate a warning; use zero-init form instead