### PR TITLE
fix python_bindings bad float cast

### DIFF
--- a/python_bindings/correctness/float_precision_test.py
+++ b/python_bindings/correctness/float_precision_test.py
@@ -1,3 +1,5 @@
+import sys
+
 import halide as hl
 import numpy
 
@@ -7,8 +9,11 @@ def test():
         x = hl.Var("x")
         f = hl.Func("f")
         f[x] = x * c
-        for i, v in enumerate(numpy.asarray(f.realize(10))):
-            assert v == (i * c), "{}[{}]: {} != {}".format(i, c, v, (i * c))
+        for i, hl_value in enumerate(numpy.asarray(f.realize(10))):
+            py_value = (i * c)
+            delta = hl_value - py_value
+            check = delta < sys.float_info.epsilon
+            assert check, "{}[{}]: {} != {}".format(i, c, hl_value, py_value)
 
     test_pattern(0.123456789012345678)
     test_pattern(0.987654321098765432)

--- a/python_bindings/correctness/float_precision_test.py
+++ b/python_bindings/correctness/float_precision_test.py
@@ -1,4 +1,4 @@
-import sys
+import math
 
 import halide as hl
 import numpy
@@ -11,8 +11,7 @@ def test():
         f[x] = x * c
         for i, hl_value in enumerate(numpy.asarray(f.realize(10))):
             py_value = (i * c)
-            delta = hl_value - py_value
-            check = delta < sys.float_info.epsilon
+            check = math.isclose(hl_value, py_value)
             assert check, "{}[{}]: {} != {}".format(i, c, hl_value, py_value)
 
     test_pattern(0.123456789012345678)

--- a/python_bindings/correctness/float_precision_test.py
+++ b/python_bindings/correctness/float_precision_test.py
@@ -1,0 +1,18 @@
+import halide as hl
+import numpy
+
+
+def test():
+    def test_pattern(c):
+        x = hl.Var("x")
+        f = hl.Func("f")
+        f[x] = x * c
+        for i, v in enumerate(numpy.asarray(f.realize(10))):
+            assert v == (i * c), "{}[{}]: {} != {}".format(i, c, v, (i * c))
+
+    test_pattern(0.123456789012345678)
+    test_pattern(0.987654321098765432)
+
+
+if __name__ == "__main__":
+    test()

--- a/python_bindings/correctness/float_precision_test.py
+++ b/python_bindings/correctness/float_precision_test.py
@@ -8,9 +8,9 @@ def test():
     def test_pattern(c):
         x = hl.Var("x")
         f = hl.Func("f")
-        f[x] = x * c
+        f[x] = x * c * (hl.f64(0.1) + hl.f64(0.2))
         for i, hl_value in enumerate(numpy.asarray(f.realize(10))):
-            py_value = (i * c)
+            py_value = i * c * (0.1 + 0.2)
             check = math.isclose(hl_value, py_value)
             assert check, "{}[{}]: {} != {}".format(i, c, hl_value, py_value)
 

--- a/python_bindings/src/PyExpr.cpp
+++ b/python_bindings/src/PyExpr.cpp
@@ -22,7 +22,6 @@ void define_expr(py::module &m) {
             // PyBind11 searches in declared order,
             // int should be tried before float conversion
             .def(py::init<int>())
-            //.def(py::init<float>())
             .def(py::init<double>())
             .def(py::init<std::string>())
 

--- a/python_bindings/src/PyExpr.cpp
+++ b/python_bindings/src/PyExpr.cpp
@@ -22,7 +22,7 @@ void define_expr(py::module &m) {
             // PyBind11 searches in declared order,
             // int should be tried before float conversion
             .def(py::init<int>())
-            .def(py::init<float>())
+            //.def(py::init<float>())
             .def(py::init<double>())
             .def(py::init<std::string>())
 


### PR DESCRIPTION
always double to float cast.

----------

Test code

```python
import halide
import numpy

def run_test():
    test = halide.Func("test")
    x = halide.Var("x")
    test[x] = x * halide.f64(0.12345678901234)
    for i, val in enumerate(numpy.asarray(test.realize(10))):
        print("{}: {:.20f}".format(i, val))
```

before:
```
>>> run_test()
0: 0.00000000000000000000
1: 0.12345679104328155518
2: 0.24691358208656311035
3: 0.37037037312984466553
4: 0.49382716417312622070
5: 0.61728395521640777588
6: 0.74074074625968933105
7: 0.86419753730297088623
8: 0.98765432834625244141
9: 1.11111111938953399658
```

after:
```
>>> run_test()
0: 0.00000000000000000000
1: 0.12345678901234000135
2: 0.24691357802468000271
3: 0.37037036703701997631
4: 0.49382715604936000542
5: 0.61728394506170003453
6: 0.74074073407403995262
7: 0.86419752308637998173
8: 0.98765431209872001084
9: 1.11111110111105992893
```