### PR TITLE
Print types when not inferrable from context

### DIFF
--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -203,14 +203,14 @@ void IRPrinter::test() {
         "let y = 17\n"
         "assert((y >= 3), halide_error_param_too_small_i64(\"y\", y, 3))\n"
         "produce buf {\n"
-        "  parallel (x, -2, (y + 2)) {\n"
-        "    buf[(y - 1)] = ((x*17)/(x - 3))\n"
-        "  }\n"
+        " parallel (x, -2, (y + 2)) {\n"
+        "  buf[(y - 1)] = ((x*17)/(x - 3))\n"
+        " }\n"
         "}\n"
         "consume buf {\n"
-        "  vectorized (x, 0, y) {\n"
-        "    out[x] = (buf((x % 3)) + 1)\n"
-        "  }\n"
+        " vectorized (x, 0, y) {\n"
+        "  out[x] = (buf((x % 3)) + 1)\n"
+        " }\n"
         "}\n";
 
     if (source.str() != correct_source) {
@@ -421,8 +421,10 @@ void IRPrinter::visit(const Cast *op) {
 }
 
 void IRPrinter::visit(const Variable *op) {
-    // omit the type
-    // stream << op->name << "." << op->type;
+    if (!known_type.contains(op->name) &&
+        (op->type != Int(32))) {
+        stream << '(' << op->type << ')';
+    }
     stream << op->name;
 }
 
@@ -567,6 +569,9 @@ void IRPrinter::visit(const Load *op) {
     if (has_pred) {
         stream << "(";
     }
+    if (!known_type.contains(op->name)) {
+        stream << '(' << op->type << ')';
+    }
     stream << op->name << "[";
     print(op->index);
     if (show_alignment) {
@@ -596,18 +601,17 @@ void IRPrinter::visit(const Broadcast *op) {
 
 void IRPrinter::visit(const Call *op) {
     // TODO: Print indication of C vs C++?
-    stream << op->name << "(";
-    if (op->is_intrinsic(Call::reinterpret) ||
-        op->is_intrinsic(Call::make_struct)) {
-        // For calls that define a type that isn't just a function of
-        // the types of the args, we also print the type.
-        stream << op->type << ", ";
+    if (!known_type.contains(op->name) &&
+        (op->type != Int(32))) {
+        stream << '(' << op->type << ')';
     }
+    stream << op->name << "(";
     print_list(op->args);
     stream << ")";
 }
 
 void IRPrinter::visit(const Let *op) {
+    ScopedBinding<> bind(known_type, op->name);
     stream << "(let " << op->name << " = ";
     print(op->value);
     stream << " in ";
@@ -616,6 +620,7 @@ void IRPrinter::visit(const Let *op) {
 }
 
 void IRPrinter::visit(const LetStmt *op) {
+    ScopedBinding<> bind(known_type, op->name);
     do_indent();
     stream << "let " << op->name << " = ";
     print(op->value);
@@ -640,15 +645,15 @@ void IRPrinter::visit(const ProducerConsumer *op) {
     } else {
         stream << "consume " << op->name << " {\n";
     }
-    indent += 2;
+    indent++;
     print(op->body);
-    indent -= 2;
+    indent--;
     do_indent();
     stream << "}\n";
 }
 
 void IRPrinter::visit(const For *op) {
-
+    ScopedBinding<> bind(known_type, op->name);
     do_indent();
     stream << op->for_type << op->device_api << " (" << op->name << ", ";
     print(op->min);
@@ -656,9 +661,9 @@ void IRPrinter::visit(const For *op) {
     print(op->extent);
     stream << ") {\n";
 
-    indent += 2;
+    indent++;
     print(op->body);
-    indent -= 2;
+    indent--;
 
     do_indent();
     stream << "}\n";
@@ -671,11 +676,26 @@ void IRPrinter::visit(const Acquire *op) {
     stream << ", ";
     print(op->count);
     stream << ") {\n";
-    indent += 2;
+    indent++;
     print(op->body);
-    indent -= 2;
+    indent--;
     do_indent();
     stream << "}\n";
+}
+
+void IRPrinter::print_lets(const Let *let) {
+    do_indent();
+    ScopedBinding<> bind(known_type, let->name);
+    stream << "let " << let->name << " = ";
+    print(let->value);
+    stream << " in\n";
+    if (const Let *next = let->body.as<Let>()) {
+        print_lets(next);
+    } else {
+        do_indent();
+        print(let->body);
+        stream << "\n";
+    }
 }
 
 void IRPrinter::visit(const Store *op) {
@@ -683,8 +703,10 @@ void IRPrinter::visit(const Store *op) {
     const bool has_pred = !is_one(op->predicate);
     const bool show_alignment = op->value.type().is_vector() && (op->alignment.modulus > 1);
     if (has_pred) {
-        stream << "predicate (" << op->predicate << ")\n";
-        indent += 2;
+        stream << "predicate (";
+        print(op->predicate);
+        stream << ")\n";
+        indent++;
         do_indent();
     }
     stream << op->name << "[";
@@ -696,10 +718,19 @@ void IRPrinter::visit(const Store *op) {
                << op->alignment.remainder << ")";
     }
     stream << "] = ";
-    print(op->value);
+    if (const Let *let = op->value.as<Let>()) {
+        // Use some nicer line breaks for containing Lets
+        stream << '\n';
+        indent += 2;
+        print_lets(let);
+        indent -= 2;
+    } else {
+        // Just print the value in-line
+        print(op->value);
+    }
     stream << '\n';
     if (has_pred) {
-        indent -= 2;
+        indent--;
     }
 }
 
@@ -720,6 +751,7 @@ void IRPrinter::visit(const Provide *op) {
 }
 
 void IRPrinter::visit(const Allocate *op) {
+    ScopedBinding<> bind(known_type, op->name);
     do_indent();
     stream << "allocate " << op->name << "[" << op->type;
     for (size_t i = 0; i < op->extents.size(); i++) {
@@ -737,7 +769,9 @@ void IRPrinter::visit(const Allocate *op) {
     if (op->new_expr.defined()) {
         stream << "\n";
         do_indent();
-        stream << " custom_new { " << op->new_expr << " }";
+        stream << " custom_new { ";
+        print(op->new_expr);
+        stream << " }";
     }
     if (!op->free_function.empty()) {
         stream << "\n";
@@ -755,6 +789,7 @@ void IRPrinter::visit(const Free *op) {
 }
 
 void IRPrinter::visit(const Realize *op) {
+    ScopedBinding<> bind(known_type, op->name);
     do_indent();
     stream << "realize " << op->name << "(";
     for (size_t i = 0; i < op->bounds.size(); i++) {
@@ -775,9 +810,9 @@ void IRPrinter::visit(const Realize *op) {
     }
     stream << " {\n";
 
-    indent += 2;
+    indent++;
     print(op->body);
-    indent -= 2;
+    indent--;
 
     do_indent();
     stream << "}\n";
@@ -787,8 +822,10 @@ void IRPrinter::visit(const Prefetch *op) {
     do_indent();
     const bool has_cond = !is_one(op->condition);
     if (has_cond) {
-        stream << "if (" << op->condition << ") {\n";
-        indent += 2;
+        stream << "if (";
+        print(op->condition);
+        stream << ") {\n";
+        indent++;
         do_indent();
     }
     stream << "prefetch " << op->name << "(";
@@ -802,7 +839,7 @@ void IRPrinter::visit(const Prefetch *op) {
     }
     stream << ")\n";
     if (has_cond) {
-        indent -= 2;
+        indent--;
         do_indent();
         stream << "}\n";
     }
@@ -828,9 +865,9 @@ void IRPrinter::visit(const Fork *op) {
     stream << "fork ";
     for (Stmt s : stmts) {
         stream << "{\n";
-        indent += 2;
+        indent++;
         print(s);
-        indent -= 2;
+        indent--;
         do_indent();
         stream << "} ";
     }
@@ -840,10 +877,12 @@ void IRPrinter::visit(const Fork *op) {
 void IRPrinter::visit(const IfThenElse *op) {
     do_indent();
     while (1) {
-        stream << "if (" << op->condition << ") {\n";
-        indent += 2;
+        stream << "if (";
+        print(op->condition);
+        stream << ") {\n";
+        indent++;
         print(op->then_case);
-        indent -= 2;
+        indent--;
 
         if (!op->else_case.defined()) {
             break;
@@ -856,9 +895,9 @@ void IRPrinter::visit(const IfThenElse *op) {
         } else {
             do_indent();
             stream << "} else {\n";
-            indent += 2;
+            indent++;
             print(op->else_case);
-            indent -= 2;
+            indent--;
             break;
         }
     }
@@ -886,13 +925,14 @@ void IRPrinter::visit(const Shuffle *op) {
     } else if (op->is_extract_element()) {
         stream << "extract_element(";
         print_list(op->vectors);
-        stream << ", " << op->indices[0];
-        stream << ")";
+        stream << ", " << op->indices[0] << ")";
     } else if (op->is_slice()) {
         stream << "slice_vectors(";
         print_list(op->vectors);
-        stream << ", " << op->slice_begin() << ", " << op->slice_stride() << ", " << op->indices.size();
-        stream << ")";
+        stream << ", " << op->slice_begin()
+               << ", " << op->slice_stride()
+               << ", " << op->indices.size()
+               << ")";
     } else {
         stream << "shuffle(";
         print_list(op->vectors);

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -18,6 +18,7 @@
 
 #include "IRVisitor.h"
 #include "Module.h"
+#include "Scope.h"
 
 namespace Halide {
 
@@ -113,6 +114,13 @@ protected:
 
     /** Emit spaces according to the current indentation level */
     void do_indent();
+
+    /** The symbols whose types can be inferred from values printed
+     * already. */
+    Scope<> known_type;
+
+    /** A helper for printing a chain of lets with line breaks */
+    void print_lets(const Let *let);
 
     void visit(const IntImm *) override;
     void visit(const UIntImm *) override;


### PR DESCRIPTION
It's currently hard to parse Halide Exprs in isolation, because the types of Vars, Loads, and similar depend on the context, which is not always present. This PR tracks which names have a type that can be inferred from the context, and prints the type too when they're not (and when they're not just Int(32) - having a default case cuts down on clutter). With this change a hypothetical parser would just need to track a Scope from strings to types.

Also as a drive-by I added prettier printing of chains of lets around store nodes. They can get large right now. 

This PR is related to #4233 

Here's a sample of the new IR printing excerpted from local laplacian. The most obvious change in the newlines, but note also that `beta` is now `(float32)beta`. All of the other types can be inferred from the context.

```
...
                 produce f125 {
                  consume f126 {
                   let t5569 = (((output.s0.v1.v1 + t5504)*t5105) + t5503)
                   let t5568 = (output.s0.v1.v1 + t5506)
                   for (f125.s0.v0.v0, 0, t5163) {
                    let f125.s0.v0.v28.base.s = min((f125.s0.v0.v0*8), t5131)
                    f125[ramp(f125.s0.v0.v28.base.s, 1, 8)] = 
                      let t4086 = (((f125.s0.v0.v28.base.s + output.min.0)/2) + (((f125.s0.v0.v28.base.s + output.min.0) % 2)*2)) in
                      let t4090 = ((t5568/2) + ((t5568 % 2)*2)) in
                      let t4093 = f2[ramp((f125.s0.v0.v28.base.s + t5569), 2, 4)] in
                      let t4094 = (t4093*x4(t5130)) in
                      let t4095.s = min(int32x4(t4094), x4(t5065)) in
                      let t4096 = ((max(min(int32x4((t4094*x4(256.000000f))), x4(t5106)), x4(0)) - x4(f0.v0.min_realized.s)) - (max(t4095.s, x4(0))*x4(256))) in
                      let t4097 = float32x4(max(t4095.s, x4(0))) in
                      let t4098 = (t4097*x4(t5107)) in
                      let t4103 = ((max(t4095.s, x4(0)) - x4(t5066))*x4((t5097 + 1))) in
                      let t4104 = (((f125.s0.v0.v28.base.s + output.min.0)/2) + ((((t5568/2) + t5096)*f4.stride.1) - f4.v0.min_realized)) in
                      let t4107 = (((f125.s0.v0.v28.base.s + output.min.0)/2) + (((t4090 + t5096)*f4.stride.1) - f4.v0.min_realized)) in
                      let t4108 = (float32x4((max(t4095.s, x4(0)) + x4(1)))*x4(t5107)) in
                      let t4112 = (((f125.s0.v0.v28.base.s + t5134)/2) + (((f125.s0.v0.v28.base.s + t5134) % 2)*2)) in
                      let t4115 = f2[ramp(((f125.s0.v0.v28.base.s + t5569) + 1), 2, 4)] in
                      let t4116 = (t4115*x4(t5130)) in
                      let t4117.s = min(int32x4(t4116), x4(t5065)) in
                      let t4118 = ((max(min(int32x4((t4116*x4(256.000000f))), x4(t5106)), x4(0)) - x4(f0.v0.min_realized.s)) - (max(t4117.s, x4(0))*x4(256))) in
                      let t4119 = float32x4(max(t4117.s, x4(0))) in
                      let t4120 = (t4119*x4(t5107)) in
                      let t4122 = ((max(t4117.s, x4(0)) - x4(t5066))*x4((t5097 + 1))) in
                      let t4123 = (((f125.s0.v0.v28.base.s + t5134)/2) + ((((t5568/2) + t5096)*f4.stride.1) - f4.v0.min_realized)) in
                      let t4125 = (((f125.s0.v0.v28.base.s + t5134)/2) + (((t4090 + t5096)*f4.stride.1) - f4.v0.min_realized)) in
                      let t4126 = (float32x4((max(t4117.s, x4(0)) + x4(1)))*x4(t5107)) in
                      interleave_vectors((((((f126[ramp((((((t5568/2) % 8)*t5501) + (t4086 - t5502)) + -1), 1, 4)] + (f126[ramp(((((t5568/2) % 8)*t5501) + (((f125.s0.v0.v28.base.s + output.min.0)/2) - t5502)), 1, 4)]*x4(3.000000f)))*x4(3.000000f)) + (f126[ramp((((((t4090 + 7) % 8)*t5501) + (t4086 - t5502)) + -1), 1, 4)] + (f126[ramp(((((t4090 + 7) % 8)*t5501) + (((f125.s0.v0.v28.base.s + output.min.0)/2) - t5502)), 1, 4)]*x4(3.000000f))))*x4(0.062500f)) + ((((f0[(t4096 + x4(256))] + (((t4093 - t4098)*x4((float32)beta)) + t4098)) - ((((f4[(ramp(((((((t5568/2) + t5096)*f4.stride.1) - f4.v0.min_realized) + t4086) + -1), 1, 4) + t4103)] + (f4[(ramp(t4104, 1, 4) + t4103)]*x4(3.000000f)))*x4(3.000000f)) + (f4[(ramp(((((((t4090 + t5096)*f4.stride.1) - f4.v0.min_realized) + t4086) - f4.stride.1) + -1), 1, 4) + t4103)] + (f4[(ramp((t4107 - f4.stride.1), 1, 4) + t4103)]*x4(3.000000f))))*x4(0.062500f)))*((t4097 - t4094) + x4(1.000000f))) + ((t4094 - t4097)*((f0[t4096] + (((t4093 - t4108)*x4((float32)beta)) + t4108)) - ((((f4[(ramp(((((((t5568/2) + t5096)*f4.stride.1) - f4.v0.min_realized) + t4086) + t5097), 1, 4) + t4103)] + (f4[(ramp(((t4104 + t5097) + 1), 1, 4) + t4103)]*x4(3.000000f)))*x4(3.000000f)) + (f4[(ramp(((t5097 - f4.stride.1) + ((((t4090 + t5096)*f4.stride.1) - f4.v0.min_realized) + t4086)), 1, 4) + t4103)] + (f4[(ramp((((t5097 - f4.stride.1) + t4107) + 1), 1, 4) + t4103)]*x4(3.000000f))))*x4(0.062500f)))))), (((((f126[ramp((((((t5568/2) % 8)*t5501) + (t4112 - t5502)) + -1), 1, 4)] + (f126[ramp(((((t5568/2) % 8)*t5501) + (((f125.s0.v0.v28.base.s + t5134)/2) - t5502)), 1, 4)]*x4(3.000000f)))*x4(3.000000f)) + (f126[ramp((((((t4090 + 7) % 8)*t5501) + (t4112 - t5502)) + -1), 1, 4)] + (f126[ramp(((((t4090 + 7) % 8)*t5501) + (((f125.s0.v0.v28.base.s + t5134)/2) - t5502)), 1, 4)]*x4(3.000000f))))*x4(0.062500f)) + ((((f0[(t4118 + x4(256))] + (((t4115 - t4120)*x4((float32)beta)) + t4120)) - ((((f4[(ramp(((((((t5568/2) + t5096)*f4.stride.1) - f4.v0.min_realized) + t4112) + -1), 1, 4) + t4122)] + (f4[(ramp(t4123, 1, 4) + t4122)]*x4(3.000000f)))*x4(3.000000f)) + (f4[(ramp(((((((t4090 + t5096)*f4.stride.1) - f4.v0.min_realized) + t4112) - f4.stride.1) + -1), 1, 4) + t4122)] + (f4[(ramp((t4125 - f4.stride.1), 1, 4) + t4122)]*x4(3.000000f))))*x4(0.062500f)))*((t4119 - t4116) + x4(1.000000f))) + ((t4116 - t4119)*((f0[t4118] + (((t4115 - t4126)*x4((float32)beta)) + t4126)) - ((((f4[(ramp(((((((t5568/2) + t5096)*f4.stride.1) - f4.v0.min_realized) + t4112) + t5097), 1, 4) + t4122)] + (f4[(ramp(((t4123 + t5097) + 1), 1, 4) + t4122)]*x4(3.000000f)))*x4(3.000000f)) + (f4[(ramp(((t5097 - f4.stride.1) + ((((t4090 + t5096)*f4.stride.1) - f4.v0.min_realized) + t4112)), 1, 4) + t4122)] + (f4[(ramp((((t5097 - f4.stride.1) + t4125) + 1), 1, 4) + t4122)]*x4(3.000000f))))*x4(0.062500f)))))))

                   }
                  }
                 }

...
```

