### PR TITLE
Use $(MAKE) instead of make for test_python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2011,7 +2011,7 @@ benchmark_apps: $(BENCHMARK_APPS)
 
 .PHONY: test_python2
 test_python2: distrib $(BIN_DIR)/host/runtime.a
-	make -C $(ROOT_DIR)/python_bindings \
+	$(MAKE) -C $(ROOT_DIR)/python_bindings \
 		-f $(ROOT_DIR)/python_bindings/Makefile \
 		test \
 		HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
@@ -2021,7 +2021,7 @@ test_python2: distrib $(BIN_DIR)/host/runtime.a
 
 .PHONY: test_python
 test_python: distrib $(BIN_DIR)/host/runtime.a
-	make -C $(ROOT_DIR)/python_bindings \
+	$(MAKE) -C $(ROOT_DIR)/python_bindings \
 		-f $(ROOT_DIR)/python_bindings/Makefile \
 		test \
 		HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \


### PR DESCRIPTION
This allows the -j parameter to be propagated properly to the submake, allowing much faster build times. (On my Linux box, `make -j72 test_python` goes from 6m30s -> 51s in realtime)