### PR TITLE
Explicitly enable RTTI in retrain_cost_model (cmdline.h requires it)

### DIFF
--- a/apps/support/autoscheduler.inc
+++ b/apps/support/autoscheduler.inc
@@ -68,7 +68,7 @@ $(AUTOSCHED_BIN)/retrain_cost_model: $(AUTOSCHED_SRC)/retrain_cost_model.cpp \
 									$(AUTOSCHED_WEIGHT_OBJECTS) \
 									$(AUTOSCHED_BIN)/auto_schedule_runtime.a
 	@mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) -Wall -I ../support -I $(AUTOSCHED_BIN)/cost_model $(OPTIMIZE) $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(USE_OPEN_MP)
+	$(CXX) $(CXXFLAGS) -frtti -Wall -I ../support -I $(AUTOSCHED_BIN)/cost_model $(OPTIMIZE) $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(USE_OPEN_MP)
 
 $(AUTOSCHED_BIN)/featurization_to_sample: $(AUTOSCHED_SRC)/featurization_to_sample.cpp
 	@mkdir -p $(@D)


### PR DESCRIPTION
attn @shubhamp-ca 