### PR TITLE
Various followup cleanups to 'Outputs' change

### DIFF
--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -200,9 +200,6 @@ void define_func(py::module &m) {
         .def("compile_to_file", &Func::compile_to_file,
             py::arg("filename_prefix"), py::arg("arguments"), py::arg("fn_name") = "", py::arg("target") = get_target_from_environment())
 
-        .def("compile_to_python_extension", &Func::compile_to_python_extension,
-            py::arg("filename_prefix"), py::arg("arguments"), py::arg("fn_name") = "", py::arg("target") = get_target_from_environment())
-
         .def("compile_to_static_library", &Func::compile_to_static_library,
             py::arg("filename_prefix"), py::arg("arguments"), py::arg("fn_name") = "", py::arg("target") = get_target_from_environment())
 

--- a/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
+++ b/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
@@ -62,8 +62,11 @@ def main():
     # For AOT-compiled code, we need to explicitly declare the
     # arguments to the routine. This routine takes two. Arguments are
     # usually Params or ImageParams.
-    brighter.compile_to_file("lesson_10_halide", [input, offset], "lesson_10_halide")
-    brighter.compile_to_python_extension("lesson_10_halide.py.cpp", [input, offset], "lesson_10_halide")
+    fname = "lesson_10_halide"
+    brighter.compile_to({hl.Output.object: "lesson_10_halide.o",
+                         hl.Output.c_header: "lesson_10_halide.h",
+                         hl.Output.python_extension: "lesson_10_halide.py.cpp"},
+                         [input, offset], "lesson_10_halide")
 
     print("Halide pipeline compiled, but not yet run.")
 

--- a/src/BoundaryConditions.cpp
+++ b/src/BoundaryConditions.cpp
@@ -10,7 +10,7 @@ Func repeat_edge(const Func &source,
     user_assert(args.size() >= bounds.size()) <<
         "repeat_edge called with more bounds (" << bounds.size() <<
         ") than dimensions (" << args.size() << ") Func " <<
-        source.name() << "has.\n";
+        source.name() << " has.\n";
 
     std::vector<Expr> actuals;
     for (size_t i = 0; i < bounds.size(); i++) {
@@ -44,7 +44,7 @@ Func constant_exterior(const Func &source, Tuple value,
     user_assert(args.size() >= bounds.size()) <<
         "constant_exterior called with more bounds (" << bounds.size() <<
         ") than dimensions (" << source_args.size() << ") Func " <<
-        source.name() << "has.\n";
+        source.name() << " has.\n";
 
     Expr out_of_bounds = cast<bool>(false);
     for (size_t i = 0; i < bounds.size(); i++) {
@@ -88,7 +88,7 @@ Func repeat_image(const Func &source,
     user_assert(args.size() >= bounds.size()) <<
         "repeat_image called with more bounds (" << bounds.size() <<
         ") than dimensions (" << args.size() << ") Func " <<
-        source.name() << "has.\n";
+        source.name() << " has.\n";
 
     std::vector<Expr> actuals;
     for (size_t i = 0; i < bounds.size(); i++) {
@@ -129,7 +129,7 @@ Func mirror_image(const Func &source,
     user_assert(args.size() >= bounds.size()) <<
         "mirror_image called with more bounds (" << bounds.size() <<
         ") than dimensions (" << args.size() << ") Func " <<
-        source.name() << "has.\n";
+        source.name() << " has.\n";
 
     std::vector<Expr> actuals;
     for (size_t i = 0; i < bounds.size(); i++) {
@@ -170,7 +170,7 @@ Func mirror_interior(const Func &source,
     user_assert(args.size() >= bounds.size()) <<
         "mirror_interior called with more bounds (" << bounds.size() <<
         ") than dimensions (" << args.size() << ") Func " <<
-        source.name() << "has.\n";
+        source.name() << " has.\n";
 
     std::vector<Expr> actuals;
     for (size_t i = 0; i < bounds.size(); i++) {

--- a/src/CodeGen_PyTorch.cpp
+++ b/src/CodeGen_PyTorch.cpp
@@ -3,6 +3,7 @@
 #include "CodeGen_PyTorch.h"
 #include "IROperator.h"
 #include "Param.h"
+#include "Util.h"
 #include "Var.h"
 
 namespace Halide {

--- a/src/CodeGen_PyTorch.h
+++ b/src/CodeGen_PyTorch.h
@@ -24,28 +24,22 @@ struct Argument;
 namespace Internal {
 
 /** This class emits C++ code to wrap a Halide pipeline so that it can
- * be used as a C++ extension operator in PyTorch. 
+ * be used as a C++ extension operator in PyTorch.
  */
 class CodeGen_PyTorch : public IRPrinter {
 public:
-    CodeGen_PyTorch(std::ostream &dest, Target target, std::string name);
+    CodeGen_PyTorch(std::ostream &dest, const Target &target, const std::string &cpp_header_path);
     ~CodeGen_PyTorch() = default;
 
     /** Emit the PyTorch C++ wrapper for the Halide pipeline. */
     void compile(const Module &module);
 
-    /** The target we're generating code for */
-    const Target &get_target() const { return target; }
-
     static void test();
 
-protected:
-    virtual void compile(const LoweredFunc &func, bool is_cuda);
+private:
+    const Target target;
 
-    /** The target being generated for. */
-    Target target;
-
-    std::string cpp_header;
+    void compile(const LoweredFunc &func, bool is_cuda);
 };
 
 }

--- a/src/CodeGen_PyTorch.h
+++ b/src/CodeGen_PyTorch.h
@@ -15,12 +15,8 @@
 
 #include "IRPrinter.h"
 #include "Module.h"
-#include "Scope.h"
 
 namespace Halide {
-
-struct Argument;
-
 namespace Internal {
 
 /** This class emits C++ code to wrap a Halide pipeline so that it can
@@ -42,7 +38,7 @@ private:
     void compile(const LoweredFunc &func, bool is_cuda);
 };
 
-}
-}
+}  // namespace Internal
+}  // namespace Halide
 
-#endif
+#endif  // HALIDE_CODEGEN_PYTORCH_H

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -3020,13 +3020,6 @@ void Func::compile_to_lowered_stmt(const string &filename,
     pipeline().compile_to_lowered_stmt(filename, args, fmt, target);
 }
 
-void Func::compile_to_python_extension(const string &filename_prefix,
-                                       const vector<Argument> &args,
-                                       const string &fn_name,
-                                       const Target &target) {
-    pipeline().compile_to_python_extension(filename_prefix, args, fn_name, target);
-}
-
 void Func::print_loop_nest() {
     pipeline().print_loop_nest();
 }

--- a/src/Func.h
+++ b/src/Func.h
@@ -886,12 +886,6 @@ public:
                                  StmtOutputFormat fmt = Text,
                                  const Target &target = get_target_from_environment());
 
-    /** Emit a Python Extension glue .py.cpp file. */
-    void compile_to_python_extension(const std::string &filename_prefix,
-                                     const std::vector<Argument> &args,
-                                     const std::string &fn_name,
-                                     const Target &target = get_target_from_environment());
-
     /** Write out the loop nests specified by the schedule for this
      * Function. Helpful for understanding what a schedule is
      * doing. */

--- a/src/Func.h
+++ b/src/Func.h
@@ -886,7 +886,7 @@ public:
                                  StmtOutputFormat fmt = Text,
                                  const Target &target = get_target_from_environment());
 
-    /** Emit a Python Extension glue .c file. */
+    /** Emit a Python Extension glue .py.cpp file. */
     void compile_to_python_extension(const std::string &filename_prefix,
                                      const std::vector<Argument> &args,
                                      const std::string &fn_name,

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -105,7 +105,7 @@ public:
     static void test();
 
 protected:
-    /** The stream we're outputting on */
+    /** The stream on which we're outputting */
     std::ostream &stream;
 
     /** The current indentation level, useful for pretty-printing

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -27,6 +27,14 @@ namespace Internal {
 // and the appropriate file extension for each output type. If you are
 // explicitly managing file extensions somewhere else, you are probably
 // doing it wrong; please prefer to use this table as the source of truth.
+//
+// Note that we deliberately default to ".py.cpp" (rather than .py.c) here for python_extension;
+// in theory, the Python extension file we generate can be compiled just
+// fine as a plain-C file... but if we are building with cpp-name-mangling
+// enabled in the target, we will include generated .h files that can't be compiled.
+// We really don't want to vary the file extensions based on target flags,
+// and in practice, it's extremely unlikely that anyone needs to rely on this
+// being pure C output (vs possibly C++).
 std::map<Output, OutputInfo> get_output_info(const Target &target) {
     const bool is_windows_coff = target.os == Target::Windows &&
                                 !target.has_feature(Target::MinGW);

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -268,26 +268,6 @@ void Pipeline::compile_to_c(const string &filename,
     m.compile(single_output(filename, m, Output::c_source));
 }
 
-void Pipeline::compile_to_python_extension(const string &filename,
-                                           const vector<Argument> &args,
-                                           const string &fn_name,
-                                           const Target &target) {
-    Module m = compile_to_module(args, fn_name, target);
-    // Note that we deliberately default to ".py.cpp" (rather than .py.c) here;
-    // in theory, the Python extension file we generate can be compiled just
-    // fine as a plain-C file... but if we are building with cpp-name-mangling
-    // enabled in the target, we will include generated .h files that can't be compiled.
-    // We really don't want to vary the file extensions based on target flags,
-    // and in practice, it's extremely unlikely that anyone needs to rely on this
-    // being pure C output (vs possibly C++).
-    auto ext = get_output_info(target);
-    std::map<Output, std::string> outputs = {
-        { Output::c_header, output_name(filename, m, ext.at(Output::c_header).extension) },
-        { Output::python_extension, output_name(filename, m, ext.at(Output::python_extension).extension) },
-    };
-    m.compile(outputs);
-}
-
 void Pipeline::print_loop_nest() {
     user_assert(defined()) << "Can't print loop nest of undefined Pipeline.\n";
     debug(0) << Halide::Internal::print_loop_nest(contents->outputs);

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -239,8 +239,8 @@ void Pipeline::compile_to_object(const string &filename,
                                  const string &fn_name,
                                  const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    const char* ext = target.os == Target::Windows && !target.has_feature(Target::MinGW) ? ".obj" : ".o";
-    m.compile({{Output::object, output_name(filename, m, ext)}});
+    auto ext = get_output_info(target);
+    m.compile({{Output::object, output_name(filename, m, ext.at(Output::object).extension)}});
 }
 
 void Pipeline::compile_to_header(const string &filename,
@@ -280,7 +280,12 @@ void Pipeline::compile_to_python_extension(const string &filename,
     // We really don't want to vary the file extensions based on target flags,
     // and in practice, it's extremely unlikely that anyone needs to rely on this
     // being pure C output (vs possibly C++).
-    m.compile(single_output(filename, m, Output::python_extension));
+    auto ext = get_output_info(target);
+    std::map<Output, std::string> outputs = {
+        { Output::c_header, output_name(filename, m, ext.at(Output::c_header).extension) },
+        { Output::python_extension, output_name(filename, m, ext.at(Output::python_extension).extension) },
+    };
+    m.compile(outputs);
 }
 
 void Pipeline::print_loop_nest() {

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -215,12 +215,6 @@ public:
                       const std::string &fn_name,
                       const Target &target = get_target_from_environment());
 
-    /** Emit a Python extension glue .c file. */
-    void compile_to_python_extension(const std::string &filename,
-                                     const std::vector<Argument> &args,
-                                     const std::string &fn_name,
-                                     const Target &target = get_target_from_environment());
-
     /** Write out an internal representation of lowered code. Useful
      * for analyzing and debugging scheduling. Can emit html or plain
      * text. */

--- a/test/correctness/python_extension_gen.cpp
+++ b/test/correctness/python_extension_gen.cpp
@@ -37,23 +37,28 @@ int main(int argc, char **argv) {
 
     f(x, y) = buffer_u8(x, y) + int_param8;
 
-    Target t = get_target_from_environment();
-    t.set_feature(Target::CPlusPlusMangling);
+    Target target = get_target_from_environment().with_feature(Target::CPlusPlusMangling);
 
     std::string pyext_filename = Internal::get_test_tmp_dir() + "halide_python.py.cpp";
     std::string header_filename = Internal::get_test_tmp_dir() + "halide_python.h";
     std::string c_filename = Internal::get_test_tmp_dir() + "halide_python.cc";
+    std::string function_name = "org::halide::halide_python::f";
 
-    f.compile_to_c(c_filename, params,
-                   "org::halide::halide_python::f", t);
-    f.compile_to_header(header_filename, params,
-                   "org::halide::halide_python::f", t);
-    f.compile_to_python_extension(pyext_filename, params,
-                   "org::halide::halide_python::f", t);
+    f.compile_to(
+        {
+            {Output::c_source, c_filename},
+            {Output::c_header, header_filename},
+            {Output::python_extension, pyext_filename}
+        },
+        params,
+        function_name,
+        target
+    );
 
     Internal::assert_file_exists(header_filename);
     Internal::assert_file_exists(c_filename);
     Internal::assert_file_exists(pyext_filename);
 
-    exit(0);
+    printf("Success!\n");
+    return 0;
 }


### PR DESCRIPTION
- Code in Module.cpp should just require the c_header to be generated along with PyTorch (and PythonExtension) rather than trying to fake one
- Removed `compile_to_python_extension()` as a public API entirely; since you must generate at the same time as the header file, it's more sensible to just require using the `compile_to()` method for this instead
- strip the header path into 'leaf' form uniformly
- don't put 'using' into root namespace in generated header files
- fix ad-hoc .pytorch.h extension usage in favor of putting the right thing into the table (overlooked in recent Outputs overhaul)
- nuked unnecessary member vars, virtual decls, suboptimal grammar, other detritus

attn: @mgharbi 
