### PR TITLE
Fix linking of test_apps_autoscheduler

### DIFF
--- a/apps/autoscheduler/CMakeLists.txt
+++ b/apps/autoscheduler/CMakeLists.txt
@@ -146,6 +146,9 @@ target_include_directories(
   test_apps_autoscheduler
   PRIVATE "${HALIDE_INCLUDE_DIR}" "${HALIDE_TOOLS_DIR}")
 target_link_libraries(test_apps_autoscheduler PRIVATE Halide)
+if (NOT WIN32)
+  target_link_libraries(test_apps_autoscheduler PRIVATE dl)
+endif()
 
 add_executable(test_perfect_hash_map test_perfect_hash_map.cpp)
 


### PR DESCRIPTION
With lld, i get
```
[1/6] Linking CXX executable bin/test_apps_autoscheduler
FAILED: bin/test_apps_autoscheduler
: && /usr/bin/clang++-8  -pipe  -rdynamic apps/autoscheduler/CMakeFiles/test_apps_autoscheduler.dir/test.cpp.o  -o bin/test_apps_autoscheduler  -Wl,-rpath,/repositories/Halide/build/lib lib/libHalide.so && :
ld: error: undefined symbol: dlopen
>>> referenced by test.cpp
>>>               apps/autoscheduler/CMakeFiles/test_apps_autoscheduler.dir/test.cpp.o:(main)

ld: error: undefined symbol: dlerror
>>> referenced by test.cpp
>>>               apps/autoscheduler/CMakeFiles/test_apps_autoscheduler.dir/test.cpp.o:(main)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Explicitly linking to `dl` library fixes the issue.
I believe this is the correct fix, since `tutorial/CMakeLists.txt`
already has a similar block:
https://github.com/halide/Halide/blob/3165336dd29525cbc8eb9dd2ef9d76fe660b205f/tutorial/CMakeLists.txt#L95-L97