### PR TITLE
PyTorch and PyExt: emit extern decls directly...

### DIFF
--- a/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
+++ b/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
@@ -64,7 +64,6 @@ def main():
     # usually Params or ImageParams.
     fname = "lesson_10_halide"
     brighter.compile_to({hl.Output.object: "lesson_10_halide.o",
-                         hl.Output.c_header: "lesson_10_halide.h",
                          hl.Output.python_extension: "lesson_10_halide.py.cpp"},
                          [input, offset], "lesson_10_halide")
 

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -28,6 +28,8 @@ public:
         CPlusPlusHeader,
         CImplementation,
         CPlusPlusImplementation,
+        CExternDecl,
+        CPlusPlusExternDecl,
     };
 
     /** Initialize a C code generator pointing at a particular output
@@ -120,10 +122,22 @@ protected:
                output_kind == CPlusPlusHeader;
     }
 
+    /** Return true if only generating an interface, which may be extern "C" or C++ */
+    bool is_extern_decl() {
+        return output_kind == CExternDecl ||
+               output_kind == CPlusPlusExternDecl;
+    }
+
+    /** Return true if only generating an interface, which may be extern "C" or C++ */
+    bool is_header_or_extern_decl() {
+        return is_header() || is_extern_decl();
+    }
+
     /** Return true if generating C++ linkage. */
     bool is_c_plus_plus_interface() {
         return output_kind == CPlusPlusHeader ||
-               output_kind == CPlusPlusImplementation;
+               output_kind == CPlusPlusImplementation ||
+               output_kind == CPlusPlusExternDecl;
     }
 
     /** Open a new C scope (i.e. throw in a brace, increase the indent) */

--- a/src/CodeGen_PyTorch.h
+++ b/src/CodeGen_PyTorch.h
@@ -24,7 +24,7 @@ namespace Internal {
  */
 class CodeGen_PyTorch : public IRPrinter {
 public:
-    CodeGen_PyTorch(std::ostream &dest, const Target &target, const std::string &cpp_header_path);
+    CodeGen_PyTorch(std::ostream &dest);
     ~CodeGen_PyTorch() = default;
 
     /** Emit the PyTorch C++ wrapper for the Halide pipeline. */
@@ -33,8 +33,6 @@ public:
     static void test();
 
 private:
-    const Target target;
-
     void compile(const LoweredFunc &func, bool is_cuda);
 };
 

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -641,11 +641,8 @@ void Module::compile(const std::map<Output, std::string> &output_files) const {
     }
     if (contains(output_files, Output::python_extension)) {
         debug(1) << "Module.compile(): python_extension " << output_files.at(Output::python_extension) << "\n";
-        user_assert(contains(output_files, Output::c_header)) << "You must specify c_header when specifying python_extension.";
-        auto c_header_leaf = leaf(output_files.at(Output::c_header));
-
         std::ofstream file(output_files.at(Output::python_extension));
-        Internal::PythonExtensionGen python_extension_gen(file, c_header_leaf, target());
+        Internal::PythonExtensionGen python_extension_gen(file);
         python_extension_gen.compile(*this);
     }
     if (contains(output_files, Output::schedule)) {
@@ -678,11 +675,9 @@ void Module::compile(const std::map<Output, std::string> &output_files) const {
     }
     if (contains(output_files, Output::pytorch_wrapper)) {
         debug(1) << "Module.compile(): pytorch_wrapper " << output_files.at(Output::pytorch_wrapper) << "\n" ;
-        user_assert(contains(output_files, Output::c_header)) << "You must specify c_header when specifying pytorch_wrapper.";
-        auto c_header_leaf = leaf(output_files.at(Output::c_header));
 
         std::ofstream file(output_files.at(Output::pytorch_wrapper));
-        Internal::CodeGen_PyTorch cg(file, target(), c_header_leaf);
+        Internal::CodeGen_PyTorch cg(file);
         cg.compile(*this);
     }
 }

--- a/src/PythonExtensionGen.h
+++ b/src/PythonExtensionGen.h
@@ -14,15 +14,15 @@ namespace Internal {
 
 class PythonExtensionGen {
 public:
-    PythonExtensionGen(std::ostream &dest, const std::string &header_name, Target target);
+    PythonExtensionGen(std::ostream &dest);
 
     void compile(const Module &module);
-    void compile(const LoweredFunc &f);
+
 private:
-    void convert_buffer(std::string name, const LoweredArgument* arg);
     std::ostream &dest;
-    std::string header_name;
-    Target target;
+
+    void compile(const LoweredFunc &f);
+    void convert_buffer(std::string name, const LoweredArgument* arg);
 };
 
 }

--- a/test/correctness/python_extension_gen.cpp
+++ b/test/correctness/python_extension_gen.cpp
@@ -40,14 +40,12 @@ int main(int argc, char **argv) {
     Target target = get_target_from_environment().with_feature(Target::CPlusPlusMangling);
 
     std::string pyext_filename = Internal::get_test_tmp_dir() + "halide_python.py.cpp";
-    std::string header_filename = Internal::get_test_tmp_dir() + "halide_python.h";
     std::string c_filename = Internal::get_test_tmp_dir() + "halide_python.cc";
     std::string function_name = "org::halide::halide_python::f";
 
     f.compile_to(
         {
             {Output::c_source, c_filename},
-            {Output::c_header, header_filename},
             {Output::python_extension, pyext_filename}
         },
         params,
@@ -55,7 +53,6 @@ int main(int argc, char **argv) {
         target
     );
 
-    Internal::assert_file_exists(header_filename);
     Internal::assert_file_exists(c_filename);
     Internal::assert_file_exists(pyext_filename);
 


### PR DESCRIPTION
...rather than including .h files. This simplifies certain compile/build setups (since we don't have to build the .h files in tandem and/or get include paths right), and should be totally safe, since we are using literally  the same codegen logic that produces the .h file anyway.