### PR TITLE
Minor Clang-Tidy fixes

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -142,16 +142,6 @@ std::map<Output, std::string> add_suffixes(const std::map<Output, std::string> &
     return out;
 }
 
-// Given a pathname of the form /path/to/name.ext, return the leaf (name.ext)
-std::string leaf(const std::string &path) {
-    size_t slash_pos = std::min(path.rfind('/'), path.rfind('\\'));
-    if (slash_pos != std::string::npos) {
-        return path.substr(slash_pos + 1);
-    } else {
-        return path;
-    }
-}
-
 void emit_registration(const Module &m, std::ostream &stream) {
     /*
         This relies on the filter library being linked in a way that doesn't

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -50,6 +50,7 @@ class SimdOpCheckTest {
             .with_feature(Target::DisableLLVMLoopOpt);
         num_threads = Internal::ThreadPool<void>::num_processors_online();
     }
+    virtual ~SimdOpCheckTest() = default;
     size_t get_num_threads() const {
         return num_threads;
     }


### PR DESCRIPTION
- remove unused 'leaf' method
- SimdOpCheckTest has virtual methods, so it should have a virtual dtor