### PR TITLE
Clean IRPrinter indentation code

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1681,18 +1681,15 @@ void CodeGen_C::compile(const LoweredFunc &f) {
         indent += 1;
 
         if (uses_gpu_for_loops) {
-            do_indent();
-            stream << "halide_error("
+            stream << get_indent() << "halide_error("
                    << (have_user_context ? "__user_context_" : "nullptr")
                    << ", \"C++ Backend does not support gpu_blocks() or gpu_threads() yet, "
                    << "this function will always fail at runtime\");\n";
-            do_indent();
-            stream << "return halide_error_code_device_malloc_failed;\n";
+            stream << get_indent() << "return halide_error_code_device_malloc_failed;\n";
         } else {
             // Emit a local user_context we can pass in all cases, either
             // aliasing __user_context or nullptr.
-            do_indent();
-            stream << "void * const _ucon = "
+            stream << get_indent() << "void * const _ucon = "
                    << (have_user_context ? "const_cast<void *>(__user_context)" : "nullptr")
                    << ";\n";
 
@@ -1700,8 +1697,7 @@ void CodeGen_C::compile(const LoweredFunc &f) {
             print(f.body);
 
             // Return success.
-            do_indent();
-            stream << "return 0;\n";
+            stream << get_indent() << "return 0;\n";
         }
 
         indent -= 1;
@@ -1751,13 +1747,13 @@ void CodeGen_C::compile(const Buffer<> &buffer) {
 
     // Emit the data
     stream << "static " << (is_constant ? "const" : "") << " uint8_t " << name << "_data[] HALIDE_ATTRIBUTE_ALIGN(32) = {\n";
-    do_indent();
+    stream << get_indent();
     for (size_t i = 0; i < num_elems * b.type.bytes(); i++) {
         if (i > 0) {
             stream << ",";
             if (i % 16 == 0) {
                 stream << "\n";
-                do_indent();
+                stream << get_indent();
             } else {
                 stream << " ";
             }
@@ -1824,8 +1820,7 @@ string CodeGen_C::print_assignment(Type t, const std::string &rhs) {
     auto cached = cache.find(rhs);
     if (cached == cache.end()) {
         id = unique_name('_');
-        do_indent();
-        stream << print_type(t, AppendSpace) << (output_kind == CPlusPlusImplementation ? "const " : "") << id << " = " << rhs << ";\n";
+        stream << get_indent() << print_type(t, AppendSpace) << (output_kind == CPlusPlusImplementation ? "const " : "") << id << " = " << rhs << ";\n";
         cache[rhs] = id;
     } else {
         id = cached->second;
@@ -1835,7 +1830,7 @@ string CodeGen_C::print_assignment(Type t, const std::string &rhs) {
 
 void CodeGen_C::open_scope() {
     cache.clear();
-    do_indent();
+    stream << get_indent();
     indent++;
     stream << "{\n";
 }
@@ -1843,7 +1838,7 @@ void CodeGen_C::open_scope() {
 void CodeGen_C::close_scope(const std::string &comment) {
     cache.clear();
     indent--;
-    do_indent();
+    stream << get_indent();
     if (!comment.empty()) {
         stream << "} // " << comment << "\n";
     } else {
@@ -2105,25 +2100,20 @@ void CodeGen_C::visit(const Call *op) {
 
         string result_id = unique_name('_');
 
-        do_indent();
-        stream << print_type(op->args[1].type(), AppendSpace)
+        stream << get_indent() << print_type(op->args[1].type(), AppendSpace)
                << result_id << ";\n";
 
         string cond_id = print_expr(op->args[0]);
 
-        do_indent();
-        stream << "if (" << cond_id << ")\n";
+        stream << get_indent() << "if (" << cond_id << ")\n";
         open_scope();
         string true_case = print_expr(op->args[1]);
-        do_indent();
-        stream << result_id << " = " << true_case << ";\n";
+        stream << get_indent() << result_id << " = " << true_case << ";\n";
         close_scope("if " + cond_id);
-        do_indent();
-        stream << "else\n";
+        stream << get_indent() << "else\n";
         open_scope();
         string false_case = print_expr(op->args[2]);
-        do_indent();
-        stream << result_id << " = " << false_case << ";\n";
+        stream << get_indent() << result_id << " = " << false_case << ";\n";
         close_scope("if " + cond_id + " else");
 
         rhs << result_id;
@@ -2149,14 +2139,14 @@ void CodeGen_C::visit(const Call *op) {
         const Call *call = op->args[0].as<Call>();
         if (op->type == type_of<struct halide_buffer_t *>() &&
             call && call->is_intrinsic(Call::size_of_halide_buffer_t)) {
-            do_indent();
+            stream << get_indent();
             string buf_name = unique_name('b');
             stream << "halide_buffer_t " << buf_name << ";\n";
             rhs << "&" << buf_name;
         } else {
             // Make a stack of uint64_ts
             string size = print_expr(simplify((op->args[0] + 7)/8));
-            do_indent();
+            stream << get_indent();
             string array_name = unique_name('a');
             stream << "uint64_t " << array_name << "[" << size << "];";
             rhs << "(" << print_type(op->type) << ")(&" << array_name << ")";
@@ -2175,29 +2165,24 @@ void CodeGen_C::visit(const Call *op) {
             for (size_t i = 0; i < op->args.size(); i++) {
                 values.push_back(print_expr(op->args[i]));
             }
-            do_indent();
-            stream << "struct {\n";
+            stream << get_indent() << "struct {\n";
             // List the types.
             indent++;
             for (size_t i = 0; i < op->args.size(); i++) {
-                do_indent();
-                stream << "const " << print_type(op->args[i].type()) << " f_" << i << ";\n";
+                stream << get_indent() << "const " << print_type(op->args[i].type()) << " f_" << i << ";\n";
             }
             indent--;
             string struct_name = unique_name('s');
-            do_indent();
-            stream << "} " << struct_name << " = {\n";
+            stream << get_indent() << "} " << struct_name << " = {\n";
             // List the values.
             indent++;
             for (size_t i = 0; i < op->args.size(); i++) {
-                do_indent();
-                stream << values[i];
+                stream << get_indent() << values[i];
                 if (i < op->args.size() - 1) stream << ",";
                 stream << "\n";
             }
             indent--;
-            do_indent();
-            stream << "};\n";
+            stream << get_indent() << "};\n";
             // Return a pointer to it of the appropriate type
             if (op->type.handle_type) {
                 rhs << "(" << print_type(op->type) << ")";
@@ -2232,10 +2217,8 @@ void CodeGen_C::visit(const Call *op) {
 
         }
         string buf_name = unique_name('b');
-        do_indent();
-        stream << "char " << buf_name << "[1024];\n";
-        do_indent();
-        stream << "snprintf(" << buf_name << ", 1024, \"" << format_string << "\", " << with_commas(printf_args) << ");\n";
+        stream << get_indent() << "char " << buf_name << "[1024];\n";
+        stream << get_indent() << "snprintf(" << buf_name << ", 1024, \"" << format_string << "\", " << with_commas(printf_args) << ");\n";
         rhs << buf_name;
 
     } else if (op->is_intrinsic(Call::register_destructor)) {
@@ -2244,7 +2227,7 @@ void CodeGen_C::visit(const Call *op) {
         internal_assert(fn);
         string arg = print_expr(op->args[1]);
 
-        do_indent();
+        stream << get_indent();
         // Make a struct on the stack that calls the given function as a destructor
         string struct_name = unique_name('s');
         string instance_name = unique_name('d');
@@ -2308,8 +2291,7 @@ void CodeGen_C::visit(const Call *op) {
     // an ignored int, but as halide_print() has many overrides downstream (and in third-party
     // consumers), this is arguably a simpler fix for allowing halide_print() to work in the C++ backend.
     if (op->name == "halide_print") {
-        do_indent();
-        stream << rhs.str() << ";\n";
+        stream << get_indent() << rhs.str() << ";\n";
         // Make an innocuous assignment value for our caller (probably an Evaluate node) to ignore.
         print_assignment(op->type, "0");
     } else {
@@ -2321,8 +2303,7 @@ string CodeGen_C::print_scalarized_expr(Expr e) {
     Type t = e.type();
     internal_assert(t.is_vector());
     string v = unique_name('_');
-    do_indent();
-    stream << print_type(t, AppendSpace) << v << ";\n";
+    stream << get_indent() << print_type(t, AppendSpace) << v << ";\n";
     for (int lane = 0; lane < t.lanes(); lane++) {
         Expr e2 = extract_lane(e, lane);
         string elem = print_expr(e2);
@@ -2406,14 +2387,12 @@ void CodeGen_C::visit(const Store *op) {
     if (dense_ramp_base.defined()) {
         internal_assert(op->value.type().is_vector());
         string id_ramp_base = print_expr(dense_ramp_base);
-        do_indent();
-        stream << id_value + ".store(" << name << ", " << id_ramp_base << ");\n";
+        stream << get_indent() << id_value + ".store(" << name << ", " << id_ramp_base << ");\n";
     } else if (op->index.type().is_vector()) {
         // If index is a vector, scatter vector elements.
         internal_assert(t.is_vector());
         string id_index = print_expr(op->index);
-        do_indent();
-        stream << id_value + ".store(" << name << ", " << id_index << ");\n";
+        stream << get_indent() << id_value + ".store(" << name << ", " << id_index << ");\n";
     } else {
         bool type_cast_needed =
             t.is_handle() ||
@@ -2421,7 +2400,7 @@ void CodeGen_C::visit(const Store *op) {
             allocations.get(op->name).type != t;
 
         string id_index = print_expr(op->index);
-        do_indent();
+        stream << get_indent();
         if (type_cast_needed) {
             stream << "((" << print_type(t) << " *)" << name << ")";
         } else {
@@ -2438,8 +2417,7 @@ void CodeGen_C::visit(const Let *op) {
     if (op->value.type().is_handle()) {
         // The body might contain a Load that references this directly
         // by name, so we can't rewrite the name.
-        do_indent();
-        stream << print_type(op->value.type())
+        stream << get_indent() << print_type(op->value.type())
                << " " << print_name(op->name)
                << " = " << id_value << ";\n";
     } else {
@@ -2476,8 +2454,7 @@ void CodeGen_C::visit(const LetStmt *op) {
     if (op->value.type().is_handle()) {
         // The body might contain a Load or Store that references this
         // directly by name, so we can't rewrite the name.
-        do_indent();
-        stream << print_type(op->value.type())
+        stream << get_indent() << print_type(op->value.type())
                << " " << print_name(op->name)
                << " = " << id_value << ";\n";
     } else {
@@ -2494,11 +2471,9 @@ void CodeGen_C::visit(const LetStmt *op) {
 void CodeGen_C::create_assertion(const string &id_cond, const string &id_msg) {
     if (target.has_feature(Target::NoAsserts)) return;
 
-    do_indent();
-    stream << "if (!" << id_cond << ")\n";
+    stream << get_indent() << "if (!" << id_cond << ")\n";
     open_scope();
-    do_indent();
-    stream << "return " << id_msg << ";\n";
+    stream << get_indent() << "return " << id_msg << ";\n";
     close_scope("");
 }
 
@@ -2510,12 +2485,10 @@ void CodeGen_C::create_assertion(const string &id_cond, Expr message) {
 
     // don't call the create_assertion(string, string) version because
     // we don't want to force evaluation of 'message' unless the condition fails
-    do_indent();
-    stream << "if (!" << id_cond << ") ";
+    stream << get_indent() << "if (!" << id_cond << ") ";
     open_scope();
     string id_msg = print_expr(message);
-    do_indent();
-    stream << "return " << id_msg << ";\n";
+    stream << get_indent() << "return " << id_msg << ";\n";
     close_scope("");
 }
 
@@ -2528,7 +2501,7 @@ void CodeGen_C::visit(const AssertStmt *op) {
 }
 
 void CodeGen_C::visit(const ProducerConsumer *op) {
-    do_indent();
+    stream << get_indent();
     if (op->is_producer) {
         stream << "// produce " << op->name << '\n';
     } else {
@@ -2539,24 +2512,19 @@ void CodeGen_C::visit(const ProducerConsumer *op) {
 
 void CodeGen_C::visit(const Fork *op) {
     // TODO: This doesn't actually work with nested tasks
-    do_indent();
-    stream << "#pragma omp parallel\n";
+    stream << get_indent() << "#pragma omp parallel\n";
     open_scope();
-    do_indent();
-    stream << "#pragma omp single\n";
+    stream << get_indent() << "#pragma omp single\n";
     open_scope();
-    do_indent();
-    stream << "#pragma omp task\n";
+    stream << get_indent() << "#pragma omp task\n";
     open_scope();
     print_stmt(op->first);
     close_scope("");
-    do_indent();
-    stream << "#pragma omp task\n";
+    stream << get_indent() << "#pragma omp task\n";
     open_scope();
     print_stmt(op->rest);
     close_scope("");
-    do_indent();
-    stream << "#pragma omp taskwait\n";
+    stream << get_indent() << "#pragma omp taskwait\n";
     close_scope("");
     close_scope("");
 }
@@ -2565,11 +2533,9 @@ void CodeGen_C::visit(const Acquire *op) {
     string id_sem = print_expr(op->semaphore);
     string id_count = print_expr(op->count);
     open_scope();
-    do_indent();
-    stream << "while (!halide_semaphore_try_acquire(" << id_sem << ", " << id_count << "))\n";
+    stream << get_indent() << "while (!halide_semaphore_try_acquire(" << id_sem << ", " << id_count << "))\n";
     open_scope();
-    do_indent();
-    stream << "#pragma omp taskyield\n";
+    stream << get_indent() << "#pragma omp taskyield\n";
     close_scope("");
     op->body.accept(this);
     close_scope("");
@@ -2580,15 +2546,13 @@ void CodeGen_C::visit(const For *op) {
     string id_extent = print_expr(op->extent);
 
     if (op->for_type == ForType::Parallel) {
-        do_indent();
-        stream << "#pragma omp parallel for\n";
+        stream << get_indent() << "#pragma omp parallel for\n";
     } else {
         internal_assert(op->for_type == ForType::Serial)
             << "Can only emit serial or parallel for loops to C\n";
     }
 
-    do_indent();
-    stream << "for (int "
+    stream << get_indent() << "for (int "
            << print_name(op->name)
            << " = " << id_min
            << "; "
@@ -2684,17 +2648,15 @@ void CodeGen_C::visit(const Allocate *op) {
                 }
                 size_id = print_assignment(Int(64), new_size_id_rhs);
             }
-            do_indent();
-            stream << "if ((" << size_id << " > ((int64_t(1) << 31) - 1)) || ((" << size_id <<
+            stream << get_indent() << "if ((" << size_id << " > ((int64_t(1) << 31) - 1)) || ((" << size_id <<
               " * sizeof(" << op_type << ")) > ((int64_t(1) << 31) - 1)))\n";
             open_scope();
-            do_indent();
+            stream << get_indent();
             // TODO: call halide_error_buffer_allocation_too_large() here instead
             // TODO: call create_assertion() so that NoAssertions works
             stream << "halide_error(_ucon, "
                    << "\"32-bit signed overflow computing size of allocation " << op->name << "\\n\");\n";
-            do_indent();
-            stream << "return -1;\n";
+            stream << get_indent() << "return -1;\n";
             close_scope("overflow test " + op->name);
         }
 
@@ -2714,8 +2676,7 @@ void CodeGen_C::visit(const Allocate *op) {
         alloc.type = op->type;
         allocations.push(op->name, alloc);
 
-        do_indent();
-        stream << op_type;
+        stream << get_indent() << op_type;
 
         if (on_stack) {
             stream << op_name
@@ -2735,7 +2696,7 @@ void CodeGen_C::visit(const Allocate *op) {
     if (!on_stack) {
         create_assertion(op_name, "halide_error_out_of_memory(_ucon)");
 
-        do_indent();
+        stream << get_indent();
         string free_function = op->free_function.empty() ? "halide_free" : op->free_function;
         stream << "HalideFreeHelper " << op_name << "_free(_ucon, "
                << op_name << ", " << free_function << ");\n";
@@ -2751,8 +2712,7 @@ void CodeGen_C::visit(const Allocate *op) {
 
 void CodeGen_C::visit(const Free *op) {
     if (heap_allocations.contains(op->name)) {
-        do_indent();
-        stream << print_name(op->name) << "_free.free();\n";
+        stream << get_indent() << print_name(op->name) << "_free.free();\n";
         heap_allocations.pop(op->name);
     }
     allocations.pop(op->name);
@@ -2769,15 +2729,13 @@ void CodeGen_C::visit(const Prefetch *op) {
 void CodeGen_C::visit(const IfThenElse *op) {
     string cond_id = print_expr(op->condition);
 
-    do_indent();
-    stream << "if (" << cond_id << ")\n";
+    stream << get_indent() << "if (" << cond_id << ")\n";
     open_scope();
     op->then_case.accept(this);
     close_scope("if " + cond_id);
 
     if (op->else_case.defined()) {
-        do_indent();
-        stream << "else\n";
+        stream << get_indent() << "else\n";
         open_scope();
         op->else_case.accept(this);
         close_scope("if " + cond_id + " else");
@@ -2787,8 +2745,7 @@ void CodeGen_C::visit(const IfThenElse *op) {
 void CodeGen_C::visit(const Evaluate *op) {
     if (is_const(op->value)) return;
     string id = print_expr(op->value);
-    do_indent();
-    stream << "(void)" << id << ";\n";
+    stream << get_indent() << "(void)" << id << ";\n";
 }
 
 void CodeGen_C::visit(const Shuffle *op) {
@@ -2811,8 +2768,7 @@ void CodeGen_C::visit(const Shuffle *op) {
     if (op->vectors.size() > 1) {
         ostringstream rhs;
         string storage_name = unique_name('_');
-        do_indent();
-        stream << "const " << print_type(op->vectors[0].type()) << " " << storage_name << "[] = { " << with_commas(vecs) << " };\n";
+        stream << get_indent() << "const " << print_type(op->vectors[0].type()) << " " << storage_name << "[] = { " << with_commas(vecs) << " };\n";
 
         rhs << print_type(op->type) << "::concat(" << op->vectors.size() << ", " << storage_name << ")";
         src = print_assignment(op->type, rhs.str());
@@ -2822,8 +2778,7 @@ void CodeGen_C::visit(const Shuffle *op) {
         rhs << src << "[" << op->indices[0] << "]";
     } else {
         string indices_name = unique_name('_');
-        do_indent();
-        stream << "const int32_t " << indices_name << "[" << op->indices.size() << "] = { " << with_commas(op->indices) << " };\n";
+        stream << get_indent() << "const int32_t " << indices_name << "[" << op->indices.size() << "] = { " << with_commas(op->indices) << " };\n";
         rhs << print_type(op->type) << "::shuffle(" << src << ", " << indices_name << ")";
     }
     print_assignment(op->type, rhs.str());

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -211,8 +211,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const For *loop)
         << "kernel loop must be either gpu block or gpu thread\n";
     internal_assert(is_zero(loop->min));
 
-    do_indent();
-    stream << print_type(Int(32)) << " " << print_name(loop->name)
+    stream << get_indent() << print_type(Int(32)) << " " << print_name(loop->name)
             << " = " << simt_intrinsic(loop->name) << ";\n";
 
     loop->body.accept(this);
@@ -260,8 +259,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Call *op) {
         // NOTE(marcos): using "WithGroupSync" here just to be safe, as a
         // simple "GroupMemoryBarrier" is probably too relaxed for Halide
         // (also note we need to return an integer)
-        do_indent();
-        stream << "GroupMemoryBarrierWithGroupSync();\n";
+        stream << get_indent() << "GroupMemoryBarrierWithGroupSync();\n";
         print_assignment(op->type, "0");
     } else {
         CodeGen_C::visit(op);
@@ -439,13 +437,11 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Load *op)
         id = unique_name('_');
         cache[rhs.str()] = id;
 
-        do_indent();
-        stream << print_type(op->type)
+        stream << get_indent() << print_type(op->type)
                << " " << id << ";\n";
 
         for (int i = 0; i < op->type.lanes(); ++i) {
-            do_indent();
-            stream << id << "[" << i << "] = "
+            stream << get_indent() << id << "[" << i << "] = "
                    << print_type(op->type.element_of())
                    << "("
                    << print_name(op->name)
@@ -472,8 +468,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Store *op)
             << " = "
             << print_reinterpret(UInt(32), op->value)
             << ";\n";
-        do_indent();
-        stream << rhs.str();
+        stream << get_indent() << rhs.str();
 #if 0
         // NOTE(marcos): let's keep this block of code here (disabled) in case
         // we need to "emulate" byte/short packing in shared memory (recall that
@@ -515,10 +510,8 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Store *op)
             // the performance impact of atomic operations on shared memory is
             // not well documented... here is something:
             // https://stackoverflow.com/a/19548723
-            do_indent();
-            stream << "InterlockedAnd(" << word.str() << ", " << "~" << mask.str() << ");\n";
-            do_indent();
-            stream << "InterlockedXor(" << word.str() << ", " << value.str() << ");\n";
+            stream << get_indent() << "InterlockedAnd(" << word.str() << ", " << "~" << mask.str() << ");\n";
+            stream << get_indent() << "InterlockedXor(" << word.str() << ", " << value.str() << ");\n";
         }
 #endif
         return;
@@ -545,8 +538,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Store *op)
                 << i
                 << "]"
                 << ";\n";
-            do_indent();
-            stream << rhs.str();
+            stream << get_indent() << rhs.str();
         }
     } else if (op->index.type().is_vector()) {
         // If index is a vector, scatter vector elements.
@@ -560,8 +552,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Store *op)
                 << "]"
                 << " = "
                 << print_expr(op->value) << "[" << i << "];\n";
-            do_indent();
-            stream << rhs.str();
+            stream << get_indent() << rhs.str();
         }
     } else {
         ostringstream rhs;
@@ -570,8 +561,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Store *op)
             << " = "
             << print_expr(op->value)
             << ";\n";
-        do_indent();
-        stream << rhs.str();
+        stream << get_indent() << rhs.str();
     }
 
     cache.clear();
@@ -610,10 +600,9 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Allocate *op)
             << "Only fixed-size allocations are supported on the gpu. "
             << "Try storing into shared memory instead.";
 
-        do_indent();
-        stream << print_storage_type(op->type) << ' '
+        stream << get_indent() << print_storage_type(op->type) << ' '
                << print_name(op->name) << "[" << size << "];\n";
-        do_indent();
+        stream << get_indent();
 
         Allocation alloc;
         alloc.type = op->type;
@@ -635,7 +624,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Free *op) {
         // Should have been freed internally
         internal_assert(allocations.contains(op->name));
         allocations.pop(op->name);
-        do_indent();
+        stream << get_indent();
     }
 }
 

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -90,8 +90,7 @@ string CodeGen_Metal_Dev::CodeGen_Metal_C::print_reinterpret(Type type, Expr e) 
 
     string temp = unique_name('V');
     string expr = print_expr(e);
-    do_indent();
-    stream << print_type(e.type()) << " " << temp << " = " << expr << ";\n";
+    stream << get_indent() << print_type(e.type()) << " " << temp << " = " << expr << ";\n";
     oss << "*(" << print_type(type) << " thread *)(&" << temp << ")";
     return oss.str();
 }
@@ -174,8 +173,7 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const For *loop) {
             << "kernel loop must be either gpu block or gpu thread\n";
         internal_assert(is_zero(loop->min));
 
-        do_indent();
-        stream << print_type(Int(32)) << " " << print_name(loop->name)
+        stream << get_indent() << print_type(Int(32)) << " " << print_name(loop->name)
                << " = " << simt_intrinsic(loop->name) << ";\n";
 
         loop->body.accept(this);
@@ -212,8 +210,7 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Broadcast *op) {
 
 void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Call *op) {
     if (op->is_intrinsic(Call::gpu_thread_barrier)) {
-        do_indent();
-        stream << "threadgroup_barrier(mem_flags::mem_threadgroup);\n";
+        stream << get_indent() << "threadgroup_barrier(mem_flags::mem_threadgroup);\n";
         print_assignment(op->type, "0");
     } else {
         CodeGen_C::visit(op);
@@ -293,12 +290,11 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Load *op) {
         id = unique_name('_');
         cache[rhs.str()] = id;
 
-        do_indent();
-        stream << print_type(op->type)
+        stream << get_indent() << print_type(op->type)
                << " " << id << ";\n";
 
         for (int i = 0; i < op->type.lanes(); ++i) {
-            do_indent();
+            stream << get_indent();
             stream
               << id << "[" << i << "]"
                 << " = ((" << get_memory_space(op->name) << " "
@@ -324,8 +320,7 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Store *op) {
         internal_assert(op->value.type().is_vector());
         string id_ramp_base = print_expr(ramp_base);
 
-        do_indent();
-        stream << "*(" << get_memory_space(op->name) << " " << print_storage_type(t) << " *)(("
+        stream << get_indent() << "*(" << get_memory_space(op->name) << " " << print_storage_type(t) << " *)(("
                << get_memory_space(op->name) << " " << print_type(t.element_of()) << " *)" << print_name(op->name)
                << " + " << id_ramp_base << ") = " << id_value << ";\n";
     } else if (op->index.type().is_vector()) {
@@ -335,8 +330,7 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Store *op) {
         string id_index = print_expr(op->index);
 
         for (int i = 0; i < t.lanes(); ++i) {
-            do_indent();
-            stream << "((" << get_memory_space(op->name) << " "
+            stream << get_indent() << "((" << get_memory_space(op->name) << " "
                    << print_storage_type(t.element_of()) << " *)"
                    << print_name(op->name)
                    << ")["
@@ -349,7 +343,7 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Store *op) {
 
         string id_index = print_expr(op->index);
         string id_value = print_expr(op->value);
-        do_indent();
+        stream << get_indent();
 
         if (type_cast_needed) {
             stream << "(("
@@ -401,11 +395,9 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Allocate *op) {
             << "Only fixed-size allocations are supported on the gpu. "
             << "Try storing into shared memory instead.";
 
-        do_indent();
-        stream << print_storage_type(op->type) << ' '
+        stream << get_indent() << print_storage_type(op->type) << ' '
                << print_name(op->name) << "[" << size << "];\n";
-        do_indent();
-        stream << "#define " << get_memory_space(op->name) << " thread\n";
+        stream << get_indent() << "#define " << get_memory_space(op->name) << " thread\n";
 
         Allocation alloc;
         alloc.type = op->type;
@@ -427,8 +419,7 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Free *op) {
         // Should have been freed internally
         internal_assert(allocations.contains(op->name));
         allocations.pop(op->name);
-        do_indent();
-        stream << "#undef " << get_memory_space(op->name) << "\n";
+        stream << get_indent() << "#undef " << get_memory_space(op->name) << "\n";
     }
 }
 

--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -134,8 +134,7 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Cast *op) {
 
 void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Call *op) {
     if (op->is_intrinsic(Call::gpu_thread_barrier)) {
-        do_indent();
-        stream << "barrier();\n";
+        stream << get_indent() << "barrier();\n";
         print_assignment(op->type, "0");
     } else {
         CodeGen_GLSLBase::visit(op);
@@ -166,8 +165,7 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const For *loop) 
             debug(4) << "Workgroup size for index " << index << " is " << workgroup_size[index] << "\n";
         }
 
-        do_indent();
-        stream << print_type(Int(32)) << " " << print_name(loop->name)
+        stream << get_indent() << print_type(Int(32)) << " " << print_name(loop->name)
                << " = int(" << simt_intrinsic(loop->name) << ");\n";
 
         loop->body.accept(this);
@@ -225,8 +223,7 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Store *op) 
 
     string id_value = print_expr(op->value);
 
-    do_indent();
-    stream << print_name(op->name);
+    stream << get_indent() << print_name(op->name);
     if (!allocations.contains(op->name)) {
         stream << ".data";
     }
@@ -350,7 +347,7 @@ void CodeGen_OpenGLCompute_Dev::init_module() {
 void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Allocate *op) {
     debug(2) << "OpenGLCompute: Allocate " << op->name << " of type " << op->type << " on device\n";
 
-    do_indent();
+    stream << get_indent();
     Allocation alloc;
     alloc.type = op->type;
     allocations.push(op->name, alloc);
@@ -366,7 +363,7 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Allocate *o
     if (!starts_with(op->name, "__shared_")) {
         stream << "{\n";
         indent += 2;
-        do_indent();
+        stream << get_indent();
         // Shared allocations were already declared at global scope.
         stream << print_type(op->type) << " "
                << print_name(op->name) << "["
@@ -376,8 +373,7 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Allocate *o
 
     if (!starts_with(op->name, "__shared_")) {
         indent -= 2;
-        do_indent();
-        stream << "}\n";
+        stream << get_indent() << "}\n";
     }
 }
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -12,6 +12,7 @@
 #endif
 
 #include "Generator.h"
+#include "IRPrinter.h"
 #include "Module.h"
 #include "Simplify.h"
 
@@ -239,64 +240,56 @@ private:
     }
 
     /** Emit spaces according to the current indentation level */
-    std::string indent();
+    Indentation get_indent() const { return Indentation{indent_level}; }
 
     void emit_inputs_struct();
     void emit_generator_params_struct();
 };
 
-std::string StubEmitter::indent() {
-    std::ostringstream o;
-    for (int i = 0; i < indent_level; i++) {
-        o << "  ";
-    }
-    return o.str();
-}
-
 void StubEmitter::emit_generator_params_struct() {
     const auto &v = generator_params;
     std::string name = "GeneratorParams";
-    stream << indent() << "struct " << name << " final {\n";
+    stream << get_indent() << "struct " << name << " final {\n";
     indent_level++;
     if (!v.empty()) {
         for (auto p : v) {
-            stream << indent() << p->get_c_type() << " " << p->name << "{ " << p->get_default_value() << " };\n";
+            stream << get_indent() << p->get_c_type() << " " << p->name << "{ " << p->get_default_value() << " };\n";
         }
         stream << "\n";
     }
 
-    stream << indent() << name << "() {}\n";
+    stream << get_indent() << name << "() {}\n";
     stream << "\n";
 
     if (!v.empty()) {
-        stream << indent() << name << "(\n";
+        stream << get_indent() << name << "(\n";
         indent_level++;
         std::string comma = "";
         for (auto p : v) {
-            stream << indent() << comma << p->get_c_type() << " " << p->name << "\n";
+            stream << get_indent() << comma << p->get_c_type() << " " << p->name << "\n";
             comma = ", ";
         }
         indent_level--;
-        stream << indent() << ") : \n";
+        stream << get_indent() << ") : \n";
         indent_level++;
         comma = "";
         for (auto p : v) {
-            stream << indent() << comma << p->name << "(" << p->name << ")\n";
+            stream << get_indent() << comma << p->name << "(" << p->name << ")\n";
             comma = ", ";
         }
         indent_level--;
-        stream << indent() << "{\n";
-        stream << indent() << "}\n";
+        stream << get_indent() << "{\n";
+        stream << get_indent() << "}\n";
         stream << "\n";
     }
 
-    stream << indent() << "inline HALIDE_NO_USER_CODE_INLINE Halide::Internal::GeneratorParamsMap to_generator_params_map() const {\n";
+    stream << get_indent() << "inline HALIDE_NO_USER_CODE_INLINE Halide::Internal::GeneratorParamsMap to_generator_params_map() const {\n";
     indent_level++;
-    stream << indent() << "return {\n";
+    stream << get_indent() << "return {\n";
     indent_level++;
     std::string comma = "";
     for (auto p : v) {
-        stream << indent() << comma << "{\"" << p->name << "\", ";
+        stream << get_indent() << comma << "{\"" << p->name << "\", ";
         if (p->is_looplevel_param()) {
             stream << p->name << "}\n";
         } else {
@@ -305,12 +298,12 @@ void StubEmitter::emit_generator_params_struct() {
         comma = ", ";
     }
     indent_level--;
-    stream << indent() << "};\n";
+    stream << get_indent() << "};\n";
     indent_level--;
-    stream << indent() << "}\n";
+    stream << get_indent() << "}\n";
 
     indent_level--;
-    stream << indent() << "};\n";
+    stream << get_indent() << "};\n";
     stream << "\n";
 }
 
@@ -329,38 +322,38 @@ void StubEmitter::emit_inputs_struct() {
     }
 
     const std::string name = "Inputs";
-    stream << indent() << "struct " << name << " final {\n";
+    stream << get_indent() << "struct " << name << " final {\n";
     indent_level++;
     for (auto in : in_info) {
-        stream << indent() << in.c_type << " " << in.name << ";\n";
+        stream << get_indent() << in.c_type << " " << in.name << ";\n";
     }
     stream << "\n";
 
-    stream << indent() << name << "() {}\n";
+    stream << get_indent() << name << "() {}\n";
     stream << "\n";
     if (!in_info.empty()) {
-        stream << indent() << name << "(\n";
+        stream << get_indent() << name << "(\n";
         indent_level++;
         std::string comma = "";
         for (auto in : in_info) {
-            stream << indent() << comma << "const " << in.c_type << "& " << in.name << "\n";
+            stream << get_indent() << comma << "const " << in.c_type << "& " << in.name << "\n";
             comma = ", ";
         }
         indent_level--;
-        stream << indent() << ") : \n";
+        stream << get_indent() << ") : \n";
         indent_level++;
         comma = "";
         for (auto in : in_info) {
-            stream << indent() << comma << in.name << "(" << in.name << ")\n";
+            stream << get_indent() << comma << in.name << "(" << in.name << ")\n";
             comma = ", ";
         }
         indent_level--;
-        stream << indent() << "{\n";
-        stream << indent() << "}\n";
+        stream << get_indent() << "{\n";
+        stream << get_indent() << "}\n";
 
         indent_level--;
     }
-    stream << indent() << "};\n";
+    stream << get_indent() << "};\n";
     stream << "\n";
 }
 
@@ -410,21 +403,21 @@ void StubEmitter::emit() {
     }
     guard << "_" << class_name;
 
-    stream << indent() << "#ifndef " << guard.str() << "\n";
-    stream << indent() << "#define " << guard.str() << "\n";
+    stream << get_indent() << "#ifndef " << guard.str() << "\n";
+    stream << get_indent() << "#define " << guard.str() << "\n";
     stream << "\n";
 
-    stream << indent() << "/* MACHINE-GENERATED - DO NOT EDIT */\n";
+    stream << get_indent() << "/* MACHINE-GENERATED - DO NOT EDIT */\n";
     stream << "\n";
 
-    stream << indent() << "#include <cassert>\n";
-    stream << indent() << "#include <map>\n";
-    stream << indent() << "#include <memory>\n";
-    stream << indent() << "#include <string>\n";
-    stream << indent() << "#include <utility>\n";
-    stream << indent() << "#include <vector>\n";
+    stream << get_indent() << "#include <cassert>\n";
+    stream << get_indent() << "#include <map>\n";
+    stream << get_indent() << "#include <memory>\n";
+    stream << get_indent() << "#include <string>\n";
+    stream << get_indent() << "#include <utility>\n";
+    stream << get_indent() << "#include <vector>\n";
     stream << "\n";
-    stream << indent() << "#include \"Halide.h\"\n";
+    stream << get_indent() << "#include \"Halide.h\"\n";
     stream << "\n";
 
     stream << "namespace halide_register_generator {\n";
@@ -435,7 +428,7 @@ void StubEmitter::emit() {
     stream << "\n";
 
     for (const auto &ns : namespaces) {
-        stream << indent() << "namespace " << ns << " {\n";
+        stream << get_indent() << "namespace " << ns << " {\n";
     }
     stream << "\n";
 
@@ -445,23 +438,23 @@ void StubEmitter::emit() {
         stream << decl << "\n";
     }
 
-    stream << indent() << "class " << class_name << " final : public Halide::NamesInterface {\n";
-    stream << indent() << "public:\n";
+    stream << get_indent() << "class " << class_name << " final : public Halide::NamesInterface {\n";
+    stream << get_indent() << "public:\n";
     indent_level++;
 
     emit_inputs_struct();
     emit_generator_params_struct();
 
-    stream << indent() << "struct Outputs final {\n";
+    stream << get_indent() << "struct Outputs final {\n";
     indent_level++;
-    stream << indent() << "// Outputs\n";
+    stream << get_indent() << "// Outputs\n";
     for (const auto &out : out_info) {
-        stream << indent() << out.ctype << " " << out.name << ";\n";
+        stream << get_indent() << out.ctype << " " << out.name << ";\n";
     }
 
     stream << "\n";
-    stream << indent() << "// The Target used\n";
-    stream << indent() << "Target target;\n";
+    stream << get_indent() << "// The Target used\n";
+    stream << get_indent() << "Target target;\n";
 
     if (out_info.size() == 1) {
         stream << "\n";
@@ -469,179 +462,179 @@ void StubEmitter::emit() {
             std::string name = out_info.at(0).name;
             auto output = outputs[0];
             if (output->is_array()) {
-                stream << indent() << "operator std::vector<Halide::Func>() const {\n";
+                stream << get_indent() << "operator std::vector<Halide::Func>() const {\n";
                 indent_level++;
-                stream << indent() << "return " << name << ";\n";
+                stream << get_indent() << "return " << name << ";\n";
                 indent_level--;
-                stream << indent() << "}\n";
+                stream << get_indent() << "}\n";
 
-                stream << indent() << "Halide::Func operator[](size_t i) const {\n";
+                stream << get_indent() << "Halide::Func operator[](size_t i) const {\n";
                 indent_level++;
-                stream << indent() << "return " << name << "[i];\n";
+                stream << get_indent() << "return " << name << "[i];\n";
                 indent_level--;
-                stream << indent() << "}\n";
+                stream << get_indent() << "}\n";
 
-                stream << indent() << "Halide::Func at(size_t i) const {\n";
+                stream << get_indent() << "Halide::Func at(size_t i) const {\n";
                 indent_level++;
-                stream << indent() << "return " << name << ".at(i);\n";
+                stream << get_indent() << "return " << name << ".at(i);\n";
                 indent_level--;
-                stream << indent() << "}\n";
+                stream << get_indent() << "}\n";
 
-                stream << indent() << "// operator operator()() overloads omitted because the sole Output is array-of-Func.\n";
+                stream << get_indent() << "// operator operator()() overloads omitted because the sole Output is array-of-Func.\n";
             } else {
                 // If there is exactly one output, add overloads
                 // for operator Func and operator().
-                stream << indent() << "operator Halide::Func() const {\n";
+                stream << get_indent() << "operator Halide::Func() const {\n";
                 indent_level++;
-                stream << indent() << "return " << name << ";\n";
+                stream << get_indent() << "return " << name << ";\n";
                 indent_level--;
-                stream << indent() << "}\n";
+                stream << get_indent() << "}\n";
 
                 stream << "\n";
-                stream << indent() << "template <typename... Args>\n";
-                stream << indent() << "Halide::FuncRef operator()(Args&&... args) const {\n";
+                stream << get_indent() << "template <typename... Args>\n";
+                stream << get_indent() << "Halide::FuncRef operator()(Args&&... args) const {\n";
                 indent_level++;
-                stream << indent() << "return " << name << "(std::forward<Args>(args)...);\n";
+                stream << get_indent() << "return " << name << "(std::forward<Args>(args)...);\n";
                 indent_level--;
-                stream << indent() << "}\n";
+                stream << get_indent() << "}\n";
 
                 stream << "\n";
-                stream << indent() << "template <typename ExprOrVar>\n";
-                stream << indent() << "Halide::FuncRef operator()(std::vector<ExprOrVar> args) const {\n";
+                stream << get_indent() << "template <typename ExprOrVar>\n";
+                stream << get_indent() << "Halide::FuncRef operator()(std::vector<ExprOrVar> args) const {\n";
                 indent_level++;
-                stream << indent() << "return " << name << "()(args);\n";
+                stream << get_indent() << "return " << name << "()(args);\n";
                 indent_level--;
-                stream << indent() << "}\n";
+                stream << get_indent() << "}\n";
             }
         } else {
-            stream << indent() << "// operator Func() and operator()() overloads omitted because the sole Output is not Func.\n";
+            stream << get_indent() << "// operator Func() and operator()() overloads omitted because the sole Output is not Func.\n";
         }
     }
 
     stream << "\n";
     if (all_outputs_are_func) {
-        stream << indent() << "Halide::Pipeline get_pipeline() const {\n";
+        stream << get_indent() << "Halide::Pipeline get_pipeline() const {\n";
         indent_level++;
-        stream << indent() << "return Halide::Pipeline(std::vector<Halide::Func>{\n";
+        stream << get_indent() << "return Halide::Pipeline(std::vector<Halide::Func>{\n";
         indent_level++;
         int commas = (int)out_info.size() - 1;
         for (const auto &out : out_info) {
-            stream << indent() << out.name << (commas-- ? "," : "") << "\n";
+            stream << get_indent() << out.name << (commas-- ? "," : "") << "\n";
         }
         indent_level--;
-        stream << indent() << "});\n";
+        stream << get_indent() << "});\n";
         indent_level--;
-        stream << indent() << "}\n";
+        stream << get_indent() << "}\n";
 
         stream << "\n";
-        stream << indent() << "Halide::Realization realize(std::vector<int32_t> sizes) {\n";
+        stream << get_indent() << "Halide::Realization realize(std::vector<int32_t> sizes) {\n";
         indent_level++;
-        stream << indent() << "return get_pipeline().realize(sizes, target);\n";
+        stream << get_indent() << "return get_pipeline().realize(sizes, target);\n";
         indent_level--;
-        stream << indent() << "}\n";
+        stream << get_indent() << "}\n";
 
         stream << "\n";
-        stream << indent() << "template <typename... Args, typename std::enable_if<Halide::Internal::NoRealizations<Args...>::value>::type * = nullptr>\n";
-        stream << indent() << "Halide::Realization realize(Args&&... args) {\n";
+        stream << get_indent() << "template <typename... Args, typename std::enable_if<Halide::Internal::NoRealizations<Args...>::value>::type * = nullptr>\n";
+        stream << get_indent() << "Halide::Realization realize(Args&&... args) {\n";
         indent_level++;
-        stream << indent() << "return get_pipeline().realize(std::forward<Args>(args)..., target);\n";
+        stream << get_indent() << "return get_pipeline().realize(std::forward<Args>(args)..., target);\n";
         indent_level--;
-        stream << indent() << "}\n";
+        stream << get_indent() << "}\n";
 
         stream << "\n";
-        stream << indent() << "void realize(Halide::Realization r) {\n";
+        stream << get_indent() << "void realize(Halide::Realization r) {\n";
         indent_level++;
-        stream << indent() << "get_pipeline().realize(r, target);\n";
+        stream << get_indent() << "get_pipeline().realize(r, target);\n";
         indent_level--;
-        stream << indent() << "}\n";
+        stream << get_indent() << "}\n";
     } else {
-        stream << indent() << "// get_pipeline() and realize() overloads omitted because some Outputs are not Func.\n";
+        stream << get_indent() << "// get_pipeline() and realize() overloads omitted because some Outputs are not Func.\n";
     }
 
     indent_level--;
-    stream << indent() << "};\n";
+    stream << get_indent() << "};\n";
     stream << "\n";
 
-    stream << indent() << "HALIDE_NO_USER_CODE_INLINE static Outputs generate(\n";
+    stream << get_indent() << "HALIDE_NO_USER_CODE_INLINE static Outputs generate(\n";
     indent_level++;
-    stream << indent() << "const GeneratorContext& context,\n";
-    stream << indent() << "const Inputs& inputs,\n";
-    stream << indent() << "const GeneratorParams& generator_params = GeneratorParams()\n";
+    stream << get_indent() << "const GeneratorContext& context,\n";
+    stream << get_indent() << "const Inputs& inputs,\n";
+    stream << get_indent() << "const GeneratorParams& generator_params = GeneratorParams()\n";
     indent_level--;
-    stream << indent() << ")\n";
-    stream << indent() << "{\n";
+    stream << get_indent() << ")\n";
+    stream << get_indent() << "{\n";
     indent_level++;
-    stream << indent() << "using Stub = Halide::Internal::GeneratorStub;\n";
-    stream << indent() << "Stub stub(\n";
+    stream << get_indent() << "using Stub = Halide::Internal::GeneratorStub;\n";
+    stream << get_indent() << "Stub stub(\n";
     indent_level++;
-    stream << indent() << "context,\n";
-    stream << indent() << "halide_register_generator::" << generator_registered_name << "_ns::factory,\n";
-    stream << indent() << "generator_params.to_generator_params_map(),\n";
-    stream << indent() << "{\n";
+    stream << get_indent() << "context,\n";
+    stream << get_indent() << "halide_register_generator::" << generator_registered_name << "_ns::factory,\n";
+    stream << get_indent() << "generator_params.to_generator_params_map(),\n";
+    stream << get_indent() << "{\n";
     indent_level++;
     for (size_t i = 0; i < inputs.size(); ++i) {
-        stream << indent() << "Stub::to_stub_input_vector(inputs." << inputs[i]->name() << ")";
+        stream << get_indent() << "Stub::to_stub_input_vector(inputs." << inputs[i]->name() << ")";
         stream << ",\n";
     }
     indent_level--;
-    stream << indent() << "}\n";
+    stream << get_indent() << "}\n";
     indent_level--;
-    stream << indent() << ");\n";
+    stream << get_indent() << ");\n";
 
-    stream << indent() << "return {\n";
+    stream << get_indent() << "return {\n";
     indent_level++;
     for (const auto &out : out_info) {
-        stream << indent() << "stub." << out.getter << ",\n";
+        stream << get_indent() << "stub." << out.getter << ",\n";
     }
-    stream << indent() << "stub.generator->get_target()\n";
+    stream << get_indent() << "stub.generator->get_target()\n";
     indent_level--;
-    stream << indent() << "};\n";
+    stream << get_indent() << "};\n";
     indent_level--;
-    stream << indent() << "}\n";
+    stream << get_indent() << "}\n";
     stream << "\n";
 
-    stream << indent() << "// overload to allow GeneratorContext-pointer\n";
-    stream << indent() << "inline static Outputs generate(\n";
+    stream << get_indent() << "// overload to allow GeneratorContext-pointer\n";
+    stream << get_indent() << "inline static Outputs generate(\n";
     indent_level++;
-    stream << indent() << "const GeneratorContext* context,\n";
-    stream << indent() << "const Inputs& inputs,\n";
-    stream << indent() << "const GeneratorParams& generator_params = GeneratorParams()\n";
+    stream << get_indent() << "const GeneratorContext* context,\n";
+    stream << get_indent() << "const Inputs& inputs,\n";
+    stream << get_indent() << "const GeneratorParams& generator_params = GeneratorParams()\n";
     indent_level--;
-    stream << indent() << ")\n";
-    stream << indent() << "{\n";
+    stream << get_indent() << ")\n";
+    stream << get_indent() << "{\n";
     indent_level++;
-    stream << indent() << "return generate(*context, inputs, generator_params);\n";
+    stream << get_indent() << "return generate(*context, inputs, generator_params);\n";
     indent_level--;
-    stream << indent() << "}\n";
+    stream << get_indent() << "}\n";
     stream << "\n";
 
-    stream << indent() << "// overload to allow Target instead of GeneratorContext.\n";
-    stream << indent() << "inline static Outputs generate(\n";
+    stream << get_indent() << "// overload to allow Target instead of GeneratorContext.\n";
+    stream << get_indent() << "inline static Outputs generate(\n";
     indent_level++;
-    stream << indent() << "const Target& target,\n";
-    stream << indent() << "const Inputs& inputs,\n";
-    stream << indent() << "const GeneratorParams& generator_params = GeneratorParams()\n";
+    stream << get_indent() << "const Target& target,\n";
+    stream << get_indent() << "const Inputs& inputs,\n";
+    stream << get_indent() << "const GeneratorParams& generator_params = GeneratorParams()\n";
     indent_level--;
-    stream << indent() << ")\n";
-    stream << indent() << "{\n";
+    stream << get_indent() << ")\n";
+    stream << get_indent() << "{\n";
     indent_level++;
-    stream << indent() << "return generate(Halide::GeneratorContext(target), inputs, generator_params);\n";
+    stream << get_indent() << "return generate(Halide::GeneratorContext(target), inputs, generator_params);\n";
     indent_level--;
-    stream << indent() << "}\n";
+    stream << get_indent() << "}\n";
     stream << "\n";
 
-    stream << indent() << class_name << "() = delete;\n";
+    stream << get_indent() << class_name << "() = delete;\n";
 
     indent_level--;
-    stream << indent() << "};\n";
+    stream << get_indent() << "};\n";
     stream << "\n";
 
     for (int i = (int)namespaces.size() - 1; i >= 0 ; --i) {
-        stream << indent() << "}  // namespace " << namespaces[i] << "\n";
+        stream << get_indent() << "}  // namespace " << namespaces[i] << "\n";
     }
     stream << "\n";
 
-    stream << indent() << "#endif  // " << guard.str() << "\n";
+    stream << get_indent() << "#endif  // " << guard.str() << "\n";
 }
 
 GeneratorStub::GeneratorStub(const GeneratorContext &context,

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -80,6 +80,11 @@ std::ostream &operator<<(std::ostream &stream, const LoweredFunc &);
 /** Emit a halide linkage value in a human readable format */
 std::ostream &operator<<(std::ostream &stream, const LinkageType &);
 
+struct Indentation {
+    int indent;
+};
+std::ostream &operator<<(std::ostream &stream, const Indentation &);
+
 /** An IRVisitor that emits IR to the given output stream in a human
  * readable form. Can be subclassed if you want to modify the way in
  * which it prints.
@@ -105,15 +110,14 @@ public:
     static void test();
 
 protected:
+    Indentation get_indent() const { return Indentation{indent}; }
+
     /** The stream on which we're outputting */
     std::ostream &stream;
 
     /** The current indentation level, useful for pretty-printing
      * statements */
     int indent;
-
-    /** Emit spaces according to the current indentation level */
-    void do_indent();
 
     /** The symbols whose types can be inferred from values printed
      * already. */
@@ -167,6 +171,7 @@ protected:
     void visit(const Shuffle *) override;
     void visit(const Prefetch *) override;
 };
+
 }  // namespace Internal
 }  // namespace Halide
 

--- a/src/PrintLoopNest.cpp
+++ b/src/PrintLoopNest.cpp
@@ -32,11 +32,7 @@ private:
 
     using IRVisitor::visit;
 
-    void do_indent() {
-        for (int i = 0; i < indent; i++) {
-            out << ' ';
-        }
-    }
+    Indentation get_indent() const { return Indentation{indent}; }
 
     string simplify_var_name(const string &s) {
         return simplify_name(s, false);
@@ -75,9 +71,7 @@ private:
     }
 
     void visit(const For *op) override {
-        do_indent();
-
-        out << op->for_type << ' ' << simplify_var_name(op->name);
+        out << get_indent() << op->for_type << ' ' << simplify_var_name(op->name);
 
         // If the min or extent are constants, print them. At this
         // stage they're all variables.
@@ -113,7 +107,7 @@ private:
         if (it != env.end() &&
             !(it->second.schedule().store_level() ==
               it->second.schedule().compute_level())) {
-            do_indent();
+            out << get_indent();
             out << "store " << simplify_func_name(op->name) << ":\n";
             indent += 2;
             op->body.accept(this);
@@ -124,7 +118,7 @@ private:
     }
 
     void visit(const ProducerConsumer *op) override {
-        do_indent();
+        out << get_indent();
         if (op->is_producer) {
             out << "produce " << simplify_func_name(op->name) << ":\n";
         } else {
@@ -136,8 +130,7 @@ private:
     }
 
     void visit(const Provide *op) override {
-        do_indent();
-        out << simplify_func_name(op->name) << "(...) = ...\n";
+        out << get_indent() << simplify_func_name(op->name) << "(...) = ...\n";
     }
 
     void visit(const LetStmt *op) override {

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1590,11 +1590,7 @@ class PrintUsesOfFunc : public IRVisitor {
     bool last_print_was_ellipsis = false;
     std::ostream &stream;
 
-    void do_indent() {
-        for (int i = 0; i < indent; i++) {
-            stream << "  ";
-        }
-    }
+    Indentation get_indent() const { return Indentation{indent}; }
 
     void visit(const For *op) override {
         if (ends_with(op->name, Var::outermost().name()) ||
@@ -1608,13 +1604,11 @@ class PrintUsesOfFunc : public IRVisitor {
             op->body.accept(&uses);
             if (!uses.result) {
                 if (!last_print_was_ellipsis) {
-                    do_indent();
-                    stream << "...\n";
+                    stream << get_indent() << "...\n";
                     last_print_was_ellipsis = true;
                 }
             } else {
-                do_indent();
-                stream << "for " << op->name << ":\n";
+                stream << get_indent() << "for " << op->name << ":\n";
                 last_print_was_ellipsis = false;
                 indent++;
             }
@@ -1637,8 +1631,7 @@ class PrintUsesOfFunc : public IRVisitor {
 
     void visit(const Call *op) override {
         if (op->name == func) {
-            do_indent();
-            stream << caller << " uses " << func << "\n";
+            stream << get_indent() << caller << " uses " << func << "\n";
             last_print_was_ellipsis = false;
         } else {
             IRVisitor::visit(op);
@@ -1649,8 +1642,7 @@ class PrintUsesOfFunc : public IRVisitor {
         if (op->type.is_handle() &&
             starts_with(op->name, func + ".") &&
             ends_with(op->name, ".buffer")) {
-            do_indent();
-            stream << caller << " uses " << func << "\n";
+            stream << get_indent() << caller << " uses " << func << "\n";
             last_print_was_ellipsis = false;
         } else {
             IRVisitor::visit(op);


### PR DESCRIPTION
It's always bugged me that IRPrinter used a separate call (`do_indent()`) to indent outputs, rather than some approach that mixed into the stream flow of operator<<.

This is a completely nonessential change that nevertheless (I think) improves the code; it creates a new type, `Indentation`, which has an `operator<<` overload. This means that stream writes that begin with an indent are more obvious (since it's part of the ordinary stream syntax).