### PR TITLE
Allowing f[g[1]] = 2 in Python bindings

### DIFF
--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -160,7 +160,7 @@ def test_basics4():
     g[x] = 1
     f[x] = 0
     r = hl.RDom([(0, 100)])
-    f[g[1]] = 2
+    f[g[r]] = 2
     f.compute_root()
     f.compile_jit()
 

--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -160,9 +160,9 @@ def test_basics4():
     f = hl.Func('f')
     g = hl.Func('g')
     g[x] = 1
-    f[x] = 0
+    f[x] = 0.0
     r = hl.RDom([(0, 100)])
-    f[g[r]] = 2
+    f[g[r]] = 2.3 # This triggers a warning of double-to-float conversion
     f.compute_root()
     f.compile_jit()
 

--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -154,6 +154,8 @@ def test_basics3():
     left += ss
 
 def test_basics4():
+    # Test for f[g[r]] = ...
+    # See https://github.com/halide/Halide/issues/4285
     x = hl.Var('x')
     f = hl.Func('f')
     g = hl.Func('g')

--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -153,6 +153,17 @@ def test_basics3():
     left += 5
     left += ss
 
+def test_basics4():
+    x = hl.Var('x')
+    f = hl.Func('f')
+    g = hl.Func('g')
+    g[x] = 1
+    f[x] = 0
+    r = hl.RDom([(0, 100)])
+    f[g[1]] = 2
+    f.compute_root()
+    f.compile_jit()
+
 def test_float_or_int():
     x = hl.Var('x')
     i32, f32 =  hl.Int(32), hl.Float(32)
@@ -214,3 +225,4 @@ if __name__ == "__main__":
     test_basics()
     test_basics2()
     test_basics3()
+    test_basics4()

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -36,6 +36,25 @@ void define_set(py::class_<Func> &func_class) {
     ;
 }
 
+// See the usages below this function to see why we are specializing this function.
+template<typename RHS>
+void define_set_func_ref(py::class_<Func> &func_class) {
+    func_class
+        .def("__setitem__", [](Func &func, const FuncRef &lhs, const RHS &rhs) -> Stage {
+            return func(lhs) = rhs;
+        });
+}
+
+// Special case: there is no implicit conversion of double in C++ Halide
+// but there is implicit conversion of double in Python.
+template<>
+void define_set_func_ref<double>(py::class_<Func> &func_class) {
+    func_class
+        .def("__setitem__", [](Func &func, const FuncRef &lhs, const double &rhs) -> Stage {
+            return func(lhs) = Expr(rhs);
+        });
+}
+
 py::object realization_to_object(const Realization &r) {
     // Only one Buffer -> just return it
     if (r.size() == 1) {
@@ -338,6 +357,22 @@ void define_func(py::module &m) {
     define_get<std::vector<Expr>>(func_class);
     define_get<Var>(func_class);
     define_get<std::vector<Var>>(func_class);
+
+    // Special cases of f[g[...]] = ...
+    // We need to capture this case here since otherwise
+    // pybind11 would try to convert g[...], which is a FuncRef
+    // to a list of Var. 
+    // However, to do this it has to check g[...][0] is a Var or not.
+    // If g is not defined as a Tuple this results in a runtime error 
+    // inside Halide.
+    // We also can't rely on implicit conversion in pybind11 since it
+    // happens after all function overloads have been visited.
+    define_set_func_ref<FuncRef>(func_class);
+    define_set_func_ref<Expr>(func_class);
+    define_set_func_ref<Tuple>(func_class);
+    define_set_func_ref<int>(func_class);
+    define_set_func_ref<float>(func_class);
+    define_set_func_ref<double>(func_class);
 
     // LHS(Var, ...Var) is LHS of an ordinary Func definition.
     define_set<Var, FuncRef>(func_class);

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -56,9 +56,11 @@ void define_set_func_ref<double>(py::class_<Func> &func_class) {
             float f = rhs;
             if (Internal::reinterpret_bits<uint64_t>(rhs) !=
                     Internal::reinterpret_bits<uint64_t>((double)f)) {
+                double diff = rhs - f;
                 std::ostringstream os;
                 os << "Loss of precision detected when casting " <<
-                    rhs << " to a single precision float.";
+                    rhs << " to a single precision float. The difference is " <<
+                    diff << ".";
                 std::string msg = os.str();
                 PyErr_WarnEx(NULL, msg.c_str(), 1);
             }
@@ -382,7 +384,6 @@ void define_func(py::module &m) {
     define_set_func_ref<Expr>(func_class);
     define_set_func_ref<Tuple>(func_class);
     define_set_func_ref<int>(func_class);
-    define_set_func_ref<float>(func_class);
     define_set_func_ref<double>(func_class);
 
     // LHS(Var, ...Var) is LHS of an ordinary Func definition.


### PR DESCRIPTION
An attempt to fix https://github.com/halide/Halide/issues/4285. As mentioned the issue is that when pybind11 is visiting all possible overloaded function for `Func.__setitem__(key, value)`, it tries to convert the key `g[1]` into a list of `Var` or `Expr`. To do this it checks whether `g[1][0]` is a Var/Expr or not, but this triggers a runtime error inside Halide, since `g` is not a Tuple.

My proposed solution to this is to define a set of overloaded functions so that the overloading test ends before it enters the list testing conversion phase. Another possible fix is to rewrite `__getitem__` in FuncRef such that it doesn't trigger runtime error even when `g` is not a Tuple.