### PR TITLE
CMake: add optional LLVM_USE_SHARED_LLVM_LIBRARY option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-nm${CMAKE_EXECUTABLE_SUFFIX}"
 file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/clang${CMAKE_EXECUTABLE_SUFFIX}" CLANG)
 file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-config${CMAKE_EXECUTABLE_SUFFIX}" LLVM_CONFIG)
 
-if(HALIDE_SHARED_LLVM_LIBRARY)
+if(LLVM_USE_SHARED_LLVM_LIBRARY)
   # Since we will be linking to the shared LLVM library,
   # we will get all the transitive dependencies for free automagically.
   set(HALIDE_SYSTEM_LIBS)
@@ -191,7 +191,7 @@ option(TARGET_OPENGL "Include OpenGL/GLSL target" ON)
 option(TARGET_OPENGLCOMPUTE "Include OpenGLCompute target" ON)
 option(TARGET_D3D12COMPUTE "Include Direct3D 12 Compute target" ON)
 option(HALIDE_SHARED_LIBRARY "Build as a shared library" ON)
-option(HALIDE_SHARED_LLVM_LIBRARY "Use shared versions of LLVM libraries" OFF)
+option(LLVM_USE_SHARED_LLVM_LIBRARY "Use shared versions of LLVM libraries" OFF)
 option(HALIDE_ENABLE_RTTI "Enable RTTI" ${LLVM_ENABLE_RTTI})
 option(HALIDE_ENABLE_EXCEPTIONS "Enable exceptions" ${LLVM_ENABLE_EH})
 option(HALIDE_USE_CODEMODEL_LARGE "Use the Large LLVM codemodel" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,16 +75,22 @@ file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-nm${CMAKE_EXECUTABLE_SUFFIX}"
 file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/clang${CMAKE_EXECUTABLE_SUFFIX}" CLANG)
 file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-config${CMAKE_EXECUTABLE_SUFFIX}" LLVM_CONFIG)
 
-# LLVM doesn't appear to expose --system-libs via its CMake interface,
-# so we must shell out to llvm-config to find this info
-execute_process(COMMAND ${LLVM_CONFIG} --system-libs --link-static OUTPUT_VARIABLE HALIDE_SYSTEM_LIBS_RAW)
-string(STRIP "${HALIDE_SYSTEM_LIBS_RAW}" HALIDE_SYSTEM_LIBS_RAW)  # strip whitespace from start & end
-string(REPLACE " " ";" HALIDE_SYSTEM_LIBS "${HALIDE_SYSTEM_LIBS_RAW}")  # convert into a list
-if("${HALIDE_SYSTEM_LIBS}" STREQUAL "")
-  # It's theoretically possible that this could be legitimately empty,
-  # but in practice that doesn't really happen, so we'll assume it means we
-  # aren't configured correctly.
-  message(WARNING "'llvm-config --system-libs --link-static' is empty; this is possibly wrong.")
+if(HALIDE_SHARED_LLVM_LIBRARY)
+  # Since we will be linking to the shared LLVM library,
+  # we will get all the transitive dependencies for free automagically.
+  set(HALIDE_SYSTEM_LIBS)
+else()
+  # LLVM doesn't appear to expose --system-libs via its CMake interface,
+  # so we must shell out to llvm-config to find this info
+  execute_process(COMMAND ${LLVM_CONFIG} --system-libs --link-static OUTPUT_VARIABLE HALIDE_SYSTEM_LIBS_RAW)
+  string(STRIP "${HALIDE_SYSTEM_LIBS_RAW}" HALIDE_SYSTEM_LIBS_RAW)  # strip whitespace from start & end
+  string(REPLACE " " ";" HALIDE_SYSTEM_LIBS "${HALIDE_SYSTEM_LIBS_RAW}")  # convert into a list
+  if("${HALIDE_SYSTEM_LIBS}" STREQUAL "")
+    # It's theoretically possible that this could be legitimately empty,
+    # but in practice that doesn't really happen, so we'll assume it means we
+    # aren't configured correctly.
+    message(WARNING "'llvm-config --system-libs --link-static' is empty; this is possibly wrong.")
+  endif()
 endif()
 
 execute_process(COMMAND ${LLVM_CONFIG} --cxxflags OUTPUT_VARIABLE LLVM_CONFIG_CXXFLAGS)
@@ -185,6 +191,7 @@ option(TARGET_OPENGL "Include OpenGL/GLSL target" ON)
 option(TARGET_OPENGLCOMPUTE "Include OpenGLCompute target" ON)
 option(TARGET_D3D12COMPUTE "Include Direct3D 12 Compute target" ON)
 option(HALIDE_SHARED_LIBRARY "Build as a shared library" ON)
+option(HALIDE_SHARED_LLVM_LIBRARY "Use shared versions of LLVM libraries" OFF)
 option(HALIDE_ENABLE_RTTI "Enable RTTI" ${LLVM_ENABLE_RTTI})
 option(HALIDE_ENABLE_EXCEPTIONS "Enable exceptions" ${LLVM_ENABLE_EH})
 option(HALIDE_USE_CODEMODEL_LARGE "Use the Large LLVM codemodel" OFF)

--- a/halide.cmake
+++ b/halide.cmake
@@ -712,7 +712,7 @@ if("${HALIDE_TOOLS_DIR}" STREQUAL "" OR
   endif()
 endif()
 
-if("${HALIDE_SYSTEM_LIBS}" STREQUAL "")
+if(NOT DEFINED HALIDE_SYSTEM_LIBS)
   # If HALIDE_SYSTEM_LIBS isn't defined, we are compiling against a Halide distribution
   # folder; this is normally captured in the halide_config.cmake file. If that file
   # exists in the same directory as this one, just include it here.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -761,16 +761,16 @@ endif()
 # When building a shared library the LLVM libraries will either be
 # embedded or linked into the Halide library. When building a static library
 # LLVM is not embedded/linked but CMake knows that when building an executable
-# against the Halide static library that it needs to link LLVM too, IFF the
-# halide is being built as a subproject. (which means, statically-built halide
-# doesn't work out-of-installation directory)
+# against Halide static library that it needs to link LLVM too, IFF the
+# halide is being built as a subproject. (Which means, statically-built Halide
+# doesn't work out-of-installation directory.)
 # FIXME: migrate to proper cmake config magic.
-if(HALIDE_SHARED_LLVM_LIBRARY)
+if(LLVM_USE_SHARED_LLVM_LIBRARY)
   set(LLVM_USE_SHARED "USE_SHARED")
 endif()
 llvm_config(Halide ${LLVM_USE_SHARED} ${LLVM_COMPONENTS})
 
-if (NOT MSVC AND NOT HALIDE_SHARED_LLVM_LIBRARY)
+if (NOT MSVC AND NOT LLVM_USE_SHARED_LLVM_LIBRARY)
   set(LLVM_CONFIG ${LLVM_TOOLS_BINARY_DIR}/llvm-config)
   execute_process(COMMAND "${LLVM_CONFIG}" --system-libs ${LLVM_COMPONENTS} OUTPUT_VARIABLE EXTRA_LIBS)
   string(STRIP EXTRA_LIBS "${EXTRA_LIBS}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -758,17 +758,19 @@ else()
   endif()
 endif()
 
-# Get the LLVM libraries we need
-llvm_map_components_to_libnames(LIBS ${LLVM_COMPONENTS})
+# When building a shared library the LLVM libraries will either be
+# embedded or linked into the Halide library. When building a static library
+# LLVM is not embedded/linked but CMake knows that when building an executable
+# against the Halide static library that it needs to link LLVM too, IFF the
+# halide is being built as a subproject. (which means, statically-built halide
+# doesn't work out-of-installation directory)
+# FIXME: migrate to proper cmake config magic.
+if(HALIDE_SHARED_LLVM_LIBRARY)
+  set(LLVM_USE_SHARED "USE_SHARED")
+endif()
+llvm_config(Halide ${LLVM_USE_SHARED} ${LLVM_COMPONENTS})
 
-# When building a shared library the LLVM libraries will be
-# embedded in the Halide library. When building a static library
-# LLVM is not embedded but CMake knows that when building an executable
-# against the Halide static library that it needs to link LLVM too so
-# PRIVATE scope is the correct choice here.
-target_link_libraries(Halide PRIVATE ${LIBS})
-
-if (NOT MSVC)
+if (NOT MSVC AND NOT HALIDE_SHARED_LLVM_LIBRARY)
   set(LLVM_CONFIG ${LLVM_TOOLS_BINARY_DIR}/llvm-config)
   execute_process(COMMAND "${LLVM_CONFIG}" --system-libs ${LLVM_COMPONENTS} OUTPUT_VARIABLE EXTRA_LIBS)
   string(STRIP EXTRA_LIBS "${EXTRA_LIBS}")


### PR DESCRIPTION
As discussed in https://github.com/halide/Halide/issues/4284
one important thing is to be able to link to shared versions
of LLVM libraries. This is off-by-default, so i don't believe
this should have any impact on existing users.

The important [existing] caveat to note is that i don't see
where those LLVM libraries-to-be-linked are specified anywhere
in the `halide_config.cmake`, so as long as you are
a. building static halide
and
b. not building halide as a cmake sub-project (via `add_subdirectory()`)
i don't see how the linking can succeed, both either with
old static LLVM libraries, and now with shared LLVM library.

The best i can tell `llvm-config --system-libs` is only needed
when linking to static libraries, to propagate their deps,
so let's not do that for shared LLVM libs.

And the switch to `llvm_config()` is the main thing here,
it internally handles `USE_SHARED`, and does `target_link_libraries()`.
