### PR TITLE
Autoscheduler: Weights::randomize(): silence clang's -Wimplicit-int-float-conversion

### DIFF
--- a/apps/autoscheduler/Weights.cpp
+++ b/apps/autoscheduler/Weights.cpp
@@ -19,7 +19,7 @@ void Weights::randomize(uint32_t seed) {
     // Fill the weights with random values
     for_each_buffer([&rng](Buffer<float> &w) {
         w.for_each_value([&rng](float &f) {
-            f = ((float)rng()) / rng.max() - 0.5f;
+            f = ((float)rng()) / ((float)rng.max()) - 0.5f;
         });
     });
 }


### PR DESCRIPTION
```
Halide/apps/autoscheduler/Weights.cpp:22:34: error: implicit conversion from 'std::mersenne_twister_engine<unsigned long, 32, 624, 397, 31, 2567483615, 11, 4294967295, 7, 2636928640, 15, 4022730752, 18, 1812433253>::result_type' (aka 'unsigned long') to 'float' changes value from 4294967295 to 4294967296 [-Werror,-Wimplicit-int-float-conversion]
            f = ((float)rng()) / rng.max() - 0.5f;
                               ~ ^~~~~~~~~
```

I think we should just make the cast explicit here?