### PR TITLE
Link libHalide for building libauto_schedule.so

### DIFF
--- a/apps/autoscheduler/Makefile
+++ b/apps/autoscheduler/Makefile
@@ -6,7 +6,7 @@ include ../support/autoscheduler.inc
 # autoscheduler can't find the libHalide symbols that it needs.
 $(GENERATOR_BIN)/demo.generator: demo_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) $(USE_EXPORT_DYNAMIC) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
+	$(CXX) $(CXXFLAGS) $(USE_EXPORT_DYNAMIC) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS) $(GENERATOR_LDFLAGS)
 
 # To use the autoscheduler, set a few environment variables and use the -p flag to the generator to load the autoscheduler as a plugin
 $(BIN)/%/demo.a: $(GENERATOR_BIN)/demo.generator $(AUTOSCHED_BIN)/libauto_schedule.so

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -126,7 +126,7 @@ endif
 GENERATOR_DEPS ?= $(LIB_HALIDE) $(HALIDE_DISTRIB_PATH)/include/Halide.h $(HALIDE_DISTRIB_PATH)/tools/GenGen.cpp
 
 # Generators which use autoscheduler plugin need to specify the linker where to find libHalide.so required by the plugin.
-GENERATOR_LDFLAGS ?= -Wl,-rpath=$(dir $(LIB_HALIDE))
+GENERATOR_LDFLAGS ?= -Wl,-rpath,$(dir $(LIB_HALIDE))
 
 LIBPNG_LIBS_DEFAULT = $(shell libpng-config --ldflags)
 LIBPNG_CXX_FLAGS ?= $(shell libpng-config --cflags)

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -125,6 +125,9 @@ endif
 
 GENERATOR_DEPS ?= $(LIB_HALIDE) $(HALIDE_DISTRIB_PATH)/include/Halide.h $(HALIDE_DISTRIB_PATH)/tools/GenGen.cpp
 
+# Generators which use autoscheduler plugin need to specify the linker where to find libHalide.so required by the plugin.
+GENERATOR_LDFLAGS ?= -Wl,-rpath=$(dir $(LIB_HALIDE))
+
 LIBPNG_LIBS_DEFAULT = $(shell libpng-config --ldflags)
 LIBPNG_CXX_FLAGS ?= $(shell libpng-config --cflags)
 # Workaround for libpng-config pointing to 64-bit versions on linux even when we're building for 32-bit

--- a/apps/support/autoscheduler.inc
+++ b/apps/support/autoscheduler.inc
@@ -54,7 +54,7 @@ $(AUTOSCHED_BIN)/libauto_schedule.so: $(AUTOSCHED_SRC)/AutoSchedule.cpp \
 										$(GENERATOR_DEPS) \
 										$(AUTOSCHED_BIN)/auto_schedule_runtime.a
 	@mkdir -p $(@D)
-	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC $(CXXFLAGS) -g $(OPTIMIZE) -I $(AUTOSCHED_BIN)/cost_model $(filter-out %.h,$^) -o $@ $(HALIDE_SYSTEM_LIBS)
+	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC $(CXXFLAGS) -g $(OPTIMIZE) -I $(AUTOSCHED_BIN)/cost_model $(filter-out %.h $(LIB_HALIDE),$^) -o $@ $(HALIDE_SYSTEM_LIBS) -L$(dir $(LIB_HALIDE)) -lHalide
 
 $(AUTOSCHED_BIN)/retrain_cost_model: $(AUTOSCHED_SRC)/retrain_cost_model.cpp \
 									$(AUTOSCHED_SRC)/ASLog.cpp \

--- a/apps/support/autoscheduler.inc
+++ b/apps/support/autoscheduler.inc
@@ -54,7 +54,7 @@ $(AUTOSCHED_BIN)/libauto_schedule.so: $(AUTOSCHED_SRC)/AutoSchedule.cpp \
 										$(GENERATOR_DEPS) \
 										$(AUTOSCHED_BIN)/auto_schedule_runtime.a
 	@mkdir -p $(@D)
-	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC $(CXXFLAGS) -g $(OPTIMIZE) -I $(AUTOSCHED_BIN)/cost_model $(filter-out %.h $(LIB_HALIDE),$^) -o $@ $(HALIDE_SYSTEM_LIBS) -L$(dir $(LIB_HALIDE)) -lHalide
+	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC $(CXXFLAGS) -g $(OPTIMIZE) -I $(AUTOSCHED_BIN)/cost_model $(filter-out %.h $(LIB_HALIDE),$^) -o $@ $(HALIDE_SYSTEM_LIBS)
 
 $(AUTOSCHED_BIN)/retrain_cost_model: $(AUTOSCHED_SRC)/retrain_cost_model.cpp \
 									$(AUTOSCHED_SRC)/ASLog.cpp \


### PR DESCRIPTION
Passing libHalide.so as an input while building the autoscheduler
inside apps/autoscheduler is creating a dependency on libHalide for
the shared plugin library where libauto_schedule.so looks for
libHalide.so in the absolute path and fails to open if the libHalide
is not found in that path. This makes the plugin not portable, as it
warrants the libHalide.so to be present in the same location while using
the plugin.

Using readelf -d on the built libauto_schedule.so --

`(NEEDED)             Shared library: [/mnt/workspace/Halide/distrib/bin/libHalide.so]`

While using the plugin, if libHalide is loaded from other path, the
plugin fails to load as it searches for libHalide in the absolute
path used while building autoscheduler.

This change links to the built libHalide.so instead of passing it as
an input file while building experimental autoscheduler plugin
libauto_schedule.so.