### PR TITLE
Detect clang++ as host-compiler reliably

### DIFF
--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -47,7 +47,8 @@ OPTIMIZE ?= -O3
 CFLAGS += $(OPTIMIZE) -I $(HALIDE_DISTRIB_PATH)/include/ -I $(HALIDE_DISTRIB_PATH)/tools/ -I $(HALIDE_DISTRIB_PATH)/apps/support/
 CXXFLAGS += $(OPTIMIZE) -std=c++11 -I $(HALIDE_DISTRIB_PATH)/include/ -I $(HALIDE_DISTRIB_PATH)/tools/ $(SANITIZER_FLAGS) -Wall -Werror -Wno-unused-function -Wcast-qual -Wignored-qualifiers -Wno-comment -Wsign-compare -Wno-unknown-warning-option -Wno-psabi
 
-ifeq ($(CXX), clang++)
+CXX_VERSION = $(shell $(CXX) --version | head -n1)
+ifneq (,$(findstring clang,$(CXX_VERSION)))
 CXXFLAGS += $(findstring -stdlib=libc++, $(HALIDE_LLVM_CXX_FLAGS))
 endif
 


### PR DESCRIPTION
CXX may include absolute path to clang++ or
maybe symlinked to clang++. Detect that it points
to clang++ to check if Halide was built using libc++.