### PR TITLE
Warn user if using JIT + MSAN

### DIFF
--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -993,6 +993,14 @@ Pipeline::make_externs_jit_module(const Target &target,
 }
 
 int Pipeline::call_jit_code(const Target &target, const JITCallArgs &args) {
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+    user_warning << "MSAN does not support JIT compilers of any sort, and will report "
+                    "false positives when used in conjunction with the Halide JIT. "
+                    "If you need to test with MSAN enabled, you must use ahead-of-time "
+                    "compilation for Halide code.";
+#endif
+#endif
     if (target.arch == Target::WebAssembly) {
         internal_assert(contents->wasm_module.contents.defined());
         return contents->wasm_module.run(args.store);
@@ -1002,15 +1010,6 @@ int Pipeline::call_jit_code(const Target &target, const JITCallArgs &args) {
 
 void Pipeline::realize(RealizationArg outputs, const Target &t,
                        const ParamMap &param_map) {
-#if defined(__has_feature)
-#if __has_feature(memory_sanitizer)
-    user_warning << "MSAN does not support JIT compilers of any sort, and will report "
-                    "false positives when used in conjunction with the Halide JIT. "
-                    "If you need to test with MSAN enabled, you must use ahead-of-time "
-                    "compilation for Halide code.";
-#endif
-#endif
-
     Target target = t;
     user_assert(defined()) << "Can't realize an undefined Pipeline\n";
 

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -1002,6 +1002,15 @@ int Pipeline::call_jit_code(const Target &target, const JITCallArgs &args) {
 
 void Pipeline::realize(RealizationArg outputs, const Target &t,
                        const ParamMap &param_map) {
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+    user_warning << "MSAN does not support JIT compilers of any sort, and will report "
+                    "false positives when used in conjunction with the Halide JIT. "
+                    "If you need to test with MSAN enabled, you must use ahead-of-time "
+                    "compilation for Halide code.";
+#endif
+#endif
+
     Target target = t;
     user_assert(defined()) << "Can't realize an undefined Pipeline\n";
 


### PR DESCRIPTION
MSAN is well-documented as not support JIT compilers of any sort, and will report false positives in that case. We should (at least) emit a warning if the user tries to use the JIT if libHalide is compiled with MSAN enabled (regardless of whether 'msan' is in the Halide::Target).

(I'm tempted to make this a user_error instead of a warning. Thoughts?)