### PR TITLE
added imageio package to dependencies

### DIFF
--- a/python_bindings/requirements.txt
+++ b/python_bindings/requirements.txt
@@ -8,3 +8,4 @@
 numpy
 scipy
 pillow
+imageio


### PR DESCRIPTION
Without it the example apps (and hence the target test_python) will fail to run, as the apps use it to load/store images.