### PR TITLE
More Python Cleanup

### DIFF
--- a/apps/HelloPyTorch/test.py
+++ b/apps/HelloPyTorch/test.py
@@ -1,6 +1,5 @@
 """Verifies the Halide operator functions properly."""
 
-from __future__ import print_function
 
 import os
 import unittest

--- a/apps/onnx/halide_as_onnx_backend.py
+++ b/apps/onnx/halide_as_onnx_backend.py
@@ -1,9 +1,5 @@
 """Backend for running ONNX using Halide"""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from onnx.backend.base import Backend as BackendBase
 import onnx

--- a/apps/onnx/halide_as_onnx_backend_test.py
+++ b/apps/onnx/halide_as_onnx_backend_test.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import unittest
 import onnx.backend.test

--- a/apps/onnx/model.py
+++ b/apps/onnx/model.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import model_cpp
 

--- a/apps/onnx/model_test.py
+++ b/apps/onnx/model_test.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 from model import Model
 from onnx import helper

--- a/python_bindings/apps/bilateral_grid.py
+++ b/python_bindings/apps/bilateral_grid.py
@@ -6,7 +6,7 @@ Bilateral histogram.
 import halide as hl
 
 import numpy as np
-from imageio import imread, imsave
+import imageio
 import os.path
 
 def get_bilateral_grid(input, r_sigma, s_sigma):
@@ -102,7 +102,7 @@ def get_input_data():
     image_path = os.path.join(os.path.dirname(__file__), "../../apps/images/rgb.png")
     assert os.path.exists(image_path), \
         "Could not find %s" % image_path
-    rgb_data = imread(image_path)
+    rgb_data = imageio.imread(image_path)
     #print("rgb_data", type(rgb_data), rgb_data.shape, rgb_data.dtype)
 
     grey_data = np.mean(rgb_data, axis=2, dtype=np.float32)
@@ -131,8 +131,8 @@ def filter_test_image(bilateral_grid, input):
     # save results
     input_path = "bilateral_grid_input.png"
     output_path = "bilateral_grid.png"
-    imsave(input_path, input_data)
-    imsave(output_path, output_data)
+    imageio.imsave(input_path, input_data)
+    imageio.imsave(output_path, output_data)
     print("\nbilateral_grid realized on output_image.")
     print("Result saved at '", output_path,
           "' ( input data copy at '", input_path, "' ).", sep="")

--- a/python_bindings/apps/bilateral_grid.py
+++ b/python_bindings/apps/bilateral_grid.py
@@ -2,8 +2,6 @@
 Bilateral histogram.
 """
 
-from __future__ import print_function
-from __future__ import division
 
 import halide as hl
 

--- a/python_bindings/apps/blur.py
+++ b/python_bindings/apps/blur.py
@@ -1,7 +1,7 @@
 import halide as hl
 
 import numpy as np
-from imageio import imread, imsave
+import imageio
 import os.path
 
 def get_blur(input):
@@ -34,7 +34,7 @@ def get_input_data():
     image_path = os.path.join(os.path.dirname(__file__), "../../apps/images/rgb.png")
     assert os.path.exists(image_path), \
         "Could not find %s" % image_path
-    rgb_data = imread(image_path)
+    rgb_data = imageio.imread(image_path)
     print("rgb_data", type(rgb_data), rgb_data.shape, rgb_data.dtype)
 
     grey_data = np.mean(rgb_data, axis=2, dtype=np.float32).astype(rgb_data.dtype)
@@ -65,8 +65,8 @@ def main():
     # save results
     input_path = "blur_input.png"
     output_path = "blur_result.png"
-    imsave(input_path, input_data)
-    imsave(output_path, output_data)
+    imageio.imsave(input_path, input_data)
+    imageio.imsave(output_path, output_data)
     print("\nblur realized on output image.",
           "Result saved at", output_path,
           "( input data copy at", input_path, ")")

--- a/python_bindings/apps/erode.py
+++ b/python_bindings/apps/erode.py
@@ -5,7 +5,7 @@ Erode application using Python Halide bindings
 import halide as hl
 
 import numpy as np
-from imageio import imread, imsave
+import imageio
 import os.path
 
 def get_erode(input):
@@ -39,7 +39,7 @@ def get_input_data():
     image_path = os.path.join(os.path.dirname(__file__), "../../apps/images/rgb.png")
     assert os.path.exists(image_path), \
         "Could not find %s" % image_path
-    rgb_data = imread(image_path)
+    rgb_data = imageio.imread(image_path)
     print("rgb_data", type(rgb_data), rgb_data.shape, rgb_data.dtype)
 
     input_data = np.copy(rgb_data, order="F")
@@ -71,8 +71,8 @@ def main():
     # save results
     input_path = "erode_input.png"
     output_path = "erode_result.png"
-    imsave(input_path, input_data)
-    imsave(output_path, output_data)
+    imageio.imsave(input_path, input_data)
+    imageio.imsave(output_path, output_data)
     print("\nerode realized on output image.",
           "Result saved at", output_path,
           "( input data copy at", input_path, ")")

--- a/python_bindings/apps/interpolate.py
+++ b/python_bindings/apps/interpolate.py
@@ -7,7 +7,7 @@ import time, sys
 import halide as hl
 
 from datetime import datetime
-from imageio import imread, imsave
+import imageio
 import numpy as np
 import os.path
 
@@ -157,7 +157,7 @@ def get_input_data():
 
     image_path = os.path.join(os.path.dirname(__file__), "../../apps/images/rgba.png")
     assert os.path.exists(image_path), "Could not find %s" % image_path
-    rgba_data = imread(image_path)
+    rgba_data = imageio.imread(image_path)
     #print("rgba_data", type(rgba_data), rgba_data.shape, rgba_data.dtype)
 
     input_data = np.copy(rgba_data, order="F").astype(np.float32) / 255.0
@@ -192,8 +192,8 @@ def main():
     # save results
     input_path = "interpolate_input.png"
     output_path = "interpolate_result.png"
-    imsave(input_path, input_data)
-    imsave(output_path, output_data)
+    imageio.imsave(input_path, input_data)
+    imageio.imsave(output_path, output_data)
     print("\nblur realized on output image.",
           "Result saved at", output_path,
           "( input data copy at", input_path, ")")

--- a/python_bindings/apps/interpolate.py
+++ b/python_bindings/apps/interpolate.py
@@ -2,8 +2,6 @@
 Fast image interpolation using a pyramid.
 """
 
-from __future__ import print_function
-from __future__ import division
 
 import time, sys
 import halide as hl

--- a/python_bindings/apps/local_laplacian.py
+++ b/python_bindings/apps/local_laplacian.py
@@ -2,8 +2,6 @@
 Local Laplacian, see e.g. Aubry et al 2011, "Fast and Robust Pyramid-based Image Processing".
 """
 
-from __future__ import print_function
-from __future__ import division
 
 import halide as hl
 

--- a/python_bindings/apps/local_laplacian.py
+++ b/python_bindings/apps/local_laplacian.py
@@ -6,7 +6,7 @@ Local Laplacian, see e.g. Aubry et al 2011, "Fast and Robust Pyramid-based Image
 import halide as hl
 
 import numpy as np
-from imageio import imread, imsave
+import imageio
 import os.path
 
 
@@ -190,7 +190,7 @@ def get_input_data():
     image_path = os.path.join(os.path.dirname(__file__), "../../apps/images/rgb.png")
     assert os.path.exists(image_path), \
         "Could not find %s" % image_path
-    rgb_data = imread(image_path)
+    rgb_data = imageio.imread(image_path)
     #print("rgb_data", type(rgb_data), rgb_data.shape, rgb_data.dtype)
 
     input_data = np.copy(rgb_data.astype(np.uint16), order="F") << 8
@@ -222,8 +222,8 @@ def filter_test_image(local_laplacian, input):
     # save results
     input_path = "local_laplacian_input.png"
     output_path = "local_laplacian.png"
-    imsave(input_path, input_data)
-    imsave(output_path, output_data)
+    imageio.imsave(input_path, input_data)
+    imageio.imsave(output_path, output_data)
     print("\nlocal_laplacian realized on output_image.")
     print("Result saved at '", output_path,
           "' ( input data copy at '", input_path, "' ).", sep="")

--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import division
 
 import halide as hl
 import numpy as np

--- a/python_bindings/correctness/bit_test.py
+++ b/python_bindings/correctness/bit_test.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import array
 import bit

--- a/python_bindings/correctness/boundary_conditions.py
+++ b/python_bindings/correctness/boundary_conditions.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import division
 
 import halide as hl
 

--- a/python_bindings/correctness/buffer.py
+++ b/python_bindings/correctness/buffer.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import division
 
 import halide as hl
 import numpy as np

--- a/python_bindings/correctness/division.py
+++ b/python_bindings/correctness/division.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import halide as hl
 
 # TODO: Func.evaluate() needs a wrapper added;

--- a/python_bindings/correctness/iroperator.py
+++ b/python_bindings/correctness/iroperator.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import division
 
 from contextlib import contextmanager
 import halide as hl

--- a/python_bindings/correctness/multipass_constraints.py
+++ b/python_bindings/correctness/multipass_constraints.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import division
 
 import halide as hl
 
@@ -22,9 +20,9 @@ def test_multipass_constraints():
         extent = input.dim(1).extent() + o.dim(0).extent()
     )
 
-    o.dim(0).set_bounds(min = 0, 
-                        extent = hl.select(o.dim(0).extent() < 22, 
-                                           o.dim(0).extent() + 1, 
+    o.dim(0).set_bounds(min = 0,
+                        extent = hl.select(o.dim(0).extent() < 22,
+                                           o.dim(0).extent() + 1,
                                            o.dim(0).extent()))
 
     # Make a bounds query buffer
@@ -44,14 +42,14 @@ def test_multipass_constraints():
 
         print("Constraints not correctly satisfied:\n",
                "in:",
-               input.get().dim(0).min(), 
+               input.get().dim(0).min(),
                input.get().dim(0).extent(),
-               input.get().dim(1).min(), 
+               input.get().dim(1).min(),
                input.get().dim(1).extent(),
                "out:",
-               query_buf.dim(0).min(), 
+               query_buf.dim(0).min(),
                query_buf.dim(0).extent(),
-               query_buf.dim(1).min(), 
+               query_buf.dim(1).min(),
                query_buf.dim(1).extent())
         assert False
 

--- a/python_bindings/correctness/pystub.py
+++ b/python_bindings/correctness/pystub.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import division
 
 import halide as hl
 

--- a/python_bindings/tutorial/lesson_02_input_image.py
+++ b/python_bindings/tutorial/lesson_02_input_image.py
@@ -20,7 +20,7 @@
 
 import halide as hl
 import numpy as np
-from imageio import imread, imsave
+import imageio
 import os.path
 
 def main():
@@ -32,7 +32,7 @@ def main():
     image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/rgb.png")
 
     # We create a hl.Buffer object to wrap the numpy array
-    input = hl.Buffer(imread(image_path))
+    input = hl.Buffer(imageio.imread(image_path))
     assert input.type() == hl.UInt(8)
 
     # Next we define our hl.Func object that represents our one pipeline
@@ -97,7 +97,7 @@ def main():
     assert output_image.type() == hl.UInt(8)
 
     # Save the output for inspection. It should look like a bright parrot.
-    imsave("brighter.png", output_image)
+    imageio.imsave("brighter.png", output_image)
     print("Created brighter.png result file.")
 
     print("Success!")

--- a/python_bindings/tutorial/lesson_03_debugging_1.py
+++ b/python_bindings/tutorial/lesson_03_debugging_1.py
@@ -16,9 +16,6 @@
 # g++ lesson_03*.cpp -g -I ../include -L ../bin -lHalide -o lesson_03 -std=c++11
 # DYLD_LIBRARY_PATH=../bin ./lesson_03
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import halide as hl
 

--- a/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
+++ b/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
@@ -24,7 +24,7 @@ import halide as hl
 
 # Support code for loading pngs.
 #include "image_io.h"
-from imageio import imread, imsave
+import imageio
 import os.path
 
 def main():
@@ -37,7 +37,7 @@ def main():
     # first horizontally, and then vertically.
     if True:
         # Take a color 8-bit input
-        input = hl.Buffer(imread(image_path))
+        input = hl.Buffer(imageio.imread(image_path))
         assert input.type() == hl.UInt(8)
 
         # Upgrade it to 16-bit, so we can do math without it overflowing.
@@ -93,7 +93,7 @@ def main():
         # parrot, and it should be two pixels narrower and two pixels
         # shorter than the input image.
 
-        imsave("blurry_parrot_1.png", result)
+        imageio.imsave("blurry_parrot_1.png", result)
         print("Created blurry_parrot_1.png")
 
         # This is usually the fastest way to deal with boundaries:
@@ -104,7 +104,7 @@ def main():
     # The same pipeline, with a boundary condition on the input.
     if True:
         # Take a color 8-bit input
-        input = hl.Buffer(imread(image_path))
+        input = hl.Buffer(imageio.imread(image_path))
         assert input.type() == hl.UInt(8)
 
         # This time, we'll wrap the input in a hl.Func that prevents
@@ -161,7 +161,7 @@ def main():
         # Save the result. It should look like a slightly blurry
         # parrot, but this time it will be the same size as the
         # input.
-        imsave("blurry_parrot_2.png", result)
+        imageio.imsave("blurry_parrot_2.png", result)
         print("Created blurry_parrot_2.png")
 
     print("Success!")

--- a/python_bindings/tutorial/lesson_09_update_definitions.py
+++ b/python_bindings/tutorial/lesson_09_update_definitions.py
@@ -33,7 +33,7 @@ import halide as hl
 
 # Support code for loading pngs.
 #include "image_io.h"
-from imageio import imread
+import imageio
 import numpy as np
 import os.path
 
@@ -43,7 +43,7 @@ def main():
 
     # Load a grayscale image to use as an input.
     image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/gray.png")
-    input_data = imread(image_path)
+    input_data = imageio.imread(image_path)
     if True:
          # making the image smaller to go faster
         input_data = input_data[:160, :150]

--- a/python_bindings/tutorial/lesson_12_using_the_gpu.py
+++ b/python_bindings/tutorial/lesson_12_using_the_gpu.py
@@ -24,7 +24,7 @@ import halide as hl
 
 # Include some support code for loading pngs.
 #include "image_io.h"
-from imageio import imread
+import imageio
 import os.path
 
 # Include a clock to do performance testing.
@@ -273,7 +273,7 @@ class MyPipeline:
 def main():
     # Load an input image.
     image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/rgb.png")
-    input = hl.Buffer(imread(image_path))
+    input = hl.Buffer(imageio.imread(image_path))
 
     # Allocated an image that will store the correct output
     reference_output = hl.Buffer(hl.UInt(8), [input.width(), input.height(), input.channels()])

--- a/python_bindings/tutorial/lesson_13_tuples.py
+++ b/python_bindings/tutorial/lesson_13_tuples.py
@@ -17,7 +17,6 @@
 #    make tutorial_lesson_13_tuples
 # in a shell with the current directory at the top of the halide
 # source tree.
-from __future__ import print_function
 
 import halide as hl
 


### PR DESCRIPTION
- Remove all `from __future__ import`, as they are unnecessary for Python3
- restructure how imageio.imread and imageio.imsave are imported & called, to avoid warnings with some strict-import-checking tools (the previous technique could be construed as an ambiguity, apparently)