### PR TITLE
Add device_sync and halide_reuse_device_allocations to some apps

### DIFF
--- a/apps/bilateral_grid/filter.cpp
+++ b/apps/bilateral_grid/filter.cpp
@@ -48,6 +48,7 @@ int main(int argc, char **argv) {
     // Auto-scheduled version
     double min_t_auto = benchmark(timing_iterations, 10, [&]() {
         bilateral_grid_auto_schedule(input, r_sigma, output);
+        output.device_sync();
     });
     printf("Auto-scheduled time: %gms\n", min_t_auto * 1e3);
     #endif

--- a/apps/blur/test.cpp
+++ b/apps/blur/test.cpp
@@ -173,6 +173,11 @@ int main(int argc, char **argv) {
         }
     }
 
+    // Let the Halide runtime hold onto GPU allocations for
+    // intermediates and reuse them instead of eagerly freeing
+    // them. cuMemAlloc/cuMemFree is slower than the algorithm!
+    halide_reuse_device_allocations(nullptr, true);
+
     Buffer<uint16_t> blurry = blur(input);
     double slow_time = t;
 

--- a/apps/camera_pipe/process.cpp
+++ b/apps/camera_pipe/process.cpp
@@ -28,6 +28,11 @@ int main(int argc, char **argv) {
     halide_enable_malloc_trace();
 #endif
 
+    // Let the Halide runtime hold onto GPU allocations for
+    // intermediates and reuse them instead of eagerly freeing
+    // them. cuMemAlloc/cuMemFree is slower than the algorithm!
+    halide_reuse_device_allocations(nullptr, true);
+
     fprintf(stderr, "input: %s\n", argv[1]);
     Buffer<uint16_t> input = load_and_convert_image(argv[1]);
     fprintf(stderr, "       %d %d\n", input.width(), input.height());

--- a/apps/cuda_mat_mul/runner.cpp
+++ b/apps/cuda_mat_mul/runner.cpp
@@ -13,6 +13,11 @@ int main(int argc, char **argv) {
         size = atoi(argv[1]);
     }
 
+    // Let the Halide runtime hold onto GPU allocations for
+    // intermediates and reuse them instead of eagerly freeing
+    // them. cuMemAlloc/cuMemFree is slower than the algorithm!
+    halide_reuse_device_allocations(nullptr, true);
+
     // Check correctness using small-integer matrices
     if (1) {
         Buffer<float> A(size, size), B(size, size), C(size, size);

--- a/apps/lens_blur/process.cpp
+++ b/apps/lens_blur/process.cpp
@@ -18,6 +18,11 @@ int main(int argc, char **argv) {
         return 0;
     }
 
+    // Let the Halide runtime hold onto GPU allocations for
+    // intermediates and reuse them instead of eagerly freeing
+    // them. cuMemAlloc/cuMemFree is slower than the algorithm!
+    halide_reuse_device_allocations(nullptr, true);
+
     Buffer<uint8_t> left_im = load_image(argv[1]);
     Buffer<uint8_t> right_im = load_image(argv[1]);
     uint32_t slices = atoi(argv[2]);
@@ -44,6 +49,7 @@ int main(int argc, char **argv) {
     double min_t_auto = benchmark(timing_iterations, 10, [&]() {
         lens_blur_auto_schedule(left_im, right_im, slices, focus_depth,
                                 blur_radius_scale, aperture_samples, output);
+        output.device_sync();
     });
     printf("Auto-scheduled time: %gms\n", min_t_auto * 1e3);
 


### PR DESCRIPTION
Many of the apps don't have proper device_sync called when running on GPU. I also found that `halide_reuse_device_allocations` significantly improves performance on all of them consistently. Should we just make reuse allocation default to be true?