### PR TITLE
Fix Python building instruction

### DIFF
--- a/python_bindings/readme.md
+++ b/python_bindings/readme.md
@@ -61,7 +61,7 @@ requirements.txt`)
 
 ## Compilation instructions
 
-Build using: `bash make`
+Build using: `make`
 
 ## Documentation and Examples
 


### PR DESCRIPTION
Should be `make` instead of `bash make`