### PR TITLE
Add Buffer.defined() checks in Python bindings

### DIFF
--- a/apps/bilateral_grid/filter.cpp
+++ b/apps/bilateral_grid/filter.cpp
@@ -27,11 +27,6 @@ int main(int argc, char **argv) {
     Buffer<float> input = load_and_convert_image(argv[1]);
     Buffer<float> output(input.width(), input.height());
 
-    // Let the Halide runtime hold onto GPU allocations for
-    // intermediates and reuse them instead of eagerly freeing
-    // them. cuMemAlloc/cuMemFree is slower than the algorithm!
-    halide_reuse_device_allocations(nullptr, true);
-
     bilateral_grid(input, r_sigma, output);
 
     // Timing code. Timing doesn't include copying the input data to

--- a/apps/blur/test.cpp
+++ b/apps/blur/test.cpp
@@ -173,11 +173,6 @@ int main(int argc, char **argv) {
         }
     }
 
-    // Let the Halide runtime hold onto GPU allocations for
-    // intermediates and reuse them instead of eagerly freeing
-    // them. cuMemAlloc/cuMemFree is slower than the algorithm!
-    halide_reuse_device_allocations(nullptr, true);
-
     Buffer<uint16_t> blurry = blur(input);
     double slow_time = t;
 

--- a/apps/camera_pipe/process.cpp
+++ b/apps/camera_pipe/process.cpp
@@ -28,11 +28,6 @@ int main(int argc, char **argv) {
     halide_enable_malloc_trace();
 #endif
 
-    // Let the Halide runtime hold onto GPU allocations for
-    // intermediates and reuse them instead of eagerly freeing
-    // them. cuMemAlloc/cuMemFree is slower than the algorithm!
-    halide_reuse_device_allocations(nullptr, true);
-
     fprintf(stderr, "input: %s\n", argv[1]);
     Buffer<uint16_t> input = load_and_convert_image(argv[1]);
     fprintf(stderr, "       %d %d\n", input.width(), input.height());

--- a/apps/conv_layer/process.cpp
+++ b/apps/conv_layer/process.cpp
@@ -41,11 +41,6 @@ int main(int argc, char **argv) {
 
     Buffer<float> output(64, 64, 32, 4);
 
-    // Let the Halide runtime hold onto GPU allocations for
-    // intermediates and reuse them instead of eagerly freeing
-    // them. cuMemAlloc/cuMemFree is slower than the algorithm!
-    halide_reuse_device_allocations(nullptr, true);
-
     conv_layer(input, filter, bias, output);
 
     // Timing code

--- a/apps/cuda_mat_mul/runner.cpp
+++ b/apps/cuda_mat_mul/runner.cpp
@@ -13,11 +13,6 @@ int main(int argc, char **argv) {
         size = atoi(argv[1]);
     }
 
-    // Let the Halide runtime hold onto GPU allocations for
-    // intermediates and reuse them instead of eagerly freeing
-    // them. cuMemAlloc/cuMemFree is slower than the algorithm!
-    halide_reuse_device_allocations(nullptr, true);
-
     // Check correctness using small-integer matrices
     if (1) {
         Buffer<float> A(size, size), B(size, size), C(size, size);

--- a/apps/local_laplacian/process.cpp
+++ b/apps/local_laplacian/process.cpp
@@ -20,11 +20,6 @@ int main(int argc, char **argv) {
         return 0;
     }
 
-    // Let the Halide runtime hold onto GPU allocations for
-    // intermediates and reuse them instead of eagerly freeing
-    // them. cuMemAlloc/cuMemFree is slower than the algorithm!
-    halide_reuse_device_allocations(nullptr, true);
-
     // Input may be a PNG8
     Buffer<uint16_t> input = load_and_convert_image(argv[1]);
 

--- a/apps/stencil_chain/process.cpp
+++ b/apps/stencil_chain/process.cpp
@@ -20,11 +20,6 @@ int main(int argc, char **argv) {
         return 0;
     }
 
-    // Let the Halide runtime hold onto GPU allocations for
-    // intermediates and reuse them instead of eagerly freeing
-    // them. cuMemAlloc/cuMemFree is slower than the algorithm!
-    halide_reuse_device_allocations(nullptr, true);
-
     // Input may be a PNG8
     Buffer<uint16_t> input = load_and_convert_image(argv[1]);
     // Just take the red channel

--- a/python_bindings/readme.md
+++ b/python_bindings/readme.md
@@ -61,7 +61,7 @@ requirements.txt`)
 
 ## Compilation instructions
 
-Build using: `bash make`
+Build using: `make`
 
 ## Documentation and Examples
 

--- a/python_bindings/src/PyBuffer.cpp
+++ b/python_bindings/src/PyBuffer.cpp
@@ -32,6 +32,10 @@ std::ostream &operator<<(std::ostream &stream, const std::vector<halide_dimensio
 // Given a Buffer<>, return its shape in the form of a vector<halide_dimension_t>.
 // (Oddly, Buffer<> has no API to do this directly.)
 std::vector<halide_dimension_t> get_buffer_shape(const Buffer<> &b) {
+    if (!b.defined()) {
+        // Return an empty vector if the buffer is not defined.
+        return {};
+    }
     std::vector<halide_dimension_t> s;
     for (int i = 0; i < b.dimensions(); ++i) {
         s.push_back(b.raw_buffer()->dim[i]);
@@ -531,7 +535,11 @@ void define_buffer(py::module &m) {
 
         .def("__repr__", [](const Buffer<> &b) -> std::string {
             std::ostringstream o;
-            o << "<halide.Buffer of type " << halide_type_to_string(b.type()) << " shape:" << get_buffer_shape(b) << ">";
+            if (b.defined()) {
+                o << "<halide.Buffer of type " << halide_type_to_string(b.type()) << " shape:" << get_buffer_shape(b) << ">";
+            } else {
+                o << "<undefined halide.Buffer>";
+            }
             return o.str();
         })
     ;

--- a/src/runtime/allocation_cache.cpp
+++ b/src/runtime/allocation_cache.cpp
@@ -6,7 +6,7 @@ namespace Halide {
 namespace Runtime {
 namespace Internal {
 
-WEAK bool halide_reuse_device_allocations_flag = false;
+WEAK bool halide_reuse_device_allocations_flag = true;
 
 WEAK halide_mutex allocation_pools_lock;
 WEAK halide_device_allocation_pool *device_allocation_pools = NULL;


### PR DESCRIPTION
Currently the following Python code causes segmentation fault:
```
import halide as hl
b = hl.Buffer()
print(b)
```
Is there any reason why we want the users to construct an empty buffer? If no I propose just to remove these constructors in Python.