### PR TITLE
Change Func.in to Func.inside in Python

### DIFF
--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -164,6 +164,24 @@ def test_basics4():
     f.compute_root()
     f.compile_jit()
 
+def test_basics5():
+    x, y = hl.Var('x'), hl.Var('y')
+    f = hl.Func('f')
+    g = hl.Func('g')
+    h = hl.Func('h')
+    f[x, y] = y
+    r = hl.RDom([(0, 100)])
+    g[x] = 0
+    g[x] += f[x, r]
+    h[x] = 0
+    h[x] += f[x, r]
+    f.inside(g).compute_at(g, x)
+    f.inside(h).compute_at(h, x)
+    g.compute_root()
+    h.compute_root()
+    p = hl.Pipeline([g, h])
+    p.compile_jit()
+
 def test_float_or_int():
     x = hl.Var('x')
     i32, f32 =  hl.Int(32), hl.Float(32)
@@ -226,3 +244,4 @@ if __name__ == "__main__":
     test_basics2()
     test_basics3()
     test_basics4()
+    test_basics5()

--- a/python_bindings/readme.md
+++ b/python_bindings/readme.md
@@ -32,6 +32,7 @@ with some differences where the C++ idiom is either inappropriate or impossible:
 -   No mechanism is provided for supporting `Func::define_extern`.
 -   `Buffer::for_each_value()` is hard to implement well in Python; it's omitted
     entirely for now.
+-   `Func::in` becomes `Func.inside` because `in` is a Python keyword.
 
 ## Enhancements to the C++ API
 

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -306,9 +306,9 @@ void define_func(py::module &m) {
             f.infer_input_bounds(Realization(buffer), param_map);
         }, py::arg("dst"), py::arg("param_map") = ParamMap())
 
-        .def("in", (Func (Func::*)(const Func &)) &Func::in, py::arg("f"))
-        .def("in", (Func (Func::*)(const std::vector<Func> &fs)) &Func::in, py::arg("fs"))
-        .def("in", (Func (Func::*)()) &Func::in)
+        .def("inside", (Func (Func::*)(const Func &)) &Func::in, py::arg("f"))
+        .def("inside", (Func (Func::*)(const std::vector<Func> &fs)) &Func::in, py::arg("fs"))
+        .def("inside", (Func (Func::*)()) &Func::in)
 
         .def("clone_in", (Func (Func::*)(const Func &)) &Func::clone_in, py::arg("f"))
         .def("clone_in", (Func (Func::*)(const std::vector<Func> &fs)) &Func::clone_in, py::arg("fs"))


### PR DESCRIPTION
Currently `Func.in()` in Python is not callable since `in` is a Python keyword. I propose changing it to `Func.inside()`.