### PR TITLE
Make is_nan/is_inf/is_finite require strict_float() (Issue #4281)

### DIFF
--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -929,15 +929,18 @@ Expr round(Expr x);
 Expr trunc(Expr x);
 
 /** Returns true if the argument is a Not a Number (NaN). Requires a
-  * floating point argument.  Vectorizes cleanly. */
+  * floating point argument.  Vectorizes cleanly.
+  * Note that this call is only legal if the Expr will be evaluated in strict_float mode. */
 Expr is_nan(Expr x);
 
 /** Returns true if the argument is Inf or -Inf. Requires a
-  * floating point argument.  Vectorizes cleanly. */
+  * floating point argument.  Vectorizes cleanly.
+  * Note that this call is only legal if the Expr will be evaluated in strict_float mode. */
 Expr is_inf(Expr x);
 
 /** Returns true if the argument is a finite value (ie, neither NaN nor Inf).
-  * Requires a floating point argument.  Vectorizes cleanly. */
+  * Requires a floating point argument.  Vectorizes cleanly.
+  * Note that this call is only legal if the Expr will be evaluated in strict_float mode. */
 Expr is_finite(Expr x);
 
 /** Return the fractional part of a floating-point expression. If the argument

--- a/test/correctness/isnan.cpp
+++ b/test/correctness/isnan.cpp
@@ -6,10 +6,7 @@ using namespace Halide;
 constexpr int w = 16;
 constexpr int h = 16;
 
-/* Halide uses fast-math by default. is_nan must either be used inside
- * strict_float or as a test on inputs produced outside of
- * Halide. Using it to test results produced by math inside Halide but
- * not using strict_float is unreliable. This test covers both of these cases. */
+/* Halide uses fast-math by default. is_nan must be used inside strict_float. */
 
 int check_nans(const Buffer<float> &im) {
     for (int x = 0; x < im.dim(0).extent(); x++) {
@@ -100,7 +97,7 @@ int main(int argc, char **argv) {
         Var x;
         Var y;
 
-        f(x, y) = select(is_nan(in(x, y)), 0.0f, 1.0f);
+        f(x, y) = select(is_nan(strict_float(in(x, y))), 0.0f, 1.0f);
         f.vectorize(x, 8);
 
         in.set(non_halide_produced);
@@ -139,7 +136,7 @@ int main(int argc, char **argv) {
         Var x;
         Var y;
 
-        f(x, y) = select(is_inf(in(x, y)), 1.0f, 0.0f);
+        f(x, y) = select(is_inf(strict_float(in(x, y))), 1.0f, 0.0f);
         f.vectorize(x, 8);
 
         in.set(non_halide_produced);
@@ -178,7 +175,7 @@ int main(int argc, char **argv) {
         Var x;
         Var y;
 
-        f(x, y) = select(is_finite(in(x, y)), 1.0f, 0.0f);
+        f(x, y) = select(is_finite(strict_float(in(x, y))), 1.0f, 0.0f);
         f.vectorize(x, 8);
 
         in.set(non_halide_produced);

--- a/test/error/non_strict_is_nan.cpp
+++ b/test/error/non_strict_is_nan.cpp
@@ -1,0 +1,18 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Func f;
+    Var x;
+
+    // Should be error to call is_nan() without strict_float
+    f(x) = is_nan(cast<float>(x));
+
+    f.realize(10);
+
+    // You may find yourself living outside of strict_float()
+    // And you may ask yourself:
+    printf("How did I get here?\n");
+}


### PR DESCRIPTION
If the Expr being evaluated doesn't requires strict_float, the results are meaningless; this adds sniffing to require this to be the case, making it a compile-time error to call these if the Expr can't be proven to be using strict_float.

(Also: drive-by cleanup of code in StrictifyFloat that was a holdover from when it was possible to have contexts in which strict-float was not allowed)