### PR TITLE
Make is_nan/is_inf/is_finite enforce strict_float() (Issue #4281)

### DIFF
--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -1890,7 +1890,9 @@ Expr is_nan(Expr x) {
     user_assert(x.defined()) << "is_nan of undefined Expr\n";
     user_assert(x.type().is_float()) << "is_nan only works for float";
     Type t = Bool(x.type().lanes());
-    x = strict_float(x);
+    if (!is_const(x)) {
+        x = strict_float(x);
+    }
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(t, "is_nan_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type().element_of() == Float(16)) {
@@ -1905,7 +1907,9 @@ Expr is_inf(Expr x) {
     user_assert(x.defined()) << "is_inf of undefined Expr\n";
     user_assert(x.type().is_float()) << "is_inf only works for float";
     Type t = Bool(x.type().lanes());
-    x = strict_float(x);
+    if (!is_const(x)) {
+        x = strict_float(x);
+    }
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(t, "is_inf_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type().element_of() == Float(16)) {
@@ -1920,7 +1924,9 @@ Expr is_finite(Expr x) {
     user_assert(x.defined()) << "is_finite of undefined Expr\n";
     user_assert(x.type().is_float()) << "is_finite only works for float";
     Type t = Bool(x.type().lanes());
-    x = strict_float(x);
+    if (!is_const(x)) {
+        x = strict_float(x);
+    }
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(t, "is_finite_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type().element_of() == Float(16)) {

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -1890,6 +1890,7 @@ Expr is_nan(Expr x) {
     user_assert(x.defined()) << "is_nan of undefined Expr\n";
     user_assert(x.type().is_float()) << "is_nan only works for float";
     Type t = Bool(x.type().lanes());
+    x = strict_float(x);
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(t, "is_nan_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type().element_of() == Float(16)) {
@@ -1904,6 +1905,7 @@ Expr is_inf(Expr x) {
     user_assert(x.defined()) << "is_inf of undefined Expr\n";
     user_assert(x.type().is_float()) << "is_inf only works for float";
     Type t = Bool(x.type().lanes());
+    x = strict_float(x);
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(t, "is_inf_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type().element_of() == Float(16)) {
@@ -1918,6 +1920,7 @@ Expr is_finite(Expr x) {
     user_assert(x.defined()) << "is_finite of undefined Expr\n";
     user_assert(x.type().is_float()) << "is_finite only works for float";
     Type t = Bool(x.type().lanes());
+    x = strict_float(x);
     if (x.type().element_of() == Float(64)) {
         return Internal::Call::make(t, "is_finite_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type().element_of() == Float(16)) {

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -929,15 +929,21 @@ Expr round(Expr x);
 Expr trunc(Expr x);
 
 /** Returns true if the argument is a Not a Number (NaN). Requires a
-  * floating point argument.  Vectorizes cleanly. */
+  * floating point argument.  Vectorizes cleanly.
+  * Note that the Expr passed in will be evaluated in strict_float mode,
+  * regardless of whether strict_float mode is enabled in the current Target. */
 Expr is_nan(Expr x);
 
 /** Returns true if the argument is Inf or -Inf. Requires a
-  * floating point argument.  Vectorizes cleanly. */
+  * floating point argument.  Vectorizes cleanly.
+  * Note that the Expr passed in will be evaluated in strict_float mode,
+  * regardless of whether strict_float mode is enabled in the current Target. */
 Expr is_inf(Expr x);
 
 /** Returns true if the argument is a finite value (ie, neither NaN nor Inf).
-  * Requires a floating point argument.  Vectorizes cleanly. */
+  * Requires a floating point argument.  Vectorizes cleanly.
+  * Note that the Expr passed in will be evaluated in strict_float mode,
+  * regardless of whether strict_float mode is enabled in the current Target. */
 Expr is_finite(Expr x);
 
 /** Return the fractional part of a floating-point expression. If the argument

--- a/src/StrictifyFloat.cpp
+++ b/src/StrictifyFloat.cpp
@@ -7,7 +7,6 @@ namespace Halide {
 namespace Internal {
 
 class StrictifyFloat : public IRMutator {
-    bool strict_float_allowed;
     enum Strictness {
         FastMath,
         StrictFloat,
@@ -19,7 +18,6 @@ class StrictifyFloat : public IRMutator {
         Strictness new_strictness = strictness;
 
         if (call->is_intrinsic(Call::strict_float)) {
-            user_assert(strict_float_allowed) << "strict_float intrinsic is not allowed unless target has feature 'allow_strict_float' or 'force_strict_float'\n";
             new_strictness = StrictFloat;
             any_strict_float |= true;
         }
@@ -49,15 +47,13 @@ class StrictifyFloat : public IRMutator {
 
 public:
     enum StrictnessMode {
-        NotAllowed,
         Allowed,
         Forced
     };
     bool any_strict_float{false};
 
     StrictifyFloat(StrictnessMode mode)
-        : strict_float_allowed(mode != NotAllowed),
-          strictness((mode == Forced) ? StrictFloat : FastMath) {
+        : strictness((mode == Forced) ? StrictFloat : FastMath) {
         any_strict_float |= (mode == Forced);
     }
 };


### PR DESCRIPTION
Quietly wrap the arg to these functions in strict_float(), to ensure the results aren't meaningless.

(Also: drive-by cleanup of code in StrictifyFloat that was a holdover from when it was possible to have contexts in which strict-float was not allowed)