### PR TITLE
Fix apps/autoscheduler out-of-tree builds (Issue #4355)

### DIFF
--- a/apps/autoscheduler/Makefile
+++ b/apps/autoscheduler/Makefile
@@ -31,7 +31,8 @@ autotune: $(GENERATOR_BIN)/demo.generator $(AUTOSCHED_BIN)/featurization_to_samp
 		"" \
 		$(AUTOSCHED_SRC)/baseline.weights \
 		$(AUTOSCHED_BIN) \
-		$(HALIDE_DISTRIB_PATH)
+		$(HALIDE_DISTRIB_PATH) \
+		$(AUTOSCHED_SAMPLES_OUT)
 
 $(BIN)/test_perfect_hash_map: test_perfect_hash_map.cpp PerfectHashMap.h
 	@mkdir -p $(@D)
@@ -45,11 +46,22 @@ $(BIN)/%/test: test.cpp $(AUTOSCHED_BIN)/libauto_schedule.so
 test_perfect_hash_map: $(BIN)/test_perfect_hash_map
 	$^
 
+run_test: $(BIN)/$(HL_TARGET)/test
+	HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/baseline.weights LD_LIBRARY_PATH=$(AUTOSCHED_BIN) $<
+
+.PHONY: test clean
+
+# Note that when running the *test*, we want to ensure that we generate samples
+# to a subdir of $(BIN), so that they don't get inadvertently generated into
+# our source tree. (Normally we want samples/ to be retained, to avoid data loss;
+# for the test target, however, it's imperative it go into a transitory directory,
+# to avoid eventually consuming all disk space on the buildbot...)
+test: AUTOSCHED_SAMPLES_OUT = $(BIN)/test_samples_out
+
 # Note that 'make test' is used by Halide buildbots to spot-check changes,
 # so it's important to try a little of each of the important paths here,
 # including single-shot and autotune-loop
-test: $(BIN)/$(HL_TARGET)/test test_perfect_hash_map demo autotune included_schedule_file
-	HL_WEIGHTS_DIR=$(AUTOSCHED_SRC)/baseline.weights LD_LIBRARY_PATH=$(AUTOSCHED_BIN) $<
+test: run_test test_perfect_hash_map demo included_schedule_file autotune
 
 clean:
 	rm -rf $(BIN)

--- a/apps/autoscheduler/autotune_loop.sh
+++ b/apps/autoscheduler/autotune_loop.sh
@@ -1,8 +1,8 @@
 # Build the generator to autotune. This script will be autotuning the
 # autoscheduler's cost model training pipeline, which is large enough
 # to be interesting.
-if [ $# -lt 6 -o $# -gt 7 ]; then
-  echo "Usage: $0 /path/to/some.generator generatorname halide_target weights_file autoschedule_bin_dir halide_distrib_path [generator_args_sets]"
+if [ $# -lt 6 -o $# -gt 8 ]; then
+  echo "Usage: $0 /path/to/some.generator generatorname halide_target weights_file autoschedule_bin_dir halide_distrib_path samples_out_path [generator_args_sets]"
   exit
 fi
 
@@ -17,12 +17,13 @@ HL_TARGET=${3}
 START_WEIGHTS_FILE=${4}
 AUTOSCHED_BIN=${5}
 HALIDE_DISTRIB_PATH=${6}
+SAMPLES=${7}
 
 # Read the generator-arg sets into an array. Each set is delimited
 # by space; multiple values within each set are are delimited with ;
 # e.g. "set1arg1=1;set1arg2=foo set2=bar set3arg1=3.14;set4arg2=42"
-if [ $# -ge 7 ]; then
-    IFS=' ' read -r -a GENERATOR_ARGS_SETS_ARRAY <<< "${7}"
+if [ $# -ge 8 ]; then
+    IFS=' ' read -r -a GENERATOR_ARGS_SETS_ARRAY <<< "${8}"
 else
     declare -a GENERATOR_ARGS_SETS_ARRAY=
 fi
@@ -50,7 +51,6 @@ if [ -z ${PIPELINE} ]; then
 PIPELINE=demo
 fi
 
-SAMPLES=${PWD}/samples
 mkdir -p ${SAMPLES}
 
 WEIGHTS=${SAMPLES}/updated.weights
@@ -223,8 +223,8 @@ for ((BATCH_ID=$((FIRST+1));BATCH_ID<$((FIRST+1+NUM_BATCHES));BATCH_ID++)); do
                 --num_cores=32 \
                 --initial_weights=${WEIGHTS} \
                 --weights_out=${WEIGHTS} \
-                --best_benchmark=${PWD}/samples/best.${PIPELINE}.benchmark.txt \
-                --best_schedule=${PWD}/samples/best.${PIPELINE}.schedule.h
+                --best_benchmark=${SAMPLES}/best.${PIPELINE}.benchmark.txt \
+                --best_schedule=${SAMPLES}/best.${PIPELINE}.schedule.h
     done
 
     echo Batch ${BATCH_ID} took ${SECONDS} seconds to compile, benchmark, and retrain

--- a/apps/support/autoscheduler.inc
+++ b/apps/support/autoscheduler.inc
@@ -1,5 +1,13 @@
-AUTOSCHED_SRC ?= ../autoscheduler
-AUTOSCHED_BIN ?= $(AUTOSCHED_SRC)/bin
+ifndef BIN
+$(error BIN must be set prior to including autoscheduler.inc)
+endif
+
+AUTOSCHED_SRC ?= $(realpath ../autoscheduler)
+
+# Default to $(BIN) so that the toplevel Makefile can put all build products
+# into the build products directory (rather than into the source tree)
+AUTOSCHED_BIN ?= $(BIN)
+AUTOSCHED_SAMPLES_OUT ?= $(AUTOSCHED_SRC)/samples
 
 AUTOSCHED_WEIGHT_OBJECTS=$(AUTOSCHED_BIN)/baseline_weights.o
 


### PR DESCRIPTION
- `make test` should ensure that the `samples` output dir is a subdir of `$(BIN)`, so that it doesn't go in-source-tree and fill up the buildbots
- autoscheduler.inc should default $(AUTOSCHED_BIN) to match $(BIN) so that the toplevel Makefile can override it properly (previously we ended up with some build products in-tree and some in-build-products-dir)