### PR TITLE
gradient_autoscheduler fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1964,6 +1964,7 @@ TEST_APPS=\
 # (see https://github.com/halide/Halide/issues/4069)
 ifneq ($(OS), Windows_NT)
 	TEST_APPS += autoscheduler
+	TEST_APPS += gradient_autoscheduler
 endif
 
 TEST_APPS_DEPS=$(TEST_APPS:%=%_test_app)

--- a/apps/gradient_autoscheduler/ASLog.cpp
+++ b/apps/gradient_autoscheduler/ASLog.cpp
@@ -1,0 +1,52 @@
+#include "ASLog.h"
+
+namespace Halide {
+namespace Internal {
+
+namespace {
+
+std::string get_env_variable(char const *env_var_name) {
+    if (!env_var_name) {
+        return "";
+    }
+
+    #ifdef _MSC_VER
+    // call getenv_s without a buffer to determine the correct string length:
+    size_t length = 0;
+    if ((getenv_s(&length, NULL, 0, env_var_name) != 0) || (length == 0)) {
+        return "";
+    }
+    // call it again to retrieve the value of the environment variable;
+    // note that 'length' already accounts for the null-terminator
+    std::string lvl(length - 1, '@');
+    size_t read = 0;
+    if ((getenv_s(&read, &lvl[0], length, env_var_name) != 0) || (read != length)) {
+        return "";
+    }
+    return lvl;
+    #else
+    char *lvl = getenv(env_var_name);
+    if (lvl) return std::string(lvl);
+    #endif
+
+    return "";
+}
+
+}  // namespace
+
+int aslog::aslog_level() {
+    static int cached_aslog_level = ([]() -> int {
+        // If HL_DEBUG_AUTOSCHEDULE is defined, use that value.
+        std::string lvl = get_env_variable("HL_DEBUG_AUTOSCHEDULE");
+        if (!lvl.empty()) {
+            return atoi(lvl.c_str());
+        }
+        // Otherwise, use HL_DEBUG_CODEGEN.
+        lvl = get_env_variable("HL_DEBUG_CODEGEN");
+        return !lvl.empty() ? atoi(lvl.c_str()) : 0;
+    })();
+    return cached_aslog_level;
+}
+
+}  // namespace Internal
+}  // namespace Halide

--- a/apps/gradient_autoscheduler/ASLog.h
+++ b/apps/gradient_autoscheduler/ASLog.h
@@ -1,0 +1,35 @@
+#ifndef ASLOG_H
+#define ASLOG_H
+
+// This class is used by train_cost_model, which doesn't link to
+// libHalide, so (despite the namespace) we are better off not
+// including Halide.h, lest we reference something we won't have available 
+
+#include <cstdlib>
+#include <iostream>
+#include <utility>
+
+namespace Halide {
+namespace Internal {
+
+class aslog {
+    const bool logging;
+
+public:
+    aslog(int verbosity) : logging(verbosity <= aslog_level()) {}
+
+    template<typename T>
+    aslog &operator<<(T&& x) {
+        if (logging) {
+            std::cerr << std::forward<T>(x);
+        }
+        return *this;
+    }
+
+    static int aslog_level();
+};
+
+}  // namespace Internal
+}  // namespace Halide
+
+#endif

--- a/apps/gradient_autoscheduler/GradientAutoscheduler.cpp
+++ b/apps/gradient_autoscheduler/GradientAutoscheduler.cpp
@@ -1,4 +1,5 @@
 #include "Halide.h"
+#include "ASLog.h"
 #include "Errors.h"
 #ifdef WITH_PYTHON
     #include <pybind11/pybind11.h>
@@ -219,8 +220,8 @@ void parallelize_vars_and_rvars_gpu(
             }
         }
     }
-    
-    if (!gpu_blocks.empty() || !r_gpu_blocks.empty()) { 
+
+    if (!gpu_blocks.empty() || !r_gpu_blocks.empty()) {
         // Assign outer loops to GPU blocks
         if (!fused_var.name().empty()) {
             func_or_stage.gpu_blocks(fused_var);
@@ -404,7 +405,7 @@ void parallelize_vars_and_rvars_cpu(
             }
         }
     }
-  
+
     if (!fused_var.name().empty()) {
         // Parallelize vars
         if (num_threads_var > params.parallelism * 8) {
@@ -841,7 +842,7 @@ void generate_schedule(const std::vector<Function> &outputs,
 
     auto_scheduler_results->scheduler_name = "gradient autoscheduler";
     auto_scheduler_results->schedule_source = schedule_source.str();
-    std::cerr << schedule_source.str() << std::endl;
+    aslog(1) << schedule_source.str() << '\n';
 }
 
 

--- a/apps/gradient_autoscheduler/Makefile
+++ b/apps/gradient_autoscheduler/Makefile
@@ -1,6 +1,6 @@
 include ../support/Makefile.inc
 
-WITH_PYTHON ?= 1
+WITH_PYTHON ?= 0
 ifeq ($(WITH_PYTHON),1)
 	PYTHON ?= python3
 	# Discover pybind11 path from `python3 -m pybind11 --includes`
@@ -15,12 +15,20 @@ ifeq ($(WITH_PYTHON),1)
 		PYBIND11_PATH ?= /path/to/pybind11
 		PYBIND11_CFLAGS = -I $(PYBIND11_PATH)/include
 	endif
-	PYTHON_FLAGS = -DWITH_PYTHON $(PYBIND11_CFLAGS)
+	PYTHON_FLAGS = -DWITH_PYTHON $(PYBIND11_CFLAGS) $(shell $(PYTHON)-config --cflags)
+
+	# # DON'T link libpython* - leave those symbols to lazily resolve at load time
+	# # Cf. https://github.com/pybind/pybind11/blob/master/docs/compiling.rst#building-manually
+	ifeq ($(UNAME), Darwin)
+	    # Keep OS X builds from complaining about missing libpython symbols
+	    PYTHON_FLAGS += -undefined dynamic_lookup
+	endif
+
 endif
 
-bin/libgradient_autoscheduler.so: GradientAutoscheduler.cpp
+bin/libgradient_autoscheduler.so: GradientAutoscheduler.cpp ASLog.cpp
 	@mkdir -p $(@D)
-	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC $(CXXFLAGS) -g $(OPTIMIZE) $^ -o $@ $(HALIDE_SYSTEM_LIBS) $(PYTHON_FLAGS)
+	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC -fvisibility=hidden -fvisibility-inlines-hidden $(CXXFLAGS) -g $(OPTIMIZE) $^ -o $@ $(HALIDE_SYSTEM_LIBS) $(PYTHON_FLAGS)
 
 # Demonstrate a JIT-based use of gradient autoscheuler
 bin/test: test.cpp bin/libgradient_autoscheduler.so


### PR DESCRIPTION
- Migrate the aslog() utility from apps/autoscheduler and use aslog(1) instead of std::cerr (schedulers need to be *absolutely silent* by default to avoid build-system spam)
- Add gradient_autoscheduler to 'make test_apps'
- build with -fvisibility=hidden to save code size
- default WITH_PYTHON to 0... as written, this requires every piece of code using to link to Python, which is definitely not what we want. (The code should be modified to either have a separate library for Python usage, or to find a way to safely lazy-load the Python extension library.)
- Use `$(PYTHON)-config --cflags` to ensure path to Python.h can be found (if WITH_PYTHON=1 is set)