### PR TITLE
Add Buffer.defined() checks in Python bindings when printing buffers

### DIFF
--- a/python_bindings/correctness/buffer.py
+++ b/python_bindings/correctness/buffer.py
@@ -238,6 +238,12 @@ def test_overflow():
     except ValueError as e:
         assert 'Out of range arguments to make_dim_vec.' in str(e)
 
+def test_buffer_to_str():
+    b = hl.Buffer()
+    assert str(b) == '<undefined halide.Buffer>'
+    b = hl.Buffer(hl.Int(32), [128, 256])
+    assert str(b) == '<halide.Buffer of type int32 shape:[[0,128,1],[0,256,128]]>'
+
 if __name__ == "__main__":
     test_make_interleaved()
     test_interleaved_ndarray()
@@ -250,3 +256,4 @@ if __name__ == "__main__":
     test_int64()
     test_reorder()
     test_overflow()
+    test_buffer_to_str()

--- a/python_bindings/src/PyBuffer.cpp
+++ b/python_bindings/src/PyBuffer.cpp
@@ -32,6 +32,10 @@ std::ostream &operator<<(std::ostream &stream, const std::vector<halide_dimensio
 // Given a Buffer<>, return its shape in the form of a vector<halide_dimension_t>.
 // (Oddly, Buffer<> has no API to do this directly.)
 std::vector<halide_dimension_t> get_buffer_shape(const Buffer<> &b) {
+    if (!b.defined()) {
+        // Return an empty vector if the buffer is not defined.
+        return {};
+    }
     std::vector<halide_dimension_t> s;
     for (int i = 0; i < b.dimensions(); ++i) {
         s.push_back(b.raw_buffer()->dim[i]);
@@ -531,7 +535,11 @@ void define_buffer(py::module &m) {
 
         .def("__repr__", [](const Buffer<> &b) -> std::string {
             std::ostringstream o;
-            o << "<halide.Buffer of type " << halide_type_to_string(b.type()) << " shape:" << get_buffer_shape(b) << ">";
+            if (b.defined()) {
+                o << "<halide.Buffer of type " << halide_type_to_string(b.type()) << " shape:" << get_buffer_shape(b) << ">";
+            } else {
+                o << "<undefined halide.Buffer>";
+            }
             return o.str();
         })
     ;


### PR DESCRIPTION
Current Python bindings crashes when doing
```
import halide as hl
b = hl.Buffer()
print(b)
```
This is because the `__repr__` function in hl.Buffer does not check if the Buffer is defined when accessing its member. This PR fixes that.