### PR TITLE
Add Halide::load_plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2020,6 +2020,7 @@ benchmark_apps: $(BENCHMARK_APPS)
 # TODO(srj): the python bindings need to be put into the distrib folders;
 # this is a hopefully-temporary workaround (https://github.com/halide/Halide/issues/4368)
 .PHONY: build_python_bindings
+ifneq ($(OS), Windows_NT)
 build_python_bindings: distrib $(BIN_DIR)/host/runtime.a
 	$(MAKE) -C $(ROOT_DIR)/python_bindings \
 		-f $(ROOT_DIR)/python_bindings/Makefile \
@@ -2028,6 +2029,10 @@ build_python_bindings: distrib $(BIN_DIR)/host/runtime.a
 		BIN=$(CURDIR)/$(BIN_DIR)/python3_bindings \
 		PYTHON=python3 \
 		PYBIND11_PATH=$(REAL_PYBIND11_PATH)
+else
+# No Python support for MinGW yet
+build_python_bindings: ;
+endif
 
 .PHONY: test_python
 test_python: distrib $(BIN_DIR)/host/runtime.a build_python_bindings

--- a/Makefile
+++ b/Makefile
@@ -1973,6 +1973,7 @@ $(TEST_APPS_DEPS): distrib build_python_bindings
 	@echo Testing app $(@:%_test_app=%) for ${HL_TARGET}...
 	@$(MAKE) -C $(ROOT_DIR)/apps/$(@:%_test_app=%) test \
 		HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
+		HALIDE_PYTHON_BINDINGS_PATH=$(CURDIR)/$(BIN_DIR)/python3_bindings \
 		BIN_DIR=$(CURDIR)/$(BIN_DIR)/apps/$(@:%_test_app=%)/bin \
 		HL_TARGET=$(HL_TARGET) \
 		|| exit 1 ; \
@@ -1994,6 +1995,7 @@ $(BENCHMARK_APPS): distrib build_python_bindings
 	@$(MAKE) -C $(ROOT_DIR)/apps/$@ \
 		$(CURDIR)/$(BIN_DIR)/apps/$@/bin/$(HL_TARGET)/$@.rungen${SUFFIX} \
 		HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
+		HALIDE_PYTHON_BINDINGS_PATH=$(CURDIR)/$(BIN_DIR)/python3_bindings \
 		BIN_DIR=$(CURDIR)/$(BIN_DIR)/apps/$@/bin \
 		HL_TARGET=$(HL_TARGET) \
 		> /dev/null \
@@ -2010,6 +2012,7 @@ benchmark_apps: $(BENCHMARK_APPS)
 		make -C $(ROOT_DIR)/apps/$${APP} \
 			$${APP}.benchmark${SUFFIX} \
 			HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
+			HALIDE_PYTHON_BINDINGS_PATH=$(CURDIR)/$(BIN_DIR)/python3_bindings \
 			BIN_DIR=$(CURDIR)/$(BIN_DIR)/apps/$${APP}/bin \
 			HL_TARGET=$(HL_TARGET) ; \
 	done

--- a/apps/autoscheduler/test.cpp
+++ b/apps/autoscheduler/test.cpp
@@ -3,6 +3,8 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
+    // Loads lib auto_schedule.so (or auto_schedule.dll),
+    // which is presumed to be in current library search path
     load_plugin("auto_schedule");
     Pipeline::set_default_autoscheduler_name("Adams2019");
 

--- a/apps/autoscheduler/test.cpp
+++ b/apps/autoscheduler/test.cpp
@@ -3,10 +3,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (!::Halide::Internal::load_plugin("auto_schedule", std::cerr)) {
-        return 1;
-    }
-
+    load_plugin("auto_schedule");
     Pipeline::set_default_autoscheduler_name("Adams2019");
 
     MachineParams params(32, 16000000, 40);

--- a/apps/gradient_autoscheduler/GradientAutoscheduler.cpp
+++ b/apps/gradient_autoscheduler/GradientAutoscheduler.cpp
@@ -1,9 +1,6 @@
 #include "Halide.h"
 #include "ASLog.h"
 #include "Errors.h"
-#ifdef WITH_PYTHON
-    #include <pybind11/pybind11.h>
-#endif
 
 namespace Halide {
 namespace Internal {
@@ -867,9 +864,3 @@ struct RegisterGradientAutoscheduler {
 } // Autoscheduler
 } // Internal
 } // Halide
-
-#ifdef WITH_PYTHON
-    PYBIND11_MODULE(libgradient_autoscheduler, m) {
-        m.doc() = "Halide gradient autoscheduler";
-    }
-#endif

--- a/apps/gradient_autoscheduler/Makefile
+++ b/apps/gradient_autoscheduler/Makefile
@@ -1,8 +1,8 @@
 include ../support/Makefile.inc
 
-$(BIN)/libgradient_autoscheduler.so: GradientAutoscheduler.cpp ASLog.cpp
+$(BIN)/libgradient_autoscheduler.so: GradientAutoscheduler.cpp ASLog.cpp $(LIB_HALIDE)
 	@mkdir -p $(@D)
-	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC -fvisibility=hidden -fvisibility-inlines-hidden $(CXXFLAGS) $(OPTIMIZE) $^ -o $@ $(HALIDE_SYSTEM_LIBS)
+	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC $(CXXFLAGS) $(OPTIMIZE) $^ -o $@ $(HALIDE_SYSTEM_LIBS)
 
 # Demonstrate a JIT-based use of gradient autoscheuler
 $(BIN)/test: test.cpp $(BIN)/libgradient_autoscheduler.so
@@ -32,10 +32,10 @@ test_generator: $(BIN)/$(HL_TARGET)/demo.rungen $(BIN)/libgradient_autoscheduler
 run_test_cpp: $(BIN)/test
 	LD_LIBRARY_PATH=$(BIN) $<
 
-run_test_py: test.py
-	PYTHONPATH=$(HALIDE_PYTHON_BINDINGS_PATH):$$PYTHONPATH \
-		LD_LIBRARY_PATH=$(BIN) $(PYTHON) \
-		test.py
+run_test_py: test.py $(BIN)/libgradient_autoscheduler.so
+	PYTHONPATH=$(BIN):$(HALIDE_PYTHON_BINDINGS_PATH):$(HALIDE_DISTRIB_PATH)/bin:$$PYTHONPATH \
+		LD_LIBRARY_PATH=$(BIN):$(HALIDE_PYTHON_BINDINGS_PATH):$(HALIDE_DISTRIB_PATH)/bin \
+		$(PYTHON) test.py
 
 test: run_test_cpp run_test_py test_generator
 

--- a/apps/gradient_autoscheduler/Makefile
+++ b/apps/gradient_autoscheduler/Makefile
@@ -2,7 +2,7 @@ include ../support/Makefile.inc
 
 $(BIN)/libgradient_autoscheduler.so: GradientAutoscheduler.cpp ASLog.cpp $(LIB_HALIDE)
 	@mkdir -p $(@D)
-	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC $(CXXFLAGS) $(OPTIMIZE) $^ -o $@ $(HALIDE_SYSTEM_LIBS)
+	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC -fvisibility=hidden -fvisibility-inlines-hidden $(CXXFLAGS) $(OPTIMIZE) $^ -o $@ $(HALIDE_SYSTEM_LIBS)
 
 # Demonstrate a JIT-based use of gradient autoscheuler
 $(BIN)/test: test.cpp $(BIN)/libgradient_autoscheduler.so

--- a/apps/gradient_autoscheduler/Makefile
+++ b/apps/gradient_autoscheduler/Makefile
@@ -1,41 +1,13 @@
 include ../support/Makefile.inc
 
-WITH_PYTHON ?= 0
-ifeq ($(WITH_PYTHON),1)
-	PYTHON ?= python3
-	# Discover pybind11 path from `python3 -m pybind11 --includes`
-	# if it is pip/conda installed, which is a common case.
-	# Cf. https://github.com/pybind/pybind11/blob/master/docs/compiling.rst#building-manually
-	PYBIND11_CFLAGS = $(shell $(PYTHON) -m pybind11 --includes)
-	ifeq ($(PYBIND11_CFLAGS),)
-		ifndef PYBIND11_PATH
-			$(error Can't find pybind11 for compiling the Python module.
-				    Set the environment variable WITH_PYTHON=0 to disable Python support.)
-		endif
-		PYBIND11_PATH ?= /path/to/pybind11
-		PYBIND11_CFLAGS = -I $(PYBIND11_PATH)/include
-	endif
-	PYTHON_FLAGS = -DWITH_PYTHON $(PYBIND11_CFLAGS) $(shell $(PYTHON)-config --cflags)
-	# # DON'T link libpython* - leave those symbols to lazily resolve at load time
-	# # Cf. https://github.com/pybind/pybind11/blob/master/docs/compiling.rst#building-manually
-	ifeq ($(UNAME), Darwin)
-	    # Keep OS X builds from complaining about missing libpython symbols
-	    PYTHON_FLAGS += -undefined dynamic_lookup
-	endif
-endif
-
-bin/libgradient_autoscheduler.so: GradientAutoscheduler.cpp ASLog.cpp
+$(BIN)/libgradient_autoscheduler.so: GradientAutoscheduler.cpp ASLog.cpp
 	@mkdir -p $(@D)
-	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC -fvisibility=hidden -fvisibility-inlines-hidden $(CXXFLAGS) -g $(OPTIMIZE) $^ -o $@ $(HALIDE_SYSTEM_LIBS) $(PYTHON_FLAGS)
+	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC -fvisibility=hidden -fvisibility-inlines-hidden $(CXXFLAGS) $(OPTIMIZE) $^ -o $@ $(HALIDE_SYSTEM_LIBS)
 
 # Demonstrate a JIT-based use of gradient autoscheuler
-bin/test: test.cpp bin/libgradient_autoscheduler.so
+$(BIN)/test: test.cpp $(BIN)/libgradient_autoscheduler.so
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $(USE_EXPORT_DYNAMIC) test.cpp -o $@ $(LDFLAGS) $(LIB_HALIDE) $(HALIDE_SYSTEM_LIBS)
-
-test: bin/test
-	LD_LIBRARY_PATH=bin $<
-
 
 # Demonstrate a generator-based use of gradient autoscheuler
 $(GENERATOR_BIN)/demo.generator: demo_generator.cpp $(GENERATOR_DEPS)
@@ -43,18 +15,29 @@ $(GENERATOR_BIN)/demo.generator: demo_generator.cpp $(GENERATOR_DEPS)
 	$(CXX) $(CXXFLAGS) $(USE_EXPORT_DYNAMIC) -g $(filter-out %.h,$^) -o $@ $(LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
 # Use the -p flag to the generator to load the autoscheduler as a plugin
-$(BIN)/%/demo.a: $(GENERATOR_BIN)/demo.generator bin/libgradient_autoscheduler.so
+$(BIN)/%/demo.a: $(GENERATOR_BIN)/demo.generator $(BIN)/libgradient_autoscheduler.so
 	@mkdir -p $(@D)
-	$(GENERATOR_BIN)/demo.generator -g demo -o $(@D) -f demo target=$* auto_schedule=true -p bin/libgradient_autoscheduler.so -s Li2018
+	$(GENERATOR_BIN)/demo.generator -g demo -o $(@D) -f demo target=$* auto_schedule=true -p $(BIN)/libgradient_autoscheduler.so -s Li2018
 
 $(BIN)/%/demo.rungen: $(BIN)/%/RunGenMain.o $(BIN)/%/demo.registration.cpp $(BIN)/%/demo.a
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -I$(BIN)/$* $^ -o $@ $(HALIDE_SYSTEM_LIBS) $(IMAGE_IO_FLAGS)
 
+.PHONY: test clean run_test_cpp run_test_py test_generator
+
 # demonstrates single-shot use of the autoscheduler
-test_generator: $(BIN)/$(HL_TARGET)/demo.rungen bin/libgradient_autoscheduler.so
+test_generator: $(BIN)/$(HL_TARGET)/demo.rungen $(BIN)/libgradient_autoscheduler.so
 	$< --benchmarks=all --benchmark_min_time=1 --estimate_all
 
+run_test_cpp: $(BIN)/test
+	LD_LIBRARY_PATH=$(BIN) $<
+
+run_test_py: test.py
+	PYTHONPATH=$(HALIDE_PYTHON_BINDINGS_PATH):$$PYTHONPATH \
+		LD_LIBRARY_PATH=$(BIN) $(PYTHON) \
+		test.py
+
+test: run_test_cpp run_test_py test_generator
 
 clean:
-	rm -rf bin
+	rm -rf $(BIN)

--- a/apps/gradient_autoscheduler/test.cpp
+++ b/apps/gradient_autoscheduler/test.cpp
@@ -5,10 +5,7 @@ using namespace Halide;
 int main(int argc, char **argv) {
     // Loads libgradient_autoscheduler.so (or gradient_autoscheduler.dll),
     // which is presumed to be in current library search path
-    if (!::Halide::Internal::load_plugin("gradient_autoscheduler", std::cerr)) {
-        return 1;
-    }
-
+    load_plugin("gradient_autoscheduler");
     Pipeline::set_default_autoscheduler_name("Li2018");
 
     MachineParams params(32, 16000000, 40);

--- a/apps/gradient_autoscheduler/test.py
+++ b/apps/gradient_autoscheduler/test.py
@@ -1,10 +1,8 @@
 import halide as hl
-import sys
-sys.path.append("./bin")
-# import autoscheduler
-import libgradient_autoscheduler
 
 def main():
+    hl.load_plugin("gradient_autoscheduler")
+
     x = hl.Var('x')
     f_in = hl.Func('in')
     f_in[x] = hl.f32(x) # Cast to float 32

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -4,6 +4,13 @@ IMAGES ?= ../images
 UNAME ?= $(shell uname)
 SHELL = bash
 
+PYTHON ?= python3
+
+# TODO(srj): the python bindings need to be put into the distrib folders;
+# this is a hopefully-temporary workaround (https://github.com/halide/Halide/issues/4368)
+$(AUTOSCHED_BIN)/binary2cpp: ../../tools/binary2cpp.cpp
+HALIDE_PYTHON_BINDINGS_PATH ?= $(realpath ../../bin/python3_bindings)
+
 BIN_DIR ?= bin
 
 # Most build outputs go into $(BIN)/$(HL_TARGET)/$(HL_TARGET)/, so that you can vary the test

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -8,7 +8,6 @@ PYTHON ?= python3
 
 # TODO(srj): the python bindings need to be put into the distrib folders;
 # this is a hopefully-temporary workaround (https://github.com/halide/Halide/issues/4368)
-$(AUTOSCHED_BIN)/binary2cpp: ../../tools/binary2cpp.cpp
 HALIDE_PYTHON_BINDINGS_PATH ?= $(realpath ../../bin/python3_bindings)
 
 BIN_DIR ?= bin

--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -24,6 +24,16 @@ else
 endif
 endif
 
+ifeq ($(UNAME), Linux)
+USE_EXPORT_DYNAMIC=-rdynamic
+else
+ifeq ($(UNAME), Darwin)
+USE_EXPORT_DYNAMIC=-undefined dynamic_lookup
+else
+USE_EXPORT_DYNAMIC=
+endif
+endif
+
 LIBHALIDE ?= $(HALIDE_DISTRIB_PATH)/bin/libHalide.$(SHARED_EXT)
 
 SUFFIX = $(shell $(PYTHON)-config --extension-suffix)
@@ -52,11 +62,7 @@ CCFLAGS := $(filter-out -Wstrict-prototypes,$(CCFLAGS))
 
 # DON'T link libpython* - leave those symbols to lazily resolve at load time
 # Cf. https://github.com/pybind/pybind11/blob/master/docs/compiling.rst#building-manually
-LDFLAGS=-lz
-ifeq ($(UNAME), Darwin)
-    # Keep OS X builds from complaining about missing libpython symbols
-    LDFLAGS += -undefined dynamic_lookup
-endif
+LDFLAGS=-lz $(USE_EXPORT_DYNAMIC)
 
 PY_SRCS=$(shell ls $(ROOT_DIR)/src/*.cpp)
 PY_OBJS=$(PY_SRCS:$(ROOT_DIR)/src/%.cpp=$(BIN)/src/%.o)
@@ -188,7 +194,14 @@ $(TEST_TMP)/lesson_10_halide.so: test_tutorial_lesson_10_aot_compilation_generat
 		$(TEST_TMP)/lesson_10_halide.o \
 		-I $(TEST_TMP) -o $@
 
+.PHONY: clean
 clean:
 	rm -rf $(BIN)
 
+.PHONY: test
 test: test_correctness test_apps test_tutorial
+
+# TODO(srj): the python bindings need to be put into the distrib folders;
+# this is a hopefully-temporary workaround (https://github.com/halide/Halide/issues/4368)
+.PHONY: build_python_bindings
+build_python_bindings: $(MODULE)

--- a/python_bindings/src/PyHalide.cpp
+++ b/python_bindings/src/PyHalide.cpp
@@ -57,4 +57,7 @@ PYBIND11_MODULE(HALIDE_PYBIND_MODULE_NAME, m) {
     define_image_param(m);
     define_type(m);
     define_derivative(m);
+
+    // There is no PyUtil yet, so just put this here
+    m.def("load_plugin", &Halide::load_plugin, py::arg("lib_name"));
 }

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -806,9 +806,8 @@ int generate_filter_main_inner(int argc, char **argv, std::ostream &cerr) {
     // It's possible that in the future loaded plugins might change
     // how arguments are parsed, so we handle those first.
     for (const auto &lib : split_string(flags_info["-p"], ",")) {
-        if (lib.empty()) continue;
-        if (!load_plugin(lib, cerr)) {
-            return 1;
+        if (!lib.empty()) {
+            load_plugin(lib);
         }
     }
 

--- a/src/Util.h
+++ b/src/Util.h
@@ -48,6 +48,19 @@
 #endif
 
 namespace Halide {
+
+/** Load a plugin in the form of a dynamic library (e.g. for custom autoschedulers).
+ * If the string doesn't contain any . characters, the proper prefix and/or suffix
+ * for the platform will be added:
+ *
+ *   foo -> libfoo.so (Linux/OSX/etc -- note that .dylib is not supported)
+ *   foo -> foo.dll (Windows)
+ *
+ * otherwise, it is assumed to be an appropriate pathname.
+ *
+ * Any error in loading will assert-fail. */
+void load_plugin(const std::string &lib_name);
+
 namespace Internal {
 
 /** Some numeric conversions are UB if the value won't fit in the result;
@@ -454,16 +467,6 @@ struct IsRoundtrippable {
 
 /** Emit a version of a string that is a valid identifier in C (. is replaced with _) */
 std::string c_print_name(const std::string &name);
-
-/** Load a plugin in the form of a dynamic library (e.g. for custom autoschedulers).
- * If the string doesn't contain any . characters, the proper prefix and/or suffix
- * for the platform will be added:
- *
- *   foo -> libfoo.so (Linux/OSX/etc -- note that .dylib is not supported)
- *   foo -> foo.dll (Windows)
- *
- * otherwise, it is assumed to be an appropriate pathname. */
-bool load_plugin(const std::string &lib_name, std::ostream &error_msg);
 
 }  // namespace Internal
 }  // namespace Halide


### PR DESCRIPTION
Promote this to a first-class Halide API, along with Python wrapper. Remove the python-related code from apps/gradient_autoscheduler and use this instead. Also drive-by cleanup in gradient_autoscheduler to run all the tests properly.