### PR TITLE
Reduce binary size of of libauto_schedule.so

### DIFF
--- a/apps/support/autoscheduler.inc
+++ b/apps/support/autoscheduler.inc
@@ -33,7 +33,7 @@ $(AUTOSCHED_BIN)/cost_model.generator: $(AUTOSCHED_SRC)/cost_model_generator.cpp
 							$(AUTOSCHED_SRC)/NetworkSize.h \
 							$(GENERATOR_DEPS)
 	@mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) -g $(filter-out %.h,$^) -o $@ $(HALIDE_SYSTEM_LIBS) $(USE_EXPORT_DYNAMIC)
+	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(HALIDE_SYSTEM_LIBS) $(USE_EXPORT_DYNAMIC)
 
 $(AUTOSCHED_BIN)/auto_schedule_runtime.a: $(AUTOSCHED_BIN)/cost_model.generator
 	@mkdir -p $(@D)
@@ -62,7 +62,7 @@ $(AUTOSCHED_BIN)/libauto_schedule.so: $(AUTOSCHED_SRC)/AutoSchedule.cpp \
 										$(GENERATOR_DEPS) \
 										$(AUTOSCHED_BIN)/auto_schedule_runtime.a
 	@mkdir -p $(@D)
-	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC $(CXXFLAGS) -g $(OPTIMIZE) -I $(AUTOSCHED_BIN)/cost_model $(filter-out %.h $(LIB_HALIDE),$^) -o $@ $(HALIDE_SYSTEM_LIBS)
+	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC -fvisibility=hidden -fvisibility-inlines-hidden $(CXXFLAGS) $(OPTIMIZE) -I $(AUTOSCHED_BIN)/cost_model $(filter-out %.h $(LIB_HALIDE),$^) -o $@ $(HALIDE_SYSTEM_LIBS)
 
 $(AUTOSCHED_BIN)/retrain_cost_model: $(AUTOSCHED_SRC)/retrain_cost_model.cpp \
 									$(AUTOSCHED_SRC)/ASLog.cpp \


### PR DESCRIPTION
- Don't include debug symbols (`-g`) by default (>10x size savings); when necessary for debugging, the preferred fix here it override the value of the OPTIMIZE flag
- Add `-fvisibility=hidden -fvisibility-inlines-hidden` to save another 30k or so