### PR TITLE
Fix OSX+Homebrew+Python issue for HelloPyTorch

### DIFF
--- a/apps/HelloPyTorch/Makefile
+++ b/apps/HelloPyTorch/Makefile
@@ -12,9 +12,9 @@ CUDA_OPS =
 else
 HAS_CUDA = 1
 CUDA_OPS = $(BIN)/$(HL_TARGET)/add_cuda_float32.a \
-	   $(BIN)/$(HL_TARGET)/add_cuda_float64.a \
+	   	   $(BIN)/$(HL_TARGET)/add_cuda_float64.a \
            $(BIN)/$(HL_TARGET)/add_grad_cuda_float32.a \
-	   $(BIN)/$(HL_TARGET)/add_grad_cuda_float64.a 
+	       $(BIN)/$(HL_TARGET)/add_grad_cuda_float64.a
 endif
 
 EXT_LIB=$(BIN)/lib
@@ -23,10 +23,11 @@ PIP ?= pip3
 
 all: test
 
+CUDA_TARGET ?= host-cuda-cuda_capability_61-user_context
 
 # Run the PyTorch tests to verify the module is compiled correctly
 # .wrapper is a dummy file whose timestamps allow Make to track the dependency
-# on the Python side of the build 
+# on the Python side of the build
 
 
 test: $(BIN)/.wrapper
@@ -44,76 +45,124 @@ $(BIN)/.wrapper: $(OPS) $(CUDA_OPS) setup.py
 	@touch $(BIN)/.wrapper
 
 
+# Some common args
+
+ADD_TYPES_F32 =\
+		input_a.type=float32 \
+		input_b.type=float32 \
+		output.type=float32 \
+
+ADD_TYPES_F64 =\
+		input_a.type=float64 \
+		input_b.type=float64 \
+		output.type=float64 \
+
+ADD_GRAD_TYPES_F32 =\
+		input_a.type=float32 \
+		input_b.type=float32 \
+		d_input_a.type=float32 \
+		d_input_b.type=float32 \
+		d_output.type=float32 \
+
+ADD_GRAD_TYPES_F64 =\
+		input_a.type=float64 \
+		input_b.type=float64 \
+		d_input_a.type=float64 \
+		d_input_b.type=float64 \
+		d_output.type=float64 \
+
 # Generate the CPU version of the op ------------------------------------------
 $(BIN)/%/add_float32.a: $(GENERATOR_BIN)/add.generator
 	@mkdir -p $(@D)
 	@echo Producing CPU operator
-	@$^ -g add input_a.type=float32 input_b.type=float32 output.type=float32 \
-		-f add_float32 -e static_library,c_header,pytorch_wrapper -o $(@D) \
-		target=$* auto_schedule=false
+	@$^ -g add \
+		$(ADD_TYPES_F32) \
+		-f add_float32 \
+		-e static_library,c_header,pytorch_wrapper \
+		-o $(@D) \
+		target=$* \
+		auto_schedule=false
 
 $(BIN)/%/add_grad_float32.a: $(GENERATOR_BIN)/add.generator
 	@mkdir -p $(@D)
 	@echo Producing CPU gradient
 	@$^ -g add_grad \
-		input_a.type=float32 input_b.type=float32 \
-		d_input_a.type=float32 d_input_b.type=float32 \
-		d_output.type=float32 -f add_grad_float32 \
-		-e static_library,c_header,pytorch_wrapper -o $(@D) \
-		target=$* auto_schedule=false
+		$(ADD_GRAD_TYPES_F32) \
+		-f add_grad_float32 \
+		-e static_library,c_header,pytorch_wrapper \
+		-o $(@D) \
+		target=$* \
+		auto_schedule=false
 
 $(BIN)/%/add_float64.a: $(GENERATOR_BIN)/add.generator
 	@mkdir -p $(@D)
 	@echo "Producing CPU (double) operator"
-	@$^ -g add input_a.type=float64 input_b.type=float64 output.type=float64 \
-		-f add_float64 -e static_library,c_header,pytorch_wrapper -o $(@D) \
-		target=$* auto_schedule=false
+	@$^ -g add \
+		$(ADD_TYPES_F64) \
+		-f add_float64 \
+		-e static_library,c_header,pytorch_wrapper \
+		-o $(@D) \
+		target=$* \
+		auto_schedule=false
 
 $(BIN)/%/add_grad_float64.a: $(GENERATOR_BIN)/add.generator
 	@mkdir -p $(@D)
 	@echo "Producing CPU (double) gradient"
 	@$^ -g add_grad \
-		input_a.type=float64 input_b.type=float64 \
-		d_input_a.type=float64 d_input_b.type=float64 \
-		d_output.type=float64 -f add_grad_float64 \
-		-e static_library,c_header,pytorch_wrapper -o $(@D) \
-		target=$* auto_schedule=false
+		$(ADD_GRAD_TYPES_F64) \
+		-f add_grad_float64 \
+		-e static_library,c_header,pytorch_wrapper \
+		-o $(@D) \
+		target=$* \
+		auto_schedule=false
+
 # -----------------------------------------------------------------------------
 
 # Generate the GPU version of the op ------------------------------------------
 $(BIN)/%/add_cuda_float32.a: $(GENERATOR_BIN)/add.generator
 	@mkdir -p $(@D)
 	@echo Producing CUDA operator
-	@$^ -g add input_a.type=float32 input_b.type=float32 output.type=float32 \
-		-f add_cuda_float32 -e static_library,c_header,pytorch_wrapper -o $(@D) \
-		target=host-cuda-cuda_capability_61-user_context auto_schedule=false
+	@$^ -g add \
+		$(ADD_TYPES_F32) \
+		-f add_cuda_float32 \
+		-e static_library,c_header,pytorch_wrapper \
+		-o $(@D) \
+		target=$(CUDA_TARGET) \
+		auto_schedule=false
 
 $(BIN)/%/add_grad_cuda_float32.a: $(GENERATOR_BIN)/add.generator
 	@mkdir -p $(@D)
 	@echo "Producing CUDA (double) gradient"
 	@$^ -g add_grad \
-		input_a.type=float32 input_b.type=float32 \
-		d_input_a.type=float32 d_input_b.type=float32 \
-		d_output.type=float32 -f add_grad_cuda_float32 \
-		-e static_library,c_header,pytorch_wrapper -o $(@D) \
-		target=host-cuda-cuda_capability_61-user_context auto_schedule=false
+		$(ADD_GRAD_TYPES_F32) \
+		-f add_grad_cuda_float32 \
+		-e static_library,c_header,pytorch_wrapper \
+		-o $(@D) \
+		target=$(CUDA_TARGET) \
+		auto_schedule=false
 
 $(BIN)/%/add_cuda_float64.a: $(GENERATOR_BIN)/add.generator
 	@mkdir -p $(@D)
 	@echo "Producing CUDA (double) operator"
-	@$^ -g add input_a.type=float64 input_b.type=float64 output.type=float64 \
-		-f add_cuda_float64 -e static_library,c_header,pytorch_wrapper -o $(@D) \
-		target=host-cuda-cuda_capability_61-user_context auto_schedule=false
+	@$^ -g add \
+		$(ADD_TYPES_F64) \
+		-f add_cuda_float64 \
+		-e static_library,c_header,pytorch_wrapper \
+		-o $(@D) \
+		target=$(CUDA_TARGET) \
+		auto_schedule=false
 
 $(BIN)/%/add_grad_cuda_float64.a: $(GENERATOR_BIN)/add.generator
 	@mkdir -p $(@D)
 	@echo Producing CUDA gradient
 	@$^ -g add_grad \
-		input_a.type=float64 input_b.type=float64 \
-		d_input_a.type=float64 d_input_b.type=float64 \
-		d_output.type=float64 -f add_grad_cuda_float64 \
-		-e static_library,c_header,pytorch_wrapper -o $(@D) \
-		target=host-cuda-cuda_capability_61-user_context auto_schedule=false
+		$(ADD_GRAD_TYPES_F64) \
+		-f add_grad_cuda_float64 \
+		-e static_library,c_header,pytorch_wrapper \
+		-o $(@D) \
+		target=$(CUDA_TARGET) \
+		auto_schedule=false
+
 # -----------------------------------------------------------------------------
 
 # Build the Halide generator for the operator

--- a/apps/HelloPyTorch/setup.cfg
+++ b/apps/HelloPyTorch/setup.cfg
@@ -1,0 +1,5 @@
+# Workaround for OSX Homebrew Python issue;
+# see https://stackoverflow.com/questions/24257803/distutilsoptionerror-must-supply-either-home-or-prefix-exec-prefix-not-both
+
+[install]
+prefix=


### PR DESCRIPTION
Some combinations have a known issue and the `pip install` part of the Makefile will fail with `DistutilsOptionError: must supply either home or prefix/exec-prefix — not both`

Adding this dummy setup.cfg is (apparently) a reasonably safe solution, and works on my setup.

attn @mgharbi 