### PR TITLE
Fix name-mangling [u]int64 on IOS

### DIFF
--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -619,6 +619,8 @@ std::string cplusplus_function_mangled_name(const std::string &name, const std::
 
 namespace {
 
+constexpr int kTestTargetCount = 8;
+
 struct MangleResult {
     const char *expected;
     const char *label;
@@ -684,9 +686,11 @@ MangleResult win64_expecteds[] = {
     {"\001?test_function@test_namespace@1@YAHPEAVtest_enum@1@@Z", "test_namespace::test_namespace::test_function(test_namespace::test_enum*)"},
 };
 
-MangleResult all_types_by_target[] = {
+MangleResult all_types_by_target[kTestTargetCount] = {
     {"_Z13test_functionbahstijxyfd", "test_function(bool, signed char, unsigned char, short, unsigned short, int, unsigned int, long long, unsigned long long, float, double)"},
     {"_Z13test_functionbahstijlmfd", "test_function(bool, signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long, float, double)"},
+    {"_Z13test_functionbahstijxyfd", "test_function(bool, signed char, unsigned char, short, unsigned short, int, unsigned int, long long, unsigned long long, float, double)"},
+    {"_Z13test_functionbahstijxyfd", "test_function(bool, signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long, float, double)"},
     {"_Z13test_functionbahstijxyfd", "test_function(bool, signed char, unsigned char, short, unsigned short, int, unsigned int, long long, unsigned long long, float, double)"},
     {"_Z13test_functionbahstijxyfd", "test_function(bool, signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long, float, double)"},
     {"\001?test_function@@YAH_NCEFGHI_J_KMN@Z", "test_function(bool, signed char, unsigned char, short, unsigned short, int, unsigned int, long long, unsigned long long, float, double)"},
@@ -699,11 +703,13 @@ const char *many_type_subs_win32 = "\001?test_function@@YAHPAUs0@test_namespace@
 
 const char *many_type_subs_win64 = "\001?test_function@@YAHPEAUs0@test_namespace@@PEAUs1@2@PEAUs2@2@PEAUs3@2@PEAUs4@2@PEAUs5@2@PEAUs6@2@PEAUs7@2@PEAUs8@2@PEAUs9@2@PEAUs10@2@PEAUs11@2@PEAUs12@2@PEAUs13@2@PEAUs14@2@PEAUs15@2@PEAUs16@2@PEAUs17@2@PEAUs18@2@PEAUs19@2@PEAUs20@2@PEAUs21@2@PEAUs22@2@PEAUs23@2@PEAUs24@2@PEAUs25@2@PEAUs26@2@PEAUs27@2@PEAUs28@2@PEAUs29@2@PEAUs30@2@PEAUs31@2@PEAUs32@2@PEAUs33@2@PEAUs34@2@PEAUs35@2@PEAUs36@2@PEAUs37@2@PEAUs38@2@PEAUs39@2@PEAUs40@2@PEAUs41@2@PEAUs42@2@PEAUs43@2@PEAUs44@2@PEAUs45@2@PEAUs46@2@PEAUs47@2@PEAUs48@2@PEAUs49@2@PEAUs50@2@PEAUs51@2@PEAUs52@2@PEAUs53@2@PEAUs54@2@PEAUs55@2@PEAUs56@2@PEAUs57@2@PEAUs58@2@PEAUs59@2@PEAUs60@2@PEAUs61@2@PEAUs62@2@PEAUs63@2@PEAUs64@2@PEAUs65@2@PEAUs66@2@PEAUs67@2@PEAUs68@2@PEAUs69@2@PEAUs70@2@PEAUs71@2@PEAUs72@2@PEAUs73@2@PEAUs74@2@PEAUs75@2@PEAUs76@2@PEAUs77@2@PEAUs78@2@PEAUs79@2@PEAUs80@2@PEAUs81@2@PEAUs82@2@PEAUs83@2@PEAUs84@2@PEAUs85@2@PEAUs86@2@PEAUs87@2@PEAUs88@2@PEAUs89@2@PEAUs90@2@PEAUs91@2@PEAUs92@2@PEAUs93@2@PEAUs94@2@PEAUs95@2@PEAUs96@2@PEAUs97@2@PEAUs98@2@PEAUs99@2@0123456789PEAUs10@2@PEAUs11@2@PEAUs12@2@PEAUs13@2@PEAUs14@2@PEAUs15@2@PEAUs16@2@PEAUs17@2@PEAUs18@2@PEAUs19@2@PEAUs20@2@PEAUs21@2@PEAUs22@2@PEAUs23@2@PEAUs24@2@PEAUs25@2@PEAUs26@2@PEAUs27@2@PEAUs28@2@PEAUs29@2@PEAUs30@2@PEAUs31@2@PEAUs32@2@PEAUs33@2@PEAUs34@2@PEAUs35@2@PEAUs36@2@PEAUs37@2@PEAUs38@2@PEAUs39@2@PEAUs40@2@PEAUs41@2@PEAUs42@2@PEAUs43@2@PEAUs44@2@PEAUs45@2@PEAUs46@2@PEAUs47@2@PEAUs48@2@PEAUs49@2@PEAUs50@2@PEAUs51@2@PEAUs52@2@PEAUs53@2@PEAUs54@2@PEAUs55@2@PEAUs56@2@PEAUs57@2@PEAUs58@2@PEAUs59@2@PEAUs60@2@PEAUs61@2@PEAUs62@2@PEAUs63@2@PEAUs64@2@PEAUs65@2@PEAUs66@2@PEAUs67@2@PEAUs68@2@PEAUs69@2@PEAUs70@2@PEAUs71@2@PEAUs72@2@PEAUs73@2@PEAUs74@2@PEAUs75@2@PEAUs76@2@PEAUs77@2@PEAUs78@2@PEAUs79@2@PEAUs80@2@PEAUs81@2@PEAUs82@2@PEAUs83@2@PEAUs84@2@PEAUs85@2@PEAUs86@2@PEAUs87@2@PEAUs88@2@PEAUs89@2@PEAUs90@2@PEAUs91@2@PEAUs92@2@PEAUs93@2@PEAUs94@2@PEAUs95@2@PEAUs96@2@PEAUs97@2@PEAUs98@2@PEAUs99@2@@Z";
 
-MangleResult many_type_subs[] = {
+MangleResult many_type_subs[kTestTargetCount] = {
     {many_type_subs_itanium, "The expanded prototype is very long."},
     {many_type_subs_itanium, "No really, too large to put here."},
     {many_type_subs_itanium, "wc -l says 4394 characters."},
     {many_type_subs_itanium, "Feel free to run c++filt if you want to..."},
+    {many_type_subs_itanium, "longity long long"},
+    {many_type_subs_itanium, "It's been a long, long, long..."},
     {many_type_subs_win32, "Not gonna do it."},
     {many_type_subs_win64, "Wouldn't be prudent."}};
 
@@ -715,7 +721,9 @@ const char *many_name_subs_win64 = "\001?test_function@@YAHPEAUs@test_namespace0
 
 const char *many_name_subs_proto = "test_function(test_namespace0::s*, test_namespace1::s*, test_namespace2::s*, test_namespace3::s*, test_namespace4::s*, test_namespace5::s*, test_namespace6::s*, test_namespace7::s*, test_namespace8::s*, test_namespace9::s*, test_namespace10::s*, test_namespace11::s*, test_namespace12::s*, test_namespace13::s*, test_namespace14::s*, test_namespace15::s*, test_namespace16::s*, test_namespace17::s*, test_namespace18::s*, test_namespace19::s*, test_namespace20::s*, test_namespace21::s*, test_namespace22::s*, test_namespace23::s*, test_namespace24::s*, test_namespace0::s*, test_namespace1::s*, test_namespace2::s*, test_namespace3::s*, test_namespace4::s*, test_namespace5::s*, test_namespace6::s*, test_namespace7::s*, test_namespace8::s*, test_namespace9::s*, test_namespace10::s*, test_namespace11::s*, test_namespace12::s*, test_namespace13::s*, test_namespace14::s*, test_namespace15::s*, test_namespace16::s*, test_namespace17::s*, test_namespace18::s*, test_namespace19::s*, test_namespace20::s*, test_namespace21::s*, test_namespace22::s*, test_namespace23::s*, test_namespace24::s*)";
 
-MangleResult many_name_subs[] = {
+MangleResult many_name_subs[kTestTargetCount] = {
+    {many_name_subs_itanium, many_name_subs_proto},
+    {many_name_subs_itanium, many_name_subs_proto},
     {many_name_subs_itanium, many_name_subs_proto},
     {many_name_subs_itanium, many_name_subs_proto},
     {many_name_subs_itanium, many_name_subs_proto},
@@ -723,7 +731,9 @@ MangleResult many_name_subs[] = {
     {many_name_subs_win32, many_name_subs_proto},
     {many_name_subs_win64, many_name_subs_proto}};
 
-MangleResult stacked_indirections[] = {
+MangleResult stacked_indirections[kTestTargetCount] = {
+    {"_Z13test_functionPKiPKS0_PKS2_PKS4_PKS6_PKS8_PKSA_PKSC_", ""},
+    {"_Z13test_functionPKiPKS0_PKS2_PKS4_PKS6_PKS8_PKSA_PKSC_", ""},
     {"_Z13test_functionPKiPKS0_PKS2_PKS4_PKS6_PKS8_PKSA_PKSC_", ""},
     {"_Z13test_functionPKiPKS0_PKS2_PKS4_PKS6_PKS8_PKSA_PKSC_", ""},
     {"_Z13test_functionPKiPKS0_PKS2_PKS4_PKS6_PKS8_PKSA_PKSC_", ""},
@@ -925,14 +935,23 @@ void main_tests(const MangleResult *expecteds, const Target &target) {
 }  // namespace
 
 void cplusplus_mangle_test() {
-    Target targets[]{Target(Target::Linux, Target::X86, 32),
-                     Target(Target::Linux, Target::X86, 64),
-                     Target(Target::OSX, Target::X86, 32),
-                     Target(Target::OSX, Target::X86, 64),
-                     Target(Target::Windows, Target::X86, 32),
-                     Target(Target::Windows, Target::X86, 64)};
-    MangleResult *expecteds[]{ItaniumABIMangling_main, ItaniumABIMangling_main, ItaniumABIMangling_main,
-                              ItaniumABIMangling_main, win32_expecteds, win64_expecteds};
+    Target targets[kTestTargetCount]{
+        Target(Target::Linux, Target::X86, 32),
+        Target(Target::Linux, Target::X86, 64),
+        Target(Target::OSX, Target::X86, 32),
+        Target(Target::OSX, Target::X86, 64),
+        Target(Target::IOS, Target::ARM, 32),
+        Target(Target::IOS, Target::ARM, 64),
+        Target(Target::Windows, Target::X86, 32),
+        Target(Target::Windows, Target::X86, 64)
+    };
+    MangleResult *expecteds[kTestTargetCount]{
+        ItaniumABIMangling_main, ItaniumABIMangling_main,
+        ItaniumABIMangling_main, ItaniumABIMangling_main,
+        ItaniumABIMangling_main, ItaniumABIMangling_main,
+        win32_expecteds, win64_expecteds
+    };
+
     size_t i = 0;
     for (const auto &target : targets) {
         main_tests(expecteds[i++], target);

--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -345,6 +345,7 @@ std::string simple_type_to_mangle_char(const std::string type_name, const Target
         return "j";
     } else if (type_name == "int64_t") {
         if (target.os == Target::OSX ||
+            target.os == Target::IOS ||
             target.bits == 32 ||
             target.has_feature(Target::MinGW)) {
             return "x";
@@ -353,6 +354,7 @@ std::string simple_type_to_mangle_char(const std::string type_name, const Target
         }
     } else if (type_name == "uint64_t") {
         if (target.os == Target::OSX ||
+            target.os == Target::IOS ||
             target.bits == 32 ||
             target.has_feature(Target::MinGW)) {
             return "y";
@@ -534,6 +536,7 @@ std::string mangle_type(const Type &type, const Target &target, PrevPrefixes &pr
             return "i";
         case 64:
             if (target.os == Target::OSX ||
+                target.os == Target::IOS ||
                 target.bits == 32 ||
                 target.has_feature(Target::MinGW)) {
                 return "x";
@@ -555,6 +558,7 @@ std::string mangle_type(const Type &type, const Target &target, PrevPrefixes &pr
             return "j";
         case 64:
             if (target.os == Target::OSX ||
+                target.os == Target::IOS ||
                 target.bits == 32 ||
                 target.has_feature(Target::MinGW)) {
                 return "y";


### PR DESCRIPTION
The iOS SDK defines int64 as `long long` and uint64 as `unsigned long long`, but we are currently mangling them as `long` and `unsigned long`, so we will get linker errors for compiled filters that use one of these types as an input (assuming c_plus_plus_name_mangling is enabled).