### PR TITLE
Fix offload mode autoscheduler results.

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -530,7 +530,8 @@ Module Module::resolve_submodules() const {
         auto buf = copy.compile_to_buffer();
         lowered_module.append(buf);
     }
-
+    // Copy the autoscheduler results back into the lowered module after resolving the submodules.
+    lowered_module.set_auto_scheduler_results(*contents->auto_scheduler_results.get());
     return lowered_module;
 }
 

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -531,7 +531,9 @@ Module Module::resolve_submodules() const {
         lowered_module.append(buf);
     }
     // Copy the autoscheduler results back into the lowered module after resolving the submodules.
-    lowered_module.set_auto_scheduler_results(*contents->auto_scheduler_results.get());
+    if (auto *r = contents->auto_scheduler_results.get()) {
+        lowered_module.set_auto_scheduler_results(*r);
+    }
     return lowered_module;
 }
 


### PR DESCRIPTION
Currently, when autoscheduler is invoked in offload mode, the
the emit options {featurization and schedule} are not working
as expected and bailing out due to auto_scheduler_results not
present in the lowered module, resulting in empty feature and
schedule files produced. This happens because, when offloaded
submodules are recursively resolved, the autoscheduler results
are not copied back into the lowered module. This change fixes
this issue by setting back the auto_scheduler_results in the
ModuleContents of the module that is lowered after resolving
submodules.