### PR TITLE
Fix set_host_alignment() in simd_op_check

### DIFF
--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1,8 +1,6 @@
 #include "Halide.h"
 #include "simd_op_check.h"
 
-#include <fstream>
-#include <future>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -261,9 +261,6 @@ class SimdOpCheckTest {
     virtual void setup_images() {
         for (auto p : image_params) {
             p.reset();
-            constexpr int kHostAlignmentBits = 128;
-            constexpr int kHostAlignmentBytes = kHostAlignmentBits / 8;
-            p.set_host_alignment(kHostAlignmentBytes);
         }
     }
     virtual bool test_all() {

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -261,7 +261,9 @@ class SimdOpCheckTest {
     virtual void setup_images() {
         for (auto p : image_params) {
             p.reset();
-            p.set_host_alignment(128);
+            constexpr int kHostAlignmentBits = 128;
+            constexpr int kHostAlignmentBytes = kHostAlignmentBits / 8;
+            p.set_host_alignment(kHostAlignmentBytes);
         }
     }
     virtual bool test_all() {

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -24,7 +24,9 @@ public:
     void setup_images() override {
         for (auto p : image_params) {
             p.reset();
-            p.set_host_alignment(128);
+            constexpr int kHostAlignmentBits = 128;
+            constexpr int kHostAlignmentBytes = kHostAlignmentBits / 8;
+            p.set_host_alignment(kHostAlignmentBytes);
             Expr min = p.dim(0).min();
             p.dim(0).set_min((min/128) * 128);
         }

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -24,8 +24,8 @@ public:
     void setup_images() override {
         for (auto p : image_params) {
             p.reset();
-            constexpr int kHostAlignmentBits = 128;
-            constexpr int kHostAlignmentBytes = kHostAlignmentBits / 8;
+            // HVX needs 128 byte alignment
+            constexpr int kHostAlignmentBytes = 128;
             p.set_host_alignment(kHostAlignmentBytes);
             Expr min = p.dim(0).min();
             p.dim(0).set_min((min/128) * 128);


### PR DESCRIPTION
We have been calling set_host_alignment(128) on our input params for ~ever, but this has always been wrong; as the argument is in bytes (not bits), and most of our targets provide only a 32-byte guarantee at the memory allocator level (x86 does 64-bytes, see LLVM_Runtime_Linker.cpp)

(Note that I'm not sure if the _hvx variant really should be 128 bytes or not, please review carefully.)