### PR TITLE
Fix gradient autoscheduler's usage of output estimates

### DIFF
--- a/apps/gradient_autoscheduler/GradientAutoscheduler.cpp
+++ b/apps/gradient_autoscheduler/GradientAutoscheduler.cpp
@@ -758,14 +758,13 @@ void generate_schedule(const std::vector<Function> &outputs,
         env.insert(local_env.begin(), local_env.end());
     }
 
-    // Finalize all the LoopLevels.
+    // Finalize all the LoopLevels
     for (auto &iter : env) {
         iter.second.lock_loop_levels();
     }
 
-    // Compute the topological order.
+    // Compute the topological order
     std::vector<std::string> top_order = topological_order(outputs, env);
-
     // Run a pre-pass that inlines all trivial Funcs (i.e. the cost of
     // computing a Func <= calling that Func).
     // TODO: Note that the cost is estimated using heuristics based on CPU statistics

--- a/apps/gradient_autoscheduler/test.cpp
+++ b/apps/gradient_autoscheduler/test.cpp
@@ -136,5 +136,26 @@ int main(int argc, char **argv) {
         std::cout << std::endl;
     }
 
+    { // Test for conjunction use of bound and estimates.
+        Func in("in");
+        in(x, y) = cast<float>(x + y);
+        Func f0("f0");
+        f0(x, y) = 2.f * in(x, y);
+        Func f1("f1");
+        f1(x, y) = sin(f0(x, y));
+        Func f2("f2");
+        f2(x, y) = f1(x, y) * f1(x, y);
+
+        f2.bound(x, 0, 4);
+        // make sure it also works if we reverse the estimate order
+        f2.set_estimate(y, 0, 1024)
+          .set_estimate(x, 0, 4);
+
+        AutoSchedulerResults result =
+            Pipeline(f2).auto_schedule(target, params);
+        std::cout << "Schedule for 2D pointwise operations with small x dimension:" << std::endl;
+        std::cout << result.schedule_source << std::endl;
+        std::cout << std::endl;
+    }
     return 0;
 }


### PR DESCRIPTION
There is a bug in the gradient autoscheduler, that makes it taking the wrong output size estimates since it assumed the estimates have the same order as the output arguments. This PR fixes it.

Not sure how to test this. @steven-johnson any idea?