### PR TITLE
Bugfix: Empty device buffer on corner case

### DIFF
--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -294,6 +294,13 @@ Module lower(const vector<Function> &output_funcs,
         s = select_gpu_api(s, t);
         debug(2) << "Lowering after selecting a GPU API for extern stages:\n"
                  << s << "\n\n";
+    } else {
+        // Always mark buffers host dirty. Buffers will otherwise not be correctly copied for
+        // other pipelines with device feature enabled.
+        debug(1) << "Injecting host <-> dev buffer copies...\n";
+        s = inject_host_dev_buffer_copies(s, t);
+        debug(2) << "Lowering after injecting host <-> dev buffer copies:\n"
+                    << s << "\n\n";
     }
 
     if (t.has_feature(Target::OpenGL)) {


### PR DESCRIPTION
**Scenario**
1. Buffer is created and filled with data.
2. CUDA is **later** added to the JIT target ```set_feature(Halide::Target::CUDA)```
3. Use buffer on the device for computation

**Observation**
Buffer is not copied to Device before use.

**Solution**
Mark buffer as ```set_host_dirty``` when device memory is allocated.

**Discussion**
In the corner case, when a buffer is created and filled on the host before CUDA is added to the JIT target, the buffer is not marked as host_dirty and thus not copied on first use. Our proposed fix is to mark the host as dirty on device memory allocation.  This one-line change fixes the issue for our use cases. Is there additional tests we should do to check is validity?
