### PR TITLE
Add option to create gradient-descent variant of a Generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1571,6 +1571,9 @@ $(FILTERS_DIR)/external_code.halide_generated.cpp: $(BIN_DIR)/external_code.gene
 	@mkdir -p $(@D)
 	$(CURDIR)/$< -g external_code -e c_source -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime external_code_is_bitcode=false
 
+$(FILTERS_DIR)/autograd_grad.a: $(BIN_DIR)/autograd.generator
+	$(CURDIR)/$< -g autograd $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) -f autograd_grad  -d 1 target=$(TARGET)-no_runtime auto_schedule=true
+
 # Usually, it's considered best practice to have one Generator per
 # .cpp file, with the generator-name and filename matching;
 # nested_externs_generators.cpp is a counterexample, and thus requires
@@ -1631,6 +1634,11 @@ $(BIN_DIR)/$(TARGET)/generator_aot_alias: $(ROOT_DIR)/test/generator/alias_aotte
 $(BIN_DIR)/$(TARGET)/generator_aotwasm_alias.js: $(FILTERS_DIR)/alias_with_offset_42.a
 
 $(BIN_DIR)/$(TARGET)/generator_aotcpp_alias: $(ROOT_DIR)/test/generator/alias_aottest.cpp $(FILTERS_DIR)/alias.halide_generated.cpp $(FILTERS_DIR)/alias_with_offset_42.halide_generated.cpp $(RUNTIME_EXPORTED_INCLUDES) $(BIN_DIR)/$(TARGET)/runtime.a
+	@mkdir -p $(@D)
+	$(CXX) $(GEN_AOT_CXX_FLAGS) $(filter %.cpp %.o %.a,$^) $(GEN_AOT_INCLUDES) $(GEN_AOT_LD_FLAGS) -o $@
+
+# autograd has additional deps to link in
+$(BIN_DIR)/$(TARGET)/generator_aot_autograd: $(ROOT_DIR)/test/generator/autograd_aottest.cpp $(FILTERS_DIR)/autograd.a $(FILTERS_DIR)/autograd_grad.a $(RUNTIME_EXPORTED_INCLUDES) $(BIN_DIR)/$(TARGET)/runtime.a
 	@mkdir -p $(@D)
 	$(CXX) $(GEN_AOT_CXX_FLAGS) $(filter %.cpp %.o %.a,$^) $(GEN_AOT_INCLUDES) $(GEN_AOT_LD_FLAGS) -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -1642,6 +1642,10 @@ $(BIN_DIR)/$(TARGET)/generator_aot_autograd: $(ROOT_DIR)/test/generator/autograd
 	@mkdir -p $(@D)
 	$(CXX) $(GEN_AOT_CXX_FLAGS) $(filter %.cpp %.o %.a,$^) $(GEN_AOT_INCLUDES) $(GEN_AOT_LD_FLAGS) -o $@
 
+$(BIN_DIR)/$(TARGET)/generator_aotcpp_autograd: $(ROOT_DIR)/test/generator/autograd_aottest.cpp $(FILTERS_DIR)/autograd.halide_generated.cpp $(FILTERS_DIR)/autograd_grad.halide_generated.cpp $(RUNTIME_EXPORTED_INCLUDES) $(BIN_DIR)/$(TARGET)/runtime.a
+	@mkdir -p $(@D)
+	$(CXX) $(GEN_AOT_CXX_FLAGS) $(filter %.cpp %.o %.a,$^) $(GEN_AOT_INCLUDES) $(GEN_AOT_LD_FLAGS) -o $@
+
 # nested_externs has additional deps to link in
 $(BIN_DIR)/$(TARGET)/generator_aot_nested_externs: $(ROOT_DIR)/test/generator/nested_externs_aottest.cpp $(FILTERS_DIR)/nested_externs_root.a $(FILTERS_DIR)/nested_externs_inner.a $(FILTERS_DIR)/nested_externs_combine.a $(FILTERS_DIR)/nested_externs_leaf.a $(RUNTIME_EXPORTED_INCLUDES) $(BIN_DIR)/$(TARGET)/runtime.a
 	@mkdir -p $(@D)

--- a/apps/HelloPyTorch/Makefile
+++ b/apps/HelloPyTorch/Makefile
@@ -3,7 +3,9 @@ include ../support/Makefile.inc
 OPS = $(BIN)/$(HL_TARGET)/add_float32.a \
       $(BIN)/$(HL_TARGET)/add_float64.a \
       $(BIN)/$(HL_TARGET)/add_grad_float32.a \
-      $(BIN)/$(HL_TARGET)/add_grad_float64.a
+      $(BIN)/$(HL_TARGET)/add_grad_float64.a \
+      $(BIN)/$(HL_TARGET)/add_halidegrad_float32.a \
+      $(BIN)/$(HL_TARGET)/add_halidegrad_float64.a
 
 # Check whether we have cuda installed, if add the CUDA ops as dependencies
 ifeq ($(shell which nvcc),)
@@ -14,7 +16,9 @@ HAS_CUDA = 1
 CUDA_OPS = $(BIN)/$(HL_TARGET)/add_cuda_float32.a \
 	   	   $(BIN)/$(HL_TARGET)/add_cuda_float64.a \
            $(BIN)/$(HL_TARGET)/add_grad_cuda_float32.a \
-	       $(BIN)/$(HL_TARGET)/add_grad_cuda_float64.a
+	       $(BIN)/$(HL_TARGET)/add_grad_cuda_float64.a \
+		   $(BIN)/$(HL_TARGET)/add_halidegrad_cuda_float32.a \
+		   $(BIN)/$(HL_TARGET)/add_halidegrad_cuda_float64.a
 endif
 
 EXT_LIB=$(BIN)/lib
@@ -83,6 +87,18 @@ $(BIN)/%/add_float32.a: $(GENERATOR_BIN)/add.generator
 		target=$* \
 		auto_schedule=false
 
+$(BIN)/%/add_halidegrad_float32.a: $(GENERATOR_BIN)/add.generator
+	@mkdir -p $(@D)
+	@echo Producing CPU halidegrad
+	@$^ -g add \
+		$(ADD_TYPES_F32) \
+		-f add_halidegrad_float32 \
+		-e static_library,c_header,pytorch_wrapper \
+		-o $(@D) \
+		-d 1 \
+		target=$* \
+		auto_schedule=true
+
 $(BIN)/%/add_grad_float32.a: $(GENERATOR_BIN)/add.generator
 	@mkdir -p $(@D)
 	@echo Producing CPU gradient
@@ -104,6 +120,19 @@ $(BIN)/%/add_float64.a: $(GENERATOR_BIN)/add.generator
 		-o $(@D) \
 		target=$* \
 		auto_schedule=false
+
+$(BIN)/%/add_halidegrad_float64.a: $(GENERATOR_BIN)/add.generator
+	@mkdir -p $(@D)
+	@echo "Producing CPU (double) halidegrad"
+	@$^ -g add \
+		$(ADD_TYPES_F64) \
+		-f add_halidegrad_float64 \
+		-e static_library,c_header,pytorch_wrapper \
+		-o $(@D) \
+		target=$* \
+		-d 1 \
+		target=$* \
+		auto_schedule=true
 
 $(BIN)/%/add_grad_float64.a: $(GENERATOR_BIN)/add.generator
 	@mkdir -p $(@D)
@@ -130,6 +159,18 @@ $(BIN)/%/add_cuda_float32.a: $(GENERATOR_BIN)/add.generator
 		target=$(CUDA_TARGET) \
 		auto_schedule=false
 
+$(BIN)/%/add_halidegrad_cuda_float32.a: $(GENERATOR_BIN)/add.generator
+	@mkdir -p $(@D)
+	@echo Producing CUDA halidegrad
+	@$^ -g add \
+		$(ADD_TYPES_F32) \
+		-f add_halidegrad_cuda_float32 \
+		-e static_library,c_header,pytorch_wrapper \
+		-o $(@D) \
+		-d 1 \
+		target=$(CUDA_TARGET) \
+		auto_schedule=true
+
 $(BIN)/%/add_grad_cuda_float32.a: $(GENERATOR_BIN)/add.generator
 	@mkdir -p $(@D)
 	@echo "Producing CUDA (double) gradient"
@@ -151,6 +192,18 @@ $(BIN)/%/add_cuda_float64.a: $(GENERATOR_BIN)/add.generator
 		-o $(@D) \
 		target=$(CUDA_TARGET) \
 		auto_schedule=false
+
+$(BIN)/%/add_halidegrad_cuda_float64.a: $(GENERATOR_BIN)/add.generator
+	@mkdir -p $(@D)
+	@echo "Producing CUDA (double) halidegrad"
+	@$^ -g add \
+		$(ADD_TYPES_F64) \
+		-f add_halidegrad_cuda_float64 \
+		-e static_library,c_header,pytorch_wrapper \
+		-o $(@D) \
+		-d 1 \
+		target=$(CUDA_TARGET) \
+		auto_schedule=true
 
 $(BIN)/%/add_grad_cuda_float64.a: $(GENERATOR_BIN)/add.generator
 	@mkdir -p $(@D)

--- a/apps/HelloPyTorch/modules.py
+++ b/apps/HelloPyTorch/modules.py
@@ -40,58 +40,83 @@ def _dispatch(opname, optype=th.float32, cuda=False):
         raise ValueError("Module has no operator %s" % opname)
     return op
 
+def _forward_common(ctx, input_a, input_b):
+    tp = input_a.dtype
+    cuda = input_a.is_cuda
+    assert tp == input_b.dtype, "inputs should have the same type"
+    assert cuda == input_b.is_cuda, "inputs should be on the same device (cpu/gpu)"
 
-class AddFunction(th.autograd.Function):
-  """Registers our ops with autograd so we can backprop through it"""
+    ctx.save_for_backward(input_a, input_b)
+
+    fn_ = _dispatch("add", optype=tp, cuda=cuda)
+
+    # Create an output tensor with the proper dimensions
+    out = input_a.new()
+    out.resize_(input_a.shape)
+
+    fn_(input_a, input_b, out)
+    return out
+
+def _backward_common(ctx, d_out, backward_op):
+    tp = d_out.dtype
+    cuda = d_out.is_cuda
+
+    input_a = ctx.saved_tensors[0]
+    input_b = ctx.saved_tensors[1]
+
+    # Fetch the correct Halide operator for the type/device used
+    fn_ = _dispatch(backward_op, optype=tp, cuda=cuda)
+
+    d_input_a = d_out.new()
+    d_input_b = d_out.new()
+    d_input_a.resize_(d_out.shape)
+    d_input_b.resize_(d_out.shape)
+
+    fn_(input_a, input_b, d_out.contiguous(), d_input_a, d_input_b)
+    return d_input_a, d_input_b
+
+# TODO(srj): surely there's a better way to do this,
+# but PyTorch seems to make it tricky to pass in
+# extra info to the backward() method.
+class AddFunction_Grad(th.autograd.Function):
+  """Version using the manually-written backprop"""
   def __init__(self):
-      super(AddFunction, self).__init__()
+      super(AddFunction_Grad, self).__init__()
 
   @staticmethod
   def forward(ctx, input_a, input_b):
-      tp = input_a.dtype
-      cuda = input_a.is_cuda
-      assert tp == input_b.dtype, "inputs should have the same type"
-      assert cuda == input_b.is_cuda, "inputs should be on the same device (cpu/gpu)"
-
-      ctx.save_for_backward(input_a, input_b)
-
-      fn_ = _dispatch("add", optype=tp, cuda=cuda)
-
-      # Create an output tensor with the proper dimensions
-      out = input_a.new()
-      out.resize_(input_a.shape)
-
-      fn_(input_a, input_b, out)
-      return out
+      return _forward_common(ctx, input_a, input_b)
 
   @staticmethod
   def backward(ctx, d_out):
-      tp = d_out.dtype
-      cuda = d_out.is_cuda
+      return _backward_common(ctx, d_out, "add_grad")
 
-      input_a = ctx.saved_tensors[0]
-      input_b = ctx.saved_tensors[1]
+class AddFunction_HalideGrad(th.autograd.Function):
+  """Version using the Halide-generated backprop"""
+  def __init__(self):
+      super(AddFunction_HalideGrad, self).__init__()
 
-      # Fetch the correct Halide operator for the type/device used
-      fn_ = _dispatch("add_grad", optype=tp, cuda=cuda)
+  @staticmethod
+  def forward(ctx, input_a, input_b):
+      return _forward_common(ctx, input_a, input_b)
 
-      d_input_a = d_out.new()
-      d_input_b = d_out.new()
-      d_input_a.resize_(d_out.shape)
-      d_input_b.resize_(d_out.shape)
-
-      fn_(input_a, input_b, d_out.contiguous(), d_input_a, d_input_b)
-      return d_input_a, d_input_b
-
+  @staticmethod
+  def backward(ctx, d_out):
+      return _backward_common(ctx, d_out, "add_halidegrad")
 
 class Add(th.nn.Module):
     """Defines a module that uses our autograd function.
 
     This is so we can use it as an operator.
     """
-    def __init__(self):
+    def __init__(self, backward_op):
         super(Add, self).__init__()
-        self._adder = AddFunction()
+        if backward_op == "add_grad":
+          self._adder = AddFunction_Grad()
+        elif backward_op == "add_halidegrad":
+          self._adder = AddFunction_HalideGrad()
+        else:
+          assert False
 
     def forward(self, a, b):
         return self._adder.apply(a, b)

--- a/halide.cmake
+++ b/halide.cmake
@@ -110,7 +110,7 @@ endfunction()
 # Use a Generator target to emit a code library.
 function(halide_library_from_generator BASENAME)
   set(options )
-  set(oneValueArgs FUNCTION_NAME GENERATOR HALIDE_TARGET)
+  set(oneValueArgs FUNCTION_NAME GENERATOR HALIDE_TARGET GRADIENT_DESCENT)
   set(multiValueArgs EXTRA_OUTPUTS FILTER_DEPS GENERATOR_ARGS HALIDE_TARGET_FEATURES INCLUDES)
   cmake_parse_arguments(args "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -122,6 +122,9 @@ function(halide_library_from_generator BASENAME)
   endif()
   if ("${args_HALIDE_TARGET}" STREQUAL "")
     set(args_HALIDE_TARGET "host")
+  endif()
+  if ("${args_GRADIENT_DESCENT}" STREQUAL "")
+    set(args_GRADIENT_DESCENT "0")
   endif()
   # It's fine for EXTRA_OUTPUTS, GENERATOR_ARGS, FILTER_DEPS, HALIDE_TARGET_FEATURES to be empty
 
@@ -195,6 +198,7 @@ function(halide_library_from_generator BASENAME)
   _halide_add_target_features("${TARGET_WITH_FEATURES}" "no_runtime" TARGET_WITH_FEATURES)
 
   set(GENERATOR_EXEC_ARGS "-o" "${GENFILES_DIR}")
+  list(APPEND GENERATOR_EXEC_ARGS "-d" "${args_GRADIENT_DESCENT}")
   list(APPEND GENERATOR_EXEC_ARGS "-g" "${GENERATOR_NAME}")
   list(APPEND GENERATOR_EXEC_ARGS "-f" "${args_FUNCTION_NAME}" )
   list(APPEND GENERATOR_EXEC_ARGS "target=${TARGET_WITH_FEATURES}")

--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -5,6 +5,7 @@
 #include "Associativity.h"
 #include "BoundaryConditions.h"
 #include "CSE.h"
+#include "Debug.h"
 #include "Derivative.h"
 #include "DerivativeUtils.h"
 #include "Error.h"
@@ -1318,7 +1319,7 @@ void ReverseAccumulationVisitor::propagate_halide_function_call(
     // f'(x, y, z) += g'(x, x + 1, z - 1)
     //
     // Note that g' would correctly returns 0 outside g's boundary,
-    // therefore we do not need to impose bounds on g'. 
+    // therefore we do not need to impose bounds on g'.
     // However, consider the case where f'(...) += g'(...) * h(...):
     // we need to clamp h's arguments such that it never goes out of g's domain,
     // otherwise we may get unwanted out-of-bound buffer access.
@@ -1896,19 +1897,28 @@ void ReverseAccumulationVisitor::propagate_halide_function_call(
 
 Func Derivative::operator()(const Func &func, int update_id) const {
     auto it = adjoints.find(FuncKey{func.name(), update_id});
-    internal_assert(it != adjoints.end()) << "Could not find Func " << func.name() << "\n";
+    if (it == adjoints.end()) {
+        Internal::debug(1) << "Could not find Func " << func.name() << "\n";
+        return Func();
+    }
     return it->second;
 }
 
 Func Derivative::operator()(const Buffer<> &buffer) const {
     auto it = adjoints.find(FuncKey{buffer.name(), -1});
-    internal_assert(it != adjoints.end()) << "Could not find Buffer " << buffer.name() << "\n";
+    if (it == adjoints.end()) {
+        Internal::debug(1) << "Could not find Buffer " << buffer.name() << "\n";
+        return Func();
+    }
     return it->second;
 }
 
 Func Derivative::operator()(const Param<> &param) const {
     auto it = adjoints.find(FuncKey{param.name(), -1});
-    internal_assert(it != adjoints.end()) << "Could not find Param " << param.name() << "\n";
+    if (it == adjoints.end()) {
+        Internal::debug(1) << "Could not find Param " << param.name() << "\n";
+        return Func();
+    }
     return it->second;
 }
 

--- a/src/Derivative.h
+++ b/src/Derivative.h
@@ -31,6 +31,8 @@ public:
         : adjoints(std::move(adjoints_in)) {
     }
 
+    // These all return an undefined Func if no derivative is found
+    // (typically, if the input Funcs aren't differentiable)
     Func operator()(const Func &func, int update_id = -1) const;
     Func operator()(const Buffer<> &buffer) const;
     Func operator()(const Param<> &param) const;

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1507,8 +1507,8 @@ Module GeneratorBase::build_gradient_module(const std::string &function_name) {
             // output_name is something like "funcname_i"
             const std::string grad_in_name = replace_all(grad_input_pattern, "$OUT$", output_name);
             // TODO(srj): does it make sense for gradient to be a non-float type?
-            // For now, assume it's always float32 (unless the output was float64).
-            const Type grad_in_type = output->type() == Float(64) ? Float(64) : Float(32);
+            // For now, assume it's always float32 (unless the output is already some float).
+            const Type grad_in_type = output->type().is_float() ? output->type() : Float(32);
             const int grad_in_dimensions = f.dimensions();
             const ArgumentEstimates grad_in_estimates = f.output_buffer().parameter().get_argument_estimates();
             internal_assert((int) grad_in_estimates.buffer_estimates.size() == grad_in_dimensions);

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1534,6 +1534,8 @@ Module GeneratorBase::build_gradient_module(const std::string &function_name) {
         const ImageParam &d_output = d_output_imageparams.at(i);
         std::vector<std::pair<Expr, Expr>> bounds;
         for (const auto &e : d_output.parameter().get_argument_estimates().buffer_estimates) {
+            user_assert(e.min.defined() && e.extent.defined())
+                << "build_gradient_module: you must provide complete estimates for all inputs and outputs";
             bounds.emplace_back(e.min, e.min + e.extent - 1);
         }
         Func adjoint_func = BoundaryConditions::constant_exterior(d_output, make_zero(d_output.type()));
@@ -1558,7 +1560,7 @@ Module GeneratorBase::build_gradient_module(const std::string &function_name) {
                 d_out_wrt_in.set_estimates(est_pairs);
 
                 // Useful for debugging; ordinarily better to leave out
-                // debug(2) << "\n\n"
+                // debug(0) << "\n\n"
                 //          << "output:\n" << FuncWithDependencies(original_output) << "\n"
                 //          << "d_output:\n" << FuncWithDependencies(adjoint_func) << "\n"
                 //          << "input:\n" << FuncWithDependencies(f) << "\n"

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1533,10 +1533,8 @@ Module GeneratorBase::build_gradient_module(const std::string &function_name) {
         const Func &original_output = original_outputs.at(i);
         const ImageParam &d_output = d_output_imageparams.at(i);
         std::vector<std::pair<Expr, Expr>> bounds;
-        for (const auto &e : d_output.parameter().get_argument_estimates().buffer_estimates) {
-            user_assert(e.min.defined() && e.extent.defined())
-                << "build_gradient_module: you must provide complete estimates for all inputs and outputs";
-            bounds.emplace_back(e.min, e.min + e.extent - 1);
+        for (int i = 0; i < d_output.dimensions(); i++) {
+            bounds.emplace_back(d_output.dim(i).min(), d_output.dim(i).max());
         }
         Func adjoint_func = BoundaryConditions::constant_exterior(d_output, make_zero(d_output.type()));
         Derivative d = propagate_adjoints(original_output, adjoint_func, bounds);

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -2,6 +2,8 @@
 #include <fstream>
 #include <unordered_map>
 
+#include "BoundaryConditions.h"
+#include "Derivative.h"
 #include "Generator.h"
 #include "IRPrinter.h"
 #include "Module.h"
@@ -742,9 +744,12 @@ std::string halide_type_to_c_type(const Type &t) {
 int generate_filter_main_inner(int argc, char **argv, std::ostream &cerr) {
     const char kUsage[] =
         "gengen \n"
-        "  [-g GENERATOR_NAME] [-f FUNCTION_NAME] [-o OUTPUT_DIR] [-r RUNTIME_NAME]\n"
+        "  [-g GENERATOR_NAME] [-f FUNCTION_NAME] [-o OUTPUT_DIR] [-r RUNTIME_NAME] [-d 1|0]\n"
         "  [-e EMIT_OPTIONS] [-n FILE_BASE_NAME] [-p PLUGIN_NAME] [-s AUTOSCHEDULER_NAME]\n"
         "       target=target-string[,target-string...] [generator_arg=value [...]]\n"
+        "\n"
+        " -d  Build a module that is suitable for using for gradient descent calculationn\n"
+        "     in TensorFlow or PyTorch. See Generator::build_gradient_module() documentation.\n"
         "\n"
         " -e  A comma separated list of files to emit. Accepted values are:\n"
         "     [assembly, bitcode, cpp, h, html, o, static_library,\n"
@@ -758,15 +763,16 @@ int generate_filter_main_inner(int argc, char **argv, std::ostream &cerr) {
         "     (Note that this does not change the default autoscheduler; use the -s flag\n"
         "     to set that value.)"
         "\n"
-        " -s  The name of an autoscheduler to set as the default.\n"
-        "\n"
-        "-r   The name of a standalone runtime to generate. Only honors EMIT_OPTIONS 'o'\n"
+        " -r   The name of a standalone runtime to generate. Only honors EMIT_OPTIONS 'o'\n"
         "     and 'static_library'. When multiple targets are specified, it picks a\n"
         "     runtime that is compatible with all of the targets, or fails if it cannot\n"
         "     find one. Flags across all of the targets that do not affect runtime code\n"
-        "     generation, such as `no_asserts` and `no_runtime`, are ignored.\n";
+        "     generation, such as `no_asserts` and `no_runtime`, are ignored.\n"
+        "\n"
+        " -s  The name of an autoscheduler to set as the default.\n";
 
     std::map<std::string, std::string> flags_info = {
+        {"-d", "0"},
         {"-e", ""},
         {"-f", ""},
         {"-g", ""},
@@ -810,6 +816,13 @@ int generate_filter_main_inner(int argc, char **argv, std::ostream &cerr) {
             load_plugin(lib);
         }
     }
+
+    if (flags_info["-d"] != "1" && flags_info["-d"] != "0") {
+        cerr << "-d must be 0 or 1\n";
+        cerr << kUsage;
+        return 1;
+    }
+    const int build_gradient_module = flags_info["-d"] == "1";
 
     std::string autoscheduler_name = flags_info["-s"];
     if (!autoscheduler_name.empty()) {
@@ -948,13 +961,13 @@ int generate_filter_main_inner(int argc, char **argv, std::ostream &cerr) {
         // Don't bother with this if we're just emitting a cpp_stub.
         if (!stub_only) {
             auto output_files = compute_output_files(targets[0], base_path, outputs);
-            auto module_producer = [&generator_name, &generator_args](const std::string &name, const Target &target) -> Module {
+            auto module_producer = [&generator_name, &generator_args, build_gradient_module](const std::string &name, const Target &target) -> Module {
                 auto sub_generator_args = generator_args;
                 sub_generator_args.erase("target");
                 // Must re-create each time since each instance will have a different Target.
                 auto gen = GeneratorRegistry::create(generator_name, GeneratorContext(target));
                 gen->set_generator_param_values(sub_generator_args);
-                return gen->build_module(name);
+                return build_gradient_module ? gen->build_gradient_module(name) : gen->build_module(name);
             };
             if (targets.size() > 1) {
                 compile_multitarget(function_name, output_files, targets, module_producer);
@@ -1397,22 +1410,21 @@ Module GeneratorBase::build_module(const std::string &function_name,
         auto_schedule_results = pipeline.auto_schedule(get_target(), get_machine_params());
     }
 
-    GeneratorParamInfo &pi = param_info();
+    const GeneratorParamInfo &pi = param_info();
     std::vector<Argument> filter_arguments;
-    for (auto *input : pi.inputs()) {
+    for (const auto *input : pi.inputs()) {
         for (const auto &p : input->parameters_) {
             filter_arguments.push_back(to_argument(p, p.is_buffer() ? Expr() : input->get_def_expr()));
         }
     }
 
-    Module result = pipeline.compile_to_module(filter_arguments, function_name, target, linkage_type);
+    Module result = pipeline.compile_to_module(filter_arguments, function_name, get_target(), linkage_type);
     std::shared_ptr<ExternsMap> externs_map = get_externs_map();
     for (const auto &map_entry : *externs_map) {
         result.append(map_entry.second);
     }
 
-    auto outputs = pipeline.outputs();
-    for (auto *output : pi.outputs()) {
+    for (const auto *output : pi.outputs()) {
         for (size_t i = 0; i < output->funcs().size(); ++i) {
             auto from = output->funcs()[i].name();
             auto to = output->array_name(i);
@@ -1423,6 +1435,154 @@ Module GeneratorBase::build_module(const std::string &function_name,
             }
         }
     }
+
+    result.set_auto_scheduler_results(auto_schedule_results);
+
+    return result;
+}
+
+Module GeneratorBase::build_gradient_module(const std::string &function_name) {
+    constexpr int DBG = 1;
+
+    // I doubt these ever need customizing; if they do, we can make them arguments to this function.
+    const std::string grad_input_pattern = "_grad_loss_for_$OUT$";
+    const std::string grad_output_pattern = "_grad_loss_$OUT$_wrt_$IN$";
+    const LinkageType linkage_type = LinkageType::ExternalPlusMetadata;
+
+    user_assert(!function_name.empty()) << "build_gradient_module(): function_name cannot be empty\n";
+
+    call_configure();
+    Pipeline original_pipeline = build_pipeline();
+    std::vector<Func> original_outputs = original_pipeline.outputs();
+
+    // Construct the adjoint pipeline, which has:
+    // - All the same inputs as the original, in the same order
+    // - Followed by one grad-input for each original output
+    // - Followed by one output for each unique pairing of original-output + original-input.
+
+    const GeneratorParamInfo &pi = param_info();
+
+    // Even though propagate_adjoints() supports Funcs-of-Tuples just fine,
+    // we aren't going to support them here (yet); AFAICT, neither PyTorch nor
+    // TF support Tensors with Tuples-as-values, so we'd have to split the
+    // tuples up into separate Halide inputs and outputs anyway; since Generator
+    // doesn't support Tuple-valued Inputs at all, and Tuple-valued Outputs
+    // are quite rare, we're going to just fail up front, with the assumption
+    // that the coder will explicitly adapt their code as needed. (Note that
+    // support for Tupled outputs could be added with some effort, so if this
+    // is somehow deemed critical, go for it)
+    for (const auto *input : pi.inputs()) {
+        const size_t tuple_size = input->types_defined() ? input->types().size() : 1;
+        // Note: this should never happen
+        internal_assert(tuple_size == 1) << "Tuple Inputs are not yet supported by build_gradient_module()";
+    }
+    for (const auto *output : pi.outputs()) {
+        const size_t tuple_size = output->types_defined() ? output->types().size() : 1;
+        internal_assert(tuple_size == 1) << "Tuple Outputs are not yet supported by build_gradient_module";
+    }
+
+    std::vector<Argument> gradient_inputs;
+
+    // First: the original inputs. Note that scalar inputs remain scalar,
+    // rather being promoted into zero-dimensional buffers.
+    for (const auto *input : pi.inputs()) {
+        // There can be multiple Funcs/Parameters per input if the input is an Array
+        internal_assert(input->parameters_.size() == input->funcs_.size());
+        for (const auto &p : input->parameters_) {
+            gradient_inputs.push_back(to_argument(p, p.is_buffer() ? Expr() : input->get_def_expr()));
+            debug(DBG) << "    gradient copied input is: " << gradient_inputs.back().name << "\n";
+        }
+    }
+
+    // Next: add a grad-input for each *original* output; these will
+    // be the same shape as the output (so we should copy estimates from
+    // those outputs onto these estimates).
+    // - If an output is an Array, we'll have a separate input for each array element.
+
+    std::vector<ImageParam> d_output_imageparams;
+    for (const auto *output : pi.outputs()) {
+        for (size_t i = 0; i < output->funcs().size(); ++i) {
+            const Func &f = output->funcs()[i];
+            const std::string output_name = output->array_name(i);
+            // output_name is something like "funcname_i"
+            const std::string grad_in_name = replace_all(grad_input_pattern, "$OUT$", output_name);
+            // TODO(srj): does it make sense for gradient to be a non-float type?
+            // For now, assume it's always float32 (unless the output was float64).
+            const Type grad_in_type = output->type() == Float(64) ? Float(64) : Float(32);
+            const int grad_in_dimensions = f.dimensions();
+            const ArgumentEstimates grad_in_estimates = f.output_buffer().parameter().get_argument_estimates();
+            internal_assert((int) grad_in_estimates.buffer_estimates.size() == grad_in_dimensions);
+
+            ImageParam d_im(grad_in_type, grad_in_dimensions, grad_in_name);
+            for (int d = 0; d < grad_in_dimensions; d++) {
+                d_im.parameter().set_min_constraint_estimate(d, grad_in_estimates.buffer_estimates[i].min);
+                d_im.parameter().set_extent_constraint_estimate(d, grad_in_estimates.buffer_estimates[i].extent);
+            }
+            d_output_imageparams.push_back(d_im);
+            gradient_inputs.push_back(to_argument(d_im.parameter(), Expr()));
+
+            debug(DBG) << "    gradient synthesized input is: " << gradient_inputs.back().name << "\n";
+        }
+    }
+
+    // Finally: define the output Func(s), one for each unique output/input pair.
+    // Note that original_outputs.size() != pi.outputs().size() if any outputs are arrays.
+    internal_assert(original_outputs.size() == d_output_imageparams.size());
+    std::vector<Func> gradient_outputs;
+    for (size_t i = 0; i < original_outputs.size(); ++i) {
+        const Func &original_output = original_outputs.at(i);
+        const ImageParam &d_output = d_output_imageparams.at(i);
+        std::vector<std::pair<Expr, Expr>> bounds;
+        for (const auto &e : d_output.parameter().get_argument_estimates().buffer_estimates) {
+            bounds.emplace_back(e.min, e.min + e.extent - 1);
+        }
+        Func adjoint_func = BoundaryConditions::constant_exterior(d_output, make_zero(d_output.type()));
+        Derivative d = propagate_adjoints(original_output, adjoint_func, bounds);
+
+        const std::string output_name = original_output.name();
+        for (const auto *input : pi.inputs()) {
+            for (size_t i = 0; i < input->funcs_.size(); ++i) {
+                const std::string input_name = input->array_name(i);
+                const auto &f = input->funcs_[i];
+                const auto &p = input->parameters_[i];
+
+                const std::string grad_out_name = replace_all(replace_all(grad_output_pattern, "$OUT$", output_name), "$IN$", input_name);
+
+                Func d_out_wrt_in(grad_out_name);
+                d_out_wrt_in(Halide::_) = d(f)(Halide::_);
+
+                std::vector<std::pair<Expr, Expr>> est_pairs;
+                for (const auto e : p.get_argument_estimates().buffer_estimates) {
+                    est_pairs.emplace_back(e.min, e.extent);
+                }
+                d_out_wrt_in.set_estimates(est_pairs);
+
+                // Useful for debugging; ordinarily better to leave out
+                // debug(2) << "\n\n"
+                //          << "output:\n" << FuncWithDependencies(original_output) << "\n"
+                //          << "d_output:\n" << FuncWithDependencies(adjoint_func) << "\n"
+                //          << "input:\n" << FuncWithDependencies(f) << "\n"
+                //          << "d_out_wrt_in:\n" << FuncWithDependencies(d_out_wrt_in) << "\n";
+
+                gradient_outputs.push_back(d_out_wrt_in);
+                debug(DBG) << "    gradient output is: " << d_out_wrt_in.name() << "\n";
+            }
+        }
+    }
+
+    Pipeline grad_pipeline = Pipeline(gradient_outputs);
+
+    AutoSchedulerResults auto_schedule_results;
+    if (get_auto_schedule()) {
+        auto_schedule_results = grad_pipeline.auto_schedule(get_target(), get_machine_params());
+    } else {
+        user_warning << "Autoscheduling is not enabled in build_gradient_module(), so the resulting "
+                        "gradient module will be unscheduled; this is very unlikely to be what you want.\n";
+    }
+
+    Module result = grad_pipeline.compile_to_module(gradient_inputs, function_name, get_target(), linkage_type);
+    user_assert(get_externs_map()->empty())
+        << "Building a gradient-descent module for a Generator with ExternalCode is not supported.\n";
 
     result.set_auto_scheduler_results(auto_schedule_results);
 

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -3066,6 +3066,22 @@ public:
                         const LinkageType linkage_type = LinkageType::ExternalPlusMetadata);
 
     /**
+     * Build a module that is suitable for using for gradient descent calculation in TensorFlow or PyTorch.
+     *
+     * Essentially:
+     *   - A new Pipeline is synthesized from the current Generator (according to the rules below)
+     *   - The new Pipeline is autoscheduled (if autoscheduling is requested, but it would be odd not to do so)
+     *   - The Pipeline is compiled to a Module and returned
+     *
+     * The new Pipeline is adjoint to the original; it has:
+     *   - All the same inputs as the original, in the same order
+     *   - Followed by one grad-input for each original output
+     *   - Followed by one output for each unique pairing of original-output + original-input.
+     *     (For the common case of just one original-output, this amounts to being one output for each original-input.)
+     */
+    Module build_gradient_module(const std::string &function_name);
+
+    /**
      * set_inputs is a variadic wrapper around set_inputs_vector, which makes usage much simpler
      * in many cases, as it constructs the relevant entries for the vector for you, which
      * is often a bit unintuitive at present. The arguments are passed in Input<>-declaration-order,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -370,6 +370,15 @@ if (WITH_TEST_GENERATOR)
                                 EXTRA_OUTPUTS stmt assembly)
   target_link_libraries(generator_aot_metadata_tester PUBLIC metadata_tester_ucon)
 
+  # needs gradient-descent variant as well
+  halide_define_aot_test(autograd)
+  halide_library_from_generator(autograd_grad
+                                GENERATOR autograd.generator
+                                FUNCTION_NAME autograd_grad
+                                GRADIENT_DESCENT 1
+                                GENERATOR_ARGS "auto_schedule=true")
+  target_link_libraries(generator_aot_autograd PUBLIC autograd_grad)
+
   # Needs an extra library from this Generator
   halide_define_aot_test(alias)
   halide_library(alias_with_offset_42

--- a/test/generator/autograd_aottest.cpp
+++ b/test/generator/autograd_aottest.cpp
@@ -1,0 +1,82 @@
+#include "HalideBuffer.h"
+#include "HalideRuntime.h"
+
+#include <cmath>
+#include <cstdio>
+
+#include "autograd.h"
+#include "autograd_grad.h"
+
+using namespace Halide::Runtime;
+
+const int kSize = 32;
+
+int main(int argc, char **argv) {
+    int result;
+
+    auto f = [](float a, float b, float c) -> float {
+        return 33.f * std::pow(a, 3) +
+               22.f * std::pow(b, 2) +
+               11.f * c +
+               1.f;
+    };
+
+    Buffer<float> a(kSize);
+    Buffer<float> b(kSize);
+    Buffer<float> c(kSize);
+    Buffer<float> out(kSize);
+
+    a.for_each_element([&](int x) { a(x) = x; });
+    b.for_each_element([&](int x) { b(x) = x; });
+    c.for_each_element([&](int x) { c(x) = x; });
+
+    result = autograd(a, b, c, out);
+    if (result != 0) {
+        exit(-1);
+    }
+    out.for_each_element([&](int x) {
+        float expected = f(a(x), b(x), c(x));
+        float actual = out(x);
+        assert(expected == actual);
+    });
+
+    Buffer<float> L(kSize);
+    L.for_each_element([&](int x) { L(x) = x - kSize / 2; });
+
+    Buffer<float> grad_loss_out_wrt_a(kSize);
+    Buffer<float> grad_loss_out_wrt_b(kSize);
+    Buffer<float> grad_loss_out_wrt_c(kSize);
+    grad_loss_out_wrt_c.fill(12345);
+
+    result = autograd_grad(/*inputs*/ a, b, c, L,
+                           /*outputs*/ grad_loss_out_wrt_a,
+                           grad_loss_out_wrt_b,
+                           grad_loss_out_wrt_c);
+    if (result != 0) {
+        exit(-1);
+    }
+
+    // Although the values are float, all should be exact results,
+    // so we don't need to worry about comparing vs. an epsilon
+    grad_loss_out_wrt_a.for_each_element([&](int x) {
+        // ∂𝐿/∂a = 3a^2 * 33 * L
+        float expected = L(x) * std::pow(a(x), 2) * 3.f * 33.f;
+        float actual = grad_loss_out_wrt_a(x);
+        assert(expected == actual);
+    });
+    grad_loss_out_wrt_b.for_each_element([&](int x) {
+        // ∂𝐿/∂b = b * 44 * L
+        float expected = L(x) * b(x) * 44.f;
+        float actual = grad_loss_out_wrt_b(x);
+        assert(expected == actual);
+    });
+    grad_loss_out_wrt_c.for_each_element([&](int x) {
+        // ∂𝐿/∂c = 11 * L
+        float expected = L(x) * 11.f;
+        float actual = grad_loss_out_wrt_c(x);
+        assert(expected == actual);
+    });
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/generator/autograd_aottest.cpp
+++ b/test/generator/autograd_aottest.cpp
@@ -46,7 +46,6 @@ int main(int argc, char **argv) {
     Buffer<float> grad_loss_out_wrt_a(kSize);
     Buffer<float> grad_loss_out_wrt_b(kSize);
     Buffer<float> grad_loss_out_wrt_c(kSize);
-    grad_loss_out_wrt_c.fill(12345);
 
     result = autograd_grad(/*inputs*/ a, b, c, L,
                            /*outputs*/ grad_loss_out_wrt_a,

--- a/test/generator/autograd_aottest.cpp
+++ b/test/generator/autograd_aottest.cpp
@@ -26,9 +26,9 @@ int main(int argc, char **argv) {
     Buffer<float> c(kSize);
     Buffer<float> out(kSize);
 
-    a.for_each_element([&](int x) { a(x) = x; });
-    b.for_each_element([&](int x) { b(x) = x; });
-    c.for_each_element([&](int x) { c(x) = x; });
+    a.for_each_element([&](int x) { a(x) = (float) x; });
+    b.for_each_element([&](int x) { b(x) = (float) x; });
+    c.for_each_element([&](int x) { c(x) = (float) x; });
 
     result = autograd(a, b, c, out);
     if (result != 0) {
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
     });
 
     Buffer<float> L(kSize);
-    L.for_each_element([&](int x) { L(x) = x - kSize / 2; });
+    L.for_each_element([&](int x) { L(x) = (float) (x - kSize / 2); });
 
     Buffer<float> grad_loss_out_wrt_a(kSize);
     Buffer<float> grad_loss_out_wrt_b(kSize);

--- a/test/generator/autograd_generator.cpp
+++ b/test/generator/autograd_generator.cpp
@@ -8,19 +8,32 @@ public:
     Input<Buffer<float>> input_b{ "input_b", 1 };
     Input<Buffer<float>> input_c{ "input_c", 1 };
 
+    // Test a case for which won't be able to find a derivative
+    Input<Buffer<uint8_t>> lut{"lut", 1};
+    Input<Buffer<uint8_t>> lut_indices{"lut_indices", 1};
+
     Output<Buffer<float>> output{ "output", 1 };
+    Output<Buffer<uint8_t>> output_lut{ "output_lut", 1 };
 
     void generate() {
+        lut.dim(0).set_bounds(0, 256);
+
         Var x;
         output(x) = 33 * pow(input_a(x), 3) +
                     22 * pow(input_b(x), 2) +
                     11 * input_c(x) +
                     1;
 
+        output_lut(x) = lut(lut_indices(x));
+
         input_a.set_estimates({{0, 32}});
         input_b.set_estimates({{0, 32}});
         input_c.set_estimates({{0, 32}});
         output.set_estimates({{0, 32}});
+
+        lut.set_estimates({{0, 256}});
+        lut_indices.set_estimates({{0, 32}});
+        output_lut.set_estimates({{0, 32}});
 
         output.vectorize(x, natural_vector_size<float>());
     }

--- a/test/generator/autograd_generator.cpp
+++ b/test/generator/autograd_generator.cpp
@@ -1,0 +1,31 @@
+#include "Halide.h"
+
+namespace {
+
+class Autograd : public Halide::Generator<Autograd> {
+public:
+    Input<Buffer<float>> input_a{ "input_a", 1 };
+    Input<Buffer<float>> input_b{ "input_b", 1 };
+    Input<Buffer<float>> input_c{ "input_c", 1 };
+
+    Output<Buffer<float>> output{ "output", 1 };
+
+    void generate() {
+        Var x;
+        output(x) = 33 * pow(input_a(x), 3) +
+                    22 * pow(input_b(x), 2) +
+                    11 * input_c(x) +
+                    1;
+
+        input_a.set_estimates({{0, 32}});
+        input_b.set_estimates({{0, 32}});
+        input_c.set_estimates({{0, 32}});
+        output.set_estimates({{0, 32}});
+
+        output.vectorize(x, natural_vector_size<float>());
+    }
+};
+
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(Autograd, autograd)


### PR DESCRIPTION
This adds a new flag to Generator main (-d) that will look at the inputs and outputs of the Generator and produce a new pipeline (via propagate_adjoint) that is suitable for using as the gradient-descent stage for PyTorch, TensorFlow, etc.

A few notes:
- obviously this is lightly tested, but the heavy lifting is done by Derivative, which is in pretty good shape.
- doesn't support inputs or outputs with Tuple values; we probably could make this work with more effort, but since (AFAICT) neither PT nor TF allow tuple-valued Tensors, it's of dubious value to support
- In general the nomenclature here is dubious and may need rethinking
- Updated apps/HelloPyTorch to use this (in conjunction with the manually-written variant). Note to reviewers, there's some horrible code in the PyTorch support that needs to be improved, but it's not clear to me how to do so within the confines of PyTorch limitations; I've reached out to @mgharbi for suggestions.
- Note that the synthesized gradient-descent pipeline requests autoscheduling, but be aware that this is defaulting to the **classic** autoscheduler; what we really want is the gradient autoscheduler, but that currently isn't packaged in a way to make it easy to use outside of apps/gradient_autoscheduler. (My intent is to rectify that once the long-awaited autoscheduler refactoring is done.)

attn @mgharbi 