### PR TITLE
Small code simplifications at the beginning of the FunctionDAG constructor

### DIFF
--- a/apps/autoscheduler/FunctionDAG.cpp
+++ b/apps/autoscheduler/FunctionDAG.cpp
@@ -6,7 +6,9 @@ namespace Halide {
 namespace Internal {
 
 template<>
-RefCount &ref_count<Autoscheduler::BoundContents>(const Autoscheduler::BoundContents *t) noexcept {return t->ref_count;}
+RefCount &ref_count<Autoscheduler::BoundContents>(const Autoscheduler::BoundContents *t) noexcept {
+    return t->ref_count;
+}
 
 template<>
 void destroy<Autoscheduler::BoundContents>(const Autoscheduler::BoundContents *t) {
@@ -155,7 +157,7 @@ class Featurizer : public IRVisitor {
         } else if (op->call_type == Call::Image) {
             visit_memory_access(op->name, op->type, op->args, PipelineFeatures::AccessType::LoadImage);
             op_bucket(PipelineFeatures::OpType::ImageCall, op->type)++;
-        } // TODO: separate out different math calls a little better (sqrt vs sin vs lerp)
+        }  // TODO: separate out different math calls a little better (sqrt vs sin vs lerp)
     }
 
     // Take the derivative of an integer index expression. If it's
@@ -289,12 +291,13 @@ class Featurizer : public IRVisitor {
     }
 
 public:
-    Featurizer(Function &func, FunctionDAG::Node::Stage &stage) :
-        func(func), stage(stage) {}
+    Featurizer(Function &func, FunctionDAG::Node::Stage &stage)
+        : func(func), stage(stage) {
+    }
 
     void visit_store_args(const std::string &name, Type t, vector<Expr> args) {
         for (auto &e : args) {
-            e = common_subexpression_elimination(simplify(e)); // Get things into canonical form
+            e = common_subexpression_elimination(simplify(e));  // Get things into canonical form
         }
         visit_memory_access(name, t, args, PipelineFeatures::AccessType::Store);
     }
@@ -330,8 +333,10 @@ void BoundContents::validate() const {
         if (p.max() < p.min()) {
             aslog(0) << "Bad bounds object:\n";
             for (int j = 0; j < layout->total_size; j++) {
-                if (i == j) aslog(0) << "=> ";
-                else aslog(0) << "   ";
+                if (i == j)
+                    aslog(0) << "=> ";
+                else
+                    aslog(0) << "   ";
                 aslog(0) << j << ": " << data()[j].min() << ", " << data()[j].max() << "\n";
             }
             internal_error << "Aborting";
@@ -353,7 +358,7 @@ BoundContents::Layout::~Layout() {
 
 void BoundContents::Layout::allocate_some_more() const {
     size_t size_of_one = sizeof(BoundContents) + total_size * sizeof(Span);
-    const size_t number_per_block = std::max((size_t)8, 4096 / size_of_one); // Make a page of them, or 8, whichever is larger.
+    const size_t number_per_block = std::max((size_t)8, 4096 / size_of_one);  // Make a page of them, or 8, whichever is larger.
     const size_t bytes_to_allocate = std::max(size_of_one * number_per_block, (size_t)4096);
     unsigned char *mem = (unsigned char *)malloc(bytes_to_allocate);
 
@@ -440,7 +445,8 @@ void FunctionDAG::Node::required_to_computed(const Span *required, Span *compute
     }
 }
 
-FunctionDAG::Edge::BoundInfo::BoundInfo(const Expr &e, const Node::Stage &consumer) : expr(e) {
+FunctionDAG::Edge::BoundInfo::BoundInfo(const Expr &e, const Node::Stage &consumer)
+    : expr(e) {
     // Do the analysis to detect if this is a simple case
     // that can be evaluated more cheaply. Currently this
     // acceleration recognises affine expressions. In the
@@ -452,8 +458,8 @@ FunctionDAG::Edge::BoundInfo::BoundInfo(const Expr &e, const Node::Stage &consum
     const IntImm *coeff_imm = mul ? mul->b.as<IntImm>() : nullptr;
     const IntImm *constant_imm = add ? add->b.as<IntImm>() : nullptr;
     Expr v = (mul ? mul->a :
-              add ? add->a :
-              expr);
+                    add ? add->a :
+                          expr);
     const Variable *var = v.as<Variable>();
 
     if (const IntImm *c = e.as<IntImm>()) {
@@ -588,11 +594,9 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
     int stage_count = 0;
 
     for (size_t i = order.size(); i > 0; i--) {
-        Function consumer = env[order[i-1]];
-
         Node &node = nodes[order.size() - i];
+        Function consumer = node.func;
         Scope<Interval> scope;
-        node.func = consumer;
 
         // Create a symbolic region for this Func.
         for (int j = 0; j < consumer.dimensions(); j++) {
@@ -608,12 +612,11 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
 
         for (int s = 0; s <= (int)consumer.updates().size(); s++) {
             stage_count++;
-            Halide::Stage halide_stage = Func(consumer);
-            if (s > 0) {
-                halide_stage = Func(consumer).update(s-1);
+            if (s == 0) {
+                node.stages.emplace_back(Stage(consumer, consumer.definition(), 0));
+            } else {
+                node.stages.emplace_back(Stage(consumer, consumer.update(s - 1), s));
             }
-            Node::Stage stage(halide_stage);
-            node.stages.emplace_back(std::move(stage));
         }
 
         for (int s = 0; s <= (int)consumer.updates().size(); s++) {
@@ -793,12 +796,15 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
                     }
                 }
                 Function func;
+
             public:
                 bool is_pointwise = true;
                 int leaves = 0;
                 Type narrowest_type;
                 map<string, int> calls;
-                CheckTypes(Function f) : func(f) {}
+                CheckTypes(Function f)
+                    : func(f) {
+                }
             };
             CheckTypes checker(consumer);
             exprs.accept(&checker);
@@ -837,7 +843,7 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
                     int64_t i_min = *as_const_int(b.min);
                     int64_t i_extent = *as_const_int(b.extent);
 
-                    if ((false)) { // Intentional dead code. Extra parens to pacify clang-tidy.
+                    if ((false)) {  // Intentional dead code. Extra parens to pacify clang-tidy.
                         // Some methods we compare to compile for
                         // statically known input/output sizes. We
                         // don't need to - we take estimates but
@@ -852,8 +858,7 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
                         // it affects the scheduling space.
                         Func(node.func).bound(b.var, b.min, b.extent);
                         estimates[b.var] = Span(i_min, i_min + i_extent - 1, true);
-                    } else
-                    {
+                    } else {
                         estimates[b.var] = Span(i_min, i_min + i_extent - 1, false);
                     }
                 }
@@ -958,7 +963,7 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
 
     // Compute transitive dependencies
     for (size_t i = nodes.size(); i > 0; i--) {
-        auto &n = nodes[i-1];
+        auto &n = nodes[i - 1];
         for (auto &s : n.stages) {
             s.dependencies.resize(nodes.size(), false);
             for (auto *e : s.incoming_edges) {
@@ -983,7 +988,8 @@ void FunctionDAG::featurize() {
 
             // Pick a dimension to vectorize over - the innermost pure loop
             size_t vector_dim = 0;
-            while (vector_dim < stage.loop.size() && !stage.loop[vector_dim].pure) vector_dim++;
+            while (vector_dim < stage.loop.size() && !stage.loop[vector_dim].pure)
+                vector_dim++;
             // bool vectorized = vector_dim < stage.loop.size();
 
             Featurizer featurizer(node.func, stage);
@@ -995,11 +1001,11 @@ void FunctionDAG::featurize() {
 
             for (auto v : def.values()) {
                 featurizer.visit_store_args(node.func.name(), v.type(), def.args());
-                v = common_subexpression_elimination(simplify(v)); // Get things into canonical form
+                v = common_subexpression_elimination(simplify(v));  // Get things into canonical form
                 v.accept(&featurizer);
             }
             for (auto v : def.args()) {
-                v = common_subexpression_elimination(simplify(v)); // Get things into canonical form
+                v = common_subexpression_elimination(simplify(v));  // Get things into canonical form
                 v.accept(&featurizer);
             }
         }

--- a/apps/autoscheduler/FunctionDAG.cpp
+++ b/apps/autoscheduler/FunctionDAG.cpp
@@ -333,10 +333,11 @@ void BoundContents::validate() const {
         if (p.max() < p.min()) {
             aslog(0) << "Bad bounds object:\n";
             for (int j = 0; j < layout->total_size; j++) {
-                if (i == j)
+                if (i == j) {
                     aslog(0) << "=> ";
-                else
+                } else {
                     aslog(0) << "   ";
+                }
                 aslog(0) << j << ": " << data()[j].min() << ", " << data()[j].max() << "\n";
             }
             internal_error << "Aborting";
@@ -988,15 +989,17 @@ void FunctionDAG::featurize() {
 
             // Pick a dimension to vectorize over - the innermost pure loop
             size_t vector_dim = 0;
-            while (vector_dim < stage.loop.size() && !stage.loop[vector_dim].pure)
+            while (vector_dim < stage.loop.size() && !stage.loop[vector_dim].pure) {
                 vector_dim++;
+            }
             // bool vectorized = vector_dim < stage.loop.size();
 
             Featurizer featurizer(node.func, stage);
 
             Definition def = node.func.definition();
-            if (stage_idx > 0) def = node.func.updates()[stage_idx - 1];
-
+            if (stage_idx > 0) {
+                def = node.func.updates()[stage_idx - 1];
+            }
             stage.features = PipelineFeatures();
 
             for (auto v : def.values()) {


### PR DESCRIPTION

 Avoid setting node.func in two separate locations. The second initialization is redundant and confusing
 Streamlined the initialization of node.stages by avoiding extra stage creation and movements.

Also applied clang-format, which accounts for all the other code changes