### PR TITLE
Revert "Bugfix: Empty device buffer on corner case"

### DIFF
--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -294,13 +294,6 @@ Module lower(const vector<Function> &output_funcs,
         s = select_gpu_api(s, t);
         debug(2) << "Lowering after selecting a GPU API for extern stages:\n"
                  << s << "\n\n";
-    } else {
-        // Always mark buffers host dirty. Buffers will otherwise not be correctly copied for
-        // other pipelines with device feature enabled.
-        debug(1) << "Injecting host <-> dev buffer copies...\n";
-        s = inject_host_dev_buffer_copies(s, t);
-        debug(2) << "Lowering after injecting host <-> dev buffer copies:\n"
-                    << s << "\n\n";
     }
 
     if (t.has_feature(Target::OpenGL)) {


### PR DESCRIPTION
Reverts halide/Halide#4408 -- unfortunately, this can get us into a situation where a buffer can get both host-dirty and device-dirty bits set; I don't have the exact scenario but it involves complex `define_extern` usage that calls from CPU->Device or vice versa. For now we need to roll this back as it's breakage some obscure code.