### PR TITLE
Bring back predicated store/load

### DIFF
--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -268,10 +268,7 @@ class PredicateLoadStore : public IRMutator {
         } else if (target.arch == Target::X86) {
             // Should only attempt to predicate store/load if the lane size is
             // no less than 4
-            // TODO: disabling for now due to trunk LLVM breakage.
-            // See: https://github.com/halide/Halide/issues/3534
-            // return (bit_size == 32) && (lanes >= 4);
-            return false;
+            return (bit_size == 32) && (lanes >= 4);
         }
         // For other architecture, do not predicate vector load/store
         return false;

--- a/test/correctness/predicated_store_load.cpp
+++ b/test/correctness/predicated_store_load.cpp
@@ -47,12 +47,6 @@ class CheckPredicatedStoreLoad : public IRMutator {
 public:
     CheckPredicatedStoreLoad(const Target &target, int store, int load) :
         expected_store_count(store), expected_load_count(load) {
-        // TODO: disabling for now due to trunk LLVM breakage.
-        // See: https://github.com/halide/Halide/issues/3534
-        if (target.arch == Target::X86) {
-            expected_store_count = 0;
-            expected_load_count = 0;
-        }
     }
     using IRMutator::mutate;
 


### PR DESCRIPTION
Predicated store/load was disabled due to a "llvm trunk breakage" (https://github.com/halide/Halide/issues/3534). I tried running the tests on my machine and it runs fine now with the current llvm trunk (also one of my research projects needs predicated store/load), so I propose to revive it.