### PR TITLE
Increase autograd estimates/sizes from 32 -> 64

### DIFF
--- a/test/generator/autograd_aottest.cpp
+++ b/test/generator/autograd_aottest.cpp
@@ -9,7 +9,7 @@
 
 using namespace Halide::Runtime;
 
-const int kSize = 32;
+constexpr int kSize = 64;
 
 int main(int argc, char **argv) {
     int result;

--- a/test/generator/autograd_generator.cpp
+++ b/test/generator/autograd_generator.cpp
@@ -2,6 +2,8 @@
 
 namespace {
 
+constexpr int kSize = 64;
+
 class Autograd : public Halide::Generator<Autograd> {
 public:
     Input<Buffer<float>> input_a{ "input_a", 1 };
@@ -26,14 +28,14 @@ public:
 
         output_lut(x) = lut(lut_indices(x));
 
-        input_a.set_estimates({{0, 32}});
-        input_b.set_estimates({{0, 32}});
-        input_c.set_estimates({{0, 32}});
-        output.set_estimates({{0, 32}});
+        input_a.set_estimates({{0, kSize}});
+        input_b.set_estimates({{0, kSize}});
+        input_c.set_estimates({{0, kSize}});
+        output.set_estimates({{0, kSize}});
 
         lut.set_estimates({{0, 256}});
-        lut_indices.set_estimates({{0, 32}});
-        output_lut.set_estimates({{0, 32}});
+        lut_indices.set_estimates({{0, kSize}});
+        output_lut.set_estimates({{0, kSize}});
 
         output.vectorize(x, natural_vector_size<float>());
     }


### PR DESCRIPTION
The classic autoscheduler can over-vectorize (e.g., on Skylake it will vectorize to width=64, which will fail for inputs of width<64). This is a somewhat-known issue; rather than try to fix it here, I am just going to widen the buffers to the autograd test to avoid failure on Skylake+ machines. (Note that autograd shouldn't be using the classic autoscheduler in the first place; it should be using the gradient autoscheduler, but packaging issues make that impractical just yet.)