### PR TITLE
Use Halide::Range instead of std::pair<Expr, Expr> in Derivative (Issue #4381)

### DIFF
--- a/python_bindings/src/PyDerivative.cpp
+++ b/python_bindings/src/PyDerivative.cpp
@@ -19,8 +19,7 @@ void define_derivative(py::module &m) {
         });
 
     m.def("propagate_adjoints",
-        (Derivative (*)(const Func &, const Func &,
-            const std::vector<std::pair<Expr, Expr>> &))&propagate_adjoints);
+        (Derivative (*)(const Func &, const Func &, const Region &))&propagate_adjoints);
     m.def("propagate_adjoints",
         (Derivative (*)(const Func &, const Buffer<float> &))&propagate_adjoints);
     m.def("propagate_adjoints",

--- a/src/Derivative.h
+++ b/src/Derivative.h
@@ -44,14 +44,14 @@ private:
 /**
  *  Given a Func and a corresponding adjoint, (back)propagate the
  *  adjoint to all dependent Funcs, buffers, and parameters.
- *  The bounds of output and adjoint need to be specified with pair {min, max}
+ *  The bounds of output and adjoint need to be specified with pair {min, extent}
  *  For each Func the output depends on, and for the pure definition and
  *  each update of that Func, it generates a derivative Func stored in
  *  the Derivative.
  */
 Derivative propagate_adjoints(const Func &output,
                               const Func &adjoint,
-                              const std::vector<std::pair<Expr, Expr>> &output_bounds);
+                              const Region &output_bounds);
 /**
  *  Given a Func and a corresponding adjoint buffer, (back)propagate the
  *  adjoint to all dependent Funcs, buffers, and parameters.

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1532,9 +1532,9 @@ Module GeneratorBase::build_gradient_module(const std::string &function_name) {
     for (size_t i = 0; i < original_outputs.size(); ++i) {
         const Func &original_output = original_outputs.at(i);
         const ImageParam &d_output = d_output_imageparams.at(i);
-        std::vector<std::pair<Expr, Expr>> bounds;
+        Region bounds;
         for (int i = 0; i < d_output.dimensions(); i++) {
-            bounds.emplace_back(d_output.dim(i).min(), d_output.dim(i).max());
+            bounds.emplace_back(d_output.dim(i).min(), d_output.dim(i).extent());
         }
         Func adjoint_func = BoundaryConditions::constant_exterior(d_output, make_zero(d_output.type()));
         Derivative d = propagate_adjoints(original_output, adjoint_func, bounds);


### PR DESCRIPTION
This finishes the work stated in PR#4393, converting Derivative to use Range/Region in its API rather than pair<Expr, Expr>. Note that aside from the structure change, this is also a change from {min,max} to {min,extent}.