### PR TITLE
Smarten Range(min, extent) ctor

### DIFF
--- a/src/Expr.h
+++ b/src/Expr.h
@@ -391,13 +391,7 @@ struct Range {
     Expr min, extent;
 
     Range() = default;
-    Range(const Expr &min, const Expr &extent)
-        : min(min), extent(extent) {
-        internal_assert(!min.defined() ||
-                        !extent.defined() ||
-                        min.type() == extent.type())
-            << "Region min and extent must have same type\n";
-    }
+    Range(const Expr &min_in, const Expr &extent_in);
 };
 
 /** A multi-dimensional box. The outer product of the elements */

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -2211,4 +2211,18 @@ Expr undef(Type t) {
                                 Internal::Call::PureIntrinsic);
 }
 
+Range::Range(const Expr &min_in, const Expr &extent_in)
+    : min(min_in), extent(extent_in) {
+    // It's common to pass literal-0 for min, so add a little coercion
+    // to ensure that it matches the type of extent in that case, to avoid
+    // noise at the call site.
+    if (Internal::is_zero(min) && extent.defined()) {
+        min = Internal::make_zero(extent.type());
+    }
+    internal_assert(!min.defined() ||
+                    !extent.defined() ||
+                    min.type() == extent.type())
+        << "Region min and extent must have same type\n";
+}
+
 }  // namespace Halide

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -2213,16 +2213,9 @@ Expr undef(Type t) {
 
 Range::Range(const Expr &min_in, const Expr &extent_in)
     : min(min_in), extent(extent_in) {
-    // It's common to pass literal-0 for min, so add a little coercion
-    // to ensure that it matches the type of extent in that case, to avoid
-    // noise at the call site.
-    if (Internal::is_zero(min) && extent.defined()) {
-        min = Internal::make_zero(extent.type());
+    if (min.defined() && extent.defined()) {
+        match_types(min, extent);
     }
-    internal_assert(!min.defined() ||
-                    !extent.defined() ||
-                    min.type() == extent.type())
-        << "Region min and extent must have same type\n";
 }
 
 }  // namespace Halide


### PR DESCRIPTION
It's common to pass a literal-0 for min (especially via the RDom ctor), so quietly coerce it to a zero of the same type as extent in these cases, to make migrating old code simpler.