### PR TITLE
Range() requires Exprs to be losslessly convertible to int32

### DIFF
--- a/src/Expr.h
+++ b/src/Expr.h
@@ -391,13 +391,7 @@ struct Range {
     Expr min, extent;
 
     Range() = default;
-    Range(const Expr &min, const Expr &extent)
-        : min(min), extent(extent) {
-        internal_assert(!min.defined() ||
-                        !extent.defined() ||
-                        min.type() == extent.type())
-            << "Region min and extent must have same type\n";
-    }
+    Range(const Expr &min_in, const Expr &extent_in);
 };
 
 /** A multi-dimensional box. The outer product of the elements */

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -403,7 +403,7 @@ Expr const_false(int w) {
 }
 
 Expr lossless_cast(Type t, Expr e) {
-    if (t == e.type()) {
+    if (!e.defined() || t == e.type()) {
         return e;
     } else if (t.can_represent(e.type())) {
         return cast(t, std::move(e));
@@ -2209,6 +2209,16 @@ Expr undef(Type t) {
     return Internal::Call::make(t, Internal::Call::undef,
                                 std::vector<Expr>(),
                                 Internal::Call::PureIntrinsic);
+}
+
+Range::Range(const Expr &min_in, const Expr &extent_in)
+    : min(lossless_cast(Int(32), min_in)), extent(lossless_cast(Int(32), extent_in)) {
+    if (min_in.defined() && !min.defined()) {
+        user_error << "Min cannot be losslessly cast to an int32: " << min_in;
+    }
+    if (extent_in.defined() && !extent.defined()) {
+        user_error << "Extent cannot be losslessly cast to an int32: " << extent_in;
+    }
 }
 
 }  // namespace Halide


### PR DESCRIPTION
Alternative to https://github.com/halide/Halide/pull/4444: Range(min, extent) requires Exprs to be losslessly convertible to int32.