### PR TITLE
Add HALIDE_MUST_USE_RESULT macro to HalideRuntime.h and AOT .h

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -35,6 +35,24 @@ extern "C" unsigned char halide_internal_runtime_header_HalideRuntimeD3D12Comput
 
 namespace {
 
+// HALIDE_MUST_USE_RESULT defined here is intended to exactly
+// duplicate the definition in HalideRuntime.h (so that either or
+// both can be present, in any order).
+const char * const kDefineMustUseResult = R"INLINE_CODE(#ifndef HALIDE_MUST_USE_RESULT
+#ifdef __has_attribute
+#if __has_attribute(nodiscard)
+#define HALIDE_MUST_USE_RESULT [[nodiscard]]
+#elif __has_attribute(warn_unused_result)
+#define HALIDE_MUST_USE_RESULT __attribute__((warn_unused_result))
+#else
+#define HALIDE_MUST_USE_RESULT
+#endif
+#else
+#define HALIDE_MUST_USE_RESULT
+#endif
+#endif
+)INLINE_CODE";
+
 const string headers =
     "#include <iostream>\n"
     "#include <math.h>\n"
@@ -352,6 +370,8 @@ CodeGen_C::CodeGen_C(ostream &s, Target t, OutputKind output_kind, const std::st
         add_common_macros(stream);
         stream << '\n';
     }
+
+    stream << kDefineMustUseResult << '\n';
 
     // Throw in a default (empty) definition of HALIDE_FUNCTION_ATTRS
     // (some hosts may define this to e.g. __attribute__((warn_unused_result)))
@@ -1665,6 +1685,7 @@ void CodeGen_C::compile(const LoweredFunc &f) {
         // If the function isn't public, mark it static.
         stream << "static ";
     }
+    stream << "HALIDE_FUNCTION_ATTRS\n";
     stream << "int " << simple_name << "(";
     for (size_t i = 0; i < args.size(); i++) {
         if (args[i].is_buffer()) {
@@ -1680,9 +1701,9 @@ void CodeGen_C::compile(const LoweredFunc &f) {
     }
 
     if (is_header_or_extern_decl()) {
-        stream << ") HALIDE_FUNCTION_ATTRS;\n";
+        stream << ");\n";
     } else {
-        stream << ") HALIDE_FUNCTION_ATTRS {\n";
+        stream << ") {\n";
         indent += 1;
 
         if (uses_gpu_for_loops) {
@@ -1711,10 +1732,10 @@ void CodeGen_C::compile(const LoweredFunc &f) {
 
     if (is_header_or_extern_decl() && f.linkage == LinkageType::ExternalPlusMetadata) {
         // Emit the argv version
-        stream << "int " << simple_name << "_argv(void **args) HALIDE_FUNCTION_ATTRS;\n";
+        stream << "\nHALIDE_FUNCTION_ATTRS\nint " << simple_name << "_argv(void **args);\n";
 
         // And also the metadata.
-        stream << "const struct halide_filter_metadata_t *" << simple_name << "_metadata() HALIDE_FUNCTION_ATTRS;\n";
+        stream << "\nHALIDE_FUNCTION_ATTRS\nconst struct halide_filter_metadata_t *" << simple_name << "_metadata();\n";
     }
 
     if (!namespaces.empty()) {
@@ -2854,7 +2875,7 @@ void CodeGen_C::test() {
         globals +
         string((const char *)halide_internal_runtime_header_HalideRuntime_h) + '\n' +
         string((const char *)halide_internal_initmod_inlined_c) + '\n' +
-        macros.str() + R"GOLDEN_CODE(
+        macros.str() + '\n' + kDefineMustUseResult + R"GOLDEN_CODE(
 #ifndef HALIDE_FUNCTION_ATTRS
 #define HALIDE_FUNCTION_ATTRS
 #endif
@@ -2865,7 +2886,8 @@ void CodeGen_C::test() {
 extern "C" {
 #endif
 
-int test1(struct halide_buffer_t *_buf_buffer, float _alpha, int32_t _beta, void const *__user_context) HALIDE_FUNCTION_ATTRS {
+HALIDE_FUNCTION_ATTRS
+int test1(struct halide_buffer_t *_buf_buffer, float _alpha, int32_t _beta, void const *__user_context) {
  void * const _ucon = const_cast<void *>(__user_context);
  void *_0 = _halide_buffer_get_host(_buf_buffer);
  void * _buf = _0;

--- a/src/CodeGen_PyTorch.cpp
+++ b/src/CodeGen_PyTorch.cpp
@@ -71,6 +71,7 @@ void CodeGen_PyTorch::compile(const LoweredFunc &f, bool is_cuda) {
     const std::vector<LoweredArgument> &args = f.args;
     std::vector<LoweredArgument> buffer_args;
 
+    stream << "HALIDE_FUNCTION_ATTRS\n";
     stream << "inline int " << simple_name << "_th_(";
     for (size_t i = 0; i < args.size(); i++) {
         if (args[i].name == "__user_context") {
@@ -245,6 +246,20 @@ void CodeGen_PyTorch::test() {
 struct halide_buffer_t;
 struct halide_filter_metadata_t;
 
+#ifndef HALIDE_MUST_USE_RESULT
+#ifdef __has_attribute
+#if __has_attribute(nodiscard)
+#define HALIDE_MUST_USE_RESULT [[nodiscard]]
+#elif __has_attribute(warn_unused_result)
+#define HALIDE_MUST_USE_RESULT __attribute__((warn_unused_result))
+#else
+#define HALIDE_MUST_USE_RESULT
+#endif
+#else
+#define HALIDE_MUST_USE_RESULT
+#endif
+#endif
+
 #ifndef HALIDE_FUNCTION_ATTRS
 #define HALIDE_FUNCTION_ATTRS
 #endif
@@ -255,12 +270,14 @@ struct halide_filter_metadata_t;
 extern "C" {
 #endif
 
-int test1(struct halide_buffer_t *_buf_buffer, float _alpha, int32_t _beta) HALIDE_FUNCTION_ATTRS;
+HALIDE_FUNCTION_ATTRS
+int test1(struct halide_buffer_t *_buf_buffer, float _alpha, int32_t _beta);
 
 #ifdef __cplusplus
 }  // extern "C"
 #endif
 
+HALIDE_FUNCTION_ATTRS
 inline int test1_th_(at::Tensor &_buf, float _alpha, int32_t _beta) {
     // Check tensors have contiguous memory and are on the correct device
     HLPT_CHECK_CONTIGUOUS(_buf);
@@ -284,6 +301,20 @@ inline int test1_th_(at::Tensor &_buf, float _alpha, int32_t _beta) {
 struct halide_buffer_t;
 struct halide_filter_metadata_t;
 
+#ifndef HALIDE_MUST_USE_RESULT
+#ifdef __has_attribute
+#if __has_attribute(nodiscard)
+#define HALIDE_MUST_USE_RESULT [[nodiscard]]
+#elif __has_attribute(warn_unused_result)
+#define HALIDE_MUST_USE_RESULT __attribute__((warn_unused_result))
+#else
+#define HALIDE_MUST_USE_RESULT
+#endif
+#else
+#define HALIDE_MUST_USE_RESULT
+#endif
+#endif
+
 #ifndef HALIDE_FUNCTION_ATTRS
 #define HALIDE_FUNCTION_ATTRS
 #endif
@@ -294,12 +325,14 @@ struct halide_filter_metadata_t;
 extern "C" {
 #endif
 
-int test1(struct halide_buffer_t *_buf_buffer, float _alpha, int32_t _beta) HALIDE_FUNCTION_ATTRS;
+HALIDE_FUNCTION_ATTRS
+int test1(struct halide_buffer_t *_buf_buffer, float _alpha, int32_t _beta);
 
 #ifdef __cplusplus
 }  // extern "C"
 #endif
 
+HALIDE_FUNCTION_ATTRS
 inline int test1_th_(at::Tensor &_buf, float _alpha, int32_t _beta) {
     // Setup CUDA
     int device_id = at::cuda::current_device();

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -30,6 +30,22 @@ extern "C" {
 #define HALIDE_NEVER_INLINE __attribute__((noinline))
 #endif
 
+#ifndef HALIDE_MUST_USE_RESULT
+#ifdef __has_attribute
+#if __has_attribute(nodiscard)
+// C++17 or later
+#define HALIDE_MUST_USE_RESULT [[nodiscard]]
+#elif __has_attribute(warn_unused_result)
+// Clang/GCC
+#define HALIDE_MUST_USE_RESULT __attribute__((warn_unused_result))
+#else
+#define HALIDE_MUST_USE_RESULT
+#endif
+#else
+#define HALIDE_MUST_USE_RESULT
+#endif
+#endif
+
 /** \file
  *
  * This file declares the routines used by Halide internally in its


### PR DESCRIPTION
This is designed to make it easier to enforce examination of the result code of calls into Halide AOT code; by providing the HALIDE_MUST_USE_RESULT as part of the generated .h files, you can enable this by simply adding `-DHALIDE_FUNCTION_ATTRS=HALIDE_MUST_USE_RESULT` to your build options (rather than having to ensure that other dependencies ahead of other includes).

This mimics the definition used by Abseil, in which the C++17 [[nodiscard]] attribute is preferred when available.

(It's quite possible that HALIDE_MUST_USE_RESULT could be profitably applied to Halide APIs as well, both internal and external; I haven't attempted to look for candidates at this time.)