### PR TITLE
Improve the accuracy of the pipeline features for math functions

### DIFF
--- a/apps/autoscheduler/FunctionDAG.cpp
+++ b/apps/autoscheduler/FunctionDAG.cpp
@@ -151,9 +151,22 @@ class Featurizer : public IRVisitor {
                 visit_memory_access(op->name, op->type, op->args, PipelineFeatures::AccessType::LoadFunc);
                 op_bucket(PipelineFeatures::OpType::FuncCall, op->type)++;
             }
-        } else if (op->call_type == Call::Extern || op->call_type == Call::PureExtern ||
-                   op->call_type == Call::Intrinsic || op->call_type == Call::PureIntrinsic) {
+        } else if (op->call_type == Call::Extern || op->call_type == Call::Intrinsic ||
+                   op->call_type == Call::PureIntrinsic) {
             op_bucket(PipelineFeatures::OpType::ExternCall, op->type)++;
+        } else if (op->call_type == Call::PureExtern) {
+            if (op->name == "tanh_f32") {
+                // Number of ops derived the the eigen implementation of tanh.
+                op_bucket(PipelineFeatures::OpType::Const, op->type) += 13;
+                op_bucket(PipelineFeatures::OpType::Min, op->type) += 1;
+                op_bucket(PipelineFeatures::OpType::Max, op->type) += 1;
+                op_bucket(PipelineFeatures::OpType::Add, op->type) += 9;
+                op_bucket(PipelineFeatures::OpType::Mul, op->type) += 11;
+                op_bucket(PipelineFeatures::OpType::Div, op->type) += 1;
+            } else {
+                // Catch all
+                op_bucket(PipelineFeatures::OpType::ExternCall, op->type)++;
+            }
         } else if (op->call_type == Call::Image) {
             visit_memory_access(op->name, op->type, op->args, PipelineFeatures::AccessType::LoadImage);
             op_bucket(PipelineFeatures::OpType::ImageCall, op->type)++;

--- a/apps/autoscheduler/test_function_dag.cpp
+++ b/apps/autoscheduler/test_function_dag.cpp
@@ -162,6 +162,23 @@ void test_matmul(const MachineParams &params, const Target &target) {
               << "\n\nwithout_extern:\n " << without_extern.str() << std::endl;
 }
 
+void test_hyperbolic_funcs(const MachineParams &params, const Target &target) {
+    Var x("x");
+    Halide::Buffer<float> input(27);
+
+    Func activation_func("af");
+    activation_func(x) = Halide::tanh(input(x));
+    activation_func.set_estimate(x, 0, 27);
+    std::vector<Halide::Internal::Function> v;
+    v.push_back(activation_func.function());
+    Halide::Internal::Autoscheduler::FunctionDAG d(v, params, target);
+
+    std::ostringstream features;
+    d.dump(features);
+    std::cout << "features: \n"
+              << features.str() << std::endl;
+}
+
 int main(int argc, char **argv) {
     // Use a fixed target for the analysis to get consistent results from this test.
     MachineParams params(32, 16000000, 40);
@@ -169,6 +186,7 @@ int main(int argc, char **argv) {
 
     test_coeff_wise(params, target);
     test_matmul(params, target);
+    test_hyperbolic_funcs(params, target);
 
     return 0;
 }


### PR DESCRIPTION
Instead of modeling tanh as an extern function call, count the number of primitive
floating point operations required for an actual implementation of the function.
This PR only applies this approach to tanh, but if it seems reasonable to the Halide maintainers I will apply it more broadly to other math functions in follow up PRs. 

