### PR TITLE
stringify() should call halide_msan_annotate_memory_is_initialized()

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -3005,6 +3005,16 @@ void CodeGen_LLVM::visit(const Call *op) {
                     dst = builder->CreateCall(append_pointer, call_args);
                 }
             }
+            if (get_target().has_feature(Target::MSAN)) {
+              // Note that we mark the entire buffer as initialized;
+              // it would be more accurate to just mark (dst - buf)
+              llvm::Function *annotate = module->getFunction("halide_msan_annotate_memory_is_initialized");
+              vector<Value *> annotate_args(3);
+              annotate_args[0] = get_user_context();
+              annotate_args[1] = buf;
+              annotate_args[2] = codegen(Cast::make(Int(64), buf_size));
+              builder->CreateCall(annotate, annotate_args);
+            }
             value = buf;
         }
     } else if (op->is_intrinsic(Call::memoize_expr)) {


### PR DESCRIPTION
calls to halide_print() -- including those injected by Target::Debug -- will trigger MSAN failures currently. When the target includes MSAN, we should mark the buffer as initializaed to avoid false failures.