### PR TITLE
Move last three autoscheduler benchmark apps into master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1969,15 +1969,18 @@ time_compilation_generator_%: $(BIN_DIR)/%.generator
 TEST_APPS=\
 	HelloMatlab \
 	bilateral_grid \
+	bgu \
 	blur \
 	c_backend \
 	camera_pipe \
 	conv_layer \
 	fft \
+	hist \
 	interpolate \
 	lens_blur \
 	linear_algebra \
 	local_laplacian \
+	max_filter \
 	nl_means \
 	onnx \
 	resize \

--- a/apps/bgu/CMakeLists.txt
+++ b/apps/bgu/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_executable(bgu_filter filter.cpp)
+halide_use_image_io(bgu_filter)
+
+halide_generator(bgu.generator SRCS bgu_generator.cpp)
+foreach(AUTO_SCHEDULE false true)
+    if(${AUTO_SCHEDULE})
+        set(LIB bgu_auto_schedule)
+    else()
+        set(LIB bgu)
+    endif()
+    halide_library_from_generator(${LIB}
+                                  GENERATOR bgu.generator
+                                  GENERATOR_ARGS auto_schedule=${AUTO_SCHEDULE})
+    target_link_libraries(bgu_filter PRIVATE ${LIB})
+endforeach()

--- a/apps/bgu/Makefile
+++ b/apps/bgu/Makefile
@@ -1,0 +1,31 @@
+include ../support/Makefile.inc
+
+all: $(BIN)/$(HL_TARGET)/filter
+
+test: $(BIN)/$(HL_TARGET)/out.png
+
+$(GENERATOR_BIN)/bgu.generator: bgu_generator.cpp $(GENERATOR_DEPS)
+	@mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS) -g $(filter %.cpp,$^) -o $@ $(GENERATOR_LDFLAGS)
+
+$(BIN)/%/bgu.a: $(GENERATOR_BIN)/bgu.generator
+	@mkdir -p $(@D)
+	$< -g bgu -f bgu -o $(BIN)/$* target=$*-no_runtime auto_schedule=false
+
+$(BIN)/%/bgu_auto_schedule.a: $(GENERATOR_BIN)/bgu.generator
+	@mkdir -p $(@D)
+	$< -g bgu -f bgu_auto_schedule -o $(BIN)/$* target=$*-no_runtime auto_schedule=true
+
+$(BIN)/%/runtime.a: $(GENERATOR_BIN)/bgu.generator
+	@mkdir -p $(@D)
+	$< -r runtime -o $(BIN)/$* target=$*
+
+$(BIN)/%/filter: filter.cpp $(BIN)/%/bgu.a $(BIN)/%/bgu_auto_schedule.a $(BIN)/%/runtime.a
+	@mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS) -I$(BIN)/$* -Wall -O3 $^ -o $@ $(LDFLAGS) $(IMAGE_IO_FLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS)
+
+$(BIN)/%/out.png: $(BIN)/%/filter
+	$< ../images/rgb.png $(BIN)/$*/out.png
+
+clean:
+	rm -rf $(BIN)

--- a/apps/bgu/bgu_generator.cpp
+++ b/apps/bgu/bgu_generator.cpp
@@ -1,0 +1,507 @@
+// A Halide implementation of bilateral-guided upsampling.
+
+// Adapted from https://github.com/google/bgu/blob/master/src/halide/bgu.cpp
+
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http ://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Halide.h"
+
+namespace {
+
+using namespace Halide;
+using Halide::ConciseCasts::f32;
+using Halide::ConciseCasts::i32;
+
+Var x("x"), y("y"), z("z"), c("c");
+
+// A class to hold a matrix of Halide Exprs.
+template<int rows, int cols>
+struct Matrix {
+    Expr exprs[rows][cols];
+
+    Expr operator()(int i, int j) const {
+        return exprs[i][j];
+    }
+
+    Expr &operator()(int i, int j) {
+        return exprs[i][j];
+    }
+
+    void dump() {
+        for (int i = 0; i < rows; i++) {
+            for (int j = 0; j < cols; j++) {
+                std::cout << exprs[i][j];
+                if (j < cols - 1) {
+                    std::cout << ", ";
+                }
+            }
+            std::cout << "\n";
+        }
+    }
+};
+
+// Matrix-matrix multiply.
+template<int R, int S, int T>
+Matrix<R, T> mat_mul(const Matrix<R, S> &A, const Matrix<S, T> &B) {
+    Matrix<R, T> result;
+    for (int r = 0; r < R; r++) {
+        for (int t = 0; t < T; t++) {
+            result(r, t) = 0.0f;
+            for (int s = 0; s < S; s++) {
+                result(r, t) += A(r, s) * B(s, t);
+            }
+        }
+    }
+    return result;
+}
+
+// Solve Ax = b at each x, y, z. Compute the result at the given Func and Var.
+template<int M, int N>
+Matrix<M, N> solve(Matrix<M, M> A, Matrix<M, N> b, Func compute, Var at, bool skip_schedule) {
+    // Put the input matrices in a Func to do the Gaussian elimination.
+    Var vi, vj;
+    Func f;
+    f(x, y, z, vi, vj) = undef<float>();
+    for (int i = 0; i < M; i++) {
+        for (int j = 0; j < M; j++) {
+            f(x, y, z, i, j) = A(i, j);
+        }
+        for (int j = 0; j < N; j++) {
+            f(x, y, z, i, j + M) = b(i, j);
+        }
+    }
+
+    // eliminate lower left
+    for (int k = 0; k < M-1; k++) {
+        for (int i = k+1; i < M; i++) {
+            f(x, y, z, -1, 0) = f(x, y, z, i, k) / f(x, y, z, k, k);
+            for (int j = k+1; j < M+N; j++) {
+                f(x, y, z, i, j) -= f(x, y, z, k, j) * f(x, y, z, -1, 0);
+            }
+            f(x, y, z, i, k) = 0.0f;
+        }
+    }
+
+    // eliminate upper right
+    for (int k = M-1; k > 0; k--) {
+        for (int i = 0; i < k; i++) {
+            f(x, y, z, -1, 0) = f(x, y, z, i, k) / f(x, y, z, k, k);
+            for (int j = k+1; j < M+N; j++) {
+                f(x, y, z, i, j) -= f(x, y, z, k, j) * f(x, y, z, -1, 0);
+            }
+            f(x, y, z, i, k) = 0.0f;
+        }
+    }
+
+    // Divide by diagonal and put it in the output matrix.
+    for (int i = 0; i < M; i++) {
+        f(x, y, z, i, i) = 1.0f/f(x, y, z, i, i);
+        for (int j = 0; j < N; j++) {
+            b(i, j) = f(x, y, z, i, j+M) * f(x, y, z, i, i);
+        }
+    }
+
+    if (!skip_schedule) {
+        for (int i = 0; i < f.num_update_definitions(); i++) {
+            f.update(i).vectorize(x);
+        }
+
+        f.compute_at(compute, at);
+    }
+
+    return b;
+};
+
+
+template<int N, int M>
+Matrix<M, N> transpose(const Matrix<N, M> &in) {
+    Matrix<M, N> out;
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < M; j++) {
+            out(j, i) = in(i, j);
+        }
+    }
+    return out;
+}
+
+
+Expr pack_channels(Var c, std::vector<Expr> exprs) {
+    Expr e = exprs.back();
+    for (int i = (int)exprs.size() - 2; i >= 0; i--) {
+        e = select(c == i, exprs[i], e);
+    }
+    return e;
+}
+
+class BGU : public Generator<BGU> {
+public:
+    // Size of each luma bin in the grid. Typically 1/8.
+    Input<float> r_sigma{"r_sigma"};
+
+    // Size of each spatial bin in the grid. Typically 16.
+    Input<int> s_sigma{"s_sigma"};
+
+    Input<Buffer<float>> splat_loc{"splat_loc", 3};
+    Input<Buffer<float>> values{"values", 3};
+    Input<Buffer<float>> slice_loc{"slice_loc", 3};
+
+    Output<Buffer<float>> output{"output", 3};
+
+    void generate() {
+        // Algorithm
+
+        // Add a boundary condition to the inputs.
+        Func clamped_values = BoundaryConditions::repeat_edge(values);
+        Func clamped_splat_loc = BoundaryConditions::repeat_edge(splat_loc);
+
+        // Figure out how much we're upsampling by. Not relevant if we're
+        // just fitting curves.
+        Expr upsample_factor_x =
+            i32(ceil(f32(slice_loc.width()) / splat_loc.width()));
+        Expr upsample_factor_y =
+            i32(ceil(f32(slice_loc.height()) / splat_loc.height()));
+        Expr upsample_factor = max(upsample_factor_x, upsample_factor_y);
+
+        Func gray_splat_loc;
+        gray_splat_loc(x, y) = (0.25f * clamped_splat_loc(x, y, 0) +
+                                0.5f * clamped_splat_loc(x, y, 1) +
+                                0.25f * clamped_splat_loc(x, y, 2));
+
+        Func gray_slice_loc;
+        gray_slice_loc(x, y) = (0.25f * slice_loc(x, y, 0) +
+                                0.5f * slice_loc(x, y, 1) +
+                                0.25f * slice_loc(x, y, 2));
+
+        // Construct the bilateral grid
+        Func histogram("histogram");
+        RDom r(0, s_sigma, 0, s_sigma);
+        {
+            histogram(x, y, z, c) = 0.0f;
+
+            Expr sx = x * s_sigma + r.x - s_sigma/2, sy = y * s_sigma + r.y - s_sigma/2;
+            Expr pos = gray_splat_loc(sx, sy);
+            pos = clamp(pos, 0.0f, 1.0f);
+            Expr zi = cast<int>(round(pos * (1.0f/r_sigma)));
+
+            // Sum all the terms we need to fit a line relating
+            // low-res input to low-res output within this bilateral grid
+            // cell
+            Expr vr = clamped_values(sx, sy, 0), vg = clamped_values(sx, sy, 1), vb = clamped_values(sx, sy, 2);
+            Expr sr = clamped_splat_loc(sx, sy, 0), sg = clamped_splat_loc(sx, sy, 1), sb = clamped_splat_loc(sx, sy, 2);
+
+            histogram(x, y, zi, c) +=
+                pack_channels(c,
+                           {sr*sr, sr*sg, sr*sb, sr,
+                                   sg*sg, sg*sb, sg,
+                                          sb*sb, sb,
+                                               1.0f,
+                            vr*sr, vr*sg, vr*sb, vr,
+                            vg*sr, vg*sg, vg*sb, vg,
+                            vb*sr, vb*sg, vb*sb, vb});
+
+        }
+
+        // Convolution pyramids (Farbman et al.) suggests convolving by
+        // something 1/d^3-like to get an interpolating membrane, so we do
+        // that. We could also just use a convolution pyramid here, but
+        // these grids are really small, so it's OK for the filter to drop
+        // sharply and truncate early.
+        Expr t0 = 1.0f/64, t1 = 1.0f/27, t2 = 1.0f/8, t3 = 1.0f;
+
+        // Blur the grid using a seven-tap filter
+        Func blurx("blurx"), blury("blury"), blurz("blurz");
+
+        blurz(x, y, z, c) = (histogram(x, y, z-3, c)*t0 +
+                             histogram(x, y, z-2, c)*t1 +
+                             histogram(x, y, z-1, c)*t2 +
+                             histogram(x, y, z  , c)*t3 +
+                             histogram(x, y, z+1, c)*t2 +
+                             histogram(x, y, z+2, c)*t1 +
+                             histogram(x, y, z+3, c)*t0);
+        blury(x, y, z, c) = (blurz(x, y-3, z, c)*t0 +
+                             blurz(x, y-2, z, c)*t1 +
+                             blurz(x, y-1, z, c)*t2 +
+                             blurz(x, y  , z, c)*t3 +
+                             blurz(x, y+1, z, c)*t2 +
+                             blurz(x, y+2, z, c)*t1 +
+                             blurz(x, y+3, z, c)*t0);
+        blurx(x, y, z, c) = (blury(x-3, y, z, c)*t0 +
+                             blury(x-2, y, z, c)*t1 +
+                             blury(x-1, y, z, c)*t2 +
+                             blury(x  , y, z, c)*t3 +
+                             blury(x+1, y, z, c)*t2 +
+                             blury(x+2, y, z, c)*t1 +
+                             blury(x+3, y, z, c)*t0);
+
+        // Do the solve, to convert the accumulated values to the affine
+        // matrices.
+        Func line("line");
+        {
+            // Pull out the 4x4 symmetric matrix from the values we've
+            // accumulated.
+            Matrix<4, 4> A;
+            A(0, 0) = blurx(x, y, z, 0);
+            A(0, 1) = blurx(x, y, z, 1);
+            A(0, 2) = blurx(x, y, z, 2);
+            A(0, 3) = blurx(x, y, z, 3);
+            A(1, 0) = A(0, 1);
+            A(1, 1) = blurx(x, y, z, 4);
+            A(1, 2) = blurx(x, y, z, 5);
+            A(1, 3) = blurx(x, y, z, 6);
+            A(2, 0) = A(0, 2);
+            A(2, 1) = A(1, 2);
+            A(2, 2) = blurx(x, y, z, 7);
+            A(2, 3) = blurx(x, y, z, 8);
+            A(3, 0) = A(0, 3);
+            A(3, 1) = A(1, 3);
+            A(3, 2) = A(2, 3);
+            A(3, 3) = blurx(x, y, z, 9);
+
+            // Pull out the rhs
+            Matrix<4, 3> b;
+            b(0, 0) = blurx(x, y, z, 10);
+            b(1, 0) = blurx(x, y, z, 11);
+            b(2, 0) = blurx(x, y, z, 12);
+            b(3, 0) = blurx(x, y, z, 13);
+            b(0, 1) = blurx(x, y, z, 14);
+            b(1, 1) = blurx(x, y, z, 15);
+            b(2, 1) = blurx(x, y, z, 16);
+            b(3, 1) = blurx(x, y, z, 17);
+            b(0, 2) = blurx(x, y, z, 18);
+            b(1, 2) = blurx(x, y, z, 19);
+            b(2, 2) = blurx(x, y, z, 20);
+            b(3, 2) = blurx(x, y, z, 21);
+
+            // Regularize by pushing the solution towards the average gain
+            // in this cell = (average output luma + eps) / (average input luma + eps).
+            const float lambda = 1e-6f;
+            const float epsilon = 1e-6f;
+
+            // The bottom right entry of A is a count of the number of
+            // constraints affecting this cell.
+            Expr N = A(3, 3);
+
+            // The last row of each matrix is the sum of input and output
+            // RGB values for the pixels affecting this cell. Instead of
+            // dividing them by N+1 to get averages, we'll multiply
+            // epsilon by N+1. This saves two divisions.
+            Expr output_luma = b(3, 0) + 2 * b(3, 1) + b(3, 2) + epsilon * (N + 1);
+            Expr input_luma = A(3, 0) + 2 * A(3, 1) + A(3, 2) + epsilon * (N + 1);
+            Expr gain = output_luma / input_luma;
+
+            // Add lambda and lambda*gain to the diagonal of the
+            // matrices. The matrices are sums/moments rather than
+            // means/covariances, so just like above we need to multiply
+            // lambda by N+1 so that it's equivalent to adding a constant
+            // to the diagonal of a covariance matrix. Otherwise it does
+            // nothing in cells with lots of linearly-dependent
+            // constraints.
+            Expr weighted_lambda = lambda * (N + 1);
+            A(0, 0) += weighted_lambda;
+            A(1, 1) += weighted_lambda;
+            A(2, 2) += weighted_lambda;
+            A(3, 3) += weighted_lambda;
+
+            b(0, 0) += weighted_lambda * gain;
+            b(1, 1) += weighted_lambda * gain;
+            b(2, 2) += weighted_lambda * gain;
+
+            // Now solve Ax = b
+            Matrix<3, 4> result = transpose(solve(A, b, line, x, auto_schedule));
+
+            // Pack the resulting matrix into the output Func.
+            line(x, y, z, c) = pack_channels(c, {
+                        result(0, 0),
+                        result(0, 1),
+                        result(0, 2),
+                        result(0, 3),
+                        result(1, 0),
+                        result(1, 1),
+                        result(1, 2),
+                        result(1, 3),
+                        result(2, 0),
+                        result(2, 1),
+                        result(2, 2),
+                        result(2, 3)});
+        }
+
+        // If using the shader we stop there, and the Func "line" is the
+        // output. We also compile a more convenient but slower version
+        // that does the trilerp and evaluates the model inside the same
+        // Halide pipeline.
+
+        // We'll take trilinear samples to compute the output. We factor
+        // this into several stages to make better use of SIMD.
+        Func interpolated("interpolated");
+        Func slice_loc_z("slice_loc_z");
+        Func interpolated_matrix_x("interpolated_matrix_x");
+        Func interpolated_matrix_y("interpolated_matrix_y");
+        Func interpolated_matrix_z("interpolated_matrix_z");
+        {
+            // Spatial bin size in the high-res image.
+            Expr big_sigma = s_sigma * upsample_factor;
+
+            // Upsample the matrices in x and y.
+            Expr yf = cast<float>(y) / big_sigma;
+            Expr yi = cast<int>(floor(yf));
+            yf -= yi;
+            interpolated_matrix_y(x, y, z, c) =
+                lerp(line(x, yi, z, c),
+                     line(x, yi + 1, z, c),
+                     yf);
+
+            Expr xf = cast<float>(x) / big_sigma;
+            Expr xi = cast<int>(floor(xf));
+            xf -= xi;
+            interpolated_matrix_x(x, y, z, c) =
+                lerp(interpolated_matrix_y(xi, y, z, c),
+                     interpolated_matrix_y(xi + 1, y, z, c),
+                     xf);
+
+            // Sample it along the z direction using intensity.
+            Expr num_intensity_bins = cast<int>(1.0f / r_sigma);
+            Expr val = gray_slice_loc(x, y);
+            val = clamp(val, 0.0f, 1.0f);
+            Expr zv = val * num_intensity_bins;
+            Expr zi = cast<int>(zv);
+            Expr zf = zv - zi;
+            slice_loc_z(x, y) = {zi, zf};
+
+            interpolated_matrix_z(x, y, c) =
+                lerp(interpolated_matrix_x(x, y, slice_loc_z(x, y)[0], c),
+                     interpolated_matrix_x(x, y, slice_loc_z(x, y)[0]+1, c),
+                     slice_loc_z(x, y)[1]);
+
+            // Multiply by 3x4 by 4x1.
+            interpolated(x, y, c) =
+                (interpolated_matrix_z(x, y, 4 * c + 0) * slice_loc(x, y, 0) +
+                 interpolated_matrix_z(x, y, 4 * c + 1) * slice_loc(x, y, 1) +
+                 interpolated_matrix_z(x, y, 4 * c + 2) * slice_loc(x, y, 2) +
+                 interpolated_matrix_z(x, y, 4 * c + 3));
+        }
+
+        // Normalize
+        Func slice("slice");
+        slice(x, y, c) = clamp(interpolated(x, y, c), 0.0f, 1.0f);
+
+        output = slice;
+
+        // Schedule
+        if (!auto_schedule) {
+            // Fitting the curves.
+
+            // Compute the per tile histograms and splatting locations within
+            // rows of the blur in z.
+            histogram
+                .compute_at(blurz, y);
+            histogram.update()
+                .reorder(c, r.x, r.y, x, y)
+                .unroll(c);
+
+            gray_splat_loc
+                .compute_at(blurz, y)
+                .vectorize(x, 8);
+
+            // Compute the blur in z at root
+            blurz
+                .compute_root()
+                .reorder(c, z, x, y)
+                .parallel(y)
+                .vectorize(x, 8);
+
+            // The blurs of the Gram matrices across x and y will be computed
+            // within the outer loops of the matrix solve.
+            blury
+                .compute_at(line, z)
+                .vectorize(x, 4);
+
+            blurx
+                .compute_at(line, x)
+                .vectorize(x);
+
+            // The matrix solve. Store c innermost, because subsequent stages
+            // will do vectorized loads from this across c. If you just want
+            // the matrices, you probably want to remove this reorder storage
+            // call.
+            line
+                .compute_root()
+                .reorder_storage(c, x, y, z)
+                .reorder(c, x, z, y)
+                .parallel(y)
+                .vectorize(x, 8)
+                .bound(c, 0, 12)
+                .unroll(c);
+
+            // Applying the curves.
+
+            // You should really do the trilerp on the GPU in a shader. We can
+            // make the CPU implementation a little faster though by factoring
+            // it into a few stages. At scanline of output we first slice out
+            // a 2D array of matrices that we'll bilerp into. We'll be
+            // accessing it in vectors across the c dimension, so store c
+            // innermost.
+            interpolated_matrix_y
+                .compute_root()
+                .reorder_storage(c, x, y, z)
+                .bound(c, 0, 12)
+                .vectorize(c, 4);
+
+            // Compute the output in vectors across x.
+            slice
+                .compute_root()
+                .parallel(y)
+                .vectorize(x, 8)
+                .reorder(c, x, y)
+                .bound(c, 0, 3)
+                .unroll(c);
+
+            // Computing where to slice vectorizes nicely across x.
+            gray_slice_loc
+                .compute_root()
+                .vectorize(x, 8);
+
+            slice_loc_z
+                .compute_root()
+                .vectorize(x, 8);
+
+            // But sampling the matrix vectorizes better across c.
+            interpolated_matrix_z
+                .compute_root()
+                .vectorize(c, 4);
+        }
+
+        // Estimates
+        {
+            r_sigma.set_estimate(1.f / 8.f);
+            s_sigma.set_estimate(16.f);
+            splat_loc.dim(0).set_estimate(0, 192)
+                   .dim(1).set_estimate(0, 320)
+                   .dim(2).set_estimate(0, 3);
+            values.dim(0).set_estimate(0, 192)
+                   .dim(1).set_estimate(0, 320)
+                   .dim(2).set_estimate(0, 3);
+            slice_loc.dim(0).set_estimate(0, 1536)
+                   .dim(1).set_estimate(0, 2560)
+                   .dim(2).set_estimate(0, 3);
+            output.dim(0).set_estimate(0, 1536)
+                   .dim(1).set_estimate(0, 2560)
+                   .dim(2).set_estimate(0, 3);
+        }
+    }
+};
+
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(BGU, bgu)

--- a/apps/bgu/bgu_generator.cpp
+++ b/apps/bgu/bgu_generator.cpp
@@ -84,10 +84,10 @@ Matrix<M, N> solve(Matrix<M, M> A, Matrix<M, N> b, Func compute, Var at, bool sk
     }
 
     // eliminate lower left
-    for (int k = 0; k < M-1; k++) {
-        for (int i = k+1; i < M; i++) {
+    for (int k = 0; k < M - 1; k++) {
+        for (int i = k + 1; i < M; i++) {
             f(x, y, z, -1, 0) = f(x, y, z, i, k) / f(x, y, z, k, k);
-            for (int j = k+1; j < M+N; j++) {
+            for (int j = k + 1; j < M + N; j++) {
                 f(x, y, z, i, j) -= f(x, y, z, k, j) * f(x, y, z, -1, 0);
             }
             f(x, y, z, i, k) = 0.0f;
@@ -95,10 +95,10 @@ Matrix<M, N> solve(Matrix<M, M> A, Matrix<M, N> b, Func compute, Var at, bool sk
     }
 
     // eliminate upper right
-    for (int k = M-1; k > 0; k--) {
+    for (int k = M - 1; k > 0; k--) {
         for (int i = 0; i < k; i++) {
             f(x, y, z, -1, 0) = f(x, y, z, i, k) / f(x, y, z, k, k);
-            for (int j = k+1; j < M+N; j++) {
+            for (int j = k + 1; j < M + N; j++) {
                 f(x, y, z, i, j) -= f(x, y, z, k, j) * f(x, y, z, -1, 0);
             }
             f(x, y, z, i, k) = 0.0f;
@@ -107,9 +107,9 @@ Matrix<M, N> solve(Matrix<M, M> A, Matrix<M, N> b, Func compute, Var at, bool sk
 
     // Divide by diagonal and put it in the output matrix.
     for (int i = 0; i < M; i++) {
-        f(x, y, z, i, i) = 1.0f/f(x, y, z, i, i);
+        f(x, y, z, i, i) = 1.0f / f(x, y, z, i, i);
         for (int j = 0; j < N; j++) {
-            b(i, j) = f(x, y, z, i, j+M) * f(x, y, z, i, i);
+            b(i, j) = f(x, y, z, i, j + M) * f(x, y, z, i, i);
         }
     }
 
@@ -126,7 +126,6 @@ Matrix<M, N> solve(Matrix<M, M> A, Matrix<M, N> b, Func compute, Var at, bool sk
     return b;
 };
 
-
 template<int N, int M>
 Matrix<M, N> transpose(const Matrix<N, M> &in) {
     Matrix<M, N> out;
@@ -137,7 +136,6 @@ Matrix<M, N> transpose(const Matrix<N, M> &in) {
     }
     return out;
 }
-
 
 Expr pack_channels(Var c, std::vector<Expr> exprs) {
     Expr e = exprs.back();
@@ -192,10 +190,10 @@ public:
         {
             histogram(x, y, z, c) = 0.0f;
 
-            Expr sx = x * s_sigma + r.x - s_sigma/2, sy = y * s_sigma + r.y - s_sigma/2;
+            Expr sx = x * s_sigma + r.x - s_sigma / 2, sy = y * s_sigma + r.y - s_sigma / 2;
             Expr pos = gray_splat_loc(sx, sy);
             pos = clamp(pos, 0.0f, 1.0f);
-            Expr zi = cast<int>(round(pos * (1.0f/r_sigma)));
+            Expr zi = cast<int>(round(pos * (1.0f / r_sigma)));
 
             // Sum all the terms we need to fit a line relating
             // low-res input to low-res output within this bilateral grid
@@ -205,14 +203,13 @@ public:
 
             histogram(x, y, zi, c) +=
                 pack_channels(c,
-                           {sr*sr, sr*sg, sr*sb, sr,
-                                   sg*sg, sg*sb, sg,
-                                          sb*sb, sb,
-                                               1.0f,
-                            vr*sr, vr*sg, vr*sb, vr,
-                            vg*sr, vg*sg, vg*sb, vg,
-                            vb*sr, vb*sg, vb*sb, vb});
-
+                              {sr * sr, sr * sg, sr * sb, sr,
+                               sg * sg, sg * sb, sg,
+                               sb * sb, sb,
+                               1.0f,
+                               vr * sr, vr * sg, vr * sb, vr,
+                               vg * sr, vg * sg, vg * sb, vg,
+                               vb * sr, vb * sg, vb * sb, vb});
         }
 
         // Convolution pyramids (Farbman et al.) suggests convolving by
@@ -220,32 +217,32 @@ public:
         // that. We could also just use a convolution pyramid here, but
         // these grids are really small, so it's OK for the filter to drop
         // sharply and truncate early.
-        Expr t0 = 1.0f/64, t1 = 1.0f/27, t2 = 1.0f/8, t3 = 1.0f;
+        Expr t0 = 1.0f / 64, t1 = 1.0f / 27, t2 = 1.0f / 8, t3 = 1.0f;
 
         // Blur the grid using a seven-tap filter
         Func blurx("blurx"), blury("blury"), blurz("blurz");
 
-        blurz(x, y, z, c) = (histogram(x, y, z-3, c)*t0 +
-                             histogram(x, y, z-2, c)*t1 +
-                             histogram(x, y, z-1, c)*t2 +
-                             histogram(x, y, z  , c)*t3 +
-                             histogram(x, y, z+1, c)*t2 +
-                             histogram(x, y, z+2, c)*t1 +
-                             histogram(x, y, z+3, c)*t0);
-        blury(x, y, z, c) = (blurz(x, y-3, z, c)*t0 +
-                             blurz(x, y-2, z, c)*t1 +
-                             blurz(x, y-1, z, c)*t2 +
-                             blurz(x, y  , z, c)*t3 +
-                             blurz(x, y+1, z, c)*t2 +
-                             blurz(x, y+2, z, c)*t1 +
-                             blurz(x, y+3, z, c)*t0);
-        blurx(x, y, z, c) = (blury(x-3, y, z, c)*t0 +
-                             blury(x-2, y, z, c)*t1 +
-                             blury(x-1, y, z, c)*t2 +
-                             blury(x  , y, z, c)*t3 +
-                             blury(x+1, y, z, c)*t2 +
-                             blury(x+2, y, z, c)*t1 +
-                             blury(x+3, y, z, c)*t0);
+        blurz(x, y, z, c) = (histogram(x, y, z - 3, c) * t0 +
+                             histogram(x, y, z - 2, c) * t1 +
+                             histogram(x, y, z - 1, c) * t2 +
+                             histogram(x, y, z, c) * t3 +
+                             histogram(x, y, z + 1, c) * t2 +
+                             histogram(x, y, z + 2, c) * t1 +
+                             histogram(x, y, z + 3, c) * t0);
+        blury(x, y, z, c) = (blurz(x, y - 3, z, c) * t0 +
+                             blurz(x, y - 2, z, c) * t1 +
+                             blurz(x, y - 1, z, c) * t2 +
+                             blurz(x, y, z, c) * t3 +
+                             blurz(x, y + 1, z, c) * t2 +
+                             blurz(x, y + 2, z, c) * t1 +
+                             blurz(x, y + 3, z, c) * t0);
+        blurx(x, y, z, c) = (blury(x - 3, y, z, c) * t0 +
+                             blury(x - 2, y, z, c) * t1 +
+                             blury(x - 1, y, z, c) * t2 +
+                             blury(x, y, z, c) * t3 +
+                             blury(x + 1, y, z, c) * t2 +
+                             blury(x + 2, y, z, c) * t1 +
+                             blury(x + 3, y, z, c) * t0);
 
         // Do the solve, to convert the accumulated values to the affine
         // matrices.
@@ -324,19 +321,18 @@ public:
             Matrix<3, 4> result = transpose(solve(A, b, line, x, auto_schedule, get_target()));
 
             // Pack the resulting matrix into the output Func.
-            line(x, y, z, c) = pack_channels(c, {
-                        result(0, 0),
-                        result(0, 1),
-                        result(0, 2),
-                        result(0, 3),
-                        result(1, 0),
-                        result(1, 1),
-                        result(1, 2),
-                        result(1, 3),
-                        result(2, 0),
-                        result(2, 1),
-                        result(2, 2),
-                        result(2, 3)});
+            line(x, y, z, c) = pack_channels(c, {result(0, 0),
+                                                 result(0, 1),
+                                                 result(0, 2),
+                                                 result(0, 3),
+                                                 result(1, 0),
+                                                 result(1, 1),
+                                                 result(1, 2),
+                                                 result(1, 3),
+                                                 result(2, 0),
+                                                 result(2, 1),
+                                                 result(2, 2),
+                                                 result(2, 3)});
         }
 
         // If using the shader we stop there, and the Func "line" is the
@@ -383,7 +379,7 @@ public:
 
             interpolated_matrix_z(x, y, c) =
                 lerp(interpolated_matrix_x(x, y, slice_loc_z(x, y)[0], c),
-                     interpolated_matrix_x(x, y, slice_loc_z(x, y)[0]+1, c),
+                     interpolated_matrix_x(x, y, slice_loc_z(x, y)[0] + 1, c),
                      slice_loc_z(x, y)[1]);
 
             // Multiply by 3x4 by 4x1.
@@ -563,18 +559,18 @@ public:
         {
             r_sigma.set_estimate(1.f / 8.f);
             s_sigma.set_estimate(16.f);
-            splat_loc.dim(0).set_estimate(0, 192)
-                   .dim(1).set_estimate(0, 320)
-                   .dim(2).set_estimate(0, 3);
-            values.dim(0).set_estimate(0, 192)
-                   .dim(1).set_estimate(0, 320)
-                   .dim(2).set_estimate(0, 3);
-            slice_loc.dim(0).set_estimate(0, 1536)
-                   .dim(1).set_estimate(0, 2560)
-                   .dim(2).set_estimate(0, 3);
-            output.dim(0).set_estimate(0, 1536)
-                   .dim(1).set_estimate(0, 2560)
-                   .dim(2).set_estimate(0, 3);
+            splat_loc.dim(0).set_estimate(0, 192);
+            splat_loc.dim(1).set_estimate(0, 320);
+            splat_loc.dim(2).set_estimate(0, 3);
+            values.dim(0).set_estimate(0, 192);
+            values.dim(1).set_estimate(0, 320);
+            values.dim(2).set_estimate(0, 3);
+            slice_loc.dim(0).set_estimate(0, 1536);
+            slice_loc.dim(1).set_estimate(0, 2560);
+            slice_loc.dim(2).set_estimate(0, 3);
+            output.dim(0).set_estimate(0, 1536);
+            output.dim(1).set_estimate(0, 2560);
+            output.dim(2).set_estimate(0, 3);
         }
     }
 };

--- a/apps/bgu/bgu_generator.cpp
+++ b/apps/bgu/bgu_generator.cpp
@@ -507,7 +507,7 @@ public:
                     histogram
                         .update()
                         .split(x, xo, xi, 16)
-                        .reorder(xi, c, r.x, r.y, xo, y, c)
+                        .reorder(xi, c, r.x, r.y, xo, y)
                         .unroll(c)
                         .gpu_blocks(xo, y)
                         .gpu_threads(xi);

--- a/apps/bgu/filter.cpp
+++ b/apps/bgu/filter.cpp
@@ -1,0 +1,107 @@
+#include <cstdio>
+#include <random>
+
+#include "bgu.h"
+#include "bgu_auto_schedule.h"
+
+#include "halide_benchmark.h"
+#include "halide_image_io.h"
+
+#include "HalideBuffer.h"
+
+using namespace Halide::Tools;
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        printf("Usage: %s in out\n", argv[0]);
+        return 1;
+    }
+
+    const float r_sigma = 1.f / 8.f;
+    const int s_sigma = 16;
+
+    // Bilateral-guided upsampling (BGU) is used for cheaply
+    // transferring some effect applied to a low-res image to a
+    // high-res input. We'll make a low-res version of the input,
+    // sharpen and contrast-enhance it naively, and then call into the
+    // Halide BGU implementation to apply the same effect to the
+    // original high-res input. We're only interested in benchmarking
+    // the last part.
+
+    // BGU will be good at capturing the contrast enhancement and
+    // vignette, and bad at capturing the high-frequency sharpening.
+
+    Halide::Runtime::Buffer<float> high_res_in = load_and_convert_image(argv[1]);
+    const int W = high_res_in.width();
+    const int H = high_res_in.height();
+    const int C = high_res_in.channels();
+
+    Halide::Runtime::Buffer<float> high_res_out(W, H, C);
+    Halide::Runtime::Buffer<float> low_res_in(W/8, H/8, C);
+    Halide::Runtime::Buffer<float> low_res_out(W/8, H/8, C);
+
+    // Downsample the input with a box filter
+    low_res_in.fill(0.0f);
+    low_res_in.for_each_element([&](int x, int y, int c) {
+            float sum = 0.0f;
+            for (int sy = y*8; sy < y*8 + 8; sy++) {
+                for (int sx = x*8; sx < x*8 + 8; sx++) {
+                    sum += high_res_in(sx, sy, c);
+                }
+            }
+            low_res_in(x, y, c) = sum / 64;
+        });
+
+    // Some straw-man black-box image processing algorithm we're
+    // trying to accelerate.
+    low_res_in.for_each_element([&](int x, int y, int c) {
+            float val;
+            // Sharpen, ignoring edges
+            if (x == 0 || x == W - 1 || y == 0 || y == H - 1) {
+                val = low_res_in(x, y, c);
+            } else {
+                val =
+                    (2*low_res_in(x, y, c) -
+                     (low_res_in(x-1, y, c) +
+                      low_res_in(x+1, y, c) +
+                      low_res_in(x, y-1, c) +
+                      low_res_in(x, y+1, c))/4);
+            }
+            // Smoothstep for contrast enhancement
+            float boosted = val * val * (3 - 2 * val);
+
+            // We'll only boost the center of the image. The center of
+            // the low-res image is at W/16, H/16
+            float r = std::min(W/16, H/16);
+            float mask_x = (x - W/16) / r;
+            float mask_y = (y - H/16) / r;
+            float mask = std::sqrt(mask_x * mask_x + mask_y * mask_y);
+            val = val * mask + boosted * (1 - mask);
+
+            // Also apply a vignette.
+            val *= (2 - mask) / 2;
+
+            // Clamp to range
+            val = std::max(std::min(val, 1.0f), 0.0f);
+            low_res_out(x, y, c) = val;
+        });
+
+    // To view the low res output for debugging the algorithm above
+    // convert_and_save_image(low_res_out, "test.png");
+
+    double best_manual = benchmark([&]() {
+        bgu(r_sigma, s_sigma, low_res_in, low_res_out, high_res_in, high_res_out);
+        high_res_out.device_sync();
+    });
+    printf("Manually-tuned time: %gms\n", best_manual * 1e3);
+
+    double best_auto = benchmark([&]() {
+        bgu_auto_schedule(r_sigma, s_sigma, low_res_in, low_res_out, high_res_in, high_res_out);
+        high_res_out.device_sync();
+    });
+    printf("Auto-scheduled time: %gms\n", best_auto * 1e3);
+
+    convert_and_save_image(high_res_out, argv[2]);
+
+    return 0;
+}

--- a/apps/bgu/filter.cpp
+++ b/apps/bgu/filter.cpp
@@ -37,54 +37,55 @@ int main(int argc, char **argv) {
     const int C = high_res_in.channels();
 
     Halide::Runtime::Buffer<float> high_res_out(W, H, C);
-    Halide::Runtime::Buffer<float> low_res_in(W/8, H/8, C);
-    Halide::Runtime::Buffer<float> low_res_out(W/8, H/8, C);
+    Halide::Runtime::Buffer<float> low_res_in(W / 8, H / 8, C);
+    Halide::Runtime::Buffer<float> low_res_out(W / 8, H / 8, C);
 
     // Downsample the input with a box filter
     low_res_in.fill(0.0f);
     low_res_in.for_each_element([&](int x, int y, int c) {
-            float sum = 0.0f;
-            for (int sy = y*8; sy < y*8 + 8; sy++) {
-                for (int sx = x*8; sx < x*8 + 8; sx++) {
-                    sum += high_res_in(sx, sy, c);
-                }
+        float sum = 0.0f;
+        for (int sy = y * 8; sy < y * 8 + 8; sy++) {
+            for (int sx = x * 8; sx < x * 8 + 8; sx++) {
+                sum += high_res_in(sx, sy, c);
             }
-            low_res_in(x, y, c) = sum / 64;
-        });
+        }
+        low_res_in(x, y, c) = sum / 64;
+    });
 
     // Some straw-man black-box image processing algorithm we're
     // trying to accelerate.
     low_res_in.for_each_element([&](int x, int y, int c) {
-            float val;
-            // Sharpen, ignoring edges
-            if (x == 0 || x == W - 1 || y == 0 || y == H - 1) {
-                val = low_res_in(x, y, c);
-            } else {
-                val =
-                    (2*low_res_in(x, y, c) -
-                     (low_res_in(x-1, y, c) +
-                      low_res_in(x+1, y, c) +
-                      low_res_in(x, y-1, c) +
-                      low_res_in(x, y+1, c))/4);
-            }
-            // Smoothstep for contrast enhancement
-            float boosted = val * val * (3 - 2 * val);
+        float val;
+        // Sharpen, ignoring edges
+        if (x == 0 || x == W - 1 || y == 0 || y == H - 1) {
+            val = low_res_in(x, y, c);
+        } else {
+            val =
+                (2 * low_res_in(x, y, c) -
+                 (low_res_in(x - 1, y, c) +
+                  low_res_in(x + 1, y, c) +
+                  low_res_in(x, y - 1, c) +
+                  low_res_in(x, y + 1, c)) /
+                     4);
+        }
+        // Smoothstep for contrast enhancement
+        float boosted = val * val * (3 - 2 * val);
 
-            // We'll only boost the center of the image. The center of
-            // the low-res image is at W/16, H/16
-            float r = std::min(W/16, H/16);
-            float mask_x = (x - W/16) / r;
-            float mask_y = (y - H/16) / r;
-            float mask = std::sqrt(mask_x * mask_x + mask_y * mask_y);
-            val = val * mask + boosted * (1 - mask);
+        // We'll only boost the center of the image. The center of
+        // the low-res image is at W/16, H/16
+        float r = std::min(W / 16, H / 16);
+        float mask_x = (x - W / 16) / r;
+        float mask_y = (y - H / 16) / r;
+        float mask = std::sqrt(mask_x * mask_x + mask_y * mask_y);
+        val = val * mask + boosted * (1 - mask);
 
-            // Also apply a vignette.
-            val *= (2 - mask) / 2;
+        // Also apply a vignette.
+        val *= (2 - mask) / 2;
 
-            // Clamp to range
-            val = std::max(std::min(val, 1.0f), 0.0f);
-            low_res_out(x, y, c) = val;
-        });
+        // Clamp to range
+        val = std::max(std::min(val, 1.0f), 0.0f);
+        low_res_out(x, y, c) = val;
+    });
 
     // To view the low res output for debugging the algorithm above
     // convert_and_save_image(low_res_out, "test.png");

--- a/apps/hist/CMakeLists.txt
+++ b/apps/hist/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_executable(hist_filter filter.cpp)
+halide_use_image_io(hist_filter)
+
+halide_generator(hist.generator SRCS hist_generator.cpp)
+foreach(AUTO_SCHEDULE false true)
+    if(${AUTO_SCHEDULE})
+        set(LIB hist_auto_schedule)
+    else()
+        set(LIB hist)
+    endif()
+    halide_library_from_generator(${LIB}
+                                  GENERATOR hist.generator
+                                  GENERATOR_ARGS auto_schedule=${AUTO_SCHEDULE})
+    target_link_libraries(hist_filter PRIVATE ${LIB})
+endforeach()

--- a/apps/hist/Makefile
+++ b/apps/hist/Makefile
@@ -1,0 +1,31 @@
+include ../support/Makefile.inc
+
+all: $(BIN)/$(HL_TARGET)/filter
+
+test: $(BIN)/$(HL_TARGET)/out.png
+
+$(GENERATOR_BIN)/hist.generator: hist_generator.cpp $(GENERATOR_DEPS)
+	@mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS) -g $(filter %.cpp,$^) -o $@ $(GENERATOR_LDFLAGS)
+
+$(BIN)/%/hist.a: $(GENERATOR_BIN)/hist.generator
+	@mkdir -p $(@D)
+	$< -g hist -f hist -o $(BIN)/$* target=$*-no_runtime auto_schedule=false
+
+$(BIN)/%/hist_auto_schedule.a: $(GENERATOR_BIN)/hist.generator
+	@mkdir -p $(@D)
+	$< -g hist -f hist_auto_schedule -o $(BIN)/$* target=$*-no_runtime auto_schedule=true
+
+$(BIN)/%/runtime.a: $(GENERATOR_BIN)/hist.generator
+	@mkdir -p $(@D)
+	$< -r runtime -o $(BIN)/$* target=$*
+
+$(BIN)/%/filter: filter.cpp $(BIN)/%/hist.a $(BIN)/%/hist_auto_schedule.a $(BIN)/%/runtime.a
+	@mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS) -I$(BIN)/$* -Wall -O3 $^ -o $@ $(LDFLAGS) $(IMAGE_IO_FLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS)
+
+$(BIN)/%/out.png: $(BIN)/%/filter
+	$< ../images/rgba.png $(BIN)/$*/out.png
+
+clean:
+	rm -rf $(BIN)

--- a/apps/hist/filter.cpp
+++ b/apps/hist/filter.cpp
@@ -1,0 +1,40 @@
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+
+#include "HalideBuffer.h"
+#include "HalideRuntime.h"
+
+#include "hist.h"
+#include "hist_auto_schedule.h"
+
+#include "halide_benchmark.h"
+#include "halide_image_io.h"
+
+using namespace Halide::Tools;
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        printf("Usage: %s in out\n", argv[0]);
+        return 1;
+    }
+
+    Halide::Runtime::Buffer<uint8_t> input = load_and_convert_image(argv[1]);
+    Halide::Runtime::Buffer<uint8_t> output(input.width(), input.height(), 3);
+
+    double best_manual = benchmark([&]() {
+        hist(input, output);
+        output.device_sync();
+    });
+    printf("Manually-tuned time: %gms\n", best_manual * 1e3);
+
+    double best_auto = benchmark([&]() {
+        hist_auto_schedule(input, output);
+        output.device_sync();
+    });
+    printf("Auto-scheduled time: %gms\n", best_auto * 1e3);
+
+    convert_and_save_image(output, argv[2]);
+
+    return 0;
+}

--- a/apps/hist/hist_generator.cpp
+++ b/apps/hist/hist_generator.cpp
@@ -6,7 +6,7 @@ using namespace Halide::ConciseCasts;
 
 class Hist : public Halide::Generator<Hist> {
 public:
-    Input<Buffer<uint8_t>>  input{"input", 3};
+    Input<Buffer<uint8_t>> input{"input", 3};
     Output<Buffer<uint8_t>> output{"output", 3};
 
     void generate() {
@@ -45,24 +45,23 @@ public:
         Func eq("equalize");
 
         Expr cdf_bin = u8(clamp(Y(x, y), 0, 255));
-        eq(x, y) = clamp(cdf(cdf_bin) * (255.0f/(input.height() * input.width())), 0, 255);
+        eq(x, y) = clamp(cdf(cdf_bin) * (255.0f / (input.height() * input.width())), 0, 255);
 
         Expr red = u8(clamp(eq(x, y) + (Cr(x, y) - 128) * 1.4f, 0, 255));
-        Expr green = u8(clamp(eq(x, y) - 0.343f * (Cb(x, y) - 128) - 0.711f * (Cr(x, y) -128), 0, 255));
+        Expr green = u8(clamp(eq(x, y) - 0.343f * (Cb(x, y) - 128) - 0.711f * (Cr(x, y) - 128), 0, 255));
         Expr blue = u8(clamp(eq(x, y) + 1.765f * (Cb(x, y) - 128), 0, 255));
         output(x, y, c) = select(c == 0, red,
                                  c == 1, green,
-                                         blue);
-
+                                 blue);
 
         // Estimates (for autoscheduler; ignored otherwise)
         {
-            input.dim(0).set_estimate(0, 1536)
-                 .dim(1).set_estimate(0, 2560)
-                 .dim(2).set_estimate(0, 3);
-            output.dim(0).set_estimate(0, 1536)
-                  .dim(1).set_estimate(0, 2560)
-                  .dim(2).set_estimate(0, 3);
+            input.dim(0).set_estimate(0, 1536);
+            input.dim(1).set_estimate(0, 2560);
+            input.dim(2).set_estimate(0, 3);
+            output.dim(0).set_estimate(0, 1536);
+            output.dim(1).set_estimate(0, 2560);
+            output.dim(2).set_estimate(0, 3);
         }
 
         // Schedule

--- a/apps/hist/hist_generator.cpp
+++ b/apps/hist/hist_generator.cpp
@@ -1,0 +1,115 @@
+#include "Halide.h"
+
+namespace {
+
+using namespace Halide::ConciseCasts;
+
+class Hist : public Halide::Generator<Hist> {
+public:
+    Input<Buffer<uint8_t>>  input{"input", 3};
+    Output<Buffer<uint8_t>> output{"output", 3};
+
+    void generate() {
+        Var x("x"), y("y"), c("c");
+
+        // Algorithm
+        Func Y("Y");
+        Y(x, y) = 0.299f * input(x, y, 0) + 0.587f * input(x, y, 1)
+                  + 0.114f * input(x, y, 2);
+
+        Func Cr("Cr");
+        Expr R = input(x, y, 0);
+        Cr(x, y) = (R - Y(x, y)) * 0.713f + 128;
+
+        Func Cb("Cb");
+        Expr B = input(x, y, 2);
+        Cb(x, y) = (B - Y(x, y)) * 0.564f + 128;
+
+        Func hist_rows("hist_rows");
+        hist_rows(x, y) = 0;
+        RDom rx(0, 1536);
+        Expr bin = cast<int>(clamp(Y(rx, y), 0, 255));
+        hist_rows(bin, y) += 1;
+
+        Func hist("hist");
+        hist(x) = 0;
+        RDom ry(0, 2560);
+        hist(x) += hist_rows(x, ry);
+
+        Func cdf("cdf");
+        cdf(x) = hist(0);
+        RDom b(1, 255);
+        cdf(b.x) = cdf(b.x - 1) + hist(b.x);
+
+        Func eq("equalize");
+
+        Expr cdf_bin = u8(clamp(Y(x, y), 0, 255));
+        eq(x, y) = clamp(cdf(cdf_bin) * (255.0f/(input.height() * input.width())), 0 , 255);
+
+        Expr red = u8(clamp(eq(x, y) + (Cr(x, y) - 128) * 1.4f, 0, 255));
+        Expr green = u8(clamp(eq(x, y) - 0.343f * (Cb(x, y) - 128) - 0.711f * (Cr(x, y) -128), 0, 255));
+        Expr blue = u8(clamp(eq(x, y) + 1.765f * (Cb(x, y) - 128), 0, 255));
+        output(x, y, c) = select(c == 0, red,
+                                 c == 1, green,
+                                         blue);
+
+
+        // Estimates (for autoscheduler; ignored otherwise)
+        {
+            input.dim(0).set_estimate(0, 1536)
+                 .dim(1).set_estimate(0, 2560)
+                 .dim(2).set_estimate(0, 3);
+            output.dim(0).set_estimate(0, 1536)
+                  .dim(1).set_estimate(0, 2560)
+                  .dim(2).set_estimate(0, 3);
+        }
+
+        // Schedule
+        if (!auto_schedule) {
+            cdf.bound(x, 0, 256);
+
+            Var xi("xi"), yi("yi");
+            if (get_target().has_gpu_feature()) {
+                Y.compute_root().gpu_tile(x, y, xi, yi, 16, 16);
+                hist_rows.compute_root().gpu_tile(y, yi, 16).update().gpu_tile(y, yi, 16);
+                hist.compute_root().gpu_tile(x, xi, 16).update().gpu_tile(x, xi, 16);
+                cdf.compute_root().gpu_single_thread();
+                Cr.compute_at(output, x);
+                Cb.compute_at(output, x);
+                eq.compute_at(output, x);
+                output.compute_root()
+                      .reorder(c, x, y).bound(c, 0, 3).unroll(c)
+                      .gpu_tile(x, y, xi, yi, 16, 16);
+            } else {
+                Y.compute_root().parallel(y, 8).vectorize(x, 8);
+                hist_rows.compute_root()
+                    .vectorize(x, 8)
+                    .parallel(y, 8)
+                    .update()
+                    .parallel(y, 8);
+                hist.compute_root()
+                    .vectorize(x, 8)
+                    .update()
+                    .reorder(x, ry)
+                    .vectorize(x, 8)
+                    .unroll(x, 4)
+                    .parallel(x)
+                    .reorder(ry, x);
+
+                cdf.compute_root();
+                eq.compute_at(output, x).unroll(x);
+                Cb.compute_at(output, x).vectorize(x);
+                Cr.compute_at(output, x).vectorize(x);
+                output.reorder(c, x, y)
+                      .bound(c, 0, 3)
+                      .unroll(c)
+                      .parallel(y, 8)
+                      .vectorize(x, 8);
+            }
+        }
+    }
+};
+
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(Hist, hist)

--- a/apps/max_filter/CMakeLists.txt
+++ b/apps/max_filter/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_executable(max_filter_filter filter.cpp)
+halide_use_image_io(max_filter_filter)
+
+halide_generator(max_filter.generator SRCS max_filter_generator.cpp)
+foreach(AUTO_SCHEDULE false true)
+    if(${AUTO_SCHEDULE})
+        set(LIB max_filter_auto_schedule)
+    else()
+        set(LIB max_filter)
+    endif()
+    halide_library_from_generator(${LIB}
+                                  GENERATOR max_filter.generator
+                                  GENERATOR_ARGS auto_schedule=${AUTO_SCHEDULE})
+    target_link_libraries(max_filter_filter PRIVATE ${LIB})
+endforeach()

--- a/apps/max_filter/Makefile
+++ b/apps/max_filter/Makefile
@@ -1,0 +1,31 @@
+include ../support/Makefile.inc
+
+all: $(BIN)/$(HL_TARGET)/filter
+
+test: $(BIN)/$(HL_TARGET)/out.png
+
+$(GENERATOR_BIN)/max_filter.generator: max_filter_generator.cpp $(GENERATOR_DEPS)
+	@mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS) -g $(filter %.cpp,$^) -o $@ $(GENERATOR_LDFLAGS)
+
+$(BIN)/%/max_filter.a: $(GENERATOR_BIN)/max_filter.generator
+	@mkdir -p $(@D)
+	$< -g max_filter -f max_filter -o $(BIN)/$* target=$*-no_runtime auto_schedule=false
+
+$(BIN)/%/max_filter_auto_schedule.a: $(GENERATOR_BIN)/max_filter.generator
+	@mkdir -p $(@D)
+	$< -g max_filter -f max_filter_auto_schedule -o $(BIN)/$* target=$*-no_runtime auto_schedule=true
+
+$(BIN)/%/runtime.a: $(GENERATOR_BIN)/max_filter.generator
+	@mkdir -p $(@D)
+	$< -r runtime -o $(BIN)/$* target=$*
+
+$(BIN)/%/filter: filter.cpp $(BIN)/%/max_filter.a $(BIN)/%/max_filter_auto_schedule.a $(BIN)/%/runtime.a
+	@mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS) -I$(BIN)/$* -Wall -O3 $^ -o $@ $(LDFLAGS) $(IMAGE_IO_FLAGS) $(CUDA_LDFLAGS) $(OPENCL_LDFLAGS) $(OPENGL_LDFLAGS)
+
+$(BIN)/%/out.png: $(BIN)/%/filter
+	$< ../images/rgba.png $(BIN)/$*/out.png
+
+clean:
+	rm -rf $(BIN)

--- a/apps/max_filter/filter.cpp
+++ b/apps/max_filter/filter.cpp
@@ -1,0 +1,40 @@
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+
+#include "HalideBuffer.h"
+#include "HalideRuntime.h"
+
+#include "max_filter.h"
+#include "max_filter_auto_schedule.h"
+
+#include "halide_benchmark.h"
+#include "halide_image_io.h"
+
+using namespace Halide::Tools;
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        printf("Usage: %s in out\n", argv[0]);
+        return 1;
+    }
+
+    Halide::Runtime::Buffer<float> input = load_and_convert_image(argv[1]);
+    Halide::Runtime::Buffer<float> output(input.width(), input.height(), 3);
+
+    double best_manual = benchmark([&]() {
+        max_filter(input, output);
+        output.device_sync();
+    });
+    printf("Manually-tuned time: %gms\n", best_manual * 1e3);
+
+    double best_auto = benchmark([&]() {
+        max_filter_auto_schedule(input, output);
+        output.device_sync();
+    });
+    printf("Auto-scheduled time: %gms\n", best_auto * 1e3);
+
+    convert_and_save_image(output, argv[2]);
+
+    return 0;
+}

--- a/apps/max_filter/max_filter_generator.cpp
+++ b/apps/max_filter/max_filter_generator.cpp
@@ -57,7 +57,7 @@ public:
         {
             input_.dim(0).set_estimate(0, 1536);
             input_.dim(1).set_estimate(0, 2560);
-            intput_.dim(2).set_estimate(0, 3);
+            input_.dim(2).set_estimate(0, 3);
             output_.dim(0).set_estimate(0, 1536);
             output_.dim(1).set_estimate(0, 2560);
             output_.dim(2).set_estimate(0, 3);

--- a/apps/max_filter/max_filter_generator.cpp
+++ b/apps/max_filter/max_filter_generator.cpp
@@ -1,0 +1,112 @@
+#include "Halide.h"
+
+namespace {
+
+using namespace Halide::ConciseCasts;
+
+class Max : public Halide::Generator<Max> {
+public:
+    GeneratorParam<int>     radius_{"radius", 26};
+    Input<Buffer<float>>    input_{"input", 3};
+    Output<Buffer<float>>   output_{"output", 3};
+
+    void generate() {
+        Var x("x"), y("y"), c("c"), t("t");
+
+        Func input = Halide::BoundaryConditions::repeat_edge(input_);
+
+        const int radius = radius_;
+        const int slices = (int)(ceilf(logf(radius) / logf(2))) + 1;
+
+        // A sequence of vertically-max-filtered versions of the input,
+        // each filtered twice as tall as the previous slice. All filters
+        // are downward-looking.
+        Func vert_log("vert_log");
+        vert_log(x, y, c, t) = input(x, y, c);
+        RDom r(-radius, input_.height() + radius, 1, slices-1);
+        vert_log(x, r.x, c, r.y) = max(vert_log(x, r.x, c, r.y - 1),
+                                       vert_log(x, r.x + clamp((1<<(r.y-1)), 0, radius*2), c, r.y - 1));
+
+        // We're going to take a max filter of arbitrary diameter
+        // by maxing two samples from its floor log 2 (e.g. maxing two
+        // 8-high overlapping samples). This next Func tells us which
+        // slice to draw from for a given radius:
+        Func slice_for_radius("slice_for_radius");
+        slice_for_radius(t) = cast<int>(floor(log(2*t+1) / logf(2)));
+
+        // Produce every possible vertically-max-filtered version of the image:
+        Func vert("vert");
+        // t is the blur radius
+        Expr slice = clamp(slice_for_radius(t), 0, slices);
+        Expr first_sample = vert_log(x, y - t, c, slice);
+        Expr second_sample = vert_log(x, y + t + 1 - clamp(1 << slice, 0, 2*radius), c, slice);
+        vert(x, y, c, t) = max(first_sample, second_sample);
+
+        Func filter_height("filter_height");
+        RDom dy(0, radius+1);
+        filter_height(x) = sum(select(x*x + dy*dy < (radius+0.25f)*(radius+0.25f), 1, 0));
+
+        // Now take an appropriate horizontal max of them at each output pixel
+        RDom dx(-radius, 2*radius+1);
+        output_(x, y, c) = maximum(vert(x + dx, y, c, clamp(filter_height(dx), 0, radius+1)));
+
+        // Estimates (for autoscheduler; ignored otherwise)
+        {
+            input_.dim(0).set_estimate(0, 1536)
+                  .dim(1).set_estimate(0, 2560)
+                  .dim(2).set_estimate(0, 3);
+            output_.dim(0).set_estimate(0, 1536)
+                  .dim(1).set_estimate(0, 2560)
+                  .dim(2).set_estimate(0, 3);
+        }
+
+        // Schedule
+        if (!auto_schedule) {
+            if (get_target().has_gpu_feature()) {
+                slice_for_radius.compute_root();
+                filter_height.compute_root();
+                Var xi, xo, yi;
+
+                output_
+                    .split(x, xo, xi, 128)
+                    .reorder(xi, xo, y, c)
+                    .gpu_blocks(xo, y, c).gpu_threads(xi);
+
+                vert_log.compute_root()
+                    .reorder(c, t, x, y)
+                    .gpu_tile(x, y, xi, yi, 16, 16)
+                    .update()
+                    .split(x, xo, xi, 128)
+                    .reorder(r.x, r.y, xi, xo, c)
+                    .gpu_blocks(xo, c).gpu_threads(xi);
+            } else {
+                Var tx;
+                // These don't matter, just LUTs
+                slice_for_radius.compute_root();
+                filter_height.compute_root();
+
+                // vert_log.update(1) doesn't have enough parallelism, but I
+                // can't figure out how to give it more... Split whole image
+                // into slices.
+
+                output_.compute_root()
+                    .split(x, tx, x, 256)
+                    .reorder(x, y, c, tx)
+                    .fuse(c, tx, t)
+                    .parallel(t)
+                    .vectorize(x, 8);
+                vert_log.compute_at(output_, t);
+                vert_log.vectorize(x, 8);
+                vert_log.update()
+                    .reorder(x, r.x, r.y, c)
+                    .vectorize(x, 8);
+                vert.compute_at(output_, y)
+                    .vectorize(x, 8);
+            }
+        }
+    }
+};
+
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(Max, max_filter)

--- a/apps/max_filter/max_filter_generator.cpp
+++ b/apps/max_filter/max_filter_generator.cpp
@@ -66,6 +66,8 @@ public:
         // Schedule
         if (!auto_schedule) {
             if (get_target().has_gpu_feature()) {
+                // 11.8ms on a 2060 RTX
+
                 slice_for_radius.compute_root();
                 filter_height.compute_root();
                 Var xi, xo, yi;
@@ -84,6 +86,8 @@ public:
                     .gpu_blocks(xo, c).gpu_threads(xi);
 
             } else {
+                // 47ms on an Intel i9-9960X using 16 threads
+
                 Var tx;
                 // These don't matter, just LUTs
                 slice_for_radius.compute_root();

--- a/tools/halide_benchmark.h
+++ b/tools/halide_benchmark.h
@@ -154,7 +154,7 @@ inline BenchmarkResult benchmark(std::function<void()> op, const BenchmarkConfig
     // We will do (at least) kMinSamples samples; we will do additional
     // samples until the best the kMinSamples'th results are within the
     // accuracy tolerance (or we run out of iterations).
-    constexpr int kMinSamples = 3;
+    constexpr int kMinSamples = 5;
     double times[kMinSamples + 1] = {0};
 
     double total_time = 0;

--- a/tools/halide_benchmark.h
+++ b/tools/halide_benchmark.h
@@ -154,7 +154,7 @@ inline BenchmarkResult benchmark(std::function<void()> op, const BenchmarkConfig
     // We will do (at least) kMinSamples samples; we will do additional
     // samples until the best the kMinSamples'th results are within the
     // accuracy tolerance (or we run out of iterations).
-    constexpr int kMinSamples = 5;
+    constexpr int kMinSamples = 3;
     double times[kMinSamples + 1] = {0};
 
     double total_time = 0;


### PR DESCRIPTION
This batch is bilateral-guided-upsampling, max_filter, and histogram equalization. I believe this pulls over all of the apps from the autoscheduling 2018 siggraph paper into master, where they can be used as benchmarks in future papers.