### PR TITLE
Reschedule conv layer

### DIFF
--- a/apps/conv_layer/Makefile
+++ b/apps/conv_layer/Makefile
@@ -12,7 +12,7 @@ $(BIN)/%/conv_layer.a: $(GENERATOR_BIN)/conv_layer.generator
 
 $(BIN)/%/conv_layer_auto_schedule.a: $(GENERATOR_BIN)/conv_layer.generator
 	@mkdir -p $(@D)
-	$^ -g conv_layer -e $(GENERATOR_OUTPUTS) -o $(@D) -f conv_layer_auto_schedule target=$*-no_runtime auto_schedule=true -p ../autoscheduler/bin/libauto_schedule.so -s Adams2019
+	$^ -g conv_layer -e $(GENERATOR_OUTPUTS) -o $(@D) -f conv_layer_auto_schedule target=$*-no_runtime auto_schedule=true
 
 $(BIN)/%/process: process.cpp $(BIN)/%/conv_layer.a $(BIN)/%/conv_layer_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/conv_layer/Makefile
+++ b/apps/conv_layer/Makefile
@@ -12,7 +12,7 @@ $(BIN)/%/conv_layer.a: $(GENERATOR_BIN)/conv_layer.generator
 
 $(BIN)/%/conv_layer_auto_schedule.a: $(GENERATOR_BIN)/conv_layer.generator
 	@mkdir -p $(@D)
-	$^ -g conv_layer -e $(GENERATOR_OUTPUTS) -o $(@D) -f conv_layer_auto_schedule target=$*-no_runtime auto_schedule=true
+	$^ -g conv_layer -e $(GENERATOR_OUTPUTS) -o $(@D) -f conv_layer_auto_schedule target=$*-no_runtime auto_schedule=true -p ../autoscheduler/bin/libauto_schedule.so -s Adams2019
 
 $(BIN)/%/process: process.cpp $(BIN)/%/conv_layer.a $(BIN)/%/conv_layer_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/conv_layer/conv_layer_generator.cpp
+++ b/apps/conv_layer/conv_layer_generator.cpp
@@ -10,72 +10,174 @@ public:
     Input<Buffer<float>> filter{"filter", 4};
     Input<Buffer<float>> bias{"bias", 1};
 
-    Output<Buffer<float>> f_ReLU{"ReLU", 4};
+    Output<Buffer<float>> relu{"relu", 4};
 
     void generate() {
+        const int N = 5, CI = 128, CO = 128, W = 100, H = 80;
+
         /* THE ALGORITHM */
 
-        Var x("x"), y("y"), z("z"), n("n");
+        Var x("x"), y("y"), c("c"), n("n");
 
-        Func f_conv("conv");
-        RDom r(filter.dim(0).min(), filter.dim(0).extent(),
-               filter.dim(1).min(), filter.dim(1).extent(),
-               filter.dim(2).min(), filter.dim(2).extent());
+        Func conv("conv");
+        RDom r(0, CI, 0, 3, 0, 3);
 
-        f_conv(x, y, z, n) = bias(z);
+        conv(c, x, y, n) = bias(c);
+        conv(c, x, y, n) += filter(c, r.y, r.z, r.x) * input(r.x, x + r.y, y + r.z, n);
 
-        f_conv(x, y, z, n) += filter(r.x, r.y, r.z, z) * input(x + r.x, y + r.y, r.z, n);
-
-        f_ReLU(x, y, z, n) = max(0, f_conv(x, y, z, n));
+        relu(c, x, y, n) = max(0, conv(c, x, y, n));
 
         /* THE SCHEDULE */
 
-        if (auto_schedule) {
-            // Provide estimates on the input image
-            input.set_estimates({{0, 131}, {0, 131}, {0, 64}, {0, 4}});
-            filter.set_estimates({{0, 3}, {0, 3}, {0, 64}, {0, 64}});
-            bias.set_estimates({{0, 64}});
-            f_ReLU.set_estimates({{0, 128}, {0, 128}, {0, 64}, {0, 4}});
+        // MKL JITs code for the specific size and strides, so we'll
+        // do the same and ask Halide to compile for this specific
+        // size:
+        relu.bound(x, 0, W)
+            .bound(y, 0, H)
+            .bound(c, 0, CO)
+            .bound(n, 0, N);
 
-        } /*else if (get_target().has_gpu_feature()) {
-            // TODO: Turn off the manual GPU schedule for now.
-            // For some reasons, it sometimes triggers the (err == CL_SUCCESS)
-            // assertion on mingw.
-            Var ni, no, xi, xo, yi, yo, zi, zo;
-            f_ReLU.compute_root()
+        relu.dim(0).set_bounds(0, CO).set_stride(1)
+            .dim(1).set_bounds(0, W).set_stride(CO)
+            .dim(2).set_bounds(0, H).set_stride(CO * W)
+            .dim(3).set_bounds(0, N).set_stride(CO * H * W);
+
+        input.dim(0).set_bounds(0, CI).set_stride(1)
+            .dim(1).set_bounds(0, W + 2).set_stride(CI)
+            .dim(2).set_bounds(0, H + 2).set_stride(CI * (W + 2))
+            .dim(3).set_bounds(0, N).set_stride(CI * (W + 2) * (H + 2));
+
+        filter.dim(0).set_bounds(0, CO).set_stride(1)
+            .dim(1).set_bounds(0, 3).set_stride(CO)
+            .dim(2).set_bounds(0, 3).set_stride(CO * 3)
+            .dim(3).set_bounds(0, CI).set_stride(CO * 3 * 3);
+
+        bias.dim(0).set_bounds(0, CO).set_stride(1);
+
+        if (auto_schedule) {
+            input.dim(0).set_estimate(0, CI);
+            input.dim(1).set_estimate(0, W + 2);
+            input.dim(2).set_estimate(0, H + 2);
+            input.dim(3).set_estimate(0, N);
+
+            filter.dim(0).set_estimate(0, CO);
+            filter.dim(1).set_estimate(0, 3);
+            filter.dim(2).set_estimate(0, 3);
+            filter.dim(3).set_estimate(0, CI);
+
+            bias.dim(0).set_estimate(0, CO);
+
+            relu.dim(0).set_estimate(0, W);
+            relu.dim(1).set_estimate(0, H);
+            relu.dim(2).set_estimate(0, CO);
+            relu.dim(3).set_estimate(0, N);
+
+        } else if (get_target().has_gpu_feature()) {
+            // A basic GPU schedule. Could use some more work - it's
+            // currently slower than the CPU schedule!  Currently does
+            // no staging of inputs.
+            Var ni, no, xi, xo, yi, yo, ci, co, t;
+            RVar rxo, rxi;
+            relu.compute_root()
                 .split(x, xo, xi, 4)
                 .split(y, yo, yi, 4)
-                .split(z, zo, zi, 4)
-                .reorder(xi, yi, zi, n, xo, yo, zo)
-                .gpu_threads(xi, yi, zi)
-                .gpu_blocks(xo, yo, zo);
+                .split(c, co, ci, 32)
+                .reorder(xi, yi, ci, xo, yo, co, n)
+                .gpu_lanes(ci)
+                .unroll(xi)
+                .unroll(yi)
+                .fuse(co, n, t)
+                .gpu_blocks(xo, yo, t);
 
-            f_conv.compute_at(f_ReLU, n)
-                .gpu_threads(x, y, z)
+            conv.compute_at(relu, xo)
+                .store_in(MemoryType::Register)
+                .gpu_lanes(c)
+                .unroll(x)
+                .unroll(y)
                 .update()
-                .unroll(r.x, 3)
-                .unroll(r.y, 3)
-                .gpu_threads(x, y, z);
-        }*/
-        else {
-            // Blocking spatially with vectorization
-            Var z_t("z_t"), y_t("y_t"), par("par");
-            int vec_len = 8;
-            int o_block_size = 32;
-            int y_block = 32;
-            f_conv.compute_root();
-            f_conv.fuse(z, n, par).parallel(par);
-            f_conv.update()
-                .reorder(x, y, r.z)
-                .split(y, y, y_t, y_block)
-                .split(z, z, z_t, o_block_size)
-                .reorder(y_t, z_t, y, r.z, z)
-                .vectorize(x, vec_len)
-                .unroll(r.x, 3)
-                .unroll(r.y, 3)
-                .fuse(z, n, par)
-                .parallel(par);
-            f_ReLU.reorder(n, z).parallel(z).vectorize(x, 8);
+                .gpu_lanes(c)
+                .reorder(c, x, y, r.y, r.z, r.x)
+                .unroll(x)
+                .unroll(y)
+                .unroll(r.y)
+                .unroll(r.z)
+                .split(r.x, rxo, rxi, 32);
+
+            input.in().compute_at(conv, rxo)
+                .store_in(MemoryType::Register)
+                .gpu_lanes(_0)
+                .unroll(_1)
+                .unroll(_2);
+
+        } else if (get_target().has_feature(Target::AVX512_Skylake)) {
+            // On Skylake we have one load per fma and there are more
+            // registers available, so there's considerable
+            // flexibility in the schedule. We'll use 20 accumulator
+            // registers in a 4x5 tile.
+            Var co, ci, xo, xi, yo, yi, t;
+            relu.split(c, co, ci, 16*4)
+                .split(x, xo, xi, 5)
+                .reorder(ci, xi, xo, y, n, co)
+                .vectorize(ci, 16)
+                .unroll(ci)
+                .unroll(xi)
+                .parallel(y)
+                .parallel(n)
+                .parallel(co);
+            conv.compute_at(relu, xo)
+                .vectorize(c, 16)
+                .unroll(c)
+                .unroll(x)
+                .unroll(y)
+                .update()
+                .reorder(c, x, y, r.x, r.y, r.z, n)
+                .vectorize(c, 16)
+                .unroll(c)
+                .unroll(x)
+                .unroll(y)
+                .unroll(r.x, 2);
+            filter.in()
+                .compute_at(conv, r.x)
+                .vectorize(_0, 16)
+                .unroll(_0)
+                .unroll(_3);
+            input.in()
+                .compute_at(conv, x)
+                .unroll(_0);
+        } else {
+            // With AVX2 only we can only do one load per two fmas,
+            // which constrains the schedule to have to be a squarish
+            // 12-register tile of the output.
+            Var co, ci, xo, xi, yo, yi, t;
+            relu.split(c, co, ci, 24, TailStrategy::GuardWithIf)
+                .split(x, xo, xi, 4)
+                .reorder(ci, xi, xo, y, n, co)
+                .vectorize(ci, 8)
+                .unroll(ci)
+                .unroll(xi)
+                .parallel(y)
+                .parallel(n)
+                .parallel(co);
+            conv.compute_at(relu, xo)
+                .vectorize(c, 8)
+                .unroll(c)
+                .unroll(x)
+                .unroll(y)
+                .update()
+                .reorder(c, x, y, r.x, r.y, r.z, n)
+                .vectorize(c, 8)
+                .unroll(c)
+                .unroll(x)
+                .unroll(y)
+                .unroll(r.x, 2);
+            filter.in()
+                .compute_at(conv, r.x)
+                .vectorize(_0, 8)
+                .unroll(_0)
+                .unroll(_3);
+            input.in()
+                .compute_at(conv, x)
+                .unroll(_0);
         }
     }
 };

--- a/apps/conv_layer/conv_layer_generator.cpp
+++ b/apps/conv_layer/conv_layer_generator.cpp
@@ -50,7 +50,7 @@ public:
         filter.dim(0).set_bounds(0, CO).set_stride(1);
         filter.dim(1).set_bounds(0, 3).set_stride(CO);
         filter.dim(2).set_bounds(0, 3).set_stride(CO * 3);
-        folter.dim(3).set_bounds(0, CI).set_stride(CO * 3 * 3);
+        filter.dim(3).set_bounds(0, CI).set_stride(CO * 3 * 3);
 
         bias.dim(0).set_bounds(0, CO).set_stride(1);
 

--- a/apps/conv_layer/conv_layer_generator.cpp
+++ b/apps/conv_layer/conv_layer_generator.cpp
@@ -37,20 +37,20 @@ public:
             .bound(c, 0, CO)
             .bound(n, 0, N);
 
-        relu.dim(0).set_bounds(0, CO).set_stride(1)
-            .dim(1).set_bounds(0, W).set_stride(CO)
-            .dim(2).set_bounds(0, H).set_stride(CO * W)
-            .dim(3).set_bounds(0, N).set_stride(CO * H * W);
+        relu.dim(0).set_bounds(0, CO).set_stride(1);
+        relu.dim(1).set_bounds(0, W).set_stride(CO);
+        relu.dim(2).set_bounds(0, H).set_stride(CO * W);
+        relu.dim(3).set_bounds(0, N).set_stride(CO * H * W);
 
-        input.dim(0).set_bounds(0, CI).set_stride(1)
-            .dim(1).set_bounds(0, W + 2).set_stride(CI)
-            .dim(2).set_bounds(0, H + 2).set_stride(CI * (W + 2))
-            .dim(3).set_bounds(0, N).set_stride(CI * (W + 2) * (H + 2));
+        input.dim(0).set_bounds(0, CI).set_stride(1);
+        input.dim(1).set_bounds(0, W + 2).set_stride(CI);
+        input.dim(2).set_bounds(0, H + 2).set_stride(CI * (W + 2));
+        input.dim(3).set_bounds(0, N).set_stride(CI * (W + 2) * (H + 2));
 
-        filter.dim(0).set_bounds(0, CO).set_stride(1)
-            .dim(1).set_bounds(0, 3).set_stride(CO)
-            .dim(2).set_bounds(0, 3).set_stride(CO * 3)
-            .dim(3).set_bounds(0, CI).set_stride(CO * 3 * 3);
+        filter.dim(0).set_bounds(0, CO).set_stride(1);
+        filter.dim(1).set_bounds(0, 3).set_stride(CO);
+        filter.dim(2).set_bounds(0, 3).set_stride(CO * 3);
+        folter.dim(3).set_bounds(0, CI).set_stride(CO * 3 * 3);
 
         bias.dim(0).set_bounds(0, CO).set_stride(1);
 
@@ -112,7 +112,8 @@ public:
                 .unroll(r.z)
                 .unroll(rxii);
 
-            input.in().compute_at(conv, rxo)
+            input.in()
+                .compute_at(conv, rxo)
                 .vectorize(_0, 2)
                 .split(_1, xo, xi, 4)
                 .fuse(_0, xi, t)

--- a/apps/conv_layer/conv_layer_generator.cpp
+++ b/apps/conv_layer/conv_layer_generator.cpp
@@ -68,11 +68,14 @@ public:
             relu.dim(2).set_estimate(0, CO);
             relu.dim(3).set_estimate(0, N);
 
-        } else if (get_target().has_gpu_feature()) {
+        } else if (get_target().has_feature(Target::CUDA)) {
             // GPU schedule, tuned for a gtx 980
 
             // 2.41 ms on a GTX 980. According to nvprof this is about
             // 88% of peak flops.
+
+            // We use cuda-specific scheduling directives (gpu_lanes),
+            // so this is not a general GPGPU schedule.
 
             Var ni, no, xi, xo, yi, yo, ci, co, t;
             RVar rxo, rxi, rxii;

--- a/apps/conv_layer/conv_layer_generator.cpp
+++ b/apps/conv_layer/conv_layer_generator.cpp
@@ -32,10 +32,6 @@ public:
         // MKL JITs code for the specific size and strides, so we'll
         // do the same and ask Halide to compile for this specific
         // size:
-        relu.bound(x, 0, W)
-            .bound(y, 0, H)
-            .bound(c, 0, CO)
-            .bound(n, 0, N);
 
         relu.dim(0).set_bounds(0, CO).set_stride(1);
         relu.dim(1).set_bounds(0, W).set_stride(CO);
@@ -53,11 +49,6 @@ public:
         filter.dim(3).set_bounds(0, CI).set_stride(CO * 3 * 3);
 
         bias.dim(0).set_bounds(0, CO).set_stride(1);
-
-        input.set_host_alignment(128);
-        bias.set_host_alignment(128);
-        filter.set_host_alignment(128);
-        relu.set_host_alignment(128);
 
         if (auto_schedule) {
             input.dim(0).set_estimate(0, CI);

--- a/apps/conv_layer/process.cpp
+++ b/apps/conv_layer/process.cpp
@@ -13,7 +13,7 @@ using namespace Halide::Runtime;
 int main(int argc, char **argv) {
     const int N = 5, CI = 128, CO = 128, W = 100, H = 80;
 
-    Buffer<float> input(CI, W+2, H+2, N);
+    Buffer<float> input(CI, W + 2, H + 2, N);
     Buffer<float> filter(CO, 3, 3, CI);
     Buffer<float> bias(CO);
 

--- a/apps/conv_layer/process.cpp
+++ b/apps/conv_layer/process.cpp
@@ -46,7 +46,11 @@ int main(int argc, char **argv) {
     // This is necessary to get the PTX compiler to do a good
     // job. TODO: This should be a scheduling directive or a runtime
     // function.
+    #ifdef _WIN32
+    _putenv_s("HL_CUDA_JIT_MAX_REGISTERS", "256");
+    #else
     setenv("HL_CUDA_JIT_MAX_REGISTERS", "256", 1);
+    #endif
 
     conv_layer(input, filter, bias, output);
 

--- a/apps/conv_layer/process.cpp
+++ b/apps/conv_layer/process.cpp
@@ -43,6 +43,11 @@ int main(int argc, char **argv) {
 
     Buffer<float> output(CO, W, H, N);
 
+    // This is necessary to get the PTX compiler to do a good
+    // job. TODO: This should be a scheduling directive or a runtime
+    // function.
+    setenv("HL_CUDA_JIT_MAX_REGISTERS", "256", 1);
+
     conv_layer(input, filter, bias, output);
 
     // Timing code

--- a/apps/conv_layer/process.cpp
+++ b/apps/conv_layer/process.cpp
@@ -11,9 +11,11 @@ using namespace Halide::Tools;
 using namespace Halide::Runtime;
 
 int main(int argc, char **argv) {
-    Buffer<float> input(67, 67, 32, 4);
-    Buffer<float> filter(3, 3, 32, 32);
-    Buffer<float> bias(32);
+    const int N = 5, CI = 128, CO = 128, W = 100, H = 80;
+
+    Buffer<float> input(CI, W+2, H+2, N);
+    Buffer<float> filter(CO, 3, 3, CI);
+    Buffer<float> bias(CO);
 
     for (int c = 0; c < input.dim(3).extent(); c++) {
         for (int z = 0; z < input.channels(); z++) {
@@ -39,7 +41,7 @@ int main(int argc, char **argv) {
         bias(x) = rand();
     }
 
-    Buffer<float> output(64, 64, 32, 4);
+    Buffer<float> output(CO, W, H, N);
 
     conv_layer(input, filter, bias, output);
 

--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -3004,7 +3004,7 @@ Partitioner::analyze_spatial_locality(const FStage &stg,
 
 // Verify that function 'f' does not have partially specified schedules/bounds.
 // The current auto scheduler cannots handle such cases.
-void validate_no_partial_schedules(const Function &f) {
+void validate_no_partial_schedules(const Function &f, bool is_output) {
     if (f.has_extern_definition()) {
         return;
     }
@@ -3013,9 +3013,11 @@ void validate_no_partial_schedules(const Function &f) {
     user_assert(f.schedule().compute_level().is_inlined())
         << "AutoSchedule: cannot auto-schedule function \"" << f.name()
         << "\" since it is scheduled to be computed at root\n";
-    user_assert(f.schedule().bounds().empty())
+
+    user_assert(is_output || f.schedule().bounds().empty())
         << "AutoSchedule: cannot auto-schedule function \"" << f.name()
         << "\" since it has partially specified bounds\n";
+
 
     int num_stages = f.updates().size() + 1;
     for (int stage = 0; stage < num_stages; ++stage) {
@@ -3192,7 +3194,11 @@ string generate_schedules(const vector<Function> &outputs, const Target &target,
     // Validate that none of the functions in the pipeline have partial schedules.
     debug(2) << "Validating no partial schedules...\n";
     for (const auto &iter : env) {
-        validate_no_partial_schedules(iter.second);
+        bool is_output = false;
+        for (const auto &o : outputs) {
+            is_output |= iter.second.same_as(o);
+        }
+        validate_no_partial_schedules(iter.second, is_output);
     }
 
     // The auto scheduling algorithm requires estimates on the outputs of the


### PR DESCRIPTION
Our conv layer schedule was pretty tragic, for both CPU and GPU. This PR fixes them (on at least one machine). This conv schedule hits 88% of peak flops on my GPU, and 91.7% of peak flops on my CPU.