### PR TITLE
MSAN: check input buffers for poison (Issue #4481)

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -183,6 +183,8 @@ bool function_takes_user_context(const std::string &name) {
         "halide_msan_annotate_buffer_is_initialized_as_destructor",
         "halide_msan_annotate_buffer_is_initialized",
         "halide_msan_annotate_memory_is_initialized",
+        "halide_msan_check_buffer_is_initialized",
+        "halide_msan_check_memory_is_initialized",
         "halide_hexagon_initialize_kernels",
         "halide_hexagon_run",
         "halide_hexagon_device_release",

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -620,7 +620,7 @@ Stmt build_extern_produce(const map<string, Function> &env, Function f, const Ta
                 pre_call = mark_contents;
             }
         }
-        // Check the output buffer(s) to be sure they are fully initialized.
+        // Check the output buffer(s) from define_extern() calls to be sure they are fully initialized.
         for (const auto &buffer : buffers_to_check) {
             Stmt check_contents = Evaluate::make(
                 Call::make(Int(32), "halide_msan_check_buffer_is_initialized", {buffer}, Call::Extern));

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -934,10 +934,33 @@ extern void halide_memoization_cache_release(void *user_context, void *host);
  */
 extern void halide_memoization_cache_cleanup();
 
+/** Verify that a given range of memory has been initialized; only used when Target::MSAN is enabled.
+ *
+ * The default implementation simply calls the LLVM-provided __msan_check_mem_is_initialized() function.
+ *
+ * The return value should always be zero.
+ */
+extern int halide_msan_check_memory_is_initialized(void *user_context, const void *ptr, uint64_t len);
+
+/** Verify that the data pointed to by the buffer_t is initialized (but *not* the buffer_t itself),
+ * using halide_msan_check_memory_is_initialized() for checking.
+ *
+ * The default implementation takes pains to only check the active memory ranges
+ * (skipping padding), and sorting into ranges to always check the smallest number of
+ * ranges, in monotonically increasing memory order.
+ *
+ * Most client code should never need to replace the default implementation.
+ *
+ * The return value should always be zero.
+ */
+extern int halide_msan_check_buffer_is_initialized(void *user_context, struct halide_buffer_t *buffer);
+
 /** Annotate that a given range of memory has been initialized;
  * only used when Target::MSAN is enabled.
  *
- * The default implementation uses the LLVM-provided AnnotateMemoryIsInitialized() function.
+ * The default implementation simply calls the LLVM-provided __msan_unpoison() function.
+ *
+ * The return value should always be zero.
  */
 extern int halide_msan_annotate_memory_is_initialized(void *user_context, const void *ptr, uint64_t len);
 
@@ -949,6 +972,8 @@ extern int halide_msan_annotate_memory_is_initialized(void *user_context, const 
  * ranges, in monotonically increasing memory order.
  *
  * Most client code should never need to replace the default implementation.
+ *
+ * The return value should always be zero.
  */
 extern int halide_msan_annotate_buffer_is_initialized(void *user_context, struct halide_buffer_t *buffer);
 extern void halide_msan_annotate_buffer_is_initialized_as_destructor(void *user_context, void *buffer);

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -942,7 +942,7 @@ extern void halide_memoization_cache_cleanup();
  */
 extern int halide_msan_check_memory_is_initialized(void *user_context, const void *ptr, uint64_t len);
 
-/** Verify that the data pointed to by the buffer_t is initialized (but *not* the buffer_t itself),
+/** Verify that the data pointed to by the halide_buffer_t is initialized (but *not* the halide_buffer_t itself),
  * using halide_msan_check_memory_is_initialized() for checking.
  *
  * The default implementation takes pains to only check the active memory ranges
@@ -964,7 +964,7 @@ extern int halide_msan_check_buffer_is_initialized(void *user_context, struct ha
  */
 extern int halide_msan_annotate_memory_is_initialized(void *user_context, const void *ptr, uint64_t len);
 
-/** Mark the data pointed to by the buffer_t as initialized (but *not* the buffer_t itself),
+/** Mark the data pointed to by the halide_buffer_t as initialized (but *not* the halide_buffer_t itself),
  * using halide_msan_annotate_memory_is_initialized() for marking.
  *
  * The default implementation takes pains to only mark the active memory ranges

--- a/src/runtime/msan.cpp
+++ b/src/runtime/msan.cpp
@@ -4,11 +4,16 @@
 extern "C" {
 
 // This function is expected to be provided by LLVM as part of the MSAN implementation.
-extern void AnnotateMemoryIsInitialized(const char *file, int line,
-                                        const void *mem, size_t size);
+extern void __msan_unpoison(const volatile void *a, size_t size);
+extern void __msan_check_mem_is_initialized(const volatile void *x, size_t size);
 
 WEAK int halide_msan_annotate_memory_is_initialized(void *user_context, const void *ptr, uint64_t len) {
-    AnnotateMemoryIsInitialized("Halide", 0, ptr, (size_t) len);
+    __msan_unpoison(ptr, (size_t)len);
+    return 0;
+}
+
+WEAK int halide_msan_check_memory_is_initialized(void *user_context, const void *ptr, uint64_t len) {
+    __msan_check_mem_is_initialized(ptr, (size_t)len);
     return 0;
 }
 
@@ -17,7 +22,8 @@ namespace Runtime {
 namespace Internal {
 
 WEAK void annotate_helper(void *uc, const device_copy &c, int d, int64_t off) {
-    while (d >= 0 && c.extent[d] == 1) d--;
+    while (d >= 0 && c.extent[d] == 1)
+        d--;
 
     if (d == -1) {
         const void *from = (void *)(c.src + off);
@@ -30,7 +36,24 @@ WEAK void annotate_helper(void *uc, const device_copy &c, int d, int64_t off) {
     }
 };
 
-}}}
+WEAK void check_helper(void *uc, const device_copy &c, int d, int64_t off) {
+    while (d >= 0 && c.extent[d] == 1)
+        d--;
+
+    if (d == -1) {
+        const void *from = (void *)(c.src + off);
+        halide_msan_check_memory_is_initialized(uc, from, c.chunk_size);
+    } else {
+        for (uint64_t i = 0; i < c.extent[d]; i++) {
+            check_helper(uc, c, d - 1, off);
+            off += c.src_stride_bytes[d];
+        }
+    }
+};
+
+}  // namespace Internal
+}  // namespace Runtime
+}  // namespace Halide
 
 // Default implementation marks the data pointed to by the buffer_t as initialized
 // (but *not* the buffer_t itself); it takes pains to only mark the active memory ranges
@@ -53,12 +76,36 @@ WEAK int halide_msan_annotate_buffer_is_initialized(void *user_context, halide_b
         return 0;
     }
 
-    annotate_helper(user_context, c, MAX_COPY_DIMS-1, 0);
+    annotate_helper(user_context, c, MAX_COPY_DIMS - 1, 0);
     return 0;
 }
 
 WEAK void halide_msan_annotate_buffer_is_initialized_as_destructor(void *user_context, void *b) {
-    (void) halide_msan_annotate_buffer_is_initialized(user_context, (halide_buffer_t *)b);
+    (void)halide_msan_annotate_buffer_is_initialized(user_context, (halide_buffer_t *)b);
 }
 
+WEAK int halide_msan_check_buffer_is_initialized(void *user_context, halide_buffer_t *b) {
+    if (b == NULL) {
+        return 0;
+    }
+
+    halide_msan_check_memory_is_initialized(user_context, (void *)b, sizeof(*b));
+    halide_msan_check_memory_is_initialized(user_context, (void *)b->dim, b->dimensions * sizeof(b->dim[0]));
+
+    Halide::Runtime::Internal::device_copy c = Halide::Runtime::Internal::make_host_to_device_copy(b);
+    if (c.chunk_size == 0) {
+        return 0;
+    }
+
+    if (b->device_dirty()) {
+        // buffer has been computed on a gpu, but not copied back:
+        // don't check. (We'll assume that subsequent calls to
+        // halide_copy_to_host will force another call.)
+        return 0;
+    }
+
+    check_helper(user_context, c, MAX_COPY_DIMS - 1, 0);
+    return 0;
 }
+
+}  // extern "C"

--- a/src/runtime/msan_stubs.cpp
+++ b/src/runtime/msan_stubs.cpp
@@ -2,10 +2,22 @@
 
 extern "C" {
 
-WEAK int halide_msan_annotate_memory_is_initialized(void *user_context, const void *ptr, uint64_t len) { return 0; }
+WEAK int halide_msan_annotate_memory_is_initialized(void *user_context, const void *ptr, uint64_t len) {
+    return 0;
+}
 
-WEAK int halide_msan_annotate_buffer_is_initialized(void *user_context, halide_buffer_t *b) { return 0; }
+WEAK int halide_msan_check_memory_is_initialized(void *user_context, const void *ptr, uint64_t len) {
+    return 0;
+}
 
-WEAK void halide_msan_annotate_buffer_is_initialized_as_destructor(void *user_context, void *b) {}
+WEAK int halide_msan_check_buffer_is_initialized(void *user_context, halide_buffer_t *b) {
+    return 0;
+}
 
+WEAK int halide_msan_annotate_buffer_is_initialized(void *user_context, halide_buffer_t *b) {
+    return 0;
+}
+
+WEAK void halide_msan_annotate_buffer_is_initialized_as_destructor(void *user_context, void *b) {
+}
 }

--- a/src/runtime/runtime_api.cpp
+++ b/src/runtime/runtime_api.cpp
@@ -128,6 +128,8 @@ extern "C" __attribute__((used)) void *halide_runtime_api_functions[] = {
     (void *)&halide_msan_annotate_buffer_is_initialized,
     (void *)&halide_msan_annotate_buffer_is_initialized_as_destructor,
     (void *)&halide_msan_annotate_memory_is_initialized,
+    (void *)&halide_msan_check_buffer_is_initialized,
+    (void *)&halide_msan_check_memory_is_initialized,
     (void *)&halide_mutex_lock,
     (void *)&halide_mutex_unlock,
     (void *)&halide_mutex_array_create,

--- a/test/generator/msan_aottest.cpp
+++ b/test/generator/msan_aottest.cpp
@@ -6,8 +6,8 @@ int main(int argc, char **argv) {
     return 0;
 }
 #else
-#include "HalideRuntime.h"
 #include "HalideBuffer.h"
+#include "HalideRuntime.h"
 
 #include <iostream>
 #include <limits>
@@ -19,25 +19,87 @@ int main(int argc, char **argv) {
 using namespace std;
 using namespace Halide::Runtime;
 
+enum {
+    kAnnotate_bounds_inference_buffer,
+    kAnnotate_intermediate_buffer,
+    kAnnotate_intermediate_shape,
+    kAnnotate_output_buffer,
+    kAnnotate_output_shape,
+    kAnnotate_intermediate_contents,
+    kAnnotate_output_contents,
+} annotate_stage = kAnnotate_bounds_inference_buffer;
+
+enum {
+    kCheck_input_buffer,
+    kCheck_input_shape,
+    kCheck_input_contents,
+    kCheck_externresult_buffer,
+    kCheck_externresult_shape,
+    kCheck_externresult_contents,
+} check_stage = kCheck_input_buffer;
+
+const void *output_base = nullptr;
+const void *output_previous = nullptr;
+int bounds_inference_count = 0;
+bool expect_intermediate_buffer_error = false;
+bool skip_extern_copy = false;
+uint64_t input_contents_checked = 0;
+uint64_t input_contents_uninitialized = 0;
+uint64_t externresult_contents_checked = 0;
+uint64_t externresult_contents_uninitialized = 0;
+uint64_t output_contents_annotated = 0;
+
+void reset_state(const Buffer<uint8_t> &in, const Buffer<uint8_t> &out) {
+    annotate_stage = kAnnotate_bounds_inference_buffer;
+    check_stage = kCheck_input_buffer;
+    output_base = out.data();
+    output_previous = nullptr;
+    bounds_inference_count = 0;
+    expect_intermediate_buffer_error = false;
+    skip_extern_copy = false;
+    input_contents_uninitialized = 0;
+    input_contents_checked = 0;
+    externresult_contents_uninitialized = 0;
+    externresult_contents_checked = 0;
+    output_contents_annotated = 0;
+    // printf("IN-DATA:  %p:%p:%p\n", (void *)in.raw_buffer(), (void *)in.raw_buffer()->dim, (void *)in.data());
+    // printf("OUT-DATA: %p:%p:%p\n", (void *)out.raw_buffer(), (void *)out.raw_buffer()->dim, (void *)out.data());
+}
+
 // Just copies in -> out.
 extern "C" int msan_extern_stage(halide_buffer_t *in, halide_buffer_t *out) {
-    if (in->is_bounds_query()) {
-        in->dim[0].extent = 4;
-        in->dim[1].extent = 4;
-        in->dim[2].extent = 3;
-        in->dim[0].min = 0;
-        in->dim[1].min = 0;
-        in->dim[2].min = 0;
+    if (in->is_bounds_query() || out->is_bounds_query()) {
+        if (in->is_bounds_query()) {
+            assert(in->dimensions == 3);
+            in->dim[0].extent = 4;
+            in->dim[1].extent = 4;
+            in->dim[2].extent = 3;
+            in->dim[0].min = 0;
+            in->dim[1].min = 0;
+            in->dim[2].min = 0;
+        }
+        if (out->is_bounds_query()) {
+            assert(out->dimensions == 3);
+            out->dim[0].extent = 4;
+            out->dim[1].extent = 4;
+            out->dim[2].extent = 3;
+            out->dim[0].min = 0;
+            out->dim[1].min = 0;
+            out->dim[2].min = 0;
+        }
         return 0;
     }
-    if (!out->host) {
-        fprintf(stderr, "msan_extern_stage failure\n");
-        return -1;
-    }
+
     if (in->type != out->type) {
+        fprintf(stderr, "type mismatch\n");
         return -1;
     }
-    Buffer<int32_t>(*out).copy_from(Buffer<int32_t>(*in));
+    if (skip_extern_copy) {
+        // Fill it with zero to mimic msan "poison".
+        Buffer<uint8_t>(*out).fill(0);
+    } else {
+        Buffer<uint8_t>(*out).copy_from(Buffer<uint8_t>(*in));
+    }
     out->set_host_dirty();
     return 0;
 }
@@ -46,90 +108,115 @@ extern "C" void halide_error(void *user_context, const char *msg) {
     // Emitting "error.*:" to stdout or stderr will cause CMake to report the
     // test as a failure on Windows, regardless of error code returned,
     // hence the abbreviation to "err".
-    fprintf(stderr, "Saw err: %s\n", msg);
+    // fprintf(stderr, "Saw err: %s\n", msg);
     // Do not exit.
 }
 
-// Must provide a stub for this since we aren't compiling with LLVM MSAN
-// enabled, and the default implementation of halide_msan_annotate_memory_is_initialized()
-// expects this to be present
-extern "C" void AnnotateMemoryIsInitialized(const char *file, int line,
-                                            const void *mem, size_t size) {
+// Must provide a stub for these since we aren't compiling with LLVM MSAN
+// enabled, and the default implementation of our msan-specific runtime needs them.
+extern "C" void __msan_check_mem_is_initialized(const void *mem, size_t size) {
     fprintf(stderr, "Impossible\n");
     exit(-1);
 }
 
-enum {
-  expect_bounds_inference_buffer,
-  expect_intermediate_buffer,
-  expect_intermediate_shape,
-  expect_output_buffer,
-  expect_output_shape,
-  expect_intermediate_contents,
-  expect_output_contents,
-} annotate_stage = expect_bounds_inference_buffer;
-const void* output_base = nullptr;
-const void* output_previous = nullptr;
-int bounds_inference_count = 0;
-bool expect_error = false;
+extern "C" void __msan_unpoison(const void *mem, size_t size) {
+    fprintf(stderr, "Impossible\n");
+    exit(-1);
+}
 
-void reset_state(const void* base) {
-    annotate_stage = expect_bounds_inference_buffer;
-    output_base = base;
-    output_previous = nullptr;
-    bounds_inference_count = 0;
-    expect_error = false;
+extern "C" int halide_msan_check_memory_is_initialized(void *user_context, const void *ptr, uint64_t len) {
+    // printf("CHECK-MEM: %d:%p:%08x\n", (int)check_stage, ptr, (unsigned int)len);
+    if (check_stage == kCheck_input_buffer) {
+        if (len != sizeof(halide_buffer_t)) {
+            fprintf(stderr, "Failure: Expected sizeof(halide_buffer_t), saw %d\n", (unsigned int)len);
+            exit(-1);
+        }
+        check_stage = kCheck_input_shape;
+    } else if (check_stage == kCheck_input_shape) {
+        if (len != sizeof(halide_dimension_t) * 3) {
+            fprintf(stderr, "Failure: Expected sizeof(halide_dimension_t) * 3, saw %d\n", (unsigned int)len);
+            exit(-1);
+        }
+        check_stage = kCheck_input_contents;
+    } else if (check_stage == kCheck_input_contents) {
+        for (uint64_t i = 0; i < len; ++i) {
+            input_contents_uninitialized += (((const uint8_t *)ptr)[i] == 0);
+        }
+        input_contents_checked += len;
+        check_stage = kCheck_externresult_buffer;
+    } else if (check_stage == kCheck_externresult_buffer) {
+        if (len != sizeof(halide_buffer_t)) {
+            fprintf(stderr, "Failure: Expected sizeof(halide_buffer_t), saw %d\n", (unsigned int)len);
+            exit(-1);
+        }
+        check_stage = kCheck_externresult_shape;
+    } else if (check_stage == kCheck_externresult_shape) {
+        if (len != sizeof(halide_dimension_t) * 3) {
+            fprintf(stderr, "Failure: Expected sizeof(halide_dimension_t) * 3, saw %d\n", (unsigned int)len);
+            exit(-1);
+        }
+        check_stage = kCheck_externresult_contents;
+    } else if (check_stage == kCheck_externresult_contents) {
+        for (uint64_t i = 0; i < len; ++i) {
+            externresult_contents_uninitialized += (((const uint8_t *)ptr)[i] == 0);
+        }
+        externresult_contents_checked += len;
+    } else {
+        fprintf(stderr, "Failure: bad enum\n");
+        exit(-1);
+    }
+    return 0;
 }
 
 extern "C" int halide_msan_annotate_memory_is_initialized(void *user_context, const void *ptr, uint64_t len) {
-    printf("%d:%p:%08x\n", (int)annotate_stage, ptr, (unsigned int) len);
-    if (annotate_stage == expect_bounds_inference_buffer) {
+    // printf("ANNOTATE: %d:%p:%08x\n", (int)annotate_stage, ptr, (unsigned int)len);
+    if (annotate_stage == kAnnotate_bounds_inference_buffer) {
         if (output_previous != nullptr || len != sizeof(halide_buffer_t)) {
-            fprintf(stderr, "Failure: Expected sizeof(halide_buffer_t), saw %d\n", (unsigned int) len);
+            fprintf(stderr, "Failure: Expected sizeof(halide_buffer_t), saw %d\n", (unsigned int)len);
             exit(-1);
         }
         bounds_inference_count += 1;
         if (bounds_inference_count == 4) {
-            annotate_stage = expect_intermediate_buffer;
+            annotate_stage = kAnnotate_intermediate_buffer;
         }
-    } else if (annotate_stage == expect_intermediate_buffer) {
-        if (expect_error) {
-            if (len != 87) {
-                fprintf(stderr, "Failure: Expected error message of len=87, saw %d bytes\n", (unsigned int) len);
+    } else if (annotate_stage == kAnnotate_intermediate_buffer) {
+        if (expect_intermediate_buffer_error) {
+            if (len != 80) {
+                fprintf(stderr, "Failure: Expected error message of len=80, saw %d bytes\n", (unsigned int)len);
                 exit(-1);
             }
             return 0;  // stay in this state
         }
         if (output_previous != nullptr || len != sizeof(halide_buffer_t)) {
-            fprintf(stderr, "Failure: Expected sizeof(halide_buffer_t), saw %d\n", (unsigned int) len);
+            fprintf(stderr, "Failure: Expected sizeof(halide_buffer_t), saw %d\n", (unsigned int)len);
             exit(-1);
         }
-        annotate_stage = expect_intermediate_shape;
-    } else if (annotate_stage == expect_intermediate_shape) {
+        annotate_stage = kAnnotate_intermediate_shape;
+    } else if (annotate_stage == kAnnotate_intermediate_shape) {
         if (output_previous != nullptr || len != sizeof(halide_dimension_t) * 3) {
-            fprintf(stderr, "Failure: Expected sizeof(halide_dimension_t) * 3, saw %d\n", (unsigned int) len);
+            fprintf(stderr, "Failure: Expected sizeof(halide_dimension_t) * 3, saw %d\n", (unsigned int)len);
             exit(-1);
         }
-        annotate_stage = expect_output_buffer;
-    } else if (annotate_stage == expect_output_buffer) {
+        annotate_stage = kAnnotate_output_buffer;
+    } else if (annotate_stage == kAnnotate_output_buffer) {
         if (output_previous != nullptr || len != sizeof(halide_buffer_t)) {
-            fprintf(stderr, "Failure: Expected sizeof(halide_buffer_t), saw %d\n", (unsigned int) len);
+            fprintf(stderr, "Failure: Expected sizeof(halide_buffer_t), saw %d\n", (unsigned int)len);
             exit(-1);
         }
-        annotate_stage = expect_output_shape;
-    } else if (annotate_stage == expect_output_shape) {
+        annotate_stage = kAnnotate_output_shape;
+    } else if (annotate_stage == kAnnotate_output_shape) {
         if (output_previous != nullptr || len != sizeof(halide_dimension_t) * 3) {
-            fprintf(stderr, "Failure: Expected sizeof(halide_dimension_t) * 3, saw %d\n", (unsigned int) len);
+            fprintf(stderr, "Failure: Expected sizeof(halide_dimension_t) * 3, saw %d\n", (unsigned int)len);
             exit(-1);
         }
-        annotate_stage = expect_intermediate_contents;
-    } else if (annotate_stage == expect_intermediate_contents) {
-        if (output_previous != nullptr || len != 4 * 4 * 3 * 4) {
-            fprintf(stderr, "Failure: Expected %d, saw %d\n", 4 * 4 * 3 * 4, (unsigned int) len);
+        annotate_stage = kAnnotate_intermediate_contents;
+    } else if (annotate_stage == kAnnotate_intermediate_contents) {
+        if (output_previous != nullptr || len != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: Expected %d, saw %d\n", 4 * 4 * 3, (unsigned int)len);
             exit(-1);
         }
-        annotate_stage = expect_output_contents;
-    } else if (annotate_stage == expect_output_contents) {
+        annotate_stage = kAnnotate_output_contents;
+    } else if (annotate_stage == kAnnotate_output_contents) {
         if (output_previous == nullptr) {
             if (ptr != output_base) {
                 fprintf(stderr, "Failure: Expected base p %p but saw %p\n", output_base, ptr);
@@ -141,6 +228,7 @@ extern "C" int halide_msan_annotate_memory_is_initialized(void *user_context, co
             }
             output_previous = ptr;
         }
+        output_contents_annotated += len;
     } else {
         fprintf(stderr, "Failure: bad enum\n");
         exit(-1);
@@ -151,9 +239,9 @@ extern "C" int halide_msan_annotate_memory_is_initialized(void *user_context, co
 template<typename T>
 void verify(const T &image) {
     image.for_each_element([&](int x, int y, int c) {
-        int expected = 3;
+        int expected = 7;
         for (int i = 0; i < 4; ++i) {
-            expected += (int32_t)(i + y + c);
+            expected += (uint8_t)(i + y + c) | 0x01;
         }
         int actual = image(x, y, c);
         if (actual != expected) {
@@ -163,38 +251,78 @@ void verify(const T &image) {
     });
 }
 
+Buffer<uint8_t> make_input_for(const Buffer<uint8_t> &output) {
+    auto input = Buffer<uint8_t>::make_with_shape_of(output);
+    // Ensure that no 'valid' inputs are all-zero
+    input.for_each_element([&](int x, int y, int c) { input(x, y, c) = (uint8_t)(x + y + c) | 0x01; });
+    return input;
+}
+
 //-----------------------------------------------------------------------------
 
-int main()
-{
+int main() {
     printf("Testing interleaved...\n");
     {
-        auto out = Buffer<int32_t>::make_interleaved(4, 4, 3);
-        reset_state(out.data());
-        if (msan(out) != 0) {
+        auto out = Buffer<uint8_t>::make_interleaved(4, 4, 3);
+        auto in = make_input_for(out);
+        reset_state(in, out);
+        if (msan(in, out) != 0) {
             fprintf(stderr, "Failure!\n");
             exit(-1);
         }
         verify(out);
+        if (input_contents_uninitialized != 0) {
+            fprintf(stderr, "Failure: input_contents_uninitialized is wrong (%d).\n", (int)input_contents_uninitialized);
+            exit(-1);
+        }
+        if (input_contents_checked != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: input_contents_checked is wrong (%d).\n", (int)input_contents_checked);
+            exit(-1);
+        }
+        if (output_contents_annotated != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: output_contents_annotated is wrong (%d).\n", (int)output_contents_annotated);
+            exit(-1);
+        }
         if (output_previous == nullptr) {
             fprintf(stderr, "Failure: Expected to see annotations.\n");
             exit(-1);
         }
     }
 
-    printf("Testing sparse chunky...\n");
+    printf("Testing sparse interleaved...\n");
     {
         const int kPad = 1;
         halide_dimension_t shape[3] = {
-            { 0, 4, 3 },
-            { 0, 4, (4 * 3) + kPad },
-            { 0, 3, 1 },
+            {0, 4, 3},
+            {0, 4, (4 * 3) + kPad},
+            {0, 3, 1},
         };
-        std::vector<int32_t> data(((4 * 3) + kPad) * 4);
-        auto out = Buffer<int32_t>(data.data(), 3, shape);
-        reset_state(out.data());
-        if (msan(out) != 0) {
+        std::vector<uint8_t> data(((4 * 3) + kPad) * 4);
+        auto out = Buffer<uint8_t>(data.data(), 3, shape);
+        auto in = make_input_for(out);
+        reset_state(in, out);
+        if (msan(in, out) != 0) {
             fprintf(stderr, "Failure!\n");
+            exit(-1);
+        }
+        if (input_contents_uninitialized != 0) {
+            fprintf(stderr, "Failure: input_contents_uninitialized is wrong (%d).\n", (int)input_contents_uninitialized);
+            exit(-1);
+        }
+        if (input_contents_checked != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: input_contents_checked is wrong (%d).\n", (int)input_contents_checked);
+            exit(-1);
+        }
+        if (externresult_contents_uninitialized != 0) {
+            fprintf(stderr, "Failure: externresult_contents_uninitialized is wrong (%d).\n", (int)externresult_contents_uninitialized);
+            exit(-1);
+        }
+        if (externresult_contents_checked != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: externresult_contents_checked is wrong (%d).\n", (int)externresult_contents_checked);
+            exit(-1);
+        }
+        if (output_contents_annotated != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: output_contents_annotated is wrong (%d).\n", (int)output_contents_annotated);
             exit(-1);
         }
         if (output_previous == nullptr) {
@@ -205,10 +333,31 @@ int main()
 
     printf("Testing planar...\n");
     {
-        auto out = Buffer<int32_t>(4, 4, 3);
-        reset_state(out.data());
-        if (msan(out) != 0) {
+        auto out = Buffer<uint8_t>(4, 4, 3);
+        auto in = make_input_for(out);
+        reset_state(in, out);
+        if (msan(in, out) != 0) {
             fprintf(stderr, "Failure!\n");
+            exit(-1);
+        }
+        if (input_contents_uninitialized != 0) {
+            fprintf(stderr, "Failure: input_contents_uninitialized is wrong (%d).\n", (int)input_contents_uninitialized);
+            exit(-1);
+        }
+        if (input_contents_checked != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: input_contents_checked is wrong (%d).\n", (int)input_contents_checked);
+            exit(-1);
+        }
+        if (externresult_contents_uninitialized != 0) {
+            fprintf(stderr, "Failure: externresult_contents_uninitialized is wrong (%d).\n", (int)externresult_contents_uninitialized);
+            exit(-1);
+        }
+        if (externresult_contents_checked != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: externresult_contents_checked is wrong (%d).\n", (int)externresult_contents_checked);
+            exit(-1);
+        }
+        if (output_contents_annotated != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: output_contents_annotated is wrong (%d).\n", (int)output_contents_annotated);
             exit(-1);
         }
         if (output_previous == nullptr) {
@@ -221,15 +370,36 @@ int main()
     {
         const int kPad = 1;
         halide_dimension_t shape[3] = {
-            { 0, 4, 1 },
-            { 0, 4, 4 + kPad },
-            { 0, 3, (4 + kPad) * 4 },
+            {0, 4, 1},
+            {0, 4, 4 + kPad},
+            {0, 3, (4 + kPad) * 4},
         };
-        std::vector<int32_t> data((4 + kPad) * 4 * 3);
-        auto out = Buffer<int32_t>(data.data(), 3, shape);
-        reset_state(out.data());
-        if (msan(out) != 0) {
+        std::vector<uint8_t> data((4 + kPad) * 4 * 3);
+        auto out = Buffer<uint8_t>(data.data(), 3, shape);
+        auto in = make_input_for(out);
+        reset_state(in, out);
+        if (msan(in, out) != 0) {
             fprintf(stderr, "Failure!\n");
+            exit(-1);
+        }
+        if (input_contents_uninitialized != 0) {
+            fprintf(stderr, "Failure: input_contents_uninitialized is wrong (%d).\n", (int)input_contents_uninitialized);
+            exit(-1);
+        }
+        if (input_contents_checked != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: input_contents_checked is wrong (%d).\n", (int)input_contents_checked);
+            exit(-1);
+        }
+        if (externresult_contents_uninitialized != 0) {
+            fprintf(stderr, "Failure: externresult_contents_uninitialized is wrong (%d).\n", (int)externresult_contents_uninitialized);
+            exit(-1);
+        }
+        if (externresult_contents_checked != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: externresult_contents_checked is wrong (%d).\n", (int)externresult_contents_checked);
+            exit(-1);
+        }
+        if (output_contents_annotated != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: output_contents_annotated is wrong (%d).\n", (int)output_contents_annotated);
             exit(-1);
         }
         if (output_previous == nullptr) {
@@ -237,20 +407,114 @@ int main()
             exit(-1);
         }
     }
+
     // Buffers should not be marked as "initialized" if the filter fails with an error.
-    printf("Testing error case...\n");
+    printf("Verifying that output is not marked when error occurs...\n");
     {
-        auto out = Buffer<int32_t>(1, 1, 1);
-        reset_state(out.data());
-        expect_error = true;
-        if (msan(out) == 0) {
+        auto out = Buffer<uint8_t>(1, 1, 1);
+        auto in = make_input_for(out);
+        reset_state(in, out);
+        expect_intermediate_buffer_error = true;
+        if (msan(in, out) == 0) {
             fprintf(stderr, "Failure (expected failure but did not)!\n");
+            exit(-1);
+        }
+        if (input_contents_uninitialized != 0) {
+            fprintf(stderr, "Failure: input_contents_uninitialized is wrong (%d).\n", (int)input_contents_uninitialized);
+            exit(-1);
+        }
+        if (input_contents_checked != 1) {
+            fprintf(stderr, "Failure: input_contents_checked is wrong (%d).\n", (int)input_contents_checked);
+            exit(-1);
+        }
+        if (externresult_contents_uninitialized != 0) {
+            fprintf(stderr, "Failure: externresult_contents_uninitialized is wrong (%d).\n", (int)externresult_contents_uninitialized);
+            exit(-1);
+        }
+        if (externresult_contents_checked != 0) {
+            fprintf(stderr, "Failure: externresult_contents_checked is wrong (%d).\n", (int)externresult_contents_checked);
+            exit(-1);
+        }
+        if (output_contents_annotated != 0) {
+            fprintf(stderr, "Failure: expected no output contents to be annotated.\n");
             exit(-1);
         }
         if (output_previous != nullptr) {
             fprintf(stderr, "Failure: Expected NOT to see annotations.\n");
             exit(-1);
         }
+    }
+
+    // Buffers should not be marked as "initialized" if the filter fails with an error.
+    // We'll test the mechanism by ensuring that our valid input buffer never has
+    // only nonzero elements, and then checking for those.
+    printf("Verifying that input is checked for initialization...\n");
+    {
+        auto out = Buffer<uint8_t>::make_interleaved(4, 4, 3);
+        auto in = make_input_for(out);
+        // Make exactly one element "uninitialized"
+        in(3, 2, 1) = 0;
+        reset_state(in, out);
+        // Note that with "real" msan in place, we would expect this to never return;
+        // halide_msan_check_memory_is_initialized() would abort if it encounters
+        // uninitialized memory. It's hard to simulate that in our test harness, so
+        // we'll actually let it "complete" successfully and check the uninitialized state at the end.
+        if (msan(in, out) != 0) {
+            fprintf(stderr, "Failure!\n");
+            exit(-1);
+        }
+        if (input_contents_uninitialized != sizeof(uint8_t)) {
+            fprintf(stderr, "Failure: input_contents_uninitialized is wrong (%d).\n", (int)input_contents_uninitialized);
+            exit(-1);
+        }
+        if (input_contents_checked != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: input_contents_checked is wrong (%d).\n", (int)input_contents_checked);
+            exit(-1);
+        }
+        if (externresult_contents_uninitialized != 0) {
+            fprintf(stderr, "Failure: externresult_contents_uninitialized is wrong (%d).\n", (int)externresult_contents_uninitialized);
+            exit(-1);
+        }
+        if (externresult_contents_checked != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: externresult_contents_checked is wrong (%d).\n", (int)externresult_contents_checked);
+            exit(-1);
+        }
+        // Don't bother checking outputs here.
+    }
+
+    printf("Verifying that result of define_extern is checked for initialization...\n");
+    {
+        auto out = Buffer<uint8_t>::make_interleaved(4, 4, 3);
+        auto in = make_input_for(out);
+        // Make exactly one element "uninitialized"
+        in(3, 2, 1) = 0;
+        reset_state(in, out);
+        skip_extern_copy = true;
+        // Note that with "real" msan in place, we would expect this to never return;
+        // halide_msan_check_memory_is_initialized() would abort if it encounters
+        // uninitialized memory. It's hard to simulate that in our test harness, so
+        // we'll actually let it "complete" successfully and check the uninitialized state at the end.
+        if (msan(in, out) != 0) {
+            fprintf(stderr, "Failure!\n");
+            exit(-1);
+        }
+        if (input_contents_uninitialized != sizeof(uint8_t)) {
+            fprintf(stderr, "Failure: input_contents_uninitialized is wrong (%d).\n", (int)input_contents_uninitialized);
+            exit(-1);
+        }
+        if (input_contents_checked != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: input_contents_checked is wrong (%d).\n", (int)input_contents_checked);
+            exit(-1);
+        }
+        if (externresult_contents_uninitialized != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: externresult_contents_uninitialized is wrong (%d).\n", (int)externresult_contents_uninitialized);
+            exit(-1);
+        }
+        if (externresult_contents_checked != 4 * 4 * 3) {
+            fprintf(stderr, "Failure: externresult_contents_checked is wrong (%d).\n", (int)externresult_contents_checked);
+            exit(-1);
+        }
+        // Don't bother checking outputs here.
     }
 
     printf("Success!\n");

--- a/test/generator/msan_generator.cpp
+++ b/test/generator/msan_generator.cpp
@@ -4,37 +4,37 @@ namespace {
 
 class MSAN : public Halide::Generator<MSAN> {
 public:
-    Output<Buffer<int32_t>> msan_output{"msan_output"};
+    Input<Buffer<uint8_t>> input{"input", 3};
+    Output<Buffer<uint8_t>> output{"output", 3};
 
     void generate() {
         // Currently the test just exercises Target::MSAN
-        input(x, y, c) = cast<int32_t>(x + y + c);
+        input_plus_1(x, y, c) = input(x, y, c) + 1;
 
         // This just makes an exact copy
-        msan_extern_stage.define_extern("msan_extern_stage", {input}, Int(32), 3, NameMangling::C);
+        msan_extern_stage.define_extern("msan_extern_stage", {input_plus_1}, UInt(8), 3, NameMangling::C);
 
         RDom r(0, 4);
-        msan_output(x, y, c) = sum(msan_extern_stage(r, y, c));
+        output(x, y, c) = sum(msan_extern_stage(r, y, c));
 
         // Add two update phases to be sure annotation happens post-update
-        msan_output(r, y, c) += 1;
-        msan_output(x, r, c) += 2;
+        output(r, y, c) += cast<uint8_t>(1);
+        output(x, r, c) += cast<uint8_t>(2);
     }
 
     void schedule() {
-        input.compute_root();
+        input_plus_1.compute_root();
         msan_extern_stage.compute_root();
-        msan_output.parallel(y).vectorize(x, 4);
-        msan_output.dim(0).set_stride(Expr()).set_extent(4)
-                   .dim(1).set_extent(4)
-                   .dim(2).set_extent(3);
-
+        input.dim(0).set_stride(Expr()).set_extent(4).dim(1).set_extent(4).dim(2).set_extent(3);
+        output.parallel(y).vectorize(x, 4);
+        output.dim(0).set_stride(Expr()).set_extent(4).dim(1).set_extent(4).dim(2).set_extent(3);
     }
+
 private:
     // Currently the test just exercises Target::MSAN
     Var x, y, c;
 
-    Func input, msan_extern_stage;
+    Func input_plus_1, msan_extern_stage;
 };
 
 }  // namespace


### PR DESCRIPTION
Augment our MSAN support to ensure that input buffers (and the output of extern stages) are checked for uninitialized data.

Note 1: msan_aottest has become an ugly mess of code; it should probably be changed to use a table-driven state machine. Not sure if that blocks this or not.

Note 2: this should probably get checked inside Google before landing (which will probably happen post-holidays), as we have a fair number of complex pipelines that are running with msan enabled.