### PR TITLE
Reapply clang-format to src/*

### DIFF
--- a/src/AddAtomicMutex.cpp
+++ b/src/AddAtomicMutex.cpp
@@ -19,7 +19,8 @@ namespace {
 class CollectProducerStoreNames : public IRGraphVisitor {
 public:
     CollectProducerStoreNames(const std::string &producer_name)
-        : producer_name(producer_name) {}
+        : producer_name(producer_name) {
+    }
 
     Scope<void> store_names;
 
@@ -42,16 +43,17 @@ protected:
 class FindProducerStoreIndex : public IRGraphVisitor {
 public:
     FindProducerStoreIndex(const std::string &producer_name)
-        : producer_name(producer_name) {}
+        : producer_name(producer_name) {
+    }
 
-    Expr index; // The returned index.
+    Expr index;  // The returned index.
 
 protected:
     using IRGraphVisitor::visit;
 
     // Need to also extract the let bindings of a Store index.
     void visit(const Let *op) override {
-        IRGraphVisitor::visit(op); // Make sure we visit the Store first.
+        IRGraphVisitor::visit(op);  // Make sure we visit the Store first.
         if (index.defined()) {
             if (expr_uses_var(index, op->name)) {
                 index = Let::make(op->name, op->value, index);
@@ -59,7 +61,7 @@ protected:
         }
     }
     void visit(const LetStmt *op) override {
-        IRGraphVisitor::visit(op); // Make sure we visit the Store first.
+        IRGraphVisitor::visit(op);  // Make sure we visit the Store first.
         if (index.defined()) {
             if (expr_uses_var(index, op->name)) {
                 index = Let::make(op->name, op->value, index);
@@ -120,7 +122,8 @@ protected:
 class FindAtomicLetBindings : public IRGraphVisitor {
 public:
     FindAtomicLetBindings(const Scope<void> &store_names)
-        : store_names(store_names) {}
+        : store_names(store_names) {
+    }
 
     bool found = false;
 
@@ -205,7 +208,8 @@ public:
     using IRGraphVisitor::visit;
 
     FindStoreInAtomicMutex(const std::set<std::string> &store_names)
-        : store_names(store_names) {}
+        : store_names(store_names) {
+    }
 
     bool found = false;
     string producer_name;
@@ -243,8 +247,9 @@ protected:
 /** Replace the indices in the Store nodes with the specified variable. */
 class ReplaceStoreIndexWithVar : public IRMutator {
 public:
-    ReplaceStoreIndexWithVar(const std::string &producer_name, Expr var) :
-        producer_name(producer_name), var(var) {}
+    ReplaceStoreIndexWithVar(const std::string &producer_name, Expr var)
+        : producer_name(producer_name), var(var) {
+    }
 
 protected:
     using IRMutator::visit;
@@ -268,7 +273,8 @@ protected:
 class AddAtomicMutex : public IRMutator {
 public:
     AddAtomicMutex(const map<string, Function> &env)
-        : env(env) {}
+        : env(env) {
+    }
 
 protected:
     using IRMutator::visit;
@@ -395,7 +401,7 @@ protected:
         Stmt body = op->body;
 
         Expr index = find.index;
-        Expr index_let; // If defined, represents the value of the lifted let binding.
+        Expr index_let;  // If defined, represents the value of the lifted let binding.
         if (!index.defined()) {
             // Scalar output.
             index = Expr(0);

--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -3018,7 +3018,6 @@ void validate_no_partial_schedules(const Function &f, bool is_output) {
         << "AutoSchedule: cannot auto-schedule function \"" << f.name()
         << "\" since it has partially specified bounds\n";
 
-
     int num_stages = f.updates().size() + 1;
     for (int stage = 0; stage < num_stages; ++stage) {
         const Definition &def = get_stage_definition(f, stage);

--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -943,14 +943,12 @@ void cplusplus_mangle_test() {
         Target(Target::IOS, Target::ARM, 32),
         Target(Target::IOS, Target::ARM, 64),
         Target(Target::Windows, Target::X86, 32),
-        Target(Target::Windows, Target::X86, 64)
-    };
+        Target(Target::Windows, Target::X86, 64)};
     MangleResult *expecteds[kTestTargetCount]{
         ItaniumABIMangling_main, ItaniumABIMangling_main,
         ItaniumABIMangling_main, ItaniumABIMangling_main,
         ItaniumABIMangling_main, ItaniumABIMangling_main,
-        win32_expecteds, win64_expecteds
-    };
+        win32_expecteds, win64_expecteds};
 
     size_t i = 0;
     for (const auto &target : targets) {

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -38,7 +38,7 @@ namespace {
 // HALIDE_MUST_USE_RESULT defined here is intended to exactly
 // duplicate the definition in HalideRuntime.h (so that either or
 // both can be present, in any order).
-const char * const kDefineMustUseResult = R"INLINE_CODE(#ifndef HALIDE_MUST_USE_RESULT
+const char *const kDefineMustUseResult = R"INLINE_CODE(#ifndef HALIDE_MUST_USE_RESULT
 #ifdef __has_attribute
 #if __has_attribute(nodiscard)
 #define HALIDE_MUST_USE_RESULT [[nodiscard]]
@@ -2205,10 +2205,10 @@ void CodeGen_C::visit(const Call *op) {
             for (int i = 0; i < dimension; i++) {
                 stream
                     << get_indent() << "{"
-                    << values[i*4 + 0] << ", "
-                    << values[i*4 + 1] << ", "
-                    << values[i*4 + 2] << ", "
-                    << values[i*4 + 3] << "},\n";
+                    << values[i * 4 + 0] << ", "
+                    << values[i * 4 + 1] << ", "
+                    << values[i * 4 + 2] << ", "
+                    << values[i * 4 + 3] << "},\n";
             }
             indent--;
             stream << get_indent() << "};\n";

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -2038,10 +2038,11 @@ Value *CodeGen_Hexagon::vlut(Value *lut, Value *idx, int min_index, int max_inde
     // Construct a new index with 16-bit elements.
     unsigned idx16_elems = idx_elems;
     Value *idx16 = (idx_elem_size == 8) ?
-                    call_intrin(VectorType::get(i16_t, idx16_elems),
-                    "halide.hexagon.unpack.vub", {idx}) : idx;
+                       call_intrin(VectorType::get(i16_t, idx16_elems),
+                                   "halide.hexagon.unpack.vub", {idx}) :
+                       idx;
 
-    const int replicate = lut_ty->getScalarSizeInBits()/16;
+    const int replicate = lut_ty->getScalarSizeInBits() / 16;
     if (replicate > 1) {
         // Replicate the LUT indices and use vlut16.
         // For LUT32: create two indices:
@@ -2068,7 +2069,7 @@ Value *CodeGen_Hexagon::vlut(Value *lut, Value *idx, int min_index, int max_inde
         lut = builder->CreateBitCast(lut, lut_ty);
     }
 
-    llvm::Type *i8x_t  = VectorType::get(i8_t,  idx16_elems);
+    llvm::Type *i8x_t = VectorType::get(i8_t, idx16_elems);
     llvm::Type *i16x_t = VectorType::get(i16_t, idx16_elems);
     Value *minus_one = create_vector(i16x_t, -1);
 
@@ -2077,7 +2078,8 @@ Value *CodeGen_Hexagon::vlut(Value *lut, Value *idx, int min_index, int max_inde
         // If the idx already had 8 bit elements and no replication was needed,
         // we can use idx else we need to pack idx16.
         Value *idx8 = (idx_elem_size == 16 || idx_elems != idx16_elems) ?
-                       call_intrin(i8x_t, "halide.hexagon.pack.vh", {idx16}) : idx;
+                          call_intrin(i8x_t, "halide.hexagon.pack.vh", {idx16}) :
+                          idx;
         Value *result_val = vlut256(lut, idx8, min_index, max_index);
         return builder->CreateBitCast(result_val, result_ty);
     }
@@ -2102,12 +2104,13 @@ Value *CodeGen_Hexagon::vlut(Value *lut, Value *idx, int min_index, int max_inde
         // truncate to 8 bits, as vlut requires.
         indices = call_intrin(i8x_t, "halide.hexagon.pack.vh", {indices});
         use_index = (lut_ty->getScalarSizeInBits() == 8) ?
-                    call_intrin(i8x_t, "halide.hexagon.pack.vh", {use_index}) : use_index;
+                        call_intrin(i8x_t, "halide.hexagon.pack.vh", {use_index}) :
+                        use_index;
 
         int range_extent_i = std::min(max_index - min_index_i, 255);
         Value *range_i = vlut256(slice_vector(lut, min_index_i, range_extent_i),
                                  indices, 0, range_extent_i);
-        ranges.push_back({ range_i, use_index });
+        ranges.push_back({range_i, use_index});
     }
 
     // TODO: This could be reduced hierarchically instead of in

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1309,7 +1309,7 @@ void CodeGen_LLVM::optimize_module() {
     mpm.run(*module, mam);
 
     if (llvm::verifyModule(*module, &errs()))
-      report_fatal_error("Transformation resulted in an invalid module\n");
+        report_fatal_error("Transformation resulted in an invalid module\n");
 
 #else
     // Keep the legacy pass manager for LLVM < 90
@@ -3006,14 +3006,14 @@ void CodeGen_LLVM::visit(const Call *op) {
                 }
             }
             if (get_target().has_feature(Target::MSAN)) {
-              // Note that we mark the entire buffer as initialized;
-              // it would be more accurate to just mark (dst - buf)
-              llvm::Function *annotate = module->getFunction("halide_msan_annotate_memory_is_initialized");
-              vector<Value *> annotate_args(3);
-              annotate_args[0] = get_user_context();
-              annotate_args[1] = buf;
-              annotate_args[2] = codegen(Cast::make(Int(64), buf_size));
-              builder->CreateCall(annotate, annotate_args);
+                // Note that we mark the entire buffer as initialized;
+                // it would be more accurate to just mark (dst - buf)
+                llvm::Function *annotate = module->getFunction("halide_msan_annotate_memory_is_initialized");
+                vector<Value *> annotate_args(3);
+                annotate_args[0] = get_user_context();
+                annotate_args[1] = buf;
+                annotate_args[2] = codegen(Cast::make(Int(64), buf_size));
+                builder->CreateCall(annotate, annotate_args);
             }
             value = buf;
         }

--- a/src/CodeGen_PyTorch.cpp
+++ b/src/CodeGen_PyTorch.cpp
@@ -292,11 +292,11 @@ inline int test1_th_(at::Tensor &_buf, float _alpha, int32_t _beta) {
     return 0;
 }
 
-#include "torch/extension.h"
-#include "HalideBuffer.h"
-#include "HalidePyTorchHelpers.h"
 #include "ATen/cuda/CUDAContext.h"
+#include "HalideBuffer.h"
 #include "HalidePyTorchCudaHelpers.h"
+#include "HalidePyTorchHelpers.h"
+#include "torch/extension.h"
 
 struct halide_buffer_t;
 struct halide_filter_metadata_t;

--- a/src/DerivativeUtils.cpp
+++ b/src/DerivativeUtils.cpp
@@ -540,7 +540,9 @@ bool is_calling_function(
 struct SubstituteCallArgWithPureArg : public IRMutator {
 public:
     SubstituteCallArgWithPureArg(Func f, int variable_id)
-        : f(f), variable_id(variable_id) {}
+        : f(f), variable_id(variable_id) {
+    }
+
 protected:
     using IRMutator::visit;
     Expr visit(const Call *op) override {

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1511,7 +1511,7 @@ Module GeneratorBase::build_gradient_module(const std::string &function_name) {
             const Type grad_in_type = output->type().is_float() ? output->type() : Float(32);
             const int grad_in_dimensions = f.dimensions();
             const ArgumentEstimates grad_in_estimates = f.output_buffer().parameter().get_argument_estimates();
-            internal_assert((int) grad_in_estimates.buffer_estimates.size() == grad_in_dimensions);
+            internal_assert((int)grad_in_estimates.buffer_estimates.size() == grad_in_dimensions);
 
             ImageParam d_im(grad_in_type, grad_in_dimensions, grad_in_name);
             for (int d = 0; d < grad_in_dimensions; d++) {

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -325,13 +325,13 @@ std::unique_ptr<llvm::Module> clone_module(const llvm::Module &module_in) {
 
 }  // namespace
 
-void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out, 
+void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out,
 #if LLVM_VERSION >= 100
-                llvm::CodeGenFileType file_type
+               llvm::CodeGenFileType file_type
 #else
-                llvm::TargetMachine::CodeGenFileType file_type
+               llvm::TargetMachine::CodeGenFileType file_type
 #endif
-                ) {
+) {
     Internal::debug(1) << "emit_file.Compiling to native code...\n";
     Internal::debug(2) << "Target triple: " << module_in.getTargetTriple() << "\n";
 

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -300,7 +300,7 @@ Module lower(const vector<Function> &output_funcs,
         debug(1) << "Injecting host <-> dev buffer copies...\n";
         s = inject_host_dev_buffer_copies(s, t);
         debug(2) << "Lowering after injecting host <-> dev buffer copies:\n"
-                    << s << "\n\n";
+                 << s << "\n\n";
     }
 
     if (t.has_feature(Target::OpenGL)) {

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -162,7 +162,7 @@ Pipeline::Pipeline(const vector<Func> &outputs)
 
 vector<Func> Pipeline::outputs() const {
     vector<Func> funcs;
-    for (const Function& f : contents->outputs) {
+    for (const Function &f : contents->outputs) {
         funcs.emplace_back(f);
     }
     return funcs;
@@ -188,8 +188,7 @@ void Pipeline::auto_schedule_Mullapudi2016(Pipeline pipeline, const Target &targ
 /* static */
 std::map<std::string, AutoSchedulerFn> &Pipeline::get_autoscheduler_map() {
     static std::map<std::string, AutoSchedulerFn> autoschedulers = {
-        { "Mullapudi2016", auto_schedule_Mullapudi2016 }
-    };
+        {"Mullapudi2016", auto_schedule_Mullapudi2016}};
     return autoschedulers;
 }
 
@@ -239,7 +238,7 @@ void Pipeline::add_autoscheduler(const std::string &autoscheduler_name, const Au
 
 /* static */
 void Pipeline::set_default_autoscheduler_name(const std::string &autoscheduler_name) {
-    (void) find_autoscheduler(autoscheduler_name);  // ensure it's valid
+    (void)find_autoscheduler(autoscheduler_name);  // ensure it's valid
     get_default_autoscheduler_name() = autoscheduler_name;
 }
 

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -38,7 +38,7 @@ struct MachineParams {
     float balance;
 
     explicit MachineParams(int parallelism, uint64_t llc, float balance)
-            : parallelism(parallelism), last_level_cache_size(llc), balance(balance) {
+        : parallelism(parallelism), last_level_cache_size(llc), balance(balance) {
     }
 
     /** Default machine parameters for generic CPU architecture. */
@@ -183,7 +183,6 @@ public:
     AutoSchedulerResults auto_schedule(const std::string &autoscheduler_name,
                                        const Target &target,
                                        const MachineParams &arch_params = MachineParams::generic());
-
 
     /** Add a new the autoscheduler method with the given name. Does not affect the current default autoscheduler.
      * It is an error to call this with the same name multiple times. */

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -287,7 +287,7 @@ struct StageScheduleContents {
     StageScheduleContents()
         : fuse_level(FuseLoopLevel()), touched(false),
           allow_race_conditions(false), atomic(false),
-          override_atomic_associativity_test(false) {};
+          override_atomic_associativity_test(false){};
 
     // Pass an IRMutator through to all Exprs referenced in the StageScheduleContents
     void mutate(IRMutator *mutator) {

--- a/src/Simplify_Add.cpp
+++ b/src/Simplify_Add.cpp
@@ -49,100 +49,99 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
             return rewrite.result;
         }
 
-        if (EVAL_IN_LAMBDA
-            (rewrite(x + x, x * 2) ||
-             rewrite(ramp(x, y) + ramp(z, w), ramp(x + z, y + w, lanes)) ||
-             rewrite(ramp(x, y) + broadcast(z), ramp(x + z, y, lanes)) ||
-             rewrite(broadcast(x) + broadcast(y), broadcast(x + y, lanes)) ||
-             rewrite(select(x, y, z) + select(x, w, u), select(x, y + w, z + u)) ||
-             rewrite(select(x, c0, c1) + c2, select(x, fold(c0 + c2), fold(c1 + c2))) ||
-             rewrite(select(x, y, c1) + c2, select(x, y + c2, fold(c1 + c2))) ||
-             rewrite(select(x, c0, y) + c2, select(x, fold(c0 + c2), y + c2)) ||
+        if (EVAL_IN_LAMBDA(rewrite(x + x, x * 2) ||
+                           rewrite(ramp(x, y) + ramp(z, w), ramp(x + z, y + w, lanes)) ||
+                           rewrite(ramp(x, y) + broadcast(z), ramp(x + z, y, lanes)) ||
+                           rewrite(broadcast(x) + broadcast(y), broadcast(x + y, lanes)) ||
+                           rewrite(select(x, y, z) + select(x, w, u), select(x, y + w, z + u)) ||
+                           rewrite(select(x, c0, c1) + c2, select(x, fold(c0 + c2), fold(c1 + c2))) ||
+                           rewrite(select(x, y, c1) + c2, select(x, y + c2, fold(c1 + c2))) ||
+                           rewrite(select(x, c0, y) + c2, select(x, fold(c0 + c2), y + c2)) ||
 
-             rewrite((select(x, y, z) + w) + select(x, u, v), select(x, y + u, z + v) + w) ||
-             rewrite((w + select(x, y, z)) + select(x, u, v), select(x, y + u, z + v) + w) ||
-             rewrite(select(x, y, z) + (select(x, u, v) + w), select(x, y + u, z + v) + w) ||
-             rewrite(select(x, y, z) + (w + select(x, u, v)), select(x, y + u, z + v) + w) ||
-             rewrite((select(x, y, z) - w) + select(x, u, v), select(x, y + u, z + v) - w) ||
-             rewrite(select(x, y, z) + (select(x, u, v) - w), select(x, y + u, z + v) - w) ||
-             rewrite((w - select(x, y, z)) + select(x, u, v), select(x, u - y, v - z) + w) ||
-             rewrite(select(x, y, z) + (w - select(x, u, v)), select(x, y - u, z - v) + w) ||
+                           rewrite((select(x, y, z) + w) + select(x, u, v), select(x, y + u, z + v) + w) ||
+                           rewrite((w + select(x, y, z)) + select(x, u, v), select(x, y + u, z + v) + w) ||
+                           rewrite(select(x, y, z) + (select(x, u, v) + w), select(x, y + u, z + v) + w) ||
+                           rewrite(select(x, y, z) + (w + select(x, u, v)), select(x, y + u, z + v) + w) ||
+                           rewrite((select(x, y, z) - w) + select(x, u, v), select(x, y + u, z + v) - w) ||
+                           rewrite(select(x, y, z) + (select(x, u, v) - w), select(x, y + u, z + v) - w) ||
+                           rewrite((w - select(x, y, z)) + select(x, u, v), select(x, u - y, v - z) + w) ||
+                           rewrite(select(x, y, z) + (w - select(x, u, v)), select(x, y - u, z - v) + w) ||
 
-             rewrite((x + c0) + c1, x + fold(c0 + c1)) ||
-             rewrite((x + c0) + y, (x + y) + c0) ||
-             rewrite(x + (y + c0), (x + y) + c0) ||
-             rewrite((c0 - x) + c1, fold(c0 + c1) - x) ||
-             rewrite((c0 - x) + y, (y - x) + c0) ||
+                           rewrite((x + c0) + c1, x + fold(c0 + c1)) ||
+                           rewrite((x + c0) + y, (x + y) + c0) ||
+                           rewrite(x + (y + c0), (x + y) + c0) ||
+                           rewrite((c0 - x) + c1, fold(c0 + c1) - x) ||
+                           rewrite((c0 - x) + y, (y - x) + c0) ||
 
-             rewrite((x - y) + y, x) ||
-             rewrite(x + (y - x), y) ||
+                           rewrite((x - y) + y, x) ||
+                           rewrite(x + (y - x), y) ||
 
-             rewrite(((x - y) + z) + y, x + z) ||
-             rewrite((z + (x - y)) + y, z + x) ||
-             rewrite(x + ((y - x) + z), y + z) ||
-             rewrite(x + (z + (y - x)), z + y) ||
+                           rewrite(((x - y) + z) + y, x + z) ||
+                           rewrite((z + (x - y)) + y, z + x) ||
+                           rewrite(x + ((y - x) + z), y + z) ||
+                           rewrite(x + (z + (y - x)), z + y) ||
 
-             rewrite(x + (c0 - y), (x - y) + c0) ||
-             rewrite((x - y) + (y - z), x - z) ||
-             rewrite((x - y) + (z - x), z - y) ||
-             rewrite(x + y*c0, x - y*(-c0), c0 < 0 && -c0 > 0) ||
+                           rewrite(x + (c0 - y), (x - y) + c0) ||
+                           rewrite((x - y) + (y - z), x - z) ||
+                           rewrite((x - y) + (z - x), z - y) ||
+                           rewrite(x + y * c0, x - y * (-c0), c0 < 0 && -c0 > 0) ||
 
-             rewrite(x + (y*c0 - z), x - y*(-c0) - z, c0 < 0 && -c0 > 0) ||
-             rewrite((y*c0 - z) + x, x - y*(-c0) - z, c0 < 0 && -c0 > 0) ||
+                           rewrite(x + (y * c0 - z), x - y * (-c0) - z, c0 < 0 && -c0 > 0) ||
+                           rewrite((y * c0 - z) + x, x - y * (-c0) - z, c0 < 0 && -c0 > 0) ||
 
-             rewrite(x*c0 + y, y - x*(-c0), c0 < 0 && -c0 > 0 && !is_const(y)) ||
-             rewrite(x*y + z*y, (x + z)*y) ||
-             rewrite(x*y + y*z, (x + z)*y) ||
-             rewrite(y*x + z*y, y*(x + z)) ||
-             rewrite(y*x + y*z, y*(x + z)) ||
-             rewrite(x*c0 + y*c1, (x + y*fold(c1/c0)) * c0, c1 % c0 == 0) ||
-             rewrite(x*c0 + y*c1, (x*fold(c0/c1) + y) * c1, c0 % c1 == 0) ||
-             (no_overflow(op->type) &&
-              (rewrite(x + x*y, x * (y + 1)) ||
-               rewrite(x + y*x, (y + 1) * x) ||
-               rewrite(x*y + x, x * (y + 1)) ||
-               rewrite(y*x + x, (y + 1) * x, !is_const(x)) ||
-               rewrite((x + c0)/c1 + c2, (x + fold(c0 + c1*c2))/c1) ||
-               rewrite((x + (y + c0)/c1) + c2, x + (y + fold(c0 + c1*c2))/c1) ||
-               rewrite(((y + c0)/c1 + x) + c2, x + (y + fold(c0 + c1*c2))/c1) ||
-               rewrite((c0 - x)/c1 + c2, (fold(c0 + c1*c2) - x)/c1, c0 != 0 && c1 != 0) || // When c0 is zero, this would fight another rule
-               rewrite(x + (x + y)/c0, (fold(c0 + 1)*x + y)/c0) ||
-               rewrite(x + (y + x)/c0, (fold(c0 + 1)*x + y)/c0) ||
-               rewrite(x + (y - x)/c0, (fold(c0 - 1)*x + y)/c0) ||
-               rewrite(x + (x - y)/c0, (fold(c0 + 1)*x - y)/c0) ||
-               rewrite((x - y)/c0 + x, (fold(c0 + 1)*x - y)/c0) ||
-               rewrite((y - x)/c0 + x, (y + fold(c0 - 1)*x)/c0) ||
-               rewrite((x + y)/c0 + x, (fold(c0 + 1)*x + y)/c0) ||
-               rewrite((y + x)/c0 + x, (y + fold(c0 + 1)*x)/c0) ||
-               rewrite(min(x, y - z) + z, min(x + z, y)) ||
-               rewrite(min(y - z, x) + z, min(y, x + z)) ||
-               rewrite(min(x, y + c0) + c1, min(x + c1, y), c0 + c1 == 0) ||
-               rewrite(min(y + c0, x) + c1, min(y, x + c1), c0 + c1 == 0) ||
-               rewrite(z + min(x, y - z), min(z + x, y)) ||
-               rewrite(z + min(y - z, x), min(y, z + x)) ||
-               rewrite(z + max(x, y - z), max(z + x, y)) ||
-               rewrite(z + max(y - z, x), max(y, z + x)) ||
-               rewrite(max(x, y - z) + z, max(x + z, y)) ||
-               rewrite(max(y - z, x) + z, max(y, x + z)) ||
-               rewrite(max(x, y + c0) + c1, max(x + c1, y), c0 + c1 == 0) ||
-               rewrite(max(y + c0, x) + c1, max(y, x + c1), c0 + c1 == 0) ||
-               rewrite(max(x, y) + min(x, y), x + y) ||
-               rewrite(max(x, y) + min(y, x), x + y))) ||
-             (no_overflow_int(op->type) &&
-              (rewrite((x/y)*y + x%y, x) ||
-               rewrite((z + x/y)*y + x%y, z*y + x) ||
-               rewrite((x/y + z)*y + x%y, x + z*y) ||
-               rewrite(x%y + ((x/y)*y + z), x + z) ||
-               rewrite(x%y + ((x/y)*y - z), x - z) ||
-               rewrite(x%y + (z + (x/y)*y), x + z) ||
-               rewrite((x/y)*y + (x%y + z), x + z) ||
-               rewrite((x/y)*y + (x%y - z), x - z) ||
-               rewrite((x/y)*y + (z + x%y), x + z) ||
-               rewrite(x/2 + x%2, (x + 1) / 2) ||
+                           rewrite(x * c0 + y, y - x * (-c0), c0 < 0 && -c0 > 0 && !is_const(y)) ||
+                           rewrite(x * y + z * y, (x + z) * y) ||
+                           rewrite(x * y + y * z, (x + z) * y) ||
+                           rewrite(y * x + z * y, y * (x + z)) ||
+                           rewrite(y * x + y * z, y * (x + z)) ||
+                           rewrite(x * c0 + y * c1, (x + y * fold(c1 / c0)) * c0, c1 % c0 == 0) ||
+                           rewrite(x * c0 + y * c1, (x * fold(c0 / c1) + y) * c1, c0 % c1 == 0) ||
+                           (no_overflow(op->type) &&
+                            (rewrite(x + x * y, x * (y + 1)) ||
+                             rewrite(x + y * x, (y + 1) * x) ||
+                             rewrite(x * y + x, x * (y + 1)) ||
+                             rewrite(y * x + x, (y + 1) * x, !is_const(x)) ||
+                             rewrite((x + c0) / c1 + c2, (x + fold(c0 + c1 * c2)) / c1) ||
+                             rewrite((x + (y + c0) / c1) + c2, x + (y + fold(c0 + c1 * c2)) / c1) ||
+                             rewrite(((y + c0) / c1 + x) + c2, x + (y + fold(c0 + c1 * c2)) / c1) ||
+                             rewrite((c0 - x) / c1 + c2, (fold(c0 + c1 * c2) - x) / c1, c0 != 0 && c1 != 0) ||  // When c0 is zero, this would fight another rule
+                             rewrite(x + (x + y) / c0, (fold(c0 + 1) * x + y) / c0) ||
+                             rewrite(x + (y + x) / c0, (fold(c0 + 1) * x + y) / c0) ||
+                             rewrite(x + (y - x) / c0, (fold(c0 - 1) * x + y) / c0) ||
+                             rewrite(x + (x - y) / c0, (fold(c0 + 1) * x - y) / c0) ||
+                             rewrite((x - y) / c0 + x, (fold(c0 + 1) * x - y) / c0) ||
+                             rewrite((y - x) / c0 + x, (y + fold(c0 - 1) * x) / c0) ||
+                             rewrite((x + y) / c0 + x, (fold(c0 + 1) * x + y) / c0) ||
+                             rewrite((y + x) / c0 + x, (y + fold(c0 + 1) * x) / c0) ||
+                             rewrite(min(x, y - z) + z, min(x + z, y)) ||
+                             rewrite(min(y - z, x) + z, min(y, x + z)) ||
+                             rewrite(min(x, y + c0) + c1, min(x + c1, y), c0 + c1 == 0) ||
+                             rewrite(min(y + c0, x) + c1, min(y, x + c1), c0 + c1 == 0) ||
+                             rewrite(z + min(x, y - z), min(z + x, y)) ||
+                             rewrite(z + min(y - z, x), min(y, z + x)) ||
+                             rewrite(z + max(x, y - z), max(z + x, y)) ||
+                             rewrite(z + max(y - z, x), max(y, z + x)) ||
+                             rewrite(max(x, y - z) + z, max(x + z, y)) ||
+                             rewrite(max(y - z, x) + z, max(y, x + z)) ||
+                             rewrite(max(x, y + c0) + c1, max(x + c1, y), c0 + c1 == 0) ||
+                             rewrite(max(y + c0, x) + c1, max(y, x + c1), c0 + c1 == 0) ||
+                             rewrite(max(x, y) + min(x, y), x + y) ||
+                             rewrite(max(x, y) + min(y, x), x + y))) ||
+                           (no_overflow_int(op->type) &&
+                            (rewrite((x / y) * y + x % y, x) ||
+                             rewrite((z + x / y) * y + x % y, z * y + x) ||
+                             rewrite((x / y + z) * y + x % y, x + z * y) ||
+                             rewrite(x % y + ((x / y) * y + z), x + z) ||
+                             rewrite(x % y + ((x / y) * y - z), x - z) ||
+                             rewrite(x % y + (z + (x / y) * y), x + z) ||
+                             rewrite((x / y) * y + (x % y + z), x + z) ||
+                             rewrite((x / y) * y + (x % y - z), x - z) ||
+                             rewrite((x / y) * y + (z + x % y), x + z) ||
+                             rewrite(x / 2 + x % 2, (x + 1) / 2) ||
 
-               rewrite(x + ((c0 - x)/c1)*c1, c0 - ((c0 - x) % c1), c1 > 0) ||
-               rewrite(x + ((c0 - x)/c1 + y)*c1, y * c1 - ((c0 - x) % c1) + c0, c1 > 0) ||
-               rewrite(x + (y + (c0 - x)/c1)*c1, y * c1 - ((c0 - x) % c1) + c0, c1 > 0))))) {
+                             rewrite(x + ((c0 - x) / c1) * c1, c0 - ((c0 - x) % c1), c1 > 0) ||
+                             rewrite(x + ((c0 - x) / c1 + y) * c1, y * c1 - ((c0 - x) % c1) + c0, c1 > 0) ||
+                             rewrite(x + (y + (c0 - x) / c1) * c1, y * c1 - ((c0 - x) % c1) + c0, c1 > 0))))) {
             return mutate(std::move(rewrite.result), bounds);
         }
 

--- a/src/Simplify_And.cpp
+++ b/src/Simplify_And.cpp
@@ -18,59 +18,58 @@ Expr Simplify::visit(const And *op, ExprInfo *bounds) {
 
     auto rewrite = IRMatcher::rewriter(IRMatcher::and_op(a, b), op->type);
 
-    if (EVAL_IN_LAMBDA
-        (rewrite(x && true, a) ||
-         rewrite(x && false, b) ||
-         rewrite(x && x, a) ||
+    if (EVAL_IN_LAMBDA(rewrite(x && true, a) ||
+                       rewrite(x && false, b) ||
+                       rewrite(x && x, a) ||
 
-         rewrite((x && y) && x, a) ||
-         rewrite(x && (x && y), b) ||
-         rewrite((x && y) && y, a) ||
-         rewrite(y && (x && y), b) ||
+                       rewrite((x && y) && x, a) ||
+                       rewrite(x && (x && y), b) ||
+                       rewrite((x && y) && y, a) ||
+                       rewrite(y && (x && y), b) ||
 
-         rewrite(((x && y) && z) && x, a) ||
-         rewrite(x && ((x && y) && z), b) ||
-         rewrite((z && (x && y)) && x, a) ||
-         rewrite(x && (z && (x && y)), b) ||
-         rewrite(((x && y) && z) && y, a) ||
-         rewrite(y && ((x && y) && z), b) ||
-         rewrite((z && (x && y)) && y, a) ||
-         rewrite(y && (z && (x && y)), b) ||
+                       rewrite(((x && y) && z) && x, a) ||
+                       rewrite(x && ((x && y) && z), b) ||
+                       rewrite((z && (x && y)) && x, a) ||
+                       rewrite(x && (z && (x && y)), b) ||
+                       rewrite(((x && y) && z) && y, a) ||
+                       rewrite(y && ((x && y) && z), b) ||
+                       rewrite((z && (x && y)) && y, a) ||
+                       rewrite(y && (z && (x && y)), b) ||
 
-         rewrite((x || y) && x, b) ||
-         rewrite(x && (x || y), a) ||
-         rewrite((x || y) && y, b) ||
-         rewrite(y && (x || y), a) ||
+                       rewrite((x || y) && x, b) ||
+                       rewrite(x && (x || y), a) ||
+                       rewrite((x || y) && y, b) ||
+                       rewrite(y && (x || y), a) ||
 
-         rewrite(x != y && x == y, false) ||
-         rewrite(x != y && y == x, false) ||
-         rewrite((z && x != y) && x == y, false) ||
-         rewrite((z && x != y) && y == x, false) ||
-         rewrite((x != y && z) && x == y, false) ||
-         rewrite((x != y && z) && y == x, false) ||
-         rewrite((z && x == y) && x != y, false) ||
-         rewrite((z && x == y) && y != x, false) ||
-         rewrite((x == y && z) && x != y, false) ||
-         rewrite((x == y && z) && y != x, false) ||
-         rewrite(x && !x, false) ||
-         rewrite(!x && x, false) ||
-         rewrite(y <= x && x < y, false) ||
-         rewrite(x != c0 && x == c1, b, c0 != c1) ||
-         // Note: In the predicate below, if undefined overflow
-         // occurs, the predicate counts as false. If well-defined
-         // overflow occurs, the condition couldn't possibly
-         // trigger because c0 + 1 will be the smallest possible
-         // value.
-         rewrite(c0 < x && x < c1, false, !is_float(x) && c1 <= c0 + 1) ||
-         rewrite(x < c1 && c0 < x, false, !is_float(x) && c1 <= c0 + 1) ||
-         rewrite(x <= c1 && c0 < x, false, c1 <= c0) ||
-         rewrite(c0 <= x && x < c1, false, c1 <= c0) ||
-         rewrite(c0 <= x && x <= c1, false, c1 < c0) ||
-         rewrite(x <= c1 && c0 <= x, false, c1 < c0) ||
-         rewrite(c0 < x && c1 < x, fold(max(c0, c1)) < x) ||
-         rewrite(c0 <= x && c1 <= x, fold(max(c0, c1)) <= x) ||
-         rewrite(x < c0 && x < c1, x < fold(min(c0, c1))) ||
-         rewrite(x <= c0 && x <= c1, x <= fold(min(c0, c1))))) {
+                       rewrite(x != y && x == y, false) ||
+                       rewrite(x != y && y == x, false) ||
+                       rewrite((z && x != y) && x == y, false) ||
+                       rewrite((z && x != y) && y == x, false) ||
+                       rewrite((x != y && z) && x == y, false) ||
+                       rewrite((x != y && z) && y == x, false) ||
+                       rewrite((z && x == y) && x != y, false) ||
+                       rewrite((z && x == y) && y != x, false) ||
+                       rewrite((x == y && z) && x != y, false) ||
+                       rewrite((x == y && z) && y != x, false) ||
+                       rewrite(x && !x, false) ||
+                       rewrite(!x && x, false) ||
+                       rewrite(y <= x && x < y, false) ||
+                       rewrite(x != c0 && x == c1, b, c0 != c1) ||
+                       // Note: In the predicate below, if undefined overflow
+                       // occurs, the predicate counts as false. If well-defined
+                       // overflow occurs, the condition couldn't possibly
+                       // trigger because c0 + 1 will be the smallest possible
+                       // value.
+                       rewrite(c0 < x && x < c1, false, !is_float(x) && c1 <= c0 + 1) ||
+                       rewrite(x < c1 && c0 < x, false, !is_float(x) && c1 <= c0 + 1) ||
+                       rewrite(x <= c1 && c0 < x, false, c1 <= c0) ||
+                       rewrite(c0 <= x && x < c1, false, c1 <= c0) ||
+                       rewrite(c0 <= x && x <= c1, false, c1 < c0) ||
+                       rewrite(x <= c1 && c0 <= x, false, c1 < c0) ||
+                       rewrite(c0 < x && c1 < x, fold(max(c0, c1)) < x) ||
+                       rewrite(c0 <= x && c1 <= x, fold(max(c0, c1)) <= x) ||
+                       rewrite(x < c0 && x < c1, x < fold(min(c0, c1))) ||
+                       rewrite(x <= c0 && x <= c1, x <= fold(min(c0, c1))))) {
         return rewrite.result;
     }
 

--- a/src/Simplify_Div.cpp
+++ b/src/Simplify_Div.cpp
@@ -85,7 +85,6 @@ Expr Simplify::visit(const Div *op, ExprInfo *bounds) {
          (b_bounds.max_defined && b_bounds.max < 0) ||
          (b_bounds.alignment.remainder != 0));
 
-
     if (may_simplify(op->type)) {
 
         int lanes = op->type.lanes();
@@ -106,88 +105,87 @@ Expr Simplify::visit(const Div *op, ExprInfo *bounds) {
             return rewrite.result;
         }
 
-        if (EVAL_IN_LAMBDA
-            (rewrite(broadcast(x) / broadcast(y), broadcast(x / y, lanes)) ||
-             rewrite(select(x, c0, c1) / c2, select(x, fold(c0/c2), fold(c1/c2))) ||
-             (no_overflow(op->type) &&
-              (// Fold repeated division
-               rewrite((x / c0) / c2, x / fold(c0 * c2),                          c0 > 0 && c2 > 0 && !overflows(c0 * c2)) ||
-               rewrite((x / c0 + c1) / c2, (x + fold(c1 * c0)) / fold(c0 * c2),   c0 > 0 && c2 > 0 && !overflows(c0 * c2) && !overflows(c0 * c1)) ||
-               rewrite((x * c0) / c1, x / fold(c1 / c0),                          c1 % c0 == 0 && c0 > 0 && c1 / c0 != 0) ||
-               // Pull out terms that are a multiple of the denominator
-               rewrite((x * c0) / c1, x * fold(c0 / c1),                          c0 % c1 == 0 && c1 > 0) ||
+        if (EVAL_IN_LAMBDA(rewrite(broadcast(x) / broadcast(y), broadcast(x / y, lanes)) ||
+                           rewrite(select(x, c0, c1) / c2, select(x, fold(c0 / c2), fold(c1 / c2))) ||
+                           (no_overflow(op->type) &&
+                            (  // Fold repeated division
+                                rewrite((x / c0) / c2, x / fold(c0 * c2), c0 > 0 && c2 > 0 && !overflows(c0 * c2)) ||
+                                rewrite((x / c0 + c1) / c2, (x + fold(c1 * c0)) / fold(c0 * c2), c0 > 0 && c2 > 0 && !overflows(c0 * c2) && !overflows(c0 * c1)) ||
+                                rewrite((x * c0) / c1, x / fold(c1 / c0), c1 % c0 == 0 && c0 > 0 && c1 / c0 != 0) ||
+                                // Pull out terms that are a multiple of the denominator
+                                rewrite((x * c0) / c1, x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
 
-               rewrite((x * c0 + y) / c1, y / c1 + x * fold(c0 / c1),             c0 % c1 == 0 && c1 > 0) ||
-               rewrite((x * c0 - y) / c1, (-y) / c1 + x * fold(c0 / c1),          c0 % c1 == 0 && c1 > 0) ||
-               rewrite((y + x * c0) / c1, y / c1 + x * fold(c0 / c1),             c0 % c1 == 0 && c1 > 0) ||
-               rewrite((y - x * c0) / c1, y / c1 - x * fold(c0 / c1),             c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((x * c0 + y) / c1, y / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((x * c0 - y) / c1, (-y) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((y + x * c0) / c1, y / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((y - x * c0) / c1, y / c1 - x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
 
-               rewrite(((x * c0 + y) + z) / c1, (y + z) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite(((x * c0 - y) + z) / c1, (z - y) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite(((x * c0 + y) - z) / c1, (y - z) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite(((x * c0 - y) - z) / c1, (-y - z) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite(((x * c0 + y) + z) / c1, (y + z) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite(((x * c0 - y) + z) / c1, (z - y) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite(((x * c0 + y) - z) / c1, (y - z) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite(((x * c0 - y) - z) / c1, (-y - z) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
 
-               rewrite(((y + x * c0) + z) / c1, (y + z) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite(((y + x * c0) - z) / c1, (y - z) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite(((y - x * c0) - z) / c1, (y - z) / c1 - x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite(((y - x * c0) + z) / c1, (y + z) / c1 - x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite(((y + x * c0) + z) / c1, (y + z) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite(((y + x * c0) - z) / c1, (y - z) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite(((y - x * c0) - z) / c1, (y - z) / c1 - x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite(((y - x * c0) + z) / c1, (y + z) / c1 - x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
 
-               rewrite((z + (x * c0 + y)) / c1, (z + y) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite((z + (x * c0 - y)) / c1, (z - y) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite((z - (x * c0 - y)) / c1, (z + y) / c1 - x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite((z - (x * c0 + y)) / c1, (z - y) / c1 - x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((z + (x * c0 + y)) / c1, (z + y) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((z + (x * c0 - y)) / c1, (z - y) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((z - (x * c0 - y)) / c1, (z + y) / c1 - x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((z - (x * c0 + y)) / c1, (z - y) / c1 - x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
 
-               rewrite((z + (y + x * c0)) / c1, (z + y) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite((z - (y + x * c0)) / c1, (z - y) / c1 - x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite((z + (y - x * c0)) / c1, (z + y) / c1 - x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite((z - (y - x * c0)) / c1, (z - y) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((z + (y + x * c0)) / c1, (z + y) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((z - (y + x * c0)) / c1, (z - y) / c1 - x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((z + (y - x * c0)) / c1, (z + y) / c1 - x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((z - (y - x * c0)) / c1, (z - y) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
 
-               // For the next depth, stick to addition
-               rewrite((((x * c0 + y) + z) + w) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite((((y + x * c0) + z) + w) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite(((z + (x * c0 + y)) + w) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite(((z + (y + x * c0)) + w) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite((w + ((x * c0 + y) + z)) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite((w + ((y + x * c0) + z)) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite((w + (z + (x * c0 + y))) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
-               rewrite((w + (z + (y + x * c0))) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                // For the next depth, stick to addition
+                                rewrite((((x * c0 + y) + z) + w) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((((y + x * c0) + z) + w) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite(((z + (x * c0 + y)) + w) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite(((z + (y + x * c0)) + w) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((w + ((x * c0 + y) + z)) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((w + ((y + x * c0) + z)) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((w + (z + (x * c0 + y))) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
+                                rewrite((w + (z + (y + x * c0))) / c1, (y + z + w) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
 
-               rewrite((x + c0) / c1, x / c1 + fold(c0 / c1),                     c0 % c1 == 0) ||
-               rewrite((x + y)/x, y/x + 1) ||
-               rewrite((y + x)/x, y/x + 1) ||
-               rewrite((x - y)/x, (-y)/x + 1) ||
-               rewrite((y - x)/x, y/x - 1) ||
-               rewrite(((x + y) + z)/x, (y + z)/x + 1) ||
-               rewrite(((y + x) + z)/x, (y + z)/x + 1) ||
-               rewrite((z + (x + y))/x, (z + y)/x + 1) ||
-               rewrite((z + (y + x))/x, (z + y)/x + 1) ||
-               rewrite((x*y)/x, y) ||
-               rewrite((y*x)/x, y) ||
-               rewrite((x*y + z)/x, y + z/x) ||
-               rewrite((y*x + z)/x, y + z/x) ||
-               rewrite((z + x*y)/x, z/x + y) ||
-               rewrite((z + y*x)/x, z/x + y) ||
-               rewrite((x*y - z)/x, y + (-z)/x) ||
-               rewrite((y*x - z)/x, y + (-z)/x) ||
-               rewrite((z - x*y)/x, z/x - y) ||
-               rewrite((z - y*x)/x, z/x - y) ||
-               (op->type.is_float() && rewrite(x/c0, x * fold(1/c0))))) ||
-             (no_overflow_int(op->type) &&
-              (rewrite(ramp(x, c0) / broadcast(c1), ramp(x / c1, fold(c0 / c1), lanes), c0 % c1 == 0) ||
-               rewrite(ramp(x, c0) / broadcast(c1), broadcast(x / c1, lanes),
-                       // First and last lanes are the same when...
-                       can_prove((x % c1 + c0 * (lanes - 1)) / c1 == 0, this)))) ||
-             (no_overflow_scalar_int(op->type) &&
-              (rewrite(x / -1, -x) ||
-               rewrite(c0 / y, select(y < 0, fold(-c0), c0), c0 == -1 ) ||
-               rewrite((x * c0 + c1) / c2,
-                       (x + fold(c1 / c0)) / fold(c2 / c0),
-                       c2 > 0 && c0 > 0 && c2 % c0 == 0) ||
-               rewrite((x * c0 + c1) / c2,
-                       x * fold(c0 / c2) + fold(c1 / c2),
-                       c2 > 0 && c0 % c2 == 0) ||
-               // A very specific pattern that comes up in bounds in upsampling code.
-               rewrite((x % 2 + c0) / 2, x % 2 + fold(c0 / 2), c0 % 2 == 1))))) {
+                                rewrite((x + c0) / c1, x / c1 + fold(c0 / c1), c0 % c1 == 0) ||
+                                rewrite((x + y) / x, y / x + 1) ||
+                                rewrite((y + x) / x, y / x + 1) ||
+                                rewrite((x - y) / x, (-y) / x + 1) ||
+                                rewrite((y - x) / x, y / x - 1) ||
+                                rewrite(((x + y) + z) / x, (y + z) / x + 1) ||
+                                rewrite(((y + x) + z) / x, (y + z) / x + 1) ||
+                                rewrite((z + (x + y)) / x, (z + y) / x + 1) ||
+                                rewrite((z + (y + x)) / x, (z + y) / x + 1) ||
+                                rewrite((x * y) / x, y) ||
+                                rewrite((y * x) / x, y) ||
+                                rewrite((x * y + z) / x, y + z / x) ||
+                                rewrite((y * x + z) / x, y + z / x) ||
+                                rewrite((z + x * y) / x, z / x + y) ||
+                                rewrite((z + y * x) / x, z / x + y) ||
+                                rewrite((x * y - z) / x, y + (-z) / x) ||
+                                rewrite((y * x - z) / x, y + (-z) / x) ||
+                                rewrite((z - x * y) / x, z / x - y) ||
+                                rewrite((z - y * x) / x, z / x - y) ||
+                                (op->type.is_float() && rewrite(x / c0, x * fold(1 / c0))))) ||
+                           (no_overflow_int(op->type) &&
+                            (rewrite(ramp(x, c0) / broadcast(c1), ramp(x / c1, fold(c0 / c1), lanes), c0 % c1 == 0) ||
+                             rewrite(ramp(x, c0) / broadcast(c1), broadcast(x / c1, lanes),
+                                     // First and last lanes are the same when...
+                                     can_prove((x % c1 + c0 * (lanes - 1)) / c1 == 0, this)))) ||
+                           (no_overflow_scalar_int(op->type) &&
+                            (rewrite(x / -1, -x) ||
+                             rewrite(c0 / y, select(y < 0, fold(-c0), c0), c0 == -1) ||
+                             rewrite((x * c0 + c1) / c2,
+                                     (x + fold(c1 / c0)) / fold(c2 / c0),
+                                     c2 > 0 && c0 > 0 && c2 % c0 == 0) ||
+                             rewrite((x * c0 + c1) / c2,
+                                     x * fold(c0 / c2) + fold(c1 / c2),
+                                     c2 > 0 && c0 % c2 == 0) ||
+                             // A very specific pattern that comes up in bounds in upsampling code.
+                             rewrite((x % 2 + c0) / 2, x % 2 + fold(c0 / 2), c0 % 2 == 1))))) {
             return mutate(std::move(rewrite.result), bounds);
         }
     }

--- a/src/Simplify_LT.cpp
+++ b/src/Simplify_LT.cpp
@@ -30,333 +30,330 @@ Expr Simplify::visit(const LT *op, ExprInfo *bounds) {
 
         auto rewrite = IRMatcher::rewriter(IRMatcher::lt(a, b), op->type, ty);
 
-        if (EVAL_IN_LAMBDA
-            (rewrite(c0 < c1, fold(c0 < c1)) ||
-             rewrite(x < x, false) ||
-             rewrite(x < ty.min(), false) ||
-             rewrite(ty.max() < x, false) ||
+        if (EVAL_IN_LAMBDA(rewrite(c0 < c1, fold(c0 < c1)) ||
+                           rewrite(x < x, false) ||
+                           rewrite(x < ty.min(), false) ||
+                           rewrite(ty.max() < x, false) ||
 
-             rewrite(max(x, y) < x, false) ||
-             rewrite(max(y, x) < x, false) ||
-             rewrite(x < min(x, y), false) ||
-             rewrite(x < min(y, x), false) ||
+                           rewrite(max(x, y) < x, false) ||
+                           rewrite(max(y, x) < x, false) ||
+                           rewrite(x < min(x, y), false) ||
+                           rewrite(x < min(y, x), false) ||
 
-             // Comparisons of ramps and broadcasts. If the first
-             // and last lanes are provably < or >= the broadcast
-             // we can collapse the comparison.
-             (no_overflow(op->type) &&
-              (rewrite(ramp(x, c1) < broadcast(z), true, can_prove(x + fold(max(0, c1 * (lanes - 1))) < z, this)) ||
-               rewrite(ramp(x, c1) < broadcast(z), false, can_prove(x + fold(min(0, c1 * (lanes - 1))) >= z, this)) ||
-               rewrite(broadcast(z) < ramp(x, c1), true, can_prove(z < x + fold(min(0, c1 * (lanes - 1))), this)) ||
-               rewrite(broadcast(z) < ramp(x, c1), false, can_prove(z >= x + fold(max(0, c1 * (lanes - 1))), this)))))) {
+                           // Comparisons of ramps and broadcasts. If the first
+                           // and last lanes are provably < or >= the broadcast
+                           // we can collapse the comparison.
+                           (no_overflow(op->type) &&
+                            (rewrite(ramp(x, c1) < broadcast(z), true, can_prove(x + fold(max(0, c1 * (lanes - 1))) < z, this)) ||
+                             rewrite(ramp(x, c1) < broadcast(z), false, can_prove(x + fold(min(0, c1 * (lanes - 1))) >= z, this)) ||
+                             rewrite(broadcast(z) < ramp(x, c1), true, can_prove(z < x + fold(min(0, c1 * (lanes - 1))), this)) ||
+                             rewrite(broadcast(z) < ramp(x, c1), false, can_prove(z >= x + fold(max(0, c1 * (lanes - 1))), this)))))) {
             return rewrite.result;
         }
 
         if (rewrite(broadcast(x) < broadcast(y), broadcast(x < y, lanes)) ||
-            (no_overflow(ty) && EVAL_IN_LAMBDA
-             (rewrite(ramp(x, y) < ramp(z, y), broadcast(x < z, lanes)) ||
-              // Move constants to the RHS
-              rewrite(x + c0 < y, x < y + fold(-c0)) ||
+            (no_overflow(ty) && EVAL_IN_LAMBDA(rewrite(ramp(x, y) < ramp(z, y), broadcast(x < z, lanes)) ||
+                                               // Move constants to the RHS
+                                               rewrite(x + c0 < y, x < y + fold(-c0)) ||
 
-              // Merge RHS constant additions with a constant LHS
-              rewrite(c0 < x + c1, fold(c0 - c1) < x) ||
+                                               // Merge RHS constant additions with a constant LHS
+                                               rewrite(c0 < x + c1, fold(c0 - c1) < x) ||
 
-              // Normalize subtractions to additions to cut down on cases to consider
-              rewrite(x - y < z, x < z + y) ||
-              rewrite(z < x - y, z + y < x) ||
+                                               // Normalize subtractions to additions to cut down on cases to consider
+                                               rewrite(x - y < z, x < z + y) ||
+                                               rewrite(z < x - y, z + y < x) ||
 
-              rewrite((x - y) + z < w, x + z < y + w) ||
-              rewrite(z + (x - y) < w, x + z < y + w) ||
-              rewrite(w < (x - y) + z, w + y < x + z) ||
-              rewrite(w < z + (x - y), w + y < x + z) ||
+                                               rewrite((x - y) + z < w, x + z < y + w) ||
+                                               rewrite(z + (x - y) < w, x + z < y + w) ||
+                                               rewrite(w < (x - y) + z, w + y < x + z) ||
+                                               rewrite(w < z + (x - y), w + y < x + z) ||
 
-              rewrite(((x - y) + z) + u < w, x + z + u < w + y) ||
-              rewrite((z + (x - y)) + u < w, x + z + u < w + y) ||
-              rewrite(u + ((x - y) + z) < w, x + z + u < w + y) ||
-              rewrite(u + (z + (x - y)) < w, x + z + u < w + y) ||
+                                               rewrite(((x - y) + z) + u < w, x + z + u < w + y) ||
+                                               rewrite((z + (x - y)) + u < w, x + z + u < w + y) ||
+                                               rewrite(u + ((x - y) + z) < w, x + z + u < w + y) ||
+                                               rewrite(u + (z + (x - y)) < w, x + z + u < w + y) ||
 
-              rewrite(w < ((x - y) + z) + u, w + y < x + z + u) ||
-              rewrite(w < (z + (x - y)) + u, w + y < x + z + u) ||
-              rewrite(w < u + ((x - y) + z), w + y < x + z + u) ||
-              rewrite(w < u + (z + (x - y)), w + y < x + z + u) ||
+                                               rewrite(w < ((x - y) + z) + u, w + y < x + z + u) ||
+                                               rewrite(w < (z + (x - y)) + u, w + y < x + z + u) ||
+                                               rewrite(w < u + ((x - y) + z), w + y < x + z + u) ||
+                                               rewrite(w < u + (z + (x - y)), w + y < x + z + u) ||
 
-              // Cancellations in linear expressions
-              // 1 < 2
-              rewrite(x < x + y, 0 < y) ||
-              rewrite(x < y + x, 0 < y) ||
+                                               // Cancellations in linear expressions
+                                               // 1 < 2
+                                               rewrite(x < x + y, 0 < y) ||
+                                               rewrite(x < y + x, 0 < y) ||
 
-              // 2 < 1
-              rewrite(x + y < x, y < 0) ||
-              rewrite(y + x < x, y < 0) ||
+                                               // 2 < 1
+                                               rewrite(x + y < x, y < 0) ||
+                                               rewrite(y + x < x, y < 0) ||
 
-              // 2 < 2
-              rewrite(x + y < x + z, y < z) ||
-              rewrite(x + y < z + x, y < z) ||
-              rewrite(y + x < x + z, y < z) ||
-              rewrite(y + x < z + x, y < z) ||
+                                               // 2 < 2
+                                               rewrite(x + y < x + z, y < z) ||
+                                               rewrite(x + y < z + x, y < z) ||
+                                               rewrite(y + x < x + z, y < z) ||
+                                               rewrite(y + x < z + x, y < z) ||
 
-              // 3 < 2
-              rewrite((x + y) + w < x + z, y + w < z) ||
-              rewrite((y + x) + w < x + z, y + w < z) ||
-              rewrite(w + (x + y) < x + z, y + w < z) ||
-              rewrite(w + (y + x) < x + z, y + w < z) ||
-              rewrite((x + y) + w < z + x, y + w < z) ||
-              rewrite((y + x) + w < z + x, y + w < z) ||
-              rewrite(w + (x + y) < z + x, y + w < z) ||
-              rewrite(w + (y + x) < z + x, y + w < z) ||
+                                               // 3 < 2
+                                               rewrite((x + y) + w < x + z, y + w < z) ||
+                                               rewrite((y + x) + w < x + z, y + w < z) ||
+                                               rewrite(w + (x + y) < x + z, y + w < z) ||
+                                               rewrite(w + (y + x) < x + z, y + w < z) ||
+                                               rewrite((x + y) + w < z + x, y + w < z) ||
+                                               rewrite((y + x) + w < z + x, y + w < z) ||
+                                               rewrite(w + (x + y) < z + x, y + w < z) ||
+                                               rewrite(w + (y + x) < z + x, y + w < z) ||
 
-              // 2 < 3
-              rewrite(x + z < (x + y) + w, z < y + w) ||
-              rewrite(x + z < (y + x) + w, z < y + w) ||
-              rewrite(x + z < w + (x + y), z < y + w) ||
-              rewrite(x + z < w + (y + x), z < y + w) ||
-              rewrite(z + x < (x + y) + w, z < y + w) ||
-              rewrite(z + x < (y + x) + w, z < y + w) ||
-              rewrite(z + x < w + (x + y), z < y + w) ||
-              rewrite(z + x < w + (y + x), z < y + w) ||
+                                               // 2 < 3
+                                               rewrite(x + z < (x + y) + w, z < y + w) ||
+                                               rewrite(x + z < (y + x) + w, z < y + w) ||
+                                               rewrite(x + z < w + (x + y), z < y + w) ||
+                                               rewrite(x + z < w + (y + x), z < y + w) ||
+                                               rewrite(z + x < (x + y) + w, z < y + w) ||
+                                               rewrite(z + x < (y + x) + w, z < y + w) ||
+                                               rewrite(z + x < w + (x + y), z < y + w) ||
+                                               rewrite(z + x < w + (y + x), z < y + w) ||
 
-              // 3 < 3
-              rewrite((x + y) + w < (x + z) + u, y + w < z + u) ||
-              rewrite((y + x) + w < (x + z) + u, y + w < z + u) ||
-              rewrite((x + y) + w < (z + x) + u, y + w < z + u) ||
-              rewrite((y + x) + w < (z + x) + u, y + w < z + u) ||
-              rewrite(w + (x + y) < (x + z) + u, y + w < z + u) ||
-              rewrite(w + (y + x) < (x + z) + u, y + w < z + u) ||
-              rewrite(w + (x + y) < (z + x) + u, y + w < z + u) ||
-              rewrite(w + (y + x) < (z + x) + u, y + w < z + u) ||
-              rewrite((x + y) + w < u + (x + z), y + w < z + u) ||
-              rewrite((y + x) + w < u + (x + z), y + w < z + u) ||
-              rewrite((x + y) + w < u + (z + x), y + w < z + u) ||
-              rewrite((y + x) + w < u + (z + x), y + w < z + u) ||
-              rewrite(w + (x + y) < u + (x + z), y + w < z + u) ||
-              rewrite(w + (y + x) < u + (x + z), y + w < z + u) ||
-              rewrite(w + (x + y) < u + (z + x), y + w < z + u) ||
-              rewrite(w + (y + x) < u + (z + x), y + w < z + u) ||
+                                               // 3 < 3
+                                               rewrite((x + y) + w < (x + z) + u, y + w < z + u) ||
+                                               rewrite((y + x) + w < (x + z) + u, y + w < z + u) ||
+                                               rewrite((x + y) + w < (z + x) + u, y + w < z + u) ||
+                                               rewrite((y + x) + w < (z + x) + u, y + w < z + u) ||
+                                               rewrite(w + (x + y) < (x + z) + u, y + w < z + u) ||
+                                               rewrite(w + (y + x) < (x + z) + u, y + w < z + u) ||
+                                               rewrite(w + (x + y) < (z + x) + u, y + w < z + u) ||
+                                               rewrite(w + (y + x) < (z + x) + u, y + w < z + u) ||
+                                               rewrite((x + y) + w < u + (x + z), y + w < z + u) ||
+                                               rewrite((y + x) + w < u + (x + z), y + w < z + u) ||
+                                               rewrite((x + y) + w < u + (z + x), y + w < z + u) ||
+                                               rewrite((y + x) + w < u + (z + x), y + w < z + u) ||
+                                               rewrite(w + (x + y) < u + (x + z), y + w < z + u) ||
+                                               rewrite(w + (y + x) < u + (x + z), y + w < z + u) ||
+                                               rewrite(w + (x + y) < u + (z + x), y + w < z + u) ||
+                                               rewrite(w + (y + x) < u + (z + x), y + w < z + u) ||
 
-              // Cancel a multiplication
-              rewrite(x * c0 < y * c0, x < y, c0 > 0) ||
-              rewrite(x * c0 < y * c0, y < x, c0 < 0) ||
+                                               // Cancel a multiplication
+                                               rewrite(x * c0 < y * c0, x<y, c0> 0) ||
+                                               rewrite(x * c0 < y * c0, y < x, c0 < 0) ||
 
-              (ty.is_int()   && rewrite(x * c0 < c1, x < fold((c1 + c0 - 1) / c0), c0 > 0)) ||
-              (ty.is_float() && rewrite(x * c0 < c1, x < fold(c1 / c0), c0 > 0)) ||
-              rewrite(c1 < x * c0, fold(c1 / c0) < x, c0 > 0) ||
+                                               (ty.is_int() && rewrite(x * c0 < c1, x<fold((c1 + c0 - 1) / c0), c0> 0)) ||
+                                               (ty.is_float() && rewrite(x * c0 < c1, x<fold(c1 / c0), c0> 0)) ||
+                                               rewrite(c1<x * c0, fold(c1 / c0) < x, c0> 0) ||
 
-              // Multiply-out a division
-              rewrite(x / c0 < c1, x < c1 * c0, c0 > 0) ||
-              (ty.is_int() && rewrite(c0 < x / c1, fold((c0 + 1) * c1 - 1) < x, c1 > 0)) ||
-              (ty.is_float() && rewrite(c0 < x / c1, fold(c0 * c1) < x, c1 > 0)) ||
+                                               // Multiply-out a division
+                                               rewrite(x / c0 < c1, x<c1 * c0, c0> 0) ||
+                                               (ty.is_int() && rewrite(c0<x / c1, fold((c0 + 1) * c1 - 1) < x, c1> 0)) ||
+                                               (ty.is_float() && rewrite(c0<x / c1, fold(c0 * c1) < x, c1> 0)) ||
 
-              // We want to break max(x, y) < z into x < z && y <
-              // z in cases where one of those two terms is going
-              // to fold.
-              rewrite(min(x + c0, y) < x + c1, fold(c0 < c1) || y < x + c1) ||
-              rewrite(min(y, x + c0) < x + c1, fold(c0 < c1) || y < x + c1) ||
-              rewrite(max(x + c0, y) < x + c1, fold(c0 < c1) && y < x + c1) ||
-              rewrite(max(y, x + c0) < x + c1, fold(c0 < c1) && y < x + c1) ||
+                                               // We want to break max(x, y) < z into x < z && y <
+                                               // z in cases where one of those two terms is going
+                                               // to fold.
+                                               rewrite(min(x + c0, y) < x + c1, fold(c0 < c1) || y < x + c1) ||
+                                               rewrite(min(y, x + c0) < x + c1, fold(c0 < c1) || y < x + c1) ||
+                                               rewrite(max(x + c0, y) < x + c1, fold(c0 < c1) && y < x + c1) ||
+                                               rewrite(max(y, x + c0) < x + c1, fold(c0 < c1) && y < x + c1) ||
 
-              rewrite(x < min(x + c0, y) + c1, fold(0 < c0 + c1) && x < y + c1) ||
-              rewrite(x < min(y, x + c0) + c1, fold(0 < c0 + c1) && x < y + c1) ||
-              rewrite(x < max(x + c0, y) + c1, fold(0 < c0 + c1) || x < y + c1) ||
-              rewrite(x < max(y, x + c0) + c1, fold(0 < c0 + c1) || x < y + c1) ||
+                                               rewrite(x < min(x + c0, y) + c1, fold(0 < c0 + c1) && x < y + c1) ||
+                                               rewrite(x < min(y, x + c0) + c1, fold(0 < c0 + c1) && x < y + c1) ||
+                                               rewrite(x < max(x + c0, y) + c1, fold(0 < c0 + c1) || x < y + c1) ||
+                                               rewrite(x < max(y, x + c0) + c1, fold(0 < c0 + c1) || x < y + c1) ||
 
-              // Special cases where c0 == 0
-              rewrite(min(x, y) < x + c1, fold(0 < c1) || y < x + c1) ||
-              rewrite(min(y, x) < x + c1, fold(0 < c1) || y < x + c1) ||
-              rewrite(max(x, y) < x + c1, fold(0 < c1) && y < x + c1) ||
-              rewrite(max(y, x) < x + c1, fold(0 < c1) && y < x + c1) ||
+                                               // Special cases where c0 == 0
+                                               rewrite(min(x, y) < x + c1, fold(0 < c1) || y < x + c1) ||
+                                               rewrite(min(y, x) < x + c1, fold(0 < c1) || y < x + c1) ||
+                                               rewrite(max(x, y) < x + c1, fold(0 < c1) && y < x + c1) ||
+                                               rewrite(max(y, x) < x + c1, fold(0 < c1) && y < x + c1) ||
 
-              rewrite(x < min(x, y) + c1, fold(0 < c1) && x < y + c1) ||
-              rewrite(x < min(y, x) + c1, fold(0 < c1) && x < y + c1) ||
-              rewrite(x < max(x, y) + c1, fold(0 < c1) || x < y + c1) ||
-              rewrite(x < max(y, x) + c1, fold(0 < c1) || x < y + c1) ||
+                                               rewrite(x < min(x, y) + c1, fold(0 < c1) && x < y + c1) ||
+                                               rewrite(x < min(y, x) + c1, fold(0 < c1) && x < y + c1) ||
+                                               rewrite(x < max(x, y) + c1, fold(0 < c1) || x < y + c1) ||
+                                               rewrite(x < max(y, x) + c1, fold(0 < c1) || x < y + c1) ||
 
-              // Special cases where c1 == 0
-              rewrite(min(x + c0, y) < x, fold(c0 < 0) || y < x) ||
-              rewrite(min(y, x + c0) < x, fold(c0 < 0) || y < x) ||
-              rewrite(max(x + c0, y) < x, fold(c0 < 0) && y < x) ||
-              rewrite(max(y, x + c0) < x, fold(c0 < 0) && y < x) ||
+                                               // Special cases where c1 == 0
+                                               rewrite(min(x + c0, y) < x, fold(c0 < 0) || y < x) ||
+                                               rewrite(min(y, x + c0) < x, fold(c0 < 0) || y < x) ||
+                                               rewrite(max(x + c0, y) < x, fold(c0 < 0) && y < x) ||
+                                               rewrite(max(y, x + c0) < x, fold(c0 < 0) && y < x) ||
 
-              rewrite(x < min(x + c0, y), fold(0 < c0) && x < y) ||
-              rewrite(x < min(y, x + c0), fold(0 < c0) && x < y) ||
-              rewrite(x < max(x + c0, y), fold(0 < c0) || x < y) ||
-              rewrite(x < max(y, x + c0), fold(0 < c0) || x < y) ||
+                                               rewrite(x < min(x + c0, y), fold(0 < c0) && x < y) ||
+                                               rewrite(x < min(y, x + c0), fold(0 < c0) && x < y) ||
+                                               rewrite(x < max(x + c0, y), fold(0 < c0) || x < y) ||
+                                               rewrite(x < max(y, x + c0), fold(0 < c0) || x < y) ||
 
-              // Special cases where c0 == c1 == 0
-              rewrite(min(x, y) < x, y < x) ||
-              rewrite(min(y, x) < x, y < x) ||
-              rewrite(x < max(x, y), x < y) ||
-              rewrite(x < max(y, x), x < y) ||
+                                               // Special cases where c0 == c1 == 0
+                                               rewrite(min(x, y) < x, y < x) ||
+                                               rewrite(min(y, x) < x, y < x) ||
+                                               rewrite(x < max(x, y), x < y) ||
+                                               rewrite(x < max(y, x), x < y) ||
 
-              // Special case where x is constant
-              rewrite(min(y, c0) < c1, fold(c0 < c1) || y < c1) ||
-              rewrite(max(y, c0) < c1, fold(c0 < c1) && y < c1) ||
-              rewrite(c1 < min(y, c0), fold(c1 < c0) && c1 < y) ||
-              rewrite(c1 < max(y, c0), fold(c1 < c0) || c1 < y) ||
+                                               // Special case where x is constant
+                                               rewrite(min(y, c0) < c1, fold(c0 < c1) || y < c1) ||
+                                               rewrite(max(y, c0) < c1, fold(c0 < c1) && y < c1) ||
+                                               rewrite(c1 < min(y, c0), fold(c1 < c0) && c1 < y) ||
+                                               rewrite(c1 < max(y, c0), fold(c1 < c0) || c1 < y) ||
 
-              // Comparisons with selects:
-              // x < select(c, t, f) == c && (x < t) || !c && (x < f)
-              // This is profitable when x < t or x < f is statically provable
-              rewrite(x < select(y, x + c0, z), !y && (x < z), c0 <= 0) ||
-              rewrite(x < select(y, x + c0, z), y || (x < z), c0 > 0) ||
-              rewrite(x < select(y, z, x + c0), y && (x < z), c0 <= 0) ||
-              rewrite(x < select(y, z, x + c0), !y || (x < z), c0 > 0) ||
+                                               // Comparisons with selects:
+                                               // x < select(c, t, f) == c && (x < t) || !c && (x < f)
+                                               // This is profitable when x < t or x < f is statically provable
+                                               rewrite(x < select(y, x + c0, z), !y && (x < z), c0 <= 0) ||
+                                               rewrite(x < select(y, x + c0, z), y || (x < z), c0 > 0) ||
+                                               rewrite(x < select(y, z, x + c0), y && (x < z), c0 <= 0) ||
+                                               rewrite(x < select(y, z, x + c0), !y || (x < z), c0 > 0) ||
 
-              rewrite(x < select(y, x + c0, z) + c1, !y && (x < z + c1), c0 + c1 <= 0) ||
-              rewrite(x < select(y, x + c0, z) + c1, y || (x < z + c1), c0 + c1 > 0) ||
-              rewrite(x < select(y, z, x + c0) + c1, y && (x < z + c1), c0 + c1 <= 0) ||
-              rewrite(x < select(y, z, x + c0) + c1, !y || (x < z + c1), c0 + c1 > 0) ||
+                                               rewrite(x < select(y, x + c0, z) + c1, !y && (x < z + c1), c0 + c1 <= 0) ||
+                                               rewrite(x < select(y, x + c0, z) + c1, y || (x < z + c1), c0 + c1 > 0) ||
+                                               rewrite(x < select(y, z, x + c0) + c1, y && (x < z + c1), c0 + c1 <= 0) ||
+                                               rewrite(x < select(y, z, x + c0) + c1, !y || (x < z + c1), c0 + c1 > 0) ||
 
-              rewrite(select(y, x + c0, z) < x, !y && (z < x), c0 >= 0) ||
-              rewrite(select(y, x + c0, z) < x, y || (z < x), c0 < 0) ||
-              rewrite(select(y, z, x + c0) < x, y && (z < x), c0 >= 0) ||
-              rewrite(select(y, z, x + c0) < x, !y || (z < x), c0 < 0) ||
+                                               rewrite(select(y, x + c0, z) < x, !y && (z < x), c0 >= 0) ||
+                                               rewrite(select(y, x + c0, z) < x, y || (z < x), c0 < 0) ||
+                                               rewrite(select(y, z, x + c0) < x, y && (z < x), c0 >= 0) ||
+                                               rewrite(select(y, z, x + c0) < x, !y || (z < x), c0 < 0) ||
 
-              rewrite(select(y, x + c0, z) < x + c1, !y && (z < x + c1), c0 >= c1) ||
-              rewrite(select(y, x + c0, z) < x + c1, y || (z < x + c1), c0 < c1) ||
-              rewrite(select(y, z, x + c0) < x + c1, y && (z < x + c1), c0 >= c1) ||
-              rewrite(select(y, z, x + c0) < x + c1, !y || (z < x + c1), c0 < c1) ||
+                                               rewrite(select(y, x + c0, z) < x + c1, !y && (z < x + c1), c0 >= c1) ||
+                                               rewrite(select(y, x + c0, z) < x + c1, y || (z < x + c1), c0 < c1) ||
+                                               rewrite(select(y, z, x + c0) < x + c1, y && (z < x + c1), c0 >= c1) ||
+                                               rewrite(select(y, z, x + c0) < x + c1, !y || (z < x + c1), c0 < c1) ||
 
-              // Normalize comparison of ramps to a comparison of a ramp and a broadacst
-              rewrite(ramp(x, y) < ramp(z, w), ramp(x - z, y - w, lanes) < 0))) ||
+                                               // Normalize comparison of ramps to a comparison of a ramp and a broadacst
+                                               rewrite(ramp(x, y) < ramp(z, w), ramp(x - z, y - w, lanes) < 0))) ||
 
-            (no_overflow_int(ty) && EVAL_IN_LAMBDA
-             (rewrite(x * c0 < y * c1, x < y * fold(c1 / c0), c1 % c0 == 0 && c0 > 0) ||
-              rewrite(x * c0 < y * c1, x * fold(c0 / c1) < y, c0 % c1 == 0 && c1 > 0) ||
+            (no_overflow_int(ty) && EVAL_IN_LAMBDA(rewrite(x * c0 < y * c1, x < y * fold(c1 / c0), c1 % c0 == 0 && c0 > 0) ||
+                                                   rewrite(x * c0 < y * c1, x * fold(c0 / c1) < y, c0 % c1 == 0 && c1 > 0) ||
 
-              rewrite(x * c0 < y * c0 + c1, x < y + fold((c1 + c0 - 1)/c0), c0 > 0) ||
-              rewrite(x * c0 + c1 < y * c0, x + fold(c1/c0) < y, c0 > 0) ||
+                                                   rewrite(x * c0 < y * c0 + c1, x<y + fold((c1 + c0 - 1) / c0), c0> 0) ||
+                                                   rewrite(x * c0 + c1<y * c0, x + fold(c1 / c0) < y, c0> 0) ||
 
-              // Comparison of stair-step functions. The basic transformation is:
-              //   ((x + y)/c1)*c1 < x
-              // = (x + y) - (x + y) % c1 < x (when c1 > 0)
-              // = y - (x + y) % c1 < 0
-              // = y < (x + y) % c1
-              // This cancels x but duplicates y, so we only do it when y is a constant.
+                                                   // Comparison of stair-step functions. The basic transformation is:
+                                                   //   ((x + y)/c1)*c1 < x
+                                                   // = (x + y) - (x + y) % c1 < x (when c1 > 0)
+                                                   // = y - (x + y) % c1 < 0
+                                                   // = y < (x + y) % c1
+                                                   // This cancels x but duplicates y, so we only do it when y is a constant.
 
-              // A more general version with extra terms w and z
-              rewrite(((x + c0)/c1)*c1 + w < x + z, (w + c0) < ((x + c0) % c1) + z, c1 > 0) ||
-              rewrite(w + ((x + c0)/c1)*c1 < x + z, (w + c0) < ((x + c0) % c1) + z, c1 > 0) ||
-              rewrite(((x + c0)/c1)*c1 + w < z + x, (w + c0) < ((x + c0) % c1) + z, c1 > 0) ||
-              rewrite(w + ((x + c0)/c1)*c1 < z + x, (w + c0) < ((x + c0) % c1) + z, c1 > 0) ||
-              rewrite(x + z < ((x + c0)/c1)*c1 + w, ((x + c0) % c1) + z < w + c0, c1 > 0) ||
-              rewrite(x + z < w + ((x + c0)/c1)*c1, ((x + c0) % c1) + z < w + c0, c1 > 0) ||
-              rewrite(z + x < ((x + c0)/c1)*c1 + w, ((x + c0) % c1) + z < w + c0, c1 > 0) ||
-              rewrite(z + x < w + ((x + c0)/c1)*c1, ((x + c0) % c1) + z < w + c0, c1 > 0) ||
+                                                   // A more general version with extra terms w and z
+                                                   rewrite(((x + c0) / c1) * c1 + w<x + z, (w + c0) < ((x + c0) % c1) + z, c1> 0) ||
+                                                   rewrite(w + ((x + c0) / c1) * c1<x + z, (w + c0) < ((x + c0) % c1) + z, c1> 0) ||
+                                                   rewrite(((x + c0) / c1) * c1 + w<z + x, (w + c0) < ((x + c0) % c1) + z, c1> 0) ||
+                                                   rewrite(w + ((x + c0) / c1) * c1<z + x, (w + c0) < ((x + c0) % c1) + z, c1> 0) ||
+                                                   rewrite(x + z < ((x + c0) / c1) * c1 + w, ((x + c0) % c1) + z<w + c0, c1> 0) ||
+                                                   rewrite(x + z < w + ((x + c0) / c1) * c1, ((x + c0) % c1) + z<w + c0, c1> 0) ||
+                                                   rewrite(z + x < ((x + c0) / c1) * c1 + w, ((x + c0) % c1) + z<w + c0, c1> 0) ||
+                                                   rewrite(z + x < w + ((x + c0) / c1) * c1, ((x + c0) % c1) + z<w + c0, c1> 0) ||
 
-              // w = 0
-              rewrite(((x + c0)/c1)*c1 < x + z, c0 < ((x + c0) % c1) + z, c1 > 0) ||
-              rewrite(((x + c0)/c1)*c1 < z + x, c0 < ((x + c0) % c1) + z, c1 > 0) ||
-              rewrite(x + z < ((x + c0)/c1)*c1, ((x + c0) % c1) + z < c0, c1 > 0) ||
-              rewrite(z + x < ((x + c0)/c1)*c1, ((x + c0) % c1) + z < c0, c1 > 0) ||
+                                                   // w = 0
+                                                   rewrite(((x + c0) / c1) * c1 < x + z, c0<((x + c0) % c1) + z, c1> 0) ||
+                                                   rewrite(((x + c0) / c1) * c1 < z + x, c0<((x + c0) % c1) + z, c1> 0) ||
+                                                   rewrite(x + z < ((x + c0) / c1) * c1, ((x + c0) % c1) + z<c0, c1> 0) ||
+                                                   rewrite(z + x < ((x + c0) / c1) * c1, ((x + c0) % c1) + z<c0, c1> 0) ||
 
-              // z = 0
-              rewrite(((x + c0)/c1)*c1 + w < x, (w + c0) < ((x + c0) % c1), c1 > 0) ||
-              rewrite(w + ((x + c0)/c1)*c1 < x, (w + c0) < ((x + c0) % c1), c1 > 0) ||
-              rewrite(x < ((x + c0)/c1)*c1 + w, ((x + c0) % c1) < w + c0, c1 > 0) ||
-              rewrite(x < w + ((x + c0)/c1)*c1, ((x + c0) % c1) < w + c0, c1 > 0) ||
+                                                   // z = 0
+                                                   rewrite(((x + c0) / c1) * c1 + w<x, (w + c0) < ((x + c0) % c1), c1> 0) ||
+                                                   rewrite(w + ((x + c0) / c1) * c1<x, (w + c0) < ((x + c0) % c1), c1> 0) ||
+                                                   rewrite(x<((x + c0) / c1) * c1 + w, ((x + c0) % c1) < w + c0, c1> 0) ||
+                                                   rewrite(x<w + ((x + c0) / c1) * c1, ((x + c0) % c1) < w + c0, c1> 0) ||
 
-              // c0 = 0
-              rewrite((x/c1)*c1 + w < x + z, w < (x % c1) + z, c1 > 0) ||
-              rewrite(w + (x/c1)*c1 < x + z, w < (x % c1) + z, c1 > 0) ||
-              rewrite((x/c1)*c1 + w < z + x, w < (x % c1) + z, c1 > 0) ||
-              rewrite(w + (x/c1)*c1 < z + x, w < (x % c1) + z, c1 > 0) ||
-              rewrite(x + z < (x/c1)*c1 + w, (x % c1) + z < w, c1 > 0) ||
-              rewrite(x + z < w + (x/c1)*c1, (x % c1) + z < w, c1 > 0) ||
-              rewrite(z + x < (x/c1)*c1 + w, (x % c1) + z < w, c1 > 0) ||
-              rewrite(z + x < w + (x/c1)*c1, (x % c1) + z < w, c1 > 0) ||
+                                                   // c0 = 0
+                                                   rewrite((x / c1) * c1 + w < x + z, w<(x % c1) + z, c1> 0) ||
+                                                   rewrite(w + (x / c1) * c1 < x + z, w<(x % c1) + z, c1> 0) ||
+                                                   rewrite((x / c1) * c1 + w < z + x, w<(x % c1) + z, c1> 0) ||
+                                                   rewrite(w + (x / c1) * c1 < z + x, w<(x % c1) + z, c1> 0) ||
+                                                   rewrite(x + z < (x / c1) * c1 + w, (x % c1) + z<w, c1> 0) ||
+                                                   rewrite(x + z < w + (x / c1) * c1, (x % c1) + z<w, c1> 0) ||
+                                                   rewrite(z + x < (x / c1) * c1 + w, (x % c1) + z<w, c1> 0) ||
+                                                   rewrite(z + x < w + (x / c1) * c1, (x % c1) + z<w, c1> 0) ||
 
-              // w = 0, z = 0
-              rewrite(((x + c0)/c1)*c1 < x, c0 < ((x + c0) % c1), c1 > 0) ||
-              rewrite(x < ((x + c0)/c1)*c1, ((x + c0) % c1) < c0, c1 > 0) ||
+                                                   // w = 0, z = 0
+                                                   rewrite(((x + c0) / c1) * c1 < x, c0<((x + c0) % c1), c1> 0) ||
+                                                   rewrite(x<((x + c0) / c1) * c1, ((x + c0) % c1) < c0, c1> 0) ||
 
-              // w = 0, c0 = 0
-              rewrite((x/c1)*c1 < x + z, 0 < (x % c1) + z, c1 > 0) ||
-              rewrite((x/c1)*c1 < z + x, 0 < (x % c1) + z, c1 > 0) ||
-              rewrite(x + z < (x/c1)*c1, (x % c1) + z < 0, c1 > 0) ||
-              rewrite(z + x < (x/c1)*c1, (x % c1) + z < 0, c1 > 0) ||
+                                                   // w = 0, c0 = 0
+                                                   rewrite((x / c1) * c1<x + z, 0 < (x % c1) + z, c1> 0) ||
+                                                   rewrite((x / c1) * c1<z + x, 0 < (x % c1) + z, c1> 0) ||
+                                                   rewrite(x + z < (x / c1) * c1, (x % c1) + z<0, c1> 0) ||
+                                                   rewrite(z + x < (x / c1) * c1, (x % c1) + z<0, c1> 0) ||
 
-              // z = 0, c0 = 0
-              rewrite((x/c1)*c1 + w < x, w < (x % c1), c1 > 0) ||
-              rewrite(w + (x/c1)*c1 < x, w < (x % c1), c1 > 0) ||
-              rewrite(x < (x/c1)*c1 + w, (x % c1) < w, c1 > 0) ||
-              rewrite(x < w + (x/c1)*c1, (x % c1) < w, c1 > 0) ||
+                                                   // z = 0, c0 = 0
+                                                   rewrite((x / c1) * c1 + w < x, w<(x % c1), c1> 0) ||
+                                                   rewrite(w + (x / c1) * c1 < x, w<(x % c1), c1> 0) ||
+                                                   rewrite(x<(x / c1) * c1 + w, (x % c1) < w, c1> 0) ||
+                                                   rewrite(x<w + (x / c1) * c1, (x % c1) < w, c1> 0) ||
 
-              // z = 0, c0 = 0, w = 0
-              rewrite((x/c1)*c1 < x, (x % c1) != 0, c1 > 0) ||
-              rewrite(x < (x/c1)*c1, false, c1 > 0) ||
+                                                   // z = 0, c0 = 0, w = 0
+                                                   rewrite((x / c1) * c1<x, (x % c1) != 0, c1> 0) ||
+                                                   rewrite(x<(x / c1) * c1, false, c1> 0) ||
 
-              // Cancel a division
-              rewrite((x + c1)/c0 < (x + c2)/c0, false, c0 > 0 && c1 >= c2) ||
-              rewrite((x + c1)/c0 < (x + c2)/c0, true, c0 > 0 && c1 <= c2 - c0) ||
-              // c1 == 0
-              rewrite(x/c0 < (x + c2)/c0, false, c0 > 0 && 0 >= c2) ||
-              rewrite(x/c0 < (x + c2)/c0, true, c0 > 0 && 0 <= c2 - c0) ||
-              // c2 == 0
-              rewrite((x + c1)/c0 < x/c0, false, c0 > 0 && c1 >= 0) ||
-              rewrite((x + c1)/c0 < x/c0, true, c0 > 0 && c1 <= 0 - c0) ||
+                                                   // Cancel a division
+                                                   rewrite((x + c1) / c0<(x + c2) / c0, false, c0> 0 && c1 >= c2) ||
+                                                   rewrite((x + c1) / c0<(x + c2) / c0, true, c0> 0 && c1 <= c2 - c0) ||
+                                                   // c1 == 0
+                                                   rewrite(x / c0<(x + c2) / c0, false, c0> 0 && 0 >= c2) ||
+                                                   rewrite(x / c0<(x + c2) / c0, true, c0> 0 && 0 <= c2 - c0) ||
+                                                   // c2 == 0
+                                                   rewrite((x + c1) / c0<x / c0, false, c0> 0 && c1 >= 0) ||
+                                                   rewrite((x + c1) / c0<x / c0, true, c0> 0 && c1 <= 0 - c0) ||
 
-              // The addition on the right could be outside
-              rewrite((x + c1)/c0 < x/c0 + c2, false, c0 > 0 && c1 >= c2 * c0) ||
-              rewrite((x + c1)/c0 < x/c0 + c2, true, c0 > 0 && c1 <= c2 * c0 - c0) ||
+                                                   // The addition on the right could be outside
+                                                   rewrite((x + c1) / c0<x / c0 + c2, false, c0> 0 && c1 >= c2 * c0) ||
+                                                   rewrite((x + c1) / c0<x / c0 + c2, true, c0> 0 && c1 <= c2 * c0 - c0) ||
 
-              // With a confounding max or min
-              rewrite((x + c1)/c0 < (min(x/c0, y) + c2), false, c0 > 0 && c1 >= c2 * c0) ||
-              rewrite((x + c1)/c0 < (max(x/c0, y) + c2), true, c0 > 0 && c1 <= c2 * c0 - c0) ||
-              rewrite((x + c1)/c0 < min((x + c2)/c0, y), false, c0 > 0 && c1 >= c2) ||
-              rewrite((x + c1)/c0 < max((x + c2)/c0, y), true, c0 > 0 && c1 <= c2 - c0) ||
-              rewrite((x + c1)/c0 < min(x/c0, y), false, c0 > 0 && c1 >= 0) ||
-              rewrite((x + c1)/c0 < max(x/c0, y), true, c0 > 0 && c1 <= 0 - c0) ||
+                                                   // With a confounding max or min
+                                                   rewrite((x + c1) / c0<(min(x / c0, y) + c2), false, c0> 0 && c1 >= c2 * c0) ||
+                                                   rewrite((x + c1) / c0<(max(x / c0, y) + c2), true, c0> 0 && c1 <= c2 * c0 - c0) ||
+                                                   rewrite((x + c1) / c0<min((x + c2) / c0, y), false, c0> 0 && c1 >= c2) ||
+                                                   rewrite((x + c1) / c0<max((x + c2) / c0, y), true, c0> 0 && c1 <= c2 - c0) ||
+                                                   rewrite((x + c1) / c0<min(x / c0, y), false, c0> 0 && c1 >= 0) ||
+                                                   rewrite((x + c1) / c0<max(x / c0, y), true, c0> 0 && c1 <= 0 - c0) ||
 
-              rewrite((x + c1)/c0 < (min(y, x/c0) + c2), false, c0 > 0 && c1 >= c2 * c0) ||
-              rewrite((x + c1)/c0 < (max(y, x/c0) + c2), true, c0 > 0 && c1 <= c2 * c0 - c0) ||
-              rewrite((x + c1)/c0 < min(y, (x + c2)/c0), false, c0 > 0 && c1 >= c2) ||
-              rewrite((x + c1)/c0 < max(y, (x + c2)/c0), true, c0 > 0 && c1 <= c2 - c0) ||
-              rewrite((x + c1)/c0 < min(y, x/c0), false, c0 > 0 && c1 >= 0) ||
-              rewrite((x + c1)/c0 < max(y, x/c0), true, c0 > 0 && c1 <= 0 - c0) ||
+                                                   rewrite((x + c1) / c0<(min(y, x / c0) + c2), false, c0> 0 && c1 >= c2 * c0) ||
+                                                   rewrite((x + c1) / c0<(max(y, x / c0) + c2), true, c0> 0 && c1 <= c2 * c0 - c0) ||
+                                                   rewrite((x + c1) / c0<min(y, (x + c2) / c0), false, c0> 0 && c1 >= c2) ||
+                                                   rewrite((x + c1) / c0<max(y, (x + c2) / c0), true, c0> 0 && c1 <= c2 - c0) ||
+                                                   rewrite((x + c1) / c0<min(y, x / c0), false, c0> 0 && c1 >= 0) ||
+                                                   rewrite((x + c1) / c0<max(y, x / c0), true, c0> 0 && c1 <= 0 - c0) ||
 
-              rewrite(max((x + c2)/c0, y) < (x + c1)/c0, false, c0 > 0 && c2 >= c1) ||
-              rewrite(min((x + c2)/c0, y) < (x + c1)/c0, true, c0 > 0 && c2 <= c1 - c0) ||
-              rewrite(max(x/c0, y) < (x + c1)/c0, false, c0 > 0 && 0 >= c1) ||
-              rewrite(min(x/c0, y) < (x + c1)/c0, true, c0 > 0 && 0 <= c1 - c0) ||
-              rewrite(max(y, (x + c2)/c0) < (x + c1)/c0, false, c0 > 0 && c2 >= c1) ||
-              rewrite(min(y, (x + c2)/c0) < (x + c1)/c0, true, c0 > 0 && c2 <= c1 - c0) ||
-              rewrite(max(y, x/c0) < (x + c1)/c0, false, c0 > 0 && 0 >= c1) ||
-              rewrite(min(y, x/c0) < (x + c1)/c0, true, c0 > 0 && 0 <= c1 - c0) ||
+                                                   rewrite(max((x + c2) / c0, y) < (x + c1) / c0, false, c0 > 0 && c2 >= c1) ||
+                                                   rewrite(min((x + c2) / c0, y) < (x + c1) / c0, true, c0 > 0 && c2 <= c1 - c0) ||
+                                                   rewrite(max(x / c0, y) < (x + c1) / c0, false, c0 > 0 && 0 >= c1) ||
+                                                   rewrite(min(x / c0, y) < (x + c1) / c0, true, c0 > 0 && 0 <= c1 - c0) ||
+                                                   rewrite(max(y, (x + c2) / c0) < (x + c1) / c0, false, c0 > 0 && c2 >= c1) ||
+                                                   rewrite(min(y, (x + c2) / c0) < (x + c1) / c0, true, c0 > 0 && c2 <= c1 - c0) ||
+                                                   rewrite(max(y, x / c0) < (x + c1) / c0, false, c0 > 0 && 0 >= c1) ||
+                                                   rewrite(min(y, x / c0) < (x + c1) / c0, true, c0 > 0 && 0 <= c1 - c0) ||
 
-              // Same as above with c1 outside the division, with redundant cases removed.
-              rewrite(max((x + c2)/c0, y) < x/c0 + c1, false, c0 > 0 && c2 >= c1 * c0) ||
-              rewrite(min((x + c2)/c0, y) < x/c0 + c1, true, c0 > 0 && c2 <= c1 * c0 - c0) ||
-              rewrite(max(y, (x + c2)/c0) < x/c0 + c1, false, c0 > 0 && c2 >= c1 * c0) ||
-              rewrite(min(y, (x + c2)/c0) < x/c0 + c1, true, c0 > 0 && c2 <= c1 * c0 - c0) ||
+                                                   // Same as above with c1 outside the division, with redundant cases removed.
+                                                   rewrite(max((x + c2) / c0, y) < x / c0 + c1, false, c0 > 0 && c2 >= c1 * c0) ||
+                                                   rewrite(min((x + c2) / c0, y) < x / c0 + c1, true, c0 > 0 && c2 <= c1 * c0 - c0) ||
+                                                   rewrite(max(y, (x + c2) / c0) < x / c0 + c1, false, c0 > 0 && c2 >= c1 * c0) ||
+                                                   rewrite(min(y, (x + c2) / c0) < x / c0 + c1, true, c0 > 0 && c2 <= c1 * c0 - c0) ||
 
-              // Same as above with c1 = 0 and the predicates and redundant cases simplified accordingly.
-              rewrite(x/c0 < min((x + c2)/c0, y), false, c0 > 0 && c2 < 0) ||
-              rewrite(x/c0 < max((x + c2)/c0, y), true, c0 > 0 && c0 <= c2) ||
-              rewrite(x/c0 < min(y, (x + c2)/c0), false, c0 > 0 && c2 < 0) ||
-              rewrite(x/c0 < max(y, (x + c2)/c0), true, c0 > 0 && c0 <= c2) ||
-              rewrite(max((x + c2)/c0, y) < x/c0, false, c0 > 0 && c2 >= 0) ||
-              rewrite(min((x + c2)/c0, y) < x/c0, true, c0 > 0 && c2 + c0 <= 0) ||
-              rewrite(max(y, (x + c2)/c0) < x/c0, false, c0 > 0 && c2 >= 0) ||
-              rewrite(min(y, (x + c2)/c0) < x/c0, true, c0 > 0 && c2 + c0 <= 0) ||
+                                                   // Same as above with c1 = 0 and the predicates and redundant cases simplified accordingly.
+                                                   rewrite(x / c0<min((x + c2) / c0, y), false, c0> 0 && c2 < 0) ||
+                                                   rewrite(x / c0<max((x + c2) / c0, y), true, c0> 0 && c0 <= c2) ||
+                                                   rewrite(x / c0<min(y, (x + c2) / c0), false, c0> 0 && c2 < 0) ||
+                                                   rewrite(x / c0<max(y, (x + c2) / c0), true, c0> 0 && c0 <= c2) ||
+                                                   rewrite(max((x + c2) / c0, y) < x / c0, false, c0 > 0 && c2 >= 0) ||
+                                                   rewrite(min((x + c2) / c0, y) < x / c0, true, c0 > 0 && c2 + c0 <= 0) ||
+                                                   rewrite(max(y, (x + c2) / c0) < x / c0, false, c0 > 0 && c2 >= 0) ||
+                                                   rewrite(min(y, (x + c2) / c0) < x / c0, true, c0 > 0 && c2 + c0 <= 0) ||
 
-              // Comparison of two mins/maxes that don't cancel when subtracted
-              rewrite(min(x, c0) < min(x, c1), false, c0 >= c1) ||
-              rewrite(min(x, c0) < min(x, c1) + c2, false, c0 >= c1 + c2) ||
-              rewrite(max(x, c0) < max(x, c1), false, c0 >= c1) ||
-              rewrite(max(x, c0) < max(x, c1) + c2, false, c0 >= c1 + c2) ||
+                                                   // Comparison of two mins/maxes that don't cancel when subtracted
+                                                   rewrite(min(x, c0) < min(x, c1), false, c0 >= c1) ||
+                                                   rewrite(min(x, c0) < min(x, c1) + c2, false, c0 >= c1 + c2) ||
+                                                   rewrite(max(x, c0) < max(x, c1), false, c0 >= c1) ||
+                                                   rewrite(max(x, c0) < max(x, c1) + c2, false, c0 >= c1 + c2) ||
 
-              // Comparison of aligned ramps can simplify to a comparison of the base
-              rewrite(ramp(x * c3 + c2, c1) < broadcast(z * c0),
-                      broadcast(x * fold(c3/c0) + fold(c2/c0) < z, lanes),
-                      c0 > 0 && (c3 % c0 == 0) &&
-                      (c2 % c0) + c1 * (lanes - 1) < c0 &&
-                      (c2 % c0) + c1 * (lanes - 1) >= 0) ||
-              // c2 = 0
-              rewrite(ramp(x * c3, c1) < broadcast(z * c0),
-                      broadcast(x * fold(c3/c0) < z, lanes),
-                      c0 > 0 && (c3 % c0 == 0) &&
-                      c1 * (lanes - 1) < c0 &&
-                      c1 * (lanes - 1) >= 0)))) {
+                                                   // Comparison of aligned ramps can simplify to a comparison of the base
+                                                   rewrite(ramp(x * c3 + c2, c1) < broadcast(z * c0),
+                                                           broadcast(x * fold(c3 / c0) + fold(c2 / c0) < z, lanes),
+                                                           c0 > 0 && (c3 % c0 == 0) &&
+                                                               (c2 % c0) + c1 * (lanes - 1) < c0 &&
+                                                               (c2 % c0) + c1 * (lanes - 1) >= 0) ||
+                                                   // c2 = 0
+                                                   rewrite(ramp(x * c3, c1) < broadcast(z * c0),
+                                                           broadcast(x * fold(c3 / c0) < z, lanes),
+                                                           c0 > 0 && (c3 % c0 == 0) &&
+                                                               c1 * (lanes - 1) < c0 &&
+                                                               c1 * (lanes - 1) >= 0)))) {
             return mutate(std::move(rewrite.result), bounds);
         }
     }

--- a/src/Simplify_Max.cpp
+++ b/src/Simplify_Max.cpp
@@ -42,167 +42,165 @@ Expr Simplify::visit(const Max *op, ExprInfo *bounds) {
         int lanes = op->type.lanes();
         auto rewrite = IRMatcher::rewriter(IRMatcher::max(a, b), op->type);
 
-        if (EVAL_IN_LAMBDA
-            (rewrite(max(x, x), x) ||
-             rewrite(max(c0, c1), fold(max(c0, c1))) ||
-             rewrite(max(IRMatcher::Indeterminate(), x), a) ||
-             rewrite(max(x, IRMatcher::Indeterminate()), b) ||
-             rewrite(max(IRMatcher::Overflow(), x), a) ||
-             rewrite(max(x,IRMatcher::Overflow()), b) ||
-             // Cases where one side dominates:
-             rewrite(max(x, op->type.max()), b) ||
-             rewrite(max(x, op->type.min()), x) ||
-             rewrite(max((x/c0)*c0, x), b, c0 > 0) ||
-             rewrite(max(x, (x/c0)*c0), a, c0 > 0) ||
-             rewrite(max(max(x, y), x), a) ||
-             rewrite(max(max(x, y), y), a) ||
-             rewrite(max(max(max(x, y), z), x), a) ||
-             rewrite(max(max(max(x, y), z), y), a) ||
-             rewrite(max(max(max(max(x, y), z), w), x), a) ||
-             rewrite(max(max(max(max(x, y), z), w), y), a) ||
-             rewrite(max(max(max(max(max(x, y), z), w), u), x), a) ||
-             rewrite(max(max(max(max(max(x, y), z), w), u), y), a) ||
-             rewrite(max(x, min(x, y)), a) ||
-             rewrite(max(x, min(y, x)), a) ||
-             rewrite(max(max(x, y), min(x, y)), a) ||
-             rewrite(max(max(x, y), min(y, x)), a) ||
-             rewrite(max(min(x, y), x), b) ||
-             rewrite(max(min(y, x), x), b) ||
-             rewrite(max(min(x, c0), c1), b, c1 >= c0) ||
+        if (EVAL_IN_LAMBDA(rewrite(max(x, x), x) ||
+                           rewrite(max(c0, c1), fold(max(c0, c1))) ||
+                           rewrite(max(IRMatcher::Indeterminate(), x), a) ||
+                           rewrite(max(x, IRMatcher::Indeterminate()), b) ||
+                           rewrite(max(IRMatcher::Overflow(), x), a) ||
+                           rewrite(max(x, IRMatcher::Overflow()), b) ||
+                           // Cases where one side dominates:
+                           rewrite(max(x, op->type.max()), b) ||
+                           rewrite(max(x, op->type.min()), x) ||
+                           rewrite(max((x / c0) * c0, x), b, c0 > 0) ||
+                           rewrite(max(x, (x / c0) * c0), a, c0 > 0) ||
+                           rewrite(max(max(x, y), x), a) ||
+                           rewrite(max(max(x, y), y), a) ||
+                           rewrite(max(max(max(x, y), z), x), a) ||
+                           rewrite(max(max(max(x, y), z), y), a) ||
+                           rewrite(max(max(max(max(x, y), z), w), x), a) ||
+                           rewrite(max(max(max(max(x, y), z), w), y), a) ||
+                           rewrite(max(max(max(max(max(x, y), z), w), u), x), a) ||
+                           rewrite(max(max(max(max(max(x, y), z), w), u), y), a) ||
+                           rewrite(max(x, min(x, y)), a) ||
+                           rewrite(max(x, min(y, x)), a) ||
+                           rewrite(max(max(x, y), min(x, y)), a) ||
+                           rewrite(max(max(x, y), min(y, x)), a) ||
+                           rewrite(max(min(x, y), x), b) ||
+                           rewrite(max(min(y, x), x), b) ||
+                           rewrite(max(min(x, c0), c1), b, c1 >= c0) ||
 
-             rewrite(max(intrin(Call::likely, x), x), a) ||
-             rewrite(max(x, intrin(Call::likely, x)), b) ||
-             rewrite(max(intrin(Call::likely_if_innermost, x), x), a) ||
-             rewrite(max(x, intrin(Call::likely_if_innermost, x)), b) ||
+                           rewrite(max(intrin(Call::likely, x), x), a) ||
+                           rewrite(max(x, intrin(Call::likely, x)), b) ||
+                           rewrite(max(intrin(Call::likely_if_innermost, x), x), a) ||
+                           rewrite(max(x, intrin(Call::likely_if_innermost, x)), b) ||
 
-             (no_overflow(op->type) &&
-              (rewrite(max(ramp(x, y), broadcast(z)), a, can_prove(x + y * (lanes - 1) >= z && x >= z, this)) ||
-               rewrite(max(ramp(x, y), broadcast(z)), b, can_prove(x + y * (lanes - 1) <= z && x <= z, this)) ||
-               // Compare x to a stair-step function in x
-               rewrite(max(((x + c0)/c1)*c1 + c2, x), a, c1 > 0 && c0 + c2 >= c1 - 1) ||
-               rewrite(max(x, ((x + c0)/c1)*c1 + c2), b, c1 > 0 && c0 + c2 >= c1 - 1) ||
-               rewrite(max(((x + c0)/c1)*c1 + c2, x), b, c1 > 0 && c0 + c2 <= 0) ||
-               rewrite(max(x, ((x + c0)/c1)*c1 + c2), a, c1 > 0 && c0 + c2 <= 0) ||
-               // Special cases where c0 or c2 is zero
-               rewrite(max((x/c1)*c1 + c2, x), a, c1 > 0 && c2 >= c1 - 1) ||
-               rewrite(max(x, (x/c1)*c1 + c2), b, c1 > 0 && c2 >= c1 - 1) ||
-               rewrite(max(((x + c0)/c1)*c1, x), a, c1 > 0 && c0 >= c1 - 1) ||
-               rewrite(max(x, ((x + c0)/c1)*c1), b, c1 > 0 && c0 >= c1 - 1) ||
-               rewrite(max((x/c1)*c1 + c2, x), b, c1 > 0 && c2 <= 0) ||
-               rewrite(max(x, (x/c1)*c1 + c2), a, c1 > 0 && c2 <= 0) ||
-               rewrite(max(((x + c0)/c1)*c1, x), b, c1 > 0 && c0 <= 0) ||
-               rewrite(max(x, ((x + c0)/c1)*c1), a, c1 > 0 && c0 <= 0))))) {
+                           (no_overflow(op->type) &&
+                            (rewrite(max(ramp(x, y), broadcast(z)), a, can_prove(x + y * (lanes - 1) >= z && x >= z, this)) ||
+                             rewrite(max(ramp(x, y), broadcast(z)), b, can_prove(x + y * (lanes - 1) <= z && x <= z, this)) ||
+                             // Compare x to a stair-step function in x
+                             rewrite(max(((x + c0) / c1) * c1 + c2, x), a, c1 > 0 && c0 + c2 >= c1 - 1) ||
+                             rewrite(max(x, ((x + c0) / c1) * c1 + c2), b, c1 > 0 && c0 + c2 >= c1 - 1) ||
+                             rewrite(max(((x + c0) / c1) * c1 + c2, x), b, c1 > 0 && c0 + c2 <= 0) ||
+                             rewrite(max(x, ((x + c0) / c1) * c1 + c2), a, c1 > 0 && c0 + c2 <= 0) ||
+                             // Special cases where c0 or c2 is zero
+                             rewrite(max((x / c1) * c1 + c2, x), a, c1 > 0 && c2 >= c1 - 1) ||
+                             rewrite(max(x, (x / c1) * c1 + c2), b, c1 > 0 && c2 >= c1 - 1) ||
+                             rewrite(max(((x + c0) / c1) * c1, x), a, c1 > 0 && c0 >= c1 - 1) ||
+                             rewrite(max(x, ((x + c0) / c1) * c1), b, c1 > 0 && c0 >= c1 - 1) ||
+                             rewrite(max((x / c1) * c1 + c2, x), b, c1 > 0 && c2 <= 0) ||
+                             rewrite(max(x, (x / c1) * c1 + c2), a, c1 > 0 && c2 <= 0) ||
+                             rewrite(max(((x + c0) / c1) * c1, x), b, c1 > 0 && c0 <= 0) ||
+                             rewrite(max(x, ((x + c0) / c1) * c1), a, c1 > 0 && c0 <= 0))))) {
             return rewrite.result;
         }
 
-        if (EVAL_IN_LAMBDA
-            (rewrite(max(max(x, c0), c1), max(x, fold(max(c0, c1)))) ||
-             rewrite(max(max(x, c0), y), max(max(x, y), c0)) ||
-             rewrite(max(max(x, y), max(x, z)), max(max(y, z), x)) ||
-             rewrite(max(max(y, x), max(x, z)), max(max(y, z), x)) ||
-             rewrite(max(max(x, y), max(z, x)), max(max(y, z), x)) ||
-             rewrite(max(max(y, x), max(z, x)), max(max(y, z), x)) ||
-             rewrite(max(max(x, y), max(z, w)), max(max(max(x, y), z), w)) ||
-             rewrite(max(broadcast(x), broadcast(y)), broadcast(max(x, y), lanes)) ||
-             rewrite(max(broadcast(x), ramp(y, z)), max(b, a)) ||
-             rewrite(max(max(x, broadcast(y)), broadcast(z)), max(x, broadcast(max(y, z), lanes))) ||
-             rewrite(max(min(x, y), min(x, z)), min(x, max(y, z))) ||
-             rewrite(max(min(x, y), min(z, x)), min(x, max(y, z))) ||
-             rewrite(max(min(y, x), min(x, z)), min(max(y, z), x)) ||
-             rewrite(max(min(y, x), min(z, x)), min(max(y, z), x)) ||
-             rewrite(max(min(max(x, y), z), y), max(min(x, z), y)) ||
-             rewrite(max(min(max(y, x), z), y), max(y, min(x, z))) ||
-             rewrite(max(max(x, c0), c1), max(x, fold(max(c0, c1)))) ||
+        if (EVAL_IN_LAMBDA(rewrite(max(max(x, c0), c1), max(x, fold(max(c0, c1)))) ||
+                           rewrite(max(max(x, c0), y), max(max(x, y), c0)) ||
+                           rewrite(max(max(x, y), max(x, z)), max(max(y, z), x)) ||
+                           rewrite(max(max(y, x), max(x, z)), max(max(y, z), x)) ||
+                           rewrite(max(max(x, y), max(z, x)), max(max(y, z), x)) ||
+                           rewrite(max(max(y, x), max(z, x)), max(max(y, z), x)) ||
+                           rewrite(max(max(x, y), max(z, w)), max(max(max(x, y), z), w)) ||
+                           rewrite(max(broadcast(x), broadcast(y)), broadcast(max(x, y), lanes)) ||
+                           rewrite(max(broadcast(x), ramp(y, z)), max(b, a)) ||
+                           rewrite(max(max(x, broadcast(y)), broadcast(z)), max(x, broadcast(max(y, z), lanes))) ||
+                           rewrite(max(min(x, y), min(x, z)), min(x, max(y, z))) ||
+                           rewrite(max(min(x, y), min(z, x)), min(x, max(y, z))) ||
+                           rewrite(max(min(y, x), min(x, z)), min(max(y, z), x)) ||
+                           rewrite(max(min(y, x), min(z, x)), min(max(y, z), x)) ||
+                           rewrite(max(min(max(x, y), z), y), max(min(x, z), y)) ||
+                           rewrite(max(min(max(y, x), z), y), max(y, min(x, z))) ||
+                           rewrite(max(max(x, c0), c1), max(x, fold(max(c0, c1)))) ||
 
-             (no_overflow(op->type) &&
-              (rewrite(max(max(x, y) + c0, x), max(x, y + c0), c0 < 0) ||
-               rewrite(max(max(x, y) + c0, x), max(x, y) + c0, c0 > 0) ||
-               rewrite(max(max(y, x) + c0, x), max(y + c0, x), c0 < 0) ||
-               rewrite(max(max(y, x) + c0, x), max(y, x) + c0, c0 > 0) ||
+                           (no_overflow(op->type) &&
+                            (rewrite(max(max(x, y) + c0, x), max(x, y + c0), c0 < 0) ||
+                             rewrite(max(max(x, y) + c0, x), max(x, y) + c0, c0 > 0) ||
+                             rewrite(max(max(y, x) + c0, x), max(y + c0, x), c0 < 0) ||
+                             rewrite(max(max(y, x) + c0, x), max(y, x) + c0, c0 > 0) ||
 
-               rewrite(max(x, max(x, y) + c0), max(x, y + c0), c0 < 0) ||
-               rewrite(max(x, max(x, y) + c0), max(x, y) + c0, c0 > 0) ||
-               rewrite(max(x, max(y, x) + c0), max(x, y + c0), c0 < 0) ||
-               rewrite(max(x, max(y, x) + c0), max(x, y) + c0, c0 > 0) ||
+                             rewrite(max(x, max(x, y) + c0), max(x, y + c0), c0 < 0) ||
+                             rewrite(max(x, max(x, y) + c0), max(x, y) + c0, c0 > 0) ||
+                             rewrite(max(x, max(y, x) + c0), max(x, y + c0), c0 < 0) ||
+                             rewrite(max(x, max(y, x) + c0), max(x, y) + c0, c0 > 0) ||
 
-               rewrite(max(x + c0, c1), max(x, fold(c1 - c0)) + c0) ||
+                             rewrite(max(x + c0, c1), max(x, fold(c1 - c0)) + c0) ||
 
-               rewrite(max(x + c0, y + c1), max(x, y + fold(c1 - c0)) + c0, c1 > c0) ||
-               rewrite(max(x + c0, y + c1), max(x + fold(c0 - c1), y) + c1, c0 > c1) ||
+                             rewrite(max(x + c0, y + c1), max(x, y + fold(c1 - c0)) + c0, c1 > c0) ||
+                             rewrite(max(x + c0, y + c1), max(x + fold(c0 - c1), y) + c1, c0 > c1) ||
 
-               rewrite(max(x + y, x + z), x + max(y, z)) ||
-               rewrite(max(x + y, z + x), x + max(y, z)) ||
-               rewrite(max(y + x, x + z), max(y, z) + x) ||
-               rewrite(max(y + x, z + x), max(y, z) + x) ||
-               rewrite(max(x, x + z), x + max(z, 0)) ||
-               rewrite(max(x, z + x), x + max(z, 0)) ||
-               rewrite(max(y + x, x), max(y, 0) + x) ||
-               rewrite(max(x + y, x), x + max(y, 0)) ||
+                             rewrite(max(x + y, x + z), x + max(y, z)) ||
+                             rewrite(max(x + y, z + x), x + max(y, z)) ||
+                             rewrite(max(y + x, x + z), max(y, z) + x) ||
+                             rewrite(max(y + x, z + x), max(y, z) + x) ||
+                             rewrite(max(x, x + z), x + max(z, 0)) ||
+                             rewrite(max(x, z + x), x + max(z, 0)) ||
+                             rewrite(max(y + x, x), max(y, 0) + x) ||
+                             rewrite(max(x + y, x), x + max(y, 0)) ||
 
-               rewrite(max((x*c0 + y)*c1, x*c2 + z), max(y*c1, z) + x*c2, c0 * c1 == c2) ||
-               rewrite(max((y + x*c0)*c1, x*c2 + z), max(y*c1, z) + x*c2, c0 * c1 == c2) ||
-               rewrite(max((x*c0 + y)*c1, z + x*c2), max(y*c1, z) + x*c2, c0 * c1 == c2) ||
-               rewrite(max((y + x*c0)*c1, z + x*c2), max(y*c1, z) + x*c2, c0 * c1 == c2) ||
+                             rewrite(max((x * c0 + y) * c1, x * c2 + z), max(y * c1, z) + x * c2, c0 * c1 == c2) ||
+                             rewrite(max((y + x * c0) * c1, x * c2 + z), max(y * c1, z) + x * c2, c0 * c1 == c2) ||
+                             rewrite(max((x * c0 + y) * c1, z + x * c2), max(y * c1, z) + x * c2, c0 * c1 == c2) ||
+                             rewrite(max((y + x * c0) * c1, z + x * c2), max(y * c1, z) + x * c2, c0 * c1 == c2) ||
 
-               rewrite(max(max(x + y, z), x + w), max(x + max(y, w), z)) ||
-               rewrite(max(max(z, x + y), x + w), max(x + max(y, w), z)) ||
-               rewrite(max(max(x + y, z), w + x), max(x + max(y, w), z)) ||
-               rewrite(max(max(z, x + y), w + x), max(x + max(y, w), z)) ||
+                             rewrite(max(max(x + y, z), x + w), max(x + max(y, w), z)) ||
+                             rewrite(max(max(z, x + y), x + w), max(x + max(y, w), z)) ||
+                             rewrite(max(max(x + y, z), w + x), max(x + max(y, w), z)) ||
+                             rewrite(max(max(z, x + y), w + x), max(x + max(y, w), z)) ||
 
-               rewrite(max(max(y + x, z), x + w), max(max(y, w) + x, z)) ||
-               rewrite(max(max(z, y + x), x + w), max(max(y, w) + x, z)) ||
-               rewrite(max(max(y + x, z), w + x), max(max(y, w) + x, z)) ||
-               rewrite(max(max(z, y + x), w + x), max(max(y, w) + x, z)) ||
+                             rewrite(max(max(y + x, z), x + w), max(max(y, w) + x, z)) ||
+                             rewrite(max(max(z, y + x), x + w), max(max(y, w) + x, z)) ||
+                             rewrite(max(max(y + x, z), w + x), max(max(y, w) + x, z)) ||
+                             rewrite(max(max(z, y + x), w + x), max(max(y, w) + x, z)) ||
 
-               rewrite(max((x + w) + y, x + z), x + max(w + y, z)) ||
-               rewrite(max((w + x) + y, x + z), max(w + y, z) + x) ||
-               rewrite(max((x + w) + y, z + x), x + max(w + y, z)) ||
-               rewrite(max((w + x) + y, z + x), max(w + y, z) + x) ||
-               rewrite(max((x + w) + y, x), x + max(w + y, 0)) ||
-               rewrite(max((w + x) + y, x), x + max(w + y, 0)) ||
-               rewrite(max(x + y, (w + x) + z), x + max(w + z, y)) ||
-               rewrite(max(x + y, (x + w) + z), x + max(w + z, y)) ||
-               rewrite(max(y + x, (w + x) + z), max(w + z, y) + x) ||
-               rewrite(max(y + x, (x + w) + z), max(w + z, y) + x) ||
-               rewrite(max(x, (w + x) + z), x + max(w + z, 0)) ||
-               rewrite(max(x, (x + w) + z), x + max(w + z, 0)) ||
+                             rewrite(max((x + w) + y, x + z), x + max(w + y, z)) ||
+                             rewrite(max((w + x) + y, x + z), max(w + y, z) + x) ||
+                             rewrite(max((x + w) + y, z + x), x + max(w + y, z)) ||
+                             rewrite(max((w + x) + y, z + x), max(w + y, z) + x) ||
+                             rewrite(max((x + w) + y, x), x + max(w + y, 0)) ||
+                             rewrite(max((w + x) + y, x), x + max(w + y, 0)) ||
+                             rewrite(max(x + y, (w + x) + z), x + max(w + z, y)) ||
+                             rewrite(max(x + y, (x + w) + z), x + max(w + z, y)) ||
+                             rewrite(max(y + x, (w + x) + z), max(w + z, y) + x) ||
+                             rewrite(max(y + x, (x + w) + z), max(w + z, y) + x) ||
+                             rewrite(max(x, (w + x) + z), x + max(w + z, 0)) ||
+                             rewrite(max(x, (x + w) + z), x + max(w + z, 0)) ||
 
-               rewrite(max(y - x, z - x), max(y, z) - x) ||
-               rewrite(max(x - y, x - z), x - min(y, z)) ||
+                             rewrite(max(y - x, z - x), max(y, z) - x) ||
+                             rewrite(max(x - y, x - z), x - min(y, z)) ||
 
-               rewrite(max(x, x - y), x - min(0, y)) ||
-               rewrite(max(x - y, x), x - min(0, y)) ||
-               rewrite(max(x, (x - y) + z), x + max(0, z - y)) ||
-               rewrite(max(x, z + (x - y)), x + max(0, z - y)) ||
-               rewrite(max(x, (x - y) - z), x - min(0, y + z)) ||
-               rewrite(max((x - y) + z, x), max(0, z - y) + x) ||
-               rewrite(max(z + (x - y), x), max(0, z - y) + x) ||
-               rewrite(max((x - y) - z, x), x - min(0, y + z)) ||
+                             rewrite(max(x, x - y), x - min(0, y)) ||
+                             rewrite(max(x - y, x), x - min(0, y)) ||
+                             rewrite(max(x, (x - y) + z), x + max(0, z - y)) ||
+                             rewrite(max(x, z + (x - y)), x + max(0, z - y)) ||
+                             rewrite(max(x, (x - y) - z), x - min(0, y + z)) ||
+                             rewrite(max((x - y) + z, x), max(0, z - y) + x) ||
+                             rewrite(max(z + (x - y), x), max(0, z - y) + x) ||
+                             rewrite(max((x - y) - z, x), x - min(0, y + z)) ||
 
-               rewrite(max(x * c0, c1), max(x, fold(c1 / c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
-               rewrite(max(x * c0, c1), min(x, fold(c1 / c0)) * c0, c0 < 0 && c1 % c0 == 0) ||
+                             rewrite(max(x * c0, c1), max(x, fold(c1 / c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
+                             rewrite(max(x * c0, c1), min(x, fold(c1 / c0)) * c0, c0 < 0 && c1 % c0 == 0) ||
 
-               rewrite(max(x * c0, y * c1), max(x, y * fold(c1 / c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
-               rewrite(max(x * c0, y * c1), min(x, y * fold(c1 / c0)) * c0, c0 < 0 && c1 % c0 == 0) ||
-               rewrite(max(x * c0, y * c1), max(x * fold(c0 / c1), y) * c1, c1 > 0 && c0 % c1 == 0) ||
-               rewrite(max(x * c0, y * c1), min(x * fold(c0 / c1), y) * c1, c1 < 0 && c0 % c1 == 0) ||
-               rewrite(max(x * c0, y * c0 + c1), max(x, y + fold(c1 / c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
-               rewrite(max(x * c0, y * c0 + c1), min(x, y + fold(c1 / c0)) * c0, c0 < 0 && c1 % c0 == 0) ||
+                             rewrite(max(x * c0, y * c1), max(x, y * fold(c1 / c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
+                             rewrite(max(x * c0, y * c1), min(x, y * fold(c1 / c0)) * c0, c0 < 0 && c1 % c0 == 0) ||
+                             rewrite(max(x * c0, y * c1), max(x * fold(c0 / c1), y) * c1, c1 > 0 && c0 % c1 == 0) ||
+                             rewrite(max(x * c0, y * c1), min(x * fold(c0 / c1), y) * c1, c1 < 0 && c0 % c1 == 0) ||
+                             rewrite(max(x * c0, y * c0 + c1), max(x, y + fold(c1 / c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
+                             rewrite(max(x * c0, y * c0 + c1), min(x, y + fold(c1 / c0)) * c0, c0 < 0 && c1 % c0 == 0) ||
 
-               rewrite(max(x / c0, y / c0), max(x, y) / c0, c0 > 0) ||
-               rewrite(max(x / c0, y / c0), min(x, y) / c0, c0 < 0) ||
+                             rewrite(max(x / c0, y / c0), max(x, y) / c0, c0 > 0) ||
+                             rewrite(max(x / c0, y / c0), min(x, y) / c0, c0 < 0) ||
 
-               /* Causes some things to cancel, but also creates large constants and breaks peephole patterns
+                             /* Causes some things to cancel, but also creates large constants and breaks peephole patterns
                   rewrite(max(x / c0, c1), max(x, fold(c1 * c0)) / c0, c0 > 0 && !overflows(c1 * c0)) ||
                   rewrite(max(x / c0, c1), min(x, fold(c1 * c0)) / c0, c0 < 0 && !overflows(c1 * c0)) ||
                */
 
-               rewrite(max(x / c0, y / c0 + c1), max(x, y + fold(c1 * c0)) / c0, c0 > 0 && !overflows(c1 * c0)) ||
-               rewrite(max(x / c0, y / c0 + c1), min(x, y + fold(c1 * c0)) / c0, c0 < 0 && !overflows(c1 * c0)) ||
+                             rewrite(max(x / c0, y / c0 + c1), max(x, y + fold(c1 * c0)) / c0, c0 > 0 && !overflows(c1 * c0)) ||
+                             rewrite(max(x / c0, y / c0 + c1), min(x, y + fold(c1 * c0)) / c0, c0 < 0 && !overflows(c1 * c0)) ||
 
-               rewrite(max(select(x, y, z), select(x, w, u)), select(x, max(y, w), max(z, u))) ||
+                             rewrite(max(select(x, y, z), select(x, w, u)), select(x, max(y, w), max(z, u))) ||
 
-               rewrite(max(c0 - x, c1), c0 - min(x, fold(c0 - c1))))))) {
+                             rewrite(max(c0 - x, c1), c0 - min(x, fold(c0 - c1))))))) {
 
             return mutate(std::move(rewrite.result), bounds);
         }

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -42,170 +42,168 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
         int lanes = op->type.lanes();
         auto rewrite = IRMatcher::rewriter(IRMatcher::min(a, b), op->type);
 
-        if (EVAL_IN_LAMBDA
-            (rewrite(min(x, x), x) ||
-             rewrite(min(c0, c1), fold(min(c0, c1))) ||
-             rewrite(min(IRMatcher::Indeterminate(), x), a) ||
-             rewrite(min(x, IRMatcher::Indeterminate()), b) ||
-             rewrite(min(IRMatcher::Overflow(), x), a) ||
-             rewrite(min(x,IRMatcher::Overflow()), b) ||
-             // Cases where one side dominates:
-             rewrite(min(x, op->type.min()), b) ||
-             rewrite(min(x, op->type.max()), x) ||
-             rewrite(min((x/c0)*c0, x), a, c0 > 0) ||
-             rewrite(min(x, (x/c0)*c0), b, c0 > 0) ||
-             rewrite(min(min(x, y), x), a) ||
-             rewrite(min(min(x, y), y), a) ||
-             rewrite(min(min(min(x, y), z), x), a) ||
-             rewrite(min(min(min(x, y), z), y), a) ||
-             rewrite(min(min(min(min(x, y), z), w), x), a) ||
-             rewrite(min(min(min(min(x, y), z), w), y), a) ||
-             rewrite(min(min(min(min(min(x, y), z), w), u), x), a) ||
-             rewrite(min(min(min(min(min(x, y), z), w), u), y), a) ||
-             rewrite(min(x, max(x, y)), a) ||
-             rewrite(min(x, max(y, x)), a) ||
-             rewrite(min(max(x, y), min(x, y)), b) ||
-             rewrite(min(max(x, y), min(y, x)), b) ||
-             rewrite(min(max(x, y), x), b) ||
-             rewrite(min(max(y, x), x), b) ||
-             rewrite(min(max(x, c0), c1), b, c1 <= c0) ||
+        if (EVAL_IN_LAMBDA(rewrite(min(x, x), x) ||
+                           rewrite(min(c0, c1), fold(min(c0, c1))) ||
+                           rewrite(min(IRMatcher::Indeterminate(), x), a) ||
+                           rewrite(min(x, IRMatcher::Indeterminate()), b) ||
+                           rewrite(min(IRMatcher::Overflow(), x), a) ||
+                           rewrite(min(x, IRMatcher::Overflow()), b) ||
+                           // Cases where one side dominates:
+                           rewrite(min(x, op->type.min()), b) ||
+                           rewrite(min(x, op->type.max()), x) ||
+                           rewrite(min((x / c0) * c0, x), a, c0 > 0) ||
+                           rewrite(min(x, (x / c0) * c0), b, c0 > 0) ||
+                           rewrite(min(min(x, y), x), a) ||
+                           rewrite(min(min(x, y), y), a) ||
+                           rewrite(min(min(min(x, y), z), x), a) ||
+                           rewrite(min(min(min(x, y), z), y), a) ||
+                           rewrite(min(min(min(min(x, y), z), w), x), a) ||
+                           rewrite(min(min(min(min(x, y), z), w), y), a) ||
+                           rewrite(min(min(min(min(min(x, y), z), w), u), x), a) ||
+                           rewrite(min(min(min(min(min(x, y), z), w), u), y), a) ||
+                           rewrite(min(x, max(x, y)), a) ||
+                           rewrite(min(x, max(y, x)), a) ||
+                           rewrite(min(max(x, y), min(x, y)), b) ||
+                           rewrite(min(max(x, y), min(y, x)), b) ||
+                           rewrite(min(max(x, y), x), b) ||
+                           rewrite(min(max(y, x), x), b) ||
+                           rewrite(min(max(x, c0), c1), b, c1 <= c0) ||
 
-             rewrite(min(intrin(Call::likely, x), x), a) ||
-             rewrite(min(x, intrin(Call::likely, x)), b) ||
-             rewrite(min(intrin(Call::likely_if_innermost, x), x), a) ||
-             rewrite(min(x, intrin(Call::likely_if_innermost, x)), b) ||
+                           rewrite(min(intrin(Call::likely, x), x), a) ||
+                           rewrite(min(x, intrin(Call::likely, x)), b) ||
+                           rewrite(min(intrin(Call::likely_if_innermost, x), x), a) ||
+                           rewrite(min(x, intrin(Call::likely_if_innermost, x)), b) ||
 
-             (no_overflow(op->type) &&
-              (rewrite(min(ramp(x, y), broadcast(z)), a, can_prove(x + y * (lanes - 1) <= z && x <= z, this)) ||
-               rewrite(min(ramp(x, y), broadcast(z)), b, can_prove(x + y * (lanes - 1) >= z && x >= z, this)) ||
-               // Compare x to a stair-step function in x
-               rewrite(min(((x + c0)/c1)*c1 + c2, x), b, c1 > 0 && c0 + c2 >= c1 - 1) ||
-               rewrite(min(x, ((x + c0)/c1)*c1 + c2), a, c1 > 0 && c0 + c2 >= c1 - 1) ||
-               rewrite(min(((x + c0)/c1)*c1 + c2, x), a, c1 > 0 && c0 + c2 <= 0) ||
-               rewrite(min(x, ((x + c0)/c1)*c1 + c2), b, c1 > 0 && c0 + c2 <= 0) ||
-               // Special cases where c0 or c2 is zero
-               rewrite(min((x/c1)*c1 + c2, x), b, c1 > 0 && c2 >= c1 - 1) ||
-               rewrite(min(x, (x/c1)*c1 + c2), a, c1 > 0 && c2 >= c1 - 1) ||
-               rewrite(min(((x + c0)/c1)*c1, x), b, c1 > 0 && c0 >= c1 - 1) ||
-               rewrite(min(x, ((x + c0)/c1)*c1), a, c1 > 0 && c0 >= c1 - 1) ||
-               rewrite(min((x/c1)*c1 + c2, x), a, c1 > 0 && c2 <= 0) ||
-               rewrite(min(x, (x/c1)*c1 + c2), b, c1 > 0 && c2 <= 0) ||
-               rewrite(min(((x + c0)/c1)*c1, x), a, c1 > 0 && c0 <= 0) ||
-               rewrite(min(x, ((x + c0)/c1)*c1), b, c1 > 0 && c0 <= 0))))) {
+                           (no_overflow(op->type) &&
+                            (rewrite(min(ramp(x, y), broadcast(z)), a, can_prove(x + y * (lanes - 1) <= z && x <= z, this)) ||
+                             rewrite(min(ramp(x, y), broadcast(z)), b, can_prove(x + y * (lanes - 1) >= z && x >= z, this)) ||
+                             // Compare x to a stair-step function in x
+                             rewrite(min(((x + c0) / c1) * c1 + c2, x), b, c1 > 0 && c0 + c2 >= c1 - 1) ||
+                             rewrite(min(x, ((x + c0) / c1) * c1 + c2), a, c1 > 0 && c0 + c2 >= c1 - 1) ||
+                             rewrite(min(((x + c0) / c1) * c1 + c2, x), a, c1 > 0 && c0 + c2 <= 0) ||
+                             rewrite(min(x, ((x + c0) / c1) * c1 + c2), b, c1 > 0 && c0 + c2 <= 0) ||
+                             // Special cases where c0 or c2 is zero
+                             rewrite(min((x / c1) * c1 + c2, x), b, c1 > 0 && c2 >= c1 - 1) ||
+                             rewrite(min(x, (x / c1) * c1 + c2), a, c1 > 0 && c2 >= c1 - 1) ||
+                             rewrite(min(((x + c0) / c1) * c1, x), b, c1 > 0 && c0 >= c1 - 1) ||
+                             rewrite(min(x, ((x + c0) / c1) * c1), a, c1 > 0 && c0 >= c1 - 1) ||
+                             rewrite(min((x / c1) * c1 + c2, x), a, c1 > 0 && c2 <= 0) ||
+                             rewrite(min(x, (x / c1) * c1 + c2), b, c1 > 0 && c2 <= 0) ||
+                             rewrite(min(((x + c0) / c1) * c1, x), a, c1 > 0 && c0 <= 0) ||
+                             rewrite(min(x, ((x + c0) / c1) * c1), b, c1 > 0 && c0 <= 0))))) {
             return rewrite.result;
         }
 
-        if (EVAL_IN_LAMBDA
-            (rewrite(min(min(x, c0), c1), min(x, fold(min(c0, c1)))) ||
-             rewrite(min(min(x, c0), y), min(min(x, y), c0)) ||
-             rewrite(min(min(x, y), min(x, z)), min(min(y, z), x)) ||
-             rewrite(min(min(y, x), min(x, z)), min(min(y, z), x)) ||
-             rewrite(min(min(x, y), min(z, x)), min(min(y, z), x)) ||
-             rewrite(min(min(y, x), min(z, x)), min(min(y, z), x)) ||
-             rewrite(min(min(x, y), min(z, w)), min(min(min(x, y), z), w)) ||
-             rewrite(min(broadcast(x), broadcast(y)), broadcast(min(x, y), lanes)) ||
-             rewrite(min(broadcast(x), ramp(y, z)), min(b, a)) ||
-             rewrite(min(min(x, broadcast(y)), broadcast(z)), min(x, broadcast(min(y, z), lanes))) ||
-             rewrite(min(max(x, y), max(x, z)), max(x, min(y, z))) ||
-             rewrite(min(max(x, y), max(z, x)), max(x, min(y, z))) ||
-             rewrite(min(max(y, x), max(x, z)), max(min(y, z), x)) ||
-             rewrite(min(max(y, x), max(z, x)), max(min(y, z), x)) ||
-             rewrite(min(max(min(x, y), z), y), min(max(x, z), y)) ||
-             rewrite(min(max(min(y, x), z), y), min(y, max(x, z))) ||
-             rewrite(min(min(x, c0), c1), min(x, fold(min(c0, c1)))) ||
+        if (EVAL_IN_LAMBDA(rewrite(min(min(x, c0), c1), min(x, fold(min(c0, c1)))) ||
+                           rewrite(min(min(x, c0), y), min(min(x, y), c0)) ||
+                           rewrite(min(min(x, y), min(x, z)), min(min(y, z), x)) ||
+                           rewrite(min(min(y, x), min(x, z)), min(min(y, z), x)) ||
+                           rewrite(min(min(x, y), min(z, x)), min(min(y, z), x)) ||
+                           rewrite(min(min(y, x), min(z, x)), min(min(y, z), x)) ||
+                           rewrite(min(min(x, y), min(z, w)), min(min(min(x, y), z), w)) ||
+                           rewrite(min(broadcast(x), broadcast(y)), broadcast(min(x, y), lanes)) ||
+                           rewrite(min(broadcast(x), ramp(y, z)), min(b, a)) ||
+                           rewrite(min(min(x, broadcast(y)), broadcast(z)), min(x, broadcast(min(y, z), lanes))) ||
+                           rewrite(min(max(x, y), max(x, z)), max(x, min(y, z))) ||
+                           rewrite(min(max(x, y), max(z, x)), max(x, min(y, z))) ||
+                           rewrite(min(max(y, x), max(x, z)), max(min(y, z), x)) ||
+                           rewrite(min(max(y, x), max(z, x)), max(min(y, z), x)) ||
+                           rewrite(min(max(min(x, y), z), y), min(max(x, z), y)) ||
+                           rewrite(min(max(min(y, x), z), y), min(y, max(x, z))) ||
+                           rewrite(min(min(x, c0), c1), min(x, fold(min(c0, c1)))) ||
 
-             // Canonicalize a clamp
-             rewrite(min(max(x, c0), c1), max(min(x, c1), c0), c0 <= c1) ||
+                           // Canonicalize a clamp
+                           rewrite(min(max(x, c0), c1), max(min(x, c1), c0), c0 <= c1) ||
 
-             (no_overflow(op->type) &&
-              (rewrite(min(min(x, y) + c0, x), min(x, y + c0), c0 > 0) ||
-               rewrite(min(min(x, y) + c0, x), min(x, y) + c0, c0 < 0) ||
-               rewrite(min(min(y, x) + c0, x), min(y + c0, x), c0 > 0) ||
-               rewrite(min(min(y, x) + c0, x), min(y, x) + c0, c0 < 0) ||
+                           (no_overflow(op->type) &&
+                            (rewrite(min(min(x, y) + c0, x), min(x, y + c0), c0 > 0) ||
+                             rewrite(min(min(x, y) + c0, x), min(x, y) + c0, c0 < 0) ||
+                             rewrite(min(min(y, x) + c0, x), min(y + c0, x), c0 > 0) ||
+                             rewrite(min(min(y, x) + c0, x), min(y, x) + c0, c0 < 0) ||
 
-               rewrite(min(x, min(x, y) + c0), min(x, y + c0), c0 > 0) ||
-               rewrite(min(x, min(x, y) + c0), min(x, y) + c0, c0 < 0) ||
-               rewrite(min(x, min(y, x) + c0), min(x, y + c0), c0 > 0) ||
-               rewrite(min(x, min(y, x) + c0), min(x, y) + c0, c0 < 0) ||
+                             rewrite(min(x, min(x, y) + c0), min(x, y + c0), c0 > 0) ||
+                             rewrite(min(x, min(x, y) + c0), min(x, y) + c0, c0 < 0) ||
+                             rewrite(min(x, min(y, x) + c0), min(x, y + c0), c0 > 0) ||
+                             rewrite(min(x, min(y, x) + c0), min(x, y) + c0, c0 < 0) ||
 
-               rewrite(min(x + c0, c1), min(x, fold(c1 - c0)) + c0) ||
+                             rewrite(min(x + c0, c1), min(x, fold(c1 - c0)) + c0) ||
 
-               rewrite(min(x + c0, y + c1), min(x, y + fold(c1 - c0)) + c0, c1 > c0) ||
-               rewrite(min(x + c0, y + c1), min(x + fold(c0 - c1), y) + c1, c0 > c1) ||
+                             rewrite(min(x + c0, y + c1), min(x, y + fold(c1 - c0)) + c0, c1 > c0) ||
+                             rewrite(min(x + c0, y + c1), min(x + fold(c0 - c1), y) + c1, c0 > c1) ||
 
-               rewrite(min(x + y, x + z), x + min(y, z)) ||
-               rewrite(min(x + y, z + x), x + min(y, z)) ||
-               rewrite(min(y + x, x + z), min(y, z) + x) ||
-               rewrite(min(y + x, z + x), min(y, z) + x) ||
-               rewrite(min(x, x + z), x + min(z, 0)) ||
-               rewrite(min(x, z + x), x + min(z, 0)) ||
-               rewrite(min(y + x, x), min(y, 0) + x) ||
-               rewrite(min(x + y, x), x + min(y, 0)) ||
+                             rewrite(min(x + y, x + z), x + min(y, z)) ||
+                             rewrite(min(x + y, z + x), x + min(y, z)) ||
+                             rewrite(min(y + x, x + z), min(y, z) + x) ||
+                             rewrite(min(y + x, z + x), min(y, z) + x) ||
+                             rewrite(min(x, x + z), x + min(z, 0)) ||
+                             rewrite(min(x, z + x), x + min(z, 0)) ||
+                             rewrite(min(y + x, x), min(y, 0) + x) ||
+                             rewrite(min(x + y, x), x + min(y, 0)) ||
 
-               rewrite(min((x*c0 + y)*c1, x*c2 + z), min(y*c1, z) + x*c2, c0 * c1 == c2) ||
-               rewrite(min((y + x*c0)*c1, x*c2 + z), min(y*c1, z) + x*c2, c0 * c1 == c2) ||
-               rewrite(min((x*c0 + y)*c1, z + x*c2), min(y*c1, z) + x*c2, c0 * c1 == c2) ||
-               rewrite(min((y + x*c0)*c1, z + x*c2), min(y*c1, z) + x*c2, c0 * c1 == c2) ||
+                             rewrite(min((x * c0 + y) * c1, x * c2 + z), min(y * c1, z) + x * c2, c0 * c1 == c2) ||
+                             rewrite(min((y + x * c0) * c1, x * c2 + z), min(y * c1, z) + x * c2, c0 * c1 == c2) ||
+                             rewrite(min((x * c0 + y) * c1, z + x * c2), min(y * c1, z) + x * c2, c0 * c1 == c2) ||
+                             rewrite(min((y + x * c0) * c1, z + x * c2), min(y * c1, z) + x * c2, c0 * c1 == c2) ||
 
-               rewrite(min(min(x + y, z), x + w), min(x + min(y, w), z)) ||
-               rewrite(min(min(z, x + y), x + w), min(x + min(y, w), z)) ||
-               rewrite(min(min(x + y, z), w + x), min(x + min(y, w), z)) ||
-               rewrite(min(min(z, x + y), w + x), min(x + min(y, w), z)) ||
+                             rewrite(min(min(x + y, z), x + w), min(x + min(y, w), z)) ||
+                             rewrite(min(min(z, x + y), x + w), min(x + min(y, w), z)) ||
+                             rewrite(min(min(x + y, z), w + x), min(x + min(y, w), z)) ||
+                             rewrite(min(min(z, x + y), w + x), min(x + min(y, w), z)) ||
 
-               rewrite(min(min(y + x, z), x + w), min(min(y, w) + x, z)) ||
-               rewrite(min(min(z, y + x), x + w), min(min(y, w) + x, z)) ||
-               rewrite(min(min(y + x, z), w + x), min(min(y, w) + x, z)) ||
-               rewrite(min(min(z, y + x), w + x), min(min(y, w) + x, z)) ||
+                             rewrite(min(min(y + x, z), x + w), min(min(y, w) + x, z)) ||
+                             rewrite(min(min(z, y + x), x + w), min(min(y, w) + x, z)) ||
+                             rewrite(min(min(y + x, z), w + x), min(min(y, w) + x, z)) ||
+                             rewrite(min(min(z, y + x), w + x), min(min(y, w) + x, z)) ||
 
-               rewrite(min((x + w) + y, x + z), x + min(w + y, z)) ||
-               rewrite(min((w + x) + y, x + z), min(w + y, z) + x) ||
-               rewrite(min((x + w) + y, z + x), x + min(w + y, z)) ||
-               rewrite(min((w + x) + y, z + x), min(w + y, z) + x) ||
-               rewrite(min((x + w) + y, x), x + min(w + y, 0)) ||
-               rewrite(min((w + x) + y, x), x + min(w + y, 0)) ||
-               rewrite(min(x + y, (w + x) + z), x + min(w + z, y)) ||
-               rewrite(min(x + y, (x + w) + z), x + min(w + z, y)) ||
-               rewrite(min(y + x, (w + x) + z), min(w + z, y) + x) ||
-               rewrite(min(y + x, (x + w) + z), min(w + z, y) + x) ||
-               rewrite(min(x, (w + x) + z), x + min(w + z, 0)) ||
-               rewrite(min(x, (x + w) + z), x + min(w + z, 0)) ||
+                             rewrite(min((x + w) + y, x + z), x + min(w + y, z)) ||
+                             rewrite(min((w + x) + y, x + z), min(w + y, z) + x) ||
+                             rewrite(min((x + w) + y, z + x), x + min(w + y, z)) ||
+                             rewrite(min((w + x) + y, z + x), min(w + y, z) + x) ||
+                             rewrite(min((x + w) + y, x), x + min(w + y, 0)) ||
+                             rewrite(min((w + x) + y, x), x + min(w + y, 0)) ||
+                             rewrite(min(x + y, (w + x) + z), x + min(w + z, y)) ||
+                             rewrite(min(x + y, (x + w) + z), x + min(w + z, y)) ||
+                             rewrite(min(y + x, (w + x) + z), min(w + z, y) + x) ||
+                             rewrite(min(y + x, (x + w) + z), min(w + z, y) + x) ||
+                             rewrite(min(x, (w + x) + z), x + min(w + z, 0)) ||
+                             rewrite(min(x, (x + w) + z), x + min(w + z, 0)) ||
 
-               rewrite(min(y - x, z - x), min(y, z) - x) ||
-               rewrite(min(x - y, x - z), x - max(y, z)) ||
+                             rewrite(min(y - x, z - x), min(y, z) - x) ||
+                             rewrite(min(x - y, x - z), x - max(y, z)) ||
 
-               rewrite(min(x, x - y), x - max(0, y)) ||
-               rewrite(min(x - y, x), x - max(0, y)) ||
-               rewrite(min(x, (x - y) + z), x + min(0, z - y)) ||
-               rewrite(min(x, z + (x - y)), x + min(0, z - y)) ||
-               rewrite(min(x, (x - y) - z), x - max(0, y + z)) ||
-               rewrite(min((x - y) + z, x), min(0, z - y) + x) ||
-               rewrite(min(z + (x - y), x), min(0, z - y) + x) ||
-               rewrite(min((x - y) - z, x), x - max(0, y + z)) ||
+                             rewrite(min(x, x - y), x - max(0, y)) ||
+                             rewrite(min(x - y, x), x - max(0, y)) ||
+                             rewrite(min(x, (x - y) + z), x + min(0, z - y)) ||
+                             rewrite(min(x, z + (x - y)), x + min(0, z - y)) ||
+                             rewrite(min(x, (x - y) - z), x - max(0, y + z)) ||
+                             rewrite(min((x - y) + z, x), min(0, z - y) + x) ||
+                             rewrite(min(z + (x - y), x), min(0, z - y) + x) ||
+                             rewrite(min((x - y) - z, x), x - max(0, y + z)) ||
 
-               rewrite(min(x * c0, c1), min(x, fold(c1 / c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
-               rewrite(min(x * c0, c1), max(x, fold(c1 / c0)) * c0, c0 < 0 && c1 % c0 == 0) ||
+                             rewrite(min(x * c0, c1), min(x, fold(c1 / c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
+                             rewrite(min(x * c0, c1), max(x, fold(c1 / c0)) * c0, c0 < 0 && c1 % c0 == 0) ||
 
-               rewrite(min(x * c0, y * c1), min(x, y * fold(c1 / c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
-               rewrite(min(x * c0, y * c1), max(x, y * fold(c1 / c0)) * c0, c0 < 0 && c1 % c0 == 0) ||
-               rewrite(min(x * c0, y * c1), min(x * fold(c0 / c1), y) * c1, c1 > 0 && c0 % c1 == 0) ||
-               rewrite(min(x * c0, y * c1), max(x * fold(c0 / c1), y) * c1, c1 < 0 && c0 % c1 == 0) ||
-               rewrite(min(x * c0, y * c0 + c1), min(x, y + fold(c1 / c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
-               rewrite(min(x * c0, y * c0 + c1), max(x, y + fold(c1 / c0)) * c0, c0 < 0 && c1 % c0 == 0) ||
+                             rewrite(min(x * c0, y * c1), min(x, y * fold(c1 / c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
+                             rewrite(min(x * c0, y * c1), max(x, y * fold(c1 / c0)) * c0, c0 < 0 && c1 % c0 == 0) ||
+                             rewrite(min(x * c0, y * c1), min(x * fold(c0 / c1), y) * c1, c1 > 0 && c0 % c1 == 0) ||
+                             rewrite(min(x * c0, y * c1), max(x * fold(c0 / c1), y) * c1, c1 < 0 && c0 % c1 == 0) ||
+                             rewrite(min(x * c0, y * c0 + c1), min(x, y + fold(c1 / c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
+                             rewrite(min(x * c0, y * c0 + c1), max(x, y + fold(c1 / c0)) * c0, c0 < 0 && c1 % c0 == 0) ||
 
-               rewrite(min(x / c0, y / c0), min(x, y) / c0, c0 > 0) ||
-               rewrite(min(x / c0, y / c0), max(x, y) / c0, c0 < 0) ||
+                             rewrite(min(x / c0, y / c0), min(x, y) / c0, c0 > 0) ||
+                             rewrite(min(x / c0, y / c0), max(x, y) / c0, c0 < 0) ||
 
-               /* Causes some things to cancel, but also creates large constants and breaks peephole patterns
+                             /* Causes some things to cancel, but also creates large constants and breaks peephole patterns
                rewrite(min(x / c0, c1), min(x, fold(c1 * c0)) / c0, c0 > 0 && !overflows(c1 * c0)) ||
                rewrite(min(x / c0, c1), max(x, fold(c1 * c0)) / c0, c0 < 0 && !overflows(c1 * c0)) ||
                */
 
-               rewrite(min(x / c0, y / c0 + c1), min(x, y + fold(c1 * c0)) / c0, c0 > 0 && !overflows(c1 * c0)) ||
-               rewrite(min(x / c0, y / c0 + c1), max(x, y + fold(c1 * c0)) / c0, c0 < 0 && !overflows(c1 * c0)) ||
+                             rewrite(min(x / c0, y / c0 + c1), min(x, y + fold(c1 * c0)) / c0, c0 > 0 && !overflows(c1 * c0)) ||
+                             rewrite(min(x / c0, y / c0 + c1), max(x, y + fold(c1 * c0)) / c0, c0 < 0 && !overflows(c1 * c0)) ||
 
-               rewrite(min(select(x, y, z), select(x, w, u)), select(x, min(y, w), min(z, u))) ||
+                             rewrite(min(select(x, y, z), select(x, w, u)), select(x, min(y, w), min(z, u))) ||
 
-               rewrite(min(c0 - x, c1), c0 - max(x, fold(c0 - c1))))))) {
+                             rewrite(min(c0 - x, c1), c0 - max(x, fold(c0 - c1))))))) {
 
             return mutate(std::move(rewrite.result), bounds);
         }

--- a/src/Simplify_Mod.cpp
+++ b/src/Simplify_Mod.cpp
@@ -60,26 +60,25 @@ Expr Simplify::visit(const Mod *op, ExprInfo *bounds) {
             return rewrite.result;
         }
 
-        if (EVAL_IN_LAMBDA
-            (rewrite(broadcast(x) % broadcast(y), broadcast(x % y, lanes)) ||
-             (no_overflow_int(op->type) &&
-              (rewrite((x * c0) % c1, (x * fold(c0 % c1)) % c1, c1 > 0 && (c0 >= c1 || c0 < 0)) ||
-               rewrite((x + c0) % c1, (x + fold(c0 % c1)) % c1, c1 > 0 && (c0 >= c1 || c0 < 0)) ||
-               rewrite((x * c0) % c1, (x % fold(c1/c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
-               rewrite((x * c0 + y) % c1, y % c1, c0 % c1 == 0) ||
-               rewrite((y + x * c0) % c1, y % c1, c0 % c1 == 0) ||
-               rewrite((x * c0 - y) % c1, (-y) % c1, c0 % c1 == 0) ||
-               rewrite((y - x * c0) % c1, y % c1, c0 % c1 == 0) ||
-               rewrite((x - y) % 2, (x + y) % 2) || // Addition and subtraction are the same modulo 2, because -1 == 1
+        if (EVAL_IN_LAMBDA(rewrite(broadcast(x) % broadcast(y), broadcast(x % y, lanes)) ||
+                           (no_overflow_int(op->type) &&
+                            (rewrite((x * c0) % c1, (x * fold(c0 % c1)) % c1, c1 > 0 && (c0 >= c1 || c0 < 0)) ||
+                             rewrite((x + c0) % c1, (x + fold(c0 % c1)) % c1, c1 > 0 && (c0 >= c1 || c0 < 0)) ||
+                             rewrite((x * c0) % c1, (x % fold(c1 / c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
+                             rewrite((x * c0 + y) % c1, y % c1, c0 % c1 == 0) ||
+                             rewrite((y + x * c0) % c1, y % c1, c0 % c1 == 0) ||
+                             rewrite((x * c0 - y) % c1, (-y) % c1, c0 % c1 == 0) ||
+                             rewrite((y - x * c0) % c1, y % c1, c0 % c1 == 0) ||
+                             rewrite((x - y) % 2, (x + y) % 2) ||  // Addition and subtraction are the same modulo 2, because -1 == 1
 
-               rewrite(ramp(x, c0) % broadcast(c1), broadcast(x, lanes) % c1, c0 % c1 == 0) ||
-               rewrite(ramp(x, c0) % broadcast(c1), ramp(x % c1, c0, lanes),
-                       // First and last lanes are the same when...
-                       can_prove((x % c1 + c0 * (lanes - 1)) / c1 == 0, this)) ||
-               rewrite(ramp(x * c0, c2) % broadcast(c1), (ramp(x * fold(c0 % c1), fold(c2 % c1), lanes) % c1), c1 > 0 && (c0 >= c1 || c0 < 0)) ||
-               rewrite(ramp(x + c0, c2) % broadcast(c1), (ramp(x + fold(c0 % c1), fold(c2 % c1), lanes) % c1), c1 > 0 && (c0 >= c1 || c0 < 0)) ||
-               rewrite(ramp(x * c0 + y, c2) % broadcast(c1), ramp(y, fold(c2 % c1), lanes) % c1, c0 % c1 == 0) ||
-               rewrite(ramp(y + x * c0, c2) % broadcast(c1), ramp(y, fold(c2 % c1), lanes) % c1, c0 % c1 == 0))))) {
+                             rewrite(ramp(x, c0) % broadcast(c1), broadcast(x, lanes) % c1, c0 % c1 == 0) ||
+                             rewrite(ramp(x, c0) % broadcast(c1), ramp(x % c1, c0, lanes),
+                                     // First and last lanes are the same when...
+                                     can_prove((x % c1 + c0 * (lanes - 1)) / c1 == 0, this)) ||
+                             rewrite(ramp(x * c0, c2) % broadcast(c1), (ramp(x * fold(c0 % c1), fold(c2 % c1), lanes) % c1), c1 > 0 && (c0 >= c1 || c0 < 0)) ||
+                             rewrite(ramp(x + c0, c2) % broadcast(c1), (ramp(x + fold(c0 % c1), fold(c2 % c1), lanes) % c1), c1 > 0 && (c0 >= c1 || c0 < 0)) ||
+                             rewrite(ramp(x * c0 + y, c2) % broadcast(c1), ramp(y, fold(c2 % c1), lanes) % c1, c0 % c1 == 0) ||
+                             rewrite(ramp(y + x * c0, c2) % broadcast(c1), ramp(y, fold(c2 % c1), lanes) % c1, c0 % c1 == 0))))) {
             return mutate(std::move(rewrite.result), bounds);
         }
     }

--- a/src/Simplify_Or.cpp
+++ b/src/Simplify_Or.cpp
@@ -17,63 +17,62 @@ Expr Simplify::visit(const Or *op, ExprInfo *bounds) {
 
     auto rewrite = IRMatcher::rewriter(IRMatcher::or_op(a, b), op->type);
 
-    if (EVAL_IN_LAMBDA
-        (rewrite(x || true, b) ||
-         rewrite(x || false, a) ||
-         rewrite(x || x, a) ||
+    if (EVAL_IN_LAMBDA(rewrite(x || true, b) ||
+                       rewrite(x || false, a) ||
+                       rewrite(x || x, a) ||
 
-         rewrite((x || y) || x, a) ||
-         rewrite(x || (x || y), b) ||
-         rewrite((x || y) || y, a) ||
-         rewrite(y || (x || y), b) ||
+                       rewrite((x || y) || x, a) ||
+                       rewrite(x || (x || y), b) ||
+                       rewrite((x || y) || y, a) ||
+                       rewrite(y || (x || y), b) ||
 
-         rewrite(((x || y) || z) || x, a) ||
-         rewrite(x || ((x || y) || z), b) ||
-         rewrite((z || (x || y)) || x, a) ||
-         rewrite(x || (z || (x || y)), b) ||
-         rewrite(((x || y) || z) || y, a) ||
-         rewrite(y || ((x || y) || z), b) ||
-         rewrite((z || (x || y)) || y, a) ||
-         rewrite(y || (z || (x || y)), b) ||
+                       rewrite(((x || y) || z) || x, a) ||
+                       rewrite(x || ((x || y) || z), b) ||
+                       rewrite((z || (x || y)) || x, a) ||
+                       rewrite(x || (z || (x || y)), b) ||
+                       rewrite(((x || y) || z) || y, a) ||
+                       rewrite(y || ((x || y) || z), b) ||
+                       rewrite((z || (x || y)) || y, a) ||
+                       rewrite(y || (z || (x || y)), b) ||
 
-         rewrite((x && y) || x, b) ||
-         rewrite(x || (x && y), a) ||
-         rewrite((x && y) || y, b) ||
-         rewrite(y || (x && y), a) ||
+                       rewrite((x && y) || x, b) ||
+                       rewrite(x || (x && y), a) ||
+                       rewrite((x && y) || y, b) ||
+                       rewrite(y || (x && y), a) ||
 
-         rewrite(((x || y) || z) || x, a) ||
-         rewrite(x || ((x || y) || z), b) ||
-         rewrite((z || (x || y)) || x, a) ||
-         rewrite(x || (z || (x || y)), b) ||
-         rewrite(((x || y) || z) || y, a) ||
-         rewrite(y || ((x || y) || z), b) ||
-         rewrite((z || (x || y)) || y, a) ||
-         rewrite(y || (z || (x || y)), b) ||
+                       rewrite(((x || y) || z) || x, a) ||
+                       rewrite(x || ((x || y) || z), b) ||
+                       rewrite((z || (x || y)) || x, a) ||
+                       rewrite(x || (z || (x || y)), b) ||
+                       rewrite(((x || y) || z) || y, a) ||
+                       rewrite(y || ((x || y) || z), b) ||
+                       rewrite((z || (x || y)) || y, a) ||
+                       rewrite(y || (z || (x || y)), b) ||
 
-         rewrite(x != y || x == y, true) ||
-         rewrite(x != y || y == x, true) ||
-         rewrite((z || x != y) || x == y, true) ||
-         rewrite((z || x != y) || y == x, true) ||
-         rewrite((x != y || z) || x == y, true) ||
-         rewrite((x != y || z) || y == x, true) ||
-         rewrite((z || x == y) || x != y, true) ||
-         rewrite((z || x == y) || y != x, true) ||
-         rewrite((x == y || z) || x != y, true) ||
-         rewrite((x == y || z) || y != x, true) ||
-         rewrite(x || !x, true) ||
-         rewrite(!x || x, true) ||
-         rewrite(y <= x || x < y, true) ||
-         rewrite(x != c0 || x == c1, a, c0 != c1) ||
-         rewrite(x <= c0 || c1 <= x, true, !is_float(x) && c1 <= c0 + 1) ||
-         rewrite(c1 <= x || x <= c0, true, !is_float(x) && c1 <= c0 + 1) ||
-         rewrite(x <= c0 || c1 < x, true, c1 <= c0) ||
-         rewrite(c1 <= x || x < c0, true, c1 <= c0) ||
-         rewrite(x < c0 || c1 < x, true, c1 < c0) ||
-         rewrite(c1 < x || x < c0, true, c1 < c0) ||
-         rewrite(c0 < x || c1 < x, fold(min(c0, c1)) < x) ||
-         rewrite(c0 <= x || c1 <= x, fold(min(c0, c1)) <= x) ||
-         rewrite(x < c0 || x < c1, x < fold(max(c0, c1))) ||
-         rewrite(x <= c0 || x <= c1, x <= fold(max(c0, c1))))) {
+                       rewrite(x != y || x == y, true) ||
+                       rewrite(x != y || y == x, true) ||
+                       rewrite((z || x != y) || x == y, true) ||
+                       rewrite((z || x != y) || y == x, true) ||
+                       rewrite((x != y || z) || x == y, true) ||
+                       rewrite((x != y || z) || y == x, true) ||
+                       rewrite((z || x == y) || x != y, true) ||
+                       rewrite((z || x == y) || y != x, true) ||
+                       rewrite((x == y || z) || x != y, true) ||
+                       rewrite((x == y || z) || y != x, true) ||
+                       rewrite(x || !x, true) ||
+                       rewrite(!x || x, true) ||
+                       rewrite(y <= x || x < y, true) ||
+                       rewrite(x != c0 || x == c1, a, c0 != c1) ||
+                       rewrite(x <= c0 || c1 <= x, true, !is_float(x) && c1 <= c0 + 1) ||
+                       rewrite(c1 <= x || x <= c0, true, !is_float(x) && c1 <= c0 + 1) ||
+                       rewrite(x <= c0 || c1 < x, true, c1 <= c0) ||
+                       rewrite(c1 <= x || x < c0, true, c1 <= c0) ||
+                       rewrite(x < c0 || c1 < x, true, c1 < c0) ||
+                       rewrite(c1 < x || x < c0, true, c1 < c0) ||
+                       rewrite(c0 < x || c1 < x, fold(min(c0, c1)) < x) ||
+                       rewrite(c0 <= x || c1 <= x, fold(min(c0, c1)) <= x) ||
+                       rewrite(x < c0 || x < c1, x < fold(max(c0, c1))) ||
+                       rewrite(x <= c0 || x <= c1, x <= fold(max(c0, c1))))) {
         return rewrite.result;
     }
 

--- a/src/Simplify_Select.cpp
+++ b/src/Simplify_Select.cpp
@@ -22,115 +22,113 @@ Expr Simplify::visit(const Select *op, ExprInfo *bounds) {
     if (may_simplify(op->type)) {
         auto rewrite = IRMatcher::rewriter(IRMatcher::select(condition, true_value, false_value), op->type);
 
-        if (EVAL_IN_LAMBDA
-            (rewrite(select(IRMatcher::intrin(Call::likely, true), x, y), x) ||
-             rewrite(select(IRMatcher::intrin(Call::likely, false), x, y), y) ||
-             rewrite(select(IRMatcher::intrin(Call::likely_if_innermost, true), x, y), x) ||
-             rewrite(select(IRMatcher::intrin(Call::likely_if_innermost, false), x, y), y) ||
-             rewrite(select(1, x, y), x) ||
-             rewrite(select(0, x, y), y) ||
-             rewrite(select(x, y, y), y) ||
-             rewrite(select(x, intrin(Call::likely, y), y), true_value) ||
-             rewrite(select(x, y, intrin(Call::likely, y)), false_value) ||
-             rewrite(select(x, intrin(Call::likely_if_innermost, y), y), true_value) ||
-             rewrite(select(x, y, intrin(Call::likely_if_innermost, y)), false_value) ||
+        if (EVAL_IN_LAMBDA(rewrite(select(IRMatcher::intrin(Call::likely, true), x, y), x) ||
+                           rewrite(select(IRMatcher::intrin(Call::likely, false), x, y), y) ||
+                           rewrite(select(IRMatcher::intrin(Call::likely_if_innermost, true), x, y), x) ||
+                           rewrite(select(IRMatcher::intrin(Call::likely_if_innermost, false), x, y), y) ||
+                           rewrite(select(1, x, y), x) ||
+                           rewrite(select(0, x, y), y) ||
+                           rewrite(select(x, y, y), y) ||
+                           rewrite(select(x, intrin(Call::likely, y), y), true_value) ||
+                           rewrite(select(x, y, intrin(Call::likely, y)), false_value) ||
+                           rewrite(select(x, intrin(Call::likely_if_innermost, y), y), true_value) ||
+                           rewrite(select(x, y, intrin(Call::likely_if_innermost, y)), false_value) ||
 
-             // Select evaluates both sides, so if we have an
-             // unreachable expression on one side we can't use a
-             // signalling error. Call it UB and assume it can't
-             // happen. The tricky case to consider is:
-             // select(x > 0, a/x, select(x < 0, b/x, indeterminate()))
-             // If we use a signalling error and x > 0, then this will
-             // evaluate indeterminate(), because the top-level select
-             // evaluates both sides.
+                           // Select evaluates both sides, so if we have an
+                           // unreachable expression on one side we can't use a
+                           // signalling error. Call it UB and assume it can't
+                           // happen. The tricky case to consider is:
+                           // select(x > 0, a/x, select(x < 0, b/x, indeterminate()))
+                           // If we use a signalling error and x > 0, then this will
+                           // evaluate indeterminate(), because the top-level select
+                           // evaluates both sides.
 
-             rewrite(select(x, y, IRMatcher::Indeterminate()), y) ||
-             rewrite(select(x, IRMatcher::Indeterminate(), y), y))) {
+                           rewrite(select(x, y, IRMatcher::Indeterminate()), y) ||
+                           rewrite(select(x, IRMatcher::Indeterminate(), y), y))) {
             return rewrite.result;
         }
 
-        if (EVAL_IN_LAMBDA
-            (rewrite(select(broadcast(x), y, z), select(x, y, z)) ||
-             rewrite(select(x != y, z, w), select(x == y, w, z)) ||
-             rewrite(select(x <= y, z, w), select(y < x, w, z)) ||
-             rewrite(select(x, select(y, z, w), z), select(x && !y, w, z)) ||
-             rewrite(select(x, select(y, z, w), w), select(x && y, z, w)) ||
-             rewrite(select(x, y, select(z, y, w)), select(x || z, y, w)) ||
-             rewrite(select(x, y, select(z, w, y)), select(x || !z, y, w)) ||
-             rewrite(select(x, select(x, y, z), w), select(x, y, w)) ||
-             rewrite(select(x, y, select(x, z, w)), select(x, y, w)) ||
-             rewrite(select(x, y + z, y + w), y + select(x, z, w)) ||
-             rewrite(select(x, y + z, w + y), y + select(x, z, w)) ||
-             rewrite(select(x, z + y, y + w), y + select(x, z, w)) ||
-             rewrite(select(x, z + y, w + y), select(x, z, w) + y) ||
-             rewrite(select(x, y - z, y - w), y - select(x, z, w)) ||
-             rewrite(select(x, y - z, y + w), y + select(x, -z, w)) ||
-             rewrite(select(x, y + z, y - w), y + select(x, z, -w)) ||
-             rewrite(select(x, y - z, w + y), y + select(x, -z, w)) ||
-             rewrite(select(x, z + y, y - w), y + select(x, z, -w)) ||
-             rewrite(select(x, z - y, w - y), select(x, z, w) - y) ||
-             rewrite(select(x, y * z, y * w), y * select(x, z, w)) ||
-             rewrite(select(x, y * z, w * y), y * select(x, z, w)) ||
-             rewrite(select(x, z * y, y * w), y * select(x, z, w)) ||
-             rewrite(select(x, z * y, w * y), select(x, z, w) * y) ||
-             rewrite(select(x, z / y, w / y), select(x, z, w) / y) ||
-             rewrite(select(x, z % y, w % y), select(x, z, w) % y) ||
+        if (EVAL_IN_LAMBDA(rewrite(select(broadcast(x), y, z), select(x, y, z)) ||
+                           rewrite(select(x != y, z, w), select(x == y, w, z)) ||
+                           rewrite(select(x <= y, z, w), select(y < x, w, z)) ||
+                           rewrite(select(x, select(y, z, w), z), select(x && !y, w, z)) ||
+                           rewrite(select(x, select(y, z, w), w), select(x && y, z, w)) ||
+                           rewrite(select(x, y, select(z, y, w)), select(x || z, y, w)) ||
+                           rewrite(select(x, y, select(z, w, y)), select(x || !z, y, w)) ||
+                           rewrite(select(x, select(x, y, z), w), select(x, y, w)) ||
+                           rewrite(select(x, y, select(x, z, w)), select(x, y, w)) ||
+                           rewrite(select(x, y + z, y + w), y + select(x, z, w)) ||
+                           rewrite(select(x, y + z, w + y), y + select(x, z, w)) ||
+                           rewrite(select(x, z + y, y + w), y + select(x, z, w)) ||
+                           rewrite(select(x, z + y, w + y), select(x, z, w) + y) ||
+                           rewrite(select(x, y - z, y - w), y - select(x, z, w)) ||
+                           rewrite(select(x, y - z, y + w), y + select(x, -z, w)) ||
+                           rewrite(select(x, y + z, y - w), y + select(x, z, -w)) ||
+                           rewrite(select(x, y - z, w + y), y + select(x, -z, w)) ||
+                           rewrite(select(x, z + y, y - w), y + select(x, z, -w)) ||
+                           rewrite(select(x, z - y, w - y), select(x, z, w) - y) ||
+                           rewrite(select(x, y * z, y * w), y * select(x, z, w)) ||
+                           rewrite(select(x, y * z, w * y), y * select(x, z, w)) ||
+                           rewrite(select(x, z * y, y * w), y * select(x, z, w)) ||
+                           rewrite(select(x, z * y, w * y), select(x, z, w) * y) ||
+                           rewrite(select(x, z / y, w / y), select(x, z, w) / y) ||
+                           rewrite(select(x, z % y, w % y), select(x, z, w) % y) ||
 
-             rewrite(select(x, (y + z) + u, y + w), y + select(x, z + u, w)) ||
-             rewrite(select(x, (y + z) - u, y + w), y + select(x, z - u, w)) ||
-             rewrite(select(x, u + (y + z), y + w), y + select(x, u + z, w)) ||
-             rewrite(select(x, y + z, (y + w) + u), y + select(x, z, w + u)) ||
-             rewrite(select(x, y + z, (y + w) - u), y + select(x, z, w - u)) ||
-             rewrite(select(x, y + z, u + (y + w)), y + select(x, z, u + w)) ||
+                           rewrite(select(x, (y + z) + u, y + w), y + select(x, z + u, w)) ||
+                           rewrite(select(x, (y + z) - u, y + w), y + select(x, z - u, w)) ||
+                           rewrite(select(x, u + (y + z), y + w), y + select(x, u + z, w)) ||
+                           rewrite(select(x, y + z, (y + w) + u), y + select(x, z, w + u)) ||
+                           rewrite(select(x, y + z, (y + w) - u), y + select(x, z, w - u)) ||
+                           rewrite(select(x, y + z, u + (y + w)), y + select(x, z, u + w)) ||
 
-             rewrite(select(x, (y + z) + u, w + y), y + select(x, z + u, w)) ||
-             rewrite(select(x, (y + z) - u, w + y), y + select(x, z - u, w)) ||
-             rewrite(select(x, u + (y + z), w + y), y + select(x, u + z, w)) ||
-             rewrite(select(x, y + z, (w + y) + u), y + select(x, z, w + u)) ||
-             rewrite(select(x, y + z, (w + y) - u), y + select(x, z, w - u)) ||
-             rewrite(select(x, y + z, u + (w + y)), y + select(x, z, u + w)) ||
+                           rewrite(select(x, (y + z) + u, w + y), y + select(x, z + u, w)) ||
+                           rewrite(select(x, (y + z) - u, w + y), y + select(x, z - u, w)) ||
+                           rewrite(select(x, u + (y + z), w + y), y + select(x, u + z, w)) ||
+                           rewrite(select(x, y + z, (w + y) + u), y + select(x, z, w + u)) ||
+                           rewrite(select(x, y + z, (w + y) - u), y + select(x, z, w - u)) ||
+                           rewrite(select(x, y + z, u + (w + y)), y + select(x, z, u + w)) ||
 
-             rewrite(select(x, (z + y) + u, y + w), y + select(x, z + u, w)) ||
-             rewrite(select(x, (z + y) - u, y + w), y + select(x, z - u, w)) ||
-             rewrite(select(x, u + (z + y), y + w), y + select(x, u + z, w)) ||
-             rewrite(select(x, z + y, (y + w) + u), y + select(x, z, w + u)) ||
-             rewrite(select(x, z + y, (y + w) - u), y + select(x, z, w - u)) ||
-             rewrite(select(x, z + y, u + (y + w)), y + select(x, z, u + w)) ||
+                           rewrite(select(x, (z + y) + u, y + w), y + select(x, z + u, w)) ||
+                           rewrite(select(x, (z + y) - u, y + w), y + select(x, z - u, w)) ||
+                           rewrite(select(x, u + (z + y), y + w), y + select(x, u + z, w)) ||
+                           rewrite(select(x, z + y, (y + w) + u), y + select(x, z, w + u)) ||
+                           rewrite(select(x, z + y, (y + w) - u), y + select(x, z, w - u)) ||
+                           rewrite(select(x, z + y, u + (y + w)), y + select(x, z, u + w)) ||
 
-             rewrite(select(x, (z + y) + u, w + y), select(x, z + u, w) + y) ||
-             rewrite(select(x, (z + y) - u, w + y), select(x, z - u, w) + y) ||
-             rewrite(select(x, u + (z + y), w + y), select(x, u + z, w) + y) ||
-             rewrite(select(x, z + y, (w + y) + u), select(x, z, w + u) + y) ||
-             rewrite(select(x, z + y, (w + y) - u), select(x, z, w - u) + y) ||
-             rewrite(select(x, z + y, u + (w + y)), select(x, z, u + w) + y) ||
+                           rewrite(select(x, (z + y) + u, w + y), select(x, z + u, w) + y) ||
+                           rewrite(select(x, (z + y) - u, w + y), select(x, z - u, w) + y) ||
+                           rewrite(select(x, u + (z + y), w + y), select(x, u + z, w) + y) ||
+                           rewrite(select(x, z + y, (w + y) + u), select(x, z, w + u) + y) ||
+                           rewrite(select(x, z + y, (w + y) - u), select(x, z, w - u) + y) ||
+                           rewrite(select(x, z + y, u + (w + y)), select(x, z, u + w) + y) ||
 
-             rewrite(select(x < y, x, y), min(x, y)) ||
-             rewrite(select(x < y, y, x), max(x, y)) ||
-             rewrite(select(x < 0, x * y, 0), min(x, 0) * y) ||
-             rewrite(select(x < 0, 0, x * y), max(x, 0) * y) ||
+                           rewrite(select(x < y, x, y), min(x, y)) ||
+                           rewrite(select(x < y, y, x), max(x, y)) ||
+                           rewrite(select(x < 0, x * y, 0), min(x, 0) * y) ||
+                           rewrite(select(x < 0, 0, x * y), max(x, 0) * y) ||
 
-             (no_overflow_int(op->type) &&
-              (rewrite(select(x, y * c0, c1), select(x, y, fold(c1 / c0)) * c0, c1 % c0 == 0) ||
-               rewrite(select(x, c0, y * c1), select(x, fold(c0 / c1), y) * c1, c0 % c1 == 0) ||
+                           (no_overflow_int(op->type) &&
+                            (rewrite(select(x, y * c0, c1), select(x, y, fold(c1 / c0)) * c0, c1 % c0 == 0) ||
+                             rewrite(select(x, c0, y * c1), select(x, fold(c0 / c1), y) * c1, c0 % c1 == 0) ||
 
-               // Selects that are equivalent to mins/maxes
-               rewrite(select(c0 < x, x + c1, c2), max(x + c1, c2), c2 == c0 + c1 || c2 == c0 + c1 + 1) ||
-               rewrite(select(x < c0, c1, x + c2), max(x + c2, c1), c1 == c0 + c2 || c1 + 1 == c0 + c2) ||
-               rewrite(select(c0 < x, c1, x + c2), min(x + c2, c1), c1 == c0 + c2 || c1 == c0 + c2 + 1) ||
-               rewrite(select(x < c0, x + c1, c2), min(x + c1, c2), c2 == c0 + c1 || c2 + 1 == c0 + c1) ||
+                             // Selects that are equivalent to mins/maxes
+                             rewrite(select(c0 < x, x + c1, c2), max(x + c1, c2), c2 == c0 + c1 || c2 == c0 + c1 + 1) ||
+                             rewrite(select(x < c0, c1, x + c2), max(x + c2, c1), c1 == c0 + c2 || c1 + 1 == c0 + c2) ||
+                             rewrite(select(c0 < x, c1, x + c2), min(x + c2, c1), c1 == c0 + c2 || c1 == c0 + c2 + 1) ||
+                             rewrite(select(x < c0, x + c1, c2), min(x + c1, c2), c2 == c0 + c1 || c2 + 1 == c0 + c1) ||
 
-               rewrite(select(c0 < x, x, c1), max(x, c1), c1 == c0 + 1) ||
-               rewrite(select(x < c0, c1, x), max(x, c1), c1 + 1 == c0) ||
-               rewrite(select(c0 < x, c1, x), min(x, c1), c1 == c0 + 1) ||
-               rewrite(select(x < c0, x, c1), min(x, c1), c1 + 1 == c0))) ||
+                             rewrite(select(c0 < x, x, c1), max(x, c1), c1 == c0 + 1) ||
+                             rewrite(select(x < c0, c1, x), max(x, c1), c1 + 1 == c0) ||
+                             rewrite(select(c0 < x, c1, x), min(x, c1), c1 == c0 + 1) ||
+                             rewrite(select(x < c0, x, c1), min(x, c1), c1 + 1 == c0))) ||
 
-             (op->type.is_bool() &&
-              (rewrite(select(x, true, false), cast(op->type, x)) ||
-               rewrite(select(x, false, true), cast(op->type, !x)) ||
-               rewrite(select(x, y, false), x && y) ||
-               rewrite(select(x, y, true), !x || y) ||
-               rewrite(select(x, false, y), !x && y) ||
-               rewrite(select(x, true, y), x || y))))) {
+                           (op->type.is_bool() &&
+                            (rewrite(select(x, true, false), cast(op->type, x)) ||
+                             rewrite(select(x, false, true), cast(op->type, !x)) ||
+                             rewrite(select(x, y, false), x && y) ||
+                             rewrite(select(x, y, true), !x || y) ||
+                             rewrite(select(x, false, y), !x && y) ||
+                             rewrite(select(x, true, y), x || y))))) {
             return mutate(std::move(rewrite.result), bounds);
         }
     }

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -355,8 +355,7 @@ Stmt Simplify::visit(const Block *op) {
     const Block *block_rest = rest.as<Block>();
     const IfThenElse *if_first = first.as<IfThenElse>();
     const IfThenElse *if_next =
-        rest.as<IfThenElse>() ? rest.as<IfThenElse>()
-                              : (block_rest ? block_rest->first.as<IfThenElse>() : nullptr);
+        rest.as<IfThenElse>() ? rest.as<IfThenElse>() : (block_rest ? block_rest->first.as<IfThenElse>() : nullptr);
     Stmt if_rest = block_rest ? block_rest->rest : Stmt();
 
     if (is_no_op(first) &&

--- a/src/Simplify_Sub.cpp
+++ b/src/Simplify_Sub.cpp
@@ -44,236 +44,235 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
             return rewrite.result;
         }
 
-        if (EVAL_IN_LAMBDA
-            ((!op->type.is_uint() && rewrite(x - c0, x + fold(-c0), !overflows(-c0))) ||
-             rewrite(x - x, 0) || // We want to remutate this just to get better bounds
-             rewrite(ramp(x, y) - ramp(z, w), ramp(x - z, y - w, lanes)) ||
-             rewrite(ramp(x, y) - broadcast(z), ramp(x - z, y, lanes)) ||
-             rewrite(broadcast(x) - ramp(z, w), ramp(x - z, -w, lanes)) ||
-             rewrite(broadcast(x) - broadcast(y), broadcast(x - y, lanes)) ||
-             rewrite(select(x, y, z) - select(x, w, u), select(x, y - w, z - u)) ||
-             rewrite(select(x, y, z) - y, select(x, 0, z - y)) ||
-             rewrite(select(x, y, z) - z, select(x, y - z, 0)) ||
-             rewrite(y - select(x, y, z), select(x, 0, y - z)) ||
-             rewrite(z - select(x, y, z), select(x, z - y, 0)) ||
+        if (EVAL_IN_LAMBDA((!op->type.is_uint() && rewrite(x - c0, x + fold(-c0), !overflows(-c0))) ||
+                           rewrite(x - x, 0) ||  // We want to remutate this just to get better bounds
+                           rewrite(ramp(x, y) - ramp(z, w), ramp(x - z, y - w, lanes)) ||
+                           rewrite(ramp(x, y) - broadcast(z), ramp(x - z, y, lanes)) ||
+                           rewrite(broadcast(x) - ramp(z, w), ramp(x - z, -w, lanes)) ||
+                           rewrite(broadcast(x) - broadcast(y), broadcast(x - y, lanes)) ||
+                           rewrite(select(x, y, z) - select(x, w, u), select(x, y - w, z - u)) ||
+                           rewrite(select(x, y, z) - y, select(x, 0, z - y)) ||
+                           rewrite(select(x, y, z) - z, select(x, y - z, 0)) ||
+                           rewrite(y - select(x, y, z), select(x, 0, y - z)) ||
+                           rewrite(z - select(x, y, z), select(x, z - y, 0)) ||
 
-             rewrite(select(x, y + w, z) - y, select(x, w, z - y)) ||
-             rewrite(select(x, w + y, z) - y, select(x, w, z - y)) ||
-             rewrite(select(x, y, z + w) - z, select(x, y - z, w)) ||
-             rewrite(select(x, y, w + z) - z, select(x, y - z, w)) ||
-             rewrite(y - select(x, y + w, z), 0 - select(x, w, z - y)) ||
-             rewrite(y - select(x, w + y, z), 0 - select(x, w, z - y)) ||
-             rewrite(z - select(x, y, z + w), 0 - select(x, y - z, w)) ||
-             rewrite(z - select(x, y, w + z), 0 - select(x, y - z, w)) ||
+                           rewrite(select(x, y + w, z) - y, select(x, w, z - y)) ||
+                           rewrite(select(x, w + y, z) - y, select(x, w, z - y)) ||
+                           rewrite(select(x, y, z + w) - z, select(x, y - z, w)) ||
+                           rewrite(select(x, y, w + z) - z, select(x, y - z, w)) ||
+                           rewrite(y - select(x, y + w, z), 0 - select(x, w, z - y)) ||
+                           rewrite(y - select(x, w + y, z), 0 - select(x, w, z - y)) ||
+                           rewrite(z - select(x, y, z + w), 0 - select(x, y - z, w)) ||
+                           rewrite(z - select(x, y, w + z), 0 - select(x, y - z, w)) ||
 
-             rewrite((x + y) - x, y) ||
-             rewrite((x + y) - y, x) ||
-             rewrite(x - (x + y), -y) ||
-             rewrite(y - (x + y), -x) ||
-             rewrite((x - y) - x, -y) ||
-             rewrite((select(x, y, z) + w) - select(x, u, v), select(x, y - u, z - v) + w) ||
-             rewrite((w + select(x, y, z)) - select(x, u, v), select(x, y - u, z - v) + w) ||
-             rewrite(select(x, y, z) - (select(x, u, v) + w), select(x, y - u, z - v) - w) ||
-             rewrite(select(x, y, z) - (w + select(x, u, v)), select(x, y - u, z - v) - w) ||
-             rewrite((select(x, y, z) - w) - select(x, u, v), select(x, y - u, z - v) - w) ||
-             rewrite(c0 - select(x, c1, c2), select(x, fold(c0 - c1), fold(c0 - c2))) ||
-             rewrite((x + c0) - c1, x + fold(c0 - c1)) ||
-             rewrite((x + c0) - (c1 - y), (x + y) + fold(c0 - c1)) ||
-             rewrite((x + c0) - (y + c1), (x - y) + fold(c0 - c1)) ||
-             rewrite((x + c0) - y, (x - y) + c0) ||
-             rewrite((c0 - x) - (c1 - y), (y - x) + fold(c0 - c1)) ||
-             rewrite((c0 - x) - (y + c1), fold(c0 - c1) - (x + y)) ||
-             rewrite(x - (y - z), x + (z - y)) ||
-             rewrite(x - y*c0, x + y*fold(-c0), c0 < 0 && -c0 > 0) ||
-             rewrite(x - (y + c0), (x - y) - c0) ||
-             rewrite((c0 - x) - c1, fold(c0 - c1) - x) ||
-             rewrite(x*y - z*y, (x - z)*y) ||
-             rewrite(x*y - y*z, (x - z)*y) ||
-             rewrite(y*x - z*y, y*(x - z)) ||
-             rewrite(y*x - y*z, y*(x - z)) ||
-             rewrite((x + y) - (x + z), y - z) ||
-             rewrite((x + y) - (z + x), y - z) ||
-             rewrite((y + x) - (x + z), y - z) ||
-             rewrite((y + x) - (z + x), y - z) ||
-             rewrite(((x + y) + z) - x, y + z) ||
-             rewrite(((y + x) + z) - x, y + z) ||
-             rewrite((z + (x + y)) - x, z + y) ||
-             rewrite((z + (y + x)) - x, z + y) ||
+                           rewrite((x + y) - x, y) ||
+                           rewrite((x + y) - y, x) ||
+                           rewrite(x - (x + y), -y) ||
+                           rewrite(y - (x + y), -x) ||
+                           rewrite((x - y) - x, -y) ||
+                           rewrite((select(x, y, z) + w) - select(x, u, v), select(x, y - u, z - v) + w) ||
+                           rewrite((w + select(x, y, z)) - select(x, u, v), select(x, y - u, z - v) + w) ||
+                           rewrite(select(x, y, z) - (select(x, u, v) + w), select(x, y - u, z - v) - w) ||
+                           rewrite(select(x, y, z) - (w + select(x, u, v)), select(x, y - u, z - v) - w) ||
+                           rewrite((select(x, y, z) - w) - select(x, u, v), select(x, y - u, z - v) - w) ||
+                           rewrite(c0 - select(x, c1, c2), select(x, fold(c0 - c1), fold(c0 - c2))) ||
+                           rewrite((x + c0) - c1, x + fold(c0 - c1)) ||
+                           rewrite((x + c0) - (c1 - y), (x + y) + fold(c0 - c1)) ||
+                           rewrite((x + c0) - (y + c1), (x - y) + fold(c0 - c1)) ||
+                           rewrite((x + c0) - y, (x - y) + c0) ||
+                           rewrite((c0 - x) - (c1 - y), (y - x) + fold(c0 - c1)) ||
+                           rewrite((c0 - x) - (y + c1), fold(c0 - c1) - (x + y)) ||
+                           rewrite(x - (y - z), x + (z - y)) ||
+                           rewrite(x - y * c0, x + y * fold(-c0), c0 < 0 && -c0 > 0) ||
+                           rewrite(x - (y + c0), (x - y) - c0) ||
+                           rewrite((c0 - x) - c1, fold(c0 - c1) - x) ||
+                           rewrite(x * y - z * y, (x - z) * y) ||
+                           rewrite(x * y - y * z, (x - z) * y) ||
+                           rewrite(y * x - z * y, y * (x - z)) ||
+                           rewrite(y * x - y * z, y * (x - z)) ||
+                           rewrite((x + y) - (x + z), y - z) ||
+                           rewrite((x + y) - (z + x), y - z) ||
+                           rewrite((y + x) - (x + z), y - z) ||
+                           rewrite((y + x) - (z + x), y - z) ||
+                           rewrite(((x + y) + z) - x, y + z) ||
+                           rewrite(((y + x) + z) - x, y + z) ||
+                           rewrite((z + (x + y)) - x, z + y) ||
+                           rewrite((z + (y + x)) - x, z + y) ||
 
-             rewrite((x - y) - (x + z), 0 - y - z) ||
-             rewrite((x - y) - (z + x), 0 - y - z) ||
+                           rewrite((x - y) - (x + z), 0 - y - z) ||
+                           rewrite((x - y) - (z + x), 0 - y - z) ||
 
-             (no_overflow(op->type) &&
-              (rewrite(max(x, y) - x, max(0, y - x)) ||
-               rewrite(min(x, y) - x, min(0, y - x)) ||
-               rewrite(max(x, y) - y, max(x - y, 0)) ||
-               rewrite(min(x, y) - y, min(x - y, 0)) ||
-               rewrite(x - max(x, y), min(0, x - y), !is_const(x)) ||
-               rewrite(x - min(x, y), max(0, x - y), !is_const(x)) ||
-               rewrite(y - max(x, y), min(y - x, 0), !is_const(y)) ||
-               rewrite(y - min(x, y), max(y - x, 0), !is_const(y)) ||
-               rewrite(x*y - x, x*(y - 1)) ||
-               rewrite(x*y - y, (x - 1)*y) ||
-               rewrite(x - x*y, x*(1 - y)) ||
-               rewrite(x - y*x, (1 - y)*x) ||
-               rewrite(x - min(x + y, z), max(-y, x - z)) ||
-               rewrite(x - min(y + x, z), max(-y, x - z)) ||
-               rewrite(x - min(z, x + y), max(x - z, -y)) ||
-               rewrite(x - min(z, y + x), max(x - z, -y)) ||
-               rewrite(min(x + y, z) - x, min(y, z - x)) ||
-               rewrite(min(y + x, z) - x, min(y, z - x)) ||
-               rewrite(min(z, x + y) - x, min(z - x, y)) ||
-               rewrite(min(z, y + x) - x, min(z - x, y)) ||
-               rewrite(min(x, y) - min(y, x), 0) ||
-               rewrite(min(x, y) - min(z, w), y - w, can_prove(x - y == z - w, this)) ||
-               rewrite(min(x, y) - min(w, z), y - w, can_prove(x - y == z - w, this)) ||
+                           (no_overflow(op->type) &&
+                            (rewrite(max(x, y) - x, max(0, y - x)) ||
+                             rewrite(min(x, y) - x, min(0, y - x)) ||
+                             rewrite(max(x, y) - y, max(x - y, 0)) ||
+                             rewrite(min(x, y) - y, min(x - y, 0)) ||
+                             rewrite(x - max(x, y), min(0, x - y), !is_const(x)) ||
+                             rewrite(x - min(x, y), max(0, x - y), !is_const(x)) ||
+                             rewrite(y - max(x, y), min(y - x, 0), !is_const(y)) ||
+                             rewrite(y - min(x, y), max(y - x, 0), !is_const(y)) ||
+                             rewrite(x * y - x, x * (y - 1)) ||
+                             rewrite(x * y - y, (x - 1) * y) ||
+                             rewrite(x - x * y, x * (1 - y)) ||
+                             rewrite(x - y * x, (1 - y) * x) ||
+                             rewrite(x - min(x + y, z), max(-y, x - z)) ||
+                             rewrite(x - min(y + x, z), max(-y, x - z)) ||
+                             rewrite(x - min(z, x + y), max(x - z, -y)) ||
+                             rewrite(x - min(z, y + x), max(x - z, -y)) ||
+                             rewrite(min(x + y, z) - x, min(y, z - x)) ||
+                             rewrite(min(y + x, z) - x, min(y, z - x)) ||
+                             rewrite(min(z, x + y) - x, min(z - x, y)) ||
+                             rewrite(min(z, y + x) - x, min(z - x, y)) ||
+                             rewrite(min(x, y) - min(y, x), 0) ||
+                             rewrite(min(x, y) - min(z, w), y - w, can_prove(x - y == z - w, this)) ||
+                             rewrite(min(x, y) - min(w, z), y - w, can_prove(x - y == z - w, this)) ||
 
-               rewrite(x - max(x + y, z), min(-y, x - z)) ||
-               rewrite(x - max(y + x, z), min(-y, x - z)) ||
-               rewrite(x - max(z, x + y), min(x - z, -y)) ||
-               rewrite(x - max(z, y + x), min(x - z, -y)) ||
-               rewrite(max(x + y, z) - x, max(y, z - x)) ||
-               rewrite(max(y + x, z) - x, max(y, z - x)) ||
-               rewrite(max(z, x + y) - x, max(z - x, y)) ||
-               rewrite(max(z, y + x) - x, max(z - x, y)) ||
-               rewrite(max(x, y) - max(y, x), 0) ||
-               rewrite(max(x, y) - max(z, w), y - w, can_prove(x - y == z - w, this)) ||
-               rewrite(max(x, y) - max(w, z), y - w, can_prove(x - y == z - w, this)) ||
+                             rewrite(x - max(x + y, z), min(-y, x - z)) ||
+                             rewrite(x - max(y + x, z), min(-y, x - z)) ||
+                             rewrite(x - max(z, x + y), min(x - z, -y)) ||
+                             rewrite(x - max(z, y + x), min(x - z, -y)) ||
+                             rewrite(max(x + y, z) - x, max(y, z - x)) ||
+                             rewrite(max(y + x, z) - x, max(y, z - x)) ||
+                             rewrite(max(z, x + y) - x, max(z - x, y)) ||
+                             rewrite(max(z, y + x) - x, max(z - x, y)) ||
+                             rewrite(max(x, y) - max(y, x), 0) ||
+                             rewrite(max(x, y) - max(z, w), y - w, can_prove(x - y == z - w, this)) ||
+                             rewrite(max(x, y) - max(w, z), y - w, can_prove(x - y == z - w, this)) ||
 
-               // When you have min(x, y) - min(z, w) and no further
-               // information, there are four possible ways for the
-               // mins to resolve. However if you can prove that the
-               // decisions are correlated (i.e. x < y implies z < w or
-               // vice versa), then there are simplifications to be
-               // made that tame x. Whether or not these
-               // simplifications are profitable depends on what terms
-               // end up being constant.
+                             // When you have min(x, y) - min(z, w) and no further
+                             // information, there are four possible ways for the
+                             // mins to resolve. However if you can prove that the
+                             // decisions are correlated (i.e. x < y implies z < w or
+                             // vice versa), then there are simplifications to be
+                             // made that tame x. Whether or not these
+                             // simplifications are profitable depends on what terms
+                             // end up being constant.
 
-               // If x < y implies z < w:
-               //   min(x, y) - min(z, w)
-               // = min(x - min(z, w), y - min(z, w))   using the distributive properties of min/max
-               // = min(x - z, y - min(z, w))           using the implication
-               // This duplicates z, so it's good if x - z causes some cancellation (e.g. they are equal)
+                             // If x < y implies z < w:
+                             //   min(x, y) - min(z, w)
+                             // = min(x - min(z, w), y - min(z, w))   using the distributive properties of min/max
+                             // = min(x - z, y - min(z, w))           using the implication
+                             // This duplicates z, so it's good if x - z causes some cancellation (e.g. they are equal)
 
-               // If, on the other hand, z < w implies x < y:
-               //   min(x, y) - min(z, w)
-               // = max(min(x, y) - z, min(x, y) - w)   using the distributive properties of min/max
-               // = max(x - z, min(x, y) - w)           using the implication
-               // Again, this is profitable when x - z causes some cancellation
+                             // If, on the other hand, z < w implies x < y:
+                             //   min(x, y) - min(z, w)
+                             // = max(min(x, y) - z, min(x, y) - w)   using the distributive properties of min/max
+                             // = max(x - z, min(x, y) - w)           using the implication
+                             // Again, this is profitable when x - z causes some cancellation
 
-               // What follows are special cases of this general
-               // transformation where it is easy to see that x - z
-               // cancels and that there is an implication in one
-               // direction or the other.
+                             // What follows are special cases of this general
+                             // transformation where it is easy to see that x - z
+                             // cancels and that there is an implication in one
+                             // direction or the other.
 
-               // Then the actual rules. We consider only cases where x and z differ by a constant.
-               rewrite(min(x, y) - min(x, w), min(0, y - min(x, w)), can_prove(y <= w, this)) ||
-               rewrite(min(x, y) - min(x, w), max(0, min(x, y) - w), can_prove(y >= w, this)) ||
-               rewrite(min(x + c0, y) - min(x, w), min(c0, y - min(x, w)), can_prove(y <= w + c0, this)) ||
-               rewrite(min(x + c0, y) - min(x, w), max(c0, min(x + c0, y) - w), can_prove(y >= w + c0, this)) ||
-               rewrite(min(x, y) - min(x + c1, w), min(fold(-c1), y - min(x + c1, w)), can_prove(y + c1 <= w, this)) ||
-               rewrite(min(x, y) - min(x + c1, w), max(fold(-c1), min(x, y) - w), can_prove(y + c1 >= w, this)) ||
-               rewrite(min(x + c0, y) - min(x + c1, w), min(fold(c0 - c1), y - min(x + c1, w)), can_prove(y + c1 <= w + c0, this)) ||
-               rewrite(min(x + c0, y) - min(x + c1, w), max(fold(c0 - c1), min(x + c0, y) - w), can_prove(y + c1 >= w + c0, this)) ||
+                             // Then the actual rules. We consider only cases where x and z differ by a constant.
+                             rewrite(min(x, y) - min(x, w), min(0, y - min(x, w)), can_prove(y <= w, this)) ||
+                             rewrite(min(x, y) - min(x, w), max(0, min(x, y) - w), can_prove(y >= w, this)) ||
+                             rewrite(min(x + c0, y) - min(x, w), min(c0, y - min(x, w)), can_prove(y <= w + c0, this)) ||
+                             rewrite(min(x + c0, y) - min(x, w), max(c0, min(x + c0, y) - w), can_prove(y >= w + c0, this)) ||
+                             rewrite(min(x, y) - min(x + c1, w), min(fold(-c1), y - min(x + c1, w)), can_prove(y + c1 <= w, this)) ||
+                             rewrite(min(x, y) - min(x + c1, w), max(fold(-c1), min(x, y) - w), can_prove(y + c1 >= w, this)) ||
+                             rewrite(min(x + c0, y) - min(x + c1, w), min(fold(c0 - c1), y - min(x + c1, w)), can_prove(y + c1 <= w + c0, this)) ||
+                             rewrite(min(x + c0, y) - min(x + c1, w), max(fold(c0 - c1), min(x + c0, y) - w), can_prove(y + c1 >= w + c0, this)) ||
 
-               rewrite(min(y, x) - min(w, x), min(0, y - min(x, w)), can_prove(y <= w, this)) ||
-               rewrite(min(y, x) - min(w, x), max(0, min(x, y) - w), can_prove(y >= w, this)) ||
-               rewrite(min(y, x + c0) - min(w, x), min(c0, y - min(x, w)), can_prove(y <= w + c0, this)) ||
-               rewrite(min(y, x + c0) - min(w, x), max(c0, min(x + c0, y) - w), can_prove(y >= w + c0, this)) ||
-               rewrite(min(y, x) - min(w, x + c1), min(fold(-c1), y - min(x + c1, w)), can_prove(y + c1 <= w, this)) ||
-               rewrite(min(y, x) - min(w, x + c1), max(fold(-c1), min(x, y) - w), can_prove(y + c1 >= w, this)) ||
-               rewrite(min(y, x + c0) - min(w, x + c1), min(fold(c0 - c1), y - min(x + c1, w)), can_prove(y + c1 <= w + c0, this)) ||
-               rewrite(min(y, x + c0) - min(w, x + c1), max(fold(c0 - c1), min(x + c0, y) - w), can_prove(y + c1 >= w + c0, this)) ||
+                             rewrite(min(y, x) - min(w, x), min(0, y - min(x, w)), can_prove(y <= w, this)) ||
+                             rewrite(min(y, x) - min(w, x), max(0, min(x, y) - w), can_prove(y >= w, this)) ||
+                             rewrite(min(y, x + c0) - min(w, x), min(c0, y - min(x, w)), can_prove(y <= w + c0, this)) ||
+                             rewrite(min(y, x + c0) - min(w, x), max(c0, min(x + c0, y) - w), can_prove(y >= w + c0, this)) ||
+                             rewrite(min(y, x) - min(w, x + c1), min(fold(-c1), y - min(x + c1, w)), can_prove(y + c1 <= w, this)) ||
+                             rewrite(min(y, x) - min(w, x + c1), max(fold(-c1), min(x, y) - w), can_prove(y + c1 >= w, this)) ||
+                             rewrite(min(y, x + c0) - min(w, x + c1), min(fold(c0 - c1), y - min(x + c1, w)), can_prove(y + c1 <= w + c0, this)) ||
+                             rewrite(min(y, x + c0) - min(w, x + c1), max(fold(c0 - c1), min(x + c0, y) - w), can_prove(y + c1 >= w + c0, this)) ||
 
-               rewrite(min(x, y) - min(w, x), min(0, y - min(x, w)), can_prove(y <= w, this)) ||
-               rewrite(min(x, y) - min(w, x), max(0, min(x, y) - w), can_prove(y >= w, this)) ||
-               rewrite(min(x + c0, y) - min(w, x), min(c0, y - min(x, w)), can_prove(y <= w + c0, this)) ||
-               rewrite(min(x + c0, y) - min(w, x), max(c0, min(x + c0, y) - w), can_prove(y >= w + c0, this)) ||
-               rewrite(min(x, y) - min(w, x + c1), min(fold(-c1), y - min(x + c1, w)), can_prove(y + c1 <= w, this)) ||
-               rewrite(min(x, y) - min(w, x + c1), max(fold(-c1), min(x, y) - w), can_prove(y + c1 >= w, this)) ||
-               rewrite(min(x + c0, y) - min(w, x + c1), min(fold(c0 - c1), y - min(x + c1, w)), can_prove(y + c1 <= w + c0, this)) ||
-               rewrite(min(x + c0, y) - min(w, x + c1), max(fold(c0 - c1), min(x + c0, y) - w), can_prove(y + c1 >= w + c0, this)) ||
+                             rewrite(min(x, y) - min(w, x), min(0, y - min(x, w)), can_prove(y <= w, this)) ||
+                             rewrite(min(x, y) - min(w, x), max(0, min(x, y) - w), can_prove(y >= w, this)) ||
+                             rewrite(min(x + c0, y) - min(w, x), min(c0, y - min(x, w)), can_prove(y <= w + c0, this)) ||
+                             rewrite(min(x + c0, y) - min(w, x), max(c0, min(x + c0, y) - w), can_prove(y >= w + c0, this)) ||
+                             rewrite(min(x, y) - min(w, x + c1), min(fold(-c1), y - min(x + c1, w)), can_prove(y + c1 <= w, this)) ||
+                             rewrite(min(x, y) - min(w, x + c1), max(fold(-c1), min(x, y) - w), can_prove(y + c1 >= w, this)) ||
+                             rewrite(min(x + c0, y) - min(w, x + c1), min(fold(c0 - c1), y - min(x + c1, w)), can_prove(y + c1 <= w + c0, this)) ||
+                             rewrite(min(x + c0, y) - min(w, x + c1), max(fold(c0 - c1), min(x + c0, y) - w), can_prove(y + c1 >= w + c0, this)) ||
 
-               rewrite(min(y, x) - min(x, w), min(0, y - min(x, w)), can_prove(y <= w, this)) ||
-               rewrite(min(y, x) - min(x, w), max(0, min(x, y) - w), can_prove(y >= w, this)) ||
-               rewrite(min(y, x + c0) - min(x, w), min(c0, y - min(x, w)), can_prove(y <= w + c0, this)) ||
-               rewrite(min(y, x + c0) - min(x, w), max(c0, min(x + c0, y) - w), can_prove(y >= w + c0, this)) ||
-               rewrite(min(y, x) - min(x + c1, w), min(fold(-c1), y - min(x + c1, w)), can_prove(y + c1 <= w, this)) ||
-               rewrite(min(y, x) - min(x + c1, w), max(fold(-c1), min(x, y) - w), can_prove(y + c1 >= w, this)) ||
-               rewrite(min(y, x + c0) - min(x + c1, w), min(fold(c0 - c1), y - min(x + c1, w)), can_prove(y + c1 <= w + c0, this)) ||
-               rewrite(min(y, x + c0) - min(x + c1, w), max(fold(c0 - c1), min(x + c0, y) - w), can_prove(y + c1 >= w + c0, this)) ||
+                             rewrite(min(y, x) - min(x, w), min(0, y - min(x, w)), can_prove(y <= w, this)) ||
+                             rewrite(min(y, x) - min(x, w), max(0, min(x, y) - w), can_prove(y >= w, this)) ||
+                             rewrite(min(y, x + c0) - min(x, w), min(c0, y - min(x, w)), can_prove(y <= w + c0, this)) ||
+                             rewrite(min(y, x + c0) - min(x, w), max(c0, min(x + c0, y) - w), can_prove(y >= w + c0, this)) ||
+                             rewrite(min(y, x) - min(x + c1, w), min(fold(-c1), y - min(x + c1, w)), can_prove(y + c1 <= w, this)) ||
+                             rewrite(min(y, x) - min(x + c1, w), max(fold(-c1), min(x, y) - w), can_prove(y + c1 >= w, this)) ||
+                             rewrite(min(y, x + c0) - min(x + c1, w), min(fold(c0 - c1), y - min(x + c1, w)), can_prove(y + c1 <= w + c0, this)) ||
+                             rewrite(min(y, x + c0) - min(x + c1, w), max(fold(c0 - c1), min(x + c0, y) - w), can_prove(y + c1 >= w + c0, this)) ||
 
-               // The equivalent rules for max are what you'd
-               // expect. Just swap < and > and min and max (apply the
-               // isomorphism x -> -x).
-               rewrite(max(x, y) - max(x, w), max(0, y - max(x, w)), can_prove(y >= w, this)) ||
-               rewrite(max(x, y) - max(x, w), min(0, max(x, y) - w), can_prove(y <= w, this)) ||
-               rewrite(max(x + c0, y) - max(x, w), max(c0, y - max(x, w)), can_prove(y >= w + c0, this)) ||
-               rewrite(max(x + c0, y) - max(x, w), min(c0, max(x + c0, y) - w), can_prove(y <= w + c0, this)) ||
-               rewrite(max(x, y) - max(x + c1, w), max(fold(-c1), y - max(x + c1, w)), can_prove(y + c1 >= w, this)) ||
-               rewrite(max(x, y) - max(x + c1, w), min(fold(-c1), max(x, y) - w), can_prove(y + c1 <= w, this)) ||
-               rewrite(max(x + c0, y) - max(x + c1, w), max(fold(c0 - c1), y - max(x + c1, w)), can_prove(y + c1 >= w + c0, this)) ||
-               rewrite(max(x + c0, y) - max(x + c1, w), min(fold(c0 - c1), max(x + c0, y) - w), can_prove(y + c1 <= w + c0, this)) ||
+                             // The equivalent rules for max are what you'd
+                             // expect. Just swap < and > and min and max (apply the
+                             // isomorphism x -> -x).
+                             rewrite(max(x, y) - max(x, w), max(0, y - max(x, w)), can_prove(y >= w, this)) ||
+                             rewrite(max(x, y) - max(x, w), min(0, max(x, y) - w), can_prove(y <= w, this)) ||
+                             rewrite(max(x + c0, y) - max(x, w), max(c0, y - max(x, w)), can_prove(y >= w + c0, this)) ||
+                             rewrite(max(x + c0, y) - max(x, w), min(c0, max(x + c0, y) - w), can_prove(y <= w + c0, this)) ||
+                             rewrite(max(x, y) - max(x + c1, w), max(fold(-c1), y - max(x + c1, w)), can_prove(y + c1 >= w, this)) ||
+                             rewrite(max(x, y) - max(x + c1, w), min(fold(-c1), max(x, y) - w), can_prove(y + c1 <= w, this)) ||
+                             rewrite(max(x + c0, y) - max(x + c1, w), max(fold(c0 - c1), y - max(x + c1, w)), can_prove(y + c1 >= w + c0, this)) ||
+                             rewrite(max(x + c0, y) - max(x + c1, w), min(fold(c0 - c1), max(x + c0, y) - w), can_prove(y + c1 <= w + c0, this)) ||
 
-               rewrite(max(y, x) - max(w, x), max(0, y - max(x, w)), can_prove(y >= w, this)) ||
-               rewrite(max(y, x) - max(w, x), min(0, max(x, y) - w), can_prove(y <= w, this)) ||
-               rewrite(max(y, x + c0) - max(w, x), max(c0, y - max(x, w)), can_prove(y >= w + c0, this)) ||
-               rewrite(max(y, x + c0) - max(w, x), min(c0, max(x + c0, y) - w), can_prove(y <= w + c0, this)) ||
-               rewrite(max(y, x) - max(w, x + c1), max(fold(-c1), y - max(x + c1, w)), can_prove(y + c1 >= w, this)) ||
-               rewrite(max(y, x) - max(w, x + c1), min(fold(-c1), max(x, y) - w), can_prove(y + c1 <= w, this)) ||
-               rewrite(max(y, x + c0) - max(w, x + c1), max(fold(c0 - c1), y - max(x + c1, w)), can_prove(y + c1 >= w + c0, this)) ||
-               rewrite(max(y, x + c0) - max(w, x + c1), min(fold(c0 - c1), max(x + c0, y) - w), can_prove(y + c1 <= w + c0, this)) ||
+                             rewrite(max(y, x) - max(w, x), max(0, y - max(x, w)), can_prove(y >= w, this)) ||
+                             rewrite(max(y, x) - max(w, x), min(0, max(x, y) - w), can_prove(y <= w, this)) ||
+                             rewrite(max(y, x + c0) - max(w, x), max(c0, y - max(x, w)), can_prove(y >= w + c0, this)) ||
+                             rewrite(max(y, x + c0) - max(w, x), min(c0, max(x + c0, y) - w), can_prove(y <= w + c0, this)) ||
+                             rewrite(max(y, x) - max(w, x + c1), max(fold(-c1), y - max(x + c1, w)), can_prove(y + c1 >= w, this)) ||
+                             rewrite(max(y, x) - max(w, x + c1), min(fold(-c1), max(x, y) - w), can_prove(y + c1 <= w, this)) ||
+                             rewrite(max(y, x + c0) - max(w, x + c1), max(fold(c0 - c1), y - max(x + c1, w)), can_prove(y + c1 >= w + c0, this)) ||
+                             rewrite(max(y, x + c0) - max(w, x + c1), min(fold(c0 - c1), max(x + c0, y) - w), can_prove(y + c1 <= w + c0, this)) ||
 
-               rewrite(max(x, y) - max(w, x), max(0, y - max(x, w)), can_prove(y >= w, this)) ||
-               rewrite(max(x, y) - max(w, x), min(0, max(x, y) - w), can_prove(y <= w, this)) ||
-               rewrite(max(x + c0, y) - max(w, x), max(c0, y - max(x, w)), can_prove(y >= w + c0, this)) ||
-               rewrite(max(x + c0, y) - max(w, x), min(c0, max(x + c0, y) - w), can_prove(y <= w + c0, this)) ||
-               rewrite(max(x, y) - max(w, x + c1), max(fold(-c1), y - max(x + c1, w)), can_prove(y + c1 >= w, this)) ||
-               rewrite(max(x, y) - max(w, x + c1), min(fold(-c1), max(x, y) - w), can_prove(y + c1 <= w, this)) ||
-               rewrite(max(x + c0, y) - max(w, x + c1), max(fold(c0 - c1), y - max(x + c1, w)), can_prove(y + c1 >= w + c0, this)) ||
-               rewrite(max(x + c0, y) - max(w, x + c1), min(fold(c0 - c1), max(x + c0, y) - w), can_prove(y + c1 <= w + c0, this)) ||
+                             rewrite(max(x, y) - max(w, x), max(0, y - max(x, w)), can_prove(y >= w, this)) ||
+                             rewrite(max(x, y) - max(w, x), min(0, max(x, y) - w), can_prove(y <= w, this)) ||
+                             rewrite(max(x + c0, y) - max(w, x), max(c0, y - max(x, w)), can_prove(y >= w + c0, this)) ||
+                             rewrite(max(x + c0, y) - max(w, x), min(c0, max(x + c0, y) - w), can_prove(y <= w + c0, this)) ||
+                             rewrite(max(x, y) - max(w, x + c1), max(fold(-c1), y - max(x + c1, w)), can_prove(y + c1 >= w, this)) ||
+                             rewrite(max(x, y) - max(w, x + c1), min(fold(-c1), max(x, y) - w), can_prove(y + c1 <= w, this)) ||
+                             rewrite(max(x + c0, y) - max(w, x + c1), max(fold(c0 - c1), y - max(x + c1, w)), can_prove(y + c1 >= w + c0, this)) ||
+                             rewrite(max(x + c0, y) - max(w, x + c1), min(fold(c0 - c1), max(x + c0, y) - w), can_prove(y + c1 <= w + c0, this)) ||
 
-               rewrite(max(y, x) - max(x, w), max(0, y - max(x, w)), can_prove(y >= w, this)) ||
-               rewrite(max(y, x) - max(x, w), min(0, max(x, y) - w), can_prove(y <= w, this)) ||
-               rewrite(max(y, x + c0) - max(x, w), max(c0, y - max(x, w)), can_prove(y >= w + c0, this)) ||
-               rewrite(max(y, x + c0) - max(x, w), min(c0, max(x + c0, y) - w), can_prove(y <= w + c0, this)) ||
-               rewrite(max(y, x) - max(x + c1, w), max(fold(-c1), y - max(x + c1, w)), can_prove(y + c1 >= w, this)) ||
-               rewrite(max(y, x) - max(x + c1, w), min(fold(-c1), max(x, y) - w), can_prove(y + c1 <= w, this)) ||
-               rewrite(max(y, x + c0) - max(x + c1, w), max(fold(c0 - c1), y - max(x + c1, w)), can_prove(y + c1 >= w + c0, this)) ||
-               rewrite(max(y, x + c0) - max(x + c1, w), min(fold(c0 - c1), max(x + c0, y) - w), can_prove(y + c1 <= w + c0, this)))) ||
+                             rewrite(max(y, x) - max(x, w), max(0, y - max(x, w)), can_prove(y >= w, this)) ||
+                             rewrite(max(y, x) - max(x, w), min(0, max(x, y) - w), can_prove(y <= w, this)) ||
+                             rewrite(max(y, x + c0) - max(x, w), max(c0, y - max(x, w)), can_prove(y >= w + c0, this)) ||
+                             rewrite(max(y, x + c0) - max(x, w), min(c0, max(x + c0, y) - w), can_prove(y <= w + c0, this)) ||
+                             rewrite(max(y, x) - max(x + c1, w), max(fold(-c1), y - max(x + c1, w)), can_prove(y + c1 >= w, this)) ||
+                             rewrite(max(y, x) - max(x + c1, w), min(fold(-c1), max(x, y) - w), can_prove(y + c1 <= w, this)) ||
+                             rewrite(max(y, x + c0) - max(x + c1, w), max(fold(c0 - c1), y - max(x + c1, w)), can_prove(y + c1 >= w + c0, this)) ||
+                             rewrite(max(y, x + c0) - max(x + c1, w), min(fold(c0 - c1), max(x + c0, y) - w), can_prove(y + c1 <= w + c0, this)))) ||
 
-             (no_overflow_int(op->type) &&
-              (rewrite(c0 - (c1 - x)/c2, (fold(c0*c2 - c1 + c2 - 1) + x)/c2, c2 > 0) ||
-               rewrite(c0 - (x + c1)/c2, (fold(c0*c2 - c1 + c2 - 1) - x)/c2, c2 > 0) ||
-               rewrite(x - (x + y)/c0, (x*fold(c0 - 1) - y + fold(c0 - 1))/c0, c0 > 0) ||
-               rewrite(x - (x - y)/c0, (x*fold(c0 - 1) + y + fold(c0 - 1))/c0, c0 > 0) ||
-               rewrite(x - (y + x)/c0, (x*fold(c0 - 1) - y + fold(c0 - 1))/c0, c0 > 0) ||
-               rewrite(x - (y - x)/c0, (x*fold(c0 + 1) - y + fold(c0 - 1))/c0, c0 > 0) ||
-               rewrite((x + y)/c0 - x, (x*fold(1 - c0) + y)/c0) ||
-               rewrite((y + x)/c0 - x, (y + x*fold(1 - c0))/c0) ||
-               rewrite((x - y)/c0 - x, (x*fold(1 - c0) - y)/c0) ||
-               rewrite((y - x)/c0 - x, (y - x*fold(1 + c0))/c0) ||
+                           (no_overflow_int(op->type) &&
+                            (rewrite(c0 - (c1 - x) / c2, (fold(c0 * c2 - c1 + c2 - 1) + x) / c2, c2 > 0) ||
+                             rewrite(c0 - (x + c1) / c2, (fold(c0 * c2 - c1 + c2 - 1) - x) / c2, c2 > 0) ||
+                             rewrite(x - (x + y) / c0, (x * fold(c0 - 1) - y + fold(c0 - 1)) / c0, c0 > 0) ||
+                             rewrite(x - (x - y) / c0, (x * fold(c0 - 1) + y + fold(c0 - 1)) / c0, c0 > 0) ||
+                             rewrite(x - (y + x) / c0, (x * fold(c0 - 1) - y + fold(c0 - 1)) / c0, c0 > 0) ||
+                             rewrite(x - (y - x) / c0, (x * fold(c0 + 1) - y + fold(c0 - 1)) / c0, c0 > 0) ||
+                             rewrite((x + y) / c0 - x, (x * fold(1 - c0) + y) / c0) ||
+                             rewrite((y + x) / c0 - x, (y + x * fold(1 - c0)) / c0) ||
+                             rewrite((x - y) / c0 - x, (x * fold(1 - c0) - y) / c0) ||
+                             rewrite((y - x) / c0 - x, (y - x * fold(1 + c0)) / c0) ||
 
-               rewrite((x/c0)*c0 - x, -(x % c0), c0 > 0) ||
-               rewrite(x - (x/c0)*c0, x % c0, c0 > 0) ||
-               rewrite(((x + c0)/c1)*c1 - x, (-x) % c1, c1 > 0 && c0 + 1 == c1) ||
-               rewrite(x - ((x + c0)/c1)*c1, ((x + c0) % c1) + fold(-c0), c1 > 0 && c0 + 1 == c1) ||
-               rewrite(x * c0 - y * c1, (x * fold(c0 / c1) - y) * c1, c0 % c1 == 0) ||
-               rewrite(x * c0 - y * c1, (x - y * fold(c1 / c0)) * c0, c1 % c0 == 0) ||
-               // Various forms of (x +/- a)/c - (x +/- b)/c. We can
-               // *almost* cancel the x.  The right thing to do depends
-               // on which of a or b is a constant, and we also need to
-               // catch the cases where that constant is zero.
-               rewrite(((x + y) + z)/c0 - ((y + x) + w)/c0, ((x + y) + z)/c0 - ((x + y) + w)/c0, c0 > 0) ||
-               rewrite((x + y)/c0 - (y + x)/c0, 0, c0 != 0) ||
-               rewrite((x + y)/c0 - (x + c1)/c0, (((x + fold(c1 % c0)) % c0) + (y - c1))/c0, c0 > 0) ||
-               rewrite((x + c1)/c0 - (x + y)/c0, ((fold(c0 + c1 - 1) - y) - ((x + fold(c1 % c0)) % c0))/c0, c0 > 0) ||
-               rewrite((x - y)/c0 - (x + c1)/c0, (((x + fold(c1 % c0)) % c0) - y - c1)/c0, c0 > 0) ||
-               rewrite((x + c1)/c0 - (x - y)/c0, ((y + fold(c0 + c1 - 1)) - ((x + fold(c1 % c0)) % c0))/c0, c0 > 0) ||
-               rewrite(x/c0 - (x + y)/c0, ((fold(c0 - 1) - y) - (x % c0))/c0, c0 > 0) ||
-               rewrite((x + y)/c0 - x/c0, ((x % c0) + y)/c0, c0 > 0) ||
-               rewrite(x/c0 - (x - y)/c0, ((y + fold(c0 - 1)) - (x % c0))/c0, c0 > 0) ||
-               rewrite((x - y)/c0 - x/c0, ((x % c0) - y)/c0, c0 > 0))))) {
+                             rewrite((x / c0) * c0 - x, -(x % c0), c0 > 0) ||
+                             rewrite(x - (x / c0) * c0, x % c0, c0 > 0) ||
+                             rewrite(((x + c0) / c1) * c1 - x, (-x) % c1, c1 > 0 && c0 + 1 == c1) ||
+                             rewrite(x - ((x + c0) / c1) * c1, ((x + c0) % c1) + fold(-c0), c1 > 0 && c0 + 1 == c1) ||
+                             rewrite(x * c0 - y * c1, (x * fold(c0 / c1) - y) * c1, c0 % c1 == 0) ||
+                             rewrite(x * c0 - y * c1, (x - y * fold(c1 / c0)) * c0, c1 % c0 == 0) ||
+                             // Various forms of (x +/- a)/c - (x +/- b)/c. We can
+                             // *almost* cancel the x.  The right thing to do depends
+                             // on which of a or b is a constant, and we also need to
+                             // catch the cases where that constant is zero.
+                             rewrite(((x + y) + z) / c0 - ((y + x) + w) / c0, ((x + y) + z) / c0 - ((x + y) + w) / c0, c0 > 0) ||
+                             rewrite((x + y) / c0 - (y + x) / c0, 0, c0 != 0) ||
+                             rewrite((x + y) / c0 - (x + c1) / c0, (((x + fold(c1 % c0)) % c0) + (y - c1)) / c0, c0 > 0) ||
+                             rewrite((x + c1) / c0 - (x + y) / c0, ((fold(c0 + c1 - 1) - y) - ((x + fold(c1 % c0)) % c0)) / c0, c0 > 0) ||
+                             rewrite((x - y) / c0 - (x + c1) / c0, (((x + fold(c1 % c0)) % c0) - y - c1) / c0, c0 > 0) ||
+                             rewrite((x + c1) / c0 - (x - y) / c0, ((y + fold(c0 + c1 - 1)) - ((x + fold(c1 % c0)) % c0)) / c0, c0 > 0) ||
+                             rewrite(x / c0 - (x + y) / c0, ((fold(c0 - 1) - y) - (x % c0)) / c0, c0 > 0) ||
+                             rewrite((x + y) / c0 - x / c0, ((x % c0) + y) / c0, c0 > 0) ||
+                             rewrite(x / c0 - (x - y) / c0, ((y + fold(c0 - 1)) - (x % c0)) / c0, c0 > 0) ||
+                             rewrite((x - y) / c0 - x / c0, ((x % c0) - y) / c0, c0 > 0))))) {
             return mutate(std::move(rewrite.result), bounds);
         }
     }

--- a/src/Type.h
+++ b/src/Type.h
@@ -210,8 +210,8 @@ template<typename T>
         (is_volatile ? halide_handle_cplusplus_type::Volatile : 0));
     constexpr halide_handle_cplusplus_type::ReferenceType ref_type =
         (is_lvalue_reference ? halide_handle_cplusplus_type::LValueReference :
-         is_rvalue_reference ? halide_handle_cplusplus_type::RValueReference :
-         halide_handle_cplusplus_type::NotReference);
+                               is_rvalue_reference ? halide_handle_cplusplus_type::RValueReference :
+                                                     halide_handle_cplusplus_type::NotReference);
 
     using TNonCVBase = typename std::remove_cv<TBase>::type;
     constexpr bool known_type = halide_c_type_to_name<TNonCVBase>::known_type;

--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -1339,15 +1339,15 @@ public:
             // Insert two new for-loops for vertex buffer generation on the host
             // before the two GPU scheduled for-loops
             return LetStmt::make("glsl.num_coords_dim0", dont_simplify((int)(coords[0].size())),
-                   LetStmt::make("glsl.num_coords_dim1", dont_simplify((int)(coords[1].size())),
-                   LetStmt::make("glsl.num_padded_attributes", dont_simplify(num_padded_attributes),
-                   Allocate::make(vs.vertex_buffer_name, Float(32), MemoryType::Auto, {vertex_buffer_size}, const_true(),
-                   Block::make(vertex_setup,
-                   Block::make(loop_stmt,
-                   Block::make(used_in_codegen(Int(32), "glsl.num_coords_dim0"),
-                   Block::make(used_in_codegen(Int(32), "glsl.num_coords_dim1"),
-                   Block::make(used_in_codegen(Int(32), "glsl.num_padded_attributes"),
-                   Free::make(vs.vertex_buffer_name))))))))));
+                                 LetStmt::make("glsl.num_coords_dim1", dont_simplify((int)(coords[1].size())),
+                                               LetStmt::make("glsl.num_padded_attributes", dont_simplify(num_padded_attributes),
+                                                             Allocate::make(vs.vertex_buffer_name, Float(32), MemoryType::Auto, {vertex_buffer_size}, const_true(),
+                                                                            Block::make(vertex_setup,
+                                                                                        Block::make(loop_stmt,
+                                                                                                    Block::make(used_in_codegen(Int(32), "glsl.num_coords_dim0"),
+                                                                                                                Block::make(used_in_codegen(Int(32), "glsl.num_coords_dim1"),
+                                                                                                                            Block::make(used_in_codegen(Int(32), "glsl.num_padded_attributes"),
+                                                                                                                                        Free::make(vs.vertex_buffer_name))))))))));
         } else {
             return IRMutator::visit(op);
         }

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -16,8 +16,8 @@
 #include <vector>
 
 #ifdef WITH_V8
-#include "v8.h"
 #include "libplatform/libplatform.h"
+#include "v8.h"
 #endif
 
 // ---------------------
@@ -1017,7 +1017,7 @@ void wasm_jit___extendhfsf2_callback(const v8::FunctionCallbackInfo<v8::Value> &
     HandleScope scope(isolate);
 
     const uint16_t in = args[0]->NumberValue(context).ToChecked();
-    const float out = (float) float16_t::make_from_bits(in);
+    const float out = (float)float16_t::make_from_bits(in);
 
     args.GetReturnValue().Set(wrap_scalar(context, out));
 }


### PR DESCRIPTION
We did this in a giant batch once before, but changes have introduced drift over time. Bringing it all back up to standard.