### PR TITLE
Fix CMake breakage for recent LLVM

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -777,10 +777,9 @@ llvm_config(Halide ${LLVM_USE_SHARED} ${LLVM_COMPONENTS})
 if (NOT MSVC AND NOT LLVM_USE_SHARED_LLVM_LIBRARY)
   set(LLVM_CONFIG ${LLVM_TOOLS_BINARY_DIR}/llvm-config)
   execute_process(COMMAND "${LLVM_CONFIG}" --system-libs ${LLVM_COMPONENTS} OUTPUT_VARIABLE EXTRA_LIBS)
-  string(STRIP EXTRA_LIBS "${EXTRA_LIBS}")
-  string(REPLACE "-l" ";" EXTRA_LIBS "${EXTRA_LIBS}")
+  string(STRIP EXTRA_LIBS "${EXTRA_LIBS}")   # strip whitespace from start & end
   string(REPLACE "\n" "" EXTRA_LIBS "${EXTRA_LIBS}")
-  string(REPLACE " " "" EXTRA_LIBS "${EXTRA_LIBS}")
+  string(REPLACE " " ";" EXTRA_LIBS "${EXTRA_LIBS}")  # convert into a list
   target_link_libraries(Halide PUBLIC ${EXTRA_LIBS})
 endif()
 


### PR DESCRIPTION
The munging we did for the output of `llvm-config --system-libs` in src/CMakeLists.txt was not ideal, and could trick CMake into illegal linker lines (on Unixy systems) if the system libs contained both absolute paths and `-l` directives. I think this solves the issue.

EDIT: for posterity, it only shows up for SHARED_LIBRARY=ON, and only on LLVM trunk (this latter bit is why it never shows up for Travis, which doesn't do trunk)