### PR TITLE
More clang-format fixes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,8 @@ AccessModifierOffset: -4
 AlignEscapedNewlinesLeft: true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: Empty
+# Requires Clang-Format 10+
+# AllowShortBlocksOnASingleLine: 'Empty'
 AllowShortFunctionsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: false

--- a/python_bindings/src/PyBuffer.cpp
+++ b/python_bindings/src/PyBuffer.cpp
@@ -93,8 +93,10 @@ void call_fill(Buffer<> &b, py::object value) {
 
 bool call_all_equal(Buffer<> &b, py::object value) {
 
-#define HANDLE_BUFFER_TYPE(TYPE) \
-    if (b.type() == type_of<TYPE>()) { return b.as<TYPE>().all_equal(value_cast<TYPE>(value)); }
+#define HANDLE_BUFFER_TYPE(TYPE)                                \
+    if (b.type() == type_of<TYPE>()) {                          \
+        return b.as<TYPE>().all_equal(value_cast<TYPE>(value)); \
+    }
 
     HANDLE_BUFFER_TYPE(bool)
     HANDLE_BUFFER_TYPE(uint8_t)

--- a/src/runtime/d3d12compute.cpp
+++ b/src/runtime/d3d12compute.cpp
@@ -100,14 +100,16 @@ static int indent_end = 0;
 #define TRACEPRINT(msg) trace(user_context) << TRACEINDENT << msg;
 struct TraceLogScope {
     TraceLogScope() {
-        while (__sync_lock_test_and_set(&indent_lock, 1)) {}
+        while (__sync_lock_test_and_set(&indent_lock, 1)) {
+        }
         for (const char *p = indent_pattern; *p; ++p) {
             indent[indent_end++] = *p;
         }
         __sync_lock_release(&indent_lock);
     }
     ~TraceLogScope() {
-        while (__sync_lock_test_and_set(&indent_lock, 1)) {}
+        while (__sync_lock_test_and_set(&indent_lock, 1)) {
+        }
         for (const char *p = indent_pattern; *p; ++p) {
             indent[--indent_end] = '\0';
         }
@@ -840,7 +842,8 @@ static void D3D12WaitForPix() {
     TRACELOG;
     TRACEPRINT("[[ delay for attaching to PIX... ]]\n");
     volatile uint32_t x = (1 << 31);
-    while (--x > 0) {}
+    while (--x > 0) {
+    }
 }
 #endif
 
@@ -1829,7 +1832,8 @@ static void wait_until_completed(d3d12_compute_command_list *cmdList) {
 
     HRESULT result_before = (*device)->GetDeviceRemovedReason();
 
-    while (queue_fence->GetCompletedValue() < cmdList->signal) {}
+    while (queue_fence->GetCompletedValue() < cmdList->signal) {
+    }
 
     HRESULT result_after = (*device)->GetDeviceRemovedReason();
     if (FAILED(result_after)) {
@@ -2174,7 +2178,8 @@ WEAK int halide_d3d12compute_acquire_context(void *user_context, halide_d3d12com
     TRACELOG;
 
     halide_assert(user_context, &thread_lock != NULL);
-    while (__sync_lock_test_and_set(&thread_lock, 1)) {}
+    while (__sync_lock_test_and_set(&thread_lock, 1)) {
+    }
 
 #ifdef DEBUG_RUNTIME
     halide_start_clock(user_context);

--- a/src/runtime/hexagon_remote/sim_host.cpp
+++ b/src/runtime/hexagon_remote/sim_host.cpp
@@ -207,7 +207,9 @@ int send_message(int msg, const std::vector<int> &arguments) {
         printf("HexagonWrapper::ReadSymbolValue(rpcmsg) failed: %d\n", status);
         return -1;
     }
-    if (write_memory(remote_msg, &msg, 4) != 0) { return -1; }
+    if (write_memory(remote_msg, &msg, 4) != 0) {
+        return -1;
+    }
 
     // The arguments are individual numbered variables.
     for (size_t i = 0; i < arguments.size(); i++) {
@@ -218,7 +220,9 @@ int send_message(int msg, const std::vector<int> &arguments) {
             printf("HexagonWrapper::ReadSymbolValue(%s) failed: %d\n", rpc_arg.c_str(), status);
             return -1;
         }
-        if (write_memory(remote_arg, &arguments[i], 4) != 0) { return -1; }
+        if (write_memory(remote_arg, &arguments[i], 4) != 0) {
+            return -1;
+        }
     }
 
     HEX_4u_t remote_ret = 0;

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -285,7 +285,8 @@ extern "C" {
 WEAK int halide_metal_acquire_context(void *user_context, mtl_device **device_ret,
                                       mtl_command_queue **queue_ret, bool create) {
     halide_assert(user_context, &thread_lock != NULL);
-    while (__sync_lock_test_and_set(&thread_lock, 1)) {}
+    while (__sync_lock_test_and_set(&thread_lock, 1)) {
+    }
 
 #ifdef DEBUG_RUNTIME
     halide_start_clock(user_context);

--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -208,7 +208,8 @@ WEAK int halide_acquire_cl_context(void *user_context, cl_context *ctx, cl_comma
     halide_assert(user_context, q != NULL);
 
     halide_assert(user_context, &thread_lock != NULL);
-    while (__sync_lock_test_and_set(&thread_lock, 1)) {}
+    while (__sync_lock_test_and_set(&thread_lock, 1)) {
+    }
 
     // If the context has not been initialized, initialize it now.
     halide_assert(user_context, &context != NULL);

--- a/src/runtime/openglcompute.cpp
+++ b/src/runtime/openglcompute.cpp
@@ -302,14 +302,20 @@ WEAK int halide_openglcompute_device_malloc(void *user_context, halide_buffer_t 
 
     GLuint the_buffer;
     global_state.GenBuffers(1, &the_buffer);
-    if (global_state.CheckAndReportError(user_context, "oglc: GenBuffers")) { return 1; }
+    if (global_state.CheckAndReportError(user_context, "oglc: GenBuffers")) {
+        return 1;
+    }
     global_state.BindBuffer(GL_ARRAY_BUFFER, the_buffer);
-    if (global_state.CheckAndReportError(user_context, "oglc: BindBuffer")) { return 1; }
+    if (global_state.CheckAndReportError(user_context, "oglc: BindBuffer")) {
+        return 1;
+    }
     // OpenGLCompute only supports int32 and float data types, both of which are 4 bytes.
     size_t size_in_bytes = buf->number_of_elements() * 4;
     halide_assert(user_context, size_in_bytes != 0);
     global_state.BufferData(GL_ARRAY_BUFFER, size_in_bytes, NULL, GL_DYNAMIC_COPY);
-    if (global_state.CheckAndReportError(user_context, "oglc: BufferData")) { return 1; }
+    if (global_state.CheckAndReportError(user_context, "oglc: BufferData")) {
+        return 1;
+    }
 
     buf->device = the_buffer;
     buf->device_interface = &openglcompute_device_interface;
@@ -403,18 +409,24 @@ WEAK int halide_openglcompute_copy_to_device(void *user_context, halide_buffer_t
                         << ", the_buffer:" << the_buffer << ")\n";
 
     global_state.BindBuffer(GL_ARRAY_BUFFER, the_buffer);
-    if (global_state.CheckAndReportError(user_context, "oglc: BindBuffer")) { return 1; }
+    if (global_state.CheckAndReportError(user_context, "oglc: BindBuffer")) {
+        return 1;
+    }
 
     size_t size = buf->number_of_elements() * 4;
     global_state.BindBuffer(GL_ARRAY_BUFFER, the_buffer);
-    if (global_state.CheckAndReportError(user_context, "oglc: BindBuffer")) { return 1; }
+    if (global_state.CheckAndReportError(user_context, "oglc: BindBuffer")) {
+        return 1;
+    }
 
     debug(user_context) << "Calling global_state.MapBufferRange(GL_ARRAY_BUFFER, 0, " << (uint64_t)size << ", GL_MAP_READ_BIT|GL_MAP_WRITE_BIT)\n";
     void *device_data = global_state.MapBufferRange(GL_ARRAY_BUFFER,
                                                     0,
                                                     size,
                                                     GL_MAP_READ_BIT | GL_MAP_WRITE_BIT);
-    if (global_state.CheckAndReportError(user_context, "oglc: MapBufferRange")) { return 1; }
+    if (global_state.CheckAndReportError(user_context, "oglc: MapBufferRange")) {
+        return 1;
+    }
     halide_buffer_t buf_copy = *buf;
     buf_copy.device = (uint64_t)device_data;
     device_copy dev_copy = make_host_to_device_copy(&buf_copy);
@@ -492,13 +504,17 @@ WEAK int halide_openglcompute_copy_to_host(void *user_context, halide_buffer_t *
                         << ", size=" << (unsigned)size << ")\n";
 
     global_state.BindBuffer(GL_ARRAY_BUFFER, the_buffer);
-    if (global_state.CheckAndReportError(user_context, "oglc: BindBuffer")) { return 1; }
+    if (global_state.CheckAndReportError(user_context, "oglc: BindBuffer")) {
+        return 1;
+    }
 
     void *device_data = global_state.MapBufferRange(GL_ARRAY_BUFFER,
                                                     0,
                                                     size,
                                                     GL_MAP_READ_BIT);
-    if (global_state.CheckAndReportError(user_context, "oglc: MapBufferRange")) { return 1; }
+    if (global_state.CheckAndReportError(user_context, "oglc: MapBufferRange")) {
+        return 1;
+    }
 
     halide_buffer_t buf_copy = *buf;
     buf_copy.device = (uint64_t)device_data;
@@ -793,7 +809,9 @@ WEAK int halide_openglcompute_initialize_kernels(void *user_context, void **stat
         module->kernel = kernel;
 
         GLuint shader = global_state.CreateShader(GL_COMPUTE_SHADER);
-        if (global_state.CheckAndReportError(user_context, "create shader")) { return -1; }
+        if (global_state.CheckAndReportError(user_context, "create shader")) {
+            return -1;
+        }
         const GLchar *sources = {src};
         const GLint sources_lengths = {(GLint)src_len};
 
@@ -803,9 +821,13 @@ WEAK int halide_openglcompute_initialize_kernels(void *user_context, void **stat
 #endif
 
         global_state.ShaderSource(shader, 1, &sources, &sources_lengths);
-        if (global_state.CheckAndReportError(user_context, "shader source")) { return -1; }
+        if (global_state.CheckAndReportError(user_context, "shader source")) {
+            return -1;
+        }
         global_state.CompileShader(shader);
-        if (global_state.CheckAndReportError(user_context, "compile shader")) { return -1; }
+        if (global_state.CheckAndReportError(user_context, "compile shader")) {
+            return -1;
+        }
 
         GLint shader_ok = 0;
         global_state.GetShaderiv(shader, GL_COMPILE_STATUS, &shader_ok);
@@ -826,9 +848,13 @@ WEAK int halide_openglcompute_initialize_kernels(void *user_context, void **stat
         // Link GLSL program
         GLuint program = global_state.CreateProgram();
         global_state.AttachShader(program, shader);
-        if (global_state.CheckAndReportError(user_context, "attach shader")) { return -1; }
+        if (global_state.CheckAndReportError(user_context, "attach shader")) {
+            return -1;
+        }
         global_state.LinkProgram(program);
-        if (global_state.CheckAndReportError(user_context, "link program")) { return -1; }
+        if (global_state.CheckAndReportError(user_context, "link program")) {
+            return -1;
+        }
 
         // Release the individual shaders
         global_state.DeleteShader(shader);

--- a/src/runtime/scoped_spin_lock.h
+++ b/src/runtime/scoped_spin_lock.h
@@ -11,7 +11,8 @@ struct ScopedSpinLock {
 
     ScopedSpinLock(volatile int *l) __attribute__((always_inline))
     : lock(l) {
-        while (__sync_lock_test_and_set(lock, 1)) {}
+        while (__sync_lock_test_and_set(lock, 1)) {
+        }
     }
 
     ~ScopedSpinLock() __attribute__((always_inline)) {


### PR DESCRIPTION
- make our .clang-format style compatible with clang-format-9
- re-run 'make format' to bring everything back into conformance with the slightly-tweaked style