### PR TITLE
Followup fixes for clang-format checker

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,14 @@
+# .clang-format-ignore
+./bin
+./build
+./cmake_build
+./cmake_build_static
+./cmake_build_shared
+./distrib
+./doc
+./include
+./lib
+# Our tutorials have special formatting: skip them
+./tutorial
+# hexagon_remote/bin/src is also special
+./src/runtime/hexagon_remote/bin/src

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -16,7 +16,5 @@ jobs:
       - uses: DoozyX/clang-format-lint-action@v0.5
         with:
             source: '.'
-            # Our tutorials have special formatting: skip them
-            exclude: './tutorial'
             extensions: 'h,c,cpp'
             clangFormatVersion: 9

--- a/python_bindings/stub/PyStub.cpp
+++ b/python_bindings/stub/PyStub.cpp
@@ -46,6 +46,8 @@ static_assert(PY_MAJOR_VERSION >= 3, "Python bindings for Halide require Python 
 
 #define HALIDE_PLUGIN_IMPL(name) extern "C" HALIDE_EXPORT PyObject *PyInit_##name()
 
+// clang-format off
+
 namespace halide_register_generator {
 namespace HALIDE_CONCAT(HALIDE_PYSTUB_GENERATOR_NAME, _ns) {
     extern std::unique_ptr<Halide::Internal::GeneratorBase> factory(const Halide::GeneratorContext &context);
@@ -56,3 +58,5 @@ HALIDE_PLUGIN_IMPL(HALIDE_PYSTUB_MODULE_NAME) {
     const auto factory = halide_register_generator::HALIDE_CONCAT(HALIDE_PYSTUB_GENERATOR_NAME, _ns)::factory;
     return _halide_pystub_impl(HALIDE_TOSTRING(HALIDE_PYSTUB_MODULE_NAME), factory);
 }
+
+// clang-format on

--- a/src/runtime/hexagon_remote/bin/.clang-format
+++ b/src/runtime/hexagon_remote/bin/.clang-format
@@ -1,1 +1,0 @@
-DisableFormat: true


### PR DESCRIPTION
Exclude dirs via .clang-format-ignore. Also special-case PyStub.cpp since it has a confusing structure that varies results between clang-format 9 and 10.