### PR TITLE
Update benchmark comments in apps

### DIFF
--- a/apps/conv_layer/conv_layer_generator.cpp
+++ b/apps/conv_layer/conv_layer_generator.cpp
@@ -69,7 +69,11 @@ public:
             relu.dim(3).set_estimate(0, N);
 
         } else if (get_target().has_feature(Target::CUDA)) {
-            // GPU schedule, tuned for a gtx 980
+            // GPU schedule, tuned for a GTX 980. Seems to be good on
+            // an RTX 2060 too (About 90% peak flops on both cards).
+
+            // 1.87 ms on an RTX 2060. According to NVIDIA Nsight
+            // Compute we're at 91.5% utilization of the FMA units
 
             // 2.41 ms on a GTX 980. According to nvprof this is about
             // 88% of peak flops.
@@ -116,6 +120,18 @@ public:
                 .unroll(_2);
 
         } else {
+
+            // 4.06ms on an Intel i9-9960X using 16 threads at 3.0 GHz,
+            // which is 94.5% of peak flops assuming the math below is correct:
+
+            // 16 cores times 2 FMAs per cycle times 3G cycles per
+            // second times 16 vector lanes is a peak throughput of
+            // 1.536 TFlops.
+
+            // This conv does N * CI * CO * W * H * 3 * 3 = 5 * 128 *
+            // 128 * 100 * 80 * 3 * 3 FMAs in 4.06ms is 1.453 TFlops.
+
+            // The ratio of actual to theoretical flops hit is 0.9458
 
             int tile_w = 1;
             int tile_h = 1;

--- a/apps/stencil_chain/stencil_chain_generator.cpp
+++ b/apps/stencil_chain/stencil_chain_generator.cpp
@@ -47,18 +47,65 @@ public:
 
         if (auto_schedule) {
             // nothing
-        } else {
-            // CPU schedule. No fusion.
-            Var yi, yo, xo, xi, t;
-            for (size_t i = 1; i < stages.size() - 1; i++) {
-                Func s = stages[i];
-                s.store_at(output, t).compute_at(output, yi).vectorize(s.args()[0], 16);
+        } else if (get_target().has_gpu_feature()) {
+            // GPU schedule
+
+            // 5.90 ms on a 2060 RTX
+
+            // It seems that just compute-rooting all the stencils is
+            // fastest on this GPU, plus some unrolling to share loads
+            // between adjacent pixels.
+            Var xi, yi, xii, yii;
+            for (size_t i = 1; i < stages.size(); i++) {
+                Func &s = stages[i];
+                x = s.args()[0];
+                y = s.args()[1];
+                s.compute_root()
+                    .gpu_tile(x, y, xi, yi, 64, 16)
+                    .tile(xi, yi, xii, yii, 2, 2)
+                    .unroll(xii)
+                    .unroll(yii);
             }
-            output.compute_root()
-                .tile(x, y, xo, yo, xi, yi, 512, 512)
-                .fuse(xo, yo, t)
-                .parallel(t)
-                .vectorize(xi, 16);
+        } else {
+            // CPU schedule
+            // 4.23ms on an Intel i9-9960X using 16 threads at 3.5
+            // GHz.
+
+            // Runtime is pretty noisy, so benchmarked over 1000
+            // trials instead of the default of 10 in the
+            // Makefile. This uses AVX-512 instructions, but not
+            // floating-point ones. My CPU seems to hover at 3.5GHz on
+            // this workload.
+
+            const int vec = natural_vector_size<uint16_t>();
+
+            // How many stencils in between each compute-root
+            const int group_size = 11;
+            Var yi, yo, xo, xi, t;
+
+            const int last_stage_idx = (int)stages.size() - 1;
+            for (int j = last_stage_idx; j > 0; j -= group_size) {
+                Func out = (j == last_stage_idx) ? output : stages[j];
+
+                const int stages_to_output = last_stage_idx - j;
+                const int expansion = 4 * stages_to_output;
+                const int w = 1536 + expansion;
+                const int h = 2560 + expansion;
+
+                out.compute_root()
+                    // Break into 16 tiles for our 16 threads
+                    .tile(x, y, xo, yo, xi, yi, w / 4, h / 4)
+                    .fuse(xo, yo, t)
+                    .parallel(t)
+                    .vectorize(xi, vec);
+
+                for (int i = std::max(0, j - group_size + 1); i < j; i++) {
+                    Func s = stages[i];
+                    s.store_at(out, t)
+                        .compute_at(out, yi)
+                        .vectorize(s.args()[0], vec);
+                }
+            }
         }
     }
 };


### PR DESCRIPTION
I benchmarked a few more apps on the same machine as the recently-rescheduled ones, to get a consistent set of benchmarks for people to refer to. This is mostly useful for sanity checking numbers when doing comparisons (e.g. if it's 10x slower than the comment indicates it should be, I must be holding it wrong).

I also rescheduled stencil chain, including writing a GPU schedule. It's a very simple GPU schedule but I was unable to get a better one within an hour of messing about.