### PR TITLE
Make the Simplifier handle PureExtern functions via LUT

### DIFF
--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -479,15 +479,15 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
         {
             static const std::unordered_map<std::string, std::function<bool(double)>>
                 pure_externs_f1b = {
-                    {"is_finite_f16", [](double a) { return std::isfinite(a); }},
-                    {"is_finite_f32", [](double a) { return std::isfinite(a); }},
-                    {"is_finite_f64", [](double a) { return std::isfinite(a); }},
-                    {"is_inf_f16", [](double a) { return std::isinf(a); }},
-                    {"is_inf_f32", [](double a) { return std::isinf(a); }},
-                    {"is_inf_f64", [](double a) { return std::isinf(a); }},
-                    {"is_nan_f16", [](double a) { return std::isnan(a); }},
-                    {"is_nan_f32", [](double a) { return std::isnan(a); }},
-                    {"is_nan_f64", [](double a) { return std::isnan(a); }},
+                    {"is_finite_f16", (bool (*)(double))std::isfinite},
+                    {"is_finite_f32", (bool (*)(double))std::isfinite},
+                    {"is_finite_f64", (bool (*)(double))std::isfinite},
+                    {"is_inf_f16", (bool (*)(double))std::isinf},
+                    {"is_inf_f32", (bool (*)(double))std::isinf},
+                    {"is_inf_f64", (bool (*)(double))std::isinf},
+                    {"is_nan_f16", (bool (*)(double))std::isnan},
+                    {"is_nan_f32", (bool (*)(double))std::isnan},
+                    {"is_nan_f64", (bool (*)(double))std::isnan},
                 };
             auto it = pure_externs_f1b.find(op->name);
             if (it != pure_externs_f1b.end()) {
@@ -511,21 +511,21 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
         {
             static const std::unordered_map<std::string, std::function<double(double)>>
                 pure_externs_f1 = {
-                    {"acos_f32", [](double a) { return std::acos(a); }},
-                    {"acosh_f32", [](double a) { return std::acosh(a); }},
-                    {"asin_f32", [](double a) { return std::asin(a); }},
-                    {"asinh_f32", [](double a) { return std::asinh(a); }},
-                    {"atan_f32", [](double a) { return std::atan(a); }},
-                    {"atanh_f32", [](double a) { return std::atanh(a); }},
-                    {"cos_f32", [](double a) { return std::cos(a); }},
-                    {"cosh_f32", [](double a) { return std::cosh(a); }},
-                    {"exp_f32", [](double a) { return std::exp(a); }},
-                    {"log_f32", [](double a) { return std::log(a); }},
-                    {"sin_f32", [](double a) { return std::sin(a); }},
-                    {"sinh_f32", [](double a) { return std::sinh(a); }},
-                    {"sqrt_f32", [](double a) { return std::sqrt(a); }},
-                    {"tan_f32", [](double a) { return std::tan(a); }},
-                    {"tanh_f32", [](double a) { return std::tanh(a); }},
+                    {"acos_f32", (double (*)(double))std::acos},
+                    {"acosh_f32", (double (*)(double))std::acosh},
+                    {"asin_f32", (double (*)(double))std::asin},
+                    {"asinh_f32", (double (*)(double))std::asinh},
+                    {"atan_f32", (double (*)(double))std::atan},
+                    {"atanh_f32", (double (*)(double))std::atanh},
+                    {"cos_f32", (double (*)(double))std::cos},
+                    {"cosh_f32", (double (*)(double))std::cosh},
+                    {"exp_f32", (double (*)(double))std::exp},
+                    {"log_f32", (double (*)(double))std::log},
+                    {"sin_f32", (double (*)(double))std::sin},
+                    {"sinh_f32", (double (*)(double))std::sinh},
+                    {"sqrt_f32", (double (*)(double))std::sqrt},
+                    {"tan_f32", (double (*)(double))std::tan},
+                    {"tanh_f32", (double (*)(double))std::tanh},
                 };
             auto it = pure_externs_f1.find(op->name);
             if (it != pure_externs_f1.end()) {
@@ -546,9 +546,9 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
         {
             static const std::unordered_map<std::string, std::function<double(double)>>
                 pure_externs_truncation = {
-                    {"ceil_f32", [](double a) { return std::ceil(a); }},
-                    {"floor_f32", [](double a) { return std::floor(a); }},
-                    {"round_f32", [](double a) { return std::nearbyint(a); }},
+                    {"ceil_f32", (double (*)(double))std::ceil},
+                    {"floor_f32", (double (*)(double))std::floor},
+                    {"round_f32", (double (*)(double))std::nearbyint},
                     {"trunc_f32", [](double a) { return (a < 0 ? std::ceil(a) : std::floor(a)); }},
                 };
             auto it = pure_externs_truncation.find(op->name);
@@ -578,8 +578,8 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
         {
             static const std::unordered_map<std::string, std::function<double(double, double)>>
                 pure_externs_f2 = {
-                    {"atan2_f32", [](double a, double b) { return std::atan2(a, b); }},
-                    {"pow_f32", [](double a, double b) { return std::pow(a, b); }},
+                    {"atan2_f32", (double (*)(double, double))std::atan2},
+                    {"pow_f32", (double (*)(double, double))std::pow},
                 };
             auto it = pure_externs_f2.find(op->name);
             if (it != pure_externs_f2.end()) {

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -529,10 +529,9 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
             auto it = pure_externs_f1.find(op->name);
             if (it != pure_externs_f1.end()) {
                 Expr arg = mutate(op->args[0], nullptr);
-                double f = 0.0;
-                if (const_float(arg, &f)) {
+                if (const double *f = as_const_float(arg)) {
                     auto fn = it->second;
-                    return make_bool(fn(f));
+                    return make_const(arg.type(), fn(*f));
                 } else if (arg.same_as(op->args[0])) {
                     return op;
                 } else {
@@ -551,7 +550,6 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
                     {"round_f32", [](double a) { return std::nearbyint(a); }},
                     {"trunc_f32", [](double a) { return (a < 0 ? std::ceil(a) : std::floor(a)); }},
                 };
-
             auto it = pure_externs_truncation.find(op->name);
             if (it != pure_externs_truncation.end()) {
                 internal_assert(op->args.size() == 1);

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -506,7 +506,8 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
         }
 
         // Handle all the PureExtern cases of float -> float
-        // TODO: should we handle the f16 and f64 cases here? We never did before.
+        // TODO: should we handle the f16 and f64 cases here? (We never did before.)
+        // TODO: should we handle fast_inverse and/or fast_inverse_sqrt here?
         {
             static const std::unordered_map<std::string, std::function<double(double)>>
                 pure_externs_f1 = {
@@ -601,6 +602,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
 
         // There are other PureExterns we don't bother with (e.g. fast_inverse_f32)...
         // just fall thru and take the general case.
+        debug(2) << "Simplifier: unhandled PureExtern " << op->name;
     }
 
     // No else: we want to fall thru from the PureExtern clause.

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -602,7 +602,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
 
         // There are other PureExterns we don't bother with (e.g. fast_inverse_f32)...
         // just fall thru and take the general case.
-        debug(2) << "Simplifier: unhandled PureExtern " << op->name;
+        debug(2) << "Simplifier: unhandled PureExtern: " << op->name;
     }
 
     // No else: we want to fall thru from the PureExtern clause.

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -601,11 +601,12 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
             // else fall thru
         }
 
-        internal_error << "Unhandled PureExtern Call: " << op->name;
-        return op;
-    } else {
-        internal_assert(op->call_type != Call::PureExtern);
+        // There are other PureExterns we don't bother with (e.g. fast_inverse_f32)...
+        // just fall thru and take the general case.
+    }
 
+    // No else: we want to fall thru from the PureExtern clause.
+    {
         vector<Expr> new_args(op->args.size());
         bool changed = false;
 


### PR DESCRIPTION
There were a number of PureExtern functions we didn't handle (notably sin and cos, but many others too); rather than add even more if-else clauses, I refactored the PureExtern case into a set of LUTs to reduce redundant code.

Note that the actual motivation for this change was to ensure that sin(CONSTANT) and cos(CONSTANT) got simplified to a real constant (rather than putting us at the mercy of LLVM).

(With more cleverness we could make it a single LUT, but my first approach involved template-fu that was overly complex to read; I suspect that this approach is a better balance of compile time vs code complexity, but would welcome someone more clever to simplify it further.)