### PR TITLE
Rename/clarify the Hexagon argument 'buffer_t' type

### DIFF
--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -854,7 +854,8 @@ class InjectHexagonRpc : public IRMutator {
 
         for (const auto &i : c.buffers) {
             // Buffers are passed to the hexagon host runtime as just device
-            // handles (uint64) and host (uint8*) fields.
+            // handles (uint64) and host (uint8*) fields. They correspond
+            // to the 'hexagon_arg_buffer_t' struct declared elsewhere.
             if (i.first != scalars_buffer_name) {
                 // If this isn't the scalars buffer, assume it has a '.buffer'
                 // description in the IR.

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -855,7 +855,9 @@ class InjectHexagonRpc : public IRMutator {
         for (const auto &i : c.buffers) {
             // Buffers are passed to the hexagon host runtime as just device
             // handles (uint64) and host (uint8*) fields. They correspond
-            // to the 'hexagon_arg_buffer_t' struct declared elsewhere.
+            // to the 'hexagon_device_pointer' struct declared elsewhere;
+            // we don't use that struct here because it's simple enough that
+            // just using `make_struct`() for it is simpler.
             if (i.first != scalars_buffer_name) {
                 // If this isn't the scalars buffer, assume it has a '.buffer'
                 // description in the IR.

--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -317,8 +317,16 @@ WEAK int map_arguments(void *user_context, int arg_count,
         if ((arg_flags[i] & flag_mask) != flag_value) continue;
         remote_buffer &mapped_arg = mapped_args[mapped_count++];
         if (arg_flags[i] != 0) {
-            uint64_t device = *(uint64_t *)args[i];
-            uint8_t *host = *(uint8_t **)((uint8_t *)args[i] + sizeof(uint64_t));
+            // This is the way that HexagonOffload packages arguments for us;
+            // despite the name, it really has nothing to do with the old 'buffer_t'
+            // type (or the current 'halide_buffer_t' type).
+            struct hexagon_arg_buffer_t {
+                uint64_t dev;
+                uint8_t *host;
+            };
+            const hexagon_arg_buffer_t *b = (hexagon_arg_buffer_t *)args[i];
+            uint64_t device = b->dev;
+            uint8_t *host = b->host;
             if (device) {
                 // This argument has a device handle.
                 ion_device_handle *ion_handle = reinterpret<ion_device_handle *>(device);

--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -317,14 +317,12 @@ WEAK int map_arguments(void *user_context, int arg_count,
         if ((arg_flags[i] & flag_mask) != flag_value) continue;
         remote_buffer &mapped_arg = mapped_args[mapped_count++];
         if (arg_flags[i] != 0) {
-            // This is the way that HexagonOffload packages arguments for us;
-            // despite the name, it really has nothing to do with the old 'buffer_t'
-            // type (or the current 'halide_buffer_t' type).
-            struct hexagon_arg_buffer_t {
+            // This is the way that HexagonOffload packages arguments for us.
+            struct hexagon_device_pointer {
                 uint64_t dev;
                 uint8_t *host;
             };
-            const hexagon_arg_buffer_t *b = (hexagon_arg_buffer_t *)args[i];
+            const hexagon_device_pointer *b = (hexagon_device_pointer *)args[i];
             uint64_t device = b->dev;
             uint8_t *host = b->host;
             if (device) {

--- a/src/runtime/hexagon_remote/halide_remote.cpp
+++ b/src/runtime/hexagon_remote/halide_remote.cpp
@@ -378,21 +378,19 @@ int halide_hexagon_remote_run_v2(handle_t module_ptr, handle_t function,
     // Get a pointer to the argv version of the pipeline.
     pipeline_argv_t pipeline = reinterpret_cast<pipeline_argv_t>(function);
 
-    // Construct a list of arguments. This is only part of a
-    // buffer_t. We know that the only field of buffer_t that the
-    // generated code should access is the host field (any other
-    // fields should be passed as their own scalar parameters) so we
-    // can just make this dummy buffer_t type.
-    struct buffer_t {
+    // Construct a list of arguments. This is the way that HexagonOffload
+    // packages arguments for us; despite the name, it really has nothing
+    // to do with the old 'buffer_t' type (or the current 'halide_buffer_t' type).
+    struct hexagon_arg_buffer_t {
         uint64_t dev;
         uint8_t *host;
     };
 
     void **args = NULL;
-    buffer_t *buffers = NULL;
+    hexagon_arg_buffer_t *buffers = NULL;
 
     size_t args_size = (input_buffersLen + scalarsLen + output_buffersLen) * sizeof(void *);
-    size_t buffers_size = (input_buffersLen + output_buffersLen) * sizeof(buffer_t);
+    size_t buffers_size = (input_buffersLen + output_buffersLen) * sizeof(hexagon_arg_buffer_t);
 
     // Threshold to allocate on heap vs stack.
     const size_t heap_allocation_threshold = 1024;
@@ -400,14 +398,15 @@ int halide_hexagon_remote_run_v2(handle_t module_ptr, handle_t function,
 
     if (allocated_on_heap) {
         args = (void **)malloc(args_size);
-        buffers = (buffer_t *)malloc(buffers_size);
+        buffers = (hexagon_arg_buffer_t *)malloc(buffers_size);
     } else {
         args = (void **)__builtin_alloca(args_size);
-        buffers = (buffer_t *)__builtin_alloca(buffers_size);
+        buffers = (hexagon_arg_buffer_t *)__builtin_alloca(buffers_size);
     }
+    memset(buffers, 0, buffers_size);
 
     void **next_arg = &args[0];
-    buffer_t *next_buffer_t = &buffers[0];
+    hexagon_arg_buffer_t *next_buffer_t = &buffers[0];
     // Input buffers come first.
     for (int i = 0; i < input_buffersLen; i++, next_arg++, next_buffer_t++) {
         next_buffer_t->host = input_buffersPtrs[i].data;

--- a/src/runtime/hexagon_remote/sim_remote.cpp
+++ b/src/runtime/hexagon_remote/sim_remote.cpp
@@ -140,23 +140,21 @@ int run(handle_t module_ptr, handle_t function,
     typedef int (*pipeline_argv_t)(void **);
     pipeline_argv_t pipeline = reinterpret_cast<pipeline_argv_t>(function);
 
-    // Construct a list of arguments. This is the way that HexagonOffload
-    // packages arguments for us; despite the name, it really has nothing
-    // to do with the old 'buffer_t' type (or the current 'halide_buffer_t' type).
-    struct hexagon_arg_buffer_t {
+    // Construct a list of arguments.
+    struct hexagon_device_pointer {
         uint64_t dev;
         uint8_t *host;
     };
 
     size_t args_size = (input_buffersLen + input_scalarsLen + output_buffersLen) * sizeof(void *);
-    size_t buffers_size = (input_buffersLen + output_buffersLen) * sizeof(hexagon_arg_buffer_t);
+    size_t buffers_size = (input_buffersLen + output_buffersLen) * sizeof(hexagon_device_pointer);
 
     void **args = (void **)__builtin_alloca(args_size);
-    hexagon_arg_buffer_t *buffers = (hexagon_arg_buffer_t *)__builtin_alloca(buffers_size);
+    hexagon_device_pointer *buffers = (hexagon_device_pointer *)__builtin_alloca(buffers_size);
     memset(buffers, 0, buffers_size);
 
     void **next_arg = &args[0];
-    hexagon_arg_buffer_t *next_buffer_t = &buffers[0];
+    hexagon_device_pointer *next_buffer_t = &buffers[0];
     // Input buffers come first.
     for (int i = 0; i < input_buffersLen; i++, next_arg++, next_buffer_t++) {
         next_buffer_t->host = input_buffersPtrs[i].data;

--- a/src/runtime/hexagon_remote/sim_remote.cpp
+++ b/src/runtime/hexagon_remote/sim_remote.cpp
@@ -140,20 +140,23 @@ int run(handle_t module_ptr, handle_t function,
     typedef int (*pipeline_argv_t)(void **);
     pipeline_argv_t pipeline = reinterpret_cast<pipeline_argv_t>(function);
 
-    // Construct a list of arguments. This is only part of a
-    // buffer_t. We know that the only field of buffer_t that the
-    // generated code should access is the host field (any other
-    // fields should be passed as their own scalar parameters) so we
-    // can just make this dummy buffer_t type.
-    struct buffer_t {
+    // Construct a list of arguments. This is the way that HexagonOffload
+    // packages arguments for us; despite the name, it really has nothing
+    // to do with the old 'buffer_t' type (or the current 'halide_buffer_t' type).
+    struct hexagon_arg_buffer_t {
         uint64_t dev;
         uint8_t *host;
     };
-    void **args = (void **)__builtin_alloca((input_buffersLen + input_scalarsLen + output_buffersLen) * sizeof(void *));
-    buffer_t *buffers = (buffer_t *)__builtin_alloca((input_buffersLen + output_buffersLen) * sizeof(buffer_t));
+
+    size_t args_size = (input_buffersLen + input_scalarsLen + output_buffersLen) * sizeof(void *);
+    size_t buffers_size = (input_buffersLen + output_buffersLen) * sizeof(hexagon_arg_buffer_t);
+
+    void **args = (void **)__builtin_alloca(args_size);
+    hexagon_arg_buffer_t *buffers = (hexagon_arg_buffer_t *)__builtin_alloca(buffers_size);
+    memset(buffers, 0, buffers_size);
 
     void **next_arg = &args[0];
-    buffer_t *next_buffer_t = &buffers[0];
+    hexagon_arg_buffer_t *next_buffer_t = &buffers[0];
     // Input buffers come first.
     for (int i = 0; i < input_buffersLen; i++, next_arg++, next_buffer_t++) {
         next_buffer_t->host = input_buffersPtrs[i].data;


### PR DESCRIPTION
We currently use an odd subset of the classic 'buffer_t' type in the HVX arg-passing code; despite its name, it doesn't appear to ever we used as an old 'buffer_t' (which is good, since it's too small and would likely cause crashes). As far as I can tell, it's just a two-entry struct that is used exclusively to pass arg info from host->hvx (or host->sim). Since the old buffer_t type is long-deprecated (and hopefully going to go away entirely soon), let's avoid any possible confusion by renaming it to `hexagon_arg_buffer_t` in hexagon_remove and sim_remote, and by declaring and using it in hexagon_host.cpp (rather than unpacking the fields directly).

HexagonOffload.cpp could arguably use the same struct, but I didn't bother, instead just documenting the correspondence with a comment.