### PR TITLE
Use string literals instead of byte arrays for embedded blobs

### DIFF
--- a/tools/binary2cpp.cpp
+++ b/tools/binary2cpp.cpp
@@ -48,7 +48,7 @@ int main(int argc, const char **argv) {
         if (c == EOF) break;
         printf("\\x%02x", c);
         // Not necessary, but makes a bit easier to read
-        if (++line_break > 12) {
+        if (++line_break > 16) {
             printf("\"\n\"");
             line_break = 0;
         }

--- a/tools/binary2cpp.cpp
+++ b/tools/binary2cpp.cpp
@@ -24,7 +24,7 @@ int main(int argc, const char **argv) {
             printf("#ifndef _H_%s_binary2cpp\n", target);
             printf("#define _H_%s_binary2cpp\n", target);
             printf("extern \"C\" {\n");
-            printf("extern unsigned char %s[];\n", target);
+            printf("extern const char %s[];\n", target);
             printf("extern int %s_length;\n", target);
             printf("}  // extern \"C\"\n");
             printf("#endif  // _H_%s_binary2cpp\n", target);
@@ -40,21 +40,21 @@ int main(int argc, const char **argv) {
     setmode(fileno(stdin), O_BINARY);  // On windows bad things will happen unless we read stdin in binary mode
 #endif
     printf("extern \"C\" {\n");
-    printf("unsigned char %s[] = {\n", target);
+    printf("extern const char %s[] = \n\"", target);
     int count = 0;
     int line_break = 0;
     while (1) {
         int c = getchar();
         if (c == EOF) break;
-        printf("0x%02x, ", c);
+        printf("\\x%02x", c);
         // Not necessary, but makes a bit easier to read
         if (++line_break > 12) {
-            printf("\n");
+            printf("\"\n\"");
             line_break = 0;
         }
         count++;
     }
-    printf("0};\n");
+    printf("\";\n");
     printf("int %s_length = %d;\n", target, count);
     printf("}  // extern \"C\"\n");
     return 0;


### PR DESCRIPTION
This is a PR to speed up compilation of the compiler very slightly, using a trick I read about recently (but am sadly unable to find again, or I would cite the page).

Using string literals instead of arrays for embedded blobs speeds up compilation of the runtime modules, because a string literal is a single AST node in C++, but an array initializer needs an AST node per array entry and all the compiler overhead that entails.

For our largest runtime module (d3d12compute_64_debug), compiling the generated .cpp file takes 0.98s in master and hits 205k peak memory use. In this branch it takes 0.05s and only uses 57k, so it's a 20x speedup.

Of course this is far from the long pole in compilation of the Halide compiler, so any end-to-end benefit is lost in the noise of a big parallel compilation. Might save a few seconds, or more on our less beefy buildbots.