### PR TITLE
Fix case where there are more threads dimensions than blocks dimensions

### DIFF
--- a/test/correctness/gpu_different_blocks_threads_dimensions.cpp
+++ b/test/correctness/gpu_different_blocks_threads_dimensions.cpp
@@ -1,0 +1,34 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    if (!get_jit_target_from_environment().has_gpu_feature()) {
+        printf("No gpu target enabled. Skipping test.\n");
+        return 0;
+    }
+
+    Func f, g;
+    Var x, y, xi, yi;
+    f(x, y) = x + y;
+    g(x, y) = f(x, y);
+
+    // At one point in time, FuseGPUThreadLoops assumed that the
+    // number of blocks dimensions matched the number of threads
+    // dimensions. This test checks that things still work if they're
+    // mismatched.
+
+    g.tile(x, y, xi, yi, 16, 16)
+        .gpu_blocks(y)
+        .gpu_threads(xi, yi);
+
+    f.compute_at(g, x)
+        .store_in(MemoryType::Heap)
+        .gpu_threads(x, y);
+
+    g.compile_jit();
+
+    printf("Success!\n");
+
+    return 0;
+}


### PR DESCRIPTION
Found a bad assumption in the recent store_in support for GPUs. This PR fixes it and adds a test case that previously failed with an internal error.