### PR TITLE
Refactor of configure_pipeline_features() to avoid libHalide dependency

### DIFF
--- a/apps/autoscheduler/CostModel.h
+++ b/apps/autoscheduler/CostModel.h
@@ -3,10 +3,21 @@
 
 #include <string>
 
+#include "Featurization.h"
 #include "HalideBuffer.h"
 
 // An abstract base class for a cost model.
 namespace Halide {
+
+// This is an interface, not a concrete implementation.
+class PipelineInfo {
+public:
+    virtual ~PipelineInfo() = default;
+
+    virtual std::vector<Internal::PipelineFeatures> pipeline_features() const = 0;
+
+    virtual int num_cores() const = 0;
+};
 
 class CostModel {
 public:
@@ -14,6 +25,8 @@ public:
 
     // Configure the cost model for the algorithm to be scheduled.
     virtual void set_pipeline_features(const Halide::Runtime::Buffer<float> &pipeline_feats, int n) = 0;
+
+    virtual void configure_from_pipeline(const PipelineInfo &pipeline_info) = 0;
 
     // Enqueue a schedule to be evaluated. Returns a buffer of
     // schedule_features that should be filled in by the caller.

--- a/apps/autoscheduler/Weights.h
+++ b/apps/autoscheduler/Weights.h
@@ -1,3 +1,6 @@
+#ifndef WEIGHTS_H
+#define WEIGHTS_H
+
 #include <cstdint>
 #include <iostream>
 #include <string>
@@ -47,3 +50,5 @@ struct Weights {
 
 }  // namespace Internal
 }  // namespace Halide
+
+#endif  // WEIGHTS_H


### PR DESCRIPTION
This is my attempt at an alternate version of https://github.com/halide/Halide/pull/4462 that avoids the need to add a libHalide dependency to retrain_cost_model; this achieves the same immediate goal, though I'm not sure if it has the same long-term goal. Please take a look.