### PR TITLE
Fix duplicate allocation names in gpu kernels

### DIFF
--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -516,7 +516,7 @@ class ExtractSharedAndHeapAllocations : public IRMutator {
 
         // Wrap let expression for any allocations found within
         for (SharedAllocation &s : allocations) {
-            if (expr_uses_var(s.size, op->name) && !s.size_computed_on_host) {
+            if (expr_uses_var(s.size, op->name)) {
                 s.size = Let::make(op->name, op->value, s.size);
                 s.size = simplify(s.size);
             }

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -985,7 +985,7 @@ class ExtractRegisterAllocations : public IRMutator {
             }
         }
 
-        if (op->body.same_as(body)) {
+        if (op->body.same_as(body) && op->value.same_as(value)) {
             return op;
         } else {
             return LetOrLetStmt::make(op->name, value, body);

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -943,7 +943,7 @@ class ExtractRegisterAllocations : public IRMutator {
         for (size_t i = 0; i < op->extents.size(); i++) {
             alloc.size *= op->extents[i];
         }
-        alloc.size = simplify(alloc.size);
+        alloc.size = simplify(mutate(alloc.size));
         alloc.memory_type = op->memory_type;
 
         allocations.push_back(alloc);
@@ -977,17 +977,18 @@ class ExtractRegisterAllocations : public IRMutator {
         ExprOrStmt body = op->body;
 
         body = mutate(op->body);
+        Expr value = mutate(op->value);
 
         for (RegisterAllocation &s : allocations) {
             if (expr_uses_var(s.size, op->name)) {
-                s.size = simplify(Let::make(op->name, op->value, s.size));
+                s.size = simplify(Let::make(op->name, value, s.size));
             }
         }
 
         if (op->body.same_as(body)) {
             return op;
         } else {
-            return LetOrLetStmt::make(op->name, op->value, body);
+            return LetOrLetStmt::make(op->name, value, body);
         }
     }
 

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -387,6 +387,8 @@ class ExtractSharedAndHeapAllocations : public IRMutator {
         }
     }
 
+    int alloc_node_counter = 0;
+
     Stmt visit(const Allocate *op) override {
         user_assert(!op->new_expr.defined())
             << "Allocate node inside GPU kernel has custom new expression.\n"
@@ -410,7 +412,7 @@ class ExtractSharedAndHeapAllocations : public IRMutator {
             << "but is scheduled to live in " << op->memory_type << " memory.\n";
 
         SharedAllocation alloc;
-        alloc.name = op->name;
+        alloc.name = op->name + "." + std::to_string(alloc_node_counter++);
         alloc.type = op->type;
         alloc.liveness = IntInterval(barrier_stage, barrier_stage);
         alloc.size = 1;
@@ -471,7 +473,7 @@ class ExtractSharedAndHeapAllocations : public IRMutator {
             const string &prefix = name_for_memory_type(alloc->memory_type);
 
             if (device_api == DeviceAPI::OpenGLCompute) {
-                return Load::make(op->type, prefix + "_" + op->name,
+                return Load::make(op->type, prefix + "_" + alloc->name,
                                   index, op->image, op->param, predicate, op->alignment);
             } else {
                 return Load::make(op->type, prefix, index,
@@ -493,7 +495,7 @@ class ExtractSharedAndHeapAllocations : public IRMutator {
             Expr value = mutate(op->value);
             const string &prefix = name_for_memory_type(alloc->memory_type);
             if (device_api == DeviceAPI::OpenGLCompute) {
-                return Store::make(prefix + "_" + op->name, value, index,
+                return Store::make(prefix + "_" + alloc->name, value, index,
                                    op->param, predicate, op->alignment);
             } else {
                 return Store::make(prefix, value, index, op->param, predicate, ModulusRemainder());
@@ -505,12 +507,26 @@ class ExtractSharedAndHeapAllocations : public IRMutator {
 
     Stmt visit(const LetStmt *op) override {
         Expr value = mutate(op->value);
+
+        // Set aside the allocations we've found so far.
+        vector<SharedAllocation> old;
+        old.swap(allocations);
+
         Stmt body = mutate(op->body);
 
+        // Wrap let expression for any allocations found within
         for (SharedAllocation &s : allocations) {
-            if (expr_uses_var(s.size, op->name)) {
-                s.size = simplify(Let::make(op->name, op->value, s.size));
+            if (expr_uses_var(s.size, op->name) && !s.size_computed_on_host) {
+                s.size = Let::make(op->name, op->value, s.size);
+                s.size = simplify(s.size);
             }
+        }
+
+        // Add back on the allocations we set aside.
+        if (!allocations.empty()) {
+            allocations.insert(allocations.end(), old.begin(), old.end());
+        } else {
+            allocations.swap(old);
         }
 
         if (op->body.same_as(body) && value.same_as(op->value)) {
@@ -901,6 +917,9 @@ class ExtractRegisterAllocations : public IRMutator {
         }
     }
 
+    int alloc_node_counter = 0;
+    Scope<string> alloc_renaming;
+
     Stmt visit(const Allocate *op) override {
         if (in_lane_loop) {
             return IRMutator::visit(op);
@@ -917,7 +936,7 @@ class ExtractRegisterAllocations : public IRMutator {
         ScopedBinding<int> p(register_allocations, op->name, 0);
 
         RegisterAllocation alloc;
-        alloc.name = op->name;
+        alloc.name = op->name + "." + std::to_string(alloc_node_counter++);
         alloc.type = op->type;
         alloc.size = 1;
         alloc.loop_var = loop_var;
@@ -928,7 +947,29 @@ class ExtractRegisterAllocations : public IRMutator {
         alloc.memory_type = op->memory_type;
 
         allocations.push_back(alloc);
-        return mutate(op->body);
+        {
+            ScopedBinding<string> bind(alloc_renaming, op->name, alloc.name);
+            return mutate(op->body);
+        }
+    }
+
+    Expr visit(const Load *op) override {
+        string new_name = op->name;
+        if (alloc_renaming.contains(op->name)) {
+            new_name = alloc_renaming.get(op->name);
+        }
+        return Load::make(op->type, new_name, mutate(op->index),
+                          op->image, op->param, mutate(op->predicate),
+                          op->alignment);
+    }
+
+    Stmt visit(const Store *op) override {
+        string new_name = op->name;
+        if (alloc_renaming.contains(op->name)) {
+            new_name = alloc_renaming.get(op->name);
+        }
+        return Store::make(new_name, mutate(op->value), mutate(op->index),
+                           op->param, mutate(op->predicate), op->alignment);
     }
 
     template<typename ExprOrStmt, typename LetOrLetStmt>


### PR DESCRIPTION
This PR fixes two bugs that showed up in random fuzzing of gpu schedules in the gpu autoscheduler work. 

- Register-level allocations within a GPU kernel are hoisted outwards to the top of the kernel, which may cause them to nest with other allocations of the same name (e.g. if something was unrolled). This is usually benign - the original use of these allocations was non-overlapping, so all uses just use the innermost one. Still, it's weird. If the sizes were different somehow it could cause real bugs. This PR uniquely numbers all register-level allocations to avoid collisions.

- let stmts that are necessary for size expressions are also lifted outwards when computing shared/heap memory size outside of the kernel launch. If multiple definitions of the same name exist in non-overlapping places (again, probably due to unrolling), then they get repeatedly rewrapped around a size expression that uses it, causing the simplifier to complain later about things like "let foo = bar in let foo = bar in ... foo ..." This was fixed by only wrapping the lets that would have been in scope.