### PR TITLE
Add support and tests for pmulhrsw ssse3 and avx2 x86 instructions

### DIFF
--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -283,7 +283,7 @@ void CodeGen_X86::visit(const Cast *op) {
          u16((wild_u32x_ * wild_u32x_) / 65536)},
         {Target::AVX2, true, Int(16, 16), 9, "llvm.x86.avx2.pmul.hr.sw",
          i16((((wild_i32x_ * wild_i32x_) + 16384)) / 32768)},
- 
+
         {Target::FeatureEnd, true, Int(16, 8), 0, "llvm.x86.sse2.pmulh.w",
          i16((wild_i32x_ * wild_i32x_) / 65536)},
         {Target::FeatureEnd, true, UInt(16, 8), 0, "llvm.x86.sse2.pmulhu.w",

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -281,11 +281,15 @@ void CodeGen_X86::visit(const Cast *op) {
          i16((wild_i32x_ * wild_i32x_) / 65536)},
         {Target::AVX2, true, UInt(16, 16), 9, "llvm.x86.avx2.pmulhu.w",
          u16((wild_u32x_ * wild_u32x_) / 65536)},
-
+        {Target::AVX2, true, Int(16, 16), 9, "llvm.x86.avx2.pmul.hr.sw",
+         i16((((wild_i32x_ * wild_i32x_) + 16384)) / 32768)},
+ 
         {Target::FeatureEnd, true, Int(16, 8), 0, "llvm.x86.sse2.pmulh.w",
          i16((wild_i32x_ * wild_i32x_) / 65536)},
         {Target::FeatureEnd, true, UInt(16, 8), 0, "llvm.x86.sse2.pmulhu.w",
          u16((wild_u32x_ * wild_u32x_) / 65536)},
+        {Target::SSE41, true, Int(16, 8), 0, "llvm.x86.ssse3.pmul.hr.sw.128",
+         i16((((wild_i32x_ * wild_i32x_) + 16384)) / 32768)},
         // LLVM 6.0+ require using helpers from x86.ll, x86_avx.ll
         {Target::AVX2, true, UInt(8, 32), 17, "pavgbx32",
          u8(((wild_u16x_ + wild_u16x_) + 1) / 2)},

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -106,6 +106,7 @@ public:
             check("pmulhw", 4 * w, i16((i32(i16_1) * i32(i16_2)) >> cast<int>(16)));
             check("pmulhw", 4 * w, i16((i32(i16_1) * i32(i16_2)) << cast<int>(-16)));
 
+
             // Add a test with a constant as there was a bug on this.
             check("pmulhw", 4 * w, i16((3 * i32(i16_2)) / (256 * 256)));
 
@@ -232,6 +233,7 @@ public:
         // SSSE 3
         if (use_ssse3) {
             for (int w = 2; w <= 4; w++) {
+                check("pmulhrsw", 4 * w, i16((((i32(i16_1) * i32(i16_2)) + 16384)) / 32768));
                 check("pabsb", 8 * w, abs(i8_1));
                 check("pabsw", 4 * w, abs(i16_1));
                 check("pabsd", 2 * w, abs(i32_1));
@@ -369,6 +371,8 @@ public:
             check("vpmulhw*ymm", 16, i16((i32(i16_1) * i32(i16_2)) >> cast<int>(16)));
             check("vpmulhw*ymm", 16, i16((i32(i16_1) * i32(i16_2)) << cast<int>(-16)));
             check("vpmullw*ymm", 16, i16_1 * i16_2);
+
+            check("vpmulhrsw*ymm", 16, i16((((i32(i16_1) * i32(i16_2)) + 16384)) / 32768) );
 
             check("vpcmp*b*ymm", 32, select(u8_1 == u8_2, u8(1), u8(2)));
             check("vpcmp*b*ymm", 32, select(u8_1 > u8_2, u8(1), u8(2)));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -106,7 +106,6 @@ public:
             check("pmulhw", 4 * w, i16((i32(i16_1) * i32(i16_2)) >> cast<int>(16)));
             check("pmulhw", 4 * w, i16((i32(i16_1) * i32(i16_2)) << cast<int>(-16)));
 
-
             // Add a test with a constant as there was a bug on this.
             check("pmulhw", 4 * w, i16((3 * i32(i16_2)) / (256 * 256)));
 
@@ -372,7 +371,7 @@ public:
             check("vpmulhw*ymm", 16, i16((i32(i16_1) * i32(i16_2)) << cast<int>(-16)));
             check("vpmullw*ymm", 16, i16_1 * i16_2);
 
-            check("vpmulhrsw*ymm", 16, i16((((i32(i16_1) * i32(i16_2)) + 16384)) / 32768) );
+            check("vpmulhrsw*ymm", 16, i16((((i32(i16_1) * i32(i16_2)) + 16384)) / 32768));
 
             check("vpcmp*b*ymm", 32, select(u8_1 == u8_2, u8(1), u8(2)));
             check("vpcmp*b*ymm", 32, select(u8_1 > u8_2, u8(1), u8(2)));


### PR DESCRIPTION
The tests are:
  correctness_simd_op_check pmulhrsw
  correctness_simd_op_check vpmulhrsw*ymm