### PR TITLE
Log Target info in correctness_math

### DIFF
--- a/test/correctness/math.cpp
+++ b/test/correctness/math.cpp
@@ -268,6 +268,9 @@ fun_2(uint32_t, uint32_t, absd, absd)
 }  // namespace
 
 int main(int argc, char **argv) {
+    printf("host is:      %s\n", get_host_target().to_string().c_str());
+    printf("HL_JIT_TARGET is: %s\n", get_jit_target_from_environment().to_string().c_str());
+
     call_1_float_types(abs, 256, -1000, 1000);
     call_1_float_types(sqrt, 256, 0, 1000000);
 


### PR DESCRIPTION
Trying to track down intermittent recent failures in correctness_math; this just adds logging of the current host and JIT targets, similar to what is already done in simd_op_check.