### PR TITLE
Fix macOS static library issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -962,9 +962,9 @@ all: distrib test_internal
 # we need a different invocation to get the
 # linker map file.
 ifeq ($(UNAME), Darwin)
-    MAP_FLAG=-map
+    MAP_FLAGS= -Wl,-map -Wl,$(BUILD_DIR)/llvm_objects/list.all
 else
-    MAP_FLAG=-Map
+    MAP_FLAGS= -Wl,-Map=$(BUILD_DIR)/llvm_objects/list.all
 endif
 
 $(BUILD_DIR)/llvm_objects/list: $(OBJECTS) $(INITIAL_MODULES)
@@ -973,7 +973,7 @@ $(BUILD_DIR)/llvm_objects/list: $(OBJECTS) $(INITIAL_MODULES)
 	# part of the linker map file, the object files in which archives it uses to
 	# resolve symbols. We only care about the libLLVM ones, which we will filter below.
 	@mkdir -p $(@D)
-	$(CXX) -o /dev/null -shared -Wl,$(MAP_FLAG) -Wl,$(BUILD_DIR)/llvm_objects/list.all $(OBJECTS) $(INITIAL_MODULES) $(LLVM_STATIC_LIBS) $(LLVM_SYSTEM_LIBS) $(COMMON_LD_FLAGS) 2>&1 > /dev/null
+	$(CXX) -o /dev/null -shared $(MAP_FLAGS) $(OBJECTS) $(INITIAL_MODULES) $(LLVM_STATIC_LIBS) $(LLVM_SYSTEM_LIBS) $(COMMON_LD_FLAGS) 2>&1 > /dev/null
 	# if the list has changed since the previous build, or there
 	# is no list from a previous build, then delete any old object
 	# files and re-extract the required object files

--- a/Makefile
+++ b/Makefile
@@ -958,13 +958,22 @@ endif
 .PHONY: all
 all: distrib test_internal
 
+# Depending on which linker we're using,
+# we need a different invocation to get the
+# linker map file.
+ifeq ($(UNAME), Darwin)
+    MAP_FLAG=-map
+else
+    MAP_FLAG=-Map
+endif
+
 $(BUILD_DIR)/llvm_objects/list: $(OBJECTS) $(INITIAL_MODULES)
 	# Determine the relevant object files from llvm with a dummy
 	# compilation. Passing -map to the linker gets it to list, as
 	# part of the linker map file, the object files in which archives it uses to
 	# resolve symbols. We only care about the libLLVM ones, which we will filter below.
 	@mkdir -p $(@D)
-	$(CXX) -o /dev/null -shared -Wl,-map -Wl,$(BUILD_DIR)/llvm_objects/list.all $(OBJECTS) $(INITIAL_MODULES) $(LLVM_STATIC_LIBS) $(LLVM_SYSTEM_LIBS) $(COMMON_LD_FLAGS) 2>&1 > /dev/null
+	$(CXX) -o /dev/null -shared -Wl,$(MAP_FLAG) -Wl,$(BUILD_DIR)/llvm_objects/list.all $(OBJECTS) $(INITIAL_MODULES) $(LLVM_STATIC_LIBS) $(LLVM_SYSTEM_LIBS) $(COMMON_LD_FLAGS) 2>&1 > /dev/null
 	# if the list has changed since the previous build, or there
 	# is no list from a previous build, then delete any old object
 	# files and re-extract the required object files

--- a/Makefile
+++ b/Makefile
@@ -978,7 +978,7 @@ $(BUILD_DIR)/llvm_objects/list: $(OBJECTS) $(INITIAL_MODULES)
 	# is no list from a previous build, then delete any old object
 	# files and re-extract the required object files
 	cd $(BUILD_DIR)/llvm_objects; \
-	cat list.all |  grep "\[" |  grep "libLLVM" | grep ")"  | sed "s/\[.*\] //" > list.new; \
+	cat list.all |  grep "libLLVM" | grep ")"  | sed "s/\[.*\] //" | grep "^/" > list.new; \
 	rm list.all; \
 	if cmp -s list.new list; \
 	then \

--- a/Makefile
+++ b/Makefile
@@ -970,6 +970,8 @@ ifeq ($(OS), Windows_NT)
     # compilation fails with a file truncation error.  Instead,
     # we use the old strategy.
     # Note: we do in fact have to pass in this flag twice.
+    # Note: The grep in this line is necessary in order to avoid file truncation errors
+    # in MinGW.
     MAP_FLAGS= -Wl,-t -Wl,-t
     LIST_OUTPUT = 2>&1 | grep "libLLVM" | grep ")" > $(BUILD_DIR)/llvm_objects/list.all
 else

--- a/Makefile
+++ b/Makefile
@@ -963,8 +963,18 @@ all: distrib test_internal
 # linker map file.
 ifeq ($(UNAME), Darwin)
     MAP_FLAGS= -Wl,-map -Wl,$(BUILD_DIR)/llvm_objects/list.all
+    LIST_OUTPUT = /dev/null
+else
+ifeq ($(OS), Windows_NT)
+    # This is for MinGW: the map file gets written, but the
+    # compilation fails with a file truncation error.  Instead,
+    # we use the old strategy.
+    MAP_FLAGS= -Wl,-t
+    LIST_OUTPUT = $(BUILD_DIR)/llvm_objects/list.all
 else
     MAP_FLAGS= -Wl,-Map=$(BUILD_DIR)/llvm_objects/list.all
+    LIST_OUTPUT = /dev/null
+endif
 endif
 
 $(BUILD_DIR)/llvm_objects/list: $(OBJECTS) $(INITIAL_MODULES)
@@ -973,7 +983,7 @@ $(BUILD_DIR)/llvm_objects/list: $(OBJECTS) $(INITIAL_MODULES)
 	# part of the linker map file, the object files in which archives it uses to
 	# resolve symbols. We only care about the libLLVM ones, which we will filter below.
 	@mkdir -p $(@D)
-	$(CXX) -o /dev/null -shared $(MAP_FLAGS) $(OBJECTS) $(INITIAL_MODULES) $(LLVM_STATIC_LIBS) $(LLVM_SYSTEM_LIBS) $(COMMON_LD_FLAGS) 2>&1 > /dev/null
+	$(CXX) -o /dev/null -shared $(MAP_FLAGS) $(OBJECTS) $(INITIAL_MODULES) $(LLVM_STATIC_LIBS) $(LLVM_SYSTEM_LIBS) $(COMMON_LD_FLAGS) > $(LIST_OUTPUT)
 	# if the list has changed since the previous build, or there
 	# is no list from a previous build, then delete any old object
 	# files and re-extract the required object files

--- a/apps/blur/Makefile
+++ b/apps/blur/Makefile
@@ -3,9 +3,11 @@ include ../support/Makefile.inc
 .PHONY: build clean test
 build: $(BIN)/$(HL_TARGET)/test
 
-$(GENERATOR_BIN)/halide_blur.generator: halide_blur_generator.cpp $(GENERATOR_DEPS)
+# In order to ensure our static library works, we arbitrarily link against
+# the static library for this app.
+$(GENERATOR_BIN)/halide_blur.generator: halide_blur_generator.cpp $(GENERATOR_DEPS_STATIC)
 	@mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) $(filter %.cpp,$^) -o $@ $(GENERATOR_LDFLAGS)
+	$(CXX) $(CXXFLAGS) $(filter %.cpp,$^) -o $@ $(GENERATOR_LDFLAGS_STATIC)
 
 $(BIN)/%/halide_blur.a: $(GENERATOR_BIN)/halide_blur.generator
 	@mkdir -p $(@D)

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -128,10 +128,12 @@ LDFLAGS-$(HL_TARGET) ?= $(LDFLAGS)
 LDFLAGS-arm-64-android ?= -llog -fPIE -pie
 LDFLAGS-arm-32-android ?= -llog -fPIE -pie
 
+LIB_HALIDE_STATIC = $(HALIDE_DISTRIB_PATH)/lib/libHalide.a
+
 ifeq ($(OS), Windows_NT)
 
 # TODO: copy libHalide.dll somewhere that windows can find it, and use it instead
-LIB_HALIDE = $(HALIDE_DISTRIB_PATH)/lib/libHalide.a
+LIB_HALIDE = $(LIB_HALIDE_STATIC)
 
 else
 
@@ -140,9 +142,11 @@ LIB_HALIDE = $(HALIDE_DISTRIB_PATH)/bin/libHalide.$(SHARED_EXT)
 endif
 
 GENERATOR_DEPS ?= $(LIB_HALIDE) $(HALIDE_DISTRIB_PATH)/include/Halide.h $(HALIDE_DISTRIB_PATH)/tools/GenGen.cpp
+GENERATOR_DEPS_STATIC ?= $(LIB_HALIDE_STATIC) $(HALIDE_DISTRIB_PATH)/include/Halide.h $(HALIDE_DISTRIB_PATH)/tools/GenGen.cpp
 
 # Generators which use autoscheduler plugin need to specify the linker where to find libHalide.so required by the plugin.
 GENERATOR_LDFLAGS ?= -Wl,-rpath,$(dir $(LIB_HALIDE)) -L $(dir $(LIB_HALIDE)) -lHalide $(LDFLAGS)
+GENERATOR_LDFLAGS_STATIC ?=  -L $(dir $(LIB_HALIDE_STATIC)) -lHalide $(LDFLAGS)
 
 LIBPNG_LIBS_DEFAULT = $(shell libpng-config --ldflags)
 LIBPNG_CXX_FLAGS ?= $(shell libpng-config --cflags)


### PR DESCRIPTION
An attempt to address #4574.

This uses map files from the linker to determine the object files needed for
the static library,instead of the output from -t, which was being truncated on
macOS, likely due to the linker not flushing standard output.

It's possible some versions of the gnu tools require `-Map` instead of `-map`, but both seem to work on my system.

If this works for Makefiles, then a remaining todo is to apply this to cmake as well.

CC @mikewoodworth 