### PR TITLE
Add host_supports_device_api()

### DIFF
--- a/src/DeviceInterface.cpp
+++ b/src/DeviceInterface.cpp
@@ -30,6 +30,34 @@ bool lookup_runtime_routine(const std::string &name,
 
 }  // namespace
 
+bool host_supports_device_api(DeviceAPI d, const Target &t) {
+    const struct halide_device_interface_t *i = get_device_interface_for_device_api(d, t);
+    if (!i) {
+        debug(1) << "host_supports_device_api: get_device_interface_for_device_api() failed for d=" << (int)d << " t=" << t << "\n";
+        return false;
+    }
+
+    Halide::Runtime::Buffer<uint8_t> temp(8, 8, 3);
+    temp.fill(0);
+    temp.set_host_dirty();
+
+    Halide::Internal::JITHandlers handlers;
+    handlers.custom_error = [](void *user_context, const char *msg) {
+        debug(1) << "host_supports_device_api: saw error (" << msg << ")\n";
+    };
+    Halide::Internal::JITHandlers old_handlers = Halide::Internal::JITSharedRuntime::set_default_handlers(handlers);
+
+    int result = temp.copy_to_device(i);
+
+    Halide::Internal::JITSharedRuntime::set_default_handlers(old_handlers);
+
+    if (result != 0) {
+        debug(1) << "host_supports_device_api: copy_to_device() failed for with result=" << result << " for d=" << (int)d << " t=" << t << "\n";
+        return false;
+    }
+    return true;
+}
+
 const halide_device_interface_t *get_device_interface_for_device_api(DeviceAPI d,
                                                                      const Target &t,
                                                                      const char *error_site) {

--- a/src/DeviceInterface.cpp
+++ b/src/DeviceInterface.cpp
@@ -30,7 +30,12 @@ bool lookup_runtime_routine(const std::string &name,
 
 }  // namespace
 
-bool host_supports_device_api(DeviceAPI d, const Target &t) {
+bool host_supports_target_device(const Target &t) {
+    const DeviceAPI d = t.get_required_device_api();
+    if (d == DeviceAPI::None) {
+        return true;
+    }
+
     const struct halide_device_interface_t *i = get_device_interface_for_device_api(d, t);
     if (!i) {
         debug(1) << "host_supports_device_api: get_device_interface_for_device_api() failed for d=" << (int)d << " t=" << t << "\n";

--- a/src/DeviceInterface.h
+++ b/src/DeviceInterface.h
@@ -26,14 +26,14 @@ const halide_device_interface_t *get_device_interface_for_device_api(DeviceAPI d
  * is enabled in the target, returns DeviceAPI::Host. */
 DeviceAPI get_default_device_api_for_target(const Target &t);
 
-/** This attempts to sniff whether the given DeviceAPI/Target combination is usable on
+/** This attempts to sniff whether a given Target (and its implied DeviceAPI) is usable on
  * the current host. If it appears to be usable, return true; if not, return false.
  * Note that a return value of true does *not* guarantee that future usage of
  * that device will succeed; it is intended mainly as a simple diagnostic
  * to allow early-exit when a desired device is definitely not usable.
  * Also note that this call is *NOT* threadsafe, as it temporarily redirect various
  * global error-handling hooks in Halide. */
-bool host_supports_device_api(DeviceAPI d, const Target &t);
+bool host_supports_target_device(const Target &t);
 
 namespace Internal {
 /** Get an Expr which evaluates to the device interface for the given device api at runtime. */

--- a/src/DeviceInterface.h
+++ b/src/DeviceInterface.h
@@ -26,6 +26,15 @@ const halide_device_interface_t *get_device_interface_for_device_api(DeviceAPI d
  * is enabled in the target, returns DeviceAPI::Host. */
 DeviceAPI get_default_device_api_for_target(const Target &t);
 
+/** This attempts to sniff whether the given DeviceAPI/Target combination is usable on
+ * the current host. If it appears to be usable, return true; if not, return false.
+ * Note that a return value of true does *not* guarantee that future usage of
+ * that device will succeed; it is intended mainly as a simple diagnostic
+ * to allow early-exit when a desired device is definitely not usable.
+ * Also note that this call is *NOT* threadsafe, as it temporarily redirect various
+ * global error-handling hooks in Halide. */
+bool host_supports_device_api(DeviceAPI d, const Target &t);
+
 namespace Internal {
 /** Get an Expr which evaluates to the device interface for the given device api at runtime. */
 Expr make_device_interface_call(DeviceAPI device_api);

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -783,6 +783,18 @@ bool Target::supports_device_api(DeviceAPI api) const {
     }
 }
 
+DeviceAPI Target::get_required_device_api() const {
+    if (has_feature(Target::CUDA)) return DeviceAPI::CUDA;
+    if (has_feature(Target::D3D12Compute)) return DeviceAPI::D3D12Compute;
+    if (has_feature(Target::HVX_128)) return DeviceAPI::Hexagon;
+    if (has_feature(Target::HexagonDma)) return DeviceAPI::HexagonDma;
+    if (has_feature(Target::Metal)) return DeviceAPI::Metal;
+    if (has_feature(Target::OpenCL)) return DeviceAPI::OpenCL;
+    if (has_feature(Target::OpenGL)) return DeviceAPI::GLSL;
+    if (has_feature(Target::OpenGLCompute)) return DeviceAPI::OpenGLCompute;
+    return DeviceAPI::None;
+}
+
 Target::Feature target_feature_for_device_api(DeviceAPI api) {
     switch (api) {
     case DeviceAPI::CUDA:

--- a/src/Target.h
+++ b/src/Target.h
@@ -203,6 +203,12 @@ struct Target {
      * Target. */
     bool supports_device_api(DeviceAPI api) const;
 
+    /** If this Target (including all Features) requires a specific DeviceAPI,
+     * return it. If it doesn't, return DeviceAPI::None.  If the Target has
+     * features with multiple (different) DeviceAPI requirements, the result
+     * will be an arbitrary DeviceAPI. */
+    DeviceAPI get_required_device_api() const;
+
     bool operator==(const Target &other) const {
         return os == other.os &&
                arch == other.arch &&

--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -339,6 +339,11 @@ WEAK int create_opencl_context(void *user_context, cl_context *ctx, cl_command_q
     halide_assert(user_context, ctx != NULL && *ctx == NULL);
     halide_assert(user_context, q != NULL && *q == NULL);
 
+    if (clGetPlatformIDs == NULL) {
+        error(user_context) << "CL: clGetPlatformIDs not found\n";
+        return -1;
+    }
+
     cl_int err = 0;
 
     const cl_uint max_platforms = 4;

--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -246,14 +246,14 @@ class ClContext {
 public:
     cl_context context;
     cl_command_queue cmd_queue;
-    cl_int error;
+    cl_int error_code;
 
-    // Constructor sets 'error' if any occurs.
+    // Constructor sets 'error_code' if any occurs.
     INLINE ClContext(void *user_context)
         : user_context(user_context),
           context(NULL),
           cmd_queue(NULL),
-          error(CL_SUCCESS) {
+          error_code(CL_SUCCESS) {
         if (clCreateContext == NULL) {
             load_libopencl(user_context);
         }
@@ -262,11 +262,11 @@ public:
         halide_start_clock(user_context);
 #endif
 
-        error = halide_acquire_cl_context(user_context, &context, &cmd_queue);
+        error_code = halide_acquire_cl_context(user_context, &context, &cmd_queue);
         // don't abort: that would prevent host_supports_device_api() from being able work properly.
         if (!context || !cmd_queue) {
             error(user_context) << "OpenCL: null context or cmd_queue";
-            error = -1;
+            error_code = -1;
         }
     }
 
@@ -573,8 +573,8 @@ WEAK int halide_opencl_device_free(void *user_context, halide_buffer_t *buf) {
         << ", buf: " << buf << ") cl_mem: " << dev_ptr << "\n";
 
     ClContext ctx(user_context);
-    if (ctx.error != CL_SUCCESS) {
-        return ctx.error;
+    if (ctx.error_code != CL_SUCCESS) {
+        return ctx.error_code;
     }
 
 #ifdef DEBUG_RUNTIME
@@ -612,8 +612,8 @@ WEAK int halide_opencl_initialize_kernels(void *user_context, void **state_ptr, 
         << ", size: " << size << "\n";
 
     ClContext ctx(user_context);
-    if (ctx.error != CL_SUCCESS) {
-        return ctx.error;
+    if (ctx.error_code != CL_SUCCESS) {
+        return ctx.error_code;
     }
 
 #ifdef DEBUG_RUNTIME
@@ -724,8 +724,8 @@ WEAK int halide_opencl_device_sync(void *user_context, halide_buffer_t *) {
     debug(user_context) << "CL: halide_opencl_device_sync (user_context: " << user_context << ")\n";
 
     ClContext ctx(user_context);
-    if (ctx.error != CL_SUCCESS) {
-        return ctx.error;
+    if (ctx.error_code != CL_SUCCESS) {
+        return ctx.error_code;
     }
 
 #ifdef DEBUG_RUNTIME
@@ -806,8 +806,8 @@ WEAK int halide_opencl_device_malloc(void *user_context, halide_buffer_t *buf) {
         << ", buf: " << buf << ")\n";
 
     ClContext ctx(user_context);
-    if (ctx.error != CL_SUCCESS) {
-        return ctx.error;
+    if (ctx.error_code != CL_SUCCESS) {
+        return ctx.error_code;
     }
 
     size_t size = buf->size_in_bytes();
@@ -948,8 +948,8 @@ WEAK int halide_opencl_buffer_copy(void *user_context, struct halide_buffer_t *s
     int err = 0;
     {
         ClContext ctx(user_context);
-        if (ctx.error != CL_SUCCESS) {
-            return ctx.error;
+        if (ctx.error_code != CL_SUCCESS) {
+            return ctx.error_code;
         }
 
         debug(user_context)
@@ -1012,8 +1012,8 @@ WEAK int halide_opencl_run(void *user_context,
 
     cl_int err;
     ClContext ctx(user_context);
-    if (ctx.error != CL_SUCCESS) {
-        return ctx.error;
+    if (ctx.error_code != CL_SUCCESS) {
+        return ctx.error_code;
     }
 
 #ifdef DEBUG_RUNTIME
@@ -1226,8 +1226,8 @@ WEAK int opencl_device_crop_from_offset(void *user_context,
                                         int64_t offset,
                                         struct halide_buffer_t *dst) {
     ClContext ctx(user_context);
-    if (ctx.error != CL_SUCCESS) {
-        return ctx.error;
+    if (ctx.error_code != CL_SUCCESS) {
+        return ctx.error_code;
     }
 
     dst->device_interface = src->device_interface;
@@ -1276,8 +1276,8 @@ WEAK int halide_opencl_device_release_crop(void *user_context,
         << ", buf: " << buf << ") cl_mem: " << dev_ptr << " offset: " << ((device_handle *)buf->device)->offset << "\n";
 
     ClContext ctx(user_context);
-    if (ctx.error != CL_SUCCESS) {
-        return ctx.error;
+    if (ctx.error_code != CL_SUCCESS) {
+        return ctx.error_code;
     }
 
 #ifdef DEBUG_RUNTIME

--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -263,9 +263,9 @@ public:
 #endif
 
         error = halide_acquire_cl_context(user_context, &context, &cmd_queue);
-        // don't abort: that would prevent host_supports_device_api() from being able
-        // work properly. Setting the error code here should be sufficient.
+        // don't abort: that would prevent host_supports_device_api() from being able work properly.
         if (!context || !cmd_queue) {
+            error(user_context) << "OpenCL: null context or cmd_queue";
             error = -1;
         }
     }

--- a/tutorial/lesson_12_using_the_gpu.cpp
+++ b/tutorial/lesson_12_using_the_gpu.cpp
@@ -283,37 +283,32 @@ int main(int argc, char **argv) {
 
 // A helper function to check if OpenCL, Metal or D3D12 is present on the host machine.
 
-#ifdef _WIN32
-#include <windows.h>
-#else
-#include <dlfcn.h>
-#endif
-
 Target find_gpu_target() {
     // Start with a target suitable for the machine you're running this on.
     Target target = get_host_target();
 
-    // Uncomment the following lines to try CUDA instead:
-    // target.set_feature(Target::CUDA);
-    // return target;
+    std::vector<std::pair<DeviceAPI, Target::Feature>> devices_to_try;
+    if (target.os == Target::Windows) {
+        // Try D3D12 first; if that fails, try OpenCL.
+        devices_to_try.emplace_back(DeviceAPI::D3D12Compute, Target::D3D12Compute);
+        devices_to_try.emplace_back(DeviceAPI::OpenCL, Target::OpenCL);
+    } else if (target.os == Target::OSX) {
+        // OS X doesn't update its OpenCL drivers, so they tend to be broken.
+        // CUDA would also be a fine choice on machines with NVidia GPUs.
+        devices_to_try.emplace_back(DeviceAPI::Metal, Target::Metal);
+    } else {
+        devices_to_try.emplace_back(DeviceAPI::OpenCL, Target::OpenCL);
+    }
+    // Uncomment the following lines to also try CUDA:
+    // devices_to_try.emplace_back(DeviceAPI::CUDA, Target::CUDA);
 
-#ifdef _WIN32
-    if (LoadLibraryA("d3d12.dll") != nullptr) {
-        target.set_feature(Target::D3D12Compute);
-    } else if (LoadLibraryA("OpenCL.dll") != nullptr) {
-        target.set_feature(Target::OpenCL);
+    for (const auto &d : devices_to_try) {
+        Target new_target = target.with_feature(d.second);
+        if (host_supports_device_api(d.first, new_target)) {
+            return new_target;
+        }
     }
-#elif __APPLE__
-    // OS X doesn't update its OpenCL drivers, so they tend to be broken.
-    // CUDA would also be a fine choice on machines with NVidia GPUs.
-    if (dlopen("/System/Library/Frameworks/Metal.framework/Versions/Current/Metal", RTLD_LAZY) != NULL) {
-        target.set_feature(Target::Metal);
-    }
-#else
-    if (dlopen("libOpenCL.so", RTLD_LAZY) != NULL) {
-        target.set_feature(Target::OpenCL);
-    }
-#endif
 
+    printf("Requested GPU(s) are not supported. (Do you have the proper hardware and/or driver installed?)\n");
     return target;
 }

--- a/tutorial/lesson_12_using_the_gpu.cpp
+++ b/tutorial/lesson_12_using_the_gpu.cpp
@@ -287,24 +287,24 @@ Target find_gpu_target() {
     // Start with a target suitable for the machine you're running this on.
     Target target = get_host_target();
 
-    std::vector<std::pair<DeviceAPI, Target::Feature>> devices_to_try;
+    std::vector<Target::Feature> features_to_try;
     if (target.os == Target::Windows) {
         // Try D3D12 first; if that fails, try OpenCL.
-        devices_to_try.emplace_back(DeviceAPI::D3D12Compute, Target::D3D12Compute);
-        devices_to_try.emplace_back(DeviceAPI::OpenCL, Target::OpenCL);
+        features_to_try.push_back(Target::D3D12Compute);
+        features_to_try.push_back(Target::OpenCL);
     } else if (target.os == Target::OSX) {
         // OS X doesn't update its OpenCL drivers, so they tend to be broken.
         // CUDA would also be a fine choice on machines with NVidia GPUs.
-        devices_to_try.emplace_back(DeviceAPI::Metal, Target::Metal);
+        features_to_try.push_back(Target::Metal);
     } else {
-        devices_to_try.emplace_back(DeviceAPI::OpenCL, Target::OpenCL);
+        features_to_try.push_back(Target::OpenCL);
     }
     // Uncomment the following lines to also try CUDA:
-    // devices_to_try.emplace_back(DeviceAPI::CUDA, Target::CUDA);
+    // features_to_try.push_back(Target::CUDA);
 
-    for (const auto &d : devices_to_try) {
-        Target new_target = target.with_feature(d.second);
-        if (host_supports_device_api(d.first, new_target)) {
+    for (Target::Feature f : features_to_try) {
+        Target new_target = target.with_feature(f);
+        if (host_supports_target_device(new_target)) {
             return new_target;
         }
     }

--- a/tutorial/lesson_19_wrapper_funcs.cpp
+++ b/tutorial/lesson_19_wrapper_funcs.cpp
@@ -291,19 +291,16 @@ int main(int argc, char **argv) {
 
         // Select an appropriate GPU API, as we did in lesson 12
         Target target = get_host_target();
-        DeviceAPI d = DeviceAPI::None;
         if (target.os == Target::OSX) {
             target.set_feature(Target::Metal);
-            d = DeviceAPI::Metal;
         } else {
             target.set_feature(Target::OpenCL);
-            d = DeviceAPI::OpenCL;
         }
 
         // This check isn't strictly necessary, but it allows a more graceful
         // exit if running on a system that doesn't have the expected drivers
         // and/or hardware present.
-        if (!host_supports_device_api(d, target)) {
+        if (!host_supports_target_device(target)) {
             printf("Requested GPU is not supported; skipping this test. (Do you have the proper hardware and/or driver installed?)\n");
             return 0;
         }

--- a/tutorial/lesson_19_wrapper_funcs.cpp
+++ b/tutorial/lesson_19_wrapper_funcs.cpp
@@ -291,10 +291,21 @@ int main(int argc, char **argv) {
 
         // Select an appropriate GPU API, as we did in lesson 12
         Target target = get_host_target();
+        DeviceAPI d = DeviceAPI::None;
         if (target.os == Target::OSX) {
             target.set_feature(Target::Metal);
+            d = DeviceAPI::Metal;
         } else {
             target.set_feature(Target::OpenCL);
+            d = DeviceAPI::OpenCL;
+        }
+
+        // This check isn't strictly necessary, but it allows a more graceful
+        // exit if running on a system that doesn't have the expected drivers
+        // and/or hardware present.
+        if (!host_supports_device_api(d, target)) {
+            printf("Requested GPU is not supported; skipping this test. (Do you have the proper hardware and/or driver installed?)\n");
+            return 0;
         }
 
         // Create an interesting input image to use.


### PR DESCRIPTION
This adds a new call, `host_supports_device_api()`, which is intended to allow JIT callers to determine whether a given DeviceAPI is likely supported on the current host. Modified tutorial code to use it as appropriate. (Note that existing logic in e.g. lesson_12 that tries to load driver libraries isn't adequate, as a system may have the right software installed but no suitable hardware.)