### PR TITLE
Updated the CostModel API to take a map of schedule features. 

### DIFF
--- a/apps/autoscheduler/AutoSchedule.cpp
+++ b/apps/autoscheduler/AutoSchedule.cpp
@@ -362,46 +362,11 @@ struct State {
             return false;
         }
 
-        int num_stages = (int)features.size();
-
-        Runtime::Buffer<float> schedule_features;
-
         // Tell the cost model about this state. It won't actually
         // evaluate it until we call evaluate_costs (or if it runs out
         // of internal buffer space), so that the evaluations can be
         // batched.
-        cost_model->enqueue(num_stages, &schedule_features, &cost);
-
-        // index of current stage whose features we are reading
-        int stage = 0;
-        // load schedule features into input buffer
-        for (const auto &n : dag.nodes) {
-
-            // Inputs are computed outside of the pipeline and don't count.
-            if (n.is_input) continue;
-
-            // The remaining stage are not yet
-            // scheduled. Optimistically assume their internal costs
-            // will not depend on the decisions made already, so
-            // there's no point adding it on to the total because it's
-            // the same across all states.  An underestimate of the
-            // cost for loading from these unscheduled stages is
-            // already baked into the scheduled stages that consume
-            // them.
-            if (stage >= num_stages) break;
-
-            // Load up the schedule features for all stages of this Func.
-            for (auto it = n.stages.rbegin(); it != n.stages.rend(); it++) {
-                internal_assert(features.contains(&*it)) << n.func.name() << "\n";
-                const auto &feat = features.get(&*it);
-                for (size_t i = 0; i < ScheduleFeatures::num_features(); i++) {
-                    schedule_features(i, stage) = feat[i];
-                }
-                stage += 1;
-            }
-        }
-        // Check we considered everything we were supposed to.
-        internal_assert(stage == num_stages);
+        cost_model->enqueue(dag, features, &cost);
 
         cost_calculations++;
         return true;

--- a/apps/autoscheduler/CostModel.h
+++ b/apps/autoscheduler/CostModel.h
@@ -5,9 +5,16 @@
 
 #include "FunctionDAG.h"
 #include "HalideBuffer.h"
+#include "PerfectHashMap.h"
 
 // An abstract base class for a cost model.
 namespace Halide {
+
+namespace Internal {
+namespace Autoscheduler {
+typedef PerfectHashMap<FunctionDAG::Node::Stage, ScheduleFeatures> StageMapOfScheduleFeatures;
+}
+}  // namespace Internal
 
 class CostModel {
 public:
@@ -17,9 +24,9 @@ public:
     virtual void set_pipeline_features(const Internal::Autoscheduler::FunctionDAG &dag,
                                        const MachineParams &params) = 0;
 
-    // Enqueue a schedule to be evaluated. Returns a buffer of
-    // schedule_features that should be filled in by the caller.
-    virtual void enqueue(int ns, Halide::Runtime::Buffer<float> *schedule_feats, double *cost_ptr) = 0;
+    // Enqueue a schedule to be evaluated. Will annotate the value located at cost_ptr when the evaluation takes place.
+    // Note that the dag argument should correspond to the dag specified previously when callig set_pipeline_features.
+    virtual void enqueue(const Internal::Autoscheduler::FunctionDAG &dag, const Halide::Internal::Autoscheduler::StageMapOfScheduleFeatures &schedule_feats, double *cost_ptr) = 0;
 
     // Evaluate all schedules in the queue.
     virtual void evaluate_costs() = 0;

--- a/apps/autoscheduler/CostModel.h
+++ b/apps/autoscheduler/CostModel.h
@@ -13,7 +13,7 @@ namespace Halide {
 namespace Internal {
 namespace Autoscheduler {
 typedef PerfectHashMap<FunctionDAG::Node::Stage, ScheduleFeatures> StageMapOfScheduleFeatures;
-}
+}  // namespace Autoscheduler
 }  // namespace Internal
 
 class CostModel {
@@ -25,8 +25,10 @@ public:
                                        const MachineParams &params) = 0;
 
     // Enqueue a schedule to be evaluated. Will annotate the value located at cost_ptr when the evaluation takes place.
-    // Note that the dag argument should correspond to the dag specified previously when callig set_pipeline_features.
-    virtual void enqueue(const Internal::Autoscheduler::FunctionDAG &dag, const Halide::Internal::Autoscheduler::StageMapOfScheduleFeatures &schedule_feats, double *cost_ptr) = 0;
+    // Note that the dag argument should correspond to the dag specified previously when calling set_pipeline_features.
+    virtual void enqueue(const Internal::Autoscheduler::FunctionDAG &dag,
+                         const Halide::Internal::Autoscheduler::StageMapOfScheduleFeatures &schedule_feats,
+                         double *cost_ptr) = 0;
 
     // Evaluate all schedules in the queue.
     virtual void evaluate_costs() = 0;

--- a/apps/autoscheduler/DefaultCostModel.cpp
+++ b/apps/autoscheduler/DefaultCostModel.cpp
@@ -84,6 +84,50 @@ void DefaultCostModel::set_pipeline_features(const Runtime::Buffer<float> &pipel
     num_cores = n;
 }
 
+void DefaultCostModel::enqueue(const Internal::Autoscheduler::FunctionDAG &dag, const Halide::Internal::Autoscheduler::StageMapOfScheduleFeatures &features, double *cost_ptr) {
+    num_stages = (int)features.size();
+
+    Runtime::Buffer<float> schedule_features;
+
+    // Tell the cost model about this state. It won't actually
+    // evaluate it until we call evaluate_costs (or if it runs out
+    // of internal buffer space), so that the evaluations can be
+    // batched.
+    enqueue(num_stages, &schedule_features, cost_ptr);
+
+    // index of current stage whose features we are reading
+    int stage = 0;
+    // load schedule features into input buffer
+    for (const auto &n : dag.nodes) {
+
+        // Inputs are computed outside of the pipeline and don't count.
+        if (n.is_input) continue;
+
+        // The remaining stage are not yet
+        // scheduled. Optimistically assume their internal costs
+        // will not depend on the decisions made already, so
+        // there's no point adding it on to the total because it's
+        // the same across all states.  An underestimate of the
+        // cost for loading from these unscheduled stages is
+        // already baked into the scheduled stages that consume
+        // them.
+        if (stage >= num_stages) break;
+
+        // Load up the schedule features for all stages of this Func.
+        for (auto it = n.stages.rbegin(); it != n.stages.rend(); it++) {
+            internal_assert(features.contains(&*it)) << n.func.name() << "\\
+n";
+            const auto &feat = features.get(&*it);
+            for (size_t i = 0; i < ScheduleFeatures::num_features(); i++) {
+                schedule_features(i, stage) = feat[i];
+            }
+            stage += 1;
+        }
+    }
+    // Check we considered everything we were supposed to.
+    internal_assert(stage == num_stages);
+}
+
 void DefaultCostModel::enqueue(int ns, Runtime::Buffer<float> *schedule_feats, double *cost_ptr) {
     num_stages = ns;
 

--- a/apps/autoscheduler/DefaultCostModel.cpp
+++ b/apps/autoscheduler/DefaultCostModel.cpp
@@ -84,8 +84,10 @@ void DefaultCostModel::set_pipeline_features(const Runtime::Buffer<float> &pipel
     num_cores = n;
 }
 
-void DefaultCostModel::enqueue(const Internal::Autoscheduler::FunctionDAG &dag, const Halide::Internal::Autoscheduler::StageMapOfScheduleFeatures &features, double *cost_ptr) {
-    num_stages = (int)features.size();
+void DefaultCostModel::enqueue(const Internal::Autoscheduler::FunctionDAG &dag,
+                               const Halide::Internal::Autoscheduler::StageMapOfScheduleFeatures &schedule_feats,
+                               double *cost_ptr) {
+    num_stages = (int)schedule_feats.size();
 
     Runtime::Buffer<float> schedule_features;
 
@@ -103,7 +105,7 @@ void DefaultCostModel::enqueue(const Internal::Autoscheduler::FunctionDAG &dag, 
         // Inputs are computed outside of the pipeline and don't count.
         if (n.is_input) continue;
 
-        // The remaining stage are not yet
+        // The remaining stages are not yet
         // scheduled. Optimistically assume their internal costs
         // will not depend on the decisions made already, so
         // there's no point adding it on to the total because it's
@@ -115,9 +117,8 @@ void DefaultCostModel::enqueue(const Internal::Autoscheduler::FunctionDAG &dag, 
 
         // Load up the schedule features for all stages of this Func.
         for (auto it = n.stages.rbegin(); it != n.stages.rend(); it++) {
-            internal_assert(features.contains(&*it)) << n.func.name() << "\\
-n";
-            const auto &feat = features.get(&*it);
+            internal_assert(schedule_feats.contains(&*it)) << n.func.name() << "\\n";
+            const auto &feat = schedule_feats.get(&*it);
             for (size_t i = 0; i < ScheduleFeatures::num_features(); i++) {
                 schedule_features(i, stage) = feat[i];
             }

--- a/apps/autoscheduler/DefaultCostModel.cpp
+++ b/apps/autoscheduler/DefaultCostModel.cpp
@@ -117,7 +117,7 @@ void DefaultCostModel::enqueue(const Internal::Autoscheduler::FunctionDAG &dag,
 
         // Load up the schedule features for all stages of this Func.
         for (auto it = n.stages.rbegin(); it != n.stages.rend(); it++) {
-            internal_assert(schedule_feats.contains(&*it)) << n.func.name() << "\\n";
+            internal_assert(schedule_feats.contains(&*it)) << n.func.name() << "\n";
             const auto &feat = schedule_feats.get(&*it);
             for (size_t i = 0; i < ScheduleFeatures::num_features(); i++) {
                 schedule_features(i, stage) = feat[i];

--- a/apps/autoscheduler/DefaultCostModel.h
+++ b/apps/autoscheduler/DefaultCostModel.h
@@ -40,9 +40,10 @@ public:
                                const MachineParams &params) override;
     void set_pipeline_features(const Runtime::Buffer<float> &, int n);
 
-    // Enqueue a schedule to be evaluated. Returns a buffer of
+    // Enqueue a schedule to be evaluated. The second version of this method returns a buffer of
     // schedule_features that should be filled in by the caller.
-    void enqueue(int ns, Runtime::Buffer<float> *schedule_feats, double *cost_ptr) override;
+    void enqueue(const Internal::Autoscheduler::FunctionDAG &dag, const Halide::Internal::Autoscheduler::StageMapOfScheduleFeatures &schedule_feats, double *cost_ptr) override;
+    void enqueue(int ns, Runtime::Buffer<float> *schedule_feats, double *cost_ptr);
 
     // Evaluate all schedules in the queue.
     void evaluate_costs() override;

--- a/apps/autoscheduler/DefaultCostModel.h
+++ b/apps/autoscheduler/DefaultCostModel.h
@@ -42,7 +42,9 @@ public:
 
     // Enqueue a schedule to be evaluated. The second version of this method returns a buffer of
     // schedule_features that should be filled in by the caller.
-    void enqueue(const Internal::Autoscheduler::FunctionDAG &dag, const Halide::Internal::Autoscheduler::StageMapOfScheduleFeatures &schedule_feats, double *cost_ptr) override;
+    void enqueue(const Internal::Autoscheduler::FunctionDAG &dag,
+                 const Halide::Internal::Autoscheduler::StageMapOfScheduleFeatures &schedule_feats,
+                 double *cost_ptr) override;
     void enqueue(int ns, Runtime::Buffer<float> *schedule_feats, double *cost_ptr);
 
     // Evaluate all schedules in the queue.


### PR DESCRIPTION
This change enables implementations of the cost model to customize the way schedule features are handled.