### PR TITLE
Fix -Map output parsing for lld

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -992,7 +992,7 @@ $(BUILD_DIR)/llvm_objects/list: $(OBJECTS) $(INITIAL_MODULES)
 	# files and re-extract the required object files
 	cd $(BUILD_DIR)/llvm_objects; \
 cat list.all |  grep "libLLVM" | grep ")"  | sed "s/^[^/]*//" | sed 's/):(.*/)/' | egrep "^/|^\(" | sort | uniq > list.new; \
-	cat list.new; \
+	rm list.new; \
 	if cmp -s list.new list; \
 	then \
 	echo "No changes in LLVM deps"; \

--- a/Makefile
+++ b/Makefile
@@ -991,8 +991,8 @@ $(BUILD_DIR)/llvm_objects/list: $(OBJECTS) $(INITIAL_MODULES)
 	# is no list from a previous build, then delete any old object
 	# files and re-extract the required object files
 	cd $(BUILD_DIR)/llvm_objects; \
-	cat list.all |  grep "libLLVM" | grep ")"  | sed "s/\[.*\] //" | egrep "^/|^\(" > list.new; \
-	rm list.all; \
+cat list.all |  grep "libLLVM" | grep ")"  | sed "s/^[^/]*//" | sed 's/):(.*/)/' | egrep "^/|^\(" | sort | uniq > list.new; \
+	cat list.new; \
 	if cmp -s list.new list; \
 	then \
 	echo "No changes in LLVM deps"; \

--- a/Makefile
+++ b/Makefile
@@ -991,8 +991,8 @@ $(BUILD_DIR)/llvm_objects/list: $(OBJECTS) $(INITIAL_MODULES)
 	# is no list from a previous build, then delete any old object
 	# files and re-extract the required object files
 	cd $(BUILD_DIR)/llvm_objects; \
-cat list.all |  grep "libLLVM" | grep ")"  | sed "s/^[^/]*//" | sed 's/):(.*/)/' | egrep "^/|^\(" | sort | uniq > list.new; \
-	rm list.new; \
+	cat list.all |  grep "libLLVM" | grep ")"  | sed "s/^[^/]*//" | sed 's/).(.*/)/' | egrep "^/|^\(" | sort | uniq > list.new; \
+	rm list.all; \
 	if cmp -s list.new list; \
 	then \
 	echo "No changes in LLVM deps"; \


### PR DESCRIPTION
Here's my attempt at fixing scraping llvm objects when the linker is lld. Let's see if it still works with the other linkers. The sed invocations delete up to the first slash, and then delete everything after ):(

@shoaibkamil 