### PR TITLE
Add set(CMAKE_FIND_FRAMEWORK LAST)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,14 @@ endif()
 set(CPACK_PACKAGE_FILE_NAME "Halide" CACHE STRING "Name of package created by distrib target")
 include(CPack)
 
+# This only affects OSX system, and changes how find_xxx() commands work; the default
+# is to find frameworks before standard libraries or headers, but this can be a problem
+# on systems that have Mono installed, as it has a framework with the libjpeg and libpng
+# headers present -- so CMake finds the headers from Mono but the libraries from Homebrew,
+# and hilarity ensues. Setting this to "last" means we always try the standard libraries
+# before the frameworks.
+set(CMAKE_FIND_FRAMEWORK LAST)
+
 find_package(Threads QUIET)
 
 if("${HALIDE_REQUIRE_LLVM_VERSION}" STREQUAL "")


### PR DESCRIPTION
This addresses some issues with using libpng/libjpeg on OSX systems that have Mono installed.