### PR TITLE
Fix apps/onnx

### DIFF
--- a/src/Dimension.h
+++ b/src/Dimension.h
@@ -75,10 +75,7 @@ public:
         return set_estimate(min, extent);
     }
 
-    HALIDE_ATTRIBUTE_DEPRECATED("min_estimate() will be removed soon, do not use")
     Expr min_estimate() const;
-
-    HALIDE_ATTRIBUTE_DEPRECATED("extent_estimate() will be removed soon, do not use")
     Expr extent_estimate() const;
 
     /** Get a different dimension of the same buffer */


### PR DESCRIPTION
Looks like apps/onnx never got updated way back when Region/Range replaced pair<Expr,Expr>; this attempts to remedy that. (Also, drive-by un-deprecation of two methods in Dimension.h, because this app needs them, and I can't remember why we wanted them deprecated in the first place.)

Clearly we need to add this to test_apps, but that requires installing some prerequisites first....