### PR TITLE
Change PyBind11 build rules to rely on a pip-installed version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -419,15 +419,6 @@ THIS_MAKEFILE = $(realpath $(filter %Makefile, $(MAKEFILE_LIST)))
 ROOT_DIR = $(strip $(shell dirname $(THIS_MAKEFILE)))
 SRC_DIR  = $(ROOT_DIR)/src
 
-# Allow the user to specify PYBIND11_PATH as a relative path,
-# but canonicalize it to an absolute path since the sub-makefile
-# we call may have a different working dir.
-ifdef PYBIND11_PATH
-	REAL_PYBIND11_PATH = $(realpath $(PYBIND11_PATH))
-else
-	REAL_PYBIND11_PATH = /PYBIND11_PATH/is/undefined
-endif
-
 TARGET=$(if $(HL_TARGET),$(HL_TARGET),host)
 
 # The following directories are all relative to the output directory (i.e. $(CURDIR), not $(SRC_DIR))
@@ -2079,8 +2070,7 @@ build_python_bindings: distrib $(BIN_DIR)/host/runtime.a
 		build_python_bindings \
 		HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
 		BIN=$(CURDIR)/$(BIN_DIR)/python3_bindings \
-		PYTHON=python3 \
-		PYBIND11_PATH=$(REAL_PYBIND11_PATH)
+		PYTHON=python3
 else
 # No Python support for MinGW yet
 build_python_bindings: ;
@@ -2093,8 +2083,7 @@ test_python: distrib $(BIN_DIR)/host/runtime.a build_python_bindings
 		test \
 		HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
 		BIN=$(CURDIR)/$(BIN_DIR)/python3_bindings \
-		PYTHON=python3 \
-		PYBIND11_PATH=$(REAL_PYBIND11_PATH)
+		PYTHON=python3
 
 # It's just for compiling the runtime, so earlier clangs *might* work,
 # but best to peg it to the minimum llvm version.

--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -39,16 +39,7 @@ LIBHALIDE ?= $(HALIDE_DISTRIB_PATH)/bin/libHalide.$(SHARED_EXT)
 SUFFIX = $(shell $(PYTHON)-config --extension-suffix)
 
 # Discover PyBind path from `python3 -m pybind11 --includes`
-# if it is pip/conda installed, which is a common case.
-# Cf. https://github.com/pybind/pybind11/blob/master/docs/compiling.rst#building-manually
 PYBIND11_CFLAGS = $(shell $(PYTHON) -m pybind11 --includes)
-ifeq ($(PYBIND11_CFLAGS),)
-    ifndef PYBIND11_PATH
-        $(error PYBIND11_PATH is undefined)
-    endif
-    PYBIND11_PATH ?= /path/to/pybind11
-    PYBIND11_CFLAGS = -I $(PYBIND11_PATH)/include
-endif
 
 OPTIMIZE ?= -O3
 

--- a/python_bindings/readme.md
+++ b/python_bindings/readme.md
@@ -57,8 +57,6 @@ requirements.txt`)
 
 -   Halide compiled to a distribution (e.g. `make distrib` or similar), with the
     `HALIDE_DISTRIB_PATH` env var pointing to it
--   The PyBind11 package (https://github.com/pybind/pybind11), v2.2.1 or later,
-    with the `PYBIND11_PATH` env var pointing to it
 
 ## Compilation instructions
 

--- a/python_bindings/requirements.txt
+++ b/python_bindings/requirements.txt
@@ -9,3 +9,4 @@ numpy
 scipy
 pillow
 imageio
+pybind11


### PR DESCRIPTION
Up to now, we've required people to explicitly clone PyBind11 and point the build files at it via PYBIND11_PATH; as it turns out, there is a pip package for it, which is much simpler to manage.

This change removes usage of PYBIND11_PATH entirely, and assumes that there is a pip install that has all includes set up properly (which should be the case if you have used requirements.txt).

If this lands, there will be a followup to remove the explicit PYBIND11_PATH cruft from the buildbots.