### PR TITLE
Smarten python-config logic

### DIFF
--- a/apps/onnx/Makefile
+++ b/apps/onnx/Makefile
@@ -78,12 +78,17 @@ test: build
 	LD_LIBRARY_PATH=$(BIN) $(BIN)/$(HL_TARGET)/onnx_converter_generator_test
 
 PYTHON ?= python3
-PYBIND11_CFLAGS = $(shell $(PYTHON)-config --includes) -frtti
+PYTHON_CONFIG ?= $(PYTHON)-config
+ifeq ($(shell which $(PYTHON_CONFIG)),)
+	PYTHON_CONFIG = python-config
+endif
+
+PYBIND11_CFLAGS = $(shell $(PYTHON_CONFIG) --includes) -frtti
 ifeq ($(UNAME), Darwin)
     # Keep OS X builds from complaining about missing libpython symbols
     PYBIND11_CFLAGS += -undefined dynamic_lookup
 endif
-PY_EXT = $(shell $(PYTHON)-config --extension-suffix)
+PY_EXT = $(shell $(PYTHON_CONFIG) --extension-suffix)
 PY_MODEL_EXT = model_cpp$(PY_EXT)
 PYCXXFLAGS =  $(CXXFLAGS) $(PYBIND11_CFLAGS) -Wno-deprecated-register -Wno-deprecated-declarations
 

--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -7,6 +7,11 @@ HALIDE_PATH ?= $(ROOT_DIR)/..
 HALIDE_DISTRIB_PATH ?= $(HALIDE_PATH)/distrib
 BIN ?= $(ROOT_DIR)/bin
 PYTHON ?= python3
+PYTHON_CONFIG ?= $(PYTHON)-config
+ifeq ($(shell which $(PYTHON_CONFIG)),)
+ 	# Some python3-only installs won't provide python3-config, so fall back to python-config
+    PYTHON_CONFIG = python-config
+endif
 TEST_TMP ?= $(BIN)/tmp
 
 ifeq ($(OS), Windows_NT)
@@ -36,7 +41,7 @@ endif
 
 LIBHALIDE ?= $(HALIDE_DISTRIB_PATH)/bin/libHalide.$(SHARED_EXT)
 
-SUFFIX = $(shell $(PYTHON)-config --extension-suffix)
+SUFFIX = $(shell $(PYTHON_CONFIG) --extension-suffix)
 
 # Discover PyBind path from `python3 -m pybind11 --includes`
 # if it is pip/conda installed, which is a common case.
@@ -56,7 +61,7 @@ OPTIMIZE ?= -O3
 # OPTIMIZE ?= -g -DDEBUG=1 -UNDEBUG
 
 # Compiling with -fvisibility=hidden saves ~80k on optimized x64 builds
-CCFLAGS=$(shell $(PYTHON)-config --cflags) $(PYBIND11_CFLAGS) -I $(HALIDE_DISTRIB_PATH)/include -I $(ROOT_DIR) -std=c++11 $(FPIC) -fvisibility=hidden -fvisibility-inlines-hidden $(OPTIMIZE) $(CXXFLAGS)
+CCFLAGS=$(shell $(PYTHON_CONFIG) --cflags) $(PYBIND11_CFLAGS) -I $(HALIDE_DISTRIB_PATH)/include -I $(ROOT_DIR) -std=c++11 $(FPIC) -fvisibility=hidden -fvisibility-inlines-hidden $(OPTIMIZE) $(CXXFLAGS)
 # Filter out a pointless warning present in some Python installs
 CCFLAGS := $(filter-out -Wstrict-prototypes,$(CCFLAGS))
 


### PR DESCRIPTION
Our makefiles look for `python3-config` by default, but some python3-only installs may not provide this (providing only `python-config`). Smarten our logic to check and fall back to that if the expected name isn't present.