### PR TITLE
Can't use substitute on Expr graphs. Use graph_substitute.

### DIFF
--- a/src/ParallelRVar.cpp
+++ b/src/ParallelRVar.cpp
@@ -34,7 +34,7 @@ class FindLoads : public IRVisitor {
         IRVisitor::visit(op);
         for (size_t i = 0; i < loads.size(); i++) {
             for (size_t j = 0; j < loads[i].size(); j++) {
-                loads[i][j] = substitute(op->name, op->value, loads[i][j]);
+                loads[i][j] = graph_substitute(op->name, op->value, loads[i][j]);
             }
         }
     }


### PR DESCRIPTION
Fixes #4612 