### PR TITLE
Speedup associativitiy check by using IRGraphMutator

### DIFF
--- a/src/Associativity.cpp
+++ b/src/Associativity.cpp
@@ -37,8 +37,8 @@ vector<T> get_subvector(const vector<T> &v, const set<int> &indices) {
 
 // Replace self-references to 'func' with arguments 'args' at
 // 'value_index' in the Expr/Stmt with some Var
-class ConvertSelfRef : public IRMutator {
-    using IRMutator::visit;
+class ConvertSelfRef : public IRGraphMutator {
+    using IRGraphMutator::visit;
 
     const string &func;
     const vector<Expr> &args;
@@ -51,7 +51,7 @@ class ConvertSelfRef : public IRMutator {
         if (!is_solvable) {
             return op;
         }
-        Expr expr = IRMutator::visit(op);
+        Expr expr = IRGraphMutator::visit(op);
         op = expr.as<Call>();
         internal_assert(op);
 


### PR DESCRIPTION
The following code in `prove_associativity()` converts functions' self reference into a variable:
```
        exprs[idx] = simplify(exprs[idx]);
        exprs[idx] = common_subexpression_elimination(exprs[idx]);
        // Calling Simplify or the original expr itself might have let exprs,
        // so we should substitutes in all lets first
        exprs[idx] = substitute_in_all_lets(exprs[idx]);

        // Replace any self-reference to Func 'f' with a Var
        ConvertSelfRef csr(f, args, idx, op_x_names);
        exprs[idx] = csr.mutate(exprs[idx]);
```
Here the expression is substituted with all the lets in, however ConvertSelfRef is an IRMutator, making the replacement slow. This PR changes ConvertSelfRef to an IRGraphMutator so that it can handle large expressions.
