### PR TITLE
Fix test/generator_aot_multitarget (Issue #4619)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1489,7 +1489,9 @@ $(BIN_DIR)/$(TARGET)/generator_aotwasm_metadata_tester.js: $(FILTERS_DIR)/metada
 
 $(FILTERS_DIR)/multitarget.a: $(BIN_DIR)/multitarget.generator
 	@mkdir -p $(@D)
-	$(CURDIR)/$< -g multitarget -f "HalideTest::multitarget" $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-debug-no_runtime-c_plus_plus_name_mangling,$(TARGET)-no_runtime-c_plus_plus_name_mangling  -e assembly,bitcode,c_source,c_header,stmt_html,static_library,stmt
+	$(CURDIR)/$< -g multitarget -f "HalideTest::multitarget" $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) \
+		target=$(TARGET)-no_bounds_query-no_runtime-c_plus_plus_name_mangling,$(TARGET)-no_runtime-c_plus_plus_name_mangling  \
+		-e assembly,bitcode,c_source,c_header,stmt_html,static_library,stmt
 
 $(FILTERS_DIR)/msan.a: $(BIN_DIR)/msan.generator
 	@mkdir -p $(@D)
@@ -1682,8 +1684,8 @@ $(BIN_DIR)/generator_jit_%: $(ROOT_DIR)/test/generator/%_jittest.cpp $(BIN_DIR)/
 # generator_aot_multitarget is run multiple times, with different env vars.
 generator_aot_multitarget: $(BIN_DIR)/$(TARGET)/generator_aot_multitarget
 	@mkdir -p $(@D)
-	HL_MULTITARGET_TEST_USE_DEBUG_FEATURE=0 $(CURDIR)/$<
-	HL_MULTITARGET_TEST_USE_DEBUG_FEATURE=1 $(CURDIR)/$<
+	HL_MULTITARGET_TEST_USE_NOBOUNDSQUERY_FEATURE=0 $(CURDIR)/$<
+	HL_MULTITARGET_TEST_USE_NOBOUNDSQUERY_FEATURE=1 $(CURDIR)/$<
 	@-echo
 
 # nested externs doesn't actually contain a generator named

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -756,9 +756,10 @@ void compile_multitarget(const std::string &fn_name,
             user_error << "All Targets must have matching arch-bits-os for compile_multitarget.\n";
         }
         // Some features must match across all targets.
-        static const std::array<Target::Feature, 8> must_match_features = {{
+        static const std::array<Target::Feature, 9> must_match_features = {{
             Target::ASAN,
             Target::CPlusPlusMangling,
+            Target::Debug,
             Target::JIT,
             Target::Matlab,
             Target::MSAN,
@@ -768,7 +769,7 @@ void compile_multitarget(const std::string &fn_name,
         }};
         for (auto f : must_match_features) {
             if (target.has_feature(f) != base_target.has_feature(f)) {
-                user_error << "All Targets must have feature " << f << " set identically for compile_multitarget.\n";
+                user_error << "All Targets must have feature '" << Target::feature_to_name(f) << "'' set identically for compile_multitarget.\n";
                 break;
             }
         }

--- a/test/correctness/compile_to_multitarget.cpp
+++ b/test/correctness/compile_to_multitarget.cpp
@@ -18,7 +18,7 @@ void testCompileToOutput(Func j) {
     Internal::ensure_no_file_exists(expected_h);
 
     std::vector<Target> targets = {
-        Target("host-profile-debug"),
+        Target("host-profile-no_bounds_query"),
         Target("host-profile"),
     };
     j.compile_to_multitarget_static_library(fn_object, j.infer_arguments(), targets);

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -156,7 +156,7 @@ halide_define_aot_test(memory_profiler_mandelbrot
         HALIDE_TARGET_FEATURES profile)
 
 halide_define_aot_test(multitarget
-        HALIDE_TARGET host,host-debug
+        HALIDE_TARGET host-no_bounds_query,host
         HALIDE_TARGET_FEATURES c_plus_plus_name_mangling
         FUNCTION_NAME HalideTest::multitarget)
 

--- a/test/generator/multitarget_aottest.cpp
+++ b/test/generator/multitarget_aottest.cpp
@@ -31,10 +31,10 @@ std::pair<std::string, bool> get_env_variable(char const *env_var_name) {
     return {"", false};
 }
 
-bool use_debug_feature() {
+bool use_noboundsquery_feature() {
     std::string value;
     bool read;
-    std::tie(value, read) = get_env_variable("HL_MULTITARGET_TEST_USE_DEBUG_FEATURE");
+    std::tie(value, read) = get_env_variable("HL_MULTITARGET_TEST_USE_NOBOUNDSQUERY_FEATURE");
     if (!read) {
         return false;
     }
@@ -45,10 +45,10 @@ static std::atomic<int> can_use_count;
 
 int my_can_use_target_features(int count, const uint64_t *features) {
     can_use_count += 1;
-    const int word = halide_target_feature_debug / 64;
-    const int bit = halide_target_feature_debug % 64;
+    const int word = halide_target_feature_no_bounds_query / 64;
+    const int bit = halide_target_feature_no_bounds_query % 64;
     if (features[word] & (1ULL << bit)) {
-        if (use_debug_feature()) {
+        if (use_noboundsquery_feature()) {
             return 1;
         } else {
             return 0;
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
     // Verify output.
     for (int y = 0; y < H; y++) {
         for (int x = 0; x < W; x++) {
-            const uint32_t expected = use_debug_feature() ? 0xdeadbeef : 0xf00dcafe;
+            const uint32_t expected = use_noboundsquery_feature() ? 0xdeadbeef : 0xf00dcafe;
             const uint32_t actual = output(x, y);
             if (actual != expected) {
                 printf("Error at %d, %d: expected %x, got %x\n", x, y, expected, actual);
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    printf("Success: Saw %x for debug=%d\n", output(0, 0), use_debug_feature());
+    printf("Success: Saw %x for no_bounds_query=%d\n", output(0, 0), use_noboundsquery_feature());
 
     return 0;
 }

--- a/test/generator/multitarget_generator.cpp
+++ b/test/generator/multitarget_generator.cpp
@@ -8,7 +8,10 @@ public:
 
     void generate() {
         Var x, y;
-        if (get_target().has_feature(Target::Debug)) {
+        // Note that 'NoBoundsQuery' is essentially a somewhat-arbitrary placeholder
+        // here; we really just want to use a feature flag that doesn't require
+        // a custom runtime (as does, e.g., Target::Debug).
+        if (get_target().has_feature(Target::NoBoundsQuery)) {
             output(x, y) = cast<uint32_t>((int32_t)0xdeadbeef);
         } else {
             output(x, y) = cast<uint32_t>((int32_t)0xf00dcafe);


### PR DESCRIPTION
Need to use a feature that doesn't need a custom runtime.

(Also, drive-by addition of ::Debug to the multitarget sniff test, which it should have been in already)