### PR TITLE
Don't keep unnecessary data around.

### DIFF
--- a/apps/autoscheduler/FunctionDAG.cpp
+++ b/apps/autoscheduler/FunctionDAG.cpp
@@ -583,6 +583,7 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
 
     // Construct the mapping from Funcs to Nodes
     nodes.resize(order.size());
+    map<Function, Node *, Function::Compare> node_map;
     for (size_t i = 0; i < order.size(); i++) {
         Function f = env[order[order.size() - i - 1]];
         nodes[i].func = f;

--- a/apps/autoscheduler/FunctionDAG.h
+++ b/apps/autoscheduler/FunctionDAG.h
@@ -544,11 +544,6 @@ struct FunctionDAG {
     vector<Node> nodes;
     vector<Edge> edges;
 
-    // We're going to be querying this DAG a lot while searching for
-    // an optimal schedule, so we'll also create a variety of
-    // auxiliary data structures.
-    map<Function, Node *, Function::Compare> node_map;
-
     // Create the function DAG, and do all the dependency and cost
     // analysis. This is done once up-front before the tree search.
     FunctionDAG(const vector<Function> &outputs, const MachineParams &params, const Target &target);


### PR DESCRIPTION
The node map is only used in the constructor of FunctionDAG: make it a local datastructure instead of keeping it as a class member.