### PR TITLE
Remove the FunctionDAG::Stage::output_vector_size data member

### DIFF
--- a/apps/autoscheduler/FunctionDAG.cpp
+++ b/apps/autoscheduler/FunctionDAG.cpp
@@ -826,7 +826,6 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
             }
 
             stage.vector_size = target.natural_vector_size(checker.narrowest_type);
-            stage.output_vector_size = target.natural_vector_size(widest_output_type);
 
             if (s == 0) {
                 node.vector_size = stage.vector_size;

--- a/apps/autoscheduler/FunctionDAG.h
+++ b/apps/autoscheduler/FunctionDAG.h
@@ -439,10 +439,6 @@ struct FunctionDAG {
             // narrowest type used.
             int vector_size;
 
-            // The vector size used for storing outputs. Corresponds
-            // to the natural width for the output type.
-            int output_vector_size;
-
             // The featurization of the compute done
             PipelineFeatures features;
 


### PR DESCRIPTION
It isn't used anywhere.