### PR TITLE
Increase stack size for wasm tests as needed

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -4323,7 +4323,7 @@ Value *CodeGen_LLVM::create_alloca_at_entry(llvm::Type *t, int n, bool zero_init
     AllocaInst *ptr = builder->CreateAlloca(t, size, name);
     int align = native_vector_bits() / 8;
     llvm::DataLayout d(module.get());
-    int allocated_size = n * (int) d.getTypeAllocSize(t);
+    int allocated_size = n * (int)d.getTypeAllocSize(t);
     if (t->isVectorTy() || n > 1) {
         ptr->setAlignment(make_alignment(align));
     }

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -4322,9 +4322,12 @@ Value *CodeGen_LLVM::create_alloca_at_entry(llvm::Type *t, int n, bool zero_init
     Value *size = ConstantInt::get(i32_t, n);
     AllocaInst *ptr = builder->CreateAlloca(t, size, name);
     int align = native_vector_bits() / 8;
+    llvm::DataLayout d(module.get());
+    int allocated_size = n * (int) d.getTypeAllocSize(t);
     if (t->isVectorTy() || n > 1) {
         ptr->setAlignment(make_alignment(align));
     }
+    requested_alloca_total += allocated_size;
 
     if (zero_initialize) {
         if (n == 1) {

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -438,9 +438,18 @@ protected:
                                         bool zero_initialize = false,
                                         const std::string &name = "");
 
-    /** Total size of all alloca() storage requested (including alignment padding).
-     * Note that the actual stack space used might be less, as LLVM will promote
-     * register-sized allocas into registers in many cases. */
+    /** A (very) conservative guess at the size of all alloca() storage requested
+     * (including alignment padding). It's currently meant only to be used as
+     * a very coarse way to ensure there is enough stack space when testing
+     * on the WebAssembly backend.
+     *
+     * It is *not* meant to be a useful proxy for "stack space needed", for a
+     * number of reasons:
+     * - allocas with non-overlapping lifetimes will share space
+     * - on some backends, LLVM may promote register-sized allocas into registers
+     * - while this accounts for alloca() calls we know about, it doesn't attempt
+     *   to account for stack spills, function call overhead, etc., so
+     */
     size_t requested_alloca_total = 0;
 
     /** Which buffers came in from the outside world (and so we can't

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -84,7 +84,9 @@ public:
         const std::string &suffix,
         const std::vector<std::pair<std::string, ExternSignature>> &externs);
 
-    size_t get_requested_alloca_total() const { return requested_alloca_total; }
+    size_t get_requested_alloca_total() const {
+        return requested_alloca_total;
+    }
 
 protected:
     CodeGen_LLVM(Target t);

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -448,7 +448,7 @@ protected:
      * - allocas with non-overlapping lifetimes will share space
      * - on some backends, LLVM may promote register-sized allocas into registers
      * - while this accounts for alloca() calls we know about, it doesn't attempt
-     *   to account for stack spills, function call overhead, etc., so
+     *   to account for stack spills, function call overhead, etc.
      */
     size_t requested_alloca_total = 0;
 

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -84,6 +84,8 @@ public:
         const std::string &suffix,
         const std::vector<std::pair<std::string, ExternSignature>> &externs);
 
+    size_t get_requested_alloca_total() const { return requested_alloca_total; }
+
 protected:
     CodeGen_LLVM(Target t);
 
@@ -433,6 +435,11 @@ protected:
     llvm::Value *create_alloca_at_entry(llvm::Type *type, int n,
                                         bool zero_initialize = false,
                                         const std::string &name = "");
+
+    /** Total size of all alloca() storage requested (including alignment padding).
+     * Note that the actual stack space used might be less, as LLVM will promote
+     * register-sized allocas into registers in many cases. */
+    size_t requested_alloca_total = 0;
 
     /** Which buffers came in from the outside world (and so we can't
      * guarantee their alignment) */


### PR DESCRIPTION
CodegenLLVM deliberately makes many small (register-sized) calls to alloca, on the plausible assumption that CPU-ish backends will promote these into registers. This isn't true for the WebAssembly backend, since (as a stack machine) it doesn't do registers; in degenerate cases (e.g. a func with ~everything inlined, and tracing enabled to increase stack usage), we can overflow the default wasm stack of ~64k, which crashes in amusing ways.

To mitigate this, add some code to CodegenLLVM to track the total alloca usage, then have WasmExecutor add this amount to the stack-size specified at link time.

Note 1: AFAICT there isn't a pre-baked LLVM method for "how much stack space does this Module require"; if there is a cleaner way to do this without tracking it ourself, that would be great.

Note 2: would probably also be profitable to see if we can avoid the 'assume alloca -> register' design for the wasm backend; even if we do that, this fix is probably still desirable for other possible degenerate cases of wasm.

Note 3: drive-by fix in WasmExecutor for LLVM >= 11.0 error case of linker.