### PR TITLE
Fix build with clang trunk - mainly -Wrange-loop-construct issues

### DIFF
--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -156,7 +156,7 @@ Stmt add_image_checks(Stmt s,
     // references to the required sizes.
     map<string, Expr> replace_with_required;
 
-    for (const pair<string, FindBuffers::Result> &buf : bufs) {
+    for (const pair<const string, FindBuffers::Result> &buf : bufs) {
         const string &name = buf.first;
 
         for (int i = 0; i < buf.second.dimensions; i++) {

--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -703,7 +703,7 @@ map<string, Box> get_pipeline_bounds(DependenceAnalysis &analysis,
         }
 
         set<string> prods;
-        for (const pair<string, Function> &fpair : analysis.env) {
+        for (const pair<const string, Function> &fpair : analysis.env) {
             prods.insert(fpair.first);
         }
 
@@ -1261,7 +1261,7 @@ Cost Partitioner::get_pipeline_cost() {
     internal_assert(!group_costs.empty());
 
     Cost total_cost(0, 0);
-    for (const pair<FStage, Group> &g : groups) {
+    for (const pair<const FStage, Group> &g : groups) {
         const GroupAnalysis &analysis = get_element(group_costs, g.first);
         if (!analysis.cost.defined()) {
             return Cost();
@@ -1280,7 +1280,7 @@ void Partitioner::disp_pipeline_costs() {
     debug(0) << "Pipeline costs:" << '\n';
     debug(0) << "===============" << '\n';
     debug(0) << "Group: (name) [arith cost, mem cost, parallelism]" << '\n';
-    for (const pair<FStage, Group> &g : groups) {
+    for (const pair<const FStage, Group> &g : groups) {
         const GroupAnalysis &analysis = get_element(group_costs, g.first);
         if (!total_cost.arith.defined()) {
             continue;
@@ -1641,7 +1641,7 @@ void Partitioner::group(Partitioner::Level level) {
 
         fixpoint = true;
         vector<pair<string, string>> cand;
-        for (const pair<FStage, Group> &g : groups) {
+        for (const pair<const FStage, Group> &g : groups) {
             bool is_output = false;
             for (const Function &f : outputs) {
                 if (g.first.func.name() == f.name()) {
@@ -2867,7 +2867,7 @@ void Partitioner::generate_cpu_schedule(const Target &t, AutoSchedule &sched) {
 
     set<string> inlines;
     // Mark all functions that are inlined.
-    for (const pair<FStage, Group> &g : groups) {
+    for (const pair<const FStage, Group> &g : groups) {
         for (const string &inline_func : g.second.inlined) {
             inlines.insert(inline_func);
         }

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -388,7 +388,7 @@ public:
             size_t last_dot = loop_level.rfind('.');
             string var = loop_level.substr(last_dot + 1);
 
-            for (const pair<pair<string, int>, Box> &i : bounds) {
+            for (const pair<const pair<string, int>, Box> &i : bounds) {
                 string func_name = i.first.first;
                 int func_stage_index = i.first.second;
                 string stage_name = func_name + ".s" + std::to_string(func_stage_index);
@@ -657,7 +657,7 @@ public:
                 BufferBuilder builder;
                 builder.type = func.output_types()[j];
                 builder.dimensions = func.dimensions();
-                for (const string arg : func.args()) {
+                for (const string &arg : func.args()) {
                     string prefix = func.name() + ".s" + std::to_string(stage) + "." + arg;
                     Expr min = Variable::make(Int(32), prefix + ".min");
                     Expr max = Variable::make(Int(32), prefix + ".max");
@@ -735,7 +735,7 @@ public:
         // We need to take into account specializations which may refer to
         // different reduction variables as well.
         void populate_scope(Scope<Interval> &result) {
-            for (const string farg : func.args()) {
+            for (const string &farg : func.args()) {
                 string arg = name + ".s" + std::to_string(stage) + "." + farg;
                 result.push(farg,
                             Interval(Variable::make(Int(32), arg + ".min"),

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -347,7 +347,7 @@ JITModule JITModule::make_trampolines_module(const Target &target_arg,
     JITModule result;
     std::vector<std::pair<std::string, ExternSignature>> extern_signatures;
     std::vector<std::string> requested_exports;
-    for (const std::pair<std::string, JITExtern> &e : externs) {
+    for (const std::pair<const std::string, JITExtern> &e : externs) {
         const std::string &callee_name = e.first;
         const std::string wrapper_name = callee_name + suffix;
         const ExternCFunction &extern_c = e.second.extern_c_function();

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -145,6 +145,7 @@ public:
 };
 
 typedef std::pair<FindParameterDependencies::DependencyKey, FindParameterDependencies::DependencyInfo> DependencyKeyInfoPair;
+typedef std::pair<const FindParameterDependencies::DependencyKey, FindParameterDependencies::DependencyInfo> ConstDependencyKeyInfoPair;
 
 class KeyInfo {
     FindParameterDependencies dependencies;
@@ -156,7 +157,7 @@ class KeyInfo {
     size_t parameters_alignment() {
         int32_t max_alignment = 0;
         // Find maximum natural alignment needed.
-        for (const DependencyKeyInfoPair &i : dependencies.dependency_info) {
+        for (const ConstDependencyKeyInfoPair &i : dependencies.dependency_info) {
             int alignment = i.second.type.bytes();
             if (alignment > max_alignment) {
                 max_alignment = alignment;
@@ -199,7 +200,7 @@ public:
         }
         key_size_expr = (int32_t)size_so_far;
 
-        for (const DependencyKeyInfoPair &i : dependencies.dependency_info) {
+        for (const ConstDependencyKeyInfoPair &i : dependencies.dependency_info) {
             key_size_expr += i.second.size_expr;
         }
     }
@@ -246,7 +247,7 @@ public:
             }
         }
 
-        for (const DependencyKeyInfoPair &i : dependencies.dependency_info) {
+        for (const ConstDependencyKeyInfoPair &i : dependencies.dependency_info) {
             writes.push_back(Store::make(key_name,
                                          i.second.value_expr,
                                          (index / i.second.size_expr),
@@ -373,7 +374,7 @@ private:
             BufferBuilder builder;
             builder.dimensions = f.dimensions();
             std::string max_stage_num = std::to_string(f.updates().size());
-            for (const std::string arg : f.args()) {
+            for (const std::string &arg : f.args()) {
                 std::string prefix = op->name + ".s" + max_stage_num + "." + arg;
                 Expr min = Variable::make(Int(32), prefix + ".min");
                 Expr max = Variable::make(Int(32), prefix + ".max");

--- a/src/RealizationOrder.cpp
+++ b/src/RealizationOrder.cpp
@@ -210,7 +210,7 @@ pair<vector<string>, vector<vector<string>>> realization_order(
 
     // Collect all indirect calls made by all the functions in "env".
     map<string, map<string, Function>> indirect_calls;
-    for (const pair<string, Function> &caller : env) {
+    for (const pair<const string, Function> &caller : env) {
         map<string, Function> more_funcs = find_transitive_calls(caller.second);
         indirect_calls.emplace(caller.first, more_funcs);
     }
@@ -225,7 +225,7 @@ pair<vector<string>, vector<vector<string>>> realization_order(
     map<string, vector<FusedPair>> fused_pairs_graph;
     map<string, set<string>> fuse_adjacency_list;
 
-    for (const pair<string, Function> &caller : env) {
+    for (const pair<const string, Function> &caller : env) {
         // Find all compute_with (fused) pairs. We have to look at the update
         // definitions as well since compute_with is defined per definition (stage).
         vector<FusedPair> &func_fused_pairs = fused_pairs_graph[caller.first];
@@ -256,7 +256,7 @@ pair<vector<string>, vector<vector<string>>> realization_order(
     std::tie(fused_groups, group_name) = find_fused_groups(env, fuse_adjacency_list);
 
     // Compute the DAG representing the pipeline
-    for (const pair<string, Function> &caller : env) {
+    for (const pair<const string, Function> &caller : env) {
         const string &caller_rename = group_name.at(caller.first);
         // Create a dummy node representing the fused group and add input edge
         // dependencies from the nodes representing member of the fused group
@@ -265,7 +265,7 @@ pair<vector<string>, vector<vector<string>>> realization_order(
         // Direct the calls to calls from the dummy node. This forces all the
         // functions called by members of the fused group to be realized first.
         vector<string> &s = graph[caller_rename];
-        for (const pair<string, Function> &callee : find_direct_calls(caller.second)) {
+        for (const pair<const string, Function> &callee : find_direct_calls(caller.second)) {
             if ((callee.first != caller.first) &&  // Skip calls to itself (i.e. update stages)
                 (std::find(s.begin(), s.end(), callee.first) == s.end())) {
                 s.push_back(callee.first);
@@ -322,9 +322,9 @@ vector<string> topological_order(const vector<Function> &outputs,
     // set describing its inputs.
     map<string, vector<string>> graph;
 
-    for (const pair<string, Function> &caller : env) {
+    for (const pair<const string, Function> &caller : env) {
         vector<string> s;
-        for (const pair<string, Function> &callee : find_direct_calls(caller.second)) {
+        for (const pair<const string, Function> &callee : find_direct_calls(caller.second)) {
             if ((callee.first != caller.first) &&  // Skip calls to itself (i.e. update stages)
                 (std::find(s.begin(), s.end(), callee.first) == s.end())) {
                 s.push_back(callee.first);

--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -510,7 +510,7 @@ void prune_varying_attributes(Stmt loop_stmt, std::map<std::string, Expr> &varyi
 
     std::vector<std::string> remove_list;
 
-    for (const std::pair<std::string, Expr> &i : varying) {
+    for (const std::pair<const std::string, Expr> &i : varying) {
         const std::string &name = i.first;
         if (find.variables.find(name) == find.variables.end()) {
             debug(2) << "Removed varying attribute " << name << "\n";
@@ -1262,7 +1262,7 @@ public:
             attribute_order["__vertex_y"] = 1;
 
             int idx = 2;
-            for (const std::pair<std::string, Expr> &v : varyings) {
+            for (const std::pair<const std::string, Expr> &v : varyings) {
                 attribute_order[v.first] = idx++;
             }
 

--- a/test/correctness/reduction_schedule.cpp
+++ b/test/correctness/reduction_schedule.cpp
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
     Buffer<float> noise(size, size);
     for (int i = 0; i < size; i++) {
         for (int j = 0; j < size; j++) {
-            noise(j, i) = (float)rand() / RAND_MAX;
+            noise(j, i) = (float)rand() / (float)RAND_MAX;
         }
     }
 

--- a/test/correctness/unrolled_reduction.cpp
+++ b/test/correctness/unrolled_reduction.cpp
@@ -8,7 +8,7 @@ int main(int argc, char **argv) {
 
     Buffer<float> noise(32);
     for (int i = 0; i < 32; i++) {
-        noise(i) = (float)rand() / RAND_MAX;
+        noise(i) = (float)rand() / (float)RAND_MAX;
     }
 
     Func f("f");


### PR DESCRIPTION
All these otherwise result in diagnostics like:
```
[1/844 0.8/sec] Building CXX object src/CMakeFiles/Halide.dir/AddImageChecks.cpp.o
FAILED: src/CMakeFiles/Halide.dir/AddImageChecks.cpp.o
/usr/local/bin/clang++  -DCOMPILING_HALIDE -DHalide_EXPORTS -DHalide_SHARED -DLLVM_VERSION=90 -DNDEBUG -DWITH_AARCH64 -DWITH_AMDGPU -DWITH_ARM -DWITH_D3D12 -DWITH_HEXAGON -DWITH_METAL -DWITH_MIPS -DWITH_OPENCL -DWITH_OPENGL -DWITH_POWERPC -DWITH_PTX -DWITH_RISCV -DWITH_X86 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/usr/lib/llvm-9/include -O2 -g  -fPIC   -Wall -Wno-unused-function -Wcast-qual -Wignored-qualifiers -Woverloaded-virtual -Werror -std=c++11 -MD -MT src/CMakeFiles/Halide.dir/AddImageChecks.cpp.o -MF src/CMakeFiles/Halide.dir/AddImageChecks.cpp.o.d -o src/CMakeFiles/Halide.dir/AddImageChecks.cpp.o -c /repositories/Halide/src/AddImageChecks.cpp
/repositories/Halide/src/AddImageChecks.cpp:159:51: error: loop variable 'buf' has type 'const pair<std::string, FindBuffers::Result> &' (aka 'const pair<basic_string<char>, Halide::Internal::FindBuffers::Result> &') but is initialized with type 'std::pair<const std::__cxx11::basic_string<char>, Halide::Internal::FindBuffers::Result>' resulting in a copy [-Werror,-Wrange-loop-construct]
    for (const pair<string, FindBuffers::Result> &buf : bufs) {
                                                  ^
/repositories/Halide/src/AddImageChecks.cpp:159:10: note: use non-reference type 'pair<std::string, FindBuffers::Result>' (aka 'pair<basic_string<char>, Halide::Internal::FindBuffers::Result>') to keep the copy or type 'const std::pair<const std::__cxx11::basic_string<char>, Halide::Internal::FindBuffers::Result> &' to prevent copying
    for (const pair<string, FindBuffers::Result> &buf : bufs) {
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```
With this patch the master builds warning-free with clang trunk again.