### PR TITLE
Fix .clang-format for newer versions.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,17 +1,17 @@
 ---
 AccessModifierOffset: -4
-AlignEscapedNewlinesLeft: true
+AlignEscapedNewlines: Left
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 # Requires Clang-Format 10+
-# AllowShortBlocksOnASingleLine: 'Empty'
-AllowShortFunctionsOnASingleLine: false
-AllowShortIfStatementsOnASingleLine: true
+# AllowShortBlocksOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Always
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakTemplateDeclarations: Yes
 BinPackParameters: true
-BreakBeforeBinaryOperators: false
+BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Attach
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: false
@@ -20,10 +20,10 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DerivePointerBinding: false
+DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
 IndentCaseLabels: false
-IndentFunctionDeclarationAfterType: false
+IndentWrappedFunctionNames: false
 IndentWidth: 4
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
@@ -34,8 +34,8 @@ PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
-PointerBindsToType: false
-SpaceAfterControlStatementKeyword: true
+PointerAlignment: Right
+SpaceBeforeParens: ControlStatements
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true


### PR DESCRIPTION
Several options in our `.clang-format` are no longer recognized. See the documentation here for the version used by our GitHub Actions presubmit check.

https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormatStyleOptions.html

This PR replaces them with equivalents. Running `make format` does nothing.

Cherry picked from #4644 