### PR TITLE
Fix JIT-on-x86-32-under-CPython runtime error

### DIFF
--- a/python_bindings/correctness/buffer.py
+++ b/python_bindings/correctness/buffer.py
@@ -2,6 +2,7 @@
 import halide as hl
 import numpy as np
 import gc
+import sys
 
 def test_ndarray_to_buffer():
     a0 = np.ones((200, 300), dtype=np.int32)
@@ -85,6 +86,9 @@ def test_buffer_to_ndarray():
 def _assert_fn(e):
     assert e
 
+def _is_64bits():
+    return sys.maxsize > 2**32
+
 def test_for_each_element():
     buf = hl.Buffer(hl.Float(32), [3, 4])
     for x in range(3):
@@ -102,8 +106,13 @@ def test_fill_all_equal():
 
 
 def test_bufferinfo_sharing():
+    # Don't bother testing this on 32-bit systems (our "huge" size is too large there)
+    if not _is_64bits():
+        print("skipping test_bufferinfo_sharing()")
+        return
+
     # Torture-test to ensure that huge Python Buffer Protocol allocations are properly
-    # shared (rather than copied), and also that the lifetime is held appropriately
+    # shared (rather than copied), and also that the lifetime is held appropriately.
     a0 = np.ones((20000, 30000), dtype=np.int32)
     b0 = hl.Buffer(a0)
     del a0
@@ -221,6 +230,11 @@ def test_reorder():
     assert b.dim(3).stride() == b2.dim(3).stride()
 
 def test_overflow():
+    # Don't bother testing this on 32-bit systems (our "huge" size is too large there)
+    if not _is_64bits():
+        print("skipping test_overflow()")
+        return
+
     # size = INT_MAX
     w_intmax = 0x7FFFFFFF
 

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -226,7 +226,7 @@ public:
         // helper functions of this sort crop up in the future, this should be expanded
         // into a "builtins map".)
         if (result == 0 && name == "__udivdi3") {
-            result = (uint64_t) &__udivdi3;
+            result = (uint64_t)&__udivdi3;
         }
 #endif
         return result;

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -27,6 +27,10 @@ namespace Internal {
 
 using std::string;
 
+#if defined(__GNUC__) && defined(__i386__)
+extern "C" unsigned long __udivdi3(unsigned long a, unsigned long b);
+#endif
+
 #ifdef _WIN32
 void *get_symbol_address(const char *s) {
     return (void *)GetProcAddress(GetModuleHandle(nullptr), s);
@@ -185,7 +189,6 @@ JITModule::Symbol compile_and_get_function(ExecutionEngine &ee, const string &na
 }
 
 // Expand LLVM's search for symbols to include code contained in a set of JITModule.
-// TODO: Does this need to be conditionalized to llvm 3.6?
 class HalideJITMemoryManager : public SectionMemoryManager {
     std::vector<JITModule> modules;
     std::vector<std::pair<uint8_t *, size_t>> code_pages;
@@ -206,7 +209,27 @@ public:
                 return (uint64_t)iter->second.address;
             }
         }
-        return SectionMemoryManager::getSymbolAddress(name);
+        uint64_t result = SectionMemoryManager::getSymbolAddress(name);
+#if defined(__GNUC__) && defined(__i386__)
+        // This is a workaround for an odd corner case (cross-compiling + testing
+        // Python bindings x86-32 on an x86-64 system): __udivdi3 is a helper function
+        // that GCC uses to do u64/u64 division on 32-bit systems; it's usually included
+        // by the linker on these systems as needed. When we JIT, LLVM will include references
+        // to this call; MCJIT fixes up these references by doing (roughly) dlopen(NULL)
+        // to look up the symbol. For normal JIT tests, this works fine, as dlopen(NULL)
+        // finds the test executable, which has the right lookups to locate it inside libHalide.so.
+        // If, however, we are running a JIT-via-Python test, dlopen(NULL) returns the
+        // CPython executable... which apparently *doesn't* include this as an exported
+        // function, so the lookup fails and crashiness ensues. So our workaround here is
+        // a bit icky, but expedient: check for this name if we can't find it elsewhere,
+        // and if so, return the one we know should be present. (Obviously, if other runtime
+        // helper functions of this sort crop up in the future, this should be expanded
+        // into a "builtins map".)
+        if (result == 0 && name == "__udivdi3") {
+            result = (uint64_t) &__udivdi3;
+        }
+#endif
+        return result;
     }
 
     uint8_t *allocateCodeSection(uintptr_t size, unsigned alignment, unsigned section_id, StringRef section_name) override {


### PR DESCRIPTION
This is a workaround for an odd corner case (cross-compiling + testing Python bindings x86-32 on an x86-64 system): 

`__udivdi3` is a helper function that GCC uses to do u64/u64 division on 32-bit systems; it's usually included by the linker on these systems as needed. 

When we JIT, LLVM will include references to this call; MCJIT fixes up these references by doing (essentially) `dlopen(NULL)` + `dlsym()` to look up the symbol. For normal JIT tests, this works fine, as `dlopen(NULL)` finds the test executable, which has the right lookups to locate it inside libHalide.so. 

If, however, we are running a JIT-via-Python test, `dlopen(NULL)` returns the CPython executable... which apparently *doesn't* include this as an exported function, so the lookup fails and very confusing crashiness ensues. 

Our workaround here is a bit icky, but expedient: check for this name if we can't find it elsewhere, and if so, return the one we know should be present.

(Also: drive-by fix to test/correctness/buffer.py for 32-bit systems to avoid allocation failures.)