### PR TITLE
Add 'override' for virtual dtors as needed

### DIFF
--- a/src/CodeGen_GPU_Host.h
+++ b/src/CodeGen_GPU_Host.h
@@ -31,7 +31,7 @@ public:
      * appropriate flags from Target */
     CodeGen_GPU_Host(Target);
 
-    virtual ~CodeGen_GPU_Host();
+    ~CodeGen_GPU_Host() override;
 
 protected:
     void compile_func(const LoweredFunc &func, const std::string &simple_name, const std::string &extern_name) override;

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -62,7 +62,7 @@ public:
     static CodeGen_LLVM *new_for_target(const Target &target,
                                         llvm::LLVMContext &context);
 
-    virtual ~CodeGen_LLVM();
+    ~CodeGen_LLVM() override;
 
     /** Takes a halide Module and compiles it to an llvm Module. */
     virtual std::unique_ptr<llvm::Module> compile(const Module &module);

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -153,7 +153,7 @@ struct ExprNode : public BaseExprNode {
     ExprNode()
         : BaseExprNode(T::_node_type) {
     }
-    virtual ~ExprNode() = default;
+    ~ExprNode() override = default;
 };
 
 template<typename T>
@@ -163,7 +163,7 @@ struct StmtNode : public BaseStmtNode {
     StmtNode()
         : BaseStmtNode(T::_node_type) {
     }
-    virtual ~StmtNode() = default;
+    ~StmtNode() override = default;
 };
 
 /** IR nodes are passed around opaque handles to them. This is a

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -3041,7 +3041,7 @@ public:
 
 class GeneratorBase : public NamesInterface, public GeneratorContext {
 public:
-    virtual ~GeneratorBase();
+    ~GeneratorBase() override;
 
     void set_generator_param_values(const GeneratorParamsMap &params);
 

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -91,7 +91,7 @@ std::ostream &operator<<(std::ostream &stream, const Indentation &);
  */
 class IRPrinter : public IRVisitor {
 public:
-    virtual ~IRPrinter();
+    ~IRPrinter() override;
 
     /** Construct an IRPrinter pointed at a given output stream
      * (e.g. std::cout, or a std::ofstream) */


### PR DESCRIPTION
Clang's `-Winconsistent-missing-destructor-override` warning catches these; we don't use this yet, but will after #4644 lands.