### PR TITLE
Fix incorrect int-promotion in Python bindings

### DIFF
--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -165,7 +165,7 @@ def test_basics4():
     f.compile_jit()
 
 def test_basics5():
-    # Test Func.inside()
+    # Test Func.in_()
     x, y = hl.Var('x'), hl.Var('y')
     f = hl.Func('f')
     g = hl.Func('g')
@@ -234,6 +234,38 @@ def test_operator_order():
     hl.Expr(1) + f[x]
     1 + f[x]
 
+def _check_is_u16(e):
+    assert e.type() == hl.UInt(16), e.type()
+
+def test_int_promotion():
+    # Verify that (Exprlike op literal) correctly matches the type
+    # of the literal to the Exprlike (rather than promoting the result to int32).
+    # All types that use add_binary_operators() should be tested here.
+
+    x = hl.Var('x')
+    # All the binary ops are handled the same, so + is good enough
+
+    # Exprlike = FuncRef
+    f = hl.Func('f')
+    f[x] = hl.u16(x)
+    _check_is_u16(f[x] + 2)
+    _check_is_u16(2 + f[x])
+
+    # Exprlike = Expr
+    e = hl.Expr(f[x])
+    _check_is_u16(e + 2)
+    _check_is_u16(2 + e)
+
+    # Exprlike = Param
+    p = hl.Param(hl.UInt(16))
+    _check_is_u16(p + 2)
+    _check_is_u16(2 + p)
+
+    # Exprlike = RDom/RVar
+    # Exprlike = Var
+    # (skipped, since these can never have values of any type other than int32)
+
+
 if __name__ == "__main__":
     test_compiletime_error()
     test_runtime_error()
@@ -241,6 +273,7 @@ if __name__ == "__main__":
     test_misused_or()
     test_float_or_int()
     test_operator_order()
+    test_int_promotion()
     test_basics()
     test_basics2()
     test_basics3()

--- a/python_bindings/correctness/float_precision_test.py
+++ b/python_bindings/correctness/float_precision_test.py
@@ -49,6 +49,10 @@ def test():
     assert ctx.occurred, "RuntimeWarning didn't occur."
 
     with AssertWarnsContext(RuntimeWarning) as ctx:
+        x + hl.f64(0.123456789012345678)
+    assert not ctx.occurred, "RuntimeWarning occurred."
+
+    with AssertWarnsContext(RuntimeWarning) as ctx:
         x + 0.75  # 0.5 + 0.25
     assert not ctx.occurred, "RuntimeWarning occurred."
 

--- a/python_bindings/src/PyBinaryOperators.h
+++ b/python_bindings/src/PyBinaryOperators.h
@@ -6,24 +6,123 @@
 namespace Halide {
 namespace PythonBindings {
 
+#define DEBUG_BINARY_OPS 0
+
+#if DEBUG_BINARY_OPS
+
+inline std::string type_to_str(const Type &t) {
+    std::ostringstream o;
+    o << "h::" << t;
+    return o.str();
+}
+
+template<typename T, typename T2 = void>
+inline std::string type_desc(const T &v) {
+    return "<unknown>";
+}
+
+template<>
+inline std::string type_desc(const Halide::Expr &v) {
+    return "Expr(" + type_to_str(v.type()) + ")";
+}
+
+template<>
+inline std::string type_desc(const Halide::Var &v) {
+    return "Var(" + type_to_str(Int(32)) + ")";
+}
+
+template<typename T2>
+inline std::string type_desc(const Halide::Param<T2> &v) {
+    return "Param(" + type_to_str(Int(32)) + ")";
+}
+
+template<>
+inline std::string type_desc(const Halide::FuncTupleElementRef &v) {
+    return "FuncTupleElementRef(" + type_to_str(v.function().output_types()[0]) + ")";
+}
+
+template<>
+inline std::string type_desc(const Halide::FuncRef &v) {
+    return "FuncRef(" + type_to_str(v.function().output_types()[0]) + ")";
+}
+
+#define HANDLE_SCALAR_TYPE(x)                  \
+    template<>                                 \
+    inline std::string type_desc(const x &v) { \
+        return #x;                             \
+    }
+
+HANDLE_SCALAR_TYPE(bool)
+HANDLE_SCALAR_TYPE(uint8_t)
+HANDLE_SCALAR_TYPE(uint16_t)
+HANDLE_SCALAR_TYPE(uint32_t)
+HANDLE_SCALAR_TYPE(uint64_t)
+HANDLE_SCALAR_TYPE(int8_t)
+HANDLE_SCALAR_TYPE(int16_t)
+HANDLE_SCALAR_TYPE(int32_t)
+HANDLE_SCALAR_TYPE(int64_t)
+HANDLE_SCALAR_TYPE(float16_t)
+HANDLE_SCALAR_TYPE(float)
+HANDLE_SCALAR_TYPE(double)
+
+#undef HANDLE_SCALAR_TYPE
+
+#define LOG_PY_BINARY_OP(self, op, other, result)                  \
+    do {                                                           \
+        std::cout << (self) << ":" << type_desc(self) << " "       \
+                  << (op)                                          \
+                  << " " << (other) << ":" << type_desc(other)     \
+                  << " -> "                                        \
+                  << (result) << ":" << type_desc(result) << "\n"; \
+    } while (0)
+
+#else  // DEBUG_BINARY_OPS
+
+#define LOG_PY_BINARY_OP(self, op, other, result) \
+    do {                                          \
+    } while (0)
+
+#endif  // DEBUG_BINARY_OPS
+
+struct DoubleToExprCheck {
+    const Expr e;
+    explicit DoubleToExprCheck(double d)
+        : e(double_to_expr_check(d)) {
+    }
+    operator Expr() const {
+        return e;
+    }
+};
+
 template<typename other_t, typename PythonClass>
 void add_binary_operators_with(PythonClass &class_instance) {
     using self_t = typename PythonClass::type;
+    // If 'other_t' is double, we want to wrap it as an Expr() prior to calling the binary op
+    // (so that double literals that lose precision when converted to float issue warnings).
+    // For any other type, we just want to leave it as-is.
+    using Promote = typename std::conditional<
+        std::is_same<other_t, double>::value,
+        DoubleToExprCheck,
+        other_t>::type;
 
-#define BINARY_OP(op, method)                                                         \
-    do {                                                                              \
-        class_instance.def(                                                           \
-            "__" #method "__",                                                        \
-            [](const self_t &self, const other_t &other) -> decltype(self op other) { \
-                return self op other;                                                 \
-            },                                                                        \
-            py::is_operator());                                                       \
-        class_instance.def(                                                           \
-            "__r" #method "__",                                                       \
-            [](const self_t &self, const other_t &other) -> decltype(self op other) { \
-                return other op self;                                                 \
-            },                                                                        \
-            py::is_operator());                                                       \
+#define BINARY_OP(op, method)                                                                  \
+    do {                                                                                       \
+        class_instance.def(                                                                    \
+            "__" #method "__",                                                                 \
+            [](const self_t &self, const other_t &other) -> decltype(self op Promote(other)) { \
+                auto result = self op Promote(other);                                          \
+                LOG_PY_BINARY_OP(self, #method, other, result);                                \
+                return result;                                                                 \
+            },                                                                                 \
+            py::is_operator());                                                                \
+        class_instance.def(                                                                    \
+            "__r" #method "__",                                                                \
+            [](const self_t &self, const other_t &other) -> decltype(Promote(other) op self) { \
+                auto result = Promote(other) op self;                                          \
+                LOG_PY_BINARY_OP(self, "r" #method, other, result);                            \
+                return result;                                                                 \
+            },                                                                                 \
+            py::is_operator());                                                                \
     } while (0)
 
     BINARY_OP(+, add);
@@ -46,13 +145,9 @@ void add_binary_operators_with(PythonClass &class_instance) {
 
 #undef BINARY_OP
 
-    const auto pow_wrap = [](const self_t &self, const other_t &other) -> decltype(Halide::pow(self, other)) {
-        return Halide::pow(self, other);
-    };
-
-    const auto floordiv_wrap = [](const self_t &self, const other_t &other) -> decltype(self / other) {
-        static_assert(std::is_same<decltype(self / other), Expr>::value, "We expect all operator// overloads to produce Expr");
-        Expr e = self / other;
+    const auto floordiv_wrap = [](const self_t &self, const other_t &other) -> decltype(self / Promote(other)) {
+        static_assert(std::is_same<decltype(self / Promote(other)), Expr>::value, "We expect all operator// overloads to produce Expr");
+        Expr e = self / Promote(other);
         if (e.type().is_float()) {
             e = Halide::floor(e);
         }
@@ -60,8 +155,6 @@ void add_binary_operators_with(PythonClass &class_instance) {
     };
 
     class_instance
-        .def("__pow__", pow_wrap, py::is_operator())
-        .def("__rpow__", pow_wrap, py::is_operator())
         .def("__floordiv__", floordiv_wrap, py::is_operator())
         .def("__rfloordiv__", floordiv_wrap, py::is_operator());
 }  // namespace PythonBindings
@@ -71,11 +164,21 @@ void add_binary_operators(PythonClass &class_instance) {
     using self_t = typename PythonClass::type;
 
     // The order of definitions matters.
-    // Python first will try input value as int, then float, then self_t
+    // Python first will try input value as int, then double, then self_t
+    // (note that we skip 'float' because we should never encounter that in python;
+    // all floating-point literals should be double)
     add_binary_operators_with<self_t>(class_instance);
     add_binary_operators_with<Expr>(class_instance);
-    add_binary_operators_with<float>(class_instance);
+    add_binary_operators_with<double>(class_instance);
     add_binary_operators_with<int>(class_instance);
+
+    // Halide::pow() has only an Expr, Expr variant
+    const auto pow_wrap = [](const Expr &self, const Expr &other) -> decltype(Halide::pow(self, other)) {
+        return Halide::pow(self, other);
+    };
+    class_instance
+        .def("__pow__", pow_wrap, py::is_operator())
+        .def("__rpow__", pow_wrap, py::is_operator());
 
     // Define unary operators
     class_instance

--- a/python_bindings/src/PyExpr.cpp
+++ b/python_bindings/src/PyExpr.cpp
@@ -29,25 +29,7 @@ void define_expr(py::module &m) {
             // Python float is implemented by double
             // But Halide prohibits implicitly construct by double.
             .def(py::init([](double v) {
-                float f = static_cast<float>(v);
-                double check = static_cast<double>(f);
-                // 2^(-n) (or some combination) case is safe. e.g. 0.5, 0.25, 0.75, ...
-                // otherwise, precision will be lost.  e.g. 0.1, 0.3, ...
-                using Internal::reinterpret_bits;
-                if (reinterpret_bits<uint64_t>(v) != reinterpret_bits<uint64_t>(check)) {
-                    std::ostringstream oss;
-                    oss.precision(17);
-                    oss << std::fixed << v;
-                    PyErr_WarnEx(
-                        PyExc_RuntimeWarning,
-                        ("The floating-point value " +
-                         oss.str() +
-                         " will be interpreted as a float32 by Halide and lose precision;"
-                         " add an explicit `f32()` or `f64()`` cast to avoid this warning.")
-                            .c_str(),
-                        0);
-                }
-                return Expr(f);
+                return double_to_expr_check(v);
             }))
             .def(py::init<std::string>())
 

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -1,6 +1,5 @@
 #include "PyFunc.h"
 
-#include "PyBinaryOperators.h"
 #include "PyBuffer.h"
 #include "PyExpr.h"
 #include "PyFuncRef.h"

--- a/python_bindings/src/PyFuncRef.cpp
+++ b/python_bindings/src/PyFuncRef.cpp
@@ -10,7 +10,7 @@ void define_func_ref(py::module &m) {
         py::class_<FuncTupleElementRef>(m, "FuncTupleElementRef")
             .def("index", &FuncTupleElementRef::index);
 
-    add_binary_operators_with<Expr>(func_tuple_element_ref_class);
+    add_binary_operators(func_tuple_element_ref_class);
 
     auto func_ref_class =
         py::class_<FuncRef>(m, "FuncRef")
@@ -18,7 +18,7 @@ void define_func_ref(py::module &m) {
             .def("size", &FuncRef::size)
             .def("__len__", &FuncRef::size);
 
-    add_binary_operators_with<Expr>(func_ref_class);
+    add_binary_operators(func_ref_class);
 }
 
 }  // namespace PythonBindings

--- a/python_bindings/src/PyHalide.cpp
+++ b/python_bindings/src/PyHalide.cpp
@@ -61,3 +61,31 @@ PYBIND11_MODULE(HALIDE_PYBIND_MODULE_NAME, m) {
     // There is no PyUtil yet, so just put this here
     m.def("load_plugin", &Halide::load_plugin, py::arg("lib_name"));
 }
+
+namespace Halide {
+namespace PythonBindings {
+
+Expr double_to_expr_check(double v) {
+    float f = static_cast<float>(v);
+    double check = static_cast<double>(f);
+    // 2^(-n) (or some combination) case is safe. e.g. 0.5, 0.25, 0.75, ...
+    // otherwise, precision will be lost.  e.g. 0.1, 0.3, ...
+    using Internal::reinterpret_bits;
+    if (reinterpret_bits<uint64_t>(v) != reinterpret_bits<uint64_t>(check)) {
+        std::ostringstream oss;
+        oss.precision(17);
+        oss << std::fixed << v;
+        PyErr_WarnEx(
+            PyExc_RuntimeWarning,
+            ("The floating-point value " +
+             oss.str() +
+             " will be interpreted as a float32 by Halide and lose precision;"
+             " add an explicit `f32()` or `f64()`` cast to avoid this warning.")
+                .c_str(),
+            0);
+    }
+    return Expr(f);
+}
+
+}  // namespace PythonBindings
+}  // namespace Halide

--- a/python_bindings/src/PyHalide.h
+++ b/python_bindings/src/PyHalide.h
@@ -32,6 +32,8 @@ std::vector<T> args_to_vector(const py::args &args, size_t start_offset = 0, siz
     return v;
 }
 
+Expr double_to_expr_check(double v);
+
 }  // namespace PythonBindings
 }  // namespace Halide
 

--- a/python_bindings/src/PyParam.cpp
+++ b/python_bindings/src/PyParam.cpp
@@ -63,7 +63,7 @@ void define_param(py::module &m) {
     add_param_methods<float>(param_class);
     add_param_methods<double>(param_class);
 
-    add_binary_operators_with<Expr>(param_class);
+    add_binary_operators(param_class);
 
     m.def("user_context_value", &user_context_value);
 }

--- a/python_bindings/src/PyRDom.cpp
+++ b/python_bindings/src/PyRDom.cpp
@@ -17,7 +17,7 @@ void define_rvar(py::module &m) {
 
     py::implicitly_convertible<RDom, RVar>();
 
-    add_binary_operators_with<Expr>(rvar_class);
+    add_binary_operators(rvar_class);
 }
 
 void define_rdom(py::module &m) {
@@ -39,7 +39,7 @@ void define_rdom(py::module &m) {
             .def_readonly("z", &RDom::z)
             .def_readonly("w", &RDom::w);
 
-    add_binary_operators_with<Expr>(rdom_class);
+    add_binary_operators(rdom_class);
 }
 
 }  // namespace PythonBindings

--- a/python_bindings/src/PyVar.cpp
+++ b/python_bindings/src/PyVar.cpp
@@ -30,7 +30,7 @@ void define_var(py::module &m) {
             .def("__repr__", &var_repr)
             .def("__str__", &Var::name);
 
-    add_binary_operators_with<Expr>(var_class);
+    add_binary_operators(var_class);
 
     m.attr("_") = Halide::Var(Halide::_);
     m.attr("_0") = Halide::Var(Halide::_0);


### PR DESCRIPTION
Fixes a subtle bug in the python bindings regarding int and float handling in binary ops.

(1) In Halide, a binary op with an integer literal and an Expr should implicitly coerce the integer literal to the same type as the Expr; in Python, this was handled correctly for the cases where one type was *really* an Expr, but not for the cases where it was merely Expr-like (e.g. a FuncRef). This cleans that up and adds tests.

(2) Adding the fix above ended up breaking our detection for double->rounding errors, because we only handled this for explicit Expr conversions, rather than when the conversion was implicit from a binary operator. Restructured the checking for this case so that it should be more uniform.