### PR TITLE
Fix python tutorials

### DIFF
--- a/python_bindings/src/PyBuffer.cpp
+++ b/python_bindings/src/PyBuffer.cpp
@@ -268,6 +268,20 @@ public:
 
     PyBuffer(py::buffer buffer, const std::string &name)
         : PyBuffer(buffer.request(/*writable*/ true), name) {
+        // Default to setting host-dirty on any PyBuffer we create from an existing py::buffer;
+        // this allows (e.g.) code like
+        //
+        //     input = hl.Buffer(imageio.imread(image_path))
+        //
+        // to work as you'd expected when the buffer is used for input. (Without
+        // host_dirty being set, copying to GPU can be skipped and produce surprising
+        // results.)
+        //
+        // Note that this is a bit different from the C++ Buffer<> ctors that
+        // take pointer-to-existing data (which do *not* set host dirty); a crucial
+        // difference there is that those also do not take ownership, but here,
+        // we always take (shared) ownership of the underlying buffer.
+        this->set_host_dirty();
     }
 
     virtual ~PyBuffer() {

--- a/python_bindings/src/PyTarget.cpp
+++ b/python_bindings/src/PyTarget.cpp
@@ -60,6 +60,10 @@ void define_target(py::module &m) {
     m.def("get_target_from_environment", &get_target_from_environment);
     m.def("get_jit_target_from_environment", &get_jit_target_from_environment);
     m.def("target_feature_for_device_api", &target_feature_for_device_api);
+
+    // TODO: this really belong in PyDeviceInterface.cpp (once it exists);
+    // it's here as an expedient to make our tutorials work more cleanly.
+    m.def("host_supports_target_device", &host_supports_target_device);
 }
 
 }  // namespace PythonBindings

--- a/python_bindings/tutorial/lesson_01_basics.py
+++ b/python_bindings/tutorial/lesson_01_basics.py
@@ -81,7 +81,8 @@ def main():
         for i in range(output.width()):
             # We can access a pixel of an hl.Buffer object using similar
             # syntax to defining and using functions.
-            assert output[i, j] == i + j, "Something went wrong!\n" \
+            assert output[i, j] == i + j, \
+                "Something went wrong!\n" + \
                 "Pixel %d, %d was supposed to be %d, but instead it's %d\n" % (
                     i, j, i + j, output[i, j])
 

--- a/python_bindings/tutorial/lesson_01_basics.py
+++ b/python_bindings/tutorial/lesson_01_basics.py
@@ -5,25 +5,11 @@
 # This lesson demonstrates basic usage of Halide as a JIT compiler for imaging.
 
 # This lesson can be built by invoking the command:
-#    make tutorial_lesson_01_basics
-# in a shell with the current directory at the top of the halide source tree.
-# Otherwise, see the platform-specific compiler invocations below.
-
-# On linux, you can compile and run it like so:
-# g++ lesson_01*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_01 -std=c++11
-# LD_LIBRARY_PATH=../bin ./lesson_01
-
-# On os x:
-# g++ lesson_01*.cpp -g -I ../include -L ../bin -lHalide -o lesson_01 -std=c++11
-# DYLD_LIBRARY_PATH=../bin ./lesson_01
-
-# The only Halide header file you need is Halide.h. It includes all of Halide.
-#include "Halide.h"
-
-# We'll also include stdio for printf.
-#include <stdio.h>
+#    make test_tutorial_lesson_01_basics
+# in a shell with the current directory at python_bindings/
 
 import halide as hl
+
 
 def main():
 
@@ -95,12 +81,9 @@ def main():
         for i in range(output.width()):
             # We can access a pixel of an hl.Buffer object using similar
             # syntax to defining and using functions.
-            if (output[i, j] != i + j):
-                print("Something went wrong!\n"
-                       "Pixel %d, %d was supposed to be %d, but instead it's %d\n"
-                        % (i, j, i+j, output[i, j]))
-                return -1
-
+            assert output[i, j] == i + j, "Something went wrong!\n" \
+                "Pixel %d, %d was supposed to be %d, but instead it's %d\n" % (
+                    i, j, i + j, output[i, j])
 
     # Everything worked! We defined a hl.Func, then called 'realize' on
     # it to generate and run machine code that produced a hl.Buffer.

--- a/python_bindings/tutorial/lesson_02_input_image.py
+++ b/python_bindings/tutorial/lesson_02_input_image.py
@@ -18,8 +18,7 @@ def main():
     # brightens an image.
 
     # First we'll load the input image we wish to brighten.
-    image_path = os.path.join(os.path.dirname(
-        __file__), "../../tutorial/images/rgb.png")
+    image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/rgb.png")
 
     # We create a hl.Buffer object to wrap the numpy array
     input = hl.Buffer(imageio.imread(image_path))
@@ -83,8 +82,7 @@ def main():
     # smaller size. If we request a larger size Halide will throw an
     # error at runtime telling us we're trying to read out of bounds
     # on the input image.
-    output_image = brighter.realize(
-        input.width(), input.height(), input.channels())
+    output_image = brighter.realize(input.width(), input.height(), input.channels())
     assert output_image.type() == hl.UInt(8)
 
     # Save the output for inspection. It should look like a bright parrot.

--- a/python_bindings/tutorial/lesson_02_input_image.py
+++ b/python_bindings/tutorial/lesson_02_input_image.py
@@ -3,25 +3,14 @@
 # This lesson demonstrates how to pass in input images.
 
 # This lesson can be built by invoking the command:
-#    make tutorial_lesson_02_input_image
-# in a shell with the current directory at the top of the halide source tree.
-# Otherwise, see the platform-specific compiler invocations below.
-
-# On linux, you can compile and run it like so:
-# g++ lesson_02*.cpp -g -I ../include -L ../bin -lHalide `libpng-config --cflags --ldflags` -lpthread -ldl -o lesson_02 -std=c++11
-# LD_LIBRARY_PATH=../bin ./lesson_02
-
-# On os x:
-# g++ lesson_02*.cpp -g -I ../include -L ../bin -lHalide `libpng-config --cflags --ldflags` -o lesson_02 -std=c++11
-# DYLD_LIBRARY_PATH=../bin ./lesson_02
-
-# The only Halide header file you need is Halide.h. It includes all of Halide.
-#include "Halide.h"
+#    make test_tutorial_lesson_02_input_image
+# in a shell with the current directory at python_bindings/
 
 import halide as hl
 import numpy as np
 import imageio
 import os.path
+
 
 def main():
 
@@ -29,7 +18,8 @@ def main():
     # brightens an image.
 
     # First we'll load the input image we wish to brighten.
-    image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/rgb.png")
+    image_path = os.path.join(os.path.dirname(
+        __file__), "../../tutorial/images/rgb.png")
 
     # We create a hl.Buffer object to wrap the numpy array
     input = hl.Buffer(imageio.imread(image_path))
@@ -93,7 +83,8 @@ def main():
     # smaller size. If we request a larger size Halide will throw an
     # error at runtime telling us we're trying to read out of bounds
     # on the input image.
-    output_image = brighter.realize(input.width(), input.height(), input.channels())
+    output_image = brighter.realize(
+        input.width(), input.height(), input.channels())
     assert output_image.type() == hl.UInt(8)
 
     # Save the output for inspection. It should look like a bright parrot.

--- a/python_bindings/tutorial/lesson_03_debugging_1.py
+++ b/python_bindings/tutorial/lesson_03_debugging_1.py
@@ -1,23 +1,16 @@
 #!/usr/bin/python3
+
 # Halide tutorial lesson 3
 
-# This lesson demonstrates how to inspect what the Halide compiler is producing.
+# This lesson demonstrates how to inspect what the Halide compiler is
+# producing.
 
 # This lesson can be built by invoking the command:
-#    make tutorial_lesson_03_debugging_1
-# in a shell with the current directory at the top of the halide source tree.
-# Otherwise, see the platform-specific compiler invocations below.
-
-# On linux, you can compile and run it like so:
-# g++ lesson_03*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_03 -std=c++11
-# LD_LIBRARY_PATH=../bin ./lesson_03
-
-# On os x:
-# g++ lesson_03*.cpp -g -I ../include -L ../bin -lHalide -o lesson_03 -std=c++11
-# DYLD_LIBRARY_PATH=../bin ./lesson_03
-
+#    make test_tutorial_lesson_03_debugging_1
+# in a shell with the current directory at python_bindings/
 
 import halide as hl
+
 
 def main():
 

--- a/python_bindings/tutorial/lesson_04_debugging_2.py
+++ b/python_bindings/tutorial/lesson_04_debugging_2.py
@@ -1,25 +1,15 @@
 #!/usr/bin/python3
+
 # Halide tutorial lesson 4
 
 # This lesson demonstrates how to follow what Halide is doing at runtime.
 
 # This lesson can be built by invoking the command:
-#    make tutorial_lesson_04_debugging_2
-# in a shell with the current directory at the top of the halide source tree.
-# Otherwise, see the platform-specific compiler invocations below.
+#    make test_tutorial_lesson_04_debugging_2
+# in a shell with the current directory at python_bindings/
 
-# On linux, you can compile and run it like so:
-# g++ lesson_04*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_04 -std=c++11
-# LD_LIBRARY_PATH=../bin ./lesson_04
-
-# On os x:
-# g++ lesson_04*.cpp -g -I ../include -L ../bin -lHalide -o lesson_04 -std=c++11
-# DYLD_LIBRARY_PATH=../bin ./lesson_04
-
-#include "Halide.h"
-#include <stdio.h>
-#using namespace Halide
 import halide as hl
+
 
 def main():
 

--- a/python_bindings/tutorial/lesson_05_scheduling_1.py
+++ b/python_bindings/tutorial/lesson_05_scheduling_1.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+
 # Halide tutorial lesson 5
 
 # This lesson demonstrates how to manipulate the order in which you
@@ -6,22 +7,10 @@
 # parallelization, unrolling, and tiling.
 
 # This lesson can be built by invoking the command:
-#    make tutorial_lesson_05_scheduling_1
-# in a shell with the current directory at the top of the halide source tree.
-# Otherwise, see the platform-specific compiler invocations below.
-
-# On linux, you can compile and run it like so:
-# g++ lesson_05*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_05 -std=c++11
-# LD_LIBRARY_PATH=../bin ./lesson_05
-
-# On os x:
-# g++ lesson_05*.cpp -g -I ../include -L ../bin -lHalide -o lesson_05 -std=c++11
-# DYLD_LIBRARY_PATH=../bin ./lesson_05
-
-#include "Halide.h"
-#include <stdio.h>
-#using namespace Halide
+#    make test_tutorial_lesson_05_scheduling_1
+# in a shell with the current directory at python_bindings/
 import halide as hl
+
 
 def main():
 
@@ -29,7 +18,7 @@ def main():
     # several different ways, and see what order pixels are computed
     # in.
 
-    x, y = hl.Var("x"), hl.Var ("y")
+    x, y = hl.Var("x"), hl.Var("y")
 
     # First we observe the default ordering.
     if True:
@@ -50,7 +39,6 @@ def main():
             for xx in range(4):
                 print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
 
-
         print("\n")
 
         # Tracing is one useful way to understand what a schedule is
@@ -66,11 +54,9 @@ def main():
         #     for x:
         #       gradient(...) = ...
 
-
     # Reorder variables.
     if True:
         gradient = hl.Func("gradient_col_major")
-        print("x, y", x, y)
         gradient[x, y] = x + y
         gradient.trace_stores()
 
@@ -80,7 +66,6 @@ def main():
         # generated. The arguments are specified from the innermost
         # loop out, so the following call puts y in the inner loop:
         gradient.reorder(y, x)
-        #gradient.reorder((y, x))
 
         # This means y (the row) will vary quickly, and x (the
         # column) will vary slowly, so this is a column-major
@@ -101,7 +86,6 @@ def main():
         print("Pseudo-code for the schedule:")
         gradient.print_loop_nest()
         print()
-
 
     # Split a variable into two.
     if True:
@@ -132,7 +116,8 @@ def main():
             for x_outer in range(2):
                 for x_inner in range(2):
                     xx = x_outer * 2 + x_inner
-                    print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
+                    print("Evaluating at x = %d, y = %d: %d" %
+                          (xx, yy, xx + yy))
 
         print()
 
@@ -144,7 +129,6 @@ def main():
         # change! Splitting by itself does nothing, but it does open
         # up all of the scheduling possibilities that we will explore
         # below.
-
 
     # Fuse two variables into one.
     if True:
@@ -164,7 +148,7 @@ def main():
         output = gradient.realize(4, 4)
 
         print("Equivalent C:")
-        for fused in range(4*4):
+        for fused in range(4 * 4):
             yy = fused / 4
             xx = fused % 4
             print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
@@ -174,7 +158,6 @@ def main():
         print("Pseudo-code for the schedule:")
         gradient.print_loop_nest()
         print()
-
 
     # Evaluating in tiles.
     if True:
@@ -210,14 +193,14 @@ def main():
                     for x_inner in range(2):
                         xx = x_outer * 2 + x_inner
                         yy = y_outer * 2 + y_inner
-                        print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
+                        print("Evaluating at x = %d, y = %d: %d" %
+                              (xx, yy, xx + yy))
 
         print()
 
         print("Pseudo-code for the schedule:")
         gradient.print_loop_nest()
         print()
-
 
     # Evaluating in vectors.
     if True:
@@ -264,24 +247,23 @@ def main():
                 # expression. On x86 processors, Halide generates SSE
                 # for all of this.
                 x_vec = [x_outer * 4 + 0,
-                               x_outer * 4 + 1,
-                               x_outer * 4 + 2,
-                               x_outer * 4 + 3]
+                         x_outer * 4 + 1,
+                         x_outer * 4 + 2,
+                         x_outer * 4 + 3]
                 val = [x_vec[0] + yy,
-                             x_vec[1] + yy,
-                             x_vec[2] + yy,
-                             x_vec[3] + yy]
+                       x_vec[1] + yy,
+                       x_vec[2] + yy,
+                       x_vec[3] + yy]
                 print("Evaluating at <%d, %d, %d, %d>, <%d, %d, %d, %d>: <%d, %d, %d, %d>" % (
-                       x_vec[0], x_vec[1], x_vec[2], x_vec[3],
-                       yy, yy, yy, yy,
-                       val[0], val[1], val[2], val[3]))
+                    x_vec[0], x_vec[1], x_vec[2], x_vec[3],
+                    yy, yy, yy, yy,
+                    val[0], val[1], val[2], val[3]))
 
         print()
 
         print("Pseudo-code for the schedule:")
         gradient.print_loop_nest()
         print()
-
 
     # Unrolling a loop.
     if True:
@@ -305,7 +287,6 @@ def main():
         print("Evaluating gradient unrolled by a factor of two")
         result = gradient.realize(4, 4)
 
-
         print("Equivalent C:")
         for yy in range(4):
             for x_outer in range(2):
@@ -314,19 +295,20 @@ def main():
                 if True:
                     x_inner = 0
                     xx = x_outer * 2 + x_inner
-                    print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
+                    print("Evaluating at x = %d, y = %d: %d" %
+                          (xx, yy, xx + yy))
 
                 if True:
                     x_inner = 1
                     xx = x_outer * 2 + x_inner
-                    print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
+                    print("Evaluating at x = %d, y = %d: %d" %
+                          (xx, yy, xx + yy))
 
         print()
 
         print("Pseudo-code for the schedule:")
         gradient.print_loop_nest()
         print()
-
 
     # Splitting by factors that don't divide the extent.
     if True:
@@ -349,7 +331,7 @@ def main():
 
         print("Equivalent C:")
         for yy in range(4):
-            for x_outer in range(3): # Now runs from 0 to 3
+            for x_outer in range(3):  # Now runs from 0 to 3
                 for x_inner in range(2):
                     xx = x_outer * 2
                     # Before we add x_inner, make sure we don't
@@ -359,7 +341,8 @@ def main():
                     if xx > 3:
                         xx = 3
                     xx += x_inner
-                    print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
+                    print("Evaluating at x = %d, y = %d: %d" %
+                          (xx, yy, xx + yy))
 
         print()
 
@@ -389,7 +372,6 @@ def main():
         # the same point multiple times, so we won't apply this
         # trick. Instead the range of values computed will be rounded
         # up to the next multiple of the split factor.
-
 
     # Fusing, tiling, and parallelizing.
     if True:
@@ -427,7 +409,6 @@ def main():
         #     .fuse(x_outer, y_outer, tile_index)
         #     .parallel(tile_index)
 
-
         print("Evaluating gradient tiles in parallel")
         output = gradient.realize(4, 4)
 
@@ -435,7 +416,8 @@ def main():
         # tile the pixels will be traversed in row-major order.
 
         print("Equivalent (serial) C:")
-        # This outermost loop should be a parallel for loop, but that's hard in C.
+        # This outermost loop should be a parallel for loop, but that's hard in
+        # C.
         for tile_index in range(4):
             y_outer = tile_index / 2
             x_outer = tile_index % 2
@@ -443,14 +425,14 @@ def main():
                 for x_inner in range(2):
                     yy = y_outer * 2 + y_inner
                     xx = x_outer * 2 + x_inner
-                    print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
+                    print("Evaluating at x = %d, y = %d: %d" %
+                          (xx, yy, xx + yy))
 
         print()
 
         print("Pseudo-code for the schedule:")
         gradient.print_loop_nest()
         print()
-
 
     # Putting it all together.
     if True:
@@ -472,7 +454,8 @@ def main():
         # express this is to recursively tile again within each tile
         # into 4x2 subtiles, then vectorize the subtiles across x and
         # unroll them across y:
-        x_inner_outer, y_inner_outer = hl.Var("x_inner_outer"), hl.Var("y_inner_outer")
+        x_inner_outer, y_inner_outer = hl.Var(
+            "x_inner_outer"), hl.Var("y_inner_outer")
         x_vectors, y_pairs = hl.Var("x_vectors"), hl.Var("y_pairs")
         gradient_fast \
             .tile(x_inner, y_inner, x_inner_outer, y_inner_outer, x_vectors, y_pairs, 4, 2) \
@@ -493,54 +476,48 @@ def main():
         result = gradient_fast.realize(800, 600)
 
         print("Checking Halide result against equivalent C...")
-        for tile_index in range(4*3):
+        for tile_index in range(4 * 3):
             y_outer = tile_index // 4
             x_outer = tile_index % 4
-            for y_inner_outer in range(256//2):
-                for x_inner_outer in range(256//4):
+            for y_inner_outer in range(256 // 2):
+                for x_inner_outer in range(256 // 4):
                     # We're vectorized across x
-                    xx = min(x_outer * 256, 800-256) + x_inner_outer*4
+                    xx = min(x_outer * 256, 800 - 256) + x_inner_outer * 4
                     x_vec = [xx + 0,
-                                    xx + 1,
-                                    xx + 2,
-                                    xx + 3]
+                             xx + 1,
+                             xx + 2,
+                             xx + 3]
 
                     # And we unrolled across y
-                    y_base = min(y_outer * 256, 600-256) + y_inner_outer*2
+                    y_base = min(y_outer * 256, 600 - 256) + y_inner_outer * 2
 
                     if True:
                         # y_pairs = 0
                         yy = y_base + 0
                         y_vec = [yy, yy, yy, yy]
                         val = [x_vec[0] + y_vec[0],
-                                      x_vec[1] + y_vec[1],
-                                      x_vec[2] + y_vec[2],
-                                      x_vec[3] + y_vec[3]]
+                               x_vec[1] + y_vec[1],
+                               x_vec[2] + y_vec[2],
+                               x_vec[3] + y_vec[3]]
 
                         # Check the result.
                         for i in range(4):
-                            #print("x_vec[%i], y_vec[%i]" % (i, i),
-                            #      x_vec[i], y_vec[i])
-                            if result[x_vec[i], y_vec[i]] != val[i]:
-                                print("There was an error at %d %d!" % (x_vec[i], y_vec[i]))
-                                return -1
-
-
+                            assert result[x_vec[i], y_vec[i]] == val[
+                                i], "There was an error at %d %d!" % (x_vec[i], y_vec[i])
 
                     if True:
                         # y_pairs = 1
                         yy = y_base + 1
                         y_vec = [yy, yy, yy, yy]
                         val = [x_vec[0] + y_vec[0],
-                                      x_vec[1] + y_vec[1],
-                                      x_vec[2] + y_vec[2],
-                                      x_vec[3] + y_vec[3]]
+                               x_vec[1] + y_vec[1],
+                               x_vec[2] + y_vec[2],
+                               x_vec[3] + y_vec[3]]
 
                         # Check the result.
                         for i in range(4):
-                            if result[x_vec[i], y_vec[i]] != val[i]:
-                                print("There was an error at %d %d!" % (x_vec[i], y_vec[i]))
-
+                            assert result[x_vec[i], y_vec[i]] == val[
+                                i], "There was an error at %d %d!" % (x_vec[i], y_vec[i])
 
         print()
 

--- a/python_bindings/tutorial/lesson_05_scheduling_1.py
+++ b/python_bindings/tutorial/lesson_05_scheduling_1.py
@@ -116,8 +116,7 @@ def main():
             for x_outer in range(2):
                 for x_inner in range(2):
                     xx = x_outer * 2 + x_inner
-                    print("Evaluating at x = %d, y = %d: %d" %
-                          (xx, yy, xx + yy))
+                    print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
 
         print()
 
@@ -193,8 +192,7 @@ def main():
                     for x_inner in range(2):
                         xx = x_outer * 2 + x_inner
                         yy = y_outer * 2 + y_inner
-                        print("Evaluating at x = %d, y = %d: %d" %
-                              (xx, yy, xx + yy))
+                        print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
 
         print()
 
@@ -255,9 +253,7 @@ def main():
                        x_vec[2] + yy,
                        x_vec[3] + yy]
                 print("Evaluating at <%d, %d, %d, %d>, <%d, %d, %d, %d>: <%d, %d, %d, %d>" % (
-                    x_vec[0], x_vec[1], x_vec[2], x_vec[3],
-                    yy, yy, yy, yy,
-                    val[0], val[1], val[2], val[3]))
+                    x_vec[0], x_vec[1], x_vec[2], x_vec[3], yy, yy, yy, yy, val[0], val[1], val[2], val[3]))
 
         print()
 
@@ -295,14 +291,12 @@ def main():
                 if True:
                     x_inner = 0
                     xx = x_outer * 2 + x_inner
-                    print("Evaluating at x = %d, y = %d: %d" %
-                          (xx, yy, xx + yy))
+                    print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
 
                 if True:
                     x_inner = 1
                     xx = x_outer * 2 + x_inner
-                    print("Evaluating at x = %d, y = %d: %d" %
-                          (xx, yy, xx + yy))
+                    print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
 
         print()
 
@@ -341,8 +335,7 @@ def main():
                     if xx > 3:
                         xx = 3
                     xx += x_inner
-                    print("Evaluating at x = %d, y = %d: %d" %
-                          (xx, yy, xx + yy))
+                    print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
 
         print()
 
@@ -425,8 +418,7 @@ def main():
                 for x_inner in range(2):
                     yy = y_outer * 2 + y_inner
                     xx = x_outer * 2 + x_inner
-                    print("Evaluating at x = %d, y = %d: %d" %
-                          (xx, yy, xx + yy))
+                    print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
 
         print()
 
@@ -502,8 +494,8 @@ def main():
 
                         # Check the result.
                         for i in range(4):
-                            assert result[x_vec[i], y_vec[i]] == val[
-                                i], "There was an error at %d %d!" % (x_vec[i], y_vec[i])
+                            assert result[x_vec[i], y_vec[i]] == val[i], \
+                                "There was an error at %d %d!" % (x_vec[i], y_vec[i])
 
                     if True:
                         # y_pairs = 1
@@ -516,8 +508,8 @@ def main():
 
                         # Check the result.
                         for i in range(4):
-                            assert result[x_vec[i], y_vec[i]] == val[
-                                i], "There was an error at %d %d!" % (x_vec[i], y_vec[i])
+                            assert result[x_vec[i], y_vec[i]] == val[i], \
+                                "There was an error at %d %d!" % (x_vec[i], y_vec[i])
 
         print()
 

--- a/python_bindings/tutorial/lesson_06_realizing_over_shifted_domains.py
+++ b/python_bindings/tutorial/lesson_06_realizing_over_shifted_domains.py
@@ -1,27 +1,16 @@
 #!/usr/bin/python3
+
 # Halide tutorial lesson 6.
 
 # This lesson demonstrates how to evaluate a hl.Func over a domain that
 # does not start at (0, 0).
 
 # This lesson can be built by invoking the command:
-#    make tutorial_lesson_06_realizing_over_shifted_domains
-# in a shell with the current directory at the top of the halide source tree.
-# Otherwise, see the platform-specific compiler invocations below.
+#    make test_tutorial_lesson_06_realizing_over_shifted_domains
+# in a shell with the current directory at python_bindings/
 
-# On linux, you can compile and run it like so:
-# g++ lesson_06*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_06 -std=c++11
-# LD_LIBRARY_PATH=../bin ./lesson_06
-
-# On os x:
-# g++ lesson_06*.cpp -g -I ../include -L ../bin -lHalide -o lesson_06 -std=c++11
-# DYLD_LIBRARY_PATH=../bin ./lesson_06
-
-#include "Halide.h"
-#include <stdio.h>
-
-#using namespace Halide
 import halide as hl
+
 
 def main():
 
@@ -31,7 +20,7 @@ def main():
     # domains that do not start at the origin.
 
     # We define our familiar gradient function.
-    gradient = hl.Func ("gradient")
+    gradient = hl.Func("gradient")
     x, y = hl.Var("x"), hl.Var("y")
     gradient[x, y] = x + y
 
@@ -61,20 +50,16 @@ def main():
     # Let's check it did what we expect:
     for yy in range(8):
         for xx in range(8):
-            if result[xx, yy] != xx + yy:
-                print("Something went wrong!")
-                return -1
-
-
-
+            assert result[xx, yy] == xx + yy, "Something went wrong!"
 
     # Now let's evaluate gradient over a 5 x 7 rectangle that starts
     # somewhere else -- at position (100, 50). So x and y will run
     # from (100, 50) to (104, 56) inclusive.
 
     # We start by creating an image that represents that rectangle:
-    shifted = hl.Buffer(hl.Int(32), [5, 7]) # In the constructor we tell it the size.
-    shifted.set_min([100, 50]) # Then we tell it the top-left corner.
+    # In the constructor we tell it the size.
+    shifted = hl.Buffer(hl.Int(32), [5, 7])
+    shifted.set_min([100, 50])  # Then we tell it the top-left corner.
 
     print("Evaluating gradient from (100, 50) to (104, 56)")
 
@@ -87,11 +72,7 @@ def main():
     # that start at (100, 50).
     for yy in range(50, 57):
         for xx in range(100, 105):
-            if shifted[xx, yy] != xx + yy:
-                print("Something went wrong!")
-                return -1
-
-
+            assert shifted[xx, yy] == xx + yy, "Something went wrong!"
 
     # The image 'shifted' stores the value of our hl.Func over a domain
     # that starts at (100, 50), so asking for shifted(0, 0) would in
@@ -102,7 +83,6 @@ def main():
 
     print("Success!")
     return 0
-
 
 
 if __name__ == "__main__":

--- a/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
+++ b/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
@@ -1,37 +1,25 @@
 #!/usr/bin/python3
+
 # Halide tutorial lesson 7
 
 # This lesson demonstrates how express multi-stage pipelines.
 
 # This lesson can be built by invoking the command:
-# make tutorial_lesson_07_multi_stage_pipelines
-# in a shell with the current directory at the top of the halide source tree.
-# Otherwise, see the platform-specific compiler invocations below.
+#    make test_tutorial_lesson_07_multi_stage_pipelines
+# in a shell with the current directory at python_bindings/
 
-# On linux, you can compile and run it like so:
-# g++ lesson_07*.cpp -g -std=c++11 -I ../include -L ../bin -lHalide `libpng-config --cflags --ldflags` -lpthread -ldl -o lesson_07
-# LD_LIBRARY_PATH=../bin ./lesson_07
-
-# On os x:
-# g++ lesson_07*.cpp -g -std=c++11 -I ../include -L ../bin -lHalide `libpng-config --cflags --ldflags` -o lesson_07
-# DYLD_LIBRARY_PATH=../bin ./lesson_07
-
-#include "Halide.h"
-#include <stdio.h>
-
-#using namespace Halide
 import halide as hl
 
-# Support code for loading pngs.
-#include "image_io.h"
 import imageio
 import os.path
+
 
 def main():
     # First we'll declare some Vars to use below.
     x, y, c = hl.Var("x"), hl.Var("y"), hl.Var("c")
 
-    image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/rgb.png")
+    image_path = os.path.join(os.path.dirname(
+        __file__), "../../tutorial/images/rgb.png")
 
     # Now we'll express a multi-stage pipeline that blurs an image
     # first horizontally, and then vertically.
@@ -46,11 +34,13 @@ def main():
 
         # Blur it horizontally:
         blur_x = hl.Func("blur_x")
-        blur_x[x, y, c] = (input_16[x - 1, y, c] + 2 * input_16[x, y, c] + input_16[x + 1, y, c]) / 4
+        blur_x[x, y, c] = (input_16[x - 1, y, c] + 2 *
+                           input_16[x, y, c] + input_16[x + 1, y, c]) / 4
 
         # Blur it vertically:
         blur_y = hl.Func("blur_y")
-        blur_y[x, y, c] = (blur_x[x, y - 1, c] + 2 * blur_x[x, y, c] + blur_x[x, y + 1, c]) / 4
+        blur_y[x, y, c] = (blur_x[x, y - 1, c] + 2 *
+                           blur_x[x, y, c] + blur_x[x, y + 1, c]) / 4
 
         # Convert back to 8-bit.
         output = hl.Func("output")
@@ -85,7 +75,8 @@ def main():
         # over a domain shifted inwards by one pixel, we won't be
         # asking the Halide routine to read out of bounds. We saw how
         # to do this in the previous lesson:
-        result = hl.Buffer(hl.UInt(8), [input.width() - 2, input.height() - 2, 3])
+        result = hl.Buffer(
+            hl.UInt(8), [input.width() - 2, input.height() - 2, 3])
         result.set_min([1, 1])
         output.realize(result)
 
@@ -99,7 +90,6 @@ def main():
         # This is usually the fastest way to deal with boundaries:
         # don't write code that reads out of bounds :) The more
         # general solution is our next example.
-
 
     # The same pipeline, with a boundary condition on the input.
     if True:
@@ -144,11 +134,13 @@ def main():
 
         # Blur it horizontally:
         blur_x = hl.Func("blur_x")
-        blur_x[x, y, c] = (input_16[x - 1, y, c] + 2 * input_16[x, y, c] + input_16[x + 1, y, c]) / 4
+        blur_x[x, y, c] = (input_16[x - 1, y, c] + 2 *
+                           input_16[x, y, c] + input_16[x + 1, y, c]) / 4
 
         # Blur it vertically:
         blur_y = hl.Func("blur_y")
-        blur_y[x, y, c] = (blur_x[x, y - 1, c] + 2 * blur_x[x, y, c] + blur_x[x, y + 1, c]) / 4
+        blur_y[x, y, c] = (blur_x[x, y - 1, c] + 2 *
+                           blur_x[x, y, c] + blur_x[x, y + 1, c]) / 4
 
         # Convert back to 8-bit.
         output = hl.Func("output")

--- a/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
+++ b/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
@@ -18,8 +18,7 @@ def main():
     # First we'll declare some Vars to use below.
     x, y, c = hl.Var("x"), hl.Var("y"), hl.Var("c")
 
-    image_path = os.path.join(os.path.dirname(
-        __file__), "../../tutorial/images/rgb.png")
+    image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/rgb.png")
 
     # Now we'll express a multi-stage pipeline that blurs an image
     # first horizontally, and then vertically.
@@ -75,8 +74,7 @@ def main():
         # over a domain shifted inwards by one pixel, we won't be
         # asking the Halide routine to read out of bounds. We saw how
         # to do this in the previous lesson:
-        result = hl.Buffer(
-            hl.UInt(8), [input.width() - 2, input.height() - 2, 3])
+        result = hl.Buffer(hl.UInt(8), [input.width() - 2, input.height() - 2, 3])
         result.set_min([1, 1])
         output.realize(result)
 

--- a/python_bindings/tutorial/lesson_08_scheduling_2.py
+++ b/python_bindings/tutorial/lesson_08_scheduling_2.py
@@ -1,28 +1,17 @@
 #!/usr/bin/python3
+
 # Halide tutorial lesson 8
 
 # This lesson demonstrates how schedule multi-stage pipelines.
 
 # This lesson can be built by invoking the command:
-#    make tutorial_lesson_08_scheduling_2
-# in a shell with the current directory at the top of the halide source tree.
-# Otherwise, see the platform-specific compiler invocations below.
+#    make test_tutorial_lesson_08_scheduling_2
+# in a shell with the current directory at python_bindings/
 
-# On linux, you can compile and run it like so:
-# g++ lesson_08*.cpp -g -std=c++11 -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_08
-# LD_LIBRARY_PATH=../bin ./lesson_08
-
-# On os x:
-# g++ lesson_08*.cpp -g -std=c++11 -I ../include -L ../bin -lHalide -o lesson_08
-# DYLD_LIBRARY_PATH=../bin ./lesson_08
-
-#include "Halide.h"
-#include <stdio.h>
-
-#using namespace Halide
 import halide as hl
 import numpy as np
 import math
+
 
 def main():
     # First we'll declare some Vars to use below.
@@ -31,8 +20,9 @@ def main():
     # Let's examine various scheduling options for a simple two stage
     # pipeline. We'll start with the default schedule:
     if True:
-        print("="*50)
-        producer, consumer = hl.Func("producer_default"), hl.Func("consumer_default")
+        print("=" * 50)
+        producer, consumer = hl.Func(
+            "producer_default"), hl.Func("consumer_default")
 
         # The first stage will be some simple pointwise math similar
         # to our familiar gradient function. The value at position x,
@@ -42,9 +32,9 @@ def main():
         # Now we'll add a second stage which adds together multiple
         # points in the first stage.
         consumer[x, y] = (producer[x, y] +
-                          producer[x, y+1] +
-                          producer[x+1, y] +
-                          producer[x+1, y+1])
+                          producer[x, y + 1] +
+                          producer[x + 1, y] +
+                          producer[x + 1, y + 1])
 
         # We'll turn on tracing for both functions.
         consumer.trace_stores()
@@ -72,11 +62,10 @@ def main():
         result = np.empty((4, 4), dtype=np.float32)
         for yy in range(4):
             for xx in range(4):
-                result[yy][xx] = (math.sqrt(xx*yy) +
-                                math.sqrt(xx*(yy+1)) +
-                                math.sqrt((xx+1)*yy) +
-                                math.sqrt((xx+1)*(yy+1)))
-
+                result[yy][xx] = (math.sqrt(xx * yy) +
+                                  math.sqrt(xx * (yy + 1)) +
+                                  math.sqrt((xx + 1) * yy) +
+                                  math.sqrt((xx + 1) * (yy + 1)))
 
         print()
 
@@ -86,19 +75,18 @@ def main():
         consumer.print_loop_nest()
         print()
 
-
     # Next we'll examine the next simplest option - computing all
     # values required in the producer before computing any of the
     # consumer. We call this schedule "root".
     if True:
-        print("="*50)
+        print("=" * 50)
         # Start with the same function definitions:
         producer, consumer = hl.Func("producer_root"), hl.Func("consumer_root")
         producer[x, y] = hl.sqrt(x * y)
         consumer[x, y] = (producer[x, y] +
-                          producer[x, y+1] +
-                          producer[x+1, y] +
-                          producer[x+1, y+1])
+                          producer[x, y + 1] +
+                          producer[x + 1, y] +
+                          producer[x + 1, y + 1])
 
         # Tell Halide to evaluate all of producer before any of consumer.
         producer.compute_root()
@@ -115,30 +103,24 @@ def main():
         # A) There were stores to producer.
         # B) They all happened before any stores to consumer.
 
-
         # Equivalent C:
         result = np.empty((4, 4), dtype=np.float32)
 
         # Allocate some temporary storage for the producer.
         producer_storage = np.empty((5, 5), dtype=np.float32)
 
-
         # Compute the producer.
         for yy in range(5):
             for xx in range(5):
                 producer_storage[yy][xx] = math.sqrt(xx * yy)
 
-
-
         # Compute the consumer. Skip the prints this time.
         for yy in range(4):
             for xx in range(4):
                 result[yy][xx] = (producer_storage[yy][xx] +
-                                producer_storage[yy+1][xx] +
-                                producer_storage[yy][xx+1] +
-                                producer_storage[yy+1][xx+1])
-
-
+                                  producer_storage[yy + 1][xx] +
+                                  producer_storage[yy][xx + 1] +
+                                  producer_storage[yy + 1][xx + 1])
 
         # Note that consumer was evaluated over a 4x4 box, so Halide
         # automatically inferred that producer was needed over a 5x5
@@ -151,7 +133,6 @@ def main():
         print("Pseudo-code for the schedule:")
         consumer.print_loop_nest()
         print()
-
 
     # Let's compare the two approaches above from a performance
     # perspective.
@@ -190,14 +171,14 @@ def main():
     # compute_root. Next we'll alternate between computing the
     # producer and consumer on a per-scanline basis:
     if True:
-        print("="*50)
+        print("=" * 50)
         # Start with the same function definitions:
         producer, consumer = hl.Func("producer_y"), hl.Func("consumer_y")
         producer[x, y] = hl.sqrt(x * y)
         consumer[x, y] = (producer[x, y] +
-                          producer[x, y+1] +
-                          producer[x+1, y] +
-                          producer[x+1, y+1])
+                          producer[x, y + 1] +
+                          producer[x + 1, y] +
+                          producer[x + 1, y + 1])
 
         # Tell Halide to evaluate producer as needed per y coordinate
         # of the consumer:
@@ -229,18 +210,14 @@ def main():
             producer_storage = np.empty((2, 5), dtype=np.float32)
             for py in range(yy, yy + 2):
                 for px in range(5):
-                    producer_storage[py-yy][px] = math.sqrt(px * py)
-
-
+                    producer_storage[py - yy][px] = math.sqrt(px * py)
 
             # Compute a scanline of the consumer.
             for xx in range(4):
                 result[yy][xx] = (producer_storage[0][xx] +
-                                producer_storage[1][xx] +
-                                producer_storage[0][xx+1] +
-                                producer_storage[1][xx+1])
-
-
+                                  producer_storage[1][xx] +
+                                  producer_storage[0][xx + 1] +
+                                  producer_storage[1][xx + 1])
 
         # Again, if we print the loop nest, we'll see something very
         # similar to the C above.
@@ -261,21 +238,20 @@ def main():
         # - Stores: 56
         # - Calls to sqrt: 40
 
-
     # We could also say producer.compute_at(consumer, x), but this
     # would be very similar to full inlining (the default
     # schedule). Instead let's distinguish between the loop level at
     # which we allocate storage for producer, and the loop level at
     # which we actually compute it. This unlocks a few optimizations.
     if True:
-        print("="*50)
-        producer, consumer = hl.Func("producer_store_root_compute_y"), hl.Func("consumer_store_root_compute_y")
+        print("=" * 50)
+        producer, consumer = hl.Func("producer_store_root_compute_y"), hl.Func(
+            "consumer_store_root_compute_y")
         producer[x, y] = hl.sqrt(x * y)
         consumer[x, y] = (producer[x, y] +
-                          producer[x, y+1] +
-                          producer[x+1, y] +
-                          producer[x+1, y+1])
-
+                          producer[x, y + 1] +
+                          producer[x + 1, y] +
+                          producer[x + 1, y + 1])
 
         # Tell Halide to make a buffer to store all of producer at
         # the outermost level:
@@ -309,7 +285,6 @@ def main():
         # There's an outer loop over scanlines of consumer:
         for yy in range(4):
 
-
             # Compute enough of the producer to satisfy this scanline
             # of the consumer.
             for py in range(yy, yy + 2):
@@ -322,16 +297,12 @@ def main():
                 for px in range(5):
                     producer_storage[py][px] = math.sqrt(px * py)
 
-
-
             # Compute a scanline of the consumer.
             for xx in range(4):
                 result[yy][xx] = (producer_storage[yy][xx] +
-                                producer_storage[yy+1][xx] +
-                                producer_storage[yy][xx+1] +
-                                producer_storage[yy+1][xx+1])
-
-
+                                  producer_storage[yy + 1][xx] +
+                                  producer_storage[yy][xx + 1] +
+                                  producer_storage[yy + 1][xx + 1])
 
         print("Pseudo-code for the schedule:")
         consumer.print_loop_nest()
@@ -366,34 +337,30 @@ def main():
                         continue
 
                     for px in range(5):
-                        # Stores to producer_storage have their y coordinate bit-masked.
+                        # Stores to producer_storage have their y coordinate
+                        # bit-masked.
                         producer_storage[py & 1][px] = math.sqrt(px * py)
-
-
 
                 # Compute a scanline of the consumer.
                 for xx in range(4):
-                    # Loads from producer_storage have their y coordinate bit-masked.
+                    # Loads from producer_storage have their y coordinate
+                    # bit-masked.
                     result[yy][xx] = (producer_storage[yy & 1][xx] +
-                                    producer_storage[(yy+1) & 1][xx] +
-                                    producer_storage[yy & 1][xx+1] +
-                                    producer_storage[(yy+1) & 1][xx+1])
-
-
-
-
+                                      producer_storage[(yy + 1) & 1][xx] +
+                                      producer_storage[yy & 1][xx + 1] +
+                                      producer_storage[(yy + 1) & 1][xx + 1])
 
     # We can do even better, by leaving the storage outermost, but
     # moving the computation into the innermost loop:
     if True:
-        print("="*50)
-        producer, consumer = hl.Func("producer_store_root_compute_x"), hl.Func("consumer_store_root_compute_x")
+        print("=" * 50)
+        producer, consumer = hl.Func("producer_store_root_compute_x"), hl.Func(
+            "consumer_store_root_compute_x")
         producer[x, y] = hl.sqrt(x * y)
         consumer[x, y] = (producer[x, y] +
-                          producer[x, y+1] +
-                          producer[x+1, y] +
-                          producer[x+1, y+1])
-
+                          producer[x, y + 1] +
+                          producer[x + 1, y] +
+                          producer[x + 1, y + 1])
 
         # Store outermost, compute innermost.
         producer.store_root().compute_at(consumer, x)
@@ -422,20 +389,20 @@ def main():
                 # pixxel of the consumer, but skip values that we've
                 # alreadyy computed:
                 if (yy == 0) and (xx == 0):
-                    producer_storage[yy & 1][xx] = math.sqrt(xx*yy)
+                    producer_storage[yy & 1][xx] = math.sqrt(xx * yy)
                 if yy == 0:
-                    producer_storage[yy & 1][xx+1] = math.sqrt((xx+1)*yy)
+                    producer_storage[yy & 1][xx + 1] = math.sqrt((xx + 1) * yy)
                 if xx == 0:
-                    producer_storage[(yy+1) & 1][xx] = math.sqrt(xx*(yy+1))
+                    producer_storage[
+                        (yy + 1) & 1][xx] = math.sqrt(xx * (yy + 1))
 
-                producer_storage[(yy+1) & 1][xx+1] = math.sqrt((xx+1)*(yy+1))
+                producer_storage[(yy + 1) & 1][xx +
+                                               1] = math.sqrt((xx + 1) * (yy + 1))
 
                 result[yy][xx] = (producer_storage[yy & 1][xx] +
-                                producer_storage[(yy+1) & 1][xx] +
-                                producer_storage[yy & 1][xx+1] +
-                                producer_storage[(yy+1) & 1][xx+1])
-
-
+                                  producer_storage[(yy + 1) & 1][xx] +
+                                  producer_storage[yy & 1][xx + 1] +
+                                  producer_storage[(yy + 1) & 1][xx + 1])
 
         print("Pseudo-code for the schedule:")
         consumer.print_loop_nest()
@@ -450,7 +417,6 @@ def main():
         # - Loads: 48
         # - Stores: 56
         # - Calls to sqrt: 40
-
 
     # So what's the catch? Why not always do
     # producer.store_root().compute_at(consumer, x) for this type of
@@ -473,14 +439,13 @@ def main():
     # into new inner and outer sub-variables and then schedule with
     # respect to those. We'll use this to express fusion in tiles:
     if True:
-        print("="*50)
+        print("=" * 50)
         producer, consumer = hl.Func("producer_tile"), hl.Func("consumer_tile")
         producer[x, y] = hl.sqrt(x * y)
         consumer[x, y] = (producer[x, y] +
-                          producer[x, y+1] +
-                          producer[x+1, y] +
-                          producer[x+1, y+1])
-
+                          producer[x, y + 1] +
+                          producer[x + 1, y] +
+                          producer[x + 1, y + 1])
 
         # Tile the consumer using 2x2 tiles.
         x_outer, y_outer = hl.Var("x_outer"), hl.Var("y_outer")
@@ -501,8 +466,8 @@ def main():
         consumer.trace_stores()
 
         print("\nEvaluating:"
-               "consumer.tile(x, y, x_outer, y_outer, x_inner, y_inner, 2, 2)"
-               "producer.compute_at(consumer, x_outer)")
+              "consumer.tile(x, y, x_outer, y_outer, x_inner, y_inner, 2, 2)"
+              "producer.compute_at(consumer, x_outer)")
         consumer.realize(4, 4)
 
         # Reading the log, you should see that producer and consumer
@@ -510,13 +475,12 @@ def main():
 
         result = np.empty((4, 4), dtype=np.float32)
 
-
         # For every tile of the consumer:
         for y_outer in range(2):
             for x_outer in range(2):
                 # Compute the x and y coords of the start of this tile.
-                x_base = x_outer*2
-                y_base = y_outer*2
+                x_base = x_outer * 2
+                y_base = y_outer * 2
 
                 # Compute enough of producer to satisfy this tile. A
                 # 2x2 tile of the consumer requires a 3x3 tile of the
@@ -524,9 +488,8 @@ def main():
                 producer_storage = np.empty((3, 3), dtype=np.float32)
                 for py in range(y_base, y_base + 3):
                     for px in range(x_base + 3):
-                        producer_storage[py-y_base][px-x_base] = math.sqrt(px * py)
-
-
+                        producer_storage[py - y_base][px -
+                                                      x_base] = math.sqrt(px * py)
 
                 # Compute this tile of the consumer
                 for y_inner in range(2):
@@ -534,11 +497,9 @@ def main():
                         xx = x_base + x_inner
                         yy = y_base + y_inner
                         result[yy][xx] = (producer_storage[yy - y_base][xx - x_base] +
-                                        producer_storage[yy - y_base + 1][xx - x_base] +
-                                        producer_storage[yy - y_base][xx - x_base + 1] +
-                                        producer_storage[yy - y_base + 1][xx - x_base + 1])
-
-
+                                          producer_storage[yy - y_base + 1][xx - x_base] +
+                                          producer_storage[yy - y_base][xx - x_base + 1] +
+                                          producer_storage[yy - y_base + 1][xx - x_base + 1])
 
         print("Pseudo-code for the schedule:")
         consumer.print_loop_nest()
@@ -550,20 +511,20 @@ def main():
         # done by each tile isn't so bad once the tiles get large
         # enough.
 
-
     # Let's try a mixed strategy that combines what we have done with
     # splitting, parallelizing, and vectorizing. This is one that
     # often works well in practice for large images. If you
     # understand this schedule, then you understand 95% of scheduling
     # in Halide.
     if True:
-        print("="*50)
-        producer, consumer = hl.Func("producer_mixed"), hl.Func("consumer_mixed")
+        print("=" * 50)
+        producer, consumer = hl.Func(
+            "producer_mixed"), hl.Func("consumer_mixed")
         producer[x, y] = hl.sqrt(x * y)
         consumer[x, y] = (producer[x, y] +
-                          producer[x, y+1] +
-                          producer[x+1, y] +
-                          producer[x+1, y+1])
+                          producer[x, y + 1] +
+                          producer[x + 1, y] +
+                          producer[x + 1, y + 1])
 
         # Split the y coordinate of the consumer into strips of 16 scanlines:
         yo, yi = hl.Var("yo"), hl.Var("yi")
@@ -580,7 +541,8 @@ def main():
         # Within each strip, compute the producer per scanline of the
         # consumer, skipping work done on previous scanlines.
         producer.compute_at(consumer, yi)
-        # Also vectorize the producer (because sqrt is vectorizable on x86 using SSE).
+        # Also vectorize the producer (because sqrt is vectorizable on x86
+        # using SSE).
         producer.vectorize(x, 4)
 
         # Let's leave tracing off this time, because we're going to
@@ -595,11 +557,12 @@ def main():
         c_result = np.empty((600, 800), dtype=np.float32)
 
         # For every strip of 16 scanlines
-        for yo in range(600//16 + 1): # (this loop is parallel in the Halide version)
-            # 16 doesn't divide 600, so push the last slice upwards to fit within [0, 599] (see lesson 05).
+        for yo in range(600 // 16 + 1):  # (this loop is parallel in the Halide version)
+            # 16 doesn't divide 600, so push the last slice upwards to fit
+            # within [0, 599] (see lesson 05).
             y_base = yo * 16
-            if y_base > (600-16):
-                y_base = 600-16
+            if y_base > (600 - 16):
+                y_base = 600 - 16
 
             # Allocate a two-scanline circular buffer for the producer
             producer_storage = np.empty((2, 801), dtype=np.float32)
@@ -608,60 +571,59 @@ def main():
             for yi in range(16):
                 yy = y_base + yi
 
-                for py in range(yy, yy+2):
+                for py in range(yy, yy + 2):
                     # Skip scanlines already computed *within this task*
                     if (yi > 0) and (py == yy):
                         continue
 
                     # Compute this scanline of the producer in 4-wide vectors
-                    for x_vec in range(800//4 + 1):
-                        x_base = x_vec*4
-                        # 4 doesn't divide 801, so push the last vector left (see lesson 05).
+                    for x_vec in range(800 // 4 + 1):
+                        x_base = x_vec * 4
+                        # 4 doesn't divide 801, so push the last vector left
+                        # (see lesson 05).
                         if x_base > (801 - 4):
                             x_base = 801 - 4
 
-                        # If you're on x86, Halide generates SSE code for this part:
+                        # If you're on x86, Halide generates SSE code for this
+                        # part:
                         xx = [x_base + 0, x_base + 1, x_base + 2, x_base + 3]
-                        vec= [math.sqrt(xx[0] * py),
-                              math.sqrt(xx[1] * py),
-                              math.sqrt(xx[2] * py),
-                              math.sqrt(xx[3] * py)]
+                        vec = [math.sqrt(xx[0] * py),
+                               math.sqrt(xx[1] * py),
+                               math.sqrt(xx[2] * py),
+                               math.sqrt(xx[3] * py)]
                         producer_storage[py & 1][xx[0]] = vec[0]
                         producer_storage[py & 1][xx[1]] = vec[1]
                         producer_storage[py & 1][xx[2]] = vec[2]
                         producer_storage[py & 1][xx[3]] = vec[3]
 
-
-
                 # Now compute consumer for this scanline:
-                for x_vec in range(800//4):
+                for x_vec in range(800 // 4):
                     x_base = x_vec * 4
                     # Again, Halide's equivalent here uses SSE.
                     xx = [x_base, x_base + 1, x_base + 2, x_base + 3]
                     vec = [
                         (producer_storage[yy & 1][xx[0]] +
-                         producer_storage[(yy+1) & 1][xx[0]] +
-                         producer_storage[yy & 1][xx[0]+1] +
-                         producer_storage[(yy+1) & 1][xx[0]+1]),
+                         producer_storage[(yy + 1) & 1][xx[0]] +
+                         producer_storage[yy & 1][xx[0] + 1] +
+                         producer_storage[(yy + 1) & 1][xx[0] + 1]),
                         (producer_storage[yy & 1][xx[1]] +
-                         producer_storage[(yy+1) & 1][xx[1]] +
-                         producer_storage[yy & 1][xx[1]+1] +
-                         producer_storage[(yy+1) & 1][xx[1]+1]),
+                         producer_storage[(yy + 1) & 1][xx[1]] +
+                         producer_storage[yy & 1][xx[1] + 1] +
+                         producer_storage[(yy + 1) & 1][xx[1] + 1]),
                         (producer_storage[yy & 1][xx[2]] +
-                         producer_storage[(yy+1) & 1][xx[2]] +
-                         producer_storage[yy & 1][xx[2]+1] +
-                         producer_storage[(yy+1) & 1][xx[2]+1]),
+                         producer_storage[(yy + 1) & 1][xx[2]] +
+                         producer_storage[yy & 1][xx[2] + 1] +
+                         producer_storage[(yy + 1) & 1][xx[2] + 1]),
                         (producer_storage[yy & 1][xx[3]] +
-                         producer_storage[(yy+1) & 1][xx[3]] +
-                         producer_storage[yy & 1][xx[3]+1] +
-                         producer_storage[(yy+1) & 1][xx[3]+1])
+                         producer_storage[(yy + 1) & 1][xx[3]] +
+                         producer_storage[yy & 1][xx[3] + 1] +
+                         producer_storage[(yy + 1) & 1][xx[3] + 1])
                     ]
 
                     c_result[yy][xx[0]] = vec[0]
                     c_result[yy][xx[1]] = vec[1]
                     c_result[yy][xx[2]] = vec[2]
                     c_result[yy][xx[3]] = vec[3]
-
 
         print("Pseudo-code for the schedule:")
         consumer.print_loop_nest()
@@ -676,15 +638,8 @@ def main():
             for xx in range(800):
                 error = halide_result[xx, yy] - c_result[yy][xx]
                 # It's floating-point math, so we'll allow some slop:
-                if (error < -0.001) or (error > 0.001):
-                    raise Exception("halide_result(%d, %d) = %f instead of %f" % (
-                           xx, yy, halide_result[xx, yy], c_result[yy][xx]))
-                    return -1
-
-
-
-
-
+                assert abs(error) <= 0.001, "halide_result(%d, %d) = %f instead of %f" % (
+                    xx, yy, halide_result[xx, yy], c_result[yy][xx])
 
     # This stuff is hard. We ended up in a three-way trade-off
     # between memory bandwidth, redundant work, and
@@ -715,10 +670,9 @@ def main():
     # trade-offs between locality, redundant work, and parallelism,
     # without messing up the actual result you're trying to compute.
 
-    print("="*50)
+    print("=" * 50)
     print("Success!")
     return 0
-
 
 
 if __name__ == "__main__":

--- a/python_bindings/tutorial/lesson_08_scheduling_2.py
+++ b/python_bindings/tutorial/lesson_08_scheduling_2.py
@@ -245,8 +245,8 @@ def main():
     # which we actually compute it. This unlocks a few optimizations.
     if True:
         print("=" * 50)
-        producer, consumer = hl.Func("producer_store_root_compute_y"), hl.Func(
-            "consumer_store_root_compute_y")
+        producer = hl.Func("producer_store_root_compute_y")
+        consumer = hl.Func("consumer_store_root_compute_y")
         producer[x, y] = hl.sqrt(x * y)
         consumer[x, y] = (producer[x, y] +
                           producer[x, y + 1] +
@@ -354,8 +354,8 @@ def main():
     # moving the computation into the innermost loop:
     if True:
         print("=" * 50)
-        producer, consumer = hl.Func("producer_store_root_compute_x"), hl.Func(
-            "consumer_store_root_compute_x")
+        producer = hl.Func("producer_store_root_compute_x")
+        consumer = hl.Func("consumer_store_root_compute_x")
         producer[x, y] = hl.sqrt(x * y)
         consumer[x, y] = (producer[x, y] +
                           producer[x, y + 1] +
@@ -393,11 +393,9 @@ def main():
                 if yy == 0:
                     producer_storage[yy & 1][xx + 1] = math.sqrt((xx + 1) * yy)
                 if xx == 0:
-                    producer_storage[
-                        (yy + 1) & 1][xx] = math.sqrt(xx * (yy + 1))
+                    producer_storage[(yy + 1) & 1][xx] = math.sqrt(xx * (yy + 1))
 
-                producer_storage[(yy + 1) & 1][xx +
-                                               1] = math.sqrt((xx + 1) * (yy + 1))
+                producer_storage[(yy + 1) & 1][xx + 1] = math.sqrt((xx + 1) * (yy + 1))
 
                 result[yy][xx] = (producer_storage[yy & 1][xx] +
                                   producer_storage[(yy + 1) & 1][xx] +
@@ -488,8 +486,7 @@ def main():
                 producer_storage = np.empty((3, 3), dtype=np.float32)
                 for py in range(y_base, y_base + 3):
                     for px in range(x_base + 3):
-                        producer_storage[py - y_base][px -
-                                                      x_base] = math.sqrt(px * py)
+                        producer_storage[py - y_base][px - x_base] = math.sqrt(px * py)
 
                 # Compute this tile of the consumer
                 for y_inner in range(2):
@@ -518,8 +515,7 @@ def main():
     # in Halide.
     if True:
         print("=" * 50)
-        producer, consumer = hl.Func(
-            "producer_mixed"), hl.Func("consumer_mixed")
+        producer, consumer = hl.Func("producer_mixed"), hl.Func("consumer_mixed")
         producer[x, y] = hl.sqrt(x * y)
         consumer[x, y] = (producer[x, y] +
                           producer[x, y + 1] +
@@ -638,8 +634,9 @@ def main():
             for xx in range(800):
                 error = halide_result[xx, yy] - c_result[yy][xx]
                 # It's floating-point math, so we'll allow some slop:
-                assert abs(error) <= 0.001, "halide_result(%d, %d) = %f instead of %f" % (
-                    xx, yy, halide_result[xx, yy], c_result[yy][xx])
+                assert abs(error) <= 0.001, \
+                    "halide_result(%d, %d) = %f instead of %f" % (
+                        xx, yy, halide_result[xx, yy], c_result[yy][xx])
 
     # This stuff is hard. We ended up in a three-way trade-off
     # between memory bandwidth, redundant work, and

--- a/python_bindings/tutorial/lesson_09_update_definitions.py
+++ b/python_bindings/tutorial/lesson_09_update_definitions.py
@@ -1,48 +1,29 @@
 #!/usr/bin/python3
+
 # Halide tutorial lesson 9
 
-# This lesson demonstrates how to define a hl.Func in multiple passes, including scattering.
+# This lesson demonstrates how to define a hl.Func in multiple passes,
+# including scattering.
 
 # This lesson can be built by invoking the command:
-#    make tutorial_lesson_09_update_definitions
-# in a shell with the current directory at the top of the halide source tree.
-# Otherwise, see the platform-specific compiler invocations below.
-
-# On linux, you can compile and run it like so:
-# g++ lesson_09*.cpp -g -std=c++11 -I ../include -L ../bin -lHalide `libpng-config --cflags --ldflags` -lpthread -ldl -fopenmp -o lesson_09
-# LD_LIBRARY_PATH=../bin ./lesson_09
-
-# On os x (will only work if you actually have g++, not Apple's pretend g++ which is actually clang):
-# g++ lesson_09*.cpp -g -std=c++11 -I ../include -L ../bin -lHalide `libpng-config --cflags --ldflags` -fopenmp -o lesson_09
-# DYLD_LIBRARY_PATH=../bin ./lesson_09
-
-#include "Halide.h"
-#include <stdio.h>
-
-# We're going to be using x86 SSE intrinsics later on in this lesson.
-#ifdef __SSE2__
-#include <emmintrin.h>
-#endif
-
-# We'll also need a clock to do performance testing at the end.
-#include "clock.h"
+#    make test_tutorial_lesson_09_update_definitions
+# in a shell with the current directory at python_bindings/
 from datetime import datetime
 
-#using namespace Halide
 import halide as hl
 
-# Support code for loading pngs.
-#include "image_io.h"
 import imageio
 import numpy as np
 import os.path
 
+
 def main():
     # Declare some Vars to use below.
-    x, y = hl.Var ("x"), hl.Var ("y")
+    x, y = hl.Var("x"), hl.Var("y")
 
     # Load a grayscale image to use as an input.
-    image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/gray.png")
+    image_path = os.path.join(os.path.dirname(
+        __file__), "../../tutorial/images/gray.png")
     input_data = imageio.imread(image_path)
     if True:
          # making the image smaller to go faster
@@ -71,7 +52,7 @@ def main():
             e = f[x, y] + 17
             print("f[x, y] + 17", e)
             print("(f[x, y] + 17).type()", e.type())
-            print("(f[x, y]).type()", f[x,y].type())
+            print("(f[x, y]).type()", f[x, y].type())
 
         f[x, y] = f[x, y] + 17
 
@@ -88,16 +69,19 @@ def main():
         # definition in all references to the function on the left-
         # and right-hand sides. So the following definitions are
         # legal updates:
-        f[x, 17] = x + 8 # x is used, so all uses of f must have x as the first argument.
-        f[0, y] = y * 8  # y is used, so all uses of f must have y as the second argument.
+        # x is used, so all uses of f must have x as the first argument.
+        f[x, 17] = x + 8
+        # y is used, so all uses of f must have y as the second argument.
+        f[0, y] = y * 8
         f[x, x + 1] = x + 8
-        f[y/2, y] = f[0, y] * 17
+        f[y / 2, y] = f[0, y] * 17
 
         # But these ones would cause an error:
         # f[x, 0) = f[x + 1, 0) <- First argument to f on the right-hand-side must be 'x', not 'x + 1'.
         # f[y, y + 1) = y + 8   <- Second argument to f on the left-hand-side must be 'y', not 'y + 1'.
         # f[y, x) = y - x      <- Arguments to f on the left-hand-side are in the wrong places.
-        # f[3, 4) = x + y      <- Free variables appear on the right-hand-side but not the left-hand-side.
+        # f[3, 4) = x + y      <- Free variables appear on the right-hand-side
+        # but not the left-hand-side.
 
         # We'll realize this one just to make sure it compiles. The
         # second-to-last definition forces us to realize over a
@@ -110,20 +94,20 @@ def main():
         g = hl.Func("g")
         g[x, y] = x + y   # Pure definition
         g[2, 1] = 42      # First update definition
-        g[x, 0] = g[x, 1] # Second update definition
+        g[x, 0] = g[x, 1]  # Second update definition
 
         g.trace_loads()
         g.trace_stores()
 
         g.realize(4, 4)
 
-        # Reading the log, we see that each pass is applied in turn. The equivalent C is:
-        result = np.empty( (4,4), dtype=np.int)
+        # Reading the log, we see that each pass is applied in turn. The
+        # equivalent Python is:
+        result = np.empty((4, 4), dtype=np.int)
         # Pure definition
         for yy in range(4):
             for xx in range(4):
                 result[yy][xx] = xx + yy
-
 
         # First update definition
         result[1][2] = 42
@@ -131,7 +115,6 @@ def main():
         for xx in range(4):
             result[0][xx] = result[1][xx]
     # end of section
-
 
     # Putting update passes inside loops.
     if True:
@@ -160,32 +143,24 @@ def main():
         f[x, r] = f[x, r] * f[x, r]
         halide_result = f.realize(100, 100)
 
-        # The equivalent C is:
-        c_result = np.empty((100, 100), dtype=np.int)
+        # The equivalent Python is:
+        py_result = np.empty((100, 100), dtype=np.int)
         for yy in range(100):
             for xx in range(100):
-                c_result[yy][xx] = xx + yy
+                py_result[yy][xx] = xx + yy
 
         for xx in range(100):
             for rr in range(50):
                 # The loop over the reduction domain occurs inside of
                 # the loop over any pure variables used in the update
                 # step:
-                c_result[rr][xx] = c_result[rr][xx] * c_result[rr][xx]
-
-
+                py_result[rr][xx] = py_result[rr][xx] * py_result[rr][xx]
 
         # Check the results match:
         for yy in range(100):
             for xx in range(100):
-                if halide_result[xx, yy] != c_result[yy][xx]:
-                    raise Exception("halide_result(%d, %d) = %d instead of %d" % (
-                           xx, yy, halide_result[xx, yy], c_result[yy][xx]))
-                    return -1
-
-
-
-
+                assert halide_result[xx, yy] == py_result[yy][xx], "halide_result(%d, %d) = %d instead of %d" % (
+                    xx, yy, halide_result[xx, yy], py_result[yy][xx])
 
     # Now we'll examine a real-world use for an update definition:
     # computing a histogram.
@@ -211,26 +186,19 @@ def main():
 
         halide_result = histogram.realize(256)
 
-        # The equivalent C is:
-        c_result = np.empty((256), dtype=np.int)
+        # The equivalent Python is:
+        py_result = np.empty((256), dtype=np.int)
         for xx in range(256):
-            c_result[xx] = 0
+            py_result[xx] = 0
 
         for r_y in range(input.height()):
             for r_x in range(input.width()):
-                c_result[input_data[r_x, r_y]] += 1
-
-
+                py_result[input_data[r_x, r_y]] += 1
 
         # Check the answers agree:
         for xx in range(256):
-            if c_result[xx] != halide_result[xx]:
-                raise Exception("halide_result(%d) = %d instead of %d" % (
-                       xx, halide_result[xx], c_result[xx]))
-                return -1
-
-
-
+            assert py_result[xx] == halide_result[xx], "halide_result(%d) = %d instead of %d" % (
+                xx, halide_result[xx], py_result[xx])
 
     # Scheduling update steps
     if True:
@@ -243,7 +211,7 @@ def main():
 
         # Consider the definition:
         f = hl.Func("x")
-        f[x, y] = x*y
+        f[x, y] = x * y
         # Set the second row to equal the first row.
         f[x, 1] = f[x, 0]
         # Set the second column to equal the first column plus 2.
@@ -269,50 +237,37 @@ def main():
 
         halide_result = f.realize(16, 16)
 
-
         # Here's the equivalent (serial) C:
-        c_result = np.empty((16, 16), dtype=np.int)
-
+        py_result = np.empty((16, 16), dtype=np.int)
 
         # Pure step. Vectorized in x and parallelized in y.
-        for yy in range( 16): # Should be a parallel for loop
+        for yy in range(16):  # Should be a parallel for loop
             for x_vec in range(4):
-                xx = [x_vec*4, x_vec*4+1, x_vec*4+2, x_vec*4+3]
-                c_result[yy][xx[0]] = xx[0] * yy
-                c_result[yy][xx[1]] = xx[1] * yy
-                c_result[yy][xx[2]] = xx[2] * yy
-                c_result[yy][xx[3]] = xx[3] * yy
-
-
+                xx = [x_vec * 4, x_vec * 4 + 1, x_vec * 4 + 2, x_vec * 4 + 3]
+                py_result[yy][xx[0]] = xx[0] * yy
+                py_result[yy][xx[1]] = xx[1] * yy
+                py_result[yy][xx[2]] = xx[2] * yy
+                py_result[yy][xx[3]] = xx[3] * yy
 
         # First update. Vectorized in x.
         for x_vec in range(4):
-            xx = [x_vec*4, x_vec*4+1, x_vec*4+2, x_vec*4+3]
-            c_result[1][xx[0]] = c_result[0][xx[0]]
-            c_result[1][xx[1]] = c_result[0][xx[1]]
-            c_result[1][xx[2]] = c_result[0][xx[2]]
-            c_result[1][xx[3]] = c_result[0][xx[3]]
-
+            xx = [x_vec * 4, x_vec * 4 + 1, x_vec * 4 + 2, x_vec * 4 + 3]
+            py_result[1][xx[0]] = py_result[0][xx[0]]
+            py_result[1][xx[1]] = py_result[0][xx[1]]
+            py_result[1][xx[2]] = py_result[0][xx[2]]
+            py_result[1][xx[3]] = py_result[0][xx[3]]
 
         # Second update. Parallelized in chunks of size 4 in y.
-        for yo in range(4): # Should be a parallel for loop
+        for yo in range(4):  # Should be a parallel for loop
             for yi in range(4):
-                yy = yo*4 + yi
-                c_result[yy][1] = c_result[yy][0] + 2
-
-
+                yy = yo * 4 + yi
+                py_result[yy][1] = py_result[yy][0] + 2
 
         # Check the C and Halide results match:
-        for yy in range( 16):
-            for xx in range( 16 ):
-                if halide_result[xx, yy] != c_result[yy][xx]:
-                    raise Exception("halide_result(%d, %d) = %d instead of %d" % (
-                           xx, yy, halide_result[xx, yy], c_result[yy][xx]))
-                    return -1
-
-
-
-
+        for yy in range(16):
+            for xx in range(16):
+                assert halide_result[xx, yy] == py_result[yy][xx], "halide_result(%d, %d) = %d instead of %d" % (
+                    xx, yy, halide_result[xx, yy], py_result[yy][xx])
 
     # That covers how to schedule the variables within a hl.Func that
     # uses update steps, but what about producer-consumer
@@ -325,13 +280,13 @@ def main():
         # in the innermost loop of their consumer. Consider this
         # trivial example:
         producer, consumer = hl.Func("producer"), hl.Func("consumer")
-        producer[x] = x*17
+        producer[x] = x * 17
         producer[x] += 1
         consumer[x] = 2 * producer[x]
         halide_result = consumer.realize(10)
 
-        # The equivalent C is:
-        c_result = np.empty((10), dtype=np.int)
+        # The equivalent Python is:
+        py_result = np.empty((10), dtype=np.int)
         for xx in range(10):
             producer_storage = np.empty((1), dtype=np.int)
             # Pure step for producer
@@ -339,31 +294,26 @@ def main():
             # Update step for producer
             producer_storage[0] = producer_storage[0] + 1
             # Pure step for consumer
-            c_result[xx] = 2 * producer_storage[0]
-
+            py_result[xx] = 2 * producer_storage[0]
 
         # Check the results match
-        for xx in range( 10 ):
-            if halide_result[xx] != c_result[xx]:
-                raise Exception("halide_result(%d) = %d instead of %d" % (
-                       xx, halide_result[xx], c_result[xx]))
-                return -1
-
-
+        for xx in range(10):
+            assert halide_result[xx] == py_result[xx], "halide_result(%d) = %d instead of %d" % (
+                xx, halide_result[xx], py_result[xx])
 
         # For all other compute_at/store_at options, the reduction
         # gets placed where you would expect, somewhere in the loop
         # nest of the consumer.
 
-
     # Now let's consider a reduction as a consumer in a
     # producer-consumer pair. This is a little more involved.
     if True:
         if True:
-            # Case 1: The consumer references the producer in the pure step only.
+            # Case 1: The consumer references the producer in the pure step
+            # only.
             producer, consumer = hl.Func("producer"), hl.Func("consumer")
             # The producer is pure.
-            producer[x] = x*17
+            producer[x] = x * 17
             consumer[x] = 2 * producer[x]
             consumer[x] += 1
 
@@ -387,37 +337,31 @@ def main():
 
             halide_result = consumer.realize(10)
 
-
-            # The equivalent C is:
-            c_result = np.empty((10), dtype=np.int)
+            # The equivalent Python is:
+            py_result = np.empty((10), dtype=np.int)
 
             # Pure step for the consumer
-            for xx in range( 10 ):
+            for xx in range(10):
                 # Pure step for producer
                 producer_storage = np.empty((1), dtype=np.int)
                 producer_storage[0] = xx * 17
-                c_result[xx] = 2 * producer_storage[0]
+                py_result[xx] = 2 * producer_storage[0]
 
             # Update step for the consumer
-            for xx in range( 10 ):
-                c_result[xx] += 1
-
+            for xx in range(10):
+                py_result[xx] += 1
 
             # All of the pure step is evaluated before any of the
             # update step, so there are two separate loops over x.
 
             # Check the results match
-            for xx in range( 10 ):
-                if halide_result[xx] != c_result[xx]:
-                    raise Exception("halide_result(%d) = %d instead of %d" % (
-                           xx, halide_result[xx], c_result[xx]))
-                    return -1
-
-
-
+            for xx in range(10):
+                assert halide_result[xx] == py_result[xx], "halide_result(%d) = %d instead of %d" % (
+                    xx, halide_result[xx], py_result[xx])
 
         if True:
-            # Case 2: The consumer references the producer in the update step only
+            # Case 2: The consumer references the producer in the update step
+            # only
             producer, consumer = hl.Func("producer"), hl.Func("consumer")
             producer[x] = x * 17
             consumer[x] = x
@@ -439,31 +383,23 @@ def main():
 
             halide_result = consumer.realize(10)
 
-
-            # The equivalent C is:
-            c_result = np.empty((10), dtype=np.int)
+            # The equivalent Python is:
+            py_result = np.empty((10), dtype=np.int)
             # Pure step for the consumer
-            for xx in range( 10 ):
-                c_result[xx] = xx
+            for xx in range(10):
+                py_result[xx] = xx
 
             # Update step for the consumer
-            for xx in range( 10 ):
+            for xx in range(10):
                 # Pure step for producer
                 producer_storage = np.empty((1), dtype=np.int)
                 producer_storage[0] = xx * 17
-                c_result[xx] += producer_storage[0]
-
-
+                py_result[xx] += producer_storage[0]
 
             # Check the results match
-            for xx in range( 10 ):
-                if halide_result[xx] != c_result[xx]:
-                    raise Exception("halide_result(%d) = %d instead of %d" % (
-                           xx, halide_result[xx], c_result[xx]))
-                    return -1
-
-
-
+            for xx in range(10):
+                assert halide_result[xx] == py_result[xx], "halide_result(%d) = %d instead of %d" % (
+                    xx, halide_result[xx], py_result[xx])
 
         if True:
             # Case 3: The consumer references the producer in
@@ -482,41 +418,35 @@ def main():
 
             halide_result = consumer.realize(10)
 
-            # The equivalent C is:
-            c_result = np.empty((10), dtype=np.int)
+            # The equivalent Python is:
+            py_result = np.empty((10), dtype=np.int)
             # Pure step for the consumer
-            for xx in range( 10 ):
+            for xx in range(10):
                 # Pure step for producer
                 producer_storage = np.empty((1), dtype=np.int)
                 producer_storage[0] = xx * 17
-                c_result[xx] = producer_storage[0] * xx
+                py_result[xx] = producer_storage[0] * xx
 
             # Update step for the consumer
-            for xx in range( 10 ):
+            for xx in range(10):
                 # Another copy of the pure step for producer
                 producer_storage = np.empty((1), dtype=np.int)
                 producer_storage[0] = xx * 17
-                c_result[xx] += producer_storage[0]
-
+                py_result[xx] += producer_storage[0]
 
             # Check the results match
-            for xx in range( 10 ):
-                if halide_result[xx] != c_result[xx]:
-                    raise Exception("halide_result(%d) = %d instead of %d" % (
-                           xx, halide_result[xx], c_result[xx]))
-                    return -1
-
-
-
+            for xx in range(10):
+                assert halide_result[xx] == py_result[xx], "halide_result(%d) = %d instead of %d" % (
+                    xx, halide_result[xx], py_result[xx])
 
         if True:
             # Case 4: The consumer references the producer in
             # multiple steps that do not share common variables
             producer, consumer = hl.Func("producer"), hl.Func("consumer")
-            producer[x, y] = x*y
+            producer[x, y] = x * y
             consumer[x, y] = x + y
-            consumer[x, 0] = producer[x, x-1]
-            consumer[0, y] = producer[y, y-1]
+            consumer[x, 0] = producer[x, x - 1]
+            consumer[0, y] = producer[y, y - 1]
 
             # In this case neither producer.compute_at(consumer, x)
             # nor producer.compute_at(consumer, y) will work, because
@@ -537,8 +467,8 @@ def main():
             producer_wrapper_2[x, y] = producer[x, y]
 
             consumer_2[x, y] = x + y
-            consumer_2[x, 0] += producer_wrapper_1[x, x-1]
-            consumer_2[0, y] += producer_wrapper_2[y, y-1]
+            consumer_2[x, 0] += producer_wrapper_1[x, x - 1]
+            consumer_2[0, y] += producer_wrapper_2[y, y - 1]
 
             # The wrapper functions give us two separate handles on
             # the producer, so we can schedule them differently.
@@ -547,39 +477,31 @@ def main():
 
             halide_result = consumer_2.realize(10, 10)
 
-            # The equivalent C is:
-            c_result = np.empty((10, 10), dtype=np.int)
+            # The equivalent Python is:
+            py_result = np.empty((10, 10), dtype=np.int)
 
             # Pure step for the consumer
-            for yy in range( 10):
-                for xx in range( 10 ):
-                    c_result[yy][xx] = xx + yy
-
+            for yy in range(10):
+                for xx in range(10):
+                    py_result[yy][xx] = xx + yy
 
             # First update step for consumer
-            for xx in range( 10 ):
+            for xx in range(10):
                 producer_wrapper_1_storage = np.empty((1), dtype=np.int)
-                producer_wrapper_1_storage[0] = xx * (xx-1)
-                c_result[0][xx] += producer_wrapper_1_storage[0]
+                producer_wrapper_1_storage[0] = xx * (xx - 1)
+                py_result[0][xx] += producer_wrapper_1_storage[0]
 
             # Second update step for consumer
-            for yy in range( 10):
+            for yy in range(10):
                 producer_wrapper_2_storage = np.empty((1), dtype=np.int)
-                producer_wrapper_2_storage[0] = yy * (yy-1)
-                c_result[yy][0] += producer_wrapper_2_storage[0]
-
+                producer_wrapper_2_storage[0] = yy * (yy - 1)
+                py_result[yy][0] += producer_wrapper_2_storage[0]
 
             # Check the results match
-            for yy in range( 10):
-                for xx in range( 10 ):
-                    if halide_result[xx, yy] != c_result[yy][xx]:
-                        print("halide_result(%d, %d) = %d instead of %d",
-                               xx, yy, halide_result[xx, yy], c_result[yy][xx])
-                        return -1
-
-
-
-
+            for yy in range(10):
+                for xx in range(10):
+                    assert halide_result[xx, yy] == py_result[yy][xx], "halide_result(%d, %d) = %d instead of %d" % (
+                        xx, yy, halide_result[xx, yy], py_result[yy][xx])
 
         if True:
             # Case 5: Scheduling a producer under a reduction domain
@@ -602,15 +524,16 @@ def main():
 
             halide_result = consumer.realize(10)
 
-            # The equivalent C is:
-            c_result = np.empty((10), dtype=np.int)
+            # The equivalent Python is:
+            py_result = np.empty((10), dtype=np.int)
             # Pure step for the consumer.
             for xx in range(10):
-                c_result[xx] = xx + 10
+                py_result[xx] = xx + 10
 
             # Update step for the consumer.
-            for xx in range( 10 ):
-                for rr in range(5): # The loop over the reduction domain is always the inner loop.
+            for xx in range(10):
+                # The loop over the reduction domain is always the inner loop.
+                for rr in range(5):
                     # We've schedule the storage and computation of
                     # the producer here. We just need a single value.
                     producer_storage = np.empty((1), dtype=np.int)
@@ -618,16 +541,12 @@ def main():
                     producer_storage[0] = (xx + rr) * 17
 
                     # Now use it in the update step of the consumer.
-                    c_result[xx] += rr + producer_storage[0]
-
+                    py_result[xx] += rr + producer_storage[0]
 
             # Check the results match
-            for xx in range( 10 ):
-                if halide_result[xx] != c_result[xx]:
-                    raise Exception("halide_result(%d) = %d instead of %d" % (
-                           xx, halide_result[xx], c_result[xx]))
-                    return -1
-
+            for xx in range(10):
+                assert halide_result[xx] == py_result[xx], "halide_result(%d) = %d instead of %d" % (
+                    xx, halide_result[xx], py_result[xx])
 
     # A real-world example of a reduction inside a producer-consumer chain.
     if True:
@@ -644,7 +563,7 @@ def main():
 
         # Compute the 5x5 sum around each pixel.
         local_sum = hl.Func("local_sum")
-        local_sum[x, y] = 0 # Compute the sum as a 32-bit integer
+        local_sum[x, y] = 0  # Compute the sum as a 32-bit integer
         local_sum[x, y] += clamped[x + r.x, y + r.y]
 
         # Divide the sum by 25 to make it an average
@@ -658,39 +577,36 @@ def main():
         # definition, and so its default schedule is fully-inlined.
         # We will then compute local_sum per x coordinate of blurry,
         # because the default schedule for reductions is
-        # compute-innermost. Here's the equivalent C:
+        # compute-innermost. Here's the equivalent Python:
 
         #cast_to_uint8 = lambda x_: np.array([x_], dtype=np.uint8)[0]
         local_sum = np.empty((1), dtype=np.int32)
 
-        c_result = hl.Buffer(hl.UInt(8), [input.width(), input.height()])
+        py_result = hl.Buffer(hl.UInt(8), [input.width(), input.height()])
         for yy in range(input.height()):
             for xx in range(input.width()):
                 # FIXME this loop is quite slow
                 # Pure step of local_sum
                 local_sum[0] = 0
                 # Update step of local_sum
-                for r_y in range(-2, 2+1):
-                    for r_x in range(-2, 2+1):
+                for r_y in range(-2, 2 + 1):
+                    for r_x in range(-2, 2 + 1):
                         # The clamping has been inlined into the update step.
-                        clamped_x = min(max(xx + r_x, 0), input.width()-1)
-                        clamped_y = min(max(yy + r_y, 0), input.height()-1)
+                        clamped_x = min(max(xx + r_x, 0), input.width() - 1)
+                        clamped_y = min(max(yy + r_y, 0), input.height() - 1)
                         local_sum[0] += input[clamped_x, clamped_y]
 
                 # Pure step of blurry
-                #c_result(x, y) = (uint8_t)(local_sum[0] / 25)
-                #c_result[xx, yy] = cast_to_uint8(local_sum[0] / 25)
-                c_result[xx, yy] = int(local_sum[0] / 25) # hl.cast done internally
+                # py_result(x, y) = (uint8_t)(local_sum[0] / 25)
+                #py_result[xx, yy] = cast_to_uint8(local_sum[0] / 25)
+                # hl.cast done internally
+                py_result[xx, yy] = int(local_sum[0] / 25)
 
         # Check the results match
         for yy in range(input.height()):
             for xx in range(input.width()):
-                if halide_result[xx, yy] != c_result[xx, yy]:
-                    raise Exception("halide_result(%d, %d) = %d instead of %d"
-                                    % (xx, yy,
-                                       halide_result[xx, yy], c_result[xx, yy]))
-                    return -1
-
+                assert halide_result[xx, yy] == py_result[xx, yy], "halide_result(%d, %d) = %d instead of %d" % (
+                    xx, yy, halide_result[xx, yy], py_result[xx, yy])
 
     # Reduction helpers.
     if True:
@@ -698,11 +614,12 @@ def main():
         # Halide.h, which compute small reductions and schedule them
         # innermost into their consumer. The most useful one is
         # "sum".
-        f1 = hl.Func ("f1")
+        f1 = hl.Func("f1")
         r = hl.RDom([(0, 100)])
         f1[x] = hl.sum(r + x) * 7
 
-        # Sum creates a small anonymous hl.Func to do the reduction. It's equivalent to:
+        # Sum creates a small anonymous hl.Func to do the reduction. It's
+        # equivalent to:
         f2, anon = hl.Func("f2"), hl.Func("anon")
         anon[x] = 0
         anon[x] += r + x
@@ -714,214 +631,25 @@ def main():
         halide_result_1 = f1.realize(10)
         halide_result_2 = f2.realize(10)
 
-        # The equivalent C is:
-        c_result = np.empty((10), dtype=np.int)
-        for xx in range( 10 ):
+        # The equivalent Python is:
+        py_result = np.empty((10), dtype=np.int)
+        for xx in range(10):
             anon = np.empty((1), dtype=np.int)
             anon[0] = 0
             for rr in range(100):
                 anon[0] += rr + xx
 
-            c_result[xx] = anon[0] * 7
-
+            py_result[xx] = anon[0] * 7
 
         # Check they all match.
-        for xx in range( 10 ):
-            if halide_result_1[xx] != c_result[xx]:
-                print("halide_result_1(%d) = %d instead of %d",
-                       xx, halide_result_1[xx], c_result[xx])
-                return -1
-
-            if halide_result_2[xx] != c_result[xx]:
-                print("halide_result_2(%d) = %d instead of %d",
-                       xx, halide_result_2[xx], c_result[xx])
-                return -1
-
-
-
-
-
-    # A complex example that uses reduction helpers.
-    if False: # non-sense to port SSE code to python, skipping this test
-
-        # Other reduction helpers include "product", "minimum",
-        # "maximum", "hl.argmin", and "argmax". Using hl.argmin and argmax
-        # requires understanding tuples, which come in a later
-        # lesson. Let's use minimum and maximum to compute the local
-        # spread of our grayscale image.
-
-        # First, add a boundary condition to the input.
-        clamped = hl.Func("clamped")
-        x_clamped = hl.clamp(x, 0, input.width()-1)
-        y_clamped = hl.clamp(y, 0, input.height()-1)
-        clamped[x, y] = input[x_clamped, y_clamped]
-
-        box = hl.RDom([(-2, 5), (-2, 5)])
-        # Compute the local maximum minus the local minimum:
-        spread = hl.Func("spread")
-        spread[x, y] = (maximum(clamped(x + box.x, y + box.y)) -
-                        minimum(clamped(x + box.x, y + box.y)))
-
-        # Compute the result in strips of 32 scanlines
-        yo, yi = hl.Var("yo"), hl.Var("yi")
-        spread.split(y, yo, yi, 32).parallel(yo)
-
-        # Vectorize across x within the strips. This implicitly
-        # vectorizes stuff that is computed within the loop over x in
-        # spread, which includes our minimum and maximum helpers, so
-        # they get vectorized too.
-        spread.vectorize(x, 16)
-
-        # We'll apply the boundary condition by padding each scanline
-        # as we need it in a circular buffer (see lesson 08).
-        clamped.store_at(spread, yo).compute_at(spread, yi)
-
-        halide_result = spread.realize(input.width(), input.height())
-
-
-        # The C equivalent is almost too horrible to contemplate (and
-        # took me a long time to debug). This time I want to time
-        # both the Halide version and the C version, so I'll use sse
-        # intrinsics for the vectorization, and openmp to do the
-        # parallel for loop (you'll need to compile with -fopenmp or
-        # similar to get correct timing).
-        #ifdef __SSE2__
-
-        # Don't include the time required to allocate the output buffer.
-        c_result = hl.Buffer(hl.UInt(8), input.width(), input.height())
-
-        #ifdef _OPENMP
-        t1 = datetime.now()
-        #endif
-
-        # Run this one hundred times so we can average the timing results.
-        for iters in range(100):
-            pass
-            # #pragma omp parallel for
-            # for yo in range((input.height() + 31)/32):
-            #     y_base = hl.min(yo * 32, input.height() - 32)
-            #
-            #     # Compute clamped in a circular buffer of size 8
-            #     # (smallest power of two greater than 5). Each thread
-            #     # needs its own allocation, so it must occur here.
-            #
-            #     clamped_width = input.width() + 4
-            #     clamped_storage = np.empty((clamped_width * 8), dtype=np.uint8)
-            #
-            #     for yi in range(32):
-            #         y = y_base + yi
-            #
-            #         uint8_t *output_row = &c_result(0, y)
-            #
-            #         # Compute clamped for this scanline, skipping rows
-            #         # already computed within this slice.
-            #         int min_y_clamped = (yi == 0) ? (y - 2) : (y + 2)
-            #         int max_y_clamped = (y + 2)
-            #         for (int cy = min_y_clamped cy <= max_y_clamped cy++) {
-            #             # Figure out which row of the circular buffer
-            #             # we're filling in using bitmasking:
-            #             uint8_t *clamped_row = clamped_storage + (cy & 7) * clamped_width
-            #
-            #             # Figure out which row of the input we're reading
-            #             # from by clamping the y coordinate:
-            #             int clamped_y = std::hl.min(std::hl.max(cy, 0), input.height()-1)
-            #             uint8_t *input_row = &input(0, clamped_y)
-            #
-            #             # Fill it in with the padding.
-            #             for (int x = -2 x < input.width() + 2 ):
-            #                 int clamped_x = std::hl.min(std::hl.max(x, 0), input.width()-1)
-            #                 *clamped_row++ = input_row[clamped_x]
-            #
-            #
-            #
-            #         # Now iterate over vectors of x for the pure step of the output.
-            #         for (int x_vec = 0 x_vec < (input.width() + 15)/16 x_vec++) {
-            #             int x_base = std::hl.min(x_vec * 16, input.width() - 16)
-            #
-            #             # Allocate storage for the minimum and maximum
-            #             # helpers. One vector is enough.
-            #             __m128i minimum_storage, maximum_storage
-            #
-            #             # The pure step for the maximum is a vector of zeros
-            #             maximum_storage = (__m128i)_mm_setzero_ps()
-            #
-            #             # The update step for maximum
-            #             for (int max_y = y - 2 max_y <= y + 2 max_y++) {
-            #                 uint8_t *clamped_row = clamped_storage + (max_y & 7) * clamped_width
-            #                 for (int max_x = x_base - 2 max_x <= x_base + 2 max_):
-            #                     __m128i v = _mm_loadu_si128((__m128i const *)(clamped_row + max_x + 2))
-            #                     maximum_storage = _mm_max_epu8(maximum_storage, v)
-            #
-            #
-            #
-            #             # The pure step for the minimum is a vector of
-            #             # ones. Create it by comparing something to
-            #             # itself.
-            #             minimum_storage = (__m128i)_mm_cmpeq_ps(_mm_setzero_ps(),
-            #                                                     _mm_setzero_ps())
-            #
-            #             # The update step for minimum.
-            #             for (int min_y = y - 2 min_y <= y + 2 min_y++) {
-            #                 uint8_t *clamped_row = clamped_storage + (min_y & 7) * clamped_width
-            #                 for (int min_x = x_base - 2 min_x <= x_base + 2 min_):
-            #                     __m128i v = _mm_loadu_si128((__m128i const *)(clamped_row + min_x + 2))
-            #                     minimum_storage = _mm_min_epu8(minimum_storage, v)
-            #
-            #
-            #
-            #             # Now compute the spread.
-            #             __m128i spread = _mm_sub_epi8(maximum_storage, minimum_storage)
-            #
-            #             # Store it.
-            #             _mm_storeu_si128((__m128i *)(output_row + x_base), spread)
-            #
-            #
-            #
-            #     del clamped_storage
-            #
-        # end of hundred iterations
-
-        # Skip the timing comparison if we don't have openmp
-        # enabled. Otherwise it's unfair to C.
-        #ifdef _OPENMP
-        t2 = datetime.now()
-
-        # Now run the Halide version again without the
-        # jit-compilation overhead. Also run it one hundred times.
-        for iters in range(100):
-            spread.realize(halide_result)
-
-        t3 = datetime.now()
-
-        # Report the timings. On my machine they both take about 3ms
-        # for the 4-megapixel input (fast!), which makes sense,
-        # because they're using the same vectorization and
-        # parallelization strategy. However I find the Halide easier
-        # to read, write, debug, modify, and port.
-        print("Halide spread took %f ms. C equivalent took %f ms" % (
-               (t3 - t2).total_seconds() * 1000,
-               (t2 - t1).total_seconds() * 1000))
-
-        #endif # _OPENMP
-
-        # Check the results match:
-        for yy in range(input.height()):
-            for xx in range(input.width()):
-                if halide_result(xx, yy) != c_result(xx, yy):
-                    raise Exception("halide_result(%d, %d) = %d instead of %d" % (
-                           xx, yy, halide_result(xx, yy), c_result(xx, yy)))
-                    return -1
-
-
-
-        #endif # __SSE2__
-    else:
-        print("(Skipped the SSE2 section of the code, "
-              "since non-sense in python world.)")
+        for xx in range(10):
+            assert halide_result_1[xx] == py_result[xx], "halide_result_1(%d) = %d instead of %d" % (
+                xx, halide_result_1[xx], py_result[xx])
+            assert halide_result_2[xx] == py_result[xx], "halide_result_2(%d) = %d instead of %d" % (
+                xx, halide_result_2[xx], py_result[xx])
 
     print("Success!")
     return 0
-
 
 
 if __name__ == "__main__":

--- a/python_bindings/tutorial/lesson_09_update_definitions.py
+++ b/python_bindings/tutorial/lesson_09_update_definitions.py
@@ -22,8 +22,7 @@ def main():
     x, y = hl.Var("x"), hl.Var("y")
 
     # Load a grayscale image to use as an input.
-    image_path = os.path.join(os.path.dirname(
-        __file__), "../../tutorial/images/gray.png")
+    image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/gray.png")
     input_data = imageio.imread(image_path)
     if True:
          # making the image smaller to go faster
@@ -159,8 +158,9 @@ def main():
         # Check the results match:
         for yy in range(100):
             for xx in range(100):
-                assert halide_result[xx, yy] == py_result[yy][xx], "halide_result(%d, %d) = %d instead of %d" % (
-                    xx, yy, halide_result[xx, yy], py_result[yy][xx])
+                assert halide_result[xx, yy] == py_result[yy][xx], \
+                    "halide_result(%d, %d) = %d instead of %d" % (
+                        xx, yy, halide_result[xx, yy], py_result[yy][xx])
 
     # Now we'll examine a real-world use for an update definition:
     # computing a histogram.
@@ -197,8 +197,8 @@ def main():
 
         # Check the answers agree:
         for xx in range(256):
-            assert py_result[xx] == halide_result[xx], "halide_result(%d) = %d instead of %d" % (
-                xx, halide_result[xx], py_result[xx])
+            assert py_result[xx] == halide_result[xx], \
+                "halide_result(%d) = %d instead of %d" % (xx, halide_result[xx], py_result[xx])
 
     # Scheduling update steps
     if True:
@@ -266,8 +266,9 @@ def main():
         # Check the C and Halide results match:
         for yy in range(16):
             for xx in range(16):
-                assert halide_result[xx, yy] == py_result[yy][xx], "halide_result(%d, %d) = %d instead of %d" % (
-                    xx, yy, halide_result[xx, yy], py_result[yy][xx])
+                assert halide_result[xx, yy] == py_result[yy][xx], \
+                    "halide_result(%d, %d) = %d instead of %d" % (
+                        xx, yy, halide_result[xx, yy], py_result[yy][xx])
 
     # That covers how to schedule the variables within a hl.Func that
     # uses update steps, but what about producer-consumer
@@ -298,8 +299,8 @@ def main():
 
         # Check the results match
         for xx in range(10):
-            assert halide_result[xx] == py_result[xx], "halide_result(%d) = %d instead of %d" % (
-                xx, halide_result[xx], py_result[xx])
+            assert halide_result[xx] == py_result[xx], \
+                "halide_result(%d) = %d instead of %d" % (xx, halide_result[xx], py_result[xx])
 
         # For all other compute_at/store_at options, the reduction
         # gets placed where you would expect, somewhere in the loop
@@ -356,8 +357,8 @@ def main():
 
             # Check the results match
             for xx in range(10):
-                assert halide_result[xx] == py_result[xx], "halide_result(%d) = %d instead of %d" % (
-                    xx, halide_result[xx], py_result[xx])
+                assert halide_result[xx] == py_result[xx], \
+                    "halide_result(%d) = %d instead of %d" % (xx, halide_result[xx], py_result[xx])
 
         if True:
             # Case 2: The consumer references the producer in the update step
@@ -398,8 +399,8 @@ def main():
 
             # Check the results match
             for xx in range(10):
-                assert halide_result[xx] == py_result[xx], "halide_result(%d) = %d instead of %d" % (
-                    xx, halide_result[xx], py_result[xx])
+                assert halide_result[xx] == py_result[xx], \
+                    "halide_result(%d) = %d instead of %d" % (xx, halide_result[xx], py_result[xx])
 
         if True:
             # Case 3: The consumer references the producer in
@@ -436,8 +437,8 @@ def main():
 
             # Check the results match
             for xx in range(10):
-                assert halide_result[xx] == py_result[xx], "halide_result(%d) = %d instead of %d" % (
-                    xx, halide_result[xx], py_result[xx])
+                assert halide_result[xx] == py_result[xx], \
+                    "halide_result(%d) = %d instead of %d" % (xx, halide_result[xx], py_result[xx])
 
         if True:
             # Case 4: The consumer references the producer in
@@ -500,8 +501,9 @@ def main():
             # Check the results match
             for yy in range(10):
                 for xx in range(10):
-                    assert halide_result[xx, yy] == py_result[yy][xx], "halide_result(%d, %d) = %d instead of %d" % (
-                        xx, yy, halide_result[xx, yy], py_result[yy][xx])
+                    assert halide_result[xx, yy] == py_result[yy][xx], \
+                        "halide_result(%d, %d) = %d instead of %d" % (
+                            xx, yy, halide_result[xx, yy], py_result[yy][xx])
 
         if True:
             # Case 5: Scheduling a producer under a reduction domain
@@ -545,8 +547,8 @@ def main():
 
             # Check the results match
             for xx in range(10):
-                assert halide_result[xx] == py_result[xx], "halide_result(%d) = %d instead of %d" % (
-                    xx, halide_result[xx], py_result[xx])
+                assert halide_result[xx] == py_result[xx], \
+                    "halide_result(%d) = %d instead of %d" % (xx, halide_result[xx], py_result[xx])
 
     # A real-world example of a reduction inside a producer-consumer chain.
     if True:
@@ -605,8 +607,9 @@ def main():
         # Check the results match
         for yy in range(input.height()):
             for xx in range(input.width()):
-                assert halide_result[xx, yy] == py_result[xx, yy], "halide_result(%d, %d) = %d instead of %d" % (
-                    xx, yy, halide_result[xx, yy], py_result[xx, yy])
+                assert halide_result[xx, yy] == py_result[xx, yy], \
+                    "halide_result(%d, %d) = %d instead of %d" % (
+                        xx, yy, halide_result[xx, yy], py_result[xx, yy])
 
     # Reduction helpers.
     if True:
@@ -643,10 +646,10 @@ def main():
 
         # Check they all match.
         for xx in range(10):
-            assert halide_result_1[xx] == py_result[xx], "halide_result_1(%d) = %d instead of %d" % (
-                xx, halide_result_1[xx], py_result[xx])
-            assert halide_result_2[xx] == py_result[xx], "halide_result_2(%d) = %d instead of %d" % (
-                xx, halide_result_2[xx], py_result[xx])
+            assert halide_result_1[xx] == py_result[xx], \
+                "halide_result_1(%d) = %d instead of %d" % (xx, halide_result_1[xx], py_result[xx])
+            assert halide_result_2[xx] == py_result[xx], \
+                "halide_result_2(%d) = %d instead of %d" % (xx, halide_result_2[xx], py_result[xx])
 
     print("Success!")
     return 0

--- a/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
+++ b/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+
 # Halide tutorial lesson 10.
 
 # This lesson demonstrates how to use Halide as an more traditional
@@ -11,20 +12,20 @@
 # compiling this code is a multi-step process.
 
 # This lesson can be built by invoking the command:
-#    python tutorial_lesson_10_aot_compilation_run.py
-# in a shell with the Halide Python extension in your PYTHONPATH.
+#    make test_tutorial_lesson_10_aot_compilation_generate
+# in a shell with the current directory at python_bindings/
 
 # This will generate a file lesson_10_halide.py.cpp that still needs
 # to be compiled. Use
-#   g++ -shared -fPIC lesson_10_halide.py.cpp lesson_10_halide.o \
-#       -lpthread -o lesson_10_halide.so
-# to generate a Python module called "lesson_10_halide".
+#    make make test_tutorial_lesson_10_aot_compilation_run
+# to generate and run a Python module called "lesson_10_halide".
 
 # The benefits of this approach are that the final program:
 # - Doesn't do any jit compilation at runtime, so it's fast.
 # - Doesn't depend on libHalide at all, so it's a small, easy-to-deploy binary.
 
 import halide as hl
+
 
 def main():
 
@@ -65,11 +66,12 @@ def main():
     fname = "lesson_10_halide"
     brighter.compile_to({hl.Output.object: "lesson_10_halide.o",
                          hl.Output.python_extension: "lesson_10_halide.py.cpp"},
-                         [input, offset], "lesson_10_halide")
+                        [input, offset], "lesson_10_halide")
 
     print("Halide pipeline compiled, but not yet run.")
 
-    # To continue this lesson, look in the file lesson_10_aot_compilation_run.cpp
+    # To continue this lesson, look in the file
+    # lesson_10_aot_compilation_run.py
 
     return 0
 

--- a/python_bindings/tutorial/lesson_10_aot_compilation_run.py
+++ b/python_bindings/tutorial/lesson_10_aot_compilation_run.py
@@ -10,6 +10,7 @@ import lesson_10_halide
 
 import numpy as np
 
+
 def main():
     # Have a look at the generated files above (they won't exist until you've run
     # lesson_10_generate): lesson_10_halide.py.cpp, lesson_10_halide.h
@@ -33,7 +34,7 @@ def main():
             input[x, y] = x ^ (y + 1)
 
     # And the memory where we want to write our output:
-    output = np.empty((640,480), dtype=np.uint8, order='F')
+    output = np.empty((640, 480), dtype=np.uint8, order='F')
 
     offset_value = 5
 
@@ -49,10 +50,8 @@ def main():
             correct_val[0] = input_val
             # we add over a uint8 value (will properly model overflow)
             correct_val[0] += offset_value
-            if output_val != correct_val[0]:
-                raise Exception("output(%d, %d) was %d instead of %d" % (
-                       x, y, output_val, correct_val))
-                #return -1
+            assert output_val == correct_val[0], "output(%d, %d) was %d instead of %d" % (
+                x, y, output_val, correct_val)
 
     # Everything worked!
     print("Success!")

--- a/python_bindings/tutorial/lesson_10_aot_compilation_run.py
+++ b/python_bindings/tutorial/lesson_10_aot_compilation_run.py
@@ -50,8 +50,8 @@ def main():
             correct_val[0] = input_val
             # we add over a uint8 value (will properly model overflow)
             correct_val[0] += offset_value
-            assert output_val == correct_val[0], "output(%d, %d) was %d instead of %d" % (
-                x, y, output_val, correct_val)
+            assert output_val == correct_val[0], \
+                "output(%d, %d) was %d instead of %d" % (x, y, output_val, correct_val)
 
     # Everything worked!
     print("Success!")

--- a/python_bindings/tutorial/lesson_11_cross_compilation.py
+++ b/python_bindings/tutorial/lesson_11_cross_compilation.py
@@ -102,7 +102,7 @@ def main():
 
         header = list(unpack("B" * length, header_bytes))
         assert header == arm_32_android_magic, \
-            "Unexpected header bytes in 32-bit arm object file: " +
+            "Unexpected header bytes in 32-bit arm object file: " + \
             str([x == y for x, y in zip(header, arm_32_android_magic)])
 
     if create_windows:

--- a/python_bindings/tutorial/lesson_11_cross_compilation.py
+++ b/python_bindings/tutorial/lesson_11_cross_compilation.py
@@ -53,8 +53,8 @@ def main():
         arm_features = []             # A list of features to set
         target.set_features(arm_features)
         # Pass the target as the last argument.
-        brighter.compile_to_file(
-            "lesson_11_arm_32_android", args, "lesson_11_arm_32_android", target)
+        brighter.compile_to_file("lesson_11_arm_32_android", args,
+                                 "lesson_11_arm_32_android", target)
 
     if create_windows:
         # And now a Windows object file for 64-bit x86 with AVX and SSE 4.1:
@@ -63,8 +63,8 @@ def main():
         target.arch = hl.TargetArch.X86
         target.bits = 64
         target.set_features([hl.TargetFeature.AVX, hl.TargetFeature.SSE41])
-        brighter.compile_to_file(
-            "lesson_11_x86_64_windows", args, "lesson_11_x86_64_windows", target)
+        brighter.compile_to_file("lesson_11_x86_64_windows", args,
+                                 "lesson_11_x86_64_windows", target)
 
     if create_ios:
         # And finally an iOS mach-o object file for one of Apple's 32-bit
@@ -78,8 +78,8 @@ def main():
         target.arch = hl.TargetArch.ARM
         target.bits = 32
         target.set_features([hl.TargetFeature.ARMv7s])
-        brighter.compile_to_file(
-            "lesson_11_arm_32_ios", args, "lesson_11_arm_32_ios", target)
+        brighter.compile_to_file("lesson_11_arm_32_ios", args,
+                                 "lesson_11_arm_32_ios", target)
 
     # Now let's check these files are what they claim, by examining
     # their first few bytes.
@@ -101,7 +101,8 @@ def main():
         f.close()
 
         header = list(unpack("B" * length, header_bytes))
-        assert header == arm_32_android_magic, "Unexpected header bytes in 32-bit arm object file: " + \
+        assert header == arm_32_android_magic, \
+            "Unexpected header bytes in 32-bit arm object file: " +
             str([x == y for x, y in zip(header, arm_32_android_magic)])
 
     if create_windows:

--- a/python_bindings/tutorial/lesson_11_cross_compilation.py
+++ b/python_bindings/tutorial/lesson_11_cross_compilation.py
@@ -5,23 +5,12 @@
 # This lesson demonstrates how to use Halide as a cross-compiler.
 
 # This lesson can be built by invoking the command:
-#    make tutorial_lesson_11_cross_compilation
-# in a shell with the current directory at the top of the halide source tree.
-# Otherwise, see the platform-specific compiler invocations below.
+#    make test_tutorial_lesson_11_cross_compilation
+# in a shell with the current directory at python_bindings/
 
-# On linux, you can compile and run it like so:
-# g++ lesson_11*.cpp -g -std=c++11 -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_11
-# LD_LIBRARY_PATH=../bin ./lesson_11
-
-# On os x:
-# g++ lesson_11*.cpp -g -std=c++11 -I ../include -L ../bin -lHalide -o lesson_11
-# DYLD_LIBRARY_PATH=../bin ./lesson_11
-
-#include "Halide.h"
-#include <stdio.h>
-#using namespace Halide
 import halide as hl
 from struct import unpack
+
 
 def main():
 
@@ -64,7 +53,8 @@ def main():
         arm_features = []             # A list of features to set
         target.set_features(arm_features)
         # Pass the target as the last argument.
-        brighter.compile_to_file("lesson_11_arm_32_android", args, "lesson_11_arm_32_android", target)
+        brighter.compile_to_file(
+            "lesson_11_arm_32_android", args, "lesson_11_arm_32_android", target)
 
     if create_windows:
         # And now a Windows object file for 64-bit x86 with AVX and SSE 4.1:
@@ -73,7 +63,8 @@ def main():
         target.arch = hl.TargetArch.X86
         target.bits = 64
         target.set_features([hl.TargetFeature.AVX, hl.TargetFeature.SSE41])
-        brighter.compile_to_file("lesson_11_x86_64_windows", args, "lesson_11_x86_64_windows", target)
+        brighter.compile_to_file(
+            "lesson_11_x86_64_windows", args, "lesson_11_x86_64_windows", target)
 
     if create_ios:
         # And finally an iOS mach-o object file for one of Apple's 32-bit
@@ -87,8 +78,8 @@ def main():
         target.arch = hl.TargetArch.ARM
         target.bits = 32
         target.set_features([hl.TargetFeature.ARMv7s])
-        brighter.compile_to_file("lesson_11_arm_32_ios", args, "lesson_11_arm_32_ios", target)
-
+        brighter.compile_to_file(
+            "lesson_11_arm_32_ios", args, "lesson_11_arm_32_ios", target)
 
     # Now let's check these files are what they claim, by examining
     # their first few bytes.
@@ -96,7 +87,7 @@ def main():
     if create_android:
         # 32-arm android object files start with the magic bytes:
         # uint8_t []
-        arm_32_android_magic = [0x7f, ord('E'), ord('L'), ord('F'), # ELF format
+        arm_32_android_magic = [0x7f, ord('E'), ord('L'), ord('F'),  # ELF format
                                 1,       # 32-bit
                                 1,       # 2's complement little-endian
                                 1]       # Current version of elf
@@ -106,16 +97,12 @@ def main():
         try:
             header_bytes = f.read(length)
         except:
-            print("Android object file not generated")
-            return -1
+            assert False, "Android object file not generated"
         f.close()
 
-        header = list(unpack("B"*length, header_bytes))
-        if header != arm_32_android_magic:
-            print([x == y for x, y in zip(header, arm_32_android_magic)])
-            raise Exception("Unexpected header bytes in 32-bit arm object file.")
-            return -1
-
+        header = list(unpack("B" * length, header_bytes))
+        assert header == arm_32_android_magic, "Unexpected header bytes in 32-bit arm object file: " + \
+            str([x == y for x, y in zip(header, arm_32_android_magic)])
 
     if create_windows:
         # 64-bit windows object files start with the magic 16-bit value 0x8664
@@ -127,38 +114,30 @@ def main():
         try:
             header_bytes = f.read(2)
         except:
-            print("Windows object file not generated")
-            return -1
+            assert False, "Windows object file not generated"
         f.close()
 
-        header = list(unpack("B"*2, header_bytes))
-        if header != win_64_magic:
-            raise Exception("Unexpected header bytes in 64-bit windows object file.")
-            return -1
-
+        header = list(unpack("B" * 2, header_bytes))
+        assert header == win_64_magic, "Unexpected header bytes in 64-bit windows object file."
 
     if create_ios:
         # 32-bit arm iOS mach-o files start with the following magic bytes:
         #  uint32_t []
         arm_32_ios_magic = [
-            0xfeedface, # Mach-o magic bytes
-            #0xfe, 0xed, 0xfa, 0xce, # Mach-o magic bytes
-                                       12,  # CPU type is ARM
-                                       11,  # CPU subtype is ARMv7s
-                                       1]  # It's a relocatable object file.
+            0xfeedface,  # Mach-o magic bytes
+            # 0xfe, 0xed, 0xfa, 0xce, # Mach-o magic bytes
+            12,  # CPU type is ARM
+            11,  # CPU subtype is ARMv7s
+            1]  # It's a relocatable object file.
         f = open("lesson_11_arm_32_ios.o", "rb")
         try:
-            header_bytes = f.read(4*4)
+            header_bytes = f.read(4 * 4)
         except:
-            print("ios object file not generated")
-            return -1
+            assert False, "ios object file not generated"
         f.close()
 
-        header = list(unpack("I"*4, header_bytes))
-        if header != arm_32_ios_magic:
-            raise Exception("Unexpected header bytes in 32-bit arm ios object file.")
-            return -1
-
+        header = list(unpack("I" * 4, header_bytes))
+        assert header == arm_32_ios_magic, "Unexpected header bytes in 32-bit arm ios object file."
 
     # It looks like the object files we produced are plausible for
     # those targets. We'll count that as a success for the purposes

--- a/python_bindings/tutorial/lesson_12_using_the_gpu.py
+++ b/python_bindings/tutorial/lesson_12_using_the_gpu.py
@@ -5,39 +5,26 @@
 # This lesson demonstrates how to use Halide to run code on a GPU.
 
 # This lesson can be built by invoking the command:
-#    make tutorial_lesson_12_using_the_gpu
-# in a shell with the current directory at the top of the halide source tree.
-# Otherwise, see the platform-specific compiler invocations below.
+#    make test_tutorial_lesson_12_using_the_gpu
+# in a shell with the current directory at python_bindings/
 
-# On linux, you can compile and run it like so:
-# g++ lesson_12*.cpp -g -std=c++11 -I ../include -L ../bin -lHalide `libpng-config --cflags --ldflags` -lpthread -ldl -o lesson_12
-# LD_LIBRARY_PATH=../bin ./lesson_12
-
-# On os x:
-# g++ lesson_12*.cpp -g -std=c++11 -I ../include -L ../bin -lHalide `libpng-config --cflags --ldflags` -o lesson_12
-# DYLD_LIBRARY_PATH=../bin ./lesson_12
-
-#include "Halide.h"
-#include <stdio.h>
-#using namespace Halide
 import halide as hl
 
-# Include some support code for loading pngs.
-#include "image_io.h"
 import imageio
 import os.path
 
 # Include a clock to do performance testing.
-#include "clock.h"
 from datetime import datetime
 
-
 # Define some Vars to use.
-x, y, c, i, ii, xi, yi = hl.Var("x"), hl.Var("y"), hl.Var("c"), hl.Var("i"), hl.Var("ii"), hl.Var("xi"), hl.Var("yi")
+x, y, c, i, xo, yo, xi, yi = hl.Var("x"), hl.Var("y"), hl.Var("c"), hl.Var(
+    "i"), hl.Var("xo"), hl.Var("yo"), hl.Var("xi"), hl.Var("yi")
 
 # We're going to want to schedule a pipeline in several ways, so we
 # define the pipeline in a class so that we can recreate it several
 # times with different schedules.
+
+
 class MyPipeline:
 
     def __init__(self, input):
@@ -51,30 +38,29 @@ class MyPipeline:
         self.curved = hl.Func("curved")
         self.input = input
 
-
         # For this lesson, we'll use a two-stage pipeline that sharpens
         # and then applies a look-up-table (LUT).
 
         # First we'll define the LUT. It will be a gamma curve.
-        self.lut[i] = hl.cast(hl.UInt(8), hl.clamp(pow(i / 255.0, 1.2) * 255.0, 0, 255))
+        gamma = hl.f32(1.2)
+        self.lut[i] = hl.u8(hl.clamp(hl.pow(i / 255.0, gamma) * 255.0, 0, 255))
 
         # Augment the input with a boundary condition.
-        self.padded[x, y, c] = input[hl.clamp(x, 0, input.width()-1),
-                                hl.clamp(y, 0, input.height()-1), c]
+        self.padded[x, y, c] = input[hl.clamp(x, 0, input.width() - 1),
+                                     hl.clamp(y, 0, input.height() - 1), c]
 
         # Cast it to 16-bit to do the math.
-        self.padded16[x, y, c] = hl.cast(hl.UInt(16), self.padded[x, y, c])
+        self.padded16[x, y, c] = hl.u16(self.padded[x, y, c])
 
         # Next we sharpen it with a five-tap filter.
-        self.sharpen[x, y, c] = (self.padded16[x, y, c] * 2-
-                            (self.padded16[x - 1, y, c] +
-                             self.padded16[x, y - 1, c] +
-                             self.padded16[x + 1, y, c] +
-                             self.padded16[x, y + 1, c]) / 4)
+        self.sharpen[x, y, c] = (self.padded16[x, y, c] * 2 -
+                                 (self.padded16[x - 1, y, c] +
+                                  self.padded16[x, y - 1, c] +
+                                  self.padded16[x + 1, y, c] +
+                                  self.padded16[x, y + 1, c]) / 4)
 
         # Then apply the LUT.
         self.curved[x, y, c] = self.lut[self.sharpen[x, y, c]]
-
 
     # Now we define methods that give our pipeline several different
     # schedules.
@@ -85,26 +71,24 @@ class MyPipeline:
         # Compute color channels innermost. Promise that there will
         # be three of them and unroll across them.
         self.curved.reorder(c, x, y) \
-              .bound(c, 0, 3) \
-              .unroll(c)
+            .bound(c, 0, 3) \
+            .unroll(c)
 
         # Look-up-tables don't vectorize well, so just parallelize
         # curved in slices of 16 scanlines.
-        yo, yi = hl.Var("yo"), hl.Var("yi")
         self.curved.split(y, yo, yi, 16) \
-              .parallel(yo)
+            .parallel(yo)
 
         # Compute sharpen as needed per scanline of curved, reusing
         # previous values computed within the same strip of 16
         # scanlines.
-        self.sharpen.store_at(self.curved, yo) \
-                    .compute_at(self.curved, yi)
+        self.sharpen.compute_at(self.curved, yi)
 
         # Vectorize the sharpen. It's 16-bit so we'll vectorize it 8-wide.
         self.sharpen.vectorize(x, 8)
 
         # Compute the padded input at the same granularity as the
-        # sharpen. We'll leave the hl.cast to 16-bit inlined into
+        # sharpen. We'll leave the cast to 16-bit inlined into
         # sharpen.
         self.padded.store_at(self.curved, yo) \
             .compute_at(self.curved, yi)
@@ -114,13 +98,24 @@ class MyPipeline:
         self.padded.vectorize(x, 16)
 
         # JIT-compile the pipeline for the CPU.
-        self.curved.compile_jit()
+        target = hl.get_host_target()
+        self.curved.compile_jit(target)
 
         return
 
-
     # Now a schedule that uses CUDA or OpenCL.
     def schedule_for_gpu(self):
+        target = find_gpu_target()
+        if not target.has_gpu_feature():
+            return False
+
+        # If you want to see all of the OpenCL, Metal, CUDA or D3D 12 API
+        # calls done by the pipeline, you can also enable the Debug flag.
+        # This is helpful for figuring out which stages are slow, or when
+        # CPU -> GPU copies happen. It hurts performance though, so we'll
+        # leave it commented out.
+        # target.set_feature(hl.TargetFeature.Debug)
+
         # We make the decision about whether to use the GPU for each
         # hl.Func independently. If you have one hl.Func computed on the
         # CPU, and the next computed on the GPU, Halide will do the
@@ -147,9 +142,9 @@ class MyPipeline:
         # This is a very common scheduling pattern on the GPU, so
         # there's a shorthand for it:
 
-        # lut.gpu_tile(i, ii, 16)
+        # lut.gpu_tile(i, block, thread, 16);
 
-        # hl.Func::gpu_tile method is similar to hl.Func::tile, except that
+        # hl.Func.gpu_tile behaves the same as hl.Func.tile, except that
         # it also specifies that the tile coordinates correspond to
         # GPU blocks, and the coordinates within each tile correspond
         # to GPU threads.
@@ -161,7 +156,7 @@ class MyPipeline:
                    .unroll(c)
 
         # Compute curved in 2D 8x8 tiles using the GPU.
-        self.curved.gpu_tile(x, y, xi, yi, 8, 8)
+        self.curved.gpu_tile(x, y, xo, yo, xi, yi, 8, 8)
 
         # This is equivalent to:
         # curved.tile(x, y, xo, yo, xi, yi, 8, 8)
@@ -170,56 +165,31 @@ class MyPipeline:
 
         # We'll leave sharpen as inlined into curved.
 
-        # Compute the padded input as needed per GPU block, storing the
-        # intermediate result in shared memory. hl.Var::gpu_blocks, and
-        # hl.Var::gpu_threads exist to help you schedule producers within
-        # GPU threads and blocks.
-        self.padded.compute_at(self.curved, x)
+        # Compute the padded input as needed per GPU block, storing
+        # the intermediate result in shared memory. In the schedule
+        # above xo corresponds to GPU blocks.
+        self.padded.compute_at(self.curved, xo)
 
         # Use the GPU threads for the x and y coordinates of the
         # padded input.
         self.padded.gpu_threads(x, y)
 
-        # JIT-compile the pipeline for the GPU. CUDA or OpenCL are
-        # not enabled by default. We have to construct a hl.Target
-        # object, enable one of them, and then pass that target
-        # object to compile_jit. Otherwise your CPU will very slowly
-        # pretend it's a GPU, and use one thread per output pixel.
+        # JIT-compile the pipeline for the GPU. CUDA, OpenCL, or
+        # Metal are not enabled by default. We have to construct a
+        # Target object, enable one of them, and then pass that
+        # target object to compile_jit. Otherwise your CPU will very
+        # slowly pretend it's a GPU, and use one thread per output
+        # pixel.
 
-        # Start with a target suitable for the machine you're running
-        # this on.
-        target = hl.get_host_target()
-
-        # Then enable OpenCL or CUDA.
-        #use_opencl = False
-        use_opencl = True
-        if use_opencl:
-            # We'll enable OpenCL here, because it tends to give better
-            # performance than CUDA, even with NVidia's drivers, because
-            # NVidia's open source LLVM backend doesn't seem to do all
-            # the same optimizations their proprietary compiler does.
-            target.set_feature(hl.TargetFeature.OpenCL)
-            print("(Using OpenCL)")
-        else:
-            # Uncomment the next line and comment out the line above to
-            # try CUDA instead.
-            target.set_feature(hl.TargetFeature.CUDA)
-            print("(Using CUDA)")
-
-        # If you want to see all of the OpenCL or CUDA API calls done
-        # by the pipeline, you can also enable the Debug
-        # flag. This is helpful for figuring out which stages are
-        # slow, or when CPU -> GPU copies happen. It hurts
-        # performance though, so we'll leave it commented out.
-        # target.set_feature(hl.TargetFeature.Debug)
-
+        print("Target: ", target)
         self.curved.compile_jit(target)
+        return True
 
     def test_performance(self):
         # Test the performance of the scheduled MyPipeline.
 
         output = hl.Buffer(hl.UInt(8),
-                        [self.input.width(), self.input.height(), self.input.channels()])
+                           [self.input.width(), self.input.height(), self.input.channels()])
 
         # Run the filter once to initialize any GPU runtime state.
         self.curved.realize(output)
@@ -234,7 +204,8 @@ class MyPipeline:
             for j in range(100):
                 self.curved.realize(output)
 
-            # Force any GPU code to finish by copying the buffer back to the CPU.
+            # Force any GPU code to finish by copying the buffer back to the
+            # CPU.
             output.copy_to_host()
 
             t2 = datetime.now()
@@ -255,72 +226,85 @@ class MyPipeline:
         assert output.type() == hl.UInt(8)
 
         # Check against the reference output.
-        for c in range(self.input.channels()):
-            for y in range(self.input.height()):
-                for x in range(self.input.width()):
-                    if output[x, y, c] != reference_output[x, y, c]:
-                        print(
-                            "Mismatch between output (%d) and "
-                            "reference output (%d) at %d, %d, %d" % (
-                                output[x, y, c],
-                                reference_output[x, y, c],
-                                x, y, c))
-                        return
+        for cc in range(self.input.channels()):
+            for yy in range(self.input.height()):
+                for xx in range(self.input.width()):
+                    assert output[xx, yy, cc] == reference_output[xx, yy, cc], \
+                        "Mismatch between output (%d) and reference output (%d) at %d, %d, %d" % (
+                        output[xx, yy, cc],
+                        reference_output[xx, yy, cc],
+                        xx, yy, cc)
 
         print("CPU and GPU outputs are consistent.")
 
 
 def main():
     # Load an input image.
-    image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/rgb.png")
+    image_path = os.path.join(os.path.dirname(
+        __file__), "../../tutorial/images/rgb.png")
     input = hl.Buffer(imageio.imread(image_path))
 
-    # Allocated an image that will store the correct output
-    reference_output = hl.Buffer(hl.UInt(8), [input.width(), input.height(), input.channels()])
+    # TODO: the image-loading code in the C++ tutorials
+    # always implicitly sets this flag; the code here does not.
+    # Should this be necessary?
+    input.set_host_dirty()
 
-    print("Testing performance on CPU:")
+    # Allocated an image that will store the correct output
+    reference_output = hl.Buffer(
+        hl.UInt(8), [input.width(), input.height(), input.channels()])
+
+    print("Running pipeline on CPU:")
     p1 = MyPipeline(input)
     p1.schedule_for_cpu()
-    p1.test_performance()
     p1.curved.realize(reference_output)
 
-    if have_opencl():
-        print("Testing performance on GPU:")
-        p2 = MyPipeline(input)
-        p2.schedule_for_gpu()
-        p2.test_performance()
+    print("Running pipeline on GPU:")
+    p2 = MyPipeline(input)
+    has_gpu_target = p2.schedule_for_gpu()
+    if has_gpu_target:
+        print("Testing GPU correctness:")
         p2.test_correctness(reference_output)
     else:
-        print("Not testing performance on GPU, "
-              "because I can't find the opencl library")
+        print("No GPU target available on the host")
+
+    print("Testing performance on CPU:")
+    p1.test_performance()
+
+    if has_gpu_target:
+        print("Testing performance on GPU:")
+        p2.test_performance()
 
     return 0
 
+# A helper function to check if OpenCL, Metal or D3D12 is present on the
+# host machine.
 
 
-def have_opencl():
-    """
-    A helper function to check if OpenCL seems to exist on this machine.
-    :return: bool
-    """
+def find_gpu_target():
+    # Start with a target suitable for the machine you're running this on.
+    target = hl.get_host_target()
 
-    import ctypes
-    import platform
+    features_to_try = []
+    if target.os == hl.TargetOS.Windows:
+        # Try D3D12 first; if that fails, try OpenCL.
+        features_to_try.append(hl.TargetFeature.D3D12Compute)
+        features_to_try.append(hl.TargetFeature.OpenCL)
+    elif target.os == hl.TargetOS.OSX:
+        # OS X doesn't update its OpenCL drivers, so they tend to be broken.
+        # CUDA would also be a fine choice on machines with NVidia GPUs.
+        features_to_try.append(hl.TargetFeature.Metal)
+    else:
+        features_to_try.append(hl.TargetFeature.OpenCL)
 
-    try:
-        if platform.system() == "Windows":
-            ret = ctypes.windll.LoadLibrary("OpenCL.dll") != None
-        elif platform.system() == "Darwin": # apple
-            ret =  ctypes.cdll.LoadLibrary("/System/Library/Frameworks/OpenCL.framework/Versions/Current/OpenCL") != None
-        elif platform.system() == "Linux":
-            ret = ctypes.cdll.LoadLibrary("libOpenCL.so") != None
-        else:
-            raise Exception("Cannot check for opencl presence "
-                            "on unknown system '%s'" % platform.system())
-    except OSError:
-            ret = False
+    # Uncomment the following lines to also try CUDA:
+    # features_to_try.append(hl.TargetFeature.CUDA);
+    for f in features_to_try:
+        new_target = target.with_feature(f)
+        if (hl.host_supports_target_device(new_target)):
+            return new_target
 
-    return ret
+    print("Requested GPU(s) are not supported. (Do you have the proper hardware and/or driver installed?)")
+    return target
 
 
 if __name__ == "__main__":

--- a/python_bindings/tutorial/lesson_12_using_the_gpu.py
+++ b/python_bindings/tutorial/lesson_12_using_the_gpu.py
@@ -241,11 +241,6 @@ def main():
     image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/rgb.png")
     input = hl.Buffer(imageio.imread(image_path))
 
-    # TODO: the image-loading code in the C++ tutorials
-    # always implicitly sets this flag; the code here does not.
-    # Should this be necessary?
-    input.set_host_dirty()
-
     # Allocated an image that will store the correct output
     reference_output = hl.Buffer(hl.UInt(8), [input.width(), input.height(), input.channels()])
 

--- a/python_bindings/tutorial/lesson_12_using_the_gpu.py
+++ b/python_bindings/tutorial/lesson_12_using_the_gpu.py
@@ -231,17 +231,14 @@ class MyPipeline:
                 for xx in range(self.input.width()):
                     assert output[xx, yy, cc] == reference_output[xx, yy, cc], \
                         "Mismatch between output (%d) and reference output (%d) at %d, %d, %d" % (
-                        output[xx, yy, cc],
-                        reference_output[xx, yy, cc],
-                        xx, yy, cc)
+                            output[xx, yy, cc], reference_output[xx, yy, cc], xx, yy, cc)
 
         print("CPU and GPU outputs are consistent.")
 
 
 def main():
     # Load an input image.
-    image_path = os.path.join(os.path.dirname(
-        __file__), "../../tutorial/images/rgb.png")
+    image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/rgb.png")
     input = hl.Buffer(imageio.imread(image_path))
 
     # TODO: the image-loading code in the C++ tutorials
@@ -250,8 +247,7 @@ def main():
     input.set_host_dirty()
 
     # Allocated an image that will store the correct output
-    reference_output = hl.Buffer(
-        hl.UInt(8), [input.width(), input.height(), input.channels()])
+    reference_output = hl.Buffer(hl.UInt(8), [input.width(), input.height(), input.channels()])
 
     print("Running pipeline on CPU:")
     p1 = MyPipeline(input)

--- a/python_bindings/tutorial/lesson_13_tuples.py
+++ b/python_bindings/tutorial/lesson_13_tuples.py
@@ -89,8 +89,7 @@ def main():
     # rather than having new ones created. (The Buffers must have the correct
     # types and have identical sizes.)
     if True:
-        im1, im2 = hl.Buffer(hl.Int(32), [80, 60]), hl.Buffer(
-            hl.Float(32), [80, 60])
+        im1, im2 = hl.Buffer(hl.Int(32), [80, 60]), hl.Buffer(hl.Float(32), [80, 60])
         multi_valued.realize((im1, im2))
         assert im1[30, 40] == 30 + 40
         assert np.isclose(im2[30, 40], math.sin(30 * 40))

--- a/python_bindings/tutorial/lesson_13_tuples.py
+++ b/python_bindings/tutorial/lesson_13_tuples.py
@@ -1,27 +1,19 @@
 #!/usr/bin/python3
+
 # Halide tutorial lesson 13: Tuples
 
 # This lesson describes how to write Funcs that evaluate to multiple
 # values.
 
-# On linux, you can compile and run it like so:
-# g++ lesson_13*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_13 -std=c++11
-# LD_LIBRARY_PATH=../bin ./lesson_13
-
-# On os x:
-# g++ lesson_13*.cpp -g -I ../include -L ../bin -lHalide -o lesson_13 -std=c++11
-# DYLD_LIBRARY_PATH=../bin ./lesson_13
-
-# If you have the entire Halide source tree, you can also build it by
-# running:
-#    make tutorial_lesson_13_tuples
-# in a shell with the current directory at the top of the halide
-# source tree.
+# This lesson can be built by invoking the command:
+#    make test_tutorial_lesson_13_tuples
+# in a shell with the current directory at python_bindings/
 
 import halide as hl
 
 import numpy as np
 import math
+
 
 def main():
 
@@ -38,7 +30,7 @@ def main():
     # for every x, y coordinate indexed by c.
     color_image = hl.Func()
     c = hl.Var("c")
-    color_image[x, y, c] = hl.select(c == 0, 245, # Red value
+    color_image[x, y, c] = hl.select(c == 0, 245,  # Red value
                                      c == 1, 42,  # Green value
                                      132)        # Blue value
 
@@ -97,29 +89,29 @@ def main():
     # rather than having new ones created. (The Buffers must have the correct
     # types and have identical sizes.)
     if True:
-        im1, im2 = hl.Buffer(hl.Int(32), [80, 60]), hl.Buffer(hl.Float(32), [80, 60])
+        im1, im2 = hl.Buffer(hl.Int(32), [80, 60]), hl.Buffer(
+            hl.Float(32), [80, 60])
         multi_valued.realize((im1, im2))
         assert im1[30, 40] == 30 + 40
         assert np.isclose(im2[30, 40], math.sin(30 * 40))
-
 
     # All Tuple elements are evaluated together over the same domain
     # in the same loop nest, but stored in distinct allocations. The
     # equivalent C++ code to the above is:
     if True:
-        multi_valued_0 = np.empty((80*60), dtype=np.int32)
-        multi_valued_1 = np.empty((80*60), dtype=np.int32)
+        multi_valued_0 = np.empty((80 * 60), dtype=np.int32)
+        multi_valued_1 = np.empty((80 * 60), dtype=np.int32)
 
         for yy in range(80):
             for xx in range(60):
-                multi_valued_0[xx + 60*yy] = xx + yy
-                multi_valued_1[xx + 60*yy] = math.sin(xx*yy)
-
+                multi_valued_0[xx + 60 * yy] = xx + yy
+                multi_valued_1[xx + 60 * yy] = math.sin(xx * yy)
 
     # When compiling ahead-of-time, a Tuple-valued hl.Func evaluates
     # into multiple distinct output halide_buffer_t structs. These appear in
     # order at the end of the function signature:
-    # int multi_valued(...input buffers and params..., halide_buffer_t *output_1, halide_buffer_t *output_2)
+    # int multi_valued(...input buffers and params..., halide_buffer_t
+    # *output_1, halide_buffer_t *output_2)
 
     # You can construct a Tuple by passing multiple Exprs to the
     # Tuple constructor as we did above. Perhaps more elegantly, you
@@ -166,9 +158,9 @@ def main():
         # Update definition.
         r = hl.RDom([(1, 99)])
         old_index = arg_max[()][0]
-        old_max   = arg_max[()][1]
+        old_max = arg_max[()][1]
         new_index = hl.select(old_max > input[r], r, old_index)
-        new_max   = hl.max(input[r], old_max)
+        new_max = hl.max(input[r], old_max)
         arg_max[()] = (new_index, new_max)
 
         # The equivalent C++ is:
@@ -186,7 +178,6 @@ def main():
             arg_max_0 = new_index
             arg_max_1 = new_max
 
-
         # Let's verify that the Halide and C++ found the same maximum
         # value and index.
         if True:
@@ -197,14 +188,12 @@ def main():
             assert arg_max_0 == r0[()]
             assert np.isclose(arg_max_1, r1[()])
 
-
         # Halide provides argmax and hl.argmin as built-in reductions
         # similar to sum, product, maximum, and minimum. They return
         # a Tuple consisting of the point in the reduction domain
         # corresponding to that value, and the value itself. In the
         # case of ties they return the first value found. We'll use
         # one of these in the following section.
-
 
     # Tuples for user-defined types.
     if True:
@@ -229,11 +218,9 @@ def main():
                 "Convert to a Tuple"
                 return (self.real, self.imag)
 
-
             def __add__(self, other):
                 "Complex addition"
                 return Complex(self.real + other.real, self.imag + other.imag)
-
 
             def __mul__(self, other):
                 "Complex multiplication"
@@ -250,17 +237,15 @@ def main():
                 "Complex magnitude"
                 return (self.real * self.real) + (self.imag * self.imag)
 
-
             # Other complex operators would go here. The above are
             # sufficient for this example.
-
 
         # Let's use the Complex struct to compute a Mandelbrot set.
         mandelbrot = hl.Func()
 
         # The initial complex value corresponding to an x, y coordinate
         # in our hl.Func.
-        initial = Complex(x/15.0 - 2.5, y/6.0 - 2.0)
+        initial = Complex(x / 15.0 - 2.5, y / 6.0 - 2.0)
 
         # Pure definition.
         t = hl.Var("t")
@@ -268,11 +253,11 @@ def main():
 
         # We'll use an update definition to take 12 steps.
         r = hl.RDom([(1, 12)])
-        current = Complex(mandelbrot[x, y, r-1])
+        current = Complex(mandelbrot[x, y, r - 1])
 
         # The following line uses the complex multiplication and
         # addition we defined above.
-        mandelbrot[x, y, r] = (Complex(current*current) + initial)
+        mandelbrot[x, y, r] = (Complex(current * current) + initial)
 
         # We'll use another tuple reduction to compute the iteration
         # number where the value first escapes a circle of radius 4.
@@ -301,9 +286,8 @@ def main():
                 if index < len(code):
                     print("%c" % code[index], end="")
                 else:
-                    pass # is lesson 13 cpp version buggy ?
+                    pass  # is lesson 13 cpp version buggy ?
             print("")
-
 
     print("Success!")
 

--- a/python_bindings/tutorial/lesson_14_types.py
+++ b/python_bindings/tutorial/lesson_14_types.py
@@ -1,27 +1,16 @@
 #!/usr/bin/python3
+
 # Halide tutorial lesson 14: The Halide type system
 
 # This lesson more precisely describes Halide's type system.
 
-# On linux, you can compile and run it like so:
-# g++ lesson_14*.cpp -g -I ../include -L ../bin -lHalide -lpthread -ldl -o lesson_14 -std=c++11
-# LD_LIBRARY_PATH=../bin ./lesson_14
+# This lesson can be built by invoking the command:
+#    make test_tutorial_lesson_14_types
+# in a shell with the current directory at python_bindings/
 
-# On os x:
-# g++ lesson_14*.cpp -g -I ../include -L ../bin -lHalide -o lesson_14 -std=c++11
-# DYLD_LIBRARY_PATH=../bin ./lesson_14
-
-# If you have the entire Halide source tree, you can also build it by
-# running:
-#    make tutorial_lesson_14_types
-# in a shell with the current directory at the top of the halide
-# source tree.
 
 import halide as hl
 
-# This function is used to demonstrate generic code at the end of
-# this lesson.
-#hl.Expr average(hl.Expr a, hl.Expr b)
 
 def main():
 
@@ -35,8 +24,7 @@ def main():
     valid_halide_types = [
         hl.UInt(8), hl.UInt(16), hl.UInt(32), hl.UInt(64),
         hl.Int(8), hl.Int(16), hl.Int(32), hl.Int(64),
-        hl.Float(32), hl.Float(64), hl.Handle() ]
-
+        hl.Float(32), hl.Float(64), hl.Handle()]
 
     # Constructing and inspecting types.
     if True:
@@ -46,21 +34,19 @@ def main():
         assert hl.UInt(8).bits() == 8
         assert hl.Int(8).is_int()
 
-
-        # You can also programmatically construct Types as a function of other Types.
+        # You can also programmatically construct Types as a function of other
+        # Types.
         t = hl.UInt(8)
         t = t.with_bits(t.bits() * 2)
         assert t == hl.UInt(16)
-
-        # Or construct a Type from a C++ scalar type
-        #assert type_of<float>() == hl.Float(32)
 
         # The Type struct is also capable of representing vector types,
         # but this is reserved for Halide's internal use. You should
         # vectorize code by using hl.Func::vectorize, not by attempting to
         # construct vector expressions directly. You may encounter vector
         # types if you programmatically manipulate lowered Halide code,
-        # but this is an advanced topic (see hl.Func::add_custom_lowering_pass).
+        # but this is an advanced topic (see
+        # hl.Func::add_custom_lowering_pass).
 
         # You can query any Halide hl.Expr for its type. An hl.Expr
         # representing a hl.Var has type hl.Int(32):
@@ -71,11 +57,9 @@ def main():
         # hl.Float(32) and return a hl.Float(32):
         assert hl.sin(x).type() == hl.Float(32)
 
-        # You can hl.cast an hl.Expr from one Type to another using the hl.cast operator:
+        # You can hl.cast an hl.Expr from one Type to another using the hl.cast
+        # operator:
         assert hl.cast(hl.UInt(8), x).type() == hl.UInt(8)
-
-        # This also comes in a template form that takes a C++ type.
-        #assert hl.cast<uint8_t>(x).type() == hl.UInt(8)
 
         # You can also query any defined hl.Func for the types it produces.
         f1 = hl.Func("f1")
@@ -85,9 +69,7 @@ def main():
         f2 = hl.Func("f2")
         f2[x] = (x, hl.sin(x))
         assert f2.output_types()[0] == hl.Int(32) and \
-               f2.output_types()[1] == hl.Float(32)
-
-
+            f2.output_types()[1] == hl.Float(32)
 
     # Type promotion rules.
     if True:
@@ -110,7 +92,8 @@ def main():
         # The rules are as follows, and are applied in the order they are
         # written below.
 
-        # 1) It is an error to hl.cast or use arithmetic operators on Exprs of type hl.Handle().
+        # 1) It is an error to hl.cast or use arithmetic operators on Exprs of
+        # type hl.Handle().
 
         # 2) If the types are the same, then no type conversions occur.
         for t in valid_halide_types:
@@ -119,7 +102,6 @@ def main():
                 continue
             e = hl.cast(t, x)
             assert (e + e).type() == e.type()
-
 
         # 3) If one type is a float but the other is not, then the
         # non-float argument is promoted to a float (possibly causing a
@@ -162,13 +144,14 @@ def main():
         # case where the bit widths are the same.
         assert (u32 + s32).type() == hl.Int(32)
 
-        if False: # evaluate<X> not yet exposed to python
+        if False:  # evaluate<X> not yet exposed to python
             # When an unsigned hl.Expr is converted to a wider signed type in
             # this way, it is first widened to a wider unsigned type
             # (zero-extended), and then reinterpreted as a signed
             # integer. I.e. casting the hl.UInt(8) value 255 to an hl.Int(32)
             # produces 255, not -1.
-            #int32_t result32 = evaluate<int>(hl.cast<int32_t>(hl.cast<uint8_t>(255)))
+            # int32_t result32 =
+            # evaluate<int>(hl.cast<int32_t>(hl.cast<uint8_t>(255)))
             assert result32 == 255
 
             # When a signed type is explicitly converted to a wider unsigned
@@ -177,18 +160,14 @@ def main():
             # wider signed type (sign-extended), and then reinterpreted as
             # an unsigned integer. I.e. casting the hl.Int(8) value -1 to a
             # hl.UInt(16) produces 65535, not 255.
-            #uint16_t result16 = evaluate<uint16_t>(hl.cast<uint16_t>(hl.cast<int8_t>(-1)))
+            # uint16_t result16 =
+            # evaluate<uint16_t>(hl.cast<uint16_t>(hl.cast<int8_t>(-1)))
             assert result16 == 65535
-
 
     # The type hl.Handle().
     if True:
         # hl.Handle is used to represent opaque pointers. Applying
         # type_of to any pointer type will return hl.Handle()
-
-        #assert type_of<void *>() == hl.Handle()
-        #assert type_of<const char * const **>() == hl.Handle()
-        # (not clear what the proper python version would be)
 
         # Handles are always stored as 64-bit, regardless of the compilation
         # target.
@@ -196,7 +175,6 @@ def main():
 
         # The main use of an hl.Expr of type hl.Handle is to pass
         # it through Halide to other external code.
-
 
     # Generic code.
     if True:
@@ -209,8 +187,8 @@ def main():
         x = hl.Var("x")
         assert average(hl.cast(hl.Float(32), x), 3.0).type() == hl.Float(32)
         assert average(x, 3).type() == hl.Int(32)
-        assert average(hl.cast(hl.UInt(8), x), hl.cast(hl.UInt(8), 3)).type() == hl.UInt(8)
-
+        assert average(hl.cast(hl.UInt(8), x), hl.cast(
+            hl.UInt(8), 3)).type() == hl.UInt(8)
 
     print("Success!")
 
@@ -225,7 +203,6 @@ def average(a, b):
     if type(b) is not hl.Expr:
         b = hl.Expr(b)
 
-
     "hl.Expr average(hl.Expr a, hl.Expr b)"
     # Types must match.
     assert a.type() == b.type()
@@ -234,8 +211,7 @@ def average(a, b):
     if (a.type().is_float()):
         # The '2' will be promoted to the floating point type due to
         # rule 3 above.
-        return (a + b)/2
-
+        return (a + b) / 2
 
     # For integer types, we must compute the intermediate value in a
     # wider type to avoid overflow.
@@ -243,8 +219,7 @@ def average(a, b):
     wider = narrow.with_bits(narrow.bits() * 2)
     a = hl.cast(wider, a)
     b = hl.cast(wider, b)
-    return hl.cast(narrow, (a + b)/2)
-
+    return hl.cast(narrow, (a + b) / 2)
 
 
 if __name__ == "__main__":

--- a/python_bindings/tutorial/lesson_14_types.py
+++ b/python_bindings/tutorial/lesson_14_types.py
@@ -68,8 +68,7 @@ def main():
 
         f2 = hl.Func("f2")
         f2[x] = (x, hl.sin(x))
-        assert f2.output_types()[0] == hl.Int(32) and \
-            f2.output_types()[1] == hl.Float(32)
+        assert f2.output_types()[0] == hl.Int(32) and f2.output_types()[1] == hl.Float(32)
 
     # Type promotion rules.
     if True:
@@ -187,8 +186,7 @@ def main():
         x = hl.Var("x")
         assert average(hl.cast(hl.Float(32), x), 3.0).type() == hl.Float(32)
         assert average(x, 3).type() == hl.Int(32)
-        assert average(hl.cast(hl.UInt(8), x), hl.cast(
-            hl.UInt(8), 3)).type() == hl.UInt(8)
+        assert average(hl.cast(hl.UInt(8), x), hl.cast(hl.UInt(8), 3)).type() == hl.UInt(8)
 
     print("Success!")
 


### PR DESCRIPTION
This is mostly a stylistic fix, but there is a real bugfix in lesson12 (which led to all of this):

-- the bugfix: in addition to PR #4661 (which this depends on), we needed to add an explicit call to `set_host_dirty()` for lesson12. (The C++ image loading code always does this under the hood, but in Python we just use imread.) This is an unsatisfying fix (users shouldn't have to call this), but apparently we don't bother calling copy-to-device if host-dirty isn't set... even if the buffer has no device bits. (This feels like a separate potential bug...)

The style fixes:
- remove weird leftover C++isms and commented-out dreck
- format everything according to PEP8
- ensure that all sanity checks are uniformly handled by assert-fail (rather than raising exceptions, quietly returning -1, etc)
- lesson12 had drifted in nontrivial ways from the C++ version; besides the bugfix, I brought them back into rough alignment