### PR TITLE
Use clang-tidy to check for override flags

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,7 @@
+---
+Checks: '-*,modernize-use-override'
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*'
+AnalyzeTemporaryDtors: false
+FormatStyle: 'file'
+...

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -18,12 +18,27 @@ jobs:
           source: '.'
           extensions: 'h,c,cpp'
           clangFormatVersion: 9
+  check_clang_tidy:
+    name: Check clang-tidy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install clang-tidy
+        run: |
+          sudo apt-get install clang-tidy-9
+      - name: Build Compilation DB
+        run: |
+          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -S . -B build
+          [ -a build/compile_commands.json ]
+      - name: Run clang-tidy
+        run: |
+          clang-tidy-9 --quiet -extra-arg=-Wno-unknown-warning-option -p build src/*.cpp
   check_cmake_file_lists:
     name: Check CMake file lists
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: bash script
+      - name: Run test sources check
         run: |
           shopt -s nullglob
           diff <(awk '/SOURCES/{flag=1;next} /\)/{flag=0} flag{print$1}' test/auto_schedule/CMakeLists.txt | sort) <(cd test/auto_schedule; ls -1 *.{c,cpp} | sort)

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -896,7 +896,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::add_kernel(Stmt s,
     struct FindUninitializedSharedLoads : public IRMutator {
         using IRMutator::mutate;
         using IRMutator::visit;
-        virtual Expr visit(const Load *op) override {
+        Expr visit(const Load *op) override {
             if (op->name == "__shared") {
                 if (!latest_store) {
                     // attempting to read from __shared before anything has been
@@ -906,14 +906,14 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::add_kernel(Stmt s,
             }
             return IRMutator::visit(op);
         }
-        virtual Stmt visit(const Store *op) override {
+        Stmt visit(const Store *op) override {
             Stmt store = IRMutator::visit(op);
             if (op->name == "__shared") {
                 latest_store = op;
             }
             return store;
         }
-        virtual Stmt mutate(const Stmt &stmt) override {
+        Stmt mutate(const Stmt &stmt) override {
             if (!bad_load_expr) {
                 current_stmt = &stmt;
             }
@@ -930,7 +930,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::add_kernel(Stmt s,
         // use IRMutator to inject a zero-initialization before the load
         struct ZeroInitializeSharedMemory : public IRMutator {
             using IRMutator::mutate;
-            virtual Stmt mutate(const Stmt &op) override {
+            Stmt mutate(const Stmt &op) override {
                 if (&op != uninitialized_load_stmt) {
                     return IRMutator::mutate(op);
                 }

--- a/src/CodeGen_D3D12Compute_Dev.h
+++ b/src/CodeGen_D3D12Compute_Dev.h
@@ -36,7 +36,7 @@ public:
 
     void dump() override;
 
-    virtual std::string print_gpu_name(const std::string &name) override;
+    std::string print_gpu_name(const std::string &name) override;
 
     std::string api_unique_name() override {
         return "d3d12compute";
@@ -65,7 +65,7 @@ protected:
         std::string print_cast(Type target_type, Type source_type, std::string value_expr);
         std::string print_reinterpret_cast(Type type, std::string value_expr);
 
-        virtual std::string print_assignment(Type t, const std::string &rhs) override;
+        std::string print_assignment(Type t, const std::string &rhs) override;
 
         void visit(const Evaluate *op) override;
         void visit(const Min *) override;

--- a/src/CodeGen_PTX_Dev.h
+++ b/src/CodeGen_PTX_Dev.h
@@ -57,7 +57,7 @@ protected:
 
     /** Nodes for which we need to override default behavior for the GPU runtime */
     // @{
-    virtual void visit(const Call *) override;
+    void visit(const Call *) override;
     void visit(const For *) override;
     void visit(const Allocate *) override;
     void visit(const Free *) override;

--- a/src/CodeGen_PyTorch.h
+++ b/src/CodeGen_PyTorch.h
@@ -25,7 +25,7 @@ namespace Internal {
 class CodeGen_PyTorch : public IRPrinter {
 public:
     CodeGen_PyTorch(std::ostream &dest);
-    ~CodeGen_PyTorch() = default;
+    ~CodeGen_PyTorch() override = default;
 
     /** Emit the PyTorch C++ wrapper for the Halide pipeline. */
     void compile(const Module &module);

--- a/src/CodeGen_X86.h
+++ b/src/CodeGen_X86.h
@@ -30,7 +30,7 @@ protected:
 
     int vector_lanes_for_slice(const Type &t) const;
 
-    virtual llvm::Type *llvm_type_of(const Type &t) const override;
+    llvm::Type *llvm_type_of(const Type &t) const override;
 
     using CodeGen_Posix::visit;
 


### PR DESCRIPTION
This PR adds a presubmit check that validates that specific clang-tidy (version 9) checks pass. Currently this is limited to `modernize-use-override` which will let us get `-Wsuggest-override` (and equivalents) off the compiler command line. If there are other checks we want to run in the future, this will help enforce those without having to wait for a build to complete.

Will probably fiddle with this branch until I get the GitHub Workflow script right. 