### PR TITLE
Fix autodiff with print expressions

### DIFF
--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -351,6 +351,10 @@ void ReverseAccumulationVisitor::propagate_adjoints(
 
             // Traverse the expressions in reverse order
             for (auto it = expr_list.rbegin(); it != expr_list.rend(); it++) {
+                if (it->type().is_handle()) {
+                    // Ignore pointer types
+                    continue;
+                }
                 it->accept(this);
             }
 
@@ -700,6 +704,10 @@ void ReverseAccumulationVisitor::propagate_adjoints(
 
                 // Traverse the expressions in reverse order
                 for (auto it = expr_list.rbegin(); it != expr_list.rend(); it++) {
+                    if (it->type().is_handle()) {
+                        // Ignore pointer types
+                        continue;
+                    }
                     // Propagate adjoints
                     it->accept(this);
                 }
@@ -739,6 +747,10 @@ void ReverseAccumulationVisitor::propagate_adjoints(
                 int count = 0;
                 // Traverse the expressions in reverse order
                 for (auto it = expr_list.rbegin(); it != expr_list.rend(); it++) {
+                    if (it->type().is_handle()) {
+                        // Ignore pointer types
+                        continue;
+                    }
                     // Propagate adjoints
                     it->accept(this);
                     count++;
@@ -1136,7 +1148,9 @@ void ReverseAccumulationVisitor::visit(const Call *op) {
             accumulate(op->args[0],
                        neg_half * adjoint * inv_sqrt_x * inv_sqrt_x * inv_sqrt_x);
         } else if (op->name == "halide_print") {
-            accumulate(op->args[0], make_zero(op->type));
+            for (const auto &arg : op->args) {
+                accumulate(arg, make_zero(op->type));
+            }
         } else {
             internal_error << "The derivative of " << op->name << " is not implemented.";
         }
@@ -1156,7 +1170,7 @@ void ReverseAccumulationVisitor::visit(const Call *op) {
         } else if (op->is_intrinsic(Call::likely)) {
             accumulate(op->args[0], adjoint);
         } else if (op->is_intrinsic(Call::return_second)) {
-            // accumulate(op->args[0], make_const(op->type, 0.0));
+            accumulate(op->args[0], make_const(op->type, 0.0));
             accumulate(op->args[1], adjoint);
         } else if (op->is_intrinsic(Call::undef)) {
             // do nothing

--- a/test/correctness/autodiff.cpp
+++ b/test/correctness/autodiff.cpp
@@ -1390,6 +1390,18 @@ void test_custom_adjoint_buffer() {
     check(__LINE__, d_input_buf(2), d_blur_buf(1));
 }
 
+void test_print() {
+    Buffer<float> input(1);
+    input(0) = rand();
+    RDom r(0, 1);
+    Func out;
+    out() += print(input(r));
+    Derivative d_out_d = propagate_adjoints(out);
+    Func d_out_d_input = d_out_d(input);
+    Buffer<float> d = d_out_d_input.realize(1);
+    check(__LINE__, d(0), 1.f);
+}
+
 int main(int argc, char **argv) {
     test_scalar<float>();
     test_scalar<double>();
@@ -1430,6 +1442,7 @@ int main(int argc, char **argv) {
     test_select_guard();
     test_param();
     test_custom_adjoint_buffer();
+    test_print();
     printf("[autodiff] Success!\n");
     return 0;
 }


### PR DESCRIPTION
The following code currently causes error during autodiff:
```
    Buffer<float> input(1);
    input(0) = rand();
    RDom r(0, 1);
    Func out;
    out() += print(input(r));
    Derivative d_out_d = propagate_adjoints(out);
```

This PR fixes this by propagating the derivative through the print function. It also prevents the derivatives being propagated through the `stringnify` function since the output of that is a pointer type.