### PR TITLE
More reliable boundary conditions test

### DIFF
--- a/test/performance/boundary_conditions.cpp
+++ b/test/performance/boundary_conditions.cpp
@@ -3,13 +3,26 @@
 
 #include "halide_benchmark.h"
 
-const int W = 4000, H = 2400;
+const int W = 8000, H = 6000;
 
 using namespace Halide;
 using namespace Halide::BoundaryConditions;
 using namespace Halide::Tools;
 
 Target target;
+
+Buffer<float> make_replicated_buffer(int w, int h) {
+    // Make a buffer that is just the same memory for every scanline,
+    // to ensure it fits in L1/L2. We're just trying to measure
+    // codegen effects here, not cache effects of different boundary
+    // conditions.
+
+    Buffer<float> buf(w, 1);
+    buf.raw_buffer()->dim[1].extent = h;
+    buf.raw_buffer()->dim[1].stride = 0;
+    return buf;
+
+}
 
 struct Test {
     const char *name;
@@ -28,8 +41,9 @@ struct Test {
             g.vectorize(x, 4);
         }
 
-        Buffer<float> out = g.realize(W, H);
+        g.compile_jit();
 
+        Buffer<float> out = make_replicated_buffer(W, H);
         time = benchmark([&]() {
             g.realize(out);
             out.device_sync();
@@ -53,8 +67,9 @@ struct Test {
             g.tile(x, y, xi, yi, 8, 8).vectorize(xi, 4);
         }
 
-        Buffer<float> out = g.realize(W, H);
+        g.compile_jit();
 
+        Buffer<float> out = make_replicated_buffer(W, H);
         time = benchmark([&]() {
             g.realize(out);
             out.device_sync();
@@ -73,10 +88,10 @@ int main(int argc, char **argv) {
     // We use image params bound to concrete images. Using images
     // directly lets Halide assume things about the width and height,
     // and we don't want that to pollute the timings.
-    Buffer<float> in(W, H);
+    Buffer<float> in = make_replicated_buffer(W, H);
 
     // A padded version of the input to use as a baseline.
-    Buffer<float> padded_in(W + 16, H + 16);
+    Buffer<float> padded_in = make_replicated_buffer(W + 16, H + 16);
 
     Var x, y;
 

--- a/test/performance/boundary_conditions.cpp
+++ b/test/performance/boundary_conditions.cpp
@@ -21,7 +21,6 @@ Buffer<float> make_replicated_buffer(int w, int h) {
     buf.raw_buffer()->dim[1].extent = h;
     buf.raw_buffer()->dim[1].stride = 0;
     return buf;
-
 }
 
 struct Test {


### PR DESCRIPTION
Try to deflake the boundary conditions performance test by using a larger steady-state, but also ensuring the input and output fit in L1/2 with stride shenanigans.

The codegen looks fine, so my suspicion is that these tests are flaky because repeat_image has worse cache behavior than repeat_edge.