### PR TITLE
turn on clang-tidy's modernize-pass-by-value

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
-Checks: '-*,modernize-use-override'
+Checks: '-*,modernize-pass-by-value,modernize-use-override'
 WarningsAsErrors: '*'
-HeaderFilterRegex: '.*'
+HeaderFilterRegex: 'src/[^/]*.h'
 AnalyzeTemporaryDtors: false
 FormatStyle: 'file'
 ...

--- a/Makefile
+++ b/Makefile
@@ -2297,3 +2297,23 @@ $(BIN_DIR)/HalideTraceDump: $(ROOT_DIR)/util/HalideTraceDump.cpp $(ROOT_DIR)/uti
 format:
 	find "${ROOT_DIR}/apps" "${ROOT_DIR}/src" "${ROOT_DIR}/tools" "${ROOT_DIR}/test" "${ROOT_DIR}/util" "${ROOT_DIR}/python_bindings" -name *.cpp -o -name *.h -o -name *.c | xargs ${CLANG}-format -i -style=file
 
+# Run clang-tidy on the core source files
+$(BUILD_DIR)/compile_commands.json:
+	echo '[' >> $@
+	BD=$(realpath $(BUILD_DIR)); \
+	SD=$(realpath $(SRC_DIR)); \
+	for S in $(SOURCE_FILES); do \
+	echo "{ \"directory\": \"$${BD}\"," >> $@; \
+	echo "  \"command\": \"$(CXX) $(CXX_FLAGS) -c $$SD/$$S -o $$BD/$${S/cpp/o}\"," >> $@; \
+	echo "  \"file\": \"$$SD/$$S\" }," >> $@; \
+	done
+	echo ']' >> $@
+
+.PHONY: clang-tidy
+clang-tidy: $(BUILD_DIR)/compile_commands.json
+	${CLANG}-tidy -extra-arg=-Wno-unknown-warning-option -p $(BUILD_DIR) $(addprefix $(SRC_DIR)/,$(SOURCE_FILES))
+
+.PHONY: clang-tidy-fix
+clang-tidy-fix: $(BUILD_DIR)/compile_commands.json
+	${CLANG}-tidy -extra-arg=-Wno-unknown-warning-option -p $(BUILD_DIR) $(addprefix $(SRC_DIR)/,$(SOURCE_FILES)) -fix-errors
+

--- a/src/AddAtomicMutex.cpp
+++ b/src/AddAtomicMutex.cpp
@@ -20,8 +20,8 @@ namespace {
 /** Collect names of all stores matching the producer name inside a statement. */
 class CollectProducerStoreNames : public IRGraphVisitor {
 public:
-    CollectProducerStoreNames(const std::string &producer_name)
-        : producer_name(producer_name) {
+    CollectProducerStoreNames(std::string producer_name)
+        : producer_name(std::move(producer_name)) {
     }
 
     Scope<void> store_names;
@@ -37,15 +37,15 @@ protected:
         }
     }
 
-    const std::string &producer_name;
+    const std::string producer_name;
 };
 
 /** Find Store inside of an Atomic node for the designated producer
  *  and return their indices. */
 class FindProducerStoreIndex : public IRGraphVisitor {
 public:
-    FindProducerStoreIndex(const std::string &producer_name)
-        : producer_name(producer_name) {
+    FindProducerStoreIndex(std::string producer_name)
+        : producer_name(std::move(producer_name)) {
     }
 
     Expr index;  // The returned index.
@@ -88,7 +88,7 @@ protected:
         }
     }
 
-    const std::string &producer_name;
+    const std::string producer_name;
 };
 
 /** Throws an assertion for cases where the indexing on left-hand-side of
@@ -249,8 +249,8 @@ protected:
 /** Replace the indices in the Store nodes with the specified variable. */
 class ReplaceStoreIndexWithVar : public IRMutator {
 public:
-    ReplaceStoreIndexWithVar(const std::string &producer_name, Expr var)
-        : producer_name(producer_name), var(std::move(var)) {
+    ReplaceStoreIndexWithVar(std::string producer_name, Expr var)
+        : producer_name(std::move(producer_name)), var(std::move(var)) {
     }
 
 protected:
@@ -267,7 +267,7 @@ protected:
                            op->alignment);
     }
 
-    const std::string &producer_name;
+    const std::string producer_name;
     Expr var;
 };
 

--- a/src/AddAtomicMutex.cpp
+++ b/src/AddAtomicMutex.cpp
@@ -1,10 +1,12 @@
 #include "AddAtomicMutex.h"
+
 #include "ExprUsesVar.h"
 #include "Func.h"
 #include "IREquality.h"
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "OutputImageParam.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -248,7 +250,7 @@ protected:
 class ReplaceStoreIndexWithVar : public IRMutator {
 public:
     ReplaceStoreIndexWithVar(const std::string &producer_name, Expr var)
-        : producer_name(producer_name), var(var) {
+        : producer_name(producer_name), var(std::move(var)) {
     }
 
 protected:

--- a/src/ApplySplit.h
+++ b/src/ApplySplit.h
@@ -31,11 +31,11 @@ struct ApplySplitResult {
                 Predicate };
     Type type;
 
-    ApplySplitResult(const std::string &n, Expr val, Type t)
-        : name(n), value(val), type(t) {
+    ApplySplitResult(std::string n, Expr val, Type t)
+        : name(std::move(n)), value(std::move(val)), type(t) {
     }
     ApplySplitResult(Expr val)
-        : name(""), value(val), type(Predicate) {
+        : name(), value(std::move(val)), type(Predicate) {
     }
 
     bool is_substitution() const {

--- a/src/Argument.cpp
+++ b/src/Argument.cpp
@@ -1,5 +1,7 @@
 #include "Argument.h"
 
+#include <utility>
+
 namespace Halide {
 
 bool ArgumentEstimates::operator==(const ArgumentEstimates &rhs) const {
@@ -18,8 +20,8 @@ bool ArgumentEstimates::operator==(const ArgumentEstimates &rhs) const {
            scalar_estimate.same_as(rhs.scalar_estimate);
 }
 
-Argument::Argument(const std::string &_name, Kind _kind, const Type &_type, int _dimensions, const ArgumentEstimates &argument_estimates)
-    : name(_name), kind(_kind), dimensions((uint8_t)_dimensions), type(_type), argument_estimates(argument_estimates) {
+Argument::Argument(std::string _name, Kind _kind, const Type &_type, int _dimensions, const ArgumentEstimates &argument_estimates)
+    : name(std::move(_name)), kind(_kind), dimensions((uint8_t)_dimensions), type(_type), argument_estimates(argument_estimates) {
     internal_assert(dimensions >= 0 && dimensions <= 255);
     user_assert(!(is_scalar() && dimensions != 0)) << "Scalar Arguments must specify dimensions of 0";
     user_assert(argument_estimates.buffer_estimates.empty() ||

--- a/src/Argument.h
+++ b/src/Argument.h
@@ -71,7 +71,7 @@ struct Argument {
     ArgumentEstimates argument_estimates;
 
     Argument() = default;
-    Argument(const std::string &_name, Kind _kind, const Type &_type, int _dimensions,
+    Argument(std::string _name, Kind _kind, const Type &_type, int _dimensions,
              const ArgumentEstimates &argument_estimates);
 
     // Not explicit, so that you can put Buffer in an argument list,

--- a/src/AssociativeOpsTable.cpp
+++ b/src/AssociativeOpsTable.cpp
@@ -1,5 +1,7 @@
 #include "AssociativeOpsTable.h"
+
 #include "IRPrinter.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -93,8 +95,8 @@ struct TableKey {
     TableKey(ValType t, RootExpr r, size_t d)
         : types({t}), root(r), dim(d) {
     }
-    TableKey(const vector<ValType> &t, RootExpr r, size_t d)
-        : types(t), root(r), dim(d) {
+    TableKey(vector<ValType> t, RootExpr r, size_t d)
+        : types(std::move(t)), root(r), dim(d) {
     }
 
     bool operator==(const TableKey &other) const {

--- a/src/AssociativeOpsTable.h
+++ b/src/AssociativeOpsTable.h
@@ -9,6 +9,7 @@
 #include "IROperator.h"
 
 #include <iostream>
+#include <utility>
 #include <vector>
 
 namespace Halide {
@@ -42,8 +43,8 @@ struct AssociativePattern {
     AssociativePattern(size_t size)
         : ops(size), identities(size), is_commutative(false) {
     }
-    AssociativePattern(const std::vector<Expr> &ops, const std::vector<Expr> &ids, bool is_commutative)
-        : ops(ops), identities(ids), is_commutative(is_commutative) {
+    AssociativePattern(std::vector<Expr> ops, std::vector<Expr> ids, bool is_commutative)
+        : ops(std::move(ops)), identities(std::move(ids)), is_commutative(is_commutative) {
     }
     AssociativePattern(Expr op, Expr id, bool is_commutative)
         : ops({op}), identities({id}), is_commutative(is_commutative) {

--- a/src/Associativity.cpp
+++ b/src/Associativity.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -40,7 +41,7 @@ vector<T> get_subvector(const vector<T> &v, const set<int> &indices) {
 class ConvertSelfRef : public IRGraphMutator {
     using IRGraphMutator::visit;
 
-    const string &func;
+    const string func;
     const vector<Expr> &args;
     // If that function has multiple values, which value does this
     // call node refer to?
@@ -82,9 +83,9 @@ class ConvertSelfRef : public IRGraphMutator {
     }
 
 public:
-    ConvertSelfRef(const string &f, const vector<Expr> &args, int idx,
+    ConvertSelfRef(string f, const vector<Expr> &args, int idx,
                    const vector<string> &x_names)
-        : func(f), args(args), value_index(idx), op_x_names(x_names) {
+        : func(std::move(f)), args(args), value_index(idx), op_x_names(x_names) {
     }
 
     bool is_solvable = true;

--- a/src/Associativity.h
+++ b/src/Associativity.h
@@ -12,6 +12,7 @@
 #include "IREquality.h"
 
 #include <functional>
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -66,8 +67,8 @@ struct AssociativeOp {
         Expr expr;
 
         Replacement() = default;
-        Replacement(const std::string &var, Expr expr)
-            : var(var), expr(expr) {
+        Replacement(std::string var, Expr expr)
+            : var(std::move(var)), expr(std::move(expr)) {
         }
 
         bool operator==(const Replacement &other) const {
@@ -90,9 +91,9 @@ struct AssociativeOp {
     AssociativeOp(size_t size)
         : pattern(size), xs(size), ys(size), is_associative(false) {
     }
-    AssociativeOp(const AssociativePattern &p, const std::vector<Replacement> &xs,
-                  const std::vector<Replacement> &ys, bool is_associative)
-        : pattern(p), xs(xs), ys(ys), is_associative(is_associative) {
+    AssociativeOp(AssociativePattern p, std::vector<Replacement> xs,
+                  std::vector<Replacement> ys, bool is_associative)
+        : pattern(std::move(p)), xs(std::move(xs)), ys(std::move(ys)), is_associative(is_associative) {
     }
 
     bool associative() const {

--- a/src/AsyncProducers.cpp
+++ b/src/AsyncProducers.cpp
@@ -106,7 +106,7 @@ protected:
 };
 
 class GenerateProducerBody : public NoOpCollapsingMutator {
-    const string &func;
+    const string func;
     vector<Expr> sema;
 
     using NoOpCollapsingMutator::visit;
@@ -195,13 +195,13 @@ class GenerateProducerBody : public NoOpCollapsingMutator {
     set<string> inner_semaphores;
 
 public:
-    GenerateProducerBody(const string &f, vector<Expr> s, map<string, string> &a)
-        : func(f), sema(std::move(s)), cloned_acquires(a) {
+    GenerateProducerBody(string f, vector<Expr> s, map<string, string> &a)
+        : func(std::move(f)), sema(std::move(s)), cloned_acquires(a) {
     }
 };
 
 class GenerateConsumerBody : public NoOpCollapsingMutator {
-    const string &func;
+    const string func;
     vector<Expr> sema;
 
     using NoOpCollapsingMutator::visit;
@@ -252,15 +252,15 @@ class GenerateConsumerBody : public NoOpCollapsingMutator {
     }
 
 public:
-    GenerateConsumerBody(const string &f, vector<Expr> s)
-        : func(f), sema(std::move(s)) {
+    GenerateConsumerBody(string f, vector<Expr> s)
+        : func(std::move(f)), sema(std::move(s)) {
     }
 };
 
 class CloneAcquire : public IRMutator {
     using IRMutator::visit;
 
-    const string &old_name;
+    const string old_name;
     Expr new_var;
 
     Stmt visit(const Evaluate *op) override {
@@ -280,14 +280,14 @@ class CloneAcquire : public IRMutator {
     }
 
 public:
-    CloneAcquire(const string &o, const string &new_name)
-        : old_name(o) {
+    CloneAcquire(string o, const string &new_name)
+        : old_name(std::move(o)) {
         new_var = Variable::make(type_of<halide_semaphore_t *>(), new_name);
     }
 };
 
 class CountConsumeNodes : public IRVisitor {
-    const string &func;
+    const string func;
 
     using IRVisitor::visit;
 
@@ -299,8 +299,8 @@ class CountConsumeNodes : public IRVisitor {
     }
 
 public:
-    CountConsumeNodes(const string &f)
-        : func(f) {
+    CountConsumeNodes(string f)
+        : func(std::move(f)) {
     }
     int count = 0;
 };

--- a/src/AsyncProducers.cpp
+++ b/src/AsyncProducers.cpp
@@ -1,8 +1,10 @@
 #include "AsyncProducers.h"
+
 #include "ExprUsesVar.h"
 #include "IREquality.h"
 #include "IRMutator.h"
 #include "IROperator.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -193,8 +195,8 @@ class GenerateProducerBody : public NoOpCollapsingMutator {
     set<string> inner_semaphores;
 
 public:
-    GenerateProducerBody(const string &f, const vector<Expr> &s, map<string, string> &a)
-        : func(f), sema(s), cloned_acquires(a) {
+    GenerateProducerBody(const string &f, vector<Expr> s, map<string, string> &a)
+        : func(f), sema(std::move(s)), cloned_acquires(a) {
     }
 };
 
@@ -250,8 +252,8 @@ class GenerateConsumerBody : public NoOpCollapsingMutator {
     }
 
 public:
-    GenerateConsumerBody(const string &f, const vector<Expr> &s)
-        : func(f), sema(s) {
+    GenerateConsumerBody(const string &f, vector<Expr> s)
+        : func(f), sema(std::move(s)) {
     }
 };
 

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <utility>
 
 #include "Bounds.h"
 #include "CSE.h"
@@ -1659,7 +1660,7 @@ class SolveIfThenElse : public IRMutator {
 // (excluding 'skipped_var')
 class CollectVars : public IRGraphVisitor {
 public:
-    string skipped_var;
+    const string &skipped_var;
     set<string> vars;
 
     CollectVars(const string &v)
@@ -1681,7 +1682,7 @@ class BoxesTouched : public IRGraphVisitor {
 
 public:
     BoxesTouched(bool calls, bool provides, string fn, const Scope<Interval> *s, const FuncValueBounds &fb)
-        : func(fn), consider_calls(calls), consider_provides(provides), func_bounds(fb) {
+        : func(std::move(fn)), consider_calls(calls), consider_provides(provides), func_bounds(fb) {
         scope.set_containing_scope(s);
     }
 
@@ -1691,8 +1692,8 @@ private:
     struct VarInstance {
         string var;
         int instance;
-        VarInstance(const string &v, int i)
-            : var(v), instance(i) {
+        VarInstance(string v, int i)
+            : var(std::move(v)), instance(i) {
         }
         VarInstance() = default;
 
@@ -2032,8 +2033,8 @@ private:
 
     struct LetBound {
         string var, min_name, max_name;
-        LetBound(const string &v, const string &min, const string &max)
-            : var(v), min_name(min), max_name(max) {
+        LetBound(string v, string min, string max)
+            : var(std::move(v)), min_name(std::move(min)), max_name(std::move(max)) {
         }
     };
 

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1660,11 +1660,11 @@ class SolveIfThenElse : public IRMutator {
 // (excluding 'skipped_var')
 class CollectVars : public IRGraphVisitor {
 public:
-    const string &skipped_var;
+    const string skipped_var;
     set<string> vars;
 
-    CollectVars(const string &v)
-        : skipped_var(v) {
+    CollectVars(string v)
+        : skipped_var(std::move(v)) {
     }
 
 private:
@@ -2407,7 +2407,7 @@ map<string, Box> boxes_touched(Expr e, Stmt s, bool consider_calls, bool conside
                 }
             }
 
-            const string &fn;
+            const string fn;
             const string fn_buffer;
             Stmt no_op;
             Filter(const string &fn)

--- a/src/Bounds.h
+++ b/src/Bounds.h
@@ -6,6 +6,8 @@
  * and the regions of a function read or written by a statement.
  */
 
+#include <utility>
+
 #include "IROperator.h"
 #include "Interval.h"
 #include "Scope.h"
@@ -58,8 +60,8 @@ struct Box {
     Box(size_t sz)
         : bounds(sz) {
     }
-    Box(const std::vector<Interval> &b)
-        : bounds(b) {
+    Box(std::vector<Interval> b)
+        : bounds(std::move(b)) {
     }
 
     size_t size() const {

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -74,12 +74,12 @@ bool depends_on_bounds_inference(Expr e) {
 class BoundsOfInnerVar : public IRVisitor {
 public:
     Interval result;
-    BoundsOfInnerVar(const string &v)
-        : var(v) {
+    BoundsOfInnerVar(string v)
+        : var(std::move(v)) {
     }
 
 private:
-    const string &var;
+    const string var;
     Scope<Interval> scope;
 
     using IRVisitor::visit;

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -78,7 +79,7 @@ public:
     }
 
 private:
-    string var;
+    const string &var;
     Scope<Interval> scope;
 
     using IRVisitor::visit;
@@ -108,7 +109,7 @@ private:
     }
 };
 
-Interval bounds_of_inner_var(string var, Stmt s) {
+Interval bounds_of_inner_var(const string &var, Stmt s) {
     BoundsOfInnerVar b(var);
     s.accept(&b);
     return b.result;
@@ -190,8 +191,8 @@ public:
         Expr cond;  // Condition on params only (can't depend on loop variable)
         Expr value;
 
-        CondValue(const Expr &c, const Expr &v)
-            : cond(c), value(v) {
+        CondValue(Expr c, Expr v)
+            : cond(std::move(c)), value(std::move(v)) {
         }
     };
 

--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -134,12 +134,12 @@ struct QualsState {
     bool last_is_pointer{false};
 
     const Type &type;
-    const std::string &base_mode;
+    const std::string base_mode;
     std::string result;
 
     bool finished{false};
 
-    QualsState(const Type &type, const std::string &base_mode)
+    QualsState(const Type &type, const char *base_mode)
         : type(type), base_mode(base_mode) {
     }
 

--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -1,6 +1,7 @@
 #include "CPlusPlusMangle.h"
 
 #include <map>
+#include <utility>
 
 #include "IR.h"
 #include "IROperator.h"
@@ -133,7 +134,7 @@ struct QualsState {
     bool last_is_pointer{false};
 
     const Type &type;
-    const std::string base_mode;
+    const std::string &base_mode;
     std::string result;
 
     bool finished{false};

--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -1,4 +1,5 @@
 #include <map>
+#include <utility>
 
 #include "CSE.h"
 #include "IREquality.h"
@@ -76,8 +77,8 @@ public:
         int use_count = 0;
         // All consumer Exprs for which this is the last child Expr.
         map<ExprWithCompareCache, int> uses;
-        Entry(const Expr &e)
-            : expr(e) {
+        Entry(Expr e)
+            : expr(std::move(e)) {
         }
     };
     vector<std::unique_ptr<Entry>> entries;

--- a/src/CanonicalizeGPUVars.cpp
+++ b/src/CanonicalizeGPUVars.cpp
@@ -1,5 +1,6 @@
 #include <cmath>
 #include <sstream>
+#include <utility>
 
 #include "CanonicalizeGPUVars.h"
 #include "CodeGen_GPU_Dev.h"
@@ -29,7 +30,7 @@ string get_block_name(int index) {
 }
 
 class CountGPUBlocksThreads : public IRVisitor {
-    string prefix;  // Producer name + stage
+    const string &prefix;  // Producer name + stage
 
     using IRVisitor::visit;
 

--- a/src/CanonicalizeGPUVars.cpp
+++ b/src/CanonicalizeGPUVars.cpp
@@ -30,7 +30,7 @@ string get_block_name(int index) {
 }
 
 class CountGPUBlocksThreads : public IRVisitor {
-    const string &prefix;  // Producer name + stage
+    const string prefix;  // Producer name + stage
 
     using IRVisitor::visit;
 
@@ -70,8 +70,8 @@ class CountGPUBlocksThreads : public IRVisitor {
     }
 
 public:
-    CountGPUBlocksThreads(const string &p)
-        : prefix(p) {
+    CountGPUBlocksThreads(string p)
+        : prefix(std::move(p)) {
     }
     int nblocks = 0;
     int nthreads = 0;

--- a/src/CodeGen_ARM.h
+++ b/src/CodeGen_ARM.h
@@ -5,6 +5,8 @@
  * Defines the code-generator for producing ARM machine code
  */
 
+#include <utility>
+
 #include "CodeGen_Posix.h"
 
 namespace Halide {
@@ -51,7 +53,7 @@ protected:
         Pattern(const std::string &i32, const std::string &i64, int l, Expr p, PatternType t = Simple)
             : intrin32("llvm.arm.neon." + i32),
               intrin64("llvm.aarch64.neon." + i64),
-              intrin_lanes(l), pattern(p), type(t) {
+              intrin_lanes(l), pattern(std::move(p)), type(t) {
         }
     };
     std::vector<Pattern> casts, averagings, negations, multiplies;

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <iomanip>
 #include <sstream>
+#include <utility>
 
 #include "CodeGen_D3D12Compute_Dev.h"
 #include "CodeGen_Internal.h"
@@ -789,7 +790,7 @@ struct BufferSize {
         : size(0) {
     }
     BufferSize(string name, size_t size)
-        : name(name), size(size) {
+        : name(std::move(name)), size(size) {
     }
 
     bool operator<(const BufferSize &r) const {

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -1,6 +1,8 @@
 #include "CodeGen_GPU_Dev.h"
+
 #include "Bounds.h"
 #include "IRVisitor.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -82,10 +84,10 @@ class IsBufferConstant : public IRVisitor {
 
 public:
     bool result;
-    const std::string &buffer;
+    const std::string buffer;
 
-    IsBufferConstant(const std::string &b)
-        : result(true), buffer(b) {
+    IsBufferConstant(std::string b)
+        : result(true), buffer(std::move(b)) {
     }
 };
 }  // namespace

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <sstream>
+#include <utility>
 
 #include "CodeGen_Internal.h"
 #include "CodeGen_Metal_Dev.h"
@@ -449,7 +450,7 @@ struct BufferSize {
         : size(0) {
     }
     BufferSize(string name, size_t size)
-        : name(name), size(size) {
+        : name(std::move(name)), size(size) {
     }
 
     bool operator<(const BufferSize &r) const {

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <sstream>
+#include <utility>
 
 #include "CSE.h"
 #include "CodeGen_Internal.h"
@@ -666,7 +667,7 @@ struct BufferSize {
         : size(0) {
     }
     BufferSize(string name, size_t size)
-        : name(name), size(size) {
+        : name(std::move(name)), size(size) {
     }
 
     bool operator<(const BufferSize &r) const {

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -1,5 +1,7 @@
 #include "Deinterleave.h"
 
+#include <utility>
+
 #include "CSE.h"
 #include "Debug.h"
 #include "IREquality.h"
@@ -20,7 +22,7 @@ namespace {
 
 class StoreCollector : public IRMutator {
 public:
-    const std::string store_name;
+    const std::string &store_name;
     const int store_stride, max_stores;
     std::vector<Stmt> &let_stmts;
     std::vector<Stmt> &stores;

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -22,14 +22,14 @@ namespace {
 
 class StoreCollector : public IRMutator {
 public:
-    const std::string &store_name;
+    const std::string store_name;
     const int store_stride, max_stores;
     std::vector<Stmt> &let_stmts;
     std::vector<Stmt> &stores;
 
-    StoreCollector(const std::string &name, int stride, int ms,
+    StoreCollector(std::string name, int stride, int ms,
                    std::vector<Stmt> &lets, std::vector<Stmt> &ss)
-        : store_name(name), store_stride(stride), max_stores(ms),
+        : store_name(std::move(name)), store_stride(stride), max_stores(ms),
           let_stmts(lets), stores(ss), collecting(true) {
     }
 

--- a/src/Derivative.h
+++ b/src/Derivative.h
@@ -11,6 +11,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace Halide {
@@ -24,10 +25,7 @@ public:
     // function name & update_id, for initialization update_id == -1
     using FuncKey = std::pair<std::string, int>;
 
-    explicit Derivative(const std::map<FuncKey, Func> &adjoints_in)
-        : adjoints(adjoints_in) {
-    }
-    explicit Derivative(std::map<FuncKey, Func> &&adjoints_in)
+    explicit Derivative(std::map<FuncKey, Func> adjoints_in)
         : adjoints(std::move(adjoints_in)) {
     }
 

--- a/src/DerivativeUtils.cpp
+++ b/src/DerivativeUtils.cpp
@@ -2,6 +2,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "CSE.h"
@@ -540,7 +541,7 @@ bool is_calling_function(
 struct SubstituteCallArgWithPureArg : public IRMutator {
 public:
     SubstituteCallArgWithPureArg(Func f, int variable_id)
-        : f(f), variable_id(variable_id) {
+        : f(std::move(f)), variable_id(variable_id) {
     }
 
 protected:

--- a/src/DeviceArgument.h
+++ b/src/DeviceArgument.h
@@ -5,6 +5,8 @@
  * Defines helpers for passing arguments to separate devices, such as GPUs.
  */
 
+#include <utility>
+
 #include "Closure.h"
 #include "IR.h"
 #include "ModulusRemainder.h"
@@ -72,12 +74,12 @@ struct DeviceArgument {
           write(false) {
     }
 
-    DeviceArgument(const std::string &_name,
+    DeviceArgument(std::string _name,
                    bool _is_buffer,
                    Type _type,
                    uint8_t _dimensions,
                    size_t _size = 0)
-        : name(_name),
+        : name(std::move(_name)),
           is_buffer(_is_buffer),
           dimensions(_dimensions),
           type(_type),

--- a/src/Dimension.cpp
+++ b/src/Dimension.cpp
@@ -1,12 +1,14 @@
 #include "Dimension.h"
+
 #include "IR.h"
 #include "IROperator.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
 
-Dimension::Dimension(const Internal::Parameter &p, int d, Func f)
-    : param(p), d(d), f(f) {
+Dimension::Dimension(Internal::Parameter p, int d, Func f)
+    : param(std::move(p)), d(d), f(std::move(f)) {
     user_assert(param.defined())
         << "Can't access the dimensions of an undefined Parameter\n";
     user_assert(param.is_buffer())

--- a/src/Dimension.h
+++ b/src/Dimension.h
@@ -90,7 +90,7 @@ private:
     /** Construct a Dimension representing dimension d of some
      * Internal::Parameter p. Only friends may construct
      * these. */
-    Dimension(const Internal::Parameter &p, int d, Func f);
+    Dimension(Internal::Parameter p, int d, Func f);
 
     Parameter param;
     int d;

--- a/src/EarlyFree.cpp
+++ b/src/EarlyFree.cpp
@@ -1,4 +1,5 @@
 #include <map>
+#include <utility>
 
 #include "EarlyFree.h"
 #include "ExprUsesVar.h"
@@ -18,7 +19,7 @@ public:
     Stmt last_use;
 
     FindLastUse(string s)
-        : func(s) {
+        : func(std::move(s)) {
     }
 
 private:

--- a/src/Elf.h
+++ b/src/Elf.h
@@ -85,8 +85,8 @@ private:
 
 public:
     Symbol() = default;
-    Symbol(const std::string &name)
-        : name(name) {
+    Symbol(std::string name)
+        : name(std::move(name)) {
     }
 
     /** Accesses the name of this symbol. */
@@ -258,8 +258,8 @@ private:
 
 public:
     Section() = default;
-    Section(const std::string &name, Type type)
-        : name(name), type(type) {
+    Section(std::string name, Type type)
+        : name(std::move(name)), type(type) {
     }
 
     Section &set_name(const std::string &name) {

--- a/src/ExternalCode.h
+++ b/src/ExternalCode.h
@@ -1,6 +1,7 @@
 #ifndef HALIDE_EXTERNAL_CODE_H
 #define HALIDE_EXTERNAL_CODE_H
 
+#include <utility>
 #include <vector>
 
 #include "Expr.h"
@@ -24,8 +25,8 @@ private:
     // Used for debugging and naming the module to llvm.
     std::string nametag;
 
-    ExternalCode(Kind kind, const Target &llvm_target, DeviceAPI device_api, const std::vector<uint8_t> &code, const std::string &name)
-        : kind(kind), llvm_target(llvm_target), device_code_kind(device_api), code(code), nametag(name) {
+    ExternalCode(Kind kind, const Target &llvm_target, DeviceAPI device_api, std::vector<uint8_t> code, std::string name)
+        : kind(kind), llvm_target(llvm_target), device_code_kind(device_api), code(std::move(code)), nametag(std::move(name)) {
     }
 
 public:

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -380,7 +380,7 @@ namespace {
 class SubstituteSelfReference : public IRMutator {
     using IRMutator::visit;
 
-    const string &func;
+    const string func;
     const Function &substitute;
     const vector<Var> &new_args;
 
@@ -401,10 +401,10 @@ class SubstituteSelfReference : public IRMutator {
     }
 
 public:
-    SubstituteSelfReference(const string &func,
+    SubstituteSelfReference(string func,
                             const Function &substitute,
                             const vector<Var> &new_args)
-        : func(func), substitute(substitute), new_args(new_args) {
+        : func(std::move(func)), substitute(substitute), new_args(new_args) {
         internal_assert(substitute.get_contents().defined());
     }
 };

--- a/src/Func.h
+++ b/src/Func.h
@@ -20,6 +20,7 @@
 #include "Var.h"
 
 #include <map>
+#include <utility>
 
 namespace Halide {
 
@@ -32,11 +33,11 @@ struct VarOrRVar {
     VarOrRVar(const std::string &n, bool r)
         : var(n), rvar(n), is_rvar(r) {
     }
-    VarOrRVar(const Var &v)
-        : var(v), is_rvar(false) {
+    VarOrRVar(Var v)
+        : var(std::move(v)), is_rvar(false) {
     }
-    VarOrRVar(const RVar &r)
-        : rvar(r), is_rvar(true) {
+    VarOrRVar(RVar r)
+        : rvar(std::move(r)), is_rvar(true) {
     }
     VarOrRVar(const RDom &r)
         : rvar(RVar(r)), is_rvar(true) {
@@ -474,7 +475,7 @@ class FuncRef {
     Stage func_ref_update(Expr e, int init_val);
 
 public:
-    FuncRef(Internal::Function, const std::vector<Expr> &,
+    FuncRef(Internal::Function, std::vector<Expr>,
             int placeholder_pos = -1, int count = 0);
     FuncRef(Internal::Function, const std::vector<Var> &,
             int placeholder_pos = -1, int count = 0);
@@ -583,7 +584,7 @@ class FuncTupleElementRef {
     Tuple values_with_undefs(Expr e) const;
 
 public:
-    FuncTupleElementRef(const FuncRef &ref, const std::vector<Expr> &args, int idx);
+    FuncTupleElementRef(const FuncRef &ref, std::vector<Expr> args, int idx);
 
     /** Use this as the left-hand-side of an update definition of Tuple
      * component 'idx' of a Func (see \ref RDom). The function must

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -183,11 +183,11 @@ struct CheckVars : public IRGraphVisitor {
     vector<string> pure_args;
     ReductionDomain reduction_domain;
     Scope<> defined_internally;
-    const std::string &name;
+    const std::string name;
     bool unbound_reduction_vars_ok = false;
 
-    CheckVars(const std::string &n)
-        : name(n) {
+    CheckVars(std::string n)
+        : name(std::move(n)) {
     }
 
     using IRVisitor::visit;
@@ -255,7 +255,7 @@ struct CheckVars : public IRGraphVisitor {
 class FreezeFunctions : public IRGraphVisitor {
     using IRGraphVisitor::visit;
 
-    const string &func;
+    const string func;
 
     void visit(const Call *op) override {
         IRGraphVisitor::visit(op);
@@ -268,8 +268,8 @@ class FreezeFunctions : public IRGraphVisitor {
     }
 
 public:
-    FreezeFunctions(const string &f)
-        : func(f) {
+    FreezeFunctions(string f)
+        : func(std::move(f)) {
     }
 };
 

--- a/src/Function.h
+++ b/src/Function.h
@@ -16,6 +16,7 @@
 #include "Util.h"
 
 #include <map>
+#include <utility>
 
 namespace Halide {
 
@@ -36,7 +37,7 @@ struct ExternFuncArgument {
     Internal::Parameter image_param;
 
     ExternFuncArgument(Internal::FunctionPtr f)
-        : arg_type(FuncArg), func(f) {
+        : arg_type(FuncArg), func(std::move(f)) {
     }
 
     template<typename T>
@@ -44,7 +45,7 @@ struct ExternFuncArgument {
         : arg_type(BufferArg), buffer(b) {
     }
     ExternFuncArgument(Expr e)
-        : arg_type(ExprArg), expr(e) {
+        : arg_type(ExprArg), expr(std::move(e)) {
     }
     ExternFuncArgument(int e)
         : arg_type(ExprArg), expr(e) {

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1,6 +1,7 @@
 #include <cmath>
 #include <fstream>
 #include <unordered_map>
+#include <utility>
 
 #include "BoundaryConditions.h"
 #include "Derivative.h"
@@ -190,17 +191,17 @@ std::vector<Expr> parameter_constraints(const Parameter &p) {
 class StubEmitter {
 public:
     StubEmitter(std::ostream &dest,
-                const std::string &generator_registered_name,
+                std::string generator_registered_name,
                 const std::string &generator_stub_name,
                 const std::vector<Internal::GeneratorParamBase *> &generator_params,
-                const std::vector<Internal::GeneratorInputBase *> &inputs,
-                const std::vector<Internal::GeneratorOutputBase *> &outputs)
+                std::vector<Internal::GeneratorInputBase *> inputs,
+                std::vector<Internal::GeneratorOutputBase *> outputs)
         : stream(dest),
-          generator_registered_name(generator_registered_name),
+          generator_registered_name(std::move(generator_registered_name)),
           generator_stub_name(generator_stub_name),
           generator_params(select_generator_params(generator_params)),
-          inputs(inputs),
-          outputs(outputs) {
+          inputs(std::move(inputs)),
+          outputs(std::move(outputs)) {
         namespaces = split_string(generator_stub_name, "::");
         internal_assert(!namespaces.empty());
         if (namespaces[0].empty()) {
@@ -997,8 +998,8 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
 }
 #endif
 
-GeneratorParamBase::GeneratorParamBase(const std::string &name)
-    : name(name) {
+GeneratorParamBase::GeneratorParamBase(std::string name)
+    : name(std::move(name)) {
     ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::GeneratorParam,
                                               this, nullptr);
 }
@@ -1635,11 +1636,11 @@ void GeneratorBase::check_input_kind(Internal::GeneratorInputBase *in, Internal:
 }
 
 GIOBase::GIOBase(size_t array_size,
-                 const std::string &name,
+                 std::string name,
                  IOKind kind,
-                 const std::vector<Type> &types,
+                 std::vector<Type> types,
                  int dims)
-    : array_size_(array_size), name_(name), kind_(kind), types_(types), dims_(dims) {
+    : array_size_(array_size), name_(std::move(name)), kind_(kind), types_(std::move(types)), dims_(dims) {
 }
 
 GIOBase::~GIOBase() {

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -266,6 +266,7 @@
 #include <sstream>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "ExternalCode.h"
@@ -391,7 +392,7 @@ class GeneratorParamInfo;
 
 class GeneratorParamBase {
 public:
-    explicit GeneratorParamBase(const std::string &name);
+    explicit GeneratorParamBase(std::string name);
     virtual ~GeneratorParamBase();
 
     const std::string name;
@@ -498,8 +499,8 @@ class GeneratorParamImpl : public GeneratorParamBase {
 public:
     using type = T;
 
-    GeneratorParamImpl(const std::string &name, const T &value)
-        : GeneratorParamBase(name), value_(value) {
+    GeneratorParamImpl(const std::string &name, T value)
+        : GeneratorParamBase(name), value_(std::move(value)) {
     }
 
     T value() const {
@@ -1310,8 +1311,8 @@ protected:
     void check_scheduled(const char *m) const;
     Target get_target() const;
 
-    explicit StubOutputBufferBase(const Func &f, std::shared_ptr<GeneratorBase> generator)
-        : f(f), generator(generator) {
+    explicit StubOutputBufferBase(Func f, std::shared_ptr<GeneratorBase> generator)
+        : f(std::move(f)), generator(std::move(generator)) {
     }
     StubOutputBufferBase() = default;
 
@@ -1376,11 +1377,11 @@ public:
     StubInput(const StubInputBuffer<T2> &b)
         : kind_(IOKind::Buffer), parameter_(b.parameter_) {
     }
-    StubInput(const Func &f)
-        : kind_(IOKind::Function), parameter_(), func_(f) {
+    StubInput(Func f)
+        : kind_(IOKind::Function), parameter_(), func_(std::move(f)) {
     }
-    StubInput(const Expr &e)
-        : kind_(IOKind::Scalar), parameter_(), expr_(e) {
+    StubInput(Expr e)
+        : kind_(IOKind::Scalar), parameter_(), expr_(std::move(e)) {
     }
 
 private:
@@ -1447,9 +1448,9 @@ public:
 
 protected:
     GIOBase(size_t array_size,
-            const std::string &name,
+            std::string name,
             IOKind kind,
-            const std::vector<Type> &types,
+            std::vector<Type> types,
             int dims);
 
     friend class GeneratorBase;
@@ -2776,8 +2777,8 @@ private:
             new GeneratorParam_Synthetic<T>(gpname, gio, which, error_msg));
     }
 
-    GeneratorParam_Synthetic(const std::string &name, GIOBase &gio, SyntheticParamType which, const std::string &error_msg = "")
-        : GeneratorParamImpl<T>(name, T()), gio(gio), which(which), error_msg(error_msg) {
+    GeneratorParam_Synthetic(const std::string &name, GIOBase &gio, SyntheticParamType which, std::string error_msg = "")
+        : GeneratorParamImpl<T>(name, T()), gio(gio), which(which), error_msg(std::move(error_msg)) {
     }
 
     template<typename T2 = T, typename std::enable_if<std::is_same<T2, ::Halide::Type>::value>::type * = nullptr>
@@ -2993,11 +2994,11 @@ struct StringOrLoopLevel {
     /*not-explicit*/ StringOrLoopLevel(const char *s)
         : string_value(s) {
     }
-    /*not-explicit*/ StringOrLoopLevel(const std::string &s)
-        : string_value(s) {
+    /*not-explicit*/ StringOrLoopLevel(std::string s)
+        : string_value(std::move(s)) {
     }
-    /*not-explicit*/ StringOrLoopLevel(const LoopLevel &loop_level)
-        : loop_level(loop_level) {
+    /*not-explicit*/ StringOrLoopLevel(LoopLevel loop_level)
+        : loop_level(std::move(loop_level)) {
     }
 };
 using GeneratorParamsMap = std::map<std::string, StringOrLoopLevel>;

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -13,6 +13,7 @@
 #include "Simplify.h"
 #include "Substitute.h"
 #include <unordered_map>
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -169,8 +170,8 @@ struct Pattern {
     int flags;
 
     Pattern() = default;
-    Pattern(const string &intrin, Expr p, int flags = 0)
-        : intrin(intrin), pattern(p), flags(flags) {
+    Pattern(string intrin, Expr p, int flags = 0)
+        : intrin(std::move(intrin)), pattern(std::move(p)), flags(flags) {
     }
 };
 

--- a/src/IREquality.h
+++ b/src/IREquality.h
@@ -5,6 +5,8 @@
  * Methods to test Exprs and Stmts for equality of value
  */
 
+#include <utility>
+
 #include "IR.h"
 
 namespace Halide {
@@ -99,8 +101,8 @@ struct ExprWithCompareCache {
     ExprWithCompareCache()
         : cache(nullptr) {
     }
-    ExprWithCompareCache(const Expr &e, IRCompareCache *c)
-        : expr(e), cache(c) {
+    ExprWithCompareCache(Expr e, IRCompareCache *c)
+        : expr(std::move(e)), cache(c) {
     }
 
     /** The comparison uses (and updates) the cache */

--- a/src/IRMatch.cpp
+++ b/src/IRMatch.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <map>
+#include <utility>
 
 #include "IREquality.h"
 #include "IRMatch.h"
@@ -57,10 +58,10 @@ public:
     Expr expr;
 
     IRMatch(Expr e, vector<Expr> &m)
-        : result(true), matches(&m), var_matches(nullptr), expr(e) {
+        : result(true), matches(&m), var_matches(nullptr), expr(std::move(e)) {
     }
     IRMatch(Expr e, map<string, Expr> &m)
-        : result(true), matches(nullptr), var_matches(&m), expr(e) {
+        : result(true), matches(nullptr), var_matches(&m), expr(std::move(e)) {
     }
 
     using IRVisitor::visit;

--- a/src/InferArguments.cpp
+++ b/src/InferArguments.cpp
@@ -1,5 +1,6 @@
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "IRVisitor.h"
@@ -30,7 +31,7 @@ public:
     }
 
 private:
-    vector<Function> outputs;
+    const vector<Function> &outputs;
     set<string> visited_functions;
 
     using IRGraphVisitor::visit;

--- a/src/InjectHostDevBufferCopies.cpp
+++ b/src/InjectHostDevBufferCopies.cpp
@@ -8,6 +8,7 @@
 #include "Substitute.h"
 
 #include <map>
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -115,7 +116,7 @@ class FindBufferUsage : public IRVisitor {
         current_device_api = old;
     }
 
-    string buffer;
+    const string &buffer;
     DeviceAPI current_device_api;
 
 public:
@@ -139,7 +140,7 @@ class InjectBufferCopiesForSingleBuffer : public IRMutator {
     using IRMutator::visit;
 
     // The buffer being managed
-    string buffer;
+    const string &buffer;
 
     bool is_external;
 
@@ -425,7 +426,7 @@ public:
     }
 
 private:
-    string buffer;
+    const string &buffer;
 
     using IRVisitor::visit;
 
@@ -508,7 +509,7 @@ class InjectBufferCopies : public IRMutator {
 
     public:
         InjectDeviceDestructor(string b)
-            : buffer(b) {
+            : buffer(std::move(b)) {
         }
     };
 
@@ -563,7 +564,7 @@ class InjectBufferCopies : public IRMutator {
 
     public:
         InjectCombinedAllocation(string b, Type t, vector<Expr> e, Expr c, DeviceAPI d)
-            : buffer(b), type(t), extents(e), condition(c), device_api(d) {
+            : buffer(std::move(b)), type(t), extents(std::move(e)), condition(std::move(c)), device_api(d) {
         }
     };
 
@@ -586,7 +587,7 @@ class InjectBufferCopies : public IRMutator {
         }
 
         FreeAfterLastUse(Stmt s, Stmt f)
-            : last_use(s), free_stmt(f) {
+            : last_use(std::move(s)), free_stmt(std::move(f)) {
         }
     };
 
@@ -767,7 +768,7 @@ public:
     }
 
     InjectBufferCopiesForInputsAndOutputs(Stmt s)
-        : site(s) {
+        : site(std::move(s)) {
     }
 };
 

--- a/src/InjectHostDevBufferCopies.cpp
+++ b/src/InjectHostDevBufferCopies.cpp
@@ -116,7 +116,7 @@ class FindBufferUsage : public IRVisitor {
         current_device_api = old;
     }
 
-    const string &buffer;
+    const string buffer;
     DeviceAPI current_device_api;
 
 public:
@@ -125,8 +125,8 @@ public:
     // bits and device allocation messed with.
     std::set<DeviceAPI> devices_touched_by_extern;
 
-    FindBufferUsage(const std::string &buf, DeviceAPI d)
-        : buffer(buf), current_device_api(d) {
+    FindBufferUsage(std::string buf, DeviceAPI d)
+        : buffer(std::move(buf)), current_device_api(d) {
     }
 };
 
@@ -140,7 +140,7 @@ class InjectBufferCopiesForSingleBuffer : public IRMutator {
     using IRMutator::visit;
 
     // The buffer being managed
-    const string &buffer;
+    const string buffer;
 
     bool is_external;
 
@@ -400,8 +400,8 @@ class InjectBufferCopiesForSingleBuffer : public IRMutator {
     }
 
 public:
-    InjectBufferCopiesForSingleBuffer(const std::string &b, bool e)
-        : buffer(b), is_external(e) {
+    InjectBufferCopiesForSingleBuffer(std::string b, bool e)
+        : buffer(std::move(b)), is_external(e) {
         if (is_external) {
             // The state of the buffer is totally unknown, which is
             // the default constructor for this->state
@@ -421,12 +421,12 @@ class FindLastUse : public IRVisitor {
 public:
     Stmt last_use;
 
-    FindLastUse(const string &b)
-        : buffer(b) {
+    FindLastUse(string b)
+        : buffer(std::move(b)) {
     }
 
 private:
-    const string &buffer;
+    const string buffer;
 
     using IRVisitor::visit;
 

--- a/src/InlineReductions.cpp
+++ b/src/InlineReductions.cpp
@@ -1,10 +1,12 @@
 #include "InlineReductions.h"
+
 #include "CSE.h"
 #include "Debug.h"
 #include "Func.h"
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "Scope.h"
+#include <utility>
 
 namespace Halide {
 
@@ -20,13 +22,13 @@ public:
     vector<Expr> call_args;
     RDom rdom;
 
-    FindFreeVars(RDom r, const string &n)
-        : rdom(r), explicit_rdom(r.defined()), name(n) {
+    FindFreeVars(RDom r, string n)
+        : rdom(r), explicit_rdom(r.defined()), name(std::move(n)) {
     }
 
 private:
     bool explicit_rdom;
-    const string &name;
+    const string name;
 
     Scope<> internal;
 

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -2,6 +2,7 @@
 #include <set>
 #include <stdint.h>
 #include <string>
+#include <utility>
 
 #ifdef _WIN32
 #ifdef _MSC_VER
@@ -194,8 +195,8 @@ class HalideJITMemoryManager : public SectionMemoryManager {
     std::vector<std::pair<uint8_t *, size_t>> code_pages;
 
 public:
-    HalideJITMemoryManager(const std::vector<JITModule> &modules)
-        : modules(modules) {
+    HalideJITMemoryManager(std::vector<JITModule> modules)
+        : modules(std::move(modules)) {
     }
 
     uint64_t getSymbolAddress(const std::string &name) override {

--- a/src/LowerWarpShuffles.cpp
+++ b/src/LowerWarpShuffles.cpp
@@ -1,4 +1,5 @@
 #include "LowerWarpShuffles.h"
+
 #include "ExprUsesVar.h"
 #include "IREquality.h"
 #include "IRMatch.h"
@@ -8,6 +9,7 @@
 #include "Simplify.h"
 #include "Solve.h"
 #include "Substitute.h"
+#include <utility>
 
 // In CUDA, allocations stored in registers and shared across lanes
 // look like private per-lane allocations, even though communication
@@ -274,8 +276,8 @@ class DetermineAllocStride : public IRVisitor {
     }
 
 public:
-    DetermineAllocStride(const string &alloc, const string &lane_var, const Expr &warp_size)
-        : alloc(alloc), lane_var(lane_var), warp_size(warp_size) {
+    DetermineAllocStride(const string &alloc, const string &lane_var, Expr warp_size)
+        : alloc(alloc), lane_var(lane_var), warp_size(std::move(warp_size)) {
         dependent_vars.push(lane_var, 1);
     }
 
@@ -739,7 +741,7 @@ class MoveIfStatementInwards : public IRMutator {
 
 public:
     MoveIfStatementInwards(Expr c)
-        : condition(c) {
+        : condition(std::move(c)) {
     }
 };
 

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -151,8 +151,8 @@ typedef std::pair<const FindParameterDependencies::DependencyKey, FindParameterD
 class KeyInfo {
     FindParameterDependencies dependencies;
     Expr key_size_expr;
-    const std::string &top_level_name;
-    const std::string &function_name;
+    const std::string top_level_name;
+    const std::string function_name;
     int memoize_instance;
 
     size_t parameters_alignment() {
@@ -187,8 +187,8 @@ class KeyInfo {
     // It was deleted as part of the address_of intrinsic cleanup).
 
 public:
-    KeyInfo(const Function &function, const std::string &name, int memoize_instance)
-        : top_level_name(name),
+    KeyInfo(const Function &function, std::string name, int memoize_instance)
+        : top_level_name(std::move(name)),
           function_name(function.origin_name()),
           memoize_instance(memoize_instance) {
         dependencies.visit_function(function);
@@ -314,14 +314,14 @@ class InjectMemoization : public IRMutator {
 public:
     const std::map<std::string, Function> &env;
     int memoize_instance;
-    const std::string &top_level_name;
+    const std::string top_level_name;
     const std::vector<Function> &outputs;
 
     InjectMemoization(const std::map<std::string, Function> &e,
                       int memoize_instance,
-                      const std::string &name,
+                      std::string name,
                       const std::vector<Function> &outputs)
-        : env(e), memoize_instance(memoize_instance), top_level_name(name), outputs(outputs) {
+        : env(e), memoize_instance(memoize_instance), top_level_name(std::move(name)), outputs(outputs) {
     }
 
 private:

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -8,6 +8,7 @@
 #include "Var.h"
 
 #include <map>
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -130,8 +131,8 @@ public:
             return false;
         }
 
-        DependencyKey(uint32_t size_arg, const std::string &name_arg)
-            : size(size_arg), name(name_arg) {
+        DependencyKey(uint32_t size_arg, std::string name_arg)
+            : size(size_arg), name(std::move(name_arg)) {
         }
     };
 

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <fstream>
 #include <future>
+#include <utility>
 
 #include "CodeGen_C.h"
 #include "CodeGen_Internal.h"
@@ -335,20 +336,20 @@ void destroy<ModuleContents>(const ModuleContents *t) {
     delete t;
 }
 
-LoweredFunc::LoweredFunc(const std::string &name,
-                         const std::vector<LoweredArgument> &args,
+LoweredFunc::LoweredFunc(std::string name,
+                         std::vector<LoweredArgument> args,
                          Stmt body,
                          LinkageType linkage,
                          NameMangling name_mangling)
-    : name(name), args(args), body(body), linkage(linkage), name_mangling(name_mangling) {
+    : name(std::move(name)), args(std::move(args)), body(std::move(body)), linkage(linkage), name_mangling(name_mangling) {
 }
 
-LoweredFunc::LoweredFunc(const std::string &name,
+LoweredFunc::LoweredFunc(std::string name,
                          const std::vector<Argument> &args,
                          Stmt body,
                          LinkageType linkage,
                          NameMangling name_mangling)
-    : name(name), body(body), linkage(linkage), name_mangling(name_mangling) {
+    : name(std::move(name)), body(std::move(body)), linkage(linkage), name_mangling(name_mangling) {
     for (const Argument &i : args) {
         this->args.push_back(LoweredArgument(i));
     }

--- a/src/Module.h
+++ b/src/Module.h
@@ -89,12 +89,12 @@ struct LoweredFunc {
      * the Target. */
     NameMangling name_mangling;
 
-    LoweredFunc(const std::string &name,
-                const std::vector<LoweredArgument> &args,
+    LoweredFunc(std::string name,
+                std::vector<LoweredArgument> args,
                 Stmt body,
                 LinkageType linkage,
                 NameMangling mangling = NameMangling::Default);
-    LoweredFunc(const std::string &name,
+    LoweredFunc(std::string name,
                 const std::vector<Argument> &args,
                 Stmt body,
                 LinkageType linkage,

--- a/src/Monotonic.cpp
+++ b/src/Monotonic.cpp
@@ -1,9 +1,11 @@
 #include "Monotonic.h"
+
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "Scope.h"
 #include "Simplify.h"
 #include "Substitute.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -29,7 +31,7 @@ std::ostream &operator<<(std::ostream &stream, const Monotonic &m) {
 using std::string;
 
 class MonotonicVisitor : public IRVisitor {
-    const string &var;
+    const string var;
 
     Scope<Monotonic> scope;
 
@@ -425,8 +427,8 @@ class MonotonicVisitor : public IRVisitor {
 public:
     Monotonic result;
 
-    MonotonicVisitor(const std::string &v, const Scope<Monotonic> &parent)
-        : var(v), result(Monotonic::Unknown) {
+    MonotonicVisitor(std::string v, const Scope<Monotonic> &parent)
+        : var(std::move(v)), result(Monotonic::Unknown) {
         scope.set_containing_scope(&parent);
     }
 };

--- a/src/OutputImageParam.cpp
+++ b/src/OutputImageParam.cpp
@@ -1,12 +1,14 @@
 #include "OutputImageParam.h"
+
 #include "IROperator.h"
+#include <utility>
 
 namespace Halide {
 
 using Internal::Dimension;
 
-OutputImageParam::OutputImageParam(const Internal::Parameter &p, Argument::Kind k, Func f)
-    : param(p), kind(k), func(f) {
+OutputImageParam::OutputImageParam(Internal::Parameter p, Argument::Kind k, Func f)
+    : param(std::move(p)), kind(k), func(std::move(f)) {
 }
 
 const std::string &OutputImageParam::name() const {

--- a/src/OutputImageParam.h
+++ b/src/OutputImageParam.h
@@ -37,7 +37,7 @@ protected:
                                           bool *placeholder_seen) const;
 
     /** Construct an OutputImageParam that wraps an Internal Parameter object. */
-    OutputImageParam(const Internal::Parameter &p, Argument::Kind k, Func f);
+    OutputImageParam(Internal::Parameter p, Argument::Kind k, Func f);
 
 public:
     /** Construct a null image parameter handle. */

--- a/src/ParallelRVar.cpp
+++ b/src/ParallelRVar.cpp
@@ -1,4 +1,5 @@
 #include "ParallelRVar.h"
+
 #include "CSE.h"
 #include "Debug.h"
 #include "IR.h"
@@ -7,6 +8,7 @@
 #include "IROperator.h"
 #include "Simplify.h"
 #include "Substitute.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -21,7 +23,7 @@ namespace {
 class FindLoads : public IRVisitor {
     using IRVisitor::visit;
 
-    const string &func;
+    const string func;
 
     void visit(const Call *op) override {
         if (op->name == func && op->call_type == Call::Halide) {
@@ -40,8 +42,8 @@ class FindLoads : public IRVisitor {
     }
 
 public:
-    FindLoads(const string &f)
-        : func(f) {
+    FindLoads(string f)
+        : func(std::move(f)) {
     }
 
     vector<vector<Expr>> loads;

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -1,9 +1,11 @@
 #include "Parameter.h"
+
 #include "Argument.h"
 #include "IR.h"
 #include "IROperator.h"
 #include "ObjectInstanceRegistry.h"
 #include "Simplify.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -25,8 +27,8 @@ struct ParameterContents {
     Expr scalar_min, scalar_max, scalar_estimate;
     const bool is_buffer;
 
-    ParameterContents(Type t, bool b, int d, const std::string &n)
-        : type(t), dimensions(d), name(n), buffer(Buffer<>()), data(0),
+    ParameterContents(Type t, bool b, int d, std::string n)
+        : type(t), dimensions(d), name(std::move(n)), buffer(Buffer<>()), data(0),
           host_alignment(t.bytes()), buffer_constraints(dimensions), is_buffer(b) {
         // stride_constraint[0] defaults to 1. This is important for
         // dense vectorization. You can unset it by setting it to a

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <utility>
 
 #include "Argument.h"
 #include "AutoSchedule.h"
@@ -1299,15 +1300,15 @@ void Pipeline::invalidate_cache() {
 }
 
 JITExtern::JITExtern(Pipeline pipeline)
-    : pipeline_(pipeline) {
+    : pipeline_(std::move(pipeline)) {
 }
 
 JITExtern::JITExtern(Func func)
     : pipeline_(func) {
 }
 
-JITExtern::JITExtern(const ExternCFunction &extern_c_function)
-    : extern_c_function_(extern_c_function) {
+JITExtern::JITExtern(ExternCFunction extern_c_function)
+    : extern_c_function_(std::move(extern_c_function)) {
 }
 
 MachineParams MachineParams::generic() {

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -8,6 +8,7 @@
  */
 
 #include <map>
+#include <utility>
 #include <vector>
 
 #include "ExternalCode.h"
@@ -553,10 +554,10 @@ private:
 public:
     ExternSignature() = default;
 
-    ExternSignature(const Type &ret_type, bool is_void_return, const std::vector<Type> &arg_types)
+    ExternSignature(const Type &ret_type, bool is_void_return, std::vector<Type> arg_types)
         : ret_type_(ret_type),
           is_void_return_(is_void_return),
-          arg_types_(arg_types) {
+          arg_types_(std::move(arg_types)) {
         internal_assert(!(is_void_return && ret_type != Type()));
     }
 
@@ -589,8 +590,8 @@ private:
 public:
     ExternCFunction() = default;
 
-    ExternCFunction(void *address, const ExternSignature &signature)
-        : address_(address), signature_(signature) {
+    ExternCFunction(void *address, ExternSignature signature)
+        : address_(address), signature_(std::move(signature)) {
     }
 
     template<typename RT, typename... Args>
@@ -616,7 +617,7 @@ private:
 public:
     JITExtern(Pipeline pipeline);
     JITExtern(Func func);
-    JITExtern(const ExternCFunction &extern_c_function);
+    JITExtern(ExternCFunction extern_c_function);
 
     template<typename RT, typename... Args>
     JITExtern(RT (*f)(Args... args))

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -163,14 +163,14 @@ private:
 
 class InjectPlaceholderPrefetch : public IRMutator {
 public:
-    InjectPlaceholderPrefetch(const map<string, Function> &e, const string &prefix,
+    InjectPlaceholderPrefetch(const map<string, Function> &e, string prefix,
                               const vector<PrefetchDirective> &prefetches)
-        : env(e), prefix(prefix), prefetch_list(prefetches) {
+        : env(e), prefix(std::move(prefix)), prefetch_list(prefetches) {
     }
 
 private:
     const map<string, Function> &env;
-    const string &prefix;
+    const string prefix;
     const vector<PrefetchDirective> &prefetch_list;
 
     using IRMutator::visit;

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <map>
 #include <string>
+#include <utility>
 
 #include "Bounds.h"
 #include "ExprUsesVar.h"
@@ -335,7 +336,7 @@ class SplitPrefetch : public IRMutator {
 
 public:
     SplitPrefetch(Expr bytes)
-        : max_byte_size(bytes) {
+        : max_byte_size(std::move(bytes)) {
     }
 };
 

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -2,6 +2,7 @@
 #include <limits>
 #include <map>
 #include <string>
+#include <utility>
 
 #include "CodeGen_Internal.h"
 #include "IRMutator.h"
@@ -25,7 +26,7 @@ public:
 
     vector<int> stack;  // What produce nodes are we currently inside of.
 
-    string pipeline_name;
+    const string &pipeline_name;
 
     InjectProfiling(const string &pipeline_name)
         : pipeline_name(pipeline_name) {
@@ -292,7 +293,7 @@ private:
     }
 };
 
-Stmt inject_profiling(Stmt s, string pipeline_name) {
+Stmt inject_profiling(Stmt s, const string &pipeline_name) {
     InjectProfiling profiling(pipeline_name);
     s = profiling.mutate(s);
 

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -26,10 +26,10 @@ public:
 
     vector<int> stack;  // What produce nodes are we currently inside of.
 
-    const string &pipeline_name;
+    const string pipeline_name;
 
-    InjectProfiling(const string &pipeline_name)
-        : pipeline_name(pipeline_name) {
+    InjectProfiling(string pipeline_name)
+        : pipeline_name(std::move(pipeline_name)) {
         indices["overhead"] = 0;
         stack.push_back(0);
     }

--- a/src/Profiling.h
+++ b/src/Profiling.h
@@ -36,7 +36,7 @@ namespace Internal {
  * storage flattening, but after all bounds inference.
  *
  */
-Stmt inject_profiling(Stmt, std::string);
+Stmt inject_profiling(Stmt, const std::string &pipeline_name);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Qualify.cpp
+++ b/src/Qualify.cpp
@@ -1,5 +1,7 @@
 #include "Qualify.h"
+
 #include "IRMutator.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -10,7 +12,7 @@ using std::string;
 class QualifyExpr : public IRMutator {
     using IRMutator::visit;
 
-    const string &prefix;
+    const string prefix;
 
     Expr visit(const Variable *v) override {
         if (v->param.defined()) {
@@ -26,8 +28,8 @@ class QualifyExpr : public IRMutator {
     }
 
 public:
-    QualifyExpr(const string &p)
-        : prefix(p) {
+    QualifyExpr(string p)
+        : prefix(std::move(p)) {
     }
 };
 

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -8,6 +8,7 @@
 
 #include "IR.h"
 
+#include <utility>
 #include <vector>
 
 namespace Halide {
@@ -35,14 +36,14 @@ public:
     }
 
     /** Construct an RVar with the given name */
-    explicit RVar(const std::string &n)
-        : _name(n) {
+    explicit RVar(std::string n)
+        : _name(std::move(n)) {
     }
 
     /** Construct a reduction variable with the given name and
      * bounds. Must be a member of the given reduction domain. */
     RVar(Internal::ReductionDomain domain, int index)
-        : _domain(domain), _index(index) {
+        : _domain(std::move(domain)), _index(index) {
     }
 
     /** The minimum value that this variable will take on */

--- a/src/Reduction.cpp
+++ b/src/Reduction.cpp
@@ -1,4 +1,5 @@
 #include "Reduction.h"
+
 #include "IR.h"
 #include "IREquality.h"
 #include "IRMutator.h"
@@ -6,6 +7,7 @@
 #include "IRVisitor.h"
 #include "Simplify.h"
 #include "Var.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -179,7 +181,7 @@ public:
     Expr predicate;
     const ReductionDomain &domain;
     DropSelfReferences(Expr p, const ReductionDomain &d)
-        : predicate(p), domain(d) {
+        : predicate(std::move(p)), domain(d) {
     }
 };
 }  // namespace

--- a/src/RegionCosts.cpp
+++ b/src/RegionCosts.cpp
@@ -1,10 +1,12 @@
 #include "RegionCosts.h"
+
 #include "FindCalls.h"
 #include "IRMutator.h"
 #include "IRVisitor.h"
 #include "PartitionLoops.h"
 #include "RealizationOrder.h"
 #include "Simplify.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -392,9 +394,9 @@ map<string, Expr> compute_expr_detailed_byte_loads(Expr expr) {
 
 }  // anonymous namespace
 
-RegionCosts::RegionCosts(const map<string, Function> &_env,
-                         const vector<string> &_order)
-    : env(_env), order(_order) {
+RegionCosts::RegionCosts(map<string, Function> _env,
+                         vector<string> _order)
+    : env(std::move(_env)), order(std::move(_order)) {
     for (const auto &kv : env) {
         // Pre-compute the function costs without any inlining.
         func_cost[kv.first] = get_func_cost(kv.second);

--- a/src/RegionCosts.h
+++ b/src/RegionCosts.h
@@ -141,8 +141,8 @@ struct RegionCosts {
     /** Construct a region cost object for the pipeline. 'env' is a map of all
      * functions in the pipeline. 'order' is the realization order of functions
      * in the pipeline. The first function to be realized comes first. */
-    RegionCosts(const std::map<std::string, Function> &env,
-                const std::vector<std::string> &order);
+    RegionCosts(std::map<std::string, Function> env,
+                std::vector<std::string> order);
 };
 
 /** Return true if the cost of inlining a function is equivalent to the

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -1,9 +1,11 @@
 #include "Schedule.h"
+
 #include "Func.h"
 #include "Function.h"
 #include "IR.h"
 #include "IRMutator.h"
 #include "Var.h"
+#include <utility>
 
 namespace {
 
@@ -31,12 +33,12 @@ struct LoopLevelContents {
     bool is_rvar;
     bool locked;
 
-    LoopLevelContents(const std::string &func_name,
-                      const std::string &var_name,
+    LoopLevelContents(std::string func_name,
+                      std::string var_name,
                       bool is_rvar,
                       int stage_index,
                       bool locked)
-        : func_name(func_name), stage_index(stage_index), var_name(var_name),
+        : func_name(std::move(func_name)), stage_index(stage_index), var_name(std::move(var_name)),
           is_rvar(is_rvar), locked(locked) {
     }
 };

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -10,6 +10,7 @@
 #include "Parameter.h"
 
 #include <map>
+#include <utility>
 
 namespace Halide {
 
@@ -159,7 +160,7 @@ class LoopLevel {
     Internal::IntrusivePtr<Internal::LoopLevelContents> contents;
 
     explicit LoopLevel(Internal::IntrusivePtr<Internal::LoopLevelContents> c)
-        : contents(c) {
+        : contents(std::move(c)) {
     }
     LoopLevel(const std::string &func_name, const std::string &var_name,
               bool is_rvar, int stage_index, bool locked = false);
@@ -250,8 +251,8 @@ struct FuseLoopLevel {
     FuseLoopLevel()
         : level(LoopLevel::inlined().lock()) {
     }
-    FuseLoopLevel(const LoopLevel &level, const std::map<std::string, LoopAlignStrategy> &align)
-        : level(level), align(align) {
+    FuseLoopLevel(LoopLevel level, std::map<std::string, LoopAlignStrategy> align)
+        : level(std::move(level)), align(std::move(align)) {
     }
 };
 
@@ -350,9 +351,9 @@ struct FusedPair {
     std::string var_name;
 
     FusedPair() = default;
-    FusedPair(const std::string &f1, size_t s1, const std::string &f2,
-              size_t s2, const std::string &var)
-        : func_1(f1), func_2(f2), stage_1(s1), stage_2(s2), var_name(var) {
+    FusedPair(std::string f1, size_t s1, std::string f2,
+              size_t s2, std::string var)
+        : func_1(std::move(f1)), func_2(std::move(f2)), stage_1(s1), stage_2(s2), var_name(std::move(var)) {
     }
 
     bool operator==(const FusedPair &other) const {
@@ -399,7 +400,7 @@ class FuncSchedule {
 
 public:
     FuncSchedule(IntrusivePtr<FuncScheduleContents> c)
-        : contents(c) {
+        : contents(std::move(c)) {
     }
     FuncSchedule(const FuncSchedule &other)
         : contents(other.contents) {
@@ -497,7 +498,7 @@ class StageSchedule {
 
 public:
     StageSchedule(IntrusivePtr<StageScheduleContents> c)
-        : contents(c) {
+        : contents(std::move(c)) {
     }
     StageSchedule(const StageSchedule &other)
         : contents(other.contents) {

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -728,7 +728,7 @@ Stmt inject_explicit_bounds(Stmt body, Function func) {
 }
 
 class IsUsedInStmt : public IRVisitor {
-    const string &func;
+    const string func;
 
     using IRVisitor::visit;
 
@@ -761,7 +761,7 @@ bool function_is_used_in_stmt(const Function &f, const Stmt &s) {
 }
 
 class IsRealizedInStmt : public IRVisitor {
-    const string &func;
+    const string func;
 
     using IRVisitor::visit;
 
@@ -974,12 +974,12 @@ public:
 };
 
 struct PlaceholderPrefetch {
-    const string &name;
+    const string name;
     const vector<Type> &types;
     const PrefetchDirective &prefetch;
 
-    PlaceholderPrefetch(const string &name, const vector<Type> &types, const PrefetchDirective &prefetch)
-        : name(name),
+    PlaceholderPrefetch(string name, const vector<Type> &types, const PrefetchDirective &prefetch)
+        : name(std::move(name)),
           types(types),
           prefetch(prefetch) {
     }
@@ -1613,7 +1613,7 @@ string schedule_to_source(const Function &f, const LoopLevel &store_at, const Lo
 
 class StmtUsesFunc : public IRVisitor {
     using IRVisitor::visit;
-    const string &func;
+    const string func;
     void visit(const Call *op) override {
         if (op->name == func) {
             result = true;
@@ -1631,8 +1631,8 @@ class StmtUsesFunc : public IRVisitor {
 
 public:
     bool result = false;
-    explicit StmtUsesFunc(const string &f)
-        : func(f) {
+    explicit StmtUsesFunc(string f)
+        : func(std::move(f)) {
     }
 };
 

--- a/src/Scope.h
+++ b/src/Scope.h
@@ -263,13 +263,13 @@ struct ScopedBinding {
 
     ScopedBinding() = default;
 
-    ScopedBinding(Scope<T> &s, const std::string &n, const T &value)
-        : scope(&s), name(n) {
+    ScopedBinding(Scope<T> &s, std::string n, const T &value)
+        : scope(&s), name(std::move(n)) {
         scope->push(name, value);
     }
 
-    ScopedBinding(bool condition, Scope<T> &s, const std::string &n, const T &value)
-        : scope(condition ? &s : nullptr), name(n) {
+    ScopedBinding(bool condition, Scope<T> &s, std::string n, const T &value)
+        : scope(condition ? &s : nullptr), name(std::move(n)) {
         if (condition) {
             scope->push(name, value);
         }
@@ -302,12 +302,12 @@ template<>
 struct ScopedBinding<void> {
     Scope<> *scope;
     std::string name;
-    ScopedBinding(Scope<> &s, const std::string &n)
-        : scope(&s), name(n) {
+    ScopedBinding(Scope<> &s, std::string n)
+        : scope(&s), name(std::move(n)) {
         scope->push(name);
     }
-    ScopedBinding(bool condition, Scope<> &s, const std::string &n)
-        : scope(condition ? &s : nullptr), name(n) {
+    ScopedBinding(bool condition, Scope<> &s, std::string n)
+        : scope(condition ? &s : nullptr), name(std::move(n)) {
         if (condition) {
             scope->push(name);
         }

--- a/src/SimplifySpecializations.cpp
+++ b/src/SimplifySpecializations.cpp
@@ -7,6 +7,7 @@
 #include "Substitute.h"
 
 #include <set>
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -51,7 +52,7 @@ public:
 
     Expr fact;
     SimplifyUsingFact(Expr f)
-        : fact(f) {
+        : fact(std::move(f)) {
     }
 };
 

--- a/src/SkipStages.cpp
+++ b/src/SkipStages.cpp
@@ -11,6 +11,7 @@
 #include "Substitute.h"
 
 #include <iterator>
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -53,7 +54,7 @@ public:
 
 private:
     using IRVisitor::visit;
-    string buffer;
+    const string &buffer;
     bool varies;
     bool treat_selects_as_guards;
     bool in_produce;
@@ -251,11 +252,11 @@ private:
 class ProductionGuarder : public IRMutator {
 public:
     ProductionGuarder(const string &b, Expr compute_p, Expr alloc_p)
-        : buffer(b), compute_predicate(compute_p), alloc_predicate(alloc_p) {
+        : buffer(b), compute_predicate(std::move(compute_p)), alloc_predicate(std::move(alloc_p)) {
     }
 
 private:
-    string buffer;
+    const string &buffer;
     Expr compute_predicate;
     Expr alloc_predicate;
 
@@ -325,7 +326,7 @@ public:
     }
 
 private:
-    string func;
+    const string &func;
     using IRMutator::visit;
 
     Scope<> vector_vars;

--- a/src/SkipStages.cpp
+++ b/src/SkipStages.cpp
@@ -44,9 +44,9 @@ bool extern_call_uses_buffer(const Call *op, const std::string &func) {
 class PredicateFinder : public IRVisitor {
 public:
     Expr predicate;
-    PredicateFinder(const string &b, bool s)
+    PredicateFinder(string b, bool s)
         : predicate(const_false()),
-          buffer(b),
+          buffer(std::move(b)),
           varies(false),
           treat_selects_as_guards(s),
           in_produce(false) {
@@ -54,7 +54,7 @@ public:
 
 private:
     using IRVisitor::visit;
-    const string &buffer;
+    const string buffer;
     bool varies;
     bool treat_selects_as_guards;
     bool in_produce;
@@ -251,12 +251,12 @@ private:
 
 class ProductionGuarder : public IRMutator {
 public:
-    ProductionGuarder(const string &b, Expr compute_p, Expr alloc_p)
-        : buffer(b), compute_predicate(std::move(compute_p)), alloc_predicate(std::move(alloc_p)) {
+    ProductionGuarder(string b, Expr compute_p, Expr alloc_p)
+        : buffer(std::move(b)), compute_predicate(std::move(compute_p)), alloc_predicate(std::move(alloc_p)) {
     }
 
 private:
-    const string &buffer;
+    const string buffer;
     Expr compute_predicate;
     Expr alloc_predicate;
 
@@ -321,12 +321,12 @@ private:
 
 class StageSkipper : public IRMutator {
 public:
-    StageSkipper(const string &f)
-        : func(f), in_vector_loop(false) {
+    StageSkipper(string f)
+        : func(std::move(f)), in_vector_loop(false) {
     }
 
 private:
-    const string &func;
+    const string func;
     using IRMutator::visit;
 
     Scope<> vector_vars;

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -45,7 +45,7 @@ public:
     }
 };
 
-bool expr_depends_on_var(Expr e, string v) {
+bool expr_depends_on_var(Expr e, const string &v) {
     ExprDependsOnVar depends(v);
     e.accept(&depends);
     return depends.result;

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -38,10 +38,10 @@ class ExprDependsOnVar : public IRVisitor {
 
 public:
     bool result;
-    const string &var;
+    const string var;
 
-    ExprDependsOnVar(const string &v)
-        : result(false), var(v) {
+    ExprDependsOnVar(string v)
+        : result(false), var(std::move(v)) {
     }
 };
 
@@ -85,7 +85,7 @@ Expr expand_expr(Expr e, const Scope<Expr> &scope) {
 // particular serial for loop
 class SlidingWindowOnFunctionAndLoop : public IRMutator {
     Function func;
-    const string &loop_var;
+    const string loop_var;
     Expr loop_min;
     Scope<Expr> scope;
 
@@ -331,8 +331,8 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
     }
 
 public:
-    SlidingWindowOnFunctionAndLoop(Function f, const string &v, Expr v_min)
-        : func(std::move(f)), loop_var(v), loop_min(std::move(v_min)) {
+    SlidingWindowOnFunctionAndLoop(Function f, string v, Expr v_min)
+        : func(std::move(f)), loop_var(std::move(v)), loop_min(std::move(v_min)) {
     }
 };
 

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -1,4 +1,5 @@
 #include "SlidingWindow.h"
+
 #include "Bounds.h"
 #include "Debug.h"
 #include "IRMutator.h"
@@ -8,6 +9,7 @@
 #include "Scope.h"
 #include "Simplify.h"
 #include "Substitute.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -36,9 +38,9 @@ class ExprDependsOnVar : public IRVisitor {
 
 public:
     bool result;
-    string var;
+    const string &var;
 
-    ExprDependsOnVar(string v)
+    ExprDependsOnVar(const string &v)
         : result(false), var(v) {
     }
 };
@@ -83,7 +85,7 @@ Expr expand_expr(Expr e, const Scope<Expr> &scope) {
 // particular serial for loop
 class SlidingWindowOnFunctionAndLoop : public IRMutator {
     Function func;
-    string loop_var;
+    const string &loop_var;
     Expr loop_min;
     Scope<Expr> scope;
 
@@ -329,8 +331,8 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
     }
 
 public:
-    SlidingWindowOnFunctionAndLoop(Function f, string v, Expr v_min)
-        : func(f), loop_var(v), loop_min(v_min) {
+    SlidingWindowOnFunctionAndLoop(Function f, const string &v, Expr v_min)
+        : func(std::move(f)), loop_var(v), loop_min(std::move(v_min)) {
     }
 };
 
@@ -361,7 +363,7 @@ class SlidingWindowOnFunction : public IRMutator {
 
 public:
     SlidingWindowOnFunction(Function f)
-        : func(f) {
+        : func(std::move(f)) {
     }
 };
 

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -1,4 +1,5 @@
 #include "Solve.h"
+
 #include "CSE.h"
 #include "ConciseCasts.h"
 #include "ExprUsesVar.h"
@@ -6,6 +7,7 @@
 #include "IRMutator.h"
 #include "Simplify.h"
 #include "Substitute.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -65,7 +67,7 @@ public:
 
 private:
     // The variable we're solving for.
-    string var;
+    const string &var;
 
     // Whether or not the just-mutated expression uses the variable.
     bool uses_var;

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -35,8 +35,8 @@ bool no_overflow_int(Type t) {
  */
 class SolveExpression : public IRMutator {
 public:
-    SolveExpression(const string &v, const Scope<Expr> &es)
-        : failed(false), var(v), uses_var(false), external_scope(es) {
+    SolveExpression(string v, const Scope<Expr> &es)
+        : failed(false), var(std::move(v)), uses_var(false), external_scope(es) {
     }
 
     using IRMutator::mutate;
@@ -67,7 +67,7 @@ public:
 
 private:
     // The variable we're solving for.
-    const string &var;
+    const string var;
 
     // Whether or not the just-mutated expression uses the variable.
     bool uses_var;
@@ -790,7 +790,7 @@ private:
 
 class SolveForInterval : public IRVisitor {
     // The var we're solving for
-    const string &var;
+    const string var;
 
     // Whether we're trying to make the condition true or false
     bool target = true;
@@ -1123,8 +1123,8 @@ class SolveForInterval : public IRVisitor {
 public:
     Interval result;
 
-    SolveForInterval(const string &v, bool o)
-        : var(v), outer(o) {
+    SolveForInterval(string v, bool o)
+        : var(std::move(v)), outer(o) {
     }
 };
 

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -1,4 +1,5 @@
 #include "StorageFolding.h"
+
 #include "Bounds.h"
 #include "CSE.h"
 #include "Debug.h"
@@ -9,6 +10,7 @@
 #include "Monotonic.h"
 #include "Simplify.h"
 #include "Substitute.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -151,7 +153,7 @@ class FoldStorageOfFunction : public IRMutator {
 
 public:
     FoldStorageOfFunction(string f, int d, Expr e, string p)
-        : func(f), dim(d), factor(e), dynamic_footprint(p) {
+        : func(std::move(f)), dim(d), factor(std::move(e)), dynamic_footprint(std::move(p)) {
     }
 };
 
@@ -390,8 +392,8 @@ public:
                        string head, string tail,
                        string loop_var, Expr sema_var,
                        int dim, const StorageDim &storage_dim)
-        : func(func),
-          head(head), tail(tail), loop_var(loop_var), sema_var(sema_var),
+        : func(std::move(func)),
+          head(std::move(head)), tail(std::move(tail)), loop_var(std::move(loop_var)), sema_var(std::move(sema_var)),
           dim(dim), storage_dim(storage_dim) {
     }
 };
@@ -817,7 +819,7 @@ public:
     vector<Fold> dims_folded;
 
     AttemptStorageFoldingOfFunction(Function f, bool explicit_only)
-        : func(f), explicit_only(explicit_only) {
+        : func(std::move(f)), explicit_only(explicit_only) {
     }
 };
 

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -29,7 +29,7 @@ using std::vector;
 
 // Count the number of producers of a particular func.
 class CountProducers : public IRVisitor {
-    const std::string &name;
+    const std::string name;
 
     void visit(const ProducerConsumer *op) override {
         if (op->is_producer && (op->name == name)) {
@@ -44,8 +44,8 @@ class CountProducers : public IRVisitor {
 public:
     int count = 0;
 
-    CountProducers(const std::string &name)
-        : name(name) {
+    CountProducers(std::string name)
+        : name(std::move(name)) {
     }
 };
 

--- a/src/Substitute.cpp
+++ b/src/Substitute.cpp
@@ -140,7 +140,7 @@ Stmt substitute(const Expr &find, const Expr &replacement, const Stmt &stmt) {
 
 /** Substitute an expr for a var in a graph. */
 class GraphSubstitute : public IRGraphMutator {
-    const string &var;
+    const string var;
     const Expr &value;
 
     using IRGraphMutator::visit;
@@ -163,8 +163,8 @@ class GraphSubstitute : public IRGraphMutator {
     }
 
 public:
-    GraphSubstitute(const string &var, const Expr &value)
-        : var(var), value(value) {
+    GraphSubstitute(string var, const Expr &value)
+        : var(std::move(var)), value(value) {
     }
 };
 

--- a/src/Substitute.cpp
+++ b/src/Substitute.cpp
@@ -1,7 +1,9 @@
 #include "Substitute.h"
+
 #include "IREquality.h"
 #include "IRMutator.h"
 #include "Scope.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -138,8 +140,8 @@ Stmt substitute(const Expr &find, const Expr &replacement, const Stmt &stmt) {
 
 /** Substitute an expr for a var in a graph. */
 class GraphSubstitute : public IRGraphMutator {
-    string var;
-    Expr value;
+    const string &var;
+    const Expr &value;
 
     using IRGraphMutator::visit;
 
@@ -169,7 +171,7 @@ public:
 /** Substitute an Expr for another Expr in a graph. Unlike substitute,
  * this only checks for shallow equality. */
 class GraphSubstituteExpr : public IRGraphMutator {
-    Expr find, replace;
+    const Expr &find, &replace;
 
 public:
     using IRGraphMutator::mutate;

--- a/src/TrimNoOps.cpp
+++ b/src/TrimNoOps.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <utility>
 
 #include "CSE.h"
 #include "CodeGen_GPU_Dev.h"
@@ -47,7 +48,7 @@ class LoadsFromBuffer : public IRVisitor {
         }
     }
 
-    string buffer;
+    const string &buffer;
 
 public:
     bool result = false;

--- a/src/TrimNoOps.cpp
+++ b/src/TrimNoOps.cpp
@@ -48,12 +48,12 @@ class LoadsFromBuffer : public IRVisitor {
         }
     }
 
-    const string &buffer;
+    const string buffer;
 
 public:
     bool result = false;
-    LoadsFromBuffer(const string &b)
-        : buffer(b) {
+    LoadsFromBuffer(string b)
+        : buffer(std::move(b)) {
     }
 };
 

--- a/src/TrimNoOps.cpp
+++ b/src/TrimNoOps.cpp
@@ -57,7 +57,7 @@ public:
     }
 };
 
-bool loads_from_buffer(Expr e, string buf) {
+bool loads_from_buffer(const Expr &e, const string &buf) {
     LoadsFromBuffer l(buf);
     e.accept(&l);
     return l.result;

--- a/src/Type.h
+++ b/src/Type.h
@@ -7,6 +7,8 @@
 #include "runtime/HalideRuntime.h"
 #include <stdint.h>
 
+#include <utility>
+
 /** \file
  * Defines halide types
  */
@@ -50,8 +52,8 @@ struct halide_cplusplus_type_name {
 
     std::string name;
 
-    halide_cplusplus_type_name(CPPTypeType cpp_type_type, const std::string &name)
-        : cpp_type_type(cpp_type_type), name(name) {
+    halide_cplusplus_type_name(CPPTypeType cpp_type_type, std::string name)
+        : cpp_type_type(cpp_type_type), name(std::move(name)) {
     }
 
     bool operator==(const halide_cplusplus_type_name &rhs) const {
@@ -109,15 +111,15 @@ struct halide_handle_cplusplus_type {
     };
     ReferenceType reference_type;
 
-    halide_handle_cplusplus_type(const halide_cplusplus_type_name &inner_name,
-                                 const std::vector<std::string> &namespaces = {},
-                                 const std::vector<halide_cplusplus_type_name> &enclosing_types = {},
-                                 const std::vector<uint8_t> &modifiers = {},
+    halide_handle_cplusplus_type(halide_cplusplus_type_name inner_name,
+                                 std::vector<std::string> namespaces = {},
+                                 std::vector<halide_cplusplus_type_name> enclosing_types = {},
+                                 std::vector<uint8_t> modifiers = {},
                                  ReferenceType reference_type = NotReference)
-        : inner_name(inner_name),
-          namespaces(namespaces),
-          enclosing_types(enclosing_types),
-          cpp_type_modifiers(modifiers),
+        : inner_name(std::move(inner_name)),
+          namespaces(std::move(namespaces)),
+          enclosing_types(std::move(enclosing_types)),
+          cpp_type_modifiers(std::move(modifiers)),
           reference_type(reference_type) {
     }
 

--- a/src/Var.cpp
+++ b/src/Var.cpp
@@ -1,10 +1,12 @@
 #include "Var.h"
+
 #include "Util.h"
+#include <utility>
 
 namespace Halide {
 
-Var::Var(const std::string &n)
-    : _name(n) {
+Var::Var(std::string n)
+    : _name(std::move(n)) {
 }
 
 Var::Var()

--- a/src/Var.h
+++ b/src/Var.h
@@ -19,7 +19,7 @@ class Var {
 
 public:
     /** Construct a Var with the given name */
-    Var(const std::string &n);
+    Var(std::string n);
 
     /** Construct a Var with an automatically-generated unique name. */
     Var();

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -27,7 +27,7 @@ namespace {
 // For a given var, replace expressions like shuffle_vector(var, 4)
 // with var.lane.4
 class ReplaceShuffleVectors : public IRMutator {
-    const string &var;
+    const string var;
 
     using IRMutator::visit;
 
@@ -43,8 +43,8 @@ class ReplaceShuffleVectors : public IRMutator {
     }
 
 public:
-    ReplaceShuffleVectors(const string &v)
-        : var(v) {
+    ReplaceShuffleVectors(string v)
+        : var(std::move(v)) {
     }
 };
 
@@ -191,7 +191,7 @@ Interval bounds_of_lanes(Expr e) {
 // rewritten slightly.
 class RewriteAccessToVectorAlloc : public IRMutator {
     Expr var;
-    const string &alloc;
+    const string alloc;
     int lanes;
 
     using IRMutator::visit;
@@ -224,8 +224,8 @@ class RewriteAccessToVectorAlloc : public IRMutator {
     }
 
 public:
-    RewriteAccessToVectorAlloc(const string &v, const string &a, int l)
-        : var(Variable::make(Int(32), v)), alloc(a), lanes(l) {
+    RewriteAccessToVectorAlloc(const string &v, string a, int l)
+        : var(Variable::make(Int(32), v)), alloc(std::move(a)), lanes(l) {
     }
 };
 

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -14,6 +14,7 @@
 #include <cmath>
 #include <mutex>
 #include <sstream>
+#include <utility>
 #include <vector>
 
 // clang-format off
@@ -1314,7 +1315,7 @@ struct WasmModuleContents {
 
     WasmModuleContents(
         const Module &module,
-        const std::vector<Argument> &arguments,
+        std::vector<Argument> arguments,
         const std::string &fn_name,
         const JITExternMap &jit_externs,
         const std::vector<JITModule> &extern_deps);
@@ -1326,12 +1327,12 @@ struct WasmModuleContents {
 
 WasmModuleContents::WasmModuleContents(
     const Module &module,
-    const std::vector<Argument> &arguments,
+    std::vector<Argument> arguments,
     const std::string &fn_name,
     const JITExternMap &jit_externs,
     const std::vector<JITModule> &extern_deps)
     : target(module.target()),
-      arguments(arguments),
+      arguments(std::move(arguments)),
       jit_externs(jit_externs),
       extern_deps(extern_deps),
       trampolines(JITModule::make_trampolines_module(get_host_target(), jit_externs, kTrampolineSuffix, extern_deps)) {


### PR DESCRIPTION
This is a scaled-back #4670, just turning on a single additional check.

In constructors that take a copy of an argument, pass by value and
std::move instead of passing by const ref and making a copy. This is
strictly better for two reasons.

1) This avoids a copy in the case where the argument was an rval.
2) The type signature loses some line noise, and makes it more obvious
to callers that a copy is going to happen.

There were a healthy number of cases this revealed where the object
should *not* have been making a copy of the argument. These were largely
local IRVisitors and IRMutators doing some sort of tightly-scoped
analysis or mutation. so I changed those to have const ref members and
continue to take the argument by const ref.

Also added a makefile target to get clang-tidy to automatically apply
suggested changes.