### PR TITLE
Clang tidy use default member initializers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
-Checks: '-*,modernize-use-override'
+Checks: '-*,modernize-pass-by-value,modernize-use-override'
 WarningsAsErrors: '*'
-HeaderFilterRegex: '.*'
+HeaderFilterRegex: 'src/[^/]*.h'
 AnalyzeTemporaryDtors: false
 FormatStyle: 'file'
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: '-*,modernize-pass-by-value,modernize-use-override'
+Checks: '-*,modernize-pass-by-value,modernize-use-override,modernize-use-equals-default,modernize-use-default-member-init'
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'src/[^/]*.h'
 AnalyzeTemporaryDtors: false

--- a/Makefile
+++ b/Makefile
@@ -2297,3 +2297,23 @@ $(BIN_DIR)/HalideTraceDump: $(ROOT_DIR)/util/HalideTraceDump.cpp $(ROOT_DIR)/uti
 format:
 	find "${ROOT_DIR}/apps" "${ROOT_DIR}/src" "${ROOT_DIR}/tools" "${ROOT_DIR}/test" "${ROOT_DIR}/util" "${ROOT_DIR}/python_bindings" -name *.cpp -o -name *.h -o -name *.c | xargs ${CLANG}-format -i -style=file
 
+# Run clang-tidy on the core source files
+$(BUILD_DIR)/compile_commands.json:
+	echo '[' >> $@
+	BD=$(realpath $(BUILD_DIR)); \
+	SD=$(realpath $(SRC_DIR)); \
+	for S in $(SOURCE_FILES); do \
+	echo "{ \"directory\": \"$${BD}\"," >> $@; \
+	echo "  \"command\": \"$(CXX) $(CXX_FLAGS) -c $$SD/$$S -o $$BD/$${S/cpp/o}\"," >> $@; \
+	echo "  \"file\": \"$$SD/$$S\" }," >> $@; \
+	done
+	echo ']' >> $@
+
+.PHONY: clang-tidy
+clang-tidy: $(BUILD_DIR)/compile_commands.json
+	${CLANG}-tidy -extra-arg=-Wno-unknown-warning-option -p $(BUILD_DIR) $(addprefix $(SRC_DIR)/,$(SOURCE_FILES))
+
+.PHONY: clang-tidy-fix
+clang-tidy-fix: $(BUILD_DIR)/compile_commands.json
+	${CLANG}-tidy -extra-arg=-Wno-unknown-warning-option -p $(BUILD_DIR) $(addprefix $(SRC_DIR)/,$(SOURCE_FILES)) -fix-errors
+

--- a/src/AddAtomicMutex.cpp
+++ b/src/AddAtomicMutex.cpp
@@ -1,10 +1,12 @@
 #include "AddAtomicMutex.h"
+
 #include "ExprUsesVar.h"
 #include "Func.h"
 #include "IREquality.h"
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "OutputImageParam.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -248,7 +250,7 @@ protected:
 class ReplaceStoreIndexWithVar : public IRMutator {
 public:
     ReplaceStoreIndexWithVar(const std::string &producer_name, Expr var)
-        : producer_name(producer_name), var(var) {
+        : producer_name(producer_name), var(std::move(var)) {
     }
 
 protected:

--- a/src/ApplySplit.h
+++ b/src/ApplySplit.h
@@ -31,11 +31,11 @@ struct ApplySplitResult {
                 Predicate };
     Type type;
 
-    ApplySplitResult(const std::string &n, Expr val, Type t)
-        : name(n), value(val), type(t) {
+    ApplySplitResult(std::string n, Expr val, Type t)
+        : name(std::move(n)), value(std::move(val)), type(t) {
     }
     ApplySplitResult(Expr val)
-        : name(""), value(val), type(Predicate) {
+        : name(), value(std::move(val)), type(Predicate) {
     }
 
     bool is_substitution() const {

--- a/src/Argument.cpp
+++ b/src/Argument.cpp
@@ -1,5 +1,7 @@
 #include "Argument.h"
 
+#include <utility>
+
 namespace Halide {
 
 bool ArgumentEstimates::operator==(const ArgumentEstimates &rhs) const {
@@ -18,8 +20,8 @@ bool ArgumentEstimates::operator==(const ArgumentEstimates &rhs) const {
            scalar_estimate.same_as(rhs.scalar_estimate);
 }
 
-Argument::Argument(const std::string &_name, Kind _kind, const Type &_type, int _dimensions, const ArgumentEstimates &argument_estimates)
-    : name(_name), kind(_kind), dimensions((uint8_t)_dimensions), type(_type), argument_estimates(argument_estimates) {
+Argument::Argument(std::string _name, Kind _kind, const Type &_type, int _dimensions, const ArgumentEstimates &argument_estimates)
+    : name(std::move(_name)), kind(_kind), dimensions((uint8_t)_dimensions), type(_type), argument_estimates(argument_estimates) {
     internal_assert(dimensions >= 0 && dimensions <= 255);
     user_assert(!(is_scalar() && dimensions != 0)) << "Scalar Arguments must specify dimensions of 0";
     user_assert(argument_estimates.buffer_estimates.empty() ||

--- a/src/Argument.h
+++ b/src/Argument.h
@@ -71,7 +71,7 @@ struct Argument {
     ArgumentEstimates argument_estimates;
 
     Argument() = default;
-    Argument(const std::string &_name, Kind _kind, const Type &_type, int _dimensions,
+    Argument(std::string _name, Kind _kind, const Type &_type, int _dimensions,
              const ArgumentEstimates &argument_estimates);
 
     // Not explicit, so that you can put Buffer in an argument list,

--- a/src/AssociativeOpsTable.cpp
+++ b/src/AssociativeOpsTable.cpp
@@ -1,5 +1,7 @@
 #include "AssociativeOpsTable.h"
+
 #include "IRPrinter.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -93,8 +95,8 @@ struct TableKey {
     TableKey(ValType t, RootExpr r, size_t d)
         : types({t}), root(r), dim(d) {
     }
-    TableKey(const vector<ValType> &t, RootExpr r, size_t d)
-        : types(t), root(r), dim(d) {
+    TableKey(vector<ValType> t, RootExpr r, size_t d)
+        : types(std::move(t)), root(r), dim(d) {
     }
 
     bool operator==(const TableKey &other) const {

--- a/src/AssociativeOpsTable.h
+++ b/src/AssociativeOpsTable.h
@@ -35,13 +35,11 @@ struct AssociativePattern {
     /** Contain the identities for each dimension of the associative op. */
     std::vector<Expr> identities;
     /** Indicate if the associative op is also commutative. */
-    bool is_commutative;
+    bool is_commutative{false};
 
-    AssociativePattern()
-        : is_commutative(false) {
-    }
+    AssociativePattern() = default;
     AssociativePattern(size_t size)
-        : ops(size), identities(size), is_commutative(false) {
+        : ops(size), identities(size) {
     }
     AssociativePattern(std::vector<Expr> ops, std::vector<Expr> ids, bool is_commutative)
         : ops(std::move(ops)), identities(std::move(ids)), is_commutative(is_commutative) {

--- a/src/AssociativeOpsTable.h
+++ b/src/AssociativeOpsTable.h
@@ -9,6 +9,7 @@
 #include "IROperator.h"
 
 #include <iostream>
+#include <utility>
 #include <vector>
 
 namespace Halide {
@@ -42,8 +43,8 @@ struct AssociativePattern {
     AssociativePattern(size_t size)
         : ops(size), identities(size), is_commutative(false) {
     }
-    AssociativePattern(const std::vector<Expr> &ops, const std::vector<Expr> &ids, bool is_commutative)
-        : ops(ops), identities(ids), is_commutative(is_commutative) {
+    AssociativePattern(std::vector<Expr> ops, std::vector<Expr> ids, bool is_commutative)
+        : ops(std::move(ops)), identities(std::move(ids)), is_commutative(is_commutative) {
     }
     AssociativePattern(Expr op, Expr id, bool is_commutative)
         : ops({op}), identities({id}), is_commutative(is_commutative) {

--- a/src/Associativity.h
+++ b/src/Associativity.h
@@ -12,6 +12,7 @@
 #include "IREquality.h"
 
 #include <functional>
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -66,8 +67,8 @@ struct AssociativeOp {
         Expr expr;
 
         Replacement() = default;
-        Replacement(const std::string &var, Expr expr)
-            : var(var), expr(expr) {
+        Replacement(std::string var, Expr expr)
+            : var(std::move(var)), expr(std::move(expr)) {
         }
 
         bool operator==(const Replacement &other) const {
@@ -90,9 +91,9 @@ struct AssociativeOp {
     AssociativeOp(size_t size)
         : pattern(size), xs(size), ys(size), is_associative(false) {
     }
-    AssociativeOp(const AssociativePattern &p, const std::vector<Replacement> &xs,
-                  const std::vector<Replacement> &ys, bool is_associative)
-        : pattern(p), xs(xs), ys(ys), is_associative(is_associative) {
+    AssociativeOp(AssociativePattern p, std::vector<Replacement> xs,
+                  std::vector<Replacement> ys, bool is_associative)
+        : pattern(std::move(p)), xs(std::move(xs)), ys(std::move(ys)), is_associative(is_associative) {
     }
 
     bool associative() const {

--- a/src/Associativity.h
+++ b/src/Associativity.h
@@ -83,13 +83,11 @@ struct AssociativeOp {
     AssociativePattern pattern;
     std::vector<Replacement> xs;
     std::vector<Replacement> ys;
-    bool is_associative;
+    bool is_associative{false};
 
-    AssociativeOp()
-        : is_associative(false) {
-    }
+    AssociativeOp() = default;
     AssociativeOp(size_t size)
-        : pattern(size), xs(size), ys(size), is_associative(false) {
+        : pattern(size), xs(size), ys(size) {
     }
     AssociativeOp(AssociativePattern p, std::vector<Replacement> xs,
                   std::vector<Replacement> ys, bool is_associative)

--- a/src/AsyncProducers.cpp
+++ b/src/AsyncProducers.cpp
@@ -1,8 +1,10 @@
 #include "AsyncProducers.h"
+
 #include "ExprUsesVar.h"
 #include "IREquality.h"
 #include "IRMutator.h"
 #include "IROperator.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -193,8 +195,8 @@ class GenerateProducerBody : public NoOpCollapsingMutator {
     set<string> inner_semaphores;
 
 public:
-    GenerateProducerBody(const string &f, const vector<Expr> &s, map<string, string> &a)
-        : func(f), sema(s), cloned_acquires(a) {
+    GenerateProducerBody(const string &f, vector<Expr> s, map<string, string> &a)
+        : func(f), sema(std::move(s)), cloned_acquires(a) {
     }
 };
 
@@ -250,8 +252,8 @@ class GenerateConsumerBody : public NoOpCollapsingMutator {
     }
 
 public:
-    GenerateConsumerBody(const string &f, const vector<Expr> &s)
-        : func(f), sema(s) {
+    GenerateConsumerBody(const string &f, vector<Expr> s)
+        : func(f), sema(std::move(s)) {
     }
 };
 

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1838,10 +1838,7 @@ private:
         }
 
     public:
-        int count;
-        CountVars()
-            : count(0) {
-        }
+        int count{0};
     };
 
     // We get better simplification if we directly substitute mins

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <utility>
 
 #include "Bounds.h"
 #include "CSE.h"
@@ -1659,7 +1660,7 @@ class SolveIfThenElse : public IRMutator {
 // (excluding 'skipped_var')
 class CollectVars : public IRGraphVisitor {
 public:
-    string skipped_var;
+    const string &skipped_var;
     set<string> vars;
 
     CollectVars(const string &v)
@@ -1681,7 +1682,7 @@ class BoxesTouched : public IRGraphVisitor {
 
 public:
     BoxesTouched(bool calls, bool provides, string fn, const Scope<Interval> *s, const FuncValueBounds &fb)
-        : func(fn), consider_calls(calls), consider_provides(provides), func_bounds(fb) {
+        : func(std::move(fn)), consider_calls(calls), consider_provides(provides), func_bounds(fb) {
         scope.set_containing_scope(s);
     }
 
@@ -1691,8 +1692,8 @@ private:
     struct VarInstance {
         string var;
         int instance;
-        VarInstance(const string &v, int i)
-            : var(v), instance(i) {
+        VarInstance(string v, int i)
+            : var(std::move(v)), instance(i) {
         }
         VarInstance() = default;
 
@@ -2032,8 +2033,8 @@ private:
 
     struct LetBound {
         string var, min_name, max_name;
-        LetBound(const string &v, const string &min, const string &max)
-            : var(v), min_name(min), max_name(max) {
+        LetBound(string v, string min, string max)
+            : var(std::move(v)), min_name(std::move(min)), max_name(std::move(max)) {
         }
     };
 

--- a/src/Bounds.h
+++ b/src/Bounds.h
@@ -6,6 +6,8 @@
  * and the regions of a function read or written by a statement.
  */
 
+#include <utility>
+
 #include "IROperator.h"
 #include "Interval.h"
 #include "Scope.h"
@@ -58,8 +60,8 @@ struct Box {
     Box(size_t sz)
         : bounds(sz) {
     }
-    Box(const std::vector<Interval> &b)
-        : bounds(b) {
+    Box(std::vector<Interval> b)
+        : bounds(std::move(b)) {
     }
 
     size_t size() const {

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -49,10 +49,7 @@ class DependsOnBoundsInference : public IRVisitor {
     }
 
 public:
-    bool result;
-    DependsOnBoundsInference()
-        : result(false) {
-    }
+    bool result{false};
 };
 
 bool depends_on_bounds_inference(Expr e) {

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -78,7 +79,7 @@ public:
     }
 
 private:
-    string var;
+    const string &var;
     Scope<Interval> scope;
 
     using IRVisitor::visit;
@@ -108,7 +109,7 @@ private:
     }
 };
 
-Interval bounds_of_inner_var(string var, Stmt s) {
+Interval bounds_of_inner_var(const string &var, Stmt s) {
     BoundsOfInnerVar b(var);
     s.accept(&b);
     return b.result;
@@ -190,8 +191,8 @@ public:
         Expr cond;  // Condition on params only (can't depend on loop variable)
         Expr value;
 
-        CondValue(const Expr &c, const Expr &v)
-            : cond(c), value(v) {
+        CondValue(Expr c, Expr v)
+            : cond(std::move(c)), value(std::move(v)) {
         }
     };
 

--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -1,6 +1,7 @@
 #include "CPlusPlusMangle.h"
 
 #include <map>
+#include <utility>
 
 #include "IR.h"
 #include "IROperator.h"
@@ -133,7 +134,7 @@ struct QualsState {
     bool last_is_pointer{false};
 
     const Type &type;
-    const std::string base_mode;
+    const std::string &base_mode;
     std::string result;
 
     bool finished{false};

--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -1,4 +1,5 @@
 #include <map>
+#include <utility>
 
 #include "CSE.h"
 #include "IREquality.h"
@@ -76,8 +77,8 @@ public:
         int use_count = 0;
         // All consumer Exprs for which this is the last child Expr.
         map<ExprWithCompareCache, int> uses;
-        Entry(const Expr &e)
-            : expr(e) {
+        Entry(Expr e)
+            : expr(std::move(e)) {
         }
     };
     vector<std::unique_ptr<Entry>> entries;

--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -311,7 +311,7 @@ namespace {
 // Normalize all names in an expr so that expr compares can be done
 // without worrying about mere name differences.
 class NormalizeVarNames : public IRMutator {
-    int counter;
+    int counter{0};
 
     map<string, string> new_names;
 
@@ -332,11 +332,6 @@ class NormalizeVarNames : public IRMutator {
         Expr value = mutate(let->value);
         Expr body = mutate(let->body);
         return Let::make(new_name, value, body);
-    }
-
-public:
-    NormalizeVarNames()
-        : counter(0) {
     }
 };
 

--- a/src/CanonicalizeGPUVars.cpp
+++ b/src/CanonicalizeGPUVars.cpp
@@ -1,5 +1,6 @@
 #include <cmath>
 #include <sstream>
+#include <utility>
 
 #include "CanonicalizeGPUVars.h"
 #include "CodeGen_GPU_Dev.h"
@@ -29,7 +30,7 @@ string get_block_name(int index) {
 }
 
 class CountGPUBlocksThreads : public IRVisitor {
-    string prefix;  // Producer name + stage
+    const string &prefix;  // Producer name + stage
 
     using IRVisitor::visit;
 

--- a/src/Closure.h
+++ b/src/Closure.h
@@ -42,20 +42,16 @@ public:
         Type type;
 
         /** The dimensionality of the buffer. */
-        uint8_t dimensions;
+        uint8_t dimensions{0};
 
         /** The buffer is read from. */
-        bool read;
+        bool read{false};
 
         /** The buffer is written to. */
-        bool write;
+        bool write{false};
 
         /** The size of the buffer if known, otherwise zero. */
-        size_t size;
-
-        Buffer()
-            : dimensions(0), read(false), write(false), size(0) {
-        }
+        size_t size{0};
     };
 
 protected:

--- a/src/CodeGen_ARM.h
+++ b/src/CodeGen_ARM.h
@@ -5,6 +5,8 @@
  * Defines the code-generator for producing ARM machine code
  */
 
+#include <utility>
+
 #include "CodeGen_Posix.h"
 
 namespace Halide {
@@ -51,7 +53,7 @@ protected:
         Pattern(const std::string &i32, const std::string &i64, int l, Expr p, PatternType t = Simple)
             : intrin32("llvm.arm.neon." + i32),
               intrin64("llvm.aarch64.neon." + i64),
-              intrin_lanes(l), pattern(p), type(t) {
+              intrin_lanes(l), pattern(std::move(p)), type(t) {
         }
     };
     std::vector<Pattern> casts, averagings, negations, multiplies;

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -784,11 +784,9 @@ void CodeGen_D3D12Compute_Dev::add_kernel(Stmt s,
 namespace {
 struct BufferSize {
     string name;
-    size_t size;
+    size_t size{0};
 
-    BufferSize()
-        : size(0) {
-    }
+    BufferSize() = default;
     BufferSize(string name, size_t size)
         : name(std::move(name)), size(size) {
     }

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <iomanip>
 #include <sstream>
+#include <utility>
 
 #include "CodeGen_D3D12Compute_Dev.h"
 #include "CodeGen_Internal.h"
@@ -789,7 +790,7 @@ struct BufferSize {
         : size(0) {
     }
     BufferSize(string name, size_t size)
-        : name(name), size(size) {
+        : name(std::move(name)), size(size) {
     }
 
     bool operator<(const BufferSize &r) const {

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -5,8 +5,7 @@
 namespace Halide {
 namespace Internal {
 
-CodeGen_GPU_Dev::~CodeGen_GPU_Dev() {
-}
+CodeGen_GPU_Dev::~CodeGen_GPU_Dev() = default;
 
 bool CodeGen_GPU_Dev::is_gpu_var(const std::string &name) {
     return is_gpu_block_var(name) || is_gpu_thread_var(name);
@@ -40,11 +39,7 @@ class IsBlockUniform : public IRVisitor {
     }
 
 public:
-    bool result;
-
-    IsBlockUniform()
-        : result(true) {
-    }
+    bool result{true};
 };
 }  // namespace
 

--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -37,14 +37,14 @@ public:
     Expr shared_mem_size;
 
     ExtractBounds()
-        : shared_mem_size(0), found_shared(false) {
+        : shared_mem_size(0) {
         for (int i = 0; i < 4; i++) {
             num_threads[i] = num_blocks[i] = 1;
         }
     }
 
 private:
-    bool found_shared;
+    bool found_shared{false};
 
     using IRVisitor::visit;
 

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -336,9 +336,7 @@ class IdPair {
     Intrinsic::ID i128 = Intrinsic::not_intrinsic;
 
 public:
-    constexpr IdPair()
-        : i64(Intrinsic::not_intrinsic), i128(Intrinsic::not_intrinsic) {
-    }
+    constexpr IdPair() = default;
     constexpr IdPair(Intrinsic::ID i64, Intrinsic::ID i128)
         : i64(i64), i128(i128) {
     }

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -444,11 +444,9 @@ void CodeGen_Metal_Dev::add_kernel(Stmt s,
 namespace {
 struct BufferSize {
     string name;
-    size_t size;
+    size_t size{0};
 
-    BufferSize()
-        : size(0) {
-    }
+    BufferSize() = default;
     BufferSize(string name, size_t size)
         : name(std::move(name)), size(size) {
     }

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <sstream>
+#include <utility>
 
 #include "CodeGen_Internal.h"
 #include "CodeGen_Metal_Dev.h"
@@ -449,7 +450,7 @@ struct BufferSize {
         : size(0) {
     }
     BufferSize(string name, size_t size)
-        : name(name), size(size) {
+        : name(std::move(name)), size(size) {
     }
 
     bool operator<(const BufferSize &r) const {

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <sstream>
+#include <utility>
 
 #include "CSE.h"
 #include "CodeGen_Internal.h"
@@ -666,7 +667,7 @@ struct BufferSize {
         : size(0) {
     }
     BufferSize(string name, size_t size)
-        : name(name), size(size) {
+        : name(std::move(name)), size(size) {
     }
 
     bool operator<(const BufferSize &r) const {

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -661,11 +661,9 @@ void CodeGen_OpenCL_Dev::add_kernel(Stmt s,
 namespace {
 struct BufferSize {
     string name;
-    size_t size;
+    size_t size{0};
 
-    BufferSize()
-        : size(0) {
-    }
+    BufferSize() = default;
     BufferSize(string name, size_t size)
         : name(std::move(name)), size(size) {
     }

--- a/src/Definition.cpp
+++ b/src/Definition.cpp
@@ -15,7 +15,7 @@ using std::vector;
 
 struct DefinitionContents {
     mutable RefCount ref_count;
-    bool is_init;
+    bool is_init{true};
     Expr predicate;
     std::vector<Expr> values, args;
     StageSchedule stage_schedule;
@@ -23,7 +23,7 @@ struct DefinitionContents {
     std::string source_location;
 
     DefinitionContents()
-        : is_init(true), predicate(const_true()) {
+        : predicate(const_true()) {
     }
 
     void accept(IRVisitor *visitor) const {

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -1,5 +1,7 @@
 #include "Deinterleave.h"
 
+#include <utility>
+
 #include "CSE.h"
 #include "Debug.h"
 #include "IREquality.h"
@@ -20,7 +22,7 @@ namespace {
 
 class StoreCollector : public IRMutator {
 public:
-    const std::string store_name;
+    const std::string &store_name;
     const int store_stride, max_stores;
     std::vector<Stmt> &let_stmts;
     std::vector<Stmt> &stores;

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -384,7 +384,7 @@ class Interleaver : public IRMutator {
 
     using IRMutator::visit;
 
-    bool should_deinterleave;
+    bool should_deinterleave{false};
     int num_lanes;
 
     Expr deinterleave_expr(Expr e) {
@@ -738,11 +738,6 @@ class Interleaver : public IRMutator {
                 return Block::make(first, rest);
             }
         }
-    }
-
-public:
-    Interleaver()
-        : should_deinterleave(false) {
     }
 };
 

--- a/src/Derivative.h
+++ b/src/Derivative.h
@@ -11,6 +11,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace Halide {
@@ -24,10 +25,7 @@ public:
     // function name & update_id, for initialization update_id == -1
     using FuncKey = std::pair<std::string, int>;
 
-    explicit Derivative(const std::map<FuncKey, Func> &adjoints_in)
-        : adjoints(adjoints_in) {
-    }
-    explicit Derivative(std::map<FuncKey, Func> &&adjoints_in)
+    explicit Derivative(std::map<FuncKey, Func> adjoints_in)
         : adjoints(std::move(adjoints_in)) {
     }
 

--- a/src/DerivativeUtils.cpp
+++ b/src/DerivativeUtils.cpp
@@ -2,6 +2,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "CSE.h"
@@ -540,7 +541,7 @@ bool is_calling_function(
 struct SubstituteCallArgWithPureArg : public IRMutator {
 public:
     SubstituteCallArgWithPureArg(Func f, int variable_id)
-        : f(f), variable_id(variable_id) {
+        : f(std::move(f)), variable_id(variable_id) {
     }
 
 protected:

--- a/src/DeviceArgument.h
+++ b/src/DeviceArgument.h
@@ -35,11 +35,11 @@ struct DeviceArgument {
      * the expected interpretation of the buffer data (e.g. float vs int),
      * but there is no runtime enforcement of this at present.
      */
-    bool is_buffer;
+    bool is_buffer{false};
 
     /** If is_buffer is true, this is the dimensionality of the buffer.
      * If is_buffer is false, this value is ignored (and should always be set to zero) */
-    uint8_t dimensions;
+    uint8_t dimensions{0};
 
     /** If this is a scalar parameter, then this is its type.
      *
@@ -50,29 +50,22 @@ struct DeviceArgument {
     Type type;
 
     /** The static size of the argument if known, or zero otherwise. */
-    size_t size;
+    size_t size{0};
 
     /** The index of the first element of the argument when packed into a wider
      * type, such as packing scalar floats into vec4 for GLSL. */
-    size_t packed_index;
+    size_t packed_index{0};
 
     /** For buffers, these two variables can be used to specify whether the
      * buffer is read or written. By default, we assume that the argument
      * buffer is read-write and set both flags. */
-    bool read;
-    bool write;
+    bool read{false};
+    bool write{false};
 
     /** Alignment information for integer parameters. */
     ModulusRemainder alignment;
 
-    DeviceArgument()
-        : is_buffer(false),
-          dimensions(0),
-          size(0),
-          packed_index(0),
-          read(false),
-          write(false) {
-    }
+    DeviceArgument() = default;
 
     DeviceArgument(std::string _name,
                    bool _is_buffer,

--- a/src/DeviceArgument.h
+++ b/src/DeviceArgument.h
@@ -5,6 +5,8 @@
  * Defines helpers for passing arguments to separate devices, such as GPUs.
  */
 
+#include <utility>
+
 #include "Closure.h"
 #include "IR.h"
 #include "ModulusRemainder.h"
@@ -72,12 +74,12 @@ struct DeviceArgument {
           write(false) {
     }
 
-    DeviceArgument(const std::string &_name,
+    DeviceArgument(std::string _name,
                    bool _is_buffer,
                    Type _type,
                    uint8_t _dimensions,
                    size_t _size = 0)
-        : name(_name),
+        : name(std::move(_name)),
           is_buffer(_is_buffer),
           dimensions(_dimensions),
           type(_type),

--- a/src/Dimension.cpp
+++ b/src/Dimension.cpp
@@ -1,12 +1,14 @@
 #include "Dimension.h"
+
 #include "IR.h"
 #include "IROperator.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
 
-Dimension::Dimension(const Internal::Parameter &p, int d, Func f)
-    : param(p), d(d), f(f) {
+Dimension::Dimension(Internal::Parameter p, int d, Func f)
+    : param(std::move(p)), d(d), f(std::move(f)) {
     user_assert(param.defined())
         << "Can't access the dimensions of an undefined Parameter\n";
     user_assert(param.is_buffer())

--- a/src/Dimension.h
+++ b/src/Dimension.h
@@ -90,7 +90,7 @@ private:
     /** Construct a Dimension representing dimension d of some
      * Internal::Parameter p. Only friends may construct
      * these. */
-    Dimension(const Internal::Parameter &p, int d, Func f);
+    Dimension(Internal::Parameter p, int d, Func f);
 
     Parameter param;
     int d;

--- a/src/EarlyFree.cpp
+++ b/src/EarlyFree.cpp
@@ -1,4 +1,5 @@
 #include <map>
+#include <utility>
 
 #include "EarlyFree.h"
 #include "ExprUsesVar.h"
@@ -18,7 +19,7 @@ public:
     Stmt last_use;
 
     FindLastUse(string s)
-        : func(s) {
+        : func(std::move(s)) {
     }
 
 private:

--- a/src/Elf.h
+++ b/src/Elf.h
@@ -85,8 +85,8 @@ private:
 
 public:
     Symbol() = default;
-    Symbol(const std::string &name)
-        : name(name) {
+    Symbol(std::string name)
+        : name(std::move(name)) {
     }
 
     /** Accesses the name of this symbol. */
@@ -258,8 +258,8 @@ private:
 
 public:
     Section() = default;
-    Section(const std::string &name, Type type)
-        : name(name), type(type) {
+    Section(std::string name, Type type)
+        : name(std::move(name)), type(type) {
     }
 
     Section &set_name(const std::string &name) {

--- a/src/ExternalCode.h
+++ b/src/ExternalCode.h
@@ -1,6 +1,7 @@
 #ifndef HALIDE_EXTERNAL_CODE_H
 #define HALIDE_EXTERNAL_CODE_H
 
+#include <utility>
 #include <vector>
 
 #include "Expr.h"
@@ -24,8 +25,8 @@ private:
     // Used for debugging and naming the module to llvm.
     std::string nametag;
 
-    ExternalCode(Kind kind, const Target &llvm_target, DeviceAPI device_api, const std::vector<uint8_t> &code, const std::string &name)
-        : kind(kind), llvm_target(llvm_target), device_code_kind(device_api), code(code), nametag(name) {
+    ExternalCode(Kind kind, const Target &llvm_target, DeviceAPI device_api, std::vector<uint8_t> code, std::string name)
+        : kind(kind), llvm_target(llvm_target), device_code_kind(device_api), code(std::move(code)), nametag(std::move(name)) {
     }
 
 public:

--- a/src/Func.h
+++ b/src/Func.h
@@ -20,6 +20,7 @@
 #include "Var.h"
 
 #include <map>
+#include <utility>
 
 namespace Halide {
 
@@ -32,11 +33,11 @@ struct VarOrRVar {
     VarOrRVar(const std::string &n, bool r)
         : var(n), rvar(n), is_rvar(r) {
     }
-    VarOrRVar(const Var &v)
-        : var(v), is_rvar(false) {
+    VarOrRVar(Var v)
+        : var(std::move(v)), is_rvar(false) {
     }
-    VarOrRVar(const RVar &r)
-        : rvar(r), is_rvar(true) {
+    VarOrRVar(RVar r)
+        : rvar(std::move(r)), is_rvar(true) {
     }
     VarOrRVar(const RDom &r)
         : rvar(RVar(r)), is_rvar(true) {
@@ -474,7 +475,7 @@ class FuncRef {
     Stage func_ref_update(Expr e, int init_val);
 
 public:
-    FuncRef(Internal::Function, const std::vector<Expr> &,
+    FuncRef(Internal::Function, std::vector<Expr>,
             int placeholder_pos = -1, int count = 0);
     FuncRef(Internal::Function, const std::vector<Var> &,
             int placeholder_pos = -1, int count = 0);
@@ -583,7 +584,7 @@ class FuncTupleElementRef {
     Tuple values_with_undefs(Expr e) const;
 
 public:
-    FuncTupleElementRef(const FuncRef &ref, const std::vector<Expr> &args, int idx);
+    FuncTupleElementRef(const FuncRef &ref, std::vector<Expr> args, int idx);
 
     /** Use this as the left-hand-side of an update definition of Tuple
      * component 'idx' of a Func (see \ref RDom). The function must

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -278,8 +278,7 @@ namespace {
 static std::atomic<int> rand_counter;
 }
 
-Function::Function() {
-}
+Function::Function() = default;
 
 Function::Function(const FunctionPtr &ptr)
     : contents(ptr) {

--- a/src/Function.h
+++ b/src/Function.h
@@ -30,7 +30,7 @@ struct ExternFuncArgument {
                    BufferArg,
                    ExprArg,
                    ImageParamArg };
-    ArgType arg_type;
+    ArgType arg_type{UndefinedArg};
     Internal::FunctionPtr func;
     Buffer<> buffer;
     Expr expr;
@@ -59,9 +59,7 @@ struct ExternFuncArgument {
         // Scalar params come in via the Expr constructor.
         internal_assert(p.is_buffer());
     }
-    ExternFuncArgument()
-        : arg_type(UndefinedArg) {
-    }
+    ExternFuncArgument() = default;
 
     bool is_func() const {
         return arg_type == FuncArg;

--- a/src/Function.h
+++ b/src/Function.h
@@ -16,6 +16,7 @@
 #include "Util.h"
 
 #include <map>
+#include <utility>
 
 namespace Halide {
 
@@ -36,7 +37,7 @@ struct ExternFuncArgument {
     Internal::Parameter image_param;
 
     ExternFuncArgument(Internal::FunctionPtr f)
-        : arg_type(FuncArg), func(f) {
+        : arg_type(FuncArg), func(std::move(f)) {
     }
 
     template<typename T>
@@ -44,7 +45,7 @@ struct ExternFuncArgument {
         : arg_type(BufferArg), buffer(b) {
     }
     ExternFuncArgument(Expr e)
-        : arg_type(ExprArg), expr(e) {
+        : arg_type(ExprArg), expr(std::move(e)) {
     }
     ExternFuncArgument(int e)
         : arg_type(ExprArg), expr(e) {

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -29,7 +29,7 @@ string shared_mem_name = "__shared";
 }  // namespace
 
 class InjectThreadBarriers : public IRMutator {
-    bool in_threads;
+    bool in_threads{false};
 
     using IRMutator::visit;
 
@@ -67,8 +67,7 @@ class InjectThreadBarriers : public IRMutator {
     }
 
 public:
-    InjectThreadBarriers()
-        : in_threads(false) {
+    InjectThreadBarriers() {
         barrier =
             Evaluate::make(Call::make(Int(32), Call::gpu_thread_barrier,
                                       vector<Expr>(), Call::Intrinsic));
@@ -1149,7 +1148,7 @@ class FuseGPUThreadLoops : public IRMutator {
 };
 
 class ZeroGPULoopMins : public IRMutator {
-    bool in_non_glsl_gpu;
+    bool in_non_glsl_gpu{false};
     using IRMutator::visit;
 
     Stmt visit(const For *op) override {
@@ -1169,11 +1168,6 @@ class ZeroGPULoopMins : public IRMutator {
             stmt = For::make(op->name, 0, op->extent, op->for_type, op->device_api, body);
         }
         return stmt;
-    }
-
-public:
-    ZeroGPULoopMins()
-        : in_non_glsl_gpu(false) {
     }
 };
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -21,9 +21,7 @@ GeneratorContext::GeneratorContext(const Target &t, bool auto_schedule,
       value_tracker(std::make_shared<Internal::ValueTracker>()) {
 }
 
-GeneratorContext::~GeneratorContext() {
-    // nothing
-}
+GeneratorContext::~GeneratorContext() = default;
 
 void GeneratorContext::init_from_context(const Halide::GeneratorContext &context) {
     target.set(context.get_target());
@@ -1643,9 +1641,7 @@ GIOBase::GIOBase(size_t array_size,
     : array_size_(array_size), name_(std::move(name)), kind_(kind), types_(std::move(types)), dims_(dims) {
 }
 
-GIOBase::~GIOBase() {
-    // nothing
-}
+GIOBase::~GIOBase() = default;
 
 bool GIOBase::array_size_defined() const {
     return array_size_ != -1;

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1,6 +1,7 @@
 #include <cmath>
 #include <fstream>
 #include <unordered_map>
+#include <utility>
 
 #include "BoundaryConditions.h"
 #include "Derivative.h"
@@ -190,17 +191,17 @@ std::vector<Expr> parameter_constraints(const Parameter &p) {
 class StubEmitter {
 public:
     StubEmitter(std::ostream &dest,
-                const std::string &generator_registered_name,
+                std::string generator_registered_name,
                 const std::string &generator_stub_name,
                 const std::vector<Internal::GeneratorParamBase *> &generator_params,
-                const std::vector<Internal::GeneratorInputBase *> &inputs,
-                const std::vector<Internal::GeneratorOutputBase *> &outputs)
+                std::vector<Internal::GeneratorInputBase *> inputs,
+                std::vector<Internal::GeneratorOutputBase *> outputs)
         : stream(dest),
-          generator_registered_name(generator_registered_name),
+          generator_registered_name(std::move(generator_registered_name)),
           generator_stub_name(generator_stub_name),
           generator_params(select_generator_params(generator_params)),
-          inputs(inputs),
-          outputs(outputs) {
+          inputs(std::move(inputs)),
+          outputs(std::move(outputs)) {
         namespaces = split_string(generator_stub_name, "::");
         internal_assert(!namespaces.empty());
         if (namespaces[0].empty()) {
@@ -997,8 +998,8 @@ int generate_filter_main(int argc, char **argv, std::ostream &cerr) {
 }
 #endif
 
-GeneratorParamBase::GeneratorParamBase(const std::string &name)
-    : name(name) {
+GeneratorParamBase::GeneratorParamBase(std::string name)
+    : name(std::move(name)) {
     ObjectInstanceRegistry::register_instance(this, 0, ObjectInstanceRegistry::GeneratorParam,
                                               this, nullptr);
 }
@@ -1635,11 +1636,11 @@ void GeneratorBase::check_input_kind(Internal::GeneratorInputBase *in, Internal:
 }
 
 GIOBase::GIOBase(size_t array_size,
-                 const std::string &name,
+                 std::string name,
                  IOKind kind,
-                 const std::vector<Type> &types,
+                 std::vector<Type> types,
                  int dims)
-    : array_size_(array_size), name_(name), kind_(kind), types_(types), dims_(dims) {
+    : array_size_(array_size), name_(std::move(name)), kind_(kind), types_(std::move(types)), dims_(dims) {
 }
 
 GIOBase::~GIOBase() {

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -266,6 +266,7 @@
 #include <sstream>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "ExternalCode.h"
@@ -391,7 +392,7 @@ class GeneratorParamInfo;
 
 class GeneratorParamBase {
 public:
-    explicit GeneratorParamBase(const std::string &name);
+    explicit GeneratorParamBase(std::string name);
     virtual ~GeneratorParamBase();
 
     const std::string name;
@@ -498,8 +499,8 @@ class GeneratorParamImpl : public GeneratorParamBase {
 public:
     using type = T;
 
-    GeneratorParamImpl(const std::string &name, const T &value)
-        : GeneratorParamBase(name), value_(value) {
+    GeneratorParamImpl(const std::string &name, T value)
+        : GeneratorParamBase(name), value_(std::move(value)) {
     }
 
     T value() const {
@@ -1310,8 +1311,8 @@ protected:
     void check_scheduled(const char *m) const;
     Target get_target() const;
 
-    explicit StubOutputBufferBase(const Func &f, std::shared_ptr<GeneratorBase> generator)
-        : f(f), generator(generator) {
+    explicit StubOutputBufferBase(Func f, std::shared_ptr<GeneratorBase> generator)
+        : f(std::move(f)), generator(std::move(generator)) {
     }
     StubOutputBufferBase() = default;
 
@@ -1376,11 +1377,11 @@ public:
     StubInput(const StubInputBuffer<T2> &b)
         : kind_(IOKind::Buffer), parameter_(b.parameter_) {
     }
-    StubInput(const Func &f)
-        : kind_(IOKind::Function), parameter_(), func_(f) {
+    StubInput(Func f)
+        : kind_(IOKind::Function), parameter_(), func_(std::move(f)) {
     }
-    StubInput(const Expr &e)
-        : kind_(IOKind::Scalar), parameter_(), expr_(e) {
+    StubInput(Expr e)
+        : kind_(IOKind::Scalar), parameter_(), expr_(std::move(e)) {
     }
 
 private:
@@ -1447,9 +1448,9 @@ public:
 
 protected:
     GIOBase(size_t array_size,
-            const std::string &name,
+            std::string name,
             IOKind kind,
-            const std::vector<Type> &types,
+            std::vector<Type> types,
             int dims);
 
     friend class GeneratorBase;
@@ -2776,8 +2777,8 @@ private:
             new GeneratorParam_Synthetic<T>(gpname, gio, which, error_msg));
     }
 
-    GeneratorParam_Synthetic(const std::string &name, GIOBase &gio, SyntheticParamType which, const std::string &error_msg = "")
-        : GeneratorParamImpl<T>(name, T()), gio(gio), which(which), error_msg(error_msg) {
+    GeneratorParam_Synthetic(const std::string &name, GIOBase &gio, SyntheticParamType which, std::string error_msg = "")
+        : GeneratorParamImpl<T>(name, T()), gio(gio), which(which), error_msg(std::move(error_msg)) {
     }
 
     template<typename T2 = T, typename std::enable_if<std::is_same<T2, ::Halide::Type>::value>::type * = nullptr>
@@ -2993,11 +2994,11 @@ struct StringOrLoopLevel {
     /*not-explicit*/ StringOrLoopLevel(const char *s)
         : string_value(s) {
     }
-    /*not-explicit*/ StringOrLoopLevel(const std::string &s)
-        : string_value(s) {
+    /*not-explicit*/ StringOrLoopLevel(std::string s)
+        : string_value(std::move(s)) {
     }
-    /*not-explicit*/ StringOrLoopLevel(const LoopLevel &loop_level)
-        : loop_level(loop_level) {
+    /*not-explicit*/ StringOrLoopLevel(LoopLevel loop_level)
+        : loop_level(std::move(loop_level)) {
     }
 };
 using GeneratorParamsMap = std::map<std::string, StringOrLoopLevel>;

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -13,6 +13,7 @@
 #include "Simplify.h"
 #include "Substitute.h"
 #include <unordered_map>
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -169,8 +170,8 @@ struct Pattern {
     int flags;
 
     Pattern() = default;
-    Pattern(const string &intrin, Expr p, int flags = 0)
-        : intrin(intrin), pattern(p), flags(flags) {
+    Pattern(string intrin, Expr p, int flags = 0)
+        : intrin(std::move(intrin)), pattern(std::move(p)), flags(flags) {
     }
 };
 

--- a/src/IREquality.cpp
+++ b/src/IREquality.cpp
@@ -21,7 +21,7 @@ public:
                      GreaterThan };
 
     /** The result of the comparison. Should be Equal, LessThan, or GreaterThan. */
-    CmpResult result;
+    CmpResult result{Equal};
 
     /** Compare two expressions or statements and return the
      * result. Returns the result immediately if it is already
@@ -36,7 +36,7 @@ public:
      * Currently this is only done in common-subexpression
      * elimination. */
     IRComparer(IRCompareCache *c = nullptr)
-        : result(Equal), cache(c) {
+        : cache(c) {
     }
 
 private:

--- a/src/IREquality.h
+++ b/src/IREquality.h
@@ -96,11 +96,9 @@ if (m.contains(ExprWithCompareCache(query, &cache))) {...}
  */
 struct ExprWithCompareCache {
     Expr expr;
-    mutable IRCompareCache *cache;
+    mutable IRCompareCache *cache{nullptr};
 
-    ExprWithCompareCache()
-        : cache(nullptr) {
-    }
+    ExprWithCompareCache() = default;
     ExprWithCompareCache(Expr e, IRCompareCache *c)
         : expr(std::move(e)), cache(c) {
     }

--- a/src/IREquality.h
+++ b/src/IREquality.h
@@ -5,6 +5,8 @@
  * Methods to test Exprs and Stmts for equality of value
  */
 
+#include <utility>
+
 #include "IR.h"
 
 namespace Halide {
@@ -99,8 +101,8 @@ struct ExprWithCompareCache {
     ExprWithCompareCache()
         : cache(nullptr) {
     }
-    ExprWithCompareCache(const Expr &e, IRCompareCache *c)
-        : expr(e), cache(c) {
+    ExprWithCompareCache(Expr e, IRCompareCache *c)
+        : expr(std::move(e)), cache(c) {
     }
 
     /** The comparison uses (and updates) the cache */

--- a/src/IRMatch.cpp
+++ b/src/IRMatch.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <map>
+#include <utility>
 
 #include "IREquality.h"
 #include "IRMatch.h"
@@ -57,10 +58,10 @@ public:
     Expr expr;
 
     IRMatch(Expr e, vector<Expr> &m)
-        : result(true), matches(&m), var_matches(nullptr), expr(e) {
+        : result(true), matches(&m), var_matches(nullptr), expr(std::move(e)) {
     }
     IRMatch(Expr e, map<string, Expr> &m)
-        : result(true), matches(nullptr), var_matches(&m), expr(e) {
+        : result(true), matches(nullptr), var_matches(&m), expr(std::move(e)) {
     }
 
     using IRVisitor::visit;

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -121,10 +121,6 @@ struct MatcherState {
         val = bound_const[i];
         type = bound_const_type[i];
     }
-
-    HALIDE_ALWAYS_INLINE
-    MatcherState() noexcept {
-    }
 };
 
 template<typename T,

--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -5,11 +5,9 @@ namespace Internal {
 
 using std::vector;
 
-IRMutator::IRMutator() {
-}
+IRMutator::IRMutator() = default;
 
-IRMutator::~IRMutator() {
-}
+IRMutator::~IRMutator() = default;
 
 Expr IRMutator::mutate(const Expr &e) {
     return e.defined() ? e.get()->mutate_expr(this) : Expr();

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -167,8 +167,7 @@ ostream &operator<<(ostream &stream, const Target &target) {
 
 namespace Internal {
 
-IRPrinter::~IRPrinter() {
-}
+IRPrinter::~IRPrinter() = default;
 
 void IRPrinter::test() {
     Type i32 = Int(32);

--- a/src/IRVisitor.cpp
+++ b/src/IRVisitor.cpp
@@ -3,11 +3,9 @@
 namespace Halide {
 namespace Internal {
 
-IRVisitor::~IRVisitor() {
-}
+IRVisitor::~IRVisitor() = default;
 
-IRVisitor::IRVisitor() {
-}
+IRVisitor::IRVisitor() = default;
 
 void IRVisitor::visit(const IntImm *) {
 }

--- a/src/InferArguments.cpp
+++ b/src/InferArguments.cpp
@@ -1,5 +1,6 @@
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "IRVisitor.h"
@@ -30,7 +31,7 @@ public:
     }
 
 private:
-    vector<Function> outputs;
+    const vector<Function> &outputs;
     set<string> visited_functions;
 
     using IRGraphVisitor::visit;

--- a/src/InjectHostDevBufferCopies.cpp
+++ b/src/InjectHostDevBufferCopies.cpp
@@ -8,6 +8,7 @@
 #include "Substitute.h"
 
 #include <map>
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -115,7 +116,7 @@ class FindBufferUsage : public IRVisitor {
         current_device_api = old;
     }
 
-    string buffer;
+    const string &buffer;
     DeviceAPI current_device_api;
 
 public:
@@ -139,7 +140,7 @@ class InjectBufferCopiesForSingleBuffer : public IRMutator {
     using IRMutator::visit;
 
     // The buffer being managed
-    string buffer;
+    const string &buffer;
 
     bool is_external;
 
@@ -425,7 +426,7 @@ public:
     }
 
 private:
-    string buffer;
+    const string &buffer;
 
     using IRVisitor::visit;
 
@@ -508,7 +509,7 @@ class InjectBufferCopies : public IRMutator {
 
     public:
         InjectDeviceDestructor(string b)
-            : buffer(b) {
+            : buffer(std::move(b)) {
         }
     };
 
@@ -563,7 +564,7 @@ class InjectBufferCopies : public IRMutator {
 
     public:
         InjectCombinedAllocation(string b, Type t, vector<Expr> e, Expr c, DeviceAPI d)
-            : buffer(b), type(t), extents(e), condition(c), device_api(d) {
+            : buffer(std::move(b)), type(t), extents(std::move(e)), condition(std::move(c)), device_api(d) {
         }
     };
 
@@ -586,7 +587,7 @@ class InjectBufferCopies : public IRMutator {
         }
 
         FreeAfterLastUse(Stmt s, Stmt f)
-            : last_use(s), free_stmt(f) {
+            : last_use(std::move(s)), free_stmt(std::move(f)) {
         }
     };
 
@@ -767,7 +768,7 @@ public:
     }
 
     InjectBufferCopiesForInputsAndOutputs(Stmt s)
-        : site(s) {
+        : site(std::move(s)) {
     }
 };
 

--- a/src/InjectOpenGLIntrinsics.cpp
+++ b/src/InjectOpenGLIntrinsics.cpp
@@ -15,11 +15,8 @@ using std::vector;
 /** Normalizes image loads/stores and produces glsl_texture_load/stores. */
 class InjectOpenGLIntrinsics : public IRMutator {
 public:
-    InjectOpenGLIntrinsics()
-        : inside_kernel_loop(false) {
-    }
     Scope<int> scope;
-    bool inside_kernel_loop;
+    bool inside_kernel_loop{false};
 
 private:
     using IRMutator::visit;

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -2,6 +2,7 @@
 #include <set>
 #include <stdint.h>
 #include <string>
+#include <utility>
 
 #ifdef _WIN32
 #ifdef _MSC_VER
@@ -194,8 +195,8 @@ class HalideJITMemoryManager : public SectionMemoryManager {
     std::vector<std::pair<uint8_t *, size_t>> code_pages;
 
 public:
-    HalideJITMemoryManager(const std::vector<JITModule> &modules)
-        : modules(modules) {
+    HalideJITMemoryManager(std::vector<JITModule> modules)
+        : modules(std::move(modules)) {
     }
 
     uint64_t getSymbolAddress(const std::string &name) override {

--- a/src/LowerWarpShuffles.cpp
+++ b/src/LowerWarpShuffles.cpp
@@ -1,4 +1,5 @@
 #include "LowerWarpShuffles.h"
+
 #include "ExprUsesVar.h"
 #include "IREquality.h"
 #include "IRMatch.h"
@@ -8,6 +9,7 @@
 #include "Simplify.h"
 #include "Solve.h"
 #include "Substitute.h"
+#include <utility>
 
 // In CUDA, allocations stored in registers and shared across lanes
 // look like private per-lane allocations, even though communication
@@ -274,8 +276,8 @@ class DetermineAllocStride : public IRVisitor {
     }
 
 public:
-    DetermineAllocStride(const string &alloc, const string &lane_var, const Expr &warp_size)
-        : alloc(alloc), lane_var(lane_var), warp_size(warp_size) {
+    DetermineAllocStride(const string &alloc, const string &lane_var, Expr warp_size)
+        : alloc(alloc), lane_var(lane_var), warp_size(std::move(warp_size)) {
         dependent_vars.push(lane_var, 1);
     }
 
@@ -739,7 +741,7 @@ class MoveIfStatementInwards : public IRMutator {
 
 public:
     MoveIfStatementInwards(Expr c)
-        : condition(c) {
+        : condition(std::move(c)) {
     }
 };
 

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -17,11 +17,6 @@ namespace {
 
 class FindParameterDependencies : public IRGraphVisitor {
 public:
-    FindParameterDependencies() {
-    }
-    ~FindParameterDependencies() override {
-    }
-
     void visit_function(const Function &function) {
         function.accept(this);
 

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -8,6 +8,7 @@
 #include "Var.h"
 
 #include <map>
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -130,8 +131,8 @@ public:
             return false;
         }
 
-        DependencyKey(uint32_t size_arg, const std::string &name_arg)
-            : size(size_arg), name(name_arg) {
+        DependencyKey(uint32_t size_arg, std::string name_arg)
+            : size(size_arg), name(std::move(name_arg)) {
         }
     };
 

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <fstream>
 #include <future>
+#include <utility>
 
 #include "CodeGen_C.h"
 #include "CodeGen_Internal.h"
@@ -335,20 +336,20 @@ void destroy<ModuleContents>(const ModuleContents *t) {
     delete t;
 }
 
-LoweredFunc::LoweredFunc(const std::string &name,
-                         const std::vector<LoweredArgument> &args,
+LoweredFunc::LoweredFunc(std::string name,
+                         std::vector<LoweredArgument> args,
                          Stmt body,
                          LinkageType linkage,
                          NameMangling name_mangling)
-    : name(name), args(args), body(body), linkage(linkage), name_mangling(name_mangling) {
+    : name(std::move(name)), args(std::move(args)), body(std::move(body)), linkage(linkage), name_mangling(name_mangling) {
 }
 
-LoweredFunc::LoweredFunc(const std::string &name,
+LoweredFunc::LoweredFunc(std::string name,
                          const std::vector<Argument> &args,
                          Stmt body,
                          LinkageType linkage,
                          NameMangling name_mangling)
-    : name(name), body(body), linkage(linkage), name_mangling(name_mangling) {
+    : name(std::move(name)), body(std::move(body)), linkage(linkage), name_mangling(name_mangling) {
     for (const Argument &i : args) {
         this->args.push_back(LoweredArgument(i));
     }

--- a/src/Module.h
+++ b/src/Module.h
@@ -89,12 +89,12 @@ struct LoweredFunc {
      * the Target. */
     NameMangling name_mangling;
 
-    LoweredFunc(const std::string &name,
-                const std::vector<LoweredArgument> &args,
+    LoweredFunc(std::string name,
+                std::vector<LoweredArgument> args,
                 Stmt body,
                 LinkageType linkage,
                 NameMangling mangling = NameMangling::Default);
-    LoweredFunc(const std::string &name,
+    LoweredFunc(std::string name,
                 const std::vector<Argument> &args,
                 Stmt body,
                 LinkageType linkage,

--- a/src/ModulusRemainder.h
+++ b/src/ModulusRemainder.h
@@ -23,14 +23,12 @@ namespace Internal {
  * remainder == 0). */
 
 struct ModulusRemainder {
-    ModulusRemainder()
-        : modulus(1), remainder(0) {
-    }
+    ModulusRemainder() = default;
     ModulusRemainder(int64_t m, int64_t r)
         : modulus(m), remainder(r) {
     }
 
-    int64_t modulus, remainder;
+    int64_t modulus{1}, remainder{0};
 
     // Take a conservatively-large union of two sets. Contains all
     // elements from both sets, and maybe some more stuff.

--- a/src/ObjectInstanceRegistry.h
+++ b/src/ObjectInstanceRegistry.h
@@ -69,14 +69,12 @@ private:
     static ObjectInstanceRegistry &get_registry();
 
     struct InstanceInfo {
-        void *subject_ptr;  // May be different from the this_ptr in the key
-        size_t size;        // May be 0 for params
-        Kind kind;
-        bool registered_for_introspection;
+        void *subject_ptr{nullptr};  // May be different from the this_ptr in the key
+        size_t size{0};              // May be 0 for params
+        Kind kind{Invalid};
+        bool registered_for_introspection{false};
 
-        InstanceInfo()
-            : subject_ptr(nullptr), size(0), kind(Invalid), registered_for_introspection(false) {
-        }
+        InstanceInfo() = default;
         InstanceInfo(size_t size, Kind kind, void *subject_ptr, bool registered_for_introspection)
             : subject_ptr(subject_ptr), size(size), kind(kind), registered_for_introspection(registered_for_introspection) {
         }

--- a/src/OutputImageParam.cpp
+++ b/src/OutputImageParam.cpp
@@ -1,12 +1,14 @@
 #include "OutputImageParam.h"
+
 #include "IROperator.h"
+#include <utility>
 
 namespace Halide {
 
 using Internal::Dimension;
 
-OutputImageParam::OutputImageParam(const Internal::Parameter &p, Argument::Kind k, Func f)
-    : param(p), kind(k), func(f) {
+OutputImageParam::OutputImageParam(Internal::Parameter p, Argument::Kind k, Func f)
+    : param(std::move(p)), kind(k), func(std::move(f)) {
 }
 
 const std::string &OutputImageParam::name() const {

--- a/src/OutputImageParam.h
+++ b/src/OutputImageParam.h
@@ -37,7 +37,7 @@ protected:
                                           bool *placeholder_seen) const;
 
     /** Construct an OutputImageParam that wraps an Internal Parameter object. */
-    OutputImageParam(const Internal::Parameter &p, Argument::Kind k, Func f);
+    OutputImageParam(Internal::Parameter p, Argument::Kind k, Func f);
 
 public:
     /** Construct a null image parameter handle. */

--- a/src/OutputImageParam.h
+++ b/src/OutputImageParam.h
@@ -24,7 +24,7 @@ protected:
     Internal::Parameter param;
 
     /** Is this an input or an output? OutputImageParam is the base class for both. */
-    Argument::Kind kind;
+    Argument::Kind kind{Argument::InputScalar};
 
     /** If Input: Func representation of the ImageParam.
      * If Output: Func that creates this OutputImageParam.
@@ -41,9 +41,7 @@ protected:
 
 public:
     /** Construct a null image parameter handle. */
-    OutputImageParam()
-        : kind(Argument::InputScalar) {
-    }
+    OutputImageParam() = default;
 
     /** Get the name of this Param */
     const std::string &name() const;

--- a/src/ParamMap.h
+++ b/src/ParamMap.h
@@ -50,11 +50,9 @@ public:
 private:
     struct ParamArg {
         Internal::Parameter mapped_param;
-        Buffer<> *buf_out_param;
+        Buffer<> *buf_out_param{nullptr};
 
-        ParamArg()
-            : buf_out_param(nullptr) {
-        }
+        ParamArg() = default;
         ParamArg(const ParamMapping &pm)
             : mapped_param(pm.parameter->type(), false, 0, pm.parameter->name()),
               buf_out_param(nullptr) {
@@ -70,8 +68,7 @@ private:
     void set(const ImageParam &p, Buffer<> &buf, Buffer<> *buf_out_param);
 
 public:
-    ParamMap() {
-    }
+    ParamMap() = default;
 
     ParamMap(const std::initializer_list<ParamMapping> &init);
 

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -1,9 +1,11 @@
 #include "Parameter.h"
+
 #include "Argument.h"
 #include "IR.h"
 #include "IROperator.h"
 #include "ObjectInstanceRegistry.h"
 #include "Simplify.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -25,8 +27,8 @@ struct ParameterContents {
     Expr scalar_min, scalar_max, scalar_estimate;
     const bool is_buffer;
 
-    ParameterContents(Type t, bool b, int d, const std::string &n)
-        : type(t), dimensions(d), name(n), buffer(Buffer<>()), data(0),
+    ParameterContents(Type t, bool b, int d, std::string n)
+        : type(t), dimensions(d), name(std::move(n)), buffer(Buffer<>()), data(0),
           host_alignment(t.bytes()), buffer_constraints(dimensions), is_buffer(b) {
         // stride_constraint[0] defaults to 1. This is important for
         // dense vectorization. You can unset it by setting it to a

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <utility>
 
 #include "Argument.h"
 #include "AutoSchedule.h"
@@ -1299,15 +1300,15 @@ void Pipeline::invalidate_cache() {
 }
 
 JITExtern::JITExtern(Pipeline pipeline)
-    : pipeline_(pipeline) {
+    : pipeline_(std::move(pipeline)) {
 }
 
 JITExtern::JITExtern(Func func)
     : pipeline_(func) {
 }
 
-JITExtern::JITExtern(const ExternCFunction &extern_c_function)
-    : extern_c_function_(extern_c_function) {
+JITExtern::JITExtern(ExternCFunction extern_c_function)
+    : extern_c_function_(std::move(extern_c_function)) {
 }
 
 MachineParams MachineParams::generic() {

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -104,10 +104,10 @@ struct PipelineContents {
 
     std::vector<Stmt> requirements;
 
-    bool trace_pipeline;
+    bool trace_pipeline{false};
 
     PipelineContents()
-        : module("", Target()), trace_pipeline(false) {
+        : module("", Target()) {
         user_context_arg.arg = Argument("__user_context", Argument::InputScalar, type_of<const void *>(), 0, ArgumentEstimates{});
         user_context_arg.param = Parameter(Handle(), false, 0, "__user_context");
     }

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -8,6 +8,7 @@
  */
 
 #include <map>
+#include <utility>
 #include <vector>
 
 #include "ExternalCode.h"
@@ -553,10 +554,10 @@ private:
 public:
     ExternSignature() = default;
 
-    ExternSignature(const Type &ret_type, bool is_void_return, const std::vector<Type> &arg_types)
+    ExternSignature(const Type &ret_type, bool is_void_return, std::vector<Type> arg_types)
         : ret_type_(ret_type),
           is_void_return_(is_void_return),
-          arg_types_(arg_types) {
+          arg_types_(std::move(arg_types)) {
         internal_assert(!(is_void_return && ret_type != Type()));
     }
 
@@ -589,8 +590,8 @@ private:
 public:
     ExternCFunction() = default;
 
-    ExternCFunction(void *address, const ExternSignature &signature)
-        : address_(address), signature_(signature) {
+    ExternCFunction(void *address, ExternSignature signature)
+        : address_(address), signature_(std::move(signature)) {
     }
 
     template<typename RT, typename... Args>
@@ -616,7 +617,7 @@ private:
 public:
     JITExtern(Pipeline pipeline);
     JITExtern(Func func);
-    JITExtern(const ExternCFunction &extern_c_function);
+    JITExtern(ExternCFunction extern_c_function);
 
     template<typename RT, typename... Args>
     JITExtern(RT (*f)(Args... args))

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <map>
 #include <string>
+#include <utility>
 
 #include "Bounds.h"
 #include "ExprUsesVar.h"
@@ -335,7 +336,7 @@ class SplitPrefetch : public IRMutator {
 
 public:
     SplitPrefetch(Expr bytes)
-        : max_byte_size(bytes) {
+        : max_byte_size(std::move(bytes)) {
     }
 };
 

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -2,6 +2,7 @@
 #include <limits>
 #include <map>
 #include <string>
+#include <utility>
 
 #include "CodeGen_Internal.h"
 #include "IRMutator.h"
@@ -25,7 +26,7 @@ public:
 
     vector<int> stack;  // What produce nodes are we currently inside of.
 
-    string pipeline_name;
+    const string &pipeline_name;
 
     InjectProfiling(const string &pipeline_name)
         : pipeline_name(pipeline_name) {
@@ -292,7 +293,7 @@ private:
     }
 };
 
-Stmt inject_profiling(Stmt s, string pipeline_name) {
+Stmt inject_profiling(Stmt s, const string &pipeline_name) {
     InjectProfiling profiling(pipeline_name);
     s = profiling.mutate(s);
 

--- a/src/Profiling.h
+++ b/src/Profiling.h
@@ -36,7 +36,7 @@ namespace Internal {
  * storage flattening, but after all bounds inference.
  *
  */
-Stmt inject_profiling(Stmt, std::string);
+Stmt inject_profiling(Stmt, const std::string &pipeline_name);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -8,6 +8,7 @@
 
 #include "IR.h"
 
+#include <utility>
 #include <vector>
 
 namespace Halide {
@@ -35,14 +36,14 @@ public:
     }
 
     /** Construct an RVar with the given name */
-    explicit RVar(const std::string &n)
-        : _name(n) {
+    explicit RVar(std::string n)
+        : _name(std::move(n)) {
     }
 
     /** Construct a reduction variable with the given name and
      * bounds. Must be a member of the given reduction domain. */
     RVar(Internal::ReductionDomain domain, int index)
-        : _domain(domain), _index(index) {
+        : _domain(std::move(domain)), _index(index) {
     }
 
     /** The minimum value that this variable will take on */

--- a/src/Reduction.cpp
+++ b/src/Reduction.cpp
@@ -95,10 +95,10 @@ struct ReductionDomainContents {
     mutable RefCount ref_count;
     std::vector<ReductionVariable> domain;
     Expr predicate;
-    bool frozen;
+    bool frozen{false};
 
     ReductionDomainContents()
-        : predicate(const_true()), frozen(false) {
+        : predicate(const_true()) {
     }
 
     // Pass an IRVisitor through to all Exprs referenced in the ReductionDomainContents

--- a/src/Reduction.cpp
+++ b/src/Reduction.cpp
@@ -1,4 +1,5 @@
 #include "Reduction.h"
+
 #include "IR.h"
 #include "IREquality.h"
 #include "IRMutator.h"
@@ -6,6 +7,7 @@
 #include "IRVisitor.h"
 #include "Simplify.h"
 #include "Var.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -179,7 +181,7 @@ public:
     Expr predicate;
     const ReductionDomain &domain;
     DropSelfReferences(Expr p, const ReductionDomain &d)
-        : predicate(p), domain(d) {
+        : predicate(std::move(p)), domain(d) {
     }
 };
 }  // namespace

--- a/src/RegionCosts.cpp
+++ b/src/RegionCosts.cpp
@@ -1,10 +1,12 @@
 #include "RegionCosts.h"
+
 #include "FindCalls.h"
 #include "IRMutator.h"
 #include "IRVisitor.h"
 #include "PartitionLoops.h"
 #include "RealizationOrder.h"
 #include "Simplify.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -392,9 +394,9 @@ map<string, Expr> compute_expr_detailed_byte_loads(Expr expr) {
 
 }  // anonymous namespace
 
-RegionCosts::RegionCosts(const map<string, Function> &_env,
-                         const vector<string> &_order)
-    : env(_env), order(_order) {
+RegionCosts::RegionCosts(map<string, Function> _env,
+                         vector<string> _order)
+    : env(std::move(_env)), order(std::move(_order)) {
     for (const auto &kv : env) {
         // Pre-compute the function costs without any inlining.
         func_cost[kv.first] = get_func_cost(kv.second);

--- a/src/RegionCosts.cpp
+++ b/src/RegionCosts.cpp
@@ -301,15 +301,11 @@ class ExprCost : public IRVisitor {
     }
 
 public:
-    int64_t arith;
-    int64_t memory;
+    int64_t arith{0};
+    int64_t memory{0};
     // Detailed breakdown of bytes loaded by the allocation or function
     // they are loaded from.
     map<string, int64_t> detailed_byte_loads;
-
-    ExprCost()
-        : arith(0), memory(0) {
-    }
 };
 
 // Return the number of bytes required to store a single value of the

--- a/src/RegionCosts.h
+++ b/src/RegionCosts.h
@@ -141,8 +141,8 @@ struct RegionCosts {
     /** Construct a region cost object for the pipeline. 'env' is a map of all
      * functions in the pipeline. 'order' is the realization order of functions
      * in the pipeline. The first function to be realized comes first. */
-    RegionCosts(const std::map<std::string, Function> &env,
-                const std::vector<std::string> &order);
+    RegionCosts(std::map<std::string, Function> env,
+                std::vector<std::string> order);
 };
 
 /** Return true if the cost of inlining a function is equivalent to the

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -220,12 +220,11 @@ struct FuncScheduleContents {
     std::vector<Bound> bounds;
     std::vector<Bound> estimates;
     std::map<std::string, Internal::FunctionPtr> wrappers;
-    MemoryType memory_type;
-    bool memoized, async;
+    MemoryType memory_type{MemoryType::Auto};
+    bool memoized{false}, async{false};
 
     FuncScheduleContents()
-        : store_level(LoopLevel::inlined()), compute_level(LoopLevel::inlined()),
-          memory_type(MemoryType::Auto), memoized(false), async(false){};
+        : store_level(LoopLevel::inlined()), compute_level(LoopLevel::inlined()){};
 
     // Pass an IRMutator through to all Exprs referenced in the FuncScheduleContents
     void mutate(IRMutator *mutator) {
@@ -281,15 +280,13 @@ struct StageScheduleContents {
     std::vector<PrefetchDirective> prefetches;
     FuseLoopLevel fuse_level;
     std::vector<FusedPair> fused_pairs;
-    bool touched;
-    bool allow_race_conditions;
-    bool atomic;
-    bool override_atomic_associativity_test;
+    bool touched{false};
+    bool allow_race_conditions{false};
+    bool atomic{false};
+    bool override_atomic_associativity_test{false};
 
     StageScheduleContents()
-        : fuse_level(FuseLoopLevel()), touched(false),
-          allow_race_conditions(false), atomic(false),
-          override_atomic_associativity_test(false) {
+        : fuse_level(FuseLoopLevel()) {
     }
 
     // Pass an IRMutator through to all Exprs referenced in the StageScheduleContents

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -1,9 +1,11 @@
 #include "Schedule.h"
+
 #include "Func.h"
 #include "Function.h"
 #include "IR.h"
 #include "IRMutator.h"
 #include "Var.h"
+#include <utility>
 
 namespace {
 
@@ -31,12 +33,12 @@ struct LoopLevelContents {
     bool is_rvar;
     bool locked;
 
-    LoopLevelContents(const std::string &func_name,
-                      const std::string &var_name,
+    LoopLevelContents(std::string func_name,
+                      std::string var_name,
                       bool is_rvar,
                       int stage_index,
                       bool locked)
-        : func_name(func_name), stage_index(stage_index), var_name(var_name),
+        : func_name(std::move(func_name)), stage_index(stage_index), var_name(std::move(var_name)),
           is_rvar(is_rvar), locked(locked) {
     }
 };

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -10,6 +10,7 @@
 #include "Parameter.h"
 
 #include <map>
+#include <utility>
 
 namespace Halide {
 
@@ -159,7 +160,7 @@ class LoopLevel {
     Internal::IntrusivePtr<Internal::LoopLevelContents> contents;
 
     explicit LoopLevel(Internal::IntrusivePtr<Internal::LoopLevelContents> c)
-        : contents(c) {
+        : contents(std::move(c)) {
     }
     LoopLevel(const std::string &func_name, const std::string &var_name,
               bool is_rvar, int stage_index, bool locked = false);
@@ -250,8 +251,8 @@ struct FuseLoopLevel {
     FuseLoopLevel()
         : level(LoopLevel::inlined().lock()) {
     }
-    FuseLoopLevel(const LoopLevel &level, const std::map<std::string, LoopAlignStrategy> &align)
-        : level(level), align(align) {
+    FuseLoopLevel(LoopLevel level, std::map<std::string, LoopAlignStrategy> align)
+        : level(std::move(level)), align(std::move(align)) {
     }
 };
 
@@ -350,9 +351,9 @@ struct FusedPair {
     std::string var_name;
 
     FusedPair() = default;
-    FusedPair(const std::string &f1, size_t s1, const std::string &f2,
-              size_t s2, const std::string &var)
-        : func_1(f1), func_2(f2), stage_1(s1), stage_2(s2), var_name(var) {
+    FusedPair(std::string f1, size_t s1, std::string f2,
+              size_t s2, std::string var)
+        : func_1(std::move(f1)), func_2(std::move(f2)), stage_1(s1), stage_2(s2), var_name(std::move(var)) {
     }
 
     bool operator==(const FusedPair &other) const {
@@ -399,7 +400,7 @@ class FuncSchedule {
 
 public:
     FuncSchedule(IntrusivePtr<FuncScheduleContents> c)
-        : contents(c) {
+        : contents(std::move(c)) {
     }
     FuncSchedule(const FuncSchedule &other)
         : contents(other.contents) {
@@ -497,7 +498,7 @@ class StageSchedule {
 
 public:
     StageSchedule(IntrusivePtr<StageScheduleContents> c)
-        : contents(c) {
+        : contents(std::move(c)) {
     }
     StageSchedule(const StageSchedule &other)
         : contents(other.contents) {

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -402,9 +402,7 @@ public:
     FuncSchedule(IntrusivePtr<FuncScheduleContents> c)
         : contents(std::move(c)) {
     }
-    FuncSchedule(const FuncSchedule &other)
-        : contents(other.contents) {
-    }
+    FuncSchedule(const FuncSchedule &other) = default;
     FuncSchedule();
 
     /** Return a deep copy of this FuncSchedule. It recursively deep copies all
@@ -500,9 +498,7 @@ public:
     StageSchedule(IntrusivePtr<StageScheduleContents> c)
         : contents(std::move(c)) {
     }
-    StageSchedule(const StageSchedule &other)
-        : contents(other.contents) {
-    }
+    StageSchedule(const StageSchedule &other) = default;
     StageSchedule();
 
     /** Return a copy of this StageSchedule. */

--- a/src/Scope.h
+++ b/src/Scope.h
@@ -263,13 +263,13 @@ struct ScopedBinding {
 
     ScopedBinding() = default;
 
-    ScopedBinding(Scope<T> &s, const std::string &n, const T &value)
-        : scope(&s), name(n) {
+    ScopedBinding(Scope<T> &s, std::string n, const T &value)
+        : scope(&s), name(std::move(n)) {
         scope->push(name, value);
     }
 
-    ScopedBinding(bool condition, Scope<T> &s, const std::string &n, const T &value)
-        : scope(condition ? &s : nullptr), name(n) {
+    ScopedBinding(bool condition, Scope<T> &s, std::string n, const T &value)
+        : scope(condition ? &s : nullptr), name(std::move(n)) {
         if (condition) {
             scope->push(name, value);
         }
@@ -302,12 +302,12 @@ template<>
 struct ScopedBinding<void> {
     Scope<> *scope;
     std::string name;
-    ScopedBinding(Scope<> &s, const std::string &n)
-        : scope(&s), name(n) {
+    ScopedBinding(Scope<> &s, std::string n)
+        : scope(&s), name(std::move(n)) {
         scope->push(name);
     }
-    ScopedBinding(bool condition, Scope<> &s, const std::string &n)
-        : scope(condition ? &s : nullptr), name(n) {
+    ScopedBinding(bool condition, Scope<> &s, std::string n)
+        : scope(condition ? &s : nullptr), name(std::move(n)) {
         if (condition) {
             scope->push(name);
         }

--- a/src/Scope.h
+++ b/src/Scope.h
@@ -197,8 +197,7 @@ public:
             : iter(i) {
         }
 
-        const_iterator() {
-        }
+        const_iterator() = default;
 
         bool operator!=(const const_iterator &other) {
             return iter != other.iter;

--- a/src/SimplifySpecializations.cpp
+++ b/src/SimplifySpecializations.cpp
@@ -7,6 +7,7 @@
 #include "Substitute.h"
 
 #include <set>
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -51,7 +52,7 @@ public:
 
     Expr fact;
     SimplifyUsingFact(Expr f)
-        : fact(f) {
+        : fact(std::move(f)) {
     }
 };
 

--- a/src/SkipStages.cpp
+++ b/src/SkipStages.cpp
@@ -11,6 +11,7 @@
 #include "Substitute.h"
 
 #include <iterator>
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -53,7 +54,7 @@ public:
 
 private:
     using IRVisitor::visit;
-    string buffer;
+    const string &buffer;
     bool varies;
     bool treat_selects_as_guards;
     bool in_produce;
@@ -251,11 +252,11 @@ private:
 class ProductionGuarder : public IRMutator {
 public:
     ProductionGuarder(const string &b, Expr compute_p, Expr alloc_p)
-        : buffer(b), compute_predicate(compute_p), alloc_predicate(alloc_p) {
+        : buffer(b), compute_predicate(std::move(compute_p)), alloc_predicate(std::move(alloc_p)) {
     }
 
 private:
-    string buffer;
+    const string &buffer;
     Expr compute_predicate;
     Expr alloc_predicate;
 
@@ -325,7 +326,7 @@ public:
     }
 
 private:
-    string func;
+    const string &func;
     using IRMutator::visit;
 
     Scope<> vector_vars;

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -1,4 +1,5 @@
 #include "SlidingWindow.h"
+
 #include "Bounds.h"
 #include "Debug.h"
 #include "IRMutator.h"
@@ -8,6 +9,7 @@
 #include "Scope.h"
 #include "Simplify.h"
 #include "Substitute.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -36,9 +38,9 @@ class ExprDependsOnVar : public IRVisitor {
 
 public:
     bool result;
-    string var;
+    const string &var;
 
-    ExprDependsOnVar(string v)
+    ExprDependsOnVar(const string &v)
         : result(false), var(v) {
     }
 };
@@ -83,7 +85,7 @@ Expr expand_expr(Expr e, const Scope<Expr> &scope) {
 // particular serial for loop
 class SlidingWindowOnFunctionAndLoop : public IRMutator {
     Function func;
-    string loop_var;
+    const string &loop_var;
     Expr loop_min;
     Scope<Expr> scope;
 
@@ -329,8 +331,8 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
     }
 
 public:
-    SlidingWindowOnFunctionAndLoop(Function f, string v, Expr v_min)
-        : func(f), loop_var(v), loop_min(v_min) {
+    SlidingWindowOnFunctionAndLoop(Function f, const string &v, Expr v_min)
+        : func(std::move(f)), loop_var(v), loop_min(std::move(v_min)) {
     }
 };
 
@@ -361,7 +363,7 @@ class SlidingWindowOnFunction : public IRMutator {
 
 public:
     SlidingWindowOnFunction(Function f)
-        : func(f) {
+        : func(std::move(f)) {
     }
 };
 

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -1,4 +1,5 @@
 #include "Solve.h"
+
 #include "CSE.h"
 #include "ConciseCasts.h"
 #include "ExprUsesVar.h"
@@ -6,6 +7,7 @@
 #include "IRMutator.h"
 #include "Simplify.h"
 #include "Substitute.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -65,7 +67,7 @@ public:
 
 private:
     // The variable we're solving for.
-    string var;
+    const string &var;
 
     // Whether or not the just-mutated expression uses the variable.
     bool uses_var;

--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -42,10 +42,7 @@ class UsesExternImage : public IRVisitor {
     }
 
 public:
-    UsesExternImage()
-        : result(false) {
-    }
-    bool result;
+    bool result{false};
 };
 
 inline bool uses_extern_image(Stmt s) {

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -1,4 +1,5 @@
 #include "StorageFolding.h"
+
 #include "Bounds.h"
 #include "CSE.h"
 #include "Debug.h"
@@ -9,6 +10,7 @@
 #include "Monotonic.h"
 #include "Simplify.h"
 #include "Substitute.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -151,7 +153,7 @@ class FoldStorageOfFunction : public IRMutator {
 
 public:
     FoldStorageOfFunction(string f, int d, Expr e, string p)
-        : func(f), dim(d), factor(e), dynamic_footprint(p) {
+        : func(std::move(f)), dim(d), factor(std::move(e)), dynamic_footprint(std::move(p)) {
     }
 };
 
@@ -390,8 +392,8 @@ public:
                        string head, string tail,
                        string loop_var, Expr sema_var,
                        int dim, const StorageDim &storage_dim)
-        : func(func),
-          head(head), tail(tail), loop_var(loop_var), sema_var(sema_var),
+        : func(std::move(func)),
+          head(std::move(head)), tail(std::move(tail)), loop_var(std::move(loop_var)), sema_var(std::move(sema_var)),
           dim(dim), storage_dim(storage_dim) {
     }
 };
@@ -817,7 +819,7 @@ public:
     vector<Fold> dims_folded;
 
     AttemptStorageFoldingOfFunction(Function f, bool explicit_only)
-        : func(f), explicit_only(explicit_only) {
+        : func(std::move(f)), explicit_only(explicit_only) {
     }
 };
 

--- a/src/Substitute.cpp
+++ b/src/Substitute.cpp
@@ -1,7 +1,9 @@
 #include "Substitute.h"
+
 #include "IREquality.h"
 #include "IRMutator.h"
 #include "Scope.h"
+#include <utility>
 
 namespace Halide {
 namespace Internal {
@@ -138,8 +140,8 @@ Stmt substitute(const Expr &find, const Expr &replacement, const Stmt &stmt) {
 
 /** Substitute an expr for a var in a graph. */
 class GraphSubstitute : public IRGraphMutator {
-    string var;
-    Expr value;
+    const string &var;
+    const Expr &value;
 
     using IRGraphMutator::visit;
 
@@ -169,7 +171,7 @@ public:
 /** Substitute an Expr for another Expr in a graph. Unlike substitute,
  * this only checks for shallow equality. */
 class GraphSubstituteExpr : public IRGraphMutator {
-    Expr find, replace;
+    const Expr &find, &replace;
 
 public:
     using IRGraphMutator::mutate;

--- a/src/Target.h
+++ b/src/Target.h
@@ -33,7 +33,7 @@ struct Target {
         NoOS,
         Fuchsia,
         WebAssemblyRuntime
-    } os;
+    } os{OSUnknown};
 
     /** The architecture used by the target. Determines the
      * instruction set to use.
@@ -47,10 +47,10 @@ struct Target {
         POWERPC,
         WebAssembly,
         RISCV
-    } arch;
+    } arch{ArchUnknown};
 
     /** The bit-width of the target machine. Must be 0 for unknown, or 32 or 64. */
-    int bits;
+    int bits{0};
 
     /** Optional features a target can have.
      * Corresponds to feature_name_map in Target.cpp.
@@ -123,9 +123,7 @@ struct Target {
         SVE2 = halide_target_feature_sve2,
         FeatureEnd = halide_target_feature_end
     };
-    Target()
-        : os(OSUnknown), arch(ArchUnknown), bits(0) {
-    }
+    Target() = default;
     Target(OS o, Arch a, int b, const std::vector<Feature> &initial_features = std::vector<Feature>())
         : os(o), arch(a), bits(b) {
         for (const auto &f : initial_features) {

--- a/src/TrimNoOps.cpp
+++ b/src/TrimNoOps.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <utility>
 
 #include "CSE.h"
 #include "CodeGen_GPU_Dev.h"
@@ -47,7 +48,7 @@ class LoadsFromBuffer : public IRVisitor {
         }
     }
 
-    string buffer;
+    const string &buffer;
 
 public:
     bool result = false;

--- a/src/Type.h
+++ b/src/Type.h
@@ -7,6 +7,8 @@
 #include "runtime/HalideRuntime.h"
 #include <stdint.h>
 
+#include <utility>
+
 /** \file
  * Defines halide types
  */
@@ -50,8 +52,8 @@ struct halide_cplusplus_type_name {
 
     std::string name;
 
-    halide_cplusplus_type_name(CPPTypeType cpp_type_type, const std::string &name)
-        : cpp_type_type(cpp_type_type), name(name) {
+    halide_cplusplus_type_name(CPPTypeType cpp_type_type, std::string name)
+        : cpp_type_type(cpp_type_type), name(std::move(name)) {
     }
 
     bool operator==(const halide_cplusplus_type_name &rhs) const {
@@ -109,15 +111,15 @@ struct halide_handle_cplusplus_type {
     };
     ReferenceType reference_type;
 
-    halide_handle_cplusplus_type(const halide_cplusplus_type_name &inner_name,
-                                 const std::vector<std::string> &namespaces = {},
-                                 const std::vector<halide_cplusplus_type_name> &enclosing_types = {},
-                                 const std::vector<uint8_t> &modifiers = {},
+    halide_handle_cplusplus_type(halide_cplusplus_type_name inner_name,
+                                 std::vector<std::string> namespaces = {},
+                                 std::vector<halide_cplusplus_type_name> enclosing_types = {},
+                                 std::vector<uint8_t> modifiers = {},
                                  ReferenceType reference_type = NotReference)
-        : inner_name(inner_name),
-          namespaces(namespaces),
-          enclosing_types(enclosing_types),
-          cpp_type_modifiers(modifiers),
+        : inner_name(std::move(inner_name)),
+          namespaces(std::move(namespaces)),
+          enclosing_types(std::move(enclosing_types)),
+          cpp_type_modifiers(std::move(modifiers)),
           reference_type(reference_type) {
     }
 

--- a/src/Type.h
+++ b/src/Type.h
@@ -287,7 +287,7 @@ public:
 
     // Default ctor initializes everything to predictable-but-unlikely values
     Type()
-        : type(Handle, 0, 0), handle_type(nullptr) {
+        : type(Handle, 0, 0) {
     }
 
     /** Construct a runtime representation of a Halide type from:
@@ -356,7 +356,7 @@ public:
     }
 
     /** Type to be printed when declaring handles of this type. */
-    const halide_handle_cplusplus_type *handle_type;
+    const halide_handle_cplusplus_type *handle_type{nullptr};
 
     /** Is this type boolean (represented as UInt(1))? */
     HALIDE_ALWAYS_INLINE

--- a/src/Var.cpp
+++ b/src/Var.cpp
@@ -1,10 +1,12 @@
 #include "Var.h"
+
 #include "Util.h"
+#include <utility>
 
 namespace Halide {
 
-Var::Var(const std::string &n)
-    : _name(n) {
+Var::Var(std::string n)
+    : _name(std::move(n)) {
 }
 
 Var::Var()

--- a/src/Var.h
+++ b/src/Var.h
@@ -19,7 +19,7 @@ class Var {
 
 public:
     /** Construct a Var with the given name */
-    Var(const std::string &n);
+    Var(std::string n);
 
     /** Construct a Var with an automatically-generated unique name. */
     Var();

--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -33,7 +33,7 @@ class FindLinearExpressions : public IRMutator {
 protected:
     using IRMutator::visit;
 
-    bool in_glsl_loops;
+    bool in_glsl_loops{false};
 
     Expr tag_linear_expression(Expr e, const std::string &name = unique_name('a')) {
 
@@ -401,18 +401,14 @@ public:
     unsigned int order;
     bool found;
 
-    unsigned int total_found;
+    unsigned int total_found{0};
 
     // This parameter controls the maximum number of linearly varying
     // expressions halide will pull out of the fragment shader and evaluate per
     // vertex, and allow the GPU to linearly interpolate across the domain. For
     // OpenGL ES 2.0 we can pass 16 vec4 varying attributes, or 64 scalars. Two
     // scalar slots are used by boilerplate code to pass pixel coordinates.
-    const unsigned int max_expressions;
-
-    FindLinearExpressions()
-        : in_glsl_loops(false), total_found(0), max_expressions(62) {
-    }
+    const unsigned int max_expressions{62};
 };
 
 Stmt find_linear_expressions(Stmt s) {

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -32,9 +32,6 @@
 
 namespace {
 struct debug_sink {
-    inline debug_sink() {
-    }
-
     template<typename T>
     inline debug_sink &operator<<(T &&x) {
         return *this;
@@ -1612,8 +1609,8 @@ int WasmModuleContents::run(const void **args) {
     return -1;
 }
 
-WasmModuleContents::~WasmModuleContents() {
 #ifdef WITH_V8
+WasmModuleContents::~WasmModuleContents() {
     if (isolate != nullptr) {
         // TODO: Do we have to do this explicitly, or does disposing the Isolate handle it?
         {
@@ -1627,8 +1624,10 @@ WasmModuleContents::~WasmModuleContents() {
         isolate->Dispose();
     }
     delete array_buffer_allocator;
-#endif
 }
+#else
+WasmModuleContents::~WasmModuleContents() = default;
+#endif
 
 template<>
 RefCount &ref_count<WasmModuleContents>(const WasmModuleContents *p) noexcept {

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -14,6 +14,7 @@
 #include <cmath>
 #include <mutex>
 #include <sstream>
+#include <utility>
 #include <vector>
 
 // clang-format off
@@ -1314,7 +1315,7 @@ struct WasmModuleContents {
 
     WasmModuleContents(
         const Module &module,
-        const std::vector<Argument> &arguments,
+        std::vector<Argument> arguments,
         const std::string &fn_name,
         const JITExternMap &jit_externs,
         const std::vector<JITModule> &extern_deps);
@@ -1326,12 +1327,12 @@ struct WasmModuleContents {
 
 WasmModuleContents::WasmModuleContents(
     const Module &module,
-    const std::vector<Argument> &arguments,
+    std::vector<Argument> arguments,
     const std::string &fn_name,
     const JITExternMap &jit_externs,
     const std::vector<JITModule> &extern_deps)
     : target(module.target()),
-      arguments(arguments),
+      arguments(std::move(arguments)),
       jit_externs(jit_externs),
       extern_deps(extern_deps),
       trampolines(JITModule::make_trampolines_module(get_host_target(), jit_externs, kTrampolineSuffix, extern_deps)) {


### PR DESCRIPTION
Use default member initializers, and either remove or explicitly default the default constructors where possible.

Builds on #4676, so the diff will be large until that is merged.

