### PR TITLE
Remove pointless std::moves, or make them not pointless

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: '-*,modernize-use-override'
+Checks: '-*,modernize-use-override,performance-move-const-arg,performance-noexcept-move-constructor'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/Makefile
+++ b/Makefile
@@ -2297,3 +2297,23 @@ $(BIN_DIR)/HalideTraceDump: $(ROOT_DIR)/util/HalideTraceDump.cpp $(ROOT_DIR)/uti
 format:
 	find "${ROOT_DIR}/apps" "${ROOT_DIR}/src" "${ROOT_DIR}/tools" "${ROOT_DIR}/test" "${ROOT_DIR}/util" "${ROOT_DIR}/python_bindings" -name *.cpp -o -name *.h -o -name *.c | xargs ${CLANG}-format -i -style=file
 
+# Run clang-tidy on the core source files
+$(BUILD_DIR)/compile_commands.json:
+	echo '[' >> $@
+	BD=$(realpath $(BUILD_DIR)); \
+	SD=$(realpath $(SRC_DIR)); \
+	for S in $(SOURCE_FILES); do \
+	echo "{ \"directory\": \"$${BD}\"," >> $@; \
+	echo "  \"command\": \"$(CXX) $(CXX_FLAGS) -c $$SD/$$S -o $$BD/$${S/cpp/o}\"," >> $@; \
+	echo "  \"file\": \"$$SD/$$S\" }," >> $@; \
+	done
+	echo ']' >> $@
+
+.PHONY: clang-tidy
+clang-tidy: $(BUILD_DIR)/compile_commands.json
+	${CLANG}-tidy -extra-arg=-Wno-unknown-warning-option -p $(BUILD_DIR) $(addprefix $(SRC_DIR)/,$(SOURCE_FILES))
+
+.PHONY: clang-tidy-fix
+clang-tidy-fix: $(BUILD_DIR)/compile_commands.json
+	${CLANG}-tidy -extra-arg=-Wno-unknown-warning-option -p $(BUILD_DIR) $(addprefix $(SRC_DIR)/,$(SOURCE_FILES)) -fix-errors
+

--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -601,7 +601,7 @@ Stmt add_image_checks(Stmt s,
     auto prepend_lets = [&](vector<pair<string, Expr>> *lets) {
         while (!lets->empty()) {
             auto &p = lets->back();
-            s = LetStmt::make(std::move(p.first), std::move(p.second), s);
+            s = LetStmt::make(p.first, std::move(p.second), s);
             lets->pop_back();
         }
     };

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -128,6 +128,9 @@ public:
     /** Trivial copy assignment operator. */
     Buffer &operator=(const Buffer &that) = default;
 
+    /** Trivial move assignment operator. */
+    Buffer &operator=(Buffer &&) noexcept = default;
+
     /** Make a Buffer from a Buffer of a different type */
     template<typename T2>
     Buffer(const Buffer<T2> &other)
@@ -137,7 +140,7 @@ public:
 
     /** Move construct from a Buffer of a different type */
     template<typename T2>
-    Buffer(Buffer<T2> &&other) {
+    Buffer(Buffer<T2> &&other) noexcept {
         assert_can_convert_from(other);
         contents = std::move(other.contents);
     }

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -258,7 +258,7 @@ Expr Ramp::make(Expr base, Expr stride, int lanes) {
     node->type = base.type().with_lanes(lanes);
     node->base = std::move(base);
     node->stride = std::move(stride);
-    node->lanes = std::move(lanes);
+    node->lanes = lanes;
     return node;
 }
 

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -20,7 +20,7 @@ namespace Halide {
 // terms, which is the degree plus one.
 namespace {
 
-Expr evaluate_polynomial(const Expr &x, float *coeff, int n) {
+Expr evaluate_polynomial(Expr x, float *coeff, int n) {
     internal_assert(n >= 2);
 
     Expr x2 = x * x;
@@ -1201,7 +1201,7 @@ Expr operator*(Expr a, Expr b) {
     return Internal::Mul::make(std::move(a), std::move(b));
 }
 
-Expr operator*(const Expr &a, int b) {
+Expr operator*(Expr a, int b) {
     user_assert(a.defined()) << "operator* of undefined Expr\n";
     Type t = a.type();
     Internal::check_representable(t, b);
@@ -1262,7 +1262,7 @@ Expr operator%(Expr a, int b) {
     return Internal::Mod::make(std::move(a), Internal::make_const(t, b));
 }
 
-Expr operator%(int a, const Expr &b) {
+Expr operator%(int a, Expr b) {
     user_assert(b.defined()) << "operator% of undefined Expr\n";
     Type t = b.type();
     Internal::check_representable(t, a);
@@ -1394,7 +1394,7 @@ Expr operator&&(Expr a, Expr b) {
     return Internal::And::make(std::move(a), std::move(b));
 }
 
-Expr operator&&(const Expr &a, bool b) {
+Expr operator&&(Expr a, bool b) {
     internal_assert(a.defined()) << "operator&& of undefined Expr\n";
     internal_assert(a.type().is_bool()) << "operator&& of Expr of type " << a.type() << "\n";
     if (b) {
@@ -1404,7 +1404,7 @@ Expr operator&&(const Expr &a, bool b) {
     }
 }
 
-Expr operator&&(bool a, const Expr &b) {
+Expr operator&&(bool a, Expr b) {
     return std::move(b) && a;
 }
 
@@ -1413,7 +1413,7 @@ Expr operator||(Expr a, Expr b) {
     return Internal::Or::make(std::move(a), std::move(b));
 }
 
-Expr operator||(const Expr &a, bool b) {
+Expr operator||(Expr a, bool b) {
     internal_assert(a.defined()) << "operator|| of undefined Expr\n";
     internal_assert(a.type().is_bool()) << "operator|| of Expr of type " << a.type() << "\n";
     if (b) {
@@ -1423,8 +1423,8 @@ Expr operator||(const Expr &a, bool b) {
     }
 }
 
-Expr operator||(bool a, const Expr &b) {
-    return b || a;
+Expr operator||(bool a, Expr b) {
+    return std::move(b) || a;
 }
 
 Expr operator!(Expr a) {

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -580,8 +580,8 @@ Expr operator&&(Expr a, Expr b);
 /** Logical and of an Expr and a bool. Either returns the Expr or an
  * Expr representing false, depending on the bool. */
 // @{
-Expr operator&&(const Expr &a, bool b);
-Expr operator&&(bool a, const Expr &b);
+Expr operator&&(Expr a, bool b);
+Expr operator&&(bool a, Expr b);
 // @}
 
 /** Returns the logical or of the two arguments */
@@ -590,8 +590,8 @@ Expr operator||(Expr a, Expr b);
 /** Logical or of an Expr and a bool. Either returns the Expr or an
  * Expr representing true, depending on the bool. */
 // @{
-Expr operator||(const Expr &a, bool b);
-Expr operator||(bool a, const Expr &b);
+Expr operator||(Expr a, bool b);
+Expr operator||(bool a, Expr b);
 // @}
 
 /** Returns the logical not the argument */

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -399,7 +399,7 @@ Expr operator*(Expr a, Expr b);
 /** Multiply an expression and a constant integer. Coerces the type of the
  * integer to match the type of the expression. Errors if the integer
  * cannot be represented in the type of the expression. */
-Expr operator*(const Expr &a, int b);
+Expr operator*(Expr a, int b);
 
 /** Multiply a constant integer and an expression. Coerces the type of
  * the integer to match the type of the expression. Errors if the
@@ -470,7 +470,7 @@ Expr operator%(Expr a, int b);
 /** Mods a constant integer by an expression. Coerces the type
  * of the integer to match the type of the expression. Errors if the
  * integer cannot be represented in the type of the expression. */
-Expr operator%(int a, const Expr &b);
+Expr operator%(int a, Expr b);
 
 /** Return a boolean expression that tests whether the first argument
  * is greater than the second, after doing any necessary type coercion

--- a/src/Simplify_Add.cpp
+++ b/src/Simplify_Add.cpp
@@ -142,7 +142,7 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
                rewrite(x + ((c0 - x)/c1)*c1, c0 - ((c0 - x) % c1), c1 > 0) ||
                rewrite(x + ((c0 - x)/c1 + y)*c1, y * c1 - ((c0 - x) % c1) + c0, c1 > 0) ||
                rewrite(x + (y + (c0 - x)/c1)*c1, y * c1 - ((c0 - x) % c1) + c0, c1 > 0))))) {
-            return mutate(std::move(rewrite.result), bounds);
+            return mutate(rewrite.result, bounds);
         }
         // clang-format on
 

--- a/src/Simplify_And.cpp
+++ b/src/Simplify_And.cpp
@@ -108,7 +108,7 @@ Expr Simplify::visit(const And *op, ExprInfo *bounds) {
         rewrite(x <= y && x <= z, x <= min(y, z)) ||
         rewrite(y <= x && z <= x, max(y, z) <= x)) {
 
-        return mutate(std::move(rewrite.result), bounds);
+        return mutate(rewrite.result, bounds);
     }
 
     if (a.same_as(op->a) &&

--- a/src/Simplify_Div.cpp
+++ b/src/Simplify_Div.cpp
@@ -212,7 +212,7 @@ Expr Simplify::visit(const Div *op, ExprInfo *bounds) {
                        c2 > 0 && c0 % c2 == 0) ||
                // A very specific pattern that comes up in bounds in upsampling code.
                rewrite((x % 2 + c0) / 2, x % 2 + fold(c0 / 2), c0 % 2 == 1))))) {
-            return mutate(std::move(rewrite.result), bounds);
+            return mutate(rewrite.result, bounds);
         }
         // clang-format on
     }

--- a/src/Simplify_EQ.cpp
+++ b/src/Simplify_EQ.cpp
@@ -28,7 +28,7 @@ Expr Simplify::visit(const EQ *op, ExprInfo *bounds) {
         if (rewrite(x == 1, x)) {
             return rewrite.result;
         } else if (rewrite(x == 0, !x)) {
-            return mutate(std::move(rewrite.result), bounds);
+            return mutate(rewrite.result, bounds);
         } else if (rewrite(x == x, const_true(lanes))) {
             return rewrite.result;
         } else if (a.same_as(op->a) && b.same_as(op->b)) {
@@ -93,7 +93,7 @@ Expr Simplify::visit(const EQ *op, ExprInfo *bounds) {
 
         false) {
 
-        return mutate(std::move(rewrite.result), bounds);
+        return mutate(rewrite.result, bounds);
     }
 
     if (rewrite(c0 == 0, fold(c0 == 0)) ||

--- a/src/Simplify_LT.cpp
+++ b/src/Simplify_LT.cpp
@@ -360,7 +360,7 @@ Expr Simplify::visit(const LT *op, ExprInfo *bounds) {
                       c0 > 0 && (c3 % c0 == 0) &&
                       c1 * (lanes - 1) < c0 &&
                       c1 * (lanes - 1) >= 0)))) {
-            return mutate(std::move(rewrite.result), bounds);
+            return mutate(rewrite.result, bounds);
         }
         // clang-format on
     }

--- a/src/Simplify_Max.cpp
+++ b/src/Simplify_Max.cpp
@@ -205,7 +205,7 @@ Expr Simplify::visit(const Max *op, ExprInfo *bounds) {
 
                rewrite(max(c0 - x, c1), c0 - min(x, fold(c0 - c1))))))) {
 
-            return mutate(std::move(rewrite.result), bounds);
+            return mutate(rewrite.result, bounds);
         }
         // clang-format on
     }

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -208,7 +208,7 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
 
                rewrite(min(c0 - x, c1), c0 - max(x, fold(c0 - c1))))))) {
 
-            return mutate(std::move(rewrite.result), bounds);
+            return mutate(rewrite.result, bounds);
         }
         // clang-format on
     }

--- a/src/Simplify_Mod.cpp
+++ b/src/Simplify_Mod.cpp
@@ -95,7 +95,7 @@ Expr Simplify::visit(const Mod *op, ExprInfo *bounds) {
                rewrite(ramp(x + c0, c2) % broadcast(c1), (ramp(x + fold(c0 % c1), fold(c2 % c1), lanes) % c1), c1 > 0 && (c0 >= c1 || c0 < 0)) ||
                rewrite(ramp(x * c0 + y, c2) % broadcast(c1), ramp(y, fold(c2 % c1), lanes) % c1, c0 % c1 == 0) ||
                rewrite(ramp(y + x * c0, c2) % broadcast(c1), ramp(y, fold(c2 % c1), lanes) % c1, c0 % c1 == 0))))) {
-            return mutate(std::move(rewrite.result), bounds);
+            return mutate(rewrite.result, bounds);
         }
         // clang-format on
     }

--- a/src/Simplify_Mul.cpp
+++ b/src/Simplify_Mul.cpp
@@ -90,7 +90,7 @@ Expr Simplify::visit(const Mul *op, ExprInfo *bounds) {
             rewrite(max(x, y) * min(y, x), y * x) ||
             rewrite(broadcast(x) * broadcast(y), broadcast(x * y, op->type.lanes())) ||
             rewrite(ramp(x, y) * broadcast(z), ramp(x * z, y * z, op->type.lanes()))) {
-            return mutate(std::move(rewrite.result), bounds);
+            return mutate(rewrite.result, bounds);
         }
     }
 

--- a/src/Simplify_Not.cpp
+++ b/src/Simplify_Not.cpp
@@ -22,7 +22,7 @@ Expr Simplify::visit(const Not *op, ExprInfo *bounds) {
     if (rewrite(!broadcast(x), broadcast(!x, op->type.lanes())) ||
         rewrite(!intrin(Call::likely, x), intrin(Call::likely, !x)) ||
         rewrite(!intrin(Call::likely_if_innermost, x), intrin(Call::likely_if_innermost, !x))) {
-        return mutate(std::move(rewrite.result), bounds);
+        return mutate(rewrite.result, bounds);
     }
 
     if (a.same_as(op->a)) {

--- a/src/Simplify_Or.cpp
+++ b/src/Simplify_Or.cpp
@@ -111,7 +111,7 @@ Expr Simplify::visit(const Or *op, ExprInfo *bounds) {
         rewrite(x <= y || x <= z, x <= max(y, z)) ||
         rewrite(y <= x || z <= x, min(y, z) <= x)) {
 
-        return mutate(std::move(rewrite.result), bounds);
+        return mutate(rewrite.result, bounds);
     }
 
     if (a.same_as(op->a) &&

--- a/src/Simplify_Select.cpp
+++ b/src/Simplify_Select.cpp
@@ -123,7 +123,7 @@ Expr Simplify::visit(const Select *op, ExprInfo *bounds) {
                rewrite(select(x, y, true), !x || y) ||
                rewrite(select(x, false, y), !x && y) ||
                rewrite(select(x, true, y), x || y))))) {
-            return mutate(std::move(rewrite.result), bounds);
+            return mutate(rewrite.result, bounds);
         }
         // clang-format on
     }

--- a/src/Simplify_Sub.cpp
+++ b/src/Simplify_Sub.cpp
@@ -273,7 +273,7 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
                rewrite((x + y)/c0 - x/c0, ((x % c0) + y)/c0, c0 > 0) ||
                rewrite(x/c0 - (x - y)/c0, ((y + fold(c0 - 1)) - (x % c0))/c0, c0 > 0) ||
                rewrite((x - y)/c0 - x/c0, ((x % c0) - y)/c0, c0 > 0))))) {
-            return mutate(std::move(rewrite.result), bounds);
+            return mutate(rewrite.result, bounds);
         }
     }
     // clang-format on

--- a/src/Util.h
+++ b/src/Util.h
@@ -340,7 +340,7 @@ struct ScopedValue {
     }
     // allow move but not copy
     ScopedValue(const ScopedValue &that) = delete;
-    ScopedValue(ScopedValue &&that) = default;
+    ScopedValue(ScopedValue &&that) noexcept = default;
 };
 
 // Wrappers for some C++14-isms that are useful and trivially implementable

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -660,7 +660,7 @@ public:
     }
 
     /** Move constructor */
-    Buffer(Buffer<T, D> &&other)
+    Buffer(Buffer<T, D> &&other) noexcept
         : buf(other.buf),
           alloc(other.alloc),
           dev_ref_count(other.dev_ref_count) {
@@ -738,7 +738,7 @@ public:
     }
 
     /** Standard move-assignment operator */
-    Buffer<T, D> &operator=(Buffer<T, D> &&other) {
+    Buffer<T, D> &operator=(Buffer<T, D> &&other) noexcept {
         decref();
         alloc = other.alloc;
         other.alloc = nullptr;


### PR DESCRIPTION
Given the last clang-tidy PR added std::moves everywhere and was met
with a meh, how about a PR that removes pointless std::moves?

These std::move were all from const args or being passed to things that
expect a const ref arg, so they just made a copy anyway and the
std::move gave a false sense that no copy occurred.

This PR either removes the std::move, or fixes the reason that a copy
was occurring. The reasons were:

- A missing move assignment operator for Buffer<>
- some of the things in IROperator taking const-refs where most didn't,
but ~all definitions assumed things were passed by value and used
std::move internally. Just made these uniformly accept Exprs by value.
- LetStmt::make takes a string by const ref
- The simplifier cleverly passing rvalues to mutate, even though mutate
takes a const ref
- We were std::moving an int in IR.cpp

Also made our move constructors / assignment operators noexcept, which
they must be if you want STL containers to move them instead of making
copies, e.g. when a vector resizes.

Enforce both things with a clang-tidy checker. We don't want to
introduce std::moves that do nothing in future, or accidentally leave
off noexcept from our move constructors.