### PR TITLE
Prefer emplace_back(args) to push_back(Constructor(args))

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: '-*,modernize-use-override,performance-move-const-arg,performance-noexcept-move-constructor,performance-unnecessary-value-param,performance-unnecessary-copy-initialization'
+Checks: '-*,modernize-use-override,performance-move-const-arg,modernize-use-emplace,performance-noexcept-move-constructor,performance-unnecessary-value-param,performance-unnecessary-copy-initialization,performance-trivially-destructible'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -330,8 +330,8 @@ Stmt add_image_checks(Stmt s,
             Expr min_required_var = Variable::make(Int(32), min_required_name);
             Expr extent_required_var = Variable::make(Int(32), extent_required_name);
 
-            lets_required.push_back({extent_required_name, extent_required});
-            lets_required.push_back({min_required_name, min_required});
+            lets_required.emplace_back(extent_required_name, extent_required);
+            lets_required.emplace_back(min_required_name, min_required);
 
             Expr actual_max = actual_min + actual_extent - 1;
             Expr max_required = min_required_var + extent_required_var - 1;
@@ -362,7 +362,7 @@ Stmt add_image_checks(Stmt s,
                 stride_required = (Variable::make(Int(32), name + ".stride." + last_dim + ".required") *
                                    Variable::make(Int(32), name + ".extent." + last_dim + ".required"));
             }
-            lets_required.push_back({name + ".stride." + dim + ".required", stride_required});
+            lets_required.emplace_back(name + ".stride." + dim + ".required", stride_required);
 
             // On 32-bit systems, insert checks to make sure the total
             // size of all input and output buffers is <= 2^31 - 1.
@@ -382,13 +382,13 @@ Stmt add_image_checks(Stmt s,
             // Don't repeat extents check for secondary buffers as extents must be the same as for the first one.
             if (!is_secondary_output_buffer) {
                 if (j == 0) {
-                    lets_overflow.push_back({name + ".total_extent." + dim, cast<int64_t>(actual_extent)});
+                    lets_overflow.emplace_back(name + ".total_extent." + dim, cast<int64_t>(actual_extent));
                 } else {
                     max_size = cast<int64_t>(max_size);
                     Expr last_dim = Variable::make(Int(64), name + ".total_extent." + std::to_string(j - 1));
                     Expr this_dim = actual_extent * last_dim;
                     Expr this_dim_var = Variable::make(Int(64), name + ".total_extent." + dim);
-                    lets_overflow.push_back({name + ".total_extent." + dim, this_dim});
+                    lets_overflow.emplace_back(name + ".total_extent." + dim, this_dim);
                     Expr error = Call::make(Int(32), "halide_error_buffer_extents_too_large",
                                             {name, this_dim_var, max_size}, Call::Extern);
                     Stmt check = AssertStmt::make(this_dim_var <= max_size, error);
@@ -488,27 +488,27 @@ Stmt add_image_checks(Stmt s,
             if (stride_constrained.defined()) {
                 // Come up with a suggested stride by passing the
                 // required region through this constraint.
-                constraints.push_back({stride_orig, stride_constrained});
+                constraints.emplace_back(stride_orig, stride_constrained);
                 stride_constrained = substitute(replace_with_required, stride_constrained);
-                lets_proposed.push_back({stride_name + ".proposed", stride_constrained});
+                lets_proposed.emplace_back(stride_name + ".proposed", stride_constrained);
             } else {
-                lets_proposed.push_back({stride_name + ".proposed", stride_required});
+                lets_proposed.emplace_back(stride_name + ".proposed", stride_required);
             }
 
             if (min_constrained.defined()) {
-                constraints.push_back({min_orig, min_constrained});
+                constraints.emplace_back(min_orig, min_constrained);
                 min_constrained = substitute(replace_with_required, min_constrained);
-                lets_proposed.push_back({min_name + ".proposed", min_constrained});
+                lets_proposed.emplace_back(min_name + ".proposed", min_constrained);
             } else {
-                lets_proposed.push_back({min_name + ".proposed", min_required});
+                lets_proposed.emplace_back(min_name + ".proposed", min_required);
             }
 
             if (extent_constrained.defined()) {
-                constraints.push_back({extent_orig, extent_constrained});
+                constraints.emplace_back(extent_orig, extent_constrained);
                 extent_constrained = substitute(replace_with_required, extent_constrained);
-                lets_proposed.push_back({extent_name + ".proposed", extent_constrained});
+                lets_proposed.emplace_back(extent_name + ".proposed", extent_constrained);
             } else {
-                lets_proposed.push_back({extent_name + ".proposed", extent_required});
+                lets_proposed.emplace_back(extent_name + ".proposed", extent_required);
             }
 
             // In bounds inference mode, make sure the proposed
@@ -543,7 +543,7 @@ Stmt add_image_checks(Stmt s,
 
             replace_with_constrained[name] = constrained_var;
 
-            lets_constrained.push_back({name + ".constrained", constraints[i].second});
+            lets_constrained.emplace_back(name + ".constrained", constraints[i].second);
 
             Expr error = 0;
             if (!no_asserts) {

--- a/src/AddParameterChecks.cpp
+++ b/src/AddParameterChecks.cpp
@@ -77,7 +77,7 @@ Stmt add_parameter_checks(const vector<Stmt> &preconditions, Stmt s, const Targe
                 constrained_value = min(constrained_value, param.max_value());
             }
 
-            lets.push_back({constrained_name, constrained_value});
+            lets.emplace_back(constrained_name, constrained_value);
         }
     }
 

--- a/src/ApplySplit.cpp
+++ b/src/ApplySplit.cpp
@@ -60,14 +60,14 @@ vector<ApplySplitResult> apply_split(const Split &split, bool is_update, const s
             string rebased_var_name = prefix + split.old_var + ".rebased";
             Expr rebased_var = Variable::make(Int(32), rebased_var_name);
 
-            result.push_back(ApplySplitResult(
-                prefix + split.old_var, rebased_var + old_min, ApplySplitResult::Substitution));
+            result.emplace_back(
+                prefix + split.old_var, rebased_var + old_min, ApplySplitResult::Substitution);
 
             // Tell Halide to optimize for the case in which this
             // condition is true by partitioning some outer loop.
             Expr cond = likely(rebased_var < old_extent);
-            result.push_back(ApplySplitResult(cond));
-            result.push_back(ApplySplitResult(rebased_var_name, rebased, ApplySplitResult::LetStmt));
+            result.emplace_back(cond);
+            result.emplace_back(rebased_var_name, rebased, ApplySplitResult::LetStmt);
 
         } else if (tail == TailStrategy::ShiftInwards) {
             // Adjust the base downwards to not compute off the
@@ -84,10 +84,10 @@ vector<ApplySplitResult> apply_split(const Split &split, bool is_update, const s
         }
 
         // Substitute in the new expression for the split variable ...
-        result.push_back(ApplySplitResult(old_var_name, base_var + inner, ApplySplitResult::Substitution));
+        result.emplace_back(old_var_name, base_var + inner, ApplySplitResult::Substitution);
         // ... but also define it as a let for the benefit of bounds inference.
-        result.push_back(ApplySplitResult(old_var_name, base_var + inner, ApplySplitResult::LetStmt));
-        result.push_back(ApplySplitResult(base_name, base, ApplySplitResult::LetStmt));
+        result.emplace_back(old_var_name, base_var + inner, ApplySplitResult::LetStmt);
+        result.emplace_back(base_name, base, ApplySplitResult::LetStmt);
 
     } else if (split.is_fuse()) {
         // Define the inner and outer in terms of the fused var
@@ -105,10 +105,10 @@ vector<ApplySplitResult> apply_split(const Split &split, bool is_update, const s
         Expr inner = fused % factor + inner_min;
         Expr outer = fused / factor + outer_min;
 
-        result.push_back(ApplySplitResult(prefix + split.inner, inner, ApplySplitResult::Substitution));
-        result.push_back(ApplySplitResult(prefix + split.outer, outer, ApplySplitResult::Substitution));
-        result.push_back(ApplySplitResult(prefix + split.inner, inner, ApplySplitResult::LetStmt));
-        result.push_back(ApplySplitResult(prefix + split.outer, outer, ApplySplitResult::LetStmt));
+        result.emplace_back(prefix + split.inner, inner, ApplySplitResult::Substitution);
+        result.emplace_back(prefix + split.outer, outer, ApplySplitResult::Substitution);
+        result.emplace_back(prefix + split.inner, inner, ApplySplitResult::LetStmt);
+        result.emplace_back(prefix + split.outer, outer, ApplySplitResult::LetStmt);
 
         // Maintain the known size of the fused dim if
         // possible. This is important for possible later splits.
@@ -120,8 +120,8 @@ vector<ApplySplitResult> apply_split(const Split &split, bool is_update, const s
         }
     } else {
         // rename or purify
-        result.push_back(ApplySplitResult(prefix + split.old_var, outer, ApplySplitResult::Substitution));
-        result.push_back(ApplySplitResult(prefix + split.old_var, outer, ApplySplitResult::LetStmt));
+        result.emplace_back(prefix + split.old_var, outer, ApplySplitResult::Substitution);
+        result.emplace_back(prefix + split.old_var, outer, ApplySplitResult::LetStmt);
     }
 
     return result;
@@ -140,24 +140,24 @@ vector<std::pair<string, Expr>> compute_loop_bounds_after_split(const Split &spl
     if (split.is_split()) {
         Expr inner_extent = split.factor;
         Expr outer_extent = (old_var_max - old_var_min + split.factor) / split.factor;
-        let_stmts.push_back({prefix + split.inner + ".loop_min", 0});
-        let_stmts.push_back({prefix + split.inner + ".loop_max", inner_extent - 1});
-        let_stmts.push_back({prefix + split.inner + ".loop_extent", inner_extent});
-        let_stmts.push_back({prefix + split.outer + ".loop_min", 0});
-        let_stmts.push_back({prefix + split.outer + ".loop_max", outer_extent - 1});
-        let_stmts.push_back({prefix + split.outer + ".loop_extent", outer_extent});
+        let_stmts.emplace_back(prefix + split.inner + ".loop_min", 0);
+        let_stmts.emplace_back(prefix + split.inner + ".loop_max", inner_extent - 1);
+        let_stmts.emplace_back(prefix + split.inner + ".loop_extent", inner_extent);
+        let_stmts.emplace_back(prefix + split.outer + ".loop_min", 0);
+        let_stmts.emplace_back(prefix + split.outer + ".loop_max", outer_extent - 1);
+        let_stmts.emplace_back(prefix + split.outer + ".loop_extent", outer_extent);
     } else if (split.is_fuse()) {
         // Define bounds on the fused var using the bounds on the inner and outer
         Expr inner_extent = Variable::make(Int(32), prefix + split.inner + ".loop_extent");
         Expr outer_extent = Variable::make(Int(32), prefix + split.outer + ".loop_extent");
         Expr fused_extent = inner_extent * outer_extent;
-        let_stmts.push_back({prefix + split.old_var + ".loop_min", 0});
-        let_stmts.push_back({prefix + split.old_var + ".loop_max", fused_extent - 1});
-        let_stmts.push_back({prefix + split.old_var + ".loop_extent", fused_extent});
+        let_stmts.emplace_back(prefix + split.old_var + ".loop_min", 0);
+        let_stmts.emplace_back(prefix + split.old_var + ".loop_max", fused_extent - 1);
+        let_stmts.emplace_back(prefix + split.old_var + ".loop_extent", fused_extent);
     } else if (split.is_rename()) {
-        let_stmts.push_back({prefix + split.outer + ".loop_min", old_var_min});
-        let_stmts.push_back({prefix + split.outer + ".loop_max", old_var_max});
-        let_stmts.push_back({prefix + split.outer + ".loop_extent", old_var_extent});
+        let_stmts.emplace_back(prefix + split.outer + ".loop_min", old_var_min);
+        let_stmts.emplace_back(prefix + split.outer + ".loop_max", old_var_max);
+        let_stmts.emplace_back(prefix + split.outer + ".loop_extent", old_var_extent);
     }
     // Do nothing for purify
 

--- a/src/AssociativeOpsTable.cpp
+++ b/src/AssociativeOpsTable.cpp
@@ -138,22 +138,22 @@ static map<TableKey, vector<AssociativePattern>> pattern_tables;
 
 void populate_ops_table_single_general_add(const vector<Type> &types, vector<AssociativePattern> &table) {
     declare_vars_single(types);
-    table.push_back({x0 + y0, zero_0, true});
+    table.emplace_back(x0 + y0, zero_0, true);
 }
 
 void populate_ops_table_single_general_mul(const vector<Type> &types, vector<AssociativePattern> &table) {
     declare_vars_single(types);
-    table.push_back({x0 * y0, one_0, true});
+    table.emplace_back(x0 * y0, one_0, true);
 }
 
 void populate_ops_table_single_general_max(const vector<Type> &types, vector<AssociativePattern> &table) {
     declare_vars_single(types);
-    table.push_back({max(x0, y0), tmin_0, true});
+    table.emplace_back(max(x0, y0), tmin_0, true);
 }
 
 void populate_ops_table_single_general_min(const vector<Type> &types, vector<AssociativePattern> &table) {
     declare_vars_single(types);
-    table.push_back({min(x0, y0), tmax_0, true});
+    table.emplace_back(min(x0, y0), tmax_0, true);
 }
 
 void populate_ops_table_single_general_sub(const vector<Type> &types, vector<AssociativePattern> &table) {
@@ -199,12 +199,12 @@ void populate_ops_table_double_general_select(const vector<Type> &types, vector<
 
 void populate_ops_table_single_uint1_and(const vector<Type> &types, vector<AssociativePattern> &table) {
     declare_vars_single(types);
-    table.push_back({x0 && y0, one_0, true});
+    table.emplace_back(x0 && y0, one_0, true);
 }
 
 void populate_ops_table_single_uint1_or(const vector<Type> &types, vector<AssociativePattern> &table) {
     declare_vars_single(types);
-    table.push_back({x0 || y0, zero_0, true});
+    table.emplace_back(x0 || y0, zero_0, true);
 }
 
 void populate_ops_table_single_uint8_cast(const vector<Type> &types, vector<AssociativePattern> &table) {
@@ -212,41 +212,41 @@ void populate_ops_table_single_uint8_cast(const vector<Type> &types, vector<Asso
     Expr k0_uint16 = Variable::make(UInt(16), "k0");
     Expr k0_uint32 = Variable::make(UInt(32), "k0");
     Expr k0_uint64 = Variable::make(UInt(64), "k0");
-    table.push_back({cast<uint8_t>(min(cast<uint16_t>(x0 + y0), k0_uint16)), zero_0, true});
-    table.push_back({cast<uint8_t>(min(cast<uint32_t>(x0 + y0), k0_uint32)), zero_0, true});
-    table.push_back({cast<uint8_t>(min(cast<uint64_t>(x0 + y0), k0_uint64)), zero_0, true});
+    table.emplace_back(cast<uint8_t>(min(cast<uint16_t>(x0 + y0), k0_uint16)), zero_0, true);
+    table.emplace_back(cast<uint8_t>(min(cast<uint32_t>(x0 + y0), k0_uint32)), zero_0, true);
+    table.emplace_back(cast<uint8_t>(min(cast<uint64_t>(x0 + y0), k0_uint64)), zero_0, true);
 }
 
 void populate_ops_table_single_uint8_select(const vector<Type> &types, vector<AssociativePattern> &table) {
     declare_vars_single(types);
-    table.push_back({select(x0 > tmax_0 - y0, tmax_0, y0), zero_0, true});  // Saturating add
-    table.push_back({select(x0 < -y0, y0, tmax_0), zero_0, true});          // Saturating add
+    table.emplace_back(select(x0 > tmax_0 - y0, tmax_0, y0), zero_0, true);  // Saturating add
+    table.emplace_back(select(x0 < -y0, y0, tmax_0), zero_0, true);          // Saturating add
 }
 
 void populate_ops_table_single_uint16_cast(const vector<Type> &types, vector<AssociativePattern> &table) {
     declare_vars_single(types);
     Expr k0_uint32 = Variable::make(UInt(32), "k0");
     Expr k0_uint64 = Variable::make(UInt(64), "k0");
-    table.push_back({cast<uint16_t>(min(cast<uint32_t>(x0 + y0), k0_uint32)), zero_0, true});
-    table.push_back({cast<uint16_t>(min(cast<uint64_t>(x0 + y0), k0_uint64)), zero_0, true});
+    table.emplace_back(cast<uint16_t>(min(cast<uint32_t>(x0 + y0), k0_uint32)), zero_0, true);
+    table.emplace_back(cast<uint16_t>(min(cast<uint64_t>(x0 + y0), k0_uint64)), zero_0, true);
 }
 
 void populate_ops_table_single_uint16_select(const vector<Type> &types, vector<AssociativePattern> &table) {
     declare_vars_single(types);
-    table.push_back({select(x0 > tmax_0 - y0, tmax_0, y0), zero_0, true});  // Saturating add
-    table.push_back({select(x0 < -y0, y0, tmax_0), zero_0, true});          // Saturating add
+    table.emplace_back(select(x0 > tmax_0 - y0, tmax_0, y0), zero_0, true);  // Saturating add
+    table.emplace_back(select(x0 < -y0, y0, tmax_0), zero_0, true);          // Saturating add
 }
 
 void populate_ops_table_single_uint32_cast(const vector<Type> &types, vector<AssociativePattern> &table) {
     declare_vars_single(types);
     Expr k0_uint64 = Variable::make(UInt(64), "k0");
-    table.push_back({cast<uint32_t>(min(cast<uint64_t>(x0 + y0), k0_uint64)), zero_0, true});
+    table.emplace_back(cast<uint32_t>(min(cast<uint64_t>(x0 + y0), k0_uint64)), zero_0, true);
 }
 
 void populate_ops_table_single_uint32_select(const vector<Type> &types, vector<AssociativePattern> &table) {
     declare_vars_single(types);
-    table.push_back({select(x0 > tmax_0 - y0, tmax_0, y0), zero_0, true});  // Saturating add
-    table.push_back({select(x0 < -y0, y0, tmax_0), zero_0, true});          // Saturating add
+    table.emplace_back(select(x0 > tmax_0 - y0, tmax_0, y0), zero_0, true);  // Saturating add
+    table.emplace_back(select(x0 < -y0, y0, tmax_0), zero_0, true);          // Saturating add
 }
 
 static const map<TableKey, void (*)(const vector<Type> &types, vector<AssociativePattern> &)> val_type_to_populate_luts_fn = {

--- a/src/Associativity.cpp
+++ b/src/Associativity.cpp
@@ -202,7 +202,7 @@ bool find_match(const vector<AssociativePattern> &table, const vector<string> &o
 
             assoc_op.xs[index] = {op_x_names[index], x_parts[index]};
             assoc_op.ys[index] = {op_y_names[index], y_part};
-            replacement.push_back({y_part, Variable::make(y_part.type(), op_y_names[index])});
+            replacement.emplace_back(y_part, Variable::make(y_part.type(), op_y_names[index]));
         }
         if (!matched) {
             continue;

--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -1450,7 +1450,7 @@ Partitioner::choose_candidate_grouping(const vector<pair<string, string>> &cands
                 grouping_cache.emplace(cand_choice, best_config);
             }
 
-            grouping.push_back(make_pair(cand_choice, best_config));
+            grouping.emplace_back(cand_choice, best_config);
         }
 
         bool no_redundant_work = false;
@@ -1679,10 +1679,10 @@ void Partitioner::group(Partitioner::Level level) {
                 if ((num_children == 1) && (level == Partitioner::Level::FastMem)) {
                     const string &prod_name = prod_f.name();
                     const string &cons_name = (*child_groups.begin());
-                    cand.push_back(make_pair(prod_name, cons_name));
+                    cand.emplace_back(prod_name, cons_name);
                 } else if ((level == Partitioner::Level::Inline) && prod_f.is_pure()) {
                     const string &prod_name = prod_f.name();
-                    cand.push_back(make_pair(prod_name, ""));
+                    cand.emplace_back(prod_name, "");
                 }
             }
         }
@@ -2969,7 +2969,7 @@ Partitioner::analyze_spatial_locality(const FStage &stg,
     vector<pair<string, vector<Expr>>> &call_args = find.call_args;
     // Account for the spatial locality of the store. Add the access on the
     // left hand side to call_args.
-    call_args.push_back(make_pair(stg.func.name(), def.args()));
+    call_args.emplace_back(stg.func.name(), def.args());
 
     // Map for holding the strides across each dimension
     map<string, Expr> var_strides;

--- a/src/AutoScheduleUtils.h
+++ b/src/AutoScheduleUtils.h
@@ -29,7 +29,7 @@ class FindAllCalls : public IRVisitor {
     void visit(const Call *call) override {
         if (call->call_type == Call::Halide || call->call_type == Call::Image) {
             funcs_called.insert(call->name);
-            call_args.push_back(std::make_pair(call->name, call->args));
+            call_args.emplace_back(call->name, call->args);
         }
         for (size_t i = 0; i < call->args.size(); i++) {
             call->args[i].accept(this);

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -294,7 +294,7 @@ public:
                                  << "(" << val << ") are equal, combine them together\n";
                         internal_assert(val.defined());
                         vec.clear();
-                        vec.push_back(CondValue(const_true(), val));
+                        vec.emplace_back(const_true(), val);
                     }
                 }
             }
@@ -322,7 +322,7 @@ public:
             exprs = result[0];
 
             if (func.extern_definition_proxy_expr().defined()) {
-                exprs.push_back(CondValue(const_true(), func.extern_definition_proxy_expr()));
+                exprs.emplace_back(const_true(), func.extern_definition_proxy_expr());
             }
 
             exprs.insert(exprs.end(), result[1].begin(), result[1].end());
@@ -617,7 +617,7 @@ public:
                         builder.dimensions = input.dimensions();
                         Expr buf = builder.build();
 
-                        lets.push_back({name, buf});
+                        lets.emplace_back(name, buf);
                         bounds_inference_args.push_back(Variable::make(type_of<struct halide_buffer_t *>(), name));
                         buffers_to_annotate.emplace_back(bounds_inference_args.back(), input.dimensions());
                     }
@@ -640,7 +640,7 @@ public:
                     query_buf = Call::make(type_of<struct halide_buffer_t *>(), Call::buffer_init_from_buffer,
                                            {query_buf, query_shape, in_buf}, Call::Extern);
 
-                    lets.push_back({query_name, query_buf});
+                    lets.emplace_back(query_name, query_buf);
                     Expr buf = Variable::make(type_of<struct halide_buffer_t *>(), query_name, b, p, ReductionDomain());
                     bounds_inference_args.push_back(buf);
                     // Although we expect ImageParams to be properly initialized and sanitized by the caller,
@@ -663,7 +663,7 @@ public:
                     Expr max = Variable::make(Int(32), prefix + ".max");
                     builder.mins.push_back(min);
                     builder.extents.push_back(max + 1 - min);
-                    builder.strides.push_back(0);
+                    builder.strides.emplace_back(0);
                 }
                 Expr output_buffer_t = builder.build();
 
@@ -672,7 +672,7 @@ public:
                 // Since this is a temporary, internal-only buffer used for bounds inference,
                 // we need to mark it
                 buffers_to_annotate.emplace_back(bounds_inference_args.back(), func.dimensions());
-                lets.push_back({buf_name, output_buffer_t});
+                lets.emplace_back(buf_name, output_buffer_t);
             }
 
             Stmt annotate;
@@ -988,7 +988,7 @@ public:
             }
 
             body = let->body;
-            lets.push_back({let->name, let->value});
+            lets.emplace_back(let->name, let->value);
         }
 
         // If there are no pipelines at this loop level, we can skip

--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -954,17 +954,17 @@ void cplusplus_mangle_test() {
     {
         // Test all primitive types.
         std::vector<ExternFuncArgument> args;
-        args.push_back(ExternFuncArgument(make_zero(Bool())));
-        args.push_back(ExternFuncArgument(make_zero(Int(8))));
-        args.push_back(ExternFuncArgument(make_zero(UInt(8))));
-        args.push_back(ExternFuncArgument(make_zero(Int(16))));
-        args.push_back(ExternFuncArgument(make_zero(UInt(16))));
-        args.push_back(ExternFuncArgument(make_zero(Int(32))));
-        args.push_back(ExternFuncArgument(make_zero(UInt(32))));
-        args.push_back(ExternFuncArgument(make_zero(Int(64))));
-        args.push_back(ExternFuncArgument(make_zero(UInt(64))));
-        args.push_back(ExternFuncArgument(make_zero(Float(32))));
-        args.push_back(ExternFuncArgument(make_zero(Float(64))));
+        args.emplace_back(make_zero(Bool()));
+        args.emplace_back(make_zero(Int(8)));
+        args.emplace_back(make_zero(UInt(8)));
+        args.emplace_back(make_zero(Int(16)));
+        args.emplace_back(make_zero(UInt(16)));
+        args.emplace_back(make_zero(Int(32)));
+        args.emplace_back(make_zero(UInt(32)));
+        args.emplace_back(make_zero(Int(64)));
+        args.emplace_back(make_zero(UInt(64)));
+        args.emplace_back(make_zero(Float(32)));
+        args.emplace_back(make_zero(Float(64)));
 
         size_t expecteds_index = 0;
         for (const auto &target : targets) {
@@ -989,7 +989,7 @@ void cplusplus_mangle_test() {
             type_info.push_back(t);
         }
         for (int i = 0; i < 200; i++) {
-            args.push_back(make_zero(Handle(1, &type_info[i % 100])));
+            args.emplace_back(make_zero(Handle(1, &type_info[i % 100])));
         }
 
         size_t expecteds_index = 0;
@@ -1015,7 +1015,7 @@ void cplusplus_mangle_test() {
             type_info.push_back(t);
         }
         for (int i = 0; i < 50; i++) {
-            args.push_back(make_zero(Handle(1, &type_info[i % 25])));
+            args.emplace_back(make_zero(Handle(1, &type_info[i % 25])));
         }
 
         size_t expecteds_index = 0;
@@ -1041,7 +1041,7 @@ void cplusplus_mangle_test() {
             type_info.push_back(t);
         }
         for (const auto &ti : type_info) {
-            args.push_back(ExternFuncArgument(make_zero(Handle(1, &ti))));
+            args.emplace_back(make_zero(Handle(1, &ti)));
         }
         size_t expecteds_index = 0;
         for (const auto &target : targets) {
@@ -1062,9 +1062,9 @@ void cplusplus_mangle_test() {
                 halide_handle_cplusplus_type t3(halide_handle_cplusplus_type(
                     halide_cplusplus_type_name(halide_cplusplus_type_name::Struct, "s"), {}, {}, {mods}, halide_handle_cplusplus_type::RValueReference));
                 std::vector<ExternFuncArgument> args;
-                args.push_back(make_zero(Handle(1, &t1)));
-                args.push_back(make_zero(Handle(1, &t2)));
-                args.push_back(make_zero(Handle(1, &t3)));
+                args.emplace_back(make_zero(Handle(1, &t1)));
+                args.emplace_back(make_zero(Handle(1, &t2)));
+                args.emplace_back(make_zero(Handle(1, &t3)));
 
                 MangleResult *expecteds = (target.os == Target::Windows) ? (target.bits == 64 ? all_mods_win64 : all_mods_win32) : all_mods_itanium;
                 check_result(expecteds, expecteds_index, target,
@@ -1079,8 +1079,8 @@ void cplusplus_mangle_test() {
         for (const auto &target : targets) {
             size_t expecteds_index = 0;
             std::vector<ExternFuncArgument> args;
-            args.push_back(make_zero(Handle(1, nullptr)));
-            args.push_back(make_zero(Handle(1, nullptr)));
+            args.emplace_back(make_zero(Handle(1, nullptr)));
+            args.emplace_back(make_zero(Handle(1, nullptr)));
 
             MangleResult *expecteds = (target.os == Target::Windows) ? (target.bits == 64 ? two_void_stars_win64 : two_void_stars_win32) : two_void_stars_itanium;
             check_result(expecteds, expecteds_index, target,

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -147,106 +147,106 @@ CodeGen_ARM::CodeGen_ARM(Target target)
         }
     }
 
-    casts.push_back(Pattern("vqrdmulh.v4i16", "sqrdmulh.v4i16", 4,
-                            i16_sat((wild_i32x4 * wild_i32x4 + (1 << 14)) / (1 << 15)),
-                            Pattern::NarrowArgs));
-    casts.push_back(Pattern("vqrdmulh.v8i16", "sqrdmulh.v8i16", 8,
-                            i16_sat((wild_i32x_ * wild_i32x_ + (1 << 14)) / (1 << 15)),
-                            Pattern::NarrowArgs));
-    casts.push_back(Pattern("vqrdmulh.v2i32", "sqrdmulh.v2i32", 2,
-                            i32_sat((wild_i64x2 * wild_i64x2 + (1 << 30)) / Expr(int64_t(1) << 31)),
-                            Pattern::NarrowArgs));
-    casts.push_back(Pattern("vqrdmulh.v4i32", "sqrdmulh.v4i32", 4,
-                            i32_sat((wild_i64x_ * wild_i64x_ + (1 << 30)) / Expr(int64_t(1) << 31)),
-                            Pattern::NarrowArgs));
+    casts.emplace_back("vqrdmulh.v4i16", "sqrdmulh.v4i16", 4,
+                       i16_sat((wild_i32x4 * wild_i32x4 + (1 << 14)) / (1 << 15)),
+                       Pattern::NarrowArgs);
+    casts.emplace_back("vqrdmulh.v8i16", "sqrdmulh.v8i16", 8,
+                       i16_sat((wild_i32x_ * wild_i32x_ + (1 << 14)) / (1 << 15)),
+                       Pattern::NarrowArgs);
+    casts.emplace_back("vqrdmulh.v2i32", "sqrdmulh.v2i32", 2,
+                       i32_sat((wild_i64x2 * wild_i64x2 + (1 << 30)) / Expr(int64_t(1) << 31)),
+                       Pattern::NarrowArgs);
+    casts.emplace_back("vqrdmulh.v4i32", "sqrdmulh.v4i32", 4,
+                       i32_sat((wild_i64x_ * wild_i64x_ + (1 << 30)) / Expr(int64_t(1) << 31)),
+                       Pattern::NarrowArgs);
 
-    casts.push_back(Pattern("vqshiftns.v8i8", "sqshrn.v8i8", 8, i8_sat(wild_i16x_ / wild_i16x_), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftns.v4i16", "sqshrn.v4i16", 4, i16_sat(wild_i32x_ / wild_i32x_), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftns.v2i32", "sqshrn.v2i32", 2, i32_sat(wild_i64x_ / wild_i64x_), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftnu.v8i8", "uqshrn.v8i8", 8, u8_sat(wild_u16x_ / wild_u16x_), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftnu.v4i16", "uqshrn.v4i16", 4, u16_sat(wild_u32x_ / wild_u32x_), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftnu.v2i32", "uqshrn.v2i32", 2, u32_sat(wild_u64x_ / wild_u64x_), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftnsu.v8i8", "sqshrun.v8i8", 8, u8_sat(wild_i16x_ / wild_i16x_), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftnsu.v4i16", "sqshrun.v4i16", 4, u16_sat(wild_i32x_ / wild_i32x_), Pattern::RightShift));
-    casts.push_back(Pattern("vqshiftnsu.v2i32", "sqshrun.v2i32", 2, u32_sat(wild_i64x_ / wild_i64x_), Pattern::RightShift));
+    casts.emplace_back("vqshiftns.v8i8", "sqshrn.v8i8", 8, i8_sat(wild_i16x_ / wild_i16x_), Pattern::RightShift);
+    casts.emplace_back("vqshiftns.v4i16", "sqshrn.v4i16", 4, i16_sat(wild_i32x_ / wild_i32x_), Pattern::RightShift);
+    casts.emplace_back("vqshiftns.v2i32", "sqshrn.v2i32", 2, i32_sat(wild_i64x_ / wild_i64x_), Pattern::RightShift);
+    casts.emplace_back("vqshiftnu.v8i8", "uqshrn.v8i8", 8, u8_sat(wild_u16x_ / wild_u16x_), Pattern::RightShift);
+    casts.emplace_back("vqshiftnu.v4i16", "uqshrn.v4i16", 4, u16_sat(wild_u32x_ / wild_u32x_), Pattern::RightShift);
+    casts.emplace_back("vqshiftnu.v2i32", "uqshrn.v2i32", 2, u32_sat(wild_u64x_ / wild_u64x_), Pattern::RightShift);
+    casts.emplace_back("vqshiftnsu.v8i8", "sqshrun.v8i8", 8, u8_sat(wild_i16x_ / wild_i16x_), Pattern::RightShift);
+    casts.emplace_back("vqshiftnsu.v4i16", "sqshrun.v4i16", 4, u16_sat(wild_i32x_ / wild_i32x_), Pattern::RightShift);
+    casts.emplace_back("vqshiftnsu.v2i32", "sqshrun.v2i32", 2, u32_sat(wild_i64x_ / wild_i64x_), Pattern::RightShift);
 
     // Where a 64-bit and 128-bit version exist, we use the 64-bit
     // version only when the args are 64-bits wide.
-    casts.push_back(Pattern("vqshifts.v8i8", "sqshl.v8i8", 8, i8_sat(i16(wild_i8x8) * wild_i16x8), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshifts.v4i16", "sqshl.v4i16", 4, i16_sat(i32(wild_i16x4) * wild_i32x4), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshifts.v2i32", "sqshl.v2i32", 2, i32_sat(i64(wild_i32x2) * wild_i64x2), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftu.v8i8", "uqshl.v8i8", 8, u8_sat(u16(wild_u8x8) * wild_u16x8), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftu.v4i16", "uqshl.v4i16", 4, u16_sat(u32(wild_u16x4) * wild_u32x4), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftu.v2i32", "uqshl.v2i32", 2, u32_sat(u64(wild_u32x2) * wild_u64x2), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftsu.v8i8", "sqshlu.v8i8", 8, u8_sat(i16(wild_i8x8) * wild_i16x8), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftsu.v4i16", "sqshlu.v4i16", 4, u16_sat(i32(wild_i16x4) * wild_i32x4), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftsu.v2i32", "sqshlu.v2i32", 2, u32_sat(i64(wild_i32x2) * wild_i64x2), Pattern::LeftShift));
+    casts.emplace_back("vqshifts.v8i8", "sqshl.v8i8", 8, i8_sat(i16(wild_i8x8) * wild_i16x8), Pattern::LeftShift);
+    casts.emplace_back("vqshifts.v4i16", "sqshl.v4i16", 4, i16_sat(i32(wild_i16x4) * wild_i32x4), Pattern::LeftShift);
+    casts.emplace_back("vqshifts.v2i32", "sqshl.v2i32", 2, i32_sat(i64(wild_i32x2) * wild_i64x2), Pattern::LeftShift);
+    casts.emplace_back("vqshiftu.v8i8", "uqshl.v8i8", 8, u8_sat(u16(wild_u8x8) * wild_u16x8), Pattern::LeftShift);
+    casts.emplace_back("vqshiftu.v4i16", "uqshl.v4i16", 4, u16_sat(u32(wild_u16x4) * wild_u32x4), Pattern::LeftShift);
+    casts.emplace_back("vqshiftu.v2i32", "uqshl.v2i32", 2, u32_sat(u64(wild_u32x2) * wild_u64x2), Pattern::LeftShift);
+    casts.emplace_back("vqshiftsu.v8i8", "sqshlu.v8i8", 8, u8_sat(i16(wild_i8x8) * wild_i16x8), Pattern::LeftShift);
+    casts.emplace_back("vqshiftsu.v4i16", "sqshlu.v4i16", 4, u16_sat(i32(wild_i16x4) * wild_i32x4), Pattern::LeftShift);
+    casts.emplace_back("vqshiftsu.v2i32", "sqshlu.v2i32", 2, u32_sat(i64(wild_i32x2) * wild_i64x2), Pattern::LeftShift);
 
     // We use the 128-bit version for all other vector widths.
-    casts.push_back(Pattern("vqshifts.v16i8", "sqshl.v16i8", 16, i8_sat(i16(wild_i8x_) * wild_i16x_), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshifts.v8i16", "sqshl.v8i16", 8, i16_sat(i32(wild_i16x_) * wild_i32x_), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshifts.v4i32", "sqshl.v4i32", 4, i32_sat(i64(wild_i32x_) * wild_i64x_), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftu.v16i8", "uqshl.v16i8", 16, u8_sat(u16(wild_u8x_) * wild_u16x_), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftu.v8i16", "uqshl.v8i16", 8, u16_sat(u32(wild_u16x_) * wild_u32x_), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftu.v4i32", "uqshl.v4i32", 4, u32_sat(u64(wild_u32x_) * wild_u64x_), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftsu.v16i8", "sqshlu.v16i8", 16, u8_sat(i16(wild_i8x_) * wild_i16x_), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftsu.v8i16", "sqshlu.v8i16", 8, u16_sat(i32(wild_i16x_) * wild_i32x_), Pattern::LeftShift));
-    casts.push_back(Pattern("vqshiftsu.v4i32", "sqshlu.v4i32", 4, u32_sat(i64(wild_i32x_) * wild_i64x_), Pattern::LeftShift));
+    casts.emplace_back("vqshifts.v16i8", "sqshl.v16i8", 16, i8_sat(i16(wild_i8x_) * wild_i16x_), Pattern::LeftShift);
+    casts.emplace_back("vqshifts.v8i16", "sqshl.v8i16", 8, i16_sat(i32(wild_i16x_) * wild_i32x_), Pattern::LeftShift);
+    casts.emplace_back("vqshifts.v4i32", "sqshl.v4i32", 4, i32_sat(i64(wild_i32x_) * wild_i64x_), Pattern::LeftShift);
+    casts.emplace_back("vqshiftu.v16i8", "uqshl.v16i8", 16, u8_sat(u16(wild_u8x_) * wild_u16x_), Pattern::LeftShift);
+    casts.emplace_back("vqshiftu.v8i16", "uqshl.v8i16", 8, u16_sat(u32(wild_u16x_) * wild_u32x_), Pattern::LeftShift);
+    casts.emplace_back("vqshiftu.v4i32", "uqshl.v4i32", 4, u32_sat(u64(wild_u32x_) * wild_u64x_), Pattern::LeftShift);
+    casts.emplace_back("vqshiftsu.v16i8", "sqshlu.v16i8", 16, u8_sat(i16(wild_i8x_) * wild_i16x_), Pattern::LeftShift);
+    casts.emplace_back("vqshiftsu.v8i16", "sqshlu.v8i16", 8, u16_sat(i32(wild_i16x_) * wild_i32x_), Pattern::LeftShift);
+    casts.emplace_back("vqshiftsu.v4i32", "sqshlu.v4i32", 4, u32_sat(i64(wild_i32x_) * wild_i64x_), Pattern::LeftShift);
 
-    casts.push_back(Pattern("vqmovns.v8i8", "sqxtn.v8i8", 8, i8_sat(wild_i16x_)));
-    casts.push_back(Pattern("vqmovns.v4i16", "sqxtn.v4i16", 4, i16_sat(wild_i32x_)));
-    casts.push_back(Pattern("vqmovns.v2i32", "sqxtn.v2i32", 2, i32_sat(wild_i64x_)));
-    casts.push_back(Pattern("vqmovnu.v8i8", "uqxtn.v8i8", 8, u8_sat(wild_u16x_)));
-    casts.push_back(Pattern("vqmovnu.v4i16", "uqxtn.v4i16", 4, u16_sat(wild_u32x_)));
-    casts.push_back(Pattern("vqmovnu.v2i32", "uqxtn.v2i32", 2, u32_sat(wild_u64x_)));
-    casts.push_back(Pattern("vqmovnsu.v8i8", "sqxtun.v8i8", 8, u8_sat(wild_i16x_)));
-    casts.push_back(Pattern("vqmovnsu.v4i16", "sqxtun.v4i16", 4, u16_sat(wild_i32x_)));
-    casts.push_back(Pattern("vqmovnsu.v2i32", "sqxtun.v2i32", 2, u32_sat(wild_i64x_)));
+    casts.emplace_back("vqmovns.v8i8", "sqxtn.v8i8", 8, i8_sat(wild_i16x_));
+    casts.emplace_back("vqmovns.v4i16", "sqxtn.v4i16", 4, i16_sat(wild_i32x_));
+    casts.emplace_back("vqmovns.v2i32", "sqxtn.v2i32", 2, i32_sat(wild_i64x_));
+    casts.emplace_back("vqmovnu.v8i8", "uqxtn.v8i8", 8, u8_sat(wild_u16x_));
+    casts.emplace_back("vqmovnu.v4i16", "uqxtn.v4i16", 4, u16_sat(wild_u32x_));
+    casts.emplace_back("vqmovnu.v2i32", "uqxtn.v2i32", 2, u32_sat(wild_u64x_));
+    casts.emplace_back("vqmovnsu.v8i8", "sqxtun.v8i8", 8, u8_sat(wild_i16x_));
+    casts.emplace_back("vqmovnsu.v4i16", "sqxtun.v4i16", 4, u16_sat(wild_i32x_));
+    casts.emplace_back("vqmovnsu.v2i32", "sqxtun.v2i32", 2, u32_sat(wild_i64x_));
 
     // Overflow for int32 is not defined by Halide, so for those we can take
     // advantage of special add-and-halve instructions.
     //
     // 64-bit averaging round-down
-    averagings.push_back(Pattern("vhadds.v2i32", "shadd.v2i32", 2, (wild_i32x2 + wild_i32x2)));
+    averagings.emplace_back("vhadds.v2i32", "shadd.v2i32", 2, (wild_i32x2 + wild_i32x2));
 
     // 128-bit
-    averagings.push_back(Pattern("vhadds.v4i32", "shadd.v4i32", 4, (wild_i32x_ + wild_i32x_)));
+    averagings.emplace_back("vhadds.v4i32", "shadd.v4i32", 4, (wild_i32x_ + wild_i32x_));
 
     // 64-bit halving subtract
-    averagings.push_back(Pattern("vhsubs.v2i32", "shsub.v2i32", 2, (wild_i32x2 - wild_i32x2)));
+    averagings.emplace_back("vhsubs.v2i32", "shsub.v2i32", 2, (wild_i32x2 - wild_i32x2));
 
     // 128-bit
-    averagings.push_back(Pattern("vhsubs.v4i32", "shsub.v4i32", 4, (wild_i32x_ - wild_i32x_)));
+    averagings.emplace_back("vhsubs.v4i32", "shsub.v4i32", 4, (wild_i32x_ - wild_i32x_));
 
     // 64-bit saturating negation
-    negations.push_back(Pattern("vqneg.v8i8", "sqneg.v8i8", 8, -max(wild_i8x8, -127)));
-    negations.push_back(Pattern("vqneg.v4i16", "sqneg.v4i16", 4, -max(wild_i16x4, -32767)));
-    negations.push_back(Pattern("vqneg.v2i32", "sqneg.v2i32", 2, -max(wild_i32x2, -(0x7fffffff))));
+    negations.emplace_back("vqneg.v8i8", "sqneg.v8i8", 8, -max(wild_i8x8, -127));
+    negations.emplace_back("vqneg.v4i16", "sqneg.v4i16", 4, -max(wild_i16x4, -32767));
+    negations.emplace_back("vqneg.v2i32", "sqneg.v2i32", 2, -max(wild_i32x2, -(0x7fffffff)));
 
     // 128-bit
-    negations.push_back(Pattern("vqneg.v16i8", "sqneg.v16i8", 16, -max(wild_i8x_, -127)));
-    negations.push_back(Pattern("vqneg.v8i16", "sqneg.v8i16", 8, -max(wild_i16x_, -32767)));
-    negations.push_back(Pattern("vqneg.v4i32", "sqneg.v4i32", 4, -max(wild_i32x_, -(0x7fffffff))));
+    negations.emplace_back("vqneg.v16i8", "sqneg.v16i8", 16, -max(wild_i8x_, -127));
+    negations.emplace_back("vqneg.v8i16", "sqneg.v8i16", 8, -max(wild_i16x_, -32767));
+    negations.emplace_back("vqneg.v4i32", "sqneg.v4i32", 4, -max(wild_i32x_, -(0x7fffffff)));
 
     // Widening multiplies.
-    multiplies.push_back(Pattern("vmulls.v2i64", "smull.v2i64", 2,
-                                 wild_i64x_ * wild_i64x_,
-                                 Pattern::NarrowArgs));
-    multiplies.push_back(Pattern("vmullu.v2i64", "umull.v2i64", 2,
-                                 wild_u64x_ * wild_u64x_,
-                                 Pattern::NarrowArgs));
-    multiplies.push_back(Pattern("vmulls.v4i32", "smull.v4i32", 4,
-                                 wild_i32x_ * wild_i32x_,
-                                 Pattern::NarrowArgs));
-    multiplies.push_back(Pattern("vmullu.v4i32", "umull.v4i32", 4,
-                                 wild_u32x_ * wild_u32x_,
-                                 Pattern::NarrowArgs));
-    multiplies.push_back(Pattern("vmulls.v8i16", "smull.v8i16", 8,
-                                 wild_i16x_ * wild_i16x_,
-                                 Pattern::NarrowArgs));
-    multiplies.push_back(Pattern("vmullu.v8i16", "umull.v8i16", 8,
-                                 wild_u16x_ * wild_u16x_,
-                                 Pattern::NarrowArgs));
+    multiplies.emplace_back("vmulls.v2i64", "smull.v2i64", 2,
+                            wild_i64x_ * wild_i64x_,
+                            Pattern::NarrowArgs);
+    multiplies.emplace_back("vmullu.v2i64", "umull.v2i64", 2,
+                            wild_u64x_ * wild_u64x_,
+                            Pattern::NarrowArgs);
+    multiplies.emplace_back("vmulls.v4i32", "smull.v4i32", 4,
+                            wild_i32x_ * wild_i32x_,
+                            Pattern::NarrowArgs);
+    multiplies.emplace_back("vmullu.v4i32", "umull.v4i32", 4,
+                            wild_u32x_ * wild_u32x_,
+                            Pattern::NarrowArgs);
+    multiplies.emplace_back("vmulls.v8i16", "smull.v8i16", 8,
+                            wild_i16x_ * wild_i16x_,
+                            Pattern::NarrowArgs);
+    multiplies.emplace_back("vmullu.v8i16", "umull.v8i16", 8,
+                            wild_u16x_ * wild_u16x_,
+                            Pattern::NarrowArgs);
 }
 
 Value *CodeGen_ARM::call_pattern(const Pattern &p, Type t, const vector<Expr> &args) {
@@ -682,7 +682,7 @@ void CodeGen_ARM::visit(const Store *op) {
     vector<pair<string, Expr>> lets;
     while (const Let *let = rhs.as<Let>()) {
         rhs = let->body;
-        lets.push_back({let->name, let->value});
+        lets.emplace_back(let->name, let->value);
     }
     const Shuffle *shuffle = rhs.as<Shuffle>();
 

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -820,7 +820,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::add_kernel(Stmt s,
     };
     for (auto &arg : args) {
         if (isConstantBuffer(arg)) {
-            constants.push_back(BufferSize(arg.name, arg.size));
+            constants.emplace_back(arg.name, arg.size);
         }
     }
 

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1108,7 +1108,7 @@ void CodeGen_Hexagon::init_module() {
             if (a.bits == 0) {
                 break;
             }
-            arg_types.push_back(fix_lanes(a));
+            arg_types.emplace_back(fix_lanes(a));
         }
         define_hvx_intrinsic(intrin, ret_type, i.name, arg_types, i.flags);
     }
@@ -1943,7 +1943,7 @@ Value *CodeGen_Hexagon::vlut(Value *lut, Value *idx, int min_index, int max_inde
         int range_extent_i = std::min(max_index - min_index_i, 255);
         Value *range_i = vlut256(slice_vector(lut, min_index_i, range_extent_i),
                                  indices, 0, range_extent_i);
-        ranges.push_back({range_i, use_index});
+        ranges.emplace_back(range_i, use_index);
     }
 
     // TODO: This could be reduced hierarchically instead of in

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -526,10 +526,10 @@ MangledNames get_mangled_names(const std::string &name,
         std::vector<ExternFuncArgument> mangle_args;
         for (const auto &arg : args) {
             if (arg.kind == Argument::InputScalar) {
-                mangle_args.push_back(ExternFuncArgument(make_zero(arg.type)));
+                mangle_args.emplace_back(make_zero(arg.type));
             } else if (arg.kind == Argument::InputBuffer ||
                        arg.kind == Argument::OutputBuffer) {
-                mangle_args.push_back(ExternFuncArgument(Buffer<>()));
+                mangle_args.emplace_back(Buffer<>());
             }
         }
         names.extern_name = cplusplus_function_mangled_name(names.simple_name, namespaces, type_of<int>(), mangle_args, target);
@@ -3348,7 +3348,7 @@ void CodeGen_LLVM::visit(const Call *op) {
             name = extract_namespaces(op->name, namespaces);
             std::vector<ExternFuncArgument> mangle_args;
             for (const auto &arg : op->args) {
-                mangle_args.push_back(ExternFuncArgument(arg));
+                mangle_args.emplace_back(arg);
             }
             name = cplusplus_function_mangled_name(name, namespaces, op->type, mangle_args, get_target());
         } else {

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -479,7 +479,7 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::add_kernel(const Stmt &s,
         if (args[i].is_buffer &&
             CodeGen_GPU_Dev::is_buffer_constant(s, args[i].name) &&
             args[i].size > 0) {
-            constants.push_back(BufferSize(args[i].name, args[i].size));
+            constants.emplace_back(args[i].name, args[i].size);
         }
     }
 

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -701,7 +701,7 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
         if (args[i].is_buffer &&
             CodeGen_GPU_Dev::is_buffer_constant(s, args[i].name) &&
             args[i].size > 0) {
-            constants.push_back(BufferSize(args[i].name, args[i].size));
+            constants.emplace_back(args[i].name, args[i].size);
         }
     }
 

--- a/src/DebugToFile.cpp
+++ b/src/DebugToFile.cpp
@@ -29,7 +29,7 @@ class DebugToFile : public IRMutator {
                 << "debug_to_file doesn't handle functions with multiple values yet\n";
 
             // The name of the file
-            args.push_back(f.debug_file());
+            args.emplace_back(f.debug_file());
 
             // Inject loads to the corners of the function so that any
             // passes doing further analysis of buffer use understand
@@ -65,7 +65,7 @@ class DebugToFile : public IRMutator {
             } else {
                 user_error << "Type " << t << " not supported for debug_to_file\n";
             }
-            args.push_back(type_code);
+            args.emplace_back(type_code);
 
             Expr buf = Variable::make(Handle(), f.name() + ".buffer");
             args.push_back(buf);
@@ -126,7 +126,7 @@ class AddDummyRealizations : public IRMutator {
                     string dim = std::to_string(i);
                     Expr min = Variable::make(Int(32), out.name() + ".min." + dim);
                     Expr extent = Variable::make(Int(32), out.name() + ".extent." + dim);
-                    output_bounds.push_back(Range(min, extent));
+                    output_bounds.emplace_back(min, extent);
                 }
                 return Realize::make(out.name(),
                                      out.output_types(),

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -114,7 +114,7 @@ private:
         }
 
         // This store is good, collect it and replace with a no-op.
-        stores.push_back(op);
+        stores.emplace_back(op);
         stmt = Evaluate::make(0);
 
         // Because we collected this store, we need to save the
@@ -146,7 +146,7 @@ private:
         if (collecting) {
             Stmt body;
             do {
-                potential_lets.push_back(op);
+                potential_lets.emplace_back(op);
                 body = op->body;
             } while ((op = body.as<LetStmt>()));
         }
@@ -578,7 +578,7 @@ class Interleaver : public IRMutator {
         // Gather all the let stmts surrounding the first.
         std::vector<Stmt> let_stmts;
         while (let) {
-            let_stmts.push_back(let);
+            let_stmts.emplace_back(let);
             store = let->body.as<Store>();
             let = let->body.as<LetStmt>();
         }
@@ -602,7 +602,7 @@ class Interleaver : public IRMutator {
 
         // Collect the rest of the stores.
         std::vector<Stmt> stores;
-        stores.push_back(store);
+        stores.emplace_back(store);
         Stmt rest = collect_strided_stores(op->rest, store->name,
                                            stride, expected_stores,
                                            let_stmts, stores);

--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -258,7 +258,7 @@ void ReverseAccumulationVisitor::propagate_adjoints(
                 Interval interval = bounds_of_expr_in_scope(args[arg_id], scope);
                 intervals.push_back(interval);
             }
-            boxes.push_back(Box(intervals));
+            boxes.emplace_back(intervals);
         }
         for (int update_id = 0;
              update_id < func.num_update_definitions(); update_id++) {
@@ -541,10 +541,7 @@ void ReverseAccumulationVisitor::propagate_adjoints(
     for (const auto &it : called_buffers_or_param) {
         // Replace all the dots in the function names to make it legal.
         Func adjoint_func(replace_all(it.first, ".", "_") + "_d__");
-        vector<Var> args;
-        for (int i = 0; i < it.second.dimension; i++) {
-            args.push_back(Var());
-        }
+        vector<Var> args(it.second.dimension);;
         adjoint_func(args) = make_zero(it.second.type);
         FuncKey func_key{it.first, -1};
         if (adjoint_funcs.find(func_key) != adjoint_funcs.end()) {
@@ -1355,7 +1352,7 @@ void ReverseAccumulationVisitor::propagate_halide_function_call(
     vector<Var> new_args;
     new_args.reserve(func_to_update.dimensions());
     for (int arg_id = 0; arg_id < (int)func_to_update.dimensions(); arg_id++) {
-        new_args.push_back(Var(unique_name("u" + std::to_string(arg_id))));
+        new_args.emplace_back(unique_name("u" + std::to_string(arg_id)));
     }
 
     // Loop over the left hand side of the update, construct equations

--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -541,7 +541,7 @@ void ReverseAccumulationVisitor::propagate_adjoints(
     for (const auto &it : called_buffers_or_param) {
         // Replace all the dots in the function names to make it legal.
         Func adjoint_func(replace_all(it.first, ".", "_") + "_d__");
-        vector<Var> args(it.second.dimension);;
+        vector<Var> args(it.second.dimension);
         adjoint_func(args) = make_zero(it.second.type);
         FuncKey func_key{it.first, -1};
         if (adjoint_funcs.find(func_key) != adjoint_funcs.end()) {

--- a/src/DerivativeUtils.cpp
+++ b/src/DerivativeUtils.cpp
@@ -303,7 +303,7 @@ vector<pair<Expr, Expr>> box_to_vector(const Box &bounds) {
     vector<pair<Expr, Expr>> ret;
     ret.reserve(bounds.size());
     for (const auto &b : bounds.bounds) {
-        ret.push_back({b.min, b.max - b.min + 1});
+        ret.emplace_back(b.min, b.max - b.min + 1);
     }
     return ret;
 }

--- a/src/DeviceArgument.cpp
+++ b/src/DeviceArgument.cpp
@@ -15,7 +15,7 @@ std::vector<DeviceArgument> HostClosure::arguments() {
     std::vector<DeviceArgument> res;
     for (const auto &v : vars) {
         debug(2) << "var: " << v.first << "\n";
-        res.push_back(DeviceArgument(v.first, false, v.second, 0));
+        res.emplace_back(v.first, false, v.second, 0);
     }
     for (const auto &b : buffers) {
         debug(2) << "buffer: " << b.first << " " << b.second.size;

--- a/src/Elf.cpp
+++ b/src/Elf.cpp
@@ -770,7 +770,7 @@ std::vector<char> write_shared_object_internal(Object &obj, Linker *linker, cons
     // will vary in ordering from run to tun.
     std::vector<std::pair<const Symbol *, const Symbol *>> sorted_symbols;
     for (const auto &i : symbols) {
-        sorted_symbols.push_back(i);
+        sorted_symbols.emplace_back(i);
     }
     std::sort(sorted_symbols.begin(), sorted_symbols.end(),
               [&](const std::pair<const Symbol *, const Symbol *> &lhs, const std::pair<const Symbol *, const Symbol *> &rhs) {

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -578,9 +578,9 @@ bool apply_split_directive(const Split &s, vector<ReductionVariable> &rvars,
 
     vector<pair<string, Expr>> rvar_bounds;
     for (const ReductionVariable &rv : rvars) {
-        rvar_bounds.push_back({rv.var + ".loop_min", rv.min});
-        rvar_bounds.push_back({rv.var + ".loop_max", simplify(rv.min + rv.extent - 1)});
-        rvar_bounds.push_back({rv.var + ".loop_extent", rv.extent});
+        rvar_bounds.emplace_back(rv.var + ".loop_min", rv.min);
+        rvar_bounds.emplace_back(rv.var + ".loop_max", simplify(rv.min + rv.extent - 1));
+        rvar_bounds.emplace_back(rv.var + ".loop_extent", rv.extent);
     }
 
     bool found = false;

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -1092,7 +1092,7 @@ pair<vector<Function>, map<string, Function>> deep_copy(
         if (iter != copied_map.end()) {
             FunctionPtr ptr = iter->second;
             debug(4) << "Adding deep-copied version to outputs: " << func.name() << "\n";
-            copy_outputs.push_back(Function(ptr));
+            copy_outputs.emplace_back(ptr);
         } else {
             debug(4) << "Adding original version to outputs: " << func.name() << "\n";
             copy_outputs.push_back(func);

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -630,7 +630,7 @@ class ExtractSharedAndHeapAllocations : public IRMutator {
                         mem_allocs[free_spaces[free_idx]].insert(allocations[i]);
                         free_spaces.erase(free_spaces.begin() + free_idx);
                     } else {
-                        mem_allocs.push_back(AllocGroup(allocations[i]));
+                        mem_allocs.emplace_back(allocations[i]);
                     }
                 } else if (allocations[i].liveness.max == stage - 1) {  // Free
                     int free_idx = -1;
@@ -819,9 +819,9 @@ public:
         Expr buffer_var = Variable::make(type_of<halide_buffer_t *>(), buffer_name);
 
         BufferBuilder builder;
-        builder.mins.push_back(0);
+        builder.mins.emplace_back(0);
         builder.extents.push_back(total_size);
-        builder.strides.push_back(1);
+        builder.strides.emplace_back(1);
         builder.type = UInt(8);
         builder.dimensions = 1;
         Expr buffer = builder.build();

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -174,7 +174,7 @@ void ValueTracker::track_values(const std::string &name, const std::vector<Expr>
 std::vector<Expr> parameter_constraints(const Parameter &p) {
     internal_assert(p.defined());
     std::vector<Expr> values;
-    values.push_back(Expr(p.host_alignment()));
+    values.emplace_back(p.host_alignment());
     if (p.is_buffer()) {
         for (int i = 0; i < p.dimensions(); ++i) {
             values.push_back(p.min_constraint(i));
@@ -1976,7 +1976,7 @@ void GeneratorOutputBase::init_internals() {
     funcs_.clear();
     if (array_size_defined()) {
         for (size_t i = 0; i < array_size(); ++i) {
-            funcs_.push_back(Func(array_name(i)));
+            funcs_.emplace_back(array_name(i));
         }
     }
 }

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -1705,7 +1705,7 @@ class OptimizeShuffles : public IRMutator {
     }
 
     Expr visit(const Let *op) override {
-        lets.push_back({op->name, op->value});
+        lets.emplace_back(op->name, op->value);
         Expr expr = visit_let<Expr>(op);
         lets.pop_back();
         return expr;

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -794,20 +794,20 @@ Expr BufferBuilder::build() const {
         if (i < mins.size()) {
             shape.push_back(mins[i]);
         } else {
-            shape.push_back(0);
+            shape.emplace_back(0);
         }
         if (i < extents.size()) {
             shape.push_back(extents[i]);
         } else {
-            shape.push_back(0);
+            shape.emplace_back(0);
         }
         if (i < strides.size()) {
             shape.push_back(strides[i]);
         } else {
-            shape.push_back(0);
+            shape.emplace_back(0);
         }
         // per-dimension flags, currently unused.
-        shape.push_back(0);
+        shape.emplace_back(0);
     }
     for (const Expr &e : shape) {
         internal_assert(e.type() == Int(32))
@@ -2132,7 +2132,7 @@ Expr random_float(Expr seed) {
             << seed << " of type " << seed.type() << "\n";
         args.push_back(std::move(seed));
     }
-    args.push_back(id);
+    args.emplace_back(id);
 
     // This is (surprisingly) pure - it's a fixed psuedo-random
     // function of its inputs.
@@ -2152,7 +2152,7 @@ Expr random_uint(Expr seed) {
             << seed << " of type " << seed.type() << "\n";
         args.push_back(std::move(seed));
     }
-    args.push_back(id);
+    args.emplace_back(id);
 
     return Internal::Call::make(UInt(32), Internal::Call::random,
                                 args, Internal::Call::PureIntrinsic);

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -321,7 +321,7 @@ inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &arg
 
 template<typename... Args>
 inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &args, const char *arg, Args &&... more_args) {
-    args.push_back(Expr(std::string(arg)));
+    args.emplace_back(std::string(arg));
     collect_print_args(args, std::forward<Args>(more_args)...);
 }
 

--- a/src/InlineReductions.cpp
+++ b/src/InlineReductions.cpp
@@ -98,8 +98,8 @@ private:
             }
         }
 
-        free_vars.push_back(Var(var_name));
-        call_args.push_back(v);
+        free_vars.emplace_back(var_name);
+        call_args.emplace_back(v);
         return expr;
     }
 };

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -234,7 +234,7 @@ public:
 
     uint8_t *allocateCodeSection(uintptr_t size, unsigned alignment, unsigned section_id, StringRef section_name) override {
         uint8_t *result = SectionMemoryManager::allocateCodeSection(size, alignment, section_id, section_name);
-        code_pages.push_back({result, size});
+        code_pages.emplace_back(result, size);
         return result;
     }
 };
@@ -376,7 +376,7 @@ JITModule JITModule::make_trampolines_module(const Target &target_arg,
         const ExternCFunction &extern_c = e.second.extern_c_function();
         result.add_extern_for_export(callee_name, extern_c);
         requested_exports.push_back(wrapper_name);
-        extern_signatures.push_back({callee_name, extern_c.signature()});
+        extern_signatures.emplace_back(callee_name, extern_c.signature());
     }
 
     std::unique_ptr<llvm::Module> llvm_module = CodeGen_LLVM::compile_trampolines(

--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -250,7 +250,7 @@ class LICM : public IRMutator {
             // Peel off containing lets. These will be lifted.
             vector<pair<string, Expr>> lets;
             while (const Let *let = dummy_call.as<Let>()) {
-                lets.push_back({let->name, let->value});
+                lets.emplace_back(let->name, let->value);
                 dummy_call = let->body;
             }
 

--- a/src/LoopCarry.cpp
+++ b/src/LoopCarry.cpp
@@ -202,7 +202,7 @@ class LoopCarryOverLoop : public IRMutator {
         Expr step = is_linear(value, linear);
         ScopedBinding<Expr> bind(linear, op->name, step);
 
-        containing_lets.push_back({op->name, value});
+        containing_lets.emplace_back(op->name, value);
 
         Stmt stmt;
         Stmt body = mutate(op->body);
@@ -406,7 +406,7 @@ class LoopCarryOverLoop : public IRMutator {
                                                         Parameter(), const_true(orig_load->type.lanes()), ModulusRemainder());
                     not_first_iteration_scratch_stores.push_back(store_to_scratch);
                 } else {
-                    initial_scratch_values.push_back(orig_load);
+                    initial_scratch_values.emplace_back(orig_load);
                 }
                 if (i > 0) {
                     Stmt shuffle = Store::make(scratch, load_from_scratch,
@@ -426,7 +426,7 @@ class LoopCarryOverLoop : public IRMutator {
             call = simplify(common_subexpression_elimination(call));
             // Peel off lets
             while (const Let *l = call.as<Let>()) {
-                initial_lets.push_back({l->name, l->value});
+                initial_lets.emplace_back(l->name, l->value);
                 call = l->body;
             }
             internal_assert(call.as<Call>());

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -441,9 +441,9 @@ Module lower(const vector<Function> &output_funcs,
     vector<Argument> public_args = args;
     for (const auto &out : outputs) {
         for (Parameter buf : out.output_buffers()) {
-            public_args.push_back(Argument(buf.name(),
-                                           Argument::OutputBuffer,
-                                           buf.type(), buf.dimensions(), buf.get_argument_estimates()));
+            public_args.emplace_back(buf.name(),
+                                     Argument::OutputBuffer,
+                                     buf.type(), buf.dimensions(), buf.get_argument_estimates());
         }
     }
 

--- a/src/LowerWarpShuffles.cpp
+++ b/src/LowerWarpShuffles.cpp
@@ -638,7 +638,7 @@ class LowerWarpShuffles : public IRMutator {
             return IRMutator::visit(op);
         } else {
             // Pick up this allocation and deposit it inside the loop over lanes at reduced size.
-            allocations.push_back(Stmt(op));
+            allocations.emplace_back(op);
             return mutate(op->body);
         }
     }
@@ -659,7 +659,7 @@ class HoistWarpShufflesFromSingleIfStmt : public IRMutator {
         if (starts_with(op->name, "llvm.nvvm.shfl.") &&
             !expr_uses_vars(op, stored_to)) {
             string name = unique_name('t');
-            lifted_lets.push_back({name, op});
+            lifted_lets.emplace_back(name, op);
             return Variable::make(op->type, name);
         } else {
             return IRMutator::visit(op);

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -269,7 +269,7 @@ public:
         args.push_back(Variable::make(type_of<uint8_t *>(), key_allocation_name));
         args.push_back(key_size());
         args.push_back(Variable::make(type_of<halide_buffer_t *>(), computed_bounds_name));
-        args.push_back(tuple_count);
+        args.emplace_back(tuple_count);
         std::vector<Expr> buffers;
         if (tuple_count == 1) {
             buffers.push_back(Variable::make(type_of<halide_buffer_t *>(), storage_base_name + ".buffer"));
@@ -290,7 +290,7 @@ public:
         args.push_back(Variable::make(type_of<uint8_t *>(), key_allocation_name));
         args.push_back(key_size());
         args.push_back(Variable::make(type_of<halide_buffer_t *>(), computed_bounds_name));
-        args.push_back(tuple_count);
+        args.emplace_back(tuple_count);
         std::vector<Expr> buffers;
         if (tuple_count == 1) {
             buffers.push_back(Variable::make(type_of<halide_buffer_t *>(), storage_base_name + ".buffer"));

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -351,7 +351,7 @@ LoweredFunc::LoweredFunc(const std::string &name,
                          NameMangling name_mangling)
     : name(name), body(std::move(body)), linkage(linkage), name_mangling(name_mangling) {
     for (const Argument &i : args) {
-        this->args.push_back(LoweredArgument(i));
+        this->args.emplace_back(i);
     }
 }
 
@@ -814,7 +814,7 @@ void compile_multitarget(const std::string &fn_name,
         if (target != base_target) {
             std::vector<Expr> features_struct_args;
             for (int i = 0; i < kFeaturesWordCount; ++i) {
-                features_struct_args.push_back(UIntImm::make(UInt(64), cur_target_features[i]));
+                features_struct_args.emplace_back(UIntImm::make(UInt(64), cur_target_features[i]));
             }
             can_use = Call::make(Int(32), "halide_can_use_target_features",
                                  {kFeaturesWordCount, Call::make(type_of<uint64_t *>(), Call::make_struct, features_struct_args, Call::Intrinsic)},
@@ -828,7 +828,7 @@ void compile_multitarget(const std::string &fn_name,
         }
 
         wrapper_args.push_back(can_use != 0);
-        wrapper_args.push_back(sub_fn_name);
+        wrapper_args.emplace_back(sub_fn_name);
     }
 
     // If we haven't specified "no runtime", build a runtime with the base target

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -825,7 +825,7 @@ class RenormalizeGPULoops : public IRMutator {
             // we'd better give it a new name.
             string new_name = unique_name('t');
             Expr new_var = Variable::make(op->value.type(), new_name);
-            lifted_lets.push_back({new_name, op->value});
+            lifted_lets.emplace_back(new_name, op->value);
             return mutate(substitute(op->name, new_var, op->body));
         }
 

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -118,7 +118,7 @@ class LowerRandom : public IRMutator {
 
 public:
     LowerRandom(const vector<string> &free_vars, int tag) {
-        extra_args.push_back(tag);
+        extra_args.emplace_back(tag);
         for (size_t i = 0; i < free_vars.size(); i++) {
             internal_assert(!free_vars[i].empty());
             extra_args.push_back(Variable::make(Int(32), free_vars[i]));

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -358,7 +358,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
                 if (last) {
                     new_args.back() = last->value + buf;
                 } else {
-                    new_args.push_back(string(buf));
+                    new_args.emplace_back(string(buf));
                 }
                 changed = true;
             } else if (last && float_imm) {
@@ -366,7 +366,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
                 if (last) {
                     new_args.back() = last->value + buf;
                 } else {
-                    new_args.push_back(string(buf));
+                    new_args.emplace_back(string(buf));
                 }
                 changed = true;
             } else {

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -280,7 +280,7 @@ Stmt Simplify::visit(const Evaluate *op) {
     // Rewrite Lets inside an evaluate as LetStmts outside the Evaluate.
     vector<pair<string, Expr>> lets;
     while (const Let *let = value.as<Let>()) {
-        lets.push_back({let->name, let->value});
+        lets.emplace_back(let->name, let->value);
         value = let->body;
     }
 

--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -173,7 +173,7 @@ class SplitTuples : public IRMutator {
             string var_name = name + ".value";
             Expr val = mutate(op->values[i]);
             if (!is_undef(val) && atomic) {
-                lets.push_back({var_name, val});
+                lets.emplace_back(var_name, val);
                 val = Variable::make(val.type(), var_name);
             }
             provides.push_back(Provide::make(name, {val}, args));

--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -676,18 +676,18 @@ private:
             print_list(symbol("interleave_vectors("), op->vectors, ")");
         } else if (op->is_extract_element()) {
             std::vector<Expr> args = op->vectors;
-            args.push_back(op->slice_begin());
+            args.emplace_back(op->slice_begin());
             print_list(symbol("extract_element("), args, ")");
         } else if (op->is_slice()) {
             std::vector<Expr> args = op->vectors;
-            args.push_back(op->slice_begin());
-            args.push_back(op->slice_stride());
-            args.push_back(static_cast<int>(op->indices.size()));
+            args.emplace_back(op->slice_begin());
+            args.emplace_back(op->slice_stride());
+            args.emplace_back(static_cast<int>(op->indices.size()));
             print_list(symbol("slice_vectors("), args, ")");
         } else {
             std::vector<Expr> args = op->vectors;
             for (int i : op->indices) {
-                args.push_back(i);
+                args.emplace_back(i);
             }
             print_list(symbol("shuffle("), args, ")");
         }

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -276,8 +276,8 @@ private:
                     args.push_back(extent);
                 }
                 for (size_t i = op->args.size(); i < 3; i++) {
-                    args.push_back(0);
-                    args.push_back(1);
+                    args.emplace_back(0);
+                    args.emplace_back(1);
                 }
 
                 return Call::make(op->type,

--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -411,7 +411,7 @@ Stmt inject_tracing(Stmt s, const string &pipeline_name, bool trace_pipeline,
             strings.emplace_back((int)func_types.size());
             for (const auto &func_type : func_types) {
                 strings.push_back(space);
-                strings.emplace_back(func_type.code());
+                strings.emplace_back((int)func_type.code());
                 strings.push_back(space);
                 strings.emplace_back(func_type.bits());
                 strings.push_back(space);

--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -69,7 +69,7 @@ public:
 private:
     void add_trace_tags(const string &name, const vector<string> &t) {
         if (!t.empty() && !trace_tags_added.count(name)) {
-            trace_tags.push_back({name, t});
+            trace_tags.emplace_back(name, t);
             trace_tags_added.insert(name);
         }
     }
@@ -204,7 +204,7 @@ private:
             for (size_t i = 0; i < args.size(); i++) {
                 if (!args[i].as<Variable>() && !is_const(args[i])) {
                     string name = unique_name('t');
-                    lets.push_back({name, args[i]});
+                    lets.emplace_back(name, args[i]);
                     args[i] = Variable::make(args[i].type(), name);
                 }
             }
@@ -406,22 +406,22 @@ Stmt inject_tracing(Stmt s, const string &pipeline_name, bool trace_pipeline,
             builder.func = func_name;
 
             vector<Expr> strings;
-            strings.push_back(Expr("func_type_and_dim:"));
+            strings.emplace_back("func_type_and_dim:");
             strings.push_back(space);
-            strings.push_back((int)func_types.size());
+            strings.emplace_back((int)func_types.size());
             for (const auto &func_type : func_types) {
                 strings.push_back(space);
-                strings.push_back(func_type.code());
+                strings.emplace_back(func_type.code());
                 strings.push_back(space);
-                strings.push_back(func_type.bits());
+                strings.emplace_back(func_type.bits());
                 strings.push_back(space);
-                strings.push_back(func_type.lanes());
+                strings.emplace_back(func_type.lanes());
             }
             auto it = bt.find(func_name);
             internal_assert(it != bt.end());
             const Box &box = it->second;
             strings.push_back(space);
-            strings.push_back(Expr((int)box.bounds.size()));
+            strings.emplace_back((int)box.bounds.size());
             for (const Interval &i : box.bounds) {
                 internal_assert(i.min.defined() && i.max.defined());
                 if (i.is_bounded()) {
@@ -435,9 +435,9 @@ Stmt inject_tracing(Stmt s, const string &pipeline_name, bool trace_pipeline,
                     // that we won't end up realizing, so we can just
                     // use any numeric values.
                     strings.push_back(space);
-                    strings.push_back(Expr(0));
+                    strings.emplace_back(0);
                     strings.push_back(space);
-                    strings.push_back(Expr(0));
+                    strings.emplace_back(0);
                 }
             }
             builder.trace_tag_expr =

--- a/src/UnpackBuffers.cpp
+++ b/src/UnpackBuffers.cpp
@@ -78,47 +78,47 @@ Stmt unpack_buffers(Stmt s) {
 
         string host_var = name;
         Expr host_val = Call::make(type_of<void *>(), Call::buffer_get_host, args, Call::Extern);
-        lets.push_back({host_var, host_val});
+        lets.emplace_back(host_var, host_val);
 
         string dev_var = name + ".device";
         Expr dev_val = Call::make(type_of<uint64_t>(), Call::buffer_get_device, args, Call::Extern);
-        lets.push_back({dev_var, dev_val});
+        lets.emplace_back(dev_var, dev_val);
 
         string dev_interface_var = name + ".device_interface";
         Expr dev_interface_val = Call::make(type_of<const halide_device_interface_t *>(),
                                             Call::buffer_get_device_interface, args, Call::Extern);
-        lets.push_back({dev_interface_var, dev_interface_val});
+        lets.emplace_back(dev_interface_var, dev_interface_val);
 
         string type_code_var = name + ".type";
         Expr type_code_val = Call::make(UInt(32), Call::buffer_get_type, args, Call::Extern);
-        lets.push_back({type_code_var, type_code_val});
+        lets.emplace_back(type_code_var, type_code_val);
 
         string host_dirty_var = name + ".host_dirty";
         Expr host_dirty_val = Call::make(Bool(), Call::buffer_get_host_dirty, args, Call::Extern);
-        lets.push_back({host_dirty_var, host_dirty_val});
+        lets.emplace_back(host_dirty_var, host_dirty_val);
 
         string dev_dirty_var = name + ".device_dirty";
         Expr dev_dirty_val = Call::make(Bool(), Call::buffer_get_device_dirty, args, Call::Extern);
-        lets.push_back({dev_dirty_var, dev_dirty_val});
+        lets.emplace_back(dev_dirty_var, dev_dirty_val);
 
         string dimensions_var = name + ".dimensions";
         Expr dimensions_val = Call::make(Int(32), Call::buffer_get_dimensions, args, Call::Extern);
-        lets.push_back({dimensions_var, dimensions_val});
+        lets.emplace_back(dimensions_var, dimensions_val);
 
         for (int i = 0; i < info.dimensions; i++) {
             vector<Expr> args = {info.handle, i};
 
             string min_var = name + ".min." + std::to_string(i);
             Expr min_val = Call::make(Int(32), Call::buffer_get_min, args, Call::Extern);
-            lets.push_back({min_var, min_val});
+            lets.emplace_back(min_var, min_val);
 
             string extent_var = name + ".extent." + std::to_string(i);
             Expr extent_val = Call::make(Int(32), Call::buffer_get_extent, args, Call::Extern);
-            lets.push_back({extent_var, extent_val});
+            lets.emplace_back(extent_var, extent_val);
 
             string stride_var = name + ".stride." + std::to_string(i);
             Expr stride_val = Call::make(Int(32), Call::buffer_get_stride, args, Call::Extern);
-            lets.push_back({stride_var, stride_val});
+            lets.emplace_back(stride_var, stride_val);
         }
     }
 

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -644,7 +644,7 @@ class VectorSubs : public IRMutator {
             mutated_name += widening_suffix;
             scope.push(op->name, mutated_value);
             // Also keep track of the original let, in case inner code scalarizes.
-            containing_lets.push_back({op->name, op->value});
+            containing_lets.emplace_back(op->name, op->value);
         }
 
         Stmt mutated_body = mutate(op->body);
@@ -899,7 +899,7 @@ class VectorSubs : public IRMutator {
         int lanes = replacement.type().lanes();
 
         // The new expanded dimension is innermost.
-        new_extents.push_back(lanes);
+        new_extents.emplace_back(lanes);
 
         for (size_t i = 0; i < op->extents.size(); i++) {
             Expr extent = mutate(op->extents[i]);


### PR DESCRIPTION
You can avoid a copy this way some of the time, so it's the preferred style according to the conventional wisdom right now.

This also replaced:
```push_back({args}) ```
with 
```emplace_back(args)```

and 
```Vector<T>::push_back(something_that_can_convert_to_T)```
with
```Vector<T>::emplace_back(something_that_can_convert_to_T)```

It looks a little odd to say:
```
vector<Expr> exprs;
exprs.emplace_back(0);
exprs.push_back(some_expr);
```
instead of 
```
vector<Expr> exprs;
exprs.push_back(0);
exprs.push_back(some_expr);
```
But it is indeed a good idea - an int can be passed by value. A temporary Expr, even an rvalue, must be placed on the stack and passed by reference. push_back(0) has to destroy this temporary (even though it has been moved from in the common case), so there's extra code. This hurts even in the case of -O3 when push_back and emplace_back both get inlined! The issue is that in the slow path of adding something to a vector you need to reallocate memory, and the reallocation might throw, so you have a temporary Exprs that genuinely needs a cleanup. In the emplace_back case you call the constructor *after* you realloc, and do a placement new, so if realloc throws, so there's no cleanup required.

In summary, a function that just does push_back(0) onto a vector of Expr has 58 lines of assembly and a function that does emplace_back(0) has 29 lines of assembly.

The advantage of just accepting all of these changes is that it can be mechanically checked. But other opinions welcome. E.g. we could take a subset of these changes and not mechanically check them

I also turned on another performance check - don't hide trivial destructors in cpp files, or they can't be optimized away. But we never did that, so it was a no-op.