### PR TITLE
Remove const that messes up move constructor

### DIFF
--- a/src/Util.h
+++ b/src/Util.h
@@ -322,7 +322,7 @@ bool mul_would_overflow(int bits, int64_t a, int64_t b);
 template<typename T>
 struct ScopedValue {
     T &var;
-    const T old_value;
+    T old_value;
     /** Preserve the old value, restored at dtor time */
     ScopedValue(T &var)
         : var(var), old_value(var) {


### PR DESCRIPTION
This const prevents the default move constructor from moving the member, because you can't move from something const. This in turns makes the noexcept a lie whenever T is something with a constructor that might throw an exception (e.g. std::string, which might allocate).