### PR TITLE
Fix LLVM10/11 breakage on arm32 (Issue #4690)

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -115,10 +115,10 @@ CodeGen_ARM::CodeGen_ARM(Target target)
 #if LLVM_VERSION >= 100
         if (t.is_int()) {
             p.intrin32 = "llvm.sadd.sat" + t_str;
-            p.intrin64 = "llvm.aarch64.neon.sqadd" + t_str;
+            p.intrin64 = "llvm.sadd.sat" + t_str;
         } else {
             p.intrin32 = "llvm.uadd.sat" + t_str;
-            p.intrin64 = "llvm.aarch64.neon.uqadd" + t_str;
+            p.intrin64 = "llvm.uadd.sat" + t_str;
         }
 #else
         if (t.is_int()) {
@@ -143,10 +143,10 @@ CodeGen_ARM::CodeGen_ARM(Target target)
 #if LLVM_VERSION >= 100
         if (t.is_int()) {
             p.intrin32 = "llvm.ssub.sat" + t_str;
-            p.intrin64 = "llvm.aarch64.neon.sqsub" + t_str;
+            p.intrin64 = "llvm.ssub.sat" + t_str;
         } else {
             p.intrin32 = "llvm.usub.sat" + t_str;
-            p.intrin64 = "llvm.aarch64.neon.uqsub" + t_str;
+            p.intrin64 = "llvm.usub.sat" + t_str;
         }
 #else
         if (t.is_int()) {

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -116,7 +116,6 @@ CodeGen_ARM::CodeGen_ARM(Target target)
         if (t.is_int()) {
             p.intrin32 = "llvm.sadd.sat" + t_str;
             p.intrin64 = "llvm.sadd.sat" + t_str;
-
         } else {
             p.intrin32 = "llvm.uadd.sat" + t_str;
             p.intrin64 = "llvm.uadd.sat" + t_str;

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -116,6 +116,7 @@ CodeGen_ARM::CodeGen_ARM(Target target)
         if (t.is_int()) {
             p.intrin32 = "llvm.sadd.sat" + t_str;
             p.intrin64 = "llvm.sadd.sat" + t_str;
+
         } else {
             p.intrin32 = "llvm.uadd.sat" + t_str;
             p.intrin64 = "llvm.uadd.sat" + t_str;

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -112,6 +112,15 @@ CodeGen_ARM::CodeGen_ARM(Target target)
         casts.push_back(p);
 
         // Saturating add
+#if LLVM_VERSION >= 100
+        if (t.is_int()) {
+            p.intrin32 = "llvm.sadd.sat" + t_str;
+            p.intrin64 = "llvm.aarch64.neon.sqadd" + t_str;
+        } else {
+            p.intrin32 = "llvm.uadd.sat" + t_str;
+            p.intrin64 = "llvm.aarch64.neon.uqadd" + t_str;
+        }
+#else
         if (t.is_int()) {
             p.intrin32 = "llvm.arm.neon.vqadds" + t_str;
             p.intrin64 = "llvm.aarch64.neon.sqadd" + t_str;
@@ -119,6 +128,7 @@ CodeGen_ARM::CodeGen_ARM(Target target)
             p.intrin32 = "llvm.arm.neon.vqaddu" + t_str;
             p.intrin64 = "llvm.aarch64.neon.uqadd" + t_str;
         }
+#endif
         p.pattern = cast(t, clamp(w_vector + w_vector, tmin, tmax));
         casts.push_back(p);
 
@@ -130,6 +140,15 @@ CodeGen_ARM::CodeGen_ARM(Target target)
 
         // Saturating subtract
         // N.B. Saturating subtracts always widen to a signed type
+#if LLVM_VERSION >= 100
+        if (t.is_int()) {
+            p.intrin32 = "llvm.ssub.sat" + t_str;
+            p.intrin64 = "llvm.aarch64.neon.sqsub" + t_str;
+        } else {
+            p.intrin32 = "llvm.usub.sat" + t_str;
+            p.intrin64 = "llvm.aarch64.neon.uqsub" + t_str;
+        }
+#else
         if (t.is_int()) {
             p.intrin32 = "llvm.arm.neon.vqsubs" + t_str;
             p.intrin64 = "llvm.aarch64.neon.sqsub" + t_str;
@@ -137,6 +156,7 @@ CodeGen_ARM::CodeGen_ARM(Target target)
             p.intrin32 = "llvm.arm.neon.vqsubu" + t_str;
             p.intrin64 = "llvm.aarch64.neon.uqsub" + t_str;
         }
+#endif
         p.pattern = cast(t, clamp(ws_vector - ws_vector, tsmin, tsmax));
         casts.push_back(p);
 


### PR DESCRIPTION
Some arm-specific intrinsics got removed (in favor of portable LLVM versions) and we didn't notice because the armbots never tested on trunk.