### PR TITLE
Fix deps and COMMAND for binary2cpp and build_halide_h

### DIFF
--- a/apps/autoscheduler/CMakeLists.txt
+++ b/apps/autoscheduler/CMakeLists.txt
@@ -5,7 +5,7 @@ set(WF_CPP ${BASENAME_WF}.cpp)
 
 add_custom_command(OUTPUT ${WF_CPP}
                    DEPENDS ${WF} binary2cpp
-                   COMMAND binary2cpp ${BASENAME_WF}_weights < ${WF} > ${WF_CPP}
+                   COMMAND $<TARGET_FILE:binary2cpp> ${BASENAME_WF}_weights < ${WF} > ${WF_CPP}
                    COMMENT "${WF} -> ${WF_CPP}"
                    VERBATIM)
 
@@ -97,7 +97,7 @@ target_link_libraries(demo_apps_autoscheduler PRIVATE demo)
 add_dependencies(demo_apps_autoscheduler demo auto_schedule)
 
 add_custom_command(TARGET demo_apps_autoscheduler POST_BUILD
-                   COMMAND demo_apps_autoscheduler
+                   COMMAND $<TARGET_FILE:demo_apps_autoscheduler>
                            --benchmarks=all
                            --benchmark_min_time=1
                            --estimate_all
@@ -126,7 +126,7 @@ add_dependencies(demo_included_schedule_file included_schedule_file
                  auto_schedule)
 
 add_custom_command(TARGET demo_included_schedule_file POST_BUILD
-                   COMMAND demo_included_schedule_file
+                   COMMAND $<TARGET_FILE:demo_included_schedule_file>
                            --benchmarks=all
                            --benchmark_min_time=1
                            --estimate_all

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,12 +202,12 @@ function(add_runtime_modules TARGET_RUNTIME_FILES TARGET_RUNTIME_DIR)
       add_custom_command(OUTPUT "${INITMOD_D}"
                          # COMMENT "${BC_D} -> ${INITMOD_D}"
                          DEPENDS "${BC_D}" binary2cpp
-                         COMMAND binary2cpp "halide_internal_initmod_${i}_${j}_debug" < "${BC_D}" > "${INITMOD_D}"
+                         COMMAND $<TARGET_FILE:binary2cpp> "halide_internal_initmod_${i}_${j}_debug" < "${BC_D}" > "${INITMOD_D}"
                          )
       add_custom_command(OUTPUT "${INITMOD}"
                          # COMMENT "${BC} -> ${INITMOD}"
                          DEPENDS "${BC}" binary2cpp
-                         COMMAND binary2cpp "halide_internal_initmod_${i}_${j}" < "${BC}" > "${INITMOD}"
+                         COMMAND $<TARGET_FILE:binary2cpp> "halide_internal_initmod_${i}_${j}" < "${BC}" > "${INITMOD}"
                          )
       list(APPEND INITIAL_MODULES ${INITMOD})
       list(APPEND INITIAL_MODULES ${INITMOD_D})
@@ -232,7 +232,7 @@ foreach (i ${RUNTIME_LL} )
   add_custom_command(OUTPUT "${INITMOD}"
                      # COMMENT "${BC} -> ${INITMOD}"
                      DEPENDS "${BC}" binary2cpp
-                     COMMAND binary2cpp "halide_internal_initmod_${i}_ll" < "${BC}" > "${INITMOD}"
+                     COMMAND $<TARGET_FILE:binary2cpp> "halide_internal_initmod_${i}_ll" < "${BC}" > "${INITMOD}"
                      )
   list(APPEND INITIAL_MODULES "${INITMOD}")
 endforeach()
@@ -241,7 +241,7 @@ foreach (i ${RUNTIME_BC} )
   add_custom_command(OUTPUT "${INITMOD}"
                      # COMMENT "Building initial module ptx_${i}..."
                      DEPENDS binary2cpp
-                     COMMAND binary2cpp "halide_internal_initmod_ptx_${i}_ll" < "${NATIVE_RUNTIME_DIR}nvidia_libdevice_bitcode/libdevice.${i}.10.bc" > "${INITMOD}"
+                     COMMAND $<TARGET_FILE:binary2cpp> "halide_internal_initmod_ptx_${i}_ll" < "${NATIVE_RUNTIME_DIR}nvidia_libdevice_bitcode/libdevice.${i}.10.bc" > "${INITMOD}"
                      VERBATIM)
   list(APPEND INITIAL_MODULES "${INITMOD}")
 endforeach()
@@ -249,7 +249,7 @@ endforeach()
 add_custom_command(OUTPUT "${INITMOD_PREFIX}inlined_c.cpp"
   # COMMENT "halide_buffer_t.cpp -> ${INITMOD_PREFIX}inlined_c.cpp"
   DEPENDS "${NATIVE_RUNTIME_DIR}halide_buffer_t.cpp" binary2cpp
-  COMMAND binary2cpp "halide_internal_initmod_inlined_c" < "${NATIVE_RUNTIME_DIR}halide_buffer_t.cpp" > "${INITMOD_PREFIX}inlined_c.cpp"
+  COMMAND $<TARGET_FILE:binary2cpp> "halide_internal_initmod_inlined_c" < "${NATIVE_RUNTIME_DIR}halide_buffer_t.cpp" > "${INITMOD_PREFIX}inlined_c.cpp"
   )
 list(APPEND INITIAL_MODULES "${INITMOD_PREFIX}inlined_c.cpp")
 
@@ -274,7 +274,7 @@ foreach (i ${RUNTIME_HEADER_FILES})
   add_custom_command(OUTPUT "${INITMOD_PREFIX}${SYM_NAME}.cpp"
     # COMMENT "${i} -> ${INITMOD_PREFIX}${SYM_NAME}.cpp"
     DEPENDS "${NATIVE_RUNTIME_DIR}${i}" binary2cpp
-    COMMAND binary2cpp "halide_internal_runtime_header_${SYM_NAME}" < "${NATIVE_RUNTIME_DIR}${i}" > "${INITMOD_PREFIX}${SYM_NAME}.cpp"
+    COMMAND $<TARGET_FILE:binary2cpp> "halide_internal_runtime_header_${SYM_NAME}" < "${NATIVE_RUNTIME_DIR}${i}" > "${INITMOD_PREFIX}${SYM_NAME}.cpp"
     )
   list(APPEND INITIAL_MODULES "${INITMOD_PREFIX}${SYM_NAME}.cpp")
 endforeach()
@@ -447,7 +447,7 @@ set(HEADER_FILES
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/include")
 file(TO_NATIVE_PATH "${CMAKE_BINARY_DIR}/include/" NATIVE_INCLUDE_PATH)
 add_custom_command(OUTPUT "${CMAKE_BINARY_DIR}/include/Halide.h"
-  COMMAND build_halide_h "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.txt" ${HEADER_FILES} > "${NATIVE_INCLUDE_PATH}Halide.h"
+  COMMAND $<TARGET_FILE:build_halide_h> "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.txt" ${HEADER_FILES} > "${NATIVE_INCLUDE_PATH}Halide.h"
   WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
   DEPENDS build_halide_h "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.txt" ${HEADER_FILES})
 add_custom_target(

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -64,21 +64,21 @@ add_custom_command(OUTPUT "${EC32}.bc"
         DEPENDS "${GEN_TEST_DIR}/external_code_extern.cpp"
         COMMAND ${CLANG} ${CXX_WARNING_FLAGS} -O3 -c -m32 -target le32-unknown-nacl-unknown -emit-llvm "${GEN_TEST_DIR}/external_code_extern.cpp" -o "${EC32}.bc")
 add_custom_command(OUTPUT "${EC32}.cpp"
-        DEPENDS "${EC32}.bc"
-        COMMAND binary2cpp external_code_extern_bitcode_32 < "${EC32}.bc" > "${EC32}.cpp")
+        DEPENDS "${EC32}.bc" binary2cpp
+        COMMAND $<TARGET_FILE:binary2cpp> external_code_extern_bitcode_32 < "${EC32}.bc" > "${EC32}.cpp")
 
 set(EC64 "${PROJECT_BINARY_DIR}/${PROJECT_NAME}.build/external_code_extern_bitcode_64")
 add_custom_command(OUTPUT "${EC64}.bc"
         DEPENDS "${GEN_TEST_DIR}/external_code_extern.cpp"
         COMMAND ${CLANG} ${CXX_WARNING_FLAGS} -O3 -c -m64 -target le64-unknown-unknown-unknown -emit-llvm "${GEN_TEST_DIR}/external_code_extern.cpp" -o "${EC64}.bc")
 add_custom_command(OUTPUT "${EC64}.cpp"
-        DEPENDS "${EC64}.bc"
-        COMMAND binary2cpp external_code_extern_bitcode_64 < "${EC64}.bc" > "${EC64}.cpp")
+        DEPENDS "${EC64}.bc" binary2cpp
+        COMMAND $<TARGET_FILE:binary2cpp> external_code_extern_bitcode_64 < "${EC64}.bc" > "${EC64}.cpp")
 
 set(ECCPP "${PROJECT_BINARY_DIR}/${PROJECT_NAME}.build/external_code_extern_cpp_source")
 add_custom_command(OUTPUT "${ECCPP}.cpp"
-        DEPENDS "${GEN_TEST_DIR}/external_code_extern.cpp"
-        COMMAND binary2cpp external_code_extern_cpp_source < "${GEN_TEST_DIR}/external_code_extern.cpp" > "${ECCPP}.cpp")
+        DEPENDS "${GEN_TEST_DIR}/external_code_extern.cpp" binary2cpp
+        COMMAND $<TARGET_FILE:binary2cpp> external_code_extern_cpp_source < "${GEN_TEST_DIR}/external_code_extern.cpp" > "${ECCPP}.cpp")
 
 add_library(external_code_generator_deps "${EC32}.cpp" "${EC64}.cpp" "${ECCPP}.cpp")
 


### PR DESCRIPTION
Some of the targets that relied on these didn't list them in their DEPENDS (so build order variance could break).

All of them should have used $<TARGET_FILE> for the COMMAND setup; the fact that it worked currently was basically luck.

(Note: the need to $<TARGET_FILE> will go away once the `cmake-modern` PR lands -- the newer CMake version used there changes the behavior -- but until then, this is needed to make some cross-compile targets work.)