### PR TITLE
Clang tidy bugprone checkers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: '-*,modernize-use-override,performance-move-const-arg,modernize-use-emplace,performance-noexcept-move-constructor,performance-unnecessary-value-param,performance-unnecessary-copy-initialization,performance-trivially-destructible'
+Checks: '-*,modernize-use-override,performance-move-const-arg,modernize-use-emplace,performance-noexcept-move-constructor,performance-unnecessary-value-param,performance-unnecessary-copy-initialization,performance-trivially-destructible,bugprone-parent-virtual-call,bugprone-macro-parenthesis,bugprone-string-constructor,bugprone-sizeof-expression'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/src/AsyncProducers.cpp
+++ b/src/AsyncProducers.cpp
@@ -216,7 +216,7 @@ class GenerateConsumerBody : public NoOpCollapsingMutator {
                 return Acquire::make(acquire_sema, 1, op);
             }
         } else {
-            return IRMutator::visit(op);
+            return NoOpCollapsingMutator::visit(op);
         }
     }
 
@@ -225,7 +225,7 @@ class GenerateConsumerBody : public NoOpCollapsingMutator {
         if (starts_with(op->name, func + ".folding_semaphore.") && ends_with(op->name, ".head")) {
             return mutate(op->body);
         } else {
-            return IRMutator::visit(op);
+            return NoOpCollapsingMutator::visit(op);
         }
     }
 
@@ -233,7 +233,7 @@ class GenerateConsumerBody : public NoOpCollapsingMutator {
         if (starts_with(op->name, func + ".folding_semaphore.") && ends_with(op->name, ".head")) {
             return Evaluate::make(0);
         } else {
-            return IRMutator::visit(op);
+            return NoOpCollapsingMutator::visit(op);
         }
     }
 
@@ -245,7 +245,7 @@ class GenerateConsumerBody : public NoOpCollapsingMutator {
         if (starts_with(var->name, func + ".folding_semaphore.")) {
             return mutate(op->body);
         } else {
-            return IRMutator::visit(op);
+            return NoOpCollapsingMutator::visit(op);
         }
     }
 

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -645,7 +645,7 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Atomic *op) {
 
     // Issue atomic stores.
     ScopedValue<bool> old_emit_atomic_stores(emit_atomic_stores, true);
-    IRVisitor::visit(op);
+    CodeGen_C::visit(op);
 }
 
 void CodeGen_OpenCL_Dev::add_kernel(Stmt s,

--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -884,12 +884,12 @@ void CodeGen_GLSL::add_kernel(const Stmt &stmt, const string &name,
             ++num_varying_floats;
         } else if (args[i].type.is_float()) {
             header << "/// UNIFORM "
-                   << CodeGen_C::print_type(args[i].type) << " "
+                   << CodeGen_GLSLBase::print_type(args[i].type) << " "
                    << print_name(args[i].name) << " uniformf" << args[i].packed_index / 4 << "[" << args[i].packed_index % 4 << "]\n";
             ++num_uniform_floats;
         } else if (args[i].type.is_int()) {
             header << "/// UNIFORM "
-                   << CodeGen_C::print_type(args[i].type) << " "
+                   << CodeGen_GLSLBase::print_type(args[i].type) << " "
                    << print_name(args[i].name) << " uniformi" << args[i].packed_index / 4 << "[" << args[i].packed_index % 4 << "]\n";
             ++num_uniform_ints;
         }

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -328,7 +328,7 @@ void CodeGen_PTX_Dev::visit(const Atomic *op) {
 
     // Issue atomic stores.
     ScopedValue<bool> old_emit_atomic_stores(emit_atomic_stores, true);
-    IRVisitor::visit(op);
+    CodeGen_LLVM::visit(op);
 }
 
 string CodeGen_PTX_Dev::march() const {

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1011,11 +1011,11 @@ public:
  * Returns type of underlying operator+. */
 // @{
 template<typename Other, typename T>
-decltype((Other)0 + (T)0) operator+(const Other &a, const GeneratorParam<T> &b) {
+auto operator+(const Other &a, const GeneratorParam<T> &b) -> decltype(a + (T)b) {
     return a + (T)b;
 }
 template<typename Other, typename T>
-decltype((T)0 + (Other)0) operator+(const GeneratorParam<T> &a, const Other &b) {
+auto operator+(const GeneratorParam<T> &a, const Other &b) -> decltype((T)a + b) {
     return (T)a + b;
 }
 // @}
@@ -1024,11 +1024,11 @@ decltype((T)0 + (Other)0) operator+(const GeneratorParam<T> &a, const Other &b) 
  * Returns type of underlying operator-. */
 // @{
 template<typename Other, typename T>
-decltype((Other)0 - (T)0) operator-(const Other &a, const GeneratorParam<T> &b) {
+auto operator-(const Other &a, const GeneratorParam<T> &b) -> decltype(a - (T)b) {
     return a - (T)b;
 }
 template<typename Other, typename T>
-decltype((T)0 - (Other)0) operator-(const GeneratorParam<T> &a, const Other &b) {
+auto operator-(const GeneratorParam<T> &a, const Other &b) -> decltype((T)a - b) {
     return (T)a - b;
 }
 // @}
@@ -1037,11 +1037,11 @@ decltype((T)0 - (Other)0) operator-(const GeneratorParam<T> &a, const Other &b) 
  * Returns type of underlying operator*. */
 // @{
 template<typename Other, typename T>
-decltype((Other)0 * (T)0) operator*(const Other &a, const GeneratorParam<T> &b) {
+auto operator*(const Other &a, const GeneratorParam<T> &b) -> decltype(a * (T)b) {
     return a * (T)b;
 }
 template<typename Other, typename T>
-decltype((Other)0 * (T)0) operator*(const GeneratorParam<T> &a, const Other &b) {
+auto operator*(const GeneratorParam<T> &a, const Other &b) -> decltype((T)a * b) {
     return (T)a * b;
 }
 // @}
@@ -1050,11 +1050,11 @@ decltype((Other)0 * (T)0) operator*(const GeneratorParam<T> &a, const Other &b) 
  * Returns type of underlying operator/. */
 // @{
 template<typename Other, typename T>
-decltype((Other)0 / (T)1) operator/(const Other &a, const GeneratorParam<T> &b) {
+auto operator/(const Other &a, const GeneratorParam<T> &b) -> decltype(a / (T)b) {
     return a / (T)b;
 }
 template<typename Other, typename T>
-decltype((T)0 / (Other)1) operator/(const GeneratorParam<T> &a, const Other &b) {
+auto operator/(const GeneratorParam<T> &a, const Other &b) -> decltype((T)a / b) {
     return (T)a / b;
 }
 // @}
@@ -1063,11 +1063,11 @@ decltype((T)0 / (Other)1) operator/(const GeneratorParam<T> &a, const Other &b) 
  * Returns type of underlying operator%. */
 // @{
 template<typename Other, typename T>
-decltype((Other)0 % (T)1) operator%(const Other &a, const GeneratorParam<T> &b) {
+auto operator%(const Other &a, const GeneratorParam<T> &b) -> decltype(a % (T)b) {
     return a % (T)b;
 }
 template<typename Other, typename T>
-decltype((T)0 % (Other)1) operator%(const GeneratorParam<T> &a, const Other &b) {
+auto operator%(const GeneratorParam<T> &a, const Other &b) -> decltype((T)a % b) {
     return (T)a % b;
 }
 // @}
@@ -1076,11 +1076,11 @@ decltype((T)0 % (Other)1) operator%(const GeneratorParam<T> &a, const Other &b) 
  * Returns type of underlying operator>. */
 // @{
 template<typename Other, typename T>
-decltype((Other)0 > (T)1) operator>(const Other &a, const GeneratorParam<T> &b) {
+auto operator>(const Other &a, const GeneratorParam<T> &b) -> decltype(a > (T)b) {
     return a > (T)b;
 }
 template<typename Other, typename T>
-decltype((T)0 > (Other)1) operator>(const GeneratorParam<T> &a, const Other &b) {
+auto operator>(const GeneratorParam<T> &a, const Other &b) -> decltype((T)a > b) {
     return (T)a > b;
 }
 // @}
@@ -1089,11 +1089,11 @@ decltype((T)0 > (Other)1) operator>(const GeneratorParam<T> &a, const Other &b) 
  * Returns type of underlying operator<. */
 // @{
 template<typename Other, typename T>
-decltype((Other)0 < (T)1) operator<(const Other &a, const GeneratorParam<T> &b) {
+auto operator<(const Other &a, const GeneratorParam<T> &b) -> decltype(a < (T)b) {
     return a < (T)b;
 }
 template<typename Other, typename T>
-decltype((T)0 < (Other)1) operator<(const GeneratorParam<T> &a, const Other &b) {
+auto operator<(const GeneratorParam<T> &a, const Other &b) -> decltype((T)a < b) {
     return (T)a < b;
 }
 // @}
@@ -1102,11 +1102,11 @@ decltype((T)0 < (Other)1) operator<(const GeneratorParam<T> &a, const Other &b) 
  * Returns type of underlying operator>=. */
 // @{
 template<typename Other, typename T>
-decltype((Other)0 >= (T)1) operator>=(const Other &a, const GeneratorParam<T> &b) {
+auto operator>=(const Other &a, const GeneratorParam<T> &b) -> decltype(a >= (T)b) {
     return a >= (T)b;
 }
 template<typename Other, typename T>
-decltype((T)0 >= (Other)1) operator>=(const GeneratorParam<T> &a, const Other &b) {
+auto operator>=(const GeneratorParam<T> &a, const Other &b) -> decltype((T)a >= b) {
     return (T)a >= b;
 }
 // @}
@@ -1115,11 +1115,11 @@ decltype((T)0 >= (Other)1) operator>=(const GeneratorParam<T> &a, const Other &b
  * Returns type of underlying operator<=. */
 // @{
 template<typename Other, typename T>
-decltype((Other)0 <= (T)1) operator<=(const Other &a, const GeneratorParam<T> &b) {
+auto operator<=(const Other &a, const GeneratorParam<T> &b) -> decltype(a <= (T)b) {
     return a <= (T)b;
 }
 template<typename Other, typename T>
-decltype((T)0 <= (Other)1) operator<=(const GeneratorParam<T> &a, const Other &b) {
+auto operator<=(const GeneratorParam<T> &a, const Other &b) -> decltype((T)a <= b) {
     return (T)a <= b;
 }
 // @}
@@ -1128,11 +1128,11 @@ decltype((T)0 <= (Other)1) operator<=(const GeneratorParam<T> &a, const Other &b
  * Returns type of underlying operator==. */
 // @{
 template<typename Other, typename T>
-decltype((Other)0 == (T)1) operator==(const Other &a, const GeneratorParam<T> &b) {
+auto operator==(const Other &a, const GeneratorParam<T> &b) -> decltype(a == (T)b) {
     return a == (T)b;
 }
 template<typename Other, typename T>
-decltype((T)0 == (Other)1) operator==(const GeneratorParam<T> &a, const Other &b) {
+auto operator==(const GeneratorParam<T> &a, const Other &b) -> decltype((T)a == b) {
     return (T)a == b;
 }
 // @}
@@ -1141,11 +1141,11 @@ decltype((T)0 == (Other)1) operator==(const GeneratorParam<T> &a, const Other &b
  * Returns type of underlying operator!=. */
 // @{
 template<typename Other, typename T>
-decltype((Other)0 != (T)1) operator!=(const Other &a, const GeneratorParam<T> &b) {
+auto operator!=(const Other &a, const GeneratorParam<T> &b) -> decltype(a != (T)b) {
     return a != (T)b;
 }
 template<typename Other, typename T>
-decltype((T)0 != (Other)1) operator!=(const GeneratorParam<T> &a, const Other &b) {
+auto operator!=(const GeneratorParam<T> &a, const Other &b) -> decltype((T)a != b) {
     return (T)a != b;
 }
 // @}
@@ -1154,15 +1154,15 @@ decltype((T)0 != (Other)1) operator!=(const GeneratorParam<T> &a, const Other &b
  * Returns type of underlying operator&&. */
 // @{
 template<typename Other, typename T>
-decltype((Other)0 && (T)1) operator&&(const Other &a, const GeneratorParam<T> &b) {
+auto operator&&(const Other &a, const GeneratorParam<T> &b) -> decltype(a && (T)b) {
     return a && (T)b;
 }
 template<typename Other, typename T>
-decltype((T)0 && (Other)1) operator&&(const GeneratorParam<T> &a, const Other &b) {
+auto operator&&(const GeneratorParam<T> &a, const Other &b) -> decltype((T)a && b) {
     return (T)a && b;
 }
 template<typename T>
-decltype((T)0 && (T)1) operator&&(const GeneratorParam<T> &a, const GeneratorParam<T> &b) {
+auto operator&&(const GeneratorParam<T> &a, const GeneratorParam<T> &b) -> decltype((T)a && (T)b) {
     return (T)a && (T)b;
 }
 // @}
@@ -1171,15 +1171,15 @@ decltype((T)0 && (T)1) operator&&(const GeneratorParam<T> &a, const GeneratorPar
  * Returns type of underlying operator||. */
 // @{
 template<typename Other, typename T>
-decltype((Other)0 || (T)1) operator||(const Other &a, const GeneratorParam<T> &b) {
+auto operator||(const Other &a, const GeneratorParam<T> &b) -> decltype(a || (T)b) {
     return a || (T)b;
 }
 template<typename Other, typename T>
-decltype((T)0 || (Other)1) operator||(const GeneratorParam<T> &a, const Other &b) {
+auto operator||(const GeneratorParam<T> &a, const Other &b) -> decltype((T)a || b) {
     return (T)a || b;
 }
 template<typename T>
-decltype((T)0 || (T)1) operator||(const GeneratorParam<T> &a, const GeneratorParam<T> &b) {
+auto operator||(const GeneratorParam<T> &a, const GeneratorParam<T> &b) -> decltype((T)a || (T)b) {
     return (T)a || (T)b;
 }
 // @}
@@ -1195,20 +1195,20 @@ using std::max;
 using std::min;
 
 template<typename Other, typename T>
-decltype(min((Other)0, (T)1)) min_forward(const Other &a, const GeneratorParam<T> &b) {
+auto min_forward(const Other &a, const GeneratorParam<T> &b) -> decltype(min(a, (T)b)) {
     return min(a, (T)b);
 }
 template<typename Other, typename T>
-decltype(min((T)0, (Other)1)) min_forward(const GeneratorParam<T> &a, const Other &b) {
+auto min_forward(const GeneratorParam<T> &a, const Other &b) -> decltype(min((T)a, b)) {
     return min((T)a, b);
 }
 
 template<typename Other, typename T>
-decltype(max((Other)0, (T)1)) max_forward(const Other &a, const GeneratorParam<T> &b) {
+auto max_forward(const Other &a, const GeneratorParam<T> &b) -> decltype(max(a, (T)b)) {
     return max(a, (T)b);
 }
 template<typename Other, typename T>
-decltype(max((T)0, (Other)1)) max_forward(const GeneratorParam<T> &a, const Other &b) {
+auto max_forward(const GeneratorParam<T> &a, const Other &b) -> decltype(max((T)a, b)) {
     return max((T)a, b);
 }
 
@@ -1243,7 +1243,7 @@ auto max(const GeneratorParam<T> &a, const Other &b) -> decltype(Internal::Gener
 
 /** Not operator for GeneratorParam */
 template<typename T>
-decltype(!(T)0) operator!(const GeneratorParam<T> &a) {
+auto operator!(const GeneratorParam<T> &a) -> decltype(!(T)a) {
     return !(T)a;
 }
 

--- a/src/RDom.cpp
+++ b/src/RDom.cpp
@@ -1,14 +1,14 @@
-
-#include "RDom.h"
+#include <array>
+#include <utility>
 
 #include "Generator.h"
 #include "IREquality.h"
 #include "IROperator.h"
 #include "IRPrinter.h"
 #include "ImageParam.h"
+#include "RDom.h"
 #include "Simplify.h"
 #include "Util.h"
-#include <utility>
 
 namespace Halide {
 

--- a/src/RDom.cpp
+++ b/src/RDom.cpp
@@ -77,9 +77,9 @@ ReductionDomain build_domain(ReductionVariable (&vars)[N]) {
 // This just initializes the predefined x, y, z, w members of RDom.
 void RDom::init_vars(const string &name) {
     const std::vector<ReductionVariable> &dom_vars = dom.domain();
-    RVar *vars[] = {&x, &y, &z, &w};
+    std::array<RVar *, 4> vars = {&x, &y, &z, &w};
 
-    for (size_t i = 0; i < sizeof(vars) / sizeof(vars[0]); i++) {
+    for (size_t i = 0; i < vars.size(); i++) {
         if (i < dom_vars.size()) {
             *(vars[i]) = RVar(dom, i);
         } else {


### PR DESCRIPTION
This turns on a few checkers for things clang-tidy considers bugprone. They are:

- Calling a grandparent's virtual method instead of the parent 
We did this in a few places, usually when there wasn't an override in the parent class, so it was fine. I think one of them was a bug though - CodeGen of atomics in opencl probably just skipped the atomic node and went straight to the body, because it called the IRVisitor visit override instead of the CodeGen_C override.

- Constructing a string from 0 is UB 
This happened in the unevaluated contexts in the LHS of the Generator operator overrides. Was introduced when we allowed `GeneratorParam<string>`

- sizeof a pointer is considered a code smell, because often you're actually trying to take sizeof an array and failing. In this case it wasn't wrong, but it was a little confusing. Using a std::array seemed cleaner.