### PR TITLE
Move first simplification before allocation bounds inference

### DIFF
--- a/src/AllocationBoundsInference.cpp
+++ b/src/AllocationBoundsInference.cpp
@@ -142,7 +142,6 @@ class StripDeclareBoxTouched : public IRMutator {
             return IRMutator::visit(op);
         }
     }
-
 };
 
 Stmt allocation_bounds_inference(Stmt s,

--- a/src/ApplySplit.cpp
+++ b/src/ApplySplit.cpp
@@ -49,25 +49,24 @@ vector<ApplySplitResult> apply_split(const Split &split, bool is_update, const s
             // but we know nothing new about the outer dimension.
         } else if (tail == TailStrategy::GuardWithIf) {
             // It's an exact split but we failed to prove that the
-            // extent divides the factor. Use predication.
+            // extent divides the factor. Use predication to avoid
+            // running off the end of the original loop.
 
-            // Make a var representing the original var minus its
-            // min. It's important that this is a single Var so
-            // that bounds inference has a chance of understanding
-            // what it means for it to be limited by the if
-            // statement's condition.
-            Expr rebased = outer * split.factor + inner;
-            string rebased_var_name = prefix + split.old_var + ".rebased";
-            Expr rebased_var = Variable::make(Int(32), rebased_var_name);
+            // Bounds inference has trouble exploiting an if
+            // condition. We'll directly tell it that the loop
+            // variable is bounded by the original loop bounds by
+            // replacing the variable with a promise-clamped version
+            // of it.
+            Expr guarded = promise_clamped(old_var, old_min, old_max);
+            string guarded_var_name = prefix + split.old_var + ".guarded";
+            Expr guarded_var = Variable::make(Int(32), guarded_var_name);
+            result.emplace_back(prefix + split.old_var, guarded_var, ApplySplitResult::Substitution);
+            result.emplace_back(guarded_var_name, guarded, ApplySplitResult::LetStmt);
 
-            result.emplace_back(
-                prefix + split.old_var, rebased_var + old_min, ApplySplitResult::Substitution);
-
-            // Tell Halide to optimize for the case in which this
-            // condition is true by partitioning some outer loop.
-            Expr cond = likely(rebased_var < old_extent);
+            // Inject the if condition *after* doing the substitution
+            // for the guarded version.
+            Expr cond = likely(old_var <= old_max);
             result.emplace_back(cond);
-            result.emplace_back(rebased_var_name, rebased, ApplySplitResult::LetStmt);
 
         } else if (tail == TailStrategy::ShiftInwards) {
             // Adjust the base downwards to not compute off the
@@ -77,15 +76,12 @@ vector<ApplySplitResult> apply_split(const Split &split, bool is_update, const s
             // partition) if we're at or inside the innermost
             // non-trivial loop.
             base = likely_if_innermost(base);
-
             base = Min::make(base, old_max + (1 - split.factor));
         } else {
             internal_assert(tail == TailStrategy::RoundUp);
         }
 
-        // Substitute in the new expression for the split variable ...
-        result.emplace_back(old_var_name, base_var + inner, ApplySplitResult::Substitution);
-        // ... but also define it as a let for the benefit of bounds inference.
+        // Define the original variable as the base value computed above plus the inner loop variable.
         result.emplace_back(old_var_name, base_var + inner, ApplySplitResult::LetStmt);
         result.emplace_back(base_name, base, ApplySplitResult::LetStmt);
 

--- a/src/ApplySplit.cpp
+++ b/src/ApplySplit.cpp
@@ -96,12 +96,7 @@ vector<ApplySplitResult> apply_split(const Split &split, bool is_update, const s
         Expr outer_min = Variable::make(Int(32), prefix + split.outer + ".loop_min");
         Expr inner_extent = Variable::make(Int(32), prefix + split.inner + ".loop_extent");
 
-        // If the inner extent is zero, the loop will never be
-        // entered, but the bounds expressions lifted out might
-        // contain divides or mods by zero. In the cases where
-        // simplification of inner and outer matter, inner_extent
-        // is a constant, so the max will simplify away.
-        Expr factor = max(inner_extent, 1);
+        const Expr &factor = inner_extent;
         Expr inner = fused % factor + inner_min;
         Expr outer = fused / factor + outer_min;
 

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -499,7 +499,6 @@ private:
         op->b.accept(this);
         Interval b = interval;
 
-
         if (!b.is_bounded()) {
             // Integer division can only make things smaller in
             // magnitude (but can flip the sign).
@@ -1769,8 +1768,8 @@ private:
             const string &func = handle->name;
             Box b(op->args.size() / 2);
             for (size_t i = 0; i < b.size(); i++) {
-                b[i].min = op->args[2*i + 1];
-                b[i].max = op->args[2*i + 2];
+                b[i].min = op->args[2 * i + 1];
+                b[i].max = op->args[2 * i + 2];
             }
             merge_boxes(boxes[func], b);
         }

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1039,7 +1039,8 @@ private:
                     bounds_of_type(t);
                 }
             }
-        } else if (op->is_intrinsic(Call::unsafe_promise_clamped)) {
+        } else if (op->is_intrinsic(Call::unsafe_promise_clamped) ||
+                   op->is_intrinsic(Call::promise_clamped)) {
             Expr full_clamp = clamp(op->args[0], op->args[1], op->args[2]);
             full_clamp.accept(this);
         } else if (op->is_intrinsic(Call::likely) ||
@@ -2814,12 +2815,12 @@ void bounds_test() {
     check(scope, Select::make(x < 4, x, x + 100), 0, 110);
     check(scope, x + y, y, y + 10);
     check(scope, x * y, min(y, 0) * 10, max(y, 0) * 10);
-    check(scope, x / (x + y), Interval::neg_inf(), Interval::pos_inf());
+    check(scope, x / (x + y), -10, 10);
     check(scope, 11 / (x + 1), 1, 11);
     check(scope, Load::make(Int(8), "buf", x, Buffer<>(), Parameter(), const_true(), ModulusRemainder()),
           i8(-128), i8(127));
     check(scope, y + (Let::make("y", x + 3, y - x + 10)), y + 3, y + 23);  // Once again, we don't know that y is correlated with x
-    check(scope, clamp(1 / (x - 2), x - 10, x + 10), -10, 20);
+    check(scope, clamp(1000 / (x - 2), x - 10, x + 10), -10, 20);
     check(scope, cast<uint16_t>(x / 2), u16(0), u16(5));
     check(scope, cast<uint16_t>((x + 10) / 2), u16(5), u16(10));
     check(scope, x < 20, make_bool(1), make_bool(1));

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1227,23 +1227,6 @@ private:
                            op->func, op->value_index, op->image, op->param),
                 Call::make(t, op->name, {interval.max}, op->call_type,
                            op->func, op->value_index, op->image, op->param));
-
-        } else if (false &&
-                   !const_bound &&
-                   (op->name == Call::buffer_get_min ||
-                    op->name == Call::buffer_get_max)) {
-            // Bounds query results should have perfect nesting. Their
-            // max over a loop is just the same bounds query call at
-            // an outer loop level. This requires that the query is
-            // also done at the outer loop level so that the buffer
-            // arg is still valid, which it is, so it is.
-            //
-            // TODO: There should be an assert injected in the inner
-            // loop to check perfect nesting.
-
-            // TODO: This is a big problem!!!
-            interval = Interval(Call::make(Int(32), Call::buffer_get_min, op->args, Call::Extern),
-                                Call::make(Int(32), Call::buffer_get_max, op->args, Call::Extern));
         } else if (op->is_intrinsic(Call::popcount) ||
                    op->is_intrinsic(Call::count_leading_zeros) ||
                    op->is_intrinsic(Call::count_trailing_zeros)) {

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1041,8 +1041,15 @@ private:
             }
         } else if (op->is_intrinsic(Call::unsafe_promise_clamped) ||
                    op->is_intrinsic(Call::promise_clamped)) {
-            Expr full_clamp = clamp(op->args[0], op->args[1], op->args[2]);
-            full_clamp.accept(this);
+            // Unlike an explicit clamp, we are also permitted to
+            // assume the upper bound is greater than the lower bound.
+            op->args[1].accept(this);
+            Interval lower = interval;
+            op->args[2].accept(this);
+            Interval upper = interval;
+            op->args[0].accept(this);
+            interval.min = Interval::make_max(interval.min, lower.min);
+            interval.max = Interval::make_min(interval.max, upper.max);
         } else if (op->is_intrinsic(Call::likely) ||
                    op->is_intrinsic(Call::likely_if_innermost)) {
             internal_assert(op->args.size() == 1);

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -183,7 +183,7 @@ public:
     // The fused group is indexed in the same way as 'fused_groups'.
     const vector<set<FusedPair>> &fused_pairs_in_groups;
     const FuncValueBounds &func_bounds;
-    set<string> in_pipeline, inner_productions;
+    set<string> in_pipeline, inner_productions, has_extern_consumer;
     const Target target;
 
     struct CondValue {
@@ -378,6 +378,7 @@ public:
                            const vector<set<FusedPair>> &fused_pairs_in_groups,
                            const set<string> &in_pipeline,
                            const set<string> &inner_productions,
+                           const set<string> &has_extern_consumer,
                            const Target &target) {
 
             // Merge all the relevant boxes.
@@ -568,12 +569,30 @@ public:
             for (size_t d = 0; d < b.size(); d++) {
                 string arg = name + ".s" + std::to_string(stage) + "." + func_args[d];
 
+                const bool clamp_to_outer_bounds =
+                    !in_pipeline.empty() && has_extern_consumer.count(name);
+                if (clamp_to_outer_bounds) {
+                    // Allocation bounds inference is going to have a
+                    // bad time lifting the results of the bounds
+                    // queries outwards. Help it out by insisting that
+                    // the bounds are clamped to lie within the bounds
+                    // one loop level up.
+                    b[d].min = max(b[d].min, Variable::make(Int(32), arg + ".outer_min"));
+                    b[d].max = min(b[d].max, Variable::make(Int(32), arg + ".outer_max"));
+                }
+
                 if (b[d].is_single_point()) {
                     s = LetStmt::make(arg + ".min", Variable::make(Int(32), arg + ".max"), s);
                 } else {
                     s = LetStmt::make(arg + ".min", b[d].min, s);
                 }
                 s = LetStmt::make(arg + ".max", b[d].max, s);
+
+                if (clamp_to_outer_bounds) {
+                    s = LetStmt::make(arg + ".outer_min", Variable::make(Int(32), arg + ".min"), s);
+                    s = LetStmt::make(arg + ".outer_max", Variable::make(Int(32), arg + ".max"), s);
+                }
+
             }
 
             if (stage > 0) {
@@ -861,6 +880,7 @@ public:
                 for (size_t j = 0; j < args.size(); j++) {
                     if (args[j].is_func()) {
                         Function f(args[j].func);
+                        has_extern_consumer.insert(f.name());
                         string stage_name = f.name() + ".s" + std::to_string(f.updates().size());
                         Box b(f.dimensions());
                         for (int d = 0; d < f.dimensions(); d++) {
@@ -1089,7 +1109,8 @@ public:
                     }
                     body = stages[i].define_bounds(
                         body, f, stage_name, stage_index, op->name, fused_groups,
-                        fused_pairs_in_groups, in_pipeline, inner_productions, target);
+                        fused_pairs_in_groups, in_pipeline, inner_productions,
+                        has_extern_consumer, target);
                 }
             }
 

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -997,17 +997,29 @@ public:
 
         Stmt body = op->body;
 
-        // Walk inside of any let statements that don't depend on
+        // Walk inside of any let/if statements that don't depend on
         // bounds inference results so that we don't needlessly
         // complicate our bounds expressions.
-        vector<pair<string, Expr>> lets;
-        while (const LetStmt *let = body.as<LetStmt>()) {
-            if (depends_on_bounds_inference(let->value)) {
+        vector<pair<string, Expr>> wrappers;
+        while (1) {
+            if (const LetStmt *let = body.as<LetStmt>()) {
+                if (depends_on_bounds_inference(let->value)) {
+                    break;
+                }
+
+                body = let->body;
+                wrappers.emplace_back(let->name, let->value);
+            } else if (const IfThenElse *if_then_else = body.as<IfThenElse>()) {
+                if (depends_on_bounds_inference(if_then_else->condition) ||
+                    if_then_else->else_case.defined()) {
+                    break;
+                }
+
+                body = if_then_else->then_case;
+                wrappers.emplace_back(std::string(), if_then_else->condition);
+            } else {
                 break;
             }
-
-            body = let->body;
-            lets.emplace_back(let->name, let->value);
         }
 
         // If there are no pipelines at this loop level, we can skip
@@ -1177,9 +1189,14 @@ public:
         inner_productions.insert(old_inner_productions.begin(),
                                  old_inner_productions.end());
 
-        // Rewrap the let statements
-        for (size_t i = lets.size(); i > 0; i--) {
-            body = LetStmt::make(lets[i - 1].first, lets[i - 1].second, body);
+        // Rewrap the let/if statements
+        for (size_t i = wrappers.size(); i > 0; i--) {
+            const auto &p = wrappers[i - 1];
+            if (p.first.empty()) {
+                body = IfThenElse::make(p.second, body);
+            } else {
+                body = LetStmt::make(p.first, p.second, body);
+            }
         }
 
         return For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -592,7 +592,6 @@ public:
                     s = LetStmt::make(arg + ".outer_min", Variable::make(Int(32), arg + ".min"), s);
                     s = LetStmt::make(arg + ".outer_max", Variable::make(Int(32), arg + ".max"), s);
                 }
-
             }
 
             if (stage > 0) {

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -635,6 +635,7 @@ const char *const intrinsic_op_names[] = {
     "stringify",
     "undef",
     "unsafe_promise_clamped",
+    "promise_clamped",
 };
 
 static_assert(sizeof(intrinsic_op_names) / sizeof(intrinsic_op_names[0]) == Call::IntrinsicOpCount,

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -592,6 +592,7 @@ const char *const intrinsic_op_names[] = {
     "cast_mask",
     "count_leading_zeros",
     "count_trailing_zeros",
+    "declare_box_touched",
     "debug_to_file",
     "div_round_to_zero",
     "dynamic_shuffle",

--- a/src/IR.h
+++ b/src/IR.h
@@ -504,6 +504,7 @@ struct Call : public ExprNode<Call> {
         cast_mask,
         count_leading_zeros,
         count_trailing_zeros,
+        declare_box_touched,
         debug_to_file,
         div_round_to_zero,
         dynamic_shuffle,

--- a/src/IR.h
+++ b/src/IR.h
@@ -547,6 +547,7 @@ struct Call : public ExprNode<Call> {
         stringify,
         undef,
         unsafe_promise_clamped,
+        promise_clamped,
         IntrinsicOpCount  // Sentinel: keep last.
     };
 

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -1136,6 +1136,20 @@ Expr unsafe_promise_clamped(const Expr &value, const Expr &min, const Expr &max)
                                 Internal::Call::Intrinsic);
 }
 
+namespace Internal {
+Expr promise_clamped(const Expr &value, const Expr &min, const Expr &max) {
+    internal_assert(value.defined()) << "promise_clamped with undefined value.\n";
+    Expr n_min_val = min.defined() ? lossless_cast(value.type(), min) : value.type().min();
+    Expr n_max_val = max.defined() ? lossless_cast(value.type(), max) : value.type().max();
+
+    // Min and max are allowed to be undefined with the meaning of no bound on that side.
+    return Internal::Call::make(value.type(),
+                                Internal::Call::promise_clamped,
+                                {value, n_min_val, n_max_val},
+                                Internal::Call::Intrinsic);
+}
+}  // namespace Internal
+
 Expr operator+(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator+ of undefined Expr\n";
     Internal::match_types(a, b);

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1372,6 +1372,14 @@ Expr strict_float(Expr e);
  */
 Expr unsafe_promise_clamped(const Expr &value, const Expr &min, const Expr &max);
 
+namespace Internal {
+/** An entirely unchecked version of unsafe_promise_clamped, used
+ * inside the compiler as an annotation of the known bounds of an
+ * Expr when it has proved something is bounded and wants to
+ * record that fact for later passes to exploit. */
+Expr promise_clamped(const Expr &value, const Expr &min, const Expr &max);
+}  // namespace Internal
+
 }  // namespace Halide
 
 #endif

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -188,6 +188,19 @@ Module lower(const vector<Function> &output_funcs,
     debug(2) << "Lowering after sliding window:\n"
              << s << '\n';
 
+    // This uniquifies the variable names, so we're good to simplify
+    // after this point. This lets later passes assume syntactic
+    // equivalence means semantic equivalence.
+    debug(1) << "Uniquifying variable names...\n";
+    s = uniquify_variable_names(s);
+    debug(2) << "Lowering after uniquifying variable names:\n"
+             << s << "\n\n";
+
+    debug(1) << "Simplifying...\n";
+    s = simplify(s, false);  // Storage folding and allocation bounds inference needs .loop_max symbols
+    debug(2) << "Lowering after first simplification:\n"
+             << s << "\n\n";
+
     debug(1) << "Simplifying correlated differences...\n";
     s = simplify_correlated_differences(s);
     debug(2) << "Lowering after simplifying correlated differences:\n"
@@ -201,19 +214,6 @@ Module lower(const vector<Function> &output_funcs,
     debug(1) << "Removing code that depends on undef values...\n";
     s = remove_undef(s);
     debug(2) << "Lowering after removing code that depends on undef values:\n"
-             << s << "\n\n";
-
-    // This uniquifies the variable names, so we're good to simplify
-    // after this point. This lets later passes assume syntactic
-    // equivalence means semantic equivalence.
-    debug(1) << "Uniquifying variable names...\n";
-    s = uniquify_variable_names(s);
-    debug(2) << "Lowering after uniquifying variable names:\n"
-             << s << "\n\n";
-
-    debug(1) << "Simplifying...\n";
-    s = simplify(s, false);  // Storage folding needs .loop_max symbols
-    debug(2) << "Lowering after first simplification:\n"
              << s << "\n\n";
 
     debug(1) << "Performing storage folding optimization...\n";

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -231,6 +231,11 @@ Module lower(const vector<Function> &output_funcs,
     debug(2) << "Lowering after injecting prefetches:\n"
              << s << "\n\n";
 
+    debug(1) << "Discarding safe promises...\n";
+    s = lower_safe_promises(s);
+    debug(2) << "Lowering after discarding safe promises:\n"
+             << s << "\n\n";
+
     debug(1) << "Dynamically skipping stages...\n";
     s = skip_stages(s, order);
     debug(2) << "Lowering after dynamically skipping stages:\n"

--- a/src/Simplify_Internal.h
+++ b/src/Simplify_Internal.h
@@ -185,6 +185,11 @@ public:
     IRMatcher::WildConst<2> c2;
     IRMatcher::WildConst<3> c3;
 
+    // Tracks whether or not we're inside a vector loop. Certain
+    // transformations are not a good idea if the code is to be
+    // vectorized.
+    bool in_vector_loop = false;
+
     // If we encounter a reference to a buffer (a Load, Store, Call,
     // or Provide), there's an implicit dependence on some associated
     // symbols.

--- a/src/Simplify_LT.cpp
+++ b/src/Simplify_LT.cpp
@@ -42,6 +42,12 @@ Expr Simplify::visit(const LT *op, ExprInfo *bounds) {
              rewrite(x < min(x, y), false) ||
              rewrite(x < min(y, x), false) ||
 
+             // From the simplifier synthesis project
+             rewrite((max(y, z) < min(x, y)), false) ||
+             rewrite((max(y, z) < min(y, x)), false) ||
+             rewrite((max(z, y) < min(x, y)), false) ||
+             rewrite((max(z, y) < min(y, x)), false) ||
+
              // Comparisons of ramps and broadcasts. If the first
              // and last lanes are provably < or >= the broadcast
              // we can collapse the comparison.

--- a/src/Simplify_Let.cpp
+++ b/src/Simplify_Let.cpp
@@ -247,7 +247,8 @@ Body Simplify::simplify_let(const LetOrLetStmt *op, ExprInfo *bounds) {
             count_var_uses(it->new_value, vars_used);
         }
 
-        if (!remove_dead_lets || (info.old_uses > 0 && vars_used.count(it->op->name) > 0)) {
+        if ((!remove_dead_lets && std::is_same<LetOrLetStmt, LetStmt>::value) ||
+            (info.old_uses > 0 && vars_used.count(it->op->name) > 0)) {
             // The old name is still in use. We'd better keep it as well.
             result = LetOrLetStmt::make(it->op->name, it->value, result);
             count_var_uses(it->value, vars_used);

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -156,15 +156,9 @@ Stmt Simplify::visit(const For *op) {
     } else if (extent_bounds.max_defined &&
                extent_bounds.max == 0) {
         return Evaluate::make(0);
-    } else if (extent_bounds.max_defined &&
-               extent_bounds.max == 1 &&
-               op->device_api == DeviceAPI::None) {
+    } else if (is_one(new_extent)) {
         Stmt s = LetStmt::make(op->name, new_min, new_body);
-        if (extent_bounds.min_defined && extent_bounds.min == 1) {
-            return mutate(s);
-        } else {
-            return mutate(IfThenElse::make(new_extent > 0, s));
-        }
+        return mutate(s);
     } else if (op->min.same_as(new_min) &&
                op->extent.same_as(new_extent) &&
                op->body.same_as(new_body)) {

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -13,13 +13,22 @@ using std::vector;
 Stmt Simplify::visit(const IfThenElse *op) {
     Expr condition = mutate(op->condition, nullptr);
 
+    // If (likely(true)) ...
+    const Call *call = condition.as<Call>();
+    Expr unwrapped_condition = condition;
+    if (call &&
+        (call->is_intrinsic(Call::likely) ||
+         call->is_intrinsic(Call::likely_if_innermost))) {
+        unwrapped_condition = call->args[0];
+    }
+
     // If (true) ...
-    if (is_one(condition)) {
+    if (is_one(unwrapped_condition)) {
         return mutate(op->then_case);
     }
 
     // If (false) ...
-    if (is_zero(condition)) {
+    if (is_zero(unwrapped_condition)) {
         if (op->else_case.defined()) {
             return mutate(op->else_case);
         } else {
@@ -29,13 +38,13 @@ Stmt Simplify::visit(const IfThenElse *op) {
 
     Stmt then_case, else_case;
     {
-        auto f = scoped_truth(condition);
+        auto f = scoped_truth(unwrapped_condition);
         // Also substitute the entire condition
         then_case = substitute(op->condition, const_true(condition.type().lanes()), op->then_case);
         then_case = mutate(then_case);
     }
     {
-        auto f = scoped_falsehood(condition);
+        auto f = scoped_falsehood(unwrapped_condition);
         else_case = substitute(op->condition, const_false(condition.type().lanes()), op->else_case);
         else_case = mutate(else_case);
     }
@@ -55,6 +64,7 @@ Stmt Simplify::visit(const IfThenElse *op) {
     const ProducerConsumer *else_pc = else_case.as<ProducerConsumer>();
     const Block *then_block = then_case.as<Block>();
     const Block *else_block = else_case.as<Block>();
+    const For *then_for = then_case.as<For>();
     if (then_acquire &&
         else_acquire &&
         equal(then_acquire->semaphore, else_acquire->semaphore) &&
@@ -89,6 +99,11 @@ Stmt Simplify::visit(const IfThenElse *op) {
     } else if (else_block && equal(then_case, else_block->rest)) {
         return Block::make(mutate(IfThenElse::make(condition, Evaluate::make(0), else_block->first)),
                            then_case);
+    } else if (then_for &&
+               !else_case.defined() &&
+               equal(unwrapped_condition, 0 < then_for->extent)) {
+        // This guard is redundant
+        return then_case;
     } else if (condition.same_as(op->condition) &&
                then_case.same_as(op->then_case) &&
                else_case.same_as(op->else_case)) {
@@ -136,6 +151,10 @@ Stmt Simplify::visit(const For *op) {
     Expr new_min = mutate(op->min, &min_bounds);
     Expr new_extent = mutate(op->extent, &extent_bounds);
 
+    ScopedValue<bool> old_in_vector_loop(in_vector_loop,
+                                         (in_vector_loop ||
+                                          op->for_type == ForType::Vectorized));
+
     bool bounds_tracked = false;
     if (min_bounds.min_defined || (min_bounds.max_defined && extent_bounds.max_defined)) {
         min_bounds.max += extent_bounds.max - 1;
@@ -159,6 +178,12 @@ Stmt Simplify::visit(const For *op) {
     } else if (is_one(new_extent)) {
         Stmt s = LetStmt::make(op->name, new_min, new_body);
         return mutate(s);
+    } else if (extent_bounds.max_defined &&
+               extent_bounds.max == 1 &&
+               !in_vector_loop &&
+               op->device_api == DeviceAPI::None) {
+        Stmt s = LetStmt::make(op->name, new_min, new_body);
+        return mutate(IfThenElse::make(0 < new_extent, s));
     } else if (op->min.same_as(new_min) &&
                op->extent.same_as(new_extent) &&
                op->body.same_as(new_body)) {

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -408,15 +408,18 @@ class HasExternConsumer : public IRVisitor {
 
     using IRVisitor::visit;
 
-    void visit(const Variable *op) {
+    void visit(const Variable *op) override {
         if (op->name == func + ".buffer") {
             result = true;
         }
     }
 
     const std::string &func;
+
 public:
-    HasExternConsumer(const std::string &func) : func(func) {}
+    HasExternConsumer(const std::string &func)
+        : func(func) {
+    }
     bool result = false;
 };
 

--- a/src/UnsafePromises.cpp
+++ b/src/UnsafePromises.cpp
@@ -27,6 +27,9 @@ class LowerUnsafePromises : public IRMutator {
             } else {
                 return mutate(op->args[0]);
             }
+        } else if (op->is_intrinsic(Call::promise_clamped)) {
+            // This is also a good point to discard safe promises
+            return mutate(op->args[0]);
         } else {
             return IRMutator::visit(op);
         }

--- a/src/UnsafePromises.cpp
+++ b/src/UnsafePromises.cpp
@@ -5,6 +5,8 @@
 namespace Halide {
 namespace Internal {
 
+namespace {
+
 class LowerUnsafePromises : public IRMutator {
     using IRMutator::visit;
 
@@ -27,9 +29,6 @@ class LowerUnsafePromises : public IRMutator {
             } else {
                 return mutate(op->args[0]);
             }
-        } else if (op->is_intrinsic(Call::promise_clamped)) {
-            // This is also a good point to discard safe promises
-            return mutate(op->args[0]);
         } else {
             return IRMutator::visit(op);
         }
@@ -43,8 +42,26 @@ public:
     }
 };
 
+class LowerSafePromises : public IRMutator {
+    using IRMutator::visit;
+
+    Expr visit(const Call *op) override {
+        if (op->is_intrinsic(Call::promise_clamped)) {
+            return mutate(op->args[0]);
+        } else {
+            return IRMutator::visit(op);
+        }
+    }
+};
+
+}  // namespace
+
 Stmt lower_unsafe_promises(const Stmt &s, const Target &t) {
     return LowerUnsafePromises(t.has_feature(Target::CheckUnsafePromises)).mutate(s);
+}
+
+Stmt lower_safe_promises(const Stmt &s) {
+    return LowerSafePromises().mutate(s);
 }
 
 }  // namespace Internal

--- a/src/UnsafePromises.h
+++ b/src/UnsafePromises.h
@@ -15,6 +15,11 @@ namespace Internal {
     code, depending on the target. */
 Stmt lower_unsafe_promises(const Stmt &s, const Target &t);
 
+/** Lower all safe promises by just stripping them. This is a good
+ * idea once no more lowering stages are going to use
+ * boxes_touched. */
+Stmt lower_safe_promises(const Stmt &s);
+
 }  // namespace Internal
 }  // namespace Halide
 

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -204,6 +204,7 @@ tests(GROUPS correctness travis
         named_updates.cpp
         nested_shiftinwards.cpp
         newtons_method.cpp
+        non_nesting_extern_bounds_query.cpp
         non_vector_aligned_embeded_buffer.cpp
         obscure_image_references.cpp
         oddly_sized_output.cpp

--- a/test/correctness/extern_output_expansion.cpp
+++ b/test/correctness/extern_output_expansion.cpp
@@ -24,10 +24,10 @@ extern "C" DLLEXPORT int extern_stage(halide_buffer_t *in, halide_buffer_t *out)
         }
 
     } else {
-        assert(out->dim[0].extent % 17 == 0);
         printf("in: %d %d, out: %d %d\n",
                in->dim[0].min, in->dim[0].extent,
                out->dim[0].min, out->dim[0].extent);
+        assert(out->dim[0].extent % 17 == 0);
         int32_t *in_origin = (int32_t *)in->host - in->dim[0].min;
         int32_t *out_origin = (int32_t *)out->host - out->dim[0].min;
         for (int i = out->dim[0].min; i < out->dim[0].min + out->dim[0].extent; i++) {

--- a/test/correctness/non_nesting_extern_bounds_query.cpp
+++ b/test/correctness/non_nesting_extern_bounds_query.cpp
@@ -1,0 +1,70 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+// Extern stages are supposed to obey the following nesting property
+// on bounds queries: If some region of the output O requires some
+// region of the input I, then requesting any subset of O should only
+// require a subset of I.
+//
+// This extern stage violates that property. We're going to set up a
+// schedule that does a bounds query to it for an entire image, and a
+// bounds query for a single scanline. For the whole-image query it
+// will claim to need a modest-sized input, but for the single
+// scanline query it will claim to need a much wider input. The result
+// is that the bounds query is not entirely respected. The actual input
+// received in non-bounds-query-mode is the intersection of what it
+// asked for for a single scanline and what it asked for for the whole
+// image.
+extern "C" DLLEXPORT int misbehaving_extern_stage(halide_buffer_t *in, halide_buffer_t *out) {
+    if (in->is_bounds_query()) {
+        // As a baseline, require the same amount of input as output, like a copy
+        memcpy(in->dim, out->dim, out->dimensions * sizeof(halide_dimension_t));
+        if (out->dim[1].extent == 1) {
+            // This is the inner query, for a single scanline of
+            // output.  Require a wider input, violating the nesting
+            // property. Shift it over a little too.
+            in->dim[0].min += 50;
+            in->dim[0].extent += 100;
+        }
+    } else {
+        // The inner (bad) bounds query should not have been respected
+        // in the x dimension. You get the intersection of the inner
+        // query and the outer query.
+
+        // Check the left edge was indeed shifted inwards, as
+        // requested by the per-scanline bounds query.
+        assert(in->dim[0].min == out->dim[0].min + 50);
+
+        // Check the right edge wasn't shifted over, but was instead
+        // clamped to lie within the outer bounds query.
+        assert(in->dim[0].extent == out->dim[0].extent - 50);
+
+        // The inner bounds query was fine in the y dimension, which
+        // correctly nested.
+        assert(in->dim[1].min == out->dim[1].min);
+        assert(in->dim[1].extent == 1);
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    Func f, g, h;
+    Var x, y;
+    f(x, y) = x + y;
+    g.define_extern("misbehaving_extern_stage", {f}, Int(32), 2);
+    h(x, y) = g(x, y);
+
+    g.compute_at(h, y);
+    f.compute_at(h, y);
+
+    h.realize(200, 200);
+
+    printf("Success!\n");
+}

--- a/test/correctness/storage_folding.cpp
+++ b/test/correctness/storage_folding.cpp
@@ -44,7 +44,7 @@ extern "C" DLLEXPORT int zigzag_buffer_copy(halide_buffer_t *in, halide_buffer_t
         auto coord_map =
             [](int y) {
                 // Reverse the bottom 8 bits
-                int new_y = y & ~255;;
+                int new_y = y & ~255;
                 for (int i = 0; i < 8; i++) {
                     if (y & (7 - i)) {
                         new_y |= (1 << i);

--- a/test/correctness/storage_folding.cpp
+++ b/test/correctness/storage_folding.cpp
@@ -39,21 +39,33 @@ extern "C" DLLEXPORT int simple_buffer_copy(halide_buffer_t *in, halide_buffer_t
 extern "C" DLLEXPORT int zigzag_buffer_copy(halide_buffer_t *in, halide_buffer_t *out) {
     if (in->is_bounds_query()) {
         memcpy(in->dim, out->dim, out->dimensions * sizeof(halide_dimension_t));
-        int y_min = in->dim[1].min;
-        int y_max = y_min + in->dim[1].extent - 1;
-        y_min &= 63;
-        if (y_min >= 32) {
-            y_min = 63 - y_min;
+
+        // An intentionally nasty mapping from y coords of the output to y coords of the input:
+        auto coord_map =
+            [](int y) {
+                // Reverse the bottom 8 bits
+                int new_y = y & ~255;;
+                for (int i = 0; i < 8; i++) {
+                    if (y & (7 - i)) {
+                        new_y |= (1 << i);
+                    }
+                }
+                return new_y;
+            };
+
+        // Just manually take a min/max over all scanlines of the output
+        int in_y_min = coord_map(out->dim[1].min);
+        int in_y_max = in_y_min;
+        for (int out_y = out->dim[1].min + 1; out_y < out->dim[1].min + out->dim[1].extent; out_y++) {
+            int in_y = coord_map(out_y);
+            in_y_min = std::min(in_y_min, in_y);
+            in_y_max = std::max(in_y_max, in_y);
         }
-        y_max &= 63;
-        if (y_max >= 32) {
-            y_max = 63 - y_max;
-        }
-        if (y_min > y_max) {
-            std::swap(y_min, y_max);
-        }
-        in->dim[1].min = y_min;
-        in->dim[1].extent = y_max - y_min + 1;
+        in->dim[1].min = in_y_min;
+        in->dim[1].extent = in_y_max - in_y_min + 1;
+        std::cerr << "Bounds query result: Output " << out->dim[1].min
+                  << " ... " << (out->dim[1].min + out->dim[1].extent - 1)
+                  << " requires input: " << in_y_min << " ... " << in_y_max << "\n";
     } else {
         // This extern stage is only used to see if it produces an
         // expected bounds error, so just fill it with a sentinel value.


### PR DESCRIPTION
This PR improves a few related things in the compiler. The main change is that I removed the dependence of allocation bounds inference and storage folding (and boxes_touched) on magic names, which means we can run full simplification earlier. This should generally make allocation bounds tighter, and also speeds up the compiler by giving allocation bounds inference less IR to chew through (by a full 10% on local laplacian lowering, and a similar amount on a 32x32 fft, 5% on lens blur).

The full story: 

I picked at a thread and a bunch of stuff unraveled.  I wanted to remove a superfluous-looking max in ApplySplit. This broke something in allocation bounds inference related that would have been fine if we could just run full simplification before we did allocation bounds inference. But we can't, because allocation bounds inference relies on magic names from bounds inference (foo.y.min/max) these magic names shadow each other, and haven't been unique'd yet, so we can't run the simplifier, which assumes two expressions that are syntactically identical have the same value, so shadowing breaks it.

But why does allocation bounds inference need these magic names? The only reason it needs them is to ensure it knows that an extern stage is going to write to the whole region required. We can just tell it that earlier instead with a marker in the IR that says "you should treat this marker as a write to this buffer over this region". Presto, no magic name.

However the other way in which allocation bounds inference (well, boxes_touched) relies on magic names was in its handling of getting the min/max out of a bounds query result. It just lifted them out of their containing scope (see the deleted code in Bounds.cpp below), assuming a bounds query buffer *of the same name* also exists in the containing scope, and also assuming that the result of that outer bounds query was a valid interval containing the result of the inner bounds query. Yuck. Instead I removed that special handling from boxes_touched, and instead explicitly clamped the inner bounds query result to be within the outer region required, which comes from the outer bounds query. That gives boxes_touched a way to bound the impure call with something. 

So now if we have a misbehaving extern stage, which lies in its outer bounds query and says it's going to ask for less than it does in the inner bounds query, it simply doesn't get what it asks for in the inner bounds query. It gets the intersection of the outer bounds query result and the inner bounds query result. Too bad. This behavior is illustrated in the new test. Formerly I'm not sure what happened, because we were just assuming that it couldn't occur. I guess that's UB. One of the tests in storage_folding actually broke this rule, but it didn't matter before because it never actually accessed the input.

I'm hoping that moving simplification earlier means we can unstick the PR that moves add_image_checks earlier too, because we'll be able to run a full simplification before it happens.

This PR needs testing inside Google, where there are lots of complex pipelines with extern stages. The interaction with storage folding of extern stages is the part I'm most worried about.
