### PR TITLE
Fix #4703: move IfInner containers to the end

### DIFF
--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -252,9 +252,7 @@ Stmt build_loop_nest(
             internal_assert(nest[j + 1].value.defined());
 
             if (!expr_uses_var(nest[j + 1].value, nest[j].name) &&
-                (nest[j].type != Container::For) 
-                && (nest[j].type != Container::If)
-                ) {
+                (nest[j].type != Container::For) && (nest[j].type != Container::If)) {
                 std::swap(nest[j + 1], nest[j]);
             } else {
                 break;


### PR DESCRIPTION
As described in #4703, in some cases when function is scheduled with compute_with, inner loop won't be properly vectorized . It seems that this is happening because bounds for the rebased variable in the said loop are not tight enough. If you look at the IR right after initial scheduling:

```
        vectorized (g.s0.x.v0, g.s0.x.v0.loop_min, g.s0.x.v0.loop_extent) {
         if ((uint1)likely((g.s0.y.fused.yo >= g.s0.y.yo.loop_min))) {
          if ((uint1)likely((g.s0.y.fused.yo <= g.s0.y.yo.loop_max))) {
           if ((uint1)likely(((g.s0.y.y.fused.y + (g.s0.y.y.y.loop_max - h.s0.y.y.y.loop_max)) >= g.s0.y.y.y.loop_min))) {
            if ((uint1)likely(((g.s0.y.y.fused.y + (g.s0.y.y.y.loop_max - h.s0.y.y.y.loop_max)) <= g.s0.y.y.y.loop_max))) {
             let g.s0.x.rebased = ((g.s0.x.x*4) + g.s0.x.v0)
             if ((uint1)likely((g.s0.x.rebased < g.s0.x.loop_extent))) {
              let g.s0.x = (g.s0.x.v0.base + g.s0.x.v0)

```

g.s0.x.rebased ends up in between two ifs and I think this makes it harder for the bounds inference to reason about it (there is actually a [comment](https://github.com/halide/Halide/blob/master/src/ScheduleFunctions.cpp#L163), which says something like this and specifically mentions rebased vars; well, I can convince myself that it says exactly the opposite, but I like it other way, because it supports my theory).

This PR attempts to fix the issue by moving `IfInner` containers to the end and giving higher 'priority' to the `If`containers during sorting. In other words, all `If` containers will go first in the outward order with `IfInner` going after and let vars still being the most inward (assuming that there are no ifs that depend on them). That being said, I don't think the order of ifs matters on its own, instead depended if, basically, serves as a guard for var it depends on against `IfInner`, which can't go outside of the loop (regular ifs can) and guaranteed to stay there.

After the change IR will look like:

```
        vectorized (g.s0.x.v0, g.s0.x.v0.loop_min, g.s0.x.v0.loop_extent) {
         let g.s0.x.rebased = ((g.s0.x.x*4) + g.s0.x.v0)
         if ((uint1)likely((g.s0.x.rebased < g.s0.x.loop_extent))) {
          if ((uint1)likely((g.s0.y.fused.yo >= g.s0.y.yo.loop_min))) {
           if ((uint1)likely((g.s0.y.fused.yo <= g.s0.y.yo.loop_max))) {
            if ((uint1)likely(((g.s0.y.y.fused.y + (g.s0.y.y.y.loop_max - h.s0.y.y.y.loop_max)) >= g.s0.y.y.y.loop_min))) {
             if ((uint1)likely(((g.s0.y.y.fused.y + (g.s0.y.y.y.loop_max - h.s0.y.y.y.loop_max)) <= g.s0.y.y.y.loop_max))) {
              let g.s0.x = (g.s0.x.v0.base + g.s0.x.v0)

```

This definitely needs a test (so far I just basically eyeballed generated IR), but wanted to send earlier to check if this makes sense at all .