### PR TITLE
Add some obviously good rules from the simplifier synthesis work

### DIFF
--- a/src/Simplify_LT.cpp
+++ b/src/Simplify_LT.cpp
@@ -42,6 +42,12 @@ Expr Simplify::visit(const LT *op, ExprInfo *bounds) {
              rewrite(x < min(x, y), false) ||
              rewrite(x < min(y, x), false) ||
 
+             // From the simplifier synthesis project
+             rewrite((max(y, z) < min(x, y)), false) ||
+             rewrite((max(y, z) < min(y, x)), false) ||
+             rewrite((max(z, y) < min(x, y)), false) ||
+             rewrite((max(z, y) < min(y, x)), false) ||
+
              // Comparisons of ramps and broadcasts. If the first
              // and last lanes are provably < or >= the broadcast
              // we can collapse the comparison.

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1190,6 +1190,16 @@ void check_boolean() {
     check(max(x, y) <= y, x <= y);
     check(min(x, y) >= y, y <= x);
 
+    check(max(x, y) < min(y, z), f);
+    check(max(x, y) < min(z, y), f);
+    check(max(y, x) < min(y, z), f);
+    check(max(y, x) < min(z, y), f);
+
+    check(max(x, y) >= min(y, z), t);
+    check(max(x, y) >= min(z, y), t);
+    check(max(y, x) >= min(y, z), t);
+    check(max(y, x) >= min(z, y), t);
+
     check((1 < y) && (2 < y), 2 < y);
 
     check(x * 5 < 4, x < 1);


### PR DESCRIPTION
Somehow we were missing these. I found them useful in another branch. The left-hand-side is at least y, and the right-hand-side is at most y, so there's no way the LHS could be strictly less than the RHS.