### PR TITLE
Add simplifier rules for for/if combinations

### DIFF
--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -14,7 +14,7 @@ using std::pair;
 using std::string;
 using std::vector;
 
-#if LOG_EXPR_MUTATIONS || LOG_STMT_MUTATIONS
+#if (LOG_EXPR_MUTATIONS || LOG_STMT_MUTATIONS)
 int Simplify::debug_indent = 0;
 #endif
 

--- a/src/Simplify_Internal.h
+++ b/src/Simplify_Internal.h
@@ -90,9 +90,12 @@ public:
         }
     };
 
-#if LOG_EXPR_MUTATIONS
+#if (LOG_EXPR_MUTATORIONS || LOG_STMT_MUTATIONS)
     static int debug_indent;
+#endif
 
+
+#if LOG_EXPR_MUTATIONS
     Expr mutate(const Expr &e, ExprInfo *b) {
         const std::string spaces(debug_indent, ' ');
         debug(1) << spaces << "Simplifying Expr: " << e << "\n";
@@ -184,6 +187,11 @@ public:
     IRMatcher::WildConst<1> c1;
     IRMatcher::WildConst<2> c2;
     IRMatcher::WildConst<3> c3;
+
+    // Tracks whether or not we're inside a vector loop. Certain
+    // transformations are not a good idea if the code is to be
+    // vectorized.
+    bool in_vector_loop = false;
 
     // If we encounter a reference to a buffer (a Load, Store, Call,
     // or Provide), there's an implicit dependence on some associated

--- a/src/Simplify_Internal.h
+++ b/src/Simplify_Internal.h
@@ -94,7 +94,6 @@ public:
     static int debug_indent;
 #endif
 
-
 #if LOG_EXPR_MUTATIONS
     Expr mutate(const Expr &e, ExprInfo *b) {
         const std::string spaces(debug_indent, ' ');

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -182,6 +182,12 @@ Stmt Simplify::visit(const For *op) {
                extent_bounds.max == 1 &&
                !in_vector_loop &&
                op->device_api == DeviceAPI::None) {
+        // If we're inside a vector loop we don't want to rewrite a
+        // for loop of extent at most one into an if, because the
+        // vectorization pass deals with those differently to an
+        // if. If the extent depends on the vectorized variable, the
+        // for loop gets an all-true vectorized case, but an if
+        // statement just gets scalarized.
         Stmt s = LetStmt::make(op->name, new_min, new_body);
         return mutate(IfThenElse::make(0 < new_extent, s));
     } else if (op->min.same_as(new_min) &&

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -175,7 +175,8 @@ Stmt Simplify::visit(const For *op) {
     } else if (extent_bounds.max_defined &&
                extent_bounds.max == 0) {
         return Evaluate::make(0);
-    } else if (is_one(new_extent)) {
+    } else if (is_one(new_extent) &&
+               op->device_api == DeviceAPI::None) {
         Stmt s = LetStmt::make(op->name, new_min, new_body);
         return mutate(s);
     } else if (extent_bounds.max_defined &&

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1358,6 +1358,17 @@ void check_boolean() {
           Block::make(IfThenElse::make(x < y, Evaluate::make(0), Evaluate::make(x + 1)),
                       Evaluate::make(x + 2)));
 
+    // A for loop is also an if statement that the extent is greater than zero
+    Stmt body = AssertStmt::make(y == z, y);
+    Stmt loop = For::make("t", 0, x, ForType::Serial, DeviceAPI::None, body);
+    check(IfThenElse::make(0 < x, loop), loop);
+
+    // A for loop where the extent is exactly one is just the body
+    check(IfThenElse::make(x == 1, loop), IfThenElse::make(x == 1, body));
+
+    // A for loop where the extent is at most one can just be an if statement
+    check(IfThenElse::make(x == y % 2, loop), IfThenElse::make(x == y % 2, IfThenElse::make(0 < x, body)));
+
     // Simplifications of selects
     check(select(x == 3, 5, 7) + 7, select(x == 3, 12, 14));
     check(select(x == 3, 5, 7) - 7, select(x == 3, -2, 0));


### PR DESCRIPTION
First, in the following:
```
if (extent > 0) { for (x = 0; x < extent; x++) {...}}

```
The if is redundant and can be removed.

Next, we can fold away `if (likely(true/false))` in the same way we fold
away `if (true/false)`

Finally, we used to transform:
```
for (x = 0; x < min(1, foo); x++)
```
to
```
if (0 < foo)
```
Because a for loop where the extent is at most one is just an if.

However, this is not a good mutation if done in a vectorized loop,
because a for loop with an extent that varies across the vector lanes is
considered a likely-if, and an all-true vectorized case is generated.
This doesn't happen for the regular if. So I just squashed this
transformation if we're inside a vector loop.