### PR TITLE
Bump the minimum cmake vesion to 3.15.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15.7)
 project(Halide)
 
 set(CPACK_PACKAGE_VENDOR "Halide")


### PR DESCRIPTION
ece4783c1a introduced a use of $<CXX_COMPILER_ID:compiler_ids> where
compiler_ids is a comma-separated list.
As $<CXX_COMPIER_ID:compiler_id> accepted only one compiier ID until
3.14, 3.15.x or higher is now required.

3.15.7 seems to be the latest documented 3.15 release.