### PR TITLE
Parallelize clang-tidy runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2298,23 +2298,37 @@ $(BIN_DIR)/HalideTraceDump: $(ROOT_DIR)/util/HalideTraceDump.cpp $(ROOT_DIR)/uti
 format:
 	find "${ROOT_DIR}/apps" "${ROOT_DIR}/src" "${ROOT_DIR}/tools" "${ROOT_DIR}/test" "${ROOT_DIR}/util" "${ROOT_DIR}/python_bindings" -name *.cpp -o -name *.h -o -name *.c | xargs ${CLANG}-format -i -style=file
 
-# Run clang-tidy on the core source files
+# run-clang-tidy.py is a script that comes with LLVM for running clang
+# tidy in parallel. Assume it's in the standard install path relative to clang.
+RUN_CLANG_TIDY ?= $(shell dirname $(CLANG))/../share/clang/run-clang-tidy.py
+
+# Run clang-tidy on everything in src/. In future we may increase this
+# surface. Not doing it for now because things outside src are not
+# performance-critical.
+CLANG_TIDY_TARGETS= $(addprefix $(SRC_DIR)/,$(SOURCE_FILES))
+
+INVOKE_CLANG_TIDY ?= $(RUN_CLANG_TIDY) -p $(BUILD_DIR) $(CLANG_TIDY_TARGETS) -clang-tidy-binary $(CLANG)-tidy -clang-apply-replacements-binary $(CLANG)-apply-replacements -quiet
+
 $(BUILD_DIR)/compile_commands.json:
+	mkdir -p $(BUILD_DIR)
 	echo '[' >> $@
-	BD=$(realpath $(BUILD_DIR)); \
-	SD=$(realpath $(SRC_DIR)); \
+	BD=$$(realpath $(BUILD_DIR)); \
+	SD=$$(realpath $(SRC_DIR)); \
+	ID=$$(realpath $(INCLUDE_DIR)); \
 	for S in $(SOURCE_FILES); do \
 	echo "{ \"directory\": \"$${BD}\"," >> $@; \
-	echo "  \"command\": \"$(CXX) $(CXX_FLAGS) -c $$SD/$$S -o $$BD/$${S/cpp/o}\"," >> $@; \
+	echo "  \"command\": \"$(CXX) $(CXX_FLAGS) -c $$SD/$$S -o /dev/null\"," >> $@; \
 	echo "  \"file\": \"$$SD/$$S\" }," >> $@; \
 	done
-	echo ']' >> $@
+	# Add a sentinel to make it valid json (no trailing comma)
+	echo "{ \"directory\": \"$${BD}\"," >> $@; \
+	echo "  \"command\": \"$(CXX) -c /dev/null -o /dev/null\"," >> $@; \
+	echo "  \"file\": \"$$S\" }]" >> $@; \
 
 .PHONY: clang-tidy
 clang-tidy: $(BUILD_DIR)/compile_commands.json
-	${CLANG}-tidy -extra-arg=-Wno-unknown-warning-option -p $(BUILD_DIR) $(addprefix $(SRC_DIR)/,$(SOURCE_FILES))
+	@$(INVOKE_CLANG_TIDY) 2>&1 | grep -v "warnings generated" | grep -v '^$(CLANG)-tidy '
 
 .PHONY: clang-tidy-fix
 clang-tidy-fix: $(BUILD_DIR)/compile_commands.json
-	${CLANG}-tidy -extra-arg=-Wno-unknown-warning-option -p $(BUILD_DIR) $(addprefix $(SRC_DIR)/,$(SOURCE_FILES)) -fix-errors
-
+	@$(INVOKE_CLANG_TIDY) -fix 2>&1 | grep -v "warnings generated" | grep -v '^$(CLANG)-tidy '

--- a/README.md
+++ b/README.md
@@ -61,15 +61,16 @@ Then build it like so:
 
     % cd llvm-project
     % mkdir build
+    % mkdir install
     % cd build
-    % cmake -DLLVM_ENABLE_PROJECTS="clang;lld" -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_TARGETS_TO_BUILD="X86;ARM;NVPTX;AArch64;Mips;PowerPC" -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_32_BITS=OFF ../llvm
-    % make -j
+    % cmake -DLLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra" -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_TARGETS_TO_BUILD="X86;ARM;NVPTX;AArch64;Mips;PowerPC;Hexagon" -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_32_BITS=OFF -DCMAKE_INSTALL_PREFIX=../install ../llvm
+    % make install -j8
 
 then to point Halide to it:
 
-    export LLVM_CONFIG=<path to llvm>/build/bin/llvm-config
+    export LLVM_CONFIG=<path to llvm>/install/bin/llvm-config
 
-(Note that you *must* add `clang` to `LLVM_ENABLE_PROJECTS`; adding `lld` to `LLVM_ENABLE_PROJECTS` is only required when using WebAssembly, but we recommend enabling it in all cases, to simplify builds.)
+(Note that you *must* add `clang` to `LLVM_ENABLE_PROJECTS`; adding `lld` to `LLVM_ENABLE_PROJECTS` is only required when using WebAssembly, and adding `clang-tools-extra` is only necessary if you plan to contribute code to Halide (so that you can run clang-tidy on your pull requests). We recommend enabling both in all cases, to simplify builds.)
 
 #### Building Halide with make
 
@@ -98,7 +99,7 @@ If you wish to use cmake to build Halide, the build procedure is:
     % mkdir cmake_build
     % cd cmake_build
     % cmake -DLLVM_DIR=/path-to-llvm-build/lib/cmake/llvm -DCMAKE_BUILD_TYPE=Release /path/to/halide
-    % make -j
+    % make -j8
 
 `LLVM_DIR` should be the folder in the LLVM installation or build tree that contains `LLVMConfig.cmake`.
 


### PR DESCRIPTION
Using a script provided by llvm. This makes it way faster to clang-tidy a branch before opening a PR.