### PR TITLE
Build python module with rpath on linux

### DIFF
--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -48,6 +48,9 @@ CCFLAGS := $(filter-out -Wstrict-prototypes,$(CCFLAGS))
 # DON'T link libpython* - leave those symbols to lazily resolve at load time
 # Cf. https://github.com/pybind/pybind11/blob/master/docs/compiling.rst#building-manually
 LDFLAGS += -lz $(USE_EXPORT_DYNAMIC)
+ifeq ($(UNAME), Linux)
+  LDFLAGS += -Wl,-rpath=$(dir $(LIBHALIDE))
+endif
 
 PY_SRCS=$(shell ls $(ROOT_DIR)/src/*.cpp)
 PY_OBJS=$(PY_SRCS:$(ROOT_DIR)/src/%.cpp=$(BIN)/src/%.o)


### PR DESCRIPTION
Add an rpath to the python module, to make libHalide.so easier to find.

The python test cases run much better with this on my ubuntu 18.04 machine.