### PR TITLE
Add `-Wno-psabi` to CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,7 @@ if (NOT MSVC)
           -Wignored-qualifiers
           $<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual>
           $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,5.1>>:-Wsuggest-override>
+          -Wno-psabi
   )
   if (WARNINGS_AS_ERRORS)
     add_compile_options(-Werror)


### PR DESCRIPTION
This disables the useless `parameter passing for argument of type ‘foo’ changed in GCC X.Y` warnings that pollute some build variants. (We've had this set in the Makefile for a long time already.)