### PR TITLE
Add a way to disable host-cuda-capability sniffing

### DIFF
--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -472,7 +472,8 @@ bool merge_string(Target &t, const std::string &target) {
         !t.has_feature(Target::CUDACapability32) &&
         !t.has_feature(Target::CUDACapability35) &&
         !t.has_feature(Target::CUDACapability50) &&
-        !t.has_feature(Target::CUDACapability61)) {
+        !t.has_feature(Target::CUDACapability61) &&
+        Internal::get_env_variable("HL_DISABLE_DETECT_HOST_CUDA_CAPABILITY") != "1") {
         // Detect host cuda capability
         t.set_feature(get_host_cuda_capability(t));
     }


### PR DESCRIPTION
This is a workaround for Issue #4708, for the cases in which it causes outright problems rather than merely a performance hit (e.g. detecting CUDA while running under QEMU user-mode detection is crashy).