### PR TITLE
Fix conv_layer initialization

### DIFF
--- a/apps/conv_layer/process.cpp
+++ b/apps/conv_layer/process.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
         for (int z = 0; z < input.channels(); z++) {
             for (int y = 0; y < input.height(); y++) {
                 for (int x = 0; x < input.width(); x++) {
-                    input(x, y) = rand();
+                    input(x, y, z, c) = rand();
                 }
             }
         }
@@ -31,7 +31,7 @@ int main(int argc, char **argv) {
         for (int z = 0; z < filter.channels(); z++) {
             for (int y = 0; y < filter.height(); y++) {
                 for (int x = 0; x < filter.width(); x++) {
-                    filter(x, y) = rand();
+                    filter(x, y, z, c) = rand();
                 }
             }
         }


### PR DESCRIPTION
The current conv_layer benchmarking code doesn't initialize all of the input buffers (see the changes). This does not really matter but we should probably fix it for pedagogical purposes.