### PR TITLE
Use internal_error instead of internal_assert(false)

### DIFF
--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -2384,7 +2384,7 @@ pair<VarOrRVar, VarOrRVar> Partitioner::split_dim(
         oss << ")";
         break;
     default:
-        internal_assert(false);
+        internal_error;
     }
     sched.push_schedule(f_handle.name(), stage_num, oss.str(),
                         {arg_name, outer_name, inner_name});

--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -77,64 +77,64 @@ protected:
     void visit(const Let *op) override;
     void visit(const Call *op) override;
     void visit(const Load *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"Load\" when differentiating.";
+        internal_error << "Encounter unexpected expression \"Load\" when differentiating.";
     }
     void visit(const Ramp *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"Ramp\" when differentiating.";
+        internal_error << "Encounter unexpected expression \"Ramp\" when differentiating.";
     }
     void visit(const Broadcast *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"Broadcast\" when differentiating.";
-    }
-    void visit(const LetStmt *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"LetStmt\" when differentiating.";
-    }
-    void visit(const AssertStmt *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"AssertStmt\" when differentiating.";
-    }
-    void visit(const ProducerConsumer *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"ProducerConsumer\" when differentiating.";
-    }
-    void visit(const For *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"For\" when differentiating.";
-    }
-    void visit(const Store *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"Store\" when differentiating.";
-    }
-    void visit(const Provide *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"Provide\" when differentiating.";
-    }
-    void visit(const Allocate *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"Allocate\" when differentiating.";
-    }
-    void visit(const Free *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"Free\" when differentiating.";
-    }
-    void visit(const Realize *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"Realize\" when differentiating.";
-    }
-    void visit(const Block *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"Block\" when differentiating.";
-    }
-    void visit(const IfThenElse *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"IfThenElse\" when differentiating.";
-    }
-    void visit(const Evaluate *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"Evaluate\" when differentiating.";
+        internal_error << "Encounter unexpected expression \"Broadcast\" when differentiating.";
     }
     void visit(const Shuffle *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"Shuffle\" when differentiating.";
+        internal_error << "Encounter unexpected expression \"Shuffle\" when differentiating.";
+    }
+    void visit(const LetStmt *op) override {
+        internal_error << "Encounter unexpected statement \"LetStmt\" when differentiating.";
+    }
+    void visit(const AssertStmt *op) override {
+        internal_error << "Encounter unexpected statement \"AssertStmt\" when differentiating.";
+    }
+    void visit(const ProducerConsumer *op) override {
+        internal_error << "Encounter unexpected statement \"ProducerConsumer\" when differentiating.";
+    }
+    void visit(const For *op) override {
+        internal_error << "Encounter unexpected statement \"For\" when differentiating.";
+    }
+    void visit(const Store *op) override {
+        internal_error << "Encounter unexpected statement \"Store\" when differentiating.";
+    }
+    void visit(const Provide *op) override {
+        internal_error << "Encounter unexpected statement \"Provide\" when differentiating.";
+    }
+    void visit(const Allocate *op) override {
+        internal_error << "Encounter unexpected statement \"Allocate\" when differentiating.";
+    }
+    void visit(const Free *op) override {
+        internal_error << "Encounter unexpected statement \"Free\" when differentiating.";
+    }
+    void visit(const Realize *op) override {
+        internal_error << "Encounter unexpected statement \"Realize\" when differentiating.";
+    }
+    void visit(const Block *op) override {
+        internal_error << "Encounter unexpected statement \"Block\" when differentiating.";
+    }
+    void visit(const IfThenElse *op) override {
+        internal_error << "Encounter unexpected statement \"IfThenElse\" when differentiating.";
+    }
+    void visit(const Evaluate *op) override {
+        internal_error << "Encounter unexpected statement \"Evaluate\" when differentiating.";
     }
     void visit(const Prefetch *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"Prefetch\" when differentiating.";
+        internal_error << "Encounter unexpected statement \"Prefetch\" when differentiating.";
     }
     void visit(const Fork *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"Fork\" when differentiating.";
+        internal_error << "Encounter unexpected statement \"Fork\" when differentiating.";
     }
     void visit(const Acquire *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"Acquire\" when differentiating.";
+        internal_error << "Encounter unexpected statement \"Acquire\" when differentiating.";
     }
     void visit(const Atomic *op) override {
-        internal_assert(false) << "Encounter unexpected statement \"Atomic\" when differentiating.";
+        internal_error << "Encounter unexpected statement \"Atomic\" when differentiating.";
     }
 
 private:

--- a/src/ModulusRemainder.cpp
+++ b/src/ModulusRemainder.cpp
@@ -423,39 +423,39 @@ void ComputeModulusRemainder::visit(const Max *op) {
 }
 
 void ComputeModulusRemainder::visit(const EQ *) {
-    internal_assert(false) << "modulus_remainder of bool\n";
+    internal_error << "modulus_remainder of bool\n";
 }
 
 void ComputeModulusRemainder::visit(const NE *) {
-    internal_assert(false) << "modulus_remainder of bool\n";
+    internal_error << "modulus_remainder of bool\n";
 }
 
 void ComputeModulusRemainder::visit(const LT *) {
-    internal_assert(false) << "modulus_remainder of bool\n";
+    internal_error << "modulus_remainder of bool\n";
 }
 
 void ComputeModulusRemainder::visit(const LE *) {
-    internal_assert(false) << "modulus_remainder of bool\n";
+    internal_error << "modulus_remainder of bool\n";
 }
 
 void ComputeModulusRemainder::visit(const GT *) {
-    internal_assert(false) << "modulus_remainder of bool\n";
+    internal_error << "modulus_remainder of bool\n";
 }
 
 void ComputeModulusRemainder::visit(const GE *) {
-    internal_assert(false) << "modulus_remainder of bool\n";
+    internal_error << "modulus_remainder of bool\n";
 }
 
 void ComputeModulusRemainder::visit(const And *) {
-    internal_assert(false) << "modulus_remainder of bool\n";
+    internal_error << "modulus_remainder of bool\n";
 }
 
 void ComputeModulusRemainder::visit(const Or *) {
-    internal_assert(false) << "modulus_remainder of bool\n";
+    internal_error << "modulus_remainder of bool\n";
 }
 
 void ComputeModulusRemainder::visit(const Not *) {
-    internal_assert(false) << "modulus_remainder of bool\n";
+    internal_error << "modulus_remainder of bool\n";
 }
 
 void ComputeModulusRemainder::visit(const Select *op) {
@@ -468,11 +468,11 @@ void ComputeModulusRemainder::visit(const Load *) {
 }
 
 void ComputeModulusRemainder::visit(const Ramp *) {
-    internal_assert(false) << "modulus_remainder of vector\n";
+    internal_error << "modulus_remainder of vector\n";
 }
 
 void ComputeModulusRemainder::visit(const Broadcast *) {
-    internal_assert(false) << "modulus_remainder of vector\n";
+    internal_error << "modulus_remainder of vector\n";
 }
 
 void ComputeModulusRemainder::visit(const Call *) {
@@ -495,67 +495,67 @@ void ComputeModulusRemainder::visit(const Shuffle *op) {
 }
 
 void ComputeModulusRemainder::visit(const LetStmt *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 void ComputeModulusRemainder::visit(const AssertStmt *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 void ComputeModulusRemainder::visit(const ProducerConsumer *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 void ComputeModulusRemainder::visit(const For *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 void ComputeModulusRemainder::visit(const Acquire *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 void ComputeModulusRemainder::visit(const Store *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 void ComputeModulusRemainder::visit(const Provide *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 void ComputeModulusRemainder::visit(const Allocate *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 void ComputeModulusRemainder::visit(const Realize *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 void ComputeModulusRemainder::visit(const Block *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 void ComputeModulusRemainder::visit(const Fork *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 void ComputeModulusRemainder::visit(const Free *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 void ComputeModulusRemainder::visit(const IfThenElse *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 void ComputeModulusRemainder::visit(const Evaluate *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 void ComputeModulusRemainder::visit(const Prefetch *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 void ComputeModulusRemainder::visit(const Atomic *) {
-    internal_assert(false) << "modulus_remainder of statement\n";
+    internal_error << "modulus_remainder of statement\n";
 }
 
 }  // namespace Internal

--- a/src/RegionCosts.cpp
+++ b/src/RegionCosts.cpp
@@ -253,49 +253,49 @@ class ExprCost : public IRVisitor {
     // None of the following IR nodes should be encountered when traversing the
     // IR at the level at which the auto scheduler operates.
     void visit(const Load *) override {
-        internal_assert(false);
+        internal_error;
     }
     void visit(const Ramp *) override {
-        internal_assert(false);
+        internal_error;
     }
     void visit(const Broadcast *) override {
-        internal_assert(false);
+        internal_error;
     }
     void visit(const LetStmt *) override {
-        internal_assert(false);
+        internal_error;
     }
     void visit(const AssertStmt *) override {
-        internal_assert(false);
+        internal_error;
     }
     void visit(const ProducerConsumer *) override {
-        internal_assert(false);
+        internal_error;
     }
     void visit(const For *) override {
-        internal_assert(false);
+        internal_error;
     }
     void visit(const Store *) override {
-        internal_assert(false);
+        internal_error;
     }
     void visit(const Provide *) override {
-        internal_assert(false);
+        internal_error;
     }
     void visit(const Allocate *) override {
-        internal_assert(false);
+        internal_error;
     }
     void visit(const Free *) override {
-        internal_assert(false);
+        internal_error;
     }
     void visit(const Realize *) override {
-        internal_assert(false);
+        internal_error;
     }
     void visit(const Block *) override {
-        internal_assert(false);
+        internal_error;
     }
     void visit(const IfThenElse *) override {
-        internal_assert(false);
+        internal_error;
     }
     void visit(const Evaluate *) override {
-        internal_assert(false);
+        internal_error;
     }
 
 public:

--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -405,7 +405,7 @@ private:
         } else if (op->for_type == ForType::GPULane) {
             stream << keyword("gpu_lane");
         } else {
-            internal_assert(false) << "Unknown for type: " << ((int)op->for_type) << "\n";
+            internal_error << "Unknown for type: " << ((int)op->for_type) << "\n";
         }
         stream << " (";
         stream << close_span();

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -576,7 +576,7 @@ std::string Target::feature_to_name(Target::Feature feature) {
             return feature_entry.first;
         }
     }
-    internal_assert(false);
+    internal_error;
     return "";
 }
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -395,7 +395,7 @@ std::string dir_make_temp() {
             break;
         }
     }
-    internal_assert(false) << "Unable to create temp directory in " << tmp_dir << "\n";
+    internal_error << "Unable to create temp directory in " << tmp_dir << "\n";
     return "";
 #else
     std::string templ = "/tmp/XXXXXX";


### PR DESCRIPTION
Just a stylistic change. Also added Shuffle to the derivative visitor. It seemed to be missing.