### PR TITLE
Move first simplification before allocation bounds inference

### DIFF
--- a/src/AllocationBoundsInference.cpp
+++ b/src/AllocationBoundsInference.cpp
@@ -31,19 +31,6 @@ class AllocationInference : public IRMutator {
 
         Scope<Interval> empty_scope;
         Box b = box_touched(op->body, op->name, empty_scope, func_bounds);
-        if (touched_by_extern.count(f.name())) {
-            // The region touched is at least the region required at this
-            // loop level of the first stage (this is important for inputs
-            // and outputs to extern stages).
-            Box required(op->bounds.size());
-            for (size_t i = 0; i < required.size(); i++) {
-                string prefix = op->name + ".s0." + f_args[i];
-                required[i] = Interval(Variable::make(Int(32), prefix + ".min"),
-                                       Variable::make(Int(32), prefix + ".max"));
-            }
-
-            merge_boxes(b, required);
-        }
 
         Stmt new_body = mutate(op->body);
         Stmt stmt = Realize::make(op->name, op->types, op->memory_type, op->bounds, op->condition, new_body);
@@ -140,11 +127,28 @@ public:
     }
 };
 
+// We can strip box_touched declarations here. We're done with
+// them. Reconsider this decision if we want to use
+// box_touched on extern stages later in lowering. Storage
+// folding currently does box_touched too, but it handles extern
+// stages specially already.
+class StripDeclareBoxTouched : public IRMutator {
+    using IRMutator::visit;
+
+    Expr visit(const Call *op) override {
+        if (op->is_intrinsic(Call::declare_box_touched)) {
+            return 0;
+        } else {
+            return IRMutator::visit(op);
+        }
+    }
+};
+
 Stmt allocation_bounds_inference(Stmt s,
                                  const map<string, Function> &env,
                                  const FuncValueBounds &fb) {
-    AllocationInference inf(env, fb);
-    s = inf.mutate(s);
+    s = AllocationInference(env, fb).mutate(s);
+    s = StripDeclareBoxTouched().mutate(s);
     return s;
 }
 

--- a/src/ApplySplit.cpp
+++ b/src/ApplySplit.cpp
@@ -92,12 +92,7 @@ vector<ApplySplitResult> apply_split(const Split &split, bool is_update, const s
         Expr outer_min = Variable::make(Int(32), prefix + split.outer + ".loop_min");
         Expr inner_extent = Variable::make(Int(32), prefix + split.inner + ".loop_extent");
 
-        // If the inner extent is zero, the loop will never be
-        // entered, but the bounds expressions lifted out might
-        // contain divides or mods by zero. In the cases where
-        // simplification of inner and outer matter, inner_extent
-        // is a constant, so the max will simplify away.
-        Expr factor = max(inner_extent, 1);
+        const Expr &factor = inner_extent;
         Expr inner = fused % factor + inner_min;
         Expr outer = fused / factor + outer_min;
 

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1263,20 +1263,6 @@ private:
                            op->func, op->value_index, op->image, op->param),
                 Call::make(t, op->name, {interval.max}, op->call_type,
                            op->func, op->value_index, op->image, op->param));
-
-        } else if (!const_bound &&
-                   (op->name == Call::buffer_get_min ||
-                    op->name == Call::buffer_get_max)) {
-            // Bounds query results should have perfect nesting. Their
-            // max over a loop is just the same bounds query call at
-            // an outer loop level. This requires that the query is
-            // also done at the outer loop level so that the buffer
-            // arg is still valid, which it is, so it is.
-            //
-            // TODO: There should be an assert injected in the inner
-            // loop to check perfect nesting.
-            interval = Interval(Call::make(Int(32), Call::buffer_get_min, op->args, Call::Extern),
-                                Call::make(Int(32), Call::buffer_get_max, op->args, Call::Extern));
         } else if (op->is_intrinsic(Call::popcount) ||
                    op->is_intrinsic(Call::count_leading_zeros) ||
                    op->is_intrinsic(Call::count_trailing_zeros)) {
@@ -1813,6 +1799,18 @@ private:
     }
 
     void visit(const Call *op) override {
+        if (op->is_intrinsic(Call::declare_box_touched)) {
+            internal_assert(!op->args.empty());
+            const Variable *handle = op->args[0].as<Variable>();
+            const string &func = handle->name;
+            Box b(op->args.size() / 2);
+            for (size_t i = 0; i < b.size(); i++) {
+                b[i].min = op->args[2 * i + 1];
+                b[i].max = op->args[2 * i + 2];
+            }
+            merge_boxes(boxes[func], b);
+        }
+
         if (consider_calls) {
             if (op->is_intrinsic(Call::if_then_else)) {
                 internal_assert(op->args.size() == 3);
@@ -2434,7 +2432,7 @@ map<string, Box> boxes_touched(const Expr &e, Stmt s, bool consider_calls, bool 
             }
 
             Expr visit(const Variable *op) override {
-                if (op->name == fn_buffer) {
+                if (op->name == fn_buffer || op->name == fn) {
                     relevant = true;
                 }
                 return op;

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -183,7 +183,7 @@ public:
     // The fused group is indexed in the same way as 'fused_groups'.
     const vector<set<FusedPair>> &fused_pairs_in_groups;
     const FuncValueBounds &func_bounds;
-    set<string> in_pipeline, inner_productions;
+    set<string> in_pipeline, inner_productions, has_extern_consumer;
     const Target target;
 
     struct CondValue {
@@ -378,6 +378,7 @@ public:
                            const vector<set<FusedPair>> &fused_pairs_in_groups,
                            const set<string> &in_pipeline,
                            const set<string> &inner_productions,
+                           const set<string> &has_extern_consumer,
                            const Target &target) {
 
             // Merge all the relevant boxes.
@@ -568,12 +569,29 @@ public:
             for (size_t d = 0; d < b.size(); d++) {
                 string arg = name + ".s" + std::to_string(stage) + "." + func_args[d];
 
+                const bool clamp_to_outer_bounds =
+                    !in_pipeline.empty() && has_extern_consumer.count(name);
+                if (clamp_to_outer_bounds) {
+                    // Allocation bounds inference is going to have a
+                    // bad time lifting the results of the bounds
+                    // queries outwards. Help it out by insisting that
+                    // the bounds are clamped to lie within the bounds
+                    // one loop level up.
+                    b[d].min = max(b[d].min, Variable::make(Int(32), arg + ".outer_min"));
+                    b[d].max = min(b[d].max, Variable::make(Int(32), arg + ".outer_max"));
+                }
+
                 if (b[d].is_single_point()) {
                     s = LetStmt::make(arg + ".min", Variable::make(Int(32), arg + ".max"), s);
                 } else {
                     s = LetStmt::make(arg + ".min", b[d].min, s);
                 }
                 s = LetStmt::make(arg + ".max", b[d].max, s);
+
+                if (clamp_to_outer_bounds) {
+                    s = LetStmt::make(arg + ".outer_min", Variable::make(Int(32), arg + ".min"), s);
+                    s = LetStmt::make(arg + ".outer_max", Variable::make(Int(32), arg + ".max"), s);
+                }
             }
 
             if (stage > 0) {
@@ -861,6 +879,7 @@ public:
                 for (size_t j = 0; j < args.size(); j++) {
                     if (args[j].is_func()) {
                         Function f(args[j].func);
+                        has_extern_consumer.insert(f.name());
                         string stage_name = f.name() + ".s" + std::to_string(f.updates().size());
                         Box b(f.dimensions());
                         for (int d = 0; d < f.dimensions(); d++) {
@@ -1101,7 +1120,8 @@ public:
                     }
                     body = stages[i].define_bounds(
                         body, f, stage_name, stage_index, op->name, fused_groups,
-                        fused_pairs_in_groups, in_pipeline, inner_productions, target);
+                        fused_pairs_in_groups, in_pipeline, inner_productions,
+                        has_extern_consumer, target);
                 }
             }
 

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -592,6 +592,7 @@ const char *const intrinsic_op_names[] = {
     "cast_mask",
     "count_leading_zeros",
     "count_trailing_zeros",
+    "declare_box_touched",
     "debug_to_file",
     "div_round_to_zero",
     "dynamic_shuffle",

--- a/src/IR.h
+++ b/src/IR.h
@@ -504,6 +504,7 @@ struct Call : public ExprNode<Call> {
         cast_mask,
         count_leading_zeros,
         count_trailing_zeros,
+        declare_box_touched,
         debug_to_file,
         div_round_to_zero,
         dynamic_shuffle,

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -188,6 +188,19 @@ Module lower(const vector<Function> &output_funcs,
     debug(2) << "Lowering after sliding window:\n"
              << s << "\n";
 
+    // This uniquifies the variable names, so we're good to simplify
+    // after this point. This lets later passes assume syntactic
+    // equivalence means semantic equivalence.
+    debug(1) << "Uniquifying variable names...\n";
+    s = uniquify_variable_names(s);
+    debug(2) << "Lowering after uniquifying variable names:\n"
+             << s << "\n\n";
+
+    debug(1) << "Simplifying...\n";
+    s = simplify(s, false);  // Storage folding and allocation bounds inference needs .loop_max symbols
+    debug(2) << "Lowering after first simplification:\n"
+             << s << "\n\n";
+
     debug(1) << "Simplifying correlated differences...\n";
     s = simplify_correlated_differences(s);
     debug(2) << "Lowering after simplifying correlated differences:\n"
@@ -201,19 +214,6 @@ Module lower(const vector<Function> &output_funcs,
     debug(1) << "Removing code that depends on undef values...\n";
     s = remove_undef(s);
     debug(2) << "Lowering after removing code that depends on undef values:\n"
-             << s << "\n\n";
-
-    // This uniquifies the variable names, so we're good to simplify
-    // after this point. This lets later passes assume syntactic
-    // equivalence means semantic equivalence.
-    debug(1) << "Uniquifying variable names...\n";
-    s = uniquify_variable_names(s);
-    debug(2) << "Lowering after uniquifying variable names:\n"
-             << s << "\n\n";
-
-    debug(1) << "Simplifying...\n";
-    s = simplify(s, false);  // Storage folding needs .loop_max symbols
-    debug(2) << "Lowering after first simplification:\n"
              << s << "\n\n";
 
     debug(1) << "Performing storage folding optimization...\n";

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -494,6 +494,16 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
                               {arg, lower, upper},
                               Call::Intrinsic);
         }
+    } else if (op->is_intrinsic(Call::likely) ||
+               op->is_intrinsic(Call::likely_if_innermost)) {
+        // The bounds of the result are the bounds of the arg
+        internal_assert(op->args.size() == 1);
+        Expr arg = mutate(op->args[0], bounds);
+        if (arg.same_as(op->args[0])) {
+            return op;
+        } else {
+            return Call::make(op->type, op->name, {arg}, op->call_type);
+        }
     } else if (op->call_type == Call::PureExtern) {
         // TODO: This could probably be simplified into a single map-lookup
         // with a bit more cleverness; not sure if the reduced lookup time

--- a/src/Simplify_Let.cpp
+++ b/src/Simplify_Let.cpp
@@ -247,7 +247,8 @@ Body Simplify::simplify_let(const LetOrLetStmt *op, ExprInfo *bounds) {
             count_var_uses(it->new_value, vars_used);
         }
 
-        if (!remove_dead_lets || (info.old_uses > 0 && vars_used.count(it->op->name) > 0)) {
+        if ((!remove_dead_lets && std::is_same<LetOrLetStmt, LetStmt>::value) ||
+            (info.old_uses > 0 && vars_used.count(it->op->name) > 0)) {
             // The old name is still in use. We'd better keep it as well.
             result = LetOrLetStmt::make(it->op->name, it->value, result);
             count_var_uses(it->value, vars_used);

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -204,6 +204,7 @@ tests(GROUPS correctness travis
         named_updates.cpp
         nested_shiftinwards.cpp
         newtons_method.cpp
+        non_nesting_extern_bounds_query.cpp
         non_vector_aligned_embeded_buffer.cpp
         obscure_image_references.cpp
         oddly_sized_output.cpp

--- a/test/correctness/extern_output_expansion.cpp
+++ b/test/correctness/extern_output_expansion.cpp
@@ -24,10 +24,10 @@ extern "C" DLLEXPORT int extern_stage(halide_buffer_t *in, halide_buffer_t *out)
         }
 
     } else {
-        assert(out->dim[0].extent % 17 == 0);
         printf("in: %d %d, out: %d %d\n",
                in->dim[0].min, in->dim[0].extent,
                out->dim[0].min, out->dim[0].extent);
+        assert(out->dim[0].extent % 17 == 0);
         int32_t *in_origin = (int32_t *)in->host - in->dim[0].min;
         int32_t *out_origin = (int32_t *)out->host - out->dim[0].min;
         for (int i = out->dim[0].min; i < out->dim[0].min + out->dim[0].extent; i++) {

--- a/test/correctness/non_nesting_extern_bounds_query.cpp
+++ b/test/correctness/non_nesting_extern_bounds_query.cpp
@@ -1,0 +1,70 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+// Extern stages are supposed to obey the following nesting property
+// on bounds queries: If some region of the output O requires some
+// region of the input I, then requesting any subset of O should only
+// require a subset of I.
+//
+// This extern stage violates that property. We're going to set up a
+// schedule that does a bounds query to it for an entire image, and a
+// bounds query for a single scanline. For the whole-image query it
+// will claim to need a modest-sized input, but for the single
+// scanline query it will claim to need a much wider input. The result
+// is that the bounds query is not entirely respected. The actual input
+// received in non-bounds-query-mode is the intersection of what it
+// asked for for a single scanline and what it asked for for the whole
+// image.
+extern "C" DLLEXPORT int misbehaving_extern_stage(halide_buffer_t *in, halide_buffer_t *out) {
+    if (in->is_bounds_query()) {
+        // As a baseline, require the same amount of input as output, like a copy
+        memcpy(in->dim, out->dim, out->dimensions * sizeof(halide_dimension_t));
+        if (out->dim[1].extent == 1) {
+            // This is the inner query, for a single scanline of
+            // output.  Require a wider input, violating the nesting
+            // property. Shift it over a little too.
+            in->dim[0].min += 50;
+            in->dim[0].extent += 100;
+        }
+    } else {
+        // The inner (bad) bounds query should not have been respected
+        // in the x dimension. You get the intersection of the inner
+        // query and the outer query.
+
+        // Check the left edge was indeed shifted inwards, as
+        // requested by the per-scanline bounds query.
+        assert(in->dim[0].min == out->dim[0].min + 50);
+
+        // Check the right edge wasn't shifted over, but was instead
+        // clamped to lie within the outer bounds query.
+        assert(in->dim[0].extent == out->dim[0].extent - 50);
+
+        // The inner bounds query was fine in the y dimension, which
+        // correctly nested.
+        assert(in->dim[1].min == out->dim[1].min);
+        assert(in->dim[1].extent == 1);
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    Func f, g, h;
+    Var x, y;
+    f(x, y) = x + y;
+    g.define_extern("misbehaving_extern_stage", {f}, Int(32), 2);
+    h(x, y) = g(x, y);
+
+    g.compute_at(h, y);
+    f.compute_at(h, y);
+
+    h.realize(200, 200);
+
+    printf("Success!\n");
+}


### PR DESCRIPTION
Removed the dependence of allocation bounds inference and storage
folding (and boxes_touched) on magic names, which means we can run full
simplification earlier. This should generally make allocation bounds
tighter, and also speeds up the compiler by giving allocation bounds
inference less IR to chew through (by a full 10% on local laplacian
lowering, and a similar amount on a 32x32 fft, 5% on lens blur).

See #4713 for the previous version of this PR.