### PR TITLE
Disable automatic GHA tests for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,16 @@
 
 name: Build+Test
 on:
+  repository_dispatch:
+
   # TODO: not sure if this is the best set of events/activity-types to use.
-  pull_request:
-    types: [opened, synchronize, reopened, edited, review_requested]
-    # TODO: do we want to limit this to certain filetypes?
-    # paths:
-    #   - '**.h'
-    #   - '**.c'
-    #   - '**.cpp'
+  # pull_request:
+  #   types: [opened, synchronize, reopened, edited, review_requested]
+  #   # TODO: do we want to limit this to certain filetypes?
+  #   # paths:
+  #   #   - '**.h'
+  #   #   - '**.c'
+  #   #   - '**.cpp'
 
 jobs:
   test_halide:


### PR DESCRIPTION
It's too easy to back up the queue with multiple commits -- disabling until I get some smarts added back in