### PR TITLE
Add SDK_ROOT control to hexagon_remote/Makefile

### DIFF
--- a/src/runtime/hexagon_remote/Makefile
+++ b/src/runtime/hexagon_remote/Makefile
@@ -8,7 +8,8 @@
 # In order to build this, you'll need to ensure that the following
 # env vars are set correctly:
 #
-# HEXAGON_SDK_ROOT   : path to Qualcom Hexagon SDK
+# SDK_ROOT           : path to Qualcomm SDK storage
+# HEXAGON_SDK_ROOT   : path to Qualcomm Hexagon SDK
 # HEXAGON_TOOLS_ROOT : path to Qualcomm Hexagon Tools
 # HEXAGON_QAIC       : path to Qualcomm qaic compiler
 #
@@ -22,7 +23,8 @@
 # from the SDK that cannot be redistributed with Halide).
 #
 
-HEXAGON_SDK_ROOT ?= ${HOME}/Qualcomm/Hexagon_SDK/3.3.3
+SDK_ROOT ?= ${HOME}/Qualcomm
+HEXAGON_SDK_ROOT ?= ${SDK_ROOT}/Hexagon_SDK/3.3.3
 HEXAGON_TOOLS_ROOT ?= ${HEXAGON_SDK_ROOT}/tools/HEXAGON_Tools/8.1.05
 
 ANDROID_NDK_ROOT ?= ${HEXAGON_SDK_ROOT}/tools/android-ndk-r10d


### PR DESCRIPTION
  - allows specifying only SDK_ROOT in a buildbot to point
    to where SDK storage is located without naming a specific
    SDK revision
  - needed to minimize buildbot script complexity when building
    multiple release streams that use differing SDK revisions
  - no change in behavior if SDK_ROOT env var is not present