### PR TITLE
mux accepts tuples

### DIFF
--- a/python_bindings/correctness/iroperator.py
+++ b/python_bindings/correctness/iroperator.py
@@ -60,6 +60,19 @@ def test_mux():
     assert b[2] == 2
     assert b[3] == 3
 
+def test_mux_tuple():
+    f = hl.Func()
+    g = hl.Func()
+    x = hl.Var()
+    c = hl.Var()
+    g[x] = (123, 456, x)
+    f[x, c] = mux(c, g[x])
+    b = f.realize(1, 4)
+    assert b[0, 0] == 123
+    assert b[0, 1] == 456
+    assert b[0, 2] == 0
+    assert b[0, 3] == 0
+
 def test_minmax():
     x = hl.Var()
     f = hl.Func()

--- a/python_bindings/correctness/iroperator.py
+++ b/python_bindings/correctness/iroperator.py
@@ -66,7 +66,7 @@ def test_mux_tuple():
     x = hl.Var()
     c = hl.Var()
     g[x] = (123, 456, x)
-    f[x, c] = mux(c, g[x])
+    f[x, c] = hl.mux(c, g[x])
     b = f.realize(1, 4)
     assert b[0, 0] == 123
     assert b[0, 1] == 456

--- a/python_bindings/src/PyIROperator.cpp
+++ b/python_bindings/src/PyIROperator.cpp
@@ -109,7 +109,7 @@ void define_operators(py::module &m) {
             << "tuple_select() may not mix Expr and Tuple for the condition elements.";
         return to_python_tuple(false_value);
     });
-    m.def("mux", &mux);
+    m.def("mux", (Expr(*)(const Expr &, const std::vector<Expr> &)) & mux);
 
     m.def("sin", &sin);
     m.def("asin", &asin);

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -1123,6 +1123,28 @@ Tuple tuple_select(const Expr &condition, const Tuple &true_value, const Tuple &
     return result;
 }
 
+Expr mux(const Expr &id, const std::vector<Expr> &values) {
+    user_assert(values.size() >= 2) << "mux() only accepts values with size >= 2.\n";
+    // Check if all the values have the same type.
+    Type t = values[0].type();
+    for (int i = 1; i < (int)values.size(); i++) {
+        user_assert(values[i].type() == t) << "mux() requires all the values to have the same type.";
+    }
+    Expr result = values.back();
+    for (int i = (int)values.size() - 2; i >= 0; i--) {
+        result = select(id == i, values[i], result);
+    }
+    return result;
+}
+
+Expr mux(const Expr &id, const Tuple &tup) {
+    return mux(id, tup.as_vector());
+}
+
+Expr mux(const Expr &id, const std::initializer_list<Expr> &values) {
+    return mux(id, std::vector<Expr>(values));
+}
+
 Expr unsafe_promise_clamped(const Expr &value, const Expr &min, const Expr &max) {
     user_assert(value.defined()) << "unsafe_promise_clamped with undefined value.\n";
     Expr n_min_val = min.defined() ? lossless_cast(value.type(), min) : value.type().min();

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -807,19 +807,9 @@ inline Tuple tuple_select(const Expr &c0, const Tuple &v0, const Expr &c1, const
  * img(x, y, c) = mux(c, {100, 50, 25});
  */
 // @{
-inline Expr mux(const Expr &id, const std::vector<Expr> &values) {
-    user_assert(values.size() >= 2) << "mux() only accepts values with size >= 2.\n";
-    // Check if all the values have the same type.
-    Type t = values[0].type();
-    for (int i = 1; i < (int)values.size(); i++) {
-        user_assert(values[i].type() == t) << "mux() requires all the values to have the same type.";
-    }
-    Expr result = values.back();
-    for (int i = (int)values.size() - 2; i >= 0; i--) {
-        result = select(id == i, values[i], result);
-    }
-    return result;
-}
+Expr mux(const Expr &id, const std::initializer_list<Expr> &values);
+Expr mux(const Expr &id, const std::vector<Expr> &values);
+Expr mux(const Expr &id, const Tuple &values);
 // @}
 
 /** Return the sine of a floating-point expression. If the argument is


### PR DESCRIPTION
I had a sudden horrifying vision of someone having to write:

`mux(c, {f(x, y)[0], f(x, y)[1], f(x, y)[2]})`

So this lets mux take a tuple as the second argument. Also needed to add
an initializer list overload to prevent ambiguity.

I still think it would be a good idea to permit f(x, y)[c], for
uniformity with Tuple's existing operator[] for integers. I can imagine
people wondering why they can't just pass an Expr there.