### PR TITLE
Simplifier improvements from #3037

### DIFF
--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -273,16 +273,16 @@ Simplify::ScopedFact::~ScopedFact() {
     }
 }
 
-Expr simplify(const Expr &e, bool remove_dead_lets,
+Expr simplify(const Expr &e, bool remove_dead_let_stmts,
               const Scope<Interval> &bounds,
               const Scope<ModulusRemainder> &alignment) {
-    return Simplify(remove_dead_lets, &bounds, &alignment).mutate(e, nullptr);
+    return Simplify(remove_dead_let_stmts, &bounds, &alignment).mutate(e, nullptr);
 }
 
-Stmt simplify(const Stmt &s, bool remove_dead_lets,
+Stmt simplify(const Stmt &s, bool remove_dead_let_stmts,
               const Scope<Interval> &bounds,
               const Scope<ModulusRemainder> &alignment) {
-    return Simplify(remove_dead_lets, &bounds, &alignment).mutate(s);
+    return Simplify(remove_dead_let_stmts, &bounds, &alignment).mutate(s);
 }
 
 class SimplifyExprs : public IRMutator {

--- a/src/Simplify.h
+++ b/src/Simplify.h
@@ -19,10 +19,10 @@ namespace Internal {
  * repeated variable names.
  */
 // @{
-Stmt simplify(const Stmt &, bool remove_dead_lets = true,
+Stmt simplify(const Stmt &, bool remove_dead_let_stmts = true,
               const Scope<Interval> &bounds = Scope<Interval>::empty_scope(),
               const Scope<ModulusRemainder> &alignment = Scope<ModulusRemainder>::empty_scope());
-Expr simplify(const Expr &, bool remove_dead_lets = true,
+Expr simplify(const Expr &, bool remove_dead_let_stmts = true,
               const Scope<Interval> &bounds = Scope<Interval>::empty_scope(),
               const Scope<ModulusRemainder> &alignment = Scope<ModulusRemainder>::empty_scope());
 // @}

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -494,6 +494,16 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
                               {arg, lower, upper},
                               Call::Intrinsic);
         }
+    } else if (op->is_intrinsic(Call::likely) ||
+               op->is_intrinsic(Call::likely_if_innermost)) {
+        // The bounds of the result are the bounds of the arg
+        internal_assert(op->args.size() == 1);
+        Expr arg = mutate(op->args[0], bounds);
+        if (arg.same_as(op->args[0])) {
+            return op;
+        } else {
+            return Call::make(op->type, op->name, {arg}, op->call_type);
+        }
     } else if (op->call_type == Call::PureExtern) {
         // TODO: This could probably be simplified into a single map-lookup
         // with a bit more cleverness; not sure if the reduced lookup time

--- a/src/Simplify_Let.cpp
+++ b/src/Simplify_Let.cpp
@@ -247,7 +247,8 @@ Body Simplify::simplify_let(const LetOrLetStmt *op, ExprInfo *bounds) {
             count_var_uses(it->new_value, vars_used);
         }
 
-        if (!remove_dead_lets || (info.old_uses > 0 && vars_used.count(it->op->name) > 0)) {
+        if ((!remove_dead_lets && std::is_same<LetOrLetStmt, LetStmt>::value) ||
+            (info.old_uses > 0 && vars_used.count(it->op->name) > 0)) {
             // The old name is still in use. We'd better keep it as well.
             result = LetOrLetStmt::make(it->op->name, it->value, result);
             count_var_uses(it->value, vars_used);

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -25,9 +25,21 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
 
     // Early out when the bounds tells us one side or the other is smaller
     if (a_bounds.max_defined && b_bounds.min_defined && a_bounds.max <= b_bounds.min) {
+        if (const Call *call = a.as<Call>()) {
+            if (call->is_intrinsic(Call::likely) ||
+                call->is_intrinsic(Call::likely_if_innermost)) {
+                return call->args[0];
+            }
+        }
         return a;
     }
     if (b_bounds.max_defined && a_bounds.min_defined && b_bounds.max <= a_bounds.min) {
+        if (const Call *call = b.as<Call>()) {
+            if (call->is_intrinsic(Call::likely) ||
+                call->is_intrinsic(Call::likely_if_innermost)) {
+                return call->args[0];
+            }
+        }
         return b;
     }
 
@@ -69,10 +81,10 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
              rewrite(min(max(y, x), x), b) ||
              rewrite(min(max(x, c0), c1), b, c1 <= c0) ||
 
-             rewrite(min(intrin(Call::likely, x), x), a) ||
-             rewrite(min(x, intrin(Call::likely, x)), b) ||
-             rewrite(min(intrin(Call::likely_if_innermost, x), x), a) ||
-             rewrite(min(x, intrin(Call::likely_if_innermost, x)), b) ||
+             rewrite(min(intrin(Call::likely, x), x), b) ||
+             rewrite(min(x, intrin(Call::likely, x)), a) ||
+             rewrite(min(intrin(Call::likely_if_innermost, x), x), b) ||
+             rewrite(min(x, intrin(Call::likely_if_innermost, x)), a) ||
 
              (no_overflow(op->type) &&
               (rewrite(min(ramp(x, y), broadcast(z)), a, can_prove(x + y * (lanes - 1) <= z && x <= z, this)) ||

--- a/src/Simplify_Select.cpp
+++ b/src/Simplify_Select.cpp
@@ -101,6 +101,13 @@ Expr Simplify::visit(const Select *op, ExprInfo *bounds) {
              rewrite(select(x < 0, x * y, 0), min(x, 0) * y) ||
              rewrite(select(x < 0, 0, x * y), max(x, 0) * y) ||
 
+             // Note that in the rules below we know y is not a
+             // constant because it appears on the LHS of an
+             // addition. These rules therefore trade a non-constant
+             // for a constant.
+             rewrite(select(x, y + z, y), y + select(x, z, 0)) ||
+             rewrite(select(x, y, y + z), y + select(x, 0, z)) ||
+
              (no_overflow_int(op->type) &&
               (rewrite(select(x, y * c0, c1), select(x, y, fold(c1 / c0)) * c0, c1 % c0 == 0) ||
                rewrite(select(x, c0, y * c1), select(x, fold(c0 / c1), y) * c1, c0 % c1 == 0) ||

--- a/src/Simplify_Select.cpp
+++ b/src/Simplify_Select.cpp
@@ -31,10 +31,10 @@ Expr Simplify::visit(const Select *op, ExprInfo *bounds) {
              rewrite(select(1, x, y), x) ||
              rewrite(select(0, x, y), y) ||
              rewrite(select(x, y, y), y) ||
-             rewrite(select(x, intrin(Call::likely, y), y), true_value) ||
-             rewrite(select(x, y, intrin(Call::likely, y)), false_value) ||
-             rewrite(select(x, intrin(Call::likely_if_innermost, y), y), true_value) ||
-             rewrite(select(x, y, intrin(Call::likely_if_innermost, y)), false_value) ||
+             rewrite(select(x, intrin(Call::likely, y), y), false_value) ||
+             rewrite(select(x, y, intrin(Call::likely, y)), true_value) ||
+             rewrite(select(x, intrin(Call::likely_if_innermost, y), y), false_value) ||
+             rewrite(select(x, y, intrin(Call::likely_if_innermost, y)), true_value) ||
              false)) {
             return rewrite.result;
         }

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -835,12 +835,20 @@ void check_bounds() {
     check(min((x / 8) * 8, x), (x / 8) * 8);
     check(min(x, (x / 8) * 8), (x / 8) * 8);
 
-    check(min(x, likely(x)), likely(x));
-    check(min(likely(x), x), likely(x));
-    check(max(x, likely(x)), likely(x));
-    check(max(likely(x), x), likely(x));
-    check(select(x > y, likely(x), x), likely(x));
-    check(select(x > y, x, likely(x)), likely(x));
+    // "likely" marks which side of a containing min/max/select is the
+    // one to optimize for, so if the min/max/select gets simplified
+    // away, the likely should be stripped too.
+    check(min(x, likely(x)), x);
+    check(min(likely(x), x), x);
+    check(max(x, likely(x)), x);
+    check(max(likely(x), x), x);
+    check(select(x > y, likely(x), x), x);
+    check(select(x > y, x, likely(x)), x);
+    // Check constant-bounds reasoning works through likelies
+    check(min(4, likely(5)), 4);
+    check(min(7, likely(5)), 5);
+    check(max(4, likely(5)), 5);
+    check(max(7, likely(5)), 7);
 
     check(min(x + 1, y) - min(x, y - 1), 1);
     check(max(x + 1, y) - max(x, y - 1), 1);

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -850,6 +850,9 @@ void check_bounds() {
     check(max(4, likely(5)), 5);
     check(max(7, likely(5)), 7);
 
+    check(select(x < y, x + y, x), select(x < y, y, 0) + x);
+    check(select(x < y, x, x + y), select(x < y, 0, y) + x);
+
     check(min(x + 1, y) - min(x, y - 1), 1);
     check(max(x + 1, y) - max(x, y - 1), 1);
     check(min(x + 1, y) - min(y - 1, x), 1);


### PR DESCRIPTION
Some simplifier improvements harvested from #3037. Bundled into a single PR to avoid overloading the bots, but done as separate commits to facilitate bisection. The are:

1) simplify min(x, likely(x)) -> x

I.e. the likely goes away. Augmented with better tracking of bounds of likely expressions. I believe this is more correct than the status quo, because a likely is supposed to mark which branch of the immediately containing min/max/select is the one to optimize for. This may result in fewer partitioned loops than before though.

2) The remove_dead_lets flag for the simplifier is now remove_dead_let_stmts. You always want to remove dead let exprs.

3) Two new rules to simplify select expressions