### PR TITLE
Prefer calling count() and treating result as bool to find() == end()

### DIFF
--- a/src/AddAtomicMutex.cpp
+++ b/src/AddAtomicMutex.cpp
@@ -235,7 +235,7 @@ protected:
 
     void visit(const Store *op) override {
         if (in_atomic_mutex) {
-            if (store_names.find(op->name) != store_names.end()) {
+            if (store_names.count(op->name)) {
                 found = true;
             }
         }
@@ -315,7 +315,7 @@ protected:
             return IRMutator::visit(op);
         }
 
-        if (allocated_mutexes.find(finder.mutex_name) != allocated_mutexes.end()) {
+        if (allocated_mutexes.count(finder.mutex_name)) {
             // We've already allocated a mutex.
             return IRMutator::visit(op);
         }
@@ -373,7 +373,7 @@ protected:
             return IRMutator::visit(op);
         }
 
-        if (allocated_mutexes.find(finder.mutex_name) != allocated_mutexes.end()) {
+        if (allocated_mutexes.count(finder.mutex_name)) {
             // We've already allocated a mutex.
             return IRMutator::visit(op);
         }

--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -79,7 +79,7 @@ public:
     void visit(const Variable *op) override {
         if (op->param.defined() &&
             op->param.is_buffer() &&
-            buffers.find(op->param.name()) == buffers.end()) {
+            !buffers.count(op->param.name())) {
             Result r;
             r.param = op->param;
             r.type = op->param.type();
@@ -105,12 +105,12 @@ class TrimStmtToPartsThatAccessBuffers : public IRMutator {
         return IRMutator::visit(op);
     }
     Stmt visit(const Provide *op) override {
-        touches_buffer |= (buffers.find(op->name) != buffers.end());
+        touches_buffer |= (buffers.count(op->name) > 0);
         return IRMutator::visit(op);
     }
     Expr visit(const Variable *op) override {
         if (op->param.defined() && op->param.is_buffer()) {
-            touches_buffer |= (buffers.find(op->param.name()) != buffers.end());
+            touches_buffer |= (buffers.count(op->param.name()) > 0);
         }
         return IRMutator::visit(op);
     }
@@ -510,14 +510,14 @@ Stmt add_image_checks(Stmt s,
                 }
 
                 std::string min0_name = buffer_name + ".0.min." + dim;
-                if (replace_with_constrained.count(min0_name) > 0) {
+                if (replace_with_constrained.count(min0_name)) {
                     min_constrained = replace_with_constrained[min0_name];
                 } else {
                     min_constrained = Variable::make(Int(32), min0_name);
                 }
 
                 std::string extent0_name = buffer_name + ".0.extent." + dim;
-                if (replace_with_constrained.count(extent0_name) > 0) {
+                if (replace_with_constrained.count(extent0_name)) {
                     extent_constrained = replace_with_constrained[extent0_name];
                 } else {
                     extent_constrained = Variable::make(Int(32), extent0_name);

--- a/src/AutoScheduleUtils.cpp
+++ b/src/AutoScheduleUtils.cpp
@@ -188,7 +188,7 @@ Expr perform_inline(Expr e, const map<string, Function> &env,
         // Inline from the last function to be realized to avoid extra
         // inlining works.
         for (const auto &call : calls) {
-            if (inlines.find(call) != inlines.end()) {
+            if (inlines.count(call)) {
                 const Function &prod_func = env.at(call);
                 // Impure functions cannot be inlined.
                 internal_assert(prod_func.is_pure());

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -3006,12 +3006,12 @@ void bounds_test() {
 
     map<string, Box> r;
     r = boxes_required(loop);
-    internal_assert(r.find("output") == r.end());
-    internal_assert(r.find("input") != r.end());
+    internal_assert(!r.count("output"));
+    internal_assert(r.count("input"));
     internal_assert(equal(simplify(r["input"][0].min), 6));
     internal_assert(equal(simplify(r["input"][0].max), 25));
     r = boxes_provided(loop);
-    internal_assert(r.find("output") != r.end());
+    internal_assert(r.count("output"));
     internal_assert(equal(simplify(r["output"][0].min), 4));
     internal_assert(equal(simplify(r["output"][0].max), 13));
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2297,7 +2297,7 @@ void CodeGen_LLVM::codegen_predicated_vector_store(const Store *op) {
         Value *vpred = codegen(op->predicate);
         Halide::Type value_type = op->value.type();
         Value *val = codegen(op->value);
-        bool is_external = (external_buffer.find(op->name) != external_buffer.end());
+        bool is_external = external_buffer.count(op->name);
         int alignment = value_type.bytes();
         int native_bits = native_vector_bits();
         int native_bytes = native_bits / 8;
@@ -2383,7 +2383,7 @@ Value *CodeGen_LLVM::codegen_dense_vector_load(const Load *load, Value *vpred) {
     const Ramp *ramp = load->index.as<Ramp>();
     internal_assert(ramp && is_one(ramp->stride)) << "Should be dense vector load\n";
 
-    bool is_external = (external_buffer.find(load->name) != external_buffer.end());
+    bool is_external = external_buffer.count(load->name);
     int alignment = load->type.bytes();  // The size of a single element
 
     int native_bits = native_vector_bits();
@@ -4091,7 +4091,7 @@ void CodeGen_LLVM::visit(const Store *op) {
     }
 
     Value *val = codegen(op->value);
-    bool is_external = (external_buffer.find(op->name) != external_buffer.end());
+    bool is_external = external_buffer.count(op->name);
     // Scalar
     if (value_type.is_scalar()) {
         Value *ptr = codegen_buffer_pointer(op->name, value_type, op->index);

--- a/src/DerivativeUtils.cpp
+++ b/src/DerivativeUtils.cpp
@@ -171,7 +171,7 @@ void ExpressionSorter::visit(const Call *op) {
 }
 
 void ExpressionSorter::visit(const Let *op) {
-    internal_assert(let_var_mapping.find(op->name) == let_var_mapping.end());
+    internal_assert(!let_var_mapping.count(op->name));
     let_var_mapping[op->name] = op->value;
 
     include(op->body);
@@ -245,7 +245,7 @@ map<string, Box> inference_bounds(const vector<Func> &funcs,
     for (auto it = order.rbegin(); it != order.rend(); it++) {
         Func func = Func(env[*it]);
         // We should already have the bounds of this function
-        internal_assert(bounds.find(*it) != bounds.end());
+        internal_assert(bounds.count(*it));
         const Box &current_bounds = bounds[*it];
         internal_assert(func.args().size() == current_bounds.size());
         // We know the range for each argument of this function

--- a/src/EmulateFloat16Math.cpp
+++ b/src/EmulateFloat16Math.cpp
@@ -141,7 +141,7 @@ const std::map<std::string, std::string> transcendental_remapping =
 }  // anonymous namespace
 
 bool is_float16_transcendental(const Call *op) {
-    return transcendental_remapping.find(op->name) != transcendental_remapping.end();
+    return transcendental_remapping.count(op->name);
 }
 
 Expr lower_float16_transcendental_to_float32_equivalent(const Call *op) {

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -869,7 +869,7 @@ int generate_filter_main_inner(int argc, char **argv, std::ostream &cerr) {
     const std::vector<std::string> emit_flags = split_string(flags_info["-e"], ",");
     const bool stub_only = (emit_flags.size() == 1 && emit_flags[0] == "cpp_stub");
     if (!stub_only) {
-        if (generator_args.find("target") == generator_args.end()) {
+        if (!generator_args.count("target")) {
             cerr << "Target missing\n";
             cerr << kUsage;
             return 1;
@@ -1039,7 +1039,7 @@ void GeneratorRegistry::register_factory(const std::string &name,
     user_assert(is_valid_name(name)) << "Invalid Generator name: " << name;
     GeneratorRegistry &registry = get_registry();
     std::lock_guard<std::mutex> lock(registry.mutex);
-    internal_assert(registry.factories.find(name) == registry.factories.end())
+    internal_assert(!registry.factories.count(name))
         << "Duplicate Generator name: " << name;
     registry.factories[name] = std::move(generator_factory);
 }
@@ -1048,7 +1048,7 @@ void GeneratorRegistry::register_factory(const std::string &name,
 void GeneratorRegistry::unregister_factory(const std::string &name) {
     GeneratorRegistry &registry = get_registry();
     std::lock_guard<std::mutex> lock(registry.mutex);
-    internal_assert(registry.factories.find(name) != registry.factories.end())
+    internal_assert(registry.factories.count(name))
         << "Generator not found: " << name;
     registry.factories.erase(name);
 }

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -1456,7 +1456,7 @@ class EliminateInterleaves : public IRMutator {
                                    op->func, op->value_index, op->image, op->param);
             // Add the interleave back to the result of the call.
             return native_interleave(expr);
-        } else if (deinterleaving_alts.find(op->name) != deinterleaving_alts.end() &&
+        } else if (deinterleaving_alts.count(op->name) &&
                    yields_removable_interleave(args)) {
             // This call has a deinterleaving alternative, and the
             // arguments are interleaved, so we should use the
@@ -2227,7 +2227,7 @@ class SyncronizationBarriers : public IRMutator {
     // Creates entry in sync map for the stmt requiring a
     // scatter-release instruction before it.
     void check_hazard(const string &name) {
-        if (in_flight.find(name) == in_flight.end()) {
+        if (!in_flight.count(name)) {
             return;
         }
         // Sync Needed. Add the scatter-release before the first different For
@@ -2269,7 +2269,7 @@ public:
         curr = &s;
         Stmt new_s = IRMutator::mutate(s);
         // Wrap the stmt with scatter-release if any hazard was detected.
-        if (sync.find(&s) != sync.end()) {
+        if (sync.count(&s)) {
             Stmt scatter_sync = Evaluate::make(Call::make(Int(32), "scatter_release",
                                                           {sync[&s]}, Call::Intrinsic));
             return Block::make(scatter_sync, new_s);

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -177,7 +177,7 @@ void write_symbol_table(std::ostream &out,
             auto err = sym.printName(symbols);
             internal_assert(!err);
             std::string name = symbols.str().str();
-            if (name_to_member_index.find(name) != name_to_member_index.end()) {
+            if (name_to_member_index.count(name)) {
                 user_warning << "Warning: symbol '" << name << "' seen multiple times in library.\n";
                 continue;
             }

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -134,7 +134,7 @@ void validate_outputs(const std::map<Output, std::string> &in) {
 }
 
 bool contains(const std::map<Output, std::string> &in, const Output &key) {
-    return in.find(key) != in.end();
+    return in.count(key);
 }
 
 std::map<Output, std::string> add_suffixes(const std::map<Output, std::string> &in, const std::string &suffix) {
@@ -536,8 +536,8 @@ Module Module::resolve_submodules() const {
 }
 
 void Module::remap_metadata_name(const std::string &from, const std::string &to) const {
-    internal_assert(contents->metadata_name_map.find(from) == contents->metadata_name_map.end());
-    internal_assert(contents->metadata_name_map.find(to) == contents->metadata_name_map.end());
+    internal_assert(!contents->metadata_name_map.count(from));
+    internal_assert(!contents->metadata_name_map.count(to));
     contents->metadata_name_map[from] = to;
 }
 

--- a/src/ObjectInstanceRegistry.cpp
+++ b/src/ObjectInstanceRegistry.cpp
@@ -17,7 +17,7 @@ void ObjectInstanceRegistry::register_instance(void *this_ptr, size_t size, Kind
     ObjectInstanceRegistry &registry = get_registry();
     std::lock_guard<std::mutex> lock(registry.mutex);
     uintptr_t key = (uintptr_t)this_ptr;
-    internal_assert(registry.instances.find(key) == registry.instances.end());
+    internal_assert(!registry.instances.count(key));
     if (introspection_helper) {
         registry.instances[key] = InstanceInfo(size, kind, subject_ptr, true);
         Introspection::register_heap_object(this_ptr, size, introspection_helper);

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -233,7 +233,7 @@ AutoSchedulerResults Pipeline::auto_schedule(const Target &target, const Machine
 /* static */
 void Pipeline::add_autoscheduler(const std::string &autoscheduler_name, const AutoSchedulerFn &autoscheduler) {
     auto &m = get_autoscheduler_map();
-    user_assert(m.find(autoscheduler_name) == m.end()) << "'" << autoscheduler_name << "' is already registered as an autoscheduler.\n";
+    user_assert(!m.count(autoscheduler_name)) << "'" << autoscheduler_name << "' is already registered as an autoscheduler.\n";
     m[autoscheduler_name] = autoscheduler;
 }
 

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -76,7 +76,7 @@ private:
         }
 
         // It is an external buffer.
-        user_assert(env.find(name) == env.end())
+        user_assert(!env.count(name))
             << "Prefetch to buffer \"" << name << "\" which has not been allocated\n";
 
         const auto &iter = external_buffers.find(name);
@@ -197,7 +197,7 @@ private:
             set<string> seen;
             for (int i = prefetch_list.size() - 1; i >= 0; --i) {
                 const PrefetchDirective &p = prefetch_list[i];
-                if (!ends_with(op->name, "." + p.var) || (seen.find(p.name) != seen.end())) {
+                if (!ends_with(op->name, "." + p.var) || seen.count(p.name)) {
                     continue;
                 }
                 seen.insert(p.name);

--- a/src/RealizationOrder.cpp
+++ b/src/RealizationOrder.cpp
@@ -29,7 +29,7 @@ void find_fused_groups_dfs(const string &current,
     internal_assert(iter != fuse_adjacency_list.end());
 
     for (const string &fn : iter->second) {
-        if (visited.find(fn) == visited.end()) {
+        if (!visited.count(fn)) {
             find_fused_groups_dfs(fn, fuse_adjacency_list, visited, group);
         }
     }
@@ -44,7 +44,7 @@ find_fused_groups(const map<string, Function> &env,
 
     for (const auto &iter : env) {
         const string &fn = iter.first;
-        if (visited.find(fn) == visited.end()) {
+        if (!visited.count(fn)) {
             vector<string> group;
             find_fused_groups_dfs(fn, fuse_adjacency_list, visited, group);
 
@@ -71,10 +71,10 @@ void realization_order_dfs(const string &current,
 
     for (const string &fn : iter->second) {
         internal_assert(fn != current);
-        if (visited.find(fn) == visited.end()) {
+        if (!visited.count(fn)) {
             realization_order_dfs(fn, graph, visited, result_set, order);
         } else {
-            internal_assert(result_set.find(fn) != result_set.end())
+            internal_assert(result_set.count(fn))
                 << "Stuck in a loop computing a realization order. "
                 << "Perhaps this pipeline has a loop involving " << current << "?\n";
         }
@@ -109,13 +109,13 @@ void validate_fused_pair(const string &fn, size_t stage_index,
     // Assert no dependencies among the functions that are computed_with.
     const auto &callees_1 = indirect_calls.find(p.func_1);
     if (callees_1 != indirect_calls.end()) {
-        user_assert(callees_1->second.find(p.func_2) == callees_1->second.end())
+        user_assert(!callees_1->second.count(p.func_2))
             << "Invalid compute_with: there is dependency between "
             << p.func_1 << " and " << p.func_2 << "\n";
     }
     const auto &callees_2 = indirect_calls.find(p.func_2);
     if (callees_2 != indirect_calls.end()) {
-        user_assert(callees_2->second.find(p.func_1) == callees_2->second.end())
+        user_assert(!callees_2->second.count(p.func_1))
             << "Invalid compute_with: there is dependency between "
             << p.func_1 << " and " << p.func_2 << "\n";
     }
@@ -279,7 +279,7 @@ pair<vector<string>, vector<vector<string>>> realization_order(
     set<string> result_set;
     set<string> visited;
     for (Function f : outputs) {
-        if (visited.find(f.name()) == visited.end()) {
+        if (!visited.count(f.name())) {
             realization_order_dfs(f.name(), graph, visited, result_set, temp);
         }
     }
@@ -337,7 +337,7 @@ vector<string> topological_order(const vector<Function> &outputs,
     set<string> result_set;
     set<string> visited;
     for (Function f : outputs) {
-        if (visited.find(f.name()) == visited.end()) {
+        if (!visited.count(f.name())) {
             realization_order_dfs(f.name(), graph, visited, result_set, order);
         }
     }

--- a/src/RegionCosts.cpp
+++ b/src/RegionCosts.cpp
@@ -479,7 +479,7 @@ Cost RegionCosts::region_cost(const map<string, Box> &regions, const set<string>
     for (const auto &f : regions) {
         // The cost for pure inlined functions will be accounted in the
         // consumer of the inlined function so they should be skipped.
-        if (inlines.find(f.first) != inlines.end()) {
+        if (inlines.count(f.first)) {
             internal_assert(get_element(env, f.first).is_pure());
             continue;
         }
@@ -610,7 +610,7 @@ RegionCosts::detailed_load_costs(const map<string, Box> &regions,
     for (const auto &r : regions) {
         // The cost for pure inlined functions will be accounted in the
         // consumer of the inlined function so they should be skipped.
-        if (inlines.find(r.first) != inlines.end()) {
+        if (inlines.count(r.first)) {
             internal_assert(get_element(env, r.first).is_pure());
             continue;
         }
@@ -718,7 +718,7 @@ Expr RegionCosts::region_footprint(const map<string, Box> &regions,
 
     for (const auto &f : regions) {
         // Inlined functions do not have allocations
-        bool is_inlined = inlined.find(f.first) != inlined.end();
+        bool is_inlined = inlined.count(f.first);
         Expr size = is_inlined ? make_zero(Int(64)) : region_size(f.first, f.second);
         if (!size.defined()) {
             return Expr();
@@ -728,7 +728,7 @@ Expr RegionCosts::region_footprint(const map<string, Box> &regions,
     }
 
     for (const auto &f : top_order) {
-        if (regions.find(f) != regions.end()) {
+        if (regions.count(f)) {
             curr_size += get_element(func_sizes, f);
         }
         working_set_size = max(curr_size, working_set_size);

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1297,7 +1297,7 @@ private:
             internal_assert(iter != env.end());
             const Function &f = iter->second;
             string prefix_2 = pair.func_2 + ".s" + std::to_string(pair.stage_2) + "." + pair.var_name;
-            if (visited.find(prefix_2) == visited.end()) {
+            if (!visited.count(prefix_2)) {
                 const Definition &def_2 = (pair.stage_2 == 0) ? f.definition() : f.update((int)(pair.stage_2 - 1));
                 collect_all_dependence_helper(prefix_2, def_2, pair, dependence, visited);
             }
@@ -1314,7 +1314,7 @@ private:
             internal_assert(iter != env.end());
             const Function &f = iter->second;
             string prefix = pair.func_2 + ".s" + std::to_string(pair.stage_2) + "." + pair.var_name;
-            if (visited.find(prefix) == visited.end()) {
+            if (!visited.count(prefix)) {
                 const Definition &def_2 = (pair.stage_2 == 0) ? f.definition() : f.update((int)(pair.stage_2 - 1));
                 collect_all_dependence_helper(prefix, def_2, pair, dependence, visited);
             }

--- a/src/Simplify_Let.cpp
+++ b/src/Simplify_Let.cpp
@@ -241,7 +241,7 @@ Body Simplify::simplify_let(const LetOrLetStmt *op, ExprInfo *bounds) {
         VarInfo info = var_info.get(it->op->name);
         var_info.pop(it->op->name);
 
-        if (it->new_value.defined() && (info.new_uses > 0 && vars_used.count(it->new_name) > 0)) {
+        if (it->new_value.defined() && (info.new_uses > 0 && vars_used.count(it->new_name))) {
             // The new name/value may be used
             result = LetOrLetStmt::make(it->new_name, it->new_value, result);
             count_var_uses(it->new_value, vars_used);

--- a/src/UniquifyVariableNames.cpp
+++ b/src/UniquifyVariableNames.cpp
@@ -16,7 +16,7 @@ class UniquifyVariableNames : public IRMutator {
     map<string, int> vars;
 
     void push_name(const string &s) {
-        if (vars.find(s) == vars.end()) {
+        if (!vars.count(s)) {
             vars[s] = 0;
         } else {
             vars[s]++;
@@ -24,7 +24,7 @@ class UniquifyVariableNames : public IRMutator {
     }
 
     string get_name(string s) {
-        if (vars.find(s) == vars.end()) {
+        if (!vars.count(s)) {
             return s;
         } else if (vars[s] == 0) {
             return s;

--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -512,7 +512,7 @@ void prune_varying_attributes(const Stmt &loop_stmt, std::map<std::string, Expr>
 
     for (const std::pair<const std::string, Expr> &i : varying) {
         const std::string &name = i.first;
-        if (find.variables.find(name) == find.variables.end()) {
+        if (find.variables.count(name)) {
             debug(2) << "Removed varying attribute " << name << "\n";
             remove_list.push_back(name);
         }

--- a/src/WrapCalls.cpp
+++ b/src/WrapCalls.cpp
@@ -98,8 +98,8 @@ map<string, Function> wrap_func_calls(const map<string, Function> &env) {
                 global_wrappers.insert(Function(wrapper).name());
                 for (const auto &wrapped_env_iter : wrapped_env) {
                     in_func = wrapped_env_iter.first;
-                    if ((wrapped_fname == in_func) ||
-                        (all_func_wrappers.find(in_func) != all_func_wrappers.end())) {
+                    if (wrapped_fname == in_func ||
+                        all_func_wrappers.count(in_func)) {
                         // The wrapper should still call the original function,
                         // so we don't want to rewrite the calls done by the
                         // wrapper. We also shouldn't rewrite the original
@@ -165,7 +165,7 @@ map<string, Function> wrap_func_calls(const map<string, Function> &env) {
     for (const auto &iter : wrapped_env) {
         const auto &substitutions = func_wrappers_map[iter.second.get_contents()];
         for (const auto &pair : substitutions) {
-            if (global_wrappers.find(Function(pair.second).name()) == global_wrappers.end()) {
+            if (!global_wrappers.count(Function(pair.second).name())) {
                 validate_custom_wrapper(iter.second, Function(pair.first), Function(pair.second));
             }
         }


### PR DESCRIPTION
For std::map, map.count(foo) just inlines to (map.find(foo) == map.end()
? 0 : 1), so the assembly is identical. This is purely a stylistic
choice that I'm raising for discussion because Steven brought it up as
being clearer in one context in another PR.

Opinions? Is this clearer on average? It's certainly fewer characters.
I'm leaning towards yes.