### PR TITLE
Instead of just assuming bounds query results can be lifted, enforce nesting

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1263,20 +1263,6 @@ private:
                            op->func, op->value_index, op->image, op->param),
                 Call::make(t, op->name, {interval.max}, op->call_type,
                            op->func, op->value_index, op->image, op->param));
-
-        } else if (!const_bound &&
-                   (op->name == Call::buffer_get_min ||
-                    op->name == Call::buffer_get_max)) {
-            // Bounds query results should have perfect nesting. Their
-            // max over a loop is just the same bounds query call at
-            // an outer loop level. This requires that the query is
-            // also done at the outer loop level so that the buffer
-            // arg is still valid, which it is, so it is.
-            //
-            // TODO: There should be an assert injected in the inner
-            // loop to check perfect nesting.
-            interval = Interval(Call::make(Int(32), Call::buffer_get_min, op->args, Call::Extern),
-                                Call::make(Int(32), Call::buffer_get_max, op->args, Call::Extern));
         } else if (op->is_intrinsic(Call::popcount) ||
                    op->is_intrinsic(Call::count_leading_zeros) ||
                    op->is_intrinsic(Call::count_trailing_zeros)) {

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -183,7 +183,7 @@ public:
     // The fused group is indexed in the same way as 'fused_groups'.
     const vector<set<FusedPair>> &fused_pairs_in_groups;
     const FuncValueBounds &func_bounds;
-    set<string> in_pipeline, inner_productions;
+    set<string> in_pipeline, inner_productions, has_extern_consumer;
     const Target target;
 
     struct CondValue {
@@ -378,6 +378,7 @@ public:
                            const vector<set<FusedPair>> &fused_pairs_in_groups,
                            const set<string> &in_pipeline,
                            const set<string> &inner_productions,
+                           const set<string> &has_extern_consumer,
                            const Target &target) {
 
             // Merge all the relevant boxes.
@@ -568,12 +569,29 @@ public:
             for (size_t d = 0; d < b.size(); d++) {
                 string arg = name + ".s" + std::to_string(stage) + "." + func_args[d];
 
+                const bool clamp_to_outer_bounds =
+                    !in_pipeline.empty() && has_extern_consumer.count(name);
+                if (clamp_to_outer_bounds) {
+                    // Allocation bounds inference is going to have a
+                    // bad time lifting the results of the bounds
+                    // queries outwards. Help it out by insisting that
+                    // the bounds are clamped to lie within the bounds
+                    // one loop level up.
+                    b[d].min = max(b[d].min, Variable::make(Int(32), arg + ".outer_min"));
+                    b[d].max = min(b[d].max, Variable::make(Int(32), arg + ".outer_max"));
+                }
+
                 if (b[d].is_single_point()) {
                     s = LetStmt::make(arg + ".min", Variable::make(Int(32), arg + ".max"), s);
                 } else {
                     s = LetStmt::make(arg + ".min", b[d].min, s);
                 }
                 s = LetStmt::make(arg + ".max", b[d].max, s);
+
+                if (clamp_to_outer_bounds) {
+                    s = LetStmt::make(arg + ".outer_min", Variable::make(Int(32), arg + ".min"), s);
+                    s = LetStmt::make(arg + ".outer_max", Variable::make(Int(32), arg + ".max"), s);
+                }
             }
 
             if (stage > 0) {
@@ -861,6 +879,7 @@ public:
                 for (size_t j = 0; j < args.size(); j++) {
                     if (args[j].is_func()) {
                         Function f(args[j].func);
+                        has_extern_consumer.insert(f.name());
                         string stage_name = f.name() + ".s" + std::to_string(f.updates().size());
                         Box b(f.dimensions());
                         for (int d = 0; d < f.dimensions(); d++) {
@@ -1101,7 +1120,8 @@ public:
                     }
                     body = stages[i].define_bounds(
                         body, f, stage_name, stage_index, op->name, fused_groups,
-                        fused_pairs_in_groups, in_pipeline, inner_productions, target);
+                        fused_pairs_in_groups, in_pipeline, inner_productions,
+                        has_extern_consumer, target);
                 }
             }
 
@@ -1238,6 +1258,7 @@ Stmt bounds_inference(Stmt s,
 
     // Add an outermost bounds inference marker
     s = For::make("<outermost>", 0, 1, ForType::Serial, DeviceAPI::None, s);
+
     s = BoundsInference(funcs, fused_func_groups, fused_pairs_in_groups,
                         outputs, func_bounds, target)
             .mutate(s);

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -204,6 +204,7 @@ tests(GROUPS correctness travis
         named_updates.cpp
         nested_shiftinwards.cpp
         newtons_method.cpp
+        non_nesting_extern_bounds_query.cpp
         non_vector_aligned_embeded_buffer.cpp
         obscure_image_references.cpp
         oddly_sized_output.cpp

--- a/test/correctness/non_nesting_extern_bounds_query.cpp
+++ b/test/correctness/non_nesting_extern_bounds_query.cpp
@@ -1,0 +1,70 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+// Extern stages are supposed to obey the following nesting property
+// on bounds queries: If some region of the output O requires some
+// region of the input I, then requesting any subset of O should only
+// require a subset of I.
+//
+// This extern stage violates that property. We're going to set up a
+// schedule that does a bounds query to it for an entire image, and a
+// bounds query for a single scanline. For the whole-image query it
+// will claim to need a modest-sized input, but for the single
+// scanline query it will claim to need a much wider input. The result
+// is that the bounds query is not entirely respected. The actual input
+// received in non-bounds-query-mode is the intersection of what it
+// asked for for a single scanline and what it asked for for the whole
+// image.
+extern "C" DLLEXPORT int misbehaving_extern_stage(halide_buffer_t *in, halide_buffer_t *out) {
+    if (in->is_bounds_query()) {
+        // As a baseline, require the same amount of input as output, like a copy
+        memcpy(in->dim, out->dim, out->dimensions * sizeof(halide_dimension_t));
+        if (out->dim[1].extent == 1) {
+            // This is the inner query, for a single scanline of
+            // output.  Require a wider input, violating the nesting
+            // property. Shift it over a little too.
+            in->dim[0].min += 50;
+            in->dim[0].extent += 100;
+        }
+    } else {
+        // The inner (bad) bounds query should not have been respected
+        // in the x dimension. You get the intersection of the inner
+        // query and the outer query.
+
+        // Check the left edge was indeed shifted inwards, as
+        // requested by the per-scanline bounds query.
+        assert(in->dim[0].min == out->dim[0].min + 50);
+
+        // Check the right edge wasn't shifted over, but was instead
+        // clamped to lie within the outer bounds query.
+        assert(in->dim[0].extent == out->dim[0].extent - 50);
+
+        // The inner bounds query was fine in the y dimension, which
+        // correctly nested.
+        assert(in->dim[1].min == out->dim[1].min);
+        assert(in->dim[1].extent == 1);
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    Func f, g, h;
+    Var x, y;
+    f(x, y) = x + y;
+    g.define_extern("misbehaving_extern_stage", {f}, Int(32), 2);
+    h(x, y) = g(x, y);
+
+    g.compute_at(h, y);
+    f.compute_at(h, y);
+
+    h.realize(200, 200);
+
+    printf("Success!\n");
+}


### PR DESCRIPTION
TL;DR: This is an improvement from #3037 / #4713 that can be tested and
checked in independently. It removes one type of magic name usage.

Allocation bounds inference (well, boxes_touched) relies on magic names
in its handling of getting the min/max out of a bounds query result. It
just lifts them out of their containing scope (see the deleted code in
Bounds.cpp below), assuming a bounds query buffer of the same name also
exists in the containing scope, and also assuming that the result of
that outer bounds query was a valid interval containing the result of
the inner bounds query. Yuck. I removed that special handling from
boxes_touched, and instead explicitly clamped the inner bounds query
result to be within the outer region required, which comes from the
outer bounds query. That gives boxes_touched a way to bound the impure
call with something.

So now if we have a misbehaving extern stage, which lies in its outer
bounds query and says it's going to ask for less than it does in the
inner bounds query, it simply doesn't get what it asks for in the inner
bounds query. It gets the intersection of the outer bounds query result
and the inner bounds query result. Too bad. This behavior is illustrated
in the new test. Formerly I'm not sure what happened, because we were
just assuming that it couldn't occur. I guess that's UB. One of the
tests in storage_folding actually broke this rule, but it didn't matter
before because it never actually accessed the input.

Storage folding needed adjusting because it incorrectly didn't even try
to fold now that the bound seems to be pure (it's a .outer_min Variable,
whereas before it was the get_min call referencing the outer bounds
query result).