### PR TITLE
Don't depend on magic names in allocation bounds inference

### DIFF
--- a/src/AllocationBoundsInference.cpp
+++ b/src/AllocationBoundsInference.cpp
@@ -31,19 +31,6 @@ class AllocationInference : public IRMutator {
 
         Scope<Interval> empty_scope;
         Box b = box_touched(op->body, op->name, empty_scope, func_bounds);
-        if (touched_by_extern.count(f.name())) {
-            // The region touched is at least the region required at this
-            // loop level of the first stage (this is important for inputs
-            // and outputs to extern stages).
-            Box required(op->bounds.size());
-            for (size_t i = 0; i < required.size(); i++) {
-                string prefix = op->name + ".s0." + f_args[i];
-                required[i] = Interval(Variable::make(Int(32), prefix + ".min"),
-                                       Variable::make(Int(32), prefix + ".max"));
-            }
-
-            merge_boxes(b, required);
-        }
 
         Stmt new_body = mutate(op->body);
         Stmt stmt = Realize::make(op->name, op->types, op->memory_type, op->bounds, op->condition, new_body);
@@ -140,11 +127,28 @@ public:
     }
 };
 
+// We can strip box_touched declarations here. We're done with
+// them. Reconsider this decision if we want to use
+// box_touched on extern stages later in lowering. Storage
+// folding currently does box_touched too, but it handles extern
+// stages specially already.
+class StripDeclareBoxTouched : public IRMutator {
+    using IRMutator::visit;
+
+    Expr visit(const Call *op) override {
+        if (op->is_intrinsic(Call::declare_box_touched)) {
+            return 0;
+        } else {
+            return IRMutator::visit(op);
+        }
+    }
+};
+
 Stmt allocation_bounds_inference(Stmt s,
                                  const map<string, Function> &env,
                                  const FuncValueBounds &fb) {
-    AllocationInference inf(env, fb);
-    s = inf.mutate(s);
+    s = AllocationInference(env, fb).mutate(s);
+    s = StripDeclareBoxTouched().mutate(s);
     return s;
 }
 

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1813,6 +1813,18 @@ private:
     }
 
     void visit(const Call *op) override {
+        if (op->is_intrinsic(Call::declare_box_touched)) {
+            internal_assert(!op->args.empty());
+            const Variable *handle = op->args[0].as<Variable>();
+            const string &func = handle->name;
+            Box b(op->args.size() / 2);
+            for (size_t i = 0; i < b.size(); i++) {
+                b[i].min = op->args[2 * i + 1];
+                b[i].max = op->args[2 * i + 2];
+            }
+            merge_boxes(boxes[func], b);
+        }
+
         if (consider_calls) {
             if (op->is_intrinsic(Call::if_then_else)) {
                 internal_assert(op->args.size() == 3);
@@ -2434,7 +2446,7 @@ map<string, Box> boxes_touched(const Expr &e, Stmt s, bool consider_calls, bool 
             }
 
             Expr visit(const Variable *op) override {
-                if (op->name == fn_buffer) {
+                if (op->name == fn_buffer || op->name == fn) {
                     relevant = true;
                 }
                 return op;

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -592,6 +592,7 @@ const char *const intrinsic_op_names[] = {
     "cast_mask",
     "count_leading_zeros",
     "count_trailing_zeros",
+    "declare_box_touched",
     "debug_to_file",
     "div_round_to_zero",
     "dynamic_shuffle",

--- a/src/IR.h
+++ b/src/IR.h
@@ -504,6 +504,7 @@ struct Call : public ExprNode<Call> {
         cast_mask,
         count_leading_zeros,
         count_trailing_zeros,
+        declare_box_touched,
         debug_to_file,
         div_round_to_zero,
         dynamic_shuffle,


### PR DESCRIPTION
This is another independent improvement carved off of #3037 / #4713

Allocation bounds inference for a Func foo depends on the magic names
foo.x.min/foo.x.max at the realization site. The only reason it needs
them is to ensure it knows that an extern stage is going to write to the
whole region required. We can just tell it that earlier instead with a
marker in the IR that says "you should treat this marker as a write to
this buffer over this region". Presto, no magic name dependence.

This is desirable because it will let us do more types of IR transformation
before allocation bounds inference.