### PR TITLE
Calls can't be considered constant if they are impure

### DIFF
--- a/src/Monotonic.cpp
+++ b/src/Monotonic.cpp
@@ -517,7 +517,7 @@ void is_monotonic_test() {
     check_constant(select(y > 3, y + 23, y - 65));
 
     std::cout << "is_monotonic test passed" << std::endl;
-}  // namespace Internal
+}
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Monotonic.cpp
+++ b/src/Monotonic.cpp
@@ -491,6 +491,9 @@ void is_monotonic_test() {
     check_unknown(x != y);
     check_unknown(x * y);
 
+    // Not constant despite having constant args, because there's a side-effect.
+    check_unknown(Call::make(Int(32), "foo", {Expr(3)}, Call::Extern));
+
     check_increasing(select(y == 2, x, x + 4));
     check_decreasing(select(y == 2, -x, x * -4));
 
@@ -514,7 +517,7 @@ void is_monotonic_test() {
     check_constant(select(y > 3, y + 23, y - 65));
 
     std::cout << "is_monotonic test passed" << std::endl;
-}
+}  // namespace Internal
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Monotonic.cpp
+++ b/src/Monotonic.cpp
@@ -323,9 +323,16 @@ class MonotonicVisitor : public IRVisitor {
             return;
         }
 
+        if (!op->is_pure()) {
+            // Even with constant args, the result could vary from one loop iteration to the next.
+            result = Monotonic::Unknown;
+            return;
+        }
+
         for (size_t i = 0; i < op->args.size(); i++) {
             op->args[i].accept(this);
             if (result != Monotonic::Constant) {
+                // One of the args is not constant.
                 result = Monotonic::Unknown;
                 return;
             }


### PR DESCRIPTION
Currently is_monotonic treats calls with constant args as pure. But impure calls could return a different value on each call, even if they have the same args, so they shouldn't be considered constant.