### PR TITLE
Generalize uniquify_variable_names

### DIFF
--- a/src/UniquifyVariableNames.cpp
+++ b/src/UniquifyVariableNames.cpp
@@ -110,8 +110,8 @@ class UniquifyVariableNames : public IRMutator {
     }
 
 public:
-    UniquifyVariableNames(Scope<string> &&free_vars)
-        : renaming(std::move(free_vars)) {
+    UniquifyVariableNames(const Scope<string> *free_vars) {
+        renaming.set_containing_scope(free_vars);
     }
 };
 
@@ -160,7 +160,7 @@ public:
 Stmt uniquify_variable_names(const Stmt &s) {
     FindFreeVars finder;
     s.accept(&finder);
-    UniquifyVariableNames u(std::move(finder.free_vars));
+    UniquifyVariableNames u(&finder.free_vars);
     return u.mutate(s);
 }
 

--- a/src/UniquifyVariableNames.cpp
+++ b/src/UniquifyVariableNames.cpp
@@ -1,42 +1,42 @@
 #include "UniquifyVariableNames.h"
+#include "IREquality.h"
 #include "IRMutator.h"
+#include "IROperator.h"
+#include "Var.h"
 #include <sstream>
 
 namespace Halide {
 namespace Internal {
 
 using std::map;
+using std::pair;
+using std::set;
 using std::string;
 using std::vector;
 
+namespace {
 class UniquifyVariableNames : public IRMutator {
 
     using IRMutator::visit;
 
-    map<string, int> vars;
+    // The mapping from old names to new names
+    Scope<string> renaming;
 
-    void push_name(const string &s) {
-        if (vars.find(s) == vars.end()) {
-            vars[s] = 0;
-        } else {
-            vars[s]++;
+    // Get a new previously unused name for a let binding or for loop,
+    // and push it onto the renaming. Will return the original name if
+    // possible, but pushes unconditionally to simplify cleanup.
+    string make_new_name(const string &base) {
+        if (!renaming.contains(base)) {
+            renaming.push(base, base);
+            return base;
         }
-    }
-
-    string get_name(string s) {
-        if (vars.find(s) == vars.end()) {
-            return s;
-        } else if (vars[s] == 0) {
-            return s;
-        } else {
-            std::ostringstream oss;
-            oss << s << "_" << vars[s];
-            return oss.str();
+        for (size_t i = std::max((size_t)1, renaming.count(base));; i++) {
+            string candidate = base + "_" + std::to_string(i);
+            if (!renaming.contains(candidate)) {
+                renaming.push(base, candidate);
+                return candidate;
+            }
         }
-    }
-
-    void pop_name(const string &s) {
-        vars[s]--;
     }
 
     template<typename LetOrLetStmt>
@@ -45,14 +45,15 @@ class UniquifyVariableNames : public IRMutator {
             const LetOrLetStmt *op;
             Expr value;
             string new_name;
+            Frame(const LetOrLetStmt *op, Expr value, string new_name)
+                : op(op), value(std::move(value)), new_name(std::move(new_name)) {
+            }
         };
 
         vector<Frame> frames;
         decltype(op->body) result;
         while (op) {
-            Expr val = mutate(op->value);
-            push_name(op->name);
-            frames.push_back({op, val, get_name(op->name)});
+            frames.emplace_back(op, mutate(op->value), make_new_name(op->name));
             result = op->body;
             op = result.template as<LetOrLetStmt>();
         }
@@ -60,7 +61,7 @@ class UniquifyVariableNames : public IRMutator {
         result = mutate(result);
 
         for (auto it = frames.rbegin(); it != frames.rend(); it++) {
-            pop_name(it->op->name);
+            renaming.pop(it->op->name);
             if (it->new_name == it->op->name &&
                 result.same_as(it->op->body) &&
                 it->op->value.same_as(it->value)) {
@@ -84,10 +85,9 @@ class UniquifyVariableNames : public IRMutator {
     Stmt visit(const For *op) override {
         Expr min = mutate(op->min);
         Expr extent = mutate(op->extent);
-        push_name(op->name);
-        string new_name = get_name(op->name);
+        string new_name = make_new_name(op->name);
         Stmt body = mutate(op->body);
-        pop_name(op->name);
+        renaming.pop(op->name);
 
         if (new_name == op->name &&
             body.same_as(op->body) &&
@@ -100,18 +100,146 @@ class UniquifyVariableNames : public IRMutator {
     }
 
     Expr visit(const Variable *op) override {
-        string new_name = get_name(op->name);
-        if (op->name != new_name) {
-            return Variable::make(op->type, new_name);
-        } else {
-            return op;
+        if (renaming.contains(op->name)) {
+            string new_name = renaming.get(op->name);
+            if (new_name != op->name) {
+                return Variable::make(op->type, new_name);
+            }
         }
+        return op;
+    }
+
+public:
+    UniquifyVariableNames(Scope<string> &&free_vars)
+        : renaming(std::move(free_vars)) {
     }
 };
 
+class FindFreeVars : public IRVisitor {
+
+    using IRVisitor::visit;
+
+    Scope<> scope;
+
+    void visit(const Variable *op) override {
+        if (!scope.contains(op->name)) {
+            free_vars.push(op->name, op->name);
+        }
+    }
+
+    void visit(const Let *op) override {
+        op->value.accept(this);
+        {
+            ScopedBinding<> bind(scope, op->name);
+            op->body.accept(this);
+        }
+    }
+
+    void visit(const LetStmt *op) override {
+        op->value.accept(this);
+        {
+            ScopedBinding<> bind(scope, op->name);
+            op->body.accept(this);
+        }
+    }
+
+    void visit(const For *op) override {
+        op->min.accept(this);
+        op->extent.accept(this);
+        {
+            ScopedBinding<> bind(scope, op->name);
+            op->body.accept(this);
+        }
+    }
+
+public:
+    Scope<string> free_vars;
+};
+}  // namespace
+
 Stmt uniquify_variable_names(const Stmt &s) {
-    UniquifyVariableNames u;
+    FindFreeVars finder;
+    s.accept(&finder);
+    UniquifyVariableNames u(std::move(finder.free_vars));
     return u.mutate(s);
+}
+
+void check(vector<pair<Var, Expr>> in,
+           vector<pair<Var, Expr>> out) {
+    Stmt in_stmt = Evaluate::make(0), out_stmt = Evaluate::make(0);
+    for (auto it = in.rbegin(); it != in.rend(); it++) {
+        in_stmt = LetStmt::make(it->first.name(), it->second, in_stmt);
+    }
+    for (auto it = out.rbegin(); it != out.rend(); it++) {
+        out_stmt = LetStmt::make(it->first.name(), it->second, out_stmt);
+    }
+
+    Stmt s = uniquify_variable_names(in_stmt);
+
+    internal_assert(equal(s, out_stmt))
+        << "Failure in uniquify_variable_names\n"
+        << "Input:\n"
+        << in_stmt << "\n"
+        << "Produced:\n"
+        << s << "\n"
+        << "Correct output:\n"
+        << out_stmt << "\n";
+}
+
+void uniquify_variable_names_test() {
+    Var x("x"), x_1("x_1"), x_2("x_2"), x_3{"x_3"};
+    Var y("y"), y_1("y_1"), y_2("y_2"), y_3{"y_3"};
+
+    // Stmts with all names already unique should be unchanged
+    check({{x, 3},
+           {y, x}},
+          {{x, 3},
+           {y, x}});
+
+    // Shadowed definitions of Vars should be given unique names
+    check({{x, 3},
+           {y, x},
+           {x, x + y},
+           {y, x + y},
+           {x, x + y},
+           {y, x + y}},
+          {{x, 3},
+           {y, x},
+           {x_1, x + y},
+           {y_1, x_1 + y},
+           {x_2, x_1 + y_1},
+           {y_2, x_2 + y_1}});
+
+    // Check a case with a free var after then end of the scope of a let of the same name
+    check({{x, Let::make(y.name(), 3, y)},      // y is bound
+           {x, y}},                             // This is not the same y. It's free and can't be renamed.
+          {{x, Let::make(y_1.name(), 3, y_1)},  // We rename the bound one
+           {x_1, y}});
+
+    // An existing in-scope use of one of the names that would be
+    // autogenerated should be skipped over
+    check({{x_1, 8},
+           {x, 3},
+           {y, x},
+           {x, x + y},
+           {y, x + y},
+           {x, x + y},
+           {y, x + y}},
+          {{x_1, 8},
+           {x, 3},
+           {y, x},
+           {x_2, x + y},
+           {y_1, x_2 + y},
+           {x_3, x_2 + y_1},
+           {y_2, x_3 + y_1}});
+
+    // Check parallel bindings. The scope doesn't overlap so they can keep their name
+    check({{x, Let::make(y.name(), 3, y)},
+           {x, Let::make(y.name(), 4, y)}},
+          {{x, Let::make(y.name(), 3, y)},
+           {x_1, Let::make(y.name(), 4, y)}});
+
+    std::cout << "is_monotonic test passed" << std::endl;
 }
 
 }  // namespace Internal

--- a/src/UniquifyVariableNames.h
+++ b/src/UniquifyVariableNames.h
@@ -15,6 +15,8 @@ namespace Internal {
  * semantic equivalence. */
 Stmt uniquify_variable_names(const Stmt &s);
 
+void uniquify_variable_names_test();
+
 }  // namespace Internal
 }  // namespace Halide
 

--- a/test/internal.cpp
+++ b/test/internal.cpp
@@ -18,6 +18,7 @@
 #include "Monotonic.h"
 #include "Reduction.h"
 #include "Solve.h"
+#include "UniquifyVariableNames.h"
 
 using namespace Halide;
 using namespace Halide::Internal;
@@ -40,6 +41,7 @@ int main(int argc, const char **argv) {
     associativity_test();
     generator_test();
     propagate_estimate_test();
+    uniquify_variable_names_test();
 
     return 0;
 }


### PR DESCRIPTION
Currently uniquify_variable_names only works on exactly the kind of
duplicate names we tend to generate in bounds inference, and only if you
run it on the entire stmt. In other circumstances it does odd things
(e.g. attach negative integer suffixes to free variables!), and we risk
introducing bugs, as I discovered in another PR.

This PR fixes uniquify_variable_names to do the right thing in the
general case, and adds tests.

Also added some needed functionality to Scope - you can now query the
number of nested definitions of the same thing, and you can move a
Scope.