### PR TITLE
Use graph_equal instead of equal in prove_associativity

### DIFF
--- a/src/Associativity.cpp
+++ b/src/Associativity.cpp
@@ -59,7 +59,7 @@ class ConvertSelfRef : public IRGraphMutator {
             internal_assert(args.size() == op->args.size())
                 << "Self-reference should have the same number of args as the original\n";
             for (size_t i = 0; i < op->args.size(); i++) {
-                if (!equal(op->args[i], args[i])) {
+                if (!graph_equal(op->args[i], args[i])) {
                     debug(5) << "Self-reference of " << op->name
                              << " with different args from the LHS. Operation is not associative\n";
                     is_solvable = false;


### PR DESCRIPTION
The `equal` in associativity proving is operating on non-CSE'd expressions, making it exponentially slow. This PR changes it to `graph_equal`. I observed significant speedup in some huge expressions generated by autodiff when calling prove_associativity(30s -> 0.02s).