### PR TITLE
constructor for 'Halide::Internal::StubInput' must explicitly initial…

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1377,13 +1377,13 @@ public:
     // *not* explicit.
     template<typename T2>
     StubInput(const StubInputBuffer<T2> &b)
-        : kind_(IOKind::Buffer), parameter_(b.parameter_) {
+        : kind_(IOKind::Buffer), parameter_(b.parameter_), func_(), expr_() {
     }
     StubInput(const Func &f)
-        : kind_(IOKind::Function), parameter_(), func_(f) {
+        : kind_(IOKind::Function), parameter_(), func_(f), expr_() {
     }
     StubInput(const Expr &e)
-        : kind_(IOKind::Scalar), parameter_(), expr_(e) {
+        : kind_(IOKind::Scalar), parameter_(), func_(), expr_(e) {
     }
 
 private:


### PR DESCRIPTION
…ize const members

  - Seen when compiling Halide apps with certain versions of clang++
  - Seems like a valid complaint (just not reported by all compilers)