### PR TITLE
Refactor loop-invariants lifting in schedule_functions to a separate pass

### DIFF
--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -39,7 +39,7 @@ class CanLift : public IRVisitor {
         }
         if (before_bounds_inference) {
             if (ends_with(op->name, ".min") ||
-                    ends_with(op->name, ".max")) {
+                ends_with(op->name, ".max")) {
                 result = false;
             }
         }
@@ -136,7 +136,8 @@ public:
     using IRMutator::mutate;
 
     LiftLoopInvariants(bool before_bounds_inference)
-        : before_bounds_inference(before_bounds_inference) {}
+        : before_bounds_inference(before_bounds_inference) {
+    }
 
     Expr mutate(const Expr &e) override {
         if (should_lift(e)) {
@@ -184,7 +185,7 @@ class SubstituteTrivialLets : public IRMutator {
 class LICM : public IRMutator {
     using IRMutator::visit;
 
-    // If before_bounds_inference==true, 
+    // If before_bounds_inference==true,
     // do the following two things:
     // 1) freeze the bound variables (with name ".min" & ".max")
     // 2) don't substitute back variables based on the cost function,

--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -266,7 +266,7 @@ class LICM : public IRMutator {
                         vars.insert(op->name);
                     }
 
-                    public:
+                public:
                     set<string> vars;
                 } vars;
                 new_stmt.accept(&vars);
@@ -339,8 +339,9 @@ class LICM : public IRMutator {
     }
 
 public:
-
-    LICM(bool always_lift) : always_lift(always_lift) {}
+    LICM(bool always_lift)
+        : always_lift(always_lift) {
+    }
 };
 
 // Reassociate summations to group together the loop invariants. Useful to run before LICM.

--- a/src/LICM.h
+++ b/src/LICM.h
@@ -14,9 +14,10 @@ namespace Internal {
  * This is especially important in cases where LLVM would not do it for us
  * automatically. For example, it hoists loop invariants out of cuda
  * kernels. By default it uses a heuristic cost function to decide
- * which variable to hoist out. If always_lift is set to false
- * all loop invariant variables are lifted out.*/
-Stmt loop_invariant_code_motion(Stmt, bool always_lift = false);
+ * which variable to hoist out. If before_bounds_inference is set to
+ * true, extra care is taken for bound inference variables that have
+ * dangling references. */
+Stmt loop_invariant_code_motion(Stmt, bool before_bounds_inference = false);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/LICM.h
+++ b/src/LICM.h
@@ -10,11 +10,13 @@
 namespace Halide {
 namespace Internal {
 
-/** Hoist loop-invariants out of inner loops. This is especially
- * important in cases where LLVM would not do it for us
+/** Hoist loop-invariant variable and conditions out of inner loops.
+ * This is especially important in cases where LLVM would not do it for us
  * automatically. For example, it hoists loop invariants out of cuda
- * kernels. */
-Stmt loop_invariant_code_motion(Stmt);
+ * kernels. By default it uses a heuristic cost function to decide
+ * which variable to hoist out. If always_lift is set to false
+ * all loop invariant variables are lifted out.*/
+Stmt loop_invariant_code_motion(Stmt, bool always_lift = false);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -132,6 +132,11 @@ Module lower(const vector<Function> &output_funcs,
     debug(2) << "Lowering after creating initial loop nests:\n"
              << s << "\n";
 
+    debug(1) << "Lifting loop invariant variables and conditions outside of the initial loop nests...\n";
+    s = loop_invariant_code_motion(s, true /* always_lift */);
+    debug(2) << "Lowering after lifting variables and conditions outside:\n"
+             << s << "\n";
+
     if (any_memoized) {
         debug(1) << "Injecting memoization...\n";
         s = inject_memoization(s, env, pipeline_name, outputs);

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -133,7 +133,7 @@ Module lower(const vector<Function> &output_funcs,
              << s << "\n";
 
     debug(1) << "Lifting loop invariant variables and conditions outside of the initial loop nests...\n";
-    s = loop_invariant_code_motion(s, true /* always_lift */);
+    s = loop_invariant_code_motion(s, true /* before_bounds_inference */);
     debug(2) << "Lowering after lifting variables and conditions outside:\n"
              << s << "\n";
 

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -165,7 +165,6 @@ Stmt build_loop_nest(
     // removed later anyway. These have to be added as outermost as possible as
     // some let stmts (e.g. the rebase let stmt) might depend on this vars;
     // otherwise, this may mess up the bounds_touched computation.
-    int n_predicates_inner = 0;
     for (int i = start_fuse; (i >= 0) && (i < (int)stage_s.dims().size() - 1); ++i) {
         string dim_var = prefix + stage_s.dims()[i].var;
         Expr var = Variable::make(Int(32), dim_var);
@@ -176,7 +175,6 @@ Stmt build_loop_nest(
         // value depends on 'var'.
         nest.emplace_back(Container::IfInner, 0, dim_var, likely(var >= min));
         nest.emplace_back(Container::IfInner, 0, dim_var, likely(var <= max));
-        n_predicates_inner += 2;
     }
 
     // Put all the reduction domain predicates into the containers vector.

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -169,6 +169,7 @@ tests(GROUPS correctness travis
         inverse.cpp
         isnan.cpp
         issue_3926.cpp
+        issue_4297.cpp
         iterate_over_circle.cpp
         lambda.cpp
         lazy_convolution.cpp
@@ -177,6 +178,7 @@ tests(GROUPS correctness travis
         legal_race_condition.cpp
         lerp.cpp
         let_in_rdom_bound.cpp
+        lift_condition.cpp
         likely.cpp
         load_library.cpp
         logical.cpp

--- a/test/correctness/issue_4297.cpp
+++ b/test/correctness/issue_4297.cpp
@@ -1,0 +1,24 @@
+#include "Halide.h"
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // See https://github.com/halide/Halide/issues/4297
+    Target target = get_jit_target_from_environment();
+    if (!target.has_gpu_feature()) {
+        return 0;
+    }
+    Var x, y, z;
+    Func f;
+    f(x, y, z) = 0;
+    Var yo, yi;
+    f.split(y, yo, yi, 32, TailStrategy::GuardWithIf)
+     .reorder(x, z, yi, yo)
+     .gpu_blocks(yo)
+     .gpu_blocks(yi)
+     .gpu_blocks(z)
+     .gpu_threads(x);
+
+    Buffer<int> imf = f.realize(10, 10, 10, target);
+    return 0;
+}
+

--- a/test/correctness/issue_4297.cpp
+++ b/test/correctness/issue_4297.cpp
@@ -12,13 +12,12 @@ int main(int argc, char **argv) {
     f(x, y, z) = 0;
     Var yo, yi;
     f.split(y, yo, yi, 32, TailStrategy::GuardWithIf)
-     .reorder(x, z, yi, yo)
-     .gpu_blocks(yo)
-     .gpu_blocks(yi)
-     .gpu_blocks(z)
-     .gpu_threads(x);
+        .reorder(x, z, yi, yo)
+        .gpu_blocks(yo)
+        .gpu_blocks(yi)
+        .gpu_blocks(z)
+        .gpu_threads(x);
 
     Buffer<int> imf = f.realize(10, 10, 10, target);
     return 0;
 }
-

--- a/test/correctness/lift_condition.cpp
+++ b/test/correctness/lift_condition.cpp
@@ -1,0 +1,24 @@
+#include "Halide.h"
+using namespace Halide;
+using namespace Halide::Internal;
+
+int main(int argc, char **argv) {
+    // Test if LICM can lift out the condition correctly
+    Stmt s = For::make("x", Expr(0), Expr(10), ForType::Serial, DeviceAPI::Host,
+        For::make("y", Expr(0), Expr(10), ForType::Serial, DeviceAPI::Host,
+            IfThenElse::make(Var("x"), Evaluate::make(0), Stmt())
+        )
+    );
+    s = loop_invariant_code_motion(s, true /* always_lift */);
+    const For *loop = s.as<For>();
+    if (loop == nullptr) {
+        printf("LICM fails to lift conditions correctly");
+        return -1;
+    }
+    if (loop->body.as<IfThenElse>() == nullptr) {
+        printf("LICM fails to lift conditions correctly");
+        return -1;
+    }
+    return 0;
+}
+

--- a/test/correctness/lift_condition.cpp
+++ b/test/correctness/lift_condition.cpp
@@ -7,7 +7,7 @@ int main(int argc, char **argv) {
     Stmt s = For::make("x", Expr(0), Expr(10), ForType::Serial, DeviceAPI::Host,
                        For::make("y", Expr(0), Expr(10), ForType::Serial, DeviceAPI::Host,
                                  IfThenElse::make(Var("x"), Evaluate::make(0), Stmt())));
-    s = loop_invariant_code_motion(s, true /* always_lift */);
+    s = loop_invariant_code_motion(s);
     const For *loop = s.as<For>();
     if (loop == nullptr) {
         printf("LICM fails to lift conditions correctly");

--- a/test/correctness/lift_condition.cpp
+++ b/test/correctness/lift_condition.cpp
@@ -5,10 +5,8 @@ using namespace Halide::Internal;
 int main(int argc, char **argv) {
     // Test if LICM can lift out the condition correctly
     Stmt s = For::make("x", Expr(0), Expr(10), ForType::Serial, DeviceAPI::Host,
-        For::make("y", Expr(0), Expr(10), ForType::Serial, DeviceAPI::Host,
-            IfThenElse::make(Var("x"), Evaluate::make(0), Stmt())
-        )
-    );
+                       For::make("y", Expr(0), Expr(10), ForType::Serial, DeviceAPI::Host,
+                                 IfThenElse::make(Var("x"), Evaluate::make(0), Stmt())));
     s = loop_invariant_code_motion(s, true /* always_lift */);
     const For *loop = s.as<For>();
     if (loop == nullptr) {
@@ -21,4 +19,3 @@ int main(int argc, char **argv) {
     }
     return 0;
 }
-


### PR DESCRIPTION
Currently the `build_loop_nest` function in the `schedule_function` pass lifts the loop invariant variables and conditions outside of the loops. This PR refactors the code by making the lifting a separate call to LICM. This simplifies `schedule_function`'s logic and importantly also fixes #4297.

To achieve this I also make LICM lift loop invariant conditions without else clause outside of a loop.