### PR TITLE
Do a full clamp of inner bounds to an outer query

### DIFF
--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -577,8 +577,10 @@ public:
                     // queries outwards. Help it out by insisting that
                     // the bounds are clamped to lie within the bounds
                     // one loop level up.
-                    b[d].min = max(b[d].min, Variable::make(Int(32), arg + ".outer_min"));
-                    b[d].max = min(b[d].max, Variable::make(Int(32), arg + ".outer_max"));
+                    Expr outer_min = Variable::make(Int(32), arg + ".outer_min");
+                    Expr outer_max = Variable::make(Int(32), arg + ".outer_max");
+                    b[d].min = clamp(b[d].min, outer_min, outer_max);
+                    b[d].max = clamp(b[d].max, outer_min, outer_max);
                 }
 
                 if (b[d].is_single_point()) {

--- a/test/correctness/non_nesting_extern_bounds_query.cpp
+++ b/test/correctness/non_nesting_extern_bounds_query.cpp
@@ -22,34 +22,55 @@ using namespace Halide;
 // received in non-bounds-query-mode is the intersection of what it
 // asked for for a single scanline and what it asked for for the whole
 // image.
-extern "C" DLLEXPORT int misbehaving_extern_stage(halide_buffer_t *in, halide_buffer_t *out) {
+extern "C" DLLEXPORT int misbehaving_extern_stage(halide_buffer_t *in, int variant, halide_buffer_t *out) {
     if (in->is_bounds_query()) {
         // As a baseline, require the same amount of input as output, like a copy
         memcpy(in->dim, out->dim, out->dimensions * sizeof(halide_dimension_t));
         if (out->dim[1].extent == 1) {
             // This is the inner query, for a single scanline of
-            // output.  Require a wider input, violating the nesting
-            // property. Shift it over a little too.
-            in->dim[0].min += 50;
-            in->dim[0].extent += 100;
+            // output.
+            if (variant == 0) {
+                // Require a wider input, violating the nesting
+                // property. Shift it over a little too. Note that it
+                // still overlaps.
+                in->dim[0].min += 50;
+                in->dim[0].extent += 100;
+            } else if (variant == 1) {
+                // Require an input somewhere off in the weeds.
+                in->dim[0].min = 10000;
+                in->dim[0].extent = 5;
+            } else {
+                abort();
+            }
         }
     } else {
-        // The inner (bad) bounds query should not have been respected
-        // in the x dimension. You get the intersection of the inner
-        // query and the outer query.
-
-        // Check the left edge was indeed shifted inwards, as
-        // requested by the per-scanline bounds query.
-        assert(in->dim[0].min == out->dim[0].min + 50);
-
-        // Check the right edge wasn't shifted over, but was instead
-        // clamped to lie within the outer bounds query.
-        assert(in->dim[0].extent == out->dim[0].extent - 50);
-
         // The inner bounds query was fine in the y dimension, which
         // correctly nested.
         assert(in->dim[1].min == out->dim[1].min);
         assert(in->dim[1].extent == 1);
+
+        // But the inner (bad) bounds query should not have been
+        // respected in the x dimension.
+        if (variant == 0) {
+            // For overlapping bounds, you get the intersection of the
+            // inner query and the outer query.
+            // Check the left edge
+            // was indeed shifted inwards, as requested by the
+            // per-scanline bounds query.
+            assert(in->dim[0].min == out->dim[0].min + 50);
+
+            // Check the right edge wasn't shifted over, but was instead
+            // clamped to lie within the outer bounds query.
+            assert(in->dim[0].extent == out->dim[0].extent - 50);
+        } else if (variant == 1) {
+            // For non-overlapping bounds, you just get squashed to
+            // the nearest edge.
+            int right_edge = out->dim[0].min + out->dim[0].extent - 1;
+            assert(in->dim[0].min == right_edge);
+            assert(in->dim[0].extent == 1);
+        } else {
+            abort();
+        }
     }
     return 0;
 }
@@ -57,13 +78,18 @@ extern "C" DLLEXPORT int misbehaving_extern_stage(halide_buffer_t *in, halide_bu
 int main(int argc, char **argv) {
     Func f, g, h;
     Var x, y;
+    Param<int> variant;
     f(x, y) = x + y;
-    g.define_extern("misbehaving_extern_stage", {f}, Int(32), 2);
+    g.define_extern("misbehaving_extern_stage", {f, variant}, Int(32), 2);
     h(x, y) = g(x, y);
 
     g.compute_at(h, y);
     f.compute_at(h, y);
 
+    variant.set(0);
+    h.realize(200, 200);
+
+    variant.set(1);
     h.realize(200, 200);
 
     printf("Success!\n");


### PR DESCRIPTION
This avoids generating buffers with negative extents in cases where the
reply to the inner bounds query doesn't overlap the outer bounds query
at all, and also, by giving an upper *and* lower bound to these
expressions, avoids a type of unbounded access discovered here:
https://github.com/halide/Halide/pull/3037#issuecomment-604136412