### PR TITLE
AlignLoads.h includes stuff it doesn't need

### DIFF
--- a/src/AlignLoads.h
+++ b/src/AlignLoads.h
@@ -5,10 +5,7 @@
  * Defines a lowering pass that rewrites unaligned loads into
  * sequences of aligned loads.
  */
-#include "IR.h"
-#include "ModulusRemainder.h"
-#include "Scope.h"
-#include "Target.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {


### PR DESCRIPTION
Inspired by #4811, I played around with include-what-you-use. Mostly it made a mess and I ultimately gave up, but one particularly egregious header was AlignLoads.h, which includes some stuff it doesn't use at all.