### PR TITLE
Simplify #include file nesting

### DIFF
--- a/src/AlignLoads.h
+++ b/src/AlignLoads.h
@@ -5,10 +5,7 @@
  * Defines a lowering pass that rewrites unaligned loads into
  * sequences of aligned loads.
  */
-#include "IR.h"
-#include "ModulusRemainder.h"
-#include "Scope.h"
-#include "Target.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Argument.h
+++ b/src/Argument.h
@@ -7,7 +7,6 @@
  */
 
 #include "Buffer.h"
-#include "Error.h"
 #include "Expr.h"
 #include "Type.h"
 #include "runtime/HalideRuntime.h"

--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -11,7 +11,6 @@
 #include "Func.h"
 #include "IR.h"
 #include "Lambda.h"
-#include "Util.h"
 
 namespace Halide {
 

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -4,7 +4,6 @@
 #include "DeviceInterface.h"
 #include "Expr.h"
 #include "IntrusivePtr.h"
-#include "Util.h"
 #include "runtime/HalideBuffer.h"
 
 namespace Halide {

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -39,7 +39,6 @@ class GlobalVariable;
 
 #include "IRVisitor.h"
 #include "Module.h"
-#include "ModulusRemainder.h"
 #include "Scope.h"
 #include "Target.h"
 

--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -1,4 +1,5 @@
 #include "Debug.h"
+#include "Util.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Definition.h
+++ b/src/Definition.h
@@ -7,7 +7,6 @@
 
 #include "Expr.h"
 #include "IntrusivePtr.h"
-#include "Reduction.h"
 #include "Schedule.h"
 
 #include <map>
@@ -17,6 +16,7 @@ namespace Halide {
 namespace Internal {
 struct DefinitionContents;
 struct FunctionContents;
+class ReductionDomain;
 }  // namespace Internal
 
 namespace Internal {

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -1,4 +1,5 @@
 #include "Error.h"
+#include "Util.h"  // for get_env_variable
 
 #include <signal.h>
 

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -13,7 +13,6 @@
 #include "Float16.h"
 #include "IntrusivePtr.h"
 #include "Type.h"
-#include "Util.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Float16.h
+++ b/src/Float16.h
@@ -1,6 +1,6 @@
 #ifndef HALIDE_FLOAT16_H
 #define HALIDE_FLOAT16_H
-#include "Util.h"
+
 #include "runtime/HalideRuntime.h"
 #include <stdint.h>
 #include <string>

--- a/src/Function.h
+++ b/src/Function.h
@@ -11,9 +11,7 @@
 #include "FunctionPtr.h"
 #include "IntrusivePtr.h"
 #include "Parameter.h"
-#include "Reduction.h"
 #include "Schedule.h"
-#include "Util.h"
 
 #include <map>
 #include <utility>

--- a/src/HexagonAlignment.h
+++ b/src/HexagonAlignment.h
@@ -6,7 +6,6 @@
  */
 
 #include "IR.h"
-#include "ModulusRemainder.h"
 #include "Scope.h"
 
 namespace Halide {

--- a/src/HexagonOptimize.h
+++ b/src/HexagonOptimize.h
@@ -6,7 +6,6 @@
  */
 
 #include "IR.h"
-#include "ModulusRemainder.h"
 #include "Scope.h"
 namespace Halide {
 namespace Internal {

--- a/src/IR.h
+++ b/src/IR.h
@@ -13,11 +13,12 @@
 #include "Error.h"
 #include "Expr.h"
 #include "Function.h"
+#include "FunctionPtr.h"
 #include "IntrusivePtr.h"
 #include "ModulusRemainder.h"
 #include "Parameter.h"
+#include "Reduction.h"
 #include "Type.h"
-#include "Util.h"
 #include "runtime/HalideBuffer.h"
 
 namespace Halide {

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -8,7 +8,6 @@
 #include "IR.h"
 #include "IREquality.h"
 #include "IROperator.h"
-#include "ModulusRemainder.h"
 
 #include <random>
 #include <set>

--- a/src/IRVisitor.h
+++ b/src/IRVisitor.h
@@ -2,7 +2,6 @@
 #define HALIDE_IR_VISITOR_H
 
 #include "IR.h"
-#include "Util.h"
 
 #include <map>
 #include <set>

--- a/src/Interval.h
+++ b/src/Interval.h
@@ -6,7 +6,6 @@
  */
 
 #include "Expr.h"
-#include "Util.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Introspection.h
+++ b/src/Introspection.h
@@ -5,8 +5,6 @@
 #include <stdint.h>
 #include <string>
 
-#include "Util.h"
-
 /** \file
  *
  * Defines methods for introspecting in C++. Relies on DWARF debugging

--- a/src/IntrusivePtr.h
+++ b/src/IntrusivePtr.h
@@ -10,8 +10,6 @@
 #include <atomic>
 #include <stdlib.h>
 
-#include "Util.h"
-
 namespace Halide {
 namespace Internal {
 

--- a/src/LLVM_Output.h
+++ b/src/LLVM_Output.h
@@ -10,7 +10,6 @@
 
 #include "Module.h"
 #include "Target.h"
-#include "Util.h"
 
 namespace llvm {
 class Module;

--- a/src/Lambda.h
+++ b/src/Lambda.h
@@ -2,7 +2,6 @@
 #define HALIDE_LAMBDA_H
 
 #include "Func.h"
-#include "Util.h"
 #include "Var.h"
 
 /** \file

--- a/src/ParallelRVar.h
+++ b/src/ParallelRVar.h
@@ -7,7 +7,7 @@
  * definition across a reduction variable.
  */
 
-#include "Function.h"
+#include "Definition.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Param.h
+++ b/src/Param.h
@@ -5,7 +5,6 @@
 
 #include "Argument.h"
 #include "IR.h"
-#include "Util.h"
 
 /** \file
  *

--- a/src/Scope.h
+++ b/src/Scope.h
@@ -6,10 +6,10 @@
 #include <stack>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "Debug.h"
 #include "Error.h"
-#include "Util.h"
 
 /** \file
  * Defines the Scope class, which is used for keeping track of names in a scope while traversing IR

--- a/src/Substitute.h
+++ b/src/Substitute.h
@@ -8,7 +8,7 @@
 
 #include <map>
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Target.h
+++ b/src/Target.h
@@ -12,7 +12,6 @@
 #include "Error.h"
 #include "Expr.h"
 #include "Type.h"
-#include "Util.h"
 #include "runtime/HalideRuntime.h"
 
 namespace Halide {

--- a/src/Tuple.h
+++ b/src/Tuple.h
@@ -7,7 +7,6 @@
  */
 
 #include "IR.h"
-#include "Util.h"
 
 namespace Halide {
 


### PR DESCRIPTION
Reduce some unnecessary .h file inclusion -- this was done semi-manually, by compiling with the gcc `-H` flag, then massaging the output to find the highest-used headers, then tweaking to reduce the top scorers. (This could be repeated more, but this felt like a good stopping point.)