### PR TITLE
Avoid including IR.h in other .h files except where necessary

### DIFF
--- a/src/AddImageChecks.h
+++ b/src/AddImageChecks.h
@@ -6,9 +6,13 @@
  * Defines the lowering pass that adds the assertions that validate
  * input and output buffers.
  */
+#include <map>
+#include <string>
+#include <vector>
 
 #include "Bounds.h"
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
 
 #include <map>
 

--- a/src/AddParameterChecks.h
+++ b/src/AddParameterChecks.h
@@ -6,13 +6,12 @@
  * Defines the lowering pass that adds the assertions that validate
  * scalar parameters.
  */
+#include <vector>
 
-#include "IR.h"
+#include "Expr.h"
+#include "Target.h"
 
 namespace Halide {
-
-struct Target;
-
 namespace Internal {
 
 /** Insert checks to make sure that all referenced parameters meet

--- a/src/AllocationBoundsInference.h
+++ b/src/AllocationBoundsInference.h
@@ -4,9 +4,13 @@
 /** \file
  * Defines the lowering pass that determines how large internal allocations should be.
  */
+#include <map>
+#include <string>
+#include <utility>
 
-#include "Bounds.h"
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
+#include "Interval.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/ApplySplit.cpp
+++ b/src/ApplySplit.cpp
@@ -1,4 +1,6 @@
 #include "ApplySplit.h"
+#include "IR.h"
+#include "IROperator.h"
 #include "Simplify.h"
 #include "Substitute.h"
 

--- a/src/ApplySplit.h
+++ b/src/ApplySplit.h
@@ -8,10 +8,11 @@
  */
 
 #include <map>
+#include <string>
 #include <utility>
 #include <vector>
 
-#include "IR.h"
+#include "Expr.h"
 #include "Schedule.h"
 
 namespace Halide {

--- a/src/Associativity.h
+++ b/src/Associativity.h
@@ -6,13 +6,13 @@
  * Methods for extracting an associative operator from a Func's update definition
  * if there is any and computing the identity of the associative operator.
  */
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "AssociativeOpsTable.h"
-#include "IR.h"
-#include "IREquality.h"
-
-#include <functional>
-#include <utility>
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/AsyncProducers.h
+++ b/src/AsyncProducers.h
@@ -4,15 +4,18 @@
 /** \file
  * Defines the lowering pass that injects task parallelism for producers that are scheduled as async.
  */
+#include <map>
+#include <string>
 
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
 
 namespace Halide {
 namespace Internal {
 
 Stmt fork_async_producers(Stmt s, const std::map<std::string, Function> &env);
 
-}
+}  // namespace Internal
 }  // namespace Halide
 
 #endif

--- a/src/BoundSmallAllocations.h
+++ b/src/BoundSmallAllocations.h
@@ -1,7 +1,7 @@
 #ifndef HALIDE_BOUND_SMALL_ALLOCATIONS
 #define HALIDE_BOUND_SMALL_ALLOCATIONS
 
-#include "IR.h"
+#include "Expr.h"
 
 /** \file
  * Defines the lowering pass that attempts to rewrite small

--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -9,7 +9,6 @@
 
 #include "Expr.h"
 #include "Func.h"
-#include "IR.h"
 #include "Lambda.h"
 
 namespace Halide {

--- a/src/Bounds.h
+++ b/src/Bounds.h
@@ -6,6 +6,7 @@
  * and the regions of a function read or written by a statement.
  */
 
+#include "Function.h"
 #include "IROperator.h"
 #include "Interval.h"
 #include "Scope.h"

--- a/src/BoundsInference.h
+++ b/src/BoundsInference.h
@@ -6,9 +6,12 @@
  */
 
 #include <map>
+#include <string>
+#include <vector>
 
-#include "Bounds.h"
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
+#include "Interval.h"
 #include "Target.h"
 
 namespace Halide {

--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -1,4 +1,5 @@
 #include "Buffer.h"
+#include "IR.h"
 #include "IREquality.h"
 #include "IROperator.h"
 #include "Var.h"

--- a/src/CPlusPlusMangle.h
+++ b/src/CPlusPlusMangle.h
@@ -5,10 +5,12 @@
  *
  * A simple function to get a C++ mangled function name for a function.
  */
-
-#include "IR.h"
-#include "Target.h"
 #include <string>
+#include <vector>
+
+#include "Expr.h"
+#include "Function.h"  // for ExternFuncArgument
+#include "Target.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/CSE.h
+++ b/src/CSE.h
@@ -4,7 +4,7 @@
 /** \file
  * Defines a pass for introducing let expressions to wrap common sub-expressions. */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/CanonicalizeGPUVars.h
+++ b/src/CanonicalizeGPUVars.h
@@ -5,7 +5,7 @@
  * Defines the lowering pass that canonicalize the GPU var names over.
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Closure.h
+++ b/src/Closure.h
@@ -5,6 +5,8 @@
  *
  * Provides Closure class.
  */
+#include <map>
+#include <string>
 
 #include "Buffer.h"
 #include "IR.h"

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -6,6 +6,7 @@
 #include "CodeGen_D3D12Compute_Dev.h"
 #include "CodeGen_Internal.h"
 #include "Debug.h"
+#include "DeviceArgument.h"
 #include "IRMutator.h"
 #include "IROperator.h"
 

--- a/src/CodeGen_GPU_Dev.h
+++ b/src/CodeGen_GPU_Dev.h
@@ -4,9 +4,11 @@
 /** \file
  * Defines the code-generator interface for producing GPU device code
  */
+#include <string>
+#include <vector>
 
 #include "DeviceArgument.h"
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -9,6 +9,7 @@
 #include "CodeGen_OpenGL_Dev.h"
 #include "CodeGen_PTX_Dev.h"
 #include "Debug.h"
+#include "DeviceArgument.h"
 #include "ExprUsesVar.h"
 #include "IROperator.h"
 #include "IRPrinter.h"

--- a/src/CodeGen_GPU_Host.h
+++ b/src/CodeGen_GPU_Host.h
@@ -6,6 +6,7 @@
  */
 
 #include <map>
+#include <string>
 
 #include "CodeGen_ARM.h"
 #include "CodeGen_MIPS.h"
@@ -13,7 +14,6 @@
 #include "CodeGen_RISCV.h"
 #include "CodeGen_WebAssembly.h"
 #include "CodeGen_X86.h"
-
 #include "IR.h"
 
 namespace Halide {

--- a/src/CodeGen_Internal.h
+++ b/src/CodeGen_Internal.h
@@ -9,10 +9,10 @@
  */
 
 #include <memory>
+#include <string>
 
 #include "Closure.h"
-#include "IR.h"
-#include "IRVisitor.h"
+#include "Expr.h"
 #include "Scope.h"
 #include "Target.h"
 

--- a/src/DebugArguments.cpp
+++ b/src/DebugArguments.cpp
@@ -1,4 +1,6 @@
 #include "DebugArguments.h"
+#include "Function.h"
+#include "IR.h"
 #include "IROperator.h"
 #include "Module.h"
 

--- a/src/DebugToFile.h
+++ b/src/DebugToFile.h
@@ -6,8 +6,10 @@
  * every realization to dump functions to a file for debugging.  */
 
 #include <map>
+#include <vector>
 
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Deinterleave.h
+++ b/src/Deinterleave.h
@@ -8,7 +8,7 @@
  * 2, f(x/2), g(x/2))
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/DeviceArgument.h
+++ b/src/DeviceArgument.h
@@ -4,9 +4,10 @@
 /** \file
  * Defines helpers for passing arguments to separate devices, such as GPUs.
  */
+#include <string>
 
 #include "Closure.h"
-#include "IR.h"
+#include "Expr.h"
 #include "ModulusRemainder.h"
 
 namespace Halide {

--- a/src/DeviceInterface.cpp
+++ b/src/DeviceInterface.cpp
@@ -1,7 +1,9 @@
 #include "DeviceInterface.h"
+#include "IR.h"
 #include "IROperator.h"
 #include "JITModule.h"
 #include "Target.h"
+#include "runtime/HalideBuffer.h"
 
 using namespace Halide;
 using namespace Halide::Internal;

--- a/src/EarlyFree.h
+++ b/src/EarlyFree.h
@@ -7,7 +7,7 @@
  * earlier.
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/EliminateBoolVectors.h
+++ b/src/EliminateBoolVectors.h
@@ -5,7 +5,7 @@
  * Method to eliminate vectors of booleans from IR.
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/FastIntegerDivide.h
+++ b/src/FastIntegerDivide.h
@@ -1,7 +1,8 @@
 #ifndef HALIDE_FAST_INTEGER_DIVIDE_H
 #define HALIDE_FAST_INTEGER_DIVIDE_H
 
-#include "IR.h"
+#include "Buffer.h"
+#include "Expr.h"
 
 namespace Halide {
 

--- a/src/FindCalls.h
+++ b/src/FindCalls.h
@@ -7,8 +7,10 @@
  */
 
 #include <map>
+#include <string>
 
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Func.h
+++ b/src/Func.h
@@ -7,9 +7,8 @@
  */
 
 #include "Argument.h"
+#include "Expr.h"
 #include "Function.h"
-#include "IR.h"
-#include "IROperator.h"
 #include "JITModule.h"
 #include "Module.h"
 #include "Param.h"

--- a/src/Function.h
+++ b/src/Function.h
@@ -4,6 +4,10 @@
 /** \file
  * Defines the internal representation of a halide function and related classes
  */
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "Buffer.h"
 #include "Definition.h"
@@ -12,9 +16,6 @@
 #include "IntrusivePtr.h"
 #include "Parameter.h"
 #include "Schedule.h"
-
-#include <map>
-#include <utility>
 
 namespace Halide {
 
@@ -93,7 +94,6 @@ struct Call;
  * a function. Similar to a front-end Func object, but with no
  * syntactic sugar to help with definitions. */
 class Function {
-
     FunctionPtr contents;
 
 public:

--- a/src/FuseGPUThreadLoops.h
+++ b/src/FuseGPUThreadLoops.h
@@ -6,7 +6,7 @@
  * threads to target CUDA, OpenCL, and Metal.
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/HexagonAlignment.h
+++ b/src/HexagonAlignment.h
@@ -6,7 +6,6 @@
  */
 
 #include "IR.h"
-#include "Scope.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/HexagonOptimize.h
+++ b/src/HexagonOptimize.h
@@ -5,8 +5,9 @@
  * Tools for optimizing IR for Hexagon.
  */
 
-#include "IR.h"
-#include "Scope.h"
+#include "Expr.h"
+#include "Target.h"
+
 namespace Halide {
 namespace Internal {
 

--- a/src/IREquality.h
+++ b/src/IREquality.h
@@ -5,7 +5,7 @@
  * Methods to test Exprs and Stmts for equality of value
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -5,12 +5,13 @@
  * Defines a method to match a fragment of IR against a pattern containing wildcards
  */
 
+#include <random>
+#include <set>
+#include <vector>
+
 #include "IR.h"
 #include "IREquality.h"
 #include "IROperator.h"
-
-#include <random>
-#include <set>
 
 namespace Halide {
 namespace Internal {

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -9,7 +9,7 @@
 
 #include <cmath>
 
-#include "IR.h"
+#include "Expr.h"
 #include "Tuple.h"
 
 namespace Halide {

--- a/src/IRVisitor.h
+++ b/src/IRVisitor.h
@@ -1,11 +1,11 @@
 #ifndef HALIDE_IR_VISITOR_H
 #define HALIDE_IR_VISITOR_H
 
-#include "IR.h"
-
 #include <map>
 #include <set>
 #include <string>
+
+#include "IR.h"
 
 /** \file
  * Defines the base class for things that recursively walk over the IR

--- a/src/InjectHostDevBufferCopies.h
+++ b/src/InjectHostDevBufferCopies.h
@@ -5,7 +5,10 @@
  * Defines the lowering passes that deal with host and device buffer flow.
  */
 
-#include "IR.h"
+#include <string>
+#include <vector>
+
+#include "Expr.h"
 #include "Target.h"
 
 namespace Halide {

--- a/src/InjectOpenGLIntrinsics.h
+++ b/src/InjectOpenGLIntrinsics.h
@@ -6,7 +6,7 @@
  * stores for opengl.
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Inline.h
+++ b/src/Inline.h
@@ -5,7 +5,8 @@
  * Methods for replacing calls to functions with their definitions.
  */
 
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/InlineReductions.h
+++ b/src/InlineReductions.h
@@ -1,7 +1,9 @@
 #ifndef HALIDE_INLINE_REDUCTIONS_H
 #define HALIDE_INLINE_REDUCTIONS_H
 
-#include "IR.h"
+#include <string>
+
+#include "Expr.h"
 #include "RDom.h"
 #include "Tuple.h"
 

--- a/src/LICM.h
+++ b/src/LICM.h
@@ -5,7 +5,7 @@
  * Methods for lifting loop invariants out of inner loops.
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Lerp.cpp
+++ b/src/Lerp.cpp
@@ -2,6 +2,7 @@
 #include <cmath>
 
 #include "CSE.h"
+#include "IR.h"
 #include "IROperator.h"
 #include "Lerp.h"
 #include "Simplify.h"

--- a/src/Lerp.h
+++ b/src/Lerp.h
@@ -5,7 +5,7 @@
  * Defines methods for converting a lerp intrinsic into Halide IR.
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Lower.h
+++ b/src/Lower.h
@@ -7,10 +7,12 @@
  * Halide function using its schedule.
  */
 
-#include <iterator>
+#include <string>
+#include <vector>
 
 #include "Argument.h"
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
 #include "Module.h"
 #include "Target.h"
 

--- a/src/LowerWarpShuffles.h
+++ b/src/LowerWarpShuffles.h
@@ -6,7 +6,7 @@
  * instructions to access storage outside of a GPULane loop.
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Memoization.h
+++ b/src/Memoization.h
@@ -8,8 +8,10 @@
  */
 
 #include <map>
+#include <string>
 
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Module.h
+++ b/src/Module.h
@@ -12,8 +12,9 @@
 #include <string>
 
 #include "Argument.h"
+#include "Expr.h"
 #include "ExternalCode.h"
-#include "IR.h"
+#include "Function.h"
 #include "ModulusRemainder.h"
 #include "Target.h"
 

--- a/src/Monotonic.h
+++ b/src/Monotonic.h
@@ -5,8 +5,10 @@
  *
  * Methods for computing whether expressions are monotonic
  */
+#include <iostream>
+#include <string>
 
-#include "IR.h"
+#include "Expr.h"
 #include "Scope.h"
 
 namespace Halide {

--- a/src/PartitionLoops.h
+++ b/src/PartitionLoops.h
@@ -7,7 +7,7 @@
  * steady-stage, and an epilogue.
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Prefetch.h
+++ b/src/Prefetch.h
@@ -7,8 +7,11 @@
  */
 
 #include <map>
+#include <string>
+#include <vector>
 
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
 #include "Schedule.h"
 #include "Target.h"
 

--- a/src/PrintLoopNest.cpp
+++ b/src/PrintLoopNest.cpp
@@ -1,5 +1,6 @@
 #include "PrintLoopNest.h"
 #include "AllocationBoundsInference.h"
+#include "Bounds.h"
 #include "BoundsInference.h"
 #include "FindCalls.h"
 #include "Func.h"

--- a/src/PrintLoopNest.h
+++ b/src/PrintLoopNest.h
@@ -9,10 +9,10 @@
 #include <string>
 #include <vector>
 
+#include "Function.h"
+
 namespace Halide {
 namespace Internal {
-
-class Function;
 
 /** Emit some simple pseudocode that shows the structure of the loop
  * nest specified by this pipeline's schedule, and the schedules of

--- a/src/Profiling.h
+++ b/src/Profiling.h
@@ -23,8 +23,9 @@
  *   mandelbrot:  0.006444ms (10%)   peak: 505344   num: 104000   avg: 5376
  *   argmin:      0.027715ms (46%)   stack: 20
  */
+#include <string>
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/PurifyIndexMath.h
+++ b/src/PurifyIndexMath.h
@@ -5,7 +5,7 @@
  * Removes side-effects in integer math.
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/PythonExtensionGen.h
+++ b/src/PythonExtensionGen.h
@@ -6,10 +6,6 @@
 #include <string>
 
 namespace Halide {
-
-class Module;
-struct Target;
-
 namespace Internal {
 
 class PythonExtensionGen {

--- a/src/Qualify.h
+++ b/src/Qualify.h
@@ -5,8 +5,9 @@
  *
  * Defines methods for prefixing names in an expression with a prefix string.
  */
+#include <string>
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -6,14 +6,19 @@
  * variables.
  */
 
-#include "IR.h"
-
+#include <iostream>
+#include <string>
 #include <utility>
 #include <vector>
 
+#include "Buffer.h"
+#include "Expr.h"
+#include "Reduction.h"
+#include "Util.h"
+
 namespace Halide {
 
-class ImageParam;
+class OutputImageParam;
 
 /** A reduction variable represents a single dimension of a reduction
  * domain (RDom). Don't construct them directly, instead construct an

--- a/src/Random.h
+++ b/src/Random.h
@@ -6,7 +6,10 @@
  * Defines deterministic random functions, and methods to redirect
  * front-end calls to random_float and random_int to use them. */
 
-#include "IR.h"
+#include <vector>
+
+#include "Expr.h"
+#include "Func.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/RemoveDeadAllocations.h
+++ b/src/RemoveDeadAllocations.h
@@ -6,7 +6,7 @@
  * are not used.
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/RemoveExternLoops.h
+++ b/src/RemoveExternLoops.h
@@ -1,7 +1,7 @@
 #ifndef HALIDE_REMOVE_EXTERN_LOOPS
 #define HALIDE_REMOVE_EXTERN_LOOPS
 
-#include "IR.h"
+#include "Expr.h"
 
 /** \file
  * Defines a lowering pass that removes placeholder loops for extern stages.

--- a/src/RemoveUndef.h
+++ b/src/RemoveUndef.h
@@ -1,7 +1,7 @@
 #ifndef HALIDE_REMOVE_UNDEF
 #define HALIDE_REMOVE_UNDEF
 
-#include "IR.h"
+#include "Expr.h"
 
 /** \file
  * Defines a lowering pass that elides stores that depend on unitialized values.

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -5,12 +5,14 @@
  * Defines the internal representation of the schedule for a function
  */
 
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "Expr.h"
 #include "FunctionPtr.h"
 #include "Parameter.h"
-
-#include <map>
-#include <utility>
 
 namespace Halide {
 

--- a/src/ScheduleFunctions.h
+++ b/src/ScheduleFunctions.h
@@ -8,16 +8,15 @@
  */
 
 #include <map>
+#include <string>
+#include <vector>
 
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
+#include "Target.h"
 
 namespace Halide {
-
-struct Target;
-
 namespace Internal {
-
-class Function;
 
 /** Build loop nests and inject Function realizations at the
  * appropriate places using the schedule. Returns a flag indicating

--- a/src/SelectGPUAPI.h
+++ b/src/SelectGPUAPI.h
@@ -1,7 +1,7 @@
 #ifndef HALIDE_INTERNAL_SELECT_GPU_API_H
 #define HALIDE_INTERNAL_SELECT_GPU_API_H
 
-#include "IR.h"
+#include "Expr.h"
 #include "Target.h"
 
 /** \file

--- a/src/Simplify.h
+++ b/src/Simplify.h
@@ -5,9 +5,10 @@
  * Methods for simplifying halide statements and expressions
  */
 
-#include "Bounds.h"
-#include "IR.h"
+#include "Expr.h"
+#include "Interval.h"
 #include "ModulusRemainder.h"
+#include "Scope.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/SimplifyCorrelatedDifferences.h
+++ b/src/SimplifyCorrelatedDifferences.h
@@ -1,7 +1,7 @@
 #ifndef HALIDE_SIMPLIFY_CORRELATED_DIFFERENCES
 #define HALIDE_SIMPLIFY_CORRELATED_DIFFERENCES
 
-#include "IR.h"
+#include "Expr.h"
 
 /** \file
  * Defines a simplification pass for handling differences of correlated expressions.

--- a/src/SimplifySpecializations.h
+++ b/src/SimplifySpecializations.h
@@ -8,8 +8,10 @@
  */
 
 #include <map>
+#include <string>
 
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/SkipStages.h
+++ b/src/SkipStages.h
@@ -1,7 +1,10 @@
 #ifndef HALIDE_SKIP_STAGES
 #define HALIDE_SKIP_STAGES
 
-#include "IR.h"
+#include <string>
+#include <vector>
+
+#include "Expr.h"
 
 /** \file
  * Defines a pass that dynamically avoids realizing unnecessary stages.

--- a/src/SlidingWindow.h
+++ b/src/SlidingWindow.h
@@ -8,8 +8,10 @@
  */
 
 #include <map>
+#include <string>
 
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Solve.h
+++ b/src/Solve.h
@@ -4,7 +4,8 @@
 /** Defines methods for manipulating and analyzing boolean expressions. */
 
 #include "Bounds.h"
-#include "IR.h"
+#include "Expr.h"
+#include "Interval.h"
 #include "Scope.h"
 
 namespace Halide {

--- a/src/StorageFlattening.h
+++ b/src/StorageFlattening.h
@@ -7,8 +7,11 @@
  */
 
 #include <map>
+#include <string>
+#include <vector>
 
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
 #include "Target.h"
 
 namespace Halide {

--- a/src/StorageFolding.h
+++ b/src/StorageFolding.h
@@ -5,8 +5,11 @@
  * Defines the lowering optimization pass that reduces large buffers
  * down to smaller circular buffers when possible
  */
+#include <map>
+#include <string>
 
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Tracing.h
+++ b/src/Tracing.h
@@ -6,8 +6,11 @@
  */
 
 #include <map>
+#include <string>
+#include <vector>
 
-#include "IR.h"
+#include "Expr.h"
+#include "Function.h"
 #include "Target.h"
 
 namespace Halide {

--- a/src/TrimNoOps.h
+++ b/src/TrimNoOps.h
@@ -6,7 +6,7 @@
  * which they actually do something.
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/Tuple.h
+++ b/src/Tuple.h
@@ -5,8 +5,9 @@
  *
  * Defines Tuple - the front-end handle on small arrays of expressions.
  */
+#include <vector>
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 

--- a/src/UnifyDuplicateLets.h
+++ b/src/UnifyDuplicateLets.h
@@ -5,7 +5,7 @@
  * Defines the lowering pass that coalesces redundant let statements
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/UniquifyVariableNames.h
+++ b/src/UniquifyVariableNames.h
@@ -5,7 +5,7 @@
  * Defines the lowering pass that renames all variables to have unique names.
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/UnpackBuffers.h
+++ b/src/UnpackBuffers.h
@@ -5,7 +5,7 @@
  * Defines the lowering pass that unpacks buffer arguments onto the symbol table
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/UnrollLoops.cpp
+++ b/src/UnrollLoops.cpp
@@ -1,4 +1,5 @@
 #include "UnrollLoops.h"
+#include "Bounds.h"
 #include "CSE.h"
 #include "IRMutator.h"
 #include "IROperator.h"

--- a/src/UnrollLoops.h
+++ b/src/UnrollLoops.h
@@ -5,7 +5,7 @@
  * Defines the lowering pass that unrolls loops marked as such
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/UnsafePromises.h
+++ b/src/UnsafePromises.h
@@ -5,7 +5,7 @@
  * Defines the lowering pass that removes unsafe promises
  */
 
-#include "IR.h"
+#include "Expr.h"
 #include "Target.h"
 
 namespace Halide {

--- a/src/Var.cpp
+++ b/src/Var.cpp
@@ -1,4 +1,5 @@
 #include "Var.h"
+#include "IR.h"
 #include "Util.h"
 
 namespace Halide {
@@ -18,6 +19,10 @@ Var Var::implicit(int n) {
 bool Var::is_implicit(const std::string &name) {
     return Internal::starts_with(name, "_") &&
            name.find_first_not_of("0123456789", 1) == std::string::npos;
+}
+
+const std::string &Var::name() const {
+    return e.as<Internal::Variable>()->name;
 }
 
 namespace Internal {

--- a/src/Var.h
+++ b/src/Var.h
@@ -4,8 +4,10 @@
 /** \file
  * Defines the Var - the front-end variable
  */
+#include <string>
+#include <vector>
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 
@@ -30,9 +32,7 @@ public:
     Var();
 
     /** Get the name of a Var */
-    const std::string &name() const {
-        return e.as<Internal::Variable>()->name;
-    }
+    const std::string &name() const;
 
     /** Test if two Vars are the same. This simply compares the names. */
     bool same_as(const Var &other) const {

--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -2,10 +2,11 @@
 
 #include <algorithm>
 
-#include "CodeGen_GPU_Dev.h"
-
 #include "CSE.h"
+#include "CodeGen_GPU_Dev.h"
+#include "IR.h"
 #include "IRMutator.h"
+#include "IROperator.h"
 #include "Simplify.h"
 
 namespace Halide {

--- a/src/VaryingAttributes.h
+++ b/src/VaryingAttributes.h
@@ -7,7 +7,7 @@
  * instead of being evaluated at each pixel location across the image.
  */
 
-#include "IR.h"
+#include "Expr.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/VectorizeLoops.h
+++ b/src/VectorizeLoops.h
@@ -5,7 +5,7 @@
  * Defines the lowering pass that vectorizes loops marked as such
  */
 
-#include "IR.h"
+#include "Expr.h"
 #include "Target.h"
 
 namespace Halide {

--- a/src/WrapCalls.h
+++ b/src/WrapCalls.h
@@ -7,8 +7,9 @@
  */
 
 #include <map>
+#include <string>
 
-#include "IR.h"
+#include "Function.h"
 
 namespace Halide {
 namespace Internal {


### PR DESCRIPTION
IR.h is an expensive header, and most includees don't need all of it (often, Expr.h is all they need). When other classes are needed (eg Function) the specific headers are included (rather than adding forward declarations).

Also did some drive-by addition of explicit std c++ headers where obvious.

In terms of build timing, it doesn't move the needle noticeably, but ClangBuildAnalyzer shows that IR.h drops from #1 to #4 (LLVM_Headers.h is now #1).  


