### PR TITLE
Minor optimization in SmallStack::push

### DIFF
--- a/src/Scope.h
+++ b/src/Scope.h
@@ -41,12 +41,11 @@ public:
     }
 
     void push(const T &t) {
-        if (_empty) {
-            _empty = false;
-        } else {
-            _rest.push_back(_top);
+        if (!_empty) {
+            _rest.push_back(std::move(_top));
         }
         _top = t;
+        _empty = false;
     }
 
     T top() const {


### PR DESCRIPTION
This method is instantiated a lot, so a couple of minor tweaks:
- skip a branch by unconditionally setting _empty=false in all cases
- use std::move for the push_back, to avoid a copy in case the type of object is movable