### PR TITLE
Avoid Function.h in other .h files

### DIFF
--- a/src/AddAtomicMutex.h
+++ b/src/AddAtomicMutex.h
@@ -2,7 +2,6 @@
 #define HALIDE_ADD_ATOMIC_MUTEX_H
 
 #include "Expr.h"
-#include "Function.h"
 #include <map>
 
 /** \file
@@ -11,8 +10,8 @@
  * the atomic operation is valid. It rejects algorithms that have indexing
  * on left-hand-side which references the buffer itself, e.g.
  * f(clamp(f(r), 0, 100)) = f(r) + 1
- * If the SplitTuple pass does not lift out the Provide value as a let 
- * expression. This is confirmed by checking whether the Provide nodes 
+ * If the SplitTuple pass does not lift out the Provide value as a let
+ * expression. This is confirmed by checking whether the Provide nodes
  * inside an Atomic node  have let binding values accessing the buffers
  * inside the atomic node.
  * Finally, it lifts the store indexing expressions inside the atomic node
@@ -21,6 +20,8 @@
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 Stmt add_atomic_mutex(Stmt s, const std::map<std::string, Function> &env);
 

--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -1,4 +1,5 @@
 #include "AddImageChecks.h"
+#include "Function.h"
 #include "IRMutator.h"
 #include "IRVisitor.h"
 #include "Simplify.h"

--- a/src/AddImageChecks.h
+++ b/src/AddImageChecks.h
@@ -12,7 +12,6 @@
 
 #include "Bounds.h"
 #include "Expr.h"
-#include "Function.h"
 
 #include <map>
 
@@ -21,6 +20,8 @@ namespace Halide {
 struct Target;
 
 namespace Internal {
+
+class Function;
 
 /** Insert checks to make sure a statement doesn't read out of bounds
  * on inputs or outputs, and that the inputs and outputs conform to

--- a/src/AllocationBoundsInference.cpp
+++ b/src/AllocationBoundsInference.cpp
@@ -1,5 +1,6 @@
 #include "AllocationBoundsInference.h"
 #include "Bounds.h"
+#include "Function.h"
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "Simplify.h"

--- a/src/AllocationBoundsInference.h
+++ b/src/AllocationBoundsInference.h
@@ -9,11 +9,12 @@
 #include <utility>
 
 #include "Expr.h"
-#include "Function.h"
 #include "Interval.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Take a partially statement with Realize nodes in terms of
  * variables, and define values for those variables. */

--- a/src/AsyncProducers.cpp
+++ b/src/AsyncProducers.cpp
@@ -1,5 +1,6 @@
 #include "AsyncProducers.h"
 #include "ExprUsesVar.h"
+#include "Function.h"
 #include "IREquality.h"
 #include "IRMutator.h"
 #include "IROperator.h"

--- a/src/AsyncProducers.h
+++ b/src/AsyncProducers.h
@@ -8,10 +8,11 @@
 #include <string>
 
 #include "Expr.h"
-#include "Function.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 Stmt fork_async_producers(Stmt s, const std::map<std::string, Function> &env);
 

--- a/src/AutoSchedule.h
+++ b/src/AutoSchedule.h
@@ -6,13 +6,13 @@
  * Defines the method that does automatic scheduling of Funcs within a pipeline.
  */
 
-#include "Function.h"
 #include "Pipeline.h"
 #include "Target.h"
 
 namespace Halide {
-
 namespace Internal {
+
+class Function;
 
 /** Generate schedules for Funcs within a pipeline. The Funcs should not already
  * have specializations or schedules as the current auto-scheduler does not take

--- a/src/AutoScheduleUtils.h
+++ b/src/AutoScheduleUtils.h
@@ -10,6 +10,7 @@
 #include <set>
 
 #include "Bounds.h"
+#include "Definition.h"
 #include "IRMutator.h"
 #include "IRVisitor.h"
 #include "Interval.h"

--- a/src/Bounds.h
+++ b/src/Bounds.h
@@ -6,13 +6,14 @@
  * and the regions of a function read or written by a statement.
  */
 
-#include "Function.h"
 #include "IROperator.h"
 #include "Interval.h"
 #include "Scope.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 typedef std::map<std::pair<std::string, int>, Interval> FuncValueBounds;
 

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -1,5 +1,6 @@
 #include "BoundsInference.h"
 #include "Bounds.h"
+#include "Function.h"
 #include "IREquality.h"
 #include "IRMutator.h"
 #include "IROperator.h"

--- a/src/BoundsInference.h
+++ b/src/BoundsInference.h
@@ -10,12 +10,13 @@
 #include <vector>
 
 #include "Expr.h"
-#include "Function.h"
 #include "Interval.h"
 #include "Target.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Take a partially lowered statement that includes symbolic
  * representations of the bounds over which things should be realized,

--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -2,6 +2,7 @@
 
 #include <map>
 
+#include "Function.h"
 #include "IR.h"
 #include "IROperator.h"
 #include "Type.h"

--- a/src/CPlusPlusMangle.h
+++ b/src/CPlusPlusMangle.h
@@ -9,10 +9,12 @@
 #include <vector>
 
 #include "Expr.h"
-#include "Function.h"  // for ExternFuncArgument
 #include "Target.h"
 
 namespace Halide {
+
+struct ExternFuncArgument;
+
 namespace Internal {
 
 /** Return the mangled C++ name for a function.

--- a/src/DebugToFile.cpp
+++ b/src/DebugToFile.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "DebugToFile.h"
+#include "Function.h"
 #include "IRMutator.h"
 #include "IROperator.h"
 

--- a/src/DebugToFile.h
+++ b/src/DebugToFile.h
@@ -9,10 +9,11 @@
 #include <vector>
 
 #include "Expr.h"
-#include "Function.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Takes a statement with Realize nodes still unlowered. If the
  * corresponding functions have a debug_file set, then inject code

--- a/src/FindCalls.cpp
+++ b/src/FindCalls.cpp
@@ -1,5 +1,6 @@
 #include "FindCalls.h"
 
+#include "Function.h"
 #include "IRVisitor.h"
 #include <utility>
 

--- a/src/FindCalls.h
+++ b/src/FindCalls.h
@@ -10,10 +10,11 @@
 #include <string>
 
 #include "Expr.h"
-#include "Function.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Construct a map from name to Function definition object for all Halide
  *  functions called directly in the definition of the Function f, including

--- a/src/Func.h
+++ b/src/Func.h
@@ -8,7 +8,6 @@
 
 #include "Argument.h"
 #include "Expr.h"
-#include "Function.h"
 #include "JITModule.h"
 #include "Module.h"
 #include "Param.h"
@@ -61,6 +60,7 @@ struct VarOrRVar {
 class ImageParam;
 
 namespace Internal {
+class Function;
 struct Split;
 struct StorageDim;
 }  // namespace Internal

--- a/src/IR.h
+++ b/src/IR.h
@@ -12,17 +12,19 @@
 #include "Debug.h"
 #include "Error.h"
 #include "Expr.h"
-#include "Function.h"
 #include "FunctionPtr.h"
 #include "IntrusivePtr.h"
 #include "ModulusRemainder.h"
 #include "Parameter.h"
 #include "Reduction.h"
+#include "Schedule.h"  // for PrefetchDirective
 #include "Type.h"
 #include "runtime/HalideBuffer.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** The actual IR nodes begin here. Remember that all the Expr
  * nodes also have a public "type" property */

--- a/src/IRVisitor.cpp
+++ b/src/IRVisitor.cpp
@@ -1,5 +1,7 @@
 #include "IRVisitor.h"
 
+#include "Function.h"
+
 namespace Halide {
 namespace Internal {
 

--- a/src/InferArguments.cpp
+++ b/src/InferArguments.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <vector>
 
+#include "Function.h"
 #include "IRVisitor.h"
 #include "InferArguments.h"
 

--- a/src/Inline.h
+++ b/src/Inline.h
@@ -6,10 +6,11 @@
  */
 
 #include "Expr.h"
-#include "Function.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Inline a single named function, which must be pure. For a pure function to
  * be inlined, it must not have any specializations (i.e. it can only have one

--- a/src/Lower.h
+++ b/src/Lower.h
@@ -12,13 +12,13 @@
 
 #include "Argument.h"
 #include "Expr.h"
-#include "Function.h"
 #include "Module.h"
 #include "Target.h"
 
 namespace Halide {
 namespace Internal {
 
+class Function;
 class IRMutator;
 
 /** Given a vector of scheduled halide functions, create a Module that

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -1,5 +1,6 @@
 #include "Memoization.h"
 #include "Error.h"
+#include "Function.h"
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "Param.h"

--- a/src/Memoization.h
+++ b/src/Memoization.h
@@ -11,10 +11,11 @@
 #include <string>
 
 #include "Expr.h"
-#include "Function.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Transform pipeline calls for Funcs scheduled with memoize to do a
  *  lookup call to the runtime cache implementation, and if there is a

--- a/src/Module.h
+++ b/src/Module.h
@@ -14,7 +14,7 @@
 #include "Argument.h"
 #include "Expr.h"
 #include "ExternalCode.h"
-#include "Function.h"
+#include "Function.h"  // for NameMangling
 #include "ModulusRemainder.h"
 #include "Target.h"
 

--- a/src/Param.h
+++ b/src/Param.h
@@ -4,6 +4,7 @@
 #include <type_traits>
 
 #include "Argument.h"
+#include "Function.h"  // for ExternFuncArgument
 #include "IR.h"
 
 /** \file

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -4,6 +4,7 @@
 #include <utility>
 
 #include "Bounds.h"
+#include "Function.h"
 #include "ExprUsesVar.h"
 #include "IRMutator.h"
 #include "Prefetch.h"

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -4,8 +4,8 @@
 #include <utility>
 
 #include "Bounds.h"
-#include "Function.h"
 #include "ExprUsesVar.h"
+#include "Function.h"
 #include "IRMutator.h"
 #include "Prefetch.h"
 #include "Scope.h"

--- a/src/Prefetch.h
+++ b/src/Prefetch.h
@@ -11,12 +11,13 @@
 #include <vector>
 
 #include "Expr.h"
-#include "Function.h"
 #include "Schedule.h"
 #include "Target.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Inject placeholder prefetches to 's'. This placholder prefetch
   * does not have explicit region to be prefetched yet. It will be computed

--- a/src/PrintLoopNest.h
+++ b/src/PrintLoopNest.h
@@ -9,10 +9,10 @@
 #include <string>
 #include <vector>
 
-#include "Function.h"
-
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Emit some simple pseudocode that shows the structure of the loop
  * nest specified by this pipeline's schedule, and the schedules of

--- a/src/RegionCosts.cpp
+++ b/src/RegionCosts.cpp
@@ -1,5 +1,6 @@
 #include "RegionCosts.h"
 #include "FindCalls.h"
+#include "Function.h"
 #include "IRMutator.h"
 #include "IRVisitor.h"
 #include "PartitionLoops.h"

--- a/src/ScheduleFunctions.h
+++ b/src/ScheduleFunctions.h
@@ -12,11 +12,12 @@
 #include <vector>
 
 #include "Expr.h"
-#include "Function.h"
 #include "Target.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Build loop nests and inject Function realizations at the
  * appropriate places using the schedule. Returns a flag indicating

--- a/src/SimplifySpecializations.cpp
+++ b/src/SimplifySpecializations.cpp
@@ -1,5 +1,6 @@
 #include "SimplifySpecializations.h"
 #include "Definition.h"
+#include "Function.h"
 #include "IREquality.h"
 #include "IRMutator.h"
 #include "IROperator.h"

--- a/src/SimplifySpecializations.h
+++ b/src/SimplifySpecializations.h
@@ -11,10 +11,11 @@
 #include <string>
 
 #include "Expr.h"
-#include "Function.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Try to simplify the RHS/LHS of a function's definition based on its
  * specializations. */

--- a/src/SlidingWindow.h
+++ b/src/SlidingWindow.h
@@ -11,10 +11,11 @@
 #include <string>
 
 #include "Expr.h"
-#include "Function.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Perform sliding window optimizations on a halide
  * statement. I.e. don't bother computing points in a function that

--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -1,5 +1,6 @@
 #include "SplitTuples.h"
 #include "Bounds.h"
+#include "Function.h"
 #include "IRMutator.h"
 
 namespace Halide {

--- a/src/SplitTuples.h
+++ b/src/SplitTuples.h
@@ -2,7 +2,6 @@
 #define HALIDE_SPLIT_TUPLES_H
 
 #include "Expr.h"
-#include "Function.h"
 #include <map>
 
 /** \file
@@ -11,6 +10,8 @@
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Rewrite all tuple-valued Realizations, Provide nodes, and Call
  * nodes into several scalar-valued ones, so that later lowering

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -1,6 +1,7 @@
 #include "StorageFlattening.h"
 
 #include "Bounds.h"
+#include "Function.h"
 #include "FuseGPUThreadLoops.h"
 #include "IRMutator.h"
 #include "IROperator.h"

--- a/src/StorageFlattening.h
+++ b/src/StorageFlattening.h
@@ -11,11 +11,12 @@
 #include <vector>
 
 #include "Expr.h"
-#include "Function.h"
 #include "Target.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Take a statement with multi-dimensional Realize, Provide, and Call
  * nodes, and turn it into a statement with single-dimensional

--- a/src/StorageFolding.h
+++ b/src/StorageFolding.h
@@ -9,10 +9,11 @@
 #include <string>
 
 #include "Expr.h"
-#include "Function.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Fold storage of functions if possible. This means reducing one of
  * the dimensions module something for the purpose of storage, if we

--- a/src/StrictifyFloat.cpp
+++ b/src/StrictifyFloat.cpp
@@ -1,5 +1,6 @@
 #include "StrictifyFloat.h"
 
+#include "Function.h"
 #include "IRMutator.h"
 #include "IROperator.h"
 

--- a/src/StrictifyFloat.h
+++ b/src/StrictifyFloat.h
@@ -7,11 +7,12 @@
 
 #include <map>
 
-#include "Function.h"
 #include "Target.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Propagate strict_float intrinisics such that they immediately wrap
  * all floating-point expressions. This makes the IR nodes context

--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -1,5 +1,6 @@
 #include "Tracing.h"
 #include "Bounds.h"
+#include "Function.h"
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "RealizationOrder.h"

--- a/src/Tracing.h
+++ b/src/Tracing.h
@@ -10,11 +10,12 @@
 #include <vector>
 
 #include "Expr.h"
-#include "Function.h"
 #include "Target.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Take a statement representing a halide pipeline, inject calls to
  * tracing functions at interesting points, such as

--- a/src/WrapCalls.cpp
+++ b/src/WrapCalls.cpp
@@ -1,5 +1,7 @@
 #include "WrapCalls.h"
 #include "FindCalls.h"
+#include "Function.h"
+#include "FunctionPtr.h"
 
 #include <set>
 

--- a/src/WrapCalls.h
+++ b/src/WrapCalls.h
@@ -9,10 +9,10 @@
 #include <map>
 #include <string>
 
-#include "Function.h"
-
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Replace every call to wrapped Functions in the Functions' definitions with
   * call to their wrapper functions. */


### PR DESCRIPTION
#including this file drags in a lot of other includes, but most includers only need a forward declaration.

(Note that this is additive to https://github.com/halide/Halide/pull/4815, not to master)