### PR TITLE
Improve set_host_dirty error message

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1570,7 +1570,7 @@ public:
     // access. Must be inlined so it can be hoisted out of loops.
     HALIDE_ALWAYS_INLINE
     void set_host_dirty(bool v = true) {
-        assert((!v || !device_dirty()) && "Cannot set host dirty when device is already dirty.");
+        assert((!v || !device_dirty()) && "Cannot set host dirty when device is already dirty. Call copy_to_host before accessing the buffer from host.");
         buf.set_host_dirty(v);
     }
 

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1570,7 +1570,7 @@ public:
     // access. Must be inlined so it can be hoisted out of loops.
     HALIDE_ALWAYS_INLINE
     void set_host_dirty(bool v = true) {
-        assert((!v || !device_dirty()) && "Cannot set host dirty when device is already dirty. Call copy_to_host before accessing the buffer from host.");
+        assert((!v || !device_dirty()) && "Cannot set host dirty when device is already dirty. Call copy_to_host() before accessing the buffer from host.");
         buf.set_host_dirty(v);
     }
 


### PR DESCRIPTION
Currently, if someone forgot to `copy_to_host` before accessing the Buffer in the host, this assertion would be triggered:
```
assert((!v || !device_dirty()) && "Cannot set host dirty when device is already dirty.");
```

This message is not very friendly to Halide newbies (like me). I propose changing it to
```
assert((!v || !device_dirty()) && "Cannot set host dirty when device is already dirty. Call copy_to_host before accessing the buffer from host.");
```

Ideally we also want to print out the name of the buffer, but doing it inside an assertion with zero overhead might be difficult.