### PR TITLE
Add Expr.cpp, move nontrivial function bodies into it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /apps/HelloMatlab/blurred.png
 /apps/HelloMatlab/iir_blur.mex
 bin/*
+build/*
 python_bindings/bin/*
 build-64/*
 build-ios/*

--- a/Makefile
+++ b/Makefile
@@ -492,6 +492,7 @@ SOURCE_FILES = \
   EliminateBoolVectors.cpp \
   EmulateFloat16Math.cpp \
   Error.cpp \
+  Expr.cpp \
   FastIntegerDivide.cpp \
   FindCalls.cpp \
   Float16.cpp \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -517,6 +517,7 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   EliminateBoolVectors.cpp
   EmulateFloat16Math.cpp
   Error.cpp
+  Expr.cpp
   FastIntegerDivide.cpp
   FindCalls.cpp
   Float16.cpp

--- a/src/Expr.cpp
+++ b/src/Expr.cpp
@@ -1,0 +1,102 @@
+#include "Expr.h"
+#include "IROperator.h"  // for lossless_cast()
+
+namespace Halide {
+namespace Internal {
+
+const IntImm *IntImm::make(Type t, int64_t value) {
+    internal_assert(t.is_int() && t.is_scalar())
+        << "IntImm must be a scalar Int\n";
+    internal_assert(t.bits() == 8 || t.bits() == 16 || t.bits() == 32 || t.bits() == 64)
+        << "IntImm must be 8, 16, 32, or 64-bit\n";
+
+    // Normalize the value by dropping the high bits.
+    // Since left-shift of negative value is UB in C++, cast to uint64 first;
+    // it's unlikely any compilers we care about will misbehave, but UBSan will complain.
+    value = (int64_t)(((uint64_t)value) << (64 - t.bits()));
+
+    // Then sign-extending to get them back
+    value >>= (64 - t.bits());
+
+    IntImm *node = new IntImm;
+    node->type = t;
+    node->value = value;
+    return node;
+}
+
+const UIntImm *UIntImm::make(Type t, uint64_t value) {
+    internal_assert(t.is_uint() && t.is_scalar())
+        << "UIntImm must be a scalar UInt\n";
+    internal_assert(t.bits() == 1 || t.bits() == 8 || t.bits() == 16 || t.bits() == 32 || t.bits() == 64)
+        << "UIntImm must be 1, 8, 16, 32, or 64-bit\n";
+
+    // Normalize the value by dropping the high bits
+    value <<= (64 - t.bits());
+    value >>= (64 - t.bits());
+
+    UIntImm *node = new UIntImm;
+    node->type = t;
+    node->value = value;
+    return node;
+}
+
+const FloatImm *FloatImm::make(Type t, double value) {
+    internal_assert(t.is_float() && t.is_scalar())
+        << "FloatImm must be a scalar Float\n";
+    FloatImm *node = new FloatImm;
+    node->type = t;
+    switch (t.bits()) {
+    case 16:
+        if (t.is_bfloat()) {
+            node->value = (double)((bfloat16_t)value);
+        } else {
+            node->value = (double)((float16_t)value);
+        }
+        break;
+    case 32:
+        node->value = (float)value;
+        break;
+    case 64:
+        node->value = value;
+        break;
+    default:
+        internal_error << "FloatImm must be 16, 32, or 64-bit\n";
+    }
+
+    return node;
+}
+
+const StringImm *StringImm::make(const std::string &val) {
+    StringImm *node = new StringImm;
+    node->type = type_of<const char *>();
+    node->value = val;
+    return node;
+}
+
+/** Check if for_type executes for loop iterations in parallel and unordered. */
+bool is_unordered_parallel(ForType for_type) {
+    return (for_type == ForType::Parallel ||
+            for_type == ForType::GPUBlock ||
+            for_type == ForType::GPUThread);
+}
+
+/** Returns true if for_type executes for loop iterations in parallel. */
+bool is_parallel(ForType for_type) {
+    return (is_unordered_parallel(for_type) ||
+            for_type == ForType::Vectorized ||
+            for_type == ForType::GPULane);
+}
+
+}  // namespace Internal
+
+Range::Range(const Expr &min_in, const Expr &extent_in)
+    : min(lossless_cast(Int(32), min_in)), extent(lossless_cast(Int(32), extent_in)) {
+    if (min_in.defined() && !min.defined()) {
+        user_error << "Min cannot be losslessly cast to an int32: " << min_in;
+    }
+    if (extent_in.defined() && !extent.defined()) {
+        user_error << "Extent cannot be losslessly cast to an int32: " << extent_in;
+    }
+}
+
+}  // namespace Halide

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -209,25 +209,7 @@ struct IRHandle : public IntrusivePtr<const IRNode> {
 struct IntImm : public ExprNode<IntImm> {
     int64_t value;
 
-    static const IntImm *make(Type t, int64_t value) {
-        internal_assert(t.is_int() && t.is_scalar())
-            << "IntImm must be a scalar Int\n";
-        internal_assert(t.bits() == 8 || t.bits() == 16 || t.bits() == 32 || t.bits() == 64)
-            << "IntImm must be 8, 16, 32, or 64-bit\n";
-
-        // Normalize the value by dropping the high bits.
-        // Since left-shift of negative value is UB in C++, cast to uint64 first;
-        // it's unlikely any compilers we care about will misbehave, but UBSan will complain.
-        value = (int64_t)(((uint64_t)value) << (64 - t.bits()));
-
-        // Then sign-extending to get them back
-        value >>= (64 - t.bits());
-
-        IntImm *node = new IntImm;
-        node->type = t;
-        node->value = value;
-        return node;
-    }
+    static const IntImm *make(Type t, int64_t value);
 
     static const IRNodeType _node_type = IRNodeType::IntImm;
 };
@@ -236,21 +218,7 @@ struct IntImm : public ExprNode<IntImm> {
 struct UIntImm : public ExprNode<UIntImm> {
     uint64_t value;
 
-    static const UIntImm *make(Type t, uint64_t value) {
-        internal_assert(t.is_uint() && t.is_scalar())
-            << "UIntImm must be a scalar UInt\n";
-        internal_assert(t.bits() == 1 || t.bits() == 8 || t.bits() == 16 || t.bits() == 32 || t.bits() == 64)
-            << "UIntImm must be 1, 8, 16, 32, or 64-bit\n";
-
-        // Normalize the value by dropping the high bits
-        value <<= (64 - t.bits());
-        value >>= (64 - t.bits());
-
-        UIntImm *node = new UIntImm;
-        node->type = t;
-        node->value = value;
-        return node;
-    }
+    static const UIntImm *make(Type t, uint64_t value);
 
     static const IRNodeType _node_type = IRNodeType::UIntImm;
 };
@@ -259,31 +227,7 @@ struct UIntImm : public ExprNode<UIntImm> {
 struct FloatImm : public ExprNode<FloatImm> {
     double value;
 
-    static const FloatImm *make(Type t, double value) {
-        internal_assert(t.is_float() && t.is_scalar())
-            << "FloatImm must be a scalar Float\n";
-        FloatImm *node = new FloatImm;
-        node->type = t;
-        switch (t.bits()) {
-        case 16:
-            if (t.is_bfloat()) {
-                node->value = (double)((bfloat16_t)value);
-            } else {
-                node->value = (double)((float16_t)value);
-            }
-            break;
-        case 32:
-            node->value = (float)value;
-            break;
-        case 64:
-            node->value = value;
-            break;
-        default:
-            internal_error << "FloatImm must be 16, 32, or 64-bit\n";
-        }
-
-        return node;
-    }
+    static const FloatImm *make(Type t, double value);
 
     static const IRNodeType _node_type = IRNodeType::FloatImm;
 };
@@ -292,12 +236,7 @@ struct FloatImm : public ExprNode<FloatImm> {
 struct StringImm : public ExprNode<StringImm> {
     std::string value;
 
-    static const StringImm *make(const std::string &val) {
-        StringImm *node = new StringImm;
-        node->type = type_of<const char *>();
-        node->value = val;
-        return node;
-    }
+    static const StringImm *make(const std::string &val);
 
     static const IRNodeType _node_type = IRNodeType::StringImm;
 };
@@ -484,18 +423,10 @@ enum class ForType {
 };
 
 /** Check if for_type executes for loop iterations in parallel and unordered. */
-inline bool is_unordered_parallel(ForType for_type) {
-    return (for_type == ForType::Parallel ||
-            for_type == ForType::GPUBlock ||
-            for_type == ForType::GPUThread);
-}
+bool is_unordered_parallel(ForType for_type);
 
 /** Returns true if for_type executes for loop iterations in parallel. */
-inline bool is_parallel(ForType for_type) {
-    return (is_unordered_parallel(for_type) ||
-            for_type == ForType::Vectorized ||
-            for_type == ForType::GPULane);
-}
+bool is_parallel(ForType for_type);
 
 /** A reference-counted handle to a statement node. */
 struct Stmt : public IRHandle {

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -2222,14 +2222,4 @@ Expr undef(Type t) {
                                 Internal::Call::PureIntrinsic);
 }
 
-Range::Range(const Expr &min_in, const Expr &extent_in)
-    : min(lossless_cast(Int(32), min_in)), extent(lossless_cast(Int(32), extent_in)) {
-    if (min_in.defined() && !min.defined()) {
-        user_error << "Min cannot be losslessly cast to an int32: " << min_in;
-    }
-    if (extent_in.defined() && !extent.defined()) {
-        user_error << "Extent cannot be losslessly cast to an int32: " << extent_in;
-    }
-}
-
 }  // namespace Halide


### PR DESCRIPTION
Expr.h is included by ~everything in Halide, so we want to minimize its complexity. There are several nontrivial function bodies in Expr.h that are likely too large to inline anyway, so add Expr.cpp and move them there. (Also move the Range ctor there since that's where it belonged anyway.)

Linux build shows a slight decrease in libHalide size (110872632 -> 110830336). Didn't try to measure performance changes.