### PR TITLE
Remove unnecessary includes of Introspection.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /apps/HelloMatlab/blurred.png
 /apps/HelloMatlab/iir_blur.mex
 bin/*
+build/*
 python_bindings/bin/*
 build-64/*
 build-ios/*

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -9,8 +9,6 @@
 #include <stdlib.h>
 #include <string>
 
-#include "Introspection.h"
-
 namespace Halide {
 
 struct Expr;

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -1,4 +1,5 @@
 #include "Error.h"
+#include "Introspection.h"
 #include "Util.h"  // for get_env_variable
 
 #include <signal.h>

--- a/src/Error.h
+++ b/src/Error.h
@@ -5,7 +5,6 @@
 #include <stdexcept>
 
 #include "Debug.h"
-#include "Introspection.h"
 #include "runtime/HalideRuntime.h"  // for HALIDE_ALWAYS_INLINE
 
 namespace Halide {

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -12,7 +12,6 @@
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "IRPrinter.h"
-#include "Introspection.h"
 #include "ParallelRVar.h"
 #include "Random.h"
 #include "Scope.h"


### PR DESCRIPTION
It was included by Debug.h and Error.h (and thus ~everywhere), but is only needed in a handful of .cpp files.