### PR TITLE
Add ExternFuncArgument.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -667,6 +667,7 @@ HEADER_FILES = \
   Expr.h \
   ExprUsesVar.h \
   Extern.h \
+  ExternFuncArgument.h \
   FastIntegerDivide.h \
   FindCalls.h \
   Float16.h \

--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -1,4 +1,5 @@
 #include "AddImageChecks.h"
+#include "ExternFuncArgument.h"
 #include "Function.h"
 #include "IRMutator.h"
 #include "IRVisitor.h"

--- a/src/AllocationBoundsInference.cpp
+++ b/src/AllocationBoundsInference.cpp
@@ -1,5 +1,6 @@
 #include "AllocationBoundsInference.h"
 #include "Bounds.h"
+#include "ExternFuncArgument.h"
 #include "Function.h"
 #include "IRMutator.h"
 #include "IROperator.h"

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -1,5 +1,6 @@
 #include "BoundsInference.h"
 #include "Bounds.h"
+#include "ExternFuncArgument.h"
 #include "Function.h"
 #include "IREquality.h"
 #include "IRMutator.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -342,6 +342,7 @@ set(HEADER_FILES
   Expr.h
   ExprUsesVar.h
   Extern.h
+  ExternFuncArgument.h
   FastIntegerDivide.h
   FindCalls.h
   Float16.h

--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -2,6 +2,7 @@
 
 #include <map>
 
+#include "ExternFuncArgument.h"
 #include "Function.h"
 #include "IR.h"
 #include "IROperator.h"

--- a/src/ExternFuncArgument.h
+++ b/src/ExternFuncArgument.h
@@ -1,0 +1,75 @@
+#ifndef HALIDE_EXTERNFUNCARGUMENT_H
+#define HALIDE_EXTERNFUNCARGUMENT_H
+
+/** \file
+ * Defines the internal representation of a halide ExternFuncArgument
+ */
+
+#include "Buffer.h"
+#include "Expr.h"
+#include "FunctionPtr.h"
+#include "Parameter.h"
+
+namespace Halide {
+
+/** An argument to an extern-defined Func. May be a Function, Buffer,
+ * ImageParam or Expr. */
+struct ExternFuncArgument {
+    enum ArgType { UndefinedArg = 0,
+                   FuncArg,
+                   BufferArg,
+                   ExprArg,
+                   ImageParamArg };
+    ArgType arg_type;
+    Internal::FunctionPtr func;
+    Buffer<> buffer;
+    Expr expr;
+    Internal::Parameter image_param;
+
+    ExternFuncArgument(Internal::FunctionPtr f)
+        : arg_type(FuncArg), func(std::move(f)) {
+    }
+
+    template<typename T>
+    ExternFuncArgument(Buffer<T> b)
+        : arg_type(BufferArg), buffer(b) {
+    }
+    ExternFuncArgument(Expr e)
+        : arg_type(ExprArg), expr(std::move(e)) {
+    }
+    ExternFuncArgument(int e)
+        : arg_type(ExprArg), expr(e) {
+    }
+    ExternFuncArgument(float e)
+        : arg_type(ExprArg), expr(e) {
+    }
+
+    ExternFuncArgument(const Internal::Parameter &p)
+        : arg_type(ImageParamArg), image_param(p) {
+        // Scalar params come in via the Expr constructor.
+        internal_assert(p.is_buffer());
+    }
+    ExternFuncArgument()
+        : arg_type(UndefinedArg) {
+    }
+
+    bool is_func() const {
+        return arg_type == FuncArg;
+    }
+    bool is_expr() const {
+        return arg_type == ExprArg;
+    }
+    bool is_buffer() const {
+        return arg_type == BufferArg;
+    }
+    bool is_image_param() const {
+        return arg_type == ImageParamArg;
+    }
+    bool defined() const {
+        return arg_type != UndefinedArg;
+    }
+};
+
+}  // namespace Halide
+
+#endif  // HALIDE_EXTERNFUNCARGUMENT_H

--- a/src/FindCalls.cpp
+++ b/src/FindCalls.cpp
@@ -1,5 +1,6 @@
 #include "FindCalls.h"
 
+#include "ExternFuncArgument.h"
 #include "Function.h"
 #include "IRVisitor.h"
 #include <utility>

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2983,6 +2983,10 @@ vector<OutputImageParam> Func::output_buffers() const {
     return bufs;
 }
 
+Func::operator ExternFuncArgument() const {
+    return ExternFuncArgument(func);
+}
+
 Pipeline Func::pipeline() {
     if (!pipeline_.defined()) {
         pipeline_ = Pipeline(*this);

--- a/src/Func.h
+++ b/src/Func.h
@@ -2356,9 +2356,7 @@ public:
     // @}
 
     /** Use a Func as an argument to an external stage. */
-    operator ExternFuncArgument() const {
-        return ExternFuncArgument(func);
-    }
+    operator ExternFuncArgument() const;
 
     /** Infer the arguments to the Func, sorted into a canonical order:
      * all buffers (sorted alphabetically by name), followed by all non-buffers

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -902,6 +902,10 @@ std::string &Function::debug_file() {
     return contents->debug_file;
 }
 
+Function::operator ExternFuncArgument() const {
+    return ExternFuncArgument(contents);
+}
+
 void Function::trace_loads() {
     contents->trace_loads = true;
 }

--- a/src/IRVisitor.cpp
+++ b/src/IRVisitor.cpp
@@ -1,5 +1,6 @@
 #include "IRVisitor.h"
 
+#include "ExternFuncArgument.h"
 #include "Function.h"
 
 namespace Halide {

--- a/src/InferArguments.cpp
+++ b/src/InferArguments.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <vector>
 
+#include "ExternFuncArgument.h"
 #include "Function.h"
 #include "IRVisitor.h"
 #include "InferArguments.h"

--- a/src/InjectHostDevBufferCopies.cpp
+++ b/src/InjectHostDevBufferCopies.cpp
@@ -2,6 +2,7 @@
 
 #include "CodeGen_GPU_Dev.h"
 #include "Debug.h"
+#include "ExternFuncArgument.h"
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "IRPrinter.h"

--- a/src/Inline.cpp
+++ b/src/Inline.cpp
@@ -2,6 +2,7 @@
 
 #include "CSE.h"
 #include "Debug.h"
+#include "ExternFuncArgument.h"
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "IRPrinter.h"

--- a/src/Param.h
+++ b/src/Param.h
@@ -4,7 +4,7 @@
 #include <type_traits>
 
 #include "Argument.h"
-#include "Function.h"  // for ExternFuncArgument
+#include "ExternFuncArgument.h"
 #include "IR.h"
 
 /** \file

--- a/src/ParamMap.h
+++ b/src/ParamMap.h
@@ -5,6 +5,7 @@
  * Defines a collection of parameters to be passed as formal arguments
  * to a JIT invocation.
  */
+#include <map>
 
 #include "Param.h"
 #include "Parameter.h"


### PR DESCRIPTION
Most that need Function don't need ExternFuncArgument,  but putting both in Function.h adds extra includes (eg Buffer.h) in places that it isn't needed. Split it out into a separate file and forward-declared in all headers (except Param.h, which will be addressed in the future).