### PR TITLE
Reduce includes in IR.h and Expr.h

### DIFF
--- a/src/Expr.h
+++ b/src/Expr.h
@@ -8,13 +8,14 @@
 #include <string>
 #include <vector>
 
-#include "Debug.h"
-#include "Error.h"
-#include "Float16.h"
 #include "IntrusivePtr.h"
 #include "Type.h"
 
 namespace Halide {
+
+struct bfloat16_t;
+struct float16_t;
+
 namespace Internal {
 
 class IRMutator;

--- a/src/IR.h
+++ b/src/IR.h
@@ -6,20 +6,15 @@
  */
 
 #include <string>
-#include <utility>
 #include <vector>
 
-#include "Debug.h"
-#include "Error.h"
 #include "Expr.h"
 #include "FunctionPtr.h"
-#include "IntrusivePtr.h"
 #include "ModulusRemainder.h"
 #include "Parameter.h"
+#include "PrefetchDirective.h"
 #include "Reduction.h"
-#include "Schedule.h"  // for PrefetchDirective
 #include "Type.h"
-#include "runtime/HalideBuffer.h"
 
 namespace Halide {
 namespace Internal {

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -5,6 +5,7 @@
  * Defines a method to match a fragment of IR against a pattern containing wildcards
  */
 
+#include <map>
 #include <random>
 #include <set>
 #include <vector>

--- a/src/IntrusivePtr.h
+++ b/src/IntrusivePtr.h
@@ -10,6 +10,8 @@
 #include <atomic>
 #include <stdlib.h>
 
+#include "runtime/HalideRuntime.h"  // for HALIDE_ALWAYS_INLINE
+
 namespace Halide {
 namespace Internal {
 

--- a/src/ModulusRemainder.h
+++ b/src/ModulusRemainder.h
@@ -5,10 +5,16 @@
  * Routines for statically determining what expressions are divisible by.
  */
 
-#include "Scope.h"
+#include <stdint.h>
 
 namespace Halide {
+
+struct Expr;
+
 namespace Internal {
+
+template<typename T>
+class Scope;
 
 /** The result of modulus_remainder analysis. These represent strided
  * subsets of the integers. A ModulusRemainder object m represents all

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -10,6 +10,7 @@
 #include "Prefetch.h"
 #include "Scope.h"
 #include "Simplify.h"
+#include "Target.h"
 #include "Util.h"
 
 namespace Halide {

--- a/src/Prefetch.h
+++ b/src/Prefetch.h
@@ -10,14 +10,15 @@
 #include <string>
 #include <vector>
 
-#include "Expr.h"
-#include "Schedule.h"
-#include "Target.h"
-
 namespace Halide {
+
+struct Target;
+
 namespace Internal {
 
 class Function;
+struct PrefetchDirective;
+struct Stmt;
 
 /** Inject placeholder prefetches to 's'. This placholder prefetch
   * does not have explicit region to be prefetched yet. It will be computed

--- a/src/PrefetchDirective.h
+++ b/src/PrefetchDirective.h
@@ -1,0 +1,50 @@
+#ifndef HALIDE_PREFETCH_DIRECTIVE_H
+#define HALIDE_PREFETCH_DIRECTIVE_H
+
+/** \file
+ * Defines the PrefetchDirective struct
+ */
+
+#include <string>
+
+#include "Expr.h"
+#include "Parameter.h"
+
+namespace Halide {
+
+/** Different ways to handle accesses outside the original extents in a prefetch. */
+enum class PrefetchBoundStrategy {
+    /** Clamp the prefetched exprs by intersecting the prefetched region with
+     * the original extents. This may make the exprs of the prefetched region
+     * more complicated. */
+    Clamp,
+
+    /** Guard the prefetch with if-guards that ignores the prefetch if
+     * any of the prefetched region ever goes beyond the original extents
+     * (i.e. all or nothing). */
+    GuardWithIf,
+
+    /** Leave the prefetched exprs as are (no if-guards around the prefetch
+     * and no intersecting with the original extents). This makes the prefetch
+     * exprs simpler but this may cause prefetching of region outside the original
+     * extents. This is good if prefetch won't fault when accessing region
+     * outside the original extents. */
+    NonFaulting
+};
+
+namespace Internal {
+
+struct PrefetchDirective {
+    std::string name;
+    std::string var;
+    Expr offset;
+    PrefetchBoundStrategy strategy;
+    // If it's a prefetch load from an image parameter, this points to that.
+    Parameter param;
+};
+
+}  // namespace Internal
+
+}  // namespace Halide
+
+#endif  // HALIDE_PREFETCH_DIRECTIVE_H

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -13,6 +13,7 @@
 #include "Expr.h"
 #include "FunctionPtr.h"
 #include "Parameter.h"
+#include "PrefetchDirective.h"
 
 namespace Halide {
 
@@ -85,26 +86,6 @@ enum class LoopAlignStrategy {
 
     /** By default, LoopAlignStrategy is set to NoAlign. */
     Auto
-};
-
-/** Different ways to handle accesses outside the original extents in a prefetch. */
-enum class PrefetchBoundStrategy {
-    /** Clamp the prefetched exprs by intersecting the prefetched region with
-     * the original extents. This may make the exprs of the prefetched region
-     * more complicated. */
-    Clamp,
-
-    /** Guard the prefetch with if-guards that ignores the prefetch if
-     * any of the prefetched region ever goes beyond the original extents
-     * (i.e. all or nothing). */
-    GuardWithIf,
-
-    /** Leave the prefetched exprs as are (no if-guards around the prefetch
-     * and no intersecting with the original extents). This makes the prefetch
-     * exprs simpler but this may cause prefetching of region outside the original
-     * extents. This is good if prefetch won't fault when accessing region
-     * outside the original extents. */
-    NonFaulting
 };
 
 /** A reference to a site in a Halide statement at the top of the
@@ -378,15 +359,6 @@ struct FusedPair {
         }
         return stage_2 < other.stage_2;
     }
-};
-
-struct PrefetchDirective {
-    std::string name;
-    std::string var;
-    Expr offset;
-    PrefetchBoundStrategy strategy;
-    // If it's a prefetch load from an image parameter, this points to that.
-    Parameter param;
 };
 
 struct FuncScheduleContents;

--- a/src/UniquifyVariableNames.cpp
+++ b/src/UniquifyVariableNames.cpp
@@ -2,6 +2,7 @@
 #include "IREquality.h"
 #include "IRMutator.h"
 #include "IROperator.h"
+#include "Scope.h"
 #include "Var.h"
 #include <sstream>
 


### PR DESCRIPTION
Remove includes that are just plain unneeded, adding forward decls as needed.

Split PrefetchDirective.h into its own header since that's the only thing that IR.h needed from Schedule.h.

Some drive-by work on related headers too.