### PR TITLE
Remove unnecessary includes of Buffer.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -547,6 +547,7 @@ SOURCE_FILES = \
   Qualify.cpp \
   Random.cpp \
   RDom.cpp \
+  Realization.cpp \
   RealizationOrder.cpp \
   Reduction.cpp \
   RegionCosts.cpp \

--- a/src/Argument.h
+++ b/src/Argument.h
@@ -6,12 +6,14 @@
  * generated halide pipeline
  */
 
-#include "Buffer.h"
 #include "Expr.h"
 #include "Type.h"
 #include "runtime/HalideRuntime.h"
 
 namespace Halide {
+
+template<typename T>
+class Buffer;
 
 struct ArgumentEstimates {
     /** If this is a scalar argument, then these are its default, min, max, and estimated values.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -573,6 +573,7 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   Qualify.cpp
   Random.cpp
   RDom.cpp
+  Realization.cpp
   RealizationOrder.cpp
   Reduction.cpp
   RegionCosts.cpp

--- a/src/Closure.h
+++ b/src/Closure.h
@@ -8,12 +8,15 @@
 #include <map>
 #include <string>
 
-#include "Buffer.h"
 #include "IR.h"
 #include "IRVisitor.h"
 #include "Scope.h"
 
 namespace Halide {
+
+template<typename T>
+class Buffer;
+
 namespace Internal {
 
 /** A helper class to manage closures. Walks over a statement and
@@ -62,7 +65,7 @@ public:
 
 protected:
     void found_buffer_ref(const std::string &name, Type type,
-                          bool read, bool written, const Halide::Buffer<> &image);
+                          bool read, bool written, const Halide::Buffer<void> &image);
 
 public:
     Closure() = default;

--- a/src/LLVM_Output.h
+++ b/src/LLVM_Output.h
@@ -5,6 +5,7 @@
  *
  */
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/Module.h
+++ b/src/Module.h
@@ -20,6 +20,9 @@
 
 namespace Halide {
 
+template<typename T>
+class Buffer;
+
 /** Enums specifying various kinds of outputs that can be produced from a Halide Pipeline. */
 enum class Output {
     assembly,
@@ -134,7 +137,7 @@ public:
 
     /** The declarations contained in this module. */
     // @{
-    const std::vector<Buffer<>> &buffers() const;
+    const std::vector<Buffer<void>> &buffers() const;
     const std::vector<Internal::LoweredFunc> &functions() const;
     std::vector<Internal::LoweredFunc> &functions();
     const std::vector<Module> &submodules() const;
@@ -147,7 +150,7 @@ public:
 
     /** Add a declaration to this module. */
     // @{
-    void append(const Buffer<> &buffer);
+    void append(const Buffer<void> &buffer);
     void append(const Internal::LoweredFunc &function);
     void append(const Module &module);
     void append(const ExternalCode &external_code);

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -11,13 +11,14 @@
 #include <utility>
 #include <vector>
 
-#include "Buffer.h"
 #include "Expr.h"
 #include "Reduction.h"
 #include "Util.h"
 
 namespace Halide {
 
+template<typename T>
+class Buffer;
 class OutputImageParam;
 
 /** A reduction variable represents a single dimension of a reduction
@@ -224,11 +225,11 @@ public:
      * a given Buffer or ImageParam. Has the same dimensionality as
      * the argument. */
     // @{
-    RDom(const Buffer<> &);
+    RDom(const Buffer<void> &);
     RDom(const OutputImageParam &);
     template<typename T>
     HALIDE_NO_USER_CODE_INLINE RDom(const Buffer<T> &im)
-        : RDom(Buffer<>(im)) {
+        : RDom(Buffer<void>(im)) {
     }
     // @}
 

--- a/src/Realization.cpp
+++ b/src/Realization.cpp
@@ -1,0 +1,48 @@
+#include "Realization.h"
+
+#include "Buffer.h"
+#include "Error.h"
+
+namespace Halide {
+
+/** The number of images in the Realization. */
+size_t Realization::size() const {
+    return images.size();
+}
+
+/** Get a const reference to one of the images. */
+const Buffer<void> &Realization::operator[](size_t x) const {
+    user_assert(x < images.size()) << "Realization access out of bounds\n";
+    return images[x];
+}
+
+/** Get a reference to one of the images. */
+Buffer<void> &Realization::operator[](size_t x) {
+    user_assert(x < images.size()) << "Realization access out of bounds\n";
+    return images[x];
+}
+
+/** Construct a Realization that refers to the buffers in an
+ * existing vector of Buffer<> */
+Realization::Realization(std::vector<Buffer<void>> &e)
+    : images(e) {
+    user_assert(!e.empty()) << "Realizations must have at least one element\n";
+}
+
+/** Call device_sync() for all Buffers in the Realization.
+ * If one of the calls returns an error, subsequent Buffers won't have
+ * device_sync called; thus callers should consider a nonzero return
+ * code to mean that potentially all of the Buffers are in an indeterminate
+ * state of sync.
+ * Calling this explicitly should rarely be necessary, except for profiling. */
+int Realization::device_sync(void *ctx) {
+    for (auto &b : images) {
+        int result = b.device_sync(ctx);
+        if (result != 0) {
+            return result;
+        }
+    }
+    return 0;
+}
+
+}  // namespace Halide


### PR DESCRIPTION
Buffer.h is a heavyweight file and should only be included when forward-declarations will not suffice.

Also, a drive-by addition of Realization.cpp.

(Note, this is additive to https://github.com/halide/Halide/pull/4823 rather than master)