### PR TITLE
Tiny size optimization in Bounds.h

### DIFF
--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -2,6 +2,7 @@
 #include "ExternFuncArgument.h"
 #include "Function.h"
 #include "IRMutator.h"
+#include "IROperator.h"
 #include "IRVisitor.h"
 #include "Simplify.h"
 #include "Substitute.h"

--- a/src/BoundSmallAllocations.cpp
+++ b/src/BoundSmallAllocations.cpp
@@ -2,6 +2,7 @@
 #include "Bounds.h"
 #include "CodeGen_Internal.h"
 #include "IRMutator.h"
+#include "IROperator.h"
 #include "Simplify.h"
 
 namespace Halide {

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -78,6 +78,10 @@ Interval find_constant_bounds(const Expr &e, const Scope<Interval> &scope) {
     return interval;
 }
 
+bool Box::maybe_unused() const {
+    return used.defined() && !is_one(used);
+}
+
 std::ostream &operator<<(std::ostream &stream, const Box &b) {
     stream << "{";
     for (size_t dim = 0; dim < b.size(); dim++) {

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -49,6 +49,11 @@ int static_sign(const Expr &x) {
 }
 }  // anonymous namespace
 
+const FuncValueBounds &empty_func_value_bounds() {
+    static FuncValueBounds empty;
+    return empty;
+}
+
 Expr find_constant_bound(const Expr &e, Direction d, const Scope<Interval> &scope) {
     Interval interval = find_constant_bounds(e, scope);
     Expr bound;
@@ -71,6 +76,18 @@ Interval find_constant_bounds(const Expr &e, const Scope<Interval> &scope) {
     if (!is_const(interval.max)) interval.max = Interval::pos_inf();
 
     return interval;
+}
+
+std::ostream &operator<<(std::ostream &stream, const Box &b) {
+    stream << "{";
+    for (size_t dim = 0; dim < b.size(); dim++) {
+        if (dim > 0) {
+            stream << ", ";
+        }
+        stream << "[" << b[dim].min << ", " << b[dim].max << "]";
+    }
+    stream << "}";
+    return stream;
 }
 
 class Bounds : public IRVisitor {

--- a/src/Bounds.h
+++ b/src/Bounds.h
@@ -17,6 +17,8 @@ class Function;
 
 typedef std::map<std::pair<std::string, int>, Interval> FuncValueBounds;
 
+const FuncValueBounds &empty_func_value_bounds();
+
 /** Given an expression in some variables, and a map from those
  * variables to their bounds (in the form of (minimum possible value,
  * maximum possible value)), compute two expressions that give the
@@ -31,7 +33,7 @@ typedef std::map<std::pair<std::string, int>, Interval> FuncValueBounds;
  */
 Interval bounds_of_expr_in_scope(const Expr &expr,
                                  const Scope<Interval> &scope,
-                                 const FuncValueBounds &func_bounds = FuncValueBounds(),
+                                 const FuncValueBounds &func_bounds = empty_func_value_bounds(),
                                  bool const_bound = false);
 
 /** Given a varying expression, try to find a constant that is either:
@@ -41,7 +43,7 @@ Interval bounds_of_expr_in_scope(const Expr &expr,
 enum class Direction { Upper,
                        Lower };
 Expr find_constant_bound(const Expr &e, Direction d,
-                         const Scope<Interval> &scope = Scope<Interval>());
+                         const Scope<Interval> &scope = Scope<Interval>::empty_scope());
 
 /** Find bounds for a varying expression that are either constants or
  * +/-inf. */
@@ -57,10 +59,10 @@ struct Box {
     std::vector<Interval> bounds;
 
     Box() = default;
-    Box(size_t sz)
+    explicit Box(size_t sz)
         : bounds(sz) {
     }
-    Box(const std::vector<Interval> &b)
+    explicit Box(const std::vector<Interval> &b)
         : bounds(b) {
     }
 
@@ -88,17 +90,7 @@ struct Box {
         return used.defined() && !is_one(used);
     }
 
-    friend std::ostream &operator<<(std::ostream &stream, const Box &b) {
-        stream << "{";
-        for (size_t dim = 0; dim < b.size(); dim++) {
-            if (dim > 0) {
-                stream << ", ";
-            }
-            stream << "[" << b[dim].min << ", " << b[dim].max << "]";
-        }
-        stream << "}";
-        return stream;
-    }
+    friend std::ostream &operator<<(std::ostream &stream, const Box &b);
 };
 
 /** Expand box a to encompass box b */
@@ -123,10 +115,10 @@ bool box_contains(const Box &a, const Box &b);
 // @{
 std::map<std::string, Box> boxes_required(const Expr &e,
                                           const Scope<Interval> &scope = Scope<Interval>::empty_scope(),
-                                          const FuncValueBounds &func_bounds = FuncValueBounds());
+                                          const FuncValueBounds &func_bounds = empty_func_value_bounds());
 std::map<std::string, Box> boxes_required(Stmt s,
                                           const Scope<Interval> &scope = Scope<Interval>::empty_scope(),
-                                          const FuncValueBounds &func_bounds = FuncValueBounds());
+                                          const FuncValueBounds &func_bounds = empty_func_value_bounds());
 // @}
 
 /** Compute rectangular domains large enough to cover all the
@@ -135,10 +127,10 @@ std::map<std::string, Box> boxes_required(Stmt s,
 // @{
 std::map<std::string, Box> boxes_provided(const Expr &e,
                                           const Scope<Interval> &scope = Scope<Interval>::empty_scope(),
-                                          const FuncValueBounds &func_bounds = FuncValueBounds());
+                                          const FuncValueBounds &func_bounds = empty_func_value_bounds());
 std::map<std::string, Box> boxes_provided(Stmt s,
                                           const Scope<Interval> &scope = Scope<Interval>::empty_scope(),
-                                          const FuncValueBounds &func_bounds = FuncValueBounds());
+                                          const FuncValueBounds &func_bounds = empty_func_value_bounds());
 // @}
 
 /** Compute rectangular domains large enough to cover all the 'Call's
@@ -147,34 +139,34 @@ std::map<std::string, Box> boxes_provided(Stmt s,
 // @{
 std::map<std::string, Box> boxes_touched(const Expr &e,
                                          const Scope<Interval> &scope = Scope<Interval>::empty_scope(),
-                                         const FuncValueBounds &func_bounds = FuncValueBounds());
+                                         const FuncValueBounds &func_bounds = empty_func_value_bounds());
 std::map<std::string, Box> boxes_touched(Stmt s,
                                          const Scope<Interval> &scope = Scope<Interval>::empty_scope(),
-                                         const FuncValueBounds &func_bounds = FuncValueBounds());
+                                         const FuncValueBounds &func_bounds = empty_func_value_bounds());
 // @}
 
 /** Variants of the above that are only concerned with a single function. */
 // @{
 Box box_required(const Expr &e, const std::string &fn,
                  const Scope<Interval> &scope = Scope<Interval>::empty_scope(),
-                 const FuncValueBounds &func_bounds = FuncValueBounds());
+                 const FuncValueBounds &func_bounds = empty_func_value_bounds());
 Box box_required(Stmt s, const std::string &fn,
                  const Scope<Interval> &scope = Scope<Interval>::empty_scope(),
-                 const FuncValueBounds &func_bounds = FuncValueBounds());
+                 const FuncValueBounds &func_bounds = empty_func_value_bounds());
 
 Box box_provided(const Expr &e, const std::string &fn,
                  const Scope<Interval> &scope = Scope<Interval>::empty_scope(),
-                 const FuncValueBounds &func_bounds = FuncValueBounds());
+                 const FuncValueBounds &func_bounds = empty_func_value_bounds());
 Box box_provided(Stmt s, const std::string &fn,
                  const Scope<Interval> &scope = Scope<Interval>::empty_scope(),
-                 const FuncValueBounds &func_bounds = FuncValueBounds());
+                 const FuncValueBounds &func_bounds = empty_func_value_bounds());
 
 Box box_touched(const Expr &e, const std::string &fn,
                 const Scope<Interval> &scope = Scope<Interval>::empty_scope(),
-                const FuncValueBounds &func_bounds = FuncValueBounds());
+                const FuncValueBounds &func_bounds = empty_func_value_bounds());
 Box box_touched(Stmt s, const std::string &fn,
                 const Scope<Interval> &scope = Scope<Interval>::empty_scope(),
-                const FuncValueBounds &func_bounds = FuncValueBounds());
+                const FuncValueBounds &func_bounds = empty_func_value_bounds());
 // @}
 
 /** Compute the maximum and minimum possible value for each function

--- a/src/Bounds.h
+++ b/src/Bounds.h
@@ -6,7 +6,6 @@
  * and the regions of a function read or written by a statement.
  */
 
-#include "IROperator.h"
 #include "Interval.h"
 #include "Scope.h"
 
@@ -86,9 +85,7 @@ struct Box {
     }
 
     /** Check if the used condition is defined and not trivially true. */
-    bool maybe_unused() const {
-        return used.defined() && !is_one(used);
-    }
+    bool maybe_unused() const;
 
     friend std::ostream &operator<<(std::ostream &stream, const Box &b);
 };

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -7,6 +7,7 @@
 #include "ExprUsesVar.h"
 #include "Function.h"
 #include "IRMutator.h"
+#include "IROperator.h"
 #include "Prefetch.h"
 #include "Scope.h"
 #include "Simplify.h"

--- a/src/RegionCosts.cpp
+++ b/src/RegionCosts.cpp
@@ -2,6 +2,7 @@
 #include "FindCalls.h"
 #include "Function.h"
 #include "IRMutator.h"
+#include "IROperator.h"
 #include "IRVisitor.h"
 #include "PartitionLoops.h"
 #include "RealizationOrder.h"

--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -2,6 +2,7 @@
 #include "Bounds.h"
 #include "Function.h"
 #include "IRMutator.h"
+#include "IROperator.h"
 
 namespace Halide {
 namespace Internal {


### PR DESCRIPTION
Add `empty_func_value_bounds()` instead of default-constructing; this reduces libHalide.so on x86-64-linux by about 4k. (Hey, I said it was tiny.)

Also, drive-by cleanup in Bounds.h.