### PR TITLE
Move most Interval method bodies to the .cpp file

### DIFF
--- a/src/Interval.cpp
+++ b/src/Interval.cpp
@@ -65,15 +65,6 @@ Expr make_min_helper(const Expr &a, const Expr &b) {
 
 }  // namespace
 
-Interval::Interval()
-    : min(neg_inf()), max(pos_inf()) {
-}
-
-Interval::Interval(const Expr &min, const Expr &max)
-    : min(min), max(max) {
-    internal_assert(min.defined() && max.defined());
-}
-
 Interval Interval::everything() {
     return Interval(neg_inf(), pos_inf());
 }

--- a/src/Interval.cpp
+++ b/src/Interval.cpp
@@ -65,6 +65,63 @@ Expr make_min_helper(const Expr &a, const Expr &b) {
 
 }  // namespace
 
+Interval::Interval()
+    : min(neg_inf()), max(pos_inf()) {
+}
+
+Interval::Interval(const Expr &min, const Expr &max)
+    : min(min), max(max) {
+    internal_assert(min.defined() && max.defined());
+}
+
+Interval Interval::everything() {
+    return Interval(neg_inf(), pos_inf());
+}
+
+Interval Interval::nothing() {
+    return Interval(pos_inf(), neg_inf());
+}
+
+Interval Interval::single_point(const Expr &e) {
+    return Interval(e, e);
+}
+
+bool Interval::is_empty() const {
+    return min.same_as(pos_inf()) || max.same_as(neg_inf());
+}
+
+bool Interval::is_everything() const {
+    return min.same_as(neg_inf()) && max.same_as(pos_inf());
+}
+
+bool Interval::is_single_point() const {
+    return min.same_as(max);
+}
+
+bool Interval::is_single_point(const Expr &e) const {
+    return min.same_as(e) && max.same_as(e);
+}
+
+bool Interval::has_upper_bound() const {
+    return !max.same_as(pos_inf()) && !is_empty();
+}
+
+bool Interval::has_lower_bound() const {
+    return !min.same_as(neg_inf()) && !is_empty();
+}
+
+bool Interval::is_bounded() const {
+    return has_upper_bound() && has_lower_bound();
+}
+
+bool Interval::same_as(const Interval &other) const {
+    return min.same_as(other.min) && max.same_as(other.max);
+}
+
+bool Interval::operator==(const Interval &other) const {
+    return (min.same_as(other.min)) && (max.same_as(other.max));
+}
+
 // This is called repeatedly by bounds inference and the solver to
 // build large expressions, so we want to simplify eagerly to avoid
 // monster expressions.

--- a/src/Interval.h
+++ b/src/Interval.h
@@ -35,70 +35,43 @@ struct Interval {
     Expr min, max;
 
     /** A default-constructed Interval is everything */
-    Interval()
-        : min(neg_inf()), max(pos_inf()) {
-    }
+    Interval();
 
     /** Construct an interval from a lower and upper bound. */
-    Interval(const Expr &min, const Expr &max)
-        : min(min), max(max) {
-        internal_assert(min.defined() && max.defined());
-    }
+    Interval(const Expr &min, const Expr &max);
 
     /** The interval representing everything. */
-    static Interval everything() {
-        return Interval(neg_inf(), pos_inf());
-    }
+    static Interval everything();
 
     /** The interval representing nothing. */
-    static Interval nothing() {
-        return Interval(pos_inf(), neg_inf());
-    }
+    static Interval nothing();
 
     /** Construct an interval representing a single point */
-    static Interval single_point(const Expr &e) {
-        return Interval(e, e);
-    }
+    static Interval single_point(const Expr &e);
 
     /** Is the interval the empty set */
-    bool is_empty() const {
-        return min.same_as(pos_inf()) || max.same_as(neg_inf());
-    }
+    bool is_empty() const;
 
     /** Is the interval the entire range */
-    bool is_everything() const {
-        return min.same_as(neg_inf()) && max.same_as(pos_inf());
-    }
+    bool is_everything() const;
 
     /** Is the interval just a single value (min == max) */
-    bool is_single_point() const {
-        return min.same_as(max);
-    }
+    bool is_single_point() const;
 
     /** Is the interval a particular single value */
-    bool is_single_point(const Expr &e) const {
-        return min.same_as(e) && max.same_as(e);
-    }
+    bool is_single_point(const Expr &e) const;
 
     /** Does the interval have a finite least upper bound */
-    bool has_upper_bound() const {
-        return !max.same_as(pos_inf()) && !is_empty();
-    }
+    bool has_upper_bound() const;
 
     /** Does the interval have a finite greatest lower bound */
-    bool has_lower_bound() const {
-        return !min.same_as(neg_inf()) && !is_empty();
-    }
+    bool has_lower_bound() const;
 
     /** Does the interval have a finite upper and lower bound */
-    bool is_bounded() const {
-        return has_upper_bound() && has_lower_bound();
-    }
+    bool is_bounded() const;
 
     /** Is the interval the same as another interval */
-    bool same_as(const Interval &other) {
-        return min.same_as(other.min) && max.same_as(other.max);
-    }
+    bool same_as(const Interval &other) const;
 
     /** Expand the interval to include another Interval */
     void include(const Interval &i);
@@ -118,9 +91,7 @@ struct Interval {
     /** An eagerly-simplifying min of two Exprs that respects infinities. */
     static Expr make_min(const Expr &a, const Expr &b);
 
-    bool operator==(const Interval &other) const {
-        return (min.same_as(other.min)) && (max.same_as(other.max));
-    }
+    bool operator==(const Interval &other) const;
 
 private:
     static Expr neg_inf_expr, pos_inf_expr;

--- a/src/Interval.h
+++ b/src/Interval.h
@@ -96,6 +96,9 @@ struct Interval {
     /** An eagerly-simplifying min of two Exprs that respects infinities. */
     static Expr make_min(const Expr &a, const Expr &b);
 
+    /** Equivalent to same_as. Exists so that the autoscheduler can
+     * compare two map<string, Interval> for equality in order to
+     * cache computations. */
     bool operator==(const Interval &other) const;
 
 private:

--- a/src/Interval.h
+++ b/src/Interval.h
@@ -35,10 +35,15 @@ struct Interval {
     Expr min, max;
 
     /** A default-constructed Interval is everything */
-    Interval();
+    Interval()
+        : min(neg_inf()), max(pos_inf()) {
+    }
 
     /** Construct an interval from a lower and upper bound. */
-    Interval(const Expr &min, const Expr &max);
+    Interval(const Expr &min, const Expr &max)
+        : min(min), max(max) {
+        internal_assert(min.defined() && max.defined());
+    }
 
     /** The interval representing everything. */
     static Interval everything();


### PR DESCRIPTION
Saves ~12k from libHalide.so on x86-64-linux; timing on local_laplacian.generator doesn't show any performance impact.