### PR TITLE
Move DeviceAPI into its own header file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -656,6 +656,7 @@ HEADER_FILES = \
   Deinterleave.h \
   Derivative.h \
   DerivativeUtils.h \
+  DeviceAPI.h \
   DeviceArgument.h \
   DeviceInterface.h \
   Dimension.h \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -331,6 +331,7 @@ set(HEADER_FILES
   Deinterleave.h
   Derivative.h
   DerivativeUtils.h
+  DeviceAPI.h
   DeviceArgument.h
   DeviceInterface.h
   Dimension.h

--- a/src/DeviceAPI.h
+++ b/src/DeviceAPI.h
@@ -1,0 +1,45 @@
+#ifndef HALIDE_DEVICEAPI_H
+#define HALIDE_DEVICEAPI_H
+
+/** \file
+ * Defines DeviceAPI.
+ */
+
+#include <string>
+#include <vector>
+
+namespace Halide {
+
+/** An enum describing a type of device API. Used by schedules, and in
+ * the For loop IR node. */
+enum class DeviceAPI {
+    None,  /// Used to denote for loops that run on the same device as the containing code.
+    Host,
+    Default_GPU,
+    CUDA,
+    OpenCL,
+    GLSL,
+    OpenGLCompute,
+    Metal,
+    Hexagon,
+    HexagonDma,
+    D3D12Compute,
+};
+
+/** An array containing all the device apis. Useful for iterating
+ * through them. */
+const DeviceAPI all_device_apis[] = {DeviceAPI::None,
+                                     DeviceAPI::Host,
+                                     DeviceAPI::Default_GPU,
+                                     DeviceAPI::CUDA,
+                                     DeviceAPI::OpenCL,
+                                     DeviceAPI::GLSL,
+                                     DeviceAPI::OpenGLCompute,
+                                     DeviceAPI::Metal,
+                                     DeviceAPI::Hexagon,
+                                     DeviceAPI::HexagonDma,
+                                     DeviceAPI::D3D12Compute};
+
+}  // namespace Halide
+
+#endif  // HALIDE_DEVICEAPI_H

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -336,36 +336,6 @@ struct Range {
 /** A multi-dimensional box. The outer product of the elements */
 typedef std::vector<Range> Region;
 
-/** An enum describing a type of device API. Used by schedules, and in
- * the For loop IR node. */
-enum class DeviceAPI {
-    None,  /// Used to denote for loops that run on the same device as the containing code.
-    Host,
-    Default_GPU,
-    CUDA,
-    OpenCL,
-    GLSL,
-    OpenGLCompute,
-    Metal,
-    Hexagon,
-    HexagonDma,
-    D3D12Compute,
-};
-
-/** An array containing all the device apis. Useful for iterating
- * through them. */
-const DeviceAPI all_device_apis[] = {DeviceAPI::None,
-                                     DeviceAPI::Host,
-                                     DeviceAPI::Default_GPU,
-                                     DeviceAPI::CUDA,
-                                     DeviceAPI::OpenCL,
-                                     DeviceAPI::GLSL,
-                                     DeviceAPI::OpenGLCompute,
-                                     DeviceAPI::Metal,
-                                     DeviceAPI::Hexagon,
-                                     DeviceAPI::HexagonDma,
-                                     DeviceAPI::D3D12Compute};
-
 /** An enum describing different address spaces to be used with Func::store_in. */
 enum class MemoryType {
     /** Let Halide select a storage type automatically */

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "DeviceAPI.h"
 #include "Expr.h"
 #include "FunctionPtr.h"
 #include "Parameter.h"

--- a/src/Target.h
+++ b/src/Target.h
@@ -9,8 +9,7 @@
 #include <stdint.h>
 #include <string>
 
-#include "Error.h"
-#include "Expr.h"
+#include "DeviceAPI.h"
 #include "Type.h"
 #include "runtime/HalideRuntime.h"
 


### PR DESCRIPTION
Nothing in Expr.h needs it, and at least one of the few users (Target.h) didn't need anything else in Expr.h.