### PR TITLE
Reduce number of copies in Scope::push

### DIFF
--- a/src/Scope.h
+++ b/src/Scope.h
@@ -35,16 +35,16 @@ public:
             _empty = true;
             _top = T();
         } else {
-            _top = _rest.back();
+            std::swap(_top, _rest.back());
             _rest.pop_back();
         }
     }
 
-    void push(const T &t) {
+    void push(T t) {
         if (!_empty) {
             _rest.push_back(std::move(_top));
         }
-        _top = t;
+        _top = std::move(t);
         _empty = false;
     }
 
@@ -178,8 +178,8 @@ public:
      */
     template<typename T2 = T,
              typename = typename std::enable_if<!std::is_same<T2, void>::value>::type>
-    void push(const std::string &name, const T2 &value) {
-        table[name].push(value);
+    void push(const std::string &name, T2 &&value) {
+        table[name].push(std::forward<T2>(value));
     }
 
     template<typename T2 = T,
@@ -276,9 +276,9 @@ struct ScopedBinding {
 
     ScopedBinding() = default;
 
-    ScopedBinding(Scope<T> &s, const std::string &n, const T &value)
+    ScopedBinding(Scope<T> &s, const std::string &n, T value)
         : scope(&s), name(n) {
-        scope->push(name, value);
+        scope->push(name, std::move(value));
     }
 
     ScopedBinding(bool condition, Scope<T> &s, const std::string &n, const T &value)

--- a/src/Scope.h
+++ b/src/Scope.h
@@ -118,8 +118,8 @@ public:
      * arguments, which would otherwise require a copy constructor
      * (with llvm in c++98 mode) */
     static const Scope<T> &empty_scope() {
-        static Scope<T> *_empty_scope = new Scope<T>();
-        return *_empty_scope;
+        static Scope<T> _empty_scope;
+        return _empty_scope;
     }
 
     /** Retrieve the value referred to by a name */

--- a/src/Scope.h
+++ b/src/Scope.h
@@ -35,7 +35,7 @@ public:
             _empty = true;
             _top = T();
         } else {
-            std::swap(_top, _rest.back());
+            _top = std::move(_rest.back());
             _rest.pop_back();
         }
     }


### PR DESCRIPTION
pushing something onto a scope currently copies it. If we accept rvals appropriately then we can avoid those copies when pushing an rval (e.g. scope.push(name, expr_a + expr_b))

This also makes it possible to use scopes with non-copyable types as values. 

Speeds up lowering about half a percent on local laplacian. Increases the size of libHalide by two pages (8k), so I guess the speed-up is due to inlining.