### PR TITLE
Tweak to ParamMap API

### DIFF
--- a/src/ParamMap.cpp
+++ b/src/ParamMap.cpp
@@ -17,7 +17,7 @@ ParamMap::ParamMap(const std::initializer_list<ParamMapping> &init) {
     }
 }
 
-void ParamMap::set(const ImageParam &p, Buffer<> &buf, Buffer<> *buf_out_param) {
+void ParamMap::set(const ImageParam &p, const Buffer<> &buf, Buffer<> *buf_out_param) {
     Internal::Parameter v(p.type(), true, p.dimensions(), p.name());
     v.set_buffer(buf);
     ParamArg pa;

--- a/src/ParamMap.h
+++ b/src/ParamMap.h
@@ -68,7 +68,7 @@ private:
     };
     mutable std::map<const Internal::Parameter, ParamArg> mapping;
 
-    void set(const ImageParam &p, Buffer<> &buf, Buffer<> *buf_out_param);
+    void set(const ImageParam &p, const Buffer<> &buf, Buffer<> *buf_out_param);
 
 public:
     ParamMap() {
@@ -86,14 +86,8 @@ public:
         mapping[p.parameter()] = pa;
     };
 
-    void set(const ImageParam &p, Buffer<> &buf) {
+    void set(const ImageParam &p, const Buffer<> &buf) {
         set(p, buf, nullptr);
-    }
-
-    template<typename T>
-    void set(const ImageParam &p, Buffer<T> &buf) {
-        Buffer<> temp = buf;
-        set(p, temp, nullptr);
     }
 
     size_t size() const {


### PR DESCRIPTION
This is minor, but I'm not sure of correctness, so I want it considered separate from some other changes I want to make:

The set() methods don't appear to need a non-const-ref to the buffer; AFAICT the only thing they do with it is pass it to Parameter::set_buffer(), which takes a const-ref to Buffer... which then internally just copies it.

Changing to const-ref allows us to stop implying there's a possible change in-pace to the buffer (which there never was) and remove the templated overload (since Buffer<T> -> Buffer<void> automatically for const ref).
