### PR TITLE
Fix visibility in Pipeline.h

### DIFF
--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -136,9 +136,8 @@ public:
         }
     };
 
+private:
     Internal::IntrusivePtr<PipelineContents> contents;
-
-    std::vector<Argument> infer_arguments(const Internal::Stmt &body);
 
     struct JITCallArgs;  // Opaque structure to optimize away dynamic allocation in this path.
 
@@ -171,6 +170,8 @@ public:
     /** Make a pipeline that computes the givens Funcs as
      * outputs. Schedules the Funcs compute_root(). */
     Pipeline(const std::vector<Func> &outputs);
+
+    std::vector<Argument> infer_arguments(const Internal::Stmt &body);
 
     /** Get the Funcs this pipeline outputs. */
     std::vector<Func> outputs() const;


### PR DESCRIPTION
Stuff that should have been private was public. Not sure how or why.