### PR TITLE
Require that rewrite rules are in canonical form

### DIFF
--- a/src/Expr.h
+++ b/src/Expr.h
@@ -23,7 +23,10 @@ class IRVisitor;
 
 /** All our IR node types get unique IDs for the purposes of RTTI */
 enum class IRNodeType {
-    // Exprs, in order of strength
+    // Exprs, in order of strength. Code in IRMatch.h and the
+    // simplifier relies on this order for canonicalization of
+    // expressions, so you may need to update those modules if you
+    // change this list.
     IntImm,
     UIntImm,
     FloatImm,
@@ -71,6 +74,8 @@ enum class IRNodeType {
     Prefetch,
     Atomic
 };
+
+constexpr IRNodeType StrongestExprNodeType = IRNodeType::Shuffle;
 
 /** The abstract base classes for a node in the Halide IR. */
 struct IRNode {

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -443,7 +443,7 @@ struct Wild {
     constexpr static uint32_t binds = 1 << (i + 16);
 
     constexpr static IRNodeType min_node_type = IRNodeType::IntImm;
-    constexpr static IRNodeType max_node_type = IRNodeType::Shuffle;
+    constexpr static IRNodeType max_node_type = StrongestExprNodeType;
     constexpr static bool canonical = true;
 
     template<uint32_t bound>
@@ -1829,6 +1829,8 @@ struct Overflows {
 
     constexpr static uint32_t binds = bindings<A>::mask;
 
+    // This rule is a predicate, so it always evaluates to a boolean,
+    // which has IRNodeType UIntImm
     constexpr static IRNodeType min_node_type = IRNodeType::UIntImm;
     constexpr static IRNodeType max_node_type = IRNodeType::UIntImm;
     constexpr static bool canonical = true;
@@ -1861,6 +1863,7 @@ struct Overflow {
 
     constexpr static uint32_t binds = 0;
 
+    // Overflow is an intrinsic, represented as a Call node
     constexpr static IRNodeType min_node_type = IRNodeType::Call;
     constexpr static IRNodeType max_node_type = IRNodeType::Call;
     constexpr static bool canonical = true;
@@ -1900,6 +1903,7 @@ struct IsConst {
 
     constexpr static uint32_t binds = bindings<A>::mask;
 
+    // This rule is a boolean-valued predicate. Bools have type UIntImm.
     constexpr static IRNodeType min_node_type = IRNodeType::UIntImm;
     constexpr static IRNodeType max_node_type = IRNodeType::UIntImm;
     constexpr static bool canonical = true;
@@ -1937,6 +1941,7 @@ struct CanProve {
 
     constexpr static uint32_t binds = bindings<A>::mask;
 
+    // This rule is a boolean-valued predicate. Bools have type UIntImm.
     constexpr static IRNodeType min_node_type = IRNodeType::UIntImm;
     constexpr static IRNodeType max_node_type = IRNodeType::UIntImm;
     constexpr static bool canonical = true;
@@ -1972,6 +1977,7 @@ struct IsFloat {
 
     constexpr static uint32_t binds = bindings<A>::mask;
 
+    // This rule is a boolean-valued predicate. Bools have type UIntImm.
     constexpr static IRNodeType min_node_type = IRNodeType::UIntImm;
     constexpr static IRNodeType max_node_type = IRNodeType::UIntImm;
     constexpr static bool canonical = true;

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -199,6 +199,11 @@ struct SpecificExpr {
 
     constexpr static uint32_t binds = 0;
 
+    // What is the weakest and strongest IR node this could possibly be
+    constexpr static IRNodeType min_node_type = IRNodeType::IntImm;
+    constexpr static IRNodeType max_node_type = IRNodeType::Shuffle;
+    constexpr static bool canonical = true;
+
     Expr expr;
 
     template<uint32_t bound>
@@ -224,6 +229,10 @@ struct WildConstInt {
     struct pattern_tag {};
 
     constexpr static uint32_t binds = 1 << i;
+
+    constexpr static IRNodeType min_node_type = IRNodeType::IntImm;
+    constexpr static IRNodeType max_node_type = IRNodeType::IntImm;
+    constexpr static bool canonical = true;
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
@@ -274,6 +283,10 @@ struct WildConstUInt {
 
     constexpr static uint32_t binds = 1 << i;
 
+    constexpr static IRNodeType min_node_type = IRNodeType::UIntImm;
+    constexpr static IRNodeType max_node_type = IRNodeType::UIntImm;
+    constexpr static bool canonical = true;
+
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
         static_assert(i >= 0 && i < max_wild, "Wild with out-of-range index");
@@ -322,6 +335,10 @@ struct WildConstFloat {
     struct pattern_tag {};
 
     constexpr static uint32_t binds = 1 << i;
+
+    constexpr static IRNodeType min_node_type = IRNodeType::FloatImm;
+    constexpr static IRNodeType max_node_type = IRNodeType::FloatImm;
+    constexpr static bool canonical = true;
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
@@ -373,6 +390,10 @@ struct WildConst {
 
     constexpr static uint32_t binds = 1 << i;
 
+    constexpr static IRNodeType min_node_type = IRNodeType::IntImm;
+    constexpr static IRNodeType max_node_type = IRNodeType::FloatImm;
+    constexpr static bool canonical = true;
+
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
         static_assert(i >= 0 && i < max_wild, "Wild with out-of-range index");
@@ -420,6 +441,10 @@ struct Wild {
     struct pattern_tag {};
 
     constexpr static uint32_t binds = 1 << (i + 16);
+
+    constexpr static IRNodeType min_node_type = IRNodeType::IntImm;
+    constexpr static IRNodeType max_node_type = IRNodeType::Shuffle;
+    constexpr static bool canonical = true;
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
@@ -474,6 +499,10 @@ struct Const {
     int64_t v;
 
     constexpr static uint32_t binds = 0;
+
+    constexpr static IRNodeType min_node_type = IRNodeType::IntImm;
+    constexpr static IRNodeType max_node_type = IRNodeType::FloatImm;
+    constexpr static bool canonical = true;
 
     HALIDE_ALWAYS_INLINE
     Const(int64_t v)
@@ -577,6 +606,44 @@ uint64_t constant_fold_bin_op(halide_type_t &, uint64_t, uint64_t) noexcept;
 template<typename Op>
 double constant_fold_bin_op(halide_type_t &, double, double) noexcept;
 
+template<typename T>
+constexpr bool commutative() {
+    return false;
+}
+
+template<>
+constexpr bool commutative<Add>() {
+    return true;
+}
+template<>
+constexpr bool commutative<Mul>() {
+    return true;
+}
+template<>
+constexpr bool commutative<And>() {
+    return true;
+}
+template<>
+constexpr bool commutative<Or>() {
+    return true;
+}
+template<>
+constexpr bool commutative<EQ>() {
+    return true;
+}
+template<>
+constexpr bool commutative<NE>() {
+    return true;
+}
+template<>
+constexpr bool commutative<Min>() {
+    return true;
+}
+template<>
+constexpr bool commutative<Max>() {
+    return true;
+}
+
 // Matches one of the binary operators
 template<typename Op, typename A, typename B>
 struct BinOp {
@@ -585,6 +652,15 @@ struct BinOp {
     B b;
 
     constexpr static uint32_t binds = bindings<A>::mask | bindings<B>::mask;
+
+    constexpr static IRNodeType min_node_type = Op::_node_type;
+    constexpr static IRNodeType max_node_type = Op::_node_type;
+
+    // For commutative bin ops, we expect the weaker IR node type on
+    // the right. That is, for the rule to be canonical it must be
+    // possible that A is at least as strong as B.
+    constexpr static bool canonical =
+        A::canonical && B::canonical && (!commutative<Op>() || (A::max_node_type >= B::min_node_type));
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
@@ -687,6 +763,14 @@ struct CmpOp {
     B b;
 
     constexpr static uint32_t binds = bindings<A>::mask | bindings<B>::mask;
+
+    constexpr static IRNodeType min_node_type = Op::_node_type;
+    constexpr static IRNodeType max_node_type = Op::_node_type;
+    constexpr static bool canonical = (A::canonical &&
+                                       B::canonical &&
+                                       (!commutative<Op>() || A::max_node_type >= B::min_node_type) &&
+                                       (Op::_node_type != IRNodeType::GE) &&
+                                       (Op::_node_type != IRNodeType::GT));
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
@@ -1242,6 +1326,15 @@ constexpr uint32_t bitwise_or_reduce(uint32_t first, Args... rest) {
     return first | bitwise_or_reduce(rest...);
 }
 
+constexpr inline bool and_reduce() {
+    return true;
+}
+
+template<typename... Args>
+constexpr bool and_reduce(bool first, Args... rest) {
+    return first && and_reduce(rest...);
+}
+
 template<typename... Args>
 struct Intrin {
     struct pattern_tag {};
@@ -1249,6 +1342,10 @@ struct Intrin {
     std::tuple<Args...> args;
 
     static constexpr uint32_t binds = bitwise_or_reduce((bindings<Args>::mask)...);
+
+    constexpr static IRNodeType min_node_type = IRNodeType::Call;
+    constexpr static IRNodeType max_node_type = IRNodeType::Call;
+    constexpr static bool canonical = and_reduce((Args::canonical)...);
 
     template<int i,
              uint32_t bound,
@@ -1331,6 +1428,10 @@ struct NotOp {
 
     constexpr static uint32_t binds = bindings<A>::mask;
 
+    constexpr static IRNodeType min_node_type = IRNodeType::Not;
+    constexpr static IRNodeType max_node_type = IRNodeType::Not;
+    constexpr static bool canonical = A::canonical;
+
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
         if (e.node_type != IRNodeType::Not) {
@@ -1384,6 +1485,11 @@ struct SelectOp {
     F f;
 
     constexpr static uint32_t binds = bindings<C>::mask | bindings<T>::mask | bindings<F>::mask;
+
+    constexpr static IRNodeType min_node_type = IRNodeType::Select;
+    constexpr static IRNodeType max_node_type = IRNodeType::Select;
+
+    constexpr static bool canonical = C::canonical && T::canonical && F::canonical;
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
@@ -1441,6 +1547,11 @@ struct BroadcastOp {
     int lanes;
 
     constexpr static uint32_t binds = bindings<A>::mask;
+
+    constexpr static IRNodeType min_node_type = IRNodeType::Broadcast;
+    constexpr static IRNodeType max_node_type = IRNodeType::Broadcast;
+
+    constexpr static bool canonical = A::canonical;
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
@@ -1507,6 +1618,11 @@ struct RampOp {
     int lanes;
 
     constexpr static uint32_t binds = bindings<A>::mask | bindings<B>::mask;
+
+    constexpr static IRNodeType min_node_type = IRNodeType::Ramp;
+    constexpr static IRNodeType max_node_type = IRNodeType::Ramp;
+
+    constexpr static bool canonical = A::canonical && B::canonical;
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
@@ -1576,6 +1692,11 @@ struct NegateOp {
     A a;
 
     constexpr static uint32_t binds = bindings<A>::mask;
+
+    constexpr static IRNodeType min_node_type = IRNodeType::Sub;
+    constexpr static IRNodeType max_node_type = IRNodeType::Sub;
+
+    constexpr static bool canonical = A::canonical;
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
@@ -1653,6 +1774,10 @@ struct CastOp {
 
     constexpr static uint32_t binds = bindings<A>::mask;
 
+    constexpr static IRNodeType min_node_type = IRNodeType::Cast;
+    constexpr static IRNodeType max_node_type = IRNodeType::Cast;
+    constexpr static bool canonical = A::canonical;
+
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
         if (e.node_type != Cast::_node_type) {
@@ -1693,6 +1818,10 @@ struct Fold {
 
     constexpr static uint32_t binds = bindings<A>::mask;
 
+    constexpr static IRNodeType min_node_type = IRNodeType::IntImm;
+    constexpr static IRNodeType max_node_type = IRNodeType::FloatImm;
+    constexpr static bool canonical = true;
+
     HALIDE_ALWAYS_INLINE
     Expr make(MatcherState &state, halide_type_t type_hint) const noexcept {
         halide_scalar_value_t c;
@@ -1727,6 +1856,10 @@ struct Overflows {
 
     constexpr static uint32_t binds = bindings<A>::mask;
 
+    constexpr static IRNodeType min_node_type = IRNodeType::UIntImm;
+    constexpr static IRNodeType max_node_type = IRNodeType::UIntImm;
+    constexpr static bool canonical = true;
+
     constexpr static bool foldable = A::foldable;
 
     template<typename A1 = A>
@@ -1754,6 +1887,10 @@ struct Overflow {
     struct pattern_tag {};
 
     constexpr static uint32_t binds = 0;
+
+    constexpr static IRNodeType min_node_type = IRNodeType::Call;
+    constexpr static IRNodeType max_node_type = IRNodeType::Call;
+    constexpr static bool canonical = true;
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
@@ -1790,6 +1927,10 @@ struct IsConst {
 
     constexpr static uint32_t binds = bindings<A>::mask;
 
+    constexpr static IRNodeType min_node_type = IRNodeType::UIntImm;
+    constexpr static IRNodeType max_node_type = IRNodeType::UIntImm;
+    constexpr static bool canonical = true;
+
     A a;
 
     constexpr static bool foldable = true;
@@ -1823,6 +1964,10 @@ struct CanProve {
 
     constexpr static uint32_t binds = bindings<A>::mask;
 
+    constexpr static IRNodeType min_node_type = IRNodeType::UIntImm;
+    constexpr static IRNodeType max_node_type = IRNodeType::UIntImm;
+    constexpr static bool canonical = true;
+
     constexpr static bool foldable = true;
 
     // Includes a raw call to an inlined make method, so don't inline.
@@ -1853,6 +1998,10 @@ struct IsFloat {
     A a;
 
     constexpr static uint32_t binds = bindings<A>::mask;
+
+    constexpr static IRNodeType min_node_type = IRNodeType::UIntImm;
+    constexpr static IRNodeType max_node_type = IRNodeType::UIntImm;
+    constexpr static bool canonical = true;
 
     constexpr static bool foldable = true;
 
@@ -2059,6 +2208,8 @@ struct Rewriter {
              typename = typename enable_if_pattern<After>::type>
     HALIDE_ALWAYS_INLINE bool operator()(Before before, After after) {
         static_assert((Before::binds & After::binds) == After::binds, "Rule result uses unbound values");
+        static_assert(Before::canonical, "LHS of rewrite rule should be in canonical form");
+        static_assert(After::canonical, "RHS of rewrite rule should be in canonical form");
 #if HALIDE_FUZZ_TEST_RULES
         fuzz_test_rule(before, after, true, wildcard_type, output_type);
 #endif
@@ -2079,6 +2230,7 @@ struct Rewriter {
     template<typename Before,
              typename = typename enable_if_pattern<Before>::type>
     HALIDE_ALWAYS_INLINE bool operator()(Before before, const Expr &after) noexcept {
+        static_assert(Before::canonical, "LHS of rewrite rule should be in canonical form");
         if (before.template match<0>(instance, state)) {
             result = after;
 #if HALIDE_DEBUG_MATCHED_RULES
@@ -2096,6 +2248,7 @@ struct Rewriter {
     template<typename Before,
              typename = typename enable_if_pattern<Before>::type>
     HALIDE_ALWAYS_INLINE bool operator()(Before before, int64_t after) noexcept {
+        static_assert(Before::canonical, "LHS of rewrite rule should be in canonical form");
 #if HALIDE_FUZZ_TEST_RULES
         fuzz_test_rule(before, Const(after), true, wildcard_type, output_type);
 #endif
@@ -2123,6 +2276,9 @@ struct Rewriter {
         static_assert(Predicate::foldable, "Predicates must consist only of operations that can constant-fold");
         static_assert((Before::binds & After::binds) == After::binds, "Rule result uses unbound values");
         static_assert((Before::binds & Predicate::binds) == Predicate::binds, "Rule predicate uses unbound values");
+        static_assert(Before::canonical, "LHS of rewrite rule should be in canonical form");
+        static_assert(After::canonical, "RHS of rewrite rule should be in canonical form");
+
 #if HALIDE_FUZZ_TEST_RULES
         fuzz_test_rule(before, after, pred, wildcard_type, output_type);
 #endif
@@ -2147,6 +2303,7 @@ struct Rewriter {
              typename = typename enable_if_pattern<Predicate>::type>
     HALIDE_ALWAYS_INLINE bool operator()(Before before, const Expr &after, Predicate pred) {
         static_assert(Predicate::foldable, "Predicates must consist only of operations that can constant-fold");
+        static_assert(Before::canonical, "LHS of rewrite rule should be in canonical form");
         if (before.template match<0>(instance, state) &&
             evaluate_predicate(pred, state)) {
             result = after;
@@ -2168,6 +2325,7 @@ struct Rewriter {
              typename = typename enable_if_pattern<Predicate>::type>
     HALIDE_ALWAYS_INLINE bool operator()(Before before, int64_t after, Predicate pred) {
         static_assert(Predicate::foldable, "Predicates must consist only of operations that can constant-fold");
+        static_assert(Before::canonical, "LHS of rewrite rule should be in canonical form");
 #if HALIDE_FUZZ_TEST_RULES
         fuzz_test_rule(before, Const(after), pred, wildcard_type, output_type);
 #endif

--- a/src/Simplify_Add.cpp
+++ b/src/Simplify_Add.cpp
@@ -60,13 +60,9 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
              rewrite(select(x, y, c1) + c2, select(x, y + c2, fold(c1 + c2))) ||
              rewrite(select(x, c0, y) + c2, select(x, fold(c0 + c2), y + c2)) ||
 
-             rewrite((select(x, y, z) + w) + select(x, u, v), select(x, y + u, z + v) + w) ||
-             rewrite((w + select(x, y, z)) + select(x, u, v), select(x, y + u, z + v) + w) ||
              rewrite(select(x, y, z) + (select(x, u, v) + w), select(x, y + u, z + v) + w) ||
              rewrite(select(x, y, z) + (w + select(x, u, v)), select(x, y + u, z + v) + w) ||
-             rewrite((select(x, y, z) - w) + select(x, u, v), select(x, y + u, z + v) - w) ||
              rewrite(select(x, y, z) + (select(x, u, v) - w), select(x, y + u, z + v) - w) ||
-             rewrite((w - select(x, y, z)) + select(x, u, v), select(x, u - y, v - z) + w) ||
              rewrite(select(x, y, z) + (w - select(x, u, v)), select(x, y - u, z - v) + w) ||
 
              rewrite((x + c0) + c1, x + fold(c0 + c1)) ||

--- a/src/Simplify_LT.cpp
+++ b/src/Simplify_LT.cpp
@@ -158,37 +158,37 @@ Expr Simplify::visit(const LT *op, ExprInfo *bounds) {
               // We want to break max(x, y) < z into x < z && y <
               // z in cases where one of those two terms is going
               // to fold.
-              rewrite(min(x + c0, y) < x + c1, fold(c0 < c1) || y < x + c1) ||
-              rewrite(min(y, x + c0) < x + c1, fold(c0 < c1) || y < x + c1) ||
-              rewrite(max(x + c0, y) < x + c1, fold(c0 < c1) && y < x + c1) ||
-              rewrite(max(y, x + c0) < x + c1, fold(c0 < c1) && y < x + c1) ||
+              rewrite(min(x + c0, y) < x + c1, y < x + c1 || fold(c0 < c1)) ||
+              rewrite(min(y, x + c0) < x + c1, y < x + c1 || fold(c0 < c1)) ||
+              rewrite(max(x + c0, y) < x + c1, y < x + c1 && fold(c0 < c1)) ||
+              rewrite(max(y, x + c0) < x + c1, y < x + c1 && fold(c0 < c1)) ||
 
-              rewrite(x < min(x + c0, y) + c1, fold(0 < c0 + c1) && x < y + c1) ||
-              rewrite(x < min(y, x + c0) + c1, fold(0 < c0 + c1) && x < y + c1) ||
-              rewrite(x < max(x + c0, y) + c1, fold(0 < c0 + c1) || x < y + c1) ||
-              rewrite(x < max(y, x + c0) + c1, fold(0 < c0 + c1) || x < y + c1) ||
+              rewrite(x < min(x + c0, y) + c1, x < y + c1 && fold(0 < c0 + c1)) ||
+              rewrite(x < min(y, x + c0) + c1, x < y + c1 && fold(0 < c0 + c1)) ||
+              rewrite(x < max(x + c0, y) + c1, x < y + c1 || fold(0 < c0 + c1)) ||
+              rewrite(x < max(y, x + c0) + c1, x < y + c1 || fold(0 < c0 + c1)) ||
 
               // Special cases where c0 == 0
-              rewrite(min(x, y) < x + c1, fold(0 < c1) || y < x + c1) ||
-              rewrite(min(y, x) < x + c1, fold(0 < c1) || y < x + c1) ||
-              rewrite(max(x, y) < x + c1, fold(0 < c1) && y < x + c1) ||
-              rewrite(max(y, x) < x + c1, fold(0 < c1) && y < x + c1) ||
+              rewrite(min(x, y) < x + c1, y < x + c1 || fold(0 < c1)) ||
+              rewrite(min(y, x) < x + c1, y < x + c1 || fold(0 < c1)) ||
+              rewrite(max(x, y) < x + c1, y < x + c1 && fold(0 < c1)) ||
+              rewrite(max(y, x) < x + c1, y < x + c1 && fold(0 < c1)) ||
 
-              rewrite(x < min(x, y) + c1, fold(0 < c1) && x < y + c1) ||
-              rewrite(x < min(y, x) + c1, fold(0 < c1) && x < y + c1) ||
-              rewrite(x < max(x, y) + c1, fold(0 < c1) || x < y + c1) ||
-              rewrite(x < max(y, x) + c1, fold(0 < c1) || x < y + c1) ||
+              rewrite(x < min(x, y) + c1, x < y + c1 && fold(0 < c1)) ||
+              rewrite(x < min(y, x) + c1, x < y + c1 && fold(0 < c1)) ||
+              rewrite(x < max(x, y) + c1, x < y + c1 || fold(0 < c1)) ||
+              rewrite(x < max(y, x) + c1, x < y + c1 || fold(0 < c1)) ||
 
               // Special cases where c1 == 0
-              rewrite(min(x + c0, y) < x, fold(c0 < 0) || y < x) ||
-              rewrite(min(y, x + c0) < x, fold(c0 < 0) || y < x) ||
-              rewrite(max(x + c0, y) < x, fold(c0 < 0) && y < x) ||
-              rewrite(max(y, x + c0) < x, fold(c0 < 0) && y < x) ||
+              rewrite(min(x + c0, y) < x, y < x || fold(c0 < 0)) ||
+              rewrite(min(y, x + c0) < x, y < x || fold(c0 < 0)) ||
+              rewrite(max(x + c0, y) < x, y < x && fold(c0 < 0)) ||
+              rewrite(max(y, x + c0) < x, y < x && fold(c0 < 0)) ||
 
-              rewrite(x < min(x + c0, y), fold(0 < c0) && x < y) ||
-              rewrite(x < min(y, x + c0), fold(0 < c0) && x < y) ||
-              rewrite(x < max(x + c0, y), fold(0 < c0) || x < y) ||
-              rewrite(x < max(y, x + c0), fold(0 < c0) || x < y) ||
+              rewrite(x < min(x + c0, y), x < y && fold(0 < c0)) ||
+              rewrite(x < min(y, x + c0), x < y && fold(0 < c0)) ||
+              rewrite(x < max(x + c0, y), x < y || fold(0 < c0)) ||
+              rewrite(x < max(y, x + c0), x < y || fold(0 < c0)) ||
 
               // Special cases where c0 == c1 == 0
               rewrite(min(x, y) < x, y < x) ||
@@ -197,10 +197,10 @@ Expr Simplify::visit(const LT *op, ExprInfo *bounds) {
               rewrite(x < max(y, x), x < y) ||
 
               // Special case where x is constant
-              rewrite(min(y, c0) < c1, fold(c0 < c1) || y < c1) ||
-              rewrite(max(y, c0) < c1, fold(c0 < c1) && y < c1) ||
-              rewrite(c1 < min(y, c0), fold(c1 < c0) && c1 < y) ||
-              rewrite(c1 < max(y, c0), fold(c1 < c0) || c1 < y) ||
+              rewrite(min(y, c0) < c1, y < c1 || fold(c0 < c1)) ||
+              rewrite(max(y, c0) < c1, y < c1 && fold(c0 < c1)) ||
+              rewrite(c1 < min(y, c0), c1 < y && fold(c1 < c0)) ||
+              rewrite(c1 < max(y, c0), c1 < y || fold(c1 < c0)) ||
 
               // Cases where we can remove a min on one side because
               // one term dominates another. These rules were

--- a/src/Simplify_Max.cpp
+++ b/src/Simplify_Max.cpp
@@ -117,7 +117,6 @@ Expr Simplify::visit(const Max *op, ExprInfo *bounds) {
              rewrite(max(max(y, x), max(z, x)), max(max(y, z), x)) ||
              rewrite(max(max(x, y), max(z, w)), max(max(max(x, y), z), w)) ||
              rewrite(max(broadcast(x), broadcast(y)), broadcast(max(x, y), lanes)) ||
-             rewrite(max(broadcast(x), ramp(y, z)), max(b, a)) ||
              rewrite(max(max(x, broadcast(y)), broadcast(z)), max(x, broadcast(max(y, z), lanes))) ||
              rewrite(max(min(x, y), min(x, z)), min(x, max(y, z))) ||
              rewrite(max(min(x, y), min(z, x)), min(x, max(y, z))) ||
@@ -183,14 +182,14 @@ Expr Simplify::visit(const Max *op, ExprInfo *bounds) {
                rewrite(max(y - x, z - x), max(y, z) - x) ||
                rewrite(max(x - y, x - z), x - min(y, z)) ||
 
-               rewrite(max(x, x - y), x - min(0, y)) ||
-               rewrite(max(x - y, x), x - min(0, y)) ||
-               rewrite(max(x, (x - y) + z), x + max(0, z - y)) ||
-               rewrite(max(x, z + (x - y)), x + max(0, z - y)) ||
-               rewrite(max(x, (x - y) - z), x - min(0, y + z)) ||
-               rewrite(max((x - y) + z, x), max(0, z - y) + x) ||
-               rewrite(max(z + (x - y), x), max(0, z - y) + x) ||
-               rewrite(max((x - y) - z, x), x - min(0, y + z)) ||
+               rewrite(max(x, x - y), x - min(y, 0)) ||
+               rewrite(max(x - y, x), x - min(y, 0)) ||
+               rewrite(max(x, (x - y) + z), x + max(z - y, 0)) ||
+               rewrite(max(x, z + (x - y)), x + max(z - y, 0)) ||
+               rewrite(max(x, (x - y) - z), x - min(y + z, 0)) ||
+               rewrite(max((x - y) + z, x), max(z - y, 0) + x) ||
+               rewrite(max(z + (x - y), x), max(z - y, 0) + x) ||
+               rewrite(max((x - y) - z, x), x - min(y + z, 0)) ||
 
                rewrite(max(x * c0, c1), max(x, fold(c1 / c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
                rewrite(max(x * c0, c1), min(x, fold(c1 / c0)) * c0, c0 < 0 && c1 % c0 == 0) ||

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -117,7 +117,6 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
              rewrite(min(min(y, x), min(z, x)), min(min(y, z), x)) ||
              rewrite(min(min(x, y), min(z, w)), min(min(min(x, y), z), w)) ||
              rewrite(min(broadcast(x), broadcast(y)), broadcast(min(x, y), lanes)) ||
-             rewrite(min(broadcast(x), ramp(y, z)), min(b, a)) ||
              rewrite(min(min(x, broadcast(y)), broadcast(z)), min(x, broadcast(min(y, z), lanes))) ||
              rewrite(min(max(x, y), max(x, z)), max(x, min(y, z))) ||
              rewrite(min(max(x, y), max(z, x)), max(x, min(y, z))) ||
@@ -186,14 +185,14 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
                rewrite(min(y - x, z - x), min(y, z) - x) ||
                rewrite(min(x - y, x - z), x - max(y, z)) ||
 
-               rewrite(min(x, x - y), x - max(0, y)) ||
-               rewrite(min(x - y, x), x - max(0, y)) ||
-               rewrite(min(x, (x - y) + z), x + min(0, z - y)) ||
-               rewrite(min(x, z + (x - y)), x + min(0, z - y)) ||
-               rewrite(min(x, (x - y) - z), x - max(0, y + z)) ||
-               rewrite(min((x - y) + z, x), min(0, z - y) + x) ||
-               rewrite(min(z + (x - y), x), min(0, z - y) + x) ||
-               rewrite(min((x - y) - z, x), x - max(0, y + z)) ||
+               rewrite(min(x, x - y), x - max(y, 0)) ||
+               rewrite(min(x - y, x), x - max(y, 0)) ||
+               rewrite(min(x, (x - y) + z), x + min(z - y, 0)) ||
+               rewrite(min(x, z + (x - y)), x + min(z - y, 0)) ||
+               rewrite(min(x, (x - y) - z), x - max(y + z, 0)) ||
+               rewrite(min((x - y) + z, x), min(z - y, 0) + x) ||
+               rewrite(min(z + (x - y), x), min(z - y, 0) + x) ||
+               rewrite(min((x - y) - z, x), x - max(y + z, 0)) ||
 
                rewrite(min(x * c0, c1), min(x, fold(c1 / c0)) * c0, c0 > 0 && c1 % c0 == 0) ||
                rewrite(min(x * c0, c1), max(x, fold(c1 / c0)) * c0, c0 < 0 && c1 % c0 == 0) ||

--- a/src/Simplify_Not.cpp
+++ b/src/Simplify_Not.cpp
@@ -11,8 +11,6 @@ Expr Simplify::visit(const Not *op, ExprInfo *bounds) {
     if (rewrite(!c0, fold(!c0)) ||
         rewrite(!(x < y), y <= x) ||
         rewrite(!(x <= y), y < x) ||
-        rewrite(!(x > y), y >= x) ||
-        rewrite(!(x >= y), y > x) ||
         rewrite(!(x == y), x != y) ||
         rewrite(!(x != y), x == y) ||
         rewrite(!!x, x)) {

--- a/src/Simplify_Or.cpp
+++ b/src/Simplify_Or.cpp
@@ -42,15 +42,6 @@ Expr Simplify::visit(const Or *op, ExprInfo *bounds) {
          rewrite((x && y) || y, b) ||
          rewrite(y || (x && y), a) ||
 
-         rewrite(((x || y) || z) || x, a) ||
-         rewrite(x || ((x || y) || z), b) ||
-         rewrite((z || (x || y)) || x, a) ||
-         rewrite(x || (z || (x || y)), b) ||
-         rewrite(((x || y) || z) || y, a) ||
-         rewrite(y || ((x || y) || z), b) ||
-         rewrite((z || (x || y)) || y, a) ||
-         rewrite(y || (z || (x || y)), b) ||
-
          rewrite(x != y || x == y, true) ||
          rewrite(x != y || y == x, true) ||
          rewrite((z || x != y) || x == y, true) ||

--- a/src/Simplify_Sub.cpp
+++ b/src/Simplify_Sub.cpp
@@ -105,12 +105,12 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
              rewrite((x - y) - (z + x), 0 - y - z) ||
 
              (no_overflow(op->type) &&
-              (rewrite(max(x, y) - x, max(0, y - x)) ||
-               rewrite(min(x, y) - x, min(0, y - x)) ||
+              (rewrite(max(x, y) - x, max(y - x, 0)) ||
+               rewrite(min(x, y) - x, min(y - x, 0)) ||
                rewrite(max(x, y) - y, max(x - y, 0)) ||
                rewrite(min(x, y) - y, min(x - y, 0)) ||
-               rewrite(x - max(x, y), min(0, x - y), !is_const(x)) ||
-               rewrite(x - min(x, y), max(0, x - y), !is_const(x)) ||
+               rewrite(x - max(x, y), min(x - y, 0), !is_const(x)) ||
+               rewrite(x - min(x, y), max(x - y, 0), !is_const(x)) ||
                rewrite(y - max(x, y), min(y - x, 0), !is_const(y)) ||
                rewrite(y - min(x, y), max(y - x, 0), !is_const(y)) ||
                rewrite(x*y - x, x*(y - 1)) ||
@@ -168,80 +168,80 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
                // direction or the other.
 
                // Then the actual rules. We consider only cases where x and z differ by a constant.
-               rewrite(min(x, y) - min(x, w), min(0, y - min(x, w)), can_prove(y <= w, this)) ||
-               rewrite(min(x, y) - min(x, w), max(0, min(x, y) - w), can_prove(y >= w, this)) ||
-               rewrite(min(x + c0, y) - min(x, w), min(c0, y - min(x, w)), can_prove(y <= w + c0, this)) ||
-               rewrite(min(x + c0, y) - min(x, w), max(c0, min(x + c0, y) - w), can_prove(y >= w + c0, this)) ||
-               rewrite(min(x, y) - min(x + c1, w), min(fold(-c1), y - min(x + c1, w)), can_prove(y + c1 <= w, this)) ||
-               rewrite(min(x, y) - min(x + c1, w), max(fold(-c1), min(x, y) - w), can_prove(y + c1 >= w, this)) ||
-               rewrite(min(x + c0, y) - min(x + c1, w), min(fold(c0 - c1), y - min(x + c1, w)), can_prove(y + c1 <= w + c0, this)) ||
-               rewrite(min(x + c0, y) - min(x + c1, w), max(fold(c0 - c1), min(x + c0, y) - w), can_prove(y + c1 >= w + c0, this)) ||
+               rewrite(min(x, y) - min(x, w), min(y - min(x, w), 0), can_prove(y <= w, this)) ||
+               rewrite(min(x, y) - min(x, w), max(min(x, y) - w, 0), can_prove(y >= w, this)) ||
+               rewrite(min(x + c0, y) - min(x, w), min(y - min(x, w), c0), can_prove(y <= w + c0, this)) ||
+               rewrite(min(x + c0, y) - min(x, w), max(min(x + c0, y) - w, c0), can_prove(y >= w + c0, this)) ||
+               rewrite(min(x, y) - min(x + c1, w), min(y - min(x + c1, w), fold(-c1)), can_prove(y + c1 <= w, this)) ||
+               rewrite(min(x, y) - min(x + c1, w), max(min(x, y) - w, fold(-c1)), can_prove(y + c1 >= w, this)) ||
+               rewrite(min(x + c0, y) - min(x + c1, w), min(y - min(x + c1, w), fold(c0 - c1)), can_prove(y + c1 <= w + c0, this)) ||
+               rewrite(min(x + c0, y) - min(x + c1, w), max(min(x + c0, y) - w, fold(c0 - c1)), can_prove(y + c1 >= w + c0, this)) ||
 
-               rewrite(min(y, x) - min(w, x), min(0, y - min(x, w)), can_prove(y <= w, this)) ||
-               rewrite(min(y, x) - min(w, x), max(0, min(x, y) - w), can_prove(y >= w, this)) ||
-               rewrite(min(y, x + c0) - min(w, x), min(c0, y - min(x, w)), can_prove(y <= w + c0, this)) ||
-               rewrite(min(y, x + c0) - min(w, x), max(c0, min(x + c0, y) - w), can_prove(y >= w + c0, this)) ||
-               rewrite(min(y, x) - min(w, x + c1), min(fold(-c1), y - min(x + c1, w)), can_prove(y + c1 <= w, this)) ||
-               rewrite(min(y, x) - min(w, x + c1), max(fold(-c1), min(x, y) - w), can_prove(y + c1 >= w, this)) ||
-               rewrite(min(y, x + c0) - min(w, x + c1), min(fold(c0 - c1), y - min(x + c1, w)), can_prove(y + c1 <= w + c0, this)) ||
-               rewrite(min(y, x + c0) - min(w, x + c1), max(fold(c0 - c1), min(x + c0, y) - w), can_prove(y + c1 >= w + c0, this)) ||
+               rewrite(min(y, x) - min(w, x), min(y - min(x, w), 0), can_prove(y <= w, this)) ||
+               rewrite(min(y, x) - min(w, x), max(min(x, y) - w, 0), can_prove(y >= w, this)) ||
+               rewrite(min(y, x + c0) - min(w, x), min(y - min(x, w), c0), can_prove(y <= w + c0, this)) ||
+               rewrite(min(y, x + c0) - min(w, x), max(min(x + c0, y) - w, c0), can_prove(y >= w + c0, this)) ||
+               rewrite(min(y, x) - min(w, x + c1), min(y - min(x + c1, w), fold(-c1)), can_prove(y + c1 <= w, this)) ||
+               rewrite(min(y, x) - min(w, x + c1), max(min(x, y) - w, fold(-c1)), can_prove(y + c1 >= w, this)) ||
+               rewrite(min(y, x + c0) - min(w, x + c1), min(y - min(x + c1, w), fold(c0 - c1)), can_prove(y + c1 <= w + c0, this)) ||
+               rewrite(min(y, x + c0) - min(w, x + c1), max(min(x + c0, y) - w, fold(c0 - c1)), can_prove(y + c1 >= w + c0, this)) ||
 
-               rewrite(min(x, y) - min(w, x), min(0, y - min(x, w)), can_prove(y <= w, this)) ||
-               rewrite(min(x, y) - min(w, x), max(0, min(x, y) - w), can_prove(y >= w, this)) ||
-               rewrite(min(x + c0, y) - min(w, x), min(c0, y - min(x, w)), can_prove(y <= w + c0, this)) ||
-               rewrite(min(x + c0, y) - min(w, x), max(c0, min(x + c0, y) - w), can_prove(y >= w + c0, this)) ||
-               rewrite(min(x, y) - min(w, x + c1), min(fold(-c1), y - min(x + c1, w)), can_prove(y + c1 <= w, this)) ||
-               rewrite(min(x, y) - min(w, x + c1), max(fold(-c1), min(x, y) - w), can_prove(y + c1 >= w, this)) ||
-               rewrite(min(x + c0, y) - min(w, x + c1), min(fold(c0 - c1), y - min(x + c1, w)), can_prove(y + c1 <= w + c0, this)) ||
-               rewrite(min(x + c0, y) - min(w, x + c1), max(fold(c0 - c1), min(x + c0, y) - w), can_prove(y + c1 >= w + c0, this)) ||
+               rewrite(min(x, y) - min(w, x), min(y - min(x, w), 0), can_prove(y <= w, this)) ||
+               rewrite(min(x, y) - min(w, x), max(min(x, y) - w, 0), can_prove(y >= w, this)) ||
+               rewrite(min(x + c0, y) - min(w, x), min(y - min(x, w), c0), can_prove(y <= w + c0, this)) ||
+               rewrite(min(x + c0, y) - min(w, x), max(min(x + c0, y) - w, c0), can_prove(y >= w + c0, this)) ||
+               rewrite(min(x, y) - min(w, x + c1), min(y - min(x + c1, w), fold(-c1)), can_prove(y + c1 <= w, this)) ||
+               rewrite(min(x, y) - min(w, x + c1), max(min(x, y) - w, fold(-c1)), can_prove(y + c1 >= w, this)) ||
+               rewrite(min(x + c0, y) - min(w, x + c1), min(y - min(x + c1, w), fold(c0 - c1)), can_prove(y + c1 <= w + c0, this)) ||
+               rewrite(min(x + c0, y) - min(w, x + c1), max(min(x + c0, y) - w, fold(c0 - c1)), can_prove(y + c1 >= w + c0, this)) ||
 
-               rewrite(min(y, x) - min(x, w), min(0, y - min(x, w)), can_prove(y <= w, this)) ||
-               rewrite(min(y, x) - min(x, w), max(0, min(x, y) - w), can_prove(y >= w, this)) ||
-               rewrite(min(y, x + c0) - min(x, w), min(c0, y - min(x, w)), can_prove(y <= w + c0, this)) ||
-               rewrite(min(y, x + c0) - min(x, w), max(c0, min(x + c0, y) - w), can_prove(y >= w + c0, this)) ||
-               rewrite(min(y, x) - min(x + c1, w), min(fold(-c1), y - min(x + c1, w)), can_prove(y + c1 <= w, this)) ||
-               rewrite(min(y, x) - min(x + c1, w), max(fold(-c1), min(x, y) - w), can_prove(y + c1 >= w, this)) ||
-               rewrite(min(y, x + c0) - min(x + c1, w), min(fold(c0 - c1), y - min(x + c1, w)), can_prove(y + c1 <= w + c0, this)) ||
-               rewrite(min(y, x + c0) - min(x + c1, w), max(fold(c0 - c1), min(x + c0, y) - w), can_prove(y + c1 >= w + c0, this)) ||
+               rewrite(min(y, x) - min(x, w), min(y - min(x, w), 0), can_prove(y <= w, this)) ||
+               rewrite(min(y, x) - min(x, w), max(min(x, y) - w, 0), can_prove(y >= w, this)) ||
+               rewrite(min(y, x + c0) - min(x, w), min(y - min(x, w), c0), can_prove(y <= w + c0, this)) ||
+               rewrite(min(y, x + c0) - min(x, w), max(min(x + c0, y) - w, c0), can_prove(y >= w + c0, this)) ||
+               rewrite(min(y, x) - min(x + c1, w), min(y - min(x + c1, w), fold(-c1)), can_prove(y + c1 <= w, this)) ||
+               rewrite(min(y, x) - min(x + c1, w), max(min(x, y) - w, fold(-c1)), can_prove(y + c1 >= w, this)) ||
+               rewrite(min(y, x + c0) - min(x + c1, w), min(y - min(x + c1, w), fold(c0 - c1)), can_prove(y + c1 <= w + c0, this)) ||
+               rewrite(min(y, x + c0) - min(x + c1, w), max(min(x + c0, y) - w, fold(c0 - c1)), can_prove(y + c1 >= w + c0, this)) ||
 
                // The equivalent rules for max are what you'd
                // expect. Just swap < and > and min and max (apply the
                // isomorphism x -> -x).
-               rewrite(max(x, y) - max(x, w), max(0, y - max(x, w)), can_prove(y >= w, this)) ||
-               rewrite(max(x, y) - max(x, w), min(0, max(x, y) - w), can_prove(y <= w, this)) ||
-               rewrite(max(x + c0, y) - max(x, w), max(c0, y - max(x, w)), can_prove(y >= w + c0, this)) ||
-               rewrite(max(x + c0, y) - max(x, w), min(c0, max(x + c0, y) - w), can_prove(y <= w + c0, this)) ||
-               rewrite(max(x, y) - max(x + c1, w), max(fold(-c1), y - max(x + c1, w)), can_prove(y + c1 >= w, this)) ||
-               rewrite(max(x, y) - max(x + c1, w), min(fold(-c1), max(x, y) - w), can_prove(y + c1 <= w, this)) ||
-               rewrite(max(x + c0, y) - max(x + c1, w), max(fold(c0 - c1), y - max(x + c1, w)), can_prove(y + c1 >= w + c0, this)) ||
-               rewrite(max(x + c0, y) - max(x + c1, w), min(fold(c0 - c1), max(x + c0, y) - w), can_prove(y + c1 <= w + c0, this)) ||
+               rewrite(max(x, y) - max(x, w), max(y - max(x, w), 0), can_prove(y >= w, this)) ||
+               rewrite(max(x, y) - max(x, w), min(max(x, y) - w, 0), can_prove(y <= w, this)) ||
+               rewrite(max(x + c0, y) - max(x, w), max(y - max(x, w), c0), can_prove(y >= w + c0, this)) ||
+               rewrite(max(x + c0, y) - max(x, w), min(max(x + c0, y) - w, c0), can_prove(y <= w + c0, this)) ||
+               rewrite(max(x, y) - max(x + c1, w), max(y - max(x + c1, w), fold(-c1)), can_prove(y + c1 >= w, this)) ||
+               rewrite(max(x, y) - max(x + c1, w), min(max(x, y) - w, fold(-c1)), can_prove(y + c1 <= w, this)) ||
+               rewrite(max(x + c0, y) - max(x + c1, w), max(y - max(x + c1, w), fold(c0 - c1)), can_prove(y + c1 >= w + c0, this)) ||
+               rewrite(max(x + c0, y) - max(x + c1, w), min(max(x + c0, y) - w, fold(c0 - c1)), can_prove(y + c1 <= w + c0, this)) ||
 
-               rewrite(max(y, x) - max(w, x), max(0, y - max(x, w)), can_prove(y >= w, this)) ||
-               rewrite(max(y, x) - max(w, x), min(0, max(x, y) - w), can_prove(y <= w, this)) ||
-               rewrite(max(y, x + c0) - max(w, x), max(c0, y - max(x, w)), can_prove(y >= w + c0, this)) ||
-               rewrite(max(y, x + c0) - max(w, x), min(c0, max(x + c0, y) - w), can_prove(y <= w + c0, this)) ||
-               rewrite(max(y, x) - max(w, x + c1), max(fold(-c1), y - max(x + c1, w)), can_prove(y + c1 >= w, this)) ||
-               rewrite(max(y, x) - max(w, x + c1), min(fold(-c1), max(x, y) - w), can_prove(y + c1 <= w, this)) ||
-               rewrite(max(y, x + c0) - max(w, x + c1), max(fold(c0 - c1), y - max(x + c1, w)), can_prove(y + c1 >= w + c0, this)) ||
-               rewrite(max(y, x + c0) - max(w, x + c1), min(fold(c0 - c1), max(x + c0, y) - w), can_prove(y + c1 <= w + c0, this)) ||
+               rewrite(max(y, x) - max(w, x), max(y - max(x, w), 0), can_prove(y >= w, this)) ||
+               rewrite(max(y, x) - max(w, x), min(max(x, y) - w, 0), can_prove(y <= w, this)) ||
+               rewrite(max(y, x + c0) - max(w, x), max(y - max(x, w), c0), can_prove(y >= w + c0, this)) ||
+               rewrite(max(y, x + c0) - max(w, x), min(max(x + c0, y) - w, c0), can_prove(y <= w + c0, this)) ||
+               rewrite(max(y, x) - max(w, x + c1), max(y - max(x + c1, w), fold(-c1)), can_prove(y + c1 >= w, this)) ||
+               rewrite(max(y, x) - max(w, x + c1), min(max(x, y) - w, fold(-c1)), can_prove(y + c1 <= w, this)) ||
+               rewrite(max(y, x + c0) - max(w, x + c1), max(y - max(x + c1, w), fold(c0 - c1)), can_prove(y + c1 >= w + c0, this)) ||
+               rewrite(max(y, x + c0) - max(w, x + c1), min(max(x + c0, y) - w, fold(c0 - c1)), can_prove(y + c1 <= w + c0, this)) ||
 
-               rewrite(max(x, y) - max(w, x), max(0, y - max(x, w)), can_prove(y >= w, this)) ||
-               rewrite(max(x, y) - max(w, x), min(0, max(x, y) - w), can_prove(y <= w, this)) ||
-               rewrite(max(x + c0, y) - max(w, x), max(c0, y - max(x, w)), can_prove(y >= w + c0, this)) ||
-               rewrite(max(x + c0, y) - max(w, x), min(c0, max(x + c0, y) - w), can_prove(y <= w + c0, this)) ||
-               rewrite(max(x, y) - max(w, x + c1), max(fold(-c1), y - max(x + c1, w)), can_prove(y + c1 >= w, this)) ||
-               rewrite(max(x, y) - max(w, x + c1), min(fold(-c1), max(x, y) - w), can_prove(y + c1 <= w, this)) ||
-               rewrite(max(x + c0, y) - max(w, x + c1), max(fold(c0 - c1), y - max(x + c1, w)), can_prove(y + c1 >= w + c0, this)) ||
-               rewrite(max(x + c0, y) - max(w, x + c1), min(fold(c0 - c1), max(x + c0, y) - w), can_prove(y + c1 <= w + c0, this)) ||
+               rewrite(max(x, y) - max(w, x), max(y - max(x, w), 0), can_prove(y >= w, this)) ||
+               rewrite(max(x, y) - max(w, x), min(max(x, y) - w, 0), can_prove(y <= w, this)) ||
+               rewrite(max(x + c0, y) - max(w, x), max(y - max(x, w), c0), can_prove(y >= w + c0, this)) ||
+               rewrite(max(x + c0, y) - max(w, x), min(max(x + c0, y) - w, c0), can_prove(y <= w + c0, this)) ||
+               rewrite(max(x, y) - max(w, x + c1), max(y - max(x + c1, w), fold(-c1)), can_prove(y + c1 >= w, this)) ||
+               rewrite(max(x, y) - max(w, x + c1), min(max(x, y) - w, fold(-c1)), can_prove(y + c1 <= w, this)) ||
+               rewrite(max(x + c0, y) - max(w, x + c1), max(y - max(x + c1, w), fold(c0 - c1)), can_prove(y + c1 >= w + c0, this)) ||
+               rewrite(max(x + c0, y) - max(w, x + c1), min(max(x + c0, y) - w, fold(c0 - c1)), can_prove(y + c1 <= w + c0, this)) ||
 
-               rewrite(max(y, x) - max(x, w), max(0, y - max(x, w)), can_prove(y >= w, this)) ||
-               rewrite(max(y, x) - max(x, w), min(0, max(x, y) - w), can_prove(y <= w, this)) ||
-               rewrite(max(y, x + c0) - max(x, w), max(c0, y - max(x, w)), can_prove(y >= w + c0, this)) ||
-               rewrite(max(y, x + c0) - max(x, w), min(c0, max(x + c0, y) - w), can_prove(y <= w + c0, this)) ||
-               rewrite(max(y, x) - max(x + c1, w), max(fold(-c1), y - max(x + c1, w)), can_prove(y + c1 >= w, this)) ||
-               rewrite(max(y, x) - max(x + c1, w), min(fold(-c1), max(x, y) - w), can_prove(y + c1 <= w, this)) ||
-               rewrite(max(y, x + c0) - max(x + c1, w), max(fold(c0 - c1), y - max(x + c1, w)), can_prove(y + c1 >= w + c0, this)) ||
-               rewrite(max(y, x + c0) - max(x + c1, w), min(fold(c0 - c1), max(x + c0, y) - w), can_prove(y + c1 <= w + c0, this)))) ||
+               rewrite(max(y, x) - max(x, w), max(y - max(x, w), 0), can_prove(y >= w, this)) ||
+               rewrite(max(y, x) - max(x, w), min(max(x, y) - w, 0), can_prove(y <= w, this)) ||
+               rewrite(max(y, x + c0) - max(x, w), max(y - max(x, w), c0), can_prove(y >= w + c0, this)) ||
+               rewrite(max(y, x + c0) - max(x, w), min(max(x + c0, y) - w, c0), can_prove(y <= w + c0, this)) ||
+               rewrite(max(y, x) - max(x + c1, w), max(y - max(x + c1, w), fold(-c1)), can_prove(y + c1 >= w, this)) ||
+               rewrite(max(y, x) - max(x + c1, w), min(max(x, y) - w, fold(-c1)), can_prove(y + c1 <= w, this)) ||
+               rewrite(max(y, x + c0) - max(x + c1, w), max(y - max(x + c1, w), fold(c0 - c1)), can_prove(y + c1 >= w + c0, this)) ||
+               rewrite(max(y, x + c0) - max(x + c1, w), min(max(x + c0, y) - w, fold(c0 - c1)), can_prove(y + c1 <= w + c0, this)))) ||
 
              (no_overflow_int(op->type) &&
               (rewrite(c0 - (c1 - x)/c2, (fold(c0*c2 - c1 + c2 - 1) + x)/c2, c2 > 0) ||

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1462,7 +1462,7 @@ void check_boolean() {
     check(IfThenElse::make(x == 1, loop), IfThenElse::make(x == 1, body));
 
     // A for loop where the extent is at most one can just be an if statement
-    check(IfThenElse::make(x == y % 2, loop), IfThenElse::make(x == y % 2, IfThenElse::make(0 < x, body)));
+    check(IfThenElse::make(y % 2 == x, loop), IfThenElse::make(y % 2 == x, IfThenElse::make(0 < x, body)));
 
     // Simplifications of selects
     check(select(x == 3, 5, 7) + 7, select(x == 3, 12, 14));


### PR DESCRIPTION
For every commutative binary op, we know that the weaker IR node is on the right, because the simplifier does that before applying any rules using should_commute. We also normalize >= and > to <= and <. 

We should never make a right-hand-side that doesn't obey these constraints. It just makes more work for the simplifier.

This PR deletes 8 simplifier rules that could never have matched. The checks are done at compile-time using static asserts.

@jn80842 