### PR TITLE
Avoid adding duplicate children in trim_scope_push

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -2103,39 +2103,80 @@ private:
         }
     };
 
-    // Build an ordered list of the unique children of 'name', such that every
-    // parent in the list comes before all its children, but without duplicates.
-    void unique_ordered_children(const string &name, set<string> &unique, vector<string> &ordered) {
-        auto result = unique.insert(name);
-        if (result.second) {
-            ordered.push_back(name);
-        }
-        for (const auto &v : children[get_var_instance(name)]) {
-            unique_ordered_children(v.var, unique, ordered);
-        }
-    }
-
     void trim_scope_push(const string &name, const Interval &bound, vector<LetBound> &let_bounds) {
+        // We want to do a topological traversal of the dependent
+        // lets. I.e. we visit a var before all the vars that use it
+        // in their definition.
+
+        // A recursive version of a topological traversal looks like:
+        // 1) if node already visited, return
+        // 2) mark node as visited
+        // 3) recursively visit children
+        // 4) prepend node to output list.
+
+        // Step 4 means that the node is the first thing in the output
+        // list, and step 3 means all of the children have been
+        // visited for sure and are in the output list somewhere
+        // else. No future operations after this recursive step
+        // returns ever move things around in the output list - we
+        // only ever prepend things. This means we have the
+        // topological sort property that every node is guaranteed to
+        // be before all of its children.
+
+        // For an example of doing this the recursive way, see
+        // realization_order_dfs in RealizationOrder.cpp. It uses two
+        // different senses of 'visited' to check for cycles, but we
+        // don't need that here. We'll assume there are no cycles.
+
+        // We're going to do it non-recursively with an explicit stack
+        // of Task structs instead. Note that there's work to do (step
+        // 4) after the recursive step (step 3), so we can't just
+        // discard nodes at the same time as we enqueue their
+        // children. We need to consider every node in the stack twice
+        // - once just before pushing its children, and once again
+        // when we reach it again after dealing with all children and
+        // it's time to pop it. As a minor optimization we'll also do
+        // the visited insert/check (steps 1 and 2) before pushing, so
+        // that already-visited nodes don't even make it into the
+        // stack. Finally, we'll append nodes to the output instead of
+        // prepending, and reverse the output at the end.
+
+        struct Task {
+            string var;
+            bool visited_children_already;
+        };
+        vector<Task> pending;
+        set<string> visited;
+
         scope.push(name, bound);
+        visited.insert(name);
+        pending.push_back(Task{name, false});
 
-        vector<string> ordered;
-        {
-            set<string> unique;
-            for (const auto &v : children[get_var_instance(name)]) {
-                unique_ordered_children(v.var, unique, ordered);
+        // We don't want our root node 'name' in the let_bounds list,
+        // so we'll stop when there's only one thing left in the
+        // pending stack.
+        do {
+            Task &next = pending.back();
+            if (!next.visited_children_already) {
+                next.visited_children_already = true;
+                // Note that pushing may invalidate the reference to next.
+                for (const auto &v : children[get_var_instance(next.var)]) {
+                    if (visited.insert(v.var).second) {
+                        pending.push_back(Task{v.var, false});
+                    }
+                }
+            } else {
+                string max_name = unique_name('t');
+                string min_name = unique_name('t');
+                let_bounds.emplace_back(next.var, min_name, max_name);
+                Type t = let_stmts.get(next.var).type();
+                Interval b = Interval(Variable::make(t, min_name), Variable::make(t, max_name));
+                scope.push(next.var, b);
+                pending.pop_back();
             }
-        }
-        for (const string &v : ordered) {
-            string max_name = unique_name('t');
-            string min_name = unique_name('t');
+        } while (pending.size() > 1);
 
-            let_bounds.insert(let_bounds.begin(), LetBound(v, min_name, max_name));
-
-            internal_assert(let_stmts.contains(v));
-            Type t = let_stmts.get(v).type();
-            Interval b = Interval(Variable::make(t, min_name), Variable::make(t, max_name));
-            scope.push(v, b);
-        }
+        std::reverse(let_bounds.begin(), let_bounds.end());
     }
 
     void trim_scope_pop(const string &name, vector<LetBound> &let_bounds) {

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -2135,8 +2135,7 @@ private:
 
             internal_assert(let_stmts.contains(v));
             Type t = let_stmts.get(v).type();
-            Interval b =
-                Interval(Variable::make(t, min_name), Variable::make(t, max_name));
+            Interval b = Interval(Variable::make(t, min_name), Variable::make(t, max_name));
             scope.push(v, b);
         }
     }

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -2105,8 +2105,7 @@ private:
 
     // Build an ordered list of the unique children of 'name', such that every
     // parent in the list comes before all its children, but without duplicates.
-    void unique_ordered_children(const string &name, set<string> &unique,
-                                 vector<string> &ordered) {
+    void unique_ordered_children(const string &name, set<string> &unique, vector<string> &ordered) {
         auto result = unique.insert(name);
         if (result.second) {
             ordered.push_back(name);
@@ -2116,8 +2115,7 @@ private:
         }
     }
 
-    void trim_scope_push(const string &name, const Interval &bound,
-                         vector<LetBound> &let_bounds) {
+    void trim_scope_push(const string &name, const Interval &bound, vector<LetBound> &let_bounds) {
         scope.push(name, bound);
 
         vector<string> ordered;


### PR DESCRIPTION
The current implementation doesn't try to avoid dupes, which can lead to size explosion in some cases (e.g. a case where ~200 unique children added ~16000 entries to the Scope).