### PR TITLE
Add RDom[i] method to Python bindings.

### DIFF
--- a/python_bindings/correctness/rdom.py
+++ b/python_bindings/correctness/rdom.py
@@ -27,14 +27,17 @@ def test_rdom():
     assert r.y.name() == r[1].name()
     try:
         r[-1].name()
+        raise Exception("underflowing index should raise KeyError")
     except KeyError:
         pass
     try:
         r[2].name()
+        raise Exception("overflowing index should raise KeyError")
     except KeyError:
         pass
     try:
         r["foo"].name()
+        raise Exception("bad index type should raise TypeError")
     except TypeError:
         pass
 

--- a/python_bindings/correctness/rdom.py
+++ b/python_bindings/correctness/rdom.py
@@ -23,6 +23,9 @@ def test_rdom():
             else:
                 assert output[ix, iy] == 1
 
+    assert r.x.name() == r[0].name()
+    assert r.y.name() == r[1].name()
+
     return 0
 
 if __name__ == "__main__":

--- a/python_bindings/correctness/rdom.py
+++ b/python_bindings/correctness/rdom.py
@@ -25,6 +25,18 @@ def test_rdom():
 
     assert r.x.name() == r[0].name()
     assert r.y.name() == r[1].name()
+    try:
+        r[-1].name()
+    except KeyError:
+        pass
+    try:
+        r[2].name()
+    except KeyError:
+        pass
+    try:
+        r["foo"].name()
+    except TypeError:
+        pass
 
     return 0
 

--- a/python_bindings/src/PyRDom.cpp
+++ b/python_bindings/src/PyRDom.cpp
@@ -35,7 +35,7 @@ void define_rdom(py::module &m) {
             .def("dimensions", &RDom::dimensions)
             .def("where", &RDom::where, py::arg("predicate"))
             .def("__getitem__", [](RDom &r, const int i) -> RVar {
-                if(i < 0 || i >= r.dimensions())
+                if (i < 0 || i >= r.dimensions())
                     throw pybind11::key_error();
                 return r[i];
             })

--- a/python_bindings/src/PyRDom.cpp
+++ b/python_bindings/src/PyRDom.cpp
@@ -34,6 +34,9 @@ void define_rdom(py::module &m) {
             .def("same_as", &RDom::same_as)
             .def("dimensions", &RDom::dimensions)
             .def("where", &RDom::where, py::arg("predicate"))
+            .def("__getitem__", [](RDom &r, const int i) -> RVar {
+                return r[i];
+            })
             .def_readonly("x", &RDom::x)
             .def_readonly("y", &RDom::y)
             .def_readonly("z", &RDom::z)

--- a/python_bindings/src/PyRDom.cpp
+++ b/python_bindings/src/PyRDom.cpp
@@ -33,6 +33,7 @@ void define_rdom(py::module &m) {
             .def("defined", &RDom::defined)
             .def("same_as", &RDom::same_as)
             .def("dimensions", &RDom::dimensions)
+            .def("__len__", &RDom::dimensions)
             .def("where", &RDom::where, py::arg("predicate"))
             .def("__getitem__", [](RDom &r, const int i) -> RVar {
                 if (i < 0 || i >= r.dimensions())

--- a/python_bindings/src/PyRDom.cpp
+++ b/python_bindings/src/PyRDom.cpp
@@ -35,6 +35,8 @@ void define_rdom(py::module &m) {
             .def("dimensions", &RDom::dimensions)
             .def("where", &RDom::where, py::arg("predicate"))
             .def("__getitem__", [](RDom &r, const int i) -> RVar {
+                if(i < 0 || i >= r.dimensions())
+                    throw pybind11::key_error();
                 return r[i];
             })
             .def_readonly("x", &RDom::x)


### PR DESCRIPTION
This allows indexed access to the RVars contained by an RDom, just like the C++ API.
