### PR TITLE
fix build (const& vs. const) with LLVM/clang 11 and -Werror

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -2187,7 +2187,7 @@ private:
     }
 
     void trim_scope_pop(const string &name, vector<LetBound> &let_bounds) {
-        for (const LetBound l : let_bounds) {
+        for (const LetBound &l : let_bounds) {
             scope.pop(l.var);
             for (pair<const string, Box> &i : boxes) {
                 Box &box = i.second;


### PR DESCRIPTION
The error message I get (LLVM and clang from today's HEAD):

error: loop variable 'l' creates a copy from type 'const Halide::Internal::BoxesTouched::LetBound' [-Werror,-Wrange-loop-construct]