### PR TITLE
fix build when -stdlib=libc++ was passed into the plain C test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,9 @@ endif()
 
 string(FIND "${LLVM_CONFIG_CXXFLAGS}" "-stdlib=libc++" LLVM_LIBCXX)
 if (LLVM_LIBCXX GREATER -1)
-  add_compile_options(-stdlib=libc++)
+  # Plain C tests must not try to link libc++ with the "clang" driver...
+  add_compile_options($<$<STREQUAL:$<TARGET_PROPERTY:LINKER_LANGUAGE>,CXX>:-stdlib=libc++>)
+  # ...only using the linker command.
   if(COMMAND add_link_options)
     add_link_options(-stdlib=libc++)
   else()


### PR DESCRIPTION
When LLVM was built with it, the -stdlib=libc++ flag would get passed to
correctness_plain_c_includes, which is (correctly) only using the clang
C compiler driver, not clang++, where this is an invalid option.

Since CMake doesn't seem to have per-language options apart from
CMAKE_CXX_FLAGS which people discourage from directly modifying,
we use a conditional instead of the string itself.

Note that passing the option to the linker is fine as is.