### PR TITLE
We want reverse topological order for let bounds

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -2145,8 +2145,8 @@ private:
         // As a minor optimization we'll also do the visited
         // insert/check (steps 1 and 2) before pushing, so that
         // already-visited nodes don't even make it into the
-        // stack. Finally, we'll append nodes to the output instead of
-        // prepending, and reverse the output at the end.
+        // stack. Finally, we actually want reverse topological order,
+        // so we'll append nodes to the output instead of prepending.
 
         struct Task {
             string var;
@@ -2182,8 +2182,6 @@ private:
                 pending.pop_back();
             }
         } while (pending.size() > 1);
-
-        std::reverse(let_bounds.begin(), let_bounds.end());
     }
 
     void trim_scope_pop(const string &name, vector<LetBound> &let_bounds) {


### PR DESCRIPTION
#4839 fixed let_bounds in trim_scope_push to use topological order instead of a redundant depth-first traversal of the entire graph. However, by printing out the order of the let_bounds array before and after we made that change (something I should have done with the original PR), I discovered that we actually want *reverse* topological order.

Turns out nothing in the public test suite was sensitive to topological order, but in the add_image_checks_after_bounds_inference branch the compute_with test is. 