### PR TITLE
Add const to some methods that can be const

### DIFF
--- a/src/AutoSchedule.cpp
+++ b/src/AutoSchedule.cpp
@@ -1142,12 +1142,12 @@ struct Partitioner {
     // the arithmetic benefit is negative, we will treat it as no benefits and we
     // should not perform the new grouping.
     Expr estimate_benefit(const GroupAnalysis &old_grouping, const GroupAnalysis &new_grouping,
-                          bool no_redundant_work, bool ensure_parallelism);
+                          bool no_redundant_work, bool ensure_parallelism) const;
 
     // Same as above; however, 'new_grouping' is a vector of function pairs that
     // are to be grouped together.
     Expr estimate_benefit(const vector<pair<GroupingChoice, GroupConfig>> &new_grouping,
-                          bool no_redundant_work, bool ensure_parallelism);
+                          bool no_redundant_work, bool ensure_parallelism) const;
 
     // Return the total estimate on arithmetic and memory costs of computing all
     // groups within the pipeline.
@@ -2155,7 +2155,7 @@ Partitioner::GroupConfig Partitioner::evaluate_choice(const GroupingChoice &choi
 Expr Partitioner::estimate_benefit(const GroupAnalysis &old_grouping,
                                    const GroupAnalysis &new_grouping,
                                    bool no_redundant_work,
-                                   bool ensure_parallelism) {
+                                   bool ensure_parallelism) const {
     // TODO: Instead of having a hard parallelism constraint, it may be better
     // to consider other metric, such as arith_cost/parallelism
     if (ensure_parallelism &&
@@ -2178,7 +2178,7 @@ Expr Partitioner::estimate_benefit(const GroupAnalysis &old_grouping,
 
 Expr Partitioner::estimate_benefit(
     const vector<pair<GroupingChoice, GroupConfig>> &new_grouping,
-    bool no_redundant_work, bool ensure_parallelism) {
+    bool no_redundant_work, bool ensure_parallelism) const {
 
     set<FStage> old_groups;
 

--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -183,7 +183,7 @@ struct QualsState {
         }
     }
 
-    const std::string &get_result() {
+    const std::string &get_result() const {
         return result;
     }
 };

--- a/src/CodeGen_Hexagon.h
+++ b/src/CodeGen_Hexagon.h
@@ -33,7 +33,7 @@ protected:
                                          std::vector<Type> arg_types,
                                          int flags);
 
-    int is_hvx_v65_or_later() {
+    int is_hvx_v65_or_later() const {
         return (isa_version >= 65);
     }
 

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -89,7 +89,7 @@ class WithLanes : public IRMutator {
 
     int lanes;
 
-    Type with_lanes(Type t) {
+    Type with_lanes(Type t) const {
         return t.with_lanes(lanes);
     }
 

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -126,7 +126,7 @@ public:
         }
         RealizationArg(RealizationArg &&from) = default;
 
-        size_t size() {
+        size_t size() const {
             if (r != nullptr) {
                 return r->size();
             } else if (buffer_list) {

--- a/src/RegionCosts.cpp
+++ b/src/RegionCosts.cpp
@@ -625,7 +625,7 @@ RegionCosts::detailed_load_costs(const map<string, Box> &regions,
 }
 
 Cost RegionCosts::get_func_stage_cost(const Function &f, int stage,
-                                      const set<string> &inlines) {
+                                      const set<string> &inlines) const {
     if (f.has_extern_definition()) {
         return Cost();
     }

--- a/src/RegionCosts.h
+++ b/src/RegionCosts.h
@@ -86,7 +86,7 @@ struct RegionCosts {
     /** Compute the cost of producing a single value by one stage of 'f'.
      * 'inlines' specifies names of all the inlined functions. */
     Cost get_func_stage_cost(const Function &f, int stage,
-                             const std::set<std::string> &inlines = std::set<std::string>());
+                             const std::set<std::string> &inlines = std::set<std::string>()) const;
 
     /** Compute the cost of producing a single value by all stages of 'f'.
      * 'inlines' specifies names of all the inlined functions. This returns a

--- a/src/Simplify_Internal.h
+++ b/src/Simplify_Internal.h
@@ -143,7 +143,7 @@ public:
     bool no_float_simplify;
 
     HALIDE_ALWAYS_INLINE
-    bool may_simplify(const Type &t) {
+    bool may_simplify(const Type &t) const {
         return !no_float_simplify || !t.is_float();
     }
 

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -831,7 +831,7 @@ class SolveForInterval : public IRVisitor {
         }
     }
 
-    Interval interval_union(Interval ia, Interval ib) {
+    Interval interval_union(Interval ia, Interval ib) const {
         if (outer) {
             // The regular union is already conservative in the right direction
             return Interval::make_union(ia, ib);
@@ -1165,7 +1165,7 @@ class AndConditionOverDomain : public IRMutator {
         return mutate(op->value);
     }
 
-    Expr fail() {
+    Expr fail() const {
         if (flipped) {
             // True is a necessary condition for anything. Any
             // predicate implies true.


### PR DESCRIPTION
These were found with a clang-tidy checker, but the clang-tidy checker
also suggested adding const to a bunch of places where it would be
technically correct but misleading due to const not being transitive
(e.g. mutating a member via a pointer).