### PR TITLE
Remove 'weak' from extern-Function declarations in AOT

### DIFF
--- a/src/LLVM_Runtime_Linker.h
+++ b/src/LLVM_Runtime_Linker.h
@@ -31,9 +31,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_ptx_device(Target, llvm::LL
 void add_bitcode_to_module(llvm::LLVMContext *context, llvm::Module &module,
                            const std::vector<uint8_t> &bitcode, const std::string &name);
 
-/** If the GlobalValue has weak linkage, convert to the equivalent non-weak linkage. */
-void convert_weak_to_strong(llvm::GlobalValue &gv);
-
 /** Take the llvm::Module(s) in extra_modules (if any), add the runtime modules needed for the WASM JIT,
  * and link into a single llvm::Module. */
 std::unique_ptr<llvm::Module> link_with_wasm_jit_runtime(llvm::LLVMContext *c, const Target &t,


### PR DESCRIPTION
This addresses an issue seen when building with Clang-for-Windows (the Chrome toolchain): when building AOT code (but not the runtime), ensure that all the 'weak' llvm::Functions are remarked as non-weak. The problem this addresses is that when we generate a call to one of the external-weak functions (e.g. `halide_string_to_string`), LLVM will declare that symbol as .weak -- on Unixy systems this is fine, but on Windows (where weak symbols don't exist), you can end up with multiple non-weak references to the same symbol, causing linkage to fail.

This fix *could* be made Windows specific, but I'd argue that the caller of an extern Func shouldn't know or care about the eventual weakness of the linked-in symbol, so we just de-weakify them for all platforms (I haven't found any apparent injections from doing so).