### PR TITLE
Delete six dubious simplifier rules

### DIFF
--- a/src/Simplify_Add.cpp
+++ b/src/Simplify_Add.cpp
@@ -57,8 +57,6 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
              rewrite((x - broadcast(y)) + broadcast(z), x + broadcast(z - y, lanes)) ||
              rewrite(select(x, y, z) + select(x, w, u), select(x, y + w, z + u)) ||
              rewrite(select(x, c0, c1) + c2, select(x, fold(c0 + c2), fold(c1 + c2))) ||
-             rewrite(select(x, y, c1) + c2, select(x, y + c2, fold(c1 + c2))) ||
-             rewrite(select(x, c0, y) + c2, select(x, fold(c0 + c2), y + c2)) ||
 
              rewrite(select(x, y, z) + (select(x, u, v) + w), select(x, y + u, z + v) + w) ||
              rewrite(select(x, y, z) + (w + select(x, u, v)), select(x, y + u, z + v) + w) ||
@@ -82,12 +80,7 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
              rewrite(x + (c0 - y), (x - y) + c0) ||
              rewrite((x - y) + (y - z), x - z) ||
              rewrite((x - y) + (z - x), z - y) ||
-             rewrite(x + y*c0, x - y*(-c0), c0 < 0 && -c0 > 0) ||
 
-             rewrite(x + (y*c0 - z), x - y*(-c0) - z, c0 < 0 && -c0 > 0) ||
-             rewrite((y*c0 - z) + x, x - y*(-c0) - z, c0 < 0 && -c0 > 0) ||
-
-             rewrite(x*c0 + y, y - x*(-c0), c0 < 0 && -c0 > 0 && !is_const(y)) ||
              rewrite(x*y + z*y, (x + z)*y) ||
              rewrite(x*y + y*z, (x + z)*y) ||
              rewrite(y*x + z*y, y*(x + z)) ||

--- a/src/Simplify_EQ.cpp
+++ b/src/Simplify_EQ.cpp
@@ -68,10 +68,17 @@ Expr Simplify::visit(const EQ *op, ExprInfo *bounds) {
 
     if (rewrite(broadcast(x) == 0, broadcast(x == 0, lanes)) ||
         (no_overflow(delta.type()) && rewrite(x * y == 0, (x == 0) || (y == 0))) ||
+
         rewrite(select(x, 0, y) == 0, x || (y == 0)) ||
         rewrite(select(x, c0, y) == 0, !x && (y == 0), c0 != 0) ||
         rewrite(select(x, y, 0) == 0, !x || (y == 0)) ||
         rewrite(select(x, y, c0) == 0, x && (y == 0), c0 != 0) ||
+
+        rewrite(select(x, c0, y) + c1 == 0, x || (y == fold(-c1)), c0 + c1 == 0) ||
+        rewrite(select(x, y, c0) + c1 == 0, !x || (y == fold(-c1)), c0 + c1 == 0) ||
+        rewrite(select(x, c0, y) + c1 == 0, !x && (y == fold(-c1)), c0 + c1 != 0) ||
+        rewrite(select(x, y, c0) + c1 == 0, x && (y == fold(-c1)), c0 + c1 != 0) ||
+
         rewrite(max(x, y) - y == 0, x <= y) ||
         rewrite(min(x, y) - y == 0, y <= x) ||
         rewrite(max(y, x) - y == 0, x <= y) ||

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -205,12 +205,6 @@ void check_algebra() {
     check(x * y - z * x, (y - z) * x);
     check(y * x - x * z, (y - z) * x);
     check(y * x - z * x, (y - z) * x);
-    check(x - y * -2, y * 2 + x);
-    check(x + y * -2, x - y * 2);
-    check(x * -2 + y, y - x * 2);
-    check(xf - yf * -2.0f, y * 2.0f + xf);
-    check(xf + yf * -2.0f, xf - y * 2.0f);
-    check(xf * -2.0f + yf, yf - x * 2.0f);
 
     check((x * 8) - (y * 4), (x * 2 - y) * 4);
     check((x * 4) - (y * 8), (x - y * 2) * 4);
@@ -415,9 +409,9 @@ void check_algebra() {
     check((w + x) - ((w + x) - y * z) / -3, (w + x) - ((w + x) - y * z) / -3);
     check(x - (y + x) / -2, x - (x + y) / -2);
     check(x - (y - x) / -6, x - (y - x) / -6);
-    check((x + y) / 3 - x, (y - x * 2) / 3);
+    check((x + y) / 3 - x, (x * -2 + y) / 3);
     check((x * y - w) / 4 - x * y, (x * y * (-3) - w) / 4);
-    check((y + x) / 5 - x, (y - x * 4) / 5);
+    check((y + x) / 5 - x, (x * -4 + y) / 5);
     check((y - x) / 6 - x, (y - x * 7) / 6);
     check(1 - (1 + y) / 2 - 1, (0 - y) / 2);
     check(1 - (-y + 1) / 2 - 1, y / 2);


### PR DESCRIPTION
The deleted rules try to make negative constants positive, but don't
reduce the total op count, and replace an addition with a subtraction,
which doesn't count as a strength reduction.

Making negative constants positive may be defensible as a strength
reduction, but other rules may make positive constants negative again,
and elsewhere we treat replacing subtraction with addition as a strength
reduction. So we were unable to prove that these rules don't cause
cycles with these other rules (and hence infinite recursion). It would
be good to just delete them if possible.

In the open source tests, this required adding a few more variants of an
EQ rule on selects. These were formally verified. In the strength
ordering the new rules are cycle-free, even though they increase the op
count in two cases. They reduce the total number of leaf nodes by one
(c0 goes away) and we're treating the leaf count as higher priority than
the op count in our total ordering over expressions.