### PR TITLE
Fix a leak in python extension wrapper code (Issue #4859)

### DIFF
--- a/src/PythonExtensionGen.h
+++ b/src/PythonExtensionGen.h
@@ -16,9 +16,11 @@ public:
 
 private:
     std::ostream &dest;
+    std::vector<std::string> buffer_refs;
 
     void compile(const LoweredFunc &f);
     void convert_buffer(const std::string &name, const LoweredArgument *arg);
+    void release_buffers(const std::string &prefix);
 };
 
 }  // namespace Internal


### PR DESCRIPTION
Add calls to PyBuffer_Release() where appropriate.
Add a buffer parameter to _convert_py_buffer_to_halide, so the caller can release it later.  
