### PR TITLE
Internal compiler code can introduce shifts by greater than the type size

### DIFF
--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -151,7 +151,9 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
 
             // LLVM shl and shr instructions produce poison for
             // shifts >= typesize, so we will follow suit in our simplifier.
-            user_assert(ub < (uint64_t)t.bits()) << "bitshift by a constant amount >= the type size is not legal in Halide.";
+            if (ub >= (uint64_t)(t.bits())) {
+                return make_signed_integer_overflow(t);
+            }
             if (a.type().is_uint() || ub < ((uint64_t)t.bits() - 1)) {
                 b = make_const(t, ((int64_t)1LL) << ub);
                 if (shift_left) {

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1761,13 +1761,13 @@ void check_bitwise() {
     check(cast(Int(16), x) << 10, cast(Int(16), x) * 1024);
     check(cast(Int(16), x) >> 10, cast(Int(16), x) / 1024);
 
-    // Correctly triggers an error (shift by negative amount).
-    // check(cast(Int(16), x) << -10, 0);
-    // check(cast(Int(16), x) >> -10, 0);
+    // Shift by negative amount is a shift in the opposite direction
+    check(cast(Int(16), x) << -10, cast(Int(16), x) / 1024);
+    check(cast(Int(16), x) >> -10, cast(Int(16), x) * 1024);
 
-    // Correctly triggers an error (shift by >= type size).
-    // check(cast(Int(16), x) << 20, 0);
-    // check(cast(Int(16), x) >> 20, 0);
+    // Shift by >= type size is an overflow
+    check_is_sio(cast(Int(16), x) << 20);
+    check_is_sio(cast(Int(16), x) >> 20);
 
     // Check bitwise_and. (Added as result of a bug.)
     // TODO: more coverage of bitwise_and and bitwise_or.


### PR DESCRIPTION
So this should be an overflow IR node instead of being an eager user_assert.

The specific case was a can_prove(x << y) substituting in random values
for y when HL_DEBUG_CODEGEN>0 to probe for counterexamples. Some of
these random values were greater than the bit-size of x.