### PR TITLE
Reenable introspection by default, and add support for the endbr64 in…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ WITH_OPENCL ?= not-empty
 WITH_METAL ?= not-empty
 WITH_OPENGL ?= not-empty
 WITH_D3D12 ?= not-empty
+WITH_INTROSPECTION ?= not-empty
 WITH_EXCEPTIONS ?=
 WITH_LLVM_INSIDE_SHARED_LIBHALIDE ?= not-empty
 

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -4,6 +4,8 @@
 
 #include "Debug.h"
 #include "Error.h"
+#include "LLVM_Headers.h"
+#include "Util.h"
 
 #include <iostream>
 #include <sstream>
@@ -2279,6 +2281,13 @@ void deregister_heap_object(const void *obj, size_t size) {
 bool saves_frame_pointer(void *fn) {
     // On x86-64, if we save the frame pointer, the first two instructions should be pushing the stack pointer and the frame pointer:
     const uint8_t *ptr = (const uint8_t *)(fn);
+    debug(5) << (int)ptr[0] << " " << (int)ptr[1] << "\n";
+    // Skip over a valid-branch-target marker (endbr64), if there is
+    // one. These sometimes start functions to help detect control flow
+    // violations.
+    if (ptr[0] == 0xf3 && ptr[1] == 0x0f && ptr[2] == 0x1e && ptr[3] == 0xfa) {
+        ptr += 4;
+    }
     return ptr[0] == 0x55;  // push %rbp
 }
 

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -2281,7 +2281,6 @@ void deregister_heap_object(const void *obj, size_t size) {
 bool saves_frame_pointer(void *fn) {
     // On x86-64, if we save the frame pointer, the first two instructions should be pushing the stack pointer and the frame pointer:
     const uint8_t *ptr = (const uint8_t *)(fn);
-    debug(5) << (int)ptr[0] << " " << (int)ptr[1] << "\n";
     // Skip over a valid-branch-target marker (endbr64), if there is
     // one. These sometimes start functions to help detect control flow
     // violations.


### PR DESCRIPTION
…struction

Was accidentally deleted in b0b6a4a84c53b47a91a05b4487ef504fe1345e73

Also add handling for newer gccs. They now inject endbr64 instructions
at function entry.