### PR TITLE
Add basic Compiler Logging engine to Halide compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,6 +476,7 @@ SOURCE_FILES = \
   CodeGen_RISCV.cpp \
   CodeGen_WebAssembly.cpp \
   CodeGen_X86.cpp \
+  CompilerLogger.cpp \
   CPlusPlusMangle.cpp \
   CSE.cpp \
   Debug.cpp \
@@ -648,6 +649,7 @@ HEADER_FILES = \
   CodeGen_RISCV.h \
   CodeGen_WebAssembly.h \
   CodeGen_X86.h \
+  CompilerLogger.h \
   ConciseCasts.h \
   CPlusPlusMangle.h \
   CSE.h \

--- a/halide.cmake
+++ b/halide.cmake
@@ -159,7 +159,7 @@ function(halide_library_from_generator BASENAME)
     endif()
   endforeach()
 
-  set(OUTPUTS static_library c_header registration)
+  set(OUTPUTS static_library c_header registration compiler_log)
   foreach(E ${args_EXTRA_OUTPUTS})
     # Convert legacy aliases
     set(cpp_current "c_source")
@@ -220,6 +220,7 @@ function(halide_library_from_generator BASENAME)
   set(static_library_ext ${CMAKE_STATIC_LIBRARY_SUFFIX})
   set(stmt_ext ".stmt")
   set(stmt_html_ext ".stmt.html")
+  set(compiler_log_ext ".halide_compiler_log")
 
   set(OUTPUT_FILES )
   foreach(OUTPUT ${OUTPUTS})

--- a/python_bindings/src/PyEnums.cpp
+++ b/python_bindings/src/PyEnums.cpp
@@ -165,7 +165,8 @@ void define_enums(py::module &m) {
         .value("schedule", Output::schedule)
         .value("static_library", Output::static_library)
         .value("stmt", Output::stmt)
-        .value("stmt_html", Output::stmt_html);
+        .value("stmt_html", Output::stmt_html)
+        .value("compiler_log", Output::compiler_log);
 }
 
 }  // namespace PythonBindings

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -321,6 +321,7 @@ set(HEADER_FILES
   CodeGen_RISCV.h
   CodeGen_WebAssembly.h
   CodeGen_X86.h
+  CompilerLogger.h
   ConciseCasts.h
   CPlusPlusMangle.h
   CSE.h
@@ -502,6 +503,7 @@ add_library(Halide ${HALIDE_LIBRARY_TYPE}
   CodeGen_RISCV.cpp
   CodeGen_WebAssembly.cpp
   CodeGen_X86.cpp
+  CompilerLogger.cpp
   CPlusPlusMangle.cpp
   CSE.cpp
   Debug.cpp

--- a/src/CompilerLogger.cpp
+++ b/src/CompilerLogger.cpp
@@ -1,0 +1,326 @@
+#include "CompilerLogger.h"
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#include "IRMutator.h"
+#include "Util.h"
+
+namespace Halide {
+namespace Internal {
+
+namespace {
+
+// TODO: for now we are just going to ignore potential issues with
+// static-initialization-order-fiasco, as CompilerLogger isn't currently used
+// from any static-initialization execution scope.
+std::unique_ptr<CompilerLogger> active_compiler_logger;
+
+class ObfuscateNames : public IRMutator {
+    using IRMutator::visit;
+
+    std::map<std::string, std::string> remapping;
+
+    Expr visit(const Call *op) override {
+        std::vector<Expr> args;
+        for (const Expr &e : op->args) {
+            args.emplace_back(mutate(e));
+        }
+
+        std::string name = op->name;
+        if (op->call_type == Call::Extern ||
+            op->call_type == Call::ExternCPlusPlus ||
+            op->call_type == Call::Halide ||
+            op->call_type == Call::Image) {
+            name = remap(op->name);
+        }
+        return Call::make(op->type, name, args, op->call_type, op->func,
+                          op->value_index, op->image, op->param);
+    }
+
+    Expr visit(const Let *op) override {
+        std::string name = remap(op->name);
+        Expr value = mutate(op->value);
+        Expr body = mutate(op->body);
+        return Let::make(name, std::move(value), std::move(body));
+    }
+
+    Expr visit(const Load *op) override {
+        std::string name = remap(op->name);
+        Expr index = mutate(op->index);
+        Expr predicate = mutate(op->predicate);
+        return Load::make(op->type, name, index, op->image, op->param,
+                          predicate, op->alignment);
+    }
+
+    Expr visit(const Variable *op) override {
+        std::string name = remap(op->name);
+        return Variable::make(op->type, name, op->image, op->param, op->reduction_domain);
+    }
+
+public:
+    ObfuscateNames() = default;
+    ObfuscateNames(const std::initializer_list<std::pair<const std::string, std::string>> &values)
+        : remapping(values) {
+    }
+
+    std::string remap(const std::string &var_name) {
+        std::string anon_name = "anon" + std::to_string(remapping.size());
+        auto p = remapping.insert({var_name, std::move(anon_name)});
+        return p.first->second;
+    }
+};
+
+}  // namespace
+
+std::unique_ptr<CompilerLogger> set_compiler_logger(std::unique_ptr<CompilerLogger> compiler_logger) {
+    std::unique_ptr<CompilerLogger> result = std::move(active_compiler_logger);
+    active_compiler_logger = std::move(compiler_logger);
+    return result;
+}
+
+CompilerLogger *get_compiler_logger() {
+    return active_compiler_logger.get();
+}
+
+JSONCompilerLogger::JSONCompilerLogger(
+    const std::string &generator_name,
+    const std::string &function_name,
+    const std::string &autoscheduler_name,
+    const Target &target,
+    const std::string &generator_args,
+    bool obfuscate_exprs)
+    : generator_name(generator_name),
+      function_name(function_name),
+      autoscheduler_name(autoscheduler_name),
+      target(target),
+      generator_args(generator_args),
+      obfuscate_exprs(obfuscate_exprs) {
+}
+
+void JSONCompilerLogger::record_matched_simplifier_rule(const std::string &rulename) {
+    matched_simplifier_rules[rulename] += 1;
+}
+
+void JSONCompilerLogger::record_non_monotonic_loop_var(const std::string &loop_var, Expr expr) {
+    non_monotonic_loop_vars[loop_var].emplace_back(std::move(expr));
+}
+void JSONCompilerLogger::record_failed_to_prove(Expr failed_to_prove, Expr original_expr) {
+    failed_to_prove_exprs.emplace_back(failed_to_prove, original_expr);
+}
+
+void JSONCompilerLogger::obfuscate() {
+    {
+        std::map<std::string, std::vector<Expr>> n;
+        int i = 0;
+        for (const auto &it : non_monotonic_loop_vars) {
+            std::string loop_name = "loop" + std::to_string(i++);
+            for (const auto &e : it.second) {
+                // Create a new obfuscater for every Expr, but take pains to ensure
+                // that the loop var has a distinct name. (Note that for nested loops,
+                // loop vars of enclosing loops will be treated like any other var.)
+                ObfuscateNames obfuscater({{it.first, loop_name}});
+                n[loop_name].emplace_back(obfuscater.mutate(e));
+            }
+        }
+        non_monotonic_loop_vars = n;
+    }
+    {
+        std::vector<std::pair<Expr, Expr>> n;
+        for (const auto &it : failed_to_prove_exprs) {
+            // Note that use a separate obfuscater for each pair, so each
+            // shares identifiers only with each other; this makes it simpler
+            // to post-process output from multiple unrelated Generators
+            // and combine Exprs with similar shapes.
+            ObfuscateNames obfuscater;
+            auto failed_to_prove = obfuscater.mutate(it.first);
+            auto original_expr = obfuscater.mutate(it.second);
+            n.emplace_back(std::move(failed_to_prove), std::move(original_expr));
+        }
+        failed_to_prove_exprs = n;
+    }
+}
+
+namespace {
+
+std::ostream &emit_eol(std::ostream &o, bool comma = true) {
+    o << (comma ? ",\n" : "\n");
+    return o;
+}
+
+std::ostream &emit_key(std::ostream &o, int indent, const std::string &key) {
+    std::string spaces(indent, ' ');
+    o << spaces << "\"" << key << "\" : ";
+    return o;
+}
+
+std::ostream &emit_object_key_open(std::ostream &o, int indent, const std::string &key) {
+    std::string spaces(indent, ' ');
+    o << spaces << "\"" << key << "\" : {\n";
+    return o;
+}
+
+std::ostream &emit_object_key_close(std::ostream &o, int indent, bool comma = true) {
+    std::string spaces(indent, ' ');
+    o << spaces << "}";
+    emit_eol(o, comma);
+    return o;
+}
+
+template<typename VALUE>
+std::ostream &emit_value(std::ostream &o, const VALUE &value) {
+    o << value;
+    return o;
+}
+
+template<>
+std::ostream &emit_value<std::string>(std::ostream &o, const std::string &value) {
+    o << "\"" << value << "\"";
+    return o;
+}
+
+template<typename VALUE>
+std::ostream &emit_key_value(std::ostream &o, int indent, const std::string &key, const VALUE &value, bool comma = true) {
+    emit_key(o, indent, key);
+    emit_value(o, value);
+    emit_eol(o, comma);
+    return o;
+}
+
+std::ostream &emit_optional_key_value(std::ostream &o, int indent, const std::string &key, const std::string &value, bool comma = true) {
+    if (!value.empty()) {
+        return emit_key_value(o, indent, key, value, comma);
+    }
+    return o;
+}
+
+template<typename T>
+std::ostream &emit_pairs(std::ostream &o, int indent, const std::string &key, const T &pairs, bool comma = true) {
+    std::string spaces(indent, ' ');
+
+    emit_key(o, indent, key);
+    o << "{\n";
+    int commas_to_emit = (int)pairs.size() - 1;
+    for (const auto &it : pairs) {
+        const bool comma = (commas_to_emit > 0);
+        emit_key_value(o, indent + 1, it.first, it.second, comma);
+        commas_to_emit--;
+    }
+    o << spaces << "}";
+    emit_eol(o, comma);
+    return o;
+}
+
+template<typename T>
+std::ostream &emit_list(std::ostream &o, int indent, const T &list, bool comma = true) {
+    std::string spaces(indent, ' ');
+    std::string spaces_in(indent + 1, ' ');
+
+    o << spaces << "[\n";
+    int commas_to_emit = (int)list.size() - 1;
+    for (const auto &it : list) {
+        o << spaces_in;
+        emit_value(o, it);
+        emit_eol(o, commas_to_emit-- > 0);
+    }
+    o << spaces << "]";
+    emit_eol(o, comma);
+    return o;
+}
+
+std::string expr_to_string(const Expr &e) {
+    std::ostringstream s;
+    s << e;
+    return s.str();
+}
+
+std::set<std::string> exprs_to_strings(const std::vector<Expr> &exprs) {
+    std::set<std::string> strings;
+    for (const auto &e : exprs) {
+        strings.insert(expr_to_string(e));
+    }
+    return strings;
+}
+
+}  // namespace
+
+std::ostream &JSONCompilerLogger::emit_to_stream(std::ostream &o) {
+    if (obfuscate_exprs) {
+        obfuscate();
+    }
+
+    // Output in JSON form
+
+    o << "{\n";
+
+    int indent = 1;
+    emit_optional_key_value(o, indent, "generator_name", generator_name);
+    emit_optional_key_value(o, indent, "function_name", function_name);
+    emit_optional_key_value(o, indent, "autoscheduler_name", autoscheduler_name);
+    emit_optional_key_value(o, indent, "target", target == Target() ? "" : target.to_string());
+    emit_optional_key_value(o, indent, "generator_args", generator_args);
+
+    if (!matched_simplifier_rules.empty()) {
+        using P = std::pair<std::string, int64_t>;
+
+        // Sort these in descending order by usage,
+        // just to make casual reading of the output easier
+        struct Compare {
+            bool operator()(const P &a, const P &b) const {
+                return a.second > b.second;
+            }
+        };
+
+        std::set<P, Compare> sorted;
+        for (const auto &it : matched_simplifier_rules) {
+            sorted.emplace(it.first, it.second);
+        }
+        emit_pairs(o, indent, "matched_simplifier_rules", sorted);
+    }
+
+    if (!non_monotonic_loop_vars.empty()) {
+        emit_object_key_open(o, indent, "non_monotonic_loop_vars");
+
+        int commas_to_emit = (int)non_monotonic_loop_vars.size() - 1;
+        for (const auto &it : non_monotonic_loop_vars) {
+            const auto &loop_var = it.first;
+            emit_key(o, indent + 1, loop_var);
+            emit_eol(o, false);
+            emit_list(o, indent + 1, exprs_to_strings(it.second), (commas_to_emit-- > 0));
+        }
+
+        emit_object_key_close(o, indent);
+    }
+
+    if (!failed_to_prove_exprs.empty()) {
+        emit_object_key_open(o, indent, "failed_to_prove");
+
+        // We'll do deduplication here, during stringification.
+        std::map<std::string, std::set<std::string>> sorted;
+        for (const auto &it : failed_to_prove_exprs) {
+            const auto failed_to_prove_str = expr_to_string(it.first);
+            const auto original_expr_str = expr_to_string(it.second);
+            sorted[failed_to_prove_str].insert(original_expr_str);
+        }
+
+        int commas_to_emit = (int)sorted.size() - 1;
+        for (const auto &it : sorted) {
+            emit_key(o, indent + 1, it.first);
+            emit_eol(o, false);
+            emit_list(o, indent + 1, it.second, (commas_to_emit-- > 0));
+        }
+
+        emit_object_key_close(o, indent);
+    }
+
+    // Emit this last as a simple way to dodge the trailing-comma nonsense
+    o << " \"version\": \"HalideJSONCompilerLoggerV1\"\n";
+    o << "}\n";
+
+    return o;
+}
+
+}  // namespace Internal
+}  // namespace Halide

--- a/src/CompilerLogger.h
+++ b/src/CompilerLogger.h
@@ -1,0 +1,103 @@
+#ifndef HALIDE_COMPILER_LOGGER_H_
+#define HALIDE_COMPILER_LOGGER_H_
+
+/** \file
+ * Defines an interface used to gather and log compile-time information, stats, etc
+ * for use in evaluating internal Halide compilation rules and efficiency.
+ *
+ * The 'standard' implementation that simply logs all gathered data to
+ * a local file (in JSON form), but the entire implementation can be
+ * replaced by custom definitions if you have unusual logging needs.
+ */
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+
+#include "Expr.h"
+#include "Target.h"
+
+namespace Halide {
+namespace Internal {
+
+class CompilerLogger {
+public:
+    CompilerLogger() = default;
+    virtual ~CompilerLogger() = default;
+
+    /** Record when a particular simplifier rule matches.
+     */
+    virtual void record_matched_simplifier_rule(const std::string &rulename) = 0;
+
+    /** Record when an expression is non-monotonic in a loop variable.
+     */
+    virtual void record_non_monotonic_loop_var(const std::string &loop_var, Expr expr) = 0;
+
+    /** Record when can_prove() fails, but cannot find a counterexample.
+     */
+    virtual void record_failed_to_prove(Expr failed_to_prove, Expr original_expr) = 0;
+
+    /**
+     * Emit all the gathered data to the given stream. This may be called multiple times.
+     */
+    virtual std::ostream &emit_to_stream(std::ostream &o) = 0;
+};
+
+/** Set the active CompilerLogger object, replacing any existing one.
+ * It is legal to pass in a nullptr (which means "don't do any compiler logging").
+ * Returns the previous CompilerLogger (if any). */
+std::unique_ptr<CompilerLogger> set_compiler_logger(std::unique_ptr<CompilerLogger> compiler_logger);
+
+/** Return the currently active CompilerLogger object. If set_compiler_logger()
+ * has never been called, a nullptr implementation will be returned.
+ * Do not save the pointer returned! It is intended to be used for immediate
+ * calls only. */
+CompilerLogger *get_compiler_logger();
+
+/** JSONCompilerLogger is a basic implementation of the CompilerLogger interface
+ * that saves logged data, then logs it all in JSON format in emit_to_stream().
+ */
+class JSONCompilerLogger : public CompilerLogger {
+public:
+    JSONCompilerLogger() = default;
+
+    JSONCompilerLogger(
+        const std::string &generator_name,
+        const std::string &function_name,
+        const std::string &autoscheduler_name,
+        const Target &target,
+        const std::string &generator_args,
+        bool obfuscate_exprs);
+
+    void record_matched_simplifier_rule(const std::string &rulename) override;
+    void record_non_monotonic_loop_var(const std::string &loop_var, Expr expr) override;
+    void record_failed_to_prove(Expr failed_to_prove, Expr original_expr) override;
+    std::ostream &emit_to_stream(std::ostream &o) override;
+
+protected:
+    const std::string generator_name;
+    const std::string function_name;
+    const std::string autoscheduler_name;
+    const Target target;
+    const std::string generator_args;
+    const bool obfuscate_exprs{false};
+
+    std::map<std::string, int64_t> matched_simplifier_rules;
+
+    // Maps loop_var -> list of Exprs that were nonmonotonic for that loop_var
+    std::map<std::string, std::vector<Expr>> non_monotonic_loop_vars;
+
+    // List of (unprovable simplfied Expr, original version of that Expr passed to can_prove()).
+    std::vector<std::pair<Expr, Expr>> failed_to_prove_exprs;
+
+    void obfuscate();
+    void emit();
+};
+
+}  // namespace Internal
+}  // namespace Halide
+
+#endif  // HALIDE_COMPILER_LOGGER_H_

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -8,6 +8,7 @@
 #include "CodeGen_C.h"
 #include "CodeGen_Internal.h"
 #include "CodeGen_PyTorch.h"
+#include "CompilerLogger.h"
 #include "Debug.h"
 #include "HexagonOffload.h"
 #include "IROperator.h"
@@ -42,6 +43,7 @@ std::map<Output, OutputInfo> get_output_info(const Target &target) {
         {Output::bitcode, {"bitcode", ".bc"}},
         {Output::c_header, {"c_header", ".h"}},
         {Output::c_source, {"c_source", ".halide_generated.cpp"}},
+        {Output::compiler_log, {"compiler_log", ".halide_compiler_log"}},
         {Output::cpp_stub, {"cpp_stub", ".stub.h"}},
         {Output::featurization, {"featurization", ".featurization"}},
         {Output::llvm_assembly, {"llvm_assembly", ".ll"}},
@@ -72,11 +74,10 @@ public:
         debug(1) << "dir_rmdir: " << dir_path << "\n";
         dir_rmdir(dir_path);
     }
-    std::string add_temp_object_file(const std::string &base_path_name,
-                                     const std::string &suffix,
-                                     const Target &target,
-                                     bool in_front = false) {
-        const char *ext = (target.os == Target::Windows) ? ".obj" : ".o";
+    std::string add_temp_file(const std::string &base_path_name,
+                              const std::string &suffix,
+                              const Target &target,
+                              bool in_front = false) {
         size_t slash_idx = base_path_name.rfind('/');
         size_t backslash_idx = base_path_name.rfind('\\');
         if (slash_idx == std::string::npos) {
@@ -90,7 +91,7 @@ public:
             backslash_idx++;
         }
         std::string base_name = base_path_name.substr(std::max(slash_idx, backslash_idx));
-        std::string name = dir_path + "/" + base_name + suffix + ext;
+        std::string name = dir_path + "/" + base_name + suffix;
         debug(1) << "add_temp_object_file: " << name << "\n";
         if (in_front) {
             dir_files.insert(dir_files.begin(), name);
@@ -98,6 +99,14 @@ public:
             dir_files.push_back(name);
         }
         return name;
+    }
+
+    std::string add_temp_object_file(const std::string &base_path_name,
+                                     const std::string &suffix,
+                                     const Target &target,
+                                     bool in_front = false) {
+        const char *ext = (target.os == Target::Windows) ? ".obj" : ".o";
+        return add_temp_file(base_path_name, suffix + ext, target, in_front);
     }
 
     const std::vector<std::string> &files() {
@@ -567,9 +576,7 @@ void Module::compile(const std::map<Output, std::string> &output_files) const {
     if (!submodules().empty()) {
         std::map<Output, std::string> output_files_copy = output_files;
         output_files_copy.erase(Output::stmt);
-        ;
         output_files_copy.erase(Output::stmt_html);
-        ;
         resolve_submodules().compile(output_files_copy);
         return;
     }
@@ -674,6 +681,20 @@ void Module::compile(const std::map<Output, std::string> &output_files) const {
         std::ofstream file(output_files.at(Output::pytorch_wrapper));
         Internal::CodeGen_PyTorch cg(file);
         cg.compile(*this);
+        file.close();
+        internal_assert(!file.fail());
+    }
+    if (contains(output_files, Output::compiler_log)) {
+        debug(1) << "Module.compile(): compiler_log " << output_files.at(Output::compiler_log) << "\n";
+        std::ofstream file(output_files.at(Output::compiler_log));
+        internal_assert(get_compiler_logger() != nullptr);
+        get_compiler_logger()->emit_to_stream(file);
+        file.close();
+        internal_assert(!file.fail());
+    }
+    // If HL_DEBUG_COMPILER_LOGGER is set, dump the log (if any) to stderr now, whether or it is required
+    if (get_env_variable("HL_DEBUG_COMPILER_LOGGER") == "1" && get_compiler_logger() != nullptr) {
+        get_compiler_logger()->emit_to_stream(std::cerr);
     }
 }
 
@@ -698,20 +719,35 @@ void compile_standalone_runtime(const std::string &object_filename, Target t) {
     compile_standalone_runtime({{Output::object, object_filename}}, t);
 }
 
+namespace {
+
+class ScopedCompilerLogger {
+public:
+    ScopedCompilerLogger(const CompilerLoggerFactory &compiler_logger_factory, const std::string &fn_name, const Target &target) {
+        internal_assert(!get_compiler_logger());
+        if (compiler_logger_factory) {
+            set_compiler_logger(compiler_logger_factory(fn_name, target));
+        } else {
+            set_compiler_logger(nullptr);
+        }
+    }
+
+    ~ScopedCompilerLogger() {
+        set_compiler_logger(nullptr);
+    }
+};
+
+}  // namespace
+
 void compile_multitarget(const std::string &fn_name,
                          const std::map<Output, std::string> &output_files,
                          const std::vector<Target> &targets,
-                         const ModuleProducer &module_producer) {
+                         const ModuleFactory &module_factory,
+                         const CompilerLoggerFactory &compiler_logger_factory) {
     validate_outputs(output_files);
 
     user_assert(!fn_name.empty()) << "Function name must be specified.\n";
     user_assert(!targets.empty()) << "Must specify at least one target.\n";
-
-    // You can't ask for .o files when doing this; it's not really useful,
-    // and would complicate output (we might have to do multiple passes
-    // if different values for NoRuntime are specified)... so just forbid
-    // it up front.
-    user_assert(!contains(output_files, Output::object)) << "Cannot request object for compile_multitarget.\n";
 
     // The final target in the list is considered "baseline", and is used
     // for (e.g.) the runtime and shared code. It is often just os-arch-bits
@@ -725,9 +761,16 @@ void compile_multitarget(const std::string &fn_name,
     const bool needs_wrapper = (targets.size() > 1);
     if (targets.size() == 1) {
         debug(1) << "compile_multitarget: single target is " << base_target.to_string() << "\n";
-        module_producer(fn_name, base_target).compile(output_files);
+        ScopedCompilerLogger activate(compiler_logger_factory, fn_name, base_target);
+        module_factory(fn_name, base_target).compile(output_files);
         return;
     }
+
+    // You can't ask for .o files when doing this; it's not really useful,
+    // and would complicate output (we might have to do multiple passes
+    // if different values for NoRuntime are specified)... so just forbid
+    // it up front.
+    user_assert(!contains(output_files, Output::object)) << "Cannot request object for compile_multitarget.\n";
 
     // For safety, the runtime must be built only with features common to all
     // of the targets; given an unusual ordering like
@@ -745,7 +788,7 @@ void compile_multitarget(const std::string &fn_name,
     constexpr int kFeaturesWordCount = (Target::FeatureEnd + 63) / (sizeof(uint64_t) * 8);
     uint64_t runtime_features[kFeaturesWordCount] = {(uint64_t)-1LL};
 
-    TemporaryObjectFileDir temp_dir;
+    TemporaryObjectFileDir temp_obj_dir, temp_compiler_log_dir;
     std::vector<Expr> wrapper_args;
     std::vector<LoweredArgument> base_target_args;
     std::vector<AutoSchedulerResults> auto_scheduler_results;
@@ -786,22 +829,26 @@ void compile_multitarget(const std::string &fn_name,
             sub_fn_target = sub_fn_target.without_feature(Target::Matlab);
         }
 
-        Module sub_module = module_producer(sub_fn_name, sub_fn_target);
-        // Re-assign every time -- should be the same across all targets anyway,
-        // but base_target is always the last one we encounter.
-        base_target_args = sub_module.get_function_by_name(sub_fn_name).args;
+        {
+            ScopedCompilerLogger activate(compiler_logger_factory, sub_fn_name, sub_fn_target);
+            Module sub_module = module_factory(sub_fn_name, sub_fn_target);
+            // Re-assign every time -- should be the same across all targets anyway,
+            // but base_target is always the last one we encounter.
+            base_target_args = sub_module.get_function_by_name(sub_fn_name).args;
 
-        auto sub_out = add_suffixes(output_files, suffix);
-        internal_assert(contains(output_files, Output::static_library));
-        sub_out[Output::object] = temp_dir.add_temp_object_file(output_files.at(Output::static_library), suffix, target);
-        sub_out.erase(Output::registration);
-        ;
-        sub_out.erase(Output::schedule);
-        ;
-        debug(1) << "compile_multitarget: compile_sub_target " << sub_out[Output::object] << "\n";
-        sub_module.compile(sub_out);
-        auto *r = sub_module.get_auto_scheduler_results();
-        auto_scheduler_results.push_back(r ? *r : AutoSchedulerResults());
+            auto sub_out = add_suffixes(output_files, suffix);
+            internal_assert(contains(output_files, Output::static_library));
+            sub_out[Output::object] = temp_obj_dir.add_temp_object_file(output_files.at(Output::static_library), suffix, target);
+            sub_out.erase(Output::registration);
+            sub_out.erase(Output::schedule);
+            if (contains(sub_out, Output::compiler_log)) {
+                sub_out[Output::compiler_log] = temp_compiler_log_dir.add_temp_file(output_files.at(Output::static_library), suffix, target);
+            }
+            debug(1) << "compile_multitarget: compile_sub_target " << sub_out[Output::object] << "\n";
+            sub_module.compile(sub_out);
+            auto *r = sub_module.get_auto_scheduler_results();
+            auto_scheduler_results.push_back(r ? *r : AutoSchedulerResults());
+        }
 
         uint64_t cur_target_features[kFeaturesWordCount] = {0};
         for (int i = 0; i < Target::FeatureEnd; ++i) {
@@ -849,7 +896,7 @@ void compile_multitarget(const std::string &fn_name,
         }
         std::map<Output, std::string> runtime_out =
             {{Output::object,
-              temp_dir.add_temp_object_file(output_files.at(Output::static_library), "_runtime", runtime_target)}};
+              temp_obj_dir.add_temp_object_file(output_files.at(Output::static_library), "_runtime", runtime_target)}};
         debug(1) << "compile_multitarget: compile_standalone_runtime " << runtime_out.at(Output::object) << "\n";
         compile_standalone_runtime(runtime_out, runtime_target);
     }
@@ -882,7 +929,7 @@ void compile_multitarget(const std::string &fn_name,
         wrapper_module.append(LoweredFunc(fn_name, base_target_args, wrapper_body, LinkageType::ExternalPlusMetadata));
 
         std::map<Output, std::string> wrapper_out = {{Output::object,
-                                                      temp_dir.add_temp_object_file(output_files.at(Output::static_library), "_wrapper", base_target, /* in_front*/ true)}};
+                                                      temp_obj_dir.add_temp_object_file(output_files.at(Output::static_library), "_wrapper", base_target, /* in_front*/ true)}};
         debug(1) << "compile_multitarget: wrapper " << wrapper_out.at(Output::object) << "\n";
         wrapper_module.compile(wrapper_out);
     }
@@ -958,7 +1005,25 @@ void compile_multitarget(const std::string &fn_name,
 
     if (contains(output_files, Output::static_library)) {
         debug(1) << "compile_multitarget: static_library " << output_files.at(Output::static_library) << "\n";
-        create_static_library(temp_dir.files(), base_target, output_files.at(Output::static_library));
+        create_static_library(temp_obj_dir.files(), base_target, output_files.at(Output::static_library));
+    }
+
+    if (contains(output_files, Output::compiler_log)) {
+        debug(1) << "compile_multitarget: compiler_log " << output_files.at(Output::compiler_log) << "\n";
+
+        std::ofstream compiler_log_file(output_files.at(Output::compiler_log));
+        compiler_log_file << "[\n";
+        const auto &f = temp_compiler_log_dir.files();
+        for (size_t i = 0; i < f.size(); i++) {
+            auto d = read_entire_file(f[i]);
+            compiler_log_file.write(d.data(), d.size());
+            if (i < f.size() - 1) {
+                compiler_log_file << ",\n";
+            }
+        }
+        compiler_log_file << "]\n";
+        compiler_log_file.close();
+        internal_assert(!compiler_log_file.fail());
     }
 }
 

--- a/src/Module.h
+++ b/src/Module.h
@@ -8,6 +8,7 @@
 
 #include <functional>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 
@@ -29,6 +30,7 @@ enum class Output {
     bitcode,
     c_header,
     c_source,
+    compiler_log,
     cpp_stub,
     featurization,
     llvm_assembly,
@@ -109,7 +111,8 @@ struct LoweredFunc {
 
 namespace Internal {
 struct ModuleContents;
-}
+class CompilerLogger;
+}  // namespace Internal
 
 struct AutoSchedulerResults;
 
@@ -200,12 +203,14 @@ void compile_standalone_runtime(const std::string &object_filename, Target t);
  */
 std::map<Output, std::string> compile_standalone_runtime(const std::map<Output, std::string> &output_files, Target t);
 
-typedef std::function<Module(const std::string &, const Target &)> ModuleProducer;
+using ModuleFactory = std::function<Module(const std::string &fn_name, const Target &target)>;
+using CompilerLoggerFactory = std::function<std::unique_ptr<Internal::CompilerLogger>(const std::string &fn_name, const Target &target)>;
 
 void compile_multitarget(const std::string &fn_name,
                          const std::map<Output, std::string> &output_files,
                          const std::vector<Target> &targets,
-                         const ModuleProducer &module_producer);
+                         const ModuleFactory &module_factory,
+                         const CompilerLoggerFactory &compiler_logger_factory = nullptr);
 
 }  // namespace Halide
 

--- a/src/SimplifyCorrelatedDifferences.cpp
+++ b/src/SimplifyCorrelatedDifferences.cpp
@@ -1,6 +1,7 @@
 #include "SimplifyCorrelatedDifferences.h"
 
 #include "CSE.h"
+#include "CompilerLogger.h"
 #include "ExprUsesVar.h"
 #include "IRMatch.h"
 #include "IRMutator.h"
@@ -218,9 +219,13 @@ class SimplifyCorrelatedDifferences : public IRMutator {
             e = PartiallyCancelDifferences().mutate(e);
             e = simplify(e);
 
-            if ((debug::debug_level() > 0) &&
+            const bool check_non_monotonic = debug::debug_level() > 0 || get_compiler_logger() != nullptr;
+            if (check_non_monotonic &&
                 is_monotonic(e, loop_var) == Monotonic::Unknown) {
                 // Might be a missed simplification opportunity. Log to help improve the simplifier.
+                if (get_compiler_logger()) {
+                    get_compiler_logger()->record_non_monotonic_loop_var(loop_var, e);
+                }
                 debug(1) << "Warning: expression is non-monotonic in loop variable "
                          << loop_var << ": " << e << "\n";
             }

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -1,6 +1,7 @@
 #include "SlidingWindow.h"
 
 #include "Bounds.h"
+#include "CompilerLogger.h"
 #include "Debug.h"
 #include "IRMutator.h"
 #include "IROperator.h"
@@ -196,11 +197,19 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
             if (monotonic_min == Monotonic::Increasing ||
                 monotonic_min == Monotonic::Constant) {
                 can_slide_up = true;
+            } else if (monotonic_min == Monotonic::Unknown) {
+                if (get_compiler_logger()) {
+                    get_compiler_logger()->record_non_monotonic_loop_var(loop_var, min_required);
+                }
             }
 
             if (monotonic_max == Monotonic::Decreasing ||
                 monotonic_max == Monotonic::Constant) {
                 can_slide_down = true;
+            } else if (monotonic_max == Monotonic::Unknown) {
+                if (get_compiler_logger()) {
+                    get_compiler_logger()->record_non_monotonic_loop_var(loop_var, max_required);
+                }
             }
 
             if (!can_slide_up && !can_slide_down) {


### PR DESCRIPTION
Up to now, we've typically gathered metadata about Halide compilation on an ad-hoc basis (e.g. via debug() statements); this adds a Telemetry output to Halide to allow us to gather data in a more structured way, so that we can do batch analysis of things like Simplifier rules more easily.

This is modeled as a Generator output for now (though it could be used manually with the JIT if desired); the `telemetry` output is a JSON file that contains basic information about the Generator being driven, along with information about:
- Expressions that failed `can_prove` (including a text version of the original and failed version)
- Loop vars that are non-monotonic
- Eventually, the usage rate for each Simplifier rule (this requires some additional scaffolding in the Simplifier to enable)

The CMake build file was modified to emit telemetry files by default for all Generators (I did not attempt to modify the Makefile in this way, though).

For debugging purposes, you can use HL_DEBUG_TELEMETRY=1 to dump all Telemetry to stderr (whether or not telemetry output is specified for a specific Generator).

You can also optionally specify HL_TELEMETRY_ANONYMIZE=1, which will cause all emitted telemetry to try to scrub interesting identifiers away; this is intended to allow gathering data on proprietary code and contributing it to a public analyzer (e.g. to find missed simplifier opportunities).

The JSON looks something like this (**UPDATED**):

```
{
 "generator_name" : "interpolate",
 "function_name" : "interpolate",
 "target" : "x86-64-linux-avx-no_runtime-sse41",
 "generator_args" : "auto_schedule=false",
 "non_monotonic_loop_vars" : {
  "downsampled_1.s0.y.v10" :
  [
   "(((downsampled_1.s0.y.v10*-2) + ((t140.s*-2) + ((t140.s*2) + (select((0 < downsampled_1.s0.y.v10), -14, -15) + (downsampled_1.s0.y.v10*2)))))*-1)",
   "(((downsampled_1.s0.y.v10*-2) + ((t142.s*-2) + ((t142.s*2) + (select((0 < downsampled_1.s0.y.v10), -14, -15) + (downsampled_1.s0.y.v10*2)))))*-1)",
   "((downsampled_1.s0.y.v10*-2) + (select((0 < downsampled_1.s0.y.v10), -14, -15) + (downsampled_1.s0.y.v10*2)))"
  ],
  "downsampled_1.s0.y.v9" :
  [
   "(let t140.s = min(((downsampled_1.s0.y.v9*8) + 4), downsampled_1.s0.y.max) in (((downsampled_1.s0.y.v10*2) + ((t140.s*2) - (select((0 < downsampled_1.s0.y.v10), -14, -15) + ((downsampled_1.s0.y.v10 + t140.s)*2)))) + -14))",
   ...etc...
  ],
  ...etc...
 },
 "failed_to_prove" : {
  "(v0 <= (min(v0, 16) + (((max(v0, 16) + -1)/16)*16)))" :
  [
   "(let t2839 = min(input.extent.0, 16) in (let t2840 = (normalize.s0.y.v10 + normalize.s0.y.v10.base) in (((((((uint1)1 && ((0 + (t2839 + -16)) <= (t2839 + -16))) && ((15 + (min((t2839 + (((max(input.extent.0, 16) + -1)/16)*16)), input.extent.0) + -16)) >= (min((((input.extent.0 + -1)/16)*16), (input.extent.0 + -16)) + 15))) && (t2840 <= t2840)) && (t2840 >= t2840)) && (0 <= 0)) && (3 >= 3))))"
  ]
 },
 "version": "HalideJSONTelemetryV1"
}
```

If you specify HL_TELEMETRY_ANONYMIZE=1, this will instead look something like  (**UPDATED**):

```
{
 // names omitted
 "non_monotonic_loop_vars" : {
  "anon0" :
  [
   "(((anon0*-2) + ((anon1*-2) + ((anon1*2) + (select((0 < anon0), -14, -15) + (anon0*2)))))*-1)",
   "(((anon0*-2) + ((anon2*-2) + ((anon2*2) + (select((0 < anon0), -14, -15) + (anon0*2)))))*-1)",
   "((anon0*-2) + (select((0 < anon0), -14, -15) + (anon0*2)))"
  ],
  "anon11" :
  [
   "((((((select((0 < anon11), 1022, 0) + anon11) + anon12)/512)*-512) + anon12) + anon11)",
   ...etc...
  ],
  ...etc...
 },
 "failed_to_prove" : {
  "(anon58 <= (min(anon58, 16) + (((max(anon58, 16) + -1)/16)*16)))" :
  [
   "(let anon59 = min(anon60, 16) in (let anon61 = (anon11 + anon62) in (((((((uint1)1 && ((0 + (anon59 + -16)) <= (anon59 + -16))) && ((15 + (min((anon59 + (((max(anon60, 16) + -1)/16)*16)), anon60) + -16)) >= (min((((anon60 + -1)/16)*16), (anon60 + -16)) + 15))) && (anon61 <= anon61)) && (anon61 >= anon61)) && (0 <= 0)) && (3 >= 3))))"
  ]
 },
 "version": "HalideJSONTelemetryV1"
}
```

If generating a multitarget, the JSON will be an array of these objects (one per subtarget):

```
[
{
 "generator_name" : "interpolate",
 "target" : "x86-64-linux-avx-sse41",
 ...
},
{
 "generator_name" : "interpolate",
 "target" : "x86-64-linux-avx",
 ...
},
{
 "generator_name" : "interpolate",
 "target" : "x86-64-linux",
 ...
}
]
```

There are definitely more things that we want to add to this that aren't yet implemented; off the top of my head:
- Halide IR-building/lowering time
- LLVM codegen time
- total compilation time
- final code size