### PR TITLE
Don't inject min/max exprs in bounds of a promise_clamped of constant

### DIFF
--- a/src/Monotonic.cpp
+++ b/src/Monotonic.cpp
@@ -317,6 +317,12 @@ class MonotonicVisitor : public IRVisitor {
             return;
         }
 
+        if (op->is_intrinsic(Call::unsafe_promise_clamped) ||
+            op->is_intrinsic(Call::promise_clamped)) {
+            op->args[0].accept(this);
+            return;
+        }
+
         if (op->is_intrinsic(Call::require)) {
             // require() returns the value of the second arg in all non-failure cases
             op->args[1].accept(this);

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -271,7 +271,7 @@ tests(GROUPS correctness travis
         skip_stages_external_array_functions.cpp
         skip_stages_memoize.cpp
         sliding_backwards.cpp
-        slicing_over_guard_with_if.cpp
+        sliding_over_guard_with_if.cpp
         sliding_reduction.cpp
         sliding_window.cpp
         sort_exprs.cpp

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -271,6 +271,7 @@ tests(GROUPS correctness travis
         skip_stages_external_array_functions.cpp
         skip_stages_memoize.cpp
         sliding_backwards.cpp
+        slicing_over_guard_with_if.cpp
         sliding_reduction.cpp
         sliding_window.cpp
         sort_exprs.cpp

--- a/test/correctness/sliding_over_guard_with_if.cpp
+++ b/test/correctness/sliding_over_guard_with_if.cpp
@@ -1,0 +1,57 @@
+#include "Halide.h"
+#include "halide_benchmark.h"
+#include <cstdio>
+#include <memory>
+
+using namespace Halide;
+using namespace Halide::Tools;
+
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+int call_count = 0;
+extern "C" DLLEXPORT int call_counter(int x, int y) {
+    call_count++;
+    return x;
+}
+HalideExtern_2(int, call_counter, int, int);
+
+int main(int argc, char **argv) {
+    Var x, y;
+
+    // A test case that requires sliding window to be able to slide
+    // over a guardwithif split + promise_clamped.
+
+    Func expensive;
+    expensive(x, y) = call_counter(x, y);
+
+    Func dst;
+    dst(x, y) = expensive(x, y - 1) + expensive(x, y) + expensive(x, y + 1);
+
+    Var yo("yo");
+    dst.compute_root()
+        .split(y, yo, y, 64, TailStrategy::GuardWithIf);
+
+    expensive
+        .compute_at(dst, y)
+        .store_at(dst, yo)
+        .fold_storage(y, 4);
+
+    Buffer<int> out = dst.realize(100, 100);
+
+    // The number of calls to 'expensive' should be the size of the
+    // output, plus some margin from the stencil, plus a little
+    // redundant recompute at the split boundary.
+    int correct = (out.height() + 2 + 2) * out.width();
+    if (call_count != correct) {
+        printf("number of calls to producer was %d instead of %d\n",
+               call_count, correct);
+        return 1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
No effect in public Halide, but I hear it causes at least one regression
inside Google. The reason for injecting the min/max exprs in the case
where the first arg doesn't vary has since gone away now that we push
producers inside the guard-with-if if statement of a consumer.