### PR TITLE
Run clang-tidy on Introspection.cpp

### DIFF
--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -205,7 +205,7 @@ class DebugSections {
 public:
     bool working;
 
-    DebugSections(std::string binary)
+    DebugSections(const std::string& binary)
         : calibrated(false), working(false) {
 #ifdef __APPLE__
         size_t last_slash = binary.rfind('/');
@@ -1610,7 +1610,7 @@ private:
 
                 } else if (fmt.tag == tag_function) {
                     if (fmt.has_children) {
-                        func_stack.push_back({func, stack_depth});
+                        func_stack.emplace_back(func, stack_depth);
                     } else {
                         functions.push_back(func);
                     }
@@ -1619,7 +1619,7 @@ private:
                            fmt.tag == tag_array_type ||
                            fmt.tag == tag_base_type) {
                     if (fmt.has_children) {
-                        type_stack.push_back({type_info, stack_depth});
+                        type_stack.emplace_back(type_info, stack_depth);
                     } else {
                         types.push_back(type_info);
                     }
@@ -1633,11 +1633,11 @@ private:
                     if (namespace_name.empty()) {
                         namespace_name = "_";
                     }
-                    namespace_stack.push_back({namespace_name, stack_depth});
+                    namespace_stack.emplace_back(namespace_name, stack_depth);
                 } else if ((fmt.tag == tag_inlined_subroutine ||
                             fmt.tag == tag_lexical_block) &&
                            live_ranges.size() && fmt.has_children) {
-                    live_range_stack.push_back({live_ranges, stack_depth});
+                    live_range_stack.emplace_back(live_ranges, stack_depth);
                 }
             }
         }
@@ -1747,15 +1747,15 @@ private:
             TypeInfo *t = &types[i];
             while (t) {
                 if (t->type == TypeInfo::Pointer) {
-                    suffix.push_back("*");
+                    suffix.emplace_back("*");
                     internal_assert(t->members.size() == 1);
                     t = t->members[0].type;
                 } else if (t->type == TypeInfo::Reference) {
-                    suffix.push_back("&");
+                    suffix.emplace_back("&");
                     internal_assert(t->members.size() == 1);
                     t = t->members[0].type;
                 } else if (t->type == TypeInfo::Const) {
-                    suffix.push_back("const");
+                    suffix.emplace_back("const");
                     internal_assert(t->members.size() == 1);
                     t = t->members[0].type;
                 } else if (t->type == TypeInfo::Array) {
@@ -1765,7 +1765,7 @@ private:
                         oss << "[" << t->size << "]";
                         suffix.push_back(oss.str());
                     } else {
-                        suffix.push_back("[]");
+                        suffix.emplace_back("[]");
                     }
                     internal_assert(t->members.size() == 1);
                     t = t->members[0].type;
@@ -1955,11 +1955,11 @@ private:
 
             vector<std::string> include_dirs;
             // The current directory is implicitly the first dir.
-            include_dirs.push_back(".");
+            include_dirs.emplace_back(".");
             while (off < end_header_off) {
                 const char *s = e.getCStr(&off);
                 if (s && s[0]) {
-                    include_dirs.push_back(s);
+                    include_dirs.emplace_back(s);
                 } else {
                     break;
                 }

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -207,21 +207,22 @@ public:
 
     DebugSections(const std::string &binary)
         : calibrated(false), working(false) {
+        std::string binary_path = binary;
 #ifdef __APPLE__
-        size_t last_slash = binary.rfind('/');
+        size_t last_slash = binary_path.rfind('/');
         if (last_slash == std::string::npos ||
-            last_slash >= binary.size() - 1) {
+            last_slash >= binary_path.size() - 1) {
             last_slash = 0;
         } else {
             last_slash++;
         }
-        std::string file_only = binary.substr(last_slash, binary.size() - last_slash);
-        binary += ".dSYM/Contents/Resources/DWARF/" + file_only;
+        std::string file_only = binary_path.substr(last_slash, binary_path.size() - last_slash);
+        binary_path += ".dSYM/Contents/Resources/DWARF/" + file_only;
 #endif
 
-        debug(5) << "Loading " << binary << "\n";
+        debug(5) << "Loading " << binary_path << "\n";
 
-        load_and_parse_object_file(binary);
+        load_and_parse_object_file(binary_path);
     }
 
     int count_trailing_zeros(int64_t x) {

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -205,7 +205,7 @@ class DebugSections {
 public:
     bool working;
 
-    DebugSections(const std::string& binary)
+    DebugSections(const std::string &binary)
         : calibrated(false), working(false) {
 #ifdef __APPLE__
         size_t last_slash = binary.rfind('/');


### PR DESCRIPTION
The clang-tidy presubmit didn't see it because it's conditionally compiled.