### PR TITLE
Call dlsym() directly in runtime/metal.cpp

### DIFF
--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -11,6 +11,8 @@
 extern "C" {
 extern objc_id MTLCreateSystemDefaultDevice();
 extern struct ObjectiveCClass _NSConcreteGlobalBlock;
+void *dlsym(void *, const char *);
+#define RTLD_DEFAULT ((void *)-2)
 }
 
 namespace Halide {
@@ -228,7 +230,9 @@ inline mtl_device *get_default_mtl_device() {
     mtl_device *device = (mtl_device *)MTLCreateSystemDefaultDevice();
     if (device == NULL) {
         // We assume Metal.framework is already loaded
-        void *handle = halide_get_symbol("MTLCopyAllDevices");
+        // (call dlsym directly, rather than halide_get_symbol, as we
+        // currently don't provide halide_get_symbol for iOS, only OSX)
+        void *handle = dlsym(RTLD_DEFAULT, "MTLCopyAllDevices");
         if (handle != NULL) {
             typedef objc_id (*mtl_copy_all_devices_method)(void);
             mtl_copy_all_devices_method method = (mtl_copy_all_devices_method)handle;


### PR DESCRIPTION
Followup to https://github.com/halide/Halide/pull/4877 -- `halide_get_symbol` isn't defined in our iOS runtime; it might be useful to add it there, but the bottlenecking is unnecessary here, so a spot-fix should be simpler.