### PR TITLE
Don't automatically fold storage along vectorized dimensions

### DIFF
--- a/test/warning/CMakeLists.txt
+++ b/test/warning/CMakeLists.txt
@@ -3,4 +3,5 @@ tests(GROUPS warning
         double_vectorize.cpp
         hidden_pure_definition.cpp
         require_const_false.cpp
+        sliding_vectors.cpp
         )

--- a/test/warning/sliding_vectors.cpp
+++ b/test/warning/sliding_vectors.cpp
@@ -1,0 +1,24 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Func f, g;
+    Var x;
+
+    f(x) = x;
+
+    g(x) = f(x - 1) + f(x + 1);
+
+    Var xo, xi, xii;
+    g.split(x, xo, xi, 1024)
+        .split(xi, xi, xii, 8)
+        .vectorize(xii);
+
+    f.store_at(g, xo)
+        .compute_at(g, xi)
+        .vectorize(x, 8);
+    g.realize(1024);
+
+    return 0;
+}


### PR DESCRIPTION
It's generally a bad idea because loads and stores scalarize, but
there's no way in the schedule to turn it off, so you can't write an
optimal schedule for the case in the newly added warning test where you
want sliding but not folding. This PR makes folding opt-in in this case
instead.

When automatic folding is rejected due to this test, we emit a warning
that includes the schedule to use to explicitly request the folding that
used to occur.

Longer term it would be good to disable automatic folding entirely. This
PR can be seen as a trial of that in one specific case.