### PR TITLE
error-checking fixes

### DIFF
--- a/apps/super_simplify/find_rules.cpp
+++ b/apps/super_simplify/find_rules.cpp
@@ -451,6 +451,8 @@ int main(int argc, char **argv) {
                             std::cout << done << " / " << futures.size() << "\n";
                         }
                         if (!success) {
+                            debug(0) << "BLACKLISTING: " << p << "\n";
+
                             // Add it to the blacklist so we
                             // don't waste time on this
                             // pattern again. Delete the

--- a/apps/super_simplify/find_rules.cpp
+++ b/apps/super_simplify/find_rules.cpp
@@ -477,6 +477,8 @@ int main(int argc, char **argv) {
         f.get();
     }
 
+    debug(0) << "Final rules length: " << rules.size() << " (sorting now)...\n";
+
     // Sort generated rules
     std::sort(rules.begin(), rules.end(), [](const pair<Expr, Expr> &r1, const pair<Expr, Expr> &r2) {
         return IRDeepCompare{}(r1.first, r2.first);

--- a/apps/super_simplify/parser.cpp
+++ b/apps/super_simplify/parser.cpp
@@ -512,6 +512,10 @@ vector<Expr> parse_halide_exprs_from_file(const std::string &filename) {
     vector<Expr> exprs;
     std::ifstream input;
     input.open(filename);
+    if (input.fail()) {
+        debug(0) << "parse_halide_exprs_from_file: Unable to open " << filename;
+        assert(false);
+    }
     for (string line; std::getline(input, line);) {
         if (line.empty()) continue;
         // It's possible to comment out lines for debugging


### PR DESCRIPTION
- make blacklist.txt a required arg (so it doesn't assume 'current directory'
- add error-checking to the iostream open() calls to ensure that failure to open files isn't overlooked