### PR TITLE
Fix clang-tidy errors in python_bindings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 Checks: '-*,modernize-use-override,performance-move-const-arg,modernize-use-emplace,performance-noexcept-move-constructor,performance-unnecessary-value-param,performance-unnecessary-copy-initialization,performance-trivially-destructible,bugprone-parent-virtual-call,bugprone-macro-parenthesis,bugprone-string-constructor,bugprone-sizeof-expression'
 WarningsAsErrors: '*'
-HeaderFilterRegex: '.*'
+HeaderFilterRegex: '(?!.*pybind11.*).*$'
 AnalyzeTemporaryDtors: false
 FormatStyle: 'file'
 ...

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -1,5 +1,5 @@
 include(FetchContent)
-FetchContent_Declare(pybind11 GIT_REPOSITORY https://github.com/pybind/pybind11.git GIT_TAG v2.4.3)
+FetchContent_Declare(pybind11 GIT_REPOSITORY https://github.com/pybind/pybind11.git GIT_TAG v2.5.0)
 FetchContent_MakeAvailable(pybind11)
 
 if (APPLE)

--- a/python_bindings/src/PyArgument.cpp
+++ b/python_bindings/src/PyArgument.cpp
@@ -15,7 +15,7 @@ void define_argument(py::module &m) {
                      return im;
                  }),
                  py::arg("im"))
-            .def(py::init([](Param<> param) -> Argument {
+            .def(py::init([](const Param<> &param) -> Argument {
                      return param;
                  }),
                  py::arg("param"))

--- a/python_bindings/src/PyBoundaryConditions.cpp
+++ b/python_bindings/src/PyBoundaryConditions.cpp
@@ -24,17 +24,17 @@ void define_boundary_conditions(py::module &m) {
     // ----- constant_exterior
 
     bc.def(
-        "constant_exterior", [](ImageParam im, Expr exterior) -> Func {
+        "constant_exterior", [](const ImageParam &im, const Expr &exterior) -> Func {
             return constant_exterior(im, exterior);
         },
         py::arg("f"), py::arg("exterior"));
     bc.def(
-        "constant_exterior", [](Buffer<> b, Expr exterior) -> Func {
+        "constant_exterior", [](const Buffer<> &b, const Expr &exterior) -> Func {
             return constant_exterior(b, exterior);
         },
         py::arg("f"), py::arg("exterior"));
     bc.def(
-        "constant_exterior", [](py::object target, Expr exterior, Region bounds) -> Func {
+        "constant_exterior", [](const py::object &target, const Expr &exterior, const Region &bounds) -> Func {
             try {
                 return constant_exterior(target.cast<Func>(), exterior, bounds);
             } catch (...) {
@@ -52,17 +52,17 @@ void define_boundary_conditions(py::module &m) {
 
     // ----- repeat_edge
     bc.def(
-        "repeat_edge", [](ImageParam im) -> Func {
+        "repeat_edge", [](const ImageParam &im) -> Func {
             return repeat_edge(im);
         },
         py::arg("f"));
     bc.def(
-        "repeat_edge", [](Buffer<> b) -> Func {
+        "repeat_edge", [](const Buffer<> &b) -> Func {
             return repeat_edge(b);
         },
         py::arg("f"));
     bc.def(
-        "repeat_edge", [](py::object target, Region bounds) -> Func {
+        "repeat_edge", [](const py::object &target, const Region &bounds) -> Func {
             try {
                 return repeat_edge(target.cast<Func>(), bounds);
             } catch (...) {
@@ -80,17 +80,17 @@ void define_boundary_conditions(py::module &m) {
 
     // ----- repeat_image
     bc.def(
-        "repeat_image", [](ImageParam im) -> Func {
+        "repeat_image", [](const ImageParam &im) -> Func {
             return repeat_image(im);
         },
         py::arg("f"));
     bc.def(
-        "repeat_image", [](Buffer<> b) -> Func {
+        "repeat_image", [](const Buffer<> &b) -> Func {
             return repeat_image(b);
         },
         py::arg("f"));
     bc.def(
-        "repeat_image", [](py::object target, Region bounds) -> Func {
+        "repeat_image", [](const py::object &target, const Region &bounds) -> Func {
             try {
                 return repeat_image(target.cast<Func>(), bounds);
             } catch (...) {
@@ -108,17 +108,17 @@ void define_boundary_conditions(py::module &m) {
 
     // ----- mirror_image
     bc.def(
-        "mirror_image", [](ImageParam im) -> Func {
+        "mirror_image", [](const ImageParam &im) -> Func {
             return mirror_image(im);
         },
         py::arg("f"));
     bc.def(
-        "mirror_image", [](Buffer<> b) -> Func {
+        "mirror_image", [](const Buffer<> &b) -> Func {
             return mirror_image(b);
         },
         py::arg("f"));
     bc.def(
-        "mirror_image", [](py::object target, Region bounds) -> Func {
+        "mirror_image", [](const py::object &target, const Region &bounds) -> Func {
             try {
                 return mirror_image(target.cast<Func>(), bounds);
             } catch (...) {
@@ -136,17 +136,17 @@ void define_boundary_conditions(py::module &m) {
 
     // ----- mirror_interior
     bc.def(
-        "mirror_interior", [](ImageParam im) -> Func {
+        "mirror_interior", [](const ImageParam &im) -> Func {
             return mirror_interior(im);
         },
         py::arg("f"));
     bc.def(
-        "mirror_interior", [](Buffer<> b) -> Func {
+        "mirror_interior", [](const Buffer<> &b) -> Func {
             return mirror_interior(b);
         },
         py::arg("f"));
     bc.def(
-        "mirror_interior", [](py::object target, Region bounds) -> Func {
+        "mirror_interior", [](const py::object &target, const Region &bounds) -> Func {
             try {
                 return mirror_interior(target.cast<Func>(), bounds);
             } catch (...) {

--- a/python_bindings/src/PyError.cpp
+++ b/python_bindings/src/PyError.cpp
@@ -15,11 +15,11 @@ void halide_python_print(void *, const char *msg) {
 
 class HalidePythonCompileTimeErrorReporter : public CompileTimeErrorReporter {
 public:
-    void warning(const char *msg) {
+    void warning(const char *msg) override {
         py::print(msg, py::arg("end") = "");
     }
 
-    void error(const char *msg) {
+    void error(const char *msg) override {
         throw Error(msg);
         // This method must not return!
     }

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -1,5 +1,7 @@
 #include "PyFunc.h"
 
+#include <utility>
+
 #include "PyBuffer.h"
 #include "PyExpr.h"
 #include "PyFuncRef.h"
@@ -129,7 +131,7 @@ void define_func(py::module &m) {
 
             .def(
                 "realize",
-                [](Func &f, std::vector<int32_t> sizes, const Target &target) -> py::object {
+                [](Func &f, const std::vector<int32_t> &sizes, const Target &target) -> py::object {
                     return realization_to_object(f.realize(sizes, target));
                 },
                 py::arg("sizes") = std::vector<int32_t>{}, py::arg("target") = Target())
@@ -181,7 +183,7 @@ void define_func(py::module &m) {
             .def("bound", &Func::bound, py::arg("var"), py::arg("min"), py::arg("extent"))
 
             .def("reorder_storage", (Func & (Func::*)(const std::vector<Var> &)) & Func::reorder_storage, py::arg("dims"))
-            .def("reorder_storage", [](Func &func, py::args args) -> Func & {
+            .def("reorder_storage", [](Func &func, const py::args &args) -> Func & {
                 return func.reorder_storage(args_to_vector<Var>(args));
             })
 

--- a/python_bindings/src/PyIROperator.cpp
+++ b/python_bindings/src/PyIROperator.cpp
@@ -1,5 +1,7 @@
 #include "PyIROperator.h"
 
+#include <utility>
+
 #include "PyTuple.h"
 
 namespace Halide {
@@ -19,7 +21,7 @@ std::vector<Expr> args_to_vector_for_print(const py::args &args, size_t start_of
         // and fail. Normally we don't want string to be convertible
         // to Expr, but in this unusual case we do.
         try {
-            v.push_back(args[i].cast<std::string>());
+            v.emplace_back(args[i].cast<std::string>());
         } catch (...) {
             v.push_back(args[i].cast<Expr>());
         }
@@ -30,7 +32,7 @@ std::vector<Expr> args_to_vector_for_print(const py::args &args, size_t start_of
 }  // namespace
 
 void define_operators(py::module &m) {
-    m.def("max", [](py::args args) -> Expr {
+    m.def("max", [](const py::args &args) -> Expr {
         if (args.size() < 2) {
             throw py::value_error("max() must have at least 2 arguments");
         }
@@ -42,7 +44,7 @@ void define_operators(py::module &m) {
         return value;
     });
 
-    m.def("min", [](py::args args) -> Expr {
+    m.def("min", [](const py::args &args) -> Expr {
         if (args.size() < 2) {
             throw py::value_error("min() must have at least 2 arguments");
         }
@@ -58,7 +60,7 @@ void define_operators(py::module &m) {
     m.def("abs", &abs);
     m.def("absd", &absd);
 
-    m.def("select", [](py::args args) -> Expr {
+    m.def("select", [](const py::args &args) -> Expr {
         if (args.size() < 3) {
             throw py::value_error("select() must have at least 3 arguments");
         }
@@ -75,7 +77,7 @@ void define_operators(py::module &m) {
         return false_value;
     });
 
-    m.def("tuple_select", [](py::args args) -> py::tuple {
+    m.def("tuple_select", [](const py::args &args) -> py::tuple {
         _halide_user_assert(args.size() >= 3)
             << "tuple_select() must have at least 3 arguments";
         _halide_user_assert((args.size() % 2) != 0)
@@ -146,16 +148,16 @@ void define_operators(py::module &m) {
     m.def("is_finite", &is_finite);
     m.def("reinterpret", (Expr(*)(Type, Expr)) & reinterpret);
     m.def("cast", (Expr(*)(Type, Expr)) & cast);
-    m.def("print", [](py::args args) -> Expr {
+    m.def("print", [](const py::args &args) -> Expr {
         return print(args_to_vector_for_print(args));
     });
     m.def(
-        "print_when", [](Expr condition, py::args args) -> Expr {
+        "print_when", [](const Expr &condition, const py::args &args) -> Expr {
             return print_when(condition, args_to_vector_for_print(args));
         },
         py::arg("condition"));
     m.def(
-        "require", [](Expr condition, Expr value, py::args args) -> Expr {
+        "require", [](const Expr &condition, const Expr &value, const py::args &args) -> Expr {
             auto v = args_to_vector<Expr>(args);
             v.insert(v.begin(), value);
             return require(condition, v);
@@ -175,7 +177,7 @@ void define_operators(py::module &m) {
     m.def("random_int", (Expr(*)(Expr)) & random_int, py::arg("seed"));
     m.def("undef", (Expr(*)(Type)) & undef);
     m.def(
-        "memoize_tag", [](Expr result, py::args cache_key_values) -> Expr {
+        "memoize_tag", [](const Expr &result, const py::args &cache_key_values) -> Expr {
             return Internal::memoize_tag_helper(result, args_to_vector<Expr>(cache_key_values));
         },
         py::arg("result"));

--- a/python_bindings/src/PyInlineReductions.cpp
+++ b/python_bindings/src/PyInlineReductions.cpp
@@ -27,23 +27,23 @@ void define_inline_reductions(py::module &m) {
           py::arg("rdom"), py::arg("expr"), py::arg("name") = "minimum");
 
     m.def(
-        "argmax", [](Expr e, const std::string &s) -> py::tuple {
+        "argmax", [](const Expr &e, const std::string &s) -> py::tuple {
             return to_python_tuple(argmax(e, s));
         },
         py::arg("expr"), py::arg("name") = "argmax");
     m.def(
-        "argmax", [](const RDom &r, Expr e, const std::string &s) -> py::tuple {
+        "argmax", [](const RDom &r, const Expr &e, const std::string &s) -> py::tuple {
             return to_python_tuple(argmax(r, e, s));
         },
         py::arg("rdom"), py::arg("expr"), py::arg("name") = "argmax");
 
     m.def(
-        "argmin", [](Expr e, const std::string &s) -> py::tuple {
+        "argmin", [](const Expr &e, const std::string &s) -> py::tuple {
             return to_python_tuple(argmin(e, s));
         },
         py::arg("expr"), py::arg("name") = "argmin");
     m.def(
-        "argmin", [](const RDom &r, Expr e, const std::string &s) -> py::tuple {
+        "argmin", [](const RDom &r, const Expr &e, const std::string &s) -> py::tuple {
             return to_python_tuple(argmin(r, e, s));
         },
         py::arg("rdom"), py::arg("expr"), py::arg("name") = "argmin");

--- a/python_bindings/src/PyLambda.cpp
+++ b/python_bindings/src/PyLambda.cpp
@@ -6,7 +6,7 @@ namespace PythonBindings {
 void define_lambda(py::module &m) {
     // TODO: 'lambda' is a reserved word in Python, so we
     // can't use it for a function. Using 'lambda_func' for now.
-    m.def("lambda_func", [](py::args args) -> Func {
+    m.def("lambda_func", [](const py::args &args) -> Func {
         auto vars = args_to_vector<Var>(args, 0, 1);
         Expr e = args[args.size() - 1].cast<Expr>();
         Func f("lambda" + Internal::unique_name('_'));

--- a/python_bindings/src/PyScheduleMethods.h
+++ b/python_bindings/src/PyScheduleMethods.h
@@ -38,7 +38,7 @@ HALIDE_NEVER_INLINE void add_schedule_methods(PythonClass &class_instance) {
              py::arg("x"), py::arg("y"), py::arg("xi"), py::arg("yi"), py::arg("xfactor"), py::arg("yfactor"), py::arg("tail") = TailStrategy::Auto)
 
         .def("reorder", (T & (T::*)(const std::vector<VarOrRVar> &)) & T::reorder, py::arg("vars"))
-        .def("reorder", [](T &t, py::args args) -> T & {
+        .def("reorder", [](T &t, const py::args &args) -> T & {
             return t.reorder(args_to_vector<VarOrRVar>(args));
         })
 

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -8,6 +8,8 @@
 
 #include <iostream>
 #include <string>
+#include <utility>
+
 #include <vector>
 
 #include "Halide.h"
@@ -39,11 +41,11 @@ void halide_python_print(void *, const char *msg) {
 
 class HalidePythonCompileTimeErrorReporter : public CompileTimeErrorReporter {
 public:
-    void warning(const char *msg) {
+    void warning(const char *msg) override {
         py::print(msg, py::arg("end") = "");
     }
 
-    void error(const char *msg) {
+    void error(const char *msg) override {
         throw Error(msg);
         // This method must not return!
     }
@@ -61,11 +63,11 @@ void install_error_handlers(py::module &m) {
 
 // Anything that defines __getitem__ looks sequencelike to pybind,
 // so also check for __len_ to avoid things like Buffer and Func here.
-bool is_real_sequence(py::object o) {
+bool is_real_sequence(const py::object &o) {
     return py::isinstance<py::sequence>(o) && py::hasattr(o, "__len__");
 }
 
-StubInput to_stub_input(py::object o) {
+StubInput to_stub_input(const py::object &o) {
     // Don't use isinstance: we want to get things that
     // can be implicitly converted as well (eg ImageParam -> Func)
     try {
@@ -83,7 +85,7 @@ StubInput to_stub_input(py::object o) {
     return StubInput(o.cast<Expr>());
 }
 
-void append_input(py::object value, std::vector<StubInput> &v) {
+void append_input(const py::object &value, std::vector<StubInput> &v) {
     if (is_real_sequence(value)) {
         for (auto o : py::reinterpret_borrow<py::sequence>(value)) {
             v.push_back(to_stub_input(o));
@@ -93,7 +95,7 @@ void append_input(py::object value, std::vector<StubInput> &v) {
     }
 }
 
-py::object generate_impl(FactoryFunc factory, const GeneratorContext &context, py::args args, py::kwargs kwargs) {
+py::object generate_impl(FactoryFunc factory, const GeneratorContext &context, const py::args &args, const py::kwargs &kwargs) {
     Stub stub(context, [factory](const GeneratorContext &context) -> std::unique_ptr<Halide::Internal::GeneratorBase> {
         return factory(context);
     });


### PR DESCRIPTION
Also, drive-by upgrade to pybind11 v2.5