### PR TITLE
minor super_simplify fixes

### DIFF
--- a/apps/super_simplify/find_rules.cpp
+++ b/apps/super_simplify/find_rules.cpp
@@ -420,7 +420,6 @@ int main(int argc, char **argv) {
                             CountOps counter;
                             counter.mutate(simpler_r);
                             if (counter.count_leaves() < lhs_ops + 1) {
-                                std::lock_guard<std::mutex> lock(mutex);
                                 e = simpler_r;
                                 break;
                             }
@@ -451,7 +450,7 @@ int main(int argc, char **argv) {
                             std::cout << done << " / " << futures.size() << "\n";
                         }
                         if (!success) {
-                            debug(0) << "BLACKLISTING: " << p << "\n";
+                            debug(1) << "BLACKLISTING: " << p << "\n";
 
                             // Add it to the blacklist so we
                             // don't waste time on this

--- a/apps/super_simplify/super_simplify.cpp
+++ b/apps/super_simplify/super_simplify.cpp
@@ -252,6 +252,11 @@ Expr super_simplify(Expr e, int size) {
     std::uniform_int_distribution<int> random_int(-3, 3);
 
     while (1) {
+        if (counterexamples.size() > 100) {
+          debug(0) << "TOO MANY COUNTEREXAMPLES, bailing for size=" << size << "\ne="<<e<<"\n";
+          return Expr();
+        }
+
         // First sythesize a counterexample to the current program.
         Expr current_program_works = substitute(current_program, program_works);
         map<string, Expr> counterexample = all_vars_zero;


### PR DESCRIPTION
- add a sanity check in super_simplify to bail from the loop if we get too many counterexamples (preventing missed pathological cases from hanging)
- remove unnecessary lock in find_rules loop
- make BLACKLISTING logging debug(1) instead of debug(0)