### PR TITLE
Support Ubuntu 20.04 LTS

### DIFF
--- a/python_bindings/requirements.txt
+++ b/python_bindings/requirements.txt
@@ -8,5 +8,8 @@
 numpy
 scipy
 pillow
+
+# Keep versions of these requirements equal to the versions in Ubuntu 20.04 LTS
+# because newer versions fix bugs we work around.
 imageio==2.4.1
 pybind11==2.4.3

--- a/python_bindings/requirements.txt
+++ b/python_bindings/requirements.txt
@@ -8,5 +8,5 @@
 numpy
 scipy
 pillow
-imageio
-pybind11
+imageio==2.4.1
+pybind11==2.4.3

--- a/python_bindings/tutorial/lesson_02_input_image.py
+++ b/python_bindings/tutorial/lesson_02_input_image.py
@@ -86,7 +86,7 @@ def main():
     assert output_image.type() == hl.UInt(8)
 
     # Save the output for inspection. It should look like a bright parrot.
-    imageio.imsave("brighter.png", output_image)
+    imageio.imsave("brighter.png", np.asanyarray(output_image))
     print("Created brighter.png result file.")
 
     print("Success!")

--- a/python_bindings/tutorial/lesson_02_input_image.py
+++ b/python_bindings/tutorial/lesson_02_input_image.py
@@ -86,6 +86,7 @@ def main():
     assert output_image.type() == hl.UInt(8)
 
     # Save the output for inspection. It should look like a bright parrot.
+    # python3-imageio versions <2.5 expect a numpy array
     imageio.imsave("brighter.png", np.asanyarray(output_image))
     print("Created brighter.png result file.")
 

--- a/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
+++ b/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
@@ -83,6 +83,7 @@ def main():
         # parrot, and it should be two pixels narrower and two pixels
         # shorter than the input image.
 
+        # python3-imageio versions <2.5 expect a numpy array
         imageio.imsave("blurry_parrot_1.png", np.asanyarray(result))
         print("Created blurry_parrot_1.png")
 
@@ -152,6 +153,8 @@ def main():
         # Save the result. It should look like a slightly blurry
         # parrot, but this time it will be the same size as the
         # input.
+
+        # python3-imageio versions <2.5 expect a numpy array
         imageio.imsave("blurry_parrot_2.png", np.asanyarray(result))
         print("Created blurry_parrot_2.png")
 

--- a/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
+++ b/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
@@ -11,6 +11,7 @@
 import halide as hl
 
 import imageio
+import numpy as np
 import os.path
 
 
@@ -82,7 +83,7 @@ def main():
         # parrot, and it should be two pixels narrower and two pixels
         # shorter than the input image.
 
-        imageio.imsave("blurry_parrot_1.png", result)
+        imageio.imsave("blurry_parrot_1.png", np.asanyarray(result))
         print("Created blurry_parrot_1.png")
 
         # This is usually the fastest way to deal with boundaries:
@@ -151,7 +152,7 @@ def main():
         # Save the result. It should look like a slightly blurry
         # parrot, but this time it will be the same size as the
         # input.
-        imageio.imsave("blurry_parrot_2.png", result)
+        imageio.imsave("blurry_parrot_2.png", np.asanyarray(result))
         print("Created blurry_parrot_2.png")
 
     print("Success!")


### PR DESCRIPTION
Ubuntu 20.04 LTS packages slightly older versions of two Python dependencies:

* `python3-imageio` **2.4.1-3**. Unfortunately this is the most recent version that conservatively rejects numpy-compatible types. This PR wraps our buffers in two tutorials with `np.asanyarray()`.
* `python3-pybind11` **2.4.3-2build2**. This version works fine for our purposes.

It would be nice to support building Halide against these versions so that building with a virtual environment is optional.

The changes to the requirements file ensure that testing is done against these versions when running in a virtual environment.