### PR TITLE
Teach the simplifier to learn bounds from non-constants

### DIFF
--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -121,29 +121,39 @@ void Simplify::ScopedFact::learn_false(const Expr &fact) {
         }
     } else if (const LT *lt = fact.as<LT>()) {
         const Variable *v = lt->a.as<Variable>();
-        const int64_t *i = as_const_int(lt->b);
-        if (v && i) {
-            // !(v < i)
-            learn_lower_bound(v, *i);
+        Simplify::ExprInfo i;
+        if (v) {
+            simplify->mutate(lt->b, &i);
+            if (i.min_defined) {
+                // !(v < i)
+                learn_lower_bound(v, i.min);
+            }
         }
         v = lt->b.as<Variable>();
-        i = as_const_int(lt->a);
-        if (v && i) {
-            // !(i < v)
-            learn_upper_bound(v, *i);
+        if (v) {
+            simplify->mutate(lt->a, &i);
+            if (i.max_defined) {
+                // !(i < v)
+                learn_upper_bound(v, i.max);
+            }
         }
     } else if (const LE *le = fact.as<LE>()) {
         const Variable *v = le->a.as<Variable>();
-        const int64_t *i = as_const_int(le->b);
-        if (v && i) {
-            // !(v <= i)
-            learn_lower_bound(v, *i + 1);
+        Simplify::ExprInfo i;
+        if (v && v->type.is_int() && v->type.bits() >= 32) {
+            simplify->mutate(le->b, &i);
+            if (i.min_defined) {
+                // !(v <= i)
+                learn_lower_bound(v, i.min + 1);
+            }
         }
         v = le->b.as<Variable>();
-        i = as_const_int(le->a);
-        if (v && i) {
-            // !(i <= v)
-            learn_upper_bound(v, *i - 1);
+        if (v && v->type.is_int() && v->type.bits() >= 32) {
+            simplify->mutate(le->a, &i);
+            if (i.max_defined) {
+                // !(i <= v)
+                learn_upper_bound(v, i.max - 1);
+            }
         }
     } else if (const Or *o = fact.as<Or>()) {
         // Both must be false
@@ -240,29 +250,39 @@ void Simplify::ScopedFact::learn_true(const Expr &fact) {
         }
     } else if (const LT *lt = fact.as<LT>()) {
         const Variable *v = lt->a.as<Variable>();
-        const int64_t *i = as_const_int(lt->b);
-        if (v && i) {
-            // v < i
-            learn_upper_bound(v, *i - 1);
+        Simplify::ExprInfo i;
+        if (v && v->type.is_int() && v->type.bits() >= 32) {
+            simplify->mutate(lt->b, &i);
+            if (i.max_defined) {
+                // v < i
+                learn_upper_bound(v, i.max - 1);
+            }
         }
         v = lt->b.as<Variable>();
-        i = as_const_int(lt->a);
-        if (v && i) {
-            // i < v
-            learn_lower_bound(v, *i + 1);
+        if (v && v->type.is_int() && v->type.bits() >= 32) {
+            simplify->mutate(lt->a, &i);
+            if (i.min_defined) {
+                // i < v
+                learn_lower_bound(v, i.min + 1);
+            }
         }
     } else if (const LE *le = fact.as<LE>()) {
         const Variable *v = le->a.as<Variable>();
-        const int64_t *i = as_const_int(le->b);
-        if (v && i) {
-            // v <= i
-            learn_upper_bound(v, *i);
+        Simplify::ExprInfo i;
+        if (v) {
+            simplify->mutate(le->b, &i);
+            if (i.max_defined) {
+                // v <= i
+                learn_upper_bound(v, i.max);
+            }
         }
         v = le->b.as<Variable>();
-        i = as_const_int(le->a);
-        if (v && i) {
-            // i <= v
-            learn_lower_bound(v, *i);
+        if (v) {
+            simplify->mutate(le->a, &i);
+            if (i.min_defined) {
+                // i <= v
+                learn_lower_bound(v, i.min);
+            }
         }
     } else if (const And *a = fact.as<And>()) {
         // Both must be true

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1519,6 +1519,45 @@ void check_boolean() {
     // A for loop where the extent is at most one can just be an if statement
     check(IfThenElse::make(y % 2 == x, loop), IfThenElse::make(y % 2 == x, IfThenElse::make(0 < x, body)));
 
+    // Check we can learn from bounds on variables
+    check(IfThenElse::make(x < 5, Evaluate::make(min(x, 17))),
+          IfThenElse::make(x < 5, Evaluate::make(x)));
+
+    check(IfThenElse::make(x < min(y, 5), Evaluate::make(min(x, 17))),
+          IfThenElse::make(x < min(y, 5), Evaluate::make(x)));
+
+    check(IfThenElse::make(5 < x, Evaluate::make(max(x, 2))),
+          IfThenElse::make(5 < x, Evaluate::make(x)));
+
+    check(IfThenElse::make(max(y, 5) < x, Evaluate::make(max(x, 2))),
+          IfThenElse::make(max(y, 5) < x, Evaluate::make(x)));
+
+    check(IfThenElse::make(x <= 5, Evaluate::make(min(x, 17))),
+          IfThenElse::make(x <= 5, Evaluate::make(x)));
+
+    check(IfThenElse::make(x <= min(y, 5), Evaluate::make(min(x, 17))),
+          IfThenElse::make(x <= min(y, 5), Evaluate::make(x)));
+
+    check(IfThenElse::make(5 <= x, Evaluate::make(max(x, 2))),
+          IfThenElse::make(5 <= x, Evaluate::make(x)));
+
+    check(IfThenElse::make(max(y, 5) <= x, Evaluate::make(max(x, 2))),
+          IfThenElse::make(max(y, 5) <= x, Evaluate::make(x)));
+
+    // Concretely, this lets us skip some redundant assertions
+    check(Block::make(AssertStmt::make(max(y, 3) < x, x),
+                      AssertStmt::make(0 < x, x)),
+          Block::make(AssertStmt::make(max(y, 3) < x, x),
+                      Evaluate::make(0)));
+
+    // Check it works transitively
+    check(IfThenElse::make(0 < x,
+                           IfThenElse::make(x < y,
+                                            IfThenElse::make(y < z,
+                                                             Evaluate::make(z == 2)))),
+          // z can't possibly be two, because x is at least one, so y
+          // is at least two, so z must be at least three.
+          Evaluate::make(const_false()));
     // Simplifications of selects
     check(select(x == 3, 5, 7) + 7, select(x == 3, 12, 14));
     check(select(x == 3, 5, 7) - 7, select(x == 3, -2, 0));
@@ -1561,7 +1600,6 @@ void check_boolean() {
     check(select(cond, x % y, z % y), select(cond, x, z) % y);
 
     {
-
         Expr b[12];
         for (int i = 0; i < 12; i++) {
             b[i] = Variable::make(Bool(), unique_name('b'));


### PR DESCRIPTION
Previously the simplifier understood that assert(x >= 0) meant that
future uses of x have an lower bound of 0. However it didn't realize
that it could learn the same from assert(x >= max(y, 0))

This meant that 
assert(x >= max(y, 0)) 

could generate worse code than the more complex expression:
assert(x >= y && x >= 0)