### PR TITLE
Keep constants outermost in LICM

### DIFF
--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -338,6 +338,10 @@ class GroupLoopInvariants : public IRMutator {
     };
 
     int expr_depth(const Expr &e) {
+        // We want to keep constants outermost
+        if (is_const(e)) {
+            return std::numeric_limits<int>::max();
+        }
         ExprDepth depth(var_depth);
         e.accept(&depth);
         return depth.result;
@@ -496,8 +500,8 @@ class GroupLoopInvariants : public IRMutator {
 };
 
 Stmt loop_invariant_code_motion(Stmt s) {
-    s = GroupLoopInvariants().mutate(s);
     s = common_subexpression_elimination(s);
+    s = GroupLoopInvariants().mutate(s);
     s = LICM().mutate(s);
     s = simplify_exprs(s);
     return s;


### PR DESCRIPTION
LICM is prone to making a bit of a mess. I found it can be tamed by not
letting it sink constants to the bottom of an expression, and by running
CSE before grouping loop invariants instead of after to stop it from
reassociating things in way that break up common subexpressions.

This provides small speedups on several of the apps. The largest gain is
1-2% on local_laplacian.