### PR TITLE
Restore division rule

### DIFF
--- a/src/Simplify_Div.cpp
+++ b/src/Simplify_Div.cpp
@@ -138,6 +138,7 @@ Expr Simplify::visit(const Div *op, ExprInfo *bounds) {
 
                rewrite((x * c0 + y) / c1, y / c1 + x * fold(c0 / c1),             c0 % c1 == 0 && c1 > 0) ||
                rewrite((x * c0 - y) / c0, x + (0 - y) / c0) ||
+               rewrite((x * c1 - y) / c0, (0 - y) / c0 - x,                       c0 + c1 == 0) ||
                rewrite((y + x * c0) / c1, y / c1 + x * fold(c0 / c1),             c0 % c1 == 0 && c1 > 0) ||
                rewrite((y - x * c0) / c1, y / c1 - x * fold(c0 / c1),             c0 % c1 == 0 && c1 > 0) ||
 
@@ -145,6 +146,7 @@ Expr Simplify::visit(const Div *op, ExprInfo *bounds) {
                rewrite(((x * c0 - y) + z) / c1, (z - y) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
                rewrite(((x * c0 + y) - z) / c1, (y - z) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
                rewrite(((x * c0 - y) - z) / c0, x + (0 - y - z) / c0) ||
+               rewrite(((x * c1 - y) - z) / c0, (0 - y - z) / c0 - x,             c0 + c1 == 0) ||
 
                rewrite(((y + x * c0) + z) / c1, (y + z) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||
                rewrite(((y + x * c0) - z) / c1, (y - z) / c1 + x * fold(c0 / c1), c0 % c1 == 0 && c1 > 0) ||

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -256,6 +256,7 @@ void check_algebra() {
     check((x * 4 + y) / 2, y / 2 + x * 2);
     check((y + x * 4) / 2, y / 2 + x * 2);
     check((x * 2 - y) / 2, (0 - y) / 2 + x);
+    check((x * -2 - y) / 2, (0 - y) / 2 - x);
     check((y - x * 4) / 2, y / 2 - x * 2);
     check((x + 3) / 2 + 7, (x + 17) / 2);
     check((x / 2 + 3) / 5, (x + 6) / 10);
@@ -272,6 +273,7 @@ void check_algebra() {
     check(((x * 4 - y) + z) / 2, (z - y) / 2 + x * 2);
     check(((x * 4 + y) - z) / 2, (y - z) / 2 + x * 2);
     check(((x * 2 - y) - z) / 2, (0 - y - z) / 2 + x);
+    check(((x * -2 - y) - z) / 2, (0 - y - z) / 2 - x);
     check((x + (y * 4 + z)) / 2, (x + z) / 2 + y * 2);
     check(((x + y * 4) + z) / 2, (x + z) / 2 + y * 2);
     check((x + (y * 4 - z)) / 2, (x - z) / 2 + y * 2);


### PR DESCRIPTION
PR #4896 reduced a rule that triggered when a term from the numerator that was a multiple of the denominator to only triggering in the case where it was equal to the denominator. This was done to respect the reduction order and keep the simplifier cycle free. We forgot about the case where the
term is multiplied by the negative of the denominator (e.g. (x*-2 - y)/2). This can also be pulled out without breaking the reduction order, because the multiply goes away.

Z3 was unable to verify this, but it was also unable to find a counterexample, and it looks correct to me.