### PR TITLE
add HL_DISABLE_CAN_PROVE_RULES

### DIFF
--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -1956,8 +1956,12 @@ struct CanProve {
     // Includes a raw call to an inlined make method, so don't inline.
     HALIDE_NEVER_INLINE void make_folded_const(halide_scalar_value_t &val, halide_type_t &ty, MatcherState &state) const {
         Expr condition = a.make(state, {});
-        condition = prover->mutate(condition, nullptr);
-        val.u.u64 = is_one(condition);
+        if (!prover->disable_can_prove_rules()) {
+            condition = prover->mutate(condition, nullptr);
+            val.u.u64 = is_one(condition);
+        } else {
+            val.u.u64 = 0;
+        }
         ty.code = halide_type_uint;
         ty.bits = 1;
         ty.lanes = condition.type().lanes();

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -40,10 +40,18 @@ Simplify::Simplify(bool r, const Scope<Interval> *bi, const Scope<ModulusRemaind
 
     use_synthesized_rules = get_use_synthesized_rules_from_environment();
 
-    // Don't require this one to be set
-    if (get_env_variable("HL_DISABLE_CAN_PROVE_RULES") == "1") {
-        user_warning << "HL_DISABLE_CAN_PROVE_RULES=1, ignoring all rules that use can_prove()\n";
-        should_disable_can_prove_rules = true;
+    {
+        static bool disable = []() -> bool {
+            bool b = get_env_variable("HL_DISABLE_CAN_PROVE_RULES") == "1";
+            if (b) {
+                user_warning << "HL_DISABLE_CAN_PROVE_RULES=1, ignoring all rules that use can_prove()\n";
+            }
+            return b;
+        }();
+
+        if (disable) {
+            should_disable_can_prove_rules = true;
+        }
     }
 
     // Only respect the constant bounds from the containing scope.

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -40,6 +40,12 @@ Simplify::Simplify(bool r, const Scope<Interval> *bi, const Scope<ModulusRemaind
 
     use_synthesized_rules = get_use_synthesized_rules_from_environment();
 
+    // Don't require this one to be set
+    if (get_env_variable("HL_DISABLE_CAN_PROVE_RULES") == "1") {
+        user_warning << "HL_DISABLE_CAN_PROVE_RULES=1, ignoring all rules that use can_prove()\n";
+        should_disable_can_prove_rules = true;
+    }
+
     // Only respect the constant bounds from the containing scope.
     if (bi) {
         for (auto iter = bi->cbegin(); iter != bi->cend(); ++iter) {

--- a/src/Simplify_Internal.h
+++ b/src/Simplify_Internal.h
@@ -32,6 +32,7 @@ class Simplify : public VariadicVisitor<Simplify, Expr, Stmt> {
     using Super = VariadicVisitor<Simplify, Expr, Stmt>;
 
     bool use_synthesized_rules = false;
+    bool should_disable_can_prove_rules = false;
 
 public:
     Simplify(bool r, const Scope<Interval> *bi, const Scope<ModulusRemainder> *ai);
@@ -164,6 +165,11 @@ public:
     HALIDE_ALWAYS_INLINE
     bool no_overflow(Type t) {
         return t.is_float() || no_overflow_int(t);
+    }
+
+    HALIDE_ALWAYS_INLINE
+    bool disable_can_prove_rules() const {
+        return should_disable_can_prove_rules;
     }
 
     struct VarInfo {

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1280,8 +1280,8 @@ void check_boolean() {
     check(x >= 20 || x <= 18, 20 <= x || x <= 18);
     check(x <= 18 && x >= 19, f);
     check(x >= 19 && x <= 18, f);
-    check(x <= 20 && x >= 20, x <= 20 && 20 <= x);
-    check(x >= 20 && x <= 20, 20 <= x && x <= 20);
+    check(x <= 20 && x >= 20, x == 20);
+    check(x >= 20 && x <= 20, x == 20);
 
     check(min(x, 20) < min(x, 19), const_false());
     check(min(x, 23) < min(x, 18) - 3, const_false());


### PR DESCRIPTION
This adds a simple way to disable all rules using can_prove via an env var (useful in this branch).

Also, a drive-by fix to allow correctness_simplify to pass.