### PR TITLE
Fix tutorial 9. Align function definition.

### DIFF
--- a/tutorial/lesson_09_update_definitions.cpp
+++ b/tutorial/lesson_09_update_definitions.cpp
@@ -515,8 +515,8 @@ int main(int argc, char **argv) {
         Func producer, consumer;
         producer(x, y) = (x * y) / 10 + 8;
         consumer(x, y) = x + y;
-        consumer(x, 0) = producer(x, x);
-        consumer(0, y) = producer(y, 9 - y);
+        consumer(x, 0) += producer(x, x);
+        consumer(0, y) += producer(y, 9 - y);
 
         // In this case neither producer.compute_at(consumer, x)
         // nor producer.compute_at(consumer, y) will work, because


### PR DESCRIPTION
The definition of `consumer` and `consumer_2` did not align in the Case 4 example.