### PR TITLE
Generator inputs/outputs should allow float16/bfloat16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1205,6 +1205,10 @@ GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_matlab,$(GENERATOR_AOTCP
 # https://github.com/halide/Halide/issues/2093
 GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_async_parallel,$(GENERATOR_AOTCPP_TESTS))
 
+# https://github.com/halide/Halide/issues/4916
+GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_stubtest,$(GENERATOR_AOTCPP_TESTS))
+GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_stubuser,$(GENERATOR_AOTCPP_TESTS))
+
 test_aotcpp_generator: $(GENERATOR_AOTCPP_TESTS)
 
 # Similar story: filter out the tests that aren't workable/useful for wasm

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -736,6 +736,8 @@ std::string halide_type_to_c_type(const Type &t) {
         {encode(UInt(16)), "uint16_t"},
         {encode(UInt(32)), "uint32_t"},
         {encode(UInt(64)), "uint64_t"},
+        {encode(BFloat(16)), "uint16_t"},  // TODO: see Issues #3709, #3967
+        {encode(Float(16)), "uint16_t"},   // TODO: see Issues #3709, #3967
         {encode(Float(32)), "float"},
         {encode(Float(64)), "double"},
         {encode(Handle(64)), "void*"}};

--- a/test/generator/stubtest_aottest.cpp
+++ b/test/generator/stubtest_aottest.cpp
@@ -56,6 +56,9 @@ int main(int argc, char **argv) {
     Buffer<uint8_t> array_buffer_input0 = make_image<uint8_t>(0);
     Buffer<uint8_t> array_buffer_input1 = make_image<uint8_t>(1);
     Buffer<float> simple_output(kSize, kSize, 3);
+    // TODO: see Issues #3709, #3967
+    Buffer<> float16_output(halide_type_t(halide_type_float, 16), kSize, kSize, 3);
+    Buffer<> bfloat16_output(halide_type_t(halide_type_bfloat, 16), kSize, kSize, 3);
     Buffer<float> tuple_output0(kSize, kSize, 3), tuple_output1(kSize, kSize, 3);
     Buffer<int16_t> array_output0(kSize, kSize), array_output1(kSize, kSize);
     Buffer<uint8_t> static_compiled_buffer_output(kSize, kSize, 3);
@@ -77,7 +80,9 @@ int main(int argc, char **argv) {
         untyped_buffer_output,
         tupled_output0, tupled_output1,
         static_compiled_buffer_output,
-        array_buffer_output0, array_buffer_output1);
+        array_buffer_output0, array_buffer_output1,
+        float16_output,
+        bfloat16_output);
 
     verify(buffer_input, 1.f, 0, typed_buffer_output);
     verify(buffer_input, 1.f, 0, untyped_buffer_output);

--- a/test/generator/stubtest_generator.cpp
+++ b/test/generator/stubtest_generator.cpp
@@ -47,9 +47,13 @@ public:
     Output<Buffer<>> tupled_output{"tupled_output", {Float(32), Int(32)}, 3};
     Output<Buffer<uint8_t>> static_compiled_buffer_output{"static_compiled_buffer_output", 3};
     Output<Buffer<uint8_t>[2]> array_buffer_output { "array_buffer_output", 3 };
+    Output<Buffer<Halide::float16_t>> float16_output{"float16_output", 3};
+    Output<Buffer<Halide::bfloat16_t>> bfloat16_output{"bfloat16_output", 3};
 
     void generate() {
         simple_output(x, y, c) = cast<float>(simple_input(x, y, c));
+        float16_output(x, y, c) = cast<Halide::float16_t>(simple_input(x, y, c));
+        bfloat16_output(x, y, c) = cast<Halide::bfloat16_t>(simple_input(x, y, c));
 
         typed_buffer_output(x, y, c) = cast<float>(typed_buffer_input(x, y, c));
         // Note that if we are being invoked via a Stub, "untyped_buffer_output.type()" will

--- a/test/generator/stubuser_aottest.cpp
+++ b/test/generator/stubuser_aottest.cpp
@@ -58,9 +58,13 @@ int main(int argc, char **argv) {
     Buffer<float> tupled_output0(kSize, kSize, 3);
     Buffer<int32_t> tupled_output1(kSize, kSize, 3);
     Buffer<int> int_output(kSize, kSize, 3);
+    // TODO: see Issues #3709, #3967
+    Buffer<> float16_output(halide_type_t(halide_type_float, 16), kSize, kSize, 3);
+    Buffer<> bfloat16_output(halide_type_t(halide_type_bfloat, 16), kSize, kSize, 3);
 
     stubuser(input, calculated_output, float32_buffer_output, int32_buffer_output,
-             array_test_output, tupled_output0, tupled_output1, int_output);
+             array_test_output, tupled_output0, tupled_output1, int_output,
+             float16_output, bfloat16_output);
     verify(input, kFloatArg, kIntArg, kOffset, calculated_output);
     verify(input, 1.f, 0, 0.f, float32_buffer_output);
     verify<uint8_t, int32_t>(input, 1.f, 0, 0.f, int32_buffer_output);

--- a/test/generator/stubuser_generator.cpp
+++ b/test/generator/stubuser_generator.cpp
@@ -32,6 +32,8 @@ public:
     // We can infer the tupled-output-type from the Stub
     Output<Buffer<>> tupled_output{"tupled_output", 3};
     Output<Buffer<int>> int_output{"int_output", 3};
+    Output<Buffer<Halide::float16_t>> float16_output{"float16_output", 3};
+    Output<Buffer<Halide::bfloat16_t>> bfloat16_output{"bfloat16_output", 3};
 
     void generate() {
         Var x{"x"}, y{"y"}, c{"c"};
@@ -66,6 +68,8 @@ public:
         int32_buffer_output = out.untyped_buffer_output;
         array_test_output = out.array_buffer_output[1];
         tupled_output = out.tupled_output;
+        float16_output = out.float16_output;
+        bfloat16_output = out.bfloat16_output;
 
         const float kOffset = 2.f;
         calculated_output(x, y, c) = cast<uint8_t>(out.tuple_output(x, y, c)[1] + kOffset);


### PR DESCRIPTION
In general, they did, but Generator Stubs were broken for statically-declare Buffers.