### PR TITLE
More portable handling of unused declarations in CodeGen_C

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -183,9 +183,12 @@ inline T halide_cpp_max(const T &a, const T &b) {return (a > b) ? a : b;}
 template<typename T>
 inline T halide_cpp_min(const T &a, const T &b) {return (a < b) ? a : b;}
 
+template<typename T>
+inline void halide_unused(const T&) {}
+
 template<typename A, typename B>
 const B &return_second(const A &a, const B &b) {
-    (void) a;
+    halide_unused(a);
     return b;
 }
 
@@ -2803,7 +2806,7 @@ void CodeGen_C::visit(const IfThenElse *op) {
 void CodeGen_C::visit(const Evaluate *op) {
     if (is_const(op->value)) return;
     string id = print_expr(op->value);
-    stream << get_indent() << "(void)" << id << ";\n";
+    stream << get_indent() << "halide_unused(" << id << ");\n";
 }
 
 void CodeGen_C::visit(const Shuffle *op) {

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -1082,6 +1082,8 @@ void CodeGen_D3D12Compute_Dev::init_module() {
            "\n"
         << "\n";
 
+    src_stream << "#define halide_unused(x) (void)(x)\n";
+
     // Write out the Halide math functions.
     src_stream
     //<< "namespace {\n"   // HLSL does not support unnamed namespaces...

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -643,6 +643,7 @@ void CodeGen_Metal_Dev::init_module() {
 
     // __shared always has address space threadgroup.
     src_stream << "#define __address_space___shared threadgroup\n";
+    src_stream << "#define halide_unused(x) (void)(x)\n";
 
     src_stream << "\n";
 

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -859,6 +859,10 @@ void CodeGen_OpenCL_Dev::init_module() {
     // __shared always has address space __local.
     src_stream << "#define __address_space___shared __local\n";
 
+    // There does not appear to be a reliable way to safely ignore unused
+    // variables in OpenCL C. See https://github.com/halide/Halide/issues/4918.
+    src_stream << "#define halide_unused(x)";
+
     if (target.has_feature(Target::CLDoubles)) {
         src_stream << "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n"
                    << "inline bool is_nan_f64(double x) {return isnan(x); }\n"

--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -298,6 +298,7 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::add_kernel(const Stmt &
     }
     add_common_macros(stream);
     stream << "float float_from_bits(int x) { return intBitsToFloat(int(x)); }\n";
+    stream << "#define halide_unused(x) (void)(x)\n";
 
     for (size_t i = 0; i < args.size(); i++) {
         if (args[i].is_buffer) {


### PR DESCRIPTION
This PR makes it so CodeGen_C uses some C++ trickery to avoid unused declaration warnings, but I can't find a reliable way to avoid unused variable declarations in OpenCL C. I think we should just let unused declarations be in OpenCL C. I doubt any OpenCL implementations treat them as errors, and warnings should never be visible.

Fixes #4918 