### PR TITLE
Add stringification for Dim.dim_type enum.

### DIFF
--- a/src/AutoScheduleUtils.cpp
+++ b/src/AutoScheduleUtils.cpp
@@ -116,7 +116,7 @@ Definition get_stage_definition(const Function &f, int stage_num) {
 
 vector<Dim> &get_stage_dims(const Function &f, int stage_num) {
     static vector<Dim> outermost_only =
-        {{Var::outermost().name(), ForType::Serial, DeviceAPI::None, Dim::Type::PureVar}};
+        {{Var::outermost().name(), ForType::Serial, DeviceAPI::None, DimType::PureVar}};
     if (f.has_extern_definition()) {
         return outermost_only;
     }

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -846,7 +846,7 @@ Func Stage::rfactor(vector<pair<RVar, Var>> preserved) {
         const auto &iter = std::find_if(dims.begin(), dims.end(),
                                         [&v](const Dim &dim) { return var_name_match(dim.var, v.name()); });
         if (iter == dims.end()) {
-            Dim d = {v.name(), ForType::Serial, DeviceAPI::None, Dim::Type::PureVar};
+            Dim d = {v.name(), ForType::Serial, DeviceAPI::None, DimType::PureVar};
             dims.insert(dims.end() - 1, d);
         }
     }
@@ -1092,7 +1092,7 @@ Stage &Stage::fuse(const VarOrRVar &inner, const VarOrRVar &outer, const VarOrRV
     string inner_name, outer_name, fused_name;
     vector<Dim> &dims = definition.schedule().dims();
 
-    Dim::Type outer_type = Dim::Type::PureRVar;
+    DimType outer_type = DimType::PureRVar;
     for (size_t i = 0; (!found_outer) && i < dims.size(); i++) {
         if (var_name_match(dims[i].var, outer.name())) {
             found_outer = true;
@@ -1117,12 +1117,12 @@ Stage &Stage::fuse(const VarOrRVar &inner, const VarOrRVar &outer, const VarOrRV
             dims[i].var = fused_name;
 
             internal_assert(
-                (dims[i].is_rvar() && ((outer_type == Dim::Type::PureRVar) ||
-                                       (outer_type == Dim::Type::ImpureRVar))) ||
-                (!dims[i].is_rvar() && (outer_type == Dim::Type::PureVar)));
+                (dims[i].is_rvar() && ((outer_type == DimType::PureRVar) ||
+                                       (outer_type == DimType::ImpureRVar))) ||
+                (!dims[i].is_rvar() && (outer_type == DimType::PureVar)));
 
             if (dims[i].is_rvar()) {
-                dims[i].dim_type = (dims[i].dim_type == Dim::Type::PureRVar) && (outer_type == Dim::Type::PureRVar) ? Dim::Type::PureRVar : Dim::Type::ImpureRVar;
+                dims[i].dim_type = (dims[i].dim_type == DimType::PureRVar) && (outer_type == DimType::PureRVar) ? DimType::PureRVar : DimType::ImpureRVar;
             }
         }
     }
@@ -1217,7 +1217,7 @@ Stage &Stage::purify(const VarOrRVar &old_var, const VarOrRVar &new_var) {
             found = true;
             old_name = dims[i].var;
             dims[i].var = new_name;
-            dims[i].dim_type = Dim::Type::PureVar;
+            dims[i].dim_type = DimType::PureVar;
         }
     }
 

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -463,7 +463,7 @@ void Function::define(const vector<string> &args, vector<Expr> values) {
     contents->init_def = Definition(init_def_args, values, rdom, true);
 
     for (size_t i = 0; i < args.size(); i++) {
-        Dim d = {args[i], ForType::Serial, DeviceAPI::None, Dim::Type::PureVar};
+        Dim d = {args[i], ForType::Serial, DeviceAPI::None, DimType::PureVar};
         contents->init_def.schedule().dims().push_back(d);
         StorageDim sd = {args[i]};
         contents->func_schedule.storage_dims().push_back(sd);
@@ -471,7 +471,7 @@ void Function::define(const vector<string> &args, vector<Expr> values) {
 
     // Add the dummy outermost dim
     {
-        Dim d = {Var::outermost().name(), ForType::Serial, DeviceAPI::None, Dim::Type::PureVar};
+        Dim d = {Var::outermost().name(), ForType::Serial, DeviceAPI::None, DimType::PureVar};
         contents->init_def.schedule().dims().push_back(d);
     }
 
@@ -657,7 +657,7 @@ void Function::define_update(const vector<Expr> &_args, vector<Expr> values) {
 
             bool pure = can_parallelize_rvar(v, name(), r);
             Dim d = {v, ForType::Serial, DeviceAPI::None,
-                     pure ? Dim::Type::PureRVar : Dim::Type::ImpureRVar};
+                     pure ? DimType::PureRVar : DimType::ImpureRVar};
             r.schedule().dims().push_back(d);
         }
     }
@@ -665,14 +665,14 @@ void Function::define_update(const vector<Expr> &_args, vector<Expr> values) {
     // Then add the pure args outside of that
     for (const auto &pure_arg : pure_args) {
         if (!pure_arg.empty()) {
-            Dim d = {pure_arg, ForType::Serial, DeviceAPI::None, Dim::Type::PureVar};
+            Dim d = {pure_arg, ForType::Serial, DeviceAPI::None, DimType::PureVar};
             r.schedule().dims().push_back(d);
         }
     }
 
     // Then the dummy outermost dim
     {
-        Dim d = {Var::outermost().name(), ForType::Serial, DeviceAPI::None, Dim::Type::PureVar};
+        Dim d = {Var::outermost().name(), ForType::Serial, DeviceAPI::None, DimType::PureVar};
         r.schedule().dims().push_back(d);
     }
 
@@ -742,11 +742,11 @@ void Function::define_extern(const std::string &function_name,
     for (size_t i = 0; i < args.size(); i++) {
         contents->func_schedule.storage_dims().push_back(StorageDim{arg_names[i]});
         contents->init_def.schedule().dims().push_back(
-            Dim{arg_names[i], ForType::Extern, DeviceAPI::None, Dim::Type::PureVar});
+            Dim{arg_names[i], ForType::Extern, DeviceAPI::None, DimType::PureVar});
     }
     // Add the dummy outermost dim
     contents->init_def.schedule().dims().push_back(
-        Dim{Var::outermost().name(), ForType::Serial, DeviceAPI::None, Dim::Type::PureVar});
+        Dim{Var::outermost().name(), ForType::Serial, DeviceAPI::None, DimType::PureVar});
 }
 
 void Function::accept(IRVisitor *visitor) const {

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -335,6 +335,21 @@ std::ostream &operator<<(std::ostream &stream, const Indentation &indentation) {
     return stream;
 }
 
+std::ostream &operator<<(std::ostream &out, const DimType &t) {
+    switch (t) {
+    case DimType::PureVar:
+        out << "PureVar";
+        break;
+    case DimType::PureRVar:
+        out << "PureRVar";
+        break;
+    case DimType::ImpureRVar:
+        out << "ImpureRVar";
+        break;
+    }
+    return out;
+}
+
 IRPrinter::IRPrinter(ostream &s)
     : stream(s), indent(0) {
     s.setf(std::ios::fixed, std::ios::floatfield);

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -80,6 +80,9 @@ std::ostream &operator<<(std::ostream &stream, const LoweredFunc &);
 /** Emit a halide linkage value in a human readable format */
 std::ostream &operator<<(std::ostream &stream, const LinkageType &);
 
+/** Emit a halide dimension type in human-readable format */
+std::ostream &operator<<(std::ostream &stream, const DimType &);
+
 struct Indentation {
     int indent;
 };

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -297,14 +297,14 @@ struct Dim {
     Type dim_type;
 
     std::string dim_type_name() const {
-        switch(dim_type) {
-            case PureVar:
+        switch (dim_type) {
+        case PureVar:
             return "PureVar";
-            case PureRVar:
+        case PureRVar:
             return "PureRVar";
-            case ImpureRVar:
+        case ImpureRVar:
             return "ImpureRVar";
-            default:
+        default:
             return "unknown value " + std::to_string(dim_type);
         }
     }

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -286,34 +286,24 @@ struct Split {
     }
 };
 
+enum class DimType {
+    PureVar = 0,
+    PureRVar,
+    ImpureRVar,
+};
+
 struct Dim {
     std::string var;
     ForType for_type;
     DeviceAPI device_api;
 
-    enum Type { PureVar = 0,
-                PureRVar,
-                ImpureRVar };
-    Type dim_type;
-
-    std::string dim_type_name() const {
-        switch (dim_type) {
-        case PureVar:
-            return "PureVar";
-        case PureRVar:
-            return "PureRVar";
-        case ImpureRVar:
-            return "ImpureRVar";
-        default:
-            return "unknown value " + std::to_string(dim_type);
-        }
-    }
+    DimType dim_type;
 
     bool is_pure() const {
-        return (dim_type == PureVar) || (dim_type == PureRVar);
+        return (dim_type == DimType::PureVar) || (dim_type == DimType::PureRVar);
     }
     bool is_rvar() const {
-        return (dim_type == PureRVar) || (dim_type == ImpureRVar);
+        return (dim_type == DimType::PureRVar) || (dim_type == DimType::ImpureRVar);
     }
     bool is_unordered_parallel() const {
         return Halide::Internal::is_unordered_parallel(for_type);

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -296,6 +296,19 @@ struct Dim {
                 ImpureRVar };
     Type dim_type;
 
+    std::string dim_type_name() const {
+        switch(dim_type) {
+            case PureVar:
+            return "PureVar";
+            case PureRVar:
+            return "PureRVar";
+            case ImpureRVar:
+            return "ImpureRVar";
+            default:
+            return "unknown value " + std::to_string(dim_type);
+        }
+    }
+
     bool is_pure() const {
         return (dim_type == PureVar) || (dim_type == PureRVar);
     }

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -2205,8 +2205,8 @@ void validate_fused_group_schedule_helper(const string &fn,
                                                         << ") do not match.\n";
             user_assert(d1.dim_type == d2.dim_type) << "Invalid compute_with: types of dim "
                                                     << i << " of " << p.func_1 << ".s" << p.stage_1 << "("
-                                                    << d1.var << " is " << d1.dim_type_name() << ") and " << p.func_2
-                                                    << ".s" << p.stage_2 << "(" << d2.var << " is " << d2.dim_type_name()
+                                                    << d1.var << " is " << d1.dim_type << ") and " << p.func_2
+                                                    << ".s" << p.stage_2 << "(" << d2.var << " is " << d2.dim_type
                                                     << ") do not match.\n";
         }
     }

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -2205,8 +2205,8 @@ void validate_fused_group_schedule_helper(const string &fn,
                                                         << ") do not match.\n";
             user_assert(d1.dim_type == d2.dim_type) << "Invalid compute_with: types of dim "
                                                     << i << " of " << p.func_1 << ".s" << p.stage_1 << "("
-                                                    << d1.var << " is " << d1.dim_type << ") and " << p.func_2
-                                                    << ".s" << p.stage_2 << "(" << d2.var << " is " << d2.dim_type
+                                                    << d1.var << " is " << d1.dim_type_name() << ") and " << p.func_2
+                                                    << ".s" << p.stage_2 << "(" << d2.var << " is " << d2.dim_type_name()
                                                     << ") do not match.\n";
         }
     }


### PR DESCRIPTION
This makes a .compute_with() error message easier to read.

Before:

`Invalid compute_with: types of dim 0 of f_intm.s1(r$z is 2) and f_intm$1.s1(r$z is 1) do not match.`

After:

`Invalid compute_with: types of dim 0 of f_intm.s1(r$z is ImpureRVar) and f_intm$1.s1(r$z is PureRVar) do not match.`
