### PR TITLE
Fix capture by reference of temporary

### DIFF
--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -765,9 +765,7 @@ public:
                         const string &group_name;
 
                     public:
-                        // Because we're passed in a temporary to construct this, don't capture
-                        // alloc_name by reference
-                        RewriteGroupAccess(const string alloc_name, const string &group_name)
+                        RewriteGroupAccess(const string &alloc_name, const string &group_name)
                             : alloc_name(alloc_name), group_name(group_name) {
                         }
                     } rewriter{heap_name + "_" + alloc.name, group_name};

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -761,11 +761,13 @@ public:
                                 return IRMutator::visit(op);
                             }
                         }
-                        const string &alloc_name;
+                        const string alloc_name;
                         const string &group_name;
 
                     public:
-                        RewriteGroupAccess(const string &alloc_name, const string &group_name)
+                        // Because we're passed in a temporary to construct this, don't capture
+                        // alloc_name by reference
+                        RewriteGroupAccess(const string alloc_name, const string &group_name)
                             : alloc_name(alloc_name), group_name(group_name) {
                         }
                     } rewriter{heap_name + "_" + alloc.name, group_name};


### PR DESCRIPTION
Fix capture by reference of the temporary string.