### PR TITLE
apps/c_backend O3 -> O2

### DIFF
--- a/apps/c_backend/Makefile
+++ b/apps/c_backend/Makefile
@@ -1,5 +1,9 @@
 include ../support/Makefile.inc
 
+# Some older arm64 compilers will choke on our C backend code at -O3;
+# we'll just use -O2 for this app since performance here isn't critical
+OPTIMIZE = -O2
+
 .PHONY: build clean test
 build: $(BIN)/$(HL_TARGET)/run $(BIN)/$(HL_TARGET)/run_cpp
 test: build


### PR DESCRIPTION
The gcc 5.x compiler that our arm64 bots use will crater with an internal compiler error when compiling ths; upgrading gcc on the bots is tedious and error prone (especially when I can't physically access them in case something goes wrong), so as a short-term fix, just crank down the optimization for this app (since its performance isn't critical anyway)