### PR TITLE
gpu_lanes() cleanup

### DIFF
--- a/apps/cuda_mat_mul/mat_mul_generator.cpp
+++ b/apps/cuda_mat_mul/mat_mul_generator.cpp
@@ -38,6 +38,9 @@ public:
         Var xi, yi, xio, xii, yii, xo, yo, x_pair, xiio, ty;
         RVar rxo, rxi;
 
+        // This schedule requires CUDA, due to use of gpu_lanes()
+        assert(get_target().has_feature(Target::CUDA));
+
         out.bound(x, 0, size)
             .bound(y, 0, size)
             .tile(x, y, xi, yi, x_tile * vec_size * warp_size, y_tile * y_unroll)

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -199,6 +199,9 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Mod *op) {
 }
 
 void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const For *loop) {
+    user_assert(loop->for_type != ForType::GPULane)
+        << "The D3D12Compute backend does not support the gpu_lanes() scheduling directive.";
+
     if (!is_gpu_var(loop->name)) {
         user_assert(loop->for_type != ForType::Parallel) << "Cannot use parallel loops inside D3D12Compute kernel\n";
         CodeGen_C::visit(loop);

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -168,6 +168,9 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Mod *op) {
 }
 
 void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const For *loop) {
+    user_assert(loop->for_type != ForType::GPULane)
+        << "The Metal backend does not support the gpu_lanes() scheduling directive.";
+
     if (is_gpu_var(loop->name)) {
         internal_assert((loop->for_type == ForType::GPUBlock) ||
                         (loop->for_type == ForType::GPUThread))

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -119,6 +119,9 @@ string simt_intrinsic(const string &name) {
 }  // namespace
 
 void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const For *loop) {
+    user_assert(loop->for_type != ForType::GPULane)
+        << "The OpenCL backend does not support the gpu_lanes() scheduling directive.";
+
     if (is_gpu_var(loop->name)) {
         internal_assert((loop->for_type == ForType::GPUBlock) ||
                         (loop->for_type == ForType::GPUThread))

--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -144,6 +144,9 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Call *op) {
 }
 
 void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const For *loop) {
+    user_assert(loop->for_type != ForType::GPULane)
+        << "The OpenGLCompute backend does not support the gpu_lanes() scheduling directive.";
+
     if (is_gpu_var(loop->name)) {
         internal_assert((loop->for_type == ForType::GPUBlock) ||
                         (loop->for_type == ForType::GPUThread))

--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -444,6 +444,9 @@ void CodeGen_GLSL::visit(const Let *op) {
 }
 
 void CodeGen_GLSL::visit(const For *loop) {
+    user_assert(loop->for_type != ForType::GPULane)
+        << "The GLSL backend does not support the gpu_lanes() scheduling directive.";
+
     if (ends_with(loop->name, ".__block_id_x") ||
         ends_with(loop->name, ".__block_id_y")) {
         internal_assert(loop->for_type == ForType::GPUBlock)


### PR DESCRIPTION
- Give apps/iir_blur a fallback GPU schedule so that non-cuda backends won't fail
- add more user-friendly failure messages if gpu_lanes() is requested for a backend that doesn't support it
- add check to apps/cuda_mat_mul that cuda is enabled (already done in the makefile but this makes it more obvious in the code)