### PR TITLE
Add 'test_correctness_multi_gpu' test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1146,6 +1146,9 @@ test_avx512: $(CORRECTNESS_TESTS:$(ROOT_DIR)/test/correctness/%.cpp=avx512_%)
 test_opengl: $(OPENGL_TESTS:$(ROOT_DIR)/test/opengl/%.cpp=opengl_%)
 test_auto_schedule: $(AUTO_SCHEDULE_TESTS:$(ROOT_DIR)/test/auto_schedule/%.cpp=auto_schedule_%)
 
+.PHONY: test_correctness_multi_gpu
+test_correctness_multi_gpu: correctness_gpu_multi_device
+
 # There are 4 types of tests for generators:
 # 1) Externally-written aot-based tests
 # 2) Externally-written aot-based tests (compiled using C++ backend)

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -1,3 +1,8 @@
+tests(GROUPS correctness_multi_gpu
+      SOURCES
+      gpu_multi_device.cpp
+      )
+
 tests(GROUPS correctness travis
         SOURCES
         align_bounds.cpp
@@ -130,7 +135,6 @@ tests(GROUPS correctness travis
         gpu_large_alloc.cpp
         gpu_mixed_dimensionality.cpp
         gpu_mixed_shared_mem_types.cpp
-        gpu_multi_device.cpp
         gpu_multi_kernel.cpp
         gpu_non_contiguous_copy.cpp
         gpu_object_lifetime_1.cpp


### PR DESCRIPTION
This simplifies an ugly special case in our buildbot testing setup