### PR TITLE
Add assert-fail in HalideJITMemoryManager::getSymbolAddress()

### DIFF
--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -229,6 +229,8 @@ public:
             result = (uint64_t)&__udivdi3;
         }
 #endif
+        internal_assert(result != 0)
+            << "HalideJITMemoryManager: unable to find address for " << name << "\n";
         return result;
     }
 


### PR DESCRIPTION
If we can't get the address of a symbol, it's likely that we're going to crash later on anyway when we try to jump to a null address, which is hard to debug; changing to an assert-fail makes the issue easier to debug.

(Note that I *think* this is always a fatal error, but it may be that this needs to be a warning instead in some cases.)