### PR TITLE
Fix clang-format issues

### DIFF
--- a/apps/autoscheduler/FunctionDAG.cpp
+++ b/apps/autoscheduler/FunctionDAG.cpp
@@ -458,9 +458,11 @@ FunctionDAG::Edge::BoundInfo::BoundInfo(const Expr &e, const Node::Stage &consum
     const Mul *mul = add ? add->a.as<Mul>() : expr.as<Mul>();
     const IntImm *coeff_imm = mul ? mul->b.as<IntImm>() : nullptr;
     const IntImm *constant_imm = add ? add->b.as<IntImm>() : nullptr;
+    // clang-format off
     Expr v = (mul ? mul->a :
-                    add ? add->a :
-                          expr);
+              add ? add->a :
+                    expr);
+    // clang-format on
     const Variable *var = v.as<Variable>();
 
     if (const IntImm *c = e.as<IntImm>()) {

--- a/apps/autoscheduler/LoopNest.cpp
+++ b/apps/autoscheduler/LoopNest.cpp
@@ -462,9 +462,11 @@ void LoopNest::compute_features(const FunctionDAG &dag,
                 const auto &b = get_bounds(e->producer);
                 int64_t bytes = e->producer->bytes_per_point, lines = 1;
                 int64_t max_extent = 1;
-                int vector_dim = (e->producer->is_input ? 0 :
-                                                          site.produce != nullptr ? site.produce->vector_dim :
-                                                                                    -1);
+                // clang-format off
+                int vector_dim = (e->producer->is_input   ? 0 :
+                                  site.produce != nullptr ? site.produce->vector_dim :
+                                                            -1);
+                // clang-format on
                 for (int i = 0; i < e->producer->dimensions; i++) {
                     int64_t extent = b->region_required(i).extent();
                     max_extent = std::max(extent, max_extent);

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -461,9 +461,11 @@ int CodeGen_X86::vector_lanes_for_slice(const Type &t) const {
     // type if we can.
     int vec_bits = t.lanes() * t.bits();
     int natural_vec_bits = target.natural_vector_size(t) * t.bits();
+    // clang-format off
     int slice_bits = ((vec_bits > 256 && natural_vec_bits > 256) ? 512 :
-                                                                   (vec_bits > 128 && natural_vec_bits > 128) ? 256 :
-                                                                                                                128);
+                      (vec_bits > 128 && natural_vec_bits > 128) ? 256 :
+                                                                   128);
+    // clang-format on
     return slice_bits / t.bits();
 }
 

--- a/src/Type.h
+++ b/src/Type.h
@@ -207,10 +207,13 @@ template<typename T>
         (is_ptr ? halide_handle_cplusplus_type::Pointer : 0) |
         (is_const ? halide_handle_cplusplus_type::Const : 0) |
         (is_volatile ? halide_handle_cplusplus_type::Volatile : 0));
+
+    // clang-format off
     constexpr halide_handle_cplusplus_type::ReferenceType ref_type =
         (is_lvalue_reference ? halide_handle_cplusplus_type::LValueReference :
-                               is_rvalue_reference ? halide_handle_cplusplus_type::RValueReference :
-                                                     halide_handle_cplusplus_type::NotReference);
+         is_rvalue_reference ? halide_handle_cplusplus_type::RValueReference :
+                               halide_handle_cplusplus_type::NotReference);
+    // clang-format on
 
     using TNonCVBase = typename std::remove_cv<TBase>::type;
     constexpr bool known_type = halide_c_type_to_name<TNonCVBase>::known_type;

--- a/src/runtime/mini_qurt.h
+++ b/src/runtime/mini_qurt.h
@@ -21,6 +21,8 @@ typedef unsigned int qurt_thread_t;
    Macros for QuRT thread attributes.
  */
 
+// clang-format off
+
 #define QURT_HTHREAD_L1I_PREFETCH 0x1 /**< Enables hardware L1 instruction cache prefetching. */
 #define QURT_HTHREAD_L1D_PREFETCH 0x2 /**< Enables hardware L1 data cache prefetching. */
 #define QURT_HTHREAD_L2I_PREFETCH 0x4 /**< Enables hardware L2 instruction cache prefetching. */
@@ -39,6 +41,8 @@ typedef unsigned int qurt_thread_t;
 #define QURT_THREAD_ATTR_BUS_PRIO_DEFAULT 255                                     /**< */
 #define QURT_THREAD_ATTR_TIMETEST_ID_DEFAULT (-2)                                 /**< */
 /** @} */                                                                         /* end_addtogroup thread_macros */
+
+// clang-format on
 
 /** Thread attributes */
 typedef struct _qurt_thread_attr {

--- a/test/correctness/gpu_large_alloc.cpp
+++ b/test/correctness/gpu_large_alloc.cpp
@@ -34,10 +34,8 @@ int main(int argc, char **argv) {
     for (int i = 0; i < W; i++) {
         for (int j = 0; j < H; j++) {
             int m = std::max(i, j);
-            // printf("img[%d, %d] = %d\n", i, j, img(i, j));
-            if (img(i, j) != (m < 20 ? 20 :
-                                       m > 100 ? 100 :
-                                                 m)) {
+            const int expected = std::min(std::max(m, 20), 100);
+            if (img(i, j) != expected) {
                 printf("img[%d, %d] = %d\n", i, j, img(i, j));
                 return -1;
             }


### PR DESCRIPTION
I don't know how/why the master branch isn't clean this way. (Maybe I have a different clang-format locally?)