### PR TITLE
Lower tuples to separate atomic nodes where possible

### DIFF
--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -134,7 +134,7 @@ class SplitTuples : public IRMutator {
         }
     }
 
-    Stmt visit_provide(const Provide *op, const Atomic *atomic = nullptr) {
+    Stmt visit_provide(const Provide *op, const Atomic *atomic) {
 
         if (op->values.size() == 1) {
             if (atomic) {
@@ -317,6 +317,10 @@ class SplitTuples : public IRMutator {
     }
 
     Stmt visit(const Atomic *op) override {
+        // At this point in lowering, the only child of an atomic node
+        // should be a single provide node. We haven't many any
+        // statement mutations yet that would put things in between
+        // the provide and the atomic.
         if (const Provide *p = op->body.as<Provide>()) {
             return visit_provide(p, op);
         } else {

--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -1,8 +1,11 @@
 #include "SplitTuples.h"
+
 #include "Bounds.h"
+#include "ExprUsesVar.h"
 #include "Function.h"
 #include "IRMutator.h"
 #include "IROperator.h"
+#include "Simplify.h"
 
 namespace Halide {
 namespace Internal {
@@ -67,7 +70,9 @@ class SplitTuples : public IRMutator {
             // Make a nested set of realize nodes for each tuple element
             Stmt body = mutate(op->body);
             for (int i = (int)op->types.size() - 1; i >= 0; i--) {
-                body = Realize::make(op->name + "." + std::to_string(i), {op->types[i]}, op->memory_type, op->bounds, op->condition, body);
+                body = Realize::make(op->name + "." + std::to_string(i),
+                                     {op->types[i]}, op->memory_type,
+                                     op->bounds, op->condition, body);
             }
             return body;
         } else {
@@ -129,29 +134,14 @@ class SplitTuples : public IRMutator {
         }
     }
 
-    Stmt visit(const Provide *op) override {
-        if (op->values.size() == 1) {
-            return IRMutator::visit(op);
-        }
+    Stmt visit_provide(const Provide *op, const Atomic *atomic = nullptr) {
 
-        // Detect if the provide needs to be lowered atomically. By
-        // this we mean can we compute and store the values one at a
-        // time (not atomic), or must we compute them all, and then
-        // store them all (atomic).
-        bool atomic = false;
-        if (!realizations.contains(op->name) &&
-            uses_extern_image(op)) {
-            // If the provide is an output (it's not inside a
-            // realization), and it uses an input, then the input
-            // might alias with the output. We'd better just do it
-            // atomically.
-            atomic = true;
-        } else {
-            // If the boxes provided and required might overlap,
-            // the provide must be done atomically.
-            Box provided = box_provided(op, op->name);
-            Box required = box_required(op, op->name);
-            atomic = boxes_overlap(provided, required);
+        if (op->values.size() == 1) {
+            if (atomic) {
+                return IRMutator::visit(atomic);
+            } else {
+                return IRMutator::visit(op);
+            }
         }
 
         // Mutate the args
@@ -165,31 +155,173 @@ class SplitTuples : public IRMutator {
         internal_assert(it != env.end());
         Function f = it->second;
 
-        // Build a list of scalar provide statements, and a list of
-        // lets to wrap them.
-        vector<Stmt> provides;
-        vector<pair<string, Expr>> lets;
+        // For the new value of each tuple component, what existing
+        // tuple components does it already depend on?
+        vector<set<int>> dependencies(op->values.size());
+        for (int i = 0; i < (int)op->values.size(); i++) {
+            class Checker : public IRVisitor {
+                using IRVisitor::visit;
+                vector<pair<string, Expr>> lets;
 
-        for (size_t i = 0; i < op->values.size(); i++) {
-            string name = op->name + "." + std::to_string(i);
-            string var_name = name + ".value";
-            Expr val = mutate(op->values[i]);
-            if (!is_undef(val) && atomic) {
-                lets.emplace_back(var_name, val);
-                val = Variable::make(val.type(), var_name);
+                void visit(const Let *op) override {
+                    op->value.accept(this);
+                    lets.emplace_back(op->name, op->value);
+                    op->body.accept(this);
+                    lets.pop_back();
+                }
+
+                void visit(const Call *op) override {
+                    if (op->call_type == Call::Halide &&
+                        op->name == func_name &&
+                        could_alias(op->args, store_args)) {
+                        deps.insert(op->value_index);
+                    }
+                }
+
+                bool could_alias(const vector<Expr> &a, const vector<Expr> &b) {
+                    internal_assert(a.size() == b.size());
+                    // Construct a boolean Expr that says the addresses are equal
+                    Expr aliases = const_true();
+                    for (size_t i = 0; i < a.size(); i++) {
+                        aliases = aliases && (a[i] == b[i]);
+                    }
+                    // Might need some of the containing lets
+                    for (auto it = lets.rbegin(); it != lets.rend(); it++) {
+                        if (expr_uses_var(aliases, it->first)) {
+                            aliases = Let::make(it->first, it->second, aliases);
+                        }
+                    }
+                    return !can_prove(!aliases);
+                }
+
+            public:
+                set<int> &deps;
+                const string &func_name;
+                const vector<Expr> &store_args;
+                Checker(set<int> &deps,
+                        const string &func_name,
+                        const vector<Expr> &store_args)
+                    : deps(deps), func_name(func_name), store_args(store_args) {
+                }
+            } checker(dependencies[i], op->name, args);
+            op->values[i].accept(&checker);
+        }
+
+        // Build clusters of tuple components where two components
+        // belong to the same cluster if any of their loads or stores
+        // may alias
+        vector<vector<int>> clusters;
+        // Reserve space so that we can use pointers to clusters.
+        clusters.reserve(op->values.size());
+        for (int i = 0; i < (int)op->values.size(); i++) {
+            // What clusters does it already belong to?
+            vector<int> *owning_cluster = nullptr;
+            for (auto &c : clusters) {
+                bool belongs_to_this_cluster = false;
+                for (int j : c) {
+                    if (dependencies[j].count(i) ||
+                        dependencies[i].count(j)) {
+                        belongs_to_this_cluster = true;
+                        break;
+                    }
+                }
+                if (belongs_to_this_cluster) {
+                    if (owning_cluster) {
+                        // It's already in a cluster! We need to merge the clusters.
+                        owning_cluster->insert(owning_cluster->end(), c.begin(), c.end());
+                        c.clear();
+                    } else {
+                        owning_cluster = &c;
+                        c.push_back(i);
+                    }
+                }
             }
-            provides.push_back(Provide::make(name, {val}, args));
+            if (!owning_cluster) {
+                // Make a new cluster
+                clusters.emplace_back();
+                clusters.back().push_back(i);
+            }
         }
 
-        Stmt result = Block::make(provides);
+        // If each cluster has only a single store in it, we can use
+        // CAS loops or atomic adds and avoid ever needing to wrap
+        // things in a mutex. We express this using separate atomic
+        // nodes per store. If there's no mutex involved at all, then
+        // there's no benefit in packing things together into a single
+        // critical section.
+        bool separate_atomic_nodes_per_store =
+            ((atomic && atomic->mutex_name.empty()) ||
+             (clusters.size() == op->values.size()));
 
-        while (!lets.empty()) {
-            auto p = lets.back();
-            lets.pop_back();
-            result = LetStmt::make(p.first, p.second, result);
+        // For each cluster, build a list of scalar provide
+        // statements, and a list of lets to wrap them.
+        vector<Stmt> result;
+        for (auto &c : clusters) {
+            if (c.empty()) {
+                continue;
+            }
+            std::sort(c.begin(), c.end());
+            vector<Stmt> provides;
+            vector<pair<string, Expr>> lets;
+
+            Stmt s;
+
+            if (c.size() == 1) {
+                // Just make a provide node
+                int i = *c.begin();
+                string name = op->name + "." + std::to_string(i);
+                s = Provide::make(name, {mutate(op->values[i])}, args);
+            } else {
+                // Make a list of let statements that compute the
+                // values (doing any loads), and then a block of
+                // provide statements that do the stores.
+                for (auto i : c) {
+                    string name = op->name + "." + std::to_string(i);
+                    string var_name = name + ".value";
+                    Expr val = mutate(op->values[i]);
+                    if (!is_undef(val)) {
+                        lets.emplace_back(var_name, val);
+                        val = Variable::make(val.type(), var_name);
+                    }
+                    provides.push_back(Provide::make(name, {val}, args));
+                }
+
+                s = Block::make(provides);
+
+                while (!lets.empty()) {
+                    auto p = lets.back();
+                    lets.pop_back();
+                    s = LetStmt::make(p.first, p.second, s);
+                }
+            }
+
+            if (atomic && separate_atomic_nodes_per_store) {
+                s = Atomic::make(atomic->producer_name, atomic->mutex_name, s);
+            }
+
+            internal_assert(s.defined());
+            result.push_back(s);
         }
 
-        return result;
+        {
+            Stmt s = Block::make(result);
+            if (atomic && !separate_atomic_nodes_per_store) {
+                s = Atomic::make(atomic->producer_name, atomic->mutex_name, s);
+            }
+            return s;
+        }
+    }
+
+    Stmt visit(const Provide *op) override {
+        return visit_provide(op, nullptr);
+    }
+
+    Stmt visit(const Atomic *op) override {
+        if (const Provide *p = op->body.as<Provide>()) {
+            return visit_provide(p, op);
+        } else {
+            return IRMutator::visit(op);
+        }
     }
 
     const map<string, Function> &env;

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -11,6 +11,7 @@ tests(GROUPS correctness
       async.cpp
       async_copy_chain.cpp
       async_device_copy.cpp
+      atomic_tuples.cpp
       atomics.cpp
       autodiff.cpp
       autoschedule_small_pure_update.cpp

--- a/test/correctness/atomic_tuples.cpp
+++ b/test/correctness/atomic_tuples.cpp
@@ -1,0 +1,224 @@
+#include "Halide.h"
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+class Checker : public IRMutator {
+    Stmt visit(const Atomic *op) override {
+        count_atomics++;
+        if (!op->mutex_name.empty()) {
+            count_atomics_with_mutexes++;
+        }
+        return IRMutator::visit(op);
+    }
+
+public:
+    int count_atomics = 0;
+    int count_atomics_with_mutexes = 0;
+};
+
+int main(int argc, char **argv) {
+    {
+        Func f, g;
+        Var x, y;
+
+        f(x, y) = {x, y};
+        f(x, y) = {f(x, y)[0] + x,
+                   f(x, y)[1] + y};
+
+        // The summation is independent in the two tuple components,
+        // so it can just be two atomic add instructions. No CAS loop
+        // required.
+        f.compute_root().update().parallel(y).atomic();
+
+        g(x, y) = f(x, y)[0] + f(x, y)[1];
+
+        Checker checker;
+        g.add_custom_lowering_pass(&checker, []() {});
+
+        Buffer<int> out = g.realize(128, 128);
+        for (int y = 0; y < 128; y++) {
+            for (int x = 0; x < 128; x++) {
+                int correct = 2 * x + 2 * y;
+                if (out(x, y) != correct) {
+                    printf("out(%d, %d) = %d instead of %d\n",
+                           x, y, out(x, y), correct);
+                    return -1;
+                }
+            }
+        }
+
+        if (checker.count_atomics != 2 || checker.count_atomics_with_mutexes != 0) {
+            printf("Expected two atomic nodes, neither of them with mutexes\n");
+            return -1;
+        }
+    }
+
+    {
+        Func f, g;
+        Var x, y;
+
+        f(x, y) = {x, y};
+        f(x, y) = {f(x, y)[1] + x,
+                   f(x, y)[0] + y};
+
+        // The summation is coupled across the two tuple components
+        // and there are two stores, so we need a mutex.
+        f.compute_root().update().parallel(y).atomic();
+
+        g(x, y) = f(x, y)[0] + f(x, y)[1];
+
+        Checker checker;
+        g.add_custom_lowering_pass(&checker, []() {});
+
+        Buffer<int> out = g.realize(128, 128);
+        for (int y = 0; y < 128; y++) {
+            for (int x = 0; x < 128; x++) {
+                int correct = 2 * x + 2 * y;
+                if (out(x, y) != correct) {
+                    printf("out(%d, %d) = %d instead of %d\n",
+                           x, y, out(x, y), correct);
+                    return -1;
+                }
+            }
+        }
+
+        if (checker.count_atomics != 1 || checker.count_atomics_with_mutexes != 1) {
+            printf("Expected one atomic node, with mutex\n");
+            return -1;
+        }
+    }
+
+    {
+        Func f, g;
+        Var x, y;
+
+        f(x, y) = {x, y, 0};
+        f(x, y) = {f(x, y)[1] + x,
+                   f(x, y)[0] + y,
+                   f(x, y)[2] + 1};
+
+        // The summation is coupled across the first two tuple
+        // components and there are two stores, so we need a mutex
+        // there. The last store could in principle be a separate atomic
+        // add, but we instead just pack it into the critical section.
+        f.compute_root().update().parallel(y).atomic();
+
+        g(x, y) = f(x, y)[0] + f(x, y)[1] + f(x, y)[2];
+
+        Checker checker;
+        g.add_custom_lowering_pass(&checker, []() {});
+
+        Buffer<int> out = g.realize(128, 128);
+        for (int y = 0; y < 128; y++) {
+            for (int x = 0; x < 128; x++) {
+                int correct = 2 * x + 2 * y + 1;
+                if (out(x, y) != correct) {
+                    printf("out(%d, %d) = %d instead of %d\n",
+                           x, y, out(x, y), correct);
+                    return -1;
+                }
+            }
+        }
+
+        if (checker.count_atomics != 1 || checker.count_atomics_with_mutexes != 1) {
+            printf("Expected one atomic nodes, with mutex\n");
+            return -1;
+        }
+    }
+
+    {
+        Func f, g;
+        Var x, y;
+
+        f(x, y) = {x, y, x, y};
+        f(x, y) = {f(x, y)[1] + x,
+                   f(x, y)[0] + y,
+                   f(x, y)[3] + x,
+                   f(x, y)[2] + y};
+
+        // The summation is coupled across the first two tuple
+        // components and the last two components, but they're
+        // independent so they *could* get two critical sections, but
+        // it would be on the same mutex, so we just pack them all
+        // into one critical section.
+        f.compute_root().update().parallel(y).atomic();
+
+        g(x, y) = f(x, y)[0] + f(x, y)[1] + f(x, y)[2] + f(x, y)[3];
+
+        Checker checker;
+        g.add_custom_lowering_pass(&checker, []() {});
+
+        Buffer<int> out = g.realize(128, 128);
+        for (int y = 0; y < 128; y++) {
+            for (int x = 0; x < 128; x++) {
+                int correct = 4 * x + 4 * y;
+                if (out(x, y) != correct) {
+                    printf("out(%d, %d) = %d instead of %d\n",
+                           x, y, out(x, y), correct);
+                    return -1;
+                }
+            }
+        }
+
+        if (checker.count_atomics != 1 || checker.count_atomics_with_mutexes != 1) {
+            printf("Expected one atomic node, with mutex\n");
+            return -1;
+        }
+    }
+
+    {
+        Func f, g;
+        Var x, y;
+
+        f(x, y) = {x, y};
+        RDom r(0, 65);
+        // Update even rows
+        f(x, r * 2) = {f(x, r * 2 + 1)[1] + x,
+                       f(x, r * 2 - 1)[0] + r * 2};
+        // Update odd rows using even rows
+        f(x, r * 2 + 1) = {f(x, r * 2)[1] + x,
+                           f(x, r * 2 + 2)[0] + r * 2 + 1};
+
+        // The tuple components have cross-talk, but the loads
+        // couldn't possibly alias with the stores because of the
+        // even/odd split. We can just use four atomic adds safely.
+        f.compute_root();
+        f.update(0)
+            .parallel(r)
+            .atomic();
+        f.update(1)
+            .parallel(r)
+            .atomic();
+
+        g(x, y) = f(x, y)[0] + f(x, y)[1];
+
+        Checker checker;
+        g.add_custom_lowering_pass(&checker, []() {});
+
+        Buffer<int> out = g.realize(128, 128);
+        for (int y = 0; y < 128; y++) {
+            for (int x = 0; x < 128; x++) {
+                int correct = 2 * x + 2 * y + 1;
+                if (y & 1) {
+                    // The odd rows happen after the even rows, so
+                    // they get another dose of x + y.
+                    correct += x + y;
+                }
+                if (out(x, y) != correct) {
+                    printf("out(%d, %d) = %d instead of %d\n",
+                           x, y, out(x, y), correct);
+                    //return -1;
+                }
+            }
+        }
+
+        if (checker.count_atomics != 4 || checker.count_atomics_with_mutexes != 0) {
+            printf("Expected four atomic nodes, with no mutexes\n");
+            return -1;
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/rfactor.cpp
+++ b/test/correctness/rfactor.cpp
@@ -971,9 +971,9 @@ int tuple_partial_reduction_rfactor_test(bool compile_module) {
         m.functions().front().body.accept(&checker);
 
         CallGraphs expected = {
-            {g.name(), {intm1.name() + ".0", g.name() + ".0", g.name() + ".1"}},
-            {intm1.name(), {intm2.name() + ".0", intm1.name() + ".0", intm1.name() + ".1"}},
-            {intm2.name(), {f.name() + ".0", intm2.name() + ".0", intm2.name() + ".1"}},
+            {g.name(), {intm1.name() + ".0", g.name() + ".0"}},
+            {intm1.name(), {intm2.name() + ".0", intm1.name() + ".0"}},
+            {intm2.name(), {f.name() + ".0", intm2.name() + ".0"}},
             {f.name(), {}},
         };
         if (check_call_graphs(checker.calls, expected) != 0) {


### PR DESCRIPTION
If tuple components have no hazards between them, they can be computed
one after another in separate atomic blocks instead of in a single
combined atomic block. This lets us use atomic adds or CAS loops more
often and mutexes less often.

As a side-effect, this also means that update definitions that don't
modify one of the tuple components now entirely elide that store as a
no-op (see the change to the rfactor test).

This is part of the atomic_vectorization branch that can be separately merged.