### PR TITLE
Increase error tolerance on blas tests

### DIFF
--- a/apps/linear_algebra/tests/test_halide_blas.cpp
+++ b/apps/linear_algebra/tests/test_halide_blas.cpp
@@ -147,7 +147,7 @@ struct BLASTestBase {
         return buff;
     }
 
-    bool compareScalars(Scalar x, Scalar y, Scalar epsilon = 4 * std::numeric_limits<Scalar>::epsilon()) {
+    bool compareScalars(Scalar x, Scalar y, Scalar epsilon = 32 * std::numeric_limits<Scalar>::epsilon()) {
         if (x == y) {
             return true;
         } else {


### PR DESCRIPTION
One of the tests is flaky on windows as-is. Hopefully increasing the error tolerance will fix it.