### PR TITLE
Fix linear algebra schedules for old x86

### DIFF
--- a/apps/linear_algebra/src/blas_l3_generators.cpp
+++ b/apps/linear_algebra/src/blas_l3_generators.cpp
@@ -38,7 +38,7 @@ public:
         const Expr num_cols = B_.height();
         const Expr sum_size = A_.height();
 
-        const int vec = natural_vector_size(a_.type());
+        const int vec = std::max(4, natural_vector_size(a_.type()));
         const int s = vec * 2;
 
         Input<Buffer<T>> *A_in = &A_;


### PR DESCRIPTION
Vectors of size 2 aren't compatible with the rest of this schedule. Set
the min vector size to 4.