### PR TITLE
Add support to locate the last index for argmin/argmax.

### DIFF
--- a/src/InlineReductions.cpp
+++ b/src/InlineReductions.cpp
@@ -190,7 +190,13 @@ Tuple argmax(const RDom &r, Expr e, const std::string &name) {
     update_tup[value_index] = e;
 
     f(v.free_vars) = initial_tup;
-    Expr better = e > f(v.free_vars)[value_index];
+
+    Expr better;
+    if(name == "argmax_last_index")
+		better = e >= f(v.free_vars)[value_index];
+    else
+		better = e > f(v.free_vars)[value_index];
+
     Tuple update = tuple_select(better, update_tup, f(v.free_vars));
     f(v.free_vars) = update;
     return f(v.call_args);
@@ -219,7 +225,13 @@ Tuple argmin(const RDom &r, Expr e, const std::string &name) {
     update_tup[value_index] = e;
 
     f(v.free_vars) = initial_tup;
-    Expr better = e < f(v.free_vars)[value_index];
+
+    Expr better;
+    if(name == "argmin_last_index")
+		better = e <= f(v.free_vars)[value_index];
+    else
+		better = e < f(v.free_vars)[value_index];
+
     f(v.free_vars) = tuple_select(better, update_tup, f(v.free_vars));
     return f(v.call_args);
 }


### PR DESCRIPTION
'argmax' and 'argmin' finds the index (and value) of the max/min value in expression. This works fine for cases when there is only one max/minima.  But for the cases when there are multiple max/minimas, the current implementation picks the first found element.  For some use cases, such as in the ONNX specification (https://github.com/onnx/onnx/blob/master/docs/Operators.md#ArgMax), requires finding last max/minima as well. The proposed fix introduces a additional option to argmax/min for support of this use case.
