### PR TITLE
Large stack printer objects break llvm debuginfo

### DIFF
--- a/src/runtime/d3d12compute.cpp
+++ b/src/runtime/d3d12compute.cpp
@@ -93,11 +93,12 @@ static char trace_indent[TRACE_BUF_SIZE] = {};
 static char trace_buf[TRACE_BUF_SIZE] = {};
 static int trace_indent_end = 0;
 #define TRACEINDENT ((const char *)trace_indent)
-#define TRACEPRINT(msg) { \
-        trace_scope___.lock();                                          \
+#define TRACEPRINT(msg)                                                                       \
+    {                                                                                         \
+        trace_scope___.lock();                                                                \
         Printer<BasicPrinter, TRACE_BUF_SIZE>(user_context, trace_buf) << TRACEINDENT << msg; \
-        trace_scope___.unlock();                                        \
-}
+        trace_scope___.unlock();                                                              \
+    }
 struct TraceLogScope {
     void *user_context;
 
@@ -110,8 +111,8 @@ struct TraceLogScope {
         __atomic_clear(&trace_indent_lock, __ATOMIC_RELEASE);
     }
 
-    TraceLogScope(void *user_context, const char *function) :
-        user_context(user_context) {
+    TraceLogScope(void *user_context, const char *function)
+        : user_context(user_context) {
         lock();
         Printer<BasicPrinter, TRACE_BUF_SIZE>(user_context, trace_buf) << TRACEINDENT << "[@] " << function << "\n";
         for (const char *p = trace_indent_pattern; *p; ++p) {
@@ -129,7 +130,7 @@ struct TraceLogScope {
         unlock();
     }
 };
-#define TRACELOG TraceLogScope trace_scope___(user_context, __FUNCTION__); 
+#define TRACELOG TraceLogScope trace_scope___(user_context, __FUNCTION__);
 
 #else
 #define TRACEINDENT ""
@@ -1078,7 +1079,7 @@ WEAK void dispatch_threadgroups(d3d12_compute_command_list *cmdList,
 
 WEAK d3d12_buffer new_buffer_resource(d3d12_device *device, size_t length, D3D12_HEAP_TYPE heaptype) {
     TRACELOG;
-    
+
     D3D12_RESOURCE_DESC desc = {};
     {
         desc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
@@ -2511,7 +2512,7 @@ namespace {
 static int do_multidimensional_copy(d3d12_device *device, const device_copy &c,
                                     uint64_t src_offset, uint64_t dst_offset, int dimensions) {
     TRACELOG;
-    
+
     if (dimensions == 0) {
         d3d12_buffer *dsrc = reinterpret_cast<d3d12_buffer *>(c.src);
         d3d12_buffer *ddst = reinterpret_cast<d3d12_buffer *>(c.dst);

--- a/src/runtime/printer.h
+++ b/src/runtime/printer.h
@@ -32,10 +32,13 @@ public:
     char *buf, *dst, *end;
     void *user_context;
     bool own_mem;
+    char scratch[length <= 256 ? length : 1];
 
     Printer(void *ctx, char *mem = NULL)
         : user_context(ctx), own_mem(mem == NULL) {
-        buf = mem ? mem : (char *)halide_malloc(user_context, length);
+        buf = (mem                       ? mem :
+               length <= sizeof(scratch) ? scratch :
+                                           (char *)malloc(length));
         dst = buf;
         if (dst) {
             end = buf + (length - 1);
@@ -132,6 +135,10 @@ public:
         return (uint64_t)(dst - buf);
     }
 
+    uint64_t capacity() const {
+        return length;
+    }
+
     // Delete the last N characters
     void erase(int n) {
         if (dst) {
@@ -165,8 +172,8 @@ public:
             }
         }
 
-        if (own_mem) {
-            halide_free(user_context, buf);
+        if (own_mem && buf != scratch) {
+            free(buf);
         }
     }
 };


### PR DESCRIPTION
This fixes several test failures on master with expected-label-after-instruction 

I tracked the error down to instances of large StackPrinter objects in the d3d12 runtime. We probably shouldn't be making large stack allocations anyway, so I avoided these by in one case using malloc, and in the other case (tracing) using a global buffer guarded by a spinlock (trace was already using globals guarded by the same spinlock).

Fixes #4996