### PR TITLE
cmake: test: fix PCH compile error with Clang v10

### DIFF
--- a/cmake/HalideTestHelpers.cmake
+++ b/cmake/HalideTestHelpers.cmake
@@ -81,6 +81,7 @@ function(tests)
         add_executable("${TARGET}" "${file}")
         target_link_libraries("${TARGET}" PRIVATE Halide::Test)
         if ("${file}" MATCHES ".cpp$")
+            # Note: source for re-use may be overriden by tests_threaded
             target_precompile_headers("${TARGET}" REUSE_FROM _test_internal)
         endif ()
 
@@ -94,3 +95,13 @@ function(tests)
 
     set(TEST_NAMES "${TEST_NAMES}" PARENT_SCOPE)
 endfunction(tests)
+
+function(tests_threaded)
+    set(targets ${ARGN})
+    # Override source target from where pre-compiled headers are re-used,
+    # (can't re-use across non/threaded b/c compiler flags must match).
+    set_property(TARGET ${targets} PROPERTY
+        PRECOMPILE_HEADERS_REUSE_FROM _test_internal_threaded)
+
+    target_link_libraries(${targets} PRIVATE Threads::Threads)
+endfunction(tests_threaded)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,9 +3,13 @@ include(HalideTestHelpers)
 # Internal tests are a special case.
 # HalideTestHelpers depends on this test being present.
 add_executable(_test_internal internal.cpp)
-target_link_libraries(_test_internal PRIVATE Halide::Test)
-target_include_directories(_test_internal PRIVATE "${Halide_SOURCE_DIR}/src")
-target_precompile_headers(_test_internal PRIVATE <Halide.h>)
+add_executable(_test_internal_threaded internal.cpp) # dummy to share PCH
+foreach(target _test_internal _test_internal_threaded)
+    target_link_libraries(${target} PRIVATE Halide::Test)
+    target_include_directories(${target} PRIVATE "${Halide_SOURCE_DIR}/src")
+    target_precompile_headers(${target} PRIVATE <Halide.h>)
+endforeach()
+target_link_libraries(_test_internal_threaded PRIVATE Threads::Threads)
 
 add_halide_test(_test_internal GROUPS internal)
 

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -347,7 +347,7 @@ foreach (TEST IN ITEMS
          correctness_thread_safety
          correctness_vector_cast
          correctness_vector_math)
-    target_link_libraries(${TEST} PRIVATE Threads::Threads)
+    tests_threaded(${TEST})
 endforeach ()
 
 # Tests which use external funcs need to enable exports.

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -31,6 +31,6 @@ tests(GROUPS performance
 
 set_tests_properties(${TEST_NAMES} PROPERTIES RUN_SERIAL TRUE)
 
-target_link_libraries(performance_thread_safe_jit PRIVATE Threads::Threads)
+tests_threaded(performance_thread_safe_jit)
 
 set_target_properties(performance_fast_pow PROPERTIES ENABLE_EXPORTS TRUE)


### PR DESCRIPTION
Clang (10.0) does not like re-using pre-compiled headers across targets
built with and without -pthread compiler arg:

	FAILED: test/correctness/CMakeFiles/correctness_thread_safety.dir/thread_safety.cpp.o

	/usr/lib/llvm/10/bin/clang++ -DHALIDE_ENABLE_RTTI -DWITH_EXCEPTIONS -I../test/common -I../tools
	-Iinclude -O0 -march=native -pthread -std=c++14 -Xclang -include-pch -Xclang
	/.../Halide/build/test/CMakeFiles/_test_internal.dir/cmake_pch.hxx.pch
	-Xclang -include -Xclang /.../Halide/build/test/CMakeFiles/_test_internal.dir/cmake_pch.hxx
	-MD -MT test/correctness/CMakeFiles/correctness_thread_safety.dir/thread_safety.cpp.o
	-MF test/correctness/CMakeFiles/correctness_thread_safety.dir/thread_safety.cpp.o.d
	-o test/correctness/CMakeFiles/correctness_thread_safety.dir/thread_safety.cpp.o
	-c ../test/correctness/thread_safety.cpp

	error: POSIX thread support was disabled in PCH file but is currently enabled

Apparently, GCC (10.1) does not care.

This patch fixes the issue by intorducing another set of pre-compiled
headers for re-use across the targets that are built with -pthread.