### PR TITLE
Fix #5012

### DIFF
--- a/test/error/atomics_gpu_mutex.cpp
+++ b/test/error/atomics_gpu_mutex.cpp
@@ -4,21 +4,18 @@ using namespace Halide;
 
 int main(int argc, char **argv) {
     int img_size = 10000;
-    int hist_size = 7;
 
-    Func im, hist;
+    Func f;
     Var x;
     RDom r(0, img_size);
 
-    im(x) = (x * x) % hist_size;
+    f(x) = Tuple(1, 0);
+    f(r) = Tuple(f(r)[1] + 1, f(r)[0] + 1);
 
-    hist(x) = Tuple(0, 0);
-    hist(im(r)) += Tuple(1, 2);
-
-    hist.compute_root();
+    f.compute_root();
 
     RVar ro, ri;
-    hist.update()
+    f.update()
         .atomic()
         .split(r, ro, ri, 8)
         .gpu_blocks(ro)
@@ -28,7 +25,7 @@ int main(int argc, char **argv) {
     // and we don't allow GPU blocks on mutex locks since
     // it leads to deadlocks.
     // This should throw an error
-    Realization out = hist.realize(hist_size);
+    Realization out = f.realize(img_size);
 
     printf("Success!\n");
     return 0;


### PR DESCRIPTION
The atomics gpu mutex test is now possible to run on the GPU, so it's not an error anymore. Made the test case harder so that it requires a mutex again.