### PR TITLE
cmake: llvm: fix linking against LLVM shared lib

### DIFF
--- a/dependencies/llvm/CMakeLists.txt
+++ b/dependencies/llvm/CMakeLists.txt
@@ -127,13 +127,23 @@ endif ()
 
 ##
 # Finish setting up llvm library
+#
+# Ideally, we would use llvm_config (instead of hardcoding LLVM lib name below):
+#    if (LLVM_USE_SHARED_LLVM_LIBRARY)
+#        set(LLVM_USE_SHARED "USE_SHARED")
+#    endif()
+#    llvm_config(Halide_LLVM ${LLVM_USE_SHARED} ${LLVM_COMPONENTS})
+# However, llvm_config (LLVM 10.0) does not accept INTERFACE_LIBRARY targets,
+# so the below code does what llvm_config() does, with the slight difference
+# that we link exclusively to the shared library without fallback to static
+# libraries for symbols not resolved by the shared library.
 ##
 
 if (LLVM_USE_SHARED_LLVM_LIBRARY)
-    set(LLVM_USE_SHARED "USE_SHARED")
+    set(LLVM_LIBNAMES LLVM)
+else ()
+    llvm_map_components_to_libnames(LLVM_LIBNAMES ${LLVM_COMPONENTS})
 endif ()
-
-llvm_map_components_to_libnames(LLVM_LIBNAMES ${LLVM_COMPONENTS})
 target_link_libraries(Halide_LLVM INTERFACE ${LLVM_LIBNAMES})
 
 ##


### PR DESCRIPTION
Fixes the build with -DLLVM_USE_SHARED_LLVM_LIBRARY=ON to
actually use the dynamic build (libLLVM.so). Relevant
for LLVM builds with -DLLVM_BUILD_LLVM_DYLIB=ON.

Tested with LLVM v10.0.0. I did not test on LLVM v9; this PR does not change
the path for LLVM_USE_SHARED_LLVM_LIBRARY=OFF, but if linking
against shared LLVM library did work in v9, then need to test this PR in v9
for regression).

There are two issues that prevent a build against LLVM shared lib:
1. cmake failure:

      CMake Error at /usr/lib/llvm/10/lib64/cmake/llvm/LLVM-Config.cmake:145 (message):
        Target NVPTX is not in the set of libraries.
      Call Stack (most recent call first):
        /usr/lib/llvm/10/lib64/cmake/llvm/LLVM-Config.cmake:270 (llvm_expand_pseudo_components)
        dependencies/llvm/CMakeLists.txt:141 (llvm_map_components_to_libnames)

2. missing -lLLVM on the link line

Regarding issue 2: the result of missing -lLLVM on the link line can
be either of the following scenarios both of which are wrong:
(A) (in theory) a successful build but with all LLVM modules linked into
libHalide.so, which is not what the user requested with
LLVM_USE_SHARED_LLVM_LIBRARY=ON,
(B) (observed) a broken libHalide.so, where linking of apps against it fails with
undefined symbols errors related to target components (related to issue
1, see more below):

      /usr/lib/gcc/x86_64-pc-linux-gnu/10.1.0/../../../../x86_64-pc-linux-gnu/bin/ld:
      src/libHalide.so: undefined reference to `LLVMInitializeX86Target'

Sidenote regarding (B), linking the app against -lLLVM makes the link
succeed but fails at runtime, because then some static LLVM data
is linked into the app binary twice, so components get loaded twice:

      : CommandLine Error: Option 'pm-max-devirt-iterations' registered more
      than once!
      LLVM ERROR: inconsistency in registered CommandLine options

The above errors from (B) are symptomps that are not important, the fix
is to just link libHalide.so against libLLVM.so.  This commit provides
two alternatives for achiving it:
(a) use llvm_config()
(b) woraround by manually doing what llvm_config() does

I think the correct way is (a), however it cannot be used yet, because
in lateset LLVM 10.0.0, llvm_config does not accept targets of
type INTERFACE_LIBRARY (the patch to do this on top of LLVM v10.0.0:
[llvm-10.0.0-cmake-llvm-config-interface-libs.patch.txt](https://github.com/halide/Halide/files/4748380/llvm-10.0.0-cmake-llvm-config-interface-libs.patch.txt). If/when LLVM starts supporting
INTERFACE_LIBRARY, then (b) should be deleted in favor of (a), see the code
for (a) in the comment in this commit.

The problem with existing cmake code that tries to link against LLVM
library(ies) was that it seemed to communicate the intent to
LLVM-Config.cmake via LLVM_USE_SHARED var, but LLVM-Config doesn't use
that var. Instead, the llvm_config method takes an argument option
USE_SHARED.

Regarding issue 1: appears to be caused by treating targets as components.

Observed when LLVM is built into a shared library with:
	-DBUILD_SHARED_LIBS=OFF
	-DLLVM_BUILD_LLVM_DYLIB=ON
	-DLLVM_LINK_LLVM_DYLIB=ON
	-DLLVM_DISTRIBUTION_COMPONENTS="comp1;comp2;..."
	-DLLVM_TARGETS_TO_BUILD=""
	-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="X86;NVPTX;...."

Note that LLVM_DYLIB_COMPONENTS is NOT set explicitly, and
I am not sure what exactly it defaults to, but the shared lib
(libLLVM.so does end up containing all components selected by
LLVM_DISTRIBUTION_COMPONENTS and all selected targets. (Not that it
matters, but this is the LLVM config used in the package recipe in the
Gentoo distribution.)

The selected LLVM components do get built as static archives (e.g.
LLVMSupport.a, etc.) and do get linked into libLLVM.so and do get
installed into the system, however, there the static archives
for target libraries (e.g. LLVMX86TargetInfo.a, etc) get linked but
do NOT get installed into the system.

So, when Halide cmake script asks for the target libraries as components
(in call to llvm_map_components_to_libnames), that call fails),
presumably because the corresponding static archives for the target
libraries do not exist in the system. However, when linking against
the LLVM shared library (as opposed to static archives), it is
not necessary to specify the targets as components on the link line.
The target components are linked into the shared object, along with the
rest of the components, and specifying just the shared object is sufficient.

Note that llvm_config implementation specifies both the shared object,
followed by static archives for sake of fallback, so I kept that same
logic. It would work equally well to only list LLVM without the static
objects for the case with LLVM_USE_SHARED_LLVM_LIBRARY=ON.