### PR TITLE
Fewer print parentheses

### DIFF
--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -351,11 +351,17 @@ std::ostream &operator<<(std::ostream &out, const DimType &t) {
 }
 
 IRPrinter::IRPrinter(ostream &s)
-    : stream(s), indent(0) {
+    : stream(s) {
     s.setf(std::ios::fixed, std::ios::floatfield);
 }
 
 void IRPrinter::print(const Expr &ir) {
+    ScopedValue<bool> old(implicit_parens, false);
+    ir.accept(this);
+}
+
+void IRPrinter::print_no_parens(const Expr &ir) {
+    ScopedValue<bool> old(implicit_parens, true);
     ir.accept(this);
 }
 
@@ -365,7 +371,7 @@ void IRPrinter::print(const Stmt &ir) {
 
 void IRPrinter::print_list(const std::vector<Expr> &exprs) {
     for (size_t i = 0; i < exprs.size(); i++) {
-        print(exprs[i]);
+        print_no_parens(exprs[i]);
         if (i < exprs.size() - 1) {
             stream << ", ";
         }
@@ -442,129 +448,146 @@ void IRPrinter::visit(const Cast *op) {
 void IRPrinter::visit(const Variable *op) {
     if (!known_type.contains(op->name) &&
         (op->type != Int(32))) {
-        stream << "(" << op->type << ")";
+        // Handle types already have parens
+        if (op->type.is_handle()) {
+            stream << op->type;
+        } else {
+            stream << "(" << op->type << ")";
+        }
     }
     stream << op->name;
 }
 
+void IRPrinter::open() {
+    if (!implicit_parens) {
+        stream << "(";
+    }
+}
+
+void IRPrinter::close() {
+    if (!implicit_parens) {
+        stream << ")";
+    }
+}
+
 void IRPrinter::visit(const Add *op) {
-    stream << "(";
+    open();
     print(op->a);
     stream << " + ";
     print(op->b);
-    stream << ")";
+    close();
 }
 
 void IRPrinter::visit(const Sub *op) {
-    stream << "(";
+    open();
     print(op->a);
     stream << " - ";
     print(op->b);
-    stream << ")";
+    close();
 }
 
 void IRPrinter::visit(const Mul *op) {
-    stream << "(";
+    open();
     print(op->a);
     stream << "*";
     print(op->b);
-    stream << ")";
+    close();
 }
 
 void IRPrinter::visit(const Div *op) {
-    stream << "(";
+    open();
     print(op->a);
     stream << "/";
     print(op->b);
-    stream << ")";
+    close();
 }
 
 void IRPrinter::visit(const Mod *op) {
-    stream << "(";
+    open();
     print(op->a);
     stream << " % ";
     print(op->b);
-    stream << ")";
+    close();
 }
 
 void IRPrinter::visit(const Min *op) {
     stream << "min(";
-    print(op->a);
+    print_no_parens(op->a);
     stream << ", ";
-    print(op->b);
-    stream << ")";
+    print_no_parens(op->b);
+    close();
 }
 
 void IRPrinter::visit(const Max *op) {
     stream << "max(";
-    print(op->a);
+    print_no_parens(op->a);
     stream << ", ";
-    print(op->b);
-    stream << ")";
+    print_no_parens(op->b);
+    close();
 }
 
 void IRPrinter::visit(const EQ *op) {
-    stream << "(";
+    open();
     print(op->a);
     stream << " == ";
     print(op->b);
-    stream << ")";
+    close();
 }
 
 void IRPrinter::visit(const NE *op) {
-    stream << "(";
+    open();
     print(op->a);
     stream << " != ";
     print(op->b);
-    stream << ")";
+    close();
 }
 
 void IRPrinter::visit(const LT *op) {
-    stream << "(";
+    open();
     print(op->a);
     stream << " < ";
     print(op->b);
-    stream << ")";
+    close();
 }
 
 void IRPrinter::visit(const LE *op) {
-    stream << "(";
+    open();
     print(op->a);
     stream << " <= ";
     print(op->b);
-    stream << ")";
+    close();
 }
 
 void IRPrinter::visit(const GT *op) {
-    stream << "(";
+    open();
     print(op->a);
     stream << " > ";
     print(op->b);
-    stream << ")";
+    close();
 }
 
 void IRPrinter::visit(const GE *op) {
-    stream << "(";
+    open();
     print(op->a);
     stream << " >= ";
     print(op->b);
-    stream << ")";
+    close();
 }
 
 void IRPrinter::visit(const And *op) {
-    stream << "(";
+    open();
     print(op->a);
     stream << " && ";
     print(op->b);
-    stream << ")";
+    close();
 }
 
 void IRPrinter::visit(const Or *op) {
-    stream << "(";
+    open();
     print(op->a);
     stream << " || ";
     print(op->b);
-    stream << ")";
+    close();
 }
 
 void IRPrinter::visit(const Not *op) {
@@ -574,11 +597,11 @@ void IRPrinter::visit(const Not *op) {
 
 void IRPrinter::visit(const Select *op) {
     stream << "select(";
-    print(op->condition);
+    print_no_parens(op->condition);
     stream << ", ";
-    print(op->true_value);
+    print_no_parens(op->true_value);
     stream << ", ";
-    print(op->false_value);
+    print_no_parens(op->false_value);
     stream << ")";
 }
 
@@ -586,13 +609,13 @@ void IRPrinter::visit(const Load *op) {
     const bool has_pred = !is_one(op->predicate);
     const bool show_alignment = op->type.is_vector() && op->alignment.modulus > 1;
     if (has_pred) {
-        stream << "(";
+        open();
     }
     if (!known_type.contains(op->name)) {
         stream << "(" << op->type << ")";
     }
     stream << op->name << "[";
-    print(op->index);
+    print_no_parens(op->index);
     if (show_alignment) {
         stream << " aligned(" << op->alignment.modulus << ", " << op->alignment.remainder << ")";
     }
@@ -600,21 +623,21 @@ void IRPrinter::visit(const Load *op) {
     if (has_pred) {
         stream << " if ";
         print(op->predicate);
-        stream << ")";
+        close();
     }
 }
 
 void IRPrinter::visit(const Ramp *op) {
     stream << "ramp(";
-    print(op->base);
+    print_no_parens(op->base);
     stream << ", ";
-    print(op->stride);
+    print_no_parens(op->stride);
     stream << ", " << op->lanes << ")";
 }
 
 void IRPrinter::visit(const Broadcast *op) {
     stream << "x" << op->lanes << "(";
-    print(op->value);
+    print_no_parens(op->value);
     stream << ")";
 }
 
@@ -622,7 +645,11 @@ void IRPrinter::visit(const Call *op) {
     // TODO: Print indication of C vs C++?
     if (!known_type.contains(op->name) &&
         (op->type != Int(32))) {
-        stream << "(" << op->type << ")";
+        if (op->type.is_handle()) {
+            stream << op->type;  // Already has parens
+        } else {
+            stream << "(" << op->type << ")";
+        }
     }
     stream << op->name << "(";
     print_list(op->args);
@@ -631,17 +658,18 @@ void IRPrinter::visit(const Call *op) {
 
 void IRPrinter::visit(const Let *op) {
     ScopedBinding<> bind(known_type, op->name);
-    stream << "(let " << op->name << " = ";
+    open();
+    stream << "let " << op->name << " = ";
     print(op->value);
     stream << " in ";
     print(op->body);
-    stream << ")";
+    close();
 }
 
 void IRPrinter::visit(const LetStmt *op) {
     ScopedBinding<> bind(known_type, op->name);
     stream << get_indent() << "let " << op->name << " = ";
-    print(op->value);
+    print_no_parens(op->value);
     stream << "\n";
 
     print(op->body);
@@ -649,9 +677,9 @@ void IRPrinter::visit(const LetStmt *op) {
 
 void IRPrinter::visit(const AssertStmt *op) {
     stream << get_indent() << "assert(";
-    print(op->condition);
+    print_no_parens(op->condition);
     stream << ", ";
-    print(op->message);
+    print_no_parens(op->message);
     stream << ")\n";
 }
 
@@ -671,9 +699,9 @@ void IRPrinter::visit(const ProducerConsumer *op) {
 void IRPrinter::visit(const For *op) {
     ScopedBinding<> bind(known_type, op->name);
     stream << get_indent() << op->for_type << op->device_api << " (" << op->name << ", ";
-    print(op->min);
+    print_no_parens(op->min);
     stream << ", ";
-    print(op->extent);
+    print_no_parens(op->extent);
     stream << ") {\n";
 
     indent++;
@@ -685,9 +713,9 @@ void IRPrinter::visit(const For *op) {
 
 void IRPrinter::visit(const Acquire *op) {
     stream << get_indent() << "acquire (";
-    print(op->semaphore);
+    print_no_parens(op->semaphore);
     stream << ", ";
-    print(op->count);
+    print_no_parens(op->count);
     stream << ") {\n";
     indent++;
     print(op->body);
@@ -699,13 +727,13 @@ void IRPrinter::print_lets(const Let *let) {
     stream << get_indent();
     ScopedBinding<> bind(known_type, let->name);
     stream << "let " << let->name << " = ";
-    print(let->value);
+    print_no_parens(let->value);
     stream << " in\n";
     if (const Let *next = let->body.as<Let>()) {
         print_lets(next);
     } else {
         stream << get_indent();
-        print(let->body);
+        print_no_parens(let->body);
         stream << "\n";
     }
 }
@@ -716,13 +744,13 @@ void IRPrinter::visit(const Store *op) {
     const bool show_alignment = op->value.type().is_vector() && (op->alignment.modulus > 1);
     if (has_pred) {
         stream << "predicate (";
-        print(op->predicate);
+        print_no_parens(op->predicate);
         stream << ")\n";
         indent++;
         stream << get_indent();
     }
     stream << op->name << "[";
-    print(op->index);
+    print_no_parens(op->index);
     if (show_alignment) {
         stream << " aligned("
                << op->alignment.modulus
@@ -738,7 +766,7 @@ void IRPrinter::visit(const Store *op) {
         indent -= 2;
     } else {
         // Just print the value in-line
-        print(op->value);
+        print_no_parens(op->value);
     }
     stream << "\n";
     if (has_pred) {
@@ -779,7 +807,7 @@ void IRPrinter::visit(const Allocate *op) {
     if (op->new_expr.defined()) {
         stream << "\n";
         stream << get_indent() << " custom_new { ";
-        print(op->new_expr);
+        print_no_parens(op->new_expr);
         stream << " }";
     }
     if (!op->free_function.empty()) {
@@ -800,9 +828,9 @@ void IRPrinter::visit(const Realize *op) {
     stream << get_indent() << "realize " << op->name << "(";
     for (size_t i = 0; i < op->bounds.size(); i++) {
         stream << "[";
-        print(op->bounds[i].min);
+        print_no_parens(op->bounds[i].min);
         stream << ", ";
-        print(op->bounds[i].extent);
+        print_no_parens(op->bounds[i].extent);
         stream << "]";
         if (i < op->bounds.size() - 1) stream << ", ";
     }
@@ -828,7 +856,7 @@ void IRPrinter::visit(const Prefetch *op) {
     const bool has_cond = !is_one(op->condition);
     if (has_cond) {
         stream << "if (";
-        print(op->condition);
+        print_no_parens(op->condition);
         stream << ") {\n";
         indent++;
         stream << get_indent();
@@ -836,9 +864,9 @@ void IRPrinter::visit(const Prefetch *op) {
     stream << "prefetch " << op->name << "(";
     for (size_t i = 0; i < op->bounds.size(); i++) {
         stream << "[";
-        print(op->bounds[i].min);
+        print_no_parens(op->bounds[i].min);
         stream << ", ";
-        print(op->bounds[i].extent);
+        print_no_parens(op->bounds[i].extent);
         stream << "]";
         if (i < op->bounds.size() - 1) stream << ", ";
     }
@@ -880,7 +908,7 @@ void IRPrinter::visit(const IfThenElse *op) {
     stream << get_indent();
     while (1) {
         stream << "if (";
-        print(op->condition);
+        print_no_parens(op->condition);
         stream << ") {\n";
         indent++;
         print(op->then_case);
@@ -907,7 +935,7 @@ void IRPrinter::visit(const IfThenElse *op) {
 
 void IRPrinter::visit(const Evaluate *op) {
     stream << get_indent();
-    print(op->value);
+    print_no_parens(op->value);
     stream << "\n";
 }
 
@@ -936,7 +964,7 @@ void IRPrinter::visit(const Shuffle *op) {
         print_list(op->vectors);
         stream << ", ";
         for (size_t i = 0; i < op->indices.size(); i++) {
-            print(op->indices[i]);
+            print_no_parens(op->indices[i]);
             if (i < op->indices.size() - 1) {
                 stream << ", ";
             }

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -201,15 +201,15 @@ void IRPrinter::test() {
     std::string correct_source =
         "allocate buf[float32 * 1023] in Stack\n"
         "let y = 17\n"
-        "assert((y >= 3), halide_error_param_too_small_i64(\"y\", y, 3))\n"
+        "assert(y >= 3, halide_error_param_too_small_i64(\"y\", y, 3))\n"
         "produce buf {\n"
-        " parallel (x, -2, (y + 2)) {\n"
-        "  buf[(y - 1)] = ((x*17)/(x - 3))\n"
+        " parallel (x, -2, y + 2) {\n"
+        "  buf[y - 1] = (x*17)/(x - 3)\n"
         " }\n"
         "}\n"
         "consume buf {\n"
         " vectorized (x, 0, y) {\n"
-        "  out[x] = (buf((x % 3)) + 1)\n"
+        "  out[x] = buf(x % 3) + 1\n"
         " }\n"
         "}\n";
 

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -101,6 +101,9 @@ public:
     /** emit an expression on the output stream */
     void print(const Expr &);
 
+    /** Emit an expression on the output stream without enclosing parens */
+    void print_no_parens(const Expr &);
+
     /** emit a statement on the output stream */
     void print(const Stmt &);
 
@@ -120,7 +123,18 @@ protected:
 
     /** The current indentation level, useful for pretty-printing
      * statements */
-    int indent;
+    int indent = 0;
+
+    /** Certain expressions do not need parens around them, e.g. the
+     * args to a call are already separated by commas and a
+     * surrounding set of parens. */
+    bool implicit_parens = false;
+
+    /** Either emits "(" or "", depending on the value of implicit_parens */
+    void open();
+
+    /** Either emits ")" or "", depending on the value of implicit_parens */
+    void close();
 
     /** The symbols whose types can be inferred from values printed
      * already. */


### PR DESCRIPTION
Make IRPrinter not add parentheses where they are not needed, e.g. in expressions in comma-separated lists, in expressions in square brackets or other parentheses already, and in expressions in between an equals sign and a newline. This makes the IR easier to visually parse. 

A snippet of local laplacian IR before:

```
produce f9 {
  consume f8 {
   let t3907 = (f8.v0.extent_realized.s.s - f8.v0.min_realized)
   let t3899 = max(f10.s0.v3.min.s, 0)
   let t3905 = (f8.v0.min_realized - f8.v0.extent_realized.s.s)
   let t3901 = ((f9.s0.v1.max - f9.s0.v1.min) + 1)
   let t3902 = ((f9.s0.v0.max - f9.s0.v0.min) + 1)
   let t3906 = (f9.v0.extent_realized.s + 1)
   let t3900 = (f9.s0.v3.loop_extent.s + 2)
   parallel (f9.s0.v3, t3899, t3900) {
    let t3908 = (f9.s0.v3 - t3899)
    for (f9.s0.v1, f9.s0.v1.min, t3901) {
     let t3911 = ((((f9.s0.v1*2) - f8.v1.min_realized)*(t3907 + 1)) + ((f8.stride.2*t3908) - f8.v0.min_realized))
     let t3913 = (((f9.s0.v1 - f9.v1.min_realized)*t3906) + ((f9.stride.2*t3908) - f9.v0.min_realized))
     for (f9.s0.v0, f9.s0.v0.min, t3902) {
      let t2609 = ((f9.s0.v0*2) + t3911)
      let t3381 = (t2609 + t3907)
      let t3382 = (t2609 + t3905)
      let t3383 = ((t3907*2) + t2609)
      f9[(f9.s0.v0 + t3913)] = ((((((f8[(t2609 + 2)] + (f8[(t2609 + -1)] + ((f8[t2609] + f8[(t2609 + 1)])*3.000000f))) + (f8[(t3381 + 3)] + (f8[t3381] + ((f8[(t3381 + 1)] + f8[(t3381 + 2)])*3.000000f))))*3.000000f) + (f8[(t3382 + 1)] + (f8[(t3382 + -2)] + ((f8[(t3382 + -1)] + f8[t3382])*3.000000f)))) + (f8[(t3383 + 4)] + (f8[(t3383 + 1)] + ((f8[(t3383 + 2)] + f8[(t3383 + 3)])*3.000000f))))*0.015625f)
     }
    }
   }
  }
 }

```
after:
```
 produce f9 {
  consume f8 {
   let t3907 = f8.v0.extent_realized.s.s - f8.v0.min_realized
   let t3899 = max(f10.s0.v3.min.s, 0
   let t3905 = f8.v0.min_realized - f8.v0.extent_realized.s.s
   let t3901 = (f9.s0.v1.max - f9.s0.v1.min) + 1
   let t3902 = (f9.s0.v0.max - f9.s0.v0.min) + 1
   let t3906 = f9.v0.extent_realized.s + 1
   let t3900 = f9.s0.v3.loop_extent.s + 2
   parallel (f9.s0.v3, t3899, t3900) {
    let t3908 = f9.s0.v3 - t3899
    for (f9.s0.v1, f9.s0.v1.min, t3901) {
     let t3911 = (((f9.s0.v1*2) - f8.v1.min_realized)*(t3907 + 1)) + ((f8.stride.2*t3908) - f8.v0.min_realized)
     let t3913 = ((f9.s0.v1 - f9.v1.min_realized)*t3906) + ((f9.stride.2*t3908) - f9.v0.min_realized)
     for (f9.s0.v0, f9.s0.v0.min, t3902) {
      let t2609 = (f9.s0.v0*2) + t3911
      let t3381 = t2609 + t3907
      let t3382 = t2609 + t3905
      let t3383 = (t3907*2) + t2609
      f9[f9.s0.v0 + t3913] = (((((f8[t2609 + 2] + (f8[t2609 + -1] + ((f8[t2609] + f8[t2609 + 1])*3.000000f))) + (f8[t3381 + 3] + (f8[t3381] + ((f8[t3381 + 1] + f8[t3381 + 2])*3.000000f))))*3.000000f) + (f8[t3382 + 1] + (f8[t3382 + -2] + ((f8[t3382 + -1] + f8[t3382])*3.000000f)))) + (f8[t3383 + 4] + (f8[t3383 + 1] + ((f8[t3383 + 2] + f8[t3383 + 3])*3.000000f))))*0.015625f
     }
    }
   }
  }
 }

```