### PR TITLE
Make gpu_thread_barrier() semantics consistent

### DIFF
--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -270,10 +270,13 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Call *op) {
         // available
         // NOTE(shoaibkamil): should we replace with AllMemoryBarrierWithGroupSync()
         // if both are required?
-        stream << get_indent() << "GroupMemoryBarrierWithGroupSync();\n";
-        if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Device) {
-          stream << get_indent() << "DeviceMemoryBarrierWithGroupSync();\n";
+        if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Device &&
+            !(fence_type & CodeGen_GPU_Dev::MemoryFenceType::Shared)) {
+                stream << get_indent() << "DeviceMemoryBarrierWithGroupSync();\n";
+        } else if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Device) {
+            stream << get_indent() << "DeviceMemoryBarrier();\n";
         }
+        stream << get_indent() << "GroupMemoryBarrierWithGroupSync();\n";
         print_assignment(op->type, "0");
     } else if (op->name == "pow_f32" && can_prove(op->args[0] > 0)) {
         // If we know pow(x, y) is called with x > 0, we can use HLSL's pow

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -261,9 +261,11 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Broadcast *op
 
 void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Call *op) {
     if (op->is_intrinsic(Call::gpu_thread_barrier)) {
-        internal_assert(op->args.size() == 1) << "gpu_thread_barrier() intrinsic must specify memory fence type\n";
+        internal_assert(op->args.size() == 1) << "gpu_thread_barrier() intrinsic must specify memory fence type.\n";
 
-        auto fence_type = *as_const_int(op->args[0]);
+        auto fence_type_ptr = as_const_int(op->args[0]);
+        internal_assert(fence_type_ptr) << "gpu_thread_barrier() parameter is not a constant integer.\n";
+        auto fence_type = *fence_type_ptr;
 
         // By default, we'll just issue a Group (aka Shared) memory barrier,
         // since it seems there isn't a sync without a memory barrier
@@ -272,7 +274,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Call *op) {
         // if both are required?
         if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Device &&
             !(fence_type & CodeGen_GPU_Dev::MemoryFenceType::Shared)) {
-                stream << get_indent() << "DeviceMemoryBarrierWithGroupSync();\n";
+            stream << get_indent() << "DeviceMemoryBarrierWithGroupSync();\n";
         } else if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Device) {
             stream << get_indent() << "DeviceMemoryBarrier();\n";
         }

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -261,14 +261,19 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Broadcast *op
 
 void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Call *op) {
     if (op->is_intrinsic(Call::gpu_thread_barrier)) {
-        // NOTE(marcos): adding both types of thread-group barriers here
-        // because Halide at the moment only has the concept of a general
-        // GPU sync point (gpu_thread_barrier); ideally, some distinction
-        // between shared memory and device memory is needed, and we could
-        // even go one step further and issue barriers that only affect
-        // memory loads/stores without synchronizing the threads...
+        internal_assert(op->args.size() == 1) << "gpu_thread_barrier() intrinsic must specify memory fence type\n";
+
+        auto fence_type = *as_const_int(op->args[0]);
+
+        // By default, we'll just issue a Group (aka Shared) memory barrier,
+        // since it seems there isn't a sync without a memory barrier
+        // available
+        // NOTE(shoaibkamil): should we replace with AllMemoryBarrierWithGroupSync()
+        // if both are required?
         stream << get_indent() << "GroupMemoryBarrierWithGroupSync();\n";
-        stream << get_indent() << "DeviceMemoryBarrierWithGroupSync();\n";
+        if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Device) {
+          stream << get_indent() << "DeviceMemoryBarrierWithGroupSync();\n";
+        }
         print_assignment(op->type, "0");
     } else if (op->name == "pow_f32" && can_prove(op->args[0] > 0)) {
         // If we know pow(x, y) is called with x > 0, we can use HLSL's pow

--- a/src/CodeGen_GPU_Dev.h
+++ b/src/CodeGen_GPU_Dev.h
@@ -67,6 +67,15 @@ struct CodeGen_GPU_Dev {
      * candidate for constant storage if it is never written to, and loads are
      * uniform within the workgroup. */
     static bool is_buffer_constant(const Stmt &kernel, const std::string &buffer);
+
+    /** An mask describing which type of memory fence to use for the gpu_thread_barrier()
+    * intrinsic.  Not all GPUs APIs support all types.
+    */
+    enum MemoryFenceType {
+        None = 0,    // No fence required (just a sync)
+        Device = 1,  // Device/global memory fence
+        Shared = 2   // Threadgroup/shared memory fence
+    };
 };
 
 }  // namespace Internal

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -220,13 +220,20 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Call *op) {
         internal_assert(fence_type_ptr) << "gpu_thread_barrier() parameter is not a constant integer.\n";
         auto fence_type = *fence_type_ptr;
 
-        stream << get_indent() << "threadgroup_barrier("
-               << "mem_flags::mem_none";
-        if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Device) {
-            stream << " | mem_flags::mem_device";
-        }
-        if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Shared) {
-            stream << " | mem_flags::mem_threadgroup";
+        // This is quite annoying: even though the MSL docs claim these flags can be combined,
+        // Metal compilers prior to Metal 1.2 give compiler errors.  So, we do not combine them,
+        // and rather use a preprocessor definition to do the right thing.
+
+        stream << get_indent() << "threadgroup_barrier(";
+        if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Device &&
+            fence_type & CodeGen_GPU_Dev::MemoryFenceType::Shared) {
+            stream << "_halide_mem_fence_device_and_threadgroup";
+        } else if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Device) {
+            stream << "mem_flags::mem_device";
+        } else if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Shared) {
+            stream << "mem_flags::mem_threadgroup";
+        } else {
+            stream << "mem_flags::mem_none";
         }
         stream << ");\n";
         print_assignment(op->type, "0");
@@ -678,6 +685,14 @@ void CodeGen_Metal_Dev::init_module() {
                << "#define tanh_f32 tanh\n"
                << "#define atanh_f32 atanh\n"
                << "#define fast_inverse_sqrt_f32 rsqrt\n"
+               // This is quite annoying: even though the MSL docs claim
+               // all versions of Metal support the same memory fence
+               // names, the truth is that 1.0 does not.
+               << "#if __METAL_VERSION__ >= 120\n"
+               << "#define _halide_mem_fence_device_and_threadgroup (mem_flags::mem_device | mem_flags::mem_threadgroup)\n"
+               << "#else\n"
+               << "#define _halide_mem_fence_device_and_threadgroup mem_flags::mem_device_and_threadgroup\n"
+               << "#endif\n"
                << "}\n";  // close namespace
 
     metal_c.add_common_macros(src_stream);

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -220,10 +220,10 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Call *op) {
         stream << get_indent() << "threadgroup_barrier("
                << "mem_flags::mem_none";
         if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Device) {
-            stream << "| mem_flags::mem_device";
+            stream << " | mem_flags::mem_device";
         }
         if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Shared) {
-            stream << "| mem_flags::mem_threadgroup";
+            stream << " | mem_flags::mem_threadgroup";
         }
         stream << ");\n";
         print_assignment(op->type, "0");

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -214,9 +214,12 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Broadcast *op) {
 
 void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Call *op) {
     if (op->is_intrinsic(Call::gpu_thread_barrier)) {
-        internal_assert(op->args.size() == 1) << "gpu_thread_barrier() intrinsic must specify memory fence type\n";
+        internal_assert(op->args.size() == 1) << "gpu_thread_barrier() intrinsic must specify memory fence type.\n";
 
-        auto fence_type = *as_const_int(op->args[0]);
+        auto fence_type_ptr = as_const_int(op->args[0]);
+        internal_assert(fence_type_ptr) << "gpu_thread_barrier() parameter is not a constant integer.\n";
+        auto fence_type = *fence_type_ptr;
+
         stream << get_indent() << "threadgroup_barrier("
                << "mem_flags::mem_none";
         if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Device) {

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -217,7 +217,16 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Call *op) {
         rhs << "abs_diff(" << print_expr(op->args[0]) << ", " << print_expr(op->args[1]) << ")";
         print_assignment(op->type, rhs.str());
     } else if (op->is_intrinsic(Call::gpu_thread_barrier)) {
-        stream << get_indent() << "barrier(CLK_LOCAL_MEM_FENCE);\n";
+        internal_assert(op->args.size() == 1) << "gpu_thread_barrier() intrinsic must specify memory fence type\n";
+        auto fence_type = *as_const_int(op->args[0]);
+        stream << get_indent() << "barrier(0";
+        if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Device) {
+            stream << "| CLK_GLOBAL_MEM_FENCE";
+        }
+        if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Shared) {
+            stream << "| CLK_LOCAL_MEM_FENCE";
+        }
+        stream << ");\n";
         print_assignment(op->type, "0");
     } else if (op->is_intrinsic(Call::shift_left) || op->is_intrinsic(Call::shift_right)) {
         // Some OpenCL implementations forbid mixing signed-and-unsigned shift values;

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -221,10 +221,10 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Call *op) {
         auto fence_type = *as_const_int(op->args[0]);
         stream << get_indent() << "barrier(0";
         if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Device) {
-            stream << "| CLK_GLOBAL_MEM_FENCE";
+            stream << " | CLK_GLOBAL_MEM_FENCE";
         }
         if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Shared) {
-            stream << "| CLK_LOCAL_MEM_FENCE";
+            stream << " | CLK_LOCAL_MEM_FENCE";
         }
         stream << ");\n";
         print_assignment(op->type, "0");

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -217,8 +217,12 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Call *op) {
         rhs << "abs_diff(" << print_expr(op->args[0]) << ", " << print_expr(op->args[1]) << ")";
         print_assignment(op->type, rhs.str());
     } else if (op->is_intrinsic(Call::gpu_thread_barrier)) {
-        internal_assert(op->args.size() == 1) << "gpu_thread_barrier() intrinsic must specify memory fence type\n";
-        auto fence_type = *as_const_int(op->args[0]);
+        internal_assert(op->args.size() == 1) << "gpu_thread_barrier() intrinsic must specify memory fence type.\n";
+
+        auto fence_type_ptr = as_const_int(op->args[0]);
+        internal_assert(fence_type_ptr) << "gpu_thread_barrier() parameter is not a constant integer.\n";
+        auto fence_type = *fence_type_ptr;
+
         stream << get_indent() << "barrier(0";
         if (fence_type & CodeGen_GPU_Dev::MemoryFenceType::Device) {
             stream << " | CLK_GLOBAL_MEM_FENCE";

--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -105,8 +105,11 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Cast *op) {
 
 void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Call *op) {
     if (op->is_intrinsic(Call::gpu_thread_barrier)) {
-        internal_assert(op->args.size() == 1) << "gpu_thread_barrier() intrinsic must specify memory fence type\n";
-        auto fence_type = *as_const_int(op->args[0]);
+        internal_assert(op->args.size() == 1) << "gpu_thread_barrier() intrinsic must specify memory fence type.\n";
+
+        auto fence_type_ptr = as_const_int(op->args[0]);
+        internal_assert(fence_type_ptr) << "gpu_thread_barrier() parameter is not a constant integer.\n";
+        auto fence_type = *fence_type_ptr;
 
         stream << get_indent() << "barrier();\n";
 

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -157,6 +157,11 @@ void CodeGen_PTX_Dev::init_module() {
 
 void CodeGen_PTX_Dev::visit(const Call *op) {
     if (op->is_intrinsic(Call::gpu_thread_barrier)) {
+        // Even though we always insert a __syncthreads equivalent
+        // (which has both a device and shared memory fence)
+        // check to make sure the intrinsic has the right number of
+        // arguments
+        internal_assert(op->args.size() == 1) << "gpu_thread_barrier() intrinsic must specify memory fence type\n";
         llvm::Function *barrier0 = module->getFunction("llvm.nvvm.barrier0");
         internal_assert(barrier0) << "Could not find PTX barrier intrinsic (llvm.nvvm.barrier0)\n";
         builder->CreateCall(barrier0);

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -161,7 +161,11 @@ void CodeGen_PTX_Dev::visit(const Call *op) {
         // (which has both a device and shared memory fence)
         // check to make sure the intrinsic has the right number of
         // arguments
-        internal_assert(op->args.size() == 1) << "gpu_thread_barrier() intrinsic must specify memory fence type\n";
+        internal_assert(op->args.size() == 1) << "gpu_thread_barrier() intrinsic must specify memory fence type.\n";
+
+        auto fence_type_ptr = as_const_int(op->args[0]);
+        internal_assert(fence_type_ptr) << "gpu_thread_barrier() parameter is not a constant integer.\n";
+
         llvm::Function *barrier0 = module->getFunction("llvm.nvvm.barrier0");
         internal_assert(barrier0) << "Could not find PTX barrier intrinsic (llvm.nvvm.barrier0)\n";
         builder->CreateCall(barrier0);

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -1062,7 +1062,7 @@ class InjectThreadBarriers : public IRMutator {
     std::set<std::string> shared_loads;
     std::set<std::string> device_loads;
 
-    MemoryType memory_type_for_name(std::string name) {
+    MemoryType memory_type_for_name(const std::string &name) {
         for (auto &x : register_allocs.allocations) {
             if (x.name == name) {
                 return x.memory_type;

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -1064,14 +1064,13 @@ class InjectThreadBarriers : public IRMutator {
     std::set<std::string> shared_stores;
     std::set<std::string> device_stores;
 
-
     MemoryType memory_type_for_name(std::string name) {
-        for (auto &x: register_allocs.allocations) {
+        for (auto &x : register_allocs.allocations) {
             if (x.name == name) {
                 return x.memory_type;
             }
         }
-        for (auto &x: block_allocs.allocations) {
+        for (auto &x : block_allocs.allocations) {
             if (x.name == name) {
                 return x.memory_type;
             }

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -59,6 +59,7 @@ class InjectThreadBarriers : public IRMutator {
 
     Stmt visit(const Block *op) override {
         if (!in_threads && op->rest.defined()) {
+            std::vector<std::string> temp_stores;
             Stmt first = mutate(op->first);
             Stmt rest = mutate(op->rest);
             return Block::make(Block::make(first, barrier), rest);
@@ -72,7 +73,9 @@ public:
         : in_threads(false) {
         barrier =
             Evaluate::make(Call::make(Int(32), Call::gpu_thread_barrier,
-                                      vector<Expr>(), Call::Intrinsic));
+                                      {CodeGen_GPU_Dev::MemoryFenceType::Device
+                                     | CodeGen_GPU_Dev::MemoryFenceType::Shared},
+                                      Call::Intrinsic));
     }
 };
 

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -1110,11 +1110,11 @@ class InjectThreadBarriers : public IRMutator {
     }
 
     Stmt visit(const Store *op) override {
-        debug(0) << "Encountered store to " << op->name << "\n";
+        debug(4) << "Encountered store to " << op->name << "\n";
         auto mem_type = memory_type_for_name(op->name);
         switch (mem_type) {
             case MemoryType::GPUShared:
-                debug(0) << "   memory type is shared\n";
+                debug(4) << "   memory type is shared\n";
                 if (shared_mem_fence_required) {
                     break;
                 }
@@ -1122,7 +1122,7 @@ class InjectThreadBarriers : public IRMutator {
                 break;
             case MemoryType::Auto:
             case MemoryType::Heap:
-                debug(0) << "   memory type is heap or auto\n";
+                debug(4) << "   memory type is heap or auto\n";
                 if (device_mem_fence_required) {
                     break;
                 }
@@ -1139,7 +1139,7 @@ class InjectThreadBarriers : public IRMutator {
     }
 
     Expr visit(const Load *op) override {
-        debug(0) << "Encountered load from " << op->name << "\n";
+        debug(4) << "Encountered load from " << op->name << "\n";
         if (shared_stores.find(op->name) != shared_stores.end()) {
             shared_mem_fence_required = true;
             shared_stores.clear();
@@ -1157,9 +1157,6 @@ class InjectThreadBarriers : public IRMutator {
             Stmt first = mutate(op->first);
             shared_mem_fence_required = false;
             device_mem_fence_required = false;
-            for (auto x: shared_stores) {
-                debug(0) << "Shared store: " << x << "\n";
-            }
             Stmt rest = mutate(op->rest);
             int mask = 0;
             if (shared_mem_fence_required) {

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -29,7 +29,6 @@ string thread_names[] = {"__thread_id_x", "__thread_id_y", "__thread_id_z", "__t
 string block_names[] = {"__block_id_x", "__block_id_y", "__block_id_z", "__block_id_w"};
 }  // namespace
 
-
 class ExtractBlockSize : public IRVisitor {
     Expr block_extent[4], block_count[4];
     string block_var_name[4];
@@ -287,6 +286,7 @@ class ExtractSharedAndHeapAllocations : public IRMutator {
 
 public:
     vector<SharedAllocation> allocations;
+
 private:
     map<string, SharedAllocation *> shared;
 


### PR DESCRIPTION
This PR attempts to address #4967 by implementing a required parameter for `gpu_thread_barrier()`: a mask that determines the memory fence behavior.

Note that this PR does not increase/decrease the number of barriers inserted.  We may need to revisit the logic that determines when to insert barriers, based on other conversations with @slomp and @abadams.

I'll add or modify a test if this approach seems reasonable to everyone.