### PR TITLE
Combine visit(Cast) for GLSL and OpenGLCompute

### DIFF
--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -76,33 +76,6 @@ int thread_loop_workgroup_index(const string &name) {
 }
 }  // namespace
 
-void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Cast *op) {
-    Type value_type = op->value.type();
-    // If both types are represented by the same GLSL type, no explicit cast
-    // is necessary.
-    if (map_type(op->type) == map_type(value_type)) {
-        Expr value = op->value;
-        if (value_type.code() == Type::Float) {
-            // float->int conversions may need explicit truncation if an
-            // integer type is embedded into a float. (Note: overflows are
-            // considered undefined behavior, so we do nothing about values
-            // that are out of range of the target type.)
-            if (op->type.code() == Type::UInt) {
-                value = simplify(floor(value));
-            } else if (op->type.code() == Type::Int) {
-                value = simplify(trunc(value));
-            }
-        }
-        // FIXME: Overflow is not UB for most Halide types
-        // https://github.com/halide/Halide/issues/4975
-        value.accept(this);
-        return;
-    } else {
-        Type target_type = map_type(op->type);
-        print_assignment(target_type, print_type(target_type) + "(" + print_expr(op->value) + ")");
-    }
-}
-
 void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::visit(const Call *op) {
     if (op->is_intrinsic(Call::gpu_thread_barrier)) {
         stream << get_indent() << "barrier();\n";

--- a/src/CodeGen_OpenGLCompute_Dev.h
+++ b/src/CodeGen_OpenGLCompute_Dev.h
@@ -53,13 +53,12 @@ protected:
     protected:
         std::string print_type(Type type, AppendSpaceIfNeeded space_option = DoNotAppendSpace) override;
 
-        using CodeGen_C::visit;
+        using CodeGen_GLSLBase::visit;
         void visit(const For *) override;
         void visit(const Ramp *op) override;
         void visit(const Broadcast *op) override;
         void visit(const Load *op) override;
         void visit(const Store *op) override;
-        void visit(const Cast *op) override;
         void visit(const Call *op) override;
         void visit(const Allocate *op) override;
         void visit(const Free *op) override;

--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -426,16 +426,7 @@ string CodeGen_GLSLBase::print_name(const string &name) {
     return replace_all(mangled, "__", "XX");
 }
 
-//
-// CodeGen_GLSL
-//
-
-CodeGen_GLSL::CodeGen_GLSL(std::ostream &s, const Target &t)
-    : CodeGen_GLSLBase(s, t) {
-    builtin["trunc_f32"] = "_trunc_f32";
-}
-
-void CodeGen_GLSL::visit(const Cast *op) {
+void CodeGen_GLSLBase::visit(const Cast *op) {
     Type value_type = op->value.type();
     // If both types are represented by the same GLSL type, no explicit cast
     // is necessary.
@@ -452,12 +443,22 @@ void CodeGen_GLSL::visit(const Cast *op) {
                 value = simplify(trunc(value));
             }
         }
+        // FIXME: Overflow is not UB for most Halide types
+        // https://github.com/halide/Halide/issues/4975
         value.accept(this);
-        return;
     } else {
         Type target_type = map_type(op->type);
         print_assignment(target_type, print_type(target_type) + "(" + print_expr(op->value) + ")");
     }
+}
+
+//
+// CodeGen_GLSL
+//
+
+CodeGen_GLSL::CodeGen_GLSL(std::ostream &s, const Target &t)
+    : CodeGen_GLSLBase(s, t) {
+    builtin["trunc_f32"] = "_trunc_f32";
 }
 
 void CodeGen_GLSL::visit(const Let *op) {

--- a/src/CodeGen_OpenGL_Dev.h
+++ b/src/CodeGen_OpenGL_Dev.h
@@ -61,6 +61,9 @@ public:
 
 protected:
     using CodeGen_C::visit;
+
+    void visit(const Cast *) override;
+
     void visit(const FloatImm *) override;
     void visit(const UIntImm *) override;
     void visit(const IntImm *) override;
@@ -99,9 +102,8 @@ public:
     static void test();
 
 protected:
-    using CodeGen_C::visit;
+    using CodeGen_GLSLBase::visit;
 
-    void visit(const Cast *) override;
     void visit(const Let *) override;
     void visit(const For *) override;
     void visit(const Select *) override;


### PR DESCRIPTION
These are the only two overrides of `visit(Cast) from GLSLBase and they both have identical implementations; combine them into one and move into GLSLBase to save code.