### PR TITLE
Fix codegen for absd() in GLSLBase

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -294,9 +294,6 @@ protected:
             for (auto &a : op->args) {
                 include_lerp_types(a.type());
             }
-        } else if (op->is_intrinsic(Call::absd)) {
-            // absd() can synthesize a new type
-            include_type(op->type.with_code(op->type.is_int() ? Type::UInt : op->type.code()));
         }
 
         IRGraphVisitor::visit(op);
@@ -2100,8 +2097,7 @@ void CodeGen_C::visit(const Call *op) {
         internal_assert(op->args.size() == 2);
         Expr a = op->args[0];
         Expr b = op->args[1];
-        Type t = op->type.with_code(op->type.is_int() ? Type::UInt : op->type.code());
-        Expr e = cast(t, select(a < b, b - a, a - b));
+        Expr e = cast(op->type, select(a < b, b - a, a - b));
         rhs << print_expr(e);
     } else if (op->is_intrinsic(Call::return_second)) {
         internal_assert(op->args.size() == 2);

--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -238,8 +238,7 @@ void CodeGen_GLSLBase::visit(const Call *op) {
         internal_assert(op->args.size() == 2);
         Expr a = op->args[0];
         Expr b = op->args[1];
-        Type t = Float(32);
-        Expr e = cast(t, select(a < b, b - a, a - b));
+        Expr e = cast(op->type, select(a < b, b - a, a - b));
         print_expr(e);
         return;
     } else if (op->is_intrinsic(Call::return_second)) {


### PR DESCRIPTION
It was emitting as a float, which is *never* correct, since absd() is only used for int or uint types. (This happened to work before because GLSL was previously also incorrectly using float for uint in some cases.)

Also did a drive-by removal of code in Codegen_C that recapitulated the logic from IROperator.cpp; maybe the type field of absd() was incorrect at some point in the past, but this calculation seems redundant and wrong now.