### PR TITLE
Don't lift constant integer offsets

### DIFF
--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -77,6 +77,13 @@ class LiftLoopInvariants : public IRMutator {
                 return false;
             }
         }
+        if (const Add *add = e.as<Add>()) {
+            if (add->type == Int(32) &&
+                is_const(add->b)) {
+                // Don't lift constant integer offsets. They're often free.
+                return false;
+            }
+        }
         return true;
     }
 


### PR DESCRIPTION
loop invariant code motion sometimes likes to lift long chains of x + 1, x + 2, x + 3, x + 4, etc. This is silly because often those are addresses, and constant offsets are usually free on loads and stores, so all you're doing is increasing register pressure. This PR tweaks it to leave those in the innermost loop.

Mostly this just cleans up the IR, because LLVM is capable of resubstituting these constant offsets too. Might have an effect on GPU kernels where the values lifted have to be packed into a closure, but I was unable to find a case where it mattered.

branch name is a misnomer - that was another approach I was trying.