### PR TITLE
Fix some "MachO doesn't support COMDAT" issues in runtime

### DIFF
--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -226,7 +226,7 @@ WEAK void *nsarray_first_object(objc_id arr) {
 // intended for non-GUI apps.  Newer versions of macOS (10.15+)
 // will not return a valid device if MTLCreateSystemDefaultDevice()
 // is used from a non-GUI app.
-inline mtl_device *get_default_mtl_device() {
+WEAK mtl_device *get_default_mtl_device() {
     mtl_device *device = (mtl_device *)MTLCreateSystemDefaultDevice();
     if (device == NULL) {
         // We assume Metal.framework is already loaded
@@ -567,7 +567,7 @@ WEAK int halide_metal_initialize_kernels(void *user_context, void **state_ptr, c
 
 namespace {
 
-inline void halide_metal_device_sync_internal(mtl_command_queue *queue, struct halide_buffer_t *buffer) {
+WEAK void halide_metal_device_sync_internal(mtl_command_queue *queue, struct halide_buffer_t *buffer) {
     const char *buffer_label = "halide_metal_device_sync_internal";
     mtl_command_buffer *sync_command_buffer = new_command_buffer(queue, buffer_label, strlen(buffer_label));
     if (buffer != NULL) {

--- a/src/runtime/synchronization_common.h
+++ b/src/runtime/synchronization_common.h
@@ -283,8 +283,12 @@ struct word_lock_queue_data {
 
     word_lock_queue_data *tail;
 
-    word_lock_queue_data()
+    __attribute__((always_inline)) word_lock_queue_data()
         : next(NULL), prev(NULL), tail(NULL) {
+    }
+
+    // Inlined, empty dtor needed to avoid confusing MachO builds
+    __attribute__((always_inline)) ~word_lock_queue_data() {
     }
 };
 
@@ -295,7 +299,7 @@ class word_lock {
     void unlock_full();
 
 public:
-    word_lock()
+    __attribute__((always_inline)) word_lock()
         : state(0) {
     }
     __attribute__((always_inline)) void lock() {
@@ -464,8 +468,11 @@ struct queue_data {
 
     uintptr_t unpark_info;
 
-    queue_data()
+    __attribute__((always_inline)) queue_data()
         : sleep_address(0), next(NULL), unpark_info(0) {
+    }
+    // Inlined, empty dtor needed to avoid confusing MachO builds
+    __attribute__((always_inline)) ~queue_data() {
     }
 };
 
@@ -490,7 +497,7 @@ struct hash_table {
 WEAK char table_storage[sizeof(hash_table)];
 #define table (*(hash_table *)table_storage)
 
-inline void check_hash(uintptr_t hash) {
+__attribute__((always_inline)) void check_hash(uintptr_t hash) {
     halide_assert(NULL, hash < sizeof(table.buckets) / sizeof(table.buckets[0]));
 }
 
@@ -508,7 +515,7 @@ WEAK void dump_hash() {
 }
 #endif
 
-static inline uintptr_t addr_hash(uintptr_t addr, uint32_t bits) {
+static __attribute__((always_inline)) uintptr_t addr_hash(uintptr_t addr, uint32_t bits) {
     // Fibonacci hashing. The golden ratio is 1.9E3779B97F4A7C15F39...
     // in hexadecimal.
     if (sizeof(uintptr_t) >= 8) {
@@ -535,7 +542,7 @@ struct bucket_pair {
     hash_bucket &from;
     hash_bucket &to;
 
-    bucket_pair(hash_bucket &from, hash_bucket &to)
+    __attribute__((always_inline)) bucket_pair(hash_bucket &from, hash_bucket &to)
         : from(from), to(to) {
     }
 };
@@ -947,7 +954,7 @@ public:
         }
     }
 
-    bool make_parked_if_locked() {
+    __attribute__((always_inline)) bool make_parked_if_locked() {
         uintptr_t val;
         atomic_load_relaxed(&state, &val);
         while (true) {
@@ -962,7 +969,7 @@ public:
         }
     }
 
-    void make_parked() {
+    __attribute__((always_inline)) void make_parked() {
         atomic_or_fetch_relaxed(&state, parked_bit);
     }
 };
@@ -971,7 +978,7 @@ struct signal_parking_control : parking_control {
     uintptr_t *cond_state;
     fast_mutex *mutex;
 
-    signal_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
+    __attribute__((always_inline)) signal_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
         : cond_state(cond_state), mutex(mutex) {
         unpark = signal_parking_control_unpark;
     }
@@ -998,7 +1005,7 @@ struct broadcast_parking_control : parking_control {
     uintptr_t *cond_state;
     fast_mutex *mutex;
 
-    broadcast_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
+    __attribute__((always_inline)) broadcast_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
         : cond_state(cond_state), mutex(mutex) {
         validate = broadcast_parking_control_validate;
         requeue_callback = broadcast_parking_control_requeue_callback;
@@ -1039,7 +1046,7 @@ struct wait_parking_control : parking_control {
     uintptr_t *cond_state;
     fast_mutex *mutex;
 
-    wait_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
+    __attribute__((always_inline)) wait_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
         : cond_state(cond_state), mutex(mutex) {
         validate = wait_parking_control_validate;
         before_sleep = wait_parking_control_before_sleep;

--- a/src/runtime/thread_pool_common.h
+++ b/src/runtime/thread_pool_common.h
@@ -43,7 +43,7 @@ struct work {
     // which condition variable is the owner sleeping on. NULL if it isn't sleeping.
     bool owner_is_sleeping;
 
-    bool make_runnable() {
+    __attribute__((always_inline)) bool make_runnable() {
         for (; next_semaphore < task.num_semaphores; next_semaphore++) {
             if (!halide_default_semaphore_try_acquire(task.semaphores[next_semaphore].semaphore,
                                                       task.semaphores[next_semaphore].count)) {
@@ -59,7 +59,7 @@ struct work {
         return true;
     }
 
-    bool running() {
+    __attribute__((always_inline)) bool running() const {
         return task.extent || active_workers;
     }
 };
@@ -138,12 +138,12 @@ struct work_queue_t {
     // to prevent deadlock due to oversubscription of threads.
     int threads_reserved;
 
-    bool running() const {
+    __attribute__((always_inline)) bool running() const {
         return !shutdown;
     }
 
     // Used to check initial state is correct.
-    void assert_zeroed() const {
+    __attribute__((always_inline)) void assert_zeroed() const {
         // Assert that all fields except the mutex and desired hreads count are zeroed.
         const char *bytes = ((const char *)&this->zero_marker);
         const char *limit = ((const char *)this) + sizeof(work_queue_t);
@@ -155,7 +155,7 @@ struct work_queue_t {
 
     // Return the work queue to initial state. Must be called while locked
     // and queue will remain locked.
-    void reset() {
+    __attribute__((always_inline)) void reset() {
         // Ensure all fields except the mutex and desired hreads count are zeroed.
         char *bytes = ((char *)&this->zero_marker);
         char *limit = ((char *)this) + sizeof(work_queue_t);

--- a/src/runtime/write_debug_image.cpp
+++ b/src/runtime/write_debug_image.cpp
@@ -107,16 +107,16 @@ WEAK bool ends_with(const char *filename, const char *suffix) {
 
 struct ScopedFile {
     void *f;
-    ScopedFile(const char *filename, const char *mode) {
+    __attribute__((always_inline)) ScopedFile(const char *filename, const char *mode) {
         f = fopen(filename, mode);
     }
-    ~ScopedFile() {
+    __attribute__((always_inline)) ~ScopedFile() {
         fclose(f);
     }
-    bool write(const void *ptr, size_t bytes) {
+    __attribute__((always_inline)) bool write(const void *ptr, size_t bytes) {
         return fwrite(ptr, bytes, 1, f);
     }
-    bool open() const {
+    __attribute__((always_inline)) bool open() const {
         return f;
     }
 };

--- a/src/runtime/x86_cpu_features.cpp
+++ b/src/runtime/x86_cpu_features.cpp
@@ -7,7 +7,7 @@ namespace Internal {
 
 extern "C" void x86_cpuid_halide(int32_t *);
 
-static inline void cpuid(int32_t fn_id, int32_t *info) {
+static __attribute__((always_inline)) void cpuid(int32_t fn_id, int32_t *info) {
     info[0] = fn_id;
     x86_cpuid_halide(info);
 }


### PR DESCRIPTION
Runtime code that will be instantiated for OSX/iOS needs to ensure that there are no plain 'inline' functions -- they must be either WEAK or __attribute__((always_inline)) -- otherwise, some compiler configurations can produce the error above. (Note that this also applies to member functions that are defined inline, even without an explicit 'inline' keyword).

(Note also that the vagaries of C++ mean that declaring a ctor implies that a dtor will be auto-created; in some of these we must explicitly declare the dtor so that it too is always-inlined, even if it is empty...)