### PR TITLE
atomic vectorization tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,9 @@ ARCH_FOR_TESTS ?= native
 TEST_CXX_FLAGS ?= $(TUTORIAL_CXX_FLAGS) $(CXX_WARNING_FLAGS) -march=${ARCH_FOR_TESTS}
 TEST_LD_FLAGS = -L$(BIN_DIR) -lHalide $(COMMON_LD_FLAGS)
 
+# In the tests, some of our expectations change depending on the llvm version
+TEST_CXX_FLAGS += -DLLVM_VERSION=$(LLVM_VERSION_TIMES_10)
+
 # gcc 4.8 fires a bogus warning on old versions of png.h
 ifneq (,$(findstring g++,$(CXX_VERSION)))
 ifneq (,$(findstring 4.8,$(CXX_VERSION)))

--- a/src/AddAtomicMutex.cpp
+++ b/src/AddAtomicMutex.cpp
@@ -191,6 +191,8 @@ protected:
         // Search for let bindings that access the producers.
         FindAtomicLetBindings finder(collector.store_names);
         op->body.accept(&finder);
+        // Each individual Store that remains can be done as a CAS
+        // loop or an actual atomic RMW of some form.
         if (finder.found) {
             // Can't remove mutex lock. Leave the Stmt as is.
             return IRMutator::visit(op);

--- a/src/AssociativeOpsTable.cpp
+++ b/src/AssociativeOpsTable.cpp
@@ -33,8 +33,9 @@ enum class ValType {
     Int16 = 6,
     Int32 = 7,
     Int64 = 8,
-    Float32 = 9,
-    Float64 = 10,
+    Float16 = 9,
+    Float32 = 10,
+    Float64 = 11,
     All = 11,  // General type (including all previous types)
 };
 
@@ -68,7 +69,9 @@ ValType convert_halide_type_to_val_type(const Type &halide_t) {
         }
     } else {
         internal_assert(halide_t.is_float());
-        if (halide_t.bits() == 32) {
+        if (halide_t.bits() == 16) {
+            val_t = ValType::Float16;
+        } else if (halide_t.bits() == 32) {
             val_t = ValType::Float32;
         } else {
             internal_assert(halide_t.bits() == 64);

--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -172,7 +172,7 @@ public:
         if (iter != gvn.output_numbering.end()) {
             gvn.entries[iter->second]->use_count++;
         } else {
-            internal_error << "Expr not in shallow numbering!\n";
+            internal_error << "Expr not in shallow numbering: " << e << "\n";
         }
 
         // Visit the children if we haven't been here before.

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -303,6 +303,7 @@ private:
 
     Expr visit(const Shuffle *op) override {
         if (op->is_interleave()) {
+            // Special case where we can discard some of the vector arguments entirely.
             internal_assert(starting_lane >= 0 && starting_lane < lane_stride);
             if ((int)op->vectors.size() == lane_stride) {
                 return op->vectors[starting_lane];
@@ -313,24 +314,17 @@ private:
                     new_vectors[i] = op->vectors[i * lane_stride + starting_lane];
                 }
                 return Shuffle::make_interleave(new_vectors);
-            } else {
-                // Interleave some vectors then deinterleave by some other factor...
-                // Brute force!
-                std::vector<int> indices;
-                for (int i = 0; i < new_lanes; i++) {
-                    indices.push_back(i * lane_stride + starting_lane);
-                }
-                return Shuffle::make({op}, indices);
             }
-        } else {
-            // Extract every nth numeric arg to the shuffle.
-            std::vector<int> indices;
-            for (int i = 0; i < new_lanes; i++) {
-                int idx = i * lane_stride + starting_lane;
-                indices.push_back(op->indices[idx]);
-            }
-            return Shuffle::make(op->vectors, indices);
         }
+
+        // Keep the same set of vectors and extract every nth numeric
+        // arg to the shuffle.
+        std::vector<int> indices;
+        for (int i = 0; i < new_lanes; i++) {
+            int idx = i * lane_stride + starting_lane;
+            indices.push_back(op->indices[idx]);
+        }
+        return Shuffle::make(op->vectors, indices);
     }
 };
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1072,16 +1072,11 @@ Stage &Stage::split(const VarOrRVar &old, const VarOrRVar &outer, const VarOrRVa
 }
 
 Stage &Stage::fuse(const VarOrRVar &inner, const VarOrRVar &outer, const VarOrRVar &fused) {
-    if (inner.is_rvar) {
-        user_assert(outer.is_rvar) << "Can't fuse RVar " << inner.name()
-                                   << " with Var " << outer.name() << "\n";
-        user_assert(fused.is_rvar) << "Can't fuse RVar " << inner.name()
-                                   << "into Var " << fused.name() << "\n";
-    } else {
-        user_assert(!outer.is_rvar) << "Can't fuse Var " << inner.name()
-                                    << " with RVar " << outer.name() << "\n";
-        user_assert(!fused.is_rvar) << "Can't fuse Var " << inner.name()
-                                    << "into RVar " << fused.name() << "\n";
+    if (!fused.is_rvar) {
+        user_assert(!outer.is_rvar) << "Can't fuse Var " << fused.name()
+                                    << " from RVar " << outer.name() << "\n";
+        user_assert(!inner.is_rvar) << "Can't fuse Var " << inner.name()
+                                    << " from RVar " << inner.name() << "\n";
     }
 
     debug(4) << "In schedule for " << name() << ", fuse " << outer.name()
@@ -1116,13 +1111,14 @@ Stage &Stage::fuse(const VarOrRVar &inner, const VarOrRVar &outer, const VarOrRV
             fused_name = inner_name + "." + fused.name();
             dims[i].var = fused_name;
 
-            internal_assert(
-                (dims[i].is_rvar() && ((outer_type == DimType::PureRVar) ||
-                                       (outer_type == DimType::ImpureRVar))) ||
-                (!dims[i].is_rvar() && (outer_type == DimType::PureVar)));
-
-            if (dims[i].is_rvar()) {
-                dims[i].dim_type = (dims[i].dim_type == DimType::PureRVar) && (outer_type == DimType::PureRVar) ? DimType::PureRVar : DimType::ImpureRVar;
+            if (dims[i].dim_type == DimType::ImpureRVar ||
+                outer_type == DimType::ImpureRVar) {
+                dims[i].dim_type = DimType::ImpureRVar;
+            } else if (dims[i].dim_type == DimType::PureRVar ||
+                       outer_type == DimType::PureRVar) {
+                dims[i].dim_type = DimType::PureRVar;
+            } else {
+                dims[i].dim_type = DimType::PureVar;
             }
         }
     }


### PR DESCRIPTION
Unrelated pieces of the atomic vectorization PR which can be merged separately.

1) Make lossless_cast more aggressive. It now looks through some adds, subs, and muls too
2) You can fuse a PureRVar and an ImpureRVar now. You get an ImpureRVar.
3) Some logic in Deinterleave.cpp handling shuffles was needlessly complex
4) 16-bit floats were never added to associative ops
5) CSE had an error message that benefited from also printing the Expr
6) The Makefile wasn't passing LLVM_VERSION to tests. Some of them care (because expectations about generated code might depend on LLVM version)