### PR TITLE
Fix broken TSAN code

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1304,7 +1304,8 @@ void CodeGen_LLVM::optimize_module() {
 #if LLVM_VERSION >= 110
         pb.registerOptimizerLastEPCallback(
             [](ModulePassManager &mpm, PassBuilder::OptimizationLevel level) {
-                mpm.addPass(ThreadSanitizerPass());
+                mpm.addPass(
+                    createModuleToFunctionPassAdaptor(ThreadSanitizerPass()));
             });
 #else
         pb.registerOptimizerLastEPCallback(


### PR DESCRIPTION
Update for a recent LLVM change was incorrect; it compiled but didn't actually work properly. (We should probably run sanitizers on the buildbots...)