### PR TITLE
It's worth cancelling correlated subexpressions in load/store indices

### DIFF
--- a/src/SimplifyCorrelatedDifferences.cpp
+++ b/src/SimplifyCorrelatedDifferences.cpp
@@ -109,17 +109,6 @@ class SimplifyCorrelatedDifferences : public IRMutator {
         return visit_let<LetStmt, Stmt>(op);
     }
 
-    Stmt visit(const Store *op) override {
-        // We only care about the expressions that determine the sizes
-        // of allocations and loop extents, so no need to look inside
-        // stores.
-        return op;
-    }
-
-    Stmt visit(const Provide *op) override {
-        return op;
-    }
-
     Stmt visit(const For *op) override {
         Stmt s = op;
         // This is unfortunately quadratic in maximum loop nesting depth

--- a/src/SimplifyCorrelatedDifferences.h
+++ b/src/SimplifyCorrelatedDifferences.h
@@ -35,8 +35,16 @@ namespace Internal {
  * monotonicity it substitutes, solves, and attempts to generally
  * simplify as aggressively as possible to try to cancel out the
  * repeated dependence on the loop var. The same is done for addition
- * nodes with arguments of opposite monotonicity. Only index
- * expressions outside of Stores/Provides are considered.
+ * nodes with arguments of opposite monotonicity.
+ *
+ * Bounds inference is particularly sensitive to these false
+ * dependencies, but removing false dependencies also helps other
+ * lowering passes. E.g. if this simplification means a value no
+ * longer depends on a loop variable, it can remain scalar during
+ * vectorization of that loop, or we can lift it out as a loop
+ * invariant, or it might avoid some of the complex paths in GPU
+ * codegen that trigger when values depend on the block index
+ * (e.g. warp shuffles).
  *
  * This pass is safe to use on code with repeated instances of the
  * same variable name (it must be, because we want to run it before


### PR DESCRIPTION
In particular, this makes warp shuffles much more reliable, because any
dependence of a load or store index on the block id is more likely to
get cancelled out. This PR massively simplifies the generated code for
cuda_mat_mul, and makes it about 30% faster (although it's still
mysteriously 2x slower than cublas on my card).

Also reduces the amount of IR in some other apps very slightly.

Doesn't seem to affect compile times.