### PR TITLE
Constant extents inferred pre-storage flattening

### DIFF
--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -264,6 +264,12 @@ Module lower(const vector<Function> &output_funcs,
                  << s << "\n";
     }
 
+    debug(1) << "Bounding small realizations...\n";
+    s = simplify_correlated_differences(s);
+    s = bound_small_allocations(s);
+    debug(2) << "Lowering after bounding small realizations:\n"
+             << s << "\n\n";
+
     debug(1) << "Performing storage flattening...\n";
     s = storage_flattening(s, outputs, env, t);
     debug(2) << "Lowering after storage flattening:\n"

--- a/src/LowerWarpShuffles.cpp
+++ b/src/LowerWarpShuffles.cpp
@@ -786,11 +786,6 @@ class HasLaneLoop : public IRVisitor {
         IRVisitor::visit(op);
     }
 
-    void visit(const Allocate *op) override {
-        result = result || op->memory_type == MemoryType::Register;
-        IRVisitor::visit(op);
-    }
-
 public:
     bool result = false;
 };

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -144,6 +144,7 @@ tests(GROUPS correctness
       gpu_param_allocation.cpp
       gpu_reuse_shared_memory.cpp
       gpu_specialize.cpp
+      gpu_store_in_register_with_no_lanes_loop.cpp
       gpu_sum_scan.cpp
       gpu_thread_barrier.cpp
       gpu_transpose.cpp

--- a/test/correctness/gpu_store_in_register_with_no_lanes_loop.cpp
+++ b/test/correctness/gpu_store_in_register_with_no_lanes_loop.cpp
@@ -1,0 +1,56 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Target t(get_jit_target_from_environment());
+    if (!t.has_gpu_feature()) {
+        printf("[SKIP] No GPU target enabled.\n");
+        return 0;
+    }
+
+    Func f, g;
+    Var x, y;
+
+    f(x, y) = x + y;
+    g(x, y) = f(x, y);
+
+    Var xi, yi, xii, yii;
+    g.compute_root()
+        .gpu_tile(x, y, xi, yi, 64, 16, TailStrategy::GuardWithIf)
+        .tile(xi, yi, xii, yii, 2, 2)
+        .unroll(xii)
+        .unroll(yii);
+
+    f.compute_at(g, xi)
+        .store_in(MemoryType::Register)
+        .unroll(x)
+        .unroll(y);
+
+    // This tests two things
+
+    // 1) Because of the GuardWithIf on g, we need a variable amount
+    // of f. If you put it in registers it should take an upper bound
+    // on the size required. It should also be possible to unroll it
+    // entirely by injecting if statements.
+
+    // 2) No other test uses MemoryType::Register without also having
+    // a GPULanes loop. This used to break (the allocation would
+    // disappear entirely).
+
+    Buffer<int> result = g.realize(123, 245);
+
+    for (int y = 0; y < result.height(); y++) {
+        for (int x = 0; x < result.width(); x++) {
+            int correct = x + y;
+            if (result(x, y) != correct) {
+                printf("result(%d, %d) = %d instead of %d\n",
+                       x, y, result(x, y), correct);
+                return -1;
+            }
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Consider an allocation that has a dynamic extent, but needs to have a
constant extent because it's stored in MemoryType::Register (e.g. see
the test). We take an upper bound in these cases to get a constant
allocation size. This PR changes things to take that upper bound
*before* storage flattening instead of after. This way the individual
per-dimension extents are all constant, instead of just their product.
If you do it after storage flattening then you get dynamic strides
within a constant-sized allocation, which is silly and not compatible
with hoisting values into registers anyway (because access is at
non-constant coords).

Also fixed the assumption that MemoryType::Register on the GPU means
that there must be a GPULanes loop.

Builds on #5035 