### PR TITLE
Put buffers before other uniforms in gl uniform list

### DIFF
--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -293,7 +293,7 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
                       if (a.is_buffer == b.is_buffer) {
                           return a.type.bits() > b.type.bits();
                       } else {
-                          return a.is_buffer < b.is_buffer;
+                          return a.is_buffer > b.is_buffer;
                       }
                   });
 

--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -293,6 +293,14 @@ void CodeGen_GPU_Host<CodeGen_CPU>::visit(const For *loop) {
                       if (a.is_buffer == b.is_buffer) {
                           return a.type.bits() > b.type.bits();
                       } else {
+                          // Ensure that buffer arguments come first:
+                          // for many OpenGL/Compute systems, the
+                          // legal indices for buffer args are much
+                          // more restrictive than for scalar args,
+                          // and scalar args can be 'grown' by
+                          // LICM. Putting buffers first makes it much
+                          // more likely we won't fail on some
+                          // hardware.
                           return a.is_buffer > b.is_buffer;
                       }
                   });

--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -222,6 +222,9 @@ class LICM : public IRMutator {
         if (old_in_gpu_loop && in_gpu_loop) {
             // Don't lift lets to in-between gpu blocks/threads
             return IRMutator::visit(op);
+        } else if (op->device_api == DeviceAPI::GLSL) {
+            // GLSL uses magic names for varying things. Just skip LICM.
+            return IRMutator::visit(op);
         } else {
 
             // Lift invariants

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -191,6 +191,7 @@ tests(GROUPS correctness
       loop_invariant_extern_calls.cpp
       loop_level_generator_param.cpp
       lots_of_dimensions.cpp
+      lots_of_loop_invariants.cpp
       make_struct.cpp
       many_dimensions.cpp
       many_small_extern_stages.cpp

--- a/test/correctness/lots_of_loop_invariants.cpp
+++ b/test/correctness/lots_of_loop_invariants.cpp
@@ -1,0 +1,30 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // Stress-test LICM by hoisting lots of loop invariants
+    Var x, y, c;
+
+    const int N = 500;
+
+    Expr e = 0;
+    for (int i = 0; i < N; i++) {
+        Expr invariant = (c + i) * (c + i);
+        e += invariant * (x + i);
+    }
+
+    Func f;
+    f(x, y, c) = e;
+
+    Target t(get_jit_target_from_environment());
+    if (t.has_gpu_feature()) {
+        Var xi, yi;
+        f.gpu_tile(x, y, xi, yi, 8, 8);
+    }
+
+    f.realize(1024, 1024, 3);
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
buffer ids are constrained to be smaller than arbitrary scalar uniforms,
so they should go first in the closure.

Also added a stress-test for lifting out lots of loop invariants, and
disabled LICM completely for GLSL, because it uses magic names
(.varying) for some things.