### PR TITLE
Clarify debug logging in copy_to_device()

### DIFF
--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -161,6 +161,7 @@ WEAK int copy_to_device_already_locked(void *user_context,
             debug(user_context) << "halide_copy_to_device " << buf << " dev_dirty is true error\n";
             return halide_error_code_copy_to_device_failed;
         } else {
+            debug(user_context) << "halide_copy_to_device " << buf << " calling copy_to_device()\n";
             result = device_interface->impl->copy_to_device(user_context, buf);
             if (result == 0) {
                 buf->set_host_dirty(false);
@@ -170,6 +171,8 @@ WEAK int copy_to_device_already_locked(void *user_context,
                 return halide_error_code_copy_to_device_failed;
             }
         }
+    } else {
+        debug(user_context) << "halide_copy_to_device " << buf << " skipped (host is not dirty)\n";
     }
 
     return 0;


### PR DESCRIPTION
We currently always call copy_to_device() on buffers that need to be on device (with the understanding that it's a no-op if no copy is needed); if the `debug` feature is on, a naive reading might make someone think that needless copy-to-device operations are actually happening. This adds a bit of logging (debug mode only) to make it clearer whether the copy to device actually happened, or if it was skipped because host was not dirty.