### PR TITLE
Add an explicit pass to lift loop invariant if statements

### DIFF
--- a/src/LICM.h
+++ b/src/LICM.h
@@ -14,7 +14,12 @@ namespace Internal {
  * important in cases where LLVM would not do it for us
  * automatically. For example, it hoists loop invariants out of cuda
  * kernels. */
-Stmt loop_invariant_code_motion(Stmt);
+Stmt hoist_loop_invariant_values(Stmt);
+
+/** Just hoist loop-invariant if statements as far up as
+ * possible. Does not lift other values. It's useful to run this
+ * earlier in lowering to simplify the IR. */
+Stmt hoist_loop_invariant_if_statements(Stmt);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -365,6 +365,11 @@ Module lower(const vector<Function> &output_funcs,
     debug(2) << "Lowering after loop trimming:\n"
              << s << "\n\n";
 
+    debug(1) << "Hoisting loop invariant if statements...\n";
+    s = hoist_loop_invariant_if_statements(s);
+    debug(2) << "Lowering after hoisting loop invariant if statements:\n"
+             << s << "\n\n";
+
     debug(1) << "Injecting early frees...\n";
     s = inject_early_frees(s);
     debug(2) << "Lowering after injecting early frees:\n"
@@ -423,7 +428,7 @@ Module lower(const vector<Function> &output_funcs,
 
     s = remove_dead_allocations(s);
     s = simplify(s);
-    s = loop_invariant_code_motion(s);
+    s = hoist_loop_invariant_values(s);
     debug(1) << "Lowering after final simplification:\n"
              << s << "\n\n";
 

--- a/src/LowerWarpShuffles.cpp
+++ b/src/LowerWarpShuffles.cpp
@@ -819,7 +819,7 @@ class LowerWarpShufflesInEachKernel : public IRMutator {
 }  // namespace
 
 Stmt lower_warp_shuffles(Stmt s) {
-    s = loop_invariant_code_motion(s);
+    s = hoist_loop_invariant_values(s);
     s = SubstituteInLaneVar().mutate(s);
     s = simplify(s);
     s = LowerWarpShufflesInEachKernel().mutate(s);

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -156,6 +156,7 @@ tests(GROUPS correctness
       hexagon_scatter.cpp
       histogram.cpp
       histogram_equalize.cpp
+      hoist_loop_invariant_if_statements.cpp
       host_alignment.cpp
       image_io.cpp
       image_of_lists.cpp

--- a/test/correctness/hoist_loop_invariant_if_statements.cpp
+++ b/test/correctness/hoist_loop_invariant_if_statements.cpp
@@ -1,0 +1,52 @@
+#include "Halide.h"
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+int main(int argc, char **argv) {
+    Func f, g;
+    Var x, y;
+    Param<bool> p;
+
+    // In Stmt IR, if statements can be injected by GuardWithIf, RDom
+    // predicates, specializations, and uses of undef. There are
+    // various situations where an if statement can end up further
+    // inside a loop nest than strictly necessary. Here's one:
+
+    f(x, y) = select(p, x + y, undef<int>());
+    g(x, y) = select(p, f(x, y), undef<int>());
+    f.compute_at(g, x);
+
+    // Both f and g get an if statement for p, which could instead be
+    // a single combined top-level if statement. Trim-no-ops is
+    // supposed to lift the if statement out of the loops to the top
+    // level. Let's check if it worked.
+
+    class Checker : public IRMutator {
+        bool in_loop = false;
+        Stmt visit(const For *op) override {
+            ScopedValue<bool> old(in_loop, true);
+            return IRMutator::visit(op);
+        }
+        Stmt visit(const IfThenElse *op) override {
+            if_in_loop |= in_loop;
+            return IRMutator::visit(op);
+        }
+
+    public:
+        bool if_in_loop = false;
+    } checker;
+
+    g.add_custom_lowering_pass(&checker, []() {});
+
+    p.set(true);
+    g.realize(1024, 1024);
+
+    if (checker.if_in_loop) {
+        printf("Found an if statement inside a loop. This was not supposed to happen\n");
+        return -1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/lots_of_loop_invariants.cpp
+++ b/test/correctness/lots_of_loop_invariants.cpp
@@ -6,7 +6,7 @@ int main(int argc, char **argv) {
     // Stress-test LICM by hoisting lots of loop invariants
     Var x, y, c;
 
-    const int N = 500;
+    const int N = 100;
 
     Expr e = 0;
     for (int i = 0; i < N; i++) {

--- a/test/correctness/trim_no_ops.cpp
+++ b/test/correctness/trim_no_ops.cpp
@@ -52,12 +52,12 @@ int main(int argc, char **argv) {
         f(x) *= select(x > 20 && x < 30, 2, 1);
         f(x) = select(x >= 60 && x <= 100, 100 - f(x), f(x));
 
-        // There should be no selects after trim_no_ops runs
+        // There should be no selects or ifs after trim_no_ops runs
         Module m = f.compile_to_module({});
         CountConditionals s;
         m.functions().front().body.accept(&s);
         if (s.count != 0) {
-            std::cerr << "There were selects in the lowered code: \n"
+            std::cerr << "There were conditionals in the lowered code: \n"
                       << m.functions().front().body << "\n";
             return -1;
         }


### PR DESCRIPTION
If statements can be injected by GuardWithIf, RDom predicates,
specializations, and uses of undef. There are various situations where
an if statement can end up further inside a loop nest than strictly
necessary. This PR adds a pass to hoist them.

This results in slightly better codegen for some conv layer schedules on
GPU.

Also reduced the expr count in lots_of_loop_invariants because it spends
a long time inside LLVM