### PR TITLE
Add ALWAYS_INLINE and WEAK_INLINE to runtime_internal.h

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -21,13 +21,15 @@ struct halide_handle_traits;
 extern "C" {
 #endif
 
-// Note that you should not use "inline" along with HALIDE_ALWAYS_INLINE;
-// it is not necessary, and may produce warnings for some build configurations.
 #ifdef _MSC_VER
+// Note that (for MSVC) you should not use "inline" along with HALIDE_ALWAYS_INLINE;
+// it is not necessary, and may produce warnings for some build configurations.
 #define HALIDE_ALWAYS_INLINE __forceinline
 #define HALIDE_NEVER_INLINE __declspec(noinline)
 #else
-#define HALIDE_ALWAYS_INLINE __attribute__((always_inline)) inline
+// Note that (for Posixy compilers) you should always use "inline" along with HALIDE_ALWAYS_INLINE;
+// otherwise some corner-case scenarios may erroneously report link errors.
+#define HALIDE_ALWAYS_INLINE inline __attribute__((always_inline))
 #define HALIDE_NEVER_INLINE __attribute__((noinline))
 #endif
 

--- a/src/runtime/alignment_128.cpp
+++ b/src/runtime/alignment_128.cpp
@@ -4,7 +4,7 @@ namespace Halide {
 namespace Runtime {
 namespace Internal {
 
-WEAK __attribute__((always_inline)) int halide_malloc_alignment() {
+WEAK_INLINE int halide_malloc_alignment() {
     return 128;
 }
 

--- a/src/runtime/alignment_32.cpp
+++ b/src/runtime/alignment_32.cpp
@@ -4,7 +4,7 @@ namespace Halide {
 namespace Runtime {
 namespace Internal {
 
-WEAK __attribute__((always_inline)) int halide_malloc_alignment() {
+WEAK_INLINE int halide_malloc_alignment() {
     return 32;
 }
 

--- a/src/runtime/alignment_64.cpp
+++ b/src/runtime/alignment_64.cpp
@@ -4,7 +4,7 @@ namespace Halide {
 namespace Runtime {
 namespace Internal {
 
-WEAK __attribute__((always_inline)) int halide_malloc_alignment() {
+WEAK_INLINE int halide_malloc_alignment() {
     return 64;
 }
 

--- a/src/runtime/cpu_features.h
+++ b/src/runtime/cpu_features.h
@@ -14,23 +14,23 @@ namespace Internal {
 struct CpuFeatures {
     static const int kWordCount = (halide_target_feature_end + 63) / (sizeof(uint64_t) * 8);
 
-    __attribute__((always_inline)) void set_known(int i) {
+    ALWAYS_INLINE void set_known(int i) {
         known[i >> 6] |= ((uint64_t)1) << (i & 63);
     }
 
-    __attribute__((always_inline)) void set_available(int i) {
+    ALWAYS_INLINE void set_available(int i) {
         available[i >> 6] |= ((uint64_t)1) << (i & 63);
     }
 
-    __attribute__((always_inline)) bool test_known(int i) const {
+    ALWAYS_INLINE bool test_known(int i) const {
         return (known[i >> 6] & ((uint64_t)1) << (i & 63)) != 0;
     }
 
-    __attribute__((always_inline)) bool test_available(int i) const {
+    ALWAYS_INLINE bool test_available(int i) const {
         return (available[i >> 6] & ((uint64_t)1) << (i & 63)) != 0;
     }
 
-    __attribute__((always_inline))
+    ALWAYS_INLINE
     CpuFeatures() {
         // Can't use in-class initing of these without C++11 enabled,
         // which isn't the case for all runtime builds

--- a/src/runtime/cuda.cpp
+++ b/src/runtime/cuda.cpp
@@ -6,8 +6,6 @@
 #include "scoped_mutex_lock.h"
 #include "scoped_spin_lock.h"
 
-#define INLINE inline __attribute__((always_inline))
-
 namespace Halide {
 namespace Runtime {
 namespace Internal {
@@ -59,7 +57,7 @@ extern "C" WEAK void *halide_cuda_get_symbol(void *user_context, const char *nam
 }
 
 template<typename T>
-INLINE T get_cuda_symbol(void *user_context, const char *name, bool optional = false) {
+ALWAYS_INLINE T get_cuda_symbol(void *user_context, const char *name, bool optional = false) {
     T s = (T)halide_cuda_get_symbol(user_context, name);
     if (!optional && !s) {
         error(user_context) << "CUDA API not found: " << name << "\n";
@@ -208,7 +206,7 @@ public:
     int error;
 
     // Constructor sets 'error' if any occurs.
-    INLINE Context(void *user_context)
+    ALWAYS_INLINE Context(void *user_context)
         : user_context(user_context),
           context(NULL),
           error(CUDA_SUCCESS) {
@@ -231,7 +229,7 @@ public:
         error = cuCtxPushCurrent(context);
     }
 
-    INLINE ~Context() {
+    ALWAYS_INLINE ~Context() {
         if (error == 0) {
             CUcontext old;
             cuCtxPopCurrent(&old);
@@ -613,7 +611,7 @@ WEAK __attribute__((constructor)) void register_cuda_allocation_pool() {
     halide_register_device_allocation_pool(&cuda_allocation_pool);
 }
 
-WEAK __attribute__((always_inline)) uint64_t quantize_allocation_size(uint64_t sz) {
+ALWAYS_INLINE uint64_t quantize_allocation_size(uint64_t sz) {
     int z = __builtin_clzll(sz);
     if (z < 60) {
         sz--;

--- a/src/runtime/d3d12compute.cpp
+++ b/src/runtime/d3d12compute.cpp
@@ -1861,10 +1861,10 @@ public:
     d3d12_command_queue *queue;
     int error;
 
-    __attribute__((always_inline)) D3D12ContextHolder(void *user_context, bool create) {
+    ALWAYS_INLINE D3D12ContextHolder(void *user_context, bool create) {
         save(user_context, create);
     }
-    __attribute__((always_inline)) ~D3D12ContextHolder() {
+    ALWAYS_INLINE ~D3D12ContextHolder() {
         restore();
     }
 };

--- a/src/runtime/destructors.cpp
+++ b/src/runtime/destructors.cpp
@@ -1,10 +1,8 @@
 #include "HalideRuntime.h"
 
-#define INLINE inline __attribute__((weak)) __attribute__((always_inline)) __attribute__((used))
-
 extern "C" {
 
-INLINE void call_destructor(void *user_context, void (*fn)(void *user_context, void *object), void **object, bool should_call) {
+ALWAYS_INLINE __attribute__((used)) void call_destructor(void *user_context, void (*fn)(void *user_context, void *object), void **object, bool should_call) {
     void *o = *object;
     *object = NULL;
     // Call the function

--- a/src/runtime/device_buffer_utils.h
+++ b/src/runtime/device_buffer_utils.h
@@ -168,7 +168,7 @@ WEAK device_copy make_device_to_host_copy(const halide_buffer_t *buf) {
 }
 
 // Caller is expected to verify that src->dimensions == dst->dimensions
-inline __attribute__((always_inline)) int64_t calc_device_crop_byte_offset(const struct halide_buffer_t *src, struct halide_buffer_t *dst) {
+ALWAYS_INLINE int64_t calc_device_crop_byte_offset(const struct halide_buffer_t *src, struct halide_buffer_t *dst) {
     int64_t offset = 0;
     for (int i = 0; i < src->dimensions; i++) {
         offset += (dst->dim[i].min - src->dim[i].min) * src->dim[i].stride;
@@ -179,7 +179,7 @@ inline __attribute__((always_inline)) int64_t calc_device_crop_byte_offset(const
 
 // Caller is expected to verify that src->dimensions == dst->dimensions + 1,
 // and that slice_dim and slice_pos are valid within src
-inline __attribute__((always_inline)) int64_t calc_device_slice_byte_offset(const struct halide_buffer_t *src, int slice_dim, int slice_pos) {
+ALWAYS_INLINE int64_t calc_device_slice_byte_offset(const struct halide_buffer_t *src, int slice_dim, int slice_pos) {
     int64_t offset = (slice_pos - src->dim[slice_dim].min) * src->dim[slice_dim].stride;
     offset *= src->type.bytes();
     return offset;

--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -59,8 +59,8 @@ WEAK int copy_to_host_already_locked(void *user_context, struct halide_buffer_t 
 
 namespace {
 
-__attribute__((always_inline)) int debug_log_and_validate_buf(void *user_context, const halide_buffer_t *buf_arg,
-                                                              const char *routine) {
+ALWAYS_INLINE int debug_log_and_validate_buf(void *user_context, const halide_buffer_t *buf_arg,
+                                             const char *routine) {
     if (buf_arg == NULL) {
         return halide_error_buffer_is_null(user_context, routine);
     }

--- a/src/runtime/halide_buffer_t.cpp
+++ b/src/runtime/halide_buffer_t.cpp
@@ -1,6 +1,6 @@
 #ifdef COMPILING_HALIDE_RUNTIME
 #include "HalideRuntime.h"
-#define HALIDE_BUFFER_HELPER_ATTRS __attribute__((always_inline, weak))
+#define HALIDE_BUFFER_HELPER_ATTRS WEAK_INLINE
 #else
 #define HALIDE_BUFFER_HELPER_ATTRS inline
 #endif

--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -97,7 +97,7 @@ WEAK void get_remote_profiler_state(int *func, int *threads) {
 }
 
 template<typename T>
-__attribute__((always_inline)) void get_symbol(void *user_context, void *host_lib, const char *name, T &sym, bool required = true) {
+ALWAYS_INLINE void get_symbol(void *user_context, void *host_lib, const char *name, T &sym, bool required = true) {
     debug(user_context) << "    halide_get_library_symbol('" << name << "') -> \n";
     sym = (T)halide_get_library_symbol(host_lib, name);
     debug(user_context) << "        " << (void *)sym << "\n";

--- a/src/runtime/matlab.cpp
+++ b/src/runtime/matlab.cpp
@@ -1,8 +1,6 @@
 #include "HalideRuntime.h"
 #include "printer.h"
 
-#define INLINE inline __attribute__((always_inline))
-
 #ifndef MX_API_VER
 #define MX_API_VER 0x07040000
 #endif
@@ -164,17 +162,17 @@ WEAK const char *get_class_name(mxClassID id) {
 
 // Get the real data pointer from an mxArray.
 template<typename T>
-INLINE T *get_data(mxArray *a) {
+ALWAYS_INLINE T *get_data(mxArray *a) {
     return (T *)mxGetData(a);
 }
 template<typename T>
-INLINE const T *get_data(const mxArray *a) {
+ALWAYS_INLINE const T *get_data(const mxArray *a) {
     return (const T *)mxGetData(a);
 }
 
 // Search for a symbol in the calling process (i.e. matlab).
 template<typename T>
-INLINE T get_mex_symbol(void *user_context, const char *name, bool required) {
+ALWAYS_INLINE T get_mex_symbol(void *user_context, const char *name, bool required) {
     T s = (T)halide_get_symbol(name);
     if (required && s == NULL) {
         error(user_context) << "mex API not found: " << name << "\n";
@@ -184,7 +182,7 @@ INLINE T get_mex_symbol(void *user_context, const char *name, bool required) {
 }
 
 // Provide Matlab API version agnostic wrappers for version specific APIs.
-INLINE size_t get_number_of_dimensions(const mxArray *a) {
+ALWAYS_INLINE size_t get_number_of_dimensions(const mxArray *a) {
     if (mxGetNumberOfDimensions_730) {
         return mxGetNumberOfDimensions_730(a);
     } else {
@@ -192,7 +190,7 @@ INLINE size_t get_number_of_dimensions(const mxArray *a) {
     }
 }
 
-INLINE size_t get_dimension(const mxArray *a, size_t n) {
+ALWAYS_INLINE size_t get_dimension(const mxArray *a, size_t n) {
     if (mxGetDimensions_730) {
         return mxGetDimensions_730(a)[n];
     } else {
@@ -200,7 +198,7 @@ INLINE size_t get_dimension(const mxArray *a, size_t n) {
     }
 }
 
-INLINE mxArray *create_numeric_matrix(size_t M, size_t N, mxClassID type, mxComplexity complexity) {
+ALWAYS_INLINE mxArray *create_numeric_matrix(size_t M, size_t N, mxClassID type, mxComplexity complexity) {
     if (mxCreateNumericMatrix_730) {
         return mxCreateNumericMatrix_730(M, N, type, complexity);
     } else {

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -376,10 +376,10 @@ public:
     mtl_command_queue *queue;
     int error;
 
-    __attribute__((always_inline)) MetalContextHolder(void *user_context, bool create) {
+    ALWAYS_INLINE MetalContextHolder(void *user_context, bool create) {
         save(user_context, create);
     }
-    __attribute__((always_inline)) ~MetalContextHolder() {
+    ALWAYS_INLINE ~MetalContextHolder() {
         restore();
     }
 };

--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -6,8 +6,6 @@
 
 #include "mini_cl.h"
 
-#define INLINE inline __attribute__((always_inline))
-
 namespace Halide {
 namespace Runtime {
 namespace Internal {
@@ -51,7 +49,7 @@ extern "C" WEAK void *halide_opencl_get_symbol(void *user_context, const char *n
 }
 
 template<typename T>
-INLINE T get_cl_symbol(void *user_context, const char *name) {
+ALWAYS_INLINE T get_cl_symbol(void *user_context, const char *name) {
     T s = (T)halide_opencl_get_symbol(user_context, name);
     if (!s) {
         error(user_context) << "OpenCL API not found: " << name << "\n";
@@ -249,7 +247,7 @@ public:
     cl_int error_code;
 
     // Constructor sets 'error_code' if any occurs.
-    INLINE ClContext(void *user_context)
+    ALWAYS_INLINE ClContext(void *user_context)
         : user_context(user_context),
           context(NULL),
           cmd_queue(NULL),
@@ -270,7 +268,7 @@ public:
         }
     }
 
-    INLINE ~ClContext() {
+    ALWAYS_INLINE ~ClContext() {
         halide_release_cl_context(user_context);
     }
 };

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -125,10 +125,10 @@ WEAK const char *gl_error_name(int32_t err) {
 }
 
 struct HalideMalloc {
-    __attribute__((always_inline)) HalideMalloc(void *user_context, size_t size)
+    ALWAYS_INLINE HalideMalloc(void *user_context, size_t size)
         : user_context(user_context), ptr(halide_malloc(user_context, size)) {
     }
-    __attribute__((always_inline)) ~HalideMalloc() {
+    ALWAYS_INLINE ~HalideMalloc() {
         halide_free(user_context, ptr);
     }
     void *const user_context;
@@ -225,10 +225,10 @@ WEAK GlobalState global_state;
 // Saves & restores OpenGL state
 class GLStateSaver {
 public:
-    __attribute__((always_inline)) GLStateSaver() {
+    ALWAYS_INLINE GLStateSaver() {
         save();
     }
-    __attribute__((always_inline)) ~GLStateSaver() {
+    ALWAYS_INLINE ~GLStateSaver() {
         restore();
     }
 
@@ -1004,11 +1004,11 @@ WEAK int halide_opengl_device_free(void *user_context, halide_buffer_t *buf) {
 
 // Can't use std::min, std::max in Halide runtime.
 template<typename T>
-__attribute__((always_inline)) T std_min(T a, T b) {
+ALWAYS_INLINE T std_min(T a, T b) {
     return (a < b) ? a : b;
 }
 template<typename T>
-__attribute__((always_inline)) T std_max(T a, T b) {
+ALWAYS_INLINE T std_max(T a, T b) {
     return (a > b) ? a : b;
 }
 
@@ -1016,7 +1016,7 @@ __attribute__((always_inline)) T std_max(T a, T b) {
 // halide_buffer_t to the packed interleaved format needed by GL. It is assumed that
 // src and dst have the same number of channels.
 template<class T>
-__attribute__((always_inline)) void halide_to_interleaved(const halide_buffer_t *src_buf, T *dst) {
+ALWAYS_INLINE void halide_to_interleaved(const halide_buffer_t *src_buf, T *dst) {
     const T *src = reinterpret_cast<const T *>(src_buf->host);
     int width = (src_buf->dimensions > 0) ? src_buf->dim[0].extent : 1;
     int height = (src_buf->dimensions > 1) ? src_buf->dim[1].extent : 1;
@@ -1042,7 +1042,7 @@ __attribute__((always_inline)) void halide_to_interleaved(const halide_buffer_t 
 // channels than dst, the excess in dst will be left untouched; if src has
 // more channels than dst, the excess will be ignored.
 template<class T>
-__attribute__((always_inline)) void interleaved_to_halide(void *user_context, const T *src, int src_channels, halide_buffer_t *dst_buf) {
+ALWAYS_INLINE void interleaved_to_halide(void *user_context, const T *src, int src_channels, halide_buffer_t *dst_buf) {
     T *dst = reinterpret_cast<T *>(dst_buf->host);
     int width = (dst_buf->dimensions > 0) ? dst_buf->dim[0].extent : 1;
     int height = (dst_buf->dimensions > 1) ? dst_buf->dim[1].extent : 1;

--- a/src/runtime/openglcompute.cpp
+++ b/src/runtime/openglcompute.cpp
@@ -90,10 +90,10 @@ WEAK const char *gl_error_name(int32_t err) {
 }
 
 struct HalideMalloc {
-    __attribute__((always_inline)) HalideMalloc(void *user_context, size_t size)
+    ALWAYS_INLINE HalideMalloc(void *user_context, size_t size)
         : user_context(user_context), ptr(halide_malloc(user_context, size)) {
     }
-    __attribute__((always_inline)) ~HalideMalloc() {
+    ALWAYS_INLINE ~HalideMalloc() {
         halide_free(user_context, ptr);
     }
     void *const user_context;
@@ -373,7 +373,7 @@ WEAK int halide_openglcompute_device_free(void *user_context, halide_buffer_t *b
 namespace {
 
 template<typename Source, typename Dest>
-__attribute__((always_inline)) void converting_copy_memory_helper(const device_copy &copy, int d, int64_t src_off, int64_t dst_off) {
+ALWAYS_INLINE void converting_copy_memory_helper(const device_copy &copy, int d, int64_t src_off, int64_t dst_off) {
     // Skip size-1 dimensions
     while (d >= 0 && copy.extent[d] == 1)
         d--;

--- a/src/runtime/posix_abort.cpp
+++ b/src/runtime/posix_abort.cpp
@@ -6,7 +6,7 @@ namespace Halide {
 namespace Runtime {
 namespace Internal {
 
-WEAK __attribute__((always_inline)) void halide_abort() {
+WEAK_INLINE void halide_abort() {
     abort();
 }
 

--- a/src/runtime/posix_threads.cpp
+++ b/src/runtime/posix_threads.cpp
@@ -99,23 +99,23 @@ struct thread_parker {
     thread_parker(const thread_parker &) = delete;
 #endif
 
-    __attribute__((always_inline)) thread_parker()
+    ALWAYS_INLINE thread_parker()
         : should_park(false) {
         pthread_mutex_init(&mutex, NULL);
         pthread_cond_init(&condvar, NULL);
         should_park = false;
     }
 
-    __attribute__((always_inline)) ~thread_parker() {
+    ALWAYS_INLINE ~thread_parker() {
         pthread_cond_destroy(&condvar);
         pthread_mutex_destroy(&mutex);
     }
 
-    __attribute__((always_inline)) void prepare_park() {
+    ALWAYS_INLINE void prepare_park() {
         should_park = true;
     }
 
-    __attribute__((always_inline)) void park() {
+    ALWAYS_INLINE void park() {
         pthread_mutex_lock(&mutex);
         while (should_park) {
             pthread_cond_wait(&condvar, &mutex);
@@ -123,16 +123,16 @@ struct thread_parker {
         pthread_mutex_unlock(&mutex);
     }
 
-    __attribute__((always_inline)) void unpark_start() {
+    ALWAYS_INLINE void unpark_start() {
         pthread_mutex_lock(&mutex);
     }
 
-    __attribute__((always_inline)) void unpark() {
+    ALWAYS_INLINE void unpark() {
         should_park = false;
         pthread_cond_signal(&condvar);
     }
 
-    __attribute__((always_inline)) void unpark_finish() {
+    ALWAYS_INLINE void unpark_finish() {
         pthread_mutex_unlock(&mutex);
     }
 };

--- a/src/runtime/prefetch.cpp
+++ b/src/runtime/prefetch.cpp
@@ -3,8 +3,9 @@
 extern "C" {
 
 // These need to inline, otherwise the extern call with the ptr
-// parameter breaks a lot of optimizations.
-WEAK __attribute__((always_inline)) int _halide_prefetch(const void *ptr) {
+// parameter breaks a lot of optimizations, but needs to be WEAK
+// so that Codegen_LLVM can find an instance of the Function to insert.
+WEAK_INLINE int _halide_prefetch(const void *ptr) {
     __builtin_prefetch(ptr, 1, 3);
     return 0;
 }

--- a/src/runtime/profiler_inlined.cpp
+++ b/src/runtime/profiler_inlined.cpp
@@ -2,7 +2,7 @@
 
 extern "C" {
 
-WEAK __attribute__((always_inline)) int halide_profiler_set_current_func(halide_profiler_state *state, int tok, int t) {
+WEAK_INLINE int halide_profiler_set_current_func(halide_profiler_state *state, int tok, int t) {
     // Use empty volatile asm blocks to prevent code motion. Otherwise
     // llvm reorders or elides the stores.
     volatile int *ptr = &(state->current_func);
@@ -14,7 +14,7 @@ WEAK __attribute__((always_inline)) int halide_profiler_set_current_func(halide_
     return 0;
 }
 
-WEAK __attribute__((always_inline)) int halide_profiler_incr_active_threads(halide_profiler_state *state) {
+WEAK_INLINE int halide_profiler_incr_active_threads(halide_profiler_state *state) {
     volatile int *ptr = &(state->active_threads);
     // clang-format off
     asm volatile ("":::);
@@ -24,7 +24,7 @@ WEAK __attribute__((always_inline)) int halide_profiler_incr_active_threads(hali
     return ret;
 }
 
-WEAK __attribute__((always_inline)) int halide_profiler_decr_active_threads(halide_profiler_state *state) {
+WEAK_INLINE int halide_profiler_decr_active_threads(halide_profiler_state *state) {
     volatile int *ptr = &(state->active_threads);
     // clang-format off
     asm volatile ("":::);

--- a/src/runtime/pseudostack.cpp
+++ b/src/runtime/pseudostack.cpp
@@ -3,7 +3,7 @@
 
 extern "C" {
 
-ALWAYS_INLINE __attribute__((used)) void *pseudostack_alloc(void *user_context, halide_pseudostack_slot_t *slot, size_t sz) {
+WEAK_INLINE __attribute__((used)) void *pseudostack_alloc(void *user_context, halide_pseudostack_slot_t *slot, size_t sz) {
     if (__builtin_expect(sz > slot->size, 0)) {
         if (slot->ptr) halide_free(user_context, slot->ptr);
         slot->ptr = halide_malloc(user_context, sz);
@@ -13,7 +13,7 @@ ALWAYS_INLINE __attribute__((used)) void *pseudostack_alloc(void *user_context, 
 }
 
 // Only called as a destructor at function exit
-ALWAYS_INLINE __attribute__((used)) void pseudostack_free(void *user_context, void *ptr) {
+WEAK_INLINE __attribute__((used)) void pseudostack_free(void *user_context, void *ptr) {
     halide_pseudostack_slot_t *slot = (halide_pseudostack_slot_t *)ptr;
     slot->size = 0;
     if (slot->ptr) halide_free(user_context, slot->ptr);

--- a/src/runtime/pseudostack.cpp
+++ b/src/runtime/pseudostack.cpp
@@ -3,7 +3,7 @@
 
 extern "C" {
 
-inline WEAK __attribute__((always_inline)) __attribute__((used)) void *pseudostack_alloc(void *user_context, halide_pseudostack_slot_t *slot, size_t sz) {
+ALWAYS_INLINE __attribute__((used)) void *pseudostack_alloc(void *user_context, halide_pseudostack_slot_t *slot, size_t sz) {
     if (__builtin_expect(sz > slot->size, 0)) {
         if (slot->ptr) halide_free(user_context, slot->ptr);
         slot->ptr = halide_malloc(user_context, sz);
@@ -13,7 +13,7 @@ inline WEAK __attribute__((always_inline)) __attribute__((used)) void *pseudosta
 }
 
 // Only called as a destructor at function exit
-inline WEAK __attribute__((always_inline)) __attribute__((used)) void pseudostack_free(void *user_context, void *ptr) {
+ALWAYS_INLINE __attribute__((used)) void pseudostack_free(void *user_context, void *ptr) {
     halide_pseudostack_slot_t *slot = (halide_pseudostack_slot_t *)ptr;
     slot->size = 0;
     if (slot->ptr) halide_free(user_context, slot->ptr);

--- a/src/runtime/qurt_hvx.cpp
+++ b/src/runtime/qurt_hvx.cpp
@@ -49,7 +49,7 @@ WEAK void halide_qurt_hvx_unlock_as_destructor(void *user_context, void * /*obj*
 
 // These need to inline, otherwise the extern call with the ptr
 // parameter breaks a lot of optimizations.
-ALWAYS_INLINE int _halide_prefetch_2d(const void *ptr, int width_bytes, int height, int stride_bytes) {
+WEAK_INLINE int _halide_prefetch_2d(const void *ptr, int width_bytes, int height, int stride_bytes) {
     // Notes:
     //  - Prefetches can be queued up to 3 deep (MAX_PREFETCH)
     //  - If 3 are already pending, the oldest request is dropped
@@ -69,7 +69,7 @@ ALWAYS_INLINE int _halide_prefetch_2d(const void *ptr, int width_bytes, int heig
     return 0;
 }
 
-ALWAYS_INLINE int _halide_prefetch(const void *ptr, int size) {
+WEAK_INLINE int _halide_prefetch(const void *ptr, int size) {
     _halide_prefetch_2d(ptr, size, 1, 1);
     return 0;
 }
@@ -79,11 +79,11 @@ struct hexagon_buffer_t_arg {
     uint8_t *host;
 };
 
-ALWAYS_INLINE uint8_t *_halide_hexagon_buffer_get_host(const hexagon_buffer_t_arg *buf) {
+WEAK_INLINE uint8_t *_halide_hexagon_buffer_get_host(const hexagon_buffer_t_arg *buf) {
     return buf->host;
 }
 
-ALWAYS_INLINE uint64_t _halide_hexagon_buffer_get_device(const hexagon_buffer_t_arg *buf) {
+WEAK_INLINE uint64_t _halide_hexagon_buffer_get_device(const hexagon_buffer_t_arg *buf) {
     return buf->device;
 }
 }

--- a/src/runtime/qurt_hvx.cpp
+++ b/src/runtime/qurt_hvx.cpp
@@ -49,7 +49,7 @@ WEAK void halide_qurt_hvx_unlock_as_destructor(void *user_context, void * /*obj*
 
 // These need to inline, otherwise the extern call with the ptr
 // parameter breaks a lot of optimizations.
-WEAK __attribute__((always_inline)) int _halide_prefetch_2d(const void *ptr, int width_bytes, int height, int stride_bytes) {
+ALWAYS_INLINE int _halide_prefetch_2d(const void *ptr, int width_bytes, int height, int stride_bytes) {
     // Notes:
     //  - Prefetches can be queued up to 3 deep (MAX_PREFETCH)
     //  - If 3 are already pending, the oldest request is dropped
@@ -69,7 +69,7 @@ WEAK __attribute__((always_inline)) int _halide_prefetch_2d(const void *ptr, int
     return 0;
 }
 
-WEAK __attribute__((always_inline)) int _halide_prefetch(const void *ptr, int size) {
+ALWAYS_INLINE int _halide_prefetch(const void *ptr, int size) {
     _halide_prefetch_2d(ptr, size, 1, 1);
     return 0;
 }
@@ -79,11 +79,11 @@ struct hexagon_buffer_t_arg {
     uint8_t *host;
 };
 
-WEAK __attribute__((always_inline)) uint8_t *_halide_hexagon_buffer_get_host(const hexagon_buffer_t_arg *buf) {
+ALWAYS_INLINE uint8_t *_halide_hexagon_buffer_get_host(const hexagon_buffer_t_arg *buf) {
     return buf->host;
 }
 
-WEAK __attribute__((always_inline)) uint64_t _halide_hexagon_buffer_get_device(const hexagon_buffer_t_arg *buf) {
+ALWAYS_INLINE uint64_t _halide_hexagon_buffer_get_device(const hexagon_buffer_t_arg *buf) {
     return buf->device;
 }
 }

--- a/src/runtime/qurt_threads.cpp
+++ b/src/runtime/qurt_threads.cpp
@@ -90,23 +90,23 @@ struct thread_parker {
     thread_parker(const thread_parker &) = delete;
 #endif
 
-    __attribute__((always_inline)) thread_parker()
+    ALWAYS_INLINE thread_parker()
         : should_park(false) {
         qurt_mutex_init(&mutex);
         qurt_cond_init(&condvar);
         should_park = false;
     }
 
-    __attribute__((always_inline)) ~thread_parker() {
+    ALWAYS_INLINE ~thread_parker() {
         qurt_cond_destroy(&condvar);
         qurt_mutex_destroy(&mutex);
     }
 
-    __attribute__((always_inline)) void prepare_park() {
+    ALWAYS_INLINE void prepare_park() {
         should_park = true;
     }
 
-    __attribute__((always_inline)) void park() {
+    ALWAYS_INLINE void park() {
         qurt_mutex_lock(&mutex);
         while (should_park) {
             qurt_cond_wait(&condvar, &mutex);
@@ -114,16 +114,16 @@ struct thread_parker {
         qurt_mutex_unlock(&mutex);
     }
 
-    __attribute__((always_inline)) void unpark_start() {
+    ALWAYS_INLINE void unpark_start() {
         qurt_mutex_lock(&mutex);
     }
 
-    __attribute__((always_inline)) void unpark() {
+    ALWAYS_INLINE void unpark() {
         should_park = false;
         qurt_cond_signal(&condvar);
     }
 
-    __attribute__((always_inline)) void unpark_finish() {
+    ALWAYS_INLINE void unpark_finish() {
         qurt_mutex_unlock(&mutex);
     }
 };

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -30,7 +30,32 @@ typedef __PTRDIFF_TYPE__ ptrdiff_t;
 typedef ptrdiff_t ssize_t;
 
 #define NULL 0
+
+// --------------
+
+// In Halide runtime code, most functions should just be WEAK, whether or not
+// they're part of the public API.
+//
+// ALWAYS_INLINE is for things that either should be inlined for performance
+// reasons, or for things that go into every compiled pipeline (not just the
+// standalone runtime), as those things have to either disappear entirely by
+// being inlined away, or have "inline" linkage to avoid multiple definition
+// errors on platforms that have no weak linkage.
+//
+// WEAK_INLINED is a special case where we are 'inlining' the bitcode at
+// bitcode-compilation time (rather than C++ compilation time); it's needed
+// for a few places in the runtime where we can't inline in the traditional
+// way.
+
 #define WEAK __attribute__((weak))
+
+// Note that ALWAYS_INLINE should *always* also be `inline`.
+#define ALWAYS_INLINE inline __attribute__((always_inline))
+
+// Note that WEAK_INLINE should *not* also be `inline`
+#define WEAK_INLINE __attribute__((weak, always_inline))
+
+// --------------
 
 #ifdef BITS_64
 #define INT64_C(c) c##L
@@ -170,32 +195,31 @@ extern WEAK void halide_use_jit_module();
 extern WEAK void halide_release_jit_module();
 
 template<typename T>
-__attribute__((always_inline)) void swap(T &a, T &b) {
+ALWAYS_INLINE void swap(T &a, T &b) {
     T t = a;
     a = b;
     b = t;
 }
 
 template<typename T>
-__attribute__((always_inline)) T max(const T &a, const T &b) {
+ALWAYS_INLINE T max(const T &a, const T &b) {
     return a > b ? a : b;
 }
 
 template<typename T>
-__attribute__((always_inline)) T min(const T &a, const T &b) {
+ALWAYS_INLINE T min(const T &a, const T &b) {
     return a < b ? a : b;
 }
 
 template<typename T, typename U>
-__attribute__((always_inline)) T reinterpret(const U &x) {
+ALWAYS_INLINE T reinterpret(const U &x) {
     T ret;
     memcpy(&ret, &x, min(sizeof(T), sizeof(U)));
     return ret;
 }
 
-extern WEAK __attribute__((always_inline)) int halide_malloc_alignment();
-
-extern WEAK __attribute__((always_inline)) void halide_abort();
+extern WEAK_INLINE int halide_malloc_alignment();
+extern WEAK_INLINE void halide_abort();
 
 void halide_thread_yield();
 

--- a/src/runtime/scoped_mutex_lock.h
+++ b/src/runtime/scoped_mutex_lock.h
@@ -11,12 +11,12 @@ namespace Internal {
 struct ScopedMutexLock {
     halide_mutex *mutex;
 
-    ScopedMutexLock(halide_mutex *mutex) __attribute__((always_inline))
-    : mutex(mutex) {
+    ALWAYS_INLINE ScopedMutexLock(halide_mutex *mutex)
+        : mutex(mutex) {
         halide_mutex_lock(mutex);
     }
 
-    ~ScopedMutexLock() __attribute__((always_inline)) {
+    ALWAYS_INLINE ~ScopedMutexLock() {
         halide_mutex_unlock(mutex);
     }
 };

--- a/src/runtime/scoped_spin_lock.h
+++ b/src/runtime/scoped_spin_lock.h
@@ -12,14 +12,14 @@ struct ScopedSpinLock {
 
     volatile AtomicFlag *const flag;
 
-    ScopedSpinLock(volatile AtomicFlag *flag) __attribute__((always_inline))
-    : flag(flag) {
+    ALWAYS_INLINE ScopedSpinLock(volatile AtomicFlag *flag)
+        : flag(flag) {
         while (__atomic_test_and_set(flag, __ATOMIC_ACQUIRE)) {
             // nothing
         }
     }
 
-    ~ScopedSpinLock() __attribute__((always_inline)) {
+    ALWAYS_INLINE ~ScopedSpinLock() {
         __atomic_clear(flag, __ATOMIC_RELEASE);
     }
 };

--- a/src/runtime/synchronization_common.h
+++ b/src/runtime/synchronization_common.h
@@ -53,173 +53,173 @@ namespace Synchronization {
 namespace {
 
 #if TSAN_ANNOTATIONS
-__attribute__((always_inline)) void if_tsan_pre_lock(void *mutex) {
+ALWAYS_INLINE void if_tsan_pre_lock(void *mutex) {
     __tsan_mutex_pre_lock(mutex, __tsan_mutex_linker_init);
 };
 // TODO(zalman|dvyukov): Is 1 the right value for a non-recursive lock? pretty sure value is ignored.
-__attribute__((always_inline)) void if_tsan_post_lock(void *mutex) {
+ALWAYS_INLINE void if_tsan_post_lock(void *mutex) {
     __tsan_mutex_post_lock(mutex, __tsan_mutex_linker_init, 1);
 }
 // TODO(zalman|dvyukov): Is it safe to ignore return value here if locks are not recursive?
-__attribute__((always_inline)) void if_tsan_pre_unlock(void *mutex) {
+ALWAYS_INLINE void if_tsan_pre_unlock(void *mutex) {
     (void)__tsan_mutex_pre_unlock(mutex, __tsan_mutex_linker_init);
 }
-__attribute__((always_inline)) void if_tsan_post_unlock(void *mutex) {
+ALWAYS_INLINE void if_tsan_post_unlock(void *mutex) {
     __tsan_mutex_post_unlock(mutex, __tsan_mutex_linker_init);
 }
-__attribute__((always_inline)) void if_tsan_pre_signal(void *cond) {
+ALWAYS_INLINE void if_tsan_pre_signal(void *cond) {
     __tsan_mutex_pre_signal(cond, 0);
 }
-__attribute__((always_inline)) void if_tsan_post_signal(void *cond) {
+ALWAYS_INLINE void if_tsan_post_signal(void *cond) {
     __tsan_mutex_post_signal(cond, 0);
 }
 #else
-__attribute__((always_inline)) void if_tsan_pre_lock(void *) {
+ALWAYS_INLINE void if_tsan_pre_lock(void *) {
 }
-__attribute__((always_inline)) void if_tsan_post_lock(void *) {
+ALWAYS_INLINE void if_tsan_post_lock(void *) {
 }
-__attribute__((always_inline)) void if_tsan_pre_unlock(void *) {
+ALWAYS_INLINE void if_tsan_pre_unlock(void *) {
 }
-__attribute__((always_inline)) void if_tsan_post_unlock(void *) {
+ALWAYS_INLINE void if_tsan_post_unlock(void *) {
 }
-__attribute__((always_inline)) void if_tsan_pre_signal(void *) {
+ALWAYS_INLINE void if_tsan_pre_signal(void *) {
 }
-__attribute__((always_inline)) void if_tsan_post_signal(void *) {
+ALWAYS_INLINE void if_tsan_post_signal(void *) {
 }
 #endif
 
 #ifdef BITS_32
-__attribute__((always_inline)) uintptr_t atomic_and_fetch_release(uintptr_t *addr, uintptr_t val) {
+ALWAYS_INLINE uintptr_t atomic_and_fetch_release(uintptr_t *addr, uintptr_t val) {
     return __sync_and_and_fetch(addr, val);
 }
 
 template<typename T>
-__attribute__((always_inline)) T atomic_fetch_add_acquire_release(T *addr, T val) {
+ALWAYS_INLINE T atomic_fetch_add_acquire_release(T *addr, T val) {
     return __sync_fetch_and_add(addr, val);
 }
 
 template<typename T>
-__attribute__((always_inline)) bool cas_strong_sequentially_consistent_helper(T *addr, T *expected, T *desired) {
+ALWAYS_INLINE bool cas_strong_sequentially_consistent_helper(T *addr, T *expected, T *desired) {
     T oldval = *expected;
     T gotval = __sync_val_compare_and_swap(addr, oldval, *desired);
     *expected = gotval;
     return oldval == gotval;
 }
 
-__attribute__((always_inline)) bool atomic_cas_strong_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+ALWAYS_INLINE bool atomic_cas_strong_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
     return cas_strong_sequentially_consistent_helper(addr, expected, desired);
 }
 
-__attribute__((always_inline)) bool atomic_cas_weak_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+ALWAYS_INLINE bool atomic_cas_weak_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
     return cas_strong_sequentially_consistent_helper(addr, expected, desired);
 }
 
 template<typename T>
-__attribute__((always_inline)) bool atomic_cas_weak_relacq_relaxed(T *addr, T *expected, T *desired) {
+ALWAYS_INLINE bool atomic_cas_weak_relacq_relaxed(T *addr, T *expected, T *desired) {
     return cas_strong_sequentially_consistent_helper(addr, expected, desired);
 }
 
-__attribute__((always_inline)) bool atomic_cas_weak_relaxed_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+ALWAYS_INLINE bool atomic_cas_weak_relaxed_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
     return cas_strong_sequentially_consistent_helper(addr, expected, desired);
 }
 
-__attribute__((always_inline)) bool atomic_cas_weak_acquire_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+ALWAYS_INLINE bool atomic_cas_weak_acquire_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
     return cas_strong_sequentially_consistent_helper(addr, expected, desired);
 }
 
-__attribute__((always_inline)) uintptr_t atomic_fetch_and_release(uintptr_t *addr, uintptr_t val) {
+ALWAYS_INLINE uintptr_t atomic_fetch_and_release(uintptr_t *addr, uintptr_t val) {
     return __sync_fetch_and_and(addr, val);
 }
 
 template<typename T>
-__attribute__((always_inline)) void atomic_load_relaxed(T *addr, T *val) {
+ALWAYS_INLINE void atomic_load_relaxed(T *addr, T *val) {
     *val = *addr;
 }
 
 template<typename T>
-__attribute__((always_inline)) void atomic_load_acquire(T *addr, T *val) {
+ALWAYS_INLINE void atomic_load_acquire(T *addr, T *val) {
     __sync_synchronize();
     *val = *addr;
 }
 
-__attribute__((always_inline)) uintptr_t atomic_or_fetch_relaxed(uintptr_t *addr, uintptr_t val) {
+ALWAYS_INLINE uintptr_t atomic_or_fetch_relaxed(uintptr_t *addr, uintptr_t val) {
     return __sync_or_and_fetch(addr, val);
 }
 
-__attribute__((always_inline)) void atomic_store_relaxed(uintptr_t *addr, uintptr_t *val) {
+ALWAYS_INLINE void atomic_store_relaxed(uintptr_t *addr, uintptr_t *val) {
     *addr = *val;
 }
 
 template<typename T>
-__attribute__((always_inline)) void atomic_store_release(T *addr, T *val) {
+ALWAYS_INLINE void atomic_store_release(T *addr, T *val) {
     *addr = *val;
     __sync_synchronize();
 }
 
-__attribute__((always_inline)) void atomic_thread_fence_acquire() {
+ALWAYS_INLINE void atomic_thread_fence_acquire() {
     __sync_synchronize();
 }
 
 #else
 
-__attribute__((always_inline)) uintptr_t atomic_and_fetch_release(uintptr_t *addr, uintptr_t val) {
+ALWAYS_INLINE uintptr_t atomic_and_fetch_release(uintptr_t *addr, uintptr_t val) {
     return __atomic_and_fetch(addr, val, __ATOMIC_RELEASE);
 }
 
 template<typename T>
-__attribute__((always_inline)) T atomic_fetch_add_acquire_release(T *addr, T val) {
+ALWAYS_INLINE T atomic_fetch_add_acquire_release(T *addr, T val) {
     return __atomic_fetch_add(addr, val, __ATOMIC_ACQ_REL);
 }
 
-__attribute__((always_inline)) bool atomic_cas_strong_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+ALWAYS_INLINE bool atomic_cas_strong_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
     return __atomic_compare_exchange(addr, expected, desired, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
 }
 
 template<typename T>
-__attribute__((always_inline)) bool atomic_cas_weak_relacq_relaxed(T *addr, T *expected, T *desired) {
+ALWAYS_INLINE bool atomic_cas_weak_relacq_relaxed(T *addr, T *expected, T *desired) {
     return __atomic_compare_exchange(addr, expected, desired, true, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED);
 }
 
-__attribute__((always_inline)) bool atomic_cas_weak_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+ALWAYS_INLINE bool atomic_cas_weak_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
     return __atomic_compare_exchange(addr, expected, desired, true, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
 }
 
-__attribute__((always_inline)) bool atomic_cas_weak_relaxed_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+ALWAYS_INLINE bool atomic_cas_weak_relaxed_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
     return __atomic_compare_exchange(addr, expected, desired, true, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
 }
 
-__attribute__((always_inline)) bool atomic_cas_weak_acquire_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+ALWAYS_INLINE bool atomic_cas_weak_acquire_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
     return __atomic_compare_exchange(addr, expected, desired, true, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 }
 
-__attribute__((always_inline)) uintptr_t atomic_fetch_and_release(uintptr_t *addr, uintptr_t val) {
+ALWAYS_INLINE uintptr_t atomic_fetch_and_release(uintptr_t *addr, uintptr_t val) {
     return __atomic_fetch_and(addr, val, __ATOMIC_RELEASE);
 }
 
 template<typename T>
-__attribute__((always_inline)) void atomic_load_relaxed(T *addr, T *val) {
+ALWAYS_INLINE void atomic_load_relaxed(T *addr, T *val) {
     __atomic_load(addr, val, __ATOMIC_RELAXED);
 }
 
 template<typename T>
-__attribute__((always_inline)) void atomic_load_acquire(T *addr, T *val) {
+ALWAYS_INLINE void atomic_load_acquire(T *addr, T *val) {
     __atomic_load(addr, val, __ATOMIC_ACQUIRE);
 }
 
-__attribute__((always_inline)) uintptr_t atomic_or_fetch_relaxed(uintptr_t *addr, uintptr_t val) {
+ALWAYS_INLINE uintptr_t atomic_or_fetch_relaxed(uintptr_t *addr, uintptr_t val) {
     return __atomic_or_fetch(addr, val, __ATOMIC_RELAXED);
 }
 
-__attribute__((always_inline)) void atomic_store_relaxed(uintptr_t *addr, uintptr_t *val) {
+ALWAYS_INLINE void atomic_store_relaxed(uintptr_t *addr, uintptr_t *val) {
     __atomic_store(addr, val, __ATOMIC_RELAXED);
 }
 
 template<typename T>
-__attribute__((always_inline)) void atomic_store_release(T *addr, T *val) {
+ALWAYS_INLINE void atomic_store_release(T *addr, T *val) {
     __atomic_store(addr, val, __ATOMIC_RELEASE);
 }
 
-__attribute__((always_inline)) void atomic_thread_fence_acquire() {
+ALWAYS_INLINE void atomic_thread_fence_acquire() {
     __atomic_thread_fence(__ATOMIC_ACQUIRE);
 }
 
@@ -232,18 +232,18 @@ class spin_control {
 
 public:
     // Everyone says this should be 40. Have not measured it.
-    __attribute__((always_inline)) spin_control()
+    ALWAYS_INLINE spin_control()
         : spin_count(40) {
     }
 
-    __attribute__((always_inline)) bool should_spin() {
+    ALWAYS_INLINE bool should_spin() {
         if (spin_count > 0) {
             spin_count--;
         }
         return spin_count > 0;
     }
 
-    __attribute__((always_inline)) void reset() {
+    ALWAYS_INLINE void reset() {
         spin_count = 40;
     }
 };
@@ -283,12 +283,12 @@ struct word_lock_queue_data {
 
     word_lock_queue_data *tail;
 
-    __attribute__((always_inline)) word_lock_queue_data()
+    ALWAYS_INLINE word_lock_queue_data()
         : next(NULL), prev(NULL), tail(NULL) {
     }
 
     // Inlined, empty dtor needed to avoid confusing MachO builds
-    __attribute__((always_inline)) ~word_lock_queue_data() {
+    ALWAYS_INLINE ~word_lock_queue_data() {
     }
 };
 
@@ -299,10 +299,10 @@ class word_lock {
     void unlock_full();
 
 public:
-    __attribute__((always_inline)) word_lock()
+    ALWAYS_INLINE word_lock()
         : state(0) {
     }
-    __attribute__((always_inline)) void lock() {
+    ALWAYS_INLINE void lock() {
         if_tsan_pre_lock(this);
 
         uintptr_t expected = 0;
@@ -315,7 +315,7 @@ public:
         if_tsan_post_lock(this);
     }
 
-    __attribute__((always_inline)) void unlock() {
+    ALWAYS_INLINE void unlock() {
         if_tsan_pre_unlock(this);
 
         uintptr_t val = atomic_fetch_and_release(&state, ~(uintptr_t)lock_bit);
@@ -468,11 +468,11 @@ struct queue_data {
 
     uintptr_t unpark_info;
 
-    __attribute__((always_inline)) queue_data()
+    ALWAYS_INLINE queue_data()
         : sleep_address(0), next(NULL), unpark_info(0) {
     }
     // Inlined, empty dtor needed to avoid confusing MachO builds
-    __attribute__((always_inline)) ~queue_data() {
+    ALWAYS_INLINE ~queue_data() {
     }
 };
 
@@ -497,7 +497,7 @@ struct hash_table {
 WEAK char table_storage[sizeof(hash_table)];
 #define table (*(hash_table *)table_storage)
 
-__attribute__((always_inline)) void check_hash(uintptr_t hash) {
+ALWAYS_INLINE void check_hash(uintptr_t hash) {
     halide_assert(NULL, hash < sizeof(table.buckets) / sizeof(table.buckets[0]));
 }
 
@@ -515,7 +515,7 @@ WEAK void dump_hash() {
 }
 #endif
 
-static __attribute__((always_inline)) uintptr_t addr_hash(uintptr_t addr, uint32_t bits) {
+static ALWAYS_INLINE uintptr_t addr_hash(uintptr_t addr, uint32_t bits) {
     // Fibonacci hashing. The golden ratio is 1.9E3779B97F4A7C15F39...
     // in hexadecimal.
     if (sizeof(uintptr_t) >= 8) {
@@ -542,7 +542,7 @@ struct bucket_pair {
     hash_bucket &from;
     hash_bucket &to;
 
-    __attribute__((always_inline)) bucket_pair(hash_bucket &from, hash_bucket &to)
+    ALWAYS_INLINE bucket_pair(hash_bucket &from, hash_bucket &to)
         : from(from), to(to) {
     }
 };
@@ -596,7 +596,7 @@ struct validate_action {
     bool unpark_one;
     uintptr_t invalid_unpark_info;
 
-    __attribute__((always_inline)) validate_action()
+    ALWAYS_INLINE validate_action()
         : unpark_one(false), invalid_unpark_info(0) {
     }
 };
@@ -616,7 +616,7 @@ struct parking_control {
     uintptr_t (*unpark)(void *control, int unparked, bool more_waiters);
     void (*requeue_callback)(void *control, const validate_action &action, bool one_to_wake, bool some_requeued);
 
-    __attribute__((always_inline)) parking_control()
+    ALWAYS_INLINE parking_control()
         : validate(parking_control_validate), before_sleep(parking_control_before_sleep),
           unpark(parking_control_unpark), requeue_callback(parking_control_requeue_callback) {
     }
@@ -850,7 +850,7 @@ WEAK uintptr_t mutex_parking_control_unpark(void *control, int unparked, bool mo
 struct mutex_parking_control : parking_control {
     uintptr_t *lock_state;
 
-    __attribute__((always_inline)) mutex_parking_control(uintptr_t *lock_state)
+    ALWAYS_INLINE mutex_parking_control(uintptr_t *lock_state)
         : lock_state(lock_state) {
         validate = mutex_parking_control_validate;
         unpark = mutex_parking_control_unpark;
@@ -880,7 +880,7 @@ WEAK uintptr_t mutex_parking_control_unpark(void *control, int unparked, bool mo
 class fast_mutex {
     uintptr_t state;
 
-    __attribute__((always_inline)) void lock_full() {
+    ALWAYS_INLINE void lock_full() {
         // Everyone says this should be 40. Have not measured it.
         spin_control spinner;
         uintptr_t expected;
@@ -922,7 +922,7 @@ class fast_mutex {
         }
     }
 
-    __attribute__((always_inline)) void unlock_full() {
+    ALWAYS_INLINE void unlock_full() {
         uintptr_t expected = lock_bit;
         uintptr_t desired = 0;
         // Try for a fast release of the lock. Redundant with code in lock, but done
@@ -936,7 +936,7 @@ class fast_mutex {
     }
 
 public:
-    __attribute__((always_inline)) void lock() {
+    ALWAYS_INLINE void lock() {
         uintptr_t expected = 0;
         uintptr_t desired = lock_bit;
         // Try for a fast grab of the lock bit. If this does not work, call the full adaptive looping code.
@@ -945,7 +945,7 @@ public:
         }
     }
 
-    __attribute__((always_inline)) void unlock() {
+    ALWAYS_INLINE void unlock() {
         uintptr_t expected = lock_bit;
         uintptr_t desired = 0;
         // Try for a fast grab of the lock bit. If this does not work, call the full adaptive looping code.
@@ -954,7 +954,7 @@ public:
         }
     }
 
-    __attribute__((always_inline)) bool make_parked_if_locked() {
+    ALWAYS_INLINE bool make_parked_if_locked() {
         uintptr_t val;
         atomic_load_relaxed(&state, &val);
         while (true) {
@@ -969,7 +969,7 @@ public:
         }
     }
 
-    __attribute__((always_inline)) void make_parked() {
+    ALWAYS_INLINE void make_parked() {
         atomic_or_fetch_relaxed(&state, parked_bit);
     }
 };
@@ -978,7 +978,7 @@ struct signal_parking_control : parking_control {
     uintptr_t *cond_state;
     fast_mutex *mutex;
 
-    __attribute__((always_inline)) signal_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
+    ALWAYS_INLINE signal_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
         : cond_state(cond_state), mutex(mutex) {
         unpark = signal_parking_control_unpark;
     }
@@ -1005,7 +1005,7 @@ struct broadcast_parking_control : parking_control {
     uintptr_t *cond_state;
     fast_mutex *mutex;
 
-    __attribute__((always_inline)) broadcast_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
+    ALWAYS_INLINE broadcast_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
         : cond_state(cond_state), mutex(mutex) {
         validate = broadcast_parking_control_validate;
         requeue_callback = broadcast_parking_control_requeue_callback;
@@ -1046,7 +1046,7 @@ struct wait_parking_control : parking_control {
     uintptr_t *cond_state;
     fast_mutex *mutex;
 
-    __attribute__((always_inline)) wait_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
+    ALWAYS_INLINE wait_parking_control(uintptr_t *cond_state, fast_mutex *mutex)
         : cond_state(cond_state), mutex(mutex) {
         validate = wait_parking_control_validate;
         before_sleep = wait_parking_control_before_sleep;
@@ -1092,11 +1092,11 @@ class fast_cond {
     uintptr_t state;
 
 public:
-    __attribute__((always_inline)) fast_cond()
+    ALWAYS_INLINE fast_cond()
         : state(0) {
     }
 
-    __attribute__((always_inline)) void signal() {
+    ALWAYS_INLINE void signal() {
         if_tsan_pre_signal(this);
 
         uintptr_t val;
@@ -1110,7 +1110,7 @@ public:
         if_tsan_post_signal(this);
     }
 
-    __attribute__((always_inline)) void broadcast() {
+    ALWAYS_INLINE void broadcast() {
         if_tsan_pre_signal(this);
         uintptr_t val;
         atomic_load_relaxed(&state, &val);
@@ -1123,7 +1123,7 @@ public:
         if_tsan_post_signal(this);
     }
 
-    __attribute__((always_inline)) void wait(fast_mutex *mutex) {
+    ALWAYS_INLINE void wait(fast_mutex *mutex) {
         wait_parking_control control(&state, mutex);
         uintptr_t result = park((uintptr_t)this, control);
         if (result != (uintptr_t)mutex) {

--- a/src/runtime/thread_pool_common.h
+++ b/src/runtime/thread_pool_common.h
@@ -43,7 +43,7 @@ struct work {
     // which condition variable is the owner sleeping on. NULL if it isn't sleeping.
     bool owner_is_sleeping;
 
-    __attribute__((always_inline)) bool make_runnable() {
+    ALWAYS_INLINE bool make_runnable() {
         for (; next_semaphore < task.num_semaphores; next_semaphore++) {
             if (!halide_default_semaphore_try_acquire(task.semaphores[next_semaphore].semaphore,
                                                       task.semaphores[next_semaphore].count)) {
@@ -59,7 +59,7 @@ struct work {
         return true;
     }
 
-    __attribute__((always_inline)) bool running() const {
+    ALWAYS_INLINE bool running() const {
         return task.extent || active_workers;
     }
 };
@@ -138,12 +138,12 @@ struct work_queue_t {
     // to prevent deadlock due to oversubscription of threads.
     int threads_reserved;
 
-    __attribute__((always_inline)) bool running() const {
+    ALWAYS_INLINE bool running() const {
         return !shutdown;
     }
 
     // Used to check initial state is correct.
-    __attribute__((always_inline)) void assert_zeroed() const {
+    ALWAYS_INLINE void assert_zeroed() const {
         // Assert that all fields except the mutex and desired hreads count are zeroed.
         const char *bytes = ((const char *)&this->zero_marker);
         const char *limit = ((const char *)this) + sizeof(work_queue_t);
@@ -155,7 +155,7 @@ struct work_queue_t {
 
     // Return the work queue to initial state. Must be called while locked
     // and queue will remain locked.
-    __attribute__((always_inline)) void reset() {
+    ALWAYS_INLINE void reset() {
         // Ensure all fields except the mutex and desired hreads count are zeroed.
         char *bytes = ((char *)&this->zero_marker);
         char *limit = ((char *)this) + sizeof(work_queue_t);

--- a/src/runtime/windows_abort.cpp
+++ b/src/runtime/windows_abort.cpp
@@ -10,7 +10,7 @@ namespace Halide {
 namespace Runtime {
 namespace Internal {
 
-WEAK __attribute__((always_inline)) void halide_abort() {
+WEAK_INLINE void halide_abort() {
     char *s = getenv("HL_DISABLE_WINDOWS_ABORT_DIALOG");
     if (s && atoi(s)) {
         // Debug variants of the MSVC runtime will present an "Abort, Retry, Ignore"

--- a/src/runtime/windows_threads.cpp
+++ b/src/runtime/windows_threads.cpp
@@ -93,23 +93,23 @@ struct thread_parker {
     thread_parker(const thread_parker &) = delete;
 #endif
 
-    __attribute__((always_inline)) thread_parker()
+    ALWAYS_INLINE thread_parker()
         : should_park(false) {
         InitializeCriticalSection(&critical_section);
         InitializeConditionVariable(&condvar);
         should_park = false;
     }
 
-    __attribute__((always_inline)) ~thread_parker() {
+    ALWAYS_INLINE ~thread_parker() {
         // Windows ConditionVariable objects do not need to be deleted. There is no API to do so.
         DeleteCriticalSection(&critical_section);
     }
 
-    __attribute__((always_inline)) void prepare_park() {
+    ALWAYS_INLINE void prepare_park() {
         should_park = true;
     }
 
-    __attribute__((always_inline)) void park() {
+    ALWAYS_INLINE void park() {
         EnterCriticalSection(&critical_section);
         while (should_park) {
             SleepConditionVariableCS(&condvar, &critical_section, -1);
@@ -117,16 +117,16 @@ struct thread_parker {
         LeaveCriticalSection(&critical_section);
     }
 
-    __attribute__((always_inline)) void unpark_start() {
+    ALWAYS_INLINE void unpark_start() {
         EnterCriticalSection(&critical_section);
     }
 
-    __attribute__((always_inline)) void unpark() {
+    ALWAYS_INLINE void unpark() {
         should_park = false;
         WakeConditionVariable(&condvar);
     }
 
-    __attribute__((always_inline)) void unpark_finish() {
+    ALWAYS_INLINE void unpark_finish() {
         LeaveCriticalSection(&critical_section);
     }
 };

--- a/src/runtime/write_debug_image.cpp
+++ b/src/runtime/write_debug_image.cpp
@@ -54,21 +54,21 @@ struct tiff_tag {
         int32_t i32;
     } value;
 
-    void assign16(uint16_t tag_code, int32_t count, int16_t value) __attribute__((always_inline)) {
+    ALWAYS_INLINE void assign16(uint16_t tag_code, int32_t count, int16_t value) {
         this->tag_code = tag_code;
         this->type_code = 3;
         this->count = count;
         this->value.i16 = value;
     }
 
-    void assign32(uint16_t tag_code, int32_t count, int32_t value) __attribute__((always_inline)) {
+    ALWAYS_INLINE void assign32(uint16_t tag_code, int32_t count, int32_t value) {
         this->tag_code = tag_code;
         this->type_code = 4;
         this->count = count;
         this->value.i32 = value;
     }
 
-    void assign32(uint16_t tag_code, int16_t type_code, int32_t count, int32_t value) __attribute__((always_inline)) {
+    ALWAYS_INLINE void assign32(uint16_t tag_code, int16_t type_code, int32_t count, int32_t value) {
         this->tag_code = tag_code;
         this->type_code = type_code;
         this->count = count;
@@ -107,16 +107,16 @@ WEAK bool ends_with(const char *filename, const char *suffix) {
 
 struct ScopedFile {
     void *f;
-    __attribute__((always_inline)) ScopedFile(const char *filename, const char *mode) {
+    ALWAYS_INLINE ScopedFile(const char *filename, const char *mode) {
         f = fopen(filename, mode);
     }
-    __attribute__((always_inline)) ~ScopedFile() {
+    ALWAYS_INLINE ~ScopedFile() {
         fclose(f);
     }
-    __attribute__((always_inline)) bool write(const void *ptr, size_t bytes) {
+    ALWAYS_INLINE bool write(const void *ptr, size_t bytes) {
         return fwrite(ptr, bytes, 1, f);
     }
-    __attribute__((always_inline)) bool open() const {
+    ALWAYS_INLINE bool open() const {
         return f;
     }
 };

--- a/src/runtime/x86_cpu_features.cpp
+++ b/src/runtime/x86_cpu_features.cpp
@@ -7,10 +7,14 @@ namespace Internal {
 
 extern "C" void x86_cpuid_halide(int32_t *);
 
-static __attribute__((always_inline)) void cpuid(int32_t fn_id, int32_t *info) {
+namespace {
+
+ALWAYS_INLINE void cpuid(int32_t fn_id, int32_t *info) {
     info[0] = fn_id;
     x86_cpuid_halide(info);
 }
+
+}  // namespace
 
 WEAK CpuFeatures halide_get_cpu_features() {
     CpuFeatures features;


### PR DESCRIPTION
Clean up haphazard function attributes in runtime code:

- Runtime code that uses `__attribute__((always_inline))`, but not `__attribute__((weak))`, should always also use `inline` (otherwise, some compilation scenarios can report link errors due to confusion over linkage types). ALWAYS_INLINE is the runtime-specific macro now used uniformly used for these cases.

- Runtime code that uses `__attribute__((always_inline))` and `__attribute__((weak))` should *never* use `inline`. WEAK_INLINE is the runtime-specific macro now used uniformly used for these cases.