### PR TITLE
Minor JITExtern (& related) cleanups

### DIFF
--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -1020,7 +1020,7 @@ Pipeline::make_externs_jit_module(const Target &target,
                 arg_types.push_back(type_of<struct halide_buffer_t *>());
             }
             ExternSignature signature(Int(32), false, arg_types);
-            iter->second = ExternCFunction(address, signature);
+            iter->second = JITExtern(ExternCFunction(address, signature));
         } else {
             free_standing_jit_externs.add_extern_for_export(iter->first, iter->second.extern_c_function());
         }

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -562,7 +562,7 @@ public:
     }
 
     template<typename RT, typename... Args>
-    ExternSignature(RT (*f)(Args... args))
+    explicit ExternSignature(RT (*f)(Args... args))
         : ret_type_(type_of<RT>()),
           is_void_return_(std::is_void<RT>::value),
           arg_types_({type_of<Args>()...}) {
@@ -579,6 +579,23 @@ public:
 
     const std::vector<Type> &arg_types() const {
         return arg_types_;
+    }
+
+    friend std::ostream &operator<<(std::ostream &stream, const ExternSignature &sig) {
+        if (sig.is_void_return_) {
+            stream << "void";
+        } else {
+            stream << sig.ret_type_;
+        }
+        stream << " (*)(";
+        bool comma = false;
+        for (const auto &t : sig.arg_types_) {
+            if (comma) stream << ", ";
+            stream << t;
+            comma = true;
+        }
+        stream << ")";
+        return stream;
     }
 };
 
@@ -615,12 +632,12 @@ private:
     ExternCFunction extern_c_function_;
 
 public:
-    JITExtern(Pipeline pipeline);
-    JITExtern(const Func &func);
-    JITExtern(const ExternCFunction &extern_c_function);
+    explicit JITExtern(Pipeline pipeline);
+    explicit JITExtern(const Func &func);
+    explicit JITExtern(const ExternCFunction &extern_c_function);
 
     template<typename RT, typename... Args>
-    JITExtern(RT (*f)(Args... args))
+    explicit JITExtern(RT (*f)(Args... args))
         : JITExtern(ExternCFunction(f)) {
     }
 

--- a/test/correctness/c_function.cpp
+++ b/test/correctness/c_function.cpp
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
     g(x, y) = my_func(x, cast<float>(y));
 
     Pipeline p(g);
-    p.set_jit_externs({{"my_func", my_func2}});
+    p.set_jit_externs({{"my_func", JITExtern{my_func2}}});
     Buffer<float> imf2 = p.realize(32, 32);
 
     // Check the result was what we expected
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
     }
 
     // Switch from my_func2 to my_func and verify a recompile happens.
-    p.set_jit_externs({{"my_func", my_func3}});
+    p.set_jit_externs({{"my_func", JITExtern{my_func3}}});
     Buffer<float> imf3 = p.realize(32, 32);
 
     // Check the result was what we expected

--- a/test/correctness/pipeline_set_jit_externs_func.cpp
+++ b/test/correctness/pipeline_set_jit_externs_func.cpp
@@ -19,10 +19,10 @@ HalideExtern_2(float, my_func, int, float);
 int main(int argc, char **argv) {
     // set_jit_externs() implicitly adds a user_context arg to the externs, which
     // we can't yet support
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
-        printf("[SKIP] WebAssembly JIT does not support passing arbitrary pointers to/from HalideExtern code.\n");
-        return 0;
-    }
+    // if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    //     printf("[SKIP] WebAssembly JIT does not support passing arbitrary pointers to/from HalideExtern code.\n");
+    //     return 0;
+    // }
 
     std::vector<ExternFuncArgument> args;
     args.push_back(user_context_value());
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
     f.define_extern("extern_func", args, Float(32), 2);
 
     Pipeline p(f);
-    p.set_jit_externs({{"extern_func", monitor}});
+    p.set_jit_externs({{"extern_func", JITExtern{monitor}}});
     Buffer<float> imf = p.realize(32, 32);
 
     // Check the result was what we expected


### PR DESCRIPTION
- make all single-arg ctors explicit, and add one missing explicit usage
- add an operator<< to ExternSignature to make debugging related issues easier