### PR TITLE
Apply simplify_correlated_differences to comparisons too

### DIFF
--- a/src/SimplifyCorrelatedDifferences.cpp
+++ b/src/SimplifyCorrelatedDifferences.cpp
@@ -172,23 +172,14 @@ class SimplifyCorrelatedDifferences : public IRMutator {
         }
     };
 
-    template<typename T>
-    Expr visit_add_or_sub(const T *op) {
-        if (op->type != Int(32) || loop_var.empty()) {
-            return IRMutator::visit(op);
-        }
-        Expr e = IRMutator::visit(op);
-        op = e.as<T>();
-        if (!op) {
-            return e;
-        }
-        auto ma = is_monotonic(op->a, loop_var, monotonic);
-        auto mb = is_monotonic(op->b, loop_var, monotonic);
+    Expr cancel_correlated_subexpression(Expr e, const Expr &a, const Expr &b, bool correlated) {
+        auto ma = is_monotonic(a, loop_var, monotonic);
+        auto mb = is_monotonic(b, loop_var, monotonic);
 
-        if ((ma == Monotonic::Increasing && mb == Monotonic::Increasing && std::is_same<T, Sub>::value) ||
-            (ma == Monotonic::Decreasing && mb == Monotonic::Decreasing && std::is_same<T, Sub>::value) ||
-            (ma == Monotonic::Increasing && mb == Monotonic::Decreasing && std::is_same<T, Add>::value) ||
-            (ma == Monotonic::Decreasing && mb == Monotonic::Increasing && std::is_same<T, Add>::value)) {
+        if ((ma == Monotonic::Increasing && mb == Monotonic::Increasing && correlated) ||
+            (ma == Monotonic::Decreasing && mb == Monotonic::Decreasing && correlated) ||
+            (ma == Monotonic::Increasing && mb == Monotonic::Decreasing && !correlated) ||
+            (ma == Monotonic::Decreasing && mb == Monotonic::Increasing && !correlated)) {
 
             for (auto it = lets.rbegin(); it != lets.rend(); it++) {
                 if (expr_uses_var(e, it->name)) {
@@ -222,12 +213,67 @@ class SimplifyCorrelatedDifferences : public IRMutator {
         return e;
     }
 
-    Expr visit(const Sub *op) override {
-        return visit_add_or_sub(op);
+    template<typename T>
+    Expr visit_binop(const T *op, bool correlated) {
+        Expr e = IRMutator::visit(op);
+        op = e.as<T>();
+        if (op == nullptr ||
+            op->a.type() != Int(32) ||
+            loop_var.empty()) {
+            return e;
+        } else {
+            // Bury the logic that doesn't depend on the template
+            // parameter in a separate function to save code size and
+            // reduce stack frame size in the recursive path.
+            return cancel_correlated_subexpression(e, op->a, op->b, correlated);
+        }
     }
 
+    // Binary ops where it pays to cancel a correlated term on both
+    // sides. E.g. consider the x in:
+    //
+    // (x*3 + y)*2 - max(x*6, 0)))
+    //
+    // Both sides increase monotonically with x so interval arithmetic
+    // will overestimate the bounds. If we subtract x*6 from both
+    // sides we get:
+    //
+    // y*2 - max(0, x*-6)
+    //
+    // Now only one side depends on x and interval arithmetic becomes
+    // exact.
+    Expr visit(const Sub *op) override {
+        return visit_binop(op, true);
+    }
+
+    Expr visit(const LT *op) override {
+        return visit_binop(op, true);
+    }
+
+    Expr visit(const LE *op) override {
+        return visit_binop(op, true);
+    }
+
+    Expr visit(const GT *op) override {
+        return visit_binop(op, true);
+    }
+
+    Expr visit(const GE *op) override {
+        return visit_binop(op, true);
+    }
+
+    Expr visit(const EQ *op) override {
+        return visit_binop(op, true);
+    }
+
+    Expr visit(const NE *op) override {
+        return visit_binop(op, true);
+    }
+
+    // For add you actually want to cancel any anti-correlated term
+    // (e.g. x in (x*3 + y)*2 + max(x*-6, 0))
     Expr visit(const Add *op) override {
-        return visit_add_or_sub(op);
+        return visit_binop(op, false);
     }
 };
 


### PR DESCRIPTION
GuardWithIf conditions can include comparisons with correlated values on
each side, e.g. `((x*8) + y)*2 + z <= x*16`. It's worth cancelling them -
in one case @aekul found it avoids an if statement tree in an unrolled
block.

This would be a fairly trivial change by itself, but I did some light
refactoring while I was there to avoid blowing up the number of template
instantiations.