### PR TITLE
Permit loop partitioning for serial loops on GPU

### DIFF
--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -491,8 +491,8 @@ class PartitionLoops : public IRMutator {
                                                            CodeGen_GPU_Dev::is_gpu_var(op->name));
 
         // If we're inside GPU kernel, and the body contains thread
-        // barriers or warp shuffles, it's not safe to duplicate code.
-        if (in_gpu_loop && contains_warp_synchronous_logic(op)) {
+        // barriers or warp shuffles, it's not safe to partition parallel loops.
+        if (is_parallel(op->for_type) && in_gpu_loop && contains_warp_synchronous_logic(op)) {
             return IRMutator::visit(op);
         }
 


### PR DESCRIPTION
We don't partition loops (e.g. to peel off tail cases) on GPU if there's
a barrier or warp synchronous thing going on, because it may result in
different threads hitting different barriers and expecting to
synchronize with each other. But this is only an issue if the loop we're
partitioning is a parallel one (i.e. a threads loop). If it's serial,
there's no change in the semantics and duplicating the barrier is fine.
In the extreme case it's legal to entirely unroll the loop, duplicating
the barrier N times.

I.e. this transformation is bad:

Before:
```
gpu_threads x in [0, 15]:
  serial y in [0, 8]:
    barrier
```
After:
```
gpu_threads x in [0, 7]:
  serial y in [0, 8]:
    barrier
gpu_threads x in [8, 15]:
  serial y in [0, 8]:
    barrier
```
But this is fine:

Before:
```
gpu_threads x in [0, 15]:
  serial y in [0, 8]:
    barrier
```

After:
```
gpu_threads x in [0, 15]:
  serial y in [0, 4]:
    barrier
  serial y in [5, 8]:
    barrier
```

@shoaibkamil does this logic sound right to you?