### PR TITLE
Add support to build and run on Apple silicon

### DIFF
--- a/cmake/HalideTestHelpers.cmake
+++ b/cmake/HalideTestHelpers.cmake
@@ -23,17 +23,6 @@ if (NOT TARGET Halide::Test)
                                INTERFACE
                                ${Halide_SOURCE_DIR}/test/common
                                ${Halide_SOURCE_DIR}/tools)
-
-    # Tests are built with the equivalent of OPTIMIZE_FOR_BUILD_TIME (-O0 or /Od).
-    # Also allow tests, via conditional compilation, to use the entire
-    # capability of the CPU being compiled on via -march=native if the
-    # the compiler supports it. This also presumes tests are run on the
-    # same machine they are compiled on.
-    target_compile_options(Halide_test INTERFACE
-                           $<$<CXX_COMPILER_ID:MSVC>:/Od>
-                           $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-O0>
-                           $<$<CXX_COMPILER_ID:Intel>:-march=native>
-                           $<$<CXX_COMPILER_ID:GNU>:-march=native>)
 endif ()
 
 if (NOT TARGET Halide::ExpectAbort)

--- a/cmake/HalideTestHelpers.cmake
+++ b/cmake/HalideTestHelpers.cmake
@@ -26,12 +26,14 @@ if (NOT TARGET Halide::Test)
 
     # Tests are built with the equivalent of OPTIMIZE_FOR_BUILD_TIME (-O0 or /Od).
     # Also allow tests, via conditional compilation, to use the entire
-    # capability of the CPU being compiled on via -march=native. This
-    # presumes tests are run on the same machine they are compiled on.
+    # capability of the CPU being compiled on via -march=native if the
+    # the compiler supports it. This also presumes tests are run on the
+    # same machine they are compiled on.
     target_compile_options(Halide_test INTERFACE
                            $<$<CXX_COMPILER_ID:MSVC>:/Od>
                            $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-O0>
-                           $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-march=native>)
+                           $<$<CXX_COMPILER_ID:Intel>:-march=native>
+                           $<$<CXX_COMPILER_ID:GNU>:-march=native>)
 endif ()
 
 if (NOT TARGET Halide::ExpectAbort)

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1244,6 +1244,8 @@ string CodeGen_ARM::mcpu() const {
     } else {
         if (target.os == Target::IOS) {
             return "cyclone";
+        } else if (target.os == Target::OSX) {
+            return "apple-a12";
         } else {
             return "generic";
         }

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -344,6 +344,8 @@ llvm::DataLayout get_data_layout_for_target(Target target) {
         } else {  // 64-bit
             if (target.os == Target::IOS) {
                 return llvm::DataLayout("e-m:o-i64:64-i128:128-n32:64-S128");
+            } else if (target.os == Target::OSX) {
+                return llvm::DataLayout("e-m:o-i64:64-i128:128-n32:64-S128");
             } else if (target.os == Target::Windows) {
                 return llvm::DataLayout("e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128");
             } else {
@@ -461,6 +463,10 @@ llvm::Triple get_triple_for_target(const Target &target) {
             }
         } else if (target.os == Target::Fuchsia) {
             triple.setOS(llvm::Triple::Fuchsia);
+        } else if (target.os == Target::OSX) {
+            triple.setVendor(llvm::Triple::Apple);
+            triple.setOS(llvm::Triple::MacOSX);
+            triple.setArchName("arm64");
         } else if (target.os == Target::NoOS) {
             // For bare-metal environments
 


### PR DESCRIPTION
Changes necessary to run successfully on Apple silicon.

If you'd like any adjustments or have feedback please let us know!

```
% xcrun cmake -DCMAKE_BUILD_TYPE=Release \
  -DLLVM_DIR=/Users/deco/Documents/llvm-install/lib/cmake/llvm \
  -DCMAKE_CXX_FLAGS='-arch arm64' -DCMAKE_C_FLAGS='-arch arm64' \
  ../Halide
% xcrun cmake --build . -- -j8

% file src/libHalide.dylib 
src/libHalide.dylib: Mach-O 64-bit dynamically linked shared library arm64

% file src/libHalide.dylib 
src/libHalide.dylib: Mach-O 64-bit dynamically linked shared library arm64
% file test/correctness/correctness_gameoflife 
test/correctness/correctness_gameoflife: Mach-O 64-bit executable arm64
% test/correctness/correctness_gameoflife     
Success!
% test/performance/performance_jit_stress 
Success!
% test/performance/performance_memcpy 
Success!
```