### PR TITLE
Remove march=native from tests build

### DIFF
--- a/cmake/HalideTestHelpers.cmake
+++ b/cmake/HalideTestHelpers.cmake
@@ -23,15 +23,6 @@ if (NOT TARGET Halide::Test)
                                INTERFACE
                                ${Halide_SOURCE_DIR}/test/common
                                ${Halide_SOURCE_DIR}/tools)
-
-    # Tests are built with the equivalent of OPTIMIZE_FOR_BUILD_TIME (-O0 or /Od).
-    # Also allow tests, via conditional compilation, to use the entire
-    # capability of the CPU being compiled on via -march=native. This
-    # presumes tests are run on the same machine they are compiled on.
-    target_compile_options(Halide_test INTERFACE
-                           $<$<CXX_COMPILER_ID:MSVC>:/Od>
-                           $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-O0>
-                           $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-march=native>)
 endif ()
 
 if (NOT TARGET Halide::ExpectAbort)


### PR DESCRIPTION
This breaks cross compiling on Apple Silicon and probably elsewhere, too. See PR #5073

Also removing disable-optimization flags here. @steven-johnson and I think it's unimportant and it just makes the build have more weird edge cases.