### PR TITLE
Add COMDATs to mergable symbols on windows

### DIFF
--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -611,6 +611,15 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t,
                 convert_weak_to_linkonce(f);
             }
         }
+
+        // Windows requires every symbol that's going to get merged
+        // has a comdat that specifies how. The linkage type alone
+        // isn't enough.
+        if (t.os == Target::Windows && f.isWeakForLinker()) {
+            llvm::Comdat *comdat = modules[0]->getOrInsertComdat(f_name);
+            comdat->setSelectionKind(llvm::Comdat::Any);
+            f.setComdat(comdat);
+        }
     }
 
     // Now remove the force-usage global that prevented clang from


### PR DESCRIPTION
Should fix the build for win-32-trunk

Having a linkonce linkage type on windows without an associated comdat to let the linker know it can pick anything produces linker errors with missing symbols. This was not previously a problem on windows because llvm just emitted linkonce symbols as extern.