### PR TITLE
Restrict total reductions to llvm 10+ to workaround arm issue

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -4347,7 +4347,7 @@ void CodeGen_LLVM::codegen_vector_reduce(const VectorReduce *op, const Expr &ini
         return;
     }
 
-#if LLVM_VERSION >= 90
+#if LLVM_VERSION >= 100
     if (output_lanes == 1) {
         const int input_lanes = val.type().lanes();
         const int input_bytes = input_lanes * val.type().bytes();


### PR DESCRIPTION
I believe this is the remaining piece to fix #5081 