### PR TITLE
Always cast objc_msgSend()

### DIFF
--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -46,7 +46,7 @@ WEAK mtl_command_queue *new_command_queue(mtl_device *device) {
 
 WEAK mtl_command_buffer *new_command_buffer(mtl_command_queue *queue, const char *label, size_t label_len) {
     objc_id label_str = wrap_string_as_ns_string(label, label_len);
-    
+
     typedef mtl_command_buffer *(*new_command_buffer_method)(objc_id queue, objc_sel sel);
     new_command_buffer_method method = (new_command_buffer_method)&objc_msgSend;
     mtl_command_buffer *command_buffer = (mtl_command_buffer *)(*method)(queue, sel_getUid("commandBuffer"));
@@ -144,7 +144,7 @@ WEAK void buffer_to_buffer_1d_copy(mtl_blit_command_encoder *encoder,
                                    mtl_buffer *to, size_t to_offset,
                                    size_t size) {
     typedef void (*copy_from_buffer_method)(objc_id obj, objc_sel sel, objc_id src_buf, size_t s_offset,
-                                           objc_id dst_buf, size_t d_offset, size_t s);
+                                            objc_id dst_buf, size_t d_offset, size_t s);
     copy_from_buffer_method method = (copy_from_buffer_method)&objc_msgSend;
     (*method)(encoder, sel_getUid("copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:"),
               from, from_offset, to, to_offset, size);
@@ -153,7 +153,8 @@ WEAK void buffer_to_buffer_1d_copy(mtl_blit_command_encoder *encoder,
 WEAK void end_encoding(mtl_blit_command_encoder *encoder) {
     typedef void (*end_encoding_method)(objc_id encoder, objc_sel sel);
     end_encoding_method method = (end_encoding_method)&objc_msgSend;
-    (*method)(encoder, sel_getUid("endEncoding"));}
+    (*method)(encoder, sel_getUid("endEncoding"));
+}
 
 WEAK bool buffer_supports_set_bytes(mtl_compute_command_encoder *encoder) {
     typedef bool (*responds_to_selector_method)(objc_id obj, objc_sel sel_1, objc_sel sel_2);
@@ -168,7 +169,7 @@ WEAK mtl_library *new_library_with_source(mtl_device *device, const char *source
 
     typedef objc_id (*options_method)(objc_id obj, objc_sel sel);
     options_method method = (options_method)&objc_msgSend;
-    
+
     objc_id options = (*method)(objc_getClass("MTLCompileOptions"), sel_getUid("alloc"));
     options = (*method)(options, sel_getUid("init"));
     typedef void (*set_fast_math_method)(objc_id options, objc_sel sel, uint8_t flag);

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -39,13 +39,17 @@ WEAK mtl_buffer *new_buffer(mtl_device *device, size_t length) {
 }
 
 WEAK mtl_command_queue *new_command_queue(mtl_device *device) {
-    return (mtl_command_queue *)objc_msgSend(device, sel_getUid("newCommandQueue"));
+    typedef mtl_command_queue *(*new_command_queue_method)(objc_id dev, objc_sel sel);
+    new_command_queue_method method = (new_command_queue_method)&objc_msgSend;
+    return (mtl_command_queue *)(*method)(device, sel_getUid("newCommandQueue"));
 }
 
 WEAK mtl_command_buffer *new_command_buffer(mtl_command_queue *queue, const char *label, size_t label_len) {
     objc_id label_str = wrap_string_as_ns_string(label, label_len);
-
-    mtl_command_buffer *command_buffer = (mtl_command_buffer *)objc_msgSend(queue, sel_getUid("commandBuffer"));
+    
+    typedef mtl_command_buffer *(*new_command_buffer_method)(objc_id queue, objc_sel sel);
+    new_command_buffer_method method = (new_command_buffer_method)&objc_msgSend;
+    mtl_command_buffer *command_buffer = (mtl_command_buffer *)(*method)(queue, sel_getUid("commandBuffer"));
 
     typedef void (*set_label_method)(objc_id command_buffer, objc_sel sel, objc_id label_string);
     set_label_method method1 = (set_label_method)&objc_msgSend;
@@ -62,15 +66,21 @@ WEAK void add_command_buffer_completed_handler(mtl_command_buffer *command_buffe
 }
 
 WEAK objc_id command_buffer_error(mtl_command_buffer *buffer) {
-    return objc_msgSend(buffer, sel_getUid("error"));
+    typedef objc_id (*error_method)(objc_id buf, objc_sel sel);
+    error_method method = (error_method)&objc_msgSend;
+    return (*method)(buffer, sel_getUid("error"));
 }
 
 WEAK mtl_compute_command_encoder *new_compute_command_encoder(mtl_command_buffer *buffer) {
-    return (mtl_compute_command_encoder *)objc_msgSend(buffer, sel_getUid("computeCommandEncoder"));
+    typedef mtl_compute_command_encoder *(*compute_command_encoder_method)(objc_id buf, objc_sel sel);
+    compute_command_encoder_method method = (compute_command_encoder_method)&objc_msgSend;
+    return (mtl_compute_command_encoder *)(*method)(buffer, sel_getUid("computeCommandEncoder"));
 }
 
 WEAK mtl_blit_command_encoder *new_blit_command_encoder(mtl_command_buffer *buffer) {
-    return (mtl_blit_command_encoder *)objc_msgSend(buffer, sel_getUid("blitCommandEncoder"));
+    typedef mtl_blit_command_encoder *(*blit_command_encoder_method)(objc_id buf, objc_sel sel);
+    blit_command_encoder_method method = (blit_command_encoder_method)&objc_msgSend;
+    return (mtl_blit_command_encoder *)(*method)(buffer, sel_getUid("blitCommandEncoder"));
 }
 
 WEAK mtl_compute_pipeline_state *new_compute_pipeline_state_with_function(mtl_device *device, mtl_function *function) {
@@ -94,7 +104,9 @@ WEAK void set_compute_pipeline_state(mtl_compute_command_encoder *encoder, mtl_c
 }
 
 WEAK void end_encoding(mtl_compute_command_encoder *encoder) {
-    objc_msgSend(encoder, sel_getUid("endEncoding"));
+    typedef void (*end_encoding_method)(objc_id encoder, objc_sel sel);
+    end_encoding_method method = (end_encoding_method)&objc_msgSend;
+    (*method)(encoder, sel_getUid("endEncoding"));
 }
 
 struct NSRange {
@@ -131,13 +143,17 @@ WEAK void buffer_to_buffer_1d_copy(mtl_blit_command_encoder *encoder,
                                    mtl_buffer *from, size_t from_offset,
                                    mtl_buffer *to, size_t to_offset,
                                    size_t size) {
-    objc_msgSend(encoder, sel_getUid("copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:"),
-                 from, from_offset, to, to_offset, size);
+    typedef void (*copy_from_buffer_method)(objc_id obj, objc_sel sel, objc_id src_buf, size_t s_offset,
+                                           objc_id dst_buf, size_t d_offset, size_t s);
+    copy_from_buffer_method method = (copy_from_buffer_method)&objc_msgSend;
+    (*method)(encoder, sel_getUid("copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:"),
+              from, from_offset, to, to_offset, size);
 }
 
 WEAK void end_encoding(mtl_blit_command_encoder *encoder) {
-    objc_msgSend(encoder, sel_getUid("endEncoding"));
-}
+    typedef void (*end_encoding_method)(objc_id encoder, objc_sel sel);
+    end_encoding_method method = (end_encoding_method)&objc_msgSend;
+    (*method)(encoder, sel_getUid("endEncoding"));}
 
 WEAK bool buffer_supports_set_bytes(mtl_compute_command_encoder *encoder) {
     typedef bool (*responds_to_selector_method)(objc_id obj, objc_sel sel_1, objc_sel sel_2);
@@ -150,8 +166,11 @@ WEAK mtl_library *new_library_with_source(mtl_device *device, const char *source
     objc_id error_return;
     objc_id source_str = wrap_string_as_ns_string(source, source_len);
 
-    objc_id options = objc_msgSend(objc_getClass("MTLCompileOptions"), sel_getUid("alloc"));
-    options = objc_msgSend(options, sel_getUid("init"));
+    typedef objc_id (*options_method)(objc_id obj, objc_sel sel);
+    options_method method = (options_method)&objc_msgSend;
+    
+    objc_id options = (*method)(objc_getClass("MTLCompileOptions"), sel_getUid("alloc"));
+    options = (*method)(options, sel_getUid("init"));
     typedef void (*set_fast_math_method)(objc_id options, objc_sel sel, uint8_t flag);
     set_fast_math_method method1 = (set_fast_math_method)&objc_msgSend;
     (*method1)(options, sel_getUid("setFastMathEnabled:"), false);
@@ -205,15 +224,21 @@ WEAK void set_threadgroup_memory_length(mtl_compute_command_encoder *encoder, ui
 }
 
 WEAK void commit_command_buffer(mtl_command_buffer *buffer) {
-    objc_msgSend(buffer, sel_getUid("commit"));
+    typedef void (*commit_method)(objc_id buf, objc_sel sel);
+    commit_method method = (commit_method)&objc_msgSend;
+    (*method)(buffer, sel_getUid("commit"));
 }
 
 WEAK void wait_until_completed(mtl_command_buffer *buffer) {
-    objc_msgSend(buffer, sel_getUid("waitUntilCompleted"));
+    typedef void (*wait_until_completed_method)(objc_id buf, objc_sel sel);
+    wait_until_completed_method method = (wait_until_completed_method)&objc_msgSend;
+    (*method)(buffer, sel_getUid("waitUntilCompleted"));
 }
 
 WEAK void *buffer_contents(mtl_buffer *buffer) {
-    return objc_msgSend(buffer, sel_getUid("contents"));
+    typedef void *(*contents_method)(objc_id buf, objc_sel sel);
+    contents_method method = (contents_method)&objc_msgSend;
+    return (void *)(*method)(buffer, sel_getUid("contents"));
 }
 
 WEAK void *nsarray_first_object(objc_id arr) {

--- a/src/runtime/objc_support.h
+++ b/src/runtime/objc_support.h
@@ -6,6 +6,12 @@ typedef void *objc_id;
 typedef void *objc_sel;
 extern objc_id objc_getClass(const char *name);
 extern objc_sel sel_getUid(const char *string);
+
+// Recent versions of macOS have changed the signature
+// for objc_msgSend(), since its implementation is ABI-dependent.
+// With this signature, users must always cast the call to the
+// correct function type, and any misuses will be caught at
+// compile time.
 extern void objc_msgSend(void);
 
 void NSLog(objc_id /* NSString * */ format, ...);

--- a/src/runtime/objc_support.h
+++ b/src/runtime/objc_support.h
@@ -10,8 +10,26 @@ extern objc_sel sel_getUid(const char *string);
 // Recent versions of macOS have changed the signature
 // for objc_msgSend(), since its implementation is ABI-dependent.
 // With this signature, users must always cast the call to the
-// correct function type, and any misuses will be caught at
-// compile time.
+// correct function type, and any calls without casting to the right
+// function type will be caught at compile time.
+//
+// A good explanation of why is here: https://www.mikeash.com/pyblog/objc_msgsends-new-prototype.html
+//
+// The TL;DR is that objc_msgSend is special in that what it does is not touch
+// the registers at all and 1) loads the ObjC class corresponding to the object, 2)
+// looks up the selector in the class’s method cache, and 3) jumps to the location of
+// the method if it’s in the cache. objc_msgSend takes as parameters an object,
+// the method selector, then all the other parameters to the method; when it
+// jumps to the method implementation, it's as if the method implementation was called
+// directly.
+// C doesn’t have a way to express this kind of function: the method implementation (usually) uses the ABI
+// calling convention for a normal non-variadic function, but the C prototype for
+// this has to be variadic. That used to be okay(ish) on x64 because the variadic and
+// normal conventions are basically the same, but on ARM a variadic function passes
+// all params on the stack, which would be a huge amount of overhead given how many
+// times its called (every single method invocation in ObjC).
+// The other problem with using a variadic signature is that C does type promotion on a variadic
+// call.
 extern void objc_msgSend(void);
 
 void NSLog(objc_id /* NSString * */ format, ...);

--- a/src/runtime/objc_support.h
+++ b/src/runtime/objc_support.h
@@ -6,7 +6,7 @@ typedef void *objc_id;
 typedef void *objc_sel;
 extern objc_id objc_getClass(const char *name);
 extern objc_sel sel_getUid(const char *string);
-extern objc_id objc_msgSend(void);
+extern void objc_msgSend(void);
 
 void NSLog(objc_id /* NSString * */ format, ...);
 }

--- a/src/runtime/objc_support.h
+++ b/src/runtime/objc_support.h
@@ -6,7 +6,7 @@ typedef void *objc_id;
 typedef void *objc_sel;
 extern objc_id objc_getClass(const char *name);
 extern objc_sel sel_getUid(const char *string);
-extern objc_id objc_msgSend(objc_id self, objc_sel op, ...);
+extern objc_id objc_msgSend(void);
 
 void NSLog(objc_id /* NSString * */ format, ...);
 }
@@ -16,28 +16,36 @@ namespace Runtime {
 namespace Internal {
 
 WEAK objc_id create_autorelease_pool() {
-    objc_id pool =
-        objc_msgSend(objc_msgSend(objc_getClass("NSAutoreleasePool"),
-                                  sel_getUid("alloc")),
-                     sel_getUid("init"));
+    typedef objc_id (*pool_method)(objc_id obj, objc_sel sel);
+    pool_method method = (pool_method)&objc_msgSend;
+    objc_id pool = (*method)(objc_getClass("NSAutoreleasePool"), sel_getUid("alloc"));
+    pool = (*method)(pool, sel_getUid("init"));
     return pool;
 }
 
 WEAK void drain_autorelease_pool(objc_id pool) {
-    objc_msgSend(pool, sel_getUid("drain"));
+    typedef objc_id (*drain_method)(objc_id obj, objc_sel sel);
+    drain_method method = (drain_method)&objc_msgSend;
+    (*method)(pool, sel_getUid("drain"));
 }
 
 WEAK void retain_ns_object(objc_id obj) {
-    objc_msgSend(obj, sel_getUid("retain"));
+    typedef objc_id (*retain_method)(objc_id obj, objc_sel sel);
+    retain_method method = (retain_method)&objc_msgSend;
+    (*method)(obj, sel_getUid("retain"));
 }
 
 WEAK void release_ns_object(objc_id obj) {
-    objc_msgSend(obj, sel_getUid("release"));
+    typedef objc_id (*release_method)(objc_id obj, objc_sel sel);
+    release_method method = (release_method)&objc_msgSend;
+    (*method)(obj, sel_getUid("release"));
 }
 
 WEAK objc_id wrap_string_as_ns_string(const char *string, size_t length) {
     typedef objc_id (*init_with_bytes_no_copy_method)(objc_id ns_string, objc_sel sel, const char *string, size_t length, size_t encoding, uint8_t freeWhenDone);
-    objc_id ns_string = objc_msgSend(objc_getClass("NSString"), sel_getUid("alloc"));
+    typedef objc_id (*alloc_method)(objc_id objc, objc_sel sel);
+    alloc_method method1 = (alloc_method)&objc_msgSend;
+    objc_id ns_string = (*method1)(objc_getClass("NSString"), sel_getUid("alloc"));
     init_with_bytes_no_copy_method method = (init_with_bytes_no_copy_method)&objc_msgSend;
     return (*method)(ns_string, sel_getUid("initWithBytesNoCopy:length:encoding:freeWhenDone:"),
                      string, length, 4, 0);


### PR DESCRIPTION
On macOS 10.15 and later, the prototype for `objc_msgSend()` changed to force code to always cast before using, since the implementation is ABI-dependent (see [Apple's docs](https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend), [Mike Ash's explanation](https://www.mikeash.com/pyblog/objc_msgsends-new-prototype.html), [Daniel Jalkut's](https://www.mikeash.com/pyblog/objc_msgsends-new-prototype.html), etc.)

This PR changes all our runtime uses to cast method calls to the right type before using, and fixes a runtime error on macOS 11 beta.  This should have no impact on previous versions of macOS and iOS; I've confirmed current iOS works as well as macOS 10.15.5; I believe the buildbot should confirm compatibility for older macOS.