### PR TITLE
cmake: python: use system pybind11 if installed

### DIFF
--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -7,16 +7,20 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 # Adding PyBind11 to the build is the recommended way of integrating with CMake.
 # See: https://pybind11.readthedocs.io/en/stable/compiling.html
 
-# Keep the version in sync with requirements.txt and the Ubuntu 20.04 LTS package (python3-pybind11)
-include(FetchContent)
-FetchContent_Declare(pybind11 GIT_REPOSITORY https://github.com/pybind/pybind11.git GIT_TAG v2.4.3)
-
 # Configure pybind11 to use the same interpreter version as was detected above.
 message(STATUS "Directing pybind11 to Python3 executable ${Python3_EXECUTABLE}")
 set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 
-# Import PyBind11
-FetchContent_MakeAvailable(pybind11)
+# Keep the version in sync with requirements.txt and the Ubuntu 20.04 LTS package (python3-pybind11)
+set(PYBIND11_VER 2.4.3)
+find_package(pybind11 ${PYBIND11_VER} QUIET)
+if (NOT pybind11_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(pybind11
+                         GIT_REPOSITORY https://github.com/pybind/pybind11.git
+                         GIT_TAG v${PYBIND11_VER})
+    FetchContent_MakeAvailable(pybind11)
+endif ()
 
 ##
 # Add our sources to this sub-tree.


### PR DESCRIPTION
Fixes builds on offline hosts (common on HPC clusters), which otherwise
fail with failure to fetch pybind11 from the Internet, introduced in
c13efffcc9e282d14c21a5149e4bdee078c85a9c:

	CMake Error at
	pybind11-subbuild/pybind11-populate-prefix/tmp/pybind11-populate-gitclone.cmake:31
	(message):
	  Failed to clone repository: 'https://github.com/pybind/pybind11.git'

Also, make build friendly to distribution packages.  Distribution
package recipe should be in control of (1) dependencies to build against
(e.g. some distros are on pybind11 2.5, and it should be used unless
it's incompatible), and (2) when fetching happens vs when building
happens. So, there is a need for a packager-friendly build mode where
the build system doesn't go out and fetch whatever dependencies it
chooses whenever it chooses. This patch gives priority to the system
pybind11 with fallback to fetching.

An alternative (if you prefer) would be to keep fetch as the default, and add a flag for distributions to use: -DWITH_SYSTEM_PYBIND11 (default OFF).