### PR TITLE
Add simplifier rules for some combinations of select and min/max

### DIFF
--- a/src/Simplify_Max.cpp
+++ b/src/Simplify_Max.cpp
@@ -126,6 +126,12 @@ Expr Simplify::visit(const Max *op, ExprInfo *bounds) {
              rewrite(max(min(max(y, x), z), y), max(y, min(x, z))) ||
              rewrite(max(max(x, c0), c1), max(x, fold(max(c0, c1)))) ||
 
+             rewrite(max(x, select(x == c0, c1, x)), select(x == c0, c1, x), c0 < c1) ||
+             rewrite(max(x, select(x == c0, c1, x)), x, c1 <= c0) ||
+             rewrite(max(select(x == c0, c1, x), c2), max(x, c2), (c0 <= c2) && (c1 <= c2)) ||
+             rewrite(max(select(x == c0, c1, x), x), select(x == c0, c1, x), c0 < c1) ||
+             rewrite(max(select(x == c0, c1, x), x), x, c1 <= c0) ||
+
              (no_overflow(op->type) &&
               (rewrite(max(max(x, y) + c0, x), max(x, y + c0), c0 < 0) ||
                rewrite(max(max(x, y) + c0, x), max(x, y) + c0, c0 > 0) ||

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -129,6 +129,12 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
              // Canonicalize a clamp
              rewrite(min(max(x, c0), c1), max(min(x, c1), c0), c0 <= c1) ||
 
+             rewrite(min(x, select(x == c0, c1, x)), select(x == c0, c1, x), c1 < c0) ||
+             rewrite(min(x, select(x == c0, c1, x)), x, c0 <= c1) ||
+             rewrite(min(select(x == c0, c1, x), c2), min(x, c2), (c2 <= c0) && (c2 <= c1)) ||
+             rewrite(min(select(x == c0, c1, x), x), select(x == c0, c1, x), c1 < c0) ||
+             rewrite(min(select(x == c0, c1, x), x), x, c0 <= c1) ||
+
              (no_overflow(op->type) &&
               (rewrite(min(min(x, y) + c0, x), min(x, y + c0), c0 > 0) ||
                rewrite(min(min(x, y) + c0, x), min(x, y) + c0, c0 < 0) ||

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1202,6 +1202,14 @@ void check_boolean() {
     check(select(x < 5, select(x < 5, 0, 1), 2), select(x < 5, 0, 2));
     check(select(x < 5, 0, select(x < 5, 1, 2)), select(x < 5, 0, 2));
 
+    check(max(select((x == -1), 1, x), 6), max(x, 6));
+    check(max(select((x == -1), 1, x), x), select((x == -1), 1, x));
+    check(max(select((x == 17), 1, x), x), x);
+
+    check(min(select((x == 1), -1, x), -6), min(x, -6));
+    check(min(select((x == 1), -1, x), x), select((x == 1), -1, x));
+    check(min(select((x == -17), -1, x), x), x);
+
     check((1 - xf) * 6 < 3, 0.5f < xf);
 
     check(!f, t);


### PR DESCRIPTION
Fixes #5100

Formally verified, but not synthesized (predicate synthesis failed, so I had to come up with predicates by hand and check them).