### PR TITLE
Add meta-targets to CMake to replicate some Make functionality

### DIFF
--- a/cmake/HalideTestHelpers.cmake
+++ b/cmake/HalideTestHelpers.cmake
@@ -52,6 +52,18 @@ function(add_halide_test TARGET)
     if (${args_EXPECT_FAILURE})
         set_tests_properties(${TARGET} PROPERTIES WILL_FAIL true)
     endif ()
+
+    # Add a meta-target for each group, to allow us to build by group easily
+    if (args_GROUPS)
+        foreach (GROUP IN LISTS args_GROUPS)
+            set(META_TARGET build_${GROUP})
+            if (NOT TARGET ${META_TARGET})
+                add_custom_target(${META_TARGET})
+            endif ()
+            add_dependencies(${META_TARGET} ${TARGET})
+        endforeach ()
+    endif()
+
 endfunction()
 
 function(tests)

--- a/cmake/HalideTestHelpers.cmake
+++ b/cmake/HalideTestHelpers.cmake
@@ -54,15 +54,13 @@ function(add_halide_test TARGET)
     endif ()
 
     # Add a meta-target for each group, to allow us to build by group easily
-    if (args_GROUPS)
-        foreach (GROUP IN LISTS args_GROUPS)
-            set(META_TARGET build_${GROUP})
-            if (NOT TARGET ${META_TARGET})
-                add_custom_target(${META_TARGET})
-            endif ()
-            add_dependencies(${META_TARGET} ${TARGET})
-        endforeach ()
-    endif()
+    foreach (GROUP IN LISTS args_GROUPS)
+        set(META_TARGET build_${GROUP})
+        if (NOT TARGET ${META_TARGET})
+            add_custom_target(${META_TARGET})
+        endif ()
+        add_dependencies(${META_TARGET} ${TARGET})
+    endforeach ()
 
 endfunction()
 


### PR DESCRIPTION
For each test group (eg 'generator') this adds a build metatarget named 'build_$GROUP'; this allows a simpler way to rebuild everything in a test group prior to running ctest.