### PR TITLE
Update many tests for WASM

### DIFF
--- a/test/auto_schedule/cost_function.cpp
+++ b/test/auto_schedule/cost_function.cpp
@@ -3,6 +3,10 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Mullapudi2016 autoscheduler does not support WebAssembly.\n");
+        return 0;
+    }
 
     int W = 6400;
     int H = 4800;

--- a/test/auto_schedule/data_dependent.cpp
+++ b/test/auto_schedule/data_dependent.cpp
@@ -3,6 +3,11 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Mullapudi2016 autoscheduler does not support WebAssembly.\n");
+        return 0;
+    }
+
     int W = 800;
     int H = 800;
     Buffer<uint16_t> input(W, H);

--- a/test/auto_schedule/extern.cpp
+++ b/test/auto_schedule/extern.cpp
@@ -127,6 +127,11 @@ void test_case_3() {
 }
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Mullapudi2016 autoscheduler does not support WebAssembly.\n");
+        return 0;
+    }
+
     test_case_1();
     test_case_2();
     test_case_3();

--- a/test/auto_schedule/fibonacci.cpp
+++ b/test/auto_schedule/fibonacci.cpp
@@ -38,6 +38,11 @@ double run_test(bool auto_schedule) {
 }
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Mullapudi2016 autoscheduler does not support WebAssembly.\n");
+        return 0;
+    }
+
     double manual_time = run_test(false);
     double auto_time = run_test(true);
 

--- a/test/auto_schedule/histogram.cpp
+++ b/test/auto_schedule/histogram.cpp
@@ -119,6 +119,11 @@ double run_test(bool auto_schedule) {
 }
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Mullapudi2016 autoscheduler does not support WebAssembly.\n");
+        return 0;
+    }
+
     double manual_time = run_test(false);
     double auto_time = run_test(true);
 

--- a/test/auto_schedule/large_window.cpp
+++ b/test/auto_schedule/large_window.cpp
@@ -3,6 +3,11 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Mullapudi2016 autoscheduler does not support WebAssembly.\n");
+        return 0;
+    }
+
     int W = 800;
     int H = 1200;
 

--- a/test/auto_schedule/mat_mul.cpp
+++ b/test/auto_schedule/mat_mul.cpp
@@ -122,6 +122,11 @@ double run_test(bool auto_schedule) {
 }
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Mullapudi2016 autoscheduler does not support WebAssembly.\n");
+        return 0;
+    }
+
     double manual_time = run_test(false);
     double auto_time = run_test(true);
 

--- a/test/auto_schedule/max_filter.cpp
+++ b/test/auto_schedule/max_filter.cpp
@@ -122,6 +122,11 @@ double run_test(bool auto_schedule) {
 }
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Mullapudi2016 autoscheduler does not support WebAssembly.\n");
+        return 0;
+    }
+
     double manual_time = run_test(false);
     double auto_time = run_test(true);
 

--- a/test/auto_schedule/multi_output.cpp
+++ b/test/auto_schedule/multi_output.cpp
@@ -3,6 +3,11 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Mullapudi2016 autoscheduler does not support WebAssembly.\n");
+        return 0;
+    }
+
     int W = 1000;
     int H = 1000;
     Buffer<uint16_t> input(W, H);

--- a/test/auto_schedule/overlap.cpp
+++ b/test/auto_schedule/overlap.cpp
@@ -4,6 +4,11 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Mullapudi2016 autoscheduler does not support WebAssembly.\n");
+        return 0;
+    }
+
     Var x("x"), y("y"), xi("xi"), yi("yi");
     Buffer<float> input = lambda(x, y, sin(x) + cos(y) + 1.0f).realize(2200, 2200);
 

--- a/test/auto_schedule/param.cpp
+++ b/test/auto_schedule/param.cpp
@@ -114,6 +114,11 @@ void run_test_4() {
 }
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Mullapudi2016 autoscheduler does not support WebAssembly.\n");
+        return 0;
+    }
+
     std::cout << "Test 1:\n";
     run_test_1();
     std::cout << "Test 2:\n";

--- a/test/auto_schedule/reorder.cpp
+++ b/test/auto_schedule/reorder.cpp
@@ -137,6 +137,11 @@ double run_test_3(bool auto_schedule) {
 }
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Mullapudi2016 autoscheduler does not support WebAssembly.\n");
+        return 0;
+    }
+
     const double slowdown_factor = 6.0;
 
     {

--- a/test/auto_schedule/tile_vs_inline.cpp
+++ b/test/auto_schedule/tile_vs_inline.cpp
@@ -3,6 +3,11 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Mullapudi2016 autoscheduler does not support WebAssembly.\n");
+        return 0;
+    }
+
     int W = 1024;
     int H = 1024;
 

--- a/test/auto_schedule/unused_func.cpp
+++ b/test/auto_schedule/unused_func.cpp
@@ -3,6 +3,11 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Mullapudi2016 autoscheduler does not support WebAssembly.\n");
+        return 0;
+    }
+
     Var x("x"), y("y");
     Func f("f"), g("g"), h("h");
 

--- a/test/auto_schedule/vectorize_var_in_update.cpp
+++ b/test/auto_schedule/vectorize_var_in_update.cpp
@@ -4,6 +4,11 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Mullapudi2016 autoscheduler does not support WebAssembly.\n");
+        return 0;
+    }
+
     // This test is making sure that the auto-scheduler picks the appropriate
     // tail strategy when splitting the var of an update definition.
     // The default tail strategy for this case (i.e. RoundUp) will cause

--- a/test/correctness/atomic_tuples.cpp
+++ b/test/correctness/atomic_tuples.cpp
@@ -18,6 +18,11 @@ public:
 };
 
 int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] Skipping test for WebAssembly as it does not support atomics yet.\n");
+        return 0;
+    }
+
     {
         Func f, g;
         Var x, y;

--- a/test/correctness/atomics.cpp
+++ b/test/correctness/atomics.cpp
@@ -1186,7 +1186,7 @@ void test_async_tuple(const Backend &backend) {
 
 int main(int argc, char **argv) {
     if (get_jit_target_from_environment().arch == Target::WebAssembly) {
-        printf("Skipping test for WebAssembly as it does not support atomics yet.\n");
+        printf("[SKIP] Skipping test for WebAssembly as it does not support atomics yet.\n");
         return 0;
     }
 

--- a/test/correctness/boundary_conditions.cpp
+++ b/test/correctness/boundary_conditions.cpp
@@ -392,6 +392,10 @@ int main(int argc, char **argv) {
         // https://github.com/halide/Halide/issues/2148
         vector_width_max = 4;
     }
+    if (target.arch == Target::WebAssembly) {
+        // The wasm jit is very slow, so shorten this test here.
+        vector_width_max = 8;
+    }
     for (int vector_width = 1; vector_width <= vector_width_max; vector_width *= 2) {
         std::cout << "Testing vector_width: " << vector_width << "\n";
         if (target.has_feature(Target::OpenGLCompute)) {

--- a/test/correctness/extern_consumer.cpp
+++ b/test/correctness/extern_consumer.cpp
@@ -65,11 +65,6 @@ bool check_result() {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
-        printf("[SKIP] WebAssembly JIT does not support passing arbitrary pointers to/from HalideExtern code.\n");
-        return 0;
-    }
-
     // Define a pipeline that dumps some squares to a file using an
     // external consumer stage.
     Func source;

--- a/test/correctness/extern_error.cpp
+++ b/test/correctness/extern_error.cpp
@@ -22,11 +22,6 @@ extern "C" DLLEXPORT void my_halide_error(void *user_context, const char *msg) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
-        printf("[SKIP] WebAssembly JIT does not support passing arbitrary pointers to/from HalideExtern code.\n");
-        return 0;
-    }
-
     std::vector<ExternFuncArgument> args;
     args.push_back(user_context_value());
 

--- a/test/correctness/external_code.cpp
+++ b/test/correctness/external_code.cpp
@@ -11,7 +11,7 @@ using namespace Halide;
 
 int main(int argc, char **argv) {
     if (get_jit_target_from_environment().arch == Target::WebAssembly) {
-        printf("Skipping test for WebAssembly as it does not support ExternalCode::bitcode_wrapper().\n");
+        printf("[SKIP] Skipping test for WebAssembly as it does not support ExternalCode::bitcode_wrapper().\n");
         return 0;
     }
 

--- a/test/correctness/func_wrapper.cpp
+++ b/test/correctness/func_wrapper.cpp
@@ -274,10 +274,13 @@ int rdom_wrapper_test() {
     Func f("f"), g("g"), result("result");
     Var x("x"), y("y");
 
+    constexpr int W = 32;
+    constexpr int H = 32;
+
     f(x, y) = x + y;
     g(x, y) = 10;
     g(x, y) += 2 * f(x, x);
-    RDom r(0, 200, 0, 200);
+    RDom r(0, W, 0, H);
     g(r.x, r.y) += 3 * f(r.y, r.y);
 
     // Make a global wrapper on 'g', so that we can schedule initialization
@@ -302,7 +305,7 @@ int rdom_wrapper_test() {
         return -1;
     }
 
-    Buffer<int> im = wrapper.realize(200, 200);
+    Buffer<int> im = wrapper.realize(W, H);
     auto func = [](int x, int y) { return 4 * x + 6 * y + 10; };
     if (check_image(im, func)) {
         return -1;

--- a/test/correctness/image_wrapper.cpp
+++ b/test/correctness/image_wrapper.cpp
@@ -293,14 +293,17 @@ int rdom_wrapper_test() {
     Func source("source"), g("g"), result("result");
     Var x("x"), y("y");
 
+    constexpr int W = 32;
+    constexpr int H = 32;
+
     source(x, y) = x + y;
     ImageParam img(Int(32), 2, "img");
-    Buffer<int> buf = source.realize(200, 200);
+    Buffer<int> buf = source.realize(W, H);
     img.set(buf);
 
     g(x, y) = 10;
     g(x, y) += 2 * img(x, x);
-    RDom r(0, 200, 0, 200);
+    RDom r(0, W, 0, H);
     g(r.x, r.y) += 3 * img(r.y, r.y);
 
     // Make a global wrapper on 'g', so that we can schedule initialization
@@ -326,7 +329,7 @@ int rdom_wrapper_test() {
         return -1;
     }
 
-    Buffer<int> im = wrapper.realize(200, 200);
+    Buffer<int> im = wrapper.realize(W, H);
     auto func = [](int x, int y) { return 4 * x + 6 * y + 10; };
     if (check_image(im, func)) {
         return -1;

--- a/test/correctness/loop_invariant_extern_calls.cpp
+++ b/test/correctness/loop_invariant_extern_calls.cpp
@@ -34,7 +34,7 @@ int not_really_parallel_for(void *ctx, int (*f)(void *, int, uint8_t *), int min
 
 int main(int argc, char **argv) {
     if (get_jit_target_from_environment().arch == Target::WebAssembly) {
-        printf("Skipping test for WebAssembly as the wasm JIT cannot support set_custom_do_par_for().\n");
+        printf("[SKIP] Skipping test for WebAssembly as the wasm JIT cannot support set_custom_do_par_for().\n");
         return 0;
     }
 

--- a/test/correctness/make_struct.cpp
+++ b/test/correctness/make_struct.cpp
@@ -32,7 +32,7 @@ HalideExtern_1(int, check_struct, struct_t *);
 
 int main(int argc, char **argv) {
     if (get_jit_target_from_environment().arch == Target::WebAssembly) {
-        printf("Skipping test for WebAssembly as the wasm JIT cannot support passing arbitrary pointers to/from HalideExtern code.\n");
+        printf("[SKIP] Skipping test for WebAssembly as the wasm JIT cannot support passing arbitrary pointers to/from HalideExtern code.\n");
         return 0;
     }
 

--- a/test/correctness/parallel_fork.cpp
+++ b/test/correctness/parallel_fork.cpp
@@ -70,7 +70,7 @@ Func make(Schedule schedule) {
 
 int main(int argc, char **argv) {
     if (get_jit_target_from_environment().arch == Target::WebAssembly) {
-        printf("Skipping test for WebAssembly as it does not support async() yet.\n");
+        printf("[SKIP] Skipping test for WebAssembly as it does not support async() yet.\n");
         return 0;
     }
 

--- a/test/correctness/pipeline_set_jit_externs_func.cpp
+++ b/test/correctness/pipeline_set_jit_externs_func.cpp
@@ -18,11 +18,11 @@ HalideExtern_2(float, my_func, int, float);
 
 int main(int argc, char **argv) {
     // set_jit_externs() implicitly adds a user_context arg to the externs, which
-    // we can't yet support
-    // if (get_jit_target_from_environment().arch == Target::WebAssembly) {
-    //     printf("[SKIP] WebAssembly JIT does not support passing arbitrary pointers to/from HalideExtern code.\n");
-    //     return 0;
-    // }
+    // we can't yet support. TODO: this actually should work, but doesn't.
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] WebAssembly JIT does not support passing arbitrary pointers to/from HalideExtern code.\n");
+        return 0;
+    }
 
     std::vector<ExternFuncArgument> args;
     args.push_back(user_context_value());

--- a/test/correctness/print.cpp
+++ b/test/correctness/print.cpp
@@ -135,7 +135,7 @@ int main(int argc, char **argv) {
     {
         Func f, g;
 
-        const int N = 1000000;
+        const int N = 100000;
 
         Expr e = reinterpret(Float(32), random_uint());
         // Make sure we cover some special values.

--- a/test/correctness/thread_safety.cpp
+++ b/test/correctness/thread_safety.cpp
@@ -5,6 +5,10 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
+    // Wasm JIT is substantially slower than others,
+    // so do fewer iterations to avoid timing out.
+    const bool is_wasm = get_jit_target_from_environment().arch == Target::WebAssembly;
+
     // Test if the compiler itself is thread-safe. This test is
     // intended to be run in a thread-sanitizer.
 
@@ -12,7 +16,7 @@ int main(int argc, char **argv) {
     // may refuse to create an arbitrary number. So let's create a smallish
     // number (8) and have each one do enough work that contention is likely
     // to be encountered.
-    constexpr int total_iters = 1024;
+    const int total_iters = is_wasm ? 256 : 1024;
     constexpr int num_threads = 8;
 
     std::vector<std::thread> threads;

--- a/test/correctness/vector_cast.cpp
+++ b/test/correctness/vector_cast.cpp
@@ -131,7 +131,12 @@ int main(int argc, char **argv) {
     // We only test power-of-two vector widths for now
     Halide::Internal::ThreadPool<bool> pool;
     std::vector<std::future<bool>> futures;
-    for (int vec_width = 1; vec_width <= 64; vec_width *= 2) {
+    int vec_width_max = 64;
+    if (target.arch == Target::WebAssembly) {
+        // The wasm jit is very slow, so shorten this test here.
+        vec_width_max = 16;
+    }
+    for (int vec_width = 1; vec_width <= vec_width_max; vec_width *= 2) {
         futures.push_back(pool.async([=]() {
             bool success = true;
             success = success && test_all<float>(vec_width, target);

--- a/test/performance/async_gpu.cpp
+++ b/test/performance/async_gpu.cpp
@@ -15,6 +15,11 @@ Expr expensive(Expr x, int c) {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     if (!target.has_gpu_feature()) {
         printf("[SKIP] No GPU target enabled.\n");
         return 0;

--- a/test/performance/block_transpose.cpp
+++ b/test/performance/block_transpose.cpp
@@ -112,6 +112,12 @@ Buffer<uint16_t> test_transpose_wrap(int mode) {
 }
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     test_transpose(scalar_trans);
     test_transpose_wrap(scalar_trans);
     test_transpose(vec_y_trans);

--- a/test/performance/boundary_conditions.cpp
+++ b/test/performance/boundary_conditions.cpp
@@ -80,6 +80,10 @@ struct Test {
 
 int main(int argc, char **argv) {
     target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
 
     ImageParam input(Float(32), 2);
     ImageParam padded_input(Float(32), 2);

--- a/test/performance/clamped_vector_load.cpp
+++ b/test/performance/clamped_vector_load.cpp
@@ -38,6 +38,12 @@ double test(Func f, bool test_correctness = true) {
 }
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     // Try doing vector loads with a boundary condition in various
     // ways and compare the performance.
 

--- a/test/performance/const_division.cpp
+++ b/test/performance/const_division.cpp
@@ -104,6 +104,12 @@ bool test(int w, bool div) {
 }
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     int seed = argc > 1 ? atoi(argv[1]) : time(nullptr);
     rng.seed(seed);
     std::cout << "const_division test seed: " << seed << std::endl;

--- a/test/performance/fan_in.cpp
+++ b/test/performance/fan_in.cpp
@@ -5,8 +5,9 @@ using namespace Halide;
 using namespace Halide::Tools;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
-        printf("[SKIP] WebAssembly does not support async() yet.\n");
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }
 

--- a/test/performance/fast_inverse.cpp
+++ b/test/performance/fast_inverse.cpp
@@ -6,6 +6,12 @@ using namespace Halide;
 using namespace Halide::Tools;
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     Func slow, fast;
     Var x;
     Param<float> p(1.0f);

--- a/test/performance/fast_pow.cpp
+++ b/test/performance/fast_pow.cpp
@@ -19,6 +19,12 @@ extern "C" DLLEXPORT float pow_ref(float x, float y) {
 HalideExtern_2(float, pow_ref, float, float);
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     Func f, g, h;
     Var x, y;
 

--- a/test/performance/fast_sine_cosine.cpp
+++ b/test/performance/fast_sine_cosine.cpp
@@ -9,6 +9,12 @@ using namespace Halide;
 using namespace Halide::Tools;
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     Func sin_f, cos_f, sin_ref, cos_ref;
     Var x;
     Expr t = x / 1000.f;

--- a/test/performance/gpu_half_throughput.cpp
+++ b/test/performance/gpu_half_throughput.cpp
@@ -5,6 +5,11 @@ using namespace Halide;
 
 int main(int argc, char **argv) {
     Target t = get_jit_target_from_environment();
+    if (t.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     if (!(t.has_feature(Target::CUDA) ||
           t.has_feature(Target::Metal))) {
         printf("[SKIP] No GPU target enabled supporting half-precision.\n");

--- a/test/performance/inner_loop_parallel.cpp
+++ b/test/performance/inner_loop_parallel.cpp
@@ -6,6 +6,12 @@ using namespace Halide;
 using namespace Halide::Tools;
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     Func f;
     Var x, y;
     f(x, y) = x + y;

--- a/test/performance/jit_stress.cpp
+++ b/test/performance/jit_stress.cpp
@@ -7,6 +7,12 @@ using namespace Halide;
 using namespace Halide::Tools;
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     Var x;
 
     ImageParam a(Int(32), 1);

--- a/test/performance/lots_of_inputs.cpp
+++ b/test/performance/lots_of_inputs.cpp
@@ -17,6 +17,12 @@ Func make_pipeline(int size) {
 }
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     for (int size = 1; size <= 128; size *= 2) {
         Func f = make_pipeline(size);
         double t_f = benchmark(1, 1, [&]() {

--- a/test/performance/lots_of_small_allocations.cpp
+++ b/test/performance/lots_of_small_allocations.cpp
@@ -4,6 +4,12 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     Param<int> p;
 
     const char *names[3] = {"heap", "pseudostack", "stack"};

--- a/test/performance/matrix_multiplication.cpp
+++ b/test/performance/matrix_multiplication.cpp
@@ -19,6 +19,12 @@ void simple_version(float *A, float *B, float *C, int width, int stride) {
 }
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     const int matrix_size = 992;
 
     ImageParam A(type_of<float>(), 2);

--- a/test/performance/memcpy.cpp
+++ b/test/performance/memcpy.cpp
@@ -9,6 +9,12 @@ using namespace Halide;
 using namespace Halide::Tools;
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     ImageParam src(UInt(8), 1);
     Func dst;
     Var x;

--- a/test/performance/memory_profiler.cpp
+++ b/test/performance/memory_profiler.cpp
@@ -103,8 +103,9 @@ int check_error_parallel(int min_heap_peak, int max_heap_peak, int exp_num_mallo
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
-        printf("[SKIP] WebAssembly JIT does not yet support the profiler.\n");
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }
 

--- a/test/performance/packed_planar_fusion.cpp
+++ b/test/performance/packed_planar_fusion.cpp
@@ -49,6 +49,11 @@ Buffer<uint8_t> make_planar(uint8_t *host, int W, int H) {
 }
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
 
     const int W = 1 << 11, H = 1 << 11;
 

--- a/test/performance/parallel_performance.cpp
+++ b/test/performance/parallel_performance.cpp
@@ -9,6 +9,12 @@ using namespace Halide::Tools;
 #define H 160
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     Var x, y;
     Func f, g;
 

--- a/test/performance/profiler.cpp
+++ b/test/performance/profiler.cpp
@@ -16,6 +16,12 @@ void my_print(void *, const char *msg) {
 }
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     // Make a long chain of finely-interleaved Funcs, of which one is very expensive.
     Func f[30];
     Var c, x;

--- a/test/performance/realize_overhead.cpp
+++ b/test/performance/realize_overhead.cpp
@@ -12,6 +12,12 @@ int null_call() {
 }
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     {
         global_to_prevent_opt = argc;
         double t = benchmark([&]() { null_call(); });

--- a/test/performance/rfactor.cpp
+++ b/test/performance/rfactor.cpp
@@ -396,6 +396,12 @@ int kitchen_sink() {
 }
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     one_d_max();
     two_d_histogram();
     four_d_argmin();

--- a/test/performance/rgb_interleaved.cpp
+++ b/test/performance/rgb_interleaved.cpp
@@ -144,6 +144,12 @@ void test_interleave(bool fast) {
 }
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     test_deinterleave();
     test_interleave(false);
     test_interleave(true);

--- a/test/performance/sort.cpp
+++ b/test/performance/sort.cpp
@@ -137,6 +137,11 @@ Func merge_sort(Func input, int total_size) {
 }
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
 
     const int N = 1 << 10;
 

--- a/test/performance/thread_safe_jit.cpp
+++ b/test/performance/thread_safe_jit.cpp
@@ -110,6 +110,12 @@ void same_func_per_thread() {
 }
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     for (auto &buf : bufs) {
         buf = Buffer<int32_t>(10);
         for (int i = 0; i < 10; i++) {

--- a/test/performance/vectorize.cpp
+++ b/test/performance/vectorize.cpp
@@ -93,6 +93,11 @@ bool test() {
 }
 
 int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
 
     bool ok = true;
 

--- a/test/performance/wrap.cpp
+++ b/test/performance/wrap.cpp
@@ -111,6 +111,11 @@ Func build_wrap() {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
+
     if (!target.has_gpu_feature()) {
         printf("[SKIP] No GPU target enabled.\n");
         return 0;


### PR DESCRIPTION
This has been split off from #5097 to make reviewing simpler; this modifies a bunch of tests for better use with WASM:
- everything in auto_schedule is skipped, since the Mullapudi2016 autoscheduler assert-fails for most non-real-CPU backends
- everything in performance is skipped, because we'll be doing wasm "jit" testing with an interpreter, so performance results would be meaningless
 - Added/updated the skip message for tests that exercise things that wasm doesn't support yet (eg atomics, threads)
- For a handful of tests that are unreasonably slow under the wasm "jit" interpreter, dialed down some of the test parameters to avoid test timeouts
- Removed some wasm-related skips that won't be necessary any longer