### PR TITLE
Fix autoscheduler emitted schedule for reorder

### DIFF
--- a/apps/autoscheduler/AutoSchedule.cpp
+++ b/apps/autoscheduler/AutoSchedule.cpp
@@ -2783,8 +2783,7 @@ struct State {
                         vars.push_back(v.var);
                         if (!first) {
                             p.second->schedule_source << ", ";
-                        }
-                        else {
+                        } else {
                             p.second->schedule_source << "{";
                         }
                         first = false;

--- a/apps/autoscheduler/AutoSchedule.cpp
+++ b/apps/autoscheduler/AutoSchedule.cpp
@@ -2784,11 +2784,14 @@ struct State {
                         if (!first) {
                             p.second->schedule_source << ", ";
                         }
+                        else {
+                            p.second->schedule_source << "{";
+                        }
                         first = false;
                         p.second->schedule_source << v.var.name();
                     }
                 }
-                p.second->schedule_source << ")";
+                p.second->schedule_source << "})";
                 stage.reorder(vars);
             }
 


### PR DESCRIPTION
The schedule emitted by Adams2019 autoscheduler sometimes results
in a compilation error. This error is seen when the autoscheduler emits
trivial reorder (reorder of a single variable). For example, the autoscheduler
emits the following schedule snippet:

`.reorder(x1);`

There is a check inplace which prevents these reorders by verifying the
the size of vector representing the `vars` to be reorderd  is greater than 1.

https://github.com/halide/Halide/blob/master/apps/autoscheduler/AutoSchedule.cpp#L806

Though, there are some cases where this check doesn't filter out trivial reorders
(when some variables don't exist).

This patch changes the reorder() directive emitted in schedule file
by the autoscheduler.

from: .reorder(VarOrRVar x, VarOrRVar y, Args && args)

to: .reorder(std::vector<VarOrRVar>& vars)

As the former reorder syntax results in an error if the schedule file
is used, in case there is a reorder of only one variable that are
sometimes caused by the autoscheduler.