### PR TITLE
Fix binary2cpp usage in CMake

### DIFF
--- a/apps/autoscheduler/CMakeLists.txt
+++ b/apps/autoscheduler/CMakeLists.txt
@@ -18,7 +18,7 @@ set(WF_CPP baseline.cpp)
 configure_file(baseline.weights baseline.weights COPYONLY)
 add_custom_command(OUTPUT ${WF_CPP}
                    DEPENDS baseline.weights binary2cpp
-                   COMMAND binary2cpp baseline_weights < baseline.weights > ${WF_CPP}
+                   COMMAND $<TARGET_FILE:binary2cpp> baseline_weights < baseline.weights > ${WF_CPP}
                    VERBATIM)
 
 # cost_model, train_cost_model

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -356,7 +356,7 @@ set(LICENSE_PATH "${Halide_SOURCE_DIR}/LICENSE.txt")
 add_custom_command(OUTPUT "${Halide_BINARY_DIR}/include/Halide.h"
                    VERBATIM
                    COMMAND ${CMAKE_COMMAND} -E make_directory "$<SHELL_PATH:${Halide_BINARY_DIR}/include>"
-                   COMMAND build_halide_h "$<SHELL_PATH:${LICENSE_PATH}>" ${HEADER_FILES} > "$<SHELL_PATH:${HALIDE_H}>"
+                   COMMAND $<TARGET_FILE:build_halide_h> "$<SHELL_PATH:${LICENSE_PATH}>" ${HEADER_FILES} > "$<SHELL_PATH:${HALIDE_H}>"
                    WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
                    DEPENDS build_halide_h "${LICENSE_PATH}" ${HEADER_FILES})
 add_custom_target(

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -191,7 +191,7 @@ foreach (i IN LISTS RUNTIME_CPP)
                                )
             add_custom_command(OUTPUT "${INITMOD}"
                                DEPENDS "${BC}" binary2cpp
-                               COMMAND binary2cpp ${SYMBOL} < "${BC}" > "${INITMOD}"
+                               COMMAND $<TARGET_FILE:binary2cpp> ${SYMBOL} < "${BC}" > "${INITMOD}"
                                )
             target_sources(Halide_initmod PRIVATE ${INITMOD})
         endforeach ()
@@ -213,7 +213,7 @@ foreach (i IN LISTS RUNTIME_LL)
                        )
     add_custom_command(OUTPUT "${INITMOD}"
                        DEPENDS "${BC}" binary2cpp
-                       COMMAND binary2cpp "halide_internal_initmod_${i}_ll" < "${BC}" > "${INITMOD}"
+                       COMMAND $<TARGET_FILE:binary2cpp> "halide_internal_initmod_${i}_ll" < "${BC}" > "${INITMOD}"
                        )
     target_sources(Halide_initmod PRIVATE ${INITMOD})
 endforeach ()
@@ -224,14 +224,14 @@ foreach (i IN LISTS RUNTIME_BC)
 
     add_custom_command(OUTPUT "${INITMOD}"
                        DEPENDS binary2cpp "${RT_BC}"
-                       COMMAND binary2cpp "halide_internal_initmod_ptx_${i}_ll" < "$<SHELL_PATH:${RT_BC}>" > "${INITMOD}"
+                       COMMAND $<TARGET_FILE:binary2cpp> "halide_internal_initmod_ptx_${i}_ll" < "$<SHELL_PATH:${RT_BC}>" > "${INITMOD}"
                        VERBATIM)
     target_sources(Halide_initmod PRIVATE ${INITMOD})
 endforeach ()
 
 add_custom_command(OUTPUT "_initmod_inlined_c.cpp"
                    DEPENDS "halide_buffer_t.cpp" binary2cpp
-                   COMMAND binary2cpp "halide_internal_initmod_inlined_c" < "${CMAKE_CURRENT_SOURCE_DIR}/halide_buffer_t.cpp" > "_initmod_inlined_c.cpp"
+                   COMMAND $<TARGET_FILE:binary2cpp> "halide_internal_initmod_inlined_c" < "${CMAKE_CURRENT_SOURCE_DIR}/halide_buffer_t.cpp" > "_initmod_inlined_c.cpp"
                    )
 target_sources(Halide_initmod PRIVATE "_initmod_inlined_c.cpp")
 
@@ -239,7 +239,7 @@ foreach (i IN LISTS RUNTIME_HEADER_FILES)
     string(REPLACE "." "_" SYM_NAME "${i}")
     add_custom_command(OUTPUT "_initmod_${SYM_NAME}.cpp"
                        DEPENDS "${i}" binary2cpp
-                       COMMAND binary2cpp "halide_internal_runtime_header_${SYM_NAME}" < "${CMAKE_CURRENT_SOURCE_DIR}/${i}" > "_initmod_${SYM_NAME}.cpp"
+                       COMMAND $<TARGET_FILE:binary2cpp> "halide_internal_runtime_header_${SYM_NAME}" < "${CMAKE_CURRENT_SOURCE_DIR}/${i}" > "_initmod_${SYM_NAME}.cpp"
                        )
     target_sources(Halide_initmod PRIVATE "_initmod_${SYM_NAME}.cpp")
 

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -171,23 +171,23 @@ add_custom_command(OUTPUT "${EC32}.bc"
                    VERBATIM
                    COMMAND clang -O3 -c -m32 -target le32-unknown-nacl-unknown -emit-llvm "$<SHELL_PATH:${EXTERNAL_CPP}>" -o "${EC32}.bc")
 add_custom_command(OUTPUT "${EC32}.cpp"
-                   DEPENDS "${EC32}.bc"
-                   COMMAND binary2cpp external_code_extern_bitcode_32 < "${EC32}.bc" > "${EC32}.cpp")
+                   DEPENDS "${EC32}.bc" binary2cpp
+                   COMMAND $<TARGET_FILE:binary2cpp> external_code_extern_bitcode_32 < "${EC32}.bc" > "${EC32}.cpp")
 
 set(EC64 "external_code_extern_bitcode_64")
 add_custom_command(OUTPUT "${EC64}.bc"
-                   DEPENDS "${EXTERNAL_CPP}"
+                   DEPENDS "${EXTERNAL_CPP}" binary2cpp
                    VERBATIM
                    COMMAND clang -O3 -c -m64 -target le64-unknown-unknown-unknown -emit-llvm "$<SHELL_PATH:${EXTERNAL_CPP}>" -o "${EC64}.bc")
 add_custom_command(OUTPUT "${EC64}.cpp"
-                   DEPENDS "${EC64}.bc"
-                   COMMAND binary2cpp external_code_extern_bitcode_64 < "${EC64}.bc" > "${EC64}.cpp")
+                   DEPENDS "${EC64}.bc" binary2cpp
+                   COMMAND $<TARGET_FILE:binary2cpp> external_code_extern_bitcode_64 < "${EC64}.bc" > "${EC64}.cpp")
 
 set(ECCPP "external_code_extern_cpp_source")
 add_custom_command(OUTPUT "${ECCPP}.cpp"
-                   DEPENDS "${EXTERNAL_CPP}"
+                   DEPENDS "${EXTERNAL_CPP}" binary2cpp
                    VERBATIM
-                   COMMAND binary2cpp external_code_extern_cpp_source < "$<SHELL_PATH:${EXTERNAL_CPP}>" > "${ECCPP}.cpp")
+                   COMMAND $<TARGET_FILE:binary2cpp> external_code_extern_cpp_source < "$<SHELL_PATH:${EXTERNAL_CPP}>" > "${ECCPP}.cpp")
 
 add_library(external_code_generator_deps OBJECT "${EC32}.cpp" "${EC64}.cpp" "${ECCPP}.cpp")
 

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -176,7 +176,7 @@ add_custom_command(OUTPUT "${EC32}.cpp"
 
 set(EC64 "external_code_extern_bitcode_64")
 add_custom_command(OUTPUT "${EC64}.bc"
-                   DEPENDS "${EXTERNAL_CPP}" binary2cpp
+                   DEPENDS "${EXTERNAL_CPP}"
                    VERBATIM
                    COMMAND clang -O3 -c -m64 -target le64-unknown-unknown-unknown -emit-llvm "$<SHELL_PATH:${EXTERNAL_CPP}>" -o "${EC64}.bc")
 add_custom_command(OUTPUT "${EC64}.cpp"


### PR DESCRIPTION
Ensure that all usage has `binary2cpp` in its DEPENDS, and use `$<TARGET_FILE:binary2cpp>` to ensure we expand a full path properly. (In theory, recent CMake builds shouldn't need the explicit expansion, but some cross-compilation configs seem to be skipping the expansion.)