### PR TITLE
Try using a different target for generic 32-bit bitcode in our runtime

### DIFF
--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -151,13 +151,10 @@ set(RUNTIME_CXX_FLAGS -O3
 foreach (i IN LISTS RUNTIME_CPP)
     foreach (j IN ITEMS 32 64)
         if (${j} EQUAL 32)
-            if (${i} MATCHES "windows_.*")
-                # win32 uses the stdcall calling convention, which is x86-specific
-                set(TARGET "i386-unknown-unknown-unknown")
-            else ()
-                # (The 'nacl' is a red herring. This is just a generic 32-bit little-endian target.)
-                set(TARGET "le32-unknown-nacl-unknown")
-            endif ()
+            # win32 uses the stdcall calling convention, which is x86-specific;
+            # it's as good as any, so we'll use it for all 32-bit here (and avoids
+            # using the long-deprecated nacl target).
+            set(TARGET "i386-unknown-unknown-unknown")
         else ()
             # generic 64-bit code
             set(TARGET "le64-unknown-unknown-unknown")


### PR DESCRIPTION
Not sure why, but it appears that using `le32-unknown-nacl-unknown` has an undesired side effect of making the `__atomic` builtins nearly unusable (almost any usage produces warnings about 'large atomic ops'). Experimentally, using `i386-unknown-unknown-unknown` as the 32-bit format for our runtime seems to solve that issue, but may well cause other problems (eg on arm32). This is just a draft run to see what changing the bitcode format does on the buildbots.

attn @abadams 