### PR TITLE
Add Target::WasmSatFloatToInt

### DIFF
--- a/python_bindings/src/PyEnums.cpp
+++ b/python_bindings/src/PyEnums.cpp
@@ -140,6 +140,7 @@ void define_enums(py::module &m) {
         .value("DisableLLVMLoopOpt", Target::Feature::DisableLLVMLoopOpt)
         .value("WasmSimd128", Target::Feature::WasmSimd128)
         .value("WasmSignExt", Target::Feature::WasmSignExt)
+        .value("WasmSatFloatToInt", Target::Feature::WasmSatFloatToInt)
         .value("SVE", Target::Feature::SVE)
         .value("SVE2", Target::Feature::SVE2)
         .value("ARMDotProd", Target::Feature::ARMDotProd)

--- a/src/CodeGen_WebAssembly.cpp
+++ b/src/CodeGen_WebAssembly.cpp
@@ -122,14 +122,10 @@ string CodeGen_WebAssembly::mattrs() const {
         sep = ",";
     }
 
-    // TODO: Emscripten doesn't seem to be able to validate wasm that contains this yet.
-    // We could only generate for JIT mode (where we know we can enable it), but that
-    // would mean the execution model for JIT vs AOT could be slightly different,
-    // so leave it out entirely until we can do it uniformly.
-    // if (target.has_feature(Target::JIT)) {
-    //    s << sep << "+nontrapping-fptoint";
-    //    sep = ",";
-    // }
+    if (target.has_feature(Target::WasmSatFloatToInt)) {
+        s << sep << "+nontrapping-fptoint";
+        sep = ",";
+    }
 
     user_assert(target.os == Target::WebAssemblyRuntime)
         << "wasmrt is the only supported 'os' for WebAssembly at this time.";

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -358,6 +358,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"enable_llvm_loop_opt", Target::EnableLLVMLoopOpt},
     {"wasm_simd128", Target::WasmSimd128},
     {"wasm_signext", Target::WasmSignExt},
+    {"wasm_sat_float_to_int", Target::WasmSatFloatToInt},
     {"sve", Target::SVE},
     {"sve2", Target::SVE2},
     {"arm_dot_prod", Target::ARMDotProd},

--- a/src/Target.h
+++ b/src/Target.h
@@ -117,6 +117,7 @@ struct Target {
         DisableLLVMLoopOpt = halide_target_feature_disable_llvm_loop_opt,
         WasmSimd128 = halide_target_feature_wasm_simd128,
         WasmSignExt = halide_target_feature_wasm_signext,
+        WasmSatFloatToInt = halide_target_feature_wasm_sat_float_to_int,
         SVE = halide_target_feature_sve,
         SVE2 = halide_target_feature_sve2,
         ARMDotProd = halide_target_feature_arm_dot_prod,

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1311,6 +1311,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_disable_llvm_loop_opt,  ///< Disable loop vectorization + unrolling in LLVM. (Ignored for non-LLVM targets.)
     halide_target_feature_wasm_simd128,           ///< Enable +simd128 instructions for WebAssembly codegen.
     halide_target_feature_wasm_signext,           ///< Enable +sign-ext instructions for WebAssembly codegen.
+    halide_target_feature_wasm_sat_float_to_int,  ///< Enable saturating (nontrapping) float-to-int instructions for WebAssembly codegen.
     halide_target_feature_sve,                    ///< Enable ARM Scalable Vector Extensions
     halide_target_feature_sve2,                   ///< Enable ARM Scalable Vector Extensions v2
     halide_target_feature_egl,                    ///< Force use of EGL support.


### PR DESCRIPTION
Cherry-picking a change from #5097 so that reviewing that PR will be simpler; this just adds another feature option for wasm that tooling wasn't ready for before, but is now (saturating float-to-int conversion).