### PR TITLE
Add vector tile methods to the Python bindings

### DIFF
--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -265,6 +265,26 @@ def test_int_promotion():
     # Exprlike = Var
     # (skipped, since these can never have values of any type other than int32)
 
+def test_vector_tile():
+    # Test Func.tile() and Stage.tile() with vector arguments
+    x,  y,  z  = [ hl.Var(c    ) for c in 'xyz' ]
+    xi, yi, zi = [ hl.Var(c+"i") for c in 'xyz' ]
+    xo, yo, zo = [ hl.Var(c+"o") for c in 'xyz' ]
+    f = hl.Func('f')
+    g = hl.Func('g')
+    h = hl.Func('h')
+    f[x, y] = y
+    f[x, y] += x
+    g[x, y, z] = x + y
+    g[x, y, z] += z
+    f.tile([x,y], [xo,yo], [x,y], [8,8])
+    f.update(0).tile([x,y], [xo,yo], [xi,yi], [8,8])
+    g.tile([x,y], [xo,yo], [x,y], [8,8], hl.TailStrategy.RoundUp)
+    g.update(0).tile([x,y], [xo,yo], [xi,yi], [8,8], hl.TailStrategy.GuardWithIf)
+    p = hl.Pipeline([f, g])
+    p.compile_jit()
+
+
 
 if __name__ == "__main__":
     test_compiletime_error()
@@ -274,6 +294,7 @@ if __name__ == "__main__":
     test_float_or_int()
     test_operator_order()
     test_int_promotion()
+    test_vector_tile()
     test_basics()
     test_basics2()
     test_basics3()

--- a/python_bindings/src/PyScheduleMethods.h
+++ b/python_bindings/src/PyScheduleMethods.h
@@ -36,6 +36,8 @@ HALIDE_NEVER_INLINE void add_schedule_methods(PythonClass &class_instance) {
              py::arg("x"), py::arg("y"), py::arg("xo"), py::arg("yo"), py::arg("xi"), py::arg("yi"), py::arg("xfactor"), py::arg("yfactor"), py::arg("tail") = TailStrategy::Auto)
         .def("tile", (T & (T::*)(const VarOrRVar &, const VarOrRVar &, const VarOrRVar &, const VarOrRVar &, const Expr &, const Expr &, TailStrategy)) & T::tile,
              py::arg("x"), py::arg("y"), py::arg("xi"), py::arg("yi"), py::arg("xfactor"), py::arg("yfactor"), py::arg("tail") = TailStrategy::Auto)
+        .def("tile", (T & (T::*)(const std::vector<VarOrRVar> &, const std::vector<VarOrRVar> &, const std::vector<VarOrRVar> &, const std::vector<Expr> &, TailStrategy)) & T::tile,
+             py::arg("previous"), py::arg("outers"), py::arg("inners"), py::arg("factors"), py::arg("tail") = TailStrategy::Auto)
 
         .def("reorder", (T & (T::*)(const std::vector<VarOrRVar> &)) & T::reorder, py::arg("vars"))
         .def("reorder", [](T &t, const py::args &args) -> T & {


### PR DESCRIPTION
PR #4898 added methods to C++; this makes them usable in Python.

Added a test case.