### PR TITLE
Upgrade clang-format to v10

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: DoozyX/clang-format-lint-action@v0.5
+      - uses: DoozyX/clang-format-lint-action@v0.7
         with:
           source: '.'
           extensions: 'h,c,cpp'
-          clangFormatVersion: 9
+          clangFormatVersion: 10
   check_clang_tidy:
     name: Check clang-tidy
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -2316,10 +2316,14 @@ $(BIN_DIR)/HalideTraceDump: $(ROOT_DIR)/util/HalideTraceDump.cpp $(ROOT_DIR)/uti
 
 # Run clang-format on most of the source. The tutorials directory is
 # explicitly skipped, as those files are manually formatted to
-# maximize readability.
+# maximize readability. NB: clang-format is *not* stable across versions;
+# we are currently standardized on the formatting from clang-format-10.
+# If CLANG_FORMAT points to a different version, you may get incorrectly-formatted code.
+CLANG_FORMAT ?= ${CLANG}-format
+
 .PHONY: format
 format:
-	find "${ROOT_DIR}/apps" "${ROOT_DIR}/src" "${ROOT_DIR}/tools" "${ROOT_DIR}/test" "${ROOT_DIR}/util" "${ROOT_DIR}/python_bindings" -name *.cpp -o -name *.h -o -name *.c | xargs ${CLANG}-format -i -style=file
+	find "${ROOT_DIR}/apps" "${ROOT_DIR}/src" "${ROOT_DIR}/tools" "${ROOT_DIR}/test" "${ROOT_DIR}/util" "${ROOT_DIR}/python_bindings" -name *.cpp -o -name *.h -o -name *.c | xargs ${CLANG_FORMAT} -i -style=file
 
 # run-clang-tidy.py is a script that comes with LLVM for running clang
 # tidy in parallel. Assume it's in the standard install path relative to clang.


### PR DESCRIPTION
Upgrade the clang-format checks to clang-format-10, and reformat code accordingly. (Note that there aren't actually any changes necessary for 9 -> 10, but there are some for 10 -> 11 or 10 -> 12.)

Also add a way tp specify the clang-format version for `make format`; it defaults to the version of Clang for the current LLVM, but since clang-format doesn't provide stable formatting across versions, this might be wrong.