### PR TITLE
Update README to suggest cloning a release of LLVM, not a branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ works well on OS X and Ubuntu.)
 If you want to build it yourself, first check it out from GitHub:
 
 ```
-% git clone https://github.com/llvm/llvm-project.git --depth 1 -b release/10.x
+% git clone --depth 1 --branch llvmorg-10.0.0 https://github.com/llvm/llvm-project.git
 ```
 
 (If you want to build LLVM 9.x, use branch `release/9.x`; for current trunk, use
@@ -217,7 +217,7 @@ Follow these steps if you want to build LLVM yourself. First, download LLVM's
 sources (these instructions use the latest 10.0 release)
 
 ```
-D:\> git clone https://github.com/llvm/llvm-project.git --depth 1 -b release/10.x
+D:\> git clone --depth 1 --branch llvmorg-10.0.0 https://github.com/llvm/llvm-project.git
 ```
 
 For a 64-bit build, run:


### PR DESCRIPTION
The release tags should be the canonical source for that version; branches can sometimes be broken.