### PR TITLE
Fix for trunk LLVM

### DIFF
--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -554,7 +554,9 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     internal_assert(llvm_target) << err_str << "\n";
 
     TargetOptions options;
+#if LLVM_VERSION < 120
     options.PrintMachineCode = false;
+#endif
     options.AllowFPOpFusion = FPOpFusion::Fast;
     options.UnsafeFPMath = true;
     options.NoInfsFPMath = true;


### PR DESCRIPTION
PrintMachineCode has been removed in LLVM 12/trunk