### PR TITLE
Improve HVX codegen error reporting

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -50,6 +50,9 @@ CodeGen_Hexagon::CodeGen_Hexagon(Target t)
     user_assert(!target.features_all_of(
         {Halide::Target::HVX_128, Halide::Target::HVX_64}))
         << "Cannot set both HVX_64 and HVX_128 at the same time.\n";
+    user_assert(!target.features_any_of(
+        {Halide::Target::HVX_128, Halide::Target::HVX_64}))
+        << "Must specify either HVX_64 or HVX_128 (but not both).\n";
 }
 
 namespace {

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1349,6 +1349,8 @@ llvm::Function *CodeGen_Hexagon::define_hvx_intrinsic(llvm::Function *intrin,
                         internal_error
                             << "unhandled broadcast_scalar_word in define_hvx_intrinsic";
                     }
+                    internal_assert(fn)
+                        << "Unable to find scalar broadcast function. Did you forget to specify either hvx_64 or hvx_128?";
                     args[i] = builder->CreateCall(fn, {args[i]});
                 } else if (args[i]->getType()->isIntegerTy()) {
                     args[i] =

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1341,19 +1341,20 @@ llvm::Function *CodeGen_Hexagon::define_hvx_intrinsic(llvm::Function *intrin,
                     // We know it is a scalar type. We can have 8 bit, 16 bit or 32 bit
                     // types only.
                     unsigned bits = arg_types[i].bits();
+                    const char *fn_name = "";
                     switch (bits) {
                     case 8:
-                        fn = module->getFunction("halide.hexagon.dup4.b");
+                        fn_name = "halide.hexagon.dup4.b";
                         break;
                     case 16:
-                        fn = module->getFunction("halide.hexagon.dup2.h");
+                        fn_name = "halide.hexagon.dup2.h";
                         break;
                     default:
                         internal_error
                             << "unhandled broadcast_scalar_word in define_hvx_intrinsic";
                     }
-                    internal_assert(fn)
-                        << "Unable to find scalar broadcast function. Did you forget to specify either hvx_64 or hvx_128?";
+                    fn = module->getFunction(fn_name);
+                    internal_assert(fn) << "Unable to find function " << fn_name << " in define_hvx_intrinsic.";
                     args[i] = builder->CreateCall(fn, {args[i]});
                 } else if (args[i]->getType()->isIntegerTy()) {
                     args[i] =

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -50,9 +50,6 @@ CodeGen_Hexagon::CodeGen_Hexagon(Target t)
     user_assert(!target.features_all_of(
         {Halide::Target::HVX_128, Halide::Target::HVX_64}))
         << "Cannot set both HVX_64 and HVX_128 at the same time.\n";
-    user_assert(target.features_any_of(
-        {Halide::Target::HVX_128, Halide::Target::HVX_64}))
-        << "Must specify either HVX_64 or HVX_128 (but not both).\n";
 }
 
 namespace {
@@ -82,6 +79,10 @@ Stmt call_halide_qurt_hvx_unlock() {
 // Wrap the stmt in a call to qurt_hvx_lock, calling qurt_hvx_unlock
 // as a destructor if successful.
 Stmt acquire_hvx_context(Stmt stmt, const Target &target) {
+    user_assert(target.features_any_of(
+        {Halide::Target::HVX_128, Halide::Target::HVX_64}))
+        << "Must specify either HVX_64 or HVX_128 (but not both).\n";
+
     // Modify the stmt to add a call to halide_qurt_hvx_lock, and
     // register a destructor to call halide_qurt_hvx_unlock.
     Stmt check_hvx_lock = call_halide_qurt_hvx_lock(target);

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -50,7 +50,7 @@ CodeGen_Hexagon::CodeGen_Hexagon(Target t)
     user_assert(!target.features_all_of(
         {Halide::Target::HVX_128, Halide::Target::HVX_64}))
         << "Cannot set both HVX_64 and HVX_128 at the same time.\n";
-    user_assert(!target.features_any_of(
+    user_assert(target.features_any_of(
         {Halide::Target::HVX_128, Halide::Target::HVX_64}))
         << "Must specify either HVX_64 or HVX_128 (but not both).\n";
 }


### PR DESCRIPTION
If you try to compile HVX standalone code with HL_TARGET=hexagon-32-noos, you will die because necessary glue functions are defined in hvx_64 or hvx_128 but not 'baseline' hvx. Add an assertion check with a helpful error meesage to avoid just segfaulting deep inside LLVM.