### PR TITLE
Get rid of stale Travis CI build info from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,6 @@ To see some example code, look in the tutorials directory.
 If you've acquired a full source distribution and want to build Halide, see the
 notes below.
 
-# Build Status
-
-| Linux                         |
-| ----------------------------- |
-| [![linux build status][1]][2] |
-
-[1]: https://travis-ci.org/halide/Halide.svg?branch=master
-[2]: https://travis-ci.org/halide/Halide
-
 # Building Halide with Make
 
 ### TL;DR


### PR DESCRIPTION
We don't use Travis anymore, so this is misleading.