### PR TITLE
Fix Doxygen warnings in runtime

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -401,11 +401,11 @@ typedef enum halide_type_code_t
     : uint8_t
 #endif
 {
-    halide_type_int = 0,     //!< signed integers
-    halide_type_uint = 1,    //!< unsigned integers
-    halide_type_float = 2,   //!< IEEE floating point numbers
-    halide_type_handle = 3,  //!< opaque pointer type (void *)
-    halide_type_bfloat = 4,  //!< floating point numbers in the bfloat format
+    halide_type_int = 0,     ///< signed integers
+    halide_type_uint = 1,    ///< unsigned integers
+    halide_type_float = 2,   ///< IEEE floating point numbers
+    halide_type_handle = 3,  ///< opaque pointer type (void *)
+    halide_type_bfloat = 4,  ///< floating point numbers in the bfloat format
 } halide_type_code_t;
 
 // Note that while __attribute__ can go before or after the declaration,

--- a/src/runtime/HalideRuntimeHexagonDma.h
+++ b/src/runtime/HalideRuntimeHexagonDma.h
@@ -23,7 +23,12 @@
 extern "C" {
 #endif
 
-/*!
+/**
+ * \defgroup rt_hexagon_dma Halide Hexagon DMA runtime
+ * @{
+ */
+
+/**
  * Image Formats to prepare the application for DMA Transfer
  */
 typedef enum {

--- a/src/runtime/mini_hexagon_dma.h
+++ b/src/runtime/mini_hexagon_dma.h
@@ -145,16 +145,18 @@ typedef struct stDmaWrapper_DmaTransferSetup {
 } t_StDmaWrapper_DmaTransferSetup;
 
 /**
+ * Abstraction for allocation of memory in cache and lock
+ *
  * @brief  API for Cache Allocation
- * @description Abstraction for allocation of memory in cache and lock
  *
  * @return NULL or Memory
  */
 void *HAP_cache_lock(unsigned int size, void **paddr_ptr);
 
 /**
+ * Abstraction for deallocation of memory and unlock cache
+ *
  * @brief  API for Free
- * @description Abstraction for deallocation of memory and unlock cache
  *
  * @return void
  */
@@ -166,10 +168,9 @@ int HAP_cache_unlock(void *vaddr_ptr);
 typedef void *t_DmaWrapper_DmaEngineHandle;
 
 /**
- * @brief       Allocates a DMA Engine to be used
+ * Allocates a DMA Engine to be used by using the default wait type (polling).
  *
- * @description Allocates a DMA Engine to be used by using the default
- *              wait type (polling).
+ * @brief       Allocates a DMA Engine to be used
  *
  * @return      Success: Engine's DMA Handle
  * @n           Failure: NULL
@@ -177,9 +178,9 @@ typedef void *t_DmaWrapper_DmaEngineHandle;
 extern t_DmaWrapper_DmaEngineHandle hDmaWrapper_AllocDma(void);
 
 /**
- * @brief       Frees a DMA Engine
+ * Frees a DMA Engine that was previously allocated by AllocDma().
  *
- * @description Frees a DMA Engine that was previously allocated by AllocDma().
+ * @brief       Frees a DMA Engine
  *
  * @param[in]   hDmaHandle - Engine's DMA Handle
  *
@@ -189,11 +190,11 @@ extern t_DmaWrapper_DmaEngineHandle hDmaWrapper_AllocDma(void);
 extern int32 nDmaWrapper_FreeDma(t_DmaWrapper_DmaEngineHandle hDmaHandle);
 
 /**
- * @brief       Starts a transfer request on the DMA engine
+ * Starts a transfer on the provided DMA engine. The transfer is based
+ * on descriptors constructed in earlier nDmaWrapper_Prepare() and
+ * nDmaWrapper_Update() calls.
  *
- * @description Starts a transfer on the provided DMA engine. The transfer is based
- *              on descriptors constructed in earlier nDmaWrapper_Prepare() and
- *              nDmaWrapper_Update() calls.
+ * @brief       Starts a transfer request on the DMA engine
  *
  * @param[in]   hDmaHandle - Engine's DMA Handle
  *
@@ -203,11 +204,11 @@ extern int32 nDmaWrapper_FreeDma(t_DmaWrapper_DmaEngineHandle hDmaHandle);
 extern int32 nDmaWrapper_Move(t_DmaWrapper_DmaEngineHandle hDmaHandle);
 
 /**
- * @brief       Waits for all outstanding transfers on the DMA to complete
+ * Blocks until all outstanding transfers on the DMA are complete.
+ * The wait type is based on the type specified when allocating the
+ * engine.
  *
- * @description Blocks until all outstanding transfers on the DMA are complete.
- *              The wait type is based on the type specified when allocating the
- *              engine.
+ * @brief       Waits for all outstanding transfers on the DMA to complete
  *
  * @param[in]   hDmaHandle - Engine's DMA Handle
  *
@@ -217,10 +218,9 @@ extern int32 nDmaWrapper_Move(t_DmaWrapper_DmaEngineHandle hDmaHandle);
 extern int32 nDmaWrapper_Wait(t_DmaWrapper_DmaEngineHandle hDmaHandle);
 
 /**
- * @brief       Cleans up all transfers and flushes DMA buffers
+ * This call flushes the DMA buffers. Blocks until the flush of the DMA is complete.
  *
- * @description This call flushes the DMA buffers.
- *              Blocks until the flush of the DMA is complete.
+ * @brief       Cleans up all transfers and flushes DMA buffers
  *
  * @param[in]   hDmaHandle - Engine's DMA Handle
  *
@@ -230,12 +230,12 @@ extern int32 nDmaWrapper_Wait(t_DmaWrapper_DmaEngineHandle hDmaHandle);
 extern int32 nDmaWrapper_FinishFrame(t_DmaWrapper_DmaEngineHandle hDmaHandle);
 
 /**
- * @brief         Get the recommended walk ROI width and height
+ * Get the recommended walk ROI width and height that should
+ * be used if walking the entire frame. The ROI returned is always
+ * in terms of frame dimensions. This function is different from
+ * nDmaWrapper_GetRecommendedRoi() as coordinates are not used.
  *
- * @description   Get the recommended walk ROI width and height that should
- *                be used if walking the entire frame. The ROI returned is always
- *                in terms of frame dimensions. This function is different from
- *                nDmaWrapper_GetRecommendedRoi() as coordinates are not used.
+ * @brief         Get the recommended walk ROI width and height
  *
  * @param[in]     eFmtId - Format ID
  * @param[in]     bIsUbwc - Is the format UBWC (TRUE/FALSE)
@@ -250,11 +250,10 @@ extern int32 nDmaWrapper_GetRecommendedWalkSize(t_eDmaFmt eFmtId, bool bIsUbwc,
                                                 t_StDmaWrapper_RoiAlignInfo *pStWalkSize);
 
 /**
+ * Calculates the HW descriptor buffer size based on the formats
+ * that will be used with the engine.
+ *
  * @brief       Get the HW descriptor buffer size per DMA engine
- *
- * @description Calculates the HW descriptor buffer size based
- *              on the formats that will be used with the engine.
- *
  * @param[in]   aeFmtId - Array of format IDs, such as eDmaFmt_NV12, eDmaFmt_NV12_Y,
  *                        eDmaFmt_NV12_UV etc..
  * @param[in]   nsize - Number of format IDs provided
@@ -264,11 +263,11 @@ extern int32 nDmaWrapper_GetRecommendedWalkSize(t_eDmaFmt eFmtId, bool bIsUbwc,
 extern int32 nDmaWrapper_GetDescbuffsize(t_eDmaFmt *aeFmtId, uint16 nsize);
 
 /**
- * @brief       Get the recommended intermediate buffer stride.
+ * Get the recommended (minimum) intermediate buffer stride for the
+ * L2 Cache that is used transfer data from/to DDR. The stride is
+ * greater than or equal to the width and must be a multiple of 256.
  *
- * @description Get the recommended (minimum) intermediate buffer stride for the
- *              L2 Cache that is used transfer data from/to DDR. The stride is
- *              greater than or equal to the width and must be a multiple of 256.
+ * @brief       Get the recommended intermediate buffer stride.
  *
  * @param[in]   eFmtId - Format ID
  * @param[in]   pStRoiSize - The ROI that will be used (should be aligned with
@@ -283,10 +282,10 @@ extern int32 nDmaWrapper_GetRecommendedIntermBufStride(t_eDmaFmt eFmtId,
                                                        bool bIsUbwc);
 
 /**
- * @brief       Get the recommended intermediate buffer size
+ * Get the recommended intermediate buffer size for the L2 cache
+ * that is used to transfer data to/from DDR.
  *
- * @description Get the recommended intermediate buffer size for the L2 cache
- *              that is used to transfer data to/from DDR.
+ * @brief       Get the recommended intermediate buffer size
  *
  * @param[in]   eFmtId - Format ID
  * @param[in]   bUse16BitPaddingInL2 - Is padding to 16 bits done in the L2 (TRUE/FALSE)
@@ -312,15 +311,14 @@ extern int32 nDmaWrapper_GetRecommendedIntermBufSize(t_eDmaFmt eFmtId, bool bUse
                                                      bool bIsUbwc, uint16 u16IntermBufStride);
 
 /**
+ * Setup Dma transfer parameters required to be ready to make DMA transfer.
+ * call this API multiple to create a descriptor link list
+ *
  * @brief       Dma transfer parameters per HW descriptor
  *
- * @description Setup Dma transfer parameters required to be ready to make DMA transfer.
- *              call this API multiple to create a descriptor link list
- *
- * @param[in]   hDmaHandle - Wrapper's DMA Handle. Represents
- *              t_StDmaWrapper_DmaEngine.
+ * @param[in]   hDmaHandle - Wrapper's DMA Handle. Represents t_StDmaWrapper_DmaEngine.
  * @param[in]   stpDmaTransferParm - Dma Transfer parameters. Each element describes
- *              complete Frame/ROI details for this Dma transfer
+ *                                   complete Frame/ROI details for this Dma transfer
  *
  * @return      Success: OK
  *              Failure: ERR
@@ -328,18 +326,21 @@ extern int32 nDmaWrapper_GetRecommendedIntermBufSize(t_eDmaFmt eFmtId, bool bUse
 extern int32 nDmaWrapper_DmaTransferSetup(t_DmaWrapper_DmaEngineHandle hDmaHandle, t_StDmaWrapper_DmaTransferSetup *stpDmaTransferParm);
 
 /**
+ * DMA power voting based on Cornercase
+ *
  * @brief       DMA power voting based on Cornercase
  *
- * @description DMA power voting
- *
  * @param[in]   cornercase:
- *                  #define PW_MIN_SVS 0
- *                  #define PW_SVS2 1
- *                  #define PW_SVS 2
- *                  #define PW_SVS_L1 3
- *                  #define PW_NORMAL 4
- *                  #define PW_NORMAL_L1 5
- *                  #define PW_TURBO 6
+ *              \code{.cpp}
+ *              #define PW_MIN_SVS 0
+ *              #define PW_SVS2 1
+ *              #define PW_SVS 2
+ *              #define PW_SVS_L1 3
+ *              #define PW_NORMAL 4
+ *              #define PW_NORMAL_L1 5
+ *              #define PW_TURBO 6
+ *              \endcode
+ *
  * @return      Success: OK
  * @n           Failure: ERR
  */

--- a/src/runtime/mini_hexagon_dma.h
+++ b/src/runtime/mini_hexagon_dma.h
@@ -22,7 +22,7 @@ __inline static int align(int x, int a) {
 
 HALIDE_HEXAGON_ENUM{QURT_EOK = 0};
 
-/*!
+/**
  * Power Corner vote
  */
 #define PW_MIN_SVS 0
@@ -33,7 +33,7 @@ HALIDE_HEXAGON_ENUM{QURT_EOK = 0};
 #define PW_NORMAL_L1 5
 #define PW_TURBO 6
 
-/*!
+/**
  * Format IDs
  */
 typedef HALIDE_HEXAGON_ENUM{
@@ -54,296 +54,295 @@ typedef HALIDE_HEXAGON_ENUM{
     eDmaFmt_MAX,
 } t_eDmaFmt;
 
-/*!
-   * DMA status
-   * Currently not use, for future development
-   */
+/**
+ * DMA status
+ * Currently not use, for future development
+ */
 typedef void *t_stDmaWrapperDmaStats;
 
-/*!
-   * Transfer type
-   */
+/**
+ * Transfer type
+ */
 typedef HALIDE_HEXAGON_ENUM eDmaWrapper_TransationType{
-    //! DDR to L2 transfer
+    /// DDR to L2 transfer
     eDmaWrapper_DdrToL2,
-    //! L2 to DDR transfer
+    /// L2 to DDR transfer
     eDmaWrapper_L2ToDdr,
 } t_eDmaWrapper_TransationType;
 
-/*!
-   * Roi Properties
-   */
+/**
+ * Roi Properties
+ */
 typedef struct stDmaWrapper_Roi {
-    //! ROI x position in pixels
+    /// ROI x position in pixels
     uint16 u16X;
-    //! ROI y position in pixels
+    /// ROI y position in pixels
     uint16 u16Y;
-    //! ROI width in pixels
+    /// ROI width in pixels
     uint16 u16W;
-    //! ROI height in pixels
+    /// ROI height in pixels
     uint16 u16H;
 } t_StDmaWrapper_Roi;
 
-/*!
-   * Frame Properties
-   */
+/**
+ * Frame Properties
+ */
 typedef struct stDmaWrapper_FrameProp {
-    //! Starting physical address to buffer
+    /// Starting physical address to buffer
     addr_t aAddr;
-    //! Frame height in pixels
+    /// Frame height in pixels
     uint16 u16H;
-    //! Frame width in pixels
+    /// Frame width in pixels
     uint16 u16W;
-    //! Frame stride in pixels
+    /// Frame stride in pixels
     uint16 u16Stride;
 } t_StDmaWrapper_FrameProp;
 
-/*!
-   * Roi alignment
-   */
+/**
+ * Roi alignment
+ */
 typedef struct stDmaWrapper_RoiAlignInfo {
-    //! ROI width in pixels
+    /// ROI width in pixels
     uint16 u16W;
-    //! ROI height in pixels
+    /// ROI height in pixels
     uint16 u16H;
 } t_StDmaWrapper_RoiAlignInfo;
 
-/*!
-   * DmaTransferSetup Properties
-   */
-
+/**
+ * DmaTransferSetup Properties
+ */
 typedef struct stDmaWrapper_DmaTransferSetup {
-    //! Frame Width in pixels
+    /// Frame Width in pixels
     uint16 u16FrameW;
-    //! Frame height in pixels
+    /// Frame height in pixels
     uint16 u16FrameH;
-    //! Frame stride in pixels
+    /// Frame stride in pixels
     uint16 u16FrameStride;
-    //! ROI x position in pixels
+    /// ROI x position in pixels
     uint16 u16RoiX;
-    //! ROI y position in pixels
+    /// ROI y position in pixels
     uint16 u16RoiY;
-    //! ROI width in pixels
+    /// ROI width in pixels
     uint16 u16RoiW;
-    //! ROI height in pixels
+    /// ROI height in pixels
     uint16 u16RoiH;
-    //! ROI stride in pixels
+    /// ROI stride in pixels
     uint16 u16RoiStride;
-    //! Virtual address of the HW descriptor buffer (must be locked in the L2$).
+    /// Virtual address of the HW descriptor buffer (must be locked in the L2$).
     void *pDescBuf;
-    //! Virtual address of the TCM pixeldata buffer (must be locked in the L2$).
+    /// Virtual address of the TCM pixeldata buffer (must be locked in the L2$).
     void *pTcmDataBuf;
-    //! Virtual address of the DDR Frame buffer .
+    /// Virtual address of the DDR Frame buffer .
     void *pFrameBuf;
     //UBWC Format
     uint16 bIsFmtUbwc;
-    //! Should the intermediate buffer be padded. This only apply for 8bit format sucha NV12, NV12-4R
+    /// Should the intermediate buffer be padded. This only apply for 8bit format sucha NV12, NV12-4R
     uint16 bUse16BitPaddingInL2;
-    //! Format
+    /// Format
     t_eDmaFmt eFmt;
-    //! TransferType: eDmaWrapper_DdrToL2 (Read from DDR), eDmaWrapper_L2ToDDR (Write to DDR);
+    /// TransferType: eDmaWrapper_DdrToL2 (Read from DDR), eDmaWrapper_L2ToDDR (Write to DDR);
     t_eDmaWrapper_TransationType eTransferType;
 } t_StDmaWrapper_DmaTransferSetup;
 
-/*!
-   * @brief  API for Cache Allocation
-   * @description Abstraction for allocation of memory in cache and lock
-   *
-   * @return NULL or Memory
-   */
+/**
+ * @brief  API for Cache Allocation
+ * @description Abstraction for allocation of memory in cache and lock
+ *
+ * @return NULL or Memory
+ */
 void *HAP_cache_lock(unsigned int size, void **paddr_ptr);
 
-/*!
-   * @brief  API for Free
-   * @description Abstraction for deallocation of memory and unlock cache
-   *
-   * @return void
-   */
+/**
+ * @brief  API for Free
+ * @description Abstraction for deallocation of memory and unlock cache
+ *
+ * @return void
+ */
 int HAP_cache_unlock(void *vaddr_ptr);
 
-/*!
-   * Handle for wrapper DMA engine
-   */
+/**
+ * Handle for wrapper DMA engine
+ */
 typedef void *t_DmaWrapper_DmaEngineHandle;
 
-/*!
-   * @brief       Allocates a DMA Engine to be used
-   *
-   * @description Allocates a DMA Engine to be used by using the default
-   *              wait type (polling).
-   *
-   * @return      Success: Engine's DMA Handle
-   * @n           Failure: NULL
-   */
+/**
+ * @brief       Allocates a DMA Engine to be used
+ *
+ * @description Allocates a DMA Engine to be used by using the default
+ *              wait type (polling).
+ *
+ * @return      Success: Engine's DMA Handle
+ * @n           Failure: NULL
+ */
 extern t_DmaWrapper_DmaEngineHandle hDmaWrapper_AllocDma(void);
 
-/*!
-   * @brief       Frees a DMA Engine
-   *
-   * @description Frees a DMA Engine that was previously allocated by AllocDma().
-   *
-   * @input       hDmaHandle - Engine's DMA Handle
-   *
-   * @return      Success: OK
-   * @n           Failure: ERR
-   */
+/**
+ * @brief       Frees a DMA Engine
+ *
+ * @description Frees a DMA Engine that was previously allocated by AllocDma().
+ *
+ * @param[in]   hDmaHandle - Engine's DMA Handle
+ *
+ * @return      Success: OK
+ * @n           Failure: ERR
+ */
 extern int32 nDmaWrapper_FreeDma(t_DmaWrapper_DmaEngineHandle hDmaHandle);
 
-/*!
-   * @brief       Starts a transfer request on the DMA engine
-   *
-   * @description Starts a transfer on the provided DMA engine. The transfer is based
-   *              on descriptors constructed in earlier nDmaWrapper_Prepare() and
-   *              nDmaWrapper_Update() calls.
-   *
-   * @input       hDmaHandle - Engine's DMA Handle
-   *
-   * @return      Success: OK
-   * @n           Failure: ERR
-   */
+/**
+ * @brief       Starts a transfer request on the DMA engine
+ *
+ * @description Starts a transfer on the provided DMA engine. The transfer is based
+ *              on descriptors constructed in earlier nDmaWrapper_Prepare() and
+ *              nDmaWrapper_Update() calls.
+ *
+ * @param[in]   hDmaHandle - Engine's DMA Handle
+ *
+ * @return      Success: OK
+ * @n           Failure: ERR
+ */
 extern int32 nDmaWrapper_Move(t_DmaWrapper_DmaEngineHandle hDmaHandle);
 
-/*!
-   * @brief       Waits for all outstanding transfers on the DMA to complete
-   *
-   * @description Blocks until all outstanding transfers on the DMA are complete.
-   *              The wait type is based on the type specified when allocating the
-   *              engine.
-   *
-   * @input       hDmaHandle - Engine's DMA Handle
-   *
-   * @return      Success: OK
-   * @n           Failure: ERR
-   */
+/**
+ * @brief       Waits for all outstanding transfers on the DMA to complete
+ *
+ * @description Blocks until all outstanding transfers on the DMA are complete.
+ *              The wait type is based on the type specified when allocating the
+ *              engine.
+ *
+ * @param[in]   hDmaHandle - Engine's DMA Handle
+ *
+ * @return      Success: OK
+ * @n           Failure: ERR
+ */
 extern int32 nDmaWrapper_Wait(t_DmaWrapper_DmaEngineHandle hDmaHandle);
 
-/*!
-   * @brief       Cleans up all transfers and flushes DMA buffers
-   *
-   * @description This call flushes the DMA buffers.
-   *              Blocks until the flush of the DMA is complete.
-   *
-   * @input       hDmaHandle - Engine's DMA Handle
-   *
-   * @return      Success: OK
-   * @n           Failure: ERR
-   */
+/**
+ * @brief       Cleans up all transfers and flushes DMA buffers
+ *
+ * @description This call flushes the DMA buffers.
+ *              Blocks until the flush of the DMA is complete.
+ *
+ * @param[in]   hDmaHandle - Engine's DMA Handle
+ *
+ * @return      Success: OK
+ * @n           Failure: ERR
+ */
 extern int32 nDmaWrapper_FinishFrame(t_DmaWrapper_DmaEngineHandle hDmaHandle);
 
-/*!
-   * @brief       Get the recommended walk ROI width and height
-   *
-   * @description Get the recommended walk ROI width and height that should
-   *              be used if walking the entire frame. The ROI returned is always
-   *              in terms of frame dimensions. This function is different from
-   *              nDmaWrapper_GetRecommendedRoi() as coordinates are not used.
-   *
-   * @input       eFmtId - Format ID
-   * @input       bIsUbwc - Is the format UBWC (TRUE/FALSE)
-   * @inout       pStWalkSize - Initial walk size, will be overwritten with
-   *                            the recommended walk size to align with DMA
-   *                            requirements
-   *
-   * @return      Success: OK
-   * @n           Failure: ERR
-   */
+/**
+ * @brief         Get the recommended walk ROI width and height
+ *
+ * @description   Get the recommended walk ROI width and height that should
+ *                be used if walking the entire frame. The ROI returned is always
+ *                in terms of frame dimensions. This function is different from
+ *                nDmaWrapper_GetRecommendedRoi() as coordinates are not used.
+ *
+ * @param[in]     eFmtId - Format ID
+ * @param[in]     bIsUbwc - Is the format UBWC (TRUE/FALSE)
+ * @param[in,out] pStWalkSize - Initial walk size, will be overwritten with
+ *                              the recommended walk size to align with DMA
+ *                              requirements
+ *
+ * @return        Success: OK
+ * @n             Failure: ERR
+ */
 extern int32 nDmaWrapper_GetRecommendedWalkSize(t_eDmaFmt eFmtId, bool bIsUbwc,
                                                 t_StDmaWrapper_RoiAlignInfo *pStWalkSize);
 
-/*!
-   * @brief       Get the HW descriptor buffer size per DMA engine
-   *
-   * @description Calculates the HW descriptor buffer size based
-   *              on the formats that will be used with the engine.
-   *
-   * @input       aeFmtId - Array of format IDs, such as eDmaFmt_NV12, eDmaFmt_NV12_Y,
-   *                        eDmaFmt_NV12_UV etc..
-   * @input       nsize - Number of format IDs provided
-   *
-   * @return      Descriptor buffer size in bytes
-   */
+/**
+ * @brief       Get the HW descriptor buffer size per DMA engine
+ *
+ * @description Calculates the HW descriptor buffer size based
+ *              on the formats that will be used with the engine.
+ *
+ * @param[in]   aeFmtId - Array of format IDs, such as eDmaFmt_NV12, eDmaFmt_NV12_Y,
+ *                        eDmaFmt_NV12_UV etc..
+ * @param[in]   nsize - Number of format IDs provided
+ *
+ * @return      Descriptor buffer size in bytes
+ */
 extern int32 nDmaWrapper_GetDescbuffsize(t_eDmaFmt *aeFmtId, uint16 nsize);
 
-/*!
-   * @brief       Get the recommended intermediate buffer stride.
-   *
-   * @description Get the recommended (minimum) intermediate buffer stride for the
-   *              L2 Cache that is used transfer data from/to DDR. The stride is
-   *              greater than or equal to the width and must be a multiple of 256.
-   *
-   * @input       eFmtId - Format ID
-   * @input         pStRoiSize - The ROI that will be used (should be aligned with
-   *                           the DMA requirements for the format)
-   * @input         bIsUbwc - Is the format UBWC (TRUE/FALSE)
-   *
-   * @return      Success: The intermediate buffer stride in pixels
-   * @n           Failure: ERR
-   */
+/**
+ * @brief       Get the recommended intermediate buffer stride.
+ *
+ * @description Get the recommended (minimum) intermediate buffer stride for the
+ *              L2 Cache that is used transfer data from/to DDR. The stride is
+ *              greater than or equal to the width and must be a multiple of 256.
+ *
+ * @param[in]   eFmtId - Format ID
+ * @param[in]   pStRoiSize - The ROI that will be used (should be aligned with
+ *                           the DMA requirements for the format)
+ * @param[in]   bIsUbwc - Is the format UBWC (TRUE/FALSE)
+ *
+ * @return      Success: The intermediate buffer stride in pixels
+ * @n           Failure: ERR
+ */
 extern int32 nDmaWrapper_GetRecommendedIntermBufStride(t_eDmaFmt eFmtId,
                                                        t_StDmaWrapper_RoiAlignInfo *pStRoiSize,
                                                        bool bIsUbwc);
 
-/*!
-   * @brief       Get the recommended intermediate buffer size
-   *
-   * @description Get the recommended intermediate buffer size for the L2 cache
-   *              that is used to transfer data to/from DDR.
-   *
-   * @input       eFmtId - Format ID
-   * @input       bUse16BitPaddingInL2 - Is padding to 16 bits done in the L2 (TRUE/FALSE)
-   * @input       pStRoiSize - The ROI that will be used (should be aligned with
-   *                           DMA requirements for the format). The Chroma ROI must
-   *                           follow the standing convention that the provided
-   *                           width and height must be specified in terms of the
-   *                           Luma plane also such that when the width is divided
-   *                           by 2 it specifies the number of interleaved Chroma
-   *                           pixels.
-   * @input               bIsUbwc - Is the format UBWC (TRUE/FALSE), note that this should
-   *                        be set to TRUE if either the DDR input or output will
-   *                        be UBWC
-   * @input               u16IntermBufStride - The stride (in pixels) to use, the minimum
-   *                                   stride may be obtained by calling
-   *                                   nDmaWrapper_GetRecommendedIntermBufStride
-   *
-   * @return      Success: The intermediate buffer size in bytes
-   * @n           Failure: ERR
-   */
+/**
+ * @brief       Get the recommended intermediate buffer size
+ *
+ * @description Get the recommended intermediate buffer size for the L2 cache
+ *              that is used to transfer data to/from DDR.
+ *
+ * @param[in]   eFmtId - Format ID
+ * @param[in]   bUse16BitPaddingInL2 - Is padding to 16 bits done in the L2 (TRUE/FALSE)
+ * @param[in]   pStRoiSize - The ROI that will be used (should be aligned with
+ *                           DMA requirements for the format). The Chroma ROI must
+ *                           follow the standing convention that the provided
+ *                           width and height must be specified in terms of the
+ *                           Luma plane also such that when the width is divided
+ *                           by 2 it specifies the number of interleaved Chroma
+ *                           pixels.
+ * @param[in]   bIsUbwc - Is the format UBWC (TRUE/FALSE), note that this should
+ *                        be set to TRUE if either the DDR input or output will
+ *                        be UBWC
+ * @param[in]   u16IntermBufStride - The stride (in pixels) to use, the minimum
+ *                                   stride may be obtained by calling
+ *                                   nDmaWrapper_GetRecommendedIntermBufStride
+ *
+ * @return      Success: The intermediate buffer size in bytes
+ * @n           Failure: ERR
+ */
 extern int32 nDmaWrapper_GetRecommendedIntermBufSize(t_eDmaFmt eFmtId, bool bUse16BitPaddingInL2,
                                                      t_StDmaWrapper_RoiAlignInfo *pStRoiSize,
                                                      bool bIsUbwc, uint16 u16IntermBufStride);
 
-/*!
-   * @brief       Dma transfer parameters per HW descriptor
-   *
-   * @description Setup Dma transfer parameters required to be ready to make DMA transfer.
-   *              call this API multiple to create a descriptor link list
-   *
-   * @input       hDmaHandle - Wrapper's DMA Handle. Represents
-   *                  t_StDmaWrapper_DmaEngine.
-   * @input       stpDmaTransferParm - Dma Transfer parameters. Each element describes
-   *                  complete Frame/ROI details for this Dma transfer
-   *
-   * @return      Success: OK
-   *              Failure: ERR
-   */
+/**
+ * @brief       Dma transfer parameters per HW descriptor
+ *
+ * @description Setup Dma transfer parameters required to be ready to make DMA transfer.
+ *              call this API multiple to create a descriptor link list
+ *
+ * @param[in]   hDmaHandle - Wrapper's DMA Handle. Represents
+ *              t_StDmaWrapper_DmaEngine.
+ * @param[in]   stpDmaTransferParm - Dma Transfer parameters. Each element describes
+ *              complete Frame/ROI details for this Dma transfer
+ *
+ * @return      Success: OK
+ *              Failure: ERR
+ */
 extern int32 nDmaWrapper_DmaTransferSetup(t_DmaWrapper_DmaEngineHandle hDmaHandle, t_StDmaWrapper_DmaTransferSetup *stpDmaTransferParm);
 
-/*!
-   * @brief       DMA power voting based on Cornercase
-   *
-   * @description DMA power voting
-   *
-   * @input       cornercase:
-   *                            #define PW_MIN_SVS 0
-   *                            #define PW_SVS2 1
-   *                            #define PW_SVS 2
-   *                            #define PW_SVS_L1 3
-   *                            #define PW_NORMAL 4
-   *                            #define PW_NORMAL_L1 5
-   *                            #define PW_TURBO 6
-   * @return      Success: OK
-   * @n           Failure: ERR
-   */
+/**
+ * @brief       DMA power voting based on Cornercase
+ *
+ * @description DMA power voting
+ *
+ * @param[in]   cornercase:
+ *                  #define PW_MIN_SVS 0
+ *                  #define PW_SVS2 1
+ *                  #define PW_SVS 2
+ *                  #define PW_SVS_L1 3
+ *                  #define PW_NORMAL 4
+ *                  #define PW_NORMAL_L1 5
+ *                  #define PW_TURBO 6
+ * @return      Success: OK
+ * @n           Failure: ERR
+ */
 extern int32 nDmaWrapper_PowerVoting(uint32 cornercase);
 
 #ifdef __cplusplus

--- a/src/runtime/mini_qurt.h
+++ b/src/runtime/mini_qurt.h
@@ -23,6 +23,10 @@ typedef unsigned int qurt_thread_t;
 
 // clang-format off
 
+/**
+ * \defgroup qurt_thread_macros QURT threading macros
+ * @{
+ */
 #define QURT_HTHREAD_L1I_PREFETCH 0x1 /**< Enables hardware L1 instruction cache prefetching. */
 #define QURT_HTHREAD_L1D_PREFETCH 0x2 /**< Enables hardware L1 data cache prefetching. */
 #define QURT_HTHREAD_L2I_PREFETCH 0x4 /**< Enables hardware L2 instruction cache prefetching. */
@@ -40,7 +44,7 @@ typedef unsigned int qurt_thread_t;
 #define QURT_THREAD_ATTR_AFFINITY_DEFAULT (-1)                                    /**< */
 #define QURT_THREAD_ATTR_BUS_PRIO_DEFAULT 255                                     /**< */
 #define QURT_THREAD_ATTR_TIMETEST_ID_DEFAULT (-2)                                 /**< */
-/** @} */                                                                         /* end_addtogroup thread_macros */
+/** @} */
 
 // clang-format on
 

--- a/test/correctness/gather.cpp
+++ b/test/correctness/gather.cpp
@@ -88,8 +88,8 @@ int main() {
         !test<int8_t>() ||
         !test<uint16_t>() ||
         !test<int16_t>()
-        //!test<uint32_t>() ||
-        //!test<int32_t>()
+        // !test<uint32_t>() ||
+        // !test<int32_t>()
         ) return 1;
     printf("Success!\n");
     return 0;


### PR DESCRIPTION
Fixes warnings generated by bad Doxygen comments. Normalizes use of `/*!` vs `/**` and `//!` vs `///` to all be the non-`!` versions, which are predominant.