### PR TITLE
Don't codegen asserts in blocks when noasserts is on

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -4160,6 +4160,10 @@ void CodeGen_LLVM::visit(const Store *op) {
 }
 
 void CodeGen_LLVM::codegen_asserts(const vector<const AssertStmt *> &asserts) {
+    if (target.has_feature(Target::NoAsserts)) {
+        return;
+    }
+
     if (asserts.size() < 4) {
         for (const auto *a : asserts) {
             codegen(Stmt(a));


### PR DESCRIPTION
Fixes #5138