### PR TITLE
Add missing overload for boundary conditions on a buffer

### DIFF
--- a/apps/fft/fft.cpp
+++ b/apps/fft/fft.cpp
@@ -905,7 +905,7 @@ Func fft2d_c2r(ComplexFunc c,
     // Add a boundary condition to prevent scheduling from causing the
     // algorithms below to reach out of the bounds we promise to define in
     // forward FFTs.
-    c = ComplexFunc(repeat_edge((Func)c, Expr(0), Expr(N0), Expr(0), Expr((N1 + 1) / 2 + 1)));
+    c = ComplexFunc(repeat_edge((Func)c, {{Expr(0), Expr(N0)}, {Expr(0), Expr((N1 + 1) / 2 + 1)}}));
 
     // If this FFT is small, the logic related to zipping and unzipping
     // the FFT may be expensive compared to just brute forcing with a complex
@@ -1020,7 +1020,7 @@ Func fft2d_c2r(ComplexFunc c,
                        target,
                        &twiddle_cache);
 
-        ComplexFunc dft_padded = ComplexFunc(repeat_edge((Func)dft, Expr(), Expr(), Expr(0), Expr(N1)));
+        ComplexFunc dft_padded = ComplexFunc(repeat_edge((Func)dft, {{Expr(), Expr()}, {Expr(0), Expr(N1)}}));
 
         // Extract the real inverse DFTs.
         Expr unzip_n0 = (n0 / (zip_width * 2)) * zip_width + (n0 % zip_width);

--- a/src/BoundaryConditions.cpp
+++ b/src/BoundaryConditions.cpp
@@ -37,7 +37,7 @@ Func repeat_edge(const Func &source,
     return bounded;
 }
 
-Func constant_exterior(const Func &source, Tuple value,
+Func constant_exterior(const Func &source, const Tuple &value,
                        const Region &bounds) {
     std::vector<Var> source_args = source.args();
     std::vector<Var> args(source_args);

--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -57,7 +57,7 @@ inline HALIDE_NO_USER_CODE_INLINE void collect_region(Region &collected_args,
 
 template<typename... Args>
 inline HALIDE_NO_USER_CODE_INLINE void collect_region(Region &collected_args,
-                                                      const Expr &a1, const Expr &a2, Args &&... args) {
+                                                      const Expr &a1, const Expr &a2, Args &&...args) {
     collected_args.push_back(Range(a1, a2));
     collect_region(collected_args, std::forward<Args>(args)...);
 }
@@ -92,13 +92,23 @@ inline HALIDE_NO_USER_CODE_INLINE Func func_like_to_func(const T &func_like) {
  *  to bound.
  */
 // @{
-Func constant_exterior(const Func &source, Tuple value,
+Func constant_exterior(const Func &source, const Tuple &value,
                        const Region &bounds);
 Func constant_exterior(const Func &source, const Expr &value,
                        const Region &bounds);
 
 template<typename T>
-inline HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, Tuple value) {
+HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Tuple &value, const Region &bounds) {
+    return constant_exterior(Internal::func_like_to_func(func_like), value, bounds);
+}
+
+template<typename T>
+HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Expr &value, const Region &bounds) {
+    return constant_exterior(Internal::func_like_to_func(func_like), value, bounds);
+}
+
+template<typename T>
+HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Tuple &value) {
     Region object_bounds;
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.push_back({Expr(func_like.dim(i).min()), Expr(func_like.dim(i).extent())});
@@ -107,22 +117,22 @@ inline HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, Tup
     return constant_exterior(Internal::func_like_to_func(func_like), value, object_bounds);
 }
 template<typename T>
-inline HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Expr &value) {
+HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Expr &value) {
     return constant_exterior(func_like, Tuple(value));
 }
 
 template<typename T, typename... Bounds,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
-inline HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, Tuple value,
-                                                         Bounds &&... bounds) {
+HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Tuple &value,
+                                                  Bounds &&...bounds) {
     Region collected_bounds;
     Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
     return constant_exterior(Internal::func_like_to_func(func_like), value, collected_bounds);
 }
 template<typename T, typename... Bounds,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
-inline HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Expr &value,
-                                                         Bounds &&... bounds) {
+HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Expr &value,
+                                                  Bounds &&...bounds) {
     return constant_exterior(func_like, Tuple(value), std::forward<Bounds>(bounds)...);
 }
 // @}
@@ -143,7 +153,12 @@ inline HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, con
 Func repeat_edge(const Func &source, const Region &bounds);
 
 template<typename T>
-inline HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like) {
+HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like, const Region &bounds) {
+    return repeat_edge(Internal::func_like_to_func(func_like), bounds);
+}
+
+template<typename T>
+HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like) {
     Region object_bounds;
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.push_back({Expr(func_like.dim(i).min()), Expr(func_like.dim(i).extent())});
@@ -154,7 +169,8 @@ inline HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like) {
 
 template<typename T, typename... Bounds,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
-inline HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like, Bounds &&... bounds) {
+HALIDE_ATTRIBUTE_DEPRECATED("Add braces around the bounds like so: {{a, b}, {c, d}}")
+HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like, Bounds &&...bounds) {
     Region collected_bounds;
     Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
     return repeat_edge(Internal::func_like_to_func(func_like), collected_bounds);
@@ -177,7 +193,12 @@ inline HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like, Bounds &&
 Func repeat_image(const Func &source, const Region &bounds);
 
 template<typename T>
-inline HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like) {
+HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like, const Region &bounds) {
+    return repeat_image(Internal::func_like_to_func(func_like), bounds);
+}
+
+template<typename T>
+HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like) {
     Region object_bounds;
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.push_back({Expr(func_like.dim(i).min()), Expr(func_like.dim(i).extent())});
@@ -188,7 +209,8 @@ inline HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like) {
 
 template<typename T, typename... Bounds,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
-inline HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like, Bounds &&... bounds) {
+HALIDE_ATTRIBUTE_DEPRECATED("Add braces around the bounds like so: {{a, b}, {c, d}}")
+HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like, Bounds &&...bounds) {
     Region collected_bounds;
     Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
     return repeat_image(Internal::func_like_to_func(func_like), collected_bounds);
@@ -211,7 +233,12 @@ inline HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like, Bounds &
 Func mirror_image(const Func &source, const Region &bounds);
 
 template<typename T>
-inline HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like) {
+HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like, const Region &bounds) {
+    return mirror_image(Internal::func_like_to_func(func_like), bounds);
+}
+
+template<typename T>
+HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like) {
     Region object_bounds;
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.push_back({Expr(func_like.dim(i).min()), Expr(func_like.dim(i).extent())});
@@ -222,7 +249,8 @@ inline HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like) {
 
 template<typename T, typename... Bounds,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
-inline HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like, Bounds &&... bounds) {
+HALIDE_ATTRIBUTE_DEPRECATED("Add braces around the bounds like so: {{a, b}, {c, d}}")
+HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like, Bounds &&...bounds) {
     Region collected_bounds;
     Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
     return mirror_image(Internal::func_like_to_func(func_like), collected_bounds);
@@ -248,7 +276,12 @@ inline HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like, Bounds &
 Func mirror_interior(const Func &source, const Region &bounds);
 
 template<typename T>
-inline HALIDE_NO_USER_CODE_INLINE Func mirror_interior(const T &func_like) {
+HALIDE_NO_USER_CODE_INLINE Func mirror_interior(const T &func_like, const Region &bounds) {
+    return mirror_interior(Internal::func_like_to_func(func_like), bounds);
+}
+
+template<typename T>
+HALIDE_NO_USER_CODE_INLINE Func mirror_interior(const T &func_like) {
     Region object_bounds;
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.push_back({Expr(func_like.dim(i).min()), Expr(func_like.dim(i).extent())});
@@ -259,7 +292,8 @@ inline HALIDE_NO_USER_CODE_INLINE Func mirror_interior(const T &func_like) {
 
 template<typename T, typename... Bounds,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
-inline HALIDE_NO_USER_CODE_INLINE Func mirror_interior(const T &func_like, Bounds &&... bounds) {
+HALIDE_ATTRIBUTE_DEPRECATED("Add braces around the bounds like so: {{a, b}, {c, d}}")
+HALIDE_NO_USER_CODE_INLINE Func mirror_interior(const T &func_like, Bounds &&...bounds) {
     Region collected_bounds;
     Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
     return mirror_interior(Internal::func_like_to_func(func_like), collected_bounds);

--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -57,7 +57,7 @@ inline HALIDE_NO_USER_CODE_INLINE void collect_region(Region &collected_args,
 
 template<typename... Args>
 inline HALIDE_NO_USER_CODE_INLINE void collect_region(Region &collected_args,
-                                                      const Expr &a1, const Expr &a2, Args &&...args) {
+                                                      const Expr &a1, const Expr &a2, Args &&... args) {
     collected_args.push_back(Range(a1, a2));
     collect_region(collected_args, std::forward<Args>(args)...);
 }
@@ -124,7 +124,7 @@ HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Expr
 template<typename T, typename... Bounds,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
 HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Tuple &value,
-                                                  Bounds &&...bounds) {
+                                                  Bounds &&... bounds) {
     Region collected_bounds;
     Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
     return constant_exterior(Internal::func_like_to_func(func_like), value, collected_bounds);
@@ -132,7 +132,7 @@ HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Tupl
 template<typename T, typename... Bounds,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
 HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Expr &value,
-                                                  Bounds &&...bounds) {
+                                                  Bounds &&... bounds) {
     return constant_exterior(func_like, Tuple(value), std::forward<Bounds>(bounds)...);
 }
 // @}
@@ -170,7 +170,7 @@ HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like) {
 template<typename T, typename... Bounds,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
 HALIDE_ATTRIBUTE_DEPRECATED("Add braces around the bounds like so: {{a, b}, {c, d}}")
-HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like, Bounds &&...bounds) {
+HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like, Bounds &&... bounds) {
     Region collected_bounds;
     Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
     return repeat_edge(Internal::func_like_to_func(func_like), collected_bounds);
@@ -210,7 +210,7 @@ HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like) {
 template<typename T, typename... Bounds,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
 HALIDE_ATTRIBUTE_DEPRECATED("Add braces around the bounds like so: {{a, b}, {c, d}}")
-HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like, Bounds &&...bounds) {
+HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like, Bounds &&... bounds) {
     Region collected_bounds;
     Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
     return repeat_image(Internal::func_like_to_func(func_like), collected_bounds);
@@ -250,7 +250,7 @@ HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like) {
 template<typename T, typename... Bounds,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
 HALIDE_ATTRIBUTE_DEPRECATED("Add braces around the bounds like so: {{a, b}, {c, d}}")
-HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like, Bounds &&...bounds) {
+HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like, Bounds &&... bounds) {
     Region collected_bounds;
     Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
     return mirror_image(Internal::func_like_to_func(func_like), collected_bounds);
@@ -293,7 +293,7 @@ HALIDE_NO_USER_CODE_INLINE Func mirror_interior(const T &func_like) {
 template<typename T, typename... Bounds,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
 HALIDE_ATTRIBUTE_DEPRECATED("Add braces around the bounds like so: {{a, b}, {c, d}}")
-HALIDE_NO_USER_CODE_INLINE Func mirror_interior(const T &func_like, Bounds &&...bounds) {
+HALIDE_NO_USER_CODE_INLINE Func mirror_interior(const T &func_like, Bounds &&... bounds) {
     Region collected_bounds;
     Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
     return mirror_interior(Internal::func_like_to_func(func_like), collected_bounds);

--- a/test/correctness/boundary_conditions.cpp
+++ b/test/correctness/boundary_conditions.cpp
@@ -203,24 +203,24 @@ bool test_all(int vector_width, Target t) {
         // Func input.
         success &= check_repeat_edge(
             input,
-            repeat_edge(input_f, 0, W, 0, H),
+            repeat_edge(input_f, {{0, W}, {0, H}}),
             test_min, test_extent, test_min, test_extent,
             vector_width, t);
         // Image input.
         success &= check_repeat_edge(
             input,
-            repeat_edge(input, 0, W, 0, H),
+            repeat_edge(input, {{0, W}, {0, H}}),
             test_min, test_extent, test_min, test_extent,
             vector_width, t);
         // Undefined bounds.
         success &= check_repeat_edge(
             input,
-            repeat_edge(input, Expr(), Expr(), 0, H),
+            repeat_edge(input, {{Expr(), Expr()}, {0, H}}),
             0, W, test_min, test_extent,
             vector_width, t);
         success &= check_repeat_edge(
             input,
-            repeat_edge(input, 0, W, Expr(), Expr()),
+            repeat_edge(input, {{0, W}, {Expr(), Expr()}}),
             test_min, test_extent, 0, H,
             vector_width, t);
         // Implicitly determined bounds.
@@ -241,24 +241,24 @@ bool test_all(int vector_width, Target t) {
         // Func input.
         success &= check_constant_exterior(
             input, exterior,
-            constant_exterior(input_f, exterior, 0, W, 0, H),
+            constant_exterior(input_f, exterior, {{0, W}, {0, H}}),
             test_min, test_extent, test_min, test_extent,
             vector_width, t);
         // Image input.
         success &= check_constant_exterior(
             input, exterior,
-            constant_exterior(input, exterior, 0, W, 0, H),
+            constant_exterior(input, exterior, {{0, W}, {0, H}}),
             test_min, test_extent, test_min, test_extent,
             vector_width, t);
         // Undefined bounds.
         success &= check_constant_exterior(
             input, exterior,
-            constant_exterior(input, exterior, Expr(), Expr(), 0, H),
+            constant_exterior(input, exterior, {{Expr(), Expr()}, {0, H}}),
             0, W, test_min, test_extent,
             vector_width, t);
         success &= check_constant_exterior(
             input, exterior,
-            constant_exterior(input, exterior, 0, W, Expr(), Expr()),
+            constant_exterior(input, exterior, {{0, W}, {Expr(), Expr()}}),
             test_min, test_extent, 0, H,
             vector_width, t);
         // Implicitly determined bounds.
@@ -277,24 +277,24 @@ bool test_all(int vector_width, Target t) {
         // Func input.
         success &= check_repeat_image(
             input,
-            repeat_image(input_f, 0, W, 0, H),
+            repeat_image(input_f, {{0, W}, {0, H}}),
             test_min, test_extent, test_min, test_extent,
             vector_width, t);
         // Image input.
         success &= check_repeat_image(
             input,
-            repeat_image(input, 0, W, 0, H),
+            repeat_image(input, {{0, W}, {0, H}}),
             test_min, test_extent, test_min, test_extent,
             vector_width, t);
         // Undefined bounds.
         success &= check_repeat_image(
             input,
-            repeat_image(input, Expr(), Expr(), 0, H),
+            repeat_image(input, {{Expr(), Expr()}, {0, H}}),
             0, W, test_min, test_extent,
             vector_width, t);
         success &= check_repeat_image(
             input,
-            repeat_image(input, 0, W, Expr(), Expr()),
+            repeat_image(input, {{0, W}, {Expr(), Expr()}}),
             test_min, test_extent, 0, H,
             vector_width, t);
         // Implicitly determined bounds.
@@ -313,24 +313,24 @@ bool test_all(int vector_width, Target t) {
         // Func input.
         success &= check_mirror_image(
             input,
-            mirror_image(input_f, 0, W, 0, H),
+            mirror_image(input_f, {{0, W}, {0, H}}),
             test_min, test_extent, test_min, test_extent,
             vector_width, t);
         // Image input.
         success &= check_mirror_image(
             input,
-            mirror_image(input, 0, W, 0, H),
+            mirror_image(input, {{0, W}, {0, H}}),
             test_min, test_extent, test_min, test_extent,
             vector_width, t);
         // Undefined bounds.
         success &= check_mirror_image(
             input,
-            mirror_image(input, Expr(), Expr(), 0, H),
+            mirror_image(input, {{Expr(), Expr()}, {0, H}}),
             0, W, test_min, test_extent,
             vector_width, t);
         success &= check_mirror_image(
             input,
-            mirror_image(input, 0, W, Expr(), Expr()),
+            mirror_image(input, {{0, W}, {Expr(), Expr()}}),
             test_min, test_extent, 0, H,
             vector_width, t);
         // Implicitly determined bounds.
@@ -349,24 +349,24 @@ bool test_all(int vector_width, Target t) {
         // Func input.
         success &= check_mirror_interior(
             input,
-            mirror_interior(input_f, 0, W, 0, H),
+            mirror_interior(input_f, {{0, W}, {0, H}}),
             test_min, test_extent, test_min, test_extent,
             vector_width, t);
         // Image input.
         success &= check_mirror_interior(
             input,
-            mirror_interior(input, 0, W, 0, H),
+            mirror_interior(input, {{0, W}, {0, H}}),
             test_min, test_extent, test_min, test_extent,
             vector_width, t);
         // Undefined bounds.
         success &= check_mirror_interior(
             input,
-            mirror_interior(input, Expr(), Expr(), 0, H),
+            mirror_interior(input, {{Expr(), Expr()}, {0, H}}),
             0, W, test_min, test_extent,
             vector_width, t);
         success &= check_mirror_interior(
             input,
-            mirror_interior(input, 0, W, Expr(), Expr()),
+            mirror_interior(input, {{0, W}, {Expr(), Expr()}}),
             test_min, test_extent, 0, H,
             vector_width, t);
         // Implicitly determined bounds.

--- a/test/correctness/likely.cpp
+++ b/test/correctness/likely.cpp
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
     // is if you use a boundary condition helper:
 
     {
-        Func g = BoundaryConditions::repeat_edge(f, 0, 100);
+        Func g = BoundaryConditions::repeat_edge(f, {{0, 100}});
         count_partitions(g, 3);
     }
 
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
         Func g;
         g(x, y) = x + y;
         g.compute_root();
-        Func h = BoundaryConditions::mirror_image(g, 0, 10, 0, 10);
+        Func h = BoundaryConditions::mirror_image(g, {{0, 10}, {0, 10}});
         count_partitions(h, 5);
     }
 
@@ -140,7 +140,7 @@ int main(int argc, char **argv) {
     // slice of the loop where *all* of the boundary conditions and
     // splitting logic simplify away.
     {
-        Func g = BoundaryConditions::mirror_interior(f, 0, 10);
+        Func g = BoundaryConditions::mirror_interior(f, {{0, 10}});
         Func h;
         Param<int> t1, t2;
         h(x) = g(x - 1) + g(x + 1);

--- a/test/correctness/require.cpp
+++ b/test/correctness/require.cpp
@@ -67,7 +67,7 @@ static void test(int vector_width) {
 
     ImageParam input(Int(32), 2);
     Expr h = require(p1 == p2, p1);
-    Func clamped = BoundaryConditions::repeat_edge(input, 0, 64, 0, h);
+    Func clamped = BoundaryConditions::repeat_edge(input, {{0, 64}, {0, h}});
     clamped.set_error_handler(&halide_error);
 
     Buffer<int32_t> input_buf(64, 64);

--- a/test/generator/blur2x2_generator.cpp
+++ b/test/generator/blur2x2_generator.cpp
@@ -31,8 +31,8 @@ public:
         // input.extent() would tell the calling kernel we can cope with any size
         // input, so it would always pass us 1x1 tiles.)
 
-        Func input_clamped = Halide::BoundaryConditions::repeat_edge(
-            input, 0, width, 0, height);
+        Func input_clamped =
+            Halide::BoundaryConditions::repeat_edge(input, {{0, width}, {0, height}});
 
         blur(x, y, c) =
             (input_clamped(x - 1, y, c) + input_clamped(x + 1, y, c) +


### PR DESCRIPTION
The following syntax did not work due to a lack of appropriate overload:

repeat_edge(buffer, {{0, W}, {0, H}})

The version that worked was:

repeat_edge(buffer, 0, W, 0, H)

but that syntax has fallen out of favor

This PR adds an overload to make the former syntax work, and explicitly
deprecates the latter.

Also removed inline qualifiers on some templated functions, because
they're already inline, and changed an arg to be by const ref instead of
pointlessly by value.