### PR TITLE
Rename WITH_PTX to WITH_NVPTX so all WITH_* macros match LLVM component names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ WITH_MIPS ?= $(findstring mips, $(LLVM_COMPONENTS))
 WITH_RISCV ?= $(findstring riscv, $(LLVM_COMPONENTS))
 WITH_AARCH64 ?= $(findstring aarch64, $(LLVM_COMPONENTS))
 WITH_POWERPC ?= $(findstring powerpc, $(LLVM_COMPONENTS))
-WITH_PTX ?= $(findstring nvptx, $(LLVM_COMPONENTS))
+WITH_NVPTX ?= $(findstring nvptx, $(LLVM_COMPONENTS))
 # AMDGPU target is WIP
 WITH_AMDGPU ?= $(findstring amdgpu, $(LLVM_COMPONENTS))
 WITH_OPENCL ?= not-empty
@@ -141,9 +141,9 @@ MIPS_LLVM_CONFIG_LIB=$(if $(WITH_MIPS), mips, )
 POWERPC_CXX_FLAGS=$(if $(WITH_POWERPC), -DWITH_POWERPC, )
 POWERPC_LLVM_CONFIG_LIB=$(if $(WITH_POWERPC), powerpc, )
 
-PTX_CXX_FLAGS=$(if $(WITH_PTX), -DWITH_NVPTX, )
-PTX_LLVM_CONFIG_LIB=$(if $(WITH_PTX), nvptx, )
-PTX_DEVICE_INITIAL_MODULES=$(if $(WITH_PTX), libdevice.compute_20.10.bc libdevice.compute_30.10.bc libdevice.compute_35.10.bc, )
+PTX_CXX_FLAGS=$(if $(WITH_NVPTX), -DWITH_NVPTX, )
+PTX_LLVM_CONFIG_LIB=$(if $(WITH_NVPTX), nvptx, )
+PTX_DEVICE_INITIAL_MODULES=$(if $(WITH_NVPTX), libdevice.compute_20.10.bc libdevice.compute_30.10.bc libdevice.compute_35.10.bc, )
 
 AMDGPU_CXX_FLAGS=$(if $(WITH_AMDGPU), -DWITH_AMDGPU, )
 AMDGPU_LLVM_CONFIG_LIB=$(if $(WITH_AMDGPU), amdgpu, )
@@ -275,7 +275,7 @@ ifeq ($(WITH_LLVM_INSIDE_SHARED_LIBHALIDE), )
 TEST_LD_FLAGS += -Wl,--rpath=$(LLVM_LIBDIR)
 endif
 
-ifneq ($(WITH_PTX), )
+ifneq ($(WITH_NVPTX), )
 ifneq (,$(findstring ptx,$(HL_TARGET)))
 TEST_CUDA = 1
 endif

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ MIPS_LLVM_CONFIG_LIB=$(if $(WITH_MIPS), mips, )
 POWERPC_CXX_FLAGS=$(if $(WITH_POWERPC), -DWITH_POWERPC, )
 POWERPC_LLVM_CONFIG_LIB=$(if $(WITH_POWERPC), powerpc, )
 
-PTX_CXX_FLAGS=$(if $(WITH_PTX), -DWITH_PTX, )
+PTX_CXX_FLAGS=$(if $(WITH_PTX), -DWITH_NVPTX, )
 PTX_LLVM_CONFIG_LIB=$(if $(WITH_PTX), nvptx, )
 PTX_DEVICE_INITIAL_MODULES=$(if $(WITH_PTX), libdevice.compute_20.10.bc libdevice.compute_30.10.bc libdevice.compute_35.10.bc, )
 

--- a/dependencies/llvm/CMakeLists.txt
+++ b/dependencies/llvm/CMakeLists.txt
@@ -50,77 +50,30 @@ function(check_llvm_target TARGET HAS_TARGET)
     endif ()
 endfunction()
 
-check_llvm_target(AArch64 WITH_AARCH64)
-check_llvm_target(AMDGPU WITH_AMDGPU)
-check_llvm_target(ARM WITH_ARM)
-check_llvm_target(Hexagon WITH_HEXAGON)
-check_llvm_target(Mips WITH_MIPS)
-check_llvm_target(NVPTX WITH_NVPTX)
-check_llvm_target(PowerPC WITH_POWERPC)
-check_llvm_target(RISCV WITH_RISCV)
-check_llvm_target(WebAssembly WITH_WEBASSEMBLY)
-check_llvm_target(X86 WITH_X86)
-
 ##
 # Create options that are initialized based on LLVM's config
 ##
 
 set(LLVM_COMPONENTS mcjit bitwriter linker passes)
-
-option(TARGET_AARCH64 "Include AARCH64 (arm64) target" ${WITH_AARCH64})
-if (TARGET_AARCH64)
-    target_compile_definitions(Halide_LLVM INTERFACE WITH_AARCH64)
-    list(APPEND LLVM_COMPONENTS AArch64)
-endif ()
-
-option(TARGET_AMDGPU "Include AMDGPU target" ${WITH_AMDGPU})
-if (TARGET_AMDGPU)
-    target_compile_definitions(Halide_LLVM INTERFACE WITH_AMDGPU)
-    list(APPEND LLVM_COMPONENTS AMDGPU)
-endif ()
-
-option(TARGET_ARM "Include ARM target" ${WITH_ARM})
-if (TARGET_ARM)
-    target_compile_definitions(Halide_LLVM INTERFACE WITH_ARM)
-    list(APPEND LLVM_COMPONENTS ARM)
-endif ()
-
-option(TARGET_HEXAGON "Include Hexagon target" ${WITH_HEXAGON})
-if (TARGET_HEXAGON)
-    target_compile_definitions(Halide_LLVM INTERFACE WITH_HEXAGON)
-    list(APPEND LLVM_COMPONENTS Hexagon)
-endif ()
-
-option(TARGET_MIPS "Include MIPS target" ${WITH_MIPS})
-if (TARGET_MIPS)
-    target_compile_definitions(Halide_LLVM INTERFACE WITH_MIPS)
-    list(APPEND LLVM_COMPONENTS Mips)
-endif ()
-
-option(TARGET_PTX "Include PTX target" ${WITH_NVPTX})
-if (TARGET_PTX)
-    target_compile_definitions(Halide_LLVM INTERFACE WITH_PTX)
-    list(APPEND LLVM_COMPONENTS NVPTX)
-endif ()
-
-option(TARGET_POWERPC "Include POWERPC target" ${WITH_POWERPC})
-if (TARGET_POWERPC)
-    target_compile_definitions(Halide_LLVM INTERFACE WITH_POWERPC)
-    list(APPEND LLVM_COMPONENTS PowerPC)
-endif ()
-
-option(TARGET_RISCV "Include RISCV target" ${WITH_RISCV})
-if (TARGET_RISCV)
-    target_compile_definitions(Halide_LLVM INTERFACE WITH_RISCV)
-    list(APPEND LLVM_COMPONENTS RISCV)
-endif ()
+set(known_components AArch64 AMDGPU ARM Hexagon Mips NVPTX PowerPC RISCV WebAssembly X86)
 
 # We don't support LLVM10 or below for wasm codegen.
 if (LLVM_PACKAGE_VERSION VERSION_LESS 11.0)
-    set(WITH_WEBASSEMBLY OFF)
+    list(REMOVE_ITEM known_components WebAssembly)
 endif ()
 
-option(TARGET_WEBASSEMBLY "Include WebAssembly target" ${WITH_WEBASSEMBLY})
+foreach (comp IN LISTS known_components)
+    string(TOUPPER "TARGET_${comp}" OPTION)
+    string(TOUPPER "WITH_${comp}" DEFINE)
+
+    check_llvm_target(${comp} present)
+    option(${OPTION} "Include ${comp} target" ${present})
+    if (${OPTION})
+        target_compile_definitions(Halide_LLVM INTERFACE ${DEFINE})
+        list(APPEND LLVM_COMPONENTS ${comp})
+    endif ()
+endforeach ()
+
 if (TARGET_WEBASSEMBLY)
     ##
     # lld libraries -- inexplicably, LLVM doesn't put these in the CMake imports,
@@ -135,24 +88,17 @@ if (TARGET_WEBASSEMBLY)
     set_target_properties(LLDCommon PROPERTIES IMPORTED_LOCATION ${LLD_COMMON})
 
     if (NOT LLD_WASM OR NOT LLD_COMMON)
-        message(WARNING 
+        message(WARNING
                 "Could not find both lldWasm and lldCommon in ${LLVM_LIBRARY_DIRS}. "
                 "Configure with -DTARGET_WEBASSEMBLY=NO to suppress. "
                 "Do you need to install liblld-${LLVM_VERSION_MAJOR}?")
     else ()
-        target_compile_definitions(Halide_LLVM INTERFACE WITH_WEBASSEMBLY)
         target_link_libraries(Halide_LLVM INTERFACE LLDWasm LLDCommon)
 
         # lto and options aren't needed to *generate* WebAssembly, but they
         # are needed to link in LLDWasm.
-        list(APPEND LLVM_COMPONENTS WebAssembly lto option)
+        list(APPEND LLVM_COMPONENTS lto option)
     endif ()
-endif ()
-
-option(TARGET_X86 "Include x86 target" ${WITH_X86})
-if (TARGET_X86)
-    target_compile_definitions(Halide_LLVM INTERFACE WITH_X86)
-    list(APPEND LLVM_COMPONENTS X86)
 endif ()
 
 ##
@@ -233,6 +179,5 @@ install(TARGETS Halide_LanguageOptions EXPORT Halide_Targets)
 # fully private implementation detail as far as CMake is concerned, so it
 # then doesn't need to expose any LLVM-related dependencies through targets.
 if (NOT BUILD_SHARED_LIBS)
-    install(TARGETS Halide_LLVM
-            EXPORT Halide_Targets)
+    install(TARGETS Halide_LLVM EXPORT Halide_Targets)
 endif ()

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -95,7 +95,7 @@ using std::vector;
 #define InitializeARMAsmPrinter() InitializeAsmPrinter(ARM)
 #endif
 
-#ifdef WITH_PTX
+#ifdef WITH_NVPTX
 #define InitializeNVPTXTarget() InitializeTarget(NVPTX)
 #define InitializeNVPTXAsmParser() InitializeAsmParser(NVPTX)
 #define InitializeNVPTXAsmPrinter() InitializeAsmPrinter(NVPTX)

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -18,7 +18,7 @@
 
 // This is declared in NVPTX.h, which is not exported. Ugly, but seems better than
 // hardcoding a path to the .h file.
-#ifdef WITH_PTX
+#ifdef WITH_NVPTX
 namespace llvm {
 FunctionPass *createNVVMReflectPass(const StringMap<int> &Mapping);
 }
@@ -34,7 +34,7 @@ using namespace llvm;
 
 CodeGen_PTX_Dev::CodeGen_PTX_Dev(Target host)
     : CodeGen_LLVM(host) {
-#if !defined(WITH_PTX)
+#if !defined(WITH_NVPTX)
     user_error << "ptx not enabled for this build of Halide.\n";
 #endif
     user_assert(llvm_NVPTX_enabled) << "llvm build not configured with nvptx target enabled\n.";
@@ -150,7 +150,7 @@ void CodeGen_PTX_Dev::add_kernel(Stmt stmt,
 void CodeGen_PTX_Dev::init_module() {
     init_context();
 
-#ifdef WITH_PTX
+#ifdef WITH_NVPTX
     module = get_initial_module_for_ptx_device(target, context);
 #endif
 }
@@ -536,7 +536,7 @@ bool CodeGen_PTX_Dev::use_soft_float_abi() const {
 
 vector<char> CodeGen_PTX_Dev::compile_to_src() {
 
-#ifdef WITH_PTX
+#ifdef WITH_NVPTX
 
     debug(2) << "In CodeGen_PTX_Dev::compile_to_src";
 
@@ -707,7 +707,7 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     // Null-terminate the ptx source
     buffer.push_back(0);
     return buffer;
-#else  // WITH_PTX
+#else  // WITH_NVPTX
     return vector<char>();
 #endif
 }

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -202,11 +202,11 @@ DECLARE_NO_INITMOD(aarch64)
 DECLARE_NO_INITMOD(aarch64_cpu_features)
 #endif  // WITH_AARCH64
 
-#ifdef WITH_PTX
+#ifdef WITH_NVPTX
 DECLARE_LL_INITMOD(ptx_compute_20)
 DECLARE_LL_INITMOD(ptx_compute_30)
 DECLARE_LL_INITMOD(ptx_compute_35)
-#endif  // WITH_PTX
+#endif  // WITH_NVPTX
 
 #ifdef WITH_X86
 DECLARE_LL_INITMOD(x86_avx2)
@@ -1198,7 +1198,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
     return std::move(modules[0]);
 }
 
-#ifdef WITH_PTX
+#ifdef WITH_NVPTX
 std::unique_ptr<llvm::Module> get_initial_module_for_ptx_device(Target target, llvm::LLVMContext *c) {
     std::vector<std::unique_ptr<llvm::Module>> modules;
     modules.push_back(get_initmod_ptx_dev_ll(c));

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -643,7 +643,7 @@ bool Target::supported() const {
 #if !defined(WITH_RISCV)
     bad |= arch == Target::RISCV;
 #endif
-#if !defined(WITH_PTX)
+#if !defined(WITH_NVPTX)
     bad |= has_feature(Target::CUDA);
 #endif
 #if !defined(WITH_OPENCL)

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -281,11 +281,11 @@ halide_define_aot_test(variable_num_threads ENABLE_IF NOT ${USING_WASM})
 
 # Acquire-Release test requires CUDA
 halide_define_aot_test(acquire_release)
-if (TARGET_PTX AND Halide_TARGET MATCHES "cuda")
+if (TARGET_NVPTX AND Halide_TARGET MATCHES "cuda")
     include(AddCudaToTarget)
     add_cuda_to_target(generator_aot_acquire_release PRIVATE)
 endif ()
-if (TARGET_PTX AND Halide_TARGET MATCHES "opencl")
+if (TARGET_NVPTX AND Halide_TARGET MATCHES "opencl")
     find_package(OpenCL REQUIRED)
     target_link_libraries(generator_aot_acquire_release PRIVATE OpenCL::OpenCL)
 endif ()
@@ -311,7 +311,7 @@ endif()
 halide_define_aot_test(cxx_mangling ENABLE_IF NOT ${USING_WASM})  # Needs extra deps / build rules
 if (TARGET cxx_mangling)
     target_link_libraries(cxx_mangling INTERFACE cxx_mangling_externs)
-    if (TARGET_PTX AND Halide_TARGET MATCHES "cuda")
+    if (TARGET_NVPTX AND Halide_TARGET MATCHES "cuda")
         add_halide_library(cxx_mangling_gpu
                            FROM cxx_mangling.generator
                            GENERATOR cxx_mangling
@@ -330,7 +330,7 @@ endif ()
 
 # Define extern for OpenCL
 halide_define_aot_test(define_extern_opencl)
-if (TARGET_PTX AND Halide_TARGET MATCHES "opencl")
+if (TARGET_NVPTX AND Halide_TARGET MATCHES "opencl")
     find_package(OpenCL REQUIRED)
     target_link_libraries(generator_aot_define_extern_opencl PRIVATE OpenCL::OpenCL)
 endif ()

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -50,7 +50,7 @@ add_tutorial(lesson_07_multi_stage_pipelines.cpp WITH_IMAGE_IO)
 add_tutorial(lesson_08_scheduling_2.cpp WITH_IMAGE_IO WITH_OPENMP)
 add_tutorial(lesson_09_update_definitions.cpp WITH_IMAGE_IO WITH_OPENMP)
 
-if (TARGET_PTX)
+if (TARGET_NVPTX)
     if (TARGET_WEBASSEMBLY AND Halide_TARGET MATCHES "wasm")
         # TODO: Requires custom build rules to work under wasm.
         message(WARNING "Not all tutorials build under WASM.")


### PR DESCRIPTION
I'm in the process of making CMake bundle LLVM as part of Halide and I'm finding that I need to contort my way around these defines because one of them -- WITH_PTX -- is not named after its corresponding LLVM component, NVPTX.

This one small change drops ~60 lines of CMake while touching ~10 lines elsewhere.