### PR TITLE
Add a Target to the args of infer_input_bounds()

### DIFF
--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -271,22 +271,22 @@ void define_func(py::module &m) {
             .def("output_buffers", &Func::output_buffers)
 
             .def(
-                "infer_input_bounds", [](Func &f, int x_size, int y_size, int z_size, int w_size) -> void {
-                    f.infer_input_bounds(x_size, y_size, z_size, w_size);
+                "infer_input_bounds", [](Func &f, int x_size, int y_size, int z_size, int w_size, const Target &target) -> void {
+                    f.infer_input_bounds(x_size, y_size, z_size, w_size, target);
                 },
-                py::arg("x_size") = 0, py::arg("y_size") = 0, py::arg("z_size") = 0, py::arg("w_size") = 0)
+                py::arg("x_size") = 0, py::arg("y_size") = 0, py::arg("z_size") = 0, py::arg("w_size") = 0, py::arg("target") = get_jit_target_from_environment())
 
             .def(
-                "infer_input_bounds", [](Func &f, Buffer<> buffer) -> void {
-                    f.infer_input_bounds(buffer);
+                "infer_input_bounds", [](Func &f, Buffer<> buffer, const Target &target) -> void {
+                    f.infer_input_bounds(buffer, target);
                 },
-                py::arg("dst"))
+                py::arg("dst"), py::arg("target") = get_jit_target_from_environment())
 
             .def(
-                "infer_input_bounds", [](Func &f, std::vector<Buffer<>> buffer) -> void {
+                "infer_input_bounds", [](Func &f, std::vector<Buffer<>> buffer, const Target &target) -> void {
                     f.infer_input_bounds(Realization(buffer));
                 },
-                py::arg("dst"))
+                py::arg("dst"), py::arg("target") = get_jit_target_from_environment())
 
             .def("in_", (Func(Func::*)(const Func &)) & Func::in, py::arg("f"))
             .def("in_", (Func(Func::*)(const std::vector<Func> &fs)) & Func::in, py::arg("fs"))

--- a/python_bindings/src/PyPipeline.cpp
+++ b/python_bindings/src/PyPipeline.cpp
@@ -138,21 +138,21 @@ void define_pipeline(py::module &m) {
                 py::arg("x_size"), py::arg("y_size"), py::arg("z_size"), py::arg("w_size"), py::arg("target") = Target())
 
             .def(
-                "infer_input_bounds", [](Pipeline &p, int x_size, int y_size, int z_size, int w_size) -> void {
-                    p.infer_input_bounds(x_size, y_size, z_size, w_size);
+                "infer_input_bounds", [](Pipeline &p, int x_size, int y_size, int z_size, int w_size, const Target &target) -> void {
+                    p.infer_input_bounds(x_size, y_size, z_size, w_size, target);
                 },
-                py::arg("x_size") = 0, py::arg("y_size") = 0, py::arg("z_size") = 0, py::arg("w_size") = 0)
+                py::arg("x_size") = 0, py::arg("y_size") = 0, py::arg("z_size") = 0, py::arg("w_size") = 0, py::arg("target") = get_jit_target_from_environment())
 
             .def(
-                "infer_input_bounds", [](Pipeline &p, Buffer<> buffer) -> void {
-                    p.infer_input_bounds(Realization(buffer));
+                "infer_input_bounds", [](Pipeline &p, Buffer<> buffer, const Target &target) -> void {
+                    p.infer_input_bounds(Realization(buffer), target);
                 },
-                py::arg("dst"))
+                py::arg("dst"), py::arg("target") = get_jit_target_from_environment())
             .def(
-                "infer_input_bounds", [](Pipeline &p, std::vector<Buffer<>> buffers) -> void {
+                "infer_input_bounds", [](Pipeline &p, std::vector<Buffer<>> buffers, const Target &target) -> void {
                     p.infer_input_bounds(Realization(buffers));
                 },
-                py::arg("dst"))
+                py::arg("dst"), py::arg("target") = get_jit_target_from_environment())
 
             .def("infer_arguments", [](Pipeline &p) -> std::vector<Argument> {
                 return p.infer_arguments();

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2991,6 +2991,7 @@ Realization Func::realize(const Target &target,
 }
 
 void Func::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
+                              const Target &target,
                               const ParamMap &param_map) {
     user_assert(defined()) << "Can't infer input bounds on an undefined Func.\n";
     vector<Buffer<>> outputs(func.outputs());
@@ -3004,7 +3005,7 @@ void Func::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
         outputs[i] = std::move(im);
     }
     Realization r(outputs);
-    infer_input_bounds(r, param_map);
+    infer_input_bounds(r, target, param_map);
 }
 
 OutputImageParam Func::output_buffer() const {
@@ -3187,9 +3188,9 @@ void Func::realize(Pipeline::RealizationArg outputs, const Target &target,
     pipeline().realize(std::move(outputs), target, param_map);
 }
 
-void Func::infer_input_bounds(Pipeline::RealizationArg outputs,
+void Func::infer_input_bounds(Pipeline::RealizationArg outputs, const Target &target,
                               const ParamMap &param_map) {
-    pipeline().infer_input_bounds(std::move(outputs), param_map);
+    pipeline().infer_input_bounds(std::move(outputs), target, param_map);
 }
 
 void Func::compile_jit(const Target &target) {

--- a/src/Func.h
+++ b/src/Func.h
@@ -833,15 +833,17 @@ public:
 
      Target t = get_jit_target_from_environment();
      Buffer<> in;
-     f.infer_input_bounds(10, 10, t, { { img, &in } });
+     f.infer_input_bounds(10, 10, 0, 0, t, { { img, &in } });
      \endcode
      * On return, in will be an allocated buffer of the correct size
      * to evaulate f over a 10x10 region.
      */
     // @{
     void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0,
+                            const Target &target = get_jit_target_from_environment(),
                             const ParamMap &param_map = ParamMap::empty_map());
     void infer_input_bounds(Pipeline::RealizationArg outputs,
+                            const Target &target = get_jit_target_from_environment(),
                             const ParamMap &param_map = ParamMap::empty_map());
     // @}
 

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -1164,13 +1164,9 @@ void Pipeline::realize(RealizationArg outputs, const Target &t,
     jit_context.finalize(exit_status);
 }
 
-void Pipeline::infer_input_bounds(RealizationArg outputs, const ParamMap &param_map) {
-    if (!contents->jit_module.compiled() ||
-        contents->jit_target.has_feature(Target::NoBoundsQuery)) {
-        Target target = get_jit_target_from_environment();
-        target.set_feature(Target::NoBoundsQuery, false);
-        compile_jit(target);
-    }
+void Pipeline::infer_input_bounds(RealizationArg outputs, const Target &target, const ParamMap &param_map) {
+    user_assert(!target.has_feature(Target::NoBoundsQuery)) << "You may not call infer_input_bounds() with Target::NoBoundsQuery set.";
+    compile_jit(target);
 
     // This has to happen after a runtime has been compiled in compile_jit.
     JITFuncCallContext jit_context(jit_handlers());
@@ -1274,6 +1270,7 @@ void Pipeline::infer_input_bounds(RealizationArg outputs, const ParamMap &param_
 }
 
 void Pipeline::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
+                                  const Target &target,
                                   const ParamMap &param_map) {
     user_assert(defined()) << "Can't infer input bounds on an undefined Pipeline.\n";
 
@@ -1288,7 +1285,7 @@ void Pipeline::infer_input_bounds(int x_size, int y_size, int z_size, int w_size
         bufs.emplace_back(t, size);
     }
     Realization r(bufs);
-    infer_input_bounds(r, param_map);
+    infer_input_bounds(r, target, param_map);
 }
 
 void Pipeline::invalidate_cache() {

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -499,8 +499,10 @@ public:
      * ImageParams. */
     // @{
     void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0,
+                            const Target &target = get_jit_target_from_environment(),
                             const ParamMap &param_map = ParamMap::empty_map());
     void infer_input_bounds(RealizationArg output,
+                            const Target &target = get_jit_target_from_environment(),
                             const ParamMap &param_map = ParamMap::empty_map());
     // @}
 

--- a/test/correctness/param_map.cpp
+++ b/test/correctness/param_map.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
     // Test bounds inference
     Buffer<uint8_t> in_bounds;
 
-    f.infer_input_bounds(20, 20, 0, 0, {{p_img, &in_bounds}});
+    f.infer_input_bounds(20, 20, 0, 0, t, {{p_img, &in_bounds}});
 
     assert(in_bounds.defined());
     assert(in_bounds.dim(0).extent() == 20);

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -224,8 +224,7 @@ public:
                                     .without_feature(Target::NoAsserts)
                                     .without_feature(Target::NoBoundsQuery);
 
-            error.compile_jit(run_target);
-            error.infer_input_bounds();
+            error.infer_input_bounds(0, 0, 0, 0, run_target);
             // Fill the inputs with noise
             std::mt19937 rng(123);
             for (auto p : image_params) {


### PR DESCRIPTION
Currently, if the code isn't already jitted (or is jitted with NoBoundsQuery enabled), infer_input_bounds() falls back to whatever is in HL_JIT_TARGET. This is suboptimal, because it hides the fact that infer_input_bounds() relies on the value of that env var. It can also cause unintentional incorrect re-jits; e.g. if simd_op_check is run for HL_TARGET=wasm-32-wasmrt (and HL_JIT_TARGET not set at all), the infer_input_bounds() call can end up re-jitting for native code instead of WebAssembly.