### PR TITLE
Clean up is-jit-compiled checks in Pipeline

### DIFF
--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -529,31 +529,38 @@ std::string Pipeline::generate_function_name() const {
     return name;
 }
 
+// This essentially is just a getter for contents->jit_target,
+// but also reality-checks that the status of the jit_module and/or wasm_module
+// match what we expect.
+Target Pipeline::get_compiled_jit_target() const {
+    const bool has_wasm = contents->wasm_module.contents.defined();
+    const bool has_native = contents->jit_module.compiled();
+    if (contents->jit_target.arch == Target::WebAssembly) {
+        internal_assert(has_wasm && !has_native);
+    } else if (contents->jit_target.defined()) {
+        internal_assert(!has_wasm && has_native);
+    } else {
+        internal_assert(!has_wasm && !has_native);
+    }
+    return contents->jit_target;
+}
+
 void Pipeline::compile_jit(const Target &target_arg) {
     user_assert(defined()) << "Pipeline is undefined\n";
+    user_assert(target_arg.defined()) << "Cannot compile_jit() for target '" << target_arg << "'\n";
 
     Target target(target_arg);
     target.set_feature(Target::JIT);
     target.set_feature(Target::UserContext);
 
-    debug(2) << "jit-compiling for: " << target_arg << "\n";
-
-    // If we're re-jitting for the same target, we can just keep the
-    // old jit module.
-    if (contents->jit_target == target) {
-        if (target.arch == Target::WebAssembly) {
-            if (contents->wasm_module.contents.defined()) {
-                debug(2) << "Reusing old wasm module compiled for :\n"
-                         << contents->jit_target << "\n";
-                return;
-            }
-        }
-        if (contents->jit_module.compiled()) {
-            debug(2) << "Reusing old jit module compiled for :\n"
-                     << contents->jit_target << "\n";
-            return;
-        }
+    // If we're re-jitting for the same target, we can just keep the old jit module.
+    if (get_compiled_jit_target() == target) {
+        debug(2) << "Reusing old jit module compiled for :\n"
+                 << target << "\n";
+        return;
     }
+
+    debug(2) << "jit-compiling for: " << target_arg << "\n";
 
     // Clear all cached info in case there is an error.
     contents->invalidate_cache();
@@ -1060,12 +1067,10 @@ void Pipeline::realize(RealizationArg outputs, const Target &t,
 
     debug(2) << "Realizing Pipeline for " << target << "\n";
 
-    // If target is unspecified...
-    if (target.os == Target::OSUnknown) {
+    if (!target.defined()) {
         // If we've already jit-compiled for a specific target, use that.
-        if (contents->jit_module.compiled()) {
-            target = contents->jit_target;
-        } else {
+        target = get_compiled_jit_target();
+        if (!target.defined()) {
             // Otherwise get the target from the environment
             target = get_jit_target_from_environment();
         }

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -537,7 +537,7 @@ Target Pipeline::get_compiled_jit_target() const {
     const bool has_native = contents->jit_module.compiled();
     if (contents->jit_target.arch == Target::WebAssembly) {
         internal_assert(has_wasm && !has_native);
-    } else if (contents->jit_target.defined()) {
+    } else if (!contents->jit_target.has_unknowns()) {
         internal_assert(!has_wasm && has_native);
     } else {
         internal_assert(!has_wasm && !has_native);
@@ -547,7 +547,7 @@ Target Pipeline::get_compiled_jit_target() const {
 
 void Pipeline::compile_jit(const Target &target_arg) {
     user_assert(defined()) << "Pipeline is undefined\n";
-    user_assert(target_arg.defined()) << "Cannot compile_jit() for target '" << target_arg << "'\n";
+    user_assert(!target_arg.has_unknowns()) << "Cannot compile_jit() for target '" << target_arg << "'\n";
 
     Target target(target_arg);
     target.set_feature(Target::JIT);
@@ -1067,10 +1067,10 @@ void Pipeline::realize(RealizationArg outputs, const Target &t,
 
     debug(2) << "Realizing Pipeline for " << target << "\n";
 
-    if (!target.defined()) {
+    if (target.has_unknowns()) {
         // If we've already jit-compiled for a specific target, use that.
         target = get_compiled_jit_target();
-        if (!target.defined()) {
+        if (target.has_unknowns()) {
             // Otherwise get the target from the environment
             target = get_jit_target_from_environment();
         }

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -159,6 +159,10 @@ private:
 
     int call_jit_code(const Target &target, const JITCallArgs &args);
 
+    // Get the value of contents->jit_target, but reality-check that the contents
+    // sensibly match the value. Return Target() if not jitted.
+    Target get_compiled_jit_target() const;
+
 public:
     /** Make an undefined Pipeline object. */
     Pipeline();

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -661,6 +661,10 @@ bool Target::supported() const {
     return !bad;
 }
 
+bool Target::defined() const {
+    return os != OSUnknown && arch != ArchUnknown && bits > 0;
+}
+
 void Target::set_feature(Feature f, bool value) {
     if (f == FeatureEnd) return;
     user_assert(f < FeatureEnd) << "Invalid Target feature.\n";
@@ -816,7 +820,7 @@ Target::Feature target_feature_for_device_api(DeviceAPI api) {
 }
 
 int Target::natural_vector_size(const Halide::Type &t) const {
-    user_assert(os != OSUnknown && arch != ArchUnknown && bits != 0)
+    user_assert(defined())
         << "natural_vector_size cannot be used on a Target with Unknown values.\n";
 
     const bool is_integer = t.is_int() || t.is_uint();

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -661,8 +661,8 @@ bool Target::supported() const {
     return !bad;
 }
 
-bool Target::defined() const {
-    return os != OSUnknown && arch != ArchUnknown && bits > 0;
+bool Target::has_unknowns() const {
+    return os == OSUnknown || arch == ArchUnknown || bits == 0;
 }
 
 void Target::set_feature(Feature f, bool value) {
@@ -820,7 +820,7 @@ Target::Feature target_feature_for_device_api(DeviceAPI api) {
 }
 
 int Target::natural_vector_size(const Halide::Type &t) const {
-    user_assert(defined())
+    user_assert(!has_unknowns())
         << "natural_vector_size cannot be used on a Target with Unknown values.\n";
 
     const bool is_integer = t.is_int() || t.is_uint();

--- a/src/Target.h
+++ b/src/Target.h
@@ -151,6 +151,10 @@ struct Target {
     /** Check if a target string is valid. */
     static bool validate_target_string(const std::string &s);
 
+    /** Return true if all of the arch/bits/os fields are well-defined;
+        return false if any of them are false/zero. */
+    bool defined() const;
+
     void set_feature(Feature f, bool value = true);
 
     void set_features(const std::vector<Feature> &features_to_set, bool value = true);

--- a/src/Target.h
+++ b/src/Target.h
@@ -151,9 +151,9 @@ struct Target {
     /** Check if a target string is valid. */
     static bool validate_target_string(const std::string &s);
 
-    /** Return true if all of the arch/bits/os fields are well-defined;
-        return false if any of them are false/zero. */
-    bool defined() const;
+    /** Return true if any of the arch/bits/os fields are "unknown"/0;
+        return false otherwise. */
+    bool has_unknowns() const;
 
     void set_feature(Feature f, bool value = true);
 


### PR DESCRIPTION
Because WebAssembly is a special beast, the way it is 'jitted' is special, and the checks to avoid redundant jitting needed extra logic in compile_jit(). Unfortunately there was another place in Pipeline that also needed this special casing. This PR adds a `get_compiled_jit_target()` bottleneck to consolidate this.

(Also added the `Target::defined()` method as a quick way to determine "are any parts of this Target unknown" -- not sure if this is the best name for the method. `is_unknown()`? Something else?)