### PR TITLE
Add infer_input_bounds(vector<int>)

### DIFF
--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -272,19 +272,46 @@ void define_func(py::module &m) {
 
             .def(
                 "infer_input_bounds", [](Func &f, int x_size, int y_size, int z_size, int w_size, const Target &target) -> void {
-                    f.infer_input_bounds(x_size, y_size, z_size, w_size, target);
+                    PyErr_WarnEx(PyExc_DeprecationWarning,
+                                 "Call infer_input_bounds() with an explicit list of ints instead.",
+                                 1);
+                    std::vector<int32_t> sizes;
+                    if (x_size) sizes.push_back(x_size);
+                    if (y_size) sizes.push_back(y_size);
+                    if (z_size) sizes.push_back(z_size);
+                    if (w_size) sizes.push_back(w_size);
+                    f.infer_input_bounds(sizes, target);
                 },
                 py::arg("x_size") = 0, py::arg("y_size") = 0, py::arg("z_size") = 0, py::arg("w_size") = 0, py::arg("target") = get_jit_target_from_environment())
 
             .def(
-                "infer_input_bounds", [](Func &f, Buffer<> buffer, const Target &target) -> void {
-                    f.infer_input_bounds(buffer, target);
-                },
-                py::arg("dst"), py::arg("target") = get_jit_target_from_environment())
+                "infer_input_bounds", [](Func &f, py::object dst, const Target &target) -> void {
+                    // dst could be Buffer<>, vector<Buffer>, or vector<int>
+                    try {
+                        Buffer<> b = dst.cast<Buffer<>>();
+                        f.infer_input_bounds(b, target);
+                        return;
+                    } catch (...) {
+                        // fall thru
+                    }
 
-            .def(
-                "infer_input_bounds", [](Func &f, std::vector<Buffer<>> buffer, const Target &target) -> void {
-                    f.infer_input_bounds(Realization(buffer));
+                    try {
+                        std::vector<Buffer<>> v = dst.cast<std::vector<Buffer<>>>();
+                        f.infer_input_bounds(Realization(v), target);
+                        return;
+                    } catch (...) {
+                        // fall thru
+                    }
+
+                    try {
+                        std::vector<int32_t> v = dst.cast<std::vector<int32_t>>();
+                        f.infer_input_bounds(v, target);
+                        return;
+                    } catch (...) {
+                        // fall thru
+                    }
+
+                    throw py::value_error("Invalid arguments to infer_input_bounds");
                 },
                 py::arg("dst"), py::arg("target") = get_jit_target_from_environment())
 

--- a/python_bindings/src/PyPipeline.cpp
+++ b/python_bindings/src/PyPipeline.cpp
@@ -137,20 +137,49 @@ void define_pipeline(py::module &m) {
                 },
                 py::arg("x_size"), py::arg("y_size"), py::arg("z_size"), py::arg("w_size"), py::arg("target") = Target())
 
+            // TODO: deprecate/remove when the C++ non-vector version of this API is removed
             .def(
                 "infer_input_bounds", [](Pipeline &p, int x_size, int y_size, int z_size, int w_size, const Target &target) -> void {
-                    p.infer_input_bounds(x_size, y_size, z_size, w_size, target);
+                    PyErr_WarnEx(PyExc_DeprecationWarning,
+                                 "Call infer_input_bounds() with an explicit list of ints instead.",
+                                 1);
+                    std::vector<int32_t> sizes;
+                    if (x_size) sizes.push_back(x_size);
+                    if (y_size) sizes.push_back(y_size);
+                    if (z_size) sizes.push_back(z_size);
+                    if (w_size) sizes.push_back(w_size);
+                    p.infer_input_bounds(sizes, target);
                 },
                 py::arg("x_size") = 0, py::arg("y_size") = 0, py::arg("z_size") = 0, py::arg("w_size") = 0, py::arg("target") = get_jit_target_from_environment())
 
             .def(
-                "infer_input_bounds", [](Pipeline &p, Buffer<> buffer, const Target &target) -> void {
-                    p.infer_input_bounds(Realization(buffer), target);
-                },
-                py::arg("dst"), py::arg("target") = get_jit_target_from_environment())
-            .def(
-                "infer_input_bounds", [](Pipeline &p, std::vector<Buffer<>> buffers, const Target &target) -> void {
-                    p.infer_input_bounds(Realization(buffers));
+                "infer_input_bounds", [](Pipeline &p, py::object dst, const Target &target) -> void {
+                    // dst could be Buffer<>, vector<Buffer>, or vector<int>
+                    try {
+                        Buffer<> b = dst.cast<Buffer<>>();
+                        p.infer_input_bounds(b, target);
+                        return;
+                    } catch (...) {
+                        // fall thru
+                    }
+
+                    try {
+                        std::vector<Buffer<>> v = dst.cast<std::vector<Buffer<>>>();
+                        p.infer_input_bounds(Realization(v), target);
+                        return;
+                    } catch (...) {
+                        // fall thru
+                    }
+
+                    try {
+                        std::vector<int32_t> v = dst.cast<std::vector<int32_t>>();
+                        p.infer_input_bounds(v, target);
+                        return;
+                    } catch (...) {
+                        // fall thru
+                    }
+
+                    throw py::value_error("Invalid arguments to infer_input_bounds");
                 },
                 py::arg("dst"), py::arg("target") = get_jit_target_from_environment())
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2993,7 +2993,6 @@ Realization Func::realize(const Target &target,
 void Func::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
                               const Target &target,
                               const ParamMap &param_map) {
-    user_assert(0) << "do not call";
     vector<int32_t> sizes;
     if (x_size) sizes.push_back(x_size);
     if (y_size) sizes.push_back(y_size);

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2993,13 +2993,20 @@ Realization Func::realize(const Target &target,
 void Func::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
                               const Target &target,
                               const ParamMap &param_map) {
-    user_assert(defined()) << "Can't infer input bounds on an undefined Func.\n";
-    vector<Buffer<>> outputs(func.outputs());
-    vector<int> sizes;
+    user_assert(0) << "do not call";
+    vector<int32_t> sizes;
     if (x_size) sizes.push_back(x_size);
     if (y_size) sizes.push_back(y_size);
     if (z_size) sizes.push_back(z_size);
     if (w_size) sizes.push_back(w_size);
+    infer_input_bounds(sizes, target, param_map);
+}
+
+void Func::infer_input_bounds(const std::vector<int32_t> &sizes,
+                              const Target &target,
+                              const ParamMap &param_map) {
+    user_assert(defined()) << "Can't infer input bounds on an undefined Func.\n";
+    vector<Buffer<>> outputs(func.outputs());
     for (size_t i = 0; i < outputs.size(); i++) {
         Buffer<> im(func.output_types()[i], nullptr, sizes);
         outputs[i] = std::move(im);

--- a/src/Func.h
+++ b/src/Func.h
@@ -833,15 +833,28 @@ public:
 
      Target t = get_jit_target_from_environment();
      Buffer<> in;
-     f.infer_input_bounds(10, 10, 0, 0, t, { { img, &in } });
+     f.infer_input_bounds({10, 10}, t, { { img, &in } });
      \endcode
      * On return, in will be an allocated buffer of the correct size
      * to evaulate f over a 10x10 region.
      */
     // @{
+    void infer_input_bounds(const std::vector<int32_t> &sizes,
+                            const Target &target = get_jit_target_from_environment(),
+                            const ParamMap &param_map = ParamMap::empty_map());
+    HALIDE_ATTRIBUTE_DEPRECATED("Call infer_input_bounds() with an explicit vector<int> instead")
     void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0,
                             const Target &target = get_jit_target_from_environment(),
                             const ParamMap &param_map = ParamMap::empty_map());
+    // TODO: this is a temporary wrapper used to disambiguate the cases where
+    // a single-entry braced list would match the deprecated overload
+    // (rather than the vector overload); when the deprecated method is removed,
+    // this should be removed, too
+    void infer_input_bounds(const std::initializer_list<int> &sizes,
+                            const Target &target = get_jit_target_from_environment(),
+                            const ParamMap &param_map = ParamMap::empty_map()) {
+        infer_input_bounds(std::vector<int>{sizes}, target, param_map);
+    }
     void infer_input_bounds(Pipeline::RealizationArg outputs,
                             const Target &target = get_jit_target_from_environment(),
                             const ParamMap &param_map = ParamMap::empty_map());

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -1272,17 +1272,21 @@ void Pipeline::infer_input_bounds(RealizationArg outputs, const Target &target, 
 void Pipeline::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
                                   const Target &target,
                                   const ParamMap &param_map) {
+    vector<int32_t> sizes;
+    if (x_size) sizes.push_back(x_size);
+    if (y_size) sizes.push_back(y_size);
+    if (z_size) sizes.push_back(z_size);
+    if (w_size) sizes.push_back(w_size);
+    infer_input_bounds(sizes, target, param_map);
+}
+
+void Pipeline::infer_input_bounds(const std::vector<int32_t> &sizes,
+                                  const Target &target,
+                                  const ParamMap &param_map) {
     user_assert(defined()) << "Can't infer input bounds on an undefined Pipeline.\n";
-
-    vector<int> size;
-    if (x_size) size.push_back(x_size);
-    if (y_size) size.push_back(y_size);
-    if (z_size) size.push_back(z_size);
-    if (w_size) size.push_back(w_size);
-
     vector<Buffer<>> bufs;
     for (Type t : contents->outputs[0].output_types()) {
-        bufs.emplace_back(t, size);
+        bufs.emplace_back(t, sizes);
     }
     Realization r(bufs);
     infer_input_bounds(r, target, param_map);

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -498,9 +498,22 @@ public:
      * of the appropriate size and binding them to the unbound
      * ImageParams. */
     // @{
+    void infer_input_bounds(const std::vector<int32_t> &sizes,
+                            const Target &target = get_jit_target_from_environment(),
+                            const ParamMap &param_map = ParamMap::empty_map());
+    HALIDE_ATTRIBUTE_DEPRECATED("Call infer_input_bounds() with an explicit vector<int> instead")
     void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0,
                             const Target &target = get_jit_target_from_environment(),
                             const ParamMap &param_map = ParamMap::empty_map());
+    // TODO: this is a temporary wrapper used to disambiguate the cases where
+    // a single-entry braced list would match the deprecated overload
+    // (rather than the vector overload); when the deprecated method is removed,
+    // this should be removed, too
+    void infer_input_bounds(const std::initializer_list<int> &sizes,
+                            const Target &target = get_jit_target_from_environment(),
+                            const ParamMap &param_map = ParamMap::empty_map()) {
+        infer_input_bounds(std::vector<int>{sizes}, target, param_map);
+    }
     void infer_input_bounds(RealizationArg output,
                             const Target &target = get_jit_target_from_environment(),
                             const ParamMap &param_map = ParamMap::empty_map());

--- a/test/correctness/autotune_bug.cpp
+++ b/test/correctness/autotune_bug.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
         .reorder(y, x);
 
     blur_y.compile_jit();
-    blur_y.infer_input_bounds(AUTOTUNE_N);
+    blur_y.infer_input_bounds({AUTOTUNE_N});
     assert(in_img.get().data());
     blur_y.realize(AUTOTUNE_N);
 

--- a/test/correctness/bounds_of_monotonic_math.cpp
+++ b/test/correctness/bounds_of_monotonic_math.cpp
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
 
     f(x) = input(cast<int>(ceil(0.3f * ceil(0.4f * floor(x * 22.5f)))));
 
-    f.infer_input_bounds(10);
+    f.infer_input_bounds({10});
 
     Buffer<float> in = input.get();
 

--- a/test/correctness/extern_bounds_inference.cpp
+++ b/test/correctness/extern_bounds_inference.cpp
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
 
         f.define_extern("translate", args, UInt(8), 2);
 
-        f.infer_input_bounds(W, H);
+        f.infer_input_bounds({W, H});
 
         // Evaluating the output over [0, 29] x [0, 19] requires the input over [3, 32] x [7, 26]
         check(input, 3, W, 7, H);
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
         Var xi, yi;
         g.tile(x, y, xi, yi, 2, 4);
 
-        g.infer_input_bounds(W, H);
+        g.infer_input_bounds({W, H});
 
         check(input, 3, W + 5, 7, H + 10);
     }
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
         f2.compute_at(g, x);
         g.reorder(y, x).vectorize(y, 4);
 
-        g.infer_input_bounds(W, H);
+        g.infer_input_bounds({W, H});
 
         check(input, 3, W + 5, 7, H + 10);
     }

--- a/test/correctness/param_map.cpp
+++ b/test/correctness/param_map.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
     // Test bounds inference
     Buffer<uint8_t> in_bounds;
 
-    f.infer_input_bounds(20, 20, 0, 0, t, {{p_img, &in_bounds}});
+    f.infer_input_bounds({20, 20}, t, {{p_img, &in_bounds}});
 
     assert(in_bounds.defined());
     assert(in_bounds.dim(0).extent() == 20);

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -224,7 +224,7 @@ public:
                                     .without_feature(Target::NoAsserts)
                                     .without_feature(Target::NoBoundsQuery);
 
-            error.infer_input_bounds(0, 0, 0, 0, run_target);
+            error.infer_input_bounds({}, run_target);
             // Fill the inputs with noise
             std::mt19937 rng(123);
             for (auto p : image_params) {

--- a/test/correctness/specialize.cpp
+++ b/test/correctness/specialize.cpp
@@ -232,7 +232,7 @@ int main(int argc, char **argv) {
         f.set_custom_trace(&my_trace);
 
         // Check bounds inference is still cool with widths < 8
-        f.infer_input_bounds(5);
+        f.infer_input_bounds({5});
         int m = im.get().min(0), e = im.get().extent(0);
         if (m != 0 || e != 5) {
             printf("min, extent = %d, %d instead of 0, 5\n", m, e);
@@ -270,7 +270,7 @@ int main(int argc, char **argv) {
         f.specialize(param);
 
         param.set(true);
-        f.infer_input_bounds(100);
+        f.infer_input_bounds({100});
         int m = im.get().min(0);
         if (m != 10) {
             printf("min %d instead of 10\n", m);
@@ -278,7 +278,7 @@ int main(int argc, char **argv) {
         }
         param.set(false);
         im.reset();
-        f.infer_input_bounds(100);
+        f.infer_input_bounds({100});
         m = im.get().min(0);
         if (m != -10) {
             printf("min %d instead of -10\n", m);
@@ -347,7 +347,7 @@ int main(int argc, char **argv) {
         f.specialize(cond).vectorize(x, 4);
 
         // Confirm that the unrolling applies to both cases using bounds inference:
-        f.infer_input_bounds(3, 1);
+        f.infer_input_bounds({3, 1});
 
         if (im.get().extent(0) != 3) {
             printf("extent(0) was supposed to be 3.\n");
@@ -467,7 +467,7 @@ int main(int argc, char **argv) {
         // depending on the param.
 
         p.set(100);
-        f.infer_input_bounds(10);
+        f.infer_input_bounds({10});
         int w = im.get().width();
         int h = im.get().height();
         if (w != 10 || h != 1) {
@@ -477,7 +477,7 @@ int main(int argc, char **argv) {
         im.reset();
 
         p.set(-100);
-        f.infer_input_bounds(10);
+        f.infer_input_bounds({10});
         w = im.get().width();
         h = im.get().height();
         if (w != 1 || h != 10) {
@@ -501,7 +501,7 @@ int main(int argc, char **argv) {
         // does when p is 100), we only access the first row of the
         // input, and bounds inference should recognize this.
         p.set(100);
-        f.infer_input_bounds(10);
+        f.infer_input_bounds({10});
         int w = im.get().width();
         int h = im.get().height();
         if (w != 10 || h != 1) {
@@ -516,7 +516,7 @@ int main(int argc, char **argv) {
         // are evaluated, so the image must be loaded over the full
         // square.
         p.set(-100);
-        f.infer_input_bounds(10);
+        f.infer_input_bounds({10});
         w = im.get().width();
         h = im.get().height();
         if (w != 10 || h != 10) {

--- a/test/correctness/unsafe_promises.cpp
+++ b/test/correctness/unsafe_promises.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
 
         f(x) = lut(unsafe_promise_clamped(in(x), Expr(), 99));
 
-        f.infer_input_bounds(10);
+        f.infer_input_bounds({10});
         Buffer<float> lut_bounds = lut.get();
 
         assert(lut_bounds.dim(0).min() == 0 && lut_bounds.dim(0).extent() == 100);
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
 
         f(x) = lut(unsafe_promise_clamped(in(x), 10, Expr()));
 
-        f.infer_input_bounds(10);
+        f.infer_input_bounds({10});
         Buffer<float> lut_bounds = lut.get();
 
         assert(lut_bounds.dim(0).min() == 10 && lut_bounds.dim(0).extent() == 246);

--- a/test/error/expanding_reduction.cpp
+++ b/test/error/expanding_reduction.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
 
     g(x, y) = f(x, y);
 
-    g.infer_input_bounds(100, 100);
+    g.infer_input_bounds({100, 100});
 
     Buffer<int> in(input.get());
     assert(in.height() == 102 && in.width() == 100);

--- a/test/error/impossible_constraints.cpp
+++ b/test/error/impossible_constraints.cpp
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
     // The requires that the input be larger than the input
     out() = input(input.width(), input.height()) + input(0, 0);
 
-    out.infer_input_bounds();
+    out.infer_input_bounds({});
 
     printf("Success!\n");
     return 0;


### PR DESCRIPTION
Add a variant of infer_input_bounds() that takes an explicit vector of int, rather than the up-to-4-int version that is a holdover from the buffer_t days; deprecate the old version; convert all existing code to use the new one.

~~There are two warts here, unfortunately: in theory we should be able to just wrap the ints in {braces}, but in practice that doesn't work for zero- or one-arg lists:~~
~~- zero-arg vectors are ambiguous wrt other overloads of the method, and the compiler will select a deprecated one~~
~~- one-arg vectors are broken in C++ with brace initialization, as a single-integer arg will invoke the "create a vector of this length" ctor rather than "create a vector of length one with this value" ctor.~~

~~These two warts leave me with a bad taste in my mouth; the 'new' approach of always a list of sizes, rather than a sorta-vararg approach, is clearly better, and yet, the ugly code in some places is ugly.~~

Added a temporary initializer-list overload to avoid `{}` and `{1}` from overloading in a way that required the annotations; PTAL
