### PR TITLE
Remove unnecessary call to halide.hexagon.pack.vh in CG_HVX

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -9,7 +9,6 @@
 #include "CSE.h"
 #include "CodeGen_Internal.h"
 #include "Debug.h"
-#include "EliminateBoolVectors.h"
 #include "HexagonOptimize.h"
 #include "IREquality.h"
 #include "IRMatch.h"
@@ -2096,9 +2095,6 @@ Value *CodeGen_Hexagon::vlut(Value *lut, Value *idx, int min_index, int max_inde
         // After we've eliminated the invalid elements, we can
         // truncate to 8 bits, as vlut requires.
         indices = call_intrin(i8x_t, "halide.hexagon.pack.vh", {indices});
-        use_index = (lut_ty->getScalarSizeInBits() == 8) ?
-                        call_intrin(i8x_t, "halide.hexagon.pack.vh", {use_index}) :
-                        use_index;
 
         int range_extent_i = std::min(max_index - min_index_i, 255);
         Value *range_i = vlut256(slice_vector(lut, min_index_i, range_extent_i),

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -304,6 +304,11 @@ public:
         check("vlut16(v*.b,v*.h,r*)", hvx_width / 2, in_u32(u8_1));
         check("vlut16(v*.b,v*.h,r*)", hvx_width / 2, in_u32(clamp(u16_1, 0, 15)));
 
+        // This tests the case of vlut with > 256 elements (thus forcing us to split into
+        // multiple vluts)
+        check("vlut16(v*.b,v*.h,r*)", hvx_width * 3, in_u16(x * 3));
+        check("vlut32(v*.b,v*.b,r*)", hvx_width * 3, in_u8(x * 3));
+
         check("v*.ub = vpack(v*.h,v*.h):sat", hvx_width / 1, u8_sat(i16_1));
         check("v*.b = vpack(v*.h,v*.h):sat", hvx_width / 1, i8_sat(i16_1));
         check("v*.uh = vpack(v*.w,v*.w):sat", hvx_width / 2, u16_sat(i32_1));


### PR DESCRIPTION
In the degenerate case of shuffle_vector() calling vlut() to shuffle a vector that is wider than 256 elements, the code was incorrectly using halide.hexagon.pack.vh on a vector-of-bool; this used to be necessary, but hasn't been for a while, so clearly this code path wasn't being exercised.

Remove the halide.hexagon.pack.vh and added a test case to exercise that path.

Also, drive-by removal of #include "EliminateBoolVectors.h" from CGHVX since it is no longer used there.