### PR TITLE
Don't allow Target strings without complete arch-bits-os

### DIFF
--- a/python_bindings/correctness/target.py
+++ b/python_bindings/correctness/target.py
@@ -1,21 +1,27 @@
 import halide as hl
 
+
 def test_target():
     # Target("") should be exactly like get_host_target().
     t1 = hl.get_host_target()
     t2 = hl.Target("")
     assert t1 == t2, "Default ctor failure"
-    assert t1.supported();
+    assert t1.supported()
 
     # to_string roundtripping
     t1 = hl.Target()
     ts = t1.to_string()
     assert ts == "arch_unknown-0-os_unknown"
-    assert hl.Target.validate_target_string(ts)
-    t2 = hl.Target(ts)
 
-    # equality
-    assert t2 == t1
+    # Note, this should *not* validate, since validate_target_string
+    # now returns false if any of arch-bits-os are undefined
+    assert not hl.Target.validate_target_string(ts)
+
+    # Don't attempt to roundtrip this: trying to create
+    # a Target with unknown portions will now assert-fail.
+    #
+    # t2 = hl.Target(ts)
+    # assert t2 == t1
 
     # repr() and str()
     assert str(t1) == "arch_unknown-0-os_unknown"
@@ -26,7 +32,7 @@ def test_target():
     assert t1.bits == 0
 
     # Full specification round-trip:
-    t1 = hl.Target(hl.TargetOS.Linux, hl.TargetArch.X86, 32, [ hl.TargetFeature.SSE41 ])
+    t1 = hl.Target(hl.TargetOS.Linux, hl.TargetArch.X86, 32, [hl.TargetFeature.SSE41])
     ts = t1.to_string()
     assert ts == "x86-32-linux-sse41"
     assert hl.Target.validate_target_string(ts)
@@ -39,9 +45,9 @@ def test_target():
 
     # Full specification round-trip, crazy features
     t1 = hl.Target(hl.TargetOS.Android, hl.TargetArch.ARM, 32,
-                [hl.TargetFeature.JIT, hl.TargetFeature.SSE41, hl.TargetFeature.AVX, hl.TargetFeature.AVX2,
-                 hl.TargetFeature.CUDA, hl.TargetFeature.OpenCL, hl.TargetFeature.OpenGL, hl.TargetFeature.OpenGLCompute,
-                 hl.TargetFeature.Debug])
+                   [hl.TargetFeature.JIT, hl.TargetFeature.SSE41, hl.TargetFeature.AVX, hl.TargetFeature.AVX2,
+                    hl.TargetFeature.CUDA, hl.TargetFeature.OpenCL, hl.TargetFeature.OpenGL, hl.TargetFeature.OpenGLCompute,
+                    hl.TargetFeature.Debug])
     ts = t1.to_string()
     assert ts == "arm-32-android-avx-avx2-cuda-debug-jit-opencl-opengl-openglcompute-sse41"
     assert hl.Target.validate_target_string(ts)
@@ -91,9 +97,11 @@ def test_target():
     assert ts == "x86-32-linux-no_asserts-no_bounds_query-sse41"
 
     # without_feature
-    t1 = hl.Target(hl.TargetOS.Linux, hl.TargetArch.X86, 32, [hl.TargetFeature.SSE41, hl.TargetFeature.NoAsserts])
+    t1 = hl.Target(hl.TargetOS.Linux, hl.TargetArch.X86, 32, [
+                   hl.TargetFeature.SSE41, hl.TargetFeature.NoAsserts])
     # Note that NoBoundsQuery wasn't set here, so 'without' is a no-op
-    t2 = t1.without_feature(hl.TargetFeature.NoAsserts).without_feature(hl.TargetFeature.NoBoundsQuery)
+    t2 = t1.without_feature(hl.TargetFeature.NoAsserts).without_feature(
+        hl.TargetFeature.NoBoundsQuery)
     ts = t2.to_string()
     assert ts == "x86-32-linux-sse41"
 
@@ -142,7 +150,7 @@ def test_target():
 
     # with_feature with non-convertible lists
     try:
-        t1 = hl.Target(hl.TargetOS.Linux, hl.TargetArch.X86, 32, [ "this is a string" ])
+        t1 = hl.Target(hl.TargetOS.Linux, hl.TargetArch.X86, 32, ["this is a string"])
     except TypeError as e:
         assert "incompatible constructor arguments" in str(e)
     else:

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -547,15 +547,7 @@ Target::Target(const std::string &target) {
         // If nothing is specified, use the full host target.
         *this = host;
     } else {
-
-        // Default to the host OS and architecture in case of partially
-        // specified targets (e.g. x86-64-cuda doesn't specify the OS, so
-        // use the host OS).
-        os = host.os;
-        arch = host.arch;
-        bits = host.bits;
-
-        if (!merge_string(*this, target)) {
+        if (!merge_string(*this, target) || has_unknowns()) {
             bad_target_string(target);
         }
     }
@@ -567,7 +559,7 @@ Target::Target(const char *s)
 
 bool Target::validate_target_string(const std::string &s) {
     Target t;
-    return merge_string(t, s);
+    return merge_string(t, s) && !t.has_unknowns();
 }
 
 std::string Target::feature_to_name(Target::Feature feature) {
@@ -659,6 +651,10 @@ bool Target::supported() const {
     bad |= has_feature(Target::D3D12Compute);
 #endif
     return !bad;
+}
+
+bool Target::has_unknowns() const {
+    return os == OSUnknown || arch == ArchUnknown || bits == 0;
 }
 
 void Target::set_feature(Feature f, bool value) {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -540,7 +540,8 @@ void bad_target_string(const std::string &target) {
 
 }  // namespace
 
-Target::Target(const std::string &target) : os(OSUnknown), arch(ArchUnknown), bits(0) {
+Target::Target(const std::string &target)
+    : os(OSUnknown), arch(ArchUnknown), bits(0) {
     Target host = get_host_target();
 
     if (target.empty()) {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -540,7 +540,7 @@ void bad_target_string(const std::string &target) {
 
 }  // namespace
 
-Target::Target(const std::string &target) {
+Target::Target(const std::string &target) : os(OSUnknown), arch(ArchUnknown), bits(0) {
     Target host = get_host_target();
 
     if (target.empty()) {

--- a/src/Target.h
+++ b/src/Target.h
@@ -151,6 +151,10 @@ struct Target {
     /** Check if a target string is valid. */
     static bool validate_target_string(const std::string &s);
 
+    /** Return true if any of the arch/bits/os fields are "unknown"/0;
+        return false otherwise. */
+    bool has_unknowns() const;
+
     void set_feature(Feature f, bool value = true);
 
     void set_features(const std::vector<Feature> &features_to_set, bool value = true);

--- a/test/correctness/target.cpp
+++ b/test/correctness/target.cpp
@@ -21,15 +21,21 @@ int main(int argc, char **argv) {
         printf("to_string failure: %s\n", ts.c_str());
         return -1;
     }
-    if (!Target::validate_target_string(ts)) {
+    // Note, this should *not* validate, since validate_target_string
+    // now returns false if any of arch-bits-os are undefined
+    if (Target::validate_target_string(ts)) {
         printf("validate_target_string failure: %s\n", ts.c_str());
         return -1;
     }
-    t2 = Target(ts);
-    if (t2 != t1) {
-        printf("roundtrip failure: %s\n", ts.c_str());
-        return -1;
-    }
+
+    // Don't attempt to roundtrip this: trying to create
+    // a Target with unknown portions will now assert-fail.
+    //
+    // t2 = Target(ts);
+    // if (t2 != t1) {
+    //     printf("roundtrip failure: %s\n", ts.c_str());
+    //     return -1;
+    // }
 
     // Full specification round-trip:
     t1 = Target(Target::Linux, Target::X86, 32, {Target::SSE41});

--- a/test/error/CMakeLists.txt
+++ b/test/error/CMakeLists.txt
@@ -42,6 +42,7 @@ tests(GROUPS error
       implicit_args.cpp
       impossible_constraints.cpp
       init_def_should_be_all_vars.cpp
+      incomplete_target.cpp
       inspect_loop_level.cpp
       lerp_float_weight_out_of_range.cpp
       lerp_mismatch.cpp

--- a/test/error/incomplete_target.cpp
+++ b/test/error/incomplete_target.cpp
@@ -1,0 +1,11 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Target t("debug");
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
We previously accepted 'incomplete' Target strings (filling in host attributes for arch-bits-os if unspecified); we thought this would be a convenience, but in practice, this is usually indicative of an error or typo. This changes to make the Target(string) ctor assert-fail if the resulting target has an unspecified arch-bits-os.

Fixes #5009 