### PR TITLE
Fix a source of GPU barrier deadlocks

### DIFF
--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -491,8 +491,8 @@ class PartitionLoops : public IRMutator {
                                                            CodeGen_GPU_Dev::is_gpu_var(op->name));
 
         // If we're inside GPU kernel, and the body contains thread
-        // barriers or warp shuffles, it's not safe to partition parallel loops.
-        if (is_parallel(op->for_type) && in_gpu_loop && contains_warp_synchronous_logic(op)) {
+        // barriers or warp shuffles, it's not safe to partition loops.
+        if (in_gpu_loop && contains_warp_synchronous_logic(op)) {
             return IRMutator::visit(op);
         }
 


### PR DESCRIPTION
Partition loops shouldn't mess with serial loops containing
thread barriers, potentially causing warp divergence and deadlock (seen
in some obscure lens blur schedules).

Also we were generating too many thread barriers in a branch where the
base mutator class was accidentally always mutating something, so
there's a change to FuseGPUThreadLoops to make it more bug-resistant.

Without these additional barriers I have been unable to come up with a
case where a barrier ends up somewhere that would deadlock, so no test.