### PR TITLE
Extend fork_async_producers to support functions scheduled with compute_with

### DIFF
--- a/src/AsyncProducers.cpp
+++ b/src/AsyncProducers.cpp
@@ -377,6 +377,8 @@ class ForkAsyncProducers : public IRMutator {
             }
         }
         internal_assert(fused_group_index < fused_groups.size());
+        // We want to make sure that for fused function group transformation is
+        // applied to inner Realize node.
         fused_group_func_counter[fused_group_index]++;
         const auto &current_group = fused_groups[fused_group_index];
 
@@ -407,6 +409,7 @@ class ForkAsyncProducers : public IRMutator {
             Stmt producer = GenerateProducerBody(current_group, cloned_acquires).mutate(body);
             Stmt consumer = GenerateConsumerBody(current_group).mutate(body);
 
+            // Insert producer/consumer semaphores.
             for (size_t ix = 0; ix < current_group.size(); ix++) {
                 producer = InsertProducerSemaphores(current_group[ix], sema_vars[ix]).mutate(producer);
                 consumer = InsertConsumerSemaphores(current_group[ix], sema_vars[ix]).mutate(consumer);

--- a/src/AsyncProducers.h
+++ b/src/AsyncProducers.h
@@ -14,7 +14,8 @@ namespace Internal {
 
 class Function;
 
-Stmt fork_async_producers(Stmt s, const std::map<std::string, Function> &env);
+Stmt fork_async_producers(Stmt s, const std::map<std::string, Function> &env,
+                          const std::vector<std::vector<std::string>> &fused_groups);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -244,7 +244,7 @@ Module lower(const vector<Function> &output_funcs,
              << s << "\n\n";
 
     debug(1) << "Forking asynchronous producers...\n";
-    s = fork_async_producers(s, env);
+    s = fork_async_producers(s, env, fused_groups);
     debug(2) << "Lowering after forking asynchronous producers:\n"
              << s << "\n";
 

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -2179,6 +2179,11 @@ void validate_fused_group_schedule_helper(const string &fn,
             << ") and " << p.func_2 << ".s" << p.stage_2 << " ("
             << func_2.schedule().compute_level().to_string() << ") do not match.\n";
 
+        // Verify that they have matching async flags.
+        user_assert(func_1.schedule().async() == func_2.schedule().async())
+            << "Invalid compute_with: functions " << func_1.name()
+            << " and " << func_2.name() << " have different async flags.\n";
+
         const vector<Dim> &dims_1 = def_1.schedule().dims();
         const vector<Dim> &dims_2 = def_2.schedule().dims();
 

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -9,6 +9,7 @@ tests(GROUPS correctness
       argmax.cpp
       assertion_failure_in_parallel_for.cpp
       async.cpp
+      async_compute_with.cpp
       async_copy_chain.cpp
       async_device_copy.cpp
       atomic_tuples.cpp

--- a/test/correctness/async_compute_with.cpp
+++ b/test/correctness/async_compute_with.cpp
@@ -3,7 +3,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    // Compute_with and async is broken.
+    // Two producers scheduled as async and two separate consumers.
     {
         Func producer1, producer2, consumer, consumer1, consumer2;
         Var x, y;
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
         });
     }
 
-    // Compute_with and async is broken.
+    // Two producers scheduled as async and one consumers.
     {
         Func producer1, producer2, producer3, consumer, consumer1, consumer2;
         Var x, y;
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
             }
         });
     }
-
+    // Two fused producers + one producer scheduled as async and one consumers.
     {
         Func producer1, producer2, producer3, consumer;
         Var x, y;
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
         });
     }
 
-    // Compute_with and async is broken.
+    // Two producers scheduled as async + one producer and one consumer.
     {
         Func producer1, producer2, producer3, consumer;
         Var x, y;
@@ -117,7 +117,7 @@ int main(int argc, char **argv) {
         });
     }
 
-    // Compute_with and async is broken.
+    // Two producers scheduled as async and two separate consumers.
     {
         Func producer1, producer2, producer3, consumer, consumer1, consumer2;
         Var x, y;

--- a/test/correctness/async_compute_with.cpp
+++ b/test/correctness/async_compute_with.cpp
@@ -1,0 +1,152 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // Compute_with and async is broken.
+    {
+        Func producer1, producer2, consumer, consumer1, consumer2;
+        Var x, y;
+
+        producer1(x, y) = x + y;
+        producer2(x, y) = 3 * x + 2 * y;
+        consumer1(x, y) = producer2(x, y);
+        consumer2(x, y) = producer1(x, y);
+        consumer(x, y) = consumer1(x, y) + consumer2(x, y);
+
+        consumer.compute_root();
+        consumer1.compute_root();
+        consumer2.compute_root();
+
+        producer1.compute_root().async();
+        producer2.compute_root().compute_with(producer1, Var::outermost()).async();
+
+        consumer.bound(x, 0, 16).bound(y, 0, 16);
+
+        Buffer<int> out = consumer.realize(16, 16);
+
+        out.for_each_element([&](int x, int y) {
+            int correct = 4 * x + 3 * y;
+            if (out(x, y) != correct) {
+                printf("out(%d, %d) = %d instead of %d\n",
+                       x, y, out(x, y), correct);
+                exit(-1);
+            }
+        });
+    }
+
+    // Compute_with and async is broken.
+    {
+        Func producer1, producer2, producer3, consumer, consumer1, consumer2;
+        Var x, y;
+
+        producer1(x, y) = x + y;
+        producer2(x, y) = 3 * x + 2 * y;
+        consumer(x, y) = producer1(x, y - 3) + producer1(x, y + 3) + producer2(x, y - 1) + producer2(x, y + 1);
+        consumer.compute_root();
+        producer1.compute_at(consumer, y).store_root().async();
+        producer2.compute_at(consumer, y).store_root().compute_with(producer1, y).async();
+
+        consumer.bound(x, 0, 16).bound(y, 0, 16);
+
+        Buffer<int> out = consumer.realize(16, 16);
+
+        out.for_each_element([&](int x, int y) {
+            int correct = 8 * x + 6 * y;
+            if (out(x, y) != correct) {
+                printf("out(%d, %d) = %d instead of %d\n",
+                       x, y, out(x, y), correct);
+                exit(-1);
+            }
+        });
+    }
+
+    {
+        Func producer1, producer2, producer3, consumer;
+        Var x, y;
+
+        producer1(x, y) = x + y;
+        producer2(x, y) = 3 * x + 2 * y;
+        producer3(x, y) = x + y;
+        consumer(x, y) = producer1(x, y - 1) + producer1(x, y + 1) + producer2(x, y - 1) + producer2(x, y + 1) + producer3(x, y);
+        consumer.compute_root();
+        producer1.compute_at(consumer, y).store_root().async();
+        producer2.compute_at(consumer, y).store_root().compute_with(producer1, y).async();
+        producer3.compute_at(consumer, y).store_root().async();
+
+        consumer.bound(x, 0, 16).bound(y, 0, 16);
+
+        Buffer<int> out = consumer.realize(16, 16);
+
+        out.for_each_element([&](int x, int y) {
+            int correct = 9 * x + 7 * y;
+            if (out(x, y) != correct) {
+                printf("out(%d, %d) = %d instead of %d\n",
+                       x, y, out(x, y), correct);
+                exit(-1);
+            }
+        });
+    }
+
+    // Compute_with and async is broken.
+    {
+        Func producer1, producer2, producer3, consumer;
+        Var x, y;
+
+        producer1(x, y) = x + y;
+        producer2(x, y) = 3 * x + 2 * y;
+        producer3(x, y) = x + y;
+        consumer(x, y) = producer1(x, y - 1) + producer1(x, y + 1) + producer2(x, y - 1) + producer2(x, y + 1) + producer3(x, y);
+        consumer.compute_root();
+        producer1.compute_at(consumer, y).store_root().async();
+        producer2.compute_at(consumer, y).store_root().compute_with(producer1, y).async();
+        // producer3 is not async.
+        producer3.compute_at(consumer, y).store_root();
+
+        consumer.bound(x, 0, 16).bound(y, 0, 16);
+
+        Buffer<int> out = consumer.realize(16, 16);
+
+        out.for_each_element([&](int x, int y) {
+            int correct = 9 * x + 7 * y;
+            if (out(x, y) != correct) {
+                printf("out(%d, %d) = %d instead of %d\n",
+                       x, y, out(x, y), correct);
+                exit(-1);
+            }
+        });
+    }
+
+    // Compute_with and async is broken.
+    {
+        Func producer1, producer2, producer3, consumer, consumer1, consumer2;
+        Var x, y;
+
+        producer1(x, y) = x + y;
+        producer2(x, y) = 3 * x + 2 * y;
+        consumer1(x, y) = 2 * producer1(x, y) + producer2(x, y);
+        consumer2(x, y) = producer1(x, y) + 2 * producer2(x, y);
+        consumer(x, y) = consumer1(x, y) + consumer2(x, y);
+        consumer.compute_root();
+        consumer1.compute_root();
+        consumer2.compute_root();
+        producer1.compute_root().async();
+        producer2.compute_root().compute_with(producer1, Var::outermost()).async();
+
+        consumer.bound(x, 0, 16).bound(y, 0, 16);
+
+        Buffer<int> out = consumer.realize(16, 16);
+
+        out.for_each_element([&](int x, int y) {
+            int correct = 12 * x + 9 * y;
+            if (out(x, y) != correct) {
+                printf("out(%d, %d) = %d instead of %d\n",
+                       x, y, out(x, y), correct);
+                exit(-1);
+            }
+        });
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/CMakeLists.txt
+++ b/test/error/CMakeLists.txt
@@ -2,6 +2,7 @@ tests(GROUPS error
       EXPECT_FAILURE
       SOURCES
       ambiguous_inline_reductions.cpp
+      async_compute_with.cpp
       async_require_fail.cpp
       atomics_gpu_8_bit.cpp
       atomics_gpu_mutex.cpp

--- a/test/error/async_compute_with.cpp
+++ b/test/error/async_compute_with.cpp
@@ -1,0 +1,23 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Func producer1, producer2, consumer;
+    Var x, y;
+
+    producer1(x, y) = x + y;
+    producer2(x, y) = 3 * x + 2 * y;
+    consumer(x, y) = producer1(x, y - 1) + producer1(x, y + 1) + producer2(x, y - 1) + producer2(x, y + 1);
+    consumer.compute_root();
+    producer1.compute_at(consumer, y).store_root();
+    producer2.compute_at(consumer, y).store_root().compute_with(producer1, y).async();
+
+    consumer.bound(x, 0, 16).bound(y, 0, 16);
+
+    Buffer<int> out = consumer.realize(16, 16);
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/async_compute_with.cpp
+++ b/test/error/async_compute_with.cpp
@@ -11,6 +11,7 @@ int main(int argc, char **argv) {
     producer2(x, y) = 3 * x + 2 * y;
     consumer(x, y) = producer1(x, y - 1) + producer1(x, y + 1) + producer2(x, y - 1) + producer2(x, y + 1);
     consumer.compute_root();
+    // Both functions should have been scheduled as async.
     producer1.compute_at(consumer, y).store_root();
     producer2.compute_at(consumer, y).store_root().compute_with(producer1, y).async();
 


### PR DESCRIPTION
As described in #5179 compute_with() and async() have issues when used together and this PR extends ForkAsyncProducers to support fused function groups to address these issues. 

The important limitation is that all functions from the same group have to be marked as async and will share fork block/task/thread. I think this is the only reasonable combination, because functions scheduled with compute_with share the loop(s) and launching them in different task would break this assumption.

(interesting side-effect of this is that now it's possible to schedule two completely independent functions to be executed in the same fork block with something like:

```
producer1.async();
producer2.compute_with(producer1, Var::outermost()).async();
```
).

I've added a number of tests which cover some of the possible combinations, but for something like async which depends on things like timing and such, it's quite difficult to be 100% convinced about correctness. For the existing functionality, I've tried to minimize changes to make sure that stuff that worked before still works. Also, I've eyeballed generated IR to make sure that forks and semaphores are generated in proper places and it looked alright. 