### PR TITLE
[Hexagon] Fix for LUT32 correctness.

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -2090,7 +2090,7 @@ Value *CodeGen_Hexagon::vlut(Value *lut, Value *idx, int min_index, int max_inde
 
         // Create a condition value for which elements of the range are valid
         // for this index.
-        Value *use_index = builder->CreateICmpSGE(indices, minus_one);
+        Value *use_index = builder->CreateICmpSGT(indices, minus_one);
 
         // After we've eliminated the invalid elements, we can
         // truncate to 8 bits, as vlut requires.

--- a/test/correctness/gather.cpp
+++ b/test/correctness/gather.cpp
@@ -87,10 +87,9 @@ int main() {
     if (!test<uint8_t>() ||
         !test<int8_t>() ||
         !test<uint16_t>() ||
-        !test<int16_t>()
-        // !test<uint32_t>() ||
-        // !test<int32_t>()
-        ) return 1;
+        !test<int16_t>() ||
+        !test<uint32_t>() ||
+        !test<int32_t>()) return 1;
     printf("Success!\n");
     return 0;
 }


### PR DESCRIPTION
**Do NOT merge.**

Lower bound for lut needs to > -1 instead of >= -1.
The bug was introduced in b7dd787c4532d759334f0a2348c993af5e21f152 commit.
@dsharletg @pranavb-ca  The lut32 test fails right now with a compilation error. 