### PR TITLE
Fix #5175: Add an extra check for input dependencies of the async producer

### DIFF
--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -11,6 +11,7 @@ tests(GROUPS correctness
       async.cpp
       async_copy_chain.cpp
       async_device_copy.cpp
+      async_order.cpp
       atomic_tuples.cpp
       atomics.cpp
       autodiff.cpp

--- a/test/correctness/async_order.cpp
+++ b/test/correctness/async_order.cpp
@@ -1,0 +1,95 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    {
+        Func producer1, producer2, consumer;
+        Var x, y;
+
+        producer1(x, y) = x + y;
+        producer2(x, y) = producer1(x, y);
+        consumer(x, y) = producer1(x, y - 1) + producer2(x, y + 1);
+
+        consumer.compute_root();
+
+        producer1.compute_at(consumer, y);
+        producer2.compute_at(consumer, y).async();
+
+        consumer.bound(x, 0, 16).bound(y, 0, 16);
+
+        Buffer<int> out = consumer.realize(16, 16);
+
+        out.for_each_element([&](int x, int y) {
+            int correct = 2 * (x + y);
+            if (out(x, y) != correct) {
+                printf("out(%d, %d) = %d instead of %d\n",
+                       x, y, out(x, y), correct);
+                exit(-1);
+            }
+        });
+    }
+    {
+        Func producer1, producer2, consumer;
+        Var x, y;
+
+        producer1(x, y) = x + y;
+        producer2(x, y) = producer1(x, y);
+        consumer(x, y) = producer1(x, y - 1) + producer2(x, y + 1);
+
+        consumer.compute_root();
+
+        producer1.compute_root();
+        producer2.store_root().compute_at(consumer, y).async();
+        // Correct
+        // producer1.compute_at(consumer, y);
+        // producer2.compute_at(consumer, y).async();
+
+        consumer.bound(x, 0, 16).bound(y, 0, 16);
+
+        Buffer<int> out = consumer.realize(16, 16);
+
+        out.for_each_element([&](int x, int y) {
+            int correct = 2 * (x + y);
+            if (out(x, y) != correct) {
+                printf("out(%d, %d) = %d instead of %d\n",
+                       x, y, out(x, y), correct);
+                exit(-1);
+            }
+        });
+    }
+
+    {
+        Func producer1, producer2, consumer;
+        Var x, y;
+
+        producer1(x, y) = x + y;
+        producer2(x, y) = producer1(x, y);
+        consumer(x, y) = producer1(x, y - 1) + producer2(x, y + 1);
+
+        consumer.compute_root();
+
+        producer1.store_root().compute_at(consumer, y).async();
+        producer2.store_root().compute_at(consumer, y).async();
+        // Correct
+        // producer1.compute_at(consumer, y);
+        // producer2.compute_at(consumer, y).async();
+
+        consumer.bound(x, 0, 16).bound(y, 0, 16);
+
+        Buffer<int> out = consumer.realize(16, 16);
+
+        out.for_each_element([&](int x, int y) {
+            int correct = 2 * (x + y);
+            if (out(x, y) != correct) {
+                printf("out(%d, %d) = %d instead of %d\n",
+                       x, y, out(x, y), correct);
+                exit(-1);
+            }
+        });
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/async_order.cpp
+++ b/test/correctness/async_order.cpp
@@ -42,10 +42,6 @@ int main(int argc, char **argv) {
 
         producer1.compute_root();
         producer2.store_root().compute_at(consumer, y).async();
-        // Correct
-        // producer1.compute_at(consumer, y);
-        // producer2.compute_at(consumer, y).async();
-
         consumer.bound(x, 0, 16).bound(y, 0, 16);
 
         Buffer<int> out = consumer.realize(16, 16);
@@ -72,10 +68,6 @@ int main(int argc, char **argv) {
 
         producer1.store_root().compute_at(consumer, y).async();
         producer2.store_root().compute_at(consumer, y).async();
-        // Correct
-        // producer1.compute_at(consumer, y);
-        // producer2.compute_at(consumer, y).async();
-
         consumer.bound(x, 0, 16).bound(y, 0, 16);
 
         Buffer<int> out = consumer.realize(16, 16);

--- a/test/error/CMakeLists.txt
+++ b/test/error/CMakeLists.txt
@@ -2,6 +2,7 @@ tests(GROUPS error
       EXPECT_FAILURE
       SOURCES
       ambiguous_inline_reductions.cpp
+      async_order.cpp
       async_require_fail.cpp
       atomics_gpu_8_bit.cpp
       atomics_gpu_mutex.cpp

--- a/test/error/async_order.cpp
+++ b/test/error/async_order.cpp
@@ -1,0 +1,24 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Func producer1, producer2, consumer;
+    Var x, y;
+
+    producer1(x, y) = x + y;
+    producer2(x, y) = producer1(x, y);
+    consumer(x, y) = producer1(x, y - 1) + producer2(x, y + 1);
+
+    consumer.compute_root();
+
+    producer1.store_root().compute_at(consumer, y);
+    producer2.store_root().compute_at(consumer, y).async();
+
+    consumer.bound(x, 0, 16).bound(y, 0, 16);
+
+    Buffer<int> out = consumer.realize(16, 16);
+
+    return 0;
+}


### PR DESCRIPTION
As described in the #5175, it's possible to write an illegal schedule which successfully goes through the code generation, but generated code produces incorrect results.

This PR adds an extra check to detect such illegal schedules by verifying that if in realize node A there is a producer node B and producer A is async and is consumer of B then B must be also scheduled as async.