### PR TITLE
Teach the python bindings how to stringify Expr, RDom, RVar.

### DIFF
--- a/python_bindings/src/PyExpr.cpp
+++ b/python_bindings/src/PyExpr.cpp
@@ -47,7 +47,7 @@ void define_expr(py::module &m) {
             .def("type", &Expr::type)
             .def("__repr__", [](const Expr &e) -> std::string {
                 std::ostringstream o;
-                o << "<halide.Expr of type " << halide_type_to_string(e.type()) << ">";
+                o << "<halide.Expr of type " << halide_type_to_string(e.type()) << ": " << e << ">";
                 return o.str();
             });
 

--- a/python_bindings/src/PyRDom.cpp
+++ b/python_bindings/src/PyRDom.cpp
@@ -13,7 +13,12 @@ void define_rvar(py::module &m) {
             .def(py::init([](const RDom &r) -> RVar { return r; }))
             .def("min", &RVar::min)
             .def("extent", &RVar::extent)
-            .def("name", &RVar::name);
+            .def("name", &RVar::name)
+            .def("__repr__", [](const RVar &v) -> std::string {
+                std::ostringstream o;
+                o << "<halide.RVar " << v << ">";
+                return o.str();
+            });
 
     py::implicitly_convertible<RDom, RVar>();
 
@@ -43,7 +48,12 @@ void define_rdom(py::module &m) {
             .def_readonly("x", &RDom::x)
             .def_readonly("y", &RDom::y)
             .def_readonly("z", &RDom::z)
-            .def_readonly("w", &RDom::w);
+            .def_readonly("w", &RDom::w)
+            .def("__repr__", [](const RDom &r) -> std::string {
+                std::ostringstream o;
+                o << "<halide.RDom " << r << ">";
+                return o.str();
+            });
 
     add_binary_operators(rdom_class);
 }


### PR DESCRIPTION
This is a quality of life improvement for Python development.

The C++ objects know how to stringify themselves.  The python objects often stringify to a generic string that looks like `<halide.Whatever object at 0xHEXADDRESS>`, which is not very informative.  It gives you the type of object, but nothing about its contents.

This patch improves the stringification of Python Expr, RDom and RVar objects.  There are other things that can also be stringified, but this is what I needed at the moment.


Expr before:

```
<halide.Expr of type float32>
```

Expr after:

```
<halide.Expr of type float32: (float32)cos_f32(float32(my_r$x))>
```

RVar before:

```
<halide.RVar object at 0x7fce2dd83670>
```


RVar after:

```
<halide.RVar my_r$x(0, 4)>
```

RDom before:

```
<halide.RDom object at 0x7f33dfa1f9f0>
```

RDom after:

```
<halide.RDom RDom(
  my_r$x(0, 4)
  my_r$y(0, g_in.extent.1)
  my_r$z(0, g_in.extent.1)
  my_r$w(0, g_in.extent.1)
  my_r$4(0, g_in.extent.1)
)
>
```
