### PR TITLE
Replace large code model build option with target feature.

### DIFF
--- a/python_bindings/src/PyEnums.cpp
+++ b/python_bindings/src/PyEnums.cpp
@@ -144,6 +144,7 @@ void define_enums(py::module &m) {
         .value("SVE", Target::Feature::SVE)
         .value("SVE2", Target::Feature::SVE2)
         .value("ARMDotProd", Target::Feature::ARMDotProd)
+        .value("LLVMLargeCodeModel", Target::Feature::LLVMLargeCodeModel)
         .value("FeatureEnd", Target::Feature::FeatureEnd);
 
     py::enum_<halide_type_code_t>(m, "TypeCode")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -446,7 +446,7 @@ target_compile_definitions(Halide
                            )
 
 ##
-# Set up macro definitions for libHalide
+# Set up additional backend options for Halide
 ##
 
 option(TARGET_OPENCL "Include OpenCL-C target" ON)
@@ -467,11 +467,6 @@ endif ()
 option(TARGET_D3D12COMPUTE "Include Direct3D 12 Compute target" ON)
 if (TARGET_D3D12COMPUTE)
     target_compile_definitions(Halide PRIVATE WITH_D3D12)
-endif ()
-
-option(Halide_USE_CODEMODEL_LARGE "Use the Large LLVM codemodel" OFF)
-if (Halide_USE_CODEMODEL_LARGE)
-    target_compile_definitions(Halide PRIVATE HALIDE_USE_CODEMODEL_LARGE)
 endif ()
 
 ##

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -670,15 +670,14 @@ std::unique_ptr<llvm::TargetMachine> make_target_machine(const llvm::Module &mod
     bool use_pic = true;
     get_md_bool(module.getModuleFlag("halide_use_pic"), use_pic);
 
+    bool use_large_code_model = false;
+    get_md_bool(module.getModuleFlag("halide_use_large_code_model"), use_large_code_model);
+
     auto *tm = llvm_target->createTargetMachine(module.getTargetTriple(),
                                                 mcpu, mattrs,
                                                 options,
                                                 use_pic ? llvm::Reloc::PIC_ : llvm::Reloc::Static,
-#ifdef HALIDE_USE_CODEMODEL_LARGE
-                                                llvm::CodeModel::Large,
-#else
-                                                llvm::CodeModel::Small,
-#endif
+                                                use_large_code_model ? llvm::CodeModel::Large : llvm::CodeModel::Small,
                                                 llvm::CodeGenOpt::Aggressive);
     return std::unique_ptr<llvm::TargetMachine>(tm);
 }

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -294,7 +294,8 @@ CodeGen_LLVM::CodeGen_LLVM(Target t)
       emit_atomic_stores(false),
 
       destructor_block(nullptr),
-      strict_float(t.has_feature(Target::StrictFloat)) {
+      strict_float(t.has_feature(Target::StrictFloat)),
+      llvm_large_code_model(t.has_feature(Target::LLVMLargeCodeModel)) {
     initialize_llvm();
 }
 
@@ -601,6 +602,7 @@ void CodeGen_LLVM::init_codegen(const std::string &name, bool any_strict_float) 
     module->addModuleFlag(llvm::Module::Warning, "halide_mcpu", MDString::get(*context, mcpu()));
     module->addModuleFlag(llvm::Module::Warning, "halide_mattrs", MDString::get(*context, mattrs()));
     module->addModuleFlag(llvm::Module::Warning, "halide_use_pic", use_pic() ? 1 : 0);
+    module->addModuleFlag(llvm::Module::Warning, "halide_use_large_code_model", llvm_large_code_model ? 1 : 0);
     module->addModuleFlag(llvm::Module::Warning, "halide_per_instruction_fast_math_flags", any_strict_float);
 
     // Ensure some types we need are defined

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -544,6 +544,9 @@ private:
     /** Turn off all unsafe math flags in scopes while this is set. */
     bool strict_float;
 
+    /** Use the LLVM large code model when this is set. */
+    bool llvm_large_code_model;
+
     /** Embed an instance of halide_filter_metadata_t in the code, using
      * the given name (by convention, this should be ${FUNCTIONNAME}_metadata)
      * as extern "C" linkage. Note that the return value is a function-returning-

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -349,6 +349,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"sve", Target::SVE},
     {"sve2", Target::SVE2},
     {"arm_dot_prod", Target::ARMDotProd},
+    {"llvm_large_code_model", Target::LLVMLargeCodeModel},
     // NOTE: When adding features to this map, be sure to update PyEnums.cpp as well.
 };
 

--- a/src/Target.h
+++ b/src/Target.h
@@ -124,6 +124,7 @@ struct Target {
         SVE = halide_target_feature_sve,
         SVE2 = halide_target_feature_sve2,
         ARMDotProd = halide_target_feature_arm_dot_prod,
+        LLVMLargeCodeModel = halide_llvm_large_code_model,
         FeatureEnd = halide_target_feature_end
     };
     Target()

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1320,6 +1320,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_egl,                    ///< Force use of EGL support.
 
     halide_target_feature_arm_dot_prod,  ///< Enable ARMv8.2-a dotprod extension (i.e. udot and sdot instructions)
+    halide_llvm_large_code_model,        ///< Use the LLVM large code model to compile
     halide_target_feature_end            ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 


### PR DESCRIPTION
The CMake build has an option, `HALIDE_USE_CODEMODEL_LARGE` that I (re)discovered while writing documentation. I am not sure why it exists. It's not mentioned anywhere in the Makefile and it doesn't seem to be used by any of our tests.

This PR turns it into a target feature rather than a build option, but another valid approach might be to remove it outright. This is probably the appropriate venue for this discussion.