### PR TITLE
Cmake/metatargets

### DIFF
--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -185,7 +185,7 @@ function(add_halide_library TARGET)
     ##
 
     if (crosscompiling)
-        add_library("${TARGET}" STATIC IMPORTED)
+        add_library("${TARGET}" STATIC IMPORTED GLOBAL)
         set_target_properties("${TARGET}" PROPERTIES
                               IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/${GENERATOR_SOURCES}")
     else ()
@@ -260,7 +260,7 @@ function(add_halide_runtime RT)
     if (crosscompiling)
         add_custom_target("${RT}.update" DEPENDS "${GEN_OUTS}")
 
-        add_library("${RT}" STATIC IMPORTED)
+        add_library("${RT}" STATIC IMPORTED GLOBAL)
         add_dependencies("${RT}" "${RT}.update")
 
         set_target_properties("${RT}" PROPERTIES

--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -79,16 +79,27 @@ function(add_halide_library TARGET)
         set(ARG_FUNCTION_NAME "${TARGET}")
     endif ()
 
+    # If no TARGETS argument, use Halide_TARGET instead
     if (NOT ARG_TARGETS)
-        if (NOT "${Halide_TARGET}" STREQUAL "")
-            set(ARG_TARGETS "${Halide_TARGET}")
-        else ()
-            _Halide_auto_target(ARG_TARGETS)
-        endif ()
-    elseif (ARG_TARGETS MATCHES "cmake")
-        _Halide_auto_target(target)
-        list(TRANSFORM ARG_TARGETS REPLACE "cmake" "${target}")
+        set(ARG_TARGETS "${Halide_TARGET}")
     endif ()
+
+    # If still no TARGET, try to use host, but if that would
+    # cross-compile, then default to 'cmake' and warn.
+    if (NOT ARG_TARGETS)
+        if (Halide_HOST_TARGET STREQUAL Halide_CMAKE_TARGET)
+            set(ARG_TARGETS host)
+        else ()
+            message(AUTHOR_WARNING
+                    "Targets must be manually specified to add_halide_library when cross-compiling. "
+                    "The default 'host' target ${Halide_HOST_TARGET} differs from the active CMake "
+                    "target ${Halide_CMAKE_TARGET}. Using ${Halide_CMAKE_TARGET} to compile ${TARGET}. "
+                    "This might result in performance degradation from missing arch flags (eg. avx).")
+            set(ARG_TARGETS "${Halide_CMAKE_TARGET}")
+        endif ()
+    endif ()
+
+    list(TRANSFORM ARG_TARGETS REPLACE "cmake" "${Halide_CMAKE_TARGET}")
 
     list(APPEND ARG_FEATURES no_runtime)
     list(JOIN ARG_FEATURES "-" ARG_FEATURES)
@@ -104,8 +115,8 @@ function(add_halide_library TARGET)
     else ()
         # If we're not using an existing runtime, create one.
         if (NOT ARG_USE_RUNTIME)
-            add_halide_runtime("${TARGET}.runtime" FROM ${ARG_FROM}
-                               TARGETS ${ARG_TARGETS})
+            _Halide_add_halide_runtime("${TARGET}.runtime" FROM ${ARG_FROM}
+                                       TARGETS ${ARG_TARGETS})
             set(ARG_USE_RUNTIME "${TARGET}.runtime")
         elseif (NOT TARGET ${ARG_USE_RUNTIME})
             message(FATAL_ERROR "Invalid runtime target ${ARG_USE_RUNTIME}")
@@ -232,7 +243,7 @@ endfunction()
 # Function for creating a standalone runtime from a generator.
 ##
 
-function(add_halide_runtime RT)
+function(_Halide_add_halide_runtime RT)
     cmake_parse_arguments(ARG "" "FROM" "TARGETS" ${ARGN})
     _Halide_get_platform_details(
             generator_cmd
@@ -298,9 +309,8 @@ function(_Halide_get_platform_details OUT_GEN OUT_XC OUT_OBJ OUT_STATIC)
         set(${OUT_GEN} ${ARG_FROM} PARENT_SCOPE)
     endif ()
 
-    _Halide_triple(halide_triple "${ARGN}")
-    _Halide_cmake_target(cmake_triple)
-    if (NOT cmake_triple STREQUAL halide_triple)
+    _Halide_get_triple(halide_triple "${ARGN}")
+    if (NOT Halide_CMAKE_TARGET STREQUAL halide_triple)
         set("${OUT_XC}" 1 PARENT_SCOPE)
     else ()
         set("${OUT_XC}" 0 PARENT_SCOPE)

--- a/cmake/HalideTargetHelpers.cmake
+++ b/cmake/HalideTargetHelpers.cmake
@@ -17,7 +17,7 @@ function(_Halide_auto_target OUTVAR)
     if (Halide_HOST_TARGET STREQUAL cmake_target)
         set(${OUTVAR} host PARENT_SCOPE)
     else ()
-        set(${OUTVAR} ${cmake} PARENT_SCOPE)
+        set(${OUTVAR} "${cmake_target}" PARENT_SCOPE)
     endif ()
 endfunction()
 

--- a/cmake/HalideTargetHelpers.cmake
+++ b/cmake/HalideTargetHelpers.cmake
@@ -12,16 +12,7 @@ endif ()
 # Utilities for manipulating Halide target triples
 ##
 
-function(_Halide_auto_target OUTVAR)
-    _Halide_cmake_target(cmake_target)
-    if (Halide_HOST_TARGET STREQUAL cmake_target)
-        set(${OUTVAR} host PARENT_SCOPE)
-    else ()
-        set(${OUTVAR} "${cmake_target}" PARENT_SCOPE)
-    endif ()
-endfunction()
-
-function(_Halide_triple OUTVAR)
+function(_Halide_get_triple OUTVAR)
     # Well-formed targets must either start with "host" or a target triple.
     if (ARGN MATCHES "host")
         set(${OUTVAR} ${Halide_HOST_TARGET})
@@ -34,10 +25,11 @@ endfunction()
 function(_Halide_cmake_target OUTVAR)
     # Get arch from CMake
     string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" arch)
-    list(TRANSFORM arch REPLACE  "^.*(x86|arm|mips|powerpc|hexagon|wasm|riscv).*$" "\\1")
+    list(TRANSFORM arch REPLACE "^.*(x86|arm|mips|powerpc|hexagon|wasm|riscv).*$" "\\1")
     list(TRANSFORM arch REPLACE "^i.?86.+$" "x86")
     list(TRANSFORM arch REPLACE "^(amd|ia|em)64t?$" "x86")
     list(TRANSFORM arch REPLACE "^ppc(64)?$" "powerpc")
+    list(TRANSFORM arch REPLACE "^aarch(64)?$" "arm")
 
     # Get bits from CMake
     math(EXPR bits "8 * ${CMAKE_SIZEOF_VOID_P}")
@@ -50,9 +42,15 @@ function(_Halide_cmake_target OUTVAR)
 endfunction()
 
 ##
-# Set Halide_HOST_TARGET when we're compiling Halide (this variable is set by package scripts)
+# Set Halide `host` and `cmake` meta-target values
 ##
 
-if (NOT DEFINED Halide_HOST_TARGET)
+# This variable is set by package scripts and might differ from Halide_CMAKE_TARGET below.
+if (NOT Halide_HOST_TARGET)
     _Halide_cmake_target(Halide_HOST_TARGET)
+endif ()
+
+if (NOT Halide_CMAKE_TARGET)
+    _Halide_cmake_target(Halide_CMAKE_TARGET)
+    message(STATUS "Halide detected active CMake target `${Halide_CMAKE_TARGET}`")
 endif ()

--- a/dependencies/llvm/CMakeLists.txt
+++ b/dependencies/llvm/CMakeLists.txt
@@ -121,7 +121,7 @@ else ()
                            $<$<COMPILE_LANG_AND_ID:CXX,GCC,Clang,AppleClang>:-fno-rtti>)
 endif ()
 
-option(Halide_ENABLE_EXCEPTIONS "Enable exceptions" YES)
+option(Halide_ENABLE_EXCEPTIONS "Enable exceptions" ON)
 if (Halide_ENABLE_EXCEPTIONS)
     message(STATUS "Compiling Halide WITH exceptions.")
     target_compile_definitions(Halide_LanguageOptions INTERFACE HALIDE_WITH_EXCEPTIONS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -424,20 +424,6 @@ add_library(Halide::Plugin ALIAS Halide_Plugin)
 # Set compiler options for libHalide
 ##
 
-option(WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
-if (WARNINGS_AS_ERRORS)
-    target_compile_options(Halide
-                           PRIVATE
-                           $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Werror>
-                           $<$<CXX_COMPILER_ID:MSVC>:/WX>)
-endif ()
-
-if (NOT Halide_ENABLE_RTTI)
-    target_compile_options(Halide PUBLIC
-                           $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/GR->
-                           $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang>:-fno-rtti>)
-endif ()
-
 target_compile_options(Halide
                        PRIVATE
                        $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall>
@@ -471,7 +457,7 @@ target_compile_options(Halide
                        # so compiling its files in parallel should not oversubscribe the system
                        $<$<CXX_COMPILER_ID:MSVC>:/MP>
 
-                       # To compile LLVM headers following was taken from LLVM CMake files:
+                       # To compile LLVM headers, the following was taken from LLVM CMake files:
                        # Disable sized deallocation if the flag is supported. MSVC fails to compile
                        # the operator new overload in LLVM/IR/Function.h and Instruction.h otherwise.
                        # See LLVM PR: 23513 (https://llvm.org/bugs/show_bug.cgi?id=23513)
@@ -510,7 +496,7 @@ if (TARGET_D3D12COMPUTE)
     target_compile_definitions(Halide PRIVATE WITH_D3D12)
 endif ()
 
-option(HALIDE_USE_CODEMODEL_LARGE "Use the Large LLVM codemodel" OFF)
-if (HALIDE_USE_CODEMODEL_LARGE)
+option(Halide_USE_CODEMODEL_LARGE "Use the Large LLVM codemodel" OFF)
+if (Halide_USE_CODEMODEL_LARGE)
     target_compile_definitions(Halide PRIVATE HALIDE_USE_CODEMODEL_LARGE)
 endif ()


### PR DESCRIPTION
In offline discussion with @abadams re: #5215 we decided that the `cmake` meta-target needs a re-think. It will now work as follows:

1. Manually setting the target triple (either through `add_halide_library(... TARGETS)` or the `Halide_TARGET` cache variable) to `cmake` results in the base target triple for the current CMake target. We document that it does _not_ detect feature flags (because it cannot).
2. Manually setting the target to `host` passes through verbatim (though we of course check to see if matches CMake's active target or not to set up the targets correctly).
3. When no target is specified, `host` is checked and if it doesn't match CMake's active target, it throws a loud AUTHOR_WARNING explaining the problem and defaults to `cmake`
4. Otherwise, it uses `host`

This is to fulfill the following design goals:

1. It should be legal to not specify a target to `add_halide_library`
2. When not specifying a target to `add_halide_library`, it should not cross-compile.
3. Silently giving bad performance is worse than a compiler error

---

Also fixes a couple small CMake oversights I discovered while writing the documentation:

1. `HALIDE_USE_CODEMODEL_LARGE` -> `Halide_USE_CODEMODEL_LARGE`
2. Ensure that cross-compiled `add_halide_library`-ies are globally visible, like normal targets (when not cross compiling)
3. Duplicated compiler flags from `Halide::LanguageOptions`
4. "cmake" -> "host" meta-target promotion was bugged