### PR TITLE
fix lesson_15 test by excluding posix/windows_abort

### DIFF
--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -801,6 +801,13 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
 
     if (module_type != ModuleGPU) {
         if (module_type != ModuleJITInlined && module_type != ModuleAOTNoRuntime) {
+            // Windows has a unique abort, but everyone else uses POSIX
+            if (t.os == Target::Windows) {
+                modules.push_back(get_initmod_windows_abort(c, bits_64, debug));
+            } else {
+                modules.push_back(get_initmod_posix_abort(c, bits_64, debug));
+            }
+
             // OS-dependent modules
             if (t.os == Target::Linux) {
                 modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
@@ -1090,12 +1097,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
         modules.push_back(get_initmod_module_jit_ref_count(c, bits_64, debug));
     } else if (module_type == ModuleAOT) {
         modules.push_back(get_initmod_module_aot_ref_count(c, bits_64, debug));
-    }
-
-    if (t.os == Target::Windows) {
-        modules.push_back(get_initmod_windows_abort(c, bits_64, debug));
-    } else {
-        modules.push_back(get_initmod_posix_abort(c, bits_64, debug));
     }
 
     if (module_type == ModuleAOT || module_type == ModuleGPU) {

--- a/test/error/metal_vector_too_large.cpp
+++ b/test/error/metal_vector_too_large.cpp
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
     f.vectorize(x, 16).gpu_blocks(y, DeviceAPI::Metal);
 
     std::string test_object = Internal::get_test_tmp_dir() + "metal_vector_too_large.o";
-    Target mac_target("osx-metal");
+    Target mac_target("x86-64-osx-metal");
 
     f.compile_to_object(test_object, {input}, "f", mac_target);
 


### PR DESCRIPTION
posix_abort and windows_abort are WEAK_INLINE, so they shouldn't be included with `no_runtime`

Also a drive-by fix for a false-success error test... we should probably write down some golden outputs for these.