### PR TITLE
Sketch of statically-typed Exprs

### DIFF
--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -339,8 +339,8 @@ Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_values);
 
 /** Cast an expression to the halide type corresponding to the C++ type T. */
 template<typename T>
-inline Expr cast(Expr a) {
-    return cast(type_of<T>(), std::move(a));
+inline ExprT<T> cast(Expr a) {
+    return cast(type_of<T>(), std::move(a)).template typed<T>();
 }
 
 /** Cast an expression to a new type. */

--- a/src/Var.cpp
+++ b/src/Var.cpp
@@ -5,11 +5,11 @@
 namespace Halide {
 
 Var::Var(const std::string &n)
-    : e(Internal::Variable::make(Int(32), n)) {
+    : e(Internal::Variable::make(Int(32), n).typed<int>()) {
 }
 
 Var::Var()
-    : e(Internal::Variable::make(Int(32), Internal::make_entity_name(this, "Halide:.*:Var", 'v'))) {
+    : e(Internal::Variable::make(Int(32), Internal::make_entity_name(this, "Halide:.*:Var", 'v')).typed<int>()) {
 }
 
 Var Var::implicit(int n) {

--- a/src/Var.h
+++ b/src/Var.h
@@ -22,7 +22,7 @@ class Var {
      * construction of the Var to avoid making a fresh Expr every time
      * the Var is used in a context in which is will be converted to
      * one. */
-    Expr e;
+    ExprT<int> e;
 
 public:
     /** Construct a Var with the given name */
@@ -155,7 +155,7 @@ public:
     //}
 
     /** A Var can be treated as an Expr of type Int(32) */
-    operator const Expr &() const {
+    operator const ExprT<int> &() const {
         return e;
     }
 
@@ -178,7 +178,7 @@ struct ImplicitVar {
     operator Var() const {
         return to_var();
     }
-    operator Expr() const {
+    operator ExprT<int>() const {
         return to_var();
     }
 };

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -315,6 +315,7 @@ tests(GROUPS correctness
       tuple_update_ops.cpp
       tuple_vector_reduce.cpp
       two_vector_args.cpp
+      typed_expr.cpp
       undef.cpp
       uninitialized_read.cpp
       unique_func_image.cpp

--- a/test/correctness/typed_expr.cpp
+++ b/test/correctness/typed_expr.cpp
@@ -1,0 +1,85 @@
+#include "Halide.h"
+#include <iostream>
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+template<typename T>
+void check_type(const Expr &e) {
+    if (e.type() != type_of<T>()) {
+        std::cerr << "constant of type " << type_of<T>() << " returned expr of type " << e.type() << "\n";
+        exit(-1);
+    }
+}
+
+template<typename T>
+void test_expr(T value) {
+    std::cout << "Test " << type_of<T>() << " = " << (0 + value) << "\n";
+
+    {
+        ExprT<T> et(value);
+        check_type<T>(et);
+
+        // ExprT<> -> Expr is always OK
+        Expr e0 = et;
+        check_type<T>(e0);
+
+        Expr e1(et);
+        check_type<T>(e1);
+
+        Expr e2(std::move(et));
+        check_type<T>(e2);
+    }
+
+    {
+        ExprT<T> et(value);
+        check_type<T>(et);
+
+        // ExprT<int> et_nope = et;  // won't compile, wrong types
+
+        // Cast the type to an int -- is generally ok, will
+        // coerce the values as appropriate
+        // (except for strings, which fill fail at runtime)
+        if (!std::is_same<T, const char *>::value) {
+            ExprT<int> et1 = cast<int>(et);
+            check_type<int>(et1);
+        }
+
+        // Obviously this won't even compile
+        // ExprT<int> et2 = et.typed<T>();
+        // check_type<int>(et2);
+
+        // Will fail at runtime if et isn't an int32
+        if (std::is_same<T, int>::value) {
+            ExprT<int> et3 = et.template typed<int>();
+            check_type<int>(et3);
+        }
+    }
+}
+
+template<typename T>
+void test_expr_range() {
+    test_expr<T>((T) 0);
+    test_expr<T>((T) 1);
+}
+
+int main(int argc, char **argv) {
+    test_expr_range<bool>();
+    test_expr_range<uint8_t>();
+    test_expr_range<uint16_t>();
+    test_expr_range<uint32_t>();
+    test_expr_range<int8_t>();
+    test_expr_range<int16_t>();
+    test_expr_range<int32_t>();
+    test_expr_range<int64_t>();
+    test_expr_range<uint64_t>();
+    test_expr_range<float16_t>();
+    test_expr_range<bfloat16_t>();
+    test_expr_range<float>();
+    test_expr_range<double>();
+
+    test_expr<const char *>("foo");
+
+    std::cout << "Success!\n";
+    return 0;
+}


### PR DESCRIPTION
This is a a rough sketch of an idea I have been pondering: could we usefully add more (optional) static typing to the Halide C++ IR?

This PR just adds a wrapper around `Expr` to allow for static typing (a la `Buffer<>`). The idea here is that an `ExprT<type>` is an Expr that can only a value of the given type (or be undefined).

The main goal here is to allow for easier readability in complex pipelines (eg if an Expr is expected to be of type uint8, this makes it more plain when reading the source code, and failures would happen at compile time, not runtime).

I'm not entirely sure if I like this or not, so I didn't expend a lot of energy trying to complete it -- there may be holes in the implementation.

In the name of science, I modified `cast<T>()` to return `ExprT<T>`, and `Var` to be convertible to `ExprT<int>` (rather than plain `Expr`).

If this seems remotely desirable, perhaps it could lead to similar wrappers for Func, ImageParam, etc.

Thoughts welcome.