### PR TITLE
Add support for Func::async in Python bindings

### DIFF
--- a/python_bindings/readme.md
+++ b/python_bindings/readme.md
@@ -32,6 +32,7 @@ with some differences where the C++ idiom is either inappropriate or impossible:
 - `Buffer::for_each_value()` is hard to implement well in Python; it's omitted
   entirely for now.
 - `Func::in` becomes `Func.in_` because `in` is a Python keyword.
+- `Func::async` becomes `Func.async_` because `async` is a Python keyword.
 
 ## Enhancements to the C++ API
 

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -195,6 +195,7 @@ void define_func(py::module &m) {
             .def("store_at", (Func & (Func::*)(const Func &, const RVar &)) & Func::store_at, py::arg("f"), py::arg("var"))
             .def("store_at", (Func & (Func::*)(LoopLevel)) & Func::store_at, py::arg("loop_level"))
 
+            .def("async_", &Func::async)
             .def("memoize", &Func::memoize)
             .def("compute_inline", &Func::compute_inline)
             .def("compute_root", &Func::compute_root)


### PR DESCRIPTION
The Python bindings were missing a wrapper for `Func::async`. This
change adds a wrapper called `Func.async_` to avoid clashes with the
Python `async` keyword.