### PR TITLE
Reschedule depthwise separable convolution again

### DIFF
--- a/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
+++ b/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
@@ -110,7 +110,7 @@ public:
             // shared if you do that.
 
             Var xi, yi, di, dii, xii, yii;
-            RVar roo, ro, ri;
+            RVar ro, ri;
 
             // The pointwise convolution kernel. Produces a 4x4 tile of output.
             Func(output)
@@ -132,9 +132,8 @@ public:
                 .unroll(x)
                 .unroll(y)
                 .unroll(d)
-                .split(rc, roo, ro, 32)
-                .split(ro, ro, ri, 4)
-                .reorder(ri, x, y, d, ro, roo)
+                .split(rc, ro, ri, 4)
+                .reorder(ri, x, y, d, ro)
                 .unroll(ri);
 
             // We're going to call in() on depthwise_convolved twice.

--- a/apps/depthwise_separable_conv/tf_separable_conv.py
+++ b/apps/depthwise_separable_conv/tf_separable_conv.py
@@ -7,11 +7,16 @@ with tf.device('/GPU:0'):
     depthwise_filter = tf.random.uniform([3, 3, 32, 1])
     pointwise_filter = tf.random.uniform([1, 1, 32 * 1, 16])
     
-    start = time.time()
-    num_iter = 100
-    for i in range(num_iter):
-        out = tf.nn.separable_conv2d(
-            img, depthwise_filter, pointwise_filter,
-            strides = (1, 1, 1, 1), padding = 'VALID')
-    end = time.time()
-    print('time: {} ms'.format(1000 * (end - start) / num_iter))
+    best = None
+    num_trials = 10
+    num_iter = 10
+    for j in range(num_trials):
+        start = time.time()
+        for i in range(num_iter):
+            out = tf.nn.separable_conv2d(
+                img, depthwise_filter, pointwise_filter,
+                strides = (1, 1, 1, 1), padding = 'VALID')
+        end = time.time()
+        t = (end - start) / num_iter
+        if not best or t < best: best = t
+    print('time: {} ms'.format(1000 * best))


### PR DESCRIPTION
I got it down to 65us, and fixed the tensorflow benchmark to use the same benchmarking methodology as we do (best of a number of trials). Tensorflow is at ~130us.

@dsharletg 