### PR TITLE
Add code to enable LLVM's internal pass-timing mode

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -417,6 +417,11 @@ void CodeGen_LLVM::initialize_llvm() {
 #include <llvm/Config/AsmPrinters.def>
 #include <utility>
 #undef LLVM_ASM_PRINTER
+
+      bool print_llvm_pass_timing = (get_env_variable("HL_PRINT_LLVM_PASS_TIMING") == "1");
+      if (print_llvm_pass_timing) {
+        llvm::TimePassesIsEnabled = true;
+      }
     });
 }
 
@@ -1219,11 +1224,6 @@ llvm::Type *CodeGen_LLVM::llvm_type_of(const Type &t) const {
 
 void CodeGen_LLVM::optimize_module() {
     debug(3) << "Optimizing module\n";
-
-    static bool print_llvm_pass_timing = (get_env_variable("HL_PRINT_LLVM_PASS_TIMING") == "1");
-    if (print_llvm_pass_timing) {
-      llvm::TimePassesIsEnabled = true;
-    }
 
     auto time_start = std::chrono::high_resolution_clock::now();
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -33,7 +33,7 @@
 #include "Util.h"
 
 namespace llvm {
-bool TimePassesIsEnabled;
+extern bool TimePassesIsEnabled;
 }  // namespace llvm
 
 #if !(__cplusplus > 199711L || _MSC_VER >= 1800)

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -418,10 +418,10 @@ void CodeGen_LLVM::initialize_llvm() {
 #include <utility>
 #undef LLVM_ASM_PRINTER
 
-      bool print_llvm_pass_timing = (get_env_variable("HL_PRINT_LLVM_PASS_TIMING") == "1");
-      if (print_llvm_pass_timing) {
-        llvm::TimePassesIsEnabled = true;
-      }
+        bool print_llvm_pass_timing = (get_env_variable("HL_PRINT_LLVM_PASS_TIMING") == "1");
+        if (print_llvm_pass_timing) {
+            llvm::TimePassesIsEnabled = true;
+        }
     });
 }
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -32,6 +32,10 @@
 #include "Simplify.h"
 #include "Util.h"
 
+namespace llvm {
+bool TimePassesIsEnabled;
+}  // namespace llvm
+
 #if !(__cplusplus > 199711L || _MSC_VER >= 1800)
 
 // VS2013 isn't fully C++11 compatible, but it supports enough of what Halide
@@ -1215,6 +1219,11 @@ llvm::Type *CodeGen_LLVM::llvm_type_of(const Type &t) const {
 
 void CodeGen_LLVM::optimize_module() {
     debug(3) << "Optimizing module\n";
+
+    static bool print_llvm_pass_timing = (get_env_variable("HL_PRINT_LLVM_PASS_TIMING") == "1");
+    if (print_llvm_pass_timing) {
+      llvm::TimePassesIsEnabled = true;
+    }
 
     auto time_start = std::chrono::high_resolution_clock::now();
 


### PR DESCRIPTION
By defining the env var HL_PRINT_LLVM_PASS_TIMING=1, we enable LLVM's internal code that dumps timing info for each optimization pass to stderr. This is entirely for internal Halide dev work and not intended for use by any Halide user.