### PR TITLE
Drop static library build from Windows.

### DIFF
--- a/tools/package-windows.bat
+++ b/tools/package-windows.bat
@@ -50,49 +50,17 @@ cmake -G "Visual Studio 16 2019" -Thost=x64 -A "%halide_arch%" ^
       "-DCMAKE_INSTALL_LIBDIR=lib/$<CONFIG>" ^
       "-DHALIDE_INSTALL_CMAKEDIR=lib" ^
       -S "%halide_source%" ^
-      -B "%halide_build_root%/shared"
+      -B "%halide_build_root%"
 
 if %errorlevel% neq 0 goto return
 
 REM We don't distribute Debug binaries because they aren't useful
-REM cmake --build %halide_build_root%/shared --config Debug
-cmake --build "%halide_build_root%/shared" --config Release
+REM cmake --build %halide_build_root% --config Debug
+cmake --build "%halide_build_root%" --config Release
 
-pushd "%halide_build_root%\shared"
-cpack -C "Release"
-popd
-
-REM REM REM REM REM REM REM REM REM REM REM REM REM REM REM REM REM REM REM REM
-
-REM Ninja Multi-Config in 3.18 has some sort of bug. Very disappointing.
-cmake -G "Visual Studio 16 2019" -Thost=x64 -A "%halide_arch%" ^
-      "-DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake" ^
-      "-DLLVM_DIR=%LLVM_DIR%" ^
-      "-DClang_DIR=%Clang_DIR%" ^
-      -DBUILD_SHARED_LIBS=NO ^
-      -DHalide_BUNDLE_LLVM=YES ^
-      -DWITH_TESTS=NO ^
-      -DWITH_APPS=NO ^
-      -DWITH_TUTORIALS=NO ^
-      -DWITH_DOCS=YES ^
-      -DWITH_UTILS=NO ^
-      -DWITH_PYTHON_BINDINGS=NO ^
-      "-DCMAKE_INSTALL_BINDIR=bin/$<CONFIG>" ^
-      "-DCMAKE_INSTALL_LIBDIR=lib/$<CONFIG>" ^
-      "-DHALIDE_INSTALL_CMAKEDIR=lib" ^
-      -S "%halide_source%" ^
-      -B "%halide_build_root%/static"
-
-if %errorlevel% neq 0 goto return
-
-REM LLVM Debug + Halide exceeds the COFF 4GB limit!!
-REM cmake --build "%halide_build_root%/static" --config Debug
-cmake --build "%halide_build_root%/static" --config Release
-
-pushd "%halide_build_root%\static"
+pushd "%halide_build_root%"
 cpack -C "Release"
 popd
 
 :return
-popd
 exit /b


### PR DESCRIPTION
Static archives were too large and of dubious benefit. We can revisit this if our users request it. 800MB compressed and 4GB uncompressed.