### PR TITLE
Allow overriding the Halide version via cmake flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.16)
-project(Halide VERSION 12.0.0)
+
+if (NOT DEFINED Halide_VERSION)
+    set(Halide_VERSION 12.0.0)
+endif ()
+project(Halide VERSION ${Halide_VERSION})
 
 enable_testing()
 

--- a/tools/package-unix.sh
+++ b/tools/package-unix.sh
@@ -3,6 +3,10 @@
 halide_source="$1"
 halide_build_root="$2"
 
+# TODO: this temporary, until release branches for Halide are created.
+# Remove as soon as that is done.
+[ -z "$Halide_VERSION" ] && echo "Must set specific Halide_VERSION for packaging" && exit
+
 [ -z "$LLVM_DIR" ] && echo "Must set specific LLVM_DIR for packaging" && exit
 [ -z "$Clang_DIR" ] && echo "Must set specific Clang_DIR for packaging" && exit
 [ -z "$halide_source" ] && echo "Usage: $0 <source-dir> <build-dir>" && exit
@@ -13,6 +17,7 @@ cmake -G Ninja \
   -DBUILD_SHARED_LIBS=YES \
   -DLLVM_DIR="$LLVM_DIR" \
   -DClang_DIR="$Clang_DIR" \
+  -DHalide_VERSION="$Halide_VERSION" \
   -DWITH_TESTS=NO \
   -DWITH_APPS=NO \
   -DWITH_TUTORIALS=NO \
@@ -28,6 +33,7 @@ cmake -G Ninja \
   -DHalide_BUNDLE_LLVM=YES \
   -DLLVM_DIR="$LLVM_DIR" \
   -DClang_DIR="$Clang_DIR" \
+  -DHalide_VERSION="$Halide_VERSION" \
   -DWITH_TESTS=NO \
   -DWITH_APPS=NO \
   -DWITH_TUTORIALS=NO \

--- a/tools/package-windows.bat
+++ b/tools/package-windows.bat
@@ -4,6 +4,13 @@ set halide_source="%~1"
 set halide_build_root="%~2"
 set halide_arch="%~3"
 
+REM TODO: this temporary, until release branches for Halide are created.
+REM Remove as soon as that is done.
+if "%Halide_VERSION%" == "" (
+    echo Must set specific Halide_VERSION for packaging
+    goto return
+)
+
 if not exist "%VCPKG_ROOT%\.vcpkg-root" (
     echo Must define VCPKG_ROOT to be the root of the VCPKG install
     goto return
@@ -39,6 +46,7 @@ cmake -G "Visual Studio 16 2019" -Thost=x64 -A "%halide_arch%" ^
       "-DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake" ^
       "-DLLVM_DIR=%LLVM_DIR%" ^
       "-DClang_DIR=%Clang_DIR%" ^
+      "-DHalide_VERSION=%Halide_VERSION%" ^
       -DBUILD_SHARED_LIBS=YES ^
       -DWITH_TESTS=NO ^
       -DWITH_APPS=NO ^


### PR DESCRIPTION
This is intended as a temporary trick; in the long run, each version will have its own release branch. This allows us to temporarily try out different 'releases' from the Halide master branch.