### PR TITLE
Simplify Call::if_then_else

### DIFF
--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -512,8 +512,6 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
 
         internal_assert(op->args.size() == 3);
         Expr cond_value = mutate(op->args[0], nullptr);
-        Expr true_value = mutate(op->args[1], nullptr);
-        Expr false_value = mutate(op->args[2], nullptr);
 
         // Ignore likelies for our purposes here
         Expr cond = cond_value;
@@ -525,18 +523,22 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
         }
 
         if (is_one(cond)) {
-            return true_value;
+            return mutate(op->args[1], bounds);
         } else if (is_zero(cond)) {
-            return false_value;
-        } else if (cond_value.same_as(op->args[0]) &&
-                   true_value.same_as(op->args[1]) &&
-                   false_value.same_as(op->args[2])) {
-            return op;
+            return mutate(op->args[2], bounds);
         } else {
-            return Internal::Call::make(op->type,
-                                        Call::if_then_else,
-                                        {std::move(cond_value), std::move(true_value), std::move(false_value)},
-                                        op->call_type);
+            Expr true_value = mutate(op->args[1], nullptr);
+            Expr false_value = mutate(op->args[2], nullptr);
+            if (cond_value.same_as(op->args[0]) &&
+                true_value.same_as(op->args[1]) &&
+                false_value.same_as(op->args[2])) {
+                return op;
+            } else {
+                return Internal::Call::make(op->type,
+                                            Call::if_then_else,
+                                            {std::move(cond_value), std::move(true_value), std::move(false_value)},
+                                            op->call_type);
+            }
         }
     } else if (op->call_type == Call::PureExtern) {
         // TODO: This could probably be simplified into a single map-lookup

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -511,9 +511,9 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
         // so this optimization should be safe.
 
         internal_assert(op->args.size() == 3);
-        Expr cond_value = mutate(op->args[0], bounds);
-        Expr true_value = mutate(op->args[1], bounds);
-        Expr false_value = mutate(op->args[2], bounds);
+        Expr cond_value = mutate(op->args[0], nullptr);
+        Expr true_value = mutate(op->args[1], nullptr);
+        Expr false_value = mutate(op->args[2], nullptr);
 
         // Ignore likelies for our purposes here
         Expr cond = cond_value;


### PR DESCRIPTION
According to @abadams, Call::if_then_else promises to evaluate exactly one (but not both) of the true and false exprs, so we should simplify cases in which the condition is provably true or false.