### PR TITLE
Appease clang-tidy

### DIFF
--- a/src/autoschedulers/adams2019/AutoSchedule.cpp
+++ b/src/autoschedulers/adams2019/AutoSchedule.cpp
@@ -100,7 +100,6 @@ namespace Autoscheduler {
 
 using std::map;
 using std::pair;
-using std::set;
 using std::string;
 using std::vector;
 

--- a/src/autoschedulers/adams2019/DefaultCostModel.cpp
+++ b/src/autoschedulers/adams2019/DefaultCostModel.cpp
@@ -29,7 +29,6 @@ namespace {
 using Halide::Internal::aslog;
 using Halide::Internal::PipelineFeatures;
 using Halide::Internal::ScheduleFeatures;
-using Halide::Internal::Weights;
 using Halide::Runtime::Buffer;
 
 bool ends_with(const std::string &str, const std::string &suffix) {


### PR DESCRIPTION
Remove two unused 'using' declarations.