### PR TITLE
Ensure that inline_all_trivial_functions() isn't dead-stripped

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -2,6 +2,7 @@
 #include "AutoScheduleUtils.h"
 #include "Debug.h"
 #include "Error.h"
+#include "Function.h"
 #include "Introspection.h"
 #include <atomic>
 #include <chrono>

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -574,7 +574,7 @@ void load_plugin(const std::string &lib_name) {
     // and this is only called when load_plugin is called anyway.
     // (If there is a better, portable way to ensure this function
     // isn't dead-stripped, then let's do that instead.)
-    (void)Halide::inline_all_trivial_functions({}, {}, {});
+    (void)Halide::Internal::inline_all_trivial_functions({}, {}, {});
 
 #ifdef _WIN32
     std::string lib_path = lib_name;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1,4 +1,5 @@
 #include "Util.h"
+#include "AutoScheduleUtils.h"
 #include "Debug.h"
 #include "Error.h"
 #include "Introspection.h"
@@ -573,7 +574,7 @@ void load_plugin(const std::string &lib_name) {
     // and this is only called when load_plugin is called anyway.
     // (If there is a better, portable way to ensure this function
     // isn't dead-stripped, then let's do that instead.)
-    (void) Halide::inline_all_trivial_functions({}, {}, {});
+    (void)Halide::inline_all_trivial_functions({}, {}, {});
 
 #ifdef _WIN32
     std::string lib_path = lib_name;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -563,6 +563,18 @@ int get_llvm_version() {
 }  // namespace Internal
 
 void load_plugin(const std::string &lib_name) {
+    // TODO: this is an ugly hack. inline_all_trivial_functions()
+    // isn't used by libHalide, but it is used by the Li2018
+    // autoscheduler plugin, so we need it to be present in the final
+    // libHalide. Unfortunately, build environments that static-link
+    // generators might deadstrip this function, causing Li2018
+    // to fail at load time. This useless call ensures that the function
+    // is kept around; calling it with empty arguments is close to free
+    // and this is only called when load_plugin is called anyway.
+    // (If there is a better, portable way to ensure this function
+    // isn't dead-stripped, then let's do that instead.)
+    (void) Halide::Internal::inline_all_trivial_functions({}, {}, {});
+
 #ifdef _WIN32
     std::string lib_path = lib_name;
     if (lib_path.find('.') == std::string::npos) {

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -573,7 +573,7 @@ void load_plugin(const std::string &lib_name) {
     // and this is only called when load_plugin is called anyway.
     // (If there is a better, portable way to ensure this function
     // isn't dead-stripped, then let's do that instead.)
-    (void) Halide::Internal::inline_all_trivial_functions({}, {}, {});
+    (void) Halide::inline_all_trivial_functions({}, {}, {});
 
 #ifdef _WIN32
     std::string lib_path = lib_name;


### PR DESCRIPTION
Can break Li2018 in some build environments.