### PR TITLE
Bundle wabt objects into libHalide

### DIFF
--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -38,7 +38,9 @@ if (WITH_WABT)
     # TODO: we want to require unique prefixes to include these files, to avoid ambiguity;
     # this means we have to prefix with "wabt-src/...", which is less bad than other alternatives,
     # but perhaps we could do better (esp. if wabt was smarter about what it exposed?)
-    target_include_directories(wabt INTERFACE
+    add_library(wabt-obj INTERFACE)
+    target_sources(wabt-obj INTERFACE $<BUILD_INTERFACE:$<TARGET_OBJECTS:wabt>>)
+    target_include_directories(wabt-obj INTERFACE
                                $<BUILD_INTERFACE:${wabt_SOURCE_DIR}>
                                $<BUILD_INTERFACE:${wabt_BINARY_DIR}>
                                $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/_deps>)

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -14,7 +14,7 @@ set(HALIDE_INSTALL_CMAKEDIR
 ##
 
 set(optional_dependencies "")
-foreach (target IN ITEMS wabt)
+foreach (target IN ITEMS wabt-obj)
     if (TARGET ${target})
         list(APPEND optional_dependencies ${target})
     endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -385,8 +385,8 @@ set_target_properties(Halide PROPERTIES
 
 add_dependencies(Halide HalideIncludes)
 
-if (TARGET wabt)
-    target_link_libraries(Halide PRIVATE wabt)
+if (TARGET wabt-obj)
+    target_link_libraries(Halide PRIVATE wabt-obj)
     target_compile_definitions(Halide PRIVATE WITH_WABT)
 endif ()
 


### PR DESCRIPTION
Only affects Halide 11+. No more need to package libwabt.a, just includes its objects into libHalide.a