### PR TITLE
Re-enable CUDAVectorize tests. 

### DIFF
--- a/test/correctness/atomics.cpp
+++ b/test/correctness/atomics.cpp
@@ -1246,13 +1246,13 @@ int main(int argc, char **argv) {
         test_all<uint64_t>(Backend::CUDA);
         test_all<int64_t>(Backend::CUDA);
         test_all<double>(Backend::CUDA);
-        // TODO: Broken currently; commented out until https://github.com/halide/Halide/pull/4628 lands
-        // test_all<uint32_t>(Backend::CUDAVectorize);
-        // test_all<int32_t>(Backend::CUDAVectorize);
-        // test_all<float>(Backend::CUDAVectorize);
-        // test_all<uint64_t>(Backend::CUDAVectorize);
-        // test_all<int64_t>(Backend::CUDAVectorize);
-        // test_all<double>(Backend::CUDAVectorize);
+
+        test_all<uint32_t>(Backend::CUDAVectorize);
+        test_all<int32_t>(Backend::CUDAVectorize);
+        test_all<float>(Backend::CUDAVectorize);
+        test_all<uint64_t>(Backend::CUDAVectorize);
+        test_all<int64_t>(Backend::CUDAVectorize);
+        test_all<double>(Backend::CUDAVectorize);
     }
     test_extern_func(Backend::CPU);
     test_extern_func(Backend::CPUVectorize);


### PR DESCRIPTION
These tests were disabled in #4683 but #4628 supposedly provided a fix. This PR re-enables them.

Fixes #4554.