### PR TITLE
Set version to 12.0.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-
-if (NOT DEFINED Halide_VERSION)
-    set(Halide_VERSION 12.0.0)
-endif ()
-project(Halide VERSION ${Halide_VERSION})
+project(Halide VERSION 12.0.0)
 
 enable_testing()
 


### PR DESCRIPTION
Since our next release will be based on LLVM 11.0.0, we should set the master version to 11. Yes, we still support LLVM trunk which is version 12, but we'll just bump our version once that one is officially released.

Fixes #5259