### PR TITLE
Avoid possibly-uninitialized use of RVar::_index

### DIFF
--- a/src/RDom.h
+++ b/src/RDom.h
@@ -29,10 +29,12 @@ class OutputImageParam;
 class RVar {
     std::string _name;
     Internal::ReductionDomain _domain;
-    int _index;
+    int _index = -1;
 
     const Internal::ReductionVariable &_var() const {
-        return _domain.domain().at(_index);
+        const auto &d = _domain.domain();
+        internal_assert(_index >= 0 && _index < (int)d.size());
+        return d.at(_index);
     }
 
 public:

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1318,10 +1318,9 @@ typedef enum halide_target_feature_t {
     halide_target_feature_sve,                    ///< Enable ARM Scalable Vector Extensions
     halide_target_feature_sve2,                   ///< Enable ARM Scalable Vector Extensions v2
     halide_target_feature_egl,                    ///< Force use of EGL support.
-
-    halide_target_feature_arm_dot_prod,  ///< Enable ARMv8.2-a dotprod extension (i.e. udot and sdot instructions)
-    halide_llvm_large_code_model,        ///< Use the LLVM large code model to compile
-    halide_target_feature_end            ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
+    halide_target_feature_arm_dot_prod,           ///< Enable ARMv8.2-a dotprod extension (i.e. udot and sdot instructions)
+    halide_llvm_large_code_model,                 ///< Use the LLVM large code model to compile
+    halide_target_feature_end                     ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 
 /** This function is called internally by Halide in some situations to determine


### PR DESCRIPTION
One of the armbots warned that this field could be used uninitialized; I can't replicate anywhere else, but indeed, the string-only ctor of RVar left this uninitialized. Defaulted it to -1 and added an explicit check in _var(). (Yes, the call to `at()` will fail when out of range, but explicit checking is better IMHO.)

(Also: unrelated drive-by formatting fix to HalideRuntime.h to avoid another PR just for that)