### PR TITLE
Fix host_supports_target_device()

### DIFF
--- a/src/DeviceInterface.cpp
+++ b/src/DeviceInterface.cpp
@@ -35,7 +35,9 @@ bool lookup_runtime_routine(const std::string &name,
 bool host_supports_target_device(const Target &t) {
     const DeviceAPI d = t.get_required_device_api();
     if (d == DeviceAPI::None) {
-        return false;
+        // If the target requires no DeviceAPI, then
+        // the host trivially supports the target device.
+        return true;
     }
 
     const struct halide_device_interface_t *i = get_device_interface_for_device_api(d, t);

--- a/src/DeviceInterface.cpp
+++ b/src/DeviceInterface.cpp
@@ -35,7 +35,7 @@ bool lookup_runtime_routine(const std::string &name,
 bool host_supports_target_device(const Target &t) {
     const DeviceAPI d = t.get_required_device_api();
     if (d == DeviceAPI::None) {
-        return true;
+        return false;
     }
 
     const struct halide_device_interface_t *i = get_device_interface_for_device_api(d, t);

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -479,14 +479,14 @@ WEAK int halide_metal_device_malloc(void *user_context, halide_buffer_t *buf) {
 
     debug(user_context) << "    allocating " << *buf << "\n";
 
-#ifdef DEBUG_RUNTIME
-    uint64_t t_before = halide_current_time_ns(user_context);
-#endif
-
     MetalContextHolder metal_context(user_context, true);
     if (metal_context.error != 0) {
         return metal_context.error;
     }
+
+#ifdef DEBUG_RUNTIME
+    uint64_t t_before = halide_current_time_ns(user_context);
+#endif
 
     device_handle *handle = (device_handle *)malloc(sizeof(device_handle));
     if (handle == NULL) {


### PR DESCRIPTION
`host_supports_target_device()` was returning true if it failed to get a `DeviceAPI` corresponding to the target.

Drive-by fix: in a `-metal-debug` target, `halide_current_time_ns()` was being called in `halide_metal_device_malloc()` before timer initialization, which happens as part of context creation.