### PR TITLE
Use adjustPassManager equivalent for NPM

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1340,9 +1340,11 @@ void CodeGen_LLVM::optimize_module() {
         }
     }
 
+#if LLVM_VERSION >= 120
     if (tm) {
         tm->registerPassBuilderCallbacks(pb, debug_pass_manager);
     }
+#endif
 
     mpm = pb.buildPerModuleDefaultPipeline(level, debug_pass_manager);
     mpm.run(*module, mam);

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1340,6 +1340,9 @@ void CodeGen_LLVM::optimize_module() {
         }
     }
 
+    if (tm)
+        tm->registerPassBuilderCallbacks(pb, debug_pass_manager);
+
     mpm = pb.buildPerModuleDefaultPipeline(level, debug_pass_manager);
     mpm.run(*module, mam);
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1340,8 +1340,9 @@ void CodeGen_LLVM::optimize_module() {
         }
     }
 
-    if (tm)
+    if (tm) {
         tm->registerPassBuilderCallbacks(pb, debug_pass_manager);
+    }
 
     mpm = pb.buildPerModuleDefaultPipeline(level, debug_pass_manager);
     mpm.run(*module, mam);


### PR DESCRIPTION
Add call to TargetMachine::registerPassBuilderCallbacks to allow targets to add passes to the pass pipeline using the New Pass Manager
@alinas PTAL