### PR TITLE
Add a header-only library that handles complex types.

### DIFF
--- a/apps/fft/complex.h
+++ b/apps/fft/complex.h
@@ -106,6 +106,9 @@ inline ComplexExpr operator/(ComplexExpr a, Halide::Expr b) {
     return ComplexExpr(re(a) / b, im(a) / b);
 }
 
+inline ComplexExpr exp(const ComplexExpr &z) {
+    return ComplexExpr(Halide::exp(re(z)) * Halide::cos(im(z)), Halide::exp(re(z)) * Halide::sin(im(z)));
+}
 // Compute exp(j*x)
 inline ComplexExpr expj(Halide::Expr x) {
     return ComplexExpr(Halide::cos(x), Halide::sin(x));

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -51,6 +51,8 @@ tests(GROUPS correctness
       compile_to_bitcode.cpp
       compile_to_lowered_stmt.cpp
       compile_to_multitarget.cpp
+      complexfunc.cpp
+      complexfunc_tuple.cpp
       compute_at_reordered_update_stage.cpp
       compute_at_split_rvar.cpp
       compute_inside_guard.cpp
@@ -386,4 +388,3 @@ set_target_properties(correctness_async
                       correctness_sliding_window
                       correctness_storage_folding
                       PROPERTIES ENABLE_EXPORTS TRUE)
-

--- a/test/correctness/complexfunc.cpp
+++ b/test/correctness/complexfunc.cpp
@@ -1,0 +1,319 @@
+#include "Halide.h"
+#include "halide_complexfunc.h"
+#include <cmath>
+#include <complex>
+#include <iostream>
+
+using namespace Halide;
+using Halide::Tools::ComplexExpr;
+using Halide::Tools::ComplexFunc;
+using Halide::Tools::exp;
+using Halide::Tools::expj;
+using std::cout;
+using std::endl;
+
+#define N 5
+
+void print_buf(const char *prefix, std::complex<double> *buf, int X, int Y) {
+    for (int y = 0; y < Y; y++) {
+        printf("%s row %d = [", prefix, y);
+        for (int x = 0; x < X; x++) {
+            std::complex<double> value = buf[y * X + x];
+            printf("%c%4.1f+%.1fi ", x ? ',' : ' ', value.real(), value.imag());
+        }
+        printf("]\n");
+    }
+}
+
+Buffer<double> gen_buf() {
+    Buffer<double> input(2, N);
+    std::complex<double> *input_ptr = (std::complex<double> *)input.begin();
+    for (int i = 0; i < N; i++) {
+        std::complex<double> value(1.0 + i, i - 1.0);
+        input_ptr[i] = value;
+    }
+    return input;
+}
+
+void test_io() {
+    printf("test_io\n");
+    // test that complex values can be passed into and out of a Halide kernel.
+    Buffer<double> input = gen_buf();
+
+    Var c("c"), x("x");
+    Func input_clamped = BoundaryConditions::constant_exterior(input, Expr(0.0));
+    ComplexFunc input_complex(c, input_clamped);
+    ComplexFunc result(c, "result");
+    result(x) = input_complex(x);
+
+    Buffer<double> output = result.inner.realize(2, N);
+
+    for (int i = 0; i < N; i++) {
+        int failure_count = 0;
+        std::complex<double> value(1.0 + i, i - 1.0);
+        if (std::abs(output(0, i) - value.real()) > 0.01) {
+            cout << "Wrong real value for element " << i << ". Expected " << value.real() << ", got " << output(0, i) << endl;
+            failure_count++;
+        }
+        if (std::abs(output(1, i) - value.imag()) > 0.01) {
+            cout << "Wrong imaginary value for element " << i << ". Expected " << value.imag() << ", got " << output(1, i) << endl;
+            failure_count++;
+        }
+        if (failure_count)
+            abort();
+    }
+}
+
+void test_ops_complex_complex() {
+    printf("test_ops_complex_complex\n");
+    Buffer<double> input = gen_buf();
+    std::complex<double> *input_ptr = (std::complex<double> *)input.begin();
+
+    Var c("c"), x("x"), y("y");
+    Func input_clamped = BoundaryConditions::constant_exterior(input, Expr(0.0));
+    ComplexFunc input_complex(c, input_clamped);
+    ComplexFunc result(c, "result");
+    result(x, y) = ComplexExpr(c, Expr(0.0), Expr(0.0));
+    result(x, 0) = ComplexExpr(c, Expr(1.1), Expr(2.2)) + input_complex(x);
+    result(x, 1) = ComplexExpr(c, Expr(3.3), Expr(4.4)) - input_complex(x);
+    result(x, 2) = ComplexExpr(c, Expr(5.5), Expr(6.6)) * input_complex(x);
+    result(x, 3) = ComplexExpr(c, Expr(7.7), Expr(8.8)) / input_complex(x);
+
+    Buffer<double> output = result.inner.realize(2, N);
+
+    //print_buf("result", (std::complex<double> *)output.begin(), N, 1);
+    Buffer<double> expected(2, N, 4);
+    std::complex<double> *expected_ptr = (std::complex<double> *)expected.begin();
+    //
+    for (int i = 0; i < N; i++) {
+        expected_ptr[i + 0 * N] = std::complex<double>(1.1, 2.2) + input_ptr[i];
+        expected_ptr[i + 1 * N] = std::complex<double>(3.3, 4.4) - input_ptr[i];
+        expected_ptr[i + 2 * N] = std::complex<double>(5.5, 6.6) * input_ptr[i];
+        expected_ptr[i + 3 * N] = std::complex<double>(7.7, 8.8) / input_ptr[i];
+        for (int j = 0; j < 4; j++) {
+            int failure_count = 0;
+            std::complex<double> value = expected_ptr[i + j * N];
+            if (std::abs(output(0, i, j) - value.real()) > 0.01) {
+                cout << "Wrong real value for element " << i << "," << j << ". Expected " << value.real() << ", got " << output(0, i, j) << endl;
+                failure_count++;
+            }
+            if (std::abs(output(1, i, j) - value.imag()) > 0.01) {
+                cout << "Wrong imaginary value for element " << i << "," << j << ". Expected " << value.imag() << ", got " << output(1, i, j) << endl;
+                failure_count++;
+            }
+            if (failure_count)
+                abort();
+        }
+    }
+}
+
+void test_ops_complex_real() {
+    printf("test_ops_complex_real\n");
+    Buffer<double> input = gen_buf();
+    std::complex<double> *input_ptr = (std::complex<double> *)input.begin();
+
+    Var c("c"), x("x"), y("y");
+    Func input_clamped = BoundaryConditions::constant_exterior(input, Expr(0.0));
+    ComplexFunc input_complex(c, input_clamped);
+    ComplexFunc result(c, "result");
+    result(x, y) = ComplexExpr(c, Expr(0.0), Expr(0.0));
+    result(x, 0) = input_complex(x) + Expr(1.2);
+    result(x, 1) = input_complex(x) - Expr(3.4);
+    result(x, 2) = input_complex(x) * Expr(5.6);
+    result(x, 3) = input_complex(x) / Expr(7.8);
+
+    Buffer<double> output = result.inner.realize(2, N, 4);
+
+    //print_buf("result", (std::complex<double> *)output.begin(), N, 1);
+    Buffer<double> expected(2, N, 4);
+    std::complex<double> *expected_ptr = (std::complex<double> *)expected.begin();
+    //
+    for (int i = 0; i < N; i++) {
+        expected_ptr[i + 0 * N] = input_ptr[i] + 1.2;
+        expected_ptr[i + 1 * N] = input_ptr[i] - 3.4;
+        expected_ptr[i + 2 * N] = input_ptr[i] * 5.6;
+        expected_ptr[i + 3 * N] = input_ptr[i] / 7.8;
+        for (int j = 0; j < 4; j++) {
+            int failure_count = 0;
+            std::complex<double> value = expected_ptr[i + j * N];
+            if (std::abs(output(0, i, j) - value.real()) > 0.01) {
+                cout << "Wrong real value for element " << i << "," << j << ". Expected " << value.real() << ", got " << output(0, i, j) << endl;
+                failure_count++;
+            }
+            if (std::abs(output(1, i, j) - value.imag()) > 0.01) {
+                cout << "Wrong imaginary value for element " << i << "," << j << ". Expected " << value.imag() << ", got " << output(1, i, j) << endl;
+                failure_count++;
+            }
+            if (failure_count)
+                abort();
+        }
+    }
+}
+void test_ops_real_complex() {
+    printf("test_ops_real_complex\n");
+    Buffer<double> input = gen_buf();
+    std::complex<double> *input_ptr = (std::complex<double> *)input.begin();
+
+    Var c("c"), x("x"), y("y");
+    Func input_clamped = BoundaryConditions::constant_exterior(input, Expr(0.0));
+    ComplexFunc input_complex(c, input_clamped);
+    ComplexFunc result(c, "result");
+    result(x, y) = ComplexExpr(c, Expr(0.0), Expr(0.0));
+    result(x, 0) = Expr(1.2) + input_complex(x);
+    result(x, 1) = Expr(3.4) - input_complex(x);
+    result(x, 2) = Expr(5.6) * input_complex(x);
+    result(x, 3) = Expr(7.8) / input_complex(x);
+
+    Buffer<double> output = result.inner.realize(2, N);
+
+    //print_buf("result", (std::complex<double> *)output.begin(), N, 1);
+    Buffer<double> expected(2, N, 4);
+    std::complex<double> *expected_ptr = (std::complex<double> *)expected.begin();
+    //
+    for (int i = 0; i < N; i++) {
+        expected_ptr[i + 0 * N] = 1.2 + input_ptr[i];
+        expected_ptr[i + 1 * N] = 3.4 - input_ptr[i];
+        expected_ptr[i + 2 * N] = 5.6 * input_ptr[i];
+        expected_ptr[i + 3 * N] = 7.8 / input_ptr[i];
+        for (int j = 0; j < 4; j++) {
+            int failure_count = 0;
+            std::complex<double> value = expected_ptr[i + j * N];
+            if (std::abs(output(0, i, j) - value.real()) > 0.01) {
+                cout << "Wrong real value for element " << i << "," << j << ". Expected " << value.real() << ", got " << output(0, i, j) << endl;
+                failure_count++;
+            }
+            if (std::abs(output(1, i, j) - value.imag()) > 0.01) {
+                cout << "Wrong imaginary value for element " << i << "," << j << ". Expected " << value.imag() << ", got " << output(1, i, j) << endl;
+                failure_count++;
+            }
+            if (failure_count)
+                abort();
+        }
+    }
+}
+void test_assignment_ops_complex_complex() {
+    printf("test_assignment_ops_complex_complex\n");
+    Buffer<double> input = gen_buf();
+    std::complex<double> *input_ptr = (std::complex<double> *)input.begin();
+
+    Var c("c"), x("x"), y("y");
+    Func input_clamped = BoundaryConditions::constant_exterior(input, Expr(0.0));
+    ComplexFunc input_complex(c, input_clamped);
+    ComplexFunc result(c, "result");
+    result(x) = input_complex(x);
+    result(x) += ComplexExpr(c, Expr(1.1), Expr(2.2));
+    result(x) -= ComplexExpr(c, Expr(3.3), Expr(4.4));
+    // result(x) *= ComplexExpr(c, Expr(5.5), Expr(6.6));
+    // result(x) /= ComplexExpr(c, Expr(7.7), Expr(8.8));
+
+    Buffer<double> output = result.inner.realize(2, N);
+
+    //print_buf("result", (std::complex<double> *)output.begin(), N, 1);
+    Buffer<double> expected(2, N);
+    std::complex<double> *expected_ptr = (std::complex<double> *)expected.begin();
+    //
+    for (int i = 0; i < N; i++) {
+        expected_ptr[i] = input_ptr[i];
+        expected_ptr[i] += std::complex<double>(1.1, 2.2);
+        expected_ptr[i] -= std::complex<double>(3.3, 4.4);
+        // expected_ptr[i] *= std::complex<double>(5.5, 6.6);
+        // expected_ptr[i] /= std::complex<double>(7.7, 8.8);
+        int failure_count = 0;
+        std::complex<double> value = expected_ptr[i];
+        if (std::abs(output(0, i) - value.real()) > 0.01) {
+            cout << "Wrong real value for element " << i << ". Expected " << value.real() << ", got " << output(0, i) << endl;
+            failure_count++;
+        }
+        if (std::abs(output(1, i) - value.imag()) > 0.01) {
+            cout << "Wrong imaginary value for element " << i << ". Expected " << value.imag() << ", got " << output(1, i) << endl;
+            failure_count++;
+        }
+        if (failure_count)
+            abort();
+    }
+}
+
+void test_assignment_ops_complex_real() {
+    printf("test_assignment_ops_complex_real\n");
+    Buffer<double> input = gen_buf();
+
+    Var c("c"), x("x"), y("y");
+    Func input_clamped = BoundaryConditions::constant_exterior(input, Expr(0.0));
+    ComplexFunc input_complex(c, input_clamped);
+    ComplexFunc result(c, "result");
+    result(x) = input_complex(x) * ComplexExpr(c, Expr(1.2), Expr(3.4)) / ComplexExpr(c, Expr(5.6), Expr(7.8)) + ComplexExpr(c, Expr(9.0), Expr(1.2)) - ComplexExpr(c, Expr(3.4), Expr(5.6));
+
+    Buffer<double> output = result.inner.realize(2, N);
+
+    for (int i = 0; i < N; i++) {
+        std::complex<double> value(1.0 + i, i - 1.0);
+        value *= std::complex<double>(1.2, 3.4);
+        value /= std::complex<double>(5.6, 7.8);
+        value += std::complex<double>(9.0, 1.2);
+        value -= std::complex<double>(3.4, 5.6);
+        int failure_count = 0;
+        if (std::abs(output(0, i) - value.real()) > 0.01) {
+            cout << "Wrong real value for element " << i << ". Expected " << value.real() << ", got " << output(0, i) << endl;
+            failure_count++;
+        }
+        if (std::abs(output(1, i) - value.imag()) > 0.01) {
+            cout << "Wrong imaginary value for element " << i << ". Expected " << value.imag() << ", got " << output(1, i) << endl;
+            failure_count++;
+        }
+        if (failure_count)
+            abort();
+    }
+}
+
+void test_helper_funcs() {
+    printf("test_helper_funcs\n");
+    Buffer<double> input = gen_buf();
+
+    Var c("c"), x("x"), y("y");
+    Func input_clamped = BoundaryConditions::constant_exterior(input, Expr(0.0));
+    ComplexFunc input_complex(c, input_clamped);
+    ComplexFunc result(c, "result");
+    result(x, y) = ComplexExpr(c, Expr(0.0), Expr(0.0));
+    result(x, 0) = exp(input_complex(x));
+    result(x, 1) = expj(input_complex.element, input_complex.inner(1, x));
+    result(x, 2) = -input_complex(x);
+    result(x, 3) = ComplexExpr(c, abs(input_complex(x)), Expr(0.0));
+    result(x, 4) = ComplexExpr(c, Expr(1.0), Expr(2.0)) * -input_complex(x) * ComplexExpr(c, Expr(3.0), Expr(4.0));
+
+    Buffer<double> output = result.inner.realize(2, N, 5);
+
+    for (int i = 0; i < N; i++) {
+        std::complex<double> values[5];
+        std::complex<double> inputvalue(1.0 + i, i - 1.0);
+        values[0] = std::exp(inputvalue);
+        values[1] = std::exp(std::complex<double>(0.0, inputvalue.imag()));
+        values[2] = -inputvalue;
+        values[3] = abs(inputvalue);
+        values[4] = std::complex<double>(1.0, 2.0) * -inputvalue * std::complex<double>(3.0, 4.0);
+
+        for (int j = 0; j < 5; j++) {
+            int failure_count = 0;
+            if (std::abs(output(0, i, j) - values[j].real()) > 0.01) {
+                cout << "Wrong real value for element " << i << "," << j << ". Expected " << values[j].real() << ", got " << output(0, i, j) << endl;
+                failure_count++;
+            }
+            if (std::abs(output(1, i, j) - values[j].imag()) > 0.01) {
+                cout << "Wrong imaginary value for element " << i << "," << j << ". Expected " << values[j].imag() << ", got " << output(1, i, j) << endl;
+                failure_count++;
+            }
+            if (failure_count)
+                abort();
+        }
+    }
+}
+
+int main(int argc, char **argv) {
+    test_io();
+    test_ops_complex_complex();
+    test_ops_complex_real();
+    test_ops_real_complex();
+    test_assignment_ops_complex_complex();
+    test_helper_funcs();
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/complexfunc_tuple.cpp
+++ b/test/correctness/complexfunc_tuple.cpp
@@ -1,0 +1,322 @@
+#include "../../apps/fft/complex.h"
+#include "Halide.h"
+#include <cmath>
+#include <complex>
+#include <iostream>
+
+using namespace Halide;
+using std::cout;
+using std::endl;
+
+#define N 5
+
+void print_buf(const char *prefix, std::complex<double> *buf, int X, int Y) {
+    for (int y = 0; y < Y; y++) {
+        printf("%s row %d = [", prefix, y);
+        for (int x = 0; x < X; x++) {
+            std::complex<double> value = buf[y * X + x];
+            printf("%c%4.1f+%.1fi ", x ? ',' : ' ', value.real(), value.imag());
+        }
+        printf("]\n");
+    }
+}
+
+Buffer<double> gen_buf() {
+    Buffer<double> input(2, 5);
+    std::complex<double> *input_ptr = (std::complex<double> *)input.begin();
+    for (int i = 0; i < N; i++) {
+        std::complex<double> value(1.0 + i, i - 1.0);
+        input_ptr[i] = value;
+    }
+    return input;
+}
+
+void test_io() {
+    printf("test_io\n");
+    // test that complex values can be passed into and out of a Halide kernel.
+    Buffer<double> input = gen_buf();
+
+    Var c("c"), x("x");
+    Func input_clamped = BoundaryConditions::constant_exterior(input, Expr(0.0));
+    ComplexFunc input_complex("input_complex");
+    input_complex(x) = ComplexExpr(input_clamped(0, x), input_clamped(1, x));
+    ComplexFunc result("result");
+    result(x) = input_complex(x);
+    Func interleaved_output("interleaved_output");
+    interleaved_output(c, x) = select(c == 0, result(x).re(), result(x).im());
+
+    Buffer<double> output = interleaved_output.realize(2, N);
+
+    for (int i = 0; i < N; i++) {
+        std::complex<double> value(1.0 + i, i - 1.0);
+        if (std::abs(output(0, i) - value.real()) > 0.01) {
+            std::cout << "Wrong real value for element " << i << ". Expected " << value.real() << ", got " << output(0, i) << endl;
+            abort();
+        }
+        if (std::abs(output(1, i) - value.imag()) > 0.01) {
+            std::cout << "Wrong imaginary value for element " << i << ". Expected " << value.imag() << ", got " << output(1, i) << endl;
+            abort();
+        }
+    }
+}
+
+void test_ops_complex_complex() {
+    printf("test_ops_complex_complex\n");
+    Buffer<double> input = gen_buf();
+    std::complex<double> *input_ptr = (std::complex<double> *)input.begin();
+
+    Var c("c"), x("x"), y("y");
+    Func input_clamped = BoundaryConditions::constant_exterior(input, Expr(0.0));
+    ComplexFunc input_complex("input_complex");
+    input_complex(x) = ComplexExpr(input_clamped(0, x), input_clamped(1, x));
+    ComplexFunc result("result");
+    result(x, y) = ComplexExpr(Expr(0.0), Expr(0.0));
+    result(x, 0) = ComplexExpr(Expr(1.1), Expr(2.2)) + input_complex(x);
+    result(x, 1) = ComplexExpr(Expr(3.3), Expr(4.4)) - input_complex(x);
+    result(x, 2) = ComplexExpr(Expr(5.5), Expr(6.6)) * input_complex(x);
+    //result(x, 3) = ComplexExpr(Expr(7.7), Expr(8.8)) / input_complex(x);
+    Func interleaved_output("interleaved_output");
+    interleaved_output(c, x, y) = select(c == 0, result(x, y).re(), result(x, y).im());
+
+    Buffer<double> output = interleaved_output.realize(2, N, 4);
+
+    Buffer<double> expected(2, N, 4);
+    std::complex<double> *expected_ptr = (std::complex<double> *)expected.begin();
+    for (int i = 0; i < N; i++) {
+        expected_ptr[i + 0 * N] = std::complex<double>(1.1, 2.2) + input_ptr[i];
+        expected_ptr[i + 1 * N] = std::complex<double>(3.3, 4.4) - input_ptr[i];
+        expected_ptr[i + 2 * N] = std::complex<double>(5.5, 6.6) * input_ptr[i];
+        //expected_ptr[i+3*N] = std::complex<double>(7.7,8.8) / input_ptr[i];
+        for (int j = 0; j < 3; j++) {
+            std::complex<double> value = expected_ptr[i + j * N];
+            if (std::abs(output(0, i, j) - value.real()) > 0.01) {
+                std::cout << "Wrong real value for element " << i << "," << j << ". Expected " << value.real() << ", got " << output(0, i, j) << endl;
+                abort();
+            }
+            if (std::abs(output(1, i, j) - value.imag()) > 0.01) {
+                std::cout << "Wrong imaginary value for element " << i << "," << j << ". Expected " << value.imag() << ", got " << output(1, i, j) << endl;
+                abort();
+            }
+        }
+    }
+}
+
+void test_ops_complex_real() {
+    printf("test_ops_complex_real\n");
+    Buffer<double> input = gen_buf();
+    std::complex<double> *input_ptr = (std::complex<double> *)input.begin();
+
+    Var c("c"), x("x"), y("y");
+    Func input_clamped = BoundaryConditions::constant_exterior(input, Expr(0.0));
+    ComplexFunc input_complex("input_complex");
+    input_complex(x) = ComplexExpr(input_clamped(0, x), input_clamped(1, x));
+    ComplexFunc result("result");
+    result(x, y) = ComplexExpr(Expr(0.0), Expr(0.0));
+    result(x, 0) = input_complex(x) + Expr(1.2);
+    result(x, 1) = input_complex(x) - Expr(3.4);
+    result(x, 2) = input_complex(x) * Expr(5.6);
+    result(x, 3) = input_complex(x) / Expr(7.8);
+    Func interleaved_output("interleaved_output");
+    interleaved_output(c, x, y) = select(c == 0, result(x, y).re(), result(x, y).im());
+
+    Buffer<double> output = interleaved_output.realize(2, N, 4);
+
+    Buffer<double> expected(2, N, 4);
+    std::complex<double> *expected_ptr = (std::complex<double> *)expected.begin();
+    for (int i = 0; i < N; i++) {
+        expected_ptr[i + 0 * N] = input_ptr[i] + 1.2;
+        expected_ptr[i + 1 * N] = input_ptr[i] - 3.4;
+        expected_ptr[i + 2 * N] = input_ptr[i] * 5.6;
+        expected_ptr[i + 3 * N] = input_ptr[i] / 7.8;
+        for (int j = 0; j < 4; j++) {
+            std::complex<double> value = expected_ptr[i + j * N];
+            if (std::abs(output(0, i, j) - value.real()) > 0.01) {
+                std::cout << "Wrong real value for element " << i << "," << j << ". Expected " << value.real() << ", got " << output(0, i, j) << endl;
+                abort();
+            }
+            if (std::abs(output(1, i, j) - value.imag()) > 0.01) {
+                std::cout << "Wrong imaginary value for element " << i << "," << j << ". Expected " << value.imag() << ", got " << output(1, i, j) << endl;
+                abort();
+            }
+        }
+    }
+}
+void test_ops_real_complex() {
+    printf("test_ops_real_complex\n");
+    Buffer<double> input = gen_buf();
+    std::complex<double> *input_ptr = (std::complex<double> *)input.begin();
+
+    Var c("c"), x("x"), y("y");
+    Func input_clamped = BoundaryConditions::constant_exterior(input, Expr(0.0));
+    ComplexFunc input_complex("input_complex");
+    input_complex(x) = ComplexExpr(input_clamped(0, x), input_clamped(1, x));
+    ComplexFunc result("result");
+    result(x, y) = ComplexExpr(Expr(0.0), Expr(0.0));
+    result(x, 0) = Expr(1.2) + input_complex(x);
+    result(x, 1) = Expr(3.4) - input_complex(x);
+    result(x, 2) = Expr(5.6) * input_complex(x);
+    //result(x, 3) = Expr(7.8) / input_complex(x);
+    Func interleaved_output("interleaved_output");
+    interleaved_output(c, x, y) = select(c == 0, result(x, y).re(), result(x, y).im());
+
+    Buffer<double> output = interleaved_output.realize(2, N, 4);
+
+    Buffer<double> expected(2, N, 4);
+    std::complex<double> *expected_ptr = (std::complex<double> *)expected.begin();
+    for (int i = 0; i < N; i++) {
+        expected_ptr[i + 0 * N] = 1.2 + input_ptr[i];
+        expected_ptr[i + 1 * N] = 3.4 - input_ptr[i];
+        expected_ptr[i + 2 * N] = 5.6 * input_ptr[i];
+        //expected_ptr[i+3*N] = 7.8 / input_ptr[i];
+        for (int j = 0; j < 3; j++) {
+            std::complex<double> value = expected_ptr[i + j * N];
+            if (std::abs(output(0, i, j) - value.real()) > 0.01) {
+                std::cout << "Wrong real value for element " << i << "," << j << ". Expected " << value.real() << ", got " << output(0, i, j) << endl;
+                abort();
+            }
+            if (std::abs(output(1, i, j) - value.imag()) > 0.01) {
+                std::cout << "Wrong imaginary value for element " << i << "," << j << ". Expected " << value.imag() << ", got " << output(1, i, j) << endl;
+                abort();
+            }
+        }
+    }
+}
+void test_assignment_ops_complex_complex() {
+    printf("test_assignment_ops_complex_complex\n");
+    Buffer<double> input = gen_buf();
+    std::complex<double> *input_ptr = (std::complex<double> *)input.begin();
+
+    Var c("c"), x("x"), y("y");
+    Func input_clamped = BoundaryConditions::constant_exterior(input, Expr(0.0));
+    ComplexFunc input_complex("input_complex");
+    input_complex(x) = ComplexExpr(input_clamped(0, x), input_clamped(1, x));
+    ComplexFunc result("result");
+    result(x, y) = input_complex(x);
+    result(x, 0) += ComplexExpr(Expr(1.1), Expr(2.2));
+    result(x, 1) -= ComplexExpr(Expr(3.3), Expr(4.4));
+    result(x, 2) *= ComplexExpr(Expr(5.5), Expr(6.6));
+    //result(x, 3) /= ComplexExpr(Expr(7.7), Expr(8.8));
+    Func interleaved_output("interleaved_output");
+    interleaved_output(c, x, y) = select(c == 0, result(x, y).re(), result(x, y).im());
+
+    Buffer<double> output = interleaved_output.realize(2, N, 4);
+
+    Buffer<double> expected(2, N, 4);
+    std::complex<double> *expected_ptr = (std::complex<double> *)expected.begin();
+    for (int i = 0; i < N; i++) {
+        expected_ptr[i + 0 * N] = input_ptr[i] + std::complex<double>(1.1, 2.2);
+        expected_ptr[i + 1 * N] = input_ptr[i] - std::complex<double>(3.3, 4.4);
+        expected_ptr[i + 2 * N] = input_ptr[i] * std::complex<double>(5.5, 6.6);
+        //expected_ptr[i+3*N] = input_ptr[i] / std::complex<double>(7.7,8.8);
+        for (int j = 0; j < 3; j++) {
+            std::complex<double> value = expected_ptr[i + j * N];
+            if (std::abs(output(0, i, j) - value.real()) > 0.01) {
+                std::cout << "Wrong real value for element " << i << "," << j << ". Expected " << value.real() << ", got " << output(0, i, j) << endl;
+                abort();
+            }
+            if (std::abs(output(1, i, j) - value.imag()) > 0.01) {
+                std::cout << "Wrong imaginary value for element " << i << "," << j << ". Expected " << value.imag() << ", got " << output(1, i, j) << endl;
+                abort();
+            }
+        }
+    }
+}
+
+void test_assignment_ops_complex_real() {
+    printf("test_assignment_ops_complex_real\n");
+    Buffer<double> input(2, 5);
+    std::complex<double> *input_ptr = (std::complex<double> *)input.begin();
+    for (int i = 0; i < N; i++) {
+        std::complex<double> value(1.0 + i, i - 1.0);
+        input_ptr[i] = value;
+    }
+
+    Var c("c"), x("x"), y("y");
+    Func input_clamped = BoundaryConditions::constant_exterior(input, Expr(0.0));
+    ComplexFunc input_complex("input_complex");
+    input_complex(x) = ComplexExpr(input_clamped(0, x), input_clamped(1, x));
+    ComplexFunc result("result");
+    result(x, y) = input_complex(x);
+    result(x, 0) += Expr(1.1);
+    result(x, 1) -= Expr(3.3);
+    result(x, 2) *= Expr(5.5);
+    //result(x, 3) /= Expr(7.7);
+    Func interleaved_output("interleaved_output");
+    interleaved_output(c, x, y) = select(c == 0, result(x, y).re(), result(x, y).im());
+
+    Buffer<double> output = interleaved_output.realize(2, N, 4);
+
+    Buffer<double> expected(2, N, 4);
+    std::complex<double> *expected_ptr = (std::complex<double> *)expected.begin();
+    for (int i = 0; i < N; i++) {
+        expected_ptr[i + 0 * N] = std::complex<double>(1.0 + i, i - 1.0) + 1.1;
+        expected_ptr[i + 1 * N] = std::complex<double>(1.0 + i, i - 1.0) - 3.3;
+        expected_ptr[i + 2 * N] = std::complex<double>(1.0 + i, i - 1.0) * 5.5;
+        //expected_ptr[i+3*N] = std::complex<double>(1.0 + i, i - 1.0) / 7.7;
+        for (int j = 0; j < 3; j++) {
+            std::complex<double> value = expected_ptr[i + j * N];
+            if (std::abs(output(0, i, j) - value.real()) > 0.01) {
+                std::cout << "Wrong real value for element " << i << "," << j << ". Expected " << value.real() << ", got " << output(0, i, j) << endl;
+                abort();
+            }
+            if (std::abs(output(1, i, j) - value.imag()) > 0.01) {
+                std::cout << "Wrong imaginary value for element " << i << "," << j << ". Expected " << value.imag() << ", got " << output(1, i, j) << endl;
+                abort();
+            }
+        }
+    }
+}
+
+void test_helper_funcs() {
+    printf("test_helper_funcs\n");
+    Buffer<double> input(2, N);
+    std::complex<double> *input_ptr = (std::complex<double> *)input.begin();
+    for (int i = 0; i < N; i++) {
+        std::complex<double> value(1.0 + i, i - 1.0);
+        input_ptr[i] = value;
+    }
+
+    Var c("c"), x("x"), y("y");
+    Func input_clamped = BoundaryConditions::constant_exterior(input, Expr(0.0));
+    ComplexFunc input_complex("input_complex");
+    input_complex(x) = ComplexExpr(input_clamped(0, x), input_clamped(1, x));
+    ComplexFunc result("result");
+    result(x, y) = ComplexExpr(Expr(0.0), Expr(0.0));
+    result(x, 0) = exp(input_complex(x));
+    result(x, 1) = expj(input_clamped(1, x));
+    result(x, 2) = -input_complex(x);
+
+    Func interleaved_output("interleaved_output");
+    interleaved_output(c, x, y) = select(c == 0, result(x, y).re(), result(x, y).im());
+    Buffer<double> output = interleaved_output.realize(2, N, 3);
+
+    for (int i = 0; i < N; i++) {
+        std::complex<double> values[3];
+        std::complex<double> inputvalue(1.0 + i, i - 1.0);
+        values[0] = std::exp(inputvalue);
+        values[1] = std::exp(std::complex<double>(0.0, inputvalue.imag()));
+        values[2] = -inputvalue;
+        for (int j = 1; j < 3; j++) {
+            if (std::abs(output(0, i, j) - values[j].real()) > 0.01) {
+                std::cout << "Wrong real value for element " << i << "," << j << ". Expected " << values[j].real() << ", got " << output(0, i, j) << endl;
+                abort();
+            }
+            if (std::abs(output(1, i, j) - values[j].imag()) > 0.01) {
+                std::cout << "Wrong imaginary value for element " << i << "," << j << ". Expected " << values[j].imag() << ", got " << output(1, i, j) << endl;
+                abort();
+            }
+        }
+    }
+}
+
+int main(int argc, char **argv) {
+    test_io();
+    test_ops_complex_complex();
+    test_ops_complex_real();
+    test_ops_real_complex();
+    test_assignment_ops_complex_complex();
+    test_assignment_ops_complex_real();
+    test_helper_funcs();
+    printf("Success!\n");
+    return 0;
+}

--- a/tools/halide_complexfunc.h
+++ b/tools/halide_complexfunc.h
@@ -1,0 +1,349 @@
+// This is a wrapper around Func, handling Complex values by adding an extra dimension of size 2.
+// There is a similar wrapper class in the FFT example, that one stores Complex numbers as tuples.
+
+#ifndef _HALIDE_COMPLEXFUNC_H
+#define _HALIDE_COMPLEXFUNC_H
+
+#include <Halide.h>
+#include <vector>
+
+namespace Halide {
+namespace Tools {
+
+class ComplexExpr;
+/*
+ * ComplexFunc wraps a Func in a way that intercepts index expressions and generates ComplexExprs for them.
+ * A 2d ComplexFunc of size [i,j] will have an underlying (inner) 3d Func of size [2,i,j].
+ * The complex axis is passed in explicitly, it should be consistent across all ComplexFuncs that participate in
+ * complex mathematical expressions.
+ */
+class ComplexFunc {
+public:
+    Halide::Func inner;
+    Halide::Var element;
+
+    ComplexFunc(Halide::Var &element, std::string name = "");
+    ComplexFunc(Halide::Var &element, Halide::Func &inner);
+    ComplexExpr operator()(std::vector<Halide::Expr>);
+    ComplexExpr operator()();
+    ComplexExpr operator()(Halide::Expr idx1);
+    ComplexExpr operator()(Halide::Expr idx1, Halide::Expr idx2);
+    ComplexExpr operator()(Halide::Expr idx1, Halide::Expr idx2, Halide::Expr idx3);
+};
+
+/*
+ * ComplexExpr represents a Complex value.  It uses operator overloading to
+ * implement mathematical operations.  These act on either the complex number
+ * as a whole or the real/imaginary elements separately, depending on the
+ * operation.
+ *
+ * Some ComplexExprs represent a position in a ComplexFunc.  This allows it to
+ * act as an lvalue and be assigned to.  All ComplexExprs can act as rvalues,
+ * except for the ones representing ComplexFuncs which have never been assigned
+ * to yet.
+ */
+class ComplexExpr {
+public:
+    Halide::Var element;
+    Halide::Expr real;                   // index contains an explicit 0
+    Halide::Expr imag;                   // index contains an explicit 1
+    Halide::Expr pair;                   // this is a mux expression
+    const ComplexFunc *func;             // Func that writes are passed through to
+    std::vector<Halide::Expr> pair_idx;  // saved index for writes
+
+    bool can_read;
+    bool can_write;
+
+    inline ComplexExpr(const ComplexFunc *func, const std::vector<Halide::Expr> &idx);               // lvalue constructor
+    inline ComplexExpr(const Halide::Var &element, const Halide::Expr &v1, const Halide::Expr &v2);  // rvalue constructor
+
+    // write ops
+    ComplexExpr &operator=(ComplexExpr rvalue);
+    ComplexExpr operator+=(ComplexExpr b);
+    ComplexExpr &operator-=(const ComplexExpr &b);
+    ComplexExpr &operator*=(const ComplexExpr &b);
+    ComplexExpr &operator/=(const ComplexExpr &b);
+    ComplexExpr &operator+=(const Halide::Expr &b);
+    ComplexExpr &operator-=(const Halide::Expr &b);
+    ComplexExpr &operator*=(const Halide::Expr &b);
+    ComplexExpr &operator/=(const Halide::Expr &b);
+};
+
+/*
+ * Create a ComplexExpr that represents an element of a ComplexFunc.  This
+ * ComplexExpr can be assigned to as an lvalue.  If the underlying Func
+ * is defined (by having been assigned to previously), this ComplexExpr
+ * can also be used as an rvalue, or as an element in a larger mathematical
+ * expression.
+ */
+inline ComplexExpr::ComplexExpr(const ComplexFunc *func, const std::vector<Halide::Expr> &idx)
+    : func(func) {
+    element = func->element;
+    std::vector<Halide::Expr> real_idx({Halide::Expr(0)});
+    std::vector<Halide::Expr> imag_idx({Halide::Expr(1)});
+    pair_idx.reserve(idx.size() + 1);
+    pair_idx.push_back(element);
+    real_idx.reserve(idx.size() + 1);
+    imag_idx.reserve(idx.size() + 1);
+    copy(idx.begin(), idx.end(), back_inserter(real_idx));
+    copy(idx.begin(), idx.end(), back_inserter(imag_idx));
+    copy(idx.begin(), idx.end(), back_inserter(pair_idx));
+    can_write = true;
+    can_read = func->inner.defined();
+    if (can_read) {
+        real = func->inner(real_idx);
+        imag = func->inner(imag_idx);
+        pair = func->inner(pair_idx);
+    }
+}
+
+/*
+ * Create a ComplexExpr representing a read-only value.  This ComplexExpr has
+ * no ComplexFunc, hence it cannot be assigned to.  It can be used as an
+ * rvalue, or as an element in a larger mathematical expression.
+ */
+inline ComplexExpr::ComplexExpr(const Halide::Var &element, const Halide::Expr &v1, const Halide::Expr &v2) {
+    real = v1;
+    imag = v2;
+    can_read = true;
+    can_write = false;
+    this->element = element;
+    pair = Halide::mux(element, {v1, v2});
+}
+
+// negation
+inline ComplexExpr operator-(const ComplexExpr &a) {
+    if (a.can_read == false)
+        throw;
+    return ComplexExpr(a.element, -a.real, -a.imag);
+}
+
+// addition
+inline ComplexExpr operator+(const ComplexExpr &a, const ComplexExpr &b) {
+    if (a.can_read == false || b.can_read == false)
+        throw;
+    return ComplexExpr(a.element, a.pair + b.real, a.pair + b.imag);
+}
+inline ComplexExpr operator+(const ComplexExpr &a, const Halide::Expr &b) {
+    if (a.can_read == false)
+        throw;
+    return ComplexExpr(a.element, a.real + b, a.imag);
+}
+inline ComplexExpr operator+(const Halide::Expr &b, const ComplexExpr &a) {
+    return a + b;
+}
+
+// subtraction
+inline ComplexExpr operator-(const ComplexExpr &a, const ComplexExpr &b) {
+    if (a.can_read == false || b.can_read == false)
+        throw;
+    return ComplexExpr(a.element, a.pair - b.real, a.pair - b.imag);
+}
+inline ComplexExpr operator-(const ComplexExpr &a, const Halide::Expr &b) {
+    if (a.can_read == false)
+        throw;
+    return ComplexExpr(a.element, a.real - b, a.imag);
+}
+inline ComplexExpr operator-(const Halide::Expr &b, const ComplexExpr &a) {
+    return -a + b;
+}
+
+// multiplication
+inline ComplexExpr operator*(const ComplexExpr &a, const ComplexExpr &b) {
+    if (a.can_read == false || b.can_read == false)
+        throw;
+    return ComplexExpr(a.element, a.real * b.real - a.imag * b.imag, a.real * b.imag + a.imag * b.real);
+}
+inline ComplexExpr operator*(const ComplexExpr &a, const Halide::Expr &b) {
+    if (a.can_read == false)
+        throw;
+    return ComplexExpr(a.element, a.real * b, a.imag * b);
+}
+inline ComplexExpr operator*(const Halide::Expr &b, const ComplexExpr &a) {
+    return a * b;
+}
+
+// conjugation
+inline ComplexExpr conj(const ComplexExpr &z) {
+    return ComplexExpr(z.element, z.real, -z.imag);
+}
+
+// division
+inline ComplexExpr operator/(const ComplexExpr &a, const ComplexExpr &b) {
+    if (a.can_read == false || b.can_read == false)
+        throw;
+    ComplexExpr conjugate = conj(b);
+    ComplexExpr numerator = a * conjugate;
+    ComplexExpr denominator = b * conjugate;
+    return ComplexExpr(a.element, numerator.real / denominator.real, numerator.imag / denominator.real);
+}
+inline ComplexExpr operator/(const ComplexExpr &a, const Halide::Expr &b) {
+    if (a.can_read == false)
+        throw;
+    return ComplexExpr(a.element, a.real / b, a.imag / b);
+}
+inline ComplexExpr operator/(const Halide::Expr &b, const ComplexExpr &a) {
+    ComplexExpr numerator = b * conj(a);
+    ComplexExpr denominator = a * conj(a);
+    return ComplexExpr(a.element, numerator.real / denominator.real, numerator.imag / denominator.real);
+}
+
+// exponential
+inline ComplexExpr exp(const ComplexExpr &z) {
+    return ComplexExpr(z.element, Halide::exp(z.real) * Halide::cos(z.imag), Halide::exp(z.real) * Halide::sin(z.imag));
+}
+inline ComplexExpr expj(const Halide::Var &element, const Halide::Expr &x) {
+    return ComplexExpr(element, Halide::cos(x), Halide::sin(x));
+}
+
+// assignment
+ComplexExpr &ComplexExpr::operator=(ComplexExpr rvalue) {
+    if (rvalue.can_read == false)
+        throw;
+    Halide::FuncRef funcref = func->inner(pair_idx);
+    funcref = rvalue.pair;
+    pair = rvalue.pair;
+    real = rvalue.real;
+    imag = rvalue.imag;
+    can_read = true;
+    return *this;
+}
+
+// updates
+ComplexExpr ComplexExpr::operator+=(ComplexExpr b) {
+    if (can_read == false || b.can_read == false)
+        throw;
+    ComplexExpr rvalue = *this + b;
+    Halide::FuncRef funcref = func->inner(pair_idx);
+    funcref = rvalue.pair;
+    return *this;
+}
+ComplexExpr &ComplexExpr::operator+=(const Halide::Expr &b) {
+    if (can_read == false)
+        throw;
+    ComplexExpr rvalue = *this + b;
+    Halide::FuncRef funcref = func->inner(pair_idx);
+    funcref = rvalue.pair;
+    return *this;
+}
+ComplexExpr &ComplexExpr::operator-=(const ComplexExpr &b) {
+    if (can_read == false || b.can_read == false)
+        throw;
+    ComplexExpr rvalue = *this - b;
+    Halide::FuncRef funcref = func->inner(pair_idx);
+    funcref = rvalue.pair;
+    return *this;
+}
+ComplexExpr &ComplexExpr::operator-=(const Halide::Expr &b) {
+    if (can_read == false)
+        throw;
+    ComplexExpr rvalue = *this - b;
+    Halide::FuncRef funcref = func->inner(pair_idx);
+    funcref = rvalue.pair;
+    return *this;
+}
+ComplexExpr &ComplexExpr::operator*=(const ComplexExpr &b) {
+    if (can_read == false || b.can_read == false)
+        throw;
+    Halide::FuncRef funcref = func->inner(pair_idx);
+    ComplexExpr rvalue = *this * b;
+    funcref = rvalue.pair;
+    return *this;
+}
+ComplexExpr &ComplexExpr::operator*=(const Halide::Expr &b) {
+    if (can_read == false)
+        throw;
+    Halide::FuncRef funcref = func->inner(pair_idx);
+    funcref *= select(func->element, b, Halide::Expr(1.0));
+    return *this;
+}
+ComplexExpr &ComplexExpr::operator/=(const ComplexExpr &b) {
+    if (can_read == false || b.can_read == false)
+        throw;
+    Halide::FuncRef funcref = func->inner(pair_idx);
+    funcref /= b.pair;
+    return *this;
+}
+ComplexExpr &ComplexExpr::operator/=(const Halide::Expr &b) {
+    if (can_read == false)
+        throw;
+    Halide::FuncRef funcref = func->inner(pair_idx);
+    funcref /= select(func->element, b, Halide::Expr(1.0));
+    return *this;
+}
+
+// other helper functions
+
+// stringification
+inline std::ostream &operator<<(std::ostream &os, const ComplexExpr &a) {
+    os << "<ComplexExpr " << a.real << ", " << a.imag << ">";
+    return os;
+}
+
+// absolute value
+inline Halide::Expr abs(ComplexExpr a) {
+    return sqrt(a.real * a.real + a.imag * a.imag);
+}
+
+// summation
+inline ComplexExpr sum(const ComplexExpr &z, const std::string &s = "sum") {
+    return ComplexExpr(z.element,
+                       Halide::sum(z.real, s + "_real"),
+                       Halide::sum(z.imag, s + "_imag"));
+}
+// selection
+inline ComplexExpr select(const Halide::Var &element, Halide::Expr c, ComplexExpr t, ComplexExpr f) {
+    return ComplexExpr(element,
+                       Halide::select(c, t.real, f.real),
+                       Halide::select(c, t.imag, f.imag));
+}
+
+inline ComplexExpr select(const Halide::Var &element,
+                          Halide::Expr c1, ComplexExpr t1,
+                          Halide::Expr c2, ComplexExpr t2,
+                          ComplexExpr f) {
+    return ComplexExpr(element,
+                       Halide::select(c1, t1.real, c2, t2.real, f.real),
+                       Halide::select(c1, t1.imag, c2, t2.imag, f.imag));
+}
+
+// ComplexFunc methods
+
+ComplexFunc::ComplexFunc(Halide::Var &element, std::string name)
+    : element(element) {
+    if (name == "") {
+        inner = Halide::Func();
+    } else {
+        inner = Halide::Func(name);
+    }
+}
+
+ComplexFunc::ComplexFunc(Halide::Var &element, Halide::Func &inner)
+    : inner(inner), element(element) {
+}
+
+ComplexExpr ComplexFunc::operator()(std::vector<Halide::Expr> idx) {
+    return ComplexExpr(this, idx);
+}
+
+ComplexExpr ComplexFunc::operator()() {
+    std::vector<Halide::Expr> idx({});
+    return (*this)(idx);
+}
+ComplexExpr ComplexFunc::operator()(Halide::Expr idx1) {
+    std::vector<Halide::Expr> idx({idx1});
+    return (*this)(idx);
+}
+ComplexExpr ComplexFunc::operator()(Halide::Expr idx1, Halide::Expr idx2) {
+    std::vector<Halide::Expr> idx({idx1, idx2});
+    return (*this)(idx);
+}
+ComplexExpr ComplexFunc::operator()(Halide::Expr idx1, Halide::Expr idx2, Halide::Expr idx3) {
+    std::vector<Halide::Expr> idx({idx1, idx2, idx3});
+    return (*this)(idx);
+}
+
+}  // namespace Tools
+}  // namespace Halide
+
+#endif /* _HALIDE_COMPLEXFUNC_H */


### PR DESCRIPTION
This adds a headerfile into `tools/`, implementing the ComplexFunc and ComplexExpr classes to provide syntax for doing math on Complex values.  It wraps around a Func, adding an extra inner dimension (of size 2) to store the real and imaginary components.

It is useful for larger applications which use Halide for certain pieces, and want to pass arrays of complex numbers between Halide and other tools.  Tools like `fftw` expect data to be laid out in memory as an array of complex values, like `double complex_array[200][2]` or  `complex<double> array[200]`.

It is inspired by the ComplexFunc implementation in the FFT application, but takes the wrapper approach instead of the Tuple approach.  The Tuple approach lays out the data in memory as two arrays, one for real elements, one for imaginary elements.  This means passing outputs to external tools requires an extra conversion step.  Acting as a wrapper makes that extra step unnecessary.

This is a work in progress.  TODO:
* implement *= and /= if possible
* move halide_complexfunc.h to src/stdlib/
