### PR TITLE
Make sure the runtime compiler settings in CMake match those in Make

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -747,7 +747,7 @@ std::string halide_type_to_c_type(const Type &t) {
 
 int generate_filter_main_inner(int argc, char **argv, std::ostream &cerr) {
     const char kUsage[] =
-        "gengen\n"
+        "gengen \n"
         "  [-g GENERATOR_NAME] [-f FUNCTION_NAME] [-o OUTPUT_DIR] [-r RUNTIME_NAME] [-d 1|0]\n"
         "  [-e EMIT_OPTIONS] [-n FILE_BASE_NAME] [-p PLUGIN_NAME] [-s AUTOSCHEDULER_NAME]\n"
         "       target=target-string[,target-string...] [generator_arg=value [...]]\n"

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -145,11 +145,27 @@ set(RUNTIME_HEADER_FILES
 # by add_custom_command, as is the case in this directory.
 add_library(Halide_initmod OBJECT)
 
-set(CXX_WARNING_FLAGS -Wall -Werror -Wno-unused-function -Wcast-qual)
-set(RUNTIME_CXX_FLAGS -O3
-    -fno-vectorize -ffreestanding -fno-blocks -fno-exceptions -fno-unwind-tables
+# Note: ensure that these flags match the flags in the Makefile.
+# Note: this always uses Clang-from-LLVM for compilation, so none of these flags should need conditionalization.
+set(RUNTIME_CXX_FLAGS
+    -O3
+    -ffreestanding
+    -fno-blocks
+    -fno-exceptions
+    -fno-unwind-tables
+    -fno-vectorize
     # Note: we don't want static locals to get thread synchronization stuff.
-    -fno-threadsafe-statics)
+    -fno-threadsafe-statics
+    -Wall
+    -Wcast-qual
+    -Werror
+    -Wignored-qualifiers
+    -Wno-comment
+    -Wno-psabi
+    -Wno-unknown-warning-option
+    -Wno-unused-function
+    -Wsign-compare
+)
 
 foreach (i IN LISTS RUNTIME_CPP)
     foreach (j IN ITEMS 32 64)


### PR DESCRIPTION
Mainly, we weren't setting any of the warning flags, so CMake builds were more forgiving than Make.