### PR TITLE
InjectBufferCopiesForInputsAndOutputs should check for unexpected Call nodes.

### DIFF
--- a/src/InjectHostDevBufferCopies.cpp
+++ b/src/InjectHostDevBufferCopies.cpp
@@ -141,9 +141,9 @@ class InjectBufferCopiesForSingleBuffer : public IRMutator {
     using IRMutator::visit;
 
     // The buffer being managed
-    string buffer;
+    const string buffer;
 
-    bool is_external;
+    const bool is_external;
 
     enum FlagState {
         Unknown,
@@ -744,6 +744,16 @@ class InjectBufferCopiesForInputsAndOutputs : public IRMutator {
 
         void visit(const Store *op) override {
             include(op->param);
+            IRVisitor::visit(op);
+        }
+
+        void visit(const Call *op) override {
+            // We shouldn't need to look for Buffers here,
+            // since we expect this to be run after StorageFlattening.
+            // Add an assertion check just in case a change to lowering ever
+            // subverts this ordering expectation.
+            internal_assert(op->call_type != Call::Halide &&
+                            op->call_type != Call::Image);
             IRVisitor::visit(op);
         }
 


### PR DESCRIPTION
~~I haven't found a case where this is actually a problem, but I noticed from debugging a different issue that the FindInputsAndOutputs doesn't look at Call nodes at all, so it can miss Buffers/Parameters associated with them.~~

~~Not sure if this is an issue in practice. Maybe we never want buffer copies for these? (If so then we should document it as such.)~~

~~This PR just adds the logic used for this in InferArguments.~~