### PR TITLE
Fix 32-bit Windows vcvars command

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ D:\> "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary
 For a 32-bit build, run:
 
 ```
-D:\> "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+D:\> "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64_x86
 ```
 
 #### Managing dependencies with vcpkg


### PR DESCRIPTION
`x64_x86` = build using 64-bit compiler, targeting 32-bit x86 (https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=vs-2019).   We had it backwards before.