### PR TITLE
fix bounds inference bug for bounded interval / unbounded interval

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -541,7 +541,7 @@ private:
                     interval.max = cast(a.min.type(), abs(a.max));
                 } else {
                     interval.min = min(-a.max, a.min);
-                    interval.max = max(-a.max, a.min);
+                    interval.max = max(-a.min, a.max);
                 }
             } else {
                 interval = Interval::everything();

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -540,6 +540,7 @@ private:
                     interval.min = -cast(a.min.type(), abs(a.min));
                     interval.max = cast(a.min.type(), abs(a.max));
                 } else {
+                    // div by 0 is 0 and the magnitude cannot increase by integer division
                     interval.min = min(-a.max, a.min);
                     interval.max = max(-a.min, a.max);
                 }


### PR DESCRIPTION
Bug in bounds inference engine, discussed with @abadams @shoaibkamil @alexreinking and @jn80842 . 
Maximum value possible from dividing a bounded interval (a0, a1) buy an unbounded interval is max(-a0, a1), which correspond to the cases that a0 is negative but greater in magnitude than a1 (and divided by -1), or where a1 is the maximum possible value (divided by 1).