### PR TITLE
Reduce GPU Tile Size in Tests

### DIFF
--- a/test/correctness/async_device_copy.cpp
+++ b/test/correctness/async_device_copy.cpp
@@ -45,23 +45,23 @@ int main(int argc, char **argv) {
         if (i == 0) {
             // Synchronously GPU -> CPU
             avg.compute_root().update().reorder(x, y, r).vectorize(x, 8);
-            frames.store_root().compute_at(frames.in(), Var::outermost()).gpu_tile(x, y, xo, yo, x, y, 32, 32);
+            frames.store_root().compute_at(frames.in(), Var::outermost()).gpu_tile(x, y, xo, yo, x, y, 16, 16);
             frames.in().store_root().compute_at(avg, r).copy_to_host();
         } else if (i == 1) {
             // Asynchronously GPU -> CPU, via a double-buffer
             avg.compute_root().update().reorder(x, y, r).vectorize(x, 8);
-            frames.store_root().compute_at(frames.in(), Var::outermost()).gpu_tile(x, y, xo, yo, x, y, 32, 32);
+            frames.store_root().compute_at(frames.in(), Var::outermost()).gpu_tile(x, y, xo, yo, x, y, 16, 16);
             frames.in().store_root().compute_at(avg, r).copy_to_host().fold_storage(t, 2).async();
         } else if (i == 2) {
             // Synchronously CPU -> GPU
-            avg.compute_root().gpu_tile(x, y, xo, yo, x, y, 32, 32).update().reorder(x, y, r).gpu_tile(x, y, xo, yo, x, y, 32, 32);
+            avg.compute_root().gpu_tile(x, y, xo, yo, x, y, 16, 16).update().reorder(x, y, r).gpu_tile(x, y, xo, yo, x, y, 16, 16);
 
             frames.store_root().compute_at(avg, r).vectorize(x, 8).fold_storage(t, 2).parallel(y);
 
             frames.in().store_root().compute_at(avg, r).copy_to_device();
         } else if (i == 3) {
             // Asynchronously CPU -> GPU, via a double-buffer
-            avg.compute_root().gpu_tile(x, y, xo, yo, x, y, 32, 32).update().reorder(x, y, r).gpu_tile(x, y, xo, yo, x, y, 32, 32);
+            avg.compute_root().gpu_tile(x, y, xo, yo, x, y, 16, 16).update().reorder(x, y, r).gpu_tile(x, y, xo, yo, x, y, 16, 16);
 
             frames.store_root().compute_at(avg, r).vectorize(x, 8).fold_storage(t, 2).async().parallel(y);
 

--- a/test/correctness/dynamic_allocation_in_gpu_kernel.cpp
+++ b/test/correctness/dynamic_allocation_in_gpu_kernel.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
     // [f1,f3,f6], another for [f2,f4], and a third for f5.
 
     Var xi, yi;
-    g.gpu_tile(x, y, xi, yi, 32, 16);
+    g.gpu_tile(x, y, xi, yi, 16, 8);
     f1.compute_at(g, x).store_in(MemoryType::Heap);
     f2.compute_at(g, x).store_in(MemoryType::Heap);
     f3.compute_at(g, x).store_in(MemoryType::Heap);

--- a/test/correctness/extern_stage_on_device.cpp
+++ b/test/correctness/extern_stage_on_device.cpp
@@ -39,7 +39,7 @@ extern "C" DLLEXPORT int extern_stage(int extern_on_device,
         f(x, y) = x + y;
 
         if (extern_on_device > 0) {
-            f.gpu_tile(x, y, xi, yi, 32, 32);
+            f.gpu_tile(x, y, xi, yi, 16, 16);
         }
         f.realize(out);
     }
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
             source.compute_root();
             sink.compute_root();
             if (sink_on_device > 0) {
-                sink.gpu_tile(x, y, xi, yi, 32, 32);
+                sink.gpu_tile(x, y, xi, yi, 16, 16);
             }
 
             Buffer<int32_t> output = sink.realize(100, 100);


### PR DESCRIPTION
OpenCL on macOS (Mojave at least) supports a maximum workgroup size of 256.  This causes a few tests to fail that specify larger workgroup sizes when targeting OpenCL on mac.  The sizes don't seem to be substantial to any of these tests, so lower them.