### PR TITLE
Remove the ADD_[U]INT64_T_SUFFIX macros

### DIFF
--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -50,10 +50,16 @@ public:
 
     static void test();
 
-    /**  Add common macros to be shared across all backends */
-    void add_common_macros(std::ostream &dest);
-
 protected:
+    enum class IntegerSuffixStyle {
+        PlainC = 0,
+        OpenCL = 1,
+        HLSL = 2
+    };
+
+    /** How to emit 64-bit integer constants */
+    IntegerSuffixStyle integer_suffix_style = IntegerSuffixStyle::PlainC;
+
     /** Emit a declaration. */
     // @{
     virtual void compile(const LoweredFunc &func);

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -1257,8 +1257,6 @@ void CodeGen_D3D12Compute_Dev::init_module() {
 
     src_stream << "\n";
 
-    d3d12compute_c.add_common_macros(src_stream);
-
     cur_kernel_name = "";
 }
 

--- a/src/CodeGen_D3D12Compute_Dev.h
+++ b/src/CodeGen_D3D12Compute_Dev.h
@@ -49,6 +49,7 @@ protected:
     public:
         CodeGen_D3D12Compute_C(std::ostream &s, Target t)
             : CodeGen_C(s, t) {
+            integer_suffix_style = IntegerSuffixStyle::HLSL;
         }
         void add_kernel(Stmt stmt,
                         const std::string &name,

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -700,8 +700,6 @@ void CodeGen_Metal_Dev::init_module() {
                << "#endif\n"
                << "}\n";  // close namespace
 
-    metal_c.add_common_macros(src_stream);
-
     src_stream << "#define halide_unused(x) (void)(x)\n";
 
     src_stream << "\n";

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -974,8 +974,6 @@ void CodeGen_OpenCL_Dev::init_module() {
 
     src_stream << "\n";
 
-    clc.add_common_macros(src_stream);
-
     // Add at least one kernel to avoid errors on some implementations for functions
     // without any GPU schedules.
     src_stream << "__kernel void _at_least_one_kernel(int x) { }\n";

--- a/src/CodeGen_OpenCL_Dev.h
+++ b/src/CodeGen_OpenCL_Dev.h
@@ -47,6 +47,7 @@ protected:
     public:
         CodeGen_OpenCL_C(std::ostream &s, Target t)
             : CodeGen_C(s, t) {
+            integer_suffix_style = IntegerSuffixStyle::OpenCL;
         }
         void add_kernel(Stmt stmt,
                         const std::string &name,

--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -255,7 +255,6 @@ void CodeGen_OpenGLCompute_Dev::CodeGen_OpenGLCompute_C::add_kernel(const Stmt &
     } else {
         stream << "#version 430\n";
     }
-    add_common_macros(stream);
     stream << "float float_from_bits(int x) { return intBitsToFloat(int(x)); }\n";
     stream << "#define halide_unused(x) (void)(x)\n";
 

--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -54,7 +54,6 @@ void CodeGen_OpenGL_Dev::add_kernel(Stmt s, const string &name,
 void CodeGen_OpenGL_Dev::init_module() {
     src_stream.str("");
     src_stream.clear();
-    glc->add_common_macros(src_stream);
     cur_kernel_name = "";
 }
 


### PR DESCRIPTION
Modify codegen for C-like backends to just emit integer constants with the correct suffix for the backend, rather than wrapping in a giant macro; the macro approach worked but lordy was it painful to read.