### PR TITLE
Mark many single-argument ctors as `explicit`

### DIFF
--- a/src/AddAtomicMutex.cpp
+++ b/src/AddAtomicMutex.cpp
@@ -20,7 +20,7 @@ namespace {
 /** Collect names of all stores matching the producer name inside a statement. */
 class CollectProducerStoreNames : public IRGraphVisitor {
 public:
-    CollectProducerStoreNames(const std::string &producer_name)
+    explicit CollectProducerStoreNames(const std::string &producer_name)
         : producer_name(producer_name) {
     }
 
@@ -44,7 +44,7 @@ protected:
  *  and return their indices. */
 class FindProducerStoreIndex : public IRGraphVisitor {
 public:
-    FindProducerStoreIndex(const std::string &producer_name)
+    explicit FindProducerStoreIndex(const std::string &producer_name)
         : producer_name(producer_name) {
     }
 
@@ -123,7 +123,7 @@ protected:
  *  binding from the Store node (currently only SplitTuple would do this). */
 class FindAtomicLetBindings : public IRGraphVisitor {
 public:
-    FindAtomicLetBindings(const Scope<void> &store_names)
+    explicit FindAtomicLetBindings(const Scope<void> &store_names)
         : store_names(store_names) {
     }
 
@@ -211,7 +211,7 @@ class FindStoreInAtomicMutex : public IRGraphVisitor {
 public:
     using IRGraphVisitor::visit;
 
-    FindStoreInAtomicMutex(const std::set<std::string> &store_names)
+    explicit FindStoreInAtomicMutex(const std::set<std::string> &store_names)
         : store_names(store_names) {
     }
 
@@ -276,7 +276,7 @@ protected:
 /** Add mutex allocation & lock & unlock if required. */
 class AddAtomicMutex : public IRMutator {
 public:
-    AddAtomicMutex(const map<string, Function> &env)
+    explicit AddAtomicMutex(const map<string, Function> &env)
         : env(env) {
     }
 

--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -137,7 +137,7 @@ class TrimStmtToPartsThatAccessBuffers : public IRMutator {
     }
 
 public:
-    TrimStmtToPartsThatAccessBuffers(const map<string, FindBuffers::Result> &bufs)
+    explicit TrimStmtToPartsThatAccessBuffers(const map<string, FindBuffers::Result> &bufs)
         : buffers(bufs) {
     }
 };

--- a/src/AlignLoads.cpp
+++ b/src/AlignLoads.cpp
@@ -21,7 +21,7 @@ namespace {
 // intended vector out of the aligned vector.
 class AlignLoads : public IRMutator {
 public:
-    AlignLoads(int alignment)
+    explicit AlignLoads(int alignment)
         : alignment_analyzer(alignment), required_alignment(alignment) {
     }
 

--- a/src/AsyncProducers.cpp
+++ b/src/AsyncProducers.cpp
@@ -298,7 +298,7 @@ class CountConsumeNodes : public IRVisitor {
     }
 
 public:
-    CountConsumeNodes(const string &f)
+    explicit CountConsumeNodes(const string &f)
         : func(f) {
     }
     int count = 0;
@@ -369,7 +369,7 @@ class ForkAsyncProducers : public IRMutator {
     }
 
 public:
-    ForkAsyncProducers(const map<string, Function> &e)
+    explicit ForkAsyncProducers(const map<string, Function> &e)
         : env(e) {
     }
 };
@@ -506,7 +506,7 @@ class TightenProducerConsumerNodes : public IRMutator {
     const map<string, Function> &env;
 
 public:
-    TightenProducerConsumerNodes(const map<string, Function> &e)
+    explicit TightenProducerConsumerNodes(const map<string, Function> &e)
         : env(e) {
     }
 };

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1717,7 +1717,7 @@ public:
     const Scope<int> &vars_depth;
     string innermost_var;
 
-    FindInnermostVar(const Scope<int> &vars_depth)
+    explicit FindInnermostVar(const Scope<int> &vars_depth)
         : vars_depth(vars_depth) {
     }
 
@@ -1793,7 +1793,7 @@ public:
     string skipped_var;
     set<string> vars;
 
-    CollectVars(const string &v)
+    explicit CollectVars(const string &v)
         : skipped_var(v) {
     }
 
@@ -2037,7 +2037,7 @@ private:
             CollectVars collect;
             string max_name, min_name;
             Interval value_bounds;
-            Frame(const LetOrLetStmt *op)
+            explicit Frame(const LetOrLetStmt *op)
                 : op(op), collect(op->name) {
             }
         };
@@ -2320,7 +2320,7 @@ private:
         public:
             const Scope<Interval> &scope;
             vector<const Variable *> result;
-            FindFreeVars(const Scope<Interval> &s)
+            explicit FindFreeVars(const Scope<Interval> &s)
                 : scope(s) {
             }
         } finder(scope);
@@ -2616,7 +2616,7 @@ map<string, Box> boxes_touched(const Expr &e, Stmt s, bool consider_calls, bool 
             const string &fn;
             const string fn_buffer;
             Stmt no_op;
-            Filter(const string &fn)
+            explicit Filter(const string &fn)
                 : fn(fn), fn_buffer(fn + ".buffer"), no_op(Evaluate::make(0)) {
             }
         } filter(fn);

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -75,7 +75,7 @@ bool depends_on_bounds_inference(const Expr &e) {
 class BoundsOfInnerVar : public IRVisitor {
 public:
     Interval result;
-    BoundsOfInnerVar(const string &v)
+    explicit BoundsOfInnerVar(const string &v)
         : var(v) {
     }
 

--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -29,10 +29,10 @@ struct MangledNamePart {
     std::string with_substitutions;
 
     MangledNamePart() = default;
-    explicit MangledNamePart(const std::string &mangled)
+    MangledNamePart(const std::string &mangled)  // NOLINT(google-explicit-constructor)
         : full_name(mangled), with_substitutions(mangled) {
     }
-    explicit MangledNamePart(const char *mangled)
+    MangledNamePart(const char *mangled)  // NOLINT(google-explicit-constructor)
         : full_name(mangled), with_substitutions(mangled) {
     }
 };
@@ -203,7 +203,7 @@ MangledNamePart mangle_inner_name(const Type &type, const Target &target, Previo
 
     std::string quals = mangle_indirection_and_cvr_quals(type, target);
     if (type.handle_type->inner_name.cpp_type_type == halide_cplusplus_type_name::Simple) {
-        return MangledNamePart(quals + simple_type_to_mangle_char(type.handle_type->inner_name.name, target));
+        return quals + simple_type_to_mangle_char(type.handle_type->inner_name.name, target);
     } else {
         std::string code;
         if (type.handle_type->inner_name.cpp_type_type == halide_cplusplus_type_name::Struct) {
@@ -239,44 +239,45 @@ MangledNamePart mangle_type(const Type &type, const Target &target, PreviousDecl
     if (type.is_int()) {
         switch (type.bits()) {
         case 8:
-            return MangledNamePart("C");
+            return "C";
         case 16:
-            return MangledNamePart("F");
+            return "F";
         case 32:
-            return MangledNamePart("H");
+            return "H";
         case 64:
-            return MangledNamePart("_J");
+            return "_J";
         }
         internal_error << "Unexpected integer size: " << type.bits() << ".\n";
-        return MangledNamePart("");
+        return "";
     } else if (type.is_uint()) {
         switch (type.bits()) {
         case 1:
-            return MangledNamePart("_N");
+            return "_N";
         case 8:
-            return MangledNamePart("E");
+            return "E";
         case 16:
-            return MangledNamePart("G");
+            return "G";
         case 32:
-            return MangledNamePart("I");
+            return "I";
         case 64:
-            return MangledNamePart("_K");
+            return "_K";
         }
-        return MangledNamePart("");
+        internal_error << "Unexpected unsigned integer size: " << type.bits() << "\n";
+        return "";
     } else if (type.is_float()) {
         if (type.bits() == 32) {
-            return MangledNamePart("M");
+            return "M";
         } else if (type.bits() == 64) {
-            return MangledNamePart("N");
+            return "N";
         }
         internal_error << "Unexpected floating-point type size: " << type.bits() << ".\n";
-        return MangledNamePart("");
+        return "";
     } else if (type.is_handle()) {
         return mangle_inner_name((type.handle_type != nullptr) ? type : non_null_void_star_type(),
                                  target, prev_decls);
     }
     internal_error << "Unexpected kind of type. Code: " << type.code() << "\n";
-    return MangledNamePart("");
+    return "";
 }
 
 std::string cplusplus_function_mangled_name(const std::string &name, const std::vector<std::string> &namespaces,
@@ -478,9 +479,9 @@ MangledNamePart mangle_qualified_name(const std::string &name, const std::vector
     if (is_directly_in_std) {
         // TODO: more cases here.
         if (name == "allocator") {
-            return MangledNamePart("Sa");
+            return "Sa";
         } else if (name == "string") {  // Not correct, but it does the right thing
-            return MangledNamePart("Ss");
+            return "Ss";
         }
         result.full_name += "St";
         result.with_substitutions += "St";
@@ -515,7 +516,7 @@ MangledNamePart mangle_qualified_name(const std::string &name, const std::vector
 
 std::string mangle_inner_name(const Type &type, const Target &target, PrevPrefixes &prevs) {
     if (type.handle_type->inner_name.cpp_type_type == halide_cplusplus_type_name::Simple) {
-        MangledNamePart result(simple_type_to_mangle_char(type.handle_type->inner_name.name, target));
+        MangledNamePart result = simple_type_to_mangle_char(type.handle_type->inner_name.name, target);
         return apply_indirection_and_cvr_quals(type, result, prevs).full_name;
     } else {
         MangledNamePart mangled = mangle_qualified_name(type.handle_type->inner_name.name, type.handle_type->namespaces,

--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -76,7 +76,7 @@ public:
         int use_count = 0;
         // All consumer Exprs for which this is the last child Expr.
         map<ExprWithCompareCache, int> uses;
-        Entry(const Expr &e)
+        explicit Entry(const Expr &e)
             : expr(e) {
         }
     };
@@ -184,7 +184,7 @@ public:
 class Replacer : public IRGraphMutator {
 public:
     Replacer() = default;
-    Replacer(const map<Expr, Expr, ExprCompare> &r)
+    explicit Replacer(const map<Expr, Expr, ExprCompare> &r)
         : IRGraphMutator() {
         expr_replacements = r;
     }
@@ -261,7 +261,7 @@ public:
         return common_subexpression_elimination(e, lift_all);
     }
 
-    CSEEveryExprInStmt(bool l)
+    explicit CSEEveryExprInStmt(bool l)
         : lift_all(l) {
     }
 };

--- a/src/CanonicalizeGPUVars.cpp
+++ b/src/CanonicalizeGPUVars.cpp
@@ -69,7 +69,7 @@ class CountGPUBlocksThreads : public IRVisitor {
     }
 
 public:
-    CountGPUBlocksThreads(const string &p)
+    explicit CountGPUBlocksThreads(const string &p)
         : prefix(p) {
     }
     int nblocks = 0;

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1368,7 +1368,7 @@ class ExternCallPrototypes : public IRGraphVisitor {
     struct NamespaceOrCall {
         const Call *call;  // nullptr if this is a subnamespace
         std::map<string, NamespaceOrCall> names;
-        NamespaceOrCall(const Call *call = nullptr)
+        explicit NamespaceOrCall(const Call *call = nullptr)
             : call(call) {
         }
     };

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -84,7 +84,7 @@ public:
     bool result;
     const std::string &buffer;
 
-    IsBufferConstant(const std::string &b)
+    explicit IsBufferConstant(const std::string &b)
         : result(true), buffer(b) {
     }
 };

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -296,7 +296,7 @@ Stmt sloppy_unpredicate_loads_and_stores(const Stmt &s) {
 
 class InjectHVXLocks : public IRMutator {
 public:
-    InjectHVXLocks(const Target &t)
+    explicit InjectHVXLocks(const Target &t)
         : target(t) {
         uses_hvx_var = Variable::make(Bool(), "uses_hvx");
     }

--- a/src/DebugToFile.cpp
+++ b/src/DebugToFile.cpp
@@ -88,7 +88,7 @@ class DebugToFile : public IRMutator {
     }
 
 public:
-    DebugToFile(const map<string, Function> &e)
+    explicit DebugToFile(const map<string, Function> &e)
         : env(e) {
     }
 };
@@ -108,7 +108,7 @@ class RemoveDummyRealizations : public IRMutator {
     }
 
 public:
-    RemoveDummyRealizations(const vector<Function> &o)
+    explicit RemoveDummyRealizations(const vector<Function> &o)
         : outputs(o) {
     }
 };
@@ -141,7 +141,7 @@ class AddDummyRealizations : public IRMutator {
     }
 
 public:
-    AddDummyRealizations(const vector<Function> &o)
+    explicit AddDummyRealizations(const vector<Function> &o)
         : outputs(o) {
     }
 };

--- a/src/DerivativeUtils.cpp
+++ b/src/DerivativeUtils.cpp
@@ -51,7 +51,7 @@ vector<int> gather_variables(const Expr &expr,
             }
         }
 
-        GatherVariables(const vector<string> &f)
+        explicit GatherVariables(const vector<string> &f)
             : filter(f) {
         }
 

--- a/src/EarlyFree.cpp
+++ b/src/EarlyFree.cpp
@@ -18,7 +18,7 @@ public:
     string func;
     Stmt last_use;
 
-    FindLastUse(string s)
+    explicit FindLastUse(string s)
         : func(std::move(s)) {
     }
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2664,7 +2664,7 @@ class CountImplicitVars : public Internal::IRGraphVisitor {
 public:
     int count;
 
-    CountImplicitVars(const vector<Expr> &e)
+    explicit CountImplicitVars(const vector<Expr> &e)
         : count(0) {
         for (size_t i = 0; i < e.size(); i++) {
             e[i].accept(this);

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -54,7 +54,7 @@ class WeakenFunctionPtrs : public IRMutator {
 
 public:
     int count = 0;
-    WeakenFunctionPtrs(FunctionContents *f)
+    explicit WeakenFunctionPtrs(FunctionContents *f)
         : func(f) {
     }
 };
@@ -186,7 +186,7 @@ struct CheckVars : public IRGraphVisitor {
     const std::string name;
     bool unbound_reduction_vars_ok = false;
 
-    CheckVars(const std::string &n)
+    explicit CheckVars(const std::string &n)
         : name(n) {
     }
 
@@ -274,7 +274,7 @@ class FreezeFunctions : public IRGraphVisitor {
     }
 
 public:
-    FreezeFunctions(const string &f)
+    explicit FreezeFunctions(const string &f)
         : func(f) {
     }
 };
@@ -1045,7 +1045,7 @@ class SubstituteCalls : public IRMutator {
     }
 
 public:
-    SubstituteCalls(const map<FunctionPtr, FunctionPtr> &substitutions)
+    explicit SubstituteCalls(const map<FunctionPtr, FunctionPtr> &substitutions)
         : substitutions(substitutions) {
     }
 };

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -219,7 +219,7 @@ class ReplaceForWithIf : public IRMutator {
     }
 
 public:
-    ReplaceForWithIf(const ExtractBlockSize &e)
+    explicit ReplaceForWithIf(const ExtractBlockSize &e)
         : block_size(e) {
     }
 };
@@ -250,7 +250,7 @@ class ExtractSharedAndHeapAllocations : public IRMutator {
 
     struct AllocGroup {
         AllocGroup() = default;
-        AllocGroup(const SharedAllocation &alloc)
+        explicit AllocGroup(const SharedAllocation &alloc)
             : name(alloc.name),
               widest_type(alloc.type),
               max_size(alloc.size),
@@ -1016,7 +1016,7 @@ public:
         return result;
     }
 
-    ExtractSharedAndHeapAllocations(DeviceAPI d)
+    explicit ExtractSharedAndHeapAllocations(DeviceAPI d)
         : in_threads(false),
           barrier_stage(0),
           device_api(d),

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -548,7 +548,7 @@ class HexagonLinker : public Linker {
 public:
     uint32_t flags;
 
-    HexagonLinker(const Target &target) {
+    explicit HexagonLinker(const Target &target) {
         if (target.has_feature(Target::HVX_v66)) {
             flags = Elf::EF_HEXAGON_MACH_V66;
         } else if (target.has_feature(Target::HVX_v65)) {
@@ -679,7 +679,7 @@ class ReplaceParams : public IRMutator {
     }
 
 public:
-    ReplaceParams(const std::map<std::string, Parameter> &replacements)
+    explicit ReplaceParams(const std::map<std::string, Parameter> &replacements)
         : replacements(replacements) {
     }
 };
@@ -921,7 +921,7 @@ class InjectHexagonRpc : public IRMutator {
     }
 
 public:
-    InjectHexagonRpc(Module &device_code)
+    explicit InjectHexagonRpc(Module &device_code)
         : device_code(device_code) {
     }
 

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -120,7 +120,7 @@ class WithLanes : public IRMutator {
     }
 
 public:
-    WithLanes(int lanes)
+    explicit WithLanes(int lanes)
         : lanes(lanes) {
     }
 };
@@ -1093,7 +1093,7 @@ private:
     }
 
 public:
-    OptimizePatterns(Target t) {
+    explicit OptimizePatterns(Target t) {
         target = t;
     }
 };
@@ -1628,7 +1628,7 @@ class EliminateInterleaves : public IRMutator {
     using IRMutator::visit;
 
 public:
-    EliminateInterleaves(int native_vector_bytes)
+    explicit EliminateInterleaves(int native_vector_bytes)
         : native_vector_bits(native_vector_bytes * 8), alignment_analyzer(native_vector_bytes) {
     }
 };
@@ -1787,7 +1787,7 @@ class OptimizeShuffles : public IRMutator {
     }
 
 public:
-    OptimizeShuffles(int lut_alignment)
+    explicit OptimizeShuffles(int lut_alignment)
         : lut_alignment(lut_alignment) {
     }
 };

--- a/src/IREquality.cpp
+++ b/src/IREquality.cpp
@@ -35,7 +35,7 @@ public:
      * subexpressions, it's worth passing in a cache to use.
      * Currently this is only done in common-subexpression
      * elimination. */
-    IRComparer(IRCompareCache *c = nullptr)
+    explicit IRComparer(IRCompareCache *c = nullptr)
         : result(Equal), cache(c) {
     }
 

--- a/src/InjectHostDevBufferCopies.cpp
+++ b/src/InjectHostDevBufferCopies.cpp
@@ -428,7 +428,7 @@ class FindLastUse : public IRVisitor {
 public:
     Stmt last_use;
 
-    FindLastUse(const string &b)
+    explicit FindLastUse(const string &b)
         : buffer(b) {
     }
 
@@ -515,7 +515,7 @@ class InjectBufferCopies : public IRMutator {
         string buffer;
 
     public:
-        InjectDeviceDestructor(string b)
+        explicit InjectDeviceDestructor(string b)
             : buffer(std::move(b)) {
         }
     };
@@ -784,7 +784,7 @@ public:
         }
     }
 
-    InjectBufferCopiesForInputsAndOutputs(Stmt s)
+    explicit InjectBufferCopiesForInputsAndOutputs(Stmt s)
         : site(std::move(s)) {
     }
 };

--- a/src/Inline.cpp
+++ b/src/Inline.cpp
@@ -172,7 +172,7 @@ class Inliner : public IRMutator {
 public:
     int found = 0;
 
-    Inliner(const Function &f)
+    explicit Inliner(const Function &f)
         : func(f) {
         internal_assert(f.can_be_inlined()) << "Illegal to inline " << f.name() << "\n";
         validate_schedule_inlined_function(f);

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -205,7 +205,7 @@ class DebugSections {
 public:
     bool working;
 
-    DebugSections(const std::string &binary)
+    explicit DebugSections(const std::string &binary)
         : calibrated(false), working(false) {
         std::string binary_path = binary;
 #ifdef __APPLE__

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -194,7 +194,7 @@ class HalideJITMemoryManager : public SectionMemoryManager {
     std::vector<std::pair<uint8_t *, size_t>> code_pages;
 
 public:
-    HalideJITMemoryManager(const std::vector<JITModule> &modules)
+    explicit HalideJITMemoryManager(const std::vector<JITModule> &modules)
         : modules(modules) {
     }
 

--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -44,7 +44,7 @@ class CanLift : public IRVisitor {
 public:
     bool result{true};
 
-    CanLift(const Scope<> &v)
+    explicit CanLift(const Scope<> &v)
         : varying(v) {
     }
 };
@@ -362,7 +362,7 @@ class GroupLoopInvariants : public IRMutator {
 
     public:
         int result = 0;
-        ExprDepth(const Scope<int> &var_depth)
+        explicit ExprDepth(const Scope<int> &var_depth)
             : depth(var_depth) {
         }
     };

--- a/src/LoopCarry.cpp
+++ b/src/LoopCarry.cpp
@@ -161,7 +161,7 @@ class StepForwards : public IRGraphMutator {
 
 public:
     bool success = true;
-    StepForwards(const Scope<Expr> &s)
+    explicit StepForwards(const Scope<Expr> &s)
         : linear(s) {
     }
 };
@@ -551,7 +551,7 @@ class LoopCarry : public IRMutator {
     }
 
 public:
-    LoopCarry(int max_carried_values)
+    explicit LoopCarry(int max_carried_values)
         : max_carried_values(max_carried_values) {
     }
 };

--- a/src/LowerWarpShuffles.cpp
+++ b/src/LowerWarpShuffles.cpp
@@ -747,7 +747,7 @@ class MoveIfStatementInwards : public IRMutator {
     Expr condition;
 
 public:
-    MoveIfStatementInwards(Expr c)
+    explicit MoveIfStatementInwards(Expr c)
         : condition(std::move(c)) {
     }
 };

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -448,7 +448,7 @@ Stmt inject_memoization(const Stmt &s, const std::map<std::string, Function> &en
 
 class RewriteMemoizedAllocations : public IRMutator {
 public:
-    RewriteMemoizedAllocations(const std::map<std::string, Function> &e)
+    explicit RewriteMemoizedAllocations(const std::map<std::string, Function> &e)
         : env(e) {
     }
 

--- a/src/ModulusRemainder.cpp
+++ b/src/ModulusRemainder.cpp
@@ -26,7 +26,7 @@ public:
     ModulusRemainder result;
     Scope<ModulusRemainder> scope;
 
-    ComputeModulusRemainder(const Scope<ModulusRemainder> *s) {
+    explicit ComputeModulusRemainder(const Scope<ModulusRemainder> *s) {
         scope.set_containing_scope(s);
     }
 

--- a/src/ParallelRVar.cpp
+++ b/src/ParallelRVar.cpp
@@ -40,7 +40,7 @@ class FindLoads : public IRVisitor {
     }
 
 public:
-    FindLoads(const string &f)
+    explicit FindLoads(const string &f)
         : func(f) {
     }
 

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -226,7 +226,7 @@ class ExprUsesInvalidBuffers : public IRVisitor {
     }
 
 public:
-    ExprUsesInvalidBuffers(const Scope<> &buffers)
+    explicit ExprUsesInvalidBuffers(const Scope<> &buffers)
         : invalid_buffers(buffers), invalid(false) {
     }
     bool invalid;
@@ -420,7 +420,7 @@ class FindSimplifications : public IRVisitor {
 public:
     vector<Simplification> simplifications;
 
-    FindSimplifications(const std::string &v) {
+    explicit FindSimplifications(const std::string &v) {
         depends_on_loop_var.push(v);
     }
 };
@@ -432,7 +432,7 @@ class MakeSimplifications : public IRMutator {
     const vector<Simplification> &simplifications;
 
 public:
-    MakeSimplifications(const vector<Simplification> &s)
+    explicit MakeSimplifications(const vector<Simplification> &s)
         : simplifications(s) {
     }
 

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -440,7 +440,7 @@ class FindExterns : public IRGraphVisitor {
     }
 
 public:
-    FindExterns(std::map<std::string, JITExtern> &externs)
+    explicit FindExterns(std::map<std::string, JITExtern> &externs)
         : externs(externs) {
     }
 
@@ -801,7 +801,7 @@ void Pipeline::add_requirement(const Expr &condition, std::vector<Expr> &error_a
         const Expr &condition;
 
     public:
-        Checker(const Expr &c)
+        explicit Checker(const Expr &c)
             : condition(c) {
             c.accept(this);
         }
@@ -865,7 +865,7 @@ struct JITFuncCallContext {
     JITUserContext jit_context;
     bool custom_error_handler;
 
-    JITFuncCallContext(const JITHandlers &handlers) {
+    explicit JITFuncCallContext(const JITHandlers &handlers) {
         void *user_context = nullptr;
         JITHandlers local_handlers = handlers;
         if (local_handlers.custom_error == nullptr) {
@@ -911,7 +911,7 @@ struct Pipeline::JITCallArgs {
     size_t size{0};
     const void **store;
 
-    JITCallArgs(size_t size)
+    explicit JITCallArgs(size_t size)
         : size(size) {
         if (size > kStoreSize) {
             store = new ConstVoidPtr[size];

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -270,7 +270,7 @@ class ReducePrefetchDimension : public IRMutator {
     }
 
 public:
-    ReducePrefetchDimension(size_t dim)
+    explicit ReducePrefetchDimension(size_t dim)
         : max_dim(dim) {
     }
 };
@@ -338,7 +338,7 @@ class SplitPrefetch : public IRMutator {
     }
 
 public:
-    SplitPrefetch(Expr bytes)
+    explicit SplitPrefetch(Expr bytes)
         : max_byte_size(std::move(bytes)) {
     }
 };

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -27,7 +27,7 @@ public:
 
     string pipeline_name;
 
-    InjectProfiling(const string &pipeline_name)
+    explicit InjectProfiling(const string &pipeline_name)
         : pipeline_name(pipeline_name) {
         indices["overhead"] = 0;
         stack.push_back(0);

--- a/src/Qualify.cpp
+++ b/src/Qualify.cpp
@@ -26,7 +26,7 @@ class QualifyExpr : public IRMutator {
     }
 
 public:
-    QualifyExpr(const string &p)
+    explicit QualifyExpr(const string &p)
         : prefix(p) {
     }
 };

--- a/src/SelectGPUAPI.cpp
+++ b/src/SelectGPUAPI.cpp
@@ -41,7 +41,7 @@ class SelectGPUAPI : public IRMutator {
     }
 
 public:
-    SelectGPUAPI(Target t)
+    explicit SelectGPUAPI(Target t)
         : target(t) {
         default_api = get_default_device_api_for_target(t);
         parent_api = DeviceAPI::Host;

--- a/src/SimplifyCorrelatedDifferences.cpp
+++ b/src/SimplifyCorrelatedDifferences.cpp
@@ -45,7 +45,7 @@ class SimplifyCorrelatedDifferences : public IRMutator {
                 : op(op),
                   binding(scope, op->name, is_monotonic(op->value, loop_var, scope)) {
             }
-            Frame(const LetStmtOrLet *op)
+            explicit Frame(const LetStmtOrLet *op)
                 : op(op) {
             }
         };

--- a/src/SimplifySpecializations.cpp
+++ b/src/SimplifySpecializations.cpp
@@ -52,7 +52,7 @@ public:
     }
 
     Expr fact;
-    SimplifyUsingFact(Expr f)
+    explicit SimplifyUsingFact(Expr f)
         : fact(std::move(f)) {
     }
 };

--- a/src/Simplify_Let.cpp
+++ b/src/Simplify_Let.cpp
@@ -29,7 +29,7 @@ class CountVarUses : public IRVisitor {
     using IRVisitor::visit;
 
 public:
-    CountVarUses(std::map<std::string, int> &var_uses)
+    explicit CountVarUses(std::map<std::string, int> &var_uses)
         : var_uses(var_uses) {
     }
 };
@@ -53,7 +53,7 @@ Body Simplify::simplify_let(const LetOrLetStmt *op, ExprInfo *bounds) {
         string new_name;
         bool new_value_alignment_tracked = false, new_value_bounds_tracked = false;
         bool value_alignment_tracked = false, value_bounds_tracked = false;
-        Frame(const LetOrLetStmt *op)
+        explicit Frame(const LetOrLetStmt *op)
             : op(op) {
         }
     };

--- a/src/SkipStages.cpp
+++ b/src/SkipStages.cpp
@@ -323,7 +323,7 @@ private:
 
 class StageSkipper : public IRMutator {
 public:
-    StageSkipper(const string &f)
+    explicit StageSkipper(const string &f)
         : func(f), in_vector_loop(false) {
     }
 

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -43,7 +43,7 @@ public:
     bool result;
     string var;
 
-    ExprDependsOnVar(string v)
+    explicit ExprDependsOnVar(string v)
         : result(false), var(std::move(v)) {
     }
 };
@@ -69,7 +69,7 @@ class ExpandExpr : public IRMutator {
     }
 
 public:
-    ExpandExpr(const Scope<Expr> &s)
+    explicit ExpandExpr(const Scope<Expr> &s)
         : scope(s) {
     }
 };
@@ -373,7 +373,7 @@ class SlidingWindowOnFunction : public IRMutator {
     }
 
 public:
-    SlidingWindowOnFunction(Function f)
+    explicit SlidingWindowOnFunction(Function f)
         : func(std::move(f)) {
     }
 };
@@ -418,7 +418,7 @@ class SlidingWindow : public IRMutator {
     }
 
 public:
-    SlidingWindow(const map<string, Function> &e)
+    explicit SlidingWindow(const map<string, Function> &e)
         : env(e) {
     }
 };

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -1375,7 +1375,7 @@ class AndConditionOverDomain : public IRMutator {
 public:
     bool relaxed = false;
 
-    AndConditionOverDomain(const Scope<Interval> &parent_scope) {
+    explicit AndConditionOverDomain(const Scope<Interval> &parent_scope) {
         scope.set_containing_scope(&parent_scope);
     }
 };

--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -332,7 +332,7 @@ class SplitTuples : public IRMutator {
     Scope<int> realizations;
 
 public:
-    SplitTuples(const map<string, Function> &e)
+    explicit SplitTuples(const map<string, Function> &e)
         : env(e) {
     }
 };

--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -797,7 +797,7 @@ public:
         scope.pop(m.name());
     }
 
-    StmtToHtml(const string &filename)
+    explicit StmtToHtml(const string &filename)
         : id_count(0), context_stack(1, 0) {
         stream.open(filename.c_str());
         stream << "<head>";

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -44,7 +44,7 @@ class CountProducers : public IRVisitor {
 public:
     int count = 0;
 
-    CountProducers(const std::string &name)
+    explicit CountProducers(const std::string &name)
         : name(name) {
     }
 };
@@ -417,7 +417,7 @@ class HasExternConsumer : public IRVisitor {
     const std::string &func;
 
 public:
-    HasExternConsumer(const std::string &func)
+    explicit HasExternConsumer(const std::string &func)
         : func(func) {
     }
     bool result = false;
@@ -993,7 +993,7 @@ class StorageFolding : public IRMutator {
     }
 
 public:
-    StorageFolding(const map<string, Function> &env)
+    explicit StorageFolding(const map<string, Function> &env)
         : env(env) {
     }
 };

--- a/src/StrictifyFloat.cpp
+++ b/src/StrictifyFloat.cpp
@@ -53,7 +53,7 @@ public:
     };
     bool any_strict_float{false};
 
-    StrictifyFloat(StrictnessMode mode)
+    explicit StrictifyFloat(StrictnessMode mode)
         : strictness((mode == Forced) ? StrictFloat : FastMath) {
         any_strict_float |= (mode == Forced);
     }

--- a/src/Substitute.cpp
+++ b/src/Substitute.cpp
@@ -23,7 +23,7 @@ class Substitute : public IRMutator {
     }
 
 public:
-    Substitute(const map<string, Expr> &m)
+    explicit Substitute(const map<string, Expr> &m)
         : replace(m) {
     }
 

--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -321,7 +321,7 @@ class RemoveRealizeOverOutput : public IRMutator {
     }
 
 public:
-    RemoveRealizeOverOutput(const vector<Function> &o)
+    explicit RemoveRealizeOverOutput(const vector<Function> &o)
         : outputs(o) {
     }
 };

--- a/src/TrimNoOps.cpp
+++ b/src/TrimNoOps.cpp
@@ -51,7 +51,7 @@ class LoadsFromBuffer : public IRVisitor {
 
 public:
     bool result = false;
-    LoadsFromBuffer(const string &b)
+    explicit LoadsFromBuffer(const string &b)
         : buffer(b) {
     }
 };

--- a/src/UniquifyVariableNames.cpp
+++ b/src/UniquifyVariableNames.cpp
@@ -115,7 +115,7 @@ class UniquifyVariableNames : public IRMutator {
     }
 
 public:
-    UniquifyVariableNames(const Scope<string> *free_vars) {
+    explicit UniquifyVariableNames(const Scope<string> *free_vars) {
         renaming.set_containing_scope(free_vars);
     }
 };

--- a/src/UnsafePromises.cpp
+++ b/src/UnsafePromises.cpp
@@ -37,7 +37,7 @@ class LowerUnsafePromises : public IRMutator {
     bool check;
 
 public:
-    LowerUnsafePromises(bool check)
+    explicit LowerUnsafePromises(bool check)
         : check(check) {
     }
 };

--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -425,7 +425,7 @@ Stmt find_linear_expressions(const Stmt &s) {
 // tagged intrinsics
 class FindVaryingAttributeTags : public IRVisitor {
 public:
-    FindVaryingAttributeTags(std::map<std::string, Expr> &varyings_)
+    explicit FindVaryingAttributeTags(std::map<std::string, Expr> &varyings_)
         : varyings(varyings_) {
     }
 
@@ -724,7 +724,7 @@ protected:
     }
 
 public:
-    CastVariablesToFloatAndOffset(const std::vector<std::string> &names_)
+    explicit CastVariablesToFloatAndOffset(const std::vector<std::string> &names_)
         : names(names_) {
     }
 

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -44,7 +44,7 @@ class ReplaceShuffleVectors : public IRMutator {
     }
 
 public:
-    ReplaceShuffleVectors(const string &v)
+    explicit ReplaceShuffleVectors(const string &v)
         : var(v) {
     }
 };
@@ -1474,7 +1474,7 @@ public:
         }
     }
 
-    LiftVectorizableExprsOutOfSingleAtomicNode(const std::set<Expr, ExprCompare> &liftable)
+    explicit LiftVectorizableExprsOutOfSingleAtomicNode(const std::set<Expr, ExprCompare> &liftable)
         : liftable(liftable) {
     }
 };
@@ -1499,7 +1499,7 @@ class LiftVectorizableExprsOutOfAllAtomicNodes : public IRMutator {
     const map<string, Function> &env;
 
 public:
-    LiftVectorizableExprsOutOfAllAtomicNodes(const map<string, Function> &env)
+    explicit LiftVectorizableExprsOutOfAllAtomicNodes(const map<string, Function> &env)
         : env(env) {
     }
 };
@@ -1541,7 +1541,7 @@ class VectorizeLoops : public IRMutator {
     }
 
 public:
-    VectorizeLoops(const Target &t)
+    explicit VectorizeLoops(const Target &t)
         : target(t), in_hexagon(false) {
     }
 };
@@ -1557,7 +1557,7 @@ class AllStoresInScope : public IRVisitor {
 public:
     bool result = true;
     const Scope<> &s;
-    AllStoresInScope(const Scope<> &s)
+    explicit AllStoresInScope(const Scope<> &s)
         : s(s) {
     }
 };


### PR DESCRIPTION
This is some low-hanging fruit found by clang-tidy that seems safe & sensible to land whether or not we decide to enforce requiring explicit in the future. 