### PR TITLE
bounds inference (mod) pessimistic on unsigned 0 interval

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -646,9 +646,12 @@ private:
             }
         } else {
             // b is bounded
-            if (b.max.type().is_uint() || (b.max.type().is_int() && is_positive_const(b.min))) {
-                // If the RHS is a positive integer, the result is in [0, max_b-1]
-                interval.max = Max::make(interval.min, b.max - make_one(t));
+            if ((b.max.type().is_int() || b.max.type().is_uint()) && is_positive_const(b.min)) {
+                // If the RHS is >= 1, the result is in [0, max_b-1]
+                interval.max = b.max - make_one(t);
+            } else if (b.max.type().is_uint()) {
+                // if b.max = 0 then result is [0, 0], else [0, b.max - 1]
+                interval.max = select(is_zero(b.max), make_zero(t), b.max - make_one(t));
             } else if (b.max.type().is_int()) {
                 // x % [4,10] -> [0,9]
                 // x % [-8,-3] -> [0,7]

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -646,7 +646,7 @@ private:
             }
         } else {
             // b is bounded
-            if ((b.max.type().is_int() || b.max.type().is_uint()) && is_positive_const(b.min)) {
+            if (b.max.type().is_int_or_uint() && is_positive_const(b.min)) {
                 // If the RHS is >= 1, the result is in [0, max_b-1]
                 interval.max = b.max - make_one(t);
             } else if (b.max.type().is_uint()) {


### PR DESCRIPTION
Fix discussed with @abadams and @alexreinking . Original code takes `b = [0u, 0u]` and produces an interval of `[0, b.type().max()]` due to wrap-around. Technically correct but pessimistic/not tight. This fix removes that case and simplifies the overall generated expression `interval.max` by removing the `max()`