### PR TITLE
min and max in the algorithm was confusing loop partitioning

### DIFF
--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -282,20 +282,21 @@ class FindSimplifications : public IRVisitor {
         bool likely_a = has_uncaptured_likely_tag(op->a);
         bool likely_b = has_uncaptured_likely_tag(op->b);
 
+        // If one side has an uncaptured likely, don't hunt for
+        // simplifications in the other side.
+        if (!likely_a) {
+            op->b.accept(this);
+        }
+        if (!likely_b) {
+            op->a.accept(this);
+        }
+
         // Prefer the side that has an uncaptured top-level likely
         // call. If neither does, prefer the side that contains any
         // likely call at all.
         if (!likely_a && !likely_b) {
             likely_a = has_likely_tag(op->a);
             likely_b = has_likely_tag(op->b);
-        }
-
-        // Don't hunt for simplifications in unlikely paths
-        if (!likely_a) {
-            op->b.accept(this);
-        }
-        if (!likely_b) {
-            op->a.accept(this);
         }
 
         if (likely_b && !likely_a) {
@@ -309,16 +310,16 @@ class FindSimplifications : public IRVisitor {
         bool likely_a = has_uncaptured_likely_tag(op->a);
         bool likely_b = has_uncaptured_likely_tag(op->b);
 
-        if (!likely_a && !likely_b) {
-            likely_a = has_likely_tag(op->a);
-            likely_b = has_likely_tag(op->b);
-        }
-
         if (!likely_a) {
             op->b.accept(this);
         }
         if (!likely_b) {
             op->a.accept(this);
+        }
+
+        if (!likely_a && !likely_b) {
+            likely_a = has_likely_tag(op->a);
+            likely_b = has_likely_tag(op->b);
         }
 
         if (likely_b && !likely_a) {

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -240,6 +240,7 @@ tests(GROUPS correctness
       partial_realization.cpp
       partition_loops.cpp
       partition_loops_bug.cpp
+      partition_max_filter.cpp
       pipeline_set_jit_externs_func.cpp
       plain_c_includes.c
       popc_clz_ctz_bounds.cpp

--- a/test/correctness/partition_max_filter.cpp
+++ b/test/correctness/partition_max_filter.cpp
@@ -1,0 +1,66 @@
+#include "Halide.h"
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+class CountForLoops : public IRMutator {
+    using IRMutator::visit;
+
+    Stmt visit(const For *op) override {
+        count++;
+        return IRMutator::visit(op);
+    }
+
+public:
+    int count = 0;
+};
+
+int main(int argc, char **argv) {
+    // See https://github.com/halide/Halide/issues/5353
+
+    const int width = 1280, height = 1024;
+    Buffer<uint8_t> input(width, height);
+    input.fill(0);
+
+    Var x, y;
+
+    Func clamped;
+    clamped = BoundaryConditions::repeat_edge(input);
+
+    Func max_x;
+    max_x(x, y) = max(clamped(x - 1, y), clamped(x, y), clamped(x + 1, y));
+
+    Func max_y;
+    max_y(x, y) = max(max_x(x, y - 1), max_x(x, y), max_x(x, y + 1));
+
+    CountForLoops counter;
+    max_y.add_custom_lowering_pass(&counter, nullptr);
+
+    Buffer<uint8_t> out = max_y.realize(width, height);
+
+    // We expect a loop structure like:
+    // Top of the image
+    // for y:
+    //  for x:
+    // Middle of the image
+    // for y:
+    //  Left edge
+    //  for x:
+    //  Center
+    //  for x:
+    //  Right edge
+    //  for x:
+    // Bottom of the image
+    // for y:
+    //  for x:
+
+    const int expected_loops = 8;
+
+    if (counter.count != expected_loops) {
+        printf("Loop was not partitioned into the expected number of cases\n");
+        return -1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Because if any likely tag at all existed on a side of the min/max, even
if captured, the other side wasn't getting mutated. This should only
happen for uncaptured likelies, where simplifications in the unlikely
path are irrelevant.

Fixes #5353 