### PR TITLE
Extend clang-tidy checks into  tools, utils, and python_bindings

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -28,15 +28,14 @@ jobs:
       - name: Install clang-tidy
         run: |
           sudo apt-get update
-          sudo apt-get install llvm-10 clang-10 libclang-10-dev clang-tidy-10
-          sudo apt-get remove llvm-8 clang-8 libclang-8-dev clang-tidy-8
-      - name: Build Compilation DB
-        run: |
-          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DLLVM_DIR=/usr/lib/llvm-10/lib/cmake/llvm -S . -B build
-          [ -a build/compile_commands.json ]
+          sudo apt-get install llvm-10 clang-10 libclang-10-dev clang-tidy-10 ninja-build
+          sudo apt-get remove llvm-8 clang-8 libclang-8-dev clang-tidy-8 llvm-9 clang-9 libclang-9-dev clang-tidy-9
       - name: Run clang-tidy
         run: |
-          clang-tidy-10 --quiet -header-filter=.* -extra-arg=-Wno-unknown-warning-option -p build src/*.cpp
+          export CC=clang-10
+          export CXX=clang++-10
+          export CLANG_TIDY_LLVM_INSTALL_DIR=/usr/lib/llvm-10
+          ./run-clang-tidy.sh
   check_cmake_file_lists:
     name: Check CMake file lists
     runs-on: ubuntu-latest

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -278,16 +278,24 @@ void define_func(py::module &m) {
                                  "Call infer_input_bounds() with an explicit list of ints instead.",
                                  1);
                     std::vector<int32_t> sizes;
-                    if (x_size) sizes.push_back(x_size);
-                    if (y_size) sizes.push_back(y_size);
-                    if (z_size) sizes.push_back(z_size);
-                    if (w_size) sizes.push_back(w_size);
+                    if (x_size) {
+                        sizes.push_back(x_size);
+                    }
+                    if (y_size) {
+                        sizes.push_back(y_size);
+                    }
+                    if (z_size) {
+                        sizes.push_back(z_size);
+                    }
+                    if (w_size) {
+                        sizes.push_back(w_size);
+                    }
                     f.infer_input_bounds(sizes, target);
                 },
                 py::arg("x_size") = 0, py::arg("y_size") = 0, py::arg("z_size") = 0, py::arg("w_size") = 0, py::arg("target") = get_jit_target_from_environment())
 
             .def(
-                "infer_input_bounds", [](Func &f, py::object dst, const Target &target) -> void {
+                "infer_input_bounds", [](Func &f, const py::object &dst, const Target &target) -> void {
                     // dst could be Buffer<>, vector<Buffer>, or vector<int>
                     try {
                         Buffer<> b = dst.cast<Buffer<>>();

--- a/python_bindings/src/PyPipeline.cpp
+++ b/python_bindings/src/PyPipeline.cpp
@@ -1,5 +1,7 @@
 #include "PyPipeline.h"
 
+#include <utility>
+
 #include "PyTuple.h"
 
 namespace Halide {
@@ -107,7 +109,7 @@ void define_pipeline(py::module &m) {
 
             .def(
                 "realize", [](Pipeline &p, std::vector<int32_t> sizes, const Target &target) -> py::object {
-                    return realization_to_object(p.realize(sizes, target));
+                    return realization_to_object(p.realize(std::move(sizes), target));
                 },
                 py::arg("sizes") = std::vector<int32_t>{}, py::arg("target") = Target())
 
@@ -146,16 +148,24 @@ void define_pipeline(py::module &m) {
                                  "Call infer_input_bounds() with an explicit list of ints instead.",
                                  1);
                     std::vector<int32_t> sizes;
-                    if (x_size) sizes.push_back(x_size);
-                    if (y_size) sizes.push_back(y_size);
-                    if (z_size) sizes.push_back(z_size);
-                    if (w_size) sizes.push_back(w_size);
+                    if (x_size) {
+                        sizes.push_back(x_size);
+                    }
+                    if (y_size) {
+                        sizes.push_back(y_size);
+                    }
+                    if (z_size) {
+                        sizes.push_back(z_size);
+                    }
+                    if (w_size) {
+                        sizes.push_back(w_size);
+                    }
                     p.infer_input_bounds(sizes, target);
                 },
                 py::arg("x_size") = 0, py::arg("y_size") = 0, py::arg("z_size") = 0, py::arg("w_size") = 0, py::arg("target") = get_jit_target_from_environment())
 
             .def(
-                "infer_input_bounds", [](Pipeline &p, py::object dst, const Target &target) -> void {
+                "infer_input_bounds", [](Pipeline &p, const py::object &dst, const Target &target) -> void {
                     // dst could be Buffer<>, vector<Buffer>, or vector<int>
                     try {
                         Buffer<> b = dst.cast<Buffer<>>();

--- a/python_bindings/src/PyRDom.cpp
+++ b/python_bindings/src/PyRDom.cpp
@@ -41,8 +41,9 @@ void define_rdom(py::module &m) {
             .def("__len__", &RDom::dimensions)
             .def("where", &RDom::where, py::arg("predicate"))
             .def("__getitem__", [](RDom &r, const int i) -> RVar {
-                if (i < 0 || i >= r.dimensions())
+                if (i < 0 || i >= r.dimensions()) {
                     throw pybind11::key_error();
+                }
                 return r[i];
             })
             .def_readonly("x", &RDom::x)

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -173,7 +173,7 @@ py::object generate_impl(FactoryFunc factory, const GeneratorContext &context, c
 
 void pystub_init(pybind11::module &m, FactoryFunc factory) {
     m.def(
-        "generate", [factory](const Halide::Target &target, py::args args, py::kwargs kwargs) -> py::object {
+        "generate", [factory](const Halide::Target &target, const py::args &args, const py::kwargs &kwargs) -> py::object {
             return generate_impl(factory, Halide::GeneratorContext(target), args, kwargs);
         },
         py::arg("target"));

--- a/src/autoschedulers/.clang-tidy
+++ b/src/autoschedulers/.clang-tidy
@@ -1,6 +1,14 @@
-# Note: if you make changes here, you may need to make changes in .clang-tidy
-# files elsewhere in the tree; clang-tidy-10 doesn't allow selective
-# inheritance of parent .clang-tidy files.
+# In clang-tidy-11 (or maybe clang-tidy-12) you can use
+#
+#  InheritParentConfig: true
+#
+# to just inherit from parent .clang-tidy files. Alas,
+# that isn't available in clang-tidy-10, so we must make copies
+# where specialization is needed.
+
+#
+# The desired change here is just to remove two performance checks.
+#
 
 ---
 Checks: >
@@ -14,8 +22,8 @@ Checks: >
     performance-move-const-arg,
     performance-noexcept-move-constructor,
     performance-trivially-destructible,
-    performance-unnecessary-copy-initialization,
-    performance-unnecessary-value-param,
+    -performance-unnecessary-copy-initialization,
+    -performance-unnecessary-value-param,
     readability-braces-around-statements
 
 WarningsAsErrors: '*'

--- a/src/autoschedulers/adams2019/ASLog.cpp
+++ b/src/autoschedulers/adams2019/ASLog.cpp
@@ -26,7 +26,9 @@ std::string get_env_variable(char const *env_var_name) {
     return lvl;
 #else
     char *lvl = getenv(env_var_name);
-    if (lvl) return std::string(lvl);
+    if (lvl) {
+        return std::string(lvl);
+    }
 #endif
 
     return "";

--- a/src/autoschedulers/adams2019/AutoSchedule.cpp
+++ b/src/autoschedulers/adams2019/AutoSchedule.cpp
@@ -105,10 +105,14 @@ using std::vector;
 
 struct ProgressBar {
     void set(double progress) {
-        if (!draw_progress_bar) return;
+        if (!draw_progress_bar) {
+            return;
+        }
         counter++;
         const int bits = 11;
-        if (counter & ((1 << bits) - 1)) return;
+        if (counter & ((1 << bits) - 1)) {
+            return;
+        }
         const int pos = (int)(progress * 78);
         aslog(0) << "[";
         for (int j = 0; j < 78; j++) {
@@ -157,7 +161,9 @@ uint32_t get_dropout_threshold() {
 // training data.
 bool random_dropout(std::mt19937 &rng, size_t num_decisions) {
     static double random_dropout_threshold = get_dropout_threshold();
-    if (random_dropout_threshold >= 100) return false;
+    if (random_dropout_threshold >= 100) {
+        return false;
+    }
 
     // The random dropout threshold is the chance that we operate
     // entirely greedily and never discard anything.
@@ -205,9 +211,15 @@ struct State {
 
     const LoopNest *deepest_common_ancestor(const map<const LoopNest *, pair<const LoopNest *, int>> &parent,
                                             const LoopNest *a, const LoopNest *b) {
-        if (a->is_root()) return a;
-        if (b->is_root()) return b;
-        if (a == b) return a;
+        if (a->is_root()) {
+            return a;
+        }
+        if (b->is_root()) {
+            return b;
+        }
+        if (a == b) {
+            return a;
+        }
 
         // Walk the deeper one up until they're at the same depth
         auto it_a = parent.find(a);
@@ -226,7 +238,9 @@ struct State {
             // Walk each up one
             a = it_a->second.first;
             b = it_b->second.first;
-            if (a == b) return a;
+            if (a == b) {
+                return a;
+            }
             it_a = parent.find(a);
             it_b = parent.find(b);
             internal_assert(it_a != parent.end() && it_b != parent.end());
@@ -271,7 +285,9 @@ struct State {
             for (const auto *e : n.outgoing_edges) {
                 const auto &consumer_site = sites.get(e->consumer);
                 const LoopNest *l = consumer_site.innermost;
-                if (!l) l = consumer_site.compute;
+                if (!l) {
+                    l = consumer_site.compute;
+                }
                 if (!l) {
                     if (aslog::aslog_level() > 0) {
                         dump();
@@ -310,7 +326,9 @@ struct State {
         compute_featurization(dag, params, &features);
 
         for (const auto &n : dag.nodes) {
-            if (n.is_input) continue;
+            if (n.is_input) {
+                continue;
+            }
             for (size_t stage_idx = n.stages.size(); stage_idx > 0; stage_idx--) {
                 const auto &s = n.stages[stage_idx - 1];
                 const size_t num_schedule_features = ScheduleFeatures::num_features();
@@ -654,7 +672,9 @@ struct State {
                         ((o.entire || min_total >= params.parallelism) &&
                          (max_total <= params.parallelism * 16));
 
-                    if (!ok) continue;
+                    if (!ok) {
+                        continue;
+                    }
 
                     options.emplace_back(std::move(o));
                 }
@@ -785,7 +805,9 @@ struct State {
         }
 
         for (auto &p : state_map) {
-            if (p.first->node->is_input) continue;
+            if (p.first->node->is_input) {
+                continue;
+            }
 
             Stage stage(p.first->stage);
 
@@ -796,8 +818,12 @@ struct State {
             vector<VarOrRVar> parallel_vars;
             bool any_parallel_vars = false, any_parallel_rvars = false;
             for (auto it = p.second->vars.rbegin(); it != p.second->vars.rend(); it++) {
-                if (!it->exists || it->extent == 1) continue;
-                if (!it->parallel) break;
+                if (!it->exists || it->extent == 1) {
+                    continue;
+                }
+                if (!it->parallel) {
+                    break;
+                }
                 any_parallel_rvars |= it->var.is_rvar;
                 any_parallel_vars |= !it->var.is_rvar;
                 parallel_tasks *= it->extent;
@@ -875,7 +901,9 @@ struct State {
         bool in_quotes = false;
         for (auto &c : schedule_source) {
             in_quotes ^= (c == '"');
-            if (!in_quotes && c == '$') c = '_';
+            if (!in_quotes && c == '$') {
+                c = '_';
+            }
         }
     }
 };
@@ -958,7 +986,7 @@ void configure_pipeline_features(const FunctionDAG &dag,
 
 // A single pass of coarse-to-fine beam search.
 IntrusivePtr<State> optimal_schedule_pass(FunctionDAG &dag,
-                                          vector<Function> outputs,
+                                          const vector<Function> &outputs,
                                           const MachineParams &params,
                                           CostModel *cost_model,
                                           std::mt19937 &rng,
@@ -1103,7 +1131,9 @@ IntrusivePtr<State> optimal_schedule_pass(FunctionDAG &dag,
                             permitted_hashes.insert(h1);
                             s = s->parent.get();
                         }
-                        if (pending.empty()) break;
+                        if (pending.empty()) {
+                            break;
+                        }
                         state = pending.pop();
                         blessed++;
                     }
@@ -1156,7 +1186,7 @@ IntrusivePtr<State> optimal_schedule_pass(FunctionDAG &dag,
 
 // Performance coarse-to-fine beam search and return the best state found.
 IntrusivePtr<State> optimal_schedule(FunctionDAG &dag,
-                                     vector<Function> outputs,
+                                     const vector<Function> &outputs,
                                      const MachineParams &params,
                                      CostModel *cost_model,
                                      std::mt19937 &rng,

--- a/src/autoschedulers/adams2019/DefaultCostModel.cpp
+++ b/src/autoschedulers/adams2019/DefaultCostModel.cpp
@@ -32,10 +32,14 @@ using Halide::Internal::ScheduleFeatures;
 using Halide::Runtime::Buffer;
 
 bool ends_with(const std::string &str, const std::string &suffix) {
-    if (str.size() < suffix.size()) return false;
+    if (str.size() < suffix.size()) {
+        return false;
+    }
     size_t off = str.size() - suffix.size();
     for (size_t i = 0; i < suffix.size(); i++) {
-        if (str[off + i] != suffix[i]) return false;
+        if (str[off + i] != suffix[i]) {
+            return false;
+        }
     }
     return true;
 }
@@ -243,7 +247,9 @@ float DefaultCostModel::backprop(const Runtime::Buffer<const float> &true_runtim
         }
         internal_assert(true_runtimes(i) > 0);
     }
-    if (any_nans) abort();
+    if (any_nans) {
+        abort();
+    }
 
     // Update weights locally
     auto update_weight = [](const Runtime::Buffer<float> &src, Runtime::Buffer<float> &dst) {
@@ -262,7 +268,9 @@ float DefaultCostModel::backprop(const Runtime::Buffer<const float> &true_runtim
 }
 
 void DefaultCostModel::evaluate_costs() {
-    if (cursor == 0 || !schedule_feat_queue.data()) return;
+    if (cursor == 0 || !schedule_feat_queue.data()) {
+        return;
+    }
 
     internal_assert(pipeline_feat_queue.data());
     internal_assert(schedule_feat_queue.data());

--- a/src/autoschedulers/adams2019/Featurization.h
+++ b/src/autoschedulers/adams2019/Featurization.h
@@ -104,7 +104,9 @@ struct PipelineFeatures {
         for (int i = 0; i < (int)ScalarType::NumScalarTypes; i++) {
             const char *type_names[] = {"Bool", "UInt8", "UInt16", "UInt32", "UInt64", "Float", "Double"};
             // Skip printing for types not used
-            if (!types_in_use[i]) continue;
+            if (!types_in_use[i]) {
+                continue;
+            }
 
             os << "    Featurization for type " << type_names[i] << "\n"
                << "     Op histogram:\n"

--- a/src/autoschedulers/adams2019/FunctionDAG.cpp
+++ b/src/autoschedulers/adams2019/FunctionDAG.cpp
@@ -496,7 +496,9 @@ FunctionDAG::Edge::BoundInfo::BoundInfo(const Expr &e, const Node::Stage &consum
 
 void FunctionDAG::Edge::add_load_jacobian(LoadJacobian j1) {
     for (auto &j2 : load_jacobians) {
-        if (j2.merge(j1)) return;
+        if (j2.merge(j1)) {
+            return;
+        }
     }
     load_jacobians.emplace_back(std::move(j1));
 }
@@ -699,7 +701,9 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
             for (size_t i = 0; i < sched.dims().size(); i++) {
                 const auto &d = sched.dims()[i];
                 // Skip synthetic loops like "__outermost"
-                if (!stage_scope_with_symbolic_rvar_bounds.contains(d.var)) continue;
+                if (!stage_scope_with_symbolic_rvar_bounds.contains(d.var)) {
+                    continue;
+                }
 
                 Node::Loop l;
                 l.var = d.var;
@@ -807,7 +811,7 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
                 int leaves = 0;
                 Type narrowest_type;
                 map<string, int> calls;
-                CheckTypes(Function f)
+                CheckTypes(const Function &f)
                     : func(f) {
                 }
             };

--- a/src/autoschedulers/adams2019/FunctionDAG.h
+++ b/src/autoschedulers/adams2019/FunctionDAG.h
@@ -9,6 +9,8 @@
 #include <map>
 #include <stdint.h>
 #include <string>
+#include <utility>
+
 #include <vector>
 
 #include "Errors.h"
@@ -57,8 +59,12 @@ struct OptionalRational {
     }
 
     OptionalRational operator*(const OptionalRational &other) const {
-        if ((*this) == 0) return *this;
-        if (other == 0) return other;
+        if ((*this) == 0) {
+            return *this;
+        }
+        if (other == 0) {
+            return other;
+        }
         int64_t num = numerator * other.numerator;
         int64_t den = denominator * other.denominator;
         bool e = exists && other.exists;
@@ -70,7 +76,9 @@ struct OptionalRational {
     // operators are not comparable, so a < b is not the same as !(a
     // >= b).
     bool operator<(int x) const {
-        if (!exists) return false;
+        if (!exists) {
+            return false;
+        }
         if (denominator > 0) {
             return numerator < x * denominator;
         } else {
@@ -79,7 +87,9 @@ struct OptionalRational {
     }
 
     bool operator<=(int x) const {
-        if (!exists) return false;
+        if (!exists) {
+            return false;
+        }
         if (denominator > 0) {
             return numerator <= x * denominator;
         } else {
@@ -88,12 +98,16 @@ struct OptionalRational {
     }
 
     bool operator>(int x) const {
-        if (!exists) return false;
+        if (!exists) {
+            return false;
+        }
         return !((*this) <= x);
     }
 
     bool operator>=(int x) const {
-        if (!exists) return false;
+        if (!exists) {
+            return false;
+        }
         return !((*this) < x);
     }
 
@@ -155,11 +169,17 @@ public:
     // Try to merge another LoadJacobian into this one, increasing the
     // count if the coefficients match.
     bool merge(const LoadJacobian &other) {
-        if (other.coeffs.size() != coeffs.size()) return false;
+        if (other.coeffs.size() != coeffs.size()) {
+            return false;
+        }
         for (size_t i = 0; i < coeffs.size(); i++) {
-            if (other.coeffs[i].size() != coeffs[i].size()) return false;
+            if (other.coeffs[i].size() != coeffs[i].size()) {
+                return false;
+            }
             for (size_t j = 0; j < coeffs[i].size(); j++) {
-                if (!(other.coeffs[i][j] == coeffs[i][j])) return false;
+                if (!(other.coeffs[i][j] == coeffs[i][j])) {
+                    return false;
+                }
             }
         }
         c += other.count();
@@ -459,7 +479,7 @@ struct FunctionDAG {
             };
 
             Stage(Halide::Stage s)
-                : stage(s) {
+                : stage(std::move(s)) {
             }
         };
         vector<Stage> stages;

--- a/src/autoschedulers/adams2019/PerfectHashMap.h
+++ b/src/autoschedulers/adams2019/PerfectHashMap.h
@@ -121,7 +121,9 @@ class PerfectHashMap {
     int find_index_small(const K *n) const {
         int i;
         for (i = 0; i < (int)occupied; i++) {
-            if (storage_bucket(i).first == n) return i;
+            if (storage_bucket(i).first == n) {
+                return i;
+            }
         }
         return i;
     }
@@ -173,7 +175,9 @@ class PerfectHashMap {
     // Methods when the map is in the large state
     T &emplace_large(const K *n, T &&t) {
         auto &p = storage_bucket(n->id);
-        if (!p.first) occupied++;
+        if (!p.first) {
+            occupied++;
+        }
         p.first = n;
         p.second = std::move(t);
         return p.second;
@@ -380,11 +384,15 @@ public:
     };
 
     iterator begin() {
-        if (state == Empty) return end();
+        if (state == Empty) {
+            return end();
+        }
         iterator it;
         it.iter = storage.data();
         it.end = it.iter + storage.size();
-        if (it.key() == nullptr) it++;
+        if (it.key() == nullptr) {
+            it++;
+        }
         phm_assert(it.iter == it.end || it.key());
         return it;
     }
@@ -396,11 +404,15 @@ public:
     }
 
     const_iterator begin() const {
-        if (storage.empty()) return end();
+        if (storage.empty()) {
+            return end();
+        }
         const_iterator it;
         it.iter = storage.data();
         it.end = it.iter + storage.size();
-        if (it.key() == nullptr) it++;
+        if (it.key() == nullptr) {
+            it++;
+        }
         phm_assert(it.iter == it.end || it.key());
         return it;
     }

--- a/src/autoschedulers/adams2019/Weights.cpp
+++ b/src/autoschedulers/adams2019/Weights.cpp
@@ -41,38 +41,64 @@ void Weights::randomize(uint32_t seed) {
 bool Weights::load(std::istream &i) {
     uint32_t signature;
     i.read((char *)&signature, sizeof(signature));
-    if (i.fail() || signature != kSignature) return false;
+    if (i.fail() || signature != kSignature) {
+        return false;
+    }
 
     i.read((char *)&pipeline_features_version, sizeof(pipeline_features_version));
-    if (i.fail()) return false;
+    if (i.fail()) {
+        return false;
+    }
 
     i.read((char *)&schedule_features_version, sizeof(schedule_features_version));
-    if (i.fail()) return false;
+    if (i.fail()) {
+        return false;
+    }
 
     uint32_t buffer_count;
     i.read((char *)&buffer_count, sizeof(buffer_count));
-    if (i.fail() || buffer_count != 6) return false;
+    if (i.fail() || buffer_count != 6) {
+        return false;
+    }
 
     const auto load_one = [&i](Buffer<float> &buf) -> bool {
         uint32_t dimension_count;
         i.read((char *)&dimension_count, sizeof(dimension_count));
-        if (i.fail() || dimension_count != (uint32_t)buf.dimensions()) return false;
+        if (i.fail() || dimension_count != (uint32_t)buf.dimensions()) {
+            return false;
+        }
         for (uint32_t d = 0; d < dimension_count; d++) {
             uint32_t extent;
             i.read((char *)&extent, sizeof(extent));
-            if (i.fail() || (int)extent != (int)buf.extent(d)) return false;
+            if (i.fail() || (int)extent != (int)buf.extent(d)) {
+                return false;
+            }
         }
         i.read((char *)(buf.data()), buf.size_in_bytes());
-        if (i.fail()) return false;
+        if (i.fail()) {
+            return false;
+        }
         return true;
     };
 
-    if (!load_one(head1_filter)) return false;
-    if (!load_one(head1_bias)) return false;
-    if (!load_one(head2_filter)) return false;
-    if (!load_one(head2_bias)) return false;
-    if (!load_one(conv1_filter)) return false;
-    if (!load_one(conv1_bias)) return false;
+    if (!load_one(head1_filter)) {
+        return false;
+    }
+    if (!load_one(head1_bias)) {
+        return false;
+    }
+    if (!load_one(head2_filter)) {
+        return false;
+    }
+    if (!load_one(head2_bias)) {
+        return false;
+    }
+    if (!load_one(conv1_filter)) {
+        return false;
+    }
+    if (!load_one(conv1_bias)) {
+        return false;
+    }
 
     return true;
 }
@@ -84,38 +110,64 @@ bool Weights::load_from_file(const std::string &filename) {
 bool Weights::save(std::ostream &o) const {
     const uint32_t signature = kSignature;
     o.write((const char *)&signature, sizeof(signature));
-    if (o.fail()) return false;
+    if (o.fail()) {
+        return false;
+    }
 
     o.write((const char *)&pipeline_features_version, sizeof(pipeline_features_version));
-    if (o.fail()) return false;
+    if (o.fail()) {
+        return false;
+    }
 
     o.write((const char *)&schedule_features_version, sizeof(schedule_features_version));
-    if (o.fail()) return false;
+    if (o.fail()) {
+        return false;
+    }
 
     const uint32_t buffer_count = 6;
     o.write((const char *)&buffer_count, sizeof(buffer_count));
-    if (o.fail()) return false;
+    if (o.fail()) {
+        return false;
+    }
 
     const auto save_one = [&o](const Buffer<float> &buf) -> bool {
         const uint32_t dimension_count = buf.dimensions();
         o.write((const char *)&dimension_count, sizeof(dimension_count));
-        if (o.fail()) return false;
+        if (o.fail()) {
+            return false;
+        }
         for (uint32_t d = 0; d < dimension_count; d++) {
             uint32_t extent = buf.extent(d);
             o.write((const char *)&extent, sizeof(extent));
-            if (o.fail()) return false;
+            if (o.fail()) {
+                return false;
+            }
         }
         o.write((const char *)(buf.data()), buf.size_in_bytes());
-        if (o.fail()) return false;
+        if (o.fail()) {
+            return false;
+        }
         return true;
     };
 
-    if (!save_one(head1_filter)) return false;
-    if (!save_one(head1_bias)) return false;
-    if (!save_one(head2_filter)) return false;
-    if (!save_one(head2_bias)) return false;
-    if (!save_one(conv1_filter)) return false;
-    if (!save_one(conv1_bias)) return false;
+    if (!save_one(head1_filter)) {
+        return false;
+    }
+    if (!save_one(head1_bias)) {
+        return false;
+    }
+    if (!save_one(head2_filter)) {
+        return false;
+    }
+    if (!save_one(head2_bias)) {
+        return false;
+    }
+    if (!save_one(conv1_filter)) {
+        return false;
+    }
+    if (!save_one(conv1_bias)) {
+        return false;
+    }
 
     return true;
 }
@@ -130,16 +182,30 @@ bool Weights::load_from_dir(const std::string &dir) {
         std::ifstream i(filename, std::ios_base::binary);
         i.read((char *)(buf.data()), buf.size_in_bytes());
         i.close();
-        if (i.fail()) return false;
+        if (i.fail()) {
+            return false;
+        }
         return true;
     };
 
-    if (!buffer_from_file(dir + "/head1_conv1_weight.data", head1_filter)) return false;
-    if (!buffer_from_file(dir + "/head1_conv1_bias.data", head1_bias)) return false;
-    if (!buffer_from_file(dir + "/head2_conv1_weight.data", head2_filter)) return false;
-    if (!buffer_from_file(dir + "/head2_conv1_bias.data", head2_bias)) return false;
-    if (!buffer_from_file(dir + "/trunk_conv1_weight.data", conv1_filter)) return false;
-    if (!buffer_from_file(dir + "/trunk_conv1_bias.data", conv1_bias)) return false;
+    if (!buffer_from_file(dir + "/head1_conv1_weight.data", head1_filter)) {
+        return false;
+    }
+    if (!buffer_from_file(dir + "/head1_conv1_bias.data", head1_bias)) {
+        return false;
+    }
+    if (!buffer_from_file(dir + "/head2_conv1_weight.data", head2_filter)) {
+        return false;
+    }
+    if (!buffer_from_file(dir + "/head2_conv1_bias.data", head2_bias)) {
+        return false;
+    }
+    if (!buffer_from_file(dir + "/trunk_conv1_weight.data", conv1_filter)) {
+        return false;
+    }
+    if (!buffer_from_file(dir + "/trunk_conv1_bias.data", conv1_bias)) {
+        return false;
+    }
 
     // Old style data doesn't record the versions, so just assume they are current
     pipeline_features_version = PipelineFeatures::version();
@@ -153,16 +219,30 @@ bool Weights::save_to_dir(const std::string &dir) const {
         std::ofstream o(filename, std::ios_base::trunc | std::ios_base::binary);
         o.write((const char *)(buf.data()), buf.size_in_bytes());
         o.close();
-        if (o.fail()) return false;
+        if (o.fail()) {
+            return false;
+        }
         return true;
     };
 
-    if (!buffer_to_file(head1_filter, dir + "/head1_conv1_weight.data")) return false;
-    if (!buffer_to_file(head1_bias, dir + "/head1_conv1_bias.data")) return false;
-    if (!buffer_to_file(head2_filter, dir + "/head2_conv1_weight.data")) return false;
-    if (!buffer_to_file(head2_bias, dir + "/head2_conv1_bias.data")) return false;
-    if (!buffer_to_file(conv1_filter, dir + "/trunk_conv1_weight.data")) return false;
-    if (!buffer_to_file(conv1_bias, dir + "/trunk_conv1_bias.data")) return false;
+    if (!buffer_to_file(head1_filter, dir + "/head1_conv1_weight.data")) {
+        return false;
+    }
+    if (!buffer_to_file(head1_bias, dir + "/head1_conv1_bias.data")) {
+        return false;
+    }
+    if (!buffer_to_file(head2_filter, dir + "/head2_conv1_weight.data")) {
+        return false;
+    }
+    if (!buffer_to_file(head2_bias, dir + "/head2_conv1_bias.data")) {
+        return false;
+    }
+    if (!buffer_to_file(conv1_filter, dir + "/trunk_conv1_weight.data")) {
+        return false;
+    }
+    if (!buffer_to_file(conv1_bias, dir + "/trunk_conv1_bias.data")) {
+        return false;
+    }
     return true;
 }
 

--- a/src/autoschedulers/adams2019/retrain_cost_model.cpp
+++ b/src/autoschedulers/adams2019/retrain_cost_model.cpp
@@ -84,8 +84,9 @@ struct Flags {
     std::vector<float> parse_floats(const std::string &s) {
         const char *c = s.c_str();
         std::vector<float> v;
-        while (isspace(*c))
+        while (isspace(*c)) {
             ++c;
+        }
         while (*c) {
             string f;
             while (*c && !isspace(*c)) {
@@ -131,10 +132,14 @@ uint64_t hash_floats(uint64_t h, const float *begin, const float *end) {
 }
 
 bool ends_with(const string &str, const string &suffix) {
-    if (str.size() < suffix.size()) return false;
+    if (str.size() < suffix.size()) {
+        return false;
+    }
     size_t off = str.size() - suffix.size();
     for (size_t i = 0; i < suffix.size(); i++) {
-        if (str[off + i] != suffix[i]) return false;
+        if (str[off + i] != suffix[i]) {
+            return false;
+        }
     }
     return true;
 }
@@ -433,7 +438,9 @@ int main(int argc, char **argv) {
                     auto &tp = tpp[model];
 
                     for (auto &p : train ? samples : validation_set) {
-                        if (kModels > 1 && rng() & 1) continue;  // If we are training multiple kModels, allow them to diverge.
+                        if (kModels > 1 && rng() & 1) {
+                            continue;  // If we are training multiple kModels, allow them to diverge.
+                        }
                         if (p.second.schedules.size() < 8) {
                             continue;
                         }
@@ -491,10 +498,14 @@ int main(int argc, char **argv) {
                             int good = 0, bad = 0;
                             for (auto &sched : p.second.schedules) {
                                 auto &ref = p.second.schedules[p.second.fastest_schedule_hash];
-                                if (sched.second.prediction[model] == 0) continue;
+                                if (sched.second.prediction[model] == 0) {
+                                    continue;
+                                }
                                 assert(sched.second.runtimes[0] >= ref.runtimes[0]);
                                 float runtime_ratio = sched.second.runtimes[0] / ref.runtimes[0];
-                                if (runtime_ratio <= 1.3f) continue;  // Within 30% of the runtime of the best
+                                if (runtime_ratio <= 1.3f) {
+                                    continue;  // Within 30% of the runtime of the best
+                                }
                                 if (sched.second.prediction[model] >= ref.prediction[model]) {
                                     good++;
                                 } else {
@@ -535,7 +546,9 @@ int main(int argc, char **argv) {
                 loss_sum[model] *= 0.9f;
                 loss_sum_counter[model] *= 0.9f;
             }
-            if (kModels > 1) std::cout << "\n";
+            if (kModels > 1) {
+                std::cout << "\n";
+            }
             std::cout << " Rate: ";
             int best_model = 0;
             float best_rate = 0;
@@ -555,7 +568,9 @@ int main(int argc, char **argv) {
                 v_correct_ordering_rate_count[model] *= 0.9f;
             }
 
-            if (kModels > 1) std::cout << "\n";
+            if (kModels > 1) {
+                std::cout << "\n";
+            }
             if (samples.count(worst_miss_pipeline_id)) {
                 std::cout << " Worst: " << worst_miss << " " << leaf(samples[worst_miss_pipeline_id].schedules[worst_miss_schedule_id].filename) << "\n";
                 // samples[worst_miss_pipeline_id].schedules.erase(worst_miss_schedule_id);

--- a/src/autoschedulers/li2018/GradientAutoscheduler.cpp
+++ b/src/autoschedulers/li2018/GradientAutoscheduler.cpp
@@ -13,7 +13,7 @@ std::map<std::string, Box> inference_bounds(const std::vector<Function> &functio
     std::vector<Func> funcs;
     funcs.reserve(functions.size());
     for (const auto &f : functions) {
-        funcs.push_back(Func(f));
+        funcs.emplace_back(f);
     }
     return inference_bounds(funcs, output_bounds);
 }
@@ -69,7 +69,7 @@ void reorder_storage(Func func,
     schedule_source << ")\n";
 }
 
-void reorder_storage(Stage stage,
+void reorder_storage(const Stage &stage,
                      const std::vector<Var> &all_vars,
                      std::ostringstream &schedule_source) {
     internal_error << "Can't reorder storage of a stage.";
@@ -252,7 +252,7 @@ void parallelize_vars_and_rvars_gpu(
     std::vector<VarOrRVar> all_vars;
     all_vars.reserve(serial_rvars.size() + 4);
     for (RVar v : serial_rvars) {
-        all_vars.push_back(v);
+        all_vars.emplace_back(v);
     }
     if (!r_gpu_threads.empty()) {
         all_vars.emplace_back(RVar(r_gpu_threads));
@@ -444,7 +444,7 @@ void parallelize_vars_and_rvars_cpu(
     std::vector<VarOrRVar> all_vars;
     all_vars.reserve(serial_rvars.size() + 4);
     for (RVar v : serial_rvars) {
-        all_vars.push_back(v);
+        all_vars.emplace_back(v);
     }
     if (!vectorized_rvar.empty()) {
         all_vars.emplace_back(RVar(vectorized_rvar));
@@ -604,7 +604,7 @@ void apply_schedule(const MachineParams &params,
         std::vector<RVar> rvars;
         rvars.reserve(reduction_vars.size());
         for (ReductionVariable r : reduction_vars) {
-            rvars.push_back(RVar(r.var));
+            rvars.emplace_back(r.var);
         }
         int rdomain_size = 1;
         for (int b : rvar_bounds) {
@@ -672,7 +672,7 @@ void apply_schedule(const MachineParams &params,
                         interim_vars.reserve(outer_rvars.size());
                         for (RVar r : outer_rvars) {
                             Var v;
-                            preserved.push_back({r, v});
+                            preserved.emplace_back(r, v);
                             interim_vars.push_back(v);
                         }
 
@@ -741,7 +741,7 @@ void apply_schedule(const MachineParams &params,
                 !var->param.defined() &&
                 !var->image.defined() &&
                 !var->reduction_domain.defined()) {
-                pure_args.push_back(Var(var->name));
+                pure_args.emplace_back(var->name);
                 pure_arg_bounds.push_back(var_bounds[arg_id]);
                 parallelism *= pure_arg_bounds.back();
             }
@@ -887,9 +887,9 @@ void generate_schedule(const std::vector<Function> &outputs,
             user_assert(found && est.min.type().is_int() && est.extent.type().is_int())
                 << "Please provide a valid estimate for dimension "
                 << arg << " of output \"" << output.name() << "\"\n";
-            b.push_back(Interval(est.min, simplify(est.min + est.extent - 1)));
+            b.emplace_back(est.min, simplify(est.min + est.extent - 1));
         }
-        output_bounds_expr.push_back(Box(b));
+        output_bounds_expr.emplace_back(b);
     }
 
     std::map<std::string, Box> func_bounds = inference_bounds(outputs, output_bounds_expr);

--- a/tools/RunGen.h
+++ b/tools/RunGen.h
@@ -112,7 +112,9 @@ struct LogEmitter {
 
     ~LogEmitter() {
         std::string s = msg.str();
-        if (s.back() != '\n') s += '\n';
+        if (s.back() != '\n') {
+            s += '\n';
+        }
         f(s);
     }
 
@@ -734,13 +736,17 @@ struct ArgData {
 
         std::vector<std::string> v = split_string(raw_string, ":");
         if (v[0] == "zero") {
-            if (v.size() != 2) fail() << "Invalid syntax: " << raw_string;
+            if (v.size() != 2) {
+                fail() << "Invalid syntax: " << raw_string;
+            }
             auto shape = parse_optional_extents(v[1]);
             Buffer<> b = allocate_buffer(metadata->type, shape);
             memset(b.data(), 0, b.size_in_bytes());
             return b;
         } else if (v[0] == "constant") {
-            if (v.size() != 3) fail() << "Invalid syntax: " << raw_string;
+            if (v.size() != 3) {
+                fail() << "Invalid syntax: " << raw_string;
+            }
             halide_scalar_value_t value;
             if (!parse_scalar(metadata->type, v[1], &value)) {
                 fail() << "Invalid value for constant value";
@@ -750,7 +756,9 @@ struct ArgData {
             dynamic_type_dispatch<FillWithScalar>(metadata->type, b, value);
             return b;
         } else if (v[0] == "identity") {
-            if (v.size() != 2) fail() << "Invalid syntax: " << raw_string;
+            if (v.size() != 2) {
+                fail() << "Invalid syntax: " << raw_string;
+            }
             auto shape = parse_optional_extents(v[1]);
             // Make a binary buffer with diagonal elements set to true. Diagonal
             // elements are those whose first two dimensions are equal.
@@ -761,7 +769,9 @@ struct ArgData {
             // Convert the binary buffer to the required type, so true becomes 1.
             return Halide::Tools::ImageTypeConversion::convert_image(b, metadata->type);
         } else if (v[0] == "random") {
-            if (v.size() != 3) fail() << "Invalid syntax: " << raw_string;
+            if (v.size() != 3) {
+                fail() << "Invalid syntax: " << raw_string;
+            }
             int seed;
             if (!parse_scalar(v[1], &seed)) {
                 fail() << "Invalid value for seed";
@@ -1014,7 +1024,9 @@ public:
                 if (!values.empty()) {
                     bool set = false;
                     for (auto &v : values) {
-                        if (!v.first) continue;
+                        if (!v.first) {
+                            continue;
+                        }
                         info() << "Argument value for: " << arg.metadata->name << " is parsed from metadata (" << v.second << ") as: "
                                << scalar_to_string(arg.metadata->type, *v.first);
                         arg.scalar_value = *v.first;

--- a/tools/binary2cpp.cpp
+++ b/tools/binary2cpp.cpp
@@ -45,7 +45,9 @@ int main(int argc, const char **argv) {
     int line_break = 0;
     while (1) {
         int c = getchar();
-        if (c == EOF) break;
+        if (c == EOF) {
+            break;
+        }
         printf("0x%02x, ", c);
         // Not necessary, but makes a bit easier to read
         if (++line_break > 12) {

--- a/tools/build_halide_h.cpp
+++ b/tools/build_halide_h.cpp
@@ -8,7 +8,9 @@
 std::set<std::string> done;
 
 void dump_header(const std::string &header) {
-    if (done.find(header) != done.end()) return;
+    if (done.find(header) != done.end()) {
+        return;
+    }
     done.insert(header);
 
     if (header.find("runtime_internal") != std::string::npos) {
@@ -32,12 +34,15 @@ void dump_header(const std::string &header) {
         if (strncmp(line, include_str, include_str_len) == 0) {
             char *sub_header = line + include_str_len;
             for (int i = 0; i < line_len - include_str_len; i++) {
-                if (sub_header[i] == '"') sub_header[i] = 0;
+                if (sub_header[i] == '"') {
+                    sub_header[i] = 0;
+                }
             }
             size_t slash_pos = header.rfind('/');
             std::string path;
-            if (slash_pos != std::string::npos)
+            if (slash_pos != std::string::npos) {
                 path = header.substr(0, slash_pos + 1);
+            }
             dump_header(path + sub_header);
         } else {
             fputs(line, stdout);

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -1588,8 +1588,9 @@ bool save_mat(ImageType &im, const std::string &filename) {
     }
 
     uint32_t name_size = (int)name.size();
-    while (name.size() & 0x7)
+    while (name.size() & 0x7) {
         name += '\0';
+    }
 
     char header[128] = "MATLAB 5.0 MAT-file, produced by Halide";
     int len = strlen(header);
@@ -1763,7 +1764,9 @@ struct ElemWriter {
     }
 
     void operator()(const ElemType &elem) {
-        if (!ok) return;
+        if (!ok) {
+            return;
+        }
 
         *next++ = elem;
         if (next == &buf[BUFFER_SIZE]) {
@@ -1772,7 +1775,9 @@ struct ElemWriter {
     }
 
     void flush() {
-        if (!ok) return;
+        if (!ok) {
+            return;
+        }
 
         if (next > buf) {
             if (!f->write_bytes(buf, (next - buf) * sizeof(ElemType))) {

--- a/tools/halide_trace_config.h
+++ b/tools/halide_trace_config.h
@@ -208,18 +208,42 @@ struct FuncConfig {
     // -- if it has a well-defined value, replace the corresponding field in 'this'
     // -- if it does not have a well-defined value, leave untouched the corresponding field in 'this'
     void merge_from(const FuncConfig &from) {
-        if (from.zoom >= 0.f) this->zoom = from.zoom;
-        if (from.load_cost >= 0) this->load_cost = from.load_cost;
-        if (from.store_cost > 0) this->store_cost = from.store_cost;
-        if (from.pos.x > std::numeric_limits<int>::lowest()) this->pos.x = from.pos.x;
-        if (from.pos.y > std::numeric_limits<int>::lowest()) this->pos.y = from.pos.y;
-        if (!from.strides.empty()) this->strides = from.strides;
-        if (from.color_dim >= -1) this->color_dim = from.color_dim;
-        if (!std::isnan(from.min)) this->min = from.min;
-        if (!std::isnan(from.max)) this->max = from.max;
-        if (!from.labels.empty()) this->labels = from.labels;
-        if (from.blank_on_end_realization >= 0) this->blank_on_end_realization = from.blank_on_end_realization;
-        if (!(from.uninitialized_memory_color & 0xff000000)) this->uninitialized_memory_color = from.uninitialized_memory_color;
+        if (from.zoom >= 0.f) {
+            this->zoom = from.zoom;
+        }
+        if (from.load_cost >= 0) {
+            this->load_cost = from.load_cost;
+        }
+        if (from.store_cost > 0) {
+            this->store_cost = from.store_cost;
+        }
+        if (from.pos.x > std::numeric_limits<int>::lowest()) {
+            this->pos.x = from.pos.x;
+        }
+        if (from.pos.y > std::numeric_limits<int>::lowest()) {
+            this->pos.y = from.pos.y;
+        }
+        if (!from.strides.empty()) {
+            this->strides = from.strides;
+        }
+        if (from.color_dim >= -1) {
+            this->color_dim = from.color_dim;
+        }
+        if (!std::isnan(from.min)) {
+            this->min = from.min;
+        }
+        if (!std::isnan(from.max)) {
+            this->max = from.max;
+        }
+        if (!from.labels.empty()) {
+            this->labels = from.labels;
+        }
+        if (from.blank_on_end_realization >= 0) {
+            this->blank_on_end_realization = from.blank_on_end_realization;
+        }
+        if (!(from.uninitialized_memory_color & 0xff000000)) {
+            this->uninitialized_memory_color = from.uninitialized_memory_color;
+        }
     }
 
     static std::string tag_start_text() {

--- a/util/HalideTraceUtils.cpp
+++ b/util/HalideTraceUtils.cpp
@@ -31,7 +31,9 @@ bool Packet::read_from_filedesc(FILE *fdesc) {
 
 bool Packet::read(void *d, size_t size, FILE *fdesc) {
     uint8_t *dst = (uint8_t *)d;
-    if (!size) return true;
+    if (!size) {
+        return true;
+    }
     size_t s = fread(dst, 1, size, fdesc);
     if (s != size) {
         if (ferror(fdesc) || !feof(fdesc)) {

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -999,7 +999,9 @@ public:
                     int px = pos.x + (((inconsolata_char_width * c + fx) * h_scale_numerator) >> 8);
                     int py = pos.y - inconsolata_char_height + fy + 1;
                     if (px < 0 || px >= frame_size.x ||
-                        py < 0 || py >= frame_size.y) continue;
+                        py < 0 || py >= frame_size.y) {
+                        continue;
+                    }
                     dst[py * frame_size.x + px] = (font_ptr[fy * inconsolata_char_width + fx] << 24) | color;
                 }
             }
@@ -1069,7 +1071,9 @@ int run(bool ignore_trace_tags, FlagProcessor flag_processor) {
     std::unique_ptr<Surface> surface;
 
     const std::function<void()> finalize_state = [&]() -> void {
-        if (is_state_finalized) return;
+        if (is_state_finalized) {
+            return;
+        }
 
         is_state_finalized = true;
 
@@ -1094,7 +1098,9 @@ int run(bool ignore_trace_tags, FlagProcessor flag_processor) {
         if (state.globals.auto_layout_grid.x < 0 || state.globals.auto_layout_grid.y < 0) {
             int cells_needed = 0;
             for (const auto &p : state.funcs) {
-                if (p.second.type_and_dim_valid) cells_needed++;
+                if (p.second.type_and_dim_valid) {
+                    cells_needed++;
+                }
             }
             Point cell_size = best_cell_size(cells_needed, state.globals.frame_size.x, state.globals.frame_size.y);
             state.globals.auto_layout_grid.x = state.globals.frame_size.x / cell_size.x;
@@ -1153,7 +1159,9 @@ int run(bool ignore_trace_tags, FlagProcessor flag_processor) {
                     int frames_since_first_draw = (halide_clock - first_draw_clock) / state.globals.timestep;
                     if (frames_since_first_draw < label.fade_in_frames) {
                         uint32_t color = ((1 + frames_since_first_draw) * 255) / std::max(1, label.fade_in_frames);
-                        if (color > 255) color = 255;
+                        if (color > 255) {
+                            color = 255;
+                        }
                         color *= 0x10101;
                         surface->draw_text(label.text, label.pos, color, label.h_scale);
                         ++it;
@@ -1266,7 +1274,9 @@ int run(bool ignore_trace_tags, FlagProcessor flag_processor) {
 
         // Draw the event
         FuncInfo &fi = state.funcs[qualified_name];
-        if (!fi.config_valid) continue;
+        if (!fi.config_valid) {
+            continue;
+        }
 
         if (fi.stats.first_draw_time < 0) {
             fi.stats.first_draw_time = halide_clock;


### PR DESCRIPTION
(and also fix the reported findings)

Note that this also extends the testing to src/autoschedulers, but *not* to src/runtime (yet). It would likely be desirable to do so at some point, but requires a bit more massaging of the build scripts.

Extending to apps/ and test/ might be nice, but would require running all Generators to produce the needed .h files.