### PR TITLE
Handle more types of nested vectorized += without scalarizing

### DIFF
--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -182,11 +182,17 @@ Interval bounds_of_lanes(const Expr &e) {
     }
 };
 
-// A ramp with the lanes repeated (e.g. <0 0 2 2 4 4 6 6>)
+// A ramp with the lanes repeated inner_repetitions times, and then
+// the whole vector repeated outer_repetitions times.
+// E.g: <0 0 2 2 4 4 6 6 0 0 2 2 4 4 6 6>.
 struct InterleavedRamp {
     Expr base, stride;
-    int lanes, repetitions;
+    int lanes, inner_repetitions, outer_repetitions;
 };
+
+bool equal_or_zero(int a, int b) {
+    return a == 0 || b == 0 || a == b;
+}
 
 bool is_interleaved_ramp(const Expr &e, const Scope<Expr> &scope, InterleavedRamp *result) {
     if (const Ramp *r = e.as<Ramp>()) {
@@ -196,13 +202,16 @@ bool is_interleaved_ramp(const Expr &e, const Scope<Expr> &scope, InterleavedRam
             result->base = r->base;
             result->stride = r->stride;
             result->lanes = r->lanes;
-            result->repetitions = 1;
+            result->inner_repetitions = 1;
+            result->outer_repetitions = 1;
             return true;
         } else if (b_base && b_stride && b_base->lanes == b_stride->lanes) {
+            // Ramp of broadcast
             result->base = b_base->value;
             result->stride = b_stride->value;
             result->lanes = r->lanes;
-            result->repetitions = b_base->lanes;
+            result->inner_repetitions = b_base->lanes;
+            result->outer_repetitions = 1;
             return true;
         }
     } else if (const Broadcast *b = e.as<Broadcast>()) {
@@ -210,35 +219,36 @@ bool is_interleaved_ramp(const Expr &e, const Scope<Expr> &scope, InterleavedRam
             result->base = b->value;
             result->stride = 0;
             result->lanes = b->lanes;
-            result->repetitions = 0;
+            result->inner_repetitions = 0;
+            result->outer_repetitions = 0;
+            return true;
+        } else if (is_interleaved_ramp(b->value, scope, result)) {
+            // Broadcast of interleaved ramp
+            result->outer_repetitions *= b->lanes;
             return true;
         }
     } else if (const Add *add = e.as<Add>()) {
         InterleavedRamp ra;
         if (is_interleaved_ramp(add->a, scope, &ra) &&
             is_interleaved_ramp(add->b, scope, result) &&
-            (ra.repetitions == 0 ||
-             result->repetitions == 0 ||
-             ra.repetitions == result->repetitions)) {
+            equal_or_zero(ra.inner_repetitions, result->inner_repetitions) &&
+            equal_or_zero(ra.outer_repetitions, result->outer_repetitions)) {
             result->base = simplify(result->base + ra.base);
             result->stride = simplify(result->stride + ra.stride);
-            if (!result->repetitions) {
-                result->repetitions = ra.repetitions;
-            }
+            result->inner_repetitions = std::max(result->inner_repetitions, ra.inner_repetitions);
+            result->outer_repetitions = std::max(result->outer_repetitions, ra.outer_repetitions);
             return true;
         }
     } else if (const Sub *sub = e.as<Sub>()) {
         InterleavedRamp ra;
         if (is_interleaved_ramp(sub->a, scope, &ra) &&
             is_interleaved_ramp(sub->b, scope, result) &&
-            (ra.repetitions == 0 ||
-             result->repetitions == 0 ||
-             ra.repetitions == result->repetitions)) {
+            equal_or_zero(ra.inner_repetitions, result->inner_repetitions) &&
+            equal_or_zero(ra.outer_repetitions, result->outer_repetitions)) {
             result->base = simplify(ra.base - result->base);
             result->stride = simplify(ra.stride - result->stride);
-            if (!result->repetitions) {
-                result->repetitions = ra.repetitions;
-            }
+            result->inner_repetitions = std::max(result->inner_repetitions, ra.inner_repetitions);
+            result->outer_repetitions = std::max(result->outer_repetitions, ra.outer_repetitions);
             return true;
         }
     } else if (const Mul *mul = e.as<Mul>()) {
@@ -254,14 +264,27 @@ bool is_interleaved_ramp(const Expr &e, const Scope<Expr> &scope, InterleavedRam
         if (is_interleaved_ramp(div->a, scope, result) &&
             (b = as_const_int(div->b)) &&
             is_one(result->stride) &&
-            (result->repetitions == 1 ||
-             result->repetitions == 0) &&
+            (result->inner_repetitions == 1 ||
+             result->inner_repetitions == 0) &&
             can_prove((result->base % (int)(*b)) == 0)) {
             // TODO: Generalize this. Currently only matches
             // ramp(base*b, 1, lanes) / b
             // broadcast(base * b, lanes) / b
             result->base = simplify(result->base / (int)(*b));
-            result->repetitions *= (int)(*b);
+            result->inner_repetitions *= (int)(*b);
+            return true;
+        }
+    } else if (const Mod *mod = e.as<Mod>()) {
+        const int64_t *b = nullptr;
+        if (is_interleaved_ramp(mod->a, scope, result) &&
+            (b = as_const_int(mod->b)) &&
+            (result->outer_repetitions == 1 ||
+             result->outer_repetitions == 0) &&
+            can_prove(((int)(*b) % result->stride) == 0)) {
+            // ramp(base, 2, lanes) % 8
+            result->base = simplify(result->base % (int)(*b));
+            result->stride = simplify(result->stride % (int)(*b));
+            result->outer_repetitions *= (int)(*b);
             return true;
         }
     } else if (const Variable *var = e.as<Variable>()) {
@@ -1167,7 +1190,8 @@ class VectorSubs : public IRMutator {
                 test = simplify(load_index == store_index);
             } else if (is_interleaved_ramp(store_index, vector_scope, &store_ir) &&
                        is_interleaved_ramp(load_index, vector_scope, &load_ir) &&
-                       store_ir.repetitions == load_ir.repetitions &&
+                       store_ir.inner_repetitions == load_ir.inner_repetitions &&
+                       store_ir.outer_repetitions == load_ir.outer_repetitions &&
                        store_ir.lanes == load_ir.lanes) {
                 test = simplify(store_ir.base == load_ir.base &&
                                 store_ir.stride == load_ir.stride);
@@ -1192,10 +1216,42 @@ class VectorSubs : public IRMutator {
                 b = VectorReduce::make(reduce_op, b, 1);
             } else {
 
-                output_lanes = store_index.type().lanes() / store_ir.repetitions;
+                output_lanes = store_index.type().lanes() / (store_ir.inner_repetitions * store_ir.outer_repetitions);
 
                 store_index = Ramp::make(store_ir.base, store_ir.stride, output_lanes / store_ir.base.type().lanes());
-                b = VectorReduce::make(reduce_op, b, output_lanes);
+                if (store_ir.inner_repetitions > 1) {
+                    b = VectorReduce::make(reduce_op, b, output_lanes * store_ir.outer_repetitions);
+                }
+
+                // Handle outer repetitions by unrolling the reduction
+                // over slices.
+                if (store_ir.outer_repetitions > 1) {
+                    Expr v = Shuffle::make_slice(b, 0, 1, output_lanes);
+                    for (int i = 1; i < store_ir.outer_repetitions; i++) {
+                        Expr slice = simplify(Shuffle::make_slice(b, i * output_lanes, 1, output_lanes));
+                        switch (reduce_op) {
+                        case VectorReduce::Add:
+                            v += slice;
+                            break;
+                        case VectorReduce::Mul:
+                            v *= slice;
+                            break;
+                        case VectorReduce::Min:
+                            v = min(v, slice);
+                            break;
+                        case VectorReduce::Max:
+                            v = max(v, slice);
+                            break;
+                        case VectorReduce::And:
+                            v = v && slice;
+                            break;
+                        case VectorReduce::Or:
+                            v = v || slice;
+                            break;
+                        }
+                    }
+                    b = v;
+                }
             }
 
             Expr new_load = Load::make(load_a->type.with_lanes(output_lanes),

--- a/test/correctness/fuse.cpp
+++ b/test/correctness/fuse.cpp
@@ -44,6 +44,16 @@ int main(int argc, char **argv) {
         }
     }
 
+    class CheckForMod : public Internal::IRMutator {
+        using IRMutator::visit;
+
+        Expr visit(const Internal::Mod *op) override {
+            std::cerr << "Found mod: " << Expr(op) << "\n";
+            exit(-1);
+            return op;
+        }
+    };
+
     {
         ImageParam p(Int(32), 2);
         Func f;
@@ -64,15 +74,57 @@ int main(int argc, char **argv) {
             .fuse(x, y, xy)
             .vectorize(xy, 16);
 
-        class CheckForMod : public Internal::IRMutator {
-            using IRMutator::visit;
+        f.add_custom_lowering_pass(new CheckForMod);
+        f.compile_jit();
+    }
 
-            Expr visit(const Internal::Mod *op) override {
-                std::cerr << "Found mod: " << Expr(op) << "\n";
-                exit(-1);
-                return op;
-            }
-        };
+    // Test two cases where the fuse arithmetic should vanish due to nested vectorization
+
+    // The first case should turn into a sum of slices of a vector
+    {
+        ImageParam p(Int(32), 2);
+        RDom r(0, 2);
+        Func f;
+
+        f(x) += p(x, r);
+
+        f.output_buffer().dim(0).set_bounds(0, 8);
+        p.dim(0).set_bounds(0, 8);
+        p.dim(1).set_stride(8);
+
+        // Fuse and vectorize x and y.
+        RVar rx;
+        f.compute_root()
+            .update()
+            .reorder(x, r)  // x is inside r, so this is a sum of slices
+            .fuse(x, r, rx)
+            .atomic()
+            .vectorize(rx);
+
+        f.add_custom_lowering_pass(new CheckForMod);
+        f.compile_jit();
+    }
+
+    // The second case should turn into a vector reduce instruction, with no modulo in the indexing
+    {
+        ImageParam p(Int(32), 2);
+        RDom r(0, 2);
+        Func f;
+
+        f(x) += p(x, r);
+
+        f.output_buffer().dim(0).set_bounds(0, 8);
+        p.dim(0).set_bounds(0, 8);
+        p.dim(1).set_stride(8);
+
+        // Fuse and vectorize x and y.
+        RVar rx;
+        f.compute_root()
+            .update()
+            .reorder(r, x)
+            .fuse(r, x, rx)  // r is inside x, so this is a vector reduce
+            .atomic()
+            .vectorize(rx);
 
         f.add_custom_lowering_pass(new CheckForMod);
         f.compile_jit();

--- a/test/performance/nested_vectorization_gemm.cpp
+++ b/test/performance/nested_vectorization_gemm.cpp
@@ -286,7 +286,7 @@ int main(int argc, char **argv) {
         }
 
         double speed_up = times[0] / times[1];
-        printf("8-bit blur with reduction dimension outermost vector dim\n"
+        printf("16-bit blur with reduction dimension outermost vector dim\n"
                "Time with nested vectorization: %0.2f ms \n"
                "Time without: %0.2f ms \n"
                "Speed-up: %0.2fx\n",

--- a/test/performance/nested_vectorization_gemm.cpp
+++ b/test/performance/nested_vectorization_gemm.cpp
@@ -219,6 +219,85 @@ int main(int argc, char **argv) {
         }
     }
 
+    // 16-bit blur into 32-bit accumulator, with reduction over
+    // adjacent vector lanes at the same time as reduction over slices
+    // of the vector
+    {
+
+        double times[2];
+
+        for (int use_nested_vectorization = 0; use_nested_vectorization < 2; use_nested_vectorization++) {
+            Var x, y;
+
+            ImageParam f(Int(16), 1), g(Int(16), 1);
+
+            RDom r(0, 128);
+            Func prod;
+            prod(x) += cast<int32_t>(f(x + r)) * g(r);
+
+            Func result;
+            result(x) = cast<int16_t>(prod(x) >> 16);
+
+            RVar ro, ri, rio, rii;
+
+            f.in().compute_at(prod, ro).vectorize(_0).bound_extent(_0, 16);
+            g.in().compute_at(prod, ro).vectorize(_0);
+
+            result
+                .vectorize(x, 8, TailStrategy::RoundUp);
+
+            if (use_nested_vectorization) {
+                prod.compute_at(result, x)
+                    .vectorize(x)
+                    .update()
+                    .split(r, ro, ri, 8)
+                    .split(ri, rio, rii, 2)
+                    .reorder(rii, x, rio, ro)
+                    .vectorize(x)
+                    .atomic()
+                    .vectorize(rio)
+                    .vectorize(rii);
+            } else {
+                prod.compute_at(result, x)
+                    .vectorize(x)
+                    .update()
+                    .split(r, ro, ri, 8)
+                    .reorder(ri, x, ro)
+                    .vectorize(x)
+                    .unroll(ri);
+            }
+
+            Buffer<int16_t> f_buf(1024 * 1024);
+            f_buf.fill(100);
+            Buffer<int16_t> g_buf(128);
+            f_buf.fill(100);
+            f.set(f_buf);
+            g.set(g_buf);
+            Buffer<int16_t> out(f_buf.width() - g_buf.width() - 128);
+
+            // Uncomment to check the asm
+            // result.compile_to_assembly("/dev/stdout", {f, g}, target);
+
+            times[use_nested_vectorization] =
+                Tools::benchmark(10, 10, [&]() {
+                    result.realize(out);
+                    out.device_sync();
+                });
+        }
+
+        double speed_up = times[0] / times[1];
+        printf("8-bit blur with reduction dimension outermost vector dim\n"
+               "Time with nested vectorization: %0.2f ms \n"
+               "Time without: %0.2f ms \n"
+               "Speed-up: %0.2fx\n",
+               times[1] * 1000,
+               times[0] * 1000,
+               speed_up);
+        if (speed_up < 0.5) {
+            printf("The nested vectorization schedule was supposed to be faster!\n");
+            return -1;
+        }
+    }
     printf("Success!\n");
 
     return 0;

--- a/test/performance/nested_vectorization_gemm.cpp
+++ b/test/performance/nested_vectorization_gemm.cpp
@@ -240,17 +240,20 @@ int main(int argc, char **argv) {
 
             RVar ro, ri, rio, rii;
 
-            f.in().compute_at(prod, ro).vectorize(_0).bound_extent(_0, 16);
-            g.in().compute_at(prod, ro).vectorize(_0);
-
             result
-                .vectorize(x, 8, TailStrategy::RoundUp);
+                .vectorize(x, 16, TailStrategy::RoundUp);
 
             if (use_nested_vectorization) {
+                f.in().compute_at(prod, ro).vectorize(_0).bound_extent(_0, 32);
+
+                // It's faster to compute this at rio and unroll rio,
+                // but that's not what we're testing.
+                g.in().compute_at(prod, ro).vectorize(_0);
+
                 prod.compute_at(result, x)
                     .vectorize(x)
                     .update()
-                    .split(r, ro, ri, 8)
+                    .split(r, ro, ri, 4)
                     .split(ri, rio, rii, 2)
                     .reorder(rii, x, rio, ro)
                     .vectorize(x)
@@ -261,7 +264,7 @@ int main(int argc, char **argv) {
                 prod.compute_at(result, x)
                     .vectorize(x)
                     .update()
-                    .split(r, ro, ri, 8)
+                    .split(r, ro, ri, 4)
                     .reorder(ri, x, ro)
                     .vectorize(x)
                     .unroll(ri);

--- a/test/performance/nested_vectorization_gemm.cpp
+++ b/test/performance/nested_vectorization_gemm.cpp
@@ -221,8 +221,8 @@ int main(int argc, char **argv) {
 
     // 16-bit blur into 32-bit accumulator, with reduction over
     // adjacent vector lanes at the same time as reduction over slices
-    // of the vector
-    {
+    // of the vector. This is only a win on platforms with a pmaddwd-like instruction.
+    if (target.arch == Target::X86) {
 
         double times[2];
 


### PR DESCRIPTION
With this change, in a nesting of vectorized vars in an
associative/commutative reduction (e.g. +=), we can now have a reduction
var outermost and a reduction var innermost and get good codegen. This
is still not fully general - there can only be one pure var in the
vectorized stack for it to work. In general is_interleaved_ramp should
be an is_tensor_contraction pass that knows how to do clever codegen for
those.

For the following schedule for a 16-bit large convolution:

```
prod.compute_at(result, x)
  .vectorize(x)
  .update()
  .split(r, ro, ri, 8)
  .split(ri, rio, rii, 2)
  .reorder(rii, x, rio, ro)
  .vectorize(x)
  .atomic()
  .vectorize(rio)
  .vectorize(rii);
```

We get the following IR:

```
let t2262 = (int32x32)vector_reduce(Add, (int32x64(shuffle((int16x15)p10_im_global_wrapper$0[ramp(0, 1, 15)], 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14)) *
                                          int32x64(shuffle((int16x8)p11_im_global_wrapper$0[ramp(0, 1, 8)], 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 4, 5, 4, 5, 4, 5, 4, 5, 4, 5, 4, 5, 4, 5, 4, 5, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7))))

f58[ramp(0, 1, 8)] = slice_vectors(t2262, 8, 1, 8) + (slice_vectors(t2262, 0, 1, 8) + (slice_vectors(t2262, 16, 1, 8) + (slice_vectors(t2262, 24, 1, 8) + f58[ramp(0, 1, 8)])))

```

The vector_reduce is from rii, and the sum of slice_vectors is from rio.

The generated asm (for avx512) is:

```
	leal	(%rbx,%rcx), %edx
	movslq	%edx, %rdx
	subq	%r14, %rdx
	vmovdqu	(%r15,%rcx,2), %xmm6
	vbroadcasti64x4	(%r12,%rdx,2), %zmm7 # zmm7 = mem[0,1,2,3,0,1,2,3]
	vpermw	%zmm7, %zmm0, %zmm8
	vpermw	%zmm7, %zmm1, %zmm7
	vpermd	%zmm6, %zmm2, %zmm6
	vpermd	%zmm6, %zmm3, %zmm9
	vpmaddwd	%zmm9, %zmm8, %zmm8
	vpermd	%zmm6, %zmm4, %zmm6
	vpmaddwd	%zmm6, %zmm7, %zmm6
	vextracti64x4	$1, %zmm6, %ymm7
	vextracti64x4	$1, %zmm8, %ymm9
	vpaddd	%ymm5, %ymm8, %ymm5
	vpaddd	%ymm6, %ymm5, %ymm5
	vpaddd	%ymm5, %ymm9, %ymm5
	vpaddd	%ymm7, %ymm5, %ymm5
	addq	$8, %rcx
	cmpq	$128, %rcx
```

The pmaddwds are from rii, and the vpaddds are from rio.

This is 3.5x faster than the best schedule that only vectorizes the pure
var, and about 2x faster than the best schedule that only vectorizes the 
pure var and an unsplit reduction variable.