### PR TITLE
Make loop partitioning a bit more robust for if statements

### DIFF
--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -361,8 +361,7 @@ class FindSimplifications : public IRVisitor {
         // statement is marked as likely, treat it as likely true and
         // partition accordingly.
         IRVisitor::visit(op);
-        const Call *call = op->condition.as<Call>();
-        if (call && call->is_intrinsic(Call::likely)) {
+        if (has_likely_tag(op->condition)) {
             new_simplification(op->condition, op->condition, const_true(), const_false());
         }
     }

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -361,7 +361,7 @@ class FindSimplifications : public IRVisitor {
         // statement is marked as likely, treat it as likely true and
         // partition accordingly.
         IRVisitor::visit(op);
-        if (has_likely_tag(op->condition)) {
+        if (has_uncaptured_likely_tag(op->condition)) {
             new_simplification(op->condition, op->condition, const_true(), const_false());
         }
     }


### PR DESCRIPTION
The other visitors in FindSimplifications all use `has_likely_tag`, which searches expressions for `likely`. If did not however, which made loop partitioning brittle, e.g. in the case of `if ((uint1)likely(x))`.