### PR TITLE
Extend clang-tidy checks to src/runtime

### DIFF
--- a/src/runtime/.clang-tidy
+++ b/src/runtime/.clang-tidy
@@ -1,0 +1,32 @@
+# In clang-tidy-11 (or maybe clang-tidy-12) you can use
+#
+#  InheritParentConfig: true
+#
+# to just inherit from parent .clang-tidy files. Alas,
+# that isn't available in clang-tidy-10, so we must make copies
+# where specialization is needed.
+
+#
+# The desired change here is just to remove bugprone-sizeof-expression.
+#
+
+---
+Checks: >
+    -*,
+    bugprone-macro-parenthesis,
+    bugprone-parent-virtual-call,
+    -bugprone-sizeof-expression,
+    bugprone-string-constructor,
+    modernize-use-emplace,
+    modernize-use-override,
+    performance-move-const-arg,
+    performance-noexcept-move-constructor,
+    performance-trivially-destructible,
+    performance-unnecessary-copy-initialization,
+    performance-unnecessary-value-param,
+    readability-braces-around-statements
+
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*'
+FormatStyle: 'file'
+...

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -112,7 +112,7 @@ set(RUNTIME_LL
     x86
     x86_avx
     x86_avx2
-    x86_avx512    
+    x86_avx512
     x86_sse41
     )
 
@@ -217,14 +217,23 @@ foreach (i IN LISTS RUNTIME_CPP)
                 set(dep_args "")
             endif ()
 
-            add_custom_command(OUTPUT "${LL}"
-                               COMMAND clang ${clang_flags} -o "${ll_path}" "$<SHELL_PATH:${SOURCE}>"
-                               DEPENDS "${SOURCE}"
-                               # Note: IMPLICIT_DEPENDS only works for Makefile generators, ${dep_args} handles Ninja.
-                               IMPLICIT_DEPENDS CXX "${SOURCE}"
-                               WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
-                               ${dep_args}
-                               VERBATIM)
+            if (CMAKE_EXPORT_COMPILE_COMMANDS)
+                # Create a 'fake' entry just so that clang-tidy will see a C++ compilation command
+                # that it can use for tidy-checking. (This branch should never be taken by 'normal'
+                # compilations.)
+                add_library(${basename} STATIC "${SOURCE}")
+                target_compile_options(${basename} PRIVATE ${RUNTIME_CXX_FLAGS} ${fpic} -m${j} -target ${TARGET})
+                target_compile_definitions(${basename} PRIVATE ${RUNTIME_DEFINES})
+            else()
+                add_custom_command(OUTPUT "${LL}"
+                                   COMMAND clang ${clang_flags} -o "${ll_path}" "$<SHELL_PATH:${SOURCE}>"
+                                   DEPENDS "${SOURCE}"
+                                   # Note: IMPLICIT_DEPENDS only works for Makefile generators, ${dep_args} handles Ninja.
+                                   IMPLICIT_DEPENDS CXX "${SOURCE}"
+                                   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+                                   ${dep_args}
+                                   VERBATIM)
+            endif()
 
             add_custom_command(OUTPUT "${BC}"
                                COMMAND llvm-as "${LL}" -o "${BC}"

--- a/src/runtime/cache.cpp
+++ b/src/runtime/cache.cpp
@@ -60,7 +60,9 @@ WEAK bool keys_equal(const uint8_t *key1, const uint8_t *key2, size_t key_size) 
 
 WEAK bool buffer_has_shape(const halide_buffer_t *buf, const halide_dimension_t *shape) {
     for (int i = 0; i < buf->dimensions; i++) {
-        if (buf->dim[i] != shape[i]) return false;
+        if (buf->dim[i] != shape[i]) {
+            return false;
+        }
     }
     return true;
 }

--- a/src/runtime/cpu_features.h
+++ b/src/runtime/cpu_features.h
@@ -2,7 +2,7 @@
 #define HALIDE_CPU_FEATURES_H
 
 #include "HalideRuntime.h"
-#include "cpu_features.h"
+#include "runtime_internal.h"
 
 namespace Halide {
 namespace Runtime {

--- a/src/runtime/d3d12compute.cpp
+++ b/src/runtime/d3d12compute.cpp
@@ -2216,12 +2216,10 @@ static void buffer_copy_command(d3d12_copy_command_list *cmdList,
 
     if (src_barrier.Transition.StateBefore != src_barrier.Transition.StateAfter) {
         (*cmdList)->ResourceBarrier(1, &src_barrier);
-
-}
+    }
     if (dst_barrier.Transition.StateBefore != dst_barrier.Transition.StateAfter) {
         (*cmdList)->ResourceBarrier(1, &dst_barrier);
-
-}
+    }
 
     UINT64 SrcOffset = src_byte_offset;
     UINT64 DstOffset = dst_byte_offset;
@@ -2234,12 +2232,10 @@ static void buffer_copy_command(d3d12_copy_command_list *cmdList,
 
     if (src_barrier.Transition.StateBefore != src_barrier.Transition.StateAfter) {
         (*cmdList)->ResourceBarrier(1, &src_barrier);
-
-}
+    }
     if (dst_barrier.Transition.StateBefore != dst_barrier.Transition.StateAfter) {
         (*cmdList)->ResourceBarrier(1, &dst_barrier);
-
-}
+    }
 }
 
 static void synchronize_host_and_device_buffer_contents(d3d12_copy_command_list *cmdList, d3d12_buffer *buffer) {

--- a/src/runtime/d3d12compute.cpp
+++ b/src/runtime/d3d12compute.cpp
@@ -2077,8 +2077,9 @@ static void commit_command_list(d3d12_compute_command_list *cmdList) {
 
 static bool spinlock_until_signaled(uint64_t signal) {
     TRACELOG;
-    while (queue_fence->GetCompletedValue() < signal)
-        ;
+    while (queue_fence->GetCompletedValue() < signal) {
+        // nothing
+    }
     return true;
 }
 
@@ -2213,10 +2214,14 @@ static void buffer_copy_command(d3d12_copy_command_list *cmdList,
         }
     }
 
-    if (src_barrier.Transition.StateBefore != src_barrier.Transition.StateAfter)
+    if (src_barrier.Transition.StateBefore != src_barrier.Transition.StateAfter) {
         (*cmdList)->ResourceBarrier(1, &src_barrier);
-    if (dst_barrier.Transition.StateBefore != dst_barrier.Transition.StateAfter)
+
+}
+    if (dst_barrier.Transition.StateBefore != dst_barrier.Transition.StateAfter) {
         (*cmdList)->ResourceBarrier(1, &dst_barrier);
+
+}
 
     UINT64 SrcOffset = src_byte_offset;
     UINT64 DstOffset = dst_byte_offset;
@@ -2227,10 +2232,14 @@ static void buffer_copy_command(d3d12_copy_command_list *cmdList,
     swap(src_barrier.Transition.StateBefore, src_barrier.Transition.StateAfter);  // restore resource state
     swap(dst_barrier.Transition.StateBefore, dst_barrier.Transition.StateAfter);  // restore resource state
 
-    if (src_barrier.Transition.StateBefore != src_barrier.Transition.StateAfter)
+    if (src_barrier.Transition.StateBefore != src_barrier.Transition.StateAfter) {
         (*cmdList)->ResourceBarrier(1, &src_barrier);
-    if (dst_barrier.Transition.StateBefore != dst_barrier.Transition.StateAfter)
+
+}
+    if (dst_barrier.Transition.StateBefore != dst_barrier.Transition.StateAfter) {
         (*cmdList)->ResourceBarrier(1, &dst_barrier);
+
+}
 }
 
 static void synchronize_host_and_device_buffer_contents(d3d12_copy_command_list *cmdList, d3d12_buffer *buffer) {

--- a/src/runtime/device_buffer_utils.h
+++ b/src/runtime/device_buffer_utils.h
@@ -46,8 +46,9 @@ struct device_copy {
 
 WEAK void copy_memory_helper(const device_copy &copy, int d, int64_t src_off, int64_t dst_off) {
     // Skip size-1 dimensions
-    while (d >= 0 && copy.extent[d] == 1)
+    while (d >= 0 && copy.extent[d] == 1) {
         d--;
+    }
 
     if (d == -1) {
         const void *from = (void *)(copy.src + src_off);

--- a/src/runtime/hexagon_dma.cpp
+++ b/src/runtime/hexagon_dma.cpp
@@ -253,8 +253,9 @@ int halide_hexagon_dma_wrapper(void *user_context, struct halide_buffer_t *src,
         << "Hexagon: Recommended ROI(w: " << roi_width << " h: " << roi_height << " s: " << roi_stride << ")\n";
 
     // account for folding, where the dim[1].stride reflects the fold_storage stride
-    if (dst->dim[1].stride > roi_stride)
+    if (dst->dim[1].stride > roi_stride) {
         roi_stride = dst->dim[1].stride;
+    }
 
     // Assert if destination stride is a multipe of recommended stride
     halide_assert(user_context, ((dst->dim[1].stride % roi_stride) == 0));

--- a/src/runtime/msan.cpp
+++ b/src/runtime/msan.cpp
@@ -28,8 +28,9 @@ namespace Runtime {
 namespace Internal {
 
 WEAK void annotate_helper(void *uc, const device_copy &c, int d, int64_t off) {
-    while (d >= 0 && c.extent[d] == 1)
+    while (d >= 0 && c.extent[d] == 1) {
         d--;
+    }
 
     if (d == -1) {
         const void *from = (void *)(c.src + off);
@@ -43,8 +44,9 @@ WEAK void annotate_helper(void *uc, const device_copy &c, int d, int64_t off) {
 };
 
 WEAK void check_helper(void *uc, const device_copy &c, int d, int64_t off, const char *buf_name) {
-    while (d >= 0 && c.extent[d] == 1)
+    while (d >= 0 && c.extent[d] == 1) {
         d--;
+    }
 
     if (d == -1) {
         const void *from = (void *)(c.src + off);

--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -365,7 +365,9 @@ WEAK int create_opencl_context(void *user_context, cl_context *ctx, cl_command_q
             const cl_uint max_platform_name = 256;
             char platform_name[max_platform_name];
             err = clGetPlatformInfo(platforms[i], CL_PLATFORM_NAME, max_platform_name, platform_name, NULL);
-            if (err != CL_SUCCESS) continue;
+            if (err != CL_SUCCESS) {
+                continue;
+            }
             debug(user_context) << "CL: platform " << i << " " << platform_name << "\n";
 
             // A platform matches the request if it is a substring of the platform name.

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -297,10 +297,11 @@ WEAK void GLStateSaver::restore() {
     free(texture_2d_binding);
 
     for (int i = 0; i < max_vertex_attribs; i++) {
-        if (vertex_attrib_array_enabled[i])
+        if (vertex_attrib_array_enabled[i]) {
             global_state.EnableVertexAttribArray(i);
-        else
+        } else {
             global_state.DisableVertexAttribArray(i);
+        }
     }
     free(vertex_attrib_array_enabled);
 
@@ -458,8 +459,9 @@ WEAK KernelInfo *create_kernel(void *user_context, const char *src, int size) {
     const char *line = kernel->source;
     while (*line) {
         const char *next_line = strchr(line, '\n') + 1;
-        if (!next_line)
+        if (!next_line) {
             next_line = line + size;
+        }
 
         const char *args;
         if ((args = match_prefix(line, kernel_marker))) {
@@ -1571,7 +1573,9 @@ WEAK int halide_opengl_run(void *user_context,
     GLint num_output_textures = 0;
     kernel_arg = kernel->arguments;
     for (int i = 0; args[i]; i++, kernel_arg = kernel_arg->next) {
-        if (kernel_arg->kind != Argument::Outbuf) continue;
+        if (kernel_arg->kind != Argument::Outbuf) {
+            continue;
+        }
 
         halide_assert(user_context, is_buffer[i] && "OpenGL Outbuf argument is not a buffer.");
 
@@ -1874,8 +1878,9 @@ WEAK int halide_opengl_initialize_kernels(void *user_context, void **state_ptr,
         int num_varying_float = 2;
 
         for (Argument *arg = kernel->arguments; arg; arg = arg->next) {
-            if (arg->kind == Argument::Varying)
+            if (arg->kind == Argument::Varying) {
                 ++num_varying_float;
+            }
         }
 
         int num_packed_varying_float = ((num_varying_float + 3) & ~0x3) / 4;
@@ -1967,7 +1972,9 @@ WEAK const halide_device_interface_t *halide_opengl_device_interface() {
 }
 
 WEAK void halide_opengl_context_lost(void *user_context) {
-    if (!global_state.initialized) return;
+    if (!global_state.initialized) {
+        return;
+    }
 
     debug(user_context) << "halide_opengl_context_lost\n";
     for (ModuleState *mod = state_list; mod; mod = mod->next) {

--- a/src/runtime/opengl_egl_context.cpp
+++ b/src/runtime/opengl_egl_context.cpp
@@ -68,20 +68,25 @@ EGLAPI void *eglGetProcAddress(const char *procname);
 extern int strcmp(const char *, const char *);
 
 WEAK int halide_opengl_create_context(void *user_context) {
-    if (eglGetCurrentContext() != EGL_NO_CONTEXT)
+    if (eglGetCurrentContext() != EGL_NO_CONTEXT) {
         return 0;
+    }
 
     EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
     if (display == EGL_NO_DISPLAY || !eglInitialize(display, 0, 0)) {
         PFNEGLQUERYDEVICESEXTPROC eglQueryDevicesEXT =
             reinterpret_cast<PFNEGLQUERYDEVICESEXTPROC>(
                 eglGetProcAddress("eglQueryDevicesEXT"));
-        if (eglQueryDevicesEXT == NULL) return 1;
+        if (eglQueryDevicesEXT == NULL) {
+            return 1;
+        }
 
         PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT =
             reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
                 eglGetProcAddress("eglGetPlatformDisplayEXT"));
-        if (eglGetPlatformDisplayEXT == NULL) return 1;
+        if (eglGetPlatformDisplayEXT == NULL) {
+            return 1;
+        }
 
         const int kMaxDevices = 32;
         EGLDeviceEXT egl_devices[kMaxDevices];

--- a/src/runtime/opengl_glx_context.cpp
+++ b/src/runtime/opengl_glx_context.cpp
@@ -43,8 +43,9 @@ namespace Internal {
 //   http://www.opengl.org/resources/features/OGLextensions/
 WEAK bool glx_extension_supported(const char *extlist, const char *extension) {
     // Extension names should not have spaces.
-    if (strchr(extension, ' ') != NULL || *extension == '\0')
+    if (strchr(extension, ' ') != NULL || *extension == '\0') {
         return false;
+    }
 
     const char *start = extlist;
     while (const char *pos = strstr(start, extension)) {

--- a/src/runtime/openglcompute.cpp
+++ b/src/runtime/openglcompute.cpp
@@ -375,8 +375,9 @@ namespace {
 template<typename Source, typename Dest>
 ALWAYS_INLINE void converting_copy_memory_helper(const device_copy &copy, int d, int64_t src_off, int64_t dst_off) {
     // Skip size-1 dimensions
-    while (d >= 0 && copy.extent[d] == 1)
+    while (d >= 0 && copy.extent[d] == 1) {
         d--;
+    }
 
     if (d == -1) {
         const Source *from = (Source *)(copy.src + src_off);

--- a/src/runtime/osx_opengl_context.cpp
+++ b/src/runtime/osx_opengl_context.cpp
@@ -39,7 +39,9 @@ WEAK void *halide_opengl_get_proc_address(void *user_context, const char *name) 
     if (!dylib) {
         dylib = halide_load_library(
             "/System/Library/Frameworks/OpenGL.framework/Versions/Current/OpenGL");
-        if (!dylib) return NULL;
+        if (!dylib) {
+            return NULL;
+        }
     }
     return halide_get_library_symbol(dylib, name);
 }

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -33,7 +33,9 @@ WEAK halide_profiler_pipeline_stats *find_or_create_pipeline(const char *pipelin
     // Create a new pipeline stats entry.
     halide_profiler_pipeline_stats *p =
         (halide_profiler_pipeline_stats *)malloc(sizeof(halide_profiler_pipeline_stats));
-    if (!p) return NULL;
+    if (!p) {
+        return NULL;
+    }
     p->next = s->pipelines;
     p->name = pipeline_name;
     p->first_func_id = s->first_free_id;
@@ -292,7 +294,9 @@ WEAK void halide_profiler_report_unlocked(void *user_context, halide_profiler_st
     for (halide_profiler_pipeline_stats *p = s->pipelines; p;
          p = (halide_profiler_pipeline_stats *)(p->next)) {
         float t = p->time / 1000000.0f;
-        if (!p->runs) continue;
+        if (!p->runs) {
+            continue;
+        }
         sstr.clear();
         int alloc_avg = 0;
         if (p->num_allocs != 0) {
@@ -331,7 +335,9 @@ WEAK void halide_profiler_report_unlocked(void *user_context, halide_profiler_st
 
                 // The first func is always a catch-all overhead
                 // slot. Only report overhead time if it's non-zero
-                if (i == 0 && fs->time == 0) continue;
+                if (i == 0 && fs->time == 0) {
+                    continue;
+                }
 
                 sstr << "  " << fs->name << ": ";
                 cursor += 25;

--- a/src/runtime/pseudostack.cpp
+++ b/src/runtime/pseudostack.cpp
@@ -5,7 +5,9 @@ extern "C" {
 
 WEAK_INLINE __attribute__((used)) void *pseudostack_alloc(void *user_context, halide_pseudostack_slot_t *slot, size_t sz) {
     if (__builtin_expect(sz > slot->size, 0)) {
-        if (slot->ptr) halide_free(user_context, slot->ptr);
+        if (slot->ptr) {
+            halide_free(user_context, slot->ptr);
+        }
         slot->ptr = halide_malloc(user_context, sz);
         slot->size = sz;
     }
@@ -16,7 +18,9 @@ WEAK_INLINE __attribute__((used)) void *pseudostack_alloc(void *user_context, ha
 WEAK_INLINE __attribute__((used)) void pseudostack_free(void *user_context, void *ptr) {
     halide_pseudostack_slot_t *slot = (halide_pseudostack_slot_t *)ptr;
     slot->size = 0;
-    if (slot->ptr) halide_free(user_context, slot->ptr);
+    if (slot->ptr) {
+        halide_free(user_context, slot->ptr);
+    }
     slot->ptr = NULL;
 }
 }

--- a/src/runtime/thread_pool_common.h
+++ b/src/runtime/thread_pool_common.h
@@ -324,7 +324,9 @@ WEAK void worker_thread_already_locked(work *owned_job) {
                        job->make_runnable()) {
                     iters++;
                 }
-                if (iters == 0) break;
+                if (iters == 0) {
+                    break;
+                }
 
                 // Do them
                 result = halide_do_loop_task(job->user_context, job->task.fn,

--- a/src/runtime/to_string.cpp
+++ b/src/runtime/to_string.cpp
@@ -3,7 +3,9 @@
 extern "C" {
 
 WEAK char *halide_string_to_string(char *dst, char *end, const char *arg) {
-    if (dst >= end) return dst;
+    if (dst >= end) {
+        return dst;
+    }
     while (1) {
         if (dst == end) {
             dst[-1] = 0;
@@ -235,7 +237,9 @@ WEAK char *halide_pointer_to_string(char *dst, char *end, const void *arg) {
     for (int i = 0; i < 16; i++) {
         *buf_ptr-- = hex_digits[bits & 15];
         bits >>= 4;
-        if (!bits) break;
+        if (!bits) {
+            break;
+        }
     }
     *buf_ptr-- = 'x';
     *buf_ptr = '0';

--- a/src/runtime/write_debug_image.cpp
+++ b/src/runtime/write_debug_image.cpp
@@ -98,7 +98,9 @@ WEAK bool ends_with(const char *filename, const char *suffix) {
         s++;
     }
     while (s != suffix && f != filename) {
-        if (*f != *s) return false;
+        if (*f != *s) {
+            return false;
+        }
         f--;
         s--;
     }
@@ -141,7 +143,9 @@ WEAK extern "C" int32_t halide_debug_to_file(void *user_context, const char *fil
     halide_copy_to_host(user_context, buf);
 
     ScopedFile f(filename, "wb");
-    if (!f.open()) return -2;
+    if (!f.open()) {
+        return -2;
+    }
 
     size_t elts = 1;
     halide_dimension_t shape[4];


### PR DESCRIPTION
(and fix resulting errors)