### PR TITLE
Enable clang-tidy's modernize-use-default-member-init check 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,7 @@ Checks: >
     -misc-unconventional-assign-operator,
     -misc-unused-parameters,
     modernize-deprecated-headers,
+    modernize-use-default-member-init,
     modernize-use-emplace,
     modernize-use-override,
     performance-*,
@@ -24,4 +25,7 @@ Checks: >
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 FormatStyle: 'file'
+CheckOptions:
+    - key:   modernize-use-default-member-init.UseAssignment
+      value: 1
 ...

--- a/src/AssociativeOpsTable.h
+++ b/src/AssociativeOpsTable.h
@@ -35,13 +35,12 @@ struct AssociativePattern {
     /** Contain the identities for each dimension of the associative op. */
     std::vector<Expr> identities;
     /** Indicate if the associative op is also commutative. */
-    bool is_commutative;
+    bool is_commutative = false;
 
-    AssociativePattern()
-        : is_commutative(false) {
+    AssociativePattern() {
     }
     AssociativePattern(size_t size)
-        : ops(size), identities(size), is_commutative(false) {
+        : ops(size), identities(size) {
     }
     AssociativePattern(const std::vector<Expr> &ops, const std::vector<Expr> &ids, bool is_commutative)
         : ops(ops), identities(ids), is_commutative(is_commutative) {

--- a/src/Associativity.h
+++ b/src/Associativity.h
@@ -83,13 +83,12 @@ struct AssociativeOp {
     AssociativePattern pattern;
     std::vector<Replacement> xs;
     std::vector<Replacement> ys;
-    bool is_associative;
+    bool is_associative = false;
 
-    AssociativeOp()
-        : is_associative(false) {
+    AssociativeOp() {
     }
     AssociativeOp(size_t size)
-        : pattern(size), xs(size), ys(size), is_associative(false) {
+        : pattern(size), xs(size), ys(size) {
     }
     AssociativeOp(const AssociativePattern &p, const std::vector<Replacement> &xs,
                   const std::vector<Replacement> &ys, bool is_associative)

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1983,9 +1983,8 @@ private:
         }
 
     public:
-        int count;
-        CountVars()
-            : count(0) {
+        int count = 0;
+        CountVars() {
         }
     };
 

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -50,9 +50,8 @@ class DependsOnBoundsInference : public IRVisitor {
     }
 
 public:
-    bool result;
-    DependsOnBoundsInference()
-        : result(false) {
+    bool result = false;
+    DependsOnBoundsInference() {
     }
 };
 

--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -337,7 +337,7 @@ namespace {
 // Normalize all names in an expr so that expr compares can be done
 // without worrying about mere name differences.
 class NormalizeVarNames : public IRMutator {
-    int counter;
+    int counter = 0;
 
     map<string, string> new_names;
 
@@ -361,8 +361,7 @@ class NormalizeVarNames : public IRMutator {
     }
 
 public:
-    NormalizeVarNames()
-        : counter(0) {
+    NormalizeVarNames() {
     }
 };
 

--- a/src/Closure.h
+++ b/src/Closure.h
@@ -47,22 +47,21 @@ public:
         Type type;
 
         /** The dimensionality of the buffer. */
-        uint8_t dimensions;
+        uint8_t dimensions = 0;
 
         /** The buffer is read from. */
-        bool read;
+        bool read = false;
 
         /** The buffer is written to. */
-        bool write;
+        bool write = false;
 
         /** The buffer is a texture */
-        MemoryType memory_type;
+        MemoryType memory_type = MemoryType::Auto;
 
         /** The size of the buffer if known, otherwise zero. */
-        size_t size;
+        size_t size = 0;
 
-        Buffer()
-            : dimensions(0), read(false), write(false), memory_type(MemoryType::Auto), size(0) {
+        Buffer() {
         }
     };
 

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -888,10 +888,9 @@ void CodeGen_D3D12Compute_Dev::add_kernel(Stmt s,
 namespace {
 struct BufferSize {
     string name;
-    size_t size;
+    size_t size = 0;
 
-    BufferSize()
-        : size(0) {
+    BufferSize() {
     }
     BufferSize(string name, size_t size)
         : name(std::move(name)), size(size) {

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -40,10 +40,9 @@ class IsBlockUniform : public IRVisitor {
     }
 
 public:
-    bool result;
+    bool result = true;
 
-    IsBlockUniform()
-        : result(true) {
+    IsBlockUniform() {
     }
 };
 }  // namespace

--- a/src/CodeGen_GPU_Host.cpp
+++ b/src/CodeGen_GPU_Host.cpp
@@ -38,14 +38,14 @@ public:
     Expr shared_mem_size;
 
     ExtractBounds()
-        : shared_mem_size(0), found_shared(false) {
+        : shared_mem_size(0) {
         for (int i = 0; i < 4; i++) {
             num_threads[i] = num_blocks[i] = 1;
         }
     }
 
 private:
-    bool found_shared;
+    bool found_shared = false;
 
     using IRVisitor::visit;
 

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -499,8 +499,7 @@ class IdPair {
     Intrinsic::ID i128 = Intrinsic::not_intrinsic;
 
 public:
-    constexpr IdPair()
-        : i64(Intrinsic::not_intrinsic), i128(Intrinsic::not_intrinsic) {
+    constexpr IdPair() {
     }
     constexpr IdPair(Intrinsic::ID i64, Intrinsic::ID i128)
         : i64(i64), i128(i128) {

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -474,10 +474,9 @@ void CodeGen_Metal_Dev::add_kernel(Stmt s,
 namespace {
 struct BufferSize {
     string name;
-    size_t size;
+    size_t size = 0;
 
-    BufferSize()
-        : size(0) {
+    BufferSize() {
     }
     BufferSize(string name, size_t size)
         : name(std::move(name)), size(size) {

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -800,10 +800,9 @@ void CodeGen_OpenCL_Dev::add_kernel(Stmt s,
 namespace {
 struct BufferSize {
     string name;
-    size_t size;
+    size_t size = 0;
 
-    BufferSize()
-        : size(0) {
+    BufferSize() {
     }
     BufferSize(string name, size_t size)
         : name(std::move(name)), size(size) {

--- a/src/Definition.cpp
+++ b/src/Definition.cpp
@@ -17,7 +17,7 @@ using std::vector;
 
 struct DefinitionContents {
     mutable RefCount ref_count;
-    bool is_init;
+    bool is_init = true;
     Expr predicate;
     std::vector<Expr> values, args;
     StageSchedule stage_schedule;
@@ -25,7 +25,7 @@ struct DefinitionContents {
     std::string source_location;
 
     DefinitionContents()
-        : is_init(true), predicate(const_true()) {
+        : predicate(const_true()) {
     }
 
     void accept(IRVisitor *visitor) const {

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -419,7 +419,7 @@ class Interleaver : public IRMutator {
 
     using IRMutator::visit;
 
-    bool should_deinterleave;
+    bool should_deinterleave = false;
     int num_lanes;
 
     Expr deinterleave_expr(Expr e) {
@@ -804,8 +804,7 @@ class Interleaver : public IRMutator {
     }
 
 public:
-    Interleaver()
-        : should_deinterleave(false) {
+    Interleaver() {
     }
 };
 

--- a/src/DeviceArgument.h
+++ b/src/DeviceArgument.h
@@ -34,17 +34,17 @@ struct DeviceArgument {
      * the expected interpretation of the buffer data (e.g. float vs int),
      * but there is no runtime enforcement of this at present.
      */
-    bool is_buffer;
+    bool is_buffer = false;
 
     /** If is_buffer == true and memory_type == GPUTexture, this argument should be
      * passed and accessed through texture sampler operations instead of
      * directly as a memory array
      */
-    MemoryType memory_type;
+    MemoryType memory_type = MemoryType::Auto;
 
     /** If is_buffer is true, this is the dimensionality of the buffer.
      * If is_buffer is false, this value is ignored (and should always be set to zero) */
-    uint8_t dimensions;
+    uint8_t dimensions = 0;
 
     /** If this is a scalar parameter, then this is its type.
      *
@@ -55,29 +55,24 @@ struct DeviceArgument {
     Type type;
 
     /** The static size of the argument if known, or zero otherwise. */
-    size_t size;
+    size_t size = 0;
 
     /** The index of the first element of the argument when packed into a wider
      * type, such as packing scalar floats into vec4 for GLSL. */
-    size_t packed_index;
+    size_t packed_index = 0;
 
     /** For buffers, these two variables can be used to specify whether the
      * buffer is read or written. By default, we assume that the argument
      * buffer is read-write and set both flags. */
-    bool read;
-    bool write;
+    bool read = false;
+    bool write = false;
 
     /** Alignment information for integer parameters. */
     ModulusRemainder alignment;
 
     DeviceArgument()
-        : is_buffer(false),
-          memory_type(MemoryType::Auto),
-          dimensions(0),
-          size(0),
-          packed_index(0),
-          read(false),
-          write(false) {
+
+    {
     }
 
     DeviceArgument(const std::string &_name,
@@ -92,7 +87,7 @@ struct DeviceArgument {
           dimensions(_dimensions),
           type(_type),
           size(_size),
-          packed_index(0),
+
           read(_is_buffer),
           write(_is_buffer) {
     }

--- a/src/ExternFuncArgument.h
+++ b/src/ExternFuncArgument.h
@@ -20,7 +20,7 @@ struct ExternFuncArgument {
                    BufferArg,
                    ExprArg,
                    ImageParamArg };
-    ArgType arg_type;
+    ArgType arg_type = UndefinedArg;
     Internal::FunctionPtr func;
     Buffer<> buffer;
     Expr expr;
@@ -49,8 +49,7 @@ struct ExternFuncArgument {
         // Scalar params come in via the Expr constructor.
         internal_assert(p.is_buffer());
     }
-    ExternFuncArgument()
-        : arg_type(UndefinedArg) {
+    ExternFuncArgument() {
     }
 
     bool is_func() const {

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -1479,7 +1479,7 @@ class FuseGPUThreadLoops : public IRMutator {
 };
 
 class ZeroGPULoopMins : public IRMutator {
-    bool in_non_glsl_gpu;
+    bool in_non_glsl_gpu = false;
     using IRMutator::visit;
 
     Stmt visit(const For *op) override {
@@ -1502,8 +1502,7 @@ class ZeroGPULoopMins : public IRMutator {
     }
 
 public:
-    ZeroGPULoopMins()
-        : in_non_glsl_gpu(false) {
+    ZeroGPULoopMins() {
     }
 };
 

--- a/src/IREquality.cpp
+++ b/src/IREquality.cpp
@@ -21,7 +21,7 @@ public:
                      GreaterThan };
 
     /** The result of the comparison. Should be Equal, LessThan, or GreaterThan. */
-    CmpResult result;
+    CmpResult result = Equal;
 
     /** Compare two expressions or statements and return the
      * result. Returns the result immediately if it is already
@@ -36,7 +36,7 @@ public:
      * Currently this is only done in common-subexpression
      * elimination. */
     IRComparer(IRCompareCache *c = nullptr)
-        : result(Equal), cache(c) {
+        : cache(c) {
     }
 
 private:

--- a/src/IREquality.h
+++ b/src/IREquality.h
@@ -94,10 +94,9 @@ if (m.contains(ExprWithCompareCache(query, &cache))) {...}
  */
 struct ExprWithCompareCache {
     Expr expr;
-    mutable IRCompareCache *cache;
+    mutable IRCompareCache *cache = nullptr;
 
-    ExprWithCompareCache()
-        : cache(nullptr) {
+    ExprWithCompareCache() {
     }
     ExprWithCompareCache(const Expr &e, IRCompareCache *c)
         : expr(e), cache(c) {

--- a/src/InjectOpenGLIntrinsics.cpp
+++ b/src/InjectOpenGLIntrinsics.cpp
@@ -15,11 +15,10 @@ using std::vector;
 /** Normalizes image loads/stores and produces glsl_texture_load/stores. */
 class InjectOpenGLIntrinsics : public IRMutator {
 public:
-    InjectOpenGLIntrinsics()
-        : inside_kernel_loop(false) {
+    InjectOpenGLIntrinsics() {
     }
     Scope<int> scope;
-    bool inside_kernel_loop;
+    bool inside_kernel_loop = false;
 
 private:
     using IRMutator::visit;

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -58,9 +58,8 @@ class DebugSections {
     bool calibrated;
 
     struct FieldFormat {
-        uint64_t name, form;
-        FieldFormat()
-            : name(0), form(0) {
+        uint64_t name = 0, form = 0;
+        FieldFormat() {
         }
         FieldFormat(uint64_t n, uint64_t f)
             : name(n), form(f) {
@@ -68,10 +67,9 @@ class DebugSections {
     };
 
     struct EntryFormat {
-        uint64_t code, tag;
-        bool has_children;
-        EntryFormat()
-            : code(0), tag(0), has_children(false) {
+        uint64_t code = 0, tag = 0;
+        bool has_children = false;
+        EntryFormat() {
         }
         vector<FieldFormat> fields;
     };
@@ -85,17 +83,12 @@ class DebugSections {
 
     struct GlobalVariable {
         std::string name;
-        TypeInfo *type;
-        uint64_t type_def_loc;
-        uint64_t def_loc, spec_loc;
-        uint64_t addr;
+        TypeInfo *type = nullptr;
+        uint64_t type_def_loc = 0;
+        uint64_t def_loc = 0, spec_loc = 0;
+        uint64_t addr = 0;
         GlobalVariable()
-            : name(""),
-              type(nullptr),
-              type_def_loc(0),
-              def_loc(0),
-              spec_loc(0),
-              addr(0) {
+            : name("") {
         }
         bool operator<(const GlobalVariable &other) const {
             return addr < other.addr;
@@ -120,30 +113,25 @@ class DebugSections {
 
     struct LocalVariable {
         std::string name;
-        TypeInfo *type;
-        int stack_offset;
-        uint64_t type_def_loc;
-        uint64_t def_loc, origin_loc;
+        TypeInfo *type = nullptr;
+        int stack_offset = 0;
+        uint64_t type_def_loc = 0;
+        uint64_t def_loc = 0, origin_loc = 0;
         // Some local vars are only alive for certain address ranges
         // (e.g. those inside a lexical block). If the ranges vector
         // is empty, the variables are alive for the entire containing
         // function.
         vector<LiveRange> live_ranges;
         LocalVariable()
-            : name(""),
-              type(nullptr),
-              stack_offset(0),
-              type_def_loc(0),
-              def_loc(0),
-              origin_loc(0) {
+            : name("") {
         }
     };
 
     struct FunctionInfo {
         std::string name;
-        uint64_t pc_begin, pc_end;
+        uint64_t pc_begin = 0, pc_end = 0;
         vector<LocalVariable> variables;
-        uint64_t def_loc, spec_loc;
+        uint64_t def_loc = 0, spec_loc = 0;
         // The stack variable offsets are w.r.t either:
         // gcc: the top of the stack frame (one below the return address to the caller)
         // clang with frame pointers: the bottom of the stack frame (one above the return address to this function)
@@ -153,7 +141,7 @@ class DebugSections {
                ClangFP,
                ClangNoFP } frame_base;
         FunctionInfo()
-            : name(""), pc_begin(0), pc_end(0), def_loc(0), spec_loc(0) {
+            : name("") {
         }
 
         bool operator<(const FunctionInfo &other) const {
@@ -175,8 +163,8 @@ class DebugSections {
 
     struct TypeInfo {
         std::string name;
-        uint64_t size;
-        uint64_t def_loc;
+        uint64_t size = 0;
+        uint64_t def_loc = 0;
         vector<LocalVariable> members;
 
         // TypeInfo can also be used to represent a pointer to
@@ -190,10 +178,9 @@ class DebugSections {
                Typedef,
                Const,
                Reference,
-               Array } type;
+               Array } type = Primitive;
 
-        TypeInfo()
-            : size(0), def_loc(0), type(Primitive) {
+        TypeInfo() {
         }
     };
     vector<TypeInfo> types;

--- a/src/Introspection.h
+++ b/src/Introspection.h
@@ -100,13 +100,12 @@ struct A {
     int an_int;
 
     class B {
-        int private_member;
+        int private_member = 17;
 
     public:
         float a_float;
         A *parent;
-        B()
-            : private_member(17) {
+        B() {
             a_float = private_member * 2.0f;
         }
     };

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -55,12 +55,11 @@ bool have_symbol(const char *s) {
 typedef struct CUctx_st *CUcontext;
 
 struct SharedCudaContext {
-    CUctx_st *ptr;
-    volatile int lock;
+    CUctx_st *ptr = 0;
+    volatile int lock = 0;
 
     // Will be created on first use by a jitted kernel that uses it
-    SharedCudaContext()
-        : ptr(0), lock(0) {
+    SharedCudaContext() {
     }
 
     // Note that we never free the context, because static destructor
@@ -75,12 +74,11 @@ typedef struct cl_command_queue_st *cl_command_queue;
 // A single global OpenCL context and command queue to share between
 // jitted functions.
 struct SharedOpenCLContext {
-    cl_context context;
-    cl_command_queue command_queue;
-    volatile int lock;
+    cl_context context = nullptr;
+    cl_command_queue command_queue = nullptr;
+    volatile int lock = 0;
 
-    SharedOpenCLContext()
-        : context(nullptr), command_queue(nullptr), lock(0) {
+    SharedOpenCLContext() {
     }
 
     // We never free the context, for the same reason as above.
@@ -138,8 +136,7 @@ public:
     mutable RefCount ref_count;
 
     // Just construct a module with symbols to import into other modules.
-    JITModuleContents()
-        : execution_engine(nullptr) {
+    JITModuleContents() {
     }
 
     ~JITModuleContents() {
@@ -151,7 +148,7 @@ public:
 
     std::map<std::string, JITModule::Symbol> exports;
     llvm::LLVMContext context;
-    ExecutionEngine *execution_engine;
+    ExecutionEngine *execution_engine = nullptr;
     std::vector<JITModule> dependencies;
     JITModule::Symbol entrypoint;
     JITModule::Symbol argv_entrypoint;

--- a/src/ModulusRemainder.h
+++ b/src/ModulusRemainder.h
@@ -29,14 +29,13 @@ class Scope;
  * remainder == 0). */
 
 struct ModulusRemainder {
-    ModulusRemainder()
-        : modulus(1), remainder(0) {
+    ModulusRemainder() {
     }
     ModulusRemainder(int64_t m, int64_t r)
         : modulus(m), remainder(r) {
     }
 
-    int64_t modulus, remainder;
+    int64_t modulus = 1, remainder = 0;
 
     // Take a conservatively-large union of two sets. Contains all
     // elements from both sets, and maybe some more stuff.

--- a/src/ObjectInstanceRegistry.h
+++ b/src/ObjectInstanceRegistry.h
@@ -69,13 +69,12 @@ private:
     static ObjectInstanceRegistry &get_registry();
 
     struct InstanceInfo {
-        void *subject_ptr;  // May be different from the this_ptr in the key
-        size_t size;        // May be 0 for params
-        Kind kind;
-        bool registered_for_introspection;
+        void *subject_ptr = nullptr;  // May be different from the this_ptr in the key
+        size_t size = 0;              // May be 0 for params
+        Kind kind = Invalid;
+        bool registered_for_introspection = false;
 
-        InstanceInfo()
-            : subject_ptr(nullptr), size(0), kind(Invalid), registered_for_introspection(false) {
+        InstanceInfo() {
         }
         InstanceInfo(size_t size, Kind kind, void *subject_ptr, bool registered_for_introspection)
             : subject_ptr(subject_ptr), size(size), kind(kind), registered_for_introspection(registered_for_introspection) {

--- a/src/OutputImageParam.h
+++ b/src/OutputImageParam.h
@@ -24,7 +24,7 @@ protected:
     Internal::Parameter param;
 
     /** Is this an input or an output? OutputImageParam is the base class for both. */
-    Argument::Kind kind;
+    Argument::Kind kind = Argument::InputScalar;
 
     /** If Input: Func representation of the ImageParam.
      * If Output: Func that creates this OutputImageParam.
@@ -41,8 +41,7 @@ protected:
 
 public:
     /** Construct a null image parameter handle. */
-    OutputImageParam()
-        : kind(Argument::InputScalar) {
+    OutputImageParam() {
     }
 
     /** Get the name of this Param */

--- a/src/ParamMap.h
+++ b/src/ParamMap.h
@@ -51,14 +51,11 @@ public:
 private:
     struct ParamArg {
         Internal::Parameter mapped_param;
-        Buffer<> *buf_out_param;
+        Buffer<> *buf_out_param = nullptr;
 
-        ParamArg()
-            : buf_out_param(nullptr) {
-        }
+        ParamArg() = default;
         ParamArg(const ParamMapping &pm)
-            : mapped_param(pm.parameter->type(), false, 0, pm.parameter->name()),
-              buf_out_param(nullptr) {
+            : mapped_param(pm.parameter->type(), false, 0, pm.parameter->name()) {
             mapped_param.set_scalar(pm.parameter->type(), pm.value);
         }
         ParamArg(Buffer<> *buf_ptr)

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -113,10 +113,10 @@ struct PipelineContents {
 
     std::vector<Stmt> requirements;
 
-    bool trace_pipeline;
+    bool trace_pipeline = false;
 
     PipelineContents()
-        : module("", Target()), trace_pipeline(false) {
+        : module("", Target()) {
         user_context_arg.arg = Argument("__user_context", Argument::InputScalar, type_of<const void *>(), 0, ArgumentEstimates{});
         user_context_arg.param = Parameter(Handle(), false, 0, "__user_context");
     }

--- a/src/Reduction.cpp
+++ b/src/Reduction.cpp
@@ -95,10 +95,10 @@ struct ReductionDomainContents {
     mutable RefCount ref_count;
     std::vector<ReductionVariable> domain;
     Expr predicate;
-    bool frozen;
+    bool frozen = false;
 
     ReductionDomainContents()
-        : predicate(const_true()), frozen(false) {
+        : predicate(const_true()) {
     }
 
     // Pass an IRVisitor through to all Exprs referenced in the ReductionDomainContents

--- a/src/RegionCosts.cpp
+++ b/src/RegionCosts.cpp
@@ -301,14 +301,13 @@ class ExprCost : public IRVisitor {
     }
 
 public:
-    int64_t arith;
-    int64_t memory;
+    int64_t arith = 0;
+    int64_t memory = 0;
     // Detailed breakdown of bytes loaded by the allocation or function
     // they are loaded from.
     map<string, int64_t> detailed_byte_loads;
 
-    ExprCost()
-        : arith(0), memory(0) {
+    ExprCost() {
     }
 };
 

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -218,12 +218,11 @@ struct FuncScheduleContents {
     std::vector<Bound> bounds;
     std::vector<Bound> estimates;
     std::map<std::string, Internal::FunctionPtr> wrappers;
-    MemoryType memory_type;
-    bool memoized, async;
+    MemoryType memory_type = MemoryType::Auto;
+    bool memoized = false, async = false;
 
     FuncScheduleContents()
-        : store_level(LoopLevel::inlined()), compute_level(LoopLevel::inlined()),
-          memory_type(MemoryType::Auto), memoized(false), async(false){};
+        : store_level(LoopLevel::inlined()), compute_level(LoopLevel::inlined()){};
 
     // Pass an IRMutator through to all Exprs referenced in the FuncScheduleContents
     void mutate(IRMutator *mutator) {
@@ -279,15 +278,13 @@ struct StageScheduleContents {
     std::vector<PrefetchDirective> prefetches;
     FuseLoopLevel fuse_level;
     std::vector<FusedPair> fused_pairs;
-    bool touched;
-    bool allow_race_conditions;
-    bool atomic;
-    bool override_atomic_associativity_test;
+    bool touched = false;
+    bool allow_race_conditions = false;
+    bool atomic = false;
+    bool override_atomic_associativity_test = false;
 
     StageScheduleContents()
-        : fuse_level(FuseLoopLevel()), touched(false),
-          allow_race_conditions(false), atomic(false),
-          override_atomic_associativity_test(false) {
+        : fuse_level(FuseLoopLevel()) {
     }
 
     // Pass an IRMutator through to all Exprs referenced in the StageScheduleContents

--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -47,10 +47,9 @@ class UsesExternImage : public IRVisitor {
     }
 
 public:
-    UsesExternImage()
-        : result(false) {
+    UsesExternImage() {
     }
-    bool result;
+    bool result = false;
 };
 
 inline bool uses_extern_image(const Stmt &s) {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -539,8 +539,7 @@ void bad_target_string(const std::string &target) {
 
 }  // namespace
 
-Target::Target(const std::string &target)
-    : os(OSUnknown), arch(ArchUnknown), bits(0) {
+Target::Target(const std::string &target) {
     Target host = get_host_target();
 
     if (target.empty()) {

--- a/src/Target.h
+++ b/src/Target.h
@@ -31,7 +31,7 @@ struct Target {
         NoOS,
         Fuchsia,
         WebAssemblyRuntime
-    } os;
+    } os = OSUnknown;
 
     /** The architecture used by the target. Determines the
      * instruction set to use.
@@ -45,10 +45,10 @@ struct Target {
         POWERPC,
         WebAssembly,
         RISCV
-    } arch;
+    } arch = ArchUnknown;
 
     /** The bit-width of the target machine. Must be 0 for unknown, or 32 or 64. */
-    int bits;
+    int bits = 0;
 
     /** Optional features a target can have.
      * Corresponds to feature_name_map in Target.cpp.
@@ -127,8 +127,7 @@ struct Target {
         LLVMLargeCodeModel = halide_llvm_large_code_model,
         FeatureEnd = halide_target_feature_end
     };
-    Target()
-        : os(OSUnknown), arch(ArchUnknown), bits(0) {
+    Target() {
     }
     Target(OS o, Arch a, int b, const std::vector<Feature> &initial_features = std::vector<Feature>())
         : os(o), arch(a), bits(b) {

--- a/src/Type.h
+++ b/src/Type.h
@@ -288,7 +288,7 @@ public:
 
     // Default ctor initializes everything to predictable-but-unlikely values
     Type()
-        : type(Handle, 0, 0), handle_type(nullptr) {
+        : type(Handle, 0, 0) {
     }
 
     /** Construct a runtime representation of a Halide type from:
@@ -357,7 +357,7 @@ public:
     }
 
     /** Type to be printed when declaring handles of this type. */
-    const halide_handle_cplusplus_type *handle_type;
+    const halide_handle_cplusplus_type *handle_type = nullptr;
 
     /** Is this type boolean (represented as UInt(1))? */
     HALIDE_ALWAYS_INLINE

--- a/src/VaryingAttributes.cpp
+++ b/src/VaryingAttributes.cpp
@@ -34,7 +34,7 @@ class FindLinearExpressions : public IRMutator {
 protected:
     using IRMutator::visit;
 
-    bool in_glsl_loops;
+    bool in_glsl_loops = false;
 
     Expr tag_linear_expression(Expr e, const std::string &name = unique_name('a')) {
 
@@ -402,17 +402,16 @@ public:
     unsigned int order;
     bool found;
 
-    unsigned int total_found;
+    unsigned int total_found = 0;
 
     // This parameter controls the maximum number of linearly varying
     // expressions halide will pull out of the fragment shader and evaluate per
     // vertex, and allow the GPU to linearly interpolate across the domain. For
     // OpenGL ES 2.0 we can pass 16 vec4 varying attributes, or 64 scalars. Two
     // scalar slots are used by boilerplate code to pass pixel coordinates.
-    const unsigned int max_expressions;
+    const unsigned int max_expressions = 62;
 
-    FindLinearExpressions()
-        : in_glsl_loops(false), total_found(0), max_expressions(62) {
+    FindLinearExpressions() {
     }
 };
 

--- a/src/autoschedulers/.clang-tidy
+++ b/src/autoschedulers/.clang-tidy
@@ -25,6 +25,7 @@ Checks: >
     -misc-unconventional-assign-operator,
     -misc-unused-parameters,
     modernize-deprecated-headers,
+    modernize-use-default-member-init,
     modernize-use-emplace,
     modernize-use-override,
     performance-*,
@@ -37,4 +38,7 @@ Checks: >
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 FormatStyle: 'file'
+CheckOptions:
+    - key:   modernize-use-default-member-init.UseAssignment
+      value: 1
 ...

--- a/src/runtime/.clang-tidy
+++ b/src/runtime/.clang-tidy
@@ -25,6 +25,7 @@ Checks: >
     -misc-unused-parameters,
     -misc-unconventional-assign-operator,
     modernize-deprecated-headers,
+    modernize-use-default-member-init,
     modernize-use-emplace,
     modernize-use-override,
     performance-*,
@@ -35,4 +36,7 @@ Checks: >
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 FormatStyle: 'file'
+CheckOptions:
+    - key:   modernize-use-default-member-init.UseAssignment
+      value: 1
 ...

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1370,15 +1370,13 @@ extern halide_can_use_target_features_t halide_set_custom_can_use_target_feature
 extern int halide_default_can_use_target_features(int count, const uint64_t *features);
 
 typedef struct halide_dimension_t {
-    int32_t min, extent, stride;
+#ifdef __cplusplus
+    int32_t min = 0, extent = 0, stride = 0;
 
     // Per-dimension flags. None are defined yet (This is reserved for future use).
-    uint32_t flags;
+    uint32_t flags = 0;
 
-#ifdef __cplusplus
-    HALIDE_ALWAYS_INLINE halide_dimension_t()
-        : min(0), extent(0), stride(0), flags(0) {
-    }
+    HALIDE_ALWAYS_INLINE halide_dimension_t() = default;
     HALIDE_ALWAYS_INLINE halide_dimension_t(int32_t m, int32_t e, int32_t s, uint32_t f = 0)
         : min(m), extent(e), stride(s), flags(f) {
     }
@@ -1393,6 +1391,11 @@ typedef struct halide_dimension_t {
     HALIDE_ALWAYS_INLINE bool operator!=(const halide_dimension_t &other) const {
         return !(*this == other);
     }
+#else
+    int32_t min, extent, stride;
+
+    // Per-dimension flags. None are defined yet (This is reserved for future use).
+    uint32_t flags;
 #endif
 } halide_dimension_t;
 

--- a/src/runtime/posix_threads.cpp
+++ b/src/runtime/posix_threads.cpp
@@ -93,14 +93,13 @@ namespace Synchronization {
 struct thread_parker {
     pthread_mutex_t mutex;
     pthread_cond_t condvar;
-    bool should_park;
+    bool should_park = false;
 
 #if __cplusplus >= 201103L
     thread_parker(const thread_parker &) = delete;
 #endif
 
-    ALWAYS_INLINE thread_parker()
-        : should_park(false) {
+    ALWAYS_INLINE thread_parker() {
         pthread_mutex_init(&mutex, NULL);
         pthread_cond_init(&condvar, NULL);
         should_park = false;

--- a/src/runtime/qurt_threads.cpp
+++ b/src/runtime/qurt_threads.cpp
@@ -84,14 +84,13 @@ namespace Synchronization {
 struct thread_parker {
     qurt_mutex_t mutex;
     qurt_cond_t condvar;
-    bool should_park;
+    bool should_park = false;
 
 #if __cplusplus >= 201103L
     thread_parker(const thread_parker &) = delete;
 #endif
 
-    ALWAYS_INLINE thread_parker()
-        : should_park(false) {
+    ALWAYS_INLINE thread_parker() {
         qurt_mutex_init(&mutex);
         qurt_cond_init(&condvar);
         should_park = false;

--- a/src/runtime/synchronization_common.h
+++ b/src/runtime/synchronization_common.h
@@ -228,12 +228,11 @@ ALWAYS_INLINE void atomic_thread_fence_acquire() {
 }  // namespace
 
 class spin_control {
-    int spin_count;
+    int spin_count = 40;
 
 public:
     // Everyone says this should be 40. Have not measured it.
-    ALWAYS_INLINE spin_control()
-        : spin_count(40) {
+    ALWAYS_INLINE spin_control() {
     }
 
     ALWAYS_INLINE bool should_spin() {
@@ -278,13 +277,12 @@ struct word_lock_queue_data {
     // The only cost is the O(n) processing, but this only needs to be done
     // once for each node, and therefore isn't too expensive.
 
-    word_lock_queue_data *next;
-    word_lock_queue_data *prev;
+    word_lock_queue_data *next = NULL;
+    word_lock_queue_data *prev = NULL;
 
-    word_lock_queue_data *tail;
+    word_lock_queue_data *tail = NULL;
 
-    ALWAYS_INLINE word_lock_queue_data()
-        : next(NULL), prev(NULL), tail(NULL) {
+    ALWAYS_INLINE word_lock_queue_data() {
     }
 
     // Inlined, empty dtor needed to avoid confusing MachO builds
@@ -293,14 +291,13 @@ struct word_lock_queue_data {
 };
 
 class word_lock {
-    uintptr_t state;
+    uintptr_t state = 0;
 
     void lock_full();
     void unlock_full();
 
 public:
-    ALWAYS_INLINE word_lock()
-        : state(0) {
+    ALWAYS_INLINE word_lock() {
     }
     ALWAYS_INLINE void lock() {
         if_tsan_pre_lock(this);
@@ -462,14 +459,13 @@ WEAK void word_lock::unlock_full() {
 struct queue_data {
     thread_parker parker;  // TODO: member or pointer?
 
-    uintptr_t sleep_address;
+    uintptr_t sleep_address = 0;
 
-    queue_data *next;
+    queue_data *next = NULL;
 
-    uintptr_t unpark_info;
+    uintptr_t unpark_info = 0;
 
-    ALWAYS_INLINE queue_data()
-        : sleep_address(0), next(NULL), unpark_info(0) {
+    ALWAYS_INLINE queue_data() {
     }
     // Inlined, empty dtor needed to avoid confusing MachO builds
     ALWAYS_INLINE ~queue_data() {
@@ -593,11 +589,10 @@ WEAK void unlock_bucket_pair(bucket_pair &buckets) {
 }
 
 struct validate_action {
-    bool unpark_one;
-    uintptr_t invalid_unpark_info;
+    bool unpark_one = false;
+    uintptr_t invalid_unpark_info = 0;
 
-    ALWAYS_INLINE validate_action()
-        : unpark_one(false), invalid_unpark_info(0) {
+    ALWAYS_INLINE validate_action() {
     }
 };
 
@@ -1089,11 +1084,10 @@ WEAK uintptr_t wait_parking_control_unpark(void *control, int unparked, bool mor
 }
 
 class fast_cond {
-    uintptr_t state;
+    uintptr_t state = 0;
 
 public:
-    ALWAYS_INLINE fast_cond()
-        : state(0) {
+    ALWAYS_INLINE fast_cond() {
     }
 
     ALWAYS_INLINE void signal() {

--- a/src/runtime/tracing.cpp
+++ b/src/runtime/tracing.cpp
@@ -17,7 +17,7 @@ namespace Internal {
 // that's a bad name. We use the __sync primitives used elsewhere in
 // the runtime for atomic work. They are well supported by clang.
 class SharedExclusiveSpinLock {
-    volatile uint32_t lock;
+    volatile uint32_t lock = 0;
 
     // Covers a single bit indicating one owner has exclusive
     // access. The waiting bit can be set while the exclusive bit is
@@ -70,8 +70,7 @@ public:
         lock = 0;
     }
 
-    SharedExclusiveSpinLock()
-        : lock(0) {
+    SharedExclusiveSpinLock() {
     }
 };
 
@@ -79,7 +78,7 @@ const static int buffer_size = 1024 * 1024;
 
 class TraceBuffer {
     SharedExclusiveSpinLock lock;
-    uint32_t cursor, overage;
+    uint32_t cursor = 0, overage = 0;
     uint8_t buf[buffer_size];
 
     // Attempt to atomically acquire space in the buffer to write a
@@ -144,8 +143,7 @@ public:
         lock.init();
     }
 
-    TraceBuffer()
-        : cursor(0), overage(0) {
+    TraceBuffer() {
     }
 };
 

--- a/src/runtime/windows_threads.cpp
+++ b/src/runtime/windows_threads.cpp
@@ -87,14 +87,13 @@ namespace Synchronization {
 struct thread_parker {
     CriticalSection critical_section;
     ConditionVariable condvar;
-    bool should_park;
+    bool should_park = false;
 
 #if __cplusplus >= 201103L
     thread_parker(const thread_parker &) = delete;
 #endif
 
-    ALWAYS_INLINE thread_parker()
-        : should_park(false) {
+    ALWAYS_INLINE thread_parker() {
         InitializeCriticalSection(&critical_section);
         InitializeConditionVariable(&condvar);
         should_park = false;


### PR DESCRIPTION
...and fix the resulting code.