### PR TITLE
Add `logical_not` function for Python

### DIFF
--- a/python_bindings/correctness/negate_test.py
+++ b/python_bindings/correctness/negate_test.py
@@ -1,0 +1,38 @@
+import halide as hl
+
+def test_free_logical_not_function():
+    x = hl.Var('x')
+
+    f = hl.Func('f')
+    f[x] = x > 5
+
+    not_f = hl.Func('not_f')
+    not_f[x] = hl.logical_not(f[x])
+
+    f_out = f.realize(10)
+    not_f_out = not_f.realize(10)
+
+    for i in range(10):
+        assert f_out[i] == (i > 5)
+        assert not_f_out[i] == (i <= 5)
+
+
+def test_member_logical_not_function():
+    x = hl.Var('x')
+
+    f = hl.Func('f')
+    f[x] = x > 5
+
+    not_f = hl.Func('not_f')
+    not_f[x] = f[x].logical_not()
+
+    f_out = f.realize(10)
+    not_f_out = not_f.realize(10)
+
+    for i in range(10):
+        assert f_out[i] == (i > 5)
+        assert not_f_out[i] == (i <= 5)
+
+if __name__ == "__main__":
+    test_free_logical_not_function()
+    test_member_logical_not_function()

--- a/python_bindings/readme.md
+++ b/python_bindings/readme.md
@@ -33,6 +33,7 @@ with some differences where the C++ idiom is either inappropriate or impossible:
   entirely for now.
 - `Func::in` becomes `Func.in_` because `in` is a Python keyword.
 - `Func::async` becomes `Func.async_` because `async` is a Python keyword.
+- The `not` keyword cannot be used to negate boolean Halide expressions. Instead, the `logical_not` function can be used and is equivalent to using `operator!` in C++.
 
 ## Enhancements to the C++ API
 

--- a/python_bindings/src/PyBinaryOperators.h
+++ b/python_bindings/src/PyBinaryOperators.h
@@ -180,11 +180,15 @@ void add_binary_operators(PythonClass &class_instance) {
         .def("__pow__", pow_wrap, py::is_operator())
         .def("__rpow__", pow_wrap, py::is_operator());
 
+    const auto logical_not_wrap = [](const self_t &self) -> decltype(!self) {
+        return !self;
+    };
+
     // Define unary operators
     class_instance
         .def(-py::self)  // neg
         .def(~py::self)  // invert
-        ;
+        .def("logical_not", logical_not_wrap);
 }
 
 }  // namespace PythonBindings

--- a/python_bindings/src/PyIROperator.cpp
+++ b/python_bindings/src/PyIROperator.cpp
@@ -185,6 +185,9 @@ void define_operators(py::module &m) {
     m.def("likely_if_innermost", &likely_if_innermost);
     m.def("saturating_cast", (Expr(*)(Type, Expr)) & saturating_cast);
     m.def("strict_float", &strict_float);
+    m.def("logical_not", [](const Expr &expr) -> Expr {
+        return !expr;
+    });
 }
 
 }  // namespace PythonBindings


### PR DESCRIPTION
This change introduces `logical_not` as a free function and member function
that calls `operator!`.

The reason why a new function is added is because there is no `operator!`
in Python and the `not` keyword cannot be overloaded. Hence, there was
currently no way to call the C++ `operator!` in Python.