### PR TITLE
Push lets near their uses (whenever possible) while CSEing +=

### DIFF
--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -230,7 +230,7 @@ class RemoveLets : public IRGraphMutator {
 class GetVarsUsed : public IRVisitor {
 private:
     using IRVisitor::visit;
-    void visit(const Variable *op) {
+    void visit(const Variable *op) override {
         vars_used.insert(op->name);
     }
 

--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -6,16 +6,15 @@
 #include "IROperator.h"
 #include "Scope.h"
 #include "Simplify.h"
-#include "ExprUsesVar.h"
 
 namespace Halide {
 namespace Internal {
 
 using std::map;
 using std::pair;
+using std::set;
 using std::string;
 using std::vector;
-using std::set;
 
 namespace {
 
@@ -234,6 +233,7 @@ private:
     void visit(const Variable *op) {
         vars_used.insert(op->name);
     }
+
 public:
     set<string> vars_used;
 };
@@ -264,7 +264,7 @@ class CSEEveryExprInStmt : public IRMutator {
         GetVarsUsed g;
         c->args[1].accept(&g);
 
-        vector<pair<string,Expr>> lets_for_letstmts;
+        vector<pair<string, Expr>> lets_for_letstmts;
         for (auto it = lets.rbegin(); it != lets.rend(); it++) {
             if (g.vars_used.count(it->first)) {
                 lets_for_letstmts.emplace_back(it->first, it->second);
@@ -279,7 +279,7 @@ class CSEEveryExprInStmt : public IRMutator {
                 v = Let::make(it->first, it->second, v);
             }
         }
-        
+
         Stmt s = Store::make(op->name, v, c->args[1],
                              op->param, mutate(op->predicate), op->alignment);
 

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -415,7 +415,7 @@ Module lower(const vector<Function> &output_funcs,
 
     debug(1) << "Simplifying...\n";
     s = common_subexpression_elimination(s);
-    debug(2) << "Lowering after common subexpression elimination"
+    debug(2) << "Lowering after common subexpression elimination:\n"
              << s << "\n\n";
 
     if (t.has_feature(Target::OpenGL)) {

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -415,6 +415,8 @@ Module lower(const vector<Function> &output_funcs,
 
     debug(1) << "Simplifying...\n";
     s = common_subexpression_elimination(s);
+    debug(2) << "Lowering after common subexpression elimination"
+             << s << "\n\n";
 
     if (t.has_feature(Target::OpenGL)) {
         debug(1) << "Detecting varying attributes...\n";


### PR DESCRIPTION
The CSE pass tries to do CSE jointly on the index and value of store nodes.
This is to stop:
```
f[x] = f[x] + y
```
from turning into
```
f[x] = f[z] + y
```
This is because the two 'x' indices are not CSE'd together.

However, one problem with jointly CSEing the store index and vaues
is that after CSEing, the pass puts the lets
(the values that were CSE'd) before the new store. That is we get,

```
let(t0...)
let(t1...)
f[t0] = f[t0] + function_of(t1)
```
Suppose however, there was nothing to CSE between the store index and value, that is
the index was unchanged after CSE. In that case, moving lets before the store puts the
lets too far away from their uses. This is ok except, there are passes like LoopCarry
that are beneficial when they are able to see a long continuous block of stores (eg. when
unrolling). But now, they'll see a long sequence of LetStmts.
Instead, if the index was unchanged after CSE, we should build up the stores as

```
f[x] = let(t0.. in (value));
```
This way LoopCarry is given a chance to see a series of stores.
Handling this in CSE, means the LoopCarry pass need not be complicated.

