### PR TITLE
Require WASM features to match

### DIFF
--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -940,7 +940,7 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
 
     const std::array<Feature, 12> intersection_features = {{SSE41, AVX, AVX2, FMA, FMA4, F16C, ARMv7s, VSX, AVX512, AVX512_KNL, AVX512_Skylake, AVX512_Cannonlake}};
 
-    const std::array<Feature, 10> matching_features = {{SoftFloatABI, Debug, TSAN, ASAN, MSAN, HVX_64, HVX_128, HexagonDma, HVX_shared_object}};
+    const std::array<Feature, 10> matching_features = {{SoftFloatABI, Debug, TSAN, ASAN, MSAN, HVX_64, HVX_128, HexagonDma, HVX_shared_object, WasmSimd128, WasmSignExt, WasmSatFloatToInt, WasmThreads}};
 
     // bitsets need to be the same width.
     decltype(result.features) union_mask;


### PR DESCRIPTION
This is based on #5395.

This will fix issue #5397 