### PR TITLE
More clang-tidy cleanup

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,13 +2,20 @@
 # files elsewhere in the tree; clang-tidy-10 doesn't allow selective
 # inheritance of parent .clang-tidy files.
 
+# TODO: some of the blocklisted bugprone checks can/should be re-enabled
+# one at a time (with careful code fixes made as necessary).
+
 ---
 Checks: >
     -*,
-    bugprone-macro-parenthesis,
-    bugprone-parent-virtual-call,
-    bugprone-sizeof-expression,
-    bugprone-string-constructor,
+    bugprone-*,
+    -bugprone-branch-clone,
+    -bugprone-exception-escape,
+    -bugprone-incorrect-roundings,
+    -bugprone-integer-division,
+    -bugprone-macro-parentheses,
+    -bugprone-narrowing-conversions,
+    -bugprone-signed-char-misuse,
     misc-*,
     -misc-non-private-member-variables-in-classes,
     -misc-unconventional-assign-operator,

--- a/src/IntrusivePtr.h
+++ b/src/IntrusivePtr.h
@@ -135,7 +135,7 @@ public:
     }
 
     IntrusivePtr<T> &operator=(const IntrusivePtr<T> &other) {
-        if (this == &other) {
+        if (other.ptr == ptr) {  // NOLINT(bugprone-unhandled-self-assignment)
             return *this;
         }
         // Other can be inside of something owned by this, so we

--- a/src/IntrusivePtr.h
+++ b/src/IntrusivePtr.h
@@ -136,6 +136,8 @@ public:
 
     // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
     IntrusivePtr<T> &operator=(const IntrusivePtr<T> &other) {
+        // Same-ptr but different-this happens frequently enough
+        // to check for (see https://github.com/halide/Halide/pull/5412)
         if (other.ptr == ptr) {
             return *this;
         }

--- a/src/IntrusivePtr.h
+++ b/src/IntrusivePtr.h
@@ -135,7 +135,7 @@ public:
     }
 
     IntrusivePtr<T> &operator=(const IntrusivePtr<T> &other) {
-        if (other.ptr == ptr) {
+        if (this == &other) {
             return *this;
         }
         // Other can be inside of something owned by this, so we

--- a/src/IntrusivePtr.h
+++ b/src/IntrusivePtr.h
@@ -134,8 +134,9 @@ public:
         other.ptr = nullptr;
     }
 
+    // NOLINTNEXTLINE(bugprone-unhandled-self-assignment)
     IntrusivePtr<T> &operator=(const IntrusivePtr<T> &other) {
-        if (other.ptr == ptr) {  // NOLINT(bugprone-unhandled-self-assignment)
+        if (other.ptr == ptr) {
             return *this;
         }
         // Other can be inside of something owned by this, so we

--- a/src/autoschedulers/.clang-tidy
+++ b/src/autoschedulers/.clang-tidy
@@ -16,10 +16,14 @@
 ---
 Checks: >
     -*,
-    bugprone-macro-parenthesis,
-    bugprone-parent-virtual-call,
-    bugprone-sizeof-expression,
-    bugprone-string-constructor,
+    bugprone-*,
+    -bugprone-branch-clone,
+    -bugprone-exception-escape,
+    -bugprone-incorrect-roundings,
+    -bugprone-integer-division,
+    -bugprone-macro-parentheses,
+    -bugprone-narrowing-conversions,
+    -bugprone-signed-char-misuse,
     misc-*,
     -misc-non-private-member-variables-in-classes,
     -misc-unconventional-assign-operator,

--- a/src/runtime/.clang-tidy
+++ b/src/runtime/.clang-tidy
@@ -7,7 +7,8 @@
 # where specialization is needed.
 
 #
-# The desired change here is just to remove:
+# The desired change here is to remove:
+#       bugprone-dynamic-static-initializers
 #       bugprone-sizeof-expression
 #       misc-definitions-in-headers
 #
@@ -15,10 +16,16 @@
 ---
 Checks: >
     -*,
-    bugprone-macro-parenthesis,
-    bugprone-parent-virtual-call,
+    bugprone-*,
+    -bugprone-branch-clone,
+    -bugprone-dynamic-static-initializers,
+    -bugprone-exception-escape,
+    -bugprone-incorrect-roundings,
+    -bugprone-integer-division,
+    -bugprone-macro-parentheses,
+    -bugprone-narrowing-conversions,
+    -bugprone-signed-char-misuse,
     -bugprone-sizeof-expression,
-    bugprone-string-constructor,
     misc-*,
     -misc-definitions-in-headers,
     -misc-non-private-member-variables-in-classes,

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -709,7 +709,8 @@ public:
 
     /** Standard assignment operator */
     Buffer<T, D> &operator=(const Buffer<T, D> &other) {
-        if (this == &other) {
+        // The cast to void* here is just to satisfy clang-tidy
+        if ((const void *)this == (const void *)&other) {
             return *this;
         }
         other.incref();


### PR DESCRIPTION
Enable all the bugprone-* checks, then disable the ones we don't want (or need code fixes for).

Made a couple of trivial changes to pacify bugprone-unhandled-self-assignment.

Some of the other disabled checks are likely worthwhile but will be done separately to ensure code review isn't confused.

