### PR TITLE
Fix various clang-tidy issues

### DIFF
--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -86,7 +86,7 @@ StubInput to_stub_input(const py::object &o) {
 
 void append_input(const py::object &value, std::vector<StubInput> &v) {
     if (is_real_sequence(value)) {
-        for (auto o : py::reinterpret_borrow<py::sequence>(value)) {
+        for (const auto &o : py::reinterpret_borrow<py::sequence>(value)) {
             v.push_back(to_stub_input(o));
         }
     } else {

--- a/src/FindCalls.cpp
+++ b/src/FindCalls.cpp
@@ -74,7 +74,7 @@ void populate_environment_helper(Function f, map<string, Function> &env,
     } else {
         env[f.name()] = f;
 
-        for (pair<string, Function> i : calls.calls) {
+        for (const pair<string, Function> &i : calls.calls) {
             populate_environment_helper(i.second, env, recursive, include_wrappers);
         }
     }

--- a/src/FindCalls.cpp
+++ b/src/FindCalls.cpp
@@ -74,7 +74,7 @@ void populate_environment_helper(Function f, map<string, Function> &env,
     } else {
         env[f.name()] = f;
 
-        for (const pair<string, Function> &i : calls.calls) {
+        for (const auto &i : calls.calls) {
             populate_environment_helper(i.second, env, recursive, include_wrappers);
         }
     }

--- a/src/FindCalls.cpp
+++ b/src/FindCalls.cpp
@@ -9,7 +9,6 @@ namespace Halide {
 namespace Internal {
 
 using std::map;
-using std::pair;
 using std::string;
 
 namespace {

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -351,7 +351,7 @@ Stmt inject_profiling(Stmt s, const string &pipeline_name) {
                            MemoryType::Auto, {num_funcs}, const_true(), s);
     }
 
-    for (std::pair<string, int> p : profiling.indices) {
+    for (const std::pair<string, int> &p : profiling.indices) {
         s = Block::make(Store::make("profiling_func_names", p.first, p.second, Parameter(), const_true(), ModulusRemainder()), s);
     }
 

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -351,7 +351,7 @@ Stmt inject_profiling(Stmt s, const string &pipeline_name) {
                            MemoryType::Auto, {num_funcs}, const_true(), s);
     }
 
-    for (const std::pair<string, int> &p : profiling.indices) {
+    for (const auto &p : profiling.indices) {
         s = Block::make(Store::make("profiling_func_names", p.first, p.second, Parameter(), const_true(), ModulusRemainder()), s);
     }
 

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -1415,7 +1415,7 @@ int run(bool ignore_trace_tags, FlagProcessor flag_processor) {
 
         // Print stats about the Func gleaned from the trace.
         std::vector<std::pair<std::string, FuncInfo>> funcs;
-        for (std::pair<std::string, FuncInfo> p : state.funcs) {
+        for (const std::pair<std::string, FuncInfo> &p : state.funcs) {
             funcs.push_back(p);
         }
         struct by_first_packet_idx {

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -1416,7 +1416,7 @@ int run(bool ignore_trace_tags, FlagProcessor flag_processor) {
         // Print stats about the Func gleaned from the trace.
         std::vector<std::pair<std::string, FuncInfo>> funcs;
         for (const auto &p : state.funcs) {
-            funcs.push_back(p);
+            funcs.emplace_back(p);
         }
         struct by_first_packet_idx {
             bool operator()(const std::pair<std::string, FuncInfo> &a,

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -1415,7 +1415,7 @@ int run(bool ignore_trace_tags, FlagProcessor flag_processor) {
 
         // Print stats about the Func gleaned from the trace.
         std::vector<std::pair<std::string, FuncInfo>> funcs;
-        for (const std::pair<std::string, FuncInfo> &p : state.funcs) {
+        for (const auto &p : state.funcs) {
             funcs.push_back(p);
         }
         struct by_first_packet_idx {


### PR DESCRIPTION
For some reason, these are only getting flagged under C++17 builds, but they are legit (minor) issues we want to fix.