### PR TITLE
Upgrade PyBind11 version in CMake to 2.5

### DIFF
--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -12,7 +12,7 @@ message(STATUS "Directing pybind11 to Python3 executable ${Python3_EXECUTABLE}")
 set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 
 # Keep the version in sync with requirements.txt and the Ubuntu 20.04 LTS package (python3-pybind11)
-set(PYBIND11_VER 2.4.3)
+set(PYBIND11_VER 2.5.0)
 find_package(pybind11 ${PYBIND11_VER} QUIET)
 if (NOT pybind11_FOUND)
     include(FetchContent)

--- a/python_bindings/requirements.txt
+++ b/python_bindings/requirements.txt
@@ -1,7 +1,7 @@
-# This file lists the python dependencies, 
+# This file lists the python dependencies,
 # it is meant to be used with pip (and/or possibly virtualenv, pbundler, etc)
 # See http://pip.readthedocs.org/en/latest/user_guide.html#requirements-files
-# You will probably want to run 
+# You will probably want to run
 # something similar to `pip3 install --user -r requirements.txt`
 
 # science packages
@@ -12,4 +12,4 @@ pillow
 # Keep versions of these requirements equal to the versions in Ubuntu 20.04 LTS
 # because newer versions fix bugs we work around.
 imageio==2.4.1
-pybind11==2.4.3
+pybind11==2.5.0


### PR DESCRIPTION
v2.4.3 can generate a lot of compiler warnings under C++17; v2.5 fixes these.

Note 1: I am unsure about the issues with keeping in sync with Ubuntu 20.04; tagging @alexreinking for comments

Note 2: the current version of PyBind11 is actually v2.6, but it has many more changes and upgrading looks nontrivial; deliberately holding off on that upgrade for now.