### PR TITLE
Use new flag for clang tidy behavior in cmake

### DIFF
--- a/README_cmake.md
+++ b/README_cmake.md
@@ -342,6 +342,7 @@ compiled.
 | `Halide_BUNDLE_LLVM`                     | `OFF`                 | When building Halide as a static library, unpack the LLVM static libraries and add those objects to libHalide.a. |
 | `Halide_SHARED_LLVM`                     | `OFF`                 | Link to the shared version of LLVM. Not available on Windows.                                                    |
 | `Halide_ENABLE_RTTI`                     | _inherited from LLVM_ | Enable RTTI when building Halide. Recommended to be set to `ON`                                                  |
+| `Halide_CLANG_TIDY_BUILD`                | `OFF`                 | Used internally to generate fake compile job when running clang-tidy                                             |
 | `Halide_ENABLE_EXCEPTIONS`               | `ON`                  | Enable exceptions when building Halide                                                                           |
 | `Halide_USE_CODEMODEL_LARGE`             | `OFF`                 | Use the Large LLVM codemodel                                                                                     |
 | `Halide_TARGET`                          | _empty_               | The default target triple to use for `add_halide_library` (and the generator tests, by extension)                |

--- a/README_cmake.md
+++ b/README_cmake.md
@@ -342,7 +342,7 @@ compiled.
 | `Halide_BUNDLE_LLVM`                     | `OFF`                 | When building Halide as a static library, unpack the LLVM static libraries and add those objects to libHalide.a. |
 | `Halide_SHARED_LLVM`                     | `OFF`                 | Link to the shared version of LLVM. Not available on Windows.                                                    |
 | `Halide_ENABLE_RTTI`                     | _inherited from LLVM_ | Enable RTTI when building Halide. Recommended to be set to `ON`                                                  |
-| `Halide_CLANG_TIDY_BUILD`                | `OFF`                 | Used internally to generate fake compile job when running clang-tidy                                             |
+| `Halide_CLANG_TIDY_BUILD`                | `OFF`                 | Used internally to generate fake compile jobs for runtime files when running clang-tidy.                         |
 | `Halide_ENABLE_EXCEPTIONS`               | `ON`                  | Enable exceptions when building Halide                                                                           |
 | `Halide_USE_CODEMODEL_LARGE`             | `OFF`                 | Use the Large LLVM codemodel                                                                                     |
 | `Halide_TARGET`                          | _empty_               | The default target triple to use for `add_halide_library` (and the generator tests, by extension)                |

--- a/run-clang-tidy.sh
+++ b/run-clang-tidy.sh
@@ -26,6 +26,7 @@ echo CLANG_TIDY_BUILD_DIR = ${CLANG_TIDY_BUILD_DIR}
 echo Building compile_commands.json...
 cmake -DCMAKE_BUILD_TYPE=Debug \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+      -DBUILDING_FOR_CLANG_TIDY=ON \
       -DLLVM_DIR=${CLANG_TIDY_LLVM_INSTALL_DIR}/lib/cmake/llvm \
       -S ${ROOT_DIR} \
       -B ${CLANG_TIDY_BUILD_DIR} \

--- a/run-clang-tidy.sh
+++ b/run-clang-tidy.sh
@@ -26,7 +26,7 @@ echo CLANG_TIDY_BUILD_DIR = ${CLANG_TIDY_BUILD_DIR}
 echo Building compile_commands.json...
 cmake -DCMAKE_BUILD_TYPE=Debug \
       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-      -DBUILDING_FOR_CLANG_TIDY=ON \
+      -DHalide_CLANG_TIDY_BUILD=ON \
       -DLLVM_DIR=${CLANG_TIDY_LLVM_INSTALL_DIR}/lib/cmake/llvm \
       -S ${ROOT_DIR} \
       -B ${CLANG_TIDY_BUILD_DIR} \

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -216,7 +216,7 @@ foreach (i IN LISTS RUNTIME_CPP)
                 set(dep_args "")
             endif ()
 
-            if (BUILDING_FOR_CLANG_TIDY)
+            if (Halide_CLANG_TIDY_BUILD)
                 # Create a 'fake' entry just so that clang-tidy will see a C++ compilation command
                 # that it can use for tidy-checking. (This branch should never be taken by 'normal'
                 # compilations.)

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -216,7 +216,7 @@ foreach (i IN LISTS RUNTIME_CPP)
                 set(dep_args "")
             endif ()
 
-            if (CMAKE_EXPORT_COMPILE_COMMANDS)
+            if (BUILDING_FOR_CLANG_TIDY)
                 # Create a 'fake' entry just so that clang-tidy will see a C++ compilation command
                 # that it can use for tidy-checking. (This branch should never be taken by 'normal'
                 # compilations.)


### PR DESCRIPTION
Every once in a while it seems that CMAKE_EXPORT_COMPILE_COMMANDS gets enabled for me, possibly by VSCode, and the build grinds to a halt. Setting it to false in the cache gets everything working again.  It seems like there are valid applications for a compilation database even when doing normal builds (such as knowing flags for parsing with other tools).  This gives the clang-tidy behavior its own flag.