### PR TITLE
Revert C++11 usage in hexagon_remote

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -445,7 +445,7 @@ struct halide_type_t {
     HALIDE_ATTRIBUTE_ALIGN(2)
     uint16_t lanes;
 
-#ifdef __cplusplus
+#if __cplusplus >= 201103L
     /** Construct a runtime representation of a Halide type from:
      * code: The fundamental type from an enum.
      * bits: The bit size of one element.
@@ -547,7 +547,7 @@ struct halide_trace_event_t {
     /** The length of the coordinates array */
     int32_t dimensions;
 
-#ifdef __cplusplus
+#if __cplusplus >= 201103L
     // If we don't explicitly mark the default ctor as inline,
     // certain build configurations can fail (notably iOS)
     HALIDE_ALWAYS_INLINE halide_trace_event_t() = default;
@@ -616,7 +616,7 @@ struct halide_trace_packet_t {
     int32_t dimensions;
     // @}
 
-#ifdef __cplusplus
+#if __cplusplus >= 201103L
     // If we don't explicitly mark the default ctor as inline,
     // certain build configurations can fail (notably iOS)
     HALIDE_ALWAYS_INLINE halide_trace_packet_t() = default;
@@ -1368,7 +1368,7 @@ extern halide_can_use_target_features_t halide_set_custom_can_use_target_feature
 extern int halide_default_can_use_target_features(int count, const uint64_t *features);
 
 typedef struct halide_dimension_t {
-#ifdef __cplusplus
+#if __cplusplus >= 201103L
     int32_t min = 0, extent = 0, stride = 0;
 
     // Per-dimension flags. None are defined yet (This is reserved for future use).
@@ -1437,7 +1437,7 @@ typedef struct halide_buffer_t {
     /** Pads the buffer up to a multiple of 8 bytes */
     void *padding;
 
-#ifdef __cplusplus
+#if __cplusplus >= 201103L
     /** Convenience methods for accessing the flags */
     // @{
     HALIDE_ALWAYS_INLINE bool get_flag(halide_buffer_flags flag) const {
@@ -1888,7 +1888,7 @@ extern void halide_register_device_allocation_pool(struct halide_device_allocati
 }  // End extern "C"
 #endif
 
-#ifdef __cplusplus
+#if __cplusplus >= 201103L
 
 namespace {
 template<typename T>
@@ -1962,6 +1962,6 @@ HALIDE_ALWAYS_INLINE halide_type_t halide_type_of<int64_t>() {
     return halide_type_t(halide_type_int, 64);
 }
 
-#endif
+#endif  // __cplusplus >= 201103L
 
 #endif  // HALIDE_HALIDERUNTIME_H

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -401,7 +401,7 @@ extern int32_t halide_debug_to_file(void *user_context, const char *filename,
  * (the bit width is expected to be encoded in a separate value).
  */
 typedef enum halide_type_code_t
-#if __cplusplus >= 201103L
+#if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L)
     : uint8_t
 #endif
 {
@@ -429,7 +429,7 @@ typedef enum halide_type_code_t
  * exactly 32-bits in size. */
 struct halide_type_t {
     /** The basic type code: signed integer, unsigned integer, or floating point. */
-#if __cplusplus >= 201103L
+#if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L)
     HALIDE_ATTRIBUTE_ALIGN(1)
     halide_type_code_t code;  // halide_type_code_t
 #else
@@ -445,7 +445,7 @@ struct halide_type_t {
     HALIDE_ATTRIBUTE_ALIGN(2)
     uint16_t lanes;
 
-#if __cplusplus >= 201103L
+#if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L)
     /** Construct a runtime representation of a Halide type from:
      * code: The fundamental type from an enum.
      * bits: The bit size of one element.
@@ -547,7 +547,7 @@ struct halide_trace_event_t {
     /** The length of the coordinates array */
     int32_t dimensions;
 
-#if __cplusplus >= 201103L
+#if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L)
     // If we don't explicitly mark the default ctor as inline,
     // certain build configurations can fail (notably iOS)
     HALIDE_ALWAYS_INLINE halide_trace_event_t() = default;
@@ -616,7 +616,7 @@ struct halide_trace_packet_t {
     int32_t dimensions;
     // @}
 
-#if __cplusplus >= 201103L
+#if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L)
     // If we don't explicitly mark the default ctor as inline,
     // certain build configurations can fail (notably iOS)
     HALIDE_ALWAYS_INLINE halide_trace_packet_t() = default;
@@ -1368,7 +1368,7 @@ extern halide_can_use_target_features_t halide_set_custom_can_use_target_feature
 extern int halide_default_can_use_target_features(int count, const uint64_t *features);
 
 typedef struct halide_dimension_t {
-#if __cplusplus >= 201103L
+#if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L)
     int32_t min = 0, extent = 0, stride = 0;
 
     // Per-dimension flags. None are defined yet (This is reserved for future use).
@@ -1437,7 +1437,7 @@ typedef struct halide_buffer_t {
     /** Pads the buffer up to a multiple of 8 bytes */
     void *padding;
 
-#if __cplusplus >= 201103L
+#if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L)
     /** Convenience methods for accessing the flags */
     // @{
     HALIDE_ALWAYS_INLINE bool get_flag(halide_buffer_flags flag) const {
@@ -1888,7 +1888,7 @@ extern void halide_register_device_allocation_pool(struct halide_device_allocati
 }  // End extern "C"
 #endif
 
-#if __cplusplus >= 201103L
+#if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L)
 
 namespace {
 template<typename T>
@@ -1962,6 +1962,6 @@ HALIDE_ALWAYS_INLINE halide_type_t halide_type_of<int64_t>() {
     return halide_type_t(halide_type_int, 64);
 }
 
-#endif  // __cplusplus >= 201103L
+#endif  // (__cplusplus >= 201103L || _MSVC_LANG >= 201103L)
 
 #endif  // HALIDE_HALIDERUNTIME_H

--- a/src/runtime/hexagon_remote/Makefile
+++ b/src/runtime/hexagon_remote/Makefile
@@ -41,24 +41,23 @@ HEXAGON_SDK_LIBS ?= "${HEXAGON_SDK_ROOT}/libs"
 
 COMMON_FLAGS = -I ${HEXAGON_SDK_INCLUDES}/stddef -I../
 COMMON_CCFLAGS = ${COMMON_FLAGS} -O3 -I ${HEXAGON_SDK_LIBS}/common/remote/ship/android_Release
-COMMON_CXXFLAGS = -std=c++11 -fno-threadsafe-statics
 HEXAGON_QAICFLAGS = ${COMMON_FLAGS}
 
 BIN ?= bin
 
 CC-host = ${CXX}
-CXX-host = ${CXX} $(COMMON_CXXFLAGS)
+CXX-host = ${CXX}
 
 CC-v62 = ${HEXAGON_TOOLS_ROOT}/Tools/bin/hexagon-clang
-CXX-v62 = ${HEXAGON_TOOLS_ROOT}/Tools/bin/hexagon-clang++ $(COMMON_CXXFLAGS)
+CXX-v62 = ${HEXAGON_TOOLS_ROOT}/Tools/bin/hexagon-clang++
 LD-v62 = ${HEXAGON_TOOLS_ROOT}/Tools/bin/hexagon-link
 
 CC-arm-64-android = ${ANDROID_NDK_ROOT}/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-gcc
-CXX-arm-64-android = ${ANDROID_NDK_ROOT}/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-g++ $(COMMON_CXXFLAGS)
+CXX-arm-64-android = ${ANDROID_NDK_ROOT}/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-g++
 CCFLAGS-arm-64-android = --sysroot ${ANDROID_NDK_ROOT}/platforms/android-21/arch-arm64
 
 CC-arm-32-android = ${ANDROID_NDK_ROOT}/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-gcc
-CXX-arm-32-android = ${ANDROID_NDK_ROOT}/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-g++ $(COMMON_CXXFLAGS)
+CXX-arm-32-android = ${ANDROID_NDK_ROOT}/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-g++
 CCFLAGS-arm-32-android = --sysroot ${ANDROID_NDK_ROOT}/platforms/android-21/arch-arm
 
 CCFLAGS-host := ${CCFLAGS} -I../ -I ${HEXAGON_TOOLS_ROOT}/Tools/include/iss/ -fPIC \
@@ -154,7 +153,7 @@ $(BIN)/%/sim_remote.o: sim_remote.cpp sim_protocol.h known_symbols.h $(BIN)/src/
 
 $(BIN)/%/sim_host.o: sim_host.cpp sim_protocol.h
 	mkdir -p $(@D)
-	$(CXX-$*) $(CCFLAGS-$*) -c sim_host.cpp -o $@
+	$(CXX-$*) -std=c++11 $(CCFLAGS-$*) -c sim_host.cpp -o $@
 
 $(BIN)/%/sim_qurt.o: sim_qurt.cpp
 	mkdir -p $(@D)


### PR DESCRIPTION
Building hexagon_remote with C++11 ends up inserting some unwanted C++11-related symbols (__gxx_personality_v0) that aren't present. This reverts those changes, and modifies HalideRuntime.h so that most of the `__cplusplus` checks are now `__cplusplus >= 201103L` (i.e., C++ convenience features only exist when compiled under C++11 or later).