### PR TITLE
Revert "Push lets near their uses (whenever possible) while CSEing +="

### DIFF
--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -12,7 +12,6 @@ namespace Internal {
 
 using std::map;
 using std::pair;
-using std::set;
 using std::string;
 using std::vector;
 
@@ -227,16 +226,6 @@ class RemoveLets : public IRGraphMutator {
     }
 };
 
-class GetVarsUsed : public IRVisitor {
-private:
-    using IRVisitor::visit;
-    void visit(const Variable *op) override {
-        vars_used.insert(op->name);
-    }
-
-public:
-    set<string> vars_used;
-};
 class CSEEveryExprInStmt : public IRMutator {
     bool lift_all;
     using IRMutator::visit;
@@ -257,34 +246,9 @@ class CSEEveryExprInStmt : public IRMutator {
         }
         const Call *c = dummy.as<Call>();
         internal_assert(c && c->is_intrinsic(Call::bundle) && c->args.size() == 2);
-
-        // Iterate over the the values that were CSEd. Those that are used by
-        // the store index will need to become LetStmts before the store. The
-        // others can be Let expressions around the store value.
-        GetVarsUsed g;
-        c->args[1].accept(&g);
-
-        vector<pair<string, Expr>> lets_for_letstmts;
-        for (auto it = lets.rbegin(); it != lets.rend(); it++) {
-            if (g.vars_used.count(it->first)) {
-                lets_for_letstmts.emplace_back(it->first, it->second);
-                it->second.accept(&g);
-            }
-        }
-
-        // First, add Let expressions, if any, around the store value.
-        Expr v = c->args[0];
-        for (auto it = lets.rbegin(); it != lets.rend(); it++) {
-            if (!g.vars_used.count(it->first)) {
-                v = Let::make(it->first, it->second, v);
-            }
-        }
-
-        Stmt s = Store::make(op->name, v, c->args[1],
+        Stmt s = Store::make(op->name, c->args[0], c->args[1],
                              op->param, mutate(op->predicate), op->alignment);
-
-        // Then add LetStmts if any around the store.
-        for (auto it = lets_for_letstmts.begin(); it != lets_for_letstmts.end(); ++it) {
+        for (auto it = lets.rbegin(); it != lets.rend(); it++) {
             s = LetStmt::make(it->first, it->second, s);
         }
         return s;

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -415,8 +415,6 @@ Module lower(const vector<Function> &output_funcs,
 
     debug(1) << "Simplifying...\n";
     s = common_subexpression_elimination(s);
-    debug(2) << "Lowering after common subexpression elimination:\n"
-             << s << "\n\n";
 
     if (t.has_feature(Target::OpenGL)) {
         debug(1) << "Detecting varying attributes...\n";


### PR DESCRIPTION
Reverts halide/Halide#5387

This change appears to be causing some of our code to crash on device. I'd like to revert it and I'll work on producing a test case to reproduce the issue.