### PR TITLE
Update Android NDK support in apps/

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,15 +540,11 @@ LD_LIBRARY_PATH=../../src/runtime/hexagon_remote/bin/host/:$HL_HEXAGON_TOOLS/lib
 
 ### To build and run the blur example in Halide/apps/blur on Android:
 
-To build the example for Android, first ensure that you have a standalone
-toolchain created from the NDK using the make-standalone-toolchain.sh script:
-
-```
-export ANDROID_NDK_HOME=$SDK_LOC/Hexagon_SDK/3.0/tools/android-ndk-r10d/
-export ANDROID_ARM64_TOOLCHAIN=<path to put new arm64 toolchain>
-$ANDROID_NDK_HOME/build/tools/make-standalone-toolchain.sh --arch=arm64 --platform=android-21 \
-    --install-dir=$ANDROID_ARM64_TOOLCHAIN
-```
+To build the example for Android, first ensure that you have Android NDK r19b or
+later installed, and the ANDROID_NDK_ROOT environment variable points to it.
+(We no longer support older versions, and it's no longer necessary to use
+the make-standalone-toolchain tool.) Note that Qualcomm Hexagon SDK v3.5.2
+includes Android NDK r19c, which is fine.
 
 Now build and run the blur example using the script to run it on device:
 

--- a/README.md
+++ b/README.md
@@ -542,9 +542,7 @@ LD_LIBRARY_PATH=../../src/runtime/hexagon_remote/bin/host/:$HL_HEXAGON_TOOLS/lib
 
 To build the example for Android, first ensure that you have Android NDK r19b or
 later installed, and the ANDROID_NDK_ROOT environment variable points to it.
-(We no longer support older versions, and it's no longer necessary to use
-the make-standalone-toolchain tool.) Note that Qualcomm Hexagon SDK v3.5.2
-includes Android NDK r19c, which is fine.
+(Note that Qualcomm Hexagon SDK v3.5.2 includes Android NDK r19c, which is fine.)
 
 Now build and run the blur example using the script to run it on device:
 

--- a/apps/hexagon_dma/Makefile
+++ b/apps/hexagon_dma/Makefile
@@ -3,22 +3,10 @@ all:
 
 include ../support/Makefile.inc
 
-# This app requires a separate toolchain to be built from the Android NDK,
-# using the make-standalone-toolchain.sh script:
-#$ build/tools/make-standalone-toolchain.sh --arch=arm64 --platform=android-21 --install-dir=$ANDROID_ARM64_TOOLCHAIN
-#$ build/tools/make-standalone-toolchain.sh --arch=arm --platform=android-21 --install-dir=$ANDROID_ARM_TOOLCHAIN
-
 #to run the specialized tests optional arguments are
 #$(BIN)/$(HL_TARGET)/process_yuv_linear_basic  width height schedule {where pipeline schedule is: basic, fold, async, split, split_async} dma_direction {ro, rw}
-CXX-host ?= $(CXX)
-CXX-arm-64-android ?= $(ANDROID_ARM64_TOOLCHAIN)/bin/aarch64-linux-android-c++
-CXX-arm-32-android ?= $(ANDROID_ARM_TOOLCHAIN)/bin/arm-linux-androideabi-c++
 CXX-arm-64-profile-android ?= $(CXX-arm-64-android)
 CXX-arm-32-profile-android ?= $(CXX-arm-32-android)
-
-CXXFLAGS-host ?=
-CXXFLAGS-arm-64-android ?=
-CXXFLAGS-arm-32-android ?=
 
 # exclude RO tests by default, unless explicitly requested via commandline SCHEDULE_ALL=n, where n is number
 ifneq ($(SCHEDULE_ALL),)
@@ -41,11 +29,8 @@ $(info defined $(HEXAGON_DMA))
 $(info #################################)
 endif
 
-LDFLAGS-host ?= -lpthread -ldl -lm
-LDFLAGS-arm-64-android ?= -llog -fPIE -pie
-LDFLAGS-arm-32-android ?= -llog -fPIE -pie
-LDFLAGS-arm-64-profile-android ?= -llog -fPIE -pie
-LDFLAGS-arm-32-profile-android ?= -llog -fPIE -pie
+LDFLAGS-arm-64-profile-android ?= $(LDFLAGS-arm-64-android)
+LDFLAGS-arm-32-profile-android ?= $(LDFLAGS-arm-32-android)
 OPTION := none
 
 

--- a/apps/hexagon_dma/mock_dma_implementation.cpp
+++ b/apps/hexagon_dma/mock_dma_implementation.cpp
@@ -3,9 +3,9 @@
 // a weak reference so that these will be called only in case of
 // unavailability of actual DMA functions.
 #define WEAK __attribute__((weak))
+#include "HalideRuntime.h"
 #include "../../src/runtime/hexagon_dma_pool.h"
 #include "../../src/runtime/mini_hexagon_dma.h"
-#include "HalideRuntime.h"
 #include <assert.h>
 #include <memory.h>
 #include <stdio.h>

--- a/apps/hexagon_dma/mock_dma_implementation.cpp
+++ b/apps/hexagon_dma/mock_dma_implementation.cpp
@@ -3,7 +3,7 @@
 // a weak reference so that these will be called only in case of
 // unavailability of actual DMA functions.
 #define WEAK __attribute__((weak))
-#include "HalideRuntime.h"
+#include "HalideRuntime.h"  // NOLINT
 #include "../../src/runtime/hexagon_dma_pool.h"
 #include "../../src/runtime/mini_hexagon_dma.h"
 #include <assert.h>

--- a/apps/simd_op_check/Makefile
+++ b/apps/simd_op_check/Makefile
@@ -1,34 +1,18 @@
-CXX-host ?= c++
+include ../support/Makefile.inc
 
-BIN ?= bin
-
-OPTIMIZE ?= -O3
-
-# Use the build/tools/make-standalone-toolchain.sh script inside the
-# android ndk to make a standalone toolchain to use for this app.
-CXX-arm-64-android ?= $(ANDROID_ARM64_TOOLCHAIN)/bin/aarch64-linux-android-c++
-CXX-arm-32-android ?= $(ANDROID_ARM_TOOLCHAIN)/bin/arm-linux-androideabi-c++
-CXX-hexagon-32-noos-hvx_64 ?= $(HL_HEXAGON_TOOLS)/bin/hexagon-clang++
 CXX-hexagon-32-noos-hvx_128 ?= $(HL_HEXAGON_TOOLS)/bin/hexagon-clang++
 
-CXXFLAGS-arm-64-android ?= -llog -fPIE -pie
-CXXFLAGS-arm-32-android ?= -llog -fPIE -pie
-CXXFLAGS-hexagon-32-noos-hvx_64 ?= -mhvx -mhvx-length=64B -G0
 CXXFLAGS-hexagon-32-noos-hvx_128 ?= -mhvx -mhvx-length=128B -G0
 
-LDFLAGS-host ?= -lpthread -ldl
-LDFLAGS-hexagon-32-noos-hvx_64 ?= -L../../src/runtime/hexagon_remote/bin/v60/ -lsim_qurt
 LDFLAGS-hexagon-32-noos-hvx_128 ?= -L../../src/runtime/hexagon_remote/bin/v60/ -lsim_qurt
 
 all: \
 	$(BIN)/driver-host \
 	$(BIN)/driver-arm-64-android \
 	$(BIN)/driver-arm-32-android \
-	$(BIN)/driver-hexagon-32-noos-hvx_64 \
 	$(BIN)/driver-hexagon-32-noos-hvx_128 \
 
 hvx_128: $(BIN)/driver-hexagon-32-noos-hvx_128
-hvx_64 : $(BIN)/driver-hexagon-32-noos-hvx_64
 
 arm_32: $(BIN)/driver-arm-32-android
 arm_64: $(BIN)/driver-arm-64-android

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -85,10 +85,17 @@ else
 SHARED_EXT=so
 endif
 
-# To run apps on android that support this, build a separate toolchain from the Android NDK
-# using the make-standalone-toolchain.sh script:
-#$ build/tools/make-standalone-toolchain.sh --arch=arm64 --platform=android-21 --install-dir=$ANDROID_ARM64_TOOLCHAIN
-#$ build/tools/make-standalone-toolchain.sh --arch=arm --platform=android-21 --install-dir=$ANDROID_ARM_TOOLCHAIN
+# We expect $ANDROID_NDK_ROOT to be defined by an env var.
+# We require at least NDK r19b or later.
+ANDROID_NDK_ROOT ?= /path/to/android_ndk_root
+
+# e.g. 'darwin' or 'linux'
+ANDROID_NDK_HOST_PLATFORM ?= $(shell echo `uname` | tr '[:upper:]' '[:lower:]')
+
+# The minimum Android API version to compile against. (This is *not* the same as the NDK version.)
+# 26 - Android 8 (aka Oreo)
+ANDROID_API_VERSION ?= 26
+
 CXX-host ?= $(CXX)
 CXX-host-opencl ?= $(CXX)
 CXX-host-opengl ?= $(CXX)
@@ -97,9 +104,10 @@ CXX-host-metal ?= $(CXX)
 CXX-host-hvx_128 ?= $(CXX)
 CXX-host-hvx_64 ?= $(CXX)
 CXX-host-hvx ?= $(CXX)
-CXX-$(HL_TARGET) ?= $(CXX)
-CXX-arm-64-android ?= $(ANDROID_ARM64_TOOLCHAIN)/bin/aarch64-linux-android-c++
-CXX-arm-32-android ?= $(ANDROID_ARM_TOOLCHAIN)/bin/arm-linux-androideabi-c++
+CXX-arm-64-android ?= ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${ANDROID_NDK_HOST_PLATFORM}-x86_64/bin/aarch64-linux-android${ANDROID_API_VERSION}-clang++
+CXX-arm-32-android ?= ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${ANDROID_NDK_HOST_PLATFORM}-x86_64/bin/armv7a-linux-androideabi${ANDROID_API_VERSION}-clang++
+CXX-arm-64-profile-android ?= $(CXX-arm-64-android)
+CXX-arm-32-profile-android ?= $(CXX-arm-32-android)
 
 CXXFLAGS-host ?= $(CXXFLAGS)
 CXXFLAGS-host-opencl ?= $(CXXFLAGS)
@@ -108,7 +116,6 @@ CXXFLAGS-host-cuda ?= $(CXXFLAGS)
 CXXFLAGS-host-metal ?= $(CXXFLAGS)
 CXXFLAGS-host-hvx_128 ?= $(CXXFLAGS)
 CXXFLAGS-host-hvx_64 ?= $(CXXFLAGS)
-CXXFLAGS-$(HL_TARGET) ?= $(CXXFLAGS)
 CXXFLAGS-arm-64-android ?= $(CXXFLAGS)
 CXXFLAGS-arm-32-android ?= $(CXXFLAGS)
 
@@ -119,9 +126,16 @@ LDFLAGS-host-cuda ?= $(LDFLAGS)
 LDFLAGS-host-metal ?= $(LDFLAGS)
 LDFLAGS-host-hvx_128 ?= $(LDFLAGS)
 LDFLAGS-host-hvx_64 ?= $(LDFLAGS)
+# Use the statically-linked version of libc++ on Android by default, for simplicity
+# of deployment. (Despite the name, this applies to libc++, not libstdc++)
+LDFLAGS-arm-64-android ?= -llog -fPIE -pie -static-libstdc++
+LDFLAGS-arm-32-android ?= -llog -fPIE -pie -static-libstdc++
+
+# Put HL_TARGET variants of all of these last, to avoid conflict with the android variants
+# if building with `HL_TARGET=arm-64-android make foo`
+CXX-$(HL_TARGET) ?= $(CXX)
+CXXFLAGS-$(HL_TARGET) ?= $(CXXFLAGS)
 LDFLAGS-$(HL_TARGET) ?= $(LDFLAGS)
-LDFLAGS-arm-64-android ?= -llog -fPIE -pie
-LDFLAGS-arm-32-android ?= -llog -fPIE -pie
 
 LIB_HALIDE_STATIC = $(HALIDE_DISTRIB_PATH)/lib/libHalide.a
 
@@ -134,10 +148,10 @@ GENERATOR_DEPS_STATIC ?= $(LIB_HALIDE_STATIC) $(HALIDE_DISTRIB_PATH)/include/Hal
 LIBHALIDE_LDFLAGS ?= -Wl,-rpath,$(dir $(LIB_HALIDE)) -L $(dir $(LIB_HALIDE)) -lHalide $(LDFLAGS)
 LIBHALIDE_LDFLAGS_STATIC ?= $(LIB_HALIDE_STATIC) $(LDFLAGS)
 
-# Autoschedulers. Mullapudi2016 is currently the default, because it's fast. 
+# Autoschedulers. Mullapudi2016 is currently the default, because it's fast.
 AUTOSCHEDULER ?= mullapudi2016
 ifneq ($(AUTOSCHEDULER),)
-LIB_AUTOSCHEDULER ?= $(HALIDE_DISTRIB_PATH)/lib/libautoschedule_$(AUTOSCHEDULER).$(SHARED_EXT) 
+LIB_AUTOSCHEDULER ?= $(HALIDE_DISTRIB_PATH)/lib/libautoschedule_$(AUTOSCHEDULER).$(SHARED_EXT)
 ifeq ($(UNAME), Darwin)
 LIBHALIDE_LDFLAGS +=  -Wl,-force_load $(HALIDE_DISTRIB_PATH)/lib/libautoschedule_$(AUTOSCHEDULER).$(SHARED_EXT)
 else

--- a/src/Func.h
+++ b/src/Func.h
@@ -718,7 +718,7 @@ public:
 
     /** Evaluate this function over some rectangular domain and return
      * the resulting buffer or buffers. Performs compilation if the
-     * Func has not previously been realized and jit_compile has not
+     * Func has not previously been realized and compile_jit has not
      * been called. If the final stage of the pipeline is on the GPU,
      * data is copied back to the host before being returned. The
      * returned Realization should probably be instantly converted to

--- a/src/runtime/hexagon_dma_pool.h
+++ b/src/runtime/hexagon_dma_pool.h
@@ -1,7 +1,11 @@
 #ifndef _HEXAGON_DMA_POOL_H_
 #define _HEXAGON_DMA_POOL_H_
 
+#ifdef COMPILING_HALIDE_RUNTIME
+// Guard this with COMPILING_HALIDE_RUNTIME so that apps/hexagon_dma
+// can include this file without getting runtime_internal.h
 #include "runtime_internal.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The Makefile help for apps/ assumed a fairly old version of the Android NDK (~2017). This updates to assume r19 or later:
- No need to do `make-standalone-toolchain` anymore
- Clang instead of GCC
- assume static linking of libc++ is the right default

I am limited in my ability to test on-device here (I don't have a device that will let me test HVX easily). apps/blur works fine onmy P2XL after this change, though.

This required a little tweaking to apps/hexagon_dma and related files to make it compile happily.

Also, drive-by fix to apps/simd_op_check to remove hvx_64 references.