### PR TITLE
Better codegen for ramps with non-const stride

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2192,9 +2192,16 @@ void CodeGen_LLVM::visit(const Ramp *op) {
         Expr broadcast = Broadcast::make(op->base, op->lanes);
         Expr ramp = Ramp::make(make_zero(op->base.type()), op->stride, op->lanes);
         value = codegen(broadcast + ramp);
+    } else if (!is_const(op->stride)) {
+        Expr broadcast_base = Broadcast::make(op->base, op->lanes);
+        Expr broadcast_stride = Broadcast::make(op->stride, op->lanes);
+        Expr ramp = Ramp::make(make_zero(op->base.type()), make_one(op->base.type()), op->lanes);
+        value = codegen(broadcast_base + broadcast_stride * ramp);
     } else {
-        // Otherwise we generate element by element by adding the stride to the base repeatedly
-
+        internal_assert(is_const(op->base) && is_const(op->stride));
+        // At this point base and stride should be constant. Generate
+        // an insert element sequence. The code will be lifted to a
+        // constant vector stored in .rodata or similar.
         Value *base = codegen(op->base);
         Value *stride = codegen(op->stride);
 


### PR DESCRIPTION
We were unnecessarily scalarizing the computation of ramps with non-constant stride, filling a vector by computing the elements one by one. This PR changes it to codegen it as base + stride * ramp(0, 1, lanes), so that the ramp itself is a constant and the work becomes broadcasting the base and stride, and then a single vector multiply and add.

Consider:

```
f(x, y) = x*y;
f.vectorize(x, 8);
```

Master:
```
        leal	(%rax,%r13), %r11d
	vmovd	%r11d, %xmm0
	leal	(%r12,%r13), %esi
	vpinsrd	$1, %esi, %xmm0, %xmm0
	leal	(%r14,%r13), %esi
	vpinsrd	$2, %esi, %xmm0, %xmm0
	leal	(%r10,%r13), %esi
	vpinsrd	$3, %esi, %xmm0, %xmm0
	leal	(%r8,%r13), %esi
	vmovd	%esi, %xmm1
	leal	(%rbp,%r13), %esi
	vpinsrd	$1, %esi, %xmm1, %xmm1
	leal	(%rdx,%r13), %esi
	vpinsrd	$2, %esi, %xmm1, %xmm1
	leal	(%rcx,%r13), %esi
	vpinsrd	$3, %esi, %xmm1, %xmm1
	vmovdqu	%xmm1, 16(%rbx)
	vmovdqu	%xmm0, (%rbx)
	addq	$32, %rbx
	addl	%r15d, %r13d
	decq	%rdi
	jne	.LBB0_4
```

This PR:
```
	vpbroadcastd	%ebp, %ymm2
	vpaddd	%ymm1, %ymm2, %ymm2
	vmovdqu	%ymm2, (%rdi)
	addq	$32, %rdi
	addl	%esi, %ebp
	decq	%rdx
	jne	.LBB0_4
```

Note that in these examples the mul was simplified by llvm into repeated addition, because it's all linear in the containing loops.

There are some existing correctness tests that hit this pattern, so we already have testing coverage. Of the apps, only the autoschedule for BGU hits this. Saves about 3% runtime and 25% code-size on that app/schedule. Rare, but worth fixing.