### PR TITLE
Improvements to apps/Makefile.inc

### DIFF
--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -97,6 +97,7 @@ ANDROID_NDK_HOST_PLATFORM ?= $(shell echo `uname` | tr '[:upper:]' '[:lower:]')
 ANDROID_API_VERSION ?= 26
 
 CXX-host ?= $(CXX)
+CXX-host-profile ?= $(CXX)
 CXX-host-opencl ?= $(CXX)
 CXX-host-opengl ?= $(CXX)
 CXX-host-cuda ?= $(CXX)
@@ -110,6 +111,7 @@ CXX-arm-64-profile-android ?= $(CXX-arm-64-android)
 CXX-arm-32-profile-android ?= $(CXX-arm-32-android)
 
 CXXFLAGS-host ?= $(CXXFLAGS)
+CXXFLAGS-host-profile ?= $(CXXFLAGS)
 CXXFLAGS-host-opencl ?= $(CXXFLAGS)
 CXXFLAGS-host-opengl ?= $(CXXFLAGS)
 CXXFLAGS-host-cuda ?= $(CXXFLAGS)
@@ -120,6 +122,7 @@ CXXFLAGS-arm-64-android ?= $(CXXFLAGS)
 CXXFLAGS-arm-32-android ?= $(CXXFLAGS)
 
 LDFLAGS-host ?= $(LDFLAGS)
+LDFLAGS-host-profile ?= $(LDFLAGS)
 LDFLAGS-host-opencl ?= $(LDFLAGS)
 LDFLAGS-host-opengl ?= $(LDFLAGS)
 LDFLAGS-host-cuda ?= $(LDFLAGS)
@@ -206,37 +209,40 @@ HL_VIDEOPLAYER ?= mplayer
 
 # ------- RunGen/Benchmark support
 
-# Really, .SECONDARY is what we want instead of .PRECIOUS (here and elsewhere),
-# but .SECONDARY doesn't accept wildcards
-.PRECIOUS: $(BIN)/%.registration.cpp
-$(BIN)/%.registration.cpp: $(BIN)/%.a
-	@echo $@ produced implicitly by $^
+RUNARGS ?=
 
 .PRECIOUS: $(BIN)/%/RunGenMain.o
 $(BIN)/%/RunGenMain.o: $(HALIDE_DISTRIB_PATH)/tools/RunGenMain.cpp $(HALIDE_DISTRIB_PATH)/tools/RunGen.h
-	@mkdir -p $(@D)
-	$(CXX) -c $< $(CXXFLAGS) -fno-exceptions $(IMAGE_IO_CXX_FLAGS) -I$(BIN)/$* -o $@
+    @mkdir -p $(@D)
+    $(CXX) -c $< $(CXXFLAGS) -fno-exceptions $(IMAGE_IO_CXX_FLAGS) -I$(BIN)/$* -o $@
 
-.PRECIOUS: $(BIN)/%.rungen
-$(BIN)/%.rungen: $(BIN)/%/RunGenMain.o $(BIN)/%.a $(BIN)/%.registration.cpp
-	$(CXX) $(CXXFLAGS) $^ -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
+# Can't have multiple wildcards in Make, so we'll use a macro
+# to stamp out all the rules we need
+define DEFINE_RUNGEN
 
-RUNARGS ?=
+.PRECIOUS: $$(BIN)/%/$(1).registration.cpp
+$$(BIN)/%/$(1).registration.cpp: $$(BIN)/%/$(1).a
+    @echo $$@ produced implicitly by $$^
+
+.PRECIOUS: $$(BIN)/%/$(1).rungen
+$$(BIN)/%/$(1).rungen: $$(BIN)/%/RunGenMain.o $$(BIN)/%/$(1).a $$(BIN)/%/$(1).registration.cpp $(2)
+    $$(CXX) $$(CXXFLAGS) $$^ -o $$@ $$(IMAGE_IO_FLAGS) $$(LDFLAGS)
 
 # Pseudo target that allows us to build-and-run in one step, e.g.
 #
 #     make bin/host/foo.run RUNARGS='input=a output=baz'
 #
-.PHONY: $(BIN)/%.run
-$(BIN)/%.run: $(BIN)/%.rungen
-	@$(CURDIR)/$< $(RUNARGS)
+.PHONY: $$(BIN)/%/$(1).run
+$$(BIN)/%/$(1).run: $$(BIN)/%/$(1).rungen
+    @$$(CURDIR)/$$< $$(RUNARGS)
 
 # Also allow 'foo.run' as a shortcut to mean host
-.PHONY: %.run
-%.run: $(BIN)/host/%.rungen
-	@$(CURDIR)/$< $(RUNARGS)
+.PHONY: $(1).run
+$(1).run: $$(BIN)/host/$(1).rungen
+    @$$(CURDIR)/$$< $$(RUNARGS)
 
-.PHONY: %.benchmark
-%.benchmark: $(BIN)/$(HL_TARGET)/%.rungen
-	@$^ --benchmarks=all --estimate_all --parsable_output
+.PHONY: $(1).bench
+$(1).bench: $$(BIN)/$$(HL_TARGET)/$(1).rungen
+    @$$^ --benchmarks=all --estimate_all --parsable_output
 
+endef


### PR DESCRIPTION
- add boilerplate for host-profile target
- rewrite the RunGen support to use a Make macro (`DEFINE_RUNGEN`) to add more flexibility; the previous approach was limited by Make's inability to have multiple wildcards. (There aren't many clients of this RunGen support in apps/, but I found it useful for an experiment so would like to capture it here for future use.)