### PR TITLE
Add Type::widen and Type::narrow helpers.

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -404,7 +404,7 @@ void CodeGen_ARM::visit(const Mul *op) {
                 value = call_pattern(pattern, t, matches);
                 return;
             } else if (pattern.type == Pattern::NarrowArgs) {
-                Type narrow_t = t.with_bits(t.bits() / 2);
+                Type narrow_t = t.narrow();
                 // Try to narrow all of the args.
                 bool all_narrow = true;
                 for (size_t i = 0; i < matches.size(); i++) {
@@ -1080,7 +1080,7 @@ void CodeGen_ARM::codegen_vector_reduce(const VectorReduce *op, const Expr &init
         if (op->op == VectorReduce::Add &&
             op->type.bits() >= 16 &&
             !op->type.is_float()) {
-            Type narrower_type = arg.type().with_bits(arg.type().bits() / 2);
+            Type narrower_type = arg.type().narrow();
             Expr narrower = lossless_cast(narrower_type, arg);
             if (!narrower.defined() && arg.type().is_int()) {
                 // We can also safely accumulate from a uint into a

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -59,7 +59,7 @@ CodeGen_ARM::CodeGen_ARM(Target target)
         }
 
         // Wider versions of the type
-        Type w = t.with_bits(t.bits() * 2);
+        Type w = t.wide();
         Type ws = Int(t.bits() * 2, t.lanes());
 
         // Vector wildcard for this type
@@ -993,7 +993,7 @@ void CodeGen_ARM::visit(const Call *op) {
         }
     } else if (op->is_intrinsic(Call::sorted_avg)) {
         Type ty = op->type;
-        Type wide_ty = ty.with_bits(ty.bits() * 2);
+        Type wide_ty = ty.wide();
         // This will codegen to vhaddu (arm32) or uhadd (arm64).
         value = codegen(cast(ty, (cast(wide_ty, op->args[0]) + cast(wide_ty, op->args[1])) / 2));
         return;

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -59,7 +59,7 @@ CodeGen_ARM::CodeGen_ARM(Target target)
         }
 
         // Wider versions of the type
-        Type w = t.wide();
+        Type w = t.widen();
         Type ws = Int(t.bits() * 2, t.lanes());
 
         // Vector wildcard for this type
@@ -992,7 +992,7 @@ void CodeGen_ARM::visit(const Call *op) {
         }
     } else if (op->is_intrinsic(Call::sorted_avg)) {
         Type ty = op->type;
-        Type wide_ty = ty.wide();
+        Type wide_ty = ty.widen();
         // This will codegen to vhaddu (arm32) or uhadd (arm64).
         value = codegen(cast(ty, (cast(wide_ty, op->args[0]) + cast(wide_ty, op->args[1])) / 2));
         return;

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -257,7 +257,7 @@ private:
 
     void include_lerp_types(const Type &t) {
         if (t.is_vector() && t.is_int_or_uint() && (t.bits() >= 8 && t.bits() <= 32)) {
-            include_type(t.wide());
+            include_type(t.widen());
         }
     }
 

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -257,8 +257,7 @@ private:
 
     void include_lerp_types(const Type &t) {
         if (t.is_vector() && t.is_int_or_uint() && (t.bits() >= 8 && t.bits() <= 32)) {
-            Type doubled = t.with_bits(t.bits() * 2);
-            include_type(doubled);
+            include_type(t.wide());
         }
     }
 

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -2248,7 +2248,7 @@ void CodeGen_Hexagon::visit(const Mul *op) {
             // We found a widening op, we need to narrow back
             // down. The widening multiply deinterleaved the result,
             // but the trunc operation reinterleaves.
-            Type wide = op->type.wide();
+            Type wide = op->type.widen();
             value = call_intrin(llvm_type_of(op->type),
                                 "halide.hexagon.trunc" + type_suffix(wide, false),
                                 {value});
@@ -2427,7 +2427,7 @@ void CodeGen_Hexagon::visit(const Call *op) {
     } else if (op->is_intrinsic(Call::mulhi_shr) && op->type.is_vector() &&
                (op->type.bits() == 8 || op->type.bits() == 16)) {
         internal_assert(op->args.size() == 3);
-        Type wide_ty = op->type.wide();
+        Type wide_ty = op->type.widen();
 
         // Generate a widening multiply.
         Expr p_wide = Call::make(

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -2248,7 +2248,7 @@ void CodeGen_Hexagon::visit(const Mul *op) {
             // We found a widening op, we need to narrow back
             // down. The widening multiply deinterleaved the result,
             // but the trunc operation reinterleaves.
-            Type wide = op->type.with_bits(op->type.bits() * 2);
+            Type wide = op->type.wide();
             value = call_intrin(llvm_type_of(op->type),
                                 "halide.hexagon.trunc" + type_suffix(wide, false),
                                 {value});
@@ -2427,7 +2427,7 @@ void CodeGen_Hexagon::visit(const Call *op) {
     } else if (op->is_intrinsic(Call::mulhi_shr) && op->type.is_vector() &&
                (op->type.bits() == 8 || op->type.bits() == 16)) {
         internal_assert(op->args.size() == 3);
-        Type wide_ty = op->type.with_bits(op->type.bits() * 2);
+        Type wide_ty = op->type.wide();
 
         // Generate a widening multiply.
         Expr p_wide = Call::make(

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2840,7 +2840,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         internal_assert(op->args.size() == 3);
 
         Type ty = op->type;
-        Type wide_ty = ty.wide();
+        Type wide_ty = ty.widen();
 
         Expr p_wide = cast(wide_ty, op->args[0]) * cast(wide_ty, op->args[1]);
         const UIntImm *shift = op->args[2].as<UIntImm>();
@@ -4638,7 +4638,7 @@ void CodeGen_LLVM::codegen_vector_reduce(const VectorReduce *op, const Expr &ini
             }
             if (narrower.defined()) {
                 // Widen it by 2x before the horizontal add
-                narrower = cast(narrower.type().wide(), narrower);
+                narrower = cast(narrower.type().widen(), narrower);
                 equiv = VectorReduce::make(op->op, narrower, intermediate_type.lanes());
                 // Then widen it by 2x again afterwards
                 equiv = cast(intermediate_type, equiv);

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2840,7 +2840,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         internal_assert(op->args.size() == 3);
 
         Type ty = op->type;
-        Type wide_ty = ty.with_bits(ty.bits() * 2);
+        Type wide_ty = ty.wide();
 
         Expr p_wide = cast(wide_ty, op->args[0]) * cast(wide_ty, op->args[1]);
         const UIntImm *shift = op->args[2].as<UIntImm>();
@@ -4629,7 +4629,7 @@ void CodeGen_LLVM::codegen_vector_reduce(const VectorReduce *op, const Expr &ini
         if (op->op == VectorReduce::Add &&
             (op->type.is_int() || op->type.is_uint()) &&
             op->type.bits() >= 32) {
-            Type narrower_type = op->value.type().with_bits(op->type.bits() / 4);
+            Type narrower_type = op->value.type().narrow().narrow();
             Expr narrower = lossless_cast(narrower_type, op->value);
             if (!narrower.defined() && narrower_type.is_int()) {
                 // Maybe we can narrow to an unsigned int instead.
@@ -4638,7 +4638,7 @@ void CodeGen_LLVM::codegen_vector_reduce(const VectorReduce *op, const Expr &ini
             }
             if (narrower.defined()) {
                 // Widen it by 2x before the horizontal add
-                narrower = cast(narrower.type().with_bits(narrower.type().bits() * 2), narrower);
+                narrower = cast(narrower.type().wide(), narrower);
                 equiv = VectorReduce::make(op->op, narrower, intermediate_type.lanes());
                 // Then widen it by 2x again afterwards
                 equiv = cast(intermediate_type, equiv);

--- a/src/FastIntegerDivide.cpp
+++ b/src/FastIntegerDivide.cpp
@@ -126,7 +126,7 @@ Expr fast_integer_divide(Expr numerator, Expr denominator) {
     user_assert(t.bits() == 8 || t.bits() == 16 || t.bits() == 32)
         << "Fast integer divide requires a numerator with 8, 16, or 32 bits\n";
 
-    Type wide = t.wide();
+    Type wide = t.widen();
 
     Expr result;
     if (t.is_uint()) {

--- a/src/FastIntegerDivide.cpp
+++ b/src/FastIntegerDivide.cpp
@@ -126,7 +126,7 @@ Expr fast_integer_divide(Expr numerator, Expr denominator) {
     user_assert(t.bits() == 8 || t.bits() == 16 || t.bits() == 32)
         << "Fast integer divide requires a numerator with 8, 16, or 32 bits\n";
 
-    Type wide = t.with_bits(t.bits() * 2);
+    Type wide = t.wide();
 
     Expr result;
     if (t.is_uint()) {

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -217,11 +217,10 @@ bool process_match_flags(vector<Expr> &matches, int flags) {
     // significant bit), so we can check for them all in a loop.
     for (size_t i = 0; i < matches.size(); i++) {
         Type t = matches[i].type();
-        Type target_t = t.with_bits(t.bits() / 2);
         if (flags & (Pattern::NarrowOp0 << i)) {
-            matches[i] = lossless_cast(target_t, matches[i]);
+            matches[i] = lossless_cast(t.narrow(), matches[i]);
         } else if (flags & (Pattern::NarrowUnsignedOp0 << i)) {
-            matches[i] = lossless_cast(target_t.with_code(Type::UInt), matches[i]);
+            matches[i] = lossless_cast(t.narrow().with_code(Type::UInt), matches[i]);
         }
         if (!matches[i].defined()) {
             return false;

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -471,8 +471,8 @@ Expr lossless_cast(Type t, Expr e) {
             // aggressively, we're good.
             // E.g. lossless_cast(uint16, (uint32)(some_u8) + 37)
             // = (uint16)(some_u8) + 37
-            Expr a = lossless_cast(t.with_bits(t.bits() / 2), add->a);
-            Expr b = lossless_cast(t.with_bits(t.bits() / 2), add->b);
+            Expr a = lossless_cast(t.narrow(), add->a);
+            Expr b = lossless_cast(t.narrow(), add->b);
             if (a.defined() && b.defined()) {
                 return cast(t, a) + cast(t, b);
             } else {
@@ -481,8 +481,8 @@ Expr lossless_cast(Type t, Expr e) {
         }
 
         if (const Sub *sub = e.as<Sub>()) {
-            Expr a = lossless_cast(t.with_bits(t.bits() / 2), sub->a);
-            Expr b = lossless_cast(t.with_bits(t.bits() / 2), sub->b);
+            Expr a = lossless_cast(t.narrow(), sub->a);
+            Expr b = lossless_cast(t.narrow(), sub->b);
             if (a.defined() && b.defined()) {
                 return cast(t, a) + cast(t, b);
             } else {
@@ -491,8 +491,8 @@ Expr lossless_cast(Type t, Expr e) {
         }
 
         if (const Mul *mul = e.as<Mul>()) {
-            Expr a = lossless_cast(t.with_bits(t.bits() / 2), mul->a);
-            Expr b = lossless_cast(t.with_bits(t.bits() / 2), mul->b);
+            Expr a = lossless_cast(t.narrow(), mul->a);
+            Expr b = lossless_cast(t.narrow(), mul->b);
             if (a.defined() && b.defined()) {
                 return cast(t, a) * cast(t, b);
             } else {

--- a/src/Type.h
+++ b/src/Type.h
@@ -357,11 +357,11 @@ public:
     }
 
     /** Return Type with the same type code and number of lanes, but with twice as many bits. */
-    Type widen() const {
+    Type wide() const {
         return with_bits(bits() * 2);
     }
 
-    /** REturn Type with the same type code and number of lanes, but with half as many bits. */
+    /** Return Type with the same type code and number of lanes, but with half as many bits. */
     Type narrow() const {
         return with_bits(bits() / 2);
     }

--- a/src/Type.h
+++ b/src/Type.h
@@ -356,6 +356,16 @@ public:
         return Type(code(), bits(), new_lanes, handle_type);
     }
 
+    /** Return Type with the same type code and number of lanes, but with twice as many bits. */
+    Type widen() const {
+        return with_bits(bits() * 2);
+    }
+
+    /** REturn Type with the same type code and number of lanes, but with half as many bits. */
+    Type narrow() const {
+        return with_bits(bits() / 2);
+    }
+
     /** Type to be printed when declaring handles of this type. */
     const halide_handle_cplusplus_type *handle_type = nullptr;
 

--- a/src/Type.h
+++ b/src/Type.h
@@ -357,7 +357,7 @@ public:
     }
 
     /** Return Type with the same type code and number of lanes, but with twice as many bits. */
-    Type wide() const {
+    Type widen() const {
         return with_bits(bits() * 2);
     }
 


### PR DESCRIPTION
Add helpers for widening and narrowing types. This has a little utility on master, but is mainly peeling off a change from another WIP branch.