### PR TITLE
Add as_intrinsic helper

### DIFF
--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -727,8 +727,7 @@ Stmt add_image_checks(const Stmt &s,
 
         Stmt visit(const Block *op) override {
             const Evaluate *e = op->first.as<Evaluate>();
-            const Call *c = e ? e->value.as<Call>() : nullptr;
-            if (c && c->is_intrinsic(Call::add_image_checks_marker)) {
+            if (e && Call::as_intrinsic(e->value, {Call::add_image_checks_marker})) {
                 return add_image_checks_inner(op->rest, outputs, t, order, env, fb, will_inject_host_copies);
             } else {
                 return IRMutator::visit(op);

--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -244,8 +244,8 @@ class CSEEveryExprInStmt : public IRMutator {
             lets.emplace_back(let->name, let->value);
             dummy = let->body;
         }
-        const Call *c = dummy.as<Call>();
-        internal_assert(c && c->is_intrinsic(Call::bundle) && c->args.size() == 2);
+        const Call *c = Call::as_intrinsic(dummy, {Call::bundle});
+        internal_assert(c && c->args.size() == 2);
         Stmt s = Store::make(op->name, c->args[0], c->args[1],
                              op->param, mutate(op->predicate), op->alignment);
         for (auto it = lets.rbegin(); it != lets.rend(); it++) {

--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -244,9 +244,9 @@ class CSEEveryExprInStmt : public IRMutator {
             lets.emplace_back(let->name, let->value);
             dummy = let->body;
         }
-        const Call *c = Call::as_intrinsic(dummy, {Call::bundle});
-        internal_assert(c && c->args.size() == 2);
-        Stmt s = Store::make(op->name, c->args[0], c->args[1],
+        const Call *bundle = Call::as_intrinsic(dummy, {Call::bundle});
+        internal_assert(bundle && bundle->args.size() == 2);
+        Stmt s = Store::make(op->name, bundle->args[0], bundle->args[1],
                              op->param, mutate(op->predicate), op->alignment);
         for (auto it = lets.rbegin(); it != lets.rend(); it++) {
             s = LetStmt::make(it->first, it->second, s);

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -357,8 +357,7 @@ void CodeGen_ARM::visit(const Cast *op) {
         (op->value.type().is_int() || op->value.type().is_uint()) &&
         t.bits() == op->value.type().bits() * 2) {
         Expr a, b;
-        const Call *c = op->value.as<Call>();
-        if (c && c->is_intrinsic(Call::absd)) {
+        if (const Call *c = Call::as_intrinsic(op->value, {Call::absd})) {
             ostringstream ss;
             int intrin_lanes = 128 / t.bits();
             ss << "vabdl_" << (c->args[0].type().is_int() ? "i" : "u") << t.bits() / 2 << "x" << intrin_lanes;

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -357,11 +357,11 @@ void CodeGen_ARM::visit(const Cast *op) {
         (op->value.type().is_int() || op->value.type().is_uint()) &&
         t.bits() == op->value.type().bits() * 2) {
         Expr a, b;
-        if (const Call *c = Call::as_intrinsic(op->value, {Call::absd})) {
+        if (const Call *absd = Call::as_intrinsic(op->value, {Call::absd})) {
             ostringstream ss;
             int intrin_lanes = 128 / t.bits();
-            ss << "vabdl_" << (c->args[0].type().is_int() ? "i" : "u") << t.bits() / 2 << "x" << intrin_lanes;
-            value = call_intrin(t, intrin_lanes, ss.str(), c->args);
+            ss << "vabdl_" << (absd->args[0].type().is_int() ? "i" : "u") << t.bits() / 2 << "x" << intrin_lanes;
+            value = call_intrin(t, intrin_lanes, ss.str(), absd->args);
             return;
         }
     }

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2062,9 +2062,8 @@ void CodeGen_C::visit(const Call *op) {
     } else if (op->is_intrinsic(Call::alloca)) {
         internal_assert(op->args.size() == 1);
         internal_assert(op->type.is_handle());
-        const Call *call = op->args[0].as<Call>();
-        if (op->type == type_of<struct halide_buffer_t *>() &&
-            call && call->is_intrinsic(Call::size_of_halide_buffer_t)) {
+        const Call *call = Call::as_intrinsic(op->args[0], {Call::size_of_halide_buffer_t});
+        if (call && op->type == type_of<struct halide_buffer_t *>()) {
             stream << get_indent();
             string buf_name = unique_name('b');
             stream << "halide_buffer_t " << buf_name << ";\n";

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2062,8 +2062,8 @@ void CodeGen_C::visit(const Call *op) {
     } else if (op->is_intrinsic(Call::alloca)) {
         internal_assert(op->args.size() == 1);
         internal_assert(op->type.is_handle());
-        const Call *call = Call::as_intrinsic(op->args[0], {Call::size_of_halide_buffer_t});
-        if (call && op->type == type_of<struct halide_buffer_t *>()) {
+        if (op->type == type_of<struct halide_buffer_t *>() &&
+            Call::as_intrinsic(op->args[0], {Call::size_of_halide_buffer_t})) {
             stream << get_indent();
             string buf_name = unique_name('b');
             stream << "halide_buffer_t " << buf_name << ";\n";

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1449,7 +1449,7 @@ Value *CodeGen_LLVM::codegen(const Expr &e) {
     // of prefetch indicates the type being prefetched, which does not match the
     // implementation of prefetch.
     // See https://github.com/halide/Halide/issues/4211.
-    const bool is_prefetch = e.as<Call>() && e.as<Call>()->is_intrinsic(Call::prefetch);
+    const bool is_prefetch = Call::as_intrinsic(e, {Call::prefetch});
     internal_assert(is_bool_vector || is_prefetch ||
                     e.type().is_handle() ||
                     value->getType()->isVoidTy() ||

--- a/src/IR.h
+++ b/src/IR.h
@@ -636,6 +636,19 @@ struct Call : public ExprNode<Call> {
         return is_intrinsic() && this->name == get_intrinsic_name(op);
     }
 
+    /** Returns a pointer to a call node if the expression is a call to
+     * one of the requested intrinsics. */
+    static const Call *as_intrinsic(const Expr &e, std::initializer_list<IntrinsicOp> intrinsics) {
+        if (const Call *c = e.as<Call>()) {
+            for (IntrinsicOp i : intrinsics) {
+                if (c->is_intrinsic(i)) {
+                    return c;
+                }
+            }
+        }
+        return nullptr;
+    }
+
     bool is_extern() const {
         return (call_type == Extern ||
                 call_type == ExternCPlusPlus ||

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -229,7 +229,7 @@ class ReducePrefetchDimension : public IRMutator {
         Stmt stmt = IRMutator::visit(op);
         op = stmt.as<Evaluate>();
         internal_assert(op);
-        const Call *call = op->value.as<Call>();
+        const Call *call = Call::as_intrinsic(op->value, {Call::prefetch});
 
         // TODO(psuriana): Ideally, we want to keep the loop size minimal to
         // minimize the number of prefetch calls. We probably want to lift
@@ -237,7 +237,7 @@ class ReducePrefetchDimension : public IRMutator {
         // the prefetch call.
 
         size_t max_arg_size = 2 + 2 * max_dim;  // Prefetch: {base, offset, extent0, stride0, extent1, stride1, ...}
-        if (call && call->is_intrinsic(Call::prefetch) && (call->args.size() > max_arg_size)) {
+        if (call && (call->args.size() > max_arg_size)) {
             const Variable *base = call->args[0].as<Variable>();
             internal_assert(base && base->type.is_handle());
 
@@ -286,9 +286,7 @@ class SplitPrefetch : public IRMutator {
         Stmt stmt = IRMutator::visit(op);
         op = stmt.as<Evaluate>();
         internal_assert(op);
-        const Call *call = op->value.as<Call>();
-
-        if (call && call->is_intrinsic(Call::prefetch)) {
+        if (const Call *call = Call::as_intrinsic(op->value, {Call::prefetch})) {
             const Variable *base = call->args[0].as<Variable>();
             internal_assert(base && base->type.is_handle());
 

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -229,7 +229,7 @@ class ReducePrefetchDimension : public IRMutator {
         Stmt stmt = IRMutator::visit(op);
         op = stmt.as<Evaluate>();
         internal_assert(op);
-        const Call *call = Call::as_intrinsic(op->value, {Call::prefetch});
+        const Call *prefetch = Call::as_intrinsic(op->value, {Call::prefetch});
 
         // TODO(psuriana): Ideally, we want to keep the loop size minimal to
         // minimize the number of prefetch calls. We probably want to lift
@@ -237,14 +237,14 @@ class ReducePrefetchDimension : public IRMutator {
         // the prefetch call.
 
         size_t max_arg_size = 2 + 2 * max_dim;  // Prefetch: {base, offset, extent0, stride0, extent1, stride1, ...}
-        if (call && (call->args.size() > max_arg_size)) {
-            const Variable *base = call->args[0].as<Variable>();
+        if (prefetch && (prefetch->args.size() > max_arg_size)) {
+            const Variable *base = prefetch->args[0].as<Variable>();
             internal_assert(base && base->type.is_handle());
 
             vector<string> index_names;
-            Expr new_offset = call->args[1];
-            for (size_t i = max_arg_size; i < call->args.size(); i += 2) {
-                Expr stride = call->args[i + 1];
+            Expr new_offset = prefetch->args[1];
+            for (size_t i = max_arg_size; i < prefetch->args.size(); i += 2) {
+                Expr stride = prefetch->args[i + 1];
                 string index_name = "prefetch_reduce_" + base->name + "." + std::to_string((i - 1) / 2);
                 index_names.push_back(index_name);
                 new_offset += Variable::make(Int(32), index_name) * stride;
@@ -252,17 +252,17 @@ class ReducePrefetchDimension : public IRMutator {
 
             vector<Expr> args = {base, new_offset};
             for (size_t i = 2; i < max_arg_size; ++i) {
-                args.push_back(call->args[i]);
+                args.push_back(prefetch->args[i]);
             }
 
-            stmt = Evaluate::make(Call::make(call->type, Call::prefetch, args, Call::Intrinsic));
+            stmt = Evaluate::make(Call::make(prefetch->type, Call::prefetch, args, Call::Intrinsic));
             for (size_t i = 0; i < index_names.size(); ++i) {
-                stmt = For::make(index_names[i], 0, call->args[(i + max_dim) * 2 + 2],
+                stmt = For::make(index_names[i], 0, prefetch->args[(i + max_dim) * 2 + 2],
                                  ForType::Serial, DeviceAPI::None, stmt);
             }
             debug(5) << "\nReduce prefetch to " << max_dim << " dim:\n"
                      << "Before:\n"
-                     << Expr(call) << "\nAfter:\n"
+                     << Expr(prefetch) << "\nAfter:\n"
                      << stmt << "\n";
         }
         return stmt;
@@ -286,18 +286,18 @@ class SplitPrefetch : public IRMutator {
         Stmt stmt = IRMutator::visit(op);
         op = stmt.as<Evaluate>();
         internal_assert(op);
-        if (const Call *call = Call::as_intrinsic(op->value, {Call::prefetch})) {
-            const Variable *base = call->args[0].as<Variable>();
+        if (const Call *prefetch = Call::as_intrinsic(op->value, {Call::prefetch})) {
+            const Variable *base = prefetch->args[0].as<Variable>();
             internal_assert(base && base->type.is_handle());
 
-            int elem_size = call->type.bytes();
+            int elem_size = prefetch->type.bytes();
 
             vector<string> index_names;
             vector<Expr> extents;
-            Expr new_offset = call->args[1];
-            for (size_t i = 2; i < call->args.size(); i += 2) {
-                Expr extent = call->args[i];
-                Expr stride = call->args[i + 1];
+            Expr new_offset = prefetch->args[1];
+            for (size_t i = 2; i < prefetch->args.size(); i += 2) {
+                Expr extent = prefetch->args[i];
+                Expr stride = prefetch->args[i + 1];
                 Expr stride_bytes = stride * elem_size;
 
                 string index_name = "prefetch_split_" + base->name + "." + std::to_string((i - 1) / 2);
@@ -321,14 +321,14 @@ class SplitPrefetch : public IRMutator {
             }
 
             vector<Expr> args = {base, new_offset, Expr(1), simplify(max_byte_size / elem_size)};
-            stmt = Evaluate::make(Call::make(call->type, Call::prefetch, args, Call::Intrinsic));
+            stmt = Evaluate::make(Call::make(prefetch->type, Call::prefetch, args, Call::Intrinsic));
             for (size_t i = 0; i < index_names.size(); ++i) {
                 stmt = For::make(index_names[i], 0, extents[i],
                                  ForType::Serial, DeviceAPI::None, stmt);
             }
             debug(5) << "\nSplit prefetch to max of " << max_byte_size << " bytes:\n"
                      << "Before:\n"
-                     << Expr(call) << "\nAfter:\n"
+                     << Expr(prefetch) << "\nAfter:\n"
                      << stmt << "\n";
         }
         return stmt;

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1056,8 +1056,8 @@ protected:
         vector<pair<string, Expr>> containers;
         while (1) {
             if (const LetStmt *l = body.as<LetStmt>()) {
-                const Call *call = Call::as_intrinsic(l->value, {Call::promise_clamped});
-                if (!call && !is_pure(l->value)) {
+                const Call *promise_clamped = Call::as_intrinsic(l->value, {Call::promise_clamped});
+                if (!promise_clamped && !is_pure(l->value)) {
                     // The consumer of the Func we're injecting may be an
                     // extern stage, which shows up in the IR as a let
                     // stmt with a side-effecty RHS. We need to take care

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -192,9 +192,7 @@ Stmt build_loop_nest(
     for (Expr pred : predicates) {
         pred = qualify(prefix, pred);
         // Add a likely qualifier if there isn't already one
-        const Call *c = pred.as<Call>();
-        if (!(c && (c->is_intrinsic(Call::likely) ||
-                    c->is_intrinsic(Call::likely_if_innermost)))) {
+        if (Call::as_intrinsic(pred, {Call::likely, Call::likely_if_innermost})) {
             pred = likely(pred);
         }
         pred_container.emplace_back(Container::If, 0, "", pred);
@@ -1058,9 +1056,8 @@ protected:
         vector<pair<string, Expr>> containers;
         while (1) {
             if (const LetStmt *l = body.as<LetStmt>()) {
-                const Call *call = l->value.as<Call>();
-                if (!(call && call->is_intrinsic(Call::promise_clamped)) &&
-                    !is_pure(l->value)) {
+                const Call *call = Call::as_intrinsic(l->value, {Call::promise_clamped});
+                if (!call && !is_pure(l->value)) {
                     // The consumer of the Func we're injecting may be an
                     // extern stage, which shows up in the IR as a let
                     // stmt with a side-effecty RHS. We need to take care

--- a/src/Simplify_Cast.cpp
+++ b/src/Simplify_Cast.cpp
@@ -16,7 +16,7 @@ Expr Simplify::visit(const Cast *op, ExprInfo *bounds) {
         double f = 0.0;
         int64_t i = 0;
         uint64_t u = 0;
-        if (const Call *call = Call::as_intrinsic(value, {Call::signed_integer_overflow})) {
+        if (Call::as_intrinsic(value, {Call::signed_integer_overflow})) {
             return make_signed_integer_overflow(op->type);
         } else if (value.type() == op->type) {
             return value;

--- a/src/Simplify_Cast.cpp
+++ b/src/Simplify_Cast.cpp
@@ -10,14 +10,13 @@ Expr Simplify::visit(const Cast *op, ExprInfo *bounds) {
     Expr value = mutate(op->value, nullptr);
 
     if (may_simplify(op->type) && may_simplify(op->value.type())) {
-        const Call *call = value.as<Call>();
         const Cast *cast = value.as<Cast>();
         const Broadcast *broadcast_value = value.as<Broadcast>();
         const Ramp *ramp_value = value.as<Ramp>();
         double f = 0.0;
         int64_t i = 0;
         uint64_t u = 0;
-        if (call && call->is_intrinsic(Call::signed_integer_overflow)) {
+        if (const Call *call = Call::as_intrinsic(value, {Call::signed_integer_overflow})) {
             return make_signed_integer_overflow(op->type);
         } else if (value.type() == op->type) {
             return value;

--- a/src/Simplify_Let.cpp
+++ b/src/Simplify_Let.cpp
@@ -94,7 +94,6 @@ Body Simplify::simplify_let(const LetOrLetStmt *op, ExprInfo *bounds) {
             const Cast *cast = f.new_value.template as<Cast>();
             const Broadcast *broadcast = f.new_value.template as<Broadcast>();
             const Shuffle *shuffle = f.new_value.template as<Shuffle>();
-            const Call *call = f.new_value.template as<Call>();
             const Variable *var_b = nullptr;
             const Variable *var_a = nullptr;
 
@@ -172,7 +171,7 @@ Body Simplify::simplify_let(const LetOrLetStmt *op, ExprInfo *bounds) {
                 Expr op_b = var_a ? new_var : shuffle->vectors[1];
                 replacement = substitute(f.new_name, Shuffle::make_concat({op_a, op_b}), replacement);
                 f.new_value = var_a ? shuffle->vectors[1] : shuffle->vectors[0];
-            } else if (call && (call->is_intrinsic(Call::likely) || call->is_intrinsic(Call::likely_if_innermost))) {
+            } else if (const Call *call = Call::as_intrinsic(f.new_value, {Call::likely, Call::likely_if_innermost})) {
                 replacement = substitute(f.new_name, Call::make(call->type, call->name, {new_var}, Call::PureIntrinsic), replacement);
                 f.new_value = call->args[0];
             } else {

--- a/src/Simplify_Let.cpp
+++ b/src/Simplify_Let.cpp
@@ -171,9 +171,9 @@ Body Simplify::simplify_let(const LetOrLetStmt *op, ExprInfo *bounds) {
                 Expr op_b = var_a ? new_var : shuffle->vectors[1];
                 replacement = substitute(f.new_name, Shuffle::make_concat({op_a, op_b}), replacement);
                 f.new_value = var_a ? shuffle->vectors[1] : shuffle->vectors[0];
-            } else if (const Call *call = Call::as_intrinsic(f.new_value, {Call::likely, Call::likely_if_innermost})) {
-                replacement = substitute(f.new_name, Call::make(call->type, call->name, {new_var}, Call::PureIntrinsic), replacement);
-                f.new_value = call->args[0];
+            } else if (const Call *likely = Call::as_intrinsic(f.new_value, {Call::likely, Call::likely_if_innermost})) {
+                replacement = substitute(f.new_name, Call::make(likely->type, likely->name, {new_var}, Call::PureIntrinsic), replacement);
+                f.new_value = likely->args[0];
             } else {
                 break;
             }

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -678,8 +678,8 @@ class VectorSubs : public IRMutator {
                 // for these are actually min/extent pairs; we need to maintain the proper dimensionality
                 // count and instead aggregate the widened values into a single pair.
                 for (size_t i = 1; i <= 2; i++) {
-                    const Call *call = new_args[i].as<Call>();
-                    internal_assert(call && call->is_intrinsic(Call::make_struct));
+                    const Call *call = Call::as_intrinsic(new_args[i], {Call::make_struct});
+                    internal_assert(call);
                     if (i == 1) {
                         // values should always be empty for these events
                         internal_assert(call->args.empty());
@@ -709,8 +709,8 @@ class VectorSubs : public IRMutator {
                 for (size_t i = 1; i <= 2; i++) {
                     // Each struct should be a struct-of-vectors, not a
                     // vector of distinct structs.
-                    const Call *call = new_args[i].as<Call>();
-                    internal_assert(call && call->is_intrinsic(Call::make_struct));
+                    const Call *call = Call::as_intrinsic(new_args[i], {Call::make_struct});
+                    internal_assert(call);
                     // Widen the call args to have the same lanes as the max lanes found
                     vector<Expr> call_args(call->args.size());
                     for (size_t j = 0; j < call_args.size(); j++) {
@@ -909,9 +909,7 @@ class VectorSubs : public IRMutator {
                      << predicated_stmt << "\n";
 
             // First check if the condition is marked as likely.
-            const Call *c = cond.as<Call>();
-            if (c && (c->is_intrinsic(Call::likely) ||
-                      c->is_intrinsic(Call::likely_if_innermost))) {
+            if (const Call *c = Call::as_intrinsic(cond, {Call::likely, Call::likely_if_innermost})) {
 
                 // The meaning of the likely intrinsic is that
                 // Halide should optimize for the case in which

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -678,17 +678,17 @@ class VectorSubs : public IRMutator {
                 // for these are actually min/extent pairs; we need to maintain the proper dimensionality
                 // count and instead aggregate the widened values into a single pair.
                 for (size_t i = 1; i <= 2; i++) {
-                    const Call *call = Call::as_intrinsic(new_args[i], {Call::make_struct});
-                    internal_assert(call);
+                    const Call *make_struct = Call::as_intrinsic(new_args[i], {Call::make_struct});
+                    internal_assert(make_struct);
                     if (i == 1) {
                         // values should always be empty for these events
-                        internal_assert(call->args.empty());
+                        internal_assert(make_struct->args.empty());
                         continue;
                     }
-                    vector<Expr> call_args(call->args.size());
+                    vector<Expr> call_args(make_struct->args.size());
                     for (size_t j = 0; j < call_args.size(); j += 2) {
-                        Expr min_v = widen(call->args[j], max_lanes);
-                        Expr extent_v = widen(call->args[j + 1], max_lanes);
+                        Expr min_v = widen(make_struct->args[j], max_lanes);
+                        Expr extent_v = widen(make_struct->args[j + 1], max_lanes);
                         Expr min_scalar = extract_lane(min_v, 0);
                         Expr max_scalar = min_scalar + extract_lane(extent_v, 0);
                         for (int k = 1; k < max_lanes; ++k) {
@@ -700,7 +700,7 @@ class VectorSubs : public IRMutator {
                         call_args[j] = min_scalar;
                         call_args[j + 1] = max_scalar - min_scalar;
                     }
-                    new_args[i] = Call::make(call->type.element_of(), Call::make_struct, call_args, Call::Intrinsic);
+                    new_args[i] = Call::make(make_struct->type.element_of(), Call::make_struct, call_args, Call::Intrinsic);
                 }
             } else {
                 // Call::trace vectorizes uniquely, because we want a
@@ -709,14 +709,14 @@ class VectorSubs : public IRMutator {
                 for (size_t i = 1; i <= 2; i++) {
                     // Each struct should be a struct-of-vectors, not a
                     // vector of distinct structs.
-                    const Call *call = Call::as_intrinsic(new_args[i], {Call::make_struct});
-                    internal_assert(call);
+                    const Call *make_struct = Call::as_intrinsic(new_args[i], {Call::make_struct});
+                    internal_assert(make_struct);
                     // Widen the call args to have the same lanes as the max lanes found
-                    vector<Expr> call_args(call->args.size());
+                    vector<Expr> call_args(make_struct->args.size());
                     for (size_t j = 0; j < call_args.size(); j++) {
-                        call_args[j] = widen(call->args[j], max_lanes);
+                        call_args[j] = widen(make_struct->args[j], max_lanes);
                     }
-                    new_args[i] = Call::make(call->type.element_of(), Call::make_struct,
+                    new_args[i] = Call::make(make_struct->type.element_of(), Call::make_struct,
                                              call_args, Call::Intrinsic);
                 }
                 // One of the arguments to the trace helper
@@ -909,16 +909,16 @@ class VectorSubs : public IRMutator {
                      << predicated_stmt << "\n";
 
             // First check if the condition is marked as likely.
-            if (const Call *c = Call::as_intrinsic(cond, {Call::likely, Call::likely_if_innermost})) {
+            if (const Call *likely = Call::as_intrinsic(cond, {Call::likely, Call::likely_if_innermost})) {
 
                 // The meaning of the likely intrinsic is that
                 // Halide should optimize for the case in which
                 // *every* likely value is true. We can do that by
                 // generating a scalar condition that checks if
                 // the least-true lane is true.
-                Expr all_true = bounds_of_lanes(c->args[0]).min;
+                Expr all_true = bounds_of_lanes(likely->args[0]).min;
                 // Wrap it in the same flavor of likely
-                all_true = Call::make(Bool(), c->name,
+                all_true = Call::make(Bool(), likely->name,
                                       {all_true}, Call::PureIntrinsic);
 
                 if (!vectorize_predicate) {

--- a/test/correctness/mul_div_mod.cpp
+++ b/test/correctness/mul_div_mod.cpp
@@ -322,7 +322,7 @@ bool mul(int vector_width, ScheduleVariant scheduling, const Target &target) {
                 Expr be = cast<RT>(Expr(bi));
                 Expr re = simplify(ae * be);
 
-                if (re.as<Call>() && re.as<Call>()->is_intrinsic(Call::signed_integer_overflow)) {
+                if (Call::as_intrinsic(re, {Call::signed_integer_overflow})) {
                     // Don't check correctness of signed integer overflow.
                 } else {
                     if (!Internal::equal(re, Expr(ri)) && (ecount++) < 10) {

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -7,8 +7,7 @@ using namespace Halide::Internal;
 
 void check_is_sio(const Expr &e) {
     Expr simpler = simplify(e);
-    const Call *call = simpler.as<Call>();
-    if (!(call && call->is_intrinsic(Call::signed_integer_overflow))) {
+    if (Call::as_intrinsic(simpler, {Call::signed_integer_overflow})) {
         std::cerr
             << "\nSimplification failure:\n"
             << "Input: " << e << "\n"

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -7,7 +7,7 @@ using namespace Halide::Internal;
 
 void check_is_sio(const Expr &e) {
     Expr simpler = simplify(e);
-    if (Call::as_intrinsic(simpler, {Call::signed_integer_overflow})) {
+    if (!Call::as_intrinsic(simpler, {Call::signed_integer_overflow})) {
         std::cerr
             << "\nSimplification failure:\n"
             << "Input: " << e << "\n"


### PR DESCRIPTION
There's a pretty common pattern (especially in a WIP branch) of doing something like:

```
const Call *c = e.as<Call>();
if (c && (c->is_intrinsic(Call::X) || c->is_intrinsic(Call::Y))) {
    ...
}
```

The call declaration can't be made part of the if, because we can't assign it and use it as part of another condition. This PR adds a helper for this:

```
if (const Call *c = Call::as_intrinsic(e, {Call::X, Call::Y}) {
    ...
}
```

