### PR TITLE
Improve speed of testing apps/

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -48,11 +48,15 @@ function(add_app_test NAME)
         "-DLLVM_DIR=${LLVM_DIR}"
         "-DHalide_TARGET=${Halide_TARGET}")
 
-    # Note that we skip all tests that have the 'benchmark' label; some of the apps
-    # have benchmarks that are in the form of tests, and running them via this path
-    # isn't very useful, since we aren't guaranteed that the machine won't be under
-    # load with other tests. (Also, some of the apps have extensive benchmarks that
-    # take quite a while to run; e.g. apps/linear_algebra, which has over 500.)
+    # As a band-aid to keep test times under control, we explicitly skip tests
+    # that are labeled with `slow_tests` -- currently, this label only applies
+    # to a number of benchmarks under apps/linear_algebra, but could be applied
+    # to others as necessary. (The issue here is that --build-and-test will treat
+    # the entire subproject as a single 'test', with a single timeout applied to all
+    # of it, and apparently no way to get useful progress information bubbled out.
+    # It may be that we need to rethink how we handle building/testing the apps
+    # under CMake, in which case the `slow_tests` label will hopefully become
+    # useless and removed.)
     #
     # Note also that we specify `--build-noclean` explicitly; apparently the default
     # for --build-and-test is to 'clean' first, which shouldn't be necessary here.
@@ -67,7 +71,7 @@ function(add_app_test NAME)
              --build-options
              ${cmakeDefinitionOpts}
              ${cmakeToolchainOpts}
-             --test-command ${CMAKE_CTEST_COMMAND} -C $<CONFIG> -LE benchmark)
+             --test-command ${CMAKE_CTEST_COMMAND} -C $<CONFIG> -LE slow_tests)
     set_tests_properties(${NAME} PROPERTIES
                          FIXTURES_REQUIRED apps
                          LABELS apps

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -48,17 +48,26 @@ function(add_app_test NAME)
         "-DLLVM_DIR=${LLVM_DIR}"
         "-DHalide_TARGET=${Halide_TARGET}")
 
+    # Note that we skip all tests that have the 'benchmark' label; some of the apps
+    # have benchmarks that are in the form of tests, and running them via this path
+    # isn't very useful, since we aren't guaranteed that the machine won't be under
+    # load with other tests. (Also, some of the apps have extensive benchmarks that
+    # take quite a while to run; e.g. apps/linear_algebra, which has over 500.)
+    #
+    # Note also that we specify `--build-noclean` explicitly; apparently the default
+    # for --build-and-test is to 'clean' first, which shouldn't be necessary here.
     add_test(NAME ${NAME}
              COMMAND ${CMAKE_CTEST_COMMAND}
              --output-on-failure
              --build-and-test "${CMAKE_CURRENT_SOURCE_DIR}/${NAME}" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}"
              --build-generator "${CMAKE_GENERATOR}"
+             --build-noclean
              ${cmakeGenOpts}
              --build-config "$<CONFIG>"
              --build-options
              ${cmakeDefinitionOpts}
              ${cmakeToolchainOpts}
-             --test-command ${CMAKE_CTEST_COMMAND} -C $<CONFIG> -V)
+             --test-command ${CMAKE_CTEST_COMMAND} -C $<CONFIG> -LE benchmark)
     set_tests_properties(${NAME} PROPERTIES
                          FIXTURES_REQUIRED apps
                          LABELS apps

--- a/apps/linear_algebra/benchmarks/CMakeLists.txt
+++ b/apps/linear_algebra/benchmarks/CMakeLists.txt
@@ -49,7 +49,7 @@ foreach (TARGET IN LISTS BENCHMARK_TARGETS)
                 add_test(NAME ${TEST_NAME}
                          COMMAND ${TARGET} ${FUNC} ${SIZE})
                 set_tests_properties("${TEST_NAME}" PROPERTIES
-                                     LABELS "${BLA_VENDOR};${LEVEL};internal_app_tests;benchmark"
+                                     LABELS "${BLA_VENDOR};${LEVEL};internal_app_tests;slow_tests"
                                      PASS_REGULAR_EXPRESSION "${FUNC}[ \t]+${SIZE}"
                                      SKIP_REGULAR_EXPRESSION "\\[SKIP\\]")
             endforeach ()

--- a/apps/linear_algebra/benchmarks/CMakeLists.txt
+++ b/apps/linear_algebra/benchmarks/CMakeLists.txt
@@ -49,7 +49,7 @@ foreach (TARGET IN LISTS BENCHMARK_TARGETS)
                 add_test(NAME ${TEST_NAME}
                          COMMAND ${TARGET} ${FUNC} ${SIZE})
                 set_tests_properties("${TEST_NAME}" PROPERTIES
-                                     LABELS "${BLA_VENDOR};${LEVEL};internal_app_tests"
+                                     LABELS "${BLA_VENDOR};${LEVEL};internal_app_tests;benchmark"
                                      PASS_REGULAR_EXPRESSION "${FUNC}[ \t]+${SIZE}"
                                      SKIP_REGULAR_EXPRESSION "\\[SKIP\\]")
             endforeach ()


### PR DESCRIPTION
- Skip all app tests that are labeled as 'benchmarks'
- Specify `--build-noclean` to avoid unnecessary full rebuilds