### PR TITLE
Reduce size of test image

### DIFF
--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -160,8 +160,8 @@ Func make_noise(int depth) {
 
 template<typename T>
 void do_test() {
-    const int width = 1600;
-    const int height = 1200;
+    const int width = 160;
+    const int height = 120;
 
     // Make some colored noise
     Func f;


### PR DESCRIPTION
I noticed that this test takes a long time on the build bots. This seems like low hanging fruit to try to speed them up a little bit.