### PR TITLE
Combine align and slice for the small vectors in align_loads

### DIFF
--- a/src/AlignLoads.cpp
+++ b/src/AlignLoads.cpp
@@ -115,8 +115,7 @@ private:
 
             // If load is smaller than a native vector and can fully fit inside of it and offset is known,
             // we can simply offset the native load and slice.
-            if (!is_aligned && aligned_offset != 0 && Int(32).can_represent(aligned_offset)
-                 && (aligned_offset + lanes <= native_lanes)) {
+            if (!is_aligned && aligned_offset != 0 && Int(32).can_represent(aligned_offset) && (aligned_offset + lanes <= native_lanes)) {
                 ramp_base = simplify(ramp_base - (int)aligned_offset);
                 alignment = alignment - aligned_offset;
                 slice_offset = aligned_offset;


### PR DESCRIPTION
This improves the case when a smaller vector load is fully contained inside of the aligned native vector load. In the current implementation it will be handled in two passes: firstly, a small vector will be extended to the native vector size (slice from the unaligned native vector load), followed by the second pass where it will be actually aligned, which leads to a) double slice and b) load of vector of double native width. This change combines these two passes when possible to avoid double slice and double load.