### PR TITLE
Enable constant folding of broadcasted constants

### DIFF
--- a/src/AssociativeOpsTable.cpp
+++ b/src/AssociativeOpsTable.cpp
@@ -38,7 +38,7 @@ enum class ValType {
     Float16 = 9,
     Float32 = 10,
     Float64 = 11,
-    All = 11,  // General type (including all previous types)
+    All = 12,  // General type (including all previous types)
 };
 
 ValType convert_halide_type_to_val_type(const Type &halide_t) {

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -1100,14 +1100,14 @@ private:
 
     Expr visit(const Div *op) override {
         if (!op->type.is_float() && op->type.is_vector()) {
-            return mutate(simplify(lower_int_uint_div(op->a, op->b)));
+            return mutate(lower_int_uint_div(op->a, op->b));
         }
         return IRMutator::visit(op);
     }
 
     Expr visit(const Mod *op) override {
         if (!op->type.is_float() && op->type.is_vector()) {
-            return mutate(simplify(lower_int_uint_mod(op->a, op->b)));
+            return mutate(lower_int_uint_mod(op->a, op->b));
         }
         return IRMutator::visit(op);
     }

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -73,9 +73,7 @@ void Simplify::found_buffer_reference(const string &name, size_t dimensions) {
 }
 
 bool Simplify::const_float(const Expr &e, double *f) {
-    if (e.type().is_vector()) {
-        return false;
-    } else if (const double *p = as_const_float(e)) {
+    if (const double *p = as_const_float(e)) {
         *f = *p;
         return true;
     } else {
@@ -84,9 +82,7 @@ bool Simplify::const_float(const Expr &e, double *f) {
 }
 
 bool Simplify::const_int(const Expr &e, int64_t *i) {
-    if (e.type().is_vector()) {
-        return false;
-    } else if (const int64_t *p = as_const_int(e)) {
+    if (const int64_t *p = as_const_int(e)) {
         *i = *p;
         return true;
     } else {
@@ -95,9 +91,7 @@ bool Simplify::const_int(const Expr &e, int64_t *i) {
 }
 
 bool Simplify::const_uint(const Expr &e, uint64_t *u) {
-    if (e.type().is_vector()) {
-        return false;
-    } else if (const uint64_t *p = as_const_uint(e)) {
+    if (const uint64_t *p = as_const_uint(e)) {
         *u = *p;
         return true;
     } else {

--- a/src/Simplify_Cast.cpp
+++ b/src/Simplify_Cast.cpp
@@ -25,42 +25,42 @@ Expr Simplify::visit(const Cast *op, ExprInfo *bounds) {
                    std::isfinite(f)) {
             // float -> int
             // Recursively call mutate just to set the bounds
-            return mutate(IntImm::make(op->type, safe_numeric_cast<int64_t>(f)), bounds);
+            return mutate(make_const(op->type, safe_numeric_cast<int64_t>(f)), bounds);
         } else if (op->type.is_uint() &&
                    const_float(value, &f) &&
                    std::isfinite(f)) {
             // float -> uint
-            return UIntImm::make(op->type, safe_numeric_cast<uint64_t>(f));
+            return make_const(op->type, safe_numeric_cast<uint64_t>(f));
         } else if (op->type.is_float() &&
                    const_float(value, &f)) {
             // float -> float
-            return FloatImm::make(op->type, f);
+            return make_const(op->type, f);
         } else if (op->type.is_int() &&
                    const_int(value, &i)) {
             // int -> int
             // Recursively call mutate just to set the bounds
-            return mutate(IntImm::make(op->type, i), bounds);
+            return mutate(make_const(op->type, i), bounds);
         } else if (op->type.is_uint() &&
                    const_int(value, &i)) {
             // int -> uint
-            return UIntImm::make(op->type, safe_numeric_cast<uint64_t>(i));
+            return make_const(op->type, safe_numeric_cast<uint64_t>(i));
         } else if (op->type.is_float() &&
                    const_int(value, &i)) {
             // int -> float
-            return FloatImm::make(op->type, safe_numeric_cast<double>(i));
+            return make_const(op->type, safe_numeric_cast<double>(i));
         } else if (op->type.is_int() &&
                    const_uint(value, &u)) {
             // uint -> int
             // Recursively call mutate just to set the bounds
-            return mutate(IntImm::make(op->type, safe_numeric_cast<int64_t>(u)), bounds);
+            return mutate(make_const(op->type, safe_numeric_cast<int64_t>(u)), bounds);
         } else if (op->type.is_uint() &&
                    const_uint(value, &u)) {
             // uint -> uint
-            return UIntImm::make(op->type, u);
+            return make_const(op->type, u);
         } else if (op->type.is_float() &&
                    const_uint(value, &u)) {
             // uint -> float
-            return FloatImm::make(op->type, safe_numeric_cast<double>(u));
+            return make_const(op->type, safe_numeric_cast<double>(u));
         } else if (cast &&
                    op->type.code() == cast->type.code() &&
                    op->type.bits() < cast->type.bits()) {

--- a/src/Simplify_Internal.h
+++ b/src/Simplify_Internal.h
@@ -200,9 +200,7 @@ public:
     void found_buffer_reference(const std::string &name, size_t dimensions = 0);
 
     // Wrappers for as_const_foo that are more convenient to use in
-    // the large chains of conditions in the visit methods
-    // below. Unlike the versions in IROperator, these only match
-    // scalars.
+    // the large chains of conditions in the visit methods below.
     bool const_float(const Expr &e, double *f);
     bool const_int(const Expr &e, int64_t *i);
     bool const_uint(const Expr &e, uint64_t *u);

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -112,14 +112,14 @@ void check_casts() {
     // Specific checks for 32 bit unsigned expressions - ensure simplifications are actually unsigned.
     // 4000000000 (4 billion) is less than 2^32 but more than 2^31.  As an int, it is negative.
     check(cast(UInt(32), (int)4000000000UL) + cast(UInt(32), 5), make_const(UInt(32), (int)4000000005UL));
-    check(cast(UInt(32), (int)4000000000UL) - cast(UInt(32), 5), make_const(UInt(32), (int)3999999995UL));
+    check(make_const(UInt(32, 4), (int)4000000000UL) - make_const(UInt(32, 4), 5), make_const(UInt(32, 4), (int)3999999995UL));
     check(cast(UInt(32), (int)4000000000UL) / cast(UInt(32), 5), make_const(UInt(32), 800000000));
     check(cast(UInt(32), 800000000) * cast(UInt(32), 5), make_const(UInt(32), (int)4000000000UL));
-    check(cast(UInt(32), (int)4000000023UL) % cast(UInt(32), 100), make_const(UInt(32), 23));
+    check(make_const(UInt(32, 2), (int)4000000023UL) % make_const(UInt(32, 2), 100), make_const(UInt(32, 2), 23));
     check(min(cast(UInt(32), (int)4000000023UL), cast(UInt(32), 1000)), make_const(UInt(32), (int)1000));
     check(max(cast(UInt(32), (int)4000000023UL), cast(UInt(32), 1000)), make_const(UInt(32), (int)4000000023UL));
     check(cast(UInt(32), (int)4000000023UL) < cast(UInt(32), 1000), const_false());
-    check(cast(UInt(32), (int)4000000023UL) == cast(UInt(32), 1000), const_false());
+    check(make_const(UInt(32, 3), (int)4000000023UL) == make_const(UInt(32, 3), 1000), const_false(3));
 
     check(cast(Float(64), 0.5f), Expr(0.5));
     check((x - cast(Float(64), 0.5f)) * (x - cast(Float(64), 0.5f)),
@@ -1798,18 +1798,30 @@ template<typename T>
 void check_clz(uint64_t value, uint64_t result) {
     Expr x = Variable::make(halide_type_of<T>(), "x");
     check(Let::make("x", cast<T>(Expr(value)), count_leading_zeros(x)), cast<T>(Expr(result)));
+
+    Type vt = halide_type_of<T>().with_lanes(4);
+    Expr xv = Variable::make(vt, "x");
+    check(Let::make("x", cast(vt, broadcast(Expr(value), 4)), count_leading_zeros(xv)), cast(vt, broadcast(Expr(result), 4)));
 }
 
 template<typename T>
 void check_ctz(uint64_t value, uint64_t result) {
     Expr x = Variable::make(halide_type_of<T>(), "x");
     check(Let::make("x", cast<T>(Expr(value)), count_trailing_zeros(x)), cast<T>(Expr(result)));
+
+    Type vt = halide_type_of<T>().with_lanes(4);
+    Expr xv = Variable::make(vt, "x");
+    check(Let::make("x", cast(vt, broadcast(Expr(value), 4)), count_trailing_zeros(xv)), cast(vt, broadcast(Expr(result), 4)));
 }
 
 template<typename T>
 void check_popcount(uint64_t value, uint64_t result) {
     Expr x = Variable::make(halide_type_of<T>(), "x");
     check(Let::make("x", cast<T>(Expr(value)), popcount(x)), cast<T>(Expr(result)));
+
+    Type vt = halide_type_of<T>().with_lanes(4);
+    Expr xv = Variable::make(vt, "x");
+    check(Let::make("x", cast(vt, broadcast(Expr(value), 4)), popcount(xv)), cast(vt, broadcast(Expr(result), 4)));
 }
 
 void check_bitwise() {
@@ -1841,6 +1853,7 @@ void check_bitwise() {
     check(v >> 2, Broadcast::make(3, 4));
     check(Broadcast::make(32768, 4) >> 1, Broadcast::make(16384, 4));
     check((Broadcast::make(1, 4) << 15) >> 1, Broadcast::make(16384, 4));
+    check(Ramp::make(0, 1, 4) << Broadcast::make(4, 4), Ramp::make(0, 16, 4));
 
     check_clz<int8_t>(10, 4);
     check_clz<int16_t>(10, 12);


### PR DESCRIPTION
Currently, things like `shift_left(x, broadcast(2))` don't get simplified, and things like `shift_right(8, broadcast(1))` don't get constant folded. This PR fixes that.