### PR TITLE
Add slow_tests label to resize app

### DIFF
--- a/apps/resize/CMakeLists.txt
+++ b/apps/resize/CMakeLists.txt
@@ -92,7 +92,7 @@ if (EXISTS ${IMAGE})
                  COMMAND resize ${INPUT} out_${VARIANT}.png -i ${INTERP} -t ${TYPE} -f ${F})
         set_tests_properties(resize_${VARIANT}
                              PROPERTIES FIXTURES_REQUIRED rgb_small
-                             LABELS internal_app_tests
+                             LABELS internal_app_tests;slow_tests
                              PASS_REGULAR_EXPRESSION "Success!"
                              SKIP_REGULAR_EXPRESSION "\\[SKIP\\]")
     endforeach ()

--- a/apps/resize/CMakeLists.txt
+++ b/apps/resize/CMakeLists.txt
@@ -92,7 +92,7 @@ if (EXISTS ${IMAGE})
                  COMMAND resize ${INPUT} out_${VARIANT}.png -i ${INTERP} -t ${TYPE} -f ${F})
         set_tests_properties(resize_${VARIANT}
                              PROPERTIES FIXTURES_REQUIRED rgb_small
-                             LABELS internal_app_tests;slow_tests
+                             LABELS "internal_app_tests;slow_tests"
                              PASS_REGULAR_EXPRESSION "Success!"
                              SKIP_REGULAR_EXPRESSION "\\[SKIP\\]")
     endforeach ()


### PR DESCRIPTION
Similar to #5482. This test builds and tests the cross product of 4 kernels, 3 data types, and upsample/downsample, which can take several minutes on the build bots.