### PR TITLE
Add CMake presets for 3.19+ users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+CMakeUserPresets.json
+
 /tutorial/figures/tmp/trace.bin
 /apps/*/bin
 /apps/*/cmake_build

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 16,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "gcc-debug",
+      "displayName": "GCC (Debug)",
+      "description": "Debug build using Ninja generator and GCC-compatible compiler",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "gcc-release",
+      "displayName": "GCC (Release)",
+      "description": "Release build using Ninja generator and GCC-compatible compiler",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CXX_FLAGS_RELEASE": "-O2 -DNDEBUG"
+      }
+    },
+    {
+      "name": "msvc-debug",
+      "displayName": "MSVC (Debug)",
+      "description": "Debug build using Ninja generator and MSVC with vcpkg dependencies.",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    },
+    {
+      "name": "msvc-release",
+      "displayName": "MSVC (Release)",
+      "description": "Debug build using Ninja generator and MSVC with vcpkg dependencies.",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    },
+    {
+      "name": "win32",
+      "displayName": "Win32 (Visual Studio)",
+      "description": "Visual Studio-based Win32 build with vcpkg dependencies.",
+      "generator": "Visual Studio 16 2019",
+      "architecture": "Win32",
+      "toolset": "x64",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    },
+    {
+      "name": "win64",
+      "displayName": "Win64 (Visual Studio)",
+      "description": "Visual Studio-based Win64 build with vcpkg dependencies.",
+      "generator": "Visual Studio 16 2019",
+      "architecture": "Win32",
+      "toolset": "x64",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -55,7 +55,7 @@
       "description": "Visual Studio-based Win32 build with vcpkg dependencies.",
       "generator": "Visual Studio 16 2019",
       "architecture": "Win32",
-      "toolset": "x64",
+      "toolset": "host=x64",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
@@ -66,8 +66,8 @@
       "displayName": "Win64 (Visual Studio)",
       "description": "Visual Studio-based Win64 build with vcpkg dependencies.",
       "generator": "Visual Studio 16 2019",
-      "architecture": "Win32",
-      "toolset": "x64",
+      "architecture": "x64",
+      "toolset": "host=x64",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,18 +13,19 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_FLAGS_RELEASE": "-O2",
+        "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g",
+        "CMAKE_CXX_FLAGS_MINSIZEREL": "-Os"
       }
     },
     {
       "name": "gcc-release",
+      "inherits": "gcc-debug",
       "displayName": "GCC (Release)",
       "description": "Release build using Ninja generator and GCC-compatible compiler",
-      "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_CXX_FLAGS_RELEASE": "-O2 -DNDEBUG"
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {

--- a/README_cmake.md
+++ b/README_cmake.md
@@ -317,7 +317,7 @@ correspond to the longer ones above.
 ```
 > cmake --preset=msvc-release  # Ninja generator, MSVC compiler, Release build
 > cmake --preset=win64         # VS 2019 generator, 64-bit build
-> cmake --preset=win32         # VC 2019 generator, 32-bit build
+> cmake --preset=win32         # VS 2019 generator, 32-bit build
 $ cmake --preset=gcc-release   # Ninja generator, GCC compiler, Release build
 
 $ cmake --list-presets         # Get full list of presets.

--- a/README_cmake.md
+++ b/README_cmake.md
@@ -308,6 +308,22 @@ If you omit `-G Ninja`, a Makefile-based generator will likely be used instead.
 In either case, [`CMAKE_BUILD_TYPE`][cmake_build_type] must be set to one of the
 standard types: `Debug`, `RelWithDebInfo`, `MinSizeRel`, or `Release`.
 
+### CMake Presets
+
+If you are using CMake 3.19+, we provide several [presets][cmake_presets] to
+make the above commands more convenient. The following CMake preset commands
+correspond to the longer ones above.
+
+```
+> cmake --preset=msvc-release  # Ninja generator, MSVC compiler, Release build
+> cmake --preset=win64         # VS 2019 generator, 64-bit build
+> cmake --preset=win32         # VC 2019 generator, 32-bit build
+$ cmake --preset=gcc-release   # Ninja generator, GCC compiler, Release build
+```
+
+The Windows and MSVC presets assume that the environment variable `VCPKG_ROOT`
+is set and points to the root of the vcpkg installation.
+
 ## Installing
 
 Once built, Halide will need to be installed somewhere before using it in a
@@ -947,6 +963,14 @@ The following are some common mistakes that lead to subtly broken builds.
   `INTERFACE`, or both (aka `PUBLIC`). Pick the most conservative one for each
   scenario. Refer to the [transitive usage requirements][cmake-propagation] docs
   for more information.
+- **Needlessly expanding variables** The [`if`][cmake_if] and
+  [`foreach`][cmake_foreach] commands generally expand variables when provided by
+  name. Expanding such variables manually can unintentionally change the behavior
+  of the command. Use `foreach (item IN LISTS list)` instead of
+  `foreach (item ${list})`. Similarly, use `if (varA STREQUAL varB)` instead of
+  `if ("${varA}" STREQUAL "${varB}")` and _definitely_ don't use
+  `if (${varA} STREQUAL ${varB})` since that will fail (in the best case) if
+  either variable's value contains a semi-colon (due to argument expansion).
 
 ### Prohibited commands list
 
@@ -1142,6 +1166,10 @@ guidelines you should follow when writing a new app.
   https://cmake.org/cmake/help/latest/variable/CMAKE_CXX_STANDARD.html
 [cmake_cxx_standard_required]:
   https://cmake.org/cmake/help/latest/variable/CMAKE_CXX_STANDARD_REQUIRED.html
+[cmake_foreach]:
+  https://cmake.org/cmake/help/latest/command/foreach.html
+[cmake_if]:
+  https://cmake.org/cmake/help/latest/command/if.html
 [cmake_lang_compiler_id]:
   https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html
 [cmake_make_program]:
@@ -1150,6 +1178,8 @@ guidelines you should follow when writing a new app.
   https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
 [cmake_prefix_path]:
   https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html
+[cmake_presets]:
+  https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html
 [cmake_sizeof_void_p]:
   https://cmake.org/cmake/help/latest/variable/CMAKE_SIZEOF_VOID_P.html
 [cmake_source_dir]:

--- a/README_cmake.md
+++ b/README_cmake.md
@@ -319,10 +319,15 @@ correspond to the longer ones above.
 > cmake --preset=win64         # VS 2019 generator, 64-bit build
 > cmake --preset=win32         # VC 2019 generator, 32-bit build
 $ cmake --preset=gcc-release   # Ninja generator, GCC compiler, Release build
+
+$ cmake --list-presets         # Get full list of presets.
 ```
 
 The Windows and MSVC presets assume that the environment variable `VCPKG_ROOT`
 is set and points to the root of the vcpkg installation.
+
+Note that the GCC presets do not define `NDEBUG` in release configurations,
+departing from the usual CMake behavior.
 
 ## Installing
 


### PR DESCRIPTION
CMake 3.19 adds a new feature called [_presets_](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html) that make it easier to store, name, and use, common sets of configurations for a CMake project.

This PR adds the necessary file (and documentation!) populated with presets for the following scenarios:

| Name             | Generator          | Build type     | Target                              | Dependencies    |
| ---------------- | ------------------ | -------------- | ----------------------------------- | --------------- |
| `gcc-release`    | Ninja              | Release        | as determined by selected compiler  | system-provided |
| `gcc-debug`      | Ninja              | Debug          | as determined by selected compiler  | system-provided |
| `msvc-release`   | Ninja              | Release        | as determined by vcvars environment | vcpkg           |
| `msvc-debug`     | Ninja              | Debug          | as determined by vcvars environment | vcpkg           |
| `win32`          | Visual Studio 2019 | _multi-config_ | 32-bit Windows, 64-bit host tools   | vcpkg           |
| `win64`          | Visual Studio 2019 | _multi-config_ | 64-bit Windows, 64-bit host tools   | vcpkg           |

The Windows/MSVC presets assume that the environment variable `VCPKG_ROOT` is set to a base vcpkg installation path.

To use them, just run `cmake --preset=gcc-release` from the Halide root and it will create a `./build` directory for you.