### PR TITLE
Fix lossless cast for nested widening casts.

### DIFF
--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -400,7 +400,7 @@ Expr lossless_cast(Type t, Expr e) {
     }
 
     if (const Cast *c = e.as<Cast>()) {
-        if (t.can_represent(c->value.type())) {
+        if (c->type.can_represent(c->value.type())) {
             // We can recurse into widening casts.
             return lossless_cast(t, c->value);
         } else {


### PR DESCRIPTION
`lossless_cast` is currently broken for double widening casts, such as `lossless_cast(uint8, i32(i16(u8)))`. I think this change also matches the behavior intended by the comment.