### PR TITLE
Add version-checking to the clang-tidy and clang-format scripts

### DIFF
--- a/run-clang-format.sh
+++ b/run-clang-format.sh
@@ -15,6 +15,15 @@ ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 [ -z "$CLANG_FORMAT_LLVM_INSTALL_DIR" ] && echo "CLANG_FORMAT_LLVM_INSTALL_DIR must point to an LLVM installation dir for this script." && exit
 echo CLANG_FORMAT_LLVM_INSTALL_DIR = ${CLANG_FORMAT_LLVM_INSTALL_DIR}
 
+VERSION=$(${CLANG_FORMAT_LLVM_INSTALL_DIR}/bin/clang-format --version)
+if [[ ${VERSION} =~ .*version\ 10.* ]]
+then
+    echo "clang-format version 10 found."
+else
+    echo "CLANG_FORMAT_LLVM_INSTALL_DIR must point to an LLVM 10 install!"
+    exit 1
+fi
+
 # Note that we specifically exclude files starting with . in order
 # to avoid finding emacs backup files
 find "${ROOT_DIR}/apps" \

--- a/run-clang-tidy.sh
+++ b/run-clang-tidy.sh
@@ -19,6 +19,16 @@ FIX=$1
 [ -z "$CLANG_TIDY_LLVM_INSTALL_DIR" ] && echo "CLANG_TIDY_LLVM_INSTALL_DIR must point to an LLVM installation dir for this script." && exit
 echo CLANG_TIDY_LLVM_INSTALL_DIR = ${CLANG_TIDY_LLVM_INSTALL_DIR}
 
+VERSION=$(${CLANG_TIDY_LLVM_INSTALL_DIR}/bin/clang-tidy --version)
+if [[ ${VERSION} =~ .*version\ 10.* ]]
+then
+    echo "clang-tidy version 10 found."
+else
+    echo "CLANG_TIDY_LLVM_INSTALL_DIR must point to an LLVM 10 install!"
+    exit 1
+fi
+
+
 # Use a temp folder for the CMake stuff here, so it's fresh & correct every time
 CLANG_TIDY_BUILD_DIR=`mktemp -d`
 echo CLANG_TIDY_BUILD_DIR = ${CLANG_TIDY_BUILD_DIR}


### PR DESCRIPTION
Using the 'wrong' version of the tools will produce results out of sync with our presubmit tests, so add checking to ensure the user has their env set up correctly.