### PR TITLE
Add simd_op_check tests and a few more patterns

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -149,6 +149,18 @@ CodeGen_ARM::CodeGen_ARM(Target target)
         }
     }
 
+    casts.emplace_back("vqdmulh.v4i16", "sqdmulh.v4i16", 4,
+                       i16_sat((wild_i32x4 * wild_i32x4) / (1 << 15)),
+                       Pattern::NarrowArgs);
+    casts.emplace_back("vqdmulh.v8i16", "sqdmulh.v8i16", 8,
+                       i16_sat((wild_i32x_ * wild_i32x_) / (1 << 15)),
+                       Pattern::NarrowArgs);
+    casts.emplace_back("vqdmulh.v2i32", "sqdmulh.v2i32", 2,
+                       i32_sat((wild_i64x2 * wild_i64x2) / Expr(int64_t(1) << 31)),
+                       Pattern::NarrowArgs);
+    casts.emplace_back("vqdmulh.v4i32", "sqdmulh.v4i32", 4,
+                       i32_sat((wild_i64x_ * wild_i64x_) / Expr(int64_t(1) << 31)),
+                       Pattern::NarrowArgs);
     casts.emplace_back("vqrdmulh.v4i16", "sqrdmulh.v4i16", 4,
                        i16_sat((wild_i32x4 * wild_i32x4 + (1 << 14)) / (1 << 15)),
                        Pattern::NarrowArgs);

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -687,24 +687,24 @@ public:
 #endif
 
             // VCLZ     I       -       Count Leading Zeros
-            check(arm32 ? "vclz.s8" : "clz*v*b", 8 * w, count_leading_zeros(i8_1));
-            check(arm32 ? "vclz.s8" : "clz*v*b", 8 * w, count_leading_zeros(u8_1));
-            check(arm32 ? "vclz.s16" : "clz*v*h", 8 * w, count_leading_zeros(i16_1));
-            check(arm32 ? "vclz.s16" : "clz*v*h", 8 * w, count_leading_zeros(u16_1));
-            check(arm32 ? "vclz.s32" : "clz*v*s", 8 * w, count_leading_zeros(i32_1));
-            check(arm32 ? "vclz.s32" : "clz*v*s", 8 * w, count_leading_zeros(u32_1));
+            check(arm32 ? "vclz.i8" : "clz*v*b", 8 * w, count_leading_zeros(i8_1));
+            check(arm32 ? "vclz.i8" : "clz*v*b", 8 * w, count_leading_zeros(u8_1));
+            check(arm32 ? "vclz.i16" : "clz*v*h", 8 * w, count_leading_zeros(i16_1));
+            check(arm32 ? "vclz.i16" : "clz*v*h", 8 * w, count_leading_zeros(u16_1));
+            check(arm32 ? "vclz.i32" : "clz*v*s", 8 * w, count_leading_zeros(i32_1));
+            check(arm32 ? "vclz.i32" : "clz*v*s", 8 * w, count_leading_zeros(u32_1));
 
             // VCMP     -       F, D    Compare Setting Flags
             // We skip this
 
             // VCNT     I       -       Count Number of Set Bits
-            check(arm32 ? "vcnt.s8" : "cnt*v*b", 8 * w, popcount(i8_1));
-            check(arm32 ? "vcnt.s8" : "cnt*v*b", 8 * w, popcount(u8_1));
+            check(arm32 ? "vcnt.8" : "cnt*v*b", 8 * w, popcount(i8_1));
+            check(arm32 ? "vcnt.8" : "cnt*v*b", 8 * w, popcount(u8_1));
             // There is only cnt for bytes, and then horizontal adds.
-            check(arm32 ? "vcnt.s16" : "cnt*v*b", 8 * w, popcount(i16_1));
-            check(arm32 ? "vcnt.s16" : "cnt*v*b", 8 * w, popcount(u16_1));
-            check(arm32 ? "vcnt.s32" : "cnt*v*b", 8 * w, popcount(i32_1));
-            check(arm32 ? "vcnt.s32" : "cnt*v*b", 8 * w, popcount(u32_1));
+            check(arm32 ? "vcnt.8" : "cnt*v*b", 8 * w, popcount(i16_1));
+            check(arm32 ? "vcnt.8" : "cnt*v*b", 8 * w, popcount(u16_1));
+            check(arm32 ? "vcnt.8" : "cnt*v*b", 8 * w, popcount(i32_1));
+            check(arm32 ? "vcnt.8" : "cnt*v*b", 8 * w, popcount(u32_1));
 
             // VCVT     I, F, H I, F, D, H      Convert Between Floating-Point and 32-bit Integer Types
             check(arm32 ? "vcvt.f32.u32" : "ucvtf*v*s", 2 * w, f32(u32_1));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -608,13 +608,9 @@ public:
             check(arm32 ? "vaddhn.i16" : "addhn*v*h", 8 * w, i8((i16_1 + i16_2) / 256));
             check(arm32 ? "vaddhn.i16" : "addhn*v*h", 8 * w, u8((u16_1 + u16_2) / 256));
             check(arm32 ? "vaddhn.i32" : "addhn*v*s", 4 * w, i16((i32_1 + i32_2) / 65536));
-            check(arm32 ? "vaddhn.i32" : "addhn*v*s", 4 * w, i16((i32_1 + i32_2) >> cast<unsigned>(16)));
-            check(arm32 ? "vaddhn.i32" : "addhn*v*s", 4 * w, i16((i32_1 + i32_2) >> cast<int>(16)));
-            check(arm32 ? "vaddhn.i32" : "addhn*v*s", 4 * w, i16((i32_1 + i32_2) << cast<int>(-16)));
             check(arm32 ? "vaddhn.i32" : "addhn*v*s", 4 * w, u16((u32_1 + u32_2) / 65536));
-            check(arm32 ? "vaddhn.i32" : "addhn*v*s", 4 * w, u16((u32_1 + u32_2) >> cast<unsigned>(16)));
-            check(arm32 ? "vaddhn.i32" : "addhn*v*s", 4 * w, u16((u32_1 + u32_2) >> cast<int>(16)));
-            check(arm32 ? "vaddhn.i32" : "addhn*v*s", 4 * w, u16((u32_1 + u32_2) << cast<int>(-16)));
+            check(arm32 ? "vaddhn.i64" : "addhn*v*s", 4 * w, i32((i64_1 + i64_2) >> 32));
+            check(arm32 ? "vaddhn.i64" : "addhn*v*s", 4 * w, u32((u64_1 + u64_2) >> 32));
 
             // VADDL    I       -       Add Long
             check(arm32 ? "vaddl.s8" : "saddl*v*b", 8 * w, i16(i8_1) + i16(i8_2));
@@ -683,10 +679,32 @@ public:
             check(arm32 ? "vcgt.f32" : "fcmgt*v*s", 2 * w, select(f32_1 > f32_2, 1.0f, 2.0f));
 
             // VCLS     I       -       Count Leading Sign Bits
+#if 0
+            // We don't currently match these, but it wouldn't be hard to do.
+            check(arm32 ? "vcls.s8" : "cls*v*b", 8 * w, max(count_leading_zeros(i8_1), count_leading_zeros(~i8_1)));
+            check(arm32 ? "vcls.s16" : "cls*v*h", 8 * w, max(count_leading_zeros(i16_1), count_leading_zeros(~i16_1)));
+            check(arm32 ? "vcls.s32" : "cls*v*s", 8 * w, max(count_leading_zeros(i32_1), count_leading_zeros(~i32_1)));
+#endif
+
             // VCLZ     I       -       Count Leading Zeros
+            check(arm32 ? "vclz.s8" : "clz*v*b", 8 * w, count_leading_zeros(i8_1));
+            check(arm32 ? "vclz.s8" : "clz*v*b", 8 * w, count_leading_zeros(u8_1));
+            check(arm32 ? "vclz.s16" : "clz*v*h", 8 * w, count_leading_zeros(i16_1));
+            check(arm32 ? "vclz.s16" : "clz*v*h", 8 * w, count_leading_zeros(u16_1));
+            check(arm32 ? "vclz.s32" : "clz*v*s", 8 * w, count_leading_zeros(i32_1));
+            check(arm32 ? "vclz.s32" : "clz*v*s", 8 * w, count_leading_zeros(u32_1));
+
             // VCMP     -       F, D    Compare Setting Flags
+            // We skip this
+
             // VCNT     I       -       Count Number of Set Bits
-            // We skip these ones
+            check(arm32 ? "vcnt.s8" : "cnt*v*b", 8 * w, popcount(i8_1));
+            check(arm32 ? "vcnt.s8" : "cnt*v*b", 8 * w, popcount(u8_1));
+            // There is only cnt for bytes, and then horizontal adds.
+            check(arm32 ? "vcnt.s16" : "cnt*v*b", 8 * w, popcount(i16_1));
+            check(arm32 ? "vcnt.s16" : "cnt*v*b", 8 * w, popcount(u16_1));
+            check(arm32 ? "vcnt.s32" : "cnt*v*b", 8 * w, popcount(i32_1));
+            check(arm32 ? "vcnt.s32" : "cnt*v*b", 8 * w, popcount(u32_1));
 
             // VCVT     I, F, H I, F, D, H      Convert Between Floating-Point and 32-bit Integer Types
             check(arm32 ? "vcvt.f32.u32" : "ucvtf*v*s", 2 * w, f32(u32_1));
@@ -1070,18 +1088,23 @@ public:
 
             check(arm32 ? "vqadd.u8" : "uqadd*v*b", 8 * w, u8(min(u16(u8_1) + u16(u8_2), max_u8)));
             check(arm32 ? "vqadd.u16" : "uqadd*v*h", 4 * w, u16(min(u32(u16_1) + u32(u16_2), max_u16)));
+            check(arm32 ? "vqadd.u32" : "uqadd*v*s", 2 * w, u32(min(u64(u32_1) + u64(u32_2), max_u32)));
 
             // Check the case where we add a constant that could be narrowed
             check(arm32 ? "vqadd.u8" : "uqadd*v*b", 8 * w, u8(min(u16(u8_1) + 17, max_u8)));
             check(arm32 ? "vqadd.u16" : "uqadd*v*h", 4 * w, u16(min(u32(u16_1) + 17, max_u16)));
+            check(arm32 ? "vqadd.u32" : "uqadd*v*s", 2 * w, u32(min(u64(u32_1) + 17, max_u32)));
 
-            // Can't do larger ones because we only have i32 constants
+            // Can't do larger ones because we can't represent the intermediate 128-bit wide ops.
 
             // VQDMLAL  I       -       Saturating Double Multiply Accumulate Long
             // VQDMLSL  I       -       Saturating Double Multiply Subtract Long
+            // We don't do these, but it would be possible.
+
             // VQDMULH  I       -       Saturating Doubling Multiply Returning High Half
             // VQDMULL  I       -       Saturating Doubling Multiply Long
-            // Not sure why I'd use these
+            check(arm32 ? "vqdmulh.s16" : "sqdmulh*v*h", 4 * w, i16_sat((i32(i16_1) * i32(i16_2)) >> 15));
+            check(arm32 ? "vqdmulh.s32" : "sqdmulh*v*s", 2 * w, i32_sat((i64(i32_1) * i64(i32_2)) >> 31));
 
             // VQMOVN   I       -       Saturating Move and Narrow
             check(arm32 ? "vqmovn.s16" : "sqxtn*v*h", 8 * w, i8_sat(i16_1));
@@ -1155,7 +1178,6 @@ public:
             check("vraddhn.i32", 4, i16((i32_1 + i32_2 + 32768)/65536));
             check("vraddhn.i32", 4, u16((u32_1 + u32_2 + 32768)/65536));
 #endif
-
             // VRECPE   I, F    -       Reciprocal Estimate
             check(arm32 ? "vrecpe.f32" : "frecpe*v*s", 2 * w, fast_inverse(f32_1));
 
@@ -1194,14 +1216,14 @@ public:
             // Boo rounding ops
 
             // VSHL     I       -       Shift Left
-            check(arm32 ? "vshl.i64" : "shl*v*d", 2 * w, i64_1 * 16);
             check(arm32 ? "vshl.i8" : "shl*v*b", 8 * w, i8_1 * 16);
             check(arm32 ? "vshl.i16" : "shl*v*h", 4 * w, i16_1 * 16);
             check(arm32 ? "vshl.i32" : "shl*v*s", 2 * w, i32_1 * 16);
-            check(arm32 ? "vshl.i64" : "shl*v*d", 2 * w, u64_1 * 16);
+            check(arm32 ? "vshl.i64" : "shl*v*d", 2 * w, i64_1 * 16);
             check(arm32 ? "vshl.i8" : "shl*v*b", 8 * w, u8_1 * 16);
             check(arm32 ? "vshl.i16" : "shl*v*h", 4 * w, u16_1 * 16);
             check(arm32 ? "vshl.i32" : "shl*v*s", 2 * w, u32_1 * 16);
+            check(arm32 ? "vshl.i64" : "shl*v*d", 2 * w, u64_1 * 16);
 
             // VSHLL    I       -       Shift Left Long
             check(arm32 ? "vshll.s8" : "sshll*v*b", 8 * w, i16(i8_1) * 16);
@@ -1212,24 +1234,28 @@ public:
             check(arm32 ? "vshll.u32" : "ushll*v*s", 2 * w, u64(u32_1) * 16);
 
             // VSHR     I       -       Shift Right
-            check(arm32 ? "vshr.s64" : "sshr*v*d", 2 * w, i64_1 / 16);
             check(arm32 ? "vshr.s8" : "sshr*v*b", 8 * w, i8_1 / 16);
             check(arm32 ? "vshr.s16" : "sshr*v*h", 4 * w, i16_1 / 16);
             check(arm32 ? "vshr.s32" : "sshr*v*s", 2 * w, i32_1 / 16);
-            check(arm32 ? "vshr.u64" : "ushr*v*d", 2 * w, u64_1 / 16);
+            check(arm32 ? "vshr.s64" : "sshr*v*d", 2 * w, i64_1 / 16);
             check(arm32 ? "vshr.u8" : "ushr*v*b", 8 * w, u8_1 / 16);
             check(arm32 ? "vshr.u16" : "ushr*v*h", 4 * w, u16_1 / 16);
             check(arm32 ? "vshr.u32" : "ushr*v*s", 2 * w, u32_1 / 16);
+            check(arm32 ? "vshr.u64" : "ushr*v*d", 2 * w, u64_1 / 16);
 
             // VSHRN    I       -       Shift Right Narrow
             check(arm32 ? "vshrn.i16" : "shrn*v*h", 8 * w, i8(i16_1 / 256));
             check(arm32 ? "vshrn.i32" : "shrn*v*s", 4 * w, i16(i32_1 / 65536));
+            check(arm32 ? "vshrn.i64" : "shrn*v*d", 2 * w, i32(i64_1 >> 32));
             check(arm32 ? "vshrn.i16" : "shrn*v*h", 8 * w, u8(u16_1 / 256));
             check(arm32 ? "vshrn.i32" : "shrn*v*s", 4 * w, u16(u32_1 / 65536));
+            check(arm32 ? "vshrn.i64" : "shrn*v*d", 2 * w, u32(u64_1 >> 32));
             check(arm32 ? "vshrn.i16" : "shrn*v*h", 8 * w, i8(i16_1 / 16));
             check(arm32 ? "vshrn.i32" : "shrn*v*s", 4 * w, i16(i32_1 / 16));
+            check(arm32 ? "vshrn.i64" : "shrn*v*d", 2 * w, i32(i64_1 / 16));
             check(arm32 ? "vshrn.i16" : "shrn*v*h", 8 * w, u8(u16_1 / 16));
             check(arm32 ? "vshrn.i32" : "shrn*v*s", 4 * w, u16(u32_1 / 16));
+            check(arm32 ? "vshrn.i64" : "shrn*v*d", 2 * w, u32(u64_1 / 16));
 
             // VSLI     X       -       Shift Left and Insert
             // I guess this could be used for (x*256) | (y & 255)? We don't do bitwise ops on integers, so skip it.
@@ -1239,28 +1265,28 @@ public:
             check(arm32 ? "vsqrt.f64" : "fsqrt*v*d", 2 * w, sqrt(f64_1));
 
             // VSRA     I       -       Shift Right and Accumulate
-            check(arm32 ? "vsra.s64" : "ssra*v*d", 2 * w, i64_2 + i64_1 / 16);
             check(arm32 ? "vsra.s8" : "ssra*v*b", 8 * w, i8_2 + i8_1 / 16);
             check(arm32 ? "vsra.s16" : "ssra*v*h", 4 * w, i16_2 + i16_1 / 16);
             check(arm32 ? "vsra.s32" : "ssra*v*s", 2 * w, i32_2 + i32_1 / 16);
-            check(arm32 ? "vsra.u64" : "usra*v*d", 2 * w, u64_2 + u64_1 / 16);
+            check(arm32 ? "vsra.s64" : "ssra*v*d", 2 * w, i64_2 + i64_1 / 16);
             check(arm32 ? "vsra.u8" : "usra*v*b", 8 * w, u8_2 + u8_1 / 16);
             check(arm32 ? "vsra.u16" : "usra*v*h", 4 * w, u16_2 + u16_1 / 16);
             check(arm32 ? "vsra.u32" : "usra*v*s", 2 * w, u32_2 + u32_1 / 16);
+            check(arm32 ? "vsra.u64" : "usra*v*d", 2 * w, u64_2 + u64_1 / 16);
 
             // VSRI     X       -       Shift Right and Insert
             // See VSLI
 
             // VSUB     I, F    F, D    Subtract
-            check(arm32 ? "vsub.i64" : "sub*v*d", 2 * w, i64_1 - i64_2);
-            check(arm32 ? "vsub.i64" : "sub*v*d", 2 * w, u64_1 - u64_2);
-            check(arm32 ? "vsub.f32" : "fsub*v*s", 4 * w, f32_1 - f32_2);
             check(arm32 ? "vsub.i8" : "sub*v*b", 8 * w, i8_1 - i8_2);
             check(arm32 ? "vsub.i8" : "sub*v*b", 8 * w, u8_1 - u8_2);
             check(arm32 ? "vsub.i16" : "sub*v*h", 4 * w, i16_1 - i16_2);
             check(arm32 ? "vsub.i16" : "sub*v*h", 4 * w, u16_1 - u16_2);
             check(arm32 ? "vsub.i32" : "sub*v*s", 2 * w, i32_1 - i32_2);
             check(arm32 ? "vsub.i32" : "sub*v*s", 2 * w, u32_1 - u32_2);
+            check(arm32 ? "vsub.i64" : "sub*v*d", 2 * w, i64_1 - i64_2);
+            check(arm32 ? "vsub.i64" : "sub*v*d", 2 * w, u64_1 - u64_2);
+            check(arm32 ? "vsub.f32" : "fsub*v*s", 4 * w, f32_1 - f32_2);
             check(arm32 ? "vsub.f32" : "fsub*v*s", 2 * w, f32_1 - f32_2);
 
             // VSUBHN   I       -       Subtract and Narrow
@@ -1268,6 +1294,8 @@ public:
             check(arm32 ? "vsubhn.i16" : "subhn*v*h", 8 * w, u8((u16_1 - u16_2) / 256));
             check(arm32 ? "vsubhn.i32" : "subhn*v*s", 4 * w, i16((i32_1 - i32_2) / 65536));
             check(arm32 ? "vsubhn.i32" : "subhn*v*s", 4 * w, u16((u32_1 - u32_2) / 65536));
+            check(arm32 ? "vsubhn.i64" : "subhn*v*d", 2 * w, i32((i64_1 - i64_2) >> 32));
+            check(arm32 ? "vsubhn.i64" : "subhn*v*d", 2 * w, u32((u64_1 - u64_2) >> 32));
 
             // VSUBL    I       -       Subtract Long
             check(arm32 ? "vsubl.s8" : "ssubl*v*b", 8 * w, i16(i8_1) - i16(i8_2));
@@ -1907,6 +1935,10 @@ int main(int argc, char **argv) {
     if (argc > 1) {
         test.filter = argv[1];
         test.set_num_threads(1);
+    }
+
+    if (getenv("FILTER")) {
+        test.filter = getenv("FILTER");
     }
 
     // TODO: multithreading here is the cause of https://github.com/halide/Halide/issues/3669;

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1937,10 +1937,6 @@ int main(int argc, char **argv) {
         test.set_num_threads(1);
     }
 
-    if (getenv("FILTER")) {
-        test.filter = getenv("FILTER");
-    }
-
     // TODO: multithreading here is the cause of https://github.com/halide/Halide/issues/3669;
     // the fundamental issue is that we make one set of ImageParams to construct many
     // Exprs, then realize those Exprs on arbitrary threads; it is known that sharing


### PR DESCRIPTION
We care about count_leading_zeros, and this PR fills in some other gaps in coverage. Also add a few patterns, I think we should have non-rounding versions of instructions we have rounding patterns for.