### PR TITLE
Enable commented clang-format option. Fix schema.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,8 +3,7 @@ AccessModifierOffset: -4
 AlignEscapedNewlines: Left
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
-# Requires Clang-Format 10+
-# AllowShortBlocksOnASingleLine: Empty
+AllowShortBlocksOnASingleLine: Empty
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: Always
 AllowShortLoopsOnASingleLine: false
@@ -44,8 +43,7 @@ SpacesBeforeTrailingComments: 2
 SpacesInAngles: false
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
-Standard: Cpp11
+Standard: c++11
 TabWidth: 8
 UseTab: Never
-
 ...


### PR DESCRIPTION
After #5122 and #5513 it made sense to fix up the `.clang-format` file to use the option that was formerly commented and fix the file according to the published schema (use `c++11` instead of `Cpp11`). Running `run-clang-format.sh` resulted in no further changes.