### PR TITLE
Point fft JIT tests to Halide binary

### DIFF
--- a/apps/fft/CMakeLists.txt
+++ b/apps/fft/CMakeLists.txt
@@ -46,5 +46,8 @@ set_tests_properties(fft_aot_test PROPERTIES
 
 foreach (i IN ITEMS 8 12 16 24 32 48)
     add_test(NAME bench${i}x${i} COMMAND bench_fft ${i} ${i} "${CMAKE_CURRENT_BINARY_DIR}")
-    set_tests_properties(bench${i}x${i} PROPERTIES LABELS fft)
+    set_tests_properties(bench${i}x${i} 
+                         PROPERTIES
+                         LABELS fft
+                         ENVIRONMENT "PATH=$<SHELL_PATH:$<TARGET_FILE_DIR:Halide::Halide>>")
 endforeach ()

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -757,7 +757,7 @@ std::string halide_type_to_c_type(const Type &t) {
 
 int generate_filter_main_inner(int argc, char **argv, std::ostream &cerr) {
     const char kUsage[] =
-        "gengen\n"
+        "gengen \n"
         "  [-g GENERATOR_NAME] [-f FUNCTION_NAME] [-o OUTPUT_DIR] [-r RUNTIME_NAME] [-d 1|0]\n"
         "  [-e EMIT_OPTIONS] [-n FILE_BASE_NAME] [-p PLUGIN_NAME] [-s AUTOSCHEDULER_NAME]\n"
         "       target=target-string[,target-string...] [generator_arg=value [...]]\n"


### PR DESCRIPTION
The FFT JIT tests didn't have Halide.dll in their path. This fixes that.