### PR TITLE
Upgrade logging code in interpret_nn

### DIFF
--- a/apps/interpret_nn/Makefile
+++ b/apps/interpret_nn/Makefile
@@ -98,7 +98,12 @@ OPS_CXXFLAGS = -I$(BIN)/$*
 
 # ---------------------- util
 
-# (empty)
+$(BIN)/%/error_util.o: util/error_util.cpp
+	@mkdir -p $(@D)
+	$(CXX-$*) $(CXXFLAGS-$*) $(APP_CXXFLAGS) -c $< -o $@
+
+UTIL_DEPS = \
+	$(BIN)/%/error_util.o
 
 # ---------------------- interpreter
 
@@ -162,43 +167,43 @@ TFLITE_PARSER_DEPS = \
 # ---------------------- test
 
 # unit tests for each op (not yet complete)
-$(BIN)/%/add_test: test/add_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE)
+$(BIN)/%/add_test: test/add_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE) $(UTIL_DEPS)
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS-$*) $(APP_CXXFLAGS) $(filter %.cpp %.o %.a,$^) -o $@ $(LDFLAGS-$*)
 
-$(BIN)/%/average_pool_test: test/average_pool_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE)
+$(BIN)/%/average_pool_test: test/average_pool_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE) $(UTIL_DEPS)
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS-$*) $(APP_CXXFLAGS) $(filter %.cpp %.o %.a,$^) -o $@ $(LDFLAGS-$*)
 
-$(BIN)/%/concatenation_test: test/concatenation_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE)
+$(BIN)/%/concatenation_test: test/concatenation_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE) $(UTIL_DEPS)
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS-$*) $(APP_CXXFLAGS) $(filter %.cpp %.o %.a,$^) -o $@ $(LDFLAGS-$*)
 
-$(BIN)/%/conv2d_test: test/conv2d_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE)
+$(BIN)/%/conv2d_test: test/conv2d_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE) $(UTIL_DEPS)
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS-$*) $(APP_CXXFLAGS) $(filter %.cpp %.o %.a,$^) -o $@ $(LDFLAGS-$*)
 
-$(BIN)/%/depthwise_conv2d_test: test/depthwise_conv2d_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE)
+$(BIN)/%/depthwise_conv2d_test: test/depthwise_conv2d_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE) $(UTIL_DEPS)
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS-$*) $(APP_CXXFLAGS) $(filter %.cpp %.o %.a,$^) -o $@ $(LDFLAGS-$*)
 
-$(BIN)/%/fully_connected_test: test/fully_connected_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE)
+$(BIN)/%/fully_connected_test: test/fully_connected_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE) $(UTIL_DEPS)
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS-$*) $(APP_CXXFLAGS) $(filter %.cpp %.o %.a,$^) -o $@ $(LDFLAGS-$*)
 
-$(BIN)/%/max_pool_test: test/max_pool_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE)
+$(BIN)/%/max_pool_test: test/max_pool_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE) $(UTIL_DEPS)
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS-$*) $(APP_CXXFLAGS) $(filter %.cpp %.o %.a,$^) -o $@ $(LDFLAGS-$*)
 
-$(BIN)/%/pad_test: test/pad_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE)
+$(BIN)/%/pad_test: test/pad_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE) $(UTIL_DEPS)
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS-$*) $(APP_CXXFLAGS) $(filter %.cpp %.o %.a,$^) -o $@ $(LDFLAGS-$*)
 
-$(BIN)/%/quantize_test: test/quantize_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE)
+$(BIN)/%/quantize_test: test/quantize_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE) $(UTIL_DEPS)
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS-$*) $(APP_CXXFLAGS) $(filter %.cpp %.o %.a,$^) -o $@ $(LDFLAGS-$*)
 
-$(BIN)/%/reshape_test: test/reshape_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE)
+$(BIN)/%/reshape_test: test/reshape_test.cpp $(BIN)/%/model.o $(BIN)/%/interval.o $(BIN)/%/ops.o $(OPS_HALIDE) $(UTIL_DEPS)
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS-$*) $(APP_CXXFLAGS) $(filter %.cpp %.o %.a,$^) -o $@ $(LDFLAGS-$*)
 
@@ -228,12 +233,12 @@ test_ops: build_test_ops
 
 # ---------------------- toplevel executables
 
-$(BIN)/%/benchmark: benchmark.cpp $(INTERPRETER_DEPS) $(TFLITE_PARSER_DEPS)
+$(BIN)/%/benchmark: benchmark.cpp $(INTERPRETER_DEPS) $(TFLITE_PARSER_DEPS) $(UTIL_DEPS)
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS-$*) $(APP_CXXFLAGS) $(filter %.cpp %.o %.a,$^) -o $@ $(LDFLAGS-$*)
 
 # Utility to explode a tflite pipeline into individual ops for testing.
-$(BIN)/%/tflite_exploder: tflite_exploder.cpp $(BIN)/schema/tflite_schema_direct_generated.h
+$(BIN)/%/tflite_exploder: tflite_exploder.cpp $(BIN)/schema/tflite_schema_direct_generated.h $(UTIL_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $(APP_CXXFLAGS) $(TFLITE_SCHEMA_CXXFLAGS) $(filter %.cpp %.o %.a,$^) -o $@ $(LDFLAGS)
 
@@ -254,7 +259,7 @@ TFLITE_STATIC_LIB ?= $(TFLITE_BASE)/tools/make/gen/native_x86_64/lib/libtensorfl
 
 TENSORFLOW_INCLUDES ?= $(TENSORFLOW_BASE)
 
-$(BIN)/%/compare_vs_tflite: compare_vs_tflite.cpp $(INTERPRETER_DEPS)  $(TFLITE_PARSER_DEPS)
+$(BIN)/%/compare_vs_tflite: compare_vs_tflite.cpp $(INTERPRETER_DEPS)  $(TFLITE_PARSER_DEPS) $(UTIL_DEPS)
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS-$*) $(APP_CXXFLAGS) -I$(TENSORFLOW_INCLUDES) $(filter %.cpp %.o %.a,$^) $(TFLITE_STATIC_LIB) -o $@ $(LDFLAGS-$*)
 

--- a/apps/interpret_nn/benchmark.cpp
+++ b/apps/interpret_nn/benchmark.cpp
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
     }
 
     if (options.verbose && options.trace) {
-        std::cerr << "You cannot specify --trace and --verbose at the same time.\n";
+        LOG(ERROR) << "You cannot specify --trace and --verbose at the same time.\n";
         exit(-1);
     }
 

--- a/apps/interpret_nn/compare_vs_tflite.cpp
+++ b/apps/interpret_nn/compare_vs_tflite.cpp
@@ -60,7 +60,7 @@ halide_type_t tf_lite_type_to_halide_type(TfLiteType t) {
     case kTfLiteNoType:
     case kTfLiteComplex64:
     case kTfLiteComplex128:
-        LOG_FATAL << "Unsupported TfLiteType: " << TfLiteTypeGetName(t);
+        CHECK(0) << "Unsupported TfLiteType: " << TfLiteTypeGetName(t);
         return halide_type_t();
     }
 }

--- a/apps/interpret_nn/interpreter/model.cpp
+++ b/apps/interpret_nn/interpreter/model.cpp
@@ -31,7 +31,7 @@ size_t sizeof_tensor_type(TensorType t) {
     // case TensorType::String:  fallthru
     // case TensorType::Bool:    fallthru
     default:
-        LOG_FATAL << "Unknown size of type";
+        CHECK(0) << "Unknown size of type";
         return 0;
     }
 }
@@ -63,7 +63,7 @@ const char *to_string(TensorType t) {
     case TensorType::Bool:
         return "bool";
     default:
-        LOG_FATAL << "Unhandled interpret_nn::TensorType";
+        CHECK(0) << "Unhandled interpret_nn::TensorType";
         return "";
     }
 }
@@ -93,7 +93,7 @@ halide_type_t to_halide_type(TensorType t) {
     case TensorType::Complex128:
     case TensorType::String:
     default:
-        LOG_FATAL << "Unhandled type in to_halide_type";
+        CHECK(0) << "Unhandled type in to_halide_type";
         return halide_type_t();
     }
 }

--- a/apps/interpret_nn/interpreter/model.h
+++ b/apps/interpret_nn/interpreter/model.h
@@ -49,7 +49,7 @@ inline TensorType to_tensor_type() {
     if (std::is_const<T>::value) {
         return to_tensor_type<typename std::remove_const<T>::type>();
     }
-    LOG_FATAL << "Type is not convertible to TensorType";
+    CHECK(0) << "Type is not convertible to TensorType";
     // unreachable
 }
 
@@ -264,7 +264,7 @@ public:
         if (output_count() == 1) {
             return without_strides(output(0)->shape());
         } else {
-            LOG_FATAL << "More than one output requires get_full_crop override.";
+            CHECK(0) << "More than one output requires get_full_crop override.";
             return Box();
         }
     }

--- a/apps/interpret_nn/test/fully_connected_test.cpp
+++ b/apps/interpret_nn/test/fully_connected_test.cpp
@@ -133,7 +133,7 @@ struct FullyConnectedOpTestFactory : public op_test::TestCaseFactory {
 }  // namespace interpret_nn
 
 int main(int argc, char **argv) {
-    std::cerr << "(fully_connected_test is not yet complete; skipping)\n";
+    LOG(ERROR) << "(fully_connected_test is not yet complete; skipping)\n";
     return 0;
     // interpret_nn::FullyConnectedOpTestFactory factory;
     // return interpret_nn::op_test::op_test_main(argc, argv, factory);

--- a/apps/interpret_nn/test/op_test_helper.h
+++ b/apps/interpret_nn/test/op_test_helper.h
@@ -236,7 +236,7 @@ public:
             // nothing
         }
         if (verbose && num_failures > 0) {
-            std::cerr << "num_failures is: " << num_failures << "\n";
+            LOG(INFO) << "num_failures is: " << num_failures << "\n";
         }
         return num_failures;
     }
@@ -258,7 +258,7 @@ int op_test_main(int argc, char **argv, TestCaseFactory &factory) {
             verbose = true;
             continue;
         }
-        std::cerr << "Usage: TODO\n";
+        LOG(INFO) << "Usage: TODO\n";
         return -1;
     }
 

--- a/apps/interpret_nn/tflite/tflite_parser.cpp
+++ b/apps/interpret_nn/tflite/tflite_parser.cpp
@@ -43,7 +43,7 @@ public:
         case tflite::ActivationFunctionType_SIGN_BIT:
             return ActivationFunction::SignBit;
         default:
-            LOG_FATAL << "Unknown tflite::ActivationFunctionType";
+            CHECK(0) << "Unknown tflite::ActivationFunctionType";
         }
     }
 
@@ -74,7 +74,7 @@ public:
         case tflite::TensorType_COMPLEX128:
             return TensorType::Complex128;
         default:
-            LOG_FATAL << "Unknown tflite::TensorType";
+            CHECK(0) << "Unknown tflite::TensorType";
         }
     }
 
@@ -85,7 +85,7 @@ public:
         case tflite::Padding_VALID:
             return Padding::Valid;
         default:
-            LOG_FATAL << "Unknown tflite::Padding";
+            CHECK(0) << "Unknown tflite::Padding";
         }
     }
 
@@ -307,8 +307,8 @@ public:
         case tflite::BuiltinOperator_FULLY_CONNECTED:
             return parse_fully_connected(op);
         default:
-            LOG_FATAL << "Unsupported op "
-                      << tflite::EnumNameBuiltinOperator(builtin_code);
+            CHECK(0) << "Unsupported op "
+                     << tflite::EnumNameBuiltinOperator(builtin_code);
         }
     }
 

--- a/apps/interpret_nn/util/buffer_util.h
+++ b/apps/interpret_nn/util/buffer_util.h
@@ -54,7 +54,7 @@ auto dynamic_type_dispatch(const halide_type_t &type, Args &&... args)
         // require handling pointer types in our functors
         // HANDLE_CASE(halide_type_handle, 64, void *)
     default:
-        LOG_FATAL << "Unsupported type";
+        CHECK(0) << "Unsupported type";
         using ReturnType = decltype(std::declval<Functor<uint8_t>>()(std::forward<Args>(args)...));
         return ReturnType();
     }

--- a/apps/interpret_nn/util/error_util.cpp
+++ b/apps/interpret_nn/util/error_util.cpp
@@ -1,0 +1,66 @@
+#include "util/error_util.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+
+#if defined(__ANDROID__)
+#include <android/log.h>
+#endif
+
+namespace interpret_nn {
+namespace internal {
+
+namespace {
+
+const char *const severity_names[] = {"INFO", "WARNING", "ERROR"};
+
+#if defined(__ANDROID__)
+int const android_severity[] = {ANDROID_LOG_INFO, ANDROID_LOG_WARN, ANDROID_LOG_ERROR};
+#endif
+
+}  // namespace
+
+Logger::Logger(LogSeverity severity, const char *file, int line)
+    : severity(severity) {
+    assert(severity >= 0 && severity <= 2);
+    msg << severity_names[(int)severity] << ": "
+        << "(" << file << ":" << line << ") ";
+}
+
+Logger::Logger(LogSeverity severity)
+    : severity(severity) {
+    assert(severity >= 0 && severity <= 2);
+    msg << severity_names[(int)severity] << ": ";
+}
+
+Logger::~Logger() noexcept(false) {
+    if (!msg.str().empty() && msg.str().back() != '\n') {
+        msg << '\n';
+    }
+
+    std::cerr << msg.str();
+
+#if defined(__ANDROID__)
+    __android_log_write(android_severity[(int)severity], "interpret_nn", msg.str().c_str());
+#endif
+
+    // TODO: call iOS-specific logger here?
+}
+
+CheckLogger::CheckLogger(LogSeverity severity, const char *condition_string)
+    : Logger(severity) {
+    msg << " Condition Failed: " << condition_string << '\n';
+}
+
+CheckLogger::CheckLogger(LogSeverity severity, const char *file, int line, const char *condition_string)
+    : Logger(severity, file, line) {
+    msg << " Condition Failed: " << condition_string << '\n';
+}
+
+CheckLogger::~CheckLogger() noexcept(false) {
+    std::abort();
+}
+
+}  // namespace internal
+}  // namespace interpret_nn


### PR DESCRIPTION
To make some integration with the Delegate code easier, I upgraded our logging code to mimic their usage pattern a bit. This is a little gratuitous but will likely pay off in the Delegate code.

- Replaced LOG_FATAL with CHECK(0) everywhere
- Added LOG(INFO/WARN/ERROR), all of which are wrappers that output to stderr (and also to __android_log on android)
- Made the guts of CHECK() a little more purpose-built
- Moved guts of Logger into a cpp file to hopefully reduce code bloat from logging
- Made inclusion of __FILE__ and __LINE__ info contingent on NDEBUG, to reduce internal info of logging that might be desirable to leave in release builds.
- Converted some (but not all) usage of std::cerr to use LOG(whatever).