### PR TITLE
Solve the COMDAT in runtime failing on Mac OS X problem once and for all.

### DIFF
--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -560,6 +560,20 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t,
     const std::set<string> retain = {"__stack_chk_guard",
                                      "__stack_chk_fail"};
 
+    // COMDAT is not supported in MachO object files, hence it does not
+    // work on Mac OS or iOS. These sometimes show up in the runtime
+    // since we compile for an abstract target that is based on ELF.
+    // This code removes the Comdat and makes the symbol a regular one,
+    // which only works if there is a single instance, which is generally
+    // the case for the runtime. Presumably if this isn't true, linking the
+    // module will fail.
+    if (t.os == Target::IOS || t.os == Target::OSX) {
+        for (auto &global_obj : modules[0]->global_objects()) {
+	    global_obj.setComdat(nullptr);
+	}
+	modules[0]->getComdatSymbolTable().clear();
+    }
+
     // Enumerate the global variables.
     for (auto &gv : modules[0]->globals()) {
         // No variables are part of the public interface (even the ones labelled halide_)

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -560,13 +560,14 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t,
     const std::set<string> retain = {"__stack_chk_guard",
                                      "__stack_chk_fail"};
 
-    // COMDAT is not supported in MachO object files, hence it does not
-    // work on Mac OS or iOS. These sometimes show up in the runtime
-    // since we compile for an abstract target that is based on ELF.
-    // This code removes the Comdat and makes the symbol a regular one,
-    // which only works if there is a single instance, which is generally
-    // the case for the runtime. Presumably if this isn't true, linking the
-    // module will fail.
+    // COMDAT is not supported in MachO object files, hence it does
+    // not work on Mac OS or iOS. These sometimes show up in the
+    // runtime since we compile for an abstract target that is based
+    // on ELF. This code removes all Comdat items and leaves the
+    // symbols they were attached to as regular definitions, which
+    // only works if there is a single instance, which is generally
+    // the case for the runtime. Presumably if this isn't true,
+    // linking the module will fail.
     if (t.os == Target::IOS || t.os == Target::OSX) {
         for (auto &global_obj : modules[0]->global_objects()) {
 	    global_obj.setComdat(nullptr);

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -570,9 +570,9 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t,
     // linking the module will fail.
     if (t.os == Target::IOS || t.os == Target::OSX) {
         for (auto &global_obj : modules[0]->global_objects()) {
-	    global_obj.setComdat(nullptr);
-	}
-	modules[0]->getComdatSymbolTable().clear();
+            global_obj.setComdat(nullptr);
+        }
+        modules[0]->getComdatSymbolTable().clear();
     }
 
     // Enumerate the global variables.

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -568,6 +568,10 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t,
     // only works if there is a single instance, which is generally
     // the case for the runtime. Presumably if this isn't true,
     // linking the module will fail.
+    //
+    // Comdats are left in for other platforms as they are required
+    // for certain things on Windows and they are useful in general in
+    // ELF based formats.
     if (t.os == Target::IOS || t.os == Target::OSX) {
         for (auto &global_obj : modules[0]->global_objects()) {
             global_obj.setComdat(nullptr);


### PR DESCRIPTION
This removes Comdat items from LLVM IR when linking a runtime for Mac OS or iOS. This would always be a failure with the current code and it is anticipated that this will either produce one valid symbol or fail with a multiple definition error. I have tested this with the GPU context consistency changes and it does fix the error that code was running into.