### PR TITLE
Change generator target for using optional target flags for apps/blur

### DIFF
--- a/apps/blur/Makefile
+++ b/apps/blur/Makefile
@@ -11,7 +11,7 @@ $(GENERATOR_BIN)/halide_blur.generator: halide_blur_generator.cpp $(GENERATOR_DE
 
 $(BIN)/%/halide_blur.a: $(GENERATOR_BIN)/halide_blur.generator
 	@mkdir -p $(@D)
-	$^ -g halide_blur -e $(GENERATOR_OUTPUTS) -o $(@D) target=$*
+	$^ -g halide_blur -e $(GENERATOR_OUTPUTS) -o $(@D) target=$(HL_TARGET)
 
 # g++ on OS X might actually be system clang without openmp
 CXX_VERSION=$(shell $(CXX) --version)


### PR DESCRIPTION
Without the change:

HL_TARGET=arm-64-android-hvx_128 make bin/arm-64-android/test

would have target=arm-64-android instead of arm-64-android-hvx_128

@dsharletg PTAL