### PR TITLE
Update images used in apps/ tests

### DIFF
--- a/apps/harris/CMakeLists.txt
+++ b/apps/harris/CMakeLists.txt
@@ -30,11 +30,11 @@ target_link_libraries(harris_filter
                       harris_auto_schedule)
 
 # Test that the app actually works!
-set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgb.png)
+set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgba.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgb.png COPYONLY)
+    configure_file(${IMAGE} rgba.png COPYONLY)
     add_test(NAME harris_filter
-             COMMAND harris_filter rgb.png out.png)
+             COMMAND harris_filter rgba.png out.png)
     set_tests_properties(harris_filter PROPERTIES
                          LABELS harris
                          PASS_REGULAR_EXPRESSION "Success!"

--- a/apps/hist/CMakeLists.txt
+++ b/apps/hist/CMakeLists.txt
@@ -31,11 +31,11 @@ target_link_libraries(hist_filter
                       hist_auto_schedule)
 
 # Test that the app actually works!
-set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgb.png)
+set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgba.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgb.png COPYONLY)
+    configure_file(${IMAGE} rgba.png COPYONLY)
     add_test(NAME hist_filter
-             COMMAND hist_filter rgb.png out.png)
+             COMMAND hist_filter rgba.png out.png)
     set_tests_properties(hist_filter PROPERTIES
                          LABELS hist
                          PASS_REGULAR_EXPRESSION "Success!"

--- a/apps/iir_blur/CMakeLists.txt
+++ b/apps/iir_blur/CMakeLists.txt
@@ -30,11 +30,11 @@ target_link_libraries(iir_blur_filter PRIVATE
                       iir_blur_auto_schedule)
 
 # Test that the app actually works!
-set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgb.png)
+set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgba.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgb.png COPYONLY)
+    configure_file(${IMAGE} rgba.png COPYONLY)
     add_test(NAME iir_blur_filter
-             COMMAND iir_blur_filter rgb.png out.png)
+             COMMAND iir_blur_filter rgba.png out.png)
     set_tests_properties(iir_blur_filter PROPERTIES
                          LABELS iir_blur
                          PASS_REGULAR_EXPRESSION "Success!"

--- a/apps/lens_blur/CMakeLists.txt
+++ b/apps/lens_blur/CMakeLists.txt
@@ -30,11 +30,11 @@ target_link_libraries(lens_blur_filter
                       lens_blur_auto_schedule)
 
 # Test that the app actually works!
-set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgb.png)
+set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgb_small.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgb.png COPYONLY)
+    configure_file(${IMAGE} rgb_small.png COPYONLY)
     add_test(NAME lens_blur_filter
-             COMMAND lens_blur_filter rgb.png 32 13 0.5 32 3 out.png)
+             COMMAND lens_blur_filter rgb_small.png 32 13 0.5 32 3 out.png)
     set_tests_properties(lens_blur_filter PROPERTIES
                          LABELS lens_blur
                          PASS_REGULAR_EXPRESSION "Success!"

--- a/apps/max_filter/CMakeLists.txt
+++ b/apps/max_filter/CMakeLists.txt
@@ -30,10 +30,10 @@ target_link_libraries(max_filter_filter
                       max_filter_auto_schedule)
 
 # Test that the app actually works!
-set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgb.png)
+set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgba.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgb.png COPYONLY)
-    add_test(NAME max_filter_filter COMMAND max_filter_filter rgb.png out.png)
+    configure_file(${IMAGE} rgba.png COPYONLY)
+    add_test(NAME max_filter_filter COMMAND max_filter_filter rgba.png out.png)
     set_tests_properties(max_filter_filter PROPERTIES
                          LABELS max_filter
                          PASS_REGULAR_EXPRESSION "Success!"

--- a/apps/unsharp/CMakeLists.txt
+++ b/apps/unsharp/CMakeLists.txt
@@ -30,10 +30,10 @@ target_link_libraries(unsharp_filter
                       unsharp_auto_schedule)
 
 # Test that the app actually works!
-set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgb.png)
+set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgba.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgb.png COPYONLY)
-    add_test(NAME unsharp_filter COMMAND unsharp_filter rgb.png out.png)
+    configure_file(${IMAGE} rgba.png COPYONLY)
+    add_test(NAME unsharp_filter COMMAND unsharp_filter rgba.png out.png)
     set_tests_properties(unsharp_filter PROPERTIES
                          LABELS unsharp
                          PASS_REGULAR_EXPRESSION "Success!"


### PR DESCRIPTION
Some of them weren't the same as the Make equivalents, which meant that the test diverged between the two build systems (sometimes causing failures due to too-large images).