### PR TITLE
Change apps/ Makefiles handling of HL_TARGET

### DIFF
--- a/apps/HelloPyTorch/Makefile
+++ b/apps/HelloPyTorch/Makefile
@@ -84,7 +84,7 @@ $(BIN)/%/add_float32.a: $(GENERATOR_BIN)/add.generator
 		-f add_float32 \
 		-e static_library,c_header,pytorch_wrapper \
 		-o $(@D) \
-		target=$* \
+		target=$(HL_TARGET) \
 		auto_schedule=false
 
 $(BIN)/%/add_halidegrad_float32.a: $(GENERATOR_BIN)/add.generator
@@ -96,7 +96,7 @@ $(BIN)/%/add_halidegrad_float32.a: $(GENERATOR_BIN)/add.generator
 		-e static_library,c_header,pytorch_wrapper \
 		-o $(@D) \
 		-d 1 \
-		target=$* \
+		target=$(HL_TARGET) \
 		auto_schedule=true
 
 $(BIN)/%/add_grad_float32.a: $(GENERATOR_BIN)/add.generator
@@ -107,7 +107,7 @@ $(BIN)/%/add_grad_float32.a: $(GENERATOR_BIN)/add.generator
 		-f add_grad_float32 \
 		-e static_library,c_header,pytorch_wrapper \
 		-o $(@D) \
-		target=$* \
+		target=$(HL_TARGET) \
 		auto_schedule=false
 
 $(BIN)/%/add_float64.a: $(GENERATOR_BIN)/add.generator
@@ -118,7 +118,7 @@ $(BIN)/%/add_float64.a: $(GENERATOR_BIN)/add.generator
 		-f add_float64 \
 		-e static_library,c_header,pytorch_wrapper \
 		-o $(@D) \
-		target=$* \
+		target=$(HL_TARGET) \
 		auto_schedule=false
 
 $(BIN)/%/add_halidegrad_float64.a: $(GENERATOR_BIN)/add.generator
@@ -129,9 +129,9 @@ $(BIN)/%/add_halidegrad_float64.a: $(GENERATOR_BIN)/add.generator
 		-f add_halidegrad_float64 \
 		-e static_library,c_header,pytorch_wrapper \
 		-o $(@D) \
-		target=$* \
+		target=$(HL_TARGET) \
 		-d 1 \
-		target=$* \
+		target=$(HL_TARGET) \
 		auto_schedule=true
 
 $(BIN)/%/add_grad_float64.a: $(GENERATOR_BIN)/add.generator
@@ -142,7 +142,7 @@ $(BIN)/%/add_grad_float64.a: $(GENERATOR_BIN)/add.generator
 		-f add_grad_float64 \
 		-e static_library,c_header,pytorch_wrapper \
 		-o $(@D) \
-		target=$* \
+		target=$(HL_TARGET) \
 		auto_schedule=false
 
 # -----------------------------------------------------------------------------

--- a/apps/auto_viz/Makefile
+++ b/apps/auto_viz/Makefile
@@ -17,7 +17,7 @@ $$(BIN)/%/auto_viz_demo_$(1)_up.a: $$(GENERATOR_BIN)/auto_viz_demo.generator
 	@mkdir -p $$(@D)
 	$$^ -g auto_viz_demo -o $$(@D) -f auto_viz_demo_$(1)_up \
 		-e $$(GENERATOR_OUTPUTS) \
-		target=$$*-no_runtime-trace_all \
+		target=$$(HL_TARGET)-no_runtime-trace_all \
 		schedule_type=$$$$(echo $(1) | cut -d_ -f1) \
 		upsample=true
 
@@ -25,7 +25,7 @@ $$(BIN)/%/auto_viz_demo_$(1)_down.a: $$(GENERATOR_BIN)/auto_viz_demo.generator
 	@mkdir -p $$(@D)
 	$$^ -g auto_viz_demo -o $$(@D) -f auto_viz_demo_$(1)_down \
 		-e $$(GENERATOR_OUTPUTS) \
-		target=$$*-no_runtime-trace_all \
+		target=$$(HL_TARGET)-no_runtime-trace_all \
 		schedule_type=$$$$(echo $(1) | cut -d_ -f1) \
 		upsample=false
 
@@ -59,7 +59,7 @@ $(foreach V,$(VARIANTS),$(eval $(call GEN_RULES,$(V))))
 
 $(BIN)/%/runtime.a: $(GENERATOR_BIN)/auto_viz_demo.generator
 	@mkdir -p $(@D)
-	$^ -r runtime -o $(@D) target=$*
+	$^ -r runtime -o $(@D) target=$(HL_TARGET)
 
 LIBRARIES = $(foreach V,$(VARIANTS),$(BIN)/%/auto_viz_demo_$(V)_up.a $(BIN)/%/auto_viz_demo_$(V)_down.a)
 $(BIN)/%/auto_viz_demo: auto_viz_demo.cpp $(BIN)/%/runtime.a $(LIBRARIES)

--- a/apps/bgu/Makefile
+++ b/apps/bgu/Makefile
@@ -12,15 +12,15 @@ $(GENERATOR_BIN)/bgu.generator: bgu_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/%/bgu.a: $(GENERATOR_BIN)/bgu.generator
 	@mkdir -p $(@D)
-	$< -g bgu -f bgu -o $(BIN)/$* target=$*-no_runtime auto_schedule=false
+	$< -g bgu -f bgu -o $(BIN)/$* target=$(HL_TARGET)-no_runtime auto_schedule=false
 
 $(BIN)/%/bgu_auto_schedule.a: $(GENERATOR_BIN)/bgu.generator
 	@mkdir -p $(@D)
-	$< -g bgu -f bgu_auto_schedule -o $(BIN)/$* target=$*-no_runtime auto_schedule=true
+	$< -g bgu -f bgu_auto_schedule -o $(BIN)/$* target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/%/runtime.a: $(GENERATOR_BIN)/bgu.generator
 	@mkdir -p $(@D)
-	$< -r runtime -o $(BIN)/$* target=$*
+	$< -r runtime -o $(BIN)/$* target=$(HL_TARGET)
 
 $(BIN)/%/filter: filter.cpp $(BIN)/%/bgu.a $(BIN)/%/bgu_auto_schedule.a $(BIN)/%/runtime.a
 	@mkdir -p $(@D)

--- a/apps/bilateral_grid/Makefile
+++ b/apps/bilateral_grid/Makefile
@@ -10,11 +10,11 @@ $(GENERATOR_BIN)/bilateral_grid.generator: bilateral_grid_generator.cpp $(GENERA
 
 $(BIN)/%/bilateral_grid.a: $(GENERATOR_BIN)/bilateral_grid.generator
 	@mkdir -p $(@D)
-	$^ -g bilateral_grid -e $(GENERATOR_OUTPUTS) -o $(@D) -f bilateral_grid target=$* auto_schedule=false
+	$^ -g bilateral_grid -e $(GENERATOR_OUTPUTS) -o $(@D) -f bilateral_grid target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/%/bilateral_grid_auto_schedule.a: $(GENERATOR_BIN)/bilateral_grid.generator
 	@mkdir -p $(@D)
-	$^ -g bilateral_grid -e $(GENERATOR_OUTPUTS) -o $(@D) -f bilateral_grid_auto_schedule target=$*-no_runtime auto_schedule=true -e static_library,c_header,schedule
+	$^ -g bilateral_grid -e $(GENERATOR_OUTPUTS) -o $(@D) -f bilateral_grid_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true -e static_library,c_header,schedule
 
 $(BIN)/%/filter: filter.cpp $(BIN)/%/bilateral_grid.a $(BIN)/%/bilateral_grid_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/blur/Makefile
+++ b/apps/blur/Makefile
@@ -11,7 +11,7 @@ $(GENERATOR_BIN)/halide_blur.generator: halide_blur_generator.cpp $(GENERATOR_DE
 
 $(BIN)/%/halide_blur.a: $(GENERATOR_BIN)/halide_blur.generator
 	@mkdir -p $(@D)
-	$^ -g halide_blur -e $(GENERATOR_OUTPUTS) -o $(@D) target=$*
+	$^ -g halide_blur -e $(GENERATOR_OUTPUTS) -o $(@D) target=$(HL_TARGET)
 
 # g++ on OS X might actually be system clang without openmp
 CXX_VERSION=$(shell $(CXX) --version)

--- a/apps/c_backend/Makefile
+++ b/apps/c_backend/Makefile
@@ -16,11 +16,11 @@ $(GENERATOR_BIN)/pipeline.generator: pipeline_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/%/pipeline_native.a: $(GENERATOR_BIN)/pipeline.generator
 	@mkdir -p $(@D)
-	$^ -g pipeline -o $(@D) -f pipeline_native -e $(GENERATOR_OUTPUTS) target=$*
+	$^ -g pipeline -o $(@D) -f pipeline_native -e $(GENERATOR_OUTPUTS) target=$(HL_TARGET)
 
 $(BIN)/%/pipeline_c.halide_generated.cpp: $(GENERATOR_BIN)/pipeline.generator
 	@mkdir -p $(@D)
-	$^ -g pipeline -o $(@D) -f pipeline_c -e c_source,c_header target=$*
+	$^ -g pipeline -o $(@D) -f pipeline_c -e c_source,c_header target=$(HL_TARGET)
 
 $(BIN)/%/run: run.cpp $(BIN)/%/pipeline_c.halide_generated.cpp $(BIN)/%/pipeline_native.a
 	$(CXX) $(CXXFLAGS) -Wall -I$(BIN)/$* $(filter-out %.h,$^) -o $@  $(LDFLAGS)

--- a/apps/camera_pipe/Makefile
+++ b/apps/camera_pipe/Makefile
@@ -12,11 +12,11 @@ $(GENERATOR_BIN)/camera_pipe.generator: camera_pipe_generator.cpp $(GENERATOR_DE
 
 $(BIN)/%/camera_pipe.a: $(GENERATOR_BIN)/camera_pipe.generator
 	@mkdir -p $(@D)
-	$^ -g camera_pipe -e $(GENERATOR_OUTPUTS) -o $(@D) -f camera_pipe target=$* auto_schedule=false
+	$^ -g camera_pipe -e $(GENERATOR_OUTPUTS) -o $(@D) -f camera_pipe target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/%/camera_pipe_auto_schedule.a: $(GENERATOR_BIN)/camera_pipe.generator
 	@mkdir -p $(@D)
-	$^ -g camera_pipe -e $(GENERATOR_OUTPUTS) -o $(@D) -f camera_pipe_auto_schedule target=$*-no_runtime auto_schedule=true
+	$^ -g camera_pipe -e $(GENERATOR_OUTPUTS) -o $(@D) -f camera_pipe_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/%/process: process.cpp $(BIN)/%/camera_pipe.a $(BIN)/%/camera_pipe_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/conv_layer/Makefile
+++ b/apps/conv_layer/Makefile
@@ -10,11 +10,11 @@ $(GENERATOR_BIN)/conv_layer.generator: conv_layer_generator.cpp $(GENERATOR_DEPS
 
 $(BIN)/%/conv_layer.a: $(GENERATOR_BIN)/conv_layer.generator
 	@mkdir -p $(@D)
-	$^ -g conv_layer -e $(GENERATOR_OUTPUTS) -o $(@D) -f conv_layer target=$* auto_schedule=false
+	$^ -g conv_layer -e $(GENERATOR_OUTPUTS) -o $(@D) -f conv_layer target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/%/conv_layer_auto_schedule.a: $(GENERATOR_BIN)/conv_layer.generator
 	@mkdir -p $(@D)
-	$^ -g conv_layer -e $(GENERATOR_OUTPUTS) -o $(@D) -f conv_layer_auto_schedule target=$*-no_runtime auto_schedule=true
+	$^ -g conv_layer -e $(GENERATOR_OUTPUTS) -o $(@D) -f conv_layer_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/%/process: process.cpp $(BIN)/%/conv_layer.a $(BIN)/%/conv_layer_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/depthwise_separable_conv/Makefile
+++ b/apps/depthwise_separable_conv/Makefile
@@ -8,11 +8,11 @@ $(GENERATOR_BIN)/depthwise_separable_conv.generator: depthwise_separable_conv_ge
 
 $(BIN)/%/depthwise_separable_conv.a: $(GENERATOR_BIN)/depthwise_separable_conv.generator
 	@mkdir -p $(@D)
-	$^ -g depthwise_separable_conv -e $(GENERATOR_OUTPUTS) -o $(@D) -f depthwise_separable_conv target=$* auto_schedule=false
+	$^ -g depthwise_separable_conv -e $(GENERATOR_OUTPUTS) -o $(@D) -f depthwise_separable_conv target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/%/depthwise_separable_conv_auto_schedule.a: $(GENERATOR_BIN)/depthwise_separable_conv.generator
 	@mkdir -p $(@D)
-	$^ -g depthwise_separable_conv -e $(GENERATOR_OUTPUTS) -o $(@D) -f depthwise_separable_conv_auto_schedule target=$*-no_runtime auto_schedule=true
+	$^ -g depthwise_separable_conv -e $(GENERATOR_OUTPUTS) -o $(@D) -f depthwise_separable_conv_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/%/process: process.cpp $(BIN)/%/depthwise_separable_conv.a $(BIN)/%/depthwise_separable_conv_auto_schedule.a
 	@-mkdir -p $(BIN)

--- a/apps/fft/Makefile
+++ b/apps/fft/Makefile
@@ -46,24 +46,24 @@ bench_64x64: $(BIN)/$(HL_TARGET)/bench_fft
 
 $(GENERATOR_BIN)/fft.generator: fft_generator.cpp fft.cpp fft.h $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) $(filter %.cpp,$^) -o $@ $(LIBHALIDE_LDFLAGS) 
+	$(CXX) $(CXXFLAGS) $(filter %.cpp,$^) -o $@ $(LIBHALIDE_LDFLAGS)
 
 # Generate four AOT compiled FFT variants. Forward versions have gain set to 1 / 256.0
 $(BIN)/%/fft_forward_r2c.a: $(GENERATOR_BIN)/fft.generator
 	@mkdir -p $(@D)
-	$^ -g fft -e $(GENERATOR_OUTPUTS) -o $(@D) -f fft_forward_r2c target=$* direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=real output_number_type=complex
+	$^ -g fft -e $(GENERATOR_OUTPUTS) -o $(@D) -f fft_forward_r2c target=$(HL_TARGET) direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=real output_number_type=complex
 
 $(BIN)/%/fft_inverse_c2r.a: $(GENERATOR_BIN)/fft.generator
 	@mkdir -p $(@D)
-	$^ -g fft -e $(GENERATOR_OUTPUTS) -o $(@D) -f fft_inverse_c2r target=$* direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=real
+	$^ -g fft -e $(GENERATOR_OUTPUTS) -o $(@D) -f fft_inverse_c2r target=$(HL_TARGET) direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=real
 
 $(BIN)/%/fft_forward_c2c.a: $(GENERATOR_BIN)/fft.generator
 	@mkdir -p $(@D)
-	$^ -g fft -e $(GENERATOR_OUTPUTS) -o $(@D) -f fft_forward_c2c target=$* direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=complex output_number_type=complex
+	$^ -g fft -e $(GENERATOR_OUTPUTS) -o $(@D) -f fft_forward_c2c target=$(HL_TARGET) direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=complex output_number_type=complex
 
 $(BIN)/%/fft_inverse_c2c.a: $(GENERATOR_BIN)/fft.generator
 	@mkdir -p $(@D)
-	$^ -g fft -e $(GENERATOR_OUTPUTS) -o $(@D) -f fft_inverse_c2c target=$* direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=complex
+	$^ -g fft -e $(GENERATOR_OUTPUTS) -o $(@D) -f fft_inverse_c2c target=$(HL_TARGET) direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=complex
 
 $(BIN)/%/fft_aot_test: fft_aot_test.cpp $(BIN)/%/fft_forward_r2c.a $(BIN)/%/fft_inverse_c2r.a $(BIN)/%/fft_forward_c2c.a $(BIN)/%/fft_inverse_c2c.a
 	@mkdir -p $(@D)

--- a/apps/glsl/Makefile
+++ b/apps/glsl/Makefile
@@ -12,7 +12,7 @@ $(GENERATOR_BIN)/halide_blur_glsl.generator: halide_blur_glsl_generator.cpp $(GE
 
 $(BIN)/%/halide_blur_glsl.a: $(GENERATOR_BIN)/halide_blur_glsl.generator
 	@mkdir -p $(@D)
-	$^ -g halide_blur_glsl -e $(GENERATOR_OUTPUTS) -o $(@D) target=$*-opengl-debug
+	$^ -g halide_blur_glsl -e $(GENERATOR_OUTPUTS) -o $(@D) target=$(HL_TARGET)-opengl-debug
 
 $(GENERATOR_BIN)/halide_ycc_glsl.generator: halide_ycc_glsl_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
@@ -20,7 +20,7 @@ $(GENERATOR_BIN)/halide_ycc_glsl.generator: halide_ycc_glsl_generator.cpp $(GENE
 
 $(BIN)/%/halide_ycc_glsl.a: $(GENERATOR_BIN)/halide_ycc_glsl.generator
 	@mkdir -p $(@D)
-	$^ -g halide_ycc_glsl -e $(GENERATOR_OUTPUTS) -o $(@D) target=$*-opengl-debug
+	$^ -g halide_ycc_glsl -e $(GENERATOR_OUTPUTS) -o $(@D) target=$(HL_TARGET)-opengl-debug
 
 $(BIN)/%/opengl_test: opengl_test.cpp $(BIN)/%/halide_blur_glsl.a $(BIN)/%/halide_ycc_glsl.a
 	@mkdir -p $(@D)

--- a/apps/harris/Makefile
+++ b/apps/harris/Makefile
@@ -10,15 +10,15 @@ $(GENERATOR_BIN)/harris.generator: harris_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/%/harris.a: $(GENERATOR_BIN)/harris.generator
 	@mkdir -p $(@D)
-	$< -g harris -f harris -o $(BIN)/$* target=$*-no_runtime auto_schedule=false
+	$< -g harris -f harris -o $(BIN)/$* target=$(HL_TARGET)-no_runtime auto_schedule=false
 
 $(BIN)/%/harris_auto_schedule.a: $(GENERATOR_BIN)/harris.generator
 	@mkdir -p $(@D)
-	$< -g harris -f harris_auto_schedule -o $(BIN)/$* target=$*-no_runtime auto_schedule=true
+	$< -g harris -f harris_auto_schedule -o $(BIN)/$* target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/%/runtime.a: $(GENERATOR_BIN)/harris.generator
 	@mkdir -p $(@D)
-	$< -r runtime -o $(BIN)/$* target=$*
+	$< -r runtime -o $(BIN)/$* target=$(HL_TARGET)
 
 $(BIN)/%/filter: filter.cpp $(BIN)/%/harris.a $(BIN)/%/harris_auto_schedule.a $(BIN)/%/runtime.a
 	@mkdir -p $(@D)

--- a/apps/hexagon_benchmarks/Makefile
+++ b/apps/hexagon_benchmarks/Makefile
@@ -22,27 +22,27 @@ $(GENERATOR_BIN)/%.generator : %_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/%/conv3x3a16.o: $(GENERATOR_BIN)/conv3x3.generator
 	@mkdir -p $(@D)
-	$^ -g conv3x3 -o $(@D) -e object,c_header -f conv3x3a16 target=$* accumulator_type=int16 ${SCHEDULING_OPTS}
+	$^ -g conv3x3 -o $(@D) -e object,c_header -f conv3x3a16 target=$(HL_TARGET) accumulator_type=int16 ${SCHEDULING_OPTS}
 
 $(BIN)/%/dilate3x3.o: $(GENERATOR_BIN)/dilate3x3.generator
 	@mkdir -p $(@D)
-	$^ -g dilate3x3 -o $(@D) -e object,c_header -f dilate3x3 target=$* ${SCHEDULING_OPTS}
+	$^ -g dilate3x3 -o $(@D) -e object,c_header -f dilate3x3 target=$(HL_TARGET) ${SCHEDULING_OPTS}
 
 $(BIN)/%/median3x3.o: $(GENERATOR_BIN)/median3x3.generator
 	@mkdir -p $(@D)
-	$^ -g median3x3 -o $(@D) -e object,c_header -f median3x3 target=$* ${SCHEDULING_OPTS}
+	$^ -g median3x3 -o $(@D) -e object,c_header -f median3x3 target=$(HL_TARGET) ${SCHEDULING_OPTS}
 
 $(BIN)/%/gaussian5x5.o: $(GENERATOR_BIN)/gaussian5x5.generator
 	@mkdir -p $(@D)
-	$^ -g gaussian5x5 -o $(@D) -e object,c_header -f gaussian5x5 target=$* ${SCHEDULING_OPTS}
+	$^ -g gaussian5x5 -o $(@D) -e object,c_header -f gaussian5x5 target=$(HL_TARGET) ${SCHEDULING_OPTS}
 
 $(BIN)/%/sobel.o: $(GENERATOR_BIN)/sobel.generator
 	@mkdir -p $(@D)
-	$^ -g sobel -o $(@D) -e object,c_header -f sobel target=$* ${SCHEDULING_OPTS}
+	$^ -g sobel -o $(@D) -e object,c_header -f sobel target=$(HL_TARGET) ${SCHEDULING_OPTS}
 
 $(BIN)/%/conv3x3a32.o: $(GENERATOR_BIN)/conv3x3.generator
 	@mkdir -p $(@D)
-	$^ -g conv3x3 -o $(@D) -e object,c_header -f conv3x3a32 target=$* accumulator_type=int32 ${SCHEDULING_OPTS}
+	$^ -g conv3x3 -o $(@D) -e object,c_header -f conv3x3a32 target=$(HL_TARGET) accumulator_type=int32 ${SCHEDULING_OPTS}
 
 $(BIN)/%/filters.a : $(OBJS)
 	ar q $(BIN)/$*/filters.a $^

--- a/apps/hexagon_dma/Makefile
+++ b/apps/hexagon_dma/Makefile
@@ -51,94 +51,94 @@ OUTPUT_YUV_16BIT = output_y.type=uint16 output_uv.type=uint16
 
 $(BIN)/%/pipeline_nv12_linear_ro_async.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=async      $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=false
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=async      $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=false
 $(BIN)/%/pipeline_nv12_linear_ro_basic.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=none       $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=false
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=none       $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=false
 $(BIN)/%/pipeline_nv12_linear_ro_fold.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=fold        $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=false
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=fold        $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=false
 $(BIN)/%/pipeline_nv12_linear_ro_split.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=split       $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=false
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=split       $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=false
 $(BIN)/%/pipeline_nv12_linear_ro_split_async.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=split_async $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=false
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=split_async $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=false
 $(BIN)/%/pipeline_nv12_linear_rw_async.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=async       $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=true
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=async       $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=true
 $(BIN)/%/pipeline_nv12_linear_rw_fold.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=fold        $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=true
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=fold        $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=true
 $(BIN)/%/pipeline_nv12_linear_rw_basic.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=none        $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=true
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=none        $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=true
 $(BIN)/%/pipeline_nv12_linear_rw_split.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=split       $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=true
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=split       $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=true
 $(BIN)/%/pipeline_nv12_linear_rw_split_async.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=split_async $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=true
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=split_async $(INPUT_YUV_8BIT)  $(OUTPUT_YUV_8BIT)  use_dma_for_output=true
 $(BIN)/%/pipeline_p010_linear_ro_async.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=async       $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=false
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=async       $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=false
 $(BIN)/%/pipeline_p010_linear_ro_basic.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=none        $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=false
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=none        $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=false
 $(BIN)/%/pipeline_p010_linear_ro_fold.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=fold        $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=false
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=fold        $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=false
 $(BIN)/%/pipeline_p010_linear_ro_split_async.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=split_async $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=false
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=split_async $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=false
 $(BIN)/%/pipeline_p010_linear_ro_split.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=split       $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=false
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=split       $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=false
 $(BIN)/%/pipeline_p010_linear_rw_async.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=async       $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=true
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=async       $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=true
 $(BIN)/%/pipeline_p010_linear_rw_fold.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=fold        $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=true
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=fold        $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=true
 $(BIN)/%/pipeline_p010_linear_rw_basic.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=none        $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=true
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=none        $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=true
 $(BIN)/%/pipeline_p010_linear_rw_split.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=split       $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=true
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=split       $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=true
 $(BIN)/%/pipeline_p010_linear_rw_split_async.o: $(BIN)/%/pipeline_yuv_linear_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=split_async $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=true
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=split_async $(INPUT_YUV_16BIT) $(OUTPUT_YUV_16BIT) use_dma_for_output=true
 $(BIN)/%/pipeline_raw_linear_interleaved_ro_async.o: $(BIN)/%/pipeline_raw_linear_interleaved_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=async       use_dma_for_output=false
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=async       use_dma_for_output=false
 $(BIN)/%/pipeline_raw_linear_interleaved_ro_basic.o: $(BIN)/%/pipeline_raw_linear_interleaved_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=none        use_dma_for_output=false
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=none        use_dma_for_output=false
 $(BIN)/%/pipeline_raw_linear_interleaved_ro_fold.o: $(BIN)/%/pipeline_raw_linear_interleaved_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=fold        use_dma_for_output=false
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=fold        use_dma_for_output=false
 $(BIN)/%/pipeline_raw_linear_interleaved_ro_split.o: $(BIN)/%/pipeline_raw_linear_interleaved_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=split       use_dma_for_output=false
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=split       use_dma_for_output=false
 $(BIN)/%/pipeline_raw_linear_interleaved_ro_split_async.o: $(BIN)/%/pipeline_raw_linear_interleaved_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=split_async use_dma_for_output=false
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=split_async use_dma_for_output=false
 $(BIN)/%/pipeline_raw_linear_interleaved_rw_async.o: $(BIN)/%/pipeline_raw_linear_interleaved_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=async       use_dma_for_output=true
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=async       use_dma_for_output=true
 $(BIN)/%/pipeline_raw_linear_interleaved_rw_basic.o: $(BIN)/%/pipeline_raw_linear_interleaved_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=none        use_dma_for_output=true
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=none        use_dma_for_output=true
 $(BIN)/%/pipeline_raw_linear_interleaved_rw_fold.o: $(BIN)/%/pipeline_raw_linear_interleaved_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=fold        use_dma_for_output=true
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=fold        use_dma_for_output=true
 $(BIN)/%/pipeline_raw_linear_interleaved_rw_split.o: $(BIN)/%/pipeline_raw_linear_interleaved_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=split       use_dma_for_output=true
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=split       use_dma_for_output=true
 $(BIN)/%/pipeline_raw_linear_interleaved_rw_split_async.o: $(BIN)/%/pipeline_raw_linear_interleaved_basic
 	@mkdir -p $(@D)
-	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$*-$(HEXAGON_DMA) schedule=split_async use_dma_for_output=true
+	$^ -g $(<F) -o $(@D) -e object,c_header,stmt_html -f $(subst .o,,$(@F)) target=$(HL_TARGET)-$(HEXAGON_DMA) schedule=split_async use_dma_for_output=true
 
 NV12_PIPE=pipeline_nv12_linear
 NV12_RW=$(BIN)/%/$(NV12_PIPE)_rw_async.o $(BIN)/%/$(NV12_PIPE)_rw_split.o $(BIN)/%/$(NV12_PIPE)_rw_split_async.o

--- a/apps/hist/Makefile
+++ b/apps/hist/Makefile
@@ -12,15 +12,15 @@ $(GENERATOR_BIN)/hist.generator: hist_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/%/hist.a: $(GENERATOR_BIN)/hist.generator
 	@mkdir -p $(@D)
-	$< -g hist -f hist -o $(BIN)/$* target=$*-no_runtime auto_schedule=false
+	$< -g hist -f hist -o $(BIN)/$* target=$(HL_TARGET)-no_runtime auto_schedule=false
 
 $(BIN)/%/hist_auto_schedule.a: $(GENERATOR_BIN)/hist.generator
 	@mkdir -p $(@D)
-	$< -g hist -f hist_auto_schedule -o $(BIN)/$* target=$*-no_runtime auto_schedule=true
+	$< -g hist -f hist_auto_schedule -o $(BIN)/$* target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/%/runtime.a: $(GENERATOR_BIN)/hist.generator
 	@mkdir -p $(@D)
-	$< -r runtime -o $(BIN)/$* target=$*
+	$< -r runtime -o $(BIN)/$* target=$(HL_TARGET)
 
 $(BIN)/%/filter: filter.cpp $(BIN)/%/hist.a $(BIN)/%/hist_auto_schedule.a $(BIN)/%/runtime.a
 	@mkdir -p $(@D)

--- a/apps/iir_blur/Makefile
+++ b/apps/iir_blur/Makefile
@@ -10,15 +10,15 @@ $(GENERATOR_BIN)/iir_blur.generator: iir_blur_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/%/iir_blur.a: $(GENERATOR_BIN)/iir_blur.generator
 	@mkdir -p $(@D)
-	$< -g iir_blur -f iir_blur -o $(BIN)/$* target=$*-no_runtime auto_schedule=false
+	$< -g iir_blur -f iir_blur -o $(BIN)/$* target=$(HL_TARGET)-no_runtime auto_schedule=false
 
 $(BIN)/%/iir_blur_auto_schedule.a: $(GENERATOR_BIN)/iir_blur.generator
 	@mkdir -p $(@D)
-	$< -g iir_blur -f iir_blur_auto_schedule -o $(BIN)/$* target=$*-no_runtime auto_schedule=true
+	$< -g iir_blur -f iir_blur_auto_schedule -o $(BIN)/$* target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/%/runtime.a: $(GENERATOR_BIN)/iir_blur.generator
 	@mkdir -p $(@D)
-	$< -r runtime -o $(BIN)/$* target=$*
+	$< -r runtime -o $(BIN)/$* target=$(HL_TARGET)
 
 $(BIN)/%/filter: filter.cpp $(BIN)/%/iir_blur.a $(BIN)/%/iir_blur_auto_schedule.a $(BIN)/%/runtime.a
 	@mkdir -p $(@D)

--- a/apps/interpolate/Makefile
+++ b/apps/interpolate/Makefile
@@ -12,15 +12,15 @@ $(GENERATOR_BIN)/interpolate.generator: interpolate_generator.cpp $(GENERATOR_DE
 
 $(BIN)/%/interpolate.a: $(GENERATOR_BIN)/interpolate.generator
 	@mkdir -p $(@D)
-	$< -g interpolate -f interpolate -o $(BIN)/$* target=$*-no_runtime auto_schedule=false
+	$< -g interpolate -f interpolate -o $(BIN)/$* target=$(HL_TARGET)-no_runtime auto_schedule=false
 
 $(BIN)/%/interpolate_auto_schedule.a: $(GENERATOR_BIN)/interpolate.generator
 	@mkdir -p $(@D)
-	$< -g interpolate -f interpolate_auto_schedule -o $(BIN)/$* target=$*-no_runtime auto_schedule=true
+	$< -g interpolate -f interpolate_auto_schedule -o $(BIN)/$* target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/%/runtime.a: $(GENERATOR_BIN)/interpolate.generator
 	@mkdir -p $(@D)
-	$< -r runtime -o $(BIN)/$* target=$*
+	$< -r runtime -o $(BIN)/$* target=$(HL_TARGET)
 
 $(BIN)/%/filter: filter.cpp $(BIN)/%/interpolate.a $(BIN)/%/interpolate_auto_schedule.a $(BIN)/%/runtime.a
 	@mkdir -p $(@D)

--- a/apps/lens_blur/Makefile
+++ b/apps/lens_blur/Makefile
@@ -11,11 +11,11 @@ $(GENERATOR_BIN)/lens_blur.generator: lens_blur_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/%/lens_blur.a: $(GENERATOR_BIN)/lens_blur.generator
 	@mkdir -p $(@D)
-	$^ -g lens_blur -e $(GENERATOR_OUTPUTS) -o $(@D) -f lens_blur target=$* auto_schedule=false
+	$^ -g lens_blur -e $(GENERATOR_OUTPUTS) -o $(@D) -f lens_blur target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/%/lens_blur_auto_schedule.a: $(GENERATOR_BIN)/lens_blur.generator
 	@mkdir -p $(@D)
-	$^ -g lens_blur -e $(GENERATOR_OUTPUTS) -o $(@D) -f lens_blur_auto_schedule target=$*-no_runtime auto_schedule=true
+	$^ -g lens_blur -e $(GENERATOR_OUTPUTS) -o $(@D) -f lens_blur_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/%/process: process.cpp $(BIN)/%/lens_blur.a $(BIN)/%/lens_blur_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -10,11 +10,11 @@ $(GENERATOR_BIN)/local_laplacian.generator: local_laplacian_generator.cpp $(GENE
 
 $(BIN)/%/local_laplacian.a: $(GENERATOR_BIN)/local_laplacian.generator
 	@mkdir -p $(@D)
-	$^ -g local_laplacian -e $(GENERATOR_OUTPUTS) -o $(@D) -f local_laplacian target=$* auto_schedule=false
+	$^ -g local_laplacian -e $(GENERATOR_OUTPUTS) -o $(@D) -f local_laplacian target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/%/local_laplacian_auto_schedule.a: $(GENERATOR_BIN)/local_laplacian.generator
 	@mkdir -p $(@D)
-	$^ -g local_laplacian -e $(GENERATOR_OUTPUTS) -o $(@D) -f local_laplacian_auto_schedule target=$*-no_runtime auto_schedule=true
+	$^ -g local_laplacian -e $(GENERATOR_OUTPUTS) -o $(@D) -f local_laplacian_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/%/process: process.cpp $(BIN)/%/local_laplacian.a $(BIN)/%/local_laplacian_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/max_filter/Makefile
+++ b/apps/max_filter/Makefile
@@ -12,15 +12,15 @@ $(GENERATOR_BIN)/max_filter.generator: max_filter_generator.cpp $(GENERATOR_DEPS
 
 $(BIN)/%/max_filter.a: $(GENERATOR_BIN)/max_filter.generator
 	@mkdir -p $(@D)
-	$< -g max_filter -f max_filter -o $(BIN)/$* target=$*-no_runtime auto_schedule=false
+	$< -g max_filter -f max_filter -o $(BIN)/$* target=$(HL_TARGET)-no_runtime auto_schedule=false
 
 $(BIN)/%/max_filter_auto_schedule.a: $(GENERATOR_BIN)/max_filter.generator
 	@mkdir -p $(@D)
-	$< -g max_filter -f max_filter_auto_schedule -o $(BIN)/$* target=$*-no_runtime auto_schedule=true
+	$< -g max_filter -f max_filter_auto_schedule -o $(BIN)/$* target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/%/runtime.a: $(GENERATOR_BIN)/max_filter.generator
 	@mkdir -p $(@D)
-	$< -r runtime -o $(BIN)/$* target=$*
+	$< -r runtime -o $(BIN)/$* target=$(HL_TARGET)
 
 $(BIN)/%/filter: filter.cpp $(BIN)/%/max_filter.a $(BIN)/%/max_filter_auto_schedule.a $(BIN)/%/runtime.a
 	@mkdir -p $(@D)

--- a/apps/nl_means/Makefile
+++ b/apps/nl_means/Makefile
@@ -10,11 +10,11 @@ $(GENERATOR_BIN)/nl_means.generator: nl_means_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/%/nl_means.a: $(GENERATOR_BIN)/nl_means.generator
 	@mkdir -p $(@D)
-	$^ -g nl_means -e $(GENERATOR_OUTPUTS) -o $(@D) -f nl_means target=$* auto_schedule=false
+	$^ -g nl_means -e $(GENERATOR_OUTPUTS) -o $(@D) -f nl_means target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/%/nl_means_auto_schedule.a: $(GENERATOR_BIN)/nl_means.generator
 	@mkdir -p $(@D)
-	$^ -g nl_means -e $(GENERATOR_OUTPUTS) -o $(@D) -f nl_means_auto_schedule target=$*-no_runtime auto_schedule=true
+	$^ -g nl_means -e $(GENERATOR_OUTPUTS) -o $(@D) -f nl_means_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/%/process: process.cpp $(BIN)/%/nl_means.a $(BIN)/%/nl_means_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/nn_ops/Makefile
+++ b/apps/nn_ops/Makefile
@@ -9,7 +9,7 @@ $(GENERATOR_BIN)/AveragePool.generator: AveragePool_generator.cpp common.cpp $(G
 
 $(BIN)/%/AveragePool.o: $(GENERATOR_BIN)/AveragePool.generator
 	@mkdir -p $(@D)
-	$^ -g AveragePool -o $(@D) -e object,c_header -f AveragePool target=$*
+	$^ -g AveragePool -o $(@D) -e object,c_header -f AveragePool target=$(HL_TARGET)
 
 $(BIN)/%/AveragePool: AveragePool.cpp $(BIN)/%/AveragePool.o
 	@mkdir -p $(@D)
@@ -21,7 +21,7 @@ $(GENERATOR_BIN)/Convolution.generator: Convolution_generator.cpp common.cpp $(G
 
 $(BIN)/%/Convolution.o: $(GENERATOR_BIN)/Convolution.generator
 	@mkdir -p $(@D)
-	$^ -g Convolution -o $(@D) -e object,c_header -f Convolution target=$*
+	$^ -g Convolution -o $(@D) -e object,c_header -f Convolution target=$(HL_TARGET)
 
 $(BIN)/%/Convolution: Convolution.cpp common_reference.cpp $(BIN)/%/Convolution.o
 	@mkdir -p $(@D)
@@ -33,23 +33,23 @@ $(GENERATOR_BIN)/DepthwiseConvolution.generator: DepthwiseConvolution_generator.
 
 $(BIN)/%/runtime.a: $(GENERATOR_BIN)/DepthwiseConvolution.generator
 	@mkdir -p $(@D)
-	@$< -r runtime -o $(@D) target=$*
+	@$< -r runtime -o $(@D) target=$(HL_TARGET)
 
 $(BIN)/%/DepthwiseConvolution_1.o: $(GENERATOR_BIN)/DepthwiseConvolution.generator
 	@mkdir -p $(@D)
-	$^ -g DepthwiseConvolution -o $(@D) -e object,c_header -f DepthwiseConvolution_1 target=$*-no_runtime depth_multiplier=1
+	$^ -g DepthwiseConvolution -o $(@D) -e object,c_header -f DepthwiseConvolution_1 target=$(HL_TARGET)-no_runtime depth_multiplier=1
 
 $(BIN)/%/DepthwiseConvolution_2.o: $(GENERATOR_BIN)/DepthwiseConvolution.generator
 	@mkdir -p $(@D)
-	$^ -g DepthwiseConvolution -o $(@D) -e object,c_header -f DepthwiseConvolution_2 target=$*-no_runtime depth_multiplier=2
+	$^ -g DepthwiseConvolution -o $(@D) -e object,c_header -f DepthwiseConvolution_2 target=$(HL_TARGET)-no_runtime depth_multiplier=2
 
 $(BIN)/%/DepthwiseConvolution_4.o: $(GENERATOR_BIN)/DepthwiseConvolution.generator
 	@mkdir -p $(@D)
-	$^ -g DepthwiseConvolution -o $(@D) -e object,c_header -f DepthwiseConvolution_4 target=$*-no_runtime depth_multiplier=4
+	$^ -g DepthwiseConvolution -o $(@D) -e object,c_header -f DepthwiseConvolution_4 target=$(HL_TARGET)-no_runtime depth_multiplier=4
 
 $(BIN)/%/DepthwiseConvolution_8.o: $(GENERATOR_BIN)/DepthwiseConvolution.generator
 	@mkdir -p $(@D)
-	$^ -g DepthwiseConvolution -o $(@D) -e object,c_header -f DepthwiseConvolution_8 target=$*-no_runtime depth_multiplier=8
+	$^ -g DepthwiseConvolution -o $(@D) -e object,c_header -f DepthwiseConvolution_8 target=$(HL_TARGET)-no_runtime depth_multiplier=8
 
 $(BIN)/%/DepthwiseConvolution: DepthwiseConvolution.cpp common_reference.cpp $(BIN)/%/DepthwiseConvolution_1.o $(BIN)/%/DepthwiseConvolution_2.o $(BIN)/%/DepthwiseConvolution_4.o $(BIN)/%/DepthwiseConvolution_8.o $(BIN)/%/runtime.a
 	@mkdir -p $(@D)
@@ -61,7 +61,7 @@ $(GENERATOR_BIN)/Im2col.generator: Im2col_generator.cpp common.cpp $(GENERATOR_D
 
 $(BIN)/%/Im2col.o: $(GENERATOR_BIN)/Im2col.generator
 	@mkdir -p $(@D)
-	$^ -g Im2col -o $(@D) -e object,c_header -f Im2col target=$*
+	$^ -g Im2col -o $(@D) -e object,c_header -f Im2col target=$(HL_TARGET)
 
 $(BIN)/%/Im2col: Im2col.cpp $(BIN)/%/Im2col.o
 	@mkdir -p $(@D)
@@ -73,7 +73,7 @@ $(GENERATOR_BIN)/MatrixMultiply.generator: MatrixMultiply_generator.cpp common.c
 
 $(BIN)/%/MatrixMultiply.o: $(GENERATOR_BIN)/MatrixMultiply.generator
 	@mkdir -p $(@D)
-	$^ -g MatrixMultiply -o $(@D) -e object,c_header -f MatrixMultiply target=$*
+	$^ -g MatrixMultiply -o $(@D) -e object,c_header -f MatrixMultiply target=$(HL_TARGET)
 
 $(BIN)/%/MatrixMultiply: MatrixMultiply.cpp common_reference.cpp $(BIN)/%/MatrixMultiply.o
 	@mkdir -p $(@D)
@@ -85,7 +85,7 @@ $(GENERATOR_BIN)/MaxPool.generator: MaxPool_generator.cpp common.cpp $(GENERATOR
 
 $(BIN)/%/MaxPool.o: $(GENERATOR_BIN)/MaxPool.generator
 	@mkdir -p $(@D)
-	$^ -g MaxPool -o $(@D) -e object,c_header -f MaxPool target=$*
+	$^ -g MaxPool -o $(@D) -e object,c_header -f MaxPool target=$(HL_TARGET)
 
 $(BIN)/%/MaxPool: MaxPool.cpp $(BIN)/%/MaxPool.o
 	@mkdir -p $(@D)

--- a/apps/onnx/Makefile
+++ b/apps/onnx/Makefile
@@ -57,7 +57,7 @@ $(GENERATOR_BIN)/onnx_converter.generator : onnx_converter_generator.cc $(GENERA
 
 #$(BIN)/%/onnx_mnist_model.a : $(GENERATOR_BIN)/onnx_converter.generator $(BIN)/%/onnx_model_zoo/mnist/model.onnx
 #	@mkdir -p $(@D)
-#	$^ -g onnx_model_inference -o $(@D) -f onnx_model_inference target=$* model_file_path=$(BIN)/$*/onnx_model_zoo/mnist/model.onnx
+#	$^ -g onnx_model_inference -o $(@D) -f onnx_model_inference target=$(HL_TARGET) model_file_path=$(BIN)/$*/onnx_model_zoo/mnist/model.onnx
 
 $(BIN)/%/test_model.onnx: test_model_proto.txt $(BIN)/%/onnx/onnx.proto
 	@mkdir -p $(@D)
@@ -65,7 +65,7 @@ $(BIN)/%/test_model.onnx: test_model_proto.txt $(BIN)/%/onnx/onnx.proto
 
 $(BIN)/%/test_model.a: $(GENERATOR_BIN)/onnx_converter.generator $(BIN)/%/test_model.onnx
 	@mkdir -p $(@D)
-	$< -g onnx_model_generator -o $(@D) -f test_model target=$* model_file_path=$(BIN)/$*/test_model.onnx
+	$< -g onnx_model_generator -o $(@D) -f test_model target=$(HL_TARGET) model_file_path=$(BIN)/$*/test_model.onnx
 
 $(BIN)/%/onnx_converter_generator_test: onnx_converter_generator_test.cc $(BIN)/%/test_model.a
 	@mkdir -p $(@D)

--- a/apps/resize/Makefile
+++ b/apps/resize/Makefile
@@ -33,7 +33,7 @@ define GEN_RULE
 $$(BIN)/%/resize_$(1).a: $$(GENERATOR_BIN)/resize.generator
 	@mkdir -p $$(@D)
 	$$^ -g resize -o $$(@D) -f resize_$(1) \
-	target=$$*-no_runtime \
+	target=$$(HL_TARGET)-no_runtime \
 	interpolation_type=$$$$(echo $(1) | cut -d_ -f1) \
 	input.type=$$$$(echo $(1) | cut -d_ -f2) \
 	upsample=$$$$(echo $(1) | cut -d_ -f3 | sed 's/up/true/;s/down/false/')
@@ -43,7 +43,7 @@ $(foreach V,$(VARIANTS),$(eval $(call GEN_RULE,$(V))))
 
 $(BIN)/%/runtime.a: $(GENERATOR_BIN)/resize.generator
 	@mkdir -p $(@D)
-	$^ -r runtime -o $(@D) target=$*
+	$^ -r runtime -o $(@D) target=$(HL_TARGET)
 
 $(BIN)/%/resize: resize.cpp $(LIBRARIES) $(BIN)/%/runtime.a
 	@mkdir -p $(@D)

--- a/apps/resnet_50/Makefile
+++ b/apps/resnet_50/Makefile
@@ -13,11 +13,11 @@ $(BIN)/%/pytorch_weights/ok:
 
 $(GENERATOR_BIN)/resnet50.generator: Resnet50Generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter %.cpp,$^) -o $@ $(LIBHALIDE_LDFLAGS) 
+	$(CXX) $(CXXFLAGS) -g -fno-rtti $(filter %.cpp,$^) -o $@ $(LIBHALIDE_LDFLAGS)
 
 $(BIN)/%/resnet50.a: $(GENERATOR_BIN)/resnet50.generator
 	@mkdir -p $(@D)
-	$^ -g resnet50 -o $(@D) -f resnet50 target=$* auto_schedule=false
+	$^ -g resnet50 -o $(@D) -f resnet50 target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/%/process: process.cpp $(BIN)/%/resnet50.a
 	@mkdir -p $(@D)

--- a/apps/simd_op_check/Makefile
+++ b/apps/simd_op_check/Makefile
@@ -31,7 +31,7 @@ $(BIN)/hexagon-32-noos-%/filters.h:
 $(BIN)/%/filters.h:
 	@mkdir -p $(@D)
 	make -C ../../ bin/correctness_simd_op_check
-	cd $(BIN)/$* && HL_TARGET=$* LD_LIBRARY_PATH=../../../../bin:$$LD_LIBRARY_PATH ../../../../bin/correctness_simd_op_check
+	cd $(BIN)/$* && HL_target=$(HL_TARGET) LD_LIBRARY_PATH=../../../../bin:$$LD_LIBRARY_PATH ../../../../bin/correctness_simd_op_check
 	cat $(BIN)/$*/test_*.h > $(BIN)/$*/filter_headers.h
 	echo "filter filters[] = {" > $(BIN)/$*/filters.h
 	cd $(BIN)/$*; for f in test_*.h; do n=$${f/.h/}; echo '{"'$${n}'", &'$${n}'},'; done >> filters.h

--- a/apps/stencil_chain/Makefile
+++ b/apps/stencil_chain/Makefile
@@ -6,15 +6,15 @@ build: $(BIN)/$(HL_TARGET)/process
 
 $(GENERATOR_BIN)/stencil_chain.generator: stencil_chain_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) $(filter %.cpp,$^) -o $@ $(LIBHALIDE_LDFLAGS) 
+	$(CXX) $(CXXFLAGS) $(filter %.cpp,$^) -o $@ $(LIBHALIDE_LDFLAGS)
 
 $(BIN)/%/stencil_chain.a: $(GENERATOR_BIN)/stencil_chain.generator
 	@mkdir -p $(@D)
-	$^ -g stencil_chain -e $(GENERATOR_OUTPUTS) -o $(@D) -f stencil_chain target=$* auto_schedule=false
+	$^ -g stencil_chain -e $(GENERATOR_OUTPUTS) -o $(@D) -f stencil_chain target=$(HL_TARGET) auto_schedule=false
 
 $(BIN)/%/stencil_chain_auto_schedule.a: $(GENERATOR_BIN)/stencil_chain.generator
 	@mkdir -p $(@D)
-	$^ -g stencil_chain -e $(GENERATOR_OUTPUTS) -o $(@D) -f stencil_chain_auto_schedule target=$*-no_runtime auto_schedule=true
+	$^ -g stencil_chain -e $(GENERATOR_OUTPUTS) -o $(@D) -f stencil_chain_auto_schedule target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/%/process: process.cpp $(BIN)/%/stencil_chain.a $(BIN)/%/stencil_chain_auto_schedule.a
 	@mkdir -p $(@D)

--- a/apps/unsharp/Makefile
+++ b/apps/unsharp/Makefile
@@ -10,15 +10,15 @@ $(GENERATOR_BIN)/unsharp.generator: unsharp_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/%/unsharp.a: $(GENERATOR_BIN)/unsharp.generator
 	@mkdir -p $(@D)
-	$< -g unsharp -f unsharp -o $(BIN)/$* target=$*-no_runtime auto_schedule=false
+	$< -g unsharp -f unsharp -o $(BIN)/$* target=$(HL_TARGET)-no_runtime auto_schedule=false
 
 $(BIN)/%/unsharp_auto_schedule.a: $(GENERATOR_BIN)/unsharp.generator
 	@mkdir -p $(@D)
-	$< -g unsharp -f unsharp_auto_schedule -o $(BIN)/$* target=$*-no_runtime auto_schedule=true
+	$< -g unsharp -f unsharp_auto_schedule -o $(BIN)/$* target=$(HL_TARGET)-no_runtime auto_schedule=true
 
 $(BIN)/%/runtime.a: $(GENERATOR_BIN)/unsharp.generator
 	@mkdir -p $(@D)
-	$< -r runtime -o $(BIN)/$* target=$*
+	$< -r runtime -o $(BIN)/$* target=$(HL_TARGET)
 
 $(BIN)/%/filter: filter.cpp $(BIN)/%/unsharp.a $(BIN)/%/unsharp_auto_schedule.a $(BIN)/%/runtime.a
 	@mkdir -p $(@D)

--- a/apps/wavelet/Makefile
+++ b/apps/wavelet/Makefile
@@ -21,7 +21,7 @@ define GEN_RULE
 $$(BIN)/%/$(1).a: $$(GENERATOR_BIN)/$(1).generator
 	@echo Running Generator $$<
 	@mkdir -p $$(@D)
-	@$$< -g $(1) -o $$(@D) target=$$*-no_runtime
+	@$$< -g $(1) -o $$(@D) target=$$(HL_TARGET)-no_runtime
 endef
 
 $(foreach V,$(VARIANTS),$(eval $(call GEN_RULE,$(V))))
@@ -29,7 +29,7 @@ $(foreach V,$(VARIANTS),$(eval $(call GEN_RULE,$(V))))
 $(BIN)/%/runtime.a: $(GENERATOR_BIN)/haar_x.generator
 	@echo Compiling Halide runtime for target $*
 	@mkdir -p $(@D)
-	@$< -r runtime -o $(@D) target=$*
+	@$< -r runtime -o $(@D) target=$(HL_TARGET)
 
 $(BIN)/%/wavelet: wavelet.cpp $(foreach V,$(VARIANTS),$(BIN)/%/$(V).a) $(BIN)/%/runtime.a
 	@$(CXX) $(CXXFLAGS) $(IMAGE_IO_CXX_FLAGS) -I$(BIN)/$* $^ $(IMAGE_IO_LIBS) $(LDFLAGS) -o $@


### PR DESCRIPTION
Always specify a Generator's `target` value as `$HL_TARGET`, rather than `$*`; this allows us more flexibility to cross-compile while adding extra features to HL_TARGET that may not be reflected in the base build tooling.