### PR TITLE
Fix fragile Makefile for apps/onnx

### DIFF
--- a/apps/onnx/Makefile
+++ b/apps/onnx/Makefile
@@ -4,7 +4,6 @@ PROTOC := $(shell which protoc)
 
 ifdef PROTOC
 
-PROTOCFLAGS = --cpp_out=.
 CXXFLAGS += -DGOOGLE_PROTOBUF_NO_RTTI -Wno-sign-compare -Wno-unused-but-set-variable
 CXXFLAGS += -I$(dir $(PROTOC))../include
 LDFLAGS += -L$(dir $(PROTOC))../lib
@@ -13,17 +12,17 @@ LDFLAGS += -lprotobuf-lite
 # Copy onnx.proto to $(BIN)
 $(BIN)/%/onnx/onnx.proto:
 	@mkdir -p $(@D)
-	if [ -f $(ONNX_SRC_DIR)/onnx/onnx.proto ]; then \
+	@if [ -f $(ONNX_SRC_DIR)/onnx/onnx.proto ]; then \
 		cp $(ONNX_SRC_DIR)/onnx/onnx.proto $@ ; \
 	else \
-		curl https://raw.githubusercontent.com/onnx/onnx/v1.4.1/onnx/onnx.proto > $@; \
+		curl -s https://raw.githubusercontent.com/onnx/onnx/v1.4.1/onnx/onnx.proto > $@; \
 	fi
 
 # protoc generates two files
 $(BIN)/%/onnx/onnx.pb.cc: $(BIN)/%/onnx/onnx.proto
 	@sed -i -e 's/package onnx;/package onnx;option optimize_for = LITE_RUNTIME;/g' $<
 	@mkdir -p $(@D)
-	$(PROTOC) $(PROTOCFLAGS) $<
+	$(PROTOC) --cpp_out=$(@D) --proto_path=$(dir $<) $<
 
 $(BIN)/%/onnx/onnx_pb.h: $(BIN)/%/onnx/onnx.pb.cc
 	cp $(BIN)/$*/onnx/onnx.pb.h $@
@@ -61,7 +60,7 @@ $(GENERATOR_BIN)/onnx_converter.generator : onnx_converter_generator.cc $(GENERA
 
 $(BIN)/%/test_model.onnx: test_model_proto.txt $(BIN)/%/onnx/onnx.proto
 	@mkdir -p $(@D)
-	cat $< | protoc --encode=onnx.ModelProto $(BIN)/$*/onnx/onnx.proto > $@
+	cat $< | $(PROTOC) --encode=onnx.ModelProto --proto_path=$(BIN)/$*/onnx $(BIN)/$*/onnx/onnx.proto > $@
 
 $(BIN)/%/test_model.a: $(GENERATOR_BIN)/onnx_converter.generator $(BIN)/%/test_model.onnx
 	@mkdir -p $(@D)

--- a/apps/onnx/onnx_converter.cc
+++ b/apps/onnx/onnx_converter.cc
@@ -2927,7 +2927,7 @@ Node convert_lrn_node(
     float bias = 1.0f;
     bool found_size = false;
     int size = 0;
-    for (const auto attr : node.attribute()) {
+    for (const auto &attr : node.attribute()) {
         if (attr.name() == "alpha") {
             alpha = attr.f();
         } else if (attr.name() == "beta") {


### PR DESCRIPTION
The protoc usage happened to work when building in the app folder but often failed when building from the toplevel Makefile. Also, drive-by silencing of noise from curl, and drive-by fix of "redundant copy" warning in onnx_converter.cc.