### PR TITLE
Modify memoization code to allow using min/extent/stride of an input.

### DIFF
--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -75,7 +75,7 @@ public:
     void visit(const Variable *var) override {
         if (var->param.defined()) {
             if (var->param.is_buffer() &&
-                var->type.is_int_or_uint()) {
+                !var->type.is_handle()) {
                 record(memoize_tag(var));
             } else {
                 record(var->param);

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -74,8 +74,14 @@ public:
 
     void visit(const Variable *var) override {
         if (var->param.defined()) {
-            record(var->param);
+            if (var->param.is_buffer() &&
+                var->type.is_int_or_uint()) {
+                record(memoize_tag(var));
+            } else {
+                record(var->param);
+            }
         }
+
         IRGraphVisitor::visit(var);
     }
 


### PR DESCRIPTION
Generally references to buffers are not allowed in memoization keys without the programmer explicitly using memoize_tag as if one has to do a lot of image accesses to construct the key, memoization is unlikely to be performant. The code that enforces this also treats accesses to the min/extent/stride, etc. of the buffer as a buffer access. This seems problematic as those values are conceptually parameters to the filter, just with more complicated names. Not allowing them in memoization keys by default causes tricky to diagnose errors if one uses the extent of an input in an RDom which is then use in a memoized Func.

The code pattern here is a bit heuristic in that I can't think of a case where a Var has a buffer but the reference isn't to a field of the buffer. This is something to think about in review. I could also pattern match the variable name, but that seems worse.