### PR TITLE
Remove <iostream> from the code generated by CodeGen_C

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -62,7 +62,6 @@ const string headers = R"INLINE_CODE(
 
 #include <assert.h>
 #include <float.h>
-#include <iostream>
 #include <limits.h>
 #include <math.h>
 #include <stdint.h>


### PR DESCRIPTION
I don't think it's ever used.