### PR TITLE
fix StrongestExprNodeType for rewriter

### DIFF
--- a/src/Expr.h
+++ b/src/Expr.h
@@ -76,7 +76,7 @@ enum class IRNodeType {
     Atomic
 };
 
-constexpr IRNodeType StrongestExprNodeType = IRNodeType::Shuffle;
+constexpr IRNodeType StrongestExprNodeType = IRNodeType::VectorReduce;
 
 /** The abstract base classes for a node in the Halide IR. */
 struct IRNode {


### PR DESCRIPTION
`StrongestExprNodeType` wasn't updated when `VectorReduce` was added