### PR TITLE
Better document how LLVM_DIR works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ release. Then change directory to the Halide repository and run:
 % cmake --build build
 ```
 
-`LLVM_DIR` is the folder in the LLVM installation tree (do not use the build
-tree by mistake) that contains `LLVMConfig.cmake`. It is not required to set
+`LLVM_DIR` is the folder in the LLVM installation tree **(do not use the build
+tree by mistake)** that contains `LLVMConfig.cmake`. It is not required to set
 this variable if you have a suitable system-wide version installed. If you have
 multiple system-wide versions installed, you can specify the version with
 `Halide_REQUIRE_LLVM_VERSION`. Add `-G Ninja` if you prefer to build with the

--- a/README_cmake.md
+++ b/README_cmake.md
@@ -442,10 +442,16 @@ First, Halide expects to find LLVM and Clang through the `CONFIG` mode of
 `find_package`. You can tell Halide where to find these dependencies by setting
 the corresponding `_DIR` variables:
 
-| Variable    | Description                                          |
-| ----------- | ---------------------------------------------------- |
-| `LLVM_DIR`  | Path to the directory containing `LLVMConfig.cmake`  |
-| `Clang_DIR` | Path to the directory containing `ClangConfig.cmake` |
+| Variable    | Description                                    |
+| ----------- | ---------------------------------------------- |
+| `LLVM_DIR`  | `$LLVM_ROOT/lib/cmake/LLVM/LLVMConfig.cmake`   |
+| `Clang_DIR` | `$LLVM_ROOT/lib/cmake/Clang/ClangConfig.cmake` |
+
+Here, `$LLVM_ROOT` is assumed to point to the root of an LLVM installation tree.
+This is either a system path or one produced by running `cmake --install` (as
+detailed in the main README.md). When building LLVM (and any other `CONFIG`
+packages) manually, it is a common mistake to point CMake to a _build tree_
+rather than an _install tree_. Doing so often produces inscrutable errors.
 
 When using CMake 3.18 or above, some of Halide's tests will search for CUDA
 using the [`FindCUDAToolkit`][findcudatoolkit] module. If it doesn't find your


### PR DESCRIPTION
Hopefully this will make understanding the CMake build easier when using a custom-built LLVM.

This also adjusts `README.md` to use the same directory layout as `README_cmake.md`.