### PR TITLE
Fix some wasm issues

### DIFF
--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -169,6 +169,9 @@ function(add_wasm_halide_test TARGET)
     if (Halide_TARGET MATCHES "wasm_simd128")
         list(APPEND WASM_SHELL_FLAGS "--experimental-wasm-simd")
     endif ()
+    if (Halide_TARGET MATCHES "wasm_threads")
+        list(APPEND WASM_SHELL_FLAGS "--experimental-wasm-threads")
+    endif ()
 
     add_halide_test("${TARGET}"
                     GROUPS ${args_GROUPS}

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -809,11 +809,11 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_posix_io(c, bits_64, debug));
                 modules.push_back(get_initmod_linux_host_cpu_count(c, bits_64, debug));
                 modules.push_back(get_initmod_linux_yield(c, bits_64, debug));
-                if (t.has_feature(Target::WasmThreads)) {
-                    modules.push_back(get_initmod_posix_threads(c, bits_64, debug));
-                } else {
-                    modules.push_back(get_initmod_fake_thread_pool(c, bits_64, debug));
-                }
+                // With recent versions of Emscripten, it appears we can use the posix-thread-pool
+                // always, even if `wasm_threads` is not enabled. Will need some more testing
+                // to be sure, but this change greatly simplifies linking together of multiple
+                // wasm modules if they have mixed target strings (some with threads, some without).
+                modules.push_back(get_initmod_posix_threads(c, bits_64, debug));
                 modules.push_back(get_initmod_fake_get_symbol(c, bits_64, debug));
             } else if (t.os == Target::OSX) {
                 modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));

--- a/test/performance/nested_vectorization_gemm.cpp
+++ b/test/performance/nested_vectorization_gemm.cpp
@@ -6,6 +6,10 @@ using namespace Halide;
 int main(int argc, char **argv) {
 
     Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
 
     // 8-bit mat-mul into 32-bit accumulator
     {


### PR DESCRIPTION
- If `wasm_threads` is in the target string, be sure to launch the external shell with `--experimental-wasm-threads`.

- Always use `posix_threads` instead of `fake_threads` for wasm; this used to fail, but apparently recent versions of Emscripten now provide stubs of the calls we need. The goal here is to simplify linkage of the Halide runtime; the current situation means that attempting to mix Halide-generated code with `wasm_threads` both enabled and disabled requires the thread-enabled runtime to work, but getting this to link correctly in some build systems can be tricky, and the failure mode is obscure.

The second change is the trickier one; in theory this shouldn't matter for code that doesn't use `wasm_threads`, but full test coverage is hard to verify. It seems to work fine in all my local testing.