### PR TITLE
Add special case for printing broadcast shuffles

### DIFF
--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -409,10 +409,10 @@ Expr unbroadcast_lossless_cast(Type ty, Expr x) {
         }
         // Check if shuffle can be treated as a broadcast.
         if (const Shuffle *shuff = x.as<Shuffle>()) {
-            int factor = ty.lanes();
-            if (shuff->is_broadcast(factor)) {
+            int factor = x.type().lanes() / ty.lanes();
+            if (shuff->is_broadcast() && shuff->broadcast_factor() % factor == 0) {
                 x = Shuffle::make(shuff->vectors, std::vector<int>(shuff->indices.begin(),
-                                                                   shuff->indices.begin() + factor));
+                                                                   shuff->indices.begin() + ty.lanes()));
             }
         }
     }

--- a/src/IR.h
+++ b/src/IR.h
@@ -760,7 +760,7 @@ struct Shuffle : public ExprNode<Shuffle> {
 
     /** Convenience constructor for making a shuffle representing a
      * broadcast of a vector. */
-    static Expr make_broadcast(Expr vector, int lanes);
+    static Expr make_broadcast(Expr vector, int factor);
 
     /** Convenience constructor for making a shuffle representing a
      * contiguous subset of a vector. */
@@ -779,7 +779,8 @@ struct Shuffle : public ExprNode<Shuffle> {
      * A uint8 shuffle of with 4*n lanes and indices:
      *     0, 1, 2, 3, 0, 1, 2, 3, ....., 0, 1, 2, 3
      * can be represented as a uint32 broadcast with n lanes (factor = 4). */
-    bool is_broadcast(int factor) const;
+    bool is_broadcast() const;
+    int broadcast_factor() const;
 
     /** Check if this shuffle is a concatenation of the vector
      * arguments. */

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -990,6 +990,10 @@ void IRPrinter::visit(const Shuffle *op) {
                << ", " << op->slice_stride()
                << ", " << op->indices.size()
                << ")";
+    } else if (op->is_broadcast()) {
+        stream << "broadcast(";
+        print_list(op->vectors);
+        stream << ", " << op->broadcast_factor() << ")";
     } else {
         stream << "shuffle(";
         print_list(op->vectors);


### PR DESCRIPTION
This reduces the volume of IR output in some cases. We get this:

```
    sum$14[ramp(0, 1, 32)] = (int32x32)vector_reduce(Add, (broadcast(int32x2(int8x2(ramp(0, 1, 2))), 32)*int32x64((int16x64)in_i16[ramp((op_v__w____vdmpy_v__h__r__b__112.s0.x.x*64) - in_i16.min.0, 1, 64) aligned(64, 0)])))
```

Instead of this:

```
    sum$14[ramp(0, 1, 32)] = (int32x32)vector_reduce(Add, (shuffle(int32x2(int8x2(ramp(0, 1, 2))), 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1)*int32x64((int16x64)in_i16[ramp((op_v__w____vdmpy_v__h__r__b__112.s0.x.x*64) - in_i16.min.0, 1, 64) aligned(64, 0)])))
```