### PR TITLE
Fix minor wasm issues

### DIFF
--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -169,6 +169,9 @@ function(add_wasm_halide_test TARGET)
     if (Halide_TARGET MATCHES "wasm_simd128")
         list(APPEND WASM_SHELL_FLAGS "--experimental-wasm-simd")
     endif ()
+    if (Halide_TARGET MATCHES "wasm_threads")
+        list(APPEND WASM_SHELL_FLAGS "--experimental-wasm-threads")
+    endif ()
 
     add_halide_test("${TARGET}"
                     GROUPS ${args_GROUPS}

--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -35,6 +35,11 @@ if (WITH_WABT)
 
     set_target_properties(wabt PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+    # Disable this very-noisy warning in GCC
+    target_compile_options(wabt
+                           PRIVATE
+                           $<$<CXX_COMPILER_ID:GNU>:-Wno-alloca-larger-than>)
+
     # TODO: we want to require unique prefixes to include these files, to avoid ambiguity;
     # this means we have to prefix with "wabt-src/...", which is less bad than other alternatives,
     # but perhaps we could do better (esp. if wabt was smarter about what it exposed?)

--- a/test/performance/nested_vectorization_gemm.cpp
+++ b/test/performance/nested_vectorization_gemm.cpp
@@ -6,6 +6,10 @@ using namespace Halide;
 int main(int argc, char **argv) {
 
     Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
+        return 0;
+    }
 
     // 8-bit mat-mul into 32-bit accumulator
     {


### PR DESCRIPTION
- If wasm_threads is in the target string, be sure to launch the external shell with --experimental-wasm-threads.
- All the test/performance tests should detect wasm and explicitly skip