### PR TITLE
Move CodeGen_Hexagon to internal linkage and don't include it without WITH_HEXAGON

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1648,7 +1648,7 @@ Value *CodeGen_Hexagon::vdelta(Value *lut, const vector<int> &indices) {
     return vlut(lut, indices);
 }
 
-static Value *create_vector(llvm::Type *ty, int val) {
+Value *create_vector(llvm::Type *ty, int val) {
     llvm::Type *scalar_ty = ty->getScalarType();
     Constant *value = ConstantInt::get(scalar_ty, val);
     return ConstantVector::getSplat(element_count(get_vector_num_elements(ty)), value);

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -28,6 +28,11 @@
 namespace Halide {
 namespace Internal {
 
+using std::string;
+using std::vector;
+
+using namespace llvm;
+
 #ifdef WITH_HEXAGON
 
 namespace {
@@ -130,11 +135,6 @@ private:
     /** Generate a LUT (8/16 bit, max_index < 256) lookup using vlut instructions. */
     llvm::Value *vlut256(llvm::Value *lut, llvm::Value *indices, int min_index = 0, int max_index = 255);
 };
-
-using std::string;
-using std::vector;
-
-using namespace llvm;
 
 CodeGen_Hexagon::CodeGen_Hexagon(Target t)
     : CodeGen_Posix(t) {

--- a/src/CodeGen_Hexagon.h
+++ b/src/CodeGen_Hexagon.h
@@ -5,109 +5,21 @@
  * Defines the code-generator for producing Hexagon machine code
  */
 
-#include "CodeGen_Posix.h"
+namespace llvm {
+
+class LLVMContext;
+
+}
 
 namespace Halide {
+
+struct Target;
+
 namespace Internal {
 
-/** A code generator that emits Hexagon code from a given Halide stmt. */
-class CodeGen_Hexagon : public CodeGen_Posix {
-public:
-    /** Create a Hexagon code generator for the given Hexagon target. */
-    CodeGen_Hexagon(Target);
+class CodeGen_Posix;
 
-protected:
-    void compile_func(const LoweredFunc &f,
-                      const std::string &simple_name, const std::string &extern_name) override;
-
-    void init_module() override;
-
-    std::string mcpu() const override;
-    std::string mattrs() const override;
-    int isa_version;
-    bool use_soft_float_abi() const override;
-    int native_vector_bits() const override;
-
-    llvm::Function *define_hvx_intrinsic(llvm::Function *intrin, Type ret_ty,
-                                         const std::string &name,
-                                         std::vector<Type> arg_types,
-                                         int flags);
-
-    int is_hvx_v65_or_later() const {
-        return (isa_version >= 65);
-    }
-
-    using CodeGen_Posix::visit;
-
-    /** Nodes for which we want to emit specific hexagon intrinsics */
-    ///@{
-    void visit(const Max *) override;
-    void visit(const Min *) override;
-    void visit(const Call *) override;
-    void visit(const Mul *) override;
-    void visit(const Select *) override;
-    void visit(const Allocate *) override;
-    ///@}
-
-    /** We ask for an extra vector on each allocation to enable fast
-     * clamped ramp loads. */
-    int allocation_padding(Type type) const override {
-        return CodeGen_Posix::allocation_padding(type) + native_vector_bits() / 8;
-    }
-
-    /** Call an LLVM intrinsic, potentially casting the operands to
-     * match the type of the function. */
-    ///@{
-    llvm::Value *call_intrin_cast(llvm::Type *ret_ty, llvm::Function *F,
-                                  std::vector<llvm::Value *> Ops);
-    llvm::Value *call_intrin_cast(llvm::Type *ret_ty, int id,
-                                  std::vector<llvm::Value *> Ops);
-    ///@}
-
-    /** Define overloads of CodeGen_LLVM::call_intrin that determine
-     * the intrin_lanes from the type, and allows the function to
-     * return null if the maybe option is true and the intrinsic is
-     * not found. */
-    ///@{
-    using CodeGen_LLVM::call_intrin;
-    llvm::Value *call_intrin(Type t, const std::string &name,
-                             std::vector<Expr>, bool maybe = false);
-    llvm::Value *call_intrin(llvm::Type *t, const std::string &name,
-                             std::vector<llvm::Value *>, bool maybe = false);
-    ///@}
-
-    /** Override CodeGen_LLVM to use hexagon intrinics when possible. */
-    ///@{
-    llvm::Value *interleave_vectors(const std::vector<llvm::Value *> &v) override;
-    llvm::Value *shuffle_vectors(llvm::Value *a, llvm::Value *b,
-                                 const std::vector<int> &indices) override;
-    using CodeGen_Posix::shuffle_vectors;
-    ///@}
-
-    /** Generate a LUT lookup using vlut instructions. */
-    ///@{
-    llvm::Value *vlut(llvm::Value *lut, llvm::Value *indices, int min_index = 0, int max_index = 1 << 30);
-    llvm::Value *vlut(llvm::Value *lut, const std::vector<int> &indices);
-    ///@}
-
-    llvm::Value *vdelta(llvm::Value *lut, const std::vector<int> &indices);
-
-    /** Because HVX intrinsics operate on vectors of i32, using them
-     * requires a lot of extraneous bitcasts, which make it difficult
-     * to manipulate the IR. This function avoids generating redundant
-     * bitcasts. */
-    llvm::Value *create_bitcast(llvm::Value *v, llvm::Type *ty);
-
-private:
-    /** Generates code for computing the size of an allocation from a
-     * list of its extents and its size. Fires a runtime assert
-     * (halide_error) if the size overflows 2^31 -1, the maximum
-     * positive number an int32_t can hold. */
-    llvm::Value *codegen_cache_allocation_size(const std::string &name, Type type, const std::vector<Expr> &extents);
-
-    /** Generate a LUT (8/16 bit, max_index < 256) lookup using vlut instructions. */
-    llvm::Value *vlut256(llvm::Value *lut, llvm::Value *indices, int min_index = 0, int max_index = 255);
-};
+CodeGen_Posix *new_CodeGen_Hexagon(const Target &target, llvm::LLVMContext &context);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -373,7 +373,7 @@ CodeGen_LLVM *CodeGen_LLVM::new_for_target(const Target &target,
     } else if (target.arch == Target::POWERPC) {
         return make_codegen<CodeGen_PowerPC>(target, context);
     } else if (target.arch == Target::Hexagon) {
-        return make_codegen<CodeGen_Hexagon>(target, context);
+        return new_CodeGen_Hexagon(target, context);
     } else if (target.arch == Target::WebAssembly) {
         return make_codegen<CodeGen_WebAssembly>(target, context);
     } else if (target.arch == Target::RISCV) {


### PR DESCRIPTION
This PR is an alternative to #5503 to address #5559. This is similar to #5548.

It moves all of `CodeGen_Hexagon` into an internal linkage namespace, and wraps the whole thing in an `#ifdef WITH_HEXAGON`.

I wanted to do this for all of the `CodeGen_*` classes, but this only works for `CodeGen_Hexagon` because it isn't used by `CodeGen_GPU_Host` as a template parameter.

I think we should move the runtime calls generated by `CodeGen_GPU_Host` to a separate lowering pass (like how HexagonOffload does it), and then we could do this for the rest of the `CodeGen_*` classes as well. I think most of the complexity there is GLSL, which might go away soon (#5475)?