### PR TITLE
replaced indentation in line 20 with spaces to show proper error message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ MAKEFLAGS += --no-builtin-rules
 UNAME = $(shell uname)
 
 ifeq ($(OS), Windows_NT)
-    $(error Halide no longer supports the MinGW environment.)
+    $(error Halide no longer supports the MinGW environment. Please use MSVC through CMake instead.)
 else
     # let's assume "normal" UNIX such as linux
     COMMON_LD_FLAGS=$(LDFLAGS) -ldl -lpthread -lz

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ MAKEFLAGS += --no-builtin-rules
 UNAME = $(shell uname)
 
 ifeq ($(OS), Windows_NT)
-	$(error Halide no longer supports the MinGW environment.)
+    $(error Halide no longer supports the MinGW environment.)
 else
     # let's assume "normal" UNIX such as linux
     COMMON_LD_FLAGS=$(LDFLAGS) -ldl -lpthread -lz


### PR DESCRIPTION
Hello,

This is referring to my Issue #5579 . All the change consist of is to fix that proper error message.

![halide makefile](https://user-images.githubusercontent.com/6540814/102742912-03a86180-430b-11eb-90b2-db0b316c037b.PNG)

Image included was of the original cloned repo first attempting to build with Make.

Thanks!

Fixes #5579 