### PR TITLE
Remove unused wildcards and old wrappers from CodeGen_LLVM

### DIFF
--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -219,31 +219,9 @@ protected:
 
     // @}
 
-    /** Some useful llvm types for subclasses */
-    // @{
-    llvm::Type *i8x8, *i8x16, *i8x32;
-    llvm::Type *i16x4, *i16x8, *i16x16;
-    llvm::Type *i32x2, *i32x4, *i32x8;
-    llvm::Type *i64x2, *i64x4;
-    llvm::Type *f32x2, *f32x4, *f32x8;
-    llvm::Type *f64x2, *f64x4;
-    // @}
-
     /** Some wildcard variables used for peephole optimizations in
      * subclasses */
     // @{
-    Expr wild_i8x8, wild_i16x4, wild_i32x2;                // 64-bit signed ints
-    Expr wild_u8x8, wild_u16x4, wild_u32x2;                // 64-bit unsigned ints
-    Expr wild_i8x16, wild_i16x8, wild_i32x4, wild_i64x2;   // 128-bit signed ints
-    Expr wild_u8x16, wild_u16x8, wild_u32x4, wild_u64x2;   // 128-bit unsigned ints
-    Expr wild_i8x32, wild_i16x16, wild_i32x8, wild_i64x4;  // 256-bit signed ints
-    Expr wild_u8x32, wild_u16x16, wild_u32x8, wild_u64x4;  // 256-bit unsigned ints
-
-    Expr wild_f32x2;              // 64-bit floats
-    Expr wild_f32x4, wild_f64x2;  // 128-bit floats
-    Expr wild_f32x8, wild_f64x4;  // 256-bit floats
-
-    // Wildcards for a varying number of lanes.
     Expr wild_u1x_, wild_i8x_, wild_u8x_, wild_i16x_, wild_u16x_;
     Expr wild_i32x_, wild_u32x_, wild_i64x_, wild_u64x_;
     Expr wild_f32x_, wild_f64x_;
@@ -252,12 +230,6 @@ protected:
     Expr wild_u1_, wild_i8_, wild_u8_, wild_i16_, wild_u16_;
     Expr wild_i32_, wild_u32_, wild_i64_, wild_u64_;
     Expr wild_f32_, wild_f64_;
-
-    Expr min_i8, max_i8, max_u8;
-    Expr min_i16, max_i16, max_u16;
-    Expr min_i32, max_i32, max_u32;
-    Expr min_i64, max_i64, max_u64;
-    Expr min_f32, max_f32, min_f64, max_f64;
     // @}
 
     /** Emit code that evaluates an expression, and return the llvm


### PR DESCRIPTION
- Remove some dead code
- The make_alignment wrapper was probably to accommodate older versions of LLVM.