### PR TITLE
Upgrade to TFLite 2.4.0

### DIFF
--- a/apps/interpret_nn/Makefile
+++ b/apps/interpret_nn/Makefile
@@ -40,11 +40,9 @@ test: test_ops
 clean:
 	rm -rf $(BIN)
 
-# Choosing TFLite 2.3.0 because it's the most recent stable release with an Android AAR file available.
-# (Inexplicably, there doesn't seem to be an AAR for 2.3.1.)
-# Upgrade
+# Choosing TFLite 2.4.0 because it's the most recent stable release with an Android AAR file available.
 TFLITE_VERSION_MAJOR ?= 2
-TFLITE_VERSION_MINOR ?= 3
+TFLITE_VERSION_MINOR ?= 4
 TFLITE_VERSION_PATCH ?= 0
 
 TFLITE_VERSION = $(TFLITE_VERSION_MAJOR).$(TFLITE_VERSION_MINOR).$(TFLITE_VERSION_PATCH)
@@ -52,7 +50,7 @@ TFLITE_TAG = v$(TFLITE_VERSION)
 
 # Define `TFLITE_VERSION` here to allow for code that compiles against multiple versions of
 # TFLite (both the C API and the Schema). This deliberately ignores the 'patch' version so
-# 2.3.x is 23. (Yes, this is inadequate if a minor version ever goes above 9.)
+# 2.3.x is 23, 2.4.x is 24, etc. (Yes, this is inadequate if a minor version ever goes above 9.)
 APP_CXXFLAGS = -I$(MAKEFILE_DIR) -DTFLITE_VERSION=$(TFLITE_VERSION_MAJOR)$(TFLITE_VERSION_MINOR)
 
 # ---------------------- halide

--- a/apps/interpret_nn/compare_vs_tflite.cpp
+++ b/apps/interpret_nn/compare_vs_tflite.cpp
@@ -52,9 +52,7 @@ halide_type_t tf_lite_type_to_halide_type(TfLiteType t) {
     case kTfLiteString:
     case kTfLiteNoType:
     case kTfLiteComplex64:
-#if TFLITE_VERSION >= 24
     case kTfLiteComplex128:
-#endif
     default:
         CHECK(0) << "Unsupported TfLiteType: " << TfLiteTypeGetName(t);
         return halide_type_t();

--- a/apps/interpret_nn/interpreter/model.cpp
+++ b/apps/interpret_nn/interpreter/model.cpp
@@ -26,10 +26,8 @@ size_t sizeof_tensor_type(TensorType t) {
         return 1;
     case TensorType::Float64:
         return 8;
-#if TFLITE_VERSION >= 24
     case TensorType::Complex128:
         return 32;
-#endif
     // case TensorType::String:  fallthru
     // case TensorType::Bool:    fallthru
     default:
@@ -58,10 +56,8 @@ const char *to_string(TensorType t) {
         return "int8";
     case TensorType::Float64:
         return "float64";
-#if TFLITE_VERSION >= 24
     case TensorType::Complex128:
         return "complex128";
-#endif
     case TensorType::String:
         return "string";
     case TensorType::Bool:
@@ -94,9 +90,7 @@ halide_type_t to_halide_type(TensorType t) {
         return halide_type_t(halide_type_uint, 8);
 
     case TensorType::Complex64:
-#if TFLITE_VERSION >= 24
     case TensorType::Complex128:
-#endif
     case TensorType::String:
     default:
         CHECK(0) << "Unhandled type in to_halide_type";

--- a/apps/interpret_nn/tflite/tflite_parser.cpp
+++ b/apps/interpret_nn/tflite/tflite_parser.cpp
@@ -13,13 +13,9 @@ namespace interpret_nn {
 namespace {
 
 tflite::BuiltinOperator get_builtin_code(const tflite::OperatorCode *op_code) {
-#if TFLITE_VERSION >= 24
     return std::max(
         op_code->builtin_code(),
         static_cast<tflite::BuiltinOperator>(op_code->deprecated_builtin_code()));
-#else
-    return op_code->builtin_code();
-#endif
 }
 
 class Parser {
@@ -75,10 +71,8 @@ public:
             return TensorType::Int8;
         case tflite::TensorType_FLOAT64:
             return TensorType::Float64;
-#if TFLITE_VERSION >= 24
         case tflite::TensorType_COMPLEX128:
             return TensorType::Complex128;
-#endif
         default:
             CHECK(0) << "Unknown tflite::TensorType";
         }

--- a/apps/interpret_nn/tflite_exploder.cpp
+++ b/apps/interpret_nn/tflite_exploder.cpp
@@ -54,13 +54,9 @@ using std::make_unique;
 #endif
 
 tflite::BuiltinOperator get_builtin_code(const tflite::OperatorCode *op_code) {
-#if TFLITE_VERSION >= 24
     return std::max(
         op_code->builtin_code(),
         static_cast<tflite::BuiltinOperator>(op_code->deprecated_builtin_code()));
-#else
-    return op_code->builtin_code();
-#endif
 }
 
 }  // namespace
@@ -167,11 +163,9 @@ int main(int argc, char **argv) {
         // Blow away all the metadata (we'll just assume we can live without it).
         new_model->metadata_buffer.clear();
         new_model->metadata.clear();
-#if TFLITE_VERSION >= 24
         // signature_defs is optional -- not sure if we need it for out purposes.
         // TODO: might need to translate it.
         new_model->signature_defs.clear();
-#endif
 
         flatbuffers::FlatBufferBuilder fbb;
         auto model_offset = tflite::Model::Pack(fbb, new_model.get());


### PR DESCRIPTION
TFLite v2.4.0 has gone final, and there is a prebuilt version in AAR form for us to use on Android, so let's upgrade the code to assume 2.4 as a baseline.