### PR TITLE
Add initial support for building a TFLite Delegate

### DIFF
--- a/apps/interpret_nn/Makefile
+++ b/apps/interpret_nn/Makefile
@@ -18,11 +18,17 @@ FLATC ?= flatc
 # This is the location that brew installs on my Mac.
 FLATBUFFERS_INCLUDE_PATH ?= /usr/local/Cellar/flatbuffers/1.12.0/include
 
-CXXFLAGS += -Wno-unused-private-field
+# Removing exceptions just because we don't need 'em and it saves space.
+#
+# -fPIC is necessary for .so builds (at least on Linux); not necessary for the non-delegate
+# builds but easier to enable it for everything.
+#
+# TODO: Not sure if -fvisibility moves the needle or not
+CXXFLAGS += -Wno-unused-private-field -fno-exceptions -fPIC -fvisibility=hidden -fvisibility-inlines-hidden
 
 MAKEFILE_DIR=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
-.PHONY: all build clean test build_test_ops
+.PHONY: all build clean test build_test_ops delegate
 all: build
 
 # .SECONDARY with no prerequisites causes all targets to be treated as secondary
@@ -172,6 +178,57 @@ $(BIN)/%/tflite_parser.o: tflite/tflite_parser.cpp $(BIN)/schema/tflite_schema_g
 TFLITE_PARSER_DEPS = \
 	$(BIN)/%/tflite_parser.o
 
+# ---------------------- delegate
+
+TFLITE_INCLUDES_FLAGS ?= -I$(HOME)/GitHub/tensorflow -I$(MAKEFILE_DIR)
+
+$(BIN)/%/halide_delegate.o: delegate/halide_delegate.cpp
+	@mkdir -p $(@D)
+	$(CXX-$*) $(CXXFLAGS-$*) $(TFLITE_INCLUDES_FLAGS) $(UTIL_CXXFLAGS) -c $< -o $@
+
+$(BIN)/%/halide_delegate_adaptor.o: delegate/halide_delegate_adaptor.cpp
+	@mkdir -p $(@D)
+	$(CXX-$*) $(CXXFLAGS-$*) $(TFLITE_INCLUDES_FLAGS) $(UTIL_CXXFLAGS) -c $< -o $@
+
+ifneq (,$(findstring host,$(HL_TARGET)))
+
+DELEGATE_LD_FLAGS=$(LDFLAGS)
+
+ifeq ($(UNAME), Darwin)
+DELEGATE_LD_FLAGS += -Wl,-exported_symbols_list delegate/exported_symbols.osx
+else
+# Assume Desktop Linux
+DELEGATE_LD_FLAGS += -Wl,--version-script=delegate/exported_symbols.linux
+DELEGATE_LD_FLAGS += -Wl,-soname,libHalideDelegate.so
+endif
+
+else ifeq (arm-64-android,$(findstring arm-64-android,$(HL_TARGET)))
+
+# Don't include $(LDFLAGS) here, it includes pthreads, which we don't want
+DELEGATE_LD_FLAGS=-static-libstdc++
+DELEGATE_LD_FLAGS += -Wl,--version-script=delegate/exported_symbols.linux
+DELEGATE_LD_FLAGS += -Wl,-soname,libHalideDelegate.so
+
+else
+
+# Other values for HL_TARGET will be special-cased here in the future.
+# Unhandled cases will fail to compile/link.
+DELEGATE_LD_FLAGS ?= ERROR_TODO
+
+endif
+
+# Note: delegates are apparently always .so on OSX (never .dylib)
+# TODO: add a linker script to expose only the exported symbols we want
+$(BIN)/%/libHalideDelegate.so: \
+		$(BIN)/%/halide_delegate.o \
+		$(BIN)/%/halide_delegate_adaptor.o \
+		$(INTERPRETER_DEPS) \
+		$(UTIL_DEPS)
+	@mkdir -p $(@D)
+	$(CXX-$*) -shared $^ $(DELEGATE_LD_FLAGS) -o $@
+
+delegate: $(BIN)/$(HL_TARGET)/libHalideDelegate.so
+
 # ---------------------- test
 
 # unit tests for each op (not yet complete)
@@ -274,7 +331,6 @@ ifneq (,$(findstring host,$(HL_TARGET)))
 # 	$ git clone https://github.com/tensorflow/tensorflow
 # 	$ cd tensorflow
 #   $ git checkout $(TFLITE_TAG)
-#	$ ./configure
 # 	$ bazelisk build -c opt //tensorflow/lite/c:tensorflowlite_c
 #
 # (Note that TFLite is very picky about the version of Bazel installed, thus this suggests
@@ -283,7 +339,8 @@ ifneq (,$(findstring host,$(HL_TARGET)))
 TENSORFLOW_BASE ?= $(HOME)/GitHub/tensorflow
 TFLITE_INCLUDES ?= $(TENSORFLOW_BASE)
 TFLITE_SHARED_LIBRARY ?= $(TENSORFLOW_BASE)/bazel-bin/tensorflow/lite/c/libtensorflowlite_c.$(SHARED_EXT)
-TFLITE_LDFLAGS=-Wl,-rpath,$(dir $(TFLITE_SHARED_LIBRARY))
+# Point at the TFLite path, but also the exe directory (for libHalideDelegate.so)
+TFLITE_LDFLAGS=-Wl,-rpath,$(dir $(TFLITE_SHARED_LIBRARY)),-rpath,$(dir $@)
 
 else ifeq (arm-64-android,$(findstring arm-64-android,$(HL_TARGET)))
 
@@ -310,8 +367,9 @@ TFLITE_SHARED_LIBRARY ?= ERROR_TODO
 
 endif
 
+
 # To build for Android, use `HL_TARGET=arm-64-android make compare_vs_tflite`
-$(BIN)/%/compare_vs_tflite: compare_vs_tflite.cpp $(INTERPRETER_DEPS) $(TFLITE_PARSER_DEPS) $(UTIL_DEPS) $(TFLITE_SHARED_LIBRARY)
+$(BIN)/%/compare_vs_tflite: compare_vs_tflite.cpp $(INTERPRETER_DEPS) $(TFLITE_PARSER_DEPS) $(UTIL_DEPS) $(TFLITE_SHARED_LIBRARY) $(BIN)/$(HL_TARGET)/libHalideDelegate.so
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS-$*) $(APP_CXXFLAGS) -I$(TFLITE_INCLUDES) $(TFLITE_LDFLAGS) $(filter %.cpp %.o %.a %.so %.$(SHARED_EXT),$^) -o $@ $(LDFLAGS-$*)
 

--- a/apps/interpret_nn/compare_vs_tflite.cpp
+++ b/apps/interpret_nn/compare_vs_tflite.cpp
@@ -1,10 +1,9 @@
 #include <chrono>
+#include <dlfcn.h>
 #include <fstream>
 #include <iostream>
 #include <random>
-#ifndef _MSC_VER
 #include <unistd.h>
-#endif
 
 #include "halide_benchmark.h"
 #include "interpreter/interpreter.h"
@@ -77,25 +76,87 @@ Buffer<void> wrap_tf_lite_tensor_with_halide_buffer(const TfLiteTensor *t) {
     return b;
 }
 
+struct DelegateFactory {
+    TfLiteDelegate *(*create_delegate)(char **options_keys,
+                                       char **options_values,
+                                       size_t num_options,
+                                       void (*report_error)(const char *));
+    void (*destroy_delegate)(TfLiteDelegate *delegate);
+};
+
 }  // namespace
 
-void run_both(const std::string &filename, int seed, int threads, bool verbose) {
+void run_all(const std::string &filename, int seed, int threads, bool verbose, DelegateFactory *delegate_factory) {
     std::cout << "Comparing " << filename << "\n";
 
     std::vector<char> buffer = read_entire_file(filename);
 
-    std::vector<Buffer<const void>> tflite_outputs, halide_outputs;
-    std::chrono::duration<double> tflite_time, halide_time;
+    struct RunResult {
+        std::vector<Buffer<const void>> outputs;
+        std::chrono::duration<double> time;
+    };
+
     std::map<std::string, int> seeds;
 
-    // ----- Run in TFLite
+    RunResult halide_result;
+
+    // ----- Run in Halide
     {
+        Model model = parse_tflite_model_from_buffer(buffer.data());
+        if (verbose) {
+            model.dump(std::cout);
+        }
+
+        ModelInterpreter interpreter(std::move(model));
+
+        // Fill in the inputs with random data (but with the same seeds as above).
+        for (Tensor *t : interpreter.inputs()) {
+            if (t->is_constant()) {
+                // Skip constant buffers, just like TFlite above.
+                continue;
+            }
+            int seed_here = seed++;
+            seeds[t->name()] = seed_here;
+            auto input_buf = t->data<void>();
+            dynamic_type_dispatch<FillWithRandom>(input_buf.type(), input_buf, seed_here);
+            if (verbose) {
+                std::cout << "HALIDE input " << t->name() << " inited with seed = " << seed_here << " type " << input_buf.type() << "\n";
+            }
+        }
+
+        halide_set_num_threads(threads);
+
+        // Execute once, to prime the pump
+        interpreter.execute();
+
+        // Now benchmark it
+        halide_result.time = bench([&interpreter]() {
+            interpreter.execute();
+        });
+
+        // Save the outputs
+        for (Tensor *t : interpreter.outputs()) {
+            if (verbose) {
+                std::cout << "HALIDE output is " << t->name() << " type " << to_string(t->type()) << "\n";
+            }
+            // Make a copy since the Buffer might reference memory owned by the interpreter
+            halide_result.outputs.emplace_back(t->data<const void>().copy());
+        }
+    }
+
+    // ----- Run in TFLite
+    const auto run_in_tflite = [&seeds](const std::vector<char> &buffer, int seed, int threads, bool verbose, TfLiteDelegate *delegate) -> RunResult {
+        RunResult result;
+
         TfLiteModel *tf_model = TfLiteModelCreate(buffer.data(), buffer.size());
         CHECK(tf_model);
 
         TfLiteInterpreterOptions *tf_options = TfLiteInterpreterOptionsCreate();
         CHECK(tf_options);
         TfLiteInterpreterOptionsSetNumThreads(tf_options, threads);
+        if (delegate) {
+            TfLiteInterpreterOptionsAddDelegate(tf_options, delegate);
+        }
 
         TfLiteInterpreter *tf_interpreter = TfLiteInterpreterCreate(tf_model, tf_options);
 
@@ -121,8 +182,9 @@ void run_both(const std::string &filename, int seed, int threads, bool verbose) 
                 }
                 continue;
             }
-            int seed_here = seed++;
-            seeds[t->name] = seed_here;
+            auto seed_i = seeds.find(t->name);
+            assert(seed_i != seeds.end());
+            int seed_here = seed_i->second;
             auto input_buf = wrap_tf_lite_tensor_with_halide_buffer(t);
             dynamic_type_dispatch<FillWithRandom>(input_buf.type(), input_buf, seed_here);
             if (verbose) {
@@ -134,8 +196,16 @@ void run_both(const std::string &filename, int seed, int threads, bool verbose) 
         // Execute once, to prime the pump
         CHECK((status = TfLiteInterpreterInvoke(tf_interpreter)) == kTfLiteOk) << status;
 
+        // TODO: left in for now for when we re-add DynamicTensor usage
+        // int input_dims[4] = { 2, 28, 28, 32};
+        // CHECK((status = TfLiteInterpreterResizeInputTensor(tf_interpreter, 0, input_dims, 4)) == kTfLiteOk) << status;
+        // CHECK((status = TfLiteInterpreterResizeInputTensor(tf_interpreter, 1, input_dims, 4)) == kTfLiteOk) << status;
+        // CHECK((status = TfLiteInterpreterAllocateTensors(tf_interpreter)) == kTfLiteOk) << status;
+        // CHECK((status = TfLiteInterpreterInvoke(tf_interpreter)) == kTfLiteOk) << status;
+        // CHECK((status = TfLiteInterpreterInvoke(tf_interpreter)) == kTfLiteOk) << status;
+
         // Now benchmark it
-        tflite_time = bench([&tf_interpreter]() {
+        result.time = bench([&tf_interpreter]() {
             TfLiteStatus status;
             CHECK((status = TfLiteInterpreterInvoke(tf_interpreter)) == kTfLiteOk) << status;
         });
@@ -147,102 +217,98 @@ void run_both(const std::string &filename, int seed, int threads, bool verbose) 
                 std::cout << "TFLITE output is " << t->name << " type " << TfLiteTypeGetName(t->type) << "\n";
             }
             // Make a copy since the Buffer might reference memory owned by the tf_interpreter
-            tflite_outputs.emplace_back(wrap_tf_lite_tensor_with_halide_buffer(t).copy());
+            result.outputs.emplace_back(wrap_tf_lite_tensor_with_halide_buffer(t).copy());
         }
 
         TfLiteInterpreterDelete(tf_interpreter);
-    }
 
-    // ----- Run in Halide
-    {
-        Model model = parse_tflite_model_from_buffer(buffer.data());
-        if (verbose) {
-            model.dump(std::cout);
+        return result;
+    };
+
+    RunResult tflite_result = run_in_tflite(buffer, seed, threads, verbose, nullptr);
+
+    RunResult delegate_result;
+    if (delegate_factory) {
+        constexpr size_t num_options = 1;
+        std::pair<std::string, std::string> options_strs[num_options] = {
+            {"num_threads", std::to_string(threads)},
+        };
+        char *keys[num_options];
+        char *values[num_options];
+        for (size_t i = 0; i < num_options; i++) {
+            keys[i] = const_cast<char *>(options_strs[i].first.c_str());
+            values[i] = const_cast<char *>(options_strs[i].second.c_str());
         }
-
-        ModelInterpreter interpreter(std::move(model));
-
-        // Fill in the inputs with random data (but with the same seeds as above).
-        for (Tensor *t : interpreter.inputs()) {
-            if (t->is_constant()) {
-                // Skip constant buffers, just like TFlite above.
-                continue;
-            }
-            auto seed_i = seeds.find(t->name());
-            assert(seed_i != seeds.end());
-            int seed_here = seed_i->second;
-            auto input_buf = t->data<void>();
-            dynamic_type_dispatch<FillWithRandom>(input_buf.type(), input_buf, seed_here);
-            if (verbose) {
-                std::cout << "HALIDE input " << t->name() << " inited with seed = " << seed_here << " type " << input_buf.type() << "\n";
-            }
-        }
-
-        halide_set_num_threads(threads);
-
-        // Execute once, to prime the pump
-        interpreter.execute();
-
-        // Now benchmark it
-        halide_time = bench([&interpreter]() {
-            interpreter.execute();
-        });
-
-        // Save the outputs
-        for (Tensor *t : interpreter.outputs()) {
-            if (verbose) {
-                std::cout << "HALIDE output is " << t->name() << " type " << to_string(t->type()) << "\n";
-            }
-            // Make a copy since the Buffer might reference memory owned by the interpreter
-            halide_outputs.emplace_back(t->data<const void>().copy());
-        }
+        TfLiteDelegate *delegate = delegate_factory->create_delegate(keys, values, num_options, nullptr);
+        assert(delegate);
+        delegate_result = run_in_tflite(buffer, seed, threads, verbose, delegate);
+        delegate_factory->destroy_delegate(delegate);
     }
 
     // ----- Log benchmark times
-    std::cout << "TFLITE Time: " << std::chrono::duration_cast<std::chrono::microseconds>(tflite_time).count() << " us"
+    std::cout << "TFLITE-DIRECT   Time: " << std::chrono::duration_cast<std::chrono::microseconds>(tflite_result.time).count() << " us"
               << "\n";
-    std::cout << "HALIDE Time: " << std::chrono::duration_cast<std::chrono::microseconds>(halide_time).count() << " us"
+    std::cout << "HALIDE-DIRECT   Time: " << std::chrono::duration_cast<std::chrono::microseconds>(halide_result.time).count() << " us"
               << "\n";
+    if (delegate_factory) {
+        std::cout << "HALIDE-DELEGATE Time: " << std::chrono::duration_cast<std::chrono::microseconds>(delegate_result.time).count() << " us"
+                  << "\n";
+    }
 
-    double ratio = (halide_time / tflite_time);
+    double ratio = (halide_result.time / tflite_result.time);
     std::cout << "HALIDE = " << ratio * 100.0 << "% of TFLITE";
     if (ratio > 1.0) {
         std::cout << "  *** HALIDE IS SLOWER";
     }
     std::cout << "\n";
 
-    // ----- Now compare the outputs
-    CHECK(tflite_outputs.size() == halide_outputs.size());
-    for (size_t i = 0; i < tflite_outputs.size(); ++i) {
-        const Buffer<const void> &tflite_buf = tflite_outputs[i];
-        const Buffer<const void> &halide_buf = halide_outputs[i];
-        CHECK(tflite_buf.type() == halide_buf.type()) << "Expected type " << tflite_buf.type() << "; saw type " << halide_buf.type();
-        CHECK(tflite_buf.dimensions() == halide_buf.dimensions());
-        for (int d = 0; d < tflite_buf.dimensions(); d++) {
-            CHECK(tflite_buf.dim(d).min() == halide_buf.dim(d).min());
-            CHECK(tflite_buf.dim(d).extent() == halide_buf.dim(d).extent());
-            CHECK(tflite_buf.dim(d).stride() == halide_buf.dim(d).stride());  // TODO: must the strides match?
+    if (delegate_factory) {
+        ratio = (delegate_result.time / tflite_result.time);
+        std::cout << "DELEGATE = " << ratio * 100.0 << "% of TFLITE";
+        if (ratio > 1.0) {
+            std::cout << "  *** DELEGATE IS SLOWER";
         }
-        CompareBuffersOptions options;
+        std::cout << "\n";
+    }
+
+    // ----- Now compare the outputs
+    const auto compare_results = [](const RunResult &a, const RunResult &b, bool verbose) {
+        CHECK(a.outputs.size() == b.outputs.size());
+        for (size_t i = 0; i < a.outputs.size(); ++i) {
+            const Buffer<const void> &tflite_buf = a.outputs[i];
+            const Buffer<const void> &halide_buf = b.outputs[i];
+            CHECK(tflite_buf.type() == halide_buf.type()) << "Expected type " << tflite_buf.type() << "; saw type " << halide_buf.type();
+            CHECK(tflite_buf.dimensions() == halide_buf.dimensions());
+            for (int d = 0; d < tflite_buf.dimensions(); d++) {
+                CHECK(tflite_buf.dim(d).min() == halide_buf.dim(d).min());
+                CHECK(tflite_buf.dim(d).extent() == halide_buf.dim(d).extent());
+                CHECK(tflite_buf.dim(d).stride() == halide_buf.dim(d).stride());  // TODO: must the strides match?
+            }
+            CompareBuffersOptions options;
 #if defined(__arm__) || defined(__aarch64__)
-        // TFLite on Arm devices generally uses the rounding-shift instructions,
-        // which should match our results exactly (since we mimic the same result,
-        // whether or not we actually generate those specific instructions).
-        // So leave the options at their default.
+            // TFLite on Arm devices generally uses the rounding-shift instructions,
+            // which should match our results exactly (since we mimic the same result,
+            // whether or not we actually generate those specific instructions).
+            // So leave the options at their default.
 #else
-        // TFLite on x86 (on desktop platforms, at least) appears to mostly
-        // use the reference implementations, which don't have the same
-        // rounding-shift behavior. We'll bump up the 'close' value for these.
-        // This is a lttle hand-wavy but is a decent proxy for now.
-        options.close_thresh = 3.0;
+            // TFLite on x86 (on desktop platforms, at least) appears to mostly
+            // use the reference implementations, which don't have the same
+            // rounding-shift behavior. We'll bump up the 'close' value for these.
+            // This is a lttle hand-wavy but is a decent proxy for now.
+            options.close_thresh = 3.0;
 #endif
-        CompareBuffersResult r = dynamic_type_dispatch<CompareBuffers>(tflite_buf.type(), tflite_buf, halide_buf, options);
-        if (r.ok) {
-            if (verbose) {
-                std::cout << "MATCHING output " << i << " is:\n";
-                dynamic_type_dispatch<DumpBuffer>(halide_buf.type(), halide_buf);
+            CompareBuffersResult r = dynamic_type_dispatch<CompareBuffers>(tflite_buf.type(), tflite_buf, halide_buf, options);
+            if (r.ok) {
+                if (verbose) {
+                    std::cout << "MATCHING output " << i << " is:\n";
+                    dynamic_type_dispatch<DumpBuffer>(halide_buf.type(), halide_buf);
+                }
             }
         }
+    };
+    compare_results(tflite_result, halide_result, verbose);
+    if (delegate_factory) {
+        compare_results(tflite_result, delegate_result, verbose);
     }
 }
 
@@ -251,11 +317,17 @@ void run_both(const std::string &filename, int seed, int threads, bool verbose) 
 int main(int argc, char **argv) {
     int seed = time(nullptr);
     int threads = 1;
+    bool use_delegate = true;
     bool verbose = false;
+    std::vector<const char *> files;
 
     for (int i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "--seed")) {
             seed = atoi(argv[++i]);
+            continue;
+        }
+        if (!strcmp(argv[i], "--use_delegate")) {
+            use_delegate = atoi(argv[++i]) != 0;
             continue;
         }
         if (!strcmp(argv[i], "--threads")) {
@@ -266,6 +338,7 @@ int main(int argc, char **argv) {
             verbose = true;
             continue;
         }
+        files.push_back(argv[i]);
     }
     if (threads <= 0) {
 #ifdef _WIN32
@@ -279,15 +352,23 @@ int main(int argc, char **argv) {
     std::cout << "Using random seed: " << seed << "\n";
     std::cout << "Using threads: " << threads << "\n";
 
-    for (int i = 1; i < argc; i++) {
-        if (!strcmp(argv[i], "--seed") || !strcmp(argv[i], "--threads")) {
-            i++;
-            continue;
+    void *delegate_lib = nullptr;
+    interpret_nn::DelegateFactory delegate_factory;
+    if (use_delegate) {
+        delegate_lib = dlopen("libHalideDelegate.so", RTLD_NOW | RTLD_LOCAL);
+        if (!delegate_lib) {
+            std::cerr << "Unable to open Halide Delegate library: " << dlerror() << "\n";
+            return 1;
         }
-        if (!strcmp(argv[i], "--verbose")) {
-            continue;
-        }
-        interpret_nn::run_both(argv[i], seed, threads, verbose);
+        assert(delegate_lib);
+        delegate_factory.create_delegate = (decltype(delegate_factory.create_delegate))dlsym(delegate_lib, "tflite_plugin_create_delegate");
+        assert(delegate_factory.create_delegate);
+        delegate_factory.destroy_delegate = (decltype(delegate_factory.destroy_delegate))dlsym(delegate_lib, "tflite_plugin_destroy_delegate");
+        assert(delegate_factory.destroy_delegate);
+    }
+
+    for (auto f : files) {
+        interpret_nn::run_all(f, seed, threads, verbose, use_delegate ? &delegate_factory : nullptr);
         std::cout << "\n";
     }
 

--- a/apps/interpret_nn/compare_vs_tflite.cpp
+++ b/apps/interpret_nn/compare_vs_tflite.cpp
@@ -124,7 +124,9 @@ void run_all(const std::string &filename, int seed, int threads, bool verbose, D
             }
         }
 
-        halide_set_num_threads(threads);
+        // No: we won't be parallelizing withing Halide code, that will be done within
+        // our interpreter. Leaving this here as an example of what *not* to do.
+        // halide_set_num_threads(threads);
 
         // Execute once, to prime the pump
         interpreter.execute();

--- a/apps/interpret_nn/delegate/exported_symbols.linux
+++ b/apps/interpret_nn/delegate/exported_symbols.linux
@@ -1,0 +1,5 @@
+{
+  global: tflite_plugin_create_delegate; tflite_plugin_destroy_delegate;
+  local: *;
+};
+

--- a/apps/interpret_nn/delegate/exported_symbols.osx
+++ b/apps/interpret_nn/delegate/exported_symbols.osx
@@ -1,0 +1,2 @@
+_tflite_plugin_create_delegate
+_tflite_plugin_destroy_delegate

--- a/apps/interpret_nn/delegate/halide_delegate.cpp
+++ b/apps/interpret_nn/delegate/halide_delegate.cpp
@@ -1,0 +1,881 @@
+#include "delegate/halide_delegate.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "interpreter/interpreter.h"
+#include "interpreter/ops.h"
+#include "tensorflow/lite/builtin_ops.h"
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/c_api.h"
+#include "util/error_util.h"
+
+#define ALLOW_DYNAMIC_TENSORS 0
+
+// Use a List-Of-X approach here to ensure that places we handle ops are kept in sync
+#define ALL_KNOWN_OPS         \
+    KNOWN_OP(Add)             \
+    KNOWN_OP(AveragePool2d)   \
+    KNOWN_OP(Concatenation)   \
+    KNOWN_OP(Conv2d)          \
+    KNOWN_OP(DepthwiseConv2d) \
+    KNOWN_OP(FullyConnected)  \
+    KNOWN_OP(MaxPool2d)       \
+    KNOWN_OP(Pad)             \
+    KNOWN_OP(Reshape)         \
+    KNOWN_OP(Quantize)
+
+namespace interpret_nn {
+namespace {
+
+constexpr char kDelegateName[] = "HalideDelegate";
+constexpr int kDelegateVersion = 1;
+
+// -------------------- Some glue code adapted from tfite/c/common.c
+int TfLiteIntArrayGetSizeInBytes(int size) {
+    static TfLiteIntArray dummy;
+    return sizeof(dummy) + sizeof(dummy.data[0]) * size;
+}
+
+TfLiteIntArray *TfLiteIntArrayCreate(int size) {
+    TfLiteIntArray *ret = (TfLiteIntArray *)malloc(TfLiteIntArrayGetSizeInBytes(size));
+    ret->size = size;
+    return ret;
+}
+
+void TfLiteIntArrayFree(TfLiteIntArray *a) {
+    free(a);
+}
+
+struct TfLiteIntArrayDeleter {
+    void operator()(TfLiteIntArray *a) {
+        ::interpret_nn::TfLiteIntArrayFree(a);
+    }
+};
+
+std::unique_ptr<TfLiteIntArray, TfLiteIntArrayDeleter> BuildTfLiteIntArray(const std::vector<int> &data) {
+    std::unique_ptr<TfLiteIntArray, TfLiteIntArrayDeleter> result(TfLiteIntArrayCreate(data.size()));
+    std::copy(data.begin(), data.end(), result->data);
+    return result;
+}
+
+// -------------------- HalideDelegate
+
+struct HalideDelegate final : public TfLiteDelegate {
+    explicit HalideDelegate(const HalideDelegateOptions *p)
+        : TfLiteDelegate(),
+          options_(p != nullptr ? *p : HalideDelegateOptions()) {
+        assert(this->data_ == nullptr);
+        assert(this->CopyFromBufferHandle == nullptr);
+        assert(this->CopyToBufferHandle == nullptr);
+        assert(this->FreeBufferHandle == nullptr);
+        this->Prepare = DelegatePrepare;
+#if ALLOW_DYNAMIC_TENSORS
+        this->flags = kTfLiteDelegateFlagsAllowDynamicTensors;
+#else
+        this->flags = 0;
+#endif
+    }
+
+    static TfLiteStatus DelegatePrepare(TfLiteContext *context, TfLiteDelegate *delegate);
+
+    const HalideDelegateOptions options_;
+};
+
+// -------------------- HalideDelegateKernel
+
+TensorType ConvertTfLiteType(TfLiteType t) {
+    // Note that TfLiteType has different numerical values from the
+    // similar enum found in tflite flatbuffers.
+    switch (t) {
+    case kTfLiteFloat32:
+        return TensorType::Float32;
+    case kTfLiteFloat16:
+        return TensorType::Float16;
+    case kTfLiteInt32:
+        return TensorType::Int32;
+    case kTfLiteUInt8:
+        return TensorType::UInt8;
+    case kTfLiteInt64:
+        return TensorType::Int64;
+    case kTfLiteString:
+        return TensorType::String;
+    case kTfLiteBool:
+        return TensorType::Bool;
+    case kTfLiteInt16:
+        return TensorType::Int16;
+    case kTfLiteComplex64:
+        return TensorType::Complex64;
+    case kTfLiteInt8:
+        return TensorType::Int8;
+    case kTfLiteFloat64:
+        return TensorType::Float64;
+    case kTfLiteNoType:
+        CHECK(0) << "kTfLiteNoType is not supported";
+    default:
+        CHECK(0) << "Unknown TfLiteType";
+    }
+}
+
+ActivationFunction ConvertTfLiteActivation(TfLiteFusedActivation a) {
+    switch (a) {
+    case kTfLiteActNone:
+        return ActivationFunction::None;
+    case kTfLiteActRelu:
+        return ActivationFunction::Relu;
+    case kTfLiteActReluN1To1:
+        return ActivationFunction::ReluN1To1;
+    case kTfLiteActRelu6:
+        return ActivationFunction::Relu6;
+    case kTfLiteActTanh:
+        return ActivationFunction::Tanh;
+    case kTfLiteActSignBit:
+        return ActivationFunction::SignBit;
+    case kTfLiteActSigmoid:
+    default:
+        CHECK(0) << "Unknown TfLiteFusedActivation";
+    }
+}
+
+Padding ConvertTfLitePadding(TfLitePadding p) {
+    switch (p) {
+    case kTfLitePaddingSame:
+        return Padding::Same;
+    case kTfLitePaddingValid:
+        return Padding::Valid;
+    default:
+        CHECK(0) << "Unknown TfLitePadding";
+    }
+}
+
+std::vector<halide_dimension_t> ConvertTfLiteShape(const TfLiteTensor &tensor, size_t *shape_size_out = nullptr) {
+    std::vector<halide_dimension_t> shape(tensor.dims->size);
+    size_t shape_size = 1;
+    for (int i = 0; i < (int)shape.size(); i++) {
+        shape[i].min = 0;
+        shape[i].extent = tensor.dims->data[shape.size() - 1 - i];
+        shape[i].stride = shape_size;
+        shape_size *= shape[i].extent;
+    }
+    if (shape_size_out) {
+        *shape_size_out = shape_size;
+    }
+    return shape;
+}
+
+std::shared_ptr<Tensor> ConvertTfLiteTensor(const TfLiteTensor &tensor) {
+    // TODO: this always makes a copy of the tensor data; we should be able to just
+    // shadow it. Needs some refactoring in Tensor (at least) to make work.
+    std::vector<uint8_t> data;
+    if (tensor.allocation_type == kTfLiteMmapRo) {
+        const uint8_t *d = (const uint8_t *)tensor.data.data;
+        data.assign(d, d + tensor.bytes);
+    }
+
+    size_t shape_size;
+    auto shape = ConvertTfLiteShape(tensor, &shape_size);
+
+    TensorType type = ConvertTfLiteType(tensor.type);
+    assert(data.empty() || data.size() == shape_size * sizeof_tensor_type(type));
+
+    QuantizationInfo quantization;
+    if (tensor.quantization.type == kTfLiteAffineQuantization) {
+        const TfLiteAffineQuantization *q = (const TfLiteAffineQuantization *)tensor.quantization.params;
+        for (int i = 0; i < q->scale->size; ++i) {
+            const float scale = q->scale->data[i];
+            quantization.scale.emplace_back(scale);
+        }
+        for (int i = 0; i < q->zero_point->size; i++) {
+            const int zero = q->zero_point->data[i];
+            quantization.zero.emplace_back(zero);
+        }
+        quantization.dimension = tensor.dims->size - q->quantized_dimension;
+    }
+
+    // tensor.name can be null, apparently. I don't think we have any requirement
+    // for unique or non-empty names in our code, so let's just map that to
+    // an empty string.
+    const char *name = tensor.name ? tensor.name : "";
+    return std::make_shared<Tensor>(name, type, std::move(shape),
+                                    std::move(data), std::move(quantization));
+}
+
+class HalideDelegateKernel final {
+public:
+    // Each kernel instance will be used from only a single thread.
+    // (It is fine for the kernel itself to use multiple threads internally.)
+    explicit HalideDelegateKernel(const HalideDelegateOptions &options)
+        : options_(options) {
+    }
+
+    // Init() will be called exactly once per instance.
+    TfLiteStatus Init(TfLiteContext *context,
+                      const TfLiteDelegateParams *params) {
+        if (model_ != nullptr || interpreter_ != nullptr) {
+            TF_LITE_KERNEL_LOG(context, "Init must not be called twice.");
+            return kTfLiteError;
+        }
+        model_ = make_unique<Model>();
+
+        std::vector<int> node_indices(params->nodes_to_replace->size);
+        for (int i = 0; i < params->nodes_to_replace->size; i++) {
+            const int node_index = params->nodes_to_replace->data[i];
+            node_indices[i] = node_index;
+        }
+        LOG(INFO) << "Delegate " << (void *)this << " Init nodes: " << node_indices << "\n";
+
+        // Pre-emptively map *all* the TFLiteTensors into our Tensor type.
+        for (size_t tensor_id = 0; tensor_id < context->tensors_size; tensor_id++) {
+            const TfLiteTensor &tensor = context->tensors[tensor_id];
+            auto t = ConvertTfLiteTensor(tensor);
+            model_->tensors.emplace_back(t);
+            assert(!tensor_id_to_tensor_ptr_.count(tensor_id));
+            tensor_id_to_tensor_ptr_[tensor_id] = t;
+            // LOG(INFO) << "tensor_id " << tensor_id << " -> " << (void*) t.get() << "\n";
+        }
+
+        // Be careful with params->input_tensors and params->output_tensors here;
+        // in particular, params->input_tensors will contain all of the 'constant'
+        // input tensors (which are generally inputs only to a specific node).
+#if ALLOW_DYNAMIC_TENSORS
+        // TODO: verify the above comment is still correct.
+#endif
+
+        // Mark the input and output tensors correctly, as code in our interpreter
+        // relies upon it. TODO: verify that is necessary.
+        for (int i = 0; i < params->input_tensors->size; i++) {
+            const int tensor_id = params->input_tensors->data[i];
+            if (tensor_id == kTfLiteOptionalTensor) {
+                continue;
+            }
+            auto t = GetTensorById(context, tensor_id);
+            t->set_input(true);
+            // LOG(INFO) << "Delegate " << (void *)this << (t->is_constant() ? " Const" : "") << " Input tensor: " << tensor_id << "\n";
+        }
+
+        // Add the output tensors.
+        for (int i = 0; i < params->output_tensors->size; i++) {
+            const int tensor_id = params->output_tensors->data[i];
+            if (tensor_id == kTfLiteOptionalTensor) {
+                continue;
+            }
+            // LOG(INFO) << "Delegate " << (void *)this << " Output tensor: " << tensor_id << "\n";
+            auto t = GetTensorById(context, tensor_id);
+            t->set_output(true);
+        }
+
+        // Add all ops.
+        TfLiteNode *node;
+        TfLiteRegistration *reg;
+        for (int node_index : node_indices) {
+            TF_LITE_ENSURE_STATUS(context->GetNodeAndRegistration(context, node_index, &node, &reg));
+            const int op_type = reg->builtin_code;
+            std::unique_ptr<Op> op;
+
+            // clang-format off
+            switch (op_type) {
+                #define KNOWN_OP(OP) case kTfLiteBuiltin##OP: op = Build##OP(context, node); break;
+                ALL_KNOWN_OPS
+                #undef KNOWN_OP
+
+            default:
+                TF_LITE_KERNEL_LOG(context, "Op not supported: %d", op_type);
+                return kTfLiteError;
+            }
+            // clang-format on
+
+            if (op == nullptr) {
+                TF_LITE_KERNEL_LOG(context, "Op factory returned null: %s", op_type);
+                return kTfLiteError;
+            }
+            model_->ops.emplace_back(std::move(op));
+        }
+
+        return kTfLiteOk;
+    }
+
+    // Prepare() will be called at least once, prior to any calls to Eval().
+    // It will be called again if tensor shape(s) change. It is preferable
+    // to do all memory allocation in Prepare(), rather than Eval(), if possible.
+    TfLiteStatus Prepare(TfLiteContext *context, TfLiteNode *node) {
+        LOG(INFO) << "Delegate " << (void *)this << " Prepare\n";
+
+        assert(model_ != nullptr);
+
+#if ALLOW_DYNAMIC_TENSORS
+        // Because we set kTfLiteDelegateFlagsAllowDynamicTensors, TFLite
+        // may call Prepare() after Eval() if only tensor shapes have changed
+        // (but nothing else in the model), which is a nice potential optimization.
+        // (Apparently, if you don't set kTfLiteDelegateFlagsAllowDynamicTensors,
+        // TFLite will create a fresh Delegate for every call instead.)
+        //
+        // TODO: will be called with interp (but no model) if inputs resized.
+        // update the tensors in the model/interp.
+        abort();  // TODO
+#else
+        if (interpreter_ != nullptr) {
+            TF_LITE_KERNEL_LOG(context, "Calling Prepare() multiple times");
+            return kTfLiteError;
+        }
+#endif
+
+        interpreter_ = make_unique<ModelInterpreter>(std::move(*model_));
+        model_.reset();
+        return kTfLiteOk;
+    }
+
+    // Eval() will be called at least once. It can expect that prepare() will
+    // have been called for the current set of tensor shape(s).
+    TfLiteStatus Eval(TfLiteContext *context, TfLiteNode *node) {
+        LOG(INFO) << "Delegate " << (void *)this << " Eval\n";
+
+        if (interpreter_ == nullptr) {
+            TF_LITE_KERNEL_LOG(context, "interpreter_ is not built in Eval");
+            return kTfLiteError;
+        }
+
+        // Copy the non-constant Tensor inputs. TODO: avoid this by sharing pointers.
+        for (int i = 0; i < node->inputs->size; i++) {
+            const int tensor_id = node->inputs->data[i];
+            if (tensor_id == kTfLiteOptionalTensor) {
+                continue;
+            }
+            assert(tensor_id >= 0 && tensor_id < (int)context->tensors_size);
+            const TfLiteTensor &tensor = context->tensors[tensor_id];
+            auto t = GetTensorById(context, tensor_id);
+            assert(t->is_constant() == (tensor.allocation_type == kTfLiteMmapRo));
+            if (t->is_constant()) {
+                continue;
+            }
+            assert(t->is_input() && !t->is_constant() && t->is_allocated());
+            auto buf = t->data<void>();
+            assert(buf.size_in_bytes() == tensor.bytes);
+
+            memcpy(buf.data(), tensor.data.data, tensor.bytes);
+        }
+
+        // TODO: execute needs to return an error code.
+        halide_set_num_threads(options_.num_threads);
+        interpreter_->execute();
+
+        // Copy the Tensor outputs. TODO: avoid this by sharing pointers.
+        for (int i = 0; i < node->outputs->size; i++) {
+            const int tensor_id = node->outputs->data[i];
+            if (tensor_id == kTfLiteOptionalTensor) {
+                continue;
+            }
+            assert(tensor_id >= 0 && tensor_id < (int)context->tensors_size);
+            const TfLiteTensor &tensor = context->tensors[tensor_id];
+            assert(tensor.allocation_type != kTfLiteMmapRo);
+            auto t = GetTensorById(context, tensor_id);
+            assert(t->is_output() && !t->is_constant() && t->is_allocated());
+            auto buf = t->data<const void>();
+            assert(buf.size_in_bytes() == tensor.bytes);
+
+            memcpy(tensor.data.data, buf.data(), tensor.bytes);
+        }
+
+        // Eval() could be called again with the same graph -- don't destroy the interpreter_ yet.
+
+        return kTfLiteOk;
+    }
+
+    static TfLiteRegistration GetRegistration() {
+        TfLiteRegistration r{};
+        r.init = InitImpl;
+        r.free = FreeImpl;
+        r.prepare = PrepareImpl;
+        r.invoke = InvokeImpl;
+        r.profiling_string = nullptr;
+        r.builtin_code = kTfLiteBuiltinDelegate;
+        r.custom_name = kDelegateName;
+        r.version = kDelegateVersion;
+        return r;
+    }
+
+private:
+    static void *InitImpl(TfLiteContext *context, const char *buffer, size_t length) {
+        const TfLiteDelegateParams *params = (const TfLiteDelegateParams *)buffer;
+        if (params == nullptr) {
+            LOG(ERROR) << "HalideDelegate.init: NULL params";
+            return nullptr;
+        }
+        HalideDelegate *halide_delegate = (HalideDelegate *)params->delegate;
+        auto self = make_unique<HalideDelegateKernel>(halide_delegate->options_);
+        if (self->Init(context, params) != kTfLiteOk) {
+            LOG(ERROR) << "HalideDelegate.init: NULL params";
+            return nullptr;
+        }
+        return self.release();
+    };
+
+    static void FreeImpl(TfLiteContext *context, void *buffer) {
+        HalideDelegateKernel *self = (HalideDelegateKernel *)buffer;
+        delete self;
+    };
+
+    static TfLiteStatus PrepareImpl(TfLiteContext *context, TfLiteNode *node) {
+        if (node->user_data == nullptr) {
+            LOG(ERROR) << "Delegate kernel was not initialized";
+            return kTfLiteError;
+        }
+        HalideDelegateKernel *self = (HalideDelegateKernel *)node->user_data;
+        return self->Prepare(context, node);
+    };
+
+    static TfLiteStatus InvokeImpl(TfLiteContext *context, TfLiteNode *node) {
+        HalideDelegateKernel *self = (HalideDelegateKernel *)node->user_data;
+        assert(self != nullptr);
+        return self->Eval(context, node);
+    };
+
+    Tensor *GetTensorById(TfLiteContext *context, int tensor_id) {
+        auto it = tensor_id_to_tensor_ptr_.find(tensor_id);
+        if (it == tensor_id_to_tensor_ptr_.end()) {
+            LOG(ERROR) << "tensor_id not found: " << tensor_id;
+            return nullptr;
+        }
+        return it->second.get();
+    }
+
+    std::unique_ptr<Op> BuildAdd(TfLiteContext *context, TfLiteNode *node) {
+        auto input1 = GetTensorById(context, node->inputs->data[0]);
+        auto input2 = GetTensorById(context, node->inputs->data[1]);
+        auto output = GetTensorById(context, node->outputs->data[0]);
+        const TfLiteAddParams *params = (const TfLiteAddParams *)(node->builtin_data);
+        auto activation = ConvertTfLiteActivation(params->activation);
+        return make_unique<AddOp>(input1, input2, output, activation);
+    }
+
+    std::unique_ptr<Op> BuildAveragePool2d(TfLiteContext *context, TfLiteNode *node) {
+        auto input = GetTensorById(context, node->inputs->data[0]);
+        auto output = GetTensorById(context, node->outputs->data[0]);
+        const TfLitePoolParams *params = (const TfLitePoolParams *)(node->builtin_data);
+        auto padding = ConvertTfLitePadding(params->padding);
+        const std::vector<int> stride = {
+            params->stride_width,
+            params->stride_height,
+        };
+        const std::vector<int> filter_size = {
+            params->filter_width,
+            params->filter_height,
+        };
+        auto activation = ConvertTfLiteActivation(params->activation);
+        return make_unique<AveragePoolOp>(input, output, stride, filter_size, padding, activation);
+    }
+
+    std::unique_ptr<Op> BuildConcatenation(TfLiteContext *context, TfLiteNode *node) {
+        std::vector<Tensor *> inputs(node->inputs->size);
+        for (int i = 0; i < node->inputs->size; i++) {
+            inputs[i] = GetTensorById(context, node->inputs->data[i]);
+        }
+        auto output = GetTensorById(context, node->outputs->data[0]);
+        const TfLiteConcatenationParams *params = (const TfLiteConcatenationParams *)(node->builtin_data);
+        auto activation = ConvertTfLiteActivation(params->activation);
+        int axis = params->axis;
+        // Handle negative values, which are legal
+        if (axis < 0) {
+            axis = (int)output->shape().size() + axis;
+        }
+        // Now 'flip' the axis so that it refers to the right dimension in
+        // the Tensor (since we reverse the dimension order)
+        axis = (int)output->shape().size() - axis - 1;
+        return make_unique<ConcatenationOp>(inputs, output, axis, activation);
+    }
+
+    std::unique_ptr<Op> BuildConv2d(TfLiteContext *context, TfLiteNode *node) {
+        auto input = GetTensorById(context, node->inputs->data[0]);
+        auto filter = GetTensorById(context, node->inputs->data[1]);
+        auto bias = GetTensorById(context, node->inputs->data[2]);
+        auto output = GetTensorById(context, node->outputs->data[0]);
+        const TfLiteConvParams *params = (const TfLiteConvParams *)(node->builtin_data);
+        auto padding = ConvertTfLitePadding(params->padding);
+        const std::vector<int> stride = {
+            params->stride_width,
+            params->stride_height,
+        };
+        const std::vector<int> dilation_factor = {
+            params->dilation_width_factor,
+            params->dilation_height_factor,
+        };
+        auto activation = ConvertTfLiteActivation(params->activation);
+        return make_unique<Conv2DOp>(input, filter, bias, output, stride,
+                                     dilation_factor, padding, activation);
+    }
+
+    std::unique_ptr<Op> BuildDepthwiseConv2d(TfLiteContext *context, TfLiteNode *node) {
+        auto input = GetTensorById(context, node->inputs->data[0]);
+        auto filter = GetTensorById(context, node->inputs->data[1]);
+        auto bias = GetTensorById(context, node->inputs->data[2]);
+        auto output = GetTensorById(context, node->outputs->data[0]);
+        const TfLiteDepthwiseConvParams *params = (const TfLiteDepthwiseConvParams *)(node->builtin_data);
+        auto padding = ConvertTfLitePadding(params->padding);
+        const std::vector<int> stride = {
+            params->stride_width,
+            params->stride_height,
+        };
+        const std::vector<int> dilation_factor = {
+            params->dilation_width_factor,
+            params->dilation_height_factor,
+        };
+        auto activation = ConvertTfLiteActivation(params->activation);
+        // TODO: depth_multiplier is considered redundant and semi-deprecated;
+        // see buildin_op_data.h in tflite source for more info.
+        int depth_multiplier = params->depth_multiplier;
+        return make_unique<DepthwiseConv2DOp>(input, filter, bias, output, depth_multiplier, stride,
+                                              dilation_factor, padding, activation);
+    }
+
+    std::unique_ptr<Op> BuildFullyConnected(TfLiteContext *context, TfLiteNode *node) {
+        auto input = GetTensorById(context, node->inputs->data[0]);
+        auto filter = GetTensorById(context, node->inputs->data[1]);
+        auto bias = GetTensorById(context, node->inputs->data[2]);
+        auto output = GetTensorById(context, node->outputs->data[0]);
+        const TfLiteFullyConnectedParams *params = (const TfLiteFullyConnectedParams *)(node->builtin_data);
+        auto activation = ConvertTfLiteActivation(params->activation);
+        return make_unique<FullyConnectedOp>(input, filter, bias, output, activation);
+    }
+
+    std::unique_ptr<Op> BuildMaxPool2d(TfLiteContext *context, TfLiteNode *node) {
+        auto input = GetTensorById(context, node->inputs->data[0]);
+        auto output = GetTensorById(context, node->outputs->data[0]);
+        const TfLitePoolParams *params = (const TfLitePoolParams *)(node->builtin_data);
+        auto padding = ConvertTfLitePadding(params->padding);
+        const std::vector<int> stride = {
+            params->stride_width,
+            params->stride_height,
+        };
+        const std::vector<int> filter_size = {
+            params->filter_width,
+            params->filter_height,
+        };
+        auto activation = ConvertTfLiteActivation(params->activation);
+        return make_unique<MaxPoolOp>(input, output, stride, filter_size, padding, activation);
+    }
+
+    std::unique_ptr<Op> BuildPad(TfLiteContext *context, TfLiteNode *node) {
+        auto input = GetTensorById(context, node->inputs->data[0]);
+        auto padding = GetTensorById(context, node->inputs->data[1]);
+        auto output = GetTensorById(context, node->outputs->data[0]);
+        return make_unique<PadOp>(input, padding, output);
+    }
+
+    std::unique_ptr<Op> BuildReshape(TfLiteContext *context, TfLiteNode *node) {
+        auto input = GetTensorById(context, node->inputs->data[0]);
+        auto output = GetTensorById(context, node->outputs->data[0]);
+        const TfLiteReshapeParams *params = (const TfLiteReshapeParams *)(node->builtin_data);
+        std::vector<int> new_shape;
+        new_shape.assign(params->shape, params->shape + params->num_dimensions);
+        return make_unique<ReshapeOp>(input, output, new_shape);
+    }
+
+    std::unique_ptr<Op> BuildQuantize(TfLiteContext *context, TfLiteNode *node) {
+        auto input = GetTensorById(context, node->inputs->data[0]);
+        auto output = GetTensorById(context, node->outputs->data[0]);
+        return make_unique<QuantizeOp>(input, output);
+    }
+
+    const HalideDelegateOptions options_;
+    std::unique_ptr<Model> model_;
+    std::unique_ptr<ModelInterpreter> interpreter_;
+    std::map<int, std::shared_ptr<Tensor>> tensor_id_to_tensor_ptr_;
+};
+
+bool InputsHaveCorrectTypes(const TfLiteNode *node,
+                            TfLiteContext *context,
+                            std::initializer_list<int> per_input_possible_types_mask) {
+    if (node->inputs->size != (int)per_input_possible_types_mask.size()) {
+        LOG(ERROR) << "inputs size mismatch in InputsHaveCorrectTypes";
+        return false;
+    }
+    int i = -1;
+    for (int possible_types_mask : per_input_possible_types_mask) {
+        ++i;
+        // Skip optional tensor.
+        const int tensor_id = node->inputs->data[i];
+        if (tensor_id == kTfLiteOptionalTensor) {
+            continue;
+        }
+        const TfLiteTensor &tensor = context->tensors[tensor_id];
+        const int tensor_type_mask = 1 << tensor.type;
+        if (!(tensor_type_mask & possible_types_mask)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool AllInputsHaveType(const TfLiteNode *node, TfLiteContext *context, int possible_types_mask) {
+    for (int i = 0; i < node->inputs->size; ++i) {
+        const int tensor_id = node->inputs->data[i];
+        if (tensor_id == kTfLiteOptionalTensor) {
+            continue;
+        }
+        const TfLiteTensor &tensor = context->tensors[tensor_id];
+        const int tensor_type_mask = 1 << tensor.type;
+        if (!(tensor_type_mask & possible_types_mask)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool IsActivationReluOrNone(TfLiteFusedActivation activation) {
+    return (activation == kTfLiteActRelu ||
+            activation == kTfLiteActRelu6 ||
+            activation == kTfLiteActReluN1To1 ||
+            activation == kTfLiteActNone);
+}
+
+// TODO: this should also allow Int8 once we fix biasing for those
+constexpr int k8BitMask = 1 << kTfLiteUInt8;
+
+bool IsNodeSupported_Add(TfLiteContext *context, TfLiteNode *node, TfLiteRegistration *registration) {
+    if (!(registration->version <= 2)) {
+        return false;
+    }
+    if (!InputsHaveCorrectTypes(
+            node, context,
+            {k8BitMask, k8BitMask})) {
+        return false;
+    }
+    const TfLiteAddParams *params = (const TfLiteAddParams *)(node->builtin_data);
+    if (!IsActivationReluOrNone(params->activation)) {
+        return false;
+    }
+    return true;
+}
+
+bool IsNodeSupported_AveragePool2d(TfLiteContext *context, TfLiteNode *node, TfLiteRegistration *registration) {
+    if (!(registration->version <= 2)) {
+        return false;
+    }
+    if (!InputsHaveCorrectTypes(
+            node, context,
+            {k8BitMask})) {
+        return false;
+    }
+    const TfLitePoolParams *params = (const TfLitePoolParams *)(node->builtin_data);
+    if (!IsActivationReluOrNone(params->activation)) {
+        return false;
+    }
+    return true;
+}
+
+bool IsNodeSupported_Concatenation(TfLiteContext *context, TfLiteNode *node, TfLiteRegistration *registration) {
+    if (!(registration->version <= 2)) {
+        return false;
+    }
+    if (!AllInputsHaveType(node, context, k8BitMask)) {
+        return false;
+    }
+    // TODO: This op has an activation but we don't appear to use it.
+    // const TfLiteConcatenationParams *params = (const TfLiteConcatenationParams *)(node->builtin_data);
+    return true;
+}
+
+bool IsNodeSupported_Conv2d(TfLiteContext *context, TfLiteNode *node, TfLiteRegistration *registration) {
+    if (!(registration->version <= 2)) {
+        return false;
+    }
+    if (!InputsHaveCorrectTypes(
+            node, context,
+            {k8BitMask, k8BitMask, 1 << kTfLiteInt32})) {
+        return false;
+    }
+    const TfLiteConvParams *params = (const TfLiteConvParams *)(node->builtin_data);
+    if (!IsActivationReluOrNone(params->activation)) {
+        return false;
+    }
+    return true;
+}
+
+bool IsNodeSupported_DepthwiseConv2d(TfLiteContext *context, TfLiteNode *node, TfLiteRegistration *registration) {
+    if (!(registration->version <= 2)) {
+        return false;
+    }
+    if (!InputsHaveCorrectTypes(
+            node, context,
+            {k8BitMask, k8BitMask, 1 << kTfLiteInt32})) {
+        return false;
+    }
+    const TfLiteDepthwiseConvParams *params = (const TfLiteDepthwiseConvParams *)(node->builtin_data);
+    if (!IsActivationReluOrNone(params->activation)) {
+        return false;
+    }
+    return true;
+}
+
+bool IsNodeSupported_FullyConnected(TfLiteContext *context, TfLiteNode *node, TfLiteRegistration *registration) {
+    // This is correct, we don't handle the params for v2 or later yet
+    if (!(registration->version <= 1)) {
+        return false;
+    }
+    if (!InputsHaveCorrectTypes(
+            node, context,
+            {k8BitMask, k8BitMask, (1 << kTfLiteInt32) | (1 << kTfLiteNoType)})) {
+        return false;
+    }
+    const TfLiteFullyConnectedParams *params = (const TfLiteFullyConnectedParams *)(node->builtin_data);
+    if (!IsActivationReluOrNone(params->activation)) {
+        return false;
+    }
+    return true;
+}
+
+bool IsNodeSupported_MaxPool2d(TfLiteContext *context, TfLiteNode *node, TfLiteRegistration *registration) {
+    if (!(registration->version <= 2)) {
+        return false;
+    }
+    if (!InputsHaveCorrectTypes(
+            node, context,
+            {k8BitMask})) {
+        return false;
+    }
+    const TfLitePoolParams *params = (const TfLitePoolParams *)(node->builtin_data);
+    if (!IsActivationReluOrNone(params->activation)) {
+        return false;
+    }
+    return true;
+}
+
+bool IsNodeSupported_Pad(TfLiteContext *context, TfLiteNode *node, TfLiteRegistration *registration) {
+    if (!(registration->version <= 2)) {
+        return false;
+    }
+    if (!InputsHaveCorrectTypes(
+            node, context,
+            {k8BitMask, 1 << kTfLiteInt32})) {
+        return false;
+    }
+    return true;
+}
+
+bool IsNodeSupported_Reshape(TfLiteContext *context, TfLiteNode *node, TfLiteRegistration *registration) {
+    if (!(registration->version <= 2)) {
+        return false;
+    }
+    // Note that Reshape can have 1 or 2 inputs.
+    if (node->inputs->size > 2) {
+        return false;
+    }
+    return true;
+}
+
+bool IsNodeSupported_Quantize(TfLiteContext *context, TfLiteNode *node, TfLiteRegistration *registration) {
+    if (!(registration->version <= 2)) {
+        return false;
+    }
+    if (!InputsHaveCorrectTypes(
+            node, context,
+            {k8BitMask})) {
+        return false;
+    }
+    return true;
+}
+
+bool IsNodeSupported(TfLiteContext *context, TfLiteNode *node, TfLiteRegistration *registration) {
+    // Ensure all inputs & outputs have dim <= 4.
+    for (int i = 0; i < node->inputs->size; ++i) {
+        const int tensor_id = node->inputs->data[i];
+        if (tensor_id == kTfLiteOptionalTensor) {
+            continue;
+        }
+        const TfLiteTensor &tensor = context->tensors[tensor_id];
+        if (tensor.dims->size > 4) {
+            return false;
+        }
+    }
+    for (int i = 0; i < node->outputs->size; ++i) {
+        const int tensor_id = node->outputs->data[i];
+        const TfLiteTensor &tensor = context->tensors[tensor_id];
+        if (tensor.dims->size > 4) {
+            return false;
+        }
+    }
+
+    // Now check for each specific node.
+    //
+    // TODO: Our existing code for TFLiteParser, etc doesn't pay
+    // attention to version (AFAICT); need to find & examine the specs of
+    // version changes to ensure this is correct. Existing version checking
+    // here is mostly bogus. See tensorflow/lite/tools/versioning/op_version.cc
+    //
+    // TODO: style here is imitation of approach used in Hexagon delegate,
+    // but a purely data-table-driven-approach might be better in the long run?
+
+    // clang-format off
+    switch (registration->builtin_code) {
+
+        #define KNOWN_OP(OP) case kTfLiteBuiltin##OP: return IsNodeSupported_##OP(context, node, registration);
+        ALL_KNOWN_OPS
+        #undef KNOWN_OP
+
+    default:
+        return false;
+    }
+    // clang-format on
+
+    return false;
+}
+
+/*static*/ TfLiteStatus HalideDelegate::DelegatePrepare(TfLiteContext *context, TfLiteDelegate *delegate) {
+    TfLiteStatus status;
+
+    TfLiteIntArray *plan = nullptr;
+    if ((status = context->GetExecutionPlan(context, &plan)) != kTfLiteOk) {
+        LOG(ERROR) << "GetExecutionPlan failed";
+        return status;
+    }
+
+    // Build up a list of the nodes we want to handle.
+    std::vector<int> supported_nodes;
+    for (int i = 0; i < plan->size; i++) {
+        const int node_index = plan->data[i];
+        TfLiteNode *node;
+        TfLiteRegistration *registration;
+        if ((status = context->GetNodeAndRegistration(context, node_index, &node, &registration)) != kTfLiteOk) {
+            LOG(ERROR) << "GetNodeAndRegistration failed";
+            return status;
+        }
+
+        if (IsNodeSupported(context, node, registration)) {
+            supported_nodes.push_back(node_index);
+        } else {
+            LOG(INFO) << "NODE REJECTED: " << node_index << "\n";
+        }
+    }
+
+    if ((status = context->ReplaceNodeSubsetsWithDelegateKernels(context,
+                                                                 HalideDelegateKernel::GetRegistration(),
+                                                                 BuildTfLiteIntArray(supported_nodes).get(),
+                                                                 delegate)) != kTfLiteOk) {
+        LOG(ERROR) << "ReplaceNodeSubsetsWithDelegateKernels failed";
+        return status;
+    }
+
+    return kTfLiteOk;
+}
+
+}  // namespace
+}  // namespace interpret_nn
+
+TfLiteDelegate *HalideDelegateCreate(const HalideDelegateOptions *options) {
+    using interpret_nn::HalideDelegate;
+
+    return new HalideDelegate(options);
+}
+
+void HalideDelegateOptionsDefault(HalideDelegateOptions *opt) {
+    *opt = HalideDelegateOptions();
+}
+
+void HalideDelegateDelete(TfLiteDelegate *delegate) {
+    using interpret_nn::HalideDelegate;
+
+    if (delegate) {
+        HalideDelegate *halide_delegate = (HalideDelegate *)delegate;
+        delete halide_delegate;
+    }
+}

--- a/apps/interpret_nn/delegate/halide_delegate.cpp
+++ b/apps/interpret_nn/delegate/halide_delegate.cpp
@@ -635,9 +635,7 @@ bool IsNodeSupported_Add(TfLiteContext *context, TfLiteNode *node, TfLiteRegistr
     if (!(registration->version <= 2)) {
         return false;
     }
-    if (!InputsHaveCorrectTypes(
-            node, context,
-            {k8BitMask, k8BitMask})) {
+    if (!InputsHaveCorrectTypes(node, context, {k8BitMask, k8BitMask})) {
         return false;
     }
     const TfLiteAddParams *params = (const TfLiteAddParams *)(node->builtin_data);
@@ -651,9 +649,7 @@ bool IsNodeSupported_AveragePool2d(TfLiteContext *context, TfLiteNode *node, TfL
     if (!(registration->version <= 2)) {
         return false;
     }
-    if (!InputsHaveCorrectTypes(
-            node, context,
-            {k8BitMask})) {
+    if (!InputsHaveCorrectTypes(node, context, {k8BitMask})) {
         return false;
     }
     const TfLitePoolParams *params = (const TfLitePoolParams *)(node->builtin_data);
@@ -679,9 +675,7 @@ bool IsNodeSupported_Conv2d(TfLiteContext *context, TfLiteNode *node, TfLiteRegi
     if (!(registration->version <= 2)) {
         return false;
     }
-    if (!InputsHaveCorrectTypes(
-            node, context,
-            {k8BitMask, k8BitMask, 1 << kTfLiteInt32})) {
+    if (!InputsHaveCorrectTypes(node, context, {k8BitMask, k8BitMask, 1 << kTfLiteInt32})) {
         return false;
     }
     const TfLiteConvParams *params = (const TfLiteConvParams *)(node->builtin_data);
@@ -695,9 +689,7 @@ bool IsNodeSupported_DepthwiseConv2d(TfLiteContext *context, TfLiteNode *node, T
     if (!(registration->version <= 2)) {
         return false;
     }
-    if (!InputsHaveCorrectTypes(
-            node, context,
-            {k8BitMask, k8BitMask, 1 << kTfLiteInt32})) {
+    if (!InputsHaveCorrectTypes(node, context, {k8BitMask, k8BitMask, 1 << kTfLiteInt32})) {
         return false;
     }
     const TfLiteDepthwiseConvParams *params = (const TfLiteDepthwiseConvParams *)(node->builtin_data);
@@ -712,9 +704,7 @@ bool IsNodeSupported_FullyConnected(TfLiteContext *context, TfLiteNode *node, Tf
     if (!(registration->version <= 1)) {
         return false;
     }
-    if (!InputsHaveCorrectTypes(
-            node, context,
-            {k8BitMask, k8BitMask, (1 << kTfLiteInt32) | (1 << kTfLiteNoType)})) {
+    if (!InputsHaveCorrectTypes(node, context, {k8BitMask, k8BitMask, (1 << kTfLiteInt32) | (1 << kTfLiteNoType)})) {
         return false;
     }
     const TfLiteFullyConnectedParams *params = (const TfLiteFullyConnectedParams *)(node->builtin_data);
@@ -728,9 +718,7 @@ bool IsNodeSupported_MaxPool2d(TfLiteContext *context, TfLiteNode *node, TfLiteR
     if (!(registration->version <= 2)) {
         return false;
     }
-    if (!InputsHaveCorrectTypes(
-            node, context,
-            {k8BitMask})) {
+    if (!InputsHaveCorrectTypes(node, context, {k8BitMask})) {
         return false;
     }
     const TfLitePoolParams *params = (const TfLitePoolParams *)(node->builtin_data);
@@ -744,9 +732,7 @@ bool IsNodeSupported_Pad(TfLiteContext *context, TfLiteNode *node, TfLiteRegistr
     if (!(registration->version <= 2)) {
         return false;
     }
-    if (!InputsHaveCorrectTypes(
-            node, context,
-            {k8BitMask, 1 << kTfLiteInt32})) {
+    if (!InputsHaveCorrectTypes(node, context, {k8BitMask, 1 << kTfLiteInt32})) {
         return false;
     }
     return true;
@@ -767,9 +753,7 @@ bool IsNodeSupported_Quantize(TfLiteContext *context, TfLiteNode *node, TfLiteRe
     if (!(registration->version <= 2)) {
         return false;
     }
-    if (!InputsHaveCorrectTypes(
-            node, context,
-            {k8BitMask})) {
+    if (!InputsHaveCorrectTypes(node, context, {k8BitMask})) {
         return false;
     }
     return true;

--- a/apps/interpret_nn/delegate/halide_delegate.h
+++ b/apps/interpret_nn/delegate/halide_delegate.h
@@ -1,0 +1,42 @@
+#ifndef DELEGATE_HALIDE_DELEGATE_H_
+#define DELEGATE_HALIDE_DELEGATE_H_
+
+#include "tensorflow/lite/c/c_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Use HalideDelegateOptionsDefault() for Default options.
+struct TFL_CAPI_EXPORT HalideDelegateOptions {
+    // The max number of threads to use in Halide.
+    // 0 means use the default (typically, host-cpu-count).
+    //
+    // TODO: should we use TfLiteContext.recommended_num_threads instead?
+    int num_threads;
+
+#ifdef __cplusplus
+    HalideDelegateOptions()
+        : num_threads(1) {
+    }
+#endif
+};
+
+// Return a delegate that uses Halide interpret_nn for ops execution.
+// Must outlive the interpreter.
+TFL_CAPI_EXPORT
+TfLiteDelegate *HalideDelegateCreate(const HalideDelegateOptions *options);
+
+// Returns HalideDelegateOptions populated with default values.
+TFL_CAPI_EXPORT
+void HalideDelegateOptionsDefault(HalideDelegateOptions *options);
+
+// Do any needed cleanup and delete 'delegate'.
+TFL_CAPI_EXPORT
+void HalideDelegateDelete(TfLiteDelegate *delegate);
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // DELEGATE_HALIDE_DELEGATE_H_

--- a/apps/interpret_nn/delegate/halide_delegate_adaptor.cpp
+++ b/apps/interpret_nn/delegate/halide_delegate_adaptor.cpp
@@ -1,0 +1,69 @@
+#include <sstream>
+
+#include "delegate/halide_delegate.h"
+#include "tensorflow/lite/c/c_api.h"
+#include "util/error_util.h"
+
+namespace {
+
+template<typename T>
+bool ParseValue(const char *in, T &result) {
+    std::istringstream stream(in);
+    stream >> result;
+    if (!stream.eof() && !stream.good()) {
+        return false;
+    }
+    return true;
+}
+
+bool ParseOptions(char **options_keys,
+                  char **options_values,
+                  size_t num_options,
+                  HalideDelegateOptions *options) {
+    HalideDelegateOptionsDefault(options);
+
+    for (size_t i = 0; i < num_options; ++i) {
+        if (!strcmp(options_keys[i], "num_threads")) {
+            if (!ParseValue(options_values[i], options->num_threads)) {
+                LOG(WARNING) << "ParseOptions: malformed option " << options_keys[i] << "\n";
+                return false;
+            }
+        } else {
+            LOG(WARNING) << "ParseOptions: unknown option " << options_keys[i] << "\n";
+            return false;
+        }
+    }
+
+    return true;
+}
+
+}  // namespace
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Defines two symbols that need to be exported to use the TFLite external
+// delegate. See tensorflow/lite/delegates/external for details.
+TFL_CAPI_EXPORT TfLiteDelegate *tflite_plugin_create_delegate(char **options_keys,
+                                                              char **options_values,
+                                                              size_t num_options,
+                                                              void (*report_error)(const char *)) {
+    HalideDelegateOptions options;
+    if (!ParseOptions(options_keys, options_values, num_options, &options)) {
+        return nullptr;
+    }
+
+    LOG(INFO) << "HalideDelegate: num_threads set to "
+              << options.num_threads << ".";
+
+    return HalideDelegateCreate(&options);
+}
+
+TFL_CAPI_EXPORT void tflite_plugin_destroy_delegate(TfLiteDelegate *delegate) {
+    HalideDelegateDelete(delegate);
+}
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus

--- a/apps/interpret_nn/run_compare_on_device.sh
+++ b/apps/interpret_nn/run_compare_on_device.sh
@@ -17,10 +17,9 @@ export HL_TARGET=${HL_TARGET:-arm-64-android}
 
 export TFLITE_SHARED_LIBRARY=${TFLITE_SHARED_LIBRARY:-${APP_DIR}/bin/tflite-android/jni/arm64-v8a/libtensorflowlite_jni.so}
 
-BINARY_NAME=compare_vs_tflite
-BUILD_TARGET="bin/${HL_TARGET}/${BINARY_NAME}"
-BINARY_PATH="${APP_DIR}/${BUILD_TARGET}"
-DEVICE_DIR="/data/local/tmp/halide/compare_vs_tflite"
+BUILD_TARGETS="bin/${HL_TARGET}/compare_vs_tflite bin/${HL_TARGET}/libHalideDelegate.so"
+DEVICE_DIR=/data/local/tmp/halide/compare_vs_tflite
+BINARIES_TO_PUSH="${APP_DIR}/${BUILD_TARGET} ${APP_DIR}/${BUILD_TARGETS}"
 
 if [[ -n "${ANDROID_SERIAL}" ]]; then
   echo Using ANDROID_SERIAL=${ANDROID_SERIAL}
@@ -32,9 +31,14 @@ adb shell rm -rf "${DEVICE_DIR}"
 adb shell mkdir -p "${DEVICE_DIR}"
 
 echo Building...
-make -j `nproc` ${BUILD_TARGET} > /dev/null
+make -j `nproc` ${BUILD_TARGETS} > /dev/null
 
-adb push "${BINARY_PATH}" "${TFLITE_SHARED_LIBRARY}" "${DEVICE_DIR}/" > /dev/null
+adb push ${BUILD_TARGETS} ${TFLITE_SHARED_LIBRARY} ${DEVICE_DIR}/ > /dev/null
+
+if [ "$#" -eq 0 ]; then
+    echo "Specify at least one .tflite file to use."
+    exit 1
+fi
 
 adb push "$@" "${DEVICE_DIR}" > /dev/null
 
@@ -45,7 +49,7 @@ do
   FILES="${FILES} ${DEVICE_DIR}/${BASENAME}"
 done
 
-adb shell "LD_LIBRARY_PATH=${DEVICE_DIR}:${LD_LIBRARY_PATH} ${DEVICE_DIR}/${BINARY_NAME} ${FILES}"
+adb shell "LD_LIBRARY_PATH=${DEVICE_DIR}:${LD_LIBRARY_PATH} ${DEVICE_DIR}/compare_vs_tflite ${FILES}"
 
 echo
 echo All comparisons complete.

--- a/apps/interpret_nn/tflite/tflite_parser.cpp
+++ b/apps/interpret_nn/tflite/tflite_parser.cpp
@@ -226,6 +226,8 @@ public:
             options->dilation_w_factor(),
             options->dilation_h_factor(),
         };
+        // TODO: depth_multiplier is considered redundant and semi-deprecated;
+        // see buildin_op_data.h in tflite source for more info.
         int depth_multiplier = options->depth_multiplier();
         ActivationFunction activation =
             parse_activation_function(options->fused_activation_function());


### PR DESCRIPTION
This builds a TFLite delegate as a shared library, and modifies compare_vs_tflite (and run_compare_on_device) to run *three* ways by default:
- vs "plain" TFLite
- vs TFLite when using our Delegate
- calling our Halide code 'directly'

This is still very rough and has oodles of rough edges and TODOs for things that need improvement, but it does run mobilenetv2 correctly (on desktop and on android). Pushing this out as a PR to preserve work over vacation (and for Dillon to take a look if he likes) but no pressure to land this just yet -- it's still a WIP so it can wait to land if we like (or land now with the understanding that it's still very rough).