### PR TITLE
Don't allow CUDACapability80 on LLVM10

### DIFF
--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -546,7 +546,12 @@ string CodeGen_PTX_Dev::march() const {
 
 string CodeGen_PTX_Dev::mcpu() const {
     if (target.has_feature(Target::CUDACapability80)) {
+#if LLVM_VERSION >= 110
         return "sm_80";
+#else
+        user_error << "CUDACapability80 requires LLVM 11 or later.";
+        return "";
+#endif
     } else if (target.has_feature(Target::CUDACapability75)) {
         return "sm_75";
     } else if (target.has_feature(Target::CUDACapability70)) {
@@ -568,7 +573,12 @@ string CodeGen_PTX_Dev::mcpu() const {
 
 string CodeGen_PTX_Dev::mattrs() const {
     if (target.has_feature(Target::CUDACapability80)) {
+#if LLVM_VERSION >= 110
         return "+ptx70";
+#else
+        user_error << "CUDACapability80 requires LLVM 11 or later.";
+        return "";
+#endif
     } else if (target.has_feature(Target::CUDACapability70) ||
                target.has_feature(Target::CUDACapability75)) {
         return "+ptx60";

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -246,7 +246,13 @@ Target::Feature calculate_host_cuda_capability(Target t) {
     } else if (ver < 80) {
         return Target::CUDACapability75;
     } else {
+#if LLVM_VERSION >= 110
         return Target::CUDACapability80;
+#else
+        // We require LLVM11+ in order to generate for CUDACapability80,
+        // so don't ever return that capability here, even if present.
+        return Target::CUDACapability75;
+#endif
     }
 }
 
@@ -753,7 +759,13 @@ int Target::get_cuda_capability_lower_bound() const {
         return 75;
     }
     if (has_feature(Target::CUDACapability80)) {
+#if LLVM_VERSION >= 110
         return 80;
+#else
+        // We require LLVM11+ in order to generate for CUDACapability80,
+        // so don't ever return that capability here, even if present.
+        return 75;
+#endif
     }
     return 20;
 }
@@ -1061,9 +1073,15 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
     if (cuda_capability < 75) {
         output.features.reset(CUDACapability75);
     }
+#if LLVM_VERSION >= 110
     if (cuda_capability < 80) {
         output.features.reset(CUDACapability80);
     }
+#else
+    // We require LLVM11+ in order to generate for CUDACapability80,
+    // so don't ever return that capability here, even if present.
+    output.features.reset(CUDACapability80);
+#endif
 
     // Pick tight lower bound for HVX version. Use fall-through to clear redundant features
     int hvx_a = get_hvx_lower_bound(*this);


### PR DESCRIPTION
LLVM10 can't handle that version of Cuda; we never noticed till now because we didn't have a buildbot with a GPU that could handle it. Modify the sniffers to cap capability at 75 for LLVM10 builds, and fail with user errors if that capability is explicitly requested.