### PR TITLE
Add 11.1 as an acceptable LLVM version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2078,7 +2078,7 @@ $(BUILD_DIR)/clang_ok:
 	@exit 1
 endif
 
-ifneq (,$(findstring $(LLVM_VERSION_TIMES_10), 100 110 120))
+ifneq (,$(findstring $(LLVM_VERSION_TIMES_10), 100 110 111 120))
 LLVM_OK=yes
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -2054,6 +2054,10 @@ ifneq (,$(findstring clang version 11.0,$(CLANG_VERSION)))
 CLANG_OK=yes
 endif
 
+ifneq (,$(findstring clang version 11.1,$(CLANG_VERSION)))
+CLANG_OK=yes
+endif
+
 ifneq (,$(findstring clang version 12.0,$(CLANG_VERSION)))
 CLANG_OK=yes
 endif


### PR DESCRIPTION
Apparently 11.1 was released but our Makefile only allows for 11.0.