### PR TITLE
Upgrade pybind11 to 2.6.x

### DIFF
--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -4,15 +4,7 @@
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 
-# Adding PyBind11 to the build is the recommended way of integrating with CMake.
-# See: https://pybind11.readthedocs.io/en/stable/compiling.html
-
-# Configure pybind11 to use the same interpreter version as was detected above.
-message(STATUS "Directing pybind11 to Python3 executable ${Python3_EXECUTABLE}")
-set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
-
-# Keep the version in sync with requirements.txt and the Ubuntu 20.04 LTS package (python3-pybind11)
-set(PYBIND11_VER 2.5.0)
+set(PYBIND11_VER 2.6.0)
 find_package(pybind11 ${PYBIND11_VER} QUIET)
 if (NOT pybind11_FOUND)
     include(FetchContent)

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 
-set(PYBIND11_VER 2.6.0)
+set(PYBIND11_VER 2.6.1)
 find_package(pybind11 ${PYBIND11_VER} QUIET)
 if (NOT pybind11_FOUND)
     include(FetchContent)

--- a/python_bindings/readme.md
+++ b/python_bindings/readme.md
@@ -45,19 +45,24 @@ with some differences where the C++ idiom is either inappropriate or impossible:
 ## Prerequisites
 
 The bindings (and demonstration applications) should work well for Python 3.4
-(or higher), on Linux and OSX platforms. Windows is not yet supported, but could
-be with CMake work. (We have dropped support for Python 2.x and will not accept
-patches to re-enable it.)
+(or higher), on Linux and OSX platforms. Windows support is experimental, and
+available through the CMake build.
 
 #### Python requirements:
 
-See requirements.txt (to be used with `pip`:
-`pip install --user requirements.txt`)
+The best way to get set up is to use a virtual environment:
+
+```console
+$ python3 -m venv venv
+$ . venv/bin/activate
+$ pip install -r requirements.txt 
+```
 
 #### C++ requirements:
 
 - Halide compiled to a distribution (e.g. `make distrib` or similar), with the
   `HALIDE_DISTRIB_PATH` env var pointing to it
+- If using CMake, simply set `-DWITH_PYTHON_BINDINGS=ON` from the main build. 
 
 ## Compilation instructions
 

--- a/python_bindings/requirements.txt
+++ b/python_bindings/requirements.txt
@@ -12,4 +12,4 @@ pillow
 # Keep versions of these requirements equal to the versions in Ubuntu 20.04 LTS
 # because newer versions fix bugs we work around.
 imageio==2.4.1
-pybind11==2.5.0
+pybind11==2.6.0

--- a/python_bindings/requirements.txt
+++ b/python_bindings/requirements.txt
@@ -12,4 +12,4 @@ pillow
 # Keep versions of these requirements equal to the versions in Ubuntu 20.04 LTS
 # because newer versions fix bugs we work around.
 imageio==2.4.1
-pybind11==2.6.0
+pybind11==2.6.1

--- a/python_bindings/src/CMakeLists.txt
+++ b/python_bindings/src/CMakeLists.txt
@@ -29,7 +29,7 @@ set(SOURCES
     PyVarOrRVar.cpp
     )
 
-pybind11_add_module(Halide_Python MODULE SYSTEM ${SOURCES})
+pybind11_add_module(Halide_Python MODULE ${SOURCES})
 add_library(Halide::Python ALIAS Halide_Python)
 set_target_properties(Halide_Python
                       PROPERTIES

--- a/python_bindings/src/PyHalide.cpp
+++ b/python_bindings/src/PyHalide.cpp
@@ -27,6 +27,9 @@
 static_assert(PYBIND11_VERSION_MAJOR == 2 && PYBIND11_VERSION_MINOR >= 6,
               "Halide requires PyBind 2.6+");
 
+static_assert(PY_VERSION_HEX >= 0x03000000,
+              "We appear to be compiling against Python 2.x rather than 3.x, which is not supported.");
+
 #ifndef HALIDE_PYBIND_MODULE_NAME
 #define HALIDE_PYBIND_MODULE_NAME halide
 #endif

--- a/python_bindings/src/PyHalide.cpp
+++ b/python_bindings/src/PyHalide.cpp
@@ -24,6 +24,9 @@
 #include "PyType.h"
 #include "PyVar.h"
 
+static_assert(PYBIND11_VERSION_MAJOR == 2 && PYBIND11_VERSION_MINOR >= 6,
+              "Halide requires PyBind 2.6+");
+
 #ifndef HALIDE_PYBIND_MODULE_NAME
 #define HALIDE_PYBIND_MODULE_NAME halide
 #endif

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -197,7 +197,9 @@ extern "C" PyObject *_halide_pystub_impl(const char *module_name, FactoryFunc fa
                      major, minor);
         return nullptr;
     }
-    auto m = pybind11::module(module_name);
+
+    // TODO: do something meaningful with the PyModuleDef & add a doc string
+    auto m = pybind11::module_::create_extension_module(module_name, nullptr, new PyModuleDef());
     try {
         Halide::PythonBindings::install_error_handlers(m);
         Halide::PythonBindings::pystub_init(m, factory);

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -757,7 +757,7 @@ std::string halide_type_to_c_type(const Type &t) {
 
 int generate_filter_main_inner(int argc, char **argv, std::ostream &cerr) {
     const char kUsage[] =
-        "gengen \n"
+        "gengen\n"
         "  [-g GENERATOR_NAME] [-f FUNCTION_NAME] [-o OUTPUT_DIR] [-r RUNTIME_NAME] [-d 1|0]\n"
         "  [-e EMIT_OPTIONS] [-n FILE_BASE_NAME] [-p PLUGIN_NAME] [-s AUTOSCHEDULER_NAME]\n"
         "       target=target-string[,target-string...] [generator_arg=value [...]]\n"

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -757,7 +757,7 @@ std::string halide_type_to_c_type(const Type &t) {
 
 int generate_filter_main_inner(int argc, char **argv, std::ostream &cerr) {
     const char kUsage[] =
-        "gengen\n"
+        "gengen \n"
         "  [-g GENERATOR_NAME] [-f FUNCTION_NAME] [-o OUTPUT_DIR] [-r RUNTIME_NAME] [-d 1|0]\n"
         "  [-e EMIT_OPTIONS] [-n FILE_BASE_NAME] [-p PLUGIN_NAME] [-s AUTOSCHEDULER_NAME]\n"
         "       target=target-string[,target-string...] [generator_arg=value [...]]\n"


### PR DESCRIPTION
Users who have 2.6.0 installed system-wide run into an issue with a hack with a workaround etc. etc. in pybind11 that ultimately means it chokes on the `SYSTEM` argument to `pybind11_add_module` on v2.6 but not on v2.5.

Since we're already diverged from Ubuntu, we might as well upgrade to pybind11 2.6, which also happens to fix a bug that lets us remove one of our own awkward workarounds.