### PR TITLE
Shrink tile size to fit in Mac Mini GPU memory.

### DIFF
--- a/apps/unsharp/unsharp_generator.cpp
+++ b/apps/unsharp/unsharp_generator.cpp
@@ -62,6 +62,10 @@ public:
 
         // Schedule
         if (!auto_schedule) {
+            // Mac Minis have Intel GPUs that don't have enough memory to handle 32x32
+            // tiles. Use a smaller size here to avoid unexpected crashes.
+            const int tile_size = get_target().has_feature(Target::Metal) ? 16 : 32;
+
             if (get_target().has_gpu_feature()) {
                 // The timing of this schedule is oddly noisy. Runs
                 // from 0.4ms to 0.5ms on a 2060 RTX.  Oddly, the
@@ -69,7 +73,7 @@ public:
                 Var xi, yi;
                 output.compute_root()
                     .reorder(c, x, y)
-                    .gpu_tile(x, y, xi, yi, 32, 32)
+                    .gpu_tile(x, y, xi, yi, tile_size, tile_size)
                     .bound(c, 0, 3)
                     .unroll(c);
                 ratio.compute_at(output, xi);

--- a/apps/unsharp/unsharp_generator.cpp
+++ b/apps/unsharp/unsharp_generator.cpp
@@ -62,8 +62,9 @@ public:
 
         // Schedule
         if (!auto_schedule) {
-            // Mac Minis have Intel GPUs that don't have enough memory to handle 32x32
-            // tiles. Use a smaller size here to avoid unexpected crashes.
+            // Some Intel Mac Minis have GPUs that require tile sizes smaller than 32x32
+            // for this pipeline because they have too few registers. Drop to 16x16 to
+            // avoid unexpected crashes in CI.
             const int tile_size = get_target().has_feature(Target::Metal) ? 16 : 32;
 
             if (get_target().has_gpu_feature()) {


### PR DESCRIPTION
As discussed on Gitter, this schedule uses tile sizes that are too large for some macs. This change shrinks the tile size to 16x16 instead of 32x32 for the Metal API.