### PR TITLE
Add Lambda.cpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,6 +479,7 @@ SOURCE_FILES = \
   IRPrinter.cpp \
   IRVisitor.cpp \
   JITModule.cpp \
+  Lambda.cpp \
   Lerp.cpp \
   LICM.cpp \
   LLVM_Output.cpp \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -252,6 +252,7 @@ set(SOURCE_FILES
     IRPrinter.cpp
     IRVisitor.cpp
     JITModule.cpp
+    Lambda.cpp
     Lerp.cpp
     LICM.cpp
     LLVM_Output.cpp

--- a/src/Lambda.cpp
+++ b/src/Lambda.cpp
@@ -1,0 +1,41 @@
+#include "Lambda.h"
+
+namespace Halide {
+
+Func lambda(const Expr &e) {
+    Func f("lambda" + Internal::unique_name('_'));
+    f(_) = e;
+    return f;
+}
+
+Func lambda(const Var &x, const Expr &e) {
+    Func f("lambda" + Internal::unique_name('_'));
+    f(x) = e;
+    return f;
+}
+
+Func lambda(const Var &x, const Var &y, const Expr &e) {
+    Func f("lambda" + Internal::unique_name('_'));
+    f(x, y) = e;
+    return f;
+}
+
+Func lambda(const Var &x, const Var &y, const Var &z, const Expr &e) {
+    Func f("lambda" + Internal::unique_name('_'));
+    f(x, y, z) = e;
+    return f;
+}
+
+Func lambda(const Var &x, const Var &y, const Var &z, const Var &w, const Expr &e) {
+    Func f("lambda" + Internal::unique_name('_'));
+    f(x, y, z, w) = e;
+    return f;
+}
+
+Func lambda(const Var &x, const Var &y, const Var &z, const Var &w, const Var &v, const Expr &e) {
+    Func f("lambda" + Internal::unique_name('_'));
+    f(x, y, z, w, v) = e;
+    return f;
+}
+
+}  // namespace Halide

--- a/src/Lambda.h
+++ b/src/Lambda.h
@@ -13,61 +13,37 @@ namespace Halide {
 /** Create a zero-dimensional halide function that returns the given
  * expression. The function may have more dimensions if the expression
  * contains implicit arguments. */
-inline Func lambda(const Expr &e) {
-    Func f("lambda" + Internal::unique_name('_'));
-    f(_) = e;
-    return f;
-}
+Func lambda(const Expr &e);
 
 /** Create a 1-D halide function in the first argument that returns
  * the second argument. The function may have more dimensions if the
  * expression contains implicit arguments and the list of Var
  * arguments contains a placeholder ("_"). */
-inline Func lambda(const Var &x, const Expr &e) {
-    Func f("lambda" + Internal::unique_name('_'));
-    f(x) = e;
-    return f;
-}
+Func lambda(const Var &x, const Expr &e);
 
 /** Create a 2-D halide function in the first two arguments that
  * returns the last argument. The function may have more dimensions if
  * the expression contains implicit arguments and the list of Var
  * arguments contains a placeholder ("_"). */
-inline Func lambda(const Var &x, const Var &y, const Expr &e) {
-    Func f("lambda" + Internal::unique_name('_'));
-    f(x, y) = e;
-    return f;
-}
+Func lambda(const Var &x, const Var &y, const Expr &e);
 
 /** Create a 3-D halide function in the first three arguments that
  * returns the last argument.  The function may have more dimensions
  * if the expression contains implicit arguments and the list of Var
  * arguments contains a placeholder ("_"). */
-inline Func lambda(const Var &x, const Var &y, const Var &z, const Expr &e) {
-    Func f("lambda" + Internal::unique_name('_'));
-    f(x, y, z) = e;
-    return f;
-}
+Func lambda(const Var &x, const Var &y, const Var &z, const Expr &e);
 
 /** Create a 4-D halide function in the first four arguments that
  * returns the last argument. The function may have more dimensions if
  * the expression contains implicit arguments and the list of Var
  * arguments contains a placeholder ("_"). */
-inline Func lambda(const Var &x, const Var &y, const Var &z, const Var &w, const Expr &e) {
-    Func f("lambda" + Internal::unique_name('_'));
-    f(x, y, z, w) = e;
-    return f;
-}
+Func lambda(const Var &x, const Var &y, const Var &z, const Var &w, const Expr &e);
 
 /** Create a 5-D halide function in the first five arguments that
  * returns the last argument. The function may have more dimensions if
  * the expression contains implicit arguments and the list of Var
  * arguments contains a placeholder ("_"). */
-inline Func lambda(const Var &x, const Var &y, const Var &z, const Var &w, const Var &v, const Expr &e) {
-    Func f("lambda" + Internal::unique_name('_'));
-    f(x, y, z, w, v) = e;
-    return f;
-}
+Func lambda(const Var &x, const Var &y, const Var &z, const Var &w, const Var &v, const Expr &e);
 
 }  // namespace Halide
 


### PR DESCRIPTION
Functions/methods that are part of the Halide public API should (generally) not be inline, to ensure the function instantiation is always in libHalide.