### PR TITLE
Add Python & PyBind version checking to PyStubImpl.cpp

### DIFF
--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -13,6 +13,12 @@
 
 #include "Halide.h"
 
+static_assert(PYBIND11_VERSION_MAJOR == 2 && PYBIND11_VERSION_MINOR >= 6,
+              "Halide requires PyBind 2.6+");
+
+static_assert(PY_VERSION_HEX >= 0x03000000,
+              "We appear to be compiling against Python 2.x rather than 3.x, which is not supported.");
+
 namespace py = pybind11;
 
 using FactoryFunc = std::unique_ptr<Halide::Internal::GeneratorBase> (*)(const Halide::GeneratorContext &context);


### PR DESCRIPTION
It's built separately from the rest of the Python bindings and could get out of sync separately.