### PR TITLE
Remove all deprecated methods for Halide 12

### DIFF
--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -166,15 +166,6 @@ HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like) {
 
     return repeat_edge(Internal::func_like_to_func(func_like), object_bounds);
 }
-
-template<typename T, typename... Bounds,
-         typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
-HALIDE_ATTRIBUTE_DEPRECATED("Add braces around the bounds like so: {{a, b}, {c, d}}")
-HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like, Bounds &&... bounds) {
-    Region collected_bounds;
-    Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
-    return repeat_edge(Internal::func_like_to_func(func_like), collected_bounds);
-}
 // @}
 
 /** Impose a boundary condition such that the entire coordinate space is
@@ -205,15 +196,6 @@ HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like) {
     }
 
     return repeat_image(Internal::func_like_to_func(func_like), object_bounds);
-}
-
-template<typename T, typename... Bounds,
-         typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
-HALIDE_ATTRIBUTE_DEPRECATED("Add braces around the bounds like so: {{a, b}, {c, d}}")
-HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like, Bounds &&... bounds) {
-    Region collected_bounds;
-    Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
-    return repeat_image(Internal::func_like_to_func(func_like), collected_bounds);
 }
 
 /** Impose a boundary condition such that the entire coordinate space is
@@ -247,14 +229,6 @@ HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like) {
     return mirror_image(Internal::func_like_to_func(func_like), object_bounds);
 }
 
-template<typename T, typename... Bounds,
-         typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
-HALIDE_ATTRIBUTE_DEPRECATED("Add braces around the bounds like so: {{a, b}, {c, d}}")
-HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like, Bounds &&... bounds) {
-    Region collected_bounds;
-    Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
-    return mirror_image(Internal::func_like_to_func(func_like), collected_bounds);
-}
 // @}
 
 /** Impose a boundary condition such that the entire coordinate space is
@@ -290,14 +264,6 @@ HALIDE_NO_USER_CODE_INLINE Func mirror_interior(const T &func_like) {
     return mirror_interior(Internal::func_like_to_func(func_like), object_bounds);
 }
 
-template<typename T, typename... Bounds,
-         typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
-HALIDE_ATTRIBUTE_DEPRECATED("Add braces around the bounds like so: {{a, b}, {c, d}}")
-HALIDE_NO_USER_CODE_INLINE Func mirror_interior(const T &func_like, Bounds &&... bounds) {
-    Region collected_bounds;
-    Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
-    return mirror_interior(Internal::func_like_to_func(func_like), collected_bounds);
-}
 // @}
 
 }  // namespace BoundaryConditions

--- a/src/Dimension.h
+++ b/src/Dimension.h
@@ -72,11 +72,6 @@ public:
      * used by the auto-scheduler and/or the RunGen tool/ */
     Dimension set_estimate(Expr min, Expr extent);
 
-    HALIDE_ATTRIBUTE_DEPRECATED("Use set_estimate() instead")
-    Dimension set_bounds_estimate(Expr min, Expr extent) {
-        return set_estimate(std::move(min), std::move(extent));
-    }
-
     Expr min_estimate() const;
     Expr extent_estimate() const;
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -3048,25 +3048,6 @@ Realization Func::realize(const Target &target,
     return realize(std::vector<int>{}, target, param_map);
 }
 
-void Func::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
-                              const Target &target,
-                              const ParamMap &param_map) {
-    vector<int32_t> sizes;
-    if (x_size) {
-        sizes.push_back(x_size);
-    }
-    if (y_size) {
-        sizes.push_back(y_size);
-    }
-    if (z_size) {
-        sizes.push_back(z_size);
-    }
-    if (w_size) {
-        sizes.push_back(w_size);
-    }
-    infer_input_bounds(sizes, target, param_map);
-}
-
 void Func::infer_input_bounds(const std::vector<int32_t> &sizes,
                               const Target &target,
                               const ParamMap &param_map) {

--- a/src/Func.h
+++ b/src/Func.h
@@ -860,19 +860,6 @@ public:
     void infer_input_bounds(const std::vector<int32_t> &sizes,
                             const Target &target = get_jit_target_from_environment(),
                             const ParamMap &param_map = ParamMap::empty_map());
-    HALIDE_ATTRIBUTE_DEPRECATED("Call infer_input_bounds() with an explicit vector<int> instead")
-    void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0,
-                            const Target &target = get_jit_target_from_environment(),
-                            const ParamMap &param_map = ParamMap::empty_map());
-    // TODO: this is a temporary wrapper used to disambiguate the cases where
-    // a single-entry braced list would match the deprecated overload
-    // (rather than the vector overload); when the deprecated method is removed,
-    // this should be removed, too
-    void infer_input_bounds(const std::initializer_list<int> &sizes,
-                            const Target &target = get_jit_target_from_environment(),
-                            const ParamMap &param_map = ParamMap::empty_map()) {
-        infer_input_bounds(std::vector<int>{sizes}, target, param_map);
-    }
     void infer_input_bounds(Pipeline::RealizationArg outputs,
                             const Target &target = get_jit_target_from_environment(),
                             const ParamMap &param_map = ParamMap::empty_map());
@@ -1542,11 +1529,6 @@ public:
      * very different from the estimates specified. These estimates are used
      * only by the auto scheduler if the function is a pipeline output. */
     Func &set_estimate(const Var &var, const Expr &min, const Expr &extent);
-
-    HALIDE_ATTRIBUTE_DEPRECATED("Use set_estimate() instead")
-    Func &estimate(const Var &var, const Expr &min, const Expr &extent) {
-        return set_estimate(var, min, extent);
-    }
 
     /** Set (min, extent) estimates for all dimensions in the Func
      * at once; this is equivalent to calling `set_estimate(args()[n], min, extent)`

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1715,11 +1715,6 @@ public:
         return *this;
     }
 
-    HALIDE_ATTRIBUTE_DEPRECATED("Use set_estimate() instead")
-    GeneratorInput_Buffer<T> &estimate(const Var &var, const Expr &min, const Expr &extent) {
-        return set_estimate(var, min, extent);
-    }
-
     GeneratorInput_Buffer<T> &set_estimates(const Region &estimates) {
         this->check_gio_access();
         this->set_estimates_impl(estimates);
@@ -1878,11 +1873,6 @@ public:
         this->check_gio_access();
         this->set_estimate_impl(var, min, extent);
         return *this;
-    }
-
-    HALIDE_ATTRIBUTE_DEPRECATED("Use set_estimate() instead")
-    GeneratorInput_Func<T> &estimate(const Var &var, const Expr &min, const Expr &extent) {
-        return set_estimate(var, min, extent);
     }
 
     GeneratorInput_Func<T> &set_estimates(const Region &estimates) {
@@ -2196,12 +2186,6 @@ protected:
     }
 
 public:
-    HALIDE_ATTRIBUTE_DEPRECATED("Use set_estimate() instead")
-    GeneratorOutputBase &estimate(const Var &var, const Expr &min, const Expr &extent) {
-        this->as<Func>().set_estimate(var, min, extent);
-        return *this;
-    }
-
     /** Forward schedule-related methods to the underlying Func. */
     // @{
     HALIDE_FORWARD_METHOD(Func, add_trace_tag)
@@ -2611,11 +2595,6 @@ public:
             f.set_estimate(var, min, extent);
         }
         return *this;
-    }
-
-    HALIDE_ATTRIBUTE_DEPRECATED("Use set_estimate() instead")
-    GeneratorOutput_Func<T> &estimate(const Var &var, const Expr &min, const Expr &extent) {
-        return set_estimate(var, min, extent);
     }
 
     GeneratorOutput_Func<T> &set_estimates(const Region &estimates) {

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -1284,25 +1284,6 @@ void Pipeline::infer_input_bounds(RealizationArg outputs, const Target &target, 
     }
 }
 
-void Pipeline::infer_input_bounds(int x_size, int y_size, int z_size, int w_size,
-                                  const Target &target,
-                                  const ParamMap &param_map) {
-    vector<int32_t> sizes;
-    if (x_size) {
-        sizes.push_back(x_size);
-    }
-    if (y_size) {
-        sizes.push_back(y_size);
-    }
-    if (z_size) {
-        sizes.push_back(z_size);
-    }
-    if (w_size) {
-        sizes.push_back(w_size);
-    }
-    infer_input_bounds(sizes, target, param_map);
-}
-
 void Pipeline::infer_input_bounds(const std::vector<int32_t> &sizes,
                                   const Target &target,
                                   const ParamMap &param_map) {

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -520,19 +520,6 @@ public:
     void infer_input_bounds(const std::vector<int32_t> &sizes,
                             const Target &target = get_jit_target_from_environment(),
                             const ParamMap &param_map = ParamMap::empty_map());
-    HALIDE_ATTRIBUTE_DEPRECATED("Call infer_input_bounds() with an explicit vector<int> instead")
-    void infer_input_bounds(int x_size = 0, int y_size = 0, int z_size = 0, int w_size = 0,
-                            const Target &target = get_jit_target_from_environment(),
-                            const ParamMap &param_map = ParamMap::empty_map());
-    // TODO: this is a temporary wrapper used to disambiguate the cases where
-    // a single-entry braced list would match the deprecated overload
-    // (rather than the vector overload); when the deprecated method is removed,
-    // this should be removed, too
-    void infer_input_bounds(const std::initializer_list<int> &sizes,
-                            const Target &target = get_jit_target_from_environment(),
-                            const ParamMap &param_map = ParamMap::empty_map()) {
-        infer_input_bounds(std::vector<int>{sizes}, target, param_map);
-    }
     void infer_input_bounds(RealizationArg output,
                             const Target &target = get_jit_target_from_environment(),
                             const ParamMap &param_map = ParamMap::empty_map());


### PR DESCRIPTION
These were all marked as deprecated in Halide 11 (and probably Halide 10 too); let's go ahead and remove them in Halide 12.