### PR TITLE
Lower saturating arithmetic without widening

### DIFF
--- a/src/FindIntrinsics.cpp
+++ b/src/FindIntrinsics.cpp
@@ -632,7 +632,7 @@ Expr lower_saturating_sub(const Expr &a, const Expr &b) {
     internal_assert(a.type() == b.type());
     // Lower saturating add without using widening arithmetic, which may require
     // types that aren't supported.
-    return simplify(clamp(a, a.type().min() - max(b, 0), a.type().max() - min(b, 0))) - b;
+    return simplify(clamp(a, a.type().min() + max(b, 0), a.type().max() + min(b, 0))) - b;
 }
 
 Expr lower_halving_add(const Expr &a, const Expr &b) {

--- a/src/FindIntrinsics.cpp
+++ b/src/FindIntrinsics.cpp
@@ -623,12 +623,16 @@ Expr lower_rounding_shift_right(const Expr &a, const Expr &b) {
 
 Expr lower_saturating_add(const Expr &a, const Expr &b) {
     internal_assert(a.type() == b.type());
-    return saturating_narrow(widening_add(a, b));
+    // Lower saturating add without using widening arithmetic, which may require
+    // types that aren't supported.
+    return simplify(clamp(a, a.type().min() - min(b, 0), a.type().max() - max(b, 0))) + b;
 }
 
 Expr lower_saturating_sub(const Expr &a, const Expr &b) {
     internal_assert(a.type() == b.type());
-    return saturating_cast(a.type(), widening_sub(a, b));
+    // Lower saturating add without using widening arithmetic, which may require
+    // types that aren't supported.
+    return simplify(clamp(a, a.type().min() - max(b, 0), a.type().max() - min(b, 0))) - b;
 }
 
 Expr lower_halving_add(const Expr &a, const Expr &b) {
@@ -676,6 +680,12 @@ Expr lower_intrinsic(const Call *op) {
     } else if (op->is_intrinsic(Call::widening_sub)) {
         internal_assert(op->args.size() == 2);
         return lower_widening_sub(op->args[0], op->args[1]);
+    } else if (op->is_intrinsic(Call::saturating_add)) {
+        internal_assert(op->args.size() == 2);
+        return lower_saturating_add(op->args[0], op->args[1]);
+    } else if (op->is_intrinsic(Call::saturating_sub)) {
+        internal_assert(op->args.size() == 2);
+        return lower_saturating_sub(op->args[0], op->args[1]);
     } else if (op->is_intrinsic(Call::widening_shift_left)) {
         internal_assert(op->args.size() == 2);
         return lower_widening_shift_left(op->args[0], op->args[1]);

--- a/test/correctness/intrinsics.cpp
+++ b/test/correctness/intrinsics.cpp
@@ -14,10 +14,10 @@ void check(Expr test, Expr expected, Type required_type) {
     test = simplify(test);
     Expr result = find_intrinsics(test);
     if (!equal(result, expected) || required_type != expected.type()) {
-        std::cout << "failure!\n";
-        std::cout << "test: " << test << "\n";
-        std::cout << "result: " << result << "\n";
-        std::cout << "exepcted: " << expected << "\n";
+        std::cerr << "failure!\n";
+        std::cerr << "test: " << test << "\n";
+        std::cerr << "result: " << result << "\n";
+        std::cerr << "exepcted: " << expected << "\n";
         abort();
     }
 }
@@ -44,17 +44,17 @@ void check_saturating_add_sub() {
             int64_t reference_add = std::min(std::max(a + b, min_t), max_t);
             int64_t reference_sub = std::min(std::max(a - b, min_t), max_t);
             if (!can_prove(result_add == make_const(halide_t, reference_add))) {
-                std::cout << "failure!\n";
-                std::cout << "test: " << add << "\n";
-                std::cout << "result: " << result_add << "\n";
-                std::cout << "expected: " << reference_add << "\n";
+                std::cerr << "failure!\n";
+                std::cerr << "test: " << add << "\n";
+                std::cerr << "result: " << result_add << "\n";
+                std::cerr << "expected: " << reference_add << "\n";
                 abort();
             }
             if (!can_prove(result_sub == make_const(halide_t, reference_sub))) {
-                std::cout << "failure!\n";
-                std::cout << "test: " << sub << "\n";
-                std::cout << "result: " << result_sub << "\n";
-                std::cout << "expected: " << reference_sub << "\n";
+                std::cerr << "failure!\n";
+                std::cerr << "test: " << sub << "\n";
+                std::cerr << "result: " << result_sub << "\n";
+                std::cerr << "expected: " << reference_sub << "\n";
                 abort();
             }
         }

--- a/test/correctness/intrinsics.cpp
+++ b/test/correctness/intrinsics.cpp
@@ -26,7 +26,7 @@ void check(Expr test, Expr expected) {
     return check(test, expected, expected.type());
 }
 
-template <typename T>
+template<typename T>
 void check_saturating_add_sub() {
     const int64_t min_t = std::numeric_limits<T>::min();
     const int64_t max_t = std::numeric_limits<T>::max();


### PR DESCRIPTION
Also, we weren't handling it in lower_intrinsic (because CodeGen_LLVM has a good default handler for it, and we don't have coverage of saturating arithmetic in CodeGen_C).