### PR TITLE
FIx intermittent OSX Python crash

### DIFF
--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -38,8 +38,10 @@ OPTIMIZE ?= -O3
 # defining DEBUG + undefining NDEBUG gives extra debug info in PyBind11
 # OPTIMIZE ?= -g -DDEBUG=1 -UNDEBUG
 
-# Compiling with -fvisibility=hidden saves ~80k on optimized x64 builds
-CCFLAGS=$(shell $(PYTHON)-config --cflags) $(PYBIND11_CFLAGS) -I $(HALIDE_DISTRIB_PATH)/include -I $(ROOT_DIR) -std=c++11 $(FPIC) -fvisibility=hidden -fvisibility-inlines-hidden $(OPTIMIZE) $(CXXFLAGS)
+# Compiling with -fvisibility=hidden saves ~80k on optimized x64 builds.
+# It's critical to include -fno-omit-frame-pointer, otherwise introspection can
+# break in amusing ways.
+CCFLAGS=$(shell $(PYTHON)-config --cflags) $(PYBIND11_CFLAGS) -I $(HALIDE_DISTRIB_PATH)/include -I $(ROOT_DIR) -std=c++11 $(FPIC) -fvisibility=hidden -fvisibility-inlines-hidden -fno-omit-frame-pointer $(OPTIMIZE) $(CXXFLAGS)
 # Filter out a pointless warning present in some Python installs
 CCFLAGS := $(filter-out -Wstrict-prototypes,$(CCFLAGS))
 

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -755,8 +755,8 @@ public:
             // are small but nonnull (eg, 0x08). It's probably better to miss introspection
             // options here than to crash during compilation.
             if (address <= (uint64_t)0xff) {
-                debug(1) << "Skipping function because address is unlikely to be valid. (Did you set -fno-omit-frame-pointer everywhere?)\n";
-                continue;
+                debug(1) << "Bailing out because we found an obviously-bad address in the backtrace. (Did you set -fno-omit-frame-pointer everywhere?)\n";
+                return "";
             }
 
             const uint8_t *inst_ptr = (const uint8_t *)address;

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -750,11 +750,12 @@ public:
 
             debug(5) << "Considering address " << ((void *)address) << "\n";
 
-            // In some situations on OSX, we can get invalid addresses here that
-            // are small but nonnull (eg, 0x08). Skip everything tiny here on the
-            // assumption that it's just noise.
+            // In some situations on OSX (most notable, compiling with different
+            // setting for -fomit-frame-pointer), we can get invalid addresses here that
+            // are small but nonnull (eg, 0x08). It's probably better to miss introspection
+            // options here than to crash during compilation.
             if (address <= (uint64_t)0xff) {
-                debug(5) << "Skipping function because address is unlikely to be valid\n";
+                debug(1) << "Skipping function because address is unlikely to be valid. (Did you set -fno-omit-frame-pointer everywhere?)\n";
                 continue;
             }
 

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -750,6 +750,14 @@ public:
 
             debug(5) << "Considering address " << ((void *)address) << "\n";
 
+            // In some situations on OSX, we can get invalid addresses here that
+            // are small but nonnull (eg, 0x08). Skip everything tiny here on the
+            // assumption that it's just noise.
+            if (address <= (uint64_t)0xff) {
+                debug(5) << "Skipping function because address is unlikely to be valid\n";
+                continue;
+            }
+
             const uint8_t *inst_ptr = (const uint8_t *)address;
             if (inst_ptr[-5] == 0xe8) {
                 // The actual address of the call is probably 5 bytes


### PR DESCRIPTION
The OSX buildbot has been crashing intermittently on some python tests; debugging showed that in some situations, Introspection's calls to `backtrace()` include bogus addresses (eg 0x08), which cause segfaults when you try to inspect memory near them. The reasons for this aren't entirely clear -- for instance, it only seems to repeat reliably when using the Makefile rather than CMake, and only when doing an 'out-of-tree' build. Rather than try to run this to ground further, this PR just checks for address fields that seem obviously unreasonable (first 256 bytes of address space) and ignore them.