### PR TITLE
Allow Tensor to use an external memory allocation

### DIFF
--- a/apps/interpret_nn/test/op_test_helper.h
+++ b/apps/interpret_nn/test/op_test_helper.h
@@ -130,11 +130,13 @@ protected:
             quantization.dimension = 0;  // TODO -- do we use this?
             quantization.scale.push_back(td.scale);
             quantization.zero.push_back(td.zero_point);
+            Tensor::Access access = Tensor::ReadWrite;
             tensors.push_back(std::make_shared<Tensor>(td.name,
                                                        td.type,
                                                        std::move(shape),
                                                        std::move(data),
-                                                       std::move(quantization)));
+                                                       std::move(quantization),
+                                                       access));
             tensors.back()->allocate();
 
             if (td.init_fn == nullptr) {


### PR DESCRIPTION
For the TFLite Delegate, Tensors which are inputs or outputs don't need their own allocation (TFLite will do that for us); we should just point at the shared memory, which will save memory allocation, plus the time to copy between TFLite and our memory.

Note that the 'read-only' inputs work basically the same as before, but for normal inputs and outputs, we must update the pointers in the Eval() method of the delegate, as they aren't guaranteed to be valid prior to then. (This is still substantially cheaper than copying the memory entirely.)

I've left the code in the delegate marked with USE_EXTERNAL_TENSORS for now, to make the change a bit clearer. It's not intended to be a long-term flag.

From local benchmarking on my Mac laptop, I don't see a meaningful performance difference for mobilenet_v2. (I haven't measured memory usage but it definitely will be lower.)