### PR TITLE
Remove deprecated variants of infer_input_bounds() in the Python bindings

### DIFF
--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -273,28 +273,6 @@ void define_func(py::module &m) {
             .def("output_buffers", &Func::output_buffers)
 
             .def(
-                "infer_input_bounds", [](Func &f, int x_size, int y_size, int z_size, int w_size, const Target &target) -> void {
-                    PyErr_WarnEx(PyExc_DeprecationWarning,
-                                 "Call infer_input_bounds() with an explicit list of ints instead.",
-                                 1);
-                    std::vector<int32_t> sizes;
-                    if (x_size) {
-                        sizes.push_back(x_size);
-                    }
-                    if (y_size) {
-                        sizes.push_back(y_size);
-                    }
-                    if (z_size) {
-                        sizes.push_back(z_size);
-                    }
-                    if (w_size) {
-                        sizes.push_back(w_size);
-                    }
-                    f.infer_input_bounds(sizes, target);
-                },
-                py::arg("x_size") = 0, py::arg("y_size") = 0, py::arg("z_size") = 0, py::arg("w_size") = 0, py::arg("target") = get_jit_target_from_environment())
-
-            .def(
                 "infer_input_bounds", [](Func &f, const py::object &dst, const Target &target) -> void {
                     // dst could be Buffer<>, vector<Buffer>, or vector<int>
                     try {

--- a/python_bindings/src/PyPipeline.cpp
+++ b/python_bindings/src/PyPipeline.cpp
@@ -141,29 +141,6 @@ void define_pipeline(py::module &m) {
                 },
                 py::arg("x_size"), py::arg("y_size"), py::arg("z_size"), py::arg("w_size"), py::arg("target") = Target())
 
-            // TODO: deprecate/remove when the C++ non-vector version of this API is removed
-            .def(
-                "infer_input_bounds", [](Pipeline &p, int x_size, int y_size, int z_size, int w_size, const Target &target) -> void {
-                    PyErr_WarnEx(PyExc_DeprecationWarning,
-                                 "Call infer_input_bounds() with an explicit list of ints instead.",
-                                 1);
-                    std::vector<int32_t> sizes;
-                    if (x_size) {
-                        sizes.push_back(x_size);
-                    }
-                    if (y_size) {
-                        sizes.push_back(y_size);
-                    }
-                    if (z_size) {
-                        sizes.push_back(z_size);
-                    }
-                    if (w_size) {
-                        sizes.push_back(w_size);
-                    }
-                    p.infer_input_bounds(sizes, target);
-                },
-                py::arg("x_size") = 0, py::arg("y_size") = 0, py::arg("z_size") = 0, py::arg("w_size") = 0, py::arg("target") = get_jit_target_from_environment())
-
             .def(
                 "infer_input_bounds", [](Pipeline &p, const py::object &dst, const Target &target) -> void {
                     // dst could be Buffer<>, vector<Buffer>, or vector<int>


### PR DESCRIPTION
The C++ versions were removed for Halide 12 already, but I missed the Python wrappers.