### PR TITLE
Fix target detection for i686

### DIFF
--- a/cmake/HalideTargetHelpers.cmake
+++ b/cmake/HalideTargetHelpers.cmake
@@ -16,7 +16,7 @@ function(_Halide_cmake_target OUTVAR)
     # Get arch from CMake
     string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" arch)
     list(TRANSFORM arch REPLACE "^.*(x86|arm|mips|powerpc|hexagon|wasm|riscv).*$" "\\1")
-    list(TRANSFORM arch REPLACE "^i.?86.+$" "x86")
+    list(TRANSFORM arch REPLACE "^i.?86.*$" "x86")
     list(TRANSFORM arch REPLACE "^(amd|ia|em)64t?$" "x86")
     list(TRANSFORM arch REPLACE "^ppc(64(le)?)?$" "powerpc")
     list(TRANSFORM arch REPLACE "^aarch(64)?$" "arm")


### PR DESCRIPTION
User @calein in #5670 reported that `i686` was not getting detected properly as an `x86` target when our CMake code tries to translate the CMake environment into a Halide target.

This (ought to) fix that.