### PR TITLE
Deprecate old-style realize() methods

### DIFF
--- a/apps/fft/main.cpp
+++ b/apps/fft/main.cpp
@@ -107,8 +107,8 @@ int main(int argc, char **argv) {
         filtered_r2c = fft2d_c2r(dft_filtered, W, H, target, inv_desc);
     }
 
-    Buffer<float> result_c2c = filtered_c2c.realize(W, H, target);
-    Buffer<float> result_r2c = filtered_r2c.realize(W, H, target);
+    Buffer<float> result_c2c = filtered_c2c.realize({W, H}, target);
+    Buffer<float> result_r2c = filtered_r2c.realize({W, H}, target);
 
     for (int y = 0; y < H; y++) {
         for (int x = 0; x < W; x++) {
@@ -140,8 +140,8 @@ int main(int argc, char **argv) {
 
     Var rep("rep");
 
-    Buffer<float> re_in = lambda(x, y, 0.0f).realize(W, H);
-    Buffer<float> im_in = lambda(x, y, 0.0f).realize(W, H);
+    Buffer<float> re_in = lambda(x, y, 0.0f).realize({W, H});
+    Buffer<float> im_in = lambda(x, y, 0.0f).realize({W, H});
 
     printf("%12s %5s%11s%5s %5s%11s%5s\n", "", "", "Halide", "", "", "FFTW", "");
     printf("%12s %10s %10s %10s %10s %10s\n", "DFT type", "Time (us)", "MFLOP/s", "Time (us)", "MFLOP/s", "Ratio");
@@ -154,7 +154,7 @@ int main(int argc, char **argv) {
     c2c_in(x, y, rep) = {re_in(x, y), im_in(x, y)};
     Func bench_c2c = fft2d_c2c(c2c_in, W, H, -1, target, fwd_desc);
     bench_c2c.compile_to_lowered_stmt(output_dir + "c2c.html", bench_c2c.infer_arguments(), HTML);
-    Realization R_c2c = bench_c2c.realize(W, H, reps, target);
+    Realization R_c2c = bench_c2c.realize({W, H, reps}, target);
     // Write all reps to the same place in memory. This means the
     // output appears to be cached on all but the first
     // iteration. This seems to match the behavior of FFTW's benchmark
@@ -185,7 +185,7 @@ int main(int argc, char **argv) {
     r2c_in(x, y, rep) = re_in(x, y);
     Func bench_r2c = fft2d_r2c(r2c_in, W, H, target, fwd_desc);
     bench_r2c.compile_to_lowered_stmt(output_dir + "r2c.html", bench_r2c.infer_arguments(), HTML);
-    Realization R_r2c = bench_r2c.realize(W, H / 2 + 1, reps, target);
+    Realization R_r2c = bench_r2c.realize({W, H / 2 + 1, reps}, target);
     // Write all reps to the same place in memory. See notes on R_c2c.
     R_r2c[0].raw_buffer()->dim[2].stride = 0;
     R_r2c[1].raw_buffer()->dim[2].stride = 0;
@@ -211,7 +211,7 @@ int main(int argc, char **argv) {
     c2r_in(x, y, rep) = {re_in(x, y), im_in(x, y)};
     Func bench_c2r = fft2d_c2r(c2r_in, W, H, target, inv_desc);
     bench_c2r.compile_to_lowered_stmt(output_dir + "c2r.html", bench_c2r.infer_arguments(), HTML);
-    Realization R_c2r = bench_c2r.realize(W, H, reps, target);
+    Realization R_c2r = bench_c2r.realize({W, H, reps}, target);
     // Write all reps to the same place in memory. See notes on R_c2c.
     R_c2r[0].raw_buffer()->dim[2].stride = 0;
 

--- a/apps/onnx/onnx_converter.cc
+++ b/apps/onnx/onnx_converter.cc
@@ -1439,7 +1439,7 @@ Node convert_tile_node(
     // Evaluate repeats if possible to compute output_shape.
     try {
         Halide::Func tiles = repeats.rep;
-        Halide::Buffer<int64_t> realized_shape = tiles.realize(rank);
+        Halide::Buffer<int64_t> realized_shape = tiles.realize({rank});
         for (int i = 0; i < rank; ++i) {
             int64_t tiling_factor = realized_shape(i);
             output_shape.push_back(
@@ -3116,7 +3116,7 @@ Node convert_reshape_node(
     bool new_shape_known = false;
     try {
         Halide::Func mutable_func = new_shape.rep;
-        Halide::Buffer<int64_t> realized_shape = mutable_func.realize(output_rank);
+        Halide::Buffer<int64_t> realized_shape = mutable_func.realize({output_rank});
         int unknown_dim = -1;
         int64_t known_size = 1;
         for (int i = 0; i < output_rank; ++i) {

--- a/apps/onnx/onnx_converter_test.cc
+++ b/apps/onnx/onnx_converter_test.cc
@@ -31,7 +31,7 @@ static void test_abs() {
     Node converted = convert_node(abs_node, node_inputs);
 
     GOOGLE_CHECK_EQ(1, converted.outputs.size());
-    Halide::Buffer<float> output = converted.outputs[0].rep.realize(200);
+    Halide::Buffer<float> output = converted.outputs[0].rep.realize({200});
     for (int i = 0; i < 200; ++i) {
         EXPECT_EQ(output(i), std::abs(input(i)));
     }
@@ -57,7 +57,7 @@ static void test_activation_function() {
     Node converted = convert_node(relu_node, node_inputs);
 
     GOOGLE_CHECK_EQ(1, converted.outputs.size());
-    Halide::Buffer<float> output = converted.outputs[0].rep.realize(200);
+    Halide::Buffer<float> output = converted.outputs[0].rep.realize({200});
     for (int i = 0; i < 200; ++i) {
         EXPECT_EQ(output(i), std::max(input(i), 0.0f));
     }
@@ -86,7 +86,7 @@ static void test_cast() {
     Node converted = convert_node(cast_node, node_inputs);
 
     GOOGLE_CHECK_EQ(1, converted.outputs.size());
-    Halide::Buffer<float> output = converted.outputs[0].rep.realize(200);
+    Halide::Buffer<float> output = converted.outputs[0].rep.realize({200});
     for (int i = 0; i < 200; ++i) {
         EXPECT_EQ(output(i), static_cast<float>(input(i)));
     }
@@ -118,7 +118,7 @@ static void test_add() {
     Node converted = convert_node(add_node, node_inputs);
 
     GOOGLE_CHECK_EQ(1, converted.outputs.size());
-    Halide::Buffer<float> output = converted.outputs[0].rep.realize(200);
+    Halide::Buffer<float> output = converted.outputs[0].rep.realize({200});
     for (int i = 0; i < 200; ++i) {
         EXPECT_NEAR(output(i), in1(i) + in2(i), 1e-6);
     }
@@ -187,7 +187,7 @@ static void test_gemm() {
     Node converted = convert_node(add_node, node_inputs);
 
     GOOGLE_CHECK_EQ(1, converted.outputs.size());
-    Halide::Buffer<float> output = converted.outputs[0].rep.realize(32, 64);
+    Halide::Buffer<float> output = converted.outputs[0].rep.realize({32, 64});
 
     for (int i = 0; i < 32; ++i) {
         for (int j = 0; j < 64; ++j) {
@@ -332,7 +332,7 @@ static void test_where_broadcast() {
 
     Node converted = convert_node(where_node, node_inputs);
     GOOGLE_CHECK_EQ(1, converted.outputs.size());
-    Halide::Buffer<float> output = converted.outputs[0].rep.realize(2, 2, 2);
+    Halide::Buffer<float> output = converted.outputs[0].rep.realize({2, 2, 2});
 
     for (int i = 0; i < 2; ++i) {
         for (int j = 0; j < 2; ++j) {
@@ -376,7 +376,7 @@ static void test_concat() {
     Node converted = convert_node(concat_node, node_inputs);
 
     GOOGLE_CHECK_EQ(1, converted.outputs.size());
-    Halide::Buffer<float> output = converted.outputs[0].rep.realize(7 + 5, 3);
+    Halide::Buffer<float> output = converted.outputs[0].rep.realize({7 + 5, 3});
     for (int i = 0; i < 3; ++i) {
         for (int j = 0; j < 7; ++j) {
             EXPECT_EQ(in1(j, i), output(j, i));
@@ -406,7 +406,7 @@ static void test_constant_fill() {
 
     Node converted = convert_node(concat_node, {});
     GOOGLE_CHECK_EQ(1, converted.outputs.size());
-    Halide::Buffer<uint16_t> output = converted.outputs[0].rep.realize(3, 4);
+    Halide::Buffer<uint16_t> output = converted.outputs[0].rep.realize({3, 4});
     for (int i = 0; i < 3; ++i) {
         for (int j = 0; j < 4; ++j) {
             EXPECT_EQ(2u, output(i, j));
@@ -493,7 +493,7 @@ static void test_model() {
     EXPECT_EQ(21, output_size());
 
     Tensor shape = converted.outputs.at("output_shape");
-    Halide::Buffer<int64_t> output_shape = shape.rep.realize(2);
+    Halide::Buffer<int64_t> output_shape = shape.rep.realize({2});
     EXPECT_EQ(3, output_shape(0));
     EXPECT_EQ(7, output_shape(1));
 }

--- a/apps/onnx/onnx_converter_test.cc
+++ b/apps/onnx/onnx_converter_test.cc
@@ -288,7 +288,7 @@ static void test_sum() {
     Node converted = convert_node(sum_node, node_inputs);
 
     GOOGLE_CHECK_EQ(1, converted.outputs.size());
-    Halide::Buffer<float> output = converted.outputs[0].rep.realize(1, 3, 1, 11);
+    Halide::Buffer<float> output = converted.outputs[0].rep.realize({1, 3, 1, 11});
     for (int i = 0; i < 3; ++i) {
         for (int j = 0; j < 11; ++j) {
             float expected = 0.0f;

--- a/python_bindings/apps/interpolate.py
+++ b/python_bindings/apps/interpolate.py
@@ -174,7 +174,7 @@ def main():
     input_width, input_height = input_data.shape[:2]
 
     t0 = datetime.now()
-    output_image = interpolate.realize(input_width, input_height, 3)
+    output_image = interpolate.realize([input_width, input_height, 3])
     t1 = datetime.now()
 
     elapsed = (t1 - t0).total_seconds()

--- a/python_bindings/apps/local_laplacian.py
+++ b/python_bindings/apps/local_laplacian.py
@@ -197,7 +197,7 @@ def filter_test_image(local_laplacian, input):
 
     # do the actual computation
     input_width, input_height = input_data.shape[:2]
-    output_image = local_laplacian.realize(input_width, input_height, 3)
+    output_image = local_laplacian.realize([input_width, input_height, 3])
     output_data = np.asanyarray(output_image)
 
     # convert back to uint8

--- a/python_bindings/correctness/atomics.py
+++ b/python_bindings/correctness/atomics.py
@@ -9,7 +9,7 @@ def test_atomics():
     f[x] = 0
     f[hl.Expr(im[r])] += 1
     f.compute_root().update().atomic().parallel(r)
-    b = f.realize(5)
+    b = f.realize([5])
 
     ref = [0, 0, 0, 0, 0]
     for i in range(100):

--- a/python_bindings/correctness/autodiff.py
+++ b/python_bindings/correctness/autodiff.py
@@ -19,36 +19,36 @@ def test_autodiff():
 
     # gradient w.r.t. the initialization of f
     d_f_init = d[f]
-    d_f_init_buf = d_f_init.realize(3)
+    d_f_init_buf = d_f_init.realize([3])
     assert(d_f_init_buf[0] == 0.0)
     assert(d_f_init_buf[1] == 5.0)
     assert(d_f_init_buf[2] == 5.0)
     d_f_init = d[f]# test different interface
-    d_f_init_buf = d_f_init.realize(3)
+    d_f_init_buf = d_f_init.realize([3])
     assert(d_f_init_buf[0] == 0.0)
     assert(d_f_init_buf[1] == 5.0)
     assert(d_f_init_buf[2] == 5.0)
 
     # gradient w.r.t. the updated f
     d_f_update_0 = d[f, 0]
-    d_f_update_0_buf = d_f_update_0.realize(3)
+    d_f_update_0_buf = d_f_update_0.realize([3])
     assert(d_f_update_0_buf[0] == 5.0)
     assert(d_f_update_0_buf[1] == 5.0)
     assert(d_f_update_0_buf[2] == 5.0)
     d_f_update_0 = d[f, 0]
-    d_f_update_0_buf = d_f_update_0.realize(3)
+    d_f_update_0_buf = d_f_update_0.realize([3])
     assert(d_f_update_0_buf[0] == 5.0)
     assert(d_f_update_0_buf[1] == 5.0)
     assert(d_f_update_0_buf[2] == 5.0)
 
     # gradient w.r.t. the buffer
     d_b = d[b]
-    d_b_buf = d_b.realize(3)
+    d_b_buf = d_b.realize([3])
     assert(d_b_buf[0] == 0.0)
     assert(d_b_buf[1] == 5.0)
     assert(d_b_buf[2] == 5.0)
     d_b = d[b]
-    d_b_buf = d_b.realize(3)
+    d_b_buf = d_b.realize([3])
     assert(d_b_buf[0] == 0.0)
     assert(d_b_buf[1] == 5.0)
     assert(d_b_buf[2] == 5.0)

--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -36,7 +36,7 @@ def test_misused_and():
     f = hl.Func('f')
     try:
         f[x, y] = hl.print_when(x == 0 and y == 0, 0, "x=",x, "y=", y)
-        f.realize(10, 10)
+        f.realize([10, 10])
     except ValueError as e:
         assert 'cannot be converted to a bool' in str(e)
     else:
@@ -48,7 +48,7 @@ def test_misused_or():
     f = hl.Func('f')
     try:
         f[x, y] = hl.print_when(x == 0 or y == 0, 0, "x=",x, "y=", y)
-        f.realize(10, 10)
+        f.realize([10, 10])
     except ValueError as e:
         assert 'cannot be converted to a bool' in str(e)
     else:

--- a/python_bindings/correctness/float_precision_test.py
+++ b/python_bindings/correctness/float_precision_test.py
@@ -35,7 +35,7 @@ def test():
         x = hl.Var("x")
         f = hl.Func("f")
         f[x] = x * hl.f64(c) * (hl.f64(0.1) + hl.f64(0.2))
-        for i, hl_value in enumerate(numpy.asarray(f.realize(10))):
+        for i, hl_value in enumerate(numpy.asarray(f.realize([10]))):
             py_value = i * c * (0.1 + 0.2)
             check = math.isclose(hl_value, py_value)
             assert check, "{}[{}]: {} != {}".format(i, c, hl_value, py_value)

--- a/python_bindings/correctness/iroperator.py
+++ b/python_bindings/correctness/iroperator.py
@@ -44,7 +44,7 @@ def test_select():
                      x == 2, (x * 24),
                      x == 2, 999,  # should be ignored: first condition wins
                              x)
-    b = f.realize(4)
+    b = f.realize([4])
     assert b[0] == 31
     assert b[1] == 1
     assert b[2] == 48
@@ -54,7 +54,7 @@ def test_mux():
     c = hl.Var()
     f = hl.Func()
     f[c] = hl.mux(c, [123, 456, c])
-    b = f.realize(4)
+    b = f.realize([4])
     assert b[0] == 123
     assert b[1] == 456
     assert b[2] == 2
@@ -67,7 +67,7 @@ def test_mux_tuple():
     c = hl.Var()
     g[x] = (123, 456, x)
     f[x, c] = hl.mux(c, g[x])
-    b = f.realize(1, 4)
+    b = f.realize([1, 4])
     assert b[0, 0] == 123
     assert b[0, 1] == 456
     assert b[0, 2] == 0
@@ -80,7 +80,7 @@ def test_minmax():
                      (x == 2) | (x == 4), hl.i32(hl.min(hl.f32(x), hl.f32(3.2), x*hl.f32(2.1))),
                      x == 3,              hl.max(x, x * 3, 1, x * 4),
                                           x)
-    b = f.realize(5)
+    b = f.realize([5])
     assert b[0] == 0
     assert b[1] == 1,b[1]
     assert b[2] == 2

--- a/python_bindings/correctness/negate_test.py
+++ b/python_bindings/correctness/negate_test.py
@@ -9,8 +9,8 @@ def test_free_logical_not_function():
     not_f = hl.Func('not_f')
     not_f[x] = hl.logical_not(f[x])
 
-    f_out = f.realize(10)
-    not_f_out = not_f.realize(10)
+    f_out = f.realize([10])
+    not_f_out = not_f.realize([10])
 
     for i in range(10):
         assert f_out[i] == (i > 5)
@@ -26,8 +26,8 @@ def test_member_logical_not_function():
     not_f = hl.Func('not_f')
     not_f[x] = f[x].logical_not()
 
-    f_out = f.realize(10)
-    not_f_out = not_f.realize(10)
+    f_out = f.realize([10])
+    not_f_out = not_f.realize([10])
 
     for i in range(10):
         assert f_out[i] == (i > 5)

--- a/python_bindings/correctness/pystub.py
+++ b/python_bindings/correctness/pystub.py
@@ -175,7 +175,7 @@ def test_complexstub():
         untyped_buffer_output,
         static_compiled_buffer_output) = r
 
-    b = simple_output.realize(32, 32, 3, target)
+    b = simple_output.realize([32, 32, 3], target)
     assert b.type() == hl.Float(32)
     for x in range(32):
         for y in range(32):
@@ -184,7 +184,7 @@ def test_complexstub():
                 actual = b[x, y, c]
                 assert expected == actual, "Expected %s Actual %s" % (expected, actual)
 
-    b = tuple_output.realize(32, 32, 3, target)
+    b = tuple_output.realize([32, 32, 3], target)
     assert b[0].type() == hl.Float(32)
     assert b[1].type() == hl.Float(32)
     assert len(b) == 2
@@ -199,7 +199,7 @@ def test_complexstub():
 
     assert len(array_output) == 2
     for a in array_output:
-        b = a.realize(32, 32, target)
+        b = a.realize([32, 32], target)
         assert b.type() == hl.Int(16)
         for x in range(32):
             for y in range(32):
@@ -211,7 +211,7 @@ def test_complexstub():
     # is used within another Generator; this isn't yet implemented since there
     # isn't yet Python bindings for Generator authoring. This section
     # of the test may need revision at that point.
-    b = typed_buffer_output.realize(32, 32, 3, target)
+    b = typed_buffer_output.realize([32, 32, 3], target)
     assert b.type() == hl.Float(32)
     for x in range(32):
         for y in range(32):
@@ -220,7 +220,7 @@ def test_complexstub():
                 actual = b[x, y, c]
                 assert expected == actual, "Expected %s Actual %s" % (expected, actual)
 
-    b = untyped_buffer_output.realize(32, 32, 3, target)
+    b = untyped_buffer_output.realize([32, 32, 3], target)
     assert b.type() == hl.UInt(8)
     for x in range(32):
         for y in range(32):
@@ -229,7 +229,7 @@ def test_complexstub():
                 actual = b[x, y, c]
                 assert expected == actual, "Expected %s Actual %s" % (expected, actual)
 
-    b = static_compiled_buffer_output.realize(4, 4, 1, target)
+    b = static_compiled_buffer_output.realize([4, 4, 1], target)
     assert b.type() == hl.UInt(8)
     for x in range(4):
         for y in range(4):

--- a/python_bindings/correctness/rdom.py
+++ b/python_bindings/correctness/rdom.py
@@ -14,8 +14,8 @@ def test_rdom():
     r.where(r.x <= r.y)
 
     diagonal[r.x, r.y] += 2
-    output = diagonal.realize(domain_width, domain_height)
-    
+    output = diagonal.realize([domain_width, domain_height])
+
     for iy in range(domain_height):
         for ix in range(domain_width):
             if ix <= iy:

--- a/python_bindings/correctness/tuple_select.py
+++ b/python_bindings/correctness/tuple_select.py
@@ -10,7 +10,7 @@ def test_tuple_select():
     f = hl.Func('f')
     f[x, y] = hl.tuple_select(x + y < 30, (x, y), (x-1, y-2))
 
-    a, b = f.realize(200, 200)
+    a, b = f.realize([200, 200])
     for xx in range(a.height()):
         for yy in range(a.width()):
             correct_a = xx if xx + yy < 30 else xx-1
@@ -22,7 +22,7 @@ def test_tuple_select():
     f = hl.Func('f')
     f[x, y] = hl.tuple_select((x < 30, y < 30), (x, y), (x-1, y-2))
 
-    a, b = f.realize(200, 200)
+    a, b = f.realize([200, 200])
     for xx in range(a.height()):
         for yy in range(a.width()):
             correct_a = xx if xx < 30 else xx-1
@@ -36,7 +36,7 @@ def test_tuple_select():
                               x + y < 100, (x-1, y-2),
                                            (x-100, y-200))
 
-    a, b = f.realize(200, 200)
+    a, b = f.realize([200, 200])
     for xx in range(a.height()):
         for yy in range(a.width()):
             correct_a = xx if xx + yy < 30 else xx-1 if xx + yy < 100 else xx - 100
@@ -50,7 +50,7 @@ def test_tuple_select():
                               (x < 100, y < 100), (x-1, y-2),
                                                   (x-100, y-200))
 
-    a, b = f.realize(200, 200)
+    a, b = f.realize([200, 200])
     for xx in range(a.height()):
         for yy in range(a.width()):
             correct_a = xx if xx < 30 else xx-1 if xx < 100 else xx - 100

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -136,35 +136,43 @@ void define_func(py::module &m) {
                 },
                 py::arg("sizes") = std::vector<int32_t>{}, py::arg("target") = Target())
 
-            // TODO: deprecate in favor of std::vector<int32_t> size version?
             .def(
                 "realize",
                 [](Func &f, int x_size, const Target &target) -> py::object {
-                    return realization_to_object(f.realize(x_size, target));
+                    PyErr_WarnEx(PyExc_DeprecationWarning,
+                                 "Call realize() with an explicit list of ints instead.",
+                                 1);
+                    return realization_to_object(f.realize(std::vector<int32_t>{x_size}, target));
                 },
                 py::arg("x_size"), py::arg("target") = Target())
 
-            // TODO: deprecate in favor of std::vector<int32_t> size version?
             .def(
                 "realize",
                 [](Func &f, int x_size, int y_size, const Target &target) -> py::object {
-                    return realization_to_object(f.realize(x_size, y_size, target));
+                    PyErr_WarnEx(PyExc_DeprecationWarning,
+                                 "Call realize() with an explicit list of ints instead.",
+                                 1);
+                    return realization_to_object(f.realize({x_size, y_size}, target));
                 },
                 py::arg("x_size"), py::arg("y_size"), py::arg("target") = Target())
 
-            // TODO: deprecate in favor of std::vector<int32_t> size version?
             .def(
                 "realize",
                 [](Func &f, int x_size, int y_size, int z_size, const Target &target) -> py::object {
-                    return realization_to_object(f.realize(x_size, y_size, z_size, target));
+                    PyErr_WarnEx(PyExc_DeprecationWarning,
+                                 "Call realize() with an explicit list of ints instead.",
+                                 1);
+                    return realization_to_object(f.realize({x_size, y_size, z_size}, target));
                 },
                 py::arg("x_size"), py::arg("y_size"), py::arg("z_size"), py::arg("target") = Target())
 
-            // TODO: deprecate in favor of std::vector<int32_t> size version?
             .def(
                 "realize",
                 [](Func &f, int x_size, int y_size, int z_size, int w_size, const Target &target) -> py::object {
-                    return realization_to_object(f.realize(x_size, y_size, z_size, w_size, target));
+                    PyErr_WarnEx(PyExc_DeprecationWarning,
+                                 "Call realize() with an explicit list of ints instead.",
+                                 1);
+                    return realization_to_object(f.realize({x_size, y_size, z_size, w_size}, target));
                 },
                 py::arg("x_size"), py::arg("y_size"), py::arg("z_size"), py::arg("w_size"), py::arg("target") = Target())
 

--- a/python_bindings/src/PyPipeline.cpp
+++ b/python_bindings/src/PyPipeline.cpp
@@ -113,31 +113,39 @@ void define_pipeline(py::module &m) {
                 },
                 py::arg("sizes") = std::vector<int32_t>{}, py::arg("target") = Target())
 
-            // TODO: deprecate in favor of std::vector<int32_t> size version?
             .def(
                 "realize", [](Pipeline &p, int x_size, const Target &target) -> py::object {
-                    return realization_to_object(p.realize(x_size, target));
+                    PyErr_WarnEx(PyExc_DeprecationWarning,
+                                 "Call realize() with an explicit list of ints instead.",
+                                 1);
+                    return realization_to_object(p.realize(std::vector<int32_t>{x_size}, target));
                 },
                 py::arg("x_size"), py::arg("target") = Target())
 
-            // TODO: deprecate in favor of std::vector<int32_t> size version?
             .def(
                 "realize", [](Pipeline &p, int x_size, int y_size, const Target &target) -> py::object {
-                    return realization_to_object(p.realize(x_size, y_size, target));
+                    PyErr_WarnEx(PyExc_DeprecationWarning,
+                                 "Call realize() with an explicit list of ints instead.",
+                                 1);
+                    return realization_to_object(p.realize({x_size, y_size}, target));
                 },
                 py::arg("x_size"), py::arg("y_size"), py::arg("target") = Target())
 
-            // TODO: deprecate in favor of std::vector<int32_t> size version?
             .def(
                 "realize", [](Pipeline &p, int x_size, int y_size, int z_size, const Target &target) -> py::object {
-                    return realization_to_object(p.realize(x_size, y_size, z_size, target));
+                    PyErr_WarnEx(PyExc_DeprecationWarning,
+                                 "Call realize() with an explicit list of ints instead.",
+                                 1);
+                    return realization_to_object(p.realize({x_size, y_size, z_size}, target));
                 },
                 py::arg("x_size"), py::arg("y_size"), py::arg("z_size"), py::arg("target") = Target())
 
-            // TODO: deprecate in favor of std::vector<int32_t> size version?
             .def(
                 "realize", [](Pipeline &p, int x_size, int y_size, int z_size, int w_size, const Target &target) -> py::object {
-                    return realization_to_object(p.realize(x_size, y_size, z_size, w_size, target));
+                    PyErr_WarnEx(PyExc_DeprecationWarning,
+                                 "Call realize() with an explicit list of ints instead.",
+                                 1);
+                    return realization_to_object(p.realize({x_size, y_size, z_size, w_size}, target));
                 },
                 py::arg("x_size"), py::arg("y_size"), py::arg("z_size"), py::arg("w_size"), py::arg("target") = Target())
 

--- a/python_bindings/tutorial/lesson_01_basics.py
+++ b/python_bindings/tutorial/lesson_01_basics.py
@@ -65,7 +65,7 @@ def main():
     # resolution of the output image. Halide.h also provides a basic
     # templatized image type we can use. We'll make an 800 x 600
     # image.
-    output = gradient.realize(800, 600)
+    output = gradient.realize([800, 600])
     assert output.type() == hl.Int(32)
 
     # Halide does type inference for you. hl.Var objects represent

--- a/python_bindings/tutorial/lesson_02_input_image.py
+++ b/python_bindings/tutorial/lesson_02_input_image.py
@@ -82,7 +82,7 @@ def main():
     # smaller size. If we request a larger size Halide will throw an
     # error at runtime telling us we're trying to read out of bounds
     # on the input image.
-    output_image = brighter.realize(input.width(), input.height(), input.channels())
+    output_image = brighter.realize([input.width(), input.height(), input.channels()])
     assert output_image.type() == hl.UInt(8)
 
     # Save the output for inspection. It should look like a bright parrot.

--- a/python_bindings/tutorial/lesson_03_debugging_1.py
+++ b/python_bindings/tutorial/lesson_03_debugging_1.py
@@ -28,7 +28,7 @@ def main():
 
     # Realize the function to produce an output image. We'll keep it
     # very small for this lesson.
-    output = gradient.realize(8, 8)
+    output = gradient.realize([8, 8])
 
     # That line compiled and ran the pipeline. Try running this
     # lesson with the environment variable HL_DEBUG_CODEGEN set to

--- a/python_bindings/tutorial/lesson_04_debugging_2.py
+++ b/python_bindings/tutorial/lesson_04_debugging_2.py
@@ -25,7 +25,7 @@ def main():
 
     # Realize the function over an 8x8 region.
     print("Evaluating gradient")
-    output = gradient.realize(8, 8)
+    output = gradient.realize([8, 8])
 
     # This will print out all the times gradient(x, y) gets
     # evaluated.
@@ -56,7 +56,7 @@ def main():
     # on linux you can control it manually using the environment
     # variable HL_NUMTHREADS.
     print("\nEvaluating parallel_gradient")
-    parallel_gradient.realize(8, 8)
+    parallel_gradient.realize([8, 8])
 
     print("Success!")
     return 0

--- a/python_bindings/tutorial/lesson_05_scheduling_1.py
+++ b/python_bindings/tutorial/lesson_05_scheduling_1.py
@@ -31,7 +31,7 @@ def main():
         # slowly. x is the column and y is the row, so this is a
         # row-major traversal.
         print("Evaluating gradient row-major")
-        output = gradient.realize(4, 4)
+        output = gradient.realize([4, 4])
 
         # The equivalent C is:
         print("Equivalent C:")
@@ -72,7 +72,7 @@ def main():
         # traversal.
 
         print("Evaluating gradient column-major")
-        output = gradient.realize(4, 4)
+        output = gradient.realize([4, 4])
 
         print("Equivalent C:")
         for yy in range(4):
@@ -109,7 +109,7 @@ def main():
         # also added within the loops.
 
         print("Evaluating gradient with x split into x_outer and x_inner ")
-        output = gradient.realize(4, 4)
+        output = gradient.realize([4, 4])
 
         print("Equivalent C:")
         for yy in range(4):
@@ -144,7 +144,7 @@ def main():
         gradient.fuse(x, y, fused)
 
         print("Evaluating gradient with x and y fused")
-        output = gradient.realize(4, 4)
+        output = gradient.realize([4, 4])
 
         print("Equivalent C:")
         for fused in range(4 * 4):
@@ -183,7 +183,7 @@ def main():
         # gradient.tile(x, y, x_outer, y_outer, x_inner, y_inner, 2, 2)
 
         print("Evaluating gradient in 2x2 tiles")
-        output = gradient.realize(4, 4)
+        output = gradient.realize([4, 4])
 
         print("Equivalent C:")
         for y_outer in range(2):
@@ -235,7 +235,7 @@ def main():
         # This time we'll evaluate over an 8x4 box, so that we have
         # more than one vector of work per scanline.
         print("Evaluating gradient with x_inner vectorized ")
-        output = gradient.realize(8, 4)
+        output = gradient.realize([8, 4])
 
         print("Equivalent C:")
         for yy in range(4):
@@ -281,7 +281,7 @@ def main():
         # gradient.unroll(x, 2)
 
         print("Evaluating gradient unrolled by a factor of two")
-        result = gradient.realize(4, 4)
+        result = gradient.realize([4, 4])
 
         print("Equivalent C:")
         for yy in range(4):
@@ -321,7 +321,7 @@ def main():
         gradient.split(x, x_outer, x_inner, 2)
 
         print("Evaluating gradient over a 5x4 box with x split by two ")
-        output = gradient.realize(5, 4)
+        output = gradient.realize([5, 4])
 
         print("Equivalent C:")
         for yy in range(4):
@@ -403,7 +403,7 @@ def main():
         #     .parallel(tile_index)
 
         print("Evaluating gradient tiles in parallel")
-        output = gradient.realize(4, 4)
+        output = gradient.realize([4, 4])
 
         # The tiles should occur in arbitrary order, but within each
         # tile the pixels will be traversed in row-major order.
@@ -465,7 +465,7 @@ def main():
         # If you like you can turn on tracing, but it's going to
         # produce a lot of prints. Instead we'll compute the answer
         # both in C and Halide and see if the answers match.
-        result = gradient_fast.realize(800, 600)
+        result = gradient_fast.realize([800, 600])
 
         print("Checking Halide result against equivalent C...")
         for tile_index in range(4 * 3):

--- a/python_bindings/tutorial/lesson_06_realizing_over_shifted_domains.py
+++ b/python_bindings/tutorial/lesson_06_realizing_over_shifted_domains.py
@@ -29,7 +29,7 @@ def main():
 
     # Previously we've realized gradient like so:
     #
-    # gradient.realize(8, 8)
+    # gradient.realize([8, 8])
     #
     # This does three things internally:
     # 1) Generates code than can evaluate gradient over an arbitrary

--- a/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
+++ b/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
@@ -55,7 +55,7 @@ def main():
 
         # Now let's realize it...
 
-        # result = output.realize(input.width(), input.height(), 3)
+        # result = output.realize([input.width(), input.height(), 3])
 
         # Except that the line above is not going to work. Uncomment
         # it to see what happens.
@@ -148,7 +148,7 @@ def main():
 
         # This time it's safe to evaluate the output over the some
         # domain as the input, because we have a boundary condition.
-        result = output.realize(input.width(), input.height(), 3)
+        result = output.realize([input.width(), input.height(), 3])
 
         # Save the result. It should look like a slightly blurry
         # parrot, but this time it will be the same size as the

--- a/python_bindings/tutorial/lesson_08_scheduling_2.py
+++ b/python_bindings/tutorial/lesson_08_scheduling_2.py
@@ -42,7 +42,7 @@ def main():
 
         # And evaluate it over a 5x5 box.
         print("\nEvaluating producer-consumer pipeline with default schedule")
-        consumer.realize(4, 4)
+        consumer.realize([4, 4])
 
         # There were no messages about computing values of the
         # producer. This is because the default schedule fully
@@ -97,7 +97,7 @@ def main():
 
         # Compile and run.
         print("\nEvaluating producer.compute_root()")
-        consumer.realize(4, 4)
+        consumer.realize([4, 4])
 
         # Reading the output we can see that:
         # A) There were stores to producer.
@@ -194,7 +194,7 @@ def main():
 
         # Compile and run.
         print("\nEvaluating producer.compute_at(consumer, y)")
-        consumer.realize(4, 4)
+        consumer.realize([4, 4])
 
         # Reading the log you should see that producer and consumer
         # alternate on a per-scanline basis. Let's look at the
@@ -264,7 +264,7 @@ def main():
         consumer.trace_stores()
 
         print("\nEvaluating producer.store_root().compute_at(consumer, y)")
-        consumer.realize(4, 4)
+        consumer.realize([4, 4])
 
         # Reading the log you should see that producer and consumer
         # again alternate on a per-scanline basis. It computes a 5x2
@@ -369,7 +369,7 @@ def main():
         consumer.trace_stores()
 
         print("\nEvaluating producer.store_root().compute_at(consumer, x)")
-        consumer.realize(4, 4)
+        consumer.realize([4, 4])
 
         # Reading the log, you should see that producer and consumer
         # now alternate on a per-pixel basis. Here's the equivalent C:
@@ -466,7 +466,7 @@ def main():
         print("\nEvaluating:"
               "consumer.tile(x, y, x_outer, y_outer, x_inner, y_inner, 2, 2)"
               "producer.compute_at(consumer, x_outer)")
-        consumer.realize(4, 4)
+        consumer.realize([4, 4])
 
         # Reading the log, you should see that producer and consumer
         # now alternate on a per-tile basis. Here's the equivalent C:
@@ -546,7 +546,7 @@ def main():
         # consumer.trace_stores()
         # producer.trace_stores()
 
-        halide_result = consumer.realize(800, 600)
+        halide_result = consumer.realize([800, 600])
 
         # Here's the equivalent (serial) C:
 

--- a/python_bindings/tutorial/lesson_09_update_definitions.py
+++ b/python_bindings/tutorial/lesson_09_update_definitions.py
@@ -85,7 +85,7 @@ def main():
         # We'll realize this one just to make sure it compiles. The
         # second-to-last definition forces us to realize over a
         # domain that is taller than it is wide.
-        f.realize(100, 101)
+        f.realize([100, 101])
 
         # For each realization of f, each step runs in its entirety
         # before the next one begins. Let's trace the loads and
@@ -98,7 +98,7 @@ def main():
         g.trace_loads()
         g.trace_stores()
 
-        g.realize(4, 4)
+        g.realize([4, 4])
 
         # Reading the log, we see that each pass is applied in turn. The
         # equivalent Python is:
@@ -140,7 +140,7 @@ def main():
         # domain" and using it inside an update definition:
         r = hl.RDom([(0, 50)])
         f[x, r] = f[x, r] * f[x, r]
-        halide_result = f.realize(100, 100)
+        halide_result = f.realize([100, 100])
 
         # The equivalent Python is:
         py_result = np.empty((100, 100), dtype=np.int)
@@ -184,7 +184,7 @@ def main():
         # input image at that point.
         histogram[input[r.x, r.y]] += 1
 
-        halide_result = histogram.realize(256)
+        halide_result = histogram.realize([256])
 
         # The equivalent Python is:
         py_result = np.empty((256), dtype=np.int)
@@ -235,7 +235,7 @@ def main():
         yo, yi = hl.Var("yo"), hl.Var("yi")
         f.update(1).split(y, yo, yi, 4).parallel(yo)
 
-        halide_result = f.realize(16, 16)
+        halide_result = f.realize([16, 16])
 
         # Here's the equivalent (serial) C:
         py_result = np.empty((16, 16), dtype=np.int)
@@ -284,7 +284,7 @@ def main():
         producer[x] = x * 17
         producer[x] += 1
         consumer[x] = 2 * producer[x]
-        halide_result = consumer.realize(10)
+        halide_result = consumer.realize([10])
 
         # The equivalent Python is:
         py_result = np.empty((10), dtype=np.int)
@@ -336,7 +336,7 @@ def main():
 
             producer.compute_at(consumer, x)
 
-            halide_result = consumer.realize(10)
+            halide_result = consumer.realize([10])
 
             # The equivalent Python is:
             py_result = np.empty((10), dtype=np.int)
@@ -382,7 +382,7 @@ def main():
             # the Vars of a hl.Func are shared across the pure and
             # update steps.
 
-            halide_result = consumer.realize(10)
+            halide_result = consumer.realize([10])
 
             # The equivalent Python is:
             py_result = np.empty((10), dtype=np.int)
@@ -417,7 +417,7 @@ def main():
             # redundant work occurs.
             producer.compute_at(consumer, x)
 
-            halide_result = consumer.realize(10)
+            halide_result = consumer.realize([10])
 
             # The equivalent Python is:
             py_result = np.empty((10), dtype=np.int)
@@ -476,7 +476,7 @@ def main():
             producer_wrapper_1.compute_at(consumer_2, x)
             producer_wrapper_2.compute_at(consumer_2, y)
 
-            halide_result = consumer_2.realize(10, 10)
+            halide_result = consumer_2.realize([10, 10])
 
             # The equivalent Python is:
             py_result = np.empty((10, 10), dtype=np.int)
@@ -524,7 +524,7 @@ def main():
 
             producer.compute_at(consumer, r)
 
-            halide_result = consumer.realize(10)
+            halide_result = consumer.realize([10])
 
             # The equivalent Python is:
             py_result = np.empty((10), dtype=np.int)
@@ -572,7 +572,7 @@ def main():
         blurry = hl.Func("blurry")
         blurry[x, y] = hl.cast(hl.UInt(8), local_sum[x, y] / 25)
 
-        halide_result = blurry.realize(input.width(), input.height())
+        halide_result = blurry.realize([input.width(), input.height()])
 
         # The default schedule will inline 'clamped' into the update
         # step of 'local_sum', because clamped only has a pure
@@ -631,8 +631,8 @@ def main():
         # So even though f1 references a reduction domain, it is a
         # pure function. The reduction domain has been swallowed to
         # define the inner anonymous reduction.
-        halide_result_1 = f1.realize(10)
-        halide_result_2 = f2.realize(10)
+        halide_result_1 = f1.realize([10])
+        halide_result_2 = f2.realize([10])
 
         # The equivalent Python is:
         py_result = np.empty((10), dtype=np.int)

--- a/python_bindings/tutorial/lesson_12_using_the_gpu.py
+++ b/python_bindings/tutorial/lesson_12_using_the_gpu.py
@@ -221,9 +221,9 @@ class MyPipeline:
     def test_correctness(self, reference_output):
 
         assert reference_output.type() == hl.UInt(8)
-        output = self.curved.realize(self.input.width(),
-                                     self.input.height(),
-                                     self.input.channels())
+        output = self.curved.realize([self.input.width(),
+                                      self.input.height(),
+                                      self.input.channels()])
         assert output.type() == hl.UInt(8)
 
         # Check against the reference output.

--- a/python_bindings/tutorial/lesson_13_tuples.py
+++ b/python_bindings/tutorial/lesson_13_tuples.py
@@ -84,7 +84,7 @@ def main():
     # Buffers. We call this a Realization. It's equivalent to a
     # std::vector of hl.Buffer/Image objects:
     if True:
-        im1, im2 = multi_valued.realize(80, 60)
+        im1, im2 = multi_valued.realize([80, 60])
         assert im1.type() == hl.Int(32)
         assert im2.type() == hl.Float(32)
         assert im1[30, 40] == 30 + 40
@@ -148,7 +148,7 @@ def main():
         # First we create an Image to take the argmax over.
         input_func = hl.Func()
         input_func[x] = hl.sin(x)
-        input = input_func.realize(100)
+        input = input_func.realize([100])
         assert input.type() == hl.Float(32)
 
         # Then we defined a 2-valued Tuple which tracks the maximum value
@@ -281,7 +281,7 @@ def main():
         escape[x, y] = first_escape[0]
 
         # Realize the pipeline and print the result as ascii art.
-        result = escape.realize(61, 25)
+        result = escape.realize([61, 25])
         assert result.type() == hl.Int(32)
         code = " .:-~*={&%#@"
         for yy in range(result.height()):

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -3038,16 +3038,6 @@ Realization Func::realize(int x_size, int y_size, const Target &target,
     return realize({x_size, y_size}, target, param_map);
 }
 
-Realization Func::realize(int x_size, const Target &target,
-                          const ParamMap &param_map) {
-    return realize(std::vector<int>{x_size}, target, param_map);
-}
-
-Realization Func::realize(const Target &target,
-                          const ParamMap &param_map) {
-    return realize(std::vector<int>{}, target, param_map);
-}
-
 void Func::infer_input_bounds(const std::vector<int32_t> &sizes,
                               const Target &target,
                               const ParamMap &param_map) {

--- a/src/Func.h
+++ b/src/Func.h
@@ -827,7 +827,7 @@ public:
     template<typename T, typename = typename std::enable_if<std::is_same<T, int>::value>::type>
     HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
     HALIDE_ALWAYS_INLINE Realization realize(T x_size, const Target &target = Target(),
-                        const ParamMap &param_map = ParamMap::empty_map()) {
+                                             const ParamMap &param_map = ParamMap::empty_map()) {
         return realize(std::vector<int32_t>{x_size}, target, param_map);
     }
     // @}

--- a/src/Func.h
+++ b/src/Func.h
@@ -780,7 +780,7 @@ public:
      params.set(img, arg_img);
 
      Target t = get_jit_target_from_environment();
-     Buffer<int32_t> result = f.realize(10, 10, t, params);
+     Buffer<int32_t> result = f.realize({10, 10}, t, params);
      \endcode
      *
      * Alternatively, an initializer list can be used
@@ -795,7 +795,7 @@ public:
      <fill in arg_img...>
 
      Target t = get_jit_target_from_environment();
-     Buffer<int32_t> result = f.realize(10, 10, t, { { p, 17 }, { img, arg_img } });
+     Buffer<int32_t> result = f.realize({10, 10}, t, { { p, 17 }, { img, arg_img } });
      \endcode
      *
      * If the Func cannot be realized into a buffer of the given size
@@ -810,18 +810,26 @@ public:
      *
      */
     // @{
-    Realization realize(std::vector<int32_t> sizes, const Target &target = Target(),
+    Realization realize(std::vector<int32_t> sizes = {}, const Target &target = Target(),
                         const ParamMap &param_map = ParamMap::empty_map());
+    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
     Realization realize(int x_size, int y_size, int z_size, int w_size, const Target &target = Target(),
                         const ParamMap &param_map = ParamMap::empty_map());
+    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
     Realization realize(int x_size, int y_size, int z_size, const Target &target = Target(),
                         const ParamMap &param_map = ParamMap::empty_map());
+    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
     Realization realize(int x_size, int y_size, const Target &target = Target(),
                         const ParamMap &param_map = ParamMap::empty_map());
-    Realization realize(int x_size, const Target &target = Target(),
-                        const ParamMap &param_map = ParamMap::empty_map());
-    Realization realize(const Target &target = Target(),
-                        const ParamMap &param_map = ParamMap::empty_map());
+
+    // Making this a template function is a trick: `{intliteral}` is a valid scalar initializer
+    // in C++, but we want it to match the vector call, not the (deprecated) scalar one.
+    template<typename T, typename = typename std::enable_if<std::is_same<T, int>::value>::type>
+    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
+    HALIDE_ALWAYS_INLINE Realization realize(T x_size, const Target &target = Target(),
+                        const ParamMap &param_map = ParamMap::empty_map()) {
+        return realize(std::vector<int32_t>{x_size}, target, param_map);
+    }
     // @}
 
     /** Evaluate this function into an existing allocated buffer or

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -2242,7 +2242,8 @@ void generator_test() {
         tester.call_generate();
         tester.call_schedule();
 
-        Buffer<float> im = tester_instance.realize(1);
+        Buffer<float> im = tester_instance.realize({1});
+        internal_assert(im.dimensions() == 1);
         internal_assert(im.dim(0).extent() == 1);
         internal_assert(im(0) == 1475.25f) << "Expected 1475.25 but saw " << im(0);
     }

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -765,19 +765,6 @@ Realization Pipeline::realize(int x_size, int y_size, const Target &target,
     return realize({x_size, y_size}, target, param_map);
 }
 
-Realization Pipeline::realize(int x_size, const Target &target,
-                              const ParamMap &param_map) {
-    // Use an explicit vector here, since {x_size} can be interpreted
-    // as a scalar initializer
-    vector<int32_t> v = {x_size};
-    return realize(v, target, param_map);
-}
-
-Realization Pipeline::realize(const Target &target,
-                              const ParamMap &param_map) {
-    return realize(vector<int32_t>(), target, param_map);
-}
-
 void Pipeline::add_requirement(const Expr &condition, std::vector<Expr> &error_args) {
     user_assert(defined()) << "Pipeline is undefined\n";
 

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -485,18 +485,26 @@ public:
 
     /** See Func::realize */
     // @{
-    Realization realize(std::vector<int32_t> sizes, const Target &target = Target(),
+    Realization realize(std::vector<int32_t> sizes = {}, const Target &target = Target(),
                         const ParamMap &param_map = ParamMap::empty_map());
+    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
     Realization realize(int x_size, int y_size, int z_size, int w_size, const Target &target = Target(),
                         const ParamMap &param_map = ParamMap::empty_map());
+    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
     Realization realize(int x_size, int y_size, int z_size, const Target &target = Target(),
                         const ParamMap &param_map = ParamMap::empty_map());
+    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
     Realization realize(int x_size, int y_size, const Target &target = Target(),
                         const ParamMap &param_map = ParamMap::empty_map());
-    Realization realize(int x_size, const Target &target = Target(),
-                        const ParamMap &param_map = ParamMap::empty_map());
-    Realization realize(const Target &target = Target(),
-                        const ParamMap &param_map = ParamMap::empty_map());
+
+    // Making this a template function is a trick: `{intliteral}` is a valid scalar initializer
+    // in C++, but we want it to match the vector call, not the (deprecated) scalar one.
+    template<typename T, typename = typename std::enable_if<std::is_same<T, int>::value>::type>
+    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
+    HALIDE_ALWAYS_INLINE Realization realize(T x_size, const Target &target = Target(),
+                        const ParamMap &param_map = ParamMap::empty_map()) {
+        return realize(std::vector<int32_t>{x_size}, target, param_map);
+    }
     // @}
 
     /** Evaluate this Pipeline into an existing allocated buffer or

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -502,7 +502,7 @@ public:
     template<typename T, typename = typename std::enable_if<std::is_same<T, int>::value>::type>
     HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
     HALIDE_ALWAYS_INLINE Realization realize(T x_size, const Target &target = Target(),
-                        const ParamMap &param_map = ParamMap::empty_map()) {
+                                             const ParamMap &param_map = ParamMap::empty_map()) {
         return realize(std::vector<int32_t>{x_size}, target, param_map);
     }
     // @}

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -89,7 +89,7 @@ public:
  RDom r(0, 10);
  f(x) = x; // the initial value
  f(r) = f(r) * 2;
- Buffer<int> result = f.realize(10);
+ Buffer<int> result = f.realize({10});
  \endcode
  *
  * This function creates a single-dimensional buffer of size 10, in

--- a/src/autoschedulers/li2018/test.py
+++ b/src/autoschedulers/li2018/test.py
@@ -24,7 +24,7 @@ def main():
     print(result.schedule_source)
 
     p.compile_jit() # compile
-    buf = p.realize(1000) # compute and get the buffer
+    buf = p.realize([1000]) # compute and get the buffer
 
 if __name__ == '__main__':
     main()

--- a/test/auto_schedule/cost_function.cpp
+++ b/test/auto_schedule/cost_function.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
     stencils[num_stencils - 1].print_loop_nest();
 
     // Run the schedule
-    p.realize(6204, 4604);
+    p.realize({6204, 4604});
 
     printf("Success!\n");
     return 0;

--- a/test/auto_schedule/data_dependent.cpp
+++ b/test/auto_schedule/data_dependent.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
     g.print_loop_nest();
 
     // Run the schedule
-    Buffer<uint16_t> out = p.realize(input.width() - 1, input.height());
+    Buffer<uint16_t> out = p.realize({input.width() - 1, input.height()});
 
     printf("Success!\n");
     return 0;

--- a/test/auto_schedule/large_window.cpp
+++ b/test/auto_schedule/large_window.cpp
@@ -52,7 +52,7 @@ int main(int argc, char **argv) {
     g.print_loop_nest();
 
     // Run the schedule
-    Buffer<uint16_t> out = p.realize(input.width(), input.height());
+    Buffer<uint16_t> out = p.realize({input.width(), input.height()});
 
     printf("Success!\n");
     return 0;

--- a/test/auto_schedule/overlap.cpp
+++ b/test/auto_schedule/overlap.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
     load_plugin(argv[1]);
 
     Var x("x"), y("y"), xi("xi"), yi("yi");
-    Buffer<float> input = lambda(x, y, sin(x) + cos(y) + 1.0f).realize(2200, 2200);
+    Buffer<float> input = lambda(x, y, sin(x) + cos(y) + 1.0f).realize({2200, 2200});
 
     int num_levels = 10;
 
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
     up[num_levels - 1].print_loop_nest();
 
     // Run the schedule
-    Buffer<float> out = p.realize(1500, 1500);
+    Buffer<float> out = p.realize({1500, 1500});
 
     printf("Success!\n");
 

--- a/test/auto_schedule/small_pure_update.cpp
+++ b/test/auto_schedule/small_pure_update.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
 
     // Ensure the autoscheduler doesn't try to RoundUp the pure loop
     // in g's update definition.
-    p.realize(13, 17);
+    p.realize({13, 17});
 
     printf("Success!\n");
     return 0;

--- a/test/auto_schedule/tile_vs_inline.cpp
+++ b/test/auto_schedule/tile_vs_inline.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
     g.print_loop_nest();
 
     // Run the schedule
-    Buffer<uint16_t> out = p.realize(input.width() - 2, input.height() - 2, 3);
+    Buffer<uint16_t> out = p.realize({input.width() - 2, input.height() - 2, 3});
 
     printf("Success!\n");
     return 0;

--- a/test/auto_schedule/unused_func.cpp
+++ b/test/auto_schedule/unused_func.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
     f.print_loop_nest();
 
     // Run the schedule
-    p.realize(256);
+    p.realize({256});
 
     printf("Success!\n");
     return 0;

--- a/test/auto_schedule/vectorize_var_in_update.cpp
+++ b/test/auto_schedule/vectorize_var_in_update.cpp
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
     h.print_loop_nest();
 
     // Run the schedule
-    Buffer<int> out = p.realize(50, 50);
+    Buffer<int> out = p.realize({50, 50});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/align_bounds.cpp
+++ b/test/correctness/align_bounds.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
 
         p.set(3);
         h.set_custom_trace(my_trace);
-        Buffer<int> result = h.realize(10);
+        Buffer<int> result = h.realize({10});
 
         for (int i = 0; i < 10; i++) {
             int correct = (i & 1) == 1 ? 6 : 22;
@@ -112,7 +112,7 @@ int main(int argc, char **argv) {
 
         p.set(3);
         h.set_custom_trace(my_trace);
-        Buffer<int> result = h.realize(10);
+        Buffer<int> result = h.realize({10});
 
         for (int i = 0; i < 10; i++) {
             int correct = (i & 1) == 1 ? 6 : 22;

--- a/test/correctness/assertion_failure_in_parallel_for.cpp
+++ b/test/correctness/assertion_failure_in_parallel_for.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
     split.set(11);
 
     g.set_error_handler(&halide_error);
-    g.realize(40, 40);
+    g.realize({40, 40});
 
     if (!error_occurred) {
         printf("There was supposed to be an error\n");

--- a/test/correctness/async.cpp
+++ b/test/correctness/async.cpp
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
         consumer.compute_root();
         producer.store_root().fold_storage(x, 8).compute_at(consumer, x).async();
 
-        Buffer<int> out = consumer.realize(16);
+        Buffer<int> out = consumer.realize({16});
 
         out.for_each_element([&](int x) {
             int correct = 2 * x - 1;

--- a/test/correctness/async.cpp
+++ b/test/correctness/async.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
         consumer.compute_root();
         producer.compute_root().async();
 
-        Buffer<int> out = consumer.realize(16, 16);
+        Buffer<int> out = consumer.realize({16, 16});
 
         out.for_each_element([&](int x, int y) {
             int correct = 2 * (x + y);
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
         consumer.compute_root();
         producer.store_root().fold_storage(x, 8, false).compute_at(consumer, x).async();
 
-        Buffer<int> out = consumer.realize(16);
+        Buffer<int> out = consumer.realize({16});
 
         out.for_each_element([&](int x) {
             int correct = -2 * x + 1;
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
         // Producer can run 5 scanlines ahead
         producer.store_root().fold_storage(y, 8).compute_at(consumer, y).async();
 
-        Buffer<int> out = consumer.realize(16, 16);
+        Buffer<int> out = consumer.realize({16, 16});
 
         out.for_each_element([&](int x, int y) {
             int correct = 2 * (x + y);
@@ -124,7 +124,7 @@ int main(int argc, char **argv) {
         // Producer can still run 5 scanlines ahead
         producer.store_root().fold_storage(y, 8).compute_at(consumer, x).async();
 
-        Buffer<int> out = consumer.realize(16, 16);
+        Buffer<int> out = consumer.realize({16, 16});
 
         out.for_each_element([&](int x, int y) {
             int correct = 2 * (x + y);
@@ -159,7 +159,7 @@ int main(int argc, char **argv) {
         // between the two scanlines, so we're a little conservative.
         producer.store_root().fold_storage(x, 8).fold_storage(y, 2).compute_at(consumer, x).async();
 
-        Buffer<int> out = consumer.realize(16, 16);
+        Buffer<int> out = consumer.realize({16, 16});
 
         out.for_each_element([&](int x, int y) {
             int correct = 2 * (x + y);
@@ -187,7 +187,7 @@ int main(int argc, char **argv) {
         producer_1.compute_root().async();
         producer_2.compute_root().async();
 
-        Buffer<int> out = consumer.realize(16, 16);
+        Buffer<int> out = consumer.realize({16, 16});
         out.for_each_element([&](int x, int y) {
             int correct = 2 * (x + y);
             if (out(x, y) != correct) {
@@ -214,7 +214,7 @@ int main(int argc, char **argv) {
         producer_2.compute_at(consumer, y).async();
         consumer.parallel(y);
 
-        Buffer<int> out = consumer.realize(16, 16);
+        Buffer<int> out = consumer.realize({16, 16});
         out.for_each_element([&](int x, int y) {
             int correct = 2 * (x + y);
             if (out(x, y) != correct) {
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
         producer_2.compute_at(consumer, x).store_at(consumer, y).async();
         consumer.parallel(y);
 
-        Buffer<int> out = consumer.realize(16, 16);
+        Buffer<int> out = consumer.realize({16, 16});
         out.for_each_element([&](int x, int y) {
             int correct = 2 * (x + y);
             if (out(x, y) != correct) {
@@ -267,7 +267,7 @@ int main(int argc, char **argv) {
         f1.compute_at(f2, y).async();
         f0.compute_at(f1, x).async();
 
-        Buffer<int> out = f2.realize(16, 16);
+        Buffer<int> out = f2.realize({16, 16});
         out.for_each_element([&](int x, int y) {
             int correct = 4 * (x + y);
             if (out(x, y) != correct) {
@@ -298,7 +298,7 @@ int main(int argc, char **argv) {
         consumer_1.store_root().compute_at(consumer_2, y).async();
         producer_1.store_at(consumer_2, y).compute_at(consumer_1, x).async();
 
-        Buffer<int> out = consumer_2.realize(16, 16);
+        Buffer<int> out = consumer_2.realize({16, 16});
         out.for_each_element([&](int x, int y) {
             int correct = 8 * (x + y);
             if (out(x, y) != correct) {
@@ -320,7 +320,7 @@ int main(int argc, char **argv) {
         consumer.compute_root();
         producer.store_root().fold_storage(y, 8).compute_at(consumer, y).async();
 
-        Buffer<int> out = consumer.realize(128, 128);
+        Buffer<int> out = consumer.realize({128, 128});
 
         out.for_each_element([&](int x, int y) {
             int correct = (x - 1 + std::min(y - 1, 15)) + (x + 1 + std::min(y + 1, 17));
@@ -345,7 +345,7 @@ int main(int argc, char **argv) {
         consumer.compute_root();
         producer.store_root().fold_storage(y, 8, false).compute_at(consumer, y).async();
 
-        Buffer<int> out = consumer.realize(128, 128);
+        Buffer<int> out = consumer.realize({128, 128});
 
         out.for_each_element([&](int x, int y) {
             int correct = (x - 1 - std::min(y - 1, 15)) + (x + 1 - std::min(y + 1, 17));
@@ -368,7 +368,7 @@ int main(int argc, char **argv) {
         consumer.compute_root();
         producer.store_root().fold_storage(y, 8).compute_at(consumer, y).async();
 
-        Buffer<int> out = consumer.realize(16, 64);
+        Buffer<int> out = consumer.realize({16, 64});
 
         out.for_each_element([&](int x, int y) {
             int correct = 4 * x + 8 * y + 2;
@@ -400,7 +400,7 @@ int main(int argc, char **argv) {
         consumer.compute_root().align_bounds(y, 2).unroll(y, 2);
         producer.store_root().fold_storage(y, 8).compute_at(consumer, y).async();
 
-        Buffer<int> out = consumer.realize(256, 256);
+        Buffer<int> out = consumer.realize({256, 256});
 
         out.for_each_element([&](int x, int y) {
             // Write it out as a 2x upsample followed by a [1 2 3
@@ -434,7 +434,7 @@ int main(int argc, char **argv) {
         consumer.compute_root();
         producer_friend.compute_at(producer, Var::outermost());
 
-        Buffer<int> out = consumer.realize(256, 256);
+        Buffer<int> out = consumer.realize({256, 256});
 
         out.for_each_element([&](int x, int y) {
             int correct = 2 * (x + y);

--- a/test/correctness/async_copy_chain.cpp
+++ b/test/correctness/async_copy_chain.cpp
@@ -5,7 +5,7 @@ using namespace Halide;
 Var x, y;
 
 void check(Func f) {
-    Buffer<int> out = f.realize(256, 256);
+    Buffer<int> out = f.realize({256, 256});
     out.for_each_element([&](int x, int y) {
         if (out(x, y) != x + y) {
             printf("out(%d, %d) = %d instead of %d\n", x, y, out(x, y), x + y);

--- a/test/correctness/async_device_copy.cpp
+++ b/test/correctness/async_device_copy.cpp
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
             frames.in().store_root().compute_at(avg, r).copy_to_device();
         }
 
-        Buffer<int> out = avg.realize(1024, 1024);
+        Buffer<int> out = avg.realize({1024, 1024});
 
         for (int y = 0; y < out.height(); y++) {
             for (int x = 0; x < out.width(); x++) {

--- a/test/correctness/atomic_tuples.cpp
+++ b/test/correctness/atomic_tuples.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
         Checker checker;
         g.add_custom_lowering_pass(&checker, []() {});
 
-        Buffer<int> out = g.realize(128, 128);
+        Buffer<int> out = g.realize({128, 128});
         for (int y = 0; y < 128; y++) {
             for (int x = 0; x < 128; x++) {
                 int correct = 2 * x + 2 * y;
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
         Checker checker;
         g.add_custom_lowering_pass(&checker, []() {});
 
-        Buffer<int> out = g.realize(128, 128);
+        Buffer<int> out = g.realize({128, 128});
         for (int y = 0; y < 128; y++) {
             for (int x = 0; x < 128; x++) {
                 int correct = 2 * x + 2 * y;
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
         Checker checker;
         g.add_custom_lowering_pass(&checker, []() {});
 
-        Buffer<int> out = g.realize(128, 128);
+        Buffer<int> out = g.realize({128, 128});
         for (int y = 0; y < 128; y++) {
             for (int x = 0; x < 128; x++) {
                 int correct = 2 * x + 2 * y + 1;
@@ -154,7 +154,7 @@ int main(int argc, char **argv) {
         Checker checker;
         g.add_custom_lowering_pass(&checker, []() {});
 
-        Buffer<int> out = g.realize(128, 128);
+        Buffer<int> out = g.realize({128, 128});
         for (int y = 0; y < 128; y++) {
             for (int x = 0; x < 128; x++) {
                 int correct = 4 * x + 4 * y;
@@ -201,7 +201,7 @@ int main(int argc, char **argv) {
         Checker checker;
         g.add_custom_lowering_pass(&checker, []() {});
 
-        Buffer<int> out = g.realize(128, 128);
+        Buffer<int> out = g.realize({128, 128});
         for (int y = 0; y < 128; y++) {
             for (int x = 0; x < 128; x++) {
                 int correct = 2 * x + 2 * y + 1;

--- a/test/correctness/atomics.cpp
+++ b/test/correctness/atomics.cpp
@@ -1174,7 +1174,7 @@ void test_async_tuple(const Backend &backend) {
 
     // Run 10 times to make sure race condition do not happen
     for (int iter = 0; iter < 10; iter++) {
-        Realization out = consumer1.realize({2} * img_size);
+        Realization out = consumer1.realize({2 * img_size});
         Buffer<int> out0 = out[0];
         Buffer<int> out1 = out[1];
         for (int i = 0; i < 2 * img_size; i++) {

--- a/test/correctness/atomics.cpp
+++ b/test/correctness/atomics.cpp
@@ -650,7 +650,7 @@ void test_hist_compute_at(const Backend &backend) {
 
     // Run 10 times to make sure race condition do happen
     for (int iter = 0; iter < 10; iter++) {
-        Buffer<T> out = final.realize(10, 10);
+        Buffer<T> out = final.realize({10, 10});
         for (int i = 0; i < 10; i++) {
             for (int j = 0; j < 10; j++) {
                 check(__LINE__, out(i, j), correct_final(i, j));
@@ -715,7 +715,7 @@ void test_hist_tuple_compute_at(const Backend &backend) {
 
     // Run 10 times to make sure race condition do happen
     for (int iter = 0; iter < 10; iter++) {
-        Realization out = final.realize(10, 10);
+        Realization out = final.realize({10, 10});
         Buffer<T> out0 = out[0];
         Buffer<T> out1 = out[1];
         for (int i = 0; i < 10; i++) {
@@ -798,7 +798,7 @@ void test_hist_store_at(const Backend &backend) {
 
     // Run 10 times to make sure race condition do happen
     for (int iter = 0; iter < 10; iter++) {
-        Buffer<T> out = final.realize(10, 10);
+        Buffer<T> out = final.realize({10, 10});
         for (int i = 0; i < 10; i++) {
             for (int j = 0; j < 10; j++) {
                 check(__LINE__, out(i, j), correct_final(i, j));
@@ -1174,7 +1174,7 @@ void test_async_tuple(const Backend &backend) {
 
     // Run 10 times to make sure race condition do not happen
     for (int iter = 0; iter < 10; iter++) {
-        Realization out = consumer1.realize(2 * img_size);
+        Realization out = consumer1.realize({2} * img_size);
         Buffer<int> out0 = out[0];
         Buffer<int> out1 = out[1];
         for (int i = 0; i < 2 * img_size; i++) {

--- a/test/correctness/atomics.cpp
+++ b/test/correctness/atomics.cpp
@@ -156,7 +156,7 @@ void test_parallel_hist(const Backend &backend) {
 
     // Run 10 times to make sure race condition do happen
     for (int iter = 0; iter < 10; iter++) {
-        Buffer<T> out = hist.realize(hist_size);
+        Buffer<T> out = hist.realize({hist_size});
         for (int i = 0; i < hist_size; i++) {
             check(__LINE__, out(i), correct(i));
         }
@@ -243,7 +243,7 @@ void test_parallel_cas_update(const Backend &backend) {
 
     // Run 10 times to make sure race condition do happen
     for (int iter = 0; iter < 10; iter++) {
-        Buffer<T> out = hist.realize(hist_size);
+        Buffer<T> out = hist.realize({hist_size});
         for (int i = 0; i < hist_size; i++) {
             check(__LINE__, out(i), correct(i));
         }
@@ -292,7 +292,7 @@ void test_parallel_hist_tuple(const Backend &backend) {
 
     // Run 10 times to make sure race condition do happen
     for (int iter = 0; iter < 10; iter++) {
-        Realization out = hist.realize(hist_size);
+        Realization out = hist.realize({hist_size});
         Buffer<T> out0 = out[0];
         Buffer<T> out1 = out[1];
         for (int i = 0; i < hist_size; i++) {
@@ -405,7 +405,7 @@ void test_predicated_hist(const Backend &backend) {
 
     // Run 10 times to make sure race condition do happen
     for (int iter = 0; iter < 10; iter++) {
-        Buffer<T> out = hist.realize(hist_size);
+        Buffer<T> out = hist.realize({hist_size});
         for (int i = 0; i < hist_size; i++) {
             check(__LINE__, out(i), correct(i));
         }
@@ -458,7 +458,7 @@ void test_parallel_hist_tuple2(const Backend &backend) {
 
     // Run 10 times to make sure race condition do happen
     for (int iter = 0; iter < 10; iter++) {
-        Realization out = hist.realize(hist_size);
+        Realization out = hist.realize({hist_size});
         Buffer<T> out0 = out[0];
         Buffer<T> out1 = out[1];
         for (int i = 0; i < hist_size; i++) {
@@ -886,7 +886,7 @@ void test_hist_rfactor(const Backend &backend) {
 
     // Run 10 times to make sure race condition do happen
     for (int iter = 0; iter < 10; iter++) {
-        Buffer<T> out = hist.realize(hist_size);
+        Buffer<T> out = hist.realize({hist_size});
         for (int i = 0; i < hist_size; i++) {
             check(__LINE__, out(i), correct(i));
         }
@@ -969,7 +969,7 @@ void test_hist_tuple_rfactor(const Backend &backend) {
 
     // Run 10 times to make sure race condition do happen
     for (int iter = 0; iter < 10; iter++) {
-        Realization out = hist.realize(hist_size);
+        Realization out = hist.realize({hist_size});
         Buffer<T> out0 = out[0];
         Buffer<T> out1 = out[1];
         for (int i = 0; i < hist_size; i++) {
@@ -1048,7 +1048,7 @@ void test_extern_func(const Backend &backend) {
 
     // Run 10 times to make sure race condition do happen
     for (int iter = 0; iter < 10; iter++) {
-        Buffer<int> out = hist.realize(hist_size);
+        Buffer<int> out = hist.realize({hist_size});
         for (int i = 0; i < hist_size; i++) {
             check(__LINE__, out(i), correct(i));
         }
@@ -1107,7 +1107,7 @@ void test_async(const Backend &backend) {
 
     // Run 10 times to make sure race condition do happen
     for (int iter = 0; iter < 10; iter++) {
-        Buffer<int> out = consumer.realize(hist_size);
+        Buffer<int> out = consumer.realize({hist_size});
         for (int i = 0; i < hist_size; i++) {
             check(__LINE__, out(i), correct(i));
         }

--- a/test/correctness/autodiff.cpp
+++ b/test/correctness/autodiff.cpp
@@ -205,9 +205,9 @@ void test_1d_box_no_clamp() {
     f_loss() += blur(r.x) * blur(r.x);
     Derivative d = propagate_adjoints(f_loss);
 
-    Buffer<float> blur_buf = blur.realize(2);
+    Buffer<float> blur_buf = blur.realize({2});
     // d loss / d blur = 2 * blur(x)
-    Buffer<float> d_blur_buf = d(blur).realize(3);
+    Buffer<float> d_blur_buf = d(blur).realize({3});
     check(__LINE__, d_blur_buf(0), 2 * blur_buf(0));
     check(__LINE__, d_blur_buf(1), 2 * blur_buf(1));
     check(__LINE__, d_blur_buf(2), 0.f);
@@ -215,7 +215,7 @@ void test_1d_box_no_clamp() {
     Func d_input = d(input);
     // Every dependency of d_input should only use pure variables in lhs
     _halide_user_assert(!has_non_pure_update(d_input)) << "Function has non pure update\n";
-    Buffer<float> d_input_buf = d_input.realize(4);
+    Buffer<float> d_input_buf = d_input.realize({4});
     check(__LINE__, d_input_buf(0), d_blur_buf(0));
     check(__LINE__, d_input_buf(1), d_blur_buf(0) + d_blur_buf(1));
     check(__LINE__, d_input_buf(2), d_blur_buf(1));
@@ -237,21 +237,21 @@ void test_1d_box() {
     f_loss() += blur(r.x) * blur(r.x);
     Derivative d = propagate_adjoints(f_loss);
 
-    Buffer<float> blur_buf = blur.realize(2);
+    Buffer<float> blur_buf = blur.realize({2});
     // d loss / d blur = 2 * blur(x)
-    Buffer<float> d_blur_buf = d(blur).realize(2);
+    Buffer<float> d_blur_buf = d(blur).realize({2});
     check(__LINE__, d_blur_buf(0), 2 * blur_buf(0));
     check(__LINE__, d_blur_buf(1), 2 * blur_buf(1));
     // d clamped(x) = d blur(x) + d blur(x - 1)
     Func d_clamped = d(clamped);
     // Every dependency of d_clamped should only use pure variables in lhs
     _halide_user_assert(!has_non_pure_update(d_clamped)) << "Function has non pure update\n";
-    Buffer<float> d_clamped_buf = d_clamped.realize(3);
+    Buffer<float> d_clamped_buf = d_clamped.realize({3});
     check(__LINE__, d_clamped_buf(0), d_blur_buf(0));
     check(__LINE__, d_clamped_buf(1), d_blur_buf(0) + d_blur_buf(1));
     check(__LINE__, d_clamped_buf(2), d_blur_buf(1));
     // d input(clamp(x, 0, 1)) = d clamped (x)
-    Buffer<float> d_input_buf = d(input).realize(2);
+    Buffer<float> d_input_buf = d(input).realize({2});
     check(__LINE__, d_input_buf(0), d_clamped_buf(0));
     check(__LINE__, d_input_buf(1), d_clamped_buf(1) + d_clamped_buf(2));
 }
@@ -278,9 +278,9 @@ void test_2d_box() {
     loss() += blur_y(r.x, r.y) * blur_y(r.x, r.y);
     Derivative d = propagate_adjoints(loss);
 
-    Buffer<float> blur_y_buf = blur_y.realize(5, 5);
+    Buffer<float> blur_y_buf = blur_y.realize({5, 5});
     // d loss / d blur_y = 2 * blur_y(x, y)
-    Buffer<float> d_blur_y_buf = d(blur_y).realize(5, 5);
+    Buffer<float> d_blur_y_buf = d(blur_y).realize({5, 5});
     const float eps = 1e-6f;
     for (int y = 0; y < 5; y++) {
         for (int x = 0; x < 5; x++) {
@@ -291,7 +291,7 @@ void test_2d_box() {
         }
     }
     // d loss / d blur_x = d blur_y(x, y) + d blur_y(x, y - 1) + d blur_y(x, y + 1)
-    Buffer<float> d_blur_x_buf = d(blur_x).realize(5, 5);
+    Buffer<float> d_blur_x_buf = d(blur_x).realize({5, 5});
     for (int y = 0; y < 5; y++) {
         for (int x = 0; x < 5; x++) {
             float target = d_blur_y_buf(x, y);
@@ -309,7 +309,7 @@ void test_2d_box() {
     Func d_clamped = d(clamped);
     // Every dependency of d_clamped should only use pure variables in lhs
     _halide_user_assert(!has_non_pure_update(d_clamped)) << "Function has non pure update\n";
-    Buffer<float> d_clamped_buf = d_clamped.realize(5, 5);
+    Buffer<float> d_clamped_buf = d_clamped.realize({5, 5});
     // d loss / d clamped = d blur_x(x, y) + d blur_x(x - 1, y) + d blur_x(x - 2, y)
     for (int y = 0; y < 5; y++) {
         for (int x = 0; x < 5; x++) {
@@ -344,9 +344,9 @@ void test_update() {
     f_loss() += blur(r.x) * blur(r.x);
     Derivative d = propagate_adjoints(f_loss);
 
-    Buffer<float> blur_buf = blur.realize(3);
+    Buffer<float> blur_buf = blur.realize({3});
     // d loss / d blur = 2 * blur(x)
-    Buffer<float> d_blur_buf = d(blur).realize(3);
+    Buffer<float> d_blur_buf = d(blur).realize({3});
 
     check(__LINE__, d_blur_buf(0), 2 * blur_buf(0));
     check(__LINE__, d_blur_buf(1), 2 * blur_buf(1));
@@ -354,7 +354,7 @@ void test_update() {
     Func d_clamped = d(clamped);
     // Every dependency of d_clamped should only use pure variables in lhs
     _halide_user_assert(!has_non_pure_update(d_clamped)) << "Function has non pure update\n";
-    Buffer<float> d_clamped_buf = d_clamped.realize(3);
+    Buffer<float> d_clamped_buf = d_clamped.realize({3});
     check(__LINE__, d_clamped_buf(0), d_blur_buf(0));
     check(__LINE__, d_clamped_buf(1), d_blur_buf(0) + d_blur_buf(1));
     check(__LINE__, d_clamped_buf(2), d_blur_buf(1) + d_blur_buf(2));
@@ -385,7 +385,7 @@ void test_nonlinear_update() {
 
     Func d_clamped = d(clamped);
     // d_clamp(x) = 2 * clamp(x) * d_update(x) + d_update(x - 1)
-    Buffer<float> d_clamped_buf = d_clamped.realize(3);
+    Buffer<float> d_clamped_buf = d_clamped.realize({3});
     check(__LINE__, d_clamped_buf(0), 2.f * input(0));
     check(__LINE__, d_clamped_buf(1), 2.f * input(1) + 1.f);
     check(__LINE__, d_clamped_buf(2), 2.f * input(2) + 1.f);
@@ -410,9 +410,9 @@ void test_rdom_conv() {
     Func f_loss("f_loss");
     f_loss() += convolved(r.x) * convolved(r.x);
     Derivative d = propagate_adjoints(f_loss);
-    Buffer<float> convolved_buf = convolved.realize(4);
+    Buffer<float> convolved_buf = convolved.realize({4});
     // d loss / d blur = 2 * blur(x)
-    Buffer<float> d_convolved_buf = d(convolved).realize(4);
+    Buffer<float> d_convolved_buf = d(convolved).realize({4});
     for (int i = 0; i < 4; i++) {
         check(__LINE__, d_convolved_buf(i), 2 * convolved_buf(i));
     }
@@ -420,7 +420,7 @@ void test_rdom_conv() {
     Func d_clamped = d(clamped);
     // Every dependency of d_clamped should only use pure variables in lhs
     _halide_user_assert(!has_non_pure_update(d_clamped)) << "Function has non pure update\n";
-    Buffer<float> d_clamped_buf = d_clamped.realize(4);
+    Buffer<float> d_clamped_buf = d_clamped.realize({4});
     for (int i = 0; i < 4; i++) {
         float target = d_convolved_buf(i) * kernel(0);
         if (i >= 1) {
@@ -433,7 +433,7 @@ void test_rdom_conv() {
     //      = 30 k0^2 + 72 k0k1 + 45 k1^2
     // d loss / d kernel(0) = 2 * k0 * 30 + 72 * k1
     // d loss / d kernel(1) = 72 * k0 + 90 * k1
-    Buffer<float> d_kernel = d(kernel).realize(2);
+    Buffer<float> d_kernel = d(kernel).realize({2});
     check(__LINE__, d_kernel(0), 60.f * kernel(0) + 72.f * kernel(1));
     check(__LINE__, d_kernel(1), 72.f * kernel(0) + 90.f * kernel(1));
 }
@@ -471,7 +471,7 @@ void test_horner_polynomial() {
     // d_poly(x, 6) = \sum_x x
     // d_poly(x, 5) = \sum_x x^2
     // ...
-    Buffer<float> d_coeffs = d(coeffs).realize(8);
+    Buffer<float> d_coeffs = d(coeffs).realize({8});
     for (int i = 0; i < 8; i++) {
         float d = 0.f;
         for (int j = 0; j < 1024; j++) {
@@ -520,7 +520,7 @@ void test_nonlinear_order_dependent_rdom() {
     din0 += df0;
     Buffer<float> loss_buf = loss.realize();
     check(__LINE__, loss_, loss_buf());
-    Buffer<float> d_in = d(in).realize(2);
+    Buffer<float> d_in = d(in).realize({2});
     check(__LINE__, d_in(0), din0);
     check(__LINE__, d_in(1), din1);
 }
@@ -541,7 +541,7 @@ void test_1d_to_2d() {
     // loss = 5i0^2 + 5i1^2
     // d loss / d i0 = 10i0 = 10
     // d loss / d i1 = 10i1 = 20
-    Buffer<float> d_output = d(output).realize(2, 2);
+    Buffer<float> d_output = d(output).realize({2, 2});
     check(__LINE__, d_output(0, 0), 2.f);
     check(__LINE__, d_output(1, 0), 4.f);
     check(__LINE__, d_output(0, 1), 4.f);
@@ -550,7 +550,7 @@ void test_1d_to_2d() {
     Func d_input = d(input);
     // Every dependency of d_input should only use pure variables in lhs
     _halide_user_assert(!has_non_pure_update(d_input)) << "Function has non pure update\n";
-    Buffer<float> d_input_buf = d_input.realize(2);
+    Buffer<float> d_input_buf = d_input.realize({2});
     check(__LINE__, d_input_buf(0), 10.f);
     check(__LINE__, d_input_buf(1), 20.f);
 }
@@ -593,15 +593,15 @@ void test_linear_resampling_1d() {
     //                    (1 - (i0[1] - floor(i0[1])))
     // d loss / d i1[2] = i0[1] - floor(i0[1])
 
-    Buffer<float> interpolate_buf = interpolate.realize(2);
+    Buffer<float> interpolate_buf = interpolate.realize({2});
     check(__LINE__, interpolate_buf(0), 1.3f);
     check(__LINE__, interpolate_buf(1), 3.6f);
 
-    Buffer<float> d_clamped0 = d(clamped0).realize(2);
+    Buffer<float> d_clamped0 = d(clamped0).realize({2});
     check(__LINE__, d_clamped0(0), 1.f);
     check(__LINE__, d_clamped0(1), 2.f);
 
-    Buffer<float> d_clamped1 = d(clamped1).realize(3);
+    Buffer<float> d_clamped1 = d(clamped1).realize({3});
     check(__LINE__, d_clamped1(0), 0.7f);
     check(__LINE__, d_clamped1(1), 0.5f);
     check(__LINE__, d_clamped1(2), 0.8f);
@@ -638,15 +638,15 @@ void test_linear_resampling_2d() {
     Derivative d = propagate_adjoints(loss);
 
     // Same as test_linear_resampling_1d()
-    Buffer<float> interpolate_buf = interpolate.realize(2, 1);
+    Buffer<float> interpolate_buf = interpolate.realize({2, 1});
     check(__LINE__, interpolate_buf(0, 0), 1.3f);
     check(__LINE__, interpolate_buf(1, 0), 3.6f);
 
-    Buffer<float> d_clamped0 = d(clamped0).realize(2, 1);
+    Buffer<float> d_clamped0 = d(clamped0).realize({2, 1});
     check(__LINE__, d_clamped0(0, 0), 1.f);
     check(__LINE__, d_clamped0(1, 0), 2.f);
 
-    Buffer<float> d_clamped1 = d(clamped1).realize(3, 1);
+    Buffer<float> d_clamped1 = d(clamped1).realize({3, 1});
     check(__LINE__, d_clamped1(0, 0), 0.7f);
     check(__LINE__, d_clamped1(1, 0), 0.5f);
     check(__LINE__, d_clamped1(2, 0), 0.8f);
@@ -673,7 +673,7 @@ void test_sparse_update() {
     loss() += output(r.x);
     Derivative d = propagate_adjoints(loss);
 
-    Buffer<float> d_input = d(input).realize(3);
+    Buffer<float> d_input = d(input).realize({3});
     check(__LINE__, d_input(0), 1.0f);
     check(__LINE__, d_input(1), 2.0f);
     check(__LINE__, d_input(2), 0.0f);
@@ -706,7 +706,7 @@ void test_histogram() {
     // d_output(2) -> d_k(1)
     // d_output(1) -> d_k(2)
     // d_output(3) -> d_k(3)
-    Buffer<float> d_k = d(k).realize(5);
+    Buffer<float> d_k = d(k).realize({5});
     check(__LINE__, d_k(0), 3.0f);
     check(__LINE__, d_k(1), 3.0f);
     check(__LINE__, d_k(2), 2.0f);
@@ -744,7 +744,7 @@ void test_histogram_no_bounds() {
     // d_output(2) -> d_k(1)
     // d_output(1) -> d_k(2)
     // d_output(3) -> d_k(3)
-    Buffer<float> d_k = d(k).realize(5);
+    Buffer<float> d_k = d(k).realize({5});
     check(__LINE__, d_k(0), 3.0f);
     check(__LINE__, d_k(1), 3.0f);
     check(__LINE__, d_k(2), 2.0f);
@@ -790,7 +790,7 @@ void test_multiple_updates_histogram() {
     // d_output(2) -> d_k(1) * 2
     // d_output(1) -> d_k(2) * 2
     // d_output(3) -> d_k(3) * 2
-    Buffer<float> d_k = d(k).realize(5);
+    Buffer<float> d_k = d(k).realize({5});
     check(__LINE__, d_k(0), 30.0f);
     check(__LINE__, d_k(1), 30.0f);
     check(__LINE__, d_k(2), 20.0f);
@@ -815,7 +815,7 @@ void test_rdom_update() {
     loss() += output(r_target);
     Derivative d = propagate_adjoints(loss);
 
-    Buffer<float> d_input = d(input).realize(3);
+    Buffer<float> d_input = d(input).realize({3});
     check(__LINE__, d_input(0), 2.0f);
     check(__LINE__, d_input(1), 1.0f);
     check(__LINE__, d_input(2), 0.0f);
@@ -835,8 +835,8 @@ void test_repeat_edge() {
     Derivative d = propagate_adjoints(loss);
     // loss = (i0 + i1) + (i1 + i1) + (i1 + i1) = i0 + 5 * i1
 
-    Buffer<float> d_blur_buf = blur.realize(3);
-    Buffer<float> d_input_buf = d(input).realize(2);
+    Buffer<float> d_blur_buf = blur.realize({3});
+    Buffer<float> d_input_buf = d(input).realize({2});
     // d loss / d i0 = 1
     // d loss / d i1 = 5
     check(__LINE__, d_input_buf(0), 1.f);
@@ -857,8 +857,8 @@ void test_constant_exterior() {
     Derivative d = propagate_adjoints(loss);
     // loss = (i0 + i1) + i1 = i0 + 2 * i1
 
-    Buffer<float> d_blur_buf = blur.realize(3);
-    Buffer<float> d_input_buf = d(input).realize(2);
+    Buffer<float> d_blur_buf = blur.realize({3});
+    Buffer<float> d_input_buf = d(input).realize({2});
     // d loss / d i0 = 1
     // d loss / d i1 = 2
     check(__LINE__, d_input_buf(0), 1.f);
@@ -879,8 +879,8 @@ void test_repeat_image() {
     Derivative d = propagate_adjoints(loss);
     // loss = (i0 + i1) + (i1 + i0) + (i0 + i1) = 3 * i0 + 3 * i1
 
-    Buffer<float> d_blur_buf = blur.realize(3);
-    Buffer<float> d_input_buf = d(input).realize(2);
+    Buffer<float> d_blur_buf = blur.realize({3});
+    Buffer<float> d_input_buf = d(input).realize({2});
     // d loss / d i0 = 3
     // d loss / d i1 = 3
     check(__LINE__, d_input_buf(0), 3.f);
@@ -901,8 +901,8 @@ void test_mirror_image() {
     Derivative d = propagate_adjoints(loss);
     // loss = (i0 + i1) + (i1 + i1) + (i1 + i0) = 2 * i0 + 4 * i1
 
-    Buffer<float> d_blur_buf = blur.realize(3);
-    Buffer<float> d_input_buf = d(input).realize(2);
+    Buffer<float> d_blur_buf = blur.realize({3});
+    Buffer<float> d_input_buf = d(input).realize({2});
     // d loss / d i0 = 2
     // d loss / d i1 = 4
     check(__LINE__, d_input_buf(0), 2.f);
@@ -923,8 +923,8 @@ void test_mirror_interior() {
     Derivative d = propagate_adjoints(loss);
     // loss = (i0 + i1) + (i1 + i0) + (i0 + i1) = 3 * i0 + 3 * i1
 
-    Buffer<float> d_blur_buf = blur.realize(3);
-    Buffer<float> d_input_buf = d(input).realize(2);
+    Buffer<float> d_blur_buf = blur.realize({3});
+    Buffer<float> d_input_buf = d(input).realize({2});
     // d loss / d i0 = 3
     // d loss / d i1 = 3
     check(__LINE__, d_input_buf(0), 3.f);
@@ -977,28 +977,28 @@ void test_second_order_conv() {
     loss1() += d_input(rl);
     Derivative d2 = propagate_adjoints(loss1);
 
-    Buffer<float> conv_buf = conv.realize(9);
-    Buffer<float> d_conv_buf = d(conv).realize(9);
+    Buffer<float> conv_buf = conv.realize({9});
+    Buffer<float> d_conv_buf = d(conv).realize({9});
     // d_conv(x) = 2 * (conv(x) - target(x))
     for (int i = 0; i < 9; i++) {
         check(__LINE__, d_conv_buf(i), 2.f * (conv_buf(i) - target(i)));
     }
     // d_input(x) = d_conv(x + 1) + d_conv(x) + d_conv(x - 1)
-    Buffer<float> d_input_buf = d_input.realize(10);
+    Buffer<float> d_input_buf = d_input.realize({10});
     check(__LINE__, d_input_buf(0), d_conv_buf(0) + d_conv_buf(1));
     for (int i = 1; i < 8; i++) {
         check(__LINE__, d_input_buf(i), d_conv_buf(i + 1) + d_conv_buf(i) + d_conv_buf(i - 1));
     }
     check(__LINE__, d_input_buf(8), d_conv_buf(7) + d_conv_buf(8));
     check(__LINE__, d_input_buf(9), d_conv_buf(8));
-    Buffer<float> d2_conv_buf = d2(conv).realize(9);
+    Buffer<float> d2_conv_buf = d2(conv).realize({9});
     // d2_conv(x) = 6
     for (int i = 0; i < 8; i++) {
         check(__LINE__, d2_conv_buf(i), 6.f);
     }
     check(__LINE__, d2_conv_buf(8), 4.f);
     // d2_input(x) = d2_conv(x + 1) + d2_conv(x) + d2_conv(x - 1)
-    Buffer<float> d2_input_buf = d2(input).realize(10);
+    Buffer<float> d2_input_buf = d2(input).realize({10});
     check(__LINE__, d2_input_buf(0), 2.f * d2_conv_buf(0) + d2_conv_buf(1));
     for (int i = 1; i <= 7; i++) {
         check(__LINE__, d2_input_buf(i), d2_conv_buf(i) + d2_conv_buf(i + 1) + d2_conv_buf(i - 1));
@@ -1022,13 +1022,13 @@ void test_implicit_vars() {
     Func d_input = d(input);
     // Every dependency of d_input should only use pure variables in lhs
     _halide_user_assert(!has_non_pure_update(d_input)) << "Function has non pure update\n";
-    Buffer<float> d_input_buf = d_input.realize(2);
+    Buffer<float> d_input_buf = d_input.realize({2});
     check(__LINE__, d_input_buf(0), 1.f);
     check(__LINE__, d_input_buf(1), 1.f);
     Func d_copy = d(copy);
     // Every dependency of d_copy should only use pure variables in lhs
     _halide_user_assert(!has_non_pure_update(d_copy)) << "Function has non pure update\n";
-    Buffer<float> d_copy_buf = d_copy.realize(2);
+    Buffer<float> d_copy_buf = d_copy.realize({2});
     check(__LINE__, d_copy_buf(0), 1.f);
     check(__LINE__, d_copy_buf(1), 1.f);
 }
@@ -1059,7 +1059,7 @@ void test_tuple() {
     Func d_tuple = d(tuple);
     // Every dependency of d_tuple should only use pure variables in lhs
     _halide_user_assert(!has_non_pure_update(d_tuple)) << "Function has non pure update\n";
-    Realization d_tuple_buf = d_tuple.realize(2);
+    Realization d_tuple_buf = d_tuple.realize({2});
     Buffer<float> d_tuple_buf_0 = d_tuple_buf[0];
     Buffer<float> d_tuple_buf_1 = d_tuple_buf[1];
     check(__LINE__, d_tuple_buf_0(0), 1.f);
@@ -1070,7 +1070,7 @@ void test_tuple() {
     Func d_input = d(input);
     // Every dependency of d_input should only use pure variables in lhs
     _halide_user_assert(!has_non_pure_update(d_input)) << "Function has non pure update\n";
-    Buffer<float> d_input_buf = d_input.realize(3);
+    Buffer<float> d_input_buf = d_input.realize({3});
     check(__LINE__, d_input_buf(0), 1.f);
     check(__LINE__, d_input_buf(1), 2.f);
     check(__LINE__, d_input_buf(2), 1.f);
@@ -1097,7 +1097,7 @@ void test_floor_ceil() {
     // ceil_output(0) == input[0]
     // ceil_output(1~4) == input[1]
     // ceil_output(5~7) = input[2]
-    Buffer<float> d_input_buf = d(input).realize(3);
+    Buffer<float> d_input_buf = d(input).realize({3});
 
     check(__LINE__, d_input_buf(0), 5.f);
     check(__LINE__, d_input_buf(1), 8.f);
@@ -1123,7 +1123,7 @@ void test_downsampling() {
     // Every dependency of d_tuple should only use pure variables in lhs
 
     // _halide_user_assert(!has_non_pure_update(d_input)) << "Function has non pure update\n";
-    Buffer<float> d_input_buf = d_input.realize(10);
+    Buffer<float> d_input_buf = d_input.realize({10});
 
     for (int i = 0; i < 8; i++) {
         check(__LINE__, d_input_buf(i), 1.f);
@@ -1147,7 +1147,7 @@ void test_upsampling() {
     Func d_input = d(input);
     // Every dependency of d_tuple should only use pure variables in lhs
     _halide_user_assert(!has_non_pure_update(d_input)) << "Function has non pure update\n";
-    Buffer<float> d_input_buf = d_input.realize(4);
+    Buffer<float> d_input_buf = d_input.realize({4});
 
     for (int i = 0; i < 4; i++) {
         check(__LINE__, d_input_buf(i), 4.f);
@@ -1175,7 +1175,7 @@ void test_transpose() {
     loss() += pow(output(r.x, r.y) - target(r.x, r.y), 2);
     Derivative d = propagate_adjoints(loss);
     Func d_input = d(input);
-    Buffer<float> d_input_buf = d_input.realize(5, 5);
+    Buffer<float> d_input_buf = d_input.realize({5, 5});
     for (int i = 0; i < 5; i++) {
         for (int j = 0; j < 5; j++) {
             check(__LINE__, d_input_buf(i, j), 2.f * (input(i, j) - target(j, i)));
@@ -1206,7 +1206,7 @@ void test_change_var() {
     loss() += pow(ab_func(r.x, r.y) - target(r.x, r.y), 2);
     Derivative d = propagate_adjoints(loss);
     Func d_input = d(input);
-    Buffer<float> d_input_buf = d_input.realize(5, 5);
+    Buffer<float> d_input_buf = d_input.realize({5, 5});
     for (int i = 0; i < 5; i++) {
         for (int j = 0; j < 5; j++) {
             check(__LINE__, d_input_buf(i, j), 2.f * (input(i, j) - target(j, i)));
@@ -1233,7 +1233,7 @@ void test_rdom_predicate() {
     loss() += circle(r_full.x, r_full.y);
     Derivative d = propagate_adjoints(loss);
     Func d_input = d(input);
-    Buffer<float> d_input_buf = d_input.realize(7, 7);
+    Buffer<float> d_input_buf = d_input.realize({7, 7});
     for (int i = 0; i < 7; i++) {
         for (int j = 0; j < 7; j++) {
             bool in_circle =
@@ -1261,7 +1261,7 @@ void test_reverse_scan() {
     loss() += reverse(r.x) * (r.x + 1.f);
     Derivative d = propagate_adjoints(loss);
     Func d_input = d(input);
-    Buffer<float> d_input_buf = d_input.realize(5);
+    Buffer<float> d_input_buf = d_input.realize({5});
     for (int i = 0; i < 5; i++) {
         check(__LINE__, d_input_buf(i), (5.f - (float)i));
     }
@@ -1281,7 +1281,7 @@ void test_diagonal() {
     loss() += f(r.x, r.y);
     Derivative d = propagate_adjoints(loss);
     Func d_input = d(input);
-    Buffer<float> d_input_buf = d_input.realize(5);
+    Buffer<float> d_input_buf = d_input.realize({5});
     check(__LINE__, d_input_buf(0), 1.f);
     check(__LINE__, d_input_buf(1), 2.f);
     check(__LINE__, d_input_buf(2), 2.f);
@@ -1304,7 +1304,7 @@ void test_input_bounds() {
     loss() += g(r);
     Derivative d = propagate_adjoints(loss);
     Func d_f = d(f);
-    Buffer<float> d_f_buf = d_f.realize(4);
+    Buffer<float> d_f_buf = d_f.realize({4});
     // d_f(x) = d_g(x) * input(x)
     check(__LINE__, d_f_buf(0), 1.f);
     check(__LINE__, d_f_buf(1), 2.f);
@@ -1312,7 +1312,7 @@ void test_input_bounds() {
     check(__LINE__, d_f_buf(3), 4.f);
     Func d_input = d(input);
 
-    Buffer<float> d_input_buf = d_input.realize(5);
+    Buffer<float> d_input_buf = d_input.realize({5});
     // d_input(x) += d_f(x) * input(x + 1)
     //            += d_f(x - 1) * input(x - 1)
     //            += d_g(x) * f(x)
@@ -1338,7 +1338,7 @@ void test_select_guard() {
     loss() += f(r);
     Derivative d = propagate_adjoints(loss);
     Func d_input = d(input);
-    Buffer<float> d_input_buf = d_input.realize(2);
+    Buffer<float> d_input_buf = d_input.realize({2});
     check(__LINE__, d_input_buf(0), 1.f + 0.f + 2.f + 3.f);
     check(__LINE__, d_input_buf(1), -2.f + 0.5f - 0.5f + 1.f);
 }
@@ -1358,7 +1358,7 @@ void test_param() {
     Buffer<float> d_param_buf = d_param.realize();
     check(__LINE__, d_param_buf(), 8.f);
     Func d_buffer = d(buffer);
-    Buffer<float> d_buffer_buf = d_buffer.realize(2);
+    Buffer<float> d_buffer_buf = d_buffer.realize({2});
     check(__LINE__, d_buffer_buf(0), 8.f);
     check(__LINE__, d_buffer_buf(1), 0.f);
 }
@@ -1376,15 +1376,15 @@ void test_custom_adjoint_buffer() {
     adjoint(1) = 1.f;
     Derivative d = propagate_adjoints(blur, adjoint);
 
-    Buffer<float> blur_buf = blur.realize(2);
-    Buffer<float> d_blur_buf = d(blur).realize(2);
+    Buffer<float> blur_buf = blur.realize({2});
+    Buffer<float> d_blur_buf = d(blur).realize({2});
     check(__LINE__, d_blur_buf(0), 1.f);
     check(__LINE__, d_blur_buf(1), 1.f);
     // d input(x) = d blur(x) + d blur(x - 1)
     Func d_input = d(input);
     // Every dependency of d_input should only use pure variables in lhs
     _halide_user_assert(!has_non_pure_update(d_input)) << "Function has non pure update\n";
-    Buffer<float> d_input_buf = d_input.realize(3);
+    Buffer<float> d_input_buf = d_input.realize({3});
     check(__LINE__, d_input_buf(0), d_blur_buf(0));
     check(__LINE__, d_input_buf(1), d_blur_buf(0) + d_blur_buf(1));
     check(__LINE__, d_input_buf(2), d_blur_buf(1));
@@ -1398,7 +1398,7 @@ void test_print() {
     out() += print(input(r));
     Derivative d_out_d = propagate_adjoints(out);
     Func d_out_d_input = d_out_d(input);
-    Buffer<float> d = d_out_d_input.realize(1);
+    Buffer<float> d = d_out_d_input.realize({1});
     check(__LINE__, d(0), 1.f);
 }
 
@@ -1412,7 +1412,7 @@ void test_random_float() {
     out(x) += random_float() * input() + r;
     Derivative d_out_d = propagate_adjoints(out);
     Func d_out_d_input = d_out_d(input);
-    Buffer<float> o = out.realize(1);
+    Buffer<float> o = out.realize({1});
     Buffer<float> d_input = d_out_d_input.realize();
     check(__LINE__, d_input(), o(0));
 }

--- a/test/correctness/autotune_bug.cpp
+++ b/test/correctness/autotune_bug.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
     blur_y.compile_jit();
     blur_y.infer_input_bounds({AUTOTUNE_N});
     assert(in_img.get().data());
-    blur_y.realize(AUTOTUNE_N);
+    blur_y.realize({AUTOTUNE_N});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/autotune_bug_2.cpp
+++ b/test/correctness/autotune_bug_2.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
     g.set_custom_trace(&my_trace);
     g.bound(x, 0, 2);
     g.output_buffer().dim(0).set_bounds(0, 2);
-    g.realize(2);
+    g.realize({2});
 
     printf("Success!\n");
 

--- a/test/correctness/autotune_bug_3.cpp
+++ b/test/correctness/autotune_bug_3.cpp
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
     g.set_custom_trace(&my_trace);
     g.bound(x, 0, 2);
     g.output_buffer().dim(0).set_bounds(0, 2);
-    g.realize(2);
+    g.realize({2});
 
     printf("Success!\n");
 

--- a/test/correctness/autotune_bug_4.cpp
+++ b/test/correctness/autotune_bug_4.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
 
     h.set_custom_trace(&my_trace);
     h.bound(x, 0, 6);
-    h.realize(6);
+    h.realize({6});
 
     printf("Success!\n");
 

--- a/test/correctness/autotune_bug_5.cpp
+++ b/test/correctness/autotune_bug_5.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
 
     upsampledx.compute_at(upsampled, yi);
 
-    upsampled.realize(100, 100);
+    upsampled.realize({100, 100});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/bad_likely.cpp
+++ b/test/correctness/bad_likely.cpp
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
     // Use a likely intrinsic to tag a disjoint range.
     f(x) = select(x < 10 || x > 20, likely(1), 2);
 
-    Buffer<int> im = f.realize(30);
+    Buffer<int> im = f.realize({30});
     for (int x = 0; x < 30; x++) {
         int correct = (x < 10 || x > 20) ? 1 : 2;
         if (im(x) != correct) {

--- a/test/correctness/bit_counting.cpp
+++ b/test/correctness/bit_counting.cpp
@@ -77,7 +77,7 @@ int test_bit_counting(const Target &target) {
     popcount_test(x) = popcount(input(x));
     schedule(popcount_test, target);
 
-    Buffer<T> popcount_result = popcount_test.realize(256);
+    Buffer<T> popcount_result = popcount_test.realize({256});
     for (int i = 0; i < 256; ++i) {
         if (popcount_result(i) != local_popcount(input(i))) {
             std::string bits_string = as_bits(input(i));
@@ -92,7 +92,7 @@ int test_bit_counting(const Target &target) {
     ctlz_test(x) = count_leading_zeros(input(x));
     schedule(ctlz_test, target);
 
-    Buffer<T> ctlz_result = ctlz_test.realize(256);
+    Buffer<T> ctlz_result = ctlz_test.realize({256});
     for (int i = 0; i < 256; ++i) {
         if (input(i) == 0) {
             // results are undefined for zero input
@@ -112,7 +112,7 @@ int test_bit_counting(const Target &target) {
     cttz_test(x) = count_trailing_zeros(input(x));
     schedule(cttz_test, target);
 
-    Buffer<T> cttz_result = cttz_test.realize(256);
+    Buffer<T> cttz_result = cttz_test.realize({256});
     for (int i = 0; i < 256; ++i) {
         if (input(i) == 0) {
             // results are undefined for zero input

--- a/test/correctness/bitwise_ops.cpp
+++ b/test/correctness/bitwise_ops.cpp
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
     // reinterpret cast
     Func f1;
     f1(x) = reinterpret<float>(input(x));
-    Buffer<float> im1 = f1.realize(256);
+    Buffer<float> im1 = f1.realize({256});
 
     for (int x = 0; x < 256; x++) {
         float halide = im1(x);
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
     // bitwise xor
     Func f2;
     f2(x) = input(x) ^ input(x + 1);
-    Buffer<uint32_t> im2 = f2.realize(128);
+    Buffer<uint32_t> im2 = f2.realize({128});
     for (int x = 0; x < 128; x++) {
         uint32_t correct = input(x) ^ input(x + 1);
         if (im2(x) != correct) {
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
     // bitwise and
     Func f3;
     f3(x) = input(x) & input(x + 1);
-    Buffer<uint32_t> im3 = f3.realize(128);
+    Buffer<uint32_t> im3 = f3.realize({128});
     for (int x = 0; x < 128; x++) {
         uint32_t correct = input(x) & input(x + 1);
         if (im3(x) != correct) {
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
     // bitwise or
     Func f4;
     f4(x) = input(x) | input(x + 1);
-    Buffer<uint32_t> im4 = f4.realize(128);
+    Buffer<uint32_t> im4 = f4.realize({128});
     for (int x = 0; x < 128; x++) {
         uint32_t correct = input(x) | input(x + 1);
         if (im4(x) != correct) {
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
     // bitwise not
     Func f5;
     f5(x) = ~input(x);
-    Buffer<uint32_t> im5 = f5.realize(128);
+    Buffer<uint32_t> im5 = f5.realize({128});
     for (int x = 0; x < 128; x++) {
         uint32_t correct = ~input(x);
         if (im5(x) != correct) {
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
     // shift left combined with masking
     Func f6;
     f6(x) = input(x) << (input(x + 1) & 0xf);
-    Buffer<uint32_t> im6 = f6.realize(128);
+    Buffer<uint32_t> im6 = f6.realize({128});
     for (int x = 0; x < 128; x++) {
         uint32_t correct = input(x) << (input(x + 1) & 0xf);
         if (im6(x) != correct) {
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
     // logical shift right
     Func f7;
     f7(x) = input(x) >> (input(x + 1) & 0xf);
-    Buffer<uint32_t> im7 = f7.realize(128);
+    Buffer<uint32_t> im7 = f7.realize({128});
     for (int x = 0; x < 128; x++) {
         uint32_t correct = input(x) >> (input(x + 1) & 0xf);
         if (im7(x) != correct) {
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
     Expr a = reinterpret<int>(input(x));
     Expr b = reinterpret<unsigned>(input(x + 1));
     f8(x) = a >> (b & 0x1f);
-    Buffer<int> im8 = f8.realize(128);
+    Buffer<int> im8 = f8.realize({128});
     for (int x = 0; x < 128; x++) {
         int correct = ((int)(input(x))) >> (((int)(input(x + 1))) & 0x1f);
         if (im8(x) != correct) {
@@ -122,7 +122,7 @@ int main(int argc, char **argv) {
     Expr a32 = cast<int32_t>(input(x));
     Expr b8 = cast<int32_t>(min(31, cast<uint8_t>(input(x + 1))));
     f9(x) = a32 >> b8;
-    Buffer<int> im9 = f9.realize(128);
+    Buffer<int> im9 = f9.realize({128});
     for (int x = 0; x < 128; x++) {
         int lhs = (int)input(x);
         int shift_amount = (uint8_t)(input(x + 1));
@@ -140,7 +140,7 @@ int main(int argc, char **argv) {
     Expr a10 = cast<int>(input(x));
     Expr b10 = cast<int>(input(x + 1));
     f10(x) = a10 << (b10 & 0x1f);
-    Buffer<int> im10 = f10.realize(128);
+    Buffer<int> im10 = f10.realize({128});
     for (int x = 0; x < 128; x++) {
         int correct = ((int)(input(x))) << (((int)(input(x + 1))) & 0x1f);
         if (im10(x) != correct) {
@@ -155,7 +155,7 @@ int main(int argc, char **argv) {
     Expr a11 = cast<int>(input(x));
     Expr b11 = cast<int>(input(x + 1));
     f11(x) = a11 >> cast<int16_t>(b11 & 0x0f);
-    Buffer<int> im11 = f11.realize(128);
+    Buffer<int> im11 = f11.realize({128});
     for (int x = 0; x < 128; x++) {
         int correct = ((int)(input(x))) >> (((int)(input(x + 1))) & 0x0f);
         if (im11(x) != correct) {
@@ -170,7 +170,7 @@ int main(int argc, char **argv) {
     Expr a12 = cast<int>(input(x));
     Expr b12 = cast<int>(input(x + 1));
     f12(x) = a12 << (-1 * (b12 & 0x1f));
-    Buffer<int> im12 = f12.realize(128);
+    Buffer<int> im12 = f12.realize({128});
     for (int x = 0; x < 128; x++) {
         int correct = ((int)(input(x))) >> (((int)(input(x + 1))) & 0x1f);
         if (im12(x) != correct) {
@@ -185,7 +185,7 @@ int main(int argc, char **argv) {
     Expr a13 = cast<int>(input(x));
     Expr b13 = cast<int>(input(x + 1));
     f13(x) = a13 >> (-1 * (b13 & 0x1f));
-    Buffer<int> im13 = f13.realize(128);
+    Buffer<int> im13 = f13.realize({128});
     for (int x = 0; x < 128; x++) {
         int correct = ((int)(input(x))) << (((int)(input(x + 1))) & 0x1f);
         if (im13(x) != correct) {
@@ -200,7 +200,7 @@ int main(int argc, char **argv) {
     Expr a14 = cast<int>(input(x));
     int b14 = 4;
     f14(x) = a14 << b14;
-    Buffer<int> im14 = f14.realize(128);
+    Buffer<int> im14 = f14.realize({128});
     for (int x = 0; x < 128; x++) {
         int correct = ((int)(input(x))) << 4;
         if (im14(x) != correct) {
@@ -215,7 +215,7 @@ int main(int argc, char **argv) {
     Expr a15 = cast<int>(input(x));
     int b15 = 4;
     f15(x) = a15 >> b15;
-    Buffer<int> im15 = f15.realize(128);
+    Buffer<int> im15 = f15.realize({128});
     for (int x = 0; x < 128; x++) {
         int correct = ((int)(input(x))) >> 4;
         if (im15(x) != correct) {
@@ -230,7 +230,7 @@ int main(int argc, char **argv) {
     Expr a16 = cast<int>(input(x));
     int b16 = -4;
     f16(x) = a16 << b16;
-    Buffer<int> im16 = f16.realize(128);
+    Buffer<int> im16 = f16.realize({128});
     for (int x = 0; x < 128; x++) {
         int correct = ((int)(input(x))) >> 4;
         if (im16(x) != correct) {
@@ -245,7 +245,7 @@ int main(int argc, char **argv) {
     Expr a17 = cast<int>(input(x));
     int b17 = -4;
     f17(x) = a17 >> b17;
-    Buffer<int> im17 = f17.realize(128);
+    Buffer<int> im17 = f17.realize({128});
     for (int x = 0; x < 128; x++) {
         int correct = ((int)(input(x))) << 4;
         if (im17(x) != correct) {
@@ -259,7 +259,7 @@ int main(int argc, char **argv) {
     Func f18;
     Expr a8 = cast<int8_t>(input(x));
     f18(x) = a8 & cast<int8_t>(0xf0);
-    Buffer<int8_t> im18 = f18.realize(128);
+    Buffer<int8_t> im18 = f18.realize({128});
     for (int x = 0; x < 128; x++) {
         int8_t correct = (int8_t)(input(x)) & 0xf0;
         if (im18(x) != correct) {

--- a/test/correctness/bound.cpp
+++ b/test/correctness/bound.cpp
@@ -12,8 +12,8 @@ int main(int argc, char **argv) {
 
     g.bound(c, 0, 3);
 
-    Buffer<int> imf = f.realize(32, 32);
-    Buffer<int> img = g.realize(32, 32, 3);
+    Buffer<int> imf = f.realize({32, 32});
+    Buffer<int> img = g.realize({32, 32, 3});
 
     // Check the result was what we expected
     for (int i = 0; i < 32; i++) {

--- a/test/correctness/bound_small_allocations.cpp
+++ b/test/correctness/bound_small_allocations.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
     h(x, y) = calc(g(x, y)) + g(x, y) / 4 + (1 << 30);
     h.vectorize(x, 8).compute_root();
 
-    Buffer<int32_t> imf = h.realize(32, 32);
+    Buffer<int32_t> imf = h.realize({32, 32});
 
     // No verification of output: just want to verify no compile-time assertion
 

--- a/test/correctness/bounds.cpp
+++ b/test/correctness/bounds.cpp
@@ -31,9 +31,9 @@ int main(int argc, char **argv) {
 
     printf("Realizing function...\n");
 
-    Buffer<int> imf = f.realize(32, 32, target);
-    Buffer<int> img = g.realize(32, 32, target);
-    Buffer<int> imh = h.realize(32, 32, target);
+    Buffer<int> imf = f.realize({32, 32}, target);
+    Buffer<int> img = g.realize({32, 32}, target);
+    Buffer<int> imh = h.realize({32, 32}, target);
 
     // Check the result was what we expected
     for (int i = 0; i < 32; i++) {

--- a/test/correctness/bounds_inference.cpp
+++ b/test/correctness/bounds_inference.cpp
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
         h.hexagon().vectorize(x, 32);
     }
 
-    Buffer<int> out = f.realize(32, 32, target);
+    Buffer<int> out = f.realize({32, 32}, target);
 
     for (int y = 0; y < 32; y++) {
         for (int x = 0; x < 32; x++) {

--- a/test/correctness/bounds_inference_chunk.cpp
+++ b/test/correctness/bounds_inference_chunk.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
 
     //f.trace();
 
-    Buffer<int> out = f.realize(32, 32);
+    Buffer<int> out = f.realize({32, 32});
 
     for (int y = 0; y < 32; y++) {
         for (int x = 0; x < 32; x++) {

--- a/test/correctness/bounds_inference_complex.cpp
+++ b/test/correctness/bounds_inference_complex.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    Buffer<int> out = f[K - 1].realize(32, 32);
+    Buffer<int> out = f[K - 1].realize({32, 32});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/bounds_of_multiply.cpp
+++ b/test/correctness/bounds_of_multiply.cpp
@@ -19,7 +19,7 @@ void test() {
     in.set(foo);
     bound.set(5);
 
-    auto result = f.realize(200);
+    auto result = f.realize({200});
 }
 
 int main(int argc, char **argv) {

--- a/test/correctness/bounds_query.cpp
+++ b/test/correctness/bounds_query.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
     second(x, y) = tmp(x - 1, y - 1) + tmp(x + 3, y + 1);
 
     // This would fail, because tmp isn't attached to an allocated buffer.
-    // Buffer<int> out = second.realize(1024, 1024);
+    // Buffer<int> out = second.realize({1024, 1024});
 
     // Allocate an output image.
     Buffer<int> out(1024, 1024);
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
     Func first_and_second;
     first_and_second(x, y) = first(x - 1, y - 1) + first(x + 3, y + 1);
 
-    Buffer<int> reference = first_and_second.realize(1024, 1024);
+    Buffer<int> reference = first_and_second.realize({1024, 1024});
 
     for (int y = 0; y < 1024; y++) {
         for (int x = 0; x < 1024; x++) {

--- a/test/correctness/c_function.cpp
+++ b/test/correctness/c_function.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
 
     f(x, y) = my_func(x, cast<float>(y));
 
-    Buffer<float> imf = f.realize(32, 32);
+    Buffer<float> imf = f.realize({32, 32});
 
     // Check the result was what we expected
     for (int i = 0; i < 32; i++) {
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
 
     Pipeline p(g);
     p.set_jit_externs({{"my_func", JITExtern{my_func2}}});
-    Buffer<float> imf2 = p.realize(32, 32);
+    Buffer<float> imf2 = p.realize({32, 32});
 
     // Check the result was what we expected
     for (int i = 0; i < 32; i++) {
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
 
     // Switch from my_func2 to my_func and verify a recompile happens.
     p.set_jit_externs({{"my_func", JITExtern{my_func3}}});
-    Buffer<float> imf3 = p.realize(32, 32);
+    Buffer<float> imf3 = p.realize({32, 32});
 
     // Check the result was what we expected
     for (int i = 0; i < 32; i++) {

--- a/test/correctness/cascaded_filters.cpp
+++ b/test/correctness/cascaded_filters.cpp
@@ -13,7 +13,7 @@ Func blur(Func in, std::string n) {
 }
 
 int main(int argc, char **argv) {
-    Buffer<float> input = lambda(x, sin(10 * x) + 1.0f).realize(1000);
+    Buffer<float> input = lambda(x, sin(10 * x) + 1.0f).realize({1000});
 
     std::vector<Func> stages;
     Func first("S0");
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
     }
 
     divisor.set(2);
-    Buffer<float> result = stages.back().realize(10);
+    Buffer<float> result = stages.back().realize({10});
 
     // After all the averaging, the result should be a flat 1.0f
     float err = evaluate_may_gpu<float>(sum(abs(result(RDom(result)) - 1.0f)));

--- a/test/correctness/cast_handle.cpp
+++ b/test/correctness/cast_handle.cpp
@@ -20,10 +20,10 @@ int main(int argc, char **argv) {
 
     handle.set(&foo);
 
-    Buffer<uint64_t> out1 = f.realize(4);
+    Buffer<uint64_t> out1 = f.realize({4});
 
     g.vectorize(x, 4);
-    Buffer<uint64_t> out2 = g.realize(4);
+    Buffer<uint64_t> out2 = g.realize({4});
 
     uint64_t correct = (uint64_t)((uintptr_t)(&foo));
 

--- a/test/correctness/chunk.cpp
+++ b/test/correctness/chunk.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
 
     printf("Realizing function...\n");
 
-    Buffer<int> im = g.realize(32, 32, target);
+    Buffer<int> im = g.realize({32, 32}, target);
 
     for (int i = 0; i < 32; i++) {
         for (int j = 0; j < 32; j++) {

--- a/test/correctness/chunk_sharing.cpp
+++ b/test/correctness/chunk_sharing.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
 
     printf("Realizing function...\n");
 
-    Buffer<int> im = d.realize(32, 32);
+    Buffer<int> im = d.realize({32, 32});
 
     for (int y = 0; y < 32; y++) {
         for (int x = 0; x < 32; x++) {

--- a/test/correctness/code_explosion.cpp
+++ b/test/correctness/code_explosion.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
     }
     Func g;
     g(x) = funcs[funcs.size() - 1](x);
-    g.realize(10);
+    g.realize({10});
 
     // Test a nest of highly connected exprs. Compilation will barf if
     // this gets expanded into a tree.
@@ -31,7 +31,7 @@ int main(int argc, char **argv) {
 
     f(x) = e[e.size() - 1];
 
-    f.realize(10);
+    f.realize({10});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/compare_vars.cpp
+++ b/test/correctness/compare_vars.cpp
@@ -8,7 +8,7 @@ int main(int argc, char **argv) {
     Var x, y;
     f(x, y) = select(x == y, 1, 0);
 
-    Buffer<int> im = f.realize(10, 10);
+    Buffer<int> im = f.realize({10, 10});
 
     for (int y = 0; y < 10; y++) {
         for (int x = 0; x < 10; x++) {

--- a/test/correctness/compute_at_reordered_update_stage.cpp
+++ b/test/correctness/compute_at_reordered_update_stage.cpp
@@ -20,7 +20,7 @@ int main(int argc, char *argv[]) {
         f.store_at(g, x).compute_at(g, y);
     }
 
-    Halide::Buffer<int> out_orig = g.realize(10, 10);
+    Halide::Buffer<int> out_orig = g.realize({10, 10});
 
     // This is here solely to test Halider::Buffer::copy()
     Halide::Buffer<int> out = out_orig.copy();

--- a/test/correctness/compute_at_split_rvar.cpp
+++ b/test/correctness/compute_at_split_rvar.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
         g.update().split(r, ro, ri, 2);
         f.compute_at(g, ri);
 
-        Buffer<int> im = g.realize(10);
+        Buffer<int> im = g.realize({10});
 
         if (call_counter != 10) {
             printf("Wrong number of calls to f: %d\n", call_counter);
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
         g.update().split(r, ro, ri, 2);
         f.compute_at(g, ro).unroll(x);
 
-        Buffer<int> im = g.realize(10);
+        Buffer<int> im = g.realize({10});
 
         if (call_counter != 10) {
             printf("Wrong number of calls to f: %d\n", call_counter);
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
         g.update().split(r, ro, ri, 2).unroll(ri);
         f.compute_at(g, ri);
 
-        Buffer<int> im = g.realize(10);
+        Buffer<int> im = g.realize({10});
 
         if (call_counter != 10) {
             printf("Wrong number of calls to f: %d\n", call_counter);
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
         g.update().split(r, ro, ri, 2).reorder(ro, ri);
         f.compute_at(g, ro);
 
-        Buffer<int> im = g.realize(10);
+        Buffer<int> im = g.realize({10});
 
         if (call_counter != 10) {
             printf("Wrong number of calls to f: %d\n", call_counter);
@@ -149,7 +149,7 @@ int main(int argc, char **argv) {
         g.update().split(r, ro, ri, 4).split(ri, rio, rii, 2).fuse(rio, ro, fused);
         f.compute_at(g, fused);
 
-        Buffer<int> im = g.realize(20);
+        Buffer<int> im = g.realize({20});
 
         if (call_counter != 20) {
             printf("Wrong number of calls to f: %d\n", call_counter);
@@ -181,7 +181,7 @@ int main(int argc, char **argv) {
         g.update().split(r, ro, ri, 3);
         f.compute_at(g, ro);
 
-        Buffer<int> im = g.realize(10);
+        Buffer<int> im = g.realize({10});
 
         if (call_counter != 10) {
             printf("Wrong number of calls to f: %d\n", call_counter);

--- a/test/correctness/compute_outermost.cpp
+++ b/test/correctness/compute_outermost.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
     blur_fn1.compute_at(out, t);
     blur_fn2.compute_at(out, t);
 
-    Buffer<int> result = out.realize(256, 256);
+    Buffer<int> result = out.realize({256, 256});
     for (int y = 0; y < 256; y++) {
         for (int x = 0; x < 256; x++) {
             int correct = 3 * x + 4 * y;

--- a/test/correctness/compute_with.cpp
+++ b/test/correctness/compute_with.cpp
@@ -96,7 +96,7 @@ int split_test() {
         f(x, y) = x + y;
         g(x, y) = x - y;
         h(x, y) = f(x - 1, y + 1) + g(x + 2, y - 2);
-        im_ref = h.realize(200, 200);
+        im_ref = h.realize({200, 200});
     }
 
     {
@@ -130,7 +130,7 @@ int split_test() {
         };
         h.set_custom_trace(&my_trace);
 
-        im = h.realize(200, 200);
+        im = h.realize({200, 200});
     }
 
     auto func = [im_ref](int x, int y) {
@@ -151,7 +151,7 @@ int fuse_test() {
         f(x, y, z) = x + y + z;
         g(x, y, z) = x - y + z;
         h(x, y, z) = f(x + 2, y - 1, z + 3) + g(x - 5, y - 6, z + 2);
-        im_ref = h.realize(100, 100, 100);
+        im_ref = h.realize({100, 100, 100});
     }
 
     {
@@ -184,7 +184,7 @@ int fuse_test() {
         };
         h.set_custom_trace(&my_trace);
 
-        im = h.realize(100, 100, 100);
+        im = h.realize({100, 100, 100});
     }
 
     auto func = [im_ref](int x, int y, int z) {
@@ -213,7 +213,7 @@ int multiple_fuse_group_test() {
         h(x, y) += f(x, y) + g(x, y);
         p(x, y) = x + 2;
         q(x, y) = h(x, y) + 2 + p(x, y);
-        im_ref = q.realize(200, 200);
+        im_ref = q.realize({200, 200});
     }
 
     {
@@ -265,7 +265,7 @@ int multiple_fuse_group_test() {
         };
         q.set_custom_trace(&my_trace);
 
-        im = q.realize(200, 200);
+        im = q.realize({200, 200});
     }
 
     auto func = [im_ref](int x, int y) {
@@ -353,7 +353,7 @@ int fuse_compute_at_test() {
         p(x, y) = h(x, y) + 2;
         q(x, y) = x * y;
         r(x, y) = p(x, y - 1) + q(x - 1, y);
-        im_ref = r.realize(167, 167);
+        im_ref = r.realize({167, 167});
     }
 
     {
@@ -403,7 +403,7 @@ int fuse_compute_at_test() {
         };
         r.set_custom_trace(&my_trace);
 
-        im = r.realize(167, 167);
+        im = r.realize({167, 167});
     }
 
     auto func = [im_ref](int x, int y) {
@@ -424,7 +424,7 @@ int double_split_fuse_test() {
         f(x, y) = x + y;
         g(x, y) = 2 + x - y;
         h(x, y) = f(x, y) + g(x, y) + 10;
-        im_ref = h.realize(200, 200);
+        im_ref = h.realize({200, 200});
     }
 
     {
@@ -460,7 +460,7 @@ int double_split_fuse_test() {
         };
         h.set_custom_trace(&my_trace);
 
-        im = h.realize(200, 200);
+        im = h.realize({200, 200});
     }
 
     auto func = [im_ref](int x, int y) {
@@ -645,7 +645,7 @@ int vectorize_test() {
         f(x, y) = x + y;
         g(x, y) = x - y;
         h(x, y) = f(x - 1, y + 1) + g(x + 2, y - 2);
-        im_ref = h.realize(111, 111);
+        im_ref = h.realize({111, 111});
     }
 
     {
@@ -681,7 +681,7 @@ int vectorize_test() {
         };
         h.set_custom_trace(&my_trace);
 
-        im = h.realize(111, 111);
+        im = h.realize({111, 111});
     }
 
     auto func = [im_ref](int x, int y) {
@@ -705,7 +705,7 @@ int some_are_skipped_test() {
         p(x, y) = x * y;
         h(x, y) = f(x, y) + g(x + 2, y - 2);
         h(x, y) += f(x - 1, y + 1) + p(x, y);
-        im_ref = h.realize(200, 200);
+        im_ref = h.realize({200, 200});
     }
 
     {
@@ -743,7 +743,7 @@ int some_are_skipped_test() {
         };
         h.set_custom_trace(&my_trace);
 
-        im = h.realize(200, 200);
+        im = h.realize({200, 200});
     }
 
     auto func = [im_ref](int x, int y) {
@@ -1108,7 +1108,7 @@ int with_specialization_test() {
         f(x, y) = x + y;
         g(x, y) = x - y;
         h(x, y) = f(x - 1, y + 1) + g(x + 2, y - 2);
-        im_ref = h.realize(200, 200);
+        im_ref = h.realize({200, 200});
     }
 
     {
@@ -1144,7 +1144,7 @@ int with_specialization_test() {
         h.set_custom_trace(&my_trace);
 
         tile.set(true);
-        im = h.realize(200, 200);
+        im = h.realize({200, 200});
     }
 
     auto func = [im_ref](int x, int y) {
@@ -2005,7 +2005,7 @@ int store_at_different_levels_test() {
 
     consumer.bound(x, 0, 16).bound(y, 0, 16);
 
-    Buffer<int> out = consumer.realize(16, 16);
+    Buffer<int> out = consumer.realize({16, 16});
 
     for (int y = 0; y < out.height(); y++) {
         for (int x = 0; x < out.width(); x++) {

--- a/test/correctness/compute_with_in.cpp
+++ b/test/correctness/compute_with_in.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
     one.compute_root();
     one.compute_at(two, Var::outermost());
 
-    output.realize(64, 64);
+    output.realize({64, 64});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/compute_with_inlined.cpp
+++ b/test/correctness/compute_with_inlined.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
     one.compute_at(two[0], Var::outermost());
     three.compute_root();
 
-    three.realize(1024, 1024);
+    three.realize({1024, 1024});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/computed_index.cpp
+++ b/test/correctness/computed_index.cpp
@@ -10,7 +10,7 @@ int main(int argc, char **argv) {
     Var x, y;
 
     f(x, y) = in2(x, y, clamp(in1(x, y), 0, 9));
-    Buffer<uint8_t> out = f.realize(256, 256);
+    Buffer<uint8_t> out = f.realize({256, 256});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/concat.cpp
+++ b/test/correctness/concat.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
     g.compute_root();
     h.compute_root();
 
-    Buffer<int> buf = h.realize(200);
+    Buffer<int> buf = h.realize({200});
 
     for (int i = 0; i < 200; i++) {
         int correct = i < 100 ? i + 1 : i + 2;

--- a/test/correctness/constant_type.cpp
+++ b/test/correctness/constant_type.cpp
@@ -9,7 +9,7 @@ bool test_type() {
     Func f;
     Var x;
     f(x) = cast<T>(1);
-    Buffer<T> im = f.realize(10);
+    Buffer<T> im = f.realize({10});
 
     if (f.value().type() != t) {
         std::cout << "Function was defined with type " << t << " but has type " << f.value().type() << "\n";

--- a/test/correctness/constraints.cpp
+++ b/test/correctness/constraints.cpp
@@ -28,7 +28,7 @@ int basic_constraints() {
     // This should be fine
     param.set(image1);
     error_occurred = false;
-    f.realize(20, 20);
+    f.realize({20, 20});
 
     if (error_occurred) {
         printf("Error incorrectly raised\n");
@@ -37,7 +37,7 @@ int basic_constraints() {
     // This should be an error, because dimension 0 of image 2 is not from 0 to 128 like we promised
     param.set(image2);
     error_occurred = false;
-    f.realize(20, 20);
+    f.realize({20, 20});
 
     if (!error_occurred) {
         printf("Error incorrectly not raised\n");
@@ -160,7 +160,7 @@ int unstructured_constraints() {
     // This should be fine
     param.set(image1);
     error_occurred = false;
-    pf.realize(20, 20);
+    pf.realize({20, 20});
 
     if (error_occurred) {
         printf("Error incorrectly raised\n");
@@ -169,7 +169,7 @@ int unstructured_constraints() {
     // This should be an error, because dimension 0 of image 2 is not from 0 to 128 like we promised
     param.set(image2);
     error_occurred = false;
-    pf.realize(20, 20);
+    pf.realize({20, 20});
 
     if (!error_occurred) {
         printf("Error incorrectly not raised\n");

--- a/test/correctness/convolution.cpp
+++ b/test/correctness/convolution.cpp
@@ -96,8 +96,8 @@ int main(int argc, char **argv) {
         blur2.vectorize(x, 4).parallel(y);
     }
 
-    Buffer<uint16_t> out1 = blur1.realize(W, H, target);
-    Buffer<uint16_t> out2 = blur2.realize(W, H, target);
+    Buffer<uint16_t> out1 = blur1.realize({W, H}, target);
+    Buffer<uint16_t> out2 = blur2.realize({W, H}, target);
 
     for (int y = 1; y < H - 1; y++) {
         for (int x = 1; x < W - 1; x++) {

--- a/test/correctness/convolution_multiple_kernels.cpp
+++ b/test/correctness/convolution_multiple_kernels.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
         blur.hexagon().vectorize(x, 64);
     }
 
-    Buffer<uint16_t> out = blur.realize(W, H, target);
+    Buffer<uint16_t> out = blur.realize({W, H}, target);
 
     for (int y = 2; y < H - 2; y++) {
         for (int x = 2; x < W - 2; x++) {

--- a/test/correctness/custom_allocator.cpp
+++ b/test/correctness/custom_allocator.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
 
     g.set_custom_allocator(my_malloc, my_free);
 
-    Buffer<int> im = g.realize(100000);
+    Buffer<int> im = g.realize({100000});
 
     assert(custom_malloc_called);
     assert(custom_free_called);

--- a/test/correctness/custom_lowering_pass.cpp
+++ b/test/correctness/custom_lowering_pass.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
     f.add_custom_lowering_pass(new CountMultiplies);
 
     const int size = 10;
-    f.realize(size);
+    f.realize({size});
 
     if (multiply_count != size * 2) {
         printf("The multiplies weren't all counted. Got %d instead of %d\n",

--- a/test/correctness/debug_to_file.cpp
+++ b/test/correctness/debug_to_file.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
             h.compute_root().debug_to_file(h_mat);
         }
 
-        Buffer<int32_t> im = h.realize(10, 10, target);
+        Buffer<int32_t> im = h.realize({10, 10}, target);
     }
 
     {

--- a/test/correctness/debug_to_file_reorder.cpp
+++ b/test/correctness/debug_to_file_reorder.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
             h.compute_root().debug_to_file(h_tmp);
         }
 
-        Buffer<float> im = h.realize(size_x, size_y, target);
+        Buffer<float> im = h.realize({size_x, size_y}, target);
     }
 
     Internal::assert_file_exists(f_tmp);

--- a/test/correctness/deferred_loop_level.cpp
+++ b/test/correctness/deferred_loop_level.cpp
@@ -67,7 +67,7 @@ struct Test {
 
     void check(const std::string &inner_loop_level,
                const std::string &outer_loop_level) {
-        Buffer<float> result = outer.realize(1, 1, 1);
+        Buffer<float> result = outer.realize({1, 1, 1});
 
         Module m = outer.compile_to_module({outer.infer_arguments()});
         CheckLoopLevels c(inner_loop_level, outer_loop_level);

--- a/test/correctness/deinterleave4.cpp
+++ b/test/correctness/deinterleave4.cpp
@@ -26,8 +26,8 @@ int main(int argc, char **argv) {
     Func f2 = build();
     f2.bound(x, 0, 64).vectorize(x);
 
-    Buffer<int> o1 = f1.realize(64);
-    Buffer<int> o2 = f2.realize(64);
+    Buffer<int> o1 = f1.realize({64});
+    Buffer<int> o2 = f2.realize({64});
 
     for (int x = 0; x < o2.width(); x++) {
         if (o1(x) != o2(x)) {

--- a/test/correctness/device_buffer_copy.cpp
+++ b/test/correctness/device_buffer_copy.cpp
@@ -17,7 +17,7 @@ Halide::Runtime::Buffer<int32_t> make_gpu_buffer(bool hexagon_rpc, int offset = 
         f.gpu_tile(x, y, xi, yi, 8, 8, TailStrategy::Auto, api);
     }
 
-    Buffer<int32_t> result = f.realize(128, 128);
+    Buffer<int32_t> result = f.realize({128, 128});
     return *result.get();
 }
 

--- a/test/correctness/device_crop.cpp
+++ b/test/correctness/device_crop.cpp
@@ -15,7 +15,7 @@ Halide::Runtime::Buffer<int32_t> make_gpu_buffer(bool hexagon_rpc) {
         f.gpu_tile(x, y, xi, yi, 8, 8);
     }
 
-    Buffer<int32_t> result = f.realize(128, 128);
+    Buffer<int32_t> result = f.realize({128, 128});
     return *result.get();
 }
 

--- a/test/correctness/device_slice.cpp
+++ b/test/correctness/device_slice.cpp
@@ -17,7 +17,7 @@ Halide::Runtime::Buffer<int32_t> make_gpu_buffer(bool hexagon_rpc) {
         f.gpu_tile(x, y, xi, yi, 8, 8);
     }
 
-    Buffer<int32_t> result = f.realize(kEdges[0], kEdges[1], kEdges[2]);
+    Buffer<int32_t> result = f.realize({kEdges[0], kEdges[1], kEdges[2]});
     return *result.get();
 }
 

--- a/test/correctness/dilate3x3.cpp
+++ b/test/correctness/dilate3x3.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
     }
 
     // Run the pipeline and verify the results are correct.
-    Buffer<uint8_t> out = dilate3x3.realize(W, H, target);
+    Buffer<uint8_t> out = dilate3x3.realize({W, H}, target);
 
     for (int y = 1; y < H - 1; y++) {
         for (int x = 1; x < W - 1; x++) {

--- a/test/correctness/div_by_zero.cpp
+++ b/test/correctness/div_by_zero.cpp
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
     Var xo, xi;
     f.vectorize(x, 8, TailStrategy::ShiftInwards);
 
-    f.realize(5);
+    f.realize({5});
 
     // Ignoring scheduling, we're only realizing f over positive
     // values of x, so this shouldn't fault. However scheduling can

--- a/test/correctness/dynamic_allocation_in_gpu_kernel.cpp
+++ b/test/correctness/dynamic_allocation_in_gpu_kernel.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
 
     for (int i = 0; i < 10; i++) {
         p.set(i);
-        Buffer<float> result = g.realize(W, H);
+        Buffer<float> result = g.realize({W, H});
         result.copy_to_host();
         for (int y = 0; y < H; y++) {
             for (int x = 0; x < W; x++) {

--- a/test/correctness/dynamic_reduction_bounds.cpp
+++ b/test/correctness/dynamic_reduction_bounds.cpp
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
     Buffer<float> im(32, 32);
     input.set(im);
 
-    f.realize(100, 100, 16);
+    f.realize({100, 100, 16});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/erf.cpp
+++ b/test/correctness/erf.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
     f(x) = erf((x - 50000) / 10000.0f);
     f.vectorize(x, 8);
 
-    Buffer<float> im = f.realize(100000);
+    Buffer<float> im = f.realize({100000});
 
     int max_err = 0;
     float max_err_x = 0;

--- a/test/correctness/exception.cpp
+++ b/test/correctness/exception.cpp
@@ -112,7 +112,7 @@ int main(int argc, char **argv) {
     f2(x) = im(x) * 2.0f;
     try {
         error = false;
-        f2.realize(10);
+        f2.realize({10});
     } catch (const Halide::RuntimeError &e) {
         error = true;
         std::cout << "Expected runtime error:\n"
@@ -123,7 +123,7 @@ int main(int argc, char **argv) {
     Buffer<float> an_image(10);
     lambda(x, x * 7.0f).realize(an_image);
     im.set(an_image);
-    Buffer<float> result = f2.realize(10);
+    Buffer<float> result = f2.realize({10});
     for (size_t i = 0; i < 10; i++) {
         float correct = i * 14.0f;
         if (result(i) != correct) {
@@ -141,7 +141,7 @@ int main(int argc, char **argv) {
         p.set(-4);
         Func f4;
         f4(x) = p;
-        f4.realize(10);
+        f4.realize({10});
     } catch (const Halide::RuntimeError &e) {
         error = true;
         std::cout << "Expected runtime error:\n"

--- a/test/correctness/explicit_inline_reductions.cpp
+++ b/test/correctness/explicit_inline_reductions.cpp
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
     f(x, y) = product(sum(r1, r1 + r3) + sum(r2, r2 * 2 + r3));
     f(r1, y) += product(r3, sum(r2, r1 + r2 + r3));
 
-    Buffer<int> result = f.realize(10, 10);
+    Buffer<int> result = f.realize({10, 10});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/extern_consumer.cpp
+++ b/test/correctness/extern_consumer.cpp
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
         return -1;
 
     // Test ImageParam ExternFuncArgument via passed in image.
-    Buffer<int32_t> buf = source.realize(10);
+    Buffer<int32_t> buf = source.realize({10});
     ImageParam passed_in(Int(32), 1);
     passed_in.set(buf);
 

--- a/test/correctness/extern_consumer_tiled.cpp
+++ b/test/correctness/extern_consumer_tiled.cpp
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
 
     input.compute_at(output, xo);
 
-    Buffer<int32_t> buf = output.realize(75, 35);  // Use uneven splits.
+    Buffer<int32_t> buf = output.realize({75, 35});  // Use uneven splits.
 
     for (int y = 0; y < buf.height(); y++) {
         for (int x = 0; x < buf.width(); x++) {

--- a/test/correctness/extern_error.cpp
+++ b/test/correctness/extern_error.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
     Func f;
     f.define_extern("extern_error", args, Float(32), 1);
     f.set_error_handler(&my_halide_error);
-    f.realize(100);
+    f.realize({100});
 
     if (!error_occurred || !extern_error_called) {
         printf("There was supposed to be an error\n");

--- a/test/correctness/extern_output_expansion.cpp
+++ b/test/correctness/extern_output_expansion.cpp
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
             g.compute_root();
         }
 
-        Buffer<int32_t> result = h.realize(100);
+        Buffer<int32_t> result = h.realize({100});
 
         for (int i = 0; i < 100; i++) {
             int32_t correct = i * i * i * 2;

--- a/test/correctness/extern_partial.cpp
+++ b/test/correctness/extern_partial.cpp
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
             input.compute_at(output, y);
         }
 
-        Buffer<int32_t> buf = output.realize(100, 100);
+        Buffer<int32_t> buf = output.realize({100, 100});
 
         for (int y = 0; y < buf.height(); y++) {
             for (int x = 0; x < buf.width(); x++) {

--- a/test/correctness/extern_producer.cpp
+++ b/test/correctness/extern_producer.cpp
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
         // Compute the source per tile of sink
         source.compute_at(sink, x);
 
-        Buffer<float> output = sink.realize(100, 100);
+        Buffer<float> output = sink.realize({100, 100});
 
         // Should be all zeroes.
         RDom r(output);
@@ -144,7 +144,7 @@ int main(int argc, char **argv) {
         // Compute the source per tile of sink
         multi.compute_at(sink_multi, x);
 
-        Buffer<float> output_multi = sink_multi.realize(100, 100);
+        Buffer<float> output_multi = sink_multi.realize({100, 100});
 
         // Should be all zeroes.
         RDom r(output_multi);

--- a/test/correctness/extern_reorder_storage.cpp
+++ b/test/correctness/extern_reorder_storage.cpp
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
     f.compute_root().reorder_storage(y, x);
 
     input.set(input_buffer);
-    Buffer<uint8_t> output = g.realize(W, H);
+    Buffer<uint8_t> output = g.realize({W, H});
     for (int i = 0; i < H; i++) {
         for (int j = 0; j < W; j++) {
             assert(output(j, i) == i + j);

--- a/test/correctness/extern_sort.cpp
+++ b/test/correctness/extern_sort.cpp
@@ -35,10 +35,10 @@ int main(int argc, char **argv) {
     std::vector<ExternFuncArgument> args;
     args.push_back(data);
     sorted.define_extern("sort_buffer", args, Float(32), 1);
-    Buffer<float> output = sorted.realize(100);
+    Buffer<float> output = sorted.realize({100});
 
     // Check the output
-    Buffer<float> reference = lambda(x, sin(x)).realize(100);
+    Buffer<float> reference = lambda(x, sin(x)).realize({100});
     std::sort(&reference(0), &reference(100));
 
     RDom r(reference);

--- a/test/correctness/extern_stage.cpp
+++ b/test/correctness/extern_stage.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
     Var xi;
     h.vectorize(x, 8).unroll(x, 2).split(x, x, xi, 4).parallel(x);
 
-    Buffer<uint8_t> result = h.realize(100);
+    Buffer<uint8_t> result = h.realize({100});
 
     for (int i = 0; i < 100; i++) {
         uint8_t correct = 4 * i * i;

--- a/test/correctness/extern_stage_on_device.cpp
+++ b/test/correctness/extern_stage_on_device.cpp
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
                 sink.gpu_tile(x, y, xi, yi, 16, 16);
             }
 
-            Buffer<int32_t> output = sink.realize(100, 100);
+            Buffer<int32_t> output = sink.realize({100, 100});
 
             // Should be all zeroes.
             RDom r(output);

--- a/test/correctness/failed_unroll.cpp
+++ b/test/correctness/failed_unroll.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
     f.unroll(x);
 
     setenv("HL_PERMIT_FAILED_UNROLL", "1", 1);
-    f.realize(17);
+    f.realize({17});
     printf("Success!\n");
 #endif
 

--- a/test/correctness/fast_trigonometric.cpp
+++ b/test/correctness/fast_trigonometric.cpp
@@ -16,8 +16,8 @@ int main(int argc, char **argv) {
     sin_f.vectorize(x, 8);
     cos_f.vectorize(x, 8);
 
-    Buffer<float> sin_result = sin_f.realize(1000);
-    Buffer<float> cos_result = cos_f.realize(1000);
+    Buffer<float> sin_result = sin_f.realize({1000});
+    Buffer<float> cos_result = cos_f.realize({1000});
 
     for (int i = 0; i < 1000; ++i) {
         const float alpha = i / 1000.f;

--- a/test/correctness/fibonacci.cpp
+++ b/test/correctness/fibonacci.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     g(x) = fib(x + 10);
 
     fib.compute_root();
-    Buffer<int> out = g.realize(10);
+    Buffer<int> out = g.realize({10});
 
     int fib_ref[20];
     fib_ref[0] = fib_ref[1] = 1;

--- a/test/correctness/float16_t.cpp
+++ b/test/correctness/float16_t.cpp
@@ -5,8 +5,8 @@ using namespace Halide;
 int main(int argc, char **argv) {
     Var x;
 
-    Buffer<float16_t> in1 = lambda(x, cast<float16_t>(-0.5f) + cast<float16_t>(x) / (128)).realize(128);
-    Buffer<bfloat16_t> in2 = lambda(x, cast<bfloat16_t>(-0.5f) + cast<bfloat16_t>(x) / (128)).realize(128);
+    Buffer<float16_t> in1 = lambda(x, cast<float16_t>(-0.5f) + cast<float16_t>(x) / (128)).realize({128});
+    Buffer<bfloat16_t> in2 = lambda(x, cast<bfloat16_t>(-0.5f) + cast<bfloat16_t>(x) / (128)).realize({128});
 
     // Check the Halide-side float 16 conversion math matches the C++-side math.
     in1.for_each_element([&](int i) {
@@ -155,7 +155,7 @@ int main(int argc, char **argv) {
         const char *names[] = {"trunc", "round", "ceil", "floor"};
 
         Pipeline p(funcs);
-        Realization r = p.realize(1024);
+        Realization r = p.realize({1024});
         for (int i = 0; i < 1024; i++) {
             for (int j = 0; j < 4; j++) {
                 float f32 = Buffer<float>(r[j])(i);
@@ -188,7 +188,7 @@ int main(int argc, char **argv) {
         Buffer<float16_t> in(8, 8);
         in.fill(float16_t(0.25f));
         input.set(in);
-        Buffer<float16_t> buf = output.realize(8, 8);
+        Buffer<float16_t> buf = output.realize({8, 8});
         for (int y = 0; y < 8; y++) {
             for (int x = 0; x < 8; x++) {
                 float16_t correct = float16_t((x * y) / 2.0f);

--- a/test/correctness/force_onto_stack.cpp
+++ b/test/correctness/force_onto_stack.cpp
@@ -44,13 +44,13 @@ int main(int argc, char **argv) {
         // Check there's no malloc when the bound is good
         g.set_custom_allocator(&my_malloc, &my_free);
         p.set(5);
-        g.realize(20);
+        g.realize({20});
         g.set_custom_allocator(nullptr, nullptr);
 
         // Check there was an assertion failure of the appropriate type when the bound is violated
         g.set_error_handler(&my_error);
         p.set(10);
-        g.realize(20);
+        g.realize({20});
 
         if (!errored) {
             printf("There was supposed to be an error\n");
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
         f.bound_extent(x, 8);
 
         g.set_custom_allocator(&my_malloc, &my_free);
-        g.realize(20);
+        g.realize({20});
     }
 
     printf("Success!\n");

--- a/test/correctness/func_clone.cpp
+++ b/test/correctness/func_clone.cpp
@@ -76,7 +76,7 @@ int func_clone_test() {
         return -1;
     }
 
-    Buffer<int> im = g.realize(200, 200);
+    Buffer<int> im = g.realize({200, 200});
     auto func = [](int x, int y) { return x; };
     if (check_image(im, func)) {
         return -1;
@@ -115,7 +115,7 @@ int multiple_funcs_sharing_clone_test() {
         return -1;
     }
 
-    Realization r = p.realize(200, 200);
+    Realization r = p.realize({200, 200});
     Buffer<int> img1 = r[0];
     Buffer<int> img2 = r[1];
     Buffer<int> img3 = r[2];
@@ -174,7 +174,7 @@ int update_defined_after_clone_test() {
             return -1;
         }
 
-        Buffer<int> im = g.realize(200, 200);
+        Buffer<int> im = g.realize({200, 200});
         auto func = [](int x, int y) {
             return ((0 <= x && x <= 99) && (0 <= y && y <= 99) && (x < y)) ? 3 * (x + y) : (x + y);
         };
@@ -201,7 +201,7 @@ int update_defined_after_clone_test() {
             return -1;
         }
 
-        Buffer<int> im = g.realize(200, 200);
+        Buffer<int> im = g.realize({200, 200});
         auto func = [](int x, int y) {
             return ((0 <= x && x <= 99) && (0 <= y && y <= 99) && (x < y)) ? 3 * (x + y) : (x + y);
         };
@@ -254,7 +254,7 @@ int clone_depend_on_mutated_func_test() {
         return -1;
     }
 
-    Realization r = p.realize(25, 25);
+    Realization r = p.realize({25, 25});
     Buffer<int> img_d = r[0];
     Buffer<int> img_e = r[1];
     Buffer<int> img_f = r[2];
@@ -317,7 +317,7 @@ int clone_on_clone_test() {
         return -1;
     }
 
-    Realization r = p.realize(25, 25);
+    Realization r = p.realize({25, 25});
     Buffer<int> img_c = r[0];
     Buffer<int> img_d = r[1];
     Buffer<int> img_e = r[2];
@@ -361,7 +361,7 @@ int clone_reduction_test() {
     sum.compute_at(f, x);
 
     Pipeline p({f, g});
-    p.realize(128);
+    p.realize({128});
 
     return 0;
 }

--- a/test/correctness/func_lifetime.cpp
+++ b/test/correctness/func_lifetime.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
     {
         printf("Realizing function f...\n");
 
-        Buffer<int> imf = f.realize(32, 32, target);
+        Buffer<int> imf = f.realize({32, 32}, target);
         if (!validate(imf, 1)) {
             return -1;
         }
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
 
         printf("Realizing function g...\n");
 
-        Buffer<int> img = g.realize(32, 32, target);
+        Buffer<int> img = g.realize({32, 32}, target);
         if (!validate(img, 2)) {
             return -1;
         }
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
     // Try using f again to ensure it is still valid (after g's destruction).
     printf("Realizing function f again...\n");
 
-    Buffer<int> imf2 = f.realize(32, 32, target);
+    Buffer<int> imf2 = f.realize({32, 32}, target);
     if (!validate(imf2, 1)) {
         return -1;
     }

--- a/test/correctness/func_lifetime_2.cpp
+++ b/test/correctness/func_lifetime_2.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
         {
             printf("Realizing function f...\n");
 
-            Buffer<int> imf = f.realize(32, 32, target);
+            Buffer<int> imf = f.realize({32, 32}, target);
             if (!validate(imf, 1)) {
                 return -1;
             }
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
 
         printf("Realizing function g...\n");
 
-        Buffer<int> img1 = g.realize(32, 32, target);
+        Buffer<int> img1 = g.realize({32, 32}, target);
         if (!validate(img1, 2)) {
             return -1;
         }
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
     // Try using g again to ensure it is still valid (after f's destruction).
     printf("Realizing function g again...\n");
 
-    Buffer<int> img2 = g.realize(32, 32, target);
+    Buffer<int> img2 = g.realize({32, 32}, target);
     if (!validate(img2, 2.0f)) {
         return -1;
     }

--- a/test/correctness/func_wrapper.cpp
+++ b/test/correctness/func_wrapper.cpp
@@ -305,7 +305,7 @@ int rdom_wrapper_test() {
         return -1;
     }
 
-    Buffer<int> im = wrapper.realize(W, H);
+    Buffer<int> im = wrapper.realize({W, H});
     auto func = [](int x, int y) { return 4 * x + 6 * y + 10; };
     if (check_image(im, func)) {
         return -1;

--- a/test/correctness/func_wrapper.cpp
+++ b/test/correctness/func_wrapper.cpp
@@ -91,7 +91,7 @@ int func_wrapper_test() {
         return -1;
     }
 
-    Buffer<int> im = g.realize(200, 200);
+    Buffer<int> im = g.realize({200, 200});
     auto func = [](int x, int y) { return x; };
     if (check_image(im, func)) {
         return -1;
@@ -130,7 +130,7 @@ int multiple_funcs_sharing_wrapper_test() {
         return -1;
     }
 
-    Realization r = p.realize(200, 200);
+    Realization r = p.realize({200, 200});
     Buffer<int> img1 = r[0];
     Buffer<int> img2 = r[1];
     Buffer<int> img3 = r[2];
@@ -179,7 +179,7 @@ int global_wrapper_test() {
         return -1;
     }
 
-    Buffer<int> im = h.realize(200, 200);
+    Buffer<int> im = h.realize({200, 200});
     auto func = [](int x, int y) { return 2 * (x + y); };
     if (check_image(im, func)) {
         return -1;
@@ -230,7 +230,7 @@ int update_defined_after_wrapper_test() {
             return -1;
         }
 
-        Buffer<int> im = g.realize(200, 200);
+        Buffer<int> im = g.realize({200, 200});
         auto func = [](int x, int y) {
             return ((0 <= x && x <= 99) && (0 <= y && y <= 99) && (x < y)) ? 3 * (x + y) : (x + y);
         };
@@ -258,7 +258,7 @@ int update_defined_after_wrapper_test() {
             return -1;
         }
 
-        Buffer<int> im = g.realize(200, 200);
+        Buffer<int> im = g.realize({200, 200});
         auto func = [](int x, int y) {
             return ((0 <= x && x <= 99) && (0 <= y && y <= 99) && (x < y)) ? 3 * (x + y) : (x + y);
         };
@@ -344,7 +344,7 @@ int global_and_custom_wrapper_test() {
         return -1;
     }
 
-    Buffer<int> im = result.realize(200, 200);
+    Buffer<int> im = result.realize({200, 200});
     auto func = [](int x, int y) { return 2 * x; };
     if (check_image(im, func)) {
         return -1;
@@ -389,7 +389,7 @@ int wrapper_depend_on_mutated_func_test() {
         return -1;
     }
 
-    Buffer<int> im = h.realize(200, 200);
+    Buffer<int> im = h.realize({200, 200});
     auto func = [](int x, int y) { return x + y; };
     if (check_image(im, func)) {
         return -1;
@@ -433,7 +433,7 @@ int wrapper_on_wrapper_test() {
         return -1;
     }
 
-    Buffer<int> im = h.realize(200, 200);
+    Buffer<int> im = h.realize({200, 200});
     auto func = [](int x, int y) { return 4 * (x + y); };
     if (check_image(im, func)) {
         return -1;
@@ -476,7 +476,7 @@ int wrapper_on_rdom_predicate_test() {
         return -1;
     }
 
-    Buffer<int> im = g.realize(200, 200);
+    Buffer<int> im = g.realize({200, 200});
     auto func = [](int x, int y) {
         return ((0 <= x && x <= 99) && (0 <= y && y <= 99) && (x + y + 5 < 50)) ? 15 : 10;
     };
@@ -516,7 +516,7 @@ int two_fold_wrapper_test() {
         return -1;
     }
 
-    Buffer<int> im = output.realize(1024, 1024);
+    Buffer<int> im = output.realize({1024, 1024});
     auto func = [](int x, int y) { return 3 * x + 2 * y; };
     if (check_image(im, func)) {
         return -1;
@@ -562,7 +562,7 @@ int multi_folds_wrapper_test() {
         return -1;
     }
 
-    Realization r = p.realize(1024, 1024);
+    Realization r = p.realize({1024, 1024});
     Buffer<int> img_g = r[0];
     Buffer<int> img_h = r[1];
     auto func = [](int x, int y) { return 3 * x + 2 * y; };

--- a/test/correctness/fused_where_inner_extent_is_zero.cpp
+++ b/test/correctness/fused_where_inner_extent_is_zero.cpp
@@ -22,11 +22,11 @@ int main(int argc, char **argv) {
         for (int o = 0; o < 2; o++) {
             inner_extent.set(i);
             outer_extent.set(o);
-            g.realize(10, 10);
+            g.realize({10, 10});
         }
     }
 
-    g.realize(10, 10);
+    g.realize({10, 10});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/fuzz_float_stores.cpp
+++ b/test/correctness/fuzz_float_stores.cpp
@@ -16,8 +16,8 @@ int main(int argc, char **argv) {
         f.vectorize(x, 8);
 
         // Pipelines that only use a few significant bits of the float should be unaffected
-        Buffer<float> im_ref = f.realize(size, target);
-        Buffer<float> im_fuzzed = f.realize(size, target_fuzzed);
+        Buffer<float> im_ref = f.realize({size}, target);
+        Buffer<float> im_fuzzed = f.realize({size}, target_fuzzed);
 
         for (int i = 0; i < im_ref.width(); i++) {
             // Test for exact floating point equality, which is exactly
@@ -36,8 +36,8 @@ int main(int argc, char **argv) {
         f(x) = sqrt(x - 42.3333333f) / 17.0f - tan(x);
         f.vectorize(x, 8);
 
-        Buffer<float> im_ref = f.realize(size, target);
-        Buffer<float> im_fuzzed = f.realize(size, target_fuzzed);
+        Buffer<float> im_ref = f.realize({size}, target);
+        Buffer<float> im_fuzzed = f.realize({size}, target_fuzzed);
 
         int differences = 0;
         for (int i = 0; i < im_ref.width(); i++) {

--- a/test/correctness/gameoflife.cpp
+++ b/test/correctness/gameoflife.cpp
@@ -54,11 +54,11 @@ int main(int argc, char **argv) {
 
         for (int i = 0; i < 10; i++) {
             input.set(board1);
-            board1 = oneIteration.realize(32, 32);
+            board1 = oneIteration.realize({32, 32});
             input.set(board1);
-            board1 = oneIteration.realize(32, 32);
+            board1 = oneIteration.realize({32, 32});
             input.set(board2);
-            board2 = twoIterations.realize(32, 32);
+            board2 = twoIterations.realize({32, 32});
 
             /*
             for (int y = 0; y < 32; y++) {

--- a/test/correctness/gather.cpp
+++ b/test/correctness/gather.cpp
@@ -62,7 +62,7 @@ bool test() {
         }
     }
 
-    Buffer<ITYPE> output_buf = output.realize(W_img, H_img);
+    Buffer<ITYPE> output_buf = output.realize({W_img, H_img});
 
     for (int y = 0; y < H_img; y++) {
         for (int x = 0; x < W_img; x++) {

--- a/test/correctness/gpu_allocation_cache.cpp
+++ b/test/correctness/gpu_allocation_cache.cpp
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
         Halide::Internal::JITSharedRuntime::reuse_device_allocations(use_cache);
 
         for (int i = 0; i < 300; i++) {
-            Buffer<float> result = f1[N - 1].realize(128, 128);
+            Buffer<float> result = f1[N - 1].realize({128, 128});
             if (validate) {
                 result.copy_to_host();
                 result.for_each_value([=](float f) {
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
         Halide::Internal::JITSharedRuntime::reuse_device_allocations(use_cache);
 
         for (int i = 0; i < 300; i++) {
-            Buffer<float> result = f2[N - 1].realize(128, 128);
+            Buffer<float> result = f2[N - 1].realize({128, 128});
             if (validate) {
                 result.copy_to_host();
                 result.for_each_value([=](float f) {
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
         Halide::Internal::JITSharedRuntime::reuse_device_allocations(use_cache);
         // Increasing size, overlapping lifetimes, looped 300 times. Should OOM on leak.
         for (int i = 0; i < 300; i++) {
-            Buffer<float> result = f3[N - 1].realize(128, 128);
+            Buffer<float> result = f3[N - 1].realize({128, 128});
             if (validate) {
                 result.copy_to_host();
                 result.for_each_value([=](float f) {

--- a/test/correctness/gpu_arg_types.cpp
+++ b/test/correctness/gpu_arg_types.cpp
@@ -19,8 +19,8 @@ int main(int argc, char *argv[]) {
     foo.set(-1);
     f.gpu_tile(x, tx, 8);
 
-    Buffer<int16_t> out = f.realize(256);
-    Buffer<int16_t> out2 = g.realize(256);
+    Buffer<int16_t> out = f.realize({256});
+    Buffer<int16_t> out2 = g.realize({256});
     out.copy_to_host();
 
     for (int i = 0; i < 256; i++) {

--- a/test/correctness/gpu_assertion_in_kernel.cpp
+++ b/test/correctness/gpu_assertion_in_kernel.cpp
@@ -43,14 +43,14 @@ int main(int argc, char **argv) {
     g.set_custom_print(&my_print);
 
     // Should succeed
-    g.realize(3, 100, t);
+    g.realize({3, 100}, t);
     if (errored) {
         printf("There was not supposed to be an error\n");
         return -1;
     }
 
     // Should trap
-    g.realize(4, 100, t);
+    g.realize({4, 100}, t);
 
     if (!errored) {
         printf("There was supposed to be an error\n");

--- a/test/correctness/gpu_condition_lifting.cpp
+++ b/test/correctness/gpu_condition_lifting.cpp
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
         .gpu_blocks(yi)
         .gpu_blocks(z);
 
-    Buffer<int> imf = f.realize(10, 10, 10, target);
+    Buffer<int> imf = f.realize({10, 10, 10}, target);
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/gpu_cpu_simultaneous_read.cpp
+++ b/test/correctness/gpu_cpu_simultaneous_read.cpp
@@ -31,10 +31,10 @@ int main() {
     t.fill(17);
     t(0) = 0;
     table.set(t);
-    Buffer<int32_t> result1 = h.realize(20, 20);
+    Buffer<int32_t> result1 = h.realize({20, 20});
     t(0) = 1;
     table.set(t);
-    Buffer<int32_t> result2 = h.realize(20, 20);
+    Buffer<int32_t> result2 = h.realize({20, 20});
 
     for (int y = 0; y < 20; y++) {
         for (int x = 0; x < 20; x++) {

--- a/test/correctness/gpu_dynamic_shared.cpp
+++ b/test/correctness/gpu_dynamic_shared.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
             f.store_in(memory_type);
 
             // The amount of shared/heap memory required varies with x
-            Buffer<int> out = g.realize(100);
+            Buffer<int> out = g.realize({100});
             for (int x = 0; x < 100; x++) {
                 int correct = 3 * x;
                 if (out(x) != correct) {

--- a/test/correctness/gpu_free_sync.cpp
+++ b/test/correctness/gpu_free_sync.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
         // frees it (calling dev_free) possibly before the compute is
         // done.
         for (int i = 0; i < 10; i++) {
-            f.realize(1024, 1024, t);
+            f.realize({1024, 1024}, t);
         }
     } else {
         // Skip this test if gpu target not enabled (it's pretty slow on a cpu).

--- a/test/correctness/gpu_give_input_buffers_device_allocations.cpp
+++ b/test/correctness/gpu_give_input_buffers_device_allocations.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
     Var x, y, xi, yi;
     f(x, y) = in(x, y);
     f.gpu_tile(x, y, xi, yi, 8, 8);
-    Buffer<float> out = f.realize(100, 100);
+    Buffer<float> out = f.realize({100, 100});
 
     // Check the output has a device allocation, and was copied to
     // host by realize.

--- a/test/correctness/gpu_jit_explicit_copy_to_device.cpp
+++ b/test/correctness/gpu_jit_explicit_copy_to_device.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
         f(x, y) = a(x, y) + b(x, y) + 2;
         f.gpu_tile(x, y, tx, ty, 8, 8, TailStrategy::Auto, d);
 
-        Buffer<float> out = f.realize(100, 100);
+        Buffer<float> out = f.realize({100, 100});
 
         out.for_each_value([&](float f) {
             if (f != 7.0f) {

--- a/test/correctness/gpu_large_alloc.cpp
+++ b/test/correctness/gpu_large_alloc.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
 
     printf("Realizing function...\n");
 
-    Buffer<int> img = g.realize(W, H, target);
+    Buffer<int> img = g.realize({W, H}, target);
 
     for (int i = 0; i < W; i++) {
         for (int j = 0; j < H; j++) {

--- a/test/correctness/gpu_mixed_dimensionality.cpp
+++ b/test/correctness/gpu_mixed_dimensionality.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
     f.compute_at(g, x);
     f.update();
 
-    Buffer<int> o = out.realize(64, 64, 64);
+    Buffer<int> o = out.realize({64, 64, 64});
 
     for (int z = 0; z < 64; z++) {
         for (int y = 0; y < 64; y++) {

--- a/test/correctness/gpu_mixed_shared_mem_types.cpp
+++ b/test/correctness/gpu_mixed_shared_mem_types.cpp
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
     out(x) = e;
     out.gpu_tile(x, xi, 23);
 
-    Buffer<> output = out.realize(23 * 5);
+    Buffer<> output = out.realize({23} * 5);
 
     int result;
     if (result_type == UInt(32)) {

--- a/test/correctness/gpu_mixed_shared_mem_types.cpp
+++ b/test/correctness/gpu_mixed_shared_mem_types.cpp
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
     out(x) = e;
     out.gpu_tile(x, xi, 23);
 
-    Buffer<> output = out.realize({23} * 5);
+    Buffer<> output = out.realize({23 * 5});
 
     int result;
     if (result_type == UInt(32)) {

--- a/test/correctness/gpu_multi_kernel.cpp
+++ b/test/correctness/gpu_multi_kernel.cpp
@@ -25,7 +25,7 @@ int main(int argc, char *argv[]) {
         kernel2.compute_root();
     }
 
-    Buffer<int32_t> result = kernel3.realize(256, target);
+    Buffer<int32_t> result = kernel3.realize({256}, target);
 
     for (int i = 0; i < 256; i++) {
         float a = floor((i + 0.5f) / 3.0f);

--- a/test/correctness/gpu_non_monotonic_shared_mem_size.cpp
+++ b/test/correctness/gpu_non_monotonic_shared_mem_size.cpp
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
 
         printf("Case 1 should use %d bytes of shared memory\n", max_elements);
 
-        g.realize(size);
+        g.realize({size});
     }
 
     {
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
         max_elements *= sizeof(int);
         printf("Case 2 should use %d bytes of shared memory\n", max_elements);
 
-        g.realize(width, height);
+        g.realize({width, height});
     }
 
     {
@@ -117,7 +117,7 @@ int main(int argc, char **argv) {
         max_elements *= (width / tile_width) * (height / tile_height);
         printf("Case 3 should use %d bytes of global memory\n", max_elements);
 
-        g.realize(width, height);
+        g.realize({width, height});
     }
 
     {
@@ -155,7 +155,7 @@ int main(int argc, char **argv) {
         printf("Case 4 should use %d bytes of global memory and %d bytes of shared memory\n",
                heap_bytes, max_elements);
 
-        g.realize(width, height);
+        g.realize({width, height});
     }
 
     printf("Success!\n");

--- a/test/correctness/gpu_object_lifetime_1.cpp
+++ b/test/correctness/gpu_object_lifetime_1.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
         }
         f.set_custom_print(halide_print);
 
-        Buffer<int32_t> result = f.realize(256, target);
+        Buffer<int32_t> result = f.realize({256}, target);
         for (int i = 0; i < 256; i++) {
             if (result(i) != i) {
                 std::cout << "Error! " << result(i) << " != " << i << "\n";

--- a/test/correctness/gpu_object_lifetime_2.cpp
+++ b/test/correctness/gpu_object_lifetime_2.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[]) {
         }
         h.set_custom_print(halide_print);
 
-        h.realize(256, target);
+        h.realize({256}, target);
     }
 
     Internal::JITSharedRuntime::release_all();

--- a/test/correctness/gpu_object_lifetime_3.cpp
+++ b/test/correctness/gpu_object_lifetime_3.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[]) {
 
         output.set_custom_print(halide_print);
 
-        output.realize(256, target);
+        output.realize({256}, target);
     }
 
     Internal::JITSharedRuntime::release_all();

--- a/test/correctness/gpu_param_allocation.cpp
+++ b/test/correctness/gpu_param_allocation.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
     f.compute_at(g, xi);
 
     slices.set(32);
-    g.realize(1024, 1024);
+    g.realize({1024, 1024});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/gpu_reuse_shared_memory.cpp
+++ b/test/correctness/gpu_reuse_shared_memory.cpp
@@ -25,7 +25,7 @@ int multi_thread_type_test(MemoryType memory_type) {
     const int size_y = 200;
     const int size_z = 4;
 
-    Buffer<uint8_t> out = f6.realize(size_x, size_y, size_z);
+    Buffer<uint8_t> out = f6.realize({size_x, size_y, size_z});
 
     uint8_t correct = 32;
     for (int z = 0; z < size_z; z++) {
@@ -69,7 +69,7 @@ int pyramid_test(MemoryType memory_type) {
             .store_in(memory_type);
     }
 
-    Buffer<int> out = funcs[levels - 1].realize(size_x, size_y);
+    Buffer<int> out = funcs[levels - 1].realize({size_x, size_y});
 
     int correct = 1;
     for (int y = 0; y < size_y; y++) {
@@ -118,7 +118,7 @@ int inverted_pyramid_test(MemoryType memory_type) {
         .bound(x, 0, size_x)
         .bound(y, 0, size_y);
 
-    Buffer<int> out = funcs[levels - 1].realize(size_x, size_y);
+    Buffer<int> out = funcs[levels - 1].realize({size_x, size_y});
 
     int correct = 1;
     for (int y = 0; y < size_y; y++) {

--- a/test/correctness/gpu_reuse_shared_memory.cpp
+++ b/test/correctness/gpu_reuse_shared_memory.cpp
@@ -151,7 +151,7 @@ int dynamic_shared_test(MemoryType memory_type) {
 
     // The amount of shared memory required varies with x
 
-    Buffer<int> out = f4.realize(500);
+    Buffer<int> out = f4.realize({500});
     for (int x = 0; x < out.width(); x++) {
         int correct = 27 * x;
         if (out(x) != correct) {

--- a/test/correctness/gpu_specialize.cpp
+++ b/test/correctness/gpu_specialize.cpp
@@ -47,9 +47,9 @@ int main(int argc, char **argv) {
         f.compute_at(g, xi);
 
         use_gpu.set(get_jit_target_from_environment().has_gpu_feature());
-        Buffer<int> out1 = h.realize(1024, 1024);
+        Buffer<int> out1 = h.realize({1024, 1024});
         use_gpu.set(false);
-        Buffer<int> out2 = h.realize(1024, 1024);
+        Buffer<int> out2 = h.realize({1024, 1024});
 
         for (int y = 0; y < out1.height(); y++) {
             for (int x = 0; x < out1.width(); x++) {
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
         g.tile(x, y, xi, yi, 2, 2).gpu_blocks(x, y);
 
         p.set(true);
-        Buffer<int> out = g.realize(32, 32);
+        Buffer<int> out = g.realize({32, 32});
 
         for (int y = 0; y < out.height(); y++) {
             for (int x = 0; x < out.width(); x++) {

--- a/test/correctness/gpu_store_in_register_with_no_lanes_loop.cpp
+++ b/test/correctness/gpu_store_in_register_with_no_lanes_loop.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
     // a GPULanes loop. This used to break (the allocation would
     // disappear entirely).
 
-    Buffer<int> result = g.realize(123, 245);
+    Buffer<int> result = g.realize({123, 245});
 
     for (int y = 0; y < result.height(); y++) {
         for (int x = 0; x < result.width(); x++) {

--- a/test/correctness/gpu_sum_scan.cpp
+++ b/test/correctness/gpu_sum_scan.cpp
@@ -46,10 +46,10 @@ int main(int argc, char **argv) {
     // Only deal with inputs that are a multiple of B
     out.bound(x, 0, im.width() / B * B);
 
-    Buffer<int> input = lambda(x, cast<int>(floor((sin(x)) * 100))).realize(N);
+    Buffer<int> input = lambda(x, cast<int>(floor((sin(x)) * 100))).realize({N});
 
     im.set(input);
-    Buffer<int> output = out.realize(N);
+    Buffer<int> output = out.realize({N});
 
     int correct = 0;
     for (int i = 0; i < N; i++) {

--- a/test/correctness/gpu_texture.cpp
+++ b/test/correctness/gpu_texture.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
             f.compute_root().store_in(memory_type).gpu_blocks(x);  // store f as integer
             g.output_buffer().store_in(memory_type);
 
-            Buffer<int> out = g.realize(100);
+            Buffer<int> out = g.realize({100});
             for (int x = 0; x < 100; x++) {
                 int correct = 2 * x + 10;
                 if (out(x) != correct) {
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
             f.compute_root().store_in(memory_type).gpu_blocks(x, y);  // store f as integer
             g.store_in(memory_type);
 
-            Buffer<int> out = g.realize(10);
+            Buffer<int> out = g.realize({10});
             for (int x = 0; x < 10; x++) {
                 int correct = 3 * x + 10;
                 if (out(x) != correct) {
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
 
             g.store_in(memory_type);
 
-            Buffer<int> out = g.realize(10);
+            Buffer<int> out = g.realize({10});
             for (int x = 0; x < 10; x++) {
                 int correct = 4 * x + 10;
                 if (out(x) != correct) {

--- a/test/correctness/gpu_thread_barrier.cpp
+++ b/test/correctness/gpu_thread_barrier.cpp
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
             f.update(i * 4 + 3).gpu_threads(x);
         }
 
-        Buffer<int> out = g.realize(100, 100);
+        Buffer<int> out = g.realize({100, 100});
         for (int y = 0; y < out.height(); y++) {
             for (int x = 0; x < out.width(); x++) {
                 int correct = 7 * 100 + 9;
@@ -134,7 +134,7 @@ int main(int argc, char **argv) {
         // non-undef definitions, and one between f and g.
         g.add_custom_lowering_pass(new CheckBarrierCount(3));
 
-        Buffer<int> out = g.realize(100, 100);
+        Buffer<int> out = g.realize({100, 100});
     }
 
     printf("Success!\n");

--- a/test/correctness/gpu_transpose.cpp
+++ b/test/correctness/gpu_transpose.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
     lambda(x, y, cast<uint8_t>(x * 17 + y)).realize(input);
     in.set(input);
 
-    Buffer<uint8_t> output = out.realize(256, 256);
+    Buffer<uint8_t> output = out.realize({256, 256});
 
     for (int y = 0; y < 256; y++) {
         for (int x = 0; x < 256; x++) {

--- a/test/correctness/gpu_vectorized_shared_memory.cpp
+++ b/test/correctness/gpu_vectorized_shared_memory.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
         g.split(x, xo, xi, 4).gpu_threads(xo).vectorize(xi);
         g.update().split(x, xo, xi, 4).gpu_threads(xo).vectorize(xi);
 
-        Buffer<int> out = h.realize(512);
+        Buffer<int> out = h.realize({512});
 
         for (int x = 0; x < out.width(); x++) {
             int correct = 4 * x + 90;

--- a/test/correctness/half_native_interleave.cpp
+++ b/test/correctness/half_native_interleave.cpp
@@ -38,9 +38,9 @@ int main(int argc, char **argv) {
     }
 
     // Run the pipeline and verify the results are correct.
-    Buffer<int16_t> out_p = product.realize(W, target);
-    Buffer<int16_t> out_s = sum.realize(W, target);
-    Buffer<int16_t> out_d = diff.realize(W, target);
+    Buffer<int16_t> out_p = product.realize({W}, target);
+    Buffer<int16_t> out_s = sum.realize({W}, target);
+    Buffer<int16_t> out_d = diff.realize({W}, target);
 
     for (int x = 1; x < W - 1; x++) {
         int16_t correct_p = input(x) * 2;

--- a/test/correctness/handle.cpp
+++ b/test/correctness/handle.cpp
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
         g.compute_root();
         h(x) = g(x);
 
-        Buffer<char *> im = h.realize(100);
+        Buffer<char *> im = h.realize({100});
 
         uint64_t handle = (uint64_t)(im(0));
         if (sizeof(char *) == 4) {

--- a/test/correctness/heap_cleanup.cpp
+++ b/test/correctness/heap_cleanup.cpp
@@ -52,7 +52,7 @@ int main(int argc, char **argv) {
     h.set_custom_allocator(my_malloc, my_free);
     h.set_error_handler(my_error_handler);
 
-    Buffer<int> im = h.realize(g_size + 100);
+    Buffer<int> im = h.realize({g_size + 100});
 
     printf("%d %d\n", (int)malloc_count, (int)free_count);
 

--- a/test/correctness/hello_gpu.cpp
+++ b/test/correctness/hello_gpu.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
 
     printf("Realizing function...\n");
 
-    Buffer<float> imf = f.realize(32, 32, target);
+    Buffer<float> imf = f.realize({32, 32}, target);
 
     // Check the result was what we expected
     for (int i = 0; i < 32; i++) {

--- a/test/correctness/hexagon_scatter.cpp
+++ b/test/correctness/hexagon_scatter.cpp
@@ -81,7 +81,7 @@ int test() {
         }
     }
 
-    Buffer<DTYPE> buf = g.realize(W, H);
+    Buffer<DTYPE> buf = g.realize({W, H});
 
     for (int y = 0; y < H; y++) {
         for (int x = 0; x < W; x++) {

--- a/test/correctness/histogram.cpp
+++ b/test/correctness/histogram.cpp
@@ -62,7 +62,7 @@ bool test() {
         hist.compute_root();
     }
 
-    Buffer<HTYPE> histogram = g.realize(128);  // buckets 10-137
+    Buffer<HTYPE> histogram = g.realize({128});  // buckets 10-137
 
     for (int i = 10; i < 138; i++) {
         if (histogram(i - 10) != reference_hist[i]) {

--- a/test/correctness/histogram_equalize.cpp
+++ b/test/correctness/histogram_equalize.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
     int pixels = in.extent(0) * in.extent(1);
     rescaled(i, _) = cast<uint8_t>((equalized(i, _) * 256) / pixels);
 
-    Buffer<uint8_t> out = rescaled.realize(in.width(), in.height());
+    Buffer<uint8_t> out = rescaled.realize({in.width(), in.height()});
 
     // Compute the histogram of the output
     int out_hist[16], in_hist[16];

--- a/test/correctness/hoist_loop_invariant_if_statements.cpp
+++ b/test/correctness/hoist_loop_invariant_if_statements.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
     g.add_custom_lowering_pass(&checker, []() {});
 
     p.set(true);
-    g.realize(1024, 1024);
+    g.realize({1024, 1024});
 
     if (checker.if_in_loop) {
         printf("Found an if statement inside a loop. This was not supposed to happen\n");

--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -169,7 +169,7 @@ void do_test() {
     const float one = std::numeric_limits<T>::max();
     f(x, y, c) = cast<T>(clamp(make_noise(10)(x, y, c), 0.0f, 1.0f) * one);
 
-    Buffer<T> color_buf = f.realize(width, height, 3);
+    Buffer<T> color_buf = f.realize({width, height, 3});
 
     // Inset it a bit to ensure that saving buffers with nonzero mins works
     const int inset = 4;

--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -206,7 +206,7 @@ void do_test() {
             // Here we test matching strides
             Func f2;
             f2(x, y, c, w) = f(x, y, c);
-            Buffer<T> funky_buf = f2.realize(10, 10, 1, 3);
+            Buffer<T> funky_buf = f2.realize({10, 10, 1, 3});
             funky_buf.fill(42);
 
             std::cout << "Testing format: " << format << " for " << halide_type_of<T>() << "x4\n";

--- a/test/correctness/image_of_lists.cpp
+++ b/test/correctness/image_of_lists.cpp
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
     // the condition into the C function.
     factors(x) = list_maybe_insert(factors(x), x % r == 0, r);
 
-    Buffer<std::list<int> *> result = factors.realize(100);
+    Buffer<std::list<int> *> result = factors.realize({100});
 
     // Inspect the results for correctness
     for (int i = 0; i < 100; i++) {

--- a/test/correctness/image_wrapper.cpp
+++ b/test/correctness/image_wrapper.cpp
@@ -298,7 +298,7 @@ int rdom_wrapper_test() {
 
     source(x, y) = x + y;
     ImageParam img(Int(32), 2, "img");
-    Buffer<int> buf = source.realize(W, H);
+    Buffer<int> buf = source.realize({W, H});
     img.set(buf);
 
     g(x, y) = 10;
@@ -329,7 +329,7 @@ int rdom_wrapper_test() {
         return -1;
     }
 
-    Buffer<int> im = wrapper.realize(W, H);
+    Buffer<int> im = wrapper.realize({W, H});
     auto func = [](int x, int y) { return 4 * x + 6 * y + 10; };
     if (check_image(im, func)) {
         return -1;

--- a/test/correctness/image_wrapper.cpp
+++ b/test/correctness/image_wrapper.cpp
@@ -71,7 +71,7 @@ int func_wrapper_test() {
 
     source(x) = x;
     ImageParam img(Int(32), 1, "img");
-    Buffer<int> buf = source.realize(200);
+    Buffer<int> buf = source.realize({200});
     img.set(buf);
 
     g(x, y) = img(x);
@@ -95,7 +95,7 @@ int func_wrapper_test() {
         return -1;
     }
 
-    Buffer<int> im = g.realize(200, 200);
+    Buffer<int> im = g.realize({200, 200});
     auto func = [](int x, int y) { return x; };
     if (check_image(im, func)) {
         return -1;
@@ -109,7 +109,7 @@ int multiple_funcs_sharing_wrapper_test() {
 
     source(x) = x;
     ImageParam img(Int(32), 1, "img");
-    Buffer<int> buf = source.realize(200);
+    Buffer<int> buf = source.realize({200});
     img.set(buf);
 
     g1(x, y) = img(x);
@@ -139,7 +139,7 @@ int multiple_funcs_sharing_wrapper_test() {
         return -1;
     }
 
-    Realization r = p.realize(200, 200);
+    Realization r = p.realize({200, 200});
     Buffer<int> img1 = r[0];
     Buffer<int> img2 = r[1];
     Buffer<int> img3 = r[2];
@@ -162,7 +162,7 @@ int global_wrapper_test() {
 
     source(x, y) = x + y;
     ImageParam img(Int(32), 2, "img");
-    Buffer<int> buf = source.realize(200, 200);
+    Buffer<int> buf = source.realize({200, 200});
     img.set(buf);
 
     g(x, y) = img(x, y);
@@ -193,7 +193,7 @@ int global_wrapper_test() {
         return -1;
     }
 
-    Buffer<int> im = h.realize(200, 200);
+    Buffer<int> im = h.realize({200, 200});
     auto func = [](int x, int y) { return 2 * (x + y); };
     if (check_image(im, func)) {
         return -1;
@@ -207,7 +207,7 @@ int update_defined_after_wrapper_test() {
 
     source(x, y) = x + y;
     ImageParam img(Int(32), 2, "img");
-    Buffer<int> buf = source.realize(200, 200);
+    Buffer<int> buf = source.realize({200, 200});
     img.set(buf);
 
     g(x, y) = img(x, y);
@@ -249,7 +249,7 @@ int update_defined_after_wrapper_test() {
             return -1;
         }
 
-        Buffer<int> im = g.realize(200, 200);
+        Buffer<int> im = g.realize({200, 200});
         auto func = [](int x, int y) {
             return ((0 <= x && x <= 99) && (0 <= y && y <= 99) && (x < y)) ? 3 * (x + y) : (x + y);
         };
@@ -277,7 +277,7 @@ int update_defined_after_wrapper_test() {
             return -1;
         }
 
-        Buffer<int> im = g.realize(200, 200);
+        Buffer<int> im = g.realize({200, 200});
         auto func = [](int x, int y) {
             return ((0 <= x && x <= 99) && (0 <= y && y <= 99) && (x < y)) ? 3 * (x + y) : (x + y);
         };
@@ -343,7 +343,7 @@ int global_and_custom_wrapper_test() {
 
     source(x) = x;
     ImageParam img(Int(32), 1, "img");
-    Buffer<int> buf = source.realize(200);
+    Buffer<int> buf = source.realize({200});
     img.set(buf);
 
     g(x, y) = img(x);
@@ -373,7 +373,7 @@ int global_and_custom_wrapper_test() {
         return -1;
     }
 
-    Buffer<int> im = result.realize(200, 200);
+    Buffer<int> im = result.realize({200, 200});
     auto func = [](int x, int y) { return 2 * x; };
     if (check_image(im, func)) {
         return -1;
@@ -387,7 +387,7 @@ int wrapper_depend_on_mutated_func_test() {
 
     source(x, y) = x + y;
     ImageParam img(Int(32), 2, "img");
-    Buffer<int> buf = source.realize(200, 200);
+    Buffer<int> buf = source.realize({200, 200});
     img.set(buf);
 
     f(x, y) = img(x, y);
@@ -423,7 +423,7 @@ int wrapper_depend_on_mutated_func_test() {
         return -1;
     }
 
-    Buffer<int> im = h.realize(200, 200);
+    Buffer<int> im = h.realize({200, 200});
     auto func = [](int x, int y) { return x + y; };
     if (check_image(im, func)) {
         return -1;
@@ -437,7 +437,7 @@ int wrapper_on_wrapper_test() {
 
     source(x, y) = x + y;
     ImageParam img(Int(32), 2, "img");
-    Buffer<int> buf = source.realize(200, 200);
+    Buffer<int> buf = source.realize({200, 200});
     img.set(buf);
 
     g(x, y) = img(x, y) + img(x, y);
@@ -469,7 +469,7 @@ int wrapper_on_wrapper_test() {
         return -1;
     }
 
-    Buffer<int> im = h.realize(200, 200);
+    Buffer<int> im = h.realize({200, 200});
     auto func = [](int x, int y) { return 4 * (x + y); };
     if (check_image(im, func)) {
         return -1;
@@ -483,7 +483,7 @@ int wrapper_on_rdom_predicate_test() {
 
     source(x, y) = x + y;
     ImageParam img(Int(32), 2, "img");
-    Buffer<int> buf = source.realize(200, 200);
+    Buffer<int> buf = source.realize({200, 200});
     img.set(buf);
 
     g(x, y) = 10;
@@ -518,7 +518,7 @@ int wrapper_on_rdom_predicate_test() {
         return -1;
     }
 
-    Buffer<int> im = g.realize(200, 200);
+    Buffer<int> im = g.realize({200, 200});
     auto func = [](int x, int y) {
         return ((0 <= x && x <= 99) && (0 <= y && y <= 99) && (x + y + 5 < 50)) ? 15 : 10;
     };
@@ -534,7 +534,7 @@ int two_fold_wrapper_test() {
 
     source(x, y) = 2 * x + 3 * y;
     ImageParam img(Int(32), 2, "img");
-    Buffer<int> buf = source.realize(1024, 1024);
+    Buffer<int> buf = source.realize({1024, 1024});
     img.set(buf);
 
     Func img_f = img;
@@ -563,7 +563,7 @@ int two_fold_wrapper_test() {
         return -1;
     }
 
-    Buffer<int> im = output.realize(1024, 1024);
+    Buffer<int> im = output.realize({1024, 1024});
     auto func = [](int x, int y) { return 3 * x + 2 * y; };
     if (check_image(im, func)) {
         return -1;
@@ -577,7 +577,7 @@ int multi_folds_wrapper_test() {
 
     source(x, y) = 2 * x + 3 * y;
     ImageParam img(Int(32), 2, "img");
-    Buffer<int> buf = source.realize(1024, 1024);
+    Buffer<int> buf = source.realize({1024, 1024});
     img.set(buf);
 
     Func img_f = img;
@@ -614,7 +614,7 @@ int multi_folds_wrapper_test() {
         return -1;
     }
 
-    Realization r = p.realize(1024, 1024);
+    Realization r = p.realize({1024, 1024});
     Buffer<int> img_g = r[0];
     Buffer<int> img_h = r[1];
     auto func = [](int x, int y) { return 3 * x + 2 * y; };

--- a/test/correctness/implicit_args.cpp
+++ b/test/correctness/implicit_args.cpp
@@ -11,10 +11,10 @@ int main(int argc, char **argv) {
     assert(im1.dimensions() == 3);
     // im1 is a 3d imageparam
 
-    Buffer<int> im1_val = lambda(x, y, z, x * y * z).realize(10, 10, 10);
+    Buffer<int> im1_val = lambda(x, y, z, x * y * z).realize({10, 10, 10});
     im1.set(im1_val);
 
-    Buffer<int> im2 = lambda(x, y, x + y).realize(10, 10);
+    Buffer<int> im2 = lambda(x, y, x + y).realize({10, 10});
     assert(im2.dimensions() == 2);
     assert(im2(4, 6) == 10);
     // im2 is a 2d image
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
     // f(x, i, j, k) = im1(i, j, k) + im2(x, i) + im2(i, j);
     // f(x, i, j, k) = i*j*k + x+i + i+j;
 
-    Buffer<int> result1 = f.realize(2, 2, 2, 2);
+    Buffer<int> result1 = f.realize({2, 2, 2, 2});
     for (int k = 0; k < 2; k++) {
         for (int j = 0; j < 2; j++) {
             for (int i = 0; i < 2; i++) {
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
 
     assert(g.dimensions() == 2);
 
-    Buffer<int> result2 = g.realize(10, 10);
+    Buffer<int> result2 = g.realize({10, 10});
     for (int j = 0; j < 10; j++) {
         for (int i = 0; i < 10; i++) {
             int correct = 2 * i * j + 2 + 2 + 2 + i + 1 + i;
@@ -66,13 +66,13 @@ int main(int argc, char **argv) {
     }
 
     // An image which ensures any transposition of unequal coordinates changes the value
-    Buffer<int> im3 = lambda(x, y, z, w, (x << 24) | (y << 16) | (z << 8) | w).realize(10, 10, 10, 10);
+    Buffer<int> im3 = lambda(x, y, z, w, (x << 24) | (y << 16) | (z << 8) | w).realize({10, 10, 10, 10});
 
     Func transpose_last_two;
     transpose_last_two(_, x, y) = im3(_, y, x);
     // Equivalent to transpose_last_two(_0, _1, x, y) = im3(_0, _1, x, y)
 
-    Buffer<int> transposed = transpose_last_two.realize(10, 10, 10, 10);
+    Buffer<int> transposed = transpose_last_two.realize({10, 10, 10, 10});
 
     for (int i = 0; i < 10; i++) {
         for (int j = 0; j < 10; j++) {
@@ -94,7 +94,7 @@ int main(int argc, char **argv) {
     // Equivalent to hairy_transpose(_0, _1, x, y) = im3(y, _0, _1, x) +
     // im3(y, x, _0, _1)
 
-    Buffer<int> hairy_transposed = hairy_transpose.realize(10, 10, 10, 10);
+    Buffer<int> hairy_transposed = hairy_transpose.realize({10, 10, 10, 10});
 
     for (int i = 0; i < 10; i++) {
         for (int j = 0; j < 10; j++) {
@@ -118,7 +118,7 @@ int main(int argc, char **argv) {
     // Equivalent to hairy_transpose2(_0, _1, _2, x) = im3(_0, _1, _2, x) +
     // im3(x, x, _0, _1)
 
-    Buffer<int> hairy_transposed2 = hairy_transpose2.realize(10, 10, 10, 10);
+    Buffer<int> hairy_transposed2 = hairy_transpose2.realize({10, 10, 10, 10});
 
     for (int i = 0; i < 10; i++) {
         for (int j = 0; j < 10; j++) {

--- a/test/correctness/implicit_args_tests.cpp
+++ b/test/correctness/implicit_args_tests.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
 
         f(x, _) = h(_) + 2;  // This means f(x, _0, _1) = h(_0, _1) + 2
 
-        Realization result = f.realize(100, 100, 100);
+        Realization result = f.realize({100, 100, 100});
         auto func = [](int x, int y, int z) {
             return y + z + 2;
         };
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
         g(x, _) = h(_) + 1;                  // This means g(x, _0, _1) = h(_0, _1) + 1
         g(clamp(f(r.x, _), 0, 50), _) += 2;  // This means g(f(r.x, _0, _1), _0, _1) += 2
 
-        Realization result = g.realize(100, 100, 100);
+        Realization result = g.realize({100, 100, 100});
         auto func = [](int x, int y, int z) {
             return (x == 0) || (x == 1) ? y + z + 3 : y + z + 1;
         };
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
         f(x, _) = h(_) + 3;      // This means f(x, _0, _1) = h(_0, _1) + 3
         f(x, _) += h(_) * g(_);  // This means f(x, _0, _1) += h(_0, _1) * g(_0)
 
-        Realization result = f.realize(100, 100, 100);
+        Realization result = f.realize({100, 100, 100});
         auto func = [](int x, int y, int z) {
             return (y + z + 3) + (y + z) * (y + 2);
         };
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
         //   f(x, _0, _1) += h(_0, _1) + 2
         f(x, _) += h(_) + 2;
 
-        Realization result = f.realize(100, 100, 100);
+        Realization result = f.realize({100, 100, 100});
         auto func = [](int x, int y, int z) {
             return y + z + 2;
         };
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
         //   f(_0, _1) += h(_0, _1)*g(_0) + 3
         f(_) += h(_) * g(_) + 3;
 
-        Realization result = f.realize(100, 100);
+        Realization result = f.realize({100, 100});
         auto func = [](int x, int y, int z) {
             return (x + y) * (x + 2) + 3;
         };
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
         // This means f(x, _0, _1) = {h(_0, _1) + 2, x + 2}
         f(x, _) = Tuple(h(_) + 2, x + 2);
 
-        Realization result = f.realize(100, 100, 100);
+        Realization result = f.realize({100, 100, 100});
         auto func1 = [](int x, int y, int z) {
             return y + z + 2;
         };
@@ -173,7 +173,7 @@ int main(int argc, char **argv) {
         // This means g(f(r.x, _0, _1), _0, _1) += {2}
         g(clamp(f(r.x, _), 0, 50), _) += Tuple(2);
 
-        Realization result = g.realize(100, 100, 100);
+        Realization result = g.realize({100, 100, 100});
         auto func = [](int x, int y, int z) {
             return (x == 0) || (x == 1) ? y + z + 3 : y + z + 1;
         };
@@ -194,7 +194,7 @@ int main(int argc, char **argv) {
         //   f(x, _0, _1) += {h(_0, _1)[0] + 2, h(_0, _1)[1] * 3}
         f(x, _) *= Tuple(h(_) + 2, h(_) * 3);
 
-        Realization result = f.realize(100, 100, 100);
+        Realization result = f.realize({100, 100, 100});
         auto func1 = [](int x, int y, int z) {
             return y + z + 2;
         };
@@ -221,7 +221,7 @@ int main(int argc, char **argv) {
         // This means f(x, _0, _1) += {h(_0, _1)[0]*g(_0)[0], h(_0, _1)[1]*g(_0)[1]}
         f(x, _) += Tuple(h(_)[0] * g(_)[0], h(_)[1] * g(_)[1]);
 
-        Realization result = f.realize(100, 100, 100);
+        Realization result = f.realize({100, 100, 100});
         auto func1 = [](int x, int y, int z) {
             return (y + z + 3) + (y + z) * (y + 2);
         };
@@ -248,7 +248,7 @@ int main(int argc, char **argv) {
         //   f(_0, _1) += {h(_0, _1)[0]*g(_0)[0] + 3, h(_0, _1)[1]*g(_0)[1] + 4}
         f(_) += Tuple(h(_)[0] * g(_)[0] + 3, h(_)[1] * g(_)[1] + 4);
 
-        Realization result = f.realize(100, 100);
+        Realization result = f.realize({100, 100});
         auto func1 = [](int x, int y, int z) {
             return (x + y) * (x + 2) + 3;
         };

--- a/test/correctness/in_place.cpp
+++ b/test/correctness/in_place.cpp
@@ -17,16 +17,16 @@ int main(int argc, char **argv) {
     f(r) += f(r - 1);
 
     // Make some test data.
-    Buffer<float> data = lambda(x, sin(x)).realize(100);
+    Buffer<float> data = lambda(x, sin(x)).realize({100});
 
     f.realize(data);
 
     // Do the same thing not in-place
-    Buffer<float> reference_in = lambda(x, sin(x)).realize(100);
+    Buffer<float> reference_in = lambda(x, sin(x)).realize({100});
     Func g;
     g(x) = reference_in(x);
     g(r) += g(r - 1);
-    Buffer<float> reference_out = g.realize(100);
+    Buffer<float> reference_out = g.realize({100});
 
     float err = evaluate_may_gpu<float>(sum(abs(data(r) - reference_out(r))));
 
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
     // storing the same value has undesireable side-effects.
 
     // This sets the even numbered entires to 1.
-    data = lambda(x, sin(x)).realize(100);
+    data = lambda(x, sin(x)).realize({100});
     Func h;
     h(x) = select(x % 2 == 0, 1.0f, undef<float>());
     h.vectorize(x, 4);

--- a/test/correctness/inline_reduction.cpp
+++ b/test/correctness/inline_reduction.cpp
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
     Expr local_mean = sum(input_val) / 9.0f;
     local_variance(x, y) = sum(input_val * input_val) / 81.0f - local_mean * local_mean;
 
-    Buffer<float> result = local_variance.realize(10, 10);
+    Buffer<float> result = local_variance.realize({10, 10});
 
     for (int y = 0; y < 10; y++) {
         for (int x = 0; x < 10; x++) {
@@ -61,10 +61,10 @@ int main(int argc, char **argv) {
     local_min.vectorize(x, 4);
     min_y.vectorize(x, 4);
 
-    Buffer<float> prod_im = local_product.realize(10, 10);
-    Buffer<float> max_im = local_max.realize(10, 10);
-    Buffer<float> min_im = local_min.realize(10, 10);
-    Buffer<float> min_im_separable = min_y.realize(10, 10);
+    Buffer<float> prod_im = local_product.realize({10, 10});
+    Buffer<float> max_im = local_max.realize({10, 10});
+    Buffer<float> min_im = local_min.realize({10, 10});
+    Buffer<float> min_im_separable = min_y.realize({10, 10});
 
     for (int y = 0; y < 10; y++) {
         for (int x = 0; x < 10; x++) {
@@ -108,32 +108,32 @@ int main(int argc, char **argv) {
     }
 
     // Verify that all inline reductions compile with implicit argument syntax.
-    Buffer<float> input_3d = lambda(x, y, z, x * 100.0f + y * 10.0f + ((z + 5 % 10))).realize(10, 10, 10);
+    Buffer<float> input_3d = lambda(x, y, z, x * 100.0f + y * 10.0f + ((z + 5 % 10))).realize({10, 10, 10});
     RDom all_z(input_3d.min(2), input_3d.extent(2));
 
     Func sum_implicit;
     sum_implicit(_) = sum(input_3d(_, all_z));
-    Buffer<float> sum_implicit_im = sum_implicit.realize(10, 10);
+    Buffer<float> sum_implicit_im = sum_implicit.realize({10, 10});
 
     Func product_implicit;
     product_implicit(_) = product(input_3d(_, all_z));
-    Buffer<float> product_implicit_im = product_implicit.realize(10, 10);
+    Buffer<float> product_implicit_im = product_implicit.realize({10, 10});
 
     Func min_implicit;
     min_implicit(_) = minimum(input_3d(_, all_z));
-    Buffer<float> min_implicit_im = min_implicit.realize(10, 10);
+    Buffer<float> min_implicit_im = min_implicit.realize({10, 10});
 
     Func max_implicit;
     max_implicit(_, y) = maximum(input_3d(_, y, all_z));
-    Buffer<float> max_implicit_im = max_implicit.realize(10, 10);
+    Buffer<float> max_implicit_im = max_implicit.realize({10, 10});
 
     Func argmin_implicit;
     argmin_implicit(_) = argmin(input_3d(_, all_z))[0];
-    Buffer<int32_t> argmin_implicit_im = argmin_implicit.realize(10, 10);
+    Buffer<int32_t> argmin_implicit_im = argmin_implicit.realize({10, 10});
 
     Func argmax_implicit;
     argmax_implicit(x, _) = argmax(input_3d(x, _, all_z))[0];
-    Buffer<int32_t> argmax_implicit_im = argmax_implicit.realize(10, 10);
+    Buffer<int32_t> argmax_implicit_im = argmax_implicit.realize({10, 10});
 
     // Verify that the min of negative floats and doubles is correct
     // (this used to be buggy due to the minimum float being the

--- a/test/correctness/inlined_generator.cpp
+++ b/test/correctness/inlined_generator.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
         // (Note that this uses the default values for all GeneratorParams.)
         auto gen = context.apply<Example>(kRuntimeFactor, kRuntimeOffset);  // gen's type is std::unique_ptr<Example>
 
-        Buffer<int32_t> img = gen->realize(kSize, kSize, 3);
+        Buffer<int32_t> img = gen->realize({kSize, kSize, 3});
         verify(img, gen->compiletime_factor, kRuntimeFactor, kRuntimeOffset);
     }
 
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
 
         gen->apply(kRuntimeFactor, kRuntimeOffset);
 
-        Buffer<int32_t> img = gen->realize(kSize, kSize, 3);
+        Buffer<int32_t> img = gen->realize({kSize, kSize, 3});
         verify(img, gen->compiletime_factor, kRuntimeFactor, kRuntimeOffset);
     }
 

--- a/test/correctness/input_image_bounds_check.cpp
+++ b/test/correctness/input_image_bounds_check.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
     f.set_error_handler(&halide_error);
 
     // One easy way to read out of bounds
-    f.realize(23);
+    f.realize({23});
 
     if (!error_occurred) {
         printf("There should have been an out-of-bounds error\n");
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
     g.compute_root().vectorize(x, 4);
 
     h.set_error_handler(&halide_error);
-    h.realize(18);
+    h.realize({18});
 
     if (error_occurred) {
         printf("There should not have been an out-of-bounds error\n");
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
     i(x) = small_input(x);
     i.vectorize(x, 4);
     i.set_error_handler(&halide_error);
-    i.realize(4);
+    i.realize({4});
     if (!error_occurred) {
         printf("There should have been an out-of-bounds error\n");
         return 1;

--- a/test/correctness/integer_powers.cpp
+++ b/test/correctness/integer_powers.cpp
@@ -50,9 +50,9 @@ int main(int argc, char **argv) {
         exact_sin(x) = sin(xf);
 
         // Evaluate from 0 to 5
-        Buffer<float> approx_result_1 = approx_sin_1.realize({256} * 5);
-        Buffer<float> approx_result_2 = approx_sin_2.realize({256} * 5);
-        Buffer<float> exact_result = exact_sin.realize({256} * 5);
+        Buffer<float> approx_result_1 = approx_sin_1.realize({256 * 5});
+        Buffer<float> approx_result_2 = approx_sin_2.realize({256 * 5});
+        Buffer<float> exact_result = exact_sin.realize({256 * 5});
 
         Func rms_1, rms_2;
         RDom r(exact_result);
@@ -92,9 +92,9 @@ int main(int argc, char **argv) {
         exact_exp(x) = exp(1.0f / xf);
 
         // Evaluate from 0 to 5
-        Buffer<float> approx_result_1 = approx_exp_1.realize({256} * 5);
-        Buffer<float> approx_result_2 = approx_exp_2.realize({256} * 5);
-        Buffer<float> exact_result = exact_exp.realize({256} * 5);
+        Buffer<float> approx_result_1 = approx_exp_1.realize({256 * 5});
+        Buffer<float> approx_result_2 = approx_exp_2.realize({256 * 5});
+        Buffer<float> exact_result = exact_exp.realize({256 * 5});
 
         Func rms_1, rms_2;
         RDom r(exact_result);

--- a/test/correctness/integer_powers.cpp
+++ b/test/correctness/integer_powers.cpp
@@ -50,9 +50,9 @@ int main(int argc, char **argv) {
         exact_sin(x) = sin(xf);
 
         // Evaluate from 0 to 5
-        Buffer<float> approx_result_1 = approx_sin_1.realize(256 * 5);
-        Buffer<float> approx_result_2 = approx_sin_2.realize(256 * 5);
-        Buffer<float> exact_result = exact_sin.realize(256 * 5);
+        Buffer<float> approx_result_1 = approx_sin_1.realize({256} * 5);
+        Buffer<float> approx_result_2 = approx_sin_2.realize({256} * 5);
+        Buffer<float> exact_result = exact_sin.realize({256} * 5);
 
         Func rms_1, rms_2;
         RDom r(exact_result);
@@ -92,9 +92,9 @@ int main(int argc, char **argv) {
         exact_exp(x) = exp(1.0f / xf);
 
         // Evaluate from 0 to 5
-        Buffer<float> approx_result_1 = approx_exp_1.realize(256 * 5);
-        Buffer<float> approx_result_2 = approx_exp_2.realize(256 * 5);
-        Buffer<float> exact_result = exact_exp.realize(256 * 5);
+        Buffer<float> approx_result_1 = approx_exp_1.realize({256} * 5);
+        Buffer<float> approx_result_2 = approx_exp_2.realize({256} * 5);
+        Buffer<float> exact_result = exact_exp.realize({256} * 5);
 
         Func rms_1, rms_2;
         RDom r(exact_result);

--- a/test/correctness/interleave.cpp
+++ b/test/correctness/interleave.cpp
@@ -110,7 +110,7 @@ int main(int argc, char **argv) {
 
         check_interleave_count(h, 1);
 
-        Realization results = h.realize(16);
+        Realization results = h.realize({16});
         for (int i = 0; i < elements; i++) {
             Buffer<float> result = results[i];
             for (int x = 0; x < 16; x++) {
@@ -324,7 +324,7 @@ int main(int argc, char **argv) {
 
             if (i == 0) {
                 // Making the reference output.
-                refs = new Realization(output6.realize(50, 4));
+                refs = new Realization(output6.realize({50, 4}));
             } else {
                 // Vectorize and compare to the reference.
                 for (int j = 0; j < 11; j++) {
@@ -333,7 +333,7 @@ int main(int argc, char **argv) {
 
                 check_interleave_count(output6, 2 * elements);
 
-                Realization outs = output6.realize(50, 4);
+                Realization outs = output6.realize({50, 4});
                 for (int e = 0; e < elements; e++) {
                     Buffer<uint8_t> ref = (*refs)[e];
                     Buffer<uint8_t> out = outs[e];

--- a/test/correctness/interleave_x.cpp
+++ b/test/correctness/interleave_x.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
         interleaved.tile(x, y, xo, yo, x, y, 8, 8).vectorize(x);
     }
 
-    Buffer<uint16_t> out = interleaved.realize(128, 128, target);
+    Buffer<uint16_t> out = interleaved.realize({128, 128}, target);
     for (int y = 0; y < out.height(); y++) {
         for (int x = 0; x < out.width(); x++) {
             uint16_t correct = x % 2 == 0 ? 3 : 7;

--- a/test/correctness/inverse.cpp
+++ b/test/correctness/inverse.cpp
@@ -78,17 +78,17 @@ int main(int argc, char **argv) {
         g5.gpu_tile(x, xi, 16);
     }
 
-    Buffer<float> imf1 = f1.realize(10000);
-    Buffer<float> imf2 = f2.realize(10000);
-    Buffer<float> imf3 = f3.realize(10000);
-    Buffer<float> imf4 = f4.realize(10000);
-    Buffer<float> imf5 = f5.realize(10000);
+    Buffer<float> imf1 = f1.realize({10000});
+    Buffer<float> imf2 = f2.realize({10000});
+    Buffer<float> imf3 = f3.realize({10000});
+    Buffer<float> imf4 = f4.realize({10000});
+    Buffer<float> imf5 = f5.realize({10000});
 
-    Buffer<float> img1 = g1.realize(10000);
-    Buffer<float> img2 = g2.realize(10000);
-    Buffer<float> img3 = g3.realize(10000);
-    Buffer<float> img4 = g4.realize(10000);
-    Buffer<float> img5 = g5.realize(10000);
+    Buffer<float> img1 = g1.realize({10000});
+    Buffer<float> img2 = g2.realize({10000});
+    Buffer<float> img3 = g3.realize({10000});
+    Buffer<float> img4 = g4.realize({10000});
+    Buffer<float> img5 = g5.realize({10000});
 
     printf("Testing accuracy of inverse\n");
     check(imf1, imf2);

--- a/test/correctness/isnan.cpp
+++ b/test/correctness/isnan.cpp
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
         f(x, y) = strict_float(select(is_nan(e), 0.0f, 1.0f));
         f.vectorize(x, 8);
 
-        Buffer<float> im = f.realize(w, h);
+        Buffer<float> im = f.realize({w, h});
         if (check_nans(im) != 0) {
             return -1;
         }
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
         f.vectorize(x, 8);
 
         in.set(non_halide_produced);
-        Buffer<float> im = f.realize(w, h);
+        Buffer<float> im = f.realize({w, h});
         if (check_nans(im) != 0) {
             return -1;
         }
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
         f(x, y) = strict_float(select(is_inf(e), 1.0f, 0.0f));
         f.vectorize(x, 8);
 
-        Buffer<float> im = f.realize(w, h);
+        Buffer<float> im = f.realize({w, h});
         if (check_infs(im) != 0) {
             return -1;
         }
@@ -143,7 +143,7 @@ int main(int argc, char **argv) {
         f.vectorize(x, 8);
 
         in.set(non_halide_produced);
-        Buffer<float> im = f.realize(w, h);
+        Buffer<float> im = f.realize({w, h});
         if (check_infs(im) != 0) {
             return -1;
         }
@@ -159,7 +159,7 @@ int main(int argc, char **argv) {
         f(x, y) = strict_float(select(is_finite(e), 1.0f, 0.0f));
         f.vectorize(x, 8);
 
-        Buffer<float> im = f.realize(w, h);
+        Buffer<float> im = f.realize({w, h});
         if (check_finites(im) != 0) {
             return -1;
         }
@@ -182,7 +182,7 @@ int main(int argc, char **argv) {
         f.vectorize(x, 8);
 
         in.set(non_halide_produced);
-        Buffer<float> im = f.realize(w, h);
+        Buffer<float> im = f.realize({w, h});
         if (check_finites(im) != 0) {
             return -1;
         }
@@ -200,7 +200,7 @@ int main(int argc, char **argv) {
             f(x, y) = strict_float(select(is_nan(e), 0.0f, 1.0f));
             f.gpu_tile(x, y, tx, ty, 8, 8);
 
-            Buffer<float> im = f.realize(w, h);
+            Buffer<float> im = f.realize({w, h});
             if (check_nans(im) != 0) {
                 return -1;
             }
@@ -224,7 +224,7 @@ int main(int argc, char **argv) {
             f.gpu_tile(x, y, tx, ty, 8, 8);
 
             in.set(non_halide_produced);
-            Buffer<float> im = f.realize(w, h);
+            Buffer<float> im = f.realize({w, h});
             if (check_nans(im) != 0) {
                 return -1;
             }
@@ -241,7 +241,7 @@ int main(int argc, char **argv) {
             f(x, y) = strict_float(select(is_inf(e), 1.0f, 0.0f));
             f.gpu_tile(x, y, tx, ty, 8, 8);
 
-            Buffer<float> im = f.realize(w, h);
+            Buffer<float> im = f.realize({w, h});
             if (check_infs(im) != 0) {
                 return -1;
             }
@@ -265,7 +265,7 @@ int main(int argc, char **argv) {
             f.gpu_tile(x, y, tx, ty, 8, 8);
 
             in.set(non_halide_produced);
-            Buffer<float> im = f.realize(w, h);
+            Buffer<float> im = f.realize({w, h});
             if (check_infs(im) != 0) {
                 return -1;
             }
@@ -282,7 +282,7 @@ int main(int argc, char **argv) {
             f(x, y) = strict_float(select(is_finite(e), 1.0f, 0.0f));
             f.gpu_tile(x, y, tx, ty, 8, 8);
 
-            Buffer<float> im = f.realize(w, h);
+            Buffer<float> im = f.realize({w, h});
             if (check_finites(im) != 0) {
                 return -1;
             }
@@ -306,7 +306,7 @@ int main(int argc, char **argv) {
             f.gpu_tile(x, y, tx, ty, 8, 8);
 
             in.set(non_halide_produced);
-            Buffer<float> im = f.realize(w, h);
+            Buffer<float> im = f.realize({w, h});
             if (check_finites(im) != 0) {
                 return -1;
             }

--- a/test/correctness/iterate_over_circle.cpp
+++ b/test/correctness/iterate_over_circle.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
 
     in.trace_loads();
     f.set_custom_trace(my_trace);
-    f.realize(20, 20);
+    f.realize({20, 20});
 
     int c = 0;
     for (int y = 0; y < 20; y++) {

--- a/test/correctness/lambda.cpp
+++ b/test/correctness/lambda.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
     Func g = lambda(x, y, x * y);
 
     // Use lambdas and implicit args in the one line
-    Buffer<int32_t> im = lambda(f(_) - g(_) + lambda(x, y, x + y)(_)).realize(10, 10);
+    Buffer<int32_t> im = lambda(f(_) - g(_) + lambda(x, y, x + y)(_)).realize({10, 10});
 
     for (int y = 0; y < 10; y++) {
         for (int x = 0; x < 10; x++) {
@@ -31,7 +31,7 @@ int main(int argc, char **argv) {
     Func h;
     h(x, y, z) = x + y * y + z * z * z;  // Ordering of arguments affects results
 
-    Buffer<int32_t> im2 = lambda(_, z, h(_, z)).realize(10, 10, 10);
+    Buffer<int32_t> im2 = lambda(_, z, h(_, z)).realize({10, 10, 10});
 
     for (int z = 0; z < 10; z++) {
         for (int y = 0; y < 10; y++) {

--- a/test/correctness/lazy_convolution.cpp
+++ b/test/correctness/lazy_convolution.cpp
@@ -31,7 +31,7 @@ int main(int argc, char **argv) {
     blur(x, y) = select(f(x, y) > 0, sum(f(x + r.x, y + r.y)), 0);
 
     call_count = 0;
-    blur.realize(100, 100);
+    blur.realize({100, 100});
 
     // If we computed the convolution everywhere, call_count would be
     // 100*100*20*20. Because we only compute it in half of the

--- a/test/correctness/leak_device_memory.cpp
+++ b/test/correctness/leak_device_memory.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
             }
 
             f.set_custom_print(halide_print);
-            f.realize(50, 50, target);
+            f.realize({50, 50}, target);
 
             // The copy now has a non-zero dev field, but the original
             // buf is unaware of that fact. It should get cleaned up

--- a/test/correctness/left_shift_negative.cpp
+++ b/test/correctness/left_shift_negative.cpp
@@ -26,8 +26,8 @@ int main(int argc, char **argv) {
     h1.vectorize(x, 16);
     h2.vectorize(x, 16);
 
-    Buffer<int16_t> im1 = h1.realize(1024);
-    Buffer<int16_t> im2 = h2.realize(1024);
+    Buffer<int16_t> im1 = h1.realize({1024});
+    Buffer<int16_t> im2 = h2.realize({1024});
 
     for (int i = 0; i < im1.width(); i++) {
         if (im1(i) != im2(i)) {

--- a/test/correctness/legal_race_condition.cpp
+++ b/test/correctness/legal_race_condition.cpp
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
         // race.  Halide's not smart enough to understand this.
         f.update().allow_race_conditions().parallel(r);
 
-        Buffer<int> out = f.realize(100);
+        Buffer<int> out = f.realize({100});
         for (int i = 0; i < 100; i++) {
             int correct = (i < 50) ? i : 0;
             if (out(i) != correct) {
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
         f(permuted) = r;
         f.update().allow_race_conditions().vectorize(r, 4).parallel(r);
 
-        Buffer<int> out = f.realize(256);
+        Buffer<int> out = f.realize({256});
 
         // Sort the output.
         std::sort(&out(0), &out(256));

--- a/test/correctness/lerp.cpp
+++ b/test/correctness/lerp.cpp
@@ -260,9 +260,9 @@ int main(int argc, char **argv) {
     input_b.set(input_b_img);
 
     w.set(0.0f);
-    Buffer<int32_t> result_should_be_a = lerp_with_casts.realize(16, 16);
+    Buffer<int32_t> result_should_be_a = lerp_with_casts.realize({16, 16});
     w.set(1.0f);
-    Buffer<int32_t> result_should_be_b = lerp_with_casts.realize(16, 16);
+    Buffer<int32_t> result_should_be_b = lerp_with_casts.realize({16, 16});
 
     for (int i = 0; i < 16; i++) {
         for (int j = 0; j < 16; j++) {

--- a/test/correctness/let_in_rdom_bound.cpp
+++ b/test/correctness/let_in_rdom_bound.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
     p.set(3);
     int rdom_bound = (3 + 8) / 3;
     rdom_bound *= rdom_bound;
-    Buffer<int> buf = f.realize(10);
+    Buffer<int> buf = f.realize({10});
 
     int correct = (rdom_bound * (rdom_bound - 1)) / 2;
 

--- a/test/correctness/likely.cpp
+++ b/test/correctness/likely.cpp
@@ -232,10 +232,10 @@ int main(int argc, char **argv) {
         // If either of these realize calls iterates from 0 to limit,
         // and then from limit to 10, we'll have a nice segfault.
         limit.set(10000000);
-        Buffer<int> result = g.realize(10);
+        Buffer<int> result = g.realize({10});
 
         limit.set(-10000000);
-        result = g.realize(10);
+        result = g.realize({10});
     }
 
     // The performance of this behavior is tested in

--- a/test/correctness/load_library.cpp
+++ b/test/correctness/load_library.cpp
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
     f.gpu_tile(x, y, xi, yi, 8, 8, TailStrategy::Auto, DeviceAPI::OpenCL);
     f.set_error_handler(my_error_handler);
 
-    Buffer<int32_t> out = f.realize(64, 64, target);
+    Buffer<int32_t> out = f.realize({64, 64}, target);
 
     fprintf(stderr, "Should not get here.\n");
     return -1;

--- a/test/correctness/logical.cpp
+++ b/test/correctness/logical.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
             f.vectorize(x, 8);
         }
 
-        Buffer<uint8_t> output = f.realize(input.width(), input.height(), target);
+        Buffer<uint8_t> output = f.realize({input.width(), input.height()}, target);
 
         for (int y = 0; y < input.height(); y++) {
             for (int x = 0; x < input.width(); x++) {
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
             f.vectorize(x, 8);
         }
 
-        Buffer<uint8_t> output = f.realize(input.width(), input.height(), target);
+        Buffer<uint8_t> output = f.realize({input.width(), input.height()}, target);
 
         for (int y = 0; y < input.height(); y++) {
             for (int x = 0; x < input.width(); x++) {
@@ -110,7 +110,7 @@ int main(int argc, char **argv) {
             f.vectorize(x, 128);
         }
 
-        Buffer<uint8_t> output = f.realize(input.width(), input.height(), target);
+        Buffer<uint8_t> output = f.realize({input.width(), input.height()}, target);
 
         for (int y = 0; y < input.height(); y++) {
             for (int x = 0; x < input.width(); x++) {
@@ -142,7 +142,7 @@ int main(int argc, char **argv) {
             f.vectorize(x, 8);
         }
 
-        Buffer<uint8_t> output = f.realize(input.width(), input.height(), target);
+        Buffer<uint8_t> output = f.realize({input.width(), input.height()}, target);
 
         for (int y = 0; y < input.height(); y++) {
             for (int x = 0; x < input.width(); x++) {
@@ -203,7 +203,7 @@ int main(int argc, char **argv) {
                 gpu.vectorize(x, 8);
             }
 
-            Realization r = out.realize(input.width(), input.height(), target);
+            Realization r = out.realize({input.width(), input.height()}, target);
             Buffer<uint32_t> cpu_output = r[0];
             Buffer<uint32_t> gpu_output = r[1];
 

--- a/test/correctness/loop_invariant_extern_calls.cpp
+++ b/test/correctness/loop_invariant_extern_calls.cpp
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
     // might have an extent of zero. It's possible wasted work.
     f.bound(x, 0, 32).bound(y, 0, 32);
 
-    Buffer<int> im = f.realize(32, 32);
+    Buffer<int> im = f.realize({32, 32});
 
     // Check the result was what we expected
     for (int y = 0; y < 32; y++) {
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
     g.parallel(y);
     // Avoid the race condition by not actually being parallel
     g.set_custom_do_par_for(&not_really_parallel_for);
-    g.realize(32, 32);
+    g.realize({32, 32});
 
     if (call_counter[3] != 1 || call_counter[4] != 32 * 32) {
         printf("Call counter for parallel call was %d, %d instead of %d, %d\n",
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
 
         Var xi, yi;
         h.gpu_tile(x, y, xi, yi, 8, 8);
-        h.realize(32, 32);
+        h.realize({32, 32});
 
         if (call_counter[5] != 1) {
             printf("Call counter for GPU call was %d instead of %d\n",

--- a/test/correctness/lots_of_loop_invariants.cpp
+++ b/test/correctness/lots_of_loop_invariants.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
         f.gpu_tile(x, y, xi, yi, 8, 8);
     }
 
-    f.realize(1024, 1024, 3);
+    f.realize({1024, 1024, 3});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/many_dimensions.cpp
+++ b/test/correctness/many_dimensions.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
     g(x, y) = f(site1) + f(site2);
 
     f.compute_at(g, x);
-    g.realize(10, 10);
+    g.realize({10, 10});
 
     printf("Success!\n");
 

--- a/test/correctness/many_small_extern_stages.cpp
+++ b/test/correctness/many_small_extern_stages.cpp
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
     f.compute_at(h, y);
     g.compute_at(h, y).store_root();
 
-    Buffer<int> result = h.realize(10, 10);
+    Buffer<int> result = h.realize({10, 10});
 
     for (int y = 0; y < result.height(); y++) {
         for (int x = 0; x < result.width(); x++) {

--- a/test/correctness/many_updates.cpp
+++ b/test/correctness/many_updates.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     }
     f.compute_root();
 
-    Buffer<int> im = f.realize(N, N);
+    Buffer<int> im = f.realize({N, N});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/math.cpp
+++ b/test/correctness/math.cpp
@@ -137,7 +137,7 @@ struct TestArgs {
         } else if (target.has_feature(Target::HVX)) {                                        \
             test_##name.hexagon();                                                           \
         }                                                                                    \
-        Buffer<type_ret> result = test_##name.realize(in.extent(0), target);                 \
+        Buffer<type_ret> result = test_##name.realize({in.extent(0)}, target);               \
         for (int i = 0; i < in.extent(0); i++) {                                             \
             type_ret c_result = c_name(in(i));                                               \
             if (!relatively_equal(c_result, result(i), target)) {                            \
@@ -164,7 +164,7 @@ struct TestArgs {
         } else if (target.has_feature(Target::HVX)) {                                               \
             test_##name.hexagon();                                                                  \
         }                                                                                           \
-        Buffer<type_ret> result = test_##name.realize(in.height(), target);                         \
+        Buffer<type_ret> result = test_##name.realize({in.height()}, target);                       \
         for (int i = 0; i < in.height(); i++) {                                                     \
             type_ret c_result = c_name(in(0, i), in(1, i));                                         \
             if (!relatively_equal(c_result, result(i), target)) {                                   \

--- a/test/correctness/median3x3.cpp
+++ b/test/correctness/median3x3.cpp
@@ -54,7 +54,7 @@ int main(int arch, char **argv) {
     }
 
     // Run the pipeline and verify the results are correct.
-    Buffer<uint8_t> out = median3x3.realize(W, H, target);
+    Buffer<uint8_t> out = median3x3.realize({W, H}, target);
 
     for (int y = 1; y < H - 1; y++) {
         for (int x = 1; x < W - 1; x++) {

--- a/test/correctness/memoize.cpp
+++ b/test/correctness/memoize.cpp
@@ -117,8 +117,8 @@ int main(int argc, char **argv) {
         g(x, y) = f();
 
         coord.set(0);
-        Buffer<uint8_t> out1 = g.realize(256, 256);
-        Buffer<uint8_t> out2 = g.realize(256, 256);
+        Buffer<uint8_t> out1 = g.realize({256, 256});
+        Buffer<uint8_t> out2 = g.realize({256, 256});
 
         for (int32_t i = 0; i < 256; i++) {
             for (int32_t j = 0; j < 256; j++) {
@@ -129,8 +129,8 @@ int main(int argc, char **argv) {
         assert(call_count == 1);
 
         coord.set(1);
-        Buffer<uint8_t> out3 = g.realize(256, 256);
-        Buffer<uint8_t> out4 = g.realize(256, 256);
+        Buffer<uint8_t> out3 = g.realize({256, 256});
+        Buffer<uint8_t> out4 = g.realize({256, 256});
 
         for (int32_t i = 0; i < 256; i++) {
             for (int32_t j = 0; j < 256; j++) {
@@ -151,8 +151,8 @@ int main(int argc, char **argv) {
         f(x, y) = count_calls(x, y) + count_calls(x, y);
         count_calls.compute_root().memoize();
 
-        Buffer<uint8_t> out1 = f.realize(256, 256);
-        Buffer<uint8_t> out2 = f.realize(256, 256);
+        Buffer<uint8_t> out1 = f.realize({256, 256});
+        Buffer<uint8_t> out2 = f.realize({256, 256});
 
         for (int32_t i = 0; i < 256; i++) {
             for (int32_t j = 0; j < 256; j++) {
@@ -178,8 +178,8 @@ int main(int argc, char **argv) {
         count_calls_23.compute_root().memoize();
         count_calls_42.compute_root().memoize();
 
-        Buffer<uint8_t> out1 = f.realize(256, 256);
-        Buffer<uint8_t> out2 = f.realize(256, 256);
+        Buffer<uint8_t> out1 = f.realize({256, 256});
+        Buffer<uint8_t> out2 = f.realize({256, 256});
 
         for (int32_t i = 0; i < 256; i++) {
             for (int32_t j = 0; j < 256; j++) {
@@ -210,20 +210,20 @@ int main(int argc, char **argv) {
         val1.set(23);
         val2.set(42);
 
-        Buffer<uint8_t> out1 = f.realize(256, 256);
-        Buffer<uint8_t> out2 = f.realize(256, 256);
+        Buffer<uint8_t> out1 = f.realize({256, 256});
+        Buffer<uint8_t> out2 = f.realize({256, 256});
 
         val1.set(42);
-        Buffer<uint8_t> out3 = f.realize(256, 256);
+        Buffer<uint8_t> out3 = f.realize({256, 256});
 
         val1.set(23);
-        Buffer<uint8_t> out4 = f.realize(256, 256);
+        Buffer<uint8_t> out4 = f.realize({256, 256});
 
         val1.set(42);
-        Buffer<uint8_t> out5 = f.realize(256, 256);
+        Buffer<uint8_t> out5 = f.realize({256, 256});
 
         val2.set(57);
-        Buffer<uint8_t> out6 = f.realize(256, 256);
+        Buffer<uint8_t> out6 = f.realize({256, 256});
 
         for (int32_t i = 0; i < 256; i++) {
             for (int32_t j = 0; j < 256; j++) {
@@ -251,9 +251,9 @@ int main(int argc, char **argv) {
         count_calls.compute_root().memoize();
 
         val.set(23.0f);
-        Buffer<uint8_t> out1 = f.realize(256, 256);
+        Buffer<uint8_t> out1 = f.realize({256, 256});
         val.set(23.4f);
-        Buffer<uint8_t> out2 = f.realize(256, 256);
+        Buffer<uint8_t> out2 = f.realize({256, 256});
 
         for (int32_t i = 0; i < 256; i++) {
             for (int32_t j = 0; j < 256; j++) {
@@ -277,9 +277,9 @@ int main(int argc, char **argv) {
         count_calls.compute_root().memoize();
 
         val.set(23.0f);
-        Buffer<uint8_t> out1 = f.realize(256, 256);
+        Buffer<uint8_t> out1 = f.realize({256, 256});
         val.set(23.4f);
-        Buffer<uint8_t> out2 = f.realize(256, 256);
+        Buffer<uint8_t> out2 = f.realize({256, 256});
 
         for (int32_t i = 0; i < 256; i++) {
             for (int32_t j = 0; j < 256; j++) {
@@ -310,13 +310,13 @@ int main(int argc, char **argv) {
 
         val.set(23.0f);
         index.set(2);
-        Buffer<uint8_t> out1 = h.realize(1);
+        Buffer<uint8_t> out1 = h.realize({1});
 
         assert(out1(0) == (uint8_t)(2 * 23 + 4 + 2));
         assert(call_count_with_arg == 3);
 
         index.set(4);
-        out1 = h.realize(1);
+        out1 = h.realize({1});
 
         assert(out1(0) == (uint8_t)(2 * 23 + 4 + 4));
         assert(call_count_with_arg == 4);
@@ -340,7 +340,7 @@ int main(int argc, char **argv) {
         g(x, y) = Tuple(f(x, y)[0] + f(x - 1, y)[0] + f(x + 1, y)[0], f(x, y)[1]);
 
         val.set(23.0f);
-        Realization out = g.realize(128, 128);
+        Realization out = g.realize({128, 128});
         Buffer<uint8_t> out0 = out[0];
         Buffer<int32_t> out1 = out[1];
 
@@ -350,7 +350,7 @@ int main(int argc, char **argv) {
                 assert(out1(i, j) == i);
             }
         }
-        out = g.realize(128, 128);
+        out = g.realize({128, 128});
         out0 = out[0];
         out1 = out[1];
 
@@ -383,7 +383,7 @@ int main(int argc, char **argv) {
         for (int v = 0; v < 1000; v++) {
             int r = rand() % 256;
             val.set((float)r);
-            Buffer<uint8_t> out1 = g.realize(128, 128);
+            Buffer<uint8_t> out1 = g.realize({128, 128});
 
             for (int32_t i = 0; i < 100; i++) {
                 for (int32_t j = 0; j < 100; j++) {
@@ -418,7 +418,7 @@ int main(int argc, char **argv) {
         for (int v = 0; v < 1000; v++) {
             int r = rand() % 256;
             val.set((float)r);
-            Buffer<uint8_t> out1 = g.realize(128, 128);
+            Buffer<uint8_t> out1 = g.realize({128, 128});
 
             for (int32_t i = 0; i < 100; i++) {
                 for (int32_t j = 0; j < 100; j++) {
@@ -431,8 +431,8 @@ int main(int argc, char **argv) {
         printf("Call count before oversize realize is %d.\n", call_count_with_arg);
         call_count_with_arg = 0;
 
-        Buffer<uint8_t> big = g.realize(1024, 1024);
-        Buffer<uint8_t> big2 = g.realize(1024, 1024);
+        Buffer<uint8_t> big = g.realize({1024, 1024});
+        Buffer<uint8_t> big2 = g.realize({1024, 1024});
 
         // TODO work out an assertion on call count here.
         printf("Call count after oversize realize is %d.\n", call_count_with_arg);
@@ -441,7 +441,7 @@ int main(int argc, char **argv) {
         for (int v = 0; v < 1000; v++) {
             int r = rand() % 256;
             val.set((float)r);
-            Buffer<uint8_t> out1 = g.realize(128, 128);
+            Buffer<uint8_t> out1 = g.realize({128, 128});
 
             for (int32_t i = 0; i < 100; i++) {
                 for (int32_t j = 0; j < 100; j++) {
@@ -477,7 +477,7 @@ int main(int argc, char **argv) {
 
         val.set(23.0f);
         Internal::JITSharedRuntime::memoization_cache_set_size(1000000);
-        Buffer<uint8_t> out = g.realize(128, 128);
+        Buffer<uint8_t> out = g.realize({128, 128});
 
         for (int32_t i = 0; i < 128; i++) {
             for (int32_t j = 0; j < 128; j++) {
@@ -561,7 +561,7 @@ int main(int argc, char **argv) {
         Func output;
         output(_) = stage[3](_);
         val.set(23.0f);
-        Buffer<uint8_t> result = output.realize(128, 128);
+        Buffer<uint8_t> result = output.realize({128, 128});
 
         for (int32_t i = 0; i < 128; i++) {
             for (int32_t j = 0; j < 128; j++) {
@@ -573,7 +573,7 @@ int main(int argc, char **argv) {
             printf("Call count for stage %d is %d.\n", i, call_count_staged[i]);
         }
 
-        result = output.realize(128, 128);
+        result = output.realize({128, 128});
         for (int32_t i = 0; i < 128; i++) {
             for (int32_t j = 0; j < 128; j++) {
                 assert(result(i, j) == (uint8_t)((i << 8) + j + 4 * 23));
@@ -615,7 +615,7 @@ int main(int argc, char **argv) {
             error_occured = false;
 
             val.set(23.0f + trial);
-            Realization out = pipe.realize(16, 16);
+            Realization out = pipe.realize({16, 16});
             if (error_occured) {
                 total_errors++;
             } else {
@@ -630,7 +630,7 @@ int main(int argc, char **argv) {
                 }
 
                 error_occured = false;
-                out = pipe.realize(16, 16);
+                out = pipe.realize({16, 16});
                 if (error_occured) {
                     total_errors++;
                 } else {

--- a/test/correctness/memoize_cloned.cpp
+++ b/test/correctness/memoize_cloned.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
     h.bound(x, 0, 1024).bound(y, 0, 32);
 
     call_count = 0;
-    h.realize(1024, 32);
+    h.realize({1024, 32});
     if (call_count != 1024 * 32) {
         printf("call_count was supposed to be 1024 * 32: %d\n", call_count);
         return 1;

--- a/test/correctness/mod.cpp
+++ b/test/correctness/mod.cpp
@@ -9,7 +9,7 @@ bool test() {
     Func f;
     f(x) = cast<T>(x) % 2;
 
-    Buffer<T> im = f.realize(16);
+    Buffer<T> im = f.realize({16});
 
     for (int i = 0; i < 16; i++) {
         if (im(i) != (T)(i % 2)) {
@@ -27,7 +27,7 @@ bool test() {
     Func nf;
     nf(x) = cast<T>(-x) % 4;
 
-    Buffer<T> nim = nf.realize(16);
+    Buffer<T> nim = nf.realize({16});
 
     for (int i = 1; i < 16; i++) {
         if (nim(i) != (T)((4 - (i % 4)) % 4)) {

--- a/test/correctness/mul_div_mod.cpp
+++ b/test/correctness/mul_div_mod.cpp
@@ -303,7 +303,7 @@ bool mul(int vector_width, ScheduleVariant scheduling, const Target &target) {
         break;
     };
 
-    Buffer<RT> r = f.realize(WIDTH, HEIGHT, target);
+    Buffer<RT> r = f.realize({WIDTH, HEIGHT}, target);
 
     int ecount = 0;
     for (i = 0; i < WIDTH; i++) {
@@ -388,7 +388,7 @@ bool div_mod(int vector_width, ScheduleVariant scheduling, const Target &target)
         break;
     };
 
-    Realization R = f.realize(WIDTH, HEIGHT, target);
+    Realization R = f.realize({WIDTH, HEIGHT}, target);
     Buffer<T> q(R[0]);
     Buffer<T> r(R[1]);
 

--- a/test/correctness/multi_pass_reduction.cpp
+++ b/test/correctness/multi_pass_reduction.cpp
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
         f(xl) = f(xl - 1) + f(xl);
         f(xr) = f(xr + 1) + f(xr);
 
-        Buffer<float> result = f.realize(11);
+        Buffer<float> result = f.realize({11});
 
         // The same thing in C
         float ref[11];
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
         f(r2) = g(r2);
 
         g.compute_at(f, r2);
-        Buffer<int> result = f.realize(110);
+        Buffer<int> result = f.realize({110});
 
         int correct[110];
         for (int i = 0; i < 110; i++) {
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
             f(i) = f(i - 1) + f(i - 2);
         }
 
-        Buffer<int> result = f.realize(20);
+        Buffer<int> result = f.realize({20});
 
         int ref[20];
         ref[0] = 1;
@@ -127,10 +127,10 @@ int main(int argc, char **argv) {
         // we don't have the ability to reorder vars with rvars yet.
         f.update(1).reorder(Var(r.x.name()), y).parallel(y);
 
-        Buffer<float> result = f.realize(100, 100);
+        Buffer<float> result = f.realize({100, 100});
 
         // Now the equivalent in C (cheating and using Halide for the initial image)
-        Buffer<float> ref = lambda(x, y, sin(x + y)).realize(100, 100);
+        Buffer<float> ref = lambda(x, y, sin(x + y)).realize({100, 100});
         for (int y = 1; y < 100; y++) {
             for (int x = 0; x < 100; x++) {
                 ref(x, y) += ref(x, y - 1);

--- a/test/correctness/multi_splits_with_diff_tail_strategies.cpp
+++ b/test/correctness/multi_splits_with_diff_tail_strategies.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
     Var yoo("yoo"), yoi("yoi");
     f.split(yo, yoo, yoi, 64, TailStrategy::GuardWithIf);
 
-    Buffer<int> im = f.realize(3000, 2000, 3);
+    Buffer<int> im = f.realize({3000, 2000, 3});
     auto func = [](int x, int y, int c) {
         return x + y + c;
     };

--- a/test/correctness/multiple_outputs.cpp
+++ b/test/correctness/multiple_outputs.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
             g.gpu_tile(x, xi, 8);
         }
 
-        g.realize(100);
+        g.realize({100});
     }
 
     // Now try a reduction where the pipeline returns that tuple value.
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
             g.gpu_tile(x, xi, 8);
         }
 
-        Realization r = Pipeline({f, g}).realize(100);
+        Realization r = Pipeline({f, g}).realize({100});
         Buffer<float> f_im = r[0];
         Buffer<uint8_t> g0_im = r[1];
         Buffer<int16_t> g1_im = r[2];

--- a/test/correctness/multiple_scatter.cpp
+++ b/test/correctness/multiple_scatter.cpp
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
     sorted1.vectorize(x, 8).update().vectorize(x, 8);
 
     Buffer<int> output1(128, 8), output2(128, 8);
-    sorted1.realize(output1);
+    sorted1.realize({output1});
 
     // Run the sorting network fully unrolled as a single big multi-scatter
     Func sorted2;
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
     sorted2(x, scatter(lhs)) = gather(rhs);
     sorted2.vectorize(x, 8).update().vectorize(x, 8);
 
-    sorted2.realize(output2);
+    sorted2.realize({output2});
 
     for (int i = 0; i < output1.dim(0).extent(); i++) {
         vector<int> correct(output1.dim(1).extent());
@@ -122,7 +122,7 @@ int main(int argc, char **argv) {
         rot(scatter(dst_x), scatter(dst_y)) =
             rot(gather(src_x), gather(src_y));
 
-        Buffer<uint8_t> output = rot.realize(sz, sz);
+        Buffer<uint8_t> output = rot.realize({sz, sz});
 
         for (int y = 0; y < sz; y++) {
             for (int x = 0; x < sz; x++) {

--- a/test/correctness/multiple_scatter.cpp
+++ b/test/correctness/multiple_scatter.cpp
@@ -157,7 +157,7 @@ int main(int argc, char **argv) {
         // 'true' to atomic().
         prod.update().atomic(true).parallel(r);
 
-        Buffer<uint8_t> result = prod.realize(2);
+        Buffer<uint8_t> result = prod.realize({2});
 
         uint8_t correct_re = 1, correct_im = 0;
         for (int i = 0; i < input.dim(1).extent(); i++) {
@@ -215,7 +215,7 @@ int main(int argc, char **argv) {
         f(x) = 0;
         f(scatter(0, 1, 2, 3)) = 5;
 
-        Buffer<int> out = f.realize(5);
+        Buffer<int> out = f.realize({5});
         for (int i = 0; i < 5; i++) {
             int correct = i < 4 ? 5 : 0;
             if (out(i) != correct) {
@@ -235,7 +235,7 @@ int main(int argc, char **argv) {
         f(x) = 0;
         f(3) = gather(1, 9);
 
-        Buffer<int> out = f.realize(5);
+        Buffer<int> out = f.realize({5});
         for (int i = 0; i < 5; i++) {
             int correct = i == 3 ? 9 : 0;
             if (out(i) != correct) {

--- a/test/correctness/mux.cpp
+++ b/test/correctness/mux.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
 
         f(x, c) = mux(c, {x, 456, 789});
 
-        Buffer<int> result = f.realize(100, 4);
+        Buffer<int> result = f.realize({100, 4});
         check(result);
     }
 
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
         Func g;
         g(x, c) = mux(c, f(x));
 
-        Buffer<int> result = g.realize(100, 4);
+        Buffer<int> result = g.realize({100, 4});
         check(result);
     }
 

--- a/test/correctness/named_updates.cpp
+++ b/test/correctness/named_updates.cpp
@@ -56,8 +56,8 @@ int main(int argc, char **argv) {
         ref(5 * r) = 2;
     }
 
-    Buffer<int> result = f.realize(128);
-    Buffer<int> result_ref = ref.realize(128);
+    Buffer<int> result = f.realize({128});
+    Buffer<int> result_ref = ref.realize({128});
 
     RDom check(result);
     uint32_t error = evaluate<uint32_t>(

--- a/test/correctness/nested_shiftinwards.cpp
+++ b/test/correctness/nested_shiftinwards.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
     // size below.
 
     // Just check it doesn't fail a bounds assertion.
-    Buffer<uint16_t> out = g.realize(input.width() - 2, input.height() - 2, 3);
+    Buffer<uint16_t> out = g.realize({input.width() - 2, input.height() - 2, 3});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/nested_tail_strategies.cpp
+++ b/test/correctness/nested_tail_strategies.cpp
@@ -43,7 +43,7 @@ void check(Func out, int line, std::vector<TailStrategy> tails) {
 
     for (int s : sizes_to_try) {
         largest_allocation = 0;
-        out.realize(s);
+        out.realize({s});
         size_t expected = (s + 1) * 4;
         if (largest_allocation > expected) {
             std::cerr << "Failure on line " << line << "\n"

--- a/test/correctness/non_nesting_extern_bounds_query.cpp
+++ b/test/correctness/non_nesting_extern_bounds_query.cpp
@@ -87,10 +87,10 @@ int main(int argc, char **argv) {
     f.compute_at(h, y);
 
     variant.set(0);
-    h.realize(200, 200);
+    h.realize({200, 200});
 
     variant.set(1);
-    h.realize(200, 200);
+    h.realize({200, 200});
 
     printf("Success!\n");
 }

--- a/test/correctness/non_vector_aligned_embeded_buffer.cpp
+++ b/test/correctness/non_vector_aligned_embeded_buffer.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     f(x) = foo(x);
     f.vectorize(x, 4);
     f.output_buffer().dim(0).set_min(0);
-    auto result = f.realize(4);
+    auto result = f.realize({4});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/obscure_image_references.cpp
+++ b/test/correctness/obscure_image_references.cpp
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
 
     j.set(3);
     im1.set(im3);
-    Buffer<int> result = f.realize(100);
+    Buffer<int> result = f.realize({100});
 
     for (int i = 0; i < 100; i++) {
         int correct = i < im2(3) ? 37 : (i + 20);

--- a/test/correctness/oddly_sized_output.cpp
+++ b/test/correctness/oddly_sized_output.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     f.vectorize(x, 4).unroll(x, 3).unroll(x, 2);
     f.split(y, y, yi, 16).parallel(y);
 
-    Buffer<int> out = f.realize(87, 93);
+    Buffer<int> out = f.realize({87, 93});
 
     for (int y = 0; y < out.height(); y++) {
         for (int x = 0; x < out.width(); x++) {

--- a/test/correctness/out_constraint.cpp
+++ b/test/correctness/out_constraint.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
         Buffer<uint8_t> dummy(size);
         dummy.fill(42);
         input.set(dummy);
-        Buffer<uint8_t> out = f.realize(size);
+        Buffer<uint8_t> out = f.realize({size});
         if (!out.all_equal(42)) {
             std::cerr << "wrong output\n";
             exit(-1);
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
 
         Buffer<uint8_t> dummy(size);
         input.set(dummy);
-        Buffer<uint8_t> out = f.realize(size);
+        Buffer<uint8_t> out = f.realize({size});
         if (!out.all_equal(42)) {
             std::cerr << "wrong output\n";
             exit(-1);

--- a/test/correctness/out_of_memory.cpp
+++ b/test/correctness/out_of_memory.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
 
     funcs[funcs.size() - 1].set_custom_allocator(&test_malloc, &test_free);
     funcs[funcs.size() - 1].set_error_handler(&handler);
-    funcs[funcs.size() - 1].realize(1);
+    funcs[funcs.size() - 1].realize({1});
 
     if (!error_occurred) {
         printf("There should have been an error\n");

--- a/test/correctness/parallel.cpp
+++ b/test/correctness/parallel.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
 
     f.parallel(x);
 
-    Buffer<int> im = f.realize(16);
+    Buffer<int> im = f.realize({16});
 
     for (int i = 0; i < 16; i++) {
         if (im(i) != i * 3) {

--- a/test/correctness/parallel_alloc.cpp
+++ b/test/correctness/parallel_alloc.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
         g.compute_at(f, y);
         f.parallel(y);
 
-        Buffer<int> im = f.realize(8, 8);
+        Buffer<int> im = f.realize({8, 8});
         f.realize(im);
 
         for (int x = 0; x < 8; x++) {

--- a/test/correctness/parallel_fork.cpp
+++ b/test/correctness/parallel_fork.cpp
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
 
     call_count = 0;
     both = make(Serial);
-    im = both.realize(10, 10, 2);
+    im = both.realize({10, 10, 2});
     count = call_count;
     time = benchmark([&]() {
         both.realize(im);
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
 
     call_count = 0;
     both = make(Parallel);
-    im = both.realize(10, 10, 2);
+    im = both.realize({10, 10, 2});
     count = call_count;
     time = benchmark([&]() {
         both.realize(im);
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
 
     both = make(AsyncRoot);
     call_count = 0;
-    im = both.realize(10, 10, 2);
+    im = both.realize({10, 10, 2});
     count = call_count;
     time = benchmark([&]() {
         both.realize(im);
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
 
     both = make(AsyncComputeAt);
     call_count = 0;
-    im = both.realize(10, 10, 2);
+    im = both.realize({10, 10, 2});
     count = call_count;
     time = benchmark([&]() {
         both.realize(im);

--- a/test/correctness/parallel_gpu_nested.cpp
+++ b/test/correctness/parallel_gpu_nested.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
     }
     f.parallel(z);
 
-    Buffer<int> im = f.realize(64, 64, 64);
+    Buffer<int> im = f.realize({64, 64, 64});
 
     for (int x = 0; x < 64; x++) {
         for (int y = 0; y < 64; y++) {

--- a/test/correctness/parallel_nested.cpp
+++ b/test/correctness/parallel_nested.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
     f.parallel(y);
     f.parallel(z);
 
-    Buffer<int> im = f.realize(64, 64, 64);
+    Buffer<int> im = f.realize({64, 64, 64});
 
     for (int x = 0; x < 64; x++) {
         for (int y = 0; y < 64; y++) {

--- a/test/correctness/parallel_nested_1.cpp
+++ b/test/correctness/parallel_nested_1.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
         f.vectorize(x, 32);
     }
 
-    Buffer<int> im = g.realize(64, 64, 64);
+    Buffer<int> im = g.realize({64, 64, 64});
 
     for (int x = 0; x < 64; x++) {
         for (int y = 0; y < 64; y++) {

--- a/test/correctness/parallel_reductions.cpp
+++ b/test/correctness/parallel_reductions.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
         sum_cols.update();
         out.output_buffer().dim(0).set_bounds(0, 256);
 
-        Buffer<int> result = out.realize(256);
+        Buffer<int> result = out.realize({256});
 
         for (int i = 0; i < 256; i++) {
             if (result(i) != correct(i)) {

--- a/test/correctness/param.cpp
+++ b/test/correctness/param.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
         }
 
         u.set(17);
-        Buffer<int> out_17 = f.realize(1024, target);
+        Buffer<int> out_17 = f.realize({1024}, target);
 
         // verify the get method.
         assert(u.get() == 17);
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
         // so setting the copy should be equivalent to setting the original.
         Param<int> u_alias = u;
         u_alias.set(123);
-        Buffer<int> out_123 = f.realize(1024, target);
+        Buffer<int> out_123 = f.realize({1024}, target);
 
         // verify the get method, again.
         assert(u.get() == 123);
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
         // For Param<void>, you must provide an explicit template argument to set(),
         // and it must match the dynamic type of the Param.
         u.set<int32_t>(17);
-        Buffer<int32_t> out_17 = f.realize(1024, target);
+        Buffer<int32_t> out_17 = f.realize({1024}, target);
 
         // For Param<void>, you must provide an explicit template argument to get(),
         // and it must match the dynamic type of the Param.
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
         // so setting the copy should be equivalent to setting the original.
         Param<> u_alias = u;
         u_alias.set(123);
-        Buffer<int32_t> out_123 = f.realize(1024, target);
+        Buffer<int32_t> out_123 = f.realize({1024}, target);
 
         assert(u.get<int32_t>() == 123);
 
@@ -105,13 +105,13 @@ int main(int argc, char **argv) {
         f(x) = u;
 
         u.set(17);
-        Buffer<int32_t> out_17 = f.realize(1);
+        Buffer<int32_t> out_17 = f.realize({1});
         assert(out_17(0) == 17);
 
         // You can always construct a Param<void> from a Param<nonvoid>
         Param<> u_alias = u;
         u_alias.set(123);
-        Buffer<int32_t> out_123 = f.realize(1);
+        Buffer<int32_t> out_123 = f.realize({1});
         assert(out_123(0) == 123);
 
         // You can also construct Param<nonvoid> from Param<void>,
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
         // of the LHS (otherwise, assert-fails)
         Param<int32_t> u_alias2 = u_alias;
         u_alias2.set(124);
-        Buffer<int32_t> out_124 = f.realize(1);
+        Buffer<int32_t> out_124 = f.realize({1});
         assert(out_124(0) == 124);
     }
 
@@ -131,7 +131,7 @@ int main(int argc, char **argv) {
         f(x) = u;
 
         u.set(17);
-        Buffer<int32_t> out_17 = f.realize(1);
+        Buffer<int32_t> out_17 = f.realize({1});
         assert(out_17(0) == 17);
 
         // You can always do Param<void> = Param<nonvoid> (LHS takes on type of RHS)
@@ -139,7 +139,7 @@ int main(int argc, char **argv) {
         u_alias = u;
         assert(u_alias.type() == Int(32));
         u_alias.set(123);
-        Buffer<int32_t> out_123 = f.realize(1);
+        Buffer<int32_t> out_123 = f.realize({1});
         assert(out_123(0) == 123);
 
         // You can also do Param<nonvoid> = Param<void>,
@@ -148,7 +148,7 @@ int main(int argc, char **argv) {
         Param<int32_t> u_alias2;
         u_alias2 = u_alias;
         u_alias2.set(124);
-        Buffer<int32_t> out_124 = f.realize(1);
+        Buffer<int32_t> out_124 = f.realize({1});
         assert(out_124(0) == 124);
     }
 

--- a/test/correctness/param_map.cpp
+++ b/test/correctness/param_map.cpp
@@ -27,16 +27,16 @@ int main(int argc, char **argv) {
     Target t = get_jit_target_from_environment();
 
     p_img.set(in1);
-    Buffer<uint8_t> result1 = f.realize(10, 10, t);
+    Buffer<uint8_t> result1 = f.realize({10, 10}, t);
 
     ParamMap params;
     params.set(p_int, 22);
     params.set(p_float, 2.0f);
     params.set(p_img, in2);
 
-    Buffer<uint8_t> result2 = f.realize(10, 10, t, params);
-    Buffer<uint8_t> result3 = f.realize(10, 10, t, {{p_int, 12}});
-    Buffer<uint8_t> result4 = f.realize(10, 10, t, {{p_int, 16}, {p_img, in2}});
+    Buffer<uint8_t> result2 = f.realize({10, 10}, t, params);
+    Buffer<uint8_t> result3 = f.realize({10, 10}, t, {{p_int, 12}});
+    Buffer<uint8_t> result4 = f.realize({10, 10}, t, {{p_int, 16}, {p_img, in2}});
 
     for (int i = 0; i < 10; i++) {
         for (int j = 0; j < 10; j++) {

--- a/test/correctness/parameter_constraints.cpp
+++ b/test/correctness/parameter_constraints.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
 
         error_occurred = false;
         p.set(2);
-        f.realize(100, 100);
+        f.realize({100, 100});
         if (error_occurred) {
             printf("Error incorrectly raised\n");
             return -1;
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
 
         p.set(0);
         error_occurred = false;
-        f.realize(100, 100);
+        f.realize({100, 100});
         if (!error_occurred) {
             printf("Error should have been raised\n");
             return -1;
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
         f.set_error_handler(my_error_handler);
 
         error_occurred = false;
-        f.realize(100, 100);
+        f.realize({100, 100});
         if (error_occurred) {
             printf("Error incorrectly raised\n");
             return -1;
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
 
         p.set(0);
         error_occurred = false;
-        f.realize(100, 100);
+        f.realize({100, 100});
         if (!error_occurred) {
             printf("Error should have been raised\n");
             return -1;

--- a/test/correctness/partial_application.cpp
+++ b/test/correctness/partial_application.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
 
     printf("Realizing function...\n");
 
-    Buffer<float> im = h.realize(4, 4);
+    Buffer<float> im = h.realize({4, 4});
 
     for (int y = 0; y < 4; y++) {
         for (int x = 0; x < 4; x++) {

--- a/test/correctness/partial_realization.cpp
+++ b/test/correctness/partial_realization.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
 
         // Hist can only be realized over 256 values, so if we ask for
         // less we get a cropped view.
-        Buffer<int> h = hist.realize(100);
+        Buffer<int> h = hist.realize({100});
         for (int i = 0; i < 100; i++) {
             // There's one zero at the top left corner, two ones, three twos, etc.
             int correct = i + 1;
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
         Var xi, yi;
         f.tile(x, y, xi, yi, 16, 8, TailStrategy::RoundUp);
 
-        Buffer<int> buf = f.realize(30, 20);
+        Buffer<int> buf = f.realize({30, 20});
 
         // There's no way to realize over that domain with the given
         // schedule. Instead Halide has realized a 32x24 buffer and

--- a/test/correctness/partition_loops.cpp
+++ b/test/correctness/partition_loops.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[]) {
 
     Func output("output");
     output(x, y, c) = cast<float>(f(x, y, c));
-    Buffer<float> im = output.realize(1024, 1024, 3);
+    Buffer<float> im = output.realize({1024, 1024, 3});
 
     for (int y = 0; y < input.height(); y++) {
         for (int x = 0; x < input.width(); x++) {

--- a/test/correctness/partition_loops_bug.cpp
+++ b/test/correctness/partition_loops_bug.cpp
@@ -21,7 +21,7 @@ Buffer<double> test(bool with_vectorize) {
         output.vectorize(y, 4);
     }
 
-    Buffer<double> img = lambda(x, y, Expr(1.0)).realize(4, 4);
+    Buffer<double> img = lambda(x, y, Expr(1.0)).realize({4, 4});
     input.set(img);
 
     Buffer<double> result(4, 4);

--- a/test/correctness/partition_max_filter.cpp
+++ b/test/correctness/partition_max_filter.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
     CountForLoops counter;
     max_y.add_custom_lowering_pass(&counter, nullptr);
 
-    Buffer<uint8_t> out = max_y.realize(width, height);
+    Buffer<uint8_t> out = max_y.realize({width, height});
 
     // We expect a loop structure like:
     // Top of the image

--- a/test/correctness/pipeline_set_jit_externs_func.cpp
+++ b/test/correctness/pipeline_set_jit_externs_func.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
 
     Pipeline p(f);
     p.set_jit_externs({{"extern_func", JITExtern{monitor}}});
-    Buffer<float> imf = p.realize(32, 32);
+    Buffer<float> imf = p.realize({32, 32});
 
     // Check the result was what we expected
     for (int i = 0; i < 32; i++) {

--- a/test/correctness/popc_clz_ctz_bounds.cpp
+++ b/test/correctness/popc_clz_ctz_bounds.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
         }
         in.set(data);
 
-        Realization result = f.realize(16);
+        Realization result = f.realize({16});
         Buffer<uint8_t> popc_result = result[0];
         Buffer<uint8_t> clz_result = result[1];
         Buffer<uint8_t> ctz_result = result[2];

--- a/test/correctness/predicated_store_load.cpp
+++ b/test/correctness/predicated_store_load.cpp
@@ -115,7 +115,7 @@ int vectorized_dense_load_with_stride_minus_one_test(const Target &t) {
     g.compute_root();
 
     ref(x, y) = select(x < 23, g(size - x, y) * 2 + g(20 - x, y), undef<int>());
-    Buffer<int> im_ref = ref.realize(size, size);
+    Buffer<int> im_ref = ref.realize({size, size});
 
     f(x, y) = select(x < 23, g(size - x, y) * 2 + g(20 - x, y), undef<int>());
 
@@ -126,7 +126,7 @@ int vectorized_dense_load_with_stride_minus_one_test(const Target &t) {
         f.add_custom_lowering_pass(new CheckPredicatedStoreLoad(t, 2, 4));
     }
 
-    Buffer<int> im = f.realize(size, size);
+    Buffer<int> im = f.realize({size, size});
     auto func = [&im_ref, &im](int x, int y, int z) {
         // For x >= 23, the buffer is undef
         return (x < 23) ? im_ref(x, y, z) : im(x, y, z);
@@ -151,7 +151,7 @@ int multiple_vectorized_predicate_test(const Target &t) {
 
     ref(x, y) = 10;
     ref(r.x, r.y) = g(size - r.x, r.y) * 2 + g(67 - r.x, r.y);
-    Buffer<int> im_ref = ref.realize(size, size);
+    Buffer<int> im_ref = ref.realize({size, size});
 
     f(x, y) = 10;
     f(r.x, r.y) = g(size - r.x, r.y) * 2 + g(67 - r.x, r.y);
@@ -163,7 +163,7 @@ int multiple_vectorized_predicate_test(const Target &t) {
         f.add_custom_lowering_pass(new CheckPredicatedStoreLoad(t, 3, 6));
     }
 
-    Buffer<int> im = f.realize(size, size);
+    Buffer<int> im = f.realize({size, size});
     auto func = [&im_ref](int x, int y, int z) { return im_ref(x, y, z); };
     if (check_image(im, func)) {
         return -1;
@@ -404,7 +404,7 @@ int vectorized_predicated_load_lut_test(const Target &t) {
     dst.update().allow_race_conditions().vectorize(r, vector_size);
     dst.add_custom_lowering_pass(new CheckPredicatedStoreLoad(t, 1, 3));
 
-    dst.realize(dst_len);
+    dst.realize({dst_len});
 
     return 0;
 }

--- a/test/correctness/predicated_store_load.cpp
+++ b/test/correctness/predicated_store_load.cpp
@@ -86,7 +86,7 @@ int vectorized_predicated_store_scalarized_predicated_load_test(const Target &t)
 
     ref(x, y) = 10;
     ref(r.x, r.y) += g(2 * r.x, r.y) + g(2 * r.x + 1, r.y);
-    Buffer<int> im_ref = ref.realize(170, 170);
+    Buffer<int> im_ref = ref.realize({170, 170});
 
     f(x, y) = 10;
     f(r.x, r.y) += g(2 * r.x, r.y) + g(2 * r.x + 1, r.y);
@@ -98,7 +98,7 @@ int vectorized_predicated_store_scalarized_predicated_load_test(const Target &t)
         f.add_custom_lowering_pass(new CheckPredicatedStoreLoad(t, 3, 9));
     }
 
-    Buffer<int> im = f.realize(170, 170);
+    Buffer<int> im = f.realize({170, 170});
     auto func = [im_ref](int x, int y, int z) { return im_ref(x, y, z); };
     if (check_image(im, func)) {
         return -1;
@@ -183,7 +183,7 @@ int scalar_load_test(const Target &t) {
 
     ref(x, y) = 10;
     ref(r.x, r.y) += 1 + max(g(0, 1), g(2 * r.x + 1, r.y));
-    Buffer<int> im_ref = ref.realize(160, 160);
+    Buffer<int> im_ref = ref.realize({160, 160});
 
     f(x, y) = 10;
     f(r.x, r.y) += 1 + max(g(0, 1), g(2 * r.x + 1, r.y));
@@ -195,7 +195,7 @@ int scalar_load_test(const Target &t) {
         f.add_custom_lowering_pass(new CheckPredicatedStoreLoad(t, 1, 2));
     }
 
-    Buffer<int> im = f.realize(160, 160);
+    Buffer<int> im = f.realize({160, 160});
     auto func = [im_ref](int x, int y, int z) { return im_ref(x, y, z); };
     if (check_image(im, func)) {
         return -1;
@@ -215,7 +215,7 @@ int scalar_store_test(const Target &t) {
 
     ref(x, y) = 10;
     ref(13, 13) = max(g(0, 1), g(2 * r.x + 1, r.y));
-    Buffer<int> im_ref = ref.realize(160, 160);
+    Buffer<int> im_ref = ref.realize({160, 160});
 
     f(x, y) = 10;
     f(13, 13) = max(g(0, 1), g(2 * r.x + 1, r.y));
@@ -229,7 +229,7 @@ int scalar_store_test(const Target &t) {
         f.add_custom_lowering_pass(new CheckPredicatedStoreLoad(t, 1, 1));
     }
 
-    Buffer<int> im = f.realize(160, 160);
+    Buffer<int> im = f.realize({160, 160});
     auto func = [im_ref](int x, int y, int z) { return im_ref(x, y, z); };
     if (check_image(im, func)) {
         return -1;
@@ -249,7 +249,7 @@ int not_dependent_on_vectorized_var_test(const Target &t) {
 
     ref(x, y, z) = 10;
     ref(r.x, r.y, 1) = max(g(0, 1, 2), g(r.x + 1, r.y, 2));
-    Buffer<int> im_ref = ref.realize(160, 160, 160);
+    Buffer<int> im_ref = ref.realize({160, 160, 160});
 
     f(x, y, z) = 10;
     f(r.x, r.y, 1) = max(g(0, 1, 2), g(r.x + 1, r.y, 2));
@@ -263,7 +263,7 @@ int not_dependent_on_vectorized_var_test(const Target &t) {
         f.add_custom_lowering_pass(new CheckPredicatedStoreLoad(t, 0, 0));
     }
 
-    Buffer<int> im = f.realize(160, 160, 160);
+    Buffer<int> im = f.realize({160, 160, 160});
     auto func = [im_ref](int x, int y, int z) { return im_ref(x, y, z); };
     if (check_image(im, func)) {
         return -1;
@@ -281,7 +281,7 @@ int no_op_store_test(const Target &t) {
     ref(x, y) = x + y;
     ref(2 * r.x + 1, r.y) = ref(2 * r.x + 1, r.y);
     ref(2 * r.x, 3 * r.y) = ref(2 * r.x, 3 * r.y);
-    Buffer<int> im_ref = ref.realize(240, 240);
+    Buffer<int> im_ref = ref.realize({240, 240});
 
     f(x, y) = x + y;
     f(2 * r.x + 1, r.y) = f(2 * r.x + 1, r.y);
@@ -296,7 +296,7 @@ int no_op_store_test(const Target &t) {
         f.add_custom_lowering_pass(new CheckPredicatedStoreLoad(t, 0, 0));
     }
 
-    Buffer<int> im = f.realize(240, 240);
+    Buffer<int> im = f.realize({240, 240});
     auto func = [im_ref](int x, int y, int z) { return im_ref(x, y, z); };
     if (check_image(im, func)) {
         return -1;
@@ -316,7 +316,7 @@ int vectorized_predicated_predicate_with_pure_call_test(const Target &t) {
 
     ref(x, y) = 10;
     ref(r.x, r.y) += abs(r.x * r.y) + g(2 * r.x + 1, r.y);
-    Buffer<int> im_ref = ref.realize(160, 160);
+    Buffer<int> im_ref = ref.realize({160, 160});
 
     f(x, y) = 10;
     f(r.x, r.y) += abs(r.x * r.y) + g(2 * r.x + 1, r.y);
@@ -328,7 +328,7 @@ int vectorized_predicated_predicate_with_pure_call_test(const Target &t) {
         f.add_custom_lowering_pass(new CheckPredicatedStoreLoad(t, 3, 6));
     }
 
-    Buffer<int> im = f.realize(160, 160);
+    Buffer<int> im = f.realize({160, 160});
     auto func = [im_ref](int x, int y, int z) { return im_ref(x, y, z); };
     if (check_image(im, func)) {
         return -1;
@@ -354,7 +354,7 @@ int vectorized_predicated_load_const_index_test(const Target &t) {
 
     ref(x, y) = x + y;
     ref(r.x, y) = clamp(select((r.x % 2) == 0, r.x, y) + input(r.x % 2, y), 0, 10);
-    Buffer<int> im_ref = ref.realize(100, 100);
+    Buffer<int> im_ref = ref.realize({100, 100});
 
     f(x, y) = x + y;
     f(r.x, y) = clamp(select((r.x % 2) == 0, r.x, y) + input(r.x % 2, y), 0, 10);
@@ -366,7 +366,7 @@ int vectorized_predicated_load_const_index_test(const Target &t) {
         f.add_custom_lowering_pass(new CheckPredicatedStoreLoad(t, 1, 2));
     }
 
-    Buffer<int> im = f.realize(100, 100);
+    Buffer<int> im = f.realize({100, 100});
     auto func = [im_ref](int x, int y) { return im_ref(x, y); };
     if (check_image(im, func)) {
         return -1;

--- a/test/correctness/print.cpp
+++ b/test/correctness/print.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
 
         f(x) = print(x * x, "the answer is", 42.0f, "unsigned", cast<uint32_t>(145));
         f.set_custom_print(halide_print);
-        Buffer<int32_t> result = f.realize(10);
+        Buffer<int32_t> result = f.realize({10});
 
         for (int32_t i = 0; i < 10; i++) {
             if (result(i) != i * i) {
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
         // Test a string containing a printf format specifier (It should print it as-is).
         f(x) = print_when(x == 3, x * x, "g", 42.0f, "%s", param);
         f.set_custom_print(halide_print);
-        Buffer<int32_t> result = f.realize(10);
+        Buffer<int32_t> result = f.realize({10});
 
         for (int32_t i = 0; i < 10; i++) {
             if (result(i) != i * i) {
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
         }
         f(x) = print(args);
         f.set_custom_print(halide_print);
-        Buffer<uint64_t> result = f.realize(1);
+        Buffer<uint64_t> result = f.realize({1});
 
         if (result(0) != 100) {
             return -1;
@@ -213,7 +213,7 @@ int main(int argc, char **argv) {
         if (target.has_feature(Target::HVX)) {
             f.hexagon();
         }
-        Buffer<int> result = f.realize(128);
+        Buffer<int> result = f.realize({128});
 
         if (!target.has_feature(Target::HVX)) {
             assert((int)messages.size() == result.width());
@@ -238,7 +238,7 @@ int main(int argc, char **argv) {
         if (target.has_feature(Target::HVX)) {
             f.hexagon();
         }
-        Buffer<int> result = f.realize(128);
+        Buffer<int> result = f.realize({128});
 
         if (!target.has_feature(Target::HVX)) {
             assert((int)messages.size() == result.width() / 2);

--- a/test/correctness/print.cpp
+++ b/test/correctness/print.cpp
@@ -158,7 +158,7 @@ int main(int argc, char **argv) {
         f(x) = print(e);
 
         f.set_custom_print(halide_print);
-        Buffer<float> imf = f.realize(N);
+        Buffer<float> imf = f.realize({N});
 
         assert(messages.size() == (size_t)N);
 
@@ -181,7 +181,7 @@ int main(int argc, char **argv) {
 
         g(x) = print(reinterpret(Float(64), (cast<uint64_t>(random_uint()) << 32) | random_uint()));
         g.set_custom_print(halide_print);
-        Buffer<double> img = g.realize(N);
+        Buffer<double> img = g.realize({N});
 
         assert(messages.size() == (size_t)N);
 

--- a/test/correctness/process_some_tiles.cpp
+++ b/test/correctness/process_some_tiles.cpp
@@ -72,11 +72,11 @@ int main(int argc, char **argv) {
     bitmap_buf(5, 5) = true;
     bitmap.set(bitmap_buf);
 
-    Buffer<float> image_buf = lambda(x, y, (sin(x + y) + 1) / 2).realize({10} * tile_size, 10 * tile_size);
+    Buffer<float> image_buf = lambda(x, y, (sin(x + y) + 1) / 2).realize({10 * tile_size}, {10 * tile_size});
     image.set(image_buf);
 
     call_count = 0;
-    Buffer<float> result = output.realize({10} * tile_size, 10 * tile_size);
+    Buffer<float> result = output.realize({10 * tile_size}, {10 * tile_size});
 
     // Force a reload of call_count
     my_powf(1, 1);

--- a/test/correctness/process_some_tiles.cpp
+++ b/test/correctness/process_some_tiles.cpp
@@ -72,11 +72,11 @@ int main(int argc, char **argv) {
     bitmap_buf(5, 5) = true;
     bitmap.set(bitmap_buf);
 
-    Buffer<float> image_buf = lambda(x, y, (sin(x + y) + 1) / 2).realize(10 * tile_size, 10 * tile_size);
+    Buffer<float> image_buf = lambda(x, y, (sin(x + y) + 1) / 2).realize({10} * tile_size, 10 * tile_size);
     image.set(image_buf);
 
     call_count = 0;
-    Buffer<float> result = output.realize(10 * tile_size, 10 * tile_size);
+    Buffer<float> result = output.realize({10} * tile_size, 10 * tile_size);
 
     // Force a reload of call_count
     my_powf(1, 1);

--- a/test/correctness/process_some_tiles.cpp
+++ b/test/correctness/process_some_tiles.cpp
@@ -72,11 +72,11 @@ int main(int argc, char **argv) {
     bitmap_buf(5, 5) = true;
     bitmap.set(bitmap_buf);
 
-    Buffer<float> image_buf = lambda(x, y, (sin(x + y) + 1) / 2).realize({10 * tile_size}, {10 * tile_size});
+    Buffer<float> image_buf = lambda(x, y, (sin(x + y) + 1) / 2).realize({10 * tile_size, 10 * tile_size});
     image.set(image_buf);
 
     call_count = 0;
-    Buffer<float> result = output.realize({10 * tile_size}, {10 * tile_size});
+    Buffer<float> result = output.realize({10 * tile_size, 10 * tile_size});
 
     // Force a reload of call_count
     my_powf(1, 1);

--- a/test/correctness/pseudostack_shares_slots.cpp
+++ b/test/correctness/pseudostack_shares_slots.cpp
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
         for (int sz = 8; sz <= 16; sz += 8) {
             mallocs.clear();
             p.set(sz);
-            chain.back().realize(1024);
+            chain.back().realize({1024});
             size_t sz1 = sz + 2 * 20 - 1;
             size_t sz2 = sz1 - 2;
             if (mallocs.size() != 2 || mallocs[0] != sz1 || mallocs[1] != sz2) {
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
         for (int sz = 64; sz <= 128; sz += 64) {
             mallocs.clear();
             p.set(sz);
-            chain.back().realize(1024);
+            chain.back().realize({1024});
             size_t sz1 = sz / 8 + 23;
             size_t sz2 = sz1 - 2;
             size_t sz3 = sz + 19;

--- a/test/correctness/random.cpp
+++ b/test/correctness/random.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
         f(x, y) = random_float();
         f.vectorize(x, 4);
         f.parallel(y);
-        Buffer<float> rand_image = f.realize(1024, 1024);
+        Buffer<float> rand_image = f.realize({1024, 1024});
 
         // Do some tests for randomness.
 
@@ -80,14 +80,14 @@ int main(int argc, char **argv) {
 
         seed.set(0);
 
-        Buffer<double> im1 = f.realize(1024, 1024);
-        Buffer<double> im2 = f.realize(1024, 1024);
+        Buffer<double> im1 = f.realize({1024, 1024});
+        Buffer<double> im2 = f.realize({1024, 1024});
 
         Func g;
         g(x, y) = f(x, y);
         seed.set(1);
 
-        Buffer<double> im3 = g.realize(1024, 1024);
+        Buffer<double> im3 = g.realize({1024, 1024});
 
         RDom r(im1);
         Expr v1 = im1(r.x, r.y);
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
     {
         Func f;
         f(x, y) = random_int();
-        Buffer<int> im = f.realize(1024, 1024);
+        Buffer<int> im = f.realize({1024, 1024});
 
         // Count the number of set bits;
         RDom r(im);

--- a/test/correctness/reduction_chain.cpp
+++ b/test/correctness/reduction_chain.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
     f1.store_at(out, x).compute_at(g, y);
     f2.store_at(out, x).compute_at(g, x);
 
-    out.realize(10, 10);
+    out.realize({10, 10});
 
     // We just want this to not segfault.
 

--- a/test/correctness/reduction_non_rectangular.cpp
+++ b/test/correctness/reduction_non_rectangular.cpp
@@ -90,7 +90,7 @@ int equality_inequality_bound_test(int index) {
     r.where(!(r.x != 10));
     f(r.x, r.y) += 1;
 
-    Buffer<int> im = f.realize(200, 200);
+    Buffer<int> im = f.realize({200, 200});
     for (int y = 0; y < im.height(); y++) {
         for (int x = 0; x < im.width(); x++) {
             int correct = x + y;
@@ -123,7 +123,7 @@ int split_fuse_test(int index) {
     f.update().split(r.x, rx_outer, rx_inner, 4);
     f.update().fuse(rx_inner, r.y, r_fused);
 
-    Buffer<int> im = f.realize(200, 200);
+    Buffer<int> im = f.realize({200, 200});
     for (int y = 0; y < im.height(); y++) {
         for (int x = 0; x < im.width(); x++) {
             int correct = x + y;
@@ -151,7 +151,7 @@ int free_variable_bound_test(int index) {
     r.where(r.x < r.y + z);
     f(r.x, r.y, z) += 1;
 
-    Buffer<int> im = f.realize(200, 200, 200);
+    Buffer<int> im = f.realize({200, 200, 200});
     for (int z = 0; z < im.channels(); z++) {
         for (int y = 0; y < im.height(); y++) {
             for (int x = 0; x < im.width(); x++) {
@@ -194,7 +194,7 @@ int func_call_inside_bound_test(int index) {
     run_tracer = false;
     niters_expected = 100;
     niters = 0;
-    Buffer<int> im = f.realize(200, 200);
+    Buffer<int> im = f.realize({200, 200});
 
     for (int y = 0; y < im.height(); y++) {
         for (int x = 0; x < im.width(); x++) {
@@ -233,7 +233,7 @@ int func_call_inside_bound_inline_test(int index) {
     r.where(r.x < g(r.y) + h(r.x));
     f(r.x, r.y) += 1;
 
-    Buffer<int> im = f.realize(200, 200);
+    Buffer<int> im = f.realize({200, 200});
 
     for (int y = 0; y < im.height(); y++) {
         for (int x = 0; x < im.width(); x++) {
@@ -282,7 +282,7 @@ int two_linear_bounds_test(int index) {
     // boxes for bounds relationships.
     niters_expected = 34 * 34;
     niters = 0;
-    Buffer<int> im = f.realize(200, 200);
+    Buffer<int> im = f.realize({200, 200});
     for (int y = 0; y < im.height(); y++) {
         for (int x = 0; x < im.width(); x++) {
             int correct = x + y;
@@ -329,7 +329,7 @@ int circle_bound_test(int index) {
     run_tracer = false;
     niters_expected = 100 * 100;
     niters = 0;
-    Buffer<int> im = f.realize(200, 200);
+    Buffer<int> im = f.realize({200, 200});
     for (int y = 0; y < im.height(); y++) {
         for (int x = 0; x < im.width(); x++) {
             int correct = x + y;
@@ -374,7 +374,7 @@ int intermediate_computed_if_param_test(int index) {
         run_tracer = false;
         niters_expected = 100 * 100;
         niters = 0;
-        Buffer<int> im = f.realize(200, 200);
+        Buffer<int> im = f.realize({200, 200});
         for (int y = 0; y < im.height(); y++) {
             for (int x = 0; x < im.width(); x++) {
                 int correct = x + y;
@@ -401,7 +401,7 @@ int intermediate_computed_if_param_test(int index) {
         run_tracer = false;
         niters_expected = 0;
         niters = 0;
-        Buffer<int> im = f.realize(200, 200);
+        Buffer<int> im = f.realize({200, 200});
         for (int y = 0; y < im.height(); y++) {
             for (int x = 0; x < im.width(); x++) {
                 int correct = x + y;
@@ -445,7 +445,7 @@ int intermediate_bound_depend_on_output_test(int index) {
     run_tracer = false;
     niters_expected = 200 * 199 / 2;
     niters = 0;
-    Buffer<int> im = f.realize(200, 200);
+    Buffer<int> im = f.realize({200, 200});
 
     for (int y = 0; y < im.height(); y++) {
         for (int x = 0; x < im.width(); x++) {
@@ -499,7 +499,7 @@ int tile_intermediate_bound_depend_on_output_test(int index) {
     run_tracer = false;
     niters_expected = 200 * 199 / 2;
     niters = 0;
-    Buffer<int> im = f.realize(200, 200);
+    Buffer<int> im = f.realize({200, 200});
 
     for (int y = 0; y < im.height(); y++) {
         for (int x = 0; x < im.width(); x++) {
@@ -541,7 +541,7 @@ int self_reference_bound_test(int index) {
     r2.where(f(r2.x, r2.y) < 30);
     g(r2.x, r2.y) += f(r2.x, r2.y);
 
-    Buffer<int> im1 = f.realize(200, 200);
+    Buffer<int> im1 = f.realize({200, 200});
     for (int y = 0; y < im1.height(); y++) {
         for (int x = 0; x < im1.width(); x++) {
             int correct = x + y;
@@ -556,7 +556,7 @@ int self_reference_bound_test(int index) {
         }
     }
 
-    Buffer<int> im2 = g.realize(200, 200);
+    Buffer<int> im2 = g.realize({200, 200});
     for (int y = 0; y < im2.height(); y++) {
         for (int x = 0; x < im2.width(); x++) {
             int correct = 10;
@@ -586,7 +586,7 @@ int random_float_bound_test(int index) {
     r.where(f(r.x, r.y)[0]);
     f(r.x, r.y) = Tuple(f(r.x, r.y)[0], f(r.x, r.y)[1] + 10);
 
-    Realization res = f.realize(200, 200);
+    Realization res = f.realize({200, 200});
     assert(res.size() == 2);
     Buffer<bool> im0 = res[0];
     Buffer<int> im1 = res[1];
@@ -628,7 +628,7 @@ int newton_method_test() {
     inverse(x) = {inverse(x)[0] * (2 - (x + 1) * inverse(x)[0]),
                   r + 1};
     {
-        Realization r = inverse.realize(128);
+        Realization r = inverse.realize({128});
         Buffer<float> r0 = r[0];
         Buffer<int> r1 = r[1];
         for (int i = 0; i < r0.width(); i++) {
@@ -665,7 +665,7 @@ int init_on_gpu_update_on_cpu_test(int index) {
     Var xi("xi"), yi("yi");
     f.gpu_tile(x, y, xi, yi, 4, 4);
 
-    Buffer<int> im = f.realize(200, 200);
+    Buffer<int> im = f.realize({200, 200});
     for (int y = 0; y < im.height(); y++) {
         for (int x = 0; x < im.width(); x++) {
             int correct = x + y;
@@ -697,7 +697,7 @@ int init_on_cpu_update_on_gpu_test(int index) {
     RVar rxi("rxi"), ryi("ryi");
     f.update(0).gpu_tile(r.x, r.y, r.x, r.y, rxi, ryi, 4, 4);
 
-    Buffer<int> im = f.realize(200, 200);
+    Buffer<int> im = f.realize({200, 200});
     for (int y = 0; y < im.height(); y++) {
         for (int x = 0; x < im.width(); x++) {
             int correct = x + y;
@@ -746,7 +746,7 @@ int gpu_intermediate_computed_if_param_test(int index) {
         run_tracer = false;
         niters_expected = 100 * 100;
         niters = 0;
-        Buffer<int> im = f.realize(200, 200);
+        Buffer<int> im = f.realize({200, 200});
         for (int y = 0; y < im.height(); y++) {
             for (int x = 0; x < im.width(); x++) {
                 int correct = x + y;
@@ -768,7 +768,7 @@ int gpu_intermediate_computed_if_param_test(int index) {
         run_tracer = false;
         niters_expected = 0;
         niters = 0;
-        Buffer<int> im = f.realize(200, 200);
+        Buffer<int> im = f.realize({200, 200});
         for (int y = 0; y < im.height(); y++) {
             for (int x = 0; x < im.width(); x++) {
                 int correct = x + y;
@@ -801,7 +801,7 @@ int vectorize_predicated_rvar_test() {
 
     f.update(0).unroll(r.x, 2).allow_race_conditions().vectorize(r.x, 8);
 
-    Buffer<int> im = f.realize(200, 200);
+    Buffer<int> im = f.realize({200, 200});
     for (int y = 0; y < im.height(); y++) {
         for (int x = 0; x < im.width(); x++) {
             int correct = 0;

--- a/test/correctness/reduction_schedule.cpp
+++ b/test/correctness/reduction_schedule.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
                                              energy(r.x, r.y - 1),
                                              energy(xp, r.y - 1));
 
-    Buffer<float> im_energy = energy.realize(size, size);
+    Buffer<float> im_energy = energy.realize({size, size});
     Buffer<float> ref_energy(size, size);
     for (int y = 0; y < size; y++) {
         for (int x = 0; x < size; x++) {

--- a/test/correctness/register_shuffle.cpp
+++ b/test/correctness/register_shuffle.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
             .gpu_lanes(xi)
             .unroll(xo);
 
-        Buffer<uint8_t> out = g.realize(32, 4);
+        Buffer<uint8_t> out = g.realize({32, 4});
         for (int y = 0; y < out.height(); y++) {
             for (int x = 0; x < out.width(); x++) {
                 uint8_t correct = 2 * (x + y);
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
             .gpu_lanes(y)
             .store_in(MemoryType::Register);
 
-        Buffer<float> out = c.realize(32, 32);
+        Buffer<float> out = c.realize({32, 32});
         for (int y = 0; y < out.height(); y++) {
             for (int x = 0; x < out.width(); x++) {
                 float correct = x + 100 * y;
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
             .vectorize(y, 2)
             .gpu_lanes(y);
 
-        Buffer<float> out = c.realize(64, 64);
+        Buffer<float> out = c.realize({64, 64});
         for (int y = 0; y < out.height(); y++) {
             for (int x = 0; x < out.width(); x++) {
                 float correct = x + 100 * y;
@@ -171,7 +171,7 @@ int main(int argc, char **argv) {
                 .gpu_lanes(x);
         }
 
-        Buffer<int> out = d.realize(24, 2);
+        Buffer<int> out = d.realize({24, 2});
         for (int y = 0; y < out.height(); y++) {
             for (int x = 0; x < out.width(); x++) {
                 int correct = 27 * (x + y);
@@ -209,7 +209,7 @@ int main(int argc, char **argv) {
                 .gpu_lanes(x);
         }
 
-        Buffer<int> out = d.realize(24, 2);
+        Buffer<int> out = d.realize({24, 2});
         for (int y = 0; y < out.height(); y++) {
             for (int x = 0; x < out.width(); x++) {
                 int correct = 27 * (x + y);
@@ -239,7 +239,7 @@ int main(int argc, char **argv) {
             .compute_at(b, yi)
             .gpu_lanes(x);
 
-        Buffer<int> out = b.realize(32, 32);
+        Buffer<int> out = b.realize({32, 32});
         for (int y = 0; y < out.height(); y++) {
             for (int x = 0; x < out.width(); x++) {
                 int correct = x + 2 * y;
@@ -302,7 +302,7 @@ int main(int argc, char **argv) {
             .set_min(0)
             .dim(1)
             .set_min(0);
-        Buffer<float> out = upy.realize(128, 128);
+        Buffer<float> out = upy.realize({128, 128});
 
         for (int y = 0; y < out.height(); y++) {
             for (int x = 0; x < out.width(); x++) {
@@ -360,7 +360,7 @@ int main(int argc, char **argv) {
             .gpu_lanes(xi)
             .unroll(x);
 
-        Buffer<float> out = s4.realize(64, 64);
+        Buffer<float> out = s4.realize({64, 64});
 
         for (int y = 0; y < out.height(); y++) {
             for (int x = 0; x < out.width(); x++) {
@@ -420,7 +420,7 @@ int main(int argc, char **argv) {
             .gpu_lanes(xi)
             .unroll(x);
 
-        Buffer<float> out = s4.realize(32, 32);
+        Buffer<float> out = s4.realize({32, 32});
 
         for (int y = 0; y < out.height(); y++) {
             for (int x = 0; x < out.width(); x++) {
@@ -508,7 +508,7 @@ int main(int argc, char **argv) {
 
         Var xo, xi;
         f.gpu_tile(x, xo, xi, 32);
-        f.realize(1024);
+        f.realize({1024});
     }
 
     printf("Success!\n");

--- a/test/correctness/register_shuffle.cpp
+++ b/test/correctness/register_shuffle.cpp
@@ -480,7 +480,7 @@ int main(int argc, char **argv) {
             .gpu_lanes(xi)
             .unroll(xo);
 
-        Buffer<uint16_t> out = curved.realize(buf.width(), buf.height());
+        Buffer<uint16_t> out = curved.realize({buf.width(), buf.height()});
 
         for (int y = 0; y < out.height(); y++) {
             for (int x = 0; x < out.width(); x++) {

--- a/test/correctness/reorder_rvars.cpp
+++ b/test/correctness/reorder_rvars.cpp
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
         // over y outside of the loop over r, which is the default.
         sat.update(1).parallel(y);
 
-        sat.realize(100, 100);
+        sat.realize({100, 100});
     }
 
     printf("Success!\n");

--- a/test/correctness/reorder_storage.cpp
+++ b/test/correctness/reorder_storage.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
     int H = 11;
     expected_allocation = (3 * W * H + 1) * sizeof(int);
 
-    g.realize(W, H, 3);
+    g.realize({W, H, 3});
 
     int x_alignment = 16;
     f.align_storage(x, x_alignment);
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
 
     // Force g to clear it's cache...
     g.compute_root();
-    g.realize(W, H, 3);
+    g.realize({W, H, 3});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/require.cpp
+++ b/test/correctness/require.cpp
@@ -42,7 +42,7 @@ static void test(int vector_width) {
     p1.set(1);
     p2.set(2);
     error_occurred = false;
-    result = f.realize(realize_width);
+    result = f.realize({realize_width});
     if (!error_occurred) {
         printf("There should have been a requirement error (vector_width = %d)\n", vector_width);
         exit(1);
@@ -51,7 +51,7 @@ static void test(int vector_width) {
     p1.set(1);
     p2.set(kPrime1 - 1);
     error_occurred = false;
-    result = f.realize(realize_width);
+    result = f.realize({realize_width});
     if (error_occurred) {
         printf("There should not have been a requirement error (vector_width = %d)\n", vector_width);
         exit(1);

--- a/test/correctness/require.cpp
+++ b/test/correctness/require.cpp
@@ -77,7 +77,7 @@ static void test(int vector_width) {
     p2.set(15);
 
     error_occurred = false;
-    result = clamped.realize(64, 3);
+    result = clamped.realize({64, 3});
     if (!error_occurred) {
         printf("There should have been a requirement error (vector_width = %d)\n", vector_width);
         exit(1);
@@ -87,7 +87,7 @@ static void test(int vector_width) {
     p2.set(16);
 
     error_occurred = false;
-    result = clamped.realize(64, 3);
+    result = clamped.realize({64, 3});
     if (error_occurred) {
         printf("There should NOT have been a requirement error (vector_width = %d)\n", vector_width);
         exit(1);

--- a/test/correctness/reschedule.cpp
+++ b/test/correctness/reschedule.cpp
@@ -26,11 +26,11 @@ int main(int argc, char **argv) {
     f.set_custom_trace(&my_trace);
     f.trace_stores();
 
-    Buffer<int> result_1 = f.realize(10);
+    Buffer<int> result_1 = f.realize({10});
 
     f.vectorize(x, 4);
 
-    Buffer<int> result_2 = f.realize(10);
+    Buffer<int> result_2 = f.realize({10});
 
     // There should have been vector stores and scalar stores.
     if (!vector_store || !scalar_store) {

--- a/test/correctness/reuse_stack_alloc.cpp
+++ b/test/correctness/reuse_stack_alloc.cpp
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
     // Bound it so the allocations go on the stack.
     k.bound(x, 0, 16);
 
-    Buffer<int> result = k.realize(16);
+    Buffer<int> result = k.realize({16});
     for (int i = 0; i < result.width(); i++) {
         if (result(i) != 2 * i) {
             printf("Error! Allocation did not get reused at %d (%d != %d)\n", i, result(i), 2 * i);

--- a/test/correctness/rfactor.cpp
+++ b/test/correctness/rfactor.cpp
@@ -45,7 +45,7 @@ int simple_rfactor_test(bool compile_module) {
             return -1;
         }
     } else {
-        Buffer<int> im = g.realize(80, 80);
+        Buffer<int> im = g.realize({80, 80});
         auto func = [](int x, int y, int z) {
             return (10 <= x && x <= 29) && (30 <= y && y <= 69) ? std::max(40 + x + y, 40) : 40;
         };
@@ -94,7 +94,7 @@ int reorder_split_rfactor_test(bool compile_module) {
             return -1;
         }
     } else {
-        Buffer<int> im = g.realize(80, 80);
+        Buffer<int> im = g.realize({80, 80});
         auto func = [](int x, int y, int z) {
             return ((10 <= x && x <= 29) && (20 <= y && y <= 49)) ? x - y + 1 : 1;
         };
@@ -146,7 +146,7 @@ int multi_split_rfactor_test(bool compile_module) {
             return -1;
         }
     } else {
-        Buffer<int> im = g.realize(80, 80);
+        Buffer<int> im = g.realize({80, 80});
         auto func = [](int x, int y, int z) {
             return ((10 <= x && x <= 29) && (20 <= y && y <= 49)) ? x - y + 1 : 1;
         };
@@ -197,7 +197,7 @@ int reorder_fuse_wrapper_rfactor_test(bool compile_module) {
             return -1;
         }
     } else {
-        Buffer<int> im = g.realize(20, 20, 20);
+        Buffer<int> im = g.realize({20, 20, 20});
         auto func = [](int x, int y, int z) {
             return ((5 <= x && x <= 14) && (5 <= y && y <= 14) &&
                     (5 <= z && z <= 14)) ?
@@ -236,7 +236,7 @@ int non_trivial_lhs_rfactor_test(bool compile_module) {
         f.compute_root();
 
         g(x, y, z) = 2 * f(x, y);
-        im_ref = g.realize(20, 20, 20);
+        im_ref = g.realize({20, 20, 20});
     }
 
     {
@@ -273,7 +273,7 @@ int non_trivial_lhs_rfactor_test(bool compile_module) {
                 return -1;
             }
         } else {
-            Buffer<int> im = g.realize(20, 20, 20);
+            Buffer<int> im = g.realize({20, 20, 20});
             auto func = [im_ref](int x, int y, int z) {
                 return im_ref(x, y, z);
             };
@@ -321,7 +321,7 @@ int simple_rfactor_with_specialize_test(bool compile_module) {
     } else {
         {
             p.set(0);
-            Buffer<int> im = g.realize(80, 80);
+            Buffer<int> im = g.realize({80, 80});
             auto func = [](int x, int y, int z) {
                 return (10 <= x && x <= 29) && (30 <= y && y <= 69) ? std::min(x + y + 2, 40) : 40;
             };
@@ -331,7 +331,7 @@ int simple_rfactor_with_specialize_test(bool compile_module) {
         }
         {
             p.set(20);
-            Buffer<int> im = g.realize(80, 80);
+            Buffer<int> im = g.realize({80, 80});
             auto func = [](int x, int y, int z) {
                 return (10 <= x && x <= 29) && (30 <= y && y <= 69) ? std::min(x + y + 2, 40) : 40;
             };
@@ -378,7 +378,7 @@ int rdom_with_predicate_rfactor_test(bool compile_module) {
             return -1;
         }
     } else {
-        Buffer<int> im = g.realize(20, 20, 20);
+        Buffer<int> im = g.realize({20, 20, 20});
         auto func = [](int x, int y, int z) {
             return (5 <= x && x <= 14) && (5 <= y && y <= 14) &&
                            (0 <= z && z <= 19) && (x < y) && (x + 2 * y <= z) ?
@@ -440,7 +440,7 @@ int histogram_rfactor_test(bool compile_module) {
             return -1;
         }
     } else {
-        Buffer<int32_t> histogram = g.realize(10);  // buckets 10-20 only
+        Buffer<int32_t> histogram = g.realize({10});  // buckets 10-20 only
         for (int i = 10; i < 20; i++) {
             if (histogram(i - 10) != reference_hist[i]) {
                 printf("Error: bucket %d is %d instead of %d\n",
@@ -529,7 +529,7 @@ int tuple_rfactor_test(bool compile_module) {
     Func ref("ref");
     ref(x, y) = Tuple(1, 3);
     ref(x, y) = Tuple(ref(x, y)[0] + f(r.x, r.y)[0] + 3, min(ref(x, y)[1], f(r.x, r.y)[1]));
-    Realization ref_rn = ref.realize(80, 80);
+    Realization ref_rn = ref.realize({80, 80});
 
     g(x, y) = Tuple(1, 3);
     g(x, y) = Tuple(g(x, y)[0] + f(r.x, r.y)[0] + 3, min(g(x, y)[1], f(r.x, r.y)[1]));
@@ -567,7 +567,7 @@ int tuple_rfactor_test(bool compile_module) {
             return -1;
         }
     } else {
-        Realization rn = g.realize(80, 80);
+        Realization rn = g.realize({80, 80});
         Buffer<int> im1(rn[0]);
         Buffer<int> im2(rn[1]);
 
@@ -605,7 +605,7 @@ int tuple_specialize_rdom_predicate_rfactor_test(bool compile_module) {
     Func ref("ref");
     ref(x, y) = Tuple(1, 3);
     ref(x, y) = Tuple(ref(x, y)[0] * f(r.x, r.y, r.z)[0], ref(x, y)[1] + 2 * f(r.x, r.y, r.z)[1]);
-    Realization ref_rn = ref.realize(10, 10);
+    Realization ref_rn = ref.realize({10, 10});
 
     g(x, y) = Tuple(1, 3);
 
@@ -648,7 +648,7 @@ int tuple_specialize_rdom_predicate_rfactor_test(bool compile_module) {
         {
             p.set(10);
             q.set(true);
-            Realization rn = g.realize(10, 10);
+            Realization rn = g.realize({10, 10});
             Buffer<int> im1(rn[0]);
             Buffer<int> im2(rn[1]);
 
@@ -671,7 +671,7 @@ int tuple_specialize_rdom_predicate_rfactor_test(bool compile_module) {
         {
             p.set(10);
             q.set(false);
-            Realization rn = g.realize(10, 10);
+            Realization rn = g.realize({10, 10});
             Buffer<int> im1(rn[0]);
             Buffer<int> im2(rn[1]);
 
@@ -694,7 +694,7 @@ int tuple_specialize_rdom_predicate_rfactor_test(bool compile_module) {
         {
             p.set(0);
             q.set(true);
-            Realization rn = g.realize(10, 10);
+            Realization rn = g.realize({10, 10});
             Buffer<int> im1(rn[0]);
             Buffer<int> im2(rn[1]);
 
@@ -717,7 +717,7 @@ int tuple_specialize_rdom_predicate_rfactor_test(bool compile_module) {
         {
             p.set(0);
             q.set(false);
-            Realization rn = g.realize(10, 10);
+            Realization rn = g.realize({10, 10});
             Buffer<int> im1(rn[0]);
             Buffer<int> im2(rn[1]);
 
@@ -769,10 +769,10 @@ int complex_multiply_rfactor_test() {
     intm.compute_root();
     intm.update(0).vectorize(u, 2);
 
-    Realization ref_rn = ref.realize(80, 80);
+    Realization ref_rn = ref.realize({80, 80});
     Buffer<int> ref_im1(ref_rn[0]);
     Buffer<int> ref_im2(ref_rn[1]);
-    Realization rn = g.realize(80, 80);
+    Realization rn = g.realize({80, 80});
     Buffer<int> im1(rn[0]);
     Buffer<int> im2(rn[1]);
 
@@ -885,7 +885,7 @@ int check_allocation_bound_test() {
 
     f.trace_realizations();
     g.set_custom_trace(allocation_bound_test_trace);
-    g.realize(23);
+    g.realize({23});
 
     return 0;
 }
@@ -918,8 +918,8 @@ int rfactor_tile_reorder_test() {
         .parallel(u)
         .parallel(v);
 
-    Buffer<int> im_ref = ref.realize(8);
-    Buffer<int> im = f.realize(8);
+    Buffer<int> im_ref = ref.realize({8});
+    Buffer<int> im = f.realize({8});
     auto func = [&im_ref](int x, int y) {
         return im_ref(x, y);
     };
@@ -942,7 +942,7 @@ int tuple_partial_reduction_rfactor_test(bool compile_module) {
     Func ref("ref");
     ref(x, y) = Tuple(1, 3);
     ref(x, y) = Tuple(ref(x, y)[0] + f(r.x, r.y)[0] + 3, ref(x, y)[1]);
-    Realization ref_rn = ref.realize(80, 80);
+    Realization ref_rn = ref.realize({80, 80});
 
     g(x, y) = Tuple(1, 3);
     g(x, y) = Tuple(g(x, y)[0] + f(r.x, r.y)[0] + 3, g(x, y)[1]);
@@ -980,7 +980,7 @@ int tuple_partial_reduction_rfactor_test(bool compile_module) {
             return -1;
         }
     } else {
-        Realization rn = g.realize(80, 80);
+        Realization rn = g.realize({80, 80});
         Buffer<int> im1(rn[0]);
         Buffer<int> im2(rn[1]);
 
@@ -1016,7 +1016,7 @@ int self_assignment_rfactor_test() {
     Func intm = g.update(0).rfactor(r.y, u);
     intm.compute_root();
 
-    Buffer<int> im = g.realize(10, 10);
+    Buffer<int> im = g.realize({10, 10});
     auto func = [](int x, int y, int z) {
         return x + y;
     };

--- a/test/correctness/round.cpp
+++ b/test/correctness/round.cpp
@@ -12,7 +12,7 @@ bool test(Expr e, const char *funcname, int vector_width, int N, Buffer<T> &inpu
     if (vector_width > 1) {
         f.vectorize(x, vector_width);
     }
-    Buffer<T> im = f.realize(N);
+    Buffer<T> im = f.realize({N});
 
     printf("Testing %s (%s x %d)\n", funcname, type_of<T>() == Float(32) ? "float" : "double", vector_width);
     bool ok = true;

--- a/test/correctness/saturating_casts.cpp
+++ b/test/correctness/saturating_casts.cpp
@@ -56,7 +56,7 @@ void test_saturating() {
 
     f(x) = saturating_cast<target_t>(in(x));
 
-    Buffer<target_t> result = f.realize(7);
+    Buffer<target_t> result = f.realize({7});
 
     for (int32_t i = 0; i < 7; i++) {
         bool source_signed = std::numeric_limits<source_t>::is_signed;
@@ -155,7 +155,7 @@ void test_concise(cast_maker_t cast_maker, bool saturating) {
 
     f(x) = cast_maker(in(x));
 
-    Buffer<target_t> result = f.realize(7);
+    Buffer<target_t> result = f.realize({7});
 
     for (int32_t i = 0; i < 7; i++) {
         bool source_signed = std::numeric_limits<source_t>::is_signed;

--- a/test/correctness/scatter.cpp
+++ b/test/correctness/scatter.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
     g(x, y) = f(x + 5, y + 5);
 
     f.compute_root();
-    Buffer<int> result = g.realize(10, 1);
+    Buffer<int> result = g.realize({10, 1});
 
     // The init step of f should fill in (-11, 5) -- (14, 5) inclusive, to
     // cover both the reads done by the update step and g

--- a/test/correctness/shadowed_bound.cpp
+++ b/test/correctness/shadowed_bound.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
     g.compute_root().tile(x, y, xi, yi, 32, 32);
     f.compute_at(g, x).bound(c, 0, 4).unroll(c);
 
-    g.realize(1024, 1024, 4);
+    g.realize({1024, 1024, 4});
 
     // f's loop over channels has two bounds. The first outer one
     // comes from its relationship with g - it needs to satisfy

--- a/test/correctness/skip_stages.cpp
+++ b/test/correctness/skip_stages.cpp
@@ -53,12 +53,12 @@ int main(int argc, char **argv) {
 
         reset_counts();
         toggle1.set(true);
-        f4.realize(10);
+        f4.realize({10});
         check_counts(10, 0);
 
         reset_counts();
         toggle1.set(false);
-        f4.realize(10);
+        f4.realize({10});
         check_counts(0, 10);
     }
 
@@ -81,25 +81,25 @@ int main(int argc, char **argv) {
         reset_counts();
         toggle1.set(true);
         toggle2.set(true);
-        f4.realize(10);
+        f4.realize({10});
         check_counts(10, 10, 10);
 
         reset_counts();
         toggle1.set(false);
         toggle2.set(true);
-        f4.realize(10);
+        f4.realize({10});
         check_counts(10, 0, 10);
 
         reset_counts();
         toggle1.set(true);
         toggle2.set(false);
-        f4.realize(10);
+        f4.realize({10});
         check_counts(10, 10, 0);
 
         reset_counts();
         toggle1.set(false);
         toggle2.set(false);
-        f4.realize(10);
+        f4.realize({10});
         check_counts(0, 0, 0);
     }
 
@@ -118,12 +118,12 @@ int main(int argc, char **argv) {
 
         reset_counts();
         toggle1.set(true);
-        f2.realize(10);
+        f2.realize({10});
         check_counts(10, 10);
 
         reset_counts();
         toggle1.set(false);
-        f2.realize(10);
+        f2.realize({10});
         check_counts(10, 10);
     }
 
@@ -134,18 +134,18 @@ int main(int argc, char **argv) {
         f1(x) = Tuple(call_counter(x, 0), call_counter(x + 1, 1));
         f2(x) = select(toggle1, f1(x)[0], 0);
         f1.compute_root();
-        f2.realize(10);
+        f2.realize({10});
 
         f2.compile_jit();
 
         reset_counts();
         toggle1.set(true);
-        f2.realize(10);
+        f2.realize({10});
         check_counts(10, 10);
 
         reset_counts();
         toggle1.set(false);
-        f2.realize(10);
+        f2.realize({10});
         check_counts(0, 0);
     }
 
@@ -169,25 +169,25 @@ int main(int argc, char **argv) {
         reset_counts();
         toggle1.set(true);
         toggle2.set(true);
-        f4.realize(10);
+        f4.realize({10});
         check_counts(10, 10, 10);
 
         reset_counts();
         toggle1.set(false);
         toggle2.set(true);
-        f4.realize(10);
+        f4.realize({10});
         check_counts(10, 0, 10);
 
         reset_counts();
         toggle1.set(true);
         toggle2.set(false);
-        f4.realize(10);
+        f4.realize({10});
         check_counts(10, 10, 0);
 
         reset_counts();
         toggle1.set(false);
         toggle2.set(false);
-        f4.realize(10);
+        f4.realize({10});
         check_counts(0, 0, 0);
     }
 
@@ -203,7 +203,7 @@ int main(int argc, char **argv) {
 
         f.store_root().compute_at(g, x);
         g.compute_at(h, x);
-        h.realize(10);
+        h.realize({10});
         check_counts(11);
     }
 

--- a/test/correctness/skip_stages_memoize.cpp
+++ b/test/correctness/skip_stages_memoize.cpp
@@ -94,7 +94,7 @@ int single_memoize_test(int index) {
     for (bool toggle_val : {false, true}) {
         set_toggle1 = toggle_val;
         toggle.set(set_toggle1);
-        Buffer<int> out = f2.realize(10);
+        Buffer<int> out = f2.realize({10});
         if (check_correctness_single(out, set_toggle1) != 0) {
             return -1;
         }
@@ -123,7 +123,7 @@ int tuple_memoize_test(int index) {
     for (bool toggle_val : {false, true}) {
         set_toggle1 = toggle_val;
         toggle.set(set_toggle1);
-        Realization out = f2.realize(128);
+        Realization out = f2.realize({128});
         Buffer<int> out0 = out[0];
         Buffer<int> out1 = out[1];
 
@@ -163,7 +163,7 @@ int non_trivial_allocate_predicate_test(int index) {
         set_toggle1 = toggle_val;
         set_toggle2 = toggle_val;
         toggle.set(set_toggle1);
-        Buffer<int> out = f3.realize(10);
+        Buffer<int> out = f3.realize({10});
         if (check_correctness_single(out, set_toggle1) != 0) {
             return -1;
         }
@@ -198,7 +198,7 @@ int double_memoize_test(int index) {
             set_toggle2 = toggle_val2;
             toggle1.set(set_toggle1);
             toggle2.set(toggle_val2);
-            Buffer<int> out = f3.realize(10);
+            Buffer<int> out = f3.realize({10});
             if (check_correctness_double(out, set_toggle1, set_toggle2) != 0) {
                 return -1;
             }

--- a/test/correctness/sliding_backwards.cpp
+++ b/test/correctness/sliding_backwards.cpp
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
     g.compute_at(f, x);
     g.store_root();
 
-    f.realize(10);
+    f.realize({10});
 
     if (call_counter != 11) {
         printf("g was called %d times instead of %d\n", call_counter, 11);

--- a/test/correctness/sliding_over_guard_with_if.cpp
+++ b/test/correctness/sliding_over_guard_with_if.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
         .store_at(dst, yo)
         .fold_storage(y, 4);
 
-    Buffer<int> out = dst.realize(100, 100);
+    Buffer<int> out = dst.realize({100, 100});
 
     // The number of calls to 'expensive' should be the size of the
     // output, plus some margin from the stencil, plus a little

--- a/test/correctness/sliding_reduction.cpp
+++ b/test/correctness/sliding_reduction.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
         f.store_root().compute_at(g, y);
 
         counter = 0;
-        check(g.realize(2, 10));
+        check(g.realize({2, 10}));
 
         int correct = 24;
         if (counter != correct) {
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
         f.store_root().compute_at(g, y);
 
         counter = 0;
-        check(g.realize(2, 10));
+        check(g.realize({2, 10}));
 
         int correct = 60;
         if (counter != correct) {
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
         f.store_root().compute_at(g, y);
 
         counter = 0;
-        check(g.realize(2, 10));
+        check(g.realize({2, 10}));
 
         int correct = 42;
         if (counter != correct) {

--- a/test/correctness/sliding_window.cpp
+++ b/test/correctness/sliding_window.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
 
         f.store_root().compute_at(g, x);
 
-        Buffer<int> im = g.realize(100);
+        Buffer<int> im = g.realize({100});
 
         // f should be able to tell that it only needs to compute each value once
         if (count != 101) {
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
         f.store_root().compute_at(g, x);
         g.compute_at(h, x);
 
-        Buffer<int> im = h.realize(100);
+        Buffer<int> im = h.realize({100});
         if (count != 101) {
             printf("f was called %d times instead of %d times\n", count, 101);
             return -1;
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
 
         h.reorder(c, x).reorder_storage(c, x).bound(c, 0, 4).vectorize(c);
 
-        Buffer<int> im = h.realize(100, 4);
+        Buffer<int> im = h.realize({100, 4});
         if (count != 404) {
             printf("f was called %d times instead of %d times\n", count, 404);
             return -1;
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
 
         g(x, y) = f(x, y) + f(x, y - 1);
 
-        Buffer<int> im = g.realize(10, 10);
+        Buffer<int> im = g.realize({10, 10});
 
         // For each value of y, f should be evaluated over (0 .. 100) in
         // x, and (y .. y-1) in y. Sliding window optimization means that
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
         g(x, y) = f(x - 1, y) + f(x, y) + f(x, y - 1);
         f.store_root().compute_at(g, x);
 
-        Buffer<int> im = g.realize(10, 10);
+        Buffer<int> im = g.realize({10, 10});
 
         if (count != 11 * 11) {
             printf("f was called %d times instead of %d times\n", count, 11 * 11);
@@ -144,7 +144,7 @@ int main(int argc, char **argv) {
         g(x, y) = f(x + y, x - y) + f((x - 2) + y, (x - 2) - y) + f(x + (y - 2), x - (y - 2));
         f.store_root().compute_at(g, x);
 
-        Buffer<int> im = g.realize(10, 10);
+        Buffer<int> im = g.realize({10, 10});
         if (count != 1500) {
             printf("f was called %d times instead of %d times\n", count, 1500);
             return -1;
@@ -158,7 +158,7 @@ int main(int argc, char **argv) {
         g(x, y) = f(x, y) + f(x + 1, y) + f(x, y + 1) + f(x + 1, y + 1);
         f.store_at(g, y).compute_at(g, x);
         g.set_custom_allocator(&my_malloc, &my_free);
-        Buffer<int> im = g.realize(10, 10);
+        Buffer<int> im = g.realize({10, 10});
     }
 
     {
@@ -173,7 +173,7 @@ int main(int argc, char **argv) {
         f.store_root().compute_at(g, x);
 
         count = 0;
-        Buffer<int> im = g.realize(100);
+        Buffer<int> im = g.realize({100});
 
         // f should be able to tell that it only needs to compute each value once
         if (count != 6) {
@@ -192,7 +192,7 @@ int main(int argc, char **argv) {
         f.store_root().compute_at(g, x);
 
         count = 0;
-        Buffer<int> im = g.realize(100);
+        Buffer<int> im = g.realize({100});
 
         // f should be able to tell that it only needs to compute each value once
         if (count != 34) {
@@ -213,7 +213,7 @@ int main(int argc, char **argv) {
         f.store_root().compute_at(g, x).unroll(x);
 
         count = 0;
-        Buffer<int> im = g.realize(100);
+        Buffer<int> im = g.realize({100});
 
         if (count != 101) {
             printf("f was called %d times instead of %d times\n", count, 101);

--- a/test/correctness/sort_exprs.cpp
+++ b/test/correctness/sort_exprs.cpp
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
         g(i) = exprs[i];
     }
 
-    Buffer<float> result = g.realize(N);
+    Buffer<float> result = g.realize({N});
 
     for (int i = 0; i < N; i++) {
         printf("%f ", result(i));

--- a/test/correctness/specialize.cpp
+++ b/test/correctness/specialize.cpp
@@ -194,7 +194,7 @@ int main(int argc, char **argv) {
 
         reset_alloc_counts();
         param.set(true);
-        out.realize(100);
+        out.realize({100});
 
         if (empty_allocs != 1 || nonempty_allocs != 2 || frees != 3) {
             printf("There were supposed to be 1 empty alloc, 2 nonempty allocs, and 3 frees.\n"
@@ -205,7 +205,7 @@ int main(int argc, char **argv) {
 
         reset_alloc_counts();
         param.set(false);
-        out.realize(100);
+        out.realize({100});
 
         if (empty_allocs != 2 || nonempty_allocs != 1 || frees != 3) {
             printf("There were supposed to be 2 empty allocs, 1 nonempty alloc, and 3 frees.\n"
@@ -241,7 +241,7 @@ int main(int argc, char **argv) {
 
         // Check we don't crash with the small input, and that it uses scalar stores
         reset_trace();
-        f.realize(5);
+        f.realize({5});
         if (!scalar_store || vector_store) {
             printf("These stores were supposed to be scalar.\n");
             return -1;
@@ -252,7 +252,7 @@ int main(int argc, char **argv) {
         im.set(image);
 
         reset_trace();
-        f.realize(100);
+        f.realize({100});
         if (scalar_store || !vector_store) {
             printf("These stores were supposed to be vector.\n");
             return -1;
@@ -306,7 +306,7 @@ int main(int argc, char **argv) {
         size.set(1);
 
         // Not crashing is enough
-        f.realize(100);
+        f.realize({100});
     }
 
     {
@@ -326,7 +326,7 @@ int main(int argc, char **argv) {
         im.set(image);
         // The image is too small, but that should be OK, because the
         // param is false so the image will never be used.
-        f.realize(100);
+        f.realize({100});
     }
 
     {
@@ -555,12 +555,12 @@ int main(int argc, char **argv) {
 
         vector_store_lanes = 0;
         p.set(0);
-        f.realize(100);
+        f.realize({100});
         _halide_user_assert(vector_store_lanes == 32);
 
         vector_store_lanes = 0;
         p.set(42);  // just a nonzero value
-        f.realize(100);
+        f.realize({100});
         _halide_user_assert(vector_store_lanes == 4);
     }
 
@@ -603,12 +603,12 @@ int main(int argc, char **argv) {
 
         vector_store_lanes = 0;
         p.set(42);  // Chosen to ensure pruned branch is pruned
-        f.realize(100);
+        f.realize({100});
         _halide_user_assert(vector_store_lanes == 16);
 
         vector_store_lanes = 0;
         p.set(0);
-        f.realize(100);
+        f.realize({100});
         _halide_user_assert(vector_store_lanes == 32);
     }
 
@@ -630,12 +630,12 @@ int main(int argc, char **argv) {
 
         vector_store_lanes = 0;
         p.set(42);  // arbitrary nonzero value
-        f.realize(100);
+        f.realize({100});
         _halide_user_assert(vector_store_lanes == 16);
 
         vector_store_lanes = 0;
         p.set(0);
-        f.realize(100);
+        f.realize({100});
         _halide_user_assert(vector_store_lanes == 32);
     }
 
@@ -660,7 +660,7 @@ int main(int argc, char **argv) {
 
         vector_store_lanes = 0;
         p.set(0);
-        f.realize(100);
+        f.realize({100});
         _halide_user_assert(vector_store_lanes == 32);
     }
 

--- a/test/correctness/split_by_non_factor.cpp
+++ b/test/correctness/split_by_non_factor.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
         for (int i = 1; i < 20; i++) {
             for (int j = 1; j < i; j++) {
                 sum_size.set(j);
-                f.realize(i);
+                f.realize({i});
             }
         }
     }

--- a/test/correctness/split_by_non_factor.cpp
+++ b/test/correctness/split_by_non_factor.cpp
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
         f(x) = 0;
         f(x) += x;
         f.update().unroll(x, 2, TailStrategy::GuardWithIf);
-        Buffer<int> result = f.realize(3);
+        Buffer<int> result = f.realize({3});
         for (int i = 0; i < result.width(); i++) {
             if (result(i) != i) {
                 printf("result(%d) was %d instead of %d\n", i, result(i), i);
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
         f.update().split(x, xo, xi, 7, TailStrategy::GuardWithIf);
         g.compute_at(f, xo);
         h.compute_at(f, xi);
-        Buffer<int> result = f.realize(15);
+        Buffer<int> result = f.realize({15});
         for (int i = 0; i < result.width(); i++) {
             int correct = (i - 3) + i * 7;
             int actual = result(i);
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
         f.update().split(x, xo, xi, 4).split(xi, xio, xii, 6);
         Func g;
         g(x) = f(x);
-        Buffer<int> result = g.realize(32);
+        Buffer<int> result = g.realize({32});
         for (int i = 0; i < result.width(); i++) {
             int correct = i + 1;
             int actual = result(i);

--- a/test/correctness/split_fuse_rvar.cpp
+++ b/test/correctness/split_fuse_rvar.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
         RVar rxy, rxyo, rxyi;
         g.update(0).fuse(r.x, r.y, rxy).split(rxy, rxyo, rxyi, 2);
 
-        Buffer<int> Rg = g.realize(4, 4);
+        Buffer<int> Rg = g.realize({4, 4});
 
         for (int i = 0; i < 4; i++) {
             for (int j = 0; j < 4; j++) {
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
         RVar ro, ri, roi;
         g.update(0).split(r, ro, ri, 2).fuse(ro, ri, roi);
 
-        Buffer<int> Rg = g.realize(16);
+        Buffer<int> Rg = g.realize({16});
 
         for (int i = 0; i < 16; i++) {
             if (Rg(i) != i) {

--- a/test/correctness/split_reuse_inner_name_bug.cpp
+++ b/test/correctness/split_reuse_inner_name_bug.cpp
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
 
     f(x) = 1;
     f.compute_root().split(x, x0, x, 16).split(x, x, x1, 2).split(x, x2, x, 4).split(x, x, x3, 2);
-    f.realize(1024);
+    f.realize({1024});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/split_store_compute.cpp
+++ b/test/correctness/split_store_compute.cpp
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
     g.compute_at(h, y);
     f.compute_root();
 
-    Buffer<int> imh = h.realize(32, 32);
+    Buffer<int> imh = h.realize({32, 32});
 
     bool success = true;
 

--- a/test/correctness/stack_allocations.cpp
+++ b/test/correctness/stack_allocations.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
     // f and g should both do stack allocations
     h.set_custom_allocator(&my_malloc, &my_free);
 
-    h.realize(10, 10);
+    h.realize({10, 10});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/stencil_chain_in_update_definitions.cpp
+++ b/test/correctness/stencil_chain_in_update_definitions.cpp
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
 
     g.trace_stores();
     h.set_custom_trace(&my_trace);
-    h.realize(output_extent);
+    h.realize({output_extent});
 
     if (num_stores != expected) {
         printf("Did not store to g the right numbers of times\n"

--- a/test/correctness/storage_folding.cpp
+++ b/test/correctness/storage_folding.cpp
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
 
         g.set_custom_allocator(my_malloc, my_free);
 
-        Buffer<int> im = g.realize(100, 1000, 3);
+        Buffer<int> im = g.realize({100, 1000, 3});
 
         size_t expected_size = 101 * 4 * sizeof(int) + sizeof(int);
         if (custom_malloc_size == 0 || custom_malloc_size != expected_size) {
@@ -131,7 +131,7 @@ int main(int argc, char **argv) {
 
         g.set_custom_allocator(my_malloc, my_free);
 
-        Buffer<int> im = g.realize(100, 1000, 3);
+        Buffer<int> im = g.realize({100, 1000, 3});
 
         size_t expected_size = 101 * 1002 * 3 * sizeof(int) + sizeof(int);
         if (custom_malloc_size == 0 || custom_malloc_size != expected_size) {
@@ -155,7 +155,7 @@ int main(int argc, char **argv) {
 
         g.set_custom_allocator(my_malloc, my_free);
 
-        Buffer<int> im = g.realize(100, 1000);
+        Buffer<int> im = g.realize({100, 1000});
 
         size_t expected_size = 101 * 3 * sizeof(int) + sizeof(int);
         if (custom_malloc_size == 0 || custom_malloc_size != expected_size) {
@@ -178,7 +178,7 @@ int main(int argc, char **argv) {
 
         f.set_custom_allocator(my_malloc, my_free);
 
-        Buffer<int> im = f.realize(1000, 1000);
+        Buffer<int> im = f.realize({1000, 1000});
 
         if (custom_malloc_size != 0) {
             printf("There should not have been a heap allocation\n");
@@ -211,7 +211,7 @@ int main(int argc, char **argv) {
 
         f.set_custom_allocator(my_malloc, my_free);
 
-        Buffer<int> im = f.realize(1000, 1000);
+        Buffer<int> im = f.realize({1000, 1000});
 
         if (custom_malloc_size != 0) {
             printf("There should not have been a heap allocation\n");
@@ -245,7 +245,7 @@ int main(int argc, char **argv) {
 
         f.set_custom_allocator(my_malloc, my_free);
 
-        Buffer<int> im = f.realize(1000, 1000);
+        Buffer<int> im = f.realize({1000, 1000});
 
         // Halide allocates one extra scalar, so we account for that.
         size_t expected_size = 2 * 1002 * 4 * sizeof(int) + sizeof(int);
@@ -283,7 +283,7 @@ int main(int argc, char **argv) {
 
         f.set_custom_allocator(my_malloc, my_free);
 
-        Buffer<int> im = f.realize(1000, 1000);
+        Buffer<int> im = f.realize({1000, 1000});
 
         // Halide allocates one extra scalar, so we account for that.
         size_t expected_size = 1000 * 8 * sizeof(int) + sizeof(int);
@@ -320,7 +320,7 @@ int main(int argc, char **argv) {
 
         f.set_custom_allocator(my_malloc, my_free);
 
-        Buffer<int> im = f.realize(1000, 1000);
+        Buffer<int> im = f.realize({1000, 1000});
 
         // Halide allocates one extra scalar, so we account for that.
         size_t expected_size = 2 * 1002 * 3 * sizeof(int) + sizeof(int);
@@ -353,7 +353,7 @@ int main(int argc, char **argv) {
 
         f.set_custom_allocator(my_malloc, my_free);
 
-        Buffer<int> im = f.realize(1000, 1000);
+        Buffer<int> im = f.realize({1000, 1000});
 
         // Halide allocates one extra scalar, so we account for that.
         size_t expected_size = 1000 * 2 * sizeof(int) + sizeof(int);
@@ -390,7 +390,7 @@ int main(int argc, char **argv) {
 
         g.set_custom_allocator(my_malloc, my_free);
 
-        Buffer<int> im = g.realize(100, 1000, 3);
+        Buffer<int> im = g.realize({100, 1000, 3});
 
         size_t expected_size;
         if (interleave) {
@@ -416,7 +416,7 @@ int main(int argc, char **argv) {
         g.store_root().compute_at(h, y).fold_storage(g.args()[1], 8);
         h.compute_root();
 
-        Buffer<int> out = h.realize(64, 64);
+        Buffer<int> out = h.realize({64, 64});
         out.for_each_element([&](int x, int y) {
             if (out(x, y) != x + y) {
                 printf("out(%d, %d) = %d instead of %d\n", x, y, out(x, y), x + y);
@@ -437,7 +437,7 @@ int main(int argc, char **argv) {
         g.compute_at(h, y);
         h.compute_root();
 
-        Buffer<int> out = h.realize(64, 64);
+        Buffer<int> out = h.realize({64, 64});
         out.for_each_element([&](int x, int y) {
             if (out(x, y) != x + y) {
                 printf("out(%d, %d) = %d instead of %d\n", x, y, out(x, y), x + y);
@@ -547,7 +547,7 @@ int main(int argc, char **argv) {
             .fold_storage(y, 4)  // <<-- this should be OK, but previously it sometimes wanted 6.
             .align_bounds(y, 2);
 
-        Buffer<int> im = output.realize(64, 64);
+        Buffer<int> im = output.realize({64, 64});
     }
 
     printf("Success!\n");

--- a/test/correctness/storage_folding.cpp
+++ b/test/correctness/storage_folding.cpp
@@ -83,7 +83,7 @@ void expected_error(void *, const char *msg) {
 void realize_and_expect_error(Func f, int w, int h) {
     error_occurred = false;
     f.set_error_handler(expected_error);
-    f.realize(w, h);
+    f.realize({w, h});
     if (!error_occurred) {
         printf("Expected an error!\n");
         abort();

--- a/test/correctness/store_in.cpp
+++ b/test/correctness/store_in.cpp
@@ -40,7 +40,7 @@ void check(MemoryType t1, MemoryType t2, MemoryType t3) {
 
     mallocs = 0;
     f.set_custom_allocator(my_malloc, my_free);
-    f.realize(1024);
+    f.realize({1024});
     if (mallocs != expected_mallocs) {
         std::cerr << "Wrong number of mallocs for " << t1 << ", " << t2 << ", " << t3 << "\n"
                   << "Expected " << expected_mallocs << " got " << mallocs << "\n";

--- a/test/correctness/stream_compaction.cpp
+++ b/test/correctness/stream_compaction.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
     // for Halide to prove:
     ones.update().allow_race_conditions().parallel(r, 50);
 
-    Buffer<int> result = ones.realize(1001);
+    Buffer<int> result = ones.realize({1001});
     int next = 0;
     for (int i = 0; i < result.width(); i++) {
         if (result(i) != next) {

--- a/test/correctness/strict_float.cpp
+++ b/test/correctness/strict_float.cpp
@@ -81,7 +81,7 @@ Buffer<float> one_million_rando_floats() {
     Var x("x");
     Func randos;
     randos(x) = random_float();
-    return randos.realize({1}e6);
+    return randos.realize({1e6});
 }
 
 ImageParam in(Float(32), 1);

--- a/test/correctness/strict_float.cpp
+++ b/test/correctness/strict_float.cpp
@@ -81,7 +81,7 @@ Buffer<float> one_million_rando_floats() {
     Var x("x");
     Func randos;
     randos(x) = random_float();
-    return randos.realize({1e6});
+    return randos.realize({1000000});
 }
 
 ImageParam in(Float(32), 1);
@@ -176,7 +176,7 @@ Func kahan_sum(int vectorize) {
 }
 
 float eval(Func f, const Target &t, const std::string &name, const std::string &suffix, float expected) {
-    float val = ((Buffer<float>)f.realize(t))();
+    float val = ((Buffer<float>)f.realize({}, t))();
     std::cout << "        " << name << ": " << val;
     if (expected != 0.0f) {
         std::cout << " residual: " << val - expected;

--- a/test/correctness/strict_float.cpp
+++ b/test/correctness/strict_float.cpp
@@ -81,7 +81,7 @@ Buffer<float> one_million_rando_floats() {
     Var x("x");
     Func randos;
     randos(x) = random_float();
-    return randos.realize(1e6);
+    return randos.realize({1}e6);
 }
 
 ImageParam in(Float(32), 1);

--- a/test/correctness/strict_float_bounds.cpp
+++ b/test/correctness/strict_float_bounds.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
     f_param.set(0.0f);
     // This test verifies that this realize() doesn't explode in bounds infererence
     // with "unbounded access of input"
-    Buffer<float> result = output.realize(1, t);
+    Buffer<float> result = output.realize({1}, t);
     assert(result(0) == 2.5f);
 
     printf("Success!\n");

--- a/test/correctness/strided_load.cpp
+++ b/test/correctness/strided_load.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
 
     //g.compile_to_assembly("/dev/stdout", std::vector<Argument>(), "g");
 
-    g.realize(425);
+    g.realize({425});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/thread_safety.cpp
+++ b/test/correctness/thread_safety.cpp
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
                 Func f;
                 Var x;
                 f(x) = x;
-                f.realize(100);
+                f.realize({100});
             }
         });
     }

--- a/test/correctness/tracing.cpp
+++ b/test/correctness/tracing.cpp
@@ -197,7 +197,7 @@ int main(int argc, char **argv) {
     f.set_custom_trace(&my_trace);
 
     // Check that Target::TracePipeline works.
-    f.realize(10, get_jit_target_from_environment().with_feature(Target::TracePipeline));
+    f.realize({10}, get_jit_target_from_environment().with_feature(Target::TracePipeline));
 
     // The golden trace, recorded when this test was written
     event correct_pipeline_trace[] = {
@@ -222,7 +222,7 @@ int main(int argc, char **argv) {
 
     input.trace_loads();
 
-    f.realize(10, get_jit_target_from_environment());
+    f.realize({10}, get_jit_target_from_environment());
 
     // The golden trace, recorded when this test was written
     event correct_trace[] = {

--- a/test/correctness/tracing_broadcast.cpp
+++ b/test/correctness/tracing_broadcast.cpp
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
 
     f.trace_stores();
     f.set_custom_trace(&my_trace);
-    f.realize(8, 8);
+    f.realize({8, 8});
 
     printf("Success!\n");
 

--- a/test/correctness/tracing_stack.cpp
+++ b/test/correctness/tracing_stack.cpp
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
     h.trace_realizations();
 
     h.set_custom_trace(&my_trace);
-    h.realize(100, 100);
+    h.realize({100, 100});
 
     printf("The code should not have reached this print statement.\n");
     return -1;

--- a/test/correctness/transitive_bounds.cpp
+++ b/test/correctness/transitive_bounds.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
     // Should be ok to unroll x because it's bounded by a constant in its only consumer
     f.compute_root().unroll(x);
 
-    g.realize(4);
+    g.realize({4});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/trim_no_ops.cpp
+++ b/test/correctness/trim_no_ops.cpp
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
         }
 
         // Also check the output is correct
-        Buffer<int> im = f.realize(100);
+        Buffer<int> im = f.realize({100});
         for (int x = 0; x < im.width(); x++) {
             int correct = x;
             correct += (x > 10 && x < 20) ? 1 : 0;
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
         }
 
         // Also check the output is correct
-        Buffer<int> im = f.realize(100, 100);
+        Buffer<int> im = f.realize({100, 100});
         for (int y = 0; y < im.height(); y++) {
             for (int x = 0; x < im.width(); x++) {
                 int correct = x + y;
@@ -137,7 +137,7 @@ int main(int argc, char **argv) {
                 return -1;
             }
         }
-        Buffer<int> hist_result = hist.realize(256);
+        Buffer<int> hist_result = hist.realize({256});
 
         // Also check the output is correct.
         Func true_hist;
@@ -146,7 +146,7 @@ int main(int argc, char **argv) {
             true_hist(x) = 0;
             true_hist(f(r.x, r.y)) += 1;
         }
-        Buffer<int> true_hist_result = true_hist.realize(256);
+        Buffer<int> true_hist_result = true_hist.realize({256});
 
         for (int i = 0; i < 256; i++) {
             if (hist_result(i) != true_hist_result(i)) {
@@ -200,7 +200,7 @@ int main(int argc, char **argv) {
         RVar rxi, ryi;
         f.update(0).gpu_tile(r.x, r.y, rxi, ryi, 4, 4);
 
-        Buffer<int> im = f.realize(200, 200);
+        Buffer<int> im = f.realize({200, 200});
 
         // There should be no selects after trim_no_ops runs. The select should
         // be lifted out as if condition. We can't trim gpu loop r.x based on the

--- a/test/correctness/truncated_pyramid.cpp
+++ b/test/correctness/truncated_pyramid.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
     // age of the universe if anything combinatorial is going on.
     width.set(1000);
     height.set(1000);
-    pyr_up[0].realize(1000, 1000);
+    pyr_up[0].realize({1000, 1000});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/tuple_partial_update.cpp
+++ b/test/correctness/tuple_partial_update.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
         f(x, y)[1] *= 4;
         f(x, y)[1] /= 2;
 
-        Realization result = f.realize(1024, 1024);
+        Realization result = f.realize({1024, 1024});
         Buffer<int> a = result[0], b = result[1];
         for (int y = 0; y < a.height(); y++) {
             for (int x = 0; x < a.width(); x++) {
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
         f(x, y) = Tuple(x, y);
         f(x, y)[1] += select(x < 20, 20 * x, undef<int>());
 
-        Realization result = f.realize(1024, 1024);
+        Realization result = f.realize({1024, 1024});
         Buffer<int> a = result[0], b = result[1];
         for (int y = 0; y < a.height(); y++) {
             for (int x = 0; x < a.width(); x++) {

--- a/test/correctness/tuple_reduction.cpp
+++ b/test/correctness/tuple_reduction.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
             f.update().hexagon(y).vectorize(x, 32);
         }
 
-        Realization result = f.realize(1024, 1024);
+        Realization result = f.realize({1024, 1024});
 
         Buffer<int> a = result[0], b = result[1];
 
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
             }
         }
 
-        Realization result = f.realize(1024, 1024);
+        Realization result = f.realize({1024, 1024});
 
         Buffer<int> a = result[0], b = result[1];
 
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
             }
         }
 
-        Realization result = f.realize(1024, 1024);
+        Realization result = f.realize({1024, 1024});
 
         Buffer<int> a = result[0], b = result[1];
 
@@ -157,7 +157,7 @@ int main(int argc, char **argv) {
             }
         }
 
-        Realization result = f.realize(1024, 1024);
+        Realization result = f.realize({1024, 1024});
 
         Buffer<int> a = result[0], b = result[1];
 

--- a/test/correctness/tuple_select.cpp
+++ b/test/correctness/tuple_select.cpp
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
 
         f(x, y) = tuple_select(x + y < 30, Tuple(x, y), Tuple(x - 1, y - 2));
 
-        Realization result = f.realize(200, 200);
+        Realization result = f.realize({200, 200});
         Buffer<int> a = result[0], b = result[1];
         for (int y = 0; y < a.height(); y++) {
             for (int x = 0; x < a.width(); x++) {
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
 
         f(x, y) = tuple_select(Tuple(x < 30, y < 30), Tuple(x, y), Tuple(x - 1, y - 2));
 
-        Realization result = f.realize(200, 200);
+        Realization result = f.realize({200, 200});
         Buffer<int> a = result[0], b = result[1];
         for (int y = 0; y < a.height(); y++) {
             for (int x = 0; x < a.width(); x++) {
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
                                x + y < 100, Tuple(x - 1, y - 2),
                                Tuple(x - 100, y - 200));
 
-        Realization result = f.realize(200, 200);
+        Realization result = f.realize({200, 200});
         Buffer<int> a = result[0], b = result[1];
         for (int y = 0; y < a.height(); y++) {
             for (int x = 0; x < a.width(); x++) {
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
                                Tuple(x < 100, y < 100), Tuple(x - 1, y - 2),
                                Tuple(x - 100, y - 200));
 
-        Realization result = f.realize(200, 200);
+        Realization result = f.realize({200, 200});
         Buffer<int> a = result[0], b = result[1];
         for (int y = 0; y < a.height(); y++) {
             for (int x = 0; x < a.width(); x++) {

--- a/test/correctness/tuple_update_ops.cpp
+++ b/test/correctness/tuple_update_ops.cpp
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
 
         f(x, y) += Tuple(x + y);
 
-        Realization result = f.realize(1024, 1024);
+        Realization result = f.realize({1024, 1024});
         Buffer<int> a = result[0];
         for (int y = 0; y < a.height(); y++) {
             for (int x = 0; x < a.width(); x++) {
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
         f(x, y) /= Tuple(2, 2);
         f(x, y) -= Tuple(x, y);
 
-        Realization result = f.realize(1024, 1024);
+        Realization result = f.realize({1024, 1024});
         Buffer<int> a = result[0], b = result[1];
         for (int y = 0; y < a.height(); y++) {
             for (int x = 0; x < a.width(); x++) {
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
         f(x, _) = Tuple(cast<int16_t>(x), cast<int32_t>(g(_)));
         f(x, _) += Tuple(cast<int16_t>(2 * x), cast<int32_t>(x));
 
-        Realization result = f.realize(100, 100, 100);
+        Realization result = f.realize({100, 100, 100});
         Buffer<int16_t> a = result[0];
         Buffer<int32_t> b = result[1];
         for (int j = 0; j < a.channels(); j++) {
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
         f(x, y) = Tuple(x + 13, x + y);
         f(x, y) *= f(x, y);
 
-        Realization result = f.realize(1024, 1024);
+        Realization result = f.realize({1024, 1024});
         Buffer<int> a = result[0], b = result[1];
         for (int y = 0; y < a.height(); y++) {
             for (int x = 0; x < a.width(); x++) {
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
         f(x, y) += Tuple(x);
         f(x, y) *= f(x, y);
 
-        Realization result = f.realize(1024, 1024);
+        Realization result = f.realize({1024, 1024});
         Buffer<int> a = result[0];
         for (int y = 0; y < a.height(); y++) {
             for (int x = 0; x < a.width(); x++) {

--- a/test/correctness/two_vector_args.cpp
+++ b/test/correctness/two_vector_args.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
 
     f.vectorize(x, 4);
 
-    Buffer<int> out = f.realize(4, 4);
+    Buffer<int> out = f.realize({4, 4});
 
     printf("Success!\n");
 

--- a/test/correctness/undef.cpp
+++ b/test/correctness/undef.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     // Update rule
     f1(r) = f1(r - 1) + f1(r - 2);
 
-    Buffer<int> fib1 = f1.realize(102);
+    Buffer<int> fib1 = f1.realize({102});
 
     // That code needlessly set the entire buffer to zero before
     // computing fibonacci. We know for our use of fibonacci that
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
     f2(1) = 0;
     f2(r) = f2(r - 1) + f2(r - 2);
 
-    Buffer<int> fib2 = f2.realize(102);
+    Buffer<int> fib2 = f2.realize({102});
 
     int err = evaluate_may_gpu<int>(maximum(fib1(r) - fib2(r)));
     if (err > 0) {
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
         f3(rx) = Tuple(f3(rx)[0] + f3(rx)[1] + f3(left)[1] + f3(right)[1], undef<float>());
         f3(rx) = Tuple(undef<float>(), f3(rx)[1] + f3(rx)[0] + f3(left)[0] + f3(right)[0]);
     }
-    f3.realize(100);
+    f3.realize({100});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/uninitialized_read.cpp
+++ b/test/correctness/uninitialized_read.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
 
     f.trace_realizations();
     h.set_custom_trace(&my_trace);
-    h.realize(1);
+    h.realize({1});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/unique_func_image.cpp
+++ b/test/correctness/unique_func_image.cpp
@@ -19,8 +19,8 @@ int main(int argc, char **argv) {
 
     assert(ext1.name() != ext2.name() && "Programmer-specified function names have not been made unique!");
 
-    Buffer<int> out1 = ext1.realize(10);
-    Buffer<int> out2 = ext2.realize(10);
+    Buffer<int> out1 = ext1.realize({10});
+    Buffer<int> out2 = ext2.realize({10});
 
     for (int i = 0; i < 10; i++) {
         assert(out1(i) == i + 1 && "Incorrect result from call to ext1");
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
     Func out1_as_func(out1);
     Func ext3 = add2(out1_as_func);
 
-    Buffer<int> out3 = ext3.realize(10);
+    Buffer<int> out3 = ext3.realize({10});
 
     for (int i = 0; i < 10; i++) {
         assert(out3(i) == i + 3 && "Incorrect result from call to add2");

--- a/test/correctness/unroll_dynamic_loop.cpp
+++ b/test/correctness/unroll_dynamic_loop.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
     g.split(x, xo, xi, 8, TailStrategy::GuardWithIf).unroll(xi);
     f.compute_at(g, xo).unroll(x).store_in(MemoryType::Stack);
 
-    Buffer<float> result = g.realize(23);
+    Buffer<float> result = g.realize({23});
     for (int i = 0; i < 23; i++) {
         float correct = i * 2 * 3 * 2;
         if (result(i) != correct) {

--- a/test/correctness/unrolled_reduction.cpp
+++ b/test/correctness/unrolled_reduction.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
     g.compute_at(f, y).update().split(r.x, rxo, rxi, 2).unroll(rxi);
     f.unroll(z, 2);
 
-    Buffer<float> im = f.realize(64, 64, 4);
+    Buffer<float> im = f.realize({64, 64, 4});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/unsafe_promises.cpp
+++ b/test/correctness/unsafe_promises.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
         in.set(ten_bit_data);
         lut.set(ten_bit_lut);
 
-        auto result = f.realize(100);
+        auto result = f.realize({100});
     }
 
     {

--- a/test/correctness/update_chunk.cpp
+++ b/test/correctness/update_chunk.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     g(x, r) = f(r, x) + 1;
 
     f.compute_at(g, r);
-    g.realize(10, 10);
+    g.realize({10, 10});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/vector_bounds_inference.cpp
+++ b/test/correctness/vector_bounds_inference.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     h.compute_root().vectorize(x, 4);
     g.compute_root().vectorize(x, 4);
 
-    Buffer<int> out = f.realize(36, 2);
+    Buffer<int> out = f.realize({36, 2});
 
     for (int y = 0; y < 2; y++) {
         for (int x = 0; x < 36; x++) {

--- a/test/correctness/vector_cast.cpp
+++ b/test/correctness/vector_cast.cpp
@@ -69,7 +69,7 @@ bool test(int vec_width, const Target &target) {
         }
     }
 
-    Buffer<B> output = f.realize(W, H);
+    Buffer<B> output = f.realize({W, H});
 
     /*
     for (int y = 0; y < H; y++) {

--- a/test/correctness/vector_extern.cpp
+++ b/test/correctness/vector_extern.cpp
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
     f(x) = sqrt(cast<float>(x));
 
     f.vectorize(x, 4);
-    Buffer<float> im = f.realize(32);
+    Buffer<float> im = f.realize({32});
 
     for (int i = 0; i < 32; i++) {
         float correct = sqrtf((float)i);

--- a/test/correctness/vector_math.cpp
+++ b/test/correctness/vector_math.cpp
@@ -184,7 +184,7 @@ bool test(int lanes, int seed) {
         Func f1;
         f1(x, y) = input(x, y) + input(x + 1, y);
         f1.vectorize(x, lanes);
-        Buffer<A> im1 = f1.realize(W, H);
+        Buffer<A> im1 = f1.realize({W, H});
 
         for (int y = 0; y < H; y++) {
             for (int x = 0; x < W; x++) {
@@ -203,7 +203,7 @@ bool test(int lanes, int seed) {
         Func f2;
         f2(x, y) = input(x, y) - input(x + 1, y);
         f2.vectorize(x, lanes);
-        Buffer<A> im2 = f2.realize(W, H);
+        Buffer<A> im2 = f2.realize({W, H});
 
         for (int y = 0; y < H; y++) {
             for (int x = 0; x < W; x++) {
@@ -222,7 +222,7 @@ bool test(int lanes, int seed) {
         Func f3;
         f3(x, y) = input(x, y) * input(x + 1, y);
         f3.vectorize(x, lanes);
-        Buffer<A> im3 = f3.realize(W, H);
+        Buffer<A> im3 = f3.realize({W, H});
 
         for (int y = 0; y < H; y++) {
             for (int x = 0; x < W; x++) {
@@ -241,7 +241,7 @@ bool test(int lanes, int seed) {
         Func f4;
         f4(x, y) = select(input(x, y) > input(x + 1, y), input(x + 2, y), input(x + 3, y));
         f4.vectorize(x, lanes);
-        Buffer<A> im4 = f4.realize(W, H);
+        Buffer<A> im4 = f4.realize({W, H});
 
         for (int y = 0; y < H; y++) {
             for (int x = 0; x < W; x++) {
@@ -262,7 +262,7 @@ bool test(int lanes, int seed) {
         Expr yCoord = clamp(cast<int>(input(x + 1, y)), 0, H - 1);
         f5(x, y) = input(xCoord, yCoord);
         f5.vectorize(x, lanes);
-        Buffer<A> im5 = f5.realize(W, H);
+        Buffer<A> im5 = f5.realize({W, H});
 
         for (int y = 0; y < H; y++) {
             for (int x = 0; x < W; x++) {
@@ -289,7 +289,7 @@ bool test(int lanes, int seed) {
         Func f5a;
         f5a(x, y) = input(x, y) * cast<A>(2);
         f5a.vectorize(y, lanes);
-        Buffer<A> im5a = f5a.realize(W, H);
+        Buffer<A> im5a = f5a.realize({W, H});
 
         for (int y = 0; y < H; y++) {
             for (int x = 0; x < W; x++) {
@@ -312,7 +312,7 @@ bool test(int lanes, int seed) {
 
         f6.update().vectorize(x, lanes);
 
-        Buffer<int> im6 = f6.realize(W, H);
+        Buffer<int> im6 = f6.realize({W, H});
 
         for (int x = 0; x < W; x++) {
             int yCoord = x * x;
@@ -334,7 +334,7 @@ bool test(int lanes, int seed) {
         Func f7;
         f7(x, y) = clamp(input(x, y), cast<A>(10), cast<A>(20));
         f7.vectorize(x, lanes);
-        Buffer<A> im7 = f7.realize(W, H);
+        Buffer<A> im7 = f7.realize({W, H});
 
         for (int y = 0; y < H; y++) {
             for (int x = 0; x < W; x++) {
@@ -358,7 +358,7 @@ bool test(int lanes, int seed) {
         Func f8;
         f8(x, y) = hypot(1.1f, cast<float>(input(x, y)));
         f8.vectorize(x, lanes);
-        Buffer<float> im8 = f8.realize(W, H);
+        Buffer<float> im8 = f8.realize({W, H});
 
         for (int y = 0; y < H; y++) {
             for (int x = 0; x < W; x++) {
@@ -378,7 +378,7 @@ bool test(int lanes, int seed) {
         Func f9;
         f9(x, y) = input(x, y) / clamp(input(x + 1, y), cast<A>(1), cast<A>(3));
         f9.vectorize(x, lanes);
-        Buffer<A> im9 = f9.realize(W, H);
+        Buffer<A> im9 = f9.realize({W, H});
 
         for (int y = 0; y < H; y++) {
             for (int x = 0; x < W; x++) {
@@ -405,7 +405,7 @@ bool test(int lanes, int seed) {
             Func f10;
             f10(x, y) = (input(x, y)) / cast<A>(Expr(c));
             f10.vectorize(x, lanes);
-            Buffer<A> im10 = f10.realize(W, H);
+            Buffer<A> im10 = f10.realize({W, H});
 
             for (int y = 0; y < H; y++) {
                 for (int x = 0; x < W; x++) {
@@ -430,7 +430,7 @@ bool test(int lanes, int seed) {
         Func f11;
         f11(x, y) = select((x % 2) == 0, input(x / 2, y), input(x / 2, y + 1));
         f11.vectorize(x, lanes);
-        Buffer<A> im11 = f11.realize(W, H);
+        Buffer<A> im11 = f11.realize({W, H});
 
         for (int y = 0; y < H; y++) {
             for (int x = 0; x < W; x++) {
@@ -449,7 +449,7 @@ bool test(int lanes, int seed) {
         Func f12;
         f12(x, y) = input(W - 1 - x, H - 1 - y);
         f12.vectorize(x, lanes);
-        Buffer<A> im12 = f12.realize(W, H);
+        Buffer<A> im12 = f12.realize({W, H});
 
         for (int y = 0; y < H; y++) {
             for (int x = 0; x < W; x++) {
@@ -468,7 +468,7 @@ bool test(int lanes, int seed) {
         Func f13;
         f13(x, y) = input(x + 3, y);
         f13.vectorize(x, lanes);
-        Buffer<A> im13 = f13.realize(W, H);
+        Buffer<A> im13 = f13.realize({W, H});
 
         for (int y = 0; y < H; y++) {
             for (int x = 0; x < W; x++) {
@@ -486,7 +486,7 @@ bool test(int lanes, int seed) {
             if (verbose) printf("Absolute value\n");
             Func f14;
             f14(x, y) = cast<A>(abs(input(x, y)));
-            Buffer<A> im14 = f14.realize(W, H);
+            Buffer<A> im14 = f14.realize({W, H});
 
             for (int y = 0; y < H; y++) {
                 for (int x = 0; x < W; x++) {
@@ -509,8 +509,8 @@ bool test(int lanes, int seed) {
             f16(x, y) = cast<int>(input(x, y)) * input(x, y + 2) - cast<int>(input(x, y + 1)) * input(x, y + 3);
             f15.vectorize(x, lanes);
             f16.vectorize(x, lanes);
-            Buffer<int32_t> im15 = f15.realize(W, H);
-            Buffer<int32_t> im16 = f16.realize(W, H);
+            Buffer<int32_t> im15 = f15.realize({W, H});
+            Buffer<int32_t> im16 = f16.realize({W, H});
             for (int y = 0; y < H; y++) {
                 for (int x = 0; x < W; x++) {
                     int correct15 = int(input(x, y) * input(x, y + 2) + input(x, y + 1) * input(x, y + 3));
@@ -535,32 +535,32 @@ bool test(int lanes, int seed) {
         {
             Func f15;
             f15(x, y) = log(a);
-            im15 = f15.realize(W, H);
+            im15 = f15.realize({W, H});
         }
         {
             Func f16;
             f16(x, y) = exp(b);
-            im16 = f16.realize(W, H);
+            im16 = f16.realize({W, H});
         }
         {
             Func f17;
             f17(x, y) = pow(a, b / 16.0f);
-            im17 = f17.realize(W, H);
+            im17 = f17.realize({W, H});
         }
         {
             Func f18;
             f18(x, y) = fast_log(a);
-            im18 = f18.realize(W, H);
+            im18 = f18.realize({W, H});
         }
         {
             Func f19;
             f19(x, y) = fast_exp(b);
-            im19 = f19.realize(W, H);
+            im19 = f19.realize({W, H});
         }
         {
             Func f20;
             f20(x, y) = fast_pow(a, b / 16.0f);
-            im20 = f20.realize(W, H);
+            im20 = f20.realize({W, H});
         }
 
         int worst_log_mantissa = 0;
@@ -666,7 +666,7 @@ bool test(int lanes, int seed) {
             weight = cast(UInt(t.bits(), t.lanes()), max(0, weight));
         }
         f21(x, y) = lerp(input(x, y), input(x + 1, y), weight);
-        Buffer<A> im21 = f21.realize(W, H);
+        Buffer<A> im21 = f21.realize({W, H});
 
         for (int y = 0; y < H; y++) {
             for (int x = 0; x < W; x++) {
@@ -701,7 +701,7 @@ bool test(int lanes, int seed) {
         Func f22;
         f22(x, y) = absd(input(x, y), input(x + 1, y));
         f22.vectorize(x, lanes);
-        Buffer<typename with_unsigned<A>::type> im22 = f22.realize(W, H);
+        Buffer<typename with_unsigned<A>::type> im22 = f22.realize({W, H});
 
         for (int y = 0; y < H; y++) {
             for (int x = 0; x < W; x++) {

--- a/test/correctness/vector_print_bug.cpp
+++ b/test/correctness/vector_print_bug.cpp
@@ -7,7 +7,7 @@ int main(int argc, char **argv) {
     Var x;
     f(x) = print(x);
     f.vectorize(x, 4);
-    f.realize(8);
+    f.realize({8});
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/vector_tile.cpp
+++ b/test/correctness/vector_tile.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
 
         Var io, jo;
         f.tile({i, j}, {io, jo}, {i, j}, {8, 8}, {TailStrategy::RoundUp, TailStrategy::RoundUp});
-        f.realize(128, 128);
+        f.realize({128, 128});
     }
 
     {
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
 
         Var io, jo;
         f.tile({i, j}, {io, jo}, {i, j}, {8, 8});
-        f.realize(128, 128);
+        f.realize({128, 128});
     }
 
     {
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
 
         Var io, jo;
         f.update(0).tile({i, j}, {io, jo}, {i, j}, {8, 8});
-        f.realize(128, 128);
+        f.realize({128, 128});
     }
 
     printf("Success!\n");

--- a/test/correctness/vectorize_guard_with_if.cpp
+++ b/test/correctness/vectorize_guard_with_if.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
     f.set_custom_trace(&my_trace);
     f.trace_stores();
 
-    Buffer<int> result = f.realize(w);
+    Buffer<int> result = f.realize({w});
 
     if (num_vector_stores != expected_vector_stores) {
         printf("There were %d vector stores instead of %d\n",

--- a/test/correctness/vectorize_mixed_widths.cpp
+++ b/test/correctness/vectorize_mixed_widths.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     f.compute_at(g, x).split(x, xo, xi, 16).vectorize(xi, 8).unroll(xi);
     g.compute_root().vectorize(x, 16);
 
-    Buffer<int> r = g.realize(16);
+    Buffer<int> r = g.realize({16});
     for (int i = 0; i < 16; i++) {
         if (r(i) != i) {
             std::cout << "Error at " << i << ": " << r(i) << std::endl;

--- a/test/correctness/vectorize_nested.cpp
+++ b/test/correctness/vectorize_nested.cpp
@@ -17,7 +17,7 @@ int vectorize_2d_round_up() {
         .vectorize(xi)
         .vectorize(yi);
 
-    Buffer<int> result = f.realize(width, height);
+    Buffer<int> result = f.realize({width, height});
 
     auto cmp_func = [](int x, int y) {
         return 3 * x + y;
@@ -43,7 +43,7 @@ int vectorize_2d_guard_with_if() {
         .vectorize(xi)
         .vectorize(yi);
 
-    Buffer<int> result = f.realize(width, height);
+    Buffer<int> result = f.realize({width, height});
 
     auto cmp_func = [](int x, int y) {
         return 3 * x + y;
@@ -71,7 +71,7 @@ int vectorize_2d_inlined_with_update() {
         .vectorize(xi)
         .vectorize(yi);
 
-    Buffer<int> result = f.realize(width, height);
+    Buffer<int> result = f.realize({width, height});
 
     auto cmp_func = [](int x, int y) {
         return x + 2 * y + 45;
@@ -97,7 +97,7 @@ int vectorize_2d_with_inner_for() {
         .vectorize(xi)
         .vectorize(yi);
 
-    Buffer<int> result = f.realize(width, height, 3);
+    Buffer<int> result = f.realize({width, height, 3});
 
     auto cmp_func = [](int x, int y, int c) {
         return 3 * x + y + 7 * c;
@@ -122,7 +122,7 @@ int vectorize_2d_with_compute_at_vectorized() {
     g.split(x, x, xi, 8).vectorize(xi);
     f.compute_at(g, xi).vectorize(x);
 
-    Buffer<int> result = g.realize(width, height);
+    Buffer<int> result = g.realize({width, height});
 
     auto cmp_func = [](int x, int y) {
         return 6 * x + 3 + 2 * y;
@@ -150,7 +150,7 @@ int vectorize_2d_with_compute_at() {
         .vectorize(xii);
     f.compute_at(g, xii).vectorize(x);
 
-    Buffer<int> result = g.realize(width, height);
+    Buffer<int> result = g.realize({width, height});
 
     auto cmp_func = [](int x, int y) {
         return 6 * x + 3 + 2 * y;
@@ -179,7 +179,7 @@ int vectorize_all_d() {
         .vectorize(yi);
 
     f.bound(x, 0, width).bound(y, 0, height);
-    Buffer<int> result = f.realize(width, height);
+    Buffer<int> result = f.realize({width, height});
 
     auto cmp_func = [](int x, int y) {
         return 3 * x + y;

--- a/test/correctness/vectorize_varying_allocation_size.cpp
+++ b/test/correctness/vectorize_varying_allocation_size.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     // The region required of f is [min(x, x*x-20), max(x, x*x-20)],
     // which varies nastily with the var being vectorized.
 
-    Buffer<int> out = g.realize(100);
+    Buffer<int> out = g.realize({100});
 
     for (int i = 0; i < 4; i++) {
         int correct = i + i * i - 20;

--- a/test/correctness/vectorized_initialization.cpp
+++ b/test/correctness/vectorized_initialization.cpp
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
     f.update();
 
     g(x) = f(x);
-    Buffer<int> result = g.realize(4);
+    Buffer<int> result = g.realize({4});
 
     // The sequence generated should be:
     // -1, (-1 + 1) = 0, 0 + 2 = 2, 2 + 3 = 5, 5 + 4 = 9

--- a/test/correctness/vectorized_load_from_vectorized_allocation.cpp
+++ b/test/correctness/vectorized_load_from_vectorized_allocation.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
     g.compute_at(f, r.y);
     g.bound_extent(x, size * size);
 
-    Buffer<int> im = f.realize(size, size, size);
+    Buffer<int> im = f.realize({size, size, size});
 
     for (int z = 0; z < im.channels(); z++) {
         for (int y = 0; y < im.height(); y++) {

--- a/test/correctness/vectorized_reduction_bug.cpp
+++ b/test/correctness/vectorized_reduction_bug.cpp
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
 
         foo.vectorize(c, 4);
 
-        Buffer<int32_t> output = foo.realize(2, 2, 4);
+        Buffer<int32_t> output = foo.realize({2, 2, 4});
         for (int y = 0; y < 2; y++) {
             for (int x = 0; x < 2; x++) {
                 for (int c = 0; c < 4; c++) {
@@ -51,7 +51,7 @@ int main(int argc, char *argv[]) {
         g.update(0).vectorize(x);
 
         f.compute_root();
-        Buffer<int32_t> im = f.realize(100, 100);
+        Buffer<int32_t> im = f.realize({100, 100});
 
         for (int y = 0; y < im.height(); y++) {
             for (int x = 0; x < im.width(); x++) {

--- a/test/correctness/widening_reduction.cpp
+++ b/test/correctness/widening_reduction.cpp
@@ -49,7 +49,7 @@ int main(int arch, char **argv) {
         }
 
         // Run the pipeline and verify the results are correct.
-        Buffer<uint8_t> out = f.realize(W, H, target);
+        Buffer<uint8_t> out = f.realize({W, H}, target);
 
         for (int y = 1; y < H - 1; y++) {
             for (int x = 1; x < W - 1; x++) {
@@ -91,7 +91,7 @@ int main(int arch, char **argv) {
         }
 
         // Run the pipeline and verify the results are correct.
-        Buffer<uint8_t> out = g.realize(W, H, target);
+        Buffer<uint8_t> out = g.realize({W, H}, target);
 
         for (int y = 1; y < H - 1; y++) {
             for (int x = 1; x < W - 1; x++) {
@@ -136,7 +136,7 @@ int main(int arch, char **argv) {
         g.output_buffer().dim(1).set_min(0).set_extent(H);
 
         // Run the pipeline and verify the results are correct.
-        Buffer<uint8_t> out = g.realize(W - 2, H, target);
+        Buffer<uint8_t> out = g.realize({W - 2, H}, target);
 
         for (int y = 1; y < H - 1; y++) {
             for (int x = 0; x < W - 3; x++) {

--- a/test/error/ambiguous_inline_reductions.cpp
+++ b/test/error/ambiguous_inline_reductions.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
     // reduction domains.
     f(r1, y) += product(sum(r2, r1 + r2 + r3));
 
-    Buffer<int> result = f.realize(10, 10);
+    Buffer<int> result = f.realize({10, 10});
 
     printf("Success!\n");
     return 0;

--- a/test/error/async_require_fail.cpp
+++ b/test/error/async_require_fail.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
     // choose values that will fail
     p1.set(1);
     p2.set(2);
-    result = g.realize(1);
+    result = g.realize({1});
 
     printf("Success!\n");
     return 0;

--- a/test/error/atomics_gpu_8_bit.cpp
+++ b/test/error/atomics_gpu_8_bit.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
         .gpu_threads(ri);
 
     // GPU doesn't support 8/16-bit atomics
-    Realization out = hist.realize(hist_size);
+    Realization out = hist.realize({hist_size});
 
     printf("Success!\n");
     return 0;

--- a/test/error/atomics_gpu_mutex.cpp
+++ b/test/error/atomics_gpu_mutex.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
     // and we don't allow GPU blocks on mutex locks since
     // it leads to deadlocks.
     // This should throw an error
-    Realization out = f.realize(img_size);
+    Realization out = f.realize({img_size});
 
     printf("Success!\n");
     return 0;

--- a/test/error/atomics_self_reference.cpp
+++ b/test/error/atomics_self_reference.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
         .parallel(r);
 
     // f references itself on the index, making the atomic illegal.
-    Realization out = f.realize(100);
+    Realization out = f.realize({100});
 
     printf("Success!\n");
     return 0;

--- a/test/error/bad_compute_at.cpp
+++ b/test/error/bad_compute_at.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
     // This makes no sense, because f is also used by g, which is computed at (h, y), which is outside of (h, x).
     f.compute_at(h, x);
 
-    h.realize(10);
+    h.realize({10});
 
     printf("Success!\n");
     return 0;

--- a/test/error/bad_compute_with.cpp
+++ b/test/error/bad_compute_with.cpp
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
     f(x, y) += 2;
     f.update(0).compute_with(f, x);
 
-    f.realize(10, 10);
+    f.realize({10, 10});
 
     printf("Success!\n");
     return 0;

--- a/test/error/bad_compute_with_invalid_specialization.cpp
+++ b/test/error/bad_compute_with_invalid_specialization.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
     g.compute_with(f.specialize(tile), y, LoopAlignStrategy::AlignEnd);
 
     tile.set(true);
-    h.realize(200, 200);
+    h.realize({200, 200});
 
     printf("Success!\n");
     return 0;

--- a/test/error/bad_compute_with_parent_func_not_used.cpp
+++ b/test/error/bad_compute_with_parent_func_not_used.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
 
     p.compute_with(f, x);
     g.compute_with(f, x);
-    h.realize(200, 200);
+    h.realize({200, 200});
 
     printf("Success!\n");
     return 0;

--- a/test/error/bad_dimensions.cpp
+++ b/test/error/bad_dimensions.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
     Buffer<uint8_t> b(10, 10, 3);
     im.set(b);
 
-    f.realize(10, 10);
+    f.realize({10, 10});
 
     printf("Success!\n");
     return 0;

--- a/test/error/bad_fold.cpp
+++ b/test/error/bad_fold.cpp
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
     g(x, y) = f(x - 1, y + 1) + f(x, y - 1);
     f.store_root().compute_at(g, y).fold_storage(y, 2);
 
-    Buffer<int> im = g.realize(100, 1000);
+    Buffer<int> im = g.realize({100, 1000});
 
     printf("Success!\n");
     return 0;

--- a/test/error/bad_host_alignment.cpp
+++ b/test/error/bad_host_alignment.cpp
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
     f.compute_root();
 
     in.set(param_buf);
-    Buffer<uint8_t> result = f.realize(10, 10);
+    Buffer<uint8_t> result = f.realize({10, 10});
 
     printf("Success!\n");
     return 0;

--- a/test/error/bad_rvar_order.cpp
+++ b/test/error/bad_rvar_order.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     // domain variables when it could change the meaning.
     f.update().reorder(r1.y, r1.x);
 
-    f.realize(10, 10);
+    f.realize({10, 10});
 
     printf("Success!\n");
     return 0;

--- a/test/error/bad_schedule.cpp
+++ b/test/error/bad_schedule.cpp
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
     // f is inlined, so this schedule is bad.
     f.vectorize(x, 4);
 
-    g.realize(10);
+    g.realize({10});
 
     printf("Success!\n");
     return 0;

--- a/test/error/bad_store_at.cpp
+++ b/test/error/bad_store_at.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
     // This makes no sense, because the compute_at level is higher than the store_at level
     f.store_at(h, y).compute_root();
 
-    h.realize(10, 10);
+    h.realize({10, 10});
 
     printf("Success!\n");
     return 0;

--- a/test/error/broken_promise.cpp
+++ b/test/error/broken_promise.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
     in.set(ten_bit_data);
     lut.set(ten_bit_lut);
 
-    auto result = f.realize(100, get_jit_target_from_environment().with_feature(Target::CheckUnsafePromises));
+    auto result = f.realize({100}, get_jit_target_from_environment().with_feature(Target::CheckUnsafePromises));
 
     printf("Success!\n");
     return 0;

--- a/test/error/clamp_out_of_range.cpp
+++ b/test/error/clamp_out_of_range.cpp
@@ -8,7 +8,7 @@ int main(int argc, char **argv) {
     Func f;
 
     f(x) = clamp(cast<int8_t>(x), 0, 255);
-    Buffer<> result = f.realize(42);
+    Buffer<> result = f.realize({42});
 
     printf("Success!\n");
     return 0;

--- a/test/error/compute_with_crossing_edges1.cpp
+++ b/test/error/compute_with_crossing_edges1.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
     f.update(1).compute_with(g, y);
 
     Pipeline p({f, g});
-    p.realize(200, 200);
+    p.realize({200, 200});
 
     printf("Success!\n");
     return 0;

--- a/test/error/compute_with_crossing_edges2.cpp
+++ b/test/error/compute_with_crossing_edges2.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
     f.update(0).compute_with(g, y);
 
     Pipeline p({f, g});
-    p.realize(200, 200);
+    p.realize({200, 200});
 
     printf("Success!\n");
     return 0;

--- a/test/error/constraint_uses_non_param.cpp
+++ b/test/error/constraint_uses_non_param.cpp
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
     // This can't possibly be a precondition
     p.add_requirement(x == 4 && f(3, 2) == 5);
 
-    p.realize(100, 100);
+    p.realize({100, 100});
 
     printf("Success!\n");
     return 0;

--- a/test/error/define_after_realize.cpp
+++ b/test/error/define_after_realize.cpp
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
 
     f(x) = x;
 
-    Buffer<int> im = f.realize(10);
+    Buffer<int> im = f.realize({10});
 
     // Now try to add an update definition to f
     f(x) += 1;

--- a/test/error/device_dirty_with_no_device_support.cpp
+++ b/test/error/device_dirty_with_no_device_support.cpp
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
     im.set_device_dirty(true);
 
     // Explicitly don't use device support
-    f.realize(128, 128, Target{"host"});
+    f.realize({128, 128}, Target{"host"});
 
     printf("Success!\n");
     return 0;

--- a/test/error/five_d_gpu_buffer.cpp
+++ b/test/error/five_d_gpu_buffer.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
     Func g;
     g(v0) = f(v0 % 2, (v0 / 2) % 2, (v0 / 4) % 2, (v0 / 8) % 2, (v0 / 16) % 2);
 
-    Buffer<int> result = g.realize(32);
+    Buffer<int> result = g.realize({32});
 
     // Delete this code once this test works.
     printf("Error: I should not have successfully compiled.\n");

--- a/test/error/init_def_should_be_all_vars.cpp
+++ b/test/error/init_def_should_be_all_vars.cpp
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
     Func f("f");
     RDom r(0, in.width(), 0, in.height());
     f(r.x, r.y) = in(r.x, r.y) + 2;
-    f.realize(in.width(), in.height());
+    f.realize({in.width(), in.height()});
 
     printf("Success!\n");
     return 0;

--- a/test/error/memoize_different_compute_store.cpp
+++ b/test/error/memoize_different_compute_store.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
     f.compute_at(g, y).memoize();
 
     val.set(23.0f);
-    Buffer<uint8_t> out = g.realize(128, 128);
+    Buffer<uint8_t> out = g.realize({128, 128});
 
     for (int32_t i = 0; i < 128; i++) {
         for (int32_t j = 0; j < 128; j++) {

--- a/test/error/memoize_redefine_eviction_key.cpp
+++ b/test/error/memoize_redefine_eviction_key.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
     f.compute_root().memoize(EvictionKey(1764));
 
     val.set(23.0f);
-    Buffer<float> out = g.realize(128, 128);
+    Buffer<float> out = g.realize({128, 128});
 
     printf("Success!\n");
     return 0;

--- a/test/error/metal_threads_too_large.cpp
+++ b/test/error/metal_threads_too_large.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
     f.gpu_blocks(y).gpu_threads(x, DeviceAPI::Metal);
 
     // 65536 is larger enough than `maxTotalThreadsPerThreadgroup`
-    Buffer<uint16_t> input = lambda(x, y, cast<uint16_t>(x + y)).realize(65536, 1);
+    Buffer<uint16_t> input = lambda(x, y, cast<uint16_t>(x + y)).realize({65536, 1});
     input.set_host_dirty();
     im.set(input);
 

--- a/test/error/null_host_field.cpp
+++ b/test/error/null_host_field.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
     f.compute_root();
 
     in.set(param_buf);
-    Buffer<uint8_t> result = f.realize(10, 10);
+    Buffer<uint8_t> result = f.realize({10, 10});
 
     // Avoid a freak-out in the destructor of param_buf.
     param_buf.raw_buffer()->device = 0;

--- a/test/error/overflow_during_constant_folding.cpp
+++ b/test/error/overflow_during_constant_folding.cpp
@@ -7,7 +7,7 @@ int main(int argc, char **argv) {
     Var x;
     f(x) = Expr(0x12345678) * Expr(0x76543210);
 
-    f.realize(10);
+    f.realize({10});
 
     printf("Success!\n");
     return 0;

--- a/test/error/reduction_bounds.cpp
+++ b/test/error/reduction_bounds.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
 
     // Use of f is unbounded in g.
 
-    g.realize(100);
+    g.realize({100});
 
     printf("Success!\n");
     return 0;

--- a/test/error/reduction_type_mismatch.cpp
+++ b/test/error/reduction_type_mismatch.cpp
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
     f(dom) += 1.0f;           // does not match the type here.
 
     // Should result in an error
-    Buffer<float> result = f.realize(50);
+    Buffer<float> result = f.realize({50});
 
     printf("Success!\n");
     return 0;

--- a/test/error/require_fail.cpp
+++ b/test/error/require_fail.cpp
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
     // choose values that will fail
     p1.set(1);
     p2.set(2);
-    result = f.realize(1);
+    result = f.realize({1});
 
     printf("Success!\n");
     return 0;

--- a/test/error/specialize_fail.cpp
+++ b/test/error/specialize_fail.cpp
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
     f.specialize_fail("Expected failure");
 
     p.set(42);  // arbitrary nonzero value
-    f.realize(100);
+    f.realize({100});
 
     printf("Success!\n");
     return 0;

--- a/test/error/split_inner_wrong_tail_strategy.cpp
+++ b/test/error/split_inner_wrong_tail_strategy.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
 
     Func g;
     g(x) = f(x);
-    g.realize(10);
+    g.realize({10});
 
     printf("Success!\n");
     return 0;

--- a/test/error/thread_id_outside_block_id.cpp
+++ b/test/error/thread_id_outside_block_id.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
     f.gpu_tile(x, xo, xi, 16).reorder(xo, xi);
 
     f.compile_jit(t);
-    Buffer<int> result = f.realize(16);
+    Buffer<int> result = f.realize({16});
 
     printf("Success!\n");
     return 0;

--- a/test/error/too_many_args.cpp
+++ b/test/error/too_many_args.cpp
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
     bad_call(x, y) = one_arg(x, y);  // Called with two
 
     // Should result in an error
-    Buffer<uint32_t> result = bad_call.realize(256, 256);
+    Buffer<uint32_t> result = bad_call.realize({256, 256});
 
     printf("Success!\n");
     return 0;

--- a/test/error/tuple_arg_select_undef.cpp
+++ b/test/error/tuple_arg_select_undef.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
     // Different predicates for the undefs: should result in an error
     f(arg_0, arg_1) = {f(arg_0, arg_1)[0] + 10, f(arg_0, arg_1)[1] + 5};
 
-    f.realize(100, 100);
+    f.realize({100, 100});
 
     printf("Success!\n");
     return 0;

--- a/test/error/tuple_val_select_undef.cpp
+++ b/test/error/tuple_val_select_undef.cpp
@@ -10,7 +10,7 @@ int main(int argc, char **argv) {
 
     // Should result in an error
     f(x) = {x, select(x < 20, 20 * x, undef<int>())};
-    f.realize(10);
+    f.realize({10});
 
     printf("Success!\n");
     return 0;

--- a/test/error/undefined_func_realize.cpp
+++ b/test/error/undefined_func_realize.cpp
@@ -8,7 +8,7 @@ using namespace Halide;
 int main(int argc, char **argv) {
     Func f("f");
 
-    Buffer<int32_t> result = f.realize(100, 5, 3);
+    Buffer<int32_t> result = f.realize({100, 5, 3});
 
     // We shouldn't reach here, because there should have been a compile error.
     printf("Success!\n");

--- a/test/error/undefined_loop_level.cpp
+++ b/test/error/undefined_loop_level.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
     g.compute_root();
 
     // Trying to lower/realize with an undefined LoopLevel should be fatal
-    Buffer<int> result = g.realize(1);
+    Buffer<int> result = g.realize({1});
 
     printf("Success!\n");
     return 0;

--- a/test/error/undefined_pipeline_realize.cpp
+++ b/test/error/undefined_pipeline_realize.cpp
@@ -8,7 +8,7 @@ int main(int argc, char **argv) {
     Func f("f");
 
     Pipeline p(f);
-    Buffer<int32_t> result = p.realize(100, 5, 3);
+    Buffer<int32_t> result = p.realize({100, 5, 3});
 
     // We shouldn't reach here, because there should have been a compile error.
     printf("Success!\n");

--- a/test/error/undefined_rdom_dimension.cpp
+++ b/test/error/undefined_rdom_dimension.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
     f(r.x, r.y, c) = f(r.x - 1, r.y, c) + h(r.x, r.y, c);
 
     f.set_error_handler(&halide_error);
-    Buffer<int32_t> result = f.realize(100, 5, 3);
+    Buffer<int32_t> result = f.realize({100, 5, 3});
 
     assert(error_occurred);
 

--- a/test/error/vectorize_dynamic.cpp
+++ b/test/error/vectorize_dynamic.cpp
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
 
     // Should result in an error
     vector_size.set(4);
-    Buffer<int> out = f.realize(5, 5);
+    Buffer<int> out = f.realize({5, 5});
 
     printf("Success!\n");
     return 0;

--- a/test/error/vectorize_too_little.cpp
+++ b/test/error/vectorize_too_little.cpp
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
     f.vectorize(x, 0);
 
     // Should result in an error
-    Buffer<int> out = f.realize(5, 5);
+    Buffer<int> out = f.realize({5, 5});
 
     printf("Success!\n");
     return 0;

--- a/test/error/vectorize_too_much.cpp
+++ b/test/error/vectorize_too_much.cpp
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
     f.vectorize(x, 8).vectorize(y, 8);
 
     // Should result in an error
-    Buffer<int> out = f.realize(5, 5);
+    Buffer<int> out = f.realize({5, 5});
 
     printf("Success!\n");
     return 0;

--- a/test/error/wrapper_never_used.cpp
+++ b/test/error/wrapper_never_used.cpp
@@ -15,7 +15,7 @@ int main() {
 
     // This should cause an error since f.in(g) was called but 'f' is
     // never used in 'g'.
-    h.realize(5, 5);
+    h.realize({5, 5});
 
     printf("Success!\n");
     return 0;

--- a/test/error/wrong_type.cpp
+++ b/test/error/wrong_type.cpp
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
     Func f;
     Var x;
     f(x) = x;
-    Buffer<float> im = f.realize(100);
+    Buffer<float> im = f.realize({100});
 
     printf("Success!\n");
     return 0;

--- a/test/failing_with_issue/3292_async_specialize.cpp
+++ b/test/failing_with_issue/3292_async_specialize.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
 
         g.set_custom_allocator(my_malloc, my_free);
 
-        Buffer<int> im = g.realize(100, 1000);
+        Buffer<int> im = g.realize({100, 1000});
 
         size_t expected_size = 101 * 3 * sizeof(int) + sizeof(int);
         if (custom_malloc_size == 0 || custom_malloc_size != expected_size) {

--- a/test/failing_with_issue/3293_storage_folding_async.cpp
+++ b/test/failing_with_issue/3293_storage_folding_async.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
 
         h.set_custom_allocator(my_malloc, my_free);
 
-        Buffer<int> im = h.realize(100, 1000);
+        Buffer<int> im = h.realize({100, 1000});
 
         size_t expected_size = 101 * 3 * sizeof(int) + sizeof(int);
         if (custom_malloc_size == 0 || custom_malloc_size != expected_size) {

--- a/test/failing_with_issue/3357_vectorize_pred.cpp
+++ b/test/failing_with_issue/3357_vectorize_pred.cpp
@@ -60,8 +60,8 @@ bool test(int vec_width) {
     g(r.x, r.y) = e;
     f.update(0).vectorize(r.x);
 
-    Buffer<A> outputg = g.realize(W, H);
-    Buffer<A> outputf = f.realize(W, H);
+    Buffer<A> outputg = g.realize({W, H});
+    Buffer<A> outputf = f.realize({W, H});
 
     double t_g = benchmark([&]() {
         g.realize(outputg);

--- a/test/failing_with_issue/4283_store_at_gpu.cpp
+++ b/test/failing_with_issue/4283_store_at_gpu.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[]) {
 
     // Run 100 times to make sure race condition do happen
     for (int iter = 0; iter < 100; iter++) {
-        Buffer<T> out = final.realize(10, 10);
+        Buffer<T> out = final.realize({10, 10});
         for (int i = 0; i < 10; i++) {
             for (int j = 0; j < 10; j++) {
                 check(__LINE__, out(i, j), correct_final(i, j));

--- a/test/generator/configure_jittest.cpp
+++ b/test/generator/configure_jittest.cpp
@@ -52,9 +52,9 @@ int main(int argc, char **argv) {
                                                    func_extra,
                                                    extra_scalar});
 
-    Buffer<int32_t> output = result.output.realize(kSize, kSize, 3);
-    Buffer<float> extra_buffer_output = result.extra_buffer_output.realize(kSize, kSize, 3);
-    Buffer<double> extra_func_output = result.extra_func_output.realize(kSize, kSize);
+    Buffer<int32_t> output = result.output.realize({kSize, kSize, 3});
+    Buffer<float> extra_buffer_output = result.extra_buffer_output.realize({kSize, kSize, 3});
+    Buffer<double> extra_func_output = result.extra_func_output.realize({kSize, kSize});
 
     output.for_each_element([&](int x, int y, int c) {
         assert(output(x, y, c) == input(x, y, c) + bias + extra_value);

--- a/test/generator/example_jittest.cpp
+++ b/test/generator/example_jittest.cpp
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
         // The Generator's Input<>s are specified via a struct that is initialized
         // via an {initializer-list}, in the order the Input<>s are declared in the Generator.
         Func f = example::generate(context, {runtime_factor});
-        Buffer<int32_t> img = f.realize(kSize, kSize, 3);
+        Buffer<int32_t> img = f.realize({kSize, kSize, 3});
         verify(img, 1.f, runtime_factor, 3);
     }
 
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
         inputs.runtime_factor = runtime_factor;
 
         Func f = example::generate(context, inputs);
-        Buffer<int32_t> img = f.realize(kSize, kSize, 3);
+        Buffer<int32_t> img = f.realize({kSize, kSize, 3});
         verify(img, 1.f, runtime_factor, 3);
     }
 
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
         gp.compiletime_factor = 2.5f;
 
         Func f = example::generate(context, {runtime_factor}, gp);
-        Buffer<int32_t> img = f.realize(kSize, kSize, 3);
+        Buffer<int32_t> img = f.realize({kSize, kSize, 3});
         verify(img, gp.compiletime_factor, runtime_factor, 3);
     }
 
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
         // In this case, we'll save it to a temporary to make the typing explicit.
         example::Outputs result = example::generate(context, {runtime_factor});
 
-        Buffer<int32_t> img = result.realize(kSize, kSize, 3);
+        Buffer<int32_t> img = result.realize({kSize, kSize, 3});
         verify(img, 1.f, runtime_factor, 3);
     }
 

--- a/test/generator/stubtest_jittest.cpp
+++ b/test/generator/stubtest_jittest.cpp
@@ -77,36 +77,36 @@ int main(int argc, char **argv) {
 
     gp.intermediate_level.set(LoopLevel(gen.tuple_output, gen.tuple_output.args().at(1)));
 
-    Realization simple_output_realized = gen.simple_output.realize(kSize, kSize, 3);
+    Realization simple_output_realized = gen.simple_output.realize({kSize, kSize, 3});
     Buffer<float> s0 = simple_output_realized;
     verify(array_input[0], 1.f, 0, s0);
 
-    Realization tuple_output_realized = gen.tuple_output.realize(kSize, kSize, 3);
+    Realization tuple_output_realized = gen.tuple_output.realize({kSize, kSize, 3});
     Buffer<float> f0 = tuple_output_realized[0];
     Buffer<float> f1 = tuple_output_realized[1];
     verify(array_input[0], 1.25f, 0, f0);
     verify(array_input[0], 1.25f, 33, f1);
 
     for (int i = 0; i < kArrayCount; ++i) {
-        Realization array_output_realized = gen.array_output[i].realize(kSize, kSize, gen.target);
+        Realization array_output_realized = gen.array_output[i].realize({kSize, kSize}, gen.target);
         Buffer<int16_t> g0 = array_output_realized;
         verify(array_input[i], 1.0f, int_args[i], g0);
     }
 
-    Realization typed_buffer_output_realized = gen.typed_buffer_output.realize(kSize, kSize, 3);
+    Realization typed_buffer_output_realized = gen.typed_buffer_output.realize({kSize, kSize, 3});
     Buffer<float> b0 = typed_buffer_output_realized;
     verify(buffer_input, 1.f, 0, b0);
 
-    Realization untyped_buffer_output_realized = gen.untyped_buffer_output.realize(kSize, kSize, 3);
+    Realization untyped_buffer_output_realized = gen.untyped_buffer_output.realize({kSize, kSize, 3});
     Buffer<float> b1 = untyped_buffer_output_realized;
     verify(buffer_input, 1.f, 0, b1);
 
-    Realization static_compiled_buffer_output_realized = gen.static_compiled_buffer_output.realize(kSize, kSize, 3);
+    Realization static_compiled_buffer_output_realized = gen.static_compiled_buffer_output.realize({kSize, kSize, 3});
     Buffer<uint8_t> b2 = static_compiled_buffer_output_realized;
     verify(buffer_input, 1.f, 42, b2);
 
     for (int i = 0; i < 2; ++i) {
-        Realization array_buffer_output_realized = gen.array_buffer_output[i].realize(kSize, kSize, 3);
+        Realization array_buffer_output_realized = gen.array_buffer_output[i].realize({kSize, kSize, 3});
         Buffer<uint8_t> b2 = array_buffer_output_realized;
         verify(buffer_input, 1.f, 1 + i, b2);
     }

--- a/test/performance/const_division.cpp
+++ b/test/performance/const_division.cpp
@@ -75,13 +75,13 @@ bool test(int w, bool div) {
     g.compile_jit();
     h.compile_jit();
 
-    Buffer<T> correct = g.realize(input.width(), num_vals);
+    Buffer<T> correct = g.realize({input.width(), num_vals});
     double t_correct = benchmark([&]() { g.realize(correct); });
 
-    Buffer<T> fast = f.realize(input.width(), num_vals);
+    Buffer<T> fast = f.realize({input.width(), num_vals});
     double t_fast = benchmark([&]() { f.realize(fast); });
 
-    Buffer<T> fast_dynamic = h.realize(input.width(), num_vals);
+    Buffer<T> fast_dynamic = h.realize({input.width(), num_vals});
     double t_fast_dynamic = benchmark([&]() { h.realize(fast_dynamic); });
 
     printf("%6.3f                  %6.3f\n", t_correct / t_fast, t_correct / t_fast_dynamic);

--- a/test/performance/fast_sine_cosine.cpp
+++ b/test/performance/fast_sine_cosine.cpp
@@ -28,10 +28,10 @@ int main(int argc, char **argv) {
     sin_ref.vectorize(x, 8);
     cos_ref.vectorize(x, 8);
 
-    double t1 = 1e6 * benchmark([&]() { sin_f.realize(1000); });
-    double t2 = 1e6 * benchmark([&]() { cos_f.realize(1000); });
-    double t3 = 1e6 * benchmark([&]() { sin_ref.realize(1000); });
-    double t4 = 1e6 * benchmark([&]() { cos_ref.realize(1000); });
+    double t1 = 1e6 * benchmark([&]() { sin_f.realize({1000}); });
+    double t2 = 1e6 * benchmark([&]() { cos_f.realize({1000}); });
+    double t3 = 1e6 * benchmark([&]() { sin_ref.realize({1000}); });
+    double t4 = 1e6 * benchmark([&]() { cos_ref.realize({1000}); });
 
     printf("sin: %f ns per pixel\n"
            "fast_sine: %f ns per pixel\n"

--- a/test/performance/inner_loop_parallel.cpp
+++ b/test/performance/inner_loop_parallel.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
         p.compile_jit();
         // Start the thread pool without giving any hints as to the
         // number of tasks we'll be using.
-        p.realize(t, 1);
+        p.realize({t, 1});
         double min_time = benchmark([&]() { return p.realize({2, 1000000}); });
 
         printf("%d: %f ms\n", t, min_time * 1e3);

--- a/test/performance/inner_loop_parallel.cpp
+++ b/test/performance/inner_loop_parallel.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
         // Start the thread pool without giving any hints as to the
         // number of tasks we'll be using.
         p.realize(t, 1);
-        double min_time = benchmark([&]() { return p.realize(2, 1000000); });
+        double min_time = benchmark([&]() { return p.realize({2, 1000000}); });
 
         printf("%d: %f ms\n", t, min_time * 1e3);
         if (t == 2) {

--- a/test/performance/memory_profiler.cpp
+++ b/test/performance/memory_profiler.cpp
@@ -165,7 +165,7 @@ int main(int argc, char **argv) {
         f3.set_custom_print(&my_print);
 
         reset_stats();
-        f3.realize(1000, 1000, t);
+        f3.realize({1000, 1000}, t);
         if (check_error(0, 0, 0, 0) != 0) {
             return -1;
         }
@@ -182,7 +182,7 @@ int main(int argc, char **argv) {
         f3.set_custom_print(&my_print);
 
         reset_stats();
-        f3.realize(1000, 1000, t);
+        f3.realize({1000, 1000}, t);
         if (check_error(0, 0, 0, 0) != 0) {
             return -1;
         }

--- a/test/performance/memory_profiler.cpp
+++ b/test/performance/memory_profiler.cpp
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
         f1.set_custom_print(&my_print);
 
         reset_stats();
-        f1.realize(size_x, size_y, t);
+        f1.realize({size_x, size_y}, t);
         int stack_size = size_x * size_y * sizeof(int);
         if (check_error(0, 0, 0, stack_size) != 0) {
             return -1;
@@ -147,7 +147,7 @@ int main(int argc, char **argv) {
         f2.set_custom_print(&my_print);
 
         reset_stats();
-        f2.realize(size_x, size_y, t);
+        f2.realize({size_x, size_y}, t);
         int total = (size_x + 1) * (size_y + 1) * sizeof(int);
         if (check_error(total, 1, total, 0) != 0) {
             return -1;
@@ -213,7 +213,7 @@ int main(int argc, char **argv) {
         reset_stats();
         toggle1.set(true);
         toggle2.set(true);
-        f6.realize(size_x, t);
+        f6.realize({size_x}, t);
         total = size_x * sizeof(float);
         if (check_error(total, 1, total, 0) != 0) {
             return -1;
@@ -222,7 +222,7 @@ int main(int argc, char **argv) {
         reset_stats();
         toggle1.set(true);
         toggle2.set(false);
-        f6.realize(size_x, t);
+        f6.realize({size_x}, t);
         total = size_x * sizeof(float);
         if (check_error(total, 1, total, 0) != 0) {
             return -1;
@@ -231,7 +231,7 @@ int main(int argc, char **argv) {
         reset_stats();
         toggle1.set(false);
         toggle2.set(true);
-        f6.realize(size_x, t);
+        f6.realize({size_x}, t);
         total = size_x * sizeof(float);
         if (check_error(total, 1, total, 0) != 0) {
             return -1;
@@ -240,7 +240,7 @@ int main(int argc, char **argv) {
         reset_stats();
         toggle1.set(false);
         toggle2.set(false);
-        f6.realize(size_x, t);
+        f6.realize({size_x}, t);
         if (check_error(0, 0, 0, 0) != 0) {
             return -1;
         }
@@ -262,7 +262,7 @@ int main(int argc, char **argv) {
         f8.set_custom_print(&my_print);
 
         reset_stats();
-        f8.realize(size_x, size_y, t);
+        f8.realize({size_x, size_y}, t);
         int peak = size_x * sizeof(int);
         int total = size_x * size_y * sizeof(int);
         if (check_error(peak, size_y, total / size_y, 0) != 0) {
@@ -288,7 +288,7 @@ int main(int argc, char **argv) {
         f10.set_custom_print(&my_print);
 
         reset_stats();
-        f10.realize(size_x, size_y, t);
+        f10.realize({size_x, size_y}, t);
         int min_heap_peak = size_x * sizeof(int);
         int total = size_x * size_y * sizeof(int);
         if (check_error_parallel(min_heap_peak, total, size_y, total / size_y, 0) != 0) {
@@ -309,7 +309,7 @@ int main(int argc, char **argv) {
         f11.set_custom_print(&my_print);
 
         reset_stats();
-        f11.realize(size_x, size_y, t);
+        f11.realize({size_x, size_y}, t);
         int total = size_x * size_y * sizeof(int);
         if (check_error(total, 1, total, 0) != 0) {
             return -1;
@@ -330,7 +330,7 @@ int main(int argc, char **argv) {
         f12.set_custom_print(&my_print);
 
         reset_stats();
-        f12.realize(size_x, size_y, t);
+        f12.realize({size_x, size_y}, t);
         int stack_size = size_x * size_y * sizeof(int);
         if (check_error(0, 0, 0, stack_size) != 0) {
             return -1;

--- a/test/performance/parallel_performance.cpp
+++ b/test/performance/parallel_performance.cpp
@@ -27,12 +27,12 @@ int main(int argc, char **argv) {
 
     f.parallel(y);
 
-    Buffer<float> imf = f.realize(W, H);
+    Buffer<float> imf = f.realize({W, H});
 
     double parallelTime = benchmark([&]() { f.realize(imf); });
 
     printf("Realizing g\n");
-    Buffer<float> img = g.realize(W, H);
+    Buffer<float> img = g.realize({W, H});
     printf("Done realizing g\n");
 
     double serialTime = benchmark([&]() { g.realize(img); });

--- a/test/performance/profiler.cpp
+++ b/test/performance/profiler.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
     }
 
     Target t = get_jit_target_from_environment().with_feature(Target::Profile);
-    Buffer<float> im = out.realize(10, 1000, t);
+    Buffer<float> im = out.realize({10, 1000}, t);
 
     //out.compile_to_assembly("/dev/stdout", {}, t.with_feature(Target::JIT));
 

--- a/test/performance/rfactor.cpp
+++ b/test/performance/rfactor.cpp
@@ -100,8 +100,8 @@ int two_d_histogram() {
         .parallel(u);
     hist.update().vectorize(x, 8);
 
-    ref.realize(256);
-    hist.realize(256);
+    ref.realize({256});
+    hist.realize({256});
 
     Buffer<int> result(256);
     double t_ref = benchmark([&]() {

--- a/test/performance/thread_safe_jit.cpp
+++ b/test/performance/thread_safe_jit.cpp
@@ -47,7 +47,7 @@ void separate_func_per_thread_executor(int index) {
     test.p.set(index);
     test.in.set(bufs[index]);
     for (int i = 0; i < 10; i++) {
-        Buffer<int32_t> result = test.f.realize(10);
+        Buffer<int32_t> result = test.f.realize({10});
         for (int j = 0; j < 10; j++) {
             int64_t left = ((j - 1) * (int64_t)bufs[index](std::min(std::max(0, j - 1), 9)) + index * 75);
             int64_t middle = (j * (int64_t)bufs[index](std::min(std::max(0, j), 9)) + index * 75);
@@ -72,7 +72,7 @@ void separate_func_per_thread() {
 
 void same_func_per_thread_executor(int index, test_func &test) {
     for (int i = 0; i < 10; i++) {
-        Buffer<int32_t> result = test.f.realize(10, get_jit_target_from_environment(),
+        Buffer<int32_t> result = test.f.realize({10}, get_jit_target_from_environment(),
                                                 {{test.p, index},
                                                  {test.in, bufs[index]}});
         for (int j = 0; j < 10; j++) {

--- a/test/performance/vectorize.cpp
+++ b/test/performance/vectorize.cpp
@@ -59,8 +59,8 @@ bool test() {
     // is small enough to fit in cache.
     g.reorder(y, x);
 
-    Buffer<A> outputg = g.realize(W, H);
-    Buffer<A> outputf = f.realize(W, H);
+    Buffer<A> outputg = g.realize({W, H});
+    Buffer<A> outputf = f.realize({W, H});
 
     double t_g = benchmark([&]() {
         g.realize(outputg);

--- a/test/warning/require_const_false.cpp
+++ b/test/warning/require_const_false.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
                    (p1 + p2) * kPrime2,
                    "The parameters should add to exactly", kPrime1, "but were", p1, p2);
     f.set_error_handler(&halide_error);
-    result = f.realize(1);
+    result = f.realize({1});
 
     return 0;
 }

--- a/test/warning/sliding_vectors.cpp
+++ b/test/warning/sliding_vectors.cpp
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
     f.store_at(g, xo)
         .compute_at(g, xi)
         .vectorize(x, 8);
-    g.realize(1024);
+    g.realize({1024});
 
     return 0;
 }

--- a/tutorial/lesson_01_basics.cpp
+++ b/tutorial/lesson_01_basics.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
     // resolution of the output image. Halide.h also provides a basic
     // templatized image type we can use. We'll make an 800 x 600
     // image.
-    Halide::Buffer<int32_t> output = gradient.realize(800, 600);
+    Halide::Buffer<int32_t> output = gradient.realize({800, 600});
 
     // Halide does type inference for you. Var objects represent
     // 32-bit integers, so the Expr object 'x + y' also represents a

--- a/tutorial/lesson_02_input_image.cpp
+++ b/tutorial/lesson_02_input_image.cpp
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
     // error at runtime telling us we're trying to read out of bounds
     // on the input image.
     Halide::Buffer<uint8_t> output =
-        brighter.realize(input.width(), input.height(), input.channels());
+        brighter.realize({input.width(), input.height(), input.channels()});
 
     // Save the output for inspection. It should look like a bright parrot.
     save_image(output, "brighter.png");

--- a/tutorial/lesson_03_debugging_1.cpp
+++ b/tutorial/lesson_03_debugging_1.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
 
     // Realize the function to produce an output image. We'll keep it
     // very small for this lesson.
-    Buffer<int> output = gradient.realize(8, 8);
+    Buffer<int> output = gradient.realize({8, 8});
 
     // That line compiled and ran the pipeline. Try running this
     // lesson with the environment variable HL_DEBUG_CODEGEN set to

--- a/tutorial/lesson_04_debugging_2.cpp
+++ b/tutorial/lesson_04_debugging_2.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
 
         // Realize the function over an 8x8 region.
         printf("Evaluating gradient\n");
-        Buffer<int> output = gradient.realize(8, 8);
+        Buffer<int> output = gradient.realize({8, 8});
 
         // This will print out all the times gradient(x, y) gets
         // evaluated.
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
         // on linux you can control it manually using the environment
         // variable HL_NUM_THREADS.
         printf("\nEvaluating parallel_gradient\n");
-        parallel_gradient.realize(8, 8);
+        parallel_gradient.realize({8, 8});
     }
 
     // Printing individual Exprs.
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
         g(x, y) = sin(x) + print(cos(y));
 
         printf("\nEvaluating sin(x) + cos(y), and just printing cos(y)\n");
-        g.realize(4, 4);
+        g.realize({4, 4});
     }
 
     // Printing additional context.
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
         f(x, y) = sin(x) + print(cos(y), "<- this is cos(", y, ") when x =", x);
 
         printf("\nEvaluating sin(x) + cos(y), and printing cos(y) with more context\n");
-        f.realize(4, 4);
+        f.realize({4, 4});
 
         // It can be useful to split expressions like the one above
         // across multiple lines to make it easier to turn on and off
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
         // e = print(e, "<- this is cos(", y, ") when x =", x);
         Func g;
         g(x, y) = sin(x) + e;
-        g.realize(4, 4);
+        g.realize({4, 4});
     }
 
     // Conditional printing
@@ -131,7 +131,7 @@ int main(int argc, char **argv) {
         e = print_when(x == 37 && y == 42, e, "<- this is cos(y) at x, y == (37, 42)");
         f(x, y) = sin(x) + e;
         printf("\nEvaluating sin(x) + cos(y), and printing cos(y) at a single pixel\n");
-        f.realize(640, 480);
+        f.realize({640, 480});
 
         // print_when can also be used to check for values you're not expecting:
         Func g;
@@ -139,7 +139,7 @@ int main(int argc, char **argv) {
         e = print_when(e < 0, e, "cos(y) < 0 at y ==", y);
         g(x, y) = sin(x) + e;
         printf("\nEvaluating sin(x) + cos(y), and printing whenever cos(y) < 0\n");
-        g.realize(4, 4);
+        g.realize({4, 4});
     }
 
     // Printing expressions at compile-time.

--- a/tutorial/lesson_05_scheduling_1.cpp
+++ b/tutorial/lesson_05_scheduling_1.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
         // slowly. x is the column and y is the row, so this is a
         // row-major traversal.
         printf("Evaluating gradient row-major\n");
-        Buffer<int> output = gradient.realize(4, 4);
+        Buffer<int> output = gradient.realize({4, 4});
 
         // See figures/lesson_05_row_major.gif for a visualization of
         // what this did.
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
         // traversal.
 
         printf("Evaluating gradient column-major\n");
-        Buffer<int> output = gradient.realize(4, 4);
+        Buffer<int> output = gradient.realize({4, 4});
 
         // See figures/lesson_05_col_major.gif for a visualization of
         // what this did.
@@ -130,7 +130,7 @@ int main(int argc, char **argv) {
         // also added within the loops.
 
         printf("Evaluating gradient with x split into x_outer and x_inner \n");
-        Buffer<int> output = gradient.realize(4, 4);
+        Buffer<int> output = gradient.realize({4, 4});
 
         printf("Equivalent C:\n");
         for (int y = 0; y < 4; y++) {
@@ -168,7 +168,7 @@ int main(int argc, char **argv) {
         gradient.fuse(x, y, fused);
 
         printf("Evaluating gradient with x and y fused\n");
-        Buffer<int> output = gradient.realize(4, 4);
+        Buffer<int> output = gradient.realize({4, 4});
 
         printf("Equivalent C:\n");
         for (int fused = 0; fused < 4 * 4; fused++) {
@@ -208,7 +208,7 @@ int main(int argc, char **argv) {
         // gradient.tile(x, y, x_outer, y_outer, x_inner, y_inner, 4, 4);
 
         printf("Evaluating gradient in 4x4 tiles\n");
-        Buffer<int> output = gradient.realize(8, 8);
+        Buffer<int> output = gradient.realize({8, 8});
 
         // See figures/lesson_05_tiled.gif for a visualization of this
         // schedule.
@@ -267,7 +267,7 @@ int main(int argc, char **argv) {
         // This time we'll evaluate over an 8x4 box, so that we have
         // more than one vector of work per scanline.
         printf("Evaluating gradient with x_inner vectorized \n");
-        Buffer<int> output = gradient.realize(8, 4);
+        Buffer<int> output = gradient.realize({8, 4});
 
         // See figures/lesson_05_vectors.gif for a visualization.
 
@@ -320,7 +320,7 @@ int main(int argc, char **argv) {
         // gradient.unroll(x, 2);
 
         printf("Evaluating gradient unrolled by a factor of two\n");
-        Buffer<int> result = gradient.realize(4, 4);
+        Buffer<int> result = gradient.realize({4, 4});
 
         printf("Equivalent C:\n");
         for (int y = 0; y < 4; y++) {
@@ -362,7 +362,7 @@ int main(int argc, char **argv) {
         gradient.split(x, x_outer, x_inner, 3);
 
         printf("Evaluating gradient over a 7x2 box with x split by three \n");
-        Buffer<int> output = gradient.realize(7, 2);
+        Buffer<int> output = gradient.realize({7, 2});
 
         // See figures/lesson_05_split_7_by_3.gif for a visualization
         // of what happened. Note that some points get evaluated more
@@ -448,7 +448,7 @@ int main(int argc, char **argv) {
         //     .parallel(tile_index);
 
         printf("Evaluating gradient tiles in parallel\n");
-        Buffer<int> output = gradient.realize(8, 8);
+        Buffer<int> output = gradient.realize({8, 8});
 
         // The tiles should occur in arbitrary order, but within each
         // tile the pixels will be traversed in row-major order. See
@@ -509,7 +509,7 @@ int main(int argc, char **argv) {
         // If you like you can turn on tracing, but it's going to
         // produce a lot of printfs. Instead we'll compute the answer
         // both in C and Halide and see if the answers match.
-        Buffer<int> result = gradient_fast.realize(350, 250);
+        Buffer<int> result = gradient_fast.realize({350, 250});
 
         // See figures/lesson_05_fast.mp4 for a visualization.
 

--- a/tutorial/lesson_06_realizing_over_shifted_domains.cpp
+++ b/tutorial/lesson_06_realizing_over_shifted_domains.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
 
     // Previously we've realized gradient like so:
     //
-    // gradient.realize(8, 8);
+    // gradient.realize({8, 8});
     //
     // This does three things internally:
     // 1) Generates code than can evaluate gradient over an arbitrary

--- a/tutorial/lesson_07_multi_stage_pipelines.cpp
+++ b/tutorial/lesson_07_multi_stage_pipelines.cpp
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
 
         // Now let's realize it...
 
-        // Buffer<uint8_t> result = output.realize(input.width(), input.height(), 3);
+        // Buffer<uint8_t> result = output.realize({input.width(), input.height(), 3});
 
         // Except that the line above is not going to work. Uncomment
         // it to see what happens.
@@ -158,7 +158,7 @@ int main(int argc, char **argv) {
 
         // This time it's safe to evaluate the output over the same
         // domain as the input, because we have a boundary condition.
-        Buffer<uint8_t> result = output.realize(input.width(), input.height(), 3);
+        Buffer<uint8_t> result = output.realize({input.width(), input.height(), 3});
 
         // Save the result. It should look like a slightly blurry
         // parrot, but this time it will be the same size as the

--- a/tutorial/lesson_08_scheduling_2.cpp
+++ b/tutorial/lesson_08_scheduling_2.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
 
         // And evaluate it over a 4x4 box.
         printf("\nEvaluating producer-consumer pipeline with default schedule\n");
-        consumer.realize(4, 4);
+        consumer.realize({4, 4});
 
         // There were no messages about computing values of the
         // producer. This is because the default schedule fully
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
 
         // Compile and run.
         printf("\nEvaluating producer.compute_root()\n");
-        consumer.realize(4, 4);
+        consumer.realize({4, 4});
 
         // Reading the output we can see that:
         // A) There were stores to producer.
@@ -209,7 +209,7 @@ int main(int argc, char **argv) {
 
         // Compile and run.
         printf("\nEvaluating producer.compute_at(consumer, y)\n");
-        consumer.realize(4, 4);
+        consumer.realize({4, 4});
 
         // See figures/lesson_08_compute_y.gif for a visualization.
 
@@ -285,7 +285,7 @@ int main(int argc, char **argv) {
         consumer.trace_stores();
 
         printf("\nEvaluating producer.store_root().compute_at(consumer, y)\n");
-        consumer.realize(4, 4);
+        consumer.realize({4, 4});
 
         // See figures/lesson_08_store_root_compute_y.gif for a
         // visualization.
@@ -395,7 +395,7 @@ int main(int argc, char **argv) {
         consumer.trace_stores();
 
         printf("\nEvaluating producer.store_root().compute_at(consumer, x)\n");
-        consumer.realize(4, 4);
+        consumer.realize({4, 4});
 
         // See figures/lesson_08_store_root_compute_x.gif for a
         // visualization.
@@ -498,7 +498,7 @@ int main(int argc, char **argv) {
         printf("\nEvaluating:\n"
                "consumer.tile(x, y, x_outer, y_outer, x_inner, y_inner, 4, 4);\n"
                "producer.compute_at(consumer, x_outer);\n");
-        consumer.realize(8, 8);
+        consumer.realize({8, 8});
 
         // See figures/lesson_08_tile.gif for a visualization.
 
@@ -586,7 +586,7 @@ int main(int argc, char **argv) {
         // consumer.trace_stores();
         // producer.trace_stores();
 
-        Buffer<float> halide_result = consumer.realize(160, 160);
+        Buffer<float> halide_result = consumer.realize({160, 160});
 
         // See figures/lesson_08_mixed.mp4 for a visualization.
 

--- a/tutorial/lesson_09_update_definitions.cpp
+++ b/tutorial/lesson_09_update_definitions.cpp
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
         // We'll realize this one just to make sure it compiles. The
         // second-to-last definition forces us to realize over a
         // domain that is taller than it is wide.
-        f.realize(100, 101);
+        f.realize({100, 101});
 
         // For each realization of f, each step runs in its entirety
         // before the next one begins. Let's trace the loads and
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
         g.trace_loads();
         g.trace_stores();
 
-        g.realize(4, 4);
+        g.realize({4, 4});
 
         // See figures/lesson_09_update.gif for a visualization.
 
@@ -151,7 +151,7 @@ int main(int argc, char **argv) {
         // domain" and using it inside an update definition:
         RDom r(0, 50);
         f(x, r) = f(x, r) * f(x, r);
-        Buffer<float> halide_result = f.realize(100, 100);
+        Buffer<float> halide_result = f.realize({100, 100});
 
         // See figures/lesson_09_update_rdom.mp4 for a visualization.
 
@@ -205,7 +205,7 @@ int main(int argc, char **argv) {
         // input image at that point.
         histogram(input(r.x, r.y)) += 1;
 
-        Buffer<int> halide_result = histogram.realize(256);
+        Buffer<int> halide_result = histogram.realize({256});
 
         // The equivalent C is:
         int c_result[256];
@@ -263,7 +263,7 @@ int main(int argc, char **argv) {
         Var yo, yi;
         f.update(1).split(y, yo, yi, 4).parallel(yo);
 
-        Buffer<int> halide_result = f.realize(16, 16);
+        Buffer<int> halide_result = f.realize({16, 16});
 
         // See figures/lesson_09_update_schedule.mp4 for a visualization.
 
@@ -324,7 +324,7 @@ int main(int argc, char **argv) {
         producer(x) = x * 2;
         producer(x) += 10;
         consumer(x) = 2 * producer(x);
-        Buffer<int> halide_result = consumer.realize(10);
+        Buffer<int> halide_result = consumer.realize({10});
 
         // See figures/lesson_09_inline_reduction.gif for a visualization.
 
@@ -383,7 +383,7 @@ int main(int argc, char **argv) {
 
         producer.compute_at(consumer, x);
 
-        Buffer<int> halide_result = consumer.realize(10);
+        Buffer<int> halide_result = consumer.realize({10});
 
         // See figures/lesson_09_compute_at_pure.gif for a visualization.
 
@@ -435,7 +435,7 @@ int main(int argc, char **argv) {
         // the Vars of a Func are shared across the pure and
         // update steps.
 
-        Buffer<int> halide_result = consumer.realize(10);
+        Buffer<int> halide_result = consumer.realize({10});
 
         // See figures/lesson_09_compute_at_update.gif for a visualization.
 
@@ -478,7 +478,7 @@ int main(int argc, char **argv) {
         // redundant work occurs.
         producer.compute_at(consumer, x);
 
-        Buffer<int> halide_result = consumer.realize(10);
+        Buffer<int> halide_result = consumer.realize({10});
 
         // See figures/lesson_09_compute_at_pure_and_update.gif for a visualization.
 
@@ -545,7 +545,7 @@ int main(int argc, char **argv) {
         producer_1.compute_at(consumer_2, x);
         producer_2.compute_at(consumer_2, y);
 
-        Buffer<int> halide_result = consumer_2.realize(10, 10);
+        Buffer<int> halide_result = consumer_2.realize({10, 10});
 
         // See figures/lesson_09_compute_at_multiple_updates.mp4 for a visualization.
 
@@ -601,7 +601,7 @@ int main(int argc, char **argv) {
 
         producer.compute_at(consumer, r);
 
-        Buffer<int> halide_result = consumer.realize(10);
+        Buffer<int> halide_result = consumer.realize({10});
 
         // See figures/lesson_09_compute_at_rvar.gif for a visualization.
 
@@ -720,8 +720,8 @@ int main(int argc, char **argv) {
         // pure function. The reduction domain has been swallowed to
         // define the inner anonymous reduction.
 
-        Buffer<int> halide_result_1 = f1.realize(10);
-        Buffer<int> halide_result_2 = f2.realize(10);
+        Buffer<int> halide_result_1 = f1.realize({10});
+        Buffer<int> halide_result_2 = f2.realize({10});
 
         // The equivalent C is:
         int c_result[10];

--- a/tutorial/lesson_09_update_definitions.cpp
+++ b/tutorial/lesson_09_update_definitions.cpp
@@ -658,7 +658,7 @@ int main(int argc, char **argv) {
         Func blurry;
         blurry(x, y) = cast<uint8_t>(local_sum(x, y) / 25);
 
-        Buffer<uint8_t> halide_result = blurry.realize(input.width(), input.height());
+        Buffer<uint8_t> halide_result = blurry.realize({input.width(), input.height()});
 
         // The default schedule will inline 'clamped' into the update
         // step of 'local_sum', because clamped only has a pure
@@ -783,7 +783,7 @@ int main(int argc, char **argv) {
         // as we need it in a circular buffer (see lesson 08).
         clamped.store_at(spread, yo).compute_at(spread, yi);
 
-        Buffer<uint8_t> halide_result = spread.realize(input.width(), input.height());
+        Buffer<uint8_t> halide_result = spread.realize({input.width(), input.height()});
 
 // The C equivalent is almost too horrible to contemplate (and
 // took me a long time to debug). This time I want to time

--- a/tutorial/lesson_12_using_the_gpu.cpp
+++ b/tutorial/lesson_12_using_the_gpu.cpp
@@ -228,7 +228,7 @@ public:
 
     void test_correctness(Buffer<uint8_t> reference_output) {
         Buffer<uint8_t> output =
-            curved.realize(input.width(), input.height(), input.channels());
+            curved.realize({input.width(), input.height(), input.channels()});
 
         // Check against the reference output.
         for (int c = 0; c < input.channels(); c++) {

--- a/tutorial/lesson_13_tuples.cpp
+++ b/tutorial/lesson_13_tuples.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
     // Buffers. We call this a Realization. It's equivalent to a
     // std::vector of Buffer objects:
     {
-        Realization r = multi_valued.realize(80, 60);
+        Realization r = multi_valued.realize({80, 60});
         assert(r.size() == 2);
         Buffer<int> im0 = r[0];
         Buffer<float> im1 = r[1];
@@ -147,7 +147,7 @@ int main(int argc, char **argv) {
         // First we create a Buffer to take the argmax over.
         Func input_func;
         input_func(x) = sin(x);
-        Buffer<float> input = input_func.realize(100);
+        Buffer<float> input = input_func.realize({100});
 
         // Then we define a 2-valued Tuple which tracks the index of
         // the maximum value and the value itself.
@@ -284,7 +284,7 @@ int main(int argc, char **argv) {
         escape(x, y) = first_escape[0];
 
         // Realize the pipeline and print the result as ascii art.
-        Buffer<int> result = escape.realize(61, 25);
+        Buffer<int> result = escape.realize({61, 25});
         const char *code = " .:-~*={}&%#@";
         for (int y = 0; y < result.height(); y++) {
             for (int x = 0; x < result.width(); x++) {

--- a/tutorial/lesson_17_predicated_rdom.cpp
+++ b/tutorial/lesson_17_predicated_rdom.cpp
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
         // After defining the predicate, we then define the update.
         circle(r.x, r.y) *= 2;
 
-        Buffer<int> halide_result = circle.realize(7, 7);
+        Buffer<int> halide_result = circle.realize({7, 7});
 
         // See figures/lesson_17_rdom_circular.mp4 for a visualization of
         // what this did.
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
         // Then define the update.
         triangle(r.x, r.y) *= 2;
 
-        Buffer<int> halide_result = triangle.realize(10, 10);
+        Buffer<int> halide_result = triangle.realize({10, 10});
 
         // See figures/lesson_17_rdom_triangular.mp4 for a
         // visualization of what this did.
@@ -172,7 +172,7 @@ int main(int argc, char **argv) {
         r2.where(f(r2.x, r2.y) < 1);
         g(r2.x, r2.y) += 17;
 
-        Buffer<int> halide_result_g = g.realize(5, 5);
+        Buffer<int> halide_result_g = g.realize({5, 5});
 
         // See figures/lesson_17_rdom_calls_in_predicate.mp4 for a
         // visualization of what this did.

--- a/tutorial/lesson_18_parallel_associative_reductions.cpp
+++ b/tutorial/lesson_18_parallel_associative_reductions.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
         histogram(input(r.x, r.y) / 32) += 1;
 
         histogram.vectorize(i, 8);
-        histogram.realize(8);
+        histogram.realize({8});
 
         // See figures/lesson_18_hist_serial.mp4 for a visualization of
         // what this does.
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
         intermediate.vectorize(i, 8);
         histogram.vectorize(i, 8);
 
-        histogram.realize(8);
+        histogram.realize({8});
 
         // See figures/lesson_18_hist_manual_par.mp4 for a visualization of
         // what this does.
@@ -156,7 +156,7 @@ int main(int argc, char **argv) {
         // can't prove the associativity of a reduction, it will throw
         // an error.
 
-        Buffer<int> halide_result = histogram.realize(8);
+        Buffer<int> halide_result = histogram.realize({8});
 
         // See figures/lesson_18_hist_rfactor_par.mp4 for a
         // visualization of what this does.
@@ -223,7 +223,7 @@ int main(int argc, char **argv) {
         intermediate.vectorize(x, 8);
         histogram.vectorize(x, 8);
 
-        Buffer<int> halide_result = histogram.realize(8);
+        Buffer<int> halide_result = histogram.realize({8});
 
         // See figures/lesson_18_hist_rfactor_vec.mp4 for a
         // visualization of what this does.
@@ -294,7 +294,7 @@ int main(int argc, char **argv) {
         intermediate.vectorize(x, 8);
         histogram.vectorize(x, 8);
 
-        Buffer<int> halide_result = histogram.realize(8);
+        Buffer<int> halide_result = histogram.realize({8});
 
         // See figures/lesson_18_hist_rfactor_tile.mp4 for a visualization of
         // what this does.

--- a/tutorial/lesson_19_wrapper_funcs.cpp
+++ b/tutorial/lesson_19_wrapper_funcs.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
         //   for x:
         //     g(x, y) = 2 * f_in_g(x, y) + 3
 
-        g.realize(5, 5);
+        g.realize({5, 5});
 
         // See figures/lesson_19_wrapper_local.mp4 for a visualization.
 
@@ -122,7 +122,7 @@ int main(int argc, char **argv) {
         //   for x:
         //     h(x, y) = 3 + g(x, y) - f_in(x, y)
 
-        h.realize(5, 5);
+        h.realize({5, 5});
 
         // See figures/lesson_19_wrapper_global.mp4 and for a
         // visualization of what this did.
@@ -161,7 +161,7 @@ int main(int argc, char **argv) {
         //   for x:
         //     h(x, y) = 3 + g(x, y) - f_in_h(x, y)
 
-        h.realize(5, 5);
+        h.realize({5, 5});
         // See figures/lesson_19_wrapper_unique.mp4 for a visualization.
     }
 
@@ -205,7 +205,7 @@ int main(int argc, char **argv) {
         // Note that calling f.in(g) a second time returns the wrapper
         // already created by the first call, it doesn't make a new one.
 
-        h.realize(8, 8);
+        h.realize({8, 8});
         // See figures/lesson_19_wrapper_vary_schedule.mp4 for a
         // visualization.
 
@@ -258,7 +258,7 @@ int main(int argc, char **argv) {
         // effect. Allocations that are only ever accessed at constant
         // indices can be promoted into registers.
 
-        g.realize(16, 16);
+        g.realize({16, 16});
         // See figures/lesson_19_transpose.mp4 for a visualization
     }
 
@@ -316,7 +316,7 @@ int main(int argc, char **argv) {
 
         img.set(input);
         blur.compile_jit(target);
-        Buffer<int> out = blur.realize(256, 256);
+        Buffer<int> out = blur.realize({256, 256});
 
         // Check the output is what we expected
         for (int y = out.top(); y <= out.bottom(); y++) {
@@ -403,7 +403,7 @@ int main(int argc, char **argv) {
         f.vectorize(x, 4);
         f.in(g).vectorize(x, 4);
 
-        g.realize(8, 8);
+        g.realize({8, 8});
         // See figures/lesson_19_group_updates.mp4 for a visualization.
     }
 

--- a/tutorial/lesson_20_cloning_funcs.cpp
+++ b/tutorial/lesson_20_cloning_funcs.cpp
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
         //   for x:
         //     h(x, y) = f(x, y) + g(x, y) + 10
 
-        h.realize(5, 5);
+        h.realize({5, 5});
 
         // The schedule directive f.clone_in(g) replaces all calls to 'f'
         // inside 'g' with a clone of 'f' and then returns that clone.
@@ -134,7 +134,7 @@ int main(int argc, char **argv) {
         //   for x:
         //     out(x, y) = f(x, y) + g(x, y) + h(x, y)
 
-        out.realize(5, 5);
+        out.realize({5, 5});
     }
 
     {


### PR DESCRIPTION
We had 5 extra variants of realize() (for 0-dim thru 4-dim cases); these are a holdover from both having a limit of 4 dimensions (ie, pre-halide_buffer_t) and also from pre-C++11 (ie, passing in initializer-lists of int was less convenient). Let's deprecate these for Halide 12 and remove them in Halide 13.

(Yes, this touches a *lot* of existing code.)