### PR TITLE
Avoid bogus "out-of-memory" error for multiple_scatter under wasm

### DIFF
--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -1349,6 +1349,8 @@ WasmModuleContents::WasmModuleContents(
 #if WITH_WABT
     user_assert(LLVM_VERSION >= 110) << "Using the WebAssembly JIT is only supported under LLVM 11+.";
 
+    user_assert(!target.has_feature(Target::WasmThreads)) << "The Halide WebAssembly JIT doesn't support wasm threads yet.";
+
     wdebug(1) << "Compiling wasm function " << fn_name << "\n";
 
     // Compile halide into wasm bytecode.

--- a/src/runtime/fake_thread_pool.cpp
+++ b/src/runtime/fake_thread_pool.cpp
@@ -90,6 +90,7 @@ struct halide_mutex_array {
 };
 
 WEAK halide_mutex_array *halide_mutex_array_create(int sz) {
+    halide_error(nullptr, "halide_mutex_array_create not implemented on this platform.");
     return nullptr;
 }
 

--- a/test/correctness/multiple_scatter.cpp
+++ b/test/correctness/multiple_scatter.cpp
@@ -5,6 +5,12 @@ using namespace Halide;
 using std::vector;
 
 int main(int argc, char **argv) {
+    const Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] multiple_scatter uses atomic(), which is not yet supported for WebAssembly JIT.\n");
+        return 0;
+    }
+
     // Implement a sorting network using update definitions that write to multiple outputs
 
     // The links in the sorting network. Sorts 8 things.


### PR DESCRIPTION
Several errors here:
- the `atomic()` schedule directive ends up calling `halide_mutex_array_create()`; for users of fake_thread_pool, this quietly returned null, leading to misleading error messages. Added an explicit error message if this implementation is called.
- The WebAssembly JIT cannot handle atomics yet (or threads in general) due to WABT limitations; added an assert to fail right away if you request compiling with `wasm_threads`.
- correctness_multiple_scatter uses the `atomic()` directive for one of its cases, so it now is a [SKIP] case for compiling with wasm.