### PR TITLE
Disable a few more wasm-simd ops in simd_op_check

### DIFF
--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1649,9 +1649,10 @@ public:
                 // to be used explicitly
 
                 // Shuffling using immediate indices
-                check("v8x16.shuffle", 16 * w, in_u8(2 * x));
-                check("v8x16.shuffle", 8 * w, in_u16(2 * x));
-                check("v8x16.shuffle", 4 * w, in_u32(2 * x));
+                // TODO(https://github.com/halide/Halide/issues/5130): NOT BEING GENERATED AT TRUNK
+                // check("v8x16.shuffle", 16 * w, in_u8(2 * x));
+                // check("v8x16.shuffle", 8 * w, in_u16(2 * x));
+                // check("v8x16.shuffle", 4 * w, in_u32(2 * x));
 
                 // Swizzling using variable indices
                 // (This fails to generate, but that's not entirely surprising -- I don't
@@ -1881,10 +1882,11 @@ public:
                 check("v128.load", 2 * w, f64_1);
 
                 // Load vector with identical lanes
-                check("v8x16.load_splat", 16 * w, in_u8(0));
-                check("v16x8.load_splat", 8 * w, in_u16(0));
-                check("v32x4.load_splat", 4 * w, in_u32(0));
-                check("v64x2.load_splat", 2 * w, in_u64(0));
+                // TODO(https://github.com/halide/Halide/issues/5130): NOT BEING GENERATED AT TRUNK
+                // check("v8x16.load_splat", 16 * w, in_u8(0));
+                // check("v16x8.load_splat", 8 * w, in_u16(0));
+                // check("v32x4.load_splat", 4 * w, in_u32(0));
+                // check("v64x2.load_splat", 2 * w, in_u64(0));
 
                 // Load and Extend
                 if (w == 1) {


### PR DESCRIPTION
Recent changes to the final wasm-simd spec means that some instructions aren't being generated (and may not even exist in the same form). Commented out for now; we need to revisit this once the LLVM backend for wasm gets closer to up-to-date with the final spec.