### PR TITLE
Avoid bogus out-of-memory error for multiple_scatter under wasm

### DIFF
--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -1349,6 +1349,8 @@ WasmModuleContents::WasmModuleContents(
 #if WITH_WABT
     user_assert(LLVM_VERSION >= 110) << "Using the WebAssembly JIT is only supported under LLVM 11+.";
 
+    user_assert(!target.has_feature(Target::WasmThreads)) << "The Halide WebAssembly JIT doesn't support wasm threads yet.";
+
     wdebug(1) << "Compiling wasm function " << fn_name << "\n";
 
     // Compile halide into wasm bytecode.


### PR DESCRIPTION
- The atomic() schedule directive ends up calling halide_mutex_array_create(); for users of fake_thread_pool, this quietly returned null, leading to misleading error messages. Instead, return a non-null (but unused pointer), and continue to have other calls ignore it, since we don't really need a mutex without threads in this case.
- Also: the WebAssembly JIT cannot handle threads due to WABT limitations; added an assert to fail right away if you request compiling with wasm_threads.
