### PR TITLE
Add ecx support for runtime X86 cpuid

### DIFF
--- a/src/runtime/x86.ll
+++ b/src/runtime/x86.ll
@@ -139,7 +139,7 @@ define weak_odr <4 x float> @fast_inverse_sqrt_f32x4(<4 x float> %x) nounwind uw
 }
 
 ; An admittedly ugly but functional version: "info" is an in-out parameter,
-; with the selector being passed as info[0] (other fields ignored on input),
+; with the selector being passed as info[0] and the ecx value as info[1] (other fields ignored on input),
 ; and info[0...3] as output. This is regrettable but solves two issues:
 ; -- A saner API can easily be written that spills to/from the stack internally,
 ; but it's not feasible to write one that is compatible across all LLVM versions we
@@ -147,7 +147,7 @@ define weak_odr <4 x float> @fast_inverse_sqrt_f32x4(<4 x float> %x) nounwind uw
 ; -- A version without stack spills tends to confuse the x86-32 code generator
 ; and cause it to fail via running out of registers.
 define weak_odr void @x86_cpuid_halide(i32* %info) nounwind uwtable {
-  call void asm sideeffect inteldialect "xchg ebx, esi\0A\09mov eax, dword ptr $$0 $0\0A\09mov ecx, 0\0A\09cpuid\0A\09mov dword ptr $$0 $0, eax\0A\09mov dword ptr $$4 $0, ebx\0A\09mov dword ptr $$8 $0, ecx\0A\09mov dword ptr $$12 $0, edx\0A\09xchg ebx, esi", "=*m,~{eax},~{ebx},~{ecx},~{edx},~{esi},~{dirflag},~{fpsr},~{flags}"(i32* %info)
+  call void asm sideeffect inteldialect "xchg ebx, esi\0A\09mov eax, dword ptr $$0 $0\0A\09mov ecx, dword ptr $$4 $0\0A\09cpuid\0A\09mov dword ptr $$0 $0, eax\0A\09mov dword ptr $$4 $0, ebx\0A\09mov dword ptr $$8 $0, ecx\0A\09mov dword ptr $$12 $0, edx\0A\09xchg ebx, esi", "=*m,~{eax},~{ebx},~{ecx},~{edx},~{esi},~{dirflag},~{fpsr},~{flags}"(i32* %info)
 
   ret void
 }

--- a/src/runtime/x86_cpu_features.cpp
+++ b/src/runtime/x86_cpu_features.cpp
@@ -9,8 +9,9 @@ extern "C" void x86_cpuid_halide(int32_t *);
 
 namespace {
 
-ALWAYS_INLINE void cpuid(int32_t fn_id, int32_t *info) {
+ALWAYS_INLINE void cpuid(int32_t *info, int32_t fn_id, int32_t extra = 0) {
     info[0] = fn_id;
+    info[1] = extra;
     x86_cpuid_halide(info);
 }
 
@@ -29,7 +30,7 @@ WEAK CpuFeatures halide_get_cpu_features() {
     features.set_known(halide_target_feature_avx512_cannonlake);
 
     int32_t info[4];
-    cpuid(1, info);
+    cpuid(info, 1);
 
     const bool have_sse41 = (info[2] & (1 << 19)) != 0;
     const bool have_avx = (info[2] & (1 << 28)) != 0;
@@ -52,7 +53,7 @@ WEAK CpuFeatures halide_get_cpu_features() {
     const bool use_64_bits = (sizeof(size_t) == 8);
     if (use_64_bits && have_avx && have_f16c && have_rdrand) {
         int info2[4];
-        cpuid(7, info2);
+        cpuid(info2, 7);
         const uint32_t avx2 = 1U << 5;
         const uint32_t avx512f = 1U << 16;
         const uint32_t avx512dq = 1U << 17;


### PR DESCRIPTION
Some newer X86 extensions require setting ecx when calling cpuid, for
example AVX512BF16 support is queried using cpuid(eax=7, ecx=1).