### PR TITLE
ScopedFile in write_debug_image needs sanity check

### DIFF
--- a/src/runtime/write_debug_image.cpp
+++ b/src/runtime/write_debug_image.cpp
@@ -113,13 +113,15 @@ struct ScopedFile {
         f = fopen(filename, mode);
     }
     ALWAYS_INLINE ~ScopedFile() {
-        fclose(f);
+        if (f) {
+            fclose(f);
+        }
     }
     ALWAYS_INLINE bool write(const void *ptr, size_t bytes) {
-        return fwrite(ptr, bytes, 1, f);
+        return f ? fwrite(ptr, bytes, 1, f) > 0 : false;
     }
     ALWAYS_INLINE bool open() const {
-        return f;
+        return f != nullptr;
     }
 };
 


### PR DESCRIPTION
Specifically, don't call fclose() on a null ptr, as that can crash.

Also added some code to avoid implicit int->bool conversions.