### PR TITLE
Update lens_blur estimates

### DIFF
--- a/apps/lens_blur/lens_blur_generator.cpp
+++ b/apps/lens_blur/lens_blur_generator.cpp
@@ -155,15 +155,15 @@ public:
         // (This can be useful in conjunction with RunGen and benchmarks as well
         // as auto-schedule, so we do it in all cases.)
         // Provide estimates on the input image
-        left_im.set_estimates({{0, 1536}, {0, 2560}, {0, 3}});
-        right_im.set_estimates({{0, 1536}, {0, 2560}, {0, 3}});
+        left_im.set_estimates({{0, 192}, {0, 320}, {0, 3}});
+        right_im.set_estimates({{0, 192}, {0, 320}, {0, 3}});
         // Provide estimates on the parameters
         slices.set_estimate(32);
         focus_depth.set_estimate(13);
         blur_radius_scale.set_estimate(0.5f);
         aperture_samples.set_estimate(32);
         // Provide estimates on the pipeline output
-        final.set_estimates({{0, 1536}, {0, 2560}, {0, 3}});
+        final.set_estimates({{0, 192}, {0, 320}, {0, 3}});
 
         /* THE SCHEDULE */
         if (auto_schedule) {


### PR DESCRIPTION
The lens_blur app uses rgb_small.png, but had estimates for a different image. This caused autoscheduling the app with adams2019 to end with:
```
Error: Output buffer final is accessed at -192, which is before the min (0) in dimension 0
```