### PR TITLE
Capture Exprs by ref in IRMatch

### DIFF
--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -2167,7 +2167,7 @@ struct IsConst {
         ty.code = halide_type_uint;
         ty.bits = 64;
         ty.lanes = 1;
-        val.u.u64 = is_const(e) ? 1 : 0;
+        val.u.u64 = ::Halide::Internal::is_const(e) ? 1 : 0;
     }
 };
 

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -2427,7 +2427,7 @@ struct IsMinValue {
         // a is almost certainly a very simple pattern (e.g. a wild), so just inline the make method.
         a.make_folded_const(val, ty, state);
         if (ty.code == halide_type_int) {
-            const uint64_t min_bits = (uint64_t)(1) << (ty.bits - 1);
+            const uint64_t min_bits = (uint64_t)(-1) << (ty.bits - 1);
             val.u.u64 = (val.u.u64 == min_bits);
         } else if (ty.code == halide_type_uint) {
             val.u.u64 = (val.u.u64 == 0);

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -207,23 +207,23 @@ struct SpecificExpr {
     constexpr static IRNodeType max_node_type = IRNodeType::Shuffle;
     constexpr static bool canonical = true;
 
-    Expr expr;
+    const BaseExprNode &expr;
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
-        return equal(*expr.get(), e);
+        return equal(expr, e);
     }
 
     HALIDE_ALWAYS_INLINE
     Expr make(MatcherState &state, halide_type_t type_hint) const {
-        return expr;
+        return Expr(&expr);
     }
 
     constexpr static bool foldable = false;
 };
 
 inline std::ostream &operator<<(std::ostream &s, const SpecificExpr &e) {
-    s << e.expr;
+    s << Expr(&e.expr);
     return s;
 }
 
@@ -604,7 +604,7 @@ IntLiteral pattern_arg(int64_t x) {
 }
 HALIDE_ALWAYS_INLINE
 SpecificExpr pattern_arg(const Expr &e) {
-    return {e};
+    return {*e.get()};
 }
 
 // Helpers to deref SpecificExprs to const BaseExprNode & rather than
@@ -620,7 +620,7 @@ HALIDE_ALWAYS_INLINE T unwrap(T t) {
 
 HALIDE_ALWAYS_INLINE
 const BaseExprNode &unwrap(const SpecificExpr &e) {
-    return *e.expr.get();
+    return e.expr;
 }
 
 inline std::ostream &operator<<(std::ostream &s, const IntLiteral &op) {
@@ -943,12 +943,12 @@ std::ostream &operator<<(std::ostream &s, const BinOp<Mod, A, B> &op) {
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator+(A a, B b) noexcept -> BinOp<Add, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+HALIDE_ALWAYS_INLINE auto operator+(A &&a, B &&b) noexcept -> BinOp<Add, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {pattern_arg(a), pattern_arg(b)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto add(A a, B b) -> decltype(IRMatcher::operator+(a, b)) {
+HALIDE_ALWAYS_INLINE auto add(A &&a, B &&b) -> decltype(IRMatcher::operator+(a, b)) {
     return IRMatcher::operator+(a, b);
 }
 
@@ -972,12 +972,12 @@ HALIDE_ALWAYS_INLINE double constant_fold_bin_op<Add>(halide_type_t &t, double a
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator-(A a, B b) noexcept -> BinOp<Sub, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+HALIDE_ALWAYS_INLINE auto operator-(A &&a, B &&b) noexcept -> BinOp<Sub, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {pattern_arg(a), pattern_arg(b)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto sub(A a, B b) -> decltype(IRMatcher::operator-(a, b)) {
+HALIDE_ALWAYS_INLINE auto sub(A &&a, B &&b) -> decltype(IRMatcher::operator-(a, b)) {
     return IRMatcher::operator-(a, b);
 }
 
@@ -1001,12 +1001,12 @@ HALIDE_ALWAYS_INLINE double constant_fold_bin_op<Sub>(halide_type_t &t, double a
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator*(A a, B b) noexcept -> BinOp<Mul, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+HALIDE_ALWAYS_INLINE auto operator*(A &&a, B &&b) noexcept -> BinOp<Mul, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {pattern_arg(a), pattern_arg(b)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto mul(A a, B b) -> decltype(IRMatcher::operator*(a, b)) {
+HALIDE_ALWAYS_INLINE auto mul(A &&a, B &&b) -> decltype(IRMatcher::operator*(a, b)) {
     return IRMatcher::operator*(a, b);
 }
 
@@ -1030,12 +1030,12 @@ HALIDE_ALWAYS_INLINE double constant_fold_bin_op<Mul>(halide_type_t &t, double a
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator/(A a, B b) noexcept -> BinOp<Div, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+HALIDE_ALWAYS_INLINE auto operator/(A &&a, B &&b) noexcept -> BinOp<Div, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {pattern_arg(a), pattern_arg(b)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto div(A a, B b) -> decltype(IRMatcher::operator/(a, b)) {
+HALIDE_ALWAYS_INLINE auto div(A &&a, B &&b) -> decltype(IRMatcher::operator/(a, b)) {
     return IRMatcher::operator/(a, b);
 }
 
@@ -1055,12 +1055,12 @@ HALIDE_ALWAYS_INLINE double constant_fold_bin_op<Div>(halide_type_t &t, double a
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator%(A a, B b) noexcept -> BinOp<Mod, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+HALIDE_ALWAYS_INLINE auto operator%(A &&a, B &&b) noexcept -> BinOp<Mod, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {pattern_arg(a), pattern_arg(b)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto mod(A a, B b) -> decltype(IRMatcher::operator%(a, b)) {
+HALIDE_ALWAYS_INLINE auto mod(A &&a, B &&b) -> decltype(IRMatcher::operator%(a, b)) {
     return IRMatcher::operator%(a, b);
 }
 
@@ -1080,7 +1080,7 @@ HALIDE_ALWAYS_INLINE double constant_fold_bin_op<Mod>(halide_type_t &t, double a
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto min(A a, B b) noexcept -> BinOp<Min, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+HALIDE_ALWAYS_INLINE auto min(A &&a, B &&b) noexcept -> BinOp<Min, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {pattern_arg(a), pattern_arg(b)};
 }
 
@@ -1100,7 +1100,7 @@ HALIDE_ALWAYS_INLINE double constant_fold_bin_op<Min>(halide_type_t &t, double a
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto max(A a, B b) noexcept -> BinOp<Max, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+HALIDE_ALWAYS_INLINE auto max(A &&a, B &&b) noexcept -> BinOp<Max, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {pattern_arg(a), pattern_arg(b)};
 }
 
@@ -1120,12 +1120,12 @@ HALIDE_ALWAYS_INLINE double constant_fold_bin_op<Max>(halide_type_t &t, double a
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator<(A a, B b) noexcept -> CmpOp<LT, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+HALIDE_ALWAYS_INLINE auto operator<(A &&a, B &&b) noexcept -> CmpOp<LT, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {pattern_arg(a), pattern_arg(b)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto lt(A a, B b) -> decltype(IRMatcher::operator<(a, b)) {
+HALIDE_ALWAYS_INLINE auto lt(A &&a, B &&b) -> decltype(IRMatcher::operator<(a, b)) {
     return IRMatcher::operator<(a, b);
 }
 
@@ -1145,12 +1145,12 @@ HALIDE_ALWAYS_INLINE uint64_t constant_fold_cmp_op<LT>(double a, double b) noexc
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator>(A a, B b) noexcept -> CmpOp<GT, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+HALIDE_ALWAYS_INLINE auto operator>(A &&a, B &&b) noexcept -> CmpOp<GT, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {pattern_arg(a), pattern_arg(b)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto gt(A a, B b) -> decltype(IRMatcher::operator>(a, b)) {
+HALIDE_ALWAYS_INLINE auto gt(A &&a, B &&b) -> decltype(IRMatcher::operator>(a, b)) {
     return IRMatcher::operator>(a, b);
 }
 
@@ -1170,12 +1170,12 @@ HALIDE_ALWAYS_INLINE uint64_t constant_fold_cmp_op<GT>(double a, double b) noexc
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator<=(A a, B b) noexcept -> CmpOp<LE, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+HALIDE_ALWAYS_INLINE auto operator<=(A &&a, B &&b) noexcept -> CmpOp<LE, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {pattern_arg(a), pattern_arg(b)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto le(A a, B b) -> decltype(IRMatcher::operator<=(a, b)) {
+HALIDE_ALWAYS_INLINE auto le(A &&a, B &&b) -> decltype(IRMatcher::operator<=(a, b)) {
     return IRMatcher::operator<=(a, b);
 }
 
@@ -1195,12 +1195,12 @@ HALIDE_ALWAYS_INLINE uint64_t constant_fold_cmp_op<LE>(double a, double b) noexc
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator>=(A a, B b) noexcept -> CmpOp<GE, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+HALIDE_ALWAYS_INLINE auto operator>=(A &&a, B &&b) noexcept -> CmpOp<GE, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {pattern_arg(a), pattern_arg(b)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto ge(A a, B b) -> decltype(IRMatcher::operator>=(a, b)) {
+HALIDE_ALWAYS_INLINE auto ge(A &&a, B &&b) -> decltype(IRMatcher::operator>=(a, b)) {
     return IRMatcher::operator>=(a, b);
 }
 
@@ -1220,12 +1220,12 @@ HALIDE_ALWAYS_INLINE uint64_t constant_fold_cmp_op<GE>(double a, double b) noexc
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator==(A a, B b) noexcept -> CmpOp<EQ, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+HALIDE_ALWAYS_INLINE auto operator==(A &&a, B &&b) noexcept -> CmpOp<EQ, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {pattern_arg(a), pattern_arg(b)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto eq(A a, B b) -> decltype(IRMatcher::operator==(a, b)) {
+HALIDE_ALWAYS_INLINE auto eq(A &&a, B &&b) -> decltype(IRMatcher::operator==(a, b)) {
     return IRMatcher::operator==(a, b);
 }
 
@@ -1245,12 +1245,12 @@ HALIDE_ALWAYS_INLINE uint64_t constant_fold_cmp_op<EQ>(double a, double b) noexc
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator!=(A a, B b) noexcept -> CmpOp<NE, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+HALIDE_ALWAYS_INLINE auto operator!=(A &&a, B &&b) noexcept -> CmpOp<NE, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {pattern_arg(a), pattern_arg(b)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto ne(A a, B b) -> decltype(IRMatcher::operator!=(a, b)) {
+HALIDE_ALWAYS_INLINE auto ne(A &&a, B &&b) -> decltype(IRMatcher::operator!=(a, b)) {
     return IRMatcher::operator!=(a, b);
 }
 
@@ -1270,12 +1270,12 @@ HALIDE_ALWAYS_INLINE uint64_t constant_fold_cmp_op<NE>(double a, double b) noexc
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator||(A a, B b) noexcept -> BinOp<Or, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+HALIDE_ALWAYS_INLINE auto operator||(A &&a, B &&b) noexcept -> BinOp<Or, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {pattern_arg(a), pattern_arg(b)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto or_op(A a, B b) -> decltype(IRMatcher::operator||(a, b)) {
+HALIDE_ALWAYS_INLINE auto or_op(A &&a, B &&b) -> decltype(IRMatcher::operator||(a, b)) {
     return IRMatcher::operator||(a, b);
 }
 
@@ -1296,12 +1296,12 @@ HALIDE_ALWAYS_INLINE double constant_fold_bin_op<Or>(halide_type_t &t, double a,
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator&&(A a, B b) noexcept -> BinOp<And, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+HALIDE_ALWAYS_INLINE auto operator&&(A &&a, B &&b) noexcept -> BinOp<And, decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {pattern_arg(a), pattern_arg(b)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto and_op(A a, B b) -> decltype(IRMatcher::operator&&(a, b)) {
+HALIDE_ALWAYS_INLINE auto and_op(A &&a, B &&b) -> decltype(IRMatcher::operator&&(a, b)) {
     return IRMatcher::operator&&(a, b);
 }
 
@@ -1466,55 +1466,55 @@ HALIDE_ALWAYS_INLINE auto intrin(Call::IntrinsicOp intrinsic_op, Args... args) n
 }
 
 template<typename A, typename B>
-auto widening_add(A a, B b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+auto widening_add(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {Call::widening_add, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
-auto widening_sub(A a, B b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+auto widening_sub(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {Call::widening_sub, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
-auto widening_mul(A a, B b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+auto widening_mul(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {Call::widening_mul, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
-auto saturating_add(A a, B b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+auto saturating_add(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {Call::saturating_add, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
-auto saturating_sub(A a, B b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+auto saturating_sub(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {Call::saturating_sub, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
-auto halving_add(A a, B b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+auto halving_add(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {Call::halving_add, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
-auto halving_sub(A a, B b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+auto halving_sub(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {Call::halving_sub, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
-auto rounding_halving_add(A a, B b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+auto rounding_halving_add(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {Call::rounding_halving_add, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
-auto rounding_halving_sub(A a, B b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+auto rounding_halving_sub(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {Call::rounding_halving_sub, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
-auto shift_left(A a, B b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+auto shift_left(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {Call::shift_left, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
-auto shift_right(A a, B b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+auto shift_right(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {Call::shift_right, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
-auto rounding_shift_left(A a, B b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+auto rounding_shift_left(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {Call::rounding_shift_left, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
-auto rounding_shift_right(A a, B b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
+auto rounding_shift_right(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {Call::rounding_shift_right, pattern_arg(a), pattern_arg(b)};
 }
 
@@ -1633,7 +1633,7 @@ std::ostream &operator<<(std::ostream &s, const SelectOp<C, T, F> &op) {
 }
 
 template<typename C, typename T, typename F>
-HALIDE_ALWAYS_INLINE auto select(C c, T t, F f) noexcept -> SelectOp<decltype(pattern_arg(c)), decltype(pattern_arg(t)), decltype(pattern_arg(f))> {
+HALIDE_ALWAYS_INLINE auto select(C &&c, T &&t, F &&f) noexcept -> SelectOp<decltype(pattern_arg(c)), decltype(pattern_arg(t)), decltype(pattern_arg(f))> {
     return {pattern_arg(c), pattern_arg(t), pattern_arg(f)};
 }
 
@@ -1766,7 +1766,7 @@ std::ostream &operator<<(std::ostream &s, const RampOp<A, B, C> &op) {
 }
 
 template<typename A, typename B, typename C>
-HALIDE_ALWAYS_INLINE auto ramp(A a, B b, C c) noexcept -> RampOp<decltype(pattern_arg(a)), decltype(pattern_arg(b)), decltype(pattern_arg(c))> {
+HALIDE_ALWAYS_INLINE auto ramp(A &&a, B &&b, C &&c) noexcept -> RampOp<decltype(pattern_arg(a)), decltype(pattern_arg(b)), decltype(pattern_arg(c))> {
     return {pattern_arg(a), pattern_arg(b), pattern_arg(c)};
 }
 
@@ -1821,27 +1821,27 @@ inline std::ostream &operator<<(std::ostream &s, const VectorReduceOp<A, B, redu
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto h_add(A a, B lanes) noexcept -> VectorReduceOp<decltype(pattern_arg(a)), decltype(pattern_arg(lanes)), VectorReduce::Add> {
+HALIDE_ALWAYS_INLINE auto h_add(A &&a, B lanes) noexcept -> VectorReduceOp<decltype(pattern_arg(a)), decltype(pattern_arg(lanes)), VectorReduce::Add> {
     return {pattern_arg(a), pattern_arg(lanes)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto h_min(A a, B lanes) noexcept -> VectorReduceOp<decltype(pattern_arg(a)), decltype(pattern_arg(lanes)), VectorReduce::Min> {
+HALIDE_ALWAYS_INLINE auto h_min(A &&a, B lanes) noexcept -> VectorReduceOp<decltype(pattern_arg(a)), decltype(pattern_arg(lanes)), VectorReduce::Min> {
     return {pattern_arg(a), pattern_arg(lanes)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto h_max(A a, B lanes) noexcept -> VectorReduceOp<decltype(pattern_arg(a)), decltype(pattern_arg(lanes)), VectorReduce::Max> {
+HALIDE_ALWAYS_INLINE auto h_max(A &&a, B lanes) noexcept -> VectorReduceOp<decltype(pattern_arg(a)), decltype(pattern_arg(lanes)), VectorReduce::Max> {
     return {pattern_arg(a), pattern_arg(lanes)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto h_and(A a, B lanes) noexcept -> VectorReduceOp<decltype(pattern_arg(a)), decltype(pattern_arg(lanes)), VectorReduce::And> {
+HALIDE_ALWAYS_INLINE auto h_and(A &&a, B lanes) noexcept -> VectorReduceOp<decltype(pattern_arg(a)), decltype(pattern_arg(lanes)), VectorReduce::And> {
     return {pattern_arg(a), pattern_arg(lanes)};
 }
 
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto h_or(A a, B lanes) noexcept -> VectorReduceOp<decltype(pattern_arg(a)), decltype(pattern_arg(lanes)), VectorReduce::Or> {
+HALIDE_ALWAYS_INLINE auto h_or(A &&a, B lanes) noexcept -> VectorReduceOp<decltype(pattern_arg(a)), decltype(pattern_arg(lanes)), VectorReduce::Or> {
     return {pattern_arg(a), pattern_arg(lanes)};
 }
 
@@ -1916,12 +1916,12 @@ std::ostream &operator<<(std::ostream &s, const NegateOp<A> &op) {
 }
 
 template<typename A>
-HALIDE_ALWAYS_INLINE auto operator-(A a) noexcept -> NegateOp<decltype(pattern_arg(a))> {
+HALIDE_ALWAYS_INLINE auto operator-(A &&a) noexcept -> NegateOp<decltype(pattern_arg(a))> {
     return {pattern_arg(a)};
 }
 
 template<typename A>
-HALIDE_ALWAYS_INLINE auto negate(A a) -> decltype(IRMatcher::operator-(a)) {
+HALIDE_ALWAYS_INLINE auto negate(A &&a) -> decltype(IRMatcher::operator-(a)) {
     return IRMatcher::operator-(a);
 }
 
@@ -1966,7 +1966,7 @@ std::ostream &operator<<(std::ostream &s, const CastOp<A> &op) {
 }
 
 template<typename A>
-HALIDE_ALWAYS_INLINE auto cast(halide_type_t t, A a) noexcept -> CastOp<decltype(pattern_arg(a))> {
+HALIDE_ALWAYS_INLINE auto cast(halide_type_t t, A &&a) noexcept -> CastOp<decltype(pattern_arg(a))> {
     return {t, pattern_arg(a)};
 }
 
@@ -2014,7 +2014,7 @@ struct Fold {
 };
 
 template<typename A>
-HALIDE_ALWAYS_INLINE auto fold(A a) noexcept -> Fold<decltype(pattern_arg(a))> {
+HALIDE_ALWAYS_INLINE auto fold(A &&a) noexcept -> Fold<decltype(pattern_arg(a))> {
     return {pattern_arg(a)};
 }
 
@@ -2050,7 +2050,7 @@ struct Overflows {
 };
 
 template<typename A>
-HALIDE_ALWAYS_INLINE auto overflows(A a) noexcept -> Overflows<decltype(pattern_arg(a))> {
+HALIDE_ALWAYS_INLINE auto overflows(A &&a) noexcept -> Overflows<decltype(pattern_arg(a))> {
     return {pattern_arg(a)};
 }
 
@@ -2125,7 +2125,7 @@ struct IsConst {
 };
 
 template<typename A>
-HALIDE_ALWAYS_INLINE auto is_const(A a) noexcept -> IsConst<decltype(pattern_arg(a))> {
+HALIDE_ALWAYS_INLINE auto is_const(A &&a) noexcept -> IsConst<decltype(pattern_arg(a))> {
     return {pattern_arg(a)};
 }
 
@@ -2162,7 +2162,7 @@ struct CanProve {
 };
 
 template<typename A, typename Prover>
-HALIDE_ALWAYS_INLINE auto can_prove(A a, Prover *p) noexcept -> CanProve<decltype(pattern_arg(a)), Prover> {
+HALIDE_ALWAYS_INLINE auto can_prove(A &&a, Prover *p) noexcept -> CanProve<decltype(pattern_arg(a)), Prover> {
     return {pattern_arg(a), p};
 }
 
@@ -2198,7 +2198,7 @@ struct IsFloat {
 };
 
 template<typename A>
-HALIDE_ALWAYS_INLINE auto is_float(A a) noexcept -> IsFloat<decltype(pattern_arg(a))> {
+HALIDE_ALWAYS_INLINE auto is_float(A &&a) noexcept -> IsFloat<decltype(pattern_arg(a))> {
     return {pattern_arg(a)};
 }
 
@@ -2235,7 +2235,7 @@ struct IsInt {
 };
 
 template<typename A>
-HALIDE_ALWAYS_INLINE auto is_int(A a, int bits = 0) noexcept -> IsInt<decltype(pattern_arg(a))> {
+HALIDE_ALWAYS_INLINE auto is_int(A &&a, int bits = 0) noexcept -> IsInt<decltype(pattern_arg(a))> {
     return {pattern_arg(a), bits};
 }
 
@@ -2276,7 +2276,7 @@ struct IsUInt {
 };
 
 template<typename A>
-HALIDE_ALWAYS_INLINE auto is_uint(A a, int bits = 0) noexcept -> IsUInt<decltype(pattern_arg(a))> {
+HALIDE_ALWAYS_INLINE auto is_uint(A &&a, int bits = 0) noexcept -> IsUInt<decltype(pattern_arg(a))> {
     return {pattern_arg(a), bits};
 }
 
@@ -2316,7 +2316,7 @@ struct IsScalar {
 };
 
 template<typename A>
-HALIDE_ALWAYS_INLINE auto is_scalar(A a) noexcept -> IsScalar<decltype(pattern_arg(a))> {
+HALIDE_ALWAYS_INLINE auto is_scalar(A &&a) noexcept -> IsScalar<decltype(pattern_arg(a))> {
     return {pattern_arg(a)};
 }
 
@@ -2498,8 +2498,8 @@ struct Rewriter {
     bool validate;
 
     HALIDE_ALWAYS_INLINE
-    Rewriter(Instance &&instance, halide_type_t ot, halide_type_t wt)
-        : instance(std::forward<Instance>(instance)), output_type(ot), wildcard_type(wt) {
+    Rewriter(Instance instance, halide_type_t ot, halide_type_t wt)
+        : instance(std::move(instance)), output_type(ot), wildcard_type(wt) {
     }
 
     template<typename After>

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -2788,6 +2788,9 @@ struct Rewriter {
  * some number of patterns and if so rewrite it into another form,
  * using its operator() method. See Simplify.cpp for a bunch of
  * example usage.
+ *
+ * Important: Any Exprs in patterns are captured by reference, not by
+ * value, so ensure they outlive the rewriter.
  */
 // @{
 template<typename Instance,

--- a/src/Simplify_Internal.h
+++ b/src/Simplify_Internal.h
@@ -113,9 +113,8 @@ public:
 #else
     HALIDE_ALWAYS_INLINE
     Expr mutate(const Expr &e, ExprInfo *b) {
-        Expr new_e = Super::dispatch(e, b);
-        internal_assert(new_e.type() == e.type()) << e << " -> " << new_e << "\n";
-        return new_e;
+        // This gets inlined into every call to mutate, so do not add any code here.
+        return Super::dispatch(e, b);
     }
 #endif
 

--- a/src/Simplify_Max.cpp
+++ b/src/Simplify_Max.cpp
@@ -61,8 +61,8 @@ Expr Simplify::visit(const Max *op, ExprInfo *bounds) {
              rewrite(max(IRMatcher::Overflow(), x), a) ||
              rewrite(max(x,IRMatcher::Overflow()), b) ||
              // Cases where one side dominates:
-             rewrite(max(x, op->type.max()), b) ||
-             rewrite(max(x, op->type.min()), x) ||
+             rewrite(max(x, c0), b, is_max_value(c0)) ||
+             rewrite(max(x, c0), x, is_min_value(c0)) ||
              rewrite(max((x/c0)*c0, x), b, c0 > 0) ||
              rewrite(max(x, (x/c0)*c0), a, c0 > 0) ||
              rewrite(max(max(x, y), x), a) ||

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -59,10 +59,10 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
             (rewrite(min(x, x), x) ||
              rewrite(min(c0, c1), fold(min(c0, c1))) ||
              rewrite(min(IRMatcher::Overflow(), x), a) ||
-             rewrite(min(x,IRMatcher::Overflow()), b) ||
+             rewrite(min(x, IRMatcher::Overflow()), b) ||
              // Cases where one side dominates:
-             rewrite(min(x, op->type.min()), b) ||
-             rewrite(min(x, op->type.max()), x) ||
+             rewrite(min(x, c0), b, is_min_value(c0)) ||
+             rewrite(min(x, c0), x, is_max_value(c0)) ||
              rewrite(min((x/c0)*c0, x), a, c0 > 0) ||
              rewrite(min(x, (x/c0)*c0), b, c0 > 0) ||
              rewrite(min(min(x, y), x), a) ||


### PR DESCRIPTION
The bulk of the time in the simplifier is simplifying already-simple expressions, and the bulk of the time there turned out to be the ref counting required to construct the IRMatcher object (which took a copy of the expressions). This PR changes it to capture  expressions by reference instead, which had large effect on lowering time (more than 2x on local laplacian!). 

Before:
```
$ time bin/host/local_laplacian.generator -g local_laplacian -e stmt -o bin/host -f local_laplacian target=host auto_schedule=false

real	0m1.698s
user	0m1.686s
sys	0m0.012s
```
After:
```
$ time bin/host/local_laplacian.generator -g local_laplacian -e stmt -o bin/host -f local_laplacian target=host auto_schedule=false

real	0m0.765s
user	0m0.749s
sys	0m0.016s
```
Some cleverness was required to stop people from passing rvalue Exprs to IRMatch constructors