### PR TITLE
Don't make new IR nodes if nothing changed when simplifying

### DIFF
--- a/src/Simplify_EQ.cpp
+++ b/src/Simplify_EQ.cpp
@@ -106,38 +106,26 @@ Expr Simplify::visit(const EQ *op, ExprInfo *bounds) {
         return mutate(rewrite.result, bounds);
     }
 
-    // Early-out if nothing changed
-    const Add *add = delta.as<Add>();
-    const Sub *sub = delta.as<Sub>();
-    if (sub &&
-        ((sub->a.same_as(op->a) &&
-          sub->b.same_as(op->b)) ||
-         (sub->a.same_as(op->b) &&
-          sub->b.same_as(op->a)))) {
-        return op;
-    } else if (add &&
-               add->a.same_as(op->a) &&
-               (op->b.as<IntImm>() ||
-                op->b.as<UIntImm>() ||
-                op->b.as<FloatImm>())) {
-        // a - b became a + c. c must be the negation of b, which
-        // can't possibly get simpler.
-        return op;
-    } else if (delta.same_as(op->a) &&
-               is_const_zero(op->b)) {
-        // We were comparing something to zero.
-        return op;
-    }
-
     if (rewrite(c0 == 0, fold(c0 == 0)) ||
         rewrite((x - y) + c0 == 0, x == y + fold(-c0)) ||
         rewrite(x + c0 == 0, x == fold(-c0)) ||
         rewrite(c0 - x == 0, x == c0) ||
-        rewrite(x - y == 0, x == y)) {
-        return rewrite.result;
+        rewrite(x - y == 0, x == y) ||
+        rewrite(x == 0, x == 0)) {
+
+        const EQ *eq = rewrite.result.as<EQ>();
+        if (eq &&
+            eq->a.same_as(op->a) &&
+            eq->b.same_as(op->b)) {
+            return op;
+        } else {
+            return rewrite.result;
+        }
     }
 
-    return delta == make_zero(op->a.type());
+    // Unreachable. That last rewrite catches everything and
+    // constructs delta == 0 for us.
+    return Expr();
 }
 
 // ne redirects to not eq

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -345,6 +345,8 @@ Stmt Simplify::visit(const Block *op) {
     Stmt rest = op->rest;
 
     if (const AssertStmt *first_assert = first.as<AssertStmt>()) {
+        bool unchanged = true;
+
         // Handle an entire sequence of asserts here to avoid a deeply
         // nested stack.  We won't be popping any knowledge until
         // after the end of this chain of asserts, so we can use a
@@ -363,6 +365,7 @@ Stmt Simplify::visit(const Block *op) {
         while ((rest_block = rest.as<Block>()) &&
                (first_assert = rest_block->first.as<AssertStmt>())) {
             first = mutate(first_assert);
+            unchanged &= first.same_as(first_assert);
             rest = rest_block->rest;
             result.push_back(first);
             if ((first_assert = first.as<AssertStmt>())) {
@@ -372,9 +375,15 @@ Stmt Simplify::visit(const Block *op) {
             }
         }
 
-        result.push_back(mutate(rest));
+        Stmt new_rest = mutate(rest);
+        unchanged &= new_rest.same_as(rest);
 
-        return Block::make(result);
+        if (unchanged) {
+            return op;
+        } else {
+            result.push_back(new_rest);
+            return Block::make(result);
+        }
 
     } else {
         rest = mutate(op->rest);


### PR DESCRIPTION
Some statements and expressions get crafted anew each time when
repeatedly resimplified. This PR fixes all the cases I could find.

No significant changes to most pipelines. Reduces total compile time by 7% on one particularly pathological example.