### PR TITLE
[HVX] Correct isa_version simd-op-check-hvx

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1839,6 +1839,9 @@ string CodeGen_Hexagon::mattrs() const {
     std::stringstream attrs;
     attrs << "+hvx-length128b";
     attrs << ",+long-calls";
+    if (target.has_feature(Target::HVX)) {
+        attrs << ",+hvxv" << isa_version;
+    }
     return attrs.str();
 }
 

--- a/src/runtime/hvx_128.ll
+++ b/src/runtime/hvx_128.ll
@@ -92,20 +92,6 @@ define weak_odr i32 @halide.hexagon.interleave.b.dup2.h(i8 %low, i8 %high) nounw
   ret i32 %r
 }
 
-define weak_odr <128 x i8> @halide.hexagon.splat.b(i8 %arg) nounwind uwtable readnone alwaysinline {
-  %dup4 = call i32 @halide.hexagon.dup4.b(i8 %arg)
-  %r_32 = tail call <32 x i32> @llvm.hexagon.V6.lvsplatw.128B(i32 %dup4)
-  %r = bitcast <32 x i32> %r_32 to <128 x i8>
-  ret <128 x i8> %r
-}
-
-define weak_odr <64 x i16> @halide.hexagon.splat.h(i16 %arg) nounwind uwtable readnone alwaysinline {
-  %dup2 = call i32 @halide.hexagon.dup2.h(i16 %arg)
-  %r_32 = tail call <32 x i32> @llvm.hexagon.V6.lvsplatw.128B(i32 %dup2)
-  %r = bitcast <32 x i32> %r_32 to <64 x i16>
-  ret <64 x i16> %r
-}
-
 ; Implement various 32 bit multiplications.
 declare <32 x i32> @llvm.hexagon.V6.vaslw.128B(<32 x i32>, i32)
 declare <32 x i32> @llvm.hexagon.V6.vaslw.acc.128B(<32 x i32>, <32 x i32>, i32)

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -54,10 +54,8 @@ public:
             isa_version = 66;
         } else if (target.has_feature(Halide::Target::HVX_v65)) {
             isa_version = 65;
-        } else if (target.has_feature(Halide::Target::HVX_v62)) {
-            isa_version = 62;
         } else {
-            isa_version = 60;
+            isa_version = 62;
         }
 
         // Verify that unaligned loads use the right instructions, and don't try to use
@@ -115,9 +113,7 @@ public:
         check("vadd(v*.uh,v*.uh):sat", hvx_width / 2, u16_sat(u32(u16_1) + u32(u16_2)));
         check("vadd(v*.h,v*.h):sat", hvx_width / 2, i16_sat(i32(i16_1) + i32(i16_2)));
         check("vadd(v*.w,v*.w):sat", hvx_width / 4, i32_sat(i64(i32_1) + i64(i32_2)));
-        if (isa_version >= 62) {
-            check("vadd(v*.uw,v*.uw):sat", hvx_width / 4, u32_sat(u64(u32_1) + u64(u32_2)));
-        }
+        check("vadd(v*.uw,v*.uw):sat", hvx_width / 4, u32_sat(u64(u32_1) + u64(u32_2)));
 
         check("vsub(v*.b,v*.b)", hvx_width / 1, u8_1 - u8_2);
         check("vsub(v*.h,v*.h)", hvx_width / 2, u16_1 - u16_2);
@@ -146,9 +142,7 @@ public:
         check("vadd(v*:*.uh,v*:*.uh):sat", hvx_width / 1, u16_sat(u32(u16_1) + u32(u16_2)));
         check("vadd(v*:*.h,v*:*.h):sat", hvx_width / 1, i16_sat(i32(i16_1) + i32(i16_2)));
         check("vadd(v*:*.w,v*:*.w):sat", hvx_width / 2, i32_sat(i64(i32_1) + i64(i32_2)));
-        if (isa_version >= 62) {
-            check("vadd(v*:*.uw,v*:*.uw):sat", hvx_width / 2, u32_sat(u64(u32_1) + u64(u32_2)));
-        }
+        check("vadd(v*:*.uw,v*:*.uw):sat", hvx_width / 2, u32_sat(u64(u32_1) + u64(u32_2)));
 
         check("vsub(v*:*.b,v*:*.b)", hvx_width * 2, u8_1 - u8_2);
         check("vsub(v*:*.h,v*:*.h)", hvx_width / 1, u16_1 - u16_2);
@@ -326,10 +320,8 @@ public:
         check("v*.ub = vpack(v*.h,v*.h):sat", hvx_width / 1, u8_sat(i32_1));
         check("v*.b = vpack(v*.h,v*.h):sat", hvx_width / 1, i8_sat(i32_1));
         check("v*.h = vsat(v*.w,v*.w)", hvx_width / 1, u8_sat(i32(i16_1) << 8));
-        if (isa_version >= 62) {
-            // v62 - Saturating narrowing cast
-            check("v*.uh = vsat(v*.uw, v*.uw)", hvx_width / 2, u16_sat(u32_1));
-        }
+        // Saturating narrowing cast
+        check("v*.uh = vsat(v*.uw, v*.uw)", hvx_width / 2, u16_sat(u32_1));
 
         check("vround(v*.h,v*.h)", hvx_width / 1, u8_sat((i32(i16_1) + 128) / 256));
         check("vround(v*.h,v*.h)", hvx_width / 1, i8_sat((i32(i16_1) + 128) / 256));
@@ -445,14 +437,9 @@ public:
         check("vnot(v*)", hvx_width / 2, ~u16_1);
         check("vnot(v*)", hvx_width / 4, ~u32_1);
 
-        if (isa_version >= 62) {
-            // v62 - Broadcasting unsigned 8 bit and 16 bit scalars
-            check("v*.b = vsplat(r*)", hvx_width / 1, in_u8(0));
-            check("v*.h = vsplat(r*)", hvx_width / 2, in_u16(0));
-        } else {
-            check("vsplat(r*)", hvx_width / 1, in_u8(0));
-            check("vsplat(r*)", hvx_width / 2, in_u16(0));
-        }
+        // v62 - Broadcasting unsigned scalars
+        check("v*.b = vsplat(r*)", hvx_width / 1, in_u8(0));
+        check("v*.h = vsplat(r*)", hvx_width / 2, in_u16(0));
         check("vsplat(r*)", hvx_width / 4, in_u32(0));
 
         check("vmux(q*,v*,v*)", hvx_width / 1, select(i8_1 == i8_2, i8_3, i8_2));
@@ -651,7 +638,6 @@ public:
 
         if (isa_version >= 65) {
             check("v*.h += vasl(v*.h,r*)", hvx_width / 2, i16_1 + (i16_2 << u16(y % 16)));
-            check("v*.h += vasl(v*.h,r*)", hvx_width / 2, i16_1 + (i16(y % 16) << u16_2));
             check("v*.h += vasr(v*.h,r*)", hvx_width / 2, i16_1 + (i16_2 >> u16(y % 16)));
             check("v*.h += vasl(v*.h,r*)", hvx_width / 2, u16_1 + (u16_2 * 16));
             check("v*.h += vasl(v*.h,r*)", hvx_width / 2, i16_1 + (i16_2 * 16));


### PR DESCRIPTION
The patch adds:
- Add "+hvxv6x" to mattrs
- Correct isa_version in simd_op_check_hvx

Some vsplat tests were failing with v62 and a vasl test with v65. Adding the hvx version flag in mattrs fixes the failures.

@dsharletg @pranavb-ca Please review

