### PR TITLE
HalideBuffer: cast offset operand to ptrdiff_t to avoid overflow

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1832,7 +1832,7 @@ private:
     HALIDE_ALWAYS_INLINE
         ptrdiff_t
         offset_of(int d, int first, Args... rest) const {
-        return offset_of(d + 1, rest...) + this->buf.dim[d].stride * (first - this->buf.dim[d].min);
+        return offset_of(d + 1, rest...) + (ptrdiff_t)this->buf.dim[d].stride * (first - this->buf.dim[d].min);
     }
 
     HALIDE_ALWAYS_INLINE
@@ -1855,7 +1855,7 @@ private:
     ptrdiff_t offset_of(const int *pos) const {
         ptrdiff_t offset = 0;
         for (int i = this->dimensions() - 1; i >= 0; i--) {
-            offset += this->buf.dim[i].stride * (pos[i] - this->buf.dim[i].min);
+            offset += (ptrdiff_t)this->buf.dim[i].stride * (pos[i] - this->buf.dim[i].min);
         }
         return offset;
     }

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -540,7 +540,7 @@ private:
         ptrdiff_t index = 0;
         for (int i = 0; i < dimensions(); i++) {
             if (dim(i).stride() < 0) {
-                index += dim(i).stride() * (dim(i).extent() - 1);
+                index += dim(i).stride() * (ptrdiff_t)(dim(i).extent() - 1);
             }
         }
         return index;
@@ -552,7 +552,7 @@ private:
         ptrdiff_t index = 0;
         for (int i = 0; i < dimensions(); i++) {
             if (dim(i).stride() > 0) {
-                index += dim(i).stride() * (dim(i).extent() - 1);
+                index += dim(i).stride() * (ptrdiff_t)(dim(i).extent() - 1);
             }
         }
         index += 1;

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1495,7 +1495,7 @@ typedef struct halide_buffer_t {
         ptrdiff_t index = 0;
         for (int i = 0; i < dimensions; i++) {
             if (dim[i].stride < 0) {
-                index += dim[i].stride * (dim[i].extent - 1);
+                index += (ptrdiff_t)dim[i].stride * (dim[i].extent - 1);
             }
         }
         return host + index * type.bytes();
@@ -1506,7 +1506,7 @@ typedef struct halide_buffer_t {
         ptrdiff_t index = 0;
         for (int i = 0; i < dimensions; i++) {
             if (dim[i].stride > 0) {
-                index += dim[i].stride * (dim[i].extent - 1);
+                index += (ptrdiff_t)dim[i].stride * (dim[i].extent - 1);
             }
         }
         index += 1;
@@ -1522,7 +1522,7 @@ typedef struct halide_buffer_t {
     HALIDE_ALWAYS_INLINE uint8_t *address_of(const int *pos) const {
         ptrdiff_t index = 0;
         for (int i = 0; i < dimensions; i++) {
-            index += dim[i].stride * (pos[i] - dim[i].min);
+            index += (ptrdiff_t)dim[i].stride * (pos[i] - dim[i].min);
         }
         return host + index * type.bytes();
     }


### PR DESCRIPTION
Without this, allocating large buffers from an application fails with a segfault.