### PR TITLE
Add mux intrinsic

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1472,6 +1472,14 @@ private:
                 result.include(interval);
             }
             interval = result;
+        } else if (op->is_intrinsic(Call::mux)) {
+            // Take the union of all args but the first
+            Interval result = Interval::nothing();
+            for (size_t i = 1; i < op->args.size(); i++) {
+                op->args[i].accept(this);
+                result.include(interval);
+            }
+            interval = result;
         } else if (op->call_type == Call::Halide) {
             bounds_of_func(op->name, op->value_index, op->type);
         } else {

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2207,6 +2207,8 @@ void CodeGen_C::visit(const Call *op) {
         rhs << print_expr(op->args[0]) << " / " << print_expr(op->args[1]);
     } else if (op->is_intrinsic(Call::mod_round_to_zero)) {
         rhs << print_expr(op->args[0]) << " % " << print_expr(op->args[1]);
+    } else if (op->is_intrinsic(Call::mux)) {
+        rhs << print_expr(lower_mux(op));
     } else if (op->is_intrinsic(Call::signed_integer_overflow)) {
         user_error << "Signed integer overflow occurred during constant-folding. Signed"
                       " integer overflow for int32 and int64 is undefined behavior in"

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -621,6 +621,17 @@ Expr lower_signed_shift_right(const Expr &a, const Expr &b) {
     }
 }
 
+Expr lower_mux(const Call *mux) {
+    internal_assert(mux->args.size() >= 2);
+    Expr equiv = mux->args.back();
+    Expr index = mux->args[0];
+    int num_vals = (int)mux->args.size() - 1;
+    for (int i = num_vals - 1; i >= 0; i--) {
+        equiv = select(index == make_const(index.type(), i), mux->args[i + 1], equiv);
+    }
+    return equiv;
+}
+
 bool get_md_bool(llvm::Metadata *value, bool &result) {
     if (!value) {
         return false;

--- a/src/CodeGen_Internal.h
+++ b/src/CodeGen_Internal.h
@@ -117,6 +117,9 @@ Expr lower_signed_shift_left(const Expr &a, const Expr &b);
 Expr lower_signed_shift_right(const Expr &a, const Expr &b);
 ///@}
 
+/** Reduce a mux intrinsic to a select tree */
+Expr lower_mux(const Call *mux);
+
 /** Given an llvm::Module, set llvm:TargetOptions, cpu and attr information */
 void get_target_options(const llvm::Module &module, llvm::TargetOptions &options, std::string &mcpu, std::string &mattrs);
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -3189,6 +3189,8 @@ void CodeGen_LLVM::visit(const Call *op) {
         value = codegen(op->args[0]);
     } else if (is_float16_transcendental(op)) {
         value = codegen(lower_float16_transcendental_to_float32_equivalent(op));
+    } else if (op->is_intrinsic(Call::mux)) {
+        value = codegen(lower_mux(op));
     } else if (op->is_intrinsic()) {
         Expr lowered = lower_intrinsic(op);
         if (!lowered.defined()) {

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -615,6 +615,7 @@ const char *const intrinsic_op_names[] = {
     "memoize_expr",
     "mod_round_to_zero",
     "mulhi_shr",
+    "mux",
     "popcount",
     "prefetch",
     "promise_clamped",

--- a/src/IR.h
+++ b/src/IR.h
@@ -527,6 +527,7 @@ struct Call : public ExprNode<Call> {
         memoize_expr,
         mod_round_to_zero,
         mulhi_shr,  // Compute high_half(arg[0] * arg[1]) >> arg[3]. Note that this is a shift in addition to taking the upper half of multiply result. arg[3] must be an unsigned integer immediate.
+        mux,
         popcount,
         prefetch,
         promise_clamped,

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -829,6 +829,9 @@ inline Tuple tuple_select(const Expr &c0, const Tuple &v0, const Expr &c1, const
  * This is tedious when the list is long. The following function
  * provide convinent syntax that allow one to write:
  * img(x, y, c) = mux(c, {100, 50, 25});
+ *
+ * As with the select equivalent, if the first argument (the index) is
+ * out of range, the expression evaluates to the last value.
  */
 // @{
 Expr mux(const Expr &id, const std::initializer_list<Expr> &values);


### PR DESCRIPTION
This PR turns mux into an intrinsic, instead of immediately unpacking into a select tree. When you mux a lot of values it produces a deeply nested select tree, and this is pathological for a few different lowering stages (mostly unrolling). Turning it into an intrinsic (lowered to selects during codegen) speeds up lowering time of one big pipeline by about 3x (174s -> 57s)

