### PR TITLE
runtime: fix pointer calculations to avoid overflows. Fixes #5713.

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -373,7 +373,7 @@ private:
         assert(dim(d).max() >= min + extent - 1);
         ptrdiff_t shift = min - dim(d).min();
         if (buf.host != nullptr) {
-            buf.host += shift * dim(d).stride() * type().bytes();
+            buf.host += (shift * dim(d).stride()) * type().bytes();
         }
         buf.dim[d].min = min;
         buf.dim[d].extent = extent;
@@ -411,7 +411,7 @@ private:
         buf.dimensions--;
         ptrdiff_t shift = pos - buf.dim[d].min;
         if (buf.host != nullptr) {
-            buf.host += shift * buf.dim[d].stride * type().bytes();
+            buf.host += (shift * buf.dim[d].stride) * type().bytes();
         }
         for (int i = d; i < buf.dimensions; i++) {
             buf.dim[i] = buf.dim[i + 1];

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -371,7 +371,7 @@ private:
     void crop_host(int d, int min, int extent) {
         assert(dim(d).min() <= min);
         assert(dim(d).max() >= min + extent - 1);
-        int shift = min - dim(d).min();
+        ptrdiff_t shift = min - dim(d).min();
         if (buf.host != nullptr) {
             buf.host += shift * dim(d).stride() * type().bytes();
         }
@@ -409,7 +409,7 @@ private:
         assert(d >= 0 && d < dimensions());
         assert(pos >= dim(d).min() && pos <= dim(d).max());
         buf.dimensions--;
-        int shift = pos - buf.dim[d].min;
+        ptrdiff_t shift = pos - buf.dim[d].min;
         if (buf.host != nullptr) {
             buf.host += shift * buf.dim[d].stride * type().bytes();
         }

--- a/src/runtime/device_buffer_utils.h
+++ b/src/runtime/device_buffer_utils.h
@@ -89,7 +89,7 @@ WEAK device_copy make_buffer_copy(const halide_buffer_t *src, bool src_host,
     // Offset the src base pointer to the right point in its buffer.
     c.src_begin = 0;
     for (int i = 0; i < src->dimensions; i++) {
-        c.src_begin += src->dim[i].stride * (dst->dim[i].min - src->dim[i].min);
+        c.src_begin += (uint64_t)src->dim[i].stride * (dst->dim[i].min - src->dim[i].min);
     }
     c.src_begin *= c.chunk_size;
 
@@ -114,8 +114,8 @@ WEAK device_copy make_buffer_copy(const halide_buffer_t *src, bool src_host,
     // in ascending order in the dst.
     for (int i = 0; i < dst->dimensions; i++) {
         // TODO: deal with negative strides.
-        uint64_t dst_stride_bytes = dst->dim[i].stride * dst->type.bytes();
-        uint64_t src_stride_bytes = src->dim[i].stride * src->type.bytes();
+        uint64_t dst_stride_bytes = (uint64_t)dst->dim[i].stride * dst->type.bytes();
+        uint64_t src_stride_bytes = (uint64_t)src->dim[i].stride * src->type.bytes();
         // Insert the dimension sorted into the buffer copy.
         int insert;
         for (insert = 0; insert < i; insert++) {
@@ -172,7 +172,7 @@ WEAK device_copy make_device_to_host_copy(const halide_buffer_t *buf) {
 ALWAYS_INLINE int64_t calc_device_crop_byte_offset(const struct halide_buffer_t *src, struct halide_buffer_t *dst) {
     int64_t offset = 0;
     for (int i = 0; i < src->dimensions; i++) {
-        offset += (dst->dim[i].min - src->dim[i].min) * src->dim[i].stride;
+        offset += (dst->dim[i].min - src->dim[i].min) * (int64_t)src->dim[i].stride;
     }
     offset *= src->type.bytes();
     return offset;
@@ -181,7 +181,7 @@ ALWAYS_INLINE int64_t calc_device_crop_byte_offset(const struct halide_buffer_t 
 // Caller is expected to verify that src->dimensions == dst->dimensions + 1,
 // and that slice_dim and slice_pos are valid within src
 ALWAYS_INLINE int64_t calc_device_slice_byte_offset(const struct halide_buffer_t *src, int slice_dim, int slice_pos) {
-    int64_t offset = (slice_pos - src->dim[slice_dim].min) * src->dim[slice_dim].stride;
+    int64_t offset = (slice_pos - src->dim[slice_dim].min) * (int64_t)src->dim[slice_dim].stride;
     offset *= src->type.bytes();
     return offset;
 }

--- a/src/runtime/halide_buffer_t.cpp
+++ b/src/runtime/halide_buffer_t.cpp
@@ -148,7 +148,7 @@ halide_buffer_t *_halide_buffer_crop(void *user_context,
         dst->dim[i] = src->dim[i];
         dst->dim[i].min = min[i];
         dst->dim[i].extent = extent[i];
-        offset += (min[i] - src->dim[i].min) * src->dim[i].stride;
+        offset += (min[i] - src->dim[i].min) * (int64_t)src->dim[i].stride;
     }
     if (dst->host) {
         dst->host += offset * src->type.bytes();


### PR DESCRIPTION
These changes are based primarily on visual code inspection in areas identified with some simple grep'ing as potentially problematic, with a subset of them verified to fix #5713 (e.g., I have *not* tested the data copy functions).  As I am not that familiar with the codebase, I ask that the reviewer please check the runtime sources to see if I might have missed other similarly affected lines, and I'll be happy to add such additional fixes to the PR.

I will also note that there are various data types being used for offset computations, including at least `int64_t`, `uint64_t`, and `ptrdiff_t`.  It might be better to be more consistent and use the datatypes that are actually intended for pointer calculations, like `ptrdiff_t`.  The only such changes included here are to avoid overflow, not to apply consistency in the codebase.