### PR TITLE
Fix symbol names used for outputting schedules into valid C++ source variable names

### DIFF
--- a/src/autoschedulers/adams2019/ASLog.cpp
+++ b/src/autoschedulers/adams2019/ASLog.cpp
@@ -1,5 +1,8 @@
 #include "ASLog.h"
 
+#include <algorithm>
+#include <cctype>
+
 namespace Halide {
 namespace Internal {
 
@@ -48,6 +51,21 @@ int aslog::aslog_level() {
         return !lvl.empty() ? atoi(lvl.c_str()) : 0;
     })();
     return cached_aslog_level;
+}
+
+std::string conform_name(const std::string &name, const std::string &prefix) {
+    auto invalid_contents = [] (const char& c) { 
+        return std::ispunct(c) || std::isspace(c);
+    };
+
+    auto invalid_prefix = [] (const char& c) { 
+        return (c != '_') && !(std::isalpha(c));
+    };
+
+    std::string result(name);
+    std::replace_if(result.begin(), result.end(), invalid_contents, '_');
+    if(invalid_prefix(result.front())) { result = std::string(prefix) + result; }
+    return result;
 }
 
 }  // namespace Internal

--- a/src/autoschedulers/adams2019/ASLog.h
+++ b/src/autoschedulers/adams2019/ASLog.h
@@ -31,6 +31,9 @@ public:
     static int aslog_level();
 };
 
+// Conform the given name into a valid C++ identifier (eg for dumping a Func/Var inside a schedule to a header)
+std::string conform_name(const std::string &name, const std::string &prefix="_"); 
+
 }  // namespace Internal
 }  // namespace Halide
 

--- a/src/autoschedulers/adams2019/LoopNest.cpp
+++ b/src/autoschedulers/adams2019/LoopNest.cpp
@@ -1709,7 +1709,7 @@ void LoopNest::apply(LoopLevel here,
                     internal_assert(v.innermost_pure_dim && v.exists) << v.var.name() << "\n";
                     // Is the result of a split
                     state.schedule_source
-                        << "\n    .vectorize(" << v.var.name() << ")";
+                        << "\n    .vectorize(" << conform_name(v.var.name()) << ")";
                     s.vectorize(v.var);
                 }
             } else {
@@ -1760,9 +1760,9 @@ void LoopNest::apply(LoopLevel here,
                         parent.exists = false;
                         parent.extent = 1;
                     } else {
-                        VarOrRVar inner(Var(parent.var.name() + "i"));
+                        VarOrRVar inner(Var(conform_name(parent.var.name() + "i")));
                         if (parent.var.is_rvar) {
-                            inner = RVar(parent.var.name() + "i");
+                            inner = RVar(conform_name(parent.var.name() + "i", "r"));
                         }
 
                         auto tail_strategy = pure_var_tail_strategy;
@@ -1779,8 +1779,8 @@ void LoopNest::apply(LoopLevel here,
                         s.split(parent.var, parent.var, inner, (int)factor, tail_strategy);
                         state.schedule_source
                             << "\n    .split("
-                            << parent.var.name() << ", "
-                            << parent.var.name() << ", "
+                            << conform_name(parent.var.name()) << ", "
+                            << conform_name(parent.var.name()) << ", "
                             << inner.name() << ", "
                             << factor << ", "
                             << "TailStrategy::" << tail_strategy << ")";
@@ -1819,7 +1819,7 @@ void LoopNest::apply(LoopLevel here,
                         for (size_t i = 0; i < symbolic_loop.size(); i++) {
                             if (state.vars[i].pure && state.vars[i].exists && state.vars[i].extent > 1) {
                                 s.unroll(state.vars[i].var);
-                                state.schedule_source << "\n    .unroll(" << state.vars[i].var.name() << ")";
+                                state.schedule_source << "\n    .unroll(" << conform_name(state.vars[i].var.name()) << ")";
                             }
                         }
                     }
@@ -1858,7 +1858,7 @@ void LoopNest::apply(LoopLevel here,
         if (here.is_root()) {
             loop_level = "_root()";
         } else {
-            loop_level = "_at(" + here.func() + ", " + here.var().name() + ")";
+            loop_level = "_at(" + here.func() + ", " + conform_name(here.var().name()) + ")";
         }
         for (const auto &c : children) {
             if (c->node != node) {


### PR DESCRIPTION
Since Funcs and other classes can have user defined names, the resulting strings may be invalid C++ when used directly for variable names and identifiers during the source code generation for schedules.

This PR adds a 'conform_name' around all variable names being outputted to replace invalid characters with an underscore, to make sure only valid C++ identifiers are outputted for the schedule source.