### PR TITLE
Refactor code for dealing with default values of scalar Params

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -90,9 +90,8 @@ std::map<Output, std::string> compute_output_files(const Target &target,
     return output_files;
 }
 
-Argument to_argument(const Internal::Parameter &param, const Expr &default_value) {
+Argument to_argument(const Internal::Parameter &param) {
     ArgumentEstimates argument_estimates = param.get_argument_estimates();
-    argument_estimates.scalar_def = default_value;
     return Argument(param.name(),
                     param.is_buffer() ? Argument::InputBuffer : Argument::InputScalar,
                     param.type(), param.dimensions(), argument_estimates);
@@ -1480,7 +1479,7 @@ Module GeneratorBase::build_module(const std::string &function_name,
     std::vector<Argument> filter_arguments;
     for (const auto *input : pi.inputs()) {
         for (const auto &p : input->parameters_) {
-            filter_arguments.push_back(to_argument(p, p.is_buffer() ? Expr() : input->get_def_expr()));
+            filter_arguments.push_back(to_argument(p));
         }
     }
 
@@ -1555,7 +1554,7 @@ Module GeneratorBase::build_gradient_module(const std::string &function_name) {
         // There can be multiple Funcs/Parameters per input if the input is an Array
         internal_assert(input->parameters_.size() == input->funcs_.size());
         for (const auto &p : input->parameters_) {
-            gradient_inputs.push_back(to_argument(p, p.is_buffer() ? Expr() : input->get_def_expr()));
+            gradient_inputs.push_back(to_argument(p));
             debug(DBG) << "    gradient copied input is: " << gradient_inputs.back().name << "\n";
         }
     }
@@ -1585,7 +1584,7 @@ Module GeneratorBase::build_gradient_module(const std::string &function_name) {
                 d_im.parameter().set_extent_constraint_estimate(d, grad_in_estimates.buffer_estimates[i].extent);
             }
             d_output_imageparams.push_back(d_im);
-            gradient_inputs.push_back(to_argument(d_im.parameter(), Expr()));
+            gradient_inputs.push_back(to_argument(d_im.parameter()));
 
             debug(DBG) << "    gradient synthesized input is: " << gradient_inputs.back().name << "\n";
         }
@@ -1893,10 +1892,6 @@ void GeneratorInputBase::check_value_writable() const {
 
 void GeneratorInputBase::set_def_min_max() {
     // nothing
-}
-
-Expr GeneratorInputBase::get_def_expr() const {
-    return Expr();
 }
 
 Parameter GeneratorInputBase::parameter() const {

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -150,6 +150,15 @@ public:
     Expr estimate() const;
     // @}
 
+    /** Get and set the default values for scalar parameters. At present, these
+     * are used only to emit the default values in the metadata. There isn't
+     * yet a public API in Param<> for them (this is used internally by the
+     * Generator code). */
+    // @{
+    void set_default_value(const Expr &e);
+    Expr default_value() const;
+    // @}
+
     /** Order Parameters by their IntrusivePtr so they can be used
      * to index maps. */
     bool operator<(const Parameter &other) const {


### PR DESCRIPTION
The "default" value for a scalar param is rarely used -- it's currently only possible to specify foran Input in a Generator, and that value only shows up in the generated metadata for AOT compilation.

This PR refactors this so that instead of being maintained solely as a hack in Generator data structures, it's moved into Parameter as its own field.

This seems like a lot of work some something of marginal use, but I'm reluctant to suggest removing it entirely (it's possible it could break someone's code), and refactoring it in this way will make some subsequent Generator refactoring easier to understand and review.