### PR TITLE
Fix apps/HelloPyTorch

### DIFF
--- a/apps/HelloPyTorch/Makefile
+++ b/apps/HelloPyTorch/Makefile
@@ -45,7 +45,7 @@ $(BIN)/.wrapper: $(OPS) $(CUDA_OPS) setup.py
 	      HALIDE_DISTRIB_PATH=$(HALIDE_DISTRIB_PATH) \
 	      BIN=$(BIN)/$(HL_TARGET) \
 	      PYTHONPATH=$(EXT_LIB):${PYTHONPATH} \
-	      $(PIP) install . -t $(EXT_LIB) -b $(BIN)
+	      $(PIP) install . -t $(EXT_LIB)
 	@touch $(BIN)/.wrapper
 
 

--- a/apps/HelloPyTorch/setup.py
+++ b/apps/HelloPyTorch/setup.py
@@ -46,7 +46,9 @@ if __name__ == "__main__":
         has_cuda = True
 
     include_dirs = [build_dir, os.path.join(halide_dir, "include")]
-    compile_args = ["-std=c++11", "-g"]
+    # Note that recent versions of PyTorch (at least 1.7.1) requires C++14
+    # in order to compile extensions
+    compile_args = ["-std=c++14", "-g"]
     if platform.system() == "Darwin":  # on osx libstdc++ causes trouble
         compile_args += ["-stdlib=libc++"]
 


### PR DESCRIPTION
(1) As of (at least) v1.7.1, PyTorch requires C++14 to compile C++ extensions
(2) As of pip 21.x, the `-b` flag is ignored (build files always use `/tmp` or the equivalent), so remove it to ignore annoying warnings