### PR TITLE
Treat the cost of a mux as just the cost of evaluating the args.

### DIFF
--- a/src/RegionCosts.cpp
+++ b/src/RegionCosts.cpp
@@ -221,7 +221,8 @@ class ExprCost : public IRVisitor {
                 call->is_intrinsic(Call::bitwise_not) || call->is_intrinsic(Call::bitwise_xor) ||
                 call->is_intrinsic(Call::bitwise_or) || call->is_intrinsic(Call::shift_left) ||
                 call->is_intrinsic(Call::shift_right) || call->is_intrinsic(Call::div_round_to_zero) ||
-                call->is_intrinsic(Call::mod_round_to_zero) || call->is_intrinsic(Call::undef)) {
+                call->is_intrinsic(Call::mod_round_to_zero) || call->is_intrinsic(Call::undef) ||
+                call->is_intrinsic(Call::mux)) {
                 arith += 1;
             } else if (call->is_intrinsic(Call::abs) || call->is_intrinsic(Call::absd) ||
                        call->is_intrinsic(Call::lerp) || call->is_intrinsic(Call::random) ||


### PR DESCRIPTION
This pessimistically assumes the mux doesn't get unrolled.

Fixes #5723 