### PR TITLE
Remove unnecessary .PHONY from python_bindings/Makefile

### DIFF
--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -133,7 +133,6 @@ $(BIN)/ext/%.so: $(BIN)/%.py.o $(BIN)/%.a $(BIN)/runtime.a
 
 # TODO: In the optimal case, we'd do %.run on all our generators. Unfortunately,
 # every generator needs its own settings. See https://github.com/halide/Halide/issues/2977.
-.PHONY: test_correctness_bit_test test_correctness_addconstant_test test_correctness_pystub test_correctness_user_context
 test_correctness_addconstant_test: addconstant.run ;
 test_correctness_bit_test: bit.run ;
 test_correctness_user_context_test: user_context.run ;

--- a/python_bindings/src/PyTuple.cpp
+++ b/python_bindings/src/PyTuple.cpp
@@ -17,7 +17,7 @@ void define_tuple(py::module &m) {
             .def(py::init([](const py::tuple &t) -> Tuple {
                 std::vector<Expr> v;
                 v.reserve(t.size());
-                for (const auto &o : t) {
+                for (const auto o : t) {
                     v.push_back(o.cast<Expr>());
                 }
                 return Tuple(v);


### PR DESCRIPTION
It's not necessary, and it prevents these four tests from being executed with `make test` or `make test_correctness`, etc