### PR TITLE
Fix EGL bugs

### DIFF
--- a/apps/glsl/opengl_test.cpp
+++ b/apps/glsl/opengl_test.cpp
@@ -55,4 +55,9 @@ int main(int argc, char *argv[]) {
     test_blur();
     test_ycc();
     test_device_sync();
+
+    // This is supposed to be called as an __attribute__((destructor)), but
+    // some EGL implementations can start to unload their libraries before those
+    // destructors run. On such systems, doing this outside of main() segfaults.
+    halide_device_release(nullptr, halide_opengl_device_interface());
 }

--- a/src/CodeGen_OpenGL_Dev.cpp
+++ b/src/CodeGen_OpenGL_Dev.cpp
@@ -1045,6 +1045,8 @@ void CodeGen_GLSL::add_kernel(const Stmt &stmt, const string &name,
     if (is_opengl_es(target)) {
         stream << "#ifdef GL_FRAGMENT_PRECISION_HIGH\n"
                << "precision highp float;\n"
+               << "#else\n"
+               << "precision mediump float;\n"
                << "#endif\n";
     }
 

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -994,9 +994,10 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
     // clang-format on
 
     // clang-format off
-    const std::array<Feature, 12> matching_features = {{
+    const std::array<Feature, 10> matching_features = {{
         ASAN,
         Debug,
+        EGL,
         HexagonDma,
         HVX,
         HVX_shared_object,

--- a/src/runtime/mini_opengl.h
+++ b/src/runtime/mini_opengl.h
@@ -218,4 +218,25 @@ typedef void (*PFNGLDELETEBUFFERSPROC)(GLsizei n, const GLuint *buffers);
 typedef void (*PFNGLGETACTIVEUNIFORM)(GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size, GLenum *type, GLchar *name);
 typedef GLint (*PFNGLGETUNIFORMLOCATION)(GLuint program, const GLchar *name);
 
+// ---------- KHR_debug macros ----------
+
+// clang-format off
+#define GL_DEBUG_OUTPUT                   0x92E0
+#define GL_DEBUG_OUTPUT_SYNCHRONOUS       0x8242
+#define GL_DEBUG_SEVERITY_HIGH            0x9146
+#define GL_DEBUG_SEVERITY_MEDIUM          0x9147
+#define GL_DEBUG_SEVERITY_LOW             0x9148
+#define GL_DEBUG_SEVERITY_NOTIFICATION    0x826B
+#define GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR 0x824D
+#define GL_DEBUG_TYPE_ERROR               0x824C
+#define GL_DEBUG_TYPE_MARKER              0x8268
+#define GL_DEBUG_TYPE_OTHER               0x8251
+#define GL_DEBUG_TYPE_PERFORMANCE         0x8250
+#define GL_DEBUG_TYPE_PORTABILITY         0x824F
+#define GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR  0x824E
+// clang-format on
+
+typedef void (*DEBUGPROC)(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, void *userParam);
+typedef void (*PFNGLDEBUGMESSAGECALLBACK)(DEBUGPROC callback, void *userParam);
+
 #endif  // MINI_OPENGL_H

--- a/src/runtime/opengl.cpp
+++ b/src/runtime/opengl.cpp
@@ -198,6 +198,7 @@ struct GlobalState {
     bool have_vertex_array_objects;
     bool have_texture_rg;
     bool have_texture_float;
+    bool have_color_buffer_float;
     bool have_texture_rgb8_rgba8;
 
     // Various objects shared by all filter kernels
@@ -639,6 +640,10 @@ WEAK void init_extensions(void *user_context) {
          extension_supported(user_context, "GL_ARB_texture_float")) ||
         (global_state.profile == OpenGLES &&
          extension_supported(user_context, "GL_OES_texture_float"));
+
+    global_state.have_color_buffer_float =
+        global_state.profile == OpenGL ||
+        extension_supported(user_context, "GL_EXT_color_buffer_float");
 }
 
 WEAK const char *parse_int(const char *str, int *val) {
@@ -711,7 +716,8 @@ WEAK int halide_opengl_init(void *user_context) {
         << "  vertex_array_objects: " << (global_state.have_vertex_array_objects ? "yes\n" : "no\n")
         << "  texture_rg: " << (global_state.have_texture_rg ? "yes\n" : "no\n")
         << "  have_texture_rgb8_rgba8: " << (global_state.have_texture_rgb8_rgba8 ? "yes\n" : "no\n")
-        << "  texture_float: " << (global_state.have_texture_float ? "yes\n" : "no\n");
+        << "  texture_float: " << (global_state.have_texture_float ? "yes\n" : "no\n")
+        << "  color_buffer_float: " << (global_state.have_color_buffer_float ? "yes\n" : "no\n");
 
     // Initialize framebuffer.
     global_state.GenFramebuffers(1, &global_state.framebuffer_id);

--- a/src/runtime/opengl_egl_context.cpp
+++ b/src/runtime/opengl_egl_context.cpp
@@ -148,22 +148,20 @@ WEAK int halide_opengl_create_context(void *user_context) {
     EGLContext context = eglCreateContext(display, config, EGL_NO_CONTEXT, context_attribs);
     if (context == EGL_NO_CONTEXT) {
         error(user_context) << "Error: eglCreateContext failed: " << eglGetError();
-        return -1;
+        return 1;
     }
 
     EGLint surface_attribs[] = {EGL_WIDTH, 1, EGL_HEIGHT, 1, EGL_NONE};
     EGLSurface surface = eglCreatePbufferSurface(display, config, surface_attribs);
     if (surface == EGL_NO_SURFACE) {
         error(user_context) << "Error: Could not create EGL window surface: " << eglGetError();
-        return -1;
+        return 1;
     }
 
     EGLBoolean result = eglMakeCurrent(display, surface, surface, context);
     if (result != EGL_TRUE) {
-        error(user_context) << "eglMakeCurrent fails: "
-                            << " result=" << (int)result
-                            << " eglGetError=" << eglGetError();
-        return -1;
+        error(user_context) << "eglMakeCurrent fails: result=" << (int)result << " eglGetError=" << eglGetError();
+        return 1;
     }
     return 0;
 }

--- a/test/opengl/float_texture.cpp
+++ b/test/opengl/float_texture.cpp
@@ -9,6 +9,11 @@ int main() {
     // This test must be run with an OpenGL target.
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
+    if (target.has_feature(Target::EGL)) {
+        printf("[SKIP] OpenGL ES does not support 3-channel buffers (ie. RGB)");
+        return 0;
+    }
+
     Buffer<float> input(255, 255, 3);
     input.fill([](int x, int y, int c) {
         // Note: the following values can be >1.0f to test whether

--- a/test/opengl/inline_reduction.cpp
+++ b/test/opengl/inline_reduction.cpp
@@ -9,6 +9,11 @@ int main() {
     // This test must be run with an OpenGL target.
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
+    if (target.has_feature(Target::EGL)) {
+        printf("[SKIP] OpenGL ES does not support 3-channel buffers (ie. RGB)");
+        return 0;
+    }
+
     Func f;
     Var x, y, c;
     RDom r(0, 10);

--- a/test/opengl/lut.cpp
+++ b/test/opengl/lut.cpp
@@ -1,4 +1,3 @@
-
 #include "Halide.h"
 #include <stdio.h>
 
@@ -13,6 +12,11 @@ int test_lut1d() {
 
     // This test must be run with an OpenGL target.
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
+
+    if (target.has_feature(Target::EGL)) {
+        printf("[SKIP] OpenGL ES does not support 3-channel buffers (ie. RGB)");
+        return 0;
+    }
 
     Var x("x");
     Var y("y");

--- a/test/opengl/multiple_stages.cpp
+++ b/test/opengl/multiple_stages.cpp
@@ -6,9 +6,13 @@
 using namespace Halide;
 
 int main() {
-
     // This test must be run with an OpenGL target.
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
+
+    if (target.has_feature(Target::EGL)) {
+        printf("[SKIP] OpenGL ES does not support 3-channel buffers (ie. RGB)");
+        return 0;
+    }
 
     Func f, g, h;
     Var x, y, c;

--- a/test/opengl/produce.cpp
+++ b/test/opengl/produce.cpp
@@ -14,6 +14,11 @@ int test_lut1d() {
     // This test must be run with an OpenGL target.
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
+    if (target.has_feature(Target::EGL)) {
+        printf("[SKIP] OpenGL ES does not support 3-channel buffers (ie. RGB)");
+        return 0;
+    }
+
     Var x("x");
     Var y("y");
     Var c("c");

--- a/test/opengl/save_state.cpp
+++ b/test/opengl/save_state.cpp
@@ -35,12 +35,17 @@ public:
                                         TexCoordOut = TexCoordIn; \
                                     }";
 
-        const char *fragmentShader = " \
-                                      varying vec2 TexCoordOut; \
-                                      uniform sampler2D Texture; \
-                                      void main(void) { \
-                                          gl_FragColor = texture2D(Texture, TexCoordOut); \
-                                      }";
+        const char *fragmentShader =
+            "#ifdef GL_FRAGMENT_PRECISION_HIGH\n"
+            "precision highp float;\n"
+            "#else\n"
+            "precision mediump float;\n"
+            "#endif\n"
+            "varying vec2 TexCoordOut;\n"
+            "uniform sampler2D Texture;\n"
+            "void main(void) {\n"
+            "    gl_FragColor = texture2D(Texture, TexCoordOut);\n"
+            "}\n";
 
         GLuint handle = glCreateProgram();
         glAttachShader(handle, compileShader("vertex", vertexShader, GL_VERTEX_SHADER));

--- a/test/opengl/sumcolor_reduction.cpp
+++ b/test/opengl/sumcolor_reduction.cpp
@@ -9,6 +9,11 @@ int main() {
     // This test must be run with an OpenGL target.
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
+    if (target.has_feature(Target::EGL)) {
+        printf("[SKIP] OpenGL ES does not support 3-channel buffers (ie. RGB)");
+        return 0;
+    }
+
     // Define the input.
     const int width = 10, height = 10, channels = 3;
     Buffer<float> input(width, height, channels);

--- a/test/opengl/varying.cpp
+++ b/test/opengl/varying.cpp
@@ -196,6 +196,11 @@ int main() {
     // This test must be run with an OpenGL target.
     const Target target = get_jit_target_from_environment().with_feature(Target::OpenGL);
 
+    if (target.has_feature(Target::EGL)) {
+        printf("[SKIP] OpenGL ES does not support 3-channel buffers (ie. RGB)");
+        return 0;
+    }
+
     Var x("x");
     Var y("y");
     Var c("c");


### PR DESCRIPTION
I'm trying to fix the outstanding EGL bugs on the buildbots before releasing v11. But when trying to repro locally, I ran into a _new_ set of bugs!

1. I noticed that `USE_RUNTIME` is broken because the `egl` backend has to match across all runtime targets. So I added that to the `matching_features` list in Target.cpp
2. This one is more serious. Some EGL implementations can unload their libraries _before_ (or perhaps concurrently with) `__attribute__((destructor))` functions. This causes the EGL device-release to call a function in an unmapped page and segfault. I tried re-querying the location of one of the symbols, but it's apparently cached so the best I could do was explicitly release the device before main exits in the GLSL app. 