### PR TITLE
A few small debug output improvements

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -95,6 +95,9 @@ std::ostream &operator<<(std::ostream &stream, const Box &b) {
         stream << "[" << b[dim].min << ", " << b[dim].max << "]";
     }
     stream << "}";
+    if (b.used.defined()) {
+        stream << " if " << b.used;
+    }
     return stream;
 }
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1373,7 +1373,7 @@ Value *CodeGen_LLVM::codegen(const Expr &e) {
 
 void CodeGen_LLVM::codegen(const Stmt &s) {
     internal_assert(s.defined());
-    debug(3) << "Codegen: " << s << "\n";
+    debug(4) << "Codegen: " << s << "\n";
     value = nullptr;
     s.accept(this);
 }

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -670,11 +670,15 @@ class AttemptStorageFoldingOfFunction : public IRMutator {
                     } else {
                         can_fold_backwards = true;
                     }
-                } else if (!explicit_only) {
+                } else {
                     // Can't do much with this dimension
-                    debug(3) << "Not folding because loop min or max not monotonic in the loop variable\n"
-                             << "min = " << min << "\n"
-                             << "max = " << max << "\n";
+                    if (!explicit_only) {
+                        debug(3) << "Not folding because loop min or max not monotonic in the loop variable\n"
+                                 << "min = " << min << "\n"
+                                 << "max = " << max << "\n";
+                     } else {
+                        debug(3) << "Not folding because there is no explicit storage folding factor\n"
+                     }
                     continue;
                 }
             }

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -670,7 +670,7 @@ class AttemptStorageFoldingOfFunction : public IRMutator {
                     } else {
                         can_fold_backwards = true;
                     }
-                } else {
+                } else if (!explicit_only) {
                     // Can't do much with this dimension
                     debug(3) << "Not folding because loop min or max not monotonic in the loop variable\n"
                              << "min = " << min << "\n"
@@ -936,7 +936,11 @@ class StorageFolding : public IRMutator {
         // more than one produce node for this func.
         bool explicit_only = count_producers(body, op->name) != 1;
         AttemptStorageFoldingOfFunction folder(func, explicit_only);
-        debug(3) << "Attempting to fold " << op->name << "\n";
+        if (explicit_only) {
+            debug(3) << "Attempting to fold " << op->name << " explicitly\n";
+        } else {
+            debug(3) << "Attempting to fold " << op->name << " automatically or explicitly\n";
+        }
         body = folder.mutate(body);
 
         if (body.same_as(op->body)) {

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -677,7 +677,7 @@ class AttemptStorageFoldingOfFunction : public IRMutator {
                                  << "min = " << min << "\n"
                                  << "max = " << max << "\n";
                     } else {
-                        debug(3) << "Not folding because there is no explicit storage folding factor\n"
+                        debug(3) << "Not folding because there is no explicit storage folding factor\n";
                     }
                     continue;
                 }

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -676,9 +676,9 @@ class AttemptStorageFoldingOfFunction : public IRMutator {
                         debug(3) << "Not folding because loop min or max not monotonic in the loop variable\n"
                                  << "min = " << min << "\n"
                                  << "max = " << max << "\n";
-                     } else {
+                    } else {
                         debug(3) << "Not folding because there is no explicit storage folding factor\n"
-                     }
+                    }
                     continue;
                 }
             }


### PR DESCRIPTION
- Show predicate on `Box`es
- Don't debug(3) Stmts in codegen, this produces a quadratic amount of debug output
- Fix confusing debug output from storage folding