### PR TITLE
Better handling of sparse blurs using udot/sdot

### DIFF
--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -517,7 +517,8 @@ class Interleaver : public IRMutator {
         for (int i = 2; i <= 4; ++i) {
             if (r &&
                 is_const(op->b, i) &&
-                (r->type.lanes() % i) == 0) {
+                (r->type.lanes() % i) == 0 &&
+                r->type.lanes() > i) {
                 should_deinterleave = true;
                 num_lanes = i;
                 break;

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -247,7 +247,6 @@ private:
     Expr visit(const Ramp *op) override {
         int base_lanes = op->base.type().lanes();
         if (base_lanes > 1) {
-            debug(0) << "ELEPHANT: " << base_lanes << " " << lane_stride << " " << starting_lane << "\n";
             if (new_lanes == 1) {
                 int index = starting_lane / base_lanes;
                 Expr expr = op->base + cast(op->base.type(), index) * op->stride;
@@ -257,12 +256,14 @@ private:
                 return expr;
             } else if (base_lanes == lane_stride &&
                        starting_lane < base_lanes) {
-                // Base class mutator actually works fine in this case
-                debug(0) << "ELEPHANT\n";
+                // Base class mutator actually works fine in this
+                // case, but we only want one lane from the base and
+                // one lane from the stride.
                 ScopedValue<int> old_new_lanes(new_lanes, 1);
                 return IRMutator::visit(op);
             } else {
-                // There is probably a more efficient way to this.
+                // There is probably a more efficient way to this by
+                // generalizing the two cases above.
                 return mutate(flatten_nested_ramps(op));
             }
         }
@@ -489,7 +490,6 @@ class Interleaver : public IRMutator {
             // If we deinterleave we'll get ramps of stride 1
             should_deinterleave = true;
             num_lanes = op->stride.type().lanes();
-            debug(0) << "ELEPHANT: " << num_lanes << "\n";
         }
         return IRMutator::visit(op);
     }

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -1359,7 +1359,7 @@ class FindVectorizableExprsInAtomicNode : public IRMutator {
 
     Expr visit(const Call *op) override {
         IRMutator::visit(op);
-        // unsafe_promise_clamped and similar wisn't pure because it's
+        // unsafe_promise_clamped and similar isn't pure because it's
         // not safe to lift it out of if statements. If *is* safe to
         // lift it out of atomic nodes though.
         poison |= !(op->is_pure() ||

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -1359,10 +1359,12 @@ class FindVectorizableExprsInAtomicNode : public IRMutator {
 
     Expr visit(const Call *op) override {
         IRMutator::visit(op);
-        // unsafe_promise_clamped isn't pure because it's not safe to
-        // lift it out of if statements. If *is* safe to lift it out
-        // of atomic nodes though.
-        poison |= !(op->is_pure() || op->is_intrinsic(Call::unsafe_promise_clamped));
+        // unsafe_promise_clamped and similar wisn't pure because it's
+        // not safe to lift it out of if statements. If *is* safe to
+        // lift it out of atomic nodes though.
+        poison |= !(op->is_pure() ||
+                    op->is_intrinsic(Call::unsafe_promise_clamped) ||
+                    op->is_intrinsic(Call::promise_clamped));
         return op;
     }
 
@@ -1584,7 +1586,6 @@ Stmt vectorize_loops(const Stmt &stmt, const map<string, Function> &env, const T
     // TODO: Should this be an earlier pass? It's probably a good idea
     // for non-vectorizing stuff too.
     Stmt s = LiftVectorizableExprsOutOfAllAtomicNodes(env).mutate(stmt);
-    debug(0) << s << "\n";
     s = VectorizeLoops(t).mutate(s);
     s = RemoveUnnecessaryAtomics().mutate(s);
     return s;

--- a/test/performance/nested_vectorization_gemm.cpp
+++ b/test/performance/nested_vectorization_gemm.cpp
@@ -379,7 +379,7 @@ int main(int argc, char **argv) {
             Buffer<uint32_t> out(f_buf.width() - g_buf.width() - 128);
 
             // Uncomment to check the asm
-            result.compile_to_assembly("/dev/stdout", {f, g, taps}, target);
+            // result.compile_to_assembly("/dev/stdout", {f, g, taps}, target);
 
             times[use_nested_vectorization] =
                 Tools::benchmark(10, 10, [&]() {

--- a/test/performance/nested_vectorization_gemm.cpp
+++ b/test/performance/nested_vectorization_gemm.cpp
@@ -10,6 +10,9 @@ int main(int argc, char **argv) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }
+    // We don't want to be sensitive to LLVM pulling the same tricks
+    // or not.
+    target.set_feature(Target::DisableLLVMLoopOpt);
 
     // 8-bit mat-mul into 32-bit accumulator
     {
@@ -117,7 +120,7 @@ int main(int argc, char **argv) {
 
             times[use_nested_vectorization] =
                 Tools::benchmark(20, 20, [&]() {
-                    result.realize(out);
+                    result.realize(out, target);
                     out.device_sync();
                 });
         }
@@ -204,7 +207,7 @@ int main(int argc, char **argv) {
 
             times[use_nested_vectorization] =
                 Tools::benchmark(10, 10, [&]() {
-                    result.realize(out);
+                    result.realize(out, target);
                     out.device_sync();
                 });
         }
@@ -283,11 +286,11 @@ int main(int argc, char **argv) {
             Buffer<int16_t> out(f_buf.width() - g_buf.width() - 128);
 
             // Uncomment to check the asm
-            // result.compile_to_assembly("/dev/stdout", {f, g}, target);
+            //result.compile_to_assembly("/dev/stdout", {f, g}, target);
 
             times[use_nested_vectorization] =
                 Tools::benchmark(10, 10, [&]() {
-                    result.realize(out);
+                    result.realize(out, target);
                     out.device_sync();
                 });
         }
@@ -306,6 +309,100 @@ int main(int argc, char **argv) {
         }
     }
     printf("Success!\n");
+
+    // 8-bit sparse blur into 32-bit accumulator
+    {
+
+        double times[2];
+
+        for (int use_nested_vectorization = 0; use_nested_vectorization < 2; use_nested_vectorization++) {
+            Var x, y;
+
+            ImageParam f(UInt(8), 1), g(UInt(8), 1);
+
+            // 128 filter taps at unknown locations, which we will
+            // promise are bounded.
+            ImageParam taps(Int(32), 1);
+
+            RDom r(0, 128);
+            Func prod;
+            prod(x) += cast<uint32_t>(f(x + unsafe_promise_clamped(taps(r), 0, 127))) * g(r);
+
+            Func result;
+            result(x) = prod(x);
+
+            RVar ro, ri;
+
+            g.in().compute_at(prod, ro).vectorize(_0);
+
+            result
+                .vectorize(x, 8, TailStrategy::RoundUp);
+
+            if (use_nested_vectorization) {
+
+                int reduce;
+                if (target.has_feature(Target::ARMDotProd)) {
+                    reduce = 4;
+                } else {
+                    reduce = 2;
+                }
+
+                prod.compute_at(result, x)
+                    .vectorize(x)
+                    .update()
+                    .split(r, ro, ri, 16)
+                    .reorder(ri, x, ro)
+                    .vectorize(x)
+                    .atomic()
+                    .vectorize(ri, reduce)
+                    .unroll(ri);
+            } else {
+                prod.compute_at(result, x)
+                    .vectorize(x)
+                    .update()
+                    .split(r, ro, ri, 16)
+                    .reorder(ri, x, ro)
+                    .vectorize(x);
+            }
+
+            Buffer<uint8_t> f_buf(1024 * 1024);
+            f_buf.fill(100);
+            Buffer<uint8_t> g_buf(128);
+            f_buf.fill(100);
+            f.set(f_buf);
+            g.set(g_buf);
+            Buffer<int> taps_buf(128);
+            for (int i = 0; i < 128; i++) {
+                taps_buf(i) = (i * i) & 127;
+            }
+            taps.set(taps_buf);
+            Buffer<uint32_t> out(f_buf.width() - g_buf.width() - 128);
+
+            // Uncomment to check the asm
+            result.compile_to_assembly("/dev/stdout", {f, g, taps}, target);
+
+            times[use_nested_vectorization] =
+                Tools::benchmark(10, 10, [&]() {
+                    result.realize(out, target);
+                    out.device_sync();
+                });
+        }
+
+        // We don't actually get any win from this on X86, as the
+        // basic version also manages to use pmaddwd well.
+        double speed_up = times[0] / times[1];
+        printf("8-bit sparse blur\n"
+               "Time with nested vectorization: %0.2f ms \n"
+               "Time without: %0.2f ms \n"
+               "Speed-up: %0.2fx\n",
+               times[1] * 1000,
+               times[0] * 1000,
+               speed_up);
+        if (speed_up < 0.5) {
+            printf("The nested vectorization schedule was supposed to be faster!\n");
+            return -1;
+        }
+    }
 
     return 0;
 }


### PR DESCRIPTION
There was a case (illustrated in the updated performance test) where we really should do distinct vector loads and then interleave. Fortunately we have a pass for this, so I just taught it to handle this pattern.