### PR TITLE
Interpolate app improvements

### DIFF
--- a/apps/interpolate/Makefile
+++ b/apps/interpolate/Makefile
@@ -12,11 +12,11 @@ $(GENERATOR_BIN)/interpolate.generator: interpolate_generator.cpp $(GENERATOR_DE
 
 $(BIN)/%/interpolate.a: $(GENERATOR_BIN)/interpolate.generator
 	@mkdir -p $(@D)
-	$< -g interpolate -f interpolate -o $(BIN)/$* target=$*-no_runtime auto_schedule=false
+	$< -g interpolate -e $(GENERATOR_OUTPUTS) -f interpolate -o $(BIN)/$* target=$*-no_runtime auto_schedule=false
 
 $(BIN)/%/interpolate_auto_schedule.a: $(GENERATOR_BIN)/interpolate.generator
 	@mkdir -p $(@D)
-	$< -g interpolate -f interpolate_auto_schedule -o $(BIN)/$* target=$*-no_runtime auto_schedule=true
+	$< -g interpolate -e $(GENERATOR_OUTPUTS) -f interpolate_auto_schedule -o $(BIN)/$* target=$*-no_runtime auto_schedule=true
 
 $(BIN)/%/runtime.a: $(GENERATOR_BIN)/interpolate.generator
 	@mkdir -p $(@D)

--- a/apps/interpolate/interpolate_generator.cpp
+++ b/apps/interpolate/interpolate_generator.cpp
@@ -41,8 +41,8 @@ public:
                 // to prevent the footprint of the downsamplings to extend
                 // too far off the base image. Otherwise we look 512
                 // pixels off each edge.
-                Expr w = input.width() / (1 << l);
-                Expr h = input.height() / (1 << l);
+                Expr w = input.width() / (1 << (l - 1));
+                Expr h = input.height() / (1 << (l - 1));
                 prev = lambda(x, y, c, prev(clamp(x, 0, w), clamp(y, 0, h), c));
             }
 
@@ -177,13 +177,6 @@ public:
                     .unroll(c)
                     .vectorize(xi)
                     .parallel(yo);
-
-                downsampled[0]
-                    .store_at(normalize, yo)
-                    .compute_at(normalize, yi)
-                    .reorder(c, x, y)
-                    .unroll(c)
-                    .vectorize(x, vec);
 
                 for (int l = 1; l < levels; l++) {
                     interpolated[l]


### PR DESCRIPTION
- The boundary condition on the 4th pyramid level is wrong, and results in incorrect outputs for ~half the image in each dimension.
- downsampled[0] is consumed pointwise, so just inline it. Seems to speed things up by 0-0.5ms.
- Add extra generator outputs, like other apps do.