### PR TITLE
Upgrade clang-format rules to use v11 rather than v10.

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: DoozyX/clang-format-lint-action@v0.7
+      - uses: DoozyX/clang-format-lint-action@v0.11
         with:
           source: '.'
           extensions: 'h,c,cpp'
-          clangFormatVersion: 10
+          clangFormatVersion: 11
   check_clang_tidy:
     name: Check clang-tidy
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -2315,7 +2315,7 @@ $(BIN_DIR)/HalideTraceDump: $(ROOT_DIR)/util/HalideTraceDump.cpp $(ROOT_DIR)/uti
 
 # Note: you must have CLANG_FORMAT_LLVM_INSTALL_DIR set for this rule to work.
 # Let's default to the Ubuntu install location.
-CLANG_FORMAT_LLVM_INSTALL_DIR ?= /usr/lib/llvm-10
+CLANG_FORMAT_LLVM_INSTALL_DIR ?= /usr/lib/llvm-11
 
 .PHONY: format
 format:

--- a/apps/fft/funct.h
+++ b/apps/fft/funct.h
@@ -59,7 +59,7 @@ public:
     }
 
     template<typename... Args>
-    FuncRefT<T> operator()(Args &&... args) const {
+    FuncRefT<T> operator()(Args &&...args) const {
         return Func::operator()(std::forward<Args>(args)...);
     }
 

--- a/run-clang-format.sh
+++ b/run-clang-format.sh
@@ -4,23 +4,23 @@ set -e
 
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-# We are currently standardized on using LLVM/Clang10 for this script.
+# We are currently standardized on using LLVM/Clang11 for this script.
 # Note that this is totally independent of the version of LLVM that you
-# are using to build Halide itself. If you don't have LLVM10 installed,
+# are using to build Halide itself. If you don't have LLVM11 installed,
 # you can usually install what you need easily via:
 #
-# sudo apt-get install llvm-10 clang-10 libclang-10-dev clang-tidy-10
-# export CLANG_FORMAT_LLVM_INSTALL_DIR=/usr/lib/llvm-10
+# sudo apt-get install llvm-11 clang-11 libclang-11-dev clang-tidy-11
+# export CLANG_FORMAT_LLVM_INSTALL_DIR=/usr/lib/llvm-11
 
 [ -z "$CLANG_FORMAT_LLVM_INSTALL_DIR" ] && echo "CLANG_FORMAT_LLVM_INSTALL_DIR must point to an LLVM installation dir for this script." && exit
 echo CLANG_FORMAT_LLVM_INSTALL_DIR = ${CLANG_FORMAT_LLVM_INSTALL_DIR}
 
 VERSION=$(${CLANG_FORMAT_LLVM_INSTALL_DIR}/bin/clang-format --version)
-if [[ ${VERSION} =~ .*version\ 10.* ]]
+if [[ ${VERSION} =~ .*version\ 11.* ]]
 then
-    echo "clang-format version 10 found."
+    echo "clang-format version 11 found."
 else
-    echo "CLANG_FORMAT_LLVM_INSTALL_DIR must point to an LLVM 10 install!"
+    echo "CLANG_FORMAT_LLVM_INSTALL_DIR must point to an LLVM 11 install!"
     exit 1
 fi
 

--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -57,7 +57,7 @@ inline HALIDE_NO_USER_CODE_INLINE void collect_region(Region &collected_args,
 
 template<typename... Args>
 inline HALIDE_NO_USER_CODE_INLINE void collect_region(Region &collected_args,
-                                                      const Expr &a1, const Expr &a2, Args &&... args) {
+                                                      const Expr &a1, const Expr &a2, Args &&...args) {
     collected_args.push_back(Range(a1, a2));
     collect_region(collected_args, std::forward<Args>(args)...);
 }
@@ -124,7 +124,7 @@ HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Expr
 template<typename T, typename... Bounds,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
 HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Tuple &value,
-                                                  Bounds &&... bounds) {
+                                                  Bounds &&...bounds) {
     Region collected_bounds;
     Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
     return constant_exterior(Internal::func_like_to_func(func_like), value, collected_bounds);
@@ -132,7 +132,7 @@ HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Tupl
 template<typename T, typename... Bounds,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
 HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Expr &value,
-                                                  Bounds &&... bounds) {
+                                                  Bounds &&...bounds) {
     return constant_exterior(func_like, Tuple(value), std::forward<Bounds>(bounds)...);
 }
 // @}

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -52,7 +52,7 @@ inline std::string get_name_from_end_of_parameter_pack() {
 template<typename First,
          typename Second,
          typename... Args>
-std::string get_name_from_end_of_parameter_pack(First first, Second second, Args &&... rest) {
+std::string get_name_from_end_of_parameter_pack(First first, Second second, Args &&...rest) {
     return get_name_from_end_of_parameter_pack(second, std::forward<Args>(rest)...);
 }
 
@@ -63,13 +63,13 @@ inline void get_shape_from_start_of_parameter_pack_helper(std::vector<int> &) {
 }
 
 template<typename... Args>
-void get_shape_from_start_of_parameter_pack_helper(std::vector<int> &result, int x, Args &&... rest) {
+void get_shape_from_start_of_parameter_pack_helper(std::vector<int> &result, int x, Args &&...rest) {
     result.push_back(x);
     get_shape_from_start_of_parameter_pack_helper(result, std::forward<Args>(rest)...);
 }
 
 template<typename... Args>
-std::vector<int> get_shape_from_start_of_parameter_pack(Args &&... args) {
+std::vector<int> get_shape_from_start_of_parameter_pack(Args &&...args) {
     std::vector<int> result;
     get_shape_from_start_of_parameter_pack_helper(result, std::forward<Args>(args)...);
     return result;
@@ -248,7 +248,7 @@ public:
              typename = typename std::enable_if<Internal::all_ints_and_optional_name<Args...>::value>::type>
     explicit Buffer(Type t,
                     Internal::add_const_if_T_is_const<T, void> *data,
-                    int first, Args &&... rest)
+                    int first, Args &&...rest)
         : Buffer(Runtime::Buffer<T>(t, data, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
                  Internal::get_name_from_end_of_parameter_pack(rest...)) {
     }
@@ -265,7 +265,7 @@ public:
     template<typename... Args,
              typename = typename std::enable_if<Internal::all_ints_and_optional_name<Args...>::value>::type>
     explicit Buffer(T *data,
-                    int first, Args &&... rest)
+                    int first, Args &&...rest)
         : Buffer(Runtime::Buffer<T>(data, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
                  Internal::get_name_from_end_of_parameter_pack(rest...)) {
     }
@@ -387,18 +387,18 @@ public:
     // @}
 
     // We forward numerous methods from the underlying Buffer
-#define HALIDE_BUFFER_FORWARD_CONST(method)                                                                                      \
-    template<typename... Args>                                                                                                   \
-    auto method(Args &&... args) const->decltype(std::declval<const Runtime::Buffer<T>>().method(std::forward<Args>(args)...)) { \
-        user_assert(defined()) << "Undefined buffer calling const method " #method "\n";                                         \
-        return get()->method(std::forward<Args>(args)...);                                                                       \
+#define HALIDE_BUFFER_FORWARD_CONST(method)                                                                                     \
+    template<typename... Args>                                                                                                  \
+    auto method(Args &&...args) const->decltype(std::declval<const Runtime::Buffer<T>>().method(std::forward<Args>(args)...)) { \
+        user_assert(defined()) << "Undefined buffer calling const method " #method "\n";                                        \
+        return get()->method(std::forward<Args>(args)...);                                                                      \
     }
 
-#define HALIDE_BUFFER_FORWARD(method)                                                                                \
-    template<typename... Args>                                                                                       \
-    auto method(Args &&... args)->decltype(std::declval<Runtime::Buffer<T>>().method(std::forward<Args>(args)...)) { \
-        user_assert(defined()) << "Undefined buffer calling method " #method "\n";                                   \
-        return get()->method(std::forward<Args>(args)...);                                                           \
+#define HALIDE_BUFFER_FORWARD(method)                                                                               \
+    template<typename... Args>                                                                                      \
+    auto method(Args &&...args)->decltype(std::declval<Runtime::Buffer<T>>().method(std::forward<Args>(args)...)) { \
+        user_assert(defined()) << "Undefined buffer calling method " #method "\n";                                  \
+        return get()->method(std::forward<Args>(args)...);                                                          \
     }
 
 // This is a weird-looking but effective workaround for a deficiency in "perfect forwarding":
@@ -536,12 +536,12 @@ public:
     }
 
     template<typename... Args>
-    auto operator()(int first, Args &&... args) -> decltype(std::declval<Runtime::Buffer<T>>()(first, std::forward<Args>(args)...)) {
+    auto operator()(int first, Args &&...args) -> decltype(std::declval<Runtime::Buffer<T>>()(first, std::forward<Args>(args)...)) {
         return (*get())(first, std::forward<Args>(args)...);
     }
 
     template<typename... Args>
-    auto operator()(int first, Args &&... args) const -> decltype(std::declval<const Runtime::Buffer<T>>()(first, std::forward<Args>(args)...)) {
+    auto operator()(int first, Args &&...args) const -> decltype(std::declval<const Runtime::Buffer<T>>()(first, std::forward<Args>(args)...)) {
         return (*get())(first, std::forward<Args>(args)...);
     }
 

--- a/src/Func.h
+++ b/src/Func.h
@@ -376,7 +376,7 @@ public:
 
     template<typename... Args>
     HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Stage &>::type
-    reorder(const VarOrRVar &x, const VarOrRVar &y, Args &&... args) {
+    reorder(const VarOrRVar &x, const VarOrRVar &y, Args &&...args) {
         std::vector<VarOrRVar> collected_args{x, y, std::forward<Args>(args)...};
         return reorder(collected_args);
     }
@@ -1293,7 +1293,7 @@ public:
 
     template<typename... Args>
     HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<Var, Args...>::value, FuncRef>::type
-    operator()(Args &&... args) const {
+    operator()(Args &&...args) const {
         std::vector<Var> collected_args{std::forward<Args>(args)...};
         return this->operator()(collected_args);
     }
@@ -1310,7 +1310,7 @@ public:
 
     template<typename... Args>
     HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<Expr, Args...>::value, FuncRef>::type
-    operator()(const Expr &x, Args &&... args) const {
+    operator()(const Expr &x, Args &&...args) const {
         std::vector<Expr> collected_args{x, std::forward<Args>(args)...};
         return (*this)(collected_args);
     }
@@ -1604,7 +1604,7 @@ public:
 
     template<typename... Args>
     HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Func &>::type
-    reorder(const VarOrRVar &x, const VarOrRVar &y, Args &&... args) {
+    reorder(const VarOrRVar &x, const VarOrRVar &y, Args &&...args) {
         std::vector<VarOrRVar> collected_args{x, y, std::forward<Args>(args)...};
         return reorder(collected_args);
     }
@@ -2030,7 +2030,7 @@ public:
     Func &reorder_storage(const Var &x, const Var &y);
     template<typename... Args>
     HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<Var, Args...>::value, Func &>::type
-    reorder_storage(const Var &x, const Var &y, Args &&... args) {
+    reorder_storage(const Var &x, const Var &y, Args &&...args) {
         std::vector<Var> collected_args{x, y, std::forward<Args>(args)...};
         return reorder_storage(collected_args);
     }
@@ -2472,7 +2472,7 @@ inline void assign_results(Realization &r, int idx, Last last) {
 }
 
 template<typename First, typename Second, typename... Rest>
-inline void assign_results(Realization &r, int idx, First first, Second second, Rest &&... rest) {
+inline void assign_results(Realization &r, int idx, First first, Second second, Rest &&...rest) {
     assign_results<First>(r, idx, first);
     assign_results<Second, Rest...>(r, idx + 1, second, rest...);
 }
@@ -2496,7 +2496,7 @@ HALIDE_NO_USER_CODE_INLINE T evaluate(const Expr &e) {
 
 /** JIT-compile and run enough code to evaluate a Halide Tuple. */
 template<typename First, typename... Rest>
-HALIDE_NO_USER_CODE_INLINE void evaluate(Tuple t, First first, Rest &&... rest) {
+HALIDE_NO_USER_CODE_INLINE void evaluate(Tuple t, First first, Rest &&...rest) {
     Internal::check_types<First, Rest...>(t, 0);
 
     Func f;
@@ -2541,7 +2541,7 @@ HALIDE_NO_USER_CODE_INLINE T evaluate_may_gpu(const Expr &e) {
  *  use GPU if jit target from environment specifies one. */
 // @{
 template<typename First, typename... Rest>
-HALIDE_NO_USER_CODE_INLINE void evaluate_may_gpu(Tuple t, First first, Rest &&... rest) {
+HALIDE_NO_USER_CODE_INLINE void evaluate_may_gpu(Tuple t, First first, Rest &&...rest) {
     Internal::check_types<First, Rest...>(t, 0);
 
     Func f;

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1328,7 +1328,7 @@ public:
     }
 
     template<typename... Args>
-    Realization realize(Args &&... args) {
+    Realization realize(Args &&...args) {
         check_scheduled("realize");
         return f.realize(std::forward<Args>(args)..., get_target());
     }
@@ -1629,15 +1629,15 @@ public:
 // types in question satisfy the property of copies referring to the same underlying
 // structure (returning references is just an optimization). Since this is verbose
 // and used in several places, we'll use a helper macro:
-#define HALIDE_FORWARD_METHOD(Class, Method)                                                                                                         \
-    template<typename... Args>                                                                                                                       \
-    inline auto Method(Args &&... args)->typename std::remove_reference<decltype(std::declval<Class>().Method(std::forward<Args>(args)...))>::type { \
-        return this->template as<Class>().Method(std::forward<Args>(args)...);                                                                       \
+#define HALIDE_FORWARD_METHOD(Class, Method)                                                                                                        \
+    template<typename... Args>                                                                                                                      \
+    inline auto Method(Args &&...args)->typename std::remove_reference<decltype(std::declval<Class>().Method(std::forward<Args>(args)...))>::type { \
+        return this->template as<Class>().Method(std::forward<Args>(args)...);                                                                      \
     }
 
 #define HALIDE_FORWARD_METHOD_CONST(Class, Method)                                                                  \
     template<typename... Args>                                                                                      \
-    inline auto Method(Args &&... args) const->                                                                     \
+    inline auto Method(Args &&...args) const->                                                                      \
         typename std::remove_reference<decltype(std::declval<Class>().Method(std::forward<Args>(args)...))>::type { \
         this->check_gio_access();                                                                                   \
         return this->template as<Class>().Method(std::forward<Args>(args)...);                                      \
@@ -1686,7 +1686,7 @@ public:
     }
 
     template<typename... Args>
-    Expr operator()(Args &&... args) const {
+    Expr operator()(Args &&...args) const {
         this->check_gio_access();
         return Func(*this)(std::forward<Args>(args)...);
     }
@@ -1852,7 +1852,7 @@ public:
     }
 
     template<typename... Args>
-    Expr operator()(Args &&... args) const {
+    Expr operator()(Args &&...args) const {
         this->check_gio_access();
         return this->funcs().at(0)(std::forward<Args>(args)...);
     }
@@ -2311,7 +2311,7 @@ protected:
 
 public:
     template<typename... Args, typename T2 = T, typename std::enable_if<!std::is_array<T2>::value>::type * = nullptr>
-    FuncRef operator()(Args &&... args) const {
+    FuncRef operator()(Args &&...args) const {
         this->check_gio_access();
         return get_values<ValueType>().at(0)(std::forward<Args>(args)...);
     }
@@ -2874,7 +2874,7 @@ public:
     }
 
     template<typename T, typename... Args>
-    inline std::unique_ptr<T> apply(const Args &... args) const {
+    inline std::unique_ptr<T> apply(const Args &...args) const {
         auto t = this->create<T>();
         t->apply(args...);
         return t;
@@ -3081,7 +3081,7 @@ public:
      * will assert-fail at Halide compile time.
      */
     template<typename... Args>
-    void set_inputs(const Args &... args) {
+    void set_inputs(const Args &...args) {
         // set_inputs_vector() checks this too, but checking it here allows build_inputs() to avoid out-of-range checks.
         GeneratorParamInfo &pi = this->param_info();
         user_assert(sizeof...(args) == pi.inputs().size())
@@ -3098,7 +3098,7 @@ public:
     // Only enable if none of the args are Realization; otherwise we can incorrectly
     // select this method instead of the Realization-as-outparam variant
     template<typename... Args, typename std::enable_if<NoRealizations<Args...>::value>::type * = nullptr>
-    Realization realize(Args &&... args) {
+    Realization realize(Args &&...args) {
         this->check_scheduled("realize");
         return get_pipeline().realize(std::forward<Args>(args)..., get_target());
     }
@@ -3176,7 +3176,7 @@ public:
     }
 
     template<typename... Args>
-    HALIDE_NO_USER_CODE_INLINE void add_requirement(Expr condition, Args &&... args) {
+    HALIDE_NO_USER_CODE_INLINE void add_requirement(Expr condition, Args &&...args) {
         get_pipeline().add_requirement(condition, std::forward<Args>(args)...);
     }
 
@@ -3489,7 +3489,7 @@ public:
     using Internal::GeneratorBase::create;
 
     template<typename... Args>
-    void apply(const Args &... args) {
+    void apply(const Args &...args) {
 #ifndef _MSC_VER
         // VS2015 apparently has some SFINAE issues, so this can inappropriately
         // trigger there. (We'll still fail when generate() is called, just

--- a/src/IRMutator.h
+++ b/src/IRMutator.h
@@ -106,7 +106,7 @@ public:
 
 /** A helper function for mutator-like things to mutate regions */
 template<typename Mutator, typename... Args>
-std::pair<Region, bool> mutate_region(Mutator *mutator, const Region &bounds, Args &&... args) {
+std::pair<Region, bool> mutate_region(Mutator *mutator, const Region &bounds, Args &&...args) {
     Region new_bounds(bounds.size());
     bool bounds_changed = false;
 

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -312,13 +312,13 @@ inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &arg
 }
 
 template<typename... Args>
-inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &args, const char *arg, Args &&... more_args) {
+inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &args, const char *arg, Args &&...more_args) {
     args.emplace_back(std::string(arg));
     collect_print_args(args, std::forward<Args>(more_args)...);
 }
 
 template<typename... Args>
-inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &args, Expr arg, Args &&... more_args) {
+inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &args, Expr arg, Args &&...more_args) {
     args.push_back(std::move(arg));
     collect_print_args(args, std::forward<Args>(more_args)...);
 }
@@ -656,7 +656,7 @@ inline Expr max(Expr a, float b) {
  * The arguments can be any mix of types but must all be convertible to Expr. */
 template<typename A, typename B, typename C, typename... Rest,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Rest...>::value>::type * = nullptr>
-inline Expr max(A &&a, B &&b, C &&c, Rest &&... rest) {
+inline Expr max(A &&a, B &&b, C &&c, Rest &&...rest) {
     return max(std::forward<A>(a), max(std::forward<B>(b), std::forward<C>(c), std::forward<Rest>(rest)...));
 }
 
@@ -691,7 +691,7 @@ inline Expr min(Expr a, float b) {
  * The arguments can be any mix of types but must all be convertible to Expr. */
 template<typename A, typename B, typename C, typename... Rest,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Rest...>::value>::type * = nullptr>
-inline Expr min(A &&a, B &&b, C &&c, Rest &&... rest) {
+inline Expr min(A &&a, B &&b, C &&c, Rest &&...rest) {
     return min(std::forward<A>(a), min(std::forward<B>(b), std::forward<C>(c), std::forward<Rest>(rest)...));
 }
 
@@ -796,7 +796,7 @@ Expr select(Expr condition, Expr true_value, Expr false_value);
  * final value if all conditions are false. */
 template<typename... Args,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Args...>::value>::type * = nullptr>
-inline Expr select(Expr c0, Expr v0, Expr c1, Expr v1, Args &&... args) {
+inline Expr select(Expr c0, Expr v0, Expr c1, Expr v1, Args &&...args) {
     return select(std::move(c0), std::move(v0), select(std::move(c1), std::move(v1), std::forward<Args>(args)...));
 }
 
@@ -811,12 +811,12 @@ Tuple tuple_select(const Expr &condition, const Tuple &true_value, const Tuple &
  * a Tuple, it must match the size of the true and false Tuples. */
 // @{
 template<typename... Args>
-inline Tuple tuple_select(const Tuple &c0, const Tuple &v0, const Tuple &c1, const Tuple &v1, Args &&... args) {
+inline Tuple tuple_select(const Tuple &c0, const Tuple &v0, const Tuple &c1, const Tuple &v1, Args &&...args) {
     return tuple_select(c0, v0, tuple_select(c1, v1, std::forward<Args>(args)...));
 }
 
 template<typename... Args>
-inline Tuple tuple_select(const Expr &c0, const Tuple &v0, const Expr &c1, const Tuple &v1, Args &&... args) {
+inline Tuple tuple_select(const Expr &c0, const Tuple &v0, const Expr &c1, const Tuple &v1, Args &&...args) {
     return tuple_select(c0, v0, tuple_select(c1, v1, std::forward<Args>(args)...));
 }
 // @}
@@ -1244,7 +1244,7 @@ Expr random_int(Expr seed = Expr());
 Expr print(const std::vector<Expr> &values);
 
 template<typename... Args>
-inline HALIDE_NO_USER_CODE_INLINE Expr print(Expr a, Args &&... args) {
+inline HALIDE_NO_USER_CODE_INLINE Expr print(Expr a, Args &&...args) {
     std::vector<Expr> collected_args = {std::move(a)};
     Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
     return print(collected_args);
@@ -1257,7 +1257,7 @@ inline HALIDE_NO_USER_CODE_INLINE Expr print(Expr a, Args &&... args) {
 Expr print_when(Expr condition, const std::vector<Expr> &values);
 
 template<typename... Args>
-inline HALIDE_NO_USER_CODE_INLINE Expr print_when(Expr condition, Expr a, Args &&... args) {
+inline HALIDE_NO_USER_CODE_INLINE Expr print_when(Expr condition, Expr a, Args &&...args) {
     std::vector<Expr> collected_args = {std::move(a)};
     Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
     return print_when(std::move(condition), collected_args);
@@ -1290,7 +1290,7 @@ inline HALIDE_NO_USER_CODE_INLINE Expr print_when(Expr condition, Expr a, Args &
 Expr require(Expr condition, const std::vector<Expr> &values);
 
 template<typename... Args>
-inline HALIDE_NO_USER_CODE_INLINE Expr require(Expr condition, Expr value, Args &&... args) {
+inline HALIDE_NO_USER_CODE_INLINE Expr require(Expr condition, Expr value, Args &&...args) {
     std::vector<Expr> collected_args = {std::move(value)};
     Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
     return require(std::move(condition), collected_args);
@@ -1350,7 +1350,7 @@ inline Expr undef() {
  * on the digest. */
 // @{
 template<typename... Args>
-inline HALIDE_NO_USER_CODE_INLINE Expr memoize_tag(Expr result, Args &&... args) {
+inline HALIDE_NO_USER_CODE_INLINE Expr memoize_tag(Expr result, Args &&...args) {
     std::vector<Expr> collected_args{std::forward<Args>(args)...};
     return Internal::memoize_tag_helper(std::move(result), collected_args);
 }
@@ -1502,12 +1502,12 @@ Expr scatter(const std::vector<Expr> &args);
 Expr gather(const std::vector<Expr> &args);
 
 template<typename... Args>
-Expr scatter(const Expr &e, Args &&... args) {
+Expr scatter(const Expr &e, Args &&...args) {
     return scatter({e, std::forward<Args>(args)...});
 }
 
 template<typename... Args>
-Expr gather(const Expr &e, Args &&... args) {
+Expr gather(const Expr &e, Args &&...args) {
     return gather({e, std::forward<Args>(args)...});
 }
 // @}

--- a/src/IRVisitor.h
+++ b/src/IRVisitor.h
@@ -157,7 +157,7 @@ template<typename T, typename ExprRet, typename StmtRet>
 class VariadicVisitor {
 private:
     template<typename... Args>
-    ExprRet dispatch_expr(const BaseExprNode *node, Args &&... args) {
+    ExprRet dispatch_expr(const BaseExprNode *node, Args &&...args) {
         if (node == nullptr) {
             return ExprRet{};
         };
@@ -247,7 +247,7 @@ private:
     }
 
     template<typename... Args>
-    StmtRet dispatch_stmt(const BaseStmtNode *node, Args &&... args) {
+    StmtRet dispatch_stmt(const BaseStmtNode *node, Args &&...args) {
         if (node == nullptr) {
             return StmtRet{};
         };
@@ -322,22 +322,22 @@ private:
 
 public:
     template<typename... Args>
-    HALIDE_ALWAYS_INLINE StmtRet dispatch(const Stmt &s, Args &&... args) {
+    HALIDE_ALWAYS_INLINE StmtRet dispatch(const Stmt &s, Args &&...args) {
         return dispatch_stmt(s.get(), std::forward<Args>(args)...);
     }
 
     template<typename... Args>
-    HALIDE_ALWAYS_INLINE StmtRet dispatch(Stmt &&s, Args &&... args) {
+    HALIDE_ALWAYS_INLINE StmtRet dispatch(Stmt &&s, Args &&...args) {
         return dispatch_stmt(s.get(), std::forward<Args>(args)...);
     }
 
     template<typename... Args>
-    HALIDE_ALWAYS_INLINE ExprRet dispatch(const Expr &e, Args &&... args) {
+    HALIDE_ALWAYS_INLINE ExprRet dispatch(const Expr &e, Args &&...args) {
         return dispatch_expr(e.get(), std::forward<Args>(args)...);
     }
 
     template<typename... Args>
-    HALIDE_ALWAYS_INLINE ExprRet dispatch(Expr &&e, Args &&... args) {
+    HALIDE_ALWAYS_INLINE ExprRet dispatch(Expr &&e, Args &&...args) {
         return dispatch_expr(e.get(), std::forward<Args>(args)...);
     }
 };

--- a/src/ImageParam.h
+++ b/src/ImageParam.h
@@ -64,7 +64,7 @@ public:
      */
     // @{
     template<typename... Args>
-    HALIDE_NO_USER_CODE_INLINE Expr operator()(Args &&... args) const {
+    HALIDE_NO_USER_CODE_INLINE Expr operator()(Args &&...args) const {
         return func(std::forward<Args>(args)...);
     }
     Expr operator()(std::vector<Expr>) const;

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -121,7 +121,7 @@ public:
         }
         template<typename T, typename... Args,
                  typename = typename std::enable_if<Internal::all_are_convertible<Buffer<>, Args...>::value>::type>
-        RealizationArg(Buffer<T> &a, Args &&... args) {
+        RealizationArg(Buffer<T> &a, Args &&...args) {
             buffer_list.reset(new std::vector<Buffer<>>({a, args...}));
         }
         RealizationArg(RealizationArg &&from) = default;
@@ -564,7 +564,7 @@ public:
     void trace_pipeline();
 
     template<typename... Args>
-    inline HALIDE_NO_USER_CODE_INLINE void add_requirement(const Expr &condition, Args &&... args) {
+    inline HALIDE_NO_USER_CODE_INLINE void add_requirement(const Expr &condition, Args &&...args) {
         std::vector<Expr> collected_args;
         Internal::collect_print_args(collected_args, std::forward<Args>(args)...);
         add_requirement(condition, collected_args);

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -198,7 +198,7 @@ class RDom {
     void initialize_from_region(const Region &region, std::string name = "");
 
     template<typename... Args>
-    HALIDE_NO_USER_CODE_INLINE void initialize_from_region(Region &region, const Expr &min, const Expr &extent, Args &&... args) {
+    HALIDE_NO_USER_CODE_INLINE void initialize_from_region(Region &region, const Expr &min, const Expr &extent, Args &&...args) {
         region.push_back({min, extent});
         initialize_from_region(region, std::forward<Args>(args)...);
     }
@@ -215,7 +215,7 @@ public:
     }
 
     template<typename... Args>
-    HALIDE_NO_USER_CODE_INLINE RDom(Expr min, Expr extent, Args &&... args) {
+    HALIDE_NO_USER_CODE_INLINE RDom(Expr min, Expr extent, Args &&...args) {
         // This should really just be a delegating constructor, but I couldn't make
         // that work with variadic template unpacking in visual studio 2013
         Region region;

--- a/src/Realization.h
+++ b/src/Realization.h
@@ -44,7 +44,7 @@ public:
     template<typename T,
              typename... Args,
              typename = typename std::enable_if<Internal::all_are_convertible<Buffer<void>, Args...>::value>::type>
-    Realization(Buffer<T> &a, Args &&... args) {
+    Realization(Buffer<T> &a, Args &&...args) {
         images = std::vector<Buffer<void>>({a, args...});
     }
 

--- a/src/Tuple.h
+++ b/src/Tuple.h
@@ -45,7 +45,7 @@ public:
     /** Construct a Tuple from some Exprs. */
     //@{
     template<typename... Args>
-    Tuple(const Expr &a, const Expr &b, Args &&... args) {
+    Tuple(const Expr &a, const Expr &b, Args &&...args) {
         exprs = std::vector<Expr>{a, b, std::forward<Args>(args)...};
     }
     //@}

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -928,7 +928,7 @@ public:
      * host_dirty flag. */
     template<typename... Args,
              typename = typename std::enable_if<AllInts<Args...>::value>::type>
-    explicit Buffer(halide_type_t t, add_const_if_T_is_const<void> *data, int first, Args &&... rest) {
+    explicit Buffer(halide_type_t t, add_const_if_T_is_const<void> *data, int first, Args &&...rest) {
         if (!T_is_void) {
             assert(static_halide_type() == t);
         }
@@ -945,7 +945,7 @@ public:
      * take ownership of the data and does not set the host_dirty flag. */
     template<typename... Args,
              typename = typename std::enable_if<AllInts<Args...>::value>::type>
-    explicit Buffer(T *data, int first, Args &&... rest) {
+    explicit Buffer(T *data, int first, Args &&...rest) {
         int extents[] = {first, (int)rest...};
         buf.type = static_halide_type();
         constexpr int buf_dimensions = 1 + (int)(sizeof...(rest));
@@ -2075,7 +2075,7 @@ private:
     }
 
     template<typename Fn, typename... Args, int N = sizeof...(Args) + 1>
-    void for_each_value_impl(Fn &&f, Args &&... other_buffers) const {
+    void for_each_value_impl(Fn &&f, Args &&...other_buffers) const {
         Buffer<>::for_each_value_task_dim<N> *t =
             (Buffer<>::for_each_value_task_dim<N> *)HALIDE_ALLOCA((dimensions() + 1) * sizeof(for_each_value_task_dim<N>));
         // Move the preparatory code into a non-templated helper to
@@ -2107,7 +2107,7 @@ public:
      * will result in a compilation error. */
     // @{
     template<typename Fn, typename... Args, int N = sizeof...(Args) + 1>
-    HALIDE_ALWAYS_INLINE const Buffer<T, D> &for_each_value(Fn &&f, Args &&... other_buffers) const {
+    HALIDE_ALWAYS_INLINE const Buffer<T, D> &for_each_value(Fn &&f, Args &&...other_buffers) const {
         for_each_value_impl(f, std::forward<Args>(other_buffers)...);
         return *this;
     }
@@ -2115,7 +2115,7 @@ public:
     template<typename Fn, typename... Args, int N = sizeof...(Args) + 1>
     HALIDE_ALWAYS_INLINE
         Buffer<T, D> &
-        for_each_value(Fn &&f, Args &&... other_buffers) {
+        for_each_value(Fn &&f, Args &&...other_buffers) {
         for_each_value_impl(f, std::forward<Args>(other_buffers)...);
         return *this;
     }

--- a/tools/RunGen.h
+++ b/tools/RunGen.h
@@ -203,7 +203,7 @@ inline constexpr int halide_type_code(halide_type_code_t code, int bits) {
 // variants *will* be instantiated (increasing code size), so this approach
 // should only be used when strictly necessary.
 template<template<typename> class Functor, typename... Args>
-auto dynamic_type_dispatch(const halide_type_t &type, Args &&... args) -> decltype(std::declval<Functor<uint8_t>>()(std::forward<Args>(args)...)) {
+auto dynamic_type_dispatch(const halide_type_t &type, Args &&...args) -> decltype(std::declval<Functor<uint8_t>>()(std::forward<Args>(args)...)) {
 
 #define HANDLE_CASE(CODE, BITS, TYPE)  \
     case halide_type_code(CODE, BITS): \


### PR DESCRIPTION
Reformat code as necessary due to trivial differences in v10 vs v11.

Motivation: (1) keep tooling up to date, (2) make it easier to drop support for LLVM10 from master.