### PR TITLE
Add initial support for RISCV RVV features

### DIFF
--- a/python_bindings/src/PyEnums.cpp
+++ b/python_bindings/src/PyEnums.cpp
@@ -78,6 +78,7 @@ void define_enums(py::module &m) {
         .value("MIPS", Target::Arch::MIPS)
         .value("Hexagon", Target::Arch::Hexagon)
         .value("POWERPC", Target::Arch::POWERPC)
+        .value("RISCV", Target::Arch::RISCV)
         .value("WebAssembly", Target::Arch::WebAssembly);
 
     py::enum_<Target::Feature>(m, "TargetFeature")
@@ -149,6 +150,7 @@ void define_enums(py::module &m) {
         .value("SVE2", Target::Feature::SVE2)
         .value("ARMDotProd", Target::Feature::ARMDotProd)
         .value("LLVMLargeCodeModel", Target::Feature::LLVMLargeCodeModel)
+        .value("RVV", Target::Feature::RVV)
         .value("FeatureEnd", Target::Feature::FeatureEnd);
 
     py::enum_<halide_type_code_t>(m, "TypeCode")

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -670,6 +670,8 @@ void get_target_options(const llvm::Module &module, llvm::TargetOptions &options
     get_md_bool(module.getModuleFlag("halide_use_soft_float_abi"), use_soft_float_abi);
     get_md_string(module.getModuleFlag("halide_mcpu"), mcpu);
     get_md_string(module.getModuleFlag("halide_mattrs"), mattrs);
+    std::string mabi;
+    get_md_string(module.getModuleFlag("halide_mabi"), mabi);
     bool use_pic = true;
     get_md_bool(module.getModuleFlag("halide_use_pic"), use_pic);
 
@@ -690,6 +692,7 @@ void get_target_options(const llvm::Module &module, llvm::TargetOptions &options
     options.FloatABIType =
         use_soft_float_abi ? llvm::FloatABI::Soft : llvm::FloatABI::Hard;
     options.RelaxELFRelocations = false;
+    options.MCOptions.ABIName = mabi;
 }
 
 void clone_target_options(const llvm::Module &from, llvm::Module &to) {

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -505,6 +505,7 @@ void CodeGen_LLVM::init_codegen(const std::string &name, bool any_strict_float) 
     module->addModuleFlag(llvm::Module::Warning, "halide_use_soft_float_abi", use_soft_float_abi() ? 1 : 0);
     module->addModuleFlag(llvm::Module::Warning, "halide_mcpu", MDString::get(*context, mcpu()));
     module->addModuleFlag(llvm::Module::Warning, "halide_mattrs", MDString::get(*context, mattrs()));
+    module->addModuleFlag(llvm::Module::Warning, "halide_mabi", MDString::get(*context, mabi()));
     module->addModuleFlag(llvm::Module::Warning, "halide_use_pic", use_pic() ? 1 : 0);
     module->addModuleFlag(llvm::Module::Warning, "halide_use_large_code_model", llvm_large_code_model ? 1 : 0);
     module->addModuleFlag(llvm::Module::Warning, "halide_per_instruction_fast_math_flags", any_strict_float);
@@ -5100,6 +5101,10 @@ bool CodeGen_LLVM::supports_atomic_add(const Type &t) const {
 
 bool CodeGen_LLVM::use_pic() const {
     return true;
+}
+
+std::string CodeGen_LLVM::mabi() const {
+    return "";
 }
 
 }  // namespace Internal

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -112,6 +112,7 @@ protected:
     // @{
     virtual std::string mcpu() const = 0;
     virtual std::string mattrs() const = 0;
+    virtual std::string mabi() const;
     virtual bool use_soft_float_abi() const = 0;
     virtual bool use_pic() const;
     // @}

--- a/src/CodeGen_RISCV.cpp
+++ b/src/CodeGen_RISCV.cpp
@@ -21,11 +21,36 @@ string CodeGen_RISCV::mcpu() const {
 }
 
 string CodeGen_RISCV::mattrs() const {
-    return "";
+    // Note: the default march is "rv[32|64]imafdc",
+    // which includes standard extensions:
+    //   +m Integer Multiplication and Division,
+    //   +a Atomic Instructions,
+    //   +f Single-Precision Floating-Point,
+    //   +d Double-Precision Floating-Point,
+    //   +c Compressed Instructions,
+    string arch_flags = "+m,+a,+f,+d,+c";
+
+    if (target.has_feature(Target::RVV)) {
+        arch_flags += ",+experimental-v";
+    }
+    return arch_flags;
+}
+
+string CodeGen_RISCV::mabi() const {
+    string abi;
+    if (target.bits == 32) {
+        abi = "lp32";
+    } else {
+        abi = "lp64";
+    }
+    if (!target.has_feature(Target::SoftFloatABI)) {
+        abi += "d";
+    }
+    return abi;
 }
 
 bool CodeGen_RISCV::use_soft_float_abi() const {
-    return false;
+    return target.has_feature(Target::SoftFloatABI);
 }
 
 int CodeGen_RISCV::native_vector_bits() const {

--- a/src/CodeGen_RISCV.h
+++ b/src/CodeGen_RISCV.h
@@ -22,6 +22,7 @@ protected:
 
     std::string mcpu() const override;
     std::string mattrs() const override;
+    std::string mabi() const override;
     bool use_soft_float_abi() const override;
     int native_vector_bits() const override;
 };

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -387,6 +387,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"sve2", Target::SVE2},
     {"arm_dot_prod", Target::ARMDotProd},
     {"llvm_large_code_model", Target::LLVMLargeCodeModel},
+    {"rvv", Target::RVV},
     // NOTE: When adding features to this map, be sure to update PyEnums.cpp as well.
 };
 

--- a/src/Target.h
+++ b/src/Target.h
@@ -127,6 +127,7 @@ struct Target {
         SVE2 = halide_target_feature_sve2,
         ARMDotProd = halide_target_feature_arm_dot_prod,
         LLVMLargeCodeModel = halide_llvm_large_code_model,
+        RVV = halide_target_feature_rvv,
         FeatureEnd = halide_target_feature_end
     };
     Target() = default;

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1335,6 +1335,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_egl,                    ///< Force use of EGL support.
     halide_target_feature_arm_dot_prod,           ///< Enable ARMv8.2-a dotprod extension (i.e. udot and sdot instructions)
     halide_llvm_large_code_model,                 ///< Use the LLVM large code model to compile
+    halide_target_feature_rvv,                    ///< Enable RISCV "V" Vector Extension
     halide_target_feature_end                     ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 


### PR DESCRIPTION
`mabi` is introduced because target triple doesn't encode ABI info,
and `HL_LLVM_ARGS="-riscv-v-vector-bits-min 128"` is required to enable fixed vectors to RVV codegen.