### PR TITLE
Constrain calling convention for PyStub

### DIFF
--- a/python_bindings/correctness/pystub.py
+++ b/python_bindings/correctness/pystub.py
@@ -36,40 +36,57 @@ def test_simplestub():
     f = simplestub.generate(target, buffer_input=b_in, func_input=f_in, float_arg=3.5)
     _realize_and_check(f)
 
-    # ----------- Inputs w/ mixed by-position and by-name
-    f = simplestub.generate(target, b_in, f_in, float_arg=3.5)
-    _realize_and_check(f)
-
-    f = simplestub.generate(target, b_in, float_arg=3.5, func_input=f_in)
+    f = simplestub.generate(target, float_arg=3.5, buffer_input=b_in, func_input=f_in)
     _realize_and_check(f)
 
     # ----------- Above set again, w/ GeneratorParam mixed in
     k = 42
 
+    # (positional)
     f = simplestub.generate(target, b_in, f_in, 3.5, offset=k)
     _realize_and_check(f, k)
 
+    # (keyword)
     f = simplestub.generate(target, offset=k, buffer_input=b_in, func_input=f_in, float_arg=3.5)
     _realize_and_check(f, k)
 
-    f = simplestub.generate(target, b_in, f_in, offset=k, float_arg=3.5)
+    f = simplestub.generate(target, buffer_input=b_in, offset=k, func_input=f_in, float_arg=3.5)
     _realize_and_check(f, k)
 
-    f = simplestub.generate(target, b_in, float_arg=3.5, offset=k, func_input=f_in)
+    f = simplestub.generate(target, buffer_input=b_in, func_input=f_in, offset=k, float_arg=3.5)
+    _realize_and_check(f, k)
+
+    f = simplestub.generate(target, buffer_input=b_in, float_arg=3.5, func_input=f_in, offset=k)
     _realize_and_check(f, k)
 
     # ----------- Test various failure modes
     try:
+        # Inputs w/ mixed by-position and by-name
+        f = simplestub.generate(target, b_in, f_in, float_arg=3.5)
+    except RuntimeError as e:
+        assert 'Cannot use both positional and keyword arguments for inputs.' in str(e)
+    else:
+        assert False, 'Did not see expected exception!'
+
+    try:
         # too many positional args
         f = simplestub.generate(target, b_in, f_in, 3.5, 4)
     except RuntimeError as e:
-        assert 'Expected at most 3 positional args, but saw 4.' in str(e)
+        assert 'Expected exactly 3 positional args for inputs, but saw 4.' in str(e)
+    else:
+        assert False, 'Did not see expected exception!'
+
+    try:
+        # too few positional args
+        f = simplestub.generate(target, b_in, f_in)
+    except RuntimeError as e:
+        assert 'Expected exactly 3 positional args for inputs, but saw 2.' in str(e)
     else:
         assert False, 'Did not see expected exception!'
 
     try:
         # Inputs that can't be converted to what the receiver needs (positional)
-        f = simplestub.generate(target, 3.141592, "happy")
+        f = simplestub.generate(target, hl.f32(3.141592), "happy", k)
     except RuntimeError as e:
         assert 'Unable to cast Python instance' in str(e)
     else:
@@ -84,32 +101,24 @@ def test_simplestub():
         assert False, 'Did not see expected exception!'
 
     try:
-        # Missing required inputs
-        f = simplestub.generate(target, b_in, f_in)
-    except RuntimeError as e:
-        assert "Generator Input named 'float_arg' was not specified." in str(e)
-    else:
-        assert False, 'Did not see expected exception!'
-
-    try:
         # Input specified by both pos and kwarg
         f = simplestub.generate(target, b_in, f_in, 3.5, float_arg=4.5)
     except RuntimeError as e:
-        assert "Generator Input named 'float_arg' was specified by both position and keyword." in str(e)
+        assert "Cannot use both positional and keyword arguments for inputs." in str(e)
     else:
         assert False, 'Did not see expected exception!'
 
     try:
         # Bad input name
-        f = simplestub.generate(target, b_in, float_arg=3.5, offset=k, funk_input=f_in)
+        f = simplestub.generate(target, buffer_input=b_in, float_arg=3.5, offset=k, funk_input=f_in)
     except RuntimeError as e:
-        assert "Generator Input named 'func_input' was not specified." in str(e)
+        assert "Expected exactly 3 keyword args for inputs, but saw 2." in str(e)
     else:
         assert False, 'Did not see expected exception!'
 
     try:
         # Bad gp name
-        f = simplestub.generate(target, b_in, float_arg=3.5, offset=k, func_input=f_in, nonexistent_generator_param="wat")
+        f = simplestub.generate(target, buffer_input=b_in, float_arg=3.5, offset=k, func_input=f_in, nonexistent_generator_param="wat")
     except RuntimeError as e:
         assert "Generator simplestub has no GeneratorParam named: nonexistent_generator_param" in str(e)
     else:

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -90,13 +90,15 @@ StubInput to_stub_input(const py::object &o) {
     return StubInput(o.cast<Expr>());
 }
 
-void append_input(const py::object &value, std::vector<StubInput> &v) {
+std::vector<StubInput> to_stub_inputs(const py::object &value) {
     if (is_real_sequence(value)) {
+        std::vector<StubInput> v;
         for (const auto &o : py::reinterpret_borrow<py::sequence>(value)) {
             v.push_back(to_stub_input(o));
         }
+        return v;
     } else {
-        v.push_back(to_stub_input(value));
+        return {to_stub_input(value)};
     }
 }
 
@@ -107,18 +109,20 @@ py::object generate_impl(FactoryFunc factory, const GeneratorContext &context, c
     auto names = stub.get_names();
     _halide_user_assert(!names.outputs.empty())
         << "Generators that use build() (instead of generate()+Output<>) are not supported in the Python bindings.";
-    std::map<std::string, size_t> input_name_to_pos;
-    for (size_t i = 0; i < names.inputs.size(); ++i) {
-        input_name_to_pos[names.inputs[i]] = i;
-    }
 
     // Inputs can be specified by either positional or named args,
-    // and must all be specified.
+    // but may not be mixed. (i.e., if any inputs are specified as a named
+    // arg, they all must be specified that way; otherwise they must all be
+    // positional, in the order declared in the Generator.)
     //
     // GeneratorParams can only be specified by name, and are always optional.
-    //
-    std::vector<std::vector<StubInput>> inputs;
-    inputs.resize(names.inputs.size());
+
+    std::map<std::string, std::vector<StubInput>> kw_inputs;
+    for (const auto &name : names.inputs) {
+        _halide_user_assert(kw_inputs.count(name) == 0);  // internal error
+        kw_inputs[name] = std::vector<StubInput>{};
+    }
+    size_t kw_inputs_specified = 0;
 
     GeneratorParamsMap generator_params;
 
@@ -127,29 +131,46 @@ py::object generate_impl(FactoryFunc factory, const GeneratorContext &context, c
         // If the kwarg is the name of a known input, stick it in the input
         // vector. If not, stick it in the GeneratorParamsMap (if it's invalid,
         // an error will be reported further downstream).
-        std::string key = kw.first.cast<std::string>();
+        std::string name = kw.first.cast<std::string>();
         py::handle value = kw.second;
-        auto it = input_name_to_pos.find(key);
-        if (it != input_name_to_pos.end()) {
-            append_input(py::cast<py::object>(value), inputs[it->second]);
+        auto it = kw_inputs.find(name);
+        if (it != kw_inputs.end()) {
+            _halide_user_assert(it->second.empty())
+                << "Generator Input named '" << it->first << "' was specified more than once.";
+            it->second = to_stub_inputs(py::cast<py::object>(value));
+            kw_inputs_specified++;
         } else {
             if (py::isinstance<LoopLevel>(value)) {
-                generator_params[key] = value.cast<LoopLevel>();
+                generator_params[name] = value.cast<LoopLevel>();
             } else {
-                generator_params[key] = py::str(value).cast<std::string>();
+                generator_params[name] = py::str(value).cast<std::string>();
             }
         }
     }
 
-    // Now, the positional args.
-    _halide_user_assert(args.size() <= names.inputs.size())
-        << "Expected at most " << names.inputs.size() << " positional args, but saw " << args.size() << ".";
-    for (size_t i = 0; i < args.size(); ++i) {
-        _halide_user_assert(inputs[i].empty())
-            << "Generator Input named '" << names.inputs[i] << "' was specified by both position and keyword.";
-        append_input(args[i], inputs[i]);
+    std::vector<std::vector<StubInput>> inputs;
+    inputs.reserve(names.inputs.size());
+
+    if (args.empty()) {
+        // No arguments specified positionally, so they must all be via keywords.
+        _halide_user_assert(kw_inputs_specified == names.inputs.size())
+            << "Expected exactly " << names.inputs.size() << " keyword args for inputs, but saw " << kw_inputs_specified << ".";
+        for (const auto &name : names.inputs) {
+            inputs.push_back(std::move(kw_inputs[name]));
+        }
+    } else {
+        // Some positional arguments, so all inputs must be positional (and none via keyword).
+        _halide_user_assert(kw_inputs_specified == 0)
+            << "Cannot use both positional and keyword arguments for inputs.";
+        _halide_user_assert(args.size() == names.inputs.size())
+            << "Expected exactly " << names.inputs.size() << " positional args for inputs, but saw " << args.size() << ".";
+        for (auto arg : args) {
+            inputs.push_back(to_stub_inputs(py::cast<py::object>(arg)));
+        }
     }
 
+    // Verify everything is there
+    _halide_user_assert(inputs.size() == names.inputs.size());
     for (size_t i = 0; i < inputs.size(); ++i) {
         _halide_user_assert(!inputs[i].empty())
             << "Generator Input named '" << names.inputs[i] << "' was not specified.";


### PR DESCRIPTION
There are two calling conventions that are sensible when calling a Generator from Python:
- Inputs are specified via keyword arguments (verbose but more readable)
- Inputs are specified via positional arguments (terse but more like C++)

However, the current PyStub implementation also allows for mixing positional and keyword forms of input (as long as no input is specified multiple times). This change removes that possibility (requiring either all-keyword or all-positional for inputs). I'm not sure why I thought this was a good option originally, but upon reflection (and examination of existing code), calls written in this way tend to be a confusing mess that require too much care when reading, and I think we'd be better off just forbidding this entirely.

Note that this technically is a breaking API change (thus the `release_notes` label); any user code that used this technique previously would now throw an exception and need a (trivial) update. That said, this is (AFAIK) a very rarely used API, and I rather suspect that existing code that relies on being able to mix positional and keyword inputs in this way is likely to be doing so inadvertently rather than deliberately.