### PR TITLE
Add TailStrategy::RoundUp to internal stages of local_laplacian and interpolate

### DIFF
--- a/apps/interpolate/interpolate_generator.cpp
+++ b/apps/interpolate/interpolate_generator.cpp
@@ -151,7 +151,7 @@ public:
                         .reorder(x, c, y)
                         .split(y, yo, yi, 8)
                         .parallel(yo)
-                        .vectorize(x, vec);
+                        .vectorize(x, vec, TailStrategy::RoundUp);
                 }
 
                 // downsampled[0] takes too long to compute_root, so
@@ -165,7 +165,7 @@ public:
                     .compute_at(downsampled[1], yi)
                     .reorder(c, x, y)
                     .unroll(c)
-                    .vectorize(x, vec);
+                    .vectorize(x, vec, TailStrategy::RoundUp);
 
                 normalize
                     .bound(x, 0, input.width())
@@ -182,7 +182,7 @@ public:
                     interpolated[l]
                         .store_at(normalize, yo)
                         .compute_at(normalize, yi)
-                        .vectorize(x, vec);
+                        .vectorize(x, vec, TailStrategy::RoundUp);
                 }
 
                 output = normalize;

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -133,25 +133,25 @@ public:
             remap.compute_root();
             Var yo;
             output.reorder(c, x, y).split(y, yo, y, 64).parallel(yo).vectorize(x, 8);
-            gray.compute_root().parallel(y, 32).vectorize(x, 8);
+            gray.compute_root().parallel(y, 32).vectorize(x, 8, TailStrategy::RoundUp);
             for (int j = 1; j < 5; j++) {
                 inGPyramid[j]
                     .compute_root()
                     .parallel(y, 32)
-                    .vectorize(x, 8);
+                    .vectorize(x, 8, TailStrategy::RoundUp);
                 gPyramid[j]
                     .compute_root()
                     .reorder_storage(x, k, y)
                     .reorder(k, y)
                     .parallel(y, 8)
-                    .vectorize(x, 8);
+                    .vectorize(x, 8, TailStrategy::RoundUp);
                 outGPyramid[j]
                     .store_at(output, yo)
                     .compute_at(output, y)
                     .fold_storage(y, 8)
-                    .vectorize(x, 8);
+                    .vectorize(x, 8, TailStrategy::RoundUp);
             }
-            outGPyramid[0].compute_at(output, y).vectorize(x, 8);
+            outGPyramid[0].compute_at(output, y).vectorize(x, 8, TailStrategy::RoundUp);
             for (int j = 5; j < J; j++) {
                 inGPyramid[j].compute_root();
                 gPyramid[j].compute_root().parallel(k);


### PR DESCRIPTION
This reduces the size and complexity of the IR we generate, which makes debugging issues easier (and code size/compile time a little smaller).