### PR TITLE
Track time spent in malloc/free when profiling

### DIFF
--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -83,7 +83,7 @@ private:
         return idx;
     }
 
-    Stmt set_current_func(Expr id) {
+    Stmt set_current_func(const Expr &id) {
         // This call gets inlined and becomes a single store instruction.
         return Evaluate::make(Call::make(Int(32), "halide_profiler_set_current_func",
                                          {profiler_state, profiler_token, id}, Call::Extern));

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -33,11 +33,11 @@ public:
     InjectProfiling(const string &pipeline_name)
         : pipeline_name(pipeline_name) {
         stack.push_back(get_func_id("overhead"));
+        // ID 0 is treated specially in the runtime as overhead
+        internal_assert(stack.back() == 0);
+
         malloc_id = get_func_id("halide_malloc");
         free_id = get_func_id("halide_free");
-        internal_assert(stack.back() == 0);
-        internal_assert(malloc_id == 1);
-        internal_assert(free_id == 2);
         profiler_pipeline_state = Variable::make(Handle(), "profiler_pipeline_state");
         profiler_state = Variable::make(Handle(), "profiler_state");
         profiler_token = Variable::make(Int(32), "profiler_token");


### PR DESCRIPTION
This PR separates out time spent in malloc and free in the profiling log. Here's an example where it would have been useful to me today:

Local laplacian before. Note that _output_ has weirdly low average threads doing work.
```
local_laplacian
 total time: 199.233002 ms  samples: 186  runs: 11  time/run: 18.112091 ms
 average threads used: 12.333333
 heap allocations: 30129  peak heap usage: 90842968 bytes
  f0:                    0.000ms   (0%)    threads: 0.000  peak: 14340    num: 11        avg: 14340
  f2:                    1.282ms   (7%)    threads: 9.785  peak: 22571024 num: 11        avg: 22571024
  f4:                    8.930ms   (49%)   threads: 15.397 peak: 45064320 num: 11        avg: 45064320
  f5:                    1.243ms   (6%)    threads: 13.500 peak: 11227264 num: 11        avg: 11227264
  f72:                   0.386ms   (2%)    threads: 15.250 peak: 5633040  num: 11        avg: 5633040
  f6:                    0.289ms   (1%)    threads: 6.000  peak: 2787456  num: 11        avg: 2787456
  f73:                   0.386ms   (2%)    threads: 8.000  peak: 1403408  num: 11        avg: 1403408
  f7:                    0.000ms   (0%)    threads: 0.000  peak: 687232   num: 11        avg: 687232
  f74:                   0.000ms   (0%)    threads: 0.000  peak: 348432   num: 11        avg: 348432
  f8:                    0.000ms   (0%)    threads: 0.000  peak: 167040   num: 11        avg: 167040
  f75:                   0.000ms   (0%)    threads: 0.000  peak: 85904    num: 11        avg: 85904
  f9:                    0.000ms   (0%)    threads: 0.000  peak: 39424    num: 11        avg: 39424
  f76:                   0.000ms   (0%)    threads: 0.000  peak: 20880    num: 11        avg: 20880
  f10:                   0.000ms   (0%)    threads: 0.000  peak: 8736     num: 11        avg: 8736
  f77:                   0.000ms   (0%)    threads: 0.000  peak: 4928     num: 11        avg: 4928
  f78:                   0.000ms   (0%)    threads: 0.000  peak: 1092     num: 11        avg: 1092
  f132:                  0.096ms   (0%)    threads: 1.000  peak: 1092     num: 11        avg: 1092
  f131:                  0.000ms   (0%)    threads: 0.000  peak: 4100     num: 11        avg: 4100
  f130:                  0.096ms   (0%)    threads: 1.000  peak: 15876    num: 11        avg: 15876
  output:                2.779ms   (15%)   threads: 4.034 
  f129:                  0.000ms   (0%)    threads: 0.000  peak: 49664    num: 440       avg: 3104
  f128:                  0.096ms   (0%)    threads: 16.000 peak: 98816    num: 440       avg: 6176
  f127:                  0.288ms   (1%)    threads: 13.333 peak: 197120   num: 440       avg: 12320
  f126:                  1.274ms   (7%)    threads: 14.454 peak: 393728   num: 440       avg: 24608
  f125:                  0.961ms   (5%)    threads: 11.800 peak: 98304    num: 28160     avg: 6144

```

Local laplacian after: Oh, it's because the frees for the entire pipeline are outside _output_'s parallel loop, but still included in its billing. Much clearer.

```
local_laplacian
 total time: 199.607239 ms  samples: 186  runs: 11  time/run: 18.146112 ms
 average threads used: 12.435484
 heap allocations: 30129  peak heap usage: 90842968 bytes
  halide_malloc:         0.096ms   (0%)    threads: 16.000
  halide_free:           2.492ms   (13%)   threads: 2.423 
  f0:                    0.000ms   (0%)    threads: 0.000  peak: 14340    num: 11        avg: 14340
  f2:                    1.073ms   (5%)    threads: 11.666 peak: 22571024 num: 11        avg: 22571024
  f4:                    9.283ms   (51%)   threads: 15.032 peak: 45064320 num: 11        avg: 45064320
  f5:                    1.063ms   (5%)    threads: 15.909 peak: 11227264 num: 11        avg: 11227264
  f72:                   0.482ms   (2%)    threads: 9.000  peak: 5633040  num: 11        avg: 5633040
  f6:                    0.193ms   (1%)    threads: 15.000 peak: 2787456  num: 11        avg: 2787456
  f73:                   0.289ms   (1%)    threads: 15.000 peak: 1403408  num: 11        avg: 1403408
  f7:                    0.192ms   (1%)    threads: 0.500  peak: 687232   num: 11        avg: 687232
  f74:                   0.000ms   (0%)    threads: 0.000  peak: 348432   num: 11        avg: 348432
  f8:                    0.000ms   (0%)    threads: 0.000  peak: 167040   num: 11        avg: 167040
  f75:                   0.000ms   (0%)    threads: 0.000  peak: 85904    num: 11        avg: 85904
  f9:                    0.000ms   (0%)    threads: 0.000  peak: 39424    num: 11        avg: 39424
  f76:                   0.000ms   (0%)    threads: 0.000  peak: 20880    num: 11        avg: 20880
  f10:                   0.096ms   (0%)    threads: 0.000  peak: 8736     num: 11        avg: 8736
  f77:                   0.000ms   (0%)    threads: 0.000  peak: 4928     num: 11        avg: 4928
  f78:                   0.000ms   (0%)    threads: 0.000  peak: 1092     num: 11        avg: 1092
  f132:                  0.000ms   (0%)    threads: 0.000  peak: 1092     num: 11        avg: 1092
  f131:                  0.000ms   (0%)    threads: 0.000  peak: 4100     num: 11        avg: 4100
  f130:                  0.000ms   (0%)    threads: 0.000  peak: 15876    num: 11        avg: 15876
  output:                1.345ms   (7%)    threads: 12.500
  f129:                  0.000ms   (0%)    threads: 0.000  peak: 49664    num: 440       avg: 3104
  f128:                  0.000ms   (0%)    threads: 0.000  peak: 98816    num: 440       avg: 6176
  f127:                  0.192ms   (1%)    threads: 16.000 peak: 197120   num: 440       avg: 12320
  f126:                  0.288ms   (1%)    threads: 13.333 peak: 393728   num: 440       avg: 24608
  f125:                  1.057ms   (5%)    threads: 13.909 peak: 98304    num: 28160     avg: 6144

```