### PR TITLE
Grab-bag of minor Generator-related cleanups

### DIFF
--- a/python_bindings/stub/PyStub.cpp
+++ b/python_bindings/stub/PyStub.cpp
@@ -20,7 +20,7 @@
 #define HALIDE_PYSTUB_MODULE_NAME HALIDE_PYSTUB_GENERATOR_NAME
 #endif
 
-extern "C" PyObject *_halide_pystub_impl(const char *module_name, Halide::Internal::GeneratorFactory factory);
+extern "C" PyObject *_halide_pystub_impl(const char *module_name, const Halide::Internal::GeneratorFactory &factory);
 
 #define HALIDE_STRINGIFY(x) #x
 #define HALIDE_TOSTRING(x) HALIDE_STRINGIFY(x)

--- a/python_bindings/stub/PyStub.cpp
+++ b/python_bindings/stub/PyStub.cpp
@@ -28,17 +28,17 @@ extern "C" PyObject *_halide_pystub_impl(const char *module_name, Halide::Intern
 #define _HALIDE_CONCAT(first, second) first##second
 #define HALIDE_CONCAT(first, second) _HALIDE_CONCAT(first, second)
 
-#if !defined(HALIDE_EXPORT)
+// Don't use HALIDE_EXPORT: Halide.h will already have defined it,
+// but it might be defined the wrong way (import rather than export).
 #if defined(WIN32) || defined(_WIN32)
-#define HALIDE_EXPORT __declspec(dllexport)
+#define HALIDE_PLUGIN_EXPORT __declspec(dllexport)
 #else
-#define HALIDE_EXPORT __attribute__((visibility("default")))
-#endif
+#define HALIDE_PLUGIN_EXPORT __attribute__((visibility("default")))
 #endif
 
 static_assert(PY_MAJOR_VERSION >= 3, "Python bindings for Halide require Python 3+");
 
-#define _HALIDE_PLUGIN_IMPL(name) extern "C" HALIDE_EXPORT PyObject *PyInit_##name() /* NOLINT(bugprone-macro-parentheses) */
+#define _HALIDE_PLUGIN_IMPL(name) extern "C" HALIDE_PLUGIN_EXPORT PyObject *PyInit_##name() /* NOLINT(bugprone-macro-parentheses) */
 #define HALIDE_PLUGIN_IMPL(name) _HALIDE_PLUGIN_IMPL(name)
 
 // clang-format off

--- a/python_bindings/stub/PyStub.cpp
+++ b/python_bindings/stub/PyStub.cpp
@@ -7,7 +7,10 @@
 // to simplify build requirements in downstream environments.
 
 #include <Python.h>
+#include <functional>
 #include <memory>
+
+#include "Halide.h"
 
 #ifndef HALIDE_PYSTUB_GENERATOR_NAME
 #error "HALIDE_PYSTUB_GENERATOR_NAME must be defined"
@@ -17,16 +20,7 @@
 #define HALIDE_PYSTUB_MODULE_NAME HALIDE_PYSTUB_GENERATOR_NAME
 #endif
 
-namespace Halide {
-class GeneratorContext;
-namespace Internal {
-class GeneratorBase;
-}  // namespace Internal
-}  // namespace Halide
-
-using FactoryFunc = std::unique_ptr<Halide::Internal::GeneratorBase> (*)(const Halide::GeneratorContext &context);
-
-extern "C" PyObject *_halide_pystub_impl(const char *module_name, FactoryFunc factory);
+extern "C" PyObject *_halide_pystub_impl(const char *module_name, Halide::Internal::GeneratorFactory factory);
 
 #define HALIDE_STRINGIFY(x) #x
 #define HALIDE_TOSTRING(x) HALIDE_STRINGIFY(x)

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -188,7 +188,7 @@ void pystub_init(pybind11::module &m, const GeneratorFactory &factory) {
 }  // namespace PythonBindings
 }  // namespace Halide
 
-extern "C" PyObject *_halide_pystub_impl(const char *module_name, Halide::Internal::GeneratorFactory factory) {
+extern "C" PyObject *_halide_pystub_impl(const char *module_name, const Halide::Internal::GeneratorFactory &factory) {
     int major, minor;
     if (sscanf(Py_GetVersion(), "%i.%i", &major, &minor) != 2) {
         PyErr_SetString(PyExc_ImportError, "Can't parse Python version.");

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -176,7 +176,7 @@ py::object generate_impl(const GeneratorFactory &factory, const GeneratorContext
     return std::move(py_outputs);
 }
 
-void pystub_init(pybind11::module &m, GeneratorFactory factory) {
+void pystub_init(pybind11::module &m, const GeneratorFactory &factory) {
     m.def(
         "generate", [factory](const Halide::Target &target, const py::args &args, const py::kwargs &kwargs) -> py::object {
             return generate_impl(factory, Halide::GeneratorContext(target), args, kwargs);

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -21,11 +21,10 @@ static_assert(PY_VERSION_HEX >= 0x03000000,
 
 namespace py = pybind11;
 
-using FactoryFunc = std::unique_ptr<Halide::Internal::GeneratorBase> (*)(const Halide::GeneratorContext &context);
-
 namespace Halide {
 namespace PythonBindings {
 
+using GeneratorFactory = Internal::GeneratorFactory;
 using GeneratorParamsMap = Internal::GeneratorParamsMap;
 using Stub = Internal::GeneratorStub;
 using StubInput = Internal::StubInput;
@@ -100,7 +99,7 @@ void append_input(const py::object &value, std::vector<StubInput> &v) {
     }
 }
 
-py::object generate_impl(FactoryFunc factory, const GeneratorContext &context, const py::args &args, const py::kwargs &kwargs) {
+py::object generate_impl(GeneratorFactory factory, const GeneratorContext &context, const py::args &args, const py::kwargs &kwargs) {
     Stub stub(context, [factory](const GeneratorContext &context) -> std::unique_ptr<Halide::Internal::GeneratorBase> {
         return factory(context);
     });
@@ -177,7 +176,7 @@ py::object generate_impl(FactoryFunc factory, const GeneratorContext &context, c
     return std::move(py_outputs);
 }
 
-void pystub_init(pybind11::module &m, FactoryFunc factory) {
+void pystub_init(pybind11::module &m, GeneratorFactory factory) {
     m.def(
         "generate", [factory](const Halide::Target &target, const py::args &args, const py::kwargs &kwargs) -> py::object {
             return generate_impl(factory, Halide::GeneratorContext(target), args, kwargs);
@@ -189,7 +188,7 @@ void pystub_init(pybind11::module &m, FactoryFunc factory) {
 }  // namespace PythonBindings
 }  // namespace Halide
 
-extern "C" PyObject *_halide_pystub_impl(const char *module_name, FactoryFunc factory) {
+extern "C" PyObject *_halide_pystub_impl(const char *module_name, Halide::Internal::GeneratorFactory factory) {
     int major, minor;
     if (sscanf(Py_GetVersion(), "%i.%i", &major, &minor) != 2) {
         PyErr_SetString(PyExc_ImportError, "Can't parse Python version.");

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -99,7 +99,7 @@ void append_input(const py::object &value, std::vector<StubInput> &v) {
     }
 }
 
-py::object generate_impl(GeneratorFactory factory, const GeneratorContext &context, const py::args &args, const py::kwargs &kwargs) {
+py::object generate_impl(const GeneratorFactory &factory, const GeneratorContext &context, const py::args &args, const py::kwargs &kwargs) {
     Stub stub(context, [factory](const GeneratorContext &context) -> std::unique_ptr<Halide::Internal::GeneratorBase> {
         return factory(context);
     });


### PR DESCRIPTION
Various minor code changes found during refactoring work; cherry-picking here to reduce noise later:
- de-inlining methods in Generator.h
- removing forward decls for nonexistent classes
- avoiding extern declarations that can trivially be avoided by just including Halide.h
- generator_main() should emit to the stream passed in (rather than calling user_error)
- other stuff