### PR TITLE
Various bug fixes and improvements from dsharletg/sliding-window

### DIFF
--- a/src/AsyncProducers.cpp
+++ b/src/AsyncProducers.cpp
@@ -172,9 +172,9 @@ class GenerateProducerBody : public NoOpCollapsingMutator {
         } else {
             // This semaphore will end up on both sides of the fork,
             // so we'd better duplicate it.
-            string cloned_acquire = var->name + unique_name('_');
-            cloned_acquires[var->name] = cloned_acquire;
-            return Acquire::make(Variable::make(type_of<halide_semaphore_t *>(), cloned_acquire), op->count, body);
+            vector<string> &clones = cloned_acquires[var->name];
+            clones.push_back(var->name + unique_name('_'));
+            return Acquire::make(Variable::make(type_of<halide_semaphore_t *>(), clones.back()), op->count, body);
         }
     }
 
@@ -192,11 +192,11 @@ class GenerateProducerBody : public NoOpCollapsingMutator {
         return op;
     }
 
-    map<string, string> &cloned_acquires;
+    map<string, vector<string>> &cloned_acquires;
     set<string> inner_semaphores;
 
 public:
-    GenerateProducerBody(const string &f, const vector<Expr> &s, map<string, string> &a)
+    GenerateProducerBody(const string &f, const vector<Expr> &s, map<string, vector<string>> &a)
         : func(f), sema(s), cloned_acquires(a) {
     }
 };
@@ -311,7 +311,7 @@ class ForkAsyncProducers : public IRMutator {
 
     const map<string, Function> &env;
 
-    map<string, string> cloned_acquires;
+    map<string, vector<string>> cloned_acquires;
 
     Stmt visit(const Realize *op) override {
         auto it = env.find(op->name);
@@ -354,10 +354,10 @@ class ForkAsyncProducers : public IRMutator {
                 // If there's a nested async producer, we may have
                 // recursively cloned this semaphore inside the mutation
                 // of the producer and consumer.
-                auto it = cloned_acquires.find(sema_name);
-                if (it != cloned_acquires.end()) {
-                    body = CloneAcquire(sema_name, it->second).mutate(body);
-                    body = LetStmt::make(it->second, sema_space, body);
+                const vector<string> &clones = cloned_acquires[sema_name];
+                for (const auto &i : clones) {
+                    body = CloneAcquire(sema_name, i).mutate(body);
+                    body = LetStmt::make(i, sema_space, body);
                 }
 
                 body = LetStmt::make(sema_name, sema_space, body);

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -417,9 +417,10 @@ private:
     }
 
     Expr visit(const Call *op) override {
-        // Ignore likely intrinsics
+        // Ignore intrinsics that shouldn't affect the results.
         if (op->is_intrinsic(Call::likely) ||
-            op->is_intrinsic(Call::likely_if_innermost)) {
+            op->is_intrinsic(Call::likely_if_innermost) ||
+            op->is_intrinsic(Call::promise_clamped)) {
             return mutate(op->args[0]);
         } else {
             return IRMutator::visit(op);

--- a/src/TrimNoOps.cpp
+++ b/src/TrimNoOps.cpp
@@ -163,6 +163,10 @@ class IsNoOp : public IRVisitor {
         IRVisitor::visit(op);
     }
 
+    void visit(const Acquire *op) override {
+        condition = const_false();
+    }
+
     template<typename LetOrLetStmt>
     void visit_let(const LetOrLetStmt *op) {
         IRVisitor::visit(op);
@@ -371,6 +375,8 @@ class TrimNoOps : public IRMutator {
 
         if (is_const_one(is_no_op.condition)) {
             // This loop is definitely useless
+            debug(3) << "Removed empty loop.\n"
+                     << "Old: " << Stmt(op) << "\n";
             return Evaluate::make(0);
         } else if (is_const_zero(is_no_op.condition)) {
             // This loop is definitely needed
@@ -391,6 +397,8 @@ class TrimNoOps : public IRMutator {
 
         if (i.is_empty()) {
             // Empty loop
+            debug(3) << "Removed empty loop.\n"
+                     << "Old: " << Stmt(op) << "\n";
             return Evaluate::make(0);
         }
 

--- a/src/UniquifyVariableNames.cpp
+++ b/src/UniquifyVariableNames.cpp
@@ -243,7 +243,7 @@ void uniquify_variable_names_test() {
           {{x, Let::make(y.name(), 3, y)},
            {x_1, Let::make(y.name(), 4, y)}});
 
-    std::cout << "uniquify_variable_names_test test passed" << std::endl;
+    std::cout << "uniquify_variable_names test passed" << std::endl;
 }
 
 }  // namespace Internal

--- a/src/UniquifyVariableNames.cpp
+++ b/src/UniquifyVariableNames.cpp
@@ -243,7 +243,7 @@ void uniquify_variable_names_test() {
           {{x, Let::make(y.name(), 3, y)},
            {x_1, Let::make(y.name(), 4, y)}});
 
-    std::cout << "is_monotonic test passed" << std::endl;
+    std::cout << "uniquify_variable_names_test test passed" << std::endl;
 }
 
 }  // namespace Internal

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -170,10 +170,10 @@ Interval bounds_of_nested_lanes(const Expr &e) {
 Interval bounds_of_lanes(const Expr &e) {
     Interval bounds = bounds_of_nested_lanes(e);
     if (!bounds.min.type().is_scalar()) {
-        bounds.min = bounds_of_nested_lanes(bounds.min).min;
+        bounds.min = bounds_of_lanes(bounds.min).min;
     }
     if (!bounds.max.type().is_scalar()) {
-        bounds.max = bounds_of_nested_lanes(bounds.max).max;
+        bounds.max = bounds_of_lanes(bounds.max).max;
     }
     return bounds;
 }

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -120,18 +120,18 @@ Interval bounds_of_nested_lanes(const Expr &e) {
             return {r->base + last_lane_idx * r->stride, r->base};
         }
     } else if (const LE *le = e.as<LE>()) {
-        // The least true this can be is if we maximize the LHS and minimize the RHS
-        // The most true this can be is if we minimize the LHS and maximize the RHS
-        // This is only exact if one of the two sides is a Broadcast
+        // The least true this can be is if we maximize the LHS and minimize the RHS.
+        // The most true this can be is if we minimize the LHS and maximize the RHS.
+        // This is only exact if one of the two sides is a Broadcast.
         Interval ia = bounds_of_nested_lanes(le->a);
         Interval ib = bounds_of_nested_lanes(le->b);
         if (ia.is_single_point() || ib.is_single_point()) {
             return {ia.max <= ib.min, ia.min <= ib.max};
         }
     } else if (const LT *lt = e.as<LT>()) {
-        // The least true this can be is if we maximize the LHS and minimize the RHS
-        // The most true this can be is if we minimize the LHS and maximize the RHS
-        // This is only exact if one of the two sides is a Broadcast
+        // The least true this can be is if we maximize the LHS and minimize the RHS.
+        // The most true this can be is if we minimize the LHS and maximize the RHS.
+        // This is only exact if one of the two sides is a Broadcast.
         Interval ia = bounds_of_nested_lanes(lt->a);
         Interval ib = bounds_of_nested_lanes(lt->b);
         if (ia.is_single_point() || ib.is_single_point()) {


### PR DESCRIPTION
- Fix cloning a semaphore more than once.
- Ignore promise_clamped in solve
- Acquire is not a no-op, even if it's empty
- Handle nested vectors in bounds_of_lanes

By @abadams:
- Don't count unlikely loops as inner loops for likely_if_innermost
- Handle LE/LT in bounds_of_lanes