### PR TITLE
Update simd_op_check for the final wasm simd128 spec

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -4747,8 +4747,10 @@ Value *CodeGen_LLVM::call_overloaded_intrin(const Type &result_type, const std::
     constexpr int debug_level = 4;
 
     debug(debug_level) << "call_overloaded_intrin: " << result_type << " " << name << "(";
+    const char *comma = "";
     for (const Expr &i : args) {
-        debug(debug_level) << ", " << i;
+        debug(debug_level) << comma << i;
+        comma = ", ";
     }
     debug(debug_level) << ")\n";
 
@@ -4761,10 +4763,12 @@ Value *CodeGen_LLVM::call_overloaded_intrin(const Type &result_type, const std::
     const Intrinsic *resolved = nullptr;
     for (const Intrinsic &overload : impls_i->second) {
         debug(debug_level) << "Considering candidate " << overload.result_type << "(";
+        const char *comma = "";
         for (const auto &i : overload.arg_types) {
-            debug(debug_level) << ", " << i;
+            debug(debug_level) << comma << i;
+            comma = ", ";
         }
-        debug(debug_level) << "\n";
+        debug(debug_level) << ")\n";
         if (overload.arg_types.size() != args.size()) {
             debug(debug_level) << "Wrong number of arguments\n";
             continue;


### PR DESCRIPTION
The final revision of the wasm simd128 spec (https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md) added some ops and tweaked some others. This just augments the wasm section of simd_op_check so that all the ops are referenced, with the new (or still-unimplemented) ops commented out with TODOs.

Most of the new ops will likely be implemented via pattern matching in Codegen_WebAssembly, but before that can happen in any efficient way, WABT needs to be updated to recognize all the ops in the final spec (it doesn't currently, and so we can't even load code with those ops without cratering). See https://github.com/WebAssembly/wabt/issues/1617 for tracking bug.

(Also: drive-by fix in CodegenLLVM to fix prettyprinting of some debug output)