### PR TITLE
Add missing min/max/+/- rules

### DIFF
--- a/src/Simplify_Add.cpp
+++ b/src/Simplify_Add.cpp
@@ -91,6 +91,18 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
              rewrite((x - y) + (y + z), x + z) ||
              rewrite((x - y) + (z + y), x + z) ||
 
+             rewrite(x + ((y - x) - z), y - z) ||
+             rewrite(((x - y) - z) + y, x - z) ||
+
+             rewrite(x + (y - (x + z)), y - z) ||
+             rewrite(x + (y - (z + x)), y - z) ||
+             rewrite((x - (y + z)) + y, x - z) ||
+             rewrite((x - (y + z)) + z, x - y) ||
+
+             rewrite(x + ((0 - y) - z), x - (y + z)) ||
+             rewrite(((0 - x) - y) + z, z - (x + y)) ||
+             rewrite(((c0 - x) - y) + c1, (fold(c0 + c1) - y) - x) ||
+
              rewrite(x*y + z*y, (x + z)*y) ||
              rewrite(x*y + y*z, (x + z)*y) ||
              rewrite(y*x + z*y, y*(x + z)) ||

--- a/src/Simplify_Max.cpp
+++ b/src/Simplify_Max.cpp
@@ -83,6 +83,20 @@ Expr Simplify::visit(const Max *op, ExprInfo *bounds) {
              rewrite(max(min(y, x), x), b) ||
              rewrite(max(min(x, c0), c1), b, c1 >= c0) ||
 
+             rewrite(max(x, min(y, min(x, z))), a) ||
+             rewrite(max(x, min(y, min(z, x))), a) ||
+             rewrite(max(x, min(min(x, y), z)), a) ||
+             rewrite(max(x, min(min(y, x), z)), a) ||
+             rewrite(max(min(x, min(y, z)), y), b) ||
+             rewrite(max(min(x, min(y, z)), z), b) ||
+             rewrite(max(min(min(x, y), z), x), b) ||
+             rewrite(max(min(min(x, y), z), y), b) ||
+
+             rewrite(max(max(x, y), min(x, z)), a) ||
+             rewrite(max(max(x, y), min(y, z)), a) ||
+             rewrite(max(max(x, y), min(z, x)), a) ||
+             rewrite(max(max(x, y), min(z, y)), a) ||
+
              rewrite(max(intrin(Call::likely, x), x), b) ||
              rewrite(max(x, intrin(Call::likely, x)), a) ||
              rewrite(max(intrin(Call::likely_if_innermost, x), x), b) ||
@@ -108,6 +122,16 @@ Expr Simplify::visit(const Max *op, ExprInfo *bounds) {
                rewrite(max(x, (x/c1)*c1 + c2), a, c1 > 0 && c2 <= 0) ||
                rewrite(max(((x + c0)/c1)*c1, x), b, c1 > 0 && c0 <= 0) ||
                rewrite(max(x, ((x + c0)/c1)*c1), a, c1 > 0 && c0 <= 0) ||
+
+               rewrite(max(x, min(x, y) + c0), a, c0 <= 0) ||
+               rewrite(max(x, min(y, x) + c0), a, c0 <= 0) ||
+               rewrite(max(min(x, y) + c0, x), b, c0 <= 0) ||
+               rewrite(max(min(x, y) + c0, y), b, c0 <= 0) ||
+
+               (no_overflow_int(op->type) &&
+                (rewrite(max(min(c0 - x, x), c1), b, 2*c1 >= c0 - 1) ||
+                 rewrite(max(min(x, c0 - x), c1), b, 2*c1 >= c0 - 1))) ||
+
                false)))) {
             return rewrite.result;
         }
@@ -139,6 +163,15 @@ Expr Simplify::visit(const Max *op, ExprInfo *bounds) {
              rewrite(max(select(x == c0, c1, x), c2), max(x, c2), (c0 <= c2) && (c1 <= c2)) ||
              rewrite(max(select(x == c0, c1, x), x), select(x == c0, c1, x), c0 < c1) ||
              rewrite(max(select(x == c0, c1, x), x), x, c1 <= c0) ||
+
+             rewrite(max(max(x, min(y, z)), y), max(x, y)) ||
+             rewrite(max(max(x, min(y, z)), z), max(x, z)) ||
+             rewrite(max(max(min(x, y), z), x), max(z, x)) ||
+             rewrite(max(max(min(x, y), z), y), max(z, y)) ||
+             rewrite(max(x, max(y, min(x, z))), max(y, x)) ||
+             rewrite(max(x, max(y, min(z, x))), max(y, x)) ||
+             rewrite(max(x, max(min(x, y), z)), max(x, z)) ||
+             rewrite(max(x, max(min(y, x), z)), max(x, z)) ||
 
              (no_overflow(op->type) &&
               (rewrite(max(max(x, y) + c0, x), max(x, y + c0), c0 < 0) ||

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -83,6 +83,20 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
              rewrite(min(max(y, x), x), b) ||
              rewrite(min(max(x, c0), c1), b, c1 <= c0) ||
 
+             rewrite(min(x, max(y, max(x, z))), a) ||
+             rewrite(min(x, max(y, max(z, x))), a) ||
+             rewrite(min(x, max(max(x, y), z)), a) ||
+             rewrite(min(x, max(max(y, x), z)), a) ||
+             rewrite(min(max(x, max(y, z)), y), b) ||
+             rewrite(min(max(x, max(y, z)), z), b) ||
+             rewrite(min(max(max(x, y), z), x), b) ||
+             rewrite(min(max(max(x, y), z), y), b) ||
+
+             rewrite(min(max(x, y), min(x, z)), b) ||
+             rewrite(min(max(x, y), min(y, z)), b) ||
+             rewrite(min(max(x, y), min(z, x)), b) ||
+             rewrite(min(max(x, y), min(z, y)), b) ||
+
              rewrite(min(intrin(Call::likely, x), x), b) ||
              rewrite(min(x, intrin(Call::likely, x)), a) ||
              rewrite(min(intrin(Call::likely_if_innermost, x), x), b) ||
@@ -108,6 +122,16 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
                rewrite(min(x, (x/c1)*c1 + c2), b, c1 > 0 && c2 <= 0) ||
                rewrite(min(((x + c0)/c1)*c1, x), a, c1 > 0 && c0 <= 0) ||
                rewrite(min(x, ((x + c0)/c1)*c1), b, c1 > 0 && c0 <= 0) ||
+
+               rewrite(min(x, max(x, y) + c0), a, 0 <= c0) ||
+               rewrite(min(x, max(y, x) + c0), a, 0 <= c0) ||
+               rewrite(min(max(x, y) + c0, x), b, 0 <= c0) ||
+               rewrite(min(max(x, y) + c0, y), b, 0 <= c0) ||
+
+               (no_overflow_int(op->type) &&
+                (rewrite(min(max(c0 - x, x), c1), b, 2*c1 <= c0 + 1) ||
+                 rewrite(min(max(x, c0 - x), c1), b, 2*c1 <= c0 + 1))) ||
+
                false)))) {
             return rewrite.result;
         }
@@ -142,6 +166,15 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
              rewrite(min(select(x == c0, c1, x), c2), min(x, c2), (c2 <= c0) && (c2 <= c1)) ||
              rewrite(min(select(x == c0, c1, x), x), select(x == c0, c1, x), c1 < c0) ||
              rewrite(min(select(x == c0, c1, x), x), x, c0 <= c1) ||
+
+             rewrite(min(x, min(y, max(x, z))), min(y, x)) ||
+             rewrite(min(x, min(y, max(z, x))), min(y, x)) ||
+             rewrite(min(x, min(max(x, y), z)), min(x, z)) ||
+             rewrite(min(x, min(max(y, x), z)), min(x, z)) ||
+             rewrite(min(min(x, max(y, z)), y), min(x, y)) ||
+             rewrite(min(min(x, max(y, z)), z), min(x, z)) ||
+             rewrite(min(min(max(x, y), z), x), min(z, x)) ||
+             rewrite(min(min(max(x, y), z), y), min(z, y)) ||
 
              (no_overflow(op->type) &&
               (rewrite(min(min(x, y) + c0, x), min(x, y + c0), c0 > 0) ||

--- a/src/Simplify_Sub.cpp
+++ b/src/Simplify_Sub.cpp
@@ -105,6 +105,11 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
              rewrite((z + (x + y)) - x, z + y) ||
              rewrite((z + (y + x)) - x, z + y) ||
 
+             rewrite(x - (y + (x - z)), z - y) ||
+             rewrite(x - ((x - y) + z), y - z) ||
+             rewrite((x + (y - z)) - y, x - z) ||
+             rewrite(((x - y) + z) - x, z - y) ||
+
              rewrite(x - (y + (x + z)), 0 - (y + z)) ||
              rewrite(x - (y + (z + x)), 0 - (y + z)) ||
              rewrite(x - ((x + y) + z), 0 - (y + z)) ||
@@ -121,6 +126,20 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
              rewrite((x - y) - (x + z), 0 - y - z) ||
              rewrite((x - y) - (z + x), 0 - y - z) ||
 
+             rewrite(((x + y) - z) - x, y - z) ||
+             rewrite(((x + y) - z) - y, x - z) ||
+
+             rewrite(x - min(x - y, 0), max(x, y)) ||
+             rewrite(x - max(x - y, 0), min(x, y)) ||
+             rewrite((x + y) - min(x, y), max(y, x)) ||
+             rewrite((x + y) - min(y, x), max(y, x)) ||
+             rewrite((x + y) - max(x, y), min(y, x)) ||
+             rewrite((x + y) - max(y, x), min(x, y)) ||
+
+             rewrite(0 - (x + (y - z)), z - (x + y)) ||
+             rewrite(0 - ((x - y) + z), y - (x + z)) ||
+             rewrite(((x - y) - z) - x, 0 - (y + z)) ||
+
              rewrite(x - x%c0, (x/c0)*c0) ||
 
              (no_overflow(op->type) &&
@@ -133,6 +152,18 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
                rewrite(x - min(x, y), max(x - y, 0), !is_const(x)) ||
                rewrite(y - max(x, y), min(y - x, 0), !is_const(y)) ||
                rewrite(y - min(x, y), max(y - x, 0), !is_const(y)) ||
+
+               rewrite(x - min(y, x - z), max(x - y, z)) ||
+               rewrite(x - min(x - y, z), max(y, x - z)) ||
+               rewrite(x - max(y, x - z), min(x - y, z)) ||
+               rewrite(x - max(x - y, z), min(y, x - z)) ||
+
+               rewrite(min(x - y, 0) - x, 0 - max(x, y)) ||
+               rewrite(max(x - y, 0) - x, 0 - min(x, y)) ||
+               rewrite(min(x, y) - (x + y), 0 - max(y, x)) ||
+               rewrite(min(x, y) - (y + x), 0 - max(x, y)) ||
+               rewrite(max(x, y) - (x + y), 0 - min(x, y)) ||
+               rewrite(max(x, y) - (y + x), 0 - min(y, x)) ||
 
                // Negate a clamped subtract
                rewrite(0 - max(x - y, c0), min(y - x, fold(-c0))) ||


### PR DESCRIPTION
These are almost all of the rules in <= four in terms of min/max/add/sub ops leaves that simplify to something with <= three leaves. Found via brute-force enumeration of all such expressions, and then bucketing them by evaluating them on a few random values, then testing the proposed rewrites with the formal verifier.

I left out things of the form: ```max(max(x, -x), 0) -> max(x, -x)```
While correct, that transformation actually hurts our ability to analyze that expression.