### PR TITLE
Fix wasm-interp ucon error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ python_bindings/bin/*
 build-64/*
 build-ios/*
 build-osx/*
+build_wasm/*
 cmake_build*/*
 */build/*
 tmp/*


### PR DESCRIPTION
This is a subtle error that only shows up in builds with assertions enabled in wabt; the issue is that we ask for an int64 value from a wabt `Value` struct, but that struct only has an int32, so an assertion can fail. (Note that there is always storage for both, and the values are constrained and unused inside the JIT anyway, so this is mostly just a cosmetic fix.)

Also added a .gitignore entry.