### PR TITLE
Fix correctness_memoize on arm32

### DIFF
--- a/test/correctness/memoize.cpp
+++ b/test/correctness/memoize.cpp
@@ -726,7 +726,7 @@ int main(int argc, char **argv) {
         assert(call_count == 5);
 
         Internal::JITSharedRuntime::memoization_cache_evict(1);
-        Internal::JITSharedRuntime::memoization_cache_evict((uint64_t)&call_count);
+        Internal::JITSharedRuntime::memoization_cache_evict((uint64_t)(uintptr_t)&call_count);
         result1 = f.realize();
         assert(result1(0) == 126);
 


### PR DESCRIPTION
Conversion from a pointer to an integer is "implementation defined"; in general, conversion to `uintptr_t` is reliable, but other conversions aren't. It turns out that for our arm32 compiler, casting a pointer to a `uint64_t` sign-extends, rather than zero-extends, causing unexpected behavior in memoize cache eviction *if* the pointer is in the top half of memory. The fix here is simple (cast to `uintptr_t` directly), but it brings up the question of where else in our codebase we might be doing direct conversions elsewhere in our code without noticing the potential UB.