### PR TITLE
Add Halide_CCACHE_BUILD option for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,18 +43,18 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Build Halide with ccache if the package is present
-set(Halide_CCACHE_BUILD OFF CACHE BOOL "Set to ON for a ccache enabled build")
+option(Halide_CCACHE_BUILD "Set to ON for a ccache enabled build" OFF)
 if (Halide_CCACHE_BUILD)
-  find_program(CCACHE_PROGRAM ccache)
-  if (CCACHE_PROGRAM)
-      set(Halide_CCACHE_PARAMS "CCACHE_CPP2=yes CCACHE_HASHDIR=yes"
-          CACHE STRING "Parameters to pass through to ccache")
-      set(CCACHE_PROGRAM "${Halide_CCACHE_PARAMS} ${CCACHE_PROGRAM}")
-      set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_PROGRAM})
-      message(STATUS "Enabling ccache usage for building.")
-  else ()
-    message(FATAL_ERROR "Unable to find the program ccache. Set Halide_CCACHE_BUILD to OFF")
-  endif ()
+    find_program(CCACHE_PROGRAM ccache)
+    if (CCACHE_PROGRAM)
+        set(Halide_CCACHE_PARAMS CCACHE_CPP2=yes CCACHE_HASHDIR=yes
+            CACHE STRING "Parameters to pass through to ccache")
+        set(CMAKE_C_COMPILER_LAUNCHER ${CMAKE_COMMAND} -E env ${Halide_CCACHE_PARAMS} ${CCACHE_PROGRAM})
+        set(CMAKE_CXX_COMPILER_LAUNCHER ${CMAKE_COMMAND} -E env ${Halide_CCACHE_PARAMS} ${CCACHE_PROGRAM})
+        message(STATUS "Enabling ccache usage for building.")
+    else ()
+        message(FATAL_ERROR "Unable to find the program ccache. Set Halide_CCACHE_BUILD to OFF")
+    endif ()
 endif ()
 
 ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,11 @@ option(Halide_CCACHE_BUILD "Set to ON for a ccache enabled build" OFF)
 if (Halide_CCACHE_BUILD)
     find_program(CCACHE_PROGRAM ccache)
     if (CCACHE_PROGRAM)
-        set(Halide_CCACHE_PARAMS CCACHE_CPP2=yes CCACHE_HASHDIR=yes CCACHE_SLOPPINESS=pch_defines,time_macros
+        # TODO: ccache recommends setting CCACHE_SLOPPINESS=pch_defines,time_macros to
+        # enable precompiled header caching. Our timing found it slightly faster with
+        # just CCACHE_SLOPPINESS=pch_defines, so that's what we're using. Maybe revisit
+        # if issues occur (but we don't use any of the time macros so should be irrelevant).
+        set(Halide_CCACHE_PARAMS CCACHE_CPP2=yes CCACHE_HASHDIR=yes CCACHE_SLOPPINESS=pch_defines
             CACHE STRING "Parameters to pass through to ccache")
         set(CMAKE_C_COMPILER_LAUNCHER ${CMAKE_COMMAND} -E env ${Halide_CCACHE_PARAMS} ${CCACHE_PROGRAM})
         set(CMAKE_CXX_COMPILER_LAUNCHER ${CMAKE_COMMAND} -E env ${Halide_CCACHE_PARAMS} ${CCACHE_PROGRAM})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ option(Halide_CCACHE_BUILD "Set to ON for a ccache enabled build" OFF)
 if (Halide_CCACHE_BUILD)
     find_program(CCACHE_PROGRAM ccache)
     if (CCACHE_PROGRAM)
-        set(Halide_CCACHE_PARAMS CCACHE_CPP2=yes CCACHE_HASHDIR=yes
+        set(Halide_CCACHE_PARAMS CCACHE_CPP2=yes CCACHE_HASHDIR=yes CCACHE_SLOPPINESS=pch_defines,time_macros
             CACHE STRING "Parameters to pass through to ccache")
         set(CMAKE_C_COMPILER_LAUNCHER ${CMAKE_COMMAND} -E env ${Halide_CCACHE_PARAMS} ${CCACHE_PROGRAM})
         set(CMAKE_CXX_COMPILER_LAUNCHER ${CMAKE_COMMAND} -E env ${Halide_CCACHE_PARAMS} ${CCACHE_PROGRAM})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,21 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Build Halide with ccache if the package is present
+set(Halide_CCACHE_BUILD OFF CACHE BOOL "Set to ON for a ccache enabled build")
+if (Halide_CCACHE_BUILD)
+  find_program(CCACHE_PROGRAM ccache)
+  if (CCACHE_PROGRAM)
+      set(Halide_CCACHE_PARAMS "CCACHE_CPP2=yes CCACHE_HASHDIR=yes"
+          CACHE STRING "Parameters to pass through to ccache")
+      set(CCACHE_PROGRAM "${Halide_CCACHE_PARAMS} ${CCACHE_PROGRAM}")
+      set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_PROGRAM})
+      message(STATUS "Enabling ccache usage for building.")
+  else ()
+    message(FATAL_ERROR "Unable to find the program ccache. Set Halide_CCACHE_BUILD to OFF")
+  endif ()
+endif ()
+
 ##
 # Import dependencies
 ##

--- a/README_cmake.md
+++ b/README_cmake.md
@@ -367,6 +367,7 @@ compiled.
 | `Halide_ENABLE_EXCEPTIONS`               | `ON`                  | Enable exceptions when building Halide                                                                           |
 | `Halide_USE_CODEMODEL_LARGE`             | `OFF`                 | Use the Large LLVM codemodel                                                                                     |
 | `Halide_TARGET`                          | _empty_               | The default target triple to use for `add_halide_library` (and the generator tests, by extension)                |
+| `Halide_CCACHE_BUILD`                    | `OFF`                 | Use ccache to accelerate rebuilds.                                                                               |
 
 The following options are only available when building Halide directly, ie. not
 through the [`add_subdirectory`][add_subdirectory] or


### PR DESCRIPTION
This replicates the approach LLVM already has of baking a use-cache option directly into the CMake options, without having to futz with changing CC/CXX/etc.