### PR TITLE
Conform to CMP0116 when using CMake 3.20+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.16...3.20)
 project(Halide VERSION 12.0.0)
 
 enable_testing()

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -231,17 +231,25 @@ foreach (i IN LISTS RUNTIME_CPP)
 
             set(clang_flags ${RUNTIME_CXX_FLAGS} ${fpic} ${fshort-wchar} ${RUNTIME_DEFINES${SUFFIX}} -m${j} -target ${TARGET} -emit-llvm -S)
 
-            # Dep-files are subtle and require clang to run using *just* the right
-            # relative paths to the build root, NOT the Halide build root. This is
-            # a perfect storm of bad behavior from CMake, Ninja, and Clang.
-            file(RELATIVE_PATH ll_path "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/${LL}")
-            file(TO_NATIVE_PATH "${ll_path}" ll_path)
-
+            set(ll_path "${LL}")
             if (CMAKE_GENERATOR MATCHES "Ninja")
-                list(APPEND clang_flags -MD -MF "$<SHELL_PATH:${CMAKE_CURRENT_BINARY_DIR}/${basename}.d>")
-                set(dep_args DEPFILE "${CMAKE_CURRENT_BINARY_DIR}/${basename}.d")
-            elseif (NOT CMAKE_GENERATOR MATCHES "Make")
-                set(dep_args "")
+                if (POLICY CMP0116)
+                    # CMake 3.20+ does the right thing here and transforms the depfiles for us
+                    list(APPEND clang_flags -MD -MF "${basename}.d")
+                    set(dep_args DEPFILE "${basename}.d")
+                else()
+                    # Dep-files are subtle and require clang to run using *just* the right
+                    # relative paths to the build root, NOT the Halide build root. This is
+                    # a perfect storm of bad behavior from CMake <3.20, Ninja, and Clang.
+                    file(RELATIVE_PATH ll_path "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/${LL}")
+                    file(TO_NATIVE_PATH "${ll_path}" ll_path)
+                    list(APPEND clang_flags -MD -MF "$<SHELL_PATH:${CMAKE_CURRENT_BINARY_DIR}/${basename}.d>")
+                    set(dep_args
+                        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+                        DEPFILE "${CMAKE_CURRENT_BINARY_DIR}/${basename}.d")
+                endif()
+            elseif (CMAKE_GENERATOR MATCHES "Make")
+                set(dep_args IMPLICIT_DEPENDS CXX "${SOURCE}")
             endif ()
 
             if (Halide_CLANG_TIDY_BUILD)
@@ -255,9 +263,6 @@ foreach (i IN LISTS RUNTIME_CPP)
                 add_custom_command(OUTPUT "${LL}"
                                    COMMAND clang ${clang_flags} -o "${ll_path}" "$<SHELL_PATH:${SOURCE}>"
                                    DEPENDS "${SOURCE}"
-                                   # Note: IMPLICIT_DEPENDS only works for Makefile generators, ${dep_args} handles Ninja.
-                                   IMPLICIT_DEPENDS CXX "${SOURCE}"
-                                   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
                                    ${dep_args}
                                    VERBATIM)
             endif()


### PR DESCRIPTION
Use the CMake 3.20+ depfile features when they're available (avoids throwing one warning per initmod...). This will eventually be removed when we're able to upgrade to 3.20 (maybe in a year or two).

Fixes #5373 