### PR TITLE
Upgrade pybind11 to 2.6.2

### DIFF
--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 
-set(PYBIND11_VER 2.6.1)
+set(PYBIND11_VER 2.6.2)
 find_package(pybind11 ${PYBIND11_VER} QUIET)
 if (NOT pybind11_FOUND)
     include(FetchContent)

--- a/python_bindings/requirements.txt
+++ b/python_bindings/requirements.txt
@@ -11,5 +11,6 @@ pillow
 
 # Keep versions of these requirements equal to the versions in Ubuntu 20.04 LTS
 # because newer versions fix bugs we work around.
+# TODO: what bugs? how are we working around them? is this still valid?
 imageio==2.4.1
-pybind11==2.6.1
+pybind11==2.6.2

--- a/python_bindings/requirements.txt
+++ b/python_bindings/requirements.txt
@@ -5,12 +5,10 @@
 # something similar to `pip3 install --user -r requirements.txt`
 
 # science packages
+imageio
 numpy
-scipy
 pillow
+scipy
 
-# Keep versions of these requirements equal to the versions in Ubuntu 20.04 LTS
-# because newer versions fix bugs we work around.
-# TODO: what bugs? how are we working around them? is this still valid?
-imageio==2.4.1
+# Choose a specific version for pybind11
 pybind11==2.6.2


### PR DESCRIPTION
Released January 2021 with various bug fixes, see https://github.com/pybind/pybind11/releases/tag/v2.6.2