### PR TITLE
Set CMake policy CMP0091 to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
 cmake_minimum_required(VERSION 3.16...3.20)
+
+# Enables the use of CMAKE_MSVC_RUNTIME_LIBRARY to select the MSVC runtime
+cmake_policy(SET CMP0091 NEW)
+
 project(Halide VERSION 12.0.0)
 
 enable_testing()


### PR DESCRIPTION
This enables the use of CMAKE_MSVC_RUNTIME_LIBRARY to select which
version of the MSVC runtime to link against the application.
This greatly facilitates development on Windows since one can use LLVM
in release mode while keeping Halide in Debug mode by setting
-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded, or any value that matches
the runtime used to build LLVM.

More information on the policy: [CMP0091](https://cmake.org/cmake/help/latest/policy/CMP0091.html)