### PR TITLE
Enable targeting broadcasting dot products on ARM

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1162,6 +1162,12 @@ void CodeGen_ARM::codegen_vector_reduce(const VectorReduce *op, const Expr &init
             if (!i.defined()) {
                 i = make_zero(op->type);
             }
+            if (const Shuffle *s = matches[0].as<Shuffle>()) {
+                if (s->is_broadcast()) {
+                    // LLVM wants the broadcast as the second operand.
+                    std::swap(matches[0], matches[1]);
+                }
+            }
             value = call_overloaded_intrin(op->type, p.intrin, {i, matches[0], matches[1]});
             if (value) {
                 return;

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1164,7 +1164,8 @@ void CodeGen_ARM::codegen_vector_reduce(const VectorReduce *op, const Expr &init
             }
             if (const Shuffle *s = matches[0].as<Shuffle>()) {
                 if (s->is_broadcast()) {
-                    // LLVM wants the broadcast as the second operand.
+                    // LLVM wants the broadcast as the second operand for the broadcasting
+                    // variant of udot/sdot.
                     std::swap(matches[0], matches[1]);
                 }
             }


### PR DESCRIPTION
It's currently possible to write schedules that generate the necessary shuffles for LLVM to generate the broadcasting dot product instructions, but LLVM only recognizes these when the shuffle is the second operand argument. This PR commutes the operands of dot products to make it possible to reliably generate these instructions.