### PR TITLE
Allow clean compiles when NDEBUG is defined

### DIFF
--- a/apps/hannk/Makefile
+++ b/apps/hannk/Makefile
@@ -22,7 +22,11 @@ FLATBUFFERS_INCLUDE_PATH ?= /usr/local/Cellar/flatbuffers/1.12.0/include
 #
 # -fPIC is necessary for .so builds (at least on Linux); not necessary for the non-delegate
 # builds but easier to enable it for everything.
-CXXFLAGS += -Wno-unused-private-field -fno-exceptions -fPIC -fvisibility=hidden -fvisibility-inlines-hidden
+CXXFLAGS += -Wno-unused-private-field -fno-exceptions -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wunused-variable
+
+ifneq (,$(findstring -O,$(OPTIMIZE)))
+	CXXFLAGS += -DNDEBUG
+endif
 
 MAKEFILE_DIR=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 

--- a/apps/hannk/halide/convolution_generator.cpp
+++ b/apps/hannk/halide/convolution_generator.cpp
@@ -264,7 +264,8 @@ public:
             // If we're unrolling a full vector's worth of reduction from the
             // input, explicitly load a vector of it first. This enables targeting
             // broadcasting dot products, like ARM's udot.
-            input_bounded.in(convolved).compute_at(convolved, c)
+            input_bounded.in(convolved)
+                .compute_at(convolved, c)
                 .bound_extent(c, unroll_reduction)
                 .vectorize(c);
         }
@@ -286,7 +287,8 @@ public:
                 .vectorize(c, accum_vector_size, TailStrategy::RoundUp);
 
             // Compute the sum of the input outside the loops over channels.
-            sum_input.in().compute_at(output_, y)
+            sum_input.in()
+                .compute_at(output_, y)
                 .vectorize(x, accum_vector_size, TailStrategy::RoundUp);
             sum_input.compute_at(sum_input.in(), x)
                 .vectorize(x)

--- a/apps/hannk/interpreter/ops.cpp
+++ b/apps/hannk/interpreter/ops.cpp
@@ -333,7 +333,9 @@ void Conv2DOp::execute(const Box &crop) {
 
         const int input_offset = in->quantization().zero.at(0);
         const int filter_offset = filt->quantization().zero.at(0);
+#ifndef NDEBUG
         const int bias_offset = bias()->quantization().zero.at(0);
+#endif
         const int output_offset = out->quantization().zero.at(0);
         assert(input_offset >= 0 && input_offset <= 255);
         assert(filter_offset >= 0 && filter_offset <= 255);
@@ -342,7 +344,9 @@ void Conv2DOp::execute(const Box &crop) {
 
         const float input_scale = in->quantization().scale.at(0);
         const float filter_scale = filt->quantization().scale.at(0);
+#ifndef NDEBUG
         const float bias_scale = bias()->quantization().scale.at(0);
+#endif
         const float output_scale = out->quantization().scale.at(0);
 
         const double input_product_scale = input_scale * filter_scale;
@@ -462,7 +466,9 @@ void DepthwiseConv2DOp::execute(const Box &crop) {
 
         const int input_offset = in->quantization().zero.at(0);
         const int filter_offset = filt->quantization().zero.at(0);
+#ifndef NDEBUG
         const int bias_offset = bias()->quantization().zero.at(0);
+#endif
         const int output_offset = out->quantization().zero.at(0);
         assert(input_offset >= 0 && input_offset <= 255);
         assert(filter_offset >= 0 && filter_offset <= 255);
@@ -471,7 +477,9 @@ void DepthwiseConv2DOp::execute(const Box &crop) {
 
         const float input_scale = in->quantization().scale.at(0);
         const float filter_scale = filt->quantization().scale.at(0);
+#ifndef NDEBUG
         const float bias_scale = bias()->quantization().scale.at(0);
+#endif
         const float output_scale = out->quantization().scale.at(0);
 
         const double input_product_scale = input_scale * filter_scale;
@@ -563,7 +571,9 @@ void FullyConnectedOp::execute(const Box &crop) {
 
         const int input_offset = in->quantization().zero.at(0);
         const int filter_offset = filt->quantization().zero.at(0);
+#ifndef NDEBUG
         const int bias_offset = bias()->quantization().zero.at(0);
+#endif
         const int output_offset = out->quantization().zero.at(0);
         assert(input_offset >= 0 && input_offset <= 255);
         assert(filter_offset >= 0 && filter_offset <= 255);
@@ -572,7 +582,9 @@ void FullyConnectedOp::execute(const Box &crop) {
 
         const float input_scale = in->quantization().scale.at(0);
         const float filter_scale = filt->quantization().scale.at(0);
+#ifndef NDEBUG
         const float bias_scale = bias()->quantization().scale.at(0);
+#endif
         const float output_scale = out->quantization().scale.at(0);
 
         const double input_product_scale = input_scale * filter_scale;

--- a/apps/hannk/test/conv2d_test.cpp
+++ b/apps/hannk/test/conv2d_test.cpp
@@ -31,7 +31,9 @@ struct Conv2D_ReferenceOp : public op_test::ReferenceOp {
 
         const float input_scale = in->quantization().scale.at(0);
         const float filter_scale = filt->quantization().scale.at(0);
+#ifndef NDEBUG
         const float bias_scale = bias->quantization().scale.at(0);
+#endif
         const float output_scale = out->quantization().scale.at(0);
 
         const double input_product_scale = input_scale * filter_scale;

--- a/apps/hannk/test/depthwise_conv2d_test.cpp
+++ b/apps/hannk/test/depthwise_conv2d_test.cpp
@@ -33,7 +33,9 @@ struct DepthwiseConv2D_ReferenceOp : public op_test::ReferenceOp {
 
         const float input_scale = in->quantization().scale.at(0);
         const float filter_scale = filt->quantization().scale.at(0);
+#ifndef NDEBUG
         const float bias_scale = bias->quantization().scale.at(0);
+#endif
         const float output_scale = out->quantization().scale.at(0);
 
         const double input_product_scale = (double)input_scale * (double)filter_scale;
@@ -42,7 +44,9 @@ struct DepthwiseConv2D_ReferenceOp : public op_test::ReferenceOp {
 
         const double output_multiplier = input_product_scale / output_scale;
 
+#ifndef NDEBUG
         const int input_depth = input_buf.dim(0).extent();
+#endif
         const int input_width = input_buf.dim(1).extent();
         const int input_height = input_buf.dim(2).extent();
         const int filter_width = filter_buf.dim(1).extent();

--- a/apps/hannk/test/fully_connected_test.cpp
+++ b/apps/hannk/test/fully_connected_test.cpp
@@ -31,7 +31,9 @@ struct FullyConnected_ReferenceOp : public op_test::ReferenceOp {
 
         const float input_scale = in->quantization().scale.at(0);
         const float filter_scale = filt->quantization().scale.at(0);
+#ifndef NDEBUG
         const float bias_scale = bias->quantization().scale.at(0);
+#endif
         const float output_scale = out->quantization().scale.at(0);
 
         const double input_product_scale = input_scale * filter_scale;

--- a/apps/hannk/util/hannk_log_tflite.cpp
+++ b/apps/hannk/util/hannk_log_tflite.cpp
@@ -5,20 +5,20 @@ namespace hannk {
 namespace internal {
 
 void hannk_log(LogSeverity severity, const char *msg) {
-  switch (severity) {
+    switch (severity) {
     case INFO:
-      TFLITE_LOG(INFO) << msg;
-      break;
+        TFLITE_LOG(INFO) << msg;
+        break;
     case WARNING:
-      TFLITE_LOG(WARN) << msg;
-      break;
+        TFLITE_LOG(WARN) << msg;
+        break;
     case ERROR:
-      TFLITE_LOG(ERROR) << msg;
-      break;
+        TFLITE_LOG(ERROR) << msg;
+        break;
     case FATAL:
-      TFLITE_LOG(FATAL) << msg;
-      break;
-  }
+        TFLITE_LOG(FATAL) << msg;
+        break;
+    }
 }
 
 }  // namespace internal


### PR DESCRIPTION
Mostly just removing unused-variable warnings, to avoid pain in other build systems. Also modify the Makefile to ensure that NDEBUG is actually defined if OPTIMIZE contains `-O[something]`.