### PR TITLE
 Improve wasm_threads documentation

### DIFF
--- a/README_webassembly.md
+++ b/README_webassembly.md
@@ -12,8 +12,8 @@ some limitations. Some of the most important:
 -   Sign-extension operations can be enabled via Target::WasmSignExt.
 -   Non-trapping float-to-int conversions can be enabled via
     Target::WasmSatFloatToInt.
--   Threads are not available yet. We'd like to support this in the future but
-    don't yet have a timeline.
+-   Threads have very limited support via Target::WasmThreads; see
+    [below](#using-threads) for more details.
 -   Halide's JIT for Wasm is extremely limited and really useful only for
     internal testing purposes.
 
@@ -130,6 +130,26 @@ they include JIT overhead as described elsewhere. Suitable benchmarks for Wasm
 will be provided at a later date. (See
 https://github.com/halide/Halide/issues/5119 and
 https://github.com/halide/Halide/issues/5047 to track progress.)
+
+# Using Threads
+
+You can use the `wasm_threads` feature to enable use of a normal pthread-based
+thread pool in Halide code, but with some careful caveats:
+
+-   This requires that you use a wasm runtime environment that provides
+    pthread-compatible wrappers. At this time of this writing, the only
+    environment known to support this well is Emscripten (when using the
+    `-pthread` flag, and compiling for a Web environment). In this
+    configuration, Emscripten goes to great lengths to make WebWorkers available
+    via the pthreads API. (You can see an example of this usage in
+    apps/HelloWasm.) Note that not all wasm runtimes support WebWorkers;
+    generally, you need a full browser environment to make this work (though
+    some versions of some shell tools may also support this, e.g. nodejs).
+-   There is currently no support for using threads in a WASI environment, due
+    to current limitations in the WASI specification. (We hope that this will
+    improve in the future.)
+-   There is no support for using threads in the Halide JIT environment, and no
+    plans to add them anytime in the near-term future.
 
 # Known Limitations And Caveats
 

--- a/apps/HelloWasm/README.md
+++ b/apps/HelloWasm/README.md
@@ -6,8 +6,10 @@ To try it out,
 
 - Build with `make all`
 
-- Run a local webserver using, e.g.: python -m SimpleHTTPServer 8080 &
+- Run a local webserver using, e.g.: python3 -m http.server 8080 &
 
 - Load Google chrome (at least version 84), go to chrome://flags, and turn on all the experimental webassembly stuff (e.g. threads, simd). If you don't do this, only the single-threaded scalar variant will work (at the time of writing).
+
+- Visit http://127.0.0.1:8080/index.html
 
 - Finally, run `make benchmark_native` and compare the performance you get with native code

--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -180,6 +180,12 @@ function(add_wasm_halide_test TARGET)
         list(APPEND WASM_SHELL_FLAGS "--experimental-wasm-simd")
     endif ()
     if (Halide_TARGET MATCHES "wasm_threads")
+        # wasm_threads requires compilation with Emscripten, against a *browser*
+        # environment rather than a shell environment. (This is because the 'pthreads'
+        # support is an elaborate wrapper than Emscripten provides around WebWorkers.)
+        # The version of d8/v8 that we pull does provide enough of a browser-like
+        # environment to support this, but many shell tools (e.g. wabt-interp) don't,
+        # so if you use a different WASM_SHELL, you may have to disable this.
         list(APPEND WASM_SHELL_FLAGS "--experimental-wasm-threads")
     endif ()
 

--- a/src/CodeGen_WebAssembly.cpp
+++ b/src/CodeGen_WebAssembly.cpp
@@ -275,6 +275,8 @@ string CodeGen_WebAssembly::mattrs() const {
     }
 
     if (target.has_feature(Target::WasmThreads)) {
+        // "WasmThreads" doesn't directly affect LLVM codegen,
+        // but it does end up requiring atomics, so be sure to enable them.
         s << sep << ",+atomics";
         sep = ",";
     }

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -844,6 +844,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_linux_host_cpu_count(c, bits_64, debug));
                 modules.push_back(get_initmod_linux_yield(c, bits_64, debug));
                 if (t.has_feature(Target::WasmThreads)) {
+                    // Assume that the wasm libc will be providing pthreads
                     modules.push_back(get_initmod_posix_threads(c, bits_64, debug));
                 } else {
                     modules.push_back(get_initmod_fake_thread_pool(c, bits_64, debug));

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -1364,7 +1364,7 @@ WasmModuleContents::WasmModuleContents(
 #if WITH_WABT
     user_assert(LLVM_VERSION >= 110) << "Using the WebAssembly JIT is only supported under LLVM 11+.";
 
-    user_assert(!target.has_feature(Target::WasmThreads)) << "The Halide WebAssembly JIT doesn't support wasm threads yet.";
+    user_assert(!target.has_feature(Target::WasmThreads)) << "wasm_threads requires Emscripten (or a similar compiler); it will never be supported under JIT.";
 
     wdebug(1) << "Compiling wasm function " << fn_name << "\n";
 

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1328,7 +1328,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_wasm_simd128,           ///< Enable +simd128 instructions for WebAssembly codegen.
     halide_target_feature_wasm_signext,           ///< Enable +sign-ext instructions for WebAssembly codegen.
     halide_target_feature_wasm_sat_float_to_int,  ///< Enable saturating (nontrapping) float-to-int instructions for WebAssembly codegen.
-    halide_target_feature_wasm_threads,          ///< Enable use of threads in WebAssembly codegen. Requires the use of a wasm runtime that provides pthread-compatible wrappers (typically, Emscripten with the -pthreads flag). Unsupported under WASI.
+    halide_target_feature_wasm_threads,           ///< Enable use of threads in WebAssembly codegen. Requires the use of a wasm runtime that provides pthread-compatible wrappers (typically, Emscripten with the -pthreads flag). Unsupported under WASI.
     halide_target_feature_wasm_bulk_memory,       ///< Enable +bulk-memory instructions for WebAssembly codegen.
     halide_target_feature_sve,                    ///< Enable ARM Scalable Vector Extensions
     halide_target_feature_sve2,                   ///< Enable ARM Scalable Vector Extensions v2

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1328,7 +1328,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_wasm_simd128,           ///< Enable +simd128 instructions for WebAssembly codegen.
     halide_target_feature_wasm_signext,           ///< Enable +sign-ext instructions for WebAssembly codegen.
     halide_target_feature_wasm_sat_float_to_int,  ///< Enable saturating (nontrapping) float-to-int instructions for WebAssembly codegen.
-    halide_target_feature_wasm_threads,           ///< Enable the thread pool for WebAssembly codegen. (Also enables +atomics)
+    halide_target_feature_wasm_threads,          ///< Enable use of threads in WebAssembly codegen. Requires the use of a wasm runtime that provides pthread-compatible wrappers (typically, Emscripten with the -pthreads flag). Unsupported under WASI.
     halide_target_feature_wasm_bulk_memory,       ///< Enable +bulk-memory instructions for WebAssembly codegen.
     halide_target_feature_sve,                    ///< Enable ARM Scalable Vector Extensions
     halide_target_feature_sve2,                   ///< Enable ARM Scalable Vector Extensions v2


### PR DESCRIPTION
The intent of this PR is to make the (considerably) limitations of using threads in wasm more apparent.

Background: wasm_threads  relies specifically on wasm runtime providing an implementation of the `pthreads` API; at this time, this is only (AFAICT) available in wasm when compiling with Emscripten, *and* targeting a web/browser environment. (What's happening under the hood is that Emscripten is taking great pains to use WebWorkers to implement pthreads.)

In other wasm runtime environments (e..g WASI), there is still no story for useful thread usage; in particular, WASI has no provision for creating or joining threads.



