### PR TITLE
Revise hannk::Tensor to use H::R::Buffer<>

### DIFF
--- a/apps/hannk/benchmark.cpp
+++ b/apps/hannk/benchmark.cpp
@@ -43,7 +43,7 @@ void run_benchmark(const std::string &filename, const ScheduleOptions &options) 
         std::cout << "Outputs:\n";
         std::vector<Tensor *> outputs = interpreter.outputs();
         for (Tensor *t : outputs) {
-            std::cout << "  \"" << t->name() << "\" : " << to_string(t->type()) << " x " << t->shape() << "\n";
+            t->dump(std::cout);
         }
     }
 }

--- a/apps/hannk/compare_vs_tflite.cpp
+++ b/apps/hannk/compare_vs_tflite.cpp
@@ -117,7 +117,7 @@ void run_all(const std::string &filename, int seed, int threads, int verbosity, 
             }
             int seed_here = seed++;
             seeds[t->name()] = seed_here;
-            auto input_buf = t->data<void>();
+            auto input_buf = t->buffer();
             dynamic_type_dispatch<FillWithRandom>(input_buf.type(), input_buf, seed_here);
             if (verbosity) {
                 std::cout << "HALIDE input " << t->name() << " inited with seed = " << seed_here << " type " << input_buf.type() << "\n";
@@ -142,7 +142,7 @@ void run_all(const std::string &filename, int seed, int threads, int verbosity, 
                 std::cout << "HALIDE output is " << t->name() << " type " << to_string(t->type()) << "\n";
             }
             // Make a copy since the Buffer might reference memory owned by the interpreter
-            halide_result.outputs.emplace_back(t->data<const void>().copy());
+            halide_result.outputs.emplace_back(t->buffer().copy());
         }
     }
 

--- a/apps/hannk/interpreter/interval.h
+++ b/apps/hannk/interpreter/interval.h
@@ -15,14 +15,11 @@ struct Interval {
     Interval()
         : min(0), max(0) {
     }
-    Interval(int point)
+    explicit Interval(int point)
         : min(point), max(1) {
     }
     Interval(int min, int max)
         : min(min), max(max) {
-    }
-    Interval(halide_dimension_t dim)
-        : min(dim.min), max(dim.min + dim.extent - 1) {
     }
 
     bool empty() const {

--- a/apps/hannk/interpreter/model.cpp
+++ b/apps/hannk/interpreter/model.cpp
@@ -141,27 +141,21 @@ void Model::dump(std::ostream &os) {
     os << std::endl;
 }
 
-void Tensor::allocate() {
-    size_t shape_size = 1;
-    for (halide_dimension_t &i : shape_) {
-        if (i.stride != 0) {
-            CHECK((size_t)i.stride == shape_size);
-        } else {
-            i.stride = shape_size;
-        }
-        shape_size *= i.extent;
-    }
-    shape_size *= sizeof_tensor_type(type());
-    if (data_.empty()) {
-        data_.resize(shape_size);
-    } else {
-        CHECK(data_.size() == shape_size);
-    }
-}
-
 void Tensor::dump(std::ostream &os) const {
-    os << "  " << to_string(type()) << " x " << shape()
-       << (is_allocated() ? " allocated " : " ") << name() << std::endl;
+    os << "  \"" << name() << "\" : "
+       << "  " << to_string(type()) << " x ";
+
+    const auto *b = buffer_.raw_buffer();
+    os << '{';
+    for (int i = 0; i < b->dimensions; i++) {
+        if (i > 0) {
+            os << ", ";
+        }
+        os << b->dim[i];
+    }
+    os << '}';
+
+    os << (is_allocated() ? " allocated " : " ") << name() << std::endl;
 }
 
 }  // namespace hannk

--- a/apps/hannk/interpreter/ops.cpp
+++ b/apps/hannk/interpreter/ops.cpp
@@ -182,7 +182,7 @@ Op::Bounds PoolOp::infer_bounds(const Box &crop) const {
 
     input_crop[1].max += filter_size_[0] - 1;
     input_crop[2].max += filter_size_[1] - 1;
-    input_crop = intersect(input_crop, without_strides(input()->shape()));
+    input_crop = intersect(input_crop, input()->box());
 
     Bounds result;
     result.inputs.emplace_back(input_crop);
@@ -207,9 +207,9 @@ void AddOp::execute(const Box &crop) {
     if (in1->type() == TensorType::UInt8 &&
         in2->type() == TensorType::UInt8 &&
         out->type() == TensorType::UInt8) {
-        auto in1_buf = in1->data<uint8_t>();
-        auto in2_buf = in2->data<uint8_t>();
-        auto output_buf = out->data<uint8_t>(crop);
+        auto in1_buf = in1->buffer<const uint8_t>();
+        auto in2_buf = in2->buffer<const uint8_t>();
+        auto output_buf = out->buffer<uint8_t>(crop);
 
         const int in1_offset = in1->quantization().zero.at(0);
         const int in2_offset = in2->quantization().zero.at(0);
@@ -264,8 +264,8 @@ void AveragePoolOp::execute(const Box &crop) {
     Tensor *out = output();
 
     if (in->type() == TensorType::UInt8 && out->type() == TensorType::UInt8) {
-        auto input_buf = in->data<uint8_t>();
-        auto output_buf = out->data<uint8_t>(crop);
+        auto input_buf = in->buffer<const uint8_t>();
+        auto output_buf = out->buffer<uint8_t>(crop);
 
         const auto output_range = get_output_range(activation_, out);
 
@@ -288,10 +288,10 @@ Op::Bounds ConcatenationOp::infer_bounds(const Box &crop) const {
     Bounds result;
     for (int i = 0; i < input_count(); i++) {
         result.inputs.emplace_back(crop);
-        result.inputs.back()[axis_] = input(i)->dim(axis_);
+        result.inputs.back()[axis_] = input(i)->interval(axis_);
     }
     result.outputs.emplace_back(crop);
-    result.outputs.back()[axis_] = output()->dim(axis_);
+    result.outputs.back()[axis_] = output()->interval(axis_);
     return result;
 }
 
@@ -305,15 +305,15 @@ std::vector<SplitInfo> ConcatenationOp::get_split_info() const {
 void ConcatenationOp::execute(const Box &crop) {
     Tensor *out = output();
 
-    auto output_buf = out->data<void>(crop);
+    auto output_buf = out->buffer(crop);
 
     int output_i = output_buf.dim(axis_).min();
     for (int i = 0; i < input_count(); i++) {
-        HalideBuffer<void> input_buf = input(i)->data<void>(crop);
+        auto input_buf = input(i)->buffer(crop);
         for (int j = input_buf.dim(axis_).min(); j <= input_buf.dim(axis_).max(); j++) {
             // TODO: Maybe we could just copy whole buffers?
-            HalideBuffer<void> input_j = input_buf.sliced(axis_, j);
-            HalideBuffer<void> output_j = output_buf.sliced(axis_, output_i++);
+            auto input_j = input_buf.sliced(axis_, j);
+            auto output_j = output_buf.sliced(axis_, output_i++);
             output_j.copy_from(input_j);
         }
     }
@@ -321,7 +321,7 @@ void ConcatenationOp::execute(const Box &crop) {
 
 Op::Bounds Conv2DOp::infer_bounds(const Box &crop) const {
     Box input_crop = crop;
-    Box filter_shape = without_strides(filter()->shape());
+    Box filter_shape = filter()->box();
 
     for (int dim = 1; dim <= 2; dim++) {
         input_crop[dim] *= stride_[dim - 1];
@@ -332,12 +332,12 @@ Op::Bounds Conv2DOp::infer_bounds(const Box &crop) const {
     input_crop[2].max += dilation_[1] * (filter_shape[2].extent() - 1);
 
     if (padding_ == Padding::Same) {
-        const int input_width = input()->dim(1).extent;
-        const int input_height = input()->dim(2).extent;
-        const int filter_width = filter()->dim(1).extent;
-        const int filter_height = filter()->dim(2).extent;
-        const int output_width = output()->dim(1).extent;
-        const int output_height = output()->dim(2).extent;
+        const int input_width = input()->extent(1);
+        const int input_height = input()->extent(2);
+        const int filter_width = filter()->extent(1);
+        const int filter_height = filter()->extent(2);
+        const int output_width = output()->extent(1);
+        const int output_height = output()->extent(2);
 
         const int dilated_filter_width = dilation_[0] * (filter_width - 1) + 1;
         const int dilated_filter_height = dilation_[1] * (filter_height - 1) + 1;
@@ -350,12 +350,12 @@ Op::Bounds Conv2DOp::infer_bounds(const Box &crop) const {
         input_crop[1] += pad_width;
         input_crop[2] += pad_height;
     }
-    input_crop = intersect(input_crop, without_strides(input()->shape()));
+    input_crop = intersect(input_crop, input()->box());
 
     Bounds result;
     result.inputs.emplace_back(input_crop);
     result.inputs.emplace_back(std::move(filter_shape));
-    result.inputs.emplace_back(without_strides(bias()->shape()));
+    result.inputs.emplace_back(bias()->box());
     result.outputs = {crop};
 
     return result;
@@ -378,10 +378,10 @@ void Conv2DOp::execute(const Box &crop) {
         filt->type() == TensorType::UInt8 &&
         out->type() == TensorType::UInt8) {
         // TODO: reduce code duplication between here and DepthwiseConv2D
-        auto input_buf = in->data<uint8_t>();
-        auto filter_buf = filt->data<uint8_t>();
-        auto bias_buf = bias()->data<int32_t>();
-        auto output_buf = out->data<uint8_t>(crop);
+        auto input_buf = in->buffer<const uint8_t>();
+        auto filter_buf = filt->buffer<const uint8_t>();
+        auto bias_buf = bias()->buffer<const int32_t>();
+        auto output_buf = out->buffer<uint8_t>(crop);
 
         const int input_offset = in->quantization().zero.at(0);
         const int filter_offset = filt->quantization().zero.at(0);
@@ -461,12 +461,12 @@ void Conv2DOp::execute(const Box &crop) {
 }
 
 int DepthwiseConv2DOp::depth_multiplier() const {
-    return output()->dim(0).extent / input()->dim(0).extent;
+    return output()->extent(0) / input()->extent(0);
 }
 
 Op::Bounds DepthwiseConv2DOp::infer_bounds(const Box &crop) const {
     Box input_crop = crop;
-    Box filter_shape = without_strides(filter()->shape());
+    Box filter_shape = filter()->box();
 
     input_crop[0] = crop[0];
     input_crop[0] /= depth_multiplier();
@@ -478,12 +478,12 @@ Op::Bounds DepthwiseConv2DOp::infer_bounds(const Box &crop) const {
     input_crop[2].max += dilation_[1] * (filter_shape[2].extent() - 1);
 
     if (padding_ == Padding::Same) {
-        const int input_width = input()->dim(1).extent;
-        const int input_height = input()->dim(2).extent;
-        const int filter_width = filter()->dim(1).extent;
-        const int filter_height = filter()->dim(2).extent;
-        const int output_width = output()->dim(1).extent;
-        const int output_height = output()->dim(2).extent;
+        const int input_width = input()->extent(1);
+        const int input_height = input()->extent(2);
+        const int filter_width = filter()->extent(1);
+        const int filter_height = filter()->extent(2);
+        const int output_width = output()->extent(1);
+        const int output_height = output()->extent(2);
 
         const int dilated_filter_width = dilation_[0] * (filter_width - 1) + 1;
         const int dilated_filter_height = dilation_[1] * (filter_height - 1) + 1;
@@ -497,12 +497,12 @@ Op::Bounds DepthwiseConv2DOp::infer_bounds(const Box &crop) const {
         input_crop[2] += pad_height;
     }
 
-    input_crop = intersect(input_crop, without_strides(input()->shape()));
+    input_crop = intersect(input_crop, input()->box());
 
     Bounds result;
     result.inputs.emplace_back(input_crop);
     result.inputs.emplace_back(std::move(filter_shape));
-    result.inputs.emplace_back(without_strides(bias()->shape()));
+    result.inputs.emplace_back(bias()->box());
     result.outputs = {crop};
     return result;
 }
@@ -524,10 +524,10 @@ void DepthwiseConv2DOp::execute(const Box &crop) {
         filt->type() == TensorType::UInt8 &&
         out->type() == TensorType::UInt8) {
         // TODO: reduce code duplication between here and Conv2D
-        auto input_buf = in->data<uint8_t>();
-        auto filter_buf = filt->data<uint8_t>().sliced(3, 0);
-        auto bias_buf = bias()->data<int32_t>();
-        auto output_buf = out->data<uint8_t>(crop);
+        auto input_buf = in->buffer<const uint8_t>();
+        auto filter_buf = filt->buffer<const uint8_t>().sliced(3, 0);
+        auto bias_buf = bias()->buffer<const int32_t>();
+        auto output_buf = out->buffer<uint8_t>(crop);
 
         int depth_multiplier = this->depth_multiplier();
         assert(depth_multiplier * input_buf.dim(0).extent() == output_buf.dim(0).extent());
@@ -610,10 +610,10 @@ void DepthwiseConv2DOp::execute(const Box &crop) {
 
 Op::Bounds FullyConnectedOp::infer_bounds(const Box &crop) const {
     Bounds result;
-    result.inputs.emplace_back(without_strides(input()->shape()));
-    result.inputs.emplace_back(without_strides(filter()->shape()));
-    result.inputs.emplace_back(without_strides(bias()->shape()));
-    result.outputs.emplace_back(without_strides(output()->shape()));
+    result.inputs.emplace_back(input()->box());
+    result.inputs.emplace_back(filter()->box());
+    result.inputs.emplace_back(bias()->box());
+    result.outputs.emplace_back(output()->box());
     return result;
 }
 
@@ -632,10 +632,10 @@ void FullyConnectedOp::execute(const Box &crop) {
     if (in->type() == TensorType::UInt8 &&
         filt->type() == TensorType::UInt8 &&
         out->type() == TensorType::UInt8) {
-        auto input_buf = in->data<uint8_t>();
-        auto filter_buf = filt->data<uint8_t>();
-        auto bias_buf = bias()->data<int32_t>();
-        auto output_buf = out->data<uint8_t>(crop);
+        auto input_buf = in->buffer<const uint8_t>();
+        auto filter_buf = filt->buffer<const uint8_t>();
+        auto bias_buf = bias()->buffer<const int32_t>();
+        auto output_buf = out->buffer<uint8_t>(crop);
 
         const int input_offset = in->quantization().zero.at(0);
         const int filter_offset = filt->quantization().zero.at(0);
@@ -683,8 +683,8 @@ void MaxPoolOp::execute(const Box &crop) {
     Tensor *out = output();
 
     if (in->type() == TensorType::UInt8 && out->type() == TensorType::UInt8) {
-        auto input_buf = in->data<uint8_t>();
-        auto output_buf = out->data<uint8_t>(crop);
+        auto input_buf = in->buffer<const uint8_t>();
+        auto output_buf = out->buffer<uint8_t>(crop);
 
         // TODO: does this need to handle Padding::Same?
         CHECK(padding_ == Padding::Valid) << "AveragePoolOp doesn't handle all paddings yet";
@@ -701,7 +701,7 @@ void MaxPoolOp::execute(const Box &crop) {
 }
 
 Op::Bounds PadOp::infer_bounds(const Box &crop) const {
-    auto padding = input(1)->data<const int32_t>();
+    auto padding = input(1)->buffer<const int32_t>();
 
     Bounds result;
 
@@ -711,8 +711,8 @@ Op::Bounds PadOp::infer_bounds(const Box &crop) const {
     }
 
     result.inputs.emplace_back(
-        intersect(padded_crop, without_strides(input(0)->shape())));
-    result.inputs.emplace_back(without_strides(input(1)->shape()));
+        intersect(padded_crop, input(0)->box()));
+    result.inputs.emplace_back(input(1)->box());
     result.outputs.emplace_back(crop);
     return result;
 }
@@ -723,12 +723,12 @@ std::vector<SplitInfo> PadOp::get_split_info() const {
 
 void PadOp::execute(const Box &crop) {
     const Tensor *in = input(0);
-    auto padding = input(1)->data<const int32_t>();
+    auto padding = input(1)->buffer<const int32_t>();
     Tensor *out = output();
 
     if (sizeof_tensor_type(out->type()) == 1) {
-        auto input_buf = in->data<uint8_t>();
-        auto output_buf = out->data<uint8_t>(crop);
+        auto input_buf = in->buffer<const uint8_t>();
+        auto output_buf = out->buffer<uint8_t>(crop);
 
         for (int d = 0; d < output_buf.dimensions(); d++) {
             input_buf.translate(d, padding(0, d));
@@ -747,7 +747,7 @@ void PadOp::execute(const Box &crop) {
 // TODO: Maybe this is only a reshape in some dimensions, in which case we might be able to split it.
 Op::Bounds ReshapeOp::infer_bounds(const Box &crop) const {
     Bounds result;
-    result.inputs = {without_strides(input()->shape())};
+    result.inputs = {input()->box()};
     result.outputs = {crop};
     return result;
 }
@@ -760,8 +760,8 @@ void ReshapeOp::execute(const Box &crop) {
     const Tensor *in = input();
     Tensor *out = output();
 
-    auto input_buf = in->data<void>();
-    auto output_buf = out->data<void>(crop);
+    auto input_buf = in->buffer<const void>();
+    auto output_buf = out->buffer(crop);
 
     // TODO: should reality-check that the output buf matches the shape we expect
     // assert((int) new_shape_.size() == output_buf.dimensions());
@@ -783,8 +783,8 @@ void QuantizeOp::execute(const Box &crop) {
     if (in->type() == TensorType::UInt8 && out->type() == TensorType::UInt8) {
         // We're going to implement this by just doing an Add with itself, but with
         // the quantization parameters to produce 0 for the other op.
-        auto in_buf = in->data<uint8_t>();
-        auto output_buf = out->data<uint8_t>(crop);
+        auto in_buf = in->buffer<const uint8_t>();
+        auto output_buf = out->buffer<uint8_t>(crop);
 
         const int in1_offset = in->quantization().zero.at(0);
         const int in2_offset = 0;

--- a/apps/hannk/test/add_test.cpp
+++ b/apps/hannk/test/add_test.cpp
@@ -17,9 +17,9 @@ struct Add_ReferenceOp : public op_test::ReferenceOp {
             in2->type() == to_tensor_type<T>() &&
             out->type() == to_tensor_type<T>());
 
-        auto in1_buf = in1->data<T>();
-        auto in2_buf = in2->data<T>();
-        auto out_buf = out->data<T>();
+        auto in1_buf = in1->buffer<const T>();
+        auto in2_buf = in2->buffer<const T>();
+        auto out_buf = out->buffer<T>();
 
         const int in1_offset = in1->quantization().zero.at(0);
         const int in2_offset = in2->quantization().zero.at(0);

--- a/apps/hannk/test/average_pool_test.cpp
+++ b/apps/hannk/test/average_pool_test.cpp
@@ -15,8 +15,8 @@ struct AveragePool_ReferenceOp : public op_test::ReferenceOp {
             in->type() == to_tensor_type<T>() &&
             out->type() == to_tensor_type<T>());
 
-        auto in_buf = in->data<T>();
-        auto out_buf = out->data<T>();
+        auto in_buf = in->buffer<const T>();
+        auto out_buf = out->buffer<T>();
 
         // TODO: does this need to handle Padding::Same?
         CHECK(padding == Padding::Valid) << "AveragePoolOp doesn't handle all paddings yet";

--- a/apps/hannk/test/concatenation_test.cpp
+++ b/apps/hannk/test/concatenation_test.cpp
@@ -11,7 +11,7 @@ struct Concatenation_ReferenceOp : public op_test::ReferenceOp {
         Tensor *out = outputs.at(0).get();
         CHECK(out->type() == to_tensor_type<T>());
 
-        auto out_buf = out->data<T>();
+        auto out_buf = out->buffer<T>();
         const int dims = out_buf.dimensions();
         assert(axis >= 0 && axis < dims);
 
@@ -19,7 +19,7 @@ struct Concatenation_ReferenceOp : public op_test::ReferenceOp {
         for (size_t i = 0; i < inputs.size(); i++) {
             const Tensor *in = inputs.at(i).get();
             CHECK(in->type() == to_tensor_type<T>());
-            auto in_buf = in->data<const T>();
+            auto in_buf = in->buffer<const T>();
             CHECK(in_buf.dimensions() == dims);
             for (int j = 0; j < dims; j++) {
                 if (j != axis) {

--- a/apps/hannk/test/conv2d_test.cpp
+++ b/apps/hannk/test/conv2d_test.cpp
@@ -20,10 +20,10 @@ struct Conv2D_ReferenceOp : public op_test::ReferenceOp {
             bias->type() == TensorType::Int32 &&
             out->type() == to_tensor_type<T>());
 
-        auto input_buf = in->data<T>();
-        auto filter_buf = filt->data<T>();
-        auto bias_buf = bias->data<int32_t>();
-        auto output_buf = out->data<T>();
+        auto input_buf = in->buffer<const T>();
+        auto filter_buf = filt->buffer<const T>();
+        auto bias_buf = bias->buffer<const int32_t>();
+        auto output_buf = out->buffer<T>();
 
         const int input_offset = in->quantization().zero.at(0);
         const int filter_offset = filt->quantization().zero.at(0);
@@ -97,7 +97,7 @@ struct Conv2DOpTestFactory : public op_test::TestCaseFactory {
     static void fill_tensor_with_random_bias(Tensor &t, int seed) {
         // bias is an int32, but using values outside the int16 range tends to
         // overflow and make uninteresting results.
-        auto buf = t.data<int32_t>();
+        auto buf = t.buffer<int32_t>();
         std::mt19937 rng(seed);
         std::uniform_int_distribution<int32_t> dis(-32767, 32767);
         buf.for_each_value([&rng, &dis](int32_t &value) {
@@ -165,7 +165,7 @@ struct Conv2DOpTestFactory : public op_test::TestCaseFactory {
             108, 118, 131, 102, 115, 114, 123, 133, 118, 107, 99, 114, 132, 122, 117,
             127, 133, 125, 113, 126, 124, 139, 111, 116, 131, 111, 117, 128, 120, 125,
             132, 119, 108, 122, 123, 120, 118, 121, 122};
-        auto buf = t.data<uint8_t>();
+        auto buf = t.buffer<uint8_t>();
         assert(buf.size_in_bytes() == sizeof(filter_data));
         memcpy(buf.data(), filter_data, sizeof(filter_data));
     }
@@ -182,7 +182,7 @@ struct Conv2DOpTestFactory : public op_test::TestCaseFactory {
             0, 0, 229, 251, 255, 255, 189, 44, 0, 0, 40, 45, 0, 0, 113,
             2, 0, 0, 98, 41, 0, 0, 74, 1, 0, 0, 216, 35, 0, 0,
             74, 217, 255, 255, 149, 68, 0, 0};
-        auto buf = t.data<int32_t>();
+        auto buf = t.buffer<int32_t>();
         assert(buf.size_in_bytes() == sizeof(bias_data));
         memcpy(buf.data(), bias_data, sizeof(bias_data));
     }

--- a/apps/hannk/test/depthwise_conv2d_test.cpp
+++ b/apps/hannk/test/depthwise_conv2d_test.cpp
@@ -20,10 +20,10 @@ struct DepthwiseConv2D_ReferenceOp : public op_test::ReferenceOp {
             bias->type() == TensorType::Int32 &&
             out->type() == to_tensor_type<T>());
 
-        auto input_buf = in->data<T>();
-        auto filter_buf = filt->data<T>();
-        auto bias_buf = bias->data<int32_t>();
-        auto output_buf = out->data<T>();
+        auto input_buf = in->buffer<const T>();
+        auto filter_buf = filt->buffer<const T>();
+        auto bias_buf = bias->buffer<const int32_t>();
+        auto output_buf = out->buffer<T>();
 
         int depth_multiplier = output_buf.dim(0).extent() / input_buf.dim(0).extent();
 
@@ -101,7 +101,7 @@ struct DepthwiseConv2DOpTestFactory : public op_test::TestCaseFactory {
     static void fill_tensor_with_random_bias(Tensor &t, int seed) {
         // bias is an int32, but using values outside the int16 range tends to
         // overflow and make uninteresting results.
-        auto buf = t.data<int32_t>();
+        auto buf = t.buffer<int32_t>();
         std::mt19937 rng(seed);
         std::uniform_int_distribution<int32_t> dis(-32767, 32767);
         buf.for_each_value([&rng, &dis](int32_t &value) {
@@ -126,7 +126,7 @@ struct DepthwiseConv2DOpTestFactory : public op_test::TestCaseFactory {
             106, 165, 166, 136, 165, 168, 166, 165, 172, 165, 164, 166, 164, 165, 165, 165, 165, 165, 165, 43,
             160, 165, 163, 172, 165, 164, 165, 165, 97, 156, 165, 165, 98, 165, 160, 106, 165, 165, 166, 165,
             165, 165, 165, 165, 165, 163, 167, 165};
-        auto buf = t.data<uint8_t>();
+        auto buf = t.buffer<uint8_t>();
         assert(buf.size_in_bytes() == sizeof(filter_data));
         memcpy(buf.data(), filter_data, sizeof(filter_data));
     }
@@ -140,7 +140,7 @@ struct DepthwiseConv2DOpTestFactory : public op_test::TestCaseFactory {
             0, 88, 255, 255, 255, 127, 0, 0, 0, 96, 1, 0, 0, 19, 0, 0, 0, 65, 255, 255, 255, 122, 1, 0, 0, 126,
             1, 0, 0, 1, 0, 0, 0, 167, 1, 0, 0, 190, 255, 255, 255, 254, 0, 0, 0, 175, 255, 255, 255, 73, 253,
             255, 255};
-        auto buf = t.data<int32_t>();
+        auto buf = t.buffer<int32_t>();
         assert(buf.size_in_bytes() == sizeof(bias_data));
         memcpy(buf.data(), bias_data, sizeof(bias_data));
     }

--- a/apps/hannk/test/fully_connected_test.cpp
+++ b/apps/hannk/test/fully_connected_test.cpp
@@ -20,10 +20,10 @@ struct FullyConnected_ReferenceOp : public op_test::ReferenceOp {
             bias->type() == TensorType::Int32 &&
             out->type() == to_tensor_type<T>());
 
-        auto input_buf = in->data<T>();
-        auto filter_buf = filt->data<T>();
-        auto bias_buf = bias->data<int32_t>();
-        auto output_buf = out->data<T>();
+        auto input_buf = in->buffer<const T>();
+        auto filter_buf = filt->buffer<const T>();
+        auto bias_buf = bias->buffer<const int32_t>();
+        auto output_buf = out->buffer<T>();
 
         const int input_offset = in->quantization().zero.at(0);
         const int filter_offset = filt->quantization().zero.at(0);
@@ -71,7 +71,7 @@ struct FullyConnectedOpTestFactory : public op_test::TestCaseFactory {
     static void fill_tensor_with_random_bias(Tensor &t, int seed) {
         // bias is an int32, but using values outside the int16 range tends to
         // overflow and make uninteresting results.
-        auto buf = t.data<int32_t>();
+        auto buf = t.buffer<int32_t>();
         std::mt19937 rng(seed);
         std::uniform_int_distribution<int32_t> dis(-32767, 32767);
         buf.for_each_value([&rng, &dis](int32_t &value) {

--- a/apps/hannk/test/max_pool_test.cpp
+++ b/apps/hannk/test/max_pool_test.cpp
@@ -15,8 +15,8 @@ struct MaxPool_ReferenceOp : public op_test::ReferenceOp {
             in->type() == to_tensor_type<T>() &&
             out->type() == to_tensor_type<T>());
 
-        auto in_buf = in->data<T>();
-        auto out_buf = out->data<T>();
+        auto in_buf = in->buffer<const T>();
+        auto out_buf = out->buffer<T>();
 
         // TODO: does this need to handle Padding::Same?
         CHECK(padding == Padding::Valid) << "MaxPoolOp doesn't handle all paddings yet";

--- a/apps/hannk/test/pad_test.cpp
+++ b/apps/hannk/test/pad_test.cpp
@@ -17,9 +17,9 @@ struct Pad_ReferenceOp : public op_test::ReferenceOp {
             pad->type() == TensorType::Int32 &&
             out->type() == to_tensor_type<T>());
 
-        auto in_buf = in->data<T>();
-        auto pad_buf = pad->data<int32_t>();
-        auto out_buf = out->data<T>();
+        auto in_buf = in->buffer<const T>();
+        auto pad_buf = pad->buffer<const int32_t>();
+        auto out_buf = out->buffer<T>();
 
         const int dims = in_buf.dimensions();
         CHECK(out_buf.dimensions() == dims);
@@ -45,7 +45,7 @@ struct Pad_ReferenceOp : public op_test::ReferenceOp {
 
 struct PadOpTestFactory : public op_test::TestCaseFactory {
     static void fill_padding(Tensor &t, int seed) {
-        auto buf = t.data<int32_t>();
+        auto buf = t.buffer<int32_t>();
         buf.fill(0);
         buf(0, 0) = 4;   // add 4 values before startof dim(0)
         buf(1, 0) = 12;  // add 12 values after end of dim(0)

--- a/apps/hannk/test/quantize_test.cpp
+++ b/apps/hannk/test/quantize_test.cpp
@@ -15,8 +15,8 @@ struct Quantize_ReferenceOp : public op_test::ReferenceOp {
             in->type() == to_tensor_type<InT>() &&
             out->type() == to_tensor_type<OutT>());
 
-        auto in_buf = in->data<InT>();
-        auto out_buf = out->data<OutT>();
+        auto in_buf = in->buffer<const InT>();
+        auto out_buf = out->buffer<OutT>();
         check_shapes_match(in_buf, out_buf);
 
         const int in_offset = in->quantization().zero.at(0);

--- a/apps/hannk/test/reshape_test.cpp
+++ b/apps/hannk/test/reshape_test.cpp
@@ -17,9 +17,9 @@ struct Reshape_ReferenceOp : public op_test::ReferenceOp {
             shape->type() == TensorType::Int32 &&
             out->type() == to_tensor_type<T>());
 
-        auto in_buf = in->data<T>();
-        auto shape_buf = shape->data<int32_t>();
-        auto out_buf = out->data<T>();
+        auto in_buf = in->buffer<const T>();
+        auto shape_buf = shape->buffer<const int32_t>();
+        auto out_buf = out->buffer<T>();
 
         CHECK(shape_buf.dimensions() == 1);
         CHECK(shape_buf.dim(0).extent() == out_buf.dimensions());
@@ -38,7 +38,7 @@ struct Reshape_ReferenceOp : public op_test::ReferenceOp {
 
 struct ReshapeOpTestFactory : public op_test::TestCaseFactory {
     static void fill_shape(Tensor &t, int seed) {
-        auto buf = t.data<int32_t>();
+        auto buf = t.buffer<int32_t>();
         buf(0) = 768;
         buf(1) = 1;
     }
@@ -76,7 +76,7 @@ struct ReshapeOpTestFactory : public op_test::TestCaseFactory {
         r->outputs.push_back(out);
 
         std::vector<int> shape_vals;
-        auto shape_buf = shape->data<int32_t>();
+        auto shape_buf = shape->buffer<const int32_t>();
         for (int i = 0; i < shape_buf.dim(0).extent(); i++) {
             shape_vals.push_back(shape_buf(i));
         }

--- a/apps/hannk/util/hannk_log_tflite.cpp
+++ b/apps/hannk/util/hannk_log_tflite.cpp
@@ -7,8 +7,8 @@ namespace internal {
 void hannk_log(LogSeverity severity, const char *msg) {
     // TFLite will append std::endl, so back up to ignore any that we append
     size_t len = strlen(msg);
-    while (len > 0 && msg[len-1] == '\n') {
-      --len;
+    while (len > 0 && msg[len - 1] == '\n') {
+        --len;
     }
     switch (severity) {
     case INFO:


### PR DESCRIPTION
We originally used a bespoke mix of data and dimensions, wrapping Buffers around them on the fly; this just uses Buffer as the fundamental type, simplifying things. As a bonus, it allows us to avoid copying read-only data (since Buffer can just reference the external pointer directly), making #5671 obsolete.