### PR TITLE
Added support for ClangCL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,11 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Increase the stack size for MSVC builds:
+if(MSVC)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:8388608")
+endif()
+
 # Build Halide with ccache if the package is present
 option(Halide_CCACHE_BUILD "Set to ON for a ccache enabled build" OFF)
 if (Halide_CCACHE_BUILD)
@@ -60,6 +65,7 @@ if (Halide_CCACHE_BUILD)
         message(FATAL_ERROR "Unable to find the program ccache. Set Halide_CCACHE_BUILD to OFF")
     endif ()
 endif ()
+
 
 ##
 # Import dependencies

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -345,6 +345,9 @@ add_subdirectory(runtime)
 # Build the Halide mono-header.
 ##
 
+set(CXX_COMPILER_IS_GNU_OR_CLANG $<CXX_COMPILER_ID:GNU,Clang,AppleClang>)
+set(CXX_COMPILER_IS_GNU_OR_CLANG_AND_NOT_CLANGCL $<AND:${CXX_COMPILER_IS_GNU_OR_CLANG},$<NOT:$<STREQUAL:${CMAKE_CXX_SIMULATE_ID},MSVC>>>)
+
 set(HALIDE_H "${Halide_BINARY_DIR}/include/Halide.h")
 set(LICENSE_PATH "${Halide_SOURCE_DIR}/LICENSE.txt")
 add_custom_command(OUTPUT "${Halide_BINARY_DIR}/include/Halide.h"
@@ -372,7 +375,7 @@ target_link_libraries(Halide PUBLIC Halide::LanguageOptions)
 target_compile_definitions(Halide
                            PRIVATE
                            $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,STATIC_LIBRARY>:Halide_STATIC_DEFINE>
-                           $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:WITH_INTROSPECTION>)
+                           $<${CXX_COMPILER_IS_GNU_OR_CLANG_AND_NOT_CLANGCL}:WITH_INTROSPECTION>)
 
 include(TargetExportScript)
 ## TODO: implement something similar for Windows/link.exe
@@ -406,10 +409,10 @@ target_include_directories(Halide INTERFACE ${Halide_INCLUDE_PATH})
 
 target_compile_options(Halide
                        PRIVATE
-                       $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall>
-                       $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-unused-function>
-                       $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wcast-qual>
-                       $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wignored-qualifiers>
+                       $<${CXX_COMPILER_IS_GNU_OR_CLANG_AND_NOT_CLANGCL}:-Wall>
+                       $<${CXX_COMPILER_IS_GNU_OR_CLANG}:-Wno-unused-function>
+                       $<${CXX_COMPILER_IS_GNU_OR_CLANG}:-Wcast-qual>
+                       $<${CXX_COMPILER_IS_GNU_OR_CLANG}:-Wignored-qualifiers>
 
                        $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang>:-Woverloaded-virtual>
                        $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wsuggest-override>

--- a/src/Util.h
+++ b/src/Util.h
@@ -44,11 +44,6 @@
 #define HALIDE_NO_USER_CODE_INLINE HALIDE_NEVER_INLINE
 #endif
 
-// On windows, Halide needs a larger stack than the default MSVC provides
-#ifdef _MSC_VER
-#pragma comment(linker, "/STACK:8388608,1048576")
-#endif
-
 namespace Halide {
 
 /** Load a plugin in the form of a dynamic library (e.g. for custom autoschedulers).


### PR DESCRIPTION
This PR makes minor changes to the build in order to support ClangCl on VS. The required change is mostly about the stack size. Currently MSVC requires a higher stack size, and this setting was in `Util.h`. However clang does not support the `pragma`. Therefore this PR sets the same flag via CMake compiler options *for the executables built by this project*. The flag is currently not passed transitively to downstream projects. And it is not discriminating between executables in the Halide project - all executables get the higher stack size. This seems to be correct at least for `tutorial`, `test` and `benchmark` executables.

To be discussed:
 - What other build systems (than CMake) need to be supported?
    - Quoting from Alex Reinking (Mar 26 20:15) on Gitter: We only support CMake on Windows and that flag does not affect our non-Windows users (due to _MSC_VER check), so it's ok to move.
    - Therefore it seems the CMake build provides the same functionality as the previous solution *except* it may handle differently the case of passing the stack size to downstream projects. See the next question below.
 - Should the stack size be passed transitively to downstream projects?