### PR TITLE
CMake build: Add more user control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,13 @@ endif ()
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 # Require standard C++14
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+elseif(CMAKE_CXX_STANDARD LESS 14)
+    message(FATAL_ERROR "Halide requires C++14 or newer")
+endif()
 
 # Build Halide with ccache if the package is present
 option(Halide_CCACHE_BUILD "Set to ON for a ccache enabled build" OFF)

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -77,7 +77,9 @@ else ()
     set(rbase $ORIGIN)
 endif ()
 
-set_target_properties(${exes} PROPERTIES INSTALL_RPATH "${rbase};${rbase}/${lib_dir}")
+if (NOT CMAKE_INSTALL_RPATH)
+    set_target_properties(${exes} PROPERTIES INSTALL_RPATH "${rbase};${rbase}/${lib_dir}")
+endif ()
 
 install(TARGETS ${exes}
         EXPORT Halide_Interfaces)


### PR DESCRIPTION
This PR allows users to override the settings for `CMAKE_INSTALL_RPATH` and `CMAKE_CXX_STANDARD` from outside `CMakeLists.txt`. There should be no negative effects since the defaults are preserved. But users that want or need to override RPATH or the C++ standard get the freedom to do so.