### PR TITLE
Add wasm support for int32->f64 and f32->f64 simd ops

### DIFF
--- a/src/CodeGen_WebAssembly.cpp
+++ b/src/CodeGen_WebAssembly.cpp
@@ -97,7 +97,6 @@ const WasmIntrinsic intrinsic_defs[] = {
     {"i32_to_double_s", Float(64, 4), "int_to_double", {Int(32, 4)}, Target::WasmSimd128},
     {"i32_to_double_u", Float(64, 4), "int_to_double", {UInt(32, 4)}, Target::WasmSimd128},
     {"float_to_double", Float(64, 4), "float_to_double", {Float(32, 4)}, Target::WasmSimd128},
-#endif
 
     // Basically like ARM's SQRDMULH
     {"llvm.wasm.q15mulr.sat.signed", Int(16, 8), "q15mulr_sat_s", {Int(16, 8), Int(16, 8)}, Target::WasmSimd128},

--- a/src/runtime/wasm_math.ll
+++ b/src/runtime/wasm_math.ll
@@ -104,4 +104,35 @@ define weak_odr <4 x i64> @widening_mul_u32x4(<4 x i32> %x, <4 x i32> %y) nounwi
   ret <4 x i64> %3
 }
 
+; Integer to double-precision floating point
 
+declare <2 x double> @llvm.wasm.convert.low.signed(<4 x i32>)
+declare <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32>)
+
+define weak_odr <4 x double> @i32_to_double_s(<4 x i32> %x) nounwind alwaysinline {
+  %1 = shufflevector <4 x i32> %x, <4 x i32> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
+  %2 = tail call <2 x double> @llvm.wasm.convert.low.signed(<4 x i32> %x)
+  %3 = tail call <2 x double> @llvm.wasm.convert.low.signed(<4 x i32> %1)
+  %4 = shufflevector <2 x double> %2, <2 x double> %3, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret <4 x double> %4
+}
+
+define weak_odr <4 x double> @i32_to_double_u(<4 x i32> %x) nounwind alwaysinline {
+  %1 = shufflevector <4 x i32> %x, <4 x i32> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
+  %2 = tail call <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32> %x)
+  %3 = tail call <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32> %1)
+  %4 = shufflevector <2 x double> %2, <2 x double> %3, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret <4 x double> %4
+}
+
+; single to double-precision floating point
+
+declare <2 x double> @llvm.wasm.promote.low(<4 x float>)
+
+define weak_odr <4 x double> @float_to_double(<4 x float> %x) nounwind alwaysinline {
+  %1 = shufflevector <4 x float> %x, <4 x float> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
+  %2 = tail call <2 x double> @llvm.wasm.promote.low(<4 x float> %x)
+  %3 = tail call <2 x double> @llvm.wasm.promote.low(<4 x float> %1)
+  %4 = shufflevector <2 x double> %2, <2 x double> %3, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret <4 x double> %4
+}

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -2107,9 +2107,8 @@ public:
                 check("f32x4.convert_i32x4_u", 8 * w, cast<float>(u32_1));
 
                 // Integer to double-precision floating point
-                // TODO(https://github.com/halide/Halide/issues/5130): NOT BEING GENERATED AT TRUNK
-                // check("f64x2.convert_low_i32x4_s", 4 * w, cast<double>(i32_1));
-                // check("f64x2.convert_low_i32x4_u", 4 * w, cast<double>(u32_1));
+                check("f64x2.convert_low_i32x4_s", 2 * w, cast<double>(i32_1));
+                check("f64x2.convert_low_i32x4_u", 2 * w, cast<double>(u32_1));
 
                 // Single-precision floating point to integer with saturation
                 check("i32x4.trunc_sat_f32x4_s", 4 * w, cast<int32_t>(f32_1));
@@ -2125,8 +2124,7 @@ public:
                 // check("f32x4.demote_f64x2_zero", 4 * w, ???);
 
                 // Single-precision floating point to double-precision
-                // TODO(https://github.com/halide/Halide/issues/5130): NOT BEING GENERATED AT TRUNK
-                // check("f64x2.promote_low_f32x4", 4 * w, ???);
+                check("f64x2.promote_low_f32x4", 2 * w, cast<double>(f32_1));
 
                 // Integer to integer narrowing
                 // TODO(https://github.com/halide/Halide/issues/5130): NOT BEING GENERATED AT TRUNK

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -94,32 +94,27 @@ public:
         std::string asm_filename = output_directory + "check_" + name + ".s";
         f.compile_to_assembly(asm_filename, arg_types, target);
 
+        std::ifstream asm_file;
+        asm_file.open(asm_filename);
+
         bool found_it = false;
 
         std::ostringstream msg;
         msg << op << " did not generate for target=" << target.to_string() << " vector_width=" << vector_width << ". Instead we got:\n";
 
-        {
-            std::ifstream asm_file;
-            asm_file.open(asm_filename);
+        std::string line;
+        while (getline(asm_file, line)) {
+            msg << line << "\n";
 
-            std::string line;
-            while (getline(asm_file, line)) {
-                msg << line << "\n";
-
-                // Check for the op in question
-                found_it |= wildcard_search(op, line) && !wildcard_search("_" + op, line);
-            }
-            asm_file.close();
+            // Check for the op in question
+            found_it |= wildcard_search(op, line) && !wildcard_search("_" + op, line);
         }
 
         if (!found_it) {
             error_msg << "Failed: " << msg.str() << "\n";
-
-            // Occasionally useful for debugging: stop at the first failure.
-            // std::cerr << error_msg.str();
-            // exit(-1);
         }
+
+        asm_file.close();
 
         // Also compile the error checking Func (to be sure it compiles without error)
         std::string fn_name = "test_" + name;


### PR DESCRIPTION
At top-of-tree LLVM, the wasm backend never seems to emit the vector version of these ops; pattern-match to target them specifically.
