### PR TITLE
Use a varying seed for random test data in simd_op_check

### DIFF
--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -2192,6 +2192,10 @@ int main(int argc, char **argv) {
         test.filter = getenv("HL_SIMD_OP_CHECK_FILTER");
     }
 
+    const int seed = argc > 2 ? atoi(argv[2]) : time(nullptr);
+    std::cout << "simd_op_check test seed: " << seed << "\n";
+    test.set_seed(seed);
+
     // TODO: multithreading here is the cause of https://github.com/halide/Halide/issues/3669;
     // the fundamental issue is that we make one set of ImageParams to construct many
     // Exprs, then realize those Exprs on arbitrary threads; it is known that sharing

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -24,6 +24,7 @@ public:
     std::string filter{"*"};
     std::string output_directory{Internal::get_test_tmp_dir()};
     std::vector<Task> tasks;
+    std::mt19937 rng;
 
     Target target;
 
@@ -54,6 +55,11 @@ public:
         num_threads = Internal::ThreadPool<void>::num_processors_online();
     }
     virtual ~SimdOpCheckTest() = default;
+
+    void set_seed(int seed) {
+        rng.seed(seed);
+    }
+
     size_t get_num_threads() const {
         return num_threads;
     }
@@ -230,7 +236,6 @@ public:
 
             error.infer_input_bounds({}, run_target);
             // Fill the inputs with noise
-            std::mt19937 rng(123);
             for (auto p : image_params) {
                 Halide::Buffer<> buf = p.get();
                 if (!buf.defined()) continue;

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -732,6 +732,10 @@ int main(int argc, char **argv) {
         test_hvx.filter = getenv("HL_SIMD_OP_CHECK_FILTER");
     }
 
+    const int seed = argc > 2 ? atoi(argv[2]) : time(nullptr);
+    std::cout << "simd_op_check test seed: " << seed << "\n";
+    test_hvx.set_seed(seed);
+
     // Remove some features like simd_op_check.cpp used to do.
 
     // TODO: multithreading here is the cause of https://github.com/halide/Halide/issues/3669;


### PR DESCRIPTION
We currently use `123` as a hardcoded seed, so we may sometimes be getting lucky with test patterns that happen to match scalar and vector. Let's vary the seed in the same way we do for (eg) fuzz_simplify to slightly broaden test coverage.