### PR TITLE
Add pipeline name to assertion messages

### DIFF
--- a/src/AddImageChecks.h
+++ b/src/AddImageChecks.h
@@ -30,6 +30,7 @@ Stmt add_image_checks(const Stmt &s,
                       const Target &t,
                       const std::vector<std::string> &order,
                       const std::map<std::string, Function> &env,
+                      const std::string &pipeline_name,
                       const FuncValueBounds &fb,
                       bool will_inject_host_copies);
 

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -219,7 +219,7 @@ Module lower(const vector<Function> &output_funcs,
          (t.arch != Target::Hexagon && (t.has_feature(Target::HVX))));
 
     debug(1) << "Adding checks for images\n";
-    s = add_image_checks(s, outputs, t, order, env, func_bounds, will_inject_host_copies);
+    s = add_image_checks(s, outputs, t, order, env, pipeline_name, func_bounds, will_inject_host_copies);
     log("Lowering after injecting image checks:", s);
 
     debug(1) << "Removing code that depends on undef values...\n";

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1194,11 +1194,11 @@ extern int halide_error_extern_stage_failed(void *user_context, const char *exte
 // @{
 extern int halide_error_explicit_bounds_too_small(void *user_context, const char *func_name, const char *var_name,
                                                   int min_bound, int max_bound, int min_required, int max_required);
-extern int halide_error_bad_type(void *user_context, const char *func_name,
+extern int halide_error_bad_type(void *user_context, const char *func_name, const char *pipeline_name,
                                  uint32_t type_given, uint32_t correct_type);  // N.B. The last two args are the bit representation of a halide_type_t
-extern int halide_error_bad_dimensions(void *user_context, const char *func_name,
+extern int halide_error_bad_dimensions(void *user_context, const char *func_name, const char *pipeline_name,
                                        int32_t dimensions_given, int32_t correct_dimensions);
-extern int halide_error_access_out_of_bounds(void *user_context, const char *func_name,
+extern int halide_error_access_out_of_bounds(void *user_context, const char *func_name, const char *pipeline_name,
                                              int dimension, int min_touched, int max_touched,
                                              int min_valid, int max_valid);
 extern int halide_error_buffer_allocation_too_large(void *user_context, const char *buffer_name,

--- a/src/runtime/errors.cpp
+++ b/src/runtime/errors.cpp
@@ -27,38 +27,42 @@ WEAK int halide_error_explicit_bounds_too_small(void *user_context, const char *
     return halide_error_code_explicit_bounds_too_small;
 }
 
-WEAK int halide_error_bad_type(void *user_context, const char *func_name,
+WEAK int halide_error_bad_type(void *user_context, const char *func_name, const char *pipeline_name,
                                uint32_t type_given_bits, uint32_t correct_type_bits) {
     halide_type_t correct_type, type_given;
     memcpy(&correct_type, &correct_type_bits, sizeof(uint32_t));
     memcpy(&type_given, &type_given_bits, sizeof(uint32_t));
     error(user_context)
         << func_name << " has type " << correct_type
-        << " but type of the buffer passed in is " << type_given;
+        << " but type of the buffer passed in is " << type_given
+        << ", when running pipeline " << pipeline_name;
     return halide_error_code_bad_type;
 }
 
-WEAK int halide_error_bad_dimensions(void *user_context, const char *func_name,
+WEAK int halide_error_bad_dimensions(void *user_context, const char *func_name, const char *pipeline_name,
                                      int32_t dimensions_given, int32_t correct_dimensions) {
     error(user_context)
         << func_name << " requires a buffer of exactly " << correct_dimensions
-        << " dimensions, but the buffer passed in has " << dimensions_given << " dimensions";
+        << " dimensions, but the buffer passed in has " << dimensions_given << " dimensions"
+        << ", when running pipeline " << pipeline_name;
     return halide_error_code_bad_dimensions;
 }
 
-WEAK int halide_error_access_out_of_bounds(void *user_context, const char *func_name,
+WEAK int halide_error_access_out_of_bounds(void *user_context, const char *func_name, const char *pipeline_name,
                                            int dimension, int min_touched, int max_touched,
                                            int min_valid, int max_valid) {
     if (min_touched < min_valid) {
         error(user_context)
             << func_name << " is accessed at " << min_touched
             << ", which is before the min (" << min_valid
-            << ") in dimension " << dimension;
+            << ") in dimension " << dimension
+            << ", when running pipeline " << pipeline_name;
     } else if (max_touched > max_valid) {
         error(user_context)
             << func_name << " is accessed at " << max_touched
             << ", which is beyond the max (" << max_valid
-            << ") in dimension " << dimension;
+            << ") in dimension " << dimension
+            << ", when running pipeline " << pipeline_name;
     }
     return halide_error_code_access_out_of_bounds;
 }


### PR DESCRIPTION
This commit affects the functions:
- halide_error_bad_type
- halide_error_bad_dimensions
- halide_error_access_out_of_bounds