### PR TITLE
Add a way to set a GeneratorInput's type in code

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1736,7 +1736,7 @@ const std::vector<Type> &GIOBase::types() const {
             check_matching_types(f.at(0).output_types());
         }
     }
-    user_assert(types_defined()) << "Type is not defined for " << input_or_output() << " '" << name() << "'; you may need to specify '" << name() << ".type' as a GeneratorParam.\n";
+    user_assert(types_defined()) << "Type is not defined for " << input_or_output() << " '" << name() << "'; you may need to specify '" << name() << ".type' as a GeneratorParam, or call set_type() from the configure() method.\n";
     return types_;
 }
 
@@ -1744,6 +1744,12 @@ Type GIOBase::type() const {
     const auto &t = types();
     internal_assert(t.size() == 1) << "Expected types_.size() == 1, saw " << t.size() << " for " << name() << "\n";
     return t.at(0);
+}
+
+void GIOBase::set_type(const Type &type) {
+    generator->check_exact_phase(GeneratorBase::ConfigureCalled);
+    user_assert(!types_defined()) << "set_type() may only be called on an Input or Output that has no type specified.";
+    types_ = {type};
 }
 
 bool GIOBase::dims_defined() const {

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -174,7 +174,8 @@
  * You can dynamically add Inputs and Outputs to your Generator via adding a
  * configure() method; if present, it will be called before generate(). It can
  * examine GeneratorParams but it may not examine predeclared Inputs or Outputs;
- * the only thing it should do is call add_input<>() and/or add_output<>().
+ * the only thing it should do is call add_input<>() and/or add_output<>(), or call
+ * set_type() on an Input or Output with an unspecified type.
  * Added inputs will be appended (in order) after predeclared Inputs but before
  * any Outputs; added outputs will be appended after predeclared Outputs.
  *

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1448,6 +1448,8 @@ public:
 
     virtual ~GIOBase() = default;
 
+    void set_type(const Type &type);
+
 protected:
     GIOBase(size_t array_size,
             const std::string &name,

--- a/test/generator/configure_generator.cpp
+++ b/test/generator/configure_generator.cpp
@@ -6,7 +6,7 @@ class Configure : public Halide::Generator<Configure> {
 public:
     GeneratorParam<int> num_extra_buffer_inputs{"num_extra_buffer_inputs", 3};
 
-    Input<Buffer<int>> input{"input", 3};
+    Input<Buffer<>> input{"input", 3};
     Input<int> bias{"bias"};
 
     Output<Buffer<int>> output{"output", 3};
@@ -35,6 +35,15 @@ public:
 
         extra_func_output = add_output<Func>("extra_func_output", Float(64), 2);
 
+        // This is ok: you can't *examine* an Input or Output here, but you can call
+        // set_type() iff the type is unspecified. (This allows you to base the type on,
+        // e.g., the value in get_target(), or the value of any GeneratorParam.)
+        input.set_type(Int(32));
+
+        // Will fail: it is not legal to call set_type on an Input or Output that
+        // already has a type specified.
+        // bias.set_type(Int(32));
+
         // Will fail: it is not legal to examine Inputs in the configure() method
         // assert(input.dimensions() == 3);
 
@@ -49,6 +58,9 @@ public:
 
     void generate() {
         assert(configure_calls == 1);
+
+        // Will fail: it is not legal to call set_type() from anywhere but configure().
+        // input.set_type(Int(32));
 
         // Attempting to call add_input() outside of the configure method will fail.
         // auto *this_will_fail = add_input<Buffer<>>("untyped_uint8", UInt(8), 2);


### PR DESCRIPTION
Currently, if you want to vary the type of a Generator's inputs or outputs, you have to specify the types in the makefile. This can be awkward for things with complex logic. This PR proposes adding a way to do this: a new `set_type()` method which can only be called from the rarely-used Generator::configure() method. It only allows setting the type for an input or output that has no type specified.

I'm not 100% sure if this is a good idea, but for certain rare corner cases, it may be quite handy.

(Note that extending this to allow specifying dimensions and/or array size in the same way might be handy, but is omitted from this PR.)