### PR TITLE
Add some not simplification rules

### DIFF
--- a/src/Simplify_Not.cpp
+++ b/src/Simplify_Not.cpp
@@ -19,7 +19,12 @@ Expr Simplify::visit(const Not *op, ExprInfo *bounds) {
 
     if (rewrite(!broadcast(x, c0), broadcast(!x, c0)) ||
         rewrite(!intrin(Call::likely, x), intrin(Call::likely, !x)) ||
-        rewrite(!intrin(Call::likely_if_innermost, x), intrin(Call::likely_if_innermost, !x))) {
+        rewrite(!intrin(Call::likely_if_innermost, x), intrin(Call::likely_if_innermost, !x)) ||
+        rewrite(!(!x && y), x || !y) ||
+        rewrite(!(!x || y), x && !y) ||
+        rewrite(!(x && !y), !x || y) ||
+        rewrite(!(x || !y), !x && y) ||
+        false) {
         return mutate(rewrite.result, bounds);
     }
 


### PR DESCRIPTION
These don't actually help performance in a case I was looking at, but they do make the IR easier to read, and it is in fact simpler.