### PR TITLE
Don't strip strict_float() from lets

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -3150,8 +3150,6 @@ void CodeGen_LLVM::visit(const Call *op) {
         llvm::DataLayout d(module.get());
         value = ConstantInt::get(i32_t, (int)d.getTypeAllocSize(halide_buffer_t_type));
     } else if (op->is_intrinsic(Call::strict_float)) {
-        internal_assert(!Call::as_intrinsic(op->args[0], {Call::strict_float}))
-            << "There should be no calls of the form strict_float(strict_float(x)) after simplification.";
         IRBuilder<llvm::ConstantFolder, llvm::IRBuilderDefaultInserter>::FastMathFlagGuard guard(*builder);
         llvm::FastMathFlags safe_flags;
         safe_flags.clear();

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -3150,6 +3150,8 @@ void CodeGen_LLVM::visit(const Call *op) {
         llvm::DataLayout d(module.get());
         value = ConstantInt::get(i32_t, (int)d.getTypeAllocSize(halide_buffer_t_type));
     } else if (op->is_intrinsic(Call::strict_float)) {
+        internal_assert(!Call::as_intrinsic(op->args[0], {Call::strict_float}))
+            << "There should be no calls of the form strict_float(strict_float(x)) after simplification.";
         IRBuilder<llvm::ConstantFolder, llvm::IRBuilderDefaultInserter>::FastMathFlagGuard guard(*builder);
         llvm::FastMathFlags safe_flags;
         safe_flags.clear();

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -111,7 +111,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
     }
 
     if (op->is_intrinsic(Call::strict_float)) {
-        if (const Call *call = Call::as_intrinsic(op->args[0], {Call::strict_float})) {
+        if (Call::as_intrinsic(op->args[0], {Call::strict_float})) {
             // Always simplify strict_float(strict_float(x)) -> strict_float(x).
             Expr arg = mutate(op->args[0], nullptr);
             return arg.same_as(op->args[0]) ? op->args[0] : arg;

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -111,12 +111,18 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
     }
 
     if (op->is_intrinsic(Call::strict_float)) {
-        ScopedValue<bool> save_no_float_simplify(no_float_simplify, true);
-        Expr arg = mutate(op->args[0], nullptr);
-        if (arg.same_as(op->args[0])) {
-            return op;
+        if (const Call *call = Call::as_intrinsic(op->args[0], {Call::strict_float})) {
+            // Always simplify strict_float(strict_float(x)) -> strict_float(x).
+            Expr arg = mutate(op->args[0], nullptr);
+            return arg.same_as(op->args[0]) ? op->args[0] : arg;
         } else {
-            return strict_float(arg);
+            ScopedValue<bool> save_no_float_simplify(no_float_simplify, true);
+            Expr arg = mutate(op->args[0], nullptr);
+            if (arg.same_as(op->args[0])) {
+                return op;
+            } else {
+                return strict_float(arg);
+            }
         }
     } else if (op->is_intrinsic(Call::popcount) ||
                op->is_intrinsic(Call::count_leading_zeros) ||

--- a/src/Simplify_Let.cpp
+++ b/src/Simplify_Let.cpp
@@ -96,6 +96,7 @@ Body Simplify::simplify_let(const LetOrLetStmt *op, ExprInfo *bounds) {
             const Shuffle *shuffle = f.new_value.template as<Shuffle>();
             const Variable *var_b = nullptr;
             const Variable *var_a = nullptr;
+            const Call *tag = nullptr;
 
             if (add) {
                 var_a = add->a.as<Variable>();
@@ -174,7 +175,9 @@ Body Simplify::simplify_let(const LetOrLetStmt *op, ExprInfo *bounds) {
                 Expr op_b = var_a ? new_var : shuffle->vectors[1];
                 replacement = substitute(f.new_name, Shuffle::make_concat({op_a, op_b}), replacement);
                 f.new_value = var_a ? shuffle->vectors[1] : shuffle->vectors[0];
-            } else if (const Call *tag = Call::as_tag(f.new_value)) {
+            } else if ((tag = Call::as_tag(f.new_value)) != nullptr && !tag->is_intrinsic(Call::strict_float)) {
+                // Most tags should be stripped here, but not strict_float(); removing it will change the semantics
+                // of the let-expr we are producing.
                 replacement = substitute(f.new_name, Call::make(tag->type, tag->name, {new_var}, Call::PureIntrinsic), replacement);
                 f.new_value = tag->args[0];
             } else {

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1763,6 +1763,8 @@ void check_math() {
     check(Halide::trunc(-1.6f), -1.0f);
     check(Halide::floor(round(x)), round(x));
     check(Halide::ceil(ceil(x)), ceil(x));
+
+    check(strict_float(strict_float(x)), strict_float(x));
 }
 
 void check_overflow() {


### PR DESCRIPTION
Bug injected in #5856: the change in Simplify_Let.cpp was inadvertently stripping `strict_float()` calls that wrapped the RHS of a Let-expr, which can change results nontrivially in some cases. I don't think a new test for this fix is practical -- it would be a little fragile, as it would rely on the specifics of simplification that could change over time.

As a drive-by, also added an explicit rule to Simplify_Call to ensure that strict_float(strict_float(x)) -> strict_float(x) in *all* cases. (The existing rule didn't do this in all cases.)

Also added an assertion to Codegen_LLVM.cpp that no calls of the form strict_float(strict_float(x)) should ever be seen at that point.