### PR TITLE
Fix an issue in Halide's float16 compilation support. Add tests.

### DIFF
--- a/src/EmulateFloat16Math.cpp
+++ b/src/EmulateFloat16Math.cpp
@@ -82,7 +82,7 @@ Expr float32_to_float16(Expr value) {
 
     // Test the endpoints
     Expr is_denorm = (bits < make_const(u32_t, 0x38800000));
-    Expr is_inf = (bits == make_const(u32_t, 0x7f800000));
+    Expr is_inf = (bits >= make_const(u32_t, 0x47800000));
     Expr is_nan = (bits > make_const(u32_t, 0x7f800000));
 
     // Denorms are linearly spaced, so we can handle them

--- a/src/Float16.cpp
+++ b/src/Float16.cpp
@@ -25,10 +25,12 @@ uint16_t float_to_float16(float value) {
     }
 
     int exp;
+    // Get exponent, with bias already subtracted.
     std::frexp(value, &exp);
     if (exp > 16) {
-        // Too large, return infinity
-        return bits | 0x7c00;
+        // Too large, return infinity. Per initialization, bits only
+        // contains the sign bit, so this is +/-inf.
+        return bits | float16_t::exponent_mask;
     } else if (exp < -13) {
         // Too small, clamp to 2^-24
         value = std::ldexp(value, 24);

--- a/test/correctness/float16_t.cpp
+++ b/test/correctness/float16_t.cpp
@@ -241,7 +241,7 @@ int main(int argc, char **argv) {
         from_f16.compile_to_assembly("/dev/stdout", {}, Target("host-no_asserts-no_bounds_query-no_runtime-disable_llvm_loop_unroll-disable_llvm_loop_vectorize"));
     }
 
-    // Check inifinity handling for both float16_t and Halide codegen.
+    // Check infinity handling for both float16_t and Halide codegen.
     {
         std::pair<int, bool> test_cases[] =
           {{1, false}, {16, true}, {256, true}};

--- a/test/correctness/float16_t.cpp
+++ b/test/correctness/float16_t.cpp
@@ -8,7 +8,7 @@ bool check_infinity_case(bool use_first, float16_t value, const char *value_name
                          int increment, float16_t expected_first, float16_t expected_second,
                          const char *first_name, const char *second_name) {
     if (value != (use_first ? expected_first : expected_second)) {
-      printf("%s %d is %x, not %s.\n", value_name, increment, value.to_bits(),
+        printf("%s %d is %x, not %s.\n", value_name, increment, value.to_bits(),
                (use_first ? first_name : second_name));
         return false;
     }
@@ -244,7 +244,7 @@ int main(int argc, char **argv) {
     // Check infinity handling for both float16_t and Halide codegen.
     {
         std::pair<int, bool> test_cases[] =
-          {{1, false}, {16, true}, {256, true}};
+            {{1, false}, {16, true}, {256, true}};
 
         for (const auto &test_case : test_cases) {
             float16_t max_pos_val = float16_t::make_from_bits(0x7bff);

--- a/test/correctness/float16_t.cpp
+++ b/test/correctness/float16_t.cpp
@@ -1,6 +1,19 @@
 #include "Halide.h"
 
+#include <limits>
+
 using namespace Halide;
+
+bool check_infinity_case(bool use_first, float16_t value, const char *value_name,
+                         int increment, float16_t expected_first, float16_t expected_second,
+                         const char *first_name, const char *second_name) {
+    if (value != (use_first ? expected_first : expected_second)) {
+      printf("%s %d is %x, not %s.\n", value_name, increment, value.to_bits(),
+               (use_first ? first_name : second_name));
+        return false;
+    }
+    return true;
+}
 
 int main(int argc, char **argv) {
     Var x;
@@ -226,6 +239,84 @@ int main(int argc, char **argv) {
         from_f16.compute_root().vectorize(x, 8, TailStrategy::RoundUp);
 
         from_f16.compile_to_assembly("/dev/stdout", {}, Target("host-no_asserts-no_bounds_query-no_runtime-disable_llvm_loop_unroll-disable_llvm_loop_vectorize"));
+    }
+
+    // Check inifinity handling for both float16_t and Halide codegen.
+    {
+        std::pair<int, bool> test_cases[] =
+          { { 1, false }, {16, true}, {256, true} };
+
+        for (const auto& test_case : test_cases) {
+            float16_t max_pos_val = float16_t::make_from_bits(0x7bff);
+            float16_t min_neg_val = float16_t::make_from_bits(0xfbff);
+            float16_t increment(test_case.first);
+
+            float16_t max_plus_increment(max_pos_val + increment);
+            if (!check_infinity_case(test_case.second, max_plus_increment,
+                                     "float16_t maximum value plus", test_case.first,
+                                     float16_t::make_infinity(), max_pos_val,
+                                     "positive infinity", "maximum positive value")) {
+                return -1;
+            }
+                                     
+            float16_t min_minus_increment(min_neg_val - increment);
+            if (!check_infinity_case(test_case.second, min_minus_increment,
+                                     "float16_t minimum value minus", test_case.first,
+                                     float16_t::make_negative_infinity(), min_neg_val,
+                                     "negative infinity", "maximum negative value")) {
+                return -1;
+            }
+
+
+            Param<float16_t> a("a"), b("b");
+            a.set(max_pos_val);
+            b.set(increment);
+            float16_t c = evaluate<float16_t>(a + b);
+            if (!check_infinity_case(test_case.second, c,
+                                     "Halide float16_t maximum value plus", test_case.first,
+                                     float16_t::make_infinity(), max_pos_val,
+                                     "positive infinity", "maximum positive value")) {
+                return -1;
+            }
+
+            a.set(min_neg_val);
+            c = evaluate<float16_t>(a - b);
+            if (!check_infinity_case(test_case.second, c,
+                                     "Halide float16_t minimum value minus", test_case.first,
+                                     float16_t::make_negative_infinity(), min_neg_val,
+                                     "negative infinity", "maximum negative value")) {
+                return -1;
+            }
+
+            float pos_inf = std::numeric_limits<float>::infinity();
+            float16_t fp16_pos_inf(pos_inf);
+            if (fp16_pos_inf != float16_t::make_infinity()) {
+                printf("Conversion of 32-bit positive infinity to 16-bit float is %x, not positive infinity.\n", fp16_pos_inf.to_bits());
+                return -1;
+            }
+
+            float neg_inf = -std::numeric_limits<float>::infinity();
+            float16_t fp16_neg_inf(neg_inf);
+            if (fp16_neg_inf != float16_t::make_negative_infinity()) {
+                printf("Conversion of 32-bit negative infinity to 16-bit float is %x, not negative infinity.\n", fp16_neg_inf.to_bits());
+                return -1;
+            }
+
+            Param<float> f_in("f_in");
+            f_in.set(pos_inf);
+            c = evaluate<float16_t>(cast(Float(16), f_in));
+            if (c != float16_t::make_infinity()) {
+                printf("Halide conversion of 32-bit positive infinity to 16-bit float is %x, not positive infinity.\n", c.to_bits());
+                return -1;
+            }
+
+            f_in.set(neg_inf);
+            c = evaluate<float16_t>(cast(Float(16), f_in));
+            if (c != float16_t::make_negative_infinity()) {
+                printf("Halide conversion of 32-bit negative infinity to 16-bit float is %x, not negative infinity.\n", c.to_bits());
+                return -1;
+            }
+        }
     }
 
     printf("Success!\n");

--- a/test/correctness/float16_t.cpp
+++ b/test/correctness/float16_t.cpp
@@ -244,9 +244,9 @@ int main(int argc, char **argv) {
     // Check inifinity handling for both float16_t and Halide codegen.
     {
         std::pair<int, bool> test_cases[] =
-          { { 1, false }, {16, true}, {256, true} };
+          {{1, false}, {16, true}, {256, true}};
 
-        for (const auto& test_case : test_cases) {
+        for (const auto &test_case : test_cases) {
             float16_t max_pos_val = float16_t::make_from_bits(0x7bff);
             float16_t min_neg_val = float16_t::make_from_bits(0xfbff);
             float16_t increment(test_case.first);
@@ -258,7 +258,7 @@ int main(int argc, char **argv) {
                                      "positive infinity", "maximum positive value")) {
                 return -1;
             }
-                                     
+
             float16_t min_minus_increment(min_neg_val - increment);
             if (!check_infinity_case(test_case.second, min_minus_increment,
                                      "float16_t minimum value minus", test_case.first,
@@ -266,7 +266,6 @@ int main(int argc, char **argv) {
                                      "negative infinity", "maximum negative value")) {
                 return -1;
             }
-
 
             Param<float16_t> a("a"), b("b");
             a.set(max_pos_val);

--- a/test/correctness/strict_float.cpp
+++ b/test/correctness/strict_float.cpp
@@ -270,7 +270,12 @@ int main(int argc, char **argv) {
     in.set(transposed);
     run_all_conditions("random transposed", transposed);
 
-    // Ascending, best case for error.
+    // Originally the comments stipulated that ascending
+    // was best case and descending was worst case, neither
+    // of which are strictly true. Main idea is to compare
+    // the relative error of two significantly different orders.
+
+    // Ascending.
     std::sort(vals.begin(), vals.end());
     in.set(vals);
     run_all_conditions("sorted ascending", vals);
@@ -278,7 +283,7 @@ int main(int argc, char **argv) {
     in.set(transposed);
     run_all_conditions("sorted ascending transposed", transposed);
 
-    // Descending, worst case for error.
+    // Descending.
     std::sort(vals.begin(), vals.end(), std::greater<float>());
     in.set(vals);
     run_all_conditions("sorted descending", vals);


### PR DESCRIPTION
In EmulateFloat16Math.cpp, conversion from 32-bit float to 16-bit float could produce a NaN value when and infinity is correct. This is because for numbers larger than the exact infinity value, the mantissa could be non zero.

Add tests to cover this case, and float16 infinities in general.

Couple small style/comment cleanups.