### PR TITLE
Use fibers to guarantee stack size on Windows

### DIFF
--- a/cmake/HalideTestHelpers.cmake
+++ b/cmake/HalideTestHelpers.cmake
@@ -97,4 +97,4 @@ function(tests)
     endforeach ()
 
     set(TEST_NAMES "${TEST_NAMES}" PARENT_SCOPE)
-endfunction(tests)
+endfunction()

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -490,7 +490,7 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
     for (const auto &f : input.functions()) {
         const auto names = get_mangled_names(f, get_target());
 
-        call_with_stack_requirement([&]() {
+        run_with_large_stack([&]() {
             compile_func(f, names.simple_name, names.extern_name);
         });
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -490,7 +490,9 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
     for (const auto &f : input.functions()) {
         const auto names = get_mangled_names(f, get_target());
 
-        compile_func(f, names.simple_name, names.extern_name);
+        call_with_stack_requirement([&]() {
+            compile_func(f, names.simple_name, names.extern_name);
+        });
 
         // If the Func is externally visible, also create the argv wrapper and metadata.
         // (useful for calling from JIT and other machine interfaces).

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -1,3 +1,8 @@
+#ifdef _WINDOWS
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #include <algorithm>
 #include <chrono>
 #include <iostream>
@@ -98,22 +103,16 @@ public:
     }
 };
 
-}  // namespace
-
-Module lower(const vector<Function> &output_funcs,
-             const string &pipeline_name,
-             const Target &t,
-             const vector<Argument> &args,
-             const LinkageType linkage_type,
-             const vector<Stmt> &requirements,
-             bool trace_pipeline,
-             const vector<IRMutator *> &custom_passes) {
+void lower_impl(const vector<Function> &output_funcs,
+                const string &pipeline_name,
+                const Target &t,
+                const vector<Argument> &args,
+                const LinkageType linkage_type,
+                const vector<Stmt> &requirements,
+                bool trace_pipeline,
+                const vector<IRMutator *> &custom_passes,
+                Module &result_module) {
     auto time_start = std::chrono::high_resolution_clock::now();
-
-    std::vector<std::string> namespaces;
-    std::string simple_pipeline_name = extract_namespaces(pipeline_name, namespaces);
-
-    Module result_module(simple_pipeline_name, t);
 
     // Compute an environment
     map<string, Function> env;
@@ -524,7 +523,75 @@ Module lower(const vector<Function> &output_funcs,
         std::chrono::duration<double> diff = time_end - time_start;
         logger->record_compilation_time(CompilerLogger::Phase::HalideLowering, diff.count());
     }
+}
 
+#ifdef _WINDOWS
+
+struct DeferredFunction {
+    const std::function<void()> *run;
+    LPVOID fiber;
+};
+
+void generic_fiber_entry_point(void *argument) {
+    auto *action = reinterpret_cast<DeferredFunction *>(argument);
+    (*action->run)();
+    SwitchToFiber(action->fiber);
+}
+
+#endif
+
+void call_with_stack_requirement(const std::function<void()> &action) {
+#if _WINDOWS
+    SIZE_T required_stack = 8 * 1024 * 1024;
+
+    ULONG_PTR stack_low, stack_high;
+    GetCurrentThreadStackLimits(&stack_low, &stack_high);
+    ptrdiff_t stack_remaining = (char *)&stack_high - (char *)stack_low;
+
+    if (stack_remaining < required_stack) {
+        debug(1) << "Insufficient stack space (" << stack_remaining << " bytes). Switching to fiber with " << required_stack << "-byte stack.\n";
+
+        auto was_a_fiber = IsThreadAFiber();
+
+        auto *main_fiber = was_a_fiber ? GetCurrentFiber() : ConvertThreadToFiber(nullptr);
+        internal_assert(main_fiber) << "ConvertThreadToFiber failed with code: " << GetLastError() << "\n";
+
+        DeferredFunction func{&action, main_fiber};
+        auto *lower_fiber = CreateFiber(required_stack, generic_fiber_entry_point, &func);
+        internal_assert(lower_fiber) << "CreateFiber failed with code: " << GetLastError() << "\n";
+
+        SwitchToFiber(lower_fiber);
+        DeleteFiber(lower_fiber);
+
+        debug(1) << "Returned from fiber.\n";
+
+        if (!was_a_fiber) {
+            BOOL success = ConvertFiberToThread();
+            internal_assert(success) << "ConvertFiberToThread failed with code: " << GetLastError() << "\n";
+        }
+
+        return;
+    }
+
+#endif
+
+    action();
+}
+
+}  // namespace
+
+Module lower(const vector<Function> &output_funcs,
+             const string &pipeline_name,
+             const Target &t,
+             const vector<Argument> &args,
+             const LinkageType linkage_type,
+             const vector<Stmt> &requirements,
+             bool trace_pipeline,
+             const vector<IRMutator *> &custom_passes) {
+    Module result_module{extract_namespaces(pipeline_name), t};
+    call_with_stack_requirement([&]() {
+        lower_impl(output_funcs, pipeline_name, t, args, linkage_type, requirements, trace_pipeline, custom_passes, result_module);
+    });
     return result_module;
 }
 

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -531,7 +531,7 @@ Module lower(const vector<Function> &output_funcs,
              bool trace_pipeline,
              const vector<IRMutator *> &custom_passes) {
     Module result_module{extract_namespaces(pipeline_name), t};
-    call_with_stack_requirement([&]() {
+    run_with_large_stack([&]() {
         lower_impl(output_funcs, pipeline_name, t, args, linkage_type, requirements, trace_pipeline, custom_passes, result_module);
     });
     return result_module;

--- a/src/Simplify_Not.cpp
+++ b/src/Simplify_Not.cpp
@@ -19,7 +19,12 @@ Expr Simplify::visit(const Not *op, ExprInfo *bounds) {
 
     if (rewrite(!broadcast(x, c0), broadcast(!x, c0)) ||
         rewrite(!intrin(Call::likely, x), intrin(Call::likely, !x)) ||
-        rewrite(!intrin(Call::likely_if_innermost, x), intrin(Call::likely_if_innermost, !x))) {
+        rewrite(!intrin(Call::likely_if_innermost, x), intrin(Call::likely_if_innermost, !x)) ||
+        rewrite(!(!x && y), x || !y) ||
+        rewrite(!(!x || y), x && !y) ||
+        rewrite(!(x && !y), !x || y) ||
+        rewrite(!(x || !y), !x && y) ||
+        false) {
         return mutate(rewrite.result, bounds);
     }
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -596,7 +596,7 @@ void generic_fiber_entry_point(void *argument) {
 
 #endif
 
-void call_with_stack_requirement(const std::function<void()> &action) {
+void run_with_large_stack(const std::function<void()> &action) {
 #if _WIN32
     SIZE_T required_stack = 8 * 1024 * 1024;
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -577,6 +577,63 @@ int get_llvm_version() {
     return LLVM_VERSION;
 }
 
+#ifdef _WIN32
+
+namespace {
+
+struct DeferredFunction {
+    const std::function<void()> *run;
+    LPVOID fiber;
+};
+
+void generic_fiber_entry_point(void *argument) {
+    auto *action = reinterpret_cast<DeferredFunction *>(argument);
+    (*action->run)();
+    SwitchToFiber(action->fiber);
+}
+
+}  // namespace
+
+#endif
+
+void call_with_stack_requirement(const std::function<void()> &action) {
+#if _WIN32
+    SIZE_T required_stack = 8 * 1024 * 1024;
+
+    ULONG_PTR stack_low, stack_high;
+    GetCurrentThreadStackLimits(&stack_low, &stack_high);
+    ptrdiff_t stack_remaining = (char *)&stack_high - (char *)stack_low;
+
+    if (stack_remaining < required_stack) {
+        debug(1) << "Insufficient stack space (" << stack_remaining << " bytes). Switching to fiber with " << required_stack << "-byte stack.\n";
+
+        auto was_a_fiber = IsThreadAFiber();
+
+        auto *main_fiber = was_a_fiber ? GetCurrentFiber() : ConvertThreadToFiber(nullptr);
+        internal_assert(main_fiber) << "ConvertThreadToFiber failed with code: " << GetLastError() << "\n";
+
+        DeferredFunction func{&action, main_fiber};
+        auto *lower_fiber = CreateFiber(required_stack, generic_fiber_entry_point, &func);
+        internal_assert(lower_fiber) << "CreateFiber failed with code: " << GetLastError() << "\n";
+
+        SwitchToFiber(lower_fiber);
+        DeleteFiber(lower_fiber);
+
+        debug(1) << "Returned from fiber.\n";
+
+        if (!was_a_fiber) {
+            BOOL success = ConvertFiberToThread();
+            internal_assert(success) << "ConvertFiberToThread failed with code: " << GetLastError() << "\n";
+        }
+
+        return;
+    }
+
+#endif
+
+    action();
+}
+
 }  // namespace Internal
 
 void load_plugin(const std::string &lib_name) {

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -589,7 +589,7 @@ struct DeferredFunction {
 #endif
 };
 
-void generic_fiber_entry_point(void *argument) {
+void WINAPI generic_fiber_entry_point(LPVOID argument) {
     auto *action = reinterpret_cast<DeferredFunction *>(argument);
 #ifdef HALIDE_WITH_EXCEPTIONS
     try {

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -585,7 +585,7 @@ struct DeferredFunction {
     const std::function<void()> *run;
     LPVOID fiber;
 #ifdef HALIDE_WITH_EXCEPTIONS
-    std::exception_ptr fiber_exception = nullptr; // NOLINT - clang-tidy complains this isn't thrown
+    std::exception_ptr fiber_exception = nullptr;  // NOLINT - clang-tidy complains this isn't thrown
 #endif
 };
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -288,6 +288,11 @@ std::string extract_namespaces(const std::string &name, std::vector<std::string>
     return result;
 }
 
+std::string extract_namespaces(const std::string &name) {
+    std::vector<std::string> unused;
+    return extract_namespaces(name, unused);
+}
+
 bool file_exists(const std::string &name) {
 #ifdef _MSC_VER
     return _access(name.c_str(), 0) == 0;

--- a/src/Util.h
+++ b/src/Util.h
@@ -15,11 +15,11 @@
 
 #include <cstdint>
 #include <cstring>
+#include <functional>
 #include <limits>
 #include <string>
 #include <utility>
 #include <vector>
-#include <functional>
 
 #include "runtime/HalideRuntime.h"
 

--- a/src/Util.h
+++ b/src/Util.h
@@ -44,11 +44,6 @@
 #define HALIDE_NO_USER_CODE_INLINE HALIDE_NEVER_INLINE
 #endif
 
-// On windows, Halide needs a larger stack than the default MSVC provides
-#ifdef _MSC_VER
-#pragma comment(linker, "/STACK:8388608,1048576")
-#endif
-
 namespace Halide {
 
 /** Load a plugin in the form of a dynamic library (e.g. for custom autoschedulers).
@@ -211,6 +206,9 @@ struct all_are_convertible : meta_and<std::is_convertible<Args, To>...> {};
 
 /** Returns base name and fills in namespaces, outermost one first in vector. */
 std::string extract_namespaces(const std::string &name, std::vector<std::string> &namespaces);
+
+/** Overload that returns base name only */
+std::string extract_namespaces(const std::string &name);
 
 struct FileStat {
     uint64_t file_size;

--- a/src/Util.h
+++ b/src/Util.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <functional>
 
 #include "runtime/HalideRuntime.h"
 
@@ -463,6 +464,11 @@ std::string c_print_name(const std::string &name);
  * only for internal tests which need to verify behavior; please don't use this outside
  * of Halide tests. */
 int get_llvm_version();
+
+/** Call the given action in a platform-specific context that provides at least
+ * 8MB of stack space. Currently only has any effect on Windows where it uses
+ * a Fiber. */
+void call_with_stack_requirement(const std::function<void()> &action);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Util.h
+++ b/src/Util.h
@@ -468,7 +468,7 @@ int get_llvm_version();
 /** Call the given action in a platform-specific context that provides at least
  * 8MB of stack space. Currently only has any effect on Windows where it uses
  * a Fiber. */
-void call_with_stack_requirement(const std::function<void()> &action);
+void run_with_large_stack(const std::function<void()> &action);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/test/error/CMakeLists.txt
+++ b/test/error/CMakeLists.txt
@@ -69,6 +69,7 @@ tests(GROUPS error
       reuse_var_in_schedule.cpp
       reused_args.cpp
       rfactor_inner_dim_non_commutative.cpp
+      run_with_large_stack_throws.cpp
       specialize_fail.cpp
       split_inner_wrong_tail_strategy.cpp
       thread_id_outside_block_id.cpp

--- a/test/error/run_with_large_stack_throws.cpp
+++ b/test/error/run_with_large_stack_throws.cpp
@@ -1,0 +1,16 @@
+#include "Halide.h"
+#include <iostream>
+
+int main() {
+    try {
+        Halide::Internal::run_with_large_stack([]() {
+            throw Halide::RuntimeError("Exception from run_with_large_stack");
+        });
+    } catch (const Halide::RuntimeError &ex) {
+        std::cerr << ex.what() << "\n";
+        return 1;
+    }
+
+    std::cout << "Success!\n";
+    return 0;
+}

--- a/test/error/run_with_large_stack_throws.cpp
+++ b/test/error/run_with_large_stack_throws.cpp
@@ -4,7 +4,7 @@
 int main() {
     try {
         Halide::Internal::run_with_large_stack([]() {
-            throw Halide::RuntimeError("Exception from run_with_large_stack");
+            throw Halide::RuntimeError("Error from run_with_large_stack");
         });
     } catch (const Halide::RuntimeError &ex) {
         std::cerr << ex.what() << "\n";

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -141,7 +141,7 @@ add_dependencies(lesson_15_targets
 
 ##
 add_test(NAME tutorial_lesson_15_build_gens
-         COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target lesson_15_targets)
+         COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target lesson_15_targets --config $<CONFIG>)
 set_tests_properties(tutorial_lesson_15_build_gens PROPERTIES
                      LABELS tutorial
                      FIXTURES_SETUP tutorial_lesson_15)


### PR DESCRIPTION
We used to use `#pragma comment(linker, "/STACK:8388608")` to enforce an 8MB stack on Windows. Unfortunately, clang-cl and lld-link don't support this pragma. I have opened a PR with upstream LLVM to correct this<sup>[1]</sup>, but it is clear we need a more robust solution than a transitive linker flag.

This PR adds a helper, `run_with_large_stack` to execute a `std::function<void()>` in a context where it will have at least 8 MB of stack space. Currently, it merely calls the function on Linux, but on Windows it creates a new fiber with the appropriate stack size and runs it there, blocking until the fiber returns.

It is applied in two places: around `lower()` and around the call to `compile_func` in CodeGen LLVM. This was sufficient to build locally on Windows, but there might be more places it's required. We'll let the buildbots sort that out.

<sup>[1]</sup> https://reviews.llvm.org/D99680