### PR TITLE
Simplify asserts always true with Target::LargeBuffers

### DIFF
--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -423,13 +423,12 @@ Stmt add_image_checks_inner(Stmt s,
             // is used in the schedule to combine multiple extents,
             // but it is here for extra safety. On 64-bit targets with the
             // LargeBuffers feature, the maximum size is 2^63 - 1.
-            Expr max_size = make_const(Int(64), t.maximum_buffer_size());
-            Expr actual_size = cast<int64_t>(actual_extent) * actual_stride;
+            Expr max_size = make_const(UInt(64), t.maximum_buffer_size());
+            Expr max_extent = make_const(UInt(64), 0x7fffffff);
+            Expr actual_size = abs(cast<int64_t>(actual_extent) * actual_stride);
             Expr allocation_size_error = Call::make(Int(32), "halide_error_buffer_allocation_too_large",
                                                     {name, actual_size, max_size}, Call::Extern);
-            // We can't use abs here, because the simplifier can't prove
-            // this is always true when LargeBuffers is set.
-            Stmt check = AssertStmt::make(-max_size <= actual_size && actual_size <= max_size, allocation_size_error);
+            Stmt check = AssertStmt::make(actual_size <= max_size, allocation_size_error);
             dims_no_overflow_asserts.push_back(check);
 
             // Don't repeat extents check for secondary buffers as extents must be the same as for the first one.

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -113,6 +113,14 @@ CodeGen_ARM::CodeGen_ARM(const Target &target)
     casts.emplace_back("qrdmulh", i16_sat(rounding_shift_right(widening_mul(wild_i16x_, wild_i16x_), u16(15))));
     casts.emplace_back("qrdmulh", i32_sat(rounding_shift_right(widening_mul(wild_i32x_, wild_i32x_), u32(31))));
 
+    // The lower saturation for the above two rules is not actually needed, the simplifier
+    // might have removed it. I think the upper saturation is not needed for the non-rounding
+    // version either, but the simplifier doesn't remove those?
+    casts.emplace_back("qdmulh", i16(min(widening_mul(wild_i16x_, wild_i16x_) >> u16(15), Int(16).max())));
+    casts.emplace_back("qdmulh", i32(min(widening_mul(wild_i32x_, wild_i32x_) >> u32(31), Int(32).max())));
+    casts.emplace_back("qrdmulh", i16(min(rounding_shift_right(widening_mul(wild_i16x_, wild_i16x_), u16(15)), Int(16).max())));
+    casts.emplace_back("qrdmulh", i32(min(rounding_shift_right(widening_mul(wild_i32x_, wild_i32x_), u32(31)), Int(32).max())));
+
     // RSHRN - Rounding shift right narrow (by immediate in [1, output bits])
     casts.emplace_back("rounding_shift_right_narrow", i8(rounding_shift_right(wild_i16x_, bc(wild_u16_))));
     casts.emplace_back("rounding_shift_right_narrow", u8(rounding_shift_right(wild_u16x_, bc(wild_u16_))));

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -849,15 +849,22 @@ private:
             // Scalar multiply keep high half, with multiplication by 2.
             {"halide.hexagon.trunc_satw_mpy2.vh.h", i16_sat(widening_mul(wild_i16x, wild_i16) >> wild_u32)},
             {"halide.hexagon.trunc_satw_mpy2.vh.h", i16_sat(widening_mul(wild_i16, wild_i16x) >> wild_u32), Pattern::SwapOps01},
+            {"halide.hexagon.trunc_satw_mpy2.vh.h", i16(min(widening_mul(wild_i16x, wild_i16) >> wild_u32, Int(16).max()))},
+            {"halide.hexagon.trunc_satw_mpy2.vh.h", i16(min(widening_mul(wild_i16, wild_i16x) >> wild_u32, Int(32).max())), Pattern::SwapOps01},
 
             // Scalar and vector multiply keep high half, with multiplication by 2, and rounding.
             {"halide.hexagon.trunc_satw_mpy2_rnd.vh.h", i16_sat(rounding_shift_right(widening_mul(wild_i16x, wild_i16), wild_u32))},
             {"halide.hexagon.trunc_satw_mpy2_rnd.vh.h", i16_sat(rounding_shift_right(widening_mul(wild_i16, wild_i16x), wild_u32)), Pattern::SwapOps01},
             {"halide.hexagon.trunc_satw_mpy2_rnd.vh.vh", i16_sat(rounding_shift_right(widening_mul(wild_i16x, wild_i16x), wild_u32))},
             {"halide.hexagon.trunc_satdw_mpy2_rnd.vw.vw", i32_sat(rounding_shift_right(widening_mul(wild_i32x, wild_i32x), wild_u64))},
+            {"halide.hexagon.trunc_satw_mpy2_rnd.vh.h", i16(min(rounding_shift_right(widening_mul(wild_i16x, wild_i16), wild_u32), Int(16).max()))},
+            {"halide.hexagon.trunc_satw_mpy2_rnd.vh.h", i16(min(rounding_shift_right(widening_mul(wild_i16, wild_i16x), wild_u32), Int(16).max())), Pattern::SwapOps01},
+            {"halide.hexagon.trunc_satw_mpy2_rnd.vh.vh", i16(min(rounding_shift_right(widening_mul(wild_i16x, wild_i16x), wild_u32), Int(16).max()))},
+            {"halide.hexagon.trunc_satdw_mpy2_rnd.vw.vw", i32(min(rounding_shift_right(widening_mul(wild_i32x, wild_i32x), wild_u64), Int(32).max()))},
 
             // Vector multiply keep high half, with multiplication by 2.
             {"halide.hexagon.trunc_satdw_mpy2.vw.vw", i32_sat(widening_mul(wild_i32x, wild_i32x) >> wild_u64)},
+            {"halide.hexagon.trunc_satdw_mpy2.vw.vw", i32(min(widening_mul(wild_i32x, wild_i32x) >> wild_u64, Int(32).max()))},
         };
 
         static const vector<Pattern> casts = {

--- a/src/Simplify_Add.cpp
+++ b/src/Simplify_Add.cpp
@@ -38,8 +38,7 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
 
         auto rewrite = IRMatcher::rewriter(IRMatcher::add(a, b), op->type);
 
-        if (rewrite(c0 + c1, fold(c0 + c1)) ||
-            rewrite(IRMatcher::Overflow() + x, a) ||
+        if (rewrite(IRMatcher::Overflow() + x, a) ||
             rewrite(x + IRMatcher::Overflow(), b) ||
             rewrite(x + 0, x) ||
             rewrite(0 + x, x)) {
@@ -48,7 +47,8 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
 
         // clang-format off
         if (EVAL_IN_LAMBDA
-            (rewrite(x + x, x * 2) ||
+            (rewrite(c0 + c1, fold(c0 + c1)) ||
+             rewrite(x + x, x * 2) ||
              rewrite(ramp(x, y, c0) + ramp(z, w, c0), ramp(x + z, y + w, c0)) ||
              rewrite(ramp(x, y, c0) + broadcast(z, c0), ramp(x + z, y, c0)) ||
              rewrite(broadcast(x, c0) + broadcast(y, c1), broadcast(x + broadcast(y, fold(c1/c0)), c0), c1 % c0 == 0) ||

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -362,6 +362,18 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
             return mutate(unbroadcast, bounds);
         }
 
+        if (bounds) {
+            bounds->min = 0;
+            bounds->min_defined = true;
+            if (a_bounds.min_defined && a_bounds.max_defined) {
+                if (a_bounds.min != std::numeric_limits<int64_t>::min() &&
+                    a_bounds.max != std::numeric_limits<int64_t>::min()) {
+                    bounds->max_defined = true;
+                    bounds->max = std::max(std::abs(a_bounds.min), std::abs(a_bounds.max));
+                }
+            }
+        }
+
         Type ta = a.type();
         int64_t ia = 0;
         double fa = 0;

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -362,18 +362,6 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
             return mutate(unbroadcast, bounds);
         }
 
-        if (bounds) {
-            bounds->min = 0;
-            bounds->min_defined = true;
-            if (a_bounds.min_defined && a_bounds.max_defined) {
-                if (a_bounds.min != std::numeric_limits<int64_t>::min() &&
-                    a_bounds.max != std::numeric_limits<int64_t>::min()) {
-                    bounds->max_defined = true;
-                    bounds->max = std::max(std::abs(a_bounds.min), std::abs(a_bounds.max));
-                }
-            }
-        }
-
         Type ta = a.type();
         int64_t ia = 0;
         double fa = 0;

--- a/src/Simplify_Div.cpp
+++ b/src/Simplify_Div.cpp
@@ -118,10 +118,6 @@ Expr Simplify::visit(const Div *op, ExprInfo *bounds) {
         if (rewrite(IRMatcher::Overflow() / x, a) ||
             rewrite(x / IRMatcher::Overflow(), b) ||
             rewrite(x / 1, x) ||
-            rewrite(c0 / c1, fold(c0 / c1)) ||
-            (!op->type.is_float() && rewrite(x / 0, 0)) ||
-            (!op->type.is_float() && denominator_non_zero && rewrite(x / x, 1)) ||
-            rewrite(0 / x, 0) ||
             false) {
             return rewrite.result;
         }
@@ -131,7 +127,11 @@ Expr Simplify::visit(const Div *op, ExprInfo *bounds) {
 
         // clang-format off
         if (EVAL_IN_LAMBDA
-            (rewrite(broadcast(x, c0) / broadcast(y, c0), broadcast(x / y, c0)) ||
+            (rewrite(c0 / c1, fold(c0 / c1)) ||
+             (!op->type.is_float() && rewrite(x / 0, 0)) ||
+             (!op->type.is_float() && denominator_non_zero && rewrite(x / x, 1)) ||
+             rewrite(0 / x, 0) ||
+             rewrite(broadcast(x, c0) / broadcast(y, c0), broadcast(x / y, c0)) ||
              rewrite(select(x, c0, c1) / c2, select(x, fold(c0/c2), fold(c1/c2))) ||
              (!op->type.is_float() &&
               rewrite(x / x, select(x == 0, 0, 1))) ||

--- a/src/Simplify_Mod.cpp
+++ b/src/Simplify_Mod.cpp
@@ -62,20 +62,19 @@ Expr Simplify::visit(const Mod *op, ExprInfo *bounds) {
         int lanes = op->type.lanes();
         auto rewrite = IRMatcher::rewriter(IRMatcher::mod(a, b), op->type);
 
-        if (rewrite(c0 % c1, fold(c0 % c1)) ||
-            rewrite(IRMatcher::Overflow() % x, a) ||
-            rewrite(x % IRMatcher::Overflow(), b) ||
-            rewrite(0 % x, 0) ||
-            rewrite(x % x, 0) ||
-            rewrite(x % 0, 0) ||
-            (!op->type.is_float() &&
-             rewrite(x % 1, 0))) {
+        if (rewrite(IRMatcher::Overflow() % x, a) ||
+            rewrite(x % IRMatcher::Overflow(), b)) {
             return rewrite.result;
         }
 
         // clang-format off
         if (EVAL_IN_LAMBDA
-            (rewrite(broadcast(x, c0) % broadcast(y, c0), broadcast(x % y, c0)) ||
+            (rewrite(c0 % c1, fold(c0 % c1)) ||
+             rewrite(0 % x, 0) ||
+             rewrite(x % x, 0) ||
+             rewrite(x % 0, 0) ||
+             (!op->type.is_float() && rewrite(x % 1, 0)) ||
+             rewrite(broadcast(x, c0) % broadcast(y, c0), broadcast(x % y, c0)) ||
              (no_overflow_int(op->type) &&
               (rewrite((x * c0) % c1, (x * fold(c0 % c1)) % c1, c1 > 0 && (c0 >= c1 || c0 < 0)) ||
                rewrite((x + c0) % c1, (x + fold(c0 % c1)) % c1, c1 > 0 && (c0 >= c1 || c0 < 0)) ||

--- a/src/Simplify_Mul.cpp
+++ b/src/Simplify_Mul.cpp
@@ -57,17 +57,17 @@ Expr Simplify::visit(const Mul *op, ExprInfo *bounds) {
         }
 
         auto rewrite = IRMatcher::rewriter(IRMatcher::mul(a, b), op->type);
-        if (rewrite(c0 * c1, fold(c0 * c1)) ||
-            rewrite(IRMatcher::Overflow() * x, a) ||
+        if (rewrite(IRMatcher::Overflow() * x, a) ||
             rewrite(x * IRMatcher::Overflow(), b) ||
-            rewrite(0 * x, 0) ||
             rewrite(1 * x, x) ||
-            rewrite(x * 0, 0) ||
             rewrite(x * 1, x)) {
             return rewrite.result;
         }
 
-        if (rewrite((x + c0) * c1, x * c1 + fold(c0 * c1), !overflows(c0 * c1)) ||
+        if (rewrite(c0 * c1, fold(c0 * c1)) ||
+            rewrite(0 * x, 0) ||
+            rewrite(x * 0, 0) ||
+            rewrite((x + c0) * c1, x * c1 + fold(c0 * c1), !overflows(c0 * c1)) ||
             rewrite((c0 - x) * c1, x * fold(-c1) + fold(c0 * c1), !overflows(c0 * c1)) ||
             rewrite((x - y) * c0, (y - x) * fold(-c0), c0 < 0 && -c0 > 0) ||
             rewrite((x * c0) * c1, x * fold(c0 * c1), !overflows(c0 * c1)) ||

--- a/src/Simplify_Sub.cpp
+++ b/src/Simplify_Sub.cpp
@@ -34,8 +34,7 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
 
         auto rewrite = IRMatcher::rewriter(IRMatcher::sub(a, b), op->type);
 
-        if (rewrite(c0 - c1, fold(c0 - c1)) ||
-            rewrite(IRMatcher::Overflow() - x, a) ||
+        if (rewrite(IRMatcher::Overflow() - x, a) ||
             rewrite(x - IRMatcher::Overflow(), b) ||
             rewrite(x - 0, x)) {
             return rewrite.result;
@@ -43,7 +42,8 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
 
         // clang-format off
         if (EVAL_IN_LAMBDA
-            ((!op->type.is_uint() && rewrite(x - c0, x + fold(-c0), !overflows(-c0))) ||
+            (rewrite(c0 - c1, fold(c0 - c1)) ||
+             (!op->type.is_uint() && rewrite(x - c0, x + fold(-c0), !overflows(-c0))) ||
              rewrite(x - x, 0) || // We want to remutate this just to get better bounds
              rewrite(ramp(x, y, c0) - ramp(z, w, c0), ramp(x - z, y - w, c0)) ||
              rewrite(ramp(x, y, c0) - broadcast(z, c0), ramp(x - z, y, c0)) ||

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -312,9 +312,9 @@ public:
         // tests. However, if the pipeline does widen, we want to generate
         // different instructions that have a built in interleaving that
         // we can cancel with the deinterleaving from widening.
-        check("v*.ub = vsat(v*.h,v*.h)", hvx_width / 1, u8_sat(i16(i8_1) << 1));
-        check("v*.uh = vasr(v*.w,v*.w,r*):sat", hvx_width / 2, u16_sat(i32(i16_1) << 1));
-        check("v*.h = vsat(v*.w,v*.w)", hvx_width / 2, i16_sat(i32(i16_1) << 1));
+        check("v*.ub = vsat(v*.h,v*.h)", hvx_width / 1, u8_sat(i16(i8_1) + 256));
+        check("v*.uh = vasr(v*.w,v*.w,r*):sat", hvx_width / 2, u16_sat(i32(i16_1) + 256));
+        check("v*.h = vsat(v*.w,v*.w)", hvx_width / 2, i16_sat(i32(i16_1) + 256));
 
         // Also check double saturating narrows.
         check("v*.ub = vpack(v*.h,v*.h):sat", hvx_width / 1, u8_sat(i32_1));

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1873,7 +1873,8 @@ void check_overflow() {
     // Check that assert conditions generated with Target::LargeBuffers simplify away.
     Expr stride = Variable::make(Int(32), "stride");
     Expr extent = Variable::make(Int(32), "extent");
-    check(abs(cast<int64_t>(extent) * cast<int64_t>(stride)) <= Expr(9223372036854775807ull), const_true());
+    Expr max_size = (cast<uint64_t>(1) << 63) - 1;
+    check(abs(cast<int64_t>(extent) * cast<int64_t>(stride)) <= max_size, const_true());
 }
 
 template<typename T>

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1869,6 +1869,11 @@ void check_overflow() {
             }
         }
     }
+
+    // Check that assert conditions generated with Target::LargeBuffers simplify away.
+    Expr stride = Variable::make(Int(32), "stride");
+    Expr extent = Variable::make(Int(32), "extent");
+    check(abs(cast<int64_t>(extent) * cast<int64_t>(stride)) <= Expr(9223372036854775807ull), const_true());
 }
 
 template<typename T>

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1873,7 +1873,9 @@ void check_overflow() {
     // Check that assert conditions generated with Target::LargeBuffers simplify away.
     Expr stride = Variable::make(Int(32), "stride");
     Expr extent = Variable::make(Int(32), "extent");
-    check(abs(cast<int64_t>(extent) * cast<int64_t>(stride)) <= Expr(9223372036854775807ull), const_true());
+    Expr actual_size = cast<int64_t>(stride) * cast<int64_t>(extent);
+    Expr max_size = make_const(Int(64), (((uint64_t)1) << 63) - 1);
+    check(-max_size <= actual_size && actual_size <= max_size, const_true());
 }
 
 template<typename T>

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1873,9 +1873,7 @@ void check_overflow() {
     // Check that assert conditions generated with Target::LargeBuffers simplify away.
     Expr stride = Variable::make(Int(32), "stride");
     Expr extent = Variable::make(Int(32), "extent");
-    Expr actual_size = cast<int64_t>(stride) * cast<int64_t>(extent);
-    Expr max_size = make_const(Int(64), (((uint64_t)1) << 63) - 1);
-    check(-max_size <= actual_size && actual_size <= max_size, const_true());
+    check(abs(cast<int64_t>(extent) * cast<int64_t>(stride)) <= Expr(9223372036854775807ull), const_true());
 }
 
 template<typename T>


### PR DESCRIPTION
This requires tracking bounds through casts, and avoiding abs where the result is the max of an int64 + 1, which the simplifier can't handle.