### PR TITLE
Fix natural_vector_size for wasm 64-bit types

### DIFF
--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -933,10 +933,6 @@ int Target::natural_vector_size(const Halide::Type &t) const {
         }
     } else if (arch == Target::WebAssembly) {
         if (has_feature(Halide::Target::WasmSimd128)) {
-            if (t.bits() == 64) {
-                // int64 and float64 aren't supported in simd128.
-                return 1;
-            }
             // 128-bit vectors for other types.
             return 16 / data_size;
         } else {


### PR DESCRIPTION
In the original spec, wasm-simd128 didn't have int64 or float64; the final spec adds these types, so this bit of code is outdated and incorrect.