### PR TITLE
error_run_with_large_stack_throws should compile without exceptions

### DIFF
--- a/test/error/run_with_large_stack_throws.cpp
+++ b/test/error/run_with_large_stack_throws.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 
 int main() {
+#ifdef __cpp_exceptions
     try {
         Halide::Internal::run_with_large_stack([]() {
             throw Halide::RuntimeError("Error from run_with_large_stack");
@@ -11,6 +12,11 @@ int main() {
         return 1;
     }
 
+#else
+    Halide::Internal::run_with_large_stack([]() {
+        _halide_user_assert(0) << "Error from run_with_large_stack (no exceptions)";
+    });
+#endif
     std::cout << "Success!\n";
     return 0;
 }


### PR DESCRIPTION
(1) Some downstream environments compile C++ without exceptions by default; this won't compile on those.
(2) We should check that assert-fail also errors out as expected.