### PR TITLE
Revert "Display the GPU device code as a string in the C/C++ backend"

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1653,33 +1653,22 @@ void CodeGen_C::compile(const Buffer<> &buffer) {
     // used to store stateful module information in offloading runtimes.
     bool is_constant = buffer.dimensions() != 0;
 
-    // If it is an GPU source kernel, we would like to see the actual output, not the
-    // uint8 representation. We use a string literal for this.
-    if (ends_with(name, "gpu_source_kernels")) {
-        stream << "static const char *" << name << "_string = R\"BUFCHARSOURCE(";
-        stream.write((char *)b.host, num_elems);
-        stream << ")BUFCHARSOURCE\";\n";
-
-        stream << "static const uint8_t *" << name << "_data HALIDE_ATTRIBUTE_ALIGN(32) = (const uint8_t *) "
-               << name << "_string;\n";
-    } else {
-        // Emit the data
-        stream << "static " << (is_constant ? "const" : "") << " uint8_t " << name << "_data[] HALIDE_ATTRIBUTE_ALIGN(32) = {\n";
-        stream << get_indent();
-        for (size_t i = 0; i < num_elems * b.type.bytes(); i++) {
-            if (i > 0) {
-                stream << ",";
-                if (i % 16 == 0) {
-                    stream << "\n";
-                    stream << get_indent();
-                } else {
-                    stream << " ";
-                }
+    // Emit the data
+    stream << "static " << (is_constant ? "const" : "") << " uint8_t " << name << "_data[] HALIDE_ATTRIBUTE_ALIGN(32) = {\n";
+    stream << get_indent();
+    for (size_t i = 0; i < num_elems * b.type.bytes(); i++) {
+        if (i > 0) {
+            stream << ",";
+            if (i % 16 == 0) {
+                stream << "\n";
+                stream << get_indent();
+            } else {
+                stream << " ";
             }
-            stream << (int)(b.host[i]);
         }
-        stream << "\n};\n";
+        stream << (int)(b.host[i]);
     }
+    stream << "\n};\n";
 
     // Emit the shape (constant even for scalar buffers)
     stream << "static const halide_dimension_t " << name << "_buffer_shape[] = {";
@@ -2597,8 +2586,7 @@ void CodeGen_C::visit(const Allocate *op) {
         alloc.type = op->type;
         allocations.push(op->name, alloc);
         heap_allocations.push(op->name);
-        string new_e = print_expr(op->new_expr);
-        stream << get_indent() << op_type << " *" << op_name << " = (" << op_type << "*)" << new_e << ";\n";
+        stream << op_type << "*" << op_name << " = (" << print_expr(op->new_expr) << ");\n";
     } else {
         constant_size = op->constant_allocation_size();
         if (constant_size > 0) {


### PR DESCRIPTION
Testing to see if this is the injection point for recent Cuda-related hangs/errors.