### PR TITLE
DisableUnrollLoops should ignore DisableLLVMLoopOpt for PTX

### DIFF
--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -687,7 +687,11 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     b.Inliner = createFunctionInliningPass(b.OptLevel, 0, false);
     b.LoopVectorize = do_loop_opt;
     b.SLPVectorize = true;
-    b.DisableUnrollLoops = !do_loop_opt;
+    // Setting DisableUnrollLoops = true can occasionally generate PTX code that
+    // will fail at runtime under some conditions (e.g. correctness_gpu_dynamic_shared
+    // using NVidia driver 460.x). Note that the (current) default value for this flag
+    // is `false`, so this setting is somewhat redundant.
+    b.DisableUnrollLoops = false;  // !do_loop_opt;
 
     target_machine->adjustPassManager(b);
 


### PR DESCRIPTION
It's not entirely clear why, but setting the `DisableUnrollLoops` flag to `true` in the PTX backend can produce Cuda code that will fail at runtime, at least for certain drivers (e.g.: some of the tests in correctness_gpu_dynamic_shared when running under NVidia v460.x).