### PR TITLE
Add missing "struct" before halide_type_t.

### DIFF
--- a/src/runtime/HalideRuntimeD3D12Compute.h
+++ b/src/runtime/HalideRuntimeD3D12Compute.h
@@ -30,7 +30,7 @@ extern int halide_d3d12compute_run(void *user_context,
                                    int blocksX, int blocksY, int blocksZ,
                                    int threadsX, int threadsY, int threadsZ,
                                    int shared_mem_bytes,
-                                   halide_type_t arg_types[], void *args[], int8_t arg_is_buffer[]);
+                                   struct halide_type_t arg_types[], void *args[], int8_t arg_is_buffer[]);
 extern void halide_d3d12compute_finalize_kernels(void *user_context, void *state_ptr);
 // @}
 


### PR DESCRIPTION
This allows it to compile as pure C instead of C++.