### PR TITLE
Comment out specializations for f64x2.convert_low_i32x4_s/u

### DIFF
--- a/src/CodeGen_WebAssembly.cpp
+++ b/src/CodeGen_WebAssembly.cpp
@@ -94,8 +94,12 @@ const WasmIntrinsic intrinsic_defs[] = {
     {"llvm.wasm.extadd.pairwise.unsigned.v8i16", Int(16, 8), "pairwise_widening_add", {UInt(8, 16)}, Target::WasmSimd128},
     {"llvm.wasm.extadd.pairwise.unsigned.v4i32", Int(32, 4), "pairwise_widening_add", {UInt(16, 8)}, Target::WasmSimd128},
 
-    {"i32_to_double_s", Float(64, 4), "int_to_double", {Int(32, 4)}, Target::WasmSimd128},
-    {"i32_to_double_u", Float(64, 4), "int_to_double", {UInt(32, 4)}, Target::WasmSimd128},
+    // TODO: these instructions are no longer available at LLVM top of tree,
+    // but LLVM isn't generating the f64x2.convert_low_i32x4_s/u instructions;
+    // investigation needed.
+    // {"i32_to_double_s", Float(64, 4), "int_to_double", {Int(32, 4)}, Target::WasmSimd128},
+    // {"i32_to_double_u", Float(64, 4), "int_to_double", {UInt(32, 4)}, Target::WasmSimd128},
+
     {"float_to_double", Float(64, 4), "float_to_double", {Float(32, 4)}, Target::WasmSimd128},
 
     // Basically like ARM's SQRDMULH

--- a/src/runtime/wasm_math.ll
+++ b/src/runtime/wasm_math.ll
@@ -141,24 +141,27 @@ define weak_odr <8 x i16> @saturating_narrow_i32x8_to_u16x8(<8 x i32> %x) nounwi
 
 ; Integer to double-precision floating point
 
-declare <2 x double> @llvm.wasm.convert.low.signed(<4 x i32>)
-declare <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32>)
-
-define weak_odr <4 x double> @i32_to_double_s(<4 x i32> %x) nounwind alwaysinline {
-  %1 = shufflevector <4 x i32> %x, <4 x i32> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
-  %2 = tail call <2 x double> @llvm.wasm.convert.low.signed(<4 x i32> %x)
-  %3 = tail call <2 x double> @llvm.wasm.convert.low.signed(<4 x i32> %1)
-  %4 = shufflevector <2 x double> %2, <2 x double> %3, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  ret <4 x double> %4
-}
-
-define weak_odr <4 x double> @i32_to_double_u(<4 x i32> %x) nounwind alwaysinline {
-  %1 = shufflevector <4 x i32> %x, <4 x i32> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
-  %2 = tail call <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32> %x)
-  %3 = tail call <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32> %1)
-  %4 = shufflevector <2 x double> %2, <2 x double> %3, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  ret <4 x double> %4
-}
+; COMMENTED OUT AT TOP OF TREE; llvm.wasm.convert.low.[un]signed is no longer
+; available, but LLVM isn't generating the f64x2.convert_low_i32x4_s/u instructions
+; that we'd expect, so investigation needs to be done.
+;   declare <2 x double> @llvm.wasm.convert.low.signed(<4 x i32>)
+;   declare <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32>)
+;
+;   define weak_odr <4 x double> @i32_to_double_s(<4 x i32> %x) nounwind alwaysinline {
+;     %1 = shufflevector <4 x i32> %x, <4 x i32> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
+;     %2 = tail call <2 x double> @llvm.wasm.convert.low.signed(<4 x i32> %x)
+;     %3 = tail call <2 x double> @llvm.wasm.convert.low.signed(<4 x i32> %1)
+;     %4 = shufflevector <2 x double> %2, <2 x double> %3, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+;     ret <4 x double> %4
+;   }
+;
+;   define weak_odr <4 x double> @i32_to_double_u(<4 x i32> %x) nounwind alwaysinline {
+;     %1 = shufflevector <4 x i32> %x, <4 x i32> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
+;     %2 = tail call <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32> %x)
+;     %3 = tail call <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32> %1)
+;     %4 = shufflevector <2 x double> %2, <2 x double> %3, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+;     ret <4 x double> %4
+;   }
 
 ; single to double-precision floating point
 

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -2149,8 +2149,11 @@ public:
 
                 // Integer to double-precision floating point
                 if (Halide::Internal::get_llvm_version() >= 130) {
-                    check("f64x2.convert_low_i32x4_s", 2 * w, cast<double>(i32_1));
-                    check("f64x2.convert_low_i32x4_u", 2 * w, cast<double>(u32_1));
+                    // TODO: we can't directly generate these instructions at LLVM top of tree,
+                    // but LLVM isn't generating the f64x2.convert_low_i32x4_s/u instructions;
+                    // investigation needed.
+                    // check("f64x2.convert_low_i32x4_s", 2 * w, cast<double>(i32_1));
+                    // check("f64x2.convert_low_i32x4_u", 2 * w, cast<double>(u32_1));
                 }
 
                 // Single-precision floating point to integer with saturation


### PR DESCRIPTION
LLVM removed the primitives we need (so our code can't be used), but it also doesn't seem to be generating the expected instructions directly (as claimed). Commenting out to un-break tests; issue has been reported to wasm/llvm team.