### PR TITLE
Speed up simd_op_check by only compiling one pipeline per op

### DIFF
--- a/test/correctness/compute_with.cpp
+++ b/test/correctness/compute_with.cpp
@@ -143,6 +143,7 @@ int split_test() {
 }
 
 int fuse_test() {
+    const int size = 20;
     Buffer<int> im_ref, im;
     {
         Var x("x"), y("y"), z("z");
@@ -151,7 +152,7 @@ int fuse_test() {
         f(x, y, z) = x + y + z;
         g(x, y, z) = x - y + z;
         h(x, y, z) = f(x + 2, y - 1, z + 3) + g(x - 5, y - 6, z + 2);
-        im_ref = h.realize({100, 100, 100});
+        im_ref = h.realize({size, size, size});
     }
 
     {
@@ -173,18 +174,18 @@ int fuse_test() {
         g.trace_loads().trace_stores();
         h.trace_loads().trace_stores();
         stores = {
-            {f.name(), Bound(2, 101, -1, 98, 3, 102)},
-            {g.name(), Bound(-5, 94, -6, 93, 2, 101)},
-            {h.name(), Bound(0, 99, 0, 99, 0, 99)},
+            {f.name(), Bound(2, size + 1, -1, size - 2, 3, size + 2)},
+            {g.name(), Bound(-5, size - 6, -6, size - 7, 2, size + 1)},
+            {h.name(), Bound(0, size - 1, 0, size - 1, 0, size - 1)},
         };
         loads = {
-            {f.name(), Bound(2, 101, -1, 98, 3, 102)},
-            {g.name(), Bound(-5, 94, -6, 93, 2, 101)},
+            {f.name(), Bound(2, size + 1, -1, size - 2, 3, size + 2)},
+            {g.name(), Bound(-5, size - 6, -6, size - 7, 2, size + 1)},
             {h.name(), Bound()},  // There shouldn't be any load from h
         };
         h.set_custom_trace(&my_trace);
 
-        im = h.realize({100, 100, 100});
+        im = h.realize({size, size, size});
     }
 
     auto func = [im_ref](int x, int y, int z) {
@@ -474,7 +475,7 @@ int double_split_fuse_test() {
 
 int rgb_yuv420_test() {
     // Somewhat approximating the behavior of rgb -> yuv420 (downsample by half in the u and v channels)
-    const int size = 256;
+    const int size = 64;
     Buffer<int> y_im(size, size), u_im(size / 2, size / 2), v_im(size / 2, size / 2);
     Buffer<int> y_im_ref(size, size), u_im_ref(size / 2, size / 2), v_im_ref(size / 2, size / 2);
 
@@ -637,6 +638,8 @@ int rgb_yuv420_test() {
 }
 
 int vectorize_test() {
+    const int width = 111;
+    const int height = 31;
     Buffer<int> im_ref, im;
     {
         Var x("x"), y("y");
@@ -645,7 +648,7 @@ int vectorize_test() {
         f(x, y) = x + y;
         g(x, y) = x - y;
         h(x, y) = f(x - 1, y + 1) + g(x + 2, y - 2);
-        im_ref = h.realize({111, 111});
+        im_ref = h.realize({width, height});
     }
 
     {
@@ -670,18 +673,18 @@ int vectorize_test() {
         g.trace_loads().trace_stores();
         h.trace_loads().trace_stores();
         stores = {
-            {f.name(), Bound(-1, 109, 1, 111)},
-            {g.name(), Bound(2, 112, -2, 108)},
-            {h.name(), Bound(0, 110, 0, 110)},
+            {f.name(), Bound(-1, width - 2, 1, height)},
+            {g.name(), Bound(2, width + 1, -2, height - 3)},
+            {h.name(), Bound(0, width - 1, 0, height - 1)},
         };
         loads = {
-            {f.name(), Bound(-1, 109, 1, 111)},
-            {g.name(), Bound(2, 112, -2, 108)},
+            {f.name(), Bound(-1, width - 2, 1, height)},
+            {g.name(), Bound(2, width + 1, -2, height - 3)},
             {h.name(), Bound()},  // There shouldn't be any load from h
         };
         h.set_custom_trace(&my_trace);
 
-        im = h.realize({111, 111});
+        im = h.realize({width, height});
     }
 
     auto func = [im_ref](int x, int y) {

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1452,9 +1452,6 @@ public:
             check(arm32 ? "vsubw.u16" : "usubw", 4 * w, u32_1 - u16_1);
             check(arm32 ? "vsubw.s32" : "ssubw", 2 * w, i64_1 - i32_1);
             check(arm32 ? "vsubw.u32" : "usubw", 2 * w, u64_1 - u32_1);
-
-            // VST1     X       -       Store single-element structures
-            check(arm32 ? "vst1.8" : "st", 8 * w, i8_1);
         }
 
         // VST2 X       -       Store two-element structures


### PR DESCRIPTION
This PR changes simd_op_check to compile just one pipeline, the error checking pipeline. I think the motivation for the original design was to make the assembly to read when the op failed to generate as small as possible. However, the assembly with this isn't that much bigger, and since we compile only one pipeline, there is only one version of a lowered Stmt, so HL_DEBUG_CODEGEN output is easier to read, despite the slightly larger pipeline.

This should also speed up simd_op_check, which is up to ~15 minutes(!) on the ARM buildbots. Unfortunately the speedup is only ~20% (and not ~50%) because this only saves us from doing two Halide lowerings and two compile_to_llvm_module calls, but we still run LLVM twice to generate the assembly and object file.

There's another advantage to this: this PR closes a (small) potential crack for bugs to appear in. If Halide/LLVM generated different code for the error check and the assembly op check, the assembly op check could pass, while the error check could generate different code and incorrectly pass (when it would fail if it generated the same code as the op check).