### PR TITLE
Temporarily disable hanging test

### DIFF
--- a/test/correctness/vector_reductions.cpp
+++ b/test/correctness/vector_reductions.cpp
@@ -3,6 +3,9 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
+    printf("[SKIP] Avoid test hang due to https://reviews.llvm.org/D100099.\n");
+    return 0;
+
     for (int dst_lanes : {1, 3}) {
         for (int reduce_factor : {2, 3, 4}) {
             std::vector<Type> types =

--- a/test/correctness/vector_reductions.cpp
+++ b/test/correctness/vector_reductions.cpp
@@ -3,7 +3,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    printf("[SKIP] Avoid test hang due to https://reviews.llvm.org/D100099.\n");
+    printf("[SKIP] Avoid test hang due to https://reviews.llvm.org/D100099 [https://github.com/halide/Halide/issues/5926].\n");
     return 0;
 
     for (int dst_lanes : {1, 3}) {


### PR DESCRIPTION
LLVM13 is causing vector_reductions to hang (https://reviews.llvm.org/D100099 appears to be the injection point). Disabling this test to unbreak the buildbots.