### PR TITLE
Fix count_leading/trailing_zeros

### DIFF
--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -502,6 +502,7 @@ void CodeGen_X86::visit(const Call *op) {
         // case.
         Value *cond = builder->CreateICmpEQ(args[0], ConstantInt::get(arg_type[0], 0));
         value = builder->CreateSelect(cond, ConstantInt::get(arg_type[0], op->args[0].type().bits()), call);
+        return;
     }
 
     CodeGen_Posix::visit(op);

--- a/test/correctness/bit_counting.cpp
+++ b/test/correctness/bit_counting.cpp
@@ -94,11 +94,6 @@ int test_bit_counting(const Target &target) {
 
     Buffer<T> ctlz_result = ctlz_test.realize({256});
     for (int i = 0; i < 256; ++i) {
-        if (input(i) == 0) {
-            // results are undefined for zero input
-            continue;
-        }
-
         if (ctlz_result(i) != local_count_leading_zeros(input(i))) {
             std::string bits_string = as_bits(input(i));
             printf("Ctlz of %u [0b%s] returned %d (should be %d)\n",
@@ -114,11 +109,6 @@ int test_bit_counting(const Target &target) {
 
     Buffer<T> cttz_result = cttz_test.realize({256});
     for (int i = 0; i < 256; ++i) {
-        if (input(i) == 0) {
-            // results are undefined for zero input
-            continue;
-        }
-
         if (cttz_result(i) != local_count_trailing_zeros(input(i))) {
             std::string bits_string = as_bits(input(i));
             printf("Cttz of %u [0b%s] returned %d (should be %d)\n",

--- a/test/correctness/bit_counting.cpp
+++ b/test/correctness/bit_counting.cpp
@@ -25,7 +25,7 @@ T local_count_trailing_zeros(T v) {
             return b;
         }
     }
-    return 0;
+    return bits;
 }
 
 template<typename T>
@@ -37,7 +37,7 @@ T local_count_leading_zeros(T v) {
             return b;
         }
     }
-    return 0;
+    return bits;
 }
 
 template<typename T>


### PR DESCRIPTION
IROperator.h claims count_leading_zeros/count_trailing_zeros return the number of bits if the argument is 0, which is a good definition, and matches ARM's behavior. However, test/correctness/bit_counting.cpp tested a different behavior, and x86 did not match the behavior defined in IROperator.h