### PR TITLE
Update bit_counting test to reflect behavior we expect

### DIFF
--- a/test/correctness/bit_counting.cpp
+++ b/test/correctness/bit_counting.cpp
@@ -25,7 +25,7 @@ T local_count_trailing_zeros(T v) {
             return b;
         }
     }
-    return 0;
+    return bits;
 }
 
 template<typename T>
@@ -37,7 +37,7 @@ T local_count_leading_zeros(T v) {
             return b;
         }
     }
-    return 0;
+    return bits;
 }
 
 template<typename T>
@@ -94,11 +94,6 @@ int test_bit_counting(const Target &target) {
 
     Buffer<T> ctlz_result = ctlz_test.realize({256});
     for (int i = 0; i < 256; ++i) {
-        if (input(i) == 0) {
-            // results are undefined for zero input
-            continue;
-        }
-
         if (ctlz_result(i) != local_count_leading_zeros(input(i))) {
             std::string bits_string = as_bits(input(i));
             printf("Ctlz of %u [0b%s] returned %d (should be %d)\n",
@@ -114,11 +109,6 @@ int test_bit_counting(const Target &target) {
 
     Buffer<T> cttz_result = cttz_test.realize({256});
     for (int i = 0; i < 256; ++i) {
-        if (input(i) == 0) {
-            // results are undefined for zero input
-            continue;
-        }
-
         if (cttz_result(i) != local_count_trailing_zeros(input(i))) {
             std::string bits_string = as_bits(input(i));
             printf("Cttz of %u [0b%s] returned %d (should be %d)\n",


### PR DESCRIPTION
We claim `count_leading_zeros` and `count_trailing_zeros` return the size of the type in bits when the argument is 0. But, the test for these treated this as undefined behavior.