### PR TITLE
Remove old multiply codegen for ARM

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -52,7 +52,6 @@ protected:
     // @{
     void visit(const Cast *) override;
     void visit(const Sub *) override;
-    void visit(const Mul *) override;
     void visit(const Min *) override;
     void visit(const Max *) override;
     void visit(const Store *) override;
@@ -769,48 +768,6 @@ void CodeGen_ARM::visit(const Cast *op) {
                 return;
             }
         }
-    }
-
-    CodeGen_Posix::visit(op);
-}
-
-void CodeGen_ARM::visit(const Mul *op) {
-    if (neon_intrinsics_disabled()) {
-        CodeGen_Posix::visit(op);
-        return;
-    }
-
-    // We only have peephole optimizations for int vectors for now
-    if (op->type.is_scalar() || op->type.is_float()) {
-        CodeGen_Posix::visit(op);
-        return;
-    }
-
-    vector<Expr> matches;
-
-    int shift_amount = 0;
-    if (is_const_power_of_two_integer(op->b, &shift_amount)) {
-        // Let LLVM handle these.
-        CodeGen_Posix::visit(op);
-        return;
-    }
-
-    // Vector multiplies by 3, 5, 7, 9 should do shift-and-add or
-    // shift-and-sub instead to reduce register pressure (the
-    // shift is an immediate)
-    // TODO: Verify this is still good codegen.
-    if (is_const(op->b, 3)) {
-        value = codegen((op->a << 1) + op->a);
-        return;
-    } else if (is_const(op->b, 5)) {
-        value = codegen((op->a << 2) + op->a);
-        return;
-    } else if (is_const(op->b, 7)) {
-        value = codegen((op->a << 3) - op->a);
-        return;
-    } else if (is_const(op->b, 9)) {
-        value = codegen((op->a << 3) + op->a);
-        return;
     }
 
     CodeGen_Posix::visit(op);


### PR DESCRIPTION
This removes CodeGen_ARM's Mul visitor. The mul visitor only did one thing differently from CodeGen_LLVM, which was to rewrite multiplies of 2^n +/- 1 to shifts and adds/subtracts. However, even if this is a helpful optimization, LLVM is rewriting it back to a multiply anyways. This codegen also doesn't use CSE, so it generates quite a lot of extra code.

After removing that, the visitor doesn't do anything differently from the base class.