### PR TITLE
Use arm as our generic target triple

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -971,10 +971,11 @@ $(BIN_DIR)/build_halide_h: $(ROOT_DIR)/tools/build_halide_h.cpp
 -include $(OBJECTS:.o=.d)
 -include $(INITIAL_MODULES:.o=.d)
 
-# Compile generic 32- or 64-bit code
-# (The 'nacl' is a red herring. This is just a generic 32-bit little-endian target.)
-RUNTIME_TRIPLE_32 = "le32-unknown-nacl-unknown"
-RUNTIME_TRIPLE_64 = "le64-unknown-unknown-unknown"
+# Compile generic 32- or 64-bit code (The 'arm/aarch64' is a red
+# herring. These targets produce generic-enough bitcode to still work
+# once the triple is rewritten)
+RUNTIME_TRIPLE_32 = "arm-unknown-unknown-eabi"
+RUNTIME_TRIPLE_64 = "aarch64-unknown-unknown-eabi"
 
 # Windows requires special handling.  The generic windows_* modules must have -fpic elided
 # and (for 64 bit) must set wchar to be 2 bytes.  The windows_*_x86 and windows_*_arm
@@ -987,7 +988,7 @@ RUNTIME_TRIPLE_WIN_X86_32 = "i386-unknown-windows-unknown"
 RUNTIME_TRIPLE_WIN_X86_64 = "x86_64-unknown-windows-unknown"
 RUNTIME_TRIPLE_WIN_ARM_32 = "arm-unknown-windows-unknown"
 RUNTIME_TRIPLE_WIN_ARM_64 = "aarch64-unknown-windows-unknown"
-RUNTIME_TRIPLE_WIN_GENERIC_64 = "le64-unknown-windows-unknown"
+RUNTIME_TRIPLE_WIN_GENERIC_64 = "aarch64-unknown-windows-unknown"
 
 # `-fno-threadsafe-statics` is very important here (note that it allows us to use a 'modern' C++
 # standard but still skip threadsafe guards for static initialization in our runtime code)

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -203,17 +203,17 @@ foreach (i IN LISTS RUNTIME_CPP)
                     # unfortunately, clang doesn't automatically set this flag even though the
                     # ABI is msvc on windows
                     set(fshort-wchar -fshort-wchar)
-                    set(TARGET "le64-unknown-windows-unknown")
+                    set(TARGET "aarch64-unknown-windows-unknown")
                 endif ()
             endif()
         # Everything else
         else()
             if (j EQUAL 32)
-                # (The 'nacl' is a red herring. This is just a generic 32-bit little-endian target.)
-                set(TARGET "le32-unknown-nacl-unknown")
+                # (The 'arm' is a red herring. This is just a generic 32-bit little-endian target.)
+                set(TARGET "arm-unknown-unknown-eabi")
             else ()
                 # generic 64-bit code
-                set(TARGET "le64-unknown-unknown-unknown")
+                set(TARGET "aarch64-unknown-unknown-eabi")
             endif ()
         endif ()
 


### PR DESCRIPTION
le64 / le32 have been removed from LLVM mainline. Let's see if using arm triples with an unknown OS works for our purposes.