### PR TITLE
[Hexagon] Try vdelta/vrdelta before vlut for some shuffles.

### DIFF
--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -652,6 +652,10 @@ public:
         check("vnormamt(v*.w)", hvx_width / 4, max(count_leading_zeros(i32_1), count_leading_zeros(~i32_1)));
         check("vpopcount(v*.h)", hvx_width / 2, popcount(u16_1));
 
+        check("v* = vdelta(v*, v*)", hvx_width, in_u8((x / 8) * 9 + x % 8));
+        check("v* = vdelta(v*, v*)", hvx_width / 2, in_u16((x / 8) * 9 + x % 8));
+        check("v* = vdelta(v*, v*)", hvx_width / 4, in_u32((x / 8) * 9 + x % 8));
+
         int rfac = 4;
         RDom r(0, rfac);
         check("v*.uw = vrmpy(v*.ub,r*.ub)", hvx_width / 4, sum(u16(in_u8(rfac * x + r))));


### PR DESCRIPTION
The patch tries to generate vdelta/vrdelta instructions for non-ramp
shuffles. Eg:

shuffle(lut_expr,
        < 0,  1,  2,  3,  4,  5,  6,  7,
          9, 10, 11, 12, 13, 14, 15, 16,
         18, 19, 20, 21, 22, 23, 24, 25,
         27, 28, 29, 30, 31, 32, 33, 34,
         36, 37, 38, 39, 40, 41, 42, 43,
         45, 46, 47, 48, 49, 50, 51, 52,
         54, 55, 56, 57, 58, 59, 60, 61,
         63, 64, 65, 66, 67, 68, 69, 70>)

can be generated using vrdelta.

The patch also fixes a bug where we bitcast vdelta/vrdelta with 16/32
bits elements to wrong type. User would see the below error:

llvm-project/llvm/lib/IR/Instructions.cpp:2905: static llvm::CastInst
*llvm::CastInst::Create(Instruction::CastOps, llvm::Value *, llvm::Type *,
                        const llvm::Twine &, llvm::Instruction *):
                        Assertion `castIsValid(op, S, Ty) &&
                        "Invalid cast!"' failed.