### PR TITLE
[Tutorial] Rename lesson 21 into two parts

### DIFF
--- a/tutorial/lesson_21_auto_scheduler_generate.cpp
+++ b/tutorial/lesson_21_auto_scheduler_generate.cpp
@@ -1,4 +1,4 @@
-// Halide tutorial lesson 21: Auto-Scheduler
+// Halide tutorial lesson 21: Auto-Scheduler part 1
 
 // So far we have written Halide schedules by hand, but it is also possible to
 // ask Halide to suggest a reasonable schedule. We call this auto-scheduling.

--- a/tutorial/lesson_21_auto_scheduler_run.cpp
+++ b/tutorial/lesson_21_auto_scheduler_run.cpp
@@ -1,4 +1,4 @@
-// Halide tutorial lesson 21: Auto-Scheduler
+// Halide tutorial lesson 21: Auto-Scheduler part 2
 
 // Before reading this file, see lesson_21_auto_scheduler_generate.cpp
 


### PR DESCRIPTION
There are two chapters with the same name, Auto-Scheduler. renaming them into two chapters seems less confusing.

Naming the title I think done from https://github.com/halide/halide.github.com/blob/master/tutorials/tutorial_introduction.html.
For that, I also send a PR - https://github.com/halide/halide.github.com/pull/11.

Signed-off-by: xgupta <shivam98.tkg@rediffmail.com>