### PR TITLE
Fix flattening of ramps involving 64-bit mins

### DIFF
--- a/src/FlattenNestedRamps.cpp
+++ b/src/FlattenNestedRamps.cpp
@@ -105,7 +105,7 @@ class FlattenRamps : public IRMutator {
                 // in the schedule somehow.
                 const int max_unused_lane_factor = 4;
                 if (extent < max_unused_lane_factor * lanes) {
-                    Expr dense_index = Ramp::make(min_lane, stride, extent);
+                    Expr dense_index = Ramp::make(min_lane, cast(min_lane.type(), stride), extent);
                     Expr dense_load =
                         Load::make(op->type.with_lanes(extent), op->name, dense_index,
                                    op->image, op->param,

--- a/src/FlattenNestedRamps.cpp
+++ b/src/FlattenNestedRamps.cpp
@@ -105,7 +105,7 @@ class FlattenRamps : public IRMutator {
                 // in the schedule somehow.
                 const int max_unused_lane_factor = 4;
                 if (extent < max_unused_lane_factor * lanes) {
-                    Expr dense_index = Ramp::make(min_lane, cast(min_lane.type(), stride), extent);
+                    Expr dense_index = Ramp::make(min_lane, make_const(min_lane.type(), stride), extent);
                     Expr dense_load =
                         Load::make(op->type.with_lanes(extent), op->name, dense_index,
                                    op->image, op->param,


### PR DESCRIPTION
With Target::LargeBuffers, min_lane is int64, but stride is an int, which then triggers an assert because the ramp is of mismatched types.