### PR TITLE
Collapse Shuffle of strided-loads to shuffle's of non-strided loads

### DIFF
--- a/src/Simplify_Shuffle.cpp
+++ b/src/Simplify_Shuffle.cpp
@@ -282,7 +282,8 @@ Expr Simplify::visit(const Shuffle *op, ExprInfo *bounds) {
         }
     }
 
-    int curr_min = 0; int curr_max = 0;
+    int curr_min = 0;
+    int curr_max = 0;
     vector<int> new_indices = op->indices;
     for (size_t i = 0; i < new_vectors.size(); i++) {
         Expr e = new_vectors[i];

--- a/src/Simplify_Shuffle.cpp
+++ b/src/Simplify_Shuffle.cpp
@@ -298,8 +298,8 @@ Expr Simplify::visit(const Shuffle *op, ExprInfo *bounds) {
                             new_indices[j] = index * (*stride);
                         }
                     }
-                    Expr new_load_index = Ramp::make(ramp->base, 1, ramp->lanes * (*stride));
-                    Type t = load->type.with_lanes(load->type.lanes() * (*stride));
+                    Expr new_load_index = Ramp::make(ramp->base, 1, (ramp->lanes - 1) * (*stride) + 1);
+                    Type t = load->type.with_lanes((load->type.lanes() - 1) * (*stride) + 1);
                     new_vectors[i] = Load::make(t, load->name, new_load_index, load->image,
                                                 load->param, const_true(t.lanes()), load->alignment);
                 }


### PR DESCRIPTION
@dsharletg I don't think we will access any out of bounds memory with the change. Can you take a look once? If you think this is a good change then I'll add the comments and testcase and clean the patch.