### PR TITLE
Fix build issue in runtime

### DIFF
--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -298,10 +298,6 @@ WEAK void halide_profiler_report_unlocked(void *user_context, halide_profiler_st
             continue;
         }
         sstr.clear();
-        int alloc_avg = 0;
-        if (p->num_allocs != 0) {
-            alloc_avg = p->memory_total / p->num_allocs;
-        }
         bool serial = p->active_threads_numerator == p->active_threads_denominator;
         float threads = p->active_threads_numerator / (p->active_threads_denominator + 1e-10);
         sstr << p->name << "\n"
@@ -375,11 +371,6 @@ WEAK void halide_profiler_report_unlocked(void *user_context, halide_profiler_st
                     }
                 }
 
-                int alloc_avg = 0;
-                if (fs->num_allocs != 0) {
-                    alloc_avg = fs->memory_total / fs->num_allocs;
-                }
-
                 if (fs->memory_peak) {
                     cursor += 15;
                     sstr << " peak: " << fs->memory_peak;
@@ -390,6 +381,10 @@ WEAK void halide_profiler_report_unlocked(void *user_context, halide_profiler_st
                     cursor += 15;
                     while (sstr.size() < cursor) {
                         sstr << " ";
+                    }
+                    int alloc_avg = 0;
+                    if (fs->num_allocs != 0) {
+                        alloc_avg = fs->memory_total / fs->num_allocs;
                     }
                     sstr << " avg: " << alloc_avg;
                 }


### PR DESCRIPTION
It seems this started failing on the buildbots recently:

```
src/runtime/profiler.cpp:301:13: error: variable 'alloc_avg' set but not used [-Werror,-Wunused-but-set-variable]
        int alloc_avg = 0;
```