### PR TITLE
Non-widening lowering of rounding shifts

### DIFF
--- a/test/correctness/intrinsics.cpp
+++ b/test/correctness/intrinsics.cpp
@@ -17,7 +17,7 @@ void check(Expr test, Expr expected, Type required_type) {
         std::cerr << "failure!\n";
         std::cerr << "test: " << test << "\n";
         std::cerr << "result: " << result << "\n";
-        std::cerr << "exepcted: " << expected << "\n";
+        std::cerr << "expected: " << expected << "\n";
         abort();
     }
 }


### PR DESCRIPTION
This version lowers it without needing to widen, which is a large win on
x86 for 16 and 32-bit types (3.8x faster and 2.8x faster respectively).
It's a very slight slowdown for 8-bit because x86 doesn't have 8-bit
shift instructions.

Also drive-by typo fix.