### PR TITLE
Small H::R::B cleanups and improvements

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -517,11 +517,7 @@ public:
     /** The total number of elements this buffer represents. Equal to
      * the product of the extents */
     size_t number_of_elements() const {
-        size_t s = 1;
-        for (int i = 0; i < dimensions(); i++) {
-            s *= dim(i).extent();
-        }
-        return s;
+        return buf.number_of_elements();
     }
 
     /** Get the dimensionality of the buffer. */
@@ -534,49 +530,23 @@ public:
         return buf.type;
     }
 
-private:
-    /** Offset to the element with the lowest address. If all
-     * strides are positive, equal to zero. Offset is in elements, not bytes. */
-    ptrdiff_t begin_offset() const {
-        ptrdiff_t index = 0;
-        for (int i = 0; i < dimensions(); i++) {
-            if (dim(i).stride() < 0) {
-                index += dim(i).stride() * (ptrdiff_t)(dim(i).extent() - 1);
-            }
-        }
-        return index;
-    }
-
-    /** An offset to one beyond the element with the highest address.
-     * Offset is in elements, not bytes. */
-    ptrdiff_t end_offset() const {
-        ptrdiff_t index = 0;
-        for (int i = 0; i < dimensions(); i++) {
-            if (dim(i).stride() > 0) {
-                index += dim(i).stride() * (ptrdiff_t)(dim(i).extent() - 1);
-            }
-        }
-        index += 1;
-        return index;
-    }
-
 public:
     /** A pointer to the element with the lowest address. If all
      * strides are positive, equal to the host pointer. */
     T *begin() const {
         assert(buf.host != nullptr);  // Cannot call begin() on an unallocated Buffer.
-        return (T *)(buf.host + begin_offset() * type().bytes());
+        return (T *)buf.begin();
     }
 
     /** A pointer to one beyond the element with the highest address. */
     T *end() const {
         assert(buf.host != nullptr);  // Cannot call end() on an unallocated Buffer.
-        return (T *)(buf.host + end_offset() * type().bytes());
+        return (T *)buf.end();
     }
 
     /** The total number of bytes spanned by the data in memory. */
     size_t size_in_bytes() const {
-        return (size_t)(end_offset() - begin_offset()) * type().bytes();
+        return buf.size_in_bytes();
     }
 
     /** Reset the Buffer to be equivalent to a default-constructed Buffer
@@ -1688,11 +1658,7 @@ public:
     }
 
     int device_sync(void *ctx = nullptr) {
-        if (buf.device_interface) {
-            return buf.device_interface->device_sync(ctx, &buf);
-        } else {
-            return 0;
-        }
+        return buf.device_sync(ctx);
     }
 
     bool has_device_allocation() const {


### PR DESCRIPTION
- Reduce duplication of some tricky code with `halide_buffer_t`
- Combine `decref` and `decref_dev`. This might help a little with overhead, and if nothing else, makes it easier to identify it (one less function in the long tail of profiler output).