### PR TITLE
Temporarily disable apps/hannk

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -26,7 +26,7 @@ add_subdirectory(cuda_mat_mul)
 add_subdirectory(depthwise_separable_conv)
 add_subdirectory(fft)
 if (ENABLE_APPS_HANNK)
-add_subdirectory(hannk)
+# add_subdirectory(hannk)
 endif ()
 add_subdirectory(harris)
 # add_subdirectory(hexagon_benchmarks)  # TODO(#5374): missing CMake build


### PR DESCRIPTION
It's failing to config/build properly on the buildbots (but not locally); disabling to avoid build failures until I sort this out