### PR TITLE
HalideBuffer should use D=max_rank instead of D=4

### DIFF
--- a/apps/hannk/compare_vs_tflite.cpp
+++ b/apps/hannk/compare_vs_tflite.cpp
@@ -58,7 +58,7 @@ halide_type_t tf_lite_type_to_halide_type(TfLiteType t) {
     }
 }
 
-Buffer<void> wrap_tf_lite_tensor_with_halide_buffer(const TfLiteTensor *t) {
+HalideBuffer<void> wrap_tf_lite_tensor_with_halide_buffer(const TfLiteTensor *t) {
     // Wrap a Halide buffer around it.
     std::vector<halide_dimension_t> shape(t->dims->size);
     size_t shape_size = 1;
@@ -71,7 +71,7 @@ Buffer<void> wrap_tf_lite_tensor_with_halide_buffer(const TfLiteTensor *t) {
     void *buffer_data = t->data.data;
 
     halide_type_t type = tf_lite_type_to_halide_type(t->type);
-    Buffer<void> b(type, buffer_data, shape.size(), shape.data());
+    HalideBuffer<void> b(type, buffer_data, shape.size(), shape.data());
     assert(b.size_in_bytes() == t->bytes);
     return b;
 }
@@ -193,7 +193,7 @@ private:
     int seed_for_name(const std::string &name);
 
     struct RunResult {
-        std::vector<Buffer<const void>> outputs;
+        std::vector<HalideBuffer<const void>> outputs;
         std::chrono::duration<double> time{0};
     };
     RunResult run_in_hannk(const std::vector<char> &buffer);
@@ -337,8 +337,8 @@ bool Runner::compare_results(const std::string &msg, const RunResult &a, const R
     bool all_matched = true;
     CHECK(a.outputs.size() == b.outputs.size());
     for (size_t i = 0; i < a.outputs.size(); ++i) {
-        const Buffer<const void> &tflite_buf = a.outputs[i];
-        const Buffer<const void> &halide_buf = b.outputs[i];
+        const HalideBuffer<const void> &tflite_buf = a.outputs[i];
+        const HalideBuffer<const void> &halide_buf = b.outputs[i];
         CHECK(tflite_buf.type() == halide_buf.type()) << "Expected type " << tflite_buf.type() << "; saw type " << halide_buf.type();
         CHECK(tflite_buf.dimensions() == halide_buf.dimensions());
         for (int d = 0; d < tflite_buf.dimensions(); d++) {

--- a/apps/hannk/interpreter/interval.h
+++ b/apps/hannk/interpreter/interval.h
@@ -10,7 +10,7 @@
 namespace hannk {
 
 // The maximum rank of any shape or array of dimension information.
-const int max_rank = 6;
+constexpr int max_rank = 6;
 
 // This class mimics std::vector, but never dynamically allocates memory.
 // It can only grow to Capacity elements.

--- a/apps/hannk/interpreter/model.h
+++ b/apps/hannk/interpreter/model.h
@@ -10,12 +10,10 @@
 
 #include "HalideBuffer.h"
 #include "interpreter/interval.h"
+#include "util/buffer_util.h"
 #include "util/error_util.h"
 
 namespace hannk {
-
-template<typename T>
-using HalideBuffer = Halide::Runtime::Buffer<T>;
 
 struct QuantizationInfo {
     std::vector<float> scale;

--- a/apps/hannk/util/buffer_util.h
+++ b/apps/hannk/util/buffer_util.h
@@ -10,6 +10,11 @@
 
 namespace hannk {
 
+// Using a Buffer with space for max_rank dimensions is a meaningful
+// win for some corner cases (when adding dimensions to > 4).
+template<typename T>
+using HalideBuffer = Halide::Runtime::Buffer<T, max_rank>;
+
 // Must be constexpr to allow use in case clauses.
 inline constexpr int halide_type_code(halide_type_code_t code, int bits) {
     return (((int)code) << 8) | bits;
@@ -61,8 +66,8 @@ auto dynamic_type_dispatch(const halide_type_t &type, Args &&...args)
 #undef HANDLE_CASE
 }
 
-inline void check_shapes_match(const Halide::Runtime::Buffer<const void> &a,
-                               const Halide::Runtime::Buffer<const void> &b) {
+inline void check_shapes_match(const HalideBuffer<const void> &a,
+                               const HalideBuffer<const void> &b) {
     CHECK(a.dimensions() == b.dimensions());
     for (int d = 0; d < a.dimensions(); d++) {
         CHECK(a.dim(d).min() == b.dim(d).min());
@@ -108,11 +113,11 @@ struct CompareBuffersResult {
 // type/shape mismatch will check-fail immediately.
 template<typename T>
 struct CompareBuffers {
-    CompareBuffersResult operator()(const Halide::Runtime::Buffer<const void> &expected_buf_dynamic,
-                                    const Halide::Runtime::Buffer<const void> &actual_buf_dynamic,
+    CompareBuffersResult operator()(const HalideBuffer<const void> &expected_buf_dynamic,
+                                    const HalideBuffer<const void> &actual_buf_dynamic,
                                     const CompareBuffersOptions &opts) {
-        Halide::Runtime::Buffer<const T> expected_buf = expected_buf_dynamic;
-        Halide::Runtime::Buffer<const T> actual_buf = actual_buf_dynamic;
+        HalideBuffer<const T> expected_buf = expected_buf_dynamic;
+        HalideBuffer<const T> actual_buf = actual_buf_dynamic;
         check_shapes_match(expected_buf, actual_buf);
 
         assert(opts.exact_thresh >= 0.0);
@@ -180,14 +185,14 @@ struct CompareBuffers {
 // with pseudorandom data.
 template<typename T>
 struct FillWithRandom {
-    void operator()(Halide::Runtime::Buffer<> &b_dynamic, int seed) {
-        Halide::Runtime::Buffer<T> b = b_dynamic;
+    void operator()(HalideBuffer<void> &b_dynamic, int seed) {
+        HalideBuffer<T> b = b_dynamic;
         std::mt19937 rng(seed);
         fill_with_random_impl(b, rng);
     }
 
 private:
-    inline static void fill_with_random_impl(Halide::Runtime::Buffer<T> &b, std::mt19937 &rng) {
+    inline static void fill_with_random_impl(HalideBuffer<T> &b, std::mt19937 &rng) {
         std::uniform_int_distribution<T> dis(std::numeric_limits<T>::min(),
                                              std::numeric_limits<T>::max());
         b.for_each_value([&rng, &dis](T &value) {
@@ -198,7 +203,7 @@ private:
 
 // Specializations must be at namespace scope, not class scope
 template<>
-inline /*static*/ void FillWithRandom<float>::fill_with_random_impl(Halide::Runtime::Buffer<float> &b, std::mt19937 &rng) {
+inline /*static*/ void FillWithRandom<float>::fill_with_random_impl(HalideBuffer<float> &b, std::mt19937 &rng) {
     // Floating point. We arbitrarily choose to use the range [0.0, 1.0].
     std::uniform_real_distribution<float> dis(0.0, 1.0);
     b.for_each_value([&rng, &dis](float &value) {
@@ -207,7 +212,7 @@ inline /*static*/ void FillWithRandom<float>::fill_with_random_impl(Halide::Runt
 }
 
 template<>
-inline /*static*/ void FillWithRandom<double>::fill_with_random_impl(Halide::Runtime::Buffer<double> &b, std::mt19937 &rng) {
+inline /*static*/ void FillWithRandom<double>::fill_with_random_impl(HalideBuffer<double> &b, std::mt19937 &rng) {
     // Floating point. We arbitrarily choose to use the range [0.0, 1.0].
     std::uniform_real_distribution<double> dis(0.0, 1.0);
     b.for_each_value([&rng, &dis](double &value) {
@@ -216,7 +221,7 @@ inline /*static*/ void FillWithRandom<double>::fill_with_random_impl(Halide::Run
 }
 
 template<>
-inline /*static*/ void FillWithRandom<bool>::fill_with_random_impl(Halide::Runtime::Buffer<bool> &b, std::mt19937 &rng) {
+inline /*static*/ void FillWithRandom<bool>::fill_with_random_impl(HalideBuffer<bool> &b, std::mt19937 &rng) {
     std::uniform_int_distribution<int> dis(0, 1);
     b.for_each_value([&rng, &dis](bool &value) {
         value = static_cast<bool>(dis(rng));
@@ -227,8 +232,8 @@ inline /*static*/ void FillWithRandom<bool>::fill_with_random_impl(Halide::Runti
 // to std::cerr in a very simple way. Intended only for temporary debugging.
 template<typename T>
 struct DumpBuffer {
-    void operator()(const Halide::Runtime::Buffer<const void> &buf_dynamic) {
-        Halide::Runtime::Buffer<const T> buf = buf_dynamic;
+    void operator()(const HalideBuffer<const void> &buf_dynamic) {
+        HalideBuffer<const T> buf = buf_dynamic;
         buf.for_each_element([&](const int *pos) {
             T val = buf(pos);
             std::cerr << "Value at (";


### PR DESCRIPTION
This prevents mallocs for some degenerate cases where we need buffers with > 4 dimensions.