### PR TITLE
Optimize add generator

### DIFF
--- a/apps/hannk/README.md
+++ b/apps/hannk/README.md
@@ -21,21 +21,21 @@ x86 OSX laptop w/ AVX2:
 | inception_v3_quant | 267 | 105.3 | 2.54 |
 | inception_v4_299_quant | 566 | 227 | 2.49 |
 | mobilenet_v1_0.25_128_quant | 1.9 | 0.68 | 2.78 |
-| mobilenet_v1_1.0_224_quant | 38.4 | 12.9 | 2.98 |
+| mobilenet_v1_1.0_224_quant | 38.4 | 12.7 | 3.02 |
 | mobilenet_v2_1.0_224_quant | 30.6 | 9.85 | 3.11 |
 
 Qualcomm Snapdragon 855 A76 core (Pixel 4):
 
 | Network | TFlite (ms)|Halide (ms)| Speedup
 | ---- | ---- | ---- | ---- |
-| inception_v1_224_quant | 24.7 | 26.3 | 0.94 |
-| inception_v2_224_quant | 49.8 | 34.8 | 1.43 |
-| inception_v3_quant | 97 | 90.9 | 1.07 |
-| inception_v4_299_quant | 198 | 190.8 | 1.04 |
+| inception_v1_224_quant | 24.7 | 25.9 | 0.95 |
+| inception_v2_224_quant | 49.8 | 34.2 | 1.46 |
+| inception_v3_quant | 97 | 89 | 1.09 |
+| inception_v4_299_quant | 198 | 186.7 | 1.06 |
 | mobilenet_v1_0.25_128_quant	| 0.97 | 0.72 | 1.34 |
 | mobilenet_v1_1.0_128_quant |4.64 | 4.44 | 1.05 |
 | mobilenet_v1_1.0_224_quant | 12.9 | 11.6 | 1.11 |
-| mobilenet_v2_1.0_224_quant | 11.8 | 10 | 1.18 |
+| mobilenet_v2_1.0_224_quant | 11.8 | 9.89 | 1.19 |
 
 ### Planned but still TODO
 - More op support

--- a/apps/hannk/halide/elementwise_generator.cpp
+++ b/apps/hannk/halide/elementwise_generator.cpp
@@ -21,7 +21,6 @@ public:
     Input<uint32_t> input2_shift_{"input2_shift"};
 
     Input<uint8_t> output_zero_{"output_zero"};
-    Input<uint32_t> output_shift_{"output_shift"};
     Input<uint8_t> output_min_{"output_min"};
     Input<uint8_t> output_max_{"output_max"};
 
@@ -38,7 +37,8 @@ public:
         input1 = rounding_shift_right(multiply_2x_high(input1, input1_multiplier_), input1_shift_);
         input2 = rounding_shift_right(multiply_2x_high(input2, input2_multiplier_), input2_shift_);
 
-        Expr output = i16_sat(rounding_shift_right(input1 + input2, output_shift_));
+        // It's significantly faster if this right shift is by a constant on ARM.
+        Expr output = i16_sat(rounding_shift_right(input1 + input2, 8));
         output = u8_sat(saturating_add(output, output_zero_));
         output_(x, y) = clamp(output, output_min_, output_max_);
 

--- a/apps/hannk/halide/elementwise_generator.cpp
+++ b/apps/hannk/halide/elementwise_generator.cpp
@@ -20,10 +20,7 @@ public:
     Input<int32_t> input2_multiplier_{"input2_multiplier"};
     Input<uint32_t> input2_shift_{"input2_shift"};
 
-    // Offset, quantization multiplier and shift for the output.
     Input<uint8_t> output_zero_{"output_zero"};
-    Input<int32_t> output_multiplier_{"output_multiplier"};
-    Input<uint32_t> output_shift_{"output_shift"};
     Input<uint8_t> output_min_{"output_min"};
     Input<uint8_t> output_max_{"output_max"};
 
@@ -38,8 +35,7 @@ public:
         input1 = rounding_shift_right(multiply_2x_high(input1, input1_multiplier_), input1_shift_);
         input2 = rounding_shift_right(multiply_2x_high(input2, input2_multiplier_), input2_shift_);
 
-        Expr output = multiply_2x_high(input1 + input2, output_multiplier_);
-        output = i16_sat(rounding_shift_right(output, output_shift_));
+        Expr output = i16(rounding_shift_right(input1 + input2, 16));
         output = u8_sat(saturating_add(output, output_zero_));
         output_(x, y) = clamp(output, output_min_, output_max_);
 

--- a/apps/hannk/halide/elementwise_generator.cpp
+++ b/apps/hannk/halide/elementwise_generator.cpp
@@ -27,6 +27,9 @@ public:
     void generate() {
         Var x("x"), y("y");
 
+        // After subtracing the zero point, we have 9 bits. We can shift
+        // up by a further 6 bits to 15 bits total to get more precision
+        // for the later operations.
         Expr input1 = (i16(input1_(x, y)) - i16(input1_zero_)) << 6;
         Expr input2 = (i16(input2_(x, y)) - i16(input2_zero_)) << 6;
 

--- a/apps/hannk/halide/elementwise_generator.cpp
+++ b/apps/hannk/halide/elementwise_generator.cpp
@@ -43,7 +43,7 @@ public:
         const int vector_size = natural_vector_size<uint8_t>();
 
         output_.compute_root()
-            .vectorize(x, vector_size, TailStrategy::Predicate);
+            .vectorize(x, vector_size * 2, TailStrategy::Predicate);
 
         // Support broadcasting in the c dimension for input2.
         input2_.dim(0).set_stride(Expr());
@@ -84,7 +84,7 @@ public:
         const int vector_size = natural_vector_size<uint8_t>();
 
         output_.compute_root()
-            .vectorize(x, vector_size, TailStrategy::Predicate);
+            .vectorize(x, vector_size * 2, TailStrategy::Predicate);
 
         // Support broadcasting in the c dimension for input2.
         input2_.dim(0).set_stride(Expr());

--- a/apps/hannk/interpreter/ops.cpp
+++ b/apps/hannk/interpreter/ops.cpp
@@ -400,8 +400,8 @@ void add_uint8(const HalideBuffer<const void> &in1, const QuantizationInfo &in1q
     const float in2_scale = in2q.uniform_scale() * (1 << output_shift);
     const float out_scale = outq.uniform_scale() * (1 << input_shift);
 
-    const int in1_multiplier = std::lround(in1_scale / out_scale);
-    const int in2_multiplier = std::lround(in2_scale / out_scale);
+    const int in1_multiplier = std::lround(in1_scale / out_scale) * in1sign;
+    const int in2_multiplier = std::lround(in2_scale / out_scale) * in2sign;
 
     const auto out_range = get_output_range(activation, outq);
 

--- a/apps/hannk/interpreter/ops.cpp
+++ b/apps/hannk/interpreter/ops.cpp
@@ -398,18 +398,17 @@ void add_uint8(const HalideBuffer<const void> &in1, const QuantizationInfo &in1q
     const float in2_scale = in2q.uniform_scale();
     const float out_scale = outq.uniform_scale();
 
-    const int left_shift = 20;
-    const double twice_max_input_scale = 2 * std::max(in1_scale, in2_scale);
-    const double real_in1_multiplier = in1_scale / twice_max_input_scale;
-    const double real_in2_multiplier = in2_scale / twice_max_input_scale;
-    const double real_out_multiplier = twice_max_input_scale / ((1 << left_shift) * out_scale);
+    const int input_shift = 20;
+    const int output_shift = 16;
+    const double real_in1_multiplier =
+        in1_scale * (1 << output_shift) / ((1 << input_shift) * out_scale);
+    const double real_in2_multiplier =
+        in2_scale * (1 << output_shift) / ((1 << input_shift) * out_scale);
 
     auto in1_mul_and_shift = get_quantized_mul_and_shift(real_in1_multiplier);
     auto in2_mul_and_shift = get_quantized_mul_and_shift(real_in2_multiplier);
-    auto out_mul_and_shift = get_quantized_mul_and_shift(real_out_multiplier);
     assert(in1_mul_and_shift.shift <= 0);
     assert(in2_mul_and_shift.shift <= 0);
-    assert(out_mul_and_shift.shift <= 0);
 
     in1_mul_and_shift.multiplier *= in1sign;
     in2_mul_and_shift.multiplier *= in2sign;
@@ -419,8 +418,7 @@ void add_uint8(const HalideBuffer<const void> &in1, const QuantizationInfo &in1q
     auto add_rank2 = [&](halide_buffer_t *in1_buf, halide_buffer_t *in2_buf, halide_buffer_t *out_buf) {
         add_uint8_uint8(in1_buf, in1_zero, in1_mul_and_shift.multiplier, -in1_mul_and_shift.shift,
                         in2_buf, in2_zero, in2_mul_and_shift.multiplier, -in2_mul_and_shift.shift,
-                        out_zero, out_mul_and_shift.multiplier, -out_mul_and_shift.shift,
-                        out_range.min, out_range.max, out_buf);
+                        out_zero, out_range.min, out_range.max, out_buf);
     };
     elementwise_loop_nest<2>(add_rank2, in1, in2, out);
 }


### PR DESCRIPTION
One of the 3 quantized multiplications is unnecessary. This speeds up add quite a bit (close to 50% on ARM).