### PR TITLE
advance_ptrs() should use refs, not ptrs

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1959,8 +1959,8 @@ private:
     // (all of different types), advance the pointers using the
     // strides.
     template<typename Ptr, typename... Ptrs>
-    HALIDE_ALWAYS_INLINE static void advance_ptrs(const std::ptrdiff_t *stride, Ptr *ptr, Ptrs... ptrs) {
-        (*ptr) += *stride;
+    HALIDE_ALWAYS_INLINE static void advance_ptrs(const std::ptrdiff_t *stride, Ptr &ptr, Ptrs... ptrs) {
+        ptr += *stride;
         advance_ptrs(stride + 1, ptrs...);
     }
 
@@ -1980,13 +1980,13 @@ private:
             } else {
                 for (std::ptrdiff_t i = t[0].extent; i != 0; i--) {
                     f(*ptr, (*ptrs)...);
-                    advance_ptrs(t[0].stride, &ptr, (&ptrs)...);
+                    advance_ptrs(t[0].stride, ptr, ptrs...);
                 }
             }
         } else {
             for (std::ptrdiff_t i = t[d].extent; i != 0; i--) {
                 for_each_value_helper(f, d - 1, innermost_strides_are_one, t, ptr, ptrs...);
-                advance_ptrs(t[d].stride, &ptr, (&ptrs)...);
+                advance_ptrs(t[d].stride, ptr, ptrs...);
             }
         }
     }

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1202,7 +1202,7 @@ public:
      * sprite onto a framebuffer, you'll want to translate the sprite
      * to the correct location first like so: \code
      * framebuffer.copy_from(sprite.translated({x, y})); \endcode
-    */
+     */
     template<typename T2, int D2>
     void copy_from(Buffer<T2, D2> src) {
         static_assert(!std::is_const<T>::value, "Cannot call copy_from() on a Buffer<const T>");
@@ -1959,7 +1959,7 @@ private:
     // (all of different types), advance the pointers using the
     // strides.
     template<typename Ptr, typename... Ptrs>
-    HALIDE_ALWAYS_INLINE static void advance_ptrs(const std::ptrdiff_t *stride, Ptr &ptr, Ptrs... ptrs) {
+    HALIDE_ALWAYS_INLINE static void advance_ptrs(const std::ptrdiff_t *stride, Ptr &ptr, Ptrs &...ptrs) {
         ptr += *stride;
         advance_ptrs(stride + 1, ptrs...);
     }


### PR DESCRIPTION
Examination of compiled output (x86-64, clang w/ optimizer) shows slightly better codegen.