### PR TITLE
Add pmaddubsw support

### DIFF
--- a/src/InlineReductions.cpp
+++ b/src/InlineReductions.cpp
@@ -156,7 +156,7 @@ Expr saturating_sum(const RDom &r, Expr e, const Func &f) {
 
     user_assert(v.rdom.defined()) << "Expression passed to saturating_sum must reference a reduction domain";
 
-    f(v.free_vars) = 0;
+    f(v.free_vars) = cast(e.type(), 0);
     f(v.free_vars) = Internal::saturating_add(f(v.free_vars), e);
     return f(v.call_args);
 }

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -291,12 +291,18 @@ public:
             // We generated pmaddwd when we do a sum of widening multiplies
             const char *check_pmaddwd =
                 (use_avx2 && w >= 4) ? "vpmaddwd" : "pmaddwd";
+            const char *check_pmaddubsw =
+                (use_avx2 && w >= 4) ? "vpmaddubsw" : "pmaddubsw";
             check(check_pmaddwd, 2 * w, i32(i16_1) * 3 + i32(i16_2) * 4);
             check(check_pmaddwd, 2 * w, i32(i16_1) * 3 - i32(i16_2) * 4);
 
             // And also for dot-products
-            RDom r(0, 4);
-            check(check_pmaddwd, 2 * w, sum(i32(in_i16(x * 4 + r)) * in_i16(x * 4 + r + 32)));
+            RDom r4(0, 4);
+            check(check_pmaddwd, 2 * w, sum(i32(in_i16(x * 4 + r4)) * in_i16(x * 4 + r4 + 32)));
+
+            RDom r2(0, 2);
+            check(check_pmaddubsw, 4 * w, saturating_sum(i16(in_u8(2 * x + r2)) * in_i8(2 * x + r2 + 32)));
+            check(check_pmaddubsw, 4 * w, saturating_sum(i16(in_i8(2 * x + r2)) * in_u8(2 * x + r2 + 32)));
         }
 
         // llvm doesn't distinguish between signed and unsigned multiplies

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -283,6 +283,15 @@ public:
             check("phminposuw", 1, maximum(in_u8(RDom(0, 16) + 16 * x)));
             check("phminposuw", 1, minimum(in_i8(RDom(0, 16) + 16 * x)));
             check("phminposuw", 1, maximum(in_i8(RDom(0, 16) + 16 * x)));
+
+            for (int w = 2; w <= 8; w++) {
+                const char *check_pmaddubsw =
+                    (use_avx2 && w >= 4) ? "vpmaddubsw" : "pmaddubsw";
+
+                RDom r2(0, 2);
+                check(check_pmaddubsw, 4 * w, saturating_sum(i16(in_u8(2 * x + r2)) * in_i8(2 * x + r2 + 32)));
+                check(check_pmaddubsw, 4 * w, saturating_sum(i16(in_i8(2 * x + r2)) * in_u8(2 * x + r2 + 32)));
+            }
         }
 
         // SSE 4.1
@@ -291,18 +300,12 @@ public:
             // We generated pmaddwd when we do a sum of widening multiplies
             const char *check_pmaddwd =
                 (use_avx2 && w >= 4) ? "vpmaddwd" : "pmaddwd";
-            const char *check_pmaddubsw =
-                (use_avx2 && w >= 4) ? "vpmaddubsw" : "pmaddubsw";
             check(check_pmaddwd, 2 * w, i32(i16_1) * 3 + i32(i16_2) * 4);
             check(check_pmaddwd, 2 * w, i32(i16_1) * 3 - i32(i16_2) * 4);
 
             // And also for dot-products
             RDom r4(0, 4);
             check(check_pmaddwd, 2 * w, sum(i32(in_i16(x * 4 + r4)) * in_i16(x * 4 + r4 + 32)));
-
-            RDom r2(0, 2);
-            check(check_pmaddubsw, 4 * w, saturating_sum(i16(in_u8(2 * x + r2)) * in_i8(2 * x + r2 + 32)));
-            check(check_pmaddubsw, 4 * w, saturating_sum(i16(in_i8(2 * x + r2)) * in_u8(2 * x + r2 + 32)));
         }
 
         // llvm doesn't distinguish between signed and unsigned multiplies


### PR DESCRIPTION
This started out more ambitious, but here's what I was left with after a while. Probably not commonly used, but also not very much code/complexity either.

A few other minor changes:
- Potential bug fix when generating pmaddwd for subtraction (negate could overflow).
- Renamed pmaddwd to dot_product, for consistency
- Cleaned up the VectorReduce patterns a little.