### PR TITLE
Fix Windows apps

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -5,7 +5,11 @@
 cmake_minimum_required(VERSION 3.16)
 project(Halide_apps)
 
-option(ENABLE_APPS_HANNK "Build apps/hannk" ON)
+if (WIN32)
+    option(ENABLE_APPS_HANNK "Build apps/hannk" OFF)
+else ()
+    option(ENABLE_APPS_HANNK "Build apps/hannk" ON)
+endif ()
 
 enable_testing()
 
@@ -26,7 +30,7 @@ add_subdirectory(cuda_mat_mul)
 add_subdirectory(depthwise_separable_conv)
 add_subdirectory(fft)
 if (ENABLE_APPS_HANNK)
-add_subdirectory(hannk)
+    add_subdirectory(hannk)
 endif ()
 add_subdirectory(harris)
 # add_subdirectory(hexagon_benchmarks)  # TODO(#5374): missing CMake build

--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -6,6 +6,10 @@ define_property(TARGET PROPERTY Halide_RT_TARGETS
                 BRIEF_DOCS "On a Halide runtime target, lists the targets the runtime backs"
                 FULL_DOCS "On a Halide runtime target, lists the targets the runtime backs")
 
+define_property(TARGET PROPERTY Halide_GENERATOR_HAS_POST_BUILD
+                BRIEF_DOCS "On a Halide generator target, true if Halide.dll copy command has already been added."
+                FULL_DOCS "On a Halide generator target, true if Halide.dll copy command has already been added.")
+
 function(add_halide_library TARGET)
     ##
     # Set up argument parsing for extra outputs.
@@ -59,6 +63,8 @@ function(add_halide_library TARGET)
     if (NOT ARG_FROM)
         message(FATAL_ERROR "Missing FROM argument specifying a Halide generator target")
     endif ()
+
+    _Halide_place_dll(${ARG_FROM})
 
     if (ARG_C_BACKEND)
         if (ARG_USE_RUNTIME)
@@ -245,6 +251,21 @@ function(add_halide_library TARGET)
 
     target_include_directories("${TARGET}" INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
     target_link_libraries("${TARGET}" INTERFACE "${ARG_USE_RUNTIME}")
+endfunction()
+
+##
+# Function for ensuring that Halide.dll is visible to the generator
+##
+
+function(_Halide_place_dll GEN)
+    get_property(is_imported TARGET ${GEN} PROPERTY IMPORTED)
+    get_property(has_post_build TARGET ${GEN} PROPERTY Halide_GENERATOR_HAS_POST_BUILD)
+    get_property(halide_type TARGET Halide::Halide PROPERTY TYPE)
+    if (WIN32 AND NOT is_imported AND NOT has_post_build AND halide_type STREQUAL "SHARED_LIBRARY")
+        add_custom_command(TARGET ${GEN} POST_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:Halide::Halide> $<TARGET_FILE_DIR:${GEN}>)
+        set_property(TARGET ${GEN} PROPERTY Halide_GENERATOR_HAS_POST_BUILD 1)
+    endif ()
 endfunction()
 
 ##


### PR DESCRIPTION
In #5973 I removed the code that ensures Halide is visible to the generators by setting the `PATH`. This is a new solution that plays nice with vcpkg by copying the Halide DLL that was actually found by CMake to the appropriate directory. This should fix the apps not finding Halide / crashing as a result.

Also disables Hannk on Windows by default because I tripped over that while testing this.