### PR TITLE
Guard against overflow in constant folding for EQ rewrite rules (Fixes #5998)

### DIFF
--- a/src/Simplify_EQ.cpp
+++ b/src/Simplify_EQ.cpp
@@ -66,8 +66,10 @@ Expr Simplify::visit(const EQ *op, ExprInfo *bounds) {
 
     auto rewrite = IRMatcher::rewriter(IRMatcher::eq(delta, 0), op->type, delta.type());
 
+    bool allowed_overflow = no_overflow(delta.type());
+
     if (rewrite(broadcast(x, c0) == 0, broadcast(x == 0, c0)) ||
-        (no_overflow(delta.type()) && rewrite(x * y == 0, (x == 0) || (y == 0))) ||
+        (allowed_overflow && rewrite(x * y == 0, (x == 0) || (y == 0))) ||
 
         rewrite(select(x, 0, y) == 0, x || (y == 0)) ||
         rewrite(select(x, c0, y) == 0, !x && (y == 0), c0 != 0) ||
@@ -87,12 +89,16 @@ Expr Simplify::visit(const EQ *op, ExprInfo *bounds) {
         rewrite(y - min(x, y) == 0, y <= x) ||
         rewrite(y - max(y, x) == 0, x <= y) ||
         rewrite(y - min(y, x) == 0, y <= x) ||
-        rewrite(max(x, c0) + c1 == 0, x == fold(-c1), c0 + c1 < 0) ||
-        rewrite(min(x, c0) + c1 == 0, x == fold(-c1), c0 + c1 > 0) ||
-        rewrite(max(x, c0) + c1 == 0, false, c0 + c1 > 0) ||
-        rewrite(min(x, c0) + c1 == 0, false, c0 + c1 < 0) ||
-        rewrite(max(x, c0) + c1 == 0, x <= c0, c0 + c1 == 0) ||
-        rewrite(min(x, c0) + c1 == 0, c0 <= x, c0 + c1 == 0) ||
+
+        // Guard against `c0 + c1` overflowing.
+        (allowed_overflow &&
+         (rewrite(max(x, c0) + c1 == 0, x == fold(-c1), c0 + c1 < 0) ||
+          rewrite(min(x, c0) + c1 == 0, x == fold(-c1), c0 + c1 > 0) ||
+          rewrite(max(x, c0) + c1 == 0, false, c0 + c1 > 0) ||
+          rewrite(min(x, c0) + c1 == 0, false, c0 + c1 < 0) ||
+          rewrite(max(x, c0) + c1 == 0, x <= c0, c0 + c1 == 0) ||
+          rewrite(min(x, c0) + c1 == 0, c0 <= x, c0 + c1 == 0))) ||
+
         // Special case the above where c1 == 0
         rewrite(max(x, c0) == 0, x == 0, c0 < 0) ||
         rewrite(min(x, c0) == 0, x == 0, c0 > 0) ||


### PR DESCRIPTION
Some rewrite rules in Simplify_EQ can perform incorrect rewrites because the predicate expression can overflow. Fixes #5998