### PR TITLE
Fix local laplacian upsample

### DIFF
--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -237,8 +237,8 @@ private:
     Func upsample(Func f) {
         using Halide::_;
         Func upx, upy;
-        upx(x, y, _) = lerp(f(x / 2, y, _), f((x + 1) / 2, y, _), ((x % 2) * 2 + 1) / 4.0f);
-        upy(x, y, _) = lerp(upx(x, y / 2, _), upx(x, (y + 1) / 2, _), ((y % 2) * 2 + 1) / 4.0f);
+        upx(x, y, _) = lerp(f((x + 1) / 2, y, _), f((x - 1) / 2, y, _), ((x % 2) * 2 + 1) / 4.0f);
+        upy(x, y, _) = lerp(upx(x, (y + 1) / 2, _), upx(x, (y - 1) / 2, _), ((y % 2) * 2 + 1) / 4.0f);
         return upy;
     }
 };


### PR DESCRIPTION
@LCJebe pointed out that the local laplacian upsample indexing is not right. This PR fixes it. Here's the output on filtering a flat disk before and after:
![out_0](https://user-images.githubusercontent.com/515398/118320192-b8a50b80-b4b0-11eb-91c4-c422fcea12de.png)
![out_1](https://user-images.githubusercontent.com/515398/118320196-b93da200-b4b0-11eb-9f08-bed1f814f02a.png)
