### PR TITLE
Add an ErrorReporter hook to TfLiteModelRunner

### DIFF
--- a/apps/hannk/util/model_runner.h
+++ b/apps/hannk/util/model_runner.h
@@ -50,6 +50,8 @@ public:
     std::vector<HalideBuffer<const void>> copy_outputs();
     ~TfLiteModelRunner();
 
+    static void ErrorReporter(void *user_data, const char *format, va_list args);
+
     // Movable but not copyable.
     TfLiteModelRunner(const TfLiteModelRunner &) = delete;
     TfLiteModelRunner &operator=(const TfLiteModelRunner &) = delete;


### PR DESCRIPTION
This allows us to silence some (but not all) of the noise that TfLite logs when we disable our own verbosity.